### PR TITLE
Product card: add missing space in the Search copy.

### DIFF
--- a/client/blocks/product-selector/index.jsx
+++ b/client/blocks/product-selector/index.jsx
@@ -234,6 +234,7 @@ export class ProductSelector extends Component {
 		if ( ! this.props.selectedSiteSlug ) {
 			return (
 				description +
+				'\n' +
 				this.props.translate(
 					'The price of this subscription is based on the number of records you have on your site.'
 				)


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Sentences are not separated in the Search product card in the copy when site info is absent.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

 At `/jetpack/connect/store`, verify that the spacing in the copy is correct.


