### PR TITLE
Jetpack Cloud: Fix history loading

### DIFF
--- a/client/landing/jetpack-cloud/sections/scan/history/index.jsx
+++ b/client/landing/jetpack-cloud/sections/scan/history/index.jsx
@@ -126,7 +126,7 @@ const ScanHistoryPage = ( {
 					'The scanning history contains a record of all previously active threats on your site.'
 				) }
 			</p>
-			{ filteredEntries.length > 0 && (
+			{ threats.length > 0 && (
 				<div className="history__filters-wrapper">
 					<ThreatStatusFilter
 						isPlaceholder={ isRequestingHistory }

--- a/client/landing/jetpack-cloud/sections/scan/history/index.jsx
+++ b/client/landing/jetpack-cloud/sections/scan/history/index.jsx
@@ -167,21 +167,22 @@ export default connect(
 		const siteName = site.name;
 		const siteSlug = getSelectedSiteSlug( state );
 		const isRequestingHistory = isRequestingJetpackScanHistory( state, siteId );
+		const siteLogEntries = getSiteScanHistory( state, siteId );
 
-		const logEntries = isRequestingHistory
+		const showPlaceholders = isRequestingHistory && 0 === siteLogEntries.length;
+		const logEntries = showPlaceholders
 			? [
 					{ id: 1, status: 'fixed' },
 					{ id: 2, status: 'ignored' },
 					{ id: 3, status: 'fixed' },
 					{ id: 4, status: 'ignored' },
 			  ]
-			: getSiteScanHistory( state, siteId );
-
+			: siteLogEntries;
 		return {
 			siteId,
 			siteName,
 			siteSlug,
-			isRequestingHistory,
+			isRequestingHistory: showPlaceholders,
 			threats: logEntries,
 		};
 	},


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Currently the Jetpack Scan history show placeholders everytime someone navigates to the section because everytime we fetch the latest history threats. This PR fixes this by showing threats that are already there if we have them.

It also fixes a case where the we hide the filters when no things to filter are there. 

#### Testing instructions

* Go the /history section for a site that doesn't have any igored fixes. 
* Does it work as expected? 

