### PR TITLE
Hide app banner from editor until later

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -28,6 +28,7 @@ import {
 	masterbarIsVisible,
 	getSectionGroup,
 	getSectionName,
+	getSelectedSite,
 } from 'state/ui/selectors';
 import isAtomicSite from 'state/selectors/is-site-automated-transfer';
 import isHappychatOpen from 'state/happychat/selectors/is-happychat-open';
@@ -56,6 +57,7 @@ import LayoutLoader from './loader';
 // goofy import for environment badge, which is SSR'd
 import 'components/environment-badge/style.scss';
 import './style.scss';
+import { getShouldShowAppBanner } from './utils';
 
 class Layout extends Component {
 	static propTypes = {
@@ -69,6 +71,7 @@ class Layout extends Component {
 		sectionGroup: PropTypes.string,
 		sectionName: PropTypes.string,
 		colorSchemePreference: PropTypes.string,
+		shouldShowAppBanner: PropTypes.bool,
 	};
 
 	componentDidMount() {
@@ -161,6 +164,8 @@ class Layout extends Component {
 			return optionalProps;
 		};
 
+		const { shouldShowAppBanner } = this.props;
+
 		return (
 			<div className={ sectionClass }>
 				<BodySectionCssClass
@@ -226,7 +231,7 @@ class Layout extends Component {
 				{ config.isEnabled( 'layout/support-article-dialog' ) && (
 					<AsyncLoad require="blocks/support-article-dialog" placeholder={ null } />
 				) }
-				{ config.isEnabled( 'layout/app-banner' ) && (
+				{ shouldShowAppBanner && config.isEnabled( 'layout/app-banner' ) && (
 					<AsyncLoad require="blocks/app-banner" placeholder={ null } />
 				) }
 				{ config.isEnabled( 'gdpr-banner' ) && (
@@ -245,6 +250,7 @@ export default connect( ( state ) => {
 	const sectionName = getSectionName( state );
 	const currentRoute = getCurrentRoute( state );
 	const siteId = getSelectedSiteId( state );
+	const shouldShowAppBanner = getShouldShowAppBanner( getSelectedSite( state ) );
 	const sectionJitmPath = getMessagePathForJITM( currentRoute );
 	const isJetpackLogin = startsWith( currentRoute, '/log-in/jetpack' );
 	const isJetpack = isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId );
@@ -278,6 +284,7 @@ export default connect( ( state ) => {
 		sectionGroup,
 		sectionName,
 		sectionJitmPath,
+		shouldShowAppBanner,
 		hasSidebar: hasSidebar( state ),
 		isOffline: isOffline( state ),
 		currentLayoutFocus: getCurrentLayoutFocus( state ),

--- a/client/layout/utils.ts
+++ b/client/layout/utils.ts
@@ -1,0 +1,16 @@
+const HOUR_IN_MS = 1000 * 60 * 60;
+
+/**
+ * Returns false if the site is unlauched or is younger than 1 hour
+ *
+ * @param site the site object
+ */
+export function getShouldShowAppBanner( site: any ): boolean {
+	if ( site && site.options ) {
+		const olderThanAnHour = Date.now() - new Date( site.options.created_at ).getTime() > HOUR_IN_MS;
+		const isLaunched = site.launch_status !== 'unlaunched';
+
+		return olderThanAnHour && isLaunched;
+	}
+	return false;
+}

--- a/client/layout/utils.ts
+++ b/client/layout/utils.ts
@@ -1,7 +1,7 @@
 const WEEK_IN_MS = 7 * 24 * 60 * 60 * 1000;
 
 /**
- * Returns false if the site is unlaunched or is younger than 1 hour
+ * Returns false if the site is unlaunched or is younger than 1 week
  *
  * @param site the site object
  */

--- a/client/layout/utils.ts
+++ b/client/layout/utils.ts
@@ -1,7 +1,7 @@
 const WEEK_IN_MS = 7 * 24 * 60 * 60 * 1000;
 
 /**
- * Returns false if the site is unlauched or is younger than 1 hour
+ * Returns false if the site is unlaunched or is younger than 1 hour
  *
  * @param site the site object
  */

--- a/client/layout/utils.ts
+++ b/client/layout/utils.ts
@@ -1,4 +1,4 @@
-const HOUR_IN_MS = 1000 * 60 * 60;
+const WEEK_IN_MS = 7 * 24 * 60 * 60 * 1000;
 
 /**
  * Returns false if the site is unlauched or is younger than 1 hour
@@ -7,10 +7,10 @@ const HOUR_IN_MS = 1000 * 60 * 60;
  */
 export function getShouldShowAppBanner( site: any ): boolean {
 	if ( site && site.options ) {
-		const olderThanAnHour = Date.now() - new Date( site.options.created_at ).getTime() > HOUR_IN_MS;
+		const olderThanAWeek = Date.now() - new Date( site.options.created_at ).getTime() > WEEK_IN_MS;
 		const isLaunched = site.launch_status !== 'unlaunched';
 
-		return olderThanAnHour && isLaunched;
+		return olderThanAWeek && isLaunched;
 	}
 	return false;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Don't show the app banner for mobile users until:

1. The site is older than 1h
2. The site is launched.

#### Testing instructions

1. Create a site using /new
2. The app banner shouldn't appear. 

Fixes https://github.com/Automattic/wp-calypso/issues/42140
