### PR TITLE
Banner: Refactor to remove upsell-related functionality

### DIFF
--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -32,6 +32,7 @@ import DismissibleCard from 'blocks/dismissible-card';
 import PlanPrice from 'my-sites/plan-price';
 import TrackComponentView from 'lib/analytics/track-component-view';
 import isSiteWPForTeams from 'state/selectors/is-site-wpforteams';
+import { preventWidows } from 'lib/formatting';
 
 /**
  * Style dependencies
@@ -227,7 +228,7 @@ export class Banner extends Component {
 						{ callToAction &&
 							( forceHref ? (
 								<Button compact primary={ primaryButton } target={ target }>
-									{ callToAction }
+									{ preventWidows( callToAction ) }
 								</Button>
 							) : (
 								<Button
@@ -237,7 +238,7 @@ export class Banner extends Component {
 									primary={ primaryButton }
 									target={ target }
 								>
-									{ callToAction }
+									{ preventWidows( callToAction ) }
 								</Button>
 							) ) }
 					</div>

--- a/client/components/banner/test/index.jsx
+++ b/client/components/banner/test/index.jsx
@@ -168,7 +168,7 @@ describe( 'Banner basic tests', () => {
 
 		expect( comp.find( 'Button' ) ).toHaveLength( 1 );
 		expect( comp.find( 'Button' ).props().href ).toBe( '/' );
-		expect( comp.find( 'Button' ).props().children ).toBe( 'Go WordPress!' );
+		expect( comp.find( 'Button' ).props().children ).toBe( 'Go\xA0WordPress!' ); //preventWidows adds \xA0 non-breaking space;
 		expect( comp.find( 'Button' ).props().onClick ).toBe( comp.instance().handleClick );
 	} );
 
@@ -182,6 +182,6 @@ describe( 'Banner basic tests', () => {
 
 		expect( comp.find( 'Button' ) ).toHaveLength( 1 );
 		expect( comp.find( 'Button' ).props().href ).toBeUndefined();
-		expect( comp.find( 'Button' ).props().children ).toBe( 'Go WordPress!' );
+		expect( comp.find( 'Button' ).props().children ).toBe( 'Go\xA0WordPress!' ); //preventWidows adds \xA0 non-breaking space;
 	} );
 } );

--- a/client/components/banner/test/index.jsx
+++ b/client/components/banner/test/index.jsx
@@ -35,26 +35,10 @@ import { shallow } from 'enzyme';
  * Internal dependencies
  */
 import { Banner } from '../index';
-import {
-	PLAN_FREE,
-	PLAN_BUSINESS,
-	PLAN_BUSINESS_2_YEARS,
-	PLAN_PREMIUM,
-	PLAN_PREMIUM_2_YEARS,
-	PLAN_PERSONAL,
-	PLAN_PERSONAL_2_YEARS,
-	PLAN_JETPACK_PERSONAL,
-	PLAN_JETPACK_PERSONAL_MONTHLY,
-	PLAN_JETPACK_PREMIUM,
-	PLAN_JETPACK_PREMIUM_MONTHLY,
-	PLAN_JETPACK_BUSINESS,
-	PLAN_JETPACK_BUSINESS_MONTHLY,
-} from 'lib/plans/constants';
 import PlanPrice from 'my-sites/plan-price/';
 
 const props = {
 	callToAction: null,
-	plan: PLAN_FREE,
 	title: 'banner title',
 };
 
@@ -199,43 +183,5 @@ describe( 'Banner basic tests', () => {
 		expect( comp.find( 'Button' ) ).toHaveLength( 1 );
 		expect( comp.find( 'Button' ).props().href ).toBeUndefined();
 		expect( comp.find( 'Button' ).props().children ).toBe( 'Go WordPress!' );
-	} );
-} );
-
-describe( 'Banner should have a class name corresponding to appropriate plan', () => {
-	[
-		PLAN_PERSONAL,
-		PLAN_PERSONAL_2_YEARS,
-		PLAN_JETPACK_PERSONAL,
-		PLAN_JETPACK_PERSONAL_MONTHLY,
-	].forEach( ( plan ) => {
-		test( 'Personal', () => {
-			const comp = shallow( <Banner { ...props } plan={ plan } /> );
-			expect( comp.find( '.is-upgrade-personal' ) ).toHaveLength( 1 );
-		} );
-	} );
-
-	[
-		PLAN_PREMIUM,
-		PLAN_PREMIUM_2_YEARS,
-		PLAN_JETPACK_PREMIUM,
-		PLAN_JETPACK_PREMIUM_MONTHLY,
-	].forEach( ( plan ) => {
-		test( 'Premium', () => {
-			const comp = shallow( <Banner { ...props } plan={ plan } /> );
-			expect( comp.find( '.is-upgrade-premium' ) ).toHaveLength( 1 );
-		} );
-	} );
-
-	[
-		PLAN_BUSINESS,
-		PLAN_BUSINESS_2_YEARS,
-		PLAN_JETPACK_BUSINESS,
-		PLAN_JETPACK_BUSINESS_MONTHLY,
-	].forEach( ( plan ) => {
-		test( 'Business', () => {
-			const comp = shallow( <Banner { ...props } plan={ plan } /> );
-			expect( comp.find( '.is-upgrade-business' ) ).toHaveLength( 1 );
-		} );
 	} );
 } );

--- a/client/components/banner/test/index.jsx
+++ b/client/components/banner/test/index.jsx
@@ -168,7 +168,7 @@ describe( 'Banner basic tests', () => {
 
 		expect( comp.find( 'Button' ) ).toHaveLength( 1 );
 		expect( comp.find( 'Button' ).props().href ).toBe( '/' );
-		expect( comp.find( 'Button' ).props().children ).toBe( 'Go\xA0WordPress!' ); //preventWidows adds \xA0 non-breaking space;
+		expect( comp.find( 'Button' ).props().children ).toBe( 'Go\xA0WordPress!' ); //preventwidows adds \xA0 non-breaking space;
 		expect( comp.find( 'Button' ).props().onClick ).toBe( comp.instance().handleClick );
 	} );
 

--- a/client/reader/following/main.jsx
+++ b/client/reader/following/main.jsx
@@ -68,6 +68,7 @@ const FollowingStream = ( props ) => {
 					event="reader-vote-prompt"
 					href="https://www.usa.gov/election-office"
 					icon="star"
+					horizontal
 				/>
 			) }
 			<CompactCard className="following__search">


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update Banner to remove unused logic.

**Visuals**

Activity Log
<img width="1089" alt="Screen Shot 2020-05-14 at 12 29 20 PM" src="https://user-images.githubusercontent.com/2124984/81961416-5638d700-95e0-11ea-9e5c-2c0ef716e463.png">

Site Settings
<img width="765" alt="Screen Shot 2020-05-14 at 12 34 13 PM" src="https://user-images.githubusercontent.com/2124984/81961413-55a04080-95e0-11ea-9c53-ac4467d519b9.png">

Reader Voting
<img width="864" alt="Screen Shot 2020-05-14 at 12 46 22 PM" src="https://user-images.githubusercontent.com/2124984/81961855-f1ca4780-95e0-11ea-9930-e4f238b39ff1.png">

Stats privacy policy reminder
<img width="1093" alt="Screen Shot 2020-05-14 at 12 54 43 PM" src="https://user-images.githubusercontent.com/2124984/81962714-1b37a300-95e2-11ea-905d-aaabf7f8660b.png">

Pending payments notice
<img width="777" alt="Screen Shot 2020-05-14 at 12 57 15 PM" src="https://user-images.githubusercontent.com/2124984/81962957-79648600-95e2-11ea-987c-2365dd8cedd8.png">

#### Testing instructions

Test the following cases; most of which I've provided instructions to see the banner locally by manipulating the code, since these are set to display under very specific conditions.

- Activity Log backup notice - `client/my-sites/activity/activity-log/index.jsx` - set conditional on line 449 to `true` or have a site with a backup underway
- Activity Log - `client/my-sites/activity/activity-log/rewind-unavailability-notice.jsx` - set conditional on line 446 to `true` but can't find this one yet
- Site Settings - `client/blocks/jetpack-backup-creds-banner/index.jsx` - set conditional on line 40 to `true` or have a Jetpack site with an ongling backup
- Reader main page voting reminder - `client/reader/following/main.jsx` - set condition on line 61 to `true`
- Stats main page - `client/blocks/privacy-policy-banner/index.jsx` - remove condition on lines 138-140 and set a description on line 148 or use an older account that has not yet accepted the new privacy policy
- Pending Payments - `client/me/pending-payments/index.jsx` - set line 77 to `false` and line 91 to `true` or have a payment pending

Also make sure UpsellNudges are still working as expected as per #41997 