### PR TITLE
Gutenboarding: add Hotjar

### DIFF
--- a/client/landing/gutenboarding/components/domain-picker/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/index.tsx
@@ -188,6 +188,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 					<div className="domain-picker__search">
 						<SearchIcon />
 						<TextControl
+							data-hj-whitelist
 							hideLabelFromVision
 							label={ label }
 							placeholder={ label }

--- a/client/landing/gutenboarding/index.tsx
+++ b/client/landing/gutenboarding/index.tsx
@@ -30,6 +30,7 @@ import { path, Step } from './path';
 import { SITE_STORE } from './stores/site';
 import { USER_STORE } from './stores/user';
 import { STORE_KEY as ONBOARD_STORE } from './stores/onboard';
+import { addHotJarScript } from 'lib/analytics/hotjar';
 
 /**
  * Style dependencies
@@ -88,6 +89,7 @@ window.AppBoot = async () => {
 	// until after the user has completed the gutenboarding flow.
 	// This also saves us from having to pull in lib/user/user and it's dependencies.
 	initializeAnalytics( undefined, generateGetSuperProps() );
+	addHotJarScript();
 	// Add accessible-focus listener.
 	accessibleFocus();
 

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
@@ -67,6 +67,7 @@ const SiteTitle: React.FunctionComponent< Props > = ( { isVisible, isMobile, onS
 					{ ! isMobile && ' ' }
 					<span
 						contentEditable
+						data-hj-whitelist
 						tabIndex={ 0 }
 						role="textbox"
 						aria-multiline="true"

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
@@ -212,6 +212,7 @@ const VerticalSelect: React.FunctionComponent< Props > = ( { onNext } ) => {
 					>
 						<span
 							contentEditable
+							data-hj-whitelist
 							tabIndex={ 0 }
 							role="textbox"
 							aria-multiline="true"


### PR DESCRIPTION
Adds Hotjar.com tracking to Gutenboarding.

We'll set up the actual tracking by `/new/*` URLs so here we just need to load the script.

#### Changes proposed in this Pull Request

* Add Hotjar script
* Whitelist a few inputs (https://help.hotjar.com/hc/en-us/articles/115015563287-Whitelisting-input-fields)

#### Testing instructions

- In the console, set `localStorage.debug='calypso:analytics:hotjar'`
- Load `/new` and you should see this in console:
    <img width="507" alt="Screenshot 2020-05-13 at 20 12 57" src="https://user-images.githubusercontent.com/87168/81843377-2e9d2c80-9556-11ea-85ff-e1b494f41c9b.png">
- In the network tab, you should see Hotjar script load once.
- Once you progress in Gutenboarding, the script goes away when you enter the editor.
- Confirm text inputs in Gutenboarding are whitelisted for Hotjar: 
    ![image](https://user-images.githubusercontent.com/87168/81845499-4f1ab600-9559-11ea-84ba-8e27f3112af4.png)
    - Vertical input, site name input, the domain name input
    - I'm not sure if whitelisting matters for `contentEditable` fields actually, but it doesn't hurt to add these in case.

If these don't load, you might get triggered by privacy settings in your browser, in which case commenting out `getDoNotTrack ` and `mayWeTrackCurrentUserGdpr ` lines here can help:

https://github.com/Automattic/wp-calypso/blob/f91f983936832090b999df84f6b4db198a7cafb0/client/lib/analytics/hotjar.js#L23-L25

Also any adblocker/privacy blocker browser extensions might also stop it from loading.
