### PR TITLE
Adds additional product actions for Scan and Backup

### DIFF
--- a/client/lib/products-values/index.js
+++ b/client/lib/products-values/index.js
@@ -12,6 +12,7 @@ import {
 	getJetpackProductsTaglines,
 	JETPACK_BACKUP_PRODUCTS,
 	JETPACK_PRODUCTS_LIST,
+	JETPACK_SCAN_PRODUCTS,
 } from './constants';
 import { PRODUCTS_LIST } from './products-list';
 import {
@@ -220,6 +221,17 @@ export function isJetpackBackup( product ) {
 	assertValidProduct( product );
 
 	return isJetpackBackupSlug( product.product_slug );
+}
+
+export function isJetpackScanSlug( productSlug ) {
+	return JETPACK_SCAN_PRODUCTS.includes( productSlug );
+}
+
+export function isJetpackScan( product ) {
+	product = formatProduct( product );
+	assertValidProduct( product );
+
+	return isJetpackScanSlug( product.product_slug );
 }
 
 export function isJetpackProductSlug( productSlug ) {

--- a/client/my-sites/plans/current-plan/my-plan-card/style.scss
+++ b/client/my-sites/plans/current-plan/my-plan-card/style.scss
@@ -164,4 +164,8 @@
 		width: 110px;
 		height: 29px;
 	}
+
+	.button ~ .button {
+		margin-left: 8px;
+	}
 }

--- a/client/my-sites/plans/current-plan/purchases-listing.jsx
+++ b/client/my-sites/plans/current-plan/purchases-listing.jsx
@@ -28,7 +28,6 @@ import { withLocalizedMoment } from 'components/localized-moment';
 import Gridicon from 'components/gridicon';
 import { managePurchase } from 'me/purchases/paths';
 import { getPlan } from 'lib/plans';
-import { addQueryArgs } from 'lib/url';
 import {
 	isExpiring,
 	isPartnerPurchase,
@@ -213,13 +212,7 @@ class PurchasesListing extends Component {
 		let serviceButton = null;
 		if ( isJetpackBackup( purchase ) ) {
 			serviceButton = (
-				<Button
-					href={ addQueryArgs(
-						{ site, source: 'calypso-backups' },
-						'https://jetpack.com/redirect/'
-					) }
-					compact
-				>
+				<Button href={ `/activity-log/${ site }?group=rewind` } compact>
 					{ translate( 'View backups' ) }
 					&nbsp;
 					<Gridicon icon="external" />
@@ -227,14 +220,8 @@ class PurchasesListing extends Component {
 			);
 		} else if ( isJetpackScan( purchase ) ) {
 			serviceButton = (
-				<Button
-					href={ addQueryArgs(
-						{ site, source: 'calypso-scanner' },
-						'https://jetpack.com/redirect/'
-					) }
-					compact
-				>
-					{ translate( 'Run scan' ) }
+				<Button href={ `/activity-log/${ site }` } compact>
+					{ translate( 'View threats' ) }
 					&nbsp;
 					<Gridicon icon="external" />
 				</Button>

--- a/client/my-sites/plans/current-plan/purchases-listing.jsx
+++ b/client/my-sites/plans/current-plan/purchases-listing.jsx
@@ -220,7 +220,7 @@ class PurchasesListing extends Component {
 			);
 		} else if ( isJetpackScan( purchase ) ) {
 			serviceButton = (
-				<Button href={ `/activity-log/${ site }` } compact>
+				<Button href={ `/activity-log/${ site }?group=rewind` } compact>
 					{ translate( 'View threats' ) }
 					&nbsp;
 					<Gridicon icon="external" />

--- a/client/my-sites/plans/current-plan/purchases-listing.jsx
+++ b/client/my-sites/plans/current-plan/purchases-listing.jsx
@@ -217,8 +217,8 @@ class PurchasesListing extends Component {
 			);
 		} else if ( isJetpackScan( purchase ) ) {
 			serviceButton = (
-				<Button href={ `/activity-log/${ site }?group=rewind` } compact>
-					{ translate( 'View threats' ) }
+				<Button href={ `/activity-log/${ site }` } compact>
+					{ translate( 'View scan results' ) }
 				</Button>
 			);
 		}

--- a/client/my-sites/plans/current-plan/purchases-listing.jsx
+++ b/client/my-sites/plans/current-plan/purchases-listing.jsx
@@ -215,7 +215,7 @@ class PurchasesListing extends Component {
 			serviceButton = (
 				<Button
 					href={ addQueryArgs(
-						{ site, source: 'jetpack-backup-dash' },
+						{ site, source: 'calypso-backups' },
 						'https://jetpack.com/redirect/'
 					) }
 					compact
@@ -229,7 +229,7 @@ class PurchasesListing extends Component {
 			serviceButton = (
 				<Button
 					href={ addQueryArgs(
-						{ site, source: 'jetpack-scan-dash' },
+						{ site, source: 'calypso-scanner' },
 						'https://jetpack.com/redirect/'
 					) }
 					compact

--- a/client/my-sites/plans/current-plan/purchases-listing.jsx
+++ b/client/my-sites/plans/current-plan/purchases-listing.jsx
@@ -26,7 +26,7 @@ import QuerySitePurchases from 'components/data/query-site-purchases';
 import ProductExpiration from 'components/product-expiration';
 import { withLocalizedMoment } from 'components/localized-moment';
 import { managePurchase } from 'me/purchases/paths';
-import { getPlan } from 'lib/plans';
+import { getPlan, planHasFeature } from 'lib/plans';
 import {
 	isExpiring,
 	isPartnerPurchase,
@@ -41,6 +41,11 @@ import {
 	isJetpackBackup,
 	isJetpackScan,
 } from 'lib/products-values';
+import {
+	PRODUCT_JETPACK_BACKUP_DAILY,
+	PRODUCT_JETPACK_SCAN,
+	PRODUCT_JETPACK_BACKUP_REALTIME,
+} from 'lib/products-values/constants';
 
 class PurchasesListing extends Component {
 	static propTypes = {
@@ -204,6 +209,44 @@ class PurchasesListing extends Component {
 		);
 	}
 
+	getPlanActionButtons( plan ) {
+		const { translate, selectedSiteSlug: site } = this.props;
+
+		// Determine if the plan contains Backup or Scan.
+		let serviceButtonText = null;
+
+		// The function planHasFeature does not check inferior features.
+		const planHasBackup =
+			planHasFeature( plan.productSlug, PRODUCT_JETPACK_BACKUP_DAILY ) ||
+			planHasFeature( plan.productSlug, PRODUCT_JETPACK_BACKUP_REALTIME );
+		const planHasScan = planHasFeature( plan.productSlug, PRODUCT_JETPACK_SCAN );
+
+		if ( planHasBackup && planHasScan ) {
+			serviceButtonText = translate( 'View Backup & Scan' );
+		} else if ( planHasBackup ) {
+			serviceButtonText = translate( 'View Backup' );
+		} else if ( planHasScan ) {
+			serviceButtonText = translate( 'View Scan' );
+		}
+
+		let serviceButton = null;
+		if ( serviceButtonText ) {
+			// Scan threats always show regardless of filter, so they'll display as well.
+			serviceButton = (
+				<Button href={ `/activity-log/${ site }?group=rewind` } compact>
+					{ serviceButtonText }
+				</Button>
+			);
+		}
+
+		return (
+			<>
+				{ this.getActionButton( plan ) }
+				{ serviceButton }
+			</>
+		);
+	}
+
 	getProductActionButtons( purchase ) {
 		const { translate, selectedSiteSlug: site } = this.props;
 		const actionButton = this.getActionButton( purchase );
@@ -243,7 +286,7 @@ class PurchasesListing extends Component {
 					<MyPlanCard isPlaceholder />
 				) : (
 					<MyPlanCard
-						action={ this.getActionButton( currentPlan ) }
+						action={ this.getPlanActionButtons( currentPlan ) }
 						details={ this.getExpirationInfoForPlan( currentPlan ) }
 						isError={ isPlanExpiring }
 						product={ currentPlanSlug }

--- a/client/my-sites/plans/current-plan/purchases-listing.jsx
+++ b/client/my-sites/plans/current-plan/purchases-listing.jsx
@@ -25,7 +25,6 @@ import QuerySitePlans from 'components/data/query-site-plans';
 import QuerySitePurchases from 'components/data/query-site-purchases';
 import ProductExpiration from 'components/product-expiration';
 import { withLocalizedMoment } from 'components/localized-moment';
-import Gridicon from 'components/gridicon';
 import { managePurchase } from 'me/purchases/paths';
 import { getPlan } from 'lib/plans';
 import {
@@ -214,16 +213,12 @@ class PurchasesListing extends Component {
 			serviceButton = (
 				<Button href={ `/activity-log/${ site }?group=rewind` } compact>
 					{ translate( 'View backups' ) }
-					&nbsp;
-					<Gridicon icon="external" />
 				</Button>
 			);
 		} else if ( isJetpackScan( purchase ) ) {
 			serviceButton = (
 				<Button href={ `/activity-log/${ site }?group=rewind` } compact>
 					{ translate( 'View threats' ) }
-					&nbsp;
-					<Gridicon icon="external" />
 				</Button>
 			);
 		}

--- a/client/my-sites/plans/current-plan/purchases-listing.jsx
+++ b/client/my-sites/plans/current-plan/purchases-listing.jsx
@@ -192,7 +192,7 @@ class PurchasesListing extends Component {
 		let label = translate( 'Manage plan' );
 
 		if ( isJetpackProduct( purchase ) ) {
-			label = translate( 'Manage Subscription' );
+			label = translate( 'Manage subscription' );
 		}
 
 		if ( purchase.autoRenew && ! shouldAddPaymentSourceInsteadOfRenewingNow( purchase ) ) {
@@ -220,7 +220,7 @@ class PurchasesListing extends Component {
 					) }
 					compact
 				>
-					{ translate( 'View Backups' ) }
+					{ translate( 'View backups' ) }
 					&nbsp;
 					<Gridicon icon="external" />
 				</Button>
@@ -234,7 +234,7 @@ class PurchasesListing extends Component {
 					) }
 					compact
 				>
-					{ translate( 'Run Scan' ) }
+					{ translate( 'Run scan' ) }
 					&nbsp;
 					<Gridicon icon="external" />
 				</Button>

--- a/client/my-sites/plans/current-plan/purchases-listing.jsx
+++ b/client/my-sites/plans/current-plan/purchases-listing.jsx
@@ -25,8 +25,10 @@ import QuerySitePlans from 'components/data/query-site-plans';
 import QuerySitePurchases from 'components/data/query-site-purchases';
 import ProductExpiration from 'components/product-expiration';
 import { withLocalizedMoment } from 'components/localized-moment';
+import Gridicon from 'components/gridicon';
 import { managePurchase } from 'me/purchases/paths';
 import { getPlan } from 'lib/plans';
+import { addQueryArgs } from 'lib/url';
 import {
 	isExpiring,
 	isPartnerPurchase,
@@ -38,6 +40,8 @@ import {
 	isJetpackProduct,
 	getJetpackProductDisplayName,
 	getJetpackProductTagline,
+	isJetpackBackup,
+	isJetpackScan,
 } from 'lib/products-values';
 
 class PurchasesListing extends Component {
@@ -188,7 +192,7 @@ class PurchasesListing extends Component {
 		let label = translate( 'Manage plan' );
 
 		if ( isJetpackProduct( purchase ) ) {
-			label = translate( 'Manage product' );
+			label = translate( 'Manage Subscription' );
 		}
 
 		if ( purchase.autoRenew && ! shouldAddPaymentSourceInsteadOfRenewingNow( purchase ) ) {
@@ -199,6 +203,49 @@ class PurchasesListing extends Component {
 			<Button href={ managePurchase( selectedSiteSlug, purchase.id ) } compact>
 				{ label }
 			</Button>
+		);
+	}
+
+	getProductActionButtons( purchase ) {
+		const { translate, selectedSiteSlug: site } = this.props;
+		const actionButton = this.getActionButton( purchase );
+
+		let serviceButton = null;
+		if ( isJetpackBackup( purchase ) ) {
+			serviceButton = (
+				<Button
+					href={ addQueryArgs(
+						{ site, source: 'jetpack-backup-dash' },
+						'https://jetpack.com/redirect/'
+					) }
+					compact
+				>
+					{ translate( 'View Backups' ) }
+					&nbsp;
+					<Gridicon icon="external" />
+				</Button>
+			);
+		} else if ( isJetpackScan( purchase ) ) {
+			serviceButton = (
+				<Button
+					href={ addQueryArgs(
+						{ site, source: 'jetpack-scan-dash' },
+						'https://jetpack.com/redirect/'
+					) }
+					compact
+				>
+					{ translate( 'Run Scan' ) }
+					&nbsp;
+					<Gridicon icon="external" />
+				</Button>
+			);
+		}
+
+		return (
+			<>
+				{ actionButton }
+				{ serviceButton }
+			</>
 		);
 	}
 
@@ -244,7 +291,7 @@ class PurchasesListing extends Component {
 				{ productPurchases.map( ( purchase ) => (
 					<MyPlanCard
 						key={ purchase.id }
-						action={ this.getActionButton( purchase ) }
+						action={ this.getProductActionButtons( purchase ) }
 						details={ this.getExpirationInfoForPurchase( purchase ) }
 						isError={ this.isProductExpiring( purchase ) }
 						isPlaceholder={ this.isLoading() }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This adds the capability for additional buttons for Scan and Backup to link to the Cloud.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to Plan > My Plan page on a site with Scan or Backup purchased.
* Click relevant links.

#### Screenshots

Product Management
<img width="1043" alt="Screen Shot 2020-05-13 at 12 20 14 PM" src="https://user-images.githubusercontent.com/1760168/81838703-7d29d700-9514-11ea-826f-26e404e64d6b.png">

Plan Management
<img width="1074" alt="Screen Shot 2020-05-18 at 12 44 17 PM" src="https://user-images.githubusercontent.com/1760168/82238626-9a401a80-9905-11ea-98f3-1094dd5b6f68.png">

Fixes 1143508703416848-as-1164157450632305.