### PR TITLE
Jetpack: Test removal of personal plan as part of offer reset project

### DIFF
--- a/client/components/product-card/style.scss
+++ b/client/components/product-card/style.scss
@@ -171,6 +171,7 @@
 	font-size: 14px;
 	line-height: 20px;
 	color: var( --color-text-subtle );
+	text-align: left;
 
 	p:last-child {
 		margin: 0;

--- a/client/jetpack-connect/plans-grid.jsx
+++ b/client/jetpack-connect/plans-grid.jsx
@@ -15,7 +15,6 @@ import FormattedHeader from 'components/formatted-header';
 import PlansFeaturesMain from 'my-sites/plans-features-main';
 import PlansSkipButton from 'components/plans/plans-skip-button';
 import { recordTracksEvent } from 'state/analytics/actions';
-import { abtest } from 'lib/abtest';
 
 /**
  * Constants
@@ -30,6 +29,7 @@ class JetpackPlansGrid extends Component {
 		isLanding: PropTypes.bool,
 		onSelect: PropTypes.func,
 		selectedSite: PropTypes.object,
+		hidePersonalOfferReset: PropTypes.bool,
 
 		// Connected
 		translate: PropTypes.func.isRequired,
@@ -54,9 +54,9 @@ class JetpackPlansGrid extends Component {
 	}
 
 	render() {
-		const { interval } = this.props;
+		const { interval, hidePersonalOfferReset } = this.props;
 		const defaultInterval = 'yearly';
-		const hidePersonal = 'withoutPersonal' === abtest( 'jpcPlansOfferResetPersonal' );
+		const hidePersonal = hidePersonalOfferReset;
 
 		return (
 			<MainWrapper isWide className="jetpack-connect__hide-plan-icons">

--- a/client/jetpack-connect/plans-grid.jsx
+++ b/client/jetpack-connect/plans-grid.jsx
@@ -5,6 +5,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -14,6 +15,7 @@ import FormattedHeader from 'components/formatted-header';
 import PlansFeaturesMain from 'my-sites/plans-features-main';
 import PlansSkipButton from 'components/plans/plans-skip-button';
 import { recordTracksEvent } from 'state/analytics/actions';
+import { abtest } from 'lib/abtest';
 
 /**
  * Constants
@@ -54,10 +56,15 @@ class JetpackPlansGrid extends Component {
 	render() {
 		const { interval } = this.props;
 		const defaultInterval = 'yearly';
+		const hidePersonal = 'withoutPersonal' === abtest( 'jpcPlansOfferResetPersonal' );
 
 		return (
 			<MainWrapper isWide className="jetpack-connect__hide-plan-icons">
-				<div className="jetpack-connect__plans">
+				<div
+					className={ classNames( 'jetpack-connect__plans', {
+						'is-offer-reset-test': hidePersonal,
+					} ) }
+				>
 					{ this.renderConnectHeader() }
 					<div id="plans">
 						<PlansFeaturesMain
@@ -69,6 +76,7 @@ class JetpackPlansGrid extends Component {
 							intervalType={ interval ? interval : defaultInterval }
 							hideFreePlan={ this.props.hideFreePlan }
 							displayJetpackPlans={ true }
+							hidePersonalPlan={ hidePersonal }
 						/>
 
 						<PlansSkipButton onClick={ this.handleSkipButtonClick } />

--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -39,6 +39,7 @@ import hasInitializedSites from 'state/selectors/has-initialized-sites';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import { persistSignupDestination } from 'signup/utils';
 import { isJetpackProductSlug as getJetpackProductSlug } from 'lib/products-values';
+import { abtest } from 'lib/abtest';
 
 const CALYPSO_PLANS_PAGE = '/plans/';
 const CALYPSO_MY_PLAN_PAGE = '/plans/my-plan/';
@@ -222,6 +223,7 @@ class Plans extends Component {
 					isLanding={ false }
 					interval={ interval }
 					selectedSite={ selectedSite }
+					hidePersonalOfferReset={ 'withoutPersonal' === abtest( 'jpcPlansOfferResetPersonal' ) }
 				>
 					<LoggedOutFormLinks>
 						<JetpackConnectHappychatButton

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -683,8 +683,22 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 		margin-bottom: 32px;
 	}
 
-	&.is-offer-reset-test .plan-features__table {
-		max-width: none;
+	&.is-offer-reset-test {
+		.plan-features__table {
+			max-width: none;
+		}
+
+		.plan-features__row .plan-features__item {
+			margin: 0 24px;
+		}
+
+		.plan-features__row .plan-features__item:last-child {
+			margin: 0 24px 12px;
+		}
+
+		.plan-features--signup .plan-features__actions {
+			padding: 0 24px 15px;
+		}
 	}
 }
 

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -688,16 +688,31 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 			max-width: none;
 		}
 
-		.plan-features__row .plan-features__item {
+		.plan-features__item {
 			margin: 0 24px;
 		}
 
-		.plan-features__row .plan-features__item:last-child {
+		.plan-features__item:last-child {
 			margin: 0 24px 12px;
 		}
 
 		.plan-features--signup .plan-features__actions {
 			padding: 0 24px 15px;
+		}
+
+		.plan-features__pricing {
+			margin-left: 24px;
+			margin-right: 24px;
+			padding: 0;
+		}
+
+		.foldable-card .foldable-card__header {
+			padding-left: 24px;
+			padding-right: 24px;
+		}
+
+		.foldable-card .foldable-card__action {
+			right: 12px;
 		}
 	}
 }

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -682,6 +682,10 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 	.plans-skip-button {
 		margin-bottom: 32px;
 	}
+
+	&.is-offer-reset-test .plan-features__table {
+		max-width: none;
+	}
 }
 
 .jetpack-connect__plans.placeholder {

--- a/client/jetpack-connect/test/__snapshots__/plans.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/plans.js.snap
@@ -20,6 +20,7 @@ exports[`Plans should render plans 1`] = `
   <Connect(Localized(JetpackPlansGrid))
     basePlansPath="/jetpack/connect/plans"
     hideFreePlan={true}
+    hidePersonalOfferReset={false}
     isLanding={false}
     onSelect={[Function]}
     selectedSite={

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -126,4 +126,14 @@ export default {
 		localeTargets: [ 'en' ],
 		countryCodeTargets: [ 'US', 'ID', 'NG', 'BD', 'NL', 'SE', 'SG', 'LK', 'NZ', 'IE' ],
 	},
+	jpcPlansOfferResetPersonal: {
+		datestamp: '20200513',
+		variations: {
+			withPersonal: 50,
+			withoutPersonal: 50,
+		},
+		defaultVariation: 'withPersonal',
+		allowExistingUsers: true,
+		localeTargets: 'any',
+	},
 };


### PR DESCRIPTION
For backstory, see p1HpG7-8PX-p2.

#### Changes proposed in this Pull Request

* Adds an AB test that removes the personal plan from the Jetpack Connect plans grid shown after a user connects.

#### Testing instructions

- Checkout this patch locally
- Start Calypso locally
- Create JN site
- Connect JN site
- After connecting the site, you should land on the plans grid. Replace `wordpress.com` in the URL with `calypso.localhost:3000`
- Ensure that you can force the variation with the following:
   - `localStorage.setItem( 'ABTests', '{"jpcPlansOfferResetPersonal_20200513":"withPersonal"}' );`
   - `localStorage.setItem( 'ABTests', '{"jpcPlansOfferResetPersonal_20200513":"withoutPersonal"}' );`
- After several minutes, view tracks events for your WP.com user and ensure that you see an event named `calypso_abtest_start` with an `abtest_name` property value of `jpcPlansOfferResetPersonal_20200513`
- Go to `/jetpack/connect/store` and ensure that personal is shown for either variation

#### After screenshot

![screencapture-calypso-localhost-3000-jetpack-connect-plans-genuine-monkey-jurassic-ninja-2020-05-13-14_10_29](https://user-images.githubusercontent.com/1126811/81854468-95552280-9523-11ea-9109-ad6f8b1f02b5.png)

#### Before screenshot

![screencapture-calypso-localhost-3000-jetpack-connect-plans-genuine-monkey-jurassic-ninja-2020-05-13-14_10_12](https://user-images.githubusercontent.com/1126811/81854482-9be39a00-9523-11ea-8d95-d0566a181117.png)
