### PR TITLE
Add /log-in screen for Jetpack Cloud

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -28,7 +28,6 @@ import { getCurrentOAuth2Client } from 'state/ui/oauth2-clients/selectors';
 import getCurrentQueryArguments from 'state/selectors/get-current-query-arguments';
 import getPartnerSlugFromQuery from 'state/selectors/get-partner-slug-from-query';
 import { rebootAfterLogin } from 'state/login/actions';
-import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
 import {
 	isCrowdsignalOAuth2Client,
 	isJetpackCloudOAuth2Client,

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -42,7 +42,7 @@ import ContinueAsUser from './continue-as-user';
 import ErrorNotice from './error-notice';
 import LoginForm from './login-form';
 import { isWebAuthnSupported } from 'lib/webauthn';
-import WordPressLogo from 'components/wordpress-logo';
+import JetpackLogo from 'components/jetpack-logo';
 
 /**
  * Style dependencies
@@ -287,7 +287,7 @@ class Login extends Component {
 				headerText = translate( 'Log in to Jetpack.com with your WordPress.com account.' );
 				preHeader = (
 					<div className="login__jetpack-cloud-wrapper">
-						<WordPressLogo />
+						<JetpackLogo full={ false } size={ 60 } />
 					</div>
 				);
 			}
@@ -458,6 +458,7 @@ class Login extends Component {
 				{ this.renderNotice() }
 
 				{ this.renderContent() }
+
 				{ this.renderFooter() }
 			</div>
 		);

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -28,7 +28,12 @@ import { getCurrentOAuth2Client } from 'state/ui/oauth2-clients/selectors';
 import getCurrentQueryArguments from 'state/selectors/get-current-query-arguments';
 import getPartnerSlugFromQuery from 'state/selectors/get-partner-slug-from-query';
 import { rebootAfterLogin } from 'state/login/actions';
-import { isCrowdsignalOAuth2Client, isWooOAuth2Client } from 'lib/oauth2-clients';
+import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
+import {
+	isCrowdsignalOAuth2Client,
+	isJetpackCloudOAuth2Client,
+	isWooOAuth2Client,
+} from 'lib/oauth2-clients';
 import { login } from 'lib/paths';
 import Notice from 'components/notice';
 import AsyncLoad from 'components/async-load';
@@ -38,6 +43,7 @@ import ContinueAsUser from './continue-as-user';
 import ErrorNotice from './error-notice';
 import LoginForm from './login-form';
 import { isWebAuthnSupported } from 'lib/webauthn';
+import WordPressLogo from 'components/wordpress-logo';
 
 /**
  * Style dependencies
@@ -278,6 +284,15 @@ class Login extends Component {
 				);
 			}
 
+			if ( isJetpackCloudOAuth2Client( oauth2Client ) ) {
+				headerText = translate( 'Log in to Jetpack.com with your WordPress.com account.' );
+				preHeader = (
+					<div className="login__jetpack-cloud-wrapper">
+						<WordPressLogo />
+					</div>
+				);
+			}
+
 			if ( isCrowdsignalOAuth2Client( oauth2Client ) ) {
 				headerText = translate( 'Sign in to %(clientTitle)s', {
 					args: {
@@ -429,9 +444,14 @@ class Login extends Component {
 	}
 
 	render() {
-		const { isJetpack } = this.props;
+		const { isJetpack, oauth2Client } = this.props;
 		return (
-			<div className={ classNames( 'login', { 'is-jetpack': isJetpack } ) }>
+			<div
+				className={ classNames( 'login', {
+					'is-jetpack': isJetpack,
+					'is-jetpack-cloud': isJetpackCloudOAuth2Client( oauth2Client ),
+				} ) }
+			>
 				{ this.renderHeader() }
 
 				<ErrorNotice />

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -122,7 +122,7 @@
 		display: block;
 		font-size: 14px;
 		line-height: 1.5;
-		font-weight: 500;
+		font-weight: 600;
 		margin-bottom: 5px;
 	}
 

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -19,6 +19,49 @@
 	}
 }
 
+.login__jetpack-cloud-wrapper {
+	svg.wordpress-logo {
+		fill: var( --studio-wordpress-blue );
+	}
+}
+
+// all colors here are taken from client/assets/stylesheets/_calypso-color-scheme-jetpack-cloud.scss
+.layout:not( .is-jetpack-woocommerce-flow ):not( .is-wccom-oauth-flow ) {
+	.login.is-jetpack-cloud {
+		.button.is-primary {
+			color: var( --studio-white );
+			background: var( --studio-jetpack-green-40 );
+			border-color: var( --studio-jetpack-green-40 );
+
+			&:hover,
+			&:focus {
+				background: var( --studio-jetpack-green-30 );
+				border-color: var( --studio-jetpack-green-30 );
+			}
+
+			&:active {
+				background: var( --studio-jetpack-green-50 );
+				border-color: var( --studio-jetpack-green-50 );
+			}
+
+			&[disabled],
+			&:disabled {
+				color: var( --studio-white );
+				background: var( --studio-gray-10 );
+				border-color: var( --studio-gray-10 );
+			}
+		}
+
+		a {
+			color: var( --studio-jetpack-green-40 );
+
+			&:focus {
+				color: var( --studio-jetpack-green-60 );
+			}
+		}
+	}
+}
+
 .layout.is-wccom-oauth-flow {
 	.layout__content {
 		padding-top: 48px;

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -19,49 +19,6 @@
 	}
 }
 
-.login__jetpack-cloud-wrapper {
-	svg.wordpress-logo {
-		fill: var( --studio-wordpress-blue );
-	}
-}
-
-// all colors here are taken from client/assets/stylesheets/_calypso-color-scheme-jetpack-cloud.scss
-.layout:not( .is-jetpack-woocommerce-flow ):not( .is-wccom-oauth-flow ) {
-	.login.is-jetpack-cloud {
-		.button.is-primary {
-			color: var( --studio-white );
-			background: var( --studio-jetpack-green-40 );
-			border-color: var( --studio-jetpack-green-40 );
-
-			&:hover,
-			&:focus {
-				background: var( --studio-jetpack-green-30 );
-				border-color: var( --studio-jetpack-green-30 );
-			}
-
-			&:active {
-				background: var( --studio-jetpack-green-50 );
-				border-color: var( --studio-jetpack-green-50 );
-			}
-
-			&[disabled],
-			&:disabled {
-				color: var( --studio-white );
-				background: var( --studio-gray-10 );
-				border-color: var( --studio-gray-10 );
-			}
-		}
-
-		a {
-			color: var( --studio-jetpack-green-40 );
-
-			&:focus {
-				color: var( --studio-jetpack-green-60 );
-			}
-		}
-	}
-}
-
 .layout.is-wccom-oauth-flow {
 	.layout__content {
 		padding-top: 48px;
@@ -165,7 +122,7 @@
 		display: block;
 		font-size: 14px;
 		line-height: 1.5;
-		font-weight: 400;
+		font-weight: 500;
 		margin-bottom: 5px;
 	}
 

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -165,7 +165,7 @@
 		display: block;
 		font-size: 14px;
 		line-height: 1.5;
-		font-weight: 600;
+		font-weight: 400;
 		margin-bottom: 5px;
 	}
 

--- a/client/layout/masterbar/oauth-client.jsx
+++ b/client/layout/masterbar/oauth-client.jsx
@@ -9,9 +9,14 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
+import {
+	isCrowdsignalOAuth2Client,
+	isWooOAuth2Client,
+	isJetpackCloudOAuth2Client,
+} from 'lib/oauth2-clients';
 import { localizeUrl } from 'lib/i18n-utils';
-import { isCrowdsignalOAuth2Client, isWooOAuth2Client } from 'lib/oauth2-clients';
 import CrowdsignalOauthMasterbar from './crowdsignal';
+import JetpackLogo from 'components/jetpack-logo';
 
 /**
  * Style dependencies
@@ -23,10 +28,16 @@ const DefaultOauthClientMasterbar = ( { oauth2Client } ) => (
 		<nav>
 			<ul className="masterbar__oauth-client-main-nav">
 				<li className="masterbar__oauth-client-current">
-					{ oauth2Client.icon && (
+					{ isJetpackCloudOAuth2Client( oauth2Client ) ? (
 						<div className="masterbar__oauth-client-logo">
-							<img src={ oauth2Client.icon } alt={ oauth2Client.title } />
+							<JetpackLogo full monochrome={ false } size={ 28 } />
 						</div>
+					) : (
+						oauth2Client.icon && (
+							<div className="masterbar__oauth-client-logo">
+								<img src={ oauth2Client.icon } alt={ oauth2Client.title } />
+							</div>
+						)
 					) }
 				</li>
 
@@ -38,7 +49,7 @@ const DefaultOauthClientMasterbar = ( { oauth2Client } ) => (
 					</li>
 				) }
 
-				{ ! isWooOAuth2Client( oauth2Client ) && (
+				{ ! isWooOAuth2Client( oauth2Client ) && ! isJetpackCloudOAuth2Client( oauth2Client ) && (
 					<li className="masterbar__oauth-client-wpcc-sign-in">
 						<a
 							href={ localizeUrl( 'https://wordpress.com/' ) }

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -711,6 +711,10 @@
 }
 
 .jetpack-cloud {
+	.login.is-jetpack-cloud {
+		max-width: 375px;
+	}
+
 	.masterbar__oauth-client {
 		height: unset;
 		.masterbar__oauth-client-main-nav {
@@ -725,7 +729,7 @@
 	}
 
 	.masterbar.masterbar__oauth-client {
-		border: none;
+		border: 1px solid var( --studio-gray-5 );
 	}
 
 	// background: #e6e6e6;
@@ -734,13 +738,21 @@
 	main.wp-login__main.main {
 		background: var( --studio-white );
 		padding-bottom: 0;
+		max-width: 640px;
+		border: 1px solid var( --studio-gray-5 );
 
 		.card.login__form,
 		.card.login__social {
 			box-shadow: none;
 		}
 		.card.login__form {
-			border-bottom: 1px solid var( --color-border-subtle );
+			border-bottom: 1px solid var( --studio-gray-5 );
+		}
+
+		.wp-login__container {
+			display: flex;
+			flex-direction: column;
+			align-items: center;
 		}
 	}
 
@@ -783,8 +795,10 @@
 	}
 
 	.login__jetpack-cloud-wrapper {
+		padding-top: 32px;
+
 		svg.wordpress-logo {
-			fill: var( --studio-wordpress-blue );
+			fill: var( --studio-wordpress-blue-40 );
 		}
 	}
 }

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -714,6 +714,10 @@
 	background: var( --studio-gray-0 );
 	min-height: 100%;
 
+	.step-wrapper .formatted-header {
+		margin-top: 0;
+	}
+
 	.login.is-jetpack-cloud {
 		width: 100%;
 		display: flex;
@@ -725,19 +729,37 @@
 		}
 	}
 
-	input:focus:hover[type='text'],
-	input:focus[type='text'],
-	input:focus:hover[type='password'],
-	input:focus[type='password'],
-	input:focus:hover[type='tel'],
-	input:focus[type='tel'] {
+	// primary text rules
+	.login__form-header,
+	.signup-form__jetpack-cloud-wrapper h3 {
+		font-weight: 600;
+		font-size: 22px;
+		line-height: 32px;
+		margin-bottom: 24px;
+		margin-top: 16px;
+		text-align: center;
+	}
+
+	input:focus:hover[type],
+	input:focus[type] {
 		box-shadow: 0 0 0 2px var( --studio-jetpack-green-10 );
+	}
+
+	.login__form-header-wrapper,
+	.signup-form__jetpack-cloud-wrapper {
+		padding: 32px 0 0;
+		display: flex;
+		align-items: center;
+		flex-direction: column;
+		width: 100%;
+		> * {
+			max-width: 375px;
+		}
 	}
 
 	.wp-login__links,
 	.login__social,
-	.login__form,
-	.login__form-header-wrapper {
+	.login__form {
 		width: 100%;
 		max-width: 375px;
 	}
@@ -914,19 +936,6 @@
 		&:hover,
 		&:focus {
 			color: var( --studio-jetpack-green-60 );
-		}
-	}
-
-	.login__form-header-wrapper {
-		padding: 16px;
-	}
-
-	.signup-form__jetpack-cloud-wrapper,
-	.login__jetpack-cloud-wrapper {
-		padding-top: 32px;
-
-		svg.wordpress-logo {
-			fill: var( --studio-wordpress-blue-40 );
 		}
 	}
 }

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -711,8 +711,10 @@
 }
 
 .jetpack-cloud {
+	background: var( --studio-gray-0 );
+	min-height: 100%;
+
 	.login.is-jetpack-cloud {
-		// 	max-width: 375px;
 		width: 100%;
 		display: flex;
 		flex-direction: column;
@@ -723,10 +725,11 @@
 		}
 	}
 
+	.wp-login__links,
+	.login__social,
+	.login__form,
 	.login__form-header-wrapper {
-		max-width: 375px;
-	}
-	.login__form {
+		width: 100%;
 		max-width: 375px;
 	}
 
@@ -742,13 +745,6 @@
 			width: 100%;
 			z-index: 1;
 		}
-	}
-
-	.login__social {
-		max-width: 375px;
-	}
-	.wp-login__links {
-		max-width: 375px;
 	}
 
 	.masterbar__oauth-client {
@@ -768,8 +764,32 @@
 		border: 1px solid var( --studio-gray-5 );
 	}
 
-	// background: #e6e6e6;
-	// min-height: 100%;
+	.signup__step.is-oauth-2-user {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		.step-wrapper {
+			background: var( --studio-white );
+			padding-bottom: 0;
+			max-width: 640px;
+			border: 1px solid var( --studio-gray-5 );
+			width: 100%;
+
+			.card.logged-out-form {
+				border: none;
+				box-shadow: none;
+			}
+
+			form {
+				max-width: 375px;
+				width: 100%;
+			}
+		}
+	}
+
+	.layout__content {
+		padding-top: 90px;
+	}
 
 	main.wp-login__main.main {
 		background: var( --studio-white );
@@ -810,6 +830,41 @@
 		}
 	}
 
+	.card.two-factor-authentication__verification-code-form,
+	.card.two-factor-authentication__actions {
+		border: none;
+		box-shadow: none;
+	}
+
+	.button:not( .social-buttons__button ) {
+		color: var( --studio-jetpack-green-60 );
+		background: var( --studio-white );
+		border: 1px solid var( --studio-jetpack-green-40 );
+		border-radius: 3px;
+
+		&:hover,
+		&:focus {
+			background: var( --studio-jetpack-green-0 );
+		}
+
+		&:active {
+			background: var( --studio-jetpack-green-5 );
+			border-color: var( --studio-jetpack-green-40 );
+			border-width: 1px;
+		}
+
+		&[disabled]:active {
+			border-width: 1px;
+		}
+
+		&[disabled],
+		&:disabled {
+			color: var( --studio-gray-10 );
+			border-color: var( --color-gray-10 );
+			background: var( --studio-white );
+		}
+	}
+
 	.button.is-primary {
 		color: var( --studio-white );
 		background: var( --studio-jetpack-green-40 );
@@ -835,7 +890,8 @@
 	}
 
 	a,
-	a:visited {
+	a:visited,
+	.login__form-change-username {
 		color: var( --studio-jetpack-green-40 );
 
 		&:hover,
@@ -848,6 +904,7 @@
 		padding: 16px;
 	}
 
+	.signup-form__jetpack-cloud-wrapper,
 	.login__jetpack-cloud-wrapper {
 		padding-top: 32px;
 

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -725,12 +725,27 @@
 		}
 	}
 
+	input:focus:hover[type='text'],
+	input:focus[type='text'],
+	input:focus:hover[type='password'],
+	input:focus[type='password'] {
+		box-shadow: 0 0 0 2px var( --studio-jetpack-green-10 );
+	}
+
 	.wp-login__links,
 	.login__social,
 	.login__form,
 	.login__form-header-wrapper {
 		width: 100%;
 		max-width: 375px;
+	}
+
+	.login__form-terms {
+		margin-top: 8px;
+	}
+
+	.login__form-signup-link {
+		padding-top: 0;
 	}
 
 	.login__divider {

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -712,6 +712,42 @@
 
 .jetpack-cloud {
 	.login.is-jetpack-cloud {
+		// 	max-width: 375px;
+		width: 100%;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+
+		form {
+			width: 100%;
+		}
+	}
+
+	.login__form-header-wrapper {
+		max-width: 375px;
+	}
+	.login__form {
+		max-width: 375px;
+	}
+
+	.login__divider {
+		width: 100%;
+		&::before {
+			background: var( --color-neutral-5 );
+			content: '';
+			height: 1px;
+			left: 0;
+			position: absolute;
+			top: 50%;
+			width: 100%;
+			z-index: 1;
+		}
+	}
+
+	.login__social {
+		max-width: 375px;
+	}
+	.wp-login__links {
 		max-width: 375px;
 	}
 
@@ -746,13 +782,31 @@
 			box-shadow: none;
 		}
 		.card.login__form {
-			border-bottom: 1px solid var( --studio-gray-5 );
+			border-bottom: unset;
 		}
 
 		.wp-login__container {
 			display: flex;
 			flex-direction: column;
 			align-items: center;
+		}
+
+		.login__form {
+			display: flex;
+			flex-direction: column;
+
+			.login__form-userdata {
+				order: 1;
+			}
+			.login__form-action {
+				order: 2;
+			}
+			.login__form-terms {
+				order: 3;
+			}
+			.login__form-signup-link {
+				order: 4;
+			}
 		}
 	}
 

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -95,7 +95,8 @@
 		background: var( --studio-gray-0 );
 	}
 
-	a, a:visited {
+	a,
+	a:visited {
 		color: inherit;
 	}
 
@@ -149,7 +150,7 @@
 		.logged-out-form__back-link {
 			border: 0;
 			color: var( --color-text );
-			font-weight: normal;
+			font-weight: 400;
 			line-height: 21px;
 			margin: 30px 0 20px;
 			padding: 10px 16px;
@@ -221,7 +222,7 @@
 
 		.login__form label {
 			color: var( --color-text );
-			font-weight: normal;
+			font-weight: 400;
 		}
 
 		.login__form-header {
@@ -293,7 +294,7 @@
 
 			label {
 				color: var( --color-text );
-				font-weight: normal;
+				font-weight: 400;
 			}
 		}
 
@@ -313,7 +314,7 @@
 
 		.magic-login__footer a {
 			color: var( --color-text );
-			font-weight: normal;
+			font-weight: 400;
 			margin: 20px 0 15px;
 			padding: 10px 16px;
 			text-align: center;
@@ -637,7 +638,7 @@
 	.logged-out-form label,
 	.login__form-userdata label {
 		font-size: 16px;
-		font-weight: normal;
+		font-weight: 400;
 	}
 
 	.login__form-signup-link {
@@ -668,7 +669,7 @@
 		button {
 			border: none;
 			font-size: 16px;
-			font-weight: normal;
+			font-weight: 400;
 			line-height: 3em;
 			text-align: center;
 		}
@@ -705,6 +706,72 @@
 		@include breakpoint-deprecated( '>480px' ) {
 			font-size: 2em;
 			margin: 2em 0 0;
+		}
+	}
+}
+
+.jetpack-cloud {
+	.masterbar.masterbar__oauth-client {
+		border: none;
+	}
+
+	// background: #e6e6e6;
+	// min-height: 100%;
+
+	main.wp-login__main.main {
+		background: var( --studio-white );
+		padding-bottom: 0;
+
+		.card.login__form,
+		.card.login__social {
+			box-shadow: none;
+		}
+		.card.login__form {
+			border-bottom: 1px solid var( --color-border-subtle );
+		}
+	}
+
+	.button.is-primary {
+		color: var( --studio-white );
+		background: var( --studio-jetpack-green-40 );
+		border-color: var( --studio-jetpack-green-40 );
+
+		&:hover,
+		&:focus {
+			background: var( --studio-jetpack-green-30 );
+			border-color: var( --studio-jetpack-green-30 );
+		}
+
+		&:active {
+			background: var( --studio-jetpack-green-50 );
+			border-color: var( --studio-jetpack-green-50 );
+		}
+
+		&[disabled],
+		&:disabled {
+			color: var( --studio-white );
+			background: var( --studio-gray-10 );
+			border-color: var( --studio-gray-10 );
+		}
+	}
+
+	a,
+	a:visited {
+		color: var( --studio-jetpack-green-40 );
+
+		&:hover,
+		&:focus {
+			color: var( --studio-jetpack-green-60 );
+		}
+	}
+
+	.login__form-header-wrapper {
+		padding: 16px;
+	}
+
+	.login__jetpack-cloud-wrapper {
+		svg.wordpress-logo {
+			fill: var( --studio-wordpress-blue );
 		}
 	}
 }

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -711,6 +711,19 @@
 }
 
 .jetpack-cloud {
+	.masterbar__oauth-client {
+		height: unset;
+		.masterbar__oauth-client-main-nav {
+			display: flex;
+			flex-direction: row;
+			justify-content: center;
+			.masterbar__oauth-client-logo {
+				padding: 14px 0;
+				line-height: normal;
+			}
+		}
+	}
+
 	.masterbar.masterbar__oauth-client {
 		border: none;
 	}

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -728,7 +728,9 @@
 	input:focus:hover[type='text'],
 	input:focus[type='text'],
 	input:focus:hover[type='password'],
-	input:focus[type='password'] {
+	input:focus[type='password'],
+	input:focus:hover[type='tel'],
+	input:focus[type='tel'] {
 		box-shadow: 0 0 0 2px var( --studio-jetpack-green-10 );
 	}
 

--- a/client/lib/oauth2-clients.js
+++ b/client/lib/oauth2-clients.js
@@ -12,3 +12,8 @@ export const isWooOAuth2Client = ( oauth2Client ) => {
 	// 50019 => WooCommerce Dev, 50915 => WooCommerce Staging, 50916 => WooCommerce Production.
 	return oauth2Client && includes( [ 50019, 50915, 50916 ], oauth2Client.id );
 };
+
+export const isJetpackCloudOAuth2Client = ( oauth2Client ) => {
+	// 68663 => Jetpack Cloud Dev,
+	return oauth2Client && includes( [ 68663 ], oauth2Client.id );
+};

--- a/client/lib/oauth2-clients.js
+++ b/client/lib/oauth2-clients.js
@@ -15,5 +15,5 @@ export const isWooOAuth2Client = ( oauth2Client ) => {
 
 export const isJetpackCloudOAuth2Client = ( oauth2Client ) => {
 	// 68663 => Jetpack Cloud Dev,
-	return oauth2Client && includes( [ 68663 ], oauth2Client.id );
+	return oauth2Client && includes( [ 68663, 69040, 69041 ], oauth2Client.id );
 };

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -15,7 +15,11 @@ import config, { isEnabled } from 'config';
 import ExternalLink from 'components/external-link';
 import Gridicon from 'components/gridicon';
 import LoggedOutFormBackLink from 'components/logged-out-form/back-link';
-import { isCrowdsignalOAuth2Client, isWooOAuth2Client } from 'lib/oauth2-clients';
+import {
+	isCrowdsignalOAuth2Client,
+	isJetpackCloudOAuth2Client,
+	isWooOAuth2Client,
+} from 'lib/oauth2-clients';
 import { addQueryArgs, getUrlParts } from 'lib/url';
 import { getCurrentOAuth2Client } from 'state/ui/oauth2-clients/selectors';
 import getCurrentQueryArguments from 'state/selectors/get-current-query-arguments';
@@ -311,6 +315,16 @@ export class LoginLinks extends React.Component {
 		if ( isGutenboarding ) {
 			const langFragment = locale && locale !== 'en' ? `/${ locale }` : '';
 			signupUrl = this.props.signupUrl || `/${ GUTENBOARDING_BASE_NAME }` + langFragment;
+		}
+
+		if ( oauth2Client && isJetpackCloudOAuth2Client( oauth2Client ) ) {
+			const redirectTo = get( currentQuery, 'redirect_to', '' );
+			const oauth2Params = new URLSearchParams( {
+				oauth2_client_id: oauth2Client.id,
+				oauth2_redirect: redirectTo,
+			} );
+
+			signupUrl = `${ signupUrl }/wpcc?${ oauth2Params.toString() }`;
 		}
 
 		return (

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -348,6 +348,7 @@ export class LoginLinks extends React.Component {
 				{ this.renderMagicLoginLink() }
 				{ this.renderResetPasswordLink() }
 				{ ! isCrowdsignalOAuth2Client( this.props.oauth2Client ) &&
+					! isJetpackCloudOAuth2Client( this.props.oauth2Client ) &&
 					! this.props.isGutenboarding &&
 					this.renderBackLink() }
 			</div>

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -186,6 +186,11 @@ export class LoginLinks extends React.Component {
 			return null;
 		}
 
+		// jetpack cloud cannot have users being sent to WordPress.com
+		if ( isJetpackCloudOAuth2Client( this.props.oauth2Client ) ) {
+			return null;
+		}
+
 		// @todo Implement a muriel version of the email login links for the WooCommerce onboarding flows
 		if (
 			config.isEnabled( 'woocommerce/onboarding-oauth' ) &&
@@ -231,6 +236,11 @@ export class LoginLinks extends React.Component {
 
 	renderResetPasswordLink() {
 		if ( this.props.twoFactorAuthType || this.props.privateSite ) {
+			return null;
+		}
+
+		// jetpack cloud needs to keep users in the flow
+		if ( isJetpackCloudOAuth2Client( this.props.oauth2Client ) ) {
 			return null;
 		}
 
@@ -348,7 +358,6 @@ export class LoginLinks extends React.Component {
 				{ this.renderMagicLoginLink() }
 				{ this.renderResetPasswordLink() }
 				{ ! isCrowdsignalOAuth2Client( this.props.oauth2Client ) &&
-					! isJetpackCloudOAuth2Client( this.props.oauth2Client ) &&
 					! this.props.isGutenboarding &&
 					this.renderBackLink() }
 			</div>

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -12,7 +12,11 @@ import cookie from 'cookie';
 /**
  * Internal dependencies
  */
-import { isCrowdsignalOAuth2Client, isWooOAuth2Client } from 'lib/oauth2-clients';
+import {
+	isCrowdsignalOAuth2Client,
+	isWooOAuth2Client,
+	isJetpackCloudOAuth2Client,
+} from 'lib/oauth2-clients';
 import StepWrapper from 'signup/step-wrapper';
 import flows from 'signup/config/flows';
 import SignupForm from 'blocks/signup-form';
@@ -30,6 +34,7 @@ import AsyncLoad from 'components/async-load';
 import WooCommerceConnectCartHeader from 'extensions/woocommerce/components/woocommerce-connect-cart-header';
 import { getSocialServiceFromClientId } from 'lib/login';
 import { abtest } from 'lib/abtest';
+import JetpackLogo from 'components/jetpack-logo';
 
 export class UserStep extends Component {
 	static propTypes = {
@@ -321,6 +326,15 @@ export class UserStep extends Component {
 						{ translate( 'Create a WordPress.com account' ) }
 					</div>
 				</Fragment>
+			);
+		}
+
+		if ( isJetpackCloudOAuth2Client( oauth2Client ) ) {
+			return (
+				<div className={ classNames( 'signup-form__jetpack-cloud-wrapper' ) }>
+					<JetpackLogo full={ false } size={ 60 } />
+					<h3>{ translate( 'Sign up to Jetpack.com with a WordPress.com account.' ) }</h3>
+				</div>
 			);
 		}
 

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -12,11 +12,7 @@ import cookie from 'cookie';
 /**
  * Internal dependencies
  */
-import {
-	isCrowdsignalOAuth2Client,
-	isJetpackCloudOAuth2Client,
-	isWooOAuth2Client,
-} from 'lib/oauth2-clients';
+import { isCrowdsignalOAuth2Client, isWooOAuth2Client } from 'lib/oauth2-clients';
 import StepWrapper from 'signup/step-wrapper';
 import flows from 'signup/config/flows';
 import SignupForm from 'blocks/signup-form';
@@ -34,7 +30,6 @@ import AsyncLoad from 'components/async-load';
 import WooCommerceConnectCartHeader from 'extensions/woocommerce/components/woocommerce-connect-cart-header';
 import { getSocialServiceFromClientId } from 'lib/login';
 import { abtest } from 'lib/abtest';
-import WordPressLogo from 'components/wordpress-logo';
 
 export class UserStep extends Component {
 	static propTypes = {
@@ -326,19 +321,6 @@ export class UserStep extends Component {
 						{ translate( 'Create a WordPress.com account' ) }
 					</div>
 				</Fragment>
-			);
-		}
-
-		if ( isJetpackCloudOAuth2Client( oauth2Client ) ) {
-			return (
-				<>
-					<div className={ classNames( 'signup-form__jetpack-cloud-wrapper' ) }>
-						<WordPressLogo />
-					</div>
-					<div className={ classNames( 'signup-form__jetpack-cloud-heading' ) }>
-						{ translate( 'Sign up for Jetpack.com with your WordPress.com account.' ) }
-					</div>
-				</>
 			);
 		}
 

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -12,7 +12,11 @@ import cookie from 'cookie';
 /**
  * Internal dependencies
  */
-import { isCrowdsignalOAuth2Client, isWooOAuth2Client } from 'lib/oauth2-clients';
+import {
+	isCrowdsignalOAuth2Client,
+	isJetpackCloudOAuth2Client,
+	isWooOAuth2Client,
+} from 'lib/oauth2-clients';
 import StepWrapper from 'signup/step-wrapper';
 import flows from 'signup/config/flows';
 import SignupForm from 'blocks/signup-form';
@@ -30,6 +34,7 @@ import AsyncLoad from 'components/async-load';
 import WooCommerceConnectCartHeader from 'extensions/woocommerce/components/woocommerce-connect-cart-header';
 import { getSocialServiceFromClientId } from 'lib/login';
 import { abtest } from 'lib/abtest';
+import WordPressLogo from 'components/wordpress-logo';
 
 export class UserStep extends Component {
 	static propTypes = {
@@ -321,6 +326,19 @@ export class UserStep extends Component {
 						{ translate( 'Create a WordPress.com account' ) }
 					</div>
 				</Fragment>
+			);
+		}
+
+		if ( isJetpackCloudOAuth2Client( oauth2Client ) ) {
+			return (
+				<>
+					<div className={ classNames( 'signup-form__jetpack-cloud-wrapper' ) }>
+						<WordPressLogo />
+					</div>
+					<div className={ classNames( 'signup-form__jetpack-cloud-heading' ) }>
+						{ translate( 'Sign up for Jetpack.com with your WordPress.com account.' ) }
+					</div>
+				</>
 			);
 		}
 

--- a/client/state/oauth2-clients/reducer.js
+++ b/client/state/oauth2-clients/reducer.js
@@ -46,6 +46,12 @@ export const initialClientsData = {
 		title: 'WooCommerce.com',
 		icon: 'https://woocommerce.com/wp-content/themes/woo/images/logo-woocommerce@2x.png',
 	},
+	68663: {
+		id: 68663,
+		name: 'jetpack-cloud',
+		title: 'Jetpack Cloud',
+		icon: 'https://s0.wp.com/wp-content/themes/a8c/jetpackme-new/images-2019/jetpack-logo.png',
+	},
 };
 
 export default function oauth2Clients( state = initialClientsData, action ) {

--- a/client/state/oauth2-clients/reducer.js
+++ b/client/state/oauth2-clients/reducer.js
@@ -52,6 +52,18 @@ export const initialClientsData = {
 		title: 'Jetpack Cloud',
 		icon: 'https://s0.wp.com/wp-content/themes/a8c/jetpackme-new/images-2019/jetpack-logo.png',
 	},
+	69040: {
+		id: 69040,
+		name: 'jetpack-cloud',
+		title: 'Jetpack Cloud',
+		icon: 'https://s0.wp.com/wp-content/themes/a8c/jetpackme-new/images-2019/jetpack-logo.png',
+	},
+	69041: {
+		id: 69041,
+		name: 'jetpack-cloud',
+		title: 'Jetpack Cloud',
+		icon: 'https://s0.wp.com/wp-content/themes/a8c/jetpackme-new/images-2019/jetpack-logo.png',
+	},
 };
 
 export default function oauth2Clients( state = initialClientsData, action ) {

--- a/client/state/oauth2-clients/reducer.js
+++ b/client/state/oauth2-clients/reducer.js
@@ -50,19 +50,16 @@ export const initialClientsData = {
 		id: 68663,
 		name: 'jetpack-cloud',
 		title: 'Jetpack Cloud',
-		icon: 'https://s0.wp.com/wp-content/themes/a8c/jetpackme-new/images-2019/jetpack-logo.png',
 	},
 	69040: {
 		id: 69040,
 		name: 'jetpack-cloud',
 		title: 'Jetpack Cloud',
-		icon: 'https://s0.wp.com/wp-content/themes/a8c/jetpackme-new/images-2019/jetpack-logo.png',
 	},
 	69041: {
 		id: 69041,
 		name: 'jetpack-cloud',
 		title: 'Jetpack Cloud',
-		icon: 'https://s0.wp.com/wp-content/themes/a8c/jetpackme-new/images-2019/jetpack-logo.png',
 	},
 };
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

![Untitled 5](https://user-images.githubusercontent.com/2810519/82847040-b95c2080-9ea0-11ea-9f98-06041a0bfe91.png)


#### Testing instructions
1. Boot branch locally ( as WordPress.com, not Jetpack Cloud )
2. Open `cloud.jetpack.com` in a private window
3. Click "Authorize Jetpack Cloud"
4. Replace "WordPress.com" in the url with "calypso.localhost:3000"
5. Navigate through the flow highlighted above, making sure it appears as in the screenshots ( hint: the image is very large, so you can open it in a new tab )
