### PR TITLE
My Home: Add the desktop app flag to API calls when appropriate.

### DIFF
--- a/client/state/data-layer/wpcom/sites/home/layout/index.js
+++ b/client/state/data-layer/wpcom/sites/home/layout/index.js
@@ -9,12 +9,16 @@ import { setHomeLayout } from 'state/home/actions';
 import config from 'config';
 
 const requestLayout = ( action ) => {
+	const query = {
+		...( config.isEnabled( 'home/layout-dev' ) && { dev: true } ),
+		...( config.isEnabled( 'desktop' ) && { 'desktop-app': true } ),
+	};
 	return http(
 		{
 			method: 'GET',
 			path: `/sites/${ action.siteId }/home/layout`,
 			apiNamespace: 'wpcom/v2',
-			...( config.isEnabled( 'home/layout-dev' ) && { query: { dev: true } } ),
+			query,
 		},
 		action
 	);


### PR DESCRIPTION
With desktop app releases not happening very often, the app can end up with out-of-date Calypso builds with respect to My Home. This PR will ensure that regardless of developments in My Home and its API, the same stable data will be delivered to desktop app users.

#### Testing instructions

* Sandbox the API and apply D43414-code to it.
* Run the desktop app locally using this branch as the Calypso build.
* Go to My Home for any site, and in the devtools, confirm the `VIEW_DESKTOP_APP` view was received from the API.
* Load My Home with a variety of types of sites; verify you always get the same view.

Fixes https://github.com/Automattic/wp-desktop/issues/877
