### PR TITLE
add launch_site event immediately after the launch button is clicked

### DIFF
--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -148,7 +148,7 @@ export default {
 		// We record the event here because the launch button itself is managed by the wpcom-block-editor app
 		// wpcom-block-editor app may be treated differently by the ad blocker but this code is guaranteed to be hit.
 		if ( context.pathname === '/start/new-launch' ) {
-			recordTracksEvent( 'calypso_site_launch_start' );
+			recordTracksEvent( 'calypso_newsite_launch_start' );
 		}
 
 		context.store.dispatch( setCurrentFlowName( flowName ) );

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -144,6 +144,13 @@ export default {
 			}
 		}
 
+		// Record a `calypso_*` tracks event after clicking the launch button.
+		// We record the event here because the launch button itself is managed by the wpcom-block-editor app
+		// wpcom-block-editor app may be treated differently by the ad blocker but this code is guaranteed to be hit.
+		if ( context.pathname === '/start/new-launch' ) {
+			recordTracksEvent( 'calypso_site_launch_start' );
+		}
+
 		context.store.dispatch( setCurrentFlowName( flowName ) );
 
 		if ( ! userLoggedIn && shouldForceLogin( flowName ) ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Added the `calypso_site_launch_start` event when the launch button is clicked after following the gutenboarding flow. This had to be done on the page after `launch` because the `launch` button is managed by the `wpcom-block-editor` app

#### Testing instructions for launch event
* [ x ] Go through the existing signup flow from `/start`
         * The `calypso_site_launch_start` event should not be triggered at any point 
* [ x ] Go through `/new` with a free domain
     * Click the `Launch` button
         * the `calypso_site_launch_start` event is triggered and you will be on the domain select page.
* [ x ] Go through `/new` with a paid domain
    * Click on the `Launch` button
         * the `calypso_site_launch_start` event is triggered and you will be on the domain select page.

