### PR TITLE
Premium Content Block: Add success message on plan creation

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/container/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/container/edit.js
@@ -2,7 +2,14 @@
  * WordPress dependencies
  */
 import { useEffect, useState, useRef } from '@wordpress/element';
-import { Placeholder, Button, ExternalLink, withNotices, Spinner } from '@wordpress/components';
+import {
+	Placeholder,
+	Button,
+	ExternalLink,
+	withNotices,
+	Spinner,
+	Notice,
+} from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { compose } from '@wordpress/compose';
 import { withSelect, withDispatch } from '@wordpress/data';
@@ -154,6 +161,7 @@ function Edit( props ) {
 				setProducts( products.concat( [ newProduct ] ) );
 				// After successful adding of product, we want to select it. Presumably that is the product user wants.
 				selectPlan( newProduct );
+				onSuccess( props, __( 'Successfully created plan', 'premium-content' ) );
 				if ( callback ) {
 					callback( true );
 				}
@@ -402,6 +410,17 @@ function onError( props, message ) {
 	const { noticeOperations } = props;
 	noticeOperations.removeAllNotices();
 	noticeOperations.createErrorNotice( message );
+}
+
+/**
+ * @param { Props } props
+ * @param { string } message
+ * @return { void }
+ */
+function onSuccess( props, message ) {
+	const { noticeOperations } = props;
+	noticeOperations.removeAllNotices();
+	noticeOperations.createNotice( { status: 'info', content: message } );
 }
 
 /**

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/style.css
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/style.css
@@ -39,3 +39,6 @@
 .wp-block-premium-content-logged-out-view h3 {
 	margin-bottom: 20px;
 }
+
+/** Notices close button **/
+.wp-block-premium-content-container .components-notice-list .components-notice__content { margin: 0; }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add Notice on successful plan creation (Premium Content Block).

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In the Block editor, add a recurring payment plan using the premium content block.  Succesful creation will show a notice.

Fixes #42048
