### PR TITLE
Gutenboarding: Add reCAPTCHA to signup form

### DIFF
--- a/client/landing/gutenboarding/components/signup-form/index.tsx
+++ b/client/landing/gutenboarding/components/signup-form/index.tsx
@@ -76,7 +76,7 @@ const SignupForm = ( { onRequestClose }: Props ) => {
 		if ( typeof recaptchaClientId === 'number' ) {
 			recaptchaToken = await recordGoogleRecaptchaAction(
 				recaptchaClientId,
-				'calypso/gutenboarding/signup/formSubmit'
+				'calypso/signup/formSubmit'
 			);
 
 			if ( ! recaptchaToken ) {

--- a/client/landing/gutenboarding/components/signup-form/index.tsx
+++ b/client/landing/gutenboarding/components/signup-form/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Button, ExternalLink, TextControl, Modal, Notice } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
@@ -17,9 +17,14 @@ import ModalSubmitButton from '../modal-submit-button';
 import './style.scss';
 import SignupFormHeader from './header';
 import GUTENBOARDING_BASE_NAME from '../../basename.json';
-import { recordOnboardingError } from '../../lib/analytics';
+import {
+	initGoogleRecaptcha,
+	recordGoogleRecaptchaAction,
+	recordOnboardingError,
+} from '../../lib/analytics';
 import { localizeUrl } from '../../../../lib/i18n-utils';
 import { useTrackModal } from '../../hooks/use-track-modal';
+import config from '../../../../config';
 
 interface Props {
 	onRequestClose: () => void;
@@ -29,6 +34,7 @@ const SignupForm = ( { onRequestClose }: Props ) => {
 	const { __ } = useI18n();
 	const [ emailVal, setEmailVal ] = useState( '' );
 	const [ passwordVal, setPasswordVal ] = useState( '' );
+	const [ recaptchaClientId, setRecaptchaClientId ] = useState< number >();
 	const { createAccount, clearErrors } = useDispatch( USER_STORE );
 	const isFetchingNewUser = useSelect( ( select ) => select( USER_STORE ).isFetchingNewUser() );
 	const newUserError = useSelect( ( select ) => select( USER_STORE ).getNewUserError() );
@@ -46,13 +52,44 @@ const SignupForm = ( { onRequestClose }: Props ) => {
 
 	const lang = useLangRouteParam();
 
+	useEffect( () => {
+		initGoogleRecaptcha(
+			'g-recaptcha',
+			'calypso/signup/pageLoad',
+			config( 'google_recaptcha_site_key' )
+		).then( ( result ) => {
+			if ( ! result ) {
+				return;
+			}
+			setRecaptchaClientId( result.clientId );
+		} );
+	}, [ setRecaptchaClientId ] );
+
 	const handleSignUp = async ( event: React.FormEvent< HTMLFormElement > ) => {
 		event.preventDefault();
 
 		const username_hint = siteTitle || siteVertical?.label || null;
 
+		let recaptchaToken;
+		let recaptchaError;
+
+		if ( typeof recaptchaClientId === 'number' ) {
+			recaptchaToken = await recordGoogleRecaptchaAction(
+				recaptchaClientId,
+				'calypso/gutenboarding/signup/formSubmit'
+			);
+
+			if ( ! recaptchaToken ) {
+				recaptchaError = 'recaptcha_failed';
+			}
+		} else {
+			recaptchaError = 'recaptcha_didnt_load';
+		}
+
 		const result = await createAccount( {
 			email: emailVal,
+			'g-recaptcha-error': recaptchaError,
+			'g-recaptcha-response': recaptchaToken || undefined,
 			password: passwordVal,
 			signup_flow_name: 'gutenboarding',
 			locale: langParam,
@@ -78,6 +115,15 @@ const SignupForm = ( { onRequestClose }: Props ) => {
 			link_to_tos: <ExternalLink href={ localizedTosLink } />,
 		}
 	);
+
+	// translators: English wording comes from Google: https://developers.google.com/recaptcha/docs/faq#id-like-to-hide-the-recaptcha-badge.-what-is-allowed
+	const recaptcha_text = __(
+		'This site is protected by reCAPTCHA and the Google <link_to_policy>Privacy Policy</link_to_policy> and <link_to_tos>Terms of Service</link_to_tos> apply.'
+	);
+	const recaptcha_tos = createInterpolateElement( recaptcha_text, {
+		link_to_policy: <ExternalLink href="https://policies.google.com/privacy" />,
+		link_to_tos: <ExternalLink href="https://policies.google.com/terms" />,
+	} );
 
 	let errorMessage: string | undefined;
 	if ( newUserError ) {
@@ -164,13 +210,20 @@ const SignupForm = ( { onRequestClose }: Props ) => {
 							</p>
 
 							<p className="signup-form__link signup-form__terms-of-service-link">{ tos }</p>
+
 							<ModalSubmitButton disabled={ isFetchingNewUser } isBusy={ isFetchingNewUser }>
 								{ __( 'Create account' ) }
 							</ModalSubmitButton>
+
+							<p className="signup-form__link signup-form__terms-of-service-link signup-form__recaptcha_tos">
+								{ recaptcha_tos }
+							</p>
 						</div>
 					</fieldset>
 				</form>
 			</div>
+
+			<div id="g-recaptcha"></div>
 		</Modal>
 	);
 };

--- a/client/landing/gutenboarding/components/signup-form/style.scss
+++ b/client/landing/gutenboarding/components/signup-form/style.scss
@@ -20,6 +20,7 @@
 	max-width: 100%;
 	max-height: 100%;
 	transform: translate( 0%, 0% );
+	overflow-x: hidden; // prevent fixed reCAPTCHA badge from creating a horizontal scrollbar
 
 	.components-modal__header {
 		display: none;
@@ -110,17 +111,23 @@
 
 	.signup-form__link,
 	.signup-form__link a {
-		color: var( --studio-gray-80 );
+		@include onboarding-medium-text;
+		color: var( --studio-gray-40 );
 	}
 
 	.signup-form__terms-of-service-link {
 		@include onboarding-medium-text;
 		text-align: center;
 		color: var( --studio-gray-30 );
-		margin: 15px 0 20px;
+		margin: 15px auto 20px;
+		max-width: 400px;
+	}
 
-		.components-external-link {
-			text-decoration: none;
+	.signup-form__recaptcha_tos {
+		margin: 20px auto 15px;
+
+		@include break-small {
+			display: none;
 		}
 	}
 
@@ -180,5 +187,13 @@
 	// override spacing between input fields
 	.components-base-control .components-base-control__field {
 		margin-bottom: 10px;
+	}
+}
+
+.grecaptcha-badge {
+	visibility: hidden;
+
+	@include break-small {
+		visibility: visible;
 	}
 }

--- a/client/landing/gutenboarding/lib/analytics/index.ts
+++ b/client/landing/gutenboarding/lib/analytics/index.ts
@@ -11,6 +11,8 @@ import { FLOW_ID } from '../../constants';
 import type { StepNameType } from '../../path';
 import type { ErrorParameters, OnboardingCompleteParameters, TracksEventProperties } from './types';
 
+export * from './recaptcha';
+
 /**
  * Make tracks call with embedded flow.
  *

--- a/client/landing/gutenboarding/lib/analytics/recaptcha.ts
+++ b/client/landing/gutenboarding/lib/analytics/recaptcha.ts
@@ -1,0 +1,147 @@
+/**
+ * External dependencies
+ */
+import debugFactory from 'debug';
+
+/**
+ * Internal dependencies
+ */
+import { loadScript } from '@automattic/load-script';
+
+const debug = debugFactory( 'calypso:analytics:recaptcha' );
+
+const GOOGLE_RECAPTCHA_SCRIPT_URL = 'https://www.google.com/recaptcha/api.js?render=explicit';
+
+type GrecaptchaRenderParams = {
+	sitekey: string;
+	size?: string;
+};
+
+type GrecaptchaAction = {
+	action: string;
+};
+
+// Properties ad ded to the `window` object:
+declare global {
+	interface Window {
+		grecaptcha?: {
+			execute: ( clientId: number, action: GrecaptchaAction ) => void;
+			ready: ( callback: () => void ) => void;
+			render: ( elementId: string, params: GrecaptchaRenderParams ) => void;
+		};
+	}
+}
+
+/**
+ * Loads Google reCAPTCHA
+ *
+ * @returns {boolean} false if the script failed to load
+ */
+async function loadGoogleRecaptchaScript() {
+	if ( window.grecaptcha ) {
+		// reCAPTCHA already loaded
+		return true;
+	}
+
+	try {
+		const src = GOOGLE_RECAPTCHA_SCRIPT_URL;
+		await loadScript( src );
+		debug( 'loadGoogleRecaptchaScript: [Loaded]', src );
+		return true;
+	} catch ( error ) {
+		debug( 'loadGoogleRecaptchaScript: [Load Error] the script failed to load: ', error );
+		return false;
+	}
+}
+
+/**
+ * Renders reCAPTCHA badge to an explicit DOM id that should already be on the page
+ *
+ * @param {string} elementId - render client to this existing DOM node
+ * @param {string} siteKey - reCAPTCHA site key
+ * @returns {number} reCAPTCHA clientId
+ */
+async function renderRecaptchaClient( elementId: string, siteKey: string ) {
+	try {
+		const clientId = await window.grecaptcha?.render( elementId, {
+			sitekey: siteKey,
+			size: 'invisible',
+		} );
+		debug( 'renderRecaptchaClient: [Success]', elementId );
+		return clientId;
+	} catch ( error ) {
+		debug( 'renderRecaptchaClient: [Error]', error );
+		return null;
+	}
+}
+
+/**
+ * Records an arbitrary action to Google reCAPTCHA
+ *
+ * @param {number} clientId - a clientId of the reCAPTCHA instance
+ * @param {string} action  - name of action to record in reCAPTCHA
+ */
+export async function recordGoogleRecaptchaAction( clientId: number, action: string ) {
+	if ( ! window.grecaptcha ) {
+		debug(
+			'recordGoogleRecaptchaAction: [Error] window.grecaptcha not defined. Did you forget to init?'
+		);
+		return null;
+	}
+
+	try {
+		const token = await window.grecaptcha?.execute( clientId, { action } );
+		debug( 'recordGoogleRecaptchaAction: [Success]', action, token, clientId );
+		return token;
+	} catch ( error ) {
+		debug( 'recordGoogleRecaptchaAction: [Error]', action, error );
+		return null;
+	}
+}
+
+/**
+ * @typedef RecaptchaActionResult
+ * @property {string} token
+ * @property {number} clientId
+ */
+
+/**
+ * Records reCAPTCHA action, loading Google script if necessary.
+ *
+ * @param {string} elementId - a DOM id in which to render the reCAPTCHA client
+ * @param {string} action - name of action to record in reCAPTCHA
+ * @param {string} siteKey - reCAPTCHA site key
+ *
+ * @returns {RecaptchaActionResult|null} either the reCAPTCHA token and clientId, or null if the function fails
+ */
+export async function initGoogleRecaptcha( elementId: string, action: string, siteKey: string ) {
+	if ( ! siteKey ) {
+		return null;
+	}
+
+	if ( ! ( await loadGoogleRecaptchaScript() ) ) {
+		return null;
+	}
+
+	await new Promise( ( resolve ) => window.grecaptcha?.ready( resolve ) );
+
+	try {
+		const clientId = await renderRecaptchaClient( elementId, siteKey );
+		if ( clientId == null ) {
+			return null;
+		}
+
+		const token = await recordGoogleRecaptchaAction( clientId, action );
+		if ( token == null ) {
+			return null;
+		}
+
+		debug( 'initGoogleRecaptcha: [Success]', action, token, clientId );
+		return { token, clientId };
+	} catch ( error ) {
+		// We don't want errors interrupting our flow, so convert any exceptions
+		// into return values.
+		debug( 'initGoogleRecaptcha: [Error]', action, error );
+		return null;
+	}
+}

--- a/client/landing/gutenboarding/lib/analytics/recaptcha.ts
+++ b/client/landing/gutenboarding/lib/analytics/recaptcha.ts
@@ -21,7 +21,7 @@ type GrecaptchaAction = {
 	action: string;
 };
 
-// Properties ad ded to the `window` object:
+// Properties added to the `window` object by https://www.google.com/recaptcha/api.js:
 declare global {
 	interface Window {
 		grecaptcha?: {

--- a/packages/data-stores/src/user/types.ts
+++ b/packages/data-stores/src/user/types.ts
@@ -62,6 +62,8 @@ export interface CreateAccountParams {
 	is_passwordless?: boolean;
 	signup_flow_name?: string;
 	locale?: string;
+	'g-recaptcha-error'?: string;
+	'g-recaptcha-response'?: string;
 	extra?: {
 		first_name?: string;
 		last_name?: string;


### PR DESCRIPTION
Add reCAPTCHA to Gutenboarding signup form, with the same behaviour as found in the legacy signup flow at `/start`.

This uses the [reCAPTCHA "invisible" badge](https://developers.google.com/recaptcha/docs/versions#recaptcha_v2_invisible_recaptcha_badge) on desktop viewports, and paragraph text on mobile.

#### Screenshots

##### Desktop

![image](https://user-images.githubusercontent.com/14988353/81894292-c05a7780-95f2-11ea-910a-db4dd2ffcf5e.png)

##### Mobile

![image](https://user-images.githubusercontent.com/14988353/81894411-0a435d80-95f3-11ea-9e1e-4cf2fcaf2fa9.png)

#### Changes proposed in this Pull Request

* Add reCAPTCHA code from Calypso to Gutenboarding, with minimal types (this isn't DRY, but I assume it's preferable to importing the existing code directly from Calypso)
* Add reCAPTCHA to signup form
* Tweak the signup form styling a little bit to include the text-based reCAPTCHA TOS notice, make the links grey and bring back the underline to get a bit closer to the designs.
* Re-use the same signup action name as is used in /start: `'calypso/signup/formSubmit'`

Note: the signup form styling still needs work to match the designs, but I thought the bulk of this could wait until we turn the modal into a proper page, and leave it out of this PR. For the moment, I'm mostly concerned with trying to make the reCAPTCHA notice look okay, but I'm keen for feedback / direction on the styling.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/new` while logged out and complete the flow until you reach the signup form
* Notice that there is now a reCaptcha badge at the bottom right of the screen that you can hover over
* Resize to mobile layout and check that the badge gets hidden, that there are no horizontal scrollbars, and that the paragraph text displays correctly beneath the `Create account` button
* Open up the developer console, and make sure you have `Preserve log` checked on the network tab
* Complete creating an account, and for the request to `users/new`, check that the correct `g-recaptcha-response` token is being sent (really just check that a random-looking string is being sent)

* Repeat the above steps with an ad-blocker that blocks anything from google.com and complete the above steps, and check that for the `users/new` request, a `g-recaptcha-error` param is sent (should be `recaptcha_didnt_load`)

To be especially sure, check that there isn't anything in the original reCAPTCHA for signup PR that I've missed here (https://github.com/Automattic/wp-calypso/pull/39269)

Fixes #42181
