### PR TITLE
Bug Fix:  Scroll to top of page when link is clicked

### DIFF
--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -141,7 +141,7 @@ export default class DesignAssets extends React.Component {
 	};
 
 	onUpdate = () => {
-		window.scrollTo(0, 0);
+		window.scrollTo( 0, 0 );
 	};
 
 	render() {

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -140,6 +140,10 @@ export default class DesignAssets extends React.Component {
 		page( '/devdocs/design/' );
 	};
 
+	onUpdate = () => {
+		window.scrollTo(0, 0);
+	};
+
 	render() {
 		const { component } = this.props;
 		const { filter } = this.state;
@@ -175,7 +179,7 @@ export default class DesignAssets extends React.Component {
 					</div>
 				) }
 
-				<Collection component={ component } filter={ filter }>
+				<Collection component={ component } filter={ filter } onClick={ this.onUpdate }>
 					{ config.isEnabled( 'devdocs/color-scheme-picker' ) && (
 						<ColorSchemePicker readmeFilePath="color-scheme-picker" />
 					) }


### PR DESCRIPTION
cc: @fditrapani 

#### Changes proposed in this Pull Request
Added onUpdate function to be executed when a link to view a component within <Collection/> is clicked (onClick).  Specifically, the issue pointed out that the <Popover/> component link would render at the bottom of the documentation page.  I noticed that the same thing happened with other components within the <Collection/> parent, so I added a function that would cause the links to render at the top of the documentation page.
*

#### Testing instructions
Go to : https://wpcalypso.wordpress.com/devdocs/design , scroll down to <Popover/> to view Popover docs (or any other link on the bottom half of the page).  The documentation for Popover should be scrolled to the top of the page after following the link.
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Fixes #
Added onUpdate function to scroll to the top of the newly rendered webpage.  Added onClick event listener to handle onUpdate function.