### PR TITLE
Gutenboarding: Ensure empty fields in intent gathering show flashing cursor on iOS

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
@@ -79,7 +79,8 @@ const SiteTitle: React.FunctionComponent< Props > = ( { isVisible, isMobile, onS
 						onKeyUp={ handleKeyUp }
 						onBlur={ handleBlur }
 					/>
-					<span className="site-title__placeholder"></span>
+					{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
+					<span className="madlib__input-placeholder"></span>
 				</span>
 			),
 		}

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
@@ -81,9 +81,17 @@
 
 .madlib__input:empty {
 	border-bottom: 2px solid transparent;
-	position: relative;
+	display: inline-block;
+	position: absolute;
 	z-index: 1;
 	vertical-align: middle;
+	height: 1em;
+	width: 1em;
+
+	@include break-small {
+		display: inline;
+		position: relative;
+	}
 }
 
 // Themed core button component

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
@@ -143,7 +143,7 @@
 .site-title__input-wrapper {
 	display: block;
 	position: relative;
-	min-height: 40px; // make sure there is a tappable area on mobile when the input is empty
+	line-height: 1em;
 
 	.madlib__input:focus ~ .madlib__input-placeholder {
 		@include break-small {

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
@@ -68,6 +68,7 @@
 
 	color: var( --mainColor );
 	border-bottom: 2px solid var( --mainColor );
+	caret-color: var( --mainColor );
 
 	&:focus {
 		outline: none;
@@ -81,15 +82,12 @@
 
 .madlib__input:empty {
 	border-bottom: 2px solid transparent;
-	display: inline-block;
 	position: absolute;
+	bottom: 0;
 	z-index: 1;
-	vertical-align: middle;
-	height: 1em;
 	width: 1em;
 
 	@include break-small {
-		display: inline;
 		position: relative;
 	}
 }

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
@@ -145,12 +145,9 @@
 	position: relative;
 	min-height: 40px; // make sure there is a tappable area on mobile when the input is empty
 
-	.madlib__input:empty {
+	.madlib__input:focus ~ .madlib__input-placeholder {
 		@include break-small {
-			padding-right: 300px; // there's not enough container width on smaller screens
-		}
-		@include break-medium {
-			padding-right: 400px;
+			display: none;
 		}
 	}
 
@@ -159,17 +156,27 @@
 	}
 }
 
-.site-title__placeholder {
+.madlib__input-placeholder {
 	display: inline-block;
 	width: 100%;
 	color: var( --studio-gray-5 );
 	cursor: text;
 
 	@include break-small {
-		height: 80px;
 		position: absolute;
+		height: 100%;
 		left: 0;
+		bottom: 0;
 		z-index: 2;
+
+		.madlib__input-placeholder-text {
+			position: absolute;
+			white-space: nowrap; // force placeholder on a single line
+			width: 100%;
+			overflow: hidden;
+			text-overflow: ellipsis;
+			line-height: 1em;
+		}
 	}
 
 	&::after {
@@ -184,12 +191,15 @@
 }
 
 /* hide the placeholder when input is not empty */
-.madlib__input:not( :empty ) ~ .site-title__placeholder {
+.madlib__input:not( :empty ) ~ .madlib__input-placeholder {
 	display: none;
 }
 
-.madlib__input:focus ~ .site-title__placeholder {
+.madlib__input:empty {
 	@include break-small {
-		display: none;
+		padding-right: 300px; // there's not enough container width on smaller screens
+	}
+	@include break-medium {
+		padding-right: 400px;
 	}
 }

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
@@ -225,8 +225,10 @@ const VerticalSelect: React.FunctionComponent< Props > = ( { onNext } ) => {
 							onFocus={ () => setIsFocused( true ) }
 							onBlur={ selectLastInputValue }
 						/>
-						<span className="vertical-select__placeholder">
-							<span className="vertical-select__placeholder-text">{ animatedPlaceholder }</span>
+						{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
+						<span className="madlib__input-placeholder">
+							{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
+							<span className="madlib__input-placeholder-text">{ animatedPlaceholder }</span>
 						</span>
 						{ showArrow && (
 							<Arrow className="vertical-select__arrow" onClick={ handleArrowClick } />

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/style.scss
@@ -96,9 +96,10 @@
 	cursor: text;
 
 	@include break-small {
-		height: 80px;
 		position: absolute;
+		height: 100%;
 		left: 0;
+		bottom: 0;
 		z-index: 2;
 
 		.vertical-select__placeholder-text {
@@ -107,6 +108,7 @@
 			width: 100%;
 			overflow: hidden;
 			text-overflow: ellipsis;
+			line-height: 1em;
 		}
 	}
 

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/style.scss
@@ -89,49 +89,6 @@
 	}
 }
 
-.vertical-select__placeholder {
-	display: inline-block;
-	width: 100%;
-	color: var( --studio-gray-5 );
-	cursor: text;
-
-	@include break-small {
-		position: absolute;
-		height: 100%;
-		left: 0;
-		bottom: 0;
-		z-index: 2;
-
-		.vertical-select__placeholder-text {
-			position: absolute;
-			white-space: nowrap; // force placeholder on a single line
-			width: 100%;
-			overflow: hidden;
-			text-overflow: ellipsis;
-			line-height: 1em;
-		}
-	}
-
-	&::after {
-		content: '';
-		position: absolute;
-		left: 0;
-		right: 0;
-		bottom: -2px;
-		height: 2px;
-		background-image: linear-gradient(
-			to right,
-			rgba( 238, 238, 238, 1 ),
-			rgba( 238, 238, 238, 0.4 )
-		);
-	}
-}
-
-/* hide the placeholder when input is not empty */
-.madlib__input:not( :empty ) ~ .vertical-select__placeholder {
-	display: none;
-}
-
 .vertical-select__arrow {
 	position: absolute;
 	bottom: 8px;


### PR DESCRIPTION
This is a small PR to get the cursor to show when the contenteditable fields in intent gathering in Gutenboarding are focused. This will hopefully help these fields to feel more like real editable fields on iOS.

#### Changes proposed in this Pull Request

* Ensure that the `.madlib__input` class when empty still has a width and height to ensure that the cursor flashes in mobile Safari
* Caret color matches the color of the text when the input has value and has default highlight color when empty.
* Placeholder grey line and coloured line when the user enters a value are in the same position, fixing the jumpy behaviour: https://cloudup.com/cRc12ecdjzH

#### Screenshot

![image](https://user-images.githubusercontent.com/14988353/81909210-995d6f00-960d-11ea-8ca9-24276493db15.png)

**Caret color on iOS before:**
![WhatsApp Image 2020-05-14 at 17 20 29](https://user-images.githubusercontent.com/14192054/81978958-ee60ab80-9634-11ea-8856-c596ae5849e9.jpeg)

**Caret color on iOS after:**
* Empty field
![WhatsApp Image 2020-05-14 at 17 22 10](https://user-images.githubusercontent.com/14192054/81979053-0f290100-9635-11ea-94d3-415531c9c84c.jpeg)
* With value


![WhatsApp Image 2020-05-14 at 17 22 47](https://user-images.githubusercontent.com/14192054/81979030-06382f80-9635-11ea-9ce0-3e95d6135a64.jpeg)



#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On a real iPhone go to `/new` and select the vertical input field. You should see the cursor flash while the field is empty
* Type some text and delete it, the cursor should continue to flash
* Submit the vertical and test the site title sub-step
* The cursor colour should be the same as it is on desktop or Android
* The placeholder line should be in the same position when the input is filled or empty
* Test across other browsers and devices to ensure there are no regressions

Related to: https://github.com/Automattic/wp-calypso/issues/41923
