### PR TITLE
Gutenboarding: Fix responsive & animation issues on domain picker button.

### DIFF
--- a/client/landing/gutenboarding/components/domain-picker-button/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-button/index.tsx
@@ -25,7 +25,6 @@ type DomainSuggestion = import('@automattic/data-stores').DomainSuggestions.Doma
 interface Props extends Omit< DomainPickerProps, 'onClose' >, Button.BaseProps {
 	className?: string;
 	currentDomain?: DomainSuggestion;
-	hasPlaceholder?: boolean;
 }
 
 const DomainPickerButton: FunctionComponent< Props > = ( {
@@ -33,7 +32,6 @@ const DomainPickerButton: FunctionComponent< Props > = ( {
 	className,
 	onDomainSelect,
 	currentDomain,
-	hasPlaceholder,
 	...buttonProps
 } ) => {
 	const buttonRef = createRef< HTMLButtonElement >();
@@ -76,7 +74,6 @@ const DomainPickerButton: FunctionComponent< Props > = ( {
 				className={ classnames( 'domain-picker-button', className, {
 					'is-open': isDomainPopoverVisible,
 					'is-modal-open': isDomainModalVisible,
-					'has-placeholder': hasPlaceholder,
 				} ) }
 				onClick={ () => setDomainPopoverVisibility( ( s ) => ! s ) }
 				ref={ buttonRef }

--- a/client/landing/gutenboarding/components/domain-picker-button/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-button/index.tsx
@@ -25,7 +25,6 @@ type DomainSuggestion = import('@automattic/data-stores').DomainSuggestions.Doma
 interface Props extends Omit< DomainPickerProps, 'onClose' >, Button.BaseProps {
 	className?: string;
 	currentDomain?: DomainSuggestion;
-	hasContent?: boolean;
 	hasPlaceholder?: boolean;
 }
 
@@ -34,7 +33,6 @@ const DomainPickerButton: FunctionComponent< Props > = ( {
 	className,
 	onDomainSelect,
 	currentDomain,
-	hasContent,
 	hasPlaceholder,
 	...buttonProps
 } ) => {
@@ -78,7 +76,6 @@ const DomainPickerButton: FunctionComponent< Props > = ( {
 				className={ classnames( 'domain-picker-button', className, {
 					'is-open': isDomainPopoverVisible,
 					'is-modal-open': isDomainModalVisible,
-					'has-content': hasContent,
 					'has-placeholder': hasPlaceholder,
 				} ) }
 				onClick={ () => setDomainPopoverVisibility( ( s ) => ! s ) }

--- a/client/landing/gutenboarding/components/domain-picker-button/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker-button/style.scss
@@ -14,7 +14,7 @@
 
 	to {
 		transform: scale( 1 );
-		padding:0;
+		padding: 0;
 	}
 }
 
@@ -24,8 +24,8 @@
 		background: var( --studio-blue-0 );
 		border-radius: $radius-round-rectangle;
 		color: var( --studio-blue-40 );
+		max-width: 100%;
 		height: auto; // prevent clipping when there are 2 lines
-		margin-top: 2px;
 		padding: 5px 12px;
 		text-align: left;
 
@@ -46,8 +46,6 @@
 	}
 
 	&__label {
-		// This makes the label ready for slide-out
-		// animation using width: 0% to width: 100%.
 		white-space: nowrap;
 		overflow: hidden;
 		text-overflow: ellipsis;

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -136,6 +136,9 @@ const Header: React.FunctionComponent = () => {
 	const hasContent =
 		!! domain || !! recommendedDomainSuggestion || previousRecommendedDomain !== '';
 
+	const hasPlaceholder =
+		!! siteTitle && ! recommendedDomainSuggestion && previousRecommendedDomain !== '';
+
 	return (
 		<div
 			className="gutenboarding__header"
@@ -164,17 +167,13 @@ const Header: React.FunctionComponent = () => {
 								<div
 									className={ classnames( 'gutenboarding__header-domain-picker-button-container', {
 										'has-content': hasContent,
+										'has-placeholder': hasPlaceholder,
 									} ) }
 								>
 									<DomainPickerButton
 										className="gutenboarding__header-domain-picker-button"
 										currentDomain={ domain }
 										onDomainSelect={ setDomain }
-										hasPlaceholder={
-											!! siteTitle &&
-											! recommendedDomainSuggestion &&
-											previousRecommendedDomain !== ''
-										}
 									>
 										{ domainElement }
 									</DomainPickerButton>

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -8,6 +8,7 @@ import { useI18n } from '@automattic/react-i18n';
 import { Icon } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useHistory } from 'react-router-dom';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -131,6 +132,10 @@ const Header: React.FunctionComponent = () => {
 			handleCreateSite( newUser.username, newUser.bearerToken, selectedPlanSlug );
 		}
 	}, [ newSite, newUser, handleCreateSite, selectedPlanSlug ] );
+
+	const hasContent =
+		!! domain || !! recommendedDomainSuggestion || previousRecommendedDomain !== '';
+
 	return (
 		<div
 			className="gutenboarding__header"
@@ -156,24 +161,27 @@ const Header: React.FunctionComponent = () => {
 						// show it comes from a site title (but hide it if it comes from a vertical).
 						domainElement &&
 							( siteTitle || previousRecommendedDomain || currentStep !== 'IntentGathering' ) && (
-								<DomainPickerButton
-									className="gutenboarding__header-domain-picker-button"
-									currentDomain={ domain }
-									onDomainSelect={ setDomain }
-									hasContent={
-										!! domain || !! recommendedDomainSuggestion || previousRecommendedDomain !== ''
-									}
-									hasPlaceholder={
-										!! siteTitle &&
-										! recommendedDomainSuggestion &&
-										previousRecommendedDomain !== ''
-									}
+								<div
+									className={ classnames( 'gutenboarding__header-domain-picker-button-container', {
+										'has-content': hasContent,
+									} ) }
 								>
-									{ domainElement }
-								</DomainPickerButton>
+									<DomainPickerButton
+										className="gutenboarding__header-domain-picker-button"
+										currentDomain={ domain }
+										onDomainSelect={ setDomain }
+										hasContent={ hasContent }
+										hasPlaceholder={
+											!! siteTitle &&
+											! recommendedDomainSuggestion &&
+											previousRecommendedDomain !== ''
+										}
+									>
+										{ domainElement }
+									</DomainPickerButton>
+								</div>
 							)
 					}
-					&nbsp;
 				</div>
 				<div className="gutenboarding__header-section-item gutenboarding__header-section-item--right">
 					<PlansButton />

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -170,7 +170,6 @@ const Header: React.FunctionComponent = () => {
 										className="gutenboarding__header-domain-picker-button"
 										currentDomain={ domain }
 										onDomainSelect={ setDomain }
-										hasContent={ hasContent }
 										hasPlaceholder={
 											!! siteTitle &&
 											! recommendedDomainSuggestion &&

--- a/client/landing/gutenboarding/components/header/style.scss
+++ b/client/landing/gutenboarding/components/header/style.scss
@@ -99,9 +99,7 @@ $padding--gutenboarding__header: $grid-unit-10;
 		opacity: 1;
 		@include reduce-motion( 'animation' );
 	}
-}
 
-.gutenboarding__header-domain-picker-button {
 	&.has-placeholder .gutenboarding__header-domain-picker-button-domain {
 		animation: loading-fade 1.6s ease-in-out infinite;
 		@include reduce-motion( 'animation' );

--- a/client/landing/gutenboarding/components/header/style.scss
+++ b/client/landing/gutenboarding/components/header/style.scss
@@ -10,25 +10,21 @@ $padding--gutenboarding__header: $grid-unit-10;
 	from {
 		max-width: 0;
 		opacity: 0;
-		padding: 5px 0;
 	}
 
 	79% {
 		max-width: 0;
 		opacity: 0;
-		padding: 5px 0;
 	}
 
 	80% {
 		max-width: 0;
 		opacity: 0.5;
-		padding: 5px 12px;
 	}
 
 	to {
 		max-width: 500px;
 		opacity: 1;
-		padding: 5px 12px;
 	}
 }
 
@@ -85,39 +81,32 @@ $padding--gutenboarding__header: $grid-unit-10;
 }
 
 .gutenboarding__header-domain-section {
-	position: relative;
-	width: 100%;
+	// Let this flex item take 100% of available width.
 	flex-grow: 1;
+	// Ensure flex item doesn't exceed 100% of th
+	// available width, allowing content to have ellipsis.
+	min-width: 0;
 }
 
-.gutenboarding__header-domain-picker-button {
-	position: absolute;
-	top: -6px;
-	left: 0;
-	max-width: 100%;
+.gutenboarding__header-domain-picker-button-container {
+	max-width: 0;
+	opacity: 0;
 
-	// Temp fix: Animation only on desktop/tablet devices.
-	@include break-mobile {
-		position: relative;
-		top: 0;
-		max-width: 0;
-		opacity: 0;
-
-		&.has-content {
-			animation-duration: 5s;
-			animation-name: gutenboarding_domain-slide-in;
-			max-width: 1500px;
-			opacity: 1;
-			@include reduce-motion( 'animation' );
-		}
-
-		&.has-placeholder .gutenboarding__header-domain-picker-button-domain {
-			animation: loading-fade 1.6s ease-in-out infinite;
-			@include reduce-motion( 'animation' );
-		}
+	&.has-content {
+		animation-duration: 5s;
+		animation-name: gutenboarding_domain-slide-in;
+		max-width: 1500px;
+		opacity: 1;
+		@include reduce-motion( 'animation' );
 	}
 }
 
+.gutenboarding__header-domain-picker-button {
+	&.has-placeholder .gutenboarding__header-domain-picker-button-domain {
+		animation: loading-fade 1.6s ease-in-out infinite;
+		@include reduce-motion( 'animation' );
+	}
+}
 
 .gutenboarding__header-site-title-section {
 	white-space: nowrap;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR brings support for domain names of any length (by ellipsing them) + slide out animation for any all breakpoints.

Previously, the issues on the domain picker button are:
- Mobile view has ellipsis but doesn't have the slide out animation.
- Non-mobile view doesn't have ellipsis (and layout may break in certain medium width viewport) but has the slide out animation.

#### Testing instructions

* Test with long domains, resize browser window, refresh to see if slides out nicely.

#### Screenshots

Testing in all viewport width.
![2020-05-14_11-26-40 (1)](https://user-images.githubusercontent.com/1287077/81918644-0b669180-95d7-11ea-90f5-1f3b4257edd7.gif)

Animation on mobile viewport.
![2020-05-14_11-24-12 (1)](https://user-images.githubusercontent.com/1287077/81918630-0570b080-95d7-11ea-84d1-396bd7b39d5c.gif)

Fixes https://github.com/Automattic/wp-calypso/pull/42040#pullrequestreview-409132739
Related https://github.com/Automattic/wp-calypso/issues/42123 https://github.com/Automattic/wp-calypso/issues/41851



