### PR TITLE
Add E2E testing for Calypso SSR

### DIFF
--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -128,6 +128,7 @@ class Document extends React.Component {
 						<div
 							id="wpcom"
 							className="wpcom-site"
+							data-calypso-ssr="true"
 							dangerouslySetInnerHTML={ {
 								__html: renderedLayout,
 							} }

--- a/test/e2e/specs/wp-ssr-spec.js
+++ b/test/e2e/specs/wp-ssr-spec.js
@@ -1,0 +1,46 @@
+/**
+ * External dependencies
+ */
+import { By as by } from 'selenium-webdriver';
+import config from 'config';
+import assert from 'assert';
+
+/**
+ * Internal dependencies
+ */
+import LoginPage from '../lib/pages/login-page';
+import ThemesPage from '../lib/pages/themes-page';
+import * as dataHelper from '../lib/data-helper';
+import * as driverManager from '../lib/driver-manager';
+
+const mochaTimeOut = config.get( 'mochaTimeoutMS' );
+const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
+
+let driver;
+
+async function ssrWorksForPage( url ) {
+	await driver.get( url );
+	const layoutSelector = by.css( '#wpcom[data-calypso-ssr="true"]' );
+	assert( await driver.findElement( layoutSelector ) );
+}
+
+before( async function () {
+	this.timeout( startBrowserTimeoutMS );
+	driver = await driverManager.startBrowser();
+	await driverManager.ensureNotLoggedIn( driver );
+} );
+
+describe( 'Server-side rendering: @canary @parallel', function () {
+	this.timeout( mochaTimeOut );
+	step( '/log-in renders on the server', async function () {
+		await ssrWorksForPage( LoginPage.getLoginURL() );
+	} );
+
+	step( '/themes renders on the server', async function () {
+		await ssrWorksForPage( ThemesPage.getStartURL() );
+	} );
+
+	step( '/theme/twentytwenty renders on the server', async function () {
+		await ssrWorksForPage( dataHelper.getCalypsoURL( 'theme/twentytwenty' ) );
+	} );
+} );


### PR DESCRIPTION
This adds tests for SSR login, themes, and theme details.
It also adds a data attribute to the HTML output of a successful SSR, so that we can check for it in the E2E tests.

This test is being added as a canary, to prevent changes that break SSR from being merged and deployed.

#### Changes proposed in this Pull Request

* Add E2E tests for Calypso server-side rendering

#### Testing instructions

To validate passing:

* Ensure that the tests pass on this PR

To validate failing:

* Check out this branch
* Modify e.g. `client/blocks/login/social.jsx` to make an unguarded access to `window` in its render function (e.g. `console.log(window)`).
* Close any running servers and start a new local server (`yarn start`)
* Run the spec (`cd test/e2e && NODE_CONFIG_ENV=development node_modules/.bin/mocha specs/wp-ssr-spec.js`)
* Ensure it fails on `/log-in`
