### PR TITLE
Jetpack Cloud: fix capitalization of section names

### DIFF
--- a/client/landing/jetpack-cloud/components/sidebar/index.jsx
+++ b/client/landing/jetpack-cloud/components/sidebar/index.jsx
@@ -119,7 +119,7 @@ class JetpackCloudSidebar extends Component {
 								/>
 								<SidebarItem
 									expandSection={ this.expandBackupSection }
-									label={ translate( 'Activity Log', {
+									label={ translate( 'Activity log', {
 										comment: 'Jetpack Cloud / Activity Log status sidebar navigation item',
 									} ) }
 									link={ backupActivityPath( selectedSiteSlug ) }

--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -160,7 +160,7 @@ class BackupsPage extends Component {
 
 		return (
 			<Main>
-				<DocumentHead title={ translate( 'Latest Backups' ) } />
+				<DocumentHead title={ translate( 'Latest backups' ) } />
 				<SidebarNavigation />
 				<PageViewTracker path="/backups/:site" title="Backups" />
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix capitalization of section names in Sidebar and Masterbar. All of them should now be using sentence case.
  * Masterbar: `Latest Backups` -> `Latest backups`
  * Sidebar: `Activity Log` -> `Activity log`

#### Before
![image](https://user-images.githubusercontent.com/390760/81923286-541d4b00-95d5-11ea-9e89-848e64248367.png)

#### After

![image](https://user-images.githubusercontent.com/390760/81923292-58496880-95d5-11ea-83fa-1d214cf6903c.png)

#### Testing instructions

* Fire up this PR locally.
* Navigate to `http://jetpack.cloud.localhost:3000/` and select a site.
* Ensure the section names capitalization in the masterbar correspond to the ones in the sidebar.