### PR TITLE
Gutenboarding: use text cursor in intent capture placeholders

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
@@ -157,6 +157,7 @@
 	display: inline-block;
 	width: 100%;
 	color: var( --studio-gray-5 );
+	cursor: text;
 
 	@include break-small {
 		height: 80px;

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/style.scss
@@ -93,6 +93,7 @@
 	display: inline-block;
 	width: 100%;
 	color: var( --studio-gray-5 );
+	cursor: text;
 
 	@include break-small {
 		height: 80px;


### PR DESCRIPTION
You can spend just 1min reviewing this :-)

#### Changes proposed in this Pull Request

* Adds text cursor to intent capture placeholder inputs, making it tad bit more clear that user can start typing in them

In vertical input(green area, animated text) would already have text-cursor, but now also rest of the area (orange area) has it:
<img width="647" alt="Screenshot 2020-05-14 at 14 24 31" src="https://user-images.githubusercontent.com/87168/81928928-bd5d8800-95ee-11ea-8dfa-edb0e8090bf0.png">

Same treatment for title placeholder:
<img width="853" alt="Screenshot 2020-05-14 at 14 24 26" src="https://user-images.githubusercontent.com/87168/81928987-d49c7580-95ee-11ea-97f8-7f6e091c40fd.png">


#### Testing instructions

* in `/new`, hover intent capture inputs while you don't have focus in the inputs and they're empty 

