### PR TITLE
Gutenboarding: allow Hotjar to record style preview iframe

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/style-preview/preview.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/preview.tsx
@@ -153,7 +153,12 @@ const Preview: React.FunctionComponent< Props > = ( { viewport } ) => {
 						<div role="presentation" className="style-preview__preview-bar-dot" />
 					</div>
 				) }
-				<iframe ref={ iframe } className="style-preview__iframe" title="preview" />
+				<iframe
+					className="style-preview__iframe"
+					data-hj-allow-iframe
+					ref={ iframe }
+					title="preview"
+				/>
 			</div>
 		</div>
 	);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Whitelist style preview iframe for HotJar recordings
    https://help.hotjar.com/hc/en-us/articles/115011624347-Can-I-track-iframes-inside-Recordings-

#### Testing instructions

- Style preview still works :-)
- The rest are hot jars