### PR TITLE
Turn on Experimentation Platform in staging/horizon

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -46,7 +46,7 @@
 		"help/courses": true,
 		"inline-help": true,
 		"i18n/translation-scanner": true,
-		"ive/use-external-assignment": false,
+		"ive/use-external-assignment": true,
 		"jetpack/api-cache": true,
 		"jetpack/concierge-sessions": false,
 		"jetpack/connect/remote-install": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -49,7 +49,7 @@
 		"help": true,
 		"help/courses": true,
 		"inline-help": true,
-		"ive/use-external-assignment": false,
+		"ive/use-external-assignment": true,
 		"jetpack/api-cache": true,
 		"jetpack/blocks/beta": true,
 		"jetpack/concierge-sessions": false,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Enables the experimentation platform on staging and horizon.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. `yarn test-client` should pass.
2. Merging should be OK in staging, as it's not enabled in production.
3. Use production API, staging wpcom, and non a11n user.
4. Validate everything works correctly.