### PR TITLE
Add jetpack cloud config for experimentation platform

### DIFF
--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -15,6 +15,7 @@
 		"current-site/domain-warning": false,
 		"current-site/notice": false,
 		"current-site/stale-cart-notice": false,
+		"ive/use-external-assignment": false,
 		"jetpack-cloud": true,
 		"jetpack-cloud/backups": true,
 		"jetpack-cloud/backups-restore": true,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -13,6 +13,7 @@
 		"current-site/domain-warning": false,
 		"current-site/notice": false,
 		"current-site/stale-cart-notice": false,
+		"ive/use-external-assignment": false,
 		"jetpack-cloud": true,
 		"jetpack-cloud/backups": true,
 		"jetpack-cloud/backups-restore": true,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -13,6 +13,7 @@
 		"current-site/domain-warning": false,
 		"current-site/notice": false,
 		"current-site/stale-cart-notice": false,
+		"ive/use-external-assignment": false,
 		"jetpack-cloud": true,
 		"jetpack-cloud/backups": true,
 		"jetpack-cloud/backups-restore": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds the disabled setting for experimentation platform in jetpack-cloud environment

This enables experimentation on the new experimentation platform (as seen in #42093). I'm mostly adding this for completeness but would like to turn this on later.
