### PR TITLE
Override Gutenberg side-effects

### DIFF
--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -179,6 +179,24 @@ const webpackConfig = {
 	},
 	module: {
 		rules: [
+			{
+				// Override side-effects for `@wordpress/blocks` while the package doesn't declare them.
+				// TODO: remove once we're using a version of `@wordpress/blocks` that declares side-effects.
+				test: /@wordpress\/blocks\/(src|build|build-module)\/api\//,
+				sideEffects: false,
+			},
+			{
+				// Override side-effects for `@wordpress/block-editor` while the package doesn't declare them.
+				// TODO: remove once we're using a version of `@wordpress/blocks` that declares side-effects.
+				test: /@wordpress\/block-editor\/(src|build|build-module)\/(components|utils)\//,
+				sideEffects: false,
+			},
+			{
+				// Override side-effects for `@wordpress/rich-text` while the package doesn't declare them.
+				// TODO: remove once we're using a version of `@wordpress/blocks` that declares side-effects.
+				test: /@wordpress\/rich-text\/(src|build|build-module)\/component\//,
+				sideEffects: false,
+			},
 			TranspileConfig.loader( {
 				workerCount,
 				configFile: path.resolve( 'babel.config.js' ),

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -181,19 +181,19 @@ const webpackConfig = {
 		rules: [
 			{
 				// Override side-effects for `@wordpress/blocks` while the package doesn't declare them.
-				// TODO: remove once we're using a version of `@wordpress/blocks` that declares side-effects.
+				// TODO: remove once we're using a version that declares side-effects.
 				test: /@wordpress\/blocks\/(src|build|build-module)\/api\//,
 				sideEffects: false,
 			},
 			{
 				// Override side-effects for `@wordpress/block-editor` while the package doesn't declare them.
-				// TODO: remove once we're using a version of `@wordpress/blocks` that declares side-effects.
+				// TODO: remove once we're using a version that declares side-effects.
 				test: /@wordpress\/block-editor\/(src|build|build-module)\/(components|utils)\//,
 				sideEffects: false,
 			},
 			{
 				// Override side-effects for `@wordpress/rich-text` while the package doesn't declare them.
-				// TODO: remove once we're using a version of `@wordpress/blocks` that declares side-effects.
+				// TODO: remove once we're using a version that declares side-effects.
 				test: /@wordpress\/rich-text\/(src|build|build-module)\/component\//,
 				sideEffects: false,
 			},


### PR DESCRIPTION
This adds a few overrides to our `webpack` config, that disable side-effects for parts of several Gutenberg packages. This serves as an experiment to validate upstream changes, and fills in the gaps while the upstream packages don't declare this.

#### Changes proposed in this Pull Request

* Add a few overrides for side effects in Gutenberg packages

#### Testing instructions

* Ensure Gutenboarding continues to work correctly!
