### PR TITLE
Enable the new domain navigation in production

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -35,6 +35,7 @@
 		"domains/kracken-ui/pagination": true,
 		"domains/new-status-design": true,
 		"domains/new-status-design/auto-renew": true,
+		"domains/new-status-design/new-options": true,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,

--- a/config/production.json
+++ b/config/production.json
@@ -34,6 +34,7 @@
 		"domains/kracken-ui/pagination": true,
 		"domains/new-status-design": true,
 		"domains/new-status-design/auto-renew": true,
+		"domains/new-status-design/new-options": true,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -37,6 +37,7 @@
 		"domains/kracken-ui/pagination": true,
 		"domains/new-status-design": true,
 		"domains/new-status-design/auto-renew": true,
+		"domains/new-status-design/new-options": true,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* We're enabling the enhanced domain navigation in production.

Here's how it looks:

<img width="740" alt="78331987-d0148400-758f-11ea-88c2-f00db4943503" src="https://user-images.githubusercontent.com/1355045/81945184-6e235180-9606-11ea-894f-1737e0077817.png">

Related PRs:

https://github.com/Automattic/wp-calypso/pull/40737
https://github.com/Automattic/wp-calypso/pull/40811
https://github.com/Automattic/wp-calypso/pull/41019
https://github.com/Automattic/wp-calypso/pull/41023
https://github.com/Automattic/wp-calypso/pull/41297
https://github.com/Automattic/wp-calypso/pull/41452
https://github.com/Automattic/wp-calypso/pull/41494
https://github.com/Automattic/wp-calypso/pull/41643
https://github.com/Automattic/wp-calypso/pull/41743

#### Testing instructions

* Just verify that in the production env you see the new navigation when you open a registered/mapped domain
