### PR TITLE
Remove/premium block jquery dep

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/premium-content.php
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/premium-content.php
@@ -59,7 +59,7 @@ function premium_content_block_init() {
 	wp_register_script(
 		'premium-content-frontend',
 		"$url_path/view.js",
-		array( 'jquery' ),
+		array(),
 		$script_asset['version']
 	);
 

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/view.js
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/view.js
@@ -1,48 +1,48 @@
-let premiumContentJWTToken = '';
+document.addEventListener( 'DOMContentLoaded', function(){
+	let premiumContentJWTToken = '';
 
-/**
- *
- * @param {event} eventFromIframe - message event that gets emmited in the checkout iframe.
- * @listens message
- */
-function handleIframeResult( eventFromIframe ) {
-	if ( eventFromIframe.origin === 'https://subscribe.wordpress.com' && eventFromIframe.data ) {
-		const data = JSON.parse( eventFromIframe.data );
-		if ( data && data.result && data.result.jwt_token ) {
-			// We save the token for now, doing nothing.
-			premiumContentJWTToken = data.result.jwt_token;
-			// We will also set this in a cookie  - just in case. This will be reloaded in the refresh, when user clicks OK.
-			// But user can close the browser window before clicking OK. IN that case, we want to leave a cookie behind.
-			const date = new Date();
-			date.setTime( date.getTime() + 365 * 24 * 60 * 60 * 1000 );
-			document.cookie =
-				'jp-premium-content-session' +
-				'=' +
-				premiumContentJWTToken +
-				'; expires=' +
-				date.toGMTString() +
-				'; path=/';
-		}
-		if ( data && data.action === 'close' && premiumContentJWTToken ) {
-			document.location.href = updateQueryStringParameter(
-				document.location.href,
-				'token',
-				premiumContentJWTToken
-			);
+	/**
+	 *
+	 * @param {event} eventFromIframe - message event that gets emitted in the checkout iframe.
+	 * @listens message
+	 */
+	function handleIframeResult( eventFromIframe ) {
+		if ( eventFromIframe.origin === 'https://subscribe.wordpress.com' && eventFromIframe.data ) {
+			const data = JSON.parse( eventFromIframe.data );
+			if ( data && data.result && data.result.jwt_token ) {
+				// We save the token for now, doing nothing.
+				premiumContentJWTToken = data.result.jwt_token;
+				// We will also set this in a cookie  - just in case. This will be reloaded in the refresh, when user clicks OK.
+				// But user can close the browser window before clicking OK. IN that case, we want to leave a cookie behind.
+				const date = new Date();
+				date.setTime( date.getTime() + 365 * 24 * 60 * 60 * 1000 );
+				document.cookie =
+					'jp-premium-content-session' +
+					'=' +
+					premiumContentJWTToken +
+					'; expires=' +
+					date.toGMTString() +
+					'; path=/';
+			}
+			if ( data && data.action === 'close' && premiumContentJWTToken ) {
+				document.location.href = updateQueryStringParameter(
+					document.location.href,
+					'token',
+					premiumContentJWTToken
+				);
+			}
 		}
 	}
-}
 
-function updateQueryStringParameter( uri, key, value ) {
-	const re = new RegExp( '([?&])' + key + '=.*?(&|$)', 'i' );
-	const separator = uri.indexOf( '?' ) !== -1 ? '&' : '?';
-	if ( uri.match( re ) ) {
-		return uri.replace( re, '$1' + key + '=' + value + '$2' );
+	function updateQueryStringParameter( uri, key, value ) {
+		const re = new RegExp( '([?&])' + key + '=.*?(&|$)', 'i' );
+		const separator = uri.indexOf( '?' ) !== -1 ? '&' : '?';
+		if ( uri.match( re ) ) {
+			return uri.replace( re, '$1' + key + '=' + value + '$2' );
+		}
+		return uri + separator + key + '=' + value;
 	}
-	return uri + separator + key + '=' + value;
-}
 
-document.addEventListener('DOMContentLoaded', (event) => {
 	if ( typeof window !== 'undefined' ) {
 		window.addEventListener('message', handleIframeResult, false);
 	}

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/view.js
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/view.js
@@ -1,44 +1,49 @@
-/*global jQuery */
-jQuery( document ).ready( function () {
-	function updateQueryStringParameter( uri, key, value ) {
-		const re = new RegExp( '([?&])' + key + '=.*?(&|$)', 'i' );
-		const separator = uri.indexOf( '?' ) !== -1 ? '&' : '?';
-		if ( uri.match( re ) ) {
-			return uri.replace( re, '$1' + key + '=' + value + '$2' );
-		}
-		return uri + separator + key + '=' + value;
-	}
-	let premiumContentJWTToken = '';
+let premiumContentJWTToken = '';
 
-	window.addEventListener(
-		'message',
-		function handleIframeResult( eventFromIframe ) {
-			if ( eventFromIframe.origin === 'https://subscribe.wordpress.com' && eventFromIframe.data ) {
-				const data = JSON.parse( eventFromIframe.data );
-				if ( data && data.result && data.result.jwt_token ) {
-					// We save the token for now, doing nothing.
-					premiumContentJWTToken = data.result.jwt_token;
-					// We will also set this in a cookie  - just in case. This will be reloaded in the refresh, when user clicks OK.
-					// But user can close the browser window before clicking OK. IN that case, we want to leave a cookie behind.
-					const date = new Date();
-					date.setTime( date.getTime() + 365 * 24 * 60 * 60 * 1000 );
-					document.cookie =
-						'jp-premium-content-session' +
-						'=' +
-						premiumContentJWTToken +
-						'; expires=' +
-						date.toGMTString() +
-						'; path=/';
-				}
-				if ( data && data.action === 'close' && premiumContentJWTToken ) {
-					document.location.href = updateQueryStringParameter(
-						document.location.href,
-						'token',
-						premiumContentJWTToken
-					);
-				}
-			}
-		},
-		false
-	);
+/**
+ *
+ * @param {event} eventFromIframe - message event that gets emmited in the checkout iframe.
+ * @listens message
+ */
+function handleIframeResult( eventFromIframe ) {
+	if ( eventFromIframe.origin === 'https://subscribe.wordpress.com' && eventFromIframe.data ) {
+		const data = JSON.parse( eventFromIframe.data );
+		if ( data && data.result && data.result.jwt_token ) {
+			// We save the token for now, doing nothing.
+			premiumContentJWTToken = data.result.jwt_token;
+			// We will also set this in a cookie  - just in case. This will be reloaded in the refresh, when user clicks OK.
+			// But user can close the browser window before clicking OK. IN that case, we want to leave a cookie behind.
+			const date = new Date();
+			date.setTime( date.getTime() + 365 * 24 * 60 * 60 * 1000 );
+			document.cookie =
+				'jp-premium-content-session' +
+				'=' +
+				premiumContentJWTToken +
+				'; expires=' +
+				date.toGMTString() +
+				'; path=/';
+		}
+		if ( data && data.action === 'close' && premiumContentJWTToken ) {
+			document.location.href = updateQueryStringParameter(
+				document.location.href,
+				'token',
+				premiumContentJWTToken
+			);
+		}
+	}
+}
+
+function updateQueryStringParameter( uri, key, value ) {
+	const re = new RegExp( '([?&])' + key + '=.*?(&|$)', 'i' );
+	const separator = uri.indexOf( '?' ) !== -1 ? '&' : '?';
+	if ( uri.match( re ) ) {
+		return uri.replace( re, '$1' + key + '=' + value + '$2' );
+	}
+	return uri + separator + key + '=' + value;
+}
+
+document.addEventListener('DOMContentLoaded', (event) => {
+	if ( typeof window !== 'undefined' ) {
+		window.addEventListener('message', handleIframeResult, false);
+	}
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR removes the JQuery dependency introduced with the premium content block.

The premium block is only using JQuery to add an event listener when the page loads but we can do this with vanilla JS listening for the `DOMContentLoaded` event.

#### Testing instructions
* On a test site, create a new post with a premium content block
* Make sure the premium content block is using a plan you haven't subscribed to already
* Publish the post and view it incognito
* Subscribe to that premium content plan and confirm that the page redirects after you close the subscribe iframe modal
* Confirm you can see the premium content in the post without any page refresh.
