### PR TITLE
Jetpack Cloud: Allow user to manually re-run a scan after threats are found

### DIFF
--- a/client/landing/jetpack-cloud/components/scan-threats/index.tsx
+++ b/client/landing/jetpack-cloud/components/scan-threats/index.tsx
@@ -102,6 +102,9 @@ const ScanThreats = ( { error, site, threats }: Props ) => {
 		( state ) => ! isEmpty( getJetpackCredentials( state, site.ID, 'main' ) )
 	);
 	const dispatch = useDispatch();
+	const dispatchScanRun = React.useCallback( () => {
+		triggerScanRun( site.ID )( dispatch );
+	}, [ dispatch, site ] );
 
 	const allFixableThreats = threats.filter(
 		( threat ): threat is FixableThreat => threat.fixable !== false
@@ -220,6 +223,19 @@ const ScanThreats = ( { error, site, threats }: Props ) => {
 						isPlaceholder={ false }
 					/>
 				) ) }
+			</div>
+
+			<div className="scan-threats__rerun">
+				{ translate(
+					'If you have manually fixed any of the threats listed above, you can {{button}}run a manual scan now{{/button}} or wait for Jetpack to scan your site later today.',
+					{
+						components: {
+							button: (
+								<Button className="scan-threats__run-scan-button" onClick={ dispatchScanRun } />
+							),
+						},
+					}
+				) }
 			</div>
 
 			{ error && <ScanError site={ site } /> }

--- a/client/landing/jetpack-cloud/components/scan-threats/index.tsx
+++ b/client/landing/jetpack-cloud/components/scan-threats/index.tsx
@@ -225,18 +225,20 @@ const ScanThreats = ( { error, site, threats }: Props ) => {
 				) ) }
 			</div>
 
-			<div className="scan-threats__rerun">
-				{ translate(
-					'If you have manually fixed any of the threats listed above, you can {{button}}run a manual scan now{{/button}} or wait for Jetpack to scan your site later today.',
-					{
-						components: {
-							button: (
-								<Button className="scan-threats__run-scan-button" onClick={ dispatchScanRun } />
-							),
-						},
-					}
-				) }
-			</div>
+			{ ! error && (
+				<div className="scan-threats__rerun">
+					{ translate(
+						'If you have manually fixed any of the threats listed above, you can {{button}}run a manual scan now{{/button}} or wait for Jetpack to scan your site later today.',
+						{
+							components: {
+								button: (
+									<Button className="scan-threats__run-scan-button" onClick={ dispatchScanRun } />
+								),
+							},
+						}
+					) }
+				</div>
+			) }
 
 			{ error && <ScanError site={ site } /> }
 

--- a/client/landing/jetpack-cloud/components/scan-threats/style.scss
+++ b/client/landing/jetpack-cloud/components/scan-threats/style.scss
@@ -3,7 +3,7 @@
 		margin: 16px 0;
 	}
 
-	&__error {
+	&__error, &__rerun {
 		text-align: center;
 		font-size: 16px;
 		line-height: 24px;

--- a/client/landing/jetpack-cloud/components/threat-item/index.tsx
+++ b/client/landing/jetpack-cloud/components/threat-item/index.tsx
@@ -74,7 +74,7 @@ const ThreatItem: React.FC< Props > = ( {
 
 		if ( ! threat.fixable ) {
 			return translate(
-				'Jetpack Scan cannot automatically fix this threat. Please {{link}}contact us{{/link}} for help.',
+				'Jetpack Scan cannot automatically fix this threat. You can fix it manually and re-run scan afterwards, or {{link}}contact us{{/link}} for help.',
 				{
 					components: {
 						link: <a href={ contactSupportUrl } rel="noopener noreferrer" target="_blank" />,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add copy and a button to the bottom of the "threats found" page to allow the user to run a scan manually.
* Add copy to unfixable threat descriptions to inform the user they can run a manual scan after resolving the threat manually.

Fixes `1151678672052943-as-1175836339721209`.

##### Implementation notes

Thinking out loud: would it make sense to move `dispatchScanRun` to a constant in file scope, since we're using it in two places now? If I recall, `dispatch` is guaranteed to be constant, but I'm not as certain about the dependency on `site.ID`.

#### Testing instructions

* **Prerequisite:** have a site with Scan enabled and no pre-existing threats.
* **Note**: check styling in both mobile and desktop layouts.
* Create a threat that is unfixable (e.g., add the EICAR string to a plugin).
* Click **Scan now** and wait for the results.
* Verify that you see "threats found" with the following copy below the threat listings
  * > If you have manually fixed any of the threats listed above, you can *run a manual scan now* or wait for Jetpack to scan your site later today.
* Verify that "*run a manual scan now*" displays with link styling and appears clickable.
* Expand the details for your unfixable threat and verify that you see the following copy under "How will we fix it?":
  * > Jetpack Scan cannot automatically fix this threat. You can fix it manually and re-run scan afterwards, or *contact us* for help.
* Manually resolve your unfixable threat.
* Click "*run a manual scan now*" below the threat listing to start a new scan.
* Verify the scan runs and comes back with no threats found.

#### Screenshots (after this PR)

##### Threats found footer text (below threat listings)

<img width="732" alt="Screen Shot 2020-05-14 at 09 27 10" src="https://user-images.githubusercontent.com/670067/81948041-e2d69b80-95c6-11ea-9425-428d068f965b.png">

<img width="395" alt="Screen Shot 2020-05-14 at 09 28 22" src="https://user-images.githubusercontent.com/670067/81947926-bb7fce80-95c6-11ea-8dac-958de0589e16.png">

##### Unfixable threat text ("How will we fix it?")

<img width="703" alt="Screen Shot 2020-05-14 at 09 27 43" src="https://user-images.githubusercontent.com/670067/81948085-f1bd4e00-95c6-11ea-8522-9e4415db69f6.png">

<img width="352" alt="Screen Shot 2020-05-14 at 09 28 35" src="https://user-images.githubusercontent.com/670067/81948096-f84bc580-95c6-11ea-8ea4-da5b4ba3edec.png">
