### PR TITLE
Jetpack Cloud: Center 'Retry scan' button and reduce margin on mobile

### DIFF
--- a/client/landing/jetpack-cloud/sections/scan/style.scss
+++ b/client/landing/jetpack-cloud/sections/scan/style.scss
@@ -79,5 +79,9 @@
 }
 
 .scan__retry-bottom {
-	margin-left: 20px;
+	margin: 0 0 16px;
+
+	@include breakpoint( '>660px' ) {
+		margin: 16px 0 16px 20px;
+	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adjust the margin for the **Retry scan** button so that it's centered for small-layout screens, and the space between buttons on mobile matches our style guide.

Fixes **1151678672052943-as-1175652872237329**.

#### Testing instructions

* Open Jetpack Cloud for a site with Scan.
* Simulate or otherwise produce an error state on the **Scanner** page.
* Verify that buttons are placed as in the screenshots below, and that on mobile layouts, the **Retry scan** button is horizontally centered on the page.

#### Screenshots

<img width="408" alt="image" src="https://user-images.githubusercontent.com/670067/81957371-179c2000-95d2-11ea-9995-3f7e9a53b53f.png">

<img width="411" alt="image" src="https://user-images.githubusercontent.com/670067/81957328-0a7f3100-95d2-11ea-84fe-2187b20df3fe.png">
