### PR TITLE
Refactor validateGoogleAppsContactInformation to accept domain names

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -745,8 +745,7 @@ Undocumented.prototype.validateGoogleAppsContactInformation = function (
 	};
 
 	const result = this.wpcom.req.post(
-		{ path: '/me/google-apps/validate' },
-		data,
+		{ path: '/me/google-apps/validate', body: data },
 		callback ? callbackFunction : null
 	);
 

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -722,15 +722,17 @@ Undocumented.prototype.validateDomainContactInformation = function (
  * Promise.
  *
  * @param {object} contactInformation - user's contact information
+ * @param {string[]} domainNames - domain names for which GSuite is being purchased
  * @param {(error: string, data: object) => void} [callback] The callback function.
  * @returns {Promise|undefined} If no callback, returns a Promise that resolves when the request completes
  */
 Undocumented.prototype.validateGoogleAppsContactInformation = function (
 	contactInformation,
+	domainNames,
 	callback
 ) {
-	const data = mapKeysRecursively( { contactInformation }, snakeCase );
-	debug( '/me/google-apps/validate', data );
+	const { contact_information } = mapKeysRecursively( { contactInformation }, snakeCase );
+	debug( '/me/google-apps/validate', contact_information, domainNames );
 
 	const callbackFunction = ( error, successData ) => {
 		if ( error ) {
@@ -745,7 +747,7 @@ Undocumented.prototype.validateGoogleAppsContactInformation = function (
 	};
 
 	const result = this.wpcom.req.post(
-		{ path: '/me/google-apps/validate', body: data },
+		{ path: '/me/google-apps/validate', body: { contact_information, domain_names: domainNames } },
 		callback ? callbackFunction : null
 	);
 

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -716,31 +716,45 @@ Undocumented.prototype.validateDomainContactInformation = function (
 /**
  * Validates the specified Google Apps contact information
  *
+ * The contactInformation keys can be in camelCase or snake_case, and will be
+ * converted to snake_case before being submitted. The returned data keys will
+ * be converted to camelCase before being passed to the callback or the resolved
+ * Promise.
+ *
  * @param {object} contactInformation - user's contact information
- * @param {Function} callback The callback function
- * @returns {Promise} A promise that resolves when the request completes
+ * @param {(error: string, data: object) => void} [callback] The callback function.
+ * @returns {Promise|undefined} If no callback, returns a Promise that resolves when the request completes
  */
 Undocumented.prototype.validateGoogleAppsContactInformation = function (
 	contactInformation,
 	callback
 ) {
 	const data = mapKeysRecursively( { contactInformation }, snakeCase );
+	debug( '/me/google-apps/validate', data );
 
-	return this.wpcom.req.post(
+	const callbackFunction = ( error, successData ) => {
+		if ( error ) {
+			return callback( error );
+		}
+
+		const newData = mapKeysRecursively( successData, ( key ) => {
+			return key === '_headers' ? key : camelCase( key );
+		} );
+
+		callback( null, newData );
+	};
+
+	const result = this.wpcom.req.post(
 		{ path: '/me/google-apps/validate' },
 		data,
-		( error, successData ) => {
-			if ( error ) {
-				return callback( error );
-			}
-
-			const newData = mapKeysRecursively( successData, ( key ) => {
-				return key === '_headers' ? key : camelCase( key );
-			} );
-
-			callback( null, newData );
-		}
+		callback ? callbackFunction : null
 	);
+
+	return result.then?.( ( successData ) => {
+		return mapKeysRecursively( successData, ( key ) => {
+			return key === '_headers' ? key : camelCase( key );
+		} );
+	} );
 };
 
 /**

--- a/client/my-sites/checkout/checkout/domain-details-form.jsx
+++ b/client/my-sites/checkout/checkout/domain-details-form.jsx
@@ -28,6 +28,7 @@ import { addGoogleAppsRegistrationData } from 'lib/cart/actions';
 import {
 	getDomainRegistrations,
 	getDomainTransfers,
+	getGoogleApps,
 	hasGoogleApps,
 	hasDomainRegistration,
 	hasInvalidAlternateEmailDomain,
@@ -107,6 +108,7 @@ export class DomainDetailsForm extends PureComponent {
 		if ( this.needsOnlyGoogleAppsDetails() ) {
 			wpcom.validateGoogleAppsContactInformation(
 				fieldValues,
+				this.getGSuiteDomainNames(),
 				this.addAlternateEmailToValidationHandler( fieldValues, validationHandler )
 			);
 			return;
@@ -124,6 +126,8 @@ export class DomainDetailsForm extends PureComponent {
 		debug( 'Switching to step: ' + newStep );
 		this.setState( { currentStep: newStep } );
 	}
+
+	getGSuiteDomainNames = () => map( getGoogleApps( this.props.cart ), 'meta' );
 
 	getDomainNames = () =>
 		map(

--- a/client/my-sites/checkout/checkout/domain-details-form.jsx
+++ b/client/my-sites/checkout/checkout/domain-details-form.jsx
@@ -28,7 +28,6 @@ import { addGoogleAppsRegistrationData } from 'lib/cart/actions';
 import {
 	getDomainRegistrations,
 	getDomainTransfers,
-	getGoogleApps,
 	hasGoogleApps,
 	hasDomainRegistration,
 	hasInvalidAlternateEmailDomain,
@@ -108,7 +107,7 @@ export class DomainDetailsForm extends PureComponent {
 		if ( this.needsOnlyGoogleAppsDetails() ) {
 			wpcom.validateGoogleAppsContactInformation(
 				fieldValues,
-				this.getGSuiteDomainNames(),
+				[],
 				this.addAlternateEmailToValidationHandler( fieldValues, validationHandler )
 			);
 			return;
@@ -126,8 +125,6 @@ export class DomainDetailsForm extends PureComponent {
 		debug( 'Switching to step: ' + newStep );
 		this.setState( { currentStep: newStep } );
 	}
-
-	getGSuiteDomainNames = () => map( getGoogleApps( this.props.cart ), 'meta' );
 
 	getDomainNames = () =>
 		map(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This modifies `wpcom.undocumented.validateGoogleAppsContactInformation()` so that it accepts an array of domain names which it will then send to the validation server. When combined with D43415-code, this will allow the validation to check if the GSuite email addresses are correctly not using the domain name to which they are connected.

This also fixes the function so it sends its data as POST data (rather than GET data) and allows it to return a Promise (as its documentation suggests it might do).

This was extracted from the changes in #41705

#### Testing instructions

- Apply D43415-code
- Visit old checkout (not composite checkout) with GSuite items in your cart, but without a domain in your cart (your site must already have a domain for this to work).
- Try entering invalid data into the fields or leaving them empty and make sure that you see validation errors and cannot proceed.
- Examine the network traffic and make sure you see a call to `/me/google-apps/validate`.
- Try entering valid data and make sure that you can proceed.
