### PR TITLE
Fix global styles bad array access.

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/global-styles/includes/class-data-point-theme.php
+++ b/apps/full-site-editing/full-site-editing-plugin/global-styles/includes/class-data-point-theme.php
@@ -57,7 +57,14 @@ class Data_Point_Theme implements Data_Point {
 	 * Implements the \Automattic\Jetpack\Global_Styles\Data_Point interface.
 	 */
 	public function get_value() {
-		$theme_support = get_theme_support( $this->feature_name )[0];
+		$theme_support = get_theme_support( $this->feature_name );
+
+		// In some cases get_theme_support returns a boolean instead of array.
+		if ( is_bool( $theme_support ) ) {
+			return $theme_support;
+		}
+		// Otherwise, assume array and get the first item.
+		$theme_support = $theme_support[0];
 
 		if ( false === $theme_support || true === $theme_support ) {
 			return $this->default_value;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Checks to see if the item returned by `get_theme_support` is a boolean value.
* If it is, we return that value.  Otherwise, continue as usual.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* I'm still trying to reproduce the original issue noted (I'm always seeing the array in practice), so for now smoke test global styles in the editor with different themes.

Fixes #42225 (hopefully?)
