### PR TITLE
p2: hide activity&backup in sidebar

### DIFF
--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -227,6 +227,10 @@ export class MySitesSidebar extends Component {
 			return null;
 		}
 
+		if ( isEnabled( 'signup/wpforteams' ) && this.props.isSiteWPForTeams ) {
+			return null;
+		}
+
 		let activityLink = '/activity-log' + siteSuffix,
 			activityLabel = translate( 'Activity' );
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-for-teams/issues/243

For now, we decided to hide the "Activity & Backups" in the sidebar as we don't have plans what to do with it yet for p2 sites (formerly WP for Teams).

## Testing

Using a p2 site, verify that you can't see the "Activity & Backups" under the "Tools" sidebar menu. Verify you can see it with a normal WP.com site.
