### PR TITLE
Fix overflow-y issue in desktop views

### DIFF
--- a/client/landing/jetpack-cloud/sections/backups/style.scss
+++ b/client/landing/jetpack-cloud/sections/backups/style.scss
@@ -17,8 +17,12 @@
 		margin: 0;
 	}
 }
-.main {
+.backups__page .main {
 	overflow-y: auto;
+
+	@include breakpoint( '>660px' ) {
+		overflow-y: visible;
+	}
 }
 .backups__main-wrap {
 	display: flex;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

On desktop views, it shows unexpected scrollbars :

![image](https://user-images.githubusercontent.com/9832440/81974837-037e1000-961e-11ea-94a3-000ae1884ee6.png)

This update ensures that the overflow-y is active only for mobile view and in the Backup section.


#### Testing instructions

- Check on a desktop view (an example: Setting section), you don't see the scrollbars
