### PR TITLE
Jetpack Cloud: Remove Broken Activity Card Links 

### DIFF
--- a/client/landing/jetpack-cloud/components/activity-card/activity-description.tsx
+++ b/client/landing/jetpack-cloud/components/activity-card/activity-description.tsx
@@ -27,27 +27,25 @@ interface Props {
 
 const ActivityDescription: FunctionComponent< Props > = ( {
 	activity: { activityName, activityDescription },
-} ) => {
-	return (
-		<>
-			{ activityDescription.map( ( description, index ) => {
-				const { intent, section, type, url } = description;
+} ) => (
+	<>
+		{ activityDescription.map( ( description, index ) => {
+			const { intent, section, type, url } = description;
 
-				const content =
-					type === 'link' && url?.startsWith( 'https://wordpress.com/' )
-						? { ...description, type: undefined, url: undefined }
-						: description;
+			const content =
+				type === 'link' && url?.startsWith( 'https://wordpress.com/' )
+					? { ...description, type: undefined, url: undefined }
+					: description;
 
-				return (
-					<FormattedBlock
-						content={ content }
-						key={ index }
-						meta={ { activity: activityName, intent, section } }
-					/>
-				);
-			} ) }
-		</>
-	);
-};
+			return (
+				<FormattedBlock
+					content={ content }
+					key={ index }
+					meta={ { activity: activityName, intent, section } }
+				/>
+			);
+		} ) }
+	</>
+);
 
 export default ActivityDescription;

--- a/client/landing/jetpack-cloud/components/activity-card/activity-description.tsx
+++ b/client/landing/jetpack-cloud/components/activity-card/activity-description.tsx
@@ -1,0 +1,47 @@
+/**
+ * External dependencies
+ */
+import React, { FunctionComponent } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import FormattedBlock from 'components/notes-formatted-block';
+
+// FUTURE WORK: move this to a shared location
+interface Activity {
+	activityName: string;
+	activityMeta: {};
+	activityDescription: [
+		{
+			intent: string;
+			section: string;
+			children: string[];
+		}
+	];
+}
+
+interface Props {
+	activity: Activity;
+}
+
+const ActivityDescription: FunctionComponent< Props > = ( {
+	activity: { activityName, activityMeta, activityDescription },
+} ) => {
+	return (
+		<>
+			{ activityDescription.map( ( part, index ) => {
+				const { intent, section, children } = part;
+				return (
+					<FormattedBlock
+						key={ index }
+						content={ children }
+						meta={ { activity: activityName, intent, section } }
+					/>
+				);
+			} ) }{ ' ' }
+		</>
+	);
+};
+
+export default ActivityDescription;

--- a/client/landing/jetpack-cloud/components/activity-card/activity-description.tsx
+++ b/client/landing/jetpack-cloud/components/activity-card/activity-description.tsx
@@ -10,15 +10,15 @@ import FormattedBlock from 'components/notes-formatted-block';
 
 // FUTURE WORK: move this to a shared location
 interface Activity {
-	activityName: string;
-	activityMeta: {};
 	activityDescription: [
 		{
-			intent: string;
-			section: string;
-			children: string[];
+			intent?: string;
+			section?: string;
+			type?: string;
+			url?: string;
 		}
 	];
+	activityName: string;
 }
 
 interface Props {
@@ -26,20 +26,26 @@ interface Props {
 }
 
 const ActivityDescription: FunctionComponent< Props > = ( {
-	activity: { activityName, activityMeta, activityDescription },
+	activity: { activityName, activityDescription },
 } ) => {
 	return (
 		<>
-			{ activityDescription.map( ( part, index ) => {
-				const { intent, section, children } = part;
+			{ activityDescription.map( ( description, index ) => {
+				const { intent, section, type, url } = description;
+
+				const content =
+					type === 'link' && url?.startsWith( 'https://wordpress.com/' )
+						? { ...description, type: undefined, url: undefined }
+						: description;
+
 				return (
 					<FormattedBlock
+						content={ content }
 						key={ index }
-						content={ children }
 						meta={ { activity: activityName, intent, section } }
 					/>
 				);
-			} ) }{ ' ' }
+			} ) }
 		</>
 	);
 };

--- a/client/landing/jetpack-cloud/components/activity-card/index.jsx
+++ b/client/landing/jetpack-cloud/components/activity-card/index.jsx
@@ -22,7 +22,7 @@ import getDoesRewindNeedCredentials from 'state/selectors/get-does-rewind-need-c
 import QueryRewindState from 'components/data/query-rewind-state';
 import { Card } from '@automattic/components';
 import ActivityActor from 'my-sites/activity/activity-log-item/activity-actor';
-import ActivityDescription from 'my-sites/activity/activity-log-item/activity-description';
+import ActivityDescription from './activity-description';
 import ActivityMedia from 'my-sites/activity/activity-log-item/activity-media';
 import Button from 'components/forms/form-button';
 import Gridicon from 'components/gridicon';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Copy `ActivityDescription` into new Jetpack Cloud component
* Remove any links from cards that go to `WordPress.com`

#### Testing instructions

1. Navigate the Activity Log, making sure there are no broken links
