### PR TITLE
Jetpack Cloud: Restore items, not files

### DIFF
--- a/client/landing/jetpack-cloud/sections/backups/rewind-flow/restore.tsx
+++ b/client/landing/jetpack-cloud/sections/backups/rewind-flow/restore.tsx
@@ -149,7 +149,7 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 			</h3>
 			<p className="rewind-flow__info">
 				{ translate(
-					'All of your selected files are now restored back to {{strong}}%(backupDisplayDate)s{{/strong}}.',
+					'All of your selected items are now restored back to {{strong}}%(backupDisplayDate)s{{/strong}}.',
 					{
 						args: {
 							backupDisplayDate,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change wording on Restore Success Screen
<img width="738" alt="Screen Shot 2020-05-14 at 4 00 15 PM" src="https://user-images.githubusercontent.com/2810519/81994467-cc4b3700-95fc-11ea-987f-640a68724064.png">


#### Testing instructions

Restore a site and verify it matches the above screenshot
