### PR TITLE
composite-checkout: Record the step ID when recording a step load error

### DIFF
--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -77,7 +77,8 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 
 				return reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_composite_step_load_error', {
-						error_message: String( action.payload ),
+						error_message: String( action.payload.message ),
+						step_id: String( action.payload.stepId ),
 					} )
 				);
 

--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -73,7 +73,11 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 				);
 
 			case 'STEP_LOAD_ERROR':
-				reduxDispatch( logStashEventAction( 'step_load', String( action.payload ) ) );
+				reduxDispatch(
+					logStashEventAction( 'step_load', String( action.payload.message ), {
+						stepId: action.payload.stepId,
+					} )
+				);
 
 				return reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_composite_step_load_error', {
@@ -456,7 +460,7 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 	};
 }
 
-function logStashEventAction( type, message ) {
+function logStashEventAction( type, message, additionalData = {} ) {
 	return logToLogstash( {
 		feature: 'calypso_client',
 		message: 'composite checkout load error',
@@ -465,6 +469,7 @@ function logStashEventAction( type, message ) {
 			env: config( 'env_id' ),
 			type,
 			message,
+			...additionalData,
 		},
 	} );
 }

--- a/packages/composite-checkout/src/components/checkout-steps.js
+++ b/packages/composite-checkout/src/components/checkout-steps.js
@@ -284,9 +284,12 @@ export function CheckoutStep( {
 		( error ) =>
 			onEvent( {
 				type: 'STEP_LOAD_ERROR',
-				payload: error.message,
+				payload: {
+					message: error.message,
+					stepId,
+				},
 			} ),
-		[ onEvent ]
+		[ onEvent, stepId ]
 	);
 
 	return (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Composite checkout currently records a Tracks and Logstash event when its React Error Boundaries are hit. One of these errors is when a step has an error, and it records the error message in both of those places. However, it would be helpful to know which step had the error, so this changes the code such that it records the step ID as well.

![Screen Shot 2020-05-14 at 7 46 38 PM](https://user-images.githubusercontent.com/2036909/81996688-a7b28780-961b-11ea-9bd4-2dd84a32b1d2.png)


#### Testing instructions

- Modify the code to cause a fatal error inside a step. For example, add `throw new Error('testing')` inside `WPContactForm`.
- Load composite checkout and verify that the broken step is not shown and instead you see the error boundary with a brief message.
- Verify that the Tracks event `calypso_checkout_composite_step_load_error` contains both the error message and the step ID.
- Verify that the Logstash event contains both the error message and the step ID.