### PR TITLE
Gutenboarding: add select_domain event

### DIFF
--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -9,6 +9,7 @@ import { Icon } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useHistory } from 'react-router-dom';
 import classnames from 'classnames';
+import { DomainSuggestions } from '@automattic/data-stores';
 
 /**
  * Internal dependencies
@@ -29,6 +30,7 @@ import {
 } from '../../utils/domain-suggestions';
 import { PAID_DOMAINS_TO_SHOW } from '../../constants';
 import { usePath, useCurrentStep, Step } from '../../path';
+import { trackEventWithFlow } from '../../lib/analytics';
 
 const Header: React.FunctionComponent = () => {
 	const { __, i18nLocale } = useI18n();
@@ -139,6 +141,13 @@ const Header: React.FunctionComponent = () => {
 	const hasPlaceholder =
 		!! siteTitle && ! recommendedDomainSuggestion && previousRecommendedDomain !== '';
 
+	const onDomainSelect = ( suggestion: DomainSuggestions.DomainSuggestion | undefined ) => {
+		trackEventWithFlow( 'calypso_newsite_select_domain', {
+			domain_name: suggestion?.domain_name,
+		} );
+		setDomain( suggestion );
+	};
+
 	return (
 		<div
 			className="gutenboarding__header"
@@ -173,7 +182,7 @@ const Header: React.FunctionComponent = () => {
 									<DomainPickerButton
 										className="gutenboarding__header-domain-picker-button"
 										currentDomain={ domain }
-										onDomainSelect={ setDomain }
+										onDomainSelect={ onDomainSelect }
 									>
 										{ domainElement }
 									</DomainPickerButton>

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -9,7 +9,6 @@ import { Icon } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useHistory } from 'react-router-dom';
 import classnames from 'classnames';
-import { DomainSuggestions } from '@automattic/data-stores';
 
 /**
  * Internal dependencies
@@ -31,6 +30,8 @@ import {
 import { PAID_DOMAINS_TO_SHOW } from '../../constants';
 import { usePath, useCurrentStep, Step } from '../../path';
 import { trackEventWithFlow } from '../../lib/analytics';
+
+type DomainSuggestion = import('@automattic/data-stores').DomainSuggestions.DomainSuggestion;
 
 const Header: React.FunctionComponent = () => {
 	const { __, i18nLocale } = useI18n();
@@ -141,7 +142,7 @@ const Header: React.FunctionComponent = () => {
 	const hasPlaceholder =
 		!! siteTitle && ! recommendedDomainSuggestion && previousRecommendedDomain !== '';
 
-	const onDomainSelect = ( suggestion: DomainSuggestions.DomainSuggestion | undefined ) => {
+	const onDomainSelect = ( suggestion: DomainSuggestion | undefined ) => {
 		trackEventWithFlow( 'calypso_newsite_select_domain', {
 			domain_name: suggestion?.domain_name,
 		} );

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -143,7 +143,7 @@ const Header: React.FunctionComponent = () => {
 		!! siteTitle && ! recommendedDomainSuggestion && previousRecommendedDomain !== '';
 
 	const onDomainSelect = ( suggestion: DomainSuggestion | undefined ) => {
-		trackEventWithFlow( 'calypso_newsite_select_domain', {
+		trackEventWithFlow( 'calypso_newsite_domain_select', {
 			domain_name: suggestion?.domain_name,
 		} );
 		setDomain( suggestion );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Added the calypso_newsite_select_domain event when a new domain name has been selected. (when clicking confirm on the modal)

#### Testing instructions
* Navigate to /new
* Open the domain picker
* Select a domain
*  Press Confirm on the domain picker dialog
* A calypso_newsite_select_domain event should be fired
