### PR TITLE
Gutenboarding: Check for a selected plan to determine whether to show the plans grid

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/plans/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/plans/index.tsx
@@ -27,10 +27,14 @@ export default function PlansStep() {
 	const currentUser = useSelect( ( select ) => select( USER_STORE ).getCurrentUser() );
 
 	const { createSite } = useDispatch( ONBOARD_STORE );
-
+	const { setHasUsedPlansStep } = useDispatch( ONBOARD_STORE );
 	const plan = useSelectedPlan();
 
 	const freeDomainSuggestion = useFreeDomainSuggestion();
+
+	useEffect( () => {
+		setHasUsedPlansStep( true );
+	}, [] );
 
 	// Keep a copy of the selected plan locally so it's available when the component is unmounting
 	const selectedPlanRef = useRef();

--- a/client/landing/gutenboarding/onboarding-block/style-preview/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/index.tsx
@@ -30,7 +30,9 @@ import './style.scss';
 
 const StylePreview: React.FunctionComponent = () => {
 	const { getSelectedFonts } = useSelect( ( select ) => select( ONBOARD_STORE ) );
-	const { selectedDesign } = useSelect( ( select ) => select( ONBOARD_STORE ).getState() );
+	const { selectedDesign, hasUsedPlansStep } = useSelect( ( select ) =>
+		select( ONBOARD_STORE ).getState()
+	);
 	const selectedPlanSlug = useSelectedPlan().getStoreSlug();
 
 	const [ showSignupDialog, setShowSignupDialog ] = useState( false );
@@ -71,12 +73,10 @@ const StylePreview: React.FunctionComponent = () => {
 	);
 
 	const handleContinue = () => {
-		// Show the plans grid to all users
-		// and all users who have seen the plans step before
-		// except if they have chosen a plan via the plans modal before they have reached the plans step
-		// or a plan is in the path
-
-		if ( isEnabled( 'gutenboarding/plans-grid' ) && ! selectedPlan ) {
+		// Skip the plans step if the user has used the plans modal to select a plan
+		// If a user has already used the plans step and then gone back, show them the plans step again
+		// to avoid confusion
+		if ( isEnabled( 'gutenboarding/plans-grid' ) && ( ! selectedPlan || hasUsedPlansStep ) ) {
 			history.push( makePath( Step.Plans ) );
 			return;
 		}

--- a/client/landing/gutenboarding/onboarding-block/style-preview/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/index.tsx
@@ -19,6 +19,7 @@ import FontSelect from './font-select';
 import { Title, SubTitle } from '../../components/titles';
 import * as T from './types';
 import { STORE_KEY as ONBOARD_STORE } from '../../stores/onboard';
+import { STORE_KEY as PLANS_STORE } from '../../stores/plans';
 import { USER_STORE } from '../../stores/user';
 import { useFreeDomainSuggestion } from '../../hooks/use-free-domain-suggestion';
 import SignupForm from '../../components/signup-form';
@@ -28,7 +29,7 @@ import BottomBarMobile from '../../components/bottom-bar-mobile';
 import './style.scss';
 
 const StylePreview: React.FunctionComponent = () => {
-	const { getSelectedFonts, hasPaidDomain } = useSelect( ( select ) => select( ONBOARD_STORE ) );
+	const { getSelectedFonts } = useSelect( ( select ) => select( ONBOARD_STORE ) );
 	const { selectedDesign } = useSelect( ( select ) => select( ONBOARD_STORE ).getState() );
 	const selectedPlanSlug = useSelectedPlan().getStoreSlug();
 
@@ -46,6 +47,8 @@ const StylePreview: React.FunctionComponent = () => {
 	const { createSite } = useDispatch( ONBOARD_STORE );
 
 	const freeDomainSuggestion = useFreeDomainSuggestion();
+
+	const selectedPlan = useSelect( ( select ) => select( PLANS_STORE ).getSelectedPlan() );
 
 	useTrackStep( 'Style', () => ( {
 		selected_heading_font: getSelectedFonts()?.headings,
@@ -68,7 +71,12 @@ const StylePreview: React.FunctionComponent = () => {
 	);
 
 	const handleContinue = () => {
-		if ( isEnabled( 'gutenboarding/plans-grid' ) && hasPaidDomain() ) {
+		// Show the plans grid to all users
+		// and all users who have seen the plans step before
+		// except if they have chosen a plan via the plans modal before they have reached the plans step
+		// or a plan is in the path
+
+		if ( isEnabled( 'gutenboarding/plans-grid' ) && ! selectedPlan ) {
 			history.push( makePath( Step.Plans ) );
 			return;
 		}

--- a/client/landing/gutenboarding/stores/onboard/actions.ts
+++ b/client/landing/gutenboarding/stores/onboard/actions.ts
@@ -88,6 +88,11 @@ export const setIsRedirecting = ( isRedirecting: boolean ) => ( {
 	isRedirecting,
 } );
 
+export const setHasUsedPlansStep = ( hasUsedPlansStep: boolean ) => ( {
+	type: 'SET_HAS_USED_PLANS_STEP' as const,
+	hasUsedPlansStep,
+} );
+
 export function* createSite(
 	username: string,
 	freeDomainSuggestion?: DomainSuggestion,
@@ -144,6 +149,7 @@ export type OnboardAction = ReturnType<
 	| typeof setDomainCategory
 	| typeof setFonts
 	| typeof setIsRedirecting
+	| typeof setHasUsedPlansStep
 	| typeof setSelectedDesign
 	| typeof setSelectedSite
 	| typeof setSiteTitle

--- a/client/landing/gutenboarding/stores/onboard/index.ts
+++ b/client/landing/gutenboarding/stores/onboard/index.ts
@@ -28,6 +28,7 @@ registerStore< State >( STORE_KEY, {
 		'domain',
 		'siteTitle',
 		'siteVertical',
+		'hasUsedPlansStep',
 		'wasVerticalSkipped',
 		'pageLayouts',
 		'selectedDesign',

--- a/client/landing/gutenboarding/stores/onboard/reducer.ts
+++ b/client/landing/gutenboarding/stores/onboard/reducer.ts
@@ -137,11 +137,22 @@ const isRedirecting: Reducer< boolean, OnboardAction > = ( state = false, action
 	return state;
 };
 
+const hasUsedPlansStep: Reducer< boolean, OnboardAction > = ( state = false, action ) => {
+	if ( action.type === 'SET_HAS_USED_PLANS_STEP' ) {
+		return action.hasUsedPlansStep;
+	}
+	if ( action.type === 'RESET_ONBOARD_STORE' ) {
+		return false;
+	}
+	return state;
+};
+
 const reducer = combineReducers( {
 	domain,
 	domainSearch,
 	domainCategory,
 	isRedirecting,
+	hasUsedPlansStep,
 	pageLayouts,
 	selectedFonts,
 	selectedDesign,

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -116,7 +116,7 @@ export default {
 		allowExistingUsers: true,
 	},
 	newSiteGutenbergOnboarding: {
-		datestamp: '20200501',
+		datestamp: '20200515',
 		variations: {
 			gutenberg: 10,
 			control: 90,


### PR DESCRIPTION
## Changes proposed in this Pull Request

Check for a selected plan to determine whether to show the plans grid. 

This doesn't yet take into account whether:

- a user has already seen the plans page, in which case we could allow it to be shown


## Testing instructions

Enter the `/new` flow and carry on without selecting a plan. You should see the plans page.
Enter the `/new` flow and select a paid domain. You should see the plans page.
Enter the `/new` flow and select a plan from the modal. You should NOT see the plans page.

## TODO

- [x] Persist the plans page if the user has already seen and interacted with it (otherwise it might cause confusion?)
- [x] Entering the `/new/premium` does not select the plan in the grid. Should we do this?

Fixes #42218
