### PR TITLE
Add `yarn dev --sync` script to the wpcom-block-editor plugin

### DIFF
--- a/apps/wpcom-block-editor/README.md
+++ b/apps/wpcom-block-editor/README.md
@@ -190,6 +190,19 @@ Then, each bundle contains features for different types of pages. For example, t
 
 ## Build
 
+### Dev workflow 
+
+The wpcom-block-editor needs an active wpcom sandbox to test.
+
+Ensure that your sandbox is set up, aliased to `wpcom-sandbox` and currently active
+
+The following will build wpcom-block-editor, and upload the results to the `widgets.wp.com/wpcom-block-editor` folder on your sandbox.
+
+```bash
+# Watch for file changes and upload build output to your sandbox
+yarn dev --sync
+```
+
 ### Manual
 
 To manually build the package, execute the command below passing the directory where the distributable files will be generated:

--- a/apps/wpcom-block-editor/bin/npm-run-build.js
+++ b/apps/wpcom-block-editor/bin/npm-run-build.js
@@ -1,0 +1,33 @@
+/**
+ * This script is adapted from ../../full-site-editing/bin/npm-run-build.js
+ *
+ **** WARNING: No ES6 modules here. Not transpiled! ****
+ */
+/* eslint-disable import/no-nodejs-modules */
+/* eslint-disable import/no-extraneous-dependencies */
+/* eslint-disable no-console */
+
+const runAll = require( 'npm-run-all' );
+
+const args = process.argv.slice( 2 );
+
+const argsToCommands = {
+	'--build': 'build:*',
+	'--dev': 'build --watch',
+	'--sync': 'wpcom-sync',
+};
+
+const commands = args.map( ( arg ) => argsToCommands[ arg ] ).filter( ( val ) => !! val );
+
+console.log( `Running the following commands: ${ commands.toString() }` );
+
+const runOptions = {
+	parallel: true,
+	stdout: process.stdout,
+	stderr: process.stderr,
+	printLabel: true,
+};
+
+runAll( commands, runOptions ).then( () => {
+	console.log( 'Finished running commands!' );
+} );

--- a/apps/wpcom-block-editor/bin/wpcom-watch-and-sync.sh
+++ b/apps/wpcom-block-editor/bin/wpcom-watch-and-sync.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+LOCAL_PATH="./dist/"
+REMOTE_PATH="/home/wpcom/public_html/widgets.wp.com/wpcom-block-editor"
+REMOTE_SSH="wpcom-sandbox"
+COMMAND="rsync -ahz $LOCAL_PATH $REMOTE_SSH:$REMOTE_PATH"
+
+npx chokidar "$LOCAL_PATH**" --debounce 1000 --throttle 10000 -c "$COMMAND"

--- a/apps/wpcom-block-editor/package.json
+++ b/apps/wpcom-block-editor/package.json
@@ -21,7 +21,9 @@
 		"build:prod": "check-npm-client && NODE_ENV=production yarn run bundle --",
 		"build": "check-npm-client && npm-run-all --parallel \"build:* -- {@}\" --",
 		"clean": "check-npm-client && npx rimraf dist",
-		"prebuild": "check-npm-client && yarn run clean"
+		"prebuild": "check-npm-client && yarn run clean",
+		"dev": "check-npm-client && node bin/npm-run-build.js --dev",
+		"wpcom-sync": "check-npm-client && ./bin/wpcom-watch-and-sync.sh"
 	},
 	"dependencies": {
 		"debug": "^4.1.1"


### PR DESCRIPTION
To match the excellent workflow that we now have in the full site editing plugin, I've coppied/adapted the script to work in the wpcom-block-editor plugin as well.

#### Changes proposed in this Pull Request

Add sync and dev build scripts from full-site-editing plugin, adapt them to work in the wpcom-block-editor

#### Testing instructions
* Following new Readme.md instructions, sandbox wordpress.com and a test website.
* run  `yarn dev --sync` in wpcom-block-editor
* Make changes to code in wpcom-block-editor
* Load the block-editor in a sandboxed site.
* You should see your changes!
