### PR TITLE
Gutenboarding: Fixes for cursor position in acquire intent contenteditable elements

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
@@ -25,6 +25,19 @@ import { recordVerticalSkip, recordSiteTitleSkip } from '../../lib/analytics';
  */
 import './style.scss';
 
+export function moveCaretToEnd( node: Node ) {
+	const numChildNodes = node.childNodes.length;
+	if ( numChildNodes ) {
+		const lastNode = node.childNodes[ numChildNodes - 1 ];
+		const range = document.createRange();
+		const selection = document.getSelection();
+		range.setStart( lastNode, lastNode?.textContent?.length || 0 );
+		range.collapse( true );
+		selection?.removeAllRanges();
+		selection?.addRange( range );
+	}
+}
+
 const AcquireIntent: React.FunctionComponent = () => {
 	const { __ } = useI18n();
 	const { getSelectedVertical, getSelectedSiteTitle, wasVerticalSkipped } = useSelect( ( select ) =>

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
@@ -37,8 +37,13 @@ const SiteTitle: React.FunctionComponent< Props > = ( { isVisible, isMobile, onS
 		}
 	};
 
-	const handleKeyUp = ( e: React.KeyboardEvent< HTMLSpanElement > ) =>
+	const handleKeyUp = ( e: React.KeyboardEvent< HTMLSpanElement > ) => {
 		setSiteTitle( e.currentTarget.innerText.trim().length ? e.currentTarget.innerText : '' );
+	};
+
+	const handleFocus = () => {
+		moveCaretToEnd( inputRef.current );
+	};
 
 	const handleBlur = () => {
 		recordSiteTitleSelection( !! siteTitle );
@@ -50,13 +55,12 @@ const SiteTitle: React.FunctionComponent< Props > = ( { isVisible, isMobile, onS
 		}
 	}, [] ); // eslint-disable-line react-hooks/exhaustive-deps
 
-	const siteVerticalLabel = siteVertical?.label;
 	React.useEffect( () => {
-		if ( ( siteVerticalLabel && isVisible ) || wasVerticalSkipped ) {
+		if ( ( siteVertical && isVisible ) || wasVerticalSkipped ) {
 			inputRef.current.focus();
 			moveCaretToEnd( inputRef.current );
 		}
-	}, [ siteVerticalLabel, isVisible, inputRef, wasVerticalSkipped ] );
+	}, [ siteVertical, isVisible, inputRef, wasVerticalSkipped ] );
 
 	// translators: Form input for a site's title where "<Input />" is replaced by user input and must be preserved verbatim in translated string.
 	const madlibTemplate = __( 'Itʼs called <Input />' );
@@ -81,6 +85,7 @@ const SiteTitle: React.FunctionComponent< Props > = ( { isVisible, isMobile, onS
 						onKeyDown={ handleKeyDown }
 						onKeyUp={ handleKeyUp }
 						onBlur={ handleBlur }
+						onFocus={ handleFocus }
 						onClick={ ( event ) => event.stopPropagation() }
 					/>
 					{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
@@ -13,6 +13,7 @@ import { useI18n } from '@automattic/react-i18n';
  */
 import { STORE_KEY } from '../../stores/onboard';
 import { recordSiteTitleSelection } from '../../lib/analytics';
+import { moveCaretToEnd } from './index';
 
 interface Props {
 	isVisible?: boolean;
@@ -49,11 +50,13 @@ const SiteTitle: React.FunctionComponent< Props > = ( { isVisible, isMobile, onS
 		}
 	}, [] ); // eslint-disable-line react-hooks/exhaustive-deps
 
+	const siteVerticalLabel = siteVertical?.label;
 	React.useEffect( () => {
-		if ( ( siteVertical?.label && isVisible ) || wasVerticalSkipped ) {
+		if ( ( siteVerticalLabel && isVisible ) || wasVerticalSkipped ) {
 			inputRef.current.focus();
+			moveCaretToEnd( inputRef.current );
 		}
-	}, [ siteVertical, isVisible, inputRef, wasVerticalSkipped ] );
+	}, [ siteVerticalLabel, isVisible, inputRef, wasVerticalSkipped ] );
 
 	// translators: Form input for a site's title where "<Input />" is replaced by user input and must be preserved verbatim in translated string.
 	const madlibTemplate = __( 'Itʼs called <Input />' );
@@ -78,6 +81,7 @@ const SiteTitle: React.FunctionComponent< Props > = ( { isVisible, isMobile, onS
 						onKeyDown={ handleKeyDown }
 						onKeyUp={ handleKeyUp }
 						onBlur={ handleBlur }
+						onClick={ ( event ) => event.stopPropagation() }
 					/>
 					{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
 					<span className="madlib__input-placeholder"></span>
@@ -93,7 +97,11 @@ const SiteTitle: React.FunctionComponent< Props > = ( { isVisible, isMobile, onS
 			className={ classnames( 'site-title', {
 				'site-title--hidden': ! isVisible,
 			} ) }
-			onClick={ () => inputRef.current.focus() } // focus the input when clicking label or next to it
+			onClick={ () => {
+				// Focus the input when clicking label or placeholder.
+				inputRef.current.focus();
+				moveCaretToEnd( inputRef.current );
+			} }
 		>
 			{ madlib }
 		</form>

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
@@ -64,7 +64,7 @@
 	line-height: 1em;
 	word-break: break-word;
 	height: 1.01em;
-	padding: 0;
+	padding: 0 1px; // 1px padding added to fix Firefox caret bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1252108
 
 	color: var( --mainColor );
 	border-bottom: 2px solid var( --mainColor );
@@ -167,7 +167,6 @@
 		height: 100%;
 		left: 0;
 		bottom: 0;
-		z-index: 2;
 
 		.madlib__input-placeholder-text {
 			position: absolute;

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
@@ -153,6 +153,12 @@ const VerticalSelect: React.FunctionComponent< Props > = ( { onNext } ) => {
 		onNext();
 	};
 
+	const handleBlurEvent = () => {
+		if ( inputText.trim() !== siteVertical?.label ) {
+			selectLastInputValue();
+		}
+	};
+
 	const handleInputKeyUpEvent = ( e: React.KeyboardEvent< HTMLSpanElement > ) => {
 		const input = e.currentTarget.innerText.trim();
 		if ( ! input.length ) {
@@ -196,6 +202,12 @@ const VerticalSelect: React.FunctionComponent< Props > = ( { onNext } ) => {
 		}
 	}, [ suggestions, isMobile ] );
 
+	React.useEffect( () => {
+		if ( isFocused && document.activeElement === inputRef.current ) {
+			moveCaretToEnd( inputRef.current );
+		}
+	}, [ isFocused ] );
+
 	// translators: Form input for a site's topic where "<Input />" is replaced by user input and must be preserved verbatim in translated string.
 	const madlibTemplate = __( 'My site is about <Input />' );
 	// translators: Form input for a site's topic where "<Input />" is replaced with the topic selected by the user.
@@ -224,7 +236,7 @@ const VerticalSelect: React.FunctionComponent< Props > = ( { onNext } ) => {
 							onKeyDown={ handleInputKeyDownEvent }
 							onKeyUp={ handleInputKeyUpEvent }
 							onFocus={ () => setIsFocused( true ) }
-							onBlur={ selectLastInputValue }
+							onBlur={ handleBlurEvent }
 							onClick={ ( event ) => event.stopPropagation() }
 						/>
 						{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
@@ -20,6 +20,7 @@ import useTyper from '../../../hooks/use-typer';
 import Arrow from '../arrow';
 import { recordVerticalSelection } from '../../../lib/analytics';
 import type { SiteVertical } from '../../../stores/onboard/types';
+import { moveCaretToEnd } from '../index';
 
 /**
  * Style dependencies
@@ -224,6 +225,7 @@ const VerticalSelect: React.FunctionComponent< Props > = ( { onNext } ) => {
 							onKeyUp={ handleInputKeyUpEvent }
 							onFocus={ () => setIsFocused( true ) }
 							onBlur={ selectLastInputValue }
+							onClick={ ( event ) => event.stopPropagation() }
 						/>
 						{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
 						<span className="madlib__input-placeholder">
@@ -257,7 +259,11 @@ const VerticalSelect: React.FunctionComponent< Props > = ( { onNext } ) => {
 			className={ classnames( 'vertical-select', {
 				'vertical-select--with-suggestions': !! suggestions.length && isMobile,
 			} ) }
-			onClick={ () => inputRef.current.focus() } // focus the input when clicking label or placeholder
+			onClick={ () => {
+				// Focus the input when clicking label or placeholder.
+				inputRef.current.focus();
+				moveCaretToEnd( inputRef.current );
+			} }
 		>
 			{ madlib }
 		</form>

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/style.scss
@@ -44,7 +44,8 @@
 	display: inline-block;
 	visibility: hidden;
 	width: 0;
-	height: 0;
+	height: 1em;
+	vertical-align: middle;
 }
 
 .vertical-select__suggestions-wrapper {


### PR DESCRIPTION
This PR attempts to fix a couple of cursor position issues in the acquire intent step of Gutenboarding. The main fixes are:

* When a user moves the cursor to the beginning of the vertical they've typed in, the cursor should not drop down lower unexpectedly (#41976).
* When a user clicks label text, it should move the cursor to the end of the associated editable field, just like a `label` on an `input` element.
* When a user gets to the Design selection step and clicks back, the cursor should be at the end of the site title.

This is kind of a speculative PR, as it introduces extra control over the cursor position. Is this something we want to do? On balance, is this change more valuable than the risk of messing around with the cursor position when someone clicks things?

#### Changes proposed in this Pull Request

* Give the whitespace a height and alignment consistent with the vertical input.
* Prevent site title from focusing too frequently by adding an `onBlur` handler for the vertical input, which checks if the vertical needs updating before selecting it. This resolves a subtle issue where if you click and hold the text preceding the vertical, the cursor would be moved to focus on the site title, until you let go of the mouse button.
* Add `moveCaretToEnd` function to move the selection to the end of the desired input area when clicking the form. This makes the label areas behave a bit more like an input field's label, by sending the cursor to the end of the editable area.
* Prevent clicking either editable field from bubbling up to the `form` onClick handler so that the browser default behaviour of clicking into a field moves the cursor to within the field as we'd expect.
* Add 1px horizontal padding to the `madlib__input` class as a workaround to fix a Firefox bug related to caret position in `contenteditable` elements: https://bugzilla.mozilla.org/show_bug.cgi?id=1252108
* Remove `z-index` from the madlib placeholder, so that it doesn't render on top of the drop-down suggestions

#### Screenshot

Demo of clicking label text to send the cursor to the end of the editable areas, and then clicking back from the Design step where the cursor then goes to the end of the site title field:

![acquire-intent-cursor-position-small](https://user-images.githubusercontent.com/14988353/82022514-279a2980-96d0-11ea-994c-ce5319a57329.gif)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Note: as @razvanpapadopol mentioned elsewhere, dealing with the cursor position can become quite hacky. So, I'm interested in your opinion here, too! Does this approach seem reasonable, or does it feel too brittle?

Things to test:

* From `/new`
* Enter and delete text in the vertical field
* With text in the vertical field, move the cursor all the way left and make sure it doesn't dip down weirdly (fixed #41976)
* Enter and delete text in the site title field
* Click within each of these fields while there's text there, to make sure the cursor goes to the correct position
* Click the label text of each, and ensure that the cursor goes to the end of the line
* Go to the design step with a site title entered, and then click back, does the cursor go to the end of the line
* Test going to the design step with no title, or no vertical, and then click back, make sure nothing breaks
* Check across a variety of browsers, Safari, Chrome, Firefox, IE, mobile browsers, and make sure nothing breaks

---

Fixes #41976 
And issue raised in PR https://github.com/Automattic/wp-calypso/pull/42197#issuecomment-629010997
And related to discussion in PR https://github.com/Automattic/wp-calypso/pull/40645#discussion_r402186180