### PR TITLE
Gutenborading: move Bowen design to be the last in grid

### DIFF
--- a/client/landing/gutenboarding/available-designs.ts
+++ b/client/landing/gutenboarding/available-designs.ts
@@ -1,18 +1,6 @@
 const availableDesigns: Readonly< AvailableDesigns > = {
 	featured: [
 		{
-			title: 'Bowen',
-			slug: 'bowen',
-			template: 'bowen',
-			theme: 'coutoire',
-			src: 'https://public-api.wordpress.com/rest/v1/template/demo/coutoire/bowen/',
-			fonts: {
-				headings: 'Playfair Display',
-				base: 'Fira Sans',
-			},
-			categories: [ 'featured', 'blog' ],
-		},
-		{
 			title: 'Edison',
 			slug: 'edison',
 			template: 'edison',
@@ -119,6 +107,18 @@ const availableDesigns: Readonly< AvailableDesigns > = {
 				base: 'Fira Sans',
 			},
 			categories: [ 'featured', 'charity', 'non-profit' ],
+		},
+		{
+			title: 'Bowen',
+			slug: 'bowen',
+			template: 'bowen',
+			theme: 'coutoire',
+			src: 'https://public-api.wordpress.com/rest/v1/template/demo/coutoire/bowen/',
+			fonts: {
+				headings: 'Playfair Display',
+				base: 'Fira Sans',
+			},
+			categories: [ 'featured', 'blog' ],
 		},
 	],
 };


### PR DESCRIPTION
Move Bowen design to be the last.

A follow-up to today's design re-ordering: https://github.com/Automattic/wp-calypso/pull/42237

cc @ianstewart 

This is due header being sub-optimal in the underlying theme "Coutoire", as it floats over the content as users scrolls on page:

![image](https://user-images.githubusercontent.com/87168/82041888-9ae07300-96b1-11ea-874c-0bc4dc7027e5.png)

See issue https://github.com/Automattic/themes/issues/1901

![image](https://user-images.githubusercontent.com/87168/82041844-8308ef00-96b1-11ea-905f-e0bdb8585e2a.png)

