### PR TITLE
Docs: Add "unpublished package as a dependency" guide

### DIFF
--- a/docs/dependency-management.md
+++ b/docs/dependency-management.md
@@ -51,6 +51,20 @@ You should add dependencies to the root project _only_ when it will be used to t
 yarn add -w <dependency>
 ```
 
+#### Unpublished package as a dependency
+
+Sometimes you'll want to [create a package](https://github.com/Automattic/wp-calypso/blob/master/docs/monorepo.md#a-sample-packagejson) and use it as another workspace's dependency before it's published. To add such dependency, make sure you **specify its exact version** because otherwise, `yarn` will try to resolve it from the `npm` registry and throw the `Not found` error.
+
+Let's say you created a polyfill package and want to add it as a dependency to `packages/calypso-polyfills`. Doing this will make `yarn` resolve to your fresh (unpublished) package and install it as a symlink:
+
+```
+cd packages/calypso-polyfills
+yarn add @automattic/my-awesome-polyfill@1.0.0
+```
+
+That's it! Don't forget to [publish the package](https://github.com/Automattic/wp-calypso/blob/master/docs/monorepo.md#publishing) after merging your PR!
+
+
 ### Delete a dependency
 
 ```


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Updating the Dependency Management docs with a guide to adding an unpublished package as a dependency. This information can be useful as `yarn` does not resolve by default to a local dependency unless its exact version is specified. Please see [this comment](https://github.com/Automattic/wp-calypso/pull/41990#issuecomment-626758995) for more context.