### PR TITLE
Modularise terms state

### DIFF
--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -93,7 +93,6 @@ import siteSettings from './site-settings/reducer';
 import sites from './sites/reducer';
 import storedCards from './stored-cards/reducer';
 import support from './support/reducer';
-import terms from './terms/reducer';
 import timezones from './timezones/reducer';
 import ui from './ui/reducer';
 import userDevices from './user-devices/reducer';
@@ -180,7 +179,6 @@ const reducers = {
 	sites,
 	storedCards,
 	support,
-	terms,
 	timezones,
 	ui,
 	userDevices,

--- a/client/state/terms/actions.js
+++ b/client/state/terms/actions.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import { filter, get, uniqueId } from 'lodash';
 
 /**
@@ -20,6 +19,8 @@ import { updateSiteSettings } from 'state/site-settings/actions';
 import { getSitePostsByTerm } from 'state/posts/selectors';
 import { getSiteSettings } from 'state/site-settings/selectors';
 import { getTerm, getTerms } from './selectors';
+
+import 'state/terms/init';
 
 /**
  * Returns an action thunk, dispatching progress of a request to add a new term

--- a/client/state/terms/init.js
+++ b/client/state/terms/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'state/redux-store';
+import termsReducer from './reducer';
+
+registerReducer( [ 'terms' ], termsReducer );

--- a/client/state/terms/package.json
+++ b/client/state/terms/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/terms/reducer.js
+++ b/client/state/terms/reducer.js
@@ -16,7 +16,7 @@ import {
 	TERMS_REQUEST_SUCCESS,
 	SERIALIZE,
 } from 'state/action-types';
-import { combineReducers, withSchemaValidation } from 'state/utils';
+import { combineReducers, withSchemaValidation, withStorageKey } from 'state/utils';
 import TermQueryManager from 'lib/query-manager/term';
 import { getSerializedTermsQuery } from './utils';
 import { queriesSchema } from './schema';
@@ -111,7 +111,10 @@ export const queries = withSchemaValidation( queriesSchema, ( state = {}, action
 	return state;
 } );
 
-export default combineReducers( {
+const combinedReducer = combineReducers( {
 	queries,
 	queryRequests,
 } );
+
+const termsReducer = withStorageKey( 'terms', combinedReducer );
+export default termsReducer;

--- a/client/state/terms/selectors.js
+++ b/client/state/terms/selectors.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import { get, range } from 'lodash';
 
 /**
@@ -9,6 +8,8 @@ import { get, range } from 'lodash';
  */
 import createSelector from 'lib/create-selector';
 import { getSerializedTermsQuery, getSerializedTermsQueryWithoutPage } from './utils';
+
+import 'state/terms/init';
 
 /**
  * Returns true if currently requesting terms for the taxonomies query, or false


### PR DESCRIPTION
This PR is one of many working on modularising state in Calypso. This one handles terms.

For more details on state modularisation, see the [modularised state documentation](https://github.com/Automattic/wp-calypso/blob/master/docs/modularized-state.md) and p4TIVU-9lM-p2.

#### Changes proposed in this Pull Request

* Modularise terms state

#### Testing instructions

* Install [Redux DevTools](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en).
* Open DevTools and switch to the Redux tab.
* Open `/read` on the live branch or your local copy of this branch.
* Click `State` on the top right to ensure you see all state, and not just the diff for the last action: 
![image](https://user-images.githubusercontent.com/409615/73774406-d3e87d80-477b-11ea-9f59-3e42cc00101f.png)
* Analyse the tree and note that there's no `terms` key, even if you expand the list of keys. This indicates that the terms state hasn't been loaded yet.
* Click `My Sites` on the masterbar, followed by `Manage` and `Settings` in the sidebar.
* Click the `Writing` tab in the settings page.
* Verify that a `terms` key is added with the terms state. This indicates that the terms state has now been loaded.
* Verify that terms-related functionality works normally. This indicates that I didn't mess up.