### PR TITLE
Trim dots from domain name when mapping/transferring domain

### DIFF
--- a/client/lib/domains/index.js
+++ b/client/lib/domains/index.js
@@ -148,7 +148,8 @@ function getFixedDomainSearch( domainName ) {
 		.replace( /^(https?:\/\/)?(www[0-9]?\.)?/, '' )
 		.replace( /^www[0-9]?\./, '' )
 		.replace( /\/$/, '' )
-		.replace( /_/g, '-' );
+		.replace( /_/g, '-' )
+		.replace( /^\.+|\.+$/, '' );
 }
 
 function isSubdomain( domainName ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* There are several occasions where users managed to map a domain with leading/trailing dot in them and that required support to help fix that. This PR strips leading/trailing dots from the domain input.

#### Testing instructions

* Try to purchase mapped domain with leading or trailing dot in it - you should always get a trimmed version of the domain in the cart.
