### PR TITLE
e2e: All for running specific files in run script, even locally

### DIFF
--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -210,6 +210,10 @@ if [ "$SUITE_TAG" != "" ]; then
   SUITE_TAG_OVERRIDE="--suiteTag='$SUITE_TAG'"
 fi
 
+if [ "$FILE_LIST" != "" ]; then
+  FILE_LIST_FLAG="--test=$FILE_LIST"
+fi
+
 # Combine any NODE_CONFIG entries into a single object
 NODE_CONFIG_ARG="$(joinStr , ${NODE_CONFIG_ARGS[*]})"
 MOCHA_ARGS+="--NODE_CONFIG={$NODE_CONFIG_ARG}"
@@ -223,14 +227,14 @@ if [ $PARALLEL == 1 ]; then
 
   if [ $CIRCLE_NODE_INDEX == $MOBILE ]; then
       echo "Executing tests at mobile screen width"
-      CMD="env BROWSERSIZE=mobile $MAGELLAN --config=$MAGELLAN_CONFIGS --mocha_args='$MOCHA_ARGS' --max_workers=$WORKERS --local_browser=$LOCAL_BROWSER"
+      CMD="env BROWSERSIZE=mobile $MAGELLAN --config=$MAGELLAN_CONFIGS --mocha_args='$MOCHA_ARGS' --max_workers=$WORKERS --local_browser=$LOCAL_BROWSER $FILE_LIST_FLAG"
 
       eval $CMD
       RETURN+=$?
   fi
   if [ $CIRCLE_NODE_INDEX == $DESKTOP ]; then
       echo "Executing tests at desktop screen width"
-      CMD="env BROWSERSIZE=desktop $MAGELLAN --config=$MAGELLAN_CONFIGS --mocha_args='$MOCHA_ARGS' --max_workers=$WORKERS --local_browser=$LOCAL_BROWSER"
+      CMD="env BROWSERSIZE=desktop $MAGELLAN --config=$MAGELLAN_CONFIGS --mocha_args='$MOCHA_ARGS' --max_workers=$WORKERS --local_browser=$LOCAL_BROWSER $FILE_LIST_FLAG"
 
       eval $CMD
       RETURN+=$?
@@ -242,7 +246,7 @@ elif [ $CIRCLE_NODE_TOTAL > 1 ]; then
       for locale in ${LOCALE_ARRAY[@]}; do
         for config in "${MAGELLAN_CONFIGS[@]}"; do
           if [ "$config" != "" ]; then
-            CMD="env BROWSERSIZE=$size BROWSERLOCALE=$locale $MAGELLAN --mocha_args='$MOCHA_ARGS' --config='$config' --max_workers=$WORKERS --local_browser=$LOCAL_BROWSER --test=$FILE_LIST $SUITE_TAG_OVERRIDE"
+            CMD="env BROWSERSIZE=$size BROWSERLOCALE=$locale $MAGELLAN --mocha_args='$MOCHA_ARGS' --config='$config' --max_workers=$WORKERS --local_browser=$LOCAL_BROWSER $FILE_LIST_FLAG $SUITE_TAG_OVERRIDE"
 
             eval $CMD
             RETURN+=$?
@@ -258,7 +262,7 @@ else # Not using multiple CircleCI containers, just queue up the tests in sequen
       for locale in ${LOCALE_ARRAY[@]}; do
         for config in "${MAGELLAN_CONFIGS[@]}"; do
           if [ "$config" != "" ]; then
-            CMD="env BROWSERSIZE=$size BROWSERLOCALE=$locale $MAGELLAN --mocha_args='$MOCHA_ARGS' --config='$config' --max_workers=$WORKERS --local_browser=$LOCAL_BROWSER"
+            CMD="env BROWSERSIZE=$size BROWSERLOCALE=$locale $MAGELLAN --mocha_args='$MOCHA_ARGS' --config='$config' --max_workers=$WORKERS --local_browser=$LOCAL_BROWSER $FILE_LIST_FLAG"
 
             eval $CMD
             RETURN+=$?


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* A while back we set up a way to specify which files to run with the run script. It was only set up to work in CI, but it is sometimes nice to be able to run only certain files locally as well. This change makes that possible.

#### Testing instructions
* Ensure tests run in CI and that they are split across the containers in the build
* Run locally using something like `./run.sh -R -x -g -f specs/wp-signup-spec.js,specs/wp-reader-spec.js` and make sure that it only runs the tests from those files specified in the `-f` flag. In this case it should run 16 tests instead of 84.
