### PR TITLE
Desktop: Override Terser Options [webpack]

### DIFF
--- a/package.json
+++ b/package.json
@@ -342,7 +342,7 @@
 		"stylelint": "^9.10.1",
 		"supertest": "^4.0.2",
 		"svgstore-cli": "^1.3.1",
-		"terser": "^4.6.11",
+		"terser": "4.6.13",
 		"ts-loader": "^6.2.1",
 		"typescript": "^3.8.3",
 		"vfile-message": "^2.0.0",

--- a/packages/calypso-build/webpack.config.js
+++ b/packages/calypso-build/webpack.config.js
@@ -21,15 +21,13 @@ const DependencyExtractionWebpackPlugin = require( '@wordpress/dependency-extrac
  * Internal dependencies
  */
 const { cssNameFromFilename, shouldTranspileDependency } = require( './webpack/util' );
-const config = require( '../../client/server/config' );
 // const { workerCount } = require( './webpack.common' ); // todo: shard...
 
 /**
  * Internal variables
  */
-const calypsoEnv = config( 'env_id' );
 const isDevelopment = process.env.NODE_ENV !== 'production';
-const isDesktop = calypsoEnv === 'desktop' || calypsoEnv === 'desktop-development';
+const isDesktop = process.env.CALYPSO_ENV === 'desktop';
 
 /**
  * Return a webpack config object

--- a/packages/calypso-build/webpack.config.js
+++ b/packages/calypso-build/webpack.config.js
@@ -21,12 +21,15 @@ const DependencyExtractionWebpackPlugin = require( '@wordpress/dependency-extrac
  * Internal dependencies
  */
 const { cssNameFromFilename, shouldTranspileDependency } = require( './webpack/util' );
+const config = require( '../../client/server/config' );
 // const { workerCount } = require( './webpack.common' ); // todo: shard...
 
 /**
  * Internal variables
  */
+const calypsoEnv = config( 'env_id' );
 const isDevelopment = process.env.NODE_ENV !== 'production';
+const isDesktop = calypsoEnv === 'desktop' || calypsoEnv === 'desktop-development';
 
 /**
  * Return a webpack config object
@@ -99,8 +102,8 @@ function getWebpackConfig(
 				extractComments: false,
 				terserOptions: {
 					ecma: 5,
-					safari10: true,
-					mangle: true,
+					safari10: ! isDesktop,
+					mangle: ! isDesktop,
 				},
 			} ),
 		},

--- a/yarn.lock
+++ b/yarn.lock
@@ -23377,7 +23377,16 @@ terser-webpack-plugin@^2.1.2, terser-webpack-plugin@^2.3.1:
     terser "^4.4.3"
     webpack-sources "^1.4.3"
 
-terser@^4.1.2, terser@^4.4.3, terser@^4.6.11, terser@^4.6.3:
+terser@4.6.13:
+  version "4.6.13"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-4.6.13.tgz#e879a7364a5e0db52ba4891ecde007422c56a916"
+  integrity sha512-wMvqukYgVpQlymbnNbabVZbtM6PN63AzqexpwJL8tbh/mRT9LE5o+ruVduAGL7D6Fpjl+Q+06U5I9Ul82odAhw==
+  dependencies:
+    commander "^2.20.0"
+    source-map "~0.6.1"
+    source-map-support "~0.5.12"
+
+terser@^4.1.2, terser@^4.4.3, terser@^4.6.3:
   version "4.6.11"
   resolved "https://registry.yarnpkg.com/terser/-/terser-4.6.11.tgz#12ff99fdd62a26de2a82f508515407eb6ccd8a9f"
   integrity sha512-76Ynm7OXUG5xhOpblhytE7X58oeNSmC8xnNhjWVo8CksHit0U0kO4hfNbPrrYwowLWFgM2n9L176VNx2QaHmtA==


### PR DESCRIPTION
### Description

This PR is attempts to fix #42163.

It seems setting the package Terser config to skip Safari and mangling optimizations seems to mitigate the build time errors we've been recently experiencing for desktop. (Note: [mangling is turned off for desktop in the client config]([url](https://github.com/Automattic/wp-calypso/blob/4537033c6794449ce0a10b69d72daf5fa658d553/client/webpack.config.js#L175-L177)), too - so at the very least we should be consistent.)

TL;DR: Calypso is frequently failing to build for the desktop due to out-of-memory errors. We've isolated the breakage to the Terser plugin used for minification. Looks like the Terser plugin is [subject to quite a few out-of-memory bugs](https://slack-redir.net/link?url=https%3A%2F%2Fgithub.com%2Fwebpack-contrib%2Fterser-webpack-plugin%2Fissues%2F143), and the desktop build is especially sensitive to memory constraints. The minification step in particular seems like a significant memory hog. Bar disabling minification completely, it appears some adjustments to the Terser config are worth a try.

I've been testing [a hacked version of this fix](https://github.com/Automattic/wp-calypso/compare/master...try-terser-options) where the vars are simply removed and it's worked ~5 times in succession with the desktop build (in contrast to the config in Calypso master which is currently failing at least 90% of the time). 

However I can't seem to get the `isDesktop` switch to work via `process.env`. Not sure what I'm missing? Should I be passing the var explicitly in the `build-packages` script in package.json? (I've double-checked and the `CALYPSO_ENV` var [is being set in the build environment](https://github.com/Automattic/wp-desktop/compare/try-build-with-calypso-terser-overrides)).