### PR TITLE
Update the API calls for keyring connections

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -979,7 +979,7 @@ Undocumented.prototype.saveSharingButtons = function ( siteId, buttons, fn ) {
  * @returns {Promise} A Promise to resolve when complete.
  */
 Undocumented.prototype.mekeyringConnections = function ( forceExternalUsersRefetch, fn ) {
-	debug( '/me/keyring-connections query' );
+	debug( '/me/connections query' );
 
 	// set defaults, first argument is actually a callback
 	if ( typeof forceExternalUsersRefetch === 'function' ) {
@@ -988,7 +988,7 @@ Undocumented.prototype.mekeyringConnections = function ( forceExternalUsersRefet
 	}
 
 	return this.wpcom.req.get(
-		'/me/keyring-connections',
+		{ path: '/me/connections', apiNamespace: 'wpcom/v2' },
 		forceExternalUsersRefetch ? { force_external_users_refetch: forceExternalUsersRefetch } : {},
 		fn
 	);
@@ -1001,11 +1001,12 @@ Undocumented.prototype.mekeyringConnections = function ( forceExternalUsersRefet
  * @param {Function} fn Method to invoke when request is complete
  */
 Undocumented.prototype.deletekeyringConnection = function ( keyringConnectionId, fn ) {
-	debug( '/me/keyring-connections/:keyring_connection_id:/delete query' );
-	return this.wpcom.req.post(
+	debug( '/me/connections/:keyring_connection_id:/ delete' );
+	return this.wpcom.req.get(
 		{
-			path: '/me/keyring-connections/' + keyringConnectionId + '/delete',
-			apiVersion: '1.1',
+			path: '/me/connections/' + keyringConnectionId,
+			apiNamespace: 'wpcom/v2',
+			method: 'DELETE',
 		},
 		fn
 	);

--- a/client/state/sharing/keyring/test/actions.js
+++ b/client/state/sharing/keyring/test/actions.js
@@ -109,13 +109,13 @@ describe( 'actions', () => {
 
 	describe( 'deleteStoredKeyringConnection()', () => {
 		useNock( ( nock ) => {
-			nock( 'https://public-api.wordpress.com:443' )
-				.post( '/wpcom/v2/me/connections/2/delete' )
+			nock( 'https://public-api.wordpress.com' )
+				.intercept( '/wpcom/v2/me/connections/2', 'DELETE' )
 				.reply( 200, {
 					ID: 2,
 					deleted: true,
 				} )
-				.post( '/wpcom/v2/me/connections/34/delete' )
+				.intercept( '/wpcom/v2/me/connections/34', 'DELETE' )
 				.reply( 403, {
 					error: 'authorization_required',
 					message: 'You do not have permission to access this Keyring connection.',

--- a/client/state/sharing/keyring/test/actions.js
+++ b/client/state/sharing/keyring/test/actions.js
@@ -32,7 +32,7 @@ describe( 'actions', () => {
 			useNock( ( nock ) => {
 				nock( 'https://public-api.wordpress.com:443' )
 					.persist()
-					.get( '/rest/v1.1/me/keyring-connections' )
+					.get( '/wpcom/v2/me/connections' )
 					.reply( 200, {
 						connections: [ { ID: 4306907 }, { ID: 7589550 } ],
 					} );
@@ -68,7 +68,7 @@ describe( 'actions', () => {
 			useNock( ( nock ) => {
 				nock( 'https://public-api.wordpress.com:443' )
 					.persist()
-					.get( '/rest/v1.1/me/keyring-connections' )
+					.get( '/wpcom/v2/me/connections' )
 					.reply( 500, {
 						error: 'server_error',
 						message: 'A server error occurred',
@@ -110,12 +110,12 @@ describe( 'actions', () => {
 	describe( 'deleteStoredKeyringConnection()', () => {
 		useNock( ( nock ) => {
 			nock( 'https://public-api.wordpress.com:443' )
-				.post( '/rest/v1.1/me/keyring-connections/2/delete' )
+				.post( '/wpcom/v2/me/connections/2/delete' )
 				.reply( 200, {
 					ID: 2,
 					deleted: true,
 				} )
-				.post( '/rest/v1.1/me/keyring-connections/34/delete' )
+				.post( '/wpcom/v2/me/connections/34/delete' )
 				.reply( 403, {
 					error: 'authorization_required',
 					message: 'You do not have permission to access this Keyring connection.',

--- a/client/state/sharing/keyring/test/actions.js
+++ b/client/state/sharing/keyring/test/actions.js
@@ -123,7 +123,7 @@ describe( 'actions', () => {
 		} );
 
 		test( 'should dispatch delete action when request completes', () => {
-			deleteStoredKeyringConnection( { ID: 2 } )( spy ).then( () => {
+			return deleteStoredKeyringConnection( { ID: 2 } )( spy ).then( () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: KEYRING_CONNECTION_DELETE,
 					connection: {
@@ -134,7 +134,7 @@ describe( 'actions', () => {
 		} );
 
 		test( 'should dispatch fail action when request fails', () => {
-			deleteStoredKeyringConnection( { ID: 34 } )( spy ).then( () => {
+			return deleteStoredKeyringConnection( { ID: 34 } )( spy ).then( () => {
 				expect( spy ).to.have.been.calledWith( {
 					type: KEYRING_CONNECTION_DELETE_FAILURE,
 					error: sinon.match( {

--- a/packages/wpcom.js/src/lib/me.js
+++ b/packages/wpcom.js/src/lib/me.js
@@ -104,7 +104,7 @@ Me.prototype.connectedApps = function ( query, fn ) {
  * @returns {Function} request handler
  */
 Me.prototype.keyringConnections = function ( query, fn ) {
-	return this.wpcom.req.get( '/me/keyring-connections', query, fn );
+	return this.wpcom.req.get( '/me/connections', query, fn );
 };
 
 /**

--- a/packages/wpcom.js/src/lib/me.js
+++ b/packages/wpcom.js/src/lib/me.js
@@ -1,5 +1,5 @@
 /**
- * Module dependencies
+ * Internal dependencies
  */
 import MeKeyringConnection from './me.keyring-connection';
 import MeConnectedApp from './me.connected-application';
@@ -10,7 +10,7 @@ import MeTwoStep from './me.two-step';
 /**
  * Create `Me` instance
  *
- * @param {WPCOM} wpcom - wpcom instance
+ * @param {object} wpcom - wpcom instance
  * @returns {null} null
  */
 export default function Me( wpcom ) {
@@ -132,7 +132,7 @@ Me.prototype.settings = function () {
  * Return a `MeConnectedApp` instance.
  *
  * @param {string} id - app id
- * @returns {ConnectedApp} Me ConnectedApp instance
+ * @returns {MeConnectedApp} Me ConnectedApp instance
  */
 Me.prototype.connectedApp = function ( id ) {
 	return new MeConnectedApp( id, this.wpcom );

--- a/packages/wpcom.js/src/lib/me.keyring-connection.js
+++ b/packages/wpcom.js/src/lib/me.keyring-connection.js
@@ -5,7 +5,7 @@ export default class KeyringConnection {
 	 * `KeyringConnection` constructor.
 	 *
 	 * @param {string} keyId - the connection ID to take action on.
-	 * @param {WPCOM} wpcom - wpcom instance
+	 * @param {object} wpcom - wpcom instance
 	 * @returns {null} null
 	 */
 	constructor( keyId, wpcom ) {

--- a/packages/wpcom.js/src/lib/me.keyring-connection.js
+++ b/packages/wpcom.js/src/lib/me.keyring-connection.js
@@ -1,4 +1,4 @@
-const root = '/me/keyring-connections/';
+const root = '/me/connections/';
 
 export default class KeyringConnection {
 	/**
@@ -24,7 +24,14 @@ export default class KeyringConnection {
 	 * @returns {Function} request handler
 	 */
 	get( query, fn ) {
-		return this.wpcom.req.get( root + this._id, query, fn );
+		return this.wpcom.req.get(
+			{
+				path: root + this._id,
+				apiNamespace: 'wpcom/v2',
+			},
+			query,
+			fn
+		);
 	}
 
 	/**
@@ -36,6 +43,14 @@ export default class KeyringConnection {
 	 * @returns {Function} request handler
 	 */
 	delete( query, fn ) {
-		return this.wpcom.req.del( root + this._id + '/delete', query, fn );
+		return this.wpcom.req.get(
+			{
+				path: root + this._id,
+				apiNamespace: 'wpcom/v2',
+				method: 'DELETE',
+			},
+			query,
+			fn
+		);
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This replaces calls to /me/keyring-connections to /me/connections a new version of the same endpoint.

#### Testing instructions

* Check that you can create/delete connections at /marketing/connections
* Check that you can still access your Google Photos from the Media Library
* Check that the Google My Business flow still works (/marketing/tools)

#### Notes
I this we'll need to update the wpcom.js package.

Fixes #41601 
