### PR TITLE
Gutenboarding: Plans show/hide toggle copy

### DIFF
--- a/client/landing/gutenboarding/components/plans/plans-grid/index.tsx
+++ b/client/landing/gutenboarding/components/plans/plans-grid/index.tsx
@@ -2,7 +2,8 @@
  * External dependencies
  */
 import * as React from 'react';
-import { Button, Icon } from '@wordpress/components';
+import { Button } from '@wordpress/components';
+import { Icon, chevronDown, chevronUp } from '@wordpress/icons';
 import { useDispatch } from '@wordpress/data';
 import { useI18n } from '@automattic/react-i18n';
 import classNames from 'classnames';
@@ -85,7 +86,7 @@ const PlansGrid: React.FunctionComponent< Props > = ( { confirmButton, cancelBut
 									onClick={ handleDetailsToggleButtonClick }
 								>
 									<span>{ __( 'Hide details' ) } </span>
-									<Icon icon="arrow-up" size={ 20 }></Icon>
+									<Icon icon={ chevronUp } size={ 20 } />
 								</Button>
 							) : (
 								<Button
@@ -94,7 +95,7 @@ const PlansGrid: React.FunctionComponent< Props > = ( { confirmButton, cancelBut
 									onClick={ handleDetailsToggleButtonClick }
 								>
 									<span>{ __( 'Show details' ) } </span>
-									<Icon icon="arrow-down" size={ 20 }></Icon>
+									<Icon icon={ chevronDown } size={ 20 } />
 								</Button>
 							) }
 						</div>

--- a/client/landing/gutenboarding/components/plans/plans-grid/index.tsx
+++ b/client/landing/gutenboarding/components/plans/plans-grid/index.tsx
@@ -84,7 +84,7 @@ const PlansGrid: React.FunctionComponent< Props > = ( { confirmButton, cancelBut
 									isLarge
 									onClick={ handleDetailsToggleButtonClick }
 								>
-									<span>{ __( 'Less details' ) } </span>
+									<span>{ __( 'Hide details' ) } </span>
 									<Icon icon="arrow-up" size={ 20 }></Icon>
 								</Button>
 							) : (
@@ -93,7 +93,7 @@ const PlansGrid: React.FunctionComponent< Props > = ( { confirmButton, cancelBut
 									isLarge
 									onClick={ handleDetailsToggleButtonClick }
 								>
-									<span>{ __( 'More details' ) } </span>
+									<span>{ __( 'Show details' ) } </span>
 									<Icon icon="arrow-down" size={ 20 }></Icon>
 								</Button>
 							) }

--- a/client/landing/gutenboarding/components/plans/plans-grid/index.tsx
+++ b/client/landing/gutenboarding/components/plans/plans-grid/index.tsx
@@ -3,10 +3,7 @@
  */
 import * as React from 'react';
 import { Button } from '@wordpress/components';
-// This package will be typed in https://github.com/Automattic/wp-calypso/pull/42031 - remove there.
-/* eslint-disable-next-line @typescript-eslint/ban-ts-ignore */
-// @ts-ignore
-import { Icon, chevronDown, chevronUp } from '@wordpress/icons';
+import { Icon, chevronDown } from '@wordpress/icons';
 import { useDispatch } from '@wordpress/data';
 import { useI18n } from '@automattic/react-i18n';
 import classNames from 'classnames';
@@ -44,7 +41,7 @@ const PlansGrid: React.FunctionComponent< Props > = ( { confirmButton, cancelBut
 	const [ showDetails, setShowDetails ] = React.useState( false );
 
 	const handleDetailsToggleButtonClick = () => {
-		setShowDetails( ! showDetails );
+		setShowDetails( ( show ) => ! show );
 	};
 
 	return (
@@ -82,25 +79,16 @@ const PlansGrid: React.FunctionComponent< Props > = ( { confirmButton, cancelBut
 				<div className="plans-grid__details-container">
 					<PlansDetails>
 						<div className="plans-grid__details-actions">
-							{ showDetails ? (
-								<Button
-									className="plans-grid__details-toggle-button is-collapse-button"
-									isLarge
-									onClick={ handleDetailsToggleButtonClick }
-								>
-									<span>{ __( 'Hide details' ) } </span>
-									<Icon icon={ chevronUp } size={ 20 } />
-								</Button>
-							) : (
-								<Button
-									className="plans-grid__details-toggle-button is-expand-button"
-									isLarge
-									onClick={ handleDetailsToggleButtonClick }
-								>
-									<span>{ __( 'Show details' ) } </span>
-									<Icon icon={ chevronDown } size={ 20 } />
-								</Button>
-							) }
+							<Button
+								className={ classNames( 'plans-grid__details-toggle-button', {
+									'is-collapsed': ! showDetails,
+								} ) }
+								isLarge
+								onClick={ handleDetailsToggleButtonClick }
+							>
+								<span>{ showDetails ? __( 'Hide details' ) : __( 'Show details' ) }</span>
+								<Icon icon={ chevronDown } size={ 20 } />
+							</Button>
 						</div>
 					</PlansDetails>
 				</div>

--- a/client/landing/gutenboarding/components/plans/plans-grid/index.tsx
+++ b/client/landing/gutenboarding/components/plans/plans-grid/index.tsx
@@ -3,6 +3,9 @@
  */
 import * as React from 'react';
 import { Button } from '@wordpress/components';
+// This package will be typed in https://github.com/Automattic/wp-calypso/pull/42031 - remove there.
+/* eslint-disable-next-line @typescript-eslint/ban-ts-ignore */
+// @ts-ignore
 import { Icon, chevronDown, chevronUp } from '@wordpress/icons';
 import { useDispatch } from '@wordpress/data';
 import { useI18n } from '@automattic/react-i18n';

--- a/client/landing/gutenboarding/components/plans/plans-grid/style.scss
+++ b/client/landing/gutenboarding/components/plans/plans-grid/style.scss
@@ -190,11 +190,16 @@
 	}
 
 	svg {
-		margin-left: 2px;
+		margin-left: 0.2em;
+		transition: transform 100ms ease-in-out;
+		transform: rotate( 180deg );
 	}
 
-	&.is-collapse-button {
+	&.is-collapsed {
 		margin-top: 70px;
+		svg {
+			transform: rotate( 0 );
+		}
 	}
 }
 

--- a/client/package.json
+++ b/client/package.json
@@ -50,6 +50,7 @@
 		"@wordpress/format-library": "^1.15.0",
 		"@wordpress/i18n": "^3.10.0",
 		"@wordpress/is-shallow-equal": "^2.0.0",
+		"@wordpress/icons": "^2.0.0",
 		"@wordpress/keycodes": "^2.10.0",
 		"@wordpress/notices": "^2.1.0",
 		"@wordpress/nux": "^3.13.0",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

I noticed an issue in the grammar: "less details" [(should be "fewer details")](https://www.grammarly.com/blog/fewer-vs-less/). I changed it to use `Show/Hide details` which seems simpler and clearer.

Before:

![Screen Shot 2020-05-15 at 17 53 23](https://user-images.githubusercontent.com/841763/82070429-0556da80-96d5-11ea-9326-6dbbc08cde3f.png)


After:


![Screen Shot 2020-05-15 at 17 35 59](https://user-images.githubusercontent.com/841763/82070115-92e5fa80-96d4-11ea-9f62-c3cd68c8d867.png)
![Screen Shot 2020-05-15 at 17 36 12](https://user-images.githubusercontent.com/841763/82070110-91b4cd80-96d4-11ea-88cd-587fd4827c17.png)


I also changed the icon to use the `@wordpress/icons` package and chevron up/down:

![Screen Shot 2020-05-15 at 17 49 51](https://user-images.githubusercontent.com/841763/82070126-95485480-96d4-11ea-82d5-18b6f0c1f5ff.png)
![Screen Shot 2020-05-15 at 17 49 46](https://user-images.githubusercontent.com/841763/82070127-95485480-96d4-11ea-920b-03c60fa1677b.png)


#### Testing instructions

* [`/new`](https://calypso.live/?branch=update/gutenboarding-fewer)
* Open the plans grid at some point during the flow by clicking the plan icon in the top bar ![Screen Shot 2020-05-15 at 17 51 23](https://user-images.githubusercontent.com/841763/82070228-bb6df480-96d4-11ea-9c5f-4896ba2d6bc9.png)
* Confirm that the show/hide toggle works well and looks good.
