### PR TITLE
Enable security key support on production.

### DIFF
--- a/client/blocks/login/two-factor-authentication/two-factor-actions.jsx
+++ b/client/blocks/login/two-factor-authentication/two-factor-actions.jsx
@@ -17,6 +17,7 @@ import { isTwoFactorAuthTypeSupported } from 'state/login/selectors';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
 import { sendSmsCode } from 'state/login/actions';
 import { login } from 'lib/paths';
+import { isWebAuthnSupported } from 'lib/webauthn';
 
 /**
  * Style dependencies
@@ -84,7 +85,8 @@ class TwoFactorActions extends Component {
 		const isSmsAvailable = isSmsSupported && twoFactorAuthType !== 'sms';
 		const isAuthenticatorAvailable =
 			isAuthenticatorSupported && twoFactorAuthType !== 'authenticator';
-		const isSecurityKeyAvailable = isSecurityKeySupported && twoFactorAuthType !== 'webauthn';
+		const isSecurityKeyAvailable =
+			isWebAuthnSupported() && isSecurityKeySupported && twoFactorAuthType !== 'webauthn';
 
 		if ( ! isSmsAvailable && ! isAuthenticatorAvailable && ! isSecurityKeyAvailable ) {
 			return null;

--- a/client/me/two-step/index.jsx
+++ b/client/me/two-step/index.jsx
@@ -23,7 +23,6 @@ import SecuritySectionNav from 'me/security-section-nav';
 import Security2faKey from 'me/security-2fa-key';
 import twoStepAuthorization from 'lib/two-step-authorization';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
-import config from 'config';
 
 /**
  * Style dependencies
@@ -175,7 +174,7 @@ class TwoStep extends Component {
 
 				<Card>{ this.renderTwoStepSection() }</Card>
 
-				{ config.isEnabled( '2fa/keys-support' ) && this.render2faKey() }
+				{ this.render2faKey() }
 				{ this.renderBackupCodes() }
 				{ this.renderApplicationPasswords() }
 			</Main>

--- a/config/desktop-development.json
+++ b/config/desktop-development.json
@@ -135,7 +135,6 @@
 		"try/preconnect": true,
 		"try/preload": true,
 		"try/single-cdn": true,
-		"2fa/keys-support": true,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,
 		"upgrades/domain-search": true,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -98,7 +98,6 @@
 		"signup/social-management": true,
 		"signup/wpcc": true,
 		"site-indicator": true,
-		"2fa/keys-support": true,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,
 		"upgrades/domain-search": true,

--- a/config/development.json
+++ b/config/development.json
@@ -177,7 +177,6 @@
 		"try/preconnect": true,
 		"try/preload": true,
 		"try/single-cdn": true,
-		"2fa/keys-support": true,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,
 		"upgrades/domain-search": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -119,7 +119,6 @@
 		"site-indicator": true,
 		"memberships": true,
 		"support-user": true,
-		"2fa/keys-support": true,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,
 		"upgrades/domain-search": true,

--- a/config/production.json
+++ b/config/production.json
@@ -129,7 +129,7 @@
 		"ssr/sample-log-cache-misses": true,
 		"support-user": true,
 		"tools/migrate": true,
-		"2fa/keys-support": false,
+		"2fa/keys-support": true,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,
 		"upgrades/domain-search": true,

--- a/config/production.json
+++ b/config/production.json
@@ -129,7 +129,6 @@
 		"ssr/sample-log-cache-misses": true,
 		"support-user": true,
 		"tools/migrate": true,
-		"2fa/keys-support": true,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,
 		"upgrades/domain-search": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -136,7 +136,6 @@
 		"site-indicator": true,
 		"support-user": true,
 		"tools/migrate": true,
-		"2fa/keys-support": true,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,
 		"upgrades/domain-search": true,

--- a/config/test.json
+++ b/config/test.json
@@ -99,7 +99,6 @@
 		"signup/social": true,
 		"site-indicator": true,
 		"support-user": true,
-		"2fa/keys-support": true,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,
 		"upgrades/domain-search": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -151,7 +151,6 @@
 		"try/preconnect": true,
 		"try/preload": true,
 		"try/single-cdn": true,
-		"2fa/keys-support": true,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,
 		"upgrades/domain-search": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Enable `webauthn` on production. This feature is enabled on staging since #36069
* Fixes a small issue where the `Continue with security key` is shown for browsers/devices that don't support it.