### PR TITLE
Allow TLDs with special contact forms through CheckoutSystemDecider

### DIFF
--- a/client/components/domains/registrant-extra-info/ca-form.jsx
+++ b/client/components/domains/registrant-extra-info/ca-form.jsx
@@ -178,7 +178,10 @@ export class RegistrantExtraInfoCaForm extends React.PureComponent {
 
 	getCiraAgreementAcceptedErrorMessage() {
 		if ( this.props.isManaged ) {
-			return this.props.contactDetailsValidationErrors?.extra?.ca?.ciraAgreementAccepted ?? '';
+			return (
+				this.props.contactDetailsValidationErrors?.extra?.ca?.ciraAgreementAccepted ??
+				this.props.translate( 'Required' )
+			);
 		}
 
 		return this.props.translate( 'Required' );

--- a/client/my-sites/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout-system-decider.js
@@ -18,8 +18,6 @@ import { getCurrentUserLocale, getCurrentUserCountryCode } from 'state/current-u
 import { isJetpackSite } from 'state/sites/selectors';
 import { abtest } from 'lib/abtest';
 import { logToLogstash } from 'state/logstash/actions';
-import { getTlds } from 'lib/cart-values/cart-items';
-import { tldsWithAdditionalDetailsForms } from 'components/domains/registrant-extra-info';
 
 const debug = debugFactory( 'calypso:checkout-system-decider' );
 const wpcom = wp.undocumented();
@@ -145,13 +143,6 @@ function shouldShowCompositeCheckout(
 	// Disable for non-US
 	if ( countryCode?.toLowerCase() !== 'us' ) {
 		debug( 'shouldShowCompositeCheckout false because country is not US' );
-		return false;
-	}
-	// Disable for TLDs that have special contact forms
-	if ( getTlds( cart ).find( ( tld ) => tldsWithAdditionalDetailsForms.includes( tld ) ) ) {
-		debug(
-			'shouldShowCompositeCheckout false because cart contains TLD with special contact form'
-		);
 		return false;
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As a follow-up to #41819, we can now allow ccTLDs that require special contact forms through to Composite Checkout. This PR enables that.

#### Testing instructions

- Add a `.fr`, `.ca`, or `.co.uk` domain to your cart and visit checkout.
- Add `?flags=composite-checkout-testing` to the checkout URL.
- Verify you see composite checkout.
