### PR TITLE
Store: Add calypsoify param to ensure ecomm plan uses calypsoify.

### DIFF
--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -524,7 +524,7 @@ export class MySitesSidebar extends Component {
 
 		let storeLink = '/store' + siteSuffix;
 		if ( isEcommerce( site.plan ) ) {
-			storeLink = site.options.admin_url + 'admin.php?page=wc-setup-checklist';
+			storeLink = site.options.admin_url + 'admin.php?page=wc-setup-checklist&calypsoify=1';
 		}
 
 		return (

--- a/client/my-sites/sidebar/test/sidebar.js
+++ b/client/my-sites/sidebar/test/sidebar.js
@@ -94,7 +94,7 @@ describe( 'MySitesSidebar', () => {
 
 			const wrapper = shallow( <Store /> );
 			expect( wrapper.props().link ).toEqual(
-				'http://test.com/wp-admin/admin.php?page=wc-setup-checklist'
+				'http://test.com/wp-admin/admin.php?page=wc-setup-checklist&calypsoify=1'
 			);
 		} );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This branch adds in the `calypsoify=1` url param to the Store link on ecommerce plan sites. This ensures that when navigating to the Store feature, the calypsoify theme will always be loaded.

#### Testing instructions

Using an ecommerce plan test site that has already completed the setup checklist on the remote AT site.

* Open up the home screen in calypso for the site, click on wp-admin in the sidebar. This will clear out the calypsoify option that is used to toggle the calypsoify theme off/on on the site.
* Go back to the wpcom homescreen for the site, click on the _Store_ link in the sidebar
* Verify you end up at `/wp-admin/edit.php?post_type=shop_order` and the Calypsoify theme is used:

<img width="1289" alt="image" src="https://user-images.githubusercontent.com/22080/82085338-b93e7280-96a1-11ea-91af-98946e861ce6.png">

Fixes #42296
