### PR TITLE
Fix missing yarn.lock package update

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -16,10 +16,10 @@
   resolved "https://registry.yarnpkg.com/@automattic/color-studio/-/color-studio-2.3.0.tgz#6549e77f823514bdcf520cb2c48932c2c9db379f"
   integrity sha512-GRMV4PMtn2iE+30+RP33LyJSe4Qp8oILFNvk+iF8zd0LzUUaErZu86rk8YpEcLvFJzOU2BTXSewSdwyGc/sa1g==
 
-"@automattic/lasagna@^0.3.2":
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/@automattic/lasagna/-/lasagna-0.3.2.tgz#20871a7a483e38b5c15197d6a3071f2980a2d492"
-  integrity sha512-HGPKC4t4xwibBs4jtNfBX5iJ0dvJm6ZuWAoL4xrZMAv+yGfpFVOPf7On8mMyCH2NWq33FZkJI7xpqON/a8vBVA==
+"@automattic/lasagna@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@automattic/lasagna/-/lasagna-0.4.0.tgz#5e5ba3de69aa8cf9257a52bfffda9f83c690e8f1"
+  integrity sha512-ewApmxIDHuzkwj/It7E2BQG9rEf10vIlrvyWIp/vETw0tvnAOWQqQyipaeikBO6xYmaW7XcTlHq3LKGqKy+tpg==
   dependencies:
     jwt-decode "^2.2.0"
     phoenix "^1.5.1"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add the `yarn.lock` update that I missed in #42298.

#### Testing instructions

1. Open Calypso Reader.
2. Verify websocket connection established (101) successfully.