### PR TITLE
Jetpack Cloud: Make all buttons use sentence case

### DIFF
--- a/client/landing/jetpack-cloud/sections/backups/rewind-flow/error.tsx
+++ b/client/landing/jetpack-cloud/sections/backups/rewind-flow/error.tsx
@@ -40,7 +40,7 @@ const RewindFlowError: FunctionComponent< Props > = ( {
 				rel="noopener noreferrer"
 				target="_blank"
 			>
-				{ translate( 'Contact Support {{externalIcon/}}', {
+				{ translate( 'Contact support {{externalIcon/}}', {
 					components: { externalIcon: <Gridicon icon="external" size={ 24 } /> },
 				} ) }
 			</Button>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adjust the `Contact support` button in the `RewindFlowError` component to match our requirement that all buttons use sentence casing (see `p9Jlb4-1ly-p2`).

Fixes `1151678672052943-as-1175116466690897`.

#### Testing instructions

Verify that the "Contact support" button is sentence-cased in all places by checking the following:
* Simulate an error state on the "Download backup" page
* Simulate an error state on the "Restore to this point" page
* Simulate trying to download or restore from a non-rewindable activity ID
* Simulate trying to download or restore from a non-existent activity ID

#### Screenshots

<img width="551" alt="image" src="https://user-images.githubusercontent.com/670067/82093280-70e27d00-96c0-11ea-98ff-20548309e995.png">

<img width="647" alt="image" src="https://user-images.githubusercontent.com/670067/82093335-8bb4f180-96c0-11ea-9409-f25c8b64497b.png">

<img width="595" alt="image" src="https://user-images.githubusercontent.com/670067/82093043-f9ace900-96bf-11ea-9ca2-86fb92ff87a9.png">

<img width="637" alt="image" src="https://user-images.githubusercontent.com/670067/82092929-c79b8700-96bf-11ea-8e2f-afb00dd6b92b.png">