### PR TITLE
Jetpack Cloud: Refine Activity Cards

### DIFF
--- a/client/landing/jetpack-cloud/components/activity-card-list/index.jsx
+++ b/client/landing/jetpack-cloud/components/activity-card-list/index.jsx
@@ -4,7 +4,6 @@
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -18,8 +17,6 @@ import { withMobileBreakpoint } from '@automattic/viewport-react';
 import ActivityCard from 'landing/jetpack-cloud/components/activity-card';
 import Filterbar from 'my-sites/activity/filterbar';
 import getActivityLogFilter from 'state/selectors/get-activity-log-filter';
-import getRewindCapabilities from 'state/selectors/get-rewind-capabilities';
-import getRewindState from 'state/selectors/get-rewind-state';
 import Pagination from 'components/pagination';
 import QueryRewindCapabilities from 'components/data/query-rewind-capabilities';
 import QueryRewindState from 'components/data/query-rewind-state';
@@ -77,7 +74,7 @@ class ActivityCardList extends Component {
 	}
 
 	renderLogs( actualPage ) {
-		const { allowRestore, logs, pageSize, showDateSeparators } = this.props;
+		const { logs, pageSize, showDateSeparators } = this.props;
 
 		const getPrimaryCardClassName = ( hasMore, dateLogsLength ) =>
 			hasMore && dateLogsLength === 1
@@ -101,7 +98,6 @@ class ActivityCardList extends Component {
 						{ dateLogs.map( ( activity ) => (
 							<ActivityCard
 								activity={ activity }
-								allowRestore={ allowRestore }
 								className={
 									isActivityBackup( activity )
 										? getPrimaryCardClassName( hasMore, dateLogs.length )
@@ -193,18 +189,9 @@ const mapStateToProps = ( state ) => {
 	const siteId = getSelectedSiteId( state );
 	const siteSlug = getSelectedSiteSlug( state );
 	const filter = getActivityLogFilter( state, siteId );
-	const rewind = getRewindState( state, siteId );
-	const siteCapabilities = getRewindCapabilities( state, siteId );
-	const restoreStatus = rewind.rewind && rewind.rewind.status;
-	const allowRestore =
-		'active' === rewind.state &&
-		! ( 'queued' === restoreStatus || 'running' === restoreStatus ) &&
-		includes( siteCapabilities, 'restore' );
 
 	return {
-		allowRestore,
 		filter,
-		rewind,
 		siteId,
 		siteSlug,
 	};

--- a/client/landing/jetpack-cloud/components/activity-card-list/index.jsx
+++ b/client/landing/jetpack-cloud/components/activity-card-list/index.jsx
@@ -77,15 +77,7 @@ class ActivityCardList extends Component {
 	}
 
 	renderLogs( actualPage ) {
-		const {
-			allowRestore,
-			logs,
-			moment,
-			pageSize,
-			showDateSeparators,
-			doesRewindNeedCredentials,
-			siteSlug,
-		} = this.props;
+		const { allowRestore, logs, pageSize, showDateSeparators } = this.props;
 
 		const getPrimaryCardClassName = ( hasMore, dateLogsLength ) =>
 			hasMore && dateLogsLength === 1
@@ -108,17 +100,14 @@ class ActivityCardList extends Component {
 					<div className="activity-card-list__date-group-content">
 						{ dateLogs.map( ( activity ) => (
 							<ActivityCard
-								{ ...{
-									key: activity.activityId,
-									doesRewindNeedCredentials,
-									moment,
-									activity,
-									allowRestore,
-									siteSlug,
-									className: isActivityBackup( activity )
+								activity={ activity }
+								allowRestore={ allowRestore }
+								className={
+									isActivityBackup( activity )
 										? getPrimaryCardClassName( hasMore, dateLogs.length )
-										: getSecondaryCardClassName( hasMore ),
-								} }
+										: getSecondaryCardClassName( hasMore )
+								}
+								key={ activity.activityId }
 							/>
 						) ) }
 					</div>

--- a/client/landing/jetpack-cloud/components/activity-card/index.jsx
+++ b/client/landing/jetpack-cloud/components/activity-card/index.jsx
@@ -10,23 +10,24 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import { applySiteOffset } from 'lib/site/timezone';
 import {
 	backupDownloadPath,
 	backupRestorePath,
 	settingsPath,
 } from 'landing/jetpack-cloud/sections/backups/paths';
-import ExternalLink from 'components/external-link';
-import { getSelectedSiteId } from 'state/ui/selectors';
-import getDoesRewindNeedCredentials from 'state/selectors/get-does-rewind-need-credentials';
-import QueryRewindState from 'components/data/query-rewind-state';
 import { Card } from '@automattic/components';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
+import { withApplySiteOffset } from 'landing/jetpack-cloud/components/site-offset';
+import { withLocalizedMoment } from 'components/localized-moment';
 import ActivityActor from 'my-sites/activity/activity-log-item/activity-actor';
 import ActivityDescription from './activity-description';
 import ActivityMedia from 'my-sites/activity/activity-log-item/activity-media';
 import Button from 'components/forms/form-button';
+import ExternalLink from 'components/external-link';
+import getDoesRewindNeedCredentials from 'state/selectors/get-does-rewind-need-credentials';
 import Gridicon from 'components/gridicon';
 import PopoverMenu from 'components/popover/menu';
+import QueryRewindState from 'components/data/query-rewind-state';
 import StreamsMediaPreview from './activity-card-streams-media-preview';
 
 /**
@@ -38,11 +39,19 @@ import missingCredentialsIcon from 'landing/jetpack-cloud/components/daily-backu
 
 class ActivityCard extends Component {
 	static propTypes = {
+		activity: PropTypes.object.isRequired,
+		allowRestore: PropTypes.bool.isRequired,
+		applySiteOffset: PropTypes.func,
+		className: PropTypes.string,
+		doesRewindNeedCredentials: PropTypes.bool,
+		moment: PropTypes.func.isRequired,
+		siteId: PropTypes.number,
+		siteSlug: PropTypes.string.isRequired,
 		summarize: PropTypes.bool,
+		translate: PropTypes.func.isRequired,
 	};
 
 	static defaultProps = {
-		doesRewindNeedCredentials: false,
 		summarize: false,
 	};
 
@@ -76,7 +85,7 @@ class ActivityCard extends Component {
 	};
 
 	renderStreams( streams = [] ) {
-		const { allowRestore, moment, siteSlug, translate } = this.props;
+		const { applySiteOffset, allowRestore, moment, siteSlug, siteId, translate } = this.props;
 
 		return streams.map( ( item, index ) => {
 			const activityMedia = item.activityMedia;
@@ -99,10 +108,12 @@ class ActivityCard extends Component {
 				<ActivityCard
 					activity={ item }
 					allowRestore={ allowRestore }
-					compact
+					applySiteOffset={ applySiteOffset }
 					key={ item.activityId }
 					moment={ moment }
 					siteSlug={ siteSlug }
+					siteId={ siteId }
+					summarize
 					translate={ translate }
 				/>
 			);
@@ -265,20 +276,11 @@ class ActivityCard extends Component {
 	}
 
 	render() {
-		const {
-			activity,
-			allowRestore,
-			className,
-			gmtOffset,
-			siteId,
-			summarize,
-			timezone,
-		} = this.props;
+		const { activity, allowRestore, applySiteOffset, className, siteId, summarize } = this.props;
 
-		const backupTimeDisplay = applySiteOffset( activity.activityTs, {
-			timezone,
-			gmtOffset,
-		} ).format( 'LT' );
+		const backupTimeDisplay = applySiteOffset
+			? applySiteOffset( activity.activityTs ).format( 'LT' )
+			: '';
 
 		const showActivityContent = this.state.showContent;
 
@@ -317,11 +319,15 @@ class ActivityCard extends Component {
 
 const mapStateToProps = ( state ) => {
 	const siteId = getSelectedSiteId( state );
+	const siteSlug = getSelectedSiteSlug( state );
 
 	return {
-		siteId,
 		doesRewindNeedCredentials: getDoesRewindNeedCredentials( state, siteId ),
+		siteId,
+		siteSlug,
 	};
 };
 
-export default connect( mapStateToProps )( localize( ActivityCard ) );
+export default connect( mapStateToProps )(
+	withLocalizedMoment( withApplySiteOffset( localize( ActivityCard ) ) )
+);

--- a/client/landing/jetpack-cloud/components/activity-card/index.jsx
+++ b/client/landing/jetpack-cloud/components/activity-card/index.jsx
@@ -24,6 +24,7 @@ import ActivityDescription from './activity-description';
 import ActivityMedia from 'my-sites/activity/activity-log-item/activity-media';
 import Button from 'components/forms/form-button';
 import ExternalLink from 'components/external-link';
+import getAllowRestore from 'state/selectors/get-allow-restore';
 import getDoesRewindNeedCredentials from 'state/selectors/get-does-rewind-need-credentials';
 import Gridicon from 'components/gridicon';
 import PopoverMenu from 'components/popover/menu';
@@ -43,7 +44,7 @@ class ActivityCard extends Component {
 		allowRestore: PropTypes.bool.isRequired,
 		applySiteOffset: PropTypes.func,
 		className: PropTypes.string,
-		doesRewindNeedCredentials: PropTypes.bool,
+		doesRewindNeedCredentials: PropTypes.bool.isRequired,
 		moment: PropTypes.func.isRequired,
 		siteId: PropTypes.number,
 		siteSlug: PropTypes.string.isRequired,
@@ -322,6 +323,7 @@ const mapStateToProps = ( state ) => {
 	const siteSlug = getSelectedSiteSlug( state );
 
 	return {
+		allowRestore: getAllowRestore( state, siteId ),
 		doesRewindNeedCredentials: getDoesRewindNeedCredentials( state, siteId ),
 		siteId,
 		siteSlug,

--- a/client/landing/jetpack-cloud/components/backup-delta/index.jsx
+++ b/client/landing/jetpack-cloud/components/backup-delta/index.jsx
@@ -16,28 +16,13 @@ import './style.scss';
 
 class BackupDelta extends Component {
 	renderRealtime() {
-		const {
-			allowRestore,
-			timezone,
-			gmtOffset,
-			moment,
-			realtimeBackups,
-			siteSlug,
-			translate,
-			isToday,
-		} = this.props;
+		const { allowRestore, realtimeBackups, translate, isToday } = this.props;
 
 		const cards = realtimeBackups.map( ( activity ) => (
 			<ActivityCard
+				activity={ activity }
+				allowRestore={ allowRestore }
 				key={ activity.activityId }
-				{ ...{
-					moment,
-					activity,
-					allowRestore,
-					timezone,
-					gmtOffset,
-					siteSlug,
-				} }
 			/>
 		) );
 

--- a/client/landing/jetpack-cloud/components/backup-delta/index.jsx
+++ b/client/landing/jetpack-cloud/components/backup-delta/index.jsx
@@ -16,14 +16,10 @@ import './style.scss';
 
 class BackupDelta extends Component {
 	renderRealtime() {
-		const { allowRestore, realtimeBackups, translate, isToday } = this.props;
+		const { realtimeBackups, translate, isToday } = this.props;
 
 		const cards = realtimeBackups.map( ( activity ) => (
-			<ActivityCard
-				activity={ activity }
-				allowRestore={ allowRestore }
-				key={ activity.activityId }
-			/>
+			<ActivityCard activity={ activity } key={ activity.activityId } />
 		) );
 
 		return (

--- a/client/landing/jetpack-cloud/components/daily-backup-status/index.jsx
+++ b/client/landing/jetpack-cloud/components/daily-backup-status/index.jsx
@@ -329,11 +329,10 @@ class DailyBackupStatus extends Component {
 	}
 
 	renderBackupDetails( backup ) {
-		const { allowRestore } = this.props;
 		return (
 			<div className="daily-backup-status__realtime-details">
 				<div className="daily-backup-status__realtime-details-card">
-					<ActivityCard activity={ backup } allowRestore={ allowRestore } summarize />
+					<ActivityCard activity={ backup } summarize />
 				</div>
 			</div>
 		);

--- a/client/landing/jetpack-cloud/components/daily-backup-status/index.jsx
+++ b/client/landing/jetpack-cloud/components/daily-backup-status/index.jsx
@@ -329,29 +329,11 @@ class DailyBackupStatus extends Component {
 	}
 
 	renderBackupDetails( backup ) {
-		const {
-			moment,
-			allowRestore,
-			doesRewindNeedCredentials,
-			timezone,
-			gmtOffset,
-			siteSlug,
-		} = this.props;
+		const { allowRestore } = this.props;
 		return (
 			<div className="daily-backup-status__realtime-details">
 				<div className="daily-backup-status__realtime-details-card">
-					<ActivityCard
-						{ ...{
-							moment,
-							activity: backup,
-							doesRewindNeedCredentials,
-							allowRestore,
-							timezone,
-							gmtOffset,
-							siteSlug,
-							summarize: true,
-						} }
-					/>
+					<ActivityCard activity={ backup } allowRestore={ allowRestore } summarize />
 				</div>
 			</div>
 		);

--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -225,7 +225,7 @@ class BackupsPage extends Component {
 	}
 
 	renderBackupSearch() {
-		const { doesRewindNeedCredentials, logs, siteSlug, translate } = this.props;
+		const { logs, siteSlug, translate } = this.props;
 
 		// Filter out anything that is not restorable
 		const restorablePoints = logs.filter( ( event ) => !! event.activityIsRewindable );
@@ -240,12 +240,7 @@ class BackupsPage extends Component {
 						'This is the complete event history for your site. Filter by date range and/ or activity type.'
 					) }
 				</div>
-				<ActivityCardList
-					logs={ restorablePoints }
-					pageSize={ 10 }
-					siteSlug={ siteSlug }
-					doesRewindNeedCredentials={ doesRewindNeedCredentials }
-				/>
+				<ActivityCardList logs={ restorablePoints } pageSize={ 10 } siteSlug={ siteSlug } />
 			</div>
 		);
 	}

--- a/client/lib/site/timezone.js
+++ b/client/lib/site/timezone.js
@@ -27,6 +27,5 @@ export function applySiteOffset( input, { timezone, gmtOffset } ) {
 	if ( gmtOffset || gmtOffset === 0 ) {
 		return moment( input ).utcOffset( gmtOffset );
 	}
-
 	return moment( input );
 }

--- a/client/lib/site/timezone.js
+++ b/client/lib/site/timezone.js
@@ -27,5 +27,6 @@ export function applySiteOffset( input, { timezone, gmtOffset } ) {
 	if ( gmtOffset || gmtOffset === 0 ) {
 		return moment( input ).utcOffset( gmtOffset );
 	}
+
 	return moment( input );
 }

--- a/client/state/selectors/get-allow-restore.js
+++ b/client/state/selectors/get-allow-restore.js
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ */
+import { includes } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import createSelector from 'lib/create-selector';
+import getRewindCapabilities from 'state/selectors/get-rewind-capabilities';
+import getRewindState from 'state/selectors/get-rewind-state';
+
+/**
+ * Based on the transactions list, returns metadata for rendering the app filters with counts
+ *
+ * @param  {object} state Global state tree
+ * @param  {number} siteId the siteId
+ * @returns {boolean} if the site allows restores
+ */
+export default createSelector(
+	( state, siteId ) => {
+		const siteCapabilities = getRewindCapabilities( state, siteId );
+		const rewind = getRewindState( state, siteId );
+
+		const restoreStatus = rewind.rewind && rewind.rewind.status;
+		return (
+			'active' === rewind.state &&
+			! ( 'queued' === restoreStatus || 'running' === restoreStatus ) &&
+			includes( siteCapabilities, 'restore' )
+		);
+	},
+	( state, siteId ) => {
+		return [ getRewindCapabilities( state, siteId ), getRewindState( state, siteId ) ];
+	}
+);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* use `withApplySiteOffset` to make sure ActivityCards get everything they need to show the correct site times
* Simplify ActivityCard components to require fewer properties
* Add `getAllowRestore` selector

#### Testing instructions

Navigate the Activity Log and Daily and Real-Time backups Backup Statuses to make sure nothing has changes