### PR TITLE
Initial attempt at userless checkout

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -29,8 +29,8 @@ export default {
 	showCompositeCheckout: {
 		datestamp: '20200508',
 		variations: {
-			composite: 50,
-			regular: 50,
+			composite: 100,
+			regular: 0,
 		},
 		defaultVariation: 'regular',
 		allowExistingUsers: true,

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -743,6 +743,13 @@ export function isSiteTopicFulfilled( stepName, defaultDependencies, nextProps )
 	}
 }
 
+export function isUserFulfilled( stepName, defaultDependencies, nextProps ) {
+	// @todo Not sure if this needs to check for other things too.
+	if ( wpcom.isTokenLoaded() ) {
+		flows.excludeStep( stepName );
+	}
+}
+
 export function addOrRemoveFromProgressStore( stepName, defaultDependencies, nextProps ) {
 	const hasdDomainItemInDependencyStore = has( nextProps, 'signupDependencies.domainItem' );
 	const hasCartItemInDependencyStore = has( nextProps, 'signupDependencies.cartItem' );

--- a/client/lib/signup/step-actions/passwordless.js
+++ b/client/lib/signup/step-actions/passwordless.js
@@ -10,10 +10,10 @@ import wpcom from 'lib/wp';
  * @param {Function} callback Callback function
  * @param {object}   data     POST data object
  */
-export function createPasswordlessUser( callback, { email } ) {
+export function createPasswordlessUser( callback, { email, always_attempt_login } ) {
 	wpcom
 		.undocumented()
-		.usersEmailNew( { email }, null )
+		.usersEmailNew( { email, always_attempt_login }, null )
 		.then( ( response ) => callback( null, response ) )
 		.catch( ( err ) => callback( err ) );
 }

--- a/client/lib/store-transactions/index.js
+++ b/client/lib/store-transactions/index.js
@@ -349,6 +349,7 @@ TransactionFlow.prototype._submitWithPayment = function ( payment ) {
 	const transaction = {
 		cart: omit( this._initialData.cart, [ 'messages' ] ), // messages contain reference to DOMNode
 		domain_details: this._initialData.domainDetails,
+		account_email: this._initialData.accountEmail,
 		payment,
 	};
 

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1165,6 +1165,7 @@ Undocumented.prototype.updateConnection = function ( siteId, connectionId, data,
  *		payment_key: {string} Either the cc token from the gateway, or the mp_ref from /me/stored_cards,
  *		payment: {object} Payment details, including payment_method and payment_key,
  *		cart: {object>shopping_cart} A Shopping cart object
+ *		account_email: {string} Email address for new account
  *		domain_details: {object>contact_information} Optional set of domain contact information
  *		locale: {string} Locale for translating strings in response data,
  * }
@@ -1455,7 +1456,7 @@ Undocumented.prototype.validateNewUser = function ( data, fn ) {
 /**
  * Sign up for a new passwordless user account
  *
- * @param {object} query - an object with the following values: email
+ * @param {object} query - an object with either or both the following values: email, always_attempt_login
  * @param {Function} fn - Function to invoke when request is complete
  */
 Undocumented.prototype.usersEmailNew = function ( query, fn ) {

--- a/client/my-sites/checkout/composite-checkout/payment-method-processors.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-processors.js
@@ -21,6 +21,7 @@ export function applePayProcessor( submitData ) {
 		{
 			...submitData,
 			siteId: select( 'wpcom' )?.getSiteId?.(),
+			accountEmail: select( 'wpcom' )?.getContactInfo?.()?.accountEmail?.value,
 			domainDetails: getDomainDetails( select ),
 			country: select( 'wpcom' )?.getContactInfo?.()?.countryCode?.value,
 			postalCode: select( 'wpcom' )?.getContactInfo?.()?.postalCode?.value,
@@ -44,6 +45,7 @@ export async function stripeCardProcessor( submitData ) {
 	const pending = submitStripeCardTransaction(
 		{
 			...submitData,
+			accountEmail: select( 'wpcom' )?.getContactInfo?.()?.accountEmail?.value,
 			country: select( 'wpcom' )?.getContactInfo?.()?.countryCode?.value,
 			postalCode: select( 'wpcom' )?.getContactInfo?.()?.postalCode?.value,
 			subdivisionCode: select( 'wpcom' )?.getContactInfo?.()?.state?.value,

--- a/client/my-sites/checkout/composite-checkout/types/transaction-endpoint.ts
+++ b/client/my-sites/checkout/composite-checkout/types/transaction-endpoint.ts
@@ -134,6 +134,7 @@ export function createTransactionEndpointRequestPayloadFromLineItems( {
 	paymentPartnerProcessorId,
 	storedDetailsId,
 	name,
+	accountEmail,
 }: {
 	siteId: string;
 	couponId?: string;
@@ -147,6 +148,7 @@ export function createTransactionEndpointRequestPayloadFromLineItems( {
 	paymentPartnerProcessorId: string;
 	storedDetailsId: string;
 	name: string;
+	accountEmail?: string;
 } ): WPCOMTransactionEndpointRequestPayload {
 	return {
 		cart: createTransactionEndpointCartFromLineItems( {
@@ -157,6 +159,7 @@ export function createTransactionEndpointRequestPayloadFromLineItems( {
 			subdivisionCode,
 			items: items.filter( ( item ) => item.type !== 'tax' ),
 		} ),
+		accountEmail,
 		domainDetails,
 		payment: {
 			paymentMethod: paymentMethodType,

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-contact-form.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-contact-form.js
@@ -113,6 +113,24 @@ function VatIdField() {
 	);
 }
 
+function AccountEmailField() {
+	const translate = useTranslate();
+	const { accountEmail } = useSelect( ( select ) => select( 'wpcom' ).getContactInfo() );
+	const { updateAccountEmail } = useDispatch( 'wpcom' );
+
+	return (
+		<FormField
+			id="contact-account-email"
+			type="text" // @todo: email?
+			label={ translate( 'Email address' ) }
+			value={ accountEmail.value }
+			onChange={ updateAccountEmail }
+			isError={ accountEmail.isTouched && ! isValid( accountEmail ) }
+			errorMessage={ translate( 'This field is required.' ) }
+		/>
+	);
+}
+
 function TaxFields( {
 	section,
 	taxInfo,
@@ -273,6 +291,7 @@ function RenderContactDetails( {
 
 	switch ( format ) {
 		case 'DOMAINS':
+			// @todo only show email field if not logged in
 			return (
 				<React.Fragment>
 					<ContactDetailsFormDescription>
@@ -280,6 +299,7 @@ function RenderContactDetails( {
 							'Registering a domain name requires valid contact information. Privacy Protection is included for all eligible domains to protect your personal information.'
 						) }
 					</ContactDetailsFormDescription>
+					<AccountEmailField />
 					{ renderDomainContactFields(
 						domainNames,
 						prepareDomainContactDetails( contactInfo ),
@@ -292,11 +312,13 @@ function RenderContactDetails( {
 				</React.Fragment>
 			);
 		default:
+			// @todo only show email field if not logged in
 			return (
 				<React.Fragment>
 					<ContactDetailsFormDescription>
 						{ translate( 'Entering your billing information helps us prevent fraud.' ) }
 					</ContactDetailsFormDescription>
+					<AccountEmailField />
 					<TaxFields
 						section="contact"
 						taxInfo={ contactInfo }

--- a/client/my-sites/checkout/composite-checkout/wpcom/hooks/wpcom-store.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/hooks/wpcom-store.ts
@@ -25,6 +25,7 @@ type WpcomStoreAction =
 	| { type: 'SET_SITE_ID'; payload: string }
 	| { type: 'TRANSACTION_COMPLETE'; payload: object }
 	| { type: 'UPDATE_VAT_ID'; payload: string }
+	| { type: 'UPDATE_ACCOUNT_EMAIL'; payload: string }
 	| { type: 'UPDATE_PHONE'; payload: string }
 	| { type: 'UPDATE_PHONE_NUMBER_COUNTRY'; payload: string }
 	| { type: 'UPDATE_POSTAL_CODE'; payload: string }
@@ -66,6 +67,8 @@ export function useWpcomStore(
 			}
 			case 'UPDATE_VAT_ID':
 				return updaters.updateVatId( state, action.payload );
+			case 'UPDATE_ACCOUNT_EMAIL':
+				return updaters.updateAccountEmail( state, action.payload );
 			case 'UPDATE_PHONE':
 				return updaters.updatePhone( state, action.payload );
 			case 'UPDATE_PHONE_NUMBER_COUNTRY':
@@ -155,6 +158,10 @@ export function useWpcomStore(
 
 			updateVatId( payload: string ): WpcomStoreAction {
 				return { type: 'UPDATE_VAT_ID', payload: payload };
+			},
+
+			updateAccountEmail( payload: string ): WpcomStoreAction {
+				return { type: 'UPDATE_ACCOUNT_EMAIL', payload: payload };
 			},
 
 			loadDomainContactDetailsFromCache(

--- a/client/my-sites/checkout/composite-checkout/wpcom/types/wpcom-store-state.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/types/wpcom-store-state.ts
@@ -34,6 +34,7 @@ export type ManagedContactDetailsShape< T > = {
 	countryCode: T;
 	fax: T;
 	vatId: T;
+	accountEmail: T;
 	tldExtraFields: ManagedContactDetailsTldExtraFieldsShape< T >;
 };
 
@@ -183,6 +184,7 @@ export function updateManagedContactDetailsShape< A, B >(
 		countryCode: combine( update.countryCode, data.countryCode ),
 		fax: combine( update.fax, data.fax ),
 		vatId: combine( update.vatId, data.vatId ),
+		accountEmail: combine( update.accountEmail, data.accountEmail ),
 		tldExtraFields,
 	};
 }
@@ -207,6 +209,7 @@ export function flattenManagedContactDetailsShape< A, B >(
 		f( x.countryCode ),
 		f( x.fax ),
 		f( x.vatId ),
+		f( x.accountEmail ),
 	];
 
 	const caValues =
@@ -561,6 +564,7 @@ export function prepareDomainContactValidationRequest(
 			countryCode: details.countryCode.value,
 			fax: details.fax.value,
 			vatId: details.vatId.value,
+			accountEmail: details.accountEmail.value,
 			extra,
 		},
 	};
@@ -585,6 +589,7 @@ export function formatDomainContactValidationResponse(
 		countryCode: response.messages?.countryCode,
 		fax: response.messages?.fax,
 		vatId: response.messages?.vatId,
+		accountEmail: response.messages?.accountEmail,
 		tldExtraFields: {
 			ca: {
 				lang: response.messages?.extra?.ca?.lang,
@@ -624,6 +629,7 @@ function prepareManagedContactDetailsUpdate(
 		countryCode: rawFields.countryCode,
 		fax: rawFields.fax,
 		vatId: rawFields.vatId,
+		accountEmail: rawFields.accountEmail,
 		tldExtraFields: {
 			ca: {
 				lang: rawFields?.extra?.ca?.lang,
@@ -674,6 +680,7 @@ export type ManagedContactDetailsUpdaters = {
 	) => ManagedContactDetails;
 	touchContactFields: ( arg0: ManagedContactDetails ) => ManagedContactDetails;
 	updateVatId: ( arg0: ManagedContactDetails, arg1: string ) => ManagedContactDetails;
+	updateAccountEmail: ( arg0: ManagedContactDetails, arg1: string ) => ManagedContactDetails;
 	setErrorMessages: (
 		arg0: ManagedContactDetails,
 		arg1: ManagedContactDetailsErrors
@@ -745,6 +752,16 @@ export const managedContactDetailsUpdaters: ManagedContactDetailsUpdaters = {
 		};
 	},
 
+	updateAccountEmail: (
+		oldDetails: ManagedContactDetails,
+		newAccountEmail: string
+	): ManagedContactDetails => {
+		return {
+			...oldDetails,
+			accountEmail: touchIfDifferent( newAccountEmail, oldDetails.accountEmail ),
+		};
+	},
+
 	setErrorMessages: (
 		oldDetails: ManagedContactDetails,
 		errors: ManagedContactDetailsErrors
@@ -797,6 +814,7 @@ export const emptyManagedContactDetails: ManagedContactDetails = {
 	countryCode: getInitialManagedValue(),
 	fax: getInitialManagedValue(),
 	vatId: getInitialManagedValue(),
+	accountEmail: getInitialManagedValue(),
 	tldExtraFields: {},
 };
 
@@ -830,6 +848,7 @@ export const domainRequiredContactDetails: ManagedContactDetailsRequiredMask = {
 	countryCode: true,
 	fax: false,
 	vatId: false,
+	accountEmail: false,
 	tldExtraFields: {},
 };
 
@@ -849,6 +868,7 @@ export const taxRequiredContactDetails: ManagedContactDetailsRequiredMask = {
 	countryCode: true,
 	fax: false,
 	vatId: false,
+	accountEmail: false,
 	tldExtraFields: {},
 };
 

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -117,6 +117,14 @@ export function generateFlows( {
 			showRecaptcha: true,
 		},
 
+		'onboarding-user-optional': {
+			steps: [ 'domains', 'plans', 'user' ],
+			destination: getSignupDestination,
+			description: 'Testing userless checkout',
+			lastModified: '2020-05-15',
+			showRecaptcha: true, // @todo?
+		},
+
 		'onboarding-plan-first': {
 			steps: [ 'user', 'plans', 'domains' ],
 			destination: getSignupDestination,

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -107,7 +107,7 @@ function filterDestination( destination, dependencies ) {
 }
 
 function getDefaultFlowName() {
-	return config.isEnabled( 'signup/onboarding-flow' ) ? 'onboarding' : 'main';
+	return 'onboarding-user-optional';
 }
 
 const Flows = {

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -37,6 +37,7 @@ export function generateSteps( {
 	removeDomainStepForPaidPlans = noop,
 	isSiteTypeFulfilled = noop,
 	isSiteTopicFulfilled = noop,
+	isUserFulfilled = noop,
 	addOrRemoveFromProgressStore = noop,
 } = {} ) {
 	return {
@@ -148,6 +149,7 @@ export function generateSteps( {
 			apiRequestFunction: createAccount,
 			providesToken: true,
 			providesDependencies: [ 'bearer_token', 'username', 'marketing_price_group' ],
+			fulfilledStepCallback: isUserFulfilled, // @todo It might be better to create a separate "user-optional" step and add this to that
 			props: {
 				isSocialSignupEnabled: config.isEnabled( 'signup/social' ),
 			},
@@ -166,7 +168,7 @@ export function generateSteps( {
 			stepName: 'plans',
 			apiRequestFunction: addPlanToCart,
 			dependencies: [ 'siteSlug' ],
-			providesDependencies: [ 'cartItem' ],
+			providesDependencies: [ 'cartItem', 'bearer_token', 'username' ], // @todo It might be better to have a separate "plans-and-create-user" step?  Alternatively, the bearer_token and username should be optional dependencies?
 			fulfilledStepCallback: isPlanFulfilled,
 		},
 

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -22,6 +22,7 @@ import {
 	removeDomainStepForPaidPlans,
 	isSiteTypeFulfilled,
 	isSiteTopicFulfilled,
+	isUserFulfilled,
 	addOrRemoveFromProgressStore,
 } from 'lib/signup/step-actions';
 import { abtest } from 'lib/abtest';
@@ -43,6 +44,7 @@ export default generateSteps( {
 	removeDomainStepForPaidPlans,
 	isSiteTypeFulfilled,
 	isSiteTopicFulfilled,
+	isUserFulfilled,
 	addOrRemoveFromProgressStore,
 } );
 

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -65,13 +65,8 @@ export default {
 			} )
 				.then( ( { geo } ) => {
 					const countryCode = geo.data.body.country_short;
-					if ( 'gutenberg' === abtest( 'newSiteGutenbergOnboarding', countryCode ) ) {
-						recordTracksEvent( 'calypso_newsite_init' );
-						window.location = window.location.origin + '/new';
-					} else {
-						removeWhiteBackground();
-						next();
-					}
+					removeWhiteBackground();
+					next();
 				} )
 				.catch( () => {
 					removeWhiteBackground();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is some test code to try out the idea of "userless checkout" on WordPress.com (i.e., waiting until checkout to ask the user for an email address and then giving them a user account after that).

This requires D43534-code (server-side WordPress.com changes) and is just a relatively hacky implementation at this point.  Definitely not ready for any kind of final review.

See pbOQVh-bS-p2 (internal discussion) for further details.

#### Testing instructions

Go through signup and choose a paid plan.  Notice that your site gets created and you get redirected to checkout without going through an account creation step.  On checkout, there is a new email address field you can fill out.  After paying with a credit card, you should fine that the purchase was successful and that your new account has the email address you provided and an auto-generated username.  You won't have a password set initially, but in the future you can either set one or log in via email login links instead.

Log out, go through signup again, and choose a free plan and site.  You'll be prompted to create a user account in the regular way, since there's no checkout (although the user account creation step is now at the end of the flow rather than the beginning).