### PR TITLE
Fix Zero GMT Offset Using Local Time Instead

### DIFF
--- a/client/lib/site/timezone.js
+++ b/client/lib/site/timezone.js
@@ -24,7 +24,7 @@ export function applySiteOffset( input, { timezone, gmtOffset } ) {
 	if ( timezone ) {
 		return moment.tz( input, timezone );
 	}
-	if ( gmtOffset ) {
+	if ( gmtOffset || gmtOffset === 0 ) {
 		return moment( input ).utcOffset( gmtOffset );
 	}
 	return moment( input );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Allow `0` gmtOffset to modify moment in `applySiteOffset`

#### Testing instructions

1. Navigate to `/activity-log` for a Jetpack site with a `UTC+0` timezone setting
2. Verify that the activity dates are now in site time
