### PR TITLE
Checkout: use pre-sales chat button when available

### DIFF
--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -443,9 +443,7 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 
 			case 'calypso_checkout_composite_summary_help_click': {
 				return reduxDispatch(
-					recordTracksEvent( 'calypso_checkout_composite_summary_help_click', {
-						is_support_chat_user: action.payload.isSupportChatUser,
-					} )
+					recordTracksEvent( 'calypso_checkout_composite_summary_help_click' )
 				);
 			}
 

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
@@ -178,7 +178,7 @@ function CheckoutSummaryHelp() {
 
 	// If chat is available and the cart has a pre-sales plan or is already eligible for chat.
 	if ( happyChatAvailable && ( isPresalesChatEligible || isSupportChatUser ) ) {
-		return <PaymentChatButtonUI />;
+		return <PaymentChatButton />;
 	}
 
 	// If chat isn't available, use the inline help button instead.
@@ -223,6 +223,15 @@ const CheckoutSummaryFeatures = styled.div`
 	@media ( ${( props ) => props.theme.breakpoints.desktopUp} ) {
 		padding: 20px;
 	}
+
+	.checkout__payment-chat-button.is-borderless {
+		color: ${( props ) => props.theme.colors.textColor};
+		padding: 0;
+
+		svg {
+			width: 20px;
+		}
+	}
 `;
 
 const CheckoutSummaryFeaturesTitle = styled.h3`
@@ -235,15 +244,6 @@ const CheckoutSummaryFeaturesListUI = styled.ul`
 	margin: 0;
 	list-style: none;
 	font-size: 14px;
-`;
-
-const PaymentChatButtonUI = styled( PaymentChatButton )`
-	color: ${( props ) => props.theme.textColor};
-	padding: 0;
-
-	svg {
-		width: 20px;
-	}
 `;
 
 const CheckoutSummaryHelpButton = styled.button`

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
@@ -183,6 +183,7 @@ function CheckoutSummaryHelp() {
 	return (
 		<>
 			<QuerySupportTypes />
+			{ ! shouldRenderPaymentChatButton && ! supportVariationDetermined && <LoadingButton /> }
 			{ shouldRenderPaymentChatButton ? (
 				<PaymentChatButton />
 			) : (
@@ -325,5 +326,13 @@ const LoadingCopy = styled.p`
 		height: 18px;
 		background: ${( props ) => props.theme.colors.borderColorLight};
 		border-radius: 100%;
+	}
+`;
+
+const LoadingButton = styled( LoadingCopy )`
+	margin: 16px 8px 0;
+
+	:before {
+		display: none;
 	}
 `;

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
@@ -170,12 +170,7 @@ function CheckoutSummaryHelp() {
 
 	const onEvent = useEvents();
 	const handleHelpButtonClicked = () => {
-		onEvent( {
-			type: 'calypso_checkout_composite_summary_help_click',
-			payload: {
-				isSupportChatUser,
-			},
-		} );
+		onEvent( { type: 'calypso_checkout_composite_summary_help_click' } );
 		reduxDispatch( showInlineHelpPopover() );
 	};
 

--- a/client/state/help/selectors.js
+++ b/client/state/help/selectors.js
@@ -9,7 +9,7 @@ import { get } from 'lodash';
 import getSelectedOrPrimarySiteId from 'state/selectors/get-selected-or-primary-site-id';
 import { getSite } from 'state/sites/selectors';
 
-export const getHelpSiteId = ( state ) => state.help.selectedSiteId;
+export const getHelpSiteId = ( state ) => state.help?.selectedSiteId;
 
 /*
  * Returns the site the customer wishes to request help for. Returns in order of preference:

--- a/client/state/selectors/is-directly-failed.js
+++ b/client/state/selectors/is-directly-failed.js
@@ -14,5 +14,5 @@
 import { STATUS_ERROR } from 'state/help/directly/constants';
 
 export default function isDirectlyFailed( state ) {
-	return state.help.directly.status === STATUS_ERROR;
+	return state.help?.directly.status === STATUS_ERROR;
 }

--- a/client/state/selectors/is-directly-ready.js
+++ b/client/state/selectors/is-directly-ready.js
@@ -14,5 +14,5 @@
 import { STATUS_READY } from 'state/help/directly/constants';
 
 export default function getDirectlyStatus( state ) {
-	return state.help.directly.status === STATUS_READY;
+	return state.help?.directly.status === STATUS_READY;
 }

--- a/client/state/selectors/is-directly-uninitialized.js
+++ b/client/state/selectors/is-directly-uninitialized.js
@@ -14,5 +14,5 @@
 import { STATUS_UNINITIALIZED } from 'state/help/directly/constants';
 
 export default function isDirectlyUninitialized( state ) {
-	return state.help.directly.status === STATUS_UNINITIALIZED;
+	return state.help?.directly.status === STATUS_UNINITIALIZED;
 }


### PR DESCRIPTION
In legacy Checkout, we allow "pre-sales" happy chat for users with a business or e-commerce plan in their cart. In new Checkout, we only allow chat in the checkout summary for users that have already purchased a plan. This allows for the same pre-sales chat when available.

<img width="975" alt="Screen Shot 2020-05-15 at 4 38 58 PM" src="https://user-images.githubusercontent.com/942359/82094639-798c8080-96cb-11ea-8f57-24805d1e598c.png">

**To test:**
Testing this is difficult, because it requires a chat to be available. You can check that the chat loads correctly by setting [`happyChatAvailable = true` here](https://github.com/Automattic/wp-calypso/compare/update/checkout-happiness-cta?expand=1#diff-1d892c5272ad36b273914f3c19b7a379R81) and [`isChatAvailable: true` here](https://github.com/Automattic/wp-calypso/blob/master/client/components/happychat/button.jsx#L110).

- if a chat is available and the user is either already eligible for chat support (via a previous plan purchase) or has an e-commerce or business plan in their cart, a chat button should be shown
- if a chat is not available the existing summary chat logic should apply (the link will open the inline help modal and the CTA text will reflect their ability to open tickets or just search the forums)