### PR TITLE
Jetpack Search: Add upgrade notice to the Thank you modal for pre-8.4 Jetpack versions.

### DIFF
--- a/client/my-sites/plans/current-plan/current-plan-thank-you/search-thank-you.js
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you/search-thank-you.js
@@ -2,27 +2,37 @@
  * External dependencies
  */
 import React from 'react';
-import { localize } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import ThankYou from './thank-you';
+import versionCompare from 'lib/version-compare';
 
-const SearchProductThankYou = ( { translate } ) => (
-	<ThankYou
-		illustration="/calypso/images/illustrations/thankYou.svg"
-		showSearchRedirects
-		title={ translate( 'Welcome to Jetpack Search!' ) }
-	>
-		<p>{ translate( 'We are currently indexing your site.' ) }</p>
-		<p>
-			{ translate(
-				'In the meantime, we have configured Jetpack Search on your site — ' +
-					'you should try customizing it in your traditional WordPress dashboard.'
-			) }
-		</p>
-	</ThankYou>
-);
+function SearchProductThankYou( { jetpackVersion } ) {
+	const translate = useTranslate();
+	return (
+		<ThankYou
+			illustration="/calypso/images/illustrations/thankYou.svg"
+			showSearchRedirects
+			title={ translate( 'Welcome to Jetpack Search!' ) }
+		>
+			<p>{ translate( 'We are currently indexing your site.' ) }</p>
+			<p>
+				{ jetpackVersion && versionCompare( jetpackVersion, '8.4', '<' )
+					? translate(
+							"In the meantime you'll need to update Jetpack to version 8.4 or higher in order " +
+								"to get the most out of Jetpack Search. Once you've updated Jetpack, " +
+								"we'll configure Search for you. You can try search and customize it to your liking."
+					  )
+					: translate(
+							'In the meantime, we have configured Jetpack Search on your site — ' +
+								'you should try customizing it in your traditional WordPress dashboard.'
+					  ) }
+			</p>
+		</ThankYou>
+	);
+}
 
-export default localize( SearchProductThankYou );
+export default SearchProductThankYou;

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { Component, Fragment } from 'react';
-import { startsWith } from 'lodash';
+import { get, startsWith } from 'lodash';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
@@ -78,7 +78,7 @@ class CurrentPlan extends Component {
 	}
 
 	renderThankYou() {
-		const { currentPlan, product } = this.props;
+		const { currentPlan, product, selectedSite } = this.props;
 
 		if ( startsWith( product, 'jetpack_backup' ) ) {
 			return <BackupProductThankYou />;
@@ -89,7 +89,9 @@ class CurrentPlan extends Component {
 		}
 
 		if ( startsWith( product, 'jetpack_search' ) ) {
-			return <SearchProductThankYou />;
+			const jetpackVersion = get( selectedSite, 'options.jetpack_version', 0 );
+
+			return <SearchProductThankYou { ...{ jetpackVersion } } />;
 		}
 
 		if ( ! currentPlan || isFreePlan( currentPlan ) || isFreeJetpackPlan( currentPlan ) ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Jetpack Search requires Jetpack 8.4 or higher for full functionality. Here, whenever applicable,  we add a notice to the post-checkout modal for an upgrade.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
Go to `plans/my-plan/:site?thank-you=&product=jetpack_search`, for a site with Jetpack version < 8.4 and verify that the notice is present and that the redirect is functional.

Obsolete/previous:
![upgrade](https://user-images.githubusercontent.com/13561163/82130423-74165f80-97cb-11ea-9669-e6b61959035c.png)

New designs after reviews:

![thankuupgrade](https://user-images.githubusercontent.com/13561163/82736872-fe5f4600-9d2c-11ea-9fdf-9365dfc3f04e.png)

Verify the lack of notice for Jetpack >= 8.4.

Note:  pending fix related to the URL accessibility https://github.com/Automattic/wp-calypso/issues/41397 

Fixes https://github.com/Automattic/wp-calypso/issues/42261
