### PR TITLE
Gutenboarding: add `calypso_signup_start|complete` events

### DIFF
--- a/client/landing/gutenboarding/lib/analytics/index.ts
+++ b/client/landing/gutenboarding/lib/analytics/index.ts
@@ -36,7 +36,10 @@ export function recordOnboardingStart( ref = '' ): void {
 	if ( ! ref ) {
 		ref = new URLSearchParams( window.location.search ).get( 'ref' ) || ref;
 	}
+
 	trackEventWithFlow( 'calypso_newsite_start', { ref } );
+	// Also fire the signup start|complete events. See: pbmFJ6-95-p2
+	trackEventWithFlow( 'calypso_signup_start', { ref } );
 }
 
 /**
@@ -45,11 +48,14 @@ export function recordOnboardingStart( ref = '' ): void {
  * @param {object} params A set of params to pass to analytics for signup completion
  */
 export function recordOnboardingComplete( params: OnboardingCompleteParameters ): void {
-	trackEventWithFlow( 'calypso_newsite_complete', {
+	const trackingParams = {
 		is_new_user: params.isNewUser,
 		is_new_site: params.isNewSite,
 		blog_id: params.blogId,
-	} );
+	};
+	trackEventWithFlow( 'calypso_newsite_complete', trackingParams );
+	// Also fire the signup start|complete events. See: pbmFJ6-95-p2
+	trackEventWithFlow( 'calypso_signup_complete', trackingParams );
 }
 
 /**


### PR DESCRIPTION
## Changes proposed in this Pull Request

In this PR we're firing `calypso_signup_start|complete` events at the same time as our  `calypso_newsite_start|complete` events.

See pbmFJ6-95-p2 for context

## Testing instructions

Head over to the branch and to `/new` 

Filter your network traffic in the browser's console to check if both `calypso_signup_start` and `calypso_newsite_start` are called with the same props.

Complete the signup flow.

Check if both `calypso_signup_complete` and `calypso_newsite_complete` are called with the same props.


