### PR TITLE
Gutenboarding: don't call calypso_newsite_start after login 

### DIFF
--- a/client/landing/gutenboarding/gutenboard.tsx
+++ b/client/landing/gutenboarding/gutenboard.tsx
@@ -21,6 +21,7 @@ import './style.scss';
 import { fontPairings, getFontTitle } from './constants';
 import { recordOnboardingStart } from './lib/analytics';
 import useOnSiteCreation from './hooks/use-on-site-creation';
+import { useNewQueryParam } from './path';
 
 registerBlockType( name, settings );
 
@@ -35,6 +36,7 @@ const BlockList = ( props: BlockListProps ) => <OriginalBlockList { ...props } /
 
 export function Gutenboard() {
 	const { __ } = useI18n();
+	const shouldTriggerCreate = useNewQueryParam();
 
 	useOnSiteCreation();
 
@@ -62,7 +64,12 @@ export function Gutenboard() {
 			document.head.appendChild( linkHeadings );
 		} );
 
-		recordOnboardingStart();
+		// If we're returning to Gutenboarding site creation
+		// e.g., from the login flow
+		// don't record flow start again
+		if ( ! shouldTriggerCreate ) {
+			recordOnboardingStart();
+		}
 	}, [] );
 
 	// @TODO: This is currently needed in addition to the routing (inside the Onboarding Block)


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When we return from login to Gutenboarding, we add a `?new` parameter to tell the app to force site creation. At this point we don't want to fire another `calypso_newsite_start` tracking event since the user has presumably already triggered one before they hopped off to the login flow.

So if we detect a `?new` we don't call `recordOnboardingStart()`

❓This approach feels a little too convenient, but it works for now. We could be more explicit here, that is, send a more descriptive url param to the login as a redirect value.

#### Testing instructions

Go to the `/new` flow.

Check that `calypso_newsite_start` and `calypso_signup_start` are called

Login with an existing account

After login and redirect to Gutenboarding site creation, check that `calypso_newsite_start` and `calypso_signup_start` **are not called**.


Fixes part of https://github.com/Automattic/wp-calypso/issues/42311
