### PR TITLE
Gutenboarding: Remove forwarding of login page's own redirect_to param to social logins

### DIFF
--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -179,12 +179,6 @@ class SocialLoginForm extends Component {
 
 	getRedirectUrl = ( service ) => {
 		const host = typeof window !== 'undefined' && window.location.host;
-
-		if ( host && window.localStorage?.getItem( 'a8c_testing_redirect_url' ) ) {
-			const { redirectTo } = this.props;
-			return `https://${ host + login( { isNative: true, socialService: service, redirectTo } ) }`;
-		}
-
 		return `https://${ host + login( { isNative: true, socialService: service } ) }`;
 	};
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This was added in #42135 and didn't fix the issue as expected. It is no
longer needed.


* Remove test code for adding redirect_to param to social logins

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test Google sign in works
* Test SSR of `/log-in` still works (#42135 broke it)
  * Disable JS in dev tools
  * `/log-in` should show a disabled log in form
* ***After deployment to staging*** test Apple sign in works
