### PR TITLE
Gutenboarding: track flow complete before checkout

### DIFF
--- a/client/landing/gutenboarding/hooks/use-on-site-creation.ts
+++ b/client/landing/gutenboarding/hooks/use-on-site-creation.ts
@@ -67,6 +67,12 @@ export default function useOnSiteCreation() {
 
 	const { resetOnboardStore, setIsRedirecting, setSelectedSite } = useDispatch( ONBOARD_STORE );
 	const { resetPlan } = useDispatch( PLANS_STORE );
+	const flowCompleteTrackingParams = {
+		isNewSite: !! newSite,
+		isNewUser: !! newUser,
+		blogId: newSite?.blogid,
+		hasCartItems: false,
+	};
 
 	React.useEffect( () => {
 		// isRedirecting check this is needed to make sure we don't overwrite the first window.location.replace() call
@@ -107,6 +113,10 @@ export default function useOnSiteCreation() {
 							: `/checkout/${ newSite.site_slug }?preLaunch=1&isGutenboardingCreate=1&redirect_to=%2Fblock-editor%2Fpage%2F${ newSite.site_slug }%2Fhome`;
 					window.location.href = redirectionUrl;
 				};
+				recordOnboardingComplete( {
+					...flowCompleteTrackingParams,
+					hasCartItems: true,
+				} );
 				go();
 				return;
 			}
@@ -139,11 +149,7 @@ export default function useOnSiteCreation() {
 				return;
 			}
 
-			recordOnboardingComplete( {
-				isNewSite: !! newSite,
-				isNewUser: !! newUser,
-				blogId: newSite.blogid,
-			} );
+			recordOnboardingComplete( flowCompleteTrackingParams );
 			resetPlan();
 			resetOnboardStore();
 			setSelectedSite( newSite.blogid );

--- a/client/landing/gutenboarding/lib/analytics/index.ts
+++ b/client/landing/gutenboarding/lib/analytics/index.ts
@@ -52,6 +52,7 @@ export function recordOnboardingComplete( params: OnboardingCompleteParameters )
 		is_new_user: params.isNewUser,
 		is_new_site: params.isNewSite,
 		blog_id: params.blogId,
+		has_cart_items: params.hasCartItems,
 	};
 	trackEventWithFlow( 'calypso_newsite_complete', trackingParams );
 	// Also fire the signup start|complete events. See: pbmFJ6-95-p2

--- a/client/landing/gutenboarding/lib/analytics/types.ts
+++ b/client/landing/gutenboarding/lib/analytics/types.ts
@@ -31,6 +31,11 @@ export interface OnboardingCompleteParameters {
 	 * The blog id of the newly created site
 	 */
 	blogId: number | string | undefined;
+
+	/**
+	 * Whether the user has a paid plan or other checkout item
+	 */
+	hasCartItems?: boolean;
 }
 
 export type TracksAcquireIntentEventProperties = {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR records a Gutenboarding flow complete tracking event (`calypso_newsite_complete`) **before** we redirect a user to the checkout, signalling that the Gutenboarding site creation is complete

We're doing this because the user never returns to any Gutenboarding step after checkout. 

This PR also adds a `has_cart_items` prop to the complete event, which features in the current `calypso_signup_complete` event.


#### Testing instructions

Test over at `/new` with and without a paid plan. 

`calypso_newsite_complete` should fire once your site is complete. If you have something in your cart `has_cart_items` should be true.

Fixes part of https://github.com/Automattic/wp-calypso/issues/42311
