### PR TITLE
Login: Honour `redirect_to` param after returning from Sign-in with Apple flow

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -55,6 +55,7 @@ class Login extends Component {
 		linkingSocialService: PropTypes.string,
 		oauth2Client: PropTypes.object,
 		privateSite: PropTypes.bool,
+		rebootAfterLogin: PropTypes.func.isRequired,
 		requestNotice: PropTypes.object,
 		socialConnect: PropTypes.bool,
 		socialService: PropTypes.string,

--- a/client/login/magic-login/handle-emailed-link-form.jsx
+++ b/client/login/magic-login/handle-emailed-link-form.jsx
@@ -15,7 +15,6 @@ import { Button } from '@automattic/components';
 import EmptyContent from 'components/empty-content';
 import EmailedLoginLinkExpired from './emailed-login-link-expired';
 import config from 'config';
-import userFactory from 'lib/user';
 import { login } from 'lib/paths';
 import { localize } from 'i18n-calypso';
 import { LINK_EXPIRED_PAGE } from 'state/login/magic-login/constants';
@@ -23,6 +22,7 @@ import {
 	fetchMagicLoginAuthenticate,
 	showMagicLoginLinkExpiredPage,
 } from 'state/login/magic-login/actions';
+import { rebootAfterLogin } from 'state/login/actions';
 import getMagicLoginCurrentView from 'state/selectors/get-magic-login-current-view';
 import getMagicLoginRequestAuthError from 'state/selectors/get-magic-login-request-auth-error';
 import getMagicLoginRequestedAuthSuccessfully from 'state/selectors/get-magic-login-requested-auth-successfully';
@@ -39,8 +39,6 @@ import {
 } from 'state/immediate-login/selectors';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
-
-const user = userFactory();
 
 class HandleEmailedLinkForm extends React.Component {
 	static propTypes = {
@@ -64,6 +62,7 @@ class HandleEmailedLinkForm extends React.Component {
 
 		// Connected action creators
 		fetchMagicLoginAuthenticate: PropTypes.func.isRequired,
+		rebootAfterLogin: PropTypes.func.isRequired,
 		recordTracksEvent: PropTypes.func.isRequired,
 		showMagicLoginLinkExpiredPage: PropTypes.func.isRequired,
 	};
@@ -96,7 +95,7 @@ class HandleEmailedLinkForm extends React.Component {
 		const { redirectToSanitized, twoFactorEnabled, twoFactorNotificationSent } = this.props;
 
 		if ( ! twoFactorEnabled ) {
-			this.rebootAfterLogin();
+			this.props.rebootAfterLogin( { magic_login: 1 } );
 		} else {
 			page(
 				login( {
@@ -107,27 +106,6 @@ class HandleEmailedLinkForm extends React.Component {
 				} )
 			);
 		}
-	};
-
-	// Lifted from `blocks/login`
-	// @TODO move to `state/login/actions` & use both places
-	rebootAfterLogin = () => {
-		const { redirectToSanitized, twoFactorEnabled } = this.props;
-
-		this.props.recordTracksEvent( 'calypso_login_success', {
-			two_factor_enabled: twoFactorEnabled,
-			magic_login: 1,
-		} );
-
-		// Redirects to / if no redirect url is available
-		const url = redirectToSanitized || '/';
-
-		// user data is persisted in localstorage at `lib/user/user` line 157
-		// therefore we need to reset it before we redirect, otherwise we'll get
-		// mixed data from old and new user
-		user.clear().then( () => {
-			window.location.href = url;
-		} );
 	};
 
 	UNSAFE_componentWillUpdate( nextProps, nextState ) {
@@ -229,6 +207,7 @@ const mapState = ( state ) => {
 
 const mapDispatch = {
 	fetchMagicLoginAuthenticate,
+	rebootAfterLogin,
 	recordTracksEvent,
 	showMagicLoginLinkExpiredPage,
 };

--- a/client/state/login/actions/index.js
+++ b/client/state/login/actions/index.js
@@ -15,3 +15,4 @@ export {
 } from 'state/login/actions/push';
 export { sendSmsCode } from 'state/login/actions/send-sms-code';
 export { updateNonce } from 'state/login/actions/update-nonce';
+export { rebootAfterLogin } from 'state/login/actions/reboot-after-login';

--- a/client/state/login/actions/reboot-after-login.ts
+++ b/client/state/login/actions/reboot-after-login.ts
@@ -1,0 +1,40 @@
+/**
+ * External dependencies
+ */
+import type { Dispatch } from 'redux';
+
+/**
+ * Internal dependencies
+ */
+import userFactory from 'lib/user';
+import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
+import { getRedirectToSanitized, isTwoFactorEnabled } from 'state/login/selectors';
+
+const user = userFactory();
+
+export const rebootAfterLogin = ( tracksEventArgs: object ) => async (
+	dispatch: Dispatch,
+	getState: () => object
+) => {
+	const redirectToSanitized = getRedirectToSanitized( getState() );
+	const twoFactorEnabled = isTwoFactorEnabled( getState() );
+
+	dispatch(
+		recordTracksEvent( 'calypso_login_success', {
+			two_factor_enabled: twoFactorEnabled,
+			...tracksEventArgs,
+		} )
+	);
+
+	// Redirects to / if no redirect url is available
+	const url = redirectToSanitized || '/';
+
+	// user data is persisted in localstorage at `lib/user/user` line 157
+	// therefore we need to reset it before we redirect, otherwise we'll get
+	// mixed data from old and new user
+	if ( user.get() ) {
+		await user.clear();
+	}
+
+	window.location.href = url;
+};

--- a/client/state/login/actions/reboot-after-login.ts
+++ b/client/state/login/actions/reboot-after-login.ts
@@ -16,18 +16,15 @@ export const rebootAfterLogin = ( tracksEventArgs: object ) => async (
 	dispatch: Dispatch,
 	getState: () => object
 ) => {
-	const redirectToSanitized = getRedirectToSanitized( getState() );
-	const twoFactorEnabled = isTwoFactorEnabled( getState() );
-
 	dispatch(
 		recordTracksEvent( 'calypso_login_success', {
-			two_factor_enabled: twoFactorEnabled,
+			two_factor_enabled: isTwoFactorEnabled( getState() ),
 			...tracksEventArgs,
 		} )
 	);
 
 	// Redirects to / if no redirect url is available
-	const url = redirectToSanitized || '/';
+	const url = getRedirectToSanitized( getState() ) || '/';
 
 	// user data is persisted in localstorage at `lib/user/user` line 157
 	// therefore we need to reset it before we redirect, otherwise we'll get


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Refactor `rebootAfterLogin()` component method to redux action

This fixes a `@TODO` to share this code between the login block and magic link form.

But more importantly it fixes redirecting to the correct place if the user is signing in with Apple. The broken flow goes like this:

1. When the user clicks "Sign in with Apple" we [stash the `redirect_to` param in session storage](https://github.com/Automattic/wp-calypso/blob/5076a5b0355409a4aedb8df28262fa05d3b414c0/client/blocks/login/social.jsx#L176)
2. After the user successfully logs in with apple, we [read the redirect url out of session storage](https://github.com/Automattic/wp-calypso/blob/5076a5b0355409a4aedb8df28262fa05d3b414c0/client/blocks/login/social.jsx#L124) and [fire a `loginSocialUser` action](https://github.com/Automattic/wp-calypso/blob/5076a5b0355409a4aedb8df28262fa05d3b414c0/client/blocks/login/social.jsx#L138)
3. `loginSocialUser` calls `/wp-login.php` and on success stores the redirect url (which has been sanitized by the backend) [in the redux store](https://github.com/Automattic/wp-calypso/blob/5076a5b0355409a4aedb8df28262fa05d3b414c0/client/state/login/actions/login-social-user.js#L58)
4. Now that `loginSocialUser` is done [the component calls its success handler](https://github.com/Automattic/wp-calypso/blob/5076a5b0355409a4aedb8df28262fa05d3b414c0/client/blocks/login/social.jsx#L142)
5. Which is [the `rebootAfterLogin` method](https://github.com/Automattic/wp-calypso/blob/5076a5b0355409a4aedb8df28262fa05d3b414c0/client/blocks/login/index.jsx#L180). It redirects the user using the `redirectTo` prop, which it got from the redux store during the last render.

However the problem is that React hasn't had a chance to re-render the `<Login>` component yet! The redux store has been updated by `loginSocialUser`, however the component still has the old value, which is `null`.

By refactoring `rebootAfterLogin` to an action, we're able to use the latest values from the store, not whatever values were used in the last render.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out branch
* Go to `http://calypso.localhost:3000/log-in?redirect_to=http%3A%2F%2Fcalypso.localhost%3A3000%2Fme`, which is a login page that will go to `/me` after a successful log in
* Test that all these login flows eventually go to 
  * Username and password
  * With 2nd factor
  * "Email me a login link"
  * Google login
  * ***After staging deployment is complete*** Apple login
* `/log-in` is still SSR'd (disable JS and check the server renders a disabled login form)

Fixes #42092