### PR TITLE
Prevent Emailed Link form from clearing Gutenboarding data on login

### DIFF
--- a/client/login/magic-login/handle-emailed-link-form.jsx
+++ b/client/login/magic-login/handle-emailed-link-form.jsx
@@ -111,7 +111,7 @@ class HandleEmailedLinkForm extends React.Component {
 
 	// Lifted from `blocks/login`
 	// @TODO move to `state/login/actions` & use both places
-	rebootAfterLogin = () => {
+	rebootAfterLogin = async () => {
 		const { redirectToSanitized, twoFactorEnabled } = this.props;
 
 		this.props.recordTracksEvent( 'calypso_login_success', {
@@ -123,11 +123,13 @@ class HandleEmailedLinkForm extends React.Component {
 		const url = redirectToSanitized || '/';
 
 		// user data is persisted in localstorage at `lib/user/user` line 157
-		// therefore we need to reset it before we redirect, otherwise we'll get
-		// mixed data from old and new user
-		user.clear().then( () => {
-			window.location.href = url;
-		} );
+		// Only clear the data if a user is currently set, otherwise keep the
+		// logged out state around so that it can be used in signup.
+		if ( user.get() ) {
+			await user.clear();
+		}
+
+		window.location.href = url;
 	};
 
 	UNSAFE_componentWillUpdate( nextProps, nextState ) {


### PR DESCRIPTION
This resolves part of: https://github.com/Automattic/wp-calypso/issues/42035 — persisting Gutenboarding signup data within the same browser session past the login boundary for users who login with a passwordless account or via `Email me a login link`.

#### Changes proposed in this Pull Request

* Ensure that the Emailed Link form does not clear out signup data (logged out user data) after clicking `Continue to WordPress.com`

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Note: this PR will be superseded by #42318 which effectively incorporates this change anyway, in the refactor
