### PR TITLE
Revert "Override Gutenberg side-effects (#42212)"

### DIFF
--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -179,24 +179,6 @@ const webpackConfig = {
 	},
 	module: {
 		rules: [
-			{
-				// Override side-effects for `@wordpress/blocks` while the package doesn't declare them.
-				// TODO: remove once we're using a version that declares side-effects.
-				test: /@wordpress\/blocks\/(src|build|build-module)\/api\//,
-				sideEffects: false,
-			},
-			{
-				// Override side-effects for `@wordpress/block-editor` while the package doesn't declare them.
-				// TODO: remove once we're using a version that declares side-effects.
-				test: /@wordpress\/block-editor\/(src|build|build-module)\/(components|utils)\//,
-				sideEffects: false,
-			},
-			{
-				// Override side-effects for `@wordpress/rich-text` while the package doesn't declare them.
-				// TODO: remove once we're using a version that declares side-effects.
-				test: /@wordpress\/rich-text\/(src|build|build-module)\/component\//,
-				sideEffects: false,
-			},
 			TranspileConfig.loader( {
 				workerCount,
 				configFile: path.resolve( 'babel.config.js' ),


### PR DESCRIPTION
This reverts commit ac7c0a50582e5c59afd55644f473e4107e39dfec.

The change was rebased after a Gutenberg upgrade and no longer works. Will need to investigate. Reverting in the meantime.

#### Changes proposed in this Pull Request

* Revert #42212

#### Testing instructions

Ensure `/new` loads correctly
