### PR TITLE
Gutenboarding: Use @wordpress/icons

### DIFF
--- a/client/landing/gutenboarding/components/domain-categories/index.tsx
+++ b/client/landing/gutenboarding/components/domain-categories/index.tsx
@@ -2,7 +2,8 @@
  * External dependencies
  */
 import * as React from 'react';
-import { Button, Icon } from '@wordpress/components';
+import { Button } from '@wordpress/components';
+import { Icon, chevronDown } from '@wordpress/icons';
 import classNames from 'classnames';
 import { useI18n } from '@automattic/react-i18n';
 import { useState } from '@wordpress/element';
@@ -39,7 +40,7 @@ const DomainPickerCategories: React.FunctionComponent< Props > = ( { onSelect, s
 				onClick={ () => setIsOpen( ! isOpen ) }
 			>
 				<span>{ ! selected ? __( 'All Categories' ) : selected }</span>
-				<Icon icon="arrow-down-alt2" size={ 12 }></Icon>
+				<Icon icon={ chevronDown } size={ 16 } />
 			</Button>
 			<ul className="domain-categories__item-group">
 				<li

--- a/client/landing/gutenboarding/components/domain-picker-button/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-button/index.tsx
@@ -2,8 +2,8 @@
  * External dependencies
  */
 import React, { createRef, FunctionComponent, useState } from 'react';
-import { Button, Dashicon } from '@wordpress/components';
-
+import { Button } from '@wordpress/components';
+import { Icon, chevronDown } from '@wordpress/icons';
 import classnames from 'classnames';
 
 /**
@@ -79,7 +79,7 @@ const DomainPickerButton: FunctionComponent< Props > = ( {
 				ref={ buttonRef }
 			>
 				<span className="domain-picker-button__label">{ children }</span>
-				<Dashicon icon="arrow-down-alt2" size={ 16 } />
+				<Icon icon={ chevronDown } size={ 22 } />
 			</Button>
 			<DomainPickerPopover
 				isOpen={ isDomainPopoverVisible }

--- a/client/landing/gutenboarding/components/domain-picker-button/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker-button/style.scss
@@ -51,12 +51,12 @@
 		text-overflow: ellipsis;
 	}
 
-	.dashicon {
-		margin-left: 0.5em;
+	svg {
+		margin-left: 0.2em;
 		transition: transform 100ms ease-in-out;
 	}
 
-	&.is-open .dashicon {
+	&.is-open svg {
 		transform: rotate( 180deg );
 	}
 

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 import { sprintf } from '@wordpress/i18n';
 import { useViewportMatch } from '@wordpress/compose';
 import { useI18n } from '@automattic/react-i18n';
-import { Icon } from '@wordpress/components';
+import { Icon, wordpress } from '@wordpress/icons';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useHistory } from 'react-router-dom';
 import classnames from 'classnames';
@@ -159,7 +159,7 @@ const Header: React.FunctionComponent = () => {
 			<section className="gutenboarding__header-section">
 				<div className="gutenboarding__header-section-item">
 					<div className="gutenboarding__header-wp-logo">
-						<Icon icon="wordpress-alt" size={ 24 } />
+						<Icon icon={ wordpress } size={ 28 } />
 					</div>
 				</div>
 				<div className="gutenboarding__header-section-item gutenboarding__header-site-title-section">

--- a/client/landing/gutenboarding/components/plans/plans-details/index.tsx
+++ b/client/landing/gutenboarding/components/plans/plans-details/index.tsx
@@ -3,7 +3,8 @@
  */
 import React from 'react';
 import { useI18n } from '@automattic/react-i18n';
-import { Icon } from '@wordpress/components';
+import { Path, SVG } from '@wordpress/primitives';
+import { Icon } from '@wordpress/icons';
 import { STORE_KEY as PLANS_STORE } from '../../../stores/plans';
 import { useSelect } from '@wordpress/data';
 
@@ -16,6 +17,12 @@ const PlansDetails: React.FunctionComponent = ( props ) => {
 	const plansDetails = useSelect( ( select ) => select( PLANS_STORE ).getPlansDetails() );
 
 	const { __ } = useI18n();
+
+	const checkIcon = (
+		<SVG width="20" height="20" viewBox="0 0 20 20">
+			<Path d="M10 2c-4.42 0-8 3.58-8 8s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8zm-.615 12.66h-1.34l-3.24-4.54 1.34-1.25 2.57 2.4 5.14-5.93 1.34.94-5.81 8.38z" />
+		</SVG>
+	);
 
 	return (
 		<div className="plans-details">
@@ -47,7 +54,7 @@ const PlansDetails: React.FunctionComponent = ( props ) => {
 												<>
 													{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
 													<span className="hidden">{ __( 'Available' ) }</span>
-													<Icon icon="yes-alt" />
+													<Icon icon={ checkIcon } size={ 20 } />
 												</>
 											) : (
 												<>

--- a/client/landing/gutenboarding/components/signup-form/header.tsx
+++ b/client/landing/gutenboarding/components/signup-form/header.tsx
@@ -2,7 +2,8 @@
  * External dependencies
  */
 import React from 'react';
-import { Button, Icon } from '@wordpress/components';
+import { Button } from '@wordpress/components';
+import { Icon, wordpress } from '@wordpress/icons';
 import { useI18n } from '@automattic/react-i18n';
 
 interface SignupFormHeaderProps {
@@ -35,7 +36,7 @@ const SignupFormHeader = ( { onRequestClose }: SignupFormHeaderProps ) => {
 		<div className="signup-form__header">
 			<div className="signup-form__header-section">
 				<div className="signup-form__header-section-item signup-form__header-wp-logo">
-					<Icon icon="wordpress-alt" size={ 24 } />
+					<Icon icon={ wordpress } size={ 28 } />
 				</div>
 			</div>
 

--- a/client/landing/gutenboarding/onboarding-block/create-site/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/create-site/index.tsx
@@ -4,7 +4,7 @@
 import * as React from 'react';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@automattic/react-i18n';
-import { Icon } from '@wordpress/components';
+import { Icon, wordpress } from '@wordpress/icons';
 import { useSelect } from '@wordpress/data';
 import { useInterval } from '../../../../lib/interval/use-interval';
 
@@ -63,7 +63,7 @@ const CreateSite: React.FunctionComponent = () => {
 			<div className="create-site__layout">
 				<div className="create-site__header">
 					<div className="gutenboarding__header-wp-logo">
-						<Icon icon="wordpress-alt" size={ 24 } />
+						<Icon icon={ wordpress } size={ 28 } />
 					</div>
 				</div>
 				<div className="create-site__content">

--- a/client/landing/gutenboarding/onboarding-block/style-preview/font-select.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/font-select.tsx
@@ -2,7 +2,8 @@
  * External dependencies
  */
 import * as React from 'react';
-import { Button, Dashicon } from '@wordpress/components';
+import { Button } from '@wordpress/components';
+import { Icon, chevronDown } from '@wordpress/icons';
 import classnames from 'classnames';
 import isShallowEqual from '@wordpress/is-shallow-equal';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -120,7 +121,7 @@ const FontSelect: React.FunctionComponent = () => {
 					>
 						<span className="style-preview__font-option-contents">
 							{ selectedFontOption }
-							<Dashicon icon="arrow-down-alt2" size={ 16 } />
+							<Icon icon={ chevronDown } size={ 22 } />
 						</span>
 					</Button>
 					<div

--- a/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
@@ -167,13 +167,13 @@
 	display: block;
 	margin-bottom: 28px;
 
-	.dashicon {
-		margin-left: 0.5em;
-		vertical-align: bottom;
+	svg {
+		margin-left: 0.2em;
+		vertical-align: middle;
 		transition: transform 100ms ease-in-out;
 	}
 
-	.is-open .dashicon {
+	.is-open svg {
 		transform: rotate( 180deg );
 	}
 

--- a/client/package.json
+++ b/client/package.json
@@ -56,6 +56,7 @@
 		"@wordpress/notices": "^2.1.0",
 		"@wordpress/nux": "^3.13.0",
 		"@wordpress/plugins": "^2.13.0",
+		"@wordpress/primitives": "^1.5.0",
 		"@wordpress/redux-routine": "^3.7.0",
 		"@wordpress/rich-text": "^3.13.0",
 		"@wordpress/server-side-render": "^1.9.0",


### PR DESCRIPTION
## Changes proposed in this Pull Request

Replace icons with `@wordpress/icons`.

### Screens

#### Header
after / before
![Screen Shot 2020-05-18 at 14 49 19](https://user-images.githubusercontent.com/841763/82215056-0d05c180-9917-11ea-8c64-783ee87d4b0d.png)

#### Create site

after / before
![Screen Shot 2020-05-18 at 14 49 52](https://user-images.githubusercontent.com/841763/82215066-1000b200-9917-11ea-9855-043742bf6e5c.png)

#### Signup header

 before / after
![Screen Shot 2020-05-18 at 16 59 20](https://user-images.githubusercontent.com/841763/82228139-0718dc00-9929-11ea-97d6-4a3e9fa12a1a.png)


#### Domain picker
after / before

![Screen Shot 2020-05-18 at 15 00 00](https://user-images.githubusercontent.com/841763/82215886-56a2dc00-9918-11ea-84f6-0f1904017bf4.png)


#### Domain categories mobile dropdown

after/before
![Screen Shot 2020-05-18 at 16 55 45](https://user-images.githubusercontent.com/841763/82227784-8c4fc100-9928-11ea-836b-926696e1088d.png)


#### Font selection mobile dropdown

after / before
![Screen Shot 2020-05-18 at 12 54 34](https://user-images.githubusercontent.com/841763/82205569-12f3a680-9907-11ea-81a3-603ea5972a27.png)


#### Plan details

##### before

![Screen Shot 2020-05-18 at 17 31 04](https://user-images.githubusercontent.com/841763/82231537-9aeca700-992d-11ea-9d43-0289b528e0bd.png)


##### after

![Screen Shot 2020-05-18 at 17 31 24](https://user-images.githubusercontent.com/841763/82231566-a17b1e80-992d-11ea-9aff-c0d11d036cda.png)

## Testing instructions

* [`/new`](https://calypso.live/new?branch=gutenboarding/wp-icons)
* *Seven* updates to icons were made here. Confirm they're working as expected (see screenshots):
  - General Header
  - Create site header
  - Signup header
  - Domain picker
  - Domain categories mobile dropdown
  - Font selection mobile dropdown
  - Plan details

