### PR TITLE
Run yarn before checking for yarn.lock dirtiness

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,7 @@ references:
     environment:
       PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: 'true'
     name: Install dependencies
-    command: CHROMEDRIVER_VERSION=$(<.chromedriver_version) yarn install
+    command: CHROMEDRIVER_VERSION=$(<.chromedriver_version) yarn install --frozen-lockfile
 
   save-yarn-cache: &save-yarn-cache
     name: 'Save yarn cache'
@@ -231,6 +231,7 @@ jobs:
           name: Lint yarn.lock
           when: always
           command: |
+            yarn
             DIRTY_FILES=$(git status --porcelain 2>/dev/null)
             if [[ ! -z "$DIRTY_FILES" ]]; then
               echo "Repository contains uncommitted changes: "

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,7 @@ references:
     environment:
       PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: 'true'
     name: Install dependencies
-    command: CHROMEDRIVER_VERSION=$(<.chromedriver_version) yarn install --frozen-lockfile
+    command: CHROMEDRIVER_VERSION=$(<.chromedriver_version) yarn install
 
   save-yarn-cache: &save-yarn-cache
     name: 'Save yarn cache'

--- a/yarn.lock
+++ b/yarn.lock
@@ -17358,7 +17358,7 @@ neo-async@^2.5.0, neo-async@^2.6.0, neo-async@^2.6.1:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.1.tgz#ac27ada66167fa8849a6addd837f6b189ad2081c"
   integrity sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==
 
-"newspack-blocks@github:Automattic/newspack-blocks#1.6.0":
+"newspack-blocks@github:Automattic/newspack-blocks#v1.6.0":
   version "1.6.0"
   resolved "https://codeload.github.com/Automattic/newspack-blocks/tar.gz/a82108db122cba23f07934a7d35a7b2362267fef"
   dependencies:


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Run`yarn` before checking for dirty `yarn.lock`. This will ensure that `yarn --frozen-lockfile` doesn't hide that `yarn.lock` is dirty.

* See https://github.com/Automattic/wp-calypso/pull/42031#issuecomment-629169455 and https://github.com/Automattic/wp-calypso/pull/42031#issuecomment-629171107 for an example where `yarn` produces a dirty `yarn.lock` but `yarn --frozen-lockfile` does not.
* Another example: checkout `3df32de5d6`, run `yarn --frozen-lockfile` (no changes in `yarn.lock`) and then `yarn` (changes in the file)

#### Testing instructions

* Verify tests still pass
