### PR TITLE
Strip text of its formatting on paste event

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
@@ -7,6 +7,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
 import { ENTER } from '@wordpress/keycodes';
 import { useI18n } from '@automattic/react-i18n';
+import EditableSpan from '../editable-span';
 
 /**
  * Internal dependencies
@@ -65,8 +66,7 @@ const SiteTitle: React.FunctionComponent< Props > = ( { isVisible, isMobile, onS
 			Input: (
 				<span className="site-title__input-wrapper">
 					{ ! isMobile && ' ' }
-					<span
-						contentEditable
+					<EditableSpan
 						data-hj-whitelist
 						tabIndex={ 0 }
 						role="textbox"

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
@@ -19,6 +19,7 @@ import { Verticals } from '@automattic/data-stores';
 import useTyper from '../../../hooks/use-typer';
 import Arrow from '../arrow';
 import { recordVerticalSelection } from '../../../lib/analytics';
+import EditableSpan from '../../editable-span';
 import type { SiteVertical } from '../../../stores/onboard/types';
 
 /**
@@ -210,8 +211,7 @@ const VerticalSelect: React.FunctionComponent< Props > = ( { onNext } ) => {
 							'vertical-select__input-wrapper--with-arrow': showArrow,
 						} ) }
 					>
-						<span
-							contentEditable
+						<EditableSpan
 							data-hj-whitelist
 							tabIndex={ 0 }
 							role="textbox"

--- a/client/landing/gutenboarding/onboarding-block/editable-span/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/editable-span/index.tsx
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import * as React from 'react';
+
+/**
+ * This is a paste event handler that strips the formatting then inserts the text
+ *
+ * @param event the paste event
+ */
+function stripFormatting( event: React.ClipboardEvent< HTMLSpanElement > ) {
+	event.preventDefault();
+	const text = event.clipboardData.getData( 'text/plain' );
+
+	// this puts the text in the right position (considers the caret position)
+	document.execCommand( 'insertHTML', false, text );
+}
+
+interface Props extends React.PropsWithoutRef< JSX.IntrinsicElements[ 'span' ] > {
+	allowFormattedPaste?: boolean;
+}
+
+export default React.forwardRef< HTMLSpanElement, Props >( function EditableSpan( props, ref ) {
+	const { allowFormattedPaste } = props;
+
+	if ( allowFormattedPaste ) {
+		return <span ref={ ref } contentEditable { ...props } />;
+	}
+	return <span ref={ ref } onPaste={ stripFormatting } contentEditable { ...props } />;
+} );


### PR DESCRIPTION
#### Testing instructions

1. Go to /new
2. Try to copy some rich text from a webpage such as this text. Then paste it in either site title or vertical name. The formatting of the page shouldn't change. 
3. Compare that to the behavior of http://wpcalypso.wordpress.com/new

Fixes https://github.com/Automattic/wp-calypso/issues/42117