### PR TITLE
Gutenboarding: fire vertical selection events correctly

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
@@ -132,6 +132,7 @@ const VerticalSelect: React.FunctionComponent< Props > = ( { onNext } ) => {
 		setIsFocused( false ); // prevent executing handleBlur()
 		// empty suggestions cache once a vertical is selceted
 		setSuggestions( [] );
+		recordVerticalSelection( vertical?.slug, vertical?.label );
 	};
 
 	const selectLastInputValue = () => {
@@ -184,9 +185,7 @@ const VerticalSelect: React.FunctionComponent< Props > = ( { onNext } ) => {
 	}, [] ); // eslint-disable-line react-hooks/exhaustive-deps
 
 	React.useEffect( () => {
-		const { slug, label } = siteVertical || {};
-		inputRef.current.innerText = label || '';
-		recordVerticalSelection( slug, label );
+		inputRef.current.innerText = siteVertical?.label || '';
 	}, [ siteVertical, inputRef ] );
 
 	React.useEffect( () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Fire vertical selection events only when user selects a new vertical.

#### Testing instructions
* Go to /new
* Enable tracks debugging
* When refreshing the page or when clearing the existing vertical value `calypso_newsite_vertical_selected` event should not be fired.
* When selecting a new vertical the event should fire as before.

Fixes p1589809679209900-slack-gutenboarding
