### PR TITLE
Jetpack Cloud: Revise 'find your credentials' copy on settings page

### DIFF
--- a/client/landing/jetpack-cloud/sections/settings/main.jsx
+++ b/client/landing/jetpack-cloud/sections/settings/main.jsx
@@ -40,7 +40,7 @@ class SettingsPage extends Component {
 		const content = isConnected
 			? translate( 'One-click restores are enabled.' )
 			: translate(
-					'Enter your server credentials to enable one-click restores for Backups. {{a}}Find your server credentials{{/a}}',
+					'Enter your server credentials to enable one-click restores for Backups. {{a}}Need help? Find your server credentials{{/a}}',
 					{
 						components: {
 							a: (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* On the Settings page, the copy for 'Find your credentials' has been revised to match feedback from our call for testing (see `p1HpG7-9a5#comment-39218`).

Fixes `1169345694087188-as-1175858234531553`

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Prerequisite: have (or create) a Jetpack site with no saved server credentials.
* Navigate to the Settings page on Jetpack Cloud for that site
* Verify that you see the 'not connected' banner, and that the link to find your credentials says `Need some help? Find your server credentials`

#### Screenshots (after)

<img width="707" alt="Screen Shot 2020-05-18 at 10 12 56" src="https://user-images.githubusercontent.com/670067/82230675-af12b300-98f1-11ea-8658-cc836c0377b6.png">
<img width="355" alt="Screen Shot 2020-05-18 at 10 19 10" src="https://user-images.githubusercontent.com/670067/82230677-af12b300-98f1-11ea-98ec-9d9f17af318e.png">

