### PR TITLE
Allow GSuite plans through CheckoutSystemDecider

### DIFF
--- a/client/my-sites/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout-system-decider.js
@@ -127,11 +127,6 @@ function shouldShowCompositeCheckout(
 		debug( 'shouldShowCompositeCheckout false because currency is not USD' );
 		return false;
 	}
-	// Disable for GSuite plans
-	if ( cart.products?.find( ( product ) => product.product_slug.includes( 'gapps' ) ) ) {
-		debug( 'shouldShowCompositeCheckout false because cart contains GSuite' );
-		return false;
-	}
 	// Disable for jetpack plans
 	if ( cart.products?.find( ( product ) => product.product_slug.includes( 'jetpack' ) ) ) {
 		debug( 'shouldShowCompositeCheckout false because cart contains jetpack' );

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-review.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-review.js
@@ -48,6 +48,7 @@ export default function WPCheckoutOrderReview( {
 					variantSelectOverride={ variantSelectOverride }
 					getItemVariants={ getItemVariants }
 					onChangePlanLength={ onChangePlanLength }
+					couponStatus={ couponStatus }
 				/>
 			</WPOrderReviewSection>
 

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
@@ -37,6 +37,7 @@ function WPLineItem( {
 	variantSelectOverride,
 	getItemVariants,
 	onChangePlanLength,
+	couponStatus,
 } ) {
 	const translate = useTranslate();
 	const hasDomainsInCart = useHasDomainsInCart();
@@ -76,9 +77,10 @@ function WPLineItem( {
 			) }
 			{ isGSuite && (
 				<LineItemMeta singleLine={ true }>
-					{ item.amount.value < item.wpcom_meta?.item_original_cost_integer && (
-						<DiscountCalloutUI>{ translate( 'Discount for first year' ) }</DiscountCalloutUI>
-					) }
+					{ item.amount.value < item.wpcom_meta?.item_original_cost_integer &&
+						couponStatus !== 'applied' && (
+							<DiscountCalloutUI>{ translate( 'Discount for first year' ) }</DiscountCalloutUI>
+						) }
 				</LineItemMeta>
 			) }
 			{ isGSuite && <GSuiteUsersList users={ item.wpcom_meta.extra.google_apps_users } /> }
@@ -153,6 +155,7 @@ WPLineItem.propTypes = {
 	} ),
 	getItemVariants: PropTypes.func,
 	onChangePlanLength: PropTypes.func,
+	couponStatus: PropTypes.bool,
 };
 
 function LineItemPrice( { item } ) {
@@ -273,6 +276,7 @@ export function WPOrderReviewLineItems( {
 	variantSelectOverride,
 	getItemVariants,
 	onChangePlanLength,
+	couponStatus,
 } ) {
 	return (
 		<WPOrderReviewList className={ joinClasses( [ className, 'order-review-line-items' ] ) }>
@@ -289,6 +293,7 @@ export function WPOrderReviewLineItems( {
 							variantSelectOverride={ variantSelectOverride }
 							getItemVariants={ getItemVariants }
 							onChangePlanLength={ onChangePlanLength }
+							couponStatus={ couponStatus }
 						/>
 					</WPOrderReviewListItem>
 				) ) }
@@ -311,6 +316,7 @@ WPOrderReviewLineItems.propTypes = {
 	),
 	getItemVariants: PropTypes.func,
 	onChangePlanLength: PropTypes.func,
+	couponStatus: PropTypes.bool,
 };
 
 const WPOrderReviewList = styled.ul`

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
@@ -76,7 +76,6 @@ function WPLineItem( {
 			) }
 			{ isGSuite && (
 				<LineItemMeta singleLine={ true }>
-					{ translate( 'billed annually' ) }
 					{ item.amount.value < item.wpcom_meta?.item_original_cost_integer && (
 						<DiscountCalloutUI>{ translate( 'Discount for first year' ) }</DiscountCalloutUI>
 					) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This modifies `CheckoutSystemDecider` so that shopping carts which contain GSuite products can be sent to composite checkout.

Requires #41705

#### Testing instructions

- Visit checkout after adding a GSuite product to your cart and verify that you see composite checkout. (Add `?flags=composite-checkout-testing` to your URL if your user is not in the ab test.)