### PR TITLE
Recurring Payments: Fix lifetime subscription UI

### DIFF
--- a/client/me/memberships/main.jsx
+++ b/client/me/memberships/main.jsx
@@ -31,48 +31,50 @@ import './main.scss';
  */
 import noMembershipsImage from 'assets/images/illustrations/no-memberships.svg';
 
-const MembershipListDate = ( { translate, subscription, moment } ) => {
-	let endDate = translate( 'Never Expires' );
-	let endDateFromNow = '-';
-	if ( subscription.end_date ) {
-		endDate = moment( subscription.end_date ).format( 'll' );
-		endDateFromNow = translate( 'Renews %s', { args: moment( subscription.end_date ).fromNow() } );
+const getMembershipEndDate = ( translate, endDate, moment ) => {
+	if ( ! endDate ) {
+		return translate( 'Never Expires' );
 	}
-
-	return (
-		<div className="memberships__list-date">
-			<div>{ endDate }</div>
-			<div className="memberships__list-sub">{ endDateFromNow }</div>
-		</div>
-	);
+	return moment( endDate ).format( 'll' );
 };
 
-const MembershipRenewalPrice = ( { translate, subscription } ) => {
-	const renewalPrice = formatCurrency( subscription.renewal_price, subscription.currency );
-	let renewalInterval = '-';
-	if ( subscription.renew_interval ) {
-		renewalInterval = translate( 'Every %s', { args: subscription.renew_interval } );
+const getMembershipEndDateFromNow = ( translate, endDate, moment ) => {
+	if ( ! endDate ) {
+		return '-';
 	}
+	return translate( 'Renews %s', { args: moment( endDate ).fromNow() } );
+};
 
-	return (
-		<div className="memberships__list-renewal-price">
-			<div className="memberships__list-amount">{ renewalPrice }</div>
-			<div className="memberships__list-sub">{ renewalInterval }</div>
-		</div>
-	);
+const getMembershipRenewalInterval = ( translate, renewalInterval ) => {
+	if ( ! renewalInterval ) {
+		return '-';
+	}
+	return translate( 'Every %s', { args: renewalInterval } );
 };
 
 const MembershipItem = ( { translate, subscription, moment } ) => (
 	<CompactCard key={ subscription.ID } href={ '/me/purchases/other/' + subscription.ID }>
 		<div className="memberships__list-subscription">
-			<MembershipListDate translate={ translate } subscription={ subscription } moment={ moment } />
+			<div className="memberships__list-date">
+				<div>{ getMembershipEndDate( translate, subscription.end_date, moment ) }</div>
+				<div className="memberships__list-sub">
+					{ getMembershipEndDateFromNow( translate, subscription.end_date, moment ) }
+				</div>
+			</div>
 			<div className="memberships__service-description">
 				<div className="memberships__service-name">{ subscription.title }</div>
 				<div className="memberships__list-sub">
 					{ translate( 'On %s', { args: subscription.site_title } ) }
 				</div>
 			</div>
-			<MembershipRenewalPrice translate={ translate } subscription={ subscription } />
+			<div className="memberships__list-renewal-price">
+				<div className="memberships__list-amount">
+					{ formatCurrency( subscription.renewal_price, subscription.currency ) }
+				</div>
+				<div className="memberships__list-sub">
+					{ getMembershipRenewalInterval( translate, subscription.renew_interval ) }
+				</div>
+			</div>
 		</div>
 	</CompactCard>
 );

--- a/client/me/memberships/main.jsx
+++ b/client/me/memberships/main.jsx
@@ -31,29 +31,48 @@ import './main.scss';
  */
 import noMembershipsImage from 'assets/images/illustrations/no-memberships.svg';
 
+const MembershipListDate = ( { translate, subscription, moment } ) => {
+	let endDate = translate( 'Never Expires' );
+	let endDateFromNow = '-';
+	if ( subscription.end_date ) {
+		endDate = moment( subscription.end_date ).format( 'll' );
+		endDateFromNow = translate( 'Renews %s', { args: moment( subscription.end_date ).fromNow() } );
+	}
+
+	return (
+		<div className="memberships__list-date">
+			<div>{ endDate }</div>
+			<div className="memberships__list-sub">{ endDateFromNow }</div>
+		</div>
+	);
+};
+
+const MembershipRenewalPrice = ( { translate, subscription } ) => {
+	const renewalPrice = formatCurrency( subscription.renewal_price, subscription.currency );
+	let renewalInterval = '-';
+	if ( subscription.renew_interval ) {
+		renewalInterval = translate( 'Every %s', { args: subscription.renew_interval } );
+	}
+
+	return (
+		<div className="memberships__list-renewal-price">
+			<div className="memberships__list-amount">{ renewalPrice }</div>
+			<div className="memberships__list-sub">{ renewalInterval }</div>
+		</div>
+	);
+};
+
 const MembershipItem = ( { translate, subscription, moment } ) => (
 	<CompactCard key={ subscription.ID } href={ '/me/purchases/other/' + subscription.ID }>
 		<div className="memberships__list-subscription">
-			<div className="memberships__list-date">
-				<div>{ moment( subscription.end_date ).format( 'll' ) }</div>
-				<div className="memberships__list-sub">
-					{ translate( 'Renews %s', { args: moment( subscription.end_date ).fromNow() } ) }
-				</div>
-			</div>
+			<MembershipListDate translate={ translate } subscription={ subscription } moment={ moment } />
 			<div className="memberships__service-description">
 				<div className="memberships__service-name">{ subscription.title }</div>
 				<div className="memberships__list-sub">
 					{ translate( 'On %s', { args: subscription.site_title } ) }
 				</div>
 			</div>
-			<div className="memberships__list-renewal-price">
-				<div className="memberships__list-amount">
-					{ formatCurrency( subscription.renewal_price, subscription.currency ) }
-				</div>
-				<div className="memberships__list-sub">
-					{ translate( 'Every %s', { args: subscription.renew_interval } ) }
-				</div>
-			</div>
+			<MembershipRenewalPrice translate={ translate } subscription={ subscription } />
 		</div>
 	</CompactCard>
 );

--- a/client/me/memberships/subscription.jsx
+++ b/client/me/memberships/subscription.jsx
@@ -34,6 +34,7 @@ class Subscription extends React.Component {
 
 	render() {
 		const { translate, subscription, moment, stoppingStatus } = this.props;
+
 		return (
 			<Main className="memberships__subscription">
 				<DocumentHead title={ translate( 'Other Sites' ) } />
@@ -83,7 +84,7 @@ class Subscription extends React.Component {
 											{ translate( 'Renew interval' ) }
 										</em>
 										<span className="memberships__subscription-inner-detail">
-											{ subscription.renew_interval }
+											{ subscription.renew_interval || '-' }
 										</span>
 									</li>
 									<li>
@@ -99,7 +100,9 @@ class Subscription extends React.Component {
 											{ translate( 'Renews on' ) }
 										</em>
 										<span className="memberships__subscription-inner-detail">
-											{ moment( subscription.end_date ).format( 'll' ) }
+											{ subscription.end_date
+												? moment( subscription.end_date ).format( 'll' )
+												: translate( 'Never Expires' ) }
 										</span>
 									</li>
 								</ul>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix UI to handle one-time payments for lifetime subscriptions (available on Longreads).

The issue is that the UI on calypso is expecting an active subscription to have an end date and a renewal interval. For users that signed up for a lifetime subscription, there is no end date or renewal interval and when the UI looks like this;

[](https://cdn-std.droplr.net/files/acc_854234/Azd4J0)

#### Testing instructions

* Use SSP with the account user ID - 1114877
* Go to http://calypso.localhost:3000/me/purchases/other
* Verify the UI makes sense
* Click on the subscription to bring you to http://calypso.localhost:3000/me/purchases/other/19561319
* Verify the UI makes sense

