### PR TITLE
Jetpack Cloud: reset server credentials form state on selected site change

### DIFF
--- a/client/landing/jetpack-cloud/components/with-server-credentials-form/index.jsx
+++ b/client/landing/jetpack-cloud/components/with-server-credentials-form/index.jsx
@@ -16,6 +16,16 @@ import getJetpackCredentialsUpdateStatus from 'state/selectors/get-jetpack-crede
 import getRewindState from 'state/selectors/get-rewind-state';
 import QueryRewindState from 'components/data/query-rewind-state';
 
+const INITIAL_FORM_STATE = {
+	protocol: 'ssh',
+	host: '',
+	port: 22,
+	user: '',
+	pass: '',
+	path: '',
+	kpri: '',
+};
+
 function withServerCredentialsForm( WrappedComponent ) {
 	const ServerCredentialsFormClass = class ServerCredentialsForm extends Component {
 		static propTypes = {
@@ -32,15 +42,7 @@ function withServerCredentialsForm( WrappedComponent ) {
 		};
 
 		state = {
-			form: {
-				protocol: 'ssh',
-				host: '',
-				port: 22,
-				user: '',
-				pass: '',
-				path: '',
-				kpri: '',
-			},
+			form: INITIAL_FORM_STATE,
 			formErrors: {
 				host: false,
 				port: false,
@@ -110,7 +112,11 @@ function withServerCredentialsForm( WrappedComponent ) {
 		UNSAFE_componentWillReceiveProps( nextProps ) {
 			const { rewindState, role, siteSlug } = nextProps;
 			const credentials = find( rewindState.credentials, { role: role } );
-			const nextForm = Object.assign( {}, this.state.form );
+			const siteHasChanged = this.props.siteId !== nextProps.siteId;
+			const nextForm = Object.assign(
+				{},
+				siteHasChanged ? { ...INITIAL_FORM_STATE } : this.state.form
+			);
 
 			// Populate the fields with data from state if credentials are already saved
 			nextForm.protocol = credentials ? credentials.type : nextForm.protocol;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Reset the form state every time the selected site has changed.

#### Testing instructions

* Prerequisite: have at least two sites available to choose from
* Go to `http://jetpack.cloud.localhost:3000/`
* Select any site from the site selector
* Go to Settings
* Verify the form is completed with the right information (server address, port number, server username, etc.)
* Go to the site selector and choose another site
* Verify the form information has been updated and matches the new selected site information

Fixes 1169345694087188-as-1173222819931609

#### Demo
![Kapture 2020-05-18 at 16 00 06](https://user-images.githubusercontent.com/3418513/82250439-d7b2a100-9921-11ea-9319-a657f0e2bfa1.gif)

