### PR TITLE
composite-checkout: Convert full credits payment method to use processor function

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -62,7 +62,11 @@ import { useStripe } from 'lib/stripe';
 import CheckoutTerms from '../checkout/checkout-terms.jsx';
 import useShowStripeLoadingErrors from './use-show-stripe-loading-errors';
 import useCreatePaymentMethods from './use-create-payment-methods';
-import { applePayProcessor, stripeCardProcessor } from './payment-method-processors';
+import {
+	applePayProcessor,
+	stripeCardProcessor,
+	fullCreditsProcessor,
+} from './payment-method-processors';
 import { useGetThankYouUrl } from './use-get-thank-you-url';
 import createAnalyticsEventHandler from './record-analytics';
 import createContactValidationCallback from './contact-validation';
@@ -384,7 +388,11 @@ export default function CompositeCheckout( {
 	);
 
 	const paymentProcessors = useMemo(
-		() => ( { 'apple-pay': applePayProcessor, card: stripeCardProcessor } ),
+		() => ( {
+			'apple-pay': applePayProcessor,
+			card: stripeCardProcessor,
+			'full-credits': fullCreditsProcessor,
+		} ),
 		[]
 	);
 

--- a/client/my-sites/checkout/composite-checkout/payment-method-processors.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-processors.js
@@ -11,6 +11,7 @@ import {
 	wpcomTransaction,
 	submitApplePayPayment,
 	submitStripeCardTransaction,
+	submitCreditsTransaction,
 } from './payment-method-helpers';
 import { createStripePaymentMethod } from 'lib/stripe';
 
@@ -69,4 +70,24 @@ function createStripePaymentMethodToken( { stripe, name, country, postalCode } )
 			postal_code: postalCode,
 		},
 	} );
+}
+
+export async function fullCreditsProcessor( submitData ) {
+	const pending = submitCreditsTransaction(
+		{
+			...submitData,
+			siteId: select( 'wpcom' )?.getSiteId?.(),
+			domainDetails: getDomainDetails( select ),
+			// this data is intentionally empty so we do not charge taxes
+			country: null,
+			postalCode: null,
+		},
+		wpcomTransaction
+	);
+	// save result so we can get receipt_id and failed_purchases in getThankYouPageUrl
+	pending.then( ( result ) => {
+		// TODO: do this automatically when calling setTransactionComplete
+		dispatch( 'wpcom' ).setTransactionResponse( result );
+	} );
+	return pending;
 }

--- a/client/my-sites/checkout/composite-checkout/use-create-payment-methods.js
+++ b/client/my-sites/checkout/composite-checkout/use-create-payment-methods.js
@@ -24,7 +24,6 @@ import {
 	wpcomPayPalExpress,
 	getDomainDetails,
 	wpcomTransaction,
-	submitCreditsTransaction,
 	WordPressCreditsLabel,
 	WordPressCreditsSummary,
 	submitFreePurchaseTransaction,
@@ -121,28 +120,7 @@ function useCreateFullCredits( { onlyLoadPaymentMethods, credits } ) {
 		if ( ! shouldLoadFullCreditsMethod ) {
 			return null;
 		}
-		return createFullCreditsMethod( {
-			registerStore,
-			submitTransaction: ( submitData ) => {
-				const pending = submitCreditsTransaction(
-					{
-						...submitData,
-						siteId: select( 'wpcom' )?.getSiteId?.(),
-						domainDetails: getDomainDetails( select ),
-						// this data is intentionally empty so we do not charge taxes
-						country: null,
-						postalCode: null,
-					},
-					wpcomTransaction
-				);
-				// save result so we can get receipt_id and failed_purchases in getThankYouPageUrl
-				pending.then( ( result ) => {
-					debug( 'saving transaction response', result );
-					dispatch( 'wpcom' ).setTransactionResponse( result );
-				} );
-				return pending;
-			},
-		} );
+		return createFullCreditsMethod();
 	}, [ shouldLoadFullCreditsMethod ] );
 	if ( fullCreditsPaymentMethod ) {
 		fullCreditsPaymentMethod.label = <WordPressCreditsLabel credits={ credits } />;

--- a/packages/composite-checkout/src/lib/payment-methods/full-credits.js
+++ b/packages/composite-checkout/src/lib/payment-methods/full-credits.js
@@ -9,8 +9,8 @@ import debugFactory from 'debug';
  */
 import Button from '../../components/button';
 import {
-	useSelect,
-	useDispatch,
+	useTransactionStatus,
+	usePaymentProcessor,
 	useMessages,
 	useLineItems,
 	useEvents,
@@ -21,66 +21,7 @@ import { useFormStatus } from '../form-status';
 
 const debug = debugFactory( 'composite-checkout:full-credits-payment-method' );
 
-export function createFullCreditsMethod( { registerStore, submitTransaction } ) {
-	const actions = {
-		*beginCreditsTransaction( payload ) {
-			let response;
-			try {
-				response = yield {
-					type: 'FULL_CREDITS_TRANSACTION_BEGIN',
-					payload,
-				};
-				debug( 'full credits transaction complete', response );
-			} catch ( error ) {
-				debug( 'full credits transaction had an error', error.message );
-				return { type: 'FULL_CREDITS_TRANSACTION_ERROR', payload: error.message };
-			}
-			debug( 'full credits transaction requires is successful' );
-			return { type: 'FULL_CREDITS_TRANSACTION_END', payload: response };
-		},
-	};
-
-	const selectors = {
-		getTransactionError( state ) {
-			return state.transactionError;
-		},
-		getTransactionStatus( state ) {
-			return state.transactionStatus;
-		},
-	};
-
-	registerStore( 'full-credits', {
-		reducer(
-			state = {
-				transactionStatus: null,
-				transactionError: null,
-			},
-			action
-		) {
-			switch ( action.type ) {
-				case 'FULL_CREDITS_TRANSACTION_END':
-					return {
-						...state,
-						transactionStatus: 'complete',
-					};
-				case 'FULL_CREDITS_TRANSACTION_ERROR':
-					return {
-						...state,
-						transactionStatus: 'error',
-						transactionError: action.payload,
-					};
-			}
-			return state;
-		},
-		actions,
-		selectors,
-		controls: {
-			FULL_CREDITS_TRANSACTION_BEGIN( action ) {
-				return submitTransaction( action.payload );
-			},
-		},
-	} );
-
+export function createFullCreditsMethod() {
 	return {
 		id: 'full-credits',
 		label: <FullCreditsLabel />,
@@ -103,17 +44,12 @@ function FullCreditsLabel() {
 
 function FullCreditsSubmitButton( { disabled } ) {
 	const localize = useLocalize();
-	const { beginCreditsTransaction } = useDispatch( 'full-credits' );
 	const [ items, total ] = useLineItems();
-	const transactionStatus = useSelect( ( select ) =>
-		select( 'full-credits' ).getTransactionStatus()
-	);
-	const transactionError = useSelect( ( select ) =>
-		select( 'full-credits' ).getTransactionError()
-	);
+	const { transactionStatus, transactionError } = useTransactionStatus();
 	const { showErrorMessage } = useMessages();
 	const { formStatus, setFormReady, setFormComplete, setFormSubmitting } = useFormStatus();
 	const onEvent = useEvents();
+	const submitTransaction = usePaymentProcessor( 'full-credits' );
 
 	useEffect( () => {
 		if ( transactionStatus === 'error' ) {
@@ -140,7 +76,7 @@ function FullCreditsSubmitButton( { disabled } ) {
 	const onClick = () => {
 		setFormSubmitting();
 		onEvent( { type: 'FULL_CREDITS_TRANSACTION_BEGIN' } );
-		beginCreditsTransaction( {
+		submitTransaction( {
 			items,
 		} );
 	};

--- a/packages/composite-checkout/src/lib/payment-methods/full-credits.js
+++ b/packages/composite-checkout/src/lib/payment-methods/full-credits.js
@@ -45,7 +45,12 @@ function FullCreditsLabel() {
 function FullCreditsSubmitButton( { disabled } ) {
 	const localize = useLocalize();
 	const [ items, total ] = useLineItems();
-	const { transactionStatus, transactionError } = useTransactionStatus();
+	const {
+		transactionStatus,
+		transactionError,
+		setTransactionComplete,
+		setTransactionError,
+	} = useTransactionStatus();
 	const { showErrorMessage } = useMessages();
 	const { formStatus, setFormReady, setFormComplete, setFormSubmitting } = useFormStatus();
 	const onEvent = useEvents();
@@ -78,7 +83,17 @@ function FullCreditsSubmitButton( { disabled } ) {
 		onEvent( { type: 'FULL_CREDITS_TRANSACTION_BEGIN' } );
 		submitTransaction( {
 			items,
-		} );
+		} )
+			.then( () => {
+				setTransactionComplete();
+			} )
+			.catch( ( error ) => {
+				// TODO: do these things automatically
+				setTransactionError( error.message );
+				setFormReady();
+				onEvent( { type: 'FULL_CREDITS_TRANSACTION_ERROR', payload: error.message } );
+				showErrorMessage( error.message );
+			} );
 	};
 
 	return (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This updates the `full-credits` payment method to use the payment processor function system added in #41767 

#### Testing instructions

- Attempt a purchase using composite checkout when you have sufficient credits to cover the entire transaction.
- Verify that the transaction completes successfully.