### PR TITLE
Lasagna: fix middleware topic TypeError

### DIFF
--- a/client/state/lasagna/post-channel/middleware.js
+++ b/client/state/lasagna/post-channel/middleware.js
@@ -87,17 +87,26 @@ export default ( store ) => ( next ) => ( action ) => {
 	switch ( action.type ) {
 		case READER_VIEWING_FULL_POST_SET: {
 			const joinParams = getJoinParams( store, action.postKey );
-			if ( joinParams ) {
-				joinChannel( store, joinParams );
+			if ( ! joinParams ) {
+				return false;
 			}
+
+			joinChannel( store, joinParams );
 			break;
 		}
 
 		case READER_VIEWING_FULL_POST_UNSET: {
-			const topic = getTopic( getJoinParams( store, action.postKey ) );
-			if ( topic ) {
-				leaveChannel( topic );
+			const joinParams = getJoinParams( store, action.postKey );
+			if ( ! joinParams ) {
+				return false;
 			}
+
+			const topic = getTopic( joinParams );
+			if ( ! topic ) {
+				return false;
+			}
+
+			leaveChannel( topic );
 			break;
 		}
 	}


### PR DESCRIPTION
In certain unload conditions, certain posts, that return empty `getSite` against Redux state, can induce a TypeError.

#### Changes proposed in this Pull Request

* Guard against Reader situations where `site` does not exist during unload.

#### Testing instructions

On `master`:

1. Load an RSS only post in the Reader full view post.
2. Hard refresh it.
3. Click "Reader" in the nav at the top left a couple times.

You should see a `TypeError` in your browser console.

Now do the same on this branch.

You show see normal loads as you'd expect.