### PR TITLE
composite-checkout: Clean up type errors

### DIFF
--- a/client/my-sites/checkout/composite-checkout/wpcom/test/wpcom-store-state.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/test/wpcom-store-state.ts
@@ -4,6 +4,7 @@
 import {
 	ManagedContactDetailsShape,
 	updateManagedContactDetailsShape,
+	mapManagedContactDetailsShape,
 	flattenManagedContactDetailsShape,
 } from '../types/wpcom-store-state';
 
@@ -210,6 +211,133 @@ describe( 'updateManagedContactDetailsShape', function () {
 			getRandomBoolean() ? undefined : getRandomInt( 0, 10 )
 		);
 		testProperty( merge, construct, update, data );
+	} );
+} );
+
+describe( 'mapManagedContactDetailsShape', function () {
+	const testPropertyWithAccessor = ( f, data ) => ( accessor ) => {
+		const value = get( mapManagedContactDetailsShape( f, data ), accessor );
+		if ( get( data, accessor ) !== undefined ) {
+			it( 'data.A is defined at ' + accessor, function () {
+				expect( value ).toEqual( f( get( data, accessor ) ) );
+			} );
+		} else if ( get( data, accessor ) === undefined ) {
+			it( 'data.A is undefined at ' + accessor, function () {
+				expect( value ).toBeUndefined();
+			} );
+		} else {
+			throw new Error( 'testPropertyWithAccessor: this case should be unreachable.' );
+		}
+		return true;
+	};
+
+	const accessors = [
+		'firstName',
+		'lastName',
+		'organization',
+		'email',
+		'alternateEmail',
+		'phone',
+		'phoneNumberCountry',
+		'address1',
+		'address2',
+		'city',
+		'state',
+		'postalCode',
+		'countryCode',
+		'fax',
+		'vatId',
+		'extra.ca.lang',
+		'extra.ca.legalType',
+		'extra.ca.ciraAgreementAccepted',
+		'extra.uk.registrantType',
+		'extra.uk.registrationNumber',
+		'extra.uk.tradingName',
+		'extra.fr.registrantType',
+		'extra.fr.trademarkNumber',
+		'extra.fr.sirenSiret',
+	];
+
+	const testProperty = ( f, data ) => {
+		expect( accessors.map( testPropertyWithAccessor( f, data ) ).every( ( x ) => x ) ).toBeTruthy();
+	};
+
+	function getRandomBoolean( prob ): boolean {
+		return Math.random() >= ( prob ?? 0.5 );
+	}
+
+	function getRandomInt( min, max ): number {
+		return Math.floor( Math.random() * ( max - min ) ) + min;
+	}
+
+	// The property should be satisfied for _all_ data, so we check it for arbitrary data.
+	const arbitraryData: ( gen: () => T ) => ManagedContactDetailsShape< T > = ( gen ) => {
+		const data = {
+			firstName: gen(),
+			lastName: gen(),
+			organization: gen(),
+			email: gen(),
+			alternateEmail: gen(),
+			phone: gen(),
+			phoneNumberCountry: gen(),
+			address1: gen(),
+			address2: gen(),
+			city: gen(),
+			state: gen(),
+			postalCode: gen(),
+			countryCode: gen(),
+			fax: gen(),
+			vatId: gen(),
+			tldExtraFields: {},
+		};
+
+		if ( getRandomBoolean() ) {
+			data.tldExtraFields.ca = {
+				lang: gen(),
+				legalType: gen(),
+				ciraAgreementAccepted: gen(),
+			};
+		}
+		if ( getRandomBoolean() ) {
+			data.tldExtraFields.uk = {
+				registrantType: gen(),
+				registrationNumber: gen(),
+				tradingName: gen(),
+			};
+		}
+		if ( getRandomBoolean() ) {
+			data.tldExtraFields.fr = {
+				registrantType: gen(),
+				trademarkNumber: gen(),
+				sirenSiret: gen(),
+			};
+		}
+
+		return data;
+	};
+
+	describe( 'with data:number', function () {
+		// arbitrarily chosen function
+		const m = getRandomInt( -10, 10 );
+		const b = getRandomInt( -10, 10 );
+		const f: ( arg0: number ) => number = ( arg0 ) => {
+			return m * arg0 + b;
+		};
+		const data: ManagedContactDetailsShape< number > = arbitraryData( () => getRandomInt( 0, 10 ) );
+		testProperty( f, data );
+	} );
+
+	describe( 'with update:boolean and data:(number | undefined)', function () {
+		// arbitrarily chosen function
+		const m = getRandomInt( -10, 10 );
+		const b = getRandomInt( -10, 10 );
+		const f: ( arg0: number ) => number = ( arg0 ) => {
+			return m * arg0 + b;
+		};
+		const data: ManagedContactDetailsShape< number > = arbitraryData( () =>
+			getRandomBoolean() ? undefined : getRandomInt( 0, 10 )
+		);
+		testProperty( f, data );
 	} );
 } );
 

--- a/client/my-sites/checkout/composite-checkout/wpcom/types/backend/domain-contact-validation-endpoint.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/types/backend/domain-contact-validation-endpoint.ts
@@ -6,21 +6,21 @@
 export type DomainContactValidationRequest = {
 	domain_names: string[];
 	contact_information: {
-		firstName: string;
-		lastName: string;
-		organization: string;
-		email: string;
-		alternateEmail: string;
-		phone: string;
-		phoneNumberCountry: string;
-		address1: string;
-		address2: string;
-		city: string;
-		state: string;
-		postalCode: string;
-		countryCode: string;
-		fax: string;
-		vatId: string;
+		firstName?: string;
+		lastName?: string;
+		organization?: string;
+		email?: string;
+		alternateEmail?: string;
+		phone?: string;
+		phoneNumberCountry?: string;
+		address1?: string;
+		address2?: string;
+		city?: string;
+		state?: string;
+		postalCode?: string;
+		countryCode?: string;
+		fax?: string;
+		vatId?: string;
 		extra?: DomainContactValidationRequestExtraFields;
 	};
 };
@@ -37,20 +37,20 @@ export type GSuiteContactValidationRequest = {
 
 export type DomainContactValidationRequestExtraFields = {
 	ca?: {
-		lang: string;
-		legal_type: string;
-		cira_agreement_accepted: boolean;
+		lang?: string;
+		legal_type?: string;
+		cira_agreement_accepted?: boolean;
 	};
 	uk?: {
-		registrant_type: string;
-		registration_number: string;
-		trading_name: string;
+		registrant_type?: string;
+		registration_number?: string;
+		trading_name?: string;
 	};
 	fr?: {
-		registrant_type: string;
-		registrant_vat_id: string;
-		trademark_number: string;
-		siren_siret: string;
+		registrant_type?: string;
+		registrant_vat_id?: string;
+		trademark_number?: string;
+		siren_siret?: string;
 	};
 };
 

--- a/client/my-sites/checkout/composite-checkout/wpcom/types/wpcom-store-state.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/types/wpcom-store-state.ts
@@ -20,39 +20,39 @@ import {
 } from './backend/domain-contact-validation-endpoint';
 
 export type ManagedContactDetailsShape< T > = {
-	firstName: T;
-	lastName: T;
-	organization: T;
-	email: T;
-	alternateEmail: T;
-	phone: T;
-	phoneNumberCountry: T;
-	address1: T;
-	address2: T;
-	city: T;
-	state: T;
-	postalCode: T;
-	countryCode: T;
-	fax: T;
-	vatId: T;
-	tldExtraFields: ManagedContactDetailsTldExtraFieldsShape< T >;
+	firstName?: T;
+	lastName?: T;
+	organization?: T;
+	email?: T;
+	alternateEmail?: T;
+	phone?: T;
+	phoneNumberCountry?: T;
+	address1?: T;
+	address2?: T;
+	city?: T;
+	state?: T;
+	postalCode?: T;
+	countryCode?: T;
+	fax?: T;
+	vatId?: T;
+	tldExtraFields?: ManagedContactDetailsTldExtraFieldsShape< T >;
 };
 
 type ManagedContactDetailsTldExtraFieldsShape< T > = {
 	ca?: {
-		lang: T;
-		legalType: T;
-		ciraAgreementAccepted: T;
+		lang?: T;
+		legalType?: T;
+		ciraAgreementAccepted?: T;
 	};
 	uk?: {
-		registrantType: T;
-		registrationNumber: T;
-		tradingName: T;
+		registrantType?: T;
+		registrationNumber?: T;
+		tradingName?: T;
 	};
 	fr?: {
-		registrantType: T;
-		trademarkNumber: T;
-		sirenSiret: T;
+		registrantType?: T;
+		trademarkNumber?: T;
+		sirenSiret?: T;
 	};
 };
 
@@ -76,13 +76,13 @@ type ManagedContactDetailsTldExtraFieldsShape< T > = {
  */
 export function updateManagedContactDetailsShape< A, B >(
 	merge: ( arg0: A, arg1: B ) => B,
-	construct: ( arg0: A ) => B,
+	construct: ( arg0: A | undefined ) => B | undefined,
 	update: ManagedContactDetailsShape< A >,
 	data: ManagedContactDetailsShape< B >
 ): ManagedContactDetailsShape< B > {
 	const tldExtraFields: ManagedContactDetailsTldExtraFieldsShape< B > = {};
 
-	const combine = ( u, v ) => {
+	const combine = ( u: A | undefined, v: B | undefined ): B | undefined => {
 		if ( typeof u !== 'undefined' && typeof v !== 'undefined' ) {
 			return merge( u, v );
 		} else if ( typeof u !== 'undefined' && typeof v === 'undefined' ) {
@@ -193,48 +193,52 @@ export function flattenManagedContactDetailsShape< A, B >(
 	x: ManagedContactDetailsShape< A >
 ): Array< B > {
 	const values = [
-		f( x.firstName ),
-		f( x.lastName ),
-		f( x.organization ),
-		f( x.email ),
-		f( x.alternateEmail ),
-		f( x.phone ),
-		f( x.phoneNumberCountry ),
-		f( x.address1 ),
-		f( x.address2 ),
-		f( x.city ),
-		f( x.state ),
-		f( x.postalCode ),
-		f( x.countryCode ),
-		f( x.fax ),
-		f( x.vatId ),
-	];
+		x.firstName ? f( x.firstName ) : null,
+		x.lastName ? f( x.lastName ) : null,
+		x.organization ? f( x.organization ) : null,
+		x.email ? f( x.email ) : null,
+		x.alternateEmail ? f( x.alternateEmail ) : null,
+		x.phone ? f( x.phone ) : null,
+		x.phoneNumberCountry ? f( x.phoneNumberCountry ) : null,
+		x.address1 ? f( x.address1 ) : null,
+		x.address2 ? f( x.address2 ) : null,
+		x.city ? f( x.city ) : null,
+		x.state ? f( x.state ) : null,
+		x.postalCode ? f( x.postalCode ) : null,
+		x.countryCode ? f( x.countryCode ) : null,
+		x.fax ? f( x.fax ) : null,
+		x.vatId ? f( x.vatId ) : null,
+	].filter( Boolean ) as B[];
 
 	const caValues =
 		x.tldExtraFields && x.tldExtraFields.ca
-			? [
-					f( x.tldExtraFields.ca.lang ),
-					f( x.tldExtraFields.ca.legalType ),
-					f( x.tldExtraFields.ca.ciraAgreementAccepted ),
-			  ]
+			? ( [
+					x.tldExtraFields.ca.lang ? f( x.tldExtraFields.ca.lang ) : null,
+					x.tldExtraFields.ca.legalType ? f( x.tldExtraFields.ca.legalType ) : null,
+					x.tldExtraFields.ca.ciraAgreementAccepted
+						? f( x.tldExtraFields.ca.ciraAgreementAccepted )
+						: null,
+			  ].filter( Boolean ) as B[] )
 			: [];
 
 	const ukValues =
 		x.tldExtraFields && x.tldExtraFields.uk
-			? [
-					f( x.tldExtraFields.uk.registrantType ),
-					f( x.tldExtraFields.uk.registrationNumber ),
-					f( x.tldExtraFields.uk.tradingName ),
-			  ]
+			? ( [
+					x.tldExtraFields.uk.registrantType ? f( x.tldExtraFields.uk.registrantType ) : null,
+					x.tldExtraFields.uk.registrationNumber
+						? f( x.tldExtraFields.uk.registrationNumber )
+						: null,
+					x.tldExtraFields.uk.tradingName ? f( x.tldExtraFields.uk.tradingName ) : null,
+			  ].filter( Boolean ) as B[] )
 			: [];
 
 	const frValues =
 		x.tldExtraFields && x.tldExtraFields.fr
-			? [
-					f( x.tldExtraFields.fr.registrantType ),
-					f( x.tldExtraFields.fr.trademarkNumber ),
-					f( x.tldExtraFields.fr.sirenSiret ),
-			  ]
+			? ( [
+					x.tldExtraFields.fr.registrantType ? f( x.tldExtraFields.fr.registrantType ) : null,
+					x.tldExtraFields.fr.trademarkNumber ? f( x.tldExtraFields.fr.trademarkNumber ) : null,
+					x.tldExtraFields.fr.sirenSiret ? f( x.tldExtraFields.fr.sirenSiret ) : null,
+			  ].filter( Boolean ) as B[] )
 			: [];
 
 	return values.concat( caValues, ukValues, frValues );
@@ -252,7 +256,7 @@ export type ManagedContactDetailsErrors = ManagedContactDetailsShape< undefined 
 /*
  * Intermediate type used to represent update payloads
  */
-type ManagedContactDetailsUpdate = ManagedContactDetailsShape< undefined | string >;
+type ManagedContactDetailsUpdate = ManagedContactDetailsShape< string >;
 
 /*
  * Different subsets of the details are mandatory depending on what is
@@ -297,13 +301,17 @@ function touchField( oldData: ManagedValue ): ManagedValue {
 	return { ...oldData, isTouched: true };
 }
 
-function touchIfDifferent( newValue: undefined | string, oldData: ManagedValue ): ManagedValue {
-	if ( newValue === undefined ) {
+function touchIfDifferent(
+	newValue: undefined | string,
+	oldData: ManagedValue | undefined
+): ManagedValue {
+	if ( newValue === undefined && oldData !== undefined ) {
 		return oldData;
 	}
-	return newValue === oldData.value
-		? oldData
-		: { ...oldData, value: newValue, isTouched: true, errors: [] };
+	if ( oldData !== undefined && newValue === oldData.value ) {
+		return oldData;
+	}
+	return { isRequired: false, ...oldData, value: newValue ?? '', isTouched: true, errors: [] };
 }
 
 function setValueUnlessTouched(
@@ -362,19 +370,19 @@ export function prepareDomainContactDetails(
 	details: ManagedContactDetails
 ): DomainContactDetails {
 	return {
-		firstName: details.firstName.value,
-		lastName: details.lastName.value,
-		organization: details.organization.value,
-		email: details.email.value,
-		alternateEmail: details.alternateEmail.value,
-		phone: details.phone.value,
-		address1: details.address1.value,
-		address2: details.address2.value,
-		city: details.city.value,
-		state: details.state.value,
-		postalCode: details.postalCode.value,
-		countryCode: details.countryCode.value,
-		fax: details.fax.value,
+		firstName: details.firstName?.value,
+		lastName: details.lastName?.value,
+		organization: details.organization?.value,
+		email: details.email?.value,
+		alternateEmail: details.alternateEmail?.value,
+		phone: details.phone?.value,
+		address1: details.address1?.value,
+		address2: details.address2?.value,
+		city: details.city?.value,
+		state: details.state?.value,
+		postalCode: details.postalCode?.value,
+		countryCode: details.countryCode?.value,
+		fax: details.fax?.value,
 		extra: prepareTldExtraContactDetails( details ),
 	};
 }
@@ -383,19 +391,19 @@ export function prepareDomainContactDetailsErrors(
 	details: ManagedContactDetails
 ): DomainContactDetailsErrors {
 	return {
-		firstName: details.firstName.errors[ 0 ],
-		lastName: details.lastName.errors[ 0 ],
-		organization: details.organization.errors[ 0 ],
-		email: details.email.errors[ 0 ],
-		alternateEmail: details.alternateEmail.errors[ 0 ],
-		phone: details.phone.errors[ 0 ],
-		address1: details.address1.errors[ 0 ],
-		address2: details.address2.errors[ 0 ],
-		city: details.city.errors[ 0 ],
-		state: details.state.errors[ 0 ],
-		postalCode: details.postalCode.errors[ 0 ],
-		countryCode: details.countryCode.errors[ 0 ],
-		fax: details.fax.errors[ 0 ],
+		firstName: details.firstName?.errors[ 0 ],
+		lastName: details.lastName?.errors[ 0 ],
+		organization: details.organization?.errors[ 0 ],
+		email: details.email?.errors[ 0 ],
+		alternateEmail: details.alternateEmail?.errors[ 0 ],
+		phone: details.phone?.errors[ 0 ],
+		address1: details.address1?.errors[ 0 ],
+		address2: details.address2?.errors[ 0 ],
+		city: details.city?.errors[ 0 ],
+		state: details.state?.errors[ 0 ],
+		postalCode: details.postalCode?.errors[ 0 ],
+		countryCode: details.countryCode?.errors[ 0 ],
+		fax: details.fax?.errors[ 0 ],
 		extra: prepareTldExtraContactDetailsErrors( details ),
 	};
 }
@@ -433,9 +441,9 @@ function prepareCaDomainContactExtraDetails(
 ): CaDomainContactExtraDetails | null {
 	if ( details.tldExtraFields?.ca ) {
 		return {
-			lang: details.tldExtraFields.ca.lang.value,
-			legalType: details.tldExtraFields.ca.legalType.value,
-			ciraAgreementAccepted: details.tldExtraFields.ca.ciraAgreementAccepted.value === 'true',
+			lang: details.tldExtraFields.ca.lang?.value,
+			legalType: details.tldExtraFields.ca.legalType?.value,
+			ciraAgreementAccepted: details.tldExtraFields.ca.ciraAgreementAccepted?.value === 'true',
 		};
 	}
 	return null;
@@ -459,9 +467,9 @@ function prepareUkDomainContactExtraDetails(
 ): UkDomainContactExtraDetails | null {
 	if ( details.tldExtraFields?.uk ) {
 		return {
-			registrantType: details.tldExtraFields.uk.registrantType.value,
-			registrationNumber: details.tldExtraFields.uk.registrationNumber.value,
-			tradingName: details.tldExtraFields.uk.tradingName.value,
+			registrantType: details.tldExtraFields.uk.registrantType?.value,
+			registrationNumber: details.tldExtraFields.uk.registrationNumber?.value,
+			tradingName: details.tldExtraFields.uk.tradingName?.value,
 		};
 	}
 	return null;
@@ -492,10 +500,10 @@ function prepareFrDomainContactExtraDetails(
 ): FrDomainContactExtraDetails | null {
 	if ( details.tldExtraFields?.fr ) {
 		return {
-			registrantType: details.tldExtraFields.fr.registrantType.value,
-			registrantVatId: details.vatId.value,
-			trademarkNumber: details.tldExtraFields.fr.trademarkNumber.value,
-			sirenSiret: details.tldExtraFields.fr.sirenSiret.value,
+			registrantType: details.tldExtraFields.fr.registrantType?.value,
+			registrantVatId: details.vatId?.value,
+			trademarkNumber: details.tldExtraFields.fr.trademarkNumber?.value,
+			sirenSiret: details.tldExtraFields.fr.sirenSiret?.value,
 		};
 	}
 	return null;
@@ -507,7 +515,7 @@ function prepareFrDomainContactExtraDetailsErrors(
 	if ( details.tldExtraFields?.fr ) {
 		return {
 			registrantType: details.tldExtraFields.fr?.registrantType?.errors,
-			registrantVatId: details.vatId.errors,
+			registrantVatId: details.vatId?.errors,
 			trademarkNumber: details.tldExtraFields.fr?.trademarkNumber?.errors,
 			sirenSiret: details.tldExtraFields.fr?.sirenSiret?.errors,
 		};
@@ -523,45 +531,45 @@ export function prepareDomainContactValidationRequest(
 
 	if ( details.tldExtraFields?.ca ) {
 		extra.ca = {
-			lang: details.tldExtraFields.ca.lang.value,
-			legal_type: details.tldExtraFields.ca.legalType.value,
-			cira_agreement_accepted: details.tldExtraFields.ca.ciraAgreementAccepted.value === 'true',
+			lang: details.tldExtraFields.ca.lang?.value,
+			legal_type: details.tldExtraFields.ca.legalType?.value,
+			cira_agreement_accepted: details.tldExtraFields.ca.ciraAgreementAccepted?.value === 'true',
 		};
 	}
 	if ( details.tldExtraFields?.uk ) {
 		extra.uk = {
-			registrant_type: details.tldExtraFields.uk.registrantType.value,
-			registration_number: details.tldExtraFields.uk.registrationNumber.value,
-			trading_name: details.tldExtraFields.uk.tradingName.value,
+			registrant_type: details.tldExtraFields.uk.registrantType?.value,
+			registration_number: details.tldExtraFields.uk.registrationNumber?.value,
+			trading_name: details.tldExtraFields.uk.tradingName?.value,
 		};
 	}
 	if ( details.tldExtraFields?.fr ) {
 		extra.fr = {
-			registrant_type: details.tldExtraFields.fr.registrantType.value,
-			registrant_vat_id: details.vatId.value,
-			trademark_number: details.tldExtraFields.fr.trademarkNumber.value,
-			siren_siret: details.tldExtraFields.fr.sirenSiret.value,
+			registrant_type: details.tldExtraFields.fr.registrantType?.value,
+			registrant_vat_id: details.vatId?.value,
+			trademark_number: details.tldExtraFields.fr.trademarkNumber?.value,
+			siren_siret: details.tldExtraFields.fr.sirenSiret?.value,
 		};
 	}
 
 	return {
 		domain_names: domainNames,
 		contact_information: {
-			firstName: details.firstName.value,
-			lastName: details.lastName.value,
-			organization: details.organization.value,
-			email: details.email.value,
-			alternateEmail: details.alternateEmail.value,
-			phone: details.phone.value,
-			phoneNumberCountry: details.phoneNumberCountry.value,
-			address1: details.address1.value,
-			address2: details.address2.value,
-			city: details.city.value,
-			state: details.state.value,
-			postalCode: details.postalCode.value,
-			countryCode: details.countryCode.value,
-			fax: details.fax.value,
-			vatId: details.vatId.value,
+			firstName: details.firstName?.value,
+			lastName: details.lastName?.value,
+			organization: details.organization?.value,
+			email: details.email?.value,
+			alternateEmail: details.alternateEmail?.value,
+			phone: details.phone?.value,
+			phoneNumberCountry: details.phoneNumberCountry?.value,
+			address1: details.address1?.value,
+			address2: details.address2?.value,
+			city: details.city?.value,
+			state: details.state?.value,
+			postalCode: details.postalCode?.value,
+			countryCode: details.countryCode?.value,
+			fax: details.fax?.value,
+			vatId: details.vatId?.value,
 			extra,
 		},
 	};
@@ -748,6 +756,7 @@ export const managedContactDetailsUpdaters: ManagedContactDetailsUpdaters = {
 	},
 
 	touchContactFields: ( oldDetails: ManagedContactDetails ): ManagedContactDetails => {
+		// TODO: reimplement this to handle new contact details format, or remove this if it is no longer necessary
 		return Object.keys( oldDetails ).reduce( ( newDetails, detailKey ) => {
 			return { ...newDetails, [ detailKey ]: touchField( oldDetails[ detailKey ] ) };
 		}, oldDetails );

--- a/client/my-sites/checkout/composite-checkout/wpcom/types/wpcom-store-state.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/types/wpcom-store-state.ts
@@ -188,6 +188,26 @@ export function updateManagedContactDetailsShape< A, B >(
 	};
 }
 
+/*
+ * Map a function over the (not undefined) fields of a ManagedContactDetailsShape.
+ * Satisfies the following property for all accessors A:
+ *
+ *  _.get( mapManagedContactDetailsShape( f, data ), A )
+ *     === f( _.get( data, A ) ) if data.A is defined;
+ *     === undefined             if data.A is undefined.
+ */
+export function mapManagedContactDetailsShape< A >(
+	f: ( arg0: A ) => A,
+	x: ManagedContactDetailsShape< A >
+): ManagedContactDetailsShape< A > {
+	return updateManagedContactDetailsShape(
+		( u: A, unused: A ) => f( u ), // eslint-disable-line @typescript-eslint/no-unused-vars
+		( unused ) => unused,
+		x,
+		x
+	);
+}
+
 export function flattenManagedContactDetailsShape< A, B >(
 	f: ( arg0: A ) => B,
 	x: ManagedContactDetailsShape< A >
@@ -756,10 +776,7 @@ export const managedContactDetailsUpdaters: ManagedContactDetailsUpdaters = {
 	},
 
 	touchContactFields: ( oldDetails: ManagedContactDetails ): ManagedContactDetails => {
-		// TODO: reimplement this to handle new contact details format, or remove this if it is no longer necessary
-		return Object.keys( oldDetails ).reduce( ( newDetails, detailKey ) => {
-			return { ...newDetails, [ detailKey ]: touchField( oldDetails[ detailKey ] ) };
-		}, oldDetails );
+		return mapManagedContactDetailsShape( touchField, oldDetails );
 	},
 
 	updateVatId: ( oldDetails: ManagedContactDetails, newVatId: string ): ManagedContactDetails => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The `client/my-sites/checkout/composite-checkout/wpcom/types/wpcom-store-state.ts` file contains several Typescript errors involving the manage contact details it manipulates. This PR attempts to resolve those issues and fix any bugs that they predict.

#### Testing instructions

This will require checking the contact details forms for domain, TLDs with special contact forms, and the GSuite contact form to make sure they work as expected. They should be able to be shown and edited correctly, as well as validated correctly.

```
yarn run test-client client/my-sites/checkout/composite-checkout/wpcom/test/wpcom-store-state.ts
```