### PR TITLE
Price test: show popular badge on Business plan for test 2 group

### DIFF
--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -132,6 +132,8 @@ class Plans extends React.Component {
 			marketingPriceGroup,
 		} = this.props;
 
+		let { customerType } = this.props;
+
 		if ( ! selectedSite || this.isInvalidPlanInterval() ) {
 			return this.renderPlaceholder();
 		}
@@ -145,6 +147,7 @@ class Plans extends React.Component {
 
 		if ( marketingPriceGroup === MARKETING_PRICE_GROUP_2020_Q2_TEST_2 ) {
 			hidePersonalPlan = true;
+			customerType = 'business';
 		} else if ( marketingPriceGroup === MARKETING_PRICE_GROUP_2020_Q2_TEST_3 ) {
 			hidePersonalPlan = true;
 			hidePremiumPlan = true;
@@ -177,7 +180,7 @@ class Plans extends React.Component {
 									hideFreePlan={ true }
 									hidePersonalPlan={ hidePersonalPlan }
 									hidePremiumPlan={ hidePremiumPlan }
-									customerType={ this.props.customerType }
+									customerType={ customerType }
 									intervalType={ this.props.intervalType }
 									selectedFeature={ this.props.selectedFeature }
 									selectedPlan={ this.props.selectedPlan }

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -96,6 +96,10 @@ export class PlansStep extends Component {
 	}
 
 	getCustomerType() {
+		if ( this.props.marketingPriceGroup === MARKETING_PRICE_GROUP_2020_Q2_TEST_2 ) {
+			return 'business';
+		}
+
 		if ( this.props.customerType ) {
 			return this.props.customerType;
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* For the users in price test 2, move the popular badge to Business instead of Premium.

More info: pbBQWj-7J-p2#comment-555

#### Testing instructions

* Boot this branch locally.
* Sandbox `public-api.wordpress.com`.
* On the backend, add this filter to your `0-sandbox.php` file:
```
add_filter( 'get_user_marketing_price_group', function( $price_group ) {
    return 'price_2020_q2_test_2';
}, 10, 1 );
```
* Visit http://calypso.localhost:3000/plans/[SITE]
* Make sure you see the popular badge on the Business plan instead of Premium.

<img width="1009" alt="Screen Shot 2020-05-18 at 8 53 13 PM" src="https://user-images.githubusercontent.com/690843/82283001-fd53a080-9949-11ea-95e3-86ce2d7894d5.png">

* Go through the flow to create a new site.
* On the plans step make sure you also see the popular badge on the Business plan.

<img width="1290" alt="Screen Shot 2020-05-18 at 8 55 33 PM" src="https://user-images.githubusercontent.com/690843/82283019-05134500-994a-11ea-9e62-e6b0c134f815.png">



