### PR TITLE
My Home: Update missing notice id

### DIFF
--- a/client/my-sites/customer-home/cards/notices/celebrate-site-launch/index.jsx
+++ b/client/my-sites/customer-home/cards/notices/celebrate-site-launch/index.jsx
@@ -14,7 +14,10 @@ import getSiteTaskList from 'state/selectors/get-site-task-list';
 import isSiteChecklistComplete from 'state/selectors/is-site-checklist-complete';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import CelebrateNotice from 'my-sites/customer-home/cards/notices/celebrate-notice';
-import { NOTICE_CELEBRATE_SITE_LAUNCH } from 'my-sites/customer-home/cards/constants';
+import {
+	NOTICE_CELEBRATE_SITE_LAUNCH,
+	NOTICE_CELEBRATE_SITE_SETUP_COMPLETE,
+} from 'my-sites/customer-home/cards/constants';
 
 /**
  * Image dependencies
@@ -32,7 +35,10 @@ const CelebrateSiteLaunch = ( { isSiteSetupComplete, pendingSiteSetupTasks, site
 
 		// Dismisses the site setup complete celebratory notice.
 		dispatch(
-			savePreference( `dismissible-card-home-notice-site-setup-complete-${ siteId }`, true )
+			savePreference(
+				`dismissible-card-${ NOTICE_CELEBRATE_SITE_SETUP_COMPLETE }-${ siteId }`,
+				true
+			)
 		);
 	};
 


### PR DESCRIPTION
Makes sure we use the right card UID when the site setup is completed after launching a site and the site setup complete notice is dismissed. Missed in #42331
