### PR TITLE
Page export: Removing the author field 

### DIFF
--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -729,7 +729,6 @@ class Page extends Component {
 			__file: 'wp_template',
 			language: 'en',
 			title: page.title,
-			author: page.author,
 			demoURL: page.URL,
 			content: page.rawContent,
 		} );


### PR DESCRIPTION
## Changes proposed in this Pull Request

Let's remove the author field from the page exports JSON. It reveals identifying information such as email addresses, IDs and pant sizes.

## Testing instructions

At wordpress.com/pages/yoursweetsite, click the `...` menu next to a page and export that page.

In the JSON you just downloaded, you should see no trace of an `author` property.
