### PR TITLE
Add pending comment count to site menu

### DIFF
--- a/client/layout/sidebar/item.jsx
+++ b/client/layout/sidebar/item.jsx
@@ -13,6 +13,7 @@ import { isFunction } from 'lodash';
  */
 import { isExternal } from 'lib/url';
 import MaterialIcon from 'components/material-icon';
+import Count from 'components/count';
 import { preload } from 'sections-helper';
 import TranslatableString from 'components/translatable/proptype';
 
@@ -23,7 +24,7 @@ export default function SidebarItem( props ) {
 		selected: props.selected,
 		'has-unseen': props.hasUnseen,
 	} );
-	const { materialIcon, materialIconStyle, icon, customIcon, hasUnseen } = props;
+	const { materialIcon, materialIconStyle, icon, customIcon, hasUnseen, count } = props;
 
 	let _preloaded = false;
 
@@ -72,6 +73,7 @@ export default function SidebarItem( props ) {
 				<span className="sidebar__menu-link-text menu-link-text" data-e2e-sidebar={ props.label }>
 					{ props.label }
 				</span>
+				{ !! count && <Count count={ count } /> }
 				{ showAsExternal && <Gridicon icon="external" size={ 24 } /> }
 				{ props.children }
 			</a>
@@ -95,4 +97,5 @@ SidebarItem.propTypes = {
 	hasUnseen: PropTypes.bool,
 	testTarget: PropTypes.string,
 	tipTarget: PropTypes.string,
+	count: PropTypes.number,
 };

--- a/client/layout/sidebar/item.jsx
+++ b/client/layout/sidebar/item.jsx
@@ -72,8 +72,8 @@ export default function SidebarItem( props ) {
 				{ /* eslint-disable wpcalypso/jsx-classname-namespace */ }
 				<span className="sidebar__menu-link-text menu-link-text" data-e2e-sidebar={ props.label }>
 					{ props.label }
+					{ !! count && <Count count={ count } /> }
 				</span>
-				{ !! count && <Count count={ count } /> }
 				{ showAsExternal && <Gridicon icon="external" size={ 24 } /> }
 				{ props.children }
 			</a>

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -132,6 +132,16 @@
 		.sidebar__menu-icon {
 			fill: var( --color-sidebar-menu-hover-text );
 		}
+
+		.count {
+			border-color: var( --color-border );
+		}
+	}
+
+	.count {
+		border-color: var( --color-neutral-5 );
+		color: var( --color-text );
+		background-color: var( --color-neutral-5 );
 	}
 
 	.badge {
@@ -145,6 +155,12 @@
 
 		.sidebar__menu-icon {
 			fill: var( --color-sidebar-menu-selected-text );
+		}
+
+		.count {
+			background-color: transparent;
+			border-color: var( --studio-blue-70 );
+			color: var( --studio-blue-70 );
 		}
 	}
 

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -143,6 +143,11 @@
 		color: var( --color-sidebar-menu-hover-text );
 		background-color: var( --color-sidebar-menu-hover-background );
 		border-color: var( --color-sidebar-menu-hover-background );
+		line-height: 0;
+		margin-left: 8px;
+		padding: 8px 6px;
+		position: absolute;
+			top: 9px;
 	}
 
 	.badge {
@@ -163,14 +168,6 @@
 			border-color: var( --color-sidebar-menu-selected-text );
 			color: var( --color-sidebar-menu-selected-text );
 		}
-	}
-
-	.selected & .count {
-		line-height: 0;
-		margin-left: 8px;
-		padding: 8px 6px;
-		position: absolute;
-			top: 9px;
 	}
 
 	// Some links are marked as "external" and show

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -165,6 +165,14 @@
 		}
 	}
 
+	.selected & .count {
+		line-height: 0;
+		margin-left: 8px;
+		padding: 8px 6px;
+		position: absolute;
+			top: 9px;
+	}
+
 	// Some links are marked as "external" and show
 	// an icon to visually indicate they will open
 	// a new window/tab.

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -139,9 +139,10 @@
 	}
 
 	.count {
-		border-color: var( --color-neutral-5 );
-		color: var( --color-text );
-		background-color: var( --color-neutral-5 );
+		//border-color: var( --color-neutral-5 );
+		//color: var( --color-text );
+		//background-color: var( --color-neutral-5 );
+		margin-left: 8px;
 	}
 
 	.badge {
@@ -158,9 +159,9 @@
 		}
 
 		.count {
-			background-color: transparent;
-			border-color: var( --studio-blue-70 );
-			color: var( --studio-blue-70 );
+			//background-color: transparent;
+			//border-color: var( --studio-blue-70 );
+			//color: var( --studio-blue-70 );
 		}
 	}
 

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -144,7 +144,6 @@
 		background-color: var( --color-sidebar-menu-hover-background );
 		border-color: var( --color-sidebar-menu-hover-background );
 		line-height: 0;
-		margin-left: 8px;
 		padding: 8px 6px;
 		position: absolute;
 			top: 9px;

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -134,15 +134,15 @@
 		}
 
 		.count {
-			border-color: var( --color-border );
+			border-color: var( --color-sidebar-menu-hover-text );
 		}
 	}
 
 	.count {
-		//border-color: var( --color-neutral-5 );
-		//color: var( --color-text );
-		//background-color: var( --color-neutral-5 );
 		margin-left: 8px;
+		color: var( --color-sidebar-menu-hover-text );
+		background-color: var( --color-sidebar-menu-hover-background );
+		border-color: var( --color-sidebar-menu-hover-background );
 	}
 
 	.badge {
@@ -159,9 +159,9 @@
 		}
 
 		.count {
-			//background-color: transparent;
-			//border-color: var( --studio-blue-70 );
-			//color: var( --studio-blue-70 );
+			background-color: transparent;
+			border-color: var( --color-sidebar-menu-selected-text );
+			color: var( --color-sidebar-menu-selected-text );
 		}
 	}
 

--- a/client/my-sites/sidebar/site-menu.jsx
+++ b/client/my-sites/sidebar/site-menu.jsx
@@ -15,6 +15,8 @@ import config from 'config';
 import SidebarItem from 'layout/sidebar/item';
 import { getPostTypes } from 'state/post-types/selectors';
 import QueryPostTypes from 'components/data/query-post-types';
+import { getSiteCommentCounts } from 'state/comments/selectors';
+import QuerySiteCommentCounts from 'components/data/query-site-comment-counts';
 import { bumpStat } from 'lib/analytics/mc';
 import { decodeEntities } from 'lib/formatting';
 import compareProps from 'lib/compare-props';
@@ -107,6 +109,7 @@ class SiteMenu extends PureComponent {
 			{
 				name: 'comments',
 				label: translate( 'Comments' ),
+				count: get( this.props.commentCounts, 'pending' ),
 				capability: 'edit_posts',
 				queryable: true,
 				config: 'manage/comments',
@@ -176,6 +179,7 @@ class SiteMenu extends PureComponent {
 			<SidebarItem
 				key={ menuItem.name }
 				label={ menuItem.label }
+				count={ menuItem.count > 0 ? menuItem.count : null }
 				selected={ itemLinkMatches( menuItem.paths || menuItem.link, this.props.path ) }
 				link={ link }
 				onNavigate={ this.onNavigate( menuItem.name ) }
@@ -257,11 +261,13 @@ class SiteMenu extends PureComponent {
 	}
 
 	render() {
+		const { siteId, canCurrentUser } = this.props;
 		const menuItems = [ ...this.getDefaultMenuItems(), ...this.getCustomMenuItems() ];
 
 		return (
 			<ul>
-				{ this.props.siteId && <QueryPostTypes siteId={ this.props.siteId } /> }
+				{ siteId && <QueryPostTypes siteId={ siteId } /> }
+				{ siteId && canCurrentUser( 'edit_posts' ) && <QuerySiteCommentCounts siteId={ siteId } /> }
 				{ menuItems.map( this.renderMenuItem, this ) }
 			</ul>
 		);
@@ -282,6 +288,7 @@ export default connect(
 		siteSlug: getSiteSlug( state, siteId ),
 		isVip: isVipSite( state, siteId ),
 		isSiteWPForTeams: isSiteWPForTeams( state, siteId ),
+		commentCounts: getSiteCommentCounts( state, siteId ),
 	} ),
 	{ expandSection, recordTracksEvent },
 	null,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* adds the count of pending comments to its menu item in the sidebar

#### Testing instructions

* My Sites > pick a site > explore the sidebar section "Site" where "Comments" item should display a count of unmoderated comments. Like this:

<img width="273" alt="Screenshot 2020-05-19 at 11 02 08" src="https://user-images.githubusercontent.com/156676/82307126-37f82000-99c0-11ea-9369-094ff4f0ee3e.png">

Fixes #41931