### PR TITLE
Modularise domains state

### DIFF
--- a/client/state/domains/actions.js
+++ b/client/state/domains/actions.js
@@ -1,8 +1,9 @@
 /**
  * Internal dependencies
  */
-
 import { composeAnalytics, recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
+
+import 'state/domains/init';
 
 export const recordAddDomainButtonClick = ( domainName, section ) =>
 	composeAnalytics(

--- a/client/state/domains/dns/actions.js
+++ b/client/state/domains/dns/actions.js
@@ -16,6 +16,8 @@ import {
 } from 'state/action-types';
 import { getDomainDns } from './selectors';
 
+import 'state/domains/init';
+
 export const fetchDns = ( domainName ) => ( dispatch, getState ) => {
 	const dns = getDomainDns( getState(), domainName );
 

--- a/client/state/domains/dns/selectors.js
+++ b/client/state/domains/dns/selectors.js
@@ -3,6 +3,8 @@
  */
 import { initialState } from './reducer';
 
+import 'state/domains/init';
+
 export function getDomainDns( state, domain ) {
 	return state.domains.dns[ domain ] || initialState;
 }

--- a/client/state/domains/init.js
+++ b/client/state/domains/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'state/redux-store';
+import domainsReducer from './reducer';
+
+registerReducer( [ 'domains' ], domainsReducer );

--- a/client/state/domains/management/actions.js
+++ b/client/state/domains/management/actions.js
@@ -1,7 +1,6 @@
 /**
  * Internal dependencies
  */
-
 import wpcom from 'lib/wp';
 import {
 	DOMAIN_MANAGEMENT_CONTACT_DETAILS_CACHE_RECEIVE,
@@ -18,6 +17,8 @@ import {
 	DOMAIN_MANAGEMENT_WHOIS_SAVE_SUCCESS,
 	DOMAIN_MANAGEMENT_WHOIS_UPDATE,
 } from 'state/action-types';
+
+import 'state/domains/init';
 
 /**
  * Returns an action object to be used in signalling that a cached domains
@@ -124,7 +125,7 @@ export function requestWhois( domain ) {
  *
  * @param   {string}   domain		domain to query
  * @param   {object}   whoisData	whois details object
- * @param	{Bool}     transferLock set 60-day transfer lock after update
+ * @param	  {boolean}  transferLock set 60-day transfer lock after update
  * @returns {Function}				Action thunk
  */
 export function saveWhois( domain, whoisData, transferLock ) {

--- a/client/state/domains/management/selectors.js
+++ b/client/state/domains/management/selectors.js
@@ -3,6 +3,11 @@
  */
 import { get } from 'lodash';
 
+/**
+ * Internal dependencies
+ */
+import 'state/domains/init';
+
 export function isUpdatingWhois( state, domain ) {
 	return get( state, [ 'domains', 'management', 'isSaving', `${ domain }`, 'saving' ], false );
 }

--- a/client/state/domains/package.json
+++ b/client/state/domains/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/domains/reducer.js
+++ b/client/state/domains/reducer.js
@@ -6,12 +6,15 @@ import management from './management/reducer';
 import siteRedirect from './site-redirect/reducer';
 import suggestions from './suggestions/reducer';
 import transfer from './transfer/reducer';
-import { combineReducers } from 'state/utils';
+import { combineReducers, withStorageKey } from 'state/utils';
 
-export default combineReducers( {
+const combinedReducer = combineReducers( {
 	dns,
 	management,
 	siteRedirect,
 	suggestions,
 	transfer,
 } );
+
+const domainsReducer = withStorageKey( 'domains', combinedReducer );
+export default domainsReducer;

--- a/client/state/domains/site-redirect/actions.js
+++ b/client/state/domains/site-redirect/actions.js
@@ -17,6 +17,8 @@ import {
 	DOMAINS_SITE_REDIRECT_UPDATE_FAILED,
 } from 'state/action-types';
 
+import 'state/domains/init';
+
 export function closeSiteRedirectNotice( siteId ) {
 	return {
 		type: DOMAINS_SITE_REDIRECT_NOTICE_CLOSE,

--- a/client/state/domains/site-redirect/selectors.js
+++ b/client/state/domains/site-redirect/selectors.js
@@ -3,6 +3,8 @@
  */
 import { initialStateForSite } from './reducer';
 
+import 'state/domains/init';
+
 export function getSiteRedirectLocation( state, siteId ) {
 	return state.domains.siteRedirect[ siteId ] || initialStateForSite;
 }

--- a/client/state/domains/suggestions/actions.js
+++ b/client/state/domains/suggestions/actions.js
@@ -1,7 +1,6 @@
 /**
  * Internal dependencies
  */
-
 import wpcom from 'lib/wp';
 import {
 	DOMAINS_SUGGESTIONS_RECEIVE,
@@ -9,6 +8,8 @@ import {
 	DOMAINS_SUGGESTIONS_REQUEST_FAILURE,
 	DOMAINS_SUGGESTIONS_REQUEST_SUCCESS,
 } from 'state/action-types';
+
+import 'state/domains/init';
 
 /**
  * Returns an action object to be used in signalling that a domains suggestion object

--- a/client/state/domains/suggestions/selectors.js
+++ b/client/state/domains/suggestions/selectors.js
@@ -1,8 +1,9 @@
 /**
  * Internal dependencies
  */
-
 import { getSerializedDomainsSuggestionsQuery } from './utils';
+
+import 'state/domains/init';
 
 /**
  * Returns domains suggestions information for a query.

--- a/client/state/domains/transfer/actions.js
+++ b/client/state/domains/transfer/actions.js
@@ -4,6 +4,7 @@
 import { DOMAIN_TRANSFER_IPS_TAG_SAVE, DOMAIN_TRANSFER_UPDATE } from 'state/action-types';
 
 import 'state/data-layer/wpcom/domains/transfer/index.js';
+import 'state/domains/init';
 
 export const saveDomainIpsTag = ( domain, selectedRegistrar ) => ( {
 	type: DOMAIN_TRANSFER_IPS_TAG_SAVE,

--- a/client/state/push-notifications/package.json
+++ b/client/state/push-notifications/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -36,7 +36,6 @@ import countryStates from './country-states/reducer';
 import currentUser from './current-user/reducer';
 import { reducer as dataRequests } from './data-layer/wpcom-http/utils';
 import documentHead from './document-head/reducer';
-import domains from './domains/reducer';
 import emailForwarding from './email-forwarding/reducer';
 import embeds from './embeds/reducer';
 import experiments from './experiments/reducer';
@@ -122,7 +121,6 @@ const reducers = {
 	currentUser,
 	dataRequests,
 	documentHead,
-	domains,
 	emailForwarding,
 	embeds,
 	experiments,

--- a/client/state/selectors/get-contact-details-cache.js
+++ b/client/state/selectors/get-contact-details-cache.js
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import 'state/domains/init';
 
 /**
  * Returns cached domain contact details if we've successfully requested them.

--- a/client/state/selectors/get-gaining-registrar.js
+++ b/client/state/selectors/get-gaining-registrar.js
@@ -4,6 +4,11 @@
 import { get } from 'lodash';
 
 /**
+ * Internal dependencies
+ */
+import 'state/domains/init';
+
+/**
  * Returns gaining registrar data for a given domain, if we've successfully
  * completed the transfer from our side.
  *

--- a/client/state/selectors/get-ips-tag-save-status.js
+++ b/client/state/selectors/get-ips-tag-save-status.js
@@ -4,6 +4,11 @@
 import { get } from 'lodash';
 
 /**
+ * Internal dependencies
+ */
+import 'state/domains/init';
+
+/**
  * Return a string indicating whether the status of a .uk transfer
  * IPS tag save.
  *

--- a/client/state/selectors/get-registrant-whois.js
+++ b/client/state/selectors/get-registrant-whois.js
@@ -1,13 +1,14 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { findRegistrantWhois } from 'lib/domains/whois/utils';
+
+import 'state/domains/init';
 
 /**
  * Returns registrant's domain contact details if we've successfully requested them.

--- a/client/state/selectors/get-validation-schemas.js
+++ b/client/state/selectors/get-validation-schemas.js
@@ -4,6 +4,11 @@
 import { get } from 'lodash';
 
 /**
+ * Internal dependencies
+ */
+import 'state/domains/init';
+
+/**
  * Returns an object with domain validation schemas keyed by tld
  *
  * @param  {object}  state Global state tree

--- a/client/state/selectors/get-whois.js
+++ b/client/state/selectors/get-whois.js
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import 'state/domains/init';
 
 /**
  * Returns domain contact details if we've successfully requested them.

--- a/client/state/selectors/is-requesting-contact-details-cache.js
+++ b/client/state/selectors/is-requesting-contact-details-cache.js
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import 'state/domains/init';
 
 /**
  * Return a boolean value indicating whether a request for domain contact details

--- a/client/state/selectors/is-requesting-whois.js
+++ b/client/state/selectors/is-requesting-whois.js
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import 'state/domains/init';
 
 /**
  * Return a boolean value indicating whether requesting WHOIS details is in progress.


### PR DESCRIPTION
This PR is one of many working on modularising state in Calypso. This one handles domains.

For mode details on state modularisation, see the [modularised state documentation](https://github.com/Automattic/wp-calypso/blob/master/docs/modularized-state.md) and p4TIVU-9lM-p2.

Note: I've added the default reviewers suggested by GitHub. Please feel free to ignore the PR or pull in someone else if you're not the right person!

#### Changes proposed in this Pull Request

* Modularise domains state

#### Testing instructions

* Install [Redux DevTools](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en).
* Open DevTools and switch to the Redux tab.
* Open `/read` on the live branch or your local copy of this branch.
* Click `State` on the top right to ensure you see all state, and not just the diff for the last action: 
![image](https://user-images.githubusercontent.com/409615/73774406-d3e87d80-477b-11ea-9f59-3e42cc00101f.png)
* Analyse the tree and note that there's no `domains` key, even if you expand the list of keys. This indicates that the domains state hasn't been loaded yet.
* Click `My Sites` on the masterbar.
* Verify that a `domains` key is added with the domains state. This indicates that the domains state has now been loaded.
* Verify that domains-related functionality works normally. This indicates that I didn't mess up.