### PR TITLE
Modularise jetpack state

### DIFF
--- a/client/state/jetpack/connection/actions.js
+++ b/client/state/jetpack/connection/actions.js
@@ -1,7 +1,6 @@
 /**
  * Internal dependencies
  */
-
 import {
 	JETPACK_CONNECTION_STATUS_RECEIVE,
 	JETPACK_CONNECTION_STATUS_REQUEST,
@@ -20,6 +19,7 @@ import {
 import wp from 'lib/wp';
 
 import 'state/data-layer/wpcom/jetpack/connection/owner';
+import 'state/jetpack/init';
 
 export const requestJetpackConnectionStatus = ( siteId ) => {
 	return ( dispatch ) => {

--- a/client/state/jetpack/credentials/actions.js
+++ b/client/state/jetpack/credentials/actions.js
@@ -10,6 +10,7 @@ import {
 import 'state/data-layer/wpcom/activity-log/delete-credentials';
 import 'state/data-layer/wpcom/activity-log/rewind/activate';
 import 'state/data-layer/wpcom/activity-log/update-credentials';
+import 'state/jetpack/init';
 
 export const updateCredentials = ( siteId, credentials ) => ( {
 	type: JETPACK_CREDENTIALS_UPDATE,

--- a/client/state/jetpack/init.js
+++ b/client/state/jetpack/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'state/redux-store';
+import jetpackReducer from './reducer';
+
+registerReducer( [ 'jetpack' ], jetpackReducer );

--- a/client/state/jetpack/modules/actions.js
+++ b/client/state/jetpack/modules/actions.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import { omit, mapValues } from 'lodash';
 
 /**
@@ -20,6 +19,8 @@ import {
 	JETPACK_MODULES_REQUEST_SUCCESS,
 } from 'state/action-types';
 import wp from 'lib/wp';
+
+import 'state/jetpack/init';
 
 export const activateModule = ( siteId, moduleSlug, silent = false ) => {
 	return ( dispatch ) => {

--- a/client/state/jetpack/package.json
+++ b/client/state/jetpack/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/jetpack/reducer.js
+++ b/client/state/jetpack/reducer.js
@@ -1,16 +1,18 @@
 /**
  * Internal dependencies
  */
-
+import { combineReducers, withStorageKey } from 'state/utils';
 import { reducer as connection } from './connection/reducer';
-import { combineReducers } from 'state/utils';
 import { reducer as credentials } from './credentials/reducer';
 import { reducer as modules } from './modules/reducer';
 import { settingsReducer as settings } from './settings/reducer';
 
-export default combineReducers( {
+const combinedReducer = combineReducers( {
 	connection,
 	credentials,
 	modules,
 	settings,
 } );
+
+const jetpackReducer = withStorageKey( 'jetpack', combinedReducer );
+export default jetpackReducer;

--- a/client/state/jetpack/settings/actions.js
+++ b/client/state/jetpack/settings/actions.js
@@ -9,6 +9,7 @@ import {
 } from 'state/action-types';
 
 import 'state/data-layer/wpcom/jetpack/settings';
+import 'state/jetpack/init';
 
 export const requestJetpackSettings = ( siteId, query ) => ( {
 	type: JETPACK_SETTINGS_REQUEST,
@@ -47,7 +48,7 @@ export const updateJetpackSettings = ( siteId, settings ) => ( {
 /**
  * Regenerate the target email of Post by Email.
  *
- * @param  {Int}     siteId  ID of the site.
+ * @param  {number}     siteId  ID of the site.
  * @returns {object}          Action object to regenerate the email when dispatched.
  */
 export const regeneratePostByEmail = ( siteId ) =>

--- a/client/state/jetpack/site-alerts/actions.js
+++ b/client/state/jetpack/site-alerts/actions.js
@@ -8,6 +8,7 @@ import {
 
 import 'state/data-layer/wpcom/sites/alerts/fix';
 import 'state/data-layer/wpcom/sites/alerts/ignore';
+import 'state/jetpack/init';
 
 export const fixThreatAlert = ( siteId, threatId ) => ( {
 	type: JETPACK_SITE_ALERT_THREAT_FIX,

--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -55,7 +55,6 @@ import imports from './imports/reducer';
 import inlineHelp from './inline-help/reducer';
 import inlineSupportArticle from './inline-support-article/reducer';
 import invites from './invites/reducer';
-import jetpack from './jetpack/reducer';
 import jetpackProductInstall from './jetpack-product-install/reducer';
 import jetpackRemoteInstall from './jetpack-remote-install/reducer';
 import jetpackSync from './jetpack-sync/reducer';
@@ -143,7 +142,6 @@ const reducers = {
 	inlineHelp,
 	inlineSupportArticle,
 	invites,
-	jetpack,
 	jetpackProductInstall,
 	jetpackRemoteInstall,
 	jetpackSync,

--- a/client/state/selectors/get-credentials-auto-config-status.js
+++ b/client/state/selectors/get-credentials-auto-config-status.js
@@ -3,6 +3,11 @@
  */
 import { get } from 'lodash';
 
+/**
+ * Internal dependencies
+ */
+import 'state/jetpack/init';
+
 export default function getCredentialsAutoConfigStatus( state, siteId ) {
 	return get( state, [ 'jetpack', 'credentials', 'items', siteId, 'main' ], false )
 		? 'requesting'

--- a/client/state/selectors/get-jetpack-connection-status.js
+++ b/client/state/selectors/get-jetpack-connection-status.js
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import 'state/jetpack/init';
 
 /**
  * Returns the current status of the connection.

--- a/client/state/selectors/get-jetpack-credentials-update-status.js
+++ b/client/state/selectors/get-jetpack-credentials-update-status.js
@@ -3,6 +3,11 @@
  */
 import { get } from 'lodash';
 
+/**
+ * Internal dependencies
+ */
+import 'state/jetpack/init';
+
 export default function getJetpackCredentialsUpdateStatus( state, siteId ) {
 	return get( state, [ 'jetpack', 'credentials', 'requestStatus', siteId ], 'unsubmitted' );
 }

--- a/client/state/selectors/get-jetpack-credentials.js
+++ b/client/state/selectors/get-jetpack-credentials.js
@@ -3,6 +3,11 @@
  */
 import { get, isEmpty } from 'lodash';
 
+/**
+ * Internal dependencies
+ */
+import 'state/jetpack/init';
+
 // We might have to re-think this approach since the credentials from `jetpackScan.scan[siteId].credentials`
 // are only updated when we receive a new response from `/scan`. So, for instance, if a user completes
 // the server credentials form, this selector won't reflect that fact since submitting that form doesn't

--- a/client/state/selectors/get-jetpack-module.js
+++ b/client/state/selectors/get-jetpack-module.js
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import 'state/jetpack/init';
 
 /**
  * Returns the data for a specified module on a certain site.

--- a/client/state/selectors/get-jetpack-modules-requiring-connection.js
+++ b/client/state/selectors/get-jetpack-modules-requiring-connection.js
@@ -1,13 +1,14 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import createSelector from 'lib/create-selector';
+
+import 'state/jetpack/init';
 
 /**
  * Returns an array of modules that require connection in order to work.

--- a/client/state/selectors/get-jetpack-modules.js
+++ b/client/state/selectors/get-jetpack-modules.js
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import 'state/jetpack/init';
 
 /**
  * Returns the data for all modules on a certain site.

--- a/client/state/selectors/get-jetpack-settings.js
+++ b/client/state/selectors/get-jetpack-settings.js
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import 'state/jetpack/init';
 
 /**
  * Returns the Jetpack settings on a certain site.

--- a/client/state/selectors/get-jetpack-user-connection.js
+++ b/client/state/selectors/get-jetpack-user-connection.js
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import 'state/jetpack/init';
 
 /**
  * Returns the connection data of the current user.

--- a/client/state/selectors/is-activating-jetpack-module.js
+++ b/client/state/selectors/is-activating-jetpack-module.js
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import 'state/jetpack/init';
 
 /**
  * Returns true if we are currently making a request to activate a module. False otherwise

--- a/client/state/selectors/is-deactivating-jetpack-module.js
+++ b/client/state/selectors/is-deactivating-jetpack-module.js
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import 'state/jetpack/init';
 
 /**
  * Returns true if we are currently making a request to deactivate a module. False otherwise

--- a/client/state/selectors/is-fetching-jetpack-modules.js
+++ b/client/state/selectors/is-fetching-jetpack-modules.js
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import 'state/jetpack/init';
 
 /**
  * Returns true if we are currently making a request to get the list of Jetpack

--- a/client/state/selectors/is-jetpack-module-active.js
+++ b/client/state/selectors/is-jetpack-module-active.js
@@ -1,10 +1,15 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import isPrivateSite from 'state/selectors/is-private-site';
+
+import 'state/jetpack/init';
 
 /**
  * Returns true if the module is currently active. False otherwise.

--- a/client/state/selectors/is-requesting-jetpack-connection-status.js
+++ b/client/state/selectors/is-requesting-jetpack-connection-status.js
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import 'state/jetpack/init';
 
 /**
  * Returns true if we are currently making a request to retrieve the connection status. False otherwise.

--- a/client/state/selectors/is-requesting-jetpack-user-connection.js
+++ b/client/state/selectors/is-requesting-jetpack-user-connection.js
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import 'state/jetpack/init';
 
 /**
  * Returns true if we are currently making a request to retrieve the user connection data. False otherwise.


### PR DESCRIPTION
This PR is one of many working on modularising state in Calypso. This one handles jetpack (only `jetpack` base state, not `jetpackSync`, `jetpackProductInstall` or `jetpackRemoteInstall`).

For mode details on state modularisation, see the [modularised state documentation](https://github.com/Automattic/wp-calypso/blob/master/docs/modularized-state.md) and p4TIVU-9lM-p2.

Note: I've added the default reviewers suggested by GitHub. Please feel free to ignore the PR or pull in someone else if you're not the right person!

#### Changes proposed in this Pull Request

* Modularise jetpack state

#### Testing instructions

* Install [Redux DevTools](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en).
* Open DevTools and switch to the Redux tab.
* Open `/read` on the live branch or your local copy of this branch.
* Click `State` on the top right to ensure you see all state, and not just the diff for the last action: 
![image](https://user-images.githubusercontent.com/409615/73774406-d3e87d80-477b-11ea-9f59-3e42cc00101f.png)
* Analyse the tree and note that there's no `jetpack` key, even if you expand the list of keys. This indicates that the jetpack state hasn't been loaded yet.
* Click `My Sites` on the masterbar.
* Verify that a `jetpack` key is added with the jetpack state. This indicates that the jetpack state has now been loaded.
* Verify that jetpack-related functionality works normally. This indicates that I didn't mess up.