### PR TITLE
Jetpack Cloud: Switch to Implicit OAuth

### DIFF
--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -121,6 +121,7 @@ const oauthTokenMiddleware = () => {
 			'/start',
 			'/authorize',
 			'/api/oauth/token',
+			'/connect',
 		];
 
 		// Forces OAuth users to the /login page if no token is present
@@ -130,7 +131,12 @@ const oauthTokenMiddleware = () => {
 			// Check we have an OAuth token, otherwise redirect to auth/login page
 			if ( getToken() === false && ! isValidSection ) {
 				const isDesktop = [ 'desktop', 'desktop-development' ].includes( config( 'env_id' ) );
-				const redirectPath = isDesktop ? config( 'login_url' ) : '/authorize';
+				const isJetpackCloud = [
+					'jetpack-cloud-development',
+					'jetpack-cloud-stage',
+					'jetpack-cloud-production',
+				].includes( config( 'env_id' ) );
+				const redirectPath = isDesktop || isJetpackCloud ? config( 'login_url' ) : '/authorize';
 				page( redirectPath );
 				return;
 			}

--- a/client/landing/jetpack-cloud/sections/auth/connect/index.tsx
+++ b/client/landing/jetpack-cloud/sections/auth/connect/index.tsx
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import React, { FunctionComponent } from 'react';
+import { useTranslate } from 'i18n-calypso';
+// import Gridicon from 'components/gridicon';
+
+/**
+ * Internal dependencies
+ */
+// import config from 'config';
+import { Button } from '@automattic/components';
+import JetpackLogo from 'components/jetpack-logo';
+import Main from 'components/main';
+
+interface Props {
+	authUrl: string;
+}
+
+const Connect: FunctionComponent< Props > = ( { authUrl } ) => {
+	const translate = useTranslate();
+
+	return (
+		<Main className="connect">
+			<JetpackLogo full monochrome={ false } size={ 72 } />
+
+			<div>
+				<p>
+					{ translate(
+						'Welcome to Jetpack Cloud. Authorize with your WordPress.com credentials to get started.'
+					) }
+				</p>
+				<Button primary href={ authUrl }>
+					{ translate( 'Authorize Jetpack Cloud' ) }
+				</Button>
+			</div>
+		</Main>
+	);
+};
+
+export default Connect;

--- a/client/landing/jetpack-cloud/sections/auth/connect/index.tsx
+++ b/client/landing/jetpack-cloud/sections/auth/connect/index.tsx
@@ -3,15 +3,18 @@
  */
 import React, { FunctionComponent } from 'react';
 import { useTranslate } from 'i18n-calypso';
-// import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies
  */
-// import config from 'config';
 import { Button } from '@automattic/components';
 import JetpackLogo from 'components/jetpack-logo';
 import Main from 'components/main';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
 
 interface Props {
 	authUrl: string;
@@ -22,9 +25,8 @@ const Connect: FunctionComponent< Props > = ( { authUrl } ) => {
 
 	return (
 		<Main className="connect">
-			<JetpackLogo full monochrome={ false } size={ 72 } />
-
-			<div>
+			<div className="connect__content">
+				<JetpackLogo full monochrome={ false } size={ 72 } />
 				<p>
 					{ translate(
 						'Welcome to Jetpack Cloud. Authorize with your WordPress.com credentials to get started.'

--- a/client/landing/jetpack-cloud/sections/auth/connect/index.tsx
+++ b/client/landing/jetpack-cloud/sections/auth/connect/index.tsx
@@ -1,8 +1,8 @@
 /**
  * External dependencies
  */
-import React, { FunctionComponent } from 'react';
 import { useTranslate } from 'i18n-calypso';
+import React, { FunctionComponent } from 'react';
 
 /**
  * Internal dependencies

--- a/client/landing/jetpack-cloud/sections/auth/connect/style.scss
+++ b/client/landing/jetpack-cloud/sections/auth/connect/style.scss
@@ -1,12 +1,14 @@
 .connect.main {
 	margin: auto;
+	max-width: 480px;
 }
 
 .connect__content {
+	align-items: center;
 	display: flex;
 	flex-direction: column;
-	align-items: center;
 	justify-content: center;
+	text-align: center;
 
 	& > * {
 		margin-bottom: 32px;

--- a/client/landing/jetpack-cloud/sections/auth/connect/style.scss
+++ b/client/landing/jetpack-cloud/sections/auth/connect/style.scss
@@ -1,0 +1,14 @@
+.connect.main {
+	margin: auto;
+}
+
+.connect__content {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+
+	& > * {
+		margin-bottom: 32px;
+	}
+}

--- a/client/landing/jetpack-cloud/sections/auth/controller.tsx
+++ b/client/landing/jetpack-cloud/sections/auth/controller.tsx
@@ -2,8 +2,9 @@
  * External dependencies
  */
 import { stringify } from 'qs';
-import React from 'react';
 import page from 'page';
+import React from 'react';
+import store from 'store';
 
 /**
  * Internal dependencies
@@ -11,11 +12,10 @@ import page from 'page';
 import config from 'config';
 import Connect from './connect';
 import GetToken from './get-token';
-import store from 'store';
 import userFactory from 'lib/user';
 import wpcom from 'lib/wp';
 
-import { authTokenRedirectPath } from './paths';
+import { authTokenRedirectPath, authConnectPath } from './paths';
 
 const WP_AUTHORIZE_ENDPOINT = 'https://public-api.wordpress.com/oauth2/authorize';
 
@@ -36,6 +36,8 @@ export const connect: PageJS.Callback = ( context, next ) => {
 		};
 
 		context.primary = <Connect authUrl={ `${ WP_AUTHORIZE_ENDPOINT }?${ stringify( params ) }` } />;
+	} else {
+		context.primary = <p>{ 'Oauth un-enabled!' }</p>;
 	}
 	// TODO: jetpack cloud needs oauth, give up otherwise
 
@@ -64,4 +66,12 @@ export const tokenRedirect: PageJS.Callback = ( context, next ) => {
 		} );
 
 	next();
+};
+
+export const logoutRedirect: PageJS.Callback = () => {
+	store.remove( 'wpcom_token' );
+	store.remove( 'wpcom_token_expires_in' );
+
+	// todo: remove token from wpcom undocumented
+	page.redirect( authConnectPath() );
 };

--- a/client/landing/jetpack-cloud/sections/auth/controller.tsx
+++ b/client/landing/jetpack-cloud/sections/auth/controller.tsx
@@ -41,7 +41,7 @@ export const connect: PageJS.Callback = ( context, next ) => {
 		// page.redirect( `${ WP_AUTHORIZE_ENDPOINT  }?${ stringify( params ) }` );
 		context.primary = <Connect authUrl={ `${ WP_AUTHORIZE_ENDPOINT }?${ stringify( params ) }` } />;
 	} else {
-		context.primary = <p>{ 'Oauth un-enabled!' }</p>;
+		context.primary = <p>{ 'Oauth un-enabled or client id missing!' }</p>;
 	}
 	next();
 };

--- a/client/landing/jetpack-cloud/sections/auth/controller.tsx
+++ b/client/landing/jetpack-cloud/sections/auth/controller.tsx
@@ -3,6 +3,7 @@
  */
 import { stringify } from 'qs';
 import React from 'react';
+import page from 'page';
 
 /**
  * Internal dependencies
@@ -30,11 +31,14 @@ export const connect: PageJS.Callback = ( context, next ) => {
 			client_id: config( 'oauth_client_id' ),
 			redirect_uri: redirectUri,
 			scope: 'global',
-			blog_id: 0,
+			type: 'jetpack-cloud',
+			cobrand: 1,
 		};
 
 		context.primary = <Connect authUrl={ `${ WP_AUTHORIZE_ENDPOINT }?${ stringify( params ) }` } />;
 	}
+	// TODO: jetpack cloud needs oauth, give up otherwise
+
 	next();
 };
 
@@ -52,11 +56,12 @@ export const tokenRedirect: PageJS.Callback = ( context, next ) => {
 	context.primary = <GetToken />;
 
 	// Fetch user and redirect to / on success.
-	const user = userFactory();
-	user.fetching = false;
-	user.fetch();
-	user.on( 'change', function() {
-		window.location = '/';
-	} );
+	userFactory()
+		.initialize()
+		.then( () => {
+			// debug( `Starting ${ appName }. Let's do this.` );
+			page( '/' );
+		} );
+
 	next();
 };

--- a/client/landing/jetpack-cloud/sections/auth/controller.tsx
+++ b/client/landing/jetpack-cloud/sections/auth/controller.tsx
@@ -34,8 +34,6 @@ export const connect: PageJS.Callback = ( context, next ) => {
 			client_id: config( 'oauth_client_id' ),
 			redirect_uri: redirectUri,
 			scope: 'global',
-			type: 'jetpack-cloud',
-			cobrand: 1,
 		};
 
 		// page.redirect( `${ WP_AUTHORIZE_ENDPOINT  }?${ stringify( params ) }` );

--- a/client/landing/jetpack-cloud/sections/auth/controller.tsx
+++ b/client/landing/jetpack-cloud/sections/auth/controller.tsx
@@ -1,0 +1,62 @@
+/**
+ * External dependencies
+ */
+import { stringify } from 'qs';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import config from 'config';
+import Connect from './connect';
+import GetToken from './get-token';
+import store from 'store';
+import userFactory from 'lib/user';
+import wpcom from 'lib/wp';
+
+import { authTokenRedirectPath } from './paths';
+
+const WP_AUTHORIZE_ENDPOINT = 'https://public-api.wordpress.com/oauth2/authorize';
+
+export const connect: PageJS.Callback = ( context, next ) => {
+	if ( config.isEnabled( 'oauth' ) && config( 'oauth_client_id' ) ) {
+		const protocol = config( 'protocol' );
+		const host = config( 'hostname' );
+		const port = config( 'port' );
+		const redirectUri = `${ protocol }://${ host }:${ port }${ authTokenRedirectPath() }`;
+
+		const params = {
+			response_type: 'token',
+			client_id: config( 'oauth_client_id' ),
+			redirect_uri: redirectUri,
+			scope: 'global',
+			blog_id: 0,
+		};
+
+		context.primary = <Connect authUrl={ `${ WP_AUTHORIZE_ENDPOINT }?${ stringify( params ) }` } />;
+	}
+	next();
+};
+
+export const tokenRedirect: PageJS.Callback = ( context, next ) => {
+	if ( context.hash && context.hash.access_token ) {
+		store.set( 'wpcom_token', context.hash.access_token );
+		wpcom.loadToken( context.hash.access_token );
+	}
+
+	if ( context.hash && context.hash.expires_in ) {
+		store.set( 'wpcom_token_expires_in', context.hash.expires_in );
+	}
+
+	// Extract this into a component...
+	context.primary = <GetToken />;
+
+	// Fetch user and redirect to / on success.
+	const user = userFactory();
+	user.fetching = false;
+	user.fetch();
+	user.on( 'change', function() {
+		window.location = '/';
+	} );
+	next();
+};

--- a/client/landing/jetpack-cloud/sections/auth/controller.tsx
+++ b/client/landing/jetpack-cloud/sections/auth/controller.tsx
@@ -5,6 +5,7 @@ import { stringify } from 'qs';
 import page from 'page';
 import React from 'react';
 import store from 'store';
+import debugFactory from 'debug';
 
 /**
  * Internal dependencies
@@ -12,12 +13,14 @@ import store from 'store';
 import config from 'config';
 import Connect from './connect';
 import GetToken from './get-token';
-import userFactory from 'lib/user';
+import userModule from 'lib/user';
 import wpcom from 'lib/wp';
+import { setCurrentUser } from 'state/current-user/actions';
 
 import { authTokenRedirectPath, authConnectPath } from './paths';
 
 const WP_AUTHORIZE_ENDPOINT = 'https://public-api.wordpress.com/oauth2/authorize';
+const debug = debugFactory( 'calypso:jetpack-cloud-connect' );
 
 export const connect: PageJS.Callback = ( context, next ) => {
 	if ( config.isEnabled( 'oauth' ) && config( 'oauth_client_id' ) ) {
@@ -35,22 +38,24 @@ export const connect: PageJS.Callback = ( context, next ) => {
 			cobrand: 1,
 		};
 
+		// page.redirect( `${ WP_AUTHORIZE_ENDPOINT  }?${ stringify( params ) }` );
 		context.primary = <Connect authUrl={ `${ WP_AUTHORIZE_ENDPOINT }?${ stringify( params ) }` } />;
 	} else {
 		context.primary = <p>{ 'Oauth un-enabled!' }</p>;
 	}
-	// TODO: jetpack cloud needs oauth, give up otherwise
-
 	next();
 };
 
 export const tokenRedirect: PageJS.Callback = ( context, next ) => {
 	if ( context.hash && context.hash.access_token ) {
+		debug( 'setting user token' );
 		store.set( 'wpcom_token', context.hash.access_token );
+		// this does not work!
 		wpcom.loadToken( context.hash.access_token );
 	}
 
 	if ( context.hash && context.hash.expires_in ) {
+		debug( 'setting user token_expires_in' );
 		store.set( 'wpcom_token_expires_in', context.hash.expires_in );
 	}
 
@@ -58,20 +63,32 @@ export const tokenRedirect: PageJS.Callback = ( context, next ) => {
 	context.primary = <GetToken />;
 
 	// Fetch user and redirect to / on success.
-	userFactory()
-		.initialize()
-		.then( () => {
-			// debug( `Starting ${ appName }. Let's do this.` );
-			page( '/' );
-		} );
+	debug( 'requesting new user' );
+
+	const user = userModule();
+
+	user.initialize().then( () => {
+		if ( user.data ) {
+			debug( 'setting current user' );
+			context.store.dispatch( setCurrentUser( user.data ) );
+		}
+		debug( 'redirecting' );
+		page.redirect( '/' );
+	} );
 
 	next();
 };
 
-export const logoutRedirect: PageJS.Callback = () => {
+export const logoutRedirect: PageJS.Callback = ( context ) => {
 	store.remove( 'wpcom_token' );
 	store.remove( 'wpcom_token_expires_in' );
 
-	// todo: remove token from wpcom undocumented
-	page.redirect( authConnectPath() );
+	wpcom.loadToken( null );
+	// this does not work like we would want
+	context.store.dispatch( setCurrentUser( { ID: null } ) );
+	userModule()
+		.clear()
+		.finally( () => {
+			page.redirect( authConnectPath() );
+		} );
 };

--- a/client/landing/jetpack-cloud/sections/auth/get-token/index.tsx
+++ b/client/landing/jetpack-cloud/sections/auth/get-token/index.tsx
@@ -1,0 +1,25 @@
+/**
+ * External dependencies
+ */
+import React, { FunctionComponent } from 'react';
+import { useTranslate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import JetpackLogo from 'components/jetpack-logo';
+import Main from 'components/main';
+import PulsingDot from 'components/pulsing-dot';
+
+const GetToken: FunctionComponent = () => {
+	const translate = useTranslate();
+	return (
+		<Main className="get-token">
+			<JetpackLogo full monochrome={ false } size={ 72 } />
+			<p>{ translate( 'Loading user…' ) }</p>
+			<PulsingDot active />
+		</Main>
+	);
+};
+
+export default GetToken;

--- a/client/landing/jetpack-cloud/sections/auth/index.ts
+++ b/client/landing/jetpack-cloud/sections/auth/index.ts
@@ -1,0 +1,19 @@
+/**
+ * External dependencies
+ */
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+import { authConnectPath, authTokenRedirectPath } from './paths';
+import { connect, tokenRedirect } from './controller';
+import { makeLayout, render as clientRender } from 'controller';
+import config from 'config';
+
+export default () => {
+	if ( config.isEnabled( 'jetpack-cloud' ) ) {
+		page( authConnectPath(), connect, makeLayout, clientRender );
+		page( authTokenRedirectPath(), tokenRedirect, makeLayout, clientRender );
+	}
+};

--- a/client/landing/jetpack-cloud/sections/auth/index.ts
+++ b/client/landing/jetpack-cloud/sections/auth/index.ts
@@ -6,8 +6,8 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import { authConnectPath, authTokenRedirectPath } from './paths';
-import { connect, tokenRedirect } from './controller';
+import { authConnectPath, authConnectLogoutPath, authTokenRedirectPath } from './paths';
+import { connect, logoutRedirect, tokenRedirect } from './controller';
 import { makeLayout, render as clientRender } from 'controller';
 import config from 'config';
 
@@ -15,5 +15,6 @@ export default () => {
 	if ( config.isEnabled( 'jetpack-cloud' ) ) {
 		page( authConnectPath(), connect, makeLayout, clientRender );
 		page( authTokenRedirectPath(), tokenRedirect, makeLayout, clientRender );
+		page( authConnectLogoutPath(), logoutRedirect, makeLayout, clientRender );
 	}
 };

--- a/client/landing/jetpack-cloud/sections/auth/paths.ts
+++ b/client/landing/jetpack-cloud/sections/auth/paths.ts
@@ -1,0 +1,3 @@
+export const authConnectPath = () => '/connect';
+
+export const authTokenRedirectPath = () => '/connect/oauth/token';

--- a/client/landing/jetpack-cloud/sections/auth/paths.ts
+++ b/client/landing/jetpack-cloud/sections/auth/paths.ts
@@ -1,3 +1,5 @@
 export const authConnectPath = () => '/connect';
 
 export const authTokenRedirectPath = () => '/connect/oauth/token';
+
+export const authConnectLogoutPath = () => '/connect/logout';

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -96,6 +96,8 @@ const LayoutLoggedOut = ( {
 
 			masterbar = <OauthClientMasterbar oauth2Client={ oauth2Client } />;
 		}
+	} else if ( config.isEnabled( 'jetpack-cloud' ) ) {
+		masterbar = null;
 	} else {
 		masterbar = (
 			<MasterbarLoggedOut

--- a/client/lib/wpcom-xhr-wrapper/index.js
+++ b/client/lib/wpcom-xhr-wrapper/index.js
@@ -1,8 +1,6 @@
 /**
  * External dependencies
  */
-
-import xhr from 'wpcom-xhr-request';
 import debugModule from 'debug';
 
 /**
@@ -11,12 +9,14 @@ import debugModule from 'debug';
 const debug = debugModule( 'calypso:wpcom-xhr-wrapper' );
 
 export default function ( params, callback ) {
-	return xhr( params, function ( error, response, headers ) {
-		if ( error && error.name === 'InvalidTokenError' ) {
-			debug( 'Invalid token error detected, authorisation probably revoked - logging out' );
-			require( 'lib/user/utils' ).logout();
-		}
+	return import( /* webpackChunkName: "wpcom-xhr-request" */ 'wpcom-xhr-request' ).then( ( xhr ) =>
+		xhr.default( params, function ( error, response, headers ) {
+			if ( error && error.name === 'InvalidTokenError' ) {
+				debug( 'Invalid token error detected, authorisation probably revoked - logging out' );
+				require( 'lib/user/utils' ).logout();
+			}
 
-		callback( error, response, headers );
-	} );
+			callback( error, response, headers );
+		} )
+	);
 }

--- a/client/root.js
+++ b/client/root.js
@@ -35,6 +35,12 @@ function setupLoggedOut() {
 		page( '/', () => {
 			page.redirect( '/devdocs/start' );
 		} );
+	} else if ( config.isEnabled( 'jetpack-cloud' ) ) {
+		page( '/', () => {
+			if ( config.isEnabled( 'oauth' ) ) {
+				page.redirect( '/connect' );
+			}
+		} );
 	}
 }
 

--- a/client/sections.js
+++ b/client/sections.js
@@ -497,6 +497,14 @@ const sections = [
 		group: 'jetpack-cloud',
 		enableLoggedOut: true,
 	},
+	{
+		name: 'jetpack-cloud-auth',
+		paths: [ '/connect', '/connect/oauth/token' ],
+		module: 'landing/jetpack-cloud/sections/auth',
+		secondary: true,
+		group: 'jetpack-cloud',
+		enableLoggedOut: true,
+	},
 ];
 
 for ( const extension of require( './extensions' ) ) {

--- a/client/server/api/index.js
+++ b/client/server/api/index.js
@@ -18,7 +18,7 @@ module.exports = function () {
 		response.json( { version } );
 	} );
 
-	if ( config.isEnabled( 'oauth' ) ) {
+	if ( config.isEnabled( 'oauth' ) && ! config.isEnabled( 'jetpack-cloud' ) ) {
 		oauth( app );
 	}
 

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -57,6 +57,10 @@ const shouldBuildChunksMap =
 	process.env.ENABLE_FEATURES === 'use-translation-chunks';
 const isCalypsoClient = process.env.BROWSERSLIST_ENV !== 'server';
 const isDesktop = calypsoEnv === 'desktop' || calypsoEnv === 'desktop-development';
+const isJetpackCloud =
+	calypsoEnv === 'jetpack-cloud-stage' ||
+	calypsoEnv === 'jetpack-cloud-development' ||
+	calypsoEnv === 'jetpack-cloud-production';
 
 const defaultBrowserslistEnv = isCalypsoClient && ! isDesktop ? 'evergreen' : 'defaults';
 const browserslistEnv = process.env.BROWSERSLIST_ENV || defaultBrowserslistEnv;
@@ -316,7 +320,7 @@ if ( isCalypsoClient ) {
 // Don't bundle `wpcom-xhr-request` for the browser.
 // Even though it's requested, we don't need it on the browser, because we're using
 // `wpcom-proxy-request` instead. Keep it for desktop and server, though.
-if ( isCalypsoClient && ! isDesktop ) {
+if ( isCalypsoClient && ! isDesktop && ! isJetpackCloud ) {
 	webpackConfig.plugins.push(
 		new webpack.NormalModuleReplacementPlugin( /^wpcom-xhr-request$/, 'lodash-es/noop' )
 	);

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -57,10 +57,6 @@ const shouldBuildChunksMap =
 	process.env.ENABLE_FEATURES === 'use-translation-chunks';
 const isCalypsoClient = process.env.BROWSERSLIST_ENV !== 'server';
 const isDesktop = calypsoEnv === 'desktop' || calypsoEnv === 'desktop-development';
-const isJetpackCloud =
-	calypsoEnv === 'jetpack-cloud-stage' ||
-	calypsoEnv === 'jetpack-cloud-development' ||
-	calypsoEnv === 'jetpack-cloud-production';
 
 const defaultBrowserslistEnv = isCalypsoClient && ! isDesktop ? 'evergreen' : 'defaults';
 const browserslistEnv = process.env.BROWSERSLIST_ENV || defaultBrowserslistEnv;
@@ -315,15 +311,6 @@ if ( ! config.isEnabled( 'desktop' ) ) {
 // Replace `lodash` with `lodash-es`.
 if ( isCalypsoClient ) {
 	webpackConfig.plugins.push( new ExtensiveLodashReplacementPlugin() );
-}
-
-// Don't bundle `wpcom-xhr-request` for the browser.
-// Even though it's requested, we don't need it on the browser, because we're using
-// `wpcom-proxy-request` instead. Keep it for desktop and server, though.
-if ( isCalypsoClient && ! isDesktop && ! isJetpackCloud ) {
-	webpackConfig.plugins.push(
-		new webpack.NormalModuleReplacementPlugin( /^wpcom-xhr-request$/, 'lodash-es/noop' )
-	);
 }
 
 if ( isCalypsoClient && browserslistEnv === 'evergreen' ) {

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -6,7 +6,7 @@
 	"protocol": "http",
 	"hostname": "jetpack.cloud.localhost",
 	"i18n_default_locale_slug": "en",
-	"port": 3000,
+	"port": 3001,
 	"rtl": false,
 	"login_url": "/connect",
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -8,7 +8,7 @@
 	"i18n_default_locale_slug": "en",
 	"port": 3000,
 	"rtl": false,
-	"login_url": "https://wordpress.com/wp-login.php",
+	"login_url": "/connect",
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
 	"site_name": "Jetpack.com",
 	"features": {
@@ -16,17 +16,18 @@
 		"current-site/notice": false,
 		"current-site/stale-cart-notice": false,
 		"jetpack-cloud": true,
-		"jetpack-cloud/backups": true,
 		"jetpack-cloud/backups-restore": true,
-		"jetpack-cloud/settings": true,
-		"jetpack-cloud/scan": true,
-		"jetpack-cloud/scan-history": true,
+		"jetpack-cloud/backups": true,
 		"jetpack-cloud/on-demand-scan": true,
+		"jetpack-cloud/scan-history": true,
+		"jetpack-cloud/scan": true,
+		"jetpack-cloud/settings": true,
 		"layout/app-banner": false,
 		"layout/guided-tours": false,
 		"layout/nps-survey-notice": false,
-		"layout/support-article-dialog": false,
 		"layout/query-selected-editor": false,
+		"layout/support-article-dialog": false,
+		"oauth": true,
 		"site-indicator": false
 	},
 	"enable_all_sections": false,
@@ -34,7 +35,8 @@
 		"jetpack-cloud": true,
 		"scan": true,
 		"backups": true,
-		"jetpack-cloud-settings": true
+		"jetpack-cloud-settings": true,
+		"jetpack-cloud-auth": true
 	},
 	"site_filter": [ "jetpack" ],
 	"theme": "jetpack-cloud"

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -11,6 +11,7 @@
 	"login_url": "/connect",
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
 	"site_name": "Jetpack.com",
+	"oauth_client_id": 68663,
 	"features": {
 		"current-site/domain-warning": false,
 		"current-site/notice": false,

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -6,7 +6,7 @@
 	"protocol": "http",
 	"hostname": "jetpack.cloud.localhost",
 	"i18n_default_locale_slug": "en",
-	"port": 3001,
+	"port": 3000,
 	"rtl": false,
 	"login_url": "/connect",
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout",

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -9,7 +9,7 @@
 	"port": 3001,
 	"rtl": false,
 	"login_url": "/connect",
-	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
+	"logout_url": "https://wordpress.com/wp-login.php?action=logout",
 	"site_name": "Jetpack.com",
 	"oauth_client_id": 68663,
 	"features": {

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -9,6 +9,7 @@
 	"login_url": "/connect",
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
 	"site_name": "Jetpack.com",
+	"oauth_client_id": 68663,
 	"features": {
 		"current-site/domain-warning": false,
 		"current-site/notice": false,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -6,7 +6,7 @@
 	"hostname": "cloud.jetpack.com",
 	"i18n_default_locale_slug": "en",
 	"rtl": false,
-	"login_url": "https://wordpress.com/wp-login.php",
+	"login_url": "/connect",
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
 	"site_name": "Jetpack.com",
 	"features": {
@@ -14,17 +14,18 @@
 		"current-site/notice": false,
 		"current-site/stale-cart-notice": false,
 		"jetpack-cloud": true,
-		"jetpack-cloud/backups": true,
 		"jetpack-cloud/backups-restore": true,
-		"jetpack-cloud/settings": true,
-		"jetpack-cloud/scan": true,
-		"jetpack-cloud/scan-history": true,
+		"jetpack-cloud/backups": true,
 		"jetpack-cloud/on-demand-scan": false,
+		"jetpack-cloud/scan-history": true,
+		"jetpack-cloud/scan": true,
+		"jetpack-cloud/settings": true,
 		"layout/app-banner": false,
 		"layout/guided-tours": false,
 		"layout/nps-survey-notice": false,
-		"layout/support-article-dialog": false,
 		"layout/query-selected-editor": false,
+		"layout/support-article-dialog": false,
+		"oauth": true,
 		"site-indicator": false
 	},
 	"enable_all_sections": false,
@@ -32,7 +33,8 @@
 		"jetpack-cloud": true,
 		"scan": true,
 		"backups": true,
-		"jetpack-cloud-settings": true
+		"jetpack-cloud-settings": true,
+		"jetpack-cloud-auth": true
 	},
 	"site_filter": [ "jetpack" ],
 	"theme": "jetpack-cloud"

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -7,7 +7,7 @@
 	"i18n_default_locale_slug": "en",
 	"rtl": false,
 	"login_url": "/connect",
-	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
+	"logout_url": "https://wordpress.com/wp-login.php?action=logout",
 	"site_name": "Jetpack.com",
 	"oauth_client_id": 69041,
 	"features": {

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -9,7 +9,7 @@
 	"login_url": "/connect",
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
 	"site_name": "Jetpack.com",
-	"oauth_client_id": 68663,
+	"oauth_client_id": 69041,
 	"features": {
 		"current-site/domain-warning": false,
 		"current-site/notice": false,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -9,6 +9,7 @@
 	"login_url": "/connect",
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
 	"site_name": "Jetpack.com",
+	"oauth_client_id": 68663,
 	"features": {
 		"current-site/domain-warning": false,
 		"current-site/notice": false,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -6,7 +6,7 @@
 	"hostname": "cloud.jetpack.com",
 	"i18n_default_locale_slug": "en",
 	"rtl": false,
-	"login_url": "https://wordpress.com/wp-login.php",
+	"login_url": "/connect",
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
 	"site_name": "Jetpack.com",
 	"features": {
@@ -14,17 +14,18 @@
 		"current-site/notice": false,
 		"current-site/stale-cart-notice": false,
 		"jetpack-cloud": true,
-		"jetpack-cloud/backups": true,
 		"jetpack-cloud/backups-restore": true,
-		"jetpack-cloud/settings": true,
-		"jetpack-cloud/scan": true,
-		"jetpack-cloud/scan-history": true,
+		"jetpack-cloud/backups": true,
 		"jetpack-cloud/on-demand-scan": true,
+		"jetpack-cloud/scan-history": true,
+		"jetpack-cloud/scan": true,
+		"jetpack-cloud/settings": true,
 		"layout/app-banner": false,
 		"layout/guided-tours": false,
 		"layout/nps-survey-notice": false,
-		"layout/support-article-dialog": false,
 		"layout/query-selected-editor": false,
+		"layout/support-article-dialog": false,
+		"oauth": true,
 		"site-indicator": false
 	},
 	"enable_all_sections": false,
@@ -32,7 +33,8 @@
 		"jetpack-cloud": true,
 		"scan": true,
 		"backups": true,
-		"jetpack-cloud-settings": true
+		"jetpack-cloud-settings": true,
+		"jetpack-cloud-auth": true
 	},
 	"site_filter": [ "jetpack" ],
 	"theme": "jetpack-cloud"

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -7,7 +7,7 @@
 	"i18n_default_locale_slug": "en",
 	"rtl": false,
 	"login_url": "/connect",
-	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
+	"logout_url": "https://wordpress.com/wp-login.php?action=logout",
 	"site_name": "Jetpack.com",
 	"oauth_client_id": 69040,
 	"features": {

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -9,7 +9,7 @@
 	"login_url": "/connect",
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
 	"site_name": "Jetpack.com",
-	"oauth_client_id": 68663,
+	"oauth_client_id": 69040,
 	"features": {
 		"current-site/domain-warning": false,
 		"current-site/notice": false,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Switch Jetpack Cloud from proxy requests to xhr w/ token
* Add flow for Jetpack Cloud to use implicit OAuth to authorize users and retrieve token
* use dynamic import for `wpcom-xhr-request` module instead of excluding at build time

#### Testing Instructions

1. start jetpack cloud in a fresh or private browser window ( optional w/ third part cookies blocked )
2. Navigate to jetpack cloud and verify you get the ( undesigned & placeholder ) logged out page:
<img width="550" alt="Screen Shot 2020-04-28 at 8 44 16 AM" src="https://user-images.githubusercontent.com/2810519/80508103-76a03a80-892c-11ea-876b-0207736b0d76.png">
3. Click "Authorize Jetpack Cloud" and log onto WordPress.com
4. Verify that you are sent back to Jetpack Cloud, and you are now logged on and network requests


#### Next Steps

* Get and implement design for the new ui components
* Finish implementing logout flow
* Devise strategy for storing oauth client id