### PR TITLE
Jetpack Cloud: Improve/collapse server creds form when connected

### DIFF
--- a/client/landing/jetpack-cloud/sections/settings/main.jsx
+++ b/client/landing/jetpack-cloud/sections/settings/main.jsx
@@ -1,9 +1,9 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
-import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { localize, useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -27,95 +27,91 @@ import './style.scss';
 import connectedIcon from './images/server-connected.svg';
 import disconnectedIcon from './images/server-disconnected.svg';
 
-class SettingsPage extends Component {
-	renderServerConnectionStatus() {
-		const { translate, rewind } = this.props;
+const connectedProps = ( translate ) => ( {
+	iconPath: connectedIcon,
+	className: 'settings_connected',
+	title: translate( 'Server status: Connected' ),
+	content: translate( 'One-click restores are enabled.' ),
+} );
 
-		const isConnected = 'active' === rewind.state;
+const disconnectedProps = ( translate ) => ( {
+	iconPath: disconnectedIcon,
+	className: 'settings_disconnected',
+	title: translate( 'Server status: Not connected' ),
+	content: translate(
+		'Enter your server credentials to enable one-click restores for Backups. {{a}}Need help? Find your server credentials{{/a}}',
+		{
+			components: {
+				a: (
+					<ExternalLink
+						className="settings__link-external"
+						icon
+						href="https://jetpack.com/support/adding-credentials-to-jetpack/"
+					/>
+				),
+			},
+		}
+	),
+} );
 
-		const iconPath = isConnected ? connectedIcon : disconnectedIcon;
-		const myClassName = isConnected ? 'settings__connected' : 'settings__disconnected';
-		const title = isConnected
-			? translate( 'Server status: Connected' )
-			: translate( 'Server status: Not connected' );
-		const content = isConnected
-			? translate( 'One-click restores are enabled.' )
-			: translate(
-					'Enter your server credentials to enable one-click restores for Backups. {{a}}Need help? Find your server credentials{{/a}}',
-					{
-						components: {
-							a: (
-								<ExternalLink
-									className="settings__link-external"
-									icon
-									href="https://jetpack.com/support/adding-credentials-to-jetpack/"
-								/>
-							),
-						},
-					}
-			  );
+const ConnectionStatus = ( { rewindState } ) => {
+	const translate = useTranslate();
 
-		return (
-			<Card compact={ true } className={ myClassName }>
-				<img className="settings__icon" src={ iconPath } alt="" />
-				<div className="settings__details">
-					<div className="settings__details-head"> { title } </div>
-					<div>{ content }</div>
-				</div>
-			</Card>
-		);
+	if ( rewindState === 'uninitialized' ) {
+		return <div className="settings__is-uninitialized" />;
 	}
 
-	logOut() {
-		// Clears everything user related on the client site by
-		// calling user.clear() which calls store.clearAll();
-		userUtilities.logout();
-		// @todo: track event (what type?)
-	}
+	const isConnected = 'active' === rewindState;
+	const cardProps = isConnected ? connectedProps( translate ) : disconnectedProps( translate );
 
-	render() {
-		const { rewind, siteId, translate } = this.props;
+	return (
+		<Card compact={ true } className={ cardProps.className }>
+			<img className="settings__icon" src={ cardProps.iconPath } alt="" />
+			<div className="settings__details">
+				<div className="settings__details-head"> { cardProps.title } </div>
+				<div>{ cardProps.content }</div>
+			</div>
+		</Card>
+	);
+};
 
-		const isInitialized = ! ( 'uninitialized' === rewind.state );
+const SettingsPage = () => {
+	const translate = useTranslate();
+	const siteId = useSelector( getSelectedSiteId );
+	const rewind = useSelector( ( state ) => getRewindState( state, siteId ) );
 
-		return (
-			<Main className="settings">
-				<DocumentHead title={ translate( 'Settings' ) } />
-				<SidebarNavigation />
-				<QueryRewindState siteId={ siteId } />
-				<PageViewTracker path="/settings/:site" title="Settings" />
+	// Clears everything user related on the client site by
+	// calling user.clear() which calls store.clearAll();
+	// @todo: track event (what type?)
+	const logOut = () => userUtilities.logout();
 
-				<Button primary scary onClick={ this.logOut }>
-					Log out
-				</Button>
+	return (
+		<Main className="settings">
+			<DocumentHead title={ translate( 'Settings' ) } />
+			<SidebarNavigation />
+			<QueryRewindState siteId={ siteId } />
+			<PageViewTracker path="/settings/:site" title="Settings" />
 
-				<div className="settings__title">
-					<h2>{ translate( 'Server connection details' ) }</h2>
-				</div>
+			<Button primary scary onClick={ logOut }>
+				Log out
+			</Button>
 
-				{ isInitialized && this.renderServerConnectionStatus() }
+			<div className="settings__title">
+				<h2>{ translate( 'Server connection details' ) }</h2>
+			</div>
 
-				{ ! isInitialized && <div className="settings__is-uninitialized" /> }
+			<ConnectionStatus rewindState={ rewind.state } />
 
-				<ServerCredentialsForm
-					role="main"
-					siteId={ siteId }
-					labels={ {
-						save: translate( 'Save credentials' ),
-					} }
-					showCancelButton={ false }
-				/>
-			</Main>
-		);
-	}
-}
+			<ServerCredentialsForm
+				role="main"
+				siteId={ siteId }
+				labels={ {
+					save: translate( 'Save credentials' ),
+				} }
+				showCancelButton={ false }
+			/>
+		</Main>
+	);
+};
 
-export default connect( ( state ) => {
-	const siteId = getSelectedSiteId( state );
-	const rewind = getRewindState( state, siteId );
-
-	return {
-		siteId,
-		rewind,
-	};
-} )( localize( SettingsPage ) );
+export default localize( SettingsPage );

--- a/client/landing/jetpack-cloud/sections/settings/style.scss
+++ b/client/landing/jetpack-cloud/sections/settings/style.scss
@@ -18,9 +18,20 @@
     height: 4rem;
 }
 
-.settings__is-uninitialized {
-	height: 100px;
-	margin-bottom: 32px;
+.settings__status-uninitialized {
+	height: 90px;
+	margin-bottom: 8px;
+	@include placeholder( --color-neutral-10 );
+}
+
+.settings__form-card {
+	margin-top: 8px;
+	background: none;
+	box-shadow: none;
+}
+
+.settings__form-uninitialized {
+	height: 64px;
 	@include placeholder( --color-neutral-10 );
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* On the Settings page, put server connection details inside a foldable card element with no background or border, per design documents (see referenced task).
* When Backup/Scan are **connected**, connection details are **hidden/folded** by default.
* When Backup/Scan are **not** connected, connection details are **shown/unfolded** by default.

Fixes `1169345694087188-as-1174867022546268`

#### Testing instructions

* Prerequisite: have a Jetpack site with Backup/Scan, either connected or disconnected.
* For connected sites:
  * On Jetpack Cloud, select the connected site.
  * Go to Settings.
  * As the page loads, observe placeholders for the connection status **and the connection details form.**
  * When the page loads, a foldable card should display (as **collapsed**) with a transparent background, no border, and the caption "Show connection details"
  * Open the foldable card; observe the card caption change to "Hide connection details" and the connection details should be displayed
  * On mobile layouts, observe the "Save credentials" button is as wide as the other form elements and is centered.
  * Collapse the card again and observe the state returns to what it was initially.
* For disconnected sites, follow the above instructions for connected sites, **except**:
  * The initial state should show the connection details form as open/unfolded;
  * The card caption should initially be "Hide connection details"
  * Click the card to fold it, and observe the caption changes to "Show connection details"

#### Screenshots

##### Loading

<img width="711" alt="loading-desktop" src="https://user-images.githubusercontent.com/670067/82369832-40128880-99dd-11ea-9795-e5cdc75d8bcf.png">

<img width="404" alt="loading-mobile" src="https://user-images.githubusercontent.com/670067/82369835-40128880-99dd-11ea-94f9-28d272d350fe.png">

##### Connected and closed (default behavior)

<img width="715" alt="connected-closed-desktop" src="https://user-images.githubusercontent.com/670067/82369826-3ee15b80-99dd-11ea-95f1-1d68d5e1ea96.png">

<img width="393" alt="connected-closed-mobile" src="https://user-images.githubusercontent.com/670067/82369827-3ee15b80-99dd-11ea-845a-e33c0318eaf6.png">

##### Connected and open (user-triggered behavior)

<img width="706" alt="connected-open-desktop" src="https://user-images.githubusercontent.com/670067/82369828-3f79f200-99dd-11ea-9685-3ba7a969dbca.png">

<img width="393" alt="connected-open-mobile" src="https://user-images.githubusercontent.com/670067/82369830-3f79f200-99dd-11ea-9e8b-3a4219971ee4.png">

##### Disconnected and open (default behavior)

<img width="701" alt="not-connected-open-desktop" src="https://user-images.githubusercontent.com/670067/82369841-40ab1f00-99dd-11ea-9ed6-b8dcd1a18eb4.png">

<img width="388" alt="not-connected-open-mobile" src="https://user-images.githubusercontent.com/670067/82369843-40ab1f00-99dd-11ea-88d8-d4d3395a3fec.png">

##### Disconnected and closed (user-triggered behavior)

<img width="700" alt="not-connected-closed-desktop" src="https://user-images.githubusercontent.com/670067/82369837-40128880-99dd-11ea-99b6-441e61007a13.png">

<img width="392" alt="not-connected-closed-mobile" src="https://user-images.githubusercontent.com/670067/82369839-40ab1f00-99dd-11ea-9860-7d0bc93f3bd8.png">

##### Bottom of mobile menu, showing full-width "Save credentials" button

<img width="390" alt="card-bottom-mobile" src="https://user-images.githubusercontent.com/670067/82369824-3ee15b80-99dd-11ea-98a0-7ec32b384d0f.png">

