### PR TITLE
Gutenborading: premium design flow

### DIFF
--- a/client/landing/gutenboarding/available-designs.ts
+++ b/client/landing/gutenboarding/available-designs.ts
@@ -24,7 +24,7 @@ const availableDesigns: Readonly< AvailableDesigns > = {
 				base: 'Fira Sans',
 			},
 			categories: [ 'featured', 'blog' ],
-			is_premium: false,
+			is_premium: true,
 		},
 		{
 			title: 'Vesta',

--- a/client/landing/gutenboarding/available-designs.ts
+++ b/client/landing/gutenboarding/available-designs.ts
@@ -35,6 +35,7 @@ const availableDesigns: Readonly< AvailableDesigns > = {
 				base: 'Raleway',
 			},
 			categories: [ 'featured', 'portfolio' ],
+			premium: true,
 		},
 		{
 			title: 'Easley',
@@ -119,7 +120,6 @@ const availableDesigns: Readonly< AvailableDesigns > = {
 				base: 'Fira Sans',
 			},
 			categories: [ 'featured', 'blog' ],
-			premium: true,
 		},
 	],
 };

--- a/client/landing/gutenboarding/available-designs.ts
+++ b/client/landing/gutenboarding/available-designs.ts
@@ -119,6 +119,7 @@ const availableDesigns: Readonly< AvailableDesigns > = {
 				base: 'Fira Sans',
 			},
 			categories: [ 'featured', 'blog' ],
+			premium: true,
 		},
 	],
 };

--- a/client/landing/gutenboarding/available-designs.ts
+++ b/client/landing/gutenboarding/available-designs.ts
@@ -11,7 +11,7 @@ const availableDesigns: Readonly< AvailableDesigns > = {
 				base: 'Open Sans',
 			},
 			categories: [ 'featured', 'blog' ],
-			is_premium: false,
+			is_premium: true,
 		},
 		{
 			title: 'Cassel',
@@ -37,7 +37,7 @@ const availableDesigns: Readonly< AvailableDesigns > = {
 				base: 'Raleway',
 			},
 			categories: [ 'featured', 'portfolio' ],
-			is_premium: true,
+			is_premium: false,
 		},
 		{
 			title: 'Easley',
@@ -128,7 +128,7 @@ const availableDesigns: Readonly< AvailableDesigns > = {
 				base: 'Fira Sans',
 			},
 			categories: [ 'featured', 'blog' ],
-			is_premium: false,
+			is_premium: true,
 		},
 	],
 };

--- a/client/landing/gutenboarding/available-designs.ts
+++ b/client/landing/gutenboarding/available-designs.ts
@@ -11,7 +11,7 @@ const availableDesigns: Readonly< AvailableDesigns > = {
 				base: 'Open Sans',
 			},
 			categories: [ 'featured', 'blog' ],
-			premium: false,
+			is_premium: false,
 		},
 		{
 			title: 'Cassel',
@@ -24,7 +24,7 @@ const availableDesigns: Readonly< AvailableDesigns > = {
 				base: 'Fira Sans',
 			},
 			categories: [ 'featured', 'blog' ],
-			premium: false,
+			is_premium: false,
 		},
 		{
 			title: 'Vesta',
@@ -37,7 +37,7 @@ const availableDesigns: Readonly< AvailableDesigns > = {
 				base: 'Raleway',
 			},
 			categories: [ 'featured', 'portfolio' ],
-			premium: true,
+			is_premium: true,
 		},
 		{
 			title: 'Easley',
@@ -50,7 +50,7 @@ const availableDesigns: Readonly< AvailableDesigns > = {
 				base: 'Roboto',
 			},
 			categories: [ 'featured', 'portfolio' ],
-			premium: false,
+			is_premium: false,
 		},
 		{
 			title: 'Camdem',
@@ -63,7 +63,7 @@ const availableDesigns: Readonly< AvailableDesigns > = {
 				base: 'Roboto',
 			},
 			categories: [ 'featured', 'portfolio' ],
-			premium: false,
+			is_premium: false,
 		},
 		{
 			title: 'Reynolds',
@@ -76,7 +76,7 @@ const availableDesigns: Readonly< AvailableDesigns > = {
 				base: 'Fira Sans',
 			},
 			categories: [ 'featured', 'portfolio' ],
-			premium: false,
+			is_premium: false,
 		},
 		{
 			title: 'Overton',
@@ -89,7 +89,7 @@ const availableDesigns: Readonly< AvailableDesigns > = {
 				base: 'Raleway',
 			},
 			categories: [ 'featured', 'business' ],
-			premium: false,
+			is_premium: false,
 		},
 		{
 			title: 'Doyle',
@@ -102,7 +102,7 @@ const availableDesigns: Readonly< AvailableDesigns > = {
 				base: 'Fira Sans',
 			},
 			categories: [ 'featured', 'business' ],
-			premium: false,
+			is_premium: false,
 		},
 		{
 			title: 'Brice',
@@ -115,7 +115,7 @@ const availableDesigns: Readonly< AvailableDesigns > = {
 				base: 'Fira Sans',
 			},
 			categories: [ 'featured', 'charity', 'non-profit' ],
-			premium: false,
+			is_premium: false,
 		},
 		{
 			title: 'Bowen',
@@ -128,7 +128,7 @@ const availableDesigns: Readonly< AvailableDesigns > = {
 				base: 'Fira Sans',
 			},
 			categories: [ 'featured', 'blog' ],
-			premium: false,
+			is_premium: false,
 		},
 	],
 };

--- a/client/landing/gutenboarding/available-designs.ts
+++ b/client/landing/gutenboarding/available-designs.ts
@@ -24,7 +24,7 @@ const availableDesigns: Readonly< AvailableDesigns > = {
 				base: 'Fira Sans',
 			},
 			categories: [ 'featured', 'blog' ],
-			is_premium: true,
+			is_premium: false,
 		},
 		{
 			title: 'Vesta',
@@ -40,6 +40,19 @@ const availableDesigns: Readonly< AvailableDesigns > = {
 			is_premium: false,
 		},
 		{
+			title: 'Doyle',
+			slug: 'doyle',
+			template: 'doyle',
+			theme: 'alves',
+			src: 'https://public-api.wordpress.com/rest/v1/template/demo/alves/doyle/',
+			fonts: {
+				headings: 'Playfair Display',
+				base: 'Fira Sans',
+			},
+			categories: [ 'featured', 'business' ],
+			is_premium: true,
+		},
+		{
 			title: 'Bowen',
 			slug: 'bowen',
 			template: 'bowen',
@@ -50,7 +63,7 @@ const availableDesigns: Readonly< AvailableDesigns > = {
 				base: 'Fira Sans',
 			},
 			categories: [ 'featured', 'blog' ],
-			is_premium: true,
+			is_premium: false,
 		},
 		{
 			title: 'Easley',
@@ -100,19 +113,6 @@ const availableDesigns: Readonly< AvailableDesigns > = {
 			fonts: {
 				headings: 'Cabin',
 				base: 'Raleway',
-			},
-			categories: [ 'featured', 'business' ],
-			is_premium: false,
-		},
-		{
-			title: 'Doyle',
-			slug: 'doyle',
-			template: 'doyle',
-			theme: 'alves',
-			src: 'https://public-api.wordpress.com/rest/v1/template/demo/alves/doyle/',
-			fonts: {
-				headings: 'Playfair Display',
-				base: 'Fira Sans',
 			},
 			categories: [ 'featured', 'business' ],
 			is_premium: false,

--- a/client/landing/gutenboarding/available-designs.ts
+++ b/client/landing/gutenboarding/available-designs.ts
@@ -11,6 +11,7 @@ const availableDesigns: Readonly< AvailableDesigns > = {
 				base: 'Open Sans',
 			},
 			categories: [ 'featured', 'blog' ],
+			premium: false,
 		},
 		{
 			title: 'Cassel',
@@ -23,6 +24,7 @@ const availableDesigns: Readonly< AvailableDesigns > = {
 				base: 'Fira Sans',
 			},
 			categories: [ 'featured', 'blog' ],
+			premium: false,
 		},
 		{
 			title: 'Vesta',
@@ -48,6 +50,7 @@ const availableDesigns: Readonly< AvailableDesigns > = {
 				base: 'Roboto',
 			},
 			categories: [ 'featured', 'portfolio' ],
+			premium: false,
 		},
 		{
 			title: 'Camdem',
@@ -60,6 +63,7 @@ const availableDesigns: Readonly< AvailableDesigns > = {
 				base: 'Roboto',
 			},
 			categories: [ 'featured', 'portfolio' ],
+			premium: false,
 		},
 		{
 			title: 'Reynolds',
@@ -72,6 +76,7 @@ const availableDesigns: Readonly< AvailableDesigns > = {
 				base: 'Fira Sans',
 			},
 			categories: [ 'featured', 'portfolio' ],
+			premium: false,
 		},
 		{
 			title: 'Overton',
@@ -84,6 +89,7 @@ const availableDesigns: Readonly< AvailableDesigns > = {
 				base: 'Raleway',
 			},
 			categories: [ 'featured', 'business' ],
+			premium: false,
 		},
 		{
 			title: 'Doyle',
@@ -96,6 +102,7 @@ const availableDesigns: Readonly< AvailableDesigns > = {
 				base: 'Fira Sans',
 			},
 			categories: [ 'featured', 'business' ],
+			premium: false,
 		},
 		{
 			title: 'Brice',
@@ -108,6 +115,7 @@ const availableDesigns: Readonly< AvailableDesigns > = {
 				base: 'Fira Sans',
 			},
 			categories: [ 'featured', 'charity', 'non-profit' ],
+			premium: false,
 		},
 		{
 			title: 'Bowen',
@@ -120,6 +128,7 @@ const availableDesigns: Readonly< AvailableDesigns > = {
 				base: 'Fira Sans',
 			},
 			categories: [ 'featured', 'blog' ],
+			premium: false,
 		},
 	],
 };

--- a/client/landing/gutenboarding/available-designs.ts
+++ b/client/landing/gutenboarding/available-designs.ts
@@ -40,6 +40,19 @@ const availableDesigns: Readonly< AvailableDesigns > = {
 			is_premium: false,
 		},
 		{
+			title: 'Bowen',
+			slug: 'bowen',
+			template: 'bowen',
+			theme: 'coutoire',
+			src: 'https://public-api.wordpress.com/rest/v1/template/demo/coutoire/bowen/',
+			fonts: {
+				headings: 'Playfair Display',
+				base: 'Fira Sans',
+			},
+			categories: [ 'featured', 'blog' ],
+			is_premium: true,
+		},
+		{
 			title: 'Easley',
 			slug: 'easley',
 			template: 'easley',
@@ -116,19 +129,6 @@ const availableDesigns: Readonly< AvailableDesigns > = {
 			},
 			categories: [ 'featured', 'charity', 'non-profit' ],
 			is_premium: false,
-		},
-		{
-			title: 'Bowen',
-			slug: 'bowen',
-			template: 'bowen',
-			theme: 'coutoire',
-			src: 'https://public-api.wordpress.com/rest/v1/template/demo/coutoire/bowen/',
-			fonts: {
-				headings: 'Playfair Display',
-				base: 'Fira Sans',
-			},
-			categories: [ 'featured', 'blog' ],
-			is_premium: true,
 		},
 	],
 };

--- a/client/landing/gutenboarding/components/badge/index.tsx
+++ b/client/landing/gutenboarding/components/badge/index.tsx
@@ -9,7 +9,12 @@ import classNames from 'classnames';
  */
 import './style.scss';
 
-const Badge: React.FunctionComponent = ( { children, className, ...props } ) => (
+interface Props {
+	children: React.ReactElement;
+	className?: string;
+}
+
+const Badge: React.FunctionComponent< Props > = ( { children, className, ...props } ) => (
 	<span { ...props } className={ classNames( 'badge', className ) }>
 		{ children }
 	</span>

--- a/client/landing/gutenboarding/components/badge/index.tsx
+++ b/client/landing/gutenboarding/components/badge/index.tsx
@@ -10,7 +10,7 @@ import classNames from 'classnames';
 import './style.scss';
 
 interface Props {
-	children: React.ReactElement;
+	children: React.ReactElement[];
 	className?: string;
 }
 

--- a/client/landing/gutenboarding/components/badge/index.tsx
+++ b/client/landing/gutenboarding/components/badge/index.tsx
@@ -1,0 +1,18 @@
+/**
+ * External dependencies
+ */
+import * as React from 'react';
+import classNames from 'classnames';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+const Badge: React.FunctionComponent = ( { children, className, ...props } ) => (
+	<span { ...props } className={ classNames( 'badge', className ) }>
+		{ children }
+	</span>
+);
+
+export default Badge;

--- a/client/landing/gutenboarding/components/badge/style.scss
+++ b/client/landing/gutenboarding/components/badge/style.scss
@@ -1,0 +1,12 @@
+.badge {
+	display: inline-block;
+	background: var( --studio-blue-40 );
+	border-radius: 2px;
+	padding: 4px 8px;
+	color: var( --studio-white );
+	margin-left: 8px;
+
+	> * {
+		vertical-align: middle;
+	}
+}

--- a/client/landing/gutenboarding/components/plans/plans-table/plan-item.tsx
+++ b/client/landing/gutenboarding/components/plans/plans-table/plan-item.tsx
@@ -7,6 +7,11 @@ import { Button, Icon } from '@wordpress/components';
 import classNames from 'classnames';
 import { PLAN_FREE } from '../../../stores/plans/constants';
 
+/**
+ * Internal dependencies
+ */
+import Badge from '../../badge';
+
 const TickIcon = (
 	<Icon
 		icon={ () => (
@@ -63,7 +68,7 @@ const PlanItem: React.FunctionComponent< Props > = ( {
 			<div className="plan-item__viewport">
 				<div className="plan-item__heading">
 					<div className="plan-item__name">{ name }</div>
-					{ isPopular && <div className="plan-item__badge">{ __( 'Popular' ) }</div> }
+					{ isPopular && <Badge className="plan-item__badge">{ __( 'Popular' ) }</Badge> }
 				</div>
 				<div className="plan-item__price">
 					<div className="plan-item__price-amount" data-is-loading={ ! price }>

--- a/client/landing/gutenboarding/components/plans/plans-table/style.scss
+++ b/client/landing/gutenboarding/components/plans/plans-table/style.scss
@@ -48,16 +48,7 @@
 }
 
 .plan-item__badge {
-	display: inline-block;
-	background: var( --studio-blue-40 );
-	border-radius: 2px;
-	padding: 4px 8px;
-	color: var( --studio-white );
 	margin-left: 8px;
-
-	> * {
-		vertical-align: middle;
-	}
 }
 
 .plan-item__price-amount {

--- a/client/landing/gutenboarding/hooks/use-selected-plan.ts
+++ b/client/landing/gutenboarding/hooks/use-selected-plan.ts
@@ -17,15 +17,16 @@ export function useSelectedPlan() {
 	const planFromPath = useSelect( ( select ) => select( PLANS_STORE ).getPlanByPath( planPath ) );
 
 	const hasPaidDomain = useSelect( ( select ) => select( ONBOARD_STORE ).hasPaidDomain() );
+	const hasPaidDesign = useSelect( ( select ) => select( ONBOARD_STORE ).hasPaidDesign() );
 	const defaultPlan = useSelect( ( select ) =>
-		select( PLANS_STORE ).getDefaultPlan( hasPaidDomain )
+		select( PLANS_STORE ).getDefaultPlan( hasPaidDomain, hasPaidDesign )
 	);
 
 	/**
 	 * Plan is decided in this order
 	 * 1. selected from PlansGrid (by dispatching setPlan)
 	 * 2. having the plan slug in the URL
-	 * 3. selecting a paid domain
+	 * 3. selecting a paid domain or design
 	 */
 	return selectedPlan || planFromPath || defaultPlan;
 }

--- a/client/landing/gutenboarding/lib/analytics/types.ts
+++ b/client/landing/gutenboarding/lib/analytics/types.ts
@@ -72,6 +72,11 @@ type TracksDesignSelectEventProperties = {
 	 * The selected theme
 	 */
 	selected_design: string | undefined;
+
+	/**
+	 * If the selected theme is premium
+	 */
+	is_selected_design_premium: boolean;
 };
 
 type TracksDomainSelectEventProperties = {

--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -105,7 +105,10 @@ const DesignSelector: React.FunctionComponent = () => {
 										>
 											<div className="design-selector__premium-container">
 												<Badge className="design-selector__premium-badge">
-													<JetpackLogo size={ 20 } />
+													<JetpackLogo
+														className="design-selector__premium-badge-logo"
+														size={ 20 }
+													/>
 													{ __( 'Premium' ) }
 												</Badge>
 											</div>

--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -14,6 +14,7 @@ import { STORE_KEY as ONBOARD_STORE } from '../../stores/onboard';
 import designs from '../../available-designs';
 import { usePath, Step } from '../../path';
 import { isEnabled } from '../../../../config';
+import Badge from '../../components/badge';
 import Link from '../../components/link';
 import { SubTitle, Title } from '../../components/titles';
 import { useTrackStep } from '../../hooks/use-track-step';
@@ -94,6 +95,9 @@ const DesignSelector: React.FunctionComponent = () => {
 							<span className="design-selector__option-overlay">
 								<span id={ makeOptionId( design ) } className="design-selector__option-name">
 									{ design.title }
+									{ design.premium && (
+										<Badge className="design-selector__premium">{ __( 'Premium' ) }</Badge>
+									) }
 								</span>
 							</span>
 						</button>

--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -109,7 +109,7 @@ const DesignSelector: React.FunctionComponent = () => {
 														className="design-selector__premium-badge-logo"
 														size={ 20 }
 													/>
-													{ __( 'Premium' ) }
+													<span>{ __( 'Premium' ) }</span>
 												</Badge>
 											</div>
 										</Tooltip>

--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -1,11 +1,13 @@
 /**
  * External dependencies
  */
-import React from 'react';
-import { useDispatch, useSelect } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
-import { useI18n } from '@automattic/react-i18n';
+import { Tooltip } from '@wordpress/components';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { useHistory } from 'react-router-dom';
+import { useI18n } from '@automattic/react-i18n';
+import React from 'react';
+import { Icon, starFilled } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -97,7 +99,15 @@ const DesignSelector: React.FunctionComponent = () => {
 								<span id={ makeOptionId( design ) } className="design-selector__option-name">
 									{ design.title }
 									{ design.premium && (
-										<Badge className="design-selector__premium">{ __( 'Premium' ) }</Badge>
+										<Tooltip
+											position="top center"
+											text={ __( 'Requires a Personal plan or above' ) }
+										>
+											<Badge className="design-selector__premium">
+												<Icon icon={ starFilled } size={ 20 } />
+												{ __( 'Premium' ) }
+											</Badge>
+										</Tooltip>
 									) }
 								</span>
 							</span>

--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -98,7 +98,7 @@ const DesignSelector: React.FunctionComponent = () => {
 							<span className="design-selector__option-overlay">
 								<span id={ makeOptionId( design ) } className="design-selector__option-name">
 									{ design.title }
-									{ design.premium && (
+									{ design.is_premium && (
 										<Tooltip
 											position="top center"
 											text={ __( 'Requires a Personal plan or above' ) }

--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -7,19 +7,19 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { useHistory } from 'react-router-dom';
 import { useI18n } from '@automattic/react-i18n';
 import React from 'react';
-import { Icon, starFilled } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
-import { STORE_KEY as ONBOARD_STORE } from '../../stores/onboard';
-import designs from '../../available-designs';
-import { usePath, Step } from '../../path';
 import { isEnabled } from '../../../../config';
-import Badge from '../../components/badge';
-import Link from '../../components/link';
+import { STORE_KEY as ONBOARD_STORE } from '../../stores/onboard';
 import { SubTitle, Title } from '../../components/titles';
+import { usePath, Step } from '../../path';
 import { useTrackStep } from '../../hooks/use-track-step';
+import Badge from '../../components/badge';
+import designs from '../../available-designs';
+import JetpackLogo from 'components/jetpack-logo'; // @TODO: extract to @automattic package
+import Link from '../../components/link';
 import './style.scss';
 
 type Design = import('../../stores/onboard/types').Design;
@@ -96,17 +96,19 @@ const DesignSelector: React.FunctionComponent = () => {
 								/>
 							</span>
 							<span className="design-selector__option-overlay">
-								<span id={ makeOptionId( design ) } className="design-selector__option-name">
-									{ design.title }
+								<span id={ makeOptionId( design ) } className="design-selector__option-meta">
+									<span className="design-selector__option-name">{ design.title }</span>
 									{ design.is_premium && (
 										<Tooltip
-											position="top center"
+											position="bottom center"
 											text={ __( 'Requires a Personal plan or above' ) }
 										>
-											<Badge className="design-selector__premium">
-												<Icon icon={ starFilled } size={ 20 } />
-												{ __( 'Premium' ) }
-											</Badge>
+											<div className="design-selector__premium-container">
+												<Badge className="design-selector__premium-badge">
+													<JetpackLogo size={ 20 } />
+													{ __( 'Premium' ) }
+												</Badge>
+											</div>
 										</Tooltip>
 									) }
 								</span>

--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -51,6 +51,7 @@ const DesignSelector: React.FunctionComponent = () => {
 
 	useTrackStep( 'DesignSelection', () => ( {
 		selected_design: getSelectedDesign()?.slug,
+		is_selected_design_premium: !! getSelectedDesign()?.premium,
 	} ) );
 
 	return (

--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -30,7 +30,7 @@ const DesignSelector: React.FunctionComponent = () => {
 	const makePath = usePath();
 
 	const { setSelectedDesign, setFonts } = useDispatch( ONBOARD_STORE );
-	const { getSelectedDesign } = useSelect( ( select ) => select( ONBOARD_STORE ) );
+	const { getSelectedDesign, hasPaidDesign } = useSelect( ( select ) => select( ONBOARD_STORE ) );
 
 	const getDesignUrl = ( design: Design ) => {
 		// We temporarily show pre-generated screenshots until we can generate tall versions dynamically using mshots.
@@ -51,7 +51,7 @@ const DesignSelector: React.FunctionComponent = () => {
 
 	useTrackStep( 'DesignSelection', () => ( {
 		selected_design: getSelectedDesign()?.slug,
-		is_selected_design_premium: !! getSelectedDesign()?.premium,
+		is_selected_design_premium: hasPaidDesign(),
 	} ) );
 
 	return (

--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -135,4 +135,8 @@
 		width: 100%;
 		@include onboarding-medium-text;
 	}
+
+	.design-selector__premium {
+		margin: 0 6px;
+	}
 }

--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -127,27 +127,44 @@
 		}
 	}
 
-	.design-selector__option-name {
-		color: var( --studio-gray-40 );
-		display: block;
+	.design-selector__option-meta {
+		display: inline-grid;
 		margin: 16px 0;
-		text-align: center;
 		width: 100%;
-		@include onboarding-medium-text;
+		gap: 6px;
+		grid-template-columns: 1fr [name] auto [badge] 1fr;
 	}
 
-	.design-selector__premium {
-		background-color: var( --studio-yellow-30 );
+	.design-selector__option-name {
+		@include onboarding-medium-text;
+		align-self: center;
+		color: var( --studio-gray-40 );
+		grid-area: name;
+		text-align: center;
+	}
+
+	.design-selector__premium-container {
+		grid-area: badge;
+		text-align: left;
+	}
+
+	.design-selector__premium-badge {
+		background-color: var( --studio-black );
 		border-radius: 1em;
 		color: var( --studio-white );
-		margin: 0 6px;
-		padding: 1px 8px;
+		margin: 0;
+		padding: 2px 8px;
+		white-space: nowrap;
 
-		svg {
+		.jetpack-logo {
 			margin-left: -4px;
 		}
 
-		path {
+		.jetpack-logo__icon-circle {
+			fill: transparent;
+		}
+
+		.jetpack-logo__icon-triangle {
 			fill: var( --studio-white );
 		}
 	}

--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -129,10 +129,15 @@
 
 	.design-selector__option-meta {
 		display: inline-grid;
-		margin: 16px 0;
+		margin-top: 8px;
 		width: 100%;
 		gap: 6px;
 		grid-template-columns: 1fr [name] auto [badge] 1fr;
+
+		> * {
+			// This is to create space between Tooltip component and other elements
+			min-height: 2em;
+		}
 	}
 
 	.design-selector__option-name {
@@ -140,6 +145,7 @@
 		align-self: center;
 		color: var( --studio-gray-40 );
 		grid-area: name;
+		padding: 2px 0; // To match line-alignment with premium badge
 		text-align: center;
 	}
 

--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -137,6 +137,13 @@
 	}
 
 	.design-selector__premium {
+		background-color: var( --studio-yellow-30 );
+		border-radius: 1em;
+		color: var( --studio-white );
 		margin: 0 6px;
+
+		path {
+			fill: var( --studio-white );
+		}
 	}
 }

--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -141,6 +141,11 @@
 		border-radius: 1em;
 		color: var( --studio-white );
 		margin: 0 6px;
+		padding: 1px 8px;
+
+		svg {
+			margin-left: -4px;
+		}
 
 		path {
 			fill: var( --studio-white );

--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -161,10 +161,10 @@
 		margin: 0;
 		padding: 2px 8px;
 		white-space: nowrap;
+	}
 
-		.jetpack-logo {
-			margin-left: -4px;
-		}
+	.design-selector__premium-badge-logo {
+		margin-left: -4px;
 
 		.jetpack-logo__icon-circle {
 			fill: transparent;

--- a/client/landing/gutenboarding/stores/onboard/selectors.ts
+++ b/client/landing/gutenboarding/stores/onboard/selectors.ts
@@ -16,7 +16,7 @@ export const hasPaidDesign = ( state: State ): boolean => {
 	if ( ! state.selectedDesign ) {
 		return false;
 	}
-	return state.selectedDesign.premium;
+	return state.selectedDesign.is_premium;
 };
 export const getSelectedDesign = ( state: State ) => state.selectedDesign;
 export const getSelectedFonts = ( state: State ) => state.selectedFonts;

--- a/client/landing/gutenboarding/stores/onboard/selectors.ts
+++ b/client/landing/gutenboarding/stores/onboard/selectors.ts
@@ -12,6 +12,12 @@ export const hasPaidDomain = ( state: State ): boolean => {
 	}
 	return ! state.domain.is_free;
 };
+export const hasPaidDesign = ( state: State ): boolean => {
+	if ( ! state.selectedDesign ) {
+		return false;
+	}
+	return state.selectedDesign.premium;
+};
 export const getSelectedDesign = ( state: State ) => state.selectedDesign;
 export const getSelectedFonts = ( state: State ) => state.selectedFonts;
 export const getSelectedVertical = ( state: State ) => state.siteVertical;

--- a/client/landing/gutenboarding/stores/onboard/types.ts
+++ b/client/landing/gutenboarding/stores/onboard/types.ts
@@ -34,5 +34,5 @@ export interface Design {
 	template: string;
 	fonts: FontPair;
 	categories: Array< string >;
-	premium: boolean;
+	is_premium: boolean;
 }

--- a/client/landing/gutenboarding/stores/onboard/types.ts
+++ b/client/landing/gutenboarding/stores/onboard/types.ts
@@ -34,4 +34,5 @@ export interface Design {
 	template: string;
 	fonts: FontPair;
 	categories: Array< string >;
+	premium: bool;
 }

--- a/client/landing/gutenboarding/stores/onboard/types.ts
+++ b/client/landing/gutenboarding/stores/onboard/types.ts
@@ -34,5 +34,5 @@ export interface Design {
 	template: string;
 	fonts: FontPair;
 	categories: Array< string >;
-	premium: bool;
+	premium: boolean;
 }

--- a/client/landing/gutenboarding/stores/plans/selectors.ts
+++ b/client/landing/gutenboarding/stores/plans/selectors.ts
@@ -18,8 +18,10 @@ function getFortifiedPlan( slug: string | undefined ) {
 }
 
 export const getSelectedPlan = ( state: State ) => getFortifiedPlan( state.selectedPlanSlug );
-export const getDefaultPlan = ( state: State, hasPaidDomain: boolean ) =>
-	hasPaidDomain ? getFortifiedPlan( DEFAULT_PAID_PLAN ) : getFortifiedPlan( PLAN_FREE );
+export const getDefaultPlan = ( state: State, hasPaidDomain: boolean, hasPaidDesign: boolean ) =>
+	hasPaidDomain || hasPaidDesign
+		? getFortifiedPlan( DEFAULT_PAID_PLAN )
+		: getFortifiedPlan( PLAN_FREE );
 export const getSupportedPlans = ( state: State ) =>
 	state.supportedPlanSlugs.map( getFortifiedPlan );
 export const getPlanByPath = ( state: State, path: string | undefined ) =>


### PR DESCRIPTION
Add premium designs flow in Gutenboarding.

![image](https://user-images.githubusercontent.com/87168/82671735-06918580-9c48-11ea-8229-4c897bd44488.png)


### Design brief was this:
![screen-capture-on-2020-05-21-at-19-57-53-1](https://user-images.githubusercontent.com/87168/82674475-085d4800-9c4c-11ea-89ae-e5097686681b.gif)

- Note how title is in the middle, followed by the badge on the right
- Tooltip opens right-away (couldn't do, there's 700ms delay)
- Tooltip has space before badge (hence there's additional `min-height` in elements to achieve that)
- Tooltip is bottom+centered (couldn't do, tooltip seems to have its own life in this regard)


#### TODO:
- [x] Add `selected_design_is_premium: true|false` prop to existing `calypso_newsite_step_leave` event alongside `selected_design` prop.
- [x] Remove premium status for the demo in Vesta design and follow-up with actual designs.

- [ ] ~Update [A/B test date](https://github.com/Automattic/wp-calypso/blob/d9b924732010fc94985703bc5af49cf80bdd2ee4/client/lib/abtest/active-tests.js#L119)~ Not doing.

#### Changes proposed in this Pull Request

* Tag one of the designs as "premium"
* Show premium badge next to design name 
* When the premium design is selected, pre-select "premium" plan

#### Testing instructions
- At Gutenboarding (start fresh with http://calypso.localhost:3000/new/?fresh)
- Confirm that selecting premium design chooses premium plan by default and that picking free design again goes back to free 
- Confirm that picking a paid domain does the same separately from design and that switching either one to free doesn't cancel the other one until both are on free options
- Confirm premium plan selected when opening plans grid
- Confirm premium plan in checkout when progressing in the flow

Test the event
- Set `localStorage.debug='calypso:analytics';` in console
- Pick premium theme and confirm `calypso_newsite_step_leave` event with `is_selected_design_premium: true` prop.
- Pick non-premium theme and confirm `calypso_newsite_step_leave` event with `is_selected_design_premium: false` prop.