### PR TITLE
Jetpack Cloud: add log out flow

### DIFF
--- a/client/landing/jetpack-cloud/sections/settings/main.jsx
+++ b/client/landing/jetpack-cloud/sections/settings/main.jsx
@@ -11,13 +11,14 @@ import { localize } from 'i18n-calypso';
 import DocumentHead from 'components/data/document-head';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import ServerCredentialsForm from 'landing/jetpack-cloud/components/server-credentials-form';
-import { Card } from '@automattic/components';
+import { Button, Card } from '@automattic/components';
 import getRewindState from 'state/selectors/get-rewind-state';
 import QueryRewindState from 'components/data/query-rewind-state';
 import Main from 'components/main';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import ExternalLink from 'components/external-link';
+import userUtilities from 'lib/user/utils';
 
 /**
  * Style dependencies
@@ -65,6 +66,13 @@ class SettingsPage extends Component {
 		);
 	}
 
+	logOut() {
+		// Clears everything user related on the client site by
+		// calling user.clear() which calls store.clearAll();
+		userUtilities.logout( 'https://jetpack.com/' );
+		// @todo: track event (what type?)
+	}
+
 	render() {
 		const { rewind, siteId, translate } = this.props;
 
@@ -76,6 +84,11 @@ class SettingsPage extends Component {
 				<SidebarNavigation />
 				<QueryRewindState siteId={ siteId } />
 				<PageViewTracker path="/settings/:site" title="Settings" />
+
+				<Button primary scary onClick={ this.logOut }>
+					Log out
+				</Button>
+
 				<div className="settings__title">
 					<h2>{ translate( 'Server connection details' ) }</h2>
 				</div>

--- a/client/landing/jetpack-cloud/sections/settings/main.jsx
+++ b/client/landing/jetpack-cloud/sections/settings/main.jsx
@@ -69,7 +69,7 @@ class SettingsPage extends Component {
 	logOut() {
 		// Clears everything user related on the client site by
 		// calling user.clear() which calls store.clearAll();
-		userUtilities.logout( 'https://jetpack.com/' );
+		userUtilities.logout();
 		// @todo: track event (what type?)
 	}
 

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -9,10 +9,11 @@
 	"port": 3000,
 	"rtl": false,
 	"login_url": "/connect",
-	"logout_url": "https://wordpress.com/wp-login.php?action=logout",
+	"logout_url": "/",
 	"site_name": "Jetpack.com",
 	"oauth_client_id": 68663,
 	"features": {
+		"always_use_logout_url": true,
 		"current-site/domain-warning": false,
 		"current-site/notice": false,
 		"current-site/stale-cart-notice": false,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -7,10 +7,11 @@
 	"i18n_default_locale_slug": "en",
 	"rtl": false,
 	"login_url": "/connect",
-	"logout_url": "https://wordpress.com/wp-login.php?action=logout",
+	"logout_url": "/",
 	"site_name": "Jetpack.com",
 	"oauth_client_id": 69041,
 	"features": {
+		"always_use_logout_url": true,
 		"current-site/domain-warning": false,
 		"current-site/notice": false,
 		"current-site/stale-cart-notice": false,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -7,10 +7,11 @@
 	"i18n_default_locale_slug": "en",
 	"rtl": false,
 	"login_url": "/connect",
-	"logout_url": "https://wordpress.com/wp-login.php?action=logout",
+	"logout_url": "/",
 	"site_name": "Jetpack.com",
 	"oauth_client_id": 69040,
 	"features": {
+		"always_use_logout_url": true,
 		"current-site/domain-warning": false,
 		"current-site/notice": false,
 		"current-site/stale-cart-notice": false,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Make it possible for users to log out from Jetpack Cloud.

#### Implementation notes

This is a WIP. While we wait for the dropdown design for the log out button, I added the button in the settings section.

For the mean time, the current implementation does a client side session clean up. In other words, this doesn't log the user out from WP.com.

#### Questions

* What information should we track and how should we name the event?
* Where should we redirect the user to?

#### Testing instructions

* Go to `http://jetpack.cloud.localhost:3000/`
* Select any site
* Go to the Settings section
* Click the `[Log out]` button
* Verify you are no longer authenticated (WP.com requires you to log in)

Fixes # 1169345694087188-as-1174701142489163

#### Demo

![Kapture 2020-05-19 at 18 01 00](https://user-images.githubusercontent.com/3418513/82377948-c8ebed00-99fa-11ea-963b-44a6eba65978.gif)
