### PR TITLE
Purchases: Use correct dates for autorenewing products in upcoming renewals notices

### DIFF
--- a/client/me/purchases/upcoming-renewals/test/upcoming-renewals-dialog.tsx
+++ b/client/me/purchases/upcoming-renewals/test/upcoming-renewals-dialog.tsx
@@ -6,6 +6,7 @@
  * External dependencies
  */
 import Modal from 'react-modal';
+import moment from 'moment';
 import { render, fireEvent, screen } from '@testing-library/react';
 import { unmountComponentAtNode } from 'react-dom';
 import React from 'react';
@@ -32,11 +33,13 @@ describe( '<UpcomingRenewalsDialog>', () => {
 		modalRoot = null;
 	} );
 
-	const purchases = [
+	const mockPurchases = () => [
 		{
 			id: 1,
 			currencyCode: 'USD',
-			expiryDate: '2020-05-20T00:00:00+00:00',
+			expiryDate: moment().add( 20, 'days' ).format(),
+			expiryStatus: 'expiring',
+			renewDate: '',
 			productSlug: 'personal-bundle',
 			productName: 'Personal Plan',
 			amount: 100,
@@ -44,7 +47,9 @@ describe( '<UpcomingRenewalsDialog>', () => {
 		{
 			id: 2,
 			currencyCode: 'USD',
-			expiryDate: '2020-05-15T00:00:00+00:00',
+			expiryDate: moment().add( 10, 'days' ).format(),
+			expiryStatus: 'expiring',
+			renewDate: '',
 			productSlug: 'dotlive_domain',
 			meta: 'personalsitetest1234.live',
 			productName: 'DotLive Domain Registration',
@@ -62,6 +67,48 @@ describe( '<UpcomingRenewalsDialog>', () => {
 		render(
 			<UpcomingRenewalsDialog
 				isVisible={ true }
+				purchases={ mockPurchases() }
+				site={ site }
+				onConfirm={ jest.fn() }
+				onClose={ jest.fn() }
+			/>
+		);
+
+		expect(
+			document.body.querySelectorAll( '.upcoming-renewals-dialog__name' )[ 0 ]
+		).toHaveTextContent(
+			/personalsitetest1234\.liveDotLive Domain Registration: expires in 10 days/
+		);
+		expect(
+			document.body.querySelectorAll( '.upcoming-renewals-dialog__price' )[ 0 ]
+		).toHaveTextContent( '$200' );
+		expect(
+			document.body.querySelectorAll( '.upcoming-renewals-dialog__name' )[ 1 ]
+		).toHaveTextContent( /Personal PlanSite Plan: expires in 20 days/ );
+		expect(
+			document.body.querySelectorAll( '.upcoming-renewals-dialog__price' )[ 1 ]
+		).toHaveTextContent( '$100' );
+	} );
+
+	test( 'uses the renewDate to display and sort purposes for autoRenewing purchases', () => {
+		const purchases = [
+			...mockPurchases(),
+			{
+				id: 3,
+				currencyCode: 'USD',
+				expiryDate: moment().add( 35, 'days' ).format(),
+				expiryStatus: 'autoRenewing',
+				renewDate: moment().add( 5, 'days' ).format(),
+				productSlug: 'dotlive_domain',
+				meta: 'autorenewing-domain.live',
+				productName: 'DotLive Domain Registration',
+				isDomainRegistration: true,
+				amount: 200,
+			},
+		];
+		render(
+			<UpcomingRenewalsDialog
+				isVisible={ true }
 				purchases={ purchases }
 				site={ site }
 				onConfirm={ jest.fn() }
@@ -71,20 +118,12 @@ describe( '<UpcomingRenewalsDialog>', () => {
 
 		expect(
 			document.body.querySelectorAll( '.upcoming-renewals-dialog__name' )[ 0 ]
-		).toHaveTextContent( /personalsitetest1234\.liveDotLive Domain Registration: expire[sd]/ );
-		expect(
-			document.body.querySelectorAll( '.upcoming-renewals-dialog__price' )[ 0 ]
-		).toHaveTextContent( '$200' );
-		expect(
-			document.body.querySelectorAll( '.upcoming-renewals-dialog__name' )[ 1 ]
-		).toHaveTextContent( /Personal PlanSite Plan: expire[sd]/ );
-		expect(
-			document.body.querySelectorAll( '.upcoming-renewals-dialog__price' )[ 1 ]
-		).toHaveTextContent( '$100' );
+		).toHaveTextContent( /autorenewing-domain\.liveDotLive Domain Registration: renews in 5 days/ );
 	} );
 
 	test( 'selects all purchases by default', () => {
 		const onConfirm = jest.fn();
+		const purchases = mockPurchases();
 		render(
 			<UpcomingRenewalsDialog
 				isVisible={ true }
@@ -102,6 +141,7 @@ describe( '<UpcomingRenewalsDialog>', () => {
 
 	test( 'submits only the selected purchases', () => {
 		const onConfirm = jest.fn();
+		const purchases = mockPurchases();
 		render(
 			<UpcomingRenewalsDialog
 				isVisible={ true }
@@ -122,7 +162,7 @@ describe( '<UpcomingRenewalsDialog>', () => {
 		render(
 			<UpcomingRenewalsDialog
 				isVisible={ true }
-				purchases={ purchases }
+				purchases={ mockPurchases() }
 				site={ site }
 				onConfirm={ jest.fn() }
 				onClose={ jest.fn() }

--- a/client/me/purchases/upcoming-renewals/upcoming-renewals-dialog.tsx
+++ b/client/me/purchases/upcoming-renewals/upcoming-renewals-dialog.tsx
@@ -16,7 +16,7 @@ import { capitalize } from 'lodash';
 /**
  * Internal dependencies
  */
-import { getName, getRenewalPrice, purchaseType, isExpired, isAutoRenewing } from 'lib/purchases';
+import { getName, getRenewalPrice, purchaseType, isExpired, isRenewing } from 'lib/purchases';
 import FormLabel from 'components/forms/form-label';
 import FormInputCheckbox from 'components/forms/form-checkbox';
 import { Button, Dialog } from '@automattic/components';
@@ -61,7 +61,7 @@ function getExpiresText(
 	moment: ReturnType< typeof useLocalizedMoment >,
 	purchase: Purchase
 ): TranslateResult {
-	if ( isAutoRenewing( purchase ) ) {
+	if ( isRenewing( purchase ) ) {
 		return translate( 'renews %(renewDate)s', {
 			comment:
 				'"renewDate" is relative to the present time and it is already localized, eg. "in a year", "in a month"',
@@ -100,8 +100,8 @@ const UpcomingRenewalsDialog: FunctionComponent< Props > = ( {
 	const purchasesSortByRecentExpiryDate = useMemo(
 		() =>
 			[ ...purchases ].sort( ( a, b ) => {
-				const compareDateA = isAutoRenewing( a ) ? a.renewDate : a.expiryDate;
-				const compareDateB = isAutoRenewing( b ) ? b.renewDate : b.expiryDate;
+				const compareDateA = isRenewing( a ) ? a.renewDate : a.expiryDate;
+				const compareDateB = isRenewing( b ) ? b.renewDate : b.expiryDate;
 
 				return compareDateA?.localeCompare?.( compareDateB );
 			} ),

--- a/client/me/purchases/upcoming-renewals/upcoming-renewals-dialog.tsx
+++ b/client/me/purchases/upcoming-renewals/upcoming-renewals-dialog.tsx
@@ -98,7 +98,13 @@ const UpcomingRenewalsDialog: FunctionComponent< Props > = ( {
 	const [ selectedPurchases, setSelectedPurchases ] = useState< number[] >( [] );
 
 	const purchasesSortByRecentExpiryDate = useMemo(
-		() => [ ...purchases ].sort( ( a, b ) => a?.expiryDate?.localeCompare( b?.expiryDate ) ),
+		() =>
+			[ ...purchases ].sort( ( a, b ) => {
+				const compareDateA = isAutoRenewing( a ) ? a.renewDate : a.expiryDate;
+				const compareDateB = isAutoRenewing( b ) ? b.renewDate : b.expiryDate;
+
+				return compareDateA?.localeCompare?.( compareDateB );
+			} ),
 		[ purchases ]
 	);
 

--- a/client/my-sites/checkout/cart/upcoming-renewals-reminder.tsx
+++ b/client/my-sites/checkout/cart/upcoming-renewals-reminder.tsx
@@ -14,7 +14,7 @@ import { recordTracksEvent } from 'state/analytics/actions';
 import QueryUserPurchases from 'components/data/query-user-purchases';
 import { Button } from '@automattic/components';
 import { getRenewalItemFromProduct } from 'lib/cart-values/cart-items';
-import { getName, isExpired, isAutoRenewing } from 'lib/purchases';
+import { getName, isExpired, isRenewing } from 'lib/purchases';
 import { isPlan, isDomainRegistration } from 'lib/products-values';
 import SectionHeader from 'components/section-header';
 import TrackComponentView from 'lib/analytics/track-component-view';
@@ -251,7 +251,7 @@ function getMessages( {
 				translateOptions
 			);
 		}
-	} else if ( isAutoRenewing( purchase ) ) {
+	} else if ( isRenewing( purchase ) ) {
 		const renewingTranslateOptions = {
 			comment:
 				'"relativeRenewDate" is relative to the present time and it is already localized, eg. "in a year", "in a month"',

--- a/client/my-sites/checkout/cart/upcoming-renewals-reminder.tsx
+++ b/client/my-sites/checkout/cart/upcoming-renewals-reminder.tsx
@@ -14,7 +14,7 @@ import { recordTracksEvent } from 'state/analytics/actions';
 import QueryUserPurchases from 'components/data/query-user-purchases';
 import { Button } from '@automattic/components';
 import { getRenewalItemFromProduct } from 'lib/cart-values/cart-items';
-import { getName, isExpired } from 'lib/purchases';
+import { getName, isExpired, isAutoRenewing } from 'lib/purchases';
 import { isPlan, isDomainRegistration } from 'lib/products-values';
 import SectionHeader from 'components/section-header';
 import TrackComponentView from 'lib/analytics/track-component-view';
@@ -226,6 +226,8 @@ function getMessages( {
 	const buttonLabel = translate( 'Add to Cart' );
 	let message: ReturnType< typeof translate > = '';
 	const translateOptions = {
+		comment:
+			'"expiry" is relative to the present time and it is already localized, eg. "in a year", "in a month", "a week ago"',
 		args: {
 			purchaseName: getName( purchase ),
 			expiry: moment( purchase.expiryDate ).fromNow(),
@@ -247,6 +249,31 @@ function getMessages( {
 			message = translate(
 				'Your %(purchaseName)s subscription expired %(expiry)s. Would you like to renew it now?',
 				translateOptions
+			);
+		}
+	} else if ( isAutoRenewing( purchase ) ) {
+		const renewingTranslateOptions = {
+			comment:
+				'"relativeRenewDate" is relative to the present time and it is already localized, eg. "in a year", "in a month"',
+			args: {
+				purchaseName: getName( purchase ),
+				relativeRenewDate: moment( purchase.renewDate ).fromNow(),
+			},
+		};
+		if ( isDomainRegistration( purchase ) ) {
+			message = translate(
+				'Your %(purchaseName)s domain is renewing %(relativeRenewDate)s. Would you like to renew it now?',
+				renewingTranslateOptions
+			);
+		} else if ( isPlan( purchase ) ) {
+			message = translate(
+				'Your %(purchaseName)s plan is renewing %(relativeRenewDate)s. Would you like to renew it now?',
+				renewingTranslateOptions
+			);
+		} else {
+			message = translate(
+				'Your %(purchaseName)s subscription is renewing %(relativeRenewDate)s. Would you like to renew it now?',
+				renewingTranslateOptions
 			);
 		}
 	} else if ( isDomainRegistration( purchase ) ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

*  In the upcoming renewals dialog, use the renew date if the product is autorenewing to determine the correct display order.
* Display a different message for autorenewing products in the checkout page:

![image](https://user-images.githubusercontent.com/15204776/82379559-b79be400-99ec-11ea-9536-f3fdb7f8cc11.png)


#### Testing instructions

* Make sure composite-checkout is enabled for your account (You may add the flag via URL using ?flags=+composite-checkout-force,+upgrades/upcoming-renewals-notices)
* Go to a site that has multiple purchases (at least 2) expiring soon (within the next 3 months). Turn on auto-renew for one of them and disable it in the rest.
* Go to Manage Purchases and open one of the purchases that has auto-renew off.
* Click in the "other purchases" link inside the notice, when the dialog opens, make sure all the purchases are ordered correctly by renew or expiration time, respectively,
* Select all the purchases but the one auto-renewing and click "Renew now".
* In the checkout a message will load saying that you have a purchase renewing soon (Just like in the image above). Make sure the text is correct and that it says "is renewing" instead of "is expiring".