### PR TITLE
My Home: Add task analytics for custom action buttons.

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/task.jsx
+++ b/client/my-sites/customer-home/cards/tasks/task.jsx
@@ -90,6 +90,14 @@ const Task = ( {
 		);
 	};
 
+	const ActionButtonWithStats = ( { children } ) => {
+		return (
+			<div onClick={ startTask } role="presentation">
+				{ children }
+			</div>
+		);
+	};
+
 	return (
 		<div className={ classnames( 'task', { 'is-loading': isLoading } ) }>
 			{ isLoading && <Spinner /> }
@@ -108,7 +116,9 @@ const Task = ( {
 				<h2 className="task__title">{ title }</h2>
 				<p className="task__description">{ description }</p>
 				<div className="task__actions">
-					{ actionButton || (
+					{ actionButton ? (
+						<ActionButtonWithStats>{ actionButton }</ActionButtonWithStats>
+					) : (
 						<Button
 							className="task__action"
 							primary


### PR DESCRIPTION
Currently, passing a custom action button to the `Task` component will not fire our task-specific stats. This PR wraps any custom `actionButton` component with the same click handler we use when given the standard action-related props.

The only task using the `actionButton` component so far is the Go Mobile task.

<img width="438" alt="Screen Shot 2020-05-19 at 2 26 52 PM" src="https://user-images.githubusercontent.com/349751/82380238-f75acf80-99dc-11ea-8008-ed0dc9faf406.png">


#### Testing instructions

* Load this branch and go to My Home for a simple site.
* Open devtools and toggle the Device Bar.
* Enable stats logging by entering `localStorage.debug='calypso:analytics*'` in the console, and refresh the page (they should be showing in the log now).
* Select an iOS device and reload.
* Click the "Download on the App Store" button. Verify that Tracks stats fired for `calypso_customer_home_task_start` with `task: "home-task-go-mobile-ios"` props, and bump stats fired for `calypso_customer_home:task_start`.
* Repeat with an Android device, and verify the appropriate stats fire.

Fixes #42133 
