### PR TITLE
Gutenboarding: forward ref prop to gutenboarding

### DIFF
--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -69,7 +69,7 @@ export default {
 				.then( ( { geo } ) => {
 					const countryCode = geo.data.body.country_short;
 					if ( 'gutenberg' === abtest( 'newSiteGutenbergOnboarding', countryCode ) ) {
-						window.location = window.location.origin + '/new';
+						window.location = window.location.origin + '/new' + window.location.search;
 					} else {
 						removeWhiteBackground();
 						next();

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -69,7 +69,7 @@ export default {
 				.then( ( { geo } ) => {
 					const countryCode = geo.data.body.country_short;
 					if ( 'gutenberg' === abtest( 'newSiteGutenbergOnboarding', countryCode ) ) {
-						window.location = window.location.origin + '/new' + window.location.search;
+						window.location.replace( window.location.origin + '/new' + window.location.search );
 					} else {
 						removeWhiteBackground();
 						next();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Forwards all query params from `/start` to `/new`
  In particular this forwards the `ref` query param so we know what campaign the user came from. But I think it's worth forwarding everything in case we want to use it in the future.
* Replaces `/start` in the browser history with `/new`
  Fixed this while I was here. If the user went to `/start` and was allocated to gutenboarding, then if they hit the back button in their browser they'd go back to `/start` again, only to be bounced back to gutenboarding. Which breaks the back button. By replacing `/start` in the history the user now goes back to what feels like the last page they were looking at.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Assign yourself to the gutenboarding cohort
* Go to `/start?site_type=blog&vertical=food&ref=dotblog-landing`
  (this is the link users would click on the `food.blog` landing page)
* You should be taken to gutenboarding, all of the query parameters are preserved
* Check network tab to see `calypso_signup_start` and `calypso_newsite_start` events have the correct `ref=dotblog-landing` property
* Click back in the browser
* You go back to wherever you came from (not `/start`)

Fixes #42382
