### PR TITLE
Reader: remove link to list editing

### DIFF
--- a/client/reader/list-stream/README.md
+++ b/client/reader/list-stream/README.md
@@ -1,9 +1,5 @@
 # Reader List Stream
 
-A stream of posts from a Reader List
+A stream of posts from a Reader list.
 
-## Props
-
-- `list`: A list object from the `reader-list-store` to pull posts for
-
-See `reader/following-stream` for more props
+Lists are a deprecated feature. Creation and editing of lists are not possible in Calypso, but it is still possible to view an existing list.

--- a/client/reader/list-stream/header.jsx
+++ b/client/reader/list-stream/header.jsx
@@ -4,21 +4,26 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
+import { localize } from 'i18n-calypso';
 import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies
  */
 import { Card } from '@automattic/components';
+import { isExternal } from 'lib/url';
 import FollowButton from 'blocks/follow-button/button';
 
 const ListStreamHeader = ( {
 	isPlaceholder,
 	title,
 	description,
+	showEdit,
+	editUrl,
 	showFollow,
 	following,
 	onFollowToggle,
+	translate,
 } ) => {
 	const classes = classnames( {
 		'list-stream__header': true,
@@ -42,6 +47,17 @@ const ListStreamHeader = ( {
 					<FollowButton iconSize={ 24 } following={ following } onFollowToggle={ onFollowToggle } />
 				</div>
 			) }
+
+			{ showEdit && editUrl && (
+				<div className="list-stream__header-edit">
+					<a href={ editUrl } rel={ isExternal( editUrl ) ? 'external' : '' }>
+						<span className="list-stream__header-action-icon">
+							<Gridicon icon="cog" size={ 24 } />
+						</span>
+						<span className="list-stream__header-action-label">{ translate( 'Edit' ) }</span>
+					</a>
+				</div>
+			) }
 		</Card>
 	);
 };
@@ -50,9 +66,11 @@ ListStreamHeader.propTypes = {
 	isPlaceholder: PropTypes.bool,
 	title: PropTypes.string,
 	description: PropTypes.string,
+	showEdit: PropTypes.bool,
+	editUrl: PropTypes.string,
 	showFollow: PropTypes.bool,
 	following: PropTypes.bool,
 	onFollowToggle: PropTypes.func,
 };
 
-export default ListStreamHeader;
+export default localize( ListStreamHeader );

--- a/client/reader/list-stream/header.jsx
+++ b/client/reader/list-stream/header.jsx
@@ -4,26 +4,21 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
-import { localize } from 'i18n-calypso';
 import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies
  */
 import { Card } from '@automattic/components';
-import { isExternal } from 'lib/url';
 import FollowButton from 'blocks/follow-button/button';
 
 const ListStreamHeader = ( {
 	isPlaceholder,
 	title,
 	description,
-	showEdit,
-	editUrl,
 	showFollow,
 	following,
 	onFollowToggle,
-	translate,
 } ) => {
 	const classes = classnames( {
 		'list-stream__header': true,
@@ -47,17 +42,6 @@ const ListStreamHeader = ( {
 					<FollowButton iconSize={ 24 } following={ following } onFollowToggle={ onFollowToggle } />
 				</div>
 			) }
-
-			{ showEdit && editUrl && (
-				<div className="list-stream__header-edit">
-					<a href={ editUrl } rel={ isExternal( editUrl ) ? 'external' : '' }>
-						<span className="list-stream__header-action-icon">
-							<Gridicon icon="cog" size={ 24 } />
-						</span>
-						<span className="list-stream__header-action-label">{ translate( 'Edit' ) }</span>
-					</a>
-				</div>
-			) }
 		</Card>
 	);
 };
@@ -66,11 +50,9 @@ ListStreamHeader.propTypes = {
 	isPlaceholder: PropTypes.bool,
 	title: PropTypes.string,
 	description: PropTypes.string,
-	showEdit: PropTypes.bool,
-	editUrl: PropTypes.string,
 	showFollow: PropTypes.bool,
 	following: PropTypes.bool,
 	onFollowToggle: PropTypes.func,
 };
 
-export default localize( ListStreamHeader );
+export default ListStreamHeader;

--- a/client/reader/list-stream/index.jsx
+++ b/client/reader/list-stream/index.jsx
@@ -61,16 +61,11 @@ class ListStream extends React.Component {
 	render() {
 		const list = this.props.list,
 			shouldShowFollow = list && ! list.is_owner,
-			shouldShowEdit = ! shouldShowFollow,
 			emptyContent = <EmptyContent />,
 			listStreamIconClasses = 'gridicon gridicon__list';
 
-		let editUrl = null;
-
 		if ( list ) {
 			this.title = list.title;
-
-			editUrl = `https://wordpress.com/read/list/${ list.owner }/${ list.slug }/edit`;
 		}
 
 		if ( this.props.isMissing ) {
@@ -117,8 +112,6 @@ class ListStream extends React.Component {
 					showFollow={ shouldShowFollow }
 					following={ this.props.isSubscribed }
 					onFollowToggle={ this.toggleFollowing }
-					showEdit={ shouldShowEdit }
-					editUrl={ editUrl }
 				/>
 			</Stream>
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When a user owns a existing  Reader list, they currently have the option to edit that list. The edit list page existed in our old Atlas/Newdash codebase and is no longer working. We are retiring the edit list feature until it is available in Calypso.

See p5PDj3-4Q5-p2.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Visit a Reader list that you own (if you don't have one, ask me for one to test). Verify that the 'cog' icon in the top right is gone.

Before:

<img width="840" alt="Screen Shot 2020-05-20 at 12 26 22" src="https://user-images.githubusercontent.com/17325/82391322-23d22280-9a95-11ea-9c44-35758f65da5d.png">

After:

<img width="885" alt="Screen Shot 2020-05-20 at 12 26 01" src="https://user-images.githubusercontent.com/17325/82391330-27fe4000-9a95-11ea-989c-24adbf966ee9.png">
