### PR TITLE
Gutenboarding: Record `calypso_page_view` events in gutenboarding

### DIFF
--- a/client/landing/gutenboarding/gutenboard.tsx
+++ b/client/landing/gutenboarding/gutenboard.tsx
@@ -21,6 +21,7 @@ import './style.scss';
 import { fontPairings, getFontTitle } from './constants';
 import { recordOnboardingStart } from './lib/analytics';
 import useOnSiteCreation from './hooks/use-on-site-creation';
+import { usePageViewTracksEvents } from './hooks/use-page-view-tracks-events';
 
 registerBlockType( name, settings );
 
@@ -28,6 +29,7 @@ export function Gutenboard() {
 	const { __ } = useI18n();
 
 	useOnSiteCreation();
+	usePageViewTracksEvents();
 
 	// TODO: Explore alternatives for loading fonts and optimizations
 	// TODO: Don't load like this

--- a/client/landing/gutenboarding/hooks/use-page-view-tracks-events.ts
+++ b/client/landing/gutenboarding/hooks/use-page-view-tracks-events.ts
@@ -1,0 +1,16 @@
+/**
+ * External dependencies
+ */
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+import { recordTracksPageViewWithPageParams } from '@automattic/calypso-analytics';
+
+export function usePageViewTracksEvents() {
+	const { pathname } = useLocation();
+
+	useEffect( () => {
+		// Use the location from `window` so that we get the full path, not just
+		// the fragment that react-router deals with.
+		recordTracksPageViewWithPageParams( window.location.pathname );
+	}, [ pathname ] );
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Record `calypso_page_view` events when user navigates in gutenboarding

I added the hook for this high up in the React tree because
1. I don't want the component that does the recording to be re-mounted, otherwise there'll be a double recording of the event
2. It's recording changes for the entire react-router context, so I think it should be pretty close to `<BrowserRouter>` in the component tree.

The old signup framework (`/start`) also adds the flow name as an event property but I decided not to do that here. We aren't trying to differentiate between any different gutenboarding flows here. But I can add it if folks disagree.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open network tab and filter for `calypso_page_view`
* Go to `/new`
* Navigate around gutenboarding
* Inspect the events properties, they should look similar to the properties we send when navigating around other parts of calypso.
* Go to `/new/es` and see that the language id is part of the event
  This is an interesting point. The `calypso_page_view` events sent by the block editor don't use the literal url path, it place holders e.g. `/block-editor/:post_type/:site/:post_id`. I can see why you'd want it to work like this, but when I compare with `/start/es`, it _doesn't_ use placeholders. I've gone with just using the literal url path because (1) it's easier, (2) gutenboarding doesn't clog the url up with ids like the block editor does.

Fixes #42383 
