### PR TITLE
Editor: Inject custom setting panel into document panel for switch to classic

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/editor.scss
+++ b/apps/wpcom-block-editor/src/calypso/editor.scss
@@ -3,3 +3,19 @@
 // Temporary load this here too to get it work on Atomic sites at least via Calypso
 // Will be moved to wpcom folder unless fixed otherwise
 @import './features/legacy-preview-button';
+
+// Putting here as this css is already enqueued so saves an extra diff for this temporary notice
+.edit-post-switch-to-classic-notice.is-dismissible {
+	margin: 0;
+	padding: 0 12px 0 0;
+
+	.components-notice__content {
+		margin: 0;
+		line-height: inherit;
+		padding: 12px;
+
+		h2 {
+			margin-top: 0;
+		}
+	}
+}

--- a/apps/wpcom-block-editor/src/calypso/editor.scss
+++ b/apps/wpcom-block-editor/src/calypso/editor.scss
@@ -3,18 +3,3 @@
 // Temporary load this here too to get it work on Atomic sites at least via Calypso
 // Will be moved to wpcom folder unless fixed otherwise
 @import './features/legacy-preview-button';
-
-// just temporarily adding here as this css file is already enqued
-.interface-interface-skeleton__sidebar.show-classic-editor-notice > div {
-    height: calc( 100% - 225px );
-}
-
-.edit-post-switch-to-classic-notice {
-    background-color: #f0f1f2;
-    height: 100%;
-    padding: 0;
-    width: 280px;
-    &__content {
-        padding: 32px;
-    }
-}

--- a/apps/wpcom-block-editor/src/calypso/editor.scss
+++ b/apps/wpcom-block-editor/src/calypso/editor.scss
@@ -6,7 +6,7 @@
 
 // Putting here as this css is already enqueued so saves an extra diff for this temporary notice
 // TODO: Remove this after ../wpcom/features/switch-to-classic-notice.js is removed
-.features__switch-to-classic-notice.is-dismissible {
+.features__switch-to-classic-notice.components-notice {
 	margin: 0;
 	padding: 0;
 

--- a/apps/wpcom-block-editor/src/calypso/editor.scss
+++ b/apps/wpcom-block-editor/src/calypso/editor.scss
@@ -5,6 +5,7 @@
 @import './features/legacy-preview-button';
 
 // Putting here as this css is already enqueued so saves an extra diff for this temporary notice
+// TODO: Remove this after ../wpcom/features/switch-to-classic-notice.js is removed
 .features__switch-to-classic-notice.is-dismissible {
 	margin: 0;
 	padding: 0;

--- a/apps/wpcom-block-editor/src/calypso/editor.scss
+++ b/apps/wpcom-block-editor/src/calypso/editor.scss
@@ -3,3 +3,18 @@
 // Temporary load this here too to get it work on Atomic sites at least via Calypso
 // Will be moved to wpcom folder unless fixed otherwise
 @import './features/legacy-preview-button';
+
+// just temporarily adding here as this css file is already enqued
+.interface-interface-skeleton__sidebar.show-classic-editor-notice > div {
+    height: calc( 100% - 225px );
+}
+
+.edit-post-switch-to-classic-notice {
+    background-color: #f0f1f2;
+    height: 100%;
+    padding: 0;
+    width: 280px;
+    &__content {
+        padding: 32px;
+    }
+}

--- a/apps/wpcom-block-editor/src/calypso/editor.scss
+++ b/apps/wpcom-block-editor/src/calypso/editor.scss
@@ -5,9 +5,9 @@
 @import './features/legacy-preview-button';
 
 // Putting here as this css is already enqueued so saves an extra diff for this temporary notice
-.edit-post-switch-to-classic-notice.is-dismissible {
+.features__switch-to-classic-notice.is-dismissible {
 	margin: 0;
-	padding: 0 12px 0 0;
+	padding: 0;
 
 	.components-notice__content {
 		margin: 0;

--- a/apps/wpcom-block-editor/src/wpcom/editor.js
+++ b/apps/wpcom-block-editor/src/wpcom/editor.js
@@ -15,6 +15,7 @@ import './features/deprecate-coblocks-buttons';
 import './features/fix-block-invalidation-errors';
 import './features/reorder-block-categories';
 import './features/tracking';
+import './features/switch-to-classic-notice';
 
 import InserterMenuTrackingEvent from './features/tracking/wpcom-inserter-menu-search-term';
 

--- a/apps/wpcom-block-editor/src/wpcom/features/switch-to-classic-notice.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/switch-to-classic-notice.js
@@ -5,18 +5,21 @@
 import { __ } from '@wordpress/i18n';
 import domReady from '@wordpress/dom-ready';
 import ReactDOM from 'react-dom';
-import { useEffect, createInterpolateElement } from '@wordpress/element';
-import { withNotices } from '@wordpress/components';
+import { useState, createInterpolateElement } from '@wordpress/element';
+import { withNotices, Notice } from '@wordpress/components';
 import url from 'url';
 /* eslint-enable import/no-extraneous-dependencies */
 
 const parsedEditorUrl = url.parse( window.location.href, true );
-const dismissNotice = () => {
-	console.log( 'Notice dismissed' );
-	localStorage.setItem( 'dismissedClassicEditorNotice', 'true' );
-};
 
-const ClassicEditorNotice = ( { noticeOperations, noticeUI } ) => {
+const ClassicEditorNotice = () => {
+	const [ noticedDismissed, setNoticeDismissed ] = useState( false );
+
+	const dismissNotice = () => {
+		setNoticeDismissed( true );
+		localStorage.setItem( 'dismissedClassicEditorNotice', 'true' );
+	};
+
 	const noticeText = createInterpolateElement(
 		'If you prefer the Classic editor, you can always switch. Open the options menu by click in the button at the top right of your screen, and select <strong>Switch to Classic editor</strong>.',
 		{ strong: <strong /> }
@@ -24,22 +27,23 @@ const ClassicEditorNotice = ( { noticeOperations, noticeUI } ) => {
 
 	const noticeContent = (
 		<div>
-			<h2>{ __( "You're usng the most modern WordPress Editor." ) } </h2>
+			<h2>{ __( "You're using the most modern WordPress Editor." ) } </h2>
 			<p>{ noticeText }</p>
 		</div>
 	);
 
-	useEffect( () => {
-		noticeOperations.createNotice( {
-			className: 'edit-post-switch-to-classic-notice',
-			status: 'info',
-			content: noticeContent,
-			isDismissible: true,
-			onRemove: dismissNotice,
-		} );
-	}, [ noticeOperations ] );
-
-	return <div>{ noticeUI }</div>;
+	return (
+		! noticedDismissed && (
+			<Notice
+				className="edit-post-switch-to-classic-notice"
+				status="info"
+				isDismissible={ true }
+				onRemove={ dismissNotice }
+			>
+				{ noticeContent }
+			</Notice>
+		)
+	);
 };
 
 const NoticeComponent = withNotices( ClassicEditorNotice );

--- a/apps/wpcom-block-editor/src/wpcom/features/switch-to-classic-notice.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/switch-to-classic-notice.js
@@ -5,6 +5,7 @@
 import { __ } from '@wordpress/i18n';
 import { registerPlugin } from '@wordpress/plugins';
 import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
+import url from 'url';
 /* eslint-enable import/no-extraneous-dependencies */
 
 const PluginDocumentSettingPanelDemo = () => (
@@ -17,7 +18,13 @@ const PluginDocumentSettingPanelDemo = () => (
 		<p>{ __( "If you'd prefer you canswitch back to the Classic Editor" ) } </p>
 	</PluginDocumentSettingPanel>
 );
-registerPlugin( 'plugin-document-setting-panel-demo', {
-	render: PluginDocumentSettingPanelDemo,
-	icon: null,
-} );
+
+const parsedEditorUrl = url.parse( window.location.href, true );
+// just temporarily using the 'action' query param - we need to pass through a custom query param
+// to identify group to show this option to as outlined in https://github.com/Automattic/wp-calypso/issues/41087.
+if ( parsedEditorUrl.query.action ) {
+	registerPlugin( 'plugin-document-setting-panel-demo', {
+		render: PluginDocumentSettingPanelDemo,
+		icon: null,
+	} );
+}

--- a/apps/wpcom-block-editor/src/wpcom/features/switch-to-classic-notice.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/switch-to-classic-notice.js
@@ -17,11 +17,13 @@ const ClassicEditorNotice = () => {
 
 	const dismissNotice = () => {
 		setNoticeDismissed( true );
-		localStorage.setItem( 'dismissedClassicEditorNotice', 'true' );
+		if ( window.localStorage ) {
+			window.localStorage.setItem( 'dismissedClassicEditorNotice', true );
+		}
 	};
 
 	const noticeText = createInterpolateElement(
-		'If you prefer the Classic editor, you can always switch. Open the options menu by click in the button at the top right of your screen, and select <strong>Switch to Classic editor</strong>.',
+		'If you prefer the Classic editor, you can always switch. Open the options menu by clicking on the button at the top right of your screen, and select <strong>Switch to Classic editor</strong>.',
 		{ strong: <strong /> }
 	);
 
@@ -35,7 +37,7 @@ const ClassicEditorNotice = () => {
 	return (
 		! noticedDismissed && (
 			<Notice
-				className="edit-post-switch-to-classic-notice"
+				className="features__switch-to-classic-notice"
 				status="info"
 				isDismissible={ true }
 				onRemove={ dismissNotice }
@@ -48,27 +50,25 @@ const ClassicEditorNotice = () => {
 
 const NoticeComponent = withNotices( ClassicEditorNotice );
 
-const noticeDismissed = localStorage.getItem( 'dismissedClassicEditorNotice' );
+const noticeDismissed = window.localStorage
+	? window.localStorage.getItem( 'dismissedClassicEditorNotice' )
+	: null;
 
-// Need to replace this check with one that checks for a specific parsedEditorUrl.query param
-// https://github.com/Automattic/wp-calypso/issues/41087.
-if ( parsedEditorUrl.query[ 'environment-id' ] === 'stage' && noticeDismissed !== 'true' ) {
+if ( parsedEditorUrl.query[ 'show-classic-notice' ] && ! noticeDismissed ) {
 	domReady( () => {
 		const editInception = setInterval( () => {
-			// Cycle through interval until sidebar is found.
-			const sidebar = document.querySelector( '.components-panel__body.edit-post-post-status' );
+			// Cycle through interval until postStatus is found.
+			const postStatus = document.querySelector( '.components-panel__body.edit-post-post-status' );
 
-			if ( ! sidebar ) {
+			if ( ! postStatus ) {
 				return;
 			}
 
 			clearInterval( editInception );
 
-			sidebar.classList.add( 'show-classic-editor-notice' );
-
 			const switchToClassicNotice = document.createElement( 'div' );
 			switchToClassicNotice.className = 'edit-post-switch-to-classic-notice';
-			sidebar.after( switchToClassicNotice );
+			postStatus.parentNode.insertBefore( switchToClassicNotice, postStatus );
 
 			ReactDOM.render( <NoticeComponent />, switchToClassicNotice );
 		} );

--- a/apps/wpcom-block-editor/src/wpcom/features/switch-to-classic-notice.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/switch-to-classic-notice.js
@@ -1,0 +1,38 @@
+/**
+ * External dependencies
+ */
+/* eslint-disable import/no-extraneous-dependencies */
+import domReady from '@wordpress/dom-ready';
+import ReactDOM from 'react-dom';
+import { __ } from '@wordpress/i18n';
+/* eslint-disable import/no-extraneous-dependencies */
+
+function ClassicEditorNotice() {
+	return (
+		<div className="switch-to-classic-notice__content">
+			<h2>{ __( 'You are using the most modern WordPress editor yet.' ) }</h2>
+			<p>{ __( "If you'd prefer you canswitch back to the Classic Editor" ) } </p>
+		</div>
+	);
+}
+
+domReady( () => {
+	const editInception = setInterval( () => {
+		// Cycle through interval until sidebar is found.
+		const sidebar = document.querySelector( '.interface-interface-skeleton__sidebar' );
+
+		if ( ! sidebar ) {
+			return;
+		}
+
+		clearInterval( editInception );
+
+		sidebar.classList.add( 'show-classic-editor-notice' );
+
+		const switchToClassicNotice = document.createElement( 'div' );
+		switchToClassicNotice.className = 'edit-post-switch-to-classic-notice';
+		sidebar.append( switchToClassicNotice );
+
+		ReactDOM.render( <ClassicEditorNotice />, switchToClassicNotice );
+	} );
+} );

--- a/apps/wpcom-block-editor/src/wpcom/features/switch-to-classic-notice.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/switch-to-classic-notice.js
@@ -3,37 +3,70 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { registerPlugin } from '@wordpress/plugins';
-import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
+import domReady from '@wordpress/dom-ready';
+import ReactDOM from 'react-dom';
+import { useEffect, createInterpolateElement } from '@wordpress/element';
+import { withNotices } from '@wordpress/components';
 import url from 'url';
 /* eslint-enable import/no-extraneous-dependencies */
 
 const parsedEditorUrl = url.parse( window.location.href, true );
+const dismissNotice = () => {
+	console.log( 'Notice dismissed' );
+	localStorage.setItem( 'dismissedClassicEditorNotice', 'true' );
+};
 
-const classicEditorUrl = `${ parsedEditorUrl.protocol }//${ parsedEditorUrl.hostname }${ parsedEditorUrl.pathname }?post=${ parsedEditorUrl.query.post }&action=${ parsedEditorUrl.query.action }&set-editor=classic`;
+const ClassicEditorNotice = ( { noticeOperations, noticeUI } ) => {
+	const noticeText = createInterpolateElement(
+		'If you prefer the Classic editor, you can always switch. Open the options menu by click in the button at the top right of your screen, and select <strong>Switch to Classic editor</strong>.',
+		{ strong: <strong /> }
+	);
 
-const PluginDocumentSettingPanelDemo = () => (
-	<PluginDocumentSettingPanel
-		name="switch-to-classic"
-		title="Switch to Classic Editor"
-		className="features__switch-to-classic"
-	>
-		<h2>{ __( 'You are using the most modern WordPress editor yet.' ) }</h2>
-		<p>
-			If you'd prefer you can switch back to the
-			<a target="_top" href={ classicEditorUrl }>
-				Classic Editor
-			</a>
-		</p>
-	</PluginDocumentSettingPanel>
-);
+	const noticeContent = (
+		<div>
+			<h2>{ __( "You're usng the most modern WordPress Editor." ) } </h2>
+			<p>{ noticeText }</p>
+		</div>
+	);
 
-// Need to replace this check with one that checks for a classicEditorUrl.query param - we need to pass through a
-// a custom query param from calyps to identify group to show this option to as outlined in
+	useEffect( () => {
+		noticeOperations.createNotice( {
+			className: 'edit-post-switch-to-classic-notice',
+			status: 'info',
+			content: noticeContent,
+			isDismissible: true,
+			onRemove: dismissNotice,
+		} );
+	}, [ noticeOperations ] );
+
+	return <div>{ noticeUI }</div>;
+};
+
+const NoticeComponent = withNotices( ClassicEditorNotice );
+
+const noticeDismissed = localStorage.getItem( 'dismissedClassicEditorNotice' );
+
+// Need to replace this check with one that checks for a specific parsedEditorUrl.query param
 // https://github.com/Automattic/wp-calypso/issues/41087.
-if ( 1 === 1 ) {
-	registerPlugin( 'plugin-document-setting-panel-demo', {
-		render: PluginDocumentSettingPanelDemo,
-		icon: null,
+if ( parsedEditorUrl.query[ 'environment-id' ] === 'stage' && noticeDismissed !== 'true' ) {
+	domReady( () => {
+		const editInception = setInterval( () => {
+			// Cycle through interval until sidebar is found.
+			const sidebar = document.querySelector( '.components-panel__body.edit-post-post-status' );
+
+			if ( ! sidebar ) {
+				return;
+			}
+
+			clearInterval( editInception );
+
+			sidebar.classList.add( 'show-classic-editor-notice' );
+
+			const switchToClassicNotice = document.createElement( 'div' );
+			switchToClassicNotice.className = 'edit-post-switch-to-classic-notice';
+			sidebar.after( switchToClassicNotice );
+
+			ReactDOM.render( <NoticeComponent />, switchToClassicNotice );
+		} );
 	} );
 }

--- a/apps/wpcom-block-editor/src/wpcom/features/switch-to-classic-notice.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/switch-to-classic-notice.js
@@ -6,7 +6,7 @@ import { __ } from '@wordpress/i18n';
 import domReady from '@wordpress/dom-ready';
 import ReactDOM from 'react-dom';
 import { useState, createInterpolateElement } from '@wordpress/element';
-import { withNotices, Notice } from '@wordpress/components';
+import { Button, Notice, withNotices } from '@wordpress/components';
 import url from 'url';
 /* eslint-enable import/no-extraneous-dependencies */
 
@@ -23,7 +23,7 @@ const ClassicEditorNotice = () => {
 	};
 
 	const noticeText = createInterpolateElement(
-		'If you prefer the Classic editor, you can always switch. Open the options menu by clicking on the button at the top right of your screen, and select <strong>Switch to Classic editor</strong>.',
+		'If you prefer the Classic editor, you can always switch. Click the 3 vertical dots at the top right of your screen, and select <strong>Switch to Classic editor</strong>.',
 		{ strong: <strong /> }
 	);
 
@@ -31,17 +31,17 @@ const ClassicEditorNotice = () => {
 		<div>
 			<h2>{ __( "You're using the most modern WordPress Editor." ) } </h2>
 			<p>{ noticeText }</p>
+			<p>
+				<Button isLink onClick={ dismissNotice }>
+					{ __( 'Dismiss this message' ) }
+				</Button>
+			</p>
 		</div>
 	);
 
 	return (
 		! noticedDismissed && (
-			<Notice
-				className="features__switch-to-classic-notice"
-				status="info"
-				isDismissible={ true }
-				onRemove={ dismissNotice }
-			>
+			<Notice className="features__switch-to-classic-notice" status="info" isDismissible={ false }>
 				{ noticeContent }
 			</Notice>
 		)
@@ -71,6 +71,6 @@ if ( parsedEditorUrl.query[ 'show-classic-notice' ] && ! noticeDismissed ) {
 			postStatus.parentNode.insertBefore( switchToClassicNotice, postStatus );
 
 			ReactDOM.render( <NoticeComponent />, switchToClassicNotice );
-		} );
+		}, 200 );
 	} );
 }

--- a/apps/wpcom-block-editor/src/wpcom/features/switch-to-classic-notice.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/switch-to-classic-notice.js
@@ -20,10 +20,10 @@ const PluginDocumentSettingPanelDemo = () => (
 	>
 		<h2>{ __( 'You are using the most modern WordPress editor yet.' ) }</h2>
 		<p>
-			If you'd prefer you can switch back to the{ ' ' }
+			If you'd prefer you can switch back to the
 			<a target="_top" href={ classicEditorUrl }>
 				Classic Editor
-			</a>{ ' ' }
+			</a>
 		</p>
 	</PluginDocumentSettingPanel>
 );

--- a/apps/wpcom-block-editor/src/wpcom/features/switch-to-classic-notice.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/switch-to-classic-notice.js
@@ -1,38 +1,23 @@
+/* eslint-disable import/no-extraneous-dependencies */
 /**
  * External dependencies
  */
-/* eslint-disable import/no-extraneous-dependencies */
-import domReady from '@wordpress/dom-ready';
-import ReactDOM from 'react-dom';
 import { __ } from '@wordpress/i18n';
-/* eslint-disable import/no-extraneous-dependencies */
+import { registerPlugin } from '@wordpress/plugins';
+import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
+/* eslint-enable import/no-extraneous-dependencies */
 
-function ClassicEditorNotice() {
-	return (
-		<div className="switch-to-classic-notice__content">
-			<h2>{ __( 'You are using the most modern WordPress editor yet.' ) }</h2>
-			<p>{ __( "If you'd prefer you canswitch back to the Classic Editor" ) } </p>
-		</div>
-	);
-}
-
-domReady( () => {
-	const editInception = setInterval( () => {
-		// Cycle through interval until sidebar is found.
-		const sidebar = document.querySelector( '.interface-interface-skeleton__sidebar' );
-
-		if ( ! sidebar ) {
-			return;
-		}
-
-		clearInterval( editInception );
-
-		sidebar.classList.add( 'show-classic-editor-notice' );
-
-		const switchToClassicNotice = document.createElement( 'div' );
-		switchToClassicNotice.className = 'edit-post-switch-to-classic-notice';
-		sidebar.append( switchToClassicNotice );
-
-		ReactDOM.render( <ClassicEditorNotice />, switchToClassicNotice );
-	} );
+const PluginDocumentSettingPanelDemo = () => (
+	<PluginDocumentSettingPanel
+		name="switch-to-classic"
+		title="Switch to Classic Editor"
+		className="features__switch-to-classic"
+	>
+		<h2>{ __( 'You are using the most modern WordPress editor yet.' ) }</h2>
+		<p>{ __( "If you'd prefer you canswitch back to the Classic Editor" ) } </p>
+	</PluginDocumentSettingPanel>
+);
+registerPlugin( 'plugin-document-setting-panel-demo', {
+	render: PluginDocumentSettingPanelDemo,
+	icon: null,
 } );

--- a/apps/wpcom-block-editor/src/wpcom/features/switch-to-classic-notice.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/switch-to-classic-notice.js
@@ -8,6 +8,10 @@ import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
 import url from 'url';
 /* eslint-enable import/no-extraneous-dependencies */
 
+const parsedEditorUrl = url.parse( window.location.href, true );
+
+const classicEditorUrl = `${ parsedEditorUrl.protocol }//${ parsedEditorUrl.hostname }${ parsedEditorUrl.pathname }?post=${ parsedEditorUrl.query.post }&action=${ parsedEditorUrl.query.action }&set-editor=classic`;
+
 const PluginDocumentSettingPanelDemo = () => (
 	<PluginDocumentSettingPanel
 		name="switch-to-classic"
@@ -15,14 +19,19 @@ const PluginDocumentSettingPanelDemo = () => (
 		className="features__switch-to-classic"
 	>
 		<h2>{ __( 'You are using the most modern WordPress editor yet.' ) }</h2>
-		<p>{ __( "If you'd prefer you canswitch back to the Classic Editor" ) } </p>
+		<p>
+			If you'd prefer you can switch back to the{ ' ' }
+			<a target="_top" href={ classicEditorUrl }>
+				Classic Editor
+			</a>{ ' ' }
+		</p>
 	</PluginDocumentSettingPanel>
 );
 
-const parsedEditorUrl = url.parse( window.location.href, true );
-// just temporarily using the 'action' query param - we need to pass through a custom query param
-// to identify group to show this option to as outlined in https://github.com/Automattic/wp-calypso/issues/41087.
-if ( parsedEditorUrl.query.action ) {
+// Need to replace this check with one that checks for a classicEditorUrl.query param - we need to pass through a
+// a custom query param from calyps to identify group to show this option to as outlined in
+// https://github.com/Automattic/wp-calypso/issues/41087.
+if ( 1 === 1 ) {
 	registerPlugin( 'plugin-document-setting-panel-demo', {
 		render: PluginDocumentSettingPanelDemo,
 		icon: null,

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -44,6 +44,7 @@ import ConvertToBlocksDialog from 'components/convert-to-blocks';
 import config from 'config';
 import EditorDocumentHead from 'post-editor/editor-document-head';
 import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
+import { getSelectedEditor } from 'state/selectors/get-selected-editor';
 
 /**
  * Types
@@ -685,11 +686,11 @@ const mapStateToProps = (
 		queryArgs[ 'editor-after-deprecation' ] = 1;
 	}
 
-	// TODO: At this point we need to work out who should get the notice
-	// Endpoint added at D43926-code returns true if user is forced to block
-	// editor on deprecation, so just need to work out best way to get this from
-	// api/store at this point
-	queryArgs[ 'show-classic-notice' ] = 1;
+	// We want to temporarily show a notice in the editor to those users that have been forced to
+	// the block editor post deprecation of the calypso classic editor
+	if ( getSelectedEditor( state, siteId ) === 'gutenberg-iframe-forced' ) {
+		queryArgs[ 'show-classic-notice' ] = 1;
+	}
 
 	const siteAdminUrl =
 		editorType === 'site'

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -685,6 +685,12 @@ const mapStateToProps = (
 		queryArgs[ 'editor-after-deprecation' ] = 1;
 	}
 
+	// TODO: At this point we need to work out who should get the notice
+	// Endpoint added at D43926-code returns true if user is forced to block
+	// editor on deprecation, so just need to work out best way to get this from
+	// api/store at this point
+	queryArgs[ 'show-classic-notice' ] = 1;
+
 	const siteAdminUrl =
 		editorType === 'site'
 			? getSiteAdminUrl( state, siteId, 'admin.php?page=gutenberg-edit-site' )

--- a/client/state/selectors/get-selected-editor.js
+++ b/client/state/selectors/get-selected-editor.js
@@ -21,6 +21,7 @@ export const getSelectedEditor = ( state, siteId ) => {
 
 	const validEditors = [
 		'gutenberg-iframe',
+		'gutenberg-iframe-forced',
 		'gutenberg-redirect',
 		'gutenberg-redirect-and-style',
 		'classic',

--- a/client/state/selectors/should-load-gutenberg.js
+++ b/client/state/selectors/should-load-gutenberg.js
@@ -4,7 +4,12 @@
 import { getSelectedEditor } from 'state/selectors/get-selected-editor';
 
 export const shouldLoadGutenberg = ( state, siteId ) => {
-	const validEditors = [ 'gutenberg-iframe', 'gutenberg-redirect', 'gutenberg-redirect-and-style' ];
+	const validEditors = [
+		'gutenberg-iframe-forced',
+		'gutenberg-iframe',
+		'gutenberg-redirect',
+		'gutenberg-redirect-and-style',
+	];
 	const selectedEditor = getSelectedEditor( state, siteId );
 	return validEditors.indexOf( selectedEditor ) > -1;
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Injects a temporary 'Switch to Classic' option in the iframed block editor as part of the classic editor deprecation.

Part of #41087

#### Testing instructions

* Check out this PR and build the wpcom block editor files with `yarn build:prod` in the `apps/wpcom-block-editor/package.json` folder.
* Sync the files created by the build in the '/dist' folder with your sandbox widgets/wpcom-block-editor folder
* Follow instructions in D43926-code
* Build and run local calypso dev this branch
* A new dismissible notice should appear in the editor document settings panel with details about how to switch back to the classic editor, as long as you view on Staging.
* Once dismissed, if you reload the notice should not appear (you can delete `dismissedClassicEditorNotice` from local storage to retest)

<img width="832" alt="Screen Shot 2020-05-27 at 11 43 19 AM" src="https://user-images.githubusercontent.com/3629020/82960780-92702c80-a00f-11ea-8278-08e217bbe237.png">
