### PR TITLE
Gutenboarding: Domain popover and modal events are distinguishable in tracks

### DIFF
--- a/client/landing/gutenboarding/components/domain-picker-button/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-button/index.tsx
@@ -22,7 +22,7 @@ import './style.scss';
 
 type DomainSuggestion = import('@automattic/data-stores').DomainSuggestions.DomainSuggestion;
 
-interface Props extends Omit< DomainPickerProps, 'onClose' >, Button.BaseProps {
+interface Props extends Omit< DomainPickerProps, 'onClose' | 'tracksName' >, Button.BaseProps {
 	className?: string;
 	currentDomain?: DomainSuggestion;
 }

--- a/client/landing/gutenboarding/components/domain-picker-modal/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-modal/index.tsx
@@ -39,7 +39,13 @@ const DomainPickerModal: React.FunctionComponent< Props > = ( { isOpen, ...props
 			overlayClassName="domain-picker-modal-overlay"
 			bodyOpenClassName="has-domain-picker-modal"
 		>
-			<DomainPicker showDomainConnectButton showDomainCategories quantity={ 10 } { ...props } />
+			<DomainPicker
+				tracksName="DomainPickerModal"
+				showDomainConnectButton
+				showDomainCategories
+				quantity={ 10 }
+				{ ...props }
+			/>
 		</Modal>
 	);
 };

--- a/client/landing/gutenboarding/components/domain-picker-modal/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-modal/index.tsx
@@ -14,7 +14,7 @@ import DomainPicker, { Props as DomainPickerProps } from '../domain-picker';
  */
 import './style.scss';
 
-interface Props extends DomainPickerProps {
+interface Props extends Omit< DomainPickerProps, 'tracksName' > {
 	isOpen: boolean;
 	onMoreOptions?: () => void;
 }

--- a/client/landing/gutenboarding/components/domain-picker-popover/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-popover/index.tsx
@@ -41,7 +41,7 @@ const DomainPickerPopover: React.FunctionComponent< Props > = ( { isOpen, ...pro
 				position={ 'bottom center' }
 				expandOnMobile={ true }
 			>
-				<DomainPicker { ...props } />
+				<DomainPicker tracksName="DomainPickerPopover" { ...props } />
 			</Popover>
 		</div>
 	);

--- a/client/landing/gutenboarding/components/domain-picker-popover/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-popover/index.tsx
@@ -15,7 +15,7 @@ import DomainPicker, { Props as DomainPickerProps } from '../domain-picker';
  */
 import './style.scss';
 
-interface Props extends DomainPickerProps {
+interface Props extends Omit< DomainPickerProps, 'tracksName' > {
 	isOpen: boolean;
 }
 

--- a/client/landing/gutenboarding/components/domain-picker/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/index.tsx
@@ -66,6 +66,11 @@ export interface Props {
 	currentDomain?: DomainSuggestion;
 
 	quantity?: number;
+
+	/**
+	 * Name used to identify this component in tracks events.
+	 */
+	tracksName?: string;
 }
 
 const DomainPicker: FunctionComponent< Props > = ( {
@@ -78,6 +83,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 	quantity = PAID_DOMAINS_TO_SHOW,
 	currentDomain,
 	recordAnalytics,
+	tracksName,
 } ) => {
 	const { __, i18nLocale } = useI18n();
 	const label = __( 'Search for a domain' );
@@ -159,7 +165,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 		}
 	}, [ allSuggestions, currentDomain ] );
 
-	useTrackModal( 'DomainPicker', () => ( {
+	useTrackModal( tracksName, () => ( {
 		selected_domain: getSelectedDomain()?.domain_name,
 	} ) );
 

--- a/client/landing/gutenboarding/components/domain-picker/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/index.tsx
@@ -70,7 +70,7 @@ export interface Props {
 	/**
 	 * Name used to identify this component in tracks events.
 	 */
-	tracksName?: string;
+	tracksName: string;
 }
 
 const DomainPicker: FunctionComponent< Props > = ( {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use a different `name` property for the domain picker popover and modal when sending `calypso_newsite_modal_*` events

The popover and modal being indistinguishable in events means we couldn't see how many people are asking for the advanced domain options during signup, making the open event for the modal pointless.

Heads up to @johnHackworth who owns all the funnels using these events.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Filter the network tab for `calypso_newsite_modal_` events
* `/new`
* Use the domain picker popover and click the "more options" button in various orders.
* Check network tab for the correct open and close events
