### PR TITLE
i18n: Handle translation chunks setup errors for locales with missing translation files

### DIFF
--- a/client/boot/locale.js
+++ b/client/boot/locale.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { get } from 'lodash';
+import debugFactory from 'debug';
 import i18n from 'i18n-calypso';
 
 /**
@@ -17,11 +18,25 @@ import {
 import { getUrlParts } from 'lib/url/url-parts';
 import { setLocale, setLocaleRawData } from 'state/ui/language/actions';
 
+const debug = debugFactory( 'calypso:i18n' );
+
 const setupTranslationChunks = async ( localeSlug, reduxStore ) => {
 	const { translatedChunks, locale } = await getLanguageManifestFile(
 		localeSlug,
 		window.BUILD_TARGET
-	);
+	).catch( () => {
+		debug( `Failed to get language manifest for ${ localeSlug }.` );
+
+		return {};
+	} );
+
+	if ( ! locale || ! translatedChunks ) {
+		debug(
+			`Encountered an error setting up translation chunks for ${ localeSlug }. Falling back to English.`
+		);
+
+		return;
+	}
 
 	reduxStore.dispatch( setLocaleRawData( locale ) );
 

--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -303,6 +303,11 @@ export default function switchLocale( localeSlug ) {
 				i18n.setLocale( body );
 				setLocaleInDOM();
 				loadUserUndeployedTranslations( localeSlug );
+			} )
+			.catch( () => {
+				debug(
+					`Encountered an error loading language manifest and/or translation chunks for ${ localeSlug }. Falling back to English.`
+				);
 			} );
 	} else {
 		getLanguageFile( localeSlug ).then(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Check for language manifest file existence before doing naive file read, as some user locales don't have translation files.
* Terminate translation chunks setup if language manifest encounters an error when fetching

#### Testing instructions

* Boot Calypso with `BUILD_TRANSLATION_CHUNKS=true ENABLE_FEATURES=use-translation-chunks,wpcom-user-bootstrap yarn start`
* Open http://calypso.localhost:3000/me/account
* Change UI language to `(Cuengh)` (or other language that we don't serve translations for
* Confirm that Calypso works properly
