### PR TITLE
Fix left alignment and margins on Activity Card with media stream

### DIFF
--- a/client/landing/jetpack-cloud/components/activity-card/style.scss
+++ b/client/landing/jetpack-cloud/components/activity-card/style.scss
@@ -155,8 +155,7 @@
 }
 
 .activity-card__streams-item {
-	text-align: center;
-	margin-top: 24px;
+	margin: 24px 0;
 }
 
 .activity-card__streams-item-title {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fix left alignment and margins on Activity Card with a media stream.

#### Testing instructions

- Apply the changes
- In a RT-Backup site, go to a date with media stream upload (small images) and check if the images are aligned to the left.
