### PR TITLE
Premium content: Decode UTF-8 characters

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/premium-content-dom.php
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/premium-content-dom.php
@@ -28,6 +28,8 @@ class Premium_Content_Dom {
 	function __construct( $content ) {
 		$this->doc = new \DOMDocument();
 		libxml_use_internal_errors( true );
+		// Ensures UTF-8 characters are correctly encoded.
+		$content = mb_convert_encoding( $content, 'HTML-ENTITIES', 'UTF-8' );
 		// Do not set doctype, html, or body tags
 		$status = $this->doc->loadHTML( $content, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD );
 		if ( $status === false ) {
@@ -59,7 +61,7 @@ class Premium_Content_Dom {
 	 * @return string
 	 */
 	public function to_html() {
-		return utf8_decode( $this->doc->saveHTML() );
+		return $this->doc->saveHTML();
 	}
 
 	/**

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/premium-content-dom.php
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/premium-content-dom.php
@@ -59,7 +59,7 @@ class Premium_Content_Dom {
 	 * @return string
 	 */
 	public function to_html() {
-		return $this->doc->saveHTML();
+		return utf8_decode( $this->doc->saveHTML() );
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Ensures the content of any premium content block is correctly decoded using the UTF-8 charset, so non-single byte UTF-8 characters are displayed correctly

Before | After
--- | ---
<img width="762" alt="Screen Shot 2020-05-20 at 11 28 05" src="https://user-images.githubusercontent.com/1233880/82433038-2599e700-9a91-11ea-9074-00233f170c05.png"> | <img width="714" alt="Screen Shot 2020-05-20 at 11 58 11" src="https://user-images.githubusercontent.com/1233880/82433067-33e80300-9a91-11ea-924d-0499cbdd1ab6.png">


#### Testing instructions

* Apply D43708-code, and sandbox the API and a testing site (make sure your sandbox doesn't have any FSE build in `plugins/full-site-editing-plugin/dev`, otherwise changes in D43708-code won't take effect).
* Set up a recurring payment plan on the testing site using the testing store. More info in PCYsg-lW4-p2 #sandbox-method.
* Create a post and insert a premium content block.
* Add some content that includes non-single byte UTF-8 characters such as emojis (🙂👾), accented characters (áèñôü) or chinese/japanese characters (漢字). 
* Make sure you add those characters in both the subscriber and non-subscriber views.
* Publish the post.
* Visit it while logged in.
* Make sure the post shows the subscriber content and all characters are displayed correctly.
* Visit it while logged out.
* Make sure the post shows the non-subscriber content and all characters are displayed correctly.

Fixes #42384
