### PR TITLE
JCloud: Use the Backup product name as title on Backup section

### DIFF
--- a/client/landing/jetpack-cloud/components/masterbar/style.scss
+++ b/client/landing/jetpack-cloud/components/masterbar/style.scss
@@ -40,6 +40,10 @@
 			margin-top: 2px;
 			color: var( --color-neutral-80 );
 		}
+
+		@include breakpoint-deprecated( '>660px' ) {
+			font-size: 20px;
+		}
 	}
 
 	.masterbar__item-me {

--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -157,10 +157,19 @@ class BackupsPage extends Component {
 		const metaDiff = getMetaDiffForDailyBackup( logs, selectedDateString );
 		const hasRealtimeBackups = includes( siteCapabilities, 'backup-realtime' );
 		const isToday = today.isSame( this.getSelectedDate(), 'day' );
+		const isBackupDaily = includes( siteCapabilities, 'backup-daily' );
+
+		let title = '';
+
+		if ( isBackupDaily ) {
+			title = translate( 'Daily Backups' );
+		} else if ( hasRealtimeBackups ) {
+			title = translate( 'Real-time Backups' );
+		}
 
 		return (
 			<Main>
-				<DocumentHead title={ translate( 'Latest backups' ) } />
+				<DocumentHead title={ title } />
 				<SidebarNavigation />
 				<PageViewTracker path="/backups/:site" title="Backups" />
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Use the Backup product name as the title on the section, "Daily Backup" or "Real-time Backup"

Expected:
![image](https://user-images.githubusercontent.com/9832440/82439527-bb824180-9a92-11ea-985c-25e3c41429f7.png)

Or:
![image](https://user-images.githubusercontent.com/9832440/82439498-ad342580-9a92-11ea-91e0-eae553b5e47c.png)


#### Testing instructions

- Apply the changes
- Go to the `Latest backups` section and check if the section shows the title "Daily Backup" or "Real-time Backup"
