### PR TITLE
Jetpack Scan: Update Jepack Scan to Jetpack Scan Daily

### DIFF
--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -64,7 +64,7 @@ const analyticsPageTitleByType = {
 	realtimebackup: 'Jetpack Realtime Backup',
 	backup: 'Jetpack Daily Backup',
 	jetpack_search: 'Jetpack Search',
-	scan: 'Jetpack Scan',
+	scan: 'Jetpack Scan Daily',
 };
 
 const removeSidebar = ( context ) => context.store.dispatch( hideSidebar() );

--- a/client/lib/products-values/constants.js
+++ b/client/lib/products-values/constants.js
@@ -84,8 +84,8 @@ export const getJetpackProductsShortNames = () => {
 		[ PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY ]: translate( 'Real-Time Backups' ),
 		[ PRODUCT_JETPACK_SEARCH ]: translate( 'Search' ),
 		[ PRODUCT_JETPACK_SEARCH_MONTHLY ]: translate( 'Search' ),
-		[ PRODUCT_JETPACK_SCAN ]: translate( 'Scan' ),
-		[ PRODUCT_JETPACK_SCAN_MONTHLY ]: translate( 'Scan' ),
+		[ PRODUCT_JETPACK_SCAN ]: translate( 'Daily Scan' ),
+		[ PRODUCT_JETPACK_SCAN_MONTHLY ]: translate( 'Daily Scan' ),
 	};
 };
 

--- a/client/lib/products-values/constants.js
+++ b/client/lib/products-values/constants.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { Fragment } from 'react';
+import React from 'react';
 import { numberFormat, translate } from 'i18n-calypso';
 
 /**
@@ -90,47 +90,48 @@ export const getJetpackProductsShortNames = () => {
 };
 
 export const getJetpackProductsDisplayNames = () => {
+	const backupDaily = (
+		<>
+			{ translate( 'Jetpack Backup {{em}}Daily{{/em}}', {
+				components: {
+					em: <em />,
+				},
+			} ) }{ ' ' }
+		</>
+	);
+
+	const backupRealtime = (
+		<>
+			{ ' ' }
+			{ translate( 'Jetpack Backup {{em}}Real-Time{{/em}}', {
+				components: {
+					em: <em />,
+				},
+			} ) }{ ' ' }
+		</>
+	);
+
+	const search = translate( 'Jetpack Search' );
+
+	const scanDaily = (
+		<>
+			{ translate( 'Jetpack Scan {{em}}Daily{{/em}}', {
+				components: {
+					em: <em />,
+				},
+			} ) }{ ' ' }
+		</>
+	);
+
 	return {
-		[ PRODUCT_JETPACK_BACKUP_DAILY ]: (
-			<Fragment>
-				{ translate( 'Jetpack Backup {{em}}Daily{{/em}}', {
-					components: {
-						em: <em />,
-					},
-				} ) }
-			</Fragment>
-		),
-		[ PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY ]: (
-			<Fragment>
-				{ translate( 'Jetpack Backup {{em}}Daily{{/em}}', {
-					components: {
-						em: <em />,
-					},
-				} ) }
-			</Fragment>
-		),
-		[ PRODUCT_JETPACK_BACKUP_REALTIME ]: (
-			<Fragment>
-				{ translate( 'Jetpack Backup {{em}}Real-Time{{/em}}', {
-					components: {
-						em: <em />,
-					},
-				} ) }
-			</Fragment>
-		),
-		[ PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY ]: (
-			<Fragment>
-				{ translate( 'Jetpack Backup {{em}}Real-Time{{/em}}', {
-					components: {
-						em: <em />,
-					},
-				} ) }
-			</Fragment>
-		),
-		[ PRODUCT_JETPACK_SEARCH ]: translate( 'Jetpack Search' ),
-		[ PRODUCT_JETPACK_SEARCH_MONTHLY ]: translate( 'Jetpack Search' ),
-		[ PRODUCT_JETPACK_SCAN ]: translate( 'Jetpack Scan' ),
-		[ PRODUCT_JETPACK_SCAN_MONTHLY ]: translate( 'Jetpack Scan' ),
+		[ PRODUCT_JETPACK_BACKUP_DAILY ]: backupDaily,
+		[ PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY ]: backupDaily,
+		[ PRODUCT_JETPACK_BACKUP_REALTIME ]: backupRealtime,
+		[ PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY ]: backupRealtime,
+		[ PRODUCT_JETPACK_SEARCH ]: search,
+		[ PRODUCT_JETPACK_SEARCH_MONTHLY ]: search,
+		[ PRODUCT_JETPACK_SCAN ]: scanDaily,
+		[ PRODUCT_JETPACK_SCAN_MONTHLY ]: scanDaily,
 	};
 };
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Since we are introducing Jetpack Scan realtime eventually. 

This PR updates calypso to use Jetpack Scan Daily instead of the current Jetpack Scan. 

Updated Screenshots
<img width="762" alt="Screen Shot 2020-05-20 at 2 51 18 PM" src="https://user-images.githubusercontent.com/115071/82448838-94376e80-9aaa-11ea-820a-1554c143ef8f.png">
<img width="773" alt="Screen Shot 2020-05-20 at 2 51 03 PM" src="https://user-images.githubusercontent.com/115071/82448840-94d00500-9aaa-11ea-90cd-404bb13ef1b9.png">
<img width="1139" alt="Screen Shot 2020-05-20 at 2 49 54 PM" src="https://user-images.githubusercontent.com/115071/82448841-95689b80-9aaa-11ea-9aba-ff90f8acf7d7.png">
<img width="528" alt="Screen Shot 2020-05-20 at 2 49 47 PM" src="https://user-images.githubusercontent.com/115071/82448843-95689b80-9aaa-11ea-98a6-d7e831be4407.png">

<img width="526" alt="Screen Shot 2020-05-20 at 3 30 43 PM" src="https://user-images.githubusercontent.com/115071/82451976-fe521280-9aae-11ea-99e8-4f0d19e46a06.png">



#### Testing instructions
1. Apply this PR. 
2. but Jetpack Scan Daily. 
3. Notice that on the Plans Page, My Plan as well as the plan manage page shows Jetpack Scan Daily. 
