### PR TITLE
Marketing Connections: Properly support for multiple Instagram accounts

### DIFF
--- a/client/my-sites/marketing/connections/service-action.jsx
+++ b/client/my-sites/marketing/connections/service-action.jsx
@@ -14,8 +14,8 @@ import { localize } from 'i18n-calypso';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { Button } from '@automattic/components';
 import { recordTracksEvent as recordTracksEventAction } from 'state/analytics/actions';
-import { getRemovableConnections } from 'state/sharing/publicize/selectors';
 import getCurrentRouteParameterized from 'state/selectors/get-current-route-parameterized';
+import getRemovableConnections from 'state/selectors/get-removable-connections';
 
 const SharingServiceAction = ( {
 	isConnecting,

--- a/client/my-sites/marketing/connections/service-connected-accounts.jsx
+++ b/client/my-sites/marketing/connections/service-connected-accounts.jsx
@@ -13,15 +13,16 @@ import { localize } from 'i18n-calypso';
 import { Button } from '@automattic/components';
 
 const SharingServiceConnectedAccounts = ( { children, connect, service, translate } ) => (
-	<div className="sharing-service-accounts-detail">
-		<ul className="sharing-service-connected-accounts">{ children }</ul>
-		{ 'publicize' === service.type && 'google_plus' !== service.ID && (
-			<Button onClick={ connect }>
-				{ translate( 'Connect a different account', {
-					comment: 'Sharing: Publicize connections',
-				} ) }
-			</Button>
-		) }
+	<div className="connections__sharing-service-accounts-detail">
+		<ul className="connections__sharing-service-connected-accounts">{ children }</ul>
+		{ ( 'publicize' === service.type || 'instagram-basic-display' === service.ID ) &&
+			'google_plus' !== service.ID && (
+				<Button onClick={ connect }>
+					{ translate( 'Connect a different account', {
+						comment: 'Sharing: Publicize connections',
+					} ) }
+				</Button>
+			) }
 	</div>
 );
 

--- a/client/my-sites/marketing/connections/service.jsx
+++ b/client/my-sites/marketing/connections/service.jsx
@@ -31,12 +31,12 @@ import {
 } from 'state/sharing/keyring/selectors';
 import {
 	getBrokenSiteUserConnectionsForService,
-	getRemovableConnections,
 	getSiteUserConnectionsForService,
 	isFetchingConnections,
 } from 'state/sharing/publicize/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import getCurrentRouteParameterized from 'state/selectors/get-current-route-parameterized';
+import getRemovableConnections from 'state/selectors/get-removable-connections';
 import { recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
 import { requestKeyringConnections } from 'state/sharing/keyring/actions';
 import ServiceAction from './service-action';

--- a/client/my-sites/marketing/connections/services/instagram.jsx
+++ b/client/my-sites/marketing/connections/services/instagram.jsx
@@ -29,10 +29,12 @@ export class Instagram extends SharingService {
 
 	/**
 	 * Deletes the passed connections.
+	 *
+	 * @param {Array} [connections] List of connections to delete. If undefined, delete all connections.
 	 */
-	removeConnection = () => {
+	removeConnection = ( connections ) => {
 		this.setState( { isDisconnecting: true } );
-		map( this.props.keyringConnections, this.props.deleteStoredKeyringConnection );
+		map( connections || this.props.keyringConnections, this.props.deleteStoredKeyringConnection );
 	};
 
 	renderLogo = () => (

--- a/client/my-sites/marketing/connections/services/instagram.jsx
+++ b/client/my-sites/marketing/connections/services/instagram.jsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { last, isEqual } from 'lodash';
+import { isEqual, map } from 'lodash';
 
 /**
  * Internal dependencies
@@ -32,7 +32,7 @@ export class Instagram extends SharingService {
 	 */
 	removeConnection = () => {
 		this.setState( { isDisconnecting: true } );
-		this.props.deleteStoredKeyringConnection( last( this.props.keyringConnections ) );
+		map( this.props.keyringConnections, this.props.deleteStoredKeyringConnection );
 	};
 
 	renderLogo = () => (

--- a/client/my-sites/marketing/style.scss
+++ b/client/my-sites/marketing/style.scss
@@ -170,7 +170,7 @@
 			display: block;
 		}
 
-		&.not-connected .sharing-service-accounts-detail,
+		&.not-connected .connections__sharing-service-accounts-detail,
 		&.not-connected .connections__sharing-service-tip {
 			display: none;
 		}
@@ -180,7 +180,7 @@
 		display: none;
 	}
 
-	.sharing-service-accounts-detail {
+	.connections__sharing-service-accounts-detail {
 		h2 {
 			font-size: 1.2em;
 		}
@@ -195,7 +195,7 @@
 		}
 	}
 
-	.sharing-service-connected-accounts {
+	.connections__sharing-service-connected-accounts {
 		margin-left: 0;
 		margin-bottom: 8px;
 	}
@@ -270,12 +270,12 @@
 	}
 }
 
-@include sharing-service( 'facebook', var( --color-facebook ));
-@include sharing-service( 'twitter', var( --color-twitter ));
-@include sharing-service( 'google_plus', var( --color-google-plus ));
-@include sharing-service( 'tumblr', var( --color-tumblr ));
-@include sharing-service( 'linkedin', var( --color-linkedin ));
-@include sharing-service( 'instagram-basic-display', var( --color-instagram ));
+@include sharing-service( 'facebook', var( --color-facebook ) );
+@include sharing-service( 'twitter', var( --color-twitter ) );
+@include sharing-service( 'google_plus', var( --color-google-plus ) );
+@include sharing-service( 'tumblr', var( --color-tumblr ) );
+@include sharing-service( 'linkedin', var( --color-linkedin ) );
+@include sharing-service( 'instagram-basic-display', var( --color-instagram ) );
 
 .sharing-service__name {
 	clear: none;
@@ -543,7 +543,8 @@
 	margin-bottom: 20px;
 	padding: 20px 24px;
 	background: var( --color-surface );
-	box-shadow: 0 0 0 1px rgba( var( --color-neutral-10-rgb ), 0.5 ), 0 1px 2px var( --color-neutral-0 );
+	box-shadow: 0 0 0 1px rgba( var( --color-neutral-10-rgb ), 0.5 ),
+		0 1px 2px var( --color-neutral-0 );
 }
 
 .sharing-buttons__fieldset-group {
@@ -915,22 +916,22 @@
 	}
 }
 
-@include sharing-button-service( 'facebook', var( --color-facebook ));
-@include sharing-button-service( 'twitter', var( --color-twitter ));
-@include sharing-button-service( 'press-this', var( --color-wordpress-com ));
-@include sharing-button-service( 'google-plus-1', var( --color-google-plus ));
-@include sharing-button-service( 'instagram-basic-display', var( --color-instagram ));
-@include sharing-button-service( 'linkedin', var( --color-linkedin ));
-@include sharing-button-service( 'stumbleupon', var( --color-stumbleupon ));
-@include sharing-button-service( 'tumblr', var( --color-tumblr ));
-@include sharing-button-service( 'reddit', var( --color-reddit ));
-@include sharing-button-service( 'pinterest', var( --color-pinterest ));
-@include sharing-button-service( 'pocket', var( --color-pocket ));
-@include sharing-button-service( 'email', var( --color-email ));
-@include sharing-button-service( 'print', var( --color-print ));
-@include sharing-button-service( 'skype', var( --color-skype ));
-@include sharing-button-service( 'telegram', var( --color-telegram ));
-@include sharing-button-service( 'jetpack-whatsapp', var( --color-whatsapp ));
+@include sharing-button-service( 'facebook', var( --color-facebook ) );
+@include sharing-button-service( 'twitter', var( --color-twitter ) );
+@include sharing-button-service( 'press-this', var( --color-wordpress-com ) );
+@include sharing-button-service( 'google-plus-1', var( --color-google-plus ) );
+@include sharing-button-service( 'instagram-basic-display', var( --color-instagram ) );
+@include sharing-button-service( 'linkedin', var( --color-linkedin ) );
+@include sharing-button-service( 'stumbleupon', var( --color-stumbleupon ) );
+@include sharing-button-service( 'tumblr', var( --color-tumblr ) );
+@include sharing-button-service( 'reddit', var( --color-reddit ) );
+@include sharing-button-service( 'pinterest', var( --color-pinterest ) );
+@include sharing-button-service( 'pocket', var( --color-pocket ) );
+@include sharing-button-service( 'email', var( --color-email ) );
+@include sharing-button-service( 'print', var( --color-print ) );
+@include sharing-button-service( 'skype', var( --color-skype ) );
+@include sharing-button-service( 'telegram', var( --color-telegram ) );
+@include sharing-button-service( 'jetpack-whatsapp', var( --color-whatsapp ) );
 
 .sharing-buttons-preview__panel {
 	position: relative;

--- a/client/state/selectors/get-removable-connections.js
+++ b/client/state/selectors/get-removable-connections.js
@@ -1,0 +1,34 @@
+/**
+ * External dependencies
+ */
+
+import { filter } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getCurrentUserId } from 'state/current-user/selectors';
+import { getKeyringConnectionsByName } from 'state/sharing/keyring/selectors';
+import { getRemovableConnections as getRemovablePublicizeConnections } from 'state/sharing/publicize/selectors';
+
+/**
+ * Given a Keyring service name, returns the connections that the current user is
+ * allowed to remove.
+ *
+ * For them to be allowed to remove a connection they need to have either the
+ * `edit_others_posts` capability or it's a connection to one of
+ * their accounts.
+ *
+ * @param   {object} state   Global state tree
+ * @param   {string} service The name of the service
+ * @returns {Array}          Connections that the current user is allowed to remove
+ */
+export default function getRemovableConnections( state, service ) {
+	const userId = getCurrentUserId( state );
+	const keyringConnections = filter(
+		getKeyringConnectionsByName( state, service ),
+		( { type, user_ID } ) => 'publicize' !== type && user_ID === userId
+	);
+
+	return [ ...keyringConnections, ...getRemovablePublicizeConnections( state, service ) ];
+}

--- a/client/state/selectors/test/get-removable-connections.js
+++ b/client/state/selectors/test/get-removable-connections.js
@@ -1,0 +1,76 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import getRemovableConnections from 'state/selectors/get-removable-connections';
+
+describe( 'getRemovableConnections()', () => {
+	const state = {
+		currentUser: {
+			id: 26957695,
+			capabilities: {
+				2916284: {
+					edit_others_posts: true,
+				},
+			},
+		},
+		sharing: {
+			keyring: {
+				items: {
+					1: { ID: 1, type: 'publicize', shared: true, service: 'twitter', user_ID: 0 },
+					2: { ID: 2, type: 'publicize', service: 'twitter', user_ID: 26957695 },
+					3: { ID: 3, type: 'publicize', service: 'facebook' },
+					4: { ID: 4, type: 'other', service: 'instagram-basic-display', user_ID: 26957695 },
+					5: { ID: 5, type: 'other', service: 'instagram-basic-display', user_ID: 0 },
+				},
+			},
+			publicize: {
+				connections: {
+					1: { ID: 1, site_ID: 2916284, shared: true, service: 'twitter', user_ID: 0 },
+					2: {
+						ID: 2,
+						site_ID: 2916284,
+						keyring_connection_user_ID: 26957695,
+						service: 'twitter',
+						user_ID: 26957695,
+					},
+					3: { ID: 2, site_ID: 2916284, keyring_connection_user_ID: 18342963, service: 'facebook' },
+				},
+			},
+		},
+		ui: {
+			selectedSiteId: 2916284,
+		},
+	};
+
+	test( 'should return an empty array for a service without connections', () => {
+		const connections = getRemovableConnections( state, 'path' );
+
+		expect( connections ).to.eql( [] );
+	} );
+
+	test( 'should return an array of connection objects that are removable by the current user without duplicates', () => {
+		const twitterConnections = getRemovableConnections( state, 'twitter' );
+
+		expect( twitterConnections ).to.eql( [
+			{ ID: 1, site_ID: 2916284, shared: true, service: 'twitter', user_ID: 0 },
+			{
+				ID: 2,
+				site_ID: 2916284,
+				keyring_connection_user_ID: 26957695,
+				service: 'twitter',
+				user_ID: 26957695,
+			},
+		] );
+
+		const instagramConnections = getRemovableConnections( state, 'instagram-basic-display' );
+
+		expect( instagramConnections ).to.eql( [
+			{ ID: 4, type: 'other', service: 'instagram-basic-display', user_ID: 26957695 },
+		] );
+	} );
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add proper support for multiple connections for the Instagram service. 
* Update the "Disconnect" button label to also cover non-Publicize services with multiple connections (e.g. Instagram).

Working on the new Latest Instagram Posts block, we eventually decided to support multiple Instagram accounts.
This is supported out of the box by Keyring, but the Marketing Connections page is not as thorough for non-Publicize connections.
While it showed all the connections, and let you disconnect them one by one, it also had some quirks:
- The "Disconnect" button label should have been "Disconnect All".
- Clicking on "Disconnect (All)" for the Instagram service should have deleted all connections, while instead it only deleted the most recent.
- The Instagram service didn't have a "Connect a different account" button.

| Before | After |
| - | - |
| <img width="631" alt="Screenshot 2020-05-20 at 15 10 46" src="https://user-images.githubusercontent.com/2070010/82456507-3a37a880-9aac-11ea-85ee-d3772085966e.png"> | <img width="631" alt="Screenshot 2020-05-20 at 15 10 06" src="https://user-images.githubusercontent.com/2070010/82456521-3e63c600-9aac-11ea-9389-7f4b99fc8c60.png"> |

#### Testing instructions

* Have ready two different Instagram accounts.
* Log into the first Instagram account.
* Open `/marketing/connections`, and add a new Instagram connection.
* Log out of the first Instagram account, and log into the second.
* Add another new Instagram connection.
* Click on disconnect all.
* Make sure all connections are gone.

(Note the confirmation notice is using the incorrect label; I'm taking care of it in D43712-code)