### PR TITLE
Recurring Payments: Display email settings

### DIFF
--- a/client/assets/stylesheets/shared/functions/_z-index.scss
+++ b/client/assets/stylesheets/shared/functions/_z-index.scss
@@ -236,7 +236,8 @@ $z-layers: (
 		'.editor-media-modal .section-nav': 10,
 		'.editor-media-modal .notice': 10,
 		'.editor-contact-form-modal .section-nav': 10,
-		'.editor-media-modal-gallery__preview-toggle': 100
+		'.editor-media-modal-gallery__preview-toggle': 100,
+		'.memberships__dialog-section.is-visible': 1,
 	),
 	'.site-settings__taxonomies': (
 		'.card__link-indicator': 1

--- a/client/my-sites/earn/memberships/products.jsx
+++ b/client/my-sites/earn/memberships/products.jsx
@@ -34,6 +34,7 @@ import FormLabel from 'components/forms/form-label';
 import FormTextArea from 'components/forms/form-textarea';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormToggle from 'components/forms/form-toggle';
+import InlineSupportLink from 'components/inline-support-link';
 import {
 	requestAddProduct,
 	requestUpdateProduct,
@@ -362,7 +363,12 @@ class MembershipsProductsSection extends Component {
 						{ translate(
 							'Allow members of this recurring payment plan to opt into receiving new posts via email.'
 						) }{ ' ' }
-						<a href="/TODO">{ translate( 'Learn more' ) }.</a>
+						<InlineSupportLink
+							supportPostId="154624"
+							supportLink="https://wordpress.com/support/wordpress-editor/blocks/recurring-payments-button/" // TODO: Link to specific section once article is update
+							showIcon={ false }
+							text={ translate( 'Learn more.' ) }
+						/>
 					</p>
 					<FormToggle
 						onChange={ ( newValue ) => this.setState( { editedPostsEmail: newValue } ) }

--- a/client/my-sites/earn/memberships/products.jsx
+++ b/client/my-sites/earn/memberships/products.jsx
@@ -418,7 +418,7 @@ class MembershipsProductsSection extends Component {
 				] }
 			>
 				<FormSectionHeading>
-					{ this.state.editedProductId && this.props.translate( 'Edit' ) }
+					{ this.state.editedProductId && this.props.translate( 'Edit Recurring Payment plan' ) }
 					{ ! this.state.editedProductId &&
 						this.props.translate( 'Add New Recurring Payment plan' ) }
 				</FormSectionHeading>

--- a/client/my-sites/earn/memberships/products.jsx
+++ b/client/my-sites/earn/memberships/products.jsx
@@ -155,6 +155,8 @@ class MembershipsProductsSection extends Component {
 					interval: this.state.editedSchedule,
 					buyer_can_change_amount: this.state.editedPayWhatYouWant,
 					multiple_per_user: this.state.editedMultiplePerUser,
+					welcome_email_content: this.state.editedCustomConfirmationMessage,
+					subscribe_as_site_subscriber: this.state.editedPostsEmail,
 				},
 				this.props.translate( 'Updated "%s" product.', { args: this.state.editedProductName } )
 			);
@@ -178,6 +180,8 @@ class MembershipsProductsSection extends Component {
 				editedPayWhatYouWant: product.buyer_can_change_amount,
 				editedMultiplePerUser: !! product.multiple_per_user,
 				focusedName: false,
+				editedCustomConfirmationMessage: product.welcome_email_content,
+				editedPostsEmail: product.subscribe_as_site_subscriber,
 			} );
 		} else {
 			this.setState( {

--- a/client/my-sites/earn/memberships/products.jsx
+++ b/client/my-sites/earn/memberships/products.jsx
@@ -357,7 +357,7 @@ class MembershipsProductsSection extends Component {
 					<p>
 						{ translate(
 							'Allow members of this recurring payment plan to opt into receiving new posts via email.'
-						) }
+						) }{ ' ' }
 						<a href="/TODO">{ translate( 'Learn more' ) }.</a>
 					</p>
 					<FormToggle

--- a/client/my-sites/earn/memberships/products.jsx
+++ b/client/my-sites/earn/memberships/products.jsx
@@ -198,6 +198,8 @@ class MembershipsProductsSection extends Component {
 				editedPayWhatYouWant: false,
 				editedMultiplePerUser: false,
 				focusedName: false,
+				editedCustomConfirmationMessage: '',
+				editedPostsEmail: false,
 			} );
 		}
 	};

--- a/client/my-sites/earn/memberships/products.jsx
+++ b/client/my-sites/earn/memberships/products.jsx
@@ -142,6 +142,8 @@ class MembershipsProductsSection extends Component {
 					interval: this.state.editedSchedule,
 					buyer_can_change_amount: this.state.editedPayWhatYouWant,
 					multiple_per_user: this.state.editedMultiplePerUser,
+					welcome_email_content: this.state.editedCustomConfirmationMessage,
+					subscribe_as_site_subscriber: this.state.editedPostsEmail,
 				},
 				this.props.translate( 'Added "%s" product.', { args: this.state.editedProductName } )
 			);

--- a/client/my-sites/earn/memberships/products.jsx
+++ b/client/my-sites/earn/memberships/products.jsx
@@ -368,7 +368,7 @@ class MembershipsProductsSection extends Component {
 							'Allow members of this recurring payment plan to opt into receiving new posts via email.'
 						) }{ ' ' }
 						<InlineSupportLink
-							supportPostId="154624"
+							supportPostId={ 154624 }
 							supportLink="https://wordpress.com/support/wordpress-editor/blocks/recurring-payments-button/" // TODO: Link to specific section once article is update
 							showIcon={ false }
 							text={ translate( 'Learn more.' ) }

--- a/client/my-sites/earn/memberships/products.jsx
+++ b/client/my-sites/earn/memberships/products.jsx
@@ -411,9 +411,7 @@ class MembershipsProductsSection extends Component {
 						action: 'cancel',
 					},
 					{
-						label: this.state.editedProductId
-							? this.props.translate( 'Edit' )
-							: this.props.translate( 'Add' ),
+						label: this.props.translate( 'Save' ),
 						action: 'submit',
 						disabled: ! this.isFormValid(),
 					},

--- a/client/my-sites/earn/memberships/style.scss
+++ b/client/my-sites/earn/memberships/style.scss
@@ -240,6 +240,32 @@
 	float: right;
 }
 
+.memberships__dialog-nav.section-nav {
+	box-shadow: none;
+	border-bottom: 1px solid var( --color-neutral-5 );
+}
+
+.memberships__dialog-sections {
+	display: grid;
+	grid-template: 'item' 1fr / 1fr;
+}
+
+.memberships__dialog-section {
+	grid-area: item; // Sections are displayed in the same grid area so the dialog takes the size of the biggest section.
+	background-color: var( --color-surface );
+	z-index: 0;
+
+	&.is-visible {
+		z-index: 1; // Visible section is placed above so it hides the ones below.
+	}
+}
+
+.memberships__dialog-form-header {
+	font-size: 14px;
+	font-weight: 600;
+	margin-bottom: 1.5em;
+}
+
 
 /**
  * Delete Site Options

--- a/client/my-sites/earn/memberships/style.scss
+++ b/client/my-sites/earn/memberships/style.scss
@@ -253,10 +253,9 @@
 .memberships__dialog-section {
 	grid-area: item; // Sections are displayed in the same grid area so the dialog takes the size of the biggest section.
 	background-color: var( --color-surface );
-	z-index: 0;
 
 	&.is-visible {
-		z-index: 1; // Visible section is placed above so it hides the ones below.
+		z-index: z-index( '.dialog__backdrop', '.memberships__dialog-section.is-visible' );  // Visible section is placed above so it hides the ones below.
 	}
 }
 

--- a/client/state/data-layer/wpcom/sites/memberships/index.js
+++ b/client/state/data-layer/wpcom/sites/memberships/index.js
@@ -33,6 +33,8 @@ export const membershipProductFromApi = ( product ) => ( {
 	renewal_schedule: product.interval,
 	buyer_can_change_amount: product.buyer_can_change_amount,
 	multiple_per_user: product.multiple_per_user,
+	subscribe_as_site_subscriber: product.subscribe_as_site_subscriber,
+	welcome_email_content: product.welcome_email_content,
 } );
 
 export const handleMembershipProductsList = dispatchRequest( {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adds support for configuring through the Calypso UI the email settings of a Recurring Payment plan introduced in D43690-code.

<img width="756" alt="Screen Shot 2020-05-21 at 12 09 49" src="https://user-images.githubusercontent.com/1233880/82550885-84c62d00-9b5f-11ea-9a1e-832ccc47805f.png">


#### Testing instructions

* Set up Recurring Payments on a site using the testing store. More info in PCYsg-lW4-p2 #sandbox-method.
* Go to Tools > Earn > Collect recurring payments > Recurring Payments plans.
* Add or edit an existing recurring payment plan.
* Make sure the dialog displays a tab navigation menu.
* Make sure the "General" section displays the same form we currently show in production.
* Make sure the "Email" section displays a form for configuring the email settings.
* Enable the "Posts via email" checkbox.
<img width="704" alt="Screen Shot 2020-05-21 at 13 18 23" src="https://user-images.githubusercontent.com/1233880/82554096-90b4ed80-9b65-11ea-85a4-a083f5a89d65.png">

* Enter some content in the "Custom confirmation message".
<img width="713" alt="Screen Shot 2020-05-21 at 13 18 37" src="https://user-images.githubusercontent.com/1233880/82554113-99a5bf00-9b65-11ea-897d-e6bc75f66599.png">

* Click on "Save".
* Publish a new post that contains a Premium Content block using the plan you saved above.
* Visit the published post as a logged out user.
* Subscribe to the plan.
* Make sure the new subscriber receives an email that contains the "Custom confirmation message" entered above.
<img width="645" alt="Screen Shot 2020-05-21 at 13 23 03" src="https://user-images.githubusercontent.com/1233880/82554450-3c5e3d80-9b66-11ea-83ae-7474ad37943f.png">

Fixes #42272
