### PR TITLE
FSE: require asset files (not _once)

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/block-inserter-modifications/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-inserter-modifications/index.php
@@ -28,7 +28,7 @@ function enqueue_script( $filename, $in_footer = false ) {
 		);
 	}
 
-	$asset = require_once $asset_path;
+	$asset = require $asset_path;
 
 	wp_enqueue_script(
 		$filename,
@@ -42,7 +42,7 @@ function enqueue_script( $filename, $in_footer = false ) {
 /**
  * Enqueues a submodule style by its filename.
  *
- * @param string  $filename  Name of the style file w/o extension.
+ * @param string $filename  Name of the style file w/o extension.
  */
 function enqueue_style( $filename ) {
 	$style_file = is_rtl()

--- a/apps/full-site-editing/full-site-editing-plugin/event-countdown-block/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/event-countdown-block/index.php
@@ -10,7 +10,7 @@ add_action(
 	function() {
 
 		$asset_file   = __DIR__ . '/dist/event-countdown-block.asset.php';
-		$asset        = file_exists( $asset_file ) ? require_once $asset_file : null;
+		$asset        = file_exists( $asset_file ) ? require $asset_file : null;
 		$dependencies = isset( $asset['dependencies'] ) ? $asset['dependencies'] : array();
 		$version      = isset( $asset['version'] ) ? $asset['version'] : filemtime( __DIR__ . '/dist/event-countdown-block.js' );
 

--- a/apps/full-site-editing/full-site-editing-plugin/global-styles/class-global-styles.php
+++ b/apps/full-site-editing/full-site-editing-plugin/global-styles/class-global-styles.php
@@ -317,7 +317,7 @@ class Global_Styles {
 	public function enqueue_block_editor_assets() {
 		$asset_file   = plugin_dir_path( __FILE__ ) . 'dist/global-styles.asset.php';
 		$asset        = file_exists( $asset_file )
-			? require_once $asset_file
+			? require $asset_file
 			: null;
 		$dependencies = isset( $asset['dependencies'] ) ?
 			$asset['dependencies'] :

--- a/apps/full-site-editing/full-site-editing-plugin/jetpack-timeline/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/jetpack-timeline/index.php
@@ -10,7 +10,7 @@ add_action(
 	'init',
 	function() {
 		$asset_file   = __DIR__ . '/dist/jetpack-timleine.asset.php';
-		$asset        = file_exists( $asset_file ) ? require_once $asset_file : null;
+		$asset        = file_exists( $asset_file ) ? require $asset_file : null;
 		$dependencies = isset( $asset['dependencies'] ) ? $asset['dependencies'] : array();
 		$version      = isset( $asset['version'] ) ? $asset['version'] : filemtime( __DIR__ . '/index.js' );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

`require` should be used for asset files not `require_once`. See https://github.com/WordPress/gutenberg/pull/18599

Illustration of the issue, note the second `require_once` returns `true`.

```
php > var_export( require_once( __DIR__ . '/global-styles.asset.php' ) );
array (
  'dependencies' =>
  array (
    0 => 'lodash',
    1 => 'wp-api-fetch',
    2 => 'wp-components',
    3 => 'wp-compose',
    4 => 'wp-data',
    5 => 'wp-dom-ready',
    6 => 'wp-edit-post',
    7 => 'wp-element',
    8 => 'wp-i18n',
    9 => 'wp-keycodes',
    10 => 'wp-plugins',
    11 => 'wp-polyfill',
  ),
  'version' => 'e53af81a8e55ea0235ea0da817d6aad4',
)
php > var_export( require_once( __DIR__ . '/global-styles.asset.php' ) );
true
```

Compare to `require`:
```
php > var_export( require( __DIR__ . '/global-styles.asset.php' ) );
array (
  'dependencies' =>
  array (
    0 => 'lodash',
    1 => 'wp-api-fetch',
    2 => 'wp-components',
    3 => 'wp-compose',
    4 => 'wp-data',
    5 => 'wp-dom-ready',
    6 => 'wp-edit-post',
    7 => 'wp-element',
    8 => 'wp-i18n',
    9 => 'wp-keycodes',
    10 => 'wp-plugins',
    11 => 'wp-polyfill',
  ),
  'version' => 'e53af81a8e55ea0235ea0da817d6aad4',
)
php > var_export( require( __DIR__ . '/global-styles.asset.php' ) );
array (
  'dependencies' =>
  array (
    0 => 'lodash',
    1 => 'wp-api-fetch',
    2 => 'wp-components',
    3 => 'wp-compose',
    4 => 'wp-data',
    5 => 'wp-dom-ready',
    6 => 'wp-edit-post',
    7 => 'wp-element',
    8 => 'wp-i18n',
    9 => 'wp-keycodes',
    10 => 'wp-plugins',
    11 => 'wp-polyfill',
  ),
  'version' => 'e53af81a8e55ea0235ea0da817d6aad4',
)
```


#### Testing instructions

* Ensure the modified FSE plugin parts continue to work as expected.
