### PR TITLE
Jetpack Cloud: fix server credentials form broken unit test

### DIFF
--- a/client/landing/jetpack-cloud/components/with-server-credentials-form/index.jsx
+++ b/client/landing/jetpack-cloud/components/with-server-credentials-form/index.jsx
@@ -41,17 +41,35 @@ function withServerCredentialsForm( WrappedComponent ) {
 			requirePath: false,
 		};
 
-		state = {
-			form: INITIAL_FORM_STATE,
-			formErrors: {
-				host: false,
-				port: false,
-				user: false,
-				pass: false,
-				path: false,
-			},
-			showAdvancedSettings: false,
-		};
+		constructor( props ) {
+			super( props );
+			const { rewindState, role, siteSlug } = props;
+			const credentials = find( rewindState.credentials, { role: role } );
+			const form = Object.assign( {}, INITIAL_FORM_STATE );
+
+			// Populate the fields with data from state if credentials are already saved
+			if ( credentials ) {
+				form.protocol = credentials.type || form.protocol;
+				form.host = credentials.host || form.host;
+				form.port = credentials.port || form.port;
+				form.user = credentials.user || form.user;
+				form.path = credentials.path || form.path;
+			}
+			// Populate the host field with the site slug if needed
+			form.host = isEmpty( form.host ) && siteSlug ? siteSlug.split( '::' )[ 0 ] : form.host;
+
+			this.state = {
+				form: form,
+				formErrors: {
+					host: false,
+					port: false,
+					user: false,
+					pass: false,
+					path: false,
+				},
+				showAdvancedSettings: false,
+			};
+		}
 
 		handleFieldChange = ( { target: { name, value } } ) => {
 			const changedProtocol = 'protocol' === name;
@@ -118,14 +136,15 @@ function withServerCredentialsForm( WrappedComponent ) {
 				siteHasChanged ? { ...INITIAL_FORM_STATE } : this.state.form
 			);
 
-			// Populate the fields with data from state if credentials are already saved
-			nextForm.protocol = credentials ? credentials.type : nextForm.protocol;
-			nextForm.host = isEmpty( nextForm.host ) && credentials ? credentials.host : nextForm.host;
-			nextForm.port = isEmpty( nextForm.port ) && credentials ? credentials.port : nextForm.port;
-			nextForm.user = isEmpty( nextForm.user ) && credentials ? credentials.user : nextForm.user;
-			nextForm.path = isEmpty( nextForm.path ) && credentials ? credentials.path : nextForm.path;
-
-			// Populate the host field with the site slug if needed
+			// Replace empty fields with what comes from the rewind state
+			if ( credentials ) {
+				nextForm.protocol = isEmpty( nextForm.protocol ) ? credentials.type : nextForm.protocol;
+				nextForm.host = isEmpty( nextForm.host ) ? credentials.host : nextForm.host;
+				nextForm.port = isEmpty( nextForm.port ) ? credentials.port : nextForm.port;
+				nextForm.user = isEmpty( nextForm.user ) ? credentials.user : nextForm.user;
+				nextForm.path = isEmpty( nextForm.path ) ? credentials.path : nextForm.path;
+				// Populate the host field with the site slug if needed
+			}
 			nextForm.host =
 				isEmpty( nextForm.host ) && siteSlug ? siteSlug.split( '::' )[ 0 ] : nextForm.host;
 

--- a/client/landing/jetpack-cloud/components/with-server-credentials-form/index.jsx
+++ b/client/landing/jetpack-cloud/components/with-server-credentials-form/index.jsx
@@ -26,6 +26,21 @@ const INITIAL_FORM_STATE = {
 	kpri: '',
 };
 
+function mergeFormWithCredentials( form, credentials, siteSlug ) {
+	const newForm = Object.assign( {}, form );
+	// Replace empty fields with what comes from the rewind state
+	if ( credentials ) {
+		newForm.protocol = credentials.type || newForm.protocol;
+		newForm.host = credentials.host || newForm.host;
+		newForm.port = credentials.port || newForm.port;
+		newForm.user = credentials.user || newForm.user;
+		newForm.path = credentials.path || newForm.path;
+	}
+	// Populate the host field with the site slug if needed
+	newForm.host = isEmpty( newForm.host ) && siteSlug ? siteSlug.split( '::' )[ 0 ] : newForm.host;
+	return newForm;
+}
+
 function withServerCredentialsForm( WrappedComponent ) {
 	const ServerCredentialsFormClass = class ServerCredentialsForm extends Component {
 		static propTypes = {
@@ -47,19 +62,8 @@ function withServerCredentialsForm( WrappedComponent ) {
 			const credentials = find( rewindState.credentials, { role: role } );
 			const form = Object.assign( {}, INITIAL_FORM_STATE );
 
-			// Populate the fields with data from state if credentials are already saved
-			if ( credentials ) {
-				form.protocol = credentials.type || form.protocol;
-				form.host = credentials.host || form.host;
-				form.port = credentials.port || form.port;
-				form.user = credentials.user || form.user;
-				form.path = credentials.path || form.path;
-			}
-			// Populate the host field with the site slug if needed
-			form.host = isEmpty( form.host ) && siteSlug ? siteSlug.split( '::' )[ 0 ] : form.host;
-
 			this.state = {
-				form: form,
+				form: mergeFormWithCredentials( form, credentials, siteSlug ),
 				formErrors: {
 					host: false,
 					port: false,
@@ -135,20 +139,7 @@ function withServerCredentialsForm( WrappedComponent ) {
 				{},
 				siteHasChanged ? { ...INITIAL_FORM_STATE } : this.state.form
 			);
-
-			// Replace empty fields with what comes from the rewind state
-			if ( credentials ) {
-				nextForm.protocol = isEmpty( nextForm.protocol ) ? credentials.type : nextForm.protocol;
-				nextForm.host = isEmpty( nextForm.host ) ? credentials.host : nextForm.host;
-				nextForm.port = isEmpty( nextForm.port ) ? credentials.port : nextForm.port;
-				nextForm.user = isEmpty( nextForm.user ) ? credentials.user : nextForm.user;
-				nextForm.path = isEmpty( nextForm.path ) ? credentials.path : nextForm.path;
-				// Populate the host field with the site slug if needed
-			}
-			nextForm.host =
-				isEmpty( nextForm.host ) && siteSlug ? siteSlug.split( '::' )[ 0 ] : nextForm.host;
-
-			this.setState( { form: nextForm } );
+			this.setState( { form: mergeFormWithCredentials( nextForm, credentials, siteSlug ) } );
 		}
 
 		render() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Pre-filling the server credentials form with rewind state stop working as expected which later broke a unit test. This PR improves the server credentials form and simplifies the unit test suite.

#### Testing instructions

* Checkout this PR locally
* Run `yarn test-client:watch client/landing/jetpack-cloud/components/with-server-credentials-form/test/index.js`
* Verify the 5 tests pass
* Run this PR
* Go to `http://jetpack.cloud.localhost:3000/`
* Select any site
* Perform regression test on the Settings section to verify everything works as before

Fixes #42394 

#### Screenshot

##### Tests
![image](https://user-images.githubusercontent.com/3418513/82463269-000ddd00-9a93-11ea-8dae-decac30eb109.png)

##### Before (pay attention to the content of the form and how it gets deleted every time the section is reopened)
![FormResetHideShow](https://user-images.githubusercontent.com/3418513/82572161-5d209600-9b5a-11ea-9406-0929870b8e35.gif)

##### After (the content stays)
![FormPrefill](https://user-images.githubusercontent.com/3418513/82572187-67db2b00-9b5a-11ea-89c4-19a310881df6.gif)
