### PR TITLE
i18n: Remove unnecessary translation keys unicode escape

### DIFF
--- a/bin/build-languages.js
+++ b/bin/build-languages.js
@@ -239,12 +239,17 @@ function buildLanguageChunks( downloadedLanguages, languageRevisions ) {
 		const translationsFlatten = _.reduce(
 			translations,
 			( result, contextTranslations, context ) => {
-				const mappedTranslations = context
-					? _.mapKeys(
-							contextTranslations,
-							( value, key ) => context + String.fromCharCode( 4 ) + key
-					  )
-					: contextTranslations;
+				const mappedTranslations = _.mapKeys( contextTranslations, ( value, key ) => {
+					let mappedKey = key.replace( /\\u([0-9a-fA-F]{4})/g, ( match, matchedGroup ) =>
+						String.fromCharCode( parseInt( matchedGroup, 16 ) )
+					);
+
+					if ( context ) {
+						mappedKey = context + String.fromCharCode( 4 ) + mappedKey;
+					}
+
+					return mappedKey;
+				} );
 
 				return _.merge( result, mappedTranslations );
 			},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove unnecessary translation keys unicode escape in translations build script when parsing the POT file, so that it matches keys in translations JSON. 

#### Testing instructions

* Boot Calypso with `BUILD_TRANSLATION_CHUNKS=true ENABLE_FEATURES=use-translation-chunks,wpcom-bootstrap-user yarn start`
* Confirm that strings with unicode characters get translated properly. For example latest post paragraph at http://calypso.localhost:3000/stats/insights/{site}, or 2FA code modal at http://calypso.localhost:3000/me

Ref.  rWP207739
