### PR TITLE
Proposal: preload design thumbs for a nicer UX

### DIFF
--- a/client/landing/gutenboarding/available-designs.ts
+++ b/client/landing/gutenboarding/available-designs.ts
@@ -1,3 +1,14 @@
+/**
+ * External dependencies
+ */
+import { addQueryArgs } from '@wordpress/url';
+
+/**
+ * Internal dependencies
+ */
+import { isEnabled } from '../../config';
+import type { Design } from './stores/onboard/types';
+
 const availableDesigns: Readonly< AvailableDesigns > = {
 	featured: [
 		{
@@ -135,5 +146,38 @@ const availableDesigns: Readonly< AvailableDesigns > = {
 
 export default availableDesigns;
 interface AvailableDesigns {
-	featured: Array< import('./stores/onboard/types').Design >;
+	featured: Design[];
+}
+
+export const getDesignImageUrl = ( design: Design ) => {
+	// We temporarily show pre-generated screenshots until we can generate tall versions dynamically using mshots.
+	// See `bin/generate-gutenboarding-design-thumbnails.js` for generating screenshots.
+	// https://github.com/Automattic/mShots/issues/16
+	// https://github.com/Automattic/wp-calypso/issues/40564
+	if ( ! isEnabled( 'gutenboarding/mshot-preview' ) ) {
+		return `/calypso/page-templates/design-screenshots/${ design.slug }_${ design.template }_${ design.theme }.jpg`;
+	}
+
+	const mshotsUrl = 'https://s.wordpress.com/mshots/v1/';
+	const previewUrl = addQueryArgs( design.src, {
+		font_headings: design.fonts.headings,
+		font_base: design.fonts.base,
+	} );
+	return mshotsUrl + encodeURIComponent( previewUrl );
+};
+
+/**
+ * Asynchronously load available design images
+ */
+export function preloadDesignThumbs() {
+	if ( typeof window !== 'undefined' ) {
+		availableDesigns.featured.forEach( ( design: Design ) => {
+			const href = getDesignImageUrl( design );
+			const link = document.createElement( 'link' );
+			link.rel = 'preload';
+			link.as = 'image';
+			link.href = href;
+			document.head.appendChild( link );
+		} );
+	}
 }

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
@@ -15,6 +15,7 @@ import { Step, usePath } from '../../path';
 import Link from '../../components/link';
 import SiteTitle from './site-title';
 import { useTrackStep } from '../../hooks/use-track-step';
+import { preloadDesignThumbs } from '../../available-designs';
 
 /**
  * Style dependencies
@@ -34,6 +35,8 @@ const AcquireIntent: React.FunctionComponent = () => {
 	} ) );
 
 	const hasSiteTitle = getSelectedSiteTitle()?.trim().length > 2;
+
+	React.useEffect( preloadDesignThumbs, [] );
 
 	const handleSiteTitleSubmit = () => {
 		history.push( nextStepPath );

--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { addQueryArgs } from '@wordpress/url';
 import { Tooltip } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useHistory } from 'react-router-dom';
@@ -11,13 +10,12 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import { isEnabled } from '../../../../config';
 import { STORE_KEY as ONBOARD_STORE } from '../../stores/onboard';
 import { SubTitle, Title } from '../../components/titles';
 import { usePath, Step } from '../../path';
 import { useTrackStep } from '../../hooks/use-track-step';
 import Badge from '../../components/badge';
-import designs from '../../available-designs';
+import designs, { getDesignImageUrl } from '../../available-designs';
 import JetpackLogo from 'components/jetpack-logo'; // @TODO: extract to @automattic package
 import Link from '../../components/link';
 import './style.scss';
@@ -33,23 +31,6 @@ const DesignSelector: React.FunctionComponent = () => {
 
 	const { setSelectedDesign, setFonts } = useDispatch( ONBOARD_STORE );
 	const { getSelectedDesign, hasPaidDesign } = useSelect( ( select ) => select( ONBOARD_STORE ) );
-
-	const getDesignUrl = ( design: Design ) => {
-		// We temporarily show pre-generated screenshots until we can generate tall versions dynamically using mshots.
-		// See `bin/generate-gutenboarding-design-thumbnails.js` for generating screenshots.
-		// https://github.com/Automattic/mShots/issues/16
-		// https://github.com/Automattic/wp-calypso/issues/40564
-		if ( ! isEnabled( 'gutenboarding/mshot-preview' ) ) {
-			return `/calypso/page-templates/design-screenshots/${ design.slug }_${ design.template }_${ design.theme }.jpg`;
-		}
-
-		const mshotsUrl = 'https://s.wordpress.com/mshots/v1/';
-		const previewUrl = addQueryArgs( design.src, {
-			font_headings: design.fonts.headings,
-			font_base: design.fonts.base,
-		} );
-		return mshotsUrl + encodeURIComponent( previewUrl );
-	};
 
 	useTrackStep( 'DesignSelection', () => ( {
 		selected_design: getSelectedDesign()?.slug,
@@ -92,7 +73,7 @@ const DesignSelector: React.FunctionComponent = () => {
 								<img
 									alt=""
 									aria-labelledby={ makeOptionId( design ) }
-									src={ getDesignUrl( design ) }
+									src={ getDesignImageUrl( design ) }
 								/>
 							</span>
 							<span className="design-selector__option-overlay">


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Preload theme previews early on asynchronously for a better UX with no downside (that I could think of).

##### Before (Fast 3G)
https://d.pr/v/R28xWF

##### After (Fast 3G)
https://d.pr/v/wsObfb


#### Testing instructions

1. Go to /new
2. Name your site
3. Click "Choose design".
4. The screenshots should appear instantly. 


