### PR TITLE
Premium Content Block: disable "Edit as HTML" option

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/logged-out-view/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/logged-out-view/index.js
@@ -69,6 +69,7 @@ const settings = {
 	supports: {
 		// Hide this block from the inserter.
 		inserter: false,
+		html: false,
 	},
 	edit,
 	save,

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/subscriber-view/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/subscriber-view/index.js
@@ -24,6 +24,7 @@ const settings = {
 	supports: {
 		// Hide this block from the inserter.
 		inserter: false,
+		html: false,
 	},
 	edit,
 	save,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove the "Edit as HTML" options for the inner blocks of the Premium Content Block.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start up the FSE environment and create a premium content block.
* Under the "Non-subscriber View", click the Subscribe button.
* Click the kabob menu (i.e. More options/horizontal dots/ellipses) and verify that the "Edit as HTML" option has been removed.

Fixes #41834
