### PR TITLE
Only load styles and script if the block is in use

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/posts-list-block/class-posts-list-block.php
+++ b/apps/full-site-editing/full-site-editing-plugin/posts-list-block/class-posts-list-block.php
@@ -52,10 +52,10 @@ class Posts_List_Block {
 	 * Enqueue block editor scripts.
 	 */
 	public function enqueue_scripts() {
-		if ( !has_block( 'a8c/posts-list' ) ) {
+		if ( ! has_block( 'a8c/posts-list' ) ) {
 			return;
 		}
-		
+
 		$asset_file          = include plugin_dir_path( __FILE__ ) . 'dist/posts-list-block.asset.php';
 		$script_dependencies = $asset_file['dependencies'];
 		wp_enqueue_script(
@@ -73,9 +73,10 @@ class Posts_List_Block {
 	 * Enqueue block styles.
 	 */
 	public function enqueue_styles() {
-		if ( !has_block( 'a8c/posts-list' ) ) {
+		if ( ! has_block( 'a8c/posts-list' ) ) {
 			return;
 		}
+
 		$style_file = is_rtl()
 			? 'posts-list-block.rtl.css'
 			: 'posts-list-block.css';
@@ -126,7 +127,7 @@ class Posts_List_Block {
 		add_filter( 'excerpt_more', array( $this, 'custom_excerpt_read_more' ) );
 
 		// Prevent situations when the block attempts rendering another a8c/posts-list block.
-		if ( $this->rendering_block !== true ) {
+		if ( true !== $this->rendering_block ) {
 			$this->rendering_block = true;
 
 			$content = render_template(

--- a/apps/full-site-editing/full-site-editing-plugin/posts-list-block/class-posts-list-block.php
+++ b/apps/full-site-editing/full-site-editing-plugin/posts-list-block/class-posts-list-block.php
@@ -52,6 +52,10 @@ class Posts_List_Block {
 	 * Enqueue block editor scripts.
 	 */
 	public function enqueue_scripts() {
+		if ( !has_block( 'a8c/posts-list' ) ) {
+			return;
+		}
+		
 		$asset_file          = include plugin_dir_path( __FILE__ ) . 'dist/posts-list-block.asset.php';
 		$script_dependencies = $asset_file['dependencies'];
 		wp_enqueue_script(
@@ -69,6 +73,9 @@ class Posts_List_Block {
 	 * Enqueue block styles.
 	 */
 	public function enqueue_styles() {
+		if ( !has_block( 'a8c/posts-list' ) ) {
+			return;
+		}
 		$style_file = is_rtl()
 			? 'posts-list-block.rtl.css'
 			: 'posts-list-block.css';


### PR DESCRIPTION
When the FSE plugin is activated a site will start loading posts-list-block.css on every page view, even when the block has never been used.

It should only do that on views where the block is in use.

#### Changes proposed in this Pull Request

* Check that the block is in use before loading extra CSS/JS

#### Testing instructions

* Activate the plugin, note that posts-list-block.css starts getting loaded on every page view.
* After change, it should only load on views where the block is being used.

Fixes #
