### PR TITLE
Revert "Jetpack: Test removal of personal plan as part of offer reset project"

### DIFF
--- a/client/components/product-card/style.scss
+++ b/client/components/product-card/style.scss
@@ -171,7 +171,6 @@
 	font-size: 14px;
 	line-height: 20px;
 	color: var( --color-text-subtle );
-	text-align: left;
 
 	p:last-child {
 		margin: 0;

--- a/client/jetpack-connect/plans-grid.jsx
+++ b/client/jetpack-connect/plans-grid.jsx
@@ -5,7 +5,6 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -29,7 +28,6 @@ class JetpackPlansGrid extends Component {
 		isLanding: PropTypes.bool,
 		onSelect: PropTypes.func,
 		selectedSite: PropTypes.object,
-		hidePersonalOfferReset: PropTypes.bool,
 
 		// Connected
 		translate: PropTypes.func.isRequired,
@@ -54,17 +52,12 @@ class JetpackPlansGrid extends Component {
 	}
 
 	render() {
-		const { interval, hidePersonalOfferReset } = this.props;
+		const { interval } = this.props;
 		const defaultInterval = 'yearly';
-		const hidePersonal = hidePersonalOfferReset;
 
 		return (
 			<MainWrapper isWide className="jetpack-connect__hide-plan-icons">
-				<div
-					className={ classNames( 'jetpack-connect__plans', {
-						'is-offer-reset-test': hidePersonal,
-					} ) }
-				>
+				<div className="jetpack-connect__plans">
 					{ this.renderConnectHeader() }
 					<div id="plans">
 						<PlansFeaturesMain
@@ -76,7 +69,6 @@ class JetpackPlansGrid extends Component {
 							intervalType={ interval ? interval : defaultInterval }
 							hideFreePlan={ this.props.hideFreePlan }
 							displayJetpackPlans={ true }
-							hidePersonalPlan={ hidePersonal }
 						/>
 
 						<PlansSkipButton onClick={ this.handleSkipButtonClick } />

--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -39,7 +39,6 @@ import hasInitializedSites from 'state/selectors/has-initialized-sites';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import { persistSignupDestination } from 'signup/utils';
 import { isJetpackProductSlug as getJetpackProductSlug } from 'lib/products-values';
-import { abtest } from 'lib/abtest';
 
 const CALYPSO_PLANS_PAGE = '/plans/';
 const CALYPSO_MY_PLAN_PAGE = '/plans/my-plan/';
@@ -223,7 +222,6 @@ class Plans extends Component {
 					isLanding={ false }
 					interval={ interval }
 					selectedSite={ selectedSite }
-					hidePersonalOfferReset={ 'withoutPersonal' === abtest( 'jpcPlansOfferResetPersonal' ) }
 				>
 					<LoggedOutFormLinks>
 						<JetpackConnectHappychatButton

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -682,39 +682,6 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 	.plans-skip-button {
 		margin-bottom: 32px;
 	}
-
-	&.is-offer-reset-test {
-		.plan-features__table {
-			max-width: none;
-		}
-
-		.plan-features__item {
-			margin: 0 24px;
-		}
-
-		.plan-features__item:last-child {
-			margin: 0 24px 12px;
-		}
-
-		.plan-features--signup .plan-features__actions {
-			padding: 0 24px 15px;
-		}
-
-		.plan-features__pricing {
-			margin-left: 24px;
-			margin-right: 24px;
-			padding: 0;
-		}
-
-		.foldable-card .foldable-card__header {
-			padding-left: 24px;
-			padding-right: 24px;
-		}
-
-		.foldable-card .foldable-card__action {
-			right: 12px;
-		}
-	}
 }
 
 .jetpack-connect__plans.placeholder {

--- a/client/jetpack-connect/test/__snapshots__/plans.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/plans.js.snap
@@ -20,7 +20,6 @@ exports[`Plans should render plans 1`] = `
   <Connect(Localized(JetpackPlansGrid))
     basePlansPath="/jetpack/connect/plans"
     hideFreePlan={true}
-    hidePersonalOfferReset={false}
     isLanding={false}
     onSelect={[Function]}
     selectedSite={

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -126,14 +126,4 @@ export default {
 		localeTargets: [ 'en' ],
 		countryCodeTargets: [ 'US', 'ID', 'NG', 'BD', 'NL', 'SE', 'SG', 'LK', 'NZ', 'IE' ],
 	},
-	jpcPlansOfferResetPersonal: {
-		datestamp: '20200513',
-		variations: {
-			withPersonal: 50,
-			withoutPersonal: 50,
-		},
-		defaultVariation: 'withPersonal',
-		allowExistingUsers: true,
-		localeTargets: 'any',
-	},
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Reverts Automattic/wp-calypso#42177

While still a bit early, we're going to cancel this AB test for now as it has caused a negative impact on conversion and revenue. There are some other factors involved though, so we're not sure about how much impact there was. We hope that cancelling the test will help us get an idea of how much impact this test had itself.

See the post at p1HpG7-8Qm-p2 for more details. 

#### Testing instructions

- Checkout this patch locally
- Start Calypso locally
- Create JN site
- Connect JN site
- After connecting the site, you should land on the plans grid. Replace `wordpress.com` in the URL with `calypso.localhost:3000`
- Ensure that after loading the connection view, that you see personal, premium, and professional plans