### PR TITLE
Manage Purchase: Expand the notices that inform about available products for renewal

### DIFF
--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -101,6 +101,7 @@ class ManagePurchase extends Component {
 		hasNonPrimaryDomainsFlag: PropTypes.bool,
 		isAtomicSite: PropTypes.bool,
 		purchase: PropTypes.object,
+		purchaseAttachedTo: PropTypes.object,
 		renewableSitePurchases: PropTypes.arrayOf( PropTypes.object ),
 		site: PropTypes.object,
 		siteId: PropTypes.number,
@@ -529,6 +530,7 @@ class ManagePurchase extends Component {
 			siteSlug,
 			renewableSitePurchases,
 			purchase,
+			purchaseAttachedTo,
 			isPurchaseTheme,
 		} = this.props;
 		const classes = 'manage-purchase';
@@ -559,6 +561,7 @@ class ManagePurchase extends Component {
 						handleRenewMultiplePurchases={ this.handleRenewMultiplePurchases }
 						selectedSite={ site }
 						purchase={ purchase }
+						purchaseAttachedTo={ purchaseAttachedTo }
 						renewableSitePurchases={ renewableSitePurchases }
 						editCardDetailsPath={ editCardDetailsPath }
 					/>
@@ -580,6 +583,10 @@ class ManagePurchase extends Component {
 
 export default connect( ( state, props ) => {
 	const purchase = getByPurchaseId( state, props.purchaseId );
+	const purchaseAttachedTo =
+		purchase && purchase.attachedToPurchaseId
+			? getByPurchaseId( state, purchase.attachedToPurchaseId )
+			: null;
 	const siteId = purchase ? purchase.siteId : null;
 	const renewableSitePurchases = getRenewableSitePurchases( state, siteId );
 	const isPurchasePlan = purchase && isPlan( purchase );
@@ -596,6 +603,7 @@ export default connect( ( state, props ) => {
 			: false,
 		hasCustomPrimaryDomain: hasCustomDomain( site ),
 		purchase,
+		purchaseAttachedTo,
 		siteId,
 		site,
 		renewableSitePurchases,

--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
+import { isEmpty, merge, minBy } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -15,18 +16,20 @@ import {
 	canExplicitRenew,
 	creditCardExpiresBeforeSubscription,
 	getName,
-	isAutoRenewing,
+	isCloseToExpiration,
 	isExpired,
 	isExpiring,
 	isIncludedWithPlan,
 	isOneTimePurchase,
 	isPartnerPurchase,
+	isRecentMonthlyPurchase,
 	isRenewable,
+	isRenewing,
 	isRechargeable,
+	needsToRenewSoon,
 	hasPaymentMethod,
 	showCreditCardExpiringWarning,
 	isPaidWithCredits,
-	subscribedWithinPastWeek,
 	shouldAddPaymentSourceInsteadOfRenewingNow,
 } from 'lib/purchases';
 import {
@@ -55,6 +58,7 @@ class PurchaseNotice extends Component {
 		handleRenew: PropTypes.func,
 		handleRenewMultiplePurchases: PropTypes.func,
 		purchase: PropTypes.object,
+		purchaseAttachedTo: PropTypes.object,
 		renewableSitePurchases: PropTypes.arrayOf( PropTypes.object ),
 		selectedSite: PropTypes.object,
 		editCardDetailsPath: PropTypes.oneOfType( [ PropTypes.string, PropTypes.bool ] ),
@@ -69,56 +73,9 @@ class PurchaseNotice extends Component {
 		const expiry = moment( purchase.expiryDate );
 
 		if ( selectedSite && purchase.expiryStatus === 'manualRenew' ) {
-			if ( isPaidWithCredits( purchase ) ) {
-				return translate(
-					'You purchased %(purchaseName)s with credits. Please add a credit card before your ' +
-						"plan expires %(expiry)s so that you don't lose out on your paid features!",
-					{
-						args: {
-							purchaseName: getName( purchase ),
-							expiry: expiry.fromNow(),
-						},
-					}
-				);
-			}
-
-			if ( hasPaymentMethod( purchase ) ) {
-				if ( isRechargeable( purchase ) ) {
-					return translate(
-						'%(purchaseName)s will expire and be removed from your site %(expiry)s. ' +
-							"Please enable auto-renewal so you don't lose out on your paid features!",
-						{
-							args: {
-								purchaseName: getName( purchase ),
-								expiry: expiry.fromNow(),
-							},
-						}
-					);
-				}
-
-				return translate(
-					'%(purchaseName)s will expire and be removed from your site %(expiry)s. ' +
-						"Please renew before expiry so you don't lose out on your paid features!",
-					{
-						args: {
-							purchaseName: getName( purchase ),
-							expiry: expiry.fromNow(),
-						},
-					}
-				);
-			}
-
-			return translate(
-				'%(purchaseName)s will expire and be removed from your site %(expiry)s. ' +
-					"Add a credit card so you don't lose out on your paid features!",
-				{
-					args: {
-						purchaseName: getName( purchase ),
-						expiry: expiry.fromNow(),
-					},
-				}
-			);
+			return this.getExpiringLaterText( purchase );
 		}
+
 		if ( isMonthly( purchase.productSlug ) ) {
 			const daysToExpiry = moment( expiry.diff( moment() ) ).format( 'D' );
 
@@ -139,6 +96,85 @@ class PurchaseNotice extends Component {
 				expiry: expiry.fromNow(),
 			},
 		} );
+	}
+
+	/**
+	 * Returns appropriate warning text for a purchase that is expiring but where the expiration is not imminent.
+	 *
+	 * @param  {object} purchase  The purchase object
+	 * @param  {React.Component} autoRenewingUpgradesLink  An optional link component, for linking to other purchases on the site that are auto-renewing rather than expiring
+	 * @returns  {string}  Translated text for the warning message.
+	 */
+	getExpiringLaterText( purchase, autoRenewingUpgradesLink = null ) {
+		const { translate, moment } = this.props;
+		const expiry = moment( purchase.expiryDate );
+
+		const translateOptions = {
+			args: {
+				purchaseName: getName( purchase ),
+				expiry: expiry.fromNow(),
+			},
+		};
+
+		if ( autoRenewingUpgradesLink ) {
+			translateOptions.components = {
+				link: autoRenewingUpgradesLink,
+			};
+		}
+
+		if ( isPaidWithCredits( purchase ) ) {
+			if ( autoRenewingUpgradesLink ) {
+				return translate(
+					"You purchased %(purchaseName)s with credits – please add a credit card before your plan expires %(expiry)s so that you don't lose out on your paid features! {{link}}Other upgrades{{/link}} on this site are scheduled to auto-renew soon.",
+					translateOptions
+				);
+			}
+
+			return translate(
+				"You purchased %(purchaseName)s with credits. Please add a credit card before your plan expires %(expiry)s so that you don't lose out on your paid features!",
+				translateOptions
+			);
+		}
+
+		if ( hasPaymentMethod( purchase ) ) {
+			if ( isRechargeable( purchase ) ) {
+				if ( autoRenewingUpgradesLink ) {
+					return translate(
+						"%(purchaseName)s will expire and be removed from your site %(expiry)s – please enable auto-renewal so you don't lose out on your paid features! {{link}}Other upgrades{{/link}} on this site are scheduled to auto-renew soon.",
+						translateOptions
+					);
+				}
+
+				return translate(
+					"%(purchaseName)s will expire and be removed from your site %(expiry)s. Please enable auto-renewal so you don't lose out on your paid features!",
+					translateOptions
+				);
+			}
+
+			if ( autoRenewingUpgradesLink ) {
+				return translate(
+					"%(purchaseName)s will expire and be removed from your site %(expiry)s – please renew before expiry so you don't lose out on your paid features! {{link}}Other upgrades{{/link}} on this site are scheduled to auto-renew soon.",
+					translateOptions
+				);
+			}
+
+			return translate(
+				"%(purchaseName)s will expire and be removed from your site %(expiry)s. Please renew before expiry so you don't lose out on your paid features!",
+				translateOptions
+			);
+		}
+
+		if ( autoRenewingUpgradesLink ) {
+			return translate(
+				"%(purchaseName)s will expire and be removed from your site %(expiry)s – add a credit card so you don't lose out on your paid features! {{link}}Other upgrades{{/link}} on this site are scheduled to auto-renew soon.",
+				translateOptions
+			);
+		}
+
+		return translate(
+			"%(purchaseName)s will expire and be removed from your site %(expiry)s. Add a credit card so you don't lose out on your paid features!",
+			translateOptions
+		);
 	}
 
 	renderRenewNoticeAction( onClick ) {
@@ -195,6 +231,10 @@ class PurchaseNotice extends Component {
 		}
 	};
 
+	handleExpiringCardNoticeUpdateAll = () => {
+		this.trackClick( 'other-purchases-expiring-card-update-all' );
+	};
+
 	handleExpiringNoticeRenewSelection = ( selectedRenewableSitePurchases ) => {
 		const { renewableSitePurchases } = this.props;
 		this.props.recordTracksEvent( 'calypso_subscription_upcoming_renewals_dialog_submit', {
@@ -207,18 +247,50 @@ class PurchaseNotice extends Component {
 	};
 
 	renderPurchaseExpiringNotice() {
-		const { moment, purchase } = this.props;
-		let noticeStatus = 'is-info';
-		if ( ! isExpiring( purchase ) ) {
+		const { moment, purchase, purchaseAttachedTo, translate } = this.props;
+
+		// For purchases included with a plan (for example, a domain mapping
+		// bundled with the plan), the plan purchase is used on this page when
+		// there are other upcoming renewals to display, so for consistency it
+		// should also be used here (where there are no upcoming renewals to
+		// display).
+		const usePlanInsteadOfIncludedPurchase = Boolean(
+			config.isEnabled( 'upgrades/upcoming-renewals-notices' ) &&
+				isIncludedWithPlan( purchase ) &&
+				purchaseAttachedTo &&
+				isPlan( purchaseAttachedTo )
+		);
+		const currentPurchase = usePlanInsteadOfIncludedPurchase ? purchaseAttachedTo : purchase;
+		const includedPurchase = purchase;
+
+		if ( ! isExpiring( currentPurchase ) ) {
 			return null;
 		}
 
-		if (
-			! subscribedWithinPastWeek( purchase ) &&
-			purchase.expiryDate &&
-			moment( purchase.expiryDate ) < moment().add( 90, 'days' )
-		) {
+		let noticeStatus = 'is-info';
+
+		if ( isCloseToExpiration( currentPurchase ) && ! isRecentMonthlyPurchase( currentPurchase ) ) {
 			noticeStatus = 'is-error';
+		}
+
+		let noticeText = '';
+		let showNoticeAction = false;
+
+		if ( usePlanInsteadOfIncludedPurchase ) {
+			noticeText = translate(
+				'Your %(purchaseName)s plan (which includes your %(includedPurchaseName)s subscription) will expire and be removed from your site %(expiry)s.',
+				{
+					args: {
+						purchaseName: getName( currentPurchase ),
+						includedPurchaseName: getName( includedPurchase ),
+						expiry: moment( currentPurchase.expiryDate ).fromNow(),
+					},
+				}
+			);
+			showNoticeAction = false;
+		} else {
+			noticeText = this.getExpiringText( currentPurchase );
+			showNoticeAction = true;
 		}
 
 		return (
@@ -226,28 +298,430 @@ class PurchaseNotice extends Component {
 				className="manage-purchase__purchase-expiring-notice"
 				showDismiss={ false }
 				status={ noticeStatus }
-				text={ this.getExpiringText( purchase ) }
+				text={ noticeText }
 			>
-				{ this.renderRenewNoticeAction( this.handleExpiringNoticeRenewal ) }
+				{ showNoticeAction && this.renderRenewNoticeAction( this.handleExpiringNoticeRenewal ) }
 				{ this.trackImpression( 'purchase-expiring' ) }
 			</Notice>
 		);
 	}
 
-	renderOtherPurchasesExpiringNotice() {
-		const { translate, purchase, selectedSite, renewableSitePurchases } = this.props;
+	renderOtherRenewablePurchasesNotice() {
+		const {
+			translate,
+			moment,
+			purchase,
+			purchaseAttachedTo,
+			selectedSite,
+			renewableSitePurchases,
+		} = this.props;
 
 		if ( ! config.isEnabled( 'upgrades/upcoming-renewals-notices' ) ) {
 			return null;
 		}
 
-		const showOtherPurchasesExpiringNotice =
-			selectedSite &&
-			! isAutoRenewing( purchase ) &&
-			renewableSitePurchases.length > 1 &&
-			renewableSitePurchases.some( ( otherPurchase ) => otherPurchase.id === purchase.id );
+		if ( ! selectedSite ) {
+			return null;
+		}
 
-		if ( ! showOtherPurchasesExpiringNotice ) {
+		// For purchases included with a plan (for example, a domain mapping
+		// bundled with the plan), the plan purchase should be used here, since
+		// that is the one that can be directly renewed.
+		const purchaseIsIncludedInPlan = Boolean(
+			isIncludedWithPlan( purchase ) && purchaseAttachedTo && isPlan( purchaseAttachedTo )
+		);
+		const currentPurchase = purchaseIsIncludedInPlan ? purchaseAttachedTo : purchase;
+		const includedPurchase = purchase;
+
+		// Show only if there is at least one other purchase to notify about.
+		const otherRenewableSitePurchases = renewableSitePurchases.filter(
+			( otherPurchase ) => otherPurchase.id !== currentPurchase.id
+		);
+		if ( isEmpty( otherRenewableSitePurchases ) ) {
+			return null;
+		}
+
+		// Main logic branches for determining which message to display.
+		const currentPurchaseNeedsToRenewSoon = needsToRenewSoon( currentPurchase );
+		const currentPurchaseCreditCardExpiresBeforeSubscription =
+			isRenewing( currentPurchase ) && creditCardExpiresBeforeSubscription( currentPurchase );
+		const currentPurchaseIsExpiring = isExpiring( currentPurchase ) || isExpired( currentPurchase );
+		const anotherPurchaseIsExpiring = otherRenewableSitePurchases.some(
+			( otherPurchase ) => isExpiring( otherPurchase ) || isExpired( otherPurchase )
+		);
+
+		// Other information needed by some of the messages.
+		const suppressErrorStylingForCurrentPurchase =
+			isRecentMonthlyPurchase( currentPurchase ) && ! isExpired( currentPurchase );
+		const suppressErrorStylingForOtherPurchases = otherRenewableSitePurchases.every(
+			( otherPurchase ) => isRecentMonthlyPurchase( otherPurchase ) && ! isExpired( otherPurchase )
+		);
+		const anotherPurchaseIsCloseToExpiration = otherRenewableSitePurchases.some(
+			( otherPurchase ) => moment( otherPurchase.expiryDate ).diff( Date.now(), 'months' ) < 1
+		);
+		const anotherPurchaseIsExpired = otherRenewableSitePurchases.some( isExpired );
+		const earliestOtherExpiringPurchase = minBy(
+			otherRenewableSitePurchases.filter(
+				( otherPurchase ) => isExpiring( otherPurchase ) || isExpired( otherPurchase )
+			),
+			( otherPurchase ) => moment( otherPurchase.expiryDate ).format( 'X' )
+		);
+
+		const expiry = moment( currentPurchase.expiryDate );
+		const translateOptions = {
+			args: {
+				purchaseName: getName( currentPurchase ),
+				includedPurchaseName: getName( includedPurchase ),
+				expiry: expiry.fromNow(),
+				earliestOtherExpiry: earliestOtherExpiringPurchase
+					? moment( earliestOtherExpiringPurchase.expiryDate ).fromNow()
+					: null,
+			},
+			components: {
+				link: (
+					<button
+						className="manage-purchase__other-upgrades-button"
+						onClick={ this.openUpcomingRenewalsDialog }
+					/>
+				),
+			},
+		};
+
+		let noticeStatus = null;
+		let noticeIcon = null;
+		let noticeActionHref = null;
+		let noticeActionOnClick = null;
+		let noticeActionText = '';
+		let noticeImpressionName = '';
+		let noticeText = '';
+
+		// Scenario 1: current-expires-soon-others-expire-soon
+		if (
+			currentPurchaseNeedsToRenewSoon &&
+			currentPurchaseIsExpiring &&
+			anotherPurchaseIsExpiring
+		) {
+			noticeStatus =
+				suppressErrorStylingForCurrentPurchase && suppressErrorStylingForOtherPurchases
+					? 'is-info'
+					: 'is-error';
+			noticeActionOnClick = this.handleExpiringNoticeRenewAll;
+			noticeActionText = translate( 'Renew all' );
+			noticeImpressionName = 'current-expires-soon-others-expire-soon';
+
+			if ( isExpired( currentPurchase ) ) {
+				if ( isDomainRegistration( currentPurchase ) ) {
+					noticeText = translate(
+						'Your %(purchaseName)s domain expired %(expiry)s, and {{link}}other upgrades{{/link}} on this site will also be removed soon unless you take action.',
+						translateOptions
+					);
+				} else if ( isPlan( currentPurchase ) ) {
+					if ( purchaseIsIncludedInPlan ) {
+						noticeText = translate(
+							'Your %(purchaseName)s plan (which includes your %(includedPurchaseName)s subscription) expired %(expiry)s, and {{link}}other upgrades{{/link}} on this site will also be removed soon unless you take action.',
+							translateOptions
+						);
+					} else {
+						noticeText = translate(
+							'Your %(purchaseName)s plan expired %(expiry)s, and {{link}}other upgrades{{/link}} on this site will also be removed soon unless you take action.',
+							translateOptions
+						);
+					}
+				} else {
+					noticeText = translate(
+						'Your %(purchaseName)s subscription expired %(expiry)s, and {{link}}other upgrades{{/link}} on this site will also be removed soon unless you take action.',
+						translateOptions
+					);
+				}
+			} else if ( anotherPurchaseIsCloseToExpiration ) {
+				if ( isDomainRegistration( currentPurchase ) ) {
+					noticeText = translate(
+						'Your %(purchaseName)s domain will expire %(expiry)s, and {{link}}other upgrades{{/link}} on this site will also be removed soon unless you take action.',
+						translateOptions
+					);
+				} else if ( isPlan( currentPurchase ) ) {
+					if ( purchaseIsIncludedInPlan ) {
+						noticeText = translate(
+							'Your %(purchaseName)s plan (which includes your %(includedPurchaseName)s subscription) will expire %(expiry)s, and {{link}}other upgrades{{/link}} on this site will also be removed soon unless you take action.',
+							translateOptions
+						);
+					} else {
+						noticeText = translate(
+							'Your %(purchaseName)s plan will expire %(expiry)s, and {{link}}other upgrades{{/link}} on this site will also be removed soon unless you take action.',
+							translateOptions
+						);
+					}
+				} else {
+					noticeText = translate(
+						'Your %(purchaseName)s subscription will expire %(expiry)s, and {{link}}other upgrades{{/link}} on this site will also be removed soon unless you take action.',
+						translateOptions
+					);
+				}
+			} else if ( isDomainRegistration( currentPurchase ) ) {
+				noticeText = translate(
+					'Your %(purchaseName)s domain will expire %(expiry)s, and {{link}}other upgrades{{/link}} on this site will also be removed unless you take action.',
+					translateOptions
+				);
+			} else if ( isPlan( currentPurchase ) ) {
+				if ( purchaseIsIncludedInPlan ) {
+					noticeText = translate(
+						'Your %(purchaseName)s plan (which includes your %(includedPurchaseName)s subscription) will expire %(expiry)s, and {{link}}other upgrades{{/link}} on this site will also be removed unless you take action.',
+						translateOptions
+					);
+				} else {
+					noticeText = translate(
+						'Your %(purchaseName)s plan will expire %(expiry)s, and {{link}}other upgrades{{/link}} on this site will also be removed unless you take action.',
+						translateOptions
+					);
+				}
+			} else {
+				noticeText = translate(
+					'Your %(purchaseName)s subscription will expire %(expiry)s, and {{link}}other upgrades{{/link}} on this site will also be removed unless you take action.',
+					translateOptions
+				);
+			}
+		}
+
+		// Scenario 2: current-expires-soon-others-renew-soon
+		if (
+			currentPurchaseNeedsToRenewSoon &&
+			currentPurchaseIsExpiring &&
+			! anotherPurchaseIsExpiring
+		) {
+			noticeStatus = suppressErrorStylingForCurrentPurchase ? 'is-info' : 'is-error';
+			noticeImpressionName = 'current-expires-soon-others-renew-soon';
+
+			if ( isExpired( currentPurchase ) ) {
+				if ( isDomainRegistration( currentPurchase ) ) {
+					noticeText = translate(
+						'Your %(purchaseName)s domain expired %(expiry)s and will be removed soon unless you take action. {{link}}Other upgrades{{/link}} on this site are scheduled to renew soon.',
+						translateOptions
+					);
+				} else if ( isPlan( currentPurchase ) ) {
+					if ( purchaseIsIncludedInPlan ) {
+						noticeText = translate(
+							'Your %(purchaseName)s plan (which includes your %(includedPurchaseName)s subscription) expired %(expiry)s and will be removed soon unless you take action. {{link}}Other upgrades{{/link}} on this site are scheduled to renew soon.',
+							translateOptions
+						);
+					} else {
+						noticeText = translate(
+							'Your %(purchaseName)s plan expired %(expiry)s and will be removed soon unless you take action. {{link}}Other upgrades{{/link}} on this site are scheduled to renew soon.',
+							translateOptions
+						);
+					}
+				} else {
+					noticeText = translate(
+						'Your %(purchaseName)s subscription expired %(expiry)s and will be removed soon unless you take action. {{link}}Other upgrades{{/link}} on this site are scheduled to renew soon.',
+						translateOptions
+					);
+				}
+			} else if ( isDomainRegistration( currentPurchase ) ) {
+				noticeText = translate(
+					'Your %(purchaseName)s domain will expire %(expiry)s unless you take action. {{link}}Other upgrades{{/link}} on this site are scheduled to renew soon.',
+					translateOptions
+				);
+			} else if ( isPlan( currentPurchase ) ) {
+				if ( purchaseIsIncludedInPlan ) {
+					noticeText = translate(
+						'Your %(purchaseName)s plan (which includes your %(includedPurchaseName)s subscription) will expire %(expiry)s unless you take action. {{link}}Other upgrades{{/link}} on this site are scheduled to renew soon.',
+						translateOptions
+					);
+				} else {
+					noticeText = translate(
+						'Your %(purchaseName)s plan will expire %(expiry)s unless you take action. {{link}}Other upgrades{{/link}} on this site are scheduled to renew soon.',
+						translateOptions
+					);
+				}
+			} else {
+				noticeText = translate(
+					'Your %(purchaseName)s subscription will expire %(expiry)s unless you take action. {{link}}Other upgrades{{/link}} on this site are scheduled to renew soon.',
+					translateOptions
+				);
+			}
+		}
+
+		// Scenario 3: current-renews-soon-others-expire-soon
+		if (
+			currentPurchaseNeedsToRenewSoon &&
+			! currentPurchaseIsExpiring &&
+			anotherPurchaseIsExpiring
+		) {
+			noticeStatus = suppressErrorStylingForOtherPurchases ? 'is-info' : 'is-error';
+			noticeActionOnClick = this.handleExpiringNoticeRenewAll;
+			noticeActionText = translate( 'Renew all' );
+			noticeImpressionName = 'current-renews-soon-others-expire-soon';
+
+			if ( anotherPurchaseIsExpired ) {
+				if ( isDomainRegistration( currentPurchase ) ) {
+					noticeText = translate(
+						'Your %(purchaseName)s domain is scheduled to renew, but {{link}}other upgrades{{/link}} on this site expired %(earliestOtherExpiry)s and will be removed soon unless you take action.',
+						translateOptions
+					);
+				} else if ( isPlan( currentPurchase ) ) {
+					if ( purchaseIsIncludedInPlan ) {
+						noticeText = translate(
+							'Your %(purchaseName)s plan (which includes your %(includedPurchaseName)s subscription) is scheduled to renew, but {{link}}other upgrades{{/link}} on this site expired %(earliestOtherExpiry)s and will be removed soon unless you take action.',
+							translateOptions
+						);
+					} else {
+						noticeText = translate(
+							'Your %(purchaseName)s plan is scheduled to renew, but {{link}}other upgrades{{/link}} on this site expired %(earliestOtherExpiry)s and will be removed soon unless you take action.',
+							translateOptions
+						);
+					}
+				} else {
+					noticeText = translate(
+						'Your %(purchaseName)s subscription is scheduled to renew, but {{link}}other upgrades{{/link}} on this site expired %(earliestOtherExpiry)s and will be removed soon unless you take action.',
+						translateOptions
+					);
+				}
+			} else if ( isDomainRegistration( currentPurchase ) ) {
+				noticeText = translate(
+					'Your %(purchaseName)s domain is scheduled to renew, but {{link}}other upgrades{{/link}} on this site will expire %(earliestOtherExpiry)s unless you take action.',
+					translateOptions
+				);
+			} else if ( isPlan( currentPurchase ) ) {
+				if ( purchaseIsIncludedInPlan ) {
+					noticeText = translate(
+						'Your %(purchaseName)s plan (which includes your %(includedPurchaseName)s subscription) is scheduled to renew, but {{link}}other upgrades{{/link}} on this site will expire %(earliestOtherExpiry)s unless you take action.',
+						translateOptions
+					);
+				} else {
+					noticeText = translate(
+						'Your %(purchaseName)s plan is scheduled to renew, but {{link}}other upgrades{{/link}} on this site will expire %(earliestOtherExpiry)s unless you take action.',
+						translateOptions
+					);
+				}
+			} else {
+				noticeText = translate(
+					'Your %(purchaseName)s subscription is scheduled to renew, but {{link}}other upgrades{{/link}} on this site will expire %(earliestOtherExpiry)s unless you take action.',
+					translateOptions
+				);
+			}
+		}
+
+		// Scenario 4: current-renews-soon-others-renew-soon and current-renews-soon-others-renew-soon-cc-expiring
+		if (
+			currentPurchaseNeedsToRenewSoon &&
+			! currentPurchaseIsExpiring &&
+			! anotherPurchaseIsExpiring
+		) {
+			if ( ! currentPurchaseCreditCardExpiresBeforeSubscription ) {
+				noticeStatus = 'is-success';
+				noticeIcon = 'info';
+				noticeImpressionName = 'current-renews-soon-others-renew-soon';
+				noticeText = translate(
+					'{{link}}Other upgrades{{/link}} on this site are also scheduled to renew soon.',
+					translateOptions
+				);
+			} else {
+				noticeStatus = showCreditCardExpiringWarning( currentPurchase ) ? 'is-error' : 'is-info';
+				noticeActionHref = '/me/purchases/add-credit-card';
+				noticeActionOnClick = this.handleExpiringCardNoticeUpdateAll;
+				noticeActionText = translate( 'Update all' );
+				noticeImpressionName = 'current-renews-soon-others-renew-soon-cc-expiring';
+				noticeText = translate(
+					'Your %(cardType)s ending in %(cardNumber)d expires %(cardExpiry)s – before the next renewal. {{link}}Other upgrades{{/link}} on this site are scheduled to renew soon and may also be affected. Please update the payment information for all your subscriptions.',
+					merge( translateOptions, { args: this.creditCardDetails( currentPurchase ) } )
+				);
+			}
+		}
+
+		// Scenario 5: current-expires-later-others-expire-soon
+		if (
+			! currentPurchaseNeedsToRenewSoon &&
+			currentPurchaseIsExpiring &&
+			anotherPurchaseIsExpiring
+		) {
+			noticeStatus = suppressErrorStylingForOtherPurchases ? 'is-info' : 'is-error';
+			noticeActionOnClick = this.handleExpiringNoticeRenewAll;
+			noticeActionText = translate( 'Renew now' );
+			noticeImpressionName = 'current-expires-later-others-expire-soon';
+
+			if ( anotherPurchaseIsExpired ) {
+				noticeText = translate(
+					'You have {{link}}other upgrades{{/link}} on this site that expired %(earliestOtherExpiry)s and will be removed soon unless you take action.',
+					translateOptions
+				);
+			} else {
+				noticeText = translate(
+					'You have {{link}}other upgrades{{/link}} on this site that will expire %(earliestOtherExpiry)s unless you take action.',
+					translateOptions
+				);
+			}
+		}
+
+		// Scenario 6: current-expires-later-others-renew-soon
+		if (
+			! currentPurchaseNeedsToRenewSoon &&
+			currentPurchaseIsExpiring &&
+			! anotherPurchaseIsExpiring
+		) {
+			noticeStatus = 'is-info';
+			noticeImpressionName = 'current-expires-later-others-renew-soon';
+
+			if ( isPlan( currentPurchase ) && purchaseIsIncludedInPlan ) {
+				noticeText = translate(
+					'{{link}}Other upgrades{{/link}} on this site are scheduled to renew soon.',
+					translateOptions
+				);
+			} else {
+				noticeText = this.getExpiringLaterText( currentPurchase, translateOptions.components.link );
+			}
+		}
+
+		// Scenario 7: current-renews-later-others-expire-soon
+		if (
+			! currentPurchaseNeedsToRenewSoon &&
+			! currentPurchaseIsExpiring &&
+			anotherPurchaseIsExpiring
+		) {
+			noticeStatus = suppressErrorStylingForOtherPurchases ? 'is-info' : 'is-error';
+			noticeActionOnClick = this.handleExpiringNoticeRenewAll;
+			noticeActionText = translate( 'Renew now' );
+			noticeImpressionName = 'current-renews-later-others-expire-soon';
+
+			if ( anotherPurchaseIsExpired ) {
+				noticeText = translate(
+					'You have {{link}}other upgrades{{/link}} on this site that expired %(earliestOtherExpiry)s and will be removed soon unless you take action.',
+					translateOptions
+				);
+			} else {
+				noticeText = translate(
+					'You have {{link}}other upgrades{{/link}} on this site that will expire %(earliestOtherExpiry)s unless you take action.',
+					translateOptions
+				);
+			}
+		}
+
+		// Scenario 8: current-renews-later-others-renew-soon and current-renews-later-others-renew-soon-cc-expiring
+		if (
+			! currentPurchaseNeedsToRenewSoon &&
+			! currentPurchaseIsExpiring &&
+			! anotherPurchaseIsExpiring
+		) {
+			if ( ! currentPurchaseCreditCardExpiresBeforeSubscription ) {
+				noticeStatus = 'is-success';
+				noticeIcon = 'info';
+				noticeImpressionName = 'current-renews-later-others-renew-soon';
+				noticeText = translate(
+					'{{link}}Other upgrades{{/link}} on this site are scheduled to renew soon.',
+					translateOptions
+				);
+			} else {
+				noticeStatus = 'is-info';
+				noticeActionHref = '/me/purchases/add-credit-card';
+				noticeActionOnClick = this.handleExpiringCardNoticeUpdateAll;
+				noticeActionText = translate( 'Update all' );
+				noticeImpressionName = 'current-renews-later-others-renew-soon-cc-expiring';
+				noticeText = translate(
+					'Your %(cardType)s ending in %(cardNumber)d expires %(cardExpiry)s – before the next renewal. {{link}}Other upgrades{{/link}} on this site are scheduled to renew soon and may also be affected. Please update the payment information for all your subscriptions.',
+					merge( translateOptions, { args: this.creditCardDetails( currentPurchase ) } )
+				);
+			}
+		}
+
+		if ( ! noticeText ) {
 			return null;
 		}
 
@@ -261,16 +735,18 @@ class PurchaseNotice extends Component {
 					onClose={ this.closeUpcomingRenewalsDialog }
 				/>
 				<Notice
-					className="manage-purchase__other-purchases-expiring-notice"
+					className="manage-purchase__other-renewable-purchases-notice"
 					showDismiss={ false }
-					status="is-info"
-					icon="notice"
-					text={ this.getOtherPurchasesExpiringText() }
+					status={ noticeStatus }
+					icon={ noticeIcon }
+					text={ noticeText }
 				>
-					<NoticeAction onClick={ this.handleExpiringNoticeRenewAll }>
-						{ translate( 'Renew all' ) }
-					</NoticeAction>
-					{ this.trackImpression( 'other-purchases-expiring' ) }
+					{ ( noticeActionHref || noticeActionOnClick ) && (
+						<NoticeAction href={ noticeActionHref } onClick={ noticeActionOnClick }>
+							{ noticeActionText }
+						</NoticeAction>
+					) }
+					{ noticeImpressionName && this.trackImpression( noticeImpressionName ) }
 				</Notice>
 			</>
 		);
@@ -285,101 +761,31 @@ class PurchaseNotice extends Component {
 		this.setState( { showUpcomingRenewalsDialog: false } );
 	};
 
-	getOtherPurchasesExpiringText() {
-		const { translate, purchase, moment, renewableSitePurchases } = this.props;
-		const expiry = moment( purchase.expiryDate );
-		const translateOptions = {
-			args: {
-				purchaseName: getName( purchase ),
-				expiry: expiry.fromNow(),
-			},
-			components: {
-				link: (
-					<button
-						className="manage-purchase__other-upgrades-button"
-						onClick={ this.openUpcomingRenewalsDialog }
-					/>
-				),
-			},
-		};
-
-		if ( isExpired( purchase ) ) {
-			if ( isDomainRegistration( purchase ) ) {
-				return translate(
-					'Your %(purchaseName)s domain expired %(expiry)s, and {{link}}other upgrades{{/link}} on this site will also be removed soon unless you take action.',
-					translateOptions
-				);
-			}
-
-			if ( isPlan( purchase ) ) {
-				return translate(
-					'Your %(purchaseName)s plan expired %(expiry)s, and {{link}}other upgrades{{/link}} on this site will also be removed soon unless you take action.',
-					translateOptions
-				);
-			}
-
-			return translate(
-				'Your %(purchaseName)s subscription expired %(expiry)s, and {{link}}other upgrades{{/link}} on this site will also be removed soon unless you take action.',
-				translateOptions
-			);
-		}
-
-		const hasOtherPurchaseExpiringSoon = renewableSitePurchases.some(
-			( otherPurchase ) =>
-				otherPurchase.id !== purchase.id &&
-				moment( otherPurchase.expiryDate ).diff( Date.now(), 'days' ) < 30
-		);
-
-		if ( hasOtherPurchaseExpiringSoon ) {
-			if ( isDomainRegistration( purchase ) ) {
-				return translate(
-					'Your %(purchaseName)s domain will expire %(expiry)s, and {{link}}other upgrades{{/link}} on this site will also be removed soon unless you take action.',
-					translateOptions
-				);
-			}
-
-			if ( isPlan( purchase ) ) {
-				return translate(
-					'Your %(purchaseName)s plan will expire %(expiry)s, and {{link}}other upgrades{{/link}} on this site will also be removed soon unless you take action.',
-					translateOptions
-				);
-			}
-
-			return translate(
-				'Your %(purchaseName)s subscription will expire %(expiry)s, and {{link}}other upgrades{{/link}} on this site will also be removed soon unless you take action.',
-				translateOptions
-			);
-		}
-
-		if ( isDomainRegistration( purchase ) ) {
-			return translate(
-				'Your %(purchaseName)s domain will expire %(expiry)s, and {{link}}other upgrades{{/link}} on this site will also be removed unless you take action.',
-				translateOptions
-			);
-		}
-
-		if ( isPlan( purchase ) ) {
-			return translate(
-				'Your %(purchaseName)s plan will expire %(expiry)s, and {{link}}other upgrades{{/link}} on this site will also be removed unless you take action.',
-				translateOptions
-			);
-		}
-
-		return translate(
-			'Your %(purchaseName)s subscription will expire %(expiry)s, and {{link}}other upgrades{{/link}} on this site will also be removed unless you take action.',
-			translateOptions
-		);
-	}
-
 	onClickUpdateCreditCardDetails = () => {
 		this.trackClick( 'credit-card-expiring' );
 	};
 
-	renderCreditCardExpiringNotice() {
-		const { editCardDetailsPath, purchase, translate, moment } = this.props;
+	/**
+	 * Returns an object with credit card details suitable for use as translation arguments.
+	 *
+	 * @param {object} purchase - the purchase to get credit card details from
+	 * @returns {object}  Translation arguments containing information on the card type, number, and expiry
+	 */
+	creditCardDetails = ( purchase ) => {
+		const { moment } = this.props;
 		const {
 			payment: { creditCard },
 		} = purchase;
+
+		return {
+			cardType: creditCard.type.toUpperCase(),
+			cardNumber: parseInt( creditCard.number, 10 ),
+			cardExpiry: moment( creditCard.expiryDate, 'MM/YY' ).format( 'MMMM YYYY' ),
+		};
+	};
+
+	renderCreditCardExpiringNotice() {
+		const { editCardDetailsPath, purchase, translate } = this.props;
 
 		if (
 			isExpired( purchase ) ||
@@ -406,11 +812,7 @@ class PurchaseNotice extends Component {
 						'Your %(cardType)s ending in %(cardNumber)d expires %(cardExpiry)s ' +
 							'– before the next renewal. Please {{a}}update your payment information{{/a}}.',
 						{
-							args: {
-								cardType: creditCard.type.toUpperCase(),
-								cardNumber: parseInt( creditCard.number, 10 ),
-								cardExpiry: moment( creditCard.expiryDate, 'MM/YY' ).format( 'MMMM YYYY' ),
-							},
+							args: this.creditCardDetails( purchase ),
 							components: {
 								a: linkComponent,
 							},
@@ -430,23 +832,52 @@ class PurchaseNotice extends Component {
 	};
 
 	renderExpiredRenewNotice() {
-		const { purchase, translate } = this.props;
+		const { purchase, purchaseAttachedTo, translate } = this.props;
 
-		if ( ! isRenewable( purchase ) ) {
+		// For purchases included with a plan (for example, a domain mapping
+		// bundled with the plan), the plan purchase is used on this page when
+		// there are other upcoming renewals to display, so for consistency it
+		// should also be used here (where there are no upcoming renewals to
+		// display).
+		const usePlanInsteadOfIncludedPurchase = Boolean(
+			config.isEnabled( 'upgrades/upcoming-renewals-notices' ) &&
+				isIncludedWithPlan( purchase ) &&
+				purchaseAttachedTo &&
+				isPlan( purchaseAttachedTo )
+		);
+		const currentPurchase = usePlanInsteadOfIncludedPurchase ? purchaseAttachedTo : purchase;
+		const includedPurchase = purchase;
+
+		if ( ! isExpired( currentPurchase ) ) {
 			return null;
 		}
 
-		if ( ! isExpired( purchase ) ) {
-			return null;
+		let noticeText = '';
+		let showNoticeAction = false;
+
+		if ( ! isRenewable( currentPurchase ) ) {
+			if ( ! usePlanInsteadOfIncludedPurchase ) {
+				return null;
+			}
+
+			noticeText = translate(
+				'Your %(purchaseName)s plan (which includes your %(includedPurchaseName)s subscription) has expired and is no longer in use.',
+				{
+					args: {
+						purchaseName: getName( currentPurchase ),
+						includedPurchaseName: getName( includedPurchase ),
+					},
+				}
+			);
+			showNoticeAction = false;
+		} else {
+			noticeText = translate( 'This purchase has expired and is no longer in use.' );
+			showNoticeAction = true;
 		}
 
 		return (
-			<Notice
-				showDismiss={ false }
-				status="is-error"
-				text={ translate( 'This purchase has expired and is no longer in use.' ) }
-			>
-				{ this.renderRenewNoticeAction( this.handleExpiredNoticeRenewal ) }
+			<Notice showDismiss={ false } status="is-error" text={ noticeText }>
+				{ showNoticeAction && this.renderRenewNoticeAction( this.handleExpiredNoticeRenewal ) }
 				{ this.trackImpression( 'purchase-expired' ) }
 			</Notice>
 		);
@@ -488,9 +919,9 @@ class PurchaseNotice extends Component {
 			return consumedConciergeSessionNotice;
 		}
 
-		const otherPurchasesExpiringNotice = this.renderOtherPurchasesExpiringNotice();
-		if ( otherPurchasesExpiringNotice ) {
-			return otherPurchasesExpiringNotice;
+		const otherRenewablePurchasesNotice = this.renderOtherRenewablePurchasesNotice();
+		if ( otherRenewablePurchasesNotice ) {
+			return otherRenewablePurchasesNotice;
 		}
 
 		const expiredNotice = this.renderExpiredRenewNotice();

--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -17,10 +17,10 @@ import {
 	isIncludedWithPlan,
 	isOneTimePurchase,
 	isPartnerPurchase,
+	isRecentMonthlyPurchase,
 	isRenewing,
 	purchaseType,
 	showCreditCardExpiringWarning,
-	subscribedWithinPastWeek,
 	getPartnerName,
 } from 'lib/purchases';
 import {
@@ -79,7 +79,7 @@ class PurchaseItem extends Component {
 
 		if ( isExpiring( purchase ) ) {
 			if ( expiry < moment().add( 30, 'days' ) ) {
-				const status = subscribedWithinPastWeek( purchase ) ? 'is-info' : 'is-error';
+				const status = isRecentMonthlyPurchase( purchase ) ? 'is-info' : 'is-error';
 				return (
 					<Notice isCompact status={ status } icon="notice">
 						{ translate( 'Expires %(timeUntilExpiry)s', {


### PR DESCRIPTION
### Changes proposed in this Pull Request

Following up on https://github.com/Automattic/wp-calypso/pull/42076, which introduced a new feature (behind a feature flag) to show information on the manage purchase pages about other purchases on the same site in some cases where they are expiring soon, this pull requests adds more comprehensive notifications (including for purchases that are auto-renewing soon also), and ensures that the message always shows pertinent information about the current purchase too, when appropriate.

The basic goal is that when viewing one purchase, users always have a way of getting information about (and taking action on) other purchases on the same site that expire or renew soon.

See also internal discussion here: pbOQVh-bC-p2

The pull request handles many cases (too many to list all here) but here are a few new ones to look at.

**Multiple subscriptions on the site are auto-renewing soon:**

![others-renew-soon](https://user-images.githubusercontent.com/235183/82594846-b5fc2880-9b72-11ea-8a16-f9c2618ebffb.png)

**Multiple subscriptions on the site are expiring soon (this was already there, but this pull request makes a small change to the wording to match the above):**

![all-expiring](https://user-images.githubusercontent.com/235183/82594935-d1673380-9b72-11ea-930a-3952922aa164.png)

**The current subscription is auto-renewing soon, but other subscriptions are expiring soon:**

![others-are-expiring](https://user-images.githubusercontent.com/235183/82594956-da580500-9b72-11ea-9e6b-6ce9e879c151.png)

**Everything is auto-renewing, but the current subscription's credit card is expired (since the message refers to multiple subscriptions now, the "Update all" action takes you to https://wordpress.com/me/purchases/add-credit-card for simplicity, to update the credit card for all the subscriptions you own at once):**

![expiring-card](https://user-images.githubusercontent.com/235183/82594978-e17f1300-9b72-11ea-84e5-f3a649a64127.png)

**Since we're showing messages about other subscriptions everywhere, domain mapping subscriptions need to get these kinds of messages too (for consistency), even though they are included in the site's plan and therefore don't normally get messages of their own.  Here is an example of what that looks like:**

![domain-mapping-other-upgrades](https://user-images.githubusercontent.com/235183/82595000-e774f400-9b72-11ea-91eb-7f0ca1d6fa00.png)

**Also for consistency, the above needs to apply even when there aren't multiple subscriptions on the site expiring/renewing soon (for example, a site that only has a plan and domain mapping):**

![domain-mapping-no-other-upgrades](https://user-images.githubusercontent.com/235183/82595032-f360b600-9b72-11ea-9712-208854208c2d.png)

(Note there is an inconsistency between the above two screenshots where the second one doesn't have a "Renew" link.  But as described in the pull request comments, we won't be solving that here.)

### Testing instructions

**Existing functionality:**

The most important thing to test is probably to ensure that existing functionality is unchanged for the time being -- without the `upgrades/upcoming-renewals-notices` flag enabled, there should be no meaningful changes to the Manage Purchase behavior.

The one small exception to that is that I standardized the code that re-styles certain kinds of error messages on these pages as information messages in the case of recently-purchased monthly subscriptions (originally added in https://github.com/Automattic/wp-calypso/pull/23017) to actually apply to monthly subscriptions only.  Without that fix, testing that the red error message appears for expiring subscriptions was a pain -- because it meant that you couldn't just create an annual subscription and then change its expiration date to something soon via the WordPress.com backend (you'd have had to always fake an earlier purchase date too).

**New functionality:**

There's a lot to test here, and I haven't tested all the combinations myself yet (I want to eventually) but to test the basics you might want to set up:
- A WordPress.com site with a plan, domain mapping, a couple domain registrations, a theme, and another purchase.
- A Jetpack site with a plan and an add-on (such as Jetpack Search).

Then, play around with changing their auto-renew settings and expiration dates and make sure the messages you see when viewing each subscription's Manage Purchase page makes sense, and that the message always gives you a way to quickly view the other upgrades that it is talking about and easily change their status in whatever way you want.