### PR TITLE
Gutenboarding: remove save text node override in the block editor

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/gutenboarding-editor-overrides.js
+++ b/apps/wpcom-block-editor/src/calypso/features/gutenboarding-editor-overrides.js
@@ -38,7 +38,9 @@ function updateSettingsBar() {
 
 		// 'Update'/'Publish' primary button to become 'Save' tertiary button.
 		const saveButton = settingsBar.querySelector( '.editor-post-publish-button__button' );
-		saveButton && ( saveButton.innerText = __( 'Save' ) );
+		// This line causes a reconciliation error in React and a page bork
+		// leaving it in there until we can decide on the UX for this component
+		//saveButton && ( saveButton.innerText = __( 'Save' ) );
 
 		// Wrap 'Launch' button link to frankenflow.
 		const launchLink = document.createElement( 'a' );
@@ -51,6 +53,6 @@ function updateSettingsBar() {
 
 		// Put 'Launch' and 'Save' back on bar in desired order.
 		settingsBar.prepend( launchLink );
-		settingsBar.prepend( saveButton );
+		saveButton && settingsBar.prepend( saveButton );
 	} );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Create a site with Gutenboarding at `/new`

Now try to create and publish a new post or page. 

You can't, can you?

Do you see this?

<img width="876" alt="Screen Shot 2020-05-21 at 10 14 50 am" src="https://user-images.githubusercontent.com/6458278/82509676-ed0b1380-9b4b-11ea-964e-73f5663882d7.png">

It's because we're manipulating the buttons in the editor's header, specifically the text node in the publish button.

<img width="603" alt="Screen Shot 2020-05-21 at 10 02 16 am" src="https://user-images.githubusercontent.com/6458278/82509649-e2507e80-9b4b-11ea-922c-5f61d23c67e6.png">

Let's not replace the text node as React does not like it at all. I'm not sure of the mechanism behind the error, but the page fails when React attempt to unmount components. It's looking for a precise node tree it appears.

props to @ianstewart for finding this bug and giving us something do 

#### Testing instructions

Code to patch in D43745-code

