### PR TITLE
[e2e] Add tests for launching a site

### DIFF
--- a/test/e2e/lib/components/find-a-domain-component.js
+++ b/test/e2e/lib/components/find-a-domain-component.js
@@ -101,6 +101,16 @@ export default class FindADomainComponent extends AsyncBaseContainer {
 		return await driverHelper.clickWhenClickable( this.driver, useOwnDomain, this.explicitWaitMS );
 	}
 
+	async skipSuggestion() {
+		// currently used in 'launch-site' and 'new-launch' signup flows
+		const skipSuggestion = By.css( '.domain-skip-suggestion > .button.domain-suggestion__action' );
+		return await driverHelper.clickWhenClickable(
+			this.driver,
+			skipSuggestion,
+			this.explicitWaitMS
+		);
+	}
+
 	async declineGoogleApps() {
 		await driverHelper.clickWhenClickable(
 			this.driver,

--- a/test/e2e/lib/flows/activate-account-flow.js
+++ b/test/e2e/lib/flows/activate-account-flow.js
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import config from 'config';
+
+/**
+ * Internal dependencies
+ */
+import EmailClient from '../email-client';
+
+const signupInboxId = config.get( 'signupInboxId' );
+
+export default class LaunchSiteFlow {
+	constructor( driver, emailAddress ) {
+		this.driver = driver;
+		this.emailAddress = emailAddress;
+	}
+
+	async activateAccount() {
+		let activationLink;
+		const emails = await new EmailClient( signupInboxId ).pollEmailsByRecipient(
+			this.emailAddress
+		);
+		for ( const email of emails ) {
+			if ( email.subject.indexOf( 'Activate' ) > -1 ) {
+				activationLink = email.html.links[ 0 ].href;
+			}
+		}
+		await this.driver.get( activationLink );
+	}
+}

--- a/test/e2e/lib/flows/create-site-flow.js
+++ b/test/e2e/lib/flows/create-site-flow.js
@@ -1,0 +1,27 @@
+/**
+ * Internal dependencies
+ */
+import FindADomainComponent from '../components/find-a-domain-component';
+import PickAPlanPage from '../pages/signup/pick-a-plan-page';
+import StartPage from '../pages/signup/start-page.js';
+import MyHomePage from '../pages/my-home-page';
+
+export default class CreateSiteFlow {
+	constructor( driver, blogName ) {
+		this.driver = driver;
+		this.blogName = blogName;
+	}
+	async createFreeSite() {
+		await StartPage.Visit( this.driver, StartPage.getStartURL() );
+
+		const findADomainComponent = await FindADomainComponent.Expect( this.driver );
+		await findADomainComponent.searchForBlogNameAndWaitForResults( this.blogName );
+		await findADomainComponent.selectFreeAddress();
+
+		const pickAPlanPage = await PickAPlanPage.Expect( this.driver );
+		await pickAPlanPage.selectFreePlan();
+
+		const myHomePage = await MyHomePage.Expect( this.driver );
+		return await myHomePage.siteSetupListExists();
+	}
+}

--- a/test/e2e/lib/flows/launch-site-flow.js
+++ b/test/e2e/lib/flows/launch-site-flow.js
@@ -1,0 +1,24 @@
+/**
+ * Internal dependencies
+ */
+import FindADomainComponent from '../components/find-a-domain-component';
+import PickAPlanPage from '../pages/signup/pick-a-plan-page';
+import MyHomePage from '../pages/my-home-page';
+
+export default class LaunchSiteFlow {
+	constructor( driver ) {
+		this.driver = driver;
+	}
+	async launchFreeSite() {
+		const myHomePage = await MyHomePage.Expect( this.driver );
+		await myHomePage.launchSiteFromSiteSetup();
+
+		const findADomainComponent = await FindADomainComponent.Expect( this.driver );
+		await findADomainComponent.skipSuggestion();
+
+		const pickAPlanPage = await PickAPlanPage.Expect( this.driver );
+		await pickAPlanPage.selectFreePlan();
+
+		return await myHomePage.isSiteLaunched();
+	}
+}

--- a/test/e2e/lib/pages/my-home-page.js
+++ b/test/e2e/lib/pages/my-home-page.js
@@ -22,6 +22,10 @@ export default class MyHomePage extends AsyncBaseContainer {
 		this.confirmEmailTaskSelector = By.css( '.customer-home__main [data-task="email_verified"]' );
 		this.startTaskButtonSelector = By.css( '.customer-home__main .site-setup-list__task-action' );
 		this.taskBadgeSelector = By.css( '.customer-home__main .site-setup-list__task-badge' );
+		this.launchSiteTaskSelector = By.css( '.customer-home__main [data-task="site_launched"]' );
+		this.launchSiteTaskCompleteSelector = By.css(
+			'.customer-home__main [data-task="site_launched"] .nav-item__complete'
+		);
 	}
 
 	async closeCelebrateNotice() {
@@ -45,9 +49,20 @@ export default class MyHomePage extends AsyncBaseContainer {
 		return assert( badgeText === 'Complete', 'Could not locate message that email is verified.' );
 	}
 
+	async isSiteLaunched() {
+		await this.closeCelebrateNotice();
+		return await driverHelper.isElementPresent( this.driver, this.launchSiteTaskCompleteSelector );
+	}
+
 	async updateHomepageFromSiteSetup() {
 		await this.closeCelebrateNotice();
 		await driverHelper.clickWhenClickable( this.driver, this.updateHomepageTaskSelector );
+		return await driverHelper.clickWhenClickable( this.driver, this.startTaskButtonSelector );
+	}
+
+	async launchSiteFromSiteSetup() {
+		await this.closeCelebrateNotice();
+		await driverHelper.clickWhenClickable( this.driver, this.launchSiteTaskSelector );
 		return await driverHelper.clickWhenClickable( this.driver, this.startTaskButtonSelector );
 	}
 }

--- a/test/e2e/specs/wp-launch-spec.js
+++ b/test/e2e/specs/wp-launch-spec.js
@@ -88,6 +88,10 @@ describe( `[${ host }] Launch (${ screenSize }) @parallel`, function () {
 			const sideBarComponent = await SidebarComponent.Expect( driver );
 			await sideBarComponent.selectSiteSwitcher();
 			await sideBarComponent.searchForSite( firstSiteName );
+			if ( driverManager.currentScreenSize() === 'mobile' ) {
+				await sideBarComponent.ensureSidebarMenuVisible();
+				await sideBarComponent.selectMyHome();
+			}
 			return await new LaunchSiteFlow( driver ).launchFreeSite();
 		} );
 

--- a/test/e2e/specs/wp-launch-spec.js
+++ b/test/e2e/specs/wp-launch-spec.js
@@ -1,0 +1,98 @@
+/**
+ * External dependencies
+ */
+import config from 'config';
+
+/**
+ * Internal dependencies
+ */
+import * as driverManager from '../lib/driver-manager.js';
+import * as dataHelper from '../lib/data-helper.js';
+
+import SignUpFlow from '../lib/flows/sign-up-flow.js';
+import CreateSiteFlow from '../lib/flows/create-site-flow.js';
+import LaunchSiteFlow from '../lib/flows/launch-site-flow.js';
+import DeleteAccountFlow from '../lib/flows/delete-account-flow.js';
+import SidebarComponent from '../lib/components/sidebar-component';
+import FindADomainComponent from '../lib/components/find-a-domain-component.js';
+import MyHomePage from '../lib/pages/my-home-page.js';
+
+const host = dataHelper.getJetpackHost();
+const mochaTimeOut = config.get( 'mochaTimeoutMS' );
+const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
+const screenSize = driverManager.currentScreenSize();
+const signupInboxId = config.get( 'signupInboxId' );
+
+let driver;
+const createAndActivateAccount = async function ( accountName ) {
+	const emailAddress = dataHelper.getEmailAddress( accountName, signupInboxId );
+	const password = config.get( 'passwordForNewTestSignUps' );
+
+	const signupFlow = new SignUpFlow( driver, {
+		accountName,
+		emailAddress: emailAddress,
+		password: password,
+	} );
+	await signupFlow.signupFreeAccount();
+	await signupFlow.activateAccount();
+};
+
+before( async function () {
+	this.timeout( startBrowserTimeoutMS );
+	driver = await driverManager.startBrowser();
+} );
+
+describe( `[${ host }] Launch (${ screenSize }) @parallel`, function () {
+	this.timeout( mochaTimeOut );
+
+	describe( 'Launch a free site', function () {
+		const accountName = dataHelper.getNewBlogName();
+		const siteName = dataHelper.getNewBlogName();
+
+		before( 'Create a site as a new user', async function () {
+			await createAndActivateAccount( accountName );
+			await new CreateSiteFlow( driver, siteName ).createFreeSite();
+		} );
+
+		step( 'Can launch a site', async function () {
+			return await new LaunchSiteFlow( driver ).launchFreeSite();
+		} );
+
+		after( 'Delete the newly created account', async function () {
+			return await new DeleteAccountFlow( driver ).deleteAccount( accountName );
+		} );
+	} );
+
+	describe( 'Launch when having multiple sites', function () {
+		const accountName = dataHelper.getNewBlogName();
+		const firstSiteName = dataHelper.getNewBlogName();
+		const secondSiteName = dataHelper.getNewBlogName();
+
+		before( 'Create 2 free sites as a new user', async function () {
+			await createAndActivateAccount( accountName );
+			await new CreateSiteFlow( driver, firstSiteName ).createFreeSite();
+			await new CreateSiteFlow( driver, secondSiteName ).createFreeSite();
+		} );
+
+		step( 'Can start launch flow and abandon', async function () {
+			const myHomePage = await MyHomePage.Expect( driver );
+			await myHomePage.launchSiteFromSiteSetup();
+			await FindADomainComponent.Expect( driver );
+			// force reloading the page from the server to simulate an expired cache
+			await driver.executeScript( 'window.location.reload(true);' );
+			await FindADomainComponent.Expect( driver );
+			return await driver.navigate().back();
+		} );
+
+		step( 'Can switch sites and launch the first site', async function () {
+			const sideBarComponent = await SidebarComponent.Expect( driver );
+			await sideBarComponent.selectSiteSwitcher();
+			await sideBarComponent.searchForSite( firstSiteName );
+			return await new LaunchSiteFlow( driver ).launchFreeSite();
+		} );
+
+		after( 'Delete the newly created account', async function () {
+			return await new DeleteAccountFlow( driver ).deleteAccount( accountName );
+		} );
+	} );
+} );

--- a/test/e2e/specs/wp-signup-spec.js
+++ b/test/e2e/specs/wp-signup-spec.js
@@ -51,6 +51,8 @@ import NewUserRegistrationUnavailableComponent from '../lib/components/new-user-
 import DeleteAccountFlow from '../lib/flows/delete-account-flow';
 import DeletePlanFlow from '../lib/flows/delete-plan-flow';
 import SignUpStep from '../lib/flows/sign-up-step';
+import LaunchSiteFlow from '../lib/flows/launch-site-flow.js';
+import ActivateAccountFlow from '../lib/flows/activate-account-flow';
 
 import * as sharedSteps from '../lib/shared-steps/wp-signup-spec';
 import AccountSettingsPage from '../lib/pages/account/account-settings-page';
@@ -358,7 +360,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 		} );
 	} );
 
-	describe( 'Sign up for a site on a premium paid plan through main flow in USD currency @parallel @canary', function () {
+	describe( 'Sign up for a site on a premium paid plan through main flow in USD currency and launch @parallel @canary', function () {
 		const blogName = dataHelper.getNewBlogName();
 		const expectedBlogAddresses = dataHelper.getExpectedFreeAddresses( blogName );
 		const emailAddress = dataHelper.getEmailAddress( blogName, signupInboxId );
@@ -488,6 +490,13 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 
 		step( 'Can delete the plan', async function () {
 			return await new DeletePlanFlow( driver ).deletePlan( 'premium' );
+		} );
+
+		step( 'Can launch the site', async function () {
+			const navBarComponent = await NavBarComponent.Expect( driver );
+			await navBarComponent.clickMySites();
+			await new ActivateAccountFlow( driver, emailAddress ).activateAccount();
+			return await new LaunchSiteFlow( driver ).launchFreeSite();
 		} );
 
 		after( 'Can delete our newly created account', async function () {


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Add an e2e test to verify that we can launch a site for free starting from My Home.
* Add a test to verify that accounts with multiple sites can switch to a new site and launch it.
* Add `LaunchSiteFlow` to lib.
* Add `CreateSiteFlow` to lib.
* Add an extra step to existing canary signup test to cover launch flow.

#### Testing instructions
* New test should pass
* Canary signup test should pass

Fixes #40135