### PR TITLE
Display a notice that when a domain is unavailable for domain-only searches

### DIFF
--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -197,6 +197,12 @@ class DomainSearchResults extends React.Component {
 						</Notice>
 					);
 				}
+			} else {
+				availabilityElement = (
+					<Notice status="is-warning" showDismiss={ false }>
+						{ domainUnavailableMessage } { offer }
+					</Notice>
+				);
 			}
 		}
 

--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -200,7 +200,7 @@ class DomainSearchResults extends React.Component {
 			} else {
 				availabilityElement = (
 					<Notice status="is-warning" showDismiss={ false }>
-						{ domainUnavailableMessage } { offer }
+						{ domainUnavailableMessage }
 					</Notice>
 				);
 			}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a notice that displays when a domain is unavailable for domain-only search results

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* When a domain isn't available, the display should resemble the following:

<img width="1078" alt="Screenshot 2020-05-21 at 7 37 45 AM" src="https://user-images.githubusercontent.com/277661/82530844-191b9a00-9b36-11ea-898a-1817cfcc5e16.png">


