### PR TITLE
Fix site launch flow after switching to a new site

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -266,7 +266,7 @@ class RegisterDomainStep extends React.Component {
 			nextProps.selectedSite.slug !== ( this.props.selectedSite || {} ).slug
 		) {
 			this.setState( this.getState( nextProps ) );
-			this.onSearch( nextProps.suggestion );
+			nextProps.suggestion && this.onSearch( nextProps.suggestion );
 		}
 
 		if (


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Update RegisterDomainStep to prevent crashing when trying to launch a site after a site change.

#### Testing instructions
* Login to an account with at least 2 unlaunched sites. Sometimes the behaviour explained in #42515 is causing the launch flow to crash.
* Launching a site after switching to a new site should always work.

Fixes #42515
Unblocks #42513
