### PR TITLE
Remove the code-splitting feature flag (try 2)

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,15 +1,13 @@
-const config = require( './client/server/config' );
 const isBrowser = process.env.BROWSERSLIST_ENV !== 'server';
 
 // Use commonjs for Node
 const modules = isBrowser ? false : 'commonjs';
-const codeSplit = config.isEnabled( 'code-splitting' );
 
 // We implicitly use browserslist configuration in package.json for build targets.
 
 const babelConfig = {
 	presets: [ [ '@automattic/calypso-build/babel/default', { modules } ] ],
-	plugins: [ [ '@automattic/transform-wpcalypso-async', { async: isBrowser && codeSplit } ] ],
+	plugins: [ [ '@automattic/transform-wpcalypso-async', { async: isBrowser } ] ],
 	env: {
 		production: {
 			plugins: [ 'babel-plugin-transform-react-remove-prop-types' ],

--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -43,7 +43,7 @@ import { getHappychatAuth } from 'state/happychat/utils';
 import wasHappychatRecentlyActive from 'state/happychat/selectors/was-happychat-recently-active';
 import { setRoute as setRouteAction } from 'state/ui/actions';
 import { getSelectedSiteId, getSectionName } from 'state/ui/selectors';
-import { setNextLayoutFocus, activateNextLayoutFocus } from 'state/ui/layout-focus/actions';
+import { setNextLayoutFocus } from 'state/ui/layout-focus/actions';
 import setupGlobalKeyboardShortcuts from 'lib/keyboard-shortcuts/global';
 import { createReduxStore } from 'state';
 import initialReducer from 'state/reducer';
@@ -289,11 +289,6 @@ const setupMiddlewares = ( currentUser, reduxStore ) => {
 		// to avoid bumping stats and changing focus to the content
 		if ( isLegacyRoute( path ) ) {
 			return next();
-		}
-
-		// Focus UI on the content on page navigation
-		if ( ! config.isEnabled( 'code-splitting' ) ) {
-			context.store.dispatch( activateNextLayoutFocus() );
 		}
 
 		// Bump general stat tracking overall Newdash usage

--- a/client/server/bundler/sections-loader.js
+++ b/client/server/bundler/sections-loader.js
@@ -1,5 +1,5 @@
 /**
- * External dependecies
+ * External dependencies
  */
 const { getOptions } = require( 'loader-utils' ); // eslint-disable-line import/no-extraneous-dependencies
 
@@ -13,19 +13,22 @@ const config = require( '../config' );
  *
  * It takes in a list of sections, and then for each one adds in a new key to the json
  * 'load'. The value for 'load' is a fn that returns the entry point for a section. (or a promise for the entry point)
- * This needs to be done in a magic webpack loader in order to keep ability to easily switch code-splitting on and off.
- * If we ever wanted to get rid of this file we need to commit to either on or off and manually adding the load
- * functions to each section object.
+ *
+ * The exact import syntax used depends on the `useRequire` parameter. If `true`, synchronous `require`
+ * expressions are used. That's needed for server. If `useRequire` is `false`, a dynamic (promise-returning)
+ * `import()` expression is generated. That's useful for the code-splitting browser bundle.
  */
-function addModuleImportToSections( { sections, shouldSplit, onlyIsomorphic } ) {
+function addModuleImportToSections( sections, { useRequire, onlyIsomorphic } = {} ) {
 	sections.forEach( ( section ) => {
 		if ( onlyIsomorphic && ! section.isomorphic ) {
+			// don't generate an import statement for the section (that will prevent its code from being
+			// bundle), but don't remove the section from the list.
 			return;
 		}
 
-		const loaderFunction = `function() { return require( /* webpackChunkName: '${ section.name }' */ '${ section.module }'); }`;
-
-		section.load = shouldSplit ? loaderFunction.replace( 'require', 'import' ) : loaderFunction;
+		section.load = useRequire
+			? `() => require( '${ section.module }' )`
+			: `() => import( /* webpackChunkName: '${ section.name }' */ '${ section.module }' )`;
 	} );
 
 	// strip the outer quotation marks from the load statement
@@ -74,7 +77,9 @@ function filterSectionsInDevelopment( sections ) {
 
 const loader = function () {
 	const options = getOptions( this ) || {};
-	const { forceRequire, onlyIsomorphic } = options;
+	const { onlyIsomorphic } = options;
+	// look also at the legacy `forceRequire` option to allow smooth migration
+	const useRequire = options.useRequire || options.forceRequire;
 	let { include } = options;
 
 	let sections = filterSectionsInDevelopment( require( this.resourcePath ) );
@@ -94,12 +99,9 @@ const loader = function () {
 		}
 	}
 
-	return addModuleImportToSections( {
-		sections,
-		shouldSplit: config.isEnabled( 'code-splitting' ) && ! forceRequire,
-		onlyIsomorphic,
-	} );
+	return addModuleImportToSections( sections, { useRequire, onlyIsomorphic } );
 };
+
 loader.addModuleImportToSections = addModuleImportToSections;
 
 module.exports = loader;

--- a/client/server/bundler/test/sections-loader.js
+++ b/client/server/bundler/test/sections-loader.js
@@ -5,7 +5,7 @@ import loader from '../sections-loader';
 const addModuleImportToSections = loader.addModuleImportToSections;
 
 describe( '#addModuleImportToSections', () => {
-	test( 'should insert a load fn to each section using import() if code splitting is turned on', () => {
+	test( 'should insert a load fn to each section using import() by default', () => {
 		const sections = [
 			{
 				name: 'moduleName',
@@ -17,14 +17,14 @@ describe( '#addModuleImportToSections', () => {
 	{
 		"name": "moduleName",
 		"module": "module-to-require",
-		"load": function() { return import( /* webpackChunkName: 'moduleName' */ 'module-to-require'); }
+		"load": () => import( /* webpackChunkName: 'moduleName' */ 'module-to-require' )
 	}
 ]`;
-		const options = { sections, shouldSplit: true, onlyIsomorphic: false };
-		expect( addModuleImportToSections( options ) ).toBe( expected );
+
+		expect( addModuleImportToSections( sections ) ).toBe( expected );
 	} );
 
-	test( 'should insert a load fn to a section using require() if code splitting is turned off', () => {
+	test( 'should insert a load fn to a section using require() if useRequire is true', () => {
 		const sections = [
 			{
 				name: 'moduleName',
@@ -36,11 +36,12 @@ describe( '#addModuleImportToSections', () => {
 	{
 		"name": "moduleName",
 		"module": "module-to-require",
-		"load": function() { return require( /* webpackChunkName: 'moduleName' */ 'module-to-require'); }
+		"load": () => require( 'module-to-require' )
 	}
 ]`;
-		const options = { sections, shouldSplit: false, onlyIsomorphic: false };
-		expect( addModuleImportToSections( options ) ).toBe( expected );
+
+		const options = { useRequire: true };
+		expect( addModuleImportToSections( sections, options ) ).toBe( expected );
 	} );
 
 	test( 'should insert a load fn exclusively to isomorphic sections if onlyIsomorphic is enabled', () => {
@@ -69,14 +70,15 @@ describe( '#addModuleImportToSections', () => {
 		"name": "moduleName2",
 		"module": "module-to-require",
 		"isomorphic": true,
-		"load": function() { return require( /* webpackChunkName: 'moduleName2' */ 'module-to-require'); }
+		"load": () => require( 'module-to-require' )
 	},
 	{
 		"name": "moduleName3",
 		"module": "module-to-require"
 	}
 ]`;
-		const options = { sections, shouldSplit: false, onlyIsomorphic: true };
-		expect( addModuleImportToSections( options ) ).toBe( expected );
+
+		const options = { useRequire: true, onlyIsomorphic: true };
+		expect( addModuleImportToSections( sections, options ) ).toBe( expected );
 	} );
 } );

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -843,7 +843,7 @@ module.exports = function () {
 		app.get( pathRegex, setupDefaultContext( entrypoint ), function ( req, res, next ) {
 			req.context.sectionName = section.name;
 
-			if ( ! entrypoint && config.isEnabled( 'code-splitting' ) ) {
+			if ( ! entrypoint ) {
 				req.context.chunkFiles = getFilesForChunk( section.name, req );
 			} else {
 				req.context.chunkFiles = EMPTY_ASSETS;

--- a/client/webpack.config.node.js
+++ b/client/webpack.config.node.js
@@ -90,7 +90,7 @@ const webpackConfig = {
 				include: path.join( __dirname, 'sections.js' ),
 				use: {
 					loader: path.join( __dirname, 'server', 'bundler', 'sections-loader' ),
-					options: { forceRequire: true, onlyIsomorphic: true },
+					options: { useRequire: true, onlyIsomorphic: true },
 				},
 			},
 			TranspileConfig.loader( {

--- a/config/README.md
+++ b/config/README.md
@@ -31,7 +31,7 @@ The config files contain a features object that can be used to determine whether
 If you want to temporarily enable/disable some feature flags for a given build, you can do so by setting the `ENABLE_FEATURES` and/or `DISABLE_FEATURES` environment variables. Set them to a comma separated list of features you want to enable/disable, respectively:
 
 ```bash
-ENABLE_FEATURES=manage/plugins/compatibility-warning DISABLE_FEATURES=code-splitting,reader yarn start
+ENABLE_FEATURES=manage/plugins/compatibility-warning DISABLE_FEATURES=reader yarn start
 ```
 ### Testing Feature Flags via URLs
 

--- a/config/desktop-development.json
+++ b/config/desktop-development.json
@@ -21,7 +21,6 @@
 		"always_use_logout_url": true,
 		"automated-transfer": true,
 		"blogger-plan": false,
-		"code-splitting": true,
 		"comments/filters-in-posts": true,
 		"comments/moderation-tools-in-posts": true,
 		"comments/management/threaded-view": false,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -17,7 +17,6 @@
 		"always_use_logout_url": true,
 		"blogger-plan": false,
 		"catch-js-errors": false,
-		"code-splitting": true,
 		"current-site/domain-warning": true,
 		"current-site/notice": true,
 		"current-site/stale-cart-notice": true,

--- a/config/development.json
+++ b/config/development.json
@@ -33,7 +33,6 @@
 		"automated-transfer": true,
 		"blogger-plan": true,
 		"calypsoify/plugins": true,
-		"code-splitting": true,
 		"comments/filters-in-posts": true,
 		"comments/moderation-tools-in-posts": true,
 		"comments/management/threaded-view": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -20,7 +20,6 @@
 		"blogger-plan": false,
 		"calypsoify/plugins": true,
 		"catch-js-errors": true,
-		"code-splitting": true,
 		"composite-checkout-testing": true,
 		"current-site/domain-warning": true,
 		"current-site/notice": true,

--- a/config/production.json
+++ b/config/production.json
@@ -20,7 +20,6 @@
 		"blogger-plan": false,
 		"calypsoify/plugins": true,
 		"catch-js-errors": true,
-		"code-splitting": true,
 		"current-site/domain-warning": true,
 		"current-site/notice": true,
 		"current-site/stale-cart-notice": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -21,7 +21,6 @@
 		"blogger-plan": false,
 		"calypsoify/plugins": true,
 		"catch-js-errors": true,
-		"code-splitting": true,
 		"current-site/domain-warning": true,
 		"current-site/notice": true,
 		"current-site/stale-cart-notice": true,

--- a/config/test.json
+++ b/config/test.json
@@ -30,7 +30,6 @@
 		"blogger-plan": false,
 		"calypsoify/plugins": true,
 		"catch-js-errors": false,
-		"code-splitting": true,
 		"current-site/domain-warning": true,
 		"current-site/notice": true,
 		"current-site/stale-cart-notice": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -23,7 +23,6 @@
 		"comments/management/threaded-view": false,
 		"calypsoify/plugins": true,
 		"catch-js-errors": true,
-		"code-splitting": true,
 		"current-site/domain-warning": true,
 		"current-site/notice": true,
 		"current-site/stale-cart-notice": true,


### PR DESCRIPTION
Trying to merge #40162 again.

The first attempt had to be reverted because it broke `wp-desktop` (#40789). It was caused by the `forceRequire` option of `section-loader` changed to more accurate `useRequire` name. But `wp-desktop` has its own webpack config that [uses the old option](https://github.com/Automattic/wp-desktop/blob/develop/webpack.shared.js#L20). The difference is then between a synchronous `require()` call and asynchronous (promise-returning) `import()` call. These are incompatible and `useRequire` must be used to build the Node.js server.

I fixed that by supporting `forceRequire` as fallback, to allow for smooth transition.

**How to test:**
Build `wp-desktop` with this Calypso patch and verify that the crash reported in #40789 no longer happens.