### PR TITLE
Nav sidebar: Integrate nav sidebar with calypsoify

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/attach-sidebar.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/attach-sidebar.tsx
@@ -49,7 +49,7 @@ async function attachSidebar() {
 		return;
 	}
 
-	addFilter( 'a8c.wpcom-block-editor.shouldCloseEditor', '', () => false );
+	addFilter( 'a8c.wpcom-block-editor.shouldCloseEditor', 'a8c/fse/attachSidebar', () => false );
 
 	// Classes need to be attached to elements that aren't controlled by React,
 	// otherwise our alterations will be removed when React re-renders. So attach

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/attach-sidebar.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/attach-sidebar.tsx
@@ -3,6 +3,7 @@
  */
 import { dispatch, select, subscribe } from '@wordpress/data';
 import React, { render } from '@wordpress/element';
+import { addFilter } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -47,6 +48,8 @@ async function attachSidebar() {
 	if ( ! closePostButton ) {
 		return;
 	}
+
+	addFilter( 'a8c.wpcom-block-editor.shouldCloseEditor', '', () => false );
 
 	// Classes need to be attached to elements that aren't controlled by React,
 	// otherwise our alterations will be removed when React re-renders. So attach

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/style.scss
@@ -16,6 +16,10 @@ $transition-period: 200ms;
 		transition: width $transition-period;
 		@include reduce-motion( 'transition' );
 	}
+
+	.edit-post-fullscreen-mode-close {
+		min-width: 0;
+	}
 }
 
 .is-wpcom-block-editor-nav-sidebar-opened {

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/style.scss
@@ -116,18 +116,18 @@ $transition-period: 200ms;
 
 @keyframes wpcom-block-editor-nav-sidebar__shrink {
 	0% {
-		scale: 100%;
+		transform: scale( 1 );
 	}
 	100% {
-		scale: 55%;
+		transform: scale( 0.55 );
 	}
 }
 
 @keyframes wpcom-block-editor-nav-sidebar__grow {
 	0% {
-		scale: 55%;
+		transform: scale( 0.55 );
 	}
 	100% {
-		scale: 100%;
+		transform: scale( 1 );
 	}
 }

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/wpcom-block-editor-nav-sidebar.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/wpcom-block-editor-nav-sidebar.tsx
@@ -7,7 +7,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { Button as OriginalButton } from '@wordpress/components';
 import { chevronLeft, wordpress } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
-import { applyFilters } from '@wordpress/hooks';
+import { applyFilters, doAction, hasAction } from '@wordpress/hooks';
 import { get } from 'lodash';
 import { addQueryArgs } from '@wordpress/url';
 import classNames from 'classnames';
@@ -64,6 +64,13 @@ export default function WpcomBlockEditorNavSidebar() {
 	let closeLabel = get( postType, [ 'labels', 'all_items' ], __( 'Back' ) );
 	closeLabel = applyFilters( 'a8c.WpcomBlockEditorNavSidebar.closeLabel', closeLabel );
 
+	const handleClose = ( e: React.WPSyntheticEvent ) => {
+		if ( hasAction( 'a8c.wpcom-block-editor.closeEditor' ) ) {
+			e.preventDefault();
+			doAction( 'a8c.wpcom-block-editor.closeEditor' );
+		}
+	};
+
 	return (
 		<div className="wpcom-block-editor-nav-sidebar__container" aria-hidden={ ! isOpen }>
 			{ ( isOpen || isClosing ) && (
@@ -100,6 +107,7 @@ export default function WpcomBlockEditorNavSidebar() {
 					href={ closeUrl }
 					className="wpcom-block-editor-nav-sidebar__home-button"
 					icon={ chevronLeft }
+					onClick={ handleClose }
 				>
 					{ closeLabel }
 				</Button>

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/wpcom-block-editor-nav-sidebar.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/wpcom-block-editor-nav-sidebar.tsx
@@ -7,6 +7,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { Button as OriginalButton } from '@wordpress/components';
 import { chevronLeft, wordpress } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
+import { applyFilters } from '@wordpress/hooks';
 import { get } from 'lodash';
 import { addQueryArgs } from '@wordpress/url';
 import classNames from 'classnames';
@@ -57,6 +58,12 @@ export default function WpcomBlockEditorNavSidebar() {
 
 	const { toggleSidebar } = useDispatch( STORE_KEY );
 
+	let closeUrl = addQueryArgs( 'edit.php', { post_type: postType.slug } );
+	closeUrl = applyFilters( 'a8c.WpcomBlockEditorNavSidebar.closeUrl', closeUrl );
+
+	let closeLabel = get( postType, [ 'labels', 'all_items' ], __( 'Back' ) );
+	closeLabel = applyFilters( 'a8c.WpcomBlockEditorNavSidebar.closeLabel', closeLabel );
+
 	return (
 		<div className="wpcom-block-editor-nav-sidebar__container" aria-hidden={ ! isOpen }>
 			{ ( isOpen || isClosing ) && (
@@ -90,13 +97,11 @@ export default function WpcomBlockEditorNavSidebar() {
 			<div className="wpcom-block-editor-nav-sidebar__header-space" />
 			<div className="wpcom-block-editor-nav-sidebar__home-button-container">
 				<Button
-					href={ addQueryArgs( 'edit.php', {
-						post_type: postType.slug,
-					} ) }
+					href={ closeUrl }
 					className="wpcom-block-editor-nav-sidebar__home-button"
 					icon={ chevronLeft }
 				>
-					{ get( postType, [ 'labels', 'all_items' ], __( 'Back' ) ) }
+					{ closeLabel }
 				</Button>
 			</div>
 			<ul className="wpcom-block-editor-nav-sidebar__page-list">

--- a/apps/full-site-editing/package.json
+++ b/apps/full-site-editing/package.json
@@ -93,8 +93,8 @@
 		"@wordpress/element": "*",
 		"@wordpress/hooks": "*",
 		"@wordpress/html-entities": "*",
-		"@wordpress/icons": "*",
 		"@wordpress/i18n": "*",
+		"@wordpress/icons": "*",
 		"@wordpress/keycodes": "*",
 		"@wordpress/plugins": "*",
 		"@wordpress/rich-text": "*",
@@ -103,5 +103,8 @@
 		"lodash": "*",
 		"moment": "*",
 		"newspack-blocks": "github:Automattic/newspack-blocks#v1.6.0"
+	},
+	"devDependencies": {
+		"@types/wordpress__hooks": "2.4.0"
 	}
 }

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -8,7 +8,7 @@ import $ from 'jquery';
 import { filter, find, forEach, get, map, partialRight } from 'lodash';
 import { dispatch, select, subscribe, use } from '@wordpress/data';
 import { createBlock, parse, rawHandler } from '@wordpress/blocks';
-import { addFilter, applyFilter } from '@wordpress/hooks';
+import { addFilter, applyFilters } from '@wordpress/hooks';
 import { addQueryArgs, getQueryArg } from '@wordpress/url';
 import { Component } from 'react';
 import tinymce from 'tinymce/tinymce';
@@ -569,7 +569,7 @@ function handleCloseEditor( calypsoPort ) {
 	const siteEditorSelector = '.edit-site-header .edit-site-fullscreen-mode-close';
 
 	const dispatchAction = ( e ) => {
-		if ( ! applyFilter( 'a8c.wpcom-block-editor.shouldCloseEditor', true ) ) {
+		if ( ! applyFilters( 'a8c.wpcom-block-editor.shouldCloseEditor', true ) ) {
 			return;
 		}
 

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -8,7 +8,7 @@ import $ from 'jquery';
 import { filter, find, forEach, get, map, partialRight } from 'lodash';
 import { dispatch, select, subscribe, use } from '@wordpress/data';
 import { createBlock, parse, rawHandler } from '@wordpress/blocks';
-import { addFilter } from '@wordpress/hooks';
+import { addFilter, applyFilter } from '@wordpress/hooks';
 import { addQueryArgs, getQueryArg } from '@wordpress/url';
 import { Component } from 'react';
 import tinymce from 'tinymce/tinymce';
@@ -569,6 +569,10 @@ function handleCloseEditor( calypsoPort ) {
 	const siteEditorSelector = '.edit-site-header .edit-site-fullscreen-mode-close';
 
 	const dispatchAction = ( e ) => {
+		if ( ! applyFilter( 'a8c.wpcom-block-editor.shouldCloseEditor', true ) ) {
+			return;
+		}
+
 		e.preventDefault();
 
 		const { port2 } = new MessageChannel();
@@ -685,6 +689,18 @@ function getCloseButtonUrl( calypsoPort ) {
 
 		window.wp.hooks.doAction( 'updateCloseButtonOverrides', data );
 	};
+
+	addFilter(
+		'a8c.WpcomBlockEditorNavSidebar.closeUrl',
+		'wpcom-block-editor/getCloseButtonUrl',
+		( closeUrl ) => calypsoifyGutenberg.closeUrl || closeUrl
+	);
+
+	addFilter(
+		'a8c.WpcomBlockEditorNavSidebar.closeLabel',
+		'wpcom-block-editor/getCloseButtonUrl',
+		( closeLabel ) => calypsoifyGutenberg.closeButtonLabel || closeLabel
+	);
 }
 
 /**

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -696,13 +696,13 @@ function getCloseButtonUrl( calypsoPort ) {
 
 	addFilter(
 		'a8c.WpcomBlockEditorNavSidebar.closeUrl',
-		'wpcom-block-editor/getCloseButtonUrl',
+		'a8c/wpcom-block-editor/getCloseButtonUrl',
 		( closeUrl ) => calypsoifyGutenberg.closeUrl || closeUrl
 	);
 
 	addFilter(
 		'a8c.WpcomBlockEditorNavSidebar.closeLabel',
-		'wpcom-block-editor/getCloseButtonUrl',
+		'a8c/wpcom-block-editor/getCloseButtonUrl',
 		( closeLabel ) => calypsoifyGutenberg.closeButtonLabel || closeLabel
 	);
 }

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -8,7 +8,7 @@ import $ from 'jquery';
 import { filter, find, forEach, get, map, partialRight } from 'lodash';
 import { dispatch, select, subscribe, use } from '@wordpress/data';
 import { createBlock, parse, rawHandler } from '@wordpress/blocks';
-import { addFilter, applyFilters } from '@wordpress/hooks';
+import { addAction, addFilter, applyFilters, doAction } from '@wordpress/hooks';
 import { addQueryArgs, getQueryArg } from '@wordpress/url';
 import { Component } from 'react';
 import tinymce from 'tinymce/tinymce';
@@ -568,13 +568,7 @@ function handleCloseEditor( calypsoPort ) {
 	const selector = '.edit-post-header .edit-post-fullscreen-mode-close';
 	const siteEditorSelector = '.edit-site-header .edit-site-fullscreen-mode-close';
 
-	const dispatchAction = ( e ) => {
-		if ( ! applyFilters( 'a8c.wpcom-block-editor.shouldCloseEditor', true ) ) {
-			return;
-		}
-
-		e.preventDefault();
-
+	addAction( 'a8c.wpcom-block-editor.closeEditor', 'a8c/wpcom-block-editor/closeEditor', () => {
 		const { port2 } = new MessageChannel();
 		calypsoPort.postMessage(
 			{
@@ -585,6 +579,16 @@ function handleCloseEditor( calypsoPort ) {
 			},
 			[ port2 ]
 		);
+	} );
+
+	const dispatchAction = ( e ) => {
+		if ( ! applyFilters( 'a8c.wpcom-block-editor.shouldCloseEditor', true ) ) {
+			return;
+		}
+
+		e.preventDefault();
+
+		doAction( 'a8c.wpcom-block-editor.closeEditor' );
 	};
 
 	$( '#editor' ).on( 'click', `${ legacySelector }, ${ selector }`, dispatchAction );

--- a/yarn.lock
+++ b/yarn.lock
@@ -4054,6 +4054,11 @@
     "@types/react-dom" "*"
     csstype "^2.2.0"
 
+"@types/wordpress__hooks@2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@types/wordpress__hooks/-/wordpress__hooks-2.4.0.tgz#5e3c6fca66d5b5ccc066dd17b22d41d202f51302"
+  integrity sha512-SixjDsBvPynmMQxBFX3i4nuWtLifqtml7PhSosoCk5RJy9S7xs/G6vvtcnAuslV3BJTyvxEbAsz4WpKaF0bqMw==
+
 "@types/wordpress__keycodes@*", "@types/wordpress__keycodes@^2.3.0":
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/@types/wordpress__keycodes/-/wordpress__keycodes-2.3.0.tgz#022c8f159c5de413f1dadcfd4a3e1dbed0f4682d"


### PR DESCRIPTION
_**Note to anyone reading this while preparing a release of the FSE plugin**_

This change doesn't require any release notes. We're developing a new feature which is currently hidden behind a flag.

#### Changes proposed in this Pull Request

The nav sidebar should work with or without calypso. The default behaviour is what runs on a .org site: closing the editor goes back to pages/posts like it currently does (without this PR). However this default behaviour can be overriden using hooks, and the calypsoify code in `iframe-bridge-server` does just that.

Ideally the dependencies would only go one way so that the sidebar doesn't have any calypso awareness. This would mean that `wpcom-block-editor` would subscribe to `full-site-editing` hooks, but not the other way around. Unfortunately at the moment the sidebar needs to disable the calypsoify override, but hopefully after Gutenberg 8.2 is out we'll be able to change how the overriding is done and the sidebar can be unaware of calypso.

* Change some of the sidebar behaviour if calypsoify is present
  * Prevent calypsoify's close behaviour from running
  * Use the same close url and label as calypsoify
  * Run the calypsoify close code when the user uses the sidebar to close
* Install type definitions for `@wordpress/hooks` (the package doesn't publish it's own type definitions yet)
* Switch animation rule from `scale` to `tranform` (TIL `scale` only works on Firefox)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run the `full-site-editing` and `wpcom-block-editor` on your sandbox with `WPCOM_BLOCK_EDITOR_SIDEBAR` defined
  * Sidebar opens and closes as expected
  * Close button should link to customer home, just like calypsoify does without the sidebar
  * Closing when the editor has un-saved changes displays this message: `You have unsaved changes. Are you sure you want to leave this page?`
* Run `full-site-editor` on a stand alone site (e.g. with `wp-env`)
  * Sidebar opens and closes as expected
  * No changes to the close link text or behaviour
* Run `wpcom-block-editor` sandboxed with `WPCOM_BLOCK_EDITOR_SIDEBAR` undefined
  * There's no sidebar
  * Calypsoify continues to override the close button behaviour as expected.
