### PR TITLE
Gutenboarding: extend our signup error messages

### DIFF
--- a/client/landing/gutenboarding/components/signup-form/index.tsx
+++ b/client/landing/gutenboarding/components/signup-form/index.tsx
@@ -131,7 +131,18 @@ const SignupForm = ( { onRequestClose }: Props ) => {
 			case 'already_taken':
 			case 'already_active':
 			case 'email_exists':
+			case 'email_reserved':
 				errorMessage = __( 'An account with this email address already exists.' );
+				break;
+			case 'email_invalid':
+				errorMessage = __( 'Please enter a valid email address.' );
+			case 'email_cant_be_used_to_signup':
+				errorMessage = __(
+					'You cannot use that email address to signup. We are having problems with them blocking some of our email. Please use another email provider.'
+				);
+				break;
+			case 'email_not_allowed':
+				errorMessage = __( 'Sorry, that email address is not allowed!' );
 				break;
 			case 'password_invalid':
 				errorMessage = newUserError.message;

--- a/client/landing/gutenboarding/components/signup-form/index.tsx
+++ b/client/landing/gutenboarding/components/signup-form/index.tsx
@@ -136,6 +136,7 @@ const SignupForm = ( { onRequestClose }: Props ) => {
 				break;
 			case 'email_invalid':
 				errorMessage = __( 'Please enter a valid email address.' );
+				break;
 			case 'email_cant_be_used_to_signup':
 				errorMessage = __(
 					'You cannot use that email address to signup. We are having problems with them blocking some of our email. Please use another email provider.'


### PR DESCRIPTION
#### Changes proposed in this Pull Request

After checking the latest signup error ids in tracks, this commit adds handlers for some of the outliers. 

We want to return decent messaging to the frontend so the user has a hint of what is going on.

#### Testing instructions

Some you won't be able to trigger as I can't find a reliable string. Just checking that signup works as expected and you get error messages for common errors, e.g., email exists,  emails from a banned domain, e.g., `asdasd.ru`, email invalid and so on.

