### PR TITLE
Gutenboarding: Show "View plans" when free selected

### DIFF
--- a/client/landing/gutenboarding/components/plans/plans-button/index.tsx
+++ b/client/landing/gutenboarding/components/plans/plans-button/index.tsx
@@ -6,7 +6,6 @@ import { Button } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@automattic/react-i18n';
-import { isFreePlan } from '../../../../../lib/plans';
 import config from 'config';
 
 /**
@@ -39,10 +38,10 @@ const PlansButton: React.FunctionComponent< Button.ButtonProps > = ( { ...button
 
 	const plan = useSelectedPlan();
 
-	/* translators: Button label where %s is the WordPress.com plan name (eg: Free, Personal, Premium, Business) */
-	const planLabel = isFreePlan( plan )
-		? __( 'View plans' )
-		: sprintf( __( '%s Plan' ), plan.getTitle() );
+	const planLabel = ! plan?.isFree
+		? /* translators: Button label where %s is the WordPress.com plan name (eg: Personal, Premium, Business) */
+		  sprintf( __( '%s Plan' ), plan.getTitle() )
+		: __( 'View plans' );
 
 	return (
 		<>

--- a/client/landing/gutenboarding/components/plans/plans-button/index.tsx
+++ b/client/landing/gutenboarding/components/plans/plans-button/index.tsx
@@ -4,6 +4,7 @@
 import * as React from 'react';
 import { Button } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
+import { useSelect } from '@wordpress/data';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@automattic/react-i18n';
 import config from 'config';
@@ -15,6 +16,7 @@ import JetpackLogo from 'components/jetpack-logo'; // @TODO: extract to @automat
 import PlansModal from '../plans-modal';
 import { useSelectedPlan } from '../../../hooks/use-selected-plan';
 import { useCurrentStep, Step } from '../../../path';
+import { STORE_KEY as PLANS } from '../../../stores/plans';
 
 /**
  * Style dependencies
@@ -23,6 +25,7 @@ import './style.scss';
 
 const PlansButton: React.FunctionComponent< Button.ButtonProps > = ( { ...buttonProps } ) => {
 	const { __ } = useI18n();
+	const selectedPlan = useSelect( ( select ) => select( PLANS ).getSelectedPlan() );
 	const currentStep = useCurrentStep();
 
 	// mobile first to match SCSS media query https://github.com/Automattic/wp-calypso/pull/41471#discussion_r415678275
@@ -36,12 +39,15 @@ const PlansButton: React.FunctionComponent< Button.ButtonProps > = ( { ...button
 		}
 	};
 
+	// This hook is different from `getSelectedPlan` in the store.
+	// This accounts for plans that may come from e.g. selecting a domain or adding a plan via URL
 	const plan = useSelectedPlan();
 
-	const planLabel = ! plan?.isFree
-		? /* translators: Button label where %s is the WordPress.com plan name (eg: Personal, Premium, Business) */
-		  sprintf( __( '%s Plan' ), plan.getTitle() )
-		: __( 'View plans' );
+	const planLabel =
+		plan?.isFree && ! selectedPlan
+			? __( 'View plans' )
+			: /* translators: Button label where %s is the WordPress.com plan name (eg: Personal, Premium, Business) */
+			  sprintf( __( '%s Plan' ), plan.getTitle() );
 
 	return (
 		<>

--- a/client/landing/gutenboarding/components/plans/plans-button/index.tsx
+++ b/client/landing/gutenboarding/components/plans/plans-button/index.tsx
@@ -6,6 +6,7 @@ import { Button } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@automattic/react-i18n';
+import { isFreePlan } from '../../../../../lib/plans';
 import config from 'config';
 
 /**
@@ -39,7 +40,9 @@ const PlansButton: React.FunctionComponent< Button.ButtonProps > = ( { ...button
 	const plan = useSelectedPlan();
 
 	/* translators: Button label where %s is the WordPress.com plan name (eg: Free, Personal, Premium, Business) */
-	const planLabel = sprintf( __( '%s Plan' ), plan.getTitle() );
+	const planLabel = isFreePlan( plan )
+		? __( 'View plans' )
+		: sprintf( __( '%s Plan' ), plan.getTitle() );
 
 	return (
 		<>


### PR DESCRIPTION
Closes #42523

Replace "Free Plan" with "View plans" when no plan is selected.

Before

![Screen Shot 2020-05-21 at 16 49 11](https://user-images.githubusercontent.com/841763/82571372-2a3ec800-9b83-11ea-9b36-a6737be677cb.png)

After
![Screen Shot 2020-05-21 at 16 48 54](https://user-images.githubusercontent.com/841763/82571381-2c088b80-9b83-11ea-81a3-60b58fffa6ad.png)


#### Testing instructions

* [`/new`](https://calypso.live/new?branch=gutenboarding/42524-plans-copy)
* Go through the flow and ensure the plans button text is correct when a paid/free plan is selected or a domain has been selected.

