### PR TITLE
Gutenboarding: Show "Pick a domain" when user haven't entered site title and haven't decided on a domain.

### DIFF
--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -96,6 +96,12 @@ const Header: React.FunctionComponent = () => {
 	const isMobile = useViewportMatch( 'mobile', '<' );
 
 	const getDomainElementContent = () => {
+		// If no site title entered (user skips intent gathering)
+		// and no domain was selected, show "Pick a domain"
+		if ( ! siteTitle && ! domain ) {
+			return __( 'Pick a domain' );
+		}
+
 		if ( recommendedDomainSuggestion || previousRecommendedDomain !== '' ) {
 			/* translators: domain name is available, eg: "yourname.com is available" */
 			return sprintf(
@@ -106,7 +112,7 @@ const Header: React.FunctionComponent = () => {
 			);
 		}
 
-		return 'example.wordpress.com';
+		return __( 'Pick a domain' );
 	};
 
 	/* eslint-disable wpcalypso/jsx-classname-namespace */


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Show "Pick a domain" when user haven't entered site title and haven't decided on a domain.

#### Testing instructions

* Go to `/new`
* Click "Skip for now".
* Domain picker button's label should be "Pick a domain".
* Open up domain picker, select a domain and click Confirm.
* Domain picker button's label should be the selected domain name.

#### Screenshot

![image](https://user-images.githubusercontent.com/1287077/82573232-cc5faf80-9b85-11ea-8762-b0de8ff7bf16.png)


Fixes #42524
