### PR TITLE
Jetpack Cloud: Add more specificity to the run-scan-button

### DIFF
--- a/client/landing/jetpack-cloud/components/scan-threats/style.scss
+++ b/client/landing/jetpack-cloud/components/scan-threats/style.scss
@@ -11,7 +11,7 @@
 		margin-top: 24px;
 	}
 
-	&__run-scan-button {
+	&__run-scan-button.scan-threats__run-scan-button {
 		padding: initial;
 		border: initial;
 		font-weight: normal;


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Fix the outline.

Before: 
<img width="725" alt="Screen Shot 2020-05-21 at 5 56 54 PM" src="https://user-images.githubusercontent.com/115071/82578428-adb0e700-9b8c-11ea-9f87-4e0b760466bb.png">
After:

<img width="814" alt="Screen Shot 2020-05-21 at 5 56 46 PM" src="https://user-images.githubusercontent.com/115071/82578432-aee21400-9b8c-11ea-9fe8-11690e953bb2.png">

#### Testing instructions

* Go to a site with threats on the scanner page you should see the link.
