### PR TITLE
composite-checkout: Do not show original price for credits line item (1)

### DIFF
--- a/client/my-sites/checkout/composite-checkout/wpcom/lib/translate-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/lib/translate-cart.ts
@@ -155,6 +155,13 @@ function translateReponseCartProductToWPCOMCartItem(
 
 	const type = isPlan( serverCartItem ) ? 'plan' : product_slug;
 
+	// for displaying crossed-out original price
+	let itemOriginalCostDisplay = item_original_cost_display || '';
+	// but for the credits item this is confusing and unnecessary
+	if ( 'wordpress-com-credits' === product_slug ) {
+		itemOriginalCostDisplay = '';
+	}
+
 	return {
 		id: uuid,
 		label,
@@ -174,7 +181,7 @@ function translateReponseCartProductToWPCOMCartItem(
 			volume,
 			is_domain_registration: is_domain_registration || false,
 			is_bundled: is_bundled || false,
-			item_original_cost_display: item_original_cost_display || '',
+			item_original_cost_display: itemOriginalCostDisplay,
 			item_original_cost_integer: item_original_cost_integer || 0,
 			product_cost_integer: product_cost_integer || 0,
 			product_cost_display: product_cost_display || '',

--- a/client/my-sites/checkout/composite-checkout/wpcom/test/translate-cart.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/test/translate-cart.js
@@ -777,4 +777,194 @@ describe( 'translateResponseCartToWPCOMCart', function () {
 			} );
 		} );
 	} );
+
+	describe( 'Cart with one plan only (BRL) and a credits line item', function () {
+		const serverResponse = {
+			blog_id: 123,
+			products: [
+				{
+					product_id: 1009,
+					product_name: 'WordPress.com Personal',
+					product_name_en: 'WordPress.com Personal',
+					product_slug: 'personal-bundle',
+					product_cost: 144,
+					meta: '',
+					cost: 144,
+					currency: 'BRL',
+					volume: 1,
+					free_trial: false,
+					orig_cost: null,
+					cost_before_coupon: 144,
+					extra: {
+						context: 'signup',
+						domain_to_bundle: 'foo.cash',
+					},
+					bill_period: 365,
+					is_domain_registration: false,
+					time_added_to_cart: 1572551402,
+					is_bundled: false,
+					item_original_cost: 144,
+					item_original_cost_integer: 14400,
+					item_original_cost_display: 'R$144',
+					item_subtotal: 144,
+					item_subtotal_integer: 14400,
+					item_subtotal_display: 'R$144',
+					item_tax: 0,
+					item_total: 144,
+					subscription_id: 0,
+					uuid: '0',
+				},
+				{
+					product_id: 18,
+					product_name: 'WordPress.com Credits',
+					product_name_en: 'WordPress.com Credits',
+					product_slug: 'wordpress-com-credits',
+					product_cost: -5,
+					product_cost_display: '$-5',
+					product_cost_integer: -500,
+					meta: null,
+					cost: -5,
+					currency: 'USD',
+					volume: 1,
+					free_trial: false,
+					orig_cost: null,
+					cost_before_coupon: 0,
+					is_sale_coupon_applied: null,
+					extra: [],
+					bill_period: '-1',
+					is_domain_registration: false,
+					time_added_to_cart: 1590076307,
+					is_bundled: false,
+					item_original_cost: 0,
+					item_original_cost_integer: 0,
+					item_original_cost_display: '$0',
+					item_subtotal: -5,
+					item_subtotal_integer: -500,
+					item_subtotal_display: '$-5',
+					item_tax: 0,
+					item_total: -5,
+					subscription_id: 0,
+					is_renewal: false,
+					domain_post_renewal_expiration_date: null,
+				},
+			],
+			tax: {
+				location: {},
+				display_taxes: true,
+			},
+			savings_total: 0,
+			savings_total_display: 'R$0',
+			savings_total_integer: 0,
+			sub_total: '144',
+			sub_total_display: 'R$144',
+			sub_total_integer: 14400,
+			total_tax: '5',
+			total_tax_display: 'R$5',
+			total_tax_integer: 500,
+			total_cost: 149,
+			total_cost_display: 'R$149',
+			total_cost_integer: 14900,
+			currency: 'BRL',
+			credits: 100,
+			credits_integer: 10000,
+			credits_display: 'R$100',
+			allowed_payment_methods: [
+				'WPCOM_Billing_Stripe_Payment_Method',
+				'WPCOM_Billing_Ebanx',
+				'WPCOM_Billing_Web_Payment',
+			],
+			coupon: 'fakecoupon',
+			coupon_discounts_integer: [],
+		};
+
+		const clientCart = translateResponseCartToWPCOMCart( serverResponse );
+
+		it( 'has a total property', function () {
+			expect( clientCart.total.amount ).toBeDefined();
+		} );
+		it( 'has the expected total value', function () {
+			expect( clientCart.total.amount.value ).toBe( 14900 );
+		} );
+		it( 'has the expected currency', function () {
+			expect( clientCart.total.amount.currency ).toBe( 'BRL' );
+		} );
+		it( 'has the expected total display value', function () {
+			expect( clientCart.total.amount.displayValue ).toBe( 'R$149' );
+		} );
+		it( 'has an array of items', function () {
+			expect( clientCart.items ).toBeDefined();
+		} );
+		it( 'has the expected number of line items', function () {
+			expect( clientCart.items.length ).toBe( 2 );
+		} );
+		it( 'has an array of allowed payment methods', function () {
+			expect( clientCart.allowedPaymentMethods ).toBeDefined();
+		} );
+		it( 'has the expected credits', function () {
+			expect( clientCart.credits.amount.value ).toBe( 10000 );
+			expect( clientCart.credits.amount.currency ).toBe( 'BRL' );
+			expect( clientCart.credits.amount.displayValue ).toBe( 'R$100' );
+		} );
+		it( 'does not show an original price for the credits item', function () {
+			const creditsItem = clientCart.items.find( ( item ) => {
+				return 'wordpress-com-credits' === item.type;
+			} );
+			expect( creditsItem.wpcom_meta.item_original_cost_display ).toBe( '' );
+		} );
+		it( 'has the expected coupon', function () {
+			expect( clientCart.couponCode ).toBe( 'fakecoupon' );
+		} );
+
+		describe( 'first cart item (plan)', function () {
+			it( 'has an id', function () {
+				expect( clientCart.items[ 0 ].id ).toBeDefined();
+			} );
+			it( 'has the expected label', function () {
+				expect( clientCart.items[ 0 ].label ).toBe( 'WordPress.com Personal' );
+			} );
+			it( 'has the expected type', function () {
+				expect( clientCart.items[ 0 ].type ).toBe( 'plan' );
+			} );
+			it( 'has the expected currency', function () {
+				expect( clientCart.items[ 0 ].amount.currency ).toBe( 'BRL' );
+			} );
+			it( 'has the expected value', function () {
+				expect( clientCart.items[ 0 ].amount.value ).toBe( 14400 );
+			} );
+			it( 'has the expected display value', function () {
+				expect( clientCart.items[ 0 ].amount.displayValue ).toBe( 'R$144' );
+			} );
+		} );
+
+		describe( 'taxes', function () {
+			it( 'has an id', function () {
+				expect( clientCart.tax.id ).toBeDefined();
+			} );
+			it( 'has the expected label', function () {
+				expect( clientCart.tax.label ).toBe( 'Tax' );
+			} );
+			it( 'has the expected type', function () {
+				expect( clientCart.tax.type ).toBe( 'tax' );
+			} );
+			it( 'has the expected currency', function () {
+				expect( clientCart.tax.amount.currency ).toBe( 'BRL' );
+			} );
+			it( 'has the expected value', function () {
+				expect( clientCart.tax.amount.value ).toBe( 500 );
+			} );
+			it( 'has the expected display value', function () {
+				expect( clientCart.tax.amount.displayValue ).toBe( 'R$5' );
+			} );
+		} );
+
+		describe( 'allowed payment methods', function () {
+			it( 'contains the expected slugs', function () {
+				expect( clientCart.allowedPaymentMethods ).toStrictEqual( [
+					'card',
+					'ebanx',
+					'apple-pay',
+				] );
+			} );
+		} );
+	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The "original price" display doesn't make sense for the credits line item. This PR sets it to the empty string.

#### Testing instructions

Enter checkout with partial credits, and check that only the credit value is displayed in the line item (no crossed out "original price").

<img width="489" alt="Screen Shot 2020-05-21 at 10 35 35 AM" src="https://user-images.githubusercontent.com/9310939/82582825-3c574100-9b58-11ea-8e08-2ce8db8f697c.png">

Note: the wonky minus sign is a separate issue.

```
yarn run test-client client/my-sites/checkout/composite-checkout/wpcom/test/translate-cart.js
```

Fixes #42168
