### PR TITLE
i18n: Improve build-languages script

### DIFF
--- a/bin/build-languages.js
+++ b/bin/build-languages.js
@@ -179,7 +179,9 @@ function downloadLanguagesRevions() {
 			} );
 			response.on( 'end', () => {
 				if ( response.statusCode !== 200 ) {
-					log( 'failed' );
+					console.error( 'Failed to download language revisions file.' );
+					process.exit( 1 );
+
 					resolve( false );
 					return;
 				}
@@ -221,7 +223,10 @@ async function downloadLanguages() {
 						files.forEach( ( file ) => response.pipe( file ) );
 						response.on( 'data', ( chunk ) => ( body += chunk ) );
 						response.on( 'end', () => {
-							if ( response.statusCode === 200 ) {
+							if ( response.statusCode !== 200 ) {
+								console.error( `Failed to download translations for "${ langSlug }".` );
+								process.exit( 1 );
+							} else {
 								downloadedLanguagesCount++;
 								log();
 							}

--- a/bin/build-languages.js
+++ b/bin/build-languages.js
@@ -8,116 +8,18 @@ const mkdirp = require( 'mkdirp' );
 const readline = require( 'readline' );
 const parse = require( 'gettext-parser' ).po.parse;
 
+const languagesMetaPath = fs.existsSync( '../client/languages/languages-meta.json' )
+	? '../client/languages/languages-meta.json'
+	: '../client/languages/fallback-languages-meta.json';
+const languages = require( languagesMetaPath );
+
 const LANGUAGES_BASE_URL = 'https://widgets.wp.com/languages/calypso';
 const LANGUAGES_REVISIONS_FILENAME = 'lang-revisions.json';
 const CALYPSO_STRINGS = './calypso-strings.pot';
 const CHUNKS_MAP_PATTERN = './chunks-map.*.json';
 const LANGUAGE_MANIFEST_FILENAME = 'language-manifest.json';
 
-const languages = [
-	'am',
-	'ast',
-	'gu',
-	'hi',
-	'hr',
-	'hu',
-	'he',
-	'af',
-	'as',
-	'ar',
-	'da',
-	'gd',
-	'cy',
-	'cs',
-	'de_formal',
-	'de',
-	'bel',
-	'bo',
-	'br',
-	'es-cl',
-	'eo',
-	'dv',
-	'bn',
-	'sl',
-	'eu',
-	'az',
-	'bg',
-	'el',
-	'en-gb',
-	'snd',
-	'es',
-	'fi',
-	'skr',
-	'el-po',
-	'sk',
-	'id',
-	'fo',
-	'so',
-	'fr-be',
-	'gl',
-	'te',
-	'es-mx',
-	'ms',
-	'hy',
-	'et',
-	'fa',
-	'fr',
-	'ml',
-	'mr',
-	'si',
-	'mn',
-	'oci',
-	'ps',
-	'fr-ch',
-	'sq',
-	'bs',
-	'ca',
-	'zh-tw',
-	'ro',
-	'pa',
-	'fr-ca',
-	'su',
-	'sr',
-	'sv',
-	'mwl',
-	'ckb',
-	'kk',
-	'kn',
-	'ne',
-	'ka',
-	'km',
-	'tir',
-	'lo',
-	'no',
-	'kir',
-	'mk',
-	'sr_latin',
-	'ta',
-	'ko',
-	'nl',
-	'zh-cn',
-	'nn',
-	'lv',
-	'ga',
-	'lt',
-	'pl',
-	'pt',
-	'ru',
-	'rup',
-	'yi',
-	'pt-br',
-	'ug',
-	'uz',
-	'vi',
-	'is',
-	'ur',
-	'uk',
-	'it',
-	'ja',
-	'tl',
-	'th',
-	'tr',
-]; // todo: can we use `../client/languages`?
+const langSlugs = languages.map( ( { langSlug } ) => langSlug );
 
 const chunksMaps = glob.sync( CHUNKS_MAP_PATTERN );
 const languagesPaths = chunksMaps
@@ -200,14 +102,14 @@ async function downloadLanguages() {
 	function log( status ) {
 		logUpdate(
 			`Downloading languages${ status ? ` ${ status }.` : '...' } ` +
-				`(${ downloadedLanguagesCount }/${ languages.length })`
+				`(${ downloadedLanguagesCount }/${ langSlugs.length })`
 		);
 	}
 
 	log();
 
 	const downloadedLanguages = await Promise.all(
-		languages.map(
+		langSlugs.map(
 			( langSlug ) =>
 				new Promise( ( resolve ) => {
 					const filename = `${ langSlug }-v1.1.json`;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use `client/languages` for the list of languages that translation chunks should be built for
* Interrupt the script if it fails to build translations for any of the languages in `lang-revisions.json`. A language that is not included in `lang-revisions.json` won't interrupt the script if it fails to download its translations.

#### Testing instructions

1. Build Calypso with `CALYPSO_ENV=production BUILD_TRANSLATION_CHUNKS=true yarn run build`
2. Confirm that translation files for supported languages are successfully built in `/public/evergreen/languages/` and `/public/fallback/languages/`