### PR TITLE
JP-Cloud: The Backup/Scan menu in the sidebar shouldn't be translated

### DIFF
--- a/client/landing/jetpack-cloud/components/sidebar/index.jsx
+++ b/client/landing/jetpack-cloud/components/sidebar/index.jsx
@@ -82,9 +82,8 @@ class JetpackCloudSidebar extends Component {
 		const { selectedSiteSlug, translate, threats, siteId, scanProgress } = this.props;
 		const numberOfThreatsFound = threats.length;
 
-		const scanTitle = this.props.translate( 'Scan', {
-			comment: 'Jetpack Cloud / Scan sidebar navigation item',
-		} );
+		const backupTitle = 'Backup';
+		const scanTitle = 'Scan';
 
 		const scanBadge = (
 			<ScanBadge progress={ scanProgress } numberOfThreatsFound={ numberOfThreatsFound } />
@@ -98,9 +97,7 @@ class JetpackCloudSidebar extends Component {
 						<ExpandableSidebarMenu
 							onClick={ this.toggleSection( SIDEBAR_SECTION_BACKUP ) }
 							expanded={ this.props.isBackupSectionOpen }
-							title={ this.props.translate( 'Backup', {
-								comment: 'Jetpack Cloud / Backup sidebar navigation item',
-							} ) }
+							title={ backupTitle }
 							materialIcon="backup"
 							materialIconStyle="filled"
 						>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The Backup/Scan menu items in the sidebar shouldn't be translated, they are Jetpack product names.

**Asana:** 1169345694087188-as-1176670093007902

#### Testing instructions

- Apply the changes
- Change the interface language to other different than English (https://wordpress.com/me/account), and then check that the menu items Backup and Scan aren't translated.
