### PR TITLE
Turn on upcoming renewal notifications in the wpcalypso environment

### DIFF
--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -159,6 +159,7 @@
 		"upgrades/premium-themes": true,
 		"upgrades/precancellation-chat": true,
 		"upgrades/presale-chat": true,
+		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,
 		"upsell/concierge-session": true,
 		"upsell/nudge-a-palooza": false,


### PR DESCRIPTION
This pull request enables the upcoming renewal notifications feature (added in previous pull requests such as https://github.com/Automattic/wp-calypso/pull/42076, https://github.com/Automattic/wp-calypso/pull/42240, and https://github.com/Automattic/wp-calypso/pull/42506) in the `wpcalypso` environment for testing purposes.