### PR TITLE
Update is available logic to only check if on WPCOM on API requests

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/subscription-service/class-wpcom-offline-subscription-service.php
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/subscription-service/class-wpcom-offline-subscription-service.php
@@ -17,13 +17,13 @@ class WPCOM_Offline_Subscription_Service extends WPCOM_Token_Subscription_Servic
 	 * @return boolean
 	 */
 	public static function available() {
-		// Return available if on WPCOM and
-		// either running a job (sending email subscription) or handling API request (reader)
-		// and the user is logged in
-		return defined( 'IS_WPCOM' ) && IS_WPCOM === true && (
-				( defined( 'IS_JOBS' ) && IS_JOBS ) ||
-				( defined( 'REST_API_REQUEST' ) && REST_API_REQUEST )
-			) && is_user_logged_in();
+		// Return available if the user is logged in and either
+		// running a job (sending email subscription) OR
+		// handling API request on WPCOM (reader)
+		return (
+			( defined( 'IS_JOBS' ) && IS_JOBS ) ||
+			( defined( 'IS_WPCOM' ) && IS_WPCOM === true && ( defined( 'REST_API_REQUEST' ) && REST_API_REQUEST ) )
+		       ) && is_user_logged_in();
 	}
 
 	/**

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/subscription-service/class-wpcom-offline-subscription-service.php
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/subscription-service/class-wpcom-offline-subscription-service.php
@@ -21,7 +21,7 @@ class WPCOM_Offline_Subscription_Service extends WPCOM_Token_Subscription_Servic
 		// running a job (sending email subscription) OR
 		// handling API request on WPCOM (reader)
 		return (
-			( defined( 'IS_JOBS' ) && IS_JOBS ) ||
+			( defined( 'WPCOM_JOBS' ) && WPCOM_JOBS ) ||
 			( defined( 'IS_WPCOM' ) && IS_WPCOM === true && ( defined( 'REST_API_REQUEST' ) && REST_API_REQUEST ) )
 		       ) && is_user_logged_in();
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This updates the logic used when determining what paywal/subscription service to use when rendering content.

The logic currently checks to see if the request to render content is from a WPCOM source, using the define `IS_WPCOM`.

I don't think `IS_WPCOM` is set when jobs are running, which means that emails sent from jobs that should have premium content are not showing the premium content as the offline subscription service is appearing as not available.

#### Testing instructions

For my tests I used the blog ID - 177049966 and post ID - 72

To make sure your test account will receive an email;
1. Go to https://eointestfse.wordpress.com/2020/05/21/a1/ and subscribe to the premium content
2. Also, follow the blog, making sure you are setup to receive new post emails instantly (check in manage subscriptions)

We need to run the email job to test this from our sandbox;

1. First add an action to the file `async-jobs/jobs.php` on your sandbox - `add_action( 'wpj_bsub_email_child_123', 'wpj_bsub_email_child' );`
2. `wp shell`
3. `>global $wpdb; $wpdb->blogid = 177049966; $GLOBALS['blog_id'] = 177049966; $data = new stdClass(); $data->limit = 100; $data->offset = 0; $data->post_id = 72;`
4. `>queue_async_job( $data, 'bsub_email_child_123' );` - This will return a job ID - Copy this ID
5. `>exit`
6. `php async-jobs/tester.php {PASTE JOB ID HERE}`
7. Check to see if your test account received an email with the line `THIS IS PREMIUM CONTENT` in the email content.

<img width="713" alt="Screenshot 2020-05-22 at 11 18 34" src="https://user-images.githubusercontent.com/5560595/82658737-7b03fe80-9c1f-11ea-9928-dead5dff0ea1.png">

To confirm that you receive **NO** premium content on new posts that have premium content blocks on a plan that you have not subscribed to, run through the test again but this time use the post ID 75.
You should receive an email with no premium content for the post - https://eointestfse.wordpress.com/2020/05/22/secrets/

Fixes #

When a new post is created with premium content, any subscriber to that premium content blocks plan that is also following the blog (and receiving email) should receive a new post email with the premium content rendered.