### PR TITLE
Premium Content: add a general transform to premium content

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/container/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/container/index.js
@@ -116,13 +116,7 @@ const settings = {
 						return createBlock( block.name, block.attributes, block.innerBlocks );
 					} );
 
-					const excerptLength = 2;
-					const loggedOutExcerpt = blocks.slice( 0, excerptLength ).map( ( block ) => {
-						return createBlock( block.name, block.attributes, block.innerBlocks );
-					} );
-
 					const innerBlocksLoggedOut = [
-						...loggedOutExcerpt,
 						createBlock( 'core/heading', {
 							content: __( 'Subscribe to get access', 'premium-content' ),
 							level: 3,

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/container/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/container/index.js
@@ -15,6 +15,16 @@ import save from './save';
 const name = 'premium-content/container';
 const category = 'common';
 
+const blockContainsPremiumBlock = ( block ) => {
+	if ( block.name.indexOf( 'premium-content/' ) === 0 ) {
+		return true;
+	}
+	if ( ! block.innerBlocks ) {
+		return false;
+	}
+	return block.innerBlocks.some( blockContainsPremiumBlock );
+};
+
 /**
  * @typedef {object} Attributes
  * @property { string } newPlanName
@@ -102,8 +112,8 @@ const settings = {
 				isMultiBlock: true,
 				blocks: [ '*' ],
 				__experimentalConvert( blocks ) {
-					// Avoid transforming a premium-content block
-					if ( blocks.length === 1 && blocks[ 0 ].name === 'premium-content/container' ) {
+					// Avoid transforming any premium-content blocks
+					if ( blocks.some( blockContainsPremiumBlock ) ) {
 						return;
 					}
 

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/container/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/container/index.js
@@ -137,22 +137,9 @@ const settings = {
 						return createBlock( block.name, block.attributes, block.innerBlocks );
 					} );
 
-					const innerBlocksLoggedOut = [
-						createBlock( 'core/heading', {
-							content: __( 'Subscribe to get access', 'premium-content' ),
-							level: 3,
-						} ),
-						createBlock( 'core/paragraph', {
-							content: __(
-								'Read more of this content when you subscribe today.',
-								'premium-content'
-							),
-						} ),
-					];
-
 					return createBlock( 'premium-content/container', {}, [
 						createBlock( 'premium-content/subscriber-view', {}, innerBlocksSubscribe ),
-						createBlock( 'premium-content/logged-out-view', {}, innerBlocksLoggedOut ),
+						createBlock( 'premium-content/logged-out-view' ),
 					] );
 				},
 			},


### PR DESCRIPTION
Works with paragraphs, any any single blocks (group, image, etc). But needed https://github.com/WordPress/gutenberg/pull/22577 to handle mixed selection blocks (for example one paragraph and one header block in a selection). I'm unsure of the reasoning but currently only the group block is allowed to do this.

I also added checks for not transforming if there were premium content blocks in the selection, including parent blocks.

![transform](https://user-images.githubusercontent.com/1270189/85478496-34345c00-b571-11ea-868e-0f92ea499375.gif)

Note that we can further improve experimental `__experimentalConvert` in follow up core patches (for example don't display the transform option if we don't allow nested premium content blocks), but we'll leave that for a future follow up.

### Testing Instructions
* `cd apps/full-site-editing;  yarn dev --sync`.
* Set up a recurring payment plan on a site using the testing store. More info in PCYsg-lW4-p2 #sandbox-method.
* Add some blocks.
* Select more than one block (if you're using a Gutenberg version that doesn't include https://github.com/WordPress/gutenberg/pull/22577 make sure to select blocks of the same type).
* Transform them to a Premium Content block.
* Select the blocks of the subscriber view and try to convert them to a Premium Content block.
* Make sure the transformation does not occur (you should get an expected `Uncaught TypeError: Cannot read property 'name' of null` error in the browser console).
* Insert two Group blocks.
* Insert a Premium Content block inside the first Group block.
* Insert any other content inside the second Group block.
* Select the two Group blocks and try to transform them to a Premium Content block.
* Make sure the transformation does not occur (you should get an expected `Uncaught TypeError: Cannot read property 'name' of null` error in the browser console).

Fixes https://github.com/Automattic/wp-calypso/issues/41598