### PR TITLE
Jetpack Cloud: Add config flag to prevent restricted requests

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -213,11 +213,13 @@ class Layout extends Component {
 						{ this.props.primary }
 					</div>
 				</div>
-				{ config.isEnabled( 'i18n/community-translator' ) ? (
-					isCommunityTranslatorEnabled() && <AsyncLoad require="components/community-translator" />
-				) : (
-					<AsyncLoad require="layout/community-translator/launcher" placeholder={ null } />
-				) }
+				{ config.isEnabled( 'i18n/community-translator' )
+					? isCommunityTranslatorEnabled() && (
+							<AsyncLoad require="components/community-translator" />
+					  )
+					: config( 'restricted_me_access' ) && (
+							<AsyncLoad require="layout/community-translator/launcher" placeholder={ null } />
+					  ) }
 				{ this.props.sectionGroup === 'sites' && <SitePreview /> }
 				{ config.isEnabled( 'happychat' ) && this.props.chatIsOpen && (
 					<AsyncLoad require="components/happychat" />

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -139,5 +139,6 @@
 	},
 	"site_filter": [],
 	"theme": "default",
-	"site_name": "WordPress.com"
+	"site_name": "WordPress.com",
+	"restricted_me_access": true
 }

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -17,7 +17,6 @@
 		"current-site/domain-warning": false,
 		"current-site/notice": false,
 		"current-site/stale-cart-notice": false,
-		"i18n/community-translator": false,
 		"jetpack-cloud": true,
 		"jetpack-cloud/backups-restore": true,
 		"jetpack-cloud/backups": true,
@@ -43,5 +42,6 @@
 		"jetpack-cloud-auth": true
 	},
 	"site_filter": [ "jetpack" ],
-	"theme": "jetpack-cloud"
+	"theme": "jetpack-cloud",
+	"restricted_me_access": false
 }

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -17,6 +17,7 @@
 		"current-site/domain-warning": false,
 		"current-site/notice": false,
 		"current-site/stale-cart-notice": false,
+		"i18n/community-translator": false,
 		"jetpack-cloud": true,
 		"jetpack-cloud/backups-restore": true,
 		"jetpack-cloud/backups": true,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -41,5 +41,6 @@
 		"jetpack-cloud-auth": true
 	},
 	"site_filter": [ "jetpack" ],
-	"theme": "jetpack-cloud"
+	"theme": "jetpack-cloud",
+	"restricted_me_access": false
 }

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -15,6 +15,7 @@
 		"current-site/domain-warning": false,
 		"current-site/notice": false,
 		"current-site/stale-cart-notice": false,
+		"i18n/community-translator": false,
 		"jetpack-cloud": true,
 		"jetpack-cloud/backups-restore": true,
 		"jetpack-cloud/backups": true,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -15,6 +15,7 @@
 		"current-site/domain-warning": false,
 		"current-site/notice": false,
 		"current-site/stale-cart-notice": false,
+		"i18n/community-translator": false,
 		"jetpack-cloud": true,
 		"jetpack-cloud/backups-restore": true,
 		"jetpack-cloud/backups": true,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -15,7 +15,6 @@
 		"current-site/domain-warning": false,
 		"current-site/notice": false,
 		"current-site/stale-cart-notice": false,
-		"i18n/community-translator": false,
 		"jetpack-cloud": true,
 		"jetpack-cloud/backups-restore": true,
 		"jetpack-cloud/backups": true,
@@ -41,5 +40,6 @@
 		"jetpack-cloud-auth": true
 	},
 	"site_filter": [ "jetpack" ],
-	"theme": "jetpack-cloud"
+	"theme": "jetpack-cloud",
+	"restricted_me_access": false
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Some APIs used by Calypso have restricted access that we will not get as Jetpack Cloud, so let's restrict these behind a config flag

#### Testing instructions

Navigate Jetpack Cloud, verifying that the `me/settings` request isn't made
