### PR TITLE
Customizer: use return query param when available

### DIFF
--- a/client/components/web-preview/toolbar.jsx
+++ b/client/components/web-preview/toolbar.jsx
@@ -207,12 +207,7 @@ export default connect(
 
 		return {
 			canUserEditThemeOptions,
-			customizeUrl: getCustomizerUrl(
-				state,
-				siteId,
-				null,
-				window.location.pathname + window.location.search
-			),
+			customizeUrl: getCustomizerUrl( state, siteId, null, window.location.href ),
 		};
 	},
 	{ recordTracksEvent }

--- a/client/components/web-preview/toolbar.jsx
+++ b/client/components/web-preview/toolbar.jsx
@@ -207,7 +207,12 @@ export default connect(
 
 		return {
 			canUserEditThemeOptions,
-			customizeUrl: getCustomizerUrl( state, siteId, null, window.location.href ),
+			customizeUrl: getCustomizerUrl(
+				state,
+				siteId,
+				null,
+				window.location.pathname + window.location.search
+			),
 		};
 	},
 	{ recordTracksEvent }

--- a/client/components/web-preview/toolbar.jsx
+++ b/client/components/web-preview/toolbar.jsx
@@ -207,7 +207,7 @@ export default connect(
 
 		return {
 			canUserEditThemeOptions,
-			customizeUrl: getCustomizerUrl( state, siteId ),
+			customizeUrl: getCustomizerUrl( state, siteId, null, window.location.href ),
 		};
 	},
 	{ recordTracksEvent }

--- a/client/my-sites/customize/main.jsx
+++ b/client/my-sites/customize/main.jsx
@@ -188,7 +188,6 @@ class Customize extends React.Component {
 		}
 		return domain + '/wp-admin/customize.php?' + this.buildCustomizerQuery();
 	};
-
 	buildCustomizerQuery = () => {
 		const { protocol, host } = window.location;
 		const query = cloneDeep( this.props.query );

--- a/client/my-sites/customize/main.jsx
+++ b/client/my-sites/customize/main.jsx
@@ -115,13 +115,10 @@ class Customize extends React.Component {
 		return false;
 	};
 
+	getReturnUrl = () => new URLSearchParams( window.location.search ).get( 'return' );
+
 	getPreviousPath = () => {
 		let path = this.props.prevPath;
-		const returnUrl = new URLSearchParams( window.location.search ).get( 'return' );
-
-		if ( returnUrl ) {
-			return returnUrl;
-		}
 
 		if ( ! path || /^\/customize\/?/.test( path ) ) {
 			path = '/stats';
@@ -133,7 +130,8 @@ class Customize extends React.Component {
 	};
 
 	goBack = () => {
-		const path = this.getPreviousPath();
+		const returnUrl = this.getReturnUrl();
+		const path = returnUrl || this.getPreviousPath();
 
 		if ( path.includes( '/themes' ) ) {
 			trackClick( 'customizer', 'close' );
@@ -193,8 +191,9 @@ class Customize extends React.Component {
 		const { protocol, host } = window.location;
 		const query = cloneDeep( this.props.query );
 		const { panel, site } = this.props;
+		const returnUrl = this.getReturnUrl();
 
-		query.return = protocol + '//' + host + this.getPreviousPath();
+		query.return = returnUrl || protocol + '//' + host + this.getPreviousPath();
 		query.calypso = true;
 		query.calypsoOrigin = protocol + '//' + host;
 		if ( site.options && site.options.frame_nonce ) {

--- a/client/my-sites/customize/main.jsx
+++ b/client/my-sites/customize/main.jsx
@@ -188,6 +188,7 @@ class Customize extends React.Component {
 		}
 		return domain + '/wp-admin/customize.php?' + this.buildCustomizerQuery();
 	};
+
 	buildCustomizerQuery = () => {
 		const { protocol, host } = window.location;
 		const query = cloneDeep( this.props.query );

--- a/client/my-sites/customize/main.jsx
+++ b/client/my-sites/customize/main.jsx
@@ -73,6 +73,11 @@ class Customize extends React.Component {
 	};
 
 	UNSAFE_componentWillMount() {
+		this.getReturnUrl().then( ( validatedUrl ) => {
+			this.setState( {
+				returnUrl: validatedUrl,
+			} );
+		} );
 		this.redirectIfNeeded( this.props.pathname );
 		this.listenToCustomizer();
 		this.waitForLoading();
@@ -82,11 +87,6 @@ class Customize extends React.Component {
 		if ( window ) {
 			window.scrollTo( 0, 0 );
 		}
-		this.getReturnUrl().then( ( validatedUrl ) => {
-			this.setState( {
-				returnUrl: validatedUrl,
-			} );
-		} );
 	}
 
 	componentWillUnmount() {
@@ -217,9 +217,8 @@ class Customize extends React.Component {
 		const { protocol, host } = window.location;
 		const query = cloneDeep( this.props.query );
 		const { panel, site } = this.props;
-		const returnUrl = this.getReturnUrl();
 
-		query.return = returnUrl || protocol + '//' + host + this.getPreviousPath();
+		query.return = protocol + '//' + host + this.getPreviousPath();
 		query.calypso = true;
 		query.calypsoOrigin = protocol + '//' + host;
 		if ( site.options && site.options.frame_nonce ) {

--- a/client/my-sites/customize/main.jsx
+++ b/client/my-sites/customize/main.jsx
@@ -117,6 +117,12 @@ class Customize extends React.Component {
 
 	getPreviousPath = () => {
 		let path = this.props.prevPath;
+		const returnUrl = new URLSearchParams( window.location.search ).get( 'return' );
+
+		if ( returnUrl ) {
+			return returnUrl;
+		}
+
 		if ( ! path || /^\/customize\/?/.test( path ) ) {
 			path = '/stats';
 			if ( this.props.domain ) {

--- a/client/my-sites/customize/main.jsx
+++ b/client/my-sites/customize/main.jsx
@@ -26,6 +26,7 @@ import { getCustomizerFocus } from './panels';
 import getMenusUrl from 'state/selectors/get-menus-url';
 import { getSelectedSite } from 'state/ui/selectors';
 import { getCustomizerUrl, isJetpackSite } from 'state/sites/selectors';
+import canCurrentUserUseCustomerHome from 'state/sites/selectors/can-current-user-use-customer-home';
 import wpcom from 'lib/wp';
 import { addItem } from 'lib/cart/actions';
 import { trackClick } from 'my-sites/themes/helpers';
@@ -63,6 +64,7 @@ class Customize extends React.Component {
 		isJetpack: PropTypes.bool,
 		customizerUrl: PropTypes.string,
 		translate: PropTypes.func.isRequired,
+		isCustomerHomeEnabled: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -146,7 +148,7 @@ class Customize extends React.Component {
 		let path = this.props.prevPath;
 
 		if ( ! path || /^\/customize\/?/.test( path ) ) {
-			path = '/home';
+			path = this.props.isCustomerHomeEnabled ? '/home' : '/stats';
 			if ( this.props.domain ) {
 				path += '/' + this.props.domain;
 			}
@@ -413,6 +415,7 @@ export default connect(
 	( state ) => {
 		const site = getSelectedSite( state );
 		const siteId = get( site, 'ID' );
+		const isCustomerHomeEnabled = canCurrentUserUseCustomerHome( state, siteId );
 		return {
 			site,
 			siteId,
@@ -420,6 +423,7 @@ export default connect(
 			isJetpack: isJetpackSite( state, siteId ),
 			// TODO: include panel from props?
 			customizerUrl: getCustomizerUrl( state, siteId ),
+			isCustomerHomeEnabled,
 		};
 	},
 	{ requestSite, themeActivated }

--- a/client/my-sites/customize/main.jsx
+++ b/client/my-sites/customize/main.jsx
@@ -146,7 +146,7 @@ class Customize extends React.Component {
 		let path = this.props.prevPath;
 
 		if ( ! path || /^\/customize\/?/.test( path ) ) {
-			path = '/stats';
+			path = '/home';
 			if ( this.props.domain ) {
 				path += '/' + this.props.domain;
 			}

--- a/client/state/sites/selectors/get-customizer-url.js
+++ b/client/state/sites/selectors/get-customizer-url.js
@@ -15,24 +15,31 @@ import isJetpackSite from './is-jetpack-site';
 /**
  * Returns the customizer URL for a site, or null if it cannot be determined.
  *
- * @param  {object} state  Global state tree
- * @param  {?number} siteId Site ID
- * @param  {string} panel  Optional panel to autofocus
- * @returns {string}        Customizer URL
+ * @param   {object}  state     Global state tree
+ * @param   {?number} siteId    Site ID
+ * @param   {string}  panel     Optional panel to autofocus
+ * @param   {string}  returnUrl Optional return url for when the user closes the customizer
+ * @returns {string}            Customizer URL
  */
-export default function getCustomizerUrl( state, siteId, panel ) {
+export default function getCustomizerUrl( state, siteId, panel, returnUrl ) {
 	if ( ! isJetpackSite( state, siteId ) ) {
 		const siteSlug = getSiteSlug( state, siteId );
-		return [ '' ].concat( compact( [ 'customize', panel, siteSlug ] ) ).join( '/' );
+		const url = [ '' ].concat( compact( [ 'customize', panel, siteSlug ] ) ).join( '/' );
+		return addQueryArgs(
+			{
+				return: returnUrl,
+			},
+			url
+		);
 	}
 
 	const adminUrl = getSiteAdminUrl( state, siteId, 'customize.php' );
+
 	if ( ! adminUrl ) {
 		return null;
 	}
 
-	let returnUrl;
-	if ( 'undefined' !== typeof window ) {
+	if ( ! returnUrl && 'undefined' !== typeof window ) {
 		returnUrl = window.location.href;
 	}
 

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -3221,12 +3221,12 @@ describe( 'selectors', () => {
 				},
 				77203199,
 				null,
-				'/things/are/going?to=be&okay=true'
+				'https://wordpress.com/things/are/going?to=be&okay=true'
 			);
 
 			chaiExpect( customizerUrl ).to.equal(
 				`/customize/example.com?return=${ encodeURIComponent(
-					'/things/are/going?to=be&okay=true'
+					'https://wordpress.com/things/are/going?to=be&okay=true'
 				) }`
 			);
 		} );

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -3206,6 +3206,29 @@ describe( 'selectors', () => {
 			chaiExpect( customizerUrl ).to.equal( '/customize/example.com' );
 		} );
 
+		test( 'should return customizer URL with return query for WordPress.com site', () => {
+			const customizerUrl = getCustomizerUrl(
+				{
+					sites: {
+						items: {
+							77203199: {
+								ID: 77203199,
+								URL: 'https://example.com',
+								jetpack: false,
+							},
+						},
+					},
+				},
+				77203199,
+				null,
+				'https://wordpress.com'
+			);
+
+			chaiExpect( customizerUrl ).to.equal(
+				`/customize/example.com?return=${ encodeURIComponent( 'https://wordpress.com' ) }`
+			);
+		} );
+
 		test( 'should return null if admin URL for Jetpack site is not known', () => {
 			const customizerUrl = getCustomizerUrl(
 				{

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -3221,11 +3221,13 @@ describe( 'selectors', () => {
 				},
 				77203199,
 				null,
-				'https://wordpress.com'
+				'/things/are/going?to=be&okay=true'
 			);
 
 			chaiExpect( customizerUrl ).to.equal(
-				`/customize/example.com?return=${ encodeURIComponent( 'https://wordpress.com' ) }`
+				`/customize/example.com?return=${ encodeURIComponent(
+					'/things/are/going?to=be&okay=true'
+				) }`
 			);
 		} );
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

* The PR uses the `return` query parameter value to override the customizer back button.
* It validates the `return` query parameter against the API to ensure it's a valid URL to redirect to.
* Updates the fallback return path for the Customizer to be the customer home (if available).

Use case: https://github.com/Automattic/wp-calypso/pull/41854#issuecomment-632118363

## Testing instructions

Fire up the branch

Head to the editor and preview a post in the preview iframe

Click on Edit Header

<img width="656" alt="Screen Shot 2020-05-22 at 9 25 44 am" src="https://user-images.githubusercontent.com/6458278/82615653-49cf0280-9c0e-11ea-96ec-5da3db115ed7.png">

Land on the customizer

Ensure that clicking the close button takes you back to the editor

<img width="455" alt="Screen Shot 2020-05-22 at 9 24 52 am" src="https://user-images.githubusercontent.com/6458278/82615661-4f2c4d00-9c0e-11ea-8bd8-1c770a1ea172.png">
