### PR TITLE
Recurring Payments: Split out edit modal.

### DIFF
--- a/client/my-sites/earn/memberships/add-edit-plan-modal.jsx
+++ b/client/my-sites/earn/memberships/add-edit-plan-modal.jsx
@@ -27,6 +27,52 @@ import SectionNavTabs from 'components/section-nav/tabs';
 import SectionNavTabItem from 'components/section-nav/item';
 
 /**
+ * @typedef {[string, number] CurrencyMinimum
+ *
+ *
+ * Stripe Currencies also supported by WordPress.com with minimum transaction amounts.
+ *
+ * https://stripe.com/docs/currencies#minimum-and-maximum-charge-amounts
+ *
+ * @type { [currency: string]: number }
+ */
+const MINIMUM_CURRENCY_AMOUNT = {
+	USD: 0.5,
+	AUD: 0.5,
+	BRL: 0.5,
+	CAD: 0.5,
+	CHF: 0.5,
+	DKK: 2.5,
+	EUR: 0.5,
+	GBP: 0.3,
+	HKD: 4.0,
+	INR: 0.5,
+	JPY: 50,
+	MXN: 10,
+	NOK: 3.0,
+	NZD: 0.5,
+	PLN: 2.0,
+	SEK: 3.0,
+	SGD: 0.5,
+};
+
+/**
+ * @type Array<{ code: string }>
+ */
+const currencyList = Object.keys( MINIMUM_CURRENCY_AMOUNT ).map( ( code ) => ( { code } ) );
+
+/**
+ * Return the minimum transaction amount for a currency.
+ *
+ *
+ * @param {string} currency - Currency.
+ * @returns {number} Minimum transaction amount for given currency.
+ */
+function minimumCurrencyTransactionAmount( currency ) {
+	return MINIMUM_CURRENCY_AMOUNT[ currency ];
+}
+
+/**
  * @type {number}
  */
 const MAX_LENGTH_CUSTOM_CONFIRMATION_EMAIL_MESSAGE = 2000;
@@ -52,13 +98,7 @@ const TAB_EMAIL = 'email';
  */
 const TABS = [ TAB_GENERAL, TAB_EMAIL ];
 
-const RecurringPaymentsPlanAddEditModal = ( {
-	currencyList,
-	isVisible,
-	minimumCurrencyTransactionAmount,
-	onClose,
-	product,
-} ) => {
+const RecurringPaymentsPlanAddEditModal = ( { isVisible, onClose, product } ) => {
 	const translate = useTranslate();
 	const initialPrice = product
 		? { currency: product.currency, value: product.price }

--- a/client/my-sites/earn/memberships/add-edit-plan-modal.jsx
+++ b/client/my-sites/earn/memberships/add-edit-plan-modal.jsx
@@ -1,0 +1,164 @@
+/**
+ * External dependencies
+ */
+
+import React, { useState } from 'react';
+import { useTranslate } from 'i18n-calypso';
+import Notice from 'components/notice';
+import formatCurrency from '@automattic/format-currency';
+/**
+ * Internal dependencies
+ */
+import { Dialog } from '@automattic/components';
+import FormInputValidation from 'components/forms/form-input-validation';
+import FormTextInput from 'components/forms/form-text-input';
+import FormSectionHeading from 'components/forms/form-section-heading';
+import FormSelect from 'components/forms/form-select';
+import FormCurrencyInput from 'components/forms/form-currency-input';
+import FormLabel from 'components/forms/form-label';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormToggle from 'components/forms/form-toggle';
+
+const RecurringPaymentsPlanAddEditModal = ( {
+	currencyList,
+	isVisible,
+	minimumCurrencyTransactionAmount,
+	onClose,
+	product,
+} ) => {
+	const translate = useTranslate();
+	const initialPrice = product
+		? { currency: product.currency, value: product.price }
+		: { currency: 'USD', value: '' };
+	const [ editedPrice, setEditedPrice ] = useState( initialPrice );
+	const [ editedProductName, setEditedProductName ] = useState( product?.title ?? '' );
+	const [ editedPayWhatYouWant, setEditedPayWhatYouWant ] = useState(
+		product?.buyer_can_change_amount ?? false
+	);
+	const [ editedMultiplePerUser, setEditedMultiplePerUser ] = useState( false );
+	const [ editedSchedule, setEditedSchedule ] = useState( '1 month' );
+	const [ focusedName, setFocusedName ] = useState( false );
+
+	const isValidCurrencyAmount = ( currency, price ) =>
+		price >= minimumCurrencyTransactionAmount( currency );
+
+	const isFormValid = ( field ) => {
+		if (
+			( field === 'price' || ! field ) &&
+			! isValidCurrencyAmount( editedPrice.currency, editedPrice.value )
+		) {
+			return false;
+		}
+		if ( ( field === 'name' || ! field ) && editedProductName.length === 0 ) {
+			return false;
+		}
+		return true;
+	};
+
+	const handleCurrencyChange = ( event ) => {
+		const { value: currency } = event.currentTarget;
+		setEditedPrice( { ...editedPrice, currency } );
+	};
+	const handlePriceChange = ( event ) => {
+		const value = parseFloat( event.currentTarget.value );
+		setEditedPrice( { ...editedPrice, value } );
+	};
+	const handlePayWhatYouWant = ( newValue ) => setEditedPayWhatYouWant( newValue );
+	const handleMultiplePerUser = ( newValue ) => setEditedMultiplePerUser( newValue );
+	const onNameChange = ( event ) => setEditedProductName( event.target.value );
+	const onSelectSchedule = ( event ) => setEditedSchedule( event.target.value );
+
+	return (
+		<Dialog
+			isVisible={ isVisible }
+			onClose={ onClose }
+			buttons={ [
+				{
+					label: translate( 'Cancel' ),
+					action: 'cancel',
+				},
+				{
+					label: product ? translate( 'Edit' ) : translate( 'Add' ),
+					action: 'submit',
+					disabled: ! isFormValid(),
+				},
+			] }
+		>
+			<FormSectionHeading>
+				{ product ? translate( 'Edit' ) : translate( 'Add New Recurring Payment plan' ) }
+			</FormSectionHeading>
+			<p>
+				{ product
+					? translate( 'Edit your existing Recurring Payments plan.' )
+					: translate(
+							'Each amount you add will create a separate Recurring Payments plan. You can create multiple plans.'
+					  ) }
+			</p>
+			<FormFieldset>
+				<FormLabel htmlFor="currency">{ translate( 'Select price' ) }</FormLabel>
+				{ product && (
+					<Notice
+						text={ translate(
+							'Updating the price will not affect existing subscribers, who will pay what they were originally charged.'
+						) }
+						showDismiss={ false }
+					/>
+				) }
+				<FormCurrencyInput
+					name="currency"
+					id="currency"
+					value={ isNaN( editedPrice.value ) ? '' : editedPrice.value }
+					onChange={ handlePriceChange }
+					currencySymbolPrefix={ editedPrice.currency }
+					onCurrencyChange={ handleCurrencyChange }
+					currencyList={ currencyList }
+					placeholder="0.00"
+				/>
+				{ ! isFormValid( 'price' ) && (
+					<FormInputValidation
+						isError
+						text={ translate( 'Please enter a price higher than %s', {
+							args: [
+								formatCurrency(
+									minimumCurrencyTransactionAmount( editedPrice.currency ),
+									editedPrice.currency
+								),
+							],
+						} ) }
+					/>
+				) }
+			</FormFieldset>
+			<FormFieldset>
+				<FormLabel htmlFor="renewal_schedule">{ translate( 'Select renewal schedule' ) }</FormLabel>
+				<FormSelect id="renewal_schedule" value={ editedSchedule } onChange={ onSelectSchedule }>
+					<option value="1 month">{ translate( 'Monthly' ) }</option>
+					<option value="1 year">{ translate( 'Yearly' ) }</option>
+				</FormSelect>
+			</FormFieldset>
+			<FormFieldset>
+				<FormLabel htmlFor="title">{ translate( 'Please describe your subscription' ) }</FormLabel>
+				<FormTextInput
+					id="title"
+					value={ editedProductName }
+					onChange={ onNameChange }
+					onBlur={ () => setFocusedName( true ) }
+				/>
+				{ ! isFormValid( 'name' ) && focusedName && (
+					<FormInputValidation isError text={ translate( 'Please input a name.' ) } />
+				) }
+			</FormFieldset>
+			<FormFieldset>
+				<FormToggle onChange={ handlePayWhatYouWant } checked={ editedPayWhatYouWant }>
+					{ translate( 'Enable customers to pick their own amount ("Pay what you want").' ) }
+				</FormToggle>
+			</FormFieldset>
+			<FormFieldset>
+				<FormToggle onChange={ handleMultiplePerUser } checked={ editedMultiplePerUser }>
+					{ translate( 'Allow the same customer to sign up multiple times to the same plan.' ) }
+				</FormToggle>
+			</FormFieldset>
+		</Dialog>
+	);
+};
+
+export default RecurringPaymentsPlanAddEditModal;

--- a/client/my-sites/earn/memberships/add-edit-plan-modal.jsx
+++ b/client/my-sites/earn/memberships/add-edit-plan-modal.jsx
@@ -6,9 +6,12 @@ import React, { useState } from 'react';
 import { useTranslate } from 'i18n-calypso';
 import Notice from 'components/notice';
 import formatCurrency from '@automattic/format-currency';
+import classnames from 'classnames';
+
 /**
  * Internal dependencies
  */
+import CountedTextArea from 'components/forms/counted-textarea';
 import { Dialog } from '@automattic/components';
 import FormInputValidation from 'components/forms/form-input-validation';
 import FormTextInput from 'components/forms/form-text-input';
@@ -18,6 +21,36 @@ import FormCurrencyInput from 'components/forms/form-currency-input';
 import FormLabel from 'components/forms/form-label';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormToggle from 'components/forms/form-toggle';
+import InlineSupportLink from 'components/inline-support-link';
+import SectionNav from 'components/section-nav';
+import SectionNavTabs from 'components/section-nav/tabs';
+import SectionNavTabItem from 'components/section-nav/item';
+
+/**
+ * @type {number}
+ */
+const MAX_LENGTH_CUSTOM_CONFIRMATION_EMAIL_MESSAGE = 2000;
+
+/**
+ * Identifier for the General tab.
+ *
+ * @type {string}
+ */
+const TAB_GENERAL = 'general';
+
+/**
+ * Identifier for the Email tab.
+ *
+ * @type {string}
+ */
+const TAB_EMAIL = 'email';
+
+/**
+ * List of tab identifiers.
+ *
+ * @type {string[]}
+ */
+const TABS = [ TAB_GENERAL, TAB_EMAIL ];
 
 const RecurringPaymentsPlanAddEditModal = ( {
 	currencyList,
@@ -29,15 +62,29 @@ const RecurringPaymentsPlanAddEditModal = ( {
 	const translate = useTranslate();
 	const initialPrice = product
 		? { currency: product.currency, value: product.price }
-		: { currency: 'USD', value: '' };
+		: { currency: 'USD', value: minimumCurrencyTransactionAmount( 'USD' ) };
+	const [ currentDialogTab, setCurrentDialogTab ] = useState( TAB_GENERAL );
+	const [ editedCustomConfirmationMessage, setEditedCustomConfirmationMessage ] = useState(
+		product?.welcome_email_content ?? ''
+	);
 	const [ editedPrice, setEditedPrice ] = useState( initialPrice );
 	const [ editedProductName, setEditedProductName ] = useState( product?.title ?? '' );
 	const [ editedPayWhatYouWant, setEditedPayWhatYouWant ] = useState(
 		product?.buyer_can_change_amount ?? false
 	);
 	const [ editedMultiplePerUser, setEditedMultiplePerUser ] = useState( false );
+	const [ editedPostsEmail, setEditedPostsEmail ] = useState( false );
 	const [ editedSchedule, setEditedSchedule ] = useState( '1 month' );
 	const [ focusedName, setFocusedName ] = useState( false );
+
+	const getTabName = ( tab ) => {
+		switch ( tab ) {
+			case TAB_GENERAL:
+				return translate( 'General' );
+			case TAB_EMAIL:
+				return translate( 'Email' );
+		}
+	};
 
 	const isValidCurrencyAmount = ( currency, price ) =>
 		price >= minimumCurrencyTransactionAmount( currency );
@@ -50,6 +97,13 @@ const RecurringPaymentsPlanAddEditModal = ( {
 			return false;
 		}
 		if ( ( field === 'name' || ! field ) && editedProductName.length === 0 ) {
+			return false;
+		}
+		if (
+			! field &&
+			editedCustomConfirmationMessage &&
+			editedCustomConfirmationMessage.length > MAX_LENGTH_CUSTOM_CONFIRMATION_EMAIL_MESSAGE
+		) {
 			return false;
 		}
 		return true;
@@ -68,6 +122,133 @@ const RecurringPaymentsPlanAddEditModal = ( {
 	const onNameChange = ( event ) => setEditedProductName( event.target.value );
 	const onSelectSchedule = ( event ) => setEditedSchedule( event.target.value );
 
+	const renderGeneralTab = () => {
+		return (
+			<>
+				<p>
+					{ product
+						? translate( 'Edit your existing Recurring Payments plan.' )
+						: translate(
+								'Each amount you add will create a separate Recurring Payments plan. You can create multiple plans.'
+						  ) }
+				</p>
+				<FormFieldset>
+					<FormLabel htmlFor="currency">{ translate( 'Select price' ) }</FormLabel>
+					{ product && (
+						<Notice
+							text={ translate(
+								'Updating the price will not affect existing subscribers, who will pay what they were originally charged.'
+							) }
+							showDismiss={ false }
+						/>
+					) }
+					<FormCurrencyInput
+						name="currency"
+						id="currency"
+						value={ isNaN( editedPrice.value ) ? '' : editedPrice.value }
+						onChange={ handlePriceChange }
+						currencySymbolPrefix={ editedPrice.currency }
+						onCurrencyChange={ handleCurrencyChange }
+						currencyList={ currencyList }
+						placeholder="0.00"
+					/>
+					{ ! isFormValid( 'price' ) && (
+						<FormInputValidation
+							isError
+							text={ translate( 'Please enter a price higher than %s', {
+								args: [
+									formatCurrency(
+										minimumCurrencyTransactionAmount( editedPrice.currency ),
+										editedPrice.currency
+									),
+								],
+							} ) }
+						/>
+					) }
+				</FormFieldset>
+				<FormFieldset>
+					<FormLabel htmlFor="renewal_schedule">
+						{ translate( 'Select renewal schedule' ) }
+					</FormLabel>
+					<FormSelect id="renewal_schedule" value={ editedSchedule } onChange={ onSelectSchedule }>
+						<option value="1 month">{ translate( 'Monthly' ) }</option>
+						<option value="1 year">{ translate( 'Yearly' ) }</option>
+					</FormSelect>
+				</FormFieldset>
+				<FormFieldset>
+					<FormLabel htmlFor="title">
+						{ translate( 'Please describe your subscription' ) }
+					</FormLabel>
+					<FormTextInput
+						id="title"
+						value={ editedProductName }
+						onChange={ onNameChange }
+						onBlur={ () => setFocusedName( true ) }
+					/>
+					{ ! isFormValid( 'name' ) && focusedName && (
+						<FormInputValidation isError text={ translate( 'Please input a name.' ) } />
+					) }
+				</FormFieldset>
+				<FormFieldset>
+					<FormToggle onChange={ handlePayWhatYouWant } checked={ editedPayWhatYouWant }>
+						{ translate( 'Enable customers to pick their own amount ("Pay what you want").' ) }
+					</FormToggle>
+				</FormFieldset>
+				<FormFieldset>
+					<FormToggle onChange={ handleMultiplePerUser } checked={ editedMultiplePerUser }>
+						{ translate( 'Allow the same customer to sign up multiple times to the same plan.' ) }
+					</FormToggle>
+				</FormFieldset>
+			</>
+		);
+	};
+
+	const renderEmailTab = () => {
+		return (
+			<>
+				<FormFieldset>
+					<h6 className="memberships__dialog-form-header">{ translate( 'Posts via email' ) }</h6>
+					<p>
+						{ translate(
+							'Allow members of this recurring payment plan to opt into receiving new posts via email.'
+						) }{ ' ' }
+						<InlineSupportLink
+							supportPostId={ 154624 }
+							supportLink="https://wordpress.com/support/wordpress-editor/blocks/recurring-payments-button/" // TODO: Link to specific section once article is update
+							showIcon={ false }
+							text={ translate( 'Learn more.' ) }
+						/>
+					</p>
+					<FormToggle
+						onChange={ ( newValue ) => setEditedPostsEmail( newValue ) }
+						checked={ editedPostsEmail }
+					>
+						{ translate(
+							'Email newly published posts to members of this recurring payment plan who have opted in.'
+						) }
+					</FormToggle>
+				</FormFieldset>
+				<FormFieldset>
+					<h6 className="memberships__dialog-form-header">
+						{ translate( 'Custom confirmation message' ) }
+					</h6>
+					<p>
+						{ translate(
+							'Add a custom message to the confirmation email that is sent out for this recurring payment plan.'
+						) }
+					</p>
+					<CountedTextArea
+						value={ editedCustomConfirmationMessage }
+						onChange={ ( event ) => setEditedCustomConfirmationMessage( event.target.value ) }
+						acceptableLength={ MAX_LENGTH_CUSTOM_CONFIRMATION_EMAIL_MESSAGE }
+						showRemainingCharacters={ true }
+						placeholder={ translate( 'Thank you for subscribing!' ) }
+					/>
+				</FormFieldset>
+			</>
+		);
+	};
+
 	return (
 		<Dialog
 			isVisible={ isVisible }
@@ -81,82 +262,47 @@ const RecurringPaymentsPlanAddEditModal = ( {
 					label: product ? translate( 'Edit' ) : translate( 'Add' ),
 					action: 'submit',
 					disabled: ! isFormValid(),
+					isPrimary: true,
 				},
 			] }
 		>
 			<FormSectionHeading>
-				{ product ? translate( 'Edit' ) : translate( 'Add New Recurring Payment plan' ) }
-			</FormSectionHeading>
-			<p>
 				{ product
-					? translate( 'Edit your existing Recurring Payments plan.' )
-					: translate(
-							'Each amount you add will create a separate Recurring Payments plan. You can create multiple plans.'
-					  ) }
-			</p>
-			<FormFieldset>
-				<FormLabel htmlFor="currency">{ translate( 'Select price' ) }</FormLabel>
-				{ product && (
-					<Notice
-						text={ translate(
-							'Updating the price will not affect existing subscribers, who will pay what they were originally charged.'
-						) }
-						showDismiss={ false }
-					/>
-				) }
-				<FormCurrencyInput
-					name="currency"
-					id="currency"
-					value={ isNaN( editedPrice.value ) ? '' : editedPrice.value }
-					onChange={ handlePriceChange }
-					currencySymbolPrefix={ editedPrice.currency }
-					onCurrencyChange={ handleCurrencyChange }
-					currencyList={ currencyList }
-					placeholder="0.00"
-				/>
-				{ ! isFormValid( 'price' ) && (
-					<FormInputValidation
-						isError
-						text={ translate( 'Please enter a price higher than %s', {
-							args: [
-								formatCurrency(
-									minimumCurrencyTransactionAmount( editedPrice.currency ),
-									editedPrice.currency
-								),
-							],
-						} ) }
-					/>
-				) }
-			</FormFieldset>
-			<FormFieldset>
-				<FormLabel htmlFor="renewal_schedule">{ translate( 'Select renewal schedule' ) }</FormLabel>
-				<FormSelect id="renewal_schedule" value={ editedSchedule } onChange={ onSelectSchedule }>
-					<option value="1 month">{ translate( 'Monthly' ) }</option>
-					<option value="1 year">{ translate( 'Yearly' ) }</option>
-				</FormSelect>
-			</FormFieldset>
-			<FormFieldset>
-				<FormLabel htmlFor="title">{ translate( 'Please describe your subscription' ) }</FormLabel>
-				<FormTextInput
-					id="title"
-					value={ editedProductName }
-					onChange={ onNameChange }
-					onBlur={ () => setFocusedName( true ) }
-				/>
-				{ ! isFormValid( 'name' ) && focusedName && (
-					<FormInputValidation isError text={ translate( 'Please input a name.' ) } />
-				) }
-			</FormFieldset>
-			<FormFieldset>
-				<FormToggle onChange={ handlePayWhatYouWant } checked={ editedPayWhatYouWant }>
-					{ translate( 'Enable customers to pick their own amount ("Pay what you want").' ) }
-				</FormToggle>
-			</FormFieldset>
-			<FormFieldset>
-				<FormToggle onChange={ handleMultiplePerUser } checked={ editedMultiplePerUser }>
-					{ translate( 'Allow the same customer to sign up multiple times to the same plan.' ) }
-				</FormToggle>
-			</FormFieldset>
+					? translate( 'Edit Recurring Payment plan' )
+					: translate( 'Add new Recurring Payment plan' ) }
+			</FormSectionHeading>
+			<SectionNav
+				className="memberships__dialog-nav"
+				selectedText={ getTabName( currentDialogTab ) }
+			>
+				<SectionNavTabs>
+					{ TABS.map( ( tab ) => (
+						<SectionNavTabItem
+							key={ tab }
+							selected={ currentDialogTab === tab }
+							onClick={ () => setCurrentDialogTab( tab ) }
+						>
+							{ getTabName( tab ) }
+						</SectionNavTabItem>
+					) ) }
+				</SectionNavTabs>
+			</SectionNav>
+			<div className="memberships__dialog-sections">
+				<div
+					className={ classnames( 'memberships__dialog-section', {
+						'is-visible': currentDialogTab === TAB_GENERAL,
+					} ) }
+				>
+					{ renderGeneralTab() }
+				</div>
+				<div
+					className={ classnames( 'memberships__dialog-section', {
+						'is-visible': currentDialogTab === TAB_EMAIL,
+					} ) }
+				>
+					{ renderEmailTab() }
+				</div>
+			</div>
 		</Dialog>
 	);
 };

--- a/client/my-sites/earn/memberships/add-edit-plan-modal.jsx
+++ b/client/my-sites/earn/memberships/add-edit-plan-modal.jsx
@@ -101,7 +101,13 @@ const TAB_EMAIL = 'email';
  */
 const TABS = [ TAB_GENERAL, TAB_EMAIL ];
 
-const RecurringPaymentsPlanAddEditModal = ( { closeDialog, product, siteId } ) => {
+const RecurringPaymentsPlanAddEditModal = ( {
+	addProduct,
+	closeDialog,
+	product,
+	siteId,
+	updateProduct,
+} ) => {
 	const translate = useTranslate();
 	const [ currentDialogTab, setCurrentDialogTab ] = useState( TAB_GENERAL );
 	const [ editedCustomConfirmationMessage, setEditedCustomConfirmationMessage ] = useState(
@@ -171,7 +177,7 @@ const RecurringPaymentsPlanAddEditModal = ( { closeDialog, product, siteId } ) =
 
 	const onClose = ( reason ) => {
 		if ( reason === 'submit' && ! product ) {
-			requestAddProduct(
+			addProduct(
 				siteId,
 				{
 					currency: editedPrice.currency,
@@ -186,7 +192,7 @@ const RecurringPaymentsPlanAddEditModal = ( { closeDialog, product, siteId } ) =
 				translate( 'Added "%s" product.', { args: editedProductName } )
 			);
 		} else if ( reason === 'submit' && product ) {
-			requestUpdateProduct(
+			updateProduct(
 				siteId,
 				{
 					ID: product.ID,
@@ -394,5 +400,5 @@ export default connect(
 	( state ) => ( {
 		siteId: getSelectedSiteId( state ),
 	} ),
-	{ requestAddProduct, requestUpdateProduct }
+	{ addProduct: requestAddProduct, updateProduct: requestUpdateProduct }
 )( RecurringPaymentsPlanAddEditModal );

--- a/client/my-sites/earn/memberships/add-edit-plan-modal.jsx
+++ b/client/my-sites/earn/memberships/add-edit-plan-modal.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { connect } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
 import Notice from 'components/notice';
@@ -101,31 +101,28 @@ const TAB_EMAIL = 'email';
  */
 const TABS = [ TAB_GENERAL, TAB_EMAIL ];
 
-const RecurringPaymentsPlanAddEditModal = ( { closeDialog, isVisible, product, siteId } ) => {
+const RecurringPaymentsPlanAddEditModal = ( { closeDialog, product, siteId } ) => {
 	const translate = useTranslate();
 	const [ currentDialogTab, setCurrentDialogTab ] = useState( TAB_GENERAL );
-	const [ editedCustomConfirmationMessage, setEditedCustomConfirmationMessage ] = useState( '' );
-	const [ editedMultiplePerUser, setEditedMultiplePerUser ] = useState( false );
-	const [ editedPayWhatYouWant, setEditedPayWhatYouWant ] = useState( false );
+	const [ editedCustomConfirmationMessage, setEditedCustomConfirmationMessage ] = useState(
+		product?.welcome_email_content ?? ''
+	);
+	const [ editedMultiplePerUser, setEditedMultiplePerUser ] = useState(
+		product?.multiple_per_user ?? false
+	);
+	const [ editedPayWhatYouWant, setEditedPayWhatYouWant ] = useState(
+		product?.buyer_can_change_amount ?? false
+	);
 	const [ editedPrice, setEditedPrice ] = useState( {
-		currency: 'USD',
-		value: minimumCurrencyTransactionAmount( 'USD' ),
+		currency: product?.currency ?? 'USD',
+		value: product?.price ?? minimumCurrencyTransactionAmount( 'USD' ),
 	} );
-	const [ editedProductName, setEditedProductName ] = useState( '' );
-	const [ editedPostsEmail, setEditedPostsEmail ] = useState( false );
-	const [ editedSchedule, setEditedSchedule ] = useState( '1 month' );
+	const [ editedProductName, setEditedProductName ] = useState( product?.title ?? '' );
+	const [ editedPostsEmail, setEditedPostsEmail ] = useState(
+		product?.subscribe_as_site_subscriber ?? false
+	);
+	const [ editedSchedule, setEditedSchedule ] = useState( product?.renewal_schedule ?? '1 month' );
 	const [ focusedName, setFocusedName ] = useState( false );
-
-	useEffect( () => {
-		if ( product ) {
-			setEditedPrice( { currency: product.currency, value: product.price } );
-			setEditedProductName( product.title );
-			setEditedPayWhatYouWant( product.buyer_can_change_amount );
-			setEditedSchedule( product.renewal_schedule );
-			setEditedCustomConfirmationMessage( product.welcome_email_content );
-			setEditedMultiplePerUser( product.multiple_per_user );
-		}
-	}, [ product ] );
 
 	const getTabName = ( tab ) => {
 		switch ( tab ) {
@@ -337,7 +334,7 @@ const RecurringPaymentsPlanAddEditModal = ( { closeDialog, isVisible, product, s
 
 	return (
 		<Dialog
-			isVisible={ isVisible }
+			isVisible={ true }
 			onClose={ onClose }
 			buttons={ [
 				{
@@ -345,7 +342,7 @@ const RecurringPaymentsPlanAddEditModal = ( { closeDialog, isVisible, product, s
 					action: 'cancel',
 				},
 				{
-					label: product ? translate( 'Edit' ) : translate( 'Add' ),
+					label: translate( 'Save' ),
 					action: 'submit',
 					disabled: ! isFormValid(),
 					isPrimary: true,

--- a/client/my-sites/earn/memberships/products.jsx
+++ b/client/my-sites/earn/memberships/products.jsx
@@ -28,41 +28,6 @@ import {
 } from 'state/memberships/product-list/actions';
 import RecurringPaymentsPlanAddEditModal from './add-edit-plan-modal';
 
-/**
- * @typedef {[string, number] CurrencyMinimum
- *
- *
- * Stripe Currencies also supported by WordPress.com with minimum transaction amounts.
- *
- * https://stripe.com/docs/currencies#minimum-and-maximum-charge-amounts
- *
- * @type { [currency: string]: number }
- */
-const MINIMUM_CURRENCY_AMOUNT = {
-	USD: 0.5,
-	AUD: 0.5,
-	BRL: 0.5,
-	CAD: 0.5,
-	CHF: 0.5,
-	DKK: 2.5,
-	EUR: 0.5,
-	GBP: 0.3,
-	HKD: 4.0,
-	INR: 0.5,
-	JPY: 50,
-	MXN: 10,
-	NOK: 3.0,
-	NZD: 0.5,
-	PLN: 2.0,
-	SEK: 3.0,
-	SGD: 0.5,
-};
-
-/**
- * @type Array<{ code: string }>
- */
-const currencyList = Object.keys( MINIMUM_CURRENCY_AMOUNT ).map( ( code ) => ( { code } ) );
-
 class MembershipsProductsSection extends Component {
 	constructor() {
 		super();
@@ -153,8 +118,6 @@ class MembershipsProductsSection extends Component {
 		return (
 			<RecurringPaymentsPlanAddEditModal
 				isVisible={ this.state.showDialog === 'addNewPlan' }
-				currencyList={ currencyList }
-				minimumCurrencyTransactionAmount={ minimumCurrencyTransactionAmount }
 				onClose={ this.onCloseDialog }
 				productId={ null }
 			/>
@@ -165,8 +128,6 @@ class MembershipsProductsSection extends Component {
 		return (
 			<RecurringPaymentsPlanAddEditModal
 				isVisible={ this.state.showDialog === 'editPlan' }
-				currencyList={ currencyList }
-				minimumCurrencyTransactionAmount={ minimumCurrencyTransactionAmount }
 				onClose={ this.onCloseDialog }
 				product={ this.state.product }
 			/>
@@ -236,17 +197,6 @@ class MembershipsProductsSection extends Component {
 			</div>
 		);
 	}
-}
-
-/**
- * Return the minimum transaction amount for a currency.
- *
- *
- * @param {string} currency - Currency.
- * @returns {number} Minimum transaction amount for given currency.
- */
-function minimumCurrencyTransactionAmount( currency ) {
-	return MINIMUM_CURRENCY_AMOUNT[ currency ];
 }
 
 export default connect(

--- a/client/my-sites/earn/memberships/products.jsx
+++ b/client/my-sites/earn/memberships/products.jsx
@@ -46,13 +46,10 @@ class MembershipsProductsSection extends Component {
 
 	openProductDialog = ( editedProductId ) => {
 		if ( editedProductId ) {
-			const product = this.props.products.filter( ( prod ) => prod.ID === editedProductId ).pop();
-			this.setState( {
-				showDialog: 'editPlan',
-				product,
-			} );
+			const product = this.props.products.find( ( prod ) => prod.ID === editedProductId );
+			this.setState( { showDialog: true, product } );
 		} else {
-			this.setState( { showDialog: 'addNewPlan' } );
+			this.setState( { showDialog: true, product: null } );
 		}
 	};
 
@@ -71,26 +68,6 @@ class MembershipsProductsSection extends Component {
 	};
 
 	closeDialog = () => this.setState( { showDialog: false } );
-
-	renderAddNewPlanDialog() {
-		return (
-			<RecurringPaymentsPlanAddEditModal
-				closeDialog={ this.closeDialog }
-				isVisible={ this.state.showDialog === 'addNewPlan' }
-				product={ null }
-			/>
-		);
-	}
-
-	renderEditPlanDialog() {
-		return (
-			<RecurringPaymentsPlanAddEditModal
-				closeDialog={ this.closeDialog }
-				isVisible={ this.state.showDialog === 'editPlan' }
-				product={ this.state.product }
-			/>
-		);
-	}
 
 	render() {
 		return (
@@ -117,8 +94,12 @@ class MembershipsProductsSection extends Component {
 						{ this.renderEllipsisMenu( product.ID ) }
 					</CompactCard>
 				) ) }
-				{ this.renderAddNewPlanDialog() }
-				{ this.renderEditPlanDialog() }
+				{ this.state.showDialog && (
+					<RecurringPaymentsPlanAddEditModal
+						closeDialog={ this.closeDialog }
+						product={ this.state.product }
+					/>
+				) }
 				<Dialog
 					isVisible={ !! this.state.deletedProductId }
 					buttons={ [

--- a/client/my-sites/earn/memberships/products.jsx
+++ b/client/my-sites/earn/memberships/products.jsx
@@ -21,21 +21,13 @@ import QueryMembershipProducts from 'components/data/query-memberships';
 import EllipsisMenu from 'components/ellipsis-menu';
 import PopoverMenuItem from 'components/popover/menu-item';
 import Gridicon from 'components/gridicon';
-import {
-	requestAddProduct,
-	requestUpdateProduct,
-	requestDeleteProduct,
-} from 'state/memberships/product-list/actions';
+import { requestDeleteProduct } from 'state/memberships/product-list/actions';
 import RecurringPaymentsPlanAddEditModal from './add-edit-plan-modal';
 
 class MembershipsProductsSection extends Component {
-	constructor() {
-		super();
-		this.onCloseDialog = this.onCloseDialog.bind( this );
-	}
 	state = {
 		showDialog: false,
-		product: {},
+		product: null,
 	};
 	renderEllipsisMenu( productId ) {
 		return (
@@ -51,42 +43,6 @@ class MembershipsProductsSection extends Component {
 			</EllipsisMenu>
 		);
 	}
-
-	onCloseDialog = ( reason ) => {
-		if ( reason === 'submit' && ! this.state.editedProductId ) {
-			this.props.requestAddProduct(
-				this.props.siteId,
-				{
-					currency: this.state.editedPrice.currency,
-					price: this.state.editedPrice.value,
-					title: this.state.editedProductName,
-					interval: this.state.editedSchedule,
-					buyer_can_change_amount: this.state.editedPayWhatYouWant,
-					multiple_per_user: this.state.editedMultiplePerUser,
-					welcome_email_content: this.state.editedCustomConfirmationMessage,
-					subscribe_as_site_subscriber: this.state.editedPostsEmail,
-				},
-				this.props.translate( 'Added "%s" product.', { args: this.state.editedProductName } )
-			);
-		} else if ( reason === 'submit' && this.state.editedProductId ) {
-			this.props.requestUpdateProduct(
-				this.props.siteId,
-				{
-					ID: this.state.editedProductId,
-					currency: this.state.editedPrice.currency,
-					price: this.state.editedPrice.value,
-					title: this.state.editedProductName,
-					interval: this.state.editedSchedule,
-					buyer_can_change_amount: this.state.editedPayWhatYouWant,
-					multiple_per_user: this.state.editedMultiplePerUser,
-					welcome_email_content: this.state.editedCustomConfirmationMessage,
-					subscribe_as_site_subscriber: this.state.editedPostsEmail,
-				},
-				this.props.translate( 'Updated "%s" product.', { args: this.state.editedProductName } )
-			);
-		}
-		this.setState( { showDialog: false, editedProductId: null } );
-	};
 
 	openProductDialog = ( editedProductId ) => {
 		if ( editedProductId ) {
@@ -114,12 +70,14 @@ class MembershipsProductsSection extends Component {
 		this.setState( { deletedProductId: null } );
 	};
 
+	closeDialog = () => this.setState( { showDialog: false } );
+
 	renderAddNewPlanDialog() {
 		return (
 			<RecurringPaymentsPlanAddEditModal
+				closeDialog={ this.closeDialog }
 				isVisible={ this.state.showDialog === 'addNewPlan' }
-				onClose={ this.onCloseDialog }
-				productId={ null }
+				product={ null }
 			/>
 		);
 	}
@@ -127,8 +85,8 @@ class MembershipsProductsSection extends Component {
 	renderEditPlanDialog() {
 		return (
 			<RecurringPaymentsPlanAddEditModal
+				closeDialog={ this.closeDialog }
 				isVisible={ this.state.showDialog === 'editPlan' }
-				onClose={ this.onCloseDialog }
 				product={ this.state.product }
 			/>
 		);
@@ -210,5 +168,5 @@ export default connect(
 			products: get( state, [ 'memberships', 'productList', 'items', siteId ], [] ),
 		};
 	},
-	{ requestAddProduct, requestUpdateProduct, requestDeleteProduct }
+	{ requestDeleteProduct }
 )( localize( MembershipsProductsSection ) );

--- a/client/my-sites/earn/memberships/products.jsx
+++ b/client/my-sites/earn/memberships/products.jsx
@@ -8,7 +8,6 @@ import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
 import formatCurrency from '@automattic/format-currency';
 import Notice from 'components/notice';
-import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -17,29 +16,17 @@ import './style.scss';
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import HeaderCake from 'components/header-cake';
 import SectionHeader from 'components/section-header';
-import SectionNav from 'components/section-nav';
-import SectionNavTabs from 'components/section-nav/tabs';
-import SectionNavTabItem from 'components/section-nav/item';
 import { Button, CompactCard, Dialog } from '@automattic/components';
 import QueryMembershipProducts from 'components/data/query-memberships';
 import EllipsisMenu from 'components/ellipsis-menu';
 import PopoverMenuItem from 'components/popover/menu-item';
 import Gridicon from 'components/gridicon';
-import FormInputValidation from 'components/forms/form-input-validation';
-import FormTextInput from 'components/forms/form-text-input';
-import FormSectionHeading from 'components/forms/form-section-heading';
-import FormSelect from 'components/forms/form-select';
-import FormCurrencyInput from 'components/forms/form-currency-input';
-import FormLabel from 'components/forms/form-label';
-import CountedTextarea from 'components/forms/counted-textarea';
-import FormFieldset from 'components/forms/form-fieldset';
-import FormToggle from 'components/forms/form-toggle';
-import InlineSupportLink from 'components/inline-support-link';
 import {
 	requestAddProduct,
 	requestUpdateProduct,
 	requestDeleteProduct,
 } from 'state/memberships/product-list/actions';
+import RecurringPaymentsPlanAddEditModal from './add-edit-plan-modal';
 
 /**
  * @typedef {[string, number] CurrencyMinimum
@@ -72,35 +59,9 @@ const MINIMUM_CURRENCY_AMOUNT = {
 };
 
 /**
- * @type {number}
- */
-const MAX_LENGTH_CUSTOM_CONFIRMATION_EMAIL_MESSAGE = 2000;
-
-/**
  * @type Array<{ code: string }>
  */
 const currencyList = Object.keys( MINIMUM_CURRENCY_AMOUNT ).map( ( code ) => ( { code } ) );
-
-/**
- * Identifier for the General tab.
- *
- * @type {string}
- */
-const TAB_GENERAL = 'general';
-
-/**
- * Identifier for the Email tab.
- *
- * @type {string}
- */
-const TAB_EMAIL = 'email';
-
-/**
- * List of tab identifiers.
- *
- * @type {string[]}
- */
-const TABS = [ TAB_GENERAL, TAB_EMAIL ];
 
 class MembershipsProductsSection extends Component {
 	constructor() {
@@ -109,17 +70,7 @@ class MembershipsProductsSection extends Component {
 	}
 	state = {
 		showDialog: false,
-		editedProductId: null,
-		deletedProductId: null,
-		editedProductName: '',
-		editedPayWhatYouWant: false,
-		editedMultiplePerUser: false,
-		editedPrice: { currency: 'USD', value: '' },
-		editedSchedule: '1 month',
-		editedPostsEmail: false,
-		editedCustomConfirmationMessage: '',
-		focusedName: false,
-		currentDialogTab: TAB_GENERAL,
+		product: {},
 	};
 	renderEllipsisMenu( productId ) {
 		return (
@@ -176,40 +127,14 @@ class MembershipsProductsSection extends Component {
 		if ( editedProductId ) {
 			const product = this.props.products.filter( ( prod ) => prod.ID === editedProductId ).pop();
 			this.setState( {
-				showDialog: true,
-				currentDialogTab: TAB_GENERAL,
-				editedProductId,
-				editedProductName: product.title,
-				editedPrice: {
-					currency: product.currency,
-					value: product.price,
-				},
-				editedSchedule: product.renewal_schedule,
-				editedPayWhatYouWant: product.buyer_can_change_amount,
-				editedMultiplePerUser: !! product.multiple_per_user,
-				focusedName: false,
-				editedCustomConfirmationMessage: product.welcome_email_content || '',
-				editedPostsEmail: product.subscribe_as_site_subscriber,
+				showDialog: 'editPlan',
+				product,
 			} );
 		} else {
-			this.setState( {
-				showDialog: true,
-				currentDialogTab: TAB_GENERAL,
-				editedProductId,
-				editedProductName: '',
-				editedPrice: {
-					currency: 'USD',
-					value: minimumCurrencyTransactionAmount( 'USD' ),
-				},
-				editedSchedule: '1 month',
-				editedPayWhatYouWant: false,
-				editedMultiplePerUser: false,
-				focusedName: false,
-				editedCustomConfirmationMessage: '',
-				editedPostsEmail: false,
-			} );
+			this.setState( { showDialog: 'addNewPlan' } );
 		}
 	};
+
 	onCloseDeleteProduct = ( reason ) => {
 		if ( reason === 'delete' ) {
 			const product = this.props.products
@@ -223,257 +148,28 @@ class MembershipsProductsSection extends Component {
 		}
 		this.setState( { deletedProductId: null } );
 	};
-	handleCurrencyChange = ( event ) => {
-		const { value: currency } = event.currentTarget;
 
-		this.setState( ( state ) => ( {
-			editedPrice: { ...state.editedPrice, currency },
-		} ) );
-	};
-	handlePriceChange = ( event ) => {
-		const value = parseFloat( event.currentTarget.value );
-
-		this.setState( ( state ) => ( {
-			editedPrice: { ...state.editedPrice, value },
-		} ) );
-	};
-	handlePayWhatYouWant = ( newValue ) => this.setState( { editedPayWhatYouWant: newValue } );
-	handleMultiplePerUser = ( newValue ) => this.setState( { editedMultiplePerUser: newValue } );
-
-	onNameChange = ( event ) => this.setState( { editedProductName: event.target.value } );
-	onSelectSchedule = ( event ) => this.setState( { editedSchedule: event.target.value } );
-	isFormValid = ( field ) => {
-		if (
-			( field === 'price' || ! field ) &&
-			! isValidCurrencyAmount( this.state.editedPrice.currency, this.state.editedPrice.value )
-		) {
-			return false;
-		}
-		if ( ( field === 'name' || ! field ) && this.state.editedProductName.length === 0 ) {
-			return false;
-		}
-		if (
-			! field &&
-			this.state.editedCustomConfirmationMessage &&
-			this.state.editedCustomConfirmationMessage.length >
-				MAX_LENGTH_CUSTOM_CONFIRMATION_EMAIL_MESSAGE
-		) {
-			return false;
-		}
-		return true;
-	};
-
-	getTabName( tab ) {
-		const { translate } = this.props;
-		switch ( tab ) {
-			case TAB_GENERAL:
-				return translate( 'General' );
-			case TAB_EMAIL:
-				return translate( 'Email' );
-		}
-	}
-
-	renderGeneralTab() {
+	renderAddNewPlanDialog() {
 		return (
-			<>
-				<p>
-					{ this.state.editedProductId &&
-						this.props.translate( 'Edit your existing Recurring Payments plan.' ) }
-					{ ! this.state.editedProductId &&
-						this.props.translate(
-							'Each amount you add will create a separate Recurring Payments plan. You can create multiple plans.'
-						) }
-				</p>
-				<FormFieldset>
-					<FormLabel htmlFor="currency">{ this.props.translate( 'Select price' ) }</FormLabel>
-					{ this.state.editedProductId && (
-						<Notice
-							text={ this.props.translate(
-								'Updating the price will not affect existing subscribers, who will pay what they were originally charged.'
-							) }
-							showDismiss={ false }
-						/>
-					) }
-					<FormCurrencyInput
-						name="currency"
-						id="currency"
-						value={ isNaN( this.state.editedPrice.value ) ? '' : this.state.editedPrice.value }
-						onChange={ this.handlePriceChange }
-						currencySymbolPrefix={ this.state.editedPrice.currency }
-						onCurrencyChange={ this.handleCurrencyChange }
-						currencyList={ currencyList }
-						placeholder="0.00"
-					/>
-					{ ! this.isFormValid( 'price' ) && (
-						<FormInputValidation
-							isError
-							text={ this.props.translate( 'Please enter a price higher than %s', {
-								args: [
-									formatCurrency(
-										minimumCurrencyTransactionAmount( this.state.editedPrice.currency ),
-										this.state.editedPrice.currency
-									),
-								],
-							} ) }
-						/>
-					) }
-				</FormFieldset>
-				<FormFieldset>
-					<FormLabel htmlFor="renewal_schedule">
-						{ this.props.translate( 'Select renewal schedule' ) }
-					</FormLabel>
-					<FormSelect
-						id="renewal_schedule"
-						value={ this.state.editedSchedule }
-						onChange={ this.onSelectSchedule }
-					>
-						<option value="1 month">{ this.props.translate( 'Monthly' ) }</option>
-						<option value="1 year">{ this.props.translate( 'Yearly' ) }</option>
-					</FormSelect>
-				</FormFieldset>
-				<FormFieldset>
-					<FormLabel htmlFor="title">
-						{ this.props.translate( 'Please describe your subscription' ) }
-					</FormLabel>
-					<FormTextInput
-						id="title"
-						value={ this.state.editedProductName }
-						onChange={ this.onNameChange }
-						onBlur={ () => this.setState( { focusedName: true } ) }
-					/>
-					{ ! this.isFormValid( 'name' ) && this.state.focusedName && (
-						<FormInputValidation isError text={ this.props.translate( 'Please input a name.' ) } />
-					) }
-				</FormFieldset>
-				<FormFieldset>
-					<FormToggle
-						onChange={ this.handlePayWhatYouWant }
-						checked={ this.state.editedPayWhatYouWant }
-					>
-						{ this.props.translate(
-							'Enable customers to pick their own amount ("Pay what you want").'
-						) }
-					</FormToggle>
-				</FormFieldset>
-				<FormFieldset>
-					<FormToggle
-						onChange={ this.handleMultiplePerUser }
-						checked={ this.state.editedMultiplePerUser }
-					>
-						{ this.props.translate(
-							'Allow the same customer to sign up multiple times to the same plan.'
-						) }
-					</FormToggle>
-				</FormFieldset>
-			</>
-		);
-	}
-
-	renderEmailTab() {
-		const { translate } = this.props;
-		const { editedPostsEmail, editedCustomConfirmationMessage } = this.state;
-		return (
-			<>
-				<FormFieldset>
-					<h6 className="memberships__dialog-form-header">{ translate( 'Posts via email' ) }</h6>
-					<p>
-						{ translate(
-							'Allow members of this recurring payment plan to opt into receiving new posts via email.'
-						) }{ ' ' }
-						<InlineSupportLink
-							supportPostId={ 154624 }
-							supportLink="https://wordpress.com/support/wordpress-editor/blocks/recurring-payments-button/" // TODO: Link to specific section once article is update
-							showIcon={ false }
-							text={ translate( 'Learn more.' ) }
-						/>
-					</p>
-					<FormToggle
-						onChange={ ( newValue ) => this.setState( { editedPostsEmail: newValue } ) }
-						checked={ editedPostsEmail }
-					>
-						{ this.props.translate(
-							'Email newly published posts to members of this recurring payment plan who have opted in.'
-						) }
-					</FormToggle>
-				</FormFieldset>
-				<FormFieldset>
-					<h6 className="memberships__dialog-form-header">
-						{ translate( 'Custom confirmation message' ) }
-					</h6>
-					<p>
-						{ translate( 'Add a short message to the confirmation email sent to subscribers.' ) }
-					</p>
-					<CountedTextarea
-						value={ editedCustomConfirmationMessage }
-						onChange={ ( event ) =>
-							this.setState( { editedCustomConfirmationMessage: event.target.value } )
-						}
-						acceptableLength={ MAX_LENGTH_CUSTOM_CONFIRMATION_EMAIL_MESSAGE }
-						showRemainingCharacters={ true }
-						placeholder={ translate( 'Thank you for subscribing!' ) }
-					/>
-				</FormFieldset>
-			</>
-		);
-	}
-
-	renderEditDialog() {
-		return (
-			<Dialog
-				className="memberships__dialog"
-				isVisible={ this.state.showDialog }
+			<RecurringPaymentsPlanAddEditModal
+				isVisible={ this.state.showDialog === 'addNewPlan' }
+				currencyList={ currencyList }
+				minimumCurrencyTransactionAmount={ minimumCurrencyTransactionAmount }
 				onClose={ this.onCloseDialog }
-				buttons={ [
-					{
-						label: this.props.translate( 'Cancel' ),
-						action: 'cancel',
-					},
-					{
-						label: this.props.translate( 'Save' ),
-						action: 'submit',
-						disabled: ! this.isFormValid(),
-						isPrimary: true,
-					},
-				] }
-			>
-				<FormSectionHeading>
-					{ this.state.editedProductId && this.props.translate( 'Edit Recurring Payment plan' ) }
-					{ ! this.state.editedProductId &&
-						this.props.translate( 'Add New Recurring Payment plan' ) }
-				</FormSectionHeading>
-				<SectionNav
-					className="memberships__dialog-nav"
-					selectedText={ this.getTabName( this.state.currentDialogTab ) }
-				>
-					<SectionNavTabs>
-						{ TABS.map( ( tab ) => (
-							<SectionNavTabItem
-								key={ tab }
-								selected={ this.state.currentDialogTab === tab }
-								onClick={ () => this.setState( { currentDialogTab: tab } ) }
-							>
-								{ this.getTabName( tab ) }
-							</SectionNavTabItem>
-						) ) }
-					</SectionNavTabs>
-				</SectionNav>
-				<div className="memberships__dialog-sections">
-					<div
-						className={ classnames( 'memberships__dialog-section', {
-							'is-visible': this.state.currentDialogTab === TAB_GENERAL,
-						} ) }
-					>
-						{ this.renderGeneralTab() }
-					</div>
-					<div
-						className={ classnames( 'memberships__dialog-section', {
-							'is-visible': this.state.currentDialogTab === TAB_EMAIL,
-						} ) }
-					>
-						{ this.renderEmailTab() }
-					</div>
-				</div>
-			</Dialog>
+				productId={ null }
+			/>
+		);
+	}
+
+	renderEditPlanDialog() {
+		return (
+			<RecurringPaymentsPlanAddEditModal
+				isVisible={ this.state.showDialog === 'editPlan' }
+				currencyList={ currencyList }
+				minimumCurrencyTransactionAmount={ minimumCurrencyTransactionAmount }
+				onClose={ this.onCloseDialog }
+				product={ this.state.product }
+			/>
 		);
 	}
 
@@ -484,7 +180,6 @@ class MembershipsProductsSection extends Component {
 				<HeaderCake backHref={ '/earn/payments/' + this.props.siteSlug }>
 					{ this.props.translate( 'Recurring Payments plans' ) }
 				</HeaderCake>
-				{ this.renderEditDialog() }
 
 				<SectionHeader>
 					<Button primary compact onClick={ () => this.openProductDialog( null ) }>
@@ -503,6 +198,8 @@ class MembershipsProductsSection extends Component {
 						{ this.renderEllipsisMenu( product.ID ) }
 					</CompactCard>
 				) ) }
+				{ this.renderAddNewPlanDialog() }
+				{ this.renderEditPlanDialog() }
 				<Dialog
 					isVisible={ !! this.state.deletedProductId }
 					buttons={ [
@@ -550,17 +247,6 @@ class MembershipsProductsSection extends Component {
  */
 function minimumCurrencyTransactionAmount( currency ) {
 	return MINIMUM_CURRENCY_AMOUNT[ currency ];
-}
-
-/**
- * Validates that the given price is at least the minimum transaction amount for the given currency.
- *
- * @param {string} currency Currency of price.
- * @param {number} price Amount in currency.
- * @returns {boolean} True if the price is valid for the currency.
- */
-function isValidCurrencyAmount( currency, price ) {
-	return price >= minimumCurrencyTransactionAmount( currency );
 }
 
 export default connect(


### PR DESCRIPTION
The "Add new plan" and "Edit" actions for payments plans (at `/earn/payments-plans/:site`) are coupled together through state and sharing a dialog in `MembershipsProductsSection`. This causes the "Add new plan" dialog to be briefly visible when dismissing the edit version of the dialog. By splitting out the dialog and handling dialog openings individually, we should end up with simpler payments plans components, and better rendering of each modal dialog.

<img width="1470" alt="Screen Shot 2020-05-21 at 4 51 04 PM" src="https://user-images.githubusercontent.com/349751/82617150-0d56c480-9b84-11ea-9181-1fea5f2033e5.png">



#### Testing instructions

* Load this branch with a site that has a Personal plan or higher.
* Go to `/earn/payments-plans/:site`.
* Add a new plan, and verify that everything works as expected.
* Load an existing plan (via the ellipsis menu Edit button), and verify initial data loads correctly, and saves correctly.
* Verify there is no flash of different modals being visible at the same time.

