### PR TITLE
Recurring Payments: Split out the Delete Plan modal. [WIP]

### DIFF
--- a/client/my-sites/earn/memberships/delete-plan-modal.jsx
+++ b/client/my-sites/earn/memberships/delete-plan-modal.jsx
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+
+import React from 'react';
+import { useTranslate } from 'i18n-calypso';
+import Notice from 'components/notice';
+/**
+ * Internal dependencies
+ */
+import { Dialog } from '@automattic/components';
+
+const RecurringPaymentsPlanDeleteModal = ( { isVisible, planName, onClose } ) => {
+	const translate = useTranslate();
+
+	return (
+		<Dialog
+			isVisible={ isVisible }
+			buttons={ [
+				{
+					label: translate( 'Cancel' ),
+					action: 'cancel',
+				},
+				{
+					label: translate( 'Delete' ),
+					isPrimary: true,
+					action: 'delete',
+				},
+			] }
+			onClose={ onClose }
+		>
+			<h1>{ translate( 'Confirmation' ) }</h1>
+			<p>
+				{ translate( 'Do you want to delete "%s"?', {
+					args: planName,
+				} ) }
+			</p>
+			<Notice
+				text={ translate(
+					'Deleting a product does not cancel the subscription for existing subscribers.{{br/}}They will continue to be charged even after you delete it.',
+					{ components: { br: <br /> } }
+				) }
+				showDismiss={ false }
+			/>
+		</Dialog>
+	);
+};
+
+export default RecurringPaymentsPlanDeleteModal;

--- a/client/my-sites/earn/memberships/products.jsx
+++ b/client/my-sites/earn/memberships/products.jsx
@@ -33,6 +33,7 @@ import {
 	requestUpdateProduct,
 	requestDeleteProduct,
 } from 'state/memberships/product-list/actions';
+import RecurringPaymentsPlanDeleteModal from './delete-plan-modal';
 
 /**
  * @typedef {[string, number] CurrencyMinimum
@@ -352,39 +353,15 @@ class MembershipsProductsSection extends Component {
 						{ this.renderEllipsisMenu( product.ID ) }
 					</CompactCard>
 				) ) }
-				<Dialog
+				<RecurringPaymentsPlanDeleteModal
 					isVisible={ !! this.state.deletedProductId }
-					buttons={ [
-						{
-							label: this.props.translate( 'Cancel' ),
-							action: 'cancel',
-						},
-						{
-							label: this.props.translate( 'Delete' ),
-							isPrimary: true,
-							action: 'delete',
-						},
-					] }
+					planName={ get(
+						this.props.products.filter( ( p ) => p.ID === this.state.deletedProductId ),
+						[ 0, 'title' ],
+						''
+					) }
 					onClose={ this.onCloseDeleteProduct }
-				>
-					<h1>{ this.props.translate( 'Confirmation' ) }</h1>
-					<p>
-						{ this.props.translate( 'Do you want to delete "%s"?', {
-							args: get(
-								this.props.products.filter( ( p ) => p.ID === this.state.deletedProductId ),
-								[ 0, 'title' ],
-								''
-							),
-						} ) }
-					</p>
-					<Notice
-						text={ this.props.translate(
-							'Deleting a product does not cancel the subscription for existing subscribers.{{br/}}They will continue to be charged even after you delete it.',
-							{ components: { br: <br /> } }
-						) }
-						showDismiss={ false }
-					/>
-				</Dialog>
+				/>
 			</div>
 		);
 	}


### PR DESCRIPTION
Partner PR to #42552 , this splits the Delete Plan modal at `/earn/payments-plans/:site` out to its own component, allowing `products.jsx` to be easier to understand.

<img width="1016" alt="Screen Shot 2020-05-21 at 5 06 07 PM" src="https://user-images.githubusercontent.com/349751/82617591-62dfa100-9b85-11ea-8bab-cdad9d29b32e.png">

#### Testing instructions

* Load this branch with a site that has a Personal plan or higher.
* Go to `/earn/payments-plans/:site`.
* Add a new plan.
* Select "Delete" in the new plan's ellipsis menu.
* Verify you get a deletion verification notice, and that the plan is no longer listed.

