### PR TITLE
Gutenboarding: Update tertiary styling for publish button in editor

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/gutenboarding-editor-overrides.scss
+++ b/apps/wpcom-block-editor/src/calypso/features/gutenboarding-editor-overrides.scss
@@ -1,14 +1,14 @@
 .gutenboarding-editor-overrides {
-    .editor-post-switch-to-draft {
-        display: none;
-    }
+	.editor-post-switch-to-draft {
+		display: none;
+	}
 
-    .gutenboarding-editor-overrides__launch-button {
-        padding: 0 12px;
-        margin: 0 12px 0 3px;
-    }
+	.gutenboarding-editor-overrides__launch-button {
+		padding: 0 12px;
+		margin: 0 12px 0 3px;
+	}
 
-    // Override 'Save' button to have tertiary styles.
+	// Override 'Save' button to have tertiary styles.
 	.edit-post-header__settings {
 		.editor-post-publish-button__button {
 			color: #007cba !important;
@@ -16,7 +16,7 @@
 			border: none !important;
 			box-shadow: none !important;
 
-			&[aria-disabled=true] {
+			&[aria-disabled='true'] {
 				opacity: 0.3 !important;
 			}
 		}

--- a/apps/wpcom-block-editor/src/calypso/features/gutenboarding-editor-overrides.scss
+++ b/apps/wpcom-block-editor/src/calypso/features/gutenboarding-editor-overrides.scss
@@ -2,21 +2,23 @@
     .editor-post-switch-to-draft {
         display: none;
     }
-    
+
     .gutenboarding-editor-overrides__launch-button {
         padding: 0 12px;
         margin: 0 12px 0 3px;
     }
 
     // Override 'Save' button to have tertiary styles.
-    .editor-post-publish-button {
-        color: #007cba !important;
-        background: none !important;
-        border: none !important;
-        box-shadow: none !important;
+	.edit-post-header__settings {
+		.editor-post-publish-button__button {
+			color: #007cba !important;
+			background: none !important;
+			border: none !important;
+			box-shadow: none !important;
 
-        &[aria-disabled=true] {
-            opacity: 0.3 !important;
-        }
-    }
+			&[aria-disabled=true] {
+				opacity: 0.3 !important;
+			}
+		}
+	}
 }


### PR DESCRIPTION
This PR adjusts the styling of the publish button in the block editor for sites created via Gutenboarding.

#### Changes proposed in this Pull Request

* Update CSS selectors so that the publish button in the slide out panel is _not_ overridden, and the publish button in the editor settings bar _is_ overridden.

#### Screenshots

##### Before

Publish button in editor settings bar:

![image](https://user-images.githubusercontent.com/14988353/82622019-11382480-9c20-11ea-9095-bce490ae365e.png)

Publish button in slide-out sidebar:

![image](https://user-images.githubusercontent.com/14988353/82622026-185f3280-9c20-11ea-816c-e84b10091065.png)

##### After

Publish button in editor settings bar looks more like a link:

![image](https://user-images.githubusercontent.com/14988353/82622037-1eedaa00-9c20-11ea-9e72-3a5c23e0464a.png)

Publish button in slide-out sidebar is a big blue button:

![image](https://user-images.githubusercontent.com/14988353/82622049-257c2180-9c20-11ea-8e4b-b8dbc056f6c5.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Sandbox: D43817-code (a build of this PR)

* Go to `/new` and create a new site via Gutenboarding
* Do not launch the site
* Exit the editor and go to add a new post or page
* Note that the publish button in the editor settings bar at the top of the screen should be in the tertiary style (look like a link instead of a primary button)
* Write something in the post or page and click to publish it.
* The slide-out sidebar panel should have a publish button in the primary style (big blue button) instead of a text link
* Make sure you can publish the post or page

---

* Test that in a non-Gutenboarding or launched Gutenboarding site, the publish button still uses the primary button style (a blue button).

Fixes #
