### PR TITLE
Gutenboarding: add user registration event

### DIFF
--- a/client/landing/gutenboarding/components/signup-form/index.tsx
+++ b/client/landing/gutenboarding/components/signup-form/index.tsx
@@ -21,6 +21,7 @@ import {
 	initGoogleRecaptcha,
 	recordGoogleRecaptchaAction,
 	recordOnboardingError,
+	recordOnboardingRegistration,
 } from '../../lib/analytics';
 import { localizeUrl } from '../../../../lib/i18n-utils';
 import { useTrackModal } from '../../hooks/use-track-modal';
@@ -98,6 +99,11 @@ const SignupForm = ( { onRequestClose }: Props ) => {
 		} );
 
 		if ( result.ok ) {
+			recordOnboardingRegistration( {
+				userId: result.userId,
+				username: result.username,
+				email: emailVal,
+			} );
 			closeModal();
 		} else {
 			recordOnboardingError( {

--- a/client/landing/gutenboarding/lib/analytics/index.ts
+++ b/client/landing/gutenboarding/lib/analytics/index.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { recordTracksEvent, identifyUser } from '@automattic/calypso-analytics';
 import { v4 as uuid } from 'uuid';
 
 /**
@@ -9,7 +9,12 @@ import { v4 as uuid } from 'uuid';
  */
 import { FLOW_ID } from '../../constants';
 import type { StepNameType } from '../../path';
-import type { ErrorParameters, OnboardingCompleteParameters, TracksEventProperties } from './types';
+import type {
+	ErrorParameters,
+	OnboardingCompleteParameters,
+	TracksEventProperties,
+	OnboardingRegistrationParameters,
+} from './types';
 
 export * from './recaptcha';
 
@@ -68,6 +73,22 @@ export function recordOnboardingError( params: ErrorParameters ): void {
 	trackEventWithFlow( 'calypso_newsite_error', {
 		error: params.error,
 		step: params.step,
+	} );
+}
+
+/**
+ * Record when a user registers for the first time
+ *
+ * @param {object} params A set of params to pass to analytics for signup errors
+ */
+export function recordOnboardingRegistration( params: OnboardingRegistrationParameters ): void {
+	identifyUser( {
+		ID: params.userId,
+		username: params.username,
+		email: params.email,
+	} );
+	trackEventWithFlow( 'calypso_user_registration_complete', {
+		type: 'default', // or 'social' when we have social
 	} );
 }
 

--- a/client/landing/gutenboarding/lib/analytics/types.ts
+++ b/client/landing/gutenboarding/lib/analytics/types.ts
@@ -38,6 +38,23 @@ export interface OnboardingCompleteParameters {
 	hasCartItems?: boolean;
 }
 
+export interface OnboardingRegistrationParameters {
+	/**
+	 * The new user ID
+	 */
+	userId: number;
+
+	/**
+	 * The new user's username if any'
+	 */
+	username: string | undefined;
+
+	/**
+	 * The new user's email
+	 */
+	email: string;
+}
+
 export type TracksAcquireIntentEventProperties = {
 	/**
 	 * The slug of the selected vertical or undefined if the vertical is free-form user input

--- a/packages/data-stores/src/user/actions.ts
+++ b/packages/data-stores/src/user/actions.ts
@@ -72,7 +72,7 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 
 			yield receiveNewUser( newUser );
 
-			return { ok: true } as const;
+			return { ok: true, username: newUser.username, userId: newUser.user_id } as const;
 		} catch ( newUserError ) {
 			yield receiveNewUserFailed( newUserError );
 


### PR DESCRIPTION
Not sure if we need this yet...

#### Changes proposed in this Pull Request

Duplicating what happens when we call `calypso_user_registration_complete` in the current signup flow for Gutenboarding


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Fixes #
