### PR TITLE
Gutenboarding: Handle confirm in PlansModal

### DIFF
--- a/client/landing/gutenboarding/components/plans/plans-modal/index.tsx
+++ b/client/landing/gutenboarding/components/plans/plans-modal/index.tsx
@@ -3,6 +3,7 @@
  */
 import * as React from 'react';
 import Modal from 'react-modal';
+import { useDispatch } from '@wordpress/data';
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
@@ -10,6 +11,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import PlansGrid, { Props as PlansGridProps } from '../plans-grid';
+import { STORE_KEY as PLANS_STORE } from '../../../stores/plans';
 import { useTrackModal } from '../../../hooks/use-track-modal';
 import { useSelectedPlan } from '../../../hooks/use-selected-plan';
 
@@ -27,6 +29,7 @@ const PlansGridModal: React.FunctionComponent< Props > = ( { onClose } ) => {
 	Modal.setAppElement( '#wpcom' );
 
 	const plan = useSelectedPlan();
+	const { setPlan } = useDispatch( PLANS_STORE );
 
 	React.useEffect( () => {
 		setTimeout( () => window.scrollTo( 0, 0 ), 0 );
@@ -42,6 +45,11 @@ const PlansGridModal: React.FunctionComponent< Props > = ( { onClose } ) => {
 		selected_plan: selectedPlanRef.current,
 	} ) );
 
+	const handleConfirm = () => {
+		setPlan( plan?.getStoreSlug() );
+		onClose();
+	};
+
 	return (
 		<Modal
 			isOpen
@@ -51,7 +59,7 @@ const PlansGridModal: React.FunctionComponent< Props > = ( { onClose } ) => {
 		>
 			<PlansGrid
 				confirmButton={
-					<Button isPrimary onClick={ onClose }>
+					<Button isPrimary onClick={ handleConfirm }>
 						{ __( 'Confirm' ) }
 					</Button>
 				}


### PR DESCRIPTION
When no explicit change in the Plans Modal was made, when closing the modal by pressing _Confirm_ button the current selection isn't saved.
Demo: https://cloudup.com/cFW1u_wYljx
This PR is fixing this.

#### Changes proposed in this Pull Request
* Use _Confirm_ button to save whatever plan is displayed as current Plan.


#### Testing instructions
* Open Plans modal when _View Plans_ label is displayed on the Plans Button.
* After pressing _Confirm_ the plan button should display _Free Plan_. 
* Plan Button label shouldn't be changed indirectly anymore (eg: when picking a paid domain).
* Plan step should be skipped.

Fixes https://github.com/Automattic/wp-calypso/pull/42525#pullrequestreview-416282301
