### PR TITLE
Recurring payments: Limit welcome email content to 2000 characters

### DIFF
--- a/client/my-sites/earn/memberships/products.jsx
+++ b/client/my-sites/earn/memberships/products.jsx
@@ -31,7 +31,7 @@ import FormSectionHeading from 'components/forms/form-section-heading';
 import FormSelect from 'components/forms/form-select';
 import FormCurrencyInput from 'components/forms/form-currency-input';
 import FormLabel from 'components/forms/form-label';
-import FormTextArea from 'components/forms/form-textarea';
+import CountedTextarea from 'components/forms/counted-textarea';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormToggle from 'components/forms/form-toggle';
 import InlineSupportLink from 'components/inline-support-link';
@@ -70,6 +70,11 @@ const MINIMUM_CURRENCY_AMOUNT = {
 	SEK: 3.0,
 	SGD: 0.5,
 };
+
+/**
+ * @type {number}
+ */
+const MAX_LENGTH_CUSTOM_CONFIRMATION_EMAIL_MESSAGE = 2000;
 
 /**
  * @type Array<{ code: string }>
@@ -247,6 +252,13 @@ class MembershipsProductsSection extends Component {
 		if ( ( field === 'name' || ! field ) && this.state.editedProductName.length === 0 ) {
 			return false;
 		}
+		if (
+			! field &&
+			this.state.editedCustomConfirmationMessage.length >
+				MAX_LENGTH_CUSTOM_CONFIRMATION_EMAIL_MESSAGE
+		) {
+			return false;
+		}
 		return true;
 	};
 
@@ -392,11 +404,14 @@ class MembershipsProductsSection extends Component {
 							'Add a custom message to the confirmation email that is sent out for this recurring payment plan.'
 						) }
 					</p>
-					<FormTextArea
+					<CountedTextarea
 						value={ editedCustomConfirmationMessage }
 						onChange={ ( event ) =>
 							this.setState( { editedCustomConfirmationMessage: event.target.value } )
 						}
+						acceptableLength={ MAX_LENGTH_CUSTOM_CONFIRMATION_EMAIL_MESSAGE }
+						showRemainingCharacters={ true }
+						placeholder={ translate( 'Write a short welcome message' ) }
 					/>
 				</FormFieldset>
 			</>
@@ -418,6 +433,7 @@ class MembershipsProductsSection extends Component {
 						label: this.props.translate( 'Save' ),
 						action: 'submit',
 						disabled: ! this.isFormValid(),
+						isPrimary: true,
 					},
 				] }
 			>

--- a/client/my-sites/earn/memberships/products.jsx
+++ b/client/my-sites/earn/memberships/products.jsx
@@ -188,7 +188,7 @@ class MembershipsProductsSection extends Component {
 				editedPayWhatYouWant: product.buyer_can_change_amount,
 				editedMultiplePerUser: !! product.multiple_per_user,
 				focusedName: false,
-				editedCustomConfirmationMessage: product.welcome_email_content,
+				editedCustomConfirmationMessage: product.welcome_email_content || '',
 				editedPostsEmail: product.subscribe_as_site_subscriber,
 			} );
 		} else {
@@ -254,6 +254,7 @@ class MembershipsProductsSection extends Component {
 		}
 		if (
 			! field &&
+			this.state.editedCustomConfirmationMessage &&
 			this.state.editedCustomConfirmationMessage.length >
 				MAX_LENGTH_CUSTOM_CONFIRMATION_EMAIL_MESSAGE
 		) {

--- a/client/my-sites/earn/memberships/products.jsx
+++ b/client/my-sites/earn/memberships/products.jsx
@@ -401,9 +401,7 @@ class MembershipsProductsSection extends Component {
 						{ translate( 'Custom confirmation message' ) }
 					</h6>
 					<p>
-						{ translate(
-							'Add a custom message to the confirmation email that is sent out for this recurring payment plan.'
-						) }
+						{ translate( 'Add a short message to the confirmation email sent to subscribers.' ) }
 					</p>
 					<CountedTextarea
 						value={ editedCustomConfirmationMessage }
@@ -412,7 +410,7 @@ class MembershipsProductsSection extends Component {
 						}
 						acceptableLength={ MAX_LENGTH_CUSTOM_CONFIRMATION_EMAIL_MESSAGE }
 						showRemainingCharacters={ true }
-						placeholder={ translate( 'Write a short welcome message' ) }
+						placeholder={ translate( 'Thank you for subscribing!' ) }
 					/>
 				</FormFieldset>
 			</>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Limits the max length of the Recurring payments' custom confirmation email messages to 2000 characters.

<img width="801" alt="Screen Shot 2020-05-22 at 13 58 23" src="https://user-images.githubusercontent.com/1233880/82665912-0936af80-9c35-11ea-8974-c271399de9fc.png">

The "Save" button is disabled if the entered message exceeds the max length:

![May-22-2020 14-00-06](https://user-images.githubusercontent.com/1233880/82666055-531f9580-9c35-11ea-8083-4ea062b2a561.gif)

Note that "Save" button is now a primary button as per @sixhours's [suggestion](https://github.com/Automattic/wp-calypso/pull/42413#issuecomment-632307423).

#### Testing instructions

* Set up Recurring Payments on a site using the testing store. More info in PCYsg-lW4-p2 #sandbox-method.
* Go to Tools > Earn > Collect recurring payments > Recurring Payments plans.
* Add or edit an existing recurring payment plan.
* Click on the Email tab.
* Make sure the "Custom confirmation message" field is limited to 2000 characters.
* Make sure the plan cannot be saved when the field exceeds the max length.

Part of #42536