### PR TITLE
Improve 2fa push fix from #42504

### DIFF
--- a/client/state/login/actions/push/impl.js
+++ b/client/state/login/actions/push/impl.js
@@ -9,6 +9,7 @@ import {
 
 import { remoteLoginUser } from 'state/login/actions/remote-login-user';
 
+import 'state/data-layer/wpcom/login-2fa';
 import 'state/login/init';
 
 export const startPollAppPushAuth = () => ( { type: TWO_FACTOR_AUTHENTICATION_PUSH_POLL_START } );

--- a/client/state/login/actions/push/index.js
+++ b/client/state/login/actions/push/index.js
@@ -1,8 +1,3 @@
-/**
- * Internal dependencies
- */
-import 'state/data-layer/wpcom/login-2fa';
-
 export {
 	receivedTwoFactorPushNotificationApproved,
 	startPollAppPushAuth,

--- a/client/state/login/actions/push/package.json
+++ b/client/state/login/actions/push/package.json
@@ -1,5 +1,0 @@
-{
-	"sideEffects": [
-		"./index.js"
-	]
-}


### PR DESCRIPTION
This PR fixes things in a less manual way.
It moves the import of the side-effectful file to the module that needs it, rather than the index module above it (which can be tree-shaken away). This will ensure that it's always present when needed.

#### Changes proposed in this Pull Request

* Rework fix in #42504

#### Testing instructions

* Build the application in production mode
* Look for the string `state/data-layer/wpcom/login-2fa/index.js` in the output. You can use the following command:
   ```sh
   grep "state/data-layer/wpcom/login-2fa/index.js" public/evergreen/*.js
   ```

The string only appears in the `state/data-layer/wpcom/login-2fa` module. If the string is present, then the module was NOT tree-shaken, which is the correct behaviour.
