### PR TITLE
Gutenboarding: update intent capture styles

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
@@ -4,7 +4,8 @@
 import * as React from 'react';
 import classnames from 'classnames';
 import { useHistory } from 'react-router-dom';
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { Button } from '@wordpress/components';
 import { useI18n } from '@automattic/react-i18n';
 
 /**
@@ -16,6 +17,7 @@ import Link from '../../components/link';
 import SiteTitle from './site-title';
 import { useTrackStep } from '../../hooks/use-track-step';
 import { preloadDesignThumbs } from '../../available-designs';
+import { recordSiteTitleSkip } from '../../lib/analytics';
 
 /**
  * Style dependencies
@@ -25,6 +27,7 @@ import './style.scss';
 const AcquireIntent: React.FunctionComponent = () => {
 	const { __ } = useI18n();
 	const { getSelectedSiteTitle } = useSelect( ( select ) => select( STORE_KEY ) );
+	const { setSiteTitle } = useDispatch( STORE_KEY );
 
 	const history = useHistory();
 	const makePath = usePath();
@@ -42,18 +45,34 @@ const AcquireIntent: React.FunctionComponent = () => {
 		history.push( nextStepPath );
 	};
 
+	const handleSkip = () => {
+		setSiteTitle( '' ); // reset site title if there is no valid entry
+		recordSiteTitleSkip();
+		handleSiteTitleSubmit();
+	};
+
 	// translators: Button label for advancing to Design Picker step in onboarding
 	const nextLabel = __( 'Choose design' );
 
+	// translators: Button label for skipping filling an optional input in onboarding
+	const skipLabel = __( 'Skip for now' );
+
+	const skipButton = (
+		<Button isLink onClick={ handleSkip } className="acquire-intent__skip-site-title">
+			{ skipLabel }
+		</Button>
+	);
+
 	return (
-		<div className="gutenboarding-page acquire-intent">
-			<SiteTitle onSubmit={ handleSiteTitleSubmit } skippable={ ! hasSiteTitle } />
-			<div
-				className={ classnames( 'acquire-intent__footer', {
-					'acquire-intent__footer--hidden': ! hasSiteTitle,
-				} ) }
-			>
-				<Link className="acquire-intent__question-skip" isPrimary to={ nextStepPath }>
+		<div
+			className={ classnames( 'gutenboarding-page acquire-intent', {
+				'acquire-intent--with-skip': ! hasSiteTitle,
+			} ) }
+		>
+			<SiteTitle skipButton={ skipButton } onSubmit={ handleSiteTitleSubmit } />
+			<div className="acquire-intent__footer">
+				{ skipButton }
+				<Link className="acquire-intent__next" isPrimary to={ nextStepPath }>
 					{ nextLabel }
 				</Link>
 			</div>

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
@@ -2,23 +2,22 @@
  * External dependencies
  */
 import * as React from 'react';
-import classnames from 'classnames';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { Button, TextControl } from '@wordpress/components';
+import { TextControl } from '@wordpress/components';
 import { useI18n } from '@automattic/react-i18n';
 
 /**
  * Internal dependencies
  */
 import { STORE_KEY } from '../../stores/onboard';
-import { recordSiteTitleSelection, recordSiteTitleSkip } from '../../lib/analytics';
+import { recordSiteTitleSelection } from '../../lib/analytics';
 
 interface Props {
+	skipButton: React.ReactNode;
 	onSubmit: () => void;
-	skippable: boolean;
 }
 
-const SiteTitle: React.FunctionComponent< Props > = ( { onSubmit, skippable } ) => {
+const SiteTitle: React.FunctionComponent< Props > = ( { skipButton, onSubmit } ) => {
 	const { __ } = useI18n();
 	const { siteTitle } = useSelect( ( select ) => select( STORE_KEY ).getState() );
 	const { setSiteTitle } = useDispatch( STORE_KEY );
@@ -33,17 +32,8 @@ const SiteTitle: React.FunctionComponent< Props > = ( { onSubmit, skippable } ) 
 		recordSiteTitleSelection( !! siteTitle );
 	};
 
-	const handleSkip = () => {
-		setSiteTitle( '' ); // reset site title if there is no valid entry
-		recordSiteTitleSkip();
-		onSubmit();
-	};
-
 	// translators: label for site title input in Gutenboarding
 	const inputLabel = __( 'My site is called' );
-
-	// translators: Button label for skipping filling an optional input in onboarding
-	const skipLabel = __( 'Skip for now' );
 
 	return (
 		<form className="site-title" onSubmit={ handleFormSubmit }>
@@ -53,9 +43,7 @@ const SiteTitle: React.FunctionComponent< Props > = ( { onSubmit, skippable } ) 
 			<div className="site-title__input-wrapper">
 				<TextControl
 					id="site-title__input"
-					className={ classnames( 'site-title__input', {
-						'site-title__input--with-value': ! skippable,
-					} ) }
+					className="site-title__input"
 					onChange={ setSiteTitle }
 					onBlur={ handleBlur }
 					value={ siteTitle }
@@ -65,11 +53,7 @@ const SiteTitle: React.FunctionComponent< Props > = ( { onSubmit, skippable } ) 
 					autoCorrect="off"
 					data-hj-whitelist
 				/>
-				{ skippable && (
-					<Button isLink onClick={ handleSkip } className="acquire-intent__skip-site-title">
-						{ skipLabel }
-					</Button>
-				) }
+				{ skipButton }
 			</div>
 		</form>
 	);

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
@@ -12,7 +12,6 @@
 	width: 100%;
 	display: flex;
 	flex-direction: column;
-	justify-content: space-between;
 	margin: 0 -20px;
 	padding: 25px 20px 20px;
 	transition: color $acquire-intent-transition-duration
@@ -124,6 +123,7 @@
 .acquire-intent__footer {
 	transition: opacity $acquire-intent-transition-duration $acquire-intent-transition-algorithm;
 	align-self: flex-end;
+	margin-top: 20px;
 
 	&--hidden {
 		// use this to fade-in the footer; since the buttons are disabled we don't need to hide them
@@ -133,6 +133,7 @@
 
 	@include break-small {
 		align-self: flex-start;
+		margin-top: 0;
 	}
 }
 

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
@@ -20,16 +20,17 @@
 			$acquire-intent-transition-algorithm;
 
 	@include break-small {
+		@include onboarding-heading-text;
 		margin: 0 -44px; // override block margins
 		padding: 0 120px;
-		font-size: 64px;
-		line-height: 80px;
 		justify-content: center;
 	}
 
 	@include break-medium {
 		margin: 0 -88px; // override block margins
 		padding: 12px 170px 0;
+		font-size: 64px;
+		line-height: 80px;
 	}
 }
 
@@ -54,11 +55,55 @@
 	height: 42px;
 	margin-top: 10px;
 
+	.acquire-intent__skip-site-title {
+		visibility: hidden;
+		opacity: 0;
+		display: none;
+	}
+
 	@include break-small {
 		margin-top: 0;
 		min-width: 300px;
-		max-width: 500px;
+		max-width: 400px;
+		height: 57px;
+
+		.acquire-intent__skip-site-title {
+			display: block;
+		}
+	}
+
+	@include break-medium {
 		height: 80px;
+		max-width: 500px;
+	}
+}
+
+.acquire-intent__footer {
+	display: flex;
+	justify-content: space-between;
+	margin-top: 25px;
+
+	@include break-small {
+		.acquire-intent__skip-site-title {
+			display: none;
+		}
+	}
+}
+
+.acquire-intent--with-skip {
+	.site-title__input::after {
+		background-image: linear-gradient( to right, $light-gray-700, $light-gray-200 );
+	}
+	.acquire-intent__footer {
+		.acquire-intent__next {
+			// use this to fade-in the footer; since the buttons are disabled we don't need to hide them
+			opacity: 0;
+			visibility: hidden;
+		}
+	}
+	.site-title__input-wrapper .acquire-intent__skip-site-title {
+		visibility: visible;
+		opacity: 1;
 	}
 }
 
@@ -73,17 +118,12 @@
 		right: 0;
 		bottom: 1px;
 		height: 2px;
-		background-image: linear-gradient( to right, rgba( 238, 238, 238, 1 ), rgba( 238, 238, 238, 0.4 ) );
+		background: var( --mainColor );
 		transition: background $acquire-intent-transition-duration $acquire-intent-transition-algorithm;
-		max-width: 400px;
 
 		@include break-small {
 			bottom: 4px;
 		}
-	}
-	&--with-value::after {
-		background: var( --mainColor );
-		max-width: none;
 	}
 
 	& > div {
@@ -105,6 +145,10 @@
 		}
 
 		@include break-small {
+			@include onboarding-heading-text;
+		}
+
+		@include break-medium {
 			font-size: 64px;
 			line-height: 80px;
 		}
@@ -120,25 +164,8 @@
 	}
 }
 
-.acquire-intent__footer {
-	transition: opacity $acquire-intent-transition-duration $acquire-intent-transition-algorithm;
-	align-self: flex-end;
-	margin-top: 20px;
-
-	&--hidden {
-		// use this to fade-in the footer; since the buttons are disabled we don't need to hide them
-		opacity: 0;
-		visibility: hidden;
-	}
-
-	@include break-small {
-		align-self: flex-start;
-		margin-top: 0;
-	}
-}
-
 // Themed core button component
-.components-button.is-primary.acquire-intent__question-skip:not( :disabled ):not( [aria-disabled='true'] ) {
+.components-button.is-primary.acquire-intent__next:not( :disabled ):not( [aria-disabled='true'] ) {
 	background: var( --mainColor );
 	border-color: var( --mainColor );
 	border-radius: 4px;
@@ -149,11 +176,8 @@
 	letter-spacing: 0;
 	padding: 20px 32px;
 	// @TODO: work out hover-state animations
-	transition: background $acquire-intent-transition-duration
-			$acquire-intent-transition-algorithm,
-		border-color $acquire-intent-transition-duration
-			$acquire-intent-transition-algorithm,
-		color $acquire-intent-transition-duration $acquire-intent-transition-algorithm;
+	transition: background, border-color, color, opacity $acquire-intent-transition-duration
+			$acquire-intent-transition-algorithm;
 
 	&:active,
 	&:hover,
@@ -169,6 +193,7 @@
 .components-button.is-link.acquire-intent__skip-site-title {
 	@include onboarding-medium-text;
 	color: var( --studio-gray-40 );
+	transition: opacity $acquire-intent-transition-duration $acquire-intent-transition-algorithm;
 
 	@include break-small {
 		position: absolute;


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Position the next button immediately below input field on mobile for iOS users to find it easier.
* Always show skip button on mobile.
* Darken a bit the placeholder grey underline to be more visible.
* Reduce font-size on tablet / mobile landscape.

#### Testing instructions
* Go to [/new](https://calypso.live/new?branch=update/intent-capture-next-button-position-mobile) on mobile.
* Tap the input and type some text.
* _Choose design_ button should be displayed on the right, immediately below the input.

#### Screenshots
<img width="300" alt="Screenshot 2020-05-22 at 17 53 09" src="https://user-images.githubusercontent.com/14192054/82680631-398e4600-9c55-11ea-983e-b76007d13dc9.png">
<img width="500" alt="Screenshot 2020-05-22 at 17 53 35" src="https://user-images.githubusercontent.com/14192054/82680620-372bec00-9c55-11ea-96c9-f486509329aa.png">