### PR TITLE
Lasagna: switch to post id - blog id format

### DIFF
--- a/client/state/lasagna/post-channel/middleware.js
+++ b/client/state/lasagna/post-channel/middleware.js
@@ -22,7 +22,8 @@ const topicIss = 'wordpress.com';
 const topicSubPrefix = 'wp_post';
 
 const getTopic = ( { scheme, post } ) => {
-	return [ scheme, topicIss, topicSubPrefix, post.global_ID ].join( ':' );
+	const postIdSiteIdKey = `${ post.ID }-${ post.site_ID }`;
+	return [ scheme, topicIss, topicSubPrefix, postIdSiteIdKey ].join( ':' );
 };
 
 const getJoinParams = ( store, postKey ) => {


### PR DESCRIPTION
global_id is branched in ways that make it inappropriate for our use as a uid.

#### Changes proposed in this Pull Request

* Switch keying post channges from `global_id` to `post_id-blog_id` format.

#### Testing instructions

1. Open a full view post in Calypso Reader.
2. Make a comment somewhere else on the same post.
3. You should see the comment pop into the page.

Ideally. do one for a WP.com blog and one for a JP blog.