### PR TITLE
Domains: Update privacy protection status copy

### DIFF
--- a/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
+++ b/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
@@ -209,9 +209,9 @@ class DomainManagementNavigationEnhanced extends React.Component {
 		if ( ! privacyAvailable ) {
 			description = translate( 'Privacy protection: not available' );
 		} else if ( privateDomain ) {
-			description = translate( 'Privacy protection: yes' );
+			description = translate( 'Privacy protection: on' );
 		} else {
-			description = translate( 'Privacy protection: no' );
+			description = translate( 'Privacy protection: off' );
 		}
 
 		return (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the privacy protection navigation item, to use on/off instead of yes/no to indicate whether privacy has been enabled for a domain.

#### Testing instructions

For a registered domain you own which supports privacy protection (e.g. .blog), try enabling/disabling the privacy protection, and verify that on/off is shown accordingly.

<img width="326" alt="Screenshot 2020-05-22 at 3 49 49 PM" src="https://user-images.githubusercontent.com/13062352/82677461-5b350080-9c48-11ea-8608-d0c71cb91e73.png">
<img width="325" alt="Screenshot 2020-05-22 at 3 50 07 PM" src="https://user-images.githubusercontent.com/13062352/82677466-5c662d80-9c48-11ea-8201-6ca3ab0f68c7.png">

