### PR TITLE
FSE: Remove obsolete typedefs for @wordpress/icons

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/types.ts
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/types.ts
@@ -1,4 +1,0 @@
-declare module '@wordpress/icons' {
-	export const chevronLeft: any;
-	export const wordpress: any;
-}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Follow-up to https://github.com/Automattic/wp-calypso/pull/41703/files#r428944660.

`@wordpress/icons` comes [with typedefs included](https://github.com/WordPress/gutenberg/blob/16d1e41c3f3fe72446d00a2f25fbe34257ae1c48/packages/icons/CHANGELOG.md#new-feature) these days.

#### Testing instructions

See #41703. (Do a `yarn distclean` first.)