### PR TITLE
Forcibly remove dashicon from build

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -129,7 +129,7 @@ module.exports = {
 						name: 'superagent',
 						message: 'Please use native `fetch` instead.',
 					},
-					// Use `@wordpress/icons` instead of `Icon` from `@wordpress/components`.
+					// Use `@wordpress/icons` instead of `Icon` or `Dashicon` from `@wordpress/components`.
 					{
 						name: '@wordpress/components',
 						importNames: [ 'Dashicon', 'Icon' ],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -129,6 +129,12 @@ module.exports = {
 						name: 'superagent',
 						message: 'Please use native `fetch` instead.',
 					},
+					// Use `@wordpress/icons` instead of `Icon` from `@wordpress/components`.
+					{
+						name: '@wordpress/components',
+						importNames: [ 'Dashicon', 'Icon' ],
+						message: 'Please use `@wordpress/icons` instead.',
+					},
 				],
 			},
 		],

--- a/client/landing/gutenboarding/onboarding-block/index.ts
+++ b/client/landing/gutenboarding/onboarding-block/index.ts
@@ -28,7 +28,6 @@ export const settings: BlockConfiguration< Attributes > = {
 		multiple: false,
 		reusable: false,
 	},
-	icon: 'universal-access-alt',
 	edit,
 	save: () => null,
 	getEditWrapperProps() {

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -318,7 +318,7 @@ if ( isCalypsoClient ) {
 	webpackConfig.plugins.push(
 		new webpack.NormalModuleReplacementPlugin( /dashicon/, ( res ) => {
 			if ( res.context.includes( '@wordpress/components/' ) ) {
-				res.request = 'lodash-es/noop';
+				res.request = 'components/empty-component';
 			}
 		} )
 	);

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -313,6 +313,17 @@ if ( isCalypsoClient ) {
 	webpackConfig.plugins.push( new ExtensiveLodashReplacementPlugin() );
 }
 
+// Forcibly remove dashicon while we wait for better tree-shaking in `@wordpress/*`.
+if ( isCalypsoClient ) {
+	webpackConfig.plugins.push(
+		new webpack.NormalModuleReplacementPlugin( /dashicon/, ( res ) => {
+			if ( res.context.includes( '@wordpress/components/' ) ) {
+				res.request = 'lodash-es/noop';
+			}
+		} )
+	);
+}
+
 if ( isCalypsoClient && browserslistEnv === 'evergreen' ) {
 	// Use "evergreen" polyfill config, rather than fallback.
 	webpackConfig.plugins.push(


### PR DESCRIPTION
While we wait for a new release of `@wordpress/*` with improved tree-shaking, we can at least manually remove `dashicon`, now that Gutenboarding no longer makes use of it (see #42325).

#### Changes proposed in this Pull Request

* Forcibly remove `dashicon` from build
* Remove last dashicon from Gutenboarding
* Add lint rule to prevent more dashicons from being used

#### Testing instructions

Ensure that Gutenboarding works normally, without errors related to missing dashicons.