### PR TITLE
Highlight the plans button when user selects a plan

### DIFF
--- a/client/landing/gutenboarding/components/plans/plans-button/index.tsx
+++ b/client/landing/gutenboarding/components/plans/plans-button/index.tsx
@@ -8,7 +8,7 @@ import { useSelect } from '@wordpress/data';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@automattic/react-i18n';
 import config from 'config';
-import classNames from 'classnames';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -56,7 +56,7 @@ const PlansButton: React.FunctionComponent< Button.ButtonProps > = ( { ...button
 			<Button
 				onClick={ handleButtonClick }
 				label={ __( planLabel ) }
-				className={ classNames( 'plans-button', { 'is-highlighted': isPlanUserSelectedOrPaid } ) }
+				className={ classnames( 'plans-button', { 'is-highlighted': isPlanUserSelectedOrPaid } ) }
 				{ ...buttonProps }
 			>
 				{ isDesktop && planLabel }

--- a/client/landing/gutenboarding/components/plans/plans-button/index.tsx
+++ b/client/landing/gutenboarding/components/plans/plans-button/index.tsx
@@ -50,12 +50,14 @@ const PlansButton: React.FunctionComponent< Button.ButtonProps > = ( { ...button
 			: /* translators: Button label where %s is the WordPress.com plan name (eg: Personal, Premium, Business) */
 			  sprintf( __( '%s Plan' ), plan.getTitle() );
 
+	const isPlanUserSelectedOrPaid = selectedPlan || ! plan?.isFree;
+
 	return (
 		<>
 			<Button
 				onClick={ handleButtonClick }
 				label={ __( planLabel ) }
-				className={ classNames( 'plans-button', { 'user-selected': selectedPlan } ) }
+				className={ classNames( 'plans-button', { 'is-highlighted': isPlanUserSelectedOrPaid } ) }
 				{ ...buttonProps }
 			>
 				{ isDesktop && planLabel }

--- a/client/landing/gutenboarding/components/plans/plans-button/index.tsx
+++ b/client/landing/gutenboarding/components/plans/plans-button/index.tsx
@@ -8,6 +8,7 @@ import { useSelect } from '@wordpress/data';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@automattic/react-i18n';
 import config from 'config';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -54,7 +55,7 @@ const PlansButton: React.FunctionComponent< Button.ButtonProps > = ( { ...button
 			<Button
 				onClick={ handleButtonClick }
 				label={ __( planLabel ) }
-				className="plans-button"
+				className={ classNames( 'plans-button', { 'user-selected': selectedPlan } ) }
 				{ ...buttonProps }
 			>
 				{ isDesktop && planLabel }

--- a/client/landing/gutenboarding/components/plans/plans-button/index.tsx
+++ b/client/landing/gutenboarding/components/plans/plans-button/index.tsx
@@ -44,13 +44,12 @@ const PlansButton: React.FunctionComponent< Button.ButtonProps > = ( { ...button
 	// This accounts for plans that may come from e.g. selecting a domain or adding a plan via URL
 	const plan = useSelectedPlan();
 
-	const planLabel =
-		plan?.isFree && ! selectedPlan
-			? __( 'View plans' )
-			: /* translators: Button label where %s is the WordPress.com plan name (eg: Personal, Premium, Business) */
-			  sprintf( __( '%s Plan' ), plan.getTitle() );
-
 	const isPlanUserSelectedOrPaid = selectedPlan || ! plan?.isFree;
+
+	const planLabel = isPlanUserSelectedOrPaid
+		? /* translators: Button label where %s is the WordPress.com plan name (eg: Personal, Premium, Business) */
+		  sprintf( __( '%s Plan' ), plan.getTitle() )
+		: __( 'View plans' );
 
 	return (
 		<>

--- a/client/landing/gutenboarding/components/plans/plans-button/style.scss
+++ b/client/landing/gutenboarding/components/plans/plans-button/style.scss
@@ -4,7 +4,7 @@
 .plans-button {
 	white-space: nowrap;
 
-	&.user-selected {
+	&.is-highlighted {
 		color: var( --studio-blue-40 );
 	}
 }

--- a/client/landing/gutenboarding/components/plans/plans-button/style.scss
+++ b/client/landing/gutenboarding/components/plans/plans-button/style.scss
@@ -1,7 +1,12 @@
 @import 'assets/stylesheets/gutenberg-base-styles';
+@import '../variables.scss';
 
 .plans-button {
 	white-space: nowrap;
+
+	&.user-selected {
+		color: var( --studio-blue-40 );
+	}
 }
 
 .plans-button__jetpack-logo {

--- a/client/landing/gutenboarding/components/plans/plans-button/style.scss
+++ b/client/landing/gutenboarding/components/plans/plans-button/style.scss
@@ -1,5 +1,4 @@
 @import 'assets/stylesheets/gutenberg-base-styles';
-@import '../variables.scss';
 
 .plans-button {
 	white-space: nowrap;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* When the users selects any plan, the button becomes blue.
* When a premium plan is selected by a side-effect (selecting a paid domain), the buttons should become blue.

#### Testing instructions

By default, the button should have black text. If the user selects a plan it should become blue. If you refresh the page after selecting a plan, it should remain blue.
