### PR TITLE
Manage Purchase: Change string structure of notices that inform about available products for renewal

### DIFF
--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -125,14 +125,21 @@ class PurchaseNotice extends Component {
 
 		if ( isPaidWithCredits( purchase ) ) {
 			if ( autoRenewingUpgradesLink ) {
-				return translate(
-					"You purchased %(purchaseName)s with credits – please add a credit card before your plan expires %(expiry)s so that you don't lose out on your paid features! You also have {{link}}other upgrades{{/link}} on this site that are scheduled to renew soon.",
-					translateOptions
+				return (
+					translate(
+						"You purchased %(purchaseName)s with credits – please add a credit card before your plan expires %(expiry)s so that you don't lose out on your paid features!",
+						translateOptions
+					) +
+					' ' +
+					translate(
+						'You also have {{link}}other upgrades{{/link}} on this site that are scheduled to renew soon.',
+						translateOptions
+					)
 				);
 			}
 
 			return translate(
-				"You purchased %(purchaseName)s with credits. Please add a credit card before your plan expires %(expiry)s so that you don't lose out on your paid features!",
+				"You purchased %(purchaseName)s with credits – please add a credit card before your plan expires %(expiry)s so that you don't lose out on your paid features!",
 				translateOptions
 			);
 		}
@@ -140,40 +147,61 @@ class PurchaseNotice extends Component {
 		if ( hasPaymentMethod( purchase ) ) {
 			if ( isRechargeable( purchase ) ) {
 				if ( autoRenewingUpgradesLink ) {
-					return translate(
-						"%(purchaseName)s will expire and be removed from your site %(expiry)s – please enable auto-renewal so you don't lose out on your paid features! You also have {{link}}other upgrades{{/link}} on this site that are scheduled to renew soon.",
-						translateOptions
+					return (
+						translate(
+							"%(purchaseName)s will expire and be removed from your site %(expiry)s – please enable auto-renewal so you don't lose out on your paid features!",
+							translateOptions
+						) +
+						' ' +
+						translate(
+							'You also have {{link}}other upgrades{{/link}} on this site that are scheduled to renew soon.',
+							translateOptions
+						)
 					);
 				}
 
 				return translate(
-					"%(purchaseName)s will expire and be removed from your site %(expiry)s. Please enable auto-renewal so you don't lose out on your paid features!",
+					"%(purchaseName)s will expire and be removed from your site %(expiry)s – please enable auto-renewal so you don't lose out on your paid features!",
 					translateOptions
 				);
 			}
 
 			if ( autoRenewingUpgradesLink ) {
-				return translate(
-					"%(purchaseName)s will expire and be removed from your site %(expiry)s – please renew before expiry so you don't lose out on your paid features! You also have {{link}}other upgrades{{/link}} on this site that are scheduled to renew soon.",
-					translateOptions
+				return (
+					translate(
+						"%(purchaseName)s will expire and be removed from your site %(expiry)s – please renew before expiry so you don't lose out on your paid features!",
+						translateOptions
+					) +
+					' ' +
+					translate(
+						'You also have {{link}}other upgrades{{/link}} on this site that are scheduled to renew soon.',
+						translateOptions
+					)
 				);
 			}
 
 			return translate(
-				"%(purchaseName)s will expire and be removed from your site %(expiry)s. Please renew before expiry so you don't lose out on your paid features!",
+				"%(purchaseName)s will expire and be removed from your site %(expiry)s – please renew before expiry so you don't lose out on your paid features!",
 				translateOptions
 			);
 		}
 
 		if ( autoRenewingUpgradesLink ) {
-			return translate(
-				"%(purchaseName)s will expire and be removed from your site %(expiry)s – add a credit card so you don't lose out on your paid features! You also have {{link}}other upgrades{{/link}} on this site that are scheduled to renew soon.",
-				translateOptions
+			return (
+				translate(
+					"%(purchaseName)s will expire and be removed from your site %(expiry)s – add a credit card so you don't lose out on your paid features!",
+					translateOptions
+				) +
+				' ' +
+				translate(
+					'You also have {{link}}other upgrades{{/link}} on this site that are scheduled to renew soon.',
+					translateOptions
+				)
 			);
 		}
 
 		return translate(
-			"%(purchaseName)s will expire and be removed from your site %(expiry)s. Add a credit card so you don't lose out on your paid features!",
+			"%(purchaseName)s will expire and be removed from your site %(expiry)s - add a credit card so you don't lose out on your paid features!",
 			translateOptions
 		);
 	}
@@ -502,50 +530,98 @@ class PurchaseNotice extends Component {
 
 			if ( isExpired( currentPurchase ) ) {
 				if ( isDomainRegistration( currentPurchase ) ) {
-					noticeText = translate(
-						'Your %(purchaseName)s domain expired %(expiry)s and will be removed soon unless you take action. You also have {{link}}other upgrades{{/link}} on this site that are scheduled to renew soon.',
-						translateOptions
-					);
+					noticeText =
+						translate(
+							'Your %(purchaseName)s domain expired %(expiry)s and will be removed soon unless you take action.',
+							translateOptions
+						) +
+						' ' +
+						translate(
+							'You also have {{link}}other upgrades{{/link}} on this site that are scheduled to renew soon.',
+							translateOptions
+						);
 				} else if ( isPlan( currentPurchase ) ) {
 					if ( purchaseIsIncludedInPlan ) {
-						noticeText = translate(
-							'Your {{managePurchase}}%(purchaseName)s plan{{/managePurchase}} (which includes your %(includedPurchaseName)s subscription) expired %(expiry)s and will be removed soon unless you take action. You also have {{link}}other upgrades{{/link}} on this site that are scheduled to renew soon.',
-							translateOptions
-						);
+						noticeText =
+							translate(
+								'Your {{managePurchase}}%(purchaseName)s plan{{/managePurchase}} (which includes your %(includedPurchaseName)s subscription) expired %(expiry)s and will be removed soon unless you take action.',
+								translateOptions
+							) +
+							' ' +
+							translate(
+								'You also have {{link}}other upgrades{{/link}} on this site that are scheduled to renew soon.',
+								translateOptions
+							);
 					} else {
-						noticeText = translate(
-							'Your %(purchaseName)s plan expired %(expiry)s and will be removed soon unless you take action. You also have {{link}}other upgrades{{/link}} on this site that are scheduled to renew soon.',
-							translateOptions
-						);
+						noticeText =
+							translate(
+								'Your %(purchaseName)s plan expired %(expiry)s and will be removed soon unless you take action.',
+								translateOptions
+							) +
+							' ' +
+							translate(
+								'You also have {{link}}other upgrades{{/link}} on this site that are scheduled to renew soon.',
+								translateOptions
+							);
 					}
 				} else {
-					noticeText = translate(
-						'Your %(purchaseName)s subscription expired %(expiry)s and will be removed soon unless you take action. You also have {{link}}other upgrades{{/link}} on this site that are scheduled to renew soon.',
-						translateOptions
-					);
+					noticeText =
+						translate(
+							'Your %(purchaseName)s subscription expired %(expiry)s and will be removed soon unless you take action.',
+							translateOptions
+						) +
+						' ' +
+						translate(
+							'You also have {{link}}other upgrades{{/link}} on this site that are scheduled to renew soon.',
+							translateOptions
+						);
 				}
 			} else if ( isDomainRegistration( currentPurchase ) ) {
-				noticeText = translate(
-					'Your %(purchaseName)s domain will expire %(expiry)s unless you take action. You also have {{link}}other upgrades{{/link}} on this site that are scheduled to renew soon.',
-					translateOptions
-				);
+				noticeText =
+					translate(
+						'Your %(purchaseName)s domain will expire %(expiry)s unless you take action.',
+						translateOptions
+					) +
+					' ' +
+					translate(
+						'You also have {{link}}other upgrades{{/link}} on this site that are scheduled to renew soon.',
+						translateOptions
+					);
 			} else if ( isPlan( currentPurchase ) ) {
 				if ( purchaseIsIncludedInPlan ) {
-					noticeText = translate(
-						'Your {{managePurchase}}%(purchaseName)s plan{{/managePurchase}} (which includes your %(includedPurchaseName)s subscription) will expire %(expiry)s unless you take action. You also have {{link}}other upgrades{{/link}} on this site that are scheduled to renew soon.',
-						translateOptions
-					);
+					noticeText =
+						translate(
+							'Your {{managePurchase}}%(purchaseName)s plan{{/managePurchase}} (which includes your %(includedPurchaseName)s subscription) will expire %(expiry)s unless you take action.',
+							translateOptions
+						) +
+						' ' +
+						translate(
+							'You also have {{link}}other upgrades{{/link}} on this site that are scheduled to renew soon.',
+							translateOptions
+						);
 				} else {
-					noticeText = translate(
-						'Your %(purchaseName)s plan will expire %(expiry)s unless you take action. You also have {{link}}other upgrades{{/link}} on this site that are scheduled to renew soon.',
-						translateOptions
-					);
+					noticeText =
+						translate(
+							'Your %(purchaseName)s plan will expire %(expiry)s unless you take action.',
+							translateOptions
+						) +
+						' ' +
+						translate(
+							'You also have {{link}}other upgrades{{/link}} on this site that are scheduled to renew soon.',
+							translateOptions
+						);
 				}
 			} else {
-				noticeText = translate(
-					'Your %(purchaseName)s subscription will expire %(expiry)s unless you take action. You also have {{link}}other upgrades{{/link}} on this site that are scheduled to renew soon.',
-					translateOptions
-				);
+				noticeText =
+					translate(
+						'Your %(purchaseName)s subscription will expire %(expiry)s unless you take action.',
+						translateOptions
+					) +
+					' ' +
+					translate(
+						'You also have {{link}}other upgrades{{/link}} on this site that are scheduled to renew soon.',
+						translateOptions
+					);
 			}
 		}
 


### PR DESCRIPTION
This updates the `translate()` strings of #42506 for easier translation. This doesn't change the screenshots below (which were taken from #42506):

![others-renew-soon](https://user-images.githubusercontent.com/235183/82594846-b5fc2880-9b72-11ea-8a16-f9c2618ebffb.png)

![all-expiring](https://user-images.githubusercontent.com/235183/82594935-d1673380-9b72-11ea-930a-3952922aa164.png)

![others-are-expiring](https://user-images.githubusercontent.com/235183/82594956-da580500-9b72-11ea-9e6b-6ce9e879c151.png)

![expiring-card](https://user-images.githubusercontent.com/235183/82594978-e17f1300-9b72-11ea-84e5-f3a649a64127.png)

![domain-mapping-other-upgrades](https://user-images.githubusercontent.com/235183/82595000-e774f400-9b72-11ea-91eb-7f0ca1d6fa00.png)

![domain-mapping-no-other-upgrades](https://user-images.githubusercontent.com/235183/82595032-f360b600-9b72-11ea-9712-208854208c2d.png)
