### PR TITLE
Full Site Editing: Add missing text-domain parameter in gettext calls

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,6 +8,7 @@ module.exports = {
 		'plugin:jsx-a11y/recommended',
 		'plugin:jest/recommended',
 		'plugin:prettier/recommended',
+		'plugin:@wordpress/eslint-plugin/i18n',
 		'prettier/react',
 	],
 	overrides: [
@@ -18,6 +19,25 @@ module.exports = {
 				'no-console': 'off',
 				'no-process-exit': 'off',
 				'valid-jsdoc': 'off',
+			},
+		},
+		{
+			files: [ 'apps/full-site-editing/**/*' ],
+			rules: {
+				'@wordpress/i18n-text-domain': [
+					'error',
+					{
+						allowedTextDomain: 'full-site-editing',
+					},
+				],
+				'wpcalypso/jsx-classname-namespace': 'off',
+				'wpcalypso/import-docblock': 'off',
+				'jsdoc/no-undefined-types': 'off',
+				'jsdoc/require-param-description': 'off',
+				'jsdoc/check-param-names': 'off',
+				'no-unused-vars': 'off',
+				'no-undef': 'off',
+				'react-hooks/exhaustive-deps': 'off',
 			},
 		},
 		{

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,7 +8,6 @@ module.exports = {
 		'plugin:jsx-a11y/recommended',
 		'plugin:jest/recommended',
 		'plugin:prettier/recommended',
-		'plugin:@wordpress/eslint-plugin/i18n',
 		'prettier/react',
 	],
 	overrides: [
@@ -19,25 +18,6 @@ module.exports = {
 				'no-console': 'off',
 				'no-process-exit': 'off',
 				'valid-jsdoc': 'off',
-			},
-		},
-		{
-			files: [ 'apps/full-site-editing/**/*' ],
-			rules: {
-				'@wordpress/i18n-text-domain': [
-					'error',
-					{
-						allowedTextDomain: 'full-site-editing',
-					},
-				],
-				'wpcalypso/jsx-classname-namespace': 'off',
-				'wpcalypso/import-docblock': 'off',
-				'jsdoc/no-undefined-types': 'off',
-				'jsdoc/require-param-description': 'off',
-				'jsdoc/check-param-names': 'off',
-				'no-unused-vars': 'off',
-				'no-undef': 'off',
-				'react-hooks/exhaustive-deps': 'off',
 			},
 		},
 		{

--- a/apps/full-site-editing/.eslintrc.js
+++ b/apps/full-site-editing/.eslintrc.js
@@ -4,7 +4,6 @@ module.exports = {
 	rules: {
 		'import/no-extraneous-dependencies': [ 'error', { packageDir: __dirname } ],
 		'react/react-in-jsx-scope': 0,
-		'jsdoc/require-param-description': 0,
 		'@wordpress/i18n-text-domain': [
 			'error',
 			{

--- a/apps/full-site-editing/.eslintrc.js
+++ b/apps/full-site-editing/.eslintrc.js
@@ -4,6 +4,7 @@ module.exports = {
 	rules: {
 		'import/no-extraneous-dependencies': [ 'error', { packageDir: __dirname } ],
 		'react/react-in-jsx-scope': 0,
+		'jsdoc/require-param-description': 0,
 		'@wordpress/i18n-text-domain': [
 			'error',
 			{

--- a/apps/full-site-editing/.eslintrc.js
+++ b/apps/full-site-editing/.eslintrc.js
@@ -1,9 +1,15 @@
 module.exports = {
 	plugins: [ 'jest' ],
-	extends: [ 'plugin:jest/recommended' ],
+	extends: [ 'plugin:jest/recommended', 'plugin:@wordpress/eslint-plugin/i18n' ],
 	rules: {
 		'import/no-extraneous-dependencies': [ 'error', { packageDir: __dirname } ],
 		'react/react-in-jsx-scope': 0,
+		'@wordpress/i18n-text-domain': [
+			'error',
+			{
+				allowedTextDomain: 'full-site-editing',
+			},
+		],
 	},
 	overrides: [
 		{

--- a/apps/full-site-editing/bin/sync-newspack-blocks.sh
+++ b/apps/full-site-editing/bin/sync-newspack-blocks.sh
@@ -124,9 +124,9 @@ cp -R $CODE/src/blocks/carousel $TARGET/blocks/
 cp -R $CODE/src/shared $TARGET/
 cp -R $CODE/src/components $TARGET/
 
-# Replace text domain
-find $TARGET/blocks/ \( -name \*.js -or -name \*.php \) -exec sed "${sedi[@]}" "s/, 'newspack-blocks' )/, 'full-site-editing' )/g" "{}" \;
-sed "${sedi[@]}" "s/'newspack-blocks',/'full-site-editing',/g" $TARGET/class-newspack-blocks.php
+# Fix the text domain
+phpcbf --sniffs=WordPress.Utils.I18nTextDomainFixer
+npx eslint . --fix
 
 if [ "$MODE" = "npm" ] ; then
 	# Finds and prints the version of newspack from package.json

--- a/apps/full-site-editing/bin/sync-newspack-blocks.sh
+++ b/apps/full-site-editing/bin/sync-newspack-blocks.sh
@@ -125,7 +125,6 @@ cp -R $CODE/src/shared $TARGET/
 cp -R $CODE/src/components $TARGET/
 
 # Fix the text domain
-phpcbf --sniffs=WordPress.Utils.I18nTextDomainFixer
 npx eslint . --fix
 
 if [ "$MODE" = "npm" ] ; then

--- a/apps/full-site-editing/full-site-editing-plugin/block-inserter-modifications/contextual-tips/list.js
+++ b/apps/full-site-editing/full-site-editing-plugin/block-inserter-modifications/contextual-tips/list.js
@@ -20,61 +20,90 @@ function getTipDescription( text, conversion, textFallback ) {
 const tips = [
 	{
 		context: 'theme',
-		keywords: [ 'theme', __( 'theme' ) ],
+		keywords: [ 'theme', __( 'theme', 'full-site-editing' ) ],
 		description: getTipDescription(
-			__( 'You can visit the <a>theme directory</a> to select a different design for your site.' ),
+			__(
+				'You can visit the <a>theme directory</a> to select a different design for your site.',
+				'full-site-editing'
+			),
 			{
 				a: <TipLink section="themes" />,
 			},
-			__( 'You can visit the theme directory to select a different design for your site.' )
+			__(
+				'You can visit the theme directory to select a different design for your site.',
+				'full-site-editing'
+			)
 		),
 		permission: 'settings',
 	},
 	{
 		context: 'css',
-		keywords: [ 'css', __( 'css' ), 'style', __( 'style' ) ],
+		keywords: [
+			'css',
+			__( 'css', 'full-site-editing' ),
+			'style',
+			__( 'style', 'full-site-editing' ),
+		],
 		description: getTipDescription(
-			__( 'You can visit the the <a>Customizer</a> to edit the CSS on your site.' ),
+			__(
+				'You can visit the the <a>Customizer</a> to edit the CSS on your site.',
+				'full-site-editing'
+			),
 			{
 				a: <TipLink section="customizer" subsection="custom_css" />,
 			},
-			__( 'You can visit the the Customizer to edit the CSS on your site.' )
+			__( 'You can visit the the Customizer to edit the CSS on your site.', 'full-site-editing' )
 		),
 		permission: 'settings',
 	},
 	{
 		context: 'plugin',
-		keywords: [ 'plugin', __( 'plugin' ) ],
+		keywords: [ 'plugin', __( 'plugin', 'full-site-editing' ) ],
 		description: getTipDescription(
-			__( 'You can visit the <a>plugin directory</a> to get started with installing new plugins.' ),
+			__(
+				'You can visit the <a>plugin directory</a> to get started with installing new plugins.',
+				'full-site-editing'
+			),
 			{
 				a: <TipLink section="plugins" />,
 			},
-			__( 'You can visit the plugin directory to get started with installing new plugins.' )
+			__(
+				'You can visit the plugin directory to get started with installing new plugins.',
+				'full-site-editing'
+			)
 		),
 		permission: 'settings',
 	},
 	{
 		context: 'header',
-		keywords: [ 'header', __( 'header' ) ],
+		keywords: [ 'header', __( 'header', 'full-site-editing' ) ],
 		description: getTipDescription(
-			__( 'You can visit the the <a>Customizer</a> to edit your logo and site title.' ),
+			__(
+				'You can visit the the <a>Customizer</a> to edit your logo and site title.',
+				'full-site-editing'
+			),
 			{
 				a: <TipLink section="customizer" subsection="title_tagline" />,
 			},
-			__( 'You can visit the the Customizer to edit your logo and site title.' )
+			__(
+				'You can visit the the Customizer to edit your logo and site title.',
+				'full-site-editing'
+			)
 		),
 		permission: 'settings',
 	},
 	{
 		context: 'color',
-		keywords: [ 'color', __( 'color' ) ],
+		keywords: [ 'color', __( 'color', 'full-site-editing' ) ],
 		description: getTipDescription(
-			__( 'You can visit the the <a>Customizer</a> to edit the colors on your site.' ),
+			__(
+				'You can visit the the <a>Customizer</a> to edit the colors on your site.',
+				'full-site-editing'
+			),
 			{
 				a: <TipLink section="customizer" subsection="colors" />,
 			},
-			__( 'You can visit the the Customizer to edit the colors on your site.' )
+			__( 'You can visit the the Customizer to edit the colors on your site.', 'full-site-editing' )
 		),
 		permission: 'settings',
 	},

--- a/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/blocks/navigation-menu/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/blocks/navigation-menu/edit.js
@@ -50,22 +50,25 @@ const NavigationMenuEdit = ( {
 				/>
 			</BlockControls>
 			<InspectorControls>
-				<PanelBody className="blocks-font-size" title={ __( 'Text Settings' ) }>
+				<PanelBody
+					className="blocks-font-size"
+					title={ __( 'Text Settings', 'full-site-editing' ) }
+				>
 					<FontSizePicker onChange={ setFontSize } value={ actualFontSize } />
 				</PanelBody>
 				<PanelColorSettings
-					title={ __( 'Color Settings' ) }
+					title={ __( 'Color Settings', 'full-site-editing' ) }
 					initialOpen={ false }
 					colorSettings={ [
 						{
 							value: backgroundColor.color,
 							onChange: setBackgroundColor,
-							label: __( 'Background Color' ),
+							label: __( 'Background Color', 'full-site-editing' ),
 						},
 						{
 							value: textColor.color,
 							onChange: setTextColor,
-							label: __( 'Text Color' ),
+							label: __( 'Text Color', 'full-site-editing' ),
 						},
 					] }
 				>

--- a/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/blocks/navigation-menu/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/blocks/navigation-menu/index.js
@@ -19,8 +19,8 @@ const icon = (
 );
 
 registerBlockType( 'a8c/navigation-menu', {
-	title: __( 'Navigation Menu' ),
-	description: __( 'Visual placeholder for site-wide navigation and menus.' ),
+	title: __( 'Navigation Menu', 'full-site-editing' ),
+	description: __( 'Visual placeholder for site-wide navigation and menus.', 'full-site-editing' ),
 	icon,
 	category: 'layout',
 	supports: {

--- a/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/blocks/post-content/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/blocks/post-content/index.js
@@ -15,8 +15,8 @@ import save from './save';
 import './style.scss';
 
 registerBlockType( 'a8c/post-content', {
-	title: __( 'Content' ),
-	description: __( 'The page content.' ),
+	title: __( 'Content', 'full-site-editing' ),
+	description: __( 'The page content.', 'full-site-editing' ),
 	icon: 'layout',
 	category: 'layout',
 	supports: {

--- a/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/blocks/site-credit/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/blocks/site-credit/edit.js
@@ -66,10 +66,13 @@ function SiteCreditEdit( {
 
 export default compose( [
 	withSiteOptions( {
-		siteTitleOption: { optionName: 'title', defaultValue: __( 'Site title loading…' ) },
+		siteTitleOption: {
+			optionName: 'title',
+			defaultValue: __( 'Site title loading…', 'full-site-editing' ),
+		},
 		footerCreditOption: {
 			optionName: 'footer_credit',
-			defaultValue: __( 'Footer credit loading…' ),
+			defaultValue: __( 'Footer credit loading…', 'full-site-editing' ),
 		},
 	} ),
 ] )( SiteCreditEdit );

--- a/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/blocks/site-credit/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/blocks/site-credit/index.js
@@ -12,8 +12,11 @@ import edit from './edit';
 import './style.scss';
 
 registerBlockType( 'a8c/site-credit', {
-	title: __( 'WordPress.com Credit' ),
-	description: __( "This block tells the world that you're using WordPress.com." ),
+	title: __( 'WordPress.com Credit', 'full-site-editing' ),
+	description: __(
+		"This block tells the world that you're using WordPress.com.",
+		'full-site-editing'
+	),
 	icon: 'wordpress-alt',
 	category: 'layout',
 	supports: {

--- a/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/blocks/site-credit/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/blocks/site-credit/index.php
@@ -145,22 +145,22 @@ function get_footer_credit_options() {
 	 */
 	return apply_filters(
 		'a8c_fse_update_footer_credit_options',
-		[
-			[
-				'label'      => __( 'Proudly powered by WordPress' ),
+		array(
+			array(
+				'label'      => __( 'Proudly powered by WordPress', 'full-site-editing' ),
 				'value'      => 'default',
 				'renderType' => 'text',
-			],
-			[
-				'label'       => __( 'WordPress Icon' ),
+			),
+			array(
+				'label'       => __( 'WordPress Icon', 'full-site-editing' ),
 				'value'       => 'svg',
 				'renderType'  => 'icon',
-				'renderProps' => [
+				'renderProps' => array(
 					'icon'  => 'wordpress',
 					'color' => 'gray',
-				],
-			],
-		]
+				),
+			),
+		)
 	);
 }
 

--- a/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/blocks/site-description/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/blocks/site-description/edit.js
@@ -61,22 +61,25 @@ function SiteDescriptionEdit( {
 				/>
 			</BlockControls>
 			<InspectorControls>
-				<PanelBody className="blocks-font-size" title={ __( 'Text Settings' ) }>
+				<PanelBody
+					className="blocks-font-size"
+					title={ __( 'Text Settings', 'full-site-editing' ) }
+				>
 					<FontSizePicker onChange={ setFontSize } value={ actualFontSize } />
 				</PanelBody>
 				<PanelColorSettings
-					title={ __( 'Color Settings' ) }
+					title={ __( 'Color Settings', 'full-site-editing' ) }
 					initialOpen={ false }
 					colorSettings={ [
 						{
 							value: backgroundColor.color,
 							onChange: setBackgroundColor,
-							label: __( 'Background Color' ),
+							label: __( 'Background Color', 'full-site-editing' ),
 						},
 						{
 							value: textColor.color,
 							onChange: setTextColor,
-							label: __( 'Text Color' ),
+							label: __( 'Text Color', 'full-site-editing' ),
 						},
 					] }
 				>
@@ -91,7 +94,7 @@ function SiteDescriptionEdit( {
 			</InspectorControls>
 			<RichText
 				allowedFormats={ [] }
-				aria-label={ __( 'Site Description' ) }
+				aria-label={ __( 'Site Description', 'full-site-editing' ) }
 				className={ classNames( 'site-description', className, {
 					'has-text-color': textColor.color,
 					'has-background': backgroundColor.color,
@@ -104,7 +107,7 @@ function SiteDescriptionEdit( {
 				onChange={ updateValue }
 				onReplace={ insertDefaultBlock }
 				onSplit={ noop }
-				placeholder={ __( 'Add a Site Description' ) }
+				placeholder={ __( 'Add a Site Description', 'full-site-editing' ) }
 				style={ {
 					backgroundColor: backgroundColor.color,
 					color: textColor.color,
@@ -135,6 +138,9 @@ export default compose( [
 			dispatch( 'core/block-editor' ).insertDefaultBlock( {}, rootClientId, blockIndex + 1 ),
 	} ) ),
 	withSiteOptions( {
-		siteDescription: { optionName: 'description', defaultValue: __( 'Site description loading…' ) },
+		siteDescription: {
+			optionName: 'description',
+			defaultValue: __( 'Site description loading…', 'full-site-editing' ),
+		},
 	} ),
 ] )( SiteDescriptionEdit );

--- a/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/blocks/site-description/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/blocks/site-description/index.js
@@ -12,8 +12,8 @@ import edit from './edit';
 import './style.scss';
 
 registerBlockType( 'a8c/site-description', {
-	title: __( 'Site Description' ),
-	description: __( 'Site description, also known as the tagline.' ),
+	title: __( 'Site Description', 'full-site-editing' ),
+	description: __( 'Site description, also known as the tagline.', 'full-site-editing' ),
 	icon: (
 		<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24">
 			<path fill="none" d="M0 0h24v24H0z" />

--- a/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/blocks/site-title/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/blocks/site-title/edit.js
@@ -58,24 +58,27 @@ function SiteTitleEdit( {
 				/>
 			</BlockControls>
 			<InspectorControls>
-				<PanelBody className="blocks-font-size" title={ __( 'Text Settings' ) }>
+				<PanelBody
+					className="blocks-font-size"
+					title={ __( 'Text Settings', 'full-site-editing' ) }
+				>
 					<FontSizePicker onChange={ setFontSize } value={ actualFontSize } />
 				</PanelBody>
 				<PanelColorSettings
-					title={ __( 'Color Settings' ) }
+					title={ __( 'Color Settings', 'full-site-editing' ) }
 					initialOpen={ false }
 					colorSettings={ [
 						{
 							value: textColor.color,
 							onChange: setTextColor,
-							label: __( 'Text Color' ),
+							label: __( 'Text Color', 'full-site-editing' ),
 						},
 					] }
 				/>
 			</InspectorControls>
 			<RichText
 				allowedFormats={ [] }
-				aria-label={ __( 'Site Title' ) }
+				aria-label={ __( 'Site Title', 'full-site-editing' ) }
 				className={ classNames( 'site-title', className, {
 					'has-text-color': textColor.color,
 					[ `has-text-align-${ textAlign }` ]: textAlign,
@@ -86,7 +89,7 @@ function SiteTitleEdit( {
 				onChange={ updateValue }
 				onReplace={ insertDefaultBlock }
 				onSplit={ noop }
-				placeholder={ __( 'Add a Site Title' ) }
+				placeholder={ __( 'Add a Site Title', 'full-site-editing' ) }
 				style={ {
 					color: textColor.color,
 					fontSize: actualFontSize ? actualFontSize + 'px' : undefined,
@@ -116,6 +119,9 @@ export default compose( [
 			dispatch( 'core/block-editor' ).insertDefaultBlock( {}, rootClientId, blockIndex + 1 ),
 	} ) ),
 	withSiteOptions( {
-		siteTitle: { optionName: 'title', defaultValue: __( 'Site title loading…' ) },
+		siteTitle: {
+			optionName: 'title',
+			defaultValue: __( 'Site title loading…', 'full-site-editing' ),
+		},
 	} ),
 ] )( SiteTitleEdit );

--- a/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/blocks/site-title/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/blocks/site-title/index.js
@@ -12,8 +12,8 @@ import edit from './edit';
 import './style.scss';
 
 registerBlockType( 'a8c/site-title', {
-	title: __( 'Site Title' ),
-	description: __( 'Your site title.' ),
+	title: __( 'Site Title', 'full-site-editing' ),
+	description: __( 'Your site title.', 'full-site-editing' ),
 	icon: 'layout',
 	category: 'layout',
 	supports: {

--- a/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/blocks/template/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/blocks/template/edit.js
@@ -177,7 +177,8 @@ const TemplateEdit = compose(
 						<Placeholder className="template-block__overlay" onClick={ save }>
 							{ navigateToTemplate && (
 								<div className="template-block__loading">
-									<Spinner /> { sprintf( __( 'Loading editor for: %s' ), templateTitle ) }
+									<Spinner />{ ' ' }
+									{ sprintf( __( 'Loading editor for: %s', 'full-site-editing' ), templateTitle ) }
 								</div>
 							) }
 							<Button
@@ -188,7 +189,7 @@ const TemplateEdit = compose(
 								isLarge
 								ref={ navButton }
 							>
-								{ sprintf( __( 'Edit %s' ), templateTitle ) }
+								{ sprintf( __( 'Edit %s', 'full-site-editing' ), templateTitle ) }
 							</Button>
 						</Placeholder>
 					</Fragment>

--- a/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/blocks/template/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/blocks/template/index.js
@@ -16,9 +16,9 @@ import './site-logo';
 
 if ( 'wp_template_part' !== fullSiteEditing.editorPostType ) {
 	registerBlockType( 'a8c/template', {
-		title: __( 'Template Part' ),
+		title: __( 'Template Part', 'full-site-editing' ),
 		__experimentalDisplayName: 'label',
-		description: __( 'Display a Template Part.' ),
+		description: __( 'Display a Template Part.', 'full-site-editing' ),
 		icon: 'layout',
 		category: 'layout',
 		attributes: {

--- a/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/lib/site-options/use-site-options.js
+++ b/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/lib/site-options/use-site-options.js
@@ -51,10 +51,12 @@ export function useSiteOptions(
 				} )
 			)
 			.catch( () => {
-				createErrorNotice( sprintf( __( 'Unable to load site %s' ), siteOption ) );
+				createErrorNotice(
+					sprintf( __( 'Unable to load site %s', 'full-site-editing' ), siteOption )
+				);
 				setSiteOptions( {
 					...siteOptions,
-					option: sprintf( __( 'Error loading site %s' ), siteOption ),
+					option: sprintf( __( 'Error loading site %s', 'full-site-editing' ), siteOption ),
 					error: true,
 				} );
 			} );
@@ -93,7 +95,9 @@ export function useSiteOptions(
 		apiFetch( { path: '/wp/v2/settings', method: 'POST', data: { [ siteOption ]: option } } )
 			.then( () => updatePreviousOption( option ) )
 			.catch( () => {
-				createErrorNotice( sprintf( __( 'Unable to save site %s' ), siteOption ) );
+				createErrorNotice(
+					sprintf( __( 'Unable to save site %s', 'full-site-editing' ), siteOption )
+				);
 				revertOption();
 			} );
 	}

--- a/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/plugins/close-button-override/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/plugins/close-button-override/index.js
@@ -85,11 +85,11 @@ domReady( () => {
 
 		let defaultLabel = closeButtonLabel || 'Back';
 		if ( 'page' === editorPostType && ! closeButtonLabel ) {
-			defaultLabel = __( 'Pages' );
+			defaultLabel = __( 'Pages', 'full-site-editing' );
 		} else if ( 'post' === editorPostType && ! closeButtonLabel ) {
-			defaultLabel = __( 'Posts' );
+			defaultLabel = __( 'Posts', 'full-site-editing' );
 		} else if ( 'wp_template_part' === editorPostType && ! closeButtonLabel ) {
-			defaultLabel = __( 'Template Parts' );
+			defaultLabel = __( 'Template Parts', 'full-site-editing' );
 		}
 
 		ReactDOM.render(

--- a/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/plugins/template-update-notice/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/plugins/template-update-notice/index.js
@@ -12,7 +12,7 @@ domReady( () => {
 	}
 	dispatch( 'core/notices' ).createNotice(
 		'info',
-		__( 'Updates to this template will affect all pages on your site.' ),
+		__( 'Updates to this template will affect all pages on your site.', 'full-site-editing' ),
 		{
 			isDismissible: false,
 		}

--- a/apps/full-site-editing/full-site-editing-plugin/global-styles/src/font-pairings-panel.js
+++ b/apps/full-site-editing/full-site-editing-plugin/global-styles/src/font-pairings-panel.js
@@ -14,7 +14,7 @@ import loadFontPairingPreview from './font-pairings-panel-previews';
 export default ( { fontPairings, fontBase, fontHeadings, update } ) => {
 	return (
 		<>
-			<h3>{ __( 'Font Pairings' ) }</h3>
+			<h3>{ __( 'Font Pairings', 'full-site-editing' ) }</h3>
 			{ fontPairings && fontHeadings && fontBase ? (
 				<div role="listbox">
 					{ fontPairings.map( ( { label, headings, base, preview } ) => {
@@ -43,7 +43,7 @@ export default ( { fontPairings, fontBase, fontHeadings, update } ) => {
 					} ) }
 				</div>
 			) : (
-				<NoSupport unsupportedFeature={ __( 'font pairings' ) } />
+				<NoSupport unsupportedFeature={ __( 'font pairings', 'full-site-editing' ) } />
 			) }
 		</>
 	);

--- a/apps/full-site-editing/full-site-editing-plugin/global-styles/src/font-selection-panel.js
+++ b/apps/full-site-editing/full-site-editing-plugin/global-styles/src/font-selection-panel.js
@@ -24,20 +24,20 @@ export default ( {
 	updateHeadingsFont,
 } ) => {
 	if ( ! fontBaseOptions || ! fontHeadingsOptions ) {
-		return <NoSupport unsupportedFeature={ __( 'custom font selection' ) } />;
+		return <NoSupport unsupportedFeature={ __( 'custom font selection', 'full-site-editing' ) } />;
 	}
 
 	return (
 		<>
 			<SelectControl
-				label={ __( 'Heading Font' ) }
+				label={ __( 'Heading Font', 'full-site-editing' ) }
 				value={ fontHeadings }
 				options={ fontHeadingsOptions }
 				onChange={ ( newValue ) => updateHeadingsFont( newValue ) }
 				style={ { fontFamily: fontHeadings !== 'unset' ? fontHeadings : fontHeadingsDefault } }
 			/>
 			<SelectControl
-				label={ __( 'Base Font' ) }
+				label={ __( 'Base Font', 'full-site-editing' ) }
 				value={ fontBase }
 				options={ fontBaseOptions }
 				onChange={ ( newValue ) => updateBaseFont( newValue ) }

--- a/apps/full-site-editing/full-site-editing-plugin/global-styles/src/global-styles-sidebar.js
+++ b/apps/full-site-editing/full-site-editing-plugin/global-styles/src/global-styles-sidebar.js
@@ -1,10 +1,9 @@
 /**
  * External dependencies
  */
-import { PluginSidebar } from '@wordpress/edit-post';
+import { PluginSidebar, PluginSidebarMoreMenuItem } from '@wordpress/edit-post';
 import { Button, PanelBody } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
-import { PluginSidebarMoreMenuItem } from '@wordpress/edit-post';
 
 /**
  * Internal dependencies
@@ -39,7 +38,7 @@ const PanelActionButtons = ( {
 } ) => (
 	<div className={ className }>
 		<Button disabled={ ! hasLocalChanges } isDefault onClick={ resetAction }>
-			{ __( 'Reset' ) }
+			{ __( 'Reset', 'full-site-editing' ) }
 		</Button>
 		<Button
 			className={ 'global-styles-sidebar__publish-button' }
@@ -47,7 +46,7 @@ const PanelActionButtons = ( {
 			isPrimary
 			onClick={ publishAction }
 		>
-			{ __( 'Publish' ) }
+			{ __( 'Publish', 'full-site-editing' ) }
 		</Button>
 	</div>
 );
@@ -73,26 +72,31 @@ export default ( {
 	return (
 		<>
 			<PluginSidebarMoreMenuItem icon={ <GlobalStylesIcon /> } target="global-styles">
-				{ __( 'Global Styles' ) }
+				{ __( 'Global Styles', 'full-site-editing' ) }
 			</PluginSidebarMoreMenuItem>
 			<PluginSidebar
 				icon={ <GlobalStylesIcon /> }
 				name={ 'global-styles' }
-				title={ __( 'Global Styles' ) }
+				title={ __( 'Global Styles', 'full-site-editing' ) }
 				className="global-styles-sidebar"
 			>
 				<PanelBody>
 					<p>
 						{
 							/* translators: %s: Name of site. */
-							sprintf( __( 'You are customizing %s.' ), siteName )
+							sprintf( __( 'You are customizing %s.', 'full-site-editing' ), siteName )
 						}
 					</p>
-					<p>{ __( 'Any change you make here will apply to the entire website.' ) }</p>
+					<p>
+						{ __(
+							'Any change you make here will apply to the entire website.',
+							'full-site-editing'
+						) }
+					</p>
 					{ hasLocalChanges ? (
 						<div>
 							<p>
-								<em>{ __( 'You have unsaved changes.' ) }</em>
+								<em>{ __( 'You have unsaved changes.', 'full-site-editing' ) }</em>
 							</p>
 							<PanelActionButtons
 								hasLocalChanges={ hasLocalChanges }
@@ -102,7 +106,7 @@ export default ( {
 						</div>
 					) : null }
 				</PanelBody>
-				<PanelBody title={ __( 'Font Selection' ) }>
+				<PanelBody title={ __( 'Font Selection', 'full-site-editing' ) }>
 					<FontSelectionPanel
 						fontBase={ fontBase }
 						fontBaseDefault={ fontBaseDefault }
@@ -125,7 +129,7 @@ export default ( {
 				<PanelBody>
 					{ hasLocalChanges ? (
 						<p>
-							<em>{ __( 'You have unsaved changes.' ) }</em>
+							<em>{ __( 'You have unsaved changes.', 'full-site-editing' ) }</em>
 						</p>
 					) : null }
 					<PanelActionButtons

--- a/apps/full-site-editing/full-site-editing-plugin/global-styles/src/no-support.js
+++ b/apps/full-site-editing/full-site-editing-plugin/global-styles/src/no-support.js
@@ -7,7 +7,10 @@ export default ( { unsupportedFeature } ) => (
 	<p>
 		{
 			/* translators: %s: feature name (i.e. font pairings, etc) */
-			sprintf( __( "Your active theme doesn't support %s." ), unsupportedFeature )
+			sprintf(
+				__( "Your active theme doesn't support %s.", 'full-site-editing' ),
+				unsupportedFeature
+			)
 		}
 	</p>
 );

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/container/controls.js
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/container/controls.js
@@ -15,7 +15,7 @@ import NewPlan from './new-plan';
 /**
  * @typedef { import('./plans').Plan } Plan
  *
- * @typedef { Object } Props
+ * @typedef {object} Props
  * @property { number } selectedPlanId
  * @property { (plan: Plan) => void } onSelected
  * @property { (plan: Plan) => string } formatPrice
@@ -42,7 +42,7 @@ export default function Controls( props ) {
 							{ planDescription && <Fragment>{ planDescription }</Fragment> }
 						</Fragment>
 					}
-					label={ __( 'Select a plan', 'premium-content' ) }
+					label={ __( 'Select a plan', 'full-site-editing' ) }
 					className={ 'premium-content-toolbar-button' }
 				>
 					{ ( { onClose } ) => (

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/container/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/container/edit.js
@@ -39,12 +39,12 @@ import { isPriceValid, minimumTransactionAmountForCurrency } from '.';
 const tabs = [
 	{
 		id: 'premium',
-		label: <span>{ __( 'Subscriber View', 'premium-content' ) }</span>,
+		label: <span>{ __( 'Subscriber View', 'full-site-editing' ) }</span>,
 		className: 'wp-premium-content-subscriber-view',
 	},
 	{
 		id: 'wall',
-		label: <span>{ __( 'Non-subscriber View', 'premium-content' ) }</span>,
+		label: <span>{ __( 'Non-subscriber View', 'full-site-editing' ) }</span>,
 		className: 'wp-premium-content-logged-out-view',
 	},
 ];
@@ -73,7 +73,7 @@ const defaultString = null;
  *
  * @typedef { import('@wordpress/components').withNotices.Props } NoticeProps
  * @typedef { import('./').Attributes } Attributes
- * @typedef { Object } OwnProps
+ * @typedef {object} OwnProps
  * @property { boolean } isSelected
  * @property { string } className
  * @property { string } clientId
@@ -111,7 +111,7 @@ function Edit( props ) {
 		const path = '/wpcom/v2/memberships/product';
 		const method = 'POST';
 		if ( ! attributes.newPlanName || attributes.newPlanName.length === 0 ) {
-			onError( props, __( 'Plan requires a name', 'premium-content' ) );
+			onError( props, __( 'Plan requires a name', 'full-site-editing' ) );
 			callback( false );
 			return;
 		}
@@ -119,7 +119,7 @@ function Edit( props ) {
 		const newPrice = parseFloat( attributes.newPlanPrice );
 		const minPrice = minimumTransactionAmountForCurrency( attributes.newPlanCurrency );
 		const minimumPriceNote = sprintf(
-			__( 'Minimum allowed price is %s.', 'premium-content' ),
+			__( 'Minimum allowed price is %s.', 'full-site-editing' ),
 			formatCurrency( minPrice, attributes.newPlanCurrency )
 		);
 
@@ -130,7 +130,7 @@ function Edit( props ) {
 		}
 
 		if ( ! isPriceValid( attributes.newPlanCurrency, newPrice ) ) {
-			onError( props, __( 'Plan requires a valid price', 'premium-content' ) );
+			onError( props, __( 'Plan requires a valid price', 'full-site-editing' ) );
 			callback( false );
 			return;
 		}
@@ -145,7 +145,7 @@ function Edit( props ) {
 		apiFetch( fetch ).then(
 			/**
 			 * @param { any } result
-			 * @return { void }
+			 * @returns { void }
 			 */
 			( result ) => {
 				/**
@@ -161,17 +161,17 @@ function Edit( props ) {
 				setProducts( products.concat( [ newProduct ] ) );
 				// After successful adding of product, we want to select it. Presumably that is the product user wants.
 				selectPlan( newProduct );
-				onSuccess( props, __( 'Successfully created plan', 'premium-content' ) );
+				onSuccess( props, __( 'Successfully created plan', 'full-site-editing' ) );
 				if ( callback ) {
 					callback( true );
 				}
 			},
 			/**
 			 * @param { Error } error
-			 * @return { void }
+			 * @returns { void }
 			 */
 			() => {
-				onError( props, __( 'There was an error when adding the plan.' ) );
+				onError( props, __( 'There was an error when adding the plan.', 'full-site-editing' ) );
 				if ( callback ) {
 					callback( false );
 				}
@@ -185,15 +185,15 @@ function Edit( props ) {
 	function getPlanDescription( plan ) {
 		const amount = formatCurrency( parseFloat( plan.price ), plan.currency );
 		if ( plan.interval === '1 month' ) {
-			return sprintf( __( '%s / month', 'premium-content' ), amount );
+			return sprintf( __( '%s / month', 'full-site-editing' ), amount );
 		}
 		if ( plan.interval === '1 year' ) {
-			return sprintf( __( '%s / year', 'premium-content' ), amount );
+			return sprintf( __( '%s / year', 'full-site-editing' ), amount );
 		}
 		if ( plan.interval === 'one-time' ) {
 			return amount;
 		}
-		return sprintf( __( '%s / %s', 'premium-content' ), amount, plan.interval );
+		return sprintf( __( '%s / %s', 'full-site-editing' ), amount, plan.interval );
 	}
 
 	/**
@@ -249,7 +249,7 @@ function Edit( props ) {
 						{
 							newPlanCurrency: 'USD',
 							newPlanPrice: 5,
-							newPlanName: __( 'Monthly Subscription' ),
+							newPlanName: __( 'Monthly Subscription', 'full-site-editing' ),
 							newPlanInterval: '1 month',
 						},
 						() => {
@@ -285,8 +285,8 @@ function Edit( props ) {
 				{ props.noticeUI }
 				<Placeholder
 					icon="lock"
-					label={ __( 'Premium Content', 'premium-content' ) }
-					instructions={ __( 'Loading data...', 'premium-content' ) }
+					label={ __( 'Premium Content', 'full-site-editing' ) }
+					instructions={ __( 'Loading data…', 'full-site-editing' ) }
 				>
 					<Spinner />
 				</Placeholder>
@@ -300,10 +300,10 @@ function Edit( props ) {
 				{ props.noticeUI }
 				<Placeholder
 					icon="lock"
-					label={ __( 'Premium Content', 'premium-content' ) }
+					label={ __( 'Premium Content', 'full-site-editing' ) }
 					instructions={ __(
 						"You'll need to upgrade your plan to use the Premium Content block.",
-						'premium-content'
+						'full-site-editing'
 					) }
 				>
 					<Button
@@ -317,11 +317,11 @@ function Edit( props ) {
 						target="_blank"
 						className="premium-content-block-nudge__button"
 					>
-						{ __( 'Upgrade Your Plan', 'premium-content' ) }
+						{ __( 'Upgrade Your Plan', 'full-site-editing' ) }
 					</Button>
 					<div className="membership-button__disclaimer">
 						<ExternalLink href="https://wordpress.com/support/premium-content-block/">
-							{ __( 'Read more about Premium Content and related fees.', 'premium-content' ) }
+							{ __( 'Read more about Premium Content and related fees.', 'full-site-editing' ) }
 						</ExternalLink>
 					</div>
 				</Placeholder>
@@ -404,7 +404,7 @@ function useOutsideAlerter( ref, callback ) {
 /**
  * @param { Props } props
  * @param { string } message
- * @return { void }
+ * @returns { void }
  */
 function onError( props, message ) {
 	const { noticeOperations } = props;
@@ -415,7 +415,7 @@ function onError( props, message ) {
 /**
  * @param { Props } props
  * @param { string } message
- * @return { void }
+ * @returns { void }
  */
 function onSuccess( props, message ) {
 	const { noticeOperations } = props;
@@ -426,7 +426,7 @@ function onSuccess( props, message ) {
 /**
  * @param { Props } props
  * @param { string } connectURL
- * @return { null | string } URL
+ * @returns { null | string } URL
  */
 function getConnectUrl( props, connectURL ) {
 	const { postId } = props;

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/container/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/container/index.js
@@ -53,13 +53,13 @@ const settings = {
 	 * This is the display title for your block, which can be translated with `i18n` functions.
 	 * The block inserter will show this name.
 	 */
-	title: __( 'Premium Content', 'premium-content' ),
+	title: __( 'Premium Content', 'full-site-editing' ),
 
 	/**
 	 * This is a short description for your block, can be translated with `i18n` functions.
 	 * It will be shown in the Block Tab in the Settings Sidebar.
 	 */
-	description: __( 'Restrict access to your content for paying subscribers.', 'premium-content' ),
+	description: __( 'Restrict access to your content for paying subscribers.', 'full-site-editing' ),
 
 	/**
 	 * Blocks are grouped into categories to help users browse and discover them.
@@ -97,9 +97,9 @@ const settings = {
 	keywords: [
 		'premium-content',
 		/* translators: block keyword */
-		__( 'premium', 'premium-content' ),
+		__( 'premium', 'full-site-editing' ),
 		/* translators: block keyword */
-		__( 'paywall', 'premium-content' ),
+		__( 'paywall', 'full-site-editing' ),
 	],
 	edit,
 	save,

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/container/inspector.js
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/container/inspector.js
@@ -24,17 +24,17 @@ const API_STATE_NOT_REQUESTING = 0;
 const API_STATE_REQUESTING = 1;
 
 /**
- * @typedef { Object } PlanAttributes
+ * @typedef {object} PlanAttributes
  * @property { string } newPlanCurrency
  * @property { string } newPlanName
  * @property { number } newPlanPrice
  * @property { string } newPlanInterval
  *
- * @typedef { Object } Currency
+ * @typedef {object} Currency
  * @property { string } label
  * @property { string } symbol
  *
- * @typedef { Object } Props
+ * @typedef {object} Props
  * @property { PlanAttributes } attributes
  * @property { (attributes: Partial<PlanAttributes>) => void } setAttributes
  * @property { string } className
@@ -55,7 +55,7 @@ export default function Inspector( props ) {
 					href={ `https://wordpress.com/earn/payments/${ siteSlug }` }
 					className={ 'wp-block-premium-content-container---link-to-earn' }
 				>
-					{ __( 'Manage your subscriptions.', 'premium-content' ) }
+					{ __( 'Manage your subscriptions.', 'full-site-editing' ) }
 				</ExternalLink>
 			) }
 			<PanelBody
@@ -66,8 +66,8 @@ export default function Inspector( props ) {
 				{ apiState === API_STATE_REQUESTING && (
 					<Placeholder
 						icon="lock"
-						label={ __( 'Premium Content', 'premium-content' ) }
-						instructions={ __( 'Saving plan...', 'premium-content' ) }
+						label={ __( 'Premium Content', 'full-site-editing' ) }
+						instructions={ __( 'Saving plan…', 'full-site-editing' ) }
 					>
 						<Spinner />
 					</Placeholder>
@@ -129,7 +129,7 @@ export default function Inspector( props ) {
 									}
 								}
 							>
-								{ __( 'Add subscription', 'premium-content' ) }
+								{ __( 'Add subscription', 'full-site-editing' ) }
 							</Button>
 						</PanelRow>
 					</div>

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/container/new-plan.js
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/container/new-plan.js
@@ -27,7 +27,7 @@ export default function NewPlan( props ) {
 					props.onClose();
 				} }
 			>
-				{ __( 'Add a new subscription', 'premium-content' ) }
+				{ __( 'Add a new subscription', 'full-site-editing' ) }
 			</MenuItem>
 		</MenuGroup>
 	);

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/container/plans.js
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/container/plans.js
@@ -11,7 +11,7 @@ import Plan from './plan';
 /**
  * @typedef { import('./plan').Plan } Plan
  *
- * @typedef { Object } Props
+ * @typedef {object} Props
  * @property { Plan[] } plans
  * @property { undefined | Plan } selectedPlan
  * @property { (plan: Plan) => void } onSelected

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/container/stripe-nudge.js
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/container/stripe-nudge.js
@@ -10,7 +10,7 @@ import { withDispatch } from '@wordpress/data';
 /**
  * @typedef { import('react').MouseEvent<HTMLElement> } MouseEvent
  *
- * @typedef { Object } Props
+ * @typedef {object} Props
  * @property { (event: MouseEvent) => void } autosaveAndRedirect
  * @property { string } stripeConnectUrl
  * @property { () => void } onClick
@@ -29,7 +29,7 @@ export const StripeNudge = ( { autosaveAndRedirect, stripeConnectUrl } ) => (
 					isDefault
 					className="premium-content-block-nudge__button"
 				>
-					{ __( 'Connect', 'premium-content' ) }
+					{ __( 'Connect', 'full-site-editing' ) }
 				</Button>,
 			]
 		}
@@ -39,12 +39,12 @@ export const StripeNudge = ( { autosaveAndRedirect, stripeConnectUrl } ) => (
 			{ <Dashicon icon="star-filled" /> }
 			<span className="premium-content-block-nudge__text-container">
 				<span className="premium-content-block-nudge__title">
-					{ __( 'Connect to Stripe to use this block on your site', 'premium-content' ) }
+					{ __( 'Connect to Stripe to use this block on your site', 'full-site-editing' ) }
 				</span>
 				<span className="premium-content-block-nudge__message">
 					{ __(
 						'This block will be hidden from your visitors until you connect to Stripe.',
-						'premium-content'
+						'full-site-editing'
 					) }
 				</span>
 			</span>
@@ -62,12 +62,14 @@ export default compose( [
 	withDispatch(
 		/**
 		 * Complicated to define the valid type with JSDoc
+		 *
+		 * @param dispatch
 		 */
 		// @ts-ignore
 		( dispatch, { stripeConnectUrl } ) => ( {
 			/**
 			 * @param { MouseEvent } event
-			 * @return { Promise<void> } When completed
+			 * @returns { Promise<void> } When completed
 			 */
 			autosaveAndRedirect: async ( event ) => {
 				event.preventDefault(); // Don't follow the href before autosaving

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/container/tab.js
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/container/tab.js
@@ -2,12 +2,12 @@
  *
  * @typedef { import('react').ReactNode } ReactNode
  *
- * @typedef { Object } Tab
+ * @typedef {object} Tab
  * @property { string } id
  * @property { (ReactNode | string) } label
  * @property { string } className
  *
- * @typedef { Object } Props
+ * @typedef {object} Props
  * @property { Tab } tab
  * @property { Tab } selectedTab
  * @property { string } className

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/container/tabs.js
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/container/tabs.js
@@ -7,7 +7,7 @@ import { dispatch, select } from '@wordpress/data';
 
 /**
  * @typedef { import('./tab').Tab } Tab
- * @typedef { Object } Props
+ * @typedef {object} Props
  * @property { string } className
  * @property { Tab } selectedTab
  * @property { Tab[] } tabs
@@ -43,7 +43,7 @@ export default function Tabs( props ) {
 				/>
 			) ) }
 			<button onClick={ focusBlock } className="edit components-button is-button is-secondary">
-				{ __( 'Edit', 'premium-content' ) }
+				{ __( 'Edit', 'full-site-editing' ) }
 			</button>
 		</div>
 	);

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/logged-out-view/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/logged-out-view/edit.js
@@ -18,7 +18,7 @@ import SubmitButtons from './submit-buttons';
  * Block edit function
  *
  * @typedef { import('./').Attributes } Attributes
- * @typedef { Object } Props
+ * @typedef {object} Props
  * @property { boolean } isSelected
  * @property { string } className
  * @property { string } clientId
@@ -62,14 +62,14 @@ function Edit( props ) {
 						template={ [
 							[
 								'core/heading',
-								{ content: __( 'Subscribe to get access', 'premium-content' ), level: 3 },
+								{ content: __( 'Subscribe to get access', 'full-site-editing' ), level: 3 },
 							],
 							[
 								'core/paragraph',
 								{
 									content: __(
 										'Read more of this content when you subscribe today.',
-										'premium-content'
+										'full-site-editing'
 									),
 								},
 							],

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/logged-out-view/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/logged-out-view/index.js
@@ -15,7 +15,7 @@ import { registerFormatType, unregisterFormatType } from '@wordpress/rich-text';
 const name = 'premium-content/logged-out-view';
 const category = 'common';
 /**
- * @typedef {Object} Attributes
+ * @typedef {object} Attributes
  * @property {string} subscribeButtonText
  * @property {string} loginButtonText
  * @property {string} buttonClasses
@@ -62,9 +62,9 @@ const settings = {
 	},
 
 	/* translators: block name */
-	title: __( 'Logged Out View', 'premium-content' ),
+	title: __( 'Logged Out View', 'full-site-editing' ),
 	/* translators: block description */
-	description: __( 'Logged Out View.', 'premium-content' ),
+	description: __( 'Logged Out View.', 'full-site-editing' ),
 	parent: [ 'premium-content/container' ],
 	supports: {
 		// Hide this block from the inserter.

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/logged-out-view/submit-buttons.js
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/logged-out-view/submit-buttons.js
@@ -63,7 +63,7 @@ const applyFallbackStyles = withFallbackStyles( ( node, ownProps ) => {
  * @property { string } slug
  *
  * @typedef { import('./').Attributes } Attributes
- * @typedef { Object } Props
+ * @typedef {object} Props
  * @property { Color } backgroundButtonColor
  * @property { Color } textButtonColor
  * @property { string } fallbackBackgroundColor
@@ -139,7 +139,7 @@ function SubmitButtons( props ) {
 		<div>
 			<div className="wp-block-button premium-content-logged-out-view-button">
 				<RichText
-					placeholder={ __( 'Add text…', 'premium-content' ) }
+					placeholder={ __( 'Add text…', 'full-site-editing' ) }
 					value={ attributes.subscribeButtonText }
 					onChange={ ( nextValue ) => setAttributes( { subscribeButtonText: nextValue } ) }
 					className={ buttonClasses }
@@ -147,7 +147,7 @@ function SubmitButtons( props ) {
 					keepPlaceholderOnFocus
 				/>
 				<RichText
-					placeholder={ __( 'Add text…', 'premium-content' ) }
+					placeholder={ __( 'Add text…', 'full-site-editing' ) }
 					value={ attributes.loginButtonText }
 					onChange={ ( nextValue ) => setAttributes( { loginButtonText: nextValue } ) }
 					className={ buttonClasses }
@@ -157,17 +157,17 @@ function SubmitButtons( props ) {
 			</div>
 			<InspectorControls>
 				<PanelColorSettings
-					title={ __( 'Button Color Settings', 'premium-content' ) }
+					title={ __( 'Button Color Settings', 'full-site-editing' ) }
 					colorSettings={ [
 						{
 							value: backgroundButtonColor || undefined,
 							onChange: setBackgroundButtonColor,
-							label: __( 'Background Color', 'premium-content' ),
+							label: __( 'Background Color', 'full-site-editing' ),
 						},
 						{
 							value: textButtonColor || undefined,
 							onChange: setTextButtonColor,
-							label: __( 'Text Color', 'premium-content' ),
+							label: __( 'Text Color', 'full-site-editing' ),
 						},
 					] }
 				/>

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/subscriber-view/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/subscriber-view/edit.js
@@ -15,7 +15,7 @@ import Context from '../container/context';
 /**
  * Block edit function
  *
- * @typedef { Object } Props
+ * @typedef {object} Props
  * @property { string } clientId
  * @property { string } containerClientId
  * @property { () => void } selectBlock
@@ -43,7 +43,7 @@ function Edit( props ) {
 								{
 									placeholder: __(
 										'Insert the piece of content you want your visitors to see after they subscribe.',
-										'premium-content'
+										'full-site-editing'
 									),
 								},
 							],

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/subscriber-view/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/subscriber-view/index.js
@@ -17,9 +17,9 @@ const settings = {
 	attributes: {},
 
 	/* translators: block name */
-	title: __( 'Subscriber View', 'premium-content' ),
+	title: __( 'Subscriber View', 'full-site-editing' ),
 	/* translators: block description */
-	description: __( 'Subscriber View.', 'premium-content' ),
+	description: __( 'Subscriber View.', 'full-site-editing' ),
 	parent: [ 'premium-content/container' ],
 	supports: {
 		// Hide this block from the inserter.

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/index.js
@@ -13,7 +13,7 @@ import * as loggedOutView from './blocks/logged-out-view';
  *
  * @typedef {import('@wordpress/blocks').BlockConfiguration} BlockConfiguration
  *
- * @typedef {Object} Block
+ * @typedef {object} Block
  * @property {string} name
  * @property {string} category
  * @property {BlockConfiguration} settings

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/premium-content.php
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/premium-content.php
@@ -38,8 +38,8 @@ require_once __DIR__ . '/premium-content-dom.php';
  * @return void
  */
 function premium_content_block_init() {
-	 $url_path = plugin_dir_url( __FILE__ );
-	$dir       = __DIR__;
+	$url_path = rtrim( plugin_dir_url( __FILE__ ), '/' );
+	$dir      = __DIR__;
 
 	$script_asset_path = "$dir/dist/premium-content.asset.php";
 	if ( ! file_exists( $script_asset_path ) ) {
@@ -94,6 +94,8 @@ function premium_content_block_init() {
 			'render_callback' => '\A8C\FSE\Earn\PremiumContent\premium_content_block_logged_out_view_render',
 		)
 	);
+
+	wp_set_script_translations( 'premium-content-container-block-editor', 'full-site-editing' );
 }
 
 /**
@@ -227,7 +229,7 @@ function premium_content_block_logged_out_view_render( $attributes, $content ) {
 		premium_content_subscription_service()->access_url(),
 		empty( $attributes['buttonClasses'] ) ? 'wp-block-button__link' : esc_attr( $attributes['buttonClasses'] ),
 		esc_attr( $button_styles ),
-		empty( $attributes['loginButtonText'] ) ? __( 'Log In', 'premium-content' ) : $attributes['loginButtonText']
+		empty( $attributes['loginButtonText'] ) ? __( 'Log In', 'full-site-editing' ) : $attributes['loginButtonText']
 	);
 
 	$subscribe_button = sprintf(
@@ -235,7 +237,7 @@ function premium_content_block_logged_out_view_render( $attributes, $content ) {
 		empty( $attributes['buttonClasses'] ) ? 'wp-block-button__link' : esc_attr( $attributes['buttonClasses'] ),
 		empty( $attributes['customTextButtonColor'] ) ? '' : esc_attr( $attributes['customTextButtonColor'] ),
 		empty( $attributes['customBackgroundButtonColor'] ) ? '' : esc_attr( $attributes['customBackgroundButtonColor'] ),
-		empty( $attributes['subscribeButtonText'] ) ? __( 'Subscribe' ) : esc_attr( $attributes['subscribeButtonText'] )
+		empty( $attributes['subscribeButtonText'] ) ? __( 'Subscribe', 'full-site-editing' ) : esc_attr( $attributes['subscribeButtonText'] )
 	);
 
 	return $content . "<div class='wp-block-premium-content-logged-out-view__buttons'>{$subscribe_button}{$login_button}</div>";

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/view.js
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/view.js
@@ -1,4 +1,4 @@
-document.addEventListener( 'DOMContentLoaded', function(){
+document.addEventListener( 'DOMContentLoaded', function () {
 	let premiumContentJWTToken = '';
 
 	/**
@@ -44,6 +44,6 @@ document.addEventListener( 'DOMContentLoaded', function(){
 	}
 
 	if ( typeof window !== 'undefined' ) {
-		window.addEventListener('message', handleIframeResult, false);
+		window.addEventListener( 'message', handleIframeResult, false );
 	}
 } );

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/index.js
@@ -57,7 +57,7 @@ registerPlugin( 'page-templates-sidebar', {
 		return (
 			<PluginDocumentSettingPanel
 				name="Template Modal Opener"
-				title={ __( 'Page Layout' ) }
+				title={ __( 'Page Layout', 'full-site-editing' ) }
 				className="page-template-modal__sidebar" // eslint-disable-line wpcalypso/jsx-classname-namespace
 				icon="none"
 			>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/block-iframe-preview.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/block-iframe-preview.js
@@ -212,7 +212,7 @@ const BlockFramePreview = ( {
 		<div ref={ frameContainerRef }>
 			<iframe
 				ref={ iframeRef }
-				title={ __( 'Preview' ) }
+				title={ __( 'Preview', 'full-site-editing' ) }
 				className={ classnames( 'editor-styles-wrapper', className ) }
 				style={ style }
 			/>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/sidebar-modal-opener.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/sidebar-modal-opener.js
@@ -32,7 +32,7 @@ class SidebarModalOpener extends Component {
 		return (
 			<div className="sidebar-modal-opener">
 				<Button isSecondary onClick={ this.toggleWarningModal }>
-					{ __( 'Change Layout' ) }
+					{ __( 'Change Layout', 'full-site-editing' ) }
 				</Button>
 
 				{ isOpen && (
@@ -51,22 +51,23 @@ class SidebarModalOpener extends Component {
 
 				{ this.state.isWarningOpen && (
 					<Modal
-						title={ __( 'Overwrite Page Content?' ) }
+						title={ __( 'Overwrite Page Content?', 'full-site-editing' ) }
 						isDismissible={ false }
 						onRequestClose={ this.toggleWarningModal }
 						className="sidebar-modal-opener__warning-modal"
 					>
 						<div className="sidebar-modal-opener__warning-text">
 							{ __(
-								`Changing the page's layout will remove any customizations or edits you have already made.`
+								`Changing the page's layout will remove any customizations or edits you have already made.`,
+								'full-site-editing'
 							) }
 						</div>
 						<div className="sidebar-modal-opener__warning-options">
 							<Button isDefault onClick={ this.toggleWarningModal }>
-								{ __( 'Cancel' ) }
+								{ __( 'Cancel', 'full-site-editing' ) }
 							</Button>
 							<Button isPrimary onClick={ this.toggleTemplateModal }>
-								{ __( 'Change Layout' ) }
+								{ __( 'Change Layout', 'full-site-editing' ) }
 							</Button>
 						</div>
 					</Modal>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -393,14 +393,14 @@ class PageTemplateModal extends Component {
 						className="page-template-modal__close-button components-icon-button"
 						onClick={ this.props.toggleTemplateModal }
 						icon="no-alt"
-						label={ __( 'Close Layout Selector' ) }
+						label={ __( 'Close Layout Selector', 'full-site-editing' ) }
 					/>
 				) : (
 					<IconButton
 						className="page-template-modal__close-button components-icon-button"
 						onClick={ this.closeModal }
 						icon="arrow-left-alt2"
-						label={ __( 'Go back' ) }
+						label={ __( 'Go back', 'full-site-editing' ) }
 					/>
 				) }
 

--- a/apps/phpcs.xml
+++ b/apps/phpcs.xml
@@ -6,6 +6,15 @@
 	<rule ref="WordPress-Core"/>
 	<rule ref="WordPress-Docs"/>
 	<rule ref="Generic.CodeAnalysis.UnusedFunctionParameter"/>
+	<rule ref="WordPress.Utils.I18nTextDomainFixer">
+		<properties>
+			<property name="old_text_domain" type="array">
+				<element value="newspack-blocks" />
+				<element value="premium-content" />
+			</property>
+			<property name="new_text_domain" value="full-site-editing" />
+		</properties>
+	</rule>
 
 	<arg name="extensions" value="php"/>
 

--- a/bin/pre-commit-hook.js
+++ b/bin/pre-commit-hook.js
@@ -9,8 +9,10 @@ const _ = require( 'lodash' );
 const path = require( 'path' );
 
 const composerBinDir = path.join( __dirname, '..', 'vendor', 'bin' );
-const phpcsPath = path.join( composerBinDir, 'phpcs' );
-const phpcbfPath = path.join( composerBinDir, 'phpcbf' );
+const phpcsPath =
+	execSync( 'command -v phpcs', { encoding: 'utf8' } ) || path.join( composerBinDir, 'phpcs' );
+const phpcbfPath =
+	execSync( 'command -v phpcbf', { encoding: 'utf8' } ) || path.join( composerBinDir, 'phpcbf' );
 
 console.log(
 	'\nBy contributing to this project, you license the materials you contribute ' +

--- a/bin/pre-commit-hook.js
+++ b/bin/pre-commit-hook.js
@@ -8,11 +8,8 @@ const chalk = require( 'chalk' );
 const _ = require( 'lodash' );
 const path = require( 'path' );
 
-const composerBinDir = path.join( __dirname, '..', 'vendor', 'bin' );
-const phpcsPath =
-	execSync( 'command -v phpcs', { encoding: 'utf8' } ) || path.join( composerBinDir, 'phpcs' );
-const phpcbfPath =
-	execSync( 'command -v phpcbf', { encoding: 'utf8' } ) || path.join( composerBinDir, 'phpcbf' );
+const phpcsPath = getPathForCommand( 'phpcs' );
+const phpcbfPath = getPathForCommand( 'phpcbf' );
 
 console.log(
 	'\nBy contributing to this project, you license the materials you contribute ' +
@@ -36,6 +33,19 @@ function parseGitDiffToPathArray( command ) {
 		.filter( ( name ) => /(?:\.json|\.[jt]sx?|\.scss|\.php)$/.test( name ) );
 }
 
+function getPathForCommand( command ) {
+	const composerBinDir = path.join( __dirname, '..', 'vendor', 'bin' );
+	let path_to_command;
+	try {
+		path_to_command = execSync( 'command -v ' + command, { encoding: 'utf8' } );
+	} catch ( e ) {
+		path_to_command = path.join( composerBinDir, command );
+	}
+	if ( typeof path_to_command === 'undefined' || ! path_to_command ) {
+		return false;
+	}
+	return _.trim( path_to_command );
+}
 function linterFailure() {
 	console.log(
 		chalk.red( 'COMMIT ABORTED:' ),


### PR DESCRIPTION
By not having the correct text-domain specified in our gettext calls, the translations are not being displayed.

#### Changes proposed in this Pull Request

* Adds an eslint rule to check the text domains which can also fix them. This has been added to the newspack sync script.
* Also adds a phpcs "Utils" sniff which will fix wrong text domains during a `phpcbf`.

As a result, we now ensure that the right text domain is set and if it is wrong there is a toolchain that will rewrite them to `full-site-editing` which is what we need when this is published as a plugin or used on WordPress.com.

#### Testing instructions

TBD, needs to be tested on .com