### PR TITLE
Jetpack Cloud: move the log out functionality to the master bar

### DIFF
--- a/client/landing/jetpack-cloud/components/masterbar/index.jsx
+++ b/client/landing/jetpack-cloud/components/masterbar/index.jsx
@@ -4,30 +4,41 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
  */
-import { getCurrentUser } from 'state/current-user/selectors';
 import { getDocumentHeadTitle } from 'state/document-head/selectors';
 import getCurrentRoute from 'state/selectors/get-current-route';
-import Gravatar from 'components/gravatar';
 import Item from 'layout/masterbar/item';
 import JetpackLogo from 'components/jetpack-logo';
 import Masterbar from 'layout/masterbar/masterbar';
+import ProfileDropdown from 'landing/jetpack-cloud/components/profile-dropdown';
 import { useBreakpoint } from '@automattic/viewport-react';
 /**
  * Style dependencies
  */
 import './style.scss';
 
+const useOpenClose = () => {
+	const [ isOpen, setIsOpen ] = React.useState( false );
+	const close = React.useCallback( () => {
+		setIsOpen( false );
+	}, [ setIsOpen ] );
+	const toggle = React.useCallback( () => {
+		setIsOpen( ! isOpen );
+	}, [ isOpen, setIsOpen ] );
+	return { isOpen, close, toggle };
+};
+
 const JetpackCloudMasterBar = () => {
 	const translate = useTranslate();
-	const user = useSelector( getCurrentUser );
 	const headerTitle = useSelector( getDocumentHeadTitle );
 	const currentRoute = useSelector( getCurrentRoute );
 	const isNarrow = useBreakpoint( '<660px' );
 	const isExteriorPage = /^\/(?:backup|scan)\/[^/]*$/.test( currentRoute );
+	const { isOpen, close, toggle } = useOpenClose();
 	return (
 		<Masterbar
 			className="is-jetpack-cloud-masterbar" // eslint-disable-line wpcalypso/jsx-classname-namespace
@@ -45,14 +56,14 @@ const JetpackCloudMasterBar = () => {
 			<Item
 				tipTarget="me"
 				url="#" // @todo: add a correct URL
+				onClick={ toggle }
 				icon="user-circle"
-				className="masterbar__item-me"
-				tooltip={ translate( 'Update your profile, personal settings, and more' ) }
+				className={ classnames( 'masterbar__item-me', {
+					'masterbar__item-me--open': isOpen,
+				} ) }
+				tooltip={ translate( 'Log out of Jetpack Cloud' ) }
 			>
-				<Gravatar user={ user } alt={ translate( 'My Profile' ) } size={ 18 } />
-				<span className="masterbar__item-me-label">
-					{ translate( 'My Profile', { context: 'Toolbar, must be shorter than ~12 chars' } ) }
-				</span>
+				<ProfileDropdown isOpen={ isOpen } close={ close } />
 			</Item>
 		</Masterbar>
 	);

--- a/client/landing/jetpack-cloud/components/masterbar/style.scss
+++ b/client/landing/jetpack-cloud/components/masterbar/style.scss
@@ -45,6 +45,14 @@
 	.masterbar__item-me {
 		min-width: 18px;
 		flex: 0 0 auto;
+
+		// Calypso's masterbar hides this item content and we need to show it
+		// so we override its display property.
+		@include breakpoint-deprecated( '<480px' ) {
+			.masterbar__item-content {
+				display: block;
+			}
+		}
 	}
 
 	.masterbar__item-me--open {

--- a/client/landing/jetpack-cloud/components/masterbar/style.scss
+++ b/client/landing/jetpack-cloud/components/masterbar/style.scss
@@ -46,4 +46,8 @@
 		min-width: 18px;
 		flex: 0 0 auto;
 	}
+
+	.masterbar__item-me--open {
+		box-shadow: 0 -1px 0 1px var( --studio-gray-20 );
+	}
 }

--- a/client/landing/jetpack-cloud/components/profile-dropdown/index.tsx
+++ b/client/landing/jetpack-cloud/components/profile-dropdown/index.tsx
@@ -1,0 +1,110 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { useTranslate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { Button } from '@automattic/components';
+import Gravatar from 'components/gravatar';
+import userUtilities from 'lib/user/utils';
+import { getCurrentUser } from 'state/current-user/selectors';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+/**
+ * Hook that executes `callback` is the 'Escape' key is pressed
+ * or if the user clicks outside of `ref`.
+ *
+ * @param ref       Ref to an HTML element
+ * @param callback  Function to be executed
+ */
+const useCallIfOutOfContext = (
+	ref: React.MutableRefObject< null | HTMLElement >,
+	callback: Function
+) => {
+	const handleEscape = React.useCallback(
+		( event: KeyboardEvent ) => {
+			if ( event.key === 'Escape' ) {
+				callback();
+			}
+		},
+		[ callback ]
+	);
+
+	const handleClick = React.useCallback(
+		( { target } ) => {
+			if ( ref.current && ! ref.current.contains( target ) ) {
+				callback();
+			}
+		},
+		[ ref, callback ]
+	);
+
+	React.useEffect( () => {
+		document.addEventListener( 'keydown', handleEscape );
+		document.addEventListener( 'click', handleClick );
+
+		return () => {
+			document.removeEventListener( 'keydown', handleEscape );
+			document.removeEventListener( 'click', handleClick );
+		};
+	}, [ handleClick, handleEscape ] );
+};
+
+interface Props {
+	isOpen: boolean;
+	close: Function;
+}
+
+const ProfileDropdown: React.FC< Props > = ( { isOpen, close } ) => {
+	const translate = useTranslate();
+	const user = useSelector( getCurrentUser );
+	// @todo: track event (what type?)
+	const logOut = () => userUtilities.logout();
+	const ref = React.useRef( null );
+	useCallIfOutOfContext( ref, close );
+
+	return (
+		<div className="profile-dropdown" ref={ ref }>
+			<Gravatar user={ user } alt={ translate( 'My Profile' ) } size={ 18 } />
+			<span className="profile-dropdown__me-label">
+				{ translate( 'My Profile', { context: 'Toolbar, must be shorter than ~12 chars' } ) }
+			</span>
+			{ isOpen && (
+				<div className="profile-dropdown__items">
+					<div className="profile-dropdown__logout-item">
+						<Gravatar
+							className="profile-dropdown__logout-gravatar"
+							user={ user }
+							alt={ translate( 'My Profile' ) }
+							size={ 64 }
+						/>
+						<span className="profile-dropdown__me-label">
+							{ translate( 'My Profile', {
+								context: 'Toolbar, must be shorter than ~12 chars',
+							} ) }
+						</span>
+
+						<div className="profile-dropdown__logout-username">
+							<span>{ user.username }</span>
+							<Button borderless onClick={ logOut }>
+								{ translate( 'Log out' ) }
+							</Button>
+						</div>
+
+						<div className="profile-dropdown__empty-space"></div>
+					</div>
+				</div>
+			) }
+		</div>
+	);
+};
+
+export default ProfileDropdown;

--- a/client/landing/jetpack-cloud/components/profile-dropdown/style.scss
+++ b/client/landing/jetpack-cloud/components/profile-dropdown/style.scss
@@ -1,0 +1,56 @@
+.profile-dropdown {
+	&__me-label {
+		display: none;
+	}
+
+	&__items {
+		position: absolute;
+		top: 100%;
+		right: -1px;
+		width: 240px;
+		padding: 8px;
+		background: #fff;
+		border: 1px solid var( --studio-gray-20 );
+	}
+
+	&__logout-item {
+		display: flex;
+		align-items: center;
+		height: 80px;
+	}
+
+	&__logout-gravatar.gravatar {
+		position: initial;
+		width: 64px;
+		height: 64px;
+		padding: 0 8px;
+	}
+
+	&__logout-username {
+		flex: 1;
+		display: flex;
+		flex-direction: column;
+		align-items: flex-start;
+
+		span {
+			max-width: 150px;
+			height: 40px;
+			white-space: nowrap;
+			overflow: hidden;
+			text-overflow: ellipsis;
+		}
+	}
+
+	&__logout-button {
+		color: var( --color-text-subtle );
+	}
+
+	&__empty-space {
+		position: absolute;
+		top: -1px;
+		right: 0;
+		height: 1px;
+		width: 54px;
+		background: #fff;
+	}
+}

--- a/client/landing/jetpack-cloud/sections/settings/main.jsx
+++ b/client/landing/jetpack-cloud/sections/settings/main.jsx
@@ -11,7 +11,7 @@ import { localize, useTranslate } from 'i18n-calypso';
 import DocumentHead from 'components/data/document-head';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import ServerCredentialsForm from 'landing/jetpack-cloud/components/server-credentials-form';
-import { Button, Card } from '@automattic/components';
+import { Card } from '@automattic/components';
 import FoldableCard from 'components/foldable-card';
 import getRewindState from 'state/selectors/get-rewind-state';
 import QueryRewindState from 'components/data/query-rewind-state';
@@ -19,7 +19,6 @@ import Main from 'components/main';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import ExternalLink from 'components/external-link';
-import userUtilities from 'lib/user/utils';
 
 /**
  * Style dependencies
@@ -83,21 +82,12 @@ const SettingsPage = () => {
 		setFormOpen( ! isConnected );
 	}, [ isConnected ] );
 
-	// Clears everything user related on the client site by
-	// calling user.clear() which calls store.clearAll();
-	// @todo: track event (what type?)
-	const logOut = () => userUtilities.logout();
-
 	return (
 		<Main className="settings">
 			<DocumentHead title={ translate( 'Settings' ) } />
 			<SidebarNavigation />
 			<QueryRewindState siteId={ siteId } />
 			<PageViewTracker path="/settings/:site" title="Settings" />
-
-			<Button primary scary onClick={ logOut }>
-				Log out
-			</Button>
 
 			<div className="settings__title">
 				<h2>{ translate( 'Server connection details' ) }</h2>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Move the log out functionality to the master bar. 

#### Questions

* Is "Log out of Jetpack Cloud" the right title for the avatar?

#### Testing instructions

* Run this PR
* Go to `http://jetpack.cloud.localhost:3000/`
* Select any site
* Click on the avatar on the top right corner of the screen (master bar)
* Verify the dropdown is closed when you press the Escape key
* Open the dropdown again
* Verify the dropdown is closed when you click outside of it
* Open the dropdown again and click Log out
* Verify you were logged out of the app

Fixes 1169345694087188-as-1176971703839350

#### Demo
![LogOutDropdown](https://user-images.githubusercontent.com/3418513/82706656-8c193380-9c50-11ea-853a-2bb4b4078c7d.gif)

