### PR TITLE
Jetpack Cloud: don't ask for server credentials when we have them (History section)

### DIFF
--- a/client/landing/jetpack-cloud/components/fix-all-threats-dialog/index.tsx
+++ b/client/landing/jetpack-cloud/components/fix-all-threats-dialog/index.tsx
@@ -24,17 +24,10 @@ interface Props {
 	onCloseDialog: Function;
 	onConfirmation: Function;
 	showDialog: boolean;
-	siteId: number;
 	threats: Array< FixableThreat >;
 }
 
-const FixAllThreatsDialog = ( {
-	onConfirmation,
-	onCloseDialog,
-	showDialog,
-	siteId,
-	threats,
-}: Props ) => {
+const FixAllThreatsDialog = ( { onConfirmation, onCloseDialog, showDialog, threats }: Props ) => {
 	const buttons = React.useMemo(
 		() => [
 			<Button className="fix-all-threats-dialog__btn" onClick={ onCloseDialog }>
@@ -49,7 +42,6 @@ const FixAllThreatsDialog = ( {
 
 	return (
 		<ServerCredentialsWizardDialog
-			siteId={ siteId }
 			showDialog={ showDialog }
 			isSingular={ false }
 			onCloseDialog={ onCloseDialog }

--- a/client/landing/jetpack-cloud/components/server-credentials-form/index.jsx
+++ b/client/landing/jetpack-cloud/components/server-credentials-form/index.jsx
@@ -39,10 +39,7 @@ const ServerCredentialsForm = ( {
 	showCancelButton = true,
 } ) => {
 	React.useEffect( () => {
-		// I'm letting the user jump to the next step even if the submission failed
-		// so one can test the UI without having to enter real credentials. On the next
-		// iteration we should fix this.
-		if ( formSubmissionStatus === 'failed' || formSubmissionStatus === 'success' ) {
+		if ( formSubmissionStatus === 'success' ) {
 			onComplete && onComplete();
 		}
 	}, [ formSubmissionStatus, onComplete ] );

--- a/client/landing/jetpack-cloud/components/server-credentials-wizard-dialog/index.tsx
+++ b/client/landing/jetpack-cloud/components/server-credentials-wizard-dialog/index.tsx
@@ -15,6 +15,7 @@ import ExternalLink from 'components/external-link';
 import Gridicon from 'components/gridicon';
 import ServerCredentialsForm from 'landing/jetpack-cloud/components/server-credentials-form';
 import getJetpackCredentials from 'state/selectors/get-jetpack-credentials';
+import { getSelectedSiteId } from 'state/ui/selectors';
 
 /**
  * Style dependencies
@@ -24,7 +25,6 @@ import './style.scss';
 interface Props {
 	onCloseDialog: Function;
 	showDialog: boolean;
-	siteId: number;
 	skipServerCredentials?: boolean;
 	isSingular?: boolean;
 	children: React.ReactNode;
@@ -37,7 +37,6 @@ interface Props {
 const ServerCredentialsWizardDialog = ( {
 	onCloseDialog,
 	showDialog,
-	siteId,
 	skipServerCredentials = false,
 	isSingular = true,
 	buttons,
@@ -46,6 +45,7 @@ const ServerCredentialsWizardDialog = ( {
 	baseDialogClassName,
 	children,
 }: Props ) => {
+	const siteId = useSelector( getSelectedSiteId );
 	const userNeedsCredentials = useSelector( ( state ) =>
 		isEmpty( getJetpackCredentials( state, siteId, 'main' ) )
 	);

--- a/client/landing/jetpack-cloud/components/threat-dialog/index.tsx
+++ b/client/landing/jetpack-cloud/components/threat-dialog/index.tsx
@@ -23,7 +23,6 @@ import { getThreatFix } from 'landing/jetpack-cloud/components/threat-item/utils
 interface Props {
 	threat: Threat;
 	action: 'fix' | 'ignore';
-	siteId: number;
 	siteName: string;
 	showDialog: boolean;
 	onCloseDialog: Function;
@@ -34,7 +33,6 @@ const ThreatDialog: React.FC< Props > = ( {
 	action,
 	onCloseDialog,
 	onConfirmation,
-	siteId,
 	siteName,
 	showDialog,
 	threat,
@@ -69,7 +67,6 @@ const ThreatDialog: React.FC< Props > = ( {
 
 	return (
 		<ServerCredentialsWizardDialog
-			siteId={ siteId }
 			showDialog={ showDialog }
 			onCloseDialog={ onCloseDialog }
 			skipServerCredentials={ action === 'ignore' }

--- a/client/landing/jetpack-cloud/sections/scan/history/index.jsx
+++ b/client/landing/jetpack-cloud/sections/scan/history/index.jsx
@@ -150,6 +150,7 @@ const ScanHistoryPage = ( {
 						showDialog={ showThreatDialog }
 						onCloseDialog={ closeDialog }
 						onConfirmation={ fixThreat }
+						siteId={ siteId }
 						siteName={ siteName }
 						threat={ selectedThreat }
 						action={ 'fix' }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix a bug that made the app ask for server credentials even when we had them. This happened when a user tried to fix a threat from the History section.

#### Testing instructions

* Prerequisites: a site that has
  * Jetpack Scan
  * At least one fixable threat
  * Server credentials
* Run this PR
* Go to `http://jetpack.cloud.localhost:3000/`
* Select a site that fulfills prerequisites
* Go to Scan -> Scanner and ignore a fixable threat
* Go to History 
* Click `[Fix threat]` on the recently ignored threat
* Verify the app doesn't ask for server credentials
* Remove the server credentials (it can be done from WP.com)
* Refresh Jetpack Cloud
* Try to fix the same threat
* Verify you're asked for server credentials

Fixes 1169345694087188-as-1176908000483285

#### Before (asked for credentials even when we have them)
![FixSCBefore](https://user-images.githubusercontent.com/3418513/82709705-912db100-9c57-11ea-89e0-1f81b6371b87.gif)

#### After
![FixSCAfter](https://user-images.githubusercontent.com/3418513/82709680-8541ef00-9c57-11ea-85e2-4ea85241747d.gif)
