### PR TITLE
Checkout: add close button to masterbar that returns user to /plans/ (1)

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -99,6 +99,10 @@ class MasterbarLoggedIn extends React.Component {
 		this.props.recordTracksEvent( 'calypso_masterbar_me_clicked' );
 	};
 
+	clickClose = () => {
+		this.props.recordTracksEvent( 'calypso_masterbar_close_clicked' );
+	};
+
 	preloadMySites = () => {
 		preload( this.props.domainOnlySite ? 'domains' : 'stats' );
 	};
@@ -155,12 +159,20 @@ class MasterbarLoggedIn extends React.Component {
 	}
 
 	render() {
-		const { domainOnlySite, translate, isCheckout, isMigrationInProgress } = this.props;
+		const { domainOnlySite, translate, isCheckout, isMigrationInProgress, siteSlug } = this.props;
 
 		if ( isCheckout === true ) {
 			return (
 				<Masterbar>
 					<div className="masterbar__secure-checkout">
+						<Item
+							url={ '/plans/' + siteSlug }
+							icon="cross"
+							className="masterbar__close-button"
+							onClick={ this.clickClose }
+							tooltip={ translate( 'Close Checkout' ) }
+							tipTarget="close"
+						/>
 						<WordPressWordmark className="masterbar__wpcom-wordmark" />
 						<span className="masterbar__secure-checkout-text">
 							{ translate( 'Secure checkout' ) }

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -37,6 +37,7 @@ import { updateSiteMigrationMeta } from 'state/sites/actions';
 import { requestHttpData } from 'state/data-layer/http-data';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { hasUnseen } from 'state/ui/reader/seen-posts/selectors';
+import getPreviousPath from 'state/selectors/get-previous-path.js';
 
 class MasterbarLoggedIn extends React.Component {
 	static propTypes = {
@@ -159,14 +160,26 @@ class MasterbarLoggedIn extends React.Component {
 	}
 
 	render() {
-		const { domainOnlySite, translate, isCheckout, isMigrationInProgress, siteSlug } = this.props;
+		const {
+			domainOnlySite,
+			translate,
+			isCheckout,
+			isMigrationInProgress,
+			previousPath,
+			siteSlug,
+		} = this.props;
 
 		if ( isCheckout === true ) {
+			let closeUrl = siteSlug ? '/plans/' + siteSlug : '/plans';
+			if ( '' !== previousPath ) {
+				closeUrl = previousPath;
+			}
+
 			return (
 				<Masterbar>
 					<div className="masterbar__secure-checkout">
 						<Item
-							url={ '/plans/' + siteSlug }
+							url={ closeUrl }
 							icon="cross"
 							className="masterbar__close-button"
 							onClick={ this.clickClose }
@@ -264,6 +277,7 @@ export default connect(
 			isMigrationInProgress,
 			migrationStatus: getSiteMigrationStatus( state, currentSelectedSiteId ),
 			currentSelectedSiteId,
+			previousPath: getPreviousPath( state ),
 		};
 	},
 	{ setNextLayoutFocus, recordTracksEvent, updateSiteMigrationMeta }

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -153,6 +153,15 @@ $autobar-height: 20px;
 		animation: none;
 	}
 
+	&.masterbar__close-button {
+		border-right: 1px solid var( --color-primary-light );
+		margin-right: 15px;
+
+		.masterbar__item-content {
+			display: none;
+		}
+	}
+
 	.is-support-session &.is-active {
 		background: var( --studio-orange-70 );
 	}
@@ -561,7 +570,6 @@ a.masterbar__quick-language-switcher {
 .masterbar__secure-checkout {
 	display: flex;
 	align-items: center;
-	padding-left: 10px;
 
 	.masterbar__wpcom-wordmark {
 		margin-right: 5px;


### PR DESCRIPTION
This adds a close button to the masterbar in Signup that takes the user to the /plans/ page.

**Before:**
![Screen Shot 2020-05-22 at 5 04 59 PM](https://user-images.githubusercontent.com/942359/82711092-74db4580-9c52-11ea-8b01-5c94d31910df.png)

**After:**
![Screen Shot 2020-05-22 at 5 04 12 PM](https://user-images.githubusercontent.com/942359/82711042-57a67700-9c52-11ea-8130-0520e3ee126b.png)
