### PR TITLE
Fix On Progress Handler for XHR requests

### DIFF
--- a/client/state/data-layer/wpcom-http/index.js
+++ b/client/state/data-layer/wpcom-http/index.js
@@ -82,8 +82,18 @@ export const queueRequest = ( processOutbound, processInbound ) => ( { dispatch 
 	);
 
 	if ( 'POST' === method && onProgress ) {
-		request.upload.onprogress = ( event ) =>
-			dispatch( extendAction( onProgress, progressMeta( event ) ) );
+		// wpcomProxyRequest request
+		if ( request.upload ) {
+			request.upload.onprogress = ( event ) =>
+				dispatch( extendAction( onProgress, progressMeta( event ) ) );
+			// wpcomXhrWrapper request
+		} else {
+			request.on( 'progress', ( event ) => {
+				if ( 'upload' === event.direction ) {
+					dispatch( extendAction( onProgress, progressMeta( event ) ) );
+				}
+			} );
+		}
 	}
 };
 

--- a/client/state/data-layer/wpcom-http/index.js
+++ b/client/state/data-layer/wpcom-http/index.js
@@ -82,17 +82,10 @@ export const queueRequest = ( processOutbound, processInbound ) => ( { dispatch 
 	);
 
 	if ( 'POST' === method && onProgress ) {
-		// wpcomProxyRequest request
+		// wpcomProxyRequest request - wpcomXhrRequests come through here with .upload
 		if ( request.upload ) {
 			request.upload.onprogress = ( event ) =>
 				dispatch( extendAction( onProgress, progressMeta( event ) ) );
-			// wpcomXhrWrapper request
-		} else {
-			request.on( 'progress', ( event ) => {
-				if ( 'upload' === event.direction ) {
-					dispatch( extendAction( onProgress, progressMeta( event ) ) );
-				}
-			} );
 		}
 	}
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* conditionally attach on progress handler to prevent errors when wpcomXhrRequest has no `upload` property

#### Testing instructions

* boot Jetpack Cloud and verify POST requests ( download, restore, scan now ) work