### PR TITLE
Nav sidebar: Add "view all" and "create new" buttons to sidebar

### DIFF
--- a/apps/full-site-editing/.eslintrc.js
+++ b/apps/full-site-editing/.eslintrc.js
@@ -10,6 +10,10 @@ module.exports = {
 				allowedTextDomain: 'full-site-editing',
 			},
 		],
+
+		// FSE components render in a Gutenberg environment and should
+		// conform to those naming conventions instead of Calypso's.
+		'wpcalypso/jsx-classname-namespace': 0,
 	},
 	ignorePatterns: [ '**/dist/*' ],
 	overrides: [

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/attach-sidebar.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/attach-sidebar.tsx
@@ -9,8 +9,7 @@ import { addFilter } from '@wordpress/hooks';
  * Internal dependencies
  */
 import { STORE_KEY } from './constants';
-import WpcomBlockEditorNavSidebar, { selectNavItems } from './wpcom-block-editor-nav-sidebar';
-import './style.scss';
+import WpcomBlockEditorNavSidebar, { selectNavItems } from './components/nav-sidebar';
 
 async function findElement( selector: string, timeoutMs = 5000 ) {
 	let pendingQuery;

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/.eslintrc.js
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/.eslintrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+	rules: {
+		// These components render in a Gutenberg environment and should
+		// conform to those naming conventions instead of Calypso's.
+		'wpcalypso/jsx-classname-namespace': 0,
+	},
+};

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/.eslintrc.js
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/.eslintrc.js
@@ -1,7 +1,0 @@
-module.exports = {
-	rules: {
-		// These components render in a Gutenberg environment and should
-		// conform to those naming conventions instead of Calypso's.
-		'wpcalypso/jsx-classname-namespace': 0,
-	},
-};

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/create-page/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/create-page/index.tsx
@@ -33,7 +33,12 @@ export default function CreatePage( { postType }: Props ) {
 	);
 
 	return (
-		<Button isPrimary className="wpcom-block-editor-nav-sidebar-create-page" href={ url }>
+		<Button
+			target={ applyFilters( 'a8c.WpcomBlockEditorNavSidebar.linkTarget', undefined ) }
+			isPrimary
+			className="wpcom-block-editor-nav-sidebar-create-page"
+			href={ url }
+		>
 			{ label }
 		</Button>
 	);

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/create-page/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/create-page/index.tsx
@@ -1,0 +1,40 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+import { Button } from '@wordpress/components';
+import React from '@wordpress/element';
+import { applyFilters } from '@wordpress/hooks';
+import { __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+interface Props {
+	postType: any;
+}
+
+export default function CreatePage( { postType }: Props ) {
+	const defaultLabel = get( postType, [ 'labels', 'add_new_item' ], __( 'Create' ) );
+	const label = applyFilters(
+		'a8c.WpcomBlockEditorNavSidebar.createPostLabel',
+		defaultLabel,
+		postType.slug
+	);
+
+	const defaultUrl = addQueryArgs( 'post-new.php', { post_type: postType.slug } );
+	const url = applyFilters(
+		'a8c.WpcomBlockEditorNavSidebar.createPostUrl',
+		defaultUrl,
+		postType.slug
+	);
+
+	return (
+		<Button isPrimary className="wpcom-block-editor-nav-sidebar-create-page" href={ url }>
+			{ label }
+		</Button>
+	);
+}

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/create-page/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/create-page/index.tsx
@@ -18,7 +18,11 @@ interface Props {
 }
 
 export default function CreatePage( { postType }: Props ) {
-	const defaultLabel = get( postType, [ 'labels', 'add_new_item' ], __( 'Create' ) );
+	const defaultLabel = get(
+		postType,
+		[ 'labels', 'add_new_item' ],
+		__( 'Create', 'full-site-editing' )
+	);
 	const label = applyFilters(
 		'a8c.WpcomBlockEditorNavSidebar.createPostLabel',
 		defaultLabel,

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/create-page/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/create-page/style.scss
@@ -1,0 +1,6 @@
+.wpcom-block-editor-nav-sidebar-create-page {
+	display: flex;
+	justify-content: center;
+	width: 100%;
+	margin-bottom: 8px;
+}

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
@@ -15,7 +15,10 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
-import { STORE_KEY } from './constants';
+import { STORE_KEY } from '../../constants';
+import CreatePage from '../create-page';
+import ViewAllPosts from '../view-all-posts';
+import './style.scss';
 
 interface Post {
 	id: number;
@@ -72,15 +75,15 @@ export default function WpcomBlockEditorNavSidebar() {
 	};
 
 	return (
-		<div className="wpcom-block-editor-nav-sidebar__container" aria-hidden={ ! isOpen }>
+		<div className="wpcom-block-editor-nav-sidebar-nav-sidebar__container" aria-hidden={ ! isOpen }>
 			{ ( isOpen || isClosing ) && (
-				<div className="wpcom-block-editor-nav-sidebar__header">
+				<div className="wpcom-block-editor-nav-sidebar-nav-sidebar__header">
 					<Button
 						icon={ wordpress }
 						iconSize={ 36 }
 						className={ classNames( {
-							'wpcom-block-editor-nav-sidebar__is-shrinking': isOpen,
-							'wpcom-block-editor-nav-sidebar__is-growing': isClosing,
+							'is-shrinking': isOpen,
+							'is-growing': isClosing,
 						} ) }
 						onClick={ () => {
 							if ( isOpen ) {
@@ -101,22 +104,26 @@ export default function WpcomBlockEditorNavSidebar() {
 					/>
 				</div>
 			) }
-			<div className="wpcom-block-editor-nav-sidebar__header-space" />
-			<div className="wpcom-block-editor-nav-sidebar__home-button-container">
+			<div className="wpcom-block-editor-nav-sidebar-nav-sidebar__header-space" />
+			<div className="wpcom-block-editor-nav-sidebar-nav-sidebar__home-button-container">
 				<Button
 					href={ closeUrl }
-					className="wpcom-block-editor-nav-sidebar__home-button"
+					className="wpcom-block-editor-nav-sidebar-nav-sidebar__home-button"
 					icon={ chevronLeft }
 					onClick={ handleClose }
 				>
 					{ closeLabel }
 				</Button>
 			</div>
-			<ul className="wpcom-block-editor-nav-sidebar__page-list">
-				{ items.map( ( item ) => (
-					<NavItem key={ item.id } item={ item } />
-				) ) }
-			</ul>
+			<div className="wpcom-block-editor-nav-sidebar-nav-sidebar__controls">
+				<ul className="wpcom-block-editor-nav-sidebar-nav-sidebar__page-list">
+					{ items.map( ( item ) => (
+						<NavItem key={ item.id } item={ item } />
+					) ) }
+				</ul>
+				<CreatePage postType={ postType } />
+				<ViewAllPosts postType={ postType } />
+			</div>
 		</div>
 	);
 }

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/style.scss
@@ -40,7 +40,7 @@ $transition-period: 200ms;
 	}
 }
 
-.wpcom-block-editor-nav-sidebar__container {
+.wpcom-block-editor-nav-sidebar-nav-sidebar__container {
 	box-sizing: border-box;
 	position: fixed;
 	top: 0;
@@ -52,11 +52,11 @@ $transition-period: 200ms;
 	@include reduce-motion( 'transition' );
 }
 
-.wpcom-block-editor-nav-sidebar__container:not( [aria-hidden=true] ) {
+.wpcom-block-editor-nav-sidebar-nav-sidebar__container:not( [aria-hidden=true] ) {
 	left: 0;
 }
 
-.wpcom-block-editor-nav-sidebar__header {
+.wpcom-block-editor-nav-sidebar-nav-sidebar__header {
 	top: 0;
 	left: 0;
 	position: fixed;
@@ -73,27 +73,27 @@ $transition-period: 200ms;
 		color: #fff !important;
 		box-shadow: none !important;
 
-		&.wpcom-block-editor-nav-sidebar__is-shrinking {
+		&.is-shrinking {
 			animation: wpcom-block-editor-nav-sidebar__shrink $transition-period normal forwards;
 			@include reduce-motion( 'animation' );
 		}
-		&.wpcom-block-editor-nav-sidebar__is-growing {
+		&.is-growing {
 			animation: wpcom-block-editor-nav-sidebar__grow $transition-period normal forwards;
 			@include reduce-motion( 'animation' );
 		}
 	}
 }
 
-.wpcom-block-editor-nav-sidebar__header-space {
+.wpcom-block-editor-nav-sidebar-nav-sidebar__header-space {
 	height: $header-height;
 	border-bottom: $border;
 }
 
-.wpcom-block-editor-nav-sidebar__home-button-container {
+.wpcom-block-editor-nav-sidebar-nav-sidebar__home-button-container {
 	border-bottom: $border;
 }
 
-.wpcom-block-editor-nav-sidebar__home-button {
+.wpcom-block-editor-nav-sidebar-nav-sidebar__home-button {
 	height: 46px;
 	width: 100%;
 	font-weight: 600;
@@ -101,15 +101,15 @@ $transition-period: 200ms;
 	box-shadow: none !important;
 }
 
-.wpcom-block-editor-nav-sidebar__home-button:hover {
+.wpcom-block-editor-nav-sidebar-nav-sidebar__home-button:hover {
 	text-decoration: underline;
 }
 
-.wpcom-block-editor-nav-sidebar__page-list {
-	margin: 10px;
+.wpcom-block-editor-nav-sidebar-nav-sidebar__controls {
+	padding: 10px;
 }
 
-.wpcom-block-editor-nav-sidebar__page-list li:hover {
+.wpcom-block-editor-nav-sidebar-nav-sidebar__page-list li:hover {
 	background: black;
 	color: white;
 }

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/view-all-posts/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/view-all-posts/index.tsx
@@ -1,0 +1,44 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+import { Button as OriginalButton } from '@wordpress/components';
+import React from '@wordpress/element';
+import { applyFilters } from '@wordpress/hooks';
+import { __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+interface Props {
+	postType: any;
+}
+
+const Button = ( { children, ...rest }: OriginalButton.Props & { isSecondary?: boolean } ) => (
+	<OriginalButton { ...rest }>{ children }</OriginalButton>
+);
+
+export default function ViewAllPosts( { postType }: Props ) {
+	const defaultLabel = get( postType, [ 'labels', 'view_items' ], __( 'Back' ) );
+	const label = applyFilters(
+		'a8c.WpcomBlockEditorNavSidebar.allPostsLabel',
+		defaultLabel,
+		postType.slug
+	);
+
+	const defaultUrl = addQueryArgs( 'edit.php', { post_type: postType.slug } );
+	const url = applyFilters(
+		'a8c.WpcomBlockEditorNavSidebar.allPostsUrl',
+		defaultUrl,
+		postType.slug
+	);
+
+	return (
+		<Button isSecondary className="wpcom-block-editor-nav-sidebar-view-all-posts" href={ url }>
+			{ label }
+		</Button>
+	);
+}

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/view-all-posts/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/view-all-posts/index.tsx
@@ -37,7 +37,12 @@ export default function ViewAllPosts( { postType }: Props ) {
 	);
 
 	return (
-		<Button isSecondary className="wpcom-block-editor-nav-sidebar-view-all-posts" href={ url }>
+		<Button
+			target={ applyFilters( 'a8c.WpcomBlockEditorNavSidebar.linkTarget', undefined ) }
+			isSecondary
+			className="wpcom-block-editor-nav-sidebar-view-all-posts"
+			href={ url }
+		>
 			{ label }
 		</Button>
 	);

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/view-all-posts/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/view-all-posts/index.tsx
@@ -22,7 +22,11 @@ const Button = ( { children, ...rest }: OriginalButton.Props & { isSecondary?: b
 );
 
 export default function ViewAllPosts( { postType }: Props ) {
-	const defaultLabel = get( postType, [ 'labels', 'view_items' ], __( 'Back' ) );
+	const defaultLabel = get(
+		postType,
+		[ 'labels', 'view_items' ],
+		__( 'Back', 'full-site-editing' )
+	);
 	const label = applyFilters(
 		'a8c.WpcomBlockEditorNavSidebar.allPostsLabel',
 		defaultLabel,

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/view-all-posts/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/view-all-posts/style.scss
@@ -1,0 +1,5 @@
+.wpcom-block-editor-nav-sidebar-view-all-posts {
+	display: flex;
+	justify-content: center;
+	width: 100%;
+}

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -818,6 +818,13 @@ function getCalypsoUrlInfo( calypsoPort ) {
 			return url;
 		}
 	);
+
+	// All links should open outside the iframe
+	addFilter(
+		'a8c.WpcomBlockEditorNavSidebar.linkTarget',
+		'wpcom-block-editor/getSiteSlug',
+		() => '_parent'
+	);
 }
 
 /**

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -734,6 +734,53 @@ function getGutenboardingStatus( calypsoPort ) {
 }
 
 /**
+ * Hooks the nav sidebar to change some of its button labels and behaviour.
+ *
+ * @param {MessagePort} calypsoPort Port used for communication with parent frame.
+ */
+function getNavSidebarLabels( calypsoPort ) {
+	let allPostsLabels = null;
+	let createPostLabels = null;
+
+	const { port1, port2 } = new MessageChannel();
+	calypsoPort.postMessage(
+		{
+			action: 'getNavSidebarLabels',
+			payload: {},
+		},
+		[ port2 ]
+	);
+	port1.onmessage = ( { data } ) => {
+		allPostsLabels = data.allPostsLabels;
+		createPostLabels = data.createPostLabels;
+	};
+
+	addFilter(
+		'a8c.WpcomBlockEditorNavSidebar.allPostsLabel',
+		'wpcom-block-editor/getNavSidebarLabels',
+		( label, postType ) => {
+			if ( allPostsLabels && allPostsLabels[ postType ] ) {
+				return allPostsLabels[ postType ];
+			}
+
+			return label;
+		}
+	);
+
+	addFilter(
+		'a8c.WpcomBlockEditorNavSidebar.createPostLabel',
+		'wpcom-block-editor/getNavSidebarLabels',
+		( label, postType ) => {
+			if ( createPostLabels && createPostLabels[ postType ] ) {
+				return createPostLabels[ postType ];
+			}
+
+			return label;
+		}
+	);
+}
+
+/**
  * Passes uncaught errors in window.onerror to Calypso for logging.
  *
  * @param {MessagePort} calypsoPort Port used for communication with parent frame.
@@ -850,6 +897,8 @@ function initPort( message ) {
 		getCloseButtonUrl( calypsoPort );
 
 		getGutenboardingStatus( calypsoPort );
+
+		getNavSidebarLabels( calypsoPort );
 
 		handleUncaughtErrors( calypsoPort );
 	}

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -758,25 +758,13 @@ function getNavSidebarLabels( calypsoPort ) {
 	addFilter(
 		'a8c.WpcomBlockEditorNavSidebar.allPostsLabel',
 		'wpcom-block-editor/getNavSidebarLabels',
-		( label, postType ) => {
-			if ( allPostsLabels && allPostsLabels[ postType ] ) {
-				return allPostsLabels[ postType ];
-			}
-
-			return label;
-		}
+		( label, postType ) => ( allPostsLabels && allPostsLabels[ postType ] ) || label
 	);
 
 	addFilter(
 		'a8c.WpcomBlockEditorNavSidebar.createPostLabel',
 		'wpcom-block-editor/getNavSidebarLabels',
-		( label, postType ) => {
-			if ( createPostLabels && createPostLabels[ postType ] ) {
-				return createPostLabels[ postType ];
-			}
-
-			return label;
-		}
+		( label, postType ) => ( createPostLabels && createPostLabels[ postType ] ) || label
 	);
 }
 

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -6,6 +6,7 @@ import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import { endsWith, get, map, partial, pickBy, startsWith, isArray } from 'lodash';
 import url from 'url';
+import { localize, LocalizeProps } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -103,9 +104,13 @@ enum EditorActions {
 	GetCloseButtonUrl = 'getCloseButtonUrl',
 	LogError = 'logError',
 	GetGutenboardingStatus = 'getGutenboardingStatus',
+	GetNavSidebarLabels = 'getNavSidebarLabels',
 }
 
-class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedFormProps, State > {
+class CalypsoifyIframe extends Component<
+	Props & ConnectedProps & ProtectedFormProps & LocalizeProps,
+	State
+> {
 	state: State = {
 		isMediaModalVisible: false,
 		isIframeLoaded: false,
@@ -302,6 +307,21 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 			ports[ 0 ].postMessage( {
 				isGutenboarding,
 				frankenflowUrl: `${ window.location.origin }/start/new-launch?siteSlug=${ this.props.siteSlug }&source=editor`,
+			} );
+		}
+
+		if ( EditorActions.GetNavSidebarLabels === action ) {
+			const { translate } = this.props;
+
+			ports[ 0 ].postMessage( {
+				allPostsLabels: {
+					page: translate( 'View all pages' ),
+					post: translate( 'View all posts' ),
+				},
+				createPostLabels: {
+					page: translate( 'Create new page' ),
+					post: translate( 'Create new post' ),
+				},
 			} );
 		}
 
@@ -751,4 +771,7 @@ const mapDispatchToProps = {
 
 type ConnectedProps = ReturnType< typeof mapStateToProps > & typeof mapDispatchToProps;
 
-export default connect( mapStateToProps, mapDispatchToProps )( protectForm( CalypsoifyIframe ) );
+export default connect(
+	mapStateToProps,
+	mapDispatchToProps
+)( localize( protectForm( CalypsoifyIframe ) ) );

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -105,6 +105,7 @@ enum EditorActions {
 	LogError = 'logError',
 	GetGutenboardingStatus = 'getGutenboardingStatus',
 	GetNavSidebarLabels = 'getNavSidebarLabels',
+	GetCalypsoUrlInfo = 'getCalypsoUrlInfo',
 }
 
 class CalypsoifyIframe extends Component<
@@ -322,6 +323,13 @@ class CalypsoifyIframe extends Component<
 					page: translate( 'Create new page' ),
 					post: translate( 'Create new post' ),
 				},
+			} );
+		}
+
+		if ( EditorActions.GetCalypsoUrlInfo === action ) {
+			ports[ 0 ].postMessage( {
+				origin: window.location.origin,
+				siteSlug: this.props.siteSlug,
 			} );
 		}
 


### PR DESCRIPTION
_**Note to anyone reading this while preparing a release of the FSE plugin**_

This change doesn't require any release notes. We're developing a new feature which is currently hidden behind a flag.

#### Changes proposed in this Pull Request

![May-25-2020 17-32-59](https://user-images.githubusercontent.com/1500769/82781446-ecf17780-9ead-11ea-803c-769ab3997732.gif)

* Re-arrange files to make room for more components
* Add "View all posts" button
  * `a8c.WpcomBlockEditorNavSidebar.allPostsLabel` hook so calypso can override label
  * `a8c.WpcomBlockEditorNavSidebar.allPostsUrl` hook so calypso can send user back to calypso rather than wp-admin
* Add "Create new post" button
  * `a8c.WpcomBlockEditorNavSidebar.createPostLabel` hook so calypso can override label
  * `a8c.WpcomBlockEditorNavSidebar.createPostUrl` hook so calypso will create new post using iframe'd block editor
* `a8c.WpcomBlockEditorNavSidebar.linkTarget` hook so calypso can ensure links open in the outer frame rather
* Disabled calypso css class name lint rule (names need to be more specific so they don't collide with elements in Gutenberg)

I decided to add a single general purpose `getCalypsoUrlInfo` message to `<CalypsoifyIframe>` rather than individual messages to get the "view all" and "create new" urls. In the future we'll want the ability to build even more calypso urls, like a block editor url for each post id. Seemed better to just give `iframe-bridge-server.js` the building blocks to do it.

I also decided to have messages to fetch the label text from `<CalypsoifyIframe>` rather than have it in `iframe-bridge-server.js`. I don't think the `wpcom-block-editor` app has support for translations.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start up dev environment for calypso, wpcom-block-editor and FSE! 3 seperate apps to make some buttons 🤦 
* Ensure `WPCOM_BLOCK_EDITOR_SIDEBAR` is defined†
* Open a page or post in the calypso block editor
  * Click (W) to open sidebar
  * Button label text should match mockups pbAok1-JQ-p2#comment-1676
  * Clicking link replaces the url in the browser
* Use `wp-env` or something similar to check the FSE plugin works in wp-admin without calypsoify. The button label text might not be perfect; I'm using some pre-existing text that already exists in core. I think it's close enough and we're not expecting this to be used in wp-admin editors initially. It just needs to not break.

---

† If running locally with `wp-env` then define `WPCOM_BLOCK_EDITOR_SIDEBAR` in `apps/full-site-editing/.wp-env.override.json`:
```
    {
      "config": {
      	"WPCOM_BLOCK_EDITOR_SIDEBAR": true
      }
    }
```

Or on the sandbox define it in `0-sandbox.php`