### PR TITLE
Gutenboarding: set the default premium paid plan for premium designs

### DIFF
--- a/client/landing/gutenboarding/hooks/use-selected-plan.ts
+++ b/client/landing/gutenboarding/hooks/use-selected-plan.ts
@@ -9,6 +9,7 @@ import { useSelect } from '@wordpress/data';
 import { STORE_KEY as PLANS_STORE } from '../stores/plans';
 import { STORE_KEY as ONBOARD_STORE } from '../stores/onboard';
 import { usePlanRouteParam } from '../path';
+import { PLAN_FREE } from '../stores/plans/constants';
 
 export function useSelectedPlan() {
 	const selectedPlan = useSelect( ( select ) => select( PLANS_STORE ).getSelectedPlan() );
@@ -18,9 +19,22 @@ export function useSelectedPlan() {
 
 	const hasPaidDomain = useSelect( ( select ) => select( ONBOARD_STORE ).hasPaidDomain() );
 	const hasPaidDesign = useSelect( ( select ) => select( ONBOARD_STORE ).hasPaidDesign() );
+
 	const defaultPlan = useSelect( ( select ) =>
 		select( PLANS_STORE ).getDefaultPlan( hasPaidDomain, hasPaidDesign )
 	);
+
+	// If the selected plan is not a paid plan
+	// and the user selects a premium domain
+	// return the default paid plan.
+	if (
+		selectedPlan?.getStoreSlug() === PLAN_FREE &&
+		defaultPlan?.getStoreSlug() !== PLAN_FREE &&
+		! planFromPath &&
+		hasPaidDesign
+	) {
+		return defaultPlan;
+	}
 
 	/**
 	 * Plan is decided in this order

--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -11,8 +11,6 @@ import React from 'react';
  * Internal dependencies
  */
 import { STORE_KEY as ONBOARD_STORE } from '../../stores/onboard';
-import { STORE_KEY as PLANS_STORE } from '../../stores/plans';
-import { DEFAULT_PAID_PLAN } from '../../stores/plans/constants';
 import { SubTitle, Title } from '../../components/titles';
 import { usePath, Step } from '../../path';
 import { useTrackStep } from '../../hooks/use-track-step';
@@ -33,25 +31,11 @@ const DesignSelector: React.FunctionComponent = () => {
 
 	const { setSelectedDesign, setFonts } = useDispatch( ONBOARD_STORE );
 	const { getSelectedDesign, hasPaidDesign } = useSelect( ( select ) => select( ONBOARD_STORE ) );
-	const { setPlan } = useDispatch( PLANS_STORE );
 
 	useTrackStep( 'DesignSelection', () => ( {
 		selected_design: getSelectedDesign()?.slug,
 		is_selected_design_premium: hasPaidDesign(),
 	} ) );
-
-	const handleDesignSelect = ( design: Design ) => {
-		setSelectedDesign( design );
-
-		// Update fonts to the design defaults
-		setFonts( design.fonts );
-
-		if ( design.is_premium ) {
-			setPlan( DEFAULT_PAID_PLAN );
-		}
-
-		push( makePath( Step.Style ) );
-	};
 
 	return (
 		<div className="gutenboarding-page design-selector">
@@ -76,7 +60,14 @@ const DesignSelector: React.FunctionComponent = () => {
 						<button
 							key={ design.slug }
 							className="design-selector__design-option"
-							onClick={ () => handleDesignSelect( design ) }
+							onClick={ () => {
+								setSelectedDesign( design );
+
+								// Update fonts to the design defaults
+								setFonts( design.fonts );
+
+								push( makePath( Step.Style ) );
+							} }
 						>
 							<span className="design-selector__image-frame">
 								<img

--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -11,6 +11,8 @@ import React from 'react';
  * Internal dependencies
  */
 import { STORE_KEY as ONBOARD_STORE } from '../../stores/onboard';
+import { STORE_KEY as PLANS_STORE } from '../../stores/plans';
+import { DEFAULT_PAID_PLAN } from '../../stores/plans/constants';
 import { SubTitle, Title } from '../../components/titles';
 import { usePath, Step } from '../../path';
 import { useTrackStep } from '../../hooks/use-track-step';
@@ -31,11 +33,25 @@ const DesignSelector: React.FunctionComponent = () => {
 
 	const { setSelectedDesign, setFonts } = useDispatch( ONBOARD_STORE );
 	const { getSelectedDesign, hasPaidDesign } = useSelect( ( select ) => select( ONBOARD_STORE ) );
+	const { setPlan } = useDispatch( PLANS_STORE );
 
 	useTrackStep( 'DesignSelection', () => ( {
 		selected_design: getSelectedDesign()?.slug,
 		is_selected_design_premium: hasPaidDesign(),
 	} ) );
+
+	const handleDesignSelect = ( design: Design ) => {
+		setSelectedDesign( design );
+
+		// Update fonts to the design defaults
+		setFonts( design.fonts );
+
+		if ( design.is_premium ) {
+			setPlan( DEFAULT_PAID_PLAN );
+		}
+
+		push( makePath( Step.Style ) );
+	};
 
 	return (
 		<div className="gutenboarding-page design-selector">
@@ -60,14 +76,7 @@ const DesignSelector: React.FunctionComponent = () => {
 						<button
 							key={ design.slug }
 							className="design-selector__design-option"
-							onClick={ () => {
-								setSelectedDesign( design );
-
-								// Update fonts to the design defaults
-								setFonts( design.fonts );
-
-								push( makePath( Step.Style ) );
-							} }
+							onClick={ () => handleDesignSelect( design ) }
 						>
 							<span className="design-selector__image-frame">
 								<img


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR adds to the design select handler to set the plan to `DEFAULT_PAID_PLAN` when a user selects a premium design.

![paid-plan-mania](https://user-images.githubusercontent.com/6458278/82768375-fceb6600-9e71-11ea-99c1-9dfaf236deec.gif)

## Testing instructions

### Default behaviour

1. Head over to `/new` 
2. Select a non-premium design 
3. If you haven't selected a plan from the grid, you should see "View Plan"
4. Navigate back to the design selector and choose a premium design
5. At the plans step you'll see that you now have the premium plan selected 
6. Repeat steps 2-5 for good measure

### Selecting a plan

1. Head over to `/new` 
2. Select personal or business or e-commerce from the plans grid modal
3. Choose a premium design, then a free design, then a paid domain, then a free domain
4. Your plan selection should persist until you change it in the plans grid

### Plans step should show if you don't select a plan
1. Head over to `/new` 
2. Select a a premium design and continue through the flow
3. You should see the plans grid step (not modal)
4. Navigate back to the design selector and choose a free design, then continue through the flow
5. You should see the plans grid step (not modal)

### Plans in the path

1. Head over to `/new/business` 
2. The business plan label should be selected in the top-right
3. Choose premium design. The business plan should still be selected
4. Go back and select a free design. The business plan should still be selected

### Paid domains

1. Head over to `/new` 
2. Select a paid domain
3. You should see a paid plan label should be selected in the top-right
3. Choose premium design. The paid plan should still be selected
4. Go back and select a free design. The paid plan should still be selected
5. Now select a free domain. You should see "View Plan"

Fixes #42601
