### PR TITLE
Gutenboarding: hide the update button in the editor toolbar

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/gutenboarding-editor-overrides.js
+++ b/apps/wpcom-block-editor/src/calypso/features/gutenboarding-editor-overrides.js
@@ -45,7 +45,6 @@ function updateSettingsBar() {
 		const textContent = document.createTextNode( __( 'Launch' ) );
 		launchLink.appendChild( textContent );
 
-		// Put 'Launch' and 'Save' back on bar in desired order.
 		settingsBar.prepend( launchLink );
 	} );
 }

--- a/apps/wpcom-block-editor/src/calypso/features/gutenboarding-editor-overrides.js
+++ b/apps/wpcom-block-editor/src/calypso/features/gutenboarding-editor-overrides.js
@@ -36,12 +36,6 @@ function updateSettingsBar() {
 		}
 		clearInterval( awaitSettingsBar );
 
-		// 'Update'/'Publish' primary button to become 'Save' tertiary button.
-		const saveButton = settingsBar.querySelector( '.editor-post-publish-button__button' );
-		// This line causes a reconciliation error in React and a page bork
-		// leaving it in there until we can decide on the UX for this component
-		//saveButton && ( saveButton.innerText = __( 'Save' ) );
-
 		// Wrap 'Launch' button link to frankenflow.
 		const launchLink = document.createElement( 'a' );
 		launchLink.href = calypsoifyGutenberg.frankenflowUrl;
@@ -53,6 +47,5 @@ function updateSettingsBar() {
 
 		// Put 'Launch' and 'Save' back on bar in desired order.
 		settingsBar.prepend( launchLink );
-		saveButton && settingsBar.prepend( saveButton );
 	} );
 }

--- a/apps/wpcom-block-editor/src/calypso/features/gutenboarding-editor-overrides.scss
+++ b/apps/wpcom-block-editor/src/calypso/features/gutenboarding-editor-overrides.scss
@@ -1,4 +1,5 @@
 .gutenboarding-editor-overrides {
+	.editor-post-publish-button__button,
 	.editor-post-switch-to-draft {
 		display: none;
 	}
@@ -6,19 +7,5 @@
 	.gutenboarding-editor-overrides__launch-button {
 		padding: 0 12px;
 		margin: 0 12px 0 3px;
-	}
-
-	// Override 'Save' button to have tertiary styles.
-	.edit-post-header__settings {
-		.editor-post-publish-button__button {
-			color: #007cba !important;
-			background: none !important;
-			border: none !important;
-			box-shadow: none !important;
-
-			&[aria-disabled='true'] {
-				opacity: 0.3 !important;
-			}
-		}
 	}
 }


### PR DESCRIPTION
## Changes proposed in this Pull Request

Let's hide the the save/update button and remove the now, redundant JS that shuffles its order!

<img width="799" alt="Screen Shot 2020-05-25 at 11 06 49 am" src="https://user-images.githubusercontent.com/6458278/82769423-dd573c00-9e77-11ea-8047-e26fbff04dca.png">


## Testing instructions

To come

Fixes #42588
