### PR TITLE
Remove two factor from profile screen

### DIFF
--- a/client/me/profile/index.jsx
+++ b/client/me/profile/index.jsx
@@ -23,10 +23,8 @@ import Main from 'components/main';
 import MeSidebarNavigation from 'me/sidebar-navigation';
 import observe from 'lib/mixins/data-observe'; //eslint-disable-line no-restricted-imports
 import ProfileLinks from 'me/profile-links';
-import ReauthRequired from 'me/reauth-required';
 import SectionHeader from 'components/section-header';
 import { localizeUrl } from 'lib/i18n-utils';
-import twoStepAuthorization from 'lib/two-step-authorization';
 import { protectForm } from 'lib/protect-form';
 import { recordGoogleEvent } from 'state/analytics/actions';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
@@ -68,7 +66,6 @@ const Profile = createReactClass( {
 			<Main className="profile">
 				<PageViewTracker path="/me" title="Me > My Profile" />
 				<MeSidebarNavigation />
-				<ReauthRequired twoStepAuthorization={ twoStepAuthorization } />
 				<SectionHeader label={ this.props.translate( 'Profile' ) } />
 				<Card className="profile__settings">
 					<EditGravatar />


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This Pull request removes the two-factor authentication from the profile screen. The two factor authentication request blocks anyone trying to access the /me section and the profile screen doesn't hold any sensitive information. 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check `https://wordpress.com/me` to make sure you have two-factor authentication enabled and that you haven't entered a code int he last 30 days
* Get calypso up and running or use Calypso.live
* now visit `/me` and confirm you don't get prompted to authenticate. 
