### PR TITLE
Add the edit route for me/domains

### DIFF
--- a/client/my-sites/domains/domain-management/edit/index.jsx
+++ b/client/my-sites/domains/domain-management/edit/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { connect } from 'react-redux';
 import React from 'react';
 import page from 'page';
 import { includes } from 'lodash';
@@ -21,6 +22,7 @@ import WpcomDomainType from './domain-types/wpcom-domain-type';
 import RegisteredDomainType from './domain-types/registered-domain-type';
 import MappedDomainType from './domain-types/mapped-domain-type';
 import TransferInDomainType from './domain-types/transfer-in-domain-type';
+import { getCurrentRoute } from 'state/selectors/get-current-route';
 
 /**
  * Style dependencies
@@ -93,8 +95,12 @@ class Edit extends React.Component {
 	};
 
 	goToDomainManagement = () => {
-		page( domainManagementList( this.props.selectedSite.slug ) );
+		page( domainManagementList( this.props.selectedSite.slug, this.props.currentRoute ) );
 	};
 }
 
-export default localize( Edit );
+export default connect( ( state ) => {
+	return {
+		currentRoute: getCurrentRoute( state ),
+	};
+} )( localize( Edit ) );

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -45,6 +45,7 @@ import DocumentHead from 'components/data/document-head';
 import FormattedHeader from 'components/formatted-header';
 import { withLocalizedMoment } from 'components/localized-moment';
 import { successNotice, errorNotice } from 'state/notices/actions';
+import { getCurrentRoute } from 'state/selectors/get-current-route';
 /**
  * Style dependencies
  */
@@ -430,7 +431,14 @@ export class List extends React.Component {
 
 	goToEditDomainRoot = ( domain ) => {
 		if ( domain.type !== type.TRANSFER ) {
-			page( domainManagementEdit( this.props.selectedSite.slug, domain.name ) );
+			page(
+				domainManagementEdit(
+					this.props.selectedSite.slug,
+					domain.name,
+					null,
+					this.props.currentRoute
+				)
+			);
 		} else {
 			page( domainManagementTransferIn( this.props.selectedSite.slug, domain.name ) );
 		}
@@ -487,6 +495,7 @@ export default connect(
 		const isOnFreePlan = get( selectedSite, 'plan.is_free', false );
 
 		return {
+			currentRoute: getCurrentRoute( state ),
 			hasDomainCredit: !! ownProps.selectedSite && hasDomainCredit( state, siteId ),
 			isDomainOnly: isDomainOnlySite( state, siteId ),
 			isAtomicSite: isSiteAutomatedTransfer( state, siteId ),

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -195,6 +195,7 @@ export default function () {
 		paths: [
 			paths.domainManagementEdit( ':site', ':domain' ),
 			paths.domainManagementTransferIn( ':site', ':domain' ),
+			paths.domainManagementEdit( ':site', ':domain', null, paths.domainManagementUserRoot() ),
 		],
 		handlers: [
 			...getCommonHandlers(),

--- a/client/my-sites/domains/paths.js
+++ b/client/my-sites/domains/paths.js
@@ -4,6 +4,13 @@
 import { filter, startsWith } from 'lodash';
 import { stringify } from 'qs';
 
+function resolveRootPath( relativeTo = null ) {
+	if ( relativeTo && relativeTo.startsWith( domainManagementUserRoot() ) ) {
+		return domainManagementUserRoot();
+	}
+	return domainManagementRoot();
+}
+
 export function domainAddNew( siteName, searchTerm ) {
 	const path = `/domains/add/${ siteName }`;
 
@@ -22,11 +29,14 @@ export function domainManagementRoot() {
 	return '/domains/manage';
 }
 
-export function domainManagementList( siteName ) {
+export function domainManagementList( siteName, relativeTo = null ) {
+	if ( relativeTo && relativeTo.startsWith( domainManagementUserRoot() ) ) {
+		return domainManagementUserRoot() + '/';
+	}
 	return domainManagementRoot() + '/' + siteName;
 }
 
-export function domainManagementEdit( siteName, domainName, slug ) {
+export function domainManagementEdit( siteName, domainName, slug, relativeTo = null ) {
 	slug = slug || 'edit';
 
 	// Encodes only real domain names and not parameter placeholders
@@ -36,7 +46,7 @@ export function domainManagementEdit( siteName, domainName, slug ) {
 		domainName = encodeURIComponent( encodeURIComponent( domainName ) );
 	}
 
-	return domainManagementRoot() + '/' + domainName + '/' + slug + '/' + siteName;
+	return resolveRootPath( relativeTo ) + '/' + domainName + '/' + slug + '/' + siteName;
 }
 
 export function domainManagementAddGSuiteUsers( siteName, domainName ) {
@@ -51,23 +61,23 @@ export function domainManagementAddGSuiteUsers( siteName, domainName ) {
 	return path;
 }
 
-export function domainManagementContactsPrivacy( siteName, domainName ) {
-	return domainManagementEdit( siteName, domainName, 'contacts-privacy' );
+export function domainManagementContactsPrivacy( siteName, domainName, relativeTo = null ) {
+	return domainManagementEdit( siteName, domainName, 'contacts-privacy', relativeTo );
 }
 
-export function domainManagementEditContactInfo( siteName, domainName ) {
-	return domainManagementEdit( siteName, domainName, 'edit-contact-info' );
+export function domainManagementEditContactInfo( siteName, domainName, relativeTo = null ) {
+	return domainManagementEdit( siteName, domainName, 'edit-contact-info', relativeTo );
 }
 
-export function domainManagementManageConsent( siteName, domainName ) {
-	return domainManagementEdit( siteName, domainName, 'manage-consent' );
+export function domainManagementManageConsent( siteName, domainName, relativeTo = null ) {
+	return domainManagementEdit( siteName, domainName, 'manage-consent', relativeTo );
 }
 
-export function domainManagementEmail( siteName, domainName ) {
+export function domainManagementEmail( siteName, domainName, relativeTo = null ) {
 	let path;
 
 	if ( domainName ) {
-		path = domainManagementEdit( siteName, domainName, 'email' );
+		path = domainManagementEdit( siteName, domainName, 'email', relativeTo );
 	} else if ( siteName ) {
 		path = domainManagementRoot() + '/email/' + siteName;
 	} else {
@@ -77,60 +87,66 @@ export function domainManagementEmail( siteName, domainName ) {
 	return path;
 }
 
-export function domainManagementEmailForwarding( siteName, domainName ) {
-	return domainManagementEdit( siteName, domainName, 'email-forwarding' );
+export function domainManagementEmailForwarding( siteName, domainName, relativeTo = null ) {
+	return domainManagementEdit( siteName, domainName, 'email-forwarding', relativeTo );
 }
 
-export function domainManagementChangeSiteAddress( siteName, domainName ) {
-	return domainManagementEdit( siteName, domainName, 'change-site-address' );
+export function domainManagementChangeSiteAddress( siteName, domainName, relativeTo = null ) {
+	return domainManagementEdit( siteName, domainName, 'change-site-address', relativeTo );
 }
 
-export function domainManagementNameServers( siteName, domainName ) {
-	return domainManagementEdit( siteName, domainName, 'name-servers' );
+export function domainManagementNameServers( siteName, domainName, relativeTo = null ) {
+	return domainManagementEdit( siteName, domainName, 'name-servers', relativeTo );
 }
 
-export function domainManagementDns( siteName, domainName ) {
-	return domainManagementEdit( siteName, domainName, 'dns' );
+export function domainManagementDns( siteName, domainName, relativeTo = null ) {
+	return domainManagementEdit( siteName, domainName, 'dns', relativeTo );
 }
 
-export function domainManagementRedirectSettings( siteName, domainName ) {
-	return domainManagementEdit( siteName, domainName, 'redirect-settings' );
+export function domainManagementRedirectSettings( siteName, domainName, relativeTo = null ) {
+	return domainManagementEdit( siteName, domainName, 'redirect-settings', relativeTo );
 }
 
-export function domainManagementSecurity( siteName, domainName ) {
-	return domainManagementEdit( siteName, domainName, 'security' );
+export function domainManagementSecurity( siteName, domainName, relativeTo = null ) {
+	return domainManagementEdit( siteName, domainName, 'security', relativeTo );
 }
 
-export function domainManagementPrimaryDomain( siteName, domainName ) {
-	return domainManagementEdit( siteName, domainName, 'primary-domain' );
+export function domainManagementPrimaryDomain( siteName, domainName, relativeTo = null ) {
+	return domainManagementEdit( siteName, domainName, 'primary-domain', relativeTo );
 }
 
-export function domainManagementTransfer( siteName, domainName, transferType = '' ) {
+export function domainManagementTransfer(
+	siteName,
+	domainName,
+	transferType = '',
+	relativeTo = null
+) {
 	return domainManagementEdit(
 		siteName,
 		domainName,
-		filter( [ 'transfer', transferType ] ).join( '/' )
+		filter( [ 'transfer', transferType ] ).join( '/' ),
+		relativeTo
 	);
 }
 
-export function domainManagementTransferIn( siteName, domainName ) {
-	return domainManagementTransfer( siteName, domainName, 'in' );
+export function domainManagementTransferIn( siteName, domainName, relativeTo = null ) {
+	return domainManagementTransfer( siteName, domainName, 'in', relativeTo );
 }
 
-export function domainManagementTransferInPrecheck( siteName, domainName ) {
-	return domainManagementTransfer( siteName, domainName, 'precheck' );
+export function domainManagementTransferInPrecheck( siteName, domainName, relativeTo = null ) {
+	return domainManagementTransfer( siteName, domainName, 'precheck', relativeTo );
 }
 
-export function domainManagementTransferOut( siteName, domainName ) {
-	return domainManagementTransfer( siteName, domainName, 'out' );
+export function domainManagementTransferOut( siteName, domainName, relativeTo = null ) {
+	return domainManagementTransfer( siteName, domainName, 'out', relativeTo );
 }
 
-export function domainManagementTransferToAnotherUser( siteName, domainName ) {
-	return domainManagementTransfer( siteName, domainName, 'other-user' );
+export function domainManagementTransferToAnotherUser( siteName, domainName, relativeTo = null ) {
+	return domainManagementTransfer( siteName, domainName, 'other-user', relativeTo );
 }
 
-export function domainManagementTransferToOtherSite( siteName, domainName ) {
-	return domainManagementTransfer( siteName, domainName, 'other-site' );
+export function domainManagementTransferToOtherSite( siteName, domainName, relativeTo = null ) {
+	return domainManagementTransfer( siteName, domainName, 'other-site', relativeTo );
 }
 
 export function domainMapping( siteName, domain = '' ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Make the domain status page work on /me/domains without changing the context back to the site

#### Testing instructions

* Open /me/domains then click on any domain - you should see the domain status page with the sidebar still showing your user profile. Then click on the back button - you should go back to /me/domains
