### PR TITLE
Design previews: use prefetch instead of preload for better perf

### DIFF
--- a/client/landing/gutenboarding/available-designs.ts
+++ b/client/landing/gutenboarding/available-designs.ts
@@ -169,12 +169,12 @@ export const getDesignImageUrl = ( design: Design ) => {
 /**
  * Asynchronously load available design images
  */
-export function preloadDesignThumbs() {
+export function prefetchDesignThumbs() {
 	if ( typeof window !== 'undefined' ) {
 		availableDesigns.featured.forEach( ( design: Design ) => {
 			const href = getDesignImageUrl( design );
 			const link = document.createElement( 'link' );
-			link.rel = 'preload';
+			link.rel = 'prefetch';
 			link.as = 'image';
 			link.href = href;
 			document.head.appendChild( link );

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
@@ -16,7 +16,7 @@ import { Step, usePath } from '../../path';
 import Link from '../../components/link';
 import SiteTitle from './site-title';
 import { useTrackStep } from '../../hooks/use-track-step';
-import { preloadDesignThumbs } from '../../available-designs';
+import { prefetchDesignThumbs } from '../../available-designs';
 import { recordSiteTitleSkip } from '../../lib/analytics';
 
 /**
@@ -39,7 +39,7 @@ const AcquireIntent: React.FunctionComponent = () => {
 
 	const hasSiteTitle = getSelectedSiteTitle()?.trim().length > 2;
 
-	React.useEffect( preloadDesignThumbs, [] );
+	React.useEffect( prefetchDesignThumbs, [] );
 
 	const handleSiteTitleSubmit = () => {
 		history.push( nextStepPath );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In https://github.com/Automattic/wp-calypso/pull/42494, I implemented style preview preloading while the user is filling their site info. But I used 'preload' instead of 'prefetch'. While results in the previews loaded with higher prio; degrading the interim performance but still improving the style preview page performance.

Thanks @sgomes for catching my mistake.

Changing 'preload' to 'prefetch' is the achieves the desired results (best of both worlds). It loads the previews with low-prio while the user is filling their site name/vertical.

#### Testing

1. Open Chrome DevTools on the Network tab.
2. Navigate to [/new](https://calypso.live/new?branch=update/change-preload-to-prefetch).
3. The waterfall should look like this, the preview JPGs should be loaded **later**
![image](https://user-images.githubusercontent.com/17054134/82804250-3c21b300-9e82-11ea-91b4-5adf6521bf4a.png)

