### PR TITLE
Fix the broken Activity Log pagination

### DIFF
--- a/client/landing/jetpack-cloud/sections/backups/backup-activity-log/index.tsx
+++ b/client/landing/jetpack-cloud/sections/backups/backup-activity-log/index.tsx
@@ -1,9 +1,9 @@
 /**
  * External dependencies
  */
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
-import isEqual from 'lodash/isEqual';
+// import isEqual from 'lodash/isEqual';
 import React, { FunctionComponent, useEffect } from 'react';
 
 /**
@@ -12,7 +12,7 @@ import React, { FunctionComponent, useEffect } from 'react';
 import { getHttpData } from 'state/data-layer/http-data';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { requestActivityLogs, getRequestActivityLogsId } from 'state/data-getters';
-import { setFilter } from 'state/activity-log/actions';
+// import { setFilter } from 'state/activity-log/actions';
 import ActivityCardList from 'landing/jetpack-cloud/components/activity-card-list';
 import DocumentHead from 'components/data/document-head';
 import getActivityLogFilter from 'state/selectors/get-activity-log-filter';
@@ -25,21 +25,22 @@ import SidebarNavigation from 'my-sites/sidebar-navigation';
  */
 import './style.scss';
 
-interface Props {
-	after?: string;
-	before?: string;
-	group?: string;
-	page?: string;
-}
+// interface Props {
+// 	after?: string;
+// 	before?: string;
+// 	group?: string;
+// 	page?: string;
+// }
 
-const BackupActivityLogPage: FunctionComponent< Props > = ( {
-	after,
-	before,
-	group,
-	page = 1,
-} ) => {
+// const BackupActivityLogPage: FunctionComponent = ( {
+// 	after,
+// 	before,
+// 	group,
+// 	page = 1,
+// } ) => {
+const BackupActivityLogPage: FunctionComponent = () => {
 	const translate = useTranslate();
-	const dispatch = useDispatch();
+	// const dispatch = useDispatch();
 
 	const siteId = useSelector( getSelectedSiteId );
 	const filter = useSelector( ( state ) => getActivityLogFilter( state, siteId ) );
@@ -50,27 +51,27 @@ const BackupActivityLogPage: FunctionComponent< Props > = ( {
 	 * ( the filterbar makes modifications to the filter in state THEN navigates to the new page. )
 	 * Since we are loading this page fresh we want to "reset" the filter to what the query args tell us
 	 */
-	useEffect( () => {
-		const processedGroup = group ? group.split( ',' ) : undefined;
-		if (
-			! isEqual( filter.group, processedGroup ) ||
-			filter.after !== after ||
-			filter.before !== before ||
-			filter.page !== page
-		)
-			dispatch( setFilter( siteId, { page: page, after, before, group: processedGroup } ) );
-	}, [
-		after,
-		before,
-		dispatch,
-		filter.after,
-		filter.before,
-		filter.group,
-		filter.page,
-		group,
-		page,
-		siteId,
-	] );
+	// useEffect( () => {
+	// 	const processedGroup = group ? group.split( ',' ) : undefined;
+	// 	if (
+	// 		! isEqual( filter.group, processedGroup ) ||
+	// 		filter.after !== after ||
+	// 		filter.before !== before ||
+	// 		filter.page !== page
+	// 	)
+	// 		dispatch( setFilter( siteId, { page: page, after, before, group: processedGroup } ) );
+	// }, [
+	// 	after,
+	// 	before,
+	// 	dispatch,
+	// 	filter.after,
+	// 	filter.before,
+	// 	filter.group,
+	// 	filter.page,
+	// 	group,
+	// 	page,
+	// 	siteId,
+	// ] );
 
 	// when the filter changes, re-request the logs
 	useEffect( () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fix the pagination in the Activity Log section. It doesn't seem to be working well when you click on any page, the view is reloaded again and it selects page 1 again.

I commented the code block that was causing the issue, reloading the view when we selected a page. After commenting the code, it works as the expected behavior, including the filters.

#### Testing instructions

- Apply the changes
- Check if you can navigate through the pagination in the Activity Log section