### PR TITLE
Jetpack Cloud: fix issues of section titles (missing translation, mobile view)

### DIFF
--- a/client/landing/jetpack-cloud/components/masterbar/style.scss
+++ b/client/landing/jetpack-cloud/components/masterbar/style.scss
@@ -38,6 +38,7 @@
 
 		.masterbar__item-content {
 			margin-top: 2px;
+			line-height: normal;
 			color: var( --color-neutral-80 );
 		}
 	}

--- a/client/landing/jetpack-cloud/sections/backups/backup-activity-log/index.tsx
+++ b/client/landing/jetpack-cloud/sections/backups/backup-activity-log/index.tsx
@@ -79,7 +79,7 @@ const BackupActivityLogPage: FunctionComponent< Props > = ( {
 
 	return (
 		<Main className="backup-activity-log">
-			<DocumentHead title="Activity log" />
+			<DocumentHead title={ translate( 'Activity log' ) } />
 			<SidebarNavigation />
 			<PageViewTracker path="/backup/activity/:site" title="Activity log" />
 			<div className="backup-activity-log__content">

--- a/client/landing/jetpack-cloud/sections/backups/backup-upsell/index.tsx
+++ b/client/landing/jetpack-cloud/sections/backups/backup-upsell/index.tsx
@@ -66,7 +66,7 @@ const BackupsUpsellBody: FunctionComponent = () => {
 
 const BackupsUpsellPage: FunctionComponent< UpsellComponentProps > = ( { reason } ) => (
 	<Main className="backup-upsell">
-		<DocumentHead title="Backups" />
+		<DocumentHead title="Backup" />
 		<SidebarNavigation />
 		<div className="backup-upsell__content">
 			{ 'vp_active_on_site' === reason ? <BackupsVPActiveBody /> : <BackupsUpsellBody /> }

--- a/client/landing/jetpack-cloud/sections/scan/upsell.jsx
+++ b/client/landing/jetpack-cloud/sections/scan/upsell.jsx
@@ -78,7 +78,7 @@ function renderUpsell( reason ) {
 export default function ScanUpsellPage( { reason } ) {
 	return (
 		<Main className="scan__main">
-			<DocumentHead title="Scanner" />
+			<DocumentHead title="Scan" />
 			<SidebarNavigation />
 			<PageViewTracker path="/scan/:site" title="Scanner Upsell" />
 			<div className="scan__content">{ renderUpsell( reason ) }</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The Activity log section title should be translated. It fixes the translation problem in mobile views (small screens). Also, the title section when we are in "upselling" mode, should be the Jetpack product name Backup or Scan.

Before:
![image](https://user-images.githubusercontent.com/9832440/82807545-ddf3d080-9e7f-11ea-9cf2-201cef24dfa6.png)

After:
![image](https://user-images.githubusercontent.com/9832440/82807576-f237cd80-9e7f-11ea-88f5-eb9cf6e0f0a7.png)

Before (iPhone 5/SE):
![image](https://user-images.githubusercontent.com/9832440/82807639-15627d00-9e80-11ea-9660-171451138dd5.png)

After:
![image](https://user-images.githubusercontent.com/9832440/82807690-2f03c480-9e80-11ea-89d6-a959a800b79e.png)

#### Testing instructions

- Apply the changes
- Select a language non-English (Spanish)
- Go to Activity log section and check if the title is translated
- Go to Latest backups section and check if the title fits okay in the header (iPhone 5 mobile view)
- Switch to a site without Scan and Backup product, check if the title of the upsell view is the product name 'Backup' or 'Scan' instead of 'Backups' or 'Scanner'
