### PR TITLE
G Suite: Rename function that determines whether G Suite can be purchased by a user

### DIFF
--- a/client/lib/gsuite/index.js
+++ b/client/lib/gsuite/index.js
@@ -38,7 +38,7 @@ function canDomainAddGSuite( domainName ) {
 		return false;
 	}
 
-	return ! isGSuiteRestricted();
+	return canUserPurchaseGSuite();
 }
 
 /**
@@ -234,22 +234,23 @@ function isGSuiteOrExtraLicenseProductSlug( productSlug ) {
 }
 
 /**
- * Is the user G Suite restricted
+ * Determines whether G Suite can be purchased by the user based on their country.
  *
- * @returns {boolean} - Is the user G Suite restricted
+ * @returns {boolean} true if the user is allowed to purchase G Suite, false otherwise
  */
-function isGSuiteRestricted() {
+function canUserPurchaseGSuite() {
 	const user = userFactory();
 
-	return ! get( user.get(), 'is_valid_google_apps_country', false );
+	return get( user.get(), 'is_valid_google_apps_country', false );
 }
 
 export {
 	canDomainAddGSuite,
+	canUserPurchaseGSuite,
 	getAnnualPrice,
 	getEligibleGSuiteDomain,
-	getGSuiteSupportedDomains,
 	getGSuiteMailboxCount,
+	getGSuiteSupportedDomains,
 	getLoginUrlWithTOSRedirect,
 	getMonthlyPrice,
 	hasGSuiteSupportedDomain,
@@ -259,5 +260,4 @@ export {
 	isGSuiteExtraLicenseProductSlug,
 	isGSuiteOrExtraLicenseProductSlug,
 	isGSuiteProductSlug,
-	isGSuiteRestricted,
 };

--- a/client/lib/gsuite/test/index.js
+++ b/client/lib/gsuite/test/index.js
@@ -3,14 +3,14 @@
  */
 import {
 	canDomainAddGSuite,
+	canUserPurchaseGSuite,
 	getAnnualPrice,
 	getEligibleGSuiteDomain,
-	getMonthlyPrice,
 	getGSuiteSupportedDomains,
+	getMonthlyPrice,
 	hasGSuiteSupportedDomain,
 	hasGSuiteWithUs,
 	hasPendingGSuiteUsers,
-	isGSuiteRestricted,
 } from 'lib/gsuite';
 
 jest.mock( 'lib/user/', () => {
@@ -249,9 +249,9 @@ describe( 'index', () => {
 		} );
 	} );
 
-	describe( '#isGSuiteRestricted', () => {
-		test( 'returns false if user is not G Suite restricted', () => {
-			expect( isGSuiteRestricted() ).toEqual( false );
+	describe( '#canUserPurchaseGSuite', () => {
+		test( 'returns true if the user is allowed to purchase G Suite', () => {
+			expect( canUserPurchaseGSuite() ).toEqual( true );
 		} );
 	} );
 } );

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -19,7 +19,7 @@ import CheckoutSystemDecider from './checkout-system-decider';
 import CheckoutPendingComponent from './checkout-thank-you/pending';
 import CheckoutThankYouComponent from './checkout-thank-you';
 import UpsellNudge from './upsell-nudge';
-import { isGSuiteRestricted } from 'lib/gsuite';
+import { canUserPurchaseGSuite } from 'lib/gsuite';
 import { getRememberedCoupon } from 'lib/cart/actions';
 import { sites } from 'my-sites/controller';
 import CartData from 'components/data/cart';
@@ -136,7 +136,7 @@ export function gsuiteNudge( context, next ) {
 		return null;
 	}
 
-	if ( isGSuiteRestricted() ) {
+	if ( ! canUserPurchaseGSuite() ) {
 		next();
 	}
 

--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -34,7 +34,7 @@ import { isATEnabled } from 'lib/automated-transfer';
 import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
 import { makeLayout, render as clientRender } from 'controller';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
-import { isGSuiteRestricted } from 'lib/gsuite';
+import { canUserPurchaseGSuite } from 'lib/gsuite';
 
 const domainsAddHeader = ( context, next ) => {
 	context.getSiteSelectionHeaderText = () => {
@@ -185,7 +185,7 @@ const transferDomainPrecheck = ( context, next ) => {
 };
 
 const googleAppsWithRegistration = ( context, next ) => {
-	if ( ! isGSuiteRestricted() ) {
+	if ( canUserPurchaseGSuite() ) {
 		context.primary = (
 			<Main>
 				<PageViewTracker

--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -19,7 +19,7 @@ import RegisterDomainStep from 'components/domains/register-domain-step';
 import PlansNavigation from 'my-sites/plans/navigation';
 import Main from 'components/main';
 import { addItem, removeItem } from 'lib/cart/actions';
-import { isGSuiteRestricted, canDomainAddGSuite } from 'lib/gsuite';
+import { canDomainAddGSuite } from 'lib/gsuite';
 import {
 	hasDomainInCart,
 	domainMapping,
@@ -123,7 +123,7 @@ class DomainSearch extends Component {
 
 		addItem( registration );
 
-		if ( ! isGSuiteRestricted() && canDomainAddGSuite( domain ) ) {
+		if ( canDomainAddGSuite( domain ) ) {
 			page( '/domains/add/' + domain + '/google-apps/' + this.props.selectedSiteSlug );
 		} else {
 			page( '/checkout/' + this.props.selectedSiteSlug );

--- a/client/my-sites/email/email-management/index.jsx
+++ b/client/my-sites/email/email-management/index.jsx
@@ -16,11 +16,11 @@ import Header from 'my-sites/domains/domain-management/components/header';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import FormattedHeader from 'components/formatted-header';
 import {
+	canUserPurchaseGSuite,
 	getEligibleGSuiteDomain,
 	hasGSuiteSupportedDomain,
 	hasGSuiteWithAnotherProvider,
 	hasGSuiteWithUs,
-	isGSuiteRestricted,
 } from 'lib/gsuite';
 import { getEligibleEmailForwardingDomain } from 'lib/domains/email-forwarding';
 import getGSuiteUsers from 'state/selectors/get-gsuite-users';
@@ -142,7 +142,7 @@ class EmailManagement extends React.Component {
 
 		const emailForwardingDomain = getEligibleEmailForwardingDomain( selectedDomainName, domains );
 
-		if ( emailForwardingDomain && isGSuiteRestricted() && selectedDomainName ) {
+		if ( emailForwardingDomain && ! canUserPurchaseGSuite() && selectedDomainName ) {
 			return this.addEmailForwardingCard( emailForwardingDomain );
 		}
 


### PR DESCRIPTION
This pull request simply renames the obscure `isGSuiteRestricted()` method into `canUserPurchaseGSuite()`. The more explicit name makes it clearer what the exact intent of this function is. The new name also plays nicely with `canDomainAddGSuite()`.

#### Testing instructions

1. Run `git checkout update/gsuite-method` and start your server, or open a [live branch](https://calypso.live/?branch=update/gsuite-method)
2. Open the [`Domains` page](http://calypso.localhost:3000/domains)
3. Purchase a domain with G Suite
4. Assert that the G Suite account was provisioning succesfully
