### PR TITLE
Site Settings: Add context to the Privacy header in Settings

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -500,7 +500,7 @@ export class SiteSettingsFormGeneral extends Component {
 					isSaving={ isSavingSettings }
 					onButtonClick={ handleSubmitForm }
 					showButton
-					title={ translate( 'Privacy', { context: 'header privacy settings' } ) }
+					title={ translate( 'Privacy', { context: 'Privacy Settings header' } ) }
 				/>
 				<Card>
 					<form>{ this.visibilityOptionsComingSoon() }</form>

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -500,7 +500,7 @@ export class SiteSettingsFormGeneral extends Component {
 					isSaving={ isSavingSettings }
 					onButtonClick={ handleSubmitForm }
 					showButton
-					title={ translate( 'Privacy' ) }
+					title={ translate( 'Privacy', { context: 'header privacy settings' } ) }
 				/>
 				<Card>
 					<form>{ this.visibilityOptionsComingSoon() }</form>


### PR DESCRIPTION
In German we need a different translation for the header but this appears in many other places, so we need to add a context:

<img width="761" alt="Screen Shot 2020-05-21 at 1 21 57 PM" src="https://user-images.githubusercontent.com/203408/82819123-2622eb00-9ea0-11ea-92e9-71ca046ffda4.png">

cc @katinthehatsite 