### PR TITLE
Enable the new domains security screen on production

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -35,6 +35,7 @@
 		"domains/new-status-design": true,
 		"domains/new-status-design/auto-renew": true,
 		"domains/new-status-design/new-options": true,
+		"domains/new-status-design/security-option": true,
 		"editor/before-deprecation": true,
 		"external-media": true,
 		"external-media/google-photos": true,

--- a/config/production.json
+++ b/config/production.json
@@ -34,6 +34,7 @@
 		"domains/new-status-design": true,
 		"domains/new-status-design/auto-renew": true,
 		"domains/new-status-design/new-options": true,
+		"domains/new-status-design/security-option": true,
 		"editor/before-deprecation": true,
 		"external-media": true,
 		"external-media/google-photos": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -37,6 +37,7 @@
 		"domains/new-status-design": true,
 		"domains/new-status-design/auto-renew": true,
 		"domains/new-status-design/new-options": true,
+		"domains/new-status-design/security-option": true,
 		"editor/before-deprecation": true,
 		"external-media": true,
 		"external-media/google-photos": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This one is just turning on a feature flag for the new domain security screen on production

The actual PR that introduces the security screen is this one - https://github.com/Automattic/wp-calypso/pull/41643

#### Testing instructions

* Verify that the security nav item and the security screen is shown for registered domains on production
