### PR TITLE
Typography: Update body font sizes to use Sass vars

### DIFF
--- a/client/assets/stylesheets/_main.scss
+++ b/client/assets/stylesheets/_main.scss
@@ -50,7 +50,7 @@ body,
 body {
 	background: var( --color-surface-backdrop );
 	color: var( --color-text );
-	font-size: 15px;
+	font-size: $font-body;
 	line-height: 1.5;
 
 	-ms-overflow-style: scrollbar;
@@ -195,7 +195,7 @@ address {
 pre {
 	background: var( --color-neutral-0 );
 	font-family: $monospace;
-	font-size: 15px;
+	font-size: $font-body;
 	line-height: 1.6;
 	margin-bottom: 1.6em;
 	padding: 1.6em;

--- a/client/assets/stylesheets/shared/_extends-forms.scss
+++ b/client/assets/stylesheets/shared/_extends-forms.scss
@@ -13,7 +13,7 @@
 	padding: 7px 14px;
 	width: 100%;
 	color: var( --color-neutral-70 );
-	font-size: 16px;
+	font-size: $font-body;
 	line-height: 1.5;
 	border: 1px solid var( --color-neutral-10 );
 	background-color: var( --color-surface );

--- a/client/assets/stylesheets/shared/_forms.scss
+++ b/client/assets/stylesheets/shared/_forms.scss
@@ -140,7 +140,7 @@ select {
 	margin: 0;
 	outline: 0;
 	overflow: hidden;
-	font-size: 16px;
+	font-size: $font-body;
 	font-weight: 400;
 	line-height: 1.4em;
 	text-overflow: ellipsis;

--- a/client/assets/stylesheets/shared/_typography.scss
+++ b/client/assets/stylesheets/shared/_typography.scss
@@ -39,3 +39,12 @@ $root-font-size: 16px;
 // If there are exceptions to these stacks,
 // please mark them with a //typography-exception comment
 // so we can easily search for them later.
+
+// Typography size variables
+
+$font-title-large: rem( 32px );
+$font-title-medium: rem( 24px );
+$font-title-small: rem( 20px );
+$font-body: rem( 16px );
+$font-body-small: rem( 14px );
+$font-body-extra-small: rem( 12px );

--- a/client/blocks/comments/post-comment-content.scss
+++ b/client/blocks/comments/post-comment-content.scss
@@ -35,7 +35,7 @@
 
 .comments__comment-content {
 	@extend %content-font;
-	font-size: 15px;
+	font-size: $font-body;
 	line-height: 1.56;
 	word-break: break-word;
 

--- a/client/blocks/disconnect-jetpack/style.scss
+++ b/client/blocks/disconnect-jetpack/style.scss
@@ -16,7 +16,7 @@
 .disconnect-jetpack__highlight {
 	color: var( --color-text-subtle );
 	margin-bottom: 1.5em;
-	font-size: 16px;
+	font-size: $font-body;
 }
 
 .disconnect-jetpack__feature {

--- a/client/blocks/gdpr-banner/style.scss
+++ b/client/blocks/gdpr-banner/style.scss
@@ -17,12 +17,12 @@
 
 	@include breakpoint-deprecated( '>660px' ) {
 		display: flex;
-		font-size: 16px;
+		font-size: $font-body;
 		padding: 16px 24px;
 	}
 
 	@include breakpoint-deprecated( '>960px' ) {
-		font-size: 16px;
+		font-size: $font-body;
 		padding: 16px 32px;
 		max-width: 960px;
 		left: calc( 50% - 480px );

--- a/client/blocks/get-apps/style.scss
+++ b/client/blocks/get-apps/style.scss
@@ -8,7 +8,7 @@
 }
 
 .get-apps__card-title {
-	font-size: 15px;
+	font-size: $font-body;
 	margin-bottom: 4px;
 
 	@include breakpoint-deprecated('>480px') {
@@ -33,7 +33,7 @@
 	margin-bottom: 4px;
 
 	@include breakpoint-deprecated('>480px') {
-		font-size: 15px;
+		font-size: $font-body;
 	}
 }
 

--- a/client/blocks/get-apps/style.scss
+++ b/client/blocks/get-apps/style.scss
@@ -158,7 +158,7 @@
 }
 
 .get-apps__illustration-heading {
-	font-size: 16px;
+	font-size: $font-body;
 	font-weight: 600;
 	padding: 0 24px;
 

--- a/client/blocks/google-my-business-stats-nudge/style.scss
+++ b/client/blocks/google-my-business-stats-nudge/style.scss
@@ -34,7 +34,7 @@
 }
 
 .google-my-business-stats-nudge__description {
-	font-size: 16px;
+	font-size: $font-body;
 	font-weight: 400;
 }
 

--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -405,7 +405,7 @@
 	font-style: italic;
 
 	@include breakpoint-deprecated( '>660px' ) {
-		font-size: 16px;
+		font-size: $font-body;
 	}
 }
 

--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -180,7 +180,7 @@
 				color: var( --color-text );
 
 				@include breakpoint-deprecated( '>660px' ) {
-					font-size: 15px;
+					font-size: $font-body;
 					padding: 16px 0;
 				}
 			}

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -80,7 +80,7 @@
 	.login__header-subtitle {
 		color: var( --color-primary-10 );
 		margin-top: 1em;
-		font-size: 16px;
+		font-size: $font-body;
 		line-height: 24px;
 		font-weight: 400;
 	}

--- a/client/blocks/reader-combined-card/style.scss
+++ b/client/blocks/reader-combined-card/style.scss
@@ -207,7 +207,7 @@
 }
 
 .reader-combined-card__post .reader-excerpt {
-	font-size: 15px;
+	font-size: $font-body;
 	font-weight: 400;
 	overflow: hidden;
 	max-height: 16px * 1.4 * 1;

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -129,7 +129,7 @@
 	max-width: 720px;
 
 	@include breakpoint-deprecated( '<480px' ) {
-		font-size: 15px;
+		font-size: $font-body;
 		line-height: 24px;
 	}
 
@@ -455,7 +455,7 @@
 .reader-full-post__header-meta {
 	display: flex;
 	flex-direction: row;
-	font-size: 15px;
+	font-size: $font-body;
 	max-width: 750px;
 }
 

--- a/client/blocks/reader-list-item/style.scss
+++ b/client/blocks/reader-list-item/style.scss
@@ -114,7 +114,7 @@
 
 .reader-list-item__site-title {
 	font-weight: 600;
-	font-size: 15px;
+	font-size: $font-body;
 }
 
 .reader-list-item__site-url-timestamp {

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -446,7 +446,7 @@
 }
 
 .reader-post-card .reader-excerpt {
-	font-size: 16px;
+	font-size: $font-body;
 	line-height: 1.55;
 	font-weight: 400;
 	margin-top: 9px;

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -194,7 +194,7 @@
 		}
 
 		.reader-post-card__post-details .reader-excerpt {
-			font-size: 15px;
+			font-size: $font-body;
 			font-weight: 400;
 			margin-top: 4px;
 			max-height: 16px * 1.4;

--- a/client/blocks/reader-related-card/style.scss
+++ b/client/blocks/reader-related-card/style.scss
@@ -129,7 +129,7 @@
 		}
 
 		.reader-related-card__excerpt {
-			font-size: 15px;
+			font-size: $font-body;
 		}
 	}
 
@@ -301,7 +301,7 @@
 
 	&.post-excerpt {
 		display: -webkit-box;
-		font-size: 15px;
+		font-size: $font-body;
 		line-height: 25px;
 		max-height: none;
 		overflow: hidden;

--- a/client/blocks/sharing-preview-pane/style.scss
+++ b/client/blocks/sharing-preview-pane/style.scss
@@ -116,7 +116,7 @@
 	font-family: $sans;
 
 	.sharing-preview-pane__title {
-		font-size: 16px;
+		font-size: $font-body;
 		font-weight: normal;
 		margin: 0;
 	}

--- a/client/blocks/signup-form/crowdsignal.scss
+++ b/client/blocks/signup-form/crowdsignal.scss
@@ -29,7 +29,7 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 
 .signup.is-crowdsignal .formatted-header__subtitle {
 	color: var( --color-text-subtle );
-	font-size: 15px;
+	font-size: $font-body;
 
 	a {
 		font-weight: 600;

--- a/client/blocks/subscription-length-picker/style.scss
+++ b/client/blocks/subscription-length-picker/style.scss
@@ -4,7 +4,7 @@
 	&__header {
 		margin-bottom: 10px;
 		flex-basis: 100%;
-		font-size: 16px;
+		font-size: $font-body;
 	}
 
 	&__options {
@@ -92,7 +92,7 @@
 	}
 
 	.subscription-length-picker__option-description {
-		font-size: 16px;
+		font-size: $font-body;
 		margin-top: 2px;
 	}
 

--- a/client/blocks/support-article-dialog/style.scss
+++ b/client/blocks/support-article-dialog/style.scss
@@ -35,7 +35,7 @@
 	}
 
 	@include breakpoint-deprecated( '<480px' ) {
-		font-size: 15px;
+		font-size: $font-body;
 		line-height: 24px;
 	}
 

--- a/client/blocks/upwork-stats-nudge/style.scss
+++ b/client/blocks/upwork-stats-nudge/style.scss
@@ -30,7 +30,7 @@
 }
 
 .upwork-stats-nudge__description {
-	font-size: 16px;
+	font-size: $font-body;
 	font-weight: 400;
 }
 

--- a/client/components/card-heading/style.scss
+++ b/client/components/card-heading/style.scss
@@ -34,7 +34,7 @@
 }
 
 .card-heading-16 {
-	font-size: 16px;
+	font-size: $font-body;
 }
 
 .card-heading-14 {

--- a/client/components/checklist/style.scss
+++ b/client/components/checklist/style.scss
@@ -113,7 +113,7 @@ $chevron-animation: transform 0.15s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
 		text-align: left;
 		color: var( --color-neutral-dark );
 		font-weight: 600;
-		font-size: 16px;
+		font-size: $font-body;
 		border-radius: 0;
 		z-index: 0;
 

--- a/client/components/credit-card-form-fields/style.scss
+++ b/client/components/credit-card-form-fields/style.scss
@@ -86,7 +86,7 @@
 .credit-card-form-fields__element {
 	padding: 12px 14px 3px;
 	border: 1px solid var( --color-neutral-10 );
-	font-size: 16px;
+	font-size: $font-body;
 	line-height: 1.5;
 	min-height: 1.5em;
 	margin-top: 5px;

--- a/client/components/credit-card-form-fields/style.scss
+++ b/client/components/credit-card-form-fields/style.scss
@@ -51,7 +51,7 @@
 	}
 
 	select {
-		font-size: 15px;
+		font-size: $font-body;
 		width: 100%;
 	}
 

--- a/client/components/domains/contact-details-form-fields/style.scss
+++ b/client/components/domains/contact-details-form-fields/style.scss
@@ -85,7 +85,7 @@
 	}
 
 	select {
-		font-size: 15px;
+		font-size: $font-body;
 		width: 100%;
 		min-width: 100px;
 	}

--- a/client/components/domains/domain-product-price/style.scss
+++ b/client/components/domains/domain-product-price/style.scss
@@ -9,7 +9,7 @@
 
 	@include breakpoint-deprecated( '>660px' ) {
 		align-items: flex-end;
-		font-size: 16px;
+		font-size: $font-body;
 
 		.featured-domain-suggestions & {
 			align-items: flex-start;

--- a/client/components/domains/domain-search-results/style.scss
+++ b/client/components/domains/domain-search-results/style.scss
@@ -10,7 +10,7 @@
 }
 
 .domain-search-results__transfer-card-copy {
-	font-size: 16px;
+	font-size: $font-body;
 
 	p {
 		margin-bottom: 0;
@@ -24,7 +24,7 @@
 		font-size: 18px;
 
 		p {
-			font-size: 16px;
+			font-size: $font-body;
 		}
 	}
 }

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -173,7 +173,7 @@
 }
 
 .domain-registration-suggestion__title {
-	font-size: 16px;
+	font-size: $font-body;
 	word-break: break-all;
 
 	@include breakpoint-deprecated( '>480px' ) {

--- a/client/components/domains/domain-transfer-suggestion/style.scss
+++ b/client/components/domains/domain-transfer-suggestion/style.scss
@@ -30,7 +30,7 @@
 	}
 
 	h3 {
-		font-size: 16px;
+		font-size: $font-body;
 	}
 
 	> p {

--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -10,7 +10,7 @@
 
 	&.featured-domain-suggestions__is-domain-management .featured-domain-suggestion {
 		.domain-suggestion__action {
-			font-size: 16px;
+			font-size: $font-body;
 		}
 	}
 

--- a/client/components/domains/free-domain-explainer/style.scss
+++ b/client/components/domains/free-domain-explainer/style.scss
@@ -11,7 +11,7 @@
 .free-domain-explainer__subtitle {
     color: var( --color-text );
     font-weight: 400;
-    font-size: 15px;
+    font-size: $font-body;
     margin: 0;
     margin-bottom: 0.3em;
 
@@ -20,7 +20,7 @@
     & .button:focus {
         color: var( --color-link );
         display: inline;
-        font-size: 15px;
+        font-size: $font-body;
         margin-left: 0.3em;
         text-decoration: underline;
         vertical-align: baseline;

--- a/client/components/domains/registrant-extra-info/style.scss
+++ b/client/components/domains/registrant-extra-info/style.scss
@@ -1,5 +1,5 @@
 .registrant-extra-info__form-title {
-	font-size: 16px;
+	font-size: $font-body;
 	font-weight: 600;
 	margin: 0 0 5px;
 }

--- a/client/components/domains/transfer-domain-step/style.scss
+++ b/client/components/domains/transfer-domain-step/style.scss
@@ -156,7 +156,7 @@
 		color: var( --color-neutral-50 );
 		align-items: center;
 		display: flex;
-		font-size: 16px;
+		font-size: $font-body;
 		justify-content: space-between;
 	}
 
@@ -291,6 +291,6 @@ input {
 
 		color: var( --color-neutral-70 );
 		margin-bottom: 0;
-		font-size: 16px;
+		font-size: $font-body;
 	}
 }

--- a/client/components/empty-content/style.scss
+++ b/client/components/empty-content/style.scss
@@ -33,7 +33,7 @@
 	margin-bottom: 40px;
 
 	@include breakpoint-deprecated( '<660px' ) {
-		font-size: 16px;
+		font-size: $font-body;
 	}
 }
 

--- a/client/components/forms/form-text-input-with-affixes/style.scss
+++ b/client/components/forms/form-text-input-with-affixes/style.scss
@@ -56,7 +56,7 @@
 	padding: 8px 14px;
 	white-space: nowrap;
 	flex: 1 0 auto;
-	font-size: 16px;
+	font-size: $font-body;
 	line-height: 1.5;
 }
 

--- a/client/components/gsuite/gsuite-features/style.scss
+++ b/client/components/gsuite/gsuite-features/style.scss
@@ -58,7 +58,7 @@
 		width: 24px;
 	}
 	.gsuite-features__feature-header {
-		font-size: 15px;
+		font-size: $font-body;
 	}
 }
 

--- a/client/components/gsuite/gsuite-learn-more/style.scss
+++ b/client/components/gsuite/gsuite-learn-more/style.scss
@@ -1,5 +1,5 @@
 .gsuite-learn-more {
 	color: var( --color-text-subtle );
-	font-size: 15px;
+	font-size: $font-body;
 	margin-top: 1em;
 }

--- a/client/components/keyed-suggestions/style.scss
+++ b/client/components/keyed-suggestions/style.scss
@@ -36,7 +36,7 @@
 	background: var( --color-surface );
 	border: 1px solid var( --color-neutral-5 );
 	border-top: 0;
-	font-size: 15px;
+	font-size: $font-body;
 	cursor: pointer;
 
 	&.has-highlight {

--- a/client/components/pie-chart/style.scss
+++ b/client/components/pie-chart/style.scss
@@ -12,7 +12,7 @@
 .pie-chart__placeholder-title,
 .pie-chart__title {
 	margin-top: 15px;
-	font-size: 16px;
+	font-size: $font-body;
 	font-weight: 600;
 }
 

--- a/client/components/post-excerpt/style.scss
+++ b/client/components/post-excerpt/style.scss
@@ -11,7 +11,7 @@
 		max-height: 24px * 3;
 
 		@include breakpoint-deprecated( '<480px' ) {
-			font-size: 15px;
+			font-size: $font-body;
 			line-height: 22px;
 			max-height: 22px * 3;
 		}

--- a/client/components/post-excerpt/style.scss
+++ b/client/components/post-excerpt/style.scss
@@ -6,7 +6,7 @@
 		-webkit-box-orient: vertical;
 		overflow: hidden;
 		-webkit-line-clamp: 3;
-		font-size: 16px;
+		font-size: $font-body;
 		line-height: 1.618;
 		max-height: 24px * 3;
 

--- a/client/components/post-schedule/style.scss
+++ b/client/components/post-schedule/style.scss
@@ -14,7 +14,7 @@
 	position: absolute;
 	z-index: z-index( '.popover', '.post-schedule__header' );
 	top: 11px;
-	font-size: 16px;
+	font-size: $font-body;
 	font-weight: 600;
 	width: 47%;
 	margin: 0 27%;

--- a/client/components/product-card/style.scss
+++ b/client/components/product-card/style.scss
@@ -147,7 +147,7 @@
 .product-card__option {
 	.plan-price,
 	.plan-price * {
-		font-size: 16px;
+		font-size: $font-body;
 		font-weight: 400;
 		vertical-align: baseline;
 

--- a/client/components/search/style.scss
+++ b/client/components/search/style.scss
@@ -161,7 +161,7 @@
 		flex: 1 1 auto;
 		height: 100%;
 		position: relative;
-		font-size: 16px;
+		font-size: $font-body;
 		border-radius: inherit;
 		&::before {
 			@include long-content-fade(
@@ -202,7 +202,8 @@
 	align-items: center;
 	flex: 1 1 auto;
 	overflow: hidden;
-	font: inherit;
+	font-size: inherit;
+	font-family: inherit;
 	width: 100%;
 	height: 100%;
 	top: 1px;

--- a/client/components/seo-preview-pane/style.scss
+++ b/client/components/seo-preview-pane/style.scss
@@ -70,7 +70,7 @@
 	font-family: $sans;
 
 	.seo-preview-pane__title {
-		font-size: 16px;
+		font-size: $font-body;
 	}
 
 	.seo-preview-pane__description {

--- a/client/components/share/linkedin-share-preview/style.scss
+++ b/client/components/share/linkedin-share-preview/style.scss
@@ -27,7 +27,7 @@
 }
 
 .linkedin-share-preview__profile-line {
-	font-size: 15px;
+	font-size: $font-body;
 	line-height: 20px;
 }
 
@@ -72,7 +72,7 @@
 .linkedin-share-preview__message {
 	color: rgba( 0, 0, 0, 0.85 );
 	display: -webkit-box;
-	font-size: 15px;
+	font-size: $font-body;
 	font-weight: 600;
 	line-height: 16px;
 	max-height: 40px;

--- a/client/components/share/twitter-share-preview/style.scss
+++ b/client/components/share/twitter-share-preview/style.scss
@@ -43,7 +43,7 @@
 
 .twitter-share-preview__message,
 .twitter-share-preview__article-url {
-	font-size: 16px;
+	font-size: $font-body;
 	line-height: 22px;
 }
 

--- a/client/components/sidebar-navigation/style.scss
+++ b/client/components/sidebar-navigation/style.scss
@@ -18,7 +18,7 @@
 		color: var( --color-neutral-70 );
 		background: var( --color-surface );
 		border-bottom: 1px solid var( --color-neutral-10 );
-		font-size: 15px;
+		font-size: $font-body;
 		line-height: 1.5;
 		text-align: left;
 		width: 100%;

--- a/client/components/site-verticals-suggestion-search/style.scss
+++ b/client/components/site-verticals-suggestion-search/style.scss
@@ -15,7 +15,7 @@
 }
 
 .site-verticals-suggestion-search__topic-list-item {
-	font-size: 15px;
+	font-size: $font-body;
 	color: var( --color-text );
 	border-bottom: 1px solid var( --color-neutral-5 );
 	padding: 10px 24px 10px 42px;

--- a/client/components/sites-popover/style.scss
+++ b/client/components/sites-popover/style.scss
@@ -1,5 +1,5 @@
 .sites-popover {
-	font-size: 15px;
+	font-size: $font-body;
 	width: 300px;
 }
 

--- a/client/components/thank-you-card/style.scss
+++ b/client/components/thank-you-card/style.scss
@@ -71,7 +71,7 @@
 }
 
 .thank-you-card__price {
-	font-size: 15px;
+	font-size: $font-body;
 	font-weight: 600;
 	color: var( --color-success-5 );
 
@@ -104,7 +104,7 @@
 	line-height: 20px;
 
 	@include breakpoint-deprecated( '>480px' ) {
-		font-size: 15px;
+		font-size: $font-body;
 	}
 }
 

--- a/client/components/tile-grid/style.scss
+++ b/client/components/tile-grid/style.scss
@@ -153,7 +153,7 @@
 	@include breakpoint-deprecated( '<480px' ) {
 		background: none;
 		text-align: left;
-		font-size: 16px;
+		font-size: $font-body;
 		line-height: 1.4;
 		border: 0;
 		padding: 0;

--- a/client/components/timeline/style.scss
+++ b/client/components/timeline/style.scss
@@ -99,7 +99,7 @@
 		}
 
 		.timeline-event__title {
-			font-size: 16px;
+			font-size: $font-body;
 			margin-top: 4px;
 		}
 

--- a/client/components/tinymce/iframe.scss
+++ b/client/components/tinymce/iframe.scss
@@ -1,7 +1,7 @@
 body {
 	@extend %content-font;
 	font-family: $serif;
-	font-size: 16px;
+	font-size: $font-body;
 	line-height: 1.7;
 	margin-top: 32px;
 	margin-bottom: 72px;

--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -298,7 +298,7 @@ a.web-preview__external.button {
 
 .web-preview__loading-message {
 	color: var( --color-text-subtle );
-	font-size: 16px;
+	font-size: $font-body;
 }
 
 .web-preview__loading-message strong {

--- a/client/devdocs/design/playground.scss
+++ b/client/devdocs/design/playground.scss
@@ -4,7 +4,7 @@
 		background: #000000;
 		box-sizing: border-box;
 		color: #eaeaea;
-		font-size: 16px;
+		font-size: $font-body;
 		line-height: 1.4;
 		margin: 0;
 		padding: 24px;

--- a/client/devdocs/style.scss
+++ b/client/devdocs/style.scss
@@ -253,7 +253,7 @@ $devdocs-max-width: 720px;
 		font-family: $code;
 		text-decoration: underline;
 		font-weight: 600;
-		font-size: 16px;
+		font-size: $font-body;
 	}
 
 	.docs-selectors__result-description {
@@ -262,7 +262,7 @@ $devdocs-max-width: 720px;
 
 	.docs-selectors__result-io {
 		display: none;
-		font-size: 16px;
+		font-size: $font-body;
 
 		.docs-selectors__result-arguments {
 			flex: 3;
@@ -341,7 +341,7 @@ $devdocs-max-width: 720px;
 .devdocs__doc-content {
 	max-width: $devdocs-max-width;
 	margin: 32px 20px;
-	font-size: 16px;
+	font-size: $font-body;
 	font-family: $serif;
 
 	@include breakpoint-deprecated( '>660px' ) {

--- a/client/devdocs/style.scss
+++ b/client/devdocs/style.scss
@@ -29,7 +29,7 @@ $devdocs-max-width: 720px;
 	}
 
 	.devdocs__result-snippet {
-		font-size: 15px;
+		font-size: $font-body;
 		color: var( --color-text );
 		margin-top: 4px;
 
@@ -325,7 +325,7 @@ $devdocs-max-width: 720px;
 		p {
 			margin: 0;
 			padding-top: 4px;
-			font-size: 15px;
+			font-size: $font-body;
 		}
 	}
 
@@ -406,7 +406,7 @@ $devdocs-max-width: 720px;
 		background-color: var( --color-surface );
 		border-radius: 3px;
 		color: var( --color-primary-dark );
-		font-size: 15px;
+		font-size: $font-body;
 		padding: 2px 6px;
 		max-width: 100px;
 	}
@@ -422,7 +422,7 @@ $devdocs-max-width: 720px;
 
 	.label {
 		font-weight: 600;
-		font-size: 15px;
+		font-size: $font-body;
 		padding: 1px 5px 2px;
 		border-radius: 3px;
 
@@ -468,7 +468,7 @@ $devdocs-max-width: 720px;
 
 .design__typography-code-example {
 	font-family: $code;
-	font-size: 15px;
+	font-size: $font-body;
 }
 
 .design__typography-modular-scale {

--- a/client/extensions/woocommerce/app/dashboard/widgets/stats-widget/style.scss
+++ b/client/extensions/woocommerce/app/dashboard/widgets/stats-widget/style.scss
@@ -56,7 +56,7 @@
 	}
 
 	.stats-widget__box-label, .table-heading .table-item__cell-title, .table.is-compact-table .table-heading {
-		font-size: 16px;
+		font-size: $font-body;
 		font-weight: 600;
 		white-space: nowrap;
 	}

--- a/client/extensions/woocommerce/app/order/style.scss
+++ b/client/extensions/woocommerce/app/order/style.scss
@@ -52,7 +52,7 @@
 	}
 
 	.section-header__label {
-		font-size: 16px;
+		font-size: $font-body;
 	}
 
 	thead {

--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -70,7 +70,7 @@
 
 .products__form .token-field__input,
 .products__form .token-field__token-text {
-	font-size: 16px;
+	font-size: $font-body;
 }
 
 .products__product-form-details-wrapper {

--- a/client/extensions/woocommerce/app/settings/email/mailchimp/style.scss
+++ b/client/extensions/woocommerce/app/settings/email/mailchimp/style.scss
@@ -146,13 +146,13 @@
 }
 
 .setup-steps__campaign-defaults-title {
-	font-size: 16px;
+	font-size: $font-body;
 	font-weight: 600;
 	margin-bottom: 8px;
 }
 
 .setup-steps__mailchimp-api-intro-notice {
-	font-size: 16px;
+	font-size: $font-body;
 	font-weight: 600;
 	margin-bottom: 16px;
 }

--- a/client/extensions/woocommerce/components/dashboard-widget/style.scss
+++ b/client/extensions/woocommerce/components/dashboard-widget/style.scss
@@ -20,7 +20,7 @@
 	}
 
 	.dashboard-widget__title {
-		font-size: 16px;
+		font-size: $font-body;
 		font-weight: 600;
 		margin-bottom: 6px;
 	}

--- a/client/extensions/woocommerce/components/text-control/style.scss
+++ b/client/extensions/woocommerce/components/text-control/style.scss
@@ -50,7 +50,7 @@
 		box-shadow: none;
 		padding: 0;
 
-		font-size: 16px;
+		font-size: $font-body;
 		line-height: 24px;
 	}
 

--- a/client/extensions/woocommerce/components/woocommerce-connect-cart-header/style.scss
+++ b/client/extensions/woocommerce/components/woocommerce-connect-cart-header/style.scss
@@ -58,7 +58,7 @@
 }
 
 .woocommerce-connect-cart-header__stepper-step-icon {
-	font-size: 16px;
+	font-size: $font-body;
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
@@ -92,7 +92,7 @@
 .woocommerce-connect-cart-header__stepper-step .woocommerce-connect-cart-header__stepper-step-label {
 	color: var( --studio-gray-90 );
 	line-height: 24px;
-	font-size: 16px;
+	font-size: $font-body;
 
 	@include breakpoint-deprecated( '<800px' ) {
 		display: none;

--- a/client/extensions/woocommerce/woocommerce-services/components/settings-group-card/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/components/settings-group-card/style.scss
@@ -14,7 +14,7 @@
 }
 
 .settings-group-card__heading {
-	font-size: 16px;
+	font-size: $font-body;
 	font-weight: 600;
 	color: var( --color-neutral-50 );
 	width: 22%;

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/customs-step/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/customs-step/style.scss
@@ -11,7 +11,7 @@
 }
 
 .customs-step__package-name {
-	font-size: 16px;
+	font-size: $font-body;
 	font-weight: 600;
 	margin-bottom: 8px;
 }

--- a/client/jetpack-connect/jetpack-new-site/style.scss
+++ b/client/jetpack-connect/jetpack-new-site/style.scss
@@ -20,7 +20,7 @@
 }
 
 .jetpack-new-site__header-text {
-	font-size: 16px;
+	font-size: $font-body;
 	color: var( --color-neutral-light );
 }
 

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -89,7 +89,7 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 
 		@include breakpoint-deprecated( '<660px' ) {
 			.button {
-				font-size: 16px;
+				font-size: $font-body;
 				padding-top: 12px;
 				padding-bottom: 14px;
 			}
@@ -977,7 +977,7 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 		.formatted-header__subtitle {
 			color: var( --color-primary-10 );
 			margin-top: 1em;
-			font-size: 16px;
+			font-size: $font-body;
 			line-height: 24px;
 			font-weight: 400;
 		}
@@ -1203,7 +1203,7 @@ body.is-section-jetpack-connect .layout.is-jetpack-woocommerce-flow {
 	.product-card__header {
 		.plan-price,
 		.plan-price * {
-			font-size: 16px;
+			font-size: $font-body;
 			line-height: 21px;
 		}
 	}

--- a/client/landing/domains/content-card/style.scss
+++ b/client/landing/domains/content-card/style.scss
@@ -24,7 +24,7 @@
 		}
 
 		@include breakpoint-deprecated( '<660px' ) {
-			font-size: 16px;
+			font-size: $font-body;
 		}
 	}
 
@@ -35,7 +35,7 @@
 		margin-bottom: 16px;
 
 		@include breakpoint-deprecated( '<660px' ) {
-			font-size: 16px;
+			font-size: $font-body;
 		}
 	}
 

--- a/client/landing/domains/header/style.scss
+++ b/client/landing/domains/header/style.scss
@@ -6,7 +6,7 @@
 		margin: 0;
 
 		@include breakpoint-deprecated( '<660px' ) {
-			font-size: 16px;
+			font-size: $font-body;
 		}
 	}
 }

--- a/client/landing/gutenboarding/components/plans/plans-grid/style.scss
+++ b/client/landing/gutenboarding/components/plans/plans-grid/style.scss
@@ -176,7 +176,7 @@
 	display: block;
 	width: 100%;
 	height: 60px;
-	font-size: 16px;
+	font-size: $font-body;
 	line-height: 19px;
 	letter-spacing: 0.2px;
 	border-top: 1px solid var( --studio-gray-5 );

--- a/client/landing/gutenboarding/components/signup-form/style.scss
+++ b/client/landing/gutenboarding/components/signup-form/style.scss
@@ -65,7 +65,7 @@
 
 	.components-text-control__input {
 		padding: 18px 14px;
-		font-size: 16px;
+		font-size: $font-body;
 		line-height: 17px;
 		border-radius: 0;
 		border: 1px solid var( --studio-gray-10 );

--- a/client/landing/jetpack-cloud/components/activity-card-list/style.scss
+++ b/client/landing/jetpack-cloud/components/activity-card-list/style.scss
@@ -44,7 +44,7 @@
 
 .activity-card-list__date-group-date {
 	font-weight: 600;
-	font-size: 16px;
+	font-size: $font-body;
 	line-height: 23px;
 	border-bottom: 1px solid #000000;
 }

--- a/client/landing/jetpack-cloud/components/activity-card/style.scss
+++ b/client/landing/jetpack-cloud/components/activity-card/style.scss
@@ -62,7 +62,7 @@
 
 .activity-card__activity-description {
 	margin: 1rem 0 0.5rem;
-	font-size: 16px;
+	font-size: $font-body;
 	word-wrap: break-word;
 
 	@include breakpoint-deprecated( '>660px' ) {
@@ -93,7 +93,7 @@
 		display: flex;
 		align-items: center;
 		@include breakpoint-deprecated( '>660px' ) {
-			font-size: 16px;
+			font-size: $font-body;
 		}
 
 		// gridicons within buttons have very specific rules for font sizes, disable them to let flex take care of it

--- a/client/landing/jetpack-cloud/components/backup-date-picker/style.scss
+++ b/client/landing/jetpack-cloud/components/backup-date-picker/style.scss
@@ -3,7 +3,7 @@
 	align-items: center;
 	background: #fff;
 	padding-top: 0.5rem;
-	font-size: 16px;
+	font-size: $font-body;
 
 	@include breakpoint-deprecated( '>660px' ) {
 		background: transparent;

--- a/client/landing/jetpack-cloud/components/backup-delta/style.scss
+++ b/client/landing/jetpack-cloud/components/backup-delta/style.scss
@@ -16,7 +16,7 @@
 }
 
 .backup-delta__realtime-header {
-    font-size: 16px;
+    font-size: $font-body;
     font-weight: 600;
     margin: 32px 0 0.5rem;
 

--- a/client/landing/jetpack-cloud/components/daily-backup-status/style.scss
+++ b/client/landing/jetpack-cloud/components/daily-backup-status/style.scss
@@ -238,7 +238,7 @@
 
 .daily-backup-status__changes-header {
 	margin-top: 32px;
-	font-size: 16px;
+	font-size: $font-body;
 	font-weight: 600;
 	border-bottom: 1px solid var( --studio-gray-10 );
 	padding-bottom: 16px;

--- a/client/landing/jetpack-cloud/components/masterbar/style.scss
+++ b/client/landing/jetpack-cloud/components/masterbar/style.scss
@@ -31,7 +31,7 @@
 	.masterbar__item-title {
 		flex: 1 1 auto;
 		padding-left: 16px;
-		font-size: 16px;
+		font-size: $font-body;
 
 		text-transform: none;
 		font-weight: 400;

--- a/client/landing/jetpack-cloud/components/missing-credentials/style.scss
+++ b/client/landing/jetpack-cloud/components/missing-credentials/style.scss
@@ -4,12 +4,12 @@
 	padding: 17px 21px;
 
 	h4 {
-		font-size: 16px;
+		font-size: $font-body;
 		font-weight: 600;
 		margin-bottom: 17px;
 	}
 	p {
-		font-size: 16px;
+		font-size: $font-body;
 	}
 }
 
@@ -28,7 +28,7 @@
 	border-radius: 3px;
 	border: 1px solid var( --color-neutral-10 );
 	color: var( --color-neutral-40 );
-	font-size: 16px;
+	font-size: $font-body;
 	font-weight: 600;
 	text-align: center;
 	width: 100%;

--- a/client/landing/jetpack-cloud/components/scan-threats/style.scss
+++ b/client/landing/jetpack-cloud/components/scan-threats/style.scss
@@ -5,7 +5,7 @@
 
 	&__error, &__rerun {
 		text-align: center;
-		font-size: 16px;
+		font-size: $font-body;
 		line-height: 24px;
 		color: var( --studio-gray-40 );
 		margin-top: 24px;

--- a/client/landing/jetpack-cloud/sections/backups/backup-activity-log/style.scss
+++ b/client/landing/jetpack-cloud/sections/backups/backup-activity-log/style.scss
@@ -17,7 +17,7 @@
 	// use sub-section styling at mobile sizes
 	@include breakpoint-deprecated( '<660px' ) {
 		h2 {
-			font-size: 16px;
+			font-size: $font-body;
 			font-weight: 600;
 			line-height: 23px;
 		}

--- a/client/landing/jetpack-cloud/sections/backups/rewind-flow/style.scss
+++ b/client/landing/jetpack-cloud/sections/backups/rewind-flow/style.scss
@@ -40,7 +40,7 @@
 .rewind-flow__rewind-config-editor-label {
 	align-items: center;
 	display: flex;
-	font-size: 16px;
+	font-size: $font-body;
 	font-weight: normal;
 	margin-bottom: 15px;
 
@@ -76,7 +76,7 @@ input.rewind-flow__rewind-config-editor-checkbox.form-checkbox {
 	a,
 	h4,
 	p {
-		font-size: 16px;
+		font-size: $font-body;
 	}
 
 	// this allows the gridicon and text to align on their centers
@@ -91,7 +91,7 @@ input.rewind-flow__rewind-config-editor-checkbox.form-checkbox {
 
 // when the reminder is default make the header more bold
 .rewind-flow-notice__title-reminder h4 {
-	font-size: 16px;
+	font-size: $font-body;
 	font-weight: 600;
 }
 
@@ -140,11 +140,11 @@ a.rewind-flow-notice__title-warning:visited {
 }
 
 .rewind-flow__info {
-	font-size: 16px;
+	font-size: $font-body;
 }
 
 .rewind-flow__cta {
-	font-size: 16px;
+	font-size: $font-body;
 	font-weight: 600;
 }
 

--- a/client/landing/jetpack-cloud/style.scss
+++ b/client/landing/jetpack-cloud/style.scss
@@ -26,7 +26,7 @@
 
 		h1.current-section__site-title {
 			color: var( --color-neutral-70 );
-			font-size: 16px;
+			font-size: $font-body;
 			font-weight: 400;
 			padding-left: 8px;
 		}
@@ -203,7 +203,7 @@ html {
 	}
 
 	h3 {
-		font-size: 16px;
+		font-size: $font-body;
 		font-weight: 600;
 		line-height: 23px;
 
@@ -214,7 +214,7 @@ html {
 	}
 
 	p {
-		font-size: 16px;
+		font-size: $font-body;
 		line-height: 24px;
 
 		@include breakpoint-deprecated('>660px') {

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -637,8 +637,8 @@
 
 	.logged-out-form label,
 	.login__form-userdata label {
-		font-size: 16px;
 		font-weight: 400;
+		font-size: $font-body;
 	}
 
 	.login__form-signup-link {
@@ -668,7 +668,7 @@
 		a,
 		button {
 			border: none;
-			font-size: 16px;
+			font-size: $font-body;
 			font-weight: 400;
 			line-height: 3em;
 			text-align: center;

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -642,7 +642,7 @@
 	}
 
 	.login__form-signup-link {
-		font-size: 15px;
+		font-size: $font-body;
 	}
 
 	.login__social,

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -6,7 +6,7 @@ $autobar-height: 20px;
 	background: var( --color-masterbar-background );
 	border-bottom: 1px solid var( --color-masterbar-border );
 	color: var( --color-masterbar-text );
-	font-size: 16px;
+	font-size: $font-body;
 	display: flex;
 	height: $masterbar-height;
 	margin: 0;

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -56,7 +56,7 @@
 // like in Reader, and for the expandable menus.
 .sidebar__heading {
 	color: var( --color-sidebar-text-alternative );
-	font-size: 15px;
+	font-size: $font-body;
 	font-weight: 600;
 	padding: 16px 8px 6px 16px;
 }
@@ -106,7 +106,7 @@
 // Menu links: The actual anchor tags that contain links to
 // various sections of Calypso.
 .sidebar__menu-link {
-	font-size: 15px;
+	font-size: $font-body;
 	line-height: 1;
 	position: relative;
 	padding: 10px 16px 10px 20px;

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -46,7 +46,7 @@ $image-height: 47px;
 
 .wp-login__header {
 	color: var( --color-neutral-40 );
-	font-size: 16px;
+	font-size: $font-body;
 	margin-bottom: 16px;
 	text-align: center;
 

--- a/client/mailing-lists/style.scss
+++ b/client/mailing-lists/style.scss
@@ -78,13 +78,13 @@
 	h4 {
 		font-weight: 600;
 		color: var( --color-neutral-50 );
-		font-size: 15px;
+		font-size: $font-body;
 	}
 
 	p {
 		color: var( --color-neutral-40 );
 		margin: 0;
-		font-size: 15px;
+		font-size: $font-body;
 	}
 
 	.button {

--- a/client/me/help/help-courses/style.scss
+++ b/client/me/help/help-courses/style.scss
@@ -48,7 +48,7 @@
 .help-courses__course-video-description,
 .help-courses__course-description {
 	@extend %content-font;
-	font-size: 15px;
+	font-size: $font-body;
 	line-height: 22px;
 	margin-bottom: 0;
 
@@ -71,7 +71,7 @@
 	white-space: normal;
 
 	@include breakpoint-deprecated( '>480px' ) {
-		font-size: 15px;
+		font-size: $font-body;
 	}
 }
 

--- a/client/me/help/help-courses/style.scss
+++ b/client/me/help/help-courses/style.scss
@@ -53,7 +53,7 @@
 	margin-bottom: 0;
 
 	@include breakpoint-deprecated( '>480px' ) {
-		font-size: 16px;
+		font-size: $font-body;
 		line-height: 1.618;
 	}
 }

--- a/client/me/help/style.scss
+++ b/client/me/help/style.scss
@@ -44,7 +44,7 @@
 }
 
 .help__support-link-title {
-	font-size: 16px;
+	font-size: $font-body;
 	color: var( --color-primary );
 	@include breakpoint-deprecated( '>660px' ) {
 		font-size: 21px;

--- a/client/me/purchases/cancel-purchase/style.scss
+++ b/client/me/purchases/cancel-purchase/style.scss
@@ -2,7 +2,7 @@
 	h2 {
 		color: var( --color-neutral-70 );
 		font-size: 21px;
-		font-weight: 200;
+		font-weight: 400;
 		margin-bottom: 20px;
 	}
 
@@ -42,7 +42,7 @@
 }
 
 .cancel-purchase__purchase-name {
-	font-size: 16px;
+	font-size: $font-body;
 	font-weight: 600;
 }
 
@@ -63,7 +63,7 @@
 
 .cancel-purchase__section-header {
 	display: block;
-	font-size: 16px;
+	font-size: $font-body;
 	font-weight: 400;
 }
 

--- a/client/me/purchases/upcoming-renewals/style.scss
+++ b/client/me/purchases/upcoming-renewals/style.scss
@@ -37,7 +37,7 @@
 		flex-direction: column;
 	}
 	&__name {
-		font-size: 16px;
+		font-size: $font-body;
 	}
 	&__detail {
 		font-size: 14px;
@@ -50,7 +50,7 @@
 		text-align: right;
 	}
 	&__price {
-		font-size: 16px;
+		font-size: $font-body;
 	}
 	&__renewal-settings-link a {
 		font-size: 14px;

--- a/client/me/security-2fa-enable/style.scss
+++ b/client/me/security-2fa-enable/style.scss
@@ -26,7 +26,7 @@
 
 .security-2fa-enable__time-code {
 	font-weight: 600;
-	font-size: 16px;
+	font-size: $font-body;
 }
 
 .security-2fa-enable__toggle {

--- a/client/my-sites/activity/filterbar/style.scss
+++ b/client/my-sites/activity/filterbar/style.scss
@@ -106,7 +106,7 @@
 
 	label {
 		margin-bottom: 7px;
-		font-size: 15px;
+		font-size: $font-body;
 		text-align: left;
 		cursor: pointer;
 

--- a/client/my-sites/checkout/cart/style.scss
+++ b/client/my-sites/checkout/cart/style.scss
@@ -334,7 +334,7 @@ div.popover-cart__popover {
 
 	.cart__total {
 		border-top: 1px solid var( --color-border-subtle );
-		font-size: 16px;
+		font-size: $font-body;
 		padding: 15px;
 	}
 
@@ -378,7 +378,7 @@ div.popover-cart__popover {
 
 	.cart__total {
 		border-top: 1px solid var( --color-border-subtle );
-		font-size: 16px;
+		font-size: $font-body;
 		padding: 15px;
 	}
 

--- a/client/my-sites/checkout/checkout-thank-you/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/style.scss
@@ -233,7 +233,7 @@
 	padding: 32px 20px;
 
 	@include breakpoint-deprecated( '>660px' ) {
-		font-size: 16px;
+		font-size: $font-body;
 		padding: 60px 24px;
 		text-align: left;
 	}
@@ -626,7 +626,7 @@
 }
 
 .is-section-checkout-thank-you .empty-content__line {
-	font-size: 16px;
+	font-size: $font-body;
 	font-weight: normal;
 }
 

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -162,7 +162,7 @@
 
 	h5 {
 		color: var( --color-neutral-40 );
-		font-size: 15px;
+		font-size: $font-body;
 		font-weight: 600;
 		opacity: 0.7;
 		text-transform: uppercase;
@@ -228,7 +228,7 @@
 		position: relative;
 
 		select {
-			font-size: 15px;
+			font-size: $font-body;
 			width: 100%;
 		}
 
@@ -518,7 +518,7 @@
 
 				> span {
 					color: var( --color-text-subtle );
-					font-size: 15px;
+					font-size: $font-body;
 				}
 			}
 
@@ -854,7 +854,7 @@
 .checkout__privacy-protection-price-text {
 	color: var( --color-neutral-light );
 	margin: 4px 0 0;
-	font-size: 15px;
+	font-size: $font-body;
 
 	span {
 		&.free-with-plan {
@@ -908,7 +908,7 @@
 .checkout__privacy-protection-radio-price-text {
 	color: var( --color-primary );
 	margin: 4px 0 0 10px;
-	font-size: 15px;
+	font-size: $font-body;
 }
 
 .checkout__alternative-payment-methods {

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -662,7 +662,7 @@
 	}
 
 	h6 {
-		font-size: 16px;
+		font-size: $font-body;
 		font-weight: 600;
 	}
 

--- a/client/my-sites/customer-home/cards/actions/quick-links/style.scss
+++ b/client/my-sites/customer-home/cards/actions/quick-links/style.scss
@@ -80,5 +80,5 @@
 }
 
 .quick-links__action-box-label {
-	font-size: 16px;
+	font-size: $font-body;
 }

--- a/client/my-sites/customer-home/cards/actions/quick-links/style.scss
+++ b/client/my-sites/customer-home/cards/actions/quick-links/style.scss
@@ -48,7 +48,7 @@
 
 	.quick-links__action-box-label {
 		color: var( --color-text );
-		font-size: 15px;
+		font-size: $font-body;
 	}
 
 	.quick-links__action-box-subtitle {

--- a/client/my-sites/customer-home/cards/education/educational-content/style.scss
+++ b/client/my-sites/customer-home/cards/education/educational-content/style.scss
@@ -13,7 +13,7 @@
 
 	h3 {
 		font-weight: 600;
-		font-size: 16px;
+		font-size: $font-body;
 		margin-bottom: 8px;
 	}
 

--- a/client/my-sites/customer-home/cards/tasks/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/style.scss
@@ -60,7 +60,7 @@
 
 	.task__description {
 		margin-bottom: 24px;
-		font-size: 16px;
+		font-size: $font-body;
 		line-height: 24px;
 		color: var( --color-text );
 

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -101,7 +101,7 @@
 .customer-home__main .card-heading,
 .customer-home__main .foldable-card__header {
 	margin-top: 0;
-	font-size: 16px;
+	font-size: $font-body;
 	font-weight: 600;
 }
 

--- a/client/my-sites/domains/domain-management/components/email-verification/style.scss
+++ b/client/my-sites/domains/domain-management/components/email-verification/style.scss
@@ -9,7 +9,7 @@
 }
 
 .email-verification__status {
-	font-size: 16px;
+	font-size: $font-body;
 	font-weight: 600;
 	line-height: 21px;
 	padding-left: 50px;

--- a/client/my-sites/domains/domain-management/edit/style.scss
+++ b/client/my-sites/domains/domain-management/edit/style.scss
@@ -78,7 +78,7 @@
 					font-size: 20px;
 				}
 				&.mobile-xxl {
-					font-size: 16px;
+					font-size: $font-body;
 				}
 			}
 
@@ -93,7 +93,7 @@
 					font-size: 20px;
 				}
 				&.desktop-xxl {
-					font-size: 16px;
+					font-size: $font-body;
 				}
 			}
 
@@ -116,7 +116,7 @@
 		}
 
 		> .domain-status__icon {
-			font-size: 16px;
+			font-size: $font-body;
 			display: flex;
 			align-items: center;
 			border-bottom: 0;

--- a/client/my-sites/domains/domain-search/style.scss
+++ b/client/my-sites/domains/domain-search/style.scss
@@ -13,7 +13,7 @@
 
 .domain-search-page-wrapper h3 {
 	color: var( --color-neutral-70 );
-	font-size: 15px;
+	font-size: $font-body;
 	word-wrap: break-word;
 
 	@include breakpoint-deprecated( '>660px' ) {

--- a/client/my-sites/draft/style.scss
+++ b/client/my-sites/draft/style.scss
@@ -44,7 +44,7 @@
 .draft__title {
 	font-family: $serif;
 	font-weight: 600;
-	font-size: 15px;
+	font-size: $font-body;
 	line-height: 1.4;
 }
 

--- a/client/my-sites/earn/ads/style.scss
+++ b/client/my-sites/earn/ads/style.scss
@@ -67,7 +67,7 @@
 	@include breakpoint-deprecated( '<480px' ) {
 		width: auto;
 		float: right;
-		font-size: 16px;
+		font-size: $font-body;
 	}
 }
 

--- a/client/my-sites/earn/memberships/style.scss
+++ b/client/my-sites/earn/memberships/style.scss
@@ -43,7 +43,7 @@
 	margin-bottom: 24px;
 }
 .memberships__onboarding-paragraph {
-	font-size: 15px;
+	font-size: $font-body;
 	margin-bottom: 24px;
 	color: var( --color-text-subtle );
 }
@@ -180,7 +180,7 @@
 	font-size: 13px;
 
 	@include breakpoint-deprecated( '>480px' ) {
-		font-size: 15px;
+		font-size: $font-body;
 		margin-top: -3px;
 	}
 }

--- a/client/my-sites/earn/memberships/style.scss
+++ b/client/my-sites/earn/memberships/style.scss
@@ -111,7 +111,7 @@
 	@include breakpoint-deprecated( '<480px' ) {
 		width: auto;
 		float: right;
-		font-size: 16px;
+		font-size: $font-body;
 	}
 }
 
@@ -160,7 +160,7 @@
 
 .memberships__subscriber-username {
 	color: var( --color-neutral-70 );
-	font-size: 16px;
+	font-size: $font-body;
 	font-weight: 600;
 	white-space: pre;
 	text-overflow: clip;
@@ -216,7 +216,7 @@
 }
 .memberships__products-product-price {
 	color: var( --color-neutral-70 );
-	font-size: 16px;
+	font-size: $font-body;
 	line-height: 1.5;
 }
 .memberships__products-product-title {

--- a/client/my-sites/exporter/guided-transfer-card/style.scss
+++ b/client/my-sites/exporter/guided-transfer-card/style.scss
@@ -72,7 +72,7 @@
 .guided-transfer-card__in-progress {
 	padding-top: 32px;
 	padding-bottom: 32px;
-	font-size: 16px;
+	font-size: $font-body;
 	text-align: center;
 
 	@include breakpoint-deprecated( '>660px' ) {

--- a/client/my-sites/feature-upsell/style.scss
+++ b/client/my-sites/feature-upsell/style.scss
@@ -119,7 +119,7 @@ $feature-upsell-break-at: '1040px';
 		display: block;
 		opacity: 0.8;
 		color: var( --studio-jetpack-green-30 );
-		font-size: 15px;
+		font-size: $font-body;
 		line-height: 31px;
 	}
 

--- a/client/my-sites/feature-upsell/style.scss
+++ b/client/my-sites/feature-upsell/style.scss
@@ -87,7 +87,7 @@ $feature-upsell-break-at: '1040px';
 
 		//@include breakpoint-deprecated( '<660px' ) {
 		//	&.is-h4 {
-		//		font-size: 16px;
+		//		font-size: $font-body;
 		//	}
 		//}
 	}
@@ -102,7 +102,7 @@ $feature-upsell-break-at: '1040px';
 
 	&-button {
 		display: block;
-		font-size: 16px;
+		font-size: $font-body;
 		padding: 14px 48px;
 		line-height: 1.2;
 
@@ -240,7 +240,7 @@ $feature-upsell-break-at: '1040px';
 	}
 
 	&-content {
-		font-size: 16px;
+		font-size: $font-body;
 		line-height: 1.625;
 		margin-top: 20px;
 		@include breakpoint-deprecated( '<660px' ) {
@@ -292,7 +292,7 @@ $feature-upsell-break-at: '1040px';
 		flex: 0;
 		flex-basis: 340px;
 		margin-left: 32px;
-		font-size: 16px;
+		font-size: $font-body;
 		line-height: 1.625;
 
 		@include breakpoint-deprecated( '<1280px' ) {
@@ -351,7 +351,7 @@ $feature-upsell-break-at: '1040px';
 	}
 
 	&-description {
-		font-size: 16px;
+		font-size: $font-body;
 		line-height: 1.625;
 		margin-top: 10px;
 		@include breakpoint-deprecated( '<660px' ) {
@@ -505,7 +505,7 @@ $feature-upsell-break-at: '1040px';
 		margin: 11px 0 0;
 
 		@include breakpoint-deprecated( '<1040px' ) {
-			font-size: 16px;
+			font-size: $font-body;
 		}
 	}
 

--- a/client/my-sites/google-my-business/location/style.scss
+++ b/client/my-sites/google-my-business/location/style.scss
@@ -43,7 +43,7 @@
 }
 
 .gmb-location__name {
-	font-size: 16px;
+	font-size: $font-body;
 	font-weight: 600;
 }
 

--- a/client/my-sites/marketing/tools/style.scss
+++ b/client/my-sites/marketing/tools/style.scss
@@ -22,7 +22,7 @@
 }
 
 .tools__header-description {
-	font-size: 16px;
+	font-size: $font-body;
 	font-weight: 400;
 }
 

--- a/client/my-sites/migrate/components/import-type-choice/style.scss
+++ b/client/my-sites/migrate/components/import-type-choice/style.scss
@@ -41,7 +41,7 @@
 				align-items: flex-start;
 
 				.import-type-choice__option-title {
-					font-size: 16px;
+					font-size: $font-body;
 					font-weight: 600;
 					line-height: 1.3;
 					margin: 0 10px 0 0;

--- a/client/my-sites/migrate/components/sites-block/style.scss
+++ b/client/my-sites/migrate/components/sites-block/style.scss
@@ -101,12 +101,12 @@
 	.sites-block__faux-site-selector-label {
 		color: var( --color-text );
 		display: block;
-		font-size: 16px;
+		font-size: $font-body;
 		font-weight: 400;
 		line-height: 1.3;
 	}
 
 	.site__title {
-		font-size: 16px;
+		font-size: $font-body;
 	}
 }

--- a/client/my-sites/migrate/section-migrate.scss
+++ b/client/my-sites/migrate/section-migrate.scss
@@ -242,7 +242,7 @@
 
 	.formatted-header__subtitle {
 		margin-bottom: 0;
-		font-size: 16px;
+		font-size: $font-body;
 	}
 }
 

--- a/client/my-sites/no-results/style.scss
+++ b/client/my-sites/no-results/style.scss
@@ -2,7 +2,7 @@
 // Used for searches.
 .no-results {
 	color: var( --color-neutral-50 );
-	font-size: 16px;
+	font-size: $font-body;
 	line-height: 56px;
 }
 

--- a/client/my-sites/people/people-invite-details/style.scss
+++ b/client/my-sites/people/people-invite-details/style.scss
@@ -27,7 +27,7 @@
 	.people-invite-details__meta-item-user {
 		margin-right: 6px;
 		font-family: $serif;
-		font-size: 16px;
+		font-size: $font-body;
 		font-weight: 600;
 		color: var( --color-text );
 	}

--- a/client/my-sites/people/people-profile/style.scss
+++ b/client/my-sites/people/people-profile/style.scss
@@ -46,7 +46,7 @@
 
 .people-profile__username {
 	color: var( --color-neutral-70 );
-	font-size: 16px;
+	font-size: $font-body;
 	font-weight: 600;
 	white-space: pre;
 	text-overflow: clip;

--- a/client/my-sites/people/people-profile/style.scss
+++ b/client/my-sites/people/people-profile/style.scss
@@ -66,7 +66,7 @@
 	font-size: 13px;
 
 	@include breakpoint-deprecated( '>480px' ) {
-		font-size: 15px;
+		font-size: $font-body;
 		margin-top: -3px;
 	}
 }

--- a/client/my-sites/plan-compare-card/style.scss
+++ b/client/my-sites/plan-compare-card/style.scss
@@ -26,7 +26,7 @@
 }
 
 .plan-compare-card__title {
-	font-size: 16px;
+	font-size: $font-body;
 	font-weight: 600;
 	color: var( --color-neutral-60 );
 }

--- a/client/my-sites/plans/current-plan/current-plan-thank-you/style.scss
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you/style.scss
@@ -4,7 +4,7 @@
 	max-width: 720px;
 
 	@include breakpoint-deprecated( '>800px' ) {
-		font-size: 16px;
+		font-size: $font-body;
 		padding: 20px 0;
 		width: 720px;
 	}

--- a/client/my-sites/plugins/plugin-item/style.scss
+++ b/client/my-sites/plugins/plugin-item/style.scss
@@ -84,7 +84,7 @@
 .plugin-item__title {
 	color: var( --color-neutral-70 );
 	display: block;
-	font-size: 15px;
+	font-size: $font-body;
 	font-weight: 600;
 	margin-top: 3px;
 	overflow: hidden;

--- a/client/my-sites/plugins/plugins-browser-item/style.scss
+++ b/client/my-sites/plugins/plugins-browser-item/style.scss
@@ -75,7 +75,7 @@
 .plugins-browser-item__title {
 	color: var( --color-neutral-70 );
 	font-weight: 600;
-	font-size: 15px;
+	font-size: $font-body;
 	margin-top: 3px;
 }
 

--- a/client/my-sites/site-settings/taxonomies/style.scss
+++ b/client/my-sites/site-settings/taxonomies/style.scss
@@ -1,5 +1,5 @@
 .taxonomies__card-title {
-	font-size: 16px;
+	font-size: $font-body;
 	line-height: 24px;
 	color: var( --color-neutral-70 );
 	padding-bottom: 10px;

--- a/client/my-sites/stats/post-trends/style.scss
+++ b/client/my-sites/stats/post-trends/style.scss
@@ -20,7 +20,7 @@ client/my-sites/stats/post-trends/style.scss
 
 .post-trends__value {
 	text-align: center;
-	font-size: 16px;
+	font-size: $font-body;
 	color: var( --color-neutral-50 );
 	margin: 20px 0 30px;
 }

--- a/client/my-sites/stats/stats-chart-tabs/style.scss
+++ b/client/my-sites/stats/stats-chart-tabs/style.scss
@@ -10,7 +10,7 @@ ul.module-tabs {
 
 	.module-tab {
 		margin: 0;
-		font-size: 16px;
+		font-size: $font-body;
 		clear: none;
 		border-top: 1px solid var( --color-neutral-0 );
 		box-sizing: border-box;
@@ -97,7 +97,7 @@ ul.module-tabs {
 			@include breakpoint-deprecated( '<480px' ) {
 				clear: none;
 				float: right;
-				font-size: 16px;
+				font-size: $font-body;
 				margin-right: 24px;
 				padding: 0;
 			}

--- a/client/my-sites/stats/stats-tabs/style.scss
+++ b/client/my-sites/stats/stats-tabs/style.scss
@@ -18,7 +18,7 @@
 		box-sizing: border-box;
 		clear: none;
 		float: none;
-		font-size: 16px;
+		font-size: $font-body;
 		margin: 0;
 		text-align: left;
 
@@ -136,7 +136,7 @@
 			@include breakpoint-deprecated( '<480px' ) {
 				clear: none;
 				float: right;
-				font-size: 16px;
+				font-size: $font-body;
 				padding: 0 20px 0 10px;
 			}
 		}

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -13,7 +13,7 @@
 .theme__sheet-bar-title {
 	display: block;
 	font-size: 33px;
-	font-weight: 100;
+	font-weight: 400;
 	padding-top: 78px;
 	padding-left: 25px;
 	line-height: 1;
@@ -23,8 +23,8 @@
 	max-width: none;
 	display: block;
 	color: var( --color-text-inverted );
-	font-size: 16px;
-	font-weight: 200;
+	font-size: $font-body;
+	font-weight: 400;
 	padding-top: 5px;
 	padding-left: 25px;
 }
@@ -279,25 +279,25 @@
 
 	h3 {
 		font-size: 20px;
-		font-weight: 200;
+		font-weight: 400;
 		margin: 40px 0 10px;
 	}
 
 	h4 {
 		font-size: 18px;
-		font-weight: 200;
+		font-weight: 400;
 		margin: 40px 0 10px;
 	}
 
 	h5 {
-		font-size: 16px;
-		font-weight: 200;
+		font-size: $font-body;
+		font-weight: 400;
 		margin: 40px 0 10px;
 	}
 
 	h6 {
 		font-size: 14px;
-		font-weight: 200;
+		font-weight: 400;
 		margin: 40px 0 10px;
 	}
 

--- a/client/post-editor/editor-confirmation-sidebar/style.scss
+++ b/client/post-editor/editor-confirmation-sidebar/style.scss
@@ -110,6 +110,6 @@
 
 .editor-confirmation-sidebar__header {
 	color: var( --color-neutral-70 );
-	font-size: 15px;
+	font-size: $font-body;
 	padding-bottom: 24px;
 }

--- a/client/post-editor/editor-diff-viewer/style.scss
+++ b/client/post-editor/editor-diff-viewer/style.scss
@@ -95,7 +95,7 @@
 
 .editor-diff-viewer__content {
 	font-family: $serif;
-	font-size: 15px;
+	font-size: $font-body;
 	white-space: pre-wrap;
 	word-wrap: break-word;
 	padding: 0;

--- a/client/post-editor/editor-revisions-list/style.scss
+++ b/client/post-editor/editor-revisions-list/style.scss
@@ -32,7 +32,7 @@
 }
 
 .editor-revisions-list__header {
-	$editor-revisions-list-header-font-size: 16px;
+	$editor-revisions-list-header-font-size: $font-body;
 	display: flex;
 	padding: 0 16px;
 	height: 48px;

--- a/client/post-editor/media-modal/index.scss
+++ b/client/post-editor/media-modal/index.scss
@@ -5,7 +5,7 @@
 }
 
 .editor-media-modal__gallery-help-content {
-	font-size: 15px;
+	font-size: $font-body;
 	text-align: left;
 }
 

--- a/client/reader/conversations/intro.scss
+++ b/client/reader/conversations/intro.scss
@@ -36,7 +36,7 @@
 		display: flex;
 		flex: 1 1 auto;
 		flex-direction: column;
-		font-size: 16px;
+		font-size: $font-body;
 		justify-content: center;
 		margin-left: 24px;
 		padding: 10px 0;

--- a/client/reader/following/style.scss
+++ b/client/reader/following/style.scss
@@ -78,7 +78,7 @@
 	}
 
 	@include breakpoint-deprecated( '<960px' ) {
-		font-size: 16px;
+		font-size: $font-body;
 	}
 
 	@include breakpoint-deprecated( '<660px' ) {
@@ -86,7 +86,7 @@
 	}
 
 	@include breakpoint-deprecated( '<480px' ) {
-		font-size: 16px;
+		font-size: $font-body;
 	}
 }
 

--- a/client/reader/list-stream/style.scss
+++ b/client/reader/list-stream/style.scss
@@ -51,7 +51,7 @@
 
 .list-stream__header-title {
 	color: var( --color-neutral-70 );
-	font-size: 16px;
+	font-size: $font-body;
 }
 
 .list-stream__header-description {

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -153,7 +153,7 @@
 		display: flex;
 
 		.reader__post-title {
-			font-size: 16px;
+			font-size: $font-body;
 			line-height: normal;
 			margin: 0;
 			cursor: pointer;
@@ -189,7 +189,7 @@
 
 		.reader__post-title {
 			display: block;
-			font-size: 16px;
+			font-size: $font-body;
 			margin: 0;
 			position: absolute;
 				top: 14px;
@@ -331,7 +331,7 @@
 		blockquote {
 			margin-left: 0;
 			margin-right: 0;
-			font-size: 16px;
+			font-size: $font-body;
 		}
 
 		p {

--- a/client/reader/style.scss
+++ b/client/reader/style.scss
@@ -148,7 +148,7 @@
 		margin: 0 -32px;
 		padding: 16px 32px 8px;
 		font-family: $sans;
-		font-size: 15px;
+		font-size: $font-body;
 		font-weight: 600;
 		line-height: 1.6;
 		border-top: 1px solid var( --color-neutral-10 );
@@ -165,7 +165,7 @@
 		position: relative;
 			top: 16px;
 		font-family: $sans;
-		font-size: 15px;
+		font-size: $font-body;
 		padding-top: 5px;
 		border-top: 1px solid var( --color-neutral-10 );
 

--- a/client/reader/update-notice/style.scss
+++ b/client/reader/update-notice/style.scss
@@ -15,7 +15,7 @@
 	transform: translateY( -100px );
 	pointer-events: none;
 	transition: background 0.15s ease-in-out, transform 0.2s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
-	font-size: 15px;
+	font-size: $font-body;
 
 	&:hover {
 		background: var( --color-primary );

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -154,7 +154,7 @@ body.is-section-signup .layout.gravatar .formatted-header {
 
 	.formatted-header__subtitle {
 		margin: 0;
-		font-size: 15px;
+		font-size: $font-body;
 		color: var( --color-text-inverted );
 	}
 

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -100,7 +100,7 @@ body.is-section-signup .layout.gravatar {
 
 	@include breakpoint-deprecated( '<660px' ) {
 		button {
-			font-size: 16px;
+			font-size: $font-body;
 			padding-top: 12px;
 			padding-bottom: 14px;
 		}
@@ -252,7 +252,7 @@ body.is-section-signup .layout.gravatar .formatted-header {
 		.formatted-header__subtitle {
 			color: var( --color-primary-10 );
 			margin-top: 1em;
-			font-size: 16px;
+			font-size: $font-body;
 			line-height: 24px;
 			font-weight: 400;
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use a Sass variable for font sizing, starting with the body font of 16px and 15px.
* This is a simple find-and-replace, which is why the diff is huge. I think this method makes the most sense for a sweeping change rather than splitting into multiple PRs -- as I found with updating font weights, going through each change one by one is not a great use of time.
* At some point we need to audit the use of `font-size` properties that override the default -- many of these instances are probably unnecessary and can be removed in favor of the cascade -- but this is a first step to get everything updated with a single set of variables.

From an order-of-operations perspective, we should roll these changes out quickly to avoid time-consuming merge conflicts.

**Visuals** (not exhaustive)

<img width="1669" alt="Screen Shot 2020-06-01 at 12 18 32 PM" src="https://user-images.githubusercontent.com/2124984/83429415-0771a680-a402-11ea-83e2-2c03f4b14f93.png">
<img width="1670" alt="Screen Shot 2020-06-01 at 12 17 38 PM" src="https://user-images.githubusercontent.com/2124984/83429427-0a6c9700-a402-11ea-86a8-50ecf7630b23.png">
<img width="1670" alt="Screen Shot 2020-06-01 at 12 17 13 PM" src="https://user-images.githubusercontent.com/2124984/83429431-0b9dc400-a402-11ea-8bc0-5f812b6c00a7.png">

#### Testing instructions

* Switch to this PR
* Note the visual changes to copy across Calypso; they're widespread, since this is the body copy and the size has increased by 1px. 
* Note any visual bugs/weirdness here.