### PR TITLE
Reader: Sentence case button copy

### DIFF
--- a/client/reader/following/main.jsx
+++ b/client/reader/following/main.jsx
@@ -95,12 +95,12 @@ const FollowingStream = ( props ) => {
 			<SectionHeader label={ translate( 'Followed Sites' ) }>
 				{ config.isEnabled( 'reader/seen-posts' ) && ! props.hasUnseen && (
 					<Button compact onClick={ markAllAsUnSeen }>
-						{ translate( 'Mark All as Unseen' ) }
+						{ translate( 'Mark all as unseen' ) }
 					</Button>
 				) }
 				{ config.isEnabled( 'reader/seen-posts' ) && props.hasUnseen && (
 					<Button compact onClick={ markAllAsSeen }>
-						{ translate( 'Mark All as Seen' ) }
+						{ translate( 'Mark all as seen' ) }
 					</Button>
 				) }
 				<Button primary compact className="following__manage" href="/following/manage">


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Noticed as I was testing something else, we're standardizing all buttons to use Sentence case (rather than Title Case) - reference post is here: p9Jlb4-1ly-p2
* This updates the "Mark all as unseen" buttons to use sentence case.

**Before**

<img width="839" alt="Screen Shot 2020-05-25 at 12 55 22 PM" src="https://user-images.githubusercontent.com/2124984/82841161-0b05aa80-9ea3-11ea-9393-69b5dec075d7.png">

**After**

<img width="837" alt="Screen Shot 2020-05-25 at 4 14 26 PM" src="https://user-images.githubusercontent.com/2124984/82841164-0f31c800-9ea3-11ea-9707-0cc3ecd65068.png">

#### Testing instructions

* Switch to this PR
* Go to `/read`
* Note the buttons under Followed Sites; the copy should be sentence case rather than title case.