### PR TITLE
composite-checkout: Convert existing card payment method to use processor function

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -66,6 +66,7 @@ import {
 	applePayProcessor,
 	stripeCardProcessor,
 	fullCreditsProcessor,
+	existingCardProcessor,
 } from './payment-method-processors';
 import { useGetThankYouUrl } from './use-get-thank-you-url';
 import createAnalyticsEventHandler from './record-analytics';
@@ -411,6 +412,7 @@ export default function CompositeCheckout( {
 			'apple-pay': applePayProcessor,
 			card: stripeCardProcessor,
 			'full-credits': fullCreditsProcessor,
+			'existing-card': existingCardProcessor,
 		} ),
 		[]
 	);

--- a/client/my-sites/checkout/composite-checkout/payment-method-processors.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-processors.js
@@ -62,6 +62,26 @@ export async function stripeCardProcessor( submitData ) {
 	return pending;
 }
 
+export async function existingCardProcessor( submitData ) {
+	const pending = submitStripeCardTransaction(
+		{
+			...submitData,
+			country: select( 'wpcom' )?.getContactInfo?.()?.countryCode?.value,
+			postalCode: select( 'wpcom' )?.getContactInfo?.()?.postalCode?.value,
+			subdivisionCode: select( 'wpcom' )?.getContactInfo?.()?.state?.value,
+			siteId: select( 'wpcom' )?.getSiteId?.(),
+			domainDetails: getDomainDetails( select ),
+		},
+		wpcomTransaction
+	);
+	// save result so we can get receipt_id and failed_purchases in getThankYouPageUrl
+	pending.then( ( result ) => {
+		// TODO: do this automatically when calling setTransactionComplete
+		dispatch( 'wpcom' ).setTransactionResponse( result );
+	} );
+	return pending;
+}
+
 function createStripePaymentMethodToken( { stripe, name, country, postalCode } ) {
 	return createStripePaymentMethod( stripe, {
 		name,

--- a/client/my-sites/checkout/composite-checkout/payment-method-processors.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-processors.js
@@ -12,6 +12,7 @@ import {
 	submitApplePayPayment,
 	submitStripeCardTransaction,
 	submitCreditsTransaction,
+	submitExistingCardPayment,
 } from './payment-method-helpers';
 import { createStripePaymentMethod } from 'lib/stripe';
 
@@ -63,7 +64,7 @@ export async function stripeCardProcessor( submitData ) {
 }
 
 export async function existingCardProcessor( submitData ) {
-	const pending = submitStripeCardTransaction(
+	const pending = submitExistingCardPayment(
 		{
 			...submitData,
 			country: select( 'wpcom' )?.getContactInfo?.()?.countryCode?.value,

--- a/client/my-sites/checkout/composite-checkout/use-create-payment-methods.js
+++ b/client/my-sites/checkout/composite-checkout/use-create-payment-methods.js
@@ -29,7 +29,6 @@ import {
 	submitFreePurchaseTransaction,
 	WordPressFreePurchaseLabel,
 	WordPressFreePurchaseSummary,
-	submitExistingCardPayment,
 } from './payment-method-helpers';
 
 const debug = debugFactory( 'calypso:composite-checkout:use-create-payment-methods' );
@@ -220,30 +219,10 @@ function useCreateExistingCards( { onlyLoadPaymentMethods, storedCards, stripeCo
 				cardExpiry: storedDetails.expiry,
 				brand: storedDetails.card_type,
 				last4: storedDetails.card,
+				storedDetailsId: storedDetails.stored_details_id,
+				paymentMethodToken: storedDetails.mp_ref,
+				paymentPartnerProcessorId: storedDetails.payment_partner,
 				stripeConfiguration,
-				submitTransaction: ( submitData ) => {
-					const pending = submitExistingCardPayment(
-						{
-							...submitData,
-							siteId: select( 'wpcom' )?.getSiteId?.(),
-							storedDetailsId: storedDetails.stored_details_id,
-							paymentMethodToken: storedDetails.mp_ref,
-							paymentPartnerProcessorId: storedDetails.payment_partner,
-							domainDetails: getDomainDetails( select ),
-						},
-						wpcomTransaction
-					);
-					// save result so we can get receipt_id and failed_purchases in getThankYouPageUrl
-					pending.then( ( result ) => {
-						debug( 'saving transaction response', result );
-						dispatch( 'wpcom' ).setTransactionResponse( result );
-					} );
-					return pending;
-				},
-				registerStore,
-				getCountry: () => select( 'wpcom' )?.getContactInfo?.()?.countryCode?.value,
-				getPostalCode: () => select( 'wpcom' )?.getContactInfo?.()?.postalCode?.value,
-				getSubdivisionCode: () => select( 'wpcom' )?.getContactInfo?.()?.state?.value,
 			} )
 		);
 	}, [ stripeConfiguration, storedCards, shouldLoadExistingCardsMethods ] );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This updates the "existing credit card" payment method to use the payment processor function system introduced in #41767 

See also previous conversion of free credits in #42348.

#### Testing instructions

- Attempt a purchase using composite checkout with a saved card.
- Verify that the purchase is successful.