### PR TITLE
Let CSS/JS load at render time

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/newspack-blocks/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/newspack-blocks/index.php
@@ -79,6 +79,15 @@ function newspack_blocks_block_args( $args, $name ) {
 
 	$args['editor_script'] = $block_prefix . 'editor';
 	$args['editor_style']  = $block_prefix . 'editor';
+	
+	// This fires from newspack-blocks at render time.
+	add_action(
+		'newspack_blocks_render_post_carousel',
+		function() use ( $block_prefix ) {
+			wp_enqueue_style( $block_prefix . 'view' );
+			wp_enqueue_script( $block_prefix . 'view' );
+		}
+	);
 
 	wp_set_script_translations( $block_prefix . 'editor', 'full-site-editing' );
 

--- a/apps/full-site-editing/full-site-editing-plugin/newspack-blocks/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/newspack-blocks/index.php
@@ -80,14 +80,23 @@ function newspack_blocks_block_args( $args, $name ) {
 	$args['editor_script'] = $block_prefix . 'editor';
 	$args['editor_style']  = $block_prefix . 'editor';
 	
-	// This fires from newspack-blocks at render time.
-	add_action(
-		'newspack_blocks_render_post_carousel',
-		function() use ( $block_prefix ) {
-			wp_enqueue_style( $block_prefix . 'view' );
-			wp_enqueue_script( $block_prefix . 'view' );
-		}
-	);
+    // This fires from newspack-blocks at render time.
+    add_action(
+        'newspack_blocks_render_post_carousel',
+        function() {
+            wp_enqueue_style( 'carousel-block-view' );
+            wp_enqueue_script( 'carousel-block-view' );
+        }
+    );
+	
+    // This fires from newspack-blocks at render time.
+    add_action(
+        'newspack_blocks_render_homepage_articles',
+        function() {
+            wp_enqueue_style( 'blog-posts-block-view' );
+            wp_enqueue_script( 'blog-posts-block-view' );
+        }
+    );
 
 	wp_set_script_translations( $block_prefix . 'editor', 'full-site-editing' );
 

--- a/apps/full-site-editing/full-site-editing-plugin/newspack-blocks/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/newspack-blocks/index.php
@@ -79,8 +79,6 @@ function newspack_blocks_block_args( $args, $name ) {
 
 	$args['editor_script'] = $block_prefix . 'editor';
 	$args['editor_style']  = $block_prefix . 'editor';
-	$args['script']        = $block_prefix . 'view';
-	$args['style']         = $block_prefix . 'view';
 
 	wp_set_script_translations( $block_prefix . 'editor', 'full-site-editing' );
 


### PR DESCRIPTION
This is the second part of https://github.com/Automattic/newspack-blocks/pull/494 - which changes the CSS/JS for the carousel and homepage-arcticle blocks to only load at render time.  Currently they are being loaded for every page view.

#### Changes proposed in this Pull Request

* Stop loading CSS/JS on every page view for newpack blocks

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Confirm that the CSS/JS load correctly for page views that use the block, and that they do not load on all other page views

Fixes #
