### PR TITLE
Reader: redirect /read/fresh to Discover

### DIFF
--- a/client/reader/README.md
+++ b/client/reader/README.md
@@ -3,10 +3,9 @@ Reader
 
 The Reader module handles the view and routing logic for the *Reader* section of Calypso.
 
-The 'following' view is the default view in Calypso, served at `/`. These routes are also served by the module:
+These routes are served by the module:
 
+- /activities/likes
 - /read/*
-- /following/*
-- /fresh
-- /recommendations
-- /activities/comments and /activities/likes
+- /recommendations (redirects to /read/search)
+- /tag/*

--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -1,12 +1,12 @@
 /**
- * External Dependencies
+ * External dependencies
  */
 import React from 'react';
 import page from 'page';
 import i18n from 'i18n-calypso';
 
 /**
- * Internal Dependencies
+ * Internal dependencies
  */
 import { abtest } from 'lib/abtest';
 import { sectionify } from 'lib/route';
@@ -50,7 +50,7 @@ const exported = {
 	},
 
 	prettyRedirects( context, next ) {
-		// Do we have a 'pretty' site or feed URL?
+		// Do we have a 'pretty' site or feed URL? We only use this for /discover.
 		let redirect;
 		if ( context.params.blog_id ) {
 			redirect = getPrettySiteUrl( context.params.blog_id );

--- a/client/reader/index.js
+++ b/client/reader/index.js
@@ -99,8 +99,11 @@ export default async function () {
 		page( '/read/post/feed/:feed_id/:post_id', legacyRedirects );
 		page( '/read/post/id/:blog_id/:post_id', legacyRedirects );
 
-		// old recommendations page
+		// Old recommendations page
 		page( '/recommendations', '/read/search' );
+
+		// Old Freshly Pressed
+		page( '/read/fresh', '/discover' );
 	}
 
 	// Automattic Employee Posts

--- a/client/sections.js
+++ b/client/sections.js
@@ -299,7 +299,7 @@ const sections = [
 	},
 	{
 		name: 'reader',
-		paths: [ '/read/feeds/[^\\/]+', '/read/blogs/[^\\/]+', '/read/a8c' ],
+		paths: [ '/read/feeds/[^\\/]+', '/read/blogs/[^\\/]+', '/read/a8c', '/recommendations' ],
 		module: 'reader',
 		secondary: true,
 		group: 'reader',
@@ -341,7 +341,7 @@ const sections = [
 	},
 	{
 		name: 'reader',
-		paths: [ '/read/search', '/recommendations' ],
+		paths: [ '/read/search' ],
 		module: 'reader/search',
 		secondary: true,
 		group: 'reader',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Reader used to have a section called 'Freshly Pressed' at `/read/fresh`. Until recently it was still possible to access it. In the last week we retired the old codebase and now all requests for `/read/*` go to Calypso. 

This PR adds a redirect for the old `/read/fresh` route to `/discover`.

It also fixes the `/recommendations` to `/read/search` redirect which was not working as intended.

Fixes 7760-wpcom.

#### Testing instructions

Go to http://calypso.localhost:3000/read/fresh and ensure you are redirected to `/discover`.

Go to http://calypso.localhost:3000/recommendations and ensure you are redirected to `/read/search`.

Ensure your usual Reader streams work as normal.