### PR TITLE
i18n: Remove trailing slash from path when getting locale slug from path

### DIFF
--- a/client/boot/locale.js
+++ b/client/boot/locale.js
@@ -84,9 +84,8 @@ export const setupLocale = ( currentUser, reduxStore ) => {
 
 	if ( useTranslationChunks && '__requireChunkCallback__' in window ) {
 		const userLocaleSlug = currentUser && currentUser.localeSlug;
-		const lastPathSegment = window.location.pathname.substr(
-			window.location.pathname.lastIndexOf( '/' ) + 1
-		);
+		const pathname = window.location.pathname.replace( /\/?$/, '' );
+		const lastPathSegment = pathname.substr( pathname.lastIndexOf( '/' ) + 1 );
 		const pathLocaleSlug =
 			getLanguageSlugs().includes( lastPathSegment ) &&
 			! isDefaultLocale( lastPathSegment ) &&

--- a/client/boot/locale.js
+++ b/client/boot/locale.js
@@ -84,7 +84,7 @@ export const setupLocale = ( currentUser, reduxStore ) => {
 
 	if ( useTranslationChunks && '__requireChunkCallback__' in window ) {
 		const userLocaleSlug = currentUser && currentUser.localeSlug;
-		const pathname = window.location.pathname.replace( /\/?$/, '' );
+		const pathname = window.location.pathname.replace( /\/$/, '' );
 		const lastPathSegment = pathname.substr( pathname.lastIndexOf( '/' ) + 1 );
 		const pathLocaleSlug =
 			getLanguageSlugs().includes( lastPathSegment ) &&


### PR DESCRIPTION
For a /start/ URL with a language as trailing slash we showed a not fully translated UI:

![Screenshot 2020-05-26 at 13 26 32](https://user-images.githubusercontent.com/203408/82895463-8bd0af00-9f54-11ea-8fd9-5a2ca60c1003.png)

Reason: that string is loaded from a cache in state and at when it is built up, the UI language is English because of the bug fixed in this PR.

#### Changes proposed in this Pull Request

* Remove trailing slash when getting locale slug from path, as it was adding another segment to the path and making it unable to read the last segment as locale slug.

#### Testing instructions

1. BUILD_TRANSLATION_CHUNKS=true ENABLE_FEATURES=use-translation-chunks yarn start
2. Confirm that both http://calypso.localhost:3000/start/user/de/ (with trailing slash) and http://calypso.localhost:3000/start/user/de are getting properly translated.
