### PR TITLE
Use ES modules in server sources

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,12 +1,9 @@
 const isBrowser = process.env.BROWSERSLIST_ENV !== 'server';
 
-// Use commonjs for Node
-const modules = isBrowser ? false : 'commonjs';
-
 // We implicitly use browserslist configuration in package.json for build targets.
 
 const babelConfig = {
-	presets: [ [ '@automattic/calypso-build/babel/default', { modules } ] ],
+	presets: [ '@automattic/calypso-build/babel/default' ],
 	plugins: [ [ '@automattic/transform-wpcalypso-async', { async: isBrowser } ] ],
 	env: {
 		production: {

--- a/client/server/api/index.js
+++ b/client/server/api/index.js
@@ -8,6 +8,8 @@ import express from 'express';
  */
 import { version } from '../../package.json';
 import config from 'config';
+import oauth from './oauth';
+import signInWithApple from './sign-in-with-apple';
 
 export default function api() {
 	const app = express();
@@ -17,11 +19,11 @@ export default function api() {
 	} );
 
 	if ( config.isEnabled( 'oauth' ) && ! config.isEnabled( 'jetpack-cloud' ) ) {
-		require( './oauth' ).default( app );
+		oauth( app );
 	}
 
 	if ( config.isEnabled( 'sign-in-with-apple/redirect' ) ) {
-		require( './sign-in-with-apple' ).default( app );
+		signInWithApple( app );
 	}
 
 	return app;

--- a/client/server/api/index.js
+++ b/client/server/api/index.js
@@ -1,17 +1,15 @@
 /**
  * External dependencies
  */
-const express = require( 'express' );
+import express from 'express';
 
 /**
  * Internal dependencies
  */
-const { version } = require( '../../package.json' );
-const config = require( 'config' );
-const oauth = require( './oauth' );
-const signInWithApple = require( './sign-in-with-apple' );
+import { version } from '../../package.json';
+import config from 'config';
 
-module.exports = function () {
+export default function api() {
 	const app = express();
 
 	app.get( '/version', function ( request, response ) {
@@ -19,12 +17,12 @@ module.exports = function () {
 	} );
 
 	if ( config.isEnabled( 'oauth' ) && ! config.isEnabled( 'jetpack-cloud' ) ) {
-		oauth( app );
+		require( './oauth' ).default( app );
 	}
 
 	if ( config.isEnabled( 'sign-in-with-apple/redirect' ) ) {
-		signInWithApple( app );
+		require( './sign-in-with-apple' ).default( app );
 	}
 
 	return app;
-};
+}

--- a/client/server/api/oauth.js
+++ b/client/server/api/oauth.js
@@ -1,13 +1,13 @@
 /**
  * External dependencies
  */
-const req = require( 'superagent' );
-const bodyParser = require( 'body-parser' );
+import req from 'superagent';
+import bodyParser from 'body-parser';
 
 /**
  * Internal dependencies
  */
-const config = require( 'config' );
+import config from 'config';
 
 function oauth() {
 	return {
@@ -108,10 +108,10 @@ function sms( request, response ) {
 		);
 }
 
-module.exports = function ( app ) {
+export default function ( app ) {
 	return app
 		.use( bodyParser.json() )
 		.post( '/oauth', proxyOAuth )
 		.get( '/logout', logout )
 		.post( '/sms', sms );
-};
+}

--- a/client/server/api/sign-in-with-apple.js
+++ b/client/server/api/sign-in-with-apple.js
@@ -72,11 +72,11 @@ function redirectToCalypso( request, response, next ) {
 	response.redirect( originalUrlPath + '#' + hashString );
 }
 
-module.exports = function ( app ) {
+export default function ( app ) {
 	return app.post(
 		[ '/log-in/apple/callback', '/start/user', '/me/security/social-login' ],
 		bodyParser.urlencoded(),
 		loginWithApple,
 		redirectToCalypso
 	);
-};
+}

--- a/client/server/boot/index.js
+++ b/client/server/boot/index.js
@@ -1,24 +1,28 @@
 /**
- * Module dependencies
+ * External dependencies
  */
+import path from 'path';
+import chalk from 'chalk';
+import express from 'express';
+import cookieParser from 'cookie-parser';
+import userAgent from 'express-useragent';
+import morgan from 'morgan';
 
-const path = require( 'path' );
-const chalk = require( 'chalk' );
-const express = require( 'express' );
-const cookieParser = require( 'cookie-parser' );
-const userAgent = require( 'express-useragent' );
-const morgan = require( 'morgan' );
-const config = require( 'server/config' );
-const pages = require( 'server/pages' );
-const pwa = require( 'server/pwa' ).default;
-const analytics = require( 'server/lib/analytics' ).default;
+/**
+ * Internal dependencies
+ */
+import analytics from 'server/lib/analytics';
+import config from 'server/config';
+import api from 'server/api';
+import pages from 'server/pages';
+import pwa from 'server/pwa';
 
 /**
  * Returns the server HTTP request handler "app".
  *
  * @returns {object} The express app
  */
-function setup() {
+export default function setup() {
 	const app = express();
 
 	// for nginx
@@ -91,7 +95,7 @@ function setup() {
 	} );
 
 	if ( config.isEnabled( 'devdocs' ) ) {
-		app.use( require( 'server/devdocs' )() );
+		app.use( require( 'server/devdocs' ).default() );
 	}
 
 	if ( config.isEnabled( 'desktop' ) ) {
@@ -101,15 +105,10 @@ function setup() {
 		);
 	}
 
-	app.use( require( 'server/api' )() );
+	app.use( api() );
 
 	// attach the pages module
 	app.use( pages() );
 
 	return app;
 }
-
-/**
- * Module exports
- */
-module.exports = setup;

--- a/client/server/bundler/sections-loader.js
+++ b/client/server/bundler/sections-loader.js
@@ -37,7 +37,7 @@ function addModuleImportToSections( sections, { useRequire, onlyIsomorphic } = {
 		'load": $1'
 	);
 
-	const sectionsFile = `module.exports = ${ sectionStringsWithImportFns }`;
+	const sectionsFile = `export default ${ sectionStringsWithImportFns }`;
 	return sectionsFile;
 }
 

--- a/client/server/bundler/test/sections-loader.js
+++ b/client/server/bundler/test/sections-loader.js
@@ -13,7 +13,7 @@ describe( '#addModuleImportToSections', () => {
 			},
 		];
 
-		const expected = `module.exports = [
+		const expected = `export default [
 	{
 		"name": "moduleName",
 		"module": "module-to-require",
@@ -32,7 +32,7 @@ describe( '#addModuleImportToSections', () => {
 			},
 		];
 
-		const expected = `module.exports = [
+		const expected = `export default [
 	{
 		"name": "moduleName",
 		"module": "module-to-require",
@@ -61,7 +61,7 @@ describe( '#addModuleImportToSections', () => {
 			},
 		];
 
-		const expected = `module.exports = [
+		const expected = `export default [
 	{
 		"name": "moduleName",
 		"module": "module-to-require"

--- a/client/server/devdocs/index.js
+++ b/client/server/devdocs/index.js
@@ -135,7 +135,7 @@ function defaultSnippet( doc ) {
 	return escapeHTML( content ) + '…';
 }
 
-module.exports = function () {
+export default function devdocs() {
 	const app = express();
 
 	// this middleware enforces access control

--- a/client/server/devdocs/index.js
+++ b/client/server/devdocs/index.js
@@ -16,7 +16,7 @@ import 'prismjs/components/prism-scss';
  */
 import config from 'config';
 import searchIndex from 'server/devdocs/search-index';
-import selectors from './selectors';
+import { primeSelectorsCache, selectorsRouter } from './selectors';
 
 const docsIndex = lunr.Index.load( searchIndex.index );
 
@@ -210,11 +210,11 @@ module.exports = function () {
 	// In environments where enabled, prime the selectors search cache whenever
 	// a request is made for DevDocs
 	app.use( '/devdocs', function ( request, response, next ) {
-		selectors.prime();
+		primeSelectorsCache();
 		next();
 	} );
 
-	app.use( '/devdocs/service/selectors', selectors.router );
+	app.use( '/devdocs/service/selectors', selectorsRouter );
 
 	return app;
-};
+}

--- a/client/server/index.js
+++ b/client/server/index.js
@@ -1,19 +1,19 @@
 /* eslint-disable no-console */
 /* eslint-disable import/no-nodejs-modules */
 
-require( '@automattic/calypso-polyfills' );
+import '@automattic/calypso-polyfills';
 
 /**
  * External dependencies.
  */
-const chalk = require( 'chalk' );
-const fs = require( 'fs' );
+import chalk from 'chalk';
+import fs from 'fs';
 
 /**
  * Internal dependencies
  */
-const boot = require( './boot' );
-const config = require( './config' );
+import boot from './boot';
+import config from './config';
 
 const start = Date.now();
 const protocol = process.env.PROTOCOL || config( 'protocol' );

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -476,7 +476,7 @@ function setUpLoggedInRoute( req, res, next ) {
 			return;
 		}
 
-		const user = require( 'server/user-bootstrap' );
+		const user = require( 'server/user-bootstrap' ).default;
 
 		start = new Date().getTime();
 
@@ -710,7 +710,7 @@ function handleLocaleSubdomains( req, res, next ) {
 	next();
 }
 
-module.exports = function () {
+export default function pages() {
 	const app = express();
 
 	app.set( 'views', __dirname );
@@ -944,7 +944,7 @@ module.exports = function () {
 		}
 
 		// Maybe not logged in, note that you need docker to test this properly
-		const user = require( 'server/user-bootstrap' );
+		const user = require( 'server/user-bootstrap' ).default;
 
 		debug( 'Issuing API call to fetch user object' );
 
@@ -985,4 +985,4 @@ module.exports = function () {
 	app.use( renderServerError() );
 
 	return app;
-};
+}

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -45,6 +45,7 @@ import {
 	attachI18n,
 } from 'server/render';
 import stateCache from 'server/state-cache';
+import getBootstrappedUser from 'server/user-bootstrap';
 import { createReduxStore } from 'state';
 import { setStore } from 'state/redux-store';
 import initialReducer from 'state/reducer';
@@ -476,13 +477,11 @@ function setUpLoggedInRoute( req, res, next ) {
 			return;
 		}
 
-		const user = require( 'server/user-bootstrap' ).default;
-
 		start = new Date().getTime();
 
 		debug( 'Issuing API call to fetch user object' );
 
-		const userPromise = user( req )
+		const userPromise = getBootstrappedUser( req )
 			.then( ( data ) => {
 				const end = new Date().getTime() - start;
 
@@ -944,11 +943,8 @@ export default function pages() {
 		}
 
 		// Maybe not logged in, note that you need docker to test this properly
-		const user = require( 'server/user-bootstrap' ).default;
-
 		debug( 'Issuing API call to fetch user object' );
-
-		user( req )
+		getBootstrappedUser( req )
 			.then( ( data ) => {
 				const activeFlags = get( data, 'meta.data.flags.active_flags', [] );
 
@@ -958,7 +954,7 @@ export default function pages() {
 				}
 
 				// Passed all checks, prepare support user session
-				return res.send(
+				res.send(
 					renderJsx( 'support-user', {
 						authorized: true,
 						supportUser: req.query.support_user,
@@ -974,7 +970,7 @@ export default function pages() {
 					domain: '.wordpress.com',
 				} );
 
-				return res.send( renderJsx( 'support-user' ) );
+				res.send( renderJsx( 'support-user' ) );
 			} );
 	} );
 

--- a/client/server/user-bootstrap/index.js
+++ b/client/server/user-bootstrap/index.js
@@ -32,10 +32,9 @@ const debug = debugFactory( 'calypso:bootstrap' ),
  * Requests the current user for user bootstrap.
  *
  * @param {object} request An Express request.
- *
  * @returns {Promise<object>} A promise for a user object.
  */
-module.exports = async function ( request ) {
+export default async function getBootstrappedUser( request ) {
 	const authCookieValue = request.cookies[ AUTH_COOKIE_NAME ];
 	const geoCountry = request.get( 'x-geoip-country-code' ) || '';
 	const supportSessionHeader = request.get( 'x-support-session' );
@@ -111,4 +110,4 @@ module.exports = async function ( request ) {
 
 		throw error;
 	}
-};
+}


### PR DESCRIPTION
Many modules in the Calypso server (`client/server`) use a questionable mix of ESM and CJS syntax:
```js
import fs from 'fs';

module.exports = function () {
  ...
}
```
This works only because the Babel config for server build [specifies](https://github.com/Automattic/wp-calypso/blob/b4e8fbb6cd9852d3017164593f2c170b9a8abc15/babel.config.js#L4) `modules: 'commonjs'`, transpiles ESM into CJS and webpack never sees a ES module source.

If webpack saw the mixed ESM/CJS module, assigning to `module.exports` would fail at runtime:
```
Cannot assign to read-only property 'exports' of object ...
```

This PR converts most of the hybrid server modules to pure ESM and removes the now redundant Babel config flag. By default (from `calypso-build`), the value will be `modules: false`, meaning "no transpilation of `import`/`export` syntax). Webpack will handle the modules when bundling.

Some modules need to remain CJS, because they are also used by the build system, i.e., Babel or webpack. Typically, it's the `config` module.

When importing an ESM module with default export with `require()`, one needs to be careful to use the `.default` field to access the default export.

See also https://github.com/Automattic/wp-desktop/pull/884#issuecomment-633522275 and https://github.com/Automattic/wp-desktop/pull/887

**How to test:**
1. Test that devdocs continue to work, including selectors search
2. Test that OAuth continues to work (in `wp-desktop`)
3. Test the "sign in with Apple" feature, as we modified the redirect API router for that (@Tug can you help with this testing? Either directly or by providing advice on how to best test this part)
4. Test the user bootstrapping (will need to happen on staging right before deploy)
