### PR TITLE
Update contextual help links when i18n changes

### DIFF
--- a/client/blocks/inline-help/contextual-help.js
+++ b/client/blocks/inline-help/contextual-help.js
@@ -967,7 +967,7 @@ const getContextLinksForSection = () => ( {
 	],
 	domains: [
 		{
-			link: localizeUrl( 'https://en.support.wordpress.com/add-email/' ),
+			link: localizeUrl( 'https://wordpress.com/support/add-email/' ),
 			post_id: 34087,
 			title: translate( 'Add Email to your Domain' ),
 			description: translate(
@@ -975,7 +975,7 @@ const getContextLinksForSection = () => ( {
 			),
 		},
 		{
-			link: localizeUrl( 'https://en.support.wordpress.com/domains/custom-dns/' ),
+			link: localizeUrl( 'https://wordpress.com/support/domains/custom-dns/' ),
 			post_id: 6595,
 			title: translate( 'Manage Custom DNS' ),
 			description: translate(
@@ -984,7 +984,7 @@ const getContextLinksForSection = () => ( {
 		},
 		{
 			link: localizeUrl(
-				'https://en.support.wordpress.com/move-domain/transfer-domain-registration/'
+				'https://wordpress.com/support/move-domain/transfer-domain-registration/'
 			),
 			post_id: 41298,
 			title: translate( 'Transfer a Domain to Another Registrar' ),
@@ -993,7 +993,7 @@ const getContextLinksForSection = () => ( {
 			),
 		},
 		{
-			link: localizeUrl( 'https://en.support.wordpress.com/domain-mapping-vs-domain-transfer/' ),
+			link: localizeUrl( 'https://wordpress.com/support/domain-mapping-vs-domain-transfer/' ),
 			post_id: 157655,
 			title: translate( 'Connect an Existing Domain' ),
 			description: translate(
@@ -1001,7 +1001,7 @@ const getContextLinksForSection = () => ( {
 			),
 		},
 		{
-			link: localizeUrl( 'https://en.support.wordpress.com/domains/' ),
+			link: localizeUrl( 'https://wordpress.com/support/domains/' ),
 			post_id: 1988,
 			title: translate( 'All about domains' ),
 			description: translate(

--- a/client/blocks/inline-help/contextual-help.js
+++ b/client/blocks/inline-help/contextual-help.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { compact, first, get } from 'lodash';
-import { translate } from 'i18n-calypso';
+import i18n, { translate } from 'i18n-calypso';
 
 /**
  * Internal Dependencies
@@ -13,7 +13,7 @@ import { localizeUrl } from 'lib/i18n-utils';
 /**
  * Module variables
  */
-const fallbackLinks = [
+const getFallbackLinks = () => [
 	{
 		link: localizeUrl(
 			'https://wordpress.com/support/do-i-need-a-website-a-blog-or-a-website-with-a-blog/'
@@ -55,8 +55,9 @@ const fallbackLinks = [
 		description: translate( 'Limit your site’s visibility or make it completely private.' ),
 	},
 ];
+let fallbackLinks = getFallbackLinks();
 
-const contextLinksForSection = {
+const getContextLinksForSection = () => ( {
 	stats: [
 		{
 			link: localizeUrl( 'https://wordpress.com/support/stats/' ),
@@ -1008,7 +1009,8 @@ const contextLinksForSection = {
 			),
 		},
 	],
-};
+} );
+let contextLinksForSection = getContextLinksForSection();
 
 /*
 source: https://www.youtube.com/playlist?list=PLQFhxUeNFfdKx9gO0a2mp9h8pKjb2y9la
@@ -1021,7 +1023,7 @@ document.querySelectorAll('.yt-simple-endpoint.ytd-playlist-video-renderer').for
 console.log( data );
 ```
 */
-const videosForSection = {
+const getVideosForSection = () => ( {
 	sharing: [
 		{
 			type: RESULT_VIDEO,
@@ -1395,9 +1397,10 @@ const videosForSection = {
 			description: translate( 'Find out how to change your WordPress.com theme.' ),
 		},
 	],
-};
+} );
+let videosForSection = getVideosForSection();
 
-const toursForSection = {
+const getToursForSection = () => ( {
 	'post-editor': [
 		{
 			type: RESULT_TOUR,
@@ -1420,7 +1423,16 @@ const toursForSection = {
 			),
 		},
 	],
-};
+} );
+let toursForSection = getToursForSection();
+
+// Update links when i18n changes.
+i18n.on( 'change', () => {
+	fallbackLinks = getFallbackLinks();
+	contextLinksForSection = getContextLinksForSection();
+	videosForSection = getVideosForSection();
+	toursForSection = getToursForSection();
+} );
 
 export function getContextResults( section ) {
 	// Posts and Pages have a common help section

--- a/client/lib/i18n-utils/test/utils.js
+++ b/client/lib/i18n-utils/test/utils.js
@@ -290,7 +290,7 @@ describe( 'utils', () => {
 
 			getLocaleSlug.mockImplementationOnce( () => 'de' ).mockImplementationOnce( () => 'de' );
 			expect(
-				localizeUrl( localizeUrl( 'https://wordpress.com/support/all-about-domains/' ) )
+				localizeUrl( localizeUrl( 'https://en.support.wordpress.com/all-about-domains/' ) )
 			).toEqual( 'https://wordpress.com/de/support/all-about-domains/' );
 			getLocaleSlug();
 			getLocaleSlug(); // make sure to consume it.
@@ -382,70 +382,70 @@ describe( 'utils', () => {
 
 		test( 'support url', () => {
 			getLocaleSlug.mockImplementationOnce( () => 'en' );
-			expect( localizeUrl( 'https://wordpress.com/support/' ) ).toEqual(
+			expect( localizeUrl( 'https://en.support.wordpress.com/' ) ).toEqual(
 				'https://wordpress.com/support/'
 			);
 			getLocaleSlug.mockImplementationOnce( () => 'de' );
-			expect( localizeUrl( 'https://wordpress.com/support/' ) ).toEqual(
+			expect( localizeUrl( 'https://en.support.wordpress.com/' ) ).toEqual(
 				'https://wordpress.com/de/support/'
 			);
 			getLocaleSlug.mockImplementationOnce( () => 'pt-br' );
-			expect( localizeUrl( 'https://wordpress.com/support/' ) ).toEqual(
+			expect( localizeUrl( 'https://en.support.wordpress.com/' ) ).toEqual(
 				'https://wordpress.com/br/support/'
 			);
 			getLocaleSlug.mockImplementationOnce( () => 'pl' );
-			expect( localizeUrl( 'https://wordpress.com/support/' ) ).toEqual(
+			expect( localizeUrl( 'https://en.support.wordpress.com/' ) ).toEqual(
 				'https://wordpress.com/support/'
 			);
 
 			getLocaleSlug.mockImplementationOnce( () => 'en' );
-			expect( localizeUrl( 'https://wordpress.com/support/path/' ) ).toEqual(
+			expect( localizeUrl( 'https://en.support.wordpress.com/path/' ) ).toEqual(
 				'https://wordpress.com/support/path/'
 			);
 			getLocaleSlug.mockImplementationOnce( () => 'de' );
-			expect( localizeUrl( 'https://wordpress.com/support/path/' ) ).toEqual(
+			expect( localizeUrl( 'https://en.support.wordpress.com/path/' ) ).toEqual(
 				'https://wordpress.com/de/support/path/'
 			);
 			getLocaleSlug.mockImplementationOnce( () => 'pt-br' );
-			expect( localizeUrl( 'https://wordpress.com/support/path/' ) ).toEqual(
+			expect( localizeUrl( 'https://en.support.wordpress.com/path/' ) ).toEqual(
 				'https://wordpress.com/br/support/path/'
 			);
 			getLocaleSlug.mockImplementationOnce( () => 'pl' );
-			expect( localizeUrl( 'https://wordpress.com/support/path/' ) ).toEqual(
+			expect( localizeUrl( 'https://en.support.wordpress.com/path/' ) ).toEqual(
 				'https://wordpress.com/support/path/'
 			);
 
 			getLocaleSlug.mockImplementationOnce( () => 'en' );
-			expect( localizeUrl( 'https://wordpress.com/support/' ) ).toEqual(
+			expect( localizeUrl( 'https://en.support.wordpress.com/' ) ).toEqual(
 				'https://wordpress.com/support/'
 			);
 			getLocaleSlug.mockImplementationOnce( () => 'de' );
-			expect( localizeUrl( 'https://wordpress.com/support/' ) ).toEqual(
+			expect( localizeUrl( 'https://en.support.wordpress.com/' ) ).toEqual(
 				'https://wordpress.com/de/support/'
 			);
 			getLocaleSlug.mockImplementationOnce( () => 'pt-br' );
-			expect( localizeUrl( 'https://wordpress.com/support/' ) ).toEqual(
+			expect( localizeUrl( 'https://en.support.wordpress.com/' ) ).toEqual(
 				'https://wordpress.com/br/support/'
 			);
 			getLocaleSlug.mockImplementationOnce( () => 'pl' );
-			expect( localizeUrl( 'https://wordpress.com/support/' ) ).toEqual(
+			expect( localizeUrl( 'https://en.support.wordpress.com/' ) ).toEqual(
 				'https://wordpress.com/support/'
 			);
 
 			getLocaleSlug.mockImplementationOnce( () => 'en' );
-			expect( localizeUrl( 'https://wordpress.com/support/path/' ) ).toEqual(
+			expect( localizeUrl( 'https://en.support.wordpress.com/path/' ) ).toEqual(
 				'https://wordpress.com/support/path/'
 			);
 			getLocaleSlug.mockImplementationOnce( () => 'de' );
-			expect( localizeUrl( 'https://wordpress.com/support/path/' ) ).toEqual(
+			expect( localizeUrl( 'https://en.support.wordpress.com/path/' ) ).toEqual(
 				'https://wordpress.com/de/support/path/'
 			);
 			getLocaleSlug.mockImplementationOnce( () => 'pt-br' );
-			expect( localizeUrl( 'https://wordpress.com/support/path/' ) ).toEqual(
+			expect( localizeUrl( 'https://en.support.wordpress.com/path/' ) ).toEqual(
 				'https://wordpress.com/br/support/path/'
 			);
 			getLocaleSlug.mockImplementationOnce( () => 'pl' );
-			expect( localizeUrl( 'https://wordpress.com/support/path/' ) ).toEqual(
+			expect( localizeUrl( 'https://en.support.wordpress.com/path/' ) ).toEqual(
 				'https://wordpress.com/support/path/'
 			);
 		} );

--- a/client/lib/i18n-utils/utils.js
+++ b/client/lib/i18n-utils/utils.js
@@ -210,7 +210,7 @@ const urlLocalizationMapping = {
 	'wordpress.com/blog/': prefixLocalizedUrlPath( localesWithBlog ),
 	'wordpress.com/tos/': setLocalizedUrlHost( 'wordpress.com', 'magnificent_non_en_locales' ),
 	'jetpack.com': setLocalizedUrlHost( 'jetpack.com', 'jetpack_com_locales' ),
-	'wordpress.com/support': setLocalizedWpComPath( '/support', 'support_site_locales' ),
+	'en.support.wordpress.com': setLocalizedWpComPath( '/support', 'support_site_locales' ),
 	'en.blog.wordpress.com': setLocalizedWpComPath( '/blog', localesWithBlog ),
 	'en.forums.wordpress.com': setLocalizedUrlHost( 'forums.wordpress.com', 'forum_locales' ),
 	'automattic.com/privacy/': prefixLocalizedUrlPath( localesWithPrivacyPolicy ),


### PR DESCRIPTION
Translate calls within contextual-help module were only called once with the declaration of the variable. Since we extend the translations table asynchronously with translation chunks, we need to re-evaluate contextual help objects in order to `translate` functions called again after required translations are loaded.

Before:

![Screenshot 2020-05-26 at 14 09 51](https://user-images.githubusercontent.com/203408/82899053-9b52f680-9f5a-11ea-9ae6-b6c6a70a7073.png)

After:

![Screenshot 2020-05-26 at 14 19 12](https://user-images.githubusercontent.com/203408/82899823-e6213e00-9f5b-11ea-96c1-becede9cb6e7.png)


#### Changes proposed in this Pull Request

* Keep contextual links in sync with i18n changes

#### Testing instructions

1. Boot Calypso with `BUILD_TRANSLATION_CHUNKS=true ENABLE_FEATURES=use-translation-chunks,wpcom-bootstrap-user yarn start`
2. Confirm that contextual help links are properly translated and url are localized.

