### PR TITLE
Inline Help: add `location` property to records tracks event

### DIFF
--- a/client/blocks/inline-help/index.jsx
+++ b/client/blocks/inline-help/index.jsx
@@ -99,13 +99,13 @@ class InlineHelp extends Component {
 
 	showInlineHelp = () => {
 		debug( 'showing inline help.' );
-		this.props.recordTracksEvent( 'calypso_inlinehelp_show' );
+		this.props.recordTracksEvent( 'calypso_inlinehelp_show', { location: 'inline-help-popover' } );
 		this.props.showInlineHelpPopover();
 	};
 
 	closeInlineHelp = () => {
 		debug( 'hiding inline help.' );
-		this.props.recordTracksEvent( 'calypso_inlinehelp_close' );
+		this.props.recordTracksEvent( 'calypso_inlinehelp_close', { location: 'inline-help-popover' } );
 		this.props.hideInlineHelpPopover();
 	};
 

--- a/client/blocks/inline-help/inline-help-forum-view.jsx
+++ b/client/blocks/inline-help/inline-help-forum-view.jsx
@@ -13,7 +13,10 @@ import { preventWidows } from 'lib/formatting';
 import { recordTracksEvent } from 'lib/analytics/tracks';
 import { localizeUrl } from 'lib/i18n-utils';
 
-const trackForumOpen = () => recordTracksEvent( 'calypso_inlinehelp_forums_open' );
+const trackForumOpen = () =>
+	recordTracksEvent( 'calypso_inlinehelp_forums_open', {
+		location: 'inline-help-popover',
+	} );
 
 const InlineHelpForumView = ( { translate = identity } ) => (
 	<div className="inline-help__forum-view">

--- a/client/blocks/inline-help/inline-help-rich-result.jsx
+++ b/client/blocks/inline-help/inline-help-rich-result.jsx
@@ -69,6 +69,7 @@ class InlineHelpRichResult extends Component {
 				search_query: searchQuery,
 				tour,
 				result_url: link,
+				location: 'inline-help-popover',
 			},
 			isUndefined
 		);

--- a/client/blocks/inline-help/inline-help-search-card.jsx
+++ b/client/blocks/inline-help/inline-help-search-card.jsx
@@ -69,7 +69,12 @@ class InlineHelpSearchCard extends Component {
 		}
 	};
 
-	onSearch = ( searchQuery ) => {
+	searchHelperHandler = ( searchQuery ) => {
+		const query = searchQuery.trim();
+		if ( ! query || ! query.length ) {
+			return debug( 'empty query. Skip recording tracks-event.' );
+		}
+
 		debug( 'search query received: ', searchQuery );
 		this.props.recordTracksEvent( 'calypso_inlinehelp_search', {
 			search_query: searchQuery,
@@ -89,7 +94,7 @@ class InlineHelpSearchCard extends Component {
 			<SearchCard
 				searching={ this.props.isSearching }
 				initialValue={ this.props.query }
-				onSearch={ this.onSearch }
+				onSearch={ this.searchHelperHandler }
 				onKeyDown={ this.onKeyDown }
 				placeholder={ this.props.translate( 'Search for help…' ) }
 				delaySearch={ true }

--- a/client/blocks/inline-help/inline-help-search-card.jsx
+++ b/client/blocks/inline-help/inline-help-search-card.jsx
@@ -71,7 +71,10 @@ class InlineHelpSearchCard extends Component {
 
 	onSearch = ( searchQuery ) => {
 		debug( 'search query received: ', searchQuery );
-		this.props.recordTracksEvent( 'calypso_inlinehelp_search', { search_query: searchQuery } );
+		this.props.recordTracksEvent( 'calypso_inlinehelp_search', {
+			search_query: searchQuery,
+			location: 'inline-help-popover',
+		} );
 
 		// Make a search
 		this.props.requestInlineHelpSearchResults( searchQuery );

--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -100,7 +100,9 @@ class InlineHelpPopover extends Component {
 
 	moreHelpClicked = () => {
 		this.props.onClose();
-		this.props.recordTracksEvent( 'calypso_inlinehelp_morehelp_click' );
+		this.props.recordTracksEvent( 'calypso_inlinehelp_morehelp_click', {
+			location: 'inline-help-popover',
+		} );
 	};
 
 	setSecondaryViewKey = ( secondaryViewKey ) => {
@@ -109,13 +111,17 @@ class InlineHelpPopover extends Component {
 
 	openSecondaryView = ( secondaryViewKey ) => {
 		this.setSecondaryViewKey( secondaryViewKey );
-		this.props.recordTracksEvent( `calypso_inlinehelp_${ secondaryViewKey }_show` );
+		this.props.recordTracksEvent( `calypso_inlinehelp_${ secondaryViewKey }_show`, {
+			location: 'inline-help-popover',
+		} );
 		this.setState( { showSecondaryView: true } );
 	};
 
 	closeSecondaryView = () => {
 		this.setSecondaryViewKey( '' );
-		this.props.recordTracksEvent( `calypso_inlinehelp_${ this.state.activeSecondaryView }_hide` );
+		this.props.recordTracksEvent( `calypso_inlinehelp_${ this.state.activeSecondaryView }_hide`, {
+			location: 'inline-help-popover',
+		} );
 		this.props.selectResult( -1 );
 		this.props.resetContactForm();
 		this.setState( { showSecondaryView: false } );
@@ -314,6 +320,7 @@ const optOut = ( siteId, classicUrl ) => {
 			),
 			recordTracksEvent( 'calypso_gutenberg_opt_in', {
 				opt_in: false,
+				location: 'inline-help-popover',
 			} ),
 			bumpStat( 'gutenberg-opt-in', 'Calypso Help Opt Out' )
 		),
@@ -332,6 +339,7 @@ const optIn = ( siteId, gutenbergUrl ) => {
 			),
 			recordTracksEvent( 'calypso_gutenberg_opt_in', {
 				opt_in: true,
+				location: 'inline-help-popover',
 			} ),
 			bumpStat( 'gutenberg-opt-in', 'Calypso Help Opt In' )
 		),

--- a/client/my-sites/customer-home/cards/features/help-search/search-card.jsx
+++ b/client/my-sites/customer-home/cards/features/help-search/search-card.jsx
@@ -99,7 +99,10 @@ const mapStateToProps = ( state, ownProps ) => ( {
 const requestInlineSearchResultsAndTrack = ( searchQuery ) =>
 	withAnalytics(
 		composeAnalytics(
-			recordTracksEvent( 'calypso_inlinehelp_search', { search_query: searchQuery } )
+			recordTracksEvent( 'calypso_inlinehelp_search', {
+				search_query: searchQuery,
+				location: 'customer-home',
+			} )
 		),
 		requestInlineHelpSearchResults( searchQuery )
 	);

--- a/client/my-sites/customer-home/cards/features/help-search/search-card.jsx
+++ b/client/my-sites/customer-home/cards/features/help-search/search-card.jsx
@@ -70,6 +70,11 @@ class HelpSearchCard extends Component {
 	};
 
 	onSearch = ( searchQuery ) => {
+		const query = searchQuery.trim();
+		if ( ! query || ! query.length ) {
+			return debug( 'empty query. Skip recording tracks-event.' );
+		}
+
 		debug( 'search query received: ', searchQuery );
 		this.props.recordTracksEvent( 'calypso_inlinehelp_search', {
 			search_query: searchQuery,

--- a/client/my-sites/customer-home/cards/features/help-search/search-card.jsx
+++ b/client/my-sites/customer-home/cards/features/help-search/search-card.jsx
@@ -63,14 +63,6 @@ class HelpSearchCard extends Component {
 		}
 	};
 
-	onSearch = ( searchQuery ) => {
-		if ( ! searchQuery || ! searchQuery.trim().length ) {
-			// Make an empty search.
-			this.props.requestInlineHelpSearchResults( searchQuery );
-		}
-		this.props.requestInlineSearchResultsAndTrack( searchQuery );
-	};
-
 	componentDidMount() {
 		this.props.requestInlineSearchResultsAndTrack();
 	}
@@ -80,7 +72,7 @@ class HelpSearchCard extends Component {
 			<SearchCard
 				searching={ this.props.isSearching }
 				initialValue={ this.props.query }
-				onSearch={ this.onSearch }
+				onSearch={ this.props.requestInlineSearchResultsAndTrack }
 				onKeyDown={ this.onKeyDown }
 				placeholder={ this.props.translate( 'Search support articles' ) }
 				delaySearch={ true }
@@ -97,15 +89,17 @@ const mapStateToProps = ( state, ownProps ) => ( {
 } );
 
 const requestInlineSearchResultsAndTrack = ( searchQuery ) =>
-	withAnalytics(
-		composeAnalytics(
-			recordTracksEvent( 'calypso_inlinehelp_search', {
-				search_query: searchQuery,
-				location: 'customer-home',
-			} )
-		),
-		requestInlineHelpSearchResults( searchQuery )
-	);
+	( ! searchQuery || ! ( searchQuery.trim() ).length )
+		? requestInlineHelpSearchResults()
+		: withAnalytics(
+			composeAnalytics(
+				recordTracksEvent( 'calypso_inlinehelp_search', {
+					search_query: searchQuery,
+					location: 'customer-home',
+				} )
+			),
+			requestInlineHelpSearchResults( searchQuery )
+		);
 
 const mapDispatchToProps = {
 	recordTracksEvent,

--- a/client/my-sites/customer-home/cards/features/help-search/search-card.jsx
+++ b/client/my-sites/customer-home/cards/features/help-search/search-card.jsx
@@ -92,14 +92,14 @@ const requestInlineSearchResultsAndTrack = ( searchQuery ) =>
 	( ! searchQuery || ! ( searchQuery.trim() ).length )
 		? requestInlineHelpSearchResults()
 		: withAnalytics(
-			composeAnalytics(
+			composeAnalytics (
 				recordTracksEvent( 'calypso_inlinehelp_search', {
 					search_query: searchQuery,
 					location: 'customer-home',
 				} )
 			),
-			requestInlineHelpSearchResults( searchQuery )
-		);
+		requestInlineHelpSearchResults( searchQuery )
+	);
 
 const mapDispatchToProps = {
 	recordTracksEvent,

--- a/client/my-sites/customer-home/cards/features/help-search/search-card.jsx
+++ b/client/my-sites/customer-home/cards/features/help-search/search-card.jsx
@@ -98,8 +98,8 @@ const requestInlineSearchResultsAndTrack = ( searchQuery ) =>
 					location: 'customer-home',
 				} )
 			),
-		requestInlineHelpSearchResults( searchQuery )
-	);
+			requestInlineHelpSearchResults( searchQuery )
+		);
 
 const mapDispatchToProps = {
 	recordTracksEvent,

--- a/client/my-sites/customer-home/cards/features/help-search/search-card.jsx
+++ b/client/my-sites/customer-home/cards/features/help-search/search-card.jsx
@@ -89,17 +89,17 @@ const mapStateToProps = ( state, ownProps ) => ( {
 } );
 
 const requestInlineSearchResultsAndTrack = ( searchQuery ) =>
-	( ! searchQuery || ! ( searchQuery.trim() ).length )
+	! searchQuery || ! searchQuery.trim().length
 		? requestInlineHelpSearchResults()
 		: withAnalytics(
-			composeAnalytics (
-				recordTracksEvent( 'calypso_inlinehelp_search', {
-					search_query: searchQuery,
-					location: 'customer-home',
-				} )
-			),
-			requestInlineHelpSearchResults( searchQuery )
-		);
+				composeAnalytics(
+					recordTracksEvent( 'calypso_inlinehelp_search', {
+						search_query: searchQuery,
+						location: 'customer-home',
+					} )
+				),
+				requestInlineHelpSearchResults( searchQuery )
+		  );
 
 const mapDispatchToProps = {
 	recordTracksEvent,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR improves recording tracks event from the Inline Help Popover component (currently working on prod) and also records the `search` event when a search occurs in the `<Support />` component.

~<Support /> isn't implemented yet. It's currently [handled on this PR](https://github.com/Automattic/wp-calypso/pull/42625). For this reason, this branch was been branched off from there.~

#### \<InlineHelperPopover /\> component

<img src="https://user-images.githubusercontent.com/77539/83031290-c137d400-a00a-11ea-8b9d-72824d17f1aa.png" width="400px" />

#### \<Support /\> component

<img src="https://user-images.githubusercontent.com/77539/83031350-d3b20d80-a00a-11ea-9d47-b9162f36f840.png" width="400px" />

### Segmentation

The primary goal here is to be able to compare where the events came from, segmenting them by the new `location` property, which could contain two different values so far: `inline-help-popover` and `customer-home`.
These values make reference to the location where the search was done by the user.

### Scope

The suggested scope is _"Record track event when the user performs a search query in the customer home, and add the `location` property to all events of the support assistant"_. It will allow us to compare stats between the customer home page and the rest (inline help popover).

### Next Steps

Once this approach merges, the next steps are:

* Keep recording more tracks event with the proper segmentation
* Re-evaluate if some of events could be combined into a single event like `calypso_inlinehelp_resource_open|view|click|hide` with property `resource=contact|morehelp|video|tour|forums`

### Testing instructions

1) Apply D43941-code to your sandbox (for testing only).
2) Set up the `debug` property of the local storage to see the recording events.
```
localStorage.setItem( 'debug', 'calypso:analytics*' );
```

3) Check that events triggered and recorded by the <InlineHelpPopover /> have the `location` property with the `inline-help-popover` value. 

* Go to any page different to customer home, for instance, stats
http://calypso.localhost:3000/stats/day/<your-testing-site>
* Open the Inline Help Popover by clicking on the FAB icon
* Tyle a query in the _🔎 Search for help..._ input
* Confirm that the events have the `location` property in the dev console.

_Trigger to record the event_
<img width="400" alt="Screen Shot 2020-05-28 at 8 39 49 AM" src="https://user-images.githubusercontent.com/77539/83137096-f30a7280-a0be-11ea-9650-69cf3511e9c2.png">


_Recorded event_
<img width="400" alt="Screen Shot 2020-05-28 at 8 40 16 AM" src="https://user-images.githubusercontent.com/77539/83137089-ef76eb80-a0be-11ea-88fb-0717057fa978.png">

4) Check the events recorded by the `<Support />` component, available in the customer home page:

* http://calypso.localhost:3000/home/<your-testing-site>
* Tyle a query in the _🔎 Search for help..._ input
* Confirm that the events have the `location` property in the dev console.

<img width="400" alt="Screen Shot 2020-05-28 at 9 01 13 AM" src="https://user-images.githubusercontent.com/77539/83138983-02d78600-a0c2-11ea-8122-69bbf1188f7e.png">

<img width="400" alt="Screen Shot 2020-05-28 at 9 01 20 AM" src="https://user-images.githubusercontent.com/77539/83138987-04a14980-a0c2-11ea-8754-8cf4822ec062.png">

5) Also, you can confirm that it doesn't record events for empty query strings.

Fixes https://github.com/Automattic/wp-calypso/issues/42105
