### PR TITLE
Remove unnecessary document head in marketing traffic page

### DIFF
--- a/client/my-sites/marketing/traffic/index.js
+++ b/client/my-sites/marketing/traffic/index.js
@@ -13,7 +13,6 @@ import { flowRight, partialRight, pick } from 'lodash';
 import Main from 'components/main';
 import EmptyContent from 'components/empty-content';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
-import DocumentHead from 'components/data/document-head';
 import SeoSettingsMain from 'my-sites/site-settings/seo-settings/main';
 import SeoSettingsHelpCard from 'my-sites/site-settings/seo-settings/help';
 import SiteVerification from 'my-sites/site-settings/seo-settings/site-verification';
@@ -49,7 +48,6 @@ const SiteSettingsTraffic = ( {
 	// eslint-disable-next-line wpcalypso/jsx-classname-namespace
 	<Main className="settings-traffic site-settings" wideLayout>
 		<PageViewTracker path="/marketing/traffic/:site" title="Marketing > Traffic" />
-		<DocumentHead title={ translate( 'Marketing and Integrations' ) } />
 		{ ! isAdmin && (
 			<EmptyContent
 				illustration="/calypso/images/illustrations/illustration-404.svg"


### PR DESCRIPTION
Parent marketing page already has the document head component with the same title and having in both the main and traffic page was causing infinite set state loop when translate was firing a re-render, e.g. when community translator is being enabled.

![Screenshot 2020-05-26 at 15 36 41](https://user-images.githubusercontent.com/203408/82907324-c2afc080-9f66-11ea-9b36-fb33872ea0aa.png)

#### Changes proposed in this Pull Request

* Remove unnecessary document head in marketing traffic page

#### Testing instructions

* Boot Calypso
* Open http://calypso.localhost:3000/marketing/traffic
* Enable community translator and confirm it's not crashing the page
