### PR TITLE
Add missing main container `security` className for security sub-pages

### DIFF
--- a/client/me/connected-applications/index.jsx
+++ b/client/me/connected-applications/index.jsx
@@ -101,7 +101,7 @@ class ConnectedApplications extends PureComponent {
 		const { translate } = this.props;
 
 		return (
-			<Main className="connected-applications">
+			<Main className="security connected-applications">
 				<QueryConnectedApplications />
 
 				<PageViewTracker

--- a/client/me/security-account-recovery/index.jsx
+++ b/client/me/security-account-recovery/index.jsx
@@ -52,7 +52,7 @@ import PageViewTracker from 'lib/analytics/page-view-tracker';
 import './style.scss';
 
 const SecurityAccountRecovery = ( props ) => (
-	<Main className="security-account-recovery">
+	<Main className="security security-account-recovery">
 		<PageViewTracker path="/me/security/account-recovery" title="Me > Account Recovery" />
 		<QueryAccountRecoverySettings />
 

--- a/client/me/social-login/index.jsx
+++ b/client/me/social-login/index.jsx
@@ -80,7 +80,7 @@ class SocialLogin extends Component {
 		const title = this.props.translate( 'Social Login' );
 
 		return (
-			<Main className="social-login">
+			<Main className="security social-login">
 				<PageViewTracker path="/me/security/social-login" title="Me > Social Login" />
 				<DocumentHead title={ title } />
 				<MeSidebarNavigation />

--- a/client/me/two-step/index.jsx
+++ b/client/me/two-step/index.jsx
@@ -162,7 +162,7 @@ class TwoStep extends Component {
 
 	render() {
 		return (
-			<Main className="two-step">
+			<Main className="security two-step">
 				<PageViewTracker path="/me/security/two-step" title="Me > Two-Step Authentication" />
 				<MeSidebarNavigation />
 


### PR DESCRIPTION
The sub-pages of `me/security` were missing the `security` class name on the main container, which was causing inconsistencies in the layout, e.g. different width of the dropdown.

#### Changes proposed in this Pull Request

* Add missing main container `security` className for security sub-pages

**Before:**
![image](https://user-images.githubusercontent.com/2722412/82910096-d8c37e00-9f72-11ea-8040-1be41a1c6d94.png)

**After:**
![image](https://user-images.githubusercontent.com/2722412/82910042-c8130800-9f72-11ea-88c7-357db2e4df5a.png)


#### Testing instructions

1. Boot Calypso
2. Open http://calypso.localhost:3000/me/security
3. Confirm that the layout of the main security page is consistent with the sub-pages.

Fixes #42653
