### PR TITLE
Decouple buttons

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/blog-posts-block/newspack-homepage-articles/blocks/homepage-articles/block.json
+++ b/apps/full-site-editing/full-site-editing-plugin/blog-posts-block/newspack-homepage-articles/blocks/homepage-articles/block.json
@@ -1,0 +1,131 @@
+{
+	"name": "homepage-articles",
+	"category": "newspack",
+	"attributes": {
+		"className": {
+			"type": "string",
+			"default": ""
+		},
+		"showExcerpt": {
+			"type": "boolean",
+			"default": true
+		},
+		"showDate": {
+			"type": "boolean",
+			"default": true
+		},
+		"showImage": {
+			"type": "boolean",
+			"default": true
+		},
+		"showCaption": {
+			"type": "boolean",
+			"default": false
+		},
+		"imageShape": {
+			"type": "string",
+			"default": "landscape"
+		},
+		"minHeight": {
+			"type": "integer",
+			"default": 0
+		},
+		"moreButton": {
+			"type": "boolean",
+			"default": false
+		},
+		"moreButtonText": {
+			"type": "string",
+			"default": ""
+		},
+		"showAuthor": {
+			"type": "boolean",
+			"default": true
+		},
+		"showAvatar": {
+			"type": "boolean",
+			"default": true
+		},
+		"showCategory": {
+			"type": "boolean",
+			"default": false
+		},
+		"postLayout": {
+			"type": "string",
+			"default": "list"
+		},
+		"columns": {
+			"type": "integer",
+			"default": 3
+		},
+		"postsToShow": {
+			"type": "integer",
+			"default": 3
+		},
+		"mediaPosition": {
+			"type": "string",
+			"default": "top"
+		},
+		"authors": {
+			"type": "array",
+			"default": [],
+			"items": { "type": "integer" }
+		},
+		"categories": {
+			"type": "array",
+			"default": [],
+			"items": { "type": "integer" }
+		},
+		"tags": {
+			"type": "array",
+			"default": [],
+			"items": { "type": "integer" }
+		},
+		"tagExclusions": {
+			"type": "array",
+			"default": [],
+			"items": { "type": "integer" }
+		},
+		"specificPosts": {
+			"type": "array",
+			"default": [],
+			"items": { "type": "integer" }
+		},
+		"typeScale": {
+			"type": "integer",
+			"default": 4
+		},
+		"imageScale": {
+			"type": "integer",
+			"default": 3
+		},
+		"mobileStack": {
+			"type": "boolean",
+			"default": false
+		},
+		"sectionHeader": {
+			"type": "string",
+			"default": ""
+		},
+		"specificMode": {
+			"type": "boolean",
+			"default": false
+		},
+		"textColor": {
+			"type": "string",
+			"default": ""
+		},
+		"customTextColor": {
+			"type": "string",
+			"default": ""
+		},
+		"singleMode": {
+			"type": "boolean",
+			"default": false
+		},
+		"showSubtitle": {
+			"type": "boolean",
+			"default": false
+		}
+	}
+}

--- a/apps/full-site-editing/full-site-editing-plugin/blog-posts-block/newspack-homepage-articles/blocks/homepage-articles/class-wp-rest-newspack-articles-controller.php
+++ b/apps/full-site-editing/full-site-editing-plugin/blog-posts-block/newspack-homepage-articles/blocks/homepage-articles/class-wp-rest-newspack-articles-controller.php
@@ -1,0 +1,178 @@
+<?php
+/**
+ * WP_REST_Newspack_Articles_Controller file.
+ *
+ * @package WordPress
+ */
+
+/**
+ * Class WP_REST_Newspack_Articles_Controller.
+ */
+class WP_REST_Newspack_Articles_Controller extends WP_REST_Controller {
+
+	/**
+	 * Attribute schema.
+	 *
+	 * @var array
+	 */
+	public $attribute_schema;
+
+	/**
+	 * Constructs the controller.
+	 *
+	 * @access public
+	 */
+	public function __construct() {
+		$this->namespace = 'newspack-blocks/v1';
+		$this->rest_base = 'articles';
+	}
+
+	/**
+	 * Registers the necessary REST API routes.
+	 *
+	 * @access public
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			[
+				[
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => [ $this, 'get_items' ],
+					'args'                => $this->get_attribute_schema(),
+					'permission_callback' => '__return_true',
+				],
+			]
+		);
+	}
+
+	/**
+	 * Returns a list of rendered posts.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response
+	 */
+	public function get_items( $request ) {
+		$page        = $request->get_param( 'page' ) ?? 1;
+		$exclude_ids = $request->get_param( 'exclude_ids' ) ?? [];
+		$next_page   = $page + 1;
+		$attributes  = wp_parse_args(
+			$request->get_params() ?? [],
+			wp_list_pluck( $this->get_attribute_schema(), 'default' )
+		);
+
+		$article_query_args = Newspack_Blocks::build_articles_query( $attributes );
+
+		$query = array_merge(
+			$article_query_args,
+			[
+				'post__not_in' => $exclude_ids,
+			]
+		);
+
+		// Run Query.
+		$article_query = new WP_Query( $query );
+
+		// Defaults.
+		$items    = [];
+		$ids      = [];
+		$next_url = '';
+
+		// The Loop.
+		while ( $article_query->have_posts() ) {
+			$article_query->the_post();
+			$html = Newspack_Blocks::template_inc(
+				__DIR__ . '/templates/article.php',
+				[
+					'attributes' => $attributes,
+				]
+			);
+
+			if ( $request->get_param( 'amp' ) ) {
+				$html = $this->generate_amp_partial( $html );
+			}
+			$items[]['html'] = $html;
+			$ids[]           = get_the_ID();
+		}
+
+		// Provide next URL if there are more pages.
+		if ( $next_page <= $article_query->max_num_pages ) {
+			$next_url = add_query_arg(
+				array_merge(
+					array_map(
+						function( $attribute ) {
+							return false === $attribute ? '0' : str_replace( '#', '%23', $attribute );
+						},
+						$attributes
+					),
+					[
+						'exclude_ids' => false,
+						'page'        => $next_page,
+						'amp'         => $request->get_param( 'amp' ),
+					]
+				),
+				rest_url( '/newspack-blocks/v1/articles' )
+			);
+		}
+
+		return rest_ensure_response(
+			[
+				'items' => $items,
+				'ids'   => $ids,
+				'next'  => $next_url,
+			]
+		);
+	}
+
+	/**
+	 * Sets up and returns attribute schema.
+	 *
+	 * @return array
+	 */
+	public function get_attribute_schema() {
+		if ( empty( $this->attribute_schema ) ) {
+			$block_json = json_decode(
+				file_get_contents( __DIR__ . '/block.json' ), // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+				true
+			);
+
+			$this->attribute_schema = array_merge(
+				$block_json['attributes'],
+				[
+					'exclude_ids' => [
+						'type'    => 'array',
+						'default' => [],
+						'items'   => [
+							'type' => 'integer',
+						],
+					],
+				]
+			);
+		}
+		return $this->attribute_schema;
+	}
+
+	/**
+	 * Use AMP Plugin functions to render markup as valid AMP.
+	 *
+	 * @param string $html Markup to convert to AMP.
+	 * @return string
+	 */
+	public function generate_amp_partial( $html ) {
+		$dom = AMP_DOM_Utils::get_dom_from_content( $html );
+
+		AMP_Content_Sanitizer::sanitize_document(
+			$dom,
+			amp_get_content_sanitizers(),
+			[
+				'use_document_element' => false,
+			]
+		);
+		$xpath = new DOMXPath( $dom );
+		foreach ( iterator_to_array( $xpath->query( '//noscript | //comment()' ) ) as $node ) {
+			$node->parentNode->removeChild( $node ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.NotSnakeCaseMemberVar
+		}
+		return AMP_DOM_Utils::get_content_from_dom( $dom );
+	}
+}

--- a/apps/full-site-editing/full-site-editing-plugin/blog-posts-block/newspack-homepage-articles/blocks/homepage-articles/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/blog-posts-block/newspack-homepage-articles/blocks/homepage-articles/edit.js
@@ -1,0 +1,701 @@
+/* eslint-disable jsx-a11y/anchor-is-valid */
+
+/**
+ * Internal dependencies
+ */
+import QueryControls from '../../components/query-controls';
+import { STORE_NAMESPACE } from './store';
+import { isBlogPrivate, isSpecificPostModeActive, queryCriteriaFromAttributes } from './utils';
+
+/**
+ * External dependencies
+ */
+import classNames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { __, _x } from '@wordpress/i18n';
+import { dateI18n, __experimentalGetSettings } from '@wordpress/date';
+import { Component, Fragment, RawHTML } from '@wordpress/element';
+import {
+	BlockControls,
+	InspectorControls,
+	PanelColorSettings,
+	RichText,
+	withColors,
+} from '@wordpress/block-editor';
+import {
+	Button,
+	ButtonGroup,
+	PanelBody,
+	PanelRow,
+	RangeControl,
+	Toolbar,
+	ToggleControl,
+	Placeholder,
+	Spinner,
+	BaseControl,
+	Path,
+	SVG,
+} from '@wordpress/components';
+import { withDispatch, withSelect } from '@wordpress/data';
+import { compose } from '@wordpress/compose';
+import { decodeEntities } from '@wordpress/html-entities';
+
+let IS_SUBTITLE_SUPPORTED_IN_THEME;
+if (
+	typeof window === 'object' &&
+	window.newspackIsPostSubtitleSupported &&
+	window.newspackIsPostSubtitleSupported.post_subtitle
+) {
+	IS_SUBTITLE_SUPPORTED_IN_THEME = true;
+}
+
+/* From https://material.io/tools/icons */
+const landscapeIcon = (
+	<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+		<Path d="M0 0h24v24H0z" fill="none" />
+		<Path d="M19 5H5c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 12H5V7h14v10z" />
+	</SVG>
+);
+
+const portraitIcon = (
+	<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+		<Path d="M0 0h24v24H0z" fill="none" />
+		<Path d="M17 3H7c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h10c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H7V5h10v14z" />
+	</SVG>
+);
+
+const squareIcon = (
+	<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+		<Path d="M0 0h24v24H0z" fill="none" />
+		<Path d="M18 4H6c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 14H6V6h12v12z" />
+	</SVG>
+);
+
+const uncroppedIcon = (
+	<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+		<Path d="M0 0h24v24H0z" fill="none" />
+		<Path d="M3 5v4h2V5h4V3H5c-1.1 0-2 .9-2 2zm2 10H3v4c0 1.1.9 2 2 2h4v-2H5v-4zm14 4h-4v2h4c1.1 0 2-.9 2-2v-4h-2v4zm0-16h-4v2h4v4h2V5c0-1.1-.9-2-2-2z" />
+	</SVG>
+);
+
+const coverIcon = (
+	<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+		<Path d="M0 0h24v24H0z" fill="none" />
+		<Path d="M4 4h7V2H4c-1.1 0-2 .9-2 2v7h2V4zm6 9l-4 5h12l-3-4-2.03 2.71L10 13zm7-4.5c0-.83-.67-1.5-1.5-1.5S14 7.67 14 8.5s.67 1.5 1.5 1.5S17 9.33 17 8.5zM20 2h-7v2h7v7h2V4c0-1.1-.9-2-2-2zm0 18h-7v2h7c1.1 0 2-.9 2-2v-7h-2v7zM4 13H2v7c0 1.1.9 2 2 2h7v-2H4v-7z" />
+	</SVG>
+);
+
+class Edit extends Component {
+	renderPost = ( post ) => {
+		const { attributes } = this.props;
+		const {
+			showImage,
+			imageShape,
+			mediaPosition,
+			minHeight,
+			showCaption,
+			showExcerpt,
+			showSubtitle,
+			showAuthor,
+			showAvatar,
+			showDate,
+			showCategory,
+			sectionHeader,
+		} = attributes;
+
+		const styles = {
+			minHeight:
+				mediaPosition === 'behind' &&
+				showImage &&
+				post.newspack_featured_image_src &&
+				minHeight + 'vh',
+			paddingTop:
+				mediaPosition === 'behind' &&
+				showImage &&
+				post.newspack_featured_image_src &&
+				minHeight / 5 + 'vh',
+		};
+
+		const postTitle = this.titleForPost( post );
+		const dateFormat = __experimentalGetSettings().formats.date;
+		return (
+			<article
+				className={ post.newspack_featured_image_src ? 'post-has-image' : null }
+				key={ post.id }
+				style={ styles }
+			>
+				{ showImage && post.newspack_featured_image_src && (
+					<figure className="post-thumbnail" key="thumbnail">
+						<a href="#">
+							{ imageShape === 'landscape' && (
+								<img src={ post.newspack_featured_image_src.landscape } alt="" />
+							) }
+							{ imageShape === 'portrait' && (
+								<img src={ post.newspack_featured_image_src.portrait } alt="" />
+							) }
+							{ imageShape === 'square' && (
+								<img src={ post.newspack_featured_image_src.square } alt="" />
+							) }
+							{ imageShape === 'uncropped' && (
+								<img src={ post.newspack_featured_image_src.uncropped } alt="" />
+							) }
+						</a>
+						{ showCaption && '' !== post.newspack_featured_image_caption && (
+							<figcaption>{ post.newspack_featured_image_caption }</figcaption>
+						) }
+					</figure>
+				) }
+
+				<div className="entry-wrapper">
+					{ showCategory && post.newspack_category_info.length && (
+						<div className="cat-links">
+							<a href="#">{ post.newspack_category_info }</a>
+						</div>
+					) }
+					{ RichText.isEmpty( sectionHeader ) ? (
+						<h2 className="entry-title" key="title">
+							<a href="#">{ postTitle }</a>
+						</h2>
+					) : (
+						<h3 className="entry-title" key="title">
+							<a href="#">{ postTitle }</a>
+						</h3>
+					) }
+					{ IS_SUBTITLE_SUPPORTED_IN_THEME && showSubtitle && (
+						<RawHTML
+							key="subtitle"
+							className="newspack-post-subtitle newspack-post-subtitle--in-homepage-block"
+						>
+							{ post.meta.newspack_post_subtitle || '' }
+						</RawHTML>
+					) }
+					{ showExcerpt && (
+						<RawHTML key="excerpt" className="excerpt-contain">
+							{ post.excerpt.rendered }
+						</RawHTML>
+					) }
+					<div className="entry-meta">
+						{ showAuthor && showAvatar && this.formatAvatars( post.newspack_author_info ) }
+						{ showAuthor && this.formatByline( post.newspack_author_info ) }
+						{ showDate && (
+							<time className="entry-date published" key="pub-date">
+								{ dateI18n( dateFormat, post.date_gmt ) }
+							</time>
+						) }
+					</div>
+				</div>
+			</article>
+		);
+	};
+
+	titleForPost = ( post ) => {
+		if ( ! post.title ) {
+			return '';
+		}
+		if ( typeof post.title === 'string' ) {
+			return decodeEntities( post.title.trim() );
+		}
+		if ( typeof post.title === 'object' && post.title.rendered ) {
+			return decodeEntities( post.title.rendered.trim() );
+		}
+	};
+
+	formatAvatars = ( authorInfo ) =>
+		authorInfo.map( ( author ) => (
+			<span className="avatar author-avatar" key={ author.id }>
+				<a className="url fn n" href="#">
+					<RawHTML>{ author.avatar }</RawHTML>
+				</a>
+			</span>
+		) );
+
+	formatByline = ( authorInfo ) => (
+		<span className="byline">
+			{ _x( 'by', 'post author', 'full-site-editing' ) }{ ' ' }
+			{ authorInfo.reduce( ( accumulator, author, index ) => {
+				return [
+					...accumulator,
+					<span className="author vcard" key={ author.id }>
+						<a className="url fn n" href="#">
+							{ author.display_name }
+						</a>
+					</span>,
+					index < authorInfo.length - 2 && ', ',
+					authorInfo.length > 1 &&
+						index === authorInfo.length - 2 &&
+						_x( ' and ', 'post author', 'full-site-editing' ),
+				];
+			}, [] ) }
+		</span>
+	);
+
+	renderInspectorControls = () => {
+		const { attributes, setAttributes, textColor, setTextColor } = this.props;
+
+		const {
+			authors,
+			specificPosts,
+			postsToShow,
+			categories,
+			columns,
+			showImage,
+			showCaption,
+			imageScale,
+			mobileStack,
+			minHeight,
+			moreButton,
+			showExcerpt,
+			showSubtitle,
+			typeScale,
+			showDate,
+			showAuthor,
+			showAvatar,
+			showCategory,
+			postLayout,
+			mediaPosition,
+			specificMode,
+			tags,
+			tagExclusions,
+		} = attributes;
+
+		const imageSizeOptions = [
+			{
+				value: 1,
+				label: /* translators: label for small size option */ __( 'Small', 'full-site-editing' ),
+				shortName: /* translators: abbreviation for small size */ __( 'S', 'full-site-editing' ),
+			},
+			{
+				value: 2,
+				label: /* translators: label for medium size option */ __( 'Medium', 'full-site-editing' ),
+				shortName: /* translators: abbreviation for medium size */ __( 'M', 'full-site-editing' ),
+			},
+			{
+				value: 3,
+				label: /* translators: label for large size option */ __( 'Large', 'full-site-editing' ),
+				shortName: /* translators: abbreviation for large size */ __( 'L', 'full-site-editing' ),
+			},
+			{
+				value: 4,
+				label: /* translators: label for extra large size option */ __(
+					'Extra Large',
+					'newspack-blocks'
+				),
+				shortName: /* translators: abbreviation for extra large size */ __(
+					'XL',
+					'newspack-blocks'
+				),
+			},
+		];
+
+		return (
+			<Fragment>
+				<PanelBody title={ __( 'Display Settings', 'full-site-editing' ) } initialOpen={ true }>
+					{ postsToShow && (
+						<QueryControls
+							numberOfItems={ postsToShow }
+							onNumberOfItemsChange={ ( _postsToShow ) =>
+								setAttributes( { postsToShow: _postsToShow } )
+							}
+							specificMode={ specificMode }
+							onSpecificModeChange={ ( _specificMode ) =>
+								setAttributes( { specificMode: _specificMode } )
+							}
+							specificPosts={ specificPosts }
+							onSpecificPostsChange={ ( _specificPosts ) =>
+								setAttributes( { specificPosts: _specificPosts } )
+							}
+							authors={ authors }
+							onAuthorsChange={ ( _authors ) => setAttributes( { authors: _authors } ) }
+							categories={ categories }
+							onCategoriesChange={ ( _categories ) => setAttributes( { categories: _categories } ) }
+							tags={ tags }
+							onTagsChange={ ( _tags ) => {
+								setAttributes( { tags: _tags } );
+							} }
+							tagExclusions={ tagExclusions }
+							onTagExclusionsChange={ ( _tagExclusions ) =>
+								setAttributes( { tagExclusions: _tagExclusions } )
+							}
+						/>
+					) }
+					{ postLayout === 'grid' && (
+						<RangeControl
+							label={ __( 'Columns', 'full-site-editing' ) }
+							value={ columns }
+							onChange={ ( _columns ) => setAttributes( { columns: _columns } ) }
+							min={ 2 }
+							max={ 6 }
+							required
+						/>
+					) }
+					{ ! specificMode && ! isBlogPrivate() && (
+						/*
+						 * Hide the "More" button option on private sites.
+						 *
+						 * Client-side fetching from a private WP.com blog requires authentication,
+						 * which is not provided in the current implementation.
+						 * See https://github.com/Automattic/newspack-blocks/issues/306.
+						 */
+						<ToggleControl
+							label={ __( 'Show "More" Button', 'full-site-editing' ) }
+							checked={ moreButton }
+							onChange={ () => setAttributes( { moreButton: ! moreButton } ) }
+						/>
+					) }
+				</PanelBody>
+				<PanelBody title={ __( 'Featured Image Settings', 'full-site-editing' ) }>
+					<PanelRow>
+						<ToggleControl
+							label={ __( 'Show Featured Image', 'full-site-editing' ) }
+							checked={ showImage }
+							onChange={ () => setAttributes( { showImage: ! showImage } ) }
+						/>
+					</PanelRow>
+
+					{ showImage && (
+						<PanelRow>
+							<ToggleControl
+								label={ __( 'Show Featured Image Caption', 'full-site-editing' ) }
+								checked={ showCaption }
+								onChange={ () => setAttributes( { showCaption: ! showCaption } ) }
+							/>
+						</PanelRow>
+					) }
+
+					{ showImage && mediaPosition !== 'top' && mediaPosition !== 'behind' && (
+						<Fragment>
+							<PanelRow>
+								<ToggleControl
+									label={ __( 'Stack on mobile', 'full-site-editing' ) }
+									checked={ mobileStack }
+									onChange={ () => setAttributes( { mobileStack: ! mobileStack } ) }
+								/>
+							</PanelRow>
+							<BaseControl
+								label={ __( 'Featured Image Size', 'full-site-editing' ) }
+								id="newspackfeatured-image-size"
+							>
+								<PanelRow>
+									<ButtonGroup
+										id="newspackfeatured-image-size"
+										aria-label={ __( 'Featured Image Size', 'full-site-editing' ) }
+									>
+										{ imageSizeOptions.map( ( option ) => {
+											const isCurrent = imageScale === option.value;
+											return (
+												<Button
+													isLarge
+													isPrimary={ isCurrent }
+													aria-pressed={ isCurrent }
+													aria-label={ option.label }
+													key={ option.value }
+													onClick={ () => setAttributes( { imageScale: option.value } ) }
+												>
+													{ option.shortName }
+												</Button>
+											);
+										} ) }
+									</ButtonGroup>
+								</PanelRow>
+							</BaseControl>
+						</Fragment>
+					) }
+
+					{ showImage && mediaPosition === 'behind' && (
+						<RangeControl
+							label={ __( 'Minimum height', 'full-site-editing' ) }
+							help={ __(
+								"Sets a minimum height for the block, using a percentage of the screen's current height.",
+								'newspack-blocks'
+							) }
+							value={ minHeight }
+							onChange={ ( _minHeight ) => setAttributes( { minHeight: _minHeight } ) }
+							min={ 0 }
+							max={ 100 }
+							required
+						/>
+					) }
+				</PanelBody>
+				<PanelBody title={ __( 'Post Control Settings', 'full-site-editing' ) }>
+					{ IS_SUBTITLE_SUPPORTED_IN_THEME && (
+						<PanelRow>
+							<ToggleControl
+								label={ __( 'Show Subtitle', 'full-site-editing' ) }
+								checked={ showSubtitle }
+								onChange={ () => setAttributes( { showSubtitle: ! showSubtitle } ) }
+							/>
+						</PanelRow>
+					) }
+					<PanelRow>
+						<ToggleControl
+							label={ __( 'Show Excerpt', 'full-site-editing' ) }
+							checked={ showExcerpt }
+							onChange={ () => setAttributes( { showExcerpt: ! showExcerpt } ) }
+						/>
+					</PanelRow>
+					<RangeControl
+						className="type-scale-slider"
+						label={ __( 'Type Scale', 'full-site-editing' ) }
+						value={ typeScale }
+						onChange={ ( _typeScale ) => setAttributes( { typeScale: _typeScale } ) }
+						min={ 1 }
+						max={ 10 }
+						beforeIcon="editor-textcolor"
+						afterIcon="editor-textcolor"
+						required
+					/>
+				</PanelBody>
+				<PanelColorSettings
+					title={ __( 'Color Settings', 'full-site-editing' ) }
+					initialOpen={ true }
+					colorSettings={ [
+						{
+							value: textColor.color,
+							onChange: setTextColor,
+							label: __( 'Text Color', 'full-site-editing' ),
+						},
+					] }
+				/>
+				<PanelBody title={ __( 'Post Meta Settings', 'full-site-editing' ) }>
+					<PanelRow>
+						<ToggleControl
+							label={ __( 'Show Date', 'full-site-editing' ) }
+							checked={ showDate }
+							onChange={ () => setAttributes( { showDate: ! showDate } ) }
+						/>
+					</PanelRow>
+					<PanelRow>
+						<ToggleControl
+							label={ __( 'Show Category', 'full-site-editing' ) }
+							checked={ showCategory }
+							onChange={ () => setAttributes( { showCategory: ! showCategory } ) }
+						/>
+					</PanelRow>
+					<PanelRow>
+						<ToggleControl
+							label={ __( 'Show Author', 'full-site-editing' ) }
+							checked={ showAuthor }
+							onChange={ () => setAttributes( { showAuthor: ! showAuthor } ) }
+						/>
+					</PanelRow>
+					{ showAuthor && (
+						<PanelRow>
+							<ToggleControl
+								label={ __( 'Show Author Avatar', 'full-site-editing' ) }
+								checked={ showAvatar }
+								onChange={ () => setAttributes( { showAvatar: ! showAvatar } ) }
+							/>
+						</PanelRow>
+					) }
+				</PanelBody>
+			</Fragment>
+		);
+	};
+
+	render() {
+		/**
+		 * Constants
+		 */
+
+		const {
+			attributes,
+			className,
+			clientId,
+			setAttributes,
+			isSelected,
+			latestPosts,
+			textColor,
+			markPostsAsDisplayed,
+		} = this.props;
+
+		const {
+			showImage,
+			imageShape,
+			postLayout,
+			mediaPosition,
+			moreButton,
+			moreButtonText,
+			columns,
+			typeScale,
+			imageScale,
+			mobileStack,
+			sectionHeader,
+			showCaption,
+			showCategory,
+			specificMode,
+		} = attributes;
+
+		const classes = classNames( className, {
+			'is-grid': postLayout === 'grid',
+			'show-image': showImage,
+			[ `columns-${ columns }` ]: postLayout === 'grid',
+			[ `ts-${ typeScale }` ]: typeScale !== '5',
+			[ `image-align${ mediaPosition }` ]: showImage,
+			[ `is-${ imageScale }` ]: imageScale !== '1' && showImage,
+			'mobile-stack': mobileStack,
+			[ `image-shape${ imageShape }` ]: imageShape !== 'landscape',
+			'has-text-color': textColor.color !== '',
+			'show-caption': showCaption,
+			'show-category': showCategory,
+			wpnbha: true,
+		} );
+
+		const blockControls = [
+			{
+				icon: 'list-view',
+				title: __( 'List View', 'full-site-editing' ),
+				onClick: () => setAttributes( { postLayout: 'list' } ),
+				isActive: postLayout === 'list',
+			},
+			{
+				icon: 'grid-view',
+				title: __( 'Grid View', 'full-site-editing' ),
+				onClick: () => setAttributes( { postLayout: 'grid' } ),
+				isActive: postLayout === 'grid',
+			},
+		];
+
+		const blockControlsImages = [
+			{
+				icon: 'align-none',
+				title: __( 'Show media on top', 'full-site-editing' ),
+				isActive: mediaPosition === 'top',
+				onClick: () => setAttributes( { mediaPosition: 'top' } ),
+			},
+			{
+				icon: 'align-pull-left',
+				title: __( 'Show media on left', 'full-site-editing' ),
+				isActive: mediaPosition === 'left',
+				onClick: () => setAttributes( { mediaPosition: 'left' } ),
+			},
+			{
+				icon: 'align-pull-right',
+				title: __( 'Show media on right', 'full-site-editing' ),
+				isActive: mediaPosition === 'right',
+				onClick: () => setAttributes( { mediaPosition: 'right' } ),
+			},
+			{
+				icon: coverIcon,
+				title: __( 'Show media behind', 'full-site-editing' ),
+				isActive: mediaPosition === 'behind',
+				onClick: () => setAttributes( { mediaPosition: 'behind' } ),
+			},
+		];
+
+		const blockControlsImageShape = [
+			{
+				icon: landscapeIcon,
+				title: __( 'Landscape Image Shape', 'full-site-editing' ),
+				isActive: imageShape === 'landscape',
+				onClick: () => setAttributes( { imageShape: 'landscape' } ),
+			},
+			{
+				icon: portraitIcon,
+				title: __( 'portrait Image Shape', 'full-site-editing' ),
+				isActive: imageShape === 'portrait',
+				onClick: () => setAttributes( { imageShape: 'portrait' } ),
+			},
+			{
+				icon: squareIcon,
+				title: __( 'Square Image Shape', 'full-site-editing' ),
+				isActive: imageShape === 'square',
+				onClick: () => setAttributes( { imageShape: 'square' } ),
+			},
+			{
+				icon: uncroppedIcon,
+				title: __( 'Uncropped', 'full-site-editing' ),
+				isActive: imageShape === 'uncropped',
+				onClick: () => setAttributes( { imageShape: 'uncropped' } ),
+			},
+		];
+
+		markPostsAsDisplayed( clientId, latestPosts );
+		return (
+			<Fragment>
+				<div
+					className={ classes }
+					style={ {
+						color: textColor.color,
+					} }
+				>
+					<div>
+						{ latestPosts && ( ! RichText.isEmpty( sectionHeader ) || isSelected ) && (
+							<RichText
+								onChange={ ( value ) => setAttributes( { sectionHeader: value } ) }
+								placeholder={ __( 'Write header…', 'full-site-editing' ) }
+								value={ sectionHeader }
+								tagName="h2"
+								className="article-section-title"
+							/>
+						) }
+						{ latestPosts && ! latestPosts.length && (
+							<Placeholder>
+								{ __( 'Sorry, no posts were found.', 'full-site-editing' ) }
+							</Placeholder>
+						) }
+						{ ! latestPosts && (
+							<Placeholder icon={ <Spinner /> } className="component-placeholder__align-center" />
+						) }
+						{ latestPosts && latestPosts.map( ( post ) => this.renderPost( post ) ) }
+					</div>
+				</div>
+
+				{ ! specificMode && latestPosts && moreButton && ! isBlogPrivate() && (
+					/*
+					 * The "More" button option is hidden for private sites, so we should
+					 * also hide the button in case it was previously enabled.
+					 */
+					<div className="editor-styles-wrapper wpnbha__wp-block-button__wrapper">
+						<div className="wp-block-button">
+							<RichText
+								placeholder={ __( 'Load more posts', 'full-site-editing' ) }
+								value={ moreButtonText }
+								onChange={ ( value ) => setAttributes( { moreButtonText: value } ) }
+								className="wp-block-button__link"
+								keepPlaceholderOnFocus
+								allowedFormats={ [] }
+							/>
+						</div>
+					</div>
+				) }
+
+				<BlockControls>
+					<Toolbar controls={ blockControls } />
+					{ showImage && <Toolbar controls={ blockControlsImages } /> }
+					{ showImage && <Toolbar controls={ blockControlsImageShape } /> }
+				</BlockControls>
+				<InspectorControls>{ this.renderInspectorControls() }</InspectorControls>
+			</Fragment>
+		);
+	}
+}
+
+export default compose( [
+	withColors( { textColor: 'color' } ),
+	withSelect( ( select, props ) => {
+		const { attributes, clientId } = props;
+
+		const latestPostsQuery = queryCriteriaFromAttributes( attributes );
+		if ( ! isSpecificPostModeActive( attributes ) ) {
+			const postIdsToExclude = select( STORE_NAMESPACE ).previousPostIds( clientId );
+			latestPostsQuery.exclude = postIdsToExclude.join( ',' );
+		}
+
+		return {
+			latestPosts: select( 'core' ).getEntityRecords( 'postType', 'post', latestPostsQuery ),
+		};
+	} ),
+	withDispatch( ( dispatch, props ) => {
+		const { attributes } = props;
+		const markPostsAsDisplayed = isSpecificPostModeActive( attributes )
+			? dispatch( STORE_NAMESPACE ).markSpecificPostsAsDisplayed
+			: dispatch( STORE_NAMESPACE ).markPostsAsDisplayed;
+
+		return {
+			markPostsAsDisplayed,
+		};
+	} ),
+] )( Edit );

--- a/apps/full-site-editing/full-site-editing-plugin/blog-posts-block/newspack-homepage-articles/blocks/homepage-articles/editor.js
+++ b/apps/full-site-editing/full-site-editing-plugin/blog-posts-block/newspack-homepage-articles/blocks/homepage-articles/editor.js
@@ -1,0 +1,9 @@
+/**
+ * Internal dependencies
+ */
+import { registerBlockType } from '@wordpress/blocks';
+import { name, settings } from '.';
+import { registerQueryStore } from './store';
+
+registerBlockType( `newspack-blocks/${ name }`, settings );
+registerQueryStore( `newspack-blocks/${ name }` );

--- a/apps/full-site-editing/full-site-editing-plugin/blog-posts-block/newspack-homepage-articles/blocks/homepage-articles/editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/blog-posts-block/newspack-homepage-articles/blocks/homepage-articles/editor.scss
@@ -1,0 +1,50 @@
+@import '../../shared/sass/variables';
+@import '../../shared/sass/placeholder';
+
+.type-scale-slider {
+	.dashicon {
+		height: 16px;
+		width: 16px;
+	}
+
+	input + .dashicon {
+		height: 24px;
+		margin-left: 10px;
+		margin-right: 0;
+		width: 24px;
+	}
+}
+
+.wpnbha {
+	article {
+		.entry-title {
+			margin: 0 0 0.25em;
+		}
+	}
+
+	.editor-rich-text {
+		width: 100%;
+	}
+
+	/* Article meta */
+	.cat-links {
+		font-size: $font__size-xs;
+	}
+
+	span.avatar {
+		display: inline-block;
+		margin-right: 0.5em;
+		div {
+			display: inline;
+		}
+	}
+
+	/* Article excerpt */
+	.excerpt-contain p {
+		margin: 0.5em 0;
+	}
+}
+
+.editor-styles-wrapper.wpnbha__wp-block-button__wrapper {
+	background-color: transparent;
+}

--- a/apps/full-site-editing/full-site-editing-plugin/blog-posts-block/newspack-homepage-articles/blocks/homepage-articles/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/blog-posts-block/newspack-homepage-articles/blocks/homepage-articles/index.js
@@ -1,0 +1,110 @@
+/**
+ * External dependencies
+ */
+import { Path, SVG } from '@wordpress/components';
+import { createBlock } from '@wordpress/blocks';
+
+/**
+ * WordPress dependencies
+ */
+import { applyFilters } from '@wordpress/hooks';
+import { __, _x } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import edit from './edit';
+
+/**
+ * Style dependencies - will load in editor
+ */
+import './editor.scss';
+import './view.scss';
+import metadata from './block.json';
+const { name, attributes, category } = metadata;
+
+// Name must be exported separately.
+export { name };
+
+export const title = __( 'Homepage Posts', 'full-site-editing' );
+
+/* From https://material.io/tools/icons */
+export const icon = (
+	<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+		<Path d="M0 0h24v24H0z" fill="none" />
+		<Path d="M4 6H2v14c0 1.1.9 2 2 2h14v-2H4V6zm16-4H8c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm0 14H8V4h12v12zM10 9h8v2h-8zm0 3h4v2h-4zm0-6h8v2h-8z" />
+	</SVG>
+);
+
+export const settings = {
+	title,
+	icon,
+	attributes,
+	category,
+	keywords: [
+		__( 'posts', 'full-site-editing' ),
+		__( 'articles', 'full-site-editing' ),
+		__( 'latest', 'full-site-editing' ),
+	],
+	description: __( 'A block for displaying homepage posts.', 'full-site-editing' ),
+	styles: [
+		{
+			name: 'default',
+			label: _x( 'Default', 'block style', 'full-site-editing' ),
+			isDefault: true,
+		},
+		{ name: 'borders', label: _x( 'Borders', 'block style', 'full-site-editing' ) },
+	],
+	supports: {
+		html: false,
+		align: [ 'wide', 'full' ],
+		default: '',
+	},
+	edit,
+	save: () => null, // to use view.php
+	transforms: {
+		from: [
+			{
+				type: 'block',
+				blocks: [ 'core/latest-posts' ],
+				transform: ( {
+					displayPostContent,
+					displayPostDate,
+					postLayout,
+					columns,
+					postsToShow,
+					categories,
+				} ) => {
+					return createBlock(
+						applyFilters( 'blocks.transforms_from_name', 'newspack-blocks/homepage-articles' ),
+						{
+							showExcerpt: displayPostContent,
+							showDate: displayPostDate,
+							postLayout,
+							columns,
+							postsToShow,
+							showAuthor: false,
+							categories: categories ? [ categories ] : [],
+						}
+					);
+				},
+			},
+		],
+		to: [
+			{
+				type: 'block',
+				blocks: [ 'core/latest-posts' ],
+				transform: ( { showExcerpt, showDate, postLayout, columns, postsToShow, categories } ) => {
+					return createBlock( 'core/latest-posts', {
+						displayPostContent: showExcerpt,
+						displayPostDate: showDate,
+						postLayout,
+						columns,
+						postsToShow,
+						categories: categories[ 0 ] || '',
+					} );
+				},
+			},
+		],
+	},
+};

--- a/apps/full-site-editing/full-site-editing-plugin/blog-posts-block/newspack-homepage-articles/blocks/homepage-articles/store.js
+++ b/apps/full-site-editing/full-site-editing-plugin/blog-posts-block/newspack-homepage-articles/blocks/homepage-articles/store.js
@@ -1,0 +1,152 @@
+/**
+ * External dependencies
+ */
+import { uniq } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { registerStore, select, subscribe, dispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+
+const { name } = metadata;
+export const STORE_NAMESPACE = name;
+
+const initialState = {
+	queryBlocks: [], // list of Query blocks in the order they are on the page
+	postsByBlock: {}, // map of returned posts to block clientId
+	specificPostsByBlock: {}, // posts displayed by specific-mode, which always return in the selector
+};
+
+const UPDATE_BLOCKS = 'UPDATE_BLOCKS';
+const MARK_POSTS_DISPLAYED = 'MARK_POSTS_DISPLAYED';
+const MARK_SPECIFIC_POSTS_DISPLAYED = 'MARK_SPECIFIC_POSTS_DISPLAYED';
+
+const actions = {
+	updateBlocks( blocks ) {
+		return {
+			type: UPDATE_BLOCKS,
+			blocks,
+		};
+	},
+	markPostsAsDisplayed( clientId, posts ) {
+		return {
+			type: MARK_POSTS_DISPLAYED,
+			clientId,
+			posts,
+		};
+	},
+	markSpecificPostsAsDisplayed( clientId, posts ) {
+		return {
+			type: MARK_SPECIFIC_POSTS_DISPLAYED,
+			clientId,
+			posts,
+		};
+	},
+};
+
+/**
+ * @typedef Block A Gutenberg editor block
+ * @type {object}
+ * @typedef uuid Unique id
+ * @type {string}
+ */
+
+/**
+ * Returns the Query blocks that appear before the current one on the page
+ *
+ * @param {Block[]} orderedBlocks Ordered Blocks
+ * @param {uuid} clientId client id
+ * @returns {Block[]} blocks
+ */
+const blocksBefore = ( orderedBlocks, clientId ) => {
+	const ourBlockIdx = orderedBlocks.findIndex( ( b ) => b.clientId === clientId );
+	return orderedBlocks.slice( 0, ourBlockIdx );
+};
+
+const selectors = {
+	previousPostIds( state, _clientId ) {
+		const { queryBlocks, specificPostsByBlock, postsByBlock } = state;
+
+		const postIdsFromSpecificMode = queryBlocks
+			.filter( ( { clientId } ) => specificPostsByBlock[ clientId ] )
+			.flatMap( ( { clientId } ) => specificPostsByBlock[ clientId ].map( ( p ) => p.id ) );
+
+		const previousPostIds = blocksBefore( queryBlocks, _clientId )
+			.filter( ( { clientId } ) => postsByBlock[ clientId ] )
+			.flatMap( ( { clientId } ) => postsByBlock[ clientId ].map( ( p ) => p.id ) );
+
+		return uniq( postIdsFromSpecificMode.concat( previousPostIds ) ).sort();
+	},
+};
+
+export const registerQueryStore = ( blockName ) => {
+	/**
+	 * Returns an array of all newspack-blocks/query blocks in the order they are on
+	 * the page. This is needed to be able to show the editor blocks in the order
+	 * that PHP will render them.
+	 *
+	 * @param {Block[]} blocks any blocks
+	 * @returns {Block[]} ordered newspack-blocks/query blocks
+	 */
+	const getQueryBlocksInOrder = ( blocks ) =>
+		blocks.flatMap( ( block ) => {
+			const queryBlocks = [];
+			if ( block.name === blockName ) {
+				queryBlocks.push( block );
+			}
+			return queryBlocks.concat( getQueryBlocksInOrder( block.innerBlocks ) );
+		} );
+
+	const reducer = ( state = initialState, action ) => {
+		switch ( action.type ) {
+			case UPDATE_BLOCKS:
+				return {
+					...state,
+					queryBlocks: getQueryBlocksInOrder( action.blocks ),
+				};
+			case MARK_POSTS_DISPLAYED:
+				return {
+					...state,
+					postsByBlock: {
+						...state.postsByBlock,
+						[ action.clientId ]: action.posts,
+					},
+				};
+			case MARK_SPECIFIC_POSTS_DISPLAYED:
+				return {
+					...state,
+					specificPostsByBlock: {
+						...state.specificPostsByBlock,
+						[ action.clientId ]: action.posts,
+					},
+				};
+		}
+		return state;
+	};
+	registerStore( STORE_NAMESPACE, {
+		reducer,
+		actions,
+		selectors,
+		initialState,
+	} );
+
+	const { getClientIdsWithDescendants, getBlocks } = select( 'core/block-editor' );
+	const { updateBlocks } = dispatch( STORE_NAMESPACE );
+
+	let currentBlocksIds;
+	subscribe( () => {
+		const newBlocksIds = getClientIdsWithDescendants();
+		// I don't know why != works but it does, I guess getClientIdsWithDescendants is memoized?
+		const blocksChanged = newBlocksIds !== currentBlocksIds;
+		currentBlocksIds = newBlocksIds;
+
+		if ( blocksChanged ) {
+			updateBlocks( getBlocks() );
+		}
+	} );
+};

--- a/apps/full-site-editing/full-site-editing-plugin/blog-posts-block/newspack-homepage-articles/blocks/homepage-articles/templates/article.php
+++ b/apps/full-site-editing/full-site-editing-plugin/blog-posts-block/newspack-homepage-articles/blocks/homepage-articles/templates/article.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * Article template.
+ *
+ * @global array $attributes Block attributes.
+ * @package WordPress
+ */
+
+call_user_func(
+	function( $data ) {
+		$attributes = $data['attributes'];
+
+		$authors = Newspack_Blocks::prepare_authors();
+
+		$styles = '';
+
+		if ( 'behind' === $attributes['mediaPosition'] && $attributes['showImage'] && has_post_thumbnail() ) {
+			$styles = 'min-height: ' . $attributes['minHeight'] . 'vh; padding-top: ' . ( $attributes['minHeight'] / 5 ) . 'vh;';
+		}
+		$image_size = 'newspack-article-block-uncropped';
+		if ( has_post_thumbnail() && 'uncropped' !== $attributes['imageShape'] ) {
+			$image_size = Newspack_Blocks::image_size_for_orientation( $attributes['imageShape'] );
+		}
+		$thumbnail_args = '';
+		// If the image position is behind, pass the object-fit setting to maintain styles with AMP.
+		if ( 'behind' === $attributes['mediaPosition'] ) {
+			$thumbnail_args = array( 'object-fit' => 'cover' );
+		}
+		$category = false;
+		// Use Yoast primary category if set.
+		if ( class_exists( 'WPSEO_Primary_Term' ) ) {
+			$primary_term = new WPSEO_Primary_Term( 'category', get_the_ID() );
+			$category_id  = $primary_term->get_primary_term();
+			if ( $category_id ) {
+				$category = get_term( $category_id );
+			}
+		}
+		if ( ! $category ) {
+			$categories_list = get_the_category();
+			if ( ! empty( $categories_list ) ) {
+				$category = $categories_list[0];
+			}
+		}
+		?>
+	<article data-post-id="<?php the_id(); ?>"
+		<?php if ( has_post_thumbnail() ) : ?>
+		class="post-has-image"
+		<?php endif; ?>
+		<?php if ( $styles ) : ?>
+		style="<?php echo esc_attr( $styles ); ?>"
+		<?php endif; ?>
+		>
+		<?php if ( has_post_thumbnail() && $attributes['showImage'] && $attributes['imageShape'] ) : ?>
+			<figure class="post-thumbnail">
+				<a href="<?php the_permalink(); ?>" rel="bookmark">
+					<?php the_post_thumbnail( $image_size, $thumbnail_args ); ?>
+				</a>
+
+				<?php if ( $attributes['showCaption'] && '' !== get_the_post_thumbnail_caption() ) : ?>
+					<figcaption><?php the_post_thumbnail_caption(); ?></figcaption>
+				<?php endif; ?>
+			</figure><!-- .featured-image -->
+		<?php endif; ?>
+
+		<div class="entry-wrapper">
+			<?php if ( $attributes['showCategory'] && $category ) : ?>
+				<div class="cat-links">
+					<a href="<?php echo esc_url( get_category_link( $category->term_id ) ); ?>">
+						<?php echo esc_html( $category->name ); ?>
+					</a>
+				</div>
+				<?php
+			endif;
+
+			if ( '' === $attributes['sectionHeader'] ) :
+				the_title( '<h2 class="entry-title"><a href="' . esc_url( get_permalink() ) . '" rel="bookmark">', '</a></h2>' );
+			else :
+				the_title( '<h3 class="entry-title"><a href="' . esc_url( get_permalink() ) . '" rel="bookmark">', '</a></h3>' );
+			endif;
+			?>
+			<?php
+			if ( $attributes['showSubtitle'] ) :
+				?>
+				<div class="newspack-post-subtitle newspack-post-subtitle--in-homepage-block">
+					<?php echo esc_html( get_post_meta( get_the_ID(), 'newspack_post_subtitle', true ) ); ?>
+				</div>
+			<?php endif; ?>
+			<?php
+			if ( $attributes['showExcerpt'] ) :
+				the_excerpt();
+			endif;
+			if ( $attributes['showAuthor'] || $attributes['showDate'] ) :
+				?>
+				<div class="entry-meta">
+					<?php
+					if ( $attributes['showAuthor'] ) :
+						if ( $attributes['showAvatar'] ) :
+							echo wp_kses(
+								newspack_blocks_format_avatars( $authors ),
+								array(
+									'img'      => array(
+										'class'  => true,
+										'src'    => true,
+										'alt'    => true,
+										'width'  => true,
+										'height' => true,
+										'data-*' => true,
+										'srcset' => true,
+									),
+									'noscript' => array(),
+									'a'        => array(
+										'href' => true,
+									),
+								)
+							);
+						endif;
+						?>
+						<span class="byline">
+							<?php echo wp_kses_post( newspack_blocks_format_byline( $authors ) ); ?>
+						</span><!-- .author-name -->
+						<?php
+					endif;
+					if ( $attributes['showDate'] ) :
+						$time_string = '<time class="entry-date published updated" datetime="%1$s">%2$s</time>';
+						if ( get_the_time( 'U' ) !== get_the_modified_time( 'U' ) ) :
+							$time_string = '<time class="entry-date published" datetime="%1$s">%2$s</time><time class="updated" datetime="%3$s">%4$s</time>';
+						endif;
+						printf(
+							wp_kses(
+								$time_string,
+								array(
+									'time' => array(
+										'class'    => true,
+										'datetime' => true,
+									),
+								)
+							),
+							esc_attr( get_the_date( DATE_W3C ) ),
+							esc_html( get_the_date() ),
+							esc_attr( get_the_modified_date( DATE_W3C ) ),
+							esc_html( get_the_modified_date() )
+						);
+					endif;
+					?>
+				</div><!-- .entry-meta -->
+			<?php endif; ?>
+		</div><!-- .entry-wrapper -->
+	</article>
+
+		<?php
+	},
+	$data // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+);

--- a/apps/full-site-editing/full-site-editing-plugin/blog-posts-block/newspack-homepage-articles/blocks/homepage-articles/templates/articles-list.php
+++ b/apps/full-site-editing/full-site-editing-plugin/blog-posts-block/newspack-homepage-articles/blocks/homepage-articles/templates/articles-list.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Article list template.
+ *
+ * @global WP_Query $article_query Article query.
+ * @global array    $attributes
+ * @package WordPress
+ */
+
+call_user_func(
+	function( $data ) {
+		echo Newspack_Blocks::template_inc( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			__DIR__ . '/articles-loop.php',
+			array(
+				'attributes'    => $data['attributes'],
+				'article_query' => $data['article_query'],
+			)
+		);
+	},
+	$data // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+);

--- a/apps/full-site-editing/full-site-editing-plugin/blog-posts-block/newspack-homepage-articles/blocks/homepage-articles/templates/articles-loop.php
+++ b/apps/full-site-editing/full-site-editing-plugin/blog-posts-block/newspack-homepage-articles/blocks/homepage-articles/templates/articles-loop.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Articles loop template.
+ *
+ * @package WordPress
+ * @global \WP_Query $article_query Article query.
+ * @global array     $attributes
+ * @global array     $newspack_blocks_post_id
+ */
+
+call_user_func(
+	function( $data ) {
+		$attributes    = $data['attributes'];
+		$article_query = $data['article_query'];
+		global $newspack_blocks_post_id;
+		$post_counter = 0;
+		while ( $article_query->have_posts() ) {
+			$article_query->the_post();
+			if ( ! $attributes['specificMode'] && ( isset( $newspack_blocks_post_id[ get_the_ID() ] ) || $post_counter >= $attributes['postsToShow'] ) ) {
+				continue;
+			}
+			$newspack_blocks_post_id[ get_the_ID() ] = true;
+			$post_counter++;
+			echo Newspack_Blocks::template_inc( __DIR__ . '/article.php', array( 'attributes' => $attributes ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		}
+		wp_reset_postdata();
+	},
+	$data // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+);

--- a/apps/full-site-editing/full-site-editing-plugin/blog-posts-block/newspack-homepage-articles/blocks/homepage-articles/utils.js
+++ b/apps/full-site-editing/full-site-editing-plugin/blog-posts-block/newspack-homepage-articles/blocks/homepage-articles/utils.js
@@ -1,0 +1,51 @@
+/**
+ * External dependencies
+ */
+import { isUndefined, pickBy } from 'lodash';
+
+/**
+ * Based global WP.com blog_public option, checks whether current blog is
+ * private or not.
+ *
+ * @return {boolean} a private WP.com blog flag
+ */
+export const isBlogPrivate = () =>
+	typeof window === 'object' &&
+	window.wpcomGutenberg &&
+	Number( window.wpcomGutenberg.blogPublic ) === -1;
+
+/**
+ * Checks whether the specific post mode is active.
+ *
+ * @param {Object} attributes block attributes
+ * @return {boolean} specific mode active flag
+ */
+export const isSpecificPostModeActive = ( { specificMode, specificPosts } ) =>
+	specificMode && specificPosts && specificPosts.length;
+
+/**
+ * Builds query criteria from given attributes.
+ *
+ * @param {Object} attributes block attributes
+ * @return {Object} criteria
+ */
+export const queryCriteriaFromAttributes = ( attributes ) => {
+	const { postsToShow, authors, categories, tags, specificPosts, tagExclusions } = attributes;
+	const criteria = pickBy(
+		isSpecificPostModeActive( attributes )
+			? {
+					include: specificPosts,
+					orderby: 'include',
+					per_page: specificPosts.length,
+			  }
+			: {
+					per_page: postsToShow,
+					categories,
+					author: authors,
+					tags,
+					tags_exclude: tagExclusions,
+			  },
+		( value ) => ! isUndefined( value )
+	);
+	return criteria;
+};

--- a/apps/full-site-editing/full-site-editing-plugin/blog-posts-block/newspack-homepage-articles/blocks/homepage-articles/view.js
+++ b/apps/full-site-editing/full-site-editing-plugin/blog-posts-block/newspack-homepage-articles/blocks/homepage-articles/view.js
@@ -1,0 +1,208 @@
+/**
+ * VIEW
+ * JavaScript used on front of site.
+ */
+
+/**
+ * Style dependencies
+ */
+import './view.scss';
+
+const fetchRetryCount = 3;
+
+/**
+ * Load More Button Handling
+ *
+ * Calls Array.prototype.forEach for IE11 compatibility.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/NodeList
+ */
+Array.prototype.forEach.call(
+	document.querySelectorAll( '.wp-block-newspack-blocks-homepage-articles.has-more-button' ),
+	buildLoadMoreHandler
+);
+
+/**
+ * Builds a function to handle clicks on the load more button.
+ * Creates internal state via closure to ensure all state is
+ * isolated to a single Block + button instance.
+ *
+ * @param {HTMLElement} blockWrapperEl the button that was clicked
+ */
+function buildLoadMoreHandler( blockWrapperEl ) {
+	const btnEl = blockWrapperEl.querySelector( '[data-next]' );
+	if ( ! btnEl ) {
+		return;
+	}
+	const postsContainerEl = blockWrapperEl.querySelector( '[data-posts]' );
+
+	// Set initial state flags.
+	let isFetching = false;
+	let isEndOfData = false;
+
+	btnEl.addEventListener( 'click', () => {
+		// Early return if still fetching or no more posts to render.
+		if ( isFetching || isEndOfData ) {
+			return false;
+		}
+
+		isFetching = true;
+
+		blockWrapperEl.classList.remove( 'is-error' );
+		blockWrapperEl.classList.add( 'is-loading' );
+
+		// Set currently rendered posts' IDs as a query param (e.g. exclude_ids=1,2,3)
+		const requestURL =
+			btnEl.getAttribute( 'data-next' ) + '&exclude_ids=' + getRenderedPostsIds().join( ',' );
+
+		fetchWithRetry( { url: requestURL, onSuccess, onError }, fetchRetryCount );
+
+		/**
+		 * @param {Object} data Post data
+		 */
+		function onSuccess( data ) {
+			// Validate received data.
+			if ( ! isPostsDataValid( data ) ) {
+				return onError();
+			}
+
+			if ( data.items.length ) {
+				// Render posts' HTML from string.
+				const postsHTML = data.items.map( ( item ) => item.html ).join( '' );
+				postsContainerEl.insertAdjacentHTML( 'beforeend', postsHTML );
+			}
+
+			if ( data.next ) {
+				// Save next URL as button's attribute.
+				btnEl.setAttribute( 'data-next', data.next );
+			}
+
+			if ( ! data.items.length || ! data.next ) {
+				isEndOfData = true;
+				blockWrapperEl.classList.remove( 'has-more-button' );
+			}
+
+			isFetching = false;
+
+			blockWrapperEl.classList.remove( 'is-loading' );
+		}
+
+		/**
+		 * Handle fetching error
+		 */
+		function onError() {
+			isFetching = false;
+
+			blockWrapperEl.classList.remove( 'is-loading' );
+			blockWrapperEl.classList.add( 'is-error' );
+		}
+	} );
+}
+
+/**
+ * Returns unique IDs for posts that are currently in the DOM.
+ */
+function getRenderedPostsIds() {
+	const postEls = document.querySelectorAll(
+		'.wp-block-newspack-blocks-homepage-articles [data-post-id]'
+	);
+	const postIds = Array.from( postEls ).map( ( el ) => el.getAttribute( 'data-post-id' ) );
+
+	return [ ...new Set( postIds ) ]; // Make values unique with Set
+}
+
+/**
+ * Wrapper for XMLHttpRequest that performs given number of retries when error
+ * occurs.
+ *
+ * @param {Object} options XMLHttpRequest options
+ * @param {number} n retry count before throwing
+ */
+function fetchWithRetry( options, n ) {
+	const xhr = new XMLHttpRequest();
+
+	xhr.onreadystatechange = () => {
+		// Return if the request is completed.
+		if ( xhr.readyState !== 4 ) {
+			return;
+		}
+
+		// Call onSuccess with parsed JSON if the request is successful.
+		if ( xhr.status >= 200 && xhr.status < 300 ) {
+			const data = JSON.parse( xhr.responseText );
+
+			return options.onSuccess( data );
+		}
+
+		// Call onError if the request has failed n + 1 times (or if n is undefined).
+		if ( ! n ) {
+			return options.onError();
+		}
+
+		// Retry fetching if request has failed and n > 0.
+		return fetchWithRetry( options, n - 1 );
+	};
+
+	xhr.open( 'GET', options.url );
+	xhr.send();
+}
+
+/**
+ * Validates the "Load more" posts endpoint schema:
+ * {
+ * 	"type": "object",
+ * 	"properties": {
+ * 		"items": {
+ * 			"type": "array",
+ * 			"items": {
+ * 				"type": "object",
+ * 				"properties": {
+ * 					"html": {
+ * 						"type": "string"
+ * 					}
+ * 				},
+ * 				"required": ["html"]
+ * 			},
+ * 			"required": ["items"]
+ * 		},
+ * 		"next": {
+ * 			"type": ["string", "null"]
+ * 		}
+ * 	},
+ * 	"required": ["items", "next"]
+ * }
+ *
+ * @param {Object} data posts endpoint payload
+ */
+function isPostsDataValid( data ) {
+	let isValid = false;
+
+	if (
+		data &&
+		hasOwnProp( data, 'items' ) &&
+		Array.isArray( data.items ) &&
+		hasOwnProp( data, 'next' ) &&
+		typeof data.next === 'string'
+	) {
+		isValid = true;
+
+		if (
+			data.items.length &&
+			! ( hasOwnProp( data.items[ 0 ], 'html' ) && typeof data.items[ 0 ].html === 'string' )
+		) {
+			isValid = false;
+		}
+	}
+
+	return isValid;
+}
+
+/**
+ * Checks if object has own property.
+ *
+ * @param {Object} obj Object
+ * @param {string} prop Property to check
+ */
+function hasOwnProp( obj, prop ) {
+	return Object.prototype.hasOwnProperty.call( obj, prop );
+}

--- a/apps/full-site-editing/full-site-editing-plugin/blog-posts-block/newspack-homepage-articles/blocks/homepage-articles/view.php
+++ b/apps/full-site-editing/full-site-editing-plugin/blog-posts-block/newspack-homepage-articles/blocks/homepage-articles/view.php
@@ -1,0 +1,272 @@
+<?php
+/**
+ * Server-side rendering of the `newspack-blocks/homepage-posts` block.
+ *
+ * @package WordPress
+ */
+
+/**
+ * Renders the `newspack-blocks/homepage-posts` block on server.
+ *
+ * @param array $attributes The block attributes.
+ *
+ * @return string Returns the post content with latest posts added.
+ */
+function newspack_blocks_render_block_homepage_articles( $attributes ) {
+	$article_query = new WP_Query( Newspack_Blocks::build_articles_query( $attributes ) );
+
+	$classes = Newspack_Blocks::block_classes( 'homepage-articles', $attributes, [ 'wpnbha' ] );
+
+	if ( isset( $attributes['postLayout'] ) && 'grid' === $attributes['postLayout'] ) {
+		$classes .= ' is-grid';
+	}
+	if ( isset( $attributes['columns'] ) && 'grid' === $attributes['postLayout'] ) {
+		$classes .= ' columns-' . $attributes['columns'];
+	}
+	if ( $attributes['showImage'] ) {
+		$classes .= ' show-image';
+	}
+	if ( $attributes['showImage'] && isset( $attributes['mediaPosition'] ) ) {
+		$classes .= ' image-align' . $attributes['mediaPosition'];
+	}
+	if ( isset( $attributes['typeScale'] ) ) {
+		$classes .= ' ts-' . $attributes['typeScale'];
+	}
+	if ( $attributes['showImage'] && isset( $attributes['imageScale'] ) ) {
+		$classes .= ' is-' . $attributes['imageScale'];
+	}
+	if ( $attributes['showImage'] && $attributes['mobileStack'] ) {
+		$classes .= ' mobile-stack';
+	}
+	if ( $attributes['showCaption'] ) {
+		$classes .= ' show-caption';
+	}
+	if ( $attributes['showCategory'] ) {
+		$classes .= ' show-category';
+	}
+	if ( isset( $attributes['className'] ) ) {
+		$classes .= ' ' . $attributes['className'];
+	}
+
+	if ( '' !== $attributes['textColor'] || '' !== $attributes['customTextColor'] ) {
+		$classes .= ' has-text-color';
+	}
+	if ( '' !== $attributes['textColor'] ) {
+		$classes .= ' has-' . $attributes['textColor'] . '-color';
+	}
+
+	$styles = '';
+
+	if ( '' !== $attributes['customTextColor'] ) {
+		$styles = 'color: ' . $attributes['customTextColor'] . ';';
+	}
+	$articles_rest_url = add_query_arg(
+		array_merge(
+			array_map(
+				function( $attribute ) {
+					return false === $attribute ? '0' : str_replace( '#', '%23', $attribute );
+				},
+				$attributes
+			),
+			[
+				'page' => 2,
+				'amp'  => Newspack_Blocks::is_amp(),
+			]
+		),
+		rest_url( '/newspack-blocks/v1/articles' )
+	);
+
+	$page = $article_query->paged ?? 1;
+
+	$has_more_pages = ( ++$page ) <= $article_query->max_num_pages;
+
+	/**
+	 * Hide the "More" button on private sites.
+	 *
+	 * Client-side fetching from a private WP.com blog requires authentication,
+	 * which is not provided in the current implementation.
+	 * See https://github.com/Automattic/newspack-blocks/issues/306.
+	 */
+	$is_blog_private = (int) get_option( 'blog_public' ) === -1;
+
+	$has_more_button = ! $is_blog_private && $has_more_pages && (bool) $attributes['moreButton'];
+
+	if ( $has_more_button ) {
+		$classes .= ' has-more-button';
+	}
+
+	ob_start();
+
+	if ( $article_query->have_posts() ) : ?>
+		<?php if ( $has_more_button && Newspack_Blocks::is_amp() ) : ?>
+			<amp-script layout="container" src="<?php echo esc_url( plugins_url( '/newspack-blocks/amp/homepage-articles/view.js' ) ); ?>">
+		<?php endif; ?>
+		<div
+			class="<?php echo esc_attr( $classes ); ?>"
+			style="<?php echo esc_attr( $styles ); ?>"
+			>
+			<div data-posts>
+				<?php if ( '' !== $attributes['sectionHeader'] ) : ?>
+					<h2 class="article-section-title">
+						<span><?php echo wp_kses_post( $attributes['sectionHeader'] ); ?></span>
+					</h2>
+				<?php endif; ?>
+				<?php
+				echo Newspack_Blocks::template_inc(
+					__DIR__ . '/templates/articles-list.php',
+					[
+						'articles_rest_url' => $articles_rest_url,
+						'article_query'     => $article_query,
+						'attributes'        => $attributes,
+					]
+				);
+				?>
+			</div>
+			<?php
+
+			if ( $has_more_button ) :
+				?>
+				<button type="button" data-next="<?php echo esc_url( $articles_rest_url ); ?>">
+				<?php
+				if ( ! empty( $attributes['moreButtonText'] ) ) {
+					echo esc_html( $attributes['moreButtonText'] );
+				} else {
+					esc_html_e( 'Load more posts', 'full-site-editing' );
+				}
+				?>
+				</button>
+				<p class="loading">
+					<?php _e( 'Loading...', 'full-site-editing' ); ?>
+				</p>
+				<p class="error">
+					<?php _e( 'Something went wrong. Please refresh the page and/or try again.', 'full-site-editing' ); ?>
+				</p>
+
+			<?php endif; ?>
+
+		</div>
+		<?php if ( $has_more_button && Newspack_Blocks::is_amp() ) : ?>
+			</amp-script>
+		<?php endif; ?>
+		<?php
+	endif;
+
+	$content = ob_get_clean();
+	Newspack_Blocks::enqueue_view_assets( 'homepage-articles' );
+
+	return $content;
+}
+
+/**
+ * Registers the `newspack-blocks/homepage-articles` block on server.
+ */
+function newspack_blocks_register_homepage_articles() {
+	$block = json_decode(
+		file_get_contents( __DIR__ . '/block.json' ), // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		true
+	);
+	register_block_type(
+		apply_filters( 'newspack_blocks_block_name', 'newspack-blocks/' . $block['name'] ),
+		apply_filters(
+			'newspack_blocks_block_args',
+			array(
+				'attributes'      => $block['attributes'],
+				'render_callback' => 'newspack_blocks_render_block_homepage_articles',
+			),
+			$block['name']
+		)
+	);
+}
+add_action( 'init', 'newspack_blocks_register_homepage_articles' );
+
+
+/**
+ * Renders author avatar markup.
+ *
+ * @param array $author_info Author info array.
+ *
+ * @return string Returns formatted Avatar markup
+ */
+function newspack_blocks_format_avatars( $author_info ) {
+	$elements = array_map(
+		function ( $author ) {
+			return sprintf( '<a href="%s">%s</a>', $author->url, $author->avatar );
+		},
+		$author_info
+	);
+
+	return implode( '', $elements );
+}
+
+/**
+ * Renders byline markup.
+ *
+ * @param array $author_info Author info array.
+ *
+ * @return string Returns byline markup.
+ */
+function newspack_blocks_format_byline( $author_info ) {
+	$index    = -1;
+	$elements = array_merge(
+		[
+			esc_html_x( 'by', 'post author', 'full-site-editing' ) . ' ',
+		],
+		array_reduce(
+			$author_info,
+			function ( $accumulator, $author ) use ( $author_info, &$index ) {
+				$index ++;
+				$penultimate = count( $author_info ) - 2;
+
+				$get_author_posts_url = get_author_posts_url( $author->ID );
+				if ( function_exists( 'coauthors_posts_links' ) ) {
+					$get_author_posts_url = get_author_posts_url( $author->ID, $author->user_nicename );
+				}
+
+				return array_merge(
+					$accumulator,
+					[
+						sprintf(
+							/* translators: 1: author link. 2: author name. 3. variable seperator (comma, 'and', or empty) */
+							'<span class="author vcard"><a class="url fn n" href="%1$s">%2$s</a></span>',
+							esc_url( $get_author_posts_url ),
+							esc_html( $author->display_name )
+						),
+						( $index < $penultimate ) ? ', ' : '',
+						( count( $author_info ) > 1 && $penultimate === $index ) ? esc_html_x( ' and ', 'post author', 'full-site-editing' ) : '',
+					]
+				);
+			},
+			[]
+		)
+	);
+
+	return implode( '', $elements );
+}
+
+
+/**
+ * Inject amp-state containing all post IDs visible on page load.
+ */
+function newspack_blocks_inject_amp_state() {
+	if ( ! Newspack_Blocks::is_amp() ) {
+		return;
+	}
+	global $newspack_blocks_post_id;
+	if ( ! $newspack_blocks_post_id || ! count( $newspack_blocks_post_id ) ) {
+		return;
+	}
+	$post_ids = implode( ', ', array_keys( $newspack_blocks_post_id ) );
+	ob_start();
+	?>
+	<amp-state id='newspackHomepagePosts'>
+		<script type="application/json">
+			{
+				"exclude_ids": [ <?php echo esc_attr( $post_ids ); ?> ]
+			}
+		</script>
+	</amp-state>
+	<?php
+	echo ob_get_clean(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+}
+
+add_action( 'wp_footer', 'newspack_blocks_inject_amp_state' );

--- a/apps/full-site-editing/full-site-editing-plugin/blog-posts-block/newspack-homepage-articles/blocks/homepage-articles/view.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/blog-posts-block/newspack-homepage-articles/blocks/homepage-articles/view.scss
@@ -1,0 +1,698 @@
+@import '../../shared/sass/variables';
+@import '../../shared/sass/mixins';
+
+.wpnbha {
+	margin-bottom: 1em;
+
+	article {
+		margin-bottom: 1.5em;
+		word-break: break-word;
+		overflow-wrap: break-word;
+		position: relative;
+
+		&:last-of-type {
+			margin-bottom: 0;
+		}
+	}
+
+	/* Section header */
+	.article-section-title {
+		font-size: $font__size-sm;
+		margin-bottom: 0.5em;
+		width: 100%; // make sure this isn't caught up in the flex styles.
+	}
+
+	/* Column styles */
+	&.is-grid > div {
+		display: flex;
+		flex-wrap: wrap;
+		justify-content: space-between;
+		padding: 0;
+		list-style: none;
+	}
+
+	&.is-grid {
+		article {
+			flex-basis: 100%;
+
+			@include media( tablet ) {
+				&:last-child,
+				& {
+					margin-bottom: 1em;
+				}
+			}
+		}
+	}
+
+	@include media( mobile ) {
+		&.columns-3 article,
+		&.columns-6 article {
+			flex-basis: calc( 33.333% - 16px );
+		}
+
+		&.columns-2 article,
+		&.columns-4 article,
+		&.columns-5 article {
+			flex-basis: calc( 50% - 16px );
+		}
+
+		&.columns-5 article:last-of-type {
+			flex-basis: 100%;
+		}
+	}
+
+	@include media( tablet ) {
+		@for $i from 2 through 6 {
+			&.columns-#{ $i } article,
+			&.columns-#{ $i } article:last-of-type {
+				flex-basis: calc( ( 100% / #{$i} ) - 16px );
+			}
+		}
+	}
+
+	/* Image styles */
+
+	.post-thumbnail {
+		margin: 0;
+		margin-bottom: 0.25em;
+
+		img {
+			height: auto;
+			width: 100%;
+		}
+
+		figcaption {
+			margin-bottom: 0.5em;
+		}
+	}
+
+	figcaption {
+		font-size: $font__size-xxs;
+	}
+
+	&.image-alignleft,
+	&.image-alignright {
+		.post-has-image {
+			display: flex;
+
+			.post-thumbnail {
+				flex-basis: 33%;
+			}
+			.entry-wrapper {
+				flex-basis: 67%;
+			}
+		}
+
+		&.mobile-stack .post-has-image {
+			display: block;
+		}
+
+		@include media( mobile ) {
+			&.mobile-stack .post-has-image {
+				display: flex;
+			}
+		}
+
+		// Image scale
+		@include media( mobile ) {
+			&.is-4 {
+				.post-thumbnail {
+					flex-basis: 75%;
+				}
+				.entry-wrapper {
+					flex-basis: 25%;
+				}
+			}
+
+			&.is-3 {
+				.post-thumbnail,
+				.entry-wrapper {
+					flex-basis: 50%;
+				}
+			}
+
+			// is-2 matches the mobile default above
+		}
+
+		&.is-1 {
+			.post-thumbnail {
+				flex-basis: 25%;
+			}
+			.entry-wrapper {
+				flex-basis: 75%;
+			}
+		}
+	}
+
+	&.image-alignleft .post-thumbnail {
+		margin-right: 1em;
+	}
+
+	&.image-alignright {
+		.post-thumbnail {
+			margin-left: 1em;
+		}
+
+		.entry-wrapper {
+			order: -1;
+		}
+	}
+
+	&.mobile-stack {
+		&.image-alignleft,
+		&.image-alignright {
+			.post-thumbnail {
+				margin-left: 0;
+				margin-right: 0;
+			}
+		}
+	}
+
+	@include media( mobile ) {
+		&.mobile-stack.image-alignleft .post-thumbnail {
+			margin-right: 1em;
+		}
+
+		&.mobile-stack.image-alignright .post-thumbnail {
+			margin-left: 1em;
+		}
+	}
+
+	/* Headings */
+	.entry-title {
+		margin: 0 0 0.25em;
+		a {
+			color: inherit;
+			text-decoration: none;
+		}
+	}
+
+	/* Article meta */
+	.cat-links {
+		font-size: $font__size-xxs;
+		font-weight: bold;
+		margin: 0 0 0.5em;
+
+		a {
+			text-decoration: none;
+
+			&:hover {
+				text-decoration: underline;
+			}
+		}
+	}
+
+	.entry-meta {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		margin-top: 0.5em;
+
+		.byline:not( :last-child ) {
+			margin-right: 1.5em;
+		}
+
+		.updated {
+			display: none;
+
+			&.published {
+				display: block;
+			}
+		}
+	}
+
+	.avatar {
+		border-radius: 100%;
+		display: block;
+		margin-right: 0.5em;
+	}
+
+	p {
+		margin: 0.5em 0;
+	}
+
+	&.has-text-color {
+		.article-section-title,
+		.entry-title,
+		.entry-title a,
+		.entry-title a:visited,
+		.entry-meta,
+		.entry-meta a,
+		.entry-meta .byline a,
+		.entry-meta .byline a:visited,
+		.cat-links,
+		.cat-links a,
+		.cat-links a:visited,
+		figcaption {
+			color: inherit;
+		}
+		.entry-meta span:not( .avatar ) {
+			opacity: 0.8;
+		}
+	}
+
+	&.image-alignbehind {
+		.post-has-image {
+			display: flex;
+			align-items: flex-end;
+			position: relative;
+
+			.post-thumbnail {
+				bottom: 0;
+				left: 0;
+				margin: 0;
+				overflow: hidden;
+				position: absolute;
+				right: 0;
+				top: 0;
+
+				img {
+					height: 100%;
+					object-fit: cover;
+					max-width: 1000%;
+					width: 100%;
+				}
+
+				figcaption {
+					bottom: 1em;
+					/* autoprefixer: ignore next */
+					-webkit-box-orient: vertical;
+					color: rgba( white, 0.9 );
+					display: -webkit-box;
+					font-style: italic;
+					left: 0;
+					-webkit-line-clamp: 1;
+					margin: 0;
+					max-height: 1.6em;
+					overflow: hidden;
+					padding: 0 1em;
+					position: absolute;
+					right: 0;
+					text-align: right;
+					text-overflow: ellipsis;
+					z-index: 2;
+				}
+
+				&::after {
+					background: rgba( 0, 0, 0, 0.5 );
+					bottom: 0;
+					content: '';
+					left: 0;
+					position: absolute;
+					right: 0;
+					top: 0;
+					z-index: 1;
+				}
+			}
+
+			.entry-wrapper {
+				padding: 2em 1em;
+				position: relative;
+				z-index: 2;
+
+				@include media( desktop ) {
+					padding: 2em 1.5em;
+				}
+			}
+
+			.entry-wrapper,
+			.entry-title a,
+			.entry-meta,
+			.entry-meta .byline a,
+			.cat-links a {
+				color: #fff;
+			}
+		}
+	}
+
+	/* "More" button & related elements styles */
+	button,
+	.loading,
+	.error {
+		display: none;
+	}
+
+	button {
+		margin-top: 1em;
+	}
+
+	&.has-more-button {
+		button {
+			display: block;
+		}
+	}
+
+	&.has-more-button.is-loading {
+		button {
+			display: none;
+		}
+		.loading {
+			display: block;
+		}
+	}
+
+	&.has-more-button.is-error {
+		button,
+		.error {
+			display: block;
+		}
+	}
+}
+
+/*
+	Some really rough font sizing.
+ */
+/* stylelint-disable no-duplicate-selectors  */
+.wpnbha {
+	/* 'Normal' size */
+	article {
+		.entry-title {
+			font-size: 1.2em;
+		}
+		.entry-meta {
+			font-size: 0.8em;
+		}
+
+		.avatar {
+			height: 25px;
+			width: 25px;
+		}
+
+		@include media( tablet ) {
+			.entry-title {
+				font-size: 1.6em;
+			}
+
+			.avatar {
+				height: 40px;
+				width: 40px;
+			}
+		}
+	}
+
+	&.ts-10,
+	&.ts-9,
+	&.ts-8 {
+		.entry-title {
+			line-height: 1.1em;
+		}
+		@include media( tablet ) {
+			article .avatar {
+				height: 2.4em;
+				width: 2.4em;
+			}
+		}
+	}
+
+	&.ts-10,
+	&.ts-9,
+	&.ts-8,
+	&.ts-7 {
+		.newspack-post-subtitle {
+			font-size: 1.4em;
+		}
+	}
+
+	&.ts-10 article {
+		.entry-title {
+			font-size: 2.6em;
+		}
+		@include media( tablet ) {
+			.entry-title {
+				font-size: 3.6em;
+			}
+		}
+		@include media( desktop ) {
+			.entry-title {
+				font-size: 4.8em;
+			}
+		}
+	}
+
+	&.ts-9 article {
+		.entry-title {
+			font-size: 2.4em;
+		}
+		@include media( tablet ) {
+			.entry-title {
+				font-size: 3.4em;
+			}
+		}
+		@include media( desktop ) {
+			.entry-title {
+				font-size: 4.2em;
+			}
+		}
+	}
+
+	&.ts-8 article {
+		.entry-title {
+			font-size: 2.2em;
+		}
+		@include media( tablet ) {
+			.entry-title {
+				font-size: 3em;
+			}
+		}
+		@include media( desktop ) {
+			.entry-title {
+				font-size: 3.6em;
+			}
+		}
+	}
+
+	&.ts-7 article {
+		.entry-title {
+			font-size: 2em;
+		}
+		@include media( tablet ) {
+			.entry-title {
+				font-size: 2.4em;
+			}
+			.avatar {
+				height: 48px;
+				width: 48px;
+			}
+		}
+		@include media( desktop ) {
+			.entry-title {
+				font-size: 3em;
+			}
+		}
+	}
+
+	&.ts-6 article {
+		.entry-title {
+			font-size: 1.7em;
+		}
+		.newspack-post-subtitle {
+			font-size: 1.4em;
+		}
+		@include media( tablet ) {
+			.entry-title {
+				font-size: 2em;
+			}
+			.avatar {
+				height: 44px;
+				width: 44px;
+			}
+		}
+		@include media( desktop ) {
+			.entry-title {
+				font-size: 2.4em;
+			}
+		}
+	}
+
+	&.ts-5 article {
+		.entry-title {
+			font-size: 1.4em;
+		}
+		.newspack-post-subtitle {
+			font-size: 1.2em;
+		}
+		@include media( tablet ) {
+			.entry-title {
+				font-size: 1.8em;
+			}
+			.avatar {
+				height: 40px;
+				width: 40px;
+			}
+		}
+		@include media( desktop ) {
+			.entry-title {
+				font-size: 2em;
+			}
+		}
+	}
+
+	/* Type Scale 4: default */
+
+	&.ts-3 article {
+		.entry-title {
+			font-size: 1em;
+		}
+		.newspack-post-subtitle,
+		.entry-wrapper p {
+			font-size: 0.8em;
+		}
+		.entry-meta {
+			font-size: 0.7em;
+		}
+		@include media( tablet ) {
+			.entry-title {
+				font-size: 1.2em;
+			}
+
+			.avatar {
+				height: 32px;
+				width: 32px;
+			}
+		}
+	}
+
+	&.ts-2 article {
+		.entry-title {
+			font-size: 0.8em;
+		}
+		.newspack-post-subtitle {
+			font-size: 0.7em;
+		}
+		.entry-wrapper p,
+		.entry-meta {
+			font-size: 0.7em;
+		}
+
+		@include media( tablet ) {
+			.entry-title {
+				font-size: 0.9em;
+			}
+
+			.avatar {
+				height: 28px;
+				width: 28px;
+			}
+		}
+	}
+
+	&.ts-1 article {
+		.entry-title,
+		.entry-wrapper p {
+			font-size: 0.7em;
+		}
+		.newspack-post-subtitle {
+			font-size: 0.7em;
+		}
+		.entry-meta {
+			font-size: 0.6em;
+		}
+		@include media( tablet ) {
+			.avatar {
+				height: 24px;
+				width: 24px;
+			}
+		}
+	}
+}
+/* stylelint-enable */
+
+/* Block styles */
+
+.wpnbha.is-style-borders {
+	article {
+		border: solid rgba( 0, 0, 0, 0.2 );
+		border-width: 0 0 1px;
+		margin-bottom: 1em;
+		padding-bottom: 1em;
+
+		&:last-of-type {
+			margin-bottom: 0;
+
+			&:not( :first-of-type ) {
+				border-bottom: 0;
+			}
+		}
+	}
+
+	@include media( mobile ) {
+		@for $i from 2 through 6 {
+			&.columns-#{ $i } article {
+				padding-right: calc( ( 16px * #{$i} ) / ( #{$i} - 1 ) );
+			}
+		}
+
+		&.columns-2,
+		&.columns-4,
+		&.columns-5 {
+			article {
+				border-width: 0;
+				&:nth-of-type( odd ) {
+					border-width: 0 1px 0 0;
+				}
+			}
+		}
+
+		&.columns-3,
+		&.columns-6 {
+			article {
+				border-width: 0;
+
+				&:nth-of-type( 3n + 1 ),
+				&:nth-of-type( 3n + 2 ) {
+					border-width: 0 1px 0 0;
+				}
+			}
+		}
+
+		&.is-grid article:last-of-type {
+			border: 0;
+		}
+	}
+
+	@include media( tablet ) {
+		&.is-grid {
+			article {
+				border-width: 0 1px 0 0;
+			}
+		}
+
+		&.is-grid article:last-of-type,
+		&.columns-1 article,
+		&.columns-2 article:nth-of-type( 2n ),
+		&.columns-3 article:nth-of-type( 3n ),
+		&.columns-4 article:nth-of-type( 4n ),
+		&.columns-5 article:nth-of-type( 5n ),
+		&.columns-6 article:nth-of-type( 6n ) {
+			border: 0;
+		}
+	}
+}
+
+/* Styles for the Subtitle, as part of the the Block */
+.newspack-post-subtitle {
+	&--in-homepage-block {
+		margin-top: 0.3em;
+		margin-bottom: 0;
+		line-height: 1.4em;
+		font-style: italic;
+	}
+}
+
+/* Prevent tree-shaking Loading and Error style rules */
+/* stylelint-disable selector-type-no-unknown  */
+amp-script .wpnbha.has-more-button.is-loading {
+	button {
+		display: none;
+	}
+	.loading {
+		display: block;
+	}
+}
+amp-script .wpnbha.has-more-button.is-error {
+	button,
+	.error {
+		display: block;
+	}
+}
+/* stylelint-enable */

--- a/apps/full-site-editing/full-site-editing-plugin/blog-posts-block/newspack-homepage-articles/class-newspack-blocks-api.php
+++ b/apps/full-site-editing/full-site-editing-plugin/blog-posts-block/newspack-homepage-articles/class-newspack-blocks-api.php
@@ -1,0 +1,250 @@
+<?php
+/**
+ * Register Newspack Blocks rest fields
+ *
+ * @package Newspack_Blocks
+ */
+
+/**
+ * `Newspack_Blocks_API` is a wrapper for `register_rest_fields()`
+ */
+class Newspack_Blocks_API {
+
+	/**
+	 * Register Newspack REST fields.
+	 */
+	public static function register_rest_fields() {
+		register_rest_field(
+			[ 'post', 'page' ],
+			'newspack_featured_image_src',
+			[
+				'get_callback' => [ 'Newspack_Blocks_API', 'newspack_blocks_get_image_src' ],
+				'schema'       => [
+					'context' => [
+						'edit',
+					],
+					'type'    => 'array',
+				],
+			]
+		);
+
+		register_rest_field(
+			[ 'post', 'page' ],
+			'newspack_featured_image_caption',
+			[
+				'get_callback' => [ 'Newspack_Blocks_API', 'newspack_blocks_get_image_caption' ],
+				'schema'       => [
+					'context' => [
+						'edit',
+					],
+					'type'    => 'string',
+				],
+			]
+		);
+
+		/* Add author info source */
+		register_rest_field(
+			'post',
+			'newspack_author_info',
+			[
+				'get_callback' => [ 'Newspack_Blocks_API', 'newspack_blocks_get_author_info' ],
+				'schema'       => [
+					'context' => [
+						'edit',
+					],
+					'type'    => 'array',
+				],
+			]
+		);
+
+		/* Add first category source */
+		register_rest_field(
+			'post',
+			'newspack_category_info',
+			[
+				'get_callback' => [ 'Newspack_Blocks_API', 'newspack_blocks_get_primary_category' ],
+				'schema'       => [
+					'context' => [
+						'edit',
+					],
+					'type'    => 'string',
+				],
+			]
+		);
+	}
+
+	/**
+	 * Get thumbnail featured image source for the rest field.
+	 *
+	 * @param array $object The object info.
+	 * @return array | bool Featured image if available, false if not.
+	 */
+	public static function newspack_blocks_get_image_src( $object ) {
+		$featured_image_set = [];
+
+		if ( 0 === $object['featured_media'] ) {
+			return false;
+		}
+
+		// Landscape image.
+		$landscape_size = Newspack_Blocks::image_size_for_orientation( 'landscape' );
+
+		$feat_img_array_landscape        = wp_get_attachment_image_src(
+			$object['featured_media'],
+			$landscape_size,
+			false
+		);
+		$featured_image_set['landscape'] = $feat_img_array_landscape[0];
+
+		// Portrait image.
+		$portrait_size = Newspack_Blocks::image_size_for_orientation( 'portrait' );
+
+		$feat_img_array_portrait        = wp_get_attachment_image_src(
+			$object['featured_media'],
+			$portrait_size,
+			false
+		);
+		$featured_image_set['portrait'] = $feat_img_array_portrait[0];
+
+		// Square image.
+		$square_size = Newspack_Blocks::image_size_for_orientation( 'square' );
+
+		$feat_img_array_square        = wp_get_attachment_image_src(
+			$object['featured_media'],
+			$square_size,
+			false
+		);
+		$featured_image_set['square'] = $feat_img_array_square[0];
+
+		// Uncropped image.
+		$uncropped_size = 'newspack-article-block-uncropped';
+
+		$feat_img_array_uncropped        = wp_get_attachment_image_src(
+			$object['featured_media'],
+			$uncropped_size,
+			false
+		);
+		$featured_image_set['uncropped'] = $feat_img_array_uncropped[0];
+
+		return $featured_image_set;
+	}
+
+	/**
+	 * Get thumbnail featured image captions for the rest field.
+	 *
+	 * @param array $object The object info.
+	 * @return string|null Image caption on success, null on failure.
+	 */
+	public static function newspack_blocks_get_image_caption( $object ) {
+		return (int) $object['featured_media'] > 0 ? trim( wp_get_attachment_caption( $object['featured_media'] ) ) : null;
+	}
+
+	/**
+	 * Get author info for the rest field.
+	 *
+	 * @param array $object The object info.
+	 * @return array Author data.
+	 */
+	public static function newspack_blocks_get_author_info( $object ) {
+		$author_data = [];
+
+		if ( function_exists( 'coauthors_posts_links' ) ) :
+			$authors = get_coauthors();
+
+			foreach ( $authors as $author ) {
+				// Check if this is a guest author post type.
+				if ( 'guest-author' === get_post_type( $author->ID ) ) {
+					// If yes, make sure the author actually has an avatar set; otherwise, coauthors_get_avatar returns a featured image.
+					if ( get_post_thumbnail_id( $author->ID ) ) {
+						$author_avatar = coauthors_get_avatar( $author, 48 );
+					} else {
+						// If there is no avatar, force it to return the current fallback image.
+						$author_avatar = get_avatar( ' ' );
+					}
+				} else {
+					$author_avatar = coauthors_get_avatar( $author, 48 );
+				}
+				$author_data[] = array(
+					/* Get the author name */
+					'display_name' => esc_html( $author->display_name ),
+					/* Get the author avatar */
+					'avatar'       => wp_kses_post( $author_avatar ),
+					/* Get the author ID */
+					'id'           => $author->ID,
+				);
+			}
+		else :
+			$author_data[] = array(
+				/* Get the author name */
+				'display_name' => get_the_author_meta( 'display_name', $object['author'] ),
+				/* Get the author avatar */
+				'avatar'       => get_avatar( $object['author'], 48 ),
+				/* Get the author ID */
+				'id'           => $object['author'],
+			);
+		endif;
+
+		/* Return the author data */
+		return $author_data;
+	}
+
+	/**
+	 * Get primary category for the rest field.
+	 *
+	 * @param array $object The object info.
+	 * @return string Category name.
+	 */
+	public static function newspack_blocks_get_primary_category( $object ) {
+		$category = false;
+
+		// Use Yoast primary category if set.
+		if ( class_exists( 'WPSEO_Primary_Term' ) ) {
+			$primary_term = new WPSEO_Primary_Term( 'category', $object['id'] );
+			$category_id = $primary_term->get_primary_term();
+			if ( $category_id ) {
+				$category = get_term( $category_id );
+			}
+		}
+
+		if ( ! $category ) {
+			$categories_list = get_the_category( $object['id'] );
+			if ( ! empty( $categories_list ) ) {
+				$category = $categories_list[0];
+			}
+		}
+
+		if ( ! $category ) {
+			return '';
+		}
+
+		return $category->name;
+	}
+
+	/**
+	 * Register the video-playlist endpoint.
+	 */
+	public static function register_video_playlist_endpoint() {
+		register_rest_route(
+			'newspack-blocks/v1',
+			'/video-playlist',
+			[
+				'methods'  => 'GET',
+				'callback' => [ 'Newspack_Blocks_API', 'video_playlist_endpoint' ],
+			]
+		);
+	}
+
+	/**
+	 * Process requests to the video-playlist endpoint.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response.
+	 */
+	public static function video_playlist_endpoint( $request ) {
+		$args = $request->get_params();
+		return new \WP_REST_Response( newspack_blocks_get_video_playlist( $args ), 200 );
+	}
+}
+
+add_action( 'rest_api_init', array( 'Newspack_Blocks_API', 'register_rest_fields' ) );
+add_action( 'rest_api_init', array( 'Newspack_Blocks_API', 'register_video_playlist_endpoint' ) );

--- a/apps/full-site-editing/full-site-editing-plugin/blog-posts-block/newspack-homepage-articles/class-newspack-blocks.php
+++ b/apps/full-site-editing/full-site-editing-plugin/blog-posts-block/newspack-homepage-articles/class-newspack-blocks.php
@@ -1,0 +1,445 @@
+<?php
+/**
+ * Newspack blocks functionality
+ *
+ * @package Newspack_Blocks
+ */
+
+/**
+ * Newspack blocks functionality
+ */
+class Newspack_Blocks {
+
+	/**
+	 * Add hooks and filters.
+	 */
+	public static function init() {
+		add_action( 'after_setup_theme', [ __CLASS__, 'add_image_sizes' ] );
+	}
+
+	/**
+	 * Gather dependencies and paths needed for script enqueuing.
+	 *
+	 * @param string $script_path Path to the script relative to plugin root.
+	 *
+	 * @return array Associative array including dependency array, version, and web path to the script. Returns false if script doesn't exist.
+	 */
+	public static function script_enqueue_helper( $script_path ) {
+		$local_path = NEWSPACK_BLOCKS__PLUGIN_DIR . $script_path;
+		if ( ! file_exists( $local_path ) ) {
+			return false;
+		}
+
+		$path_info   = pathinfo( $local_path );
+		$asset_path  = $path_info['dirname'] . '/' . $path_info['filename'] . '.asset.php';
+		$script_data = file_exists( $asset_path )
+			? require $asset_path
+			: array(
+				'dependencies' => array(),
+				'version'      => filemtime( $local_path ),
+			);
+
+		$script_data['script_path'] = plugins_url( $script_path, __FILE__ );
+		return $script_data;
+	}
+
+	/**
+	 * Enqueue block scripts and styles for editor.
+	 */
+	public static function enqueue_block_editor_assets() {
+		$script_data = static::script_enqueue_helper( NEWSPACK_BLOCKS__BLOCKS_DIRECTORY . 'editor.js' );
+
+		if ( $script_data ) {
+			wp_enqueue_script(
+				'newspack-blocks-editor',
+				$script_data['script_path'],
+				$script_data['dependencies'],
+				$script_data['version'],
+				true
+			);
+			wp_localize_script(
+				'newspack-blocks-editor',
+				'newspack_blocks_data',
+				[
+					'patterns' => self::get_patterns_for_post_type( get_post_type() ),
+				]
+			);
+
+			wp_set_script_translations(
+				'newspack-blocks-editor',
+				'full-site-editing',
+				plugin_dir_path( __FILE__ ) . 'languages'
+			);
+		}
+
+		$editor_style = plugins_url( NEWSPACK_BLOCKS__BLOCKS_DIRECTORY . 'editor.css', __FILE__ );
+
+		wp_enqueue_style(
+			'newspack-blocks-editor',
+			$editor_style,
+			array(),
+			NEWSPACK_BLOCKS__VERSION
+		);
+	}
+
+	/**
+	 * Enqueue block scripts and styles for view.
+	 */
+	public static function manage_view_scripts() {
+		if ( is_admin() ) {
+			// In editor environment, do nothing.
+			return;
+		}
+		$src_directory  = NEWSPACK_BLOCKS__PLUGIN_DIR . 'src/blocks/';
+		$dist_directory = NEWSPACK_BLOCKS__PLUGIN_DIR . 'dist/';
+		$iterator       = new DirectoryIterator( $src_directory );
+		foreach ( $iterator as $block_directory ) {
+			if ( ! $block_directory->isDir() || $block_directory->isDot() ) {
+				continue;
+			}
+			$type = $block_directory->getFilename();
+
+			/* If view.php is found, include it and use for block rendering. */
+			$view_php_path = $src_directory . $type . '/view.php';
+			if ( file_exists( $view_php_path ) ) {
+				include_once $view_php_path;
+				continue;
+			}
+
+			/* If view.php is missing but view Javascript file is found, do generic view asset loading. */
+			$view_js_path = $dist_directory . $type . '/view.js';
+			if ( file_exists( $view_js_path ) ) {
+				register_block_type(
+					"newspack-blocks/{$type}",
+					array(
+						'render_callback' => function( $attributes, $content ) use ( $type ) {
+							Newspack_Blocks::enqueue_view_assets( $type );
+							return $content;
+						},
+					)
+				);
+			}
+		}
+	}
+
+	/**
+	 * Enqueue block styles stylesheet.
+	 */
+	public static function enqueue_block_styles_assets() {
+		$style_path = NEWSPACK_BLOCKS__BLOCKS_DIRECTORY . 'block_styles' . ( is_rtl() ? '.rtl' : '' ) . '.css';
+		if ( file_exists( NEWSPACK_BLOCKS__PLUGIN_DIR . $style_path ) ) {
+			wp_enqueue_style(
+				'newspack-blocks-block-styles-stylesheet',
+				plugins_url( $style_path, __FILE__ ),
+				array(),
+				NEWSPACK_BLOCKS__VERSION
+			);
+		}
+	}
+
+	/**
+	 * Enqueue view scripts and styles for a single block.
+	 *
+	 * @param string $type The block's type.
+	 */
+	public static function enqueue_view_assets( $type ) {
+		$style_path = apply_filters(
+			'newspack_blocks_enqueue_view_assets',
+			NEWSPACK_BLOCKS__BLOCKS_DIRECTORY . $type . '/view' . ( is_rtl() ? '.rtl' : '' ) . '.css',
+			$type,
+			is_rtl()
+		);
+
+		if ( file_exists( NEWSPACK_BLOCKS__PLUGIN_DIR . $style_path ) ) {
+			wp_enqueue_style(
+				"newspack-blocks-{$type}",
+				plugins_url( $style_path, __FILE__ ),
+				array(),
+				NEWSPACK_BLOCKS__VERSION
+			);
+		}
+		if ( static::is_amp() ) {
+			return;
+		}
+		$script_data = static::script_enqueue_helper( NEWSPACK_BLOCKS__BLOCKS_DIRECTORY . $type . '/view.js' );
+		if ( $script_data ) {
+			wp_enqueue_script(
+				"newspack-blocks-{$type}",
+				$script_data['script_path'],
+				$script_data['dependencies'],
+				$script_data['version'],
+				true
+			);
+		}
+	}
+
+	/**
+	 * Utility to assemble the class for a server-side rendered block.
+	 *
+	 * @param string $type The block type.
+	 * @param array  $attributes Block attributes.
+	 * @param array  $extra Additional classes to be added to the class list.
+	 *
+	 * @return string Class list separated by spaces.
+	 */
+	public static function block_classes( $type, $attributes = array(), $extra = array() ) {
+		$classes = [ "wp-block-newspack-blocks-{$type}" ];
+
+		if ( ! empty( $attributes['align'] ) ) {
+			$classes[] = 'align' . $attributes['align'];
+		}
+		if ( isset( $attributes['className'] ) ) {
+			array_push( $classes, $attributes['className'] );
+		}
+		if ( is_array( $extra ) && ! empty( $extra ) ) {
+			$classes = array_merge( $classes, $extra );
+		}
+
+		return implode( $classes, ' ' );
+	}
+
+	/**
+	 * Checks whether the current view is served in AMP context.
+	 *
+	 * @return bool True if AMP, false otherwise.
+	 */
+	public static function is_amp() {
+		return ! is_admin() && function_exists( 'is_amp_endpoint' ) && is_amp_endpoint();
+	}
+
+	/**
+	 * Return the most appropriate thumbnail size to display.
+	 *
+	 * @param string $orientation The block's orientation settings: landscape|portrait|square.
+	 *
+	 * @return string Returns the thumbnail key to use.
+	 */
+	public static function image_size_for_orientation( $orientation = 'landscape' ) {
+		$sizes = array(
+			'landscape' => array(
+				'large'  => array(
+					1200,
+					900,
+				),
+				'medium' => array(
+					800,
+					600,
+				),
+				'small'  => array(
+					400,
+					300,
+				),
+				'tiny'   => array(
+					200,
+					150,
+				),
+			),
+			'portrait'  => array(
+				'large'  => array(
+					900,
+					1200,
+				),
+				'medium' => array(
+					600,
+					800,
+				),
+				'small'  => array(
+					300,
+					400,
+				),
+				'tiny'   => array(
+					150,
+					200,
+				),
+			),
+			'square'    => array(
+				'large'  => array(
+					1200,
+					1200,
+				),
+				'medium' => array(
+					800,
+					800,
+				),
+				'small'  => array(
+					400,
+					400,
+				),
+				'tiny'   => array(
+					200,
+					200,
+				),
+			),
+		);
+
+		foreach ( $sizes[ $orientation ] as $key => $dimensions ) {
+			$attachment = wp_get_attachment_image_src(
+				get_post_thumbnail_id( get_the_ID() ),
+				'newspack-article-block-' . $orientation . '-' . $key
+			);
+			if ( $dimensions[0] === $attachment[1] && $dimensions[1] === $attachment[2] ) {
+				return 'newspack-article-block-' . $orientation . '-' . $key;
+			}
+		}
+
+		return 'large';
+	}
+
+	/**
+	 * Registers image sizes required for Newspack Blocks.
+	 */
+	public static function add_image_sizes() {
+		add_image_size( 'newspack-article-block-landscape-large', 1200, 900, true );
+		add_image_size( 'newspack-article-block-portrait-large', 900, 1200, true );
+		add_image_size( 'newspack-article-block-square-large', 1200, 1200, true );
+
+		add_image_size( 'newspack-article-block-landscape-medium', 800, 600, true );
+		add_image_size( 'newspack-article-block-portrait-medium', 600, 800, true );
+		add_image_size( 'newspack-article-block-square-medium', 800, 800, true );
+
+		add_image_size( 'newspack-article-block-landscape-small', 400, 300, true );
+		add_image_size( 'newspack-article-block-portrait-small', 300, 400, true );
+		add_image_size( 'newspack-article-block-square-small', 400, 400, true );
+
+		add_image_size( 'newspack-article-block-landscape-tiny', 200, 150, true );
+		add_image_size( 'newspack-article-block-portrait-tiny', 150, 200, true );
+		add_image_size( 'newspack-article-block-square-tiny', 200, 200, true );
+
+		add_image_size( 'newspack-article-block-uncropped', 1200, 9999, false );
+	}
+
+	/**
+	 * Builds and returns query args based on block attributes.
+	 *
+	 * @param array $attributes An array of block attributes.
+	 *
+	 * @return array
+	 */
+	public static function build_articles_query( $attributes ) {
+		global $newspack_blocks_post_id;
+		if ( ! $newspack_blocks_post_id ) {
+			$newspack_blocks_post_id = array();
+		}
+		$authors        = isset( $attributes['authors'] ) ? $attributes['authors'] : array();
+		$categories     = isset( $attributes['categories'] ) ? $attributes['categories'] : array();
+		$tags           = isset( $attributes['tags'] ) ? $attributes['tags'] : array();
+		$tag_exclusions = isset( $attributes['tagExclusions'] ) ? $attributes['tagExclusions'] : array();
+		$specific_posts = isset( $attributes['specificPosts'] ) ? $attributes['specificPosts'] : array();
+		$posts_to_show  = intval( $attributes['postsToShow'] );
+		$specific_mode  = intval( $attributes['specificMode'] );
+		$args           = array(
+			'post_status'         => 'publish',
+			'suppress_filters'    => false,
+			'ignore_sticky_posts' => true,
+		);
+		if ( $specific_mode && $specific_posts ) {
+			$args['post__in'] = $specific_posts;
+			$args['orderby']  = 'post__in';
+		} else {
+			$args['posts_per_page'] = $posts_to_show + count( $newspack_blocks_post_id );
+			if ( $authors && count( $authors ) ) {
+				$args['author__in'] = $authors;
+			}
+			if ( $categories && count( $categories ) ) {
+				$args['category__in'] = $categories;
+			}
+			if ( $tags && count( $tags ) ) {
+				$args['tag__in'] = $tags;
+			}
+			if ( $tag_exclusions && count( $tag_exclusions ) ) {
+				$args['tag__not_in'] = $tag_exclusions;
+			}
+		}
+		return $args;
+	}
+
+	/**
+	 * Loads a template with given data in scope.
+	 *
+	 * @param string $template full Path to the template to be included.
+	 * @param array  $data          Data to be passed into the template to be included.
+	 * @return string
+	 */
+	public static function template_inc( $template, $data = array() ) {
+		if ( ! strpos( $template, '.php' ) ) {
+			$template = $template . '.php';
+		}
+		if ( ! is_file( $template ) ) {
+			return '';
+		}
+		ob_start();
+		include $template;
+		$contents = ob_get_contents();
+		ob_end_clean();
+		return $contents;
+	}
+
+	/**
+	 * Prepare an array of authors, taking presence of CoAuthors Plus into account.
+	 *
+	 * @return array Array of WP_User objects.
+	 */
+	public static function prepare_authors() {
+		if ( function_exists( 'coauthors_posts_links' ) ) {
+			$authors = get_coauthors();
+			foreach ( $authors as $author ) {
+				// Check if this is a guest author post type.
+				if ( 'guest-author' === get_post_type( $author->ID ) ) {
+					// If yes, make sure the author actually has an avatar set; otherwise, coauthors_get_avatar returns a featured image.
+					if ( get_post_thumbnail_id( $author->ID ) ) {
+						$author->avatar = coauthors_get_avatar( $author, 48 );
+					} else {
+						// If there is no avatar, force it to return the current fallback image.
+						$author->avatar = get_avatar( ' ' );
+					}
+				} else {
+					$author->avatar = coauthors_get_avatar( $author, 48 );
+				}
+				$author->url = get_author_posts_url( $author->ID, $author->user_nicename );
+			}
+			return $authors;
+		}
+		$id = get_the_author_meta( 'ID' );
+		return array(
+			(object) array(
+				'ID'            => $id,
+				'avatar'        => get_avatar( $id, 48 ),
+				'url'           => get_author_posts_url( $id ),
+				'user_nicename' => get_the_author(),
+				'display_name'  => get_the_author_meta( 'display_name' ),
+			),
+		);
+	}
+
+	/**
+	 * Get patterns for post type.
+	 *
+	 * @param string $post_type Post type.
+	 * @return array Array of patterns.
+	 */
+	public static function get_patterns_for_post_type( $post_type = null ) {
+		$patterns    = apply_filters( 'newspack_blocks_patterns', [], $post_type );
+		$categorized = [];
+		$clean       = [];
+		foreach ( $patterns as $pattern ) {
+			if ( ! isset( $pattern['image'] ) || ! $pattern['image'] ) {
+				continue;
+			}
+			$category = isset( $pattern['category'] ) ? $pattern['category'] : __( 'Common', 'newspack-blocks' );
+			if ( ! isset( $categorized[ $category ] ) ) {
+				$categorized[ $category ] = [];
+			}
+			$categorized[ $category ][] = $pattern;
+		}
+		$categories = array_keys( $categorized );
+		sort( $categories );
+		foreach ( $categories as $category ) {
+			$clean[] = [
+				'title' => $category,
+				'items' => $categorized[ $category ],
+			];
+		}
+		return $clean;
+	}
+}
+Newspack_Blocks::init();

--- a/apps/full-site-editing/full-site-editing-plugin/blog-posts-block/newspack-homepage-articles/components/autocomplete-tokenfield.js
+++ b/apps/full-site-editing/full-site-editing-plugin/blog-posts-block/newspack-homepage-articles/components/autocomplete-tokenfield.js
@@ -1,0 +1,183 @@
+/**
+ * External dependencies
+ */
+import { debounce } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+import { FormTokenField, Spinner } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import './autocomplete-tokenfield.scss';
+
+/**
+ * An multi-selecting, api-driven autocomplete input suitable for use in block attributes.
+ */
+class AutocompleteTokenField extends Component {
+	constructor( props ) {
+		super( props );
+		this.state = {
+			suggestions: [],
+			validValues: {},
+			loading: this.isFetchingInfoOnLoad(),
+		};
+
+		this.debouncedUpdateSuggestions = debounce( this.updateSuggestions, 500 );
+	}
+
+	/**
+	 * If the component has tokens passed in props, it should fetch info after it mounts.
+	 */
+	isFetchingInfoOnLoad = () => {
+		const { tokens, fetchSavedInfo } = this.props;
+		return Boolean( tokens.length && fetchSavedInfo );
+	};
+
+	/**
+	 * When the component loads, fetch information about the tokens so we can populate
+	 * the tokens with the correct labels.
+	 */
+	componentDidMount() {
+		if ( this.isFetchingInfoOnLoad() ) {
+			const { tokens, fetchSavedInfo } = this.props;
+
+			fetchSavedInfo( tokens ).then( ( results ) => {
+				const { validValues } = this.state;
+
+				results.forEach( ( suggestion ) => {
+					validValues[ suggestion.value ] = suggestion.label;
+				} );
+
+				this.setState( { validValues, loading: false } );
+			} );
+		}
+	}
+
+	/**
+	 * Clean up any unfinished autocomplete api call requests.
+	 */
+	componentWillUnmount() {
+		delete this.suggestionsRequest;
+		this.debouncedUpdateSuggestions.cancel();
+	}
+
+	/**
+	 * Get a list of labels for input values.
+	 *
+	 * @param {Array} values Array of values (ids, etc.).
+	 * @return {Array} array of valid labels corresponding to the values.
+	 */
+	getLabelsForValues( values ) {
+		const { validValues } = this.state;
+		return values.reduce(
+			( accumulator, value ) =>
+				validValues[ value ] ? [ ...accumulator, validValues[ value ] ] : accumulator,
+			[]
+		);
+	}
+
+	/**
+	 * Get a list of values for input labels.
+	 *
+	 * @param {Array} labels Array of labels from the tokens.
+	 * @return {Array} Array of valid values corresponding to the labels.
+	 */
+	getValuesForLabels( labels ) {
+		const { validValues } = this.state;
+		return labels.map( ( label ) =>
+			Object.keys( validValues ).find( ( key ) => validValues[ key ] === label )
+		);
+	}
+
+	/**
+	 * Refresh the autocomplete dropdown.
+	 *
+	 * @param {string} input Input to fetch suggestions for
+	 */
+	updateSuggestions( input ) {
+		const { fetchSuggestions } = this.props;
+		if ( ! fetchSuggestions ) {
+			return;
+		}
+
+		this.setState( { loading: true }, () => {
+			const request = fetchSuggestions( input );
+			request
+				.then( ( suggestions ) => {
+					// A fetch Promise doesn't have an abort option. It's mimicked by
+					// comparing the request reference in on the instance, which is
+					// reset or deleted on subsequent requests or unmounting.
+					if ( this.suggestionsRequest !== request ) {
+						return;
+					}
+
+					const { validValues } = this.state;
+					const currentSuggestions = [];
+
+					suggestions.forEach( ( suggestion ) => {
+						currentSuggestions.push( suggestion.label );
+						validValues[ suggestion.value ] = suggestion.label;
+					} );
+
+					this.setState( { suggestions: currentSuggestions, validValues, loading: false } );
+				} )
+				.catch( () => {
+					if ( this.suggestionsRequest === request ) {
+						this.setState( {
+							loading: false,
+						} );
+					}
+				} );
+
+			this.suggestionsRequest = request;
+		} );
+	}
+
+	/**
+	 * When a token is selected, we need to convert the string label into a recognized value suitable for saving as an attribute.
+	 *
+	 * @param {Array} tokenStrings An array of token label strings.
+	 */
+	handleOnChange( tokenStrings ) {
+		const { onChange } = this.props;
+		onChange( this.getValuesForLabels( tokenStrings ) );
+	}
+
+	/**
+	 * To populate the tokens, we need to convert the values into a human-readable label.
+	 *
+	 * @return {Array} An array of token label strings.
+	 */
+	getTokens() {
+		const { tokens } = this.props;
+		return this.getLabelsForValues( tokens );
+	}
+
+	/**
+	 * Render.
+	 */
+	render() {
+		const { help, label = '' } = this.props;
+		const { suggestions, loading } = this.state;
+
+		return (
+			<div className="autocomplete-tokenfield">
+				<FormTokenField
+					value={ this.getTokens() }
+					suggestions={ suggestions }
+					onChange={ ( tokens ) => this.handleOnChange( tokens ) }
+					onInputChange={ ( input ) => this.debouncedUpdateSuggestions( input ) }
+					label={ label }
+				/>
+				{ loading && <Spinner /> }
+				{ help && <p className="autocomplete-tokenfield__help">{ help }</p> }
+			</div>
+		);
+	}
+}
+
+export default AutocompleteTokenField;

--- a/apps/full-site-editing/full-site-editing-plugin/blog-posts-block/newspack-homepage-articles/components/autocomplete-tokenfield.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/blog-posts-block/newspack-homepage-articles/components/autocomplete-tokenfield.scss
@@ -1,0 +1,18 @@
+.autocomplete-tokenfield {
+	position: relative;
+
+	.components-spinner {
+		position: absolute;
+		top: 2em;
+		right: 0;
+	}
+
+	/* Workaround for hard-coded help text in FormTokenField. */
+	.components-form-token-field > .components-form-token-field__help {
+		display: none;
+	}
+
+	.autocomplete-tokenfield__help {
+		font-style: italic;
+	}
+}

--- a/apps/full-site-editing/full-site-editing-plugin/blog-posts-block/newspack-homepage-articles/components/query-controls.js
+++ b/apps/full-site-editing/full-site-editing-plugin/blog-posts-block/newspack-homepage-articles/components/query-controls.js
@@ -1,0 +1,254 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
+import { Button, QueryControls as BaseControl, ToggleControl } from '@wordpress/components';
+import apiFetch from '@wordpress/api-fetch';
+import { addQueryArgs } from '@wordpress/url';
+import { decodeEntities } from '@wordpress/html-entities';
+
+/**
+ * External dependencies.
+ */
+
+/**
+ * Internal dependencies.
+ */
+import AutocompleteTokenField from './autocomplete-tokenfield';
+
+class QueryControls extends Component {
+	state = {
+		showAdvancedFilters: false,
+	};
+
+	fetchPostSuggestions = ( search ) => {
+		return apiFetch( {
+			path: addQueryArgs( '/wp/v2/search', {
+				search,
+				per_page: 20,
+				_fields: 'id,title',
+				type: 'post',
+			} ),
+		} ).then( function ( posts ) {
+			const result = posts.map( ( post ) => ( {
+				value: post.id,
+				label: decodeEntities( post.title ) || __( '(no title)', 'newspack-blocks' ),
+			} ) );
+			return result;
+		} );
+	};
+	fetchSavedPosts = ( postIDs ) => {
+		return apiFetch( {
+			path: addQueryArgs( '/wp/v2/posts', {
+				per_page: 100,
+				include: postIDs.join( ',' ),
+				_fields: 'id,title',
+			} ),
+		} ).then( function ( posts ) {
+			return posts.map( ( post ) => ( {
+				value: post.id,
+				label: decodeEntities( post.title.rendered ) || __( '(no title)', 'newspack-blocks' ),
+			} ) );
+		} );
+	};
+
+	fetchAuthorSuggestions = ( search ) => {
+		return apiFetch( {
+			path: addQueryArgs( '/wp/v2/users', {
+				search,
+				per_page: 20,
+				_fields: 'id,name',
+			} ),
+		} ).then( function ( users ) {
+			return users.map( ( user ) => ( {
+				value: user.id,
+				label: decodeEntities( user.name ) || __( '(no name)', 'newspack-blocks' ),
+			} ) );
+		} );
+	};
+	fetchSavedAuthors = ( userIDs ) => {
+		return apiFetch( {
+			path: addQueryArgs( '/wp/v2/users', {
+				per_page: 100,
+				include: userIDs.join( ',' ),
+				_fields: 'id,name',
+			} ),
+		} ).then( function ( users ) {
+			return users.map( ( user ) => ( {
+				value: user.id,
+				label: decodeEntities( user.name ) || __( '(no name)', 'newspack-blocks' ),
+			} ) );
+		} );
+	};
+
+	fetchCategorySuggestions = ( search ) => {
+		return apiFetch( {
+			path: addQueryArgs( '/wp/v2/categories', {
+				search,
+				per_page: 20,
+				_fields: 'id,name',
+				orderby: 'count',
+				order: 'desc',
+			} ),
+		} ).then( function ( categories ) {
+			return categories.map( ( category ) => ( {
+				value: category.id,
+				label: decodeEntities( category.name ) || __( '(no title)', 'newspack-blocks' ),
+			} ) );
+		} );
+	};
+	fetchSavedCategories = ( categoryIDs ) => {
+		return apiFetch( {
+			path: addQueryArgs( '/wp/v2/categories', {
+				per_page: 100,
+				_fields: 'id,name',
+				include: categoryIDs.join( ',' ),
+			} ),
+		} ).then( function ( categories ) {
+			return categories.map( ( category ) => ( {
+				value: category.id,
+				label: decodeEntities( category.name ) || __( '(no title)', 'newspack-blocks' ),
+			} ) );
+		} );
+	};
+
+	fetchTagSuggestions = ( search ) => {
+		return apiFetch( {
+			path: addQueryArgs( '/wp/v2/tags', {
+				search,
+				per_page: 20,
+				_fields: 'id,name',
+				orderby: 'count',
+				order: 'desc',
+			} ),
+		} ).then( function ( tags ) {
+			return tags.map( ( tag ) => ( {
+				value: tag.id,
+				label: decodeEntities( tag.name ) || __( '(no title)', 'newspack-blocks' ),
+			} ) );
+		} );
+	};
+	fetchSavedTags = ( tagIDs ) => {
+		return apiFetch( {
+			path: addQueryArgs( '/wp/v2/tags', {
+				per_page: 100,
+				_fields: 'id,name',
+				include: tagIDs.join( ',' ),
+			} ),
+		} ).then( function ( tags ) {
+			return tags.map( ( tag ) => ( {
+				value: tag.id,
+				label: decodeEntities( tag.name ) || __( '(no title)', 'newspack-blocks' ),
+			} ) );
+		} );
+	};
+
+	render = () => {
+		const {
+			specificMode,
+			onSpecificModeChange,
+			specificPosts,
+			onSpecificPostsChange,
+			authors,
+			onAuthorsChange,
+			categories,
+			onCategoriesChange,
+			tags,
+			onTagsChange,
+			tagExclusions,
+			onTagExclusionsChange,
+			enableSpecific,
+		} = this.props;
+		const { showAdvancedFilters } = this.state;
+
+		return [
+			enableSpecific && (
+				<ToggleControl
+					key="specificMode"
+					checked={ specificMode }
+					onChange={ onSpecificModeChange }
+					label={ __( 'Choose Specific Posts', 'newspack-blocks' ) }
+				/>
+			),
+			specificMode && (
+				<AutocompleteTokenField
+					key="posts"
+					tokens={ specificPosts || [] }
+					onChange={ onSpecificPostsChange }
+					fetchSuggestions={ this.fetchPostSuggestions }
+					fetchSavedInfo={ this.fetchSavedPosts }
+					label={ __( 'Posts', 'newspack-blocks' ) }
+					help={ __(
+						'Begin typing post title, click autocomplete result to select.',
+						'newspack-blocks'
+					) }
+				/>
+			),
+			! specificMode && <BaseControl key="queryControls" { ...this.props } />,
+			! specificMode && onAuthorsChange && (
+				<AutocompleteTokenField
+					key="authors"
+					tokens={ authors || [] }
+					onChange={ onAuthorsChange }
+					fetchSuggestions={ this.fetchAuthorSuggestions }
+					fetchSavedInfo={ this.fetchSavedAuthors }
+					label={ __( 'Authors', 'newspack-blocks' ) }
+				/>
+			),
+			! specificMode && onCategoriesChange && (
+				<AutocompleteTokenField
+					key="categories"
+					tokens={ categories || [] }
+					onChange={ onCategoriesChange }
+					fetchSuggestions={ this.fetchCategorySuggestions }
+					fetchSavedInfo={ this.fetchSavedCategories }
+					label={ __( 'Categories', 'newspack-blocks' ) }
+				/>
+			),
+			! specificMode && onTagsChange && (
+				<AutocompleteTokenField
+					key="tags"
+					tokens={ tags || [] }
+					onChange={ onTagsChange }
+					fetchSuggestions={ this.fetchTagSuggestions }
+					fetchSavedInfo={ this.fetchSavedTags }
+					label={ __( 'Tags', 'newspack-blocks' ) }
+				/>
+			),
+			! specificMode && onTagExclusionsChange && (
+				<p key="toggle-advanced-filters">
+					<Button
+						isLink
+						onClick={ () => this.setState( { showAdvancedFilters: ! showAdvancedFilters } ) }
+					>
+						{ showAdvancedFilters
+							? __( 'Hide Advanced Filters', 'newspack-blocks' )
+							: __( 'Show Advanced Filters', 'newspack-blocks' ) }
+					</Button>
+				</p>
+			),
+			! specificMode && onTagExclusionsChange && showAdvancedFilters && (
+				<AutocompleteTokenField
+					key="tag-exclusion"
+					tokens={ tagExclusions || [] }
+					onChange={ onTagExclusionsChange }
+					fetchSuggestions={ this.fetchTagSuggestions }
+					fetchSavedInfo={ this.fetchSavedTags }
+					label={ __( 'Excluded Tags', 'newspack-blocks' ) }
+				/>
+			),
+		];
+	};
+}
+
+QueryControls.defaultProps = {
+	enableSpecific: true,
+	specificPosts: [],
+	authors: [],
+	categories: [],
+	tags: [],
+	tagExclusions: [],
+};
+
+export default QueryControls;

--- a/apps/full-site-editing/full-site-editing-plugin/blog-posts-block/newspack-homepage-articles/shared/js/newspack-icon.js
+++ b/apps/full-site-editing/full-site-editing-plugin/blog-posts-block/newspack-homepage-articles/shared/js/newspack-icon.js
@@ -1,0 +1,29 @@
+/**
+ * WordPress dependencies.
+ */
+import { Path, SVG } from '@wordpress/components';
+
+/**
+ * External dependencies.
+ */
+import classnames from 'classnames';
+
+export default ( { size = 24, className } ) => (
+	<SVG
+		className={ classnames( 'newspack-icon', className ) }
+		width={ size }
+		height={ size }
+		viewBox="0 0 24 24"
+	>
+		<Path
+			className="newspack-icon__circle"
+			fill="#36f"
+			d="M12 24c6.627 0 12-5.373 12-12S18.627 0 12 0 0 5.373 0 12s5.372 12 12 12z"
+		/>
+		<Path
+			className="newspack-icon__n"
+			fill="#fff"
+			d="M17.241 12.467h-1.29l-.827-.843h2.117v.843zm0-2.483h-3.727l-.826-.843h4.553v.843zm0-2.483h-6.163l-.827-.843h6.99v.843zm0 9.841L6.76 6.658v10.684h2.588v-4.484l4.4 4.484h3.494z"
+		/>
+	</SVG>
+);

--- a/apps/full-site-editing/full-site-editing-plugin/blog-posts-block/newspack-homepage-articles/shared/sass/_colors.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/blog-posts-block/newspack-homepage-articles/shared/sass/_colors.scss
@@ -1,0 +1,9 @@
+$color__primary: #36f;
+$color__secondary: #555;
+$color__background-body: #fff;
+$color__background-input: #fff;
+$color__background-screen: #f1f1f1;
+$color__text-main: #111;
+$color__text-light: #767676;
+$color__text-input-focus: #111;
+$color__border: #ccc;

--- a/apps/full-site-editing/full-site-editing-plugin/blog-posts-block/newspack-homepage-articles/shared/sass/_mixins.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/blog-posts-block/newspack-homepage-articles/shared/sass/_mixins.scss
@@ -1,0 +1,25 @@
+@mixin media( $res ) {
+	@if mobile == $res {
+		@media only screen and ( min-width: $mobile_width ) {
+			@content;
+		}
+	}
+
+	@if tablet == $res {
+		@media only screen and ( min-width: $tablet_width ) {
+			@content;
+		}
+	}
+
+	@if desktop == $res {
+		@media only screen and ( min-width: $desktop_width ) {
+			@content;
+		}
+	}
+
+	@if wide == $res {
+		@media only screen and ( min-width: $wide_width ) {
+			@content;
+		}
+	}
+}

--- a/apps/full-site-editing/full-site-editing-plugin/blog-posts-block/newspack-homepage-articles/shared/sass/_placeholder.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/blog-posts-block/newspack-homepage-articles/shared/sass/_placeholder.scss
@@ -1,0 +1,5 @@
+.wp-block[data-type^='newspack-blocks/'] {
+	.component-placeholder__align-center {
+		align-items: center;
+	}
+}

--- a/apps/full-site-editing/full-site-editing-plugin/blog-posts-block/newspack-homepage-articles/shared/sass/_variables.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/blog-posts-block/newspack-homepage-articles/shared/sass/_variables.scss
@@ -1,0 +1,26 @@
+$mobile_width: 600px;
+$tablet_width: 782px;
+$desktop_width: 1168px;
+$wide_width: 1379px;
+
+$font__size_base: 20px;
+$font__size-ratio: 1.125;
+
+$font__size-xxxs: 1em * 0.5; // 10px
+$font__size-xxs: 1em * 0.6; // 12px
+$font__size-xs: 1em * 0.7; // 14px
+$font__size-sm: 1em * 0.8; // 16px
+// $font__size_base: 1em * 1; // 20px
+$font__size-md: 1em * 1.2; // 24px
+$font__size-lg: 1em * 1.4; // 28px
+$font__size-xl: 1em * 1.8; // 36px
+$font__size-xxl: 1em * 2.2; // 44px
+$font__size-xxxl: 1em * 2.8; // 56px
+$font__size-xxxxl: 1em * 3.2; // 64px
+
+$font__line-height-body: 1.6;
+$font__line-height-pre: 1.6;
+$font__line-height-heading: 1.2;
+$font__line-height-double: 2 * $font__line-height-heading;
+
+$color__border: #ccc;

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/button/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/button/edit.js
@@ -1,0 +1,244 @@
+import { __ } from '@wordpress/i18n';
+import { useEffect } from '@wordpress/element';
+import { compose } from '@wordpress/compose';
+import { Button, ButtonGroup, PanelBody, withFallbackStyles } from '@wordpress/components';
+import {
+	BlockAlignmentToolbar,
+	BlockControls,
+	ContrastChecker,
+	InspectorControls,
+	PanelColorSettings,
+	RichText,
+	withColors,
+} from '@wordpress/block-editor';
+import { get } from 'lodash';
+import classnames from 'classnames';
+
+const { getComputedStyle } = window;
+
+const applyFallbackStyles = withFallbackStyles( ( node, ownProps ) => {
+	const { textButtonColor, backgroundButtonColor } = ownProps;
+	const backgroundColorValue = backgroundButtonColor && backgroundButtonColor.color;
+	const textColorValue = textButtonColor && textButtonColor.color;
+	//avoid the use of querySelector if textColor color is known and verify if node is available.
+
+	let textNode;
+	let button;
+
+	if ( ! textColorValue && node ) {
+		textNode = node.querySelector( '[contenteditable="true"]' );
+	}
+
+	if ( node.querySelector( '.wp-block-button__link' ) ) {
+		button = node.querySelector( '.wp-block-button__link' );
+	} else {
+		button = node;
+	}
+
+	let fallbackBackgroundColor;
+	let fallbackTextColor;
+
+	if ( node && button ) {
+		fallbackBackgroundColor = getComputedStyle( button ).backgroundColor;
+	}
+
+	if ( textNode ) {
+		fallbackTextColor = getComputedStyle( textNode ).color;
+	}
+
+	return {
+		fallbackBackgroundColor: backgroundColorValue || fallbackBackgroundColor,
+		fallbackTextColor: textColorValue || fallbackTextColor,
+	};
+} );
+
+const blockControls = ( props ) => {
+	return (
+		<BlockControls>
+			<BlockAlignmentToolbar
+				value={ props.attributes.align }
+				onChange={ ( newAlignment ) => props.setAttributes( { align: newAlignment } ) }
+				controls={ [ 'left', 'center', 'right' ] }
+			/>
+		</BlockControls>
+	);
+};
+
+const inspectorControls = ( props ) => {
+	const BUTTON_TYPES = {
+		login: {
+			label: __( 'Login', 'premium-content' ),
+			defaultButtonText: __( 'Log In', 'premium-content' ),
+		},
+		subscribe: {
+			label: __( 'Subscribe', 'premium-content' ),
+			defaultButtonText: __( 'Subscribe', 'premium-content' ),
+		},
+	};
+
+	const {
+		attributes,
+		setAttributes,
+		backgroundButtonColor,
+		textButtonColor,
+		setBackgroundButtonColor,
+		setTextButtonColor,
+		fallbackBackgroundColor,
+		fallbackTextColor,
+	} = props;
+
+	const backgroundColor = backgroundButtonColor.color || fallbackBackgroundColor;
+	const color = textButtonColor.color || fallbackTextColor;
+
+	function setButtonType( props, type, text ) {
+		props.setAttributes( {
+			buttonType: type,
+			buttonText: text,
+		} );
+	}
+
+	return (
+		<InspectorControls>
+			<PanelBody title={ __( 'Button Type', 'premium-content' ) }>
+				<div className="premium-content-button-group">
+					<ButtonGroup aria-label={ __( 'Button Type', 'premium-content' ) }>
+						{ Object.keys( BUTTON_TYPES ).map( ( t ) => (
+							<Button
+								isLarge
+								isPrimary={ attributes.buttonType === t }
+								aria-pressed={ attributes.buttonType === t }
+								onClick={ () => setButtonType( props, t, BUTTON_TYPES[ t ].defaultButtonText ) }
+							>
+								{ BUTTON_TYPES[ t ].label }
+							</Button>
+						) ) }
+					</ButtonGroup>
+				</div>
+			</PanelBody>
+			<PanelColorSettings
+				title={ __( 'Button Colors', 'premium-content' ) }
+				initialOpen={ true }
+				colorSettings={ [
+					{
+						value: backgroundButtonColor || undefined,
+						onChange: setBackgroundButtonColor,
+						label: __( 'Background Color', 'premium-content' ),
+					},
+					{
+						value: textButtonColor || undefined,
+						onChange: setTextButtonColor,
+						label: __( 'Text Color', 'premium-content' ),
+					},
+				] }
+			/>
+			<ContrastChecker
+				textColor={ color }
+				backgroundColor={ backgroundColor }
+				fallbackBackgroundColor={ fallbackBackgroundColor }
+				fallbackTextColor={ fallbackTextColor }
+			/>
+		</InspectorControls>
+	);
+};
+
+/**
+ * Block edit function
+ *
+ * @typedef { import('./').Attributes } Attributes
+ * @typedef { Object } Props
+ * @property { boolean } isSelected
+ * @property { string } className
+ * @property { string } clientId
+ * @property { string } containerClientId
+ * @property { Attributes } attributes
+ * @property { (attributes: Partial<Attributes>) => void } setAttributes
+ * @property { () => void } selectBlock
+ *
+ * @param { Props } props
+ */
+function Edit( props ) {
+	useEffect( () => {
+		setButtonClasses();
+		setCustomButtonColors();
+	}, [ props.backgroundButtonColor, props.textButtonColor ] );
+
+	function setButtonClasses() {
+		const buttonClasses = getButtonClasses();
+		props.setAttributes( { buttonClasses } );
+	}
+
+	function setCustomButtonColors() {
+		const customTextButtonColor = getTextButtonColor();
+		const customBackgroundButtonColor = getBackgroundButtonColor();
+
+		if ( customTextButtonColor !== undefined ) {
+			props.setAttributes( { customTextButtonColor } );
+		}
+
+		if ( customBackgroundButtonColor !== undefined ) {
+			props.setAttributes( { customBackgroundButtonColor } );
+		}
+	}
+
+	function getTextButtonColor() {
+		return get( props.textButtonColor, 'color' );
+	}
+
+	function getBackgroundButtonColor() {
+		return get( props.backgroundButtonColor, 'color' );
+	}
+
+	function getButtonClasses() {
+		const { textButtonColor, backgroundButtonColor } = props;
+		const textClass = get( textButtonColor, 'class' );
+		const backgroundClass = get( backgroundButtonColor, 'class' );
+		return classnames( 'wp-block-button__link', {
+			'has-text-color': textButtonColor.color,
+			[ textClass ]: textClass,
+			'has-background': backgroundButtonColor.color,
+			[ backgroundClass ]: backgroundClass,
+		} );
+	}
+
+	const {
+		isSelected,
+		attributes,
+		setAttributes,
+		backgroundButtonColor,
+		textButtonColor,
+		setBackgroundButtonColor,
+		setTextButtonColor,
+		fallbackBackgroundColor,
+		fallbackTextColor,
+	} = props;
+
+	const backgroundColor = backgroundButtonColor.color || fallbackBackgroundColor;
+	const color = textButtonColor.color || fallbackTextColor;
+	const buttonStyle = { border: 'none', backgroundColor, color };
+	const buttonClasses = getButtonClasses();
+
+	return [
+		isSelected && blockControls( props ),
+
+		isSelected && inspectorControls( props ),
+
+		<div className={ props.className }>
+			<div className="wp-block-button premium-content-logged-out-view-button">
+				<RichText
+					placeholder={ __( 'Add text…', 'premium-content' ) }
+					value={ attributes.buttonText }
+					onChange={ ( nextValue ) => setAttributes( { buttonText: nextValue } ) }
+					className={ buttonClasses }
+					style={ buttonStyle }
+					allowedFormats={ [ 'core/bold', 'core/italic', 'core/strikethrough' ] }
+					keepPlaceholderOnFocus={ true }
+				/>
+			</div>
+		</div>,
+	];
+}
+
+export default compose( [
+	withColors( { backgroundButtonColor: 'background-color' }, { textButtonColor: 'color' } ),
+	applyFallbackStyles,
+] )( Edit, inspectorControls );

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/button/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/button/edit.js
@@ -160,7 +160,14 @@ function Edit( props ) {
 	useEffect( () => {
 		setButtonClasses();
 		setCustomButtonColors();
-	}, [ props.backgroundButtonColor, props.textButtonColor ] );
+		setBlockContext();
+	}, [ props.backgroundButtonColor, props.textButtonColor, props.context ] );
+
+	function setBlockContext() {
+		const { context } = props;
+		props.setAttributes( context );
+		console.log( context );
+	}
 
 	function setButtonClasses() {
 		const buttonClasses = getButtonClasses();

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/button/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/button/index.js
@@ -1,0 +1,101 @@
+/**
+ * BLOCK: Button Block
+ *
+ * Registering a basic block with Gutenberg.
+ * Simple block, renders and saves the same content without any interactivity.
+ */
+
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import edit from './edit';
+
+const name = 'premium-content/button';
+const category = 'common';
+
+/**
+ * @typedef {object} Attributes
+ * @property { string } newPlanName
+ * @property { string } newPlanCurrency
+ * @property { number } newPlanPrice
+ * @property { string } newPlanInterval
+ * @property { number } selectedPlanId
+ *
+ * @typedef {import('@wordpress/blocks').BlockConfiguration<Attributes>} BlockConfiguration
+ * @type {BlockConfiguration}
+ */
+const settings = {
+	name,
+	attributes: {
+		blockID: {
+			type: 'string',
+			default: '',
+		},
+		buttonText: {
+			type: 'string',
+			default: 'Log In',
+		},
+		align: {
+			type: 'string',
+			default: 'center',
+		},
+		buttonType: {
+			type: 'string',
+			default: 'login',
+		},
+		buttonClasses: {
+			type: 'string',
+			default: '',
+		},
+		backgroundButtonColor: {
+			type: 'string',
+			default: '',
+		},
+		textButtonColor: {
+			type: 'string',
+			default: '',
+		},
+		customBackgroundButtonColor: {
+			type: 'string',
+			default: '',
+		},
+		customTextButtonColor: {
+			type: 'string',
+			default: '',
+		},
+	},
+
+	/**
+	 * An icon property should be specified to make it easier to identify a block.
+	 * These can be any of WordPress’ Dashicons, or a custom svg element.
+	 */
+	icon: (
+		<svg width="25" height="24" viewBox="0 0 25 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+			<path
+				d="M12.7439 14.4271L8.64053 13.165L8.51431 13.8718L8.09208 20.7415C8.06165 21.2365 8.61087 21.5526 9.02363 21.2776L12.7439 18.799L16.7475 21.304C17.1687 21.5676 17.7094 21.2343 17.6631 20.7396L17.0212 13.8718L17.0212 13.165L12.7439 14.4271Z"
+				fill="black"
+			/>
+			<circle cx="12.7439" cy="8.69796" r="5.94466" stroke="black" strokeWidth="1.5" fill="none" />
+			<path
+				d="M9.71023 8.12461L11.9543 10.3687L15.7776 6.54533"
+				stroke="black"
+				strokeWidth="1.5"
+				fill="none"
+			/>
+		</svg>
+	),
+
+	/* translators: block name */
+	title: __( 'Premium Content Button', 'premium-content' ),
+	/* translators: block description */
+	description: __( 'Premium Content Button.', 'premium-content' ),
+	supports: {
+		html: false,
+	},
+	edit,
+	save: () => null,
+};
+
+export { name, category, settings };

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/button/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/button/index.js
@@ -65,6 +65,10 @@ const settings = {
 			type: 'string',
 			default: '',
 		},
+		'premium-content/container/selectedPlanId': {
+			type: 'number',
+			default: 0,
+		},
 	},
 
 	/**
@@ -91,11 +95,13 @@ const settings = {
 	title: __( 'Premium Content Button', 'premium-content' ),
 	/* translators: block description */
 	description: __( 'Premium Content Button.', 'premium-content' ),
+	parent: [ 'premium-content/logged-out-view' ],
 	supports: {
 		html: false,
 	},
 	edit,
 	save: () => null,
+	context: [ 'premium-content/container/selectedPlanId' ],
 };
 
 export { name, category, settings };

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/container/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/container/index.js
@@ -103,6 +103,9 @@ const settings = {
 	],
 	edit,
 	save,
+	providesContext: {
+		'premium-content/container/selectedPlanId': 'selectedPlanId',
+	},
 };
 
 export { name, category, settings };

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/logged-out-view/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/logged-out-view/edit.js
@@ -32,23 +32,14 @@ import SubmitButtons from './submit-buttons';
 function Edit( props ) {
 	useEffect( () => {
 		props.selectBlock();
-	}, [] );
+		setBlockContext();
+	}, [ props.context ] );
 
-	const buttons = (
-		<SubmitButtons
-			{ ...{
-				attributes: pick( props.attributes, [
-					'subscribeButtonText',
-					'loginButtonText',
-					'backgroundButtonColor',
-					'textButtonColor',
-					'customBackgroundButtonColor',
-					'customTextButtonColor',
-				] ),
-				setAttributes: props.setAttributes,
-			} }
-		/>
-	);
+	function setBlockContext() {
+		const { context } = props;
+		props.setAttributes( context );
+		console.log( context );
+	}
 
 	return (
 		<Context.Consumer>
@@ -73,9 +64,22 @@ function Edit( props ) {
 									),
 								},
 							],
+							[
+								'core/columns',
+								{},
+								[
+									[
+										'premium-content/button',
+										{
+											buttonType: 'subscribe',
+											buttonText: __( 'Subscribe', 'premium-content' ),
+										},
+									],
+									[ 'premium-content/button' ],
+								],
+							],
 						] }
 					/>
-					{ buttons }
 				</div>
 			) }
 		</Context.Consumer>

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/logged-out-view/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/logged-out-view/index.js
@@ -59,6 +59,10 @@ const settings = {
 			type: 'string',
 			default: '',
 		},
+		'premium-content/container/selectedPlanId': {
+			type: 'number',
+			default: 0,
+		},
 	},
 
 	/* translators: block name */
@@ -73,6 +77,7 @@ const settings = {
 	},
 	edit,
 	save,
+	context: [ 'premium-content/container/selectedPlanId' ],
 };
 
 /**

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/subscriber-view/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/subscriber-view/edit.js
@@ -25,7 +25,14 @@ import Context from '../container/context';
 function Edit( props ) {
 	useEffect( () => {
 		props.selectBlock();
-	}, [] );
+		setBlockContext();
+	}, [ props.context ] );
+
+	function setBlockContext() {
+		const { context } = props;
+		props.setAttributes( context );
+		console.log( context );
+	}
 
 	return (
 		<Context.Consumer>

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/subscriber-view/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/subscriber-view/index.js
@@ -14,7 +14,12 @@ const category = 'common';
 const settings = {
 	name,
 	category,
-	attributes: {},
+	attributes: {
+		'premium-content/container/selectedPlanId': {
+			type: 'number',
+			default: 0,
+		},
+	},
 
 	/* translators: block name */
 	title: __( 'Subscriber View', 'premium-content' ),
@@ -28,6 +33,7 @@ const settings = {
 	},
 	edit,
 	save,
+	context: [ 'premium-content/container/selectedPlanId' ],
 };
 
 export { name, category, settings };

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/editor.css
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/editor.css
@@ -136,3 +136,7 @@
 	margin-bottom: 20px;
 }
 
+div.block-editor-block-list__block[data-type='premium-content/button'] {
+	margin: 0px;
+}
+

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/index.js
@@ -7,6 +7,7 @@ import { registerBlockType } from '@wordpress/blocks';
 import * as container from './blocks/container';
 import * as subscriberView from './blocks/subscriber-view';
 import * as loggedOutView from './blocks/logged-out-view';
+import * as button from './blocks/button';
 
 /**
  * Function to register an individual block.
@@ -25,6 +26,8 @@ const registerBlock = ( block ) => {
 		return;
 	}
 
+	console.log( block );
+
 	const { name, category, settings } = block;
 
 	registerBlockType( name, {
@@ -37,7 +40,7 @@ const registerBlock = ( block ) => {
  * Function to register blocks provided by CoBlocks.
  */
 export const registerPremiumContentBlocks = () => {
-	[ container, loggedOutView, subscriberView ].forEach( registerBlock );
+	[ container, loggedOutView, subscriberView, button ].forEach( registerBlock );
 };
 
 registerPremiumContentBlocks();

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/premium-content.php
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/premium-content.php
@@ -16,7 +16,6 @@ use RuntimeException;
 use function register_block_type;
 use function plugin_dir_url;
 use function apply_filters;
-use A8C\FSE\Earn\PremiumContent\Premium_Content_Dom;
 use A8C\FSE\Earn\PremiumContent\SubscriptionService\{
 	Subscription_Service,
 	Jetpack_Token_Subscription_Service,
@@ -86,11 +85,21 @@ function premium_content_block_init() {
 			'render_callback' => '\A8C\FSE\Earn\PremiumContent\premium_content_container_render',
 		)
 	);
-	register_block_type( 'premium-content/subscriber-view' );
+	register_block_type(
+		'premium-content/subscriber-view',
+		array(
+			'render_callback' => '\A8C\FSE\Earn\PremiumContent\premium_content_block_subscriber_view_render',
+		) );
 	register_block_type(
 		'premium-content/logged-out-view',
 		array(
 			'render_callback' => '\A8C\FSE\Earn\PremiumContent\premium_content_block_logged_out_view_render',
+		)
+	);
+	register_block_type(
+		'premium-content/button',
+		array(
+			'render_callback' => '\A8C\FSE\Earn\PremiumContent\premium_content_render_button_block',
 		)
 	);
 
@@ -99,47 +108,6 @@ function premium_content_block_init() {
 		"$url_path/blocks/button/front.js",
 		array(),
 		$script_asset['version']
-	);
-
-	register_block_type( 'premium-content/button',
-		array(
-			'render_callback' => '\A8C\FSE\Earn\PremiumContent\premium_content_render_button_block',
-			'editor_style' => 'premium-content-container-block-editor',
-			'attributes' => array(
-				'buttonText' => array(
-					'type' => 'string',
-					'default' => 'Log In'
-				),
-				'align' => array(
-					'type' => 'string',
-					'default' => 'center'
-				),
-				'buttonType' => array(
-					'type' => 'string',
-					'default' => 'login'
-				),
-				'buttonClasses' => array(
-					'type' => 'string',
-					'default' => ''
-				),
-				'backgroundButtonColor' => array(
-					'type' => 'string',
-					'default' => ''
-				),
-				'textButtonColor' => array(
-					'type' => 'string',
-					'default' => ''
-				),
-				'customBackgroundButtonColor' => array(
-					'type' => 'string',
-					'default' => ''
-				),
-				'customTextButtonColor' => array(
-					'type' => 'string',
-					'default' => ''
-				),
-			),
-		)
 	);
 }
 
@@ -163,12 +131,22 @@ function premium_content_current_visitor_can_access( $attributes ) {
 		return true;
 	}
 
-	if ( ! isset( $attributes['selectedPlanId'] ) ) {
+	$selected_plan_id = null;
+
+	if ( isset( $attributes['selectedPlanId'] ) ) {
+		$selected_plan_id = (int) $attributes['selectedPlanId'];
+	}
+
+	if ( isset( $attributes['premium-content/container/selectedPlanId'] ) ) {
+		$selected_plan_id = (int) $attributes['premium-content/container/selectedPlanId'];
+	}
+
+	if ( empty( $selected_plan_id ) ) {
 		return false;
 	}
 
 	$paywall  = premium_content_subscription_service();
-	$can_view = $paywall->visitor_can_view_content( array( $attributes['selectedPlanId'] ) );
+	$can_view = $paywall->visitor_can_view_content( array( $selected_plan_id ) );
 
 	if ( $can_view ) {
 		do_action( 'earn_remove_cache_headers' );
@@ -177,50 +155,27 @@ function premium_content_current_visitor_can_access( $attributes ) {
 	return $can_view;
 }
 
-// TODO: I am planning to kill the other render methods and pull everything here. The data is too tightly coupled for the render methods being seperate
+function premium_content_pre_render_checks() {
+	// If Jetpack is not yet configured, don't show anything ...
+	if ( ! class_exists( '\Jetpack_Memberships' ) ) {
+		return false;
+	}
+	// if stripe not connected don't show anything...
+	if ( empty( \Jetpack_Memberships::get_connected_account_id() ) ) {
+		return false;
+	}
+	return true;
+}
+
 /**
  * @param          array  $attributes
  * @param          string $content
  * @return         string
  * @psalm-suppress InvalidArgument
  */
-function premium_content_container_render( $attributes, $content ) {
-	// If Jetpack is not yet configured, don't show anything ...
-	if ( ! class_exists( '\Jetpack_Memberships' ) ) {
+function premium_content_container_render( $attributes, $content ){
+	if ( ! premium_content_pre_render_checks() ) {
 		return '';
-	}
-	// if stripe not connected don't show anything...
-	if ( empty( \Jetpack_Memberships::get_connected_account_id() ) ) {
-		return '';
-	}
-
-	// Parse the content so that subscribers see the subscriber view and logged out users see the logged-out view.
-	$visitor_has_access = premium_content_current_visitor_can_access( $attributes );
-	if ( ! $visitor_has_access ) {
-		$content = Premium_Content_Dom::logged_out( $content );
-		// TODO: consider moving this into the DOM editing class... (or javascript)
-		$content = preg_replace_callback(
-			'#<subscribeButtonText classNames="(.*?)" customTextButtonColor="(.*?)" customBackgroundButtonColor="(.*?)">(.*?)<\/subscribeButtonText>#is',
-			/**
-			* @param array $matches
-			*
-			* @return null|string
-			*/
-			function ( $matches ) use ( $attributes ) {
-				return \Jetpack_Memberships::get_instance()->render_button(
-					array(
-						'planId'                      => $attributes['selectedPlanId'],
-						'submitButtonClasses'         => $matches[1],
-						'customTextButtonColor'       => $matches[2],
-						'customBackgroundButtonColor' => $matches[3],
-						'submitButtonText'            => $matches[4], // This should be the text actually selected in the editor. I think I'll pass it in attributes.
-					)
-				);
-			},
-			$content
-		);
-	} else {
-		$content = Premium_Content_Dom::subscriber( $content );
 	}
 
 	return $content;
@@ -233,21 +188,49 @@ function premium_content_container_render( $attributes, $content ) {
  * Determines if the current visitor should be allowed to see the protected/premium
  * content contained within the block.
  *
- * TODO: consider moving this to the DOM editing class or in javascript
- *
  * @param  array  $attributes
  * @param  string $content
  * @return string
  */
 function premium_content_block_logged_out_view_render( $attributes, $content ) {
+	if ( ! premium_content_pre_render_checks() ) {
+		return '';
+	}
+
+	$visitor_has_access = premium_content_current_visitor_can_access( $attributes );
+	if ( !$visitor_has_access ) {
+		return $content;
+	}
+
+	return '';
+}
+
+function premium_content_block_subscriber_view_render( $attributes, $content ) {
+	if ( ! premium_content_pre_render_checks() ) {
+		return '';
+	}
+
+	$visitor_has_access = premium_content_current_visitor_can_access( $attributes );
+	if ( $visitor_has_access ) {
+		return $content;
+	}
+
+	return '';
+}
+
+function premium_content_render_button_block( $attributes ) {
+	if ( ! premium_content_pre_render_checks() ) {
+		return '';
+	}
+
 	wp_enqueue_style( 'premium-content-container-block' );
 	wp_enqueue_script( 'premium-content-frontend' );
 
 	$button_styles = array();
 	if ( ! empty( $attributes['customBackgroundButtonColor'] ) ) {
 		/**
-	* @psalm-suppress PossiblyNullArgument
-*/
+		 * @psalm-suppress PossiblyNullArgument
+		 */
 		array_push(
 			$button_styles,
 			sprintf(
@@ -258,8 +241,8 @@ function premium_content_block_logged_out_view_render( $attributes, $content ) {
 	}
 	if ( ! empty( $attributes['customTextButtonColor'] ) ) {
 		/**
-	* @psalm-suppress PossiblyNullArgument
-*/
+		 * @psalm-suppress PossiblyNullArgument
+		 */
 		array_push(
 			$button_styles,
 			sprintf(
@@ -270,23 +253,32 @@ function premium_content_block_logged_out_view_render( $attributes, $content ) {
 	}
 	$button_styles = implode( ';', $button_styles );
 
-	$login_button = sprintf(
-		'<div class="wp-block-button"><a role="button" href="%1$s" class="%2$s" style="%3$s">%4$s</a></div>',
-		premium_content_subscription_service()->access_url(),
-		empty( $attributes['buttonClasses'] ) ? 'wp-block-button__link' : esc_attr( $attributes['buttonClasses'] ),
-		esc_attr( $button_styles ),
-		empty( $attributes['loginButtonText'] ) ? __( 'Log In', 'premium-content' ) : $attributes['loginButtonText']
-	);
+	if ( $attributes['buttonType'] === 'subscribe' ) {
+		$button = \Jetpack_Memberships::get_instance()->render_button(
+			array(
+				'planId'                      => empty( $attributes['premium-content/container/selectedPlanId'] ) ? 0 : $attributes['premium-content/container/selectedPlanId'],
+				'submitButtonClasses'         => empty( $attributes['buttonClasses'] ) ? 'wp-block-button__link' : esc_attr( $attributes['buttonClasses'] ),
+				'customTextButtonColor'       => empty( $attributes['customTextButtonColor'] ) ? '' : esc_attr( $attributes['customTextButtonColor'] ),
+				'customBackgroundButtonColor' => empty( $attributes['customBackgroundButtonColor'] ) ? '' : esc_attr( $attributes['customBackgroundButtonColor'] ),
+				'submitButtonText'            => empty( $attributes['buttonText'] ) ? __( 'Subscribe' ) : esc_attr( $attributes['buttonText'] ),
+			)
+		);
+	} else {
+		$button = sprintf(
+			'<div class="wp-block-button"><a role="button" href="%1$s" class="%2$s" style="%3$s">%4$s</a></div>',
+			premium_content_subscription_service()->access_url(),
+			empty( $attributes['buttonClasses'] ) ? 'wp-block-button__link' : esc_attr( $attributes['buttonClasses'] ),
+			esc_attr( $button_styles ),
+			empty( $attributes['buttonText'] ) ? __( 'Log In', 'premium-content' ) : $attributes['buttonText']
+		);
+	}
 
-	$subscribe_button = sprintf(
-		'<subscribeButtonText classNames="%1$s" customTextButtonColor="%2$s" customBackgroundButtonColor="%3$s">%4$s</subscribeButtonText>', // I don't know how to pass this data in a different way. We could also turn it into a class and pass it via a variable.
-		empty( $attributes['buttonClasses'] ) ? 'wp-block-button__link' : esc_attr( $attributes['buttonClasses'] ),
-		empty( $attributes['customTextButtonColor'] ) ? '' : esc_attr( $attributes['customTextButtonColor'] ),
-		empty( $attributes['customBackgroundButtonColor'] ) ? '' : esc_attr( $attributes['customBackgroundButtonColor'] ),
-		empty( $attributes['subscribeButtonText'] ) ? __( 'Subscribe' ) : esc_attr( $attributes['subscribeButtonText'] )
-	);
+	$align_class = '';
+	if ( isset( $attributes['align'] ) && in_array( $attributes['align'], [ 'left', 'center', 'right' ], true ) ) {
+		$align_class = 'align' . $attributes['align'];
+	}
 
-	return $content . "<div class='wp-block-premium-content-logged-out-view__buttons'>{$subscribe_button}{$login_button}</div>";
+	return "<div class='wp-block-premium-content-logged-out-view__buttons {$align_class}'>{$button}</div>";
 }
 
 /**
@@ -338,58 +330,4 @@ add_action( 'init', 'A8C\FSE\Earn\PremiumContent\premium_content_paywall_initial
 add_action( 'init', 'A8C\FSE\Earn\PremiumContent\premium_content_block_init' );
 add_filter( PAYWALL_FILTER, 'A8C\FSE\Earn\PremiumContent\premium_content_default_service' );
 
-
-function premium_content_render_button_block( $attributes, $content ){
-	wp_enqueue_style( 'premium-content-container-block' );
-	wp_enqueue_script( 'premium-content-frontend' );
-
-	$button_styles = array();
-	if ( ! empty( $attributes['customBackgroundButtonColor'] ) ) {
-		/**
-		 * @psalm-suppress PossiblyNullArgument
-		 */
-		array_push(
-			$button_styles,
-			sprintf(
-				'background-color: %s',
-				sanitize_hex_color( $attributes['customBackgroundButtonColor'] ) ?? 'transparent'
-			)
-		);
-	}
-	if ( ! empty( $attributes['customTextButtonColor'] ) ) {
-		/**
-		 * @psalm-suppress PossiblyNullArgument
-		 */
-		array_push(
-			$button_styles,
-			sprintf(
-				'color: %s',
-				sanitize_hex_color( $attributes['customTextButtonColor'] ) ?? 'inherit'
-			)
-		);
-	}
-	$button_styles = implode( ';', $button_styles );
-
-	if ( $attributes['buttonType'] === 'login' ) {
-		$button = sprintf(
-			'<div class="wp-block-button"><a role="button" href="%1$s" class="%2$s" style="%3$s">%4$s</a></div>',
-			premium_content_subscription_service()->access_url(),
-			empty( $attributes['buttonClasses'] ) ? 'wp-block-button__link' : esc_attr( $attributes['buttonClasses'] ),
-			esc_attr( $button_styles ),
-			empty( $attributes['loginButtonText'] ) ? __( 'Log In', 'premium-content' ) : $attributes['loginButtonText']
-		);
-	} elseif ( $attributes['buttonType'] === 'subscribe' ) {
-		$button = \Jetpack_Memberships::get_instance()->render_button(
-			array(
-				'planId' => empty( $attributes['selectedPlanId'] ) ? 46 : $attributes['selectedPlanId'],
-				'submitButtonClasses' => empty( $attributes['buttonClasses'] ) ? 'wp-block-button__link' : esc_attr( $attributes['buttonClasses'] ),
-				'customTextButtonColor' => empty( $attributes['customTextButtonColor'] ) ? '' : esc_attr( $attributes['customTextButtonColor'] ),
-				'customBackgroundButtonColor' => empty( $attributes['customBackgroundButtonColor'] ) ? '' : esc_attr( $attributes['customBackgroundButtonColor'] ),
-				'submitButtonText' => empty( $attributes['subscribeButtonText'] ) ? __( 'Subscribe' ) : esc_attr( $attributes['buttonText'] ),
-			)
-		);
-	}
-
-	return $content . "<div class='wp-block-premium-content-logged-out-view__buttons'>{$button}</div>";
-}
 

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/style.css
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/style.css
@@ -24,9 +24,12 @@
 	margin-right: 20px;
 }
 
-.wp-block-premium-content-logged-out-view p:last-child,
 .wp-block-premium-content-logged-out-view h3 {
 	margin-bottom: 20px;
+}
+
+.wp-block-premium-content-logged-out-view .wp-block-columns {
+	margin-top: 20px;
 }
 
 /** Notices close button **/


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The PR will try to decouple the login and subscribe buttons used in the non-subscriber view in the premium content block

Ref: https://github.com/Automattic/wp-calypso/issues/41850

I plan to use recent changes to [block context](https://github.com/WordPress/gutenberg/blob/master/docs/designers-developers/developers/block-api/block-context.md) to allow nested blocks to know what the container's selected plan ID is so it can be used to determine if those blocks should be rendered or not.

#### Testing instructions

* Apply PR and make sure sync'd with sandbox.
* Go to test FSE site (that is sandboxed).
* Test adding a premium content block to a post.
* Test that the buttons are rendered ok in the editor and in the published post.
* Test that you can remove all buttons and add them again inside the logged out (non-subscriber) view - you shouldn't be able to add a Premium content button to the subscriber view OR outside the Premium content container.

