### PR TITLE
Sets back button visibilty to depend on the back URL

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -670,7 +670,7 @@ class DomainsStep extends React.Component {
 					</div>
 				}
 				showSiteMockups={ this.props.showSiteMockups }
-				allowBackFirstStep={ !! hasInitializedSitesBackUrl }
+				allowBackFirstStep={ !! backUrl }
 				backLabelText={ backLabelText }
 				hideSkip={ ! showSkip }
 				isTopButtons={ showSkip }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This fixes the missing Back button on the Domain page when going through the site Launch flow. The button is also missing when adding a new site by, directly, accessing https://wordpress.com/start (while logged in).
The button appears on the other flows (Add New site, Getting started).

The fix relies on setting the Back button to be shown only when there's a `backUrl` set.
Previously, visibility depended on a `state.ui.siteSelectionInitialized` which is not being initialized for this flow.

#### Testing instructions

1. Test that Launch flow now shows the `Back` button
- create a site
- go through the Launch flow
- At the domain step, click `Use a domain I own` link.
- `Back` button should be on the top left corner
2. Test that directly adding a new site to an account shows the `Back` button
- make sure you're logged in
- go to https://wordpress.com/start
- click on `Already own a domain?` 
- `Back` button should be on the top left corner
3. Add New Site flow still shows the `Back` button
- click on `Add New Site` in My Sites panel
- choose `Create a shiny new WordPress.com site`
- click on `Already own a domain?`
- `Back` button should be on the top left corner

Fixes #40330 
