### PR TITLE
composite-checkout: Convert PayPal payment method to use processor function

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -67,6 +67,7 @@ import {
 	stripeCardProcessor,
 	fullCreditsProcessor,
 	existingCardProcessor,
+	payPalProcessor,
 } from './payment-method-processors';
 import { useGetThankYouUrl } from './use-get-thank-you-url';
 import createAnalyticsEventHandler from './record-analytics';
@@ -266,14 +267,11 @@ export default function CompositeCheckout( {
 
 	const paymentMethodObjects = useCreatePaymentMethods( {
 		onlyLoadPaymentMethods,
-		getThankYouUrl,
 		isStripeLoading,
 		stripeLoadingError,
 		stripeConfiguration,
 		stripe,
 		credits,
-		items,
-		couponItem,
 		isApplePayAvailable,
 		isApplePayLoading,
 		storedCards,
@@ -413,8 +411,9 @@ export default function CompositeCheckout( {
 			card: stripeCardProcessor,
 			'full-credits': fullCreditsProcessor,
 			'existing-card': existingCardProcessor,
+			paypal: ( transactionData ) => payPalProcessor( transactionData, getThankYouUrl, couponItem ),
 		} ),
-		[]
+		[ couponItem, getThankYouUrl ]
 	);
 
 	return (

--- a/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
@@ -70,7 +70,7 @@ export async function submitApplePayPayment( transactionData, submit ) {
 	return submit( formattedTransactionData );
 }
 
-export async function makePayPalExpressRequest( transactionData, submit ) {
+export async function submitPayPalExpressRequest( transactionData, submit ) {
 	const formattedTransactionData = createPayPalExpressEndpointRequestPayloadFromLineItems( {
 		...transactionData,
 	} );

--- a/client/my-sites/checkout/composite-checkout/payment-method-processors.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-processors.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { defaultRegistry } from '@automattic/composite-checkout';
+import { format as formatUrl, parse as parseUrl } from 'url';
 
 /**
  * Internal dependencies
@@ -9,10 +10,12 @@ import { defaultRegistry } from '@automattic/composite-checkout';
 import {
 	getDomainDetails,
 	wpcomTransaction,
+	wpcomPayPalExpress,
 	submitApplePayPayment,
 	submitStripeCardTransaction,
 	submitCreditsTransaction,
 	submitExistingCardPayment,
+	submitPayPalExpressRequest,
 } from './payment-method-helpers';
 import { createStripePaymentMethod } from 'lib/stripe';
 
@@ -104,6 +107,43 @@ export async function fullCreditsProcessor( submitData ) {
 			postalCode: null,
 		},
 		wpcomTransaction
+	);
+	// save result so we can get receipt_id and failed_purchases in getThankYouPageUrl
+	pending.then( ( result ) => {
+		// TODO: do this automatically when calling setTransactionComplete
+		dispatch( 'wpcom' ).setTransactionResponse( result );
+	} );
+	return pending;
+}
+
+export async function payPalProcessor( submitData, getThankYouUrl, couponItem ) {
+	const { protocol, hostname, port, pathname } = parseUrl( window.location.href, true );
+	const successUrl = formatUrl( {
+		protocol,
+		hostname,
+		port,
+		pathname: getThankYouUrl(),
+	} );
+	const cancelUrl = formatUrl( {
+		protocol,
+		hostname,
+		port,
+		pathname,
+	} );
+
+	const pending = submitPayPalExpressRequest(
+		{
+			...submitData,
+			successUrl,
+			cancelUrl,
+			siteId: select( 'wpcom' )?.getSiteId?.() ?? '',
+			domainDetails: getDomainDetails( select ),
+			couponId: couponItem?.wpcom_meta?.couponCode,
+			country: select( 'wpcom' )?.getContactInfo?.()?.countryCode?.value ?? '',
+			postalCode: select( 'wpcom' )?.getContactInfo?.()?.postalCode?.value ?? '',
+			subdivisionCode: select( 'wpcom' )?.getContactInfo?.()?.state?.value ?? '',
+		},
+		wpcomPayPalExpress
 	);
 	// save result so we can get receipt_id and failed_purchases in getThankYouPageUrl
 	pending.then( ( result ) => {

--- a/packages/composite-checkout/src/lib/payment-methods/paypal.js
+++ b/packages/composite-checkout/src/lib/payment-methods/paypal.js
@@ -15,6 +15,7 @@ import {
 	useEvents,
 	usePaymentProcessor,
 	useTransactionStatus,
+	useLineItems,
 } from '../../public-api';
 import { useFormStatus } from '../form-status';
 import { PaymentMethodLogos } from '../styled-components/payment-method-logos';
@@ -51,10 +52,13 @@ export function PaypalSubmitButton( { disabled } ) {
 	const onEvent = useEvents();
 	const { setTransactionRedirecting, setTransactionError } = useTransactionStatus();
 	const submitTransaction = usePaymentProcessor( 'paypal' );
+	const [ items ] = useLineItems();
 
 	const onClick = () => {
 		onEvent( { type: 'PAYPAL_TRANSACTION_BEGIN' } );
-		submitTransaction()
+		submitTransaction( {
+			items,
+		} )
 			.then( ( response ) => {
 				setTransactionRedirecting( response );
 			} )

--- a/packages/composite-checkout/src/lib/payment-methods/paypal.js
+++ b/packages/composite-checkout/src/lib/payment-methods/paypal.js
@@ -10,70 +10,26 @@ import debugFactory from 'debug';
  */
 import Button from '../../components/button';
 import { useLocalize } from '../../lib/localize';
-import { useDispatch, useSelect } from '../../lib/registry';
-import { useMessages, useEvents } from '../../public-api';
+import {
+	useMessages,
+	useEvents,
+	usePaymentProcessor,
+	useTransactionStatus,
+} from '../../public-api';
 import { useFormStatus } from '../form-status';
 import { PaymentMethodLogos } from '../styled-components/payment-method-logos';
 
 const debug = debugFactory( 'composite-checkout:paypal' );
 
-export function createPayPalMethod( { registerStore } ) {
+export function createPayPalMethod() {
 	debug( 'creating new paypal payment method' );
-
-	const paymentMethod = {
+	return {
 		id: 'paypal',
 		label: <PaypalLabel />,
 		submitButton: <PaypalSubmitButton />,
 		inactiveContent: <PaypalSummary />,
 		getAriaLabel: ( localize ) => localize( 'PayPal' ),
 	};
-
-	registerStore( 'paypal', {
-		controls: {
-			PAYPAL_TRANSACTION_SUBMIT() {
-				if ( ! paymentMethod.submitTransaction ) {
-					throw new Error( 'PayPal payment method does not have a submitTransaction function' );
-				}
-				return paymentMethod.submitTransaction();
-			},
-		},
-		actions: {
-			*submitPaypalPayment( payload ) {
-				try {
-					yield { type: 'PAYPAL_TRANSACTION_BEGIN', payload };
-					const paypalResponse = yield { type: 'PAYPAL_TRANSACTION_SUBMIT' };
-					debug( 'received successful paypal endpoint response', paypalResponse );
-					return { type: 'PAYPAL_TRANSACTION_END', payload: paypalResponse };
-				} catch ( error ) {
-					return { type: 'PAYPAL_TRANSACTION_ERROR', payload: error.message };
-				}
-			},
-		},
-		reducer( state = {}, action ) {
-			switch ( action.type ) {
-				case 'PAYPAL_TRANSACTION_BEGIN':
-					return { ...state, paypalStatus: 'submitting' };
-				case 'PAYPAL_TRANSACTION_END':
-					return { ...state, paypalStatus: 'redirecting', paypalExpressUrl: action.payload };
-				case 'PAYPAL_TRANSACTION_ERROR':
-					return { ...state, paypalStatus: 'error', paypalError: action.payload };
-			}
-			return state;
-		},
-		selectors: {
-			getTransactionStatus( state ) {
-				return state.paypalStatus;
-			},
-			getTransactionError( state ) {
-				return state.paypalError;
-			},
-			getRedirectUrl( state ) {
-				return state.paypalExpressUrl;
-			},
-		},
-	} );
-
-	return paymentMethod;
 }
 
 export function PaypalLabel() {
@@ -90,14 +46,21 @@ export function PaypalLabel() {
 }
 
 export function PaypalSubmitButton( { disabled } ) {
-	const { submitPaypalPayment } = useDispatch( 'paypal' );
 	useTransactionStatusHandler();
 	const { formStatus } = useFormStatus();
 	const onEvent = useEvents();
+	const { setTransactionRedirecting, setTransactionError } = useTransactionStatus();
+	const submitTransaction = usePaymentProcessor( 'paypal' );
 
 	const onClick = () => {
 		onEvent( { type: 'PAYPAL_TRANSACTION_BEGIN' } );
-		submitPaypalPayment();
+		submitTransaction()
+			.then( ( response ) => {
+				setTransactionRedirecting( response );
+			} )
+			.catch( ( error ) => {
+				setTransactionError( error.message );
+			} );
 	};
 	return (
 		<Button
@@ -127,17 +90,15 @@ function PayPalButtonContents( { formStatus } ) {
 function useTransactionStatusHandler() {
 	const localize = useLocalize();
 	const { showErrorMessage } = useMessages();
-	const transactionStatus = useSelect( ( select ) => select( 'paypal' ).getTransactionStatus() );
-	const transactionError = useSelect( ( select ) => select( 'paypal' ).getTransactionError() );
+	const { transactionStatus, transactionError, transactionLastResponse } = useTransactionStatus();
 	const { setFormReady, setFormSubmitting } = useFormStatus();
-	const paypalExpressUrl = useSelect( ( select ) => select( 'paypal' ).getRedirectUrl() );
 	const onEvent = useEvents();
 
 	useEffect( () => {
 		if ( transactionStatus === 'redirecting' ) {
-			debug( 'redirecting to paypal url', paypalExpressUrl );
+			debug( 'redirecting to paypal url', transactionLastResponse );
 			// TODO: should this redirect go through the host page?
-			window.location.href = paypalExpressUrl;
+			window.location.href = transactionLastResponse;
 			return;
 		}
 		if ( transactionStatus === 'error' ) {
@@ -158,9 +119,9 @@ function useTransactionStatusHandler() {
 		showErrorMessage,
 		transactionStatus,
 		transactionError,
+		transactionLastResponse,
 		setFormReady,
 		setFormSubmitting,
-		paypalExpressUrl,
 	] );
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This updates the "PayPal" payment method to use the payment processor function system introduced in #41767

See also previous conversion of full credits in #42348 and existing cards in #42633.

#### Testing instructions

- Attempt a purchase using composite checkout with PayPal.
- Verify that the purchase is successful.
