### PR TITLE
composite-checkout: Remove payment method duplicate error handling

### DIFF
--- a/packages/composite-checkout/src/lib/form-status.js
+++ b/packages/composite-checkout/src/lib/form-status.js
@@ -13,16 +13,22 @@ const debug = debugFactory( 'composite-checkout:form-status' );
 
 export function useFormStatus() {
 	const { formStatus, setFormStatus } = useContext( CheckoutContext );
-	return useMemo(
+	const formStatusActions = useMemo(
 		() => ( {
-			formStatus,
 			setFormLoading: () => setFormStatus( 'loading' ),
 			setFormReady: () => setFormStatus( 'ready' ),
 			setFormSubmitting: () => setFormStatus( 'submitting' ),
 			setFormValidating: () => setFormStatus( 'validating' ),
 			setFormComplete: () => setFormStatus( 'complete' ),
 		} ),
-		[ formStatus, setFormStatus ]
+		[ setFormStatus ]
+	);
+	return useMemo(
+		() => ( {
+			...formStatusActions,
+			formStatus,
+		} ),
+		[ formStatus, formStatusActions ]
 	);
 }
 

--- a/packages/composite-checkout/src/lib/payment-methods/apple-pay.js
+++ b/packages/composite-checkout/src/lib/payment-methods/apple-pay.js
@@ -78,16 +78,11 @@ export function ApplePaySubmitButton( { disabled, stripe, stripeConfiguration } 
 					setTransactionComplete();
 				} )
 				.catch( ( error ) => {
-					// TODO: do these things automatically
 					setTransactionError( error.message );
-					setFormReady();
-					onEvent( { type: 'APPLE_PAY_TRANSACTION_ERROR', payload: error.message } );
-					showErrorMessage( error.message );
 				} );
 		},
 		[
 			submitTransaction,
-			setFormReady,
 			setTransactionComplete,
 			setTransactionError,
 			onEvent,
@@ -95,7 +90,6 @@ export function ApplePaySubmitButton( { disabled, stripe, stripeConfiguration } 
 			total,
 			stripe,
 			stripeConfiguration,
-			showErrorMessage,
 			setFormSubmitting,
 		]
 	);

--- a/packages/composite-checkout/src/lib/payment-methods/existing-credit-card.js
+++ b/packages/composite-checkout/src/lib/payment-methods/existing-credit-card.js
@@ -174,13 +174,7 @@ function ExistingCardPayButton( {
 					isSubscribed && setTransactionComplete( authenticationResponse );
 				} )
 				.catch( ( error ) => {
-					debug( 'showing error for auth', error.message );
-					showErrorMessage(
-						localize( 'Authorization failed for that card. Please try a different payment method.' )
-					);
-					onEvent( { type: 'EXISTING_CARD_TRANSACTION_ERROR', payload: error } );
-					isSubscribed && resetTransaction();
-					isSubscribed && setFormReady();
+					isSubscribed && setTransactionError( error.message );
 				} );
 		}
 
@@ -189,6 +183,7 @@ function ExistingCardPayButton( {
 		onEvent,
 		resetTransaction,
 		setTransactionComplete,
+		setTransactionError,
 		setFormReady,
 		showInfoMessage,
 		showErrorMessage,
@@ -229,9 +224,6 @@ function ExistingCardPayButton( {
 					} )
 					.catch( ( error ) => {
 						setTransactionError( error.message );
-						setFormReady();
-						onEvent( { type: 'EXISTING_CARD_TRANSACTION_ERROR', payload: error.message } );
-						showErrorMessage( error.message );
 					} );
 			} }
 			buttonState={ disabled ? 'disabled' : 'primary' }

--- a/packages/composite-checkout/src/lib/payment-methods/full-credits.js
+++ b/packages/composite-checkout/src/lib/payment-methods/full-credits.js
@@ -88,11 +88,7 @@ function FullCreditsSubmitButton( { disabled } ) {
 				setTransactionComplete();
 			} )
 			.catch( ( error ) => {
-				// TODO: do these things automatically
 				setTransactionError( error.message );
-				setFormReady();
-				onEvent( { type: 'FULL_CREDITS_TRANSACTION_ERROR', payload: error.message } );
-				showErrorMessage( error.message );
 			} );
 	};
 

--- a/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
@@ -439,13 +439,7 @@ function StripePayButton( { disabled, store, stripe, stripeConfiguration } ) {
 					isSubscribed && setTransactionComplete();
 				} )
 				.catch( ( error ) => {
-					debug( 'showing error for auth', error.message );
-					showErrorMessage(
-						localize( 'Authorization failed for that card. Please try a different payment method.' )
-					);
-					onEvent( { type: 'EXISTING_CARD_TRANSACTION_ERROR', payload: error.message } );
 					isSubscribed && setTransactionError( error.message );
-					isSubscribed && setFormReady();
 				} );
 		}
 
@@ -495,10 +489,6 @@ function StripePayButton( { disabled, store, stripe, stripeConfiguration } ) {
 						} )
 						.catch( ( error ) => {
 							setTransactionError( error.message );
-							setFormReady();
-							onEvent( { type: 'STRIPE_TRANSACTION_ERROR', payload: error.message } );
-							debug( 'showing error for submit', error.message );
-							showErrorMessage( error.message );
 						} );
 				}
 			} }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

I realized that the error handling using the new processor functions duplicates some error handling. 

When an error happens, the event handler will save the error message in `useTransactionStatus`, and then a `useEffect` in each payment method's component will display the error, change the form status back to "ready", and trigger analytics. Prior to this PR, we were also doing those things manually in the event handler. This PR changes the reliance entirely to the `useEffect`.

What's exciting about this is that the process can be generalized so that we will be able to move all of those `useEffect`s to a custom hook (maybe `useHandleTransactionStatus`) in `CheckoutProvider` that handles all payment methods. 

#### Testing instructions

We will need to test causing an error in each of these payment methods (apple pay, credit card, existing card, and full credits) to be sure that:

1. The error message is displayed
2. The analytics are recorded.
3. The form is re-enabled.