### PR TITLE
composite-checkout: Automate transaction status handling

### DIFF
--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -249,28 +249,6 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 				);
 			}
 
-			// TODO: remove this when we migrate free purchases to processor function
-			case 'FREE_PURCHASE_TRANSACTION_ERROR': {
-				reduxDispatch(
-					recordTracksEvent( 'calypso_checkout_payment_error', {
-						error_code: null,
-						reason: String( action.payload ),
-					} )
-				);
-				reduxDispatch(
-					recordTracksEvent( 'calypso_checkout_composite_payment_error', {
-						error_code: null,
-						payment_method: 'WPCOM_Billing_WPCOM',
-						reason: String( action.payload ),
-					} )
-				);
-				return reduxDispatch(
-					recordTracksEvent( 'calypso_checkout_composite_free_purchase_transaction_error', {
-						error_message: String( action.payload ),
-					} )
-				);
-			}
-
 			case 'PAYPAL_TRANSACTION_BEGIN': {
 				reduxDispatch( recordTracksEvent( 'calypso_checkout_form_redirect', {} ) );
 				reduxDispatch(

--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -212,21 +212,22 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 				reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_payment_error', {
 						error_code: null,
-						reason: String( action.payload ),
+						reason: String( action.payload.message ),
 					} )
 				);
-				// FIXME: how do we get the payment method id?
-				const payment_method = translateCheckoutPaymentMethodToWpcomPaymentMethod( id );
+				const payment_method = translateCheckoutPaymentMethodToWpcomPaymentMethod(
+					action.payload.paymentMethodId
+				);
 				reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_composite_payment_error', {
 						error_code: null,
 						payment_method,
-						reason: String( action.payload ),
+						reason: String( action.payload.message ),
 					} )
 				);
 				return reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_composite_stripe_transaction_error', {
-						error_message: String( action.payload ),
+						error_message: String( action.payload.message ),
 					} )
 				);
 			}

--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -208,17 +208,19 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 				);
 			}
 
-			case 'STRIPE_TRANSACTION_ERROR': {
+			case 'TRANSACTION_ERROR': {
 				reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_payment_error', {
 						error_code: null,
 						reason: String( action.payload ),
 					} )
 				);
+				// FIXME: how do we get the payment method id?
+				const payment_method = translateCheckoutPaymentMethodToWpcomPaymentMethod( id );
 				reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_composite_payment_error', {
 						error_code: null,
-						payment_method: 'WPCOM_Billing_Stripe_Payment_Method',
+						payment_method,
 						reason: String( action.payload ),
 					} )
 				);
@@ -247,6 +249,7 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 				);
 			}
 
+			// TODO: remove this when we migrate free purchases to processor function
 			case 'FREE_PURCHASE_TRANSACTION_ERROR': {
 				reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_payment_error', {
@@ -287,27 +290,6 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 				);
 			}
 
-			case 'PAYPAL_TRANSACTION_ERROR': {
-				reduxDispatch(
-					recordTracksEvent( 'calypso_checkout_payment_error', {
-						error_code: null,
-						reason: String( action.payload ),
-					} )
-				);
-				reduxDispatch(
-					recordTracksEvent( 'calypso_checkout_composite_payment_error', {
-						error_code: null,
-						payment_method: 'WPCOM_Billing_PayPal_Express',
-						reason: String( action.payload ),
-					} )
-				);
-				return reduxDispatch(
-					recordTracksEvent( 'calypso_checkout_composite_paypal_transaction_error', {
-						error_message: String( action.payload ),
-					} )
-				);
-			}
-
 			case 'FULL_CREDITS_TRANSACTION_BEGIN': {
 				reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_form_submit', {
@@ -326,27 +308,6 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 				);
 			}
 
-			case 'FULL_CREDITS_TRANSACTION_ERROR': {
-				reduxDispatch(
-					recordTracksEvent( 'calypso_checkout_payment_error', {
-						error_code: null,
-						reason: String( action.payload ),
-					} )
-				);
-				reduxDispatch(
-					recordTracksEvent( 'calypso_checkout_composite_payment_error', {
-						error_code: null,
-						payment_method: 'WPCOM_Billing_WPCOM',
-						reason: String( action.payload ),
-					} )
-				);
-				return reduxDispatch(
-					recordTracksEvent( 'calypso_checkout_composite_full_credits_error', {
-						error_message: String( action.payload ),
-					} )
-				);
-			}
-
 			case 'EXISTING_CARD_TRANSACTION_BEGIN': {
 				reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_form_submit', {
@@ -362,27 +323,6 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 				);
 				return reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_composite_existing_card_submit_clicked', {} )
-				);
-			}
-
-			case 'EXISTING_CARD_TRANSACTION_ERROR': {
-				reduxDispatch(
-					recordTracksEvent( 'calypso_checkout_payment_error', {
-						error_code: null,
-						reason: String( action.payload ),
-					} )
-				);
-				reduxDispatch(
-					recordTracksEvent( 'calypso_checkout_composite_payment_error', {
-						error_code: null,
-						payment_method: 'WPCOM_Billing_MoneyPress_Stored',
-						reason: String( action.payload ),
-					} )
-				);
-				return reduxDispatch(
-					recordTracksEvent( 'calypso_checkout_composite_existing_card_error', {
-						error_message: String( action.payload ),
-					} )
 				);
 			}
 
@@ -411,26 +351,6 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 						is_loading_error: true,
 					} )
 				);
-
-			case 'APPLE_PAY_TRANSACTION_ERROR': {
-				reduxDispatch(
-					recordTracksEvent( 'calypso_checkout_payment_error', {
-						error_code: null,
-						reason: String( action.payload ),
-					} )
-				);
-				reduxDispatch(
-					recordTracksEvent( 'calypso_checkout_composite_payment_error', {
-						error_code: null,
-						reason: String( action.payload ),
-					} )
-				);
-				return reduxDispatch(
-					recordTracksEvent( 'calypso_checkout_composite_apple_pay_error', {
-						error_message: String( action.payload ),
-					} )
-				);
-			}
 
 			case 'VALIDATE_DOMAIN_CONTACT_INFO': {
 				// TODO: Decide what to do here

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
@@ -268,7 +268,7 @@ describe( 'CompositeCheckout', () => {
 			renderResult = render( <MyCheckout />, container );
 		} );
 		const { getByText } = renderResult;
-		expect( getByText( 'Paypal' ) ).toBeInTheDocument();
+		expect( getByText( 'PayPal' ) ).toBeInTheDocument();
 	} );
 
 	it( 'does not render the full credits payment method option when no credits are available', async () => {
@@ -297,7 +297,7 @@ describe( 'CompositeCheckout', () => {
 			renderResult = render( <MyCheckout cartChanges={ cartChanges } />, container );
 		} );
 		const { getByText } = renderResult;
-		expect( getByText( 'Paypal' ) ).toBeInTheDocument();
+		expect( getByText( 'PayPal' ) ).toBeInTheDocument();
 	} );
 
 	it( 'renders the full credits payment method option when full credits are available', async () => {
@@ -317,7 +317,7 @@ describe( 'CompositeCheckout', () => {
 			renderResult = render( <MyCheckout cartChanges={ cartChanges } />, container );
 		} );
 		const { getByText } = renderResult;
-		expect( getByText( 'Paypal' ) ).toBeInTheDocument();
+		expect( getByText( 'PayPal' ) ).toBeInTheDocument();
 	} );
 
 	it( 'does not render the free payment method option when the purchase is not free', async () => {
@@ -336,7 +336,7 @@ describe( 'CompositeCheckout', () => {
 			renderResult = render( <MyCheckout cartChanges={ cartChanges } />, container );
 		} );
 		const { queryByText } = renderResult;
-		expect( queryByText( 'Paypal' ) ).not.toBeInTheDocument();
+		expect( queryByText( 'PayPal' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'does not render the full credits payment method option when full credits are available but the purchase is free', async () => {

--- a/client/my-sites/checkout/composite-checkout/use-create-payment-methods.js
+++ b/client/my-sites/checkout/composite-checkout/use-create-payment-methods.js
@@ -59,9 +59,6 @@ function useCreateStripe( {
 				: null,
 		[ shouldLoadStripeMethod, stripePaymentMethodStore, stripe, stripeConfiguration ]
 	);
-	if ( stripeMethod ) {
-		stripeMethod.id = 'card';
-	}
 	return stripeMethod;
 }
 

--- a/packages/composite-checkout/src/components/checkout-provider.js
+++ b/packages/composite-checkout/src/components/checkout-provider.js
@@ -46,7 +46,6 @@ export const CheckoutProvider = ( props ) => {
 		isValidating,
 		children,
 	} = props;
-	const defaultRedirect = useCallback( ( url ) => ( window.location = url ), [] );
 	const [ paymentMethodId, setPaymentMethodId ] = useState(
 		paymentMethods?.length ? paymentMethods[ 0 ].id : null
 	);
@@ -69,7 +68,6 @@ export const CheckoutProvider = ( props ) => {
 			onPaymentComplete( { paymentMethodId } );
 		}
 	}, [ formStatus, onPaymentComplete, paymentMethodId ] );
-	useTransactionStatusHandler( redirectToUrl || defaultRedirect );
 
 	// Create the registry automatically if it's not a prop
 	const registryRef = useRef( registry );
@@ -116,7 +114,10 @@ export const CheckoutProvider = ( props ) => {
 				<RegistryProvider value={ registryRef.current }>
 					<LocalizeProvider locale={ locale }>
 						<LineItemsProvider items={ items } total={ total }>
-							<CheckoutContext.Provider value={ value }>{ children }</CheckoutContext.Provider>
+							<CheckoutContext.Provider value={ value }>
+								<TransactionStatusHandler redirectToUrl={ redirectToUrl } />
+								{ children }
+							</CheckoutContext.Provider>
 						</LineItemsProvider>
 					</LocalizeProvider>
 				</RegistryProvider>
@@ -243,4 +244,10 @@ function useTransactionStatusHandler( redirectToUrl ) {
 		redirectToUrl,
 		localize,
 	] );
+}
+
+function TransactionStatusHandler( { redirectToUrl } ) {
+	const defaultRedirect = useCallback( ( url ) => ( window.location = url ), [] );
+	useTransactionStatusHandler( redirectToUrl || defaultRedirect );
+	return null;
 }

--- a/packages/composite-checkout/src/components/checkout-provider.js
+++ b/packages/composite-checkout/src/components/checkout-provider.js
@@ -209,6 +209,7 @@ function useTransactionStatusHandler( redirectToUrl ) {
 		transactionRedirectUrl,
 		transactionError,
 		resetTransaction,
+		setTransactionError,
 	} = useTransactionStatus();
 	const onEvent = useEvents();
 	const [ paymentMethodId ] = usePaymentMethodId();
@@ -235,7 +236,16 @@ function useTransactionStatusHandler( redirectToUrl ) {
 			setFormComplete();
 		}
 		if ( transactionStatus === 'redirecting' ) {
-			debug( 'redirecting' );
+			if ( ! transactionRedirectUrl ) {
+				debug( 'tried to redirect but there was no redirect url' );
+				setTransactionError(
+					localize(
+						'An error occurred while redirecting to the payment partner. Please try again or contact support.'
+					)
+				);
+				return;
+			}
+			debug( 'redirecting to', transactionRedirectUrl );
 			showInfoMessage( localize( 'Redirecting to payment partner…' ) );
 			redirectToUrl( transactionRedirectUrl );
 		}
@@ -243,6 +253,7 @@ function useTransactionStatusHandler( redirectToUrl ) {
 		paymentMethodId,
 		onEvent,
 		resetTransaction,
+		setTransactionError,
 		setFormReady,
 		setFormComplete,
 		setFormSubmitting,

--- a/packages/composite-checkout/src/components/checkout-provider.js
+++ b/packages/composite-checkout/src/components/checkout-provider.js
@@ -204,7 +204,7 @@ export function useMessages() {
 function useTransactionStatusHandler( redirectToUrl ) {
 	const localize = useLocalize();
 	const { showErrorMessage, showInfoMessage } = useMessages();
-	const { setFormReady, setFormComplete } = useFormStatus();
+	const { setFormReady, setFormComplete, setFormSubmitting } = useFormStatus();
 	const {
 		transactionStatus,
 		transactionRedirectUrl,
@@ -215,6 +215,10 @@ function useTransactionStatusHandler( redirectToUrl ) {
 	const [ paymentMethodId ] = usePaymentMethodId();
 
 	useEffect( () => {
+		if ( transactionStatus === 'pending' ) {
+			debug( 'transaction is beginning' );
+			setFormSubmitting();
+		}
 		if ( transactionStatus === 'error' ) {
 			debug( 'showing error', transactionError );
 			showErrorMessage(
@@ -242,6 +246,7 @@ function useTransactionStatusHandler( redirectToUrl ) {
 		resetTransaction,
 		setFormReady,
 		setFormComplete,
+		setFormSubmitting,
 		showErrorMessage,
 		showInfoMessage,
 		transactionStatus,

--- a/packages/composite-checkout/src/components/checkout-provider.js
+++ b/packages/composite-checkout/src/components/checkout-provider.js
@@ -11,7 +11,7 @@ import debugFactory from 'debug';
  */
 import CheckoutContext from '../lib/checkout-context';
 import CheckoutErrorBoundary from './checkout-error-boundary';
-import { LocalizeProvider } from '../lib/localize';
+import { LocalizeProvider, useLocalize } from '../lib/localize';
 import { LineItemsProvider } from '../lib/line-items';
 import { RegistryProvider, defaultRegistry } from '../lib/registry';
 import { useFormStatusManager, useFormStatus } from '../lib/form-status';
@@ -23,7 +23,6 @@ import {
 	validateLineItems,
 	validatePaymentMethods,
 } from '../lib/validation';
-import { useLocalize } from '../localize';
 import { usePaymentMethodId } from '../lib/payment-methods';
 
 const debug = debugFactory( 'composite-checkout:checkout-provider' );

--- a/packages/composite-checkout/src/components/checkout-provider.js
+++ b/packages/composite-checkout/src/components/checkout-provider.js
@@ -24,6 +24,7 @@ import {
 	validatePaymentMethods,
 } from '../lib/validation';
 import { useLocalize } from '../localize';
+import { usePaymentMethodId } from '../lib/payment-methods';
 
 const debug = debugFactory( 'composite-checkout:checkout-provider' );
 
@@ -211,6 +212,7 @@ function useTransactionStatusHandler( redirectToUrl ) {
 		resetTransaction,
 	} = useTransactionStatus();
 	const onEvent = useEvents();
+	const [ paymentMethodId ] = usePaymentMethodId();
 
 	useEffect( () => {
 		if ( transactionStatus === 'error' ) {
@@ -218,7 +220,10 @@ function useTransactionStatusHandler( redirectToUrl ) {
 			showErrorMessage(
 				transactionError || localize( 'An error occurred during the transaction' )
 			);
-			onEvent( { type: 'TRANSACTION_ERROR', payload: transactionError || '' } );
+			onEvent( {
+				type: 'TRANSACTION_ERROR',
+				payload: { message: transactionError || '', paymentMethodId },
+			} );
 			resetTransaction();
 			setFormReady();
 		}
@@ -232,6 +237,7 @@ function useTransactionStatusHandler( redirectToUrl ) {
 			redirectToUrl( transactionRedirectUrl );
 		}
 	}, [
+		paymentMethodId,
 		onEvent,
 		resetTransaction,
 		setFormReady,

--- a/packages/composite-checkout/src/lib/payment-methods/apple-pay.js
+++ b/packages/composite-checkout/src/lib/payment-methods/apple-pay.js
@@ -11,7 +11,6 @@ import {
 	useTransactionStatus,
 	usePaymentProcessor,
 	useLineItems,
-	useMessages,
 	useEvents,
 } from '../../public-api';
 import { useLocalize } from '../../lib/localize';
@@ -50,15 +49,8 @@ export function ApplePaySubmitButton( { disabled, stripe, stripeConfiguration } 
 	const localize = useLocalize();
 	const paymentRequestOptions = usePaymentRequestOptions( stripeConfiguration );
 	const [ items, total ] = useLineItems();
-	const { setFormSubmitting, setFormReady, setFormComplete } = useFormStatus();
-	const { showErrorMessage } = useMessages();
-	const {
-		transactionStatus,
-		transactionError,
-		resetTransaction,
-		setTransactionError,
-		setTransactionComplete,
-	} = useTransactionStatus();
+	const { setFormSubmitting } = useFormStatus();
+	const { setTransactionError, setTransactionComplete } = useTransactionStatus();
 	const onEvent = useEvents();
 	const submitTransaction = usePaymentProcessor( 'apple-pay' );
 	const onSubmit = useCallback(
@@ -99,31 +91,6 @@ export function ApplePaySubmitButton( { disabled, stripe, stripeConfiguration } 
 		stripe,
 	} );
 	debug( 'apple-pay button isLoading', isLoading );
-
-	useEffect( () => {
-		if ( transactionStatus === 'error' ) {
-			debug( 'showing error', transactionError );
-			showErrorMessage(
-				transactionError || localize( 'An error occurred during the transaction' )
-			);
-			onEvent( { type: 'APPLE_PAY_TRANSACTION_ERROR', payload: transactionError || '' } );
-			resetTransaction();
-			setFormReady();
-		}
-		if ( transactionStatus === 'complete' ) {
-			debug( 'marking complete' );
-			setFormComplete();
-		}
-	}, [
-		onEvent,
-		resetTransaction,
-		setFormReady,
-		setFormComplete,
-		showErrorMessage,
-		transactionStatus,
-		transactionError,
-		localize,
-	] );
 
 	if ( ! isLoading && ! canMakePayment ) {
 		onEvent( { type: 'APPLE_PAY_LOADING_ERROR', payload: 'This payment type is not supported' } );

--- a/packages/composite-checkout/src/lib/payment-methods/apple-pay.js
+++ b/packages/composite-checkout/src/lib/payment-methods/apple-pay.js
@@ -16,7 +16,6 @@ import {
 import { useLocalize } from '../../lib/localize';
 import PaymentRequestButton from '../../components/payment-request-button';
 import { PaymentMethodLogos } from '../styled-components/payment-method-logos';
-import { useFormStatus } from '../form-status';
 
 const debug = debugFactory( 'composite-checkout:apple-pay-payment-method' );
 
@@ -49,14 +48,17 @@ export function ApplePaySubmitButton( { disabled, stripe, stripeConfiguration } 
 	const localize = useLocalize();
 	const paymentRequestOptions = usePaymentRequestOptions( stripeConfiguration );
 	const [ items, total ] = useLineItems();
-	const { setFormSubmitting } = useFormStatus();
-	const { setTransactionError, setTransactionComplete } = useTransactionStatus();
+	const {
+		setTransactionError,
+		setTransactionComplete,
+		setTransactionPending,
+	} = useTransactionStatus();
 	const onEvent = useEvents();
 	const submitTransaction = usePaymentProcessor( 'apple-pay' );
 	const onSubmit = useCallback(
 		( { name, paymentMethodToken } ) => {
 			debug( 'submitting stripe payment with key', paymentMethodToken );
-			setFormSubmitting();
+			setTransactionPending();
 			onEvent( { type: 'APPLE_PAY_TRANSACTION_BEGIN' } );
 			submitTransaction( {
 				stripe,
@@ -77,12 +79,12 @@ export function ApplePaySubmitButton( { disabled, stripe, stripeConfiguration } 
 			submitTransaction,
 			setTransactionComplete,
 			setTransactionError,
+			setTransactionPending,
 			onEvent,
 			items,
 			total,
 			stripe,
 			stripeConfiguration,
-			setFormSubmitting,
 		]
 	);
 	const { paymentRequest, canMakePayment, isLoading } = useStripePaymentRequest( {

--- a/packages/composite-checkout/src/lib/payment-methods/existing-credit-card.js
+++ b/packages/composite-checkout/src/lib/payment-methods/existing-credit-card.js
@@ -119,7 +119,6 @@ function ExistingCardPayButton( {
 	const { showErrorMessage, showInfoMessage } = useMessages();
 	const {
 		transactionStatus,
-		transactionError,
 		transactionLastResponse,
 		setTransactionComplete,
 		resetTransaction,
@@ -128,37 +127,8 @@ function ExistingCardPayButton( {
 		setTransactionError,
 	} = useTransactionStatus();
 	const submitTransaction = usePaymentProcessor( 'existing-card' );
-	const { formStatus, setFormReady, setFormComplete, setFormSubmitting } = useFormStatus();
+	const { formStatus, setFormReady, setFormSubmitting } = useFormStatus();
 	const onEvent = useEvents();
-
-	useEffect( () => {
-		if ( transactionStatus === 'error' ) {
-			showErrorMessage(
-				transactionError || localize( 'An error occurred during the transaction' )
-			);
-			onEvent( { type: 'EXISTING_CARD_TRANSACTION_ERROR', payload: transactionError || '' } );
-			setFormReady();
-		}
-		if ( transactionStatus === 'complete' ) {
-			debug( 'existing card transaction is complete' );
-			setFormComplete();
-		}
-		if ( transactionStatus === 'redirect' ) {
-			debug( 'redirecting' );
-			showInfoMessage( localize( 'Redirecting...' ) );
-			window.location = transactionLastResponse.redirect_url;
-		}
-	}, [
-		onEvent,
-		transactionLastResponse,
-		setFormReady,
-		setFormComplete,
-		showErrorMessage,
-		showInfoMessage,
-		transactionStatus,
-		transactionError,
-		localize,
-	] );
 
 	useEffect( () => {
 		let isSubscribed = true;

--- a/packages/composite-checkout/src/lib/payment-methods/existing-credit-card.js
+++ b/packages/composite-checkout/src/lib/payment-methods/existing-credit-card.js
@@ -134,8 +134,9 @@ function ExistingCardPayButton( {
 	useEffect( () => {
 		let isSubscribed = true;
 
-		if ( transactionStatus === 'auth' ) {
+		if ( transactionStatus === 'authorizing' ) {
 			debug( 'showing auth' );
+			onEvent( { type: 'SHOW_MODAL_AUTHORIZATION' } );
 			showStripeModalAuth( {
 				stripeConfiguration,
 				response: transactionLastResponse,

--- a/packages/composite-checkout/src/lib/payment-methods/existing-credit-card.js
+++ b/packages/composite-checkout/src/lib/payment-methods/existing-credit-card.js
@@ -123,11 +123,12 @@ function ExistingCardPayButton( {
 		setTransactionComplete,
 		resetTransaction,
 		setTransactionRedirecting,
+		setTransactionPending,
 		setTransactionAuthorizing,
 		setTransactionError,
 	} = useTransactionStatus();
 	const submitTransaction = usePaymentProcessor( 'existing-card' );
-	const { formStatus, setFormReady, setFormSubmitting } = useFormStatus();
+	const { formStatus } = useFormStatus();
 	const onEvent = useEvents();
 
 	useEffect( () => {
@@ -154,7 +155,6 @@ function ExistingCardPayButton( {
 		resetTransaction,
 		setTransactionComplete,
 		setTransactionError,
-		setFormReady,
 		showInfoMessage,
 		showErrorMessage,
 		transactionStatus,
@@ -169,7 +169,7 @@ function ExistingCardPayButton( {
 			onClick={ () => {
 				debug( 'submitting existing card payment' );
 				onEvent( { type: 'EXISTING_CARD_TRANSACTION_BEGIN' } );
-				setFormSubmitting();
+				setTransactionPending();
 				submitTransaction( {
 					items,
 					total,

--- a/packages/composite-checkout/src/lib/payment-methods/existing-credit-card.js
+++ b/packages/composite-checkout/src/lib/payment-methods/existing-credit-card.js
@@ -216,7 +216,7 @@ function ExistingCardPayButton( {
 						}
 						if ( stripeResponse?.redirect_url ) {
 							debug( 'stripe transaction requires redirect' );
-							setTransactionRedirecting( stripeResponse );
+							setTransactionRedirecting( stripeResponse.redirect_url );
 							return;
 						}
 						debug( 'stripe transaction is successful' );

--- a/packages/composite-checkout/src/lib/payment-methods/free-purchase.js
+++ b/packages/composite-checkout/src/lib/payment-methods/free-purchase.js
@@ -1,15 +1,13 @@
 /**
  * External dependencies
  */
-import React, { useEffect } from 'react';
-import debugFactory from 'debug';
+import React from 'react';
 
 /**
  * Internal dependencies
  */
 import Button from '../../components/button';
 import {
-	useMessages,
 	useLineItems,
 	useEvents,
 	renderDisplayValueMarkdown,
@@ -18,8 +16,6 @@ import {
 } from '../../public-api';
 import { sprintf, useLocalize } from '../localize';
 import { useFormStatus } from '../form-status';
-
-const debug = debugFactory( 'composite-checkout:free-purchase-payment-method' );
 
 export function createFreePaymentMethod() {
 	return {
@@ -42,40 +38,11 @@ function FreePurchaseLabel() {
 }
 
 function FreePurchaseSubmitButton( { disabled } ) {
-	const localize = useLocalize();
 	const [ items, total ] = useLineItems();
-	const {
-		transactionStatus,
-		transactionError,
-		setTransactionComplete,
-		setTransactionError,
-	} = useTransactionStatus();
-	const { showErrorMessage } = useMessages();
-	const { formStatus, setFormReady, setFormComplete, setFormSubmitting } = useFormStatus();
+	const { setTransactionComplete, setTransactionError } = useTransactionStatus();
+	const { formStatus, setFormSubmitting } = useFormStatus();
 	const onEvent = useEvents();
 	const submitTransaction = usePaymentProcessor( 'free-purchase' );
-
-	useEffect( () => {
-		if ( transactionStatus === 'error' ) {
-			onEvent( { type: 'FREE_PURCHASE_TRANSACTION_ERROR', payload: transactionError || '' } );
-			showErrorMessage(
-				transactionError || localize( 'An error occurred during the transaction' )
-			);
-			setFormReady();
-		}
-		if ( transactionStatus === 'complete' ) {
-			debug( 'free transaction is complete' );
-			setFormComplete();
-		}
-	}, [
-		onEvent,
-		setFormReady,
-		setFormComplete,
-		showErrorMessage,
-		transactionStatus,
-		transactionError,
-		localize,
-	] );
 
 	const onClick = () => {
 		setFormSubmitting();

--- a/packages/composite-checkout/src/lib/payment-methods/free-purchase.js
+++ b/packages/composite-checkout/src/lib/payment-methods/free-purchase.js
@@ -39,13 +39,17 @@ function FreePurchaseLabel() {
 
 function FreePurchaseSubmitButton( { disabled } ) {
 	const [ items, total ] = useLineItems();
-	const { setTransactionComplete, setTransactionError } = useTransactionStatus();
-	const { formStatus, setFormSubmitting } = useFormStatus();
+	const {
+		setTransactionComplete,
+		setTransactionError,
+		setTransactionPending,
+	} = useTransactionStatus();
+	const { formStatus } = useFormStatus();
 	const onEvent = useEvents();
 	const submitTransaction = usePaymentProcessor( 'free-purchase' );
 
 	const onClick = () => {
-		setFormSubmitting();
+		setTransactionPending();
 		onEvent( { type: 'FREE_TRANSACTION_BEGIN' } );
 		submitTransaction( {
 			items,

--- a/packages/composite-checkout/src/lib/payment-methods/full-credits.js
+++ b/packages/composite-checkout/src/lib/payment-methods/full-credits.js
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useEffect } from 'react';
-import debugFactory from 'debug';
+import React from 'react';
 
 /**
  * Internal dependencies
@@ -11,15 +10,12 @@ import Button from '../../components/button';
 import {
 	useTransactionStatus,
 	usePaymentProcessor,
-	useMessages,
 	useLineItems,
 	useEvents,
 	renderDisplayValueMarkdown,
 } from '../../public-api';
 import { sprintf, useLocalize } from '../localize';
 import { useFormStatus } from '../form-status';
-
-const debug = debugFactory( 'composite-checkout:full-credits-payment-method' );
 
 export function createFullCreditsMethod() {
 	return {
@@ -43,40 +39,11 @@ function FullCreditsLabel() {
 }
 
 function FullCreditsSubmitButton( { disabled } ) {
-	const localize = useLocalize();
 	const [ items, total ] = useLineItems();
-	const {
-		transactionStatus,
-		transactionError,
-		setTransactionComplete,
-		setTransactionError,
-	} = useTransactionStatus();
-	const { showErrorMessage } = useMessages();
-	const { formStatus, setFormReady, setFormComplete, setFormSubmitting } = useFormStatus();
+	const { setTransactionComplete, setTransactionError } = useTransactionStatus();
+	const { formStatus, setFormSubmitting } = useFormStatus();
 	const onEvent = useEvents();
 	const submitTransaction = usePaymentProcessor( 'full-credits' );
-
-	useEffect( () => {
-		if ( transactionStatus === 'error' ) {
-			onEvent( { type: 'FULL_CREDITS_TRANSACTION_ERROR', payload: transactionError || '' } );
-			showErrorMessage(
-				transactionError || localize( 'An error occurred during the transaction' )
-			);
-			setFormReady();
-		}
-		if ( transactionStatus === 'complete' ) {
-			debug( 'full credits transaction is complete' );
-			setFormComplete();
-		}
-	}, [
-		onEvent,
-		setFormReady,
-		setFormComplete,
-		showErrorMessage,
-		transactionStatus,
-		transactionError,
-		localize,
-	] );
 
 	const onClick = () => {
 		setFormSubmitting();

--- a/packages/composite-checkout/src/lib/payment-methods/full-credits.js
+++ b/packages/composite-checkout/src/lib/payment-methods/full-credits.js
@@ -40,13 +40,17 @@ function FullCreditsLabel() {
 
 function FullCreditsSubmitButton( { disabled } ) {
 	const [ items, total ] = useLineItems();
-	const { setTransactionComplete, setTransactionError } = useTransactionStatus();
-	const { formStatus, setFormSubmitting } = useFormStatus();
+	const {
+		setTransactionComplete,
+		setTransactionError,
+		setTransactionPending,
+	} = useTransactionStatus();
+	const { formStatus } = useFormStatus();
 	const onEvent = useEvents();
 	const submitTransaction = usePaymentProcessor( 'full-credits' );
 
 	const onClick = () => {
-		setFormSubmitting();
+		setTransactionPending();
 		onEvent( { type: 'FULL_CREDITS_TRANSACTION_BEGIN' } );
 		submitTransaction( {
 			items,

--- a/packages/composite-checkout/src/lib/payment-methods/paypal.js
+++ b/packages/composite-checkout/src/lib/payment-methods/paypal.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useEffect } from 'react';
+import React from 'react';
 import styled from '@emotion/styled';
 import debugFactory from 'debug';
 
@@ -11,7 +11,6 @@ import debugFactory from 'debug';
 import Button from '../../components/button';
 import { useLocalize } from '../../lib/localize';
 import {
-	useMessages,
 	useEvents,
 	usePaymentProcessor,
 	useTransactionStatus,
@@ -47,8 +46,7 @@ export function PaypalLabel() {
 }
 
 export function PaypalSubmitButton( { disabled } ) {
-	useTransactionStatusHandler();
-	const { formStatus, setFormSubmitting } = useFormStatus();
+	const { formStatus } = useFormStatus();
 	const onEvent = useEvents();
 	const { setTransactionRedirecting, setTransactionError } = useTransactionStatus();
 	const submitTransaction = usePaymentProcessor( 'paypal' );
@@ -56,7 +54,6 @@ export function PaypalSubmitButton( { disabled } ) {
 
 	const onClick = () => {
 		onEvent( { type: 'PAYPAL_TRANSACTION_BEGIN' } );
-		setFormSubmitting();
 		submitTransaction( {
 			items,
 		} )
@@ -90,44 +87,6 @@ function PayPalButtonContents( { formStatus } ) {
 		return <ButtonPayPalIcon />;
 	}
 	return localize( 'Please wait…' );
-}
-
-function useTransactionStatusHandler() {
-	const localize = useLocalize();
-	const { showErrorMessage } = useMessages();
-	const { transactionStatus, transactionError, transactionLastResponse } = useTransactionStatus();
-	const { setFormReady, setFormSubmitting } = useFormStatus();
-	const onEvent = useEvents();
-
-	useEffect( () => {
-		if ( transactionStatus === 'redirecting' ) {
-			debug( 'redirecting to paypal url', transactionLastResponse );
-			// TODO: should this redirect go through the host page?
-			window.location.href = transactionLastResponse;
-			return;
-		}
-		if ( transactionStatus === 'error' ) {
-			setFormReady();
-			onEvent( { type: 'PAYPAL_TRANSACTION_ERROR', payload: transactionError || '' } );
-			showErrorMessage(
-				transactionError || localize( 'An error occurred during the transaction' )
-			);
-			return;
-		}
-		if ( transactionStatus === 'submitting' ) {
-			setFormSubmitting();
-			return;
-		}
-	}, [
-		onEvent,
-		localize,
-		showErrorMessage,
-		transactionStatus,
-		transactionError,
-		transactionLastResponse,
-		setFormReady,
-		setFormSubmitting,
-	] );
 }
 
 const ButtonPayPalIcon = styled( PaypalLogo )`

--- a/packages/composite-checkout/src/lib/payment-methods/paypal.js
+++ b/packages/composite-checkout/src/lib/payment-methods/paypal.js
@@ -48,12 +48,17 @@ export function PaypalLabel() {
 export function PaypalSubmitButton( { disabled } ) {
 	const { formStatus } = useFormStatus();
 	const onEvent = useEvents();
-	const { setTransactionRedirecting, setTransactionError } = useTransactionStatus();
+	const {
+		setTransactionPending,
+		setTransactionRedirecting,
+		setTransactionError,
+	} = useTransactionStatus();
 	const submitTransaction = usePaymentProcessor( 'paypal' );
 	const [ items ] = useLineItems();
 
 	const onClick = () => {
 		onEvent( { type: 'PAYPAL_TRANSACTION_BEGIN' } );
+		setTransactionPending();
 		submitTransaction( {
 			items,
 		} )

--- a/packages/composite-checkout/src/lib/payment-methods/paypal.js
+++ b/packages/composite-checkout/src/lib/payment-methods/paypal.js
@@ -37,7 +37,7 @@ export function PaypalLabel() {
 
 	return (
 		<React.Fragment>
-			<span>{ localize( 'Paypal' ) }</span>
+			<span>{ localize( 'PayPal' ) }</span>
 			<PaymentMethodLogos className="paypal__logo payment-logos">
 				<PaypalLogo />
 			</PaymentMethodLogos>
@@ -55,6 +55,7 @@ export function PaypalSubmitButton( { disabled } ) {
 	} = useTransactionStatus();
 	const submitTransaction = usePaymentProcessor( 'paypal' );
 	const [ items ] = useLineItems();
+	const localize = useLocalize();
 
 	const onClick = () => {
 		onEvent( { type: 'PAYPAL_TRANSACTION_BEGIN' } );
@@ -63,6 +64,14 @@ export function PaypalSubmitButton( { disabled } ) {
 			items,
 		} )
 			.then( ( response ) => {
+				if ( ! response ) {
+					setTransactionError(
+						localize(
+							'An error occurred while redirecting to PayPal. Please try again or contact support.'
+						)
+					);
+					return;
+				}
 				setTransactionRedirecting( response );
 			} )
 			.catch( ( error ) => {
@@ -100,7 +109,7 @@ const ButtonPayPalIcon = styled( PaypalLogo )`
 
 function PaypalSummary() {
 	const localize = useLocalize();
-	return localize( 'Paypal' );
+	return localize( 'PayPal' );
 }
 
 function PaypalLogo( { className } ) {

--- a/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
@@ -482,7 +482,7 @@ function StripePayButton( { disabled, store, stripe, stripeConfiguration } ) {
 							}
 							if ( stripeResponse?.redirect_url ) {
 								debug( 'stripe transaction requires redirect' );
-								setTransactionRedirecting( stripeResponse );
+								setTransactionRedirecting( stripeResponse.redirect_url );
 								return;
 							}
 							debug( 'stripe transaction is successful' );

--- a/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
@@ -378,7 +378,7 @@ function StripePayButton( { disabled, store, stripe, stripeConfiguration } ) {
 	const [ items, total ] = useLineItems();
 	const { showErrorMessage, showInfoMessage } = useMessages();
 	const cardholderName = useSelect( ( select ) => select( 'stripe' ).getCardholderName() );
-	const { formStatus, setFormReady, setFormSubmitting } = useFormStatus();
+	const { formStatus } = useFormStatus();
 	const {
 		transactionStatus,
 		transactionLastResponse,
@@ -387,6 +387,7 @@ function StripePayButton( { disabled, store, stripe, stripeConfiguration } ) {
 		setTransactionAuthorizing,
 		setTransactionRedirecting,
 		setTransactionError,
+		setTransactionPending,
 	} = useTransactionStatus();
 	const submitTransaction = usePaymentProcessor( 'card' );
 	const onEvent = useEvents();
@@ -415,7 +416,6 @@ function StripePayButton( { disabled, store, stripe, stripeConfiguration } ) {
 		onEvent,
 		setTransactionComplete,
 		resetTransaction,
-		setFormReady,
 		showInfoMessage,
 		showErrorMessage,
 		transactionStatus,
@@ -431,7 +431,7 @@ function StripePayButton( { disabled, store, stripe, stripeConfiguration } ) {
 			onClick={ () => {
 				if ( isCreditCardFormValid( store ) ) {
 					debug( 'submitting stripe payment' );
-					setFormSubmitting();
+					setTransactionPending();
 					onEvent( { type: 'STRIPE_TRANSACTION_BEGIN' } );
 					submitTransaction( {
 						stripe,

--- a/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
@@ -378,11 +378,10 @@ function StripePayButton( { disabled, store, stripe, stripeConfiguration } ) {
 	const [ items, total ] = useLineItems();
 	const { showErrorMessage, showInfoMessage } = useMessages();
 	const cardholderName = useSelect( ( select ) => select( 'stripe' ).getCardholderName() );
-	const { formStatus, setFormReady, setFormComplete, setFormSubmitting } = useFormStatus();
+	const { formStatus, setFormReady, setFormSubmitting } = useFormStatus();
 	const {
 		transactionStatus,
 		transactionLastResponse,
-		transactionError,
 		resetTransaction,
 		setTransactionComplete,
 		setTransactionAuthorizing,
@@ -391,39 +390,6 @@ function StripePayButton( { disabled, store, stripe, stripeConfiguration } ) {
 	} = useTransactionStatus();
 	const submitTransaction = usePaymentProcessor( 'card' );
 	const onEvent = useEvents();
-
-	useEffect( () => {
-		if ( transactionStatus === 'error' ) {
-			debug( 'showing error', transactionError );
-			showErrorMessage(
-				transactionError || localize( 'An error occurred during the transaction' )
-			);
-			onEvent( { type: 'STRIPE_TRANSACTION_ERROR', payload: transactionError || '' } );
-			resetTransaction();
-			setFormReady();
-		}
-		if ( transactionStatus === 'complete' ) {
-			debug( 'marking complete' );
-			setFormComplete();
-		}
-		if ( transactionStatus === 'redirecting' ) {
-			debug( 'redirecting' );
-			showInfoMessage( localize( 'Redirecting...' ) );
-			// TODO: make this redirect able to be mocked
-			window.location = transactionLastResponse.redirect_url;
-		}
-	}, [
-		onEvent,
-		resetTransaction,
-		setFormReady,
-		setFormComplete,
-		showErrorMessage,
-		showInfoMessage,
-		transactionStatus,
-		transactionError,
-		transactionLastResponse,
-		localize,
-	] );
 
 	useEffect( () => {
 		let isSubscribed = true;

--- a/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
@@ -129,7 +129,7 @@ export function createStripePaymentMethodStore() {
 
 export function createStripeMethod( { store, stripe, stripeConfiguration } ) {
 	return {
-		id: 'stripe-card',
+		id: 'card',
 		label: <CreditCardLabel />,
 		activeContent: (
 			<StripeCreditCardFields stripe={ stripe } stripeConfiguration={ stripeConfiguration } />

--- a/packages/composite-checkout/src/lib/transaction-status.js
+++ b/packages/composite-checkout/src/lib/transaction-status.js
@@ -50,13 +50,19 @@ export function useTransactionStatusManager() {
 		[]
 	);
 
-	const { transactionStatus, transactionLastResponse, transactionError } = state;
+	const {
+		transactionStatus,
+		transactionLastResponse,
+		transactionError,
+		transactionRedirectUrl,
+	} = state;
 
 	return useMemo(
 		() => ( {
 			transactionStatus,
 			transactionError,
 			transactionLastResponse,
+			transactionRedirectUrl,
 			resetTransaction,
 			setTransactionError,
 			setTransactionComplete,
@@ -68,6 +74,7 @@ export function useTransactionStatusManager() {
 			transactionStatus,
 			transactionError,
 			transactionLastResponse,
+			transactionRedirectUrl,
 			resetTransaction,
 			setTransactionError,
 			setTransactionComplete,

--- a/packages/composite-checkout/src/lib/transaction-status.js
+++ b/packages/composite-checkout/src/lib/transaction-status.js
@@ -17,6 +17,7 @@ const initialState = {
 	transactionStatus: 'not-started', // string
 	transactionError: null, // string | null
 	transactionLastResponse: null, // object | null
+	transactionRedirectUrl: null, // string | null
 };
 
 export function useTransactionStatusManager() {
@@ -39,8 +40,8 @@ export function useTransactionStatusManager() {
 		[]
 	);
 	const setTransactionRedirecting = useCallback(
-		( response ) =>
-			dispatch( { type: 'STATUS_SET', payload: { status: 'redirecting', response } } ),
+		( url ) =>
+			dispatch( { type: 'STATUS_SET', payload: { status: 'redirecting', response: null, url } } ),
 		[]
 	);
 	const setTransactionAuthorizing = useCallback(
@@ -80,11 +81,12 @@ export function useTransactionStatusManager() {
 function transactionStatusReducer( state, action ) {
 	switch ( action.type ) {
 		case 'STATUS_SET': {
-			const { status, response, error } = action.payload;
+			const { status, response, error, url } = action.payload;
 			return {
 				...state,
 				transactionStatus: status,
 				transactionLastResponse: response,
+				transactionRedirectUrl: url,
 				transactionError: error,
 			};
 		}

--- a/packages/composite-checkout/test/checkout.js
+++ b/packages/composite-checkout/test/checkout.js
@@ -24,7 +24,6 @@ import {
 	CheckoutSteps,
 	useSelect,
 	useDispatch,
-	useFormStatus,
 	createRegistry,
 	useRegisterStore,
 	useIsStepComplete,
@@ -570,11 +569,10 @@ function createMockMethod() {
 }
 
 function MockSubmitButton( { disabled } ) {
-	const { setFormSubmitting } = useFormStatus();
-	const { setTransactionComplete } = useTransactionStatus();
+	const { setTransactionComplete, setTransactionPending } = useTransactionStatus();
 	const process = usePaymentProcessor( 'mock' );
 	const onClick = () => {
-		setFormSubmitting();
+		setTransactionPending();
 		process().then( ( result ) => setTransactionComplete( result ) );
 	};
 	return (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Each payment method in composite checkout uses the `useTransactionStatus` hook to keep track of the status of the current transaction (`not-started`, `pending`, `redirecting`, `complete`, etc.). The components of that payment method then react to the transaction status to do things like display error messages, disable/enable the form, and redirect if necessary. That logic is a side effect repeated in each payment method.

This PR moves all of those side effects into one place in `CheckoutProvider`.

#### Testing instructions

We'll need to make sure that for each of the payment methods (free purchase, paypal, apple pay, credit card, existing card, and full credits), a successful purchase works correctly. For PayPal this just means redirecting to the PayPal url. For other payment methods this means completing a purchase.

- [ ] Credit card
- [x] Existing card
- [x] Free ($0 due to coupon or bundle)
- [x] Full credits
- [ ] PayPal
- [x] Apple Pay