### PR TITLE
composite-checkout: Convert free purchase payment method to use processor function

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -64,6 +64,7 @@ import useShowStripeLoadingErrors from './use-show-stripe-loading-errors';
 import useCreatePaymentMethods from './use-create-payment-methods';
 import {
 	applePayProcessor,
+	freePurchaseProcessor,
 	stripeCardProcessor,
 	fullCreditsProcessor,
 	existingCardProcessor,
@@ -408,6 +409,7 @@ export default function CompositeCheckout( {
 	const paymentProcessors = useMemo(
 		() => ( {
 			'apple-pay': applePayProcessor,
+			'free-purchase': freePurchaseProcessor,
 			card: stripeCardProcessor,
 			'full-credits': fullCreditsProcessor,
 			'existing-card': existingCardProcessor,

--- a/client/my-sites/checkout/composite-checkout/payment-method-processors.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-processors.js
@@ -13,6 +13,7 @@ import {
 	wpcomPayPalExpress,
 	submitApplePayPayment,
 	submitStripeCardTransaction,
+	submitFreePurchaseTransaction,
 	submitCreditsTransaction,
 	submitExistingCardPayment,
 	submitPayPalExpressRequest,
@@ -94,6 +95,25 @@ function createStripePaymentMethodToken( { stripe, name, country, postalCode } )
 			postal_code: postalCode,
 		},
 	} );
+}
+
+export async function freePurchaseProcessor( submitData ) {
+	const pending = submitFreePurchaseTransaction(
+		{
+			...submitData,
+			siteId: select( 'wpcom' )?.getSiteId?.(),
+			domainDetails: getDomainDetails( select ),
+			// this data is intentionally empty so we do not charge taxes
+			country: null,
+			postalCode: null,
+		},
+		wpcomTransaction
+	);
+	// save result so we can get receipt_id and failed_purchases in getThankYouPageUrl
+	pending.then( ( result ) => {
+		dispatch( 'wpcom' ).setTransactionResponse( result );
+	} );
+	return pending;
 }
 
 export async function fullCreditsProcessor( submitData ) {

--- a/client/my-sites/checkout/composite-checkout/use-create-payment-methods.js
+++ b/client/my-sites/checkout/composite-checkout/use-create-payment-methods.js
@@ -10,26 +10,17 @@ import {
 	createFreePaymentMethod,
 	createApplePayMethod,
 	createExistingCardMethod,
-	registerStore,
-	defaultRegistry,
 } from '@automattic/composite-checkout';
-import debugFactory from 'debug';
 
 /**
  * Internal dependencies
  */
 import {
-	getDomainDetails,
-	wpcomTransaction,
 	WordPressCreditsLabel,
 	WordPressCreditsSummary,
-	submitFreePurchaseTransaction,
 	WordPressFreePurchaseLabel,
 	WordPressFreePurchaseSummary,
 } from './payment-method-helpers';
-
-const debug = debugFactory( 'calypso:composite-checkout:use-create-payment-methods' );
-const { select, dispatch } = defaultRegistry;
 
 function useCreatePayPal( { onlyLoadPaymentMethods } ) {
 	const shouldLoadPayPalMethod = onlyLoadPaymentMethods
@@ -99,28 +90,7 @@ function useCreateFree( { onlyLoadPaymentMethods } ) {
 		if ( ! shouldLoadFreePaymentMethod ) {
 			return null;
 		}
-		return createFreePaymentMethod( {
-			registerStore,
-			submitTransaction: ( submitData ) => {
-				const pending = submitFreePurchaseTransaction(
-					{
-						...submitData,
-						siteId: select( 'wpcom' )?.getSiteId?.(),
-						domainDetails: getDomainDetails( select ),
-						// this data is intentionally empty so we do not charge taxes
-						country: null,
-						postalCode: null,
-					},
-					wpcomTransaction
-				);
-				// save result so we can get receipt_id and failed_purchases in getThankYouPageUrl
-				pending.then( ( result ) => {
-					debug( 'saving transaction response', result );
-					dispatch( 'wpcom' ).setTransactionResponse( result );
-				} );
-				return pending;
-			},
-		} );
+		return createFreePaymentMethod();
 	}, [ shouldLoadFreePaymentMethod ] );
 	if ( freePaymentMethod ) {
 		freePaymentMethod.label = <WordPressFreePurchaseLabel />;

--- a/packages/composite-checkout/src/lib/payment-methods/free-purchase.js
+++ b/packages/composite-checkout/src/lib/payment-methods/free-purchase.js
@@ -9,78 +9,19 @@ import debugFactory from 'debug';
  */
 import Button from '../../components/button';
 import {
-	useSelect,
-	useDispatch,
 	useMessages,
 	useLineItems,
 	useEvents,
 	renderDisplayValueMarkdown,
+	useTransactionStatus,
+	usePaymentProcessor,
 } from '../../public-api';
 import { sprintf, useLocalize } from '../localize';
 import { useFormStatus } from '../form-status';
 
 const debug = debugFactory( 'composite-checkout:free-purchase-payment-method' );
 
-export function createFreePaymentMethod( { registerStore, submitTransaction } ) {
-	const actions = {
-		*beginFreeTransaction( payload ) {
-			let response;
-			try {
-				response = yield {
-					type: 'FREE_TRANSACTION_BEGIN',
-					payload,
-				};
-				debug( 'free transaction complete', response );
-			} catch ( error ) {
-				debug( 'free transaction had an error', error.message );
-				return { type: 'FREE_PURCHASE_TRANSACTION_ERROR', payload: error.message };
-			}
-			debug( 'free transaction requires is successful' );
-			return { type: 'FREE_PURCHASE_TRANSACTION_END', payload: response };
-		},
-	};
-
-	const selectors = {
-		getTransactionError( state ) {
-			return state.transactionError;
-		},
-		getTransactionStatus( state ) {
-			return state.transactionStatus;
-		},
-	};
-
-	registerStore( 'free-purchase', {
-		reducer(
-			state = {
-				transactionStatus: null,
-				transactionError: null,
-			},
-			action
-		) {
-			switch ( action.type ) {
-				case 'FREE_PURCHASE_TRANSACTION_END':
-					return {
-						...state,
-						transactionStatus: 'complete',
-					};
-				case 'FREE_PURCHASE_TRANSACTION_ERROR':
-					return {
-						...state,
-						transactionStatus: 'error',
-						transactionError: action.payload,
-					};
-			}
-			return state;
-		},
-		actions,
-		selectors,
-		controls: {
-			FREE_TRANSACTION_BEGIN( action ) {
-				return submitTransaction( action.payload );
-			},
-		},
-	} );
-
+export function createFreePaymentMethod() {
 	return {
 		id: 'free-purchase',
 		label: <FreePurchaseLabel />,
@@ -102,17 +43,17 @@ function FreePurchaseLabel() {
 
 function FreePurchaseSubmitButton( { disabled } ) {
 	const localize = useLocalize();
-	const { beginFreeTransaction } = useDispatch( 'free-purchase' );
 	const [ items, total ] = useLineItems();
-	const transactionStatus = useSelect( ( select ) =>
-		select( 'free-purchase' ).getTransactionStatus()
-	);
-	const transactionError = useSelect( ( select ) =>
-		select( 'free-purchase' ).getTransactionError()
-	);
+	const {
+		transactionStatus,
+		transactionError,
+		setTransactionComplete,
+		setTransactionError,
+	} = useTransactionStatus();
 	const { showErrorMessage } = useMessages();
 	const { formStatus, setFormReady, setFormComplete, setFormSubmitting } = useFormStatus();
 	const onEvent = useEvents();
+	const submitTransaction = usePaymentProcessor( 'free-purchase' );
 
 	useEffect( () => {
 		if ( transactionStatus === 'error' ) {
@@ -139,9 +80,15 @@ function FreePurchaseSubmitButton( { disabled } ) {
 	const onClick = () => {
 		setFormSubmitting();
 		onEvent( { type: 'FREE_TRANSACTION_BEGIN' } );
-		beginFreeTransaction( {
+		submitTransaction( {
 			items,
-		} );
+		} )
+			.then( () => {
+				setTransactionComplete();
+			} )
+			.catch( ( error ) => {
+				setTransactionError( error.message );
+			} );
 	};
 
 	return (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This updates the "free" payment method to use the payment processor function system introduced in #41767

See also previous conversion of full credits in #42348 and existing cards in #42633 and PayPal in #42662.

#### Testing instructions

- Add a coupon to your cart that gives a 100% discount.
- Attempt a purchase using composite checkout with the "free" payment method.
- Verify that the purchase is successful.