### PR TITLE
composite-checkout: Add original monthly cost data to checkout cart

### DIFF
--- a/client/my-sites/checkout/composite-checkout/wpcom/lib/translate-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/lib/translate-cart.ts
@@ -127,6 +127,8 @@ function translateReponseCartProductToWPCOMCartItem(
 		currency,
 		item_original_cost_display,
 		item_original_cost_integer,
+		item_original_monthly_cost_display,
+		item_original_monthly_cost_integer,
 		item_subtotal_display,
 		item_subtotal_integer,
 		is_domain_registration,
@@ -157,9 +159,11 @@ function translateReponseCartProductToWPCOMCartItem(
 
 	// for displaying crossed-out original price
 	let itemOriginalCostDisplay = item_original_cost_display || '';
+	let itemOriginalMonthlyCostDisplay = item_original_monthly_cost_display || '';
 	// but for the credits item this is confusing and unnecessary
 	if ( 'wordpress-com-credits' === product_slug ) {
 		itemOriginalCostDisplay = '';
+		itemOriginalMonthlyCostDisplay = '';
 	}
 
 	return {
@@ -183,6 +187,8 @@ function translateReponseCartProductToWPCOMCartItem(
 			is_bundled: is_bundled || false,
 			item_original_cost_display: itemOriginalCostDisplay,
 			item_original_cost_integer: item_original_cost_integer || 0,
+			item_original_monthly_cost_display: itemOriginalMonthlyCostDisplay,
+			item_original_monthly_cost_integer: item_original_monthly_cost_integer || 0,
 			product_cost_integer: product_cost_integer || 0,
 			product_cost_display: product_cost_display || '',
 		},

--- a/client/my-sites/checkout/composite-checkout/wpcom/test/translate-cart.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/test/translate-cart.js
@@ -627,6 +627,8 @@ describe( 'translateResponseCartToWPCOMCart', function () {
 					item_original_cost: 144,
 					item_original_cost_integer: 14400,
 					item_original_cost_display: '$144',
+					item_original_monthly_cost_integer: 1200,
+					item_original_monthly_cost_display: '$12',
 					item_subtotal: 127,
 					item_subtotal_integer: 12700,
 					item_subtotal_display: '$127',
@@ -716,6 +718,12 @@ describe( 'translateResponseCartToWPCOMCart', function () {
 			} );
 			it( 'has the expected original cost display value', function () {
 				expect( clientCart.items[ 0 ].wpcom_meta.item_original_cost_display ).toBe( '$144' );
+			} );
+			it( 'has the expected original monthly cost value', function () {
+				expect( clientCart.items[ 0 ].wpcom_meta.item_original_monthly_cost_integer ).toBe( 1200 );
+			} );
+			it( 'has the expected original monthly cost display value', function () {
+				expect( clientCart.items[ 0 ].wpcom_meta.item_original_monthly_cost_display ).toBe( '$12' );
 			} );
 			it( 'has the expected value', function () {
 				expect( clientCart.items[ 0 ].amount.value ).toBe( 12700 );

--- a/client/my-sites/checkout/composite-checkout/wpcom/types/checkout-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/types/checkout-cart.ts
@@ -39,6 +39,8 @@ export type WPCOMCartItem = CheckoutCartItem & {
 		volume?: number;
 		item_original_cost_display: string;
 		item_original_cost_integer: number;
+		item_original_monthly_cost_display: string;
+		item_original_monthly_cost_integer: number;
 		is_bundled?: boolean;
 		is_domain_registration?: boolean;
 		couponCode?: string;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* We need the monthly prices on the frontend, and the most reliable way to get them is to compute them on the backend. This PR is a companion to D43984-code which makes this part of the endpoint response available in calypso.

#### Testing instructions

Unit test built in.

Manual test: apply D43984-code to your sandbox. Enter checkout and use the react dev tools to inspect the props of a line item. You should see `item_original_monthly_price_display` and `item_original_monthly_price_integer` in `item.wpcom_meta`.

![Screen Shot 2020-05-26 at 4 02 14 PM](https://user-images.githubusercontent.com/9310939/82950678-52f00480-9f6b-11ea-97d9-cf1564393ea8.png)
