### PR TITLE
Jetpack Cloud: update styles of the Jetpack Cloud login page to match the current design

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -42,7 +42,7 @@ import ContinueAsUser from './continue-as-user';
 import ErrorNotice from './error-notice';
 import LoginForm from './login-form';
 import { isWebAuthnSupported } from 'lib/webauthn';
-import JetpackLogo from 'components/jetpack-logo';
+import JetpackPlusWpComLogo from 'components/jetpack-plus-wpcom-logo';
 
 /**
  * Style dependencies
@@ -287,7 +287,7 @@ class Login extends Component {
 				headerText = translate( 'Log in to Jetpack.com with your WordPress.com account.' );
 				preHeader = (
 					<div className="login__jetpack-cloud-wrapper">
-						<JetpackLogo full={ false } size={ 60 } />
+						<JetpackPlusWpComLogo size={ 60 } />
 					</div>
 				);
 			}

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -284,7 +284,7 @@ class Login extends Component {
 			}
 
 			if ( isJetpackCloudOAuth2Client( oauth2Client ) ) {
-				headerText = translate( 'Log in to Jetpack.com with your WordPress.com account.' );
+				headerText = translate( 'Howdy! Log in to Jetpack.com with your WordPress.com account.' );
 				preHeader = (
 					<div className="login__jetpack-cloud-wrapper">
 						<JetpackPlusWpComLogo size={ 60 } />

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -287,7 +287,7 @@ class Login extends Component {
 				headerText = translate( 'Howdy! Log in to Jetpack.com with your WordPress.com account.' );
 				preHeader = (
 					<div className="login__jetpack-cloud-wrapper">
-						<JetpackPlusWpComLogo size={ 60 } />
+						<JetpackPlusWpComLogo className="login__jetpack-plus-wpcom-logo" size={ 24 } />
 					</div>
 				);
 			}

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -245,3 +245,7 @@
 		padding: 8px 24px;
 	}
 }
+
+.login__jetpack-plus-wpcom-logo {
+	margin: 32px 0 16px;
+}

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -247,5 +247,5 @@
 }
 
 .login__jetpack-plus-wpcom-logo {
-	margin: 32px 0 16px;
+	margin: 40px 0 16px;
 }

--- a/client/components/jetpack-plus-wpcom-logo/README.md
+++ b/client/components/jetpack-plus-wpcom-logo/README.md
@@ -1,0 +1,24 @@
+# JetpackPlusWpComLogo (JSX)
+
+This component is used to display the Jetpack Plus WPCOM logo (a Jetpack logo, a plus sign, and a WPCOM logo).
+
+---
+
+#### How to use:
+
+```js
+import JetpackPlusWpComLogo from 'components/jetpack-plus-wpcom-logo';
+
+export default function JetpackPlusWpComLogoExample() {
+	return (
+		<div>
+			<JetpackPlusWpComLogo size={ 64 } />
+		</div>
+	);
+}
+```
+
+#### Props
+
+- `className` : (string) Custom class name to be added to the SVG element
+- `size` : (number) The height of the SVG. Default is `32`

--- a/client/components/jetpack-plus-wpcom-logo/docs/example.js
+++ b/client/components/jetpack-plus-wpcom-logo/docs/example.js
@@ -1,0 +1,25 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import JetpackPlusWpComLogo from 'components/jetpack-plus-wpcom-logo';
+
+export default function JetpackPlusWpComLogoExample() {
+	return (
+		<div>
+			<pre>{ '<JetpackPlusWpComLogo />' }</pre>
+			<JetpackPlusWpComLogo />
+			<hr />
+			<pre>{ '<JetpackPlusWpComLogo size={ 24 } />' }</pre>
+			<JetpackPlusWpComLogo size={ 24 } />
+			<hr />
+			<pre>{ '<JetpackPlusWpComLogo size={ 64 } />' }</pre>
+			<JetpackPlusWpComLogo size={ 64 } />
+		</div>
+	);
+}
+JetpackPlusWpComLogoExample.displayName = 'JetpackPlusWpComLogoExample';

--- a/client/components/jetpack-plus-wpcom-logo/index.jsx
+++ b/client/components/jetpack-plus-wpcom-logo/index.jsx
@@ -1,0 +1,44 @@
+/**
+ * External dependencies
+ */
+import { colors as PALETTE } from '@automattic/color-studio';
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+/**
+ * Module constants
+ */
+const COLOR_JETPACK = PALETTE[ 'Jetpack Green 40' ];
+const COLOR_WORDPRESS = PALETTE[ 'WordPress Blue 40' ];
+const COLOR_WHITE = PALETTE[ 'White' ]; // eslint-disable-line dot-notation
+const COLOR_GRAY = PALETTE[ 'Gray 80' ];
+
+const JetpackPlusWpComLogo = ( { size = 32, className } ) => {
+	const classes = classNames( 'jetpack-plus-wpcom-logo', className );
+
+	return (
+		<svg height={ size } className={ classes } viewBox="0 0 2000 629">
+			<path
+				d="M1821.1 558.9l89-249.7c16.7-40.4 22.2-72.6 22.2-101.3 0-10.4-.7-20-2-29a274.8 274.8 0 0135.7 135.6c0 104.3-58.2 195.4-144.9 244.4zm-106.3-377c17.5-.9 33.3-2.7 33.3-2.7 15.7-1.8 13.9-24.2-1.8-23.3 0 0-47.2 3.6-77.7 3.6-28.7 0-76.8-3.6-76.8-3.6-15.7-.9-17.5 22.4-1.8 23.3 0 0 14.8 1.8 30.5 2.7l45.4 120.7-63.7 185.6L1496 181.9c17.6-.9 33.4-2.7 33.4-2.7 15.7-1.8 13.8-24.2-1.9-23.3 0 0-47.2 3.6-77.6 3.6l-18.8-.3a293.5 293.5 0 01243.5-127.5c75.9 0 145 28.2 196.8 74.3-1.3-.1-2.5-.3-3.8-.3-28.6 0-49 24.2-49 50.2 0 23.3 14 43 28.7 66.3 11 18.9 24 43 24 78 0 24.2-7.4 54.7-22.1 91.4L1820 486zm-40.2 415.4a300 300 0 01-82.3-11.5l87.4-246.6 89.6 238.1 2 4a299.2 299.2 0 01-96.7 16zm-291.4-282.8c0-41 9-80 25.2-115l139 369.5c-97.2-45.9-164.2-142.6-164.2-254.5zM1674.6 0c-178.7 0-324.1 141-324.1 314.5 0 173.4 145.4 314.5 324.1 314.5 178.7 0 324.1-141 324.1-314.5C1998.7 141 1853.3 0 1674.6 0z"
+				fill={ COLOR_WORDPRESS }
+			/>
+			<path
+				d="M311.4 629c171.7 0 310.8-140.8 310.8-314.5S483.1 0 311.4 0C139.7 0 .6 140.8.6 314.5S139.7 629 311.4 629z"
+				fill={ COLOR_JETPACK }
+			/>
+			<path d="M326.8 261.7v304.9l155.4-305zM295.4 366.7V62.4L140.6 366.7z" fill={ COLOR_WHITE } />
+			<path
+				d="M1026 341.2h84.4v-52.9H1026v-83.5h-52v83.5h-84.2v52.9h84.1v83.7h52.1z"
+				fill={ COLOR_GRAY }
+			/>
+		</svg>
+	);
+};
+
+JetpackPlusWpComLogo.propTypes = {
+	className: PropTypes.string,
+	size: PropTypes.number,
+};
+
+export default JetpackPlusWpComLogo;

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -735,8 +735,8 @@
 		font-weight: 600;
 		font-size: 22px;
 		line-height: 32px;
-		margin-bottom: 24px;
 		margin-top: 16px;
+		margin-bottom: 8px;
 		text-align: center;
 	}
 
@@ -764,11 +764,25 @@
 		max-width: 375px;
 	}
 
+	.wp-login__links a {
+		font-size: 16px;
+		font-weight: 400;
+	}
+
+	.login__form-action button {
+		font-size: 16px;
+		line-height: 23px;
+	}
+
 	.login__form-terms {
+		font-size: 14px;
+		line-height: 24px;
 		margin-top: 8px;
 	}
 
 	.login__form-signup-link {
+		font-size: 16px;
+		line-height: 24px;
 		padding-top: 0;
 	}
 
@@ -867,6 +881,21 @@
 				order: 4;
 			}
 		}
+
+		.login__form-userdata label {
+			font-size: 18px;
+			font-weight: 400;
+		}
+	}
+
+	.login__social-tos {
+		font-size: 14px;
+		line-height: 24px;
+	}
+
+	.login__social-buttons .social-buttons__button {
+		margin-top: 16px;
+		box-shadow: 0 2px 0 #afbbc6;
 	}
 
 	.card.two-factor-authentication__verification-code-form,

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -101,6 +101,14 @@ export class LoginLinks extends React.Component {
 	};
 
 	renderBackLink() {
+		if (
+			isCrowdsignalOAuth2Client( this.props.oauth2Client ) ||
+			isJetpackCloudOAuth2Client( this.props.oauth2Client ) ||
+			this.props.isGutenboarding
+		) {
+			return null;
+		}
+
 		const redirectTo = this.props.query?.redirect_to;
 		if ( redirectTo ) {
 			const { pathname, searchParams: redirectToQuery } = getUrlParts( redirectTo );
@@ -357,9 +365,7 @@ export class LoginLinks extends React.Component {
 				{ this.renderHelpLink() }
 				{ this.renderMagicLoginLink() }
 				{ this.renderResetPasswordLink() }
-				{ ! isCrowdsignalOAuth2Client( this.props.oauth2Client ) &&
-					! this.props.isGutenboarding &&
-					this.renderBackLink() }
+				{ this.renderBackLink() }
 			</div>
 		);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update styles of the Jetpack Cloud login page to match the current design.
* Update copy in the header.
* Replace Jetpack logo with Jetpack + WordPress logo.

#### Important

The end result won't look exactly as the design does mainly because the font we use in Jetpack Cloud isn't the same that was used in the design.

#### Testing instructions

* Run this PR with `yarn start`
* Visit wordpress.com and log out from your current session
* Visit cloud.jetpack.com
* You should see Jetpack Cloud login page (stage enviroment)
* Copy everything after `https://wordpress.com/` of the URL
* Replace the current URL with `http://calypso.localhost:3000/` and paste what was copied in the previous step
* You should see Jetpack Cloud login page (dev environment)
* Verify it matches the design

Fixes 1169345694087188-as-1177526555013322

#### Demo
![image](https://user-images.githubusercontent.com/3418513/82957905-77a7a480-9f8a-11ea-9b6a-6ee443a30af7.png)
![image](https://user-images.githubusercontent.com/3418513/82958244-5a270a80-9f8b-11ea-8aa3-8009c977e8f5.png)

