### PR TITLE
Reader: fix alignment of conversation caterpillar button text

### DIFF
--- a/client/blocks/conversation-caterpillar/style.scss
+++ b/client/blocks/conversation-caterpillar/style.scss
@@ -3,6 +3,7 @@
 }
 
 .conversation-caterpillar__count {
+	align-items: center;
 	cursor: pointer;
 	color: var( --color-primary );
 	display: flex;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The conversation caterpillar block (used in Reader Conversations) shows the avatars of people who have commented on a post. I just noticed that the text was aligned to the top of the avatars rather than being centred, which I believe was the case when the feature launched.

This PR restores the vertical centering.

Before:

<img width="298" alt="Screen Shot 2020-05-27 at 16 53 45" src="https://user-images.githubusercontent.com/17325/82979660-bb0e1b80-a03b-11ea-936e-7dbe393ad852.png">

After:

<img width="468" alt="Screen Shot 2020-05-27 at 16 53 36" src="https://user-images.githubusercontent.com/17325/82979669-c103fc80-a03b-11ea-8d16-d83cdebf4a65.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Visit http://calypso.localhost:3000/devdocs/blocks/conversation-caterpillar and ensure the text next to the avatars is vertically centered.