### PR TITLE
Use `yarn workspaces` instead of `lerna` in CI and docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -302,7 +302,7 @@ jobs:
       - run:
           name: Build Notifications Panel
           command: |
-            NODE_ENV=production npx lerna run build --scope='@automattic/notifications' -- -- --output-path=$CIRCLE_ARTIFACTS/notifications-panel
+            cd apps/notifications/ && NODE_ENV=production yarn build --output-path=$CIRCLE_ARTIFACTS/notifications-panel
       - store-artifacts-and-test-results
 
   build-o2-blocks:
@@ -313,7 +313,7 @@ jobs:
       - run:
           name: Build Gutenberg Blocks for internal p2s
           command: |
-            NODE_ENV=production npx lerna run build --scope='@automattic/o2-blocks' -- -- --output-path=$CIRCLE_ARTIFACTS/o2-blocks
+            cd apps/o2-blocks/ && NODE_ENV=production yarn build --output-path=$CIRCLE_ARTIFACTS/o2-blocks
       - store-artifacts-and-test-results
 
   build-wpcom-block-editor:
@@ -324,7 +324,7 @@ jobs:
       - run:
           name: Build the block editor in WordPress.com integration utils package
           command: |
-            npx lerna run build --scope='@automattic/wpcom-block-editor' -- -- --output-path=$CIRCLE_ARTIFACTS/wpcom-block-editor
+            cd apps/wpcom-block-editor/ && yarn build --output-path=$CIRCLE_ARTIFACTS/wpcom-block-editor
       - store-artifacts-and-test-results
   test-full-site-editing:
     <<: *defaults
@@ -334,7 +334,7 @@ jobs:
       - run:
           name: Run Full Site Editing client tests
           command: |
-            npx lerna run test:js --scope='@automattic/full-site-editing' --stream --no-prefix
+            cd apps/full-site-editing && yarn test:js
   test-client:
     <<: *defaults
     parallelism: 6

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -302,7 +302,7 @@ jobs:
       - run:
           name: Build Notifications Panel
           command: |
-            cd apps/notifications/ && NODE_ENV=production yarn build --output-path=$CIRCLE_ARTIFACTS/notifications-panel
+            cd apps/notifications/ && NODE_ENV=production yarn run build --output-path=$CIRCLE_ARTIFACTS/notifications-panel
       - store-artifacts-and-test-results
 
   build-o2-blocks:
@@ -313,7 +313,7 @@ jobs:
       - run:
           name: Build Gutenberg Blocks for internal p2s
           command: |
-            cd apps/o2-blocks/ && NODE_ENV=production yarn build --output-path=$CIRCLE_ARTIFACTS/o2-blocks
+            cd apps/o2-blocks/ && NODE_ENV=production yarn run build --output-path=$CIRCLE_ARTIFACTS/o2-blocks
       - store-artifacts-and-test-results
 
   build-wpcom-block-editor:
@@ -334,7 +334,7 @@ jobs:
       - run:
           name: Run Full Site Editing client tests
           command: |
-            cd apps/full-site-editing && yarn test:js
+            cd apps/full-site-editing && yarn run test:js
   test-client:
     <<: *defaults
     parallelism: 6

--- a/apps/notifications/README.md
+++ b/apps/notifications/README.md
@@ -12,7 +12,7 @@ That is, you can work in these files and rely on the normal Calypso dev server.
 **However** things are often different inside the `iframe` in unexpected ways and so we need to verify that any changes apply properly in both environments.
 
 CircleCI generates notifications panel build artifacts on every commit that it processes.
-Alternatively you can manually build the app with `lerna` and copy the built files to your sandbox.
+Alternatively you can manually build the app with `yarn` and copy the built files to your sandbox.
 
 ```bash
 # Builds files and places them in `apps/notifications/dist`

--- a/docs/monorepo.md
+++ b/docs/monorepo.md
@@ -104,13 +104,13 @@ yarn run build-packages
 Or even specific packages:
 
 ```bash
-npx lerna run prepare --scope="@automattic/calypso-build"
+yarn workspace @automattic/calypso-build run prepare
 ```
 
 Or specific apps:
 
 ```bash
-npx lerna run build --scope="@automattic/calypso-build"
+yarn workspace @automattic/wpcom-block-editor run build
 ```
 
 All `prepare` scripts found in all `package.json`s of apps and packages are always run on Calypso's `yarn`. Therefore independent apps in `/apps` directory can use `build` instead of `prepare` so avoid unnecessary builds.
@@ -118,7 +118,7 @@ All `prepare` scripts found in all `package.json`s of apps and packages are alwa
 You can also run other custom `package.json` scripts only for your app or package:
 
 ```bash
-npx lerna run your-script --scope="@automattic/your-package"
+yarn workspace @automattic/your-package run your-script
 ```
 
 ## Developing packages

--- a/packages/README.md
+++ b/packages/README.md
@@ -15,7 +15,7 @@ Packages are built on Calypso's `yarn` so you don't need to build them manually,
 If you must manually build a single package, run:
 
 ```bash
-npx lerna run prepare --scope="@automattic/package-name"
+yarn workspace @automattic/package-name run prepare
 ```
 
 ## Validating package.json

--- a/packages/material-design-icons/README.md
+++ b/packages/material-design-icons/README.md
@@ -31,6 +31,6 @@ Move the SVG files in the sub-folder matching the category used on material.io.
 
 Rebuild `material-icons.svg` by running:
 
-	yarn workspace @automattic/material-design-icons build
+	yarn workspace @automattic/material-design-icons run build
 
 Beware that default style and size for `MaterialIcon` class is `outline` and `24`.

--- a/packages/material-design-icons/README.md
+++ b/packages/material-design-icons/README.md
@@ -31,6 +31,6 @@ Move the SVG files in the sub-folder matching the category used on material.io.
 
 Rebuild `material-icons.svg` by running:
 
-	lerna run build --scope @automattic/material-design-icons
+	yarn workspace @automattic/material-design-icons build
 
 Beware that default style and size for `MaterialIcon` class is `outline` and `24`.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use `yarn worspace` instead of the `lerna` equivalent where possible

#### Testing instructions

* Verify CI still passes
