### PR TITLE
Gutenboarding: move edison premium design to be 2nd from 1st position

### DIFF
--- a/client/landing/gutenboarding/available-designs.ts
+++ b/client/landing/gutenboarding/available-designs.ts
@@ -12,19 +12,6 @@ import type { Design } from './stores/onboard/types';
 const availableDesigns: Readonly< AvailableDesigns > = {
 	featured: [
 		{
-			title: 'Edison',
-			slug: 'edison',
-			template: 'edison',
-			theme: 'stratford',
-			src: 'https://public-api.wordpress.com/rest/v1/template/demo/stratford/edison/',
-			fonts: {
-				headings: 'Chivo',
-				base: 'Open Sans',
-			},
-			categories: [ 'featured', 'blog' ],
-			is_premium: true,
-		},
-		{
 			title: 'Cassel',
 			slug: 'cassel',
 			template: 'cassel',
@@ -36,6 +23,19 @@ const availableDesigns: Readonly< AvailableDesigns > = {
 			},
 			categories: [ 'featured', 'blog' ],
 			is_premium: false,
+		},
+		{
+			title: 'Edison',
+			slug: 'edison',
+			template: 'edison',
+			theme: 'stratford',
+			src: 'https://public-api.wordpress.com/rest/v1/template/demo/stratford/edison/',
+			fonts: {
+				headings: 'Chivo',
+				base: 'Open Sans',
+			},
+			categories: [ 'featured', 'blog' ],
+			is_premium: true,
 		},
 		{
 			title: 'Vesta',


### PR DESCRIPTION
Move Edison premium design to be 2nd from 1st position.

This will help on mobile where users might pick the first design without noticing it's premium.

## Before

<img width="400" alt="Screenshot 2020-05-27 at 10 58 43" src="https://user-images.githubusercontent.com/87168/82993322-0eb34180-a009-11ea-9c95-3e2d7108f990.png">
<img width="200" alt="Screenshot 2020-05-27 at 10 58 32" src="https://user-images.githubusercontent.com/87168/82993330-11159b80-a009-11ea-85d1-6c283b670a76.png">


## After

<img width="400" alt="Screenshot 2020-05-27 at 10 58 18" src="https://user-images.githubusercontent.com/87168/82993303-0824ca00-a009-11ea-806d-690a31e3755c.png">
<img width="200" alt="Screenshot 2020-05-27 at 10 58 37" src="https://user-images.githubusercontent.com/87168/82993308-0bb85100-a009-11ea-9c21-028a1792aa26.png">
