### PR TITLE
 hide duplicate inserter for gutenberg 8.2.0

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/editor/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/editor/style.scss
@@ -1,3 +1,7 @@
+.edit-post-header-toolbar > .edit-post-header-toolbar__inserter-toggle {
+	display: none;
+}
+
 .post-type-wp_template_part {
 	.editor-post-title,
 	.editor-post-trash {


### PR DESCRIPTION
In gutenberg 8.2.0-RC.1 the inserter is no longer hidden when FSE is enabled https://github.com/WordPress/gutenberg/pull/22115/files
This lead to this issue https://github.com/Automattic/wp-calypso/issues/42611

FSE adds its own inserter in https://github.com/Automattic/wp-calypso/blob/b6944b9c4f84459bc56463e0f8ebb01b2f9727e1/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/editor/block-inserter/index.js

This change ensures that the original gutenberg inserter is hidden with CSS

#### Testing instructions
Open up a site with FSE enabled
Apply the gutenberg edge sticker
Ensure that 8.2.0-RC.1 is the current gutenberg version
There should be only one inserter present
<img width="831" alt="Screen Shot 2020-05-27 at 6 20 04 PM" src="https://user-images.githubusercontent.com/22446385/82995325-ca469680-a046-11ea-8b5e-be2a09a05387.png">


Fixes #42611
