### PR TITLE
My Home: Add support for forced views in dev mode

### DIFF
--- a/client/components/data/query-home-layout/index.js
+++ b/client/components/data/query-home-layout/index.js
@@ -9,10 +9,10 @@ import { useDispatch } from 'react-redux';
  */
 import { requestHomeLayout } from 'state/home/actions';
 
-export default function QueryHomeLayout( { siteId } ) {
+export default function QueryHomeLayout( { isDev, forcedView, siteId } ) {
 	const dispatch = useDispatch();
 	React.useEffect( () => {
-		dispatch( requestHomeLayout( siteId ) );
+		dispatch( requestHomeLayout( siteId, isDev, forcedView ) );
 	}, [ dispatch, siteId ] );
 
 	return null;

--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -15,12 +15,15 @@ export default async function ( context, next ) {
 	const state = await context.store.getState();
 	const siteId = await getSelectedSiteId( state );
 
+	const isDev = context.query.dev === 'true';
+	const forcedView = context.query.view;
+
 	// Scroll to the top
 	if ( typeof window !== 'undefined' ) {
 		window.scrollTo( 0, 0 );
 	}
 
-	context.primary = <CustomerHome key={ siteId } />;
+	context.primary = <CustomerHome key={ siteId } isDev={ isDev } forcedView={ forcedView } />;
 
 	next();
 }

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -36,7 +36,15 @@ import Experiment, { LoadingVariations, DefaultVariation, Variation } from 'comp
  */
 import './style.scss';
 
-const Home = ( { canUserUseCustomerHome, layout, site, siteId, trackViewSiteAction } ) => {
+const Home = ( {
+	canUserUseCustomerHome,
+	isDev,
+	forcedView,
+	layout,
+	site,
+	siteId,
+	trackViewSiteAction,
+} ) => {
 	const translate = useTranslate();
 
 	if ( ! canUserUseCustomerHome ) {
@@ -69,7 +77,7 @@ const Home = ( { canUserUseCustomerHome, layout, site, siteId, trackViewSiteActi
 			<PageViewTracker path={ `/home/:site` } title={ translate( 'My Home' ) } />
 			<DocumentHead title={ translate( 'My Home' ) } />
 			{ siteId && <QuerySiteChecklist siteId={ siteId } /> }
-			{ siteId && <QueryHomeLayout siteId={ siteId } /> }
+			{ siteId && <QueryHomeLayout siteId={ siteId } isDev={ isDev } forcedView={ forcedView } /> }
 			<SidebarNavigation />
 			<Experiment name="user_home_test">
 				<LoadingVariations>
@@ -101,12 +109,14 @@ const Home = ( { canUserUseCustomerHome, layout, site, siteId, trackViewSiteActi
 };
 
 Home.propTypes = {
+	canUserUseCustomerHome: PropTypes.bool.isRequired,
+	isDev: PropTypes.bool,
+	isStaticHomePage: PropTypes.bool.isRequired,
+	forcedView: PropTypes.string,
 	layout: PropTypes.object,
 	site: PropTypes.object.isRequired,
 	siteId: PropTypes.number.isRequired,
-	canUserUseCustomerHome: PropTypes.bool.isRequired,
 	trackViewSiteAction: PropTypes.func.isRequired,
-	isStaticHomePage: PropTypes.bool.isRequired,
 };
 
 const mapStateToProps = ( state ) => {

--- a/client/state/data-layer/wpcom/sites/home/layout/index.js
+++ b/client/state/data-layer/wpcom/sites/home/layout/index.js
@@ -9,12 +9,16 @@ import { setHomeLayout } from 'state/home/actions';
 import config from 'config';
 
 const requestLayout = ( action ) => {
+	const isDev = config.isEnabled( 'home/layout-dev' ) || action.isDev;
 	return http(
 		{
 			method: 'GET',
 			path: `/sites/${ action.siteId }/home/layout`,
 			apiNamespace: 'wpcom/v2',
-			...( config.isEnabled( 'home/layout-dev' ) && { query: { dev: true } } ),
+			query: {
+				...( isDev && { dev: true } ),
+				...( isDev && action.forcedView && { view: action.forcedView } ),
+			},
 		},
 		action
 	);

--- a/client/state/home/actions.js
+++ b/client/state/home/actions.js
@@ -10,7 +10,7 @@ import {
 } from 'state/action-types';
 import 'state/data-layer/wpcom/sites/home/layout';
 
-export const requestHomeLayout = ( siteId, isDev, forcedView ) => ( {
+export const requestHomeLayout = ( siteId, isDev = false, forcedView = null ) => ( {
 	type: HOME_LAYOUT_REQUEST,
 	siteId,
 	isDev,

--- a/client/state/home/actions.js
+++ b/client/state/home/actions.js
@@ -10,9 +10,11 @@ import {
 } from 'state/action-types';
 import 'state/data-layer/wpcom/sites/home/layout';
 
-export const requestHomeLayout = ( siteId ) => ( {
+export const requestHomeLayout = ( siteId, isDev, forcedView ) => ( {
 	type: HOME_LAYOUT_REQUEST,
 	siteId,
+	isDev,
+	forcedView,
 } );
 
 export const skipCurrentViewHomeLayout = ( siteId, reminder = null ) => ( {


### PR DESCRIPTION
Requires D43986-code.

#### Changes proposed in this Pull Request

Adds the ability to force displaying a particular view in My Home when the dev mode is turned on.

The forced view can be set in a `view` query param when visiting My Home.

The dev mode can be turned on either with the `home/layout-dev` feature flag (enabled by default in Calypo dev) or with a `dev` query param when visiting My Home.

#### Testing instructions

- Apply D43986-code and sandbox the API.
- Visit My Home normally and verify you get the expected view for your current site's state.
- Add a `view` query param to the URL and verify the given view is displayed (i.e. `/home/:site/?view=VIEW_WEBINARS`).
- Make sure the view is not forced when the `home/layout-dev` flag is disabled (i.e. `/home/:site?view=VIEW_WEBINARS&flags=-home/layout-dev`).
- Make sure the view is forced when the `home/layout-dev` flag is disabled but a `dev` query param is set (i.e. `/home/:site?dev=true&view=VIEW_WEBINARS&flags=-home/layout-dev`).

Fixes #42668
