### PR TITLE
Remove the /me/domains route

### DIFF
--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -20,7 +20,6 @@ import {
 	myMemberships,
 	purchasesRoot,
 } from 'me/purchases/paths';
-import { domainManagementUserRoot } from 'my-sites/domains/paths';
 import Sidebar from 'layout/sidebar';
 import SidebarFooter from 'layout/sidebar/footer';
 import SidebarHeading from 'layout/sidebar/heading';
@@ -100,7 +99,6 @@ class MeSidebar extends React.Component {
 			[ myMemberships ]: 'purchases',
 			'/me/chat': 'happychat',
 			'/me/site-blocks': 'site-blocks',
-			[ domainManagementUserRoot() ]: 'domains',
 		};
 		const filteredPath = context.path.replace( /\/\d+$/, '' ); // Remove ID from end of path
 		let selected;
@@ -165,17 +163,6 @@ class MeSidebar extends React.Component {
 								onNavigate={ this.onNavigate }
 								preloadSectionName="purchases"
 							/>
-
-							{ config.isEnabled( 'manage/all-domains' ) && (
-								<SidebarItem
-									selected={ selected === 'domains' }
-									link={ domainManagementUserRoot() }
-									label={ translate( 'Domains' ) }
-									materialIcon="language"
-									onNavigate={ this.onNavigate }
-									preloadSectionName="domains"
-								/>
-							) }
 
 							<SidebarItem
 								selected={ selected === 'security' }

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -47,7 +47,6 @@ import {
 	domainManagementTransfer,
 	domainManagementTransferOut,
 	domainManagementTransferToOtherSite,
-	domainManagementUserRoot,
 } from 'my-sites/domains/paths';
 import {
 	emailManagement,
@@ -61,7 +60,6 @@ import { makeLayout, render as clientRender } from 'controller';
 import NoSitesMessage from 'components/empty-content/no-sites-message';
 import EmptyContentComponent from 'components/empty-content';
 import DomainOnly from 'my-sites/domains/domain-management/list/domain-only';
-import AsyncLoad from 'components/async-load';
 
 /*
  * @FIXME Shorthand, but I might get rid of this.
@@ -88,10 +86,6 @@ function createNavigation( context ) {
 
 	if ( siteFragment ) {
 		basePath = sectionify( context.pathname );
-	}
-
-	if ( startsWith( context.pathname, domainManagementUserRoot() ) ) {
-		return <AsyncLoad require="me/sidebar" context={ context } />;
 	}
 
 	return (

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -171,14 +171,12 @@ export default function () {
 
 	if ( config.isEnabled( 'manage/all-domains' ) ) {
 		page(
-			paths.domainManagementUserRoot(),
+			paths.domainManagementRoot(),
 			...getCommonHandlers( { noSitePath: false } ),
 			domainManagementController.domainManagementListAllSites,
 			makeLayout,
 			clientRender
 		);
-
-		page.redirect( paths.domainManagementRoot(), paths.domainManagementUserRoot() );
 	} else {
 		page( paths.domainManagementRoot(), siteSelection, sites, makeLayout, clientRender );
 	}

--- a/client/my-sites/domains/paths.js
+++ b/client/my-sites/domains/paths.js
@@ -14,10 +14,6 @@ export function domainAddNew( siteName, searchTerm ) {
 	return path;
 }
 
-export function domainManagementUserRoot() {
-	return '/me/domains';
-}
-
 export function domainManagementRoot() {
 	return '/domains/manage';
 }

--- a/client/sections.js
+++ b/client/sections.js
@@ -227,7 +227,7 @@ const sections = [
 	},
 	{
 		name: 'domains',
-		paths: [ '/domains', '/me/domains' ],
+		paths: [ '/domains' ],
 		module: 'my-sites/domains',
 		secondary: true,
 		group: 'sites',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Revert #42071 because in the end we're going for the all my sites view

#### Testing instructions

* Go to /me - there should be no Domains menu
* Try /me/domains - again nothing should show
* Go to /domains/manage - if you're using your dev environment you should see a list of all sites domain management pages
