### PR TITLE
Refactor `state/plugins/wporg`

### DIFF
--- a/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
+++ b/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
@@ -38,7 +38,7 @@ import './style.scss';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { isRequestingSites } from 'state/sites/selectors';
 import hasInitializedSites from 'state/selectors/has-initialized-sites';
-import { getPlugin } from 'state/plugins/wporg/selectors';
+import { getAllPlugins as getAllWporgPlugins } from 'state/plugins/wporg/selectors';
 import { fetchPluginData } from 'state/plugins/wporg/actions';
 import { requestSites } from 'state/sites/actions';
 import { installPlugin } from 'state/plugins/premium/actions';
@@ -88,11 +88,11 @@ class PlansSetup extends React.Component {
 	// plugins for Jetpack sites require additional data from the wporg-data store
 	addWporgDataToPlugins = ( plugins ) => {
 		return plugins.map( ( plugin ) => {
-			const pluginData = getPlugin( this.props.wporg, plugin.slug );
+			const pluginData = this.props.wporgPlugins?.[ plugin.slug ];
 			if ( ! pluginData ) {
 				this.props.fetchPluginData( plugin.slug );
 			}
-			return Object.assign( {}, plugin, pluginData );
+			return { ...plugin, ...pluginData };
 		} );
 	};
 
@@ -161,7 +161,7 @@ class PlansSetup extends React.Component {
 		const site = this.props.selectedSite;
 
 		// Merge wporg info into the plugin object
-		plugin = Object.assign( {}, plugin, getPlugin( this.props.wporg, plugin.slug ) );
+		plugin = { ...plugin, ...this.props.wporgPlugins?.[ plugin.slug ] };
 
 		const getPluginFromStore = function () {
 			const sitePlugin = PluginsStore.getSitePlugin( site, plugin.slug );
@@ -253,7 +253,7 @@ class PlansSetup extends React.Component {
 		const plugins = this.addWporgDataToPlugins( this.props.plugins );
 
 		return plugins.map( ( item, i ) => {
-			const plugin = Object.assign( {}, item, getPlugin( this.props.wporg, item.slug ) );
+			const plugin = { ...item, ...this.props.wporgPlugins?.[ item.slug ] };
 
 			/* eslint-disable wpcalypso/jsx-classname-namespace */
 			return (
@@ -561,7 +561,7 @@ export default connect(
 		const forSpecificPlugin = ownProps.forSpecificPlugin || false;
 
 		return {
-			wporg: state.plugins.wporg.items,
+			wporgPlugins: getAllWporgPlugins( state ),
 			isRequesting: isRequesting( state, siteId ),
 			hasRequested: hasRequested( state, siteId ),
 			isInstalling: isInstalling( state, siteId, forSpecificPlugin ),

--- a/client/my-sites/plugins/main.jsx
+++ b/client/my-sites/plugins/main.jsx
@@ -22,7 +22,7 @@ import urlSearch from 'lib/url-search';
 import EmptyContent from 'components/empty-content';
 import PluginsStore from 'lib/plugins/store';
 import { fetchPluginData as wporgFetchPluginData } from 'state/plugins/wporg/actions';
-import { getPlugin } from 'state/plugins/wporg/selectors';
+import { getAllPlugins as getAllWporgPlugins } from 'state/plugins/wporg/selectors';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import PluginsList from './plugins-list';
 import { recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
@@ -99,7 +99,7 @@ export class PluginsMain extends Component {
 	// plugins for Jetpack sites require additional data from the wporg-data store
 	addWporgDataToPlugins( plugins ) {
 		return plugins.map( ( plugin ) => {
-			const pluginData = getPlugin( this.props.wporgPlugins, plugin.slug );
+			const pluginData = this.props.wporgPlugins?.[ plugin.slug ];
 			if ( ! pluginData ) {
 				this.props.wporgFetchPluginData( plugin.slug );
 			}
@@ -486,7 +486,7 @@ export default flow(
 				canJetpackSiteUpdateFiles: ( siteId ) => canJetpackSiteUpdateFiles( state, siteId ),
 				isJetpackSite: ( siteId ) => isJetpackSite( state, siteId ),
 				/* eslint-enable wpcalypso/redux-no-bound-selectors */
-				wporgPlugins: state.plugins.wporg.items,
+				wporgPlugins: getAllWporgPlugins( state ),
 				isRequestingSites: isRequestingSites( state ),
 				userCanManagePlugins: selectedSiteId
 					? canCurrentUser( state, selectedSiteId, 'manage_options' )

--- a/client/my-sites/plugins/plugin.jsx
+++ b/client/my-sites/plugins/plugin.jsx
@@ -17,7 +17,11 @@ import { Card } from '@automattic/components';
 import PluginMeta from 'my-sites/plugins/plugin-meta';
 import PluginsStore from 'lib/plugins/store';
 import PluginsLog from 'lib/plugins/log-store';
-import { getPlugin, isFetched, isFetching } from 'state/plugins/wporg/selectors';
+import {
+	isFetching as isWporgPluginFetching,
+	isFetched as isWporgPluginFetched,
+	getPlugin as getWporgPlugin,
+} from 'state/plugins/wporg/selectors';
 import { fetchPluginData as wporgFetchPluginData } from 'state/plugins/wporg/actions';
 import PluginNotices from 'lib/plugins/notices';
 import MainComponent from 'components/main';
@@ -185,7 +189,7 @@ const SinglePlugin = createReactClass( {
 	},
 
 	isFetched() {
-		return isFetched( this.props.wporgPlugins, this.props.pluginSlug );
+		return this.props.wporgFetched;
 	},
 
 	isFetchingSites() {
@@ -193,11 +197,8 @@ const SinglePlugin = createReactClass( {
 	},
 
 	getPlugin() {
-		let plugin = Object.assign( {}, this.state.plugin );
 		// assign it .org details
-		plugin = Object.assign( plugin, getPlugin( this.props.wporgPlugins, this.props.pluginSlug ) );
-
-		return plugin;
+		return { ...this.state.plugin, ...this.props.wporgPlugin };
 	},
 
 	getPluginDoesNotExistView( selectedSite ) {
@@ -352,8 +353,9 @@ export default connect(
 		const selectedSiteId = getSelectedSiteId( state );
 
 		return {
-			wporgPlugins: state.plugins.wporg.items,
-			wporgFetching: isFetching( state.plugins.wporg.fetchingItems, props.pluginSlug ),
+			wporgPlugin: getWporgPlugin( state, props.pluginSlug ),
+			wporgFetching: isWporgPluginFetching( state, props.pluginSlug ),
+			wporgFetched: isWporgPluginFetched( state, props.pluginSlug ),
 			selectedSite: getSelectedSite( state ),
 			isAtomicSite: isSiteAutomatedTransfer( state, selectedSiteId ),
 			isJetpackSite: selectedSiteId && isJetpackSite( state, selectedSiteId ),

--- a/client/state/plugins/wporg/README.md
+++ b/client/state/plugins/wporg/README.md
@@ -21,7 +21,7 @@ dispatch( fetchPluginData( 'akismet' ) );
 Data from the aforementioned actions is added to the global state tree, under `plugins.wporg`, with the following structure:
 
 ```js
-state.plugins.wporg = {
+state.plugins.wporg.items = {
 	'akismet': {
 		"isFetching": false,
 		"banners": {

--- a/client/state/plugins/wporg/selectors.js
+++ b/client/state/plugins/wporg/selectors.js
@@ -1,25 +1,22 @@
-export const getPlugin = function ( state, pluginSlug ) {
-	if ( ! state || ! state[ pluginSlug ] ) {
-		return null;
-	}
-	return Object.assign( {}, state[ pluginSlug ] );
-};
+export function getAllPlugins( state ) {
+	return state?.plugins.wporg.items;
+}
 
-export const isFetching = function ( state, pluginSlug ) {
+export function getPlugin( state, pluginSlug ) {
+	const plugin = state?.plugins.wporg.items[ pluginSlug ] ?? null;
+	return plugin ? { ...plugin } : plugin;
+}
+
+export function isFetching( state, pluginSlug ) {
 	// if the `isFetching` attribute doesn't exist yet,
 	// we assume we are still launching the fetch action, so it's true
-	if ( typeof state[ pluginSlug ] === 'undefined' ) {
-		return true;
-	}
-	return state[ pluginSlug ];
-};
+	const status = state?.plugins.wporg.fetchingItems[ pluginSlug ];
+	return status === undefined ? true : status;
+}
 
-export const isFetched = function ( state, pluginSlug ) {
+export function isFetched( state, pluginSlug ) {
 	const plugin = getPlugin( state, pluginSlug );
 	// if the plugin or the `isFetching` attribute doesn't exist yet,
 	// we assume we are still launching the fetch action, so it's true
-	if ( ! plugin ) {
-		return false;
-	}
-	return !! plugin.fetched;
-};
+	return plugin ? !! plugin.fetched : false;
+}

--- a/client/state/plugins/wporg/test/selectors.js
+++ b/client/state/plugins/wporg/test/selectors.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
 import deepFreeze from 'deep-freeze';
 
 /**
@@ -21,61 +20,64 @@ const fetchingItems = deepFreeze( {
 	fetchedTest: false,
 	fetchedTest2: true,
 } );
+const state = deepFreeze( {
+	plugins: { wporg: { items, fetchingItems } },
+} );
 
 describe( 'WPorg Selectors', () => {
 	test( 'Should contain getPlugin method', () => {
-		assert.equal( typeof getPlugin, 'function' );
+		expect( typeof getPlugin ).toBe( 'function' );
 	} );
 
 	test( 'Should contain isFetching method', () => {
-		assert.equal( typeof isFetching, 'function' );
+		expect( typeof isFetching ).toBe( 'function' );
 	} );
 
 	describe( 'getPlugin', () => {
 		test( 'Should get null if the requested plugin is not in the current state', () => {
-			assert.equal( getPlugin( items, 'no-test' ), null );
+			expect( getPlugin( state, 'no-test' ) ).toBeNull();
 		} );
 
 		test( 'Should get the plugin if the requested plugin is in the current state', () => {
-			assert.equal( getPlugin( items, 'test' ).slug, 'test' );
+			expect( getPlugin( state, 'test' ).slug ).toBe( 'test' );
 		} );
 
 		test( 'Should return a new object with no pointers to the one stored in state', () => {
-			const plugin = getPlugin( items, 'fetchedTest' );
+			const plugin = getPlugin( state, 'fetchedTest' );
 			plugin.fetched = false;
-			assert.equal( getPlugin( items, 'fetchedTest' ).fetched, true );
+			expect( getPlugin( state, 'fetchedTest' ).fetched ).toBe( true );
 		} );
 	} );
 
 	describe( 'isFetching', () => {
 		test( 'Should get `true` if the requested plugin is not in the current state', () => {
-			assert.equal( isFetching( fetchingItems, 'no.test' ), true );
+			expect( isFetching( state, 'no.test' ) ).toBe( true );
 		} );
 
 		test( 'Should get `false` if the requested plugin is not being fetched', () => {
-			assert.equal( isFetching( fetchingItems, 'test' ), false );
+			expect( isFetching( state, 'test' ) ).toBe( false );
 		} );
 
 		test( 'Should get `true` if the requested plugin is being fetched', () => {
-			assert.equal( isFetching( fetchingItems, 'fetchingTest' ), true );
+			expect( isFetching( state, 'fetchingTest' ) ).toBe( true );
 		} );
 	} );
 
 	describe( 'isFetched', () => {
 		test( 'Should get `false` if the requested plugin is not in the current state', () => {
-			assert.equal( isFetched( items, 'no.test' ), false );
+			expect( isFetched( state, 'no.test' ) ).toBe( false );
 		} );
 
 		test( 'Should get `false` if the requested plugin has not being fetched', () => {
-			assert.equal( isFetched( items, 'test' ), false );
+			expect( isFetched( state, 'test' ) ).toBe( false );
 		} );
 
 		test( 'Should get `true` if the requested plugin has being fetched', () => {
-			assert.equal( isFetched( items, 'fetchedTest' ), true );
+			expect( isFetched( state, 'fetchedTest' ) ).toBe( true );
 		} );
 
 		test( "Should get `true` if the requested plugin has being fetched even if it's being fetche again", () => {
-			assert.equal( isFetched( items, 'fetchedTest2' ), true );
+			expect( isFetched( state, 'fetchedTest2' ) ).toBe( true );
 		} );
 	} );
 } );


### PR DESCRIPTION
The so-called selectors weren't real Redux selectors, since they expected to receive a particular branch of the state tree as their first parameter, rather than the global state.

This led to components inlining direct access to state, rather than going through an external selector.

#### Changes proposed in this Pull Request

* Add selector to retrieve all plugins
* Modify existing selectors to take the global state
* Update all code accordingly
* Update tests to use jest expectations
* Tweak some of the code to make it more ES6-like

#### Testing instructions

I don't think I have access to any site for which I can change plugin configuration in Calypso, so I was unable to test this directly, and am unable to provide testing instructions 😕
