### PR TITLE
i18n: Update sub header text state on signup page when locale changes

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -16,6 +16,7 @@ import {
 	isEqual,
 	kebabCase,
 	map,
+	omit,
 	pick,
 	startsWith,
 } from 'lodash';
@@ -473,7 +474,11 @@ class Signup extends React.Component {
 		const domainItem = get( this.props, 'signupDependencies.domainItem', false );
 		const currentStepProgress = find( this.props.progress, { stepName: this.props.stepName } );
 		const CurrentComponent = this.props.stepComponent;
-		const propsFromConfig = assign( {}, this.props, steps[ this.props.stepName ].props );
+		const propsFromConfig = assign(
+			{},
+			omit( this.props, 'locale' ),
+			steps[ this.props.stepName ].props
+		);
 		const stepKey = this.state.shouldShowLoadingScreen ? 'processing' : this.props.stepName;
 		const flow = flows.getFlow( this.props.flowName );
 		const planWithDomain =

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -65,6 +65,7 @@ export class UserStep extends Component {
 
 		if (
 			this.props.flowName !== nextProps.flowName ||
+			this.props.locale !== nextProps.locale ||
 			this.props.subHeaderText !== nextProps.subHeaderText
 		) {
 			this.setSubHeaderText( nextProps );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update `subHeaderText` state in UserSignup step when `locale` prop changes
* Omit `locale` when passing props UserSignup to avoid overriding the prop from `i18n-calypso`'s `localize` HOC.

**Before:**
![image](https://user-images.githubusercontent.com/2722412/83018006-46cc7b80-a02d-11ea-8fe8-ba4e83d5975e.png)

**After:**
![image](https://user-images.githubusercontent.com/2722412/83018067-59df4b80-a02d-11ea-98c0-b058f2ca3f3b.png)


#### Testing instructions

1. Boot Calypso
2. Open http://calypso.localhost:3000/start/user
3. Switch to a different locale from the language suggestions component and confirm sub header text gets translated properly
