### PR TITLE
Jetpack Cloud: Add new copies to the Setting section

### DIFF
--- a/client/landing/jetpack-cloud/sections/settings/main.jsx
+++ b/client/landing/jetpack-cloud/sections/settings/main.jsx
@@ -87,20 +87,20 @@ const SettingsPage = () => {
 		[ DISCONNECTED ]: {
 			[ NO_PRODUCT ]: '',
 			[ HAS_BACKUP ]: translate(
-				'Enter your server credentials to enable one-click restores for [Real-time/Daily] Backups.'
+				'Enter your server credentials to enable one-click restores for backups.'
 			),
 			[ HAS_SCAN ]: translate(
 				'Enter your server credentials to enable Jetpack to auto fix threats.'
 			),
 			[ HAVE_BOTH ]: translate(
-				'Enter your server credentials to enable one-click restores for backups & to auto-fix threats.'
+				'Enter your server credentials to enable one-click restores for backups and to auto-fix threats.'
 			),
 		},
 		[ CONNECTED ]: {
 			[ NO_PRODUCT ]: '',
 			[ HAS_BACKUP ]: translate( 'One-click restores are enabled.' ),
 			[ HAS_SCAN ]: translate( 'Auto-fix threats are enabled.' ),
-			[ HAVE_BOTH ]: translate( 'One-click restores & auto-fix threats are enabled.' ),
+			[ HAVE_BOTH ]: translate( 'One-click restores and auto-fix threats are enabled.' ),
 		},
 	};
 

--- a/client/landing/jetpack-cloud/sections/settings/main.jsx
+++ b/client/landing/jetpack-cloud/sections/settings/main.jsx
@@ -150,6 +150,7 @@ const SettingsPage = () => {
 					}
 					expanded={ formOpen }
 					onClick={ () => setFormOpen( ! formOpen ) }
+					clickableHeader={ true }
 					className="settings__form-card"
 				>
 					<ServerCredentialsForm

--- a/client/landing/jetpack-cloud/sections/settings/main.jsx
+++ b/client/landing/jetpack-cloud/sections/settings/main.jsx
@@ -75,33 +75,26 @@ const SettingsPage = () => {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId );
 
-	const NO_PRODUCT = 0;
 	const HAS_BACKUP = 1;
 	const HAS_SCAN = 2;
 	const HAVE_BOTH = 3;
 
-	const DISCONNECTED = 0;
-	const CONNECTED = 1;
+	const disconnectedMessages = {
+		[ HAS_BACKUP ]: translate(
+			'Enter your server credentials to enable one-click restores for backups.'
+		),
+		[ HAS_SCAN ]: translate(
+			'Enter your server credentials to enable Jetpack to auto fix threats.'
+		),
+		[ HAVE_BOTH ]: translate(
+			'Enter your server credentials to enable one-click restores for backups and to auto-fix threats.'
+		),
+	};
 
-	const messages = {
-		[ DISCONNECTED ]: {
-			[ NO_PRODUCT ]: '',
-			[ HAS_BACKUP ]: translate(
-				'Enter your server credentials to enable one-click restores for backups.'
-			),
-			[ HAS_SCAN ]: translate(
-				'Enter your server credentials to enable Jetpack to auto fix threats.'
-			),
-			[ HAVE_BOTH ]: translate(
-				'Enter your server credentials to enable one-click restores for backups and to auto-fix threats.'
-			),
-		},
-		[ CONNECTED ]: {
-			[ NO_PRODUCT ]: '',
-			[ HAS_BACKUP ]: translate( 'One-click restores are enabled.' ),
-			[ HAS_SCAN ]: translate( 'Auto-fix threats are enabled.' ),
-			[ HAVE_BOTH ]: translate( 'One-click restores and auto-fix threats are enabled.' ),
-		},
+	const connectedMessages = {
+		[ HAS_BACKUP ]: translate( 'One-click restores are enabled.' ),
+		[ HAS_SCAN ]: translate( 'Auto-fix threats are enabled.' ),
+		[ HAVE_BOTH ]: translate( 'One-click restores and auto-fix threats are enabled.' ),
 	};
 
 	const scanState = useSelector( ( state ) => getSiteScanState( state, siteId ) );
@@ -113,9 +106,17 @@ const SettingsPage = () => {
 	const hasBackup = backupState?.state !== 'unavailable';
 	const hasScan = scanState?.state !== 'unavailable';
 
-	const productCode = hasBackup | ( hasScan << 1 );
+	const messages = isConnected ? connectedMessages : disconnectedMessages;
 
-	const message = messages[ +isConnected ][ productCode ];
+	let message = '';
+
+	if ( hasBackup && hasScan ) {
+		message = messages[ HAVE_BOTH ];
+	} else if ( hasBackup ) {
+		message = messages[ HAS_BACKUP ];
+	} else if ( hasScan ) {
+		message = messages[ HAS_SCAN ];
+	}
 
 	const cardProps = getCardProps( isConnected, message, translate );
 

--- a/client/landing/jetpack-cloud/sections/settings/main.jsx
+++ b/client/landing/jetpack-cloud/sections/settings/main.jsx
@@ -151,7 +151,6 @@ const SettingsPage = () => {
 			{ ! isInitialized && <div className="settings__form-uninitialized" /> }
 			{ isInitialized && (
 				<FoldableCard
-					clickableHeader
 					header={
 						formOpen
 							? translate( 'Hide connection details' )

--- a/client/landing/jetpack-cloud/sections/settings/main.jsx
+++ b/client/landing/jetpack-cloud/sections/settings/main.jsx
@@ -61,20 +61,15 @@ const getCardProps = ( isConnected, message, translate ) => {
 	return disconnectedProps( translate, message );
 };
 
-const ConnectionStatus = ( { cardProps } ) => {
-	// const translate = useTranslate();
-	// const cardProps = isConnected ? connectedProps( translate ) : disconnectedProps( translate );
-
-	return (
-		<Card compact={ true } className={ cardProps.className }>
-			<img className="settings__icon" src={ cardProps.iconPath } alt="" />
-			<div className="settings__details">
-				<div className="settings__details-head"> { cardProps.title } </div>
-				<div>{ cardProps.content }</div>
-			</div>
-		</Card>
-	);
-};
+const ConnectionStatus = ( { cardProps } ) => (
+	<Card compact={ true } className={ cardProps.className }>
+		<img className="settings__icon" src={ cardProps.iconPath } alt="" />
+		<div className="settings__details">
+			<div className="settings__details-head"> { cardProps.title } </div>
+			<div>{ cardProps.content }</div>
+		</div>
+	</Card>
+);
 
 const SettingsPage = () => {
 	const translate = useTranslate();
@@ -120,7 +115,7 @@ const SettingsPage = () => {
 
 	const productCode = hasBackup | ( hasScan << 1 );
 
-	const message = messages[ ( +isConnected ).toString() ][ productCode.toString() ];
+	const message = messages[ +isConnected ][ productCode ];
 
 	const cardProps = getCardProps( isConnected, message, translate );
 

--- a/client/landing/jetpack-cloud/sections/settings/style.scss
+++ b/client/landing/jetpack-cloud/sections/settings/style.scss
@@ -67,8 +67,8 @@
 }
 
 .settings__icon {
-	width: 50px;
-	height: 50px;
+	max-width: 50px;
+	max-height: 50px;
 }
 
 .settings__details-head {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

**Asana: ** 1169345694087188-as-1173737050079927

Include the new copies for the Settings section, depending on the product subscriptions.

**Copy for need credentials:**

- BACKUP ONLY: "Enter your server credentials to enable one-click restores for backups."
- SCAN ONLY: "Enter your server credentials to enable Jetpack to auto fix threats."
- BOTH: "Enter your server credentials to enable one-click restores for backups and to auto-fix threats."

**Copy for has credentials:**

- BOTH: "One-click restores and auto-fix threats are enabled."
- BACKUPS ONLY: "One-click restores are enabled."
- SCAN ONLY: "Auto-fix threats are enabled."

#### Testing instructions

- Apply the changes
- Select a site with Backup and check the copy for with and without credentials
- Select a site with Scan and check the copy for with and without credentials
- Select a site with both products and check the copy for with and without credentials
