### PR TITLE
Jetpack Cloud: improve Jetpack Cloud login page style

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -32,7 +32,11 @@ import {
 	loginUser,
 	resetAuthAccountType,
 } from 'state/login/actions';
-import { isCrowdsignalOAuth2Client, isWooOAuth2Client } from 'lib/oauth2-clients';
+import {
+	isCrowdsignalOAuth2Client,
+	isJetpackCloudOAuth2Client,
+	isWooOAuth2Client,
+} from 'lib/oauth2-clients';
 import { login } from 'lib/paths';
 import { preventWidows } from 'lib/formatting';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
@@ -291,7 +295,7 @@ export class LoginForm extends Component {
 
 	renderWooCommerce() {
 		const isFormDisabled = this.state.isFormDisabledWhileLoading || this.props.isFormDisabled;
-		const { requestError, socialAccountIsLinking: linkingSocialUser } = this.props;
+		const { oauth2Client, requestError, socialAccountIsLinking: linkingSocialUser } = this.props;
 
 		return (
 			<form method="post">
@@ -391,7 +395,7 @@ export class LoginForm extends Component {
 							</Button>
 						</div>
 
-						{ config.isEnabled( 'signup/social' ) && (
+						{ config.isEnabled( 'signup/social' ) && ! isJetpackCloudOAuth2Client( oauth2Client ) && (
 							<div className="login__form-social">
 								<div className="login__form-social-divider">
 									<span>{ this.props.translate( 'or' ) }</span>
@@ -635,7 +639,7 @@ export class LoginForm extends Component {
 					) }
 				</Card>
 
-				{ config.isEnabled( 'signup/social' ) && (
+				{ config.isEnabled( 'signup/social' ) && ! isJetpackCloudOAuth2Client( oauth2Client ) && (
 					<Fragment>
 						<Divider>{ this.props.translate( 'or' ) }</Divider>
 						<SocialLoginForm

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -764,7 +764,7 @@
 		max-width: 375px;
 	}
 
-	.wp-login__links a {
+	.wp-login__links {
 		font-size: 16px;
 		font-weight: 400;
 	}
@@ -959,7 +959,8 @@
 
 	a,
 	a:visited,
-	.login__form-change-username {
+	.login__form-change-username,
+	.wp-login__links button {
 		color: var( --studio-jetpack-green-40 );
 
 		&:hover,

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -277,7 +277,7 @@ export class LoginLinks extends React.Component {
 			locale,
 		} = this.props;
 
-		if ( isJetpackCloudOAuth2Client( oauth2Client ) ) {
+		if ( isJetpackCloudOAuth2Client( oauth2Client ) && '/log-in/authenticator' !== currentRoute ) {
 			return null;
 		}
 

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -277,6 +277,10 @@ export class LoginLinks extends React.Component {
 			locale,
 		} = this.props;
 
+		if ( isJetpackCloudOAuth2Client( oauth2Client ) ) {
+			return null;
+		}
+
 		let signupUrl = config( 'signup_url' );
 		const signupFlow = get( currentQuery, 'signup_flow' );
 		if (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove the "Create new account" button from the bottom of the login page (we already have one in the middle of the screen).
* Set the right color to the "I can't access my phone" link.

#### Testing instructions

* Run this PR with `yarn start`
* Visit wordpress.com and log out from your current session
* Visit cloud.jetpack.com
* You should see Jetpack Cloud login page (stage enviroment)
* Copy everything after `https://wordpress.com/` of the URL
* Replace the current URL with `http://calypso.localhost:3000/` and paste what was copied in the previous step
* You should see Jetpack Cloud login page (dev environment)
* Verify the "Create a new account" no longer appear at the bottom of the card
* Enter your credentials
* Verify that in the "Verification code" step, the "I can't access my phone" link has the same color as the others (Jetpack green)

Fixes 1169345694087188-as-1177555063882882

#### Before
<img src="https://user-images.githubusercontent.com/3418513/83032072-c0ec0880-a00b-11ea-9245-ec1cfb3e2334.png" width="600" />
<img src="https://user-images.githubusercontent.com/3418513/83032286-0577a400-a00c-11ea-87ed-3c2daf61c16e.png" width="600" />

#### After
<img src="https://user-images.githubusercontent.com/3418513/83029802-79fd1380-a009-11ea-9887-b6b02ef603f3.png" width="600" />
<img src="https://user-images.githubusercontent.com/3418513/83031809-6eaae780-a00b-11ea-8532-7c7ec1e67b0b.png" width="600" />
