### PR TITLE
Modularise checklist state

### DIFF
--- a/client/state/checklist/actions.js
+++ b/client/state/checklist/actions.js
@@ -8,6 +8,7 @@ import {
 } from 'state/action-types';
 
 import 'state/data-layer/wpcom/checklist';
+import 'state/checklist/init';
 
 /**
  * Action creator function: SITE_CHECKLIST_RECEIVE

--- a/client/state/checklist/init.js
+++ b/client/state/checklist/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'state/redux-store';
+import checklistReducer from './reducer';
+
+registerReducer( [ 'checklist' ], checklistReducer );

--- a/client/state/checklist/package.json
+++ b/client/state/checklist/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/checklist/reducer.js
+++ b/client/state/checklist/reducer.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { combineReducers, keyedReducer, withSchemaValidation } from 'state/utils';
+import { combineReducers, keyedReducer, withSchemaValidation, withStorageKey } from 'state/utils';
 import {
 	JETPACK_MODULE_ACTIVATE_SUCCESS,
 	JETPACK_MODULE_DEACTIVATE_SUCCESS,
@@ -57,4 +57,6 @@ const reducer = combineReducers( {
 	items,
 } );
 
-export default keyedReducer( 'siteId', reducer );
+const checklistReducer = keyedReducer( 'siteId', reducer );
+
+export default withStorageKey( 'checklist', checklistReducer );

--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -29,7 +29,6 @@ import applicationPasswords from './application-passwords/reducer';
 import atomicHosting from './hosting/reducer';
 import atomicTransfer from './atomic-transfer/reducer';
 import billingTransactions from './billing-transactions/reducer';
-import checklist from './checklist/reducer';
 import connectedApplications from './connected-applications/reducer';
 import countries from './countries/reducer';
 import countryStates from './country-states/reducer';
@@ -113,7 +112,6 @@ const reducers = {
 	atomicHosting,
 	atomicTransfer,
 	billingTransactions,
-	checklist,
 	connectedApplications,
 	countries,
 	countryStates,

--- a/client/state/selectors/get-site-checklist.js
+++ b/client/state/selectors/get-site-checklist.js
@@ -4,6 +4,11 @@
 import { get } from 'lodash';
 
 /**
+ * Internal dependencies
+ */
+import 'state/checklist/init';
+
+/**
  * Returns the checklist for the specified site ID
  *
  * @param  {object}  state  Global state tree


### PR DESCRIPTION
This PR is one of many working on modularising state in Calypso. This one handles the checklist.

For more details on state modularisation, see the [modularised state documentation](https://github.com/Automattic/wp-calypso/blob/master/docs/modularized-state.md) and p4TIVU-9lM-p2.

Note: I added all the reviewers that GitHub suggested. Please feel free to ignore the review request or pull in someone else if you're not comfortable reviewing this PR. Thank you!

Fixes #42426.

#### Changes proposed in this Pull Request

* Modularise checklist state

#### Testing instructions

* Install [Redux DevTools](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en).
* Open DevTools and switch to the Redux tab.
* Open `/read` on the live branch or your local copy of this branch.
* Click `State` on the top right to ensure you see all state, and not just the diff for the last action: 
![image](https://user-images.githubusercontent.com/409615/73774406-d3e87d80-477b-11ea-9f59-3e42cc00101f.png)
* Analyse the tree and note that there's no `checklist` key, even if you expand the list of keys. This indicates that the checklist state hasn't been loaded yet.
* Click `My Sites` on the masterbar, to open My Home.
* Verify that a `checklist` key is added with the checklist state. This indicates that the checklist state has now been loaded.
* Verify that checklist-related functionality works normally. This indicates that I didn't mess up.