### PR TITLE
Jetpack Cloud: Send production traffic to cloud.jetpack.com

### DIFF
--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -720,14 +720,6 @@ module.exports = function () {
 	app.use( setupLoggedInContext );
 	app.use( handleLocaleSubdomains );
 
-	// Temporarily redirect cloud.jetpack.com to jetpack.com in the production enviroment
-	app.use( function ( req, res, next ) {
-		if ( 'jetpack-cloud-production' === calypsoEnv ) {
-			res.redirect( 'https://jetpack.com/' );
-		}
-		next();
-	} );
-
 	// redirect homepage if the Reader is disabled
 	app.get( '/', function ( request, response, next ) {
 		if ( ! config.isEnabled( 'reader' ) && config.isEnabled( 'stats' ) ) {


### PR DESCRIPTION
Currently when a user wants to see Jetpack Cloud production they get sent to jetpack.com

This PR removed that and make Jetpack cloud available to all customers. (Production stays on cloud.jetpack.com)

#### Testing instructions
* Deploy and test that it works as expected.
* Does the code look good?