### PR TITLE
Modularise countries state

### DIFF
--- a/client/state/countries/actions.js
+++ b/client/state/countries/actions.js
@@ -10,6 +10,7 @@ import {
 import 'state/data-layer/wpcom/domains/countries-list/index.js';
 import 'state/data-layer/wpcom/me/transactions/supported-countries';
 import 'state/data-layer/wpcom/meta/sms-country-codes';
+import 'state/countries/init';
 
 export const fetchDomainCountries = () => ( { type: COUNTRIES_DOMAINS_FETCH } );
 

--- a/client/state/countries/init.js
+++ b/client/state/countries/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'state/redux-store';
+import countriesReducer from './reducer';
+
+registerReducer( [ 'countries' ], countriesReducer );

--- a/client/state/countries/package.json
+++ b/client/state/countries/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/countries/reducer.js
+++ b/client/state/countries/reducer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { combineReducers } from 'state/utils';
+import { combineReducers, withStorageKey } from 'state/utils';
 import {
 	COUNTRIES_DOMAINS_UPDATED,
 	COUNTRIES_PAYMENTS_UPDATED,
@@ -17,8 +17,11 @@ const createListReducer = ( updatedActionType ) => ( state = [], action ) => {
 	}
 };
 
-export default combineReducers( {
+const combinedReducer = combineReducers( {
 	domains: createListReducer( COUNTRIES_DOMAINS_UPDATED ),
 	payments: createListReducer( COUNTRIES_PAYMENTS_UPDATED ),
 	sms: createListReducer( COUNTRIES_SMS_UPDATED ),
 } );
+
+const countriesReducer = withStorageKey( 'countries', combinedReducer );
+export default countriesReducer;

--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -31,7 +31,6 @@ import atomicTransfer from './atomic-transfer/reducer';
 import billingTransactions from './billing-transactions/reducer';
 import checklist from './checklist/reducer';
 import connectedApplications from './connected-applications/reducer';
-import countries from './countries/reducer';
 import countryStates from './country-states/reducer';
 import currentUser from './current-user/reducer';
 import { reducer as dataRequests } from './data-layer/wpcom-http/utils';
@@ -115,7 +114,6 @@ const reducers = {
 	billingTransactions,
 	checklist,
 	connectedApplications,
-	countries,
 	countryStates,
 	currentUser,
 	dataRequests,

--- a/client/state/selectors/get-countries.js
+++ b/client/state/selectors/get-countries.js
@@ -4,6 +4,11 @@
 import { get } from 'lodash';
 
 /**
+ * Internal dependencies
+ */
+import 'state/countries/init';
+
+/**
  * Retrieves the list of countries from the specified type.
  *
  * @param {object} state - global state tree


### PR DESCRIPTION
This PR is one of many working on modularising state in Calypso. This one handles countries.

For more details on state modularisation, see the [modularised state documentation](https://github.com/Automattic/wp-calypso/blob/master/docs/modularized-state.md) and p4TIVU-9lM-p2.

Note: I added all the reviewers that GitHub suggested. Please feel free to ignore the review request or pull in someone else if you're not comfortable reviewing this PR. Thank you!

Fixes #42428.

#### Changes proposed in this Pull Request

* Modularise countries state

#### Testing instructions

* Install [Redux DevTools](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en).
* Open DevTools and switch to the Redux tab.
* Open `/read` on the live branch or your local copy of this branch.
* Click `State` on the top right to ensure you see all state, and not just the diff for the last action: 
![image](https://user-images.githubusercontent.com/409615/73774406-d3e87d80-477b-11ea-9f59-3e42cc00101f.png)
* Analyse the tree and note that there's no `countries` key, even if you expand the list of keys. This indicates that the countries state hasn't been loaded yet.
* Click `My Sites` on the masterbar, followed by `Manage` and `Domains` on the sidebar.
* Verify that a `countries` key is added with the countries state. This indicates that the countries state has now been loaded.
* Verify that country-related functionality works normally. This indicates that I didn't mess up.