### PR TITLE
Modularise legal state

### DIFF
--- a/client/state/legal/actions.js
+++ b/client/state/legal/actions.js
@@ -2,7 +2,9 @@
  * Internal dependencies
  */
 import { LEGAL_REQUEST, LEGAL_SET, TOS_ACCEPT } from 'state/action-types';
+
 import 'state/data-layer/wpcom/legal';
+import 'state/legal/init';
 
 export const requestLegalData = () => ( {
 	type: LEGAL_REQUEST,

--- a/client/state/legal/init.js
+++ b/client/state/legal/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'state/redux-store';
+import legalReducer from './reducer';
+
+registerReducer( [ 'legal' ], legalReducer );

--- a/client/state/legal/package.json
+++ b/client/state/legal/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/legal/reducer.js
+++ b/client/state/legal/reducer.js
@@ -2,5 +2,7 @@
  * Internal dependencies
  */
 import { LEGAL_SET } from 'state/action-types';
+import { withStorageKey } from 'state/utils';
 
-export default ( state = {}, { type, legalData } ) => ( type === LEGAL_SET ? legalData : state );
+const reducer = ( state = {}, { type, legalData } ) => ( type === LEGAL_SET ? legalData : state );
+export default withStorageKey( 'legal', reducer );

--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -58,7 +58,6 @@ import jetpackProductInstall from './jetpack-product-install/reducer';
 import jetpackRemoteInstall from './jetpack-remote-install/reducer';
 import jetpackSync from './jetpack-sync/reducer';
 import jitm from './jitm/reducer';
-import legal from './legal/reducer';
 import media from './media/reducer';
 import memberships from './memberships/reducer';
 import mailchimp from './mailchimp/reducer';
@@ -144,7 +143,6 @@ const reducers = {
 	jetpackRemoteInstall,
 	jetpackSync,
 	jitm,
-	legal,
 	media,
 	memberships,
 	mySites,

--- a/client/state/selectors/should-display-tos-update-banner.js
+++ b/client/state/selectors/should-display-tos-update-banner.js
@@ -1,4 +1,9 @@
 /**
+ * Internal dependencies
+ */
+import 'state/legal/init';
+
+/**
  * Indicates if a Terms or Service update banner should be displayed.
  *
  * @param state {object}


### PR DESCRIPTION
This PR is one of many working on modularising state in Calypso. This one handles legal.

For more details on state modularisation, see the [modularised state documentation](https://github.com/Automattic/wp-calypso/blob/master/docs/modularized-state.md) and p4TIVU-9lM-p2.

Note: I added all the reviewers that GitHub suggested. Please feel free to ignore the review request or pull in someone else if you're not comfortable reviewing this PR. Thank you!

Fixes #42455.

#### Changes proposed in this Pull Request

* Modularise legal state

#### Testing instructions

Since legal information can be displayed on the app banner, which is (async) loaded pretty much everywhere, there's no easy way to test this portion of state being loaded. Please ensure that legal functionality continues to work correctly.