### PR TITLE
Modularise mailchimp state

### DIFF
--- a/client/my-sites/marketing/connections/mailchimp-settings.jsx
+++ b/client/my-sites/marketing/connections/mailchimp-settings.jsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { get, isArray } from 'lodash';
+import { isArray } from 'lodash';
 
 /**
  * Internal dependencies
@@ -16,6 +16,8 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 import { isJetpackSite } from 'state/sites/selectors';
+import { getAllLists } from 'state/mailchimp/lists/selectors';
+import { getListId } from 'state/mailchimp/settings/selectors';
 import QueryJetpackConnection from 'components/data/query-jetpack-connection';
 import getJetpackConnectionStatus from 'state/selectors/get-jetpack-connection-status';
 import { localizeUrl } from 'lib/i18n-utils';
@@ -157,12 +159,8 @@ export default connect(
 			siteId,
 			isJetpack,
 			isJetpackConnectionBroken: isJetpack && getJetpackConnectionStatus( state, siteId ) === false,
-			mailchimpLists: get( state, [ 'mailchimp', 'lists', 'items', siteId ], null ),
-			mailchimpListId: get(
-				state,
-				[ 'mailchimp', 'settings', 'items', siteId, 'follower_list_id' ],
-				0
-			),
+			mailchimpLists: getAllLists( state, siteId ),
+			mailchimpListId: getListId( state, siteId ),
 		};
 	},
 	{

--- a/client/state/mailchimp/init.js
+++ b/client/state/mailchimp/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'state/redux-store';
+import mailchimpReducer from './reducer';
+
+registerReducer( [ 'mailchimp' ], mailchimpReducer );

--- a/client/state/mailchimp/lists/actions.js
+++ b/client/state/mailchimp/lists/actions.js
@@ -1,10 +1,10 @@
 /**
  * Internal dependencies
  */
-
 import { MAILCHIMP_LISTS_LIST, MAILCHIMP_LISTS_RECEIVE } from 'state/action-types';
 
 import 'state/data-layer/wpcom/sites/mailchimp';
+import 'state/mailchimp/init';
 
 export const requestList = ( siteId ) => ( {
 	siteId,

--- a/client/state/mailchimp/lists/selectors.js
+++ b/client/state/mailchimp/lists/selectors.js
@@ -1,0 +1,13 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import 'state/mailchimp/init';
+
+export function getAllLists( state, siteId ) {
+	return get( state, [ 'mailchimp', 'lists', 'items', siteId ], null );
+}

--- a/client/state/mailchimp/package.json
+++ b/client/state/mailchimp/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/mailchimp/reducer.js
+++ b/client/state/mailchimp/reducer.js
@@ -1,11 +1,14 @@
 /**
  * Internal dependencies
  */
-import { combineReducers } from 'state/utils';
+import { combineReducers, withStorageKey } from 'state/utils';
 import lists from './lists/reducer';
 import settings from './settings/reducer';
 
-export default combineReducers( {
+const combinedReducer = combineReducers( {
 	lists,
 	settings,
 } );
+
+const mailchimpReducer = withStorageKey( 'mailchimp', combinedReducer );
+export default mailchimpReducer;

--- a/client/state/mailchimp/settings/actions.js
+++ b/client/state/mailchimp/settings/actions.js
@@ -1,7 +1,6 @@
 /**
  * Internal dependencies
  */
-
 import {
 	MAILCHIMP_SETTINGS_LIST,
 	MAILCHIMP_SETTINGS_RECEIVE,
@@ -13,6 +12,7 @@ import {
 import wpcom from 'lib/wp';
 
 import 'state/data-layer/wpcom/sites/mailchimp';
+import 'state/mailchimp/init';
 
 export const requestSettings = ( siteId ) => ( {
 	siteId,

--- a/client/state/mailchimp/settings/selectors.js
+++ b/client/state/mailchimp/settings/selectors.js
@@ -1,0 +1,13 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import 'state/mailchimp/init';
+
+export function getListId( state, siteId ) {
+	return get( state, [ 'mailchimp', 'settings', 'items', siteId, 'follower_list_id' ], 0 );
+}

--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -13,7 +13,6 @@ import { reducer as form } from 'redux-form';
 /**
  * Internal dependencies
  */
-import config from 'config';
 import { combineReducers } from 'state/utils';
 import { reducer as httpData } from 'state/data-layer/http-data';
 
@@ -61,7 +60,6 @@ import jitm from './jitm/reducer';
 import legal from './legal/reducer';
 import media from './media/reducer';
 import memberships from './memberships/reducer';
-import mailchimp from './mailchimp/reducer';
 import mySites from './my-sites/reducer';
 import notices from './notices/reducer';
 import notificationSettings from './notification-settings/reducer';
@@ -185,9 +183,5 @@ const reducers = {
 	users,
 	wordads,
 };
-
-if ( config.isEnabled( 'mailchimp' ) ) {
-	reducers.mailchimp = mailchimp;
-}
 
 export default combineReducers( reducers );


### PR DESCRIPTION
This PR is one of many working on modularising state in Calypso. This one handles mailchimp.

For more details on state modularisation, see the [modularised state documentation](https://github.com/Automattic/wp-calypso/blob/master/docs/modularized-state.md) and p4TIVU-9lM-p2.

Note: I added all the reviewers that GitHub suggested. Please feel free to ignore the review request or pull in someone else if you're not comfortable reviewing this PR. Thank you!

Fixes #42458.

#### Changes proposed in this Pull Request

* Modularise mailchimp state
* Extract inline selectors into their own modules

#### Testing instructions

* Install [Redux DevTools](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en).
* Open DevTools and switch to the Redux tab.
* Open `/read` on the live branch or your local copy of this branch.
* Click `State` on the top right to ensure you see all state, and not just the diff for the last action: 
![image](https://user-images.githubusercontent.com/409615/73774406-d3e87d80-477b-11ea-9f59-3e42cc00101f.png)
* Analyse the tree and note that there's no `mailchimp` key, even if you expand the list of keys. This indicates that the mailchimp state hasn't been loaded yet.
* Click `My Sites` on the masterbar.
* Choose a site with marketing features enabled.
* Click `Tools`, followed by `Marketing` in the sidebar.
* Verify that a `mailchimp` key is added with the mailchimp state. This indicates that the mailchimp state has now been loaded.
* Verify that mailchimp-related functionality works normally. This indicates that I didn't mess up.