### PR TITLE
Ensure that we can distinguish TrainTracks data for domain-only searches

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -1213,8 +1213,6 @@ class RegisterDomainStep extends React.Component {
 				this.state.availableTlds.length > 0 ) ||
 			this.state.loadingResults;
 
-		const isSignup = this.props.isSignupStep ? '/signup' : '/domains';
-
 		const hasResults =
 			( Array.isArray( this.state.searchResults ) && this.state.searchResults.length ) > 0 &&
 			! this.state.loadingResults;
@@ -1258,7 +1256,7 @@ class RegisterDomainStep extends React.Component {
 					placeholderQuantity={ PAGE_SIZE }
 					isSignupStep={ this.props.isSignupStep }
 					railcarId={ this.state.railcarId }
-					fetchAlgo={ '/domains/search/' + this.props.vendor + isSignup }
+					fetchAlgo={ this.getFetchAlgo() }
 					cart={ this.props.cart }
 					pendingCheckSuggestion={ this.state.pendingCheckSuggestion }
 					unavailableDomains={ this.state.unavailableDomains }
@@ -1285,6 +1283,18 @@ class RegisterDomainStep extends React.Component {
 				</DomainSearchResults>
 			</>
 		);
+	}
+
+	getFetchAlgo() {
+		const fetchAlgoPrefix = '/domains/search/' + this.props.vendor;
+
+		if ( this.props.isDomainOnly ) {
+			return fetchAlgoPrefix + '/domain-only';
+		}
+		if ( this.props.isSignupStep ) {
+			return fetchAlgoPrefix + '/signup';
+		}
+		return fetchAlgoPrefix + '/domains';
 	}
 
 	getMapDomainUrl() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

At present, the main domain search component only distinguishes between searches from  onboarding and from within Calypso. However, there is a third path, which is for domain-only searches triggered by starting from `https://wordpress.com/domains`.

This change updates the logic to keep the existing two searches as-is, while also introducing a new label for domain-only searches.

#### Testing instructions

For each of the following flows, perform a domain search, and verify that we trigger network requests to `http://pixel.wp.com/t.gif` with the first URL parameter as `railcar=` and the `fetch_algo` parameter as specified below:
1. Start from `/start` and search for a domain. The `fetch_algo` parameter for the railcar requests should be 
`%2Fdomains%2Fsearch%2Fvariation4_front%2Fsignup%2Fdonuts`. (This should remain the same as before.)
2. Start from `/domains` and search for a domain. The `fetch_algo` parameter for the railcar requests should be `%2Fdomains%2Fsearch%2Fvariation4_front%2Fdomain-only%2Fdonuts` -- this is new.
3. Start from within Calypso and visit "Manage" -> "Domains" before clicking on "Add a domain to this site". Search for a domain. The `fetch_algo` parameter for the railcar requests should be `%2Fdomains%2Fsearch%2Fvariation2_front%2Fdonuts`, which is the same as before.