### PR TITLE
Domains: Update TXT record error to be clearer

### DIFF
--- a/client/my-sites/domains/domain-management/dns/txt-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/txt-record.jsx
@@ -24,12 +24,25 @@ class TxtRecord extends React.Component {
 		show: PropTypes.bool.isRequired,
 	};
 
+	getValidationErrorMessage( value ) {
+		const { translate } = this.props;
+
+		if ( value.length === 0 ) {
+			return translate( 'TXT records may not be empty' );
+		} else if ( value.length > 255 ) {
+			return translate( 'TXT records may not exceed 255 characters' );
+		}
+
+		return null;
+	}
+
 	render() {
 		const { fieldValues, isValid, onChange, selectedDomainName, show, translate } = this.props;
 		const classes = classnames( { 'is-hidden': ! show } );
 		const isNameValid = isValid( 'name' );
 		const isDataValid = isValid( 'data' );
 		const hasNonAsciiData = /[^\u0000-\u007f]/.test( fieldValues.data );
+		const validationError = this.getValidationErrorMessage( fieldValues.data );
 
 		return (
 			<div className={ classes }>
@@ -62,11 +75,8 @@ class TxtRecord extends React.Component {
 					{ hasNonAsciiData && (
 						<FormInputValidation text={ translate( 'TXT Record has non-ASCII data' ) } isWarning />
 					) }
-					{ ! isDataValid && (
-						<FormInputValidation
-							text={ translate( 'TXT records may not exceed 255 characters' ) }
-							isError
-						/>
+					{ ! isDataValid && validationError && (
+						<FormInputValidation text={ validationError } isError />
 					) }
 				</FormFieldset>
 			</div>

--- a/client/my-sites/domains/domain-management/dns/txt-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/txt-record.jsx
@@ -63,7 +63,10 @@ class TxtRecord extends React.Component {
 						<FormInputValidation text={ translate( 'TXT Record has non-ASCII data' ) } isWarning />
 					) }
 					{ ! isDataValid && (
-						<FormInputValidation text={ translate( 'Invalid TXT Record' ) } isError />
+						<FormInputValidation
+							text={ translate( 'TXT records may not exceed 255 characters' ) }
+							isError
+						/>
 					) }
 				</FormFieldset>
 			</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the error shown when a user tries to enter a TXT record that is longer than 255 characters.

#### Testing instructions

Try to add a TXT record with a value longer than 255 characters to your domain. You should see the following error:

<img width="690" alt="Screenshot 2020-05-27 at 7 49 08 PM" src="https://user-images.githubusercontent.com/13062352/83054735-2dd6c100-a053-11ea-81d6-195a4de16d42.png">

You should see a similar error as well when the TXT record is empty.
