### PR TITLE
Track Gutenboarding domain searches that use a category

### DIFF
--- a/packages/domain-picker/src/domain-picker/index.tsx
+++ b/packages/domain-picker/src/domain-picker/index.tsx
@@ -241,6 +241,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 											currentSelection?.domain_name === freeSuggestions[ 0 ].domain_name
 										}
 										domainSearch={ domainSearch }
+										categorySlug={ domainCategory }
 										onSelect={ setCurrentSelection }
 										railcarId={ railcarId ? `${ railcarId }0` : undefined }
 										recordAnalytics={ recordAnalytics || undefined }
@@ -259,6 +260,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 											suggestion={ suggestion }
 											isRecommended={ suggestion === recommendedSuggestion }
 											isSelected={ currentSelection?.domain_name === suggestion.domain_name }
+											categorySlug={ domainCategory }
 											onSelect={ setCurrentSelection }
 											key={ suggestion.domain_name }
 											railcarId={ railcarId ? `${ railcarId }${ i + 1 }` : undefined }

--- a/packages/domain-picker/src/domain-picker/suggestion-item.tsx
+++ b/packages/domain-picker/src/domain-picker/suggestion-item.tsx
@@ -15,6 +15,7 @@ interface Props {
 	suggestion: DomainSuggestion;
 	isRecommended?: boolean;
 	isSelected?: boolean;
+	categorySlug?: string;
 	onSelect: ( domainSuggestion: DomainSuggestion ) => void;
 	railcarId: string | undefined;
 	recordAnalytics?: RecordsAnalyticsHandler;
@@ -28,6 +29,7 @@ const DomainPickerSuggestionItem: FunctionComponent< Props > = ( {
 	suggestion,
 	isRecommended = false,
 	isSelected = false,
+	categorySlug = null,
 	onSelect,
 	railcarId,
 	recordAnalytics,
@@ -43,7 +45,9 @@ const DomainPickerSuggestionItem: FunctionComponent< Props > = ( {
 	const domainName = domain.slice( 0, dotPos );
 	const domainTld = domain.slice( dotPos );
 
-	const fetchAlgo = `/domains/search/${ domainSuggestionVendor }/${ analyticsFlowId }`;
+	const fetchAlgo = `/domains/search/${ domainSuggestionVendor }/${ analyticsFlowId }${
+		categorySlug ? '/' + categorySlug : ''
+	}`;
 	const [ previousDomain, setPreviousDomain ] = useState< string | undefined >();
 	const [ previousRailcarId, setPreviousRailcarId ] = useState< string | undefined >();
 

--- a/packages/domain-picker/test/suggestion-item.tsx
+++ b/packages/domain-picker/test/suggestion-item.tsx
@@ -162,6 +162,7 @@ describe( 'traintracks events', () => {
 		[
 			{ prop: 'railcarId', value1: 'id1', value2: 'id2' },
 			{ prop: 'isRecommended', value1: true, value2: false },
+			{ prop: 'categorySlug', value1: null, value2: 'test_category' },
 			{ prop: 'uiPosition', value1: 1, value2: 2 },
 			{
 				prop: 'suggestion',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR adds the category slug to the `fetchAlgo` that gets logged as part of the suggestions TrainTracks data, as we want to be able to track the behaviour for category-driven searches separately from "normal" searches in Gutenboarding.

#### Testing instructions

* Open the network tab
* Start the Gutenboarding flow and pick a site title.
* As soon as it is visible, open the domain picker.
* Verify that you get a number of requests to `http://pixel.wp.com/t.gif` with `railcar` as the leading URL parameter, and that the `fetch_algo` parameter is set to `%2Fdomains%2Fsearch%2Fvariation4_front%2Fgutenboarding` (which is the same as it was before).
* Click on the "More Options" link
* Verify that you get a number of requests to the same URL with the same `fetch_algo` value as above. (11 requests in modal, 6 requests in popover)
* Click on some of the categories and verify that the railcar requests include `/{category_slug}` as a suffix in the `fetch_algo` values. (This is new.)
* Ensure that the suffix is not present in the railcar requests if you move back to the "View All" pseudo-category, and gets added back if you pick a category again.