### PR TITLE
composite-checkout: Update local caches after purchase complete

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -293,8 +293,8 @@ export default function CompositeCheckout( {
 
 			if (
 				( responseCart.create_new_blog &&
-					transactionResult?.purchases?.length > 0 &&
-					transactionResult?.failed_purchases?.length === 0 ) ||
+					Object.keys( transactionResult?.purchases ?? {} ).length > 0 &&
+					Object.keys( transactionResult?.failed_purchases ?? {} ).length === 0 ) ||
 				( isDomainOnly && hasPlan( responseCart ) && ! siteId )
 			) {
 				notices.info( translate( 'Almost done…' ) );

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -142,16 +142,6 @@ export default function CompositeCheckout( {
 	const isLoadingCartSynchronizer =
 		cart && ( ! cart.hasLoadedFromServer || cart.hasPendingServerUpdates );
 
-	const getThankYouUrl = useGetThankYouUrl( {
-		siteSlug,
-		redirectTo,
-		purchaseId,
-		feature,
-		cart,
-		isJetpackNotAtomic,
-		product,
-		siteId,
-	} );
 	const reduxDispatch = useDispatch();
 	const recordEvent = useCallback( createAnalyticsEventHandler( reduxDispatch ), [] );
 
@@ -243,6 +233,17 @@ export default function CompositeCheckout( {
 		showAddCouponSuccessMessage,
 		recordEvent
 	);
+
+	const getThankYouUrl = useGetThankYouUrl( {
+		siteSlug,
+		redirectTo,
+		purchaseId,
+		feature,
+		cart: responseCart,
+		isJetpackNotAtomic,
+		product,
+		siteId,
+	} );
 
 	const moment = useLocalizedMoment();
 	const isDomainOnly = useSelector( ( state ) => isDomainOnlySite( state, siteId ) );

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -98,6 +98,7 @@ import { getDomainNameFromReceiptOrCart } from 'lib/domains/cart-utils';
 import { AUTO_RENEWAL } from 'lib/url/support';
 import { useLocalizedMoment } from 'components/localized-moment';
 import isDomainOnlySite from 'state/selectors/is-domain-only-site';
+import { retrieveSignupDestination, clearSignupDestinationCookie } from 'signup/utils';
 
 const debug = debugFactory( 'calypso:composite-checkout' );
 
@@ -260,6 +261,13 @@ export default function CompositeCheckout( {
 			const receiptId = transactionResult?.receipt_id;
 
 			reduxDispatch( clearPurchases() );
+
+			// Removes the destination cookie only if redirecting to the signup destination.
+			// (e.g. if the destination is an upsell nudge, it does not remove the cookie).
+			const destinationFromCookie = retrieveSignupDestination();
+			if ( url.includes( destinationFromCookie ) ) {
+				clearSignupDestinationCookie();
+			}
 
 			if ( hasRenewalItem( responseCart ) && transactionResult?.purchases ) {
 				displayRenewalSuccessNotice( responseCart, transactionResult.purchases, translate, moment );

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -81,6 +81,11 @@ import {
 	hasDomainRegistration,
 	hasTransferProduct,
 } from 'lib/cart-values/cart-items';
+import QueryContactDetailsCache from 'components/data/query-contact-details-cache';
+import QueryStoredCards from 'components/data/query-stored-cards';
+import QuerySitePlans from 'components/data/query-site-plans';
+import QueryPlans from 'components/data/query-plans';
+import QueryProducts from 'components/data/query-products-list';
 
 const debug = debugFactory( 'calypso:composite-checkout' );
 
@@ -329,6 +334,12 @@ export default function CompositeCheckout( {
 
 		return (
 			<React.Fragment>
+				<QuerySitePlans siteId={ siteId } />
+				<QueryPlans />
+				<QueryProducts />
+				<QueryContactDetailsCache />
+				<QueryStoredCards />
+
 				<ManagedContactDetailsFormFields
 					needsOnlyGoogleAppsDetails={ needsOnlyGoogleAppsDetails }
 					contactDetails={ contactDetails }

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -894,14 +894,16 @@ function displayRenewalSuccessNotice( responseCart, purchases, translate, moment
 	);
 	// and take the first product which matches the product id of the renewalItem
 	const product = purchasedProducts.find( ( item ) => {
-		return item.product_id === renewalItem.product_id;
+		return String( item.product_id ) === String( renewalItem.product_id );
 	} );
 
 	if ( ! product ) {
+		debug( 'no product found for renewal notice matching', renewalItem, 'in', purchasedProducts );
 		return;
 	}
 
 	if ( product.will_auto_renew ) {
+		debug( 'showing notice for product that will auto-renew' );
 		notices.success(
 			translate(
 				'%(productName)s has been renewed and will now auto renew in the future. ' +
@@ -920,6 +922,7 @@ function displayRenewalSuccessNotice( responseCart, purchases, translate, moment
 		return;
 	}
 
+	debug( 'showing notice for product that will not auto-renew' );
 	notices.success(
 		translate(
 			'Success! You renewed %(productName)s for %(duration)s, until %(date)s. ' +

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -259,6 +259,7 @@ export default function CompositeCheckout( {
 
 			const transactionResult = select( 'wpcom' ).getTransactionResult();
 			const receiptId = transactionResult?.receipt_id;
+			debug( 'transactionResult was', transactionResult );
 
 			reduxDispatch( clearPurchases() );
 
@@ -266,14 +267,17 @@ export default function CompositeCheckout( {
 			// (e.g. if the destination is an upsell nudge, it does not remove the cookie).
 			const destinationFromCookie = retrieveSignupDestination();
 			if ( url.includes( destinationFromCookie ) ) {
+				debug( 'clearing redirect url cookie' );
 				clearSignupDestinationCookie();
 			}
 
 			if ( hasRenewalItem( responseCart ) && transactionResult?.purchases ) {
+				debug( 'purchase had a renewal' );
 				displayRenewalSuccessNotice( responseCart, transactionResult.purchases, translate, moment );
 			}
 
 			if ( receiptId && transactionResult?.purchases && transactionResult?.failed_purchases ) {
+				debug( 'fetching receipt' );
 				reduxDispatch(
 					fetchReceiptCompleted( receiptId, {
 						...transactionResult,
@@ -298,6 +302,7 @@ export default function CompositeCheckout( {
 				const domainName = getDomainNameFromReceiptOrCart( transactionResult, responseCart );
 
 				if ( domainName ) {
+					debug( 'purchase needs to fetch before redirect', domainName );
 					fetchSitesAndUser(
 						domainName,
 						() => {
@@ -310,6 +315,7 @@ export default function CompositeCheckout( {
 				}
 			}
 
+			debug( 'just redirecting to', url );
 			page.redirect( url );
 		},
 		[

--- a/client/state/receipts/assembler.js
+++ b/client/state/receipts/assembler.js
@@ -1,3 +1,81 @@
+/**
+ * @typedef RawPurchase
+ * @type {object}
+ * @property {boolean} [delayed_provisioning]
+ * @property {boolean} [free_trial]
+ * @property {boolean} [is_domain_registration]
+ * @property {string} meta
+ * @property {string|number} product_id
+ * @property {string} product_slug
+ * @property {string} product_type
+ * @property {string} product_name
+ * @property {string} product_name_short
+ * @property {string} [registrar_support_url]
+ * @property {boolean} [is_email_verified]
+ * @property {boolean} [is_root_domain_with_us]
+ */
+
+/**
+ * @typedef RawFailedPurchase
+ * @type {object}
+ * @property {string} product_meta
+ * @property {string|number} product_id
+ * @property {string} product_slug
+ * @property {string|number} product_cost
+ * @property {string} product_name
+ */
+
+/**
+ * @typedef Purchase
+ * @type {object}
+ * @property {boolean} delayedProvisioning
+ * @property {boolean} freeTrial
+ * @property {boolean} isDomainRegistration
+ * @property {string} meta
+ * @property {string|number} productId
+ * @property {string} productSlug
+ * @property {string} productType
+ * @property {string} productName
+ * @property {string} productNameShort
+ * @property {string} registrarSupportUrl
+ * @property {boolean} isEmailVerified
+ * @property {boolean} isRootDomainWithUs
+ */
+
+/**
+ * @typedef FailedPurchase
+ * @type {object}
+ * @property {string} meta
+ * @property {string|number} productId
+ * @property {string} productSlug
+ * @property {string|number} productCost
+ * @property {string} productName
+ */
+
+/**
+ * @typedef RawReceiptData
+ * @type {object}
+ * @property {string} receipt_id
+ * @property {string} display_price
+ * @property {RawPurchase[]} purchases
+ * @property {RawFailedPurchase[]} failed_purchases
+ */
+
+/**
+ * @typedef ReceiptData
+ * @type {object}
+ * @property {string} receiptId
+ * @property {string} displayPrice
+ * @property {Purchase[]} purchases
+ * @property {FailedPurchase[]} failedPurchases
+ */
+
+/**
+ * Converts raw receipt data into receipt data
+ *
+ * @param {RawReceiptData} data The raw data returned from the server after a transaction
+ * @returns {ReceiptData} The formatted receipt data
+ */
 export function createReceiptObject( data ) {
 	return {
 		receiptId: data.receipt_id,
@@ -18,7 +96,7 @@ export function createReceiptObject( data ) {
 				isRootDomainWithUs: Boolean( purchase.is_root_domain_with_us ),
 			};
 		} ),
-		failedPurchases: ( data.failedPurchases || [] ).map( ( purchase ) => {
+		failedPurchases: ( data.failed_purchases || [] ).map( ( purchase ) => {
 			return {
 				meta: purchase.product_meta,
 				productId: purchase.product_id,

--- a/client/state/stored-cards/selectors.js
+++ b/client/state/stored-cards/selectors.js
@@ -17,7 +17,7 @@ import { isPaymentAgreement, isCreditCard } from 'lib/checkout/payment-methods';
  */
 
 export const getStoredCards = ( state ) =>
-	state.storedCards.items
+	( state.storedCards?.items ?? [] )
 		.filter( ( method ) => isCreditCard( method ) )
 		.map( ( card ) => ( {
 			...card,
@@ -32,7 +32,7 @@ export const getStoredCards = ( state ) =>
  * @returns {Array} Stored Payment Agreements
  */
 export const getStoredPaymentAgreements = ( state ) =>
-	state.storedCards.items
+	( state.storedCards?.items ?? [] )
 		.filter( ( stored ) => isPaymentAgreement( stored ) )
 		.map( ( method ) => ( {
 			...method,
@@ -71,8 +71,9 @@ export const getStoredCardById = ( state, cardId ) =>
 		.filter( ( card ) => card.stored_details_id === cardId )
 		.shift();
 
-export const hasLoadedStoredCardsFromServer = ( state ) => state.storedCards.hasLoadedFromServer;
+export const hasLoadedStoredCardsFromServer = ( state ) =>
+	Boolean( state.storedCards?.hasLoadedFromServer );
 
 export const isDeletingStoredCard = ( state, cardId ) =>
-	Boolean( state.storedCards.isDeleting[ cardId ] );
-export const isFetchingStoredCards = ( state ) => state.storedCards.isFetching;
+	Boolean( state.storedCards?.isDeleting[ cardId ] );
+export const isFetchingStoredCards = ( state ) => Boolean( state.storedCards?.isFetching );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The `handleCheckoutCompleteRedirect()` function in old checkout performs a bunch of actions before redirecting away. This PR imports those actions more-or-less wholesale into `CompositeCheckout`.

#### Testing instructions

Complete a purchase in composite checkout and be sure that there are no errors, and that the redirect works correctly.

Complete a plan purchase in composite checkout with a new site and be sure that you are redirected to the customer home page and that the plan you purchased is immediately visible in the sidebar. (Fixes #42711)

Complete a renewal purchase in composite checkout and verify that you see a special renewal notice appear after the redirect. Either "X has been renewed and will now auto renew in the future" or "Success! You renewed X for Y until Z. We sent your receipt to E." depending on if the product will auto-renew or not.