### PR TITLE
Jetpack Cloud: Make timeline icons obscure the 'timeline' around them and perfectly align with it

### DIFF
--- a/client/landing/jetpack-cloud/components/activity-card-list/style.scss
+++ b/client/landing/jetpack-cloud/components/activity-card-list/style.scss
@@ -68,7 +68,7 @@
 
 // make sure the vertical lines don't appear through the transparent backgrounds of the icons
 .activity-card-list {
-	> .activity-card {
+	.activity-card {
 		margin-bottom: 32px;
 		.activity-card__time-icon.gridicon {
 			background: var( --color-surface-backdrop );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Modify a SCSS rule to account for change in React markup, so that timeline icons will have a background color again and not be interrupted by the timeline itself

Fixes `1169345694087188-as-1177681663771100`

#### Testing instructions

* Open Jetpack Cloud for a site with Backup.
* Look through the **Activity log**. Verify that timeline icons sit "above" the timeline itself and are not obscured or intersected by it. (See screenshots for more detail.)

#### Screenshots

##### Before

<img width="137" alt="Screen Shot 2020-05-27 at 13 15 37" src="https://user-images.githubusercontent.com/670067/83057197-35c73e80-a01c-11ea-8987-6db057788884.png">
<img width="172" alt="Screen Shot 2020-05-27 at 13 15 26" src="https://user-images.githubusercontent.com/670067/83057196-352ea800-a01c-11ea-873e-d9cf72a5afb6.png">
<img width="144" alt="Screen Shot 2020-05-27 at 13 15 49" src="https://user-images.githubusercontent.com/670067/83057199-35c73e80-a01c-11ea-9816-cc821deb9075.png">


##### After

<img width="237" alt="Screen Shot 2020-05-27 at 13 02 04" src="https://user-images.githubusercontent.com/670067/83057087-0ca6ae00-a01c-11ea-9c13-ad1f5a2f688e.png">

<img width="235" alt="Screen Shot 2020-05-27 at 13 02 17" src="https://user-images.githubusercontent.com/670067/83057088-0d3f4480-a01c-11ea-8228-07d4399c6040.png">

<img width="240" alt="Screen Shot 2020-05-27 at 13 02 50" src="https://user-images.githubusercontent.com/670067/83057090-0d3f4480-a01c-11ea-9774-11b5e345a662.png">
