### PR TITLE
Checkout: query site to populate/refresh state after purchase is complete

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -26,6 +26,7 @@ import { CheckoutProvider, defaultRegistry } from '@automattic/composite-checkou
  * Internal dependencies
  */
 import { requestPlans } from 'state/plans/actions';
+import { requestSite } from 'state/sites/actions';
 import {
 	computeProductsWithPrices,
 	getProductsList,
@@ -227,6 +228,10 @@ export default function CompositeCheckout( {
 	const onPaymentComplete = useCallback(
 		( { paymentMethodId } ) => {
 			debug( 'payment completed successfully' );
+
+			// Populate new site state for sites from Signup.
+			reduxDispatch( requestSite( siteId ) );
+
 			const url = getThankYouUrl();
 			recordEvent( {
 				type: 'PAYMENT_COMPLETE',


### PR DESCRIPTION
This makes a call to the `/sites/%site` after the purchase is complete to update the Calypso state. Fixes: #42711

**To test:**
- create a new site with a plan in Signup (or add a new site to an existing account from the sidebar)
- after completing your purchase, verify that the new plan is reflected in the sidebar