### PR TITLE
Composite Checkout: add default error message to CheckoutStepBody

### DIFF
--- a/packages/composite-checkout/demo/index.js
+++ b/packages/composite-checkout/demo/index.js
@@ -398,7 +398,6 @@ function MyCheckoutBody() {
 					activeStepContent={ orderSummaryStep.activeStepContent }
 					completeStepContent={ orderSummaryStep.completeStepContent }
 					titleContent={ orderSummaryStep.titleContent }
-					errorMessage={ 'There was an error with this step.' }
 					isStepActive={ false }
 					isStepComplete={ true }
 					stepNumber={ 1 }

--- a/packages/composite-checkout/src/components/checkout-steps.js
+++ b/packages/composite-checkout/src/components/checkout-steps.js
@@ -342,8 +342,12 @@ export function CheckoutStepBody( {
 	completeStepContent,
 	onError,
 } ) {
+	const localize = useLocalize();
 	return (
-		<CheckoutErrorBoundary errorMessage={ errorMessage } onError={ onError }>
+		<CheckoutErrorBoundary
+			errorMessage={ errorMessage || localize( 'There was an error with this step.' ) }
+			onError={ onError }
+		>
 			<StepWrapperUI
 				isActive={ isStepActive }
 				isComplete={ isStepComplete }

--- a/packages/composite-checkout/src/components/checkout-steps.js
+++ b/packages/composite-checkout/src/components/checkout-steps.js
@@ -93,7 +93,6 @@ function DefaultCheckoutSteps() {
 					activeStepContent={ orderSummaryStep.activeStepContent }
 					completeStepContent={ orderSummaryStep.completeStepContent }
 					titleContent={ orderSummaryStep.titleContent }
-					errorMessage={ 'There was an error with this step.' }
 					isStepActive={ false }
 					isStepComplete={ true }
 					stepNumber={ 1 }
@@ -294,7 +293,6 @@ export function CheckoutStep( {
 
 	return (
 		<CheckoutStepBody
-			errorMessage={ localize( 'There was an error with this step.' ) }
 			onError={ onError }
 			editButtonText={ editButtonText || localize( 'Edit' ) }
 			editButtonAriaLabel={ editButtonAriaLabel || localize( 'Edit this step' ) }


### PR DESCRIPTION
`CheckoutErrorBoundary` has a required `errorMessage` prop, but the same prop on `CheckoutStepBody` is optional, resulting in a console error when one isn't explicitly provided.

This adds a default `errorMessage` to `CheckoutStepBody`.

**To test:**
- view composite checkout with `?flags=composite-checkout-force`
- verify that there isn't a console error for the `errorMessage` prop
- throw an exception in one of Checkout's `CheckoutSteps`
- verify that you see the default 'There was an error with this step.' error message for the step