### PR TITLE
Checkout: update couponStatus propType

### DIFF
--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
@@ -155,7 +155,7 @@ WPLineItem.propTypes = {
 	} ),
 	getItemVariants: PropTypes.func,
 	onChangePlanLength: PropTypes.func,
-	couponStatus: PropTypes.bool,
+	couponStatus: PropTypes.string,
 };
 
 function LineItemPrice( { item } ) {
@@ -317,7 +317,7 @@ WPOrderReviewLineItems.propTypes = {
 	),
 	getItemVariants: PropTypes.func,
 	onChangePlanLength: PropTypes.func,
-	couponStatus: PropTypes.bool,
+	couponStatus: PropTypes.string,
 };
 
 const WPOrderReviewList = styled.ul`


### PR DESCRIPTION
`couponStatus` is one of [a number of strings](https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/checkout/composite-checkout/wpcom/hooks/use-shopping-cart.ts#L334) when returned from the endpoint. This updates the relevant propTypes to reflect such.

**To test:**
- visit Checkout with `?flags=composite-checkout-force`
- verify there aren't any console errors regarding the couponStatus propType
- apply a coupon and verify that the correct discount is applied
- finish Checkout and verify that the purchase was successful