### PR TITLE
Recurring Payments: Remove flash of placeholder text on closing the delete dialog.

### DIFF
--- a/client/my-sites/earn/memberships/delete-plan-modal.jsx
+++ b/client/my-sites/earn/memberships/delete-plan-modal.jsx
@@ -1,0 +1,65 @@
+/**
+ * External dependencies
+ */
+
+import React from 'react';
+import { connect } from 'react-redux';
+import { useTranslate } from 'i18n-calypso';
+import Notice from 'components/notice';
+
+/**
+ * Internal dependencies
+ */
+import { Dialog } from '@automattic/components';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { requestDeleteProduct } from 'state/memberships/product-list/actions';
+
+const RecurringPaymentsPlanDeleteModal = ( { closeDialog, deleteProduct, product, siteId } ) => {
+	const translate = useTranslate();
+
+	const onClose = ( reason ) => {
+		if ( reason === 'delete' ) {
+			deleteProduct( siteId, product, translate( '"%s" was deleted.', { args: product.title } ) );
+		}
+		closeDialog();
+	};
+
+	return (
+		<Dialog
+			isVisible={ true }
+			buttons={ [
+				{
+					label: translate( 'Cancel' ),
+					action: 'cancel',
+				},
+				{
+					label: translate( 'Delete' ),
+					isPrimary: true,
+					action: 'delete',
+				},
+			] }
+			onClose={ onClose }
+		>
+			<h1>{ translate( 'Confirmation' ) }</h1>
+			<p>
+				{ translate( 'Do you want to delete "%s"?', {
+					args: product?.title,
+				} ) }
+			</p>
+			<Notice
+				text={ translate(
+					'Deleting a product does not cancel the subscription for existing subscribers.{{br/}}They will continue to be charged even after you delete it.',
+					{ components: { br: <br /> } }
+				) }
+				showDismiss={ false }
+			/>
+		</Dialog>
+	);
+};
+
+export default connect(
+	( state ) => ( {
+		siteId: getSelectedSiteId( state ),
+	} ),
+	{ deleteProduct: requestDeleteProduct }
+)( RecurringPaymentsPlanDeleteModal );

--- a/client/my-sites/earn/memberships/products.jsx
+++ b/client/my-sites/earn/memberships/products.jsx
@@ -7,7 +7,6 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
 import formatCurrency from '@automattic/format-currency';
-import Notice from 'components/notice';
 
 /**
  * Internal dependencies
@@ -16,27 +15,29 @@ import './style.scss';
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import HeaderCake from 'components/header-cake';
 import SectionHeader from 'components/section-header';
-import { Button, CompactCard, Dialog } from '@automattic/components';
+import { Button, CompactCard } from '@automattic/components';
 import QueryMembershipProducts from 'components/data/query-memberships';
 import EllipsisMenu from 'components/ellipsis-menu';
 import PopoverMenuItem from 'components/popover/menu-item';
 import Gridicon from 'components/gridicon';
-import { requestDeleteProduct } from 'state/memberships/product-list/actions';
 import RecurringPaymentsPlanAddEditModal from './add-edit-plan-modal';
+import RecurringPaymentsPlanDeleteModal from './delete-plan-modal';
 
 class MembershipsProductsSection extends Component {
 	state = {
-		showDialog: false,
+		showAddEditDialog: false,
+		showDeleteDialog: false,
 		product: null,
 	};
+
 	renderEllipsisMenu( productId ) {
 		return (
 			<EllipsisMenu position="bottom left">
-				<PopoverMenuItem onClick={ () => this.openProductDialog( productId ) }>
+				<PopoverMenuItem onClick={ () => this.openAddEditDialog( productId ) }>
 					<Gridicon size={ 18 } icon={ 'pencil' } />
 					{ this.props.translate( 'Edit' ) }
 				</PopoverMenuItem>
-				<PopoverMenuItem onClick={ () => this.setState( { deletedProductId: productId } ) }>
+				<PopoverMenuItem onClick={ () => this.openDeleteDialog( productId ) }>
 					<Gridicon size={ 18 } icon={ 'trash' } />
 					{ this.props.translate( 'Delete' ) }
 				</PopoverMenuItem>
@@ -44,30 +45,23 @@ class MembershipsProductsSection extends Component {
 		);
 	}
 
-	openProductDialog = ( editedProductId ) => {
-		if ( editedProductId ) {
-			const product = this.props.products.find( ( prod ) => prod.ID === editedProductId );
-			this.setState( { showDialog: true, product } );
+	openAddEditDialog = ( productId ) => {
+		if ( productId ) {
+			const product = this.props.products.find( ( prod ) => prod.ID === productId );
+			this.setState( { showAddEditDialog: true, product } );
 		} else {
-			this.setState( { showDialog: true, product: null } );
+			this.setState( { showAddEditDialog: true, product: null } );
 		}
 	};
 
-	onCloseDeleteProduct = ( reason ) => {
-		if ( reason === 'delete' ) {
-			const product = this.props.products
-				.filter( ( p ) => p.ID === this.state.deletedProductId )
-				.pop();
-			this.props.requestDeleteProduct(
-				this.props.siteId,
-				product,
-				this.props.translate( '"%s" was deleted.', { args: product.title } )
-			);
+	openDeleteDialog = ( productId ) => {
+		if ( productId ) {
+			const product = this.props.products.find( ( prod ) => prod.ID === productId );
+			this.setState( { showDeleteDialog: true, product } );
 		}
-		this.setState( { deletedProductId: null } );
 	};
 
-	closeDialog = () => this.setState( { showDialog: false } );
+	closeDialog = () => this.setState( { showAddEditDialog: false, showDeleteDialog: false } );
 
 	render() {
 		return (
@@ -78,7 +72,7 @@ class MembershipsProductsSection extends Component {
 				</HeaderCake>
 
 				<SectionHeader>
-					<Button primary compact onClick={ () => this.openProductDialog( null ) }>
+					<Button primary compact onClick={ () => this.openAddEditDialog( null ) }>
 						{ this.props.translate( 'Add new plan' ) }
 					</Button>
 				</SectionHeader>
@@ -94,60 +88,30 @@ class MembershipsProductsSection extends Component {
 						{ this.renderEllipsisMenu( product.ID ) }
 					</CompactCard>
 				) ) }
-				{ this.state.showDialog && (
+				{ this.state.showAddEditDialog && (
 					<RecurringPaymentsPlanAddEditModal
 						closeDialog={ this.closeDialog }
 						product={ this.state.product }
 					/>
 				) }
-				<Dialog
-					isVisible={ !! this.state.deletedProductId }
-					buttons={ [
-						{
-							label: this.props.translate( 'Cancel' ),
-							action: 'cancel',
-						},
-						{
-							label: this.props.translate( 'Delete' ),
-							isPrimary: true,
-							action: 'delete',
-						},
-					] }
-					onClose={ this.onCloseDeleteProduct }
-				>
-					<h1>{ this.props.translate( 'Confirmation' ) }</h1>
-					<p>
-						{ this.props.translate( 'Do you want to delete "%s"?', {
-							args: get(
-								this.props.products.filter( ( p ) => p.ID === this.state.deletedProductId ),
-								[ 0, 'title' ],
-								''
-							),
-						} ) }
-					</p>
-					<Notice
-						text={ this.props.translate(
-							'Deleting a product does not cancel the subscription for existing subscribers.{{br/}}They will continue to be charged even after you delete it.',
-							{ components: { br: <br /> } }
-						) }
-						showDismiss={ false }
+				{ this.state.showDeleteDialog && (
+					<RecurringPaymentsPlanDeleteModal
+						closeDialog={ this.closeDialog }
+						product={ this.state.product }
 					/>
-				</Dialog>
+				) }
 			</div>
 		);
 	}
 }
 
-export default connect(
-	( state ) => {
-		const site = getSelectedSite( state );
-		const siteId = getSelectedSiteId( state );
-		return {
-			site,
-			siteId,
-			siteSlug: getSelectedSiteSlug( state ),
-			products: get( state, [ 'memberships', 'productList', 'items', siteId ], [] ),
-		};
-	},
-	{ requestDeleteProduct }
-)( localize( MembershipsProductsSection ) );
+export default connect( ( state ) => {
+	const site = getSelectedSite( state );
+	const siteId = getSelectedSiteId( state );
+	return {
+		site,
+		siteId,
+		siteSlug: getSelectedSiteSlug( state ),
+		products: get( state, [ 'memberships', 'productList', 'items', siteId ], [] ),
+	};
+} )( localize( MembershipsProductsSection ) );

--- a/client/my-sites/earn/memberships/products.jsx
+++ b/client/my-sites/earn/memberships/products.jsx
@@ -5,7 +5,6 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { get } from 'lodash';
 import formatCurrency from '@automattic/format-currency';
 
 /**
@@ -112,6 +111,6 @@ export default connect( ( state ) => {
 		site,
 		siteId,
 		siteSlug: getSelectedSiteSlug( state ),
-		products: get( state, [ 'memberships', 'productList', 'items', siteId ], [] ),
+		products: state?.memberships?.productList?.items?.[ siteId ],
 	};
 } )( localize( MembershipsProductsSection ) );


### PR DESCRIPTION
When closing the Delete Plan dialog, the plan title flashes from the proper title to the `%s` argument placeholder of the `translate()` call. This PR refactors out the Delete Plan dialog and removes the flash of changing text.

![2020-05-27 12 48 51](https://user-images.githubusercontent.com/349751/83065733-d0be1980-a018-11ea-8c62-f29bdd65df64.gif)


#### Testing instructions

* On this branch, go to `/earn/payments-plans/:site` on a site that can use Recurring Payments.
* Select the ellipsis menu for a plan and choose Delete.
* Click Delete in the dialog, and verify the dialog closes without exposing the `%s` text.
