### PR TITLE
Jetpack Cloud: Last minute auth style tweaks

### DIFF
--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -714,6 +714,11 @@
 	background: var( --studio-gray-0 );
 	min-height: 100%;
 
+	// make sure jetpack logo is the correct green
+	.jetpack-logo__icon-circle {
+		fill: var( --studio-jetpack-green-40 );
+	}
+
 	.step-wrapper .formatted-header {
 		margin-top: 0;
 	}

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -727,6 +727,10 @@
 		form {
 			width: 100%;
 		}
+
+		> :last-child:not( .wp-login__links ) {
+			margin-bottom: 64px;
+		}
 	}
 
 	// primary text rules

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -768,7 +768,9 @@
 
 	.wp-login__links,
 	.login__social,
-	.login__form {
+	.login__form,
+	.two-factor-authentication__verification-code-form,
+	.two-factor-authentication__actions {
 		width: 100%;
 		max-width: 375px;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Style tweaks to Jetpack Cloud Login Flow

#### Testing instructions

- Run this PR with yarn start
- Visit wordpress.com and log out from your current session
- Visit cloud.jetpack.com
- You should see Jetpack Cloud login page (stage enviroment)
- Copy everything after https://wordpress.com/ of the URL
- Replace the current URL with http://calypso.localhost:3000/ and paste what was copied in the previous step
- You should see Jetpack Cloud login page (dev environment)
- Verify every part of the flow works as expected