### PR TITLE
Premium Content: Add Tracks events.

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/container/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/container/edit.js
@@ -315,7 +315,7 @@ function Edit( props ) {
 						isLarge
 						href={ upgradeURL }
 						target="_blank"
-						className="premium-content-block-nudge__button"
+						className="premium-content-block-nudge__button plan-nudge__button"
 					>
 						{ __( 'Upgrade Your Plan', 'premium-content' ) }
 					</Button>

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/container/stripe-nudge.js
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/container/stripe-nudge.js
@@ -27,7 +27,7 @@ export const StripeNudge = ( { autosaveAndRedirect, stripeConnectUrl } ) => (
 					onClick={ autosaveAndRedirect }
 					target="_top"
 					isDefault
-					className="premium-content-block-nudge__button"
+					className="premium-content-block-nudge__button stripe-nudge__button"
 				>
 					{ __( 'Connect', 'premium-content' ) }
 				</Button>,

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/delegate-event-tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/delegate-event-tracking.js
@@ -8,6 +8,8 @@ import debugFactory from 'debug';
  */
 import wpcomBlockEditorCloseClick from './wpcom-block-editor-close-click';
 import wpcomInserterInlineSearchTerm from './wpcom-inserter-inline-search-term';
+import wpcomBlockPremiumContentPlanUpgrade from './wpcom-block-premium-content-plan-upgrade';
+import wpcomBlockPremiumContentStripeConnect from './wpcom-block-premium-content-stripe-connect';
 
 // Debugger.
 const debug = debugFactory( 'wpcom-block-editor:tracking' );
@@ -18,7 +20,12 @@ const debug = debugFactory( 'wpcom-block-editor:tracking' );
  *
  * @type {Array}
  */
-const EVENTS_MAPPING = [ wpcomBlockEditorCloseClick(), wpcomInserterInlineSearchTerm() ];
+const EVENTS_MAPPING = [
+	wpcomBlockEditorCloseClick(),
+	wpcomInserterInlineSearchTerm(),
+	wpcomBlockPremiumContentPlanUpgrade(),
+	wpcomBlockPremiumContentStripeConnect(),
+];
 
 /**
  * Checks the event for a selector which matches

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-premium-content-plan-upgrade.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-premium-content-plan-upgrade.js
@@ -1,0 +1,15 @@
+/**
+ * Internal dependencies
+ */
+import tracksRecordEvent from './track-record-event';
+
+/**
+ * Return the event definition object to track `wpcom_block_premium_content_upgrade_click`.
+ *
+ * @returns {{handler: Function, selector: string, type: string}} event object definition.
+ */
+export default () => ( {
+	selector: '.wp-block[data-type="premium-content/container"] .plan-nudge__button',
+	type: 'click',
+	handler: () => tracksRecordEvent( 'wpcom_block_premium_content_plan_upgrade_click' ),
+} );

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-premium-content-stripe-connect.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-premium-content-stripe-connect.js
@@ -4,7 +4,7 @@
 import tracksRecordEvent from './track-record-event';
 
 /**
- * Return the event definition object to track `wpcom_block_premium_content_upgrade_click`.
+ * Return the event definition object to track `wpcom_block_premium_content_stripe_connect_click `.
  *
  * @returns {{handler: Function, selector: string, type: string}} event object definition.
  */

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-premium-content-stripe-connect.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-premium-content-stripe-connect.js
@@ -1,0 +1,15 @@
+/**
+ * Internal dependencies
+ */
+import tracksRecordEvent from './track-record-event';
+
+/**
+ * Return the event definition object to track `wpcom_block_premium_content_upgrade_click`.
+ *
+ * @returns {{handler: Function, selector: string, type: string}} event object definition.
+ */
+export default () => ( {
+	selector: '.wp-block[data-type="premium-content/container"] .stripe-nudge__button',
+	type: 'click',
+	handler: () => tracksRecordEvent( 'wpcom_block_premium_content_stripe_connect_click' ),
+} );


### PR DESCRIPTION
Add particular Tracks events for user button clicks and actions related to the Premium Content and Recurring Payments blocks.

#### Testing instructions

* Create a new free Simple site.
* Apply this branch to your local Calypso install. You do _not_ need Calypso running to test this PR.
* Sandbox the following: the API, `widgets.wp.com`, and your new test site.
* Sync the FSE plugin to your sandbox: run `yarn dev --sync` from `/apps/full-site-editing`.
* Build the WP.com block editor app: `npx lerna run build --scope='@automattic/wpcom-block-editor'`
* Sync the block editor app build to your sandbox (`scp -rp apps/wpcom-block-editor/dist/* <sandbox-hostname>:public_html/widgets.wp.com/wpcom-block-editor/` from the Calypso root should work – make sure to use a valid hostname or IP for your sandbox).
* Open a new tab and open DevTools.
* Enable console monitoring of our Tracks events with `localStorage.setItem( 'debug', 'wpcom-block-editor:*' );`.
* Check "Preserve log" in the Console panel settings.
* Open `/wp-admin/post-new.php` on your new test site.
* Add the Premium Content block.
* Click the "Upgrade your plan" button and complete the process.
* Back in the editor tab, verify a Tracks event for `wpcom_block_premium_content_plan_upgrade_click`.
* Reload the editor tab.
* Click "Connect" in the Premium Content Stripe nudge. No need to complete the process.
* Back in the editor tab, verify a Tracks event for `wpcom_block_premium_content_stripe_connect_click`.

Part of #41631 
