### PR TITLE
Jetpack Cloud: Add a query parameter called 'login_flow' to the redirect url

### DIFF
--- a/client/state/login/actions/reboot-after-login.ts
+++ b/client/state/login/actions/reboot-after-login.ts
@@ -33,5 +33,15 @@ export const rebootAfterLogin = ( tracksEventArgs: object ) => async (
 		await user.clear();
 	}
 
+	// We want to differentiate users going to `/oauth2/authorize` that are coming from
+	// the login flow by setting the `login_flow` query parameter. The other case would
+	// users going directly to `/oauth2/authorize` because they're already logged in WPCOM.
+	if ( url.startsWith( 'https://public-api.wordpress.com/oauth2/authorize' ) ) {
+		const newUrl = new URL( url );
+		newUrl.searchParams.append( 'login_flow', 'true' );
+		window.location.href = newUrl.toString();
+		return;
+	}
+
 	window.location.href = url;
 };

--- a/client/state/login/actions/reboot-after-login.ts
+++ b/client/state/login/actions/reboot-after-login.ts
@@ -34,7 +34,7 @@ export const rebootAfterLogin = ( tracksEventArgs: object ) => async (
 	}
 
 	// We want to differentiate users going to `/oauth2/authorize` that are coming from
-	// the login flow by setting the `login_flow` query parameter. The other case would
+	// the login flow by setting the `login_flow` query parameter. The other case would be
 	// users going directly to `/oauth2/authorize` because they're already logged in WPCOM.
 	if ( url.startsWith( 'https://public-api.wordpress.com/oauth2/authorize' ) ) {
 		const newUrl = new URL( url );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* We want to detect users visiting the authorize login page that are coming from the login page. For that purpose, we are adding a query parameter called `login_flow` to the redirect URL on that specific case.

#### Testing instructions

* Run this PR with `yarn start` (we want to start Calypso, not Jetpack Cloud)
* Visit wordpress.com and log out from your current session
* Visit cloud.jetpack.com
* You should see Jetpack Cloud login page (stage enviroment)
* Copy everything after `https://wordpress.com/` of the URL
* Replace the current URL with `http://calypso.localhost:3000/` and paste what was copied in the previous step
* You should see Jetpack Cloud login page (dev environment)
* Log in (enter your credentials and the authentication code)
* You should have been redirected to `https://public-api.wordpress.com/oauth2/authorize`
* Verify that at the end of the URL there is the `login_flow=true` query parameter

Fixes 1169345694087188-as-1177552794839369

#### Demo
![image](https://user-images.githubusercontent.com/3418513/83079794-fbc55f00-a052-11ea-8120-c3d636c68e49.png)

