### PR TITLE
composite-checkout: Disable payment method buttons when form is not ready

### DIFF
--- a/packages/composite-checkout/src/components/checkout-payment-methods.js
+++ b/packages/composite-checkout/src/components/checkout-payment-methods.js
@@ -19,6 +19,7 @@ import {
 	useIsStepActive,
 	useIsStepComplete,
 	useEvents,
+	useFormStatus,
 } from '../public-api';
 import CheckoutErrorBoundary from './checkout-error-boundary';
 
@@ -119,6 +120,7 @@ function PaymentMethod( {
 	ariaLabel,
 	summary,
 } ) {
+	const { formStatus } = useFormStatus();
 	if ( summary ) {
 		return inactiveContent;
 	}
@@ -129,6 +131,7 @@ function PaymentMethod( {
 			value={ id }
 			id={ id }
 			checked={ checked }
+			disabled={ formStatus !== 'ready' }
 			onChange={ onClick ? () => onClick( id ) : null }
 			ariaLabel={ ariaLabel }
 			label={ label }

--- a/packages/composite-checkout/src/components/radio-button.js
+++ b/packages/composite-checkout/src/components/radio-button.js
@@ -12,6 +12,7 @@ export default function RadioButton( {
 	onChange,
 	children,
 	label,
+	disabled,
 	id,
 	ariaLabel,
 } ) {
@@ -23,6 +24,7 @@ export default function RadioButton( {
 				type="radio"
 				name={ name }
 				id={ id }
+				disabled={ disabled }
 				value={ value }
 				checked={ checked }
 				onChange={ onChange }
@@ -47,6 +49,7 @@ RadioButton.propTypes = {
 	name: PropTypes.string.isRequired,
 	id: PropTypes.string.isRequired,
 	label: PropTypes.node.isRequired,
+	disabled: PropTypes.bool,
 	checked: PropTypes.bool,
 	value: PropTypes.string.isRequired,
 	onChange: PropTypes.func,

--- a/packages/composite-checkout/src/components/radio-button.js
+++ b/packages/composite-checkout/src/components/radio-button.js
@@ -19,7 +19,7 @@ export default function RadioButton( {
 	const [ isFocused, changeFocus ] = useState( false );
 
 	return (
-		<RadioButtonWrapper isFocused={ isFocused } checked={ checked }>
+		<RadioButtonWrapper disabled={ disabled } isFocused={ isFocused } checked={ checked }>
 			<Radio
 				type="radio"
 				name={ name }
@@ -37,7 +37,7 @@ export default function RadioButton( {
 				readOnly={ ! onChange }
 				aria-label={ ariaLabel }
 			/>
-			<Label checked={ checked } htmlFor={ id }>
+			<Label checked={ checked } htmlFor={ id } disabled={ disabled }>
 				{ label }
 			</Label>
 			{ children && <RadioButtonChildren checked={ checked }>{ children }</RadioButtonChildren> }
@@ -100,11 +100,32 @@ const RadioButtonWrapper = styled.div`
 	:hover svg {
 		filter: grayscale( 0 );
 	}
+
+	${handleWrapperDisabled};
 `;
+
+function handleWrapperDisabled( { disabled } ) {
+	if ( ! disabled ) {
+		return null;
+	}
+
+	return `
+		:before,
+		:hover:before {
+			border: 1px solid lightgray;
+		}
+
+		svg,
+		:hover svg {
+			filter: grayscale( 100% );
+			opacity: 50%;
+		}
+	`;
+}
 
 const Radio = styled.input`
 	position: absolute;
-	opacity: 0;
+	opacity: 0 !important;
 `;
 
 const Label = styled.label`
@@ -151,7 +172,37 @@ const Label = styled.label`
 		box-sizing: border-box;
 		z-index: 3;
 	}
+
+	${handleLabelDisabled};
 `;
+
+function handleLabelDisabled( { disabled } ) {
+	if ( ! disabled ) {
+		return null;
+	}
+
+	return `
+		color: lightgray;
+		font-style: italic;
+		
+		:hover {
+			cursor: default;
+		}
+		
+		:before {
+			border: 1px solid lightgray;
+			background: lightgray;
+		}
+		
+		:after {
+			background: white;
+		}
+		
+		span {
+			color: lightgray;
+		}
+	`;
+}
 
 const RadioButtonChildren = styled.div`
 	display: ${ ( props ) => ( props.checked ? 'block' : 'none' ) };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When the checkout form is pending a cart update or when it is submitting, this PR disables the buttons that let you change the current payment method.

#### Testing instructions

Complete composite checkout and when you click the submit button, verify that while the form is loading, you cannot change payment methods.