### PR TITLE
Gutenboarding: small tweaks and cleanup feature flags

### DIFF
--- a/client/landing/gutenboarding/components/plans/plans-button/index.tsx
+++ b/client/landing/gutenboarding/components/plans/plans-button/index.tsx
@@ -7,7 +7,6 @@ import { useViewportMatch } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@automattic/react-i18n';
-import config from 'config';
 import classnames from 'classnames';
 
 /**
@@ -37,9 +36,7 @@ const PlansButton: React.FunctionComponent< Button.ButtonProps > = ( { ...button
 	const [ isPlansModalVisible, setIsPlanModalVisible ] = React.useState( false );
 
 	const handleButtonClick = () => {
-		if ( config.isEnabled( 'gutenboarding/plans-grid' ) && Step[ currentStep ] !== 'plans' ) {
-			setIsPlanModalVisible( ( isVisible ) => ! isVisible );
-		}
+		setIsPlanModalVisible( ( isVisible ) => ! isVisible );
 	};
 
 	// This hook is different from `getSelectedPlan` in the store.
@@ -58,6 +55,7 @@ const PlansButton: React.FunctionComponent< Button.ButtonProps > = ( { ...button
 			<Button
 				onClick={ handleButtonClick }
 				label={ __( planLabel ) }
+				disabled={ Step[ currentStep ] === 'plans' }
 				className={ classnames( 'plans-button', { 'is-highlighted': isPlanUserSelectedOrPaid } ) }
 				{ ...buttonProps }
 			>

--- a/client/landing/gutenboarding/components/plans/plans-button/style.scss
+++ b/client/landing/gutenboarding/components/plans/plans-button/style.scss
@@ -2,9 +2,16 @@
 
 .plans-button {
 	white-space: nowrap;
+	&[disabled]:hover {
+		color: $dark-gray-primary;
+	}
 
 	&.is-highlighted {
 		color: var( --studio-blue-40 );
+
+		&:hover {
+		 	color: var( --studio-blue-40 );
+		}
 	}
 }
 

--- a/client/landing/gutenboarding/hooks/use-on-site-creation.ts
+++ b/client/landing/gutenboarding/hooks/use-on-site-creation.ts
@@ -4,7 +4,6 @@
 import * as React from 'react';
 import { useDispatch, useSelect } from '@wordpress/data';
 import wp from '../../../lib/wp';
-import { isEnabled } from 'config';
 
 /**
  * Internal dependencies
@@ -118,34 +117,6 @@ export default function useOnSiteCreation() {
 					...flowCompleteTrackingParams,
 					hasCartItems: true,
 				} );
-				go();
-				return;
-			}
-
-			if ( hasPaidDomain && ! isEnabled( 'gutenboarding/plans-grid' ) ) {
-				// I'd rather not make my own product, but this works.
-				// lib/cart-items helpers did not perform well.
-				const domainProduct = {
-					meta: domain?.domain_name,
-					product_id: domain?.product_id,
-					extra: {
-						privacy_available: domain?.supports_privacy,
-						privacy: domain?.supports_privacy,
-						source: 'gutenboarding',
-					},
-				};
-
-				const go = async () => {
-					const cart: Cart = await wpcom.getCart( newSite.site_slug );
-					await wpcom.setCart( newSite.blogid, {
-						...cart,
-						products: [ ...cart.products, domainProduct ],
-					} );
-					resetPlan();
-					resetOnboardStore();
-					setSelectedSite( newSite.blogid );
-					window.location.href = `/start/prelaunch?siteSlug=${ newSite.blogid }`;
-				};
 				go();
 				return;
 			}

--- a/client/landing/gutenboarding/onboarding-block/style-preview/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/index.tsx
@@ -6,7 +6,6 @@ import { useI18n } from '@automattic/react-i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { Button } from '@wordpress/components';
 import { useHistory } from 'react-router-dom';
-import { isEnabled } from 'config';
 
 /**
  * Internal dependencies
@@ -79,7 +78,7 @@ const StylePreview: React.FunctionComponent = () => {
 		// Skip the plans step if the user has used the plans modal to select a plan
 		// If a user has already used the plans step and then gone back, show them the plans step again
 		// to avoid confusion
-		if ( isEnabled( 'gutenboarding/plans-grid' ) && ( ! selectedPlan || hasUsedPlansStep ) ) {
+		if ( ! selectedPlan || hasUsedPlansStep ) {
 			history.push( makePath( Step.Plans ) );
 			return;
 		}

--- a/config/development.json
+++ b/config/development.json
@@ -67,7 +67,6 @@
 		"gdpr-banner": false,
 		"google-my-business": true,
 		"google-drive": true,
-		"gutenboarding/plans-grid": true,
 		"help": true,
 		"help/courses": true,
 		"home/layout-dev": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -42,7 +42,6 @@
 		"external-media/free-photo-library": true,
 		"gdpr-banner": true,
 		"google-my-business": false,
-		"gutenboarding/plans-grid": true,
 		"happychat": false,
 		"help": true,
 		"help/courses": true,

--- a/config/production.json
+++ b/config/production.json
@@ -41,7 +41,6 @@
 		"external-media/free-photo-library": true,
 		"gdpr-banner": true,
 		"google-my-business": true,
-		"gutenboarding/plans-grid": true,
 		"happychat": true,
 		"help": true,
 		"help/courses": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -46,7 +46,6 @@
 		"google-my-business": true,
 		"gutenboarding/mshot-preview": false,
 		"gutenboarding/style-preview-verticals": false,
-		"gutenboarding/plans-grid": true,
 		"happychat": true,
 		"help": true,
 		"help/courses": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -52,7 +52,6 @@
 		"google-my-business": true,
 		"gutenboarding/mshot-preview": false,
 		"gutenboarding/style-preview-verticals": false,
-		"gutenboarding/plans-grid": true,
 		"happychat": true,
 		"help": true,
 		"help/courses": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove `gutenboarding/plans-grid` feature flag no longer needed.
* Use actual disabled state for PlansButton on Plans step. Right now the button seems clickable but nothing happens when you click it.
* Fix redirects based on Gutenboarding persisted state.
  * if Site Title has a value =>  redirect to Design Selector
  * else => redirect to Intent Capture
#### Testing instructions

* With an empty state, by going to `/new/style`, `/new/plans` or `/new/create-site` you should be redirected to `/new`.
* With an existing `siteTitle` value, any of the above should redirect to `/new/design`.
* Going to `/new/design` directly should still work (site title is optional).
* On `/new/plans` step, the Plans Button should be disabled.
