### PR TITLE
Add new domain status route for the all my sites domains view

### DIFF
--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -87,10 +87,10 @@ class CurrentSite extends Component {
 				{ selectedSite && isEnabled( 'current-site/domain-warning' ) && (
 					<AsyncLoad require="my-sites/current-site/domain-warnings" placeholder={ null } />
 				) }
-				{ isEnabled( 'current-site/stale-cart-notice' ) && (
+				{ selectedSite && isEnabled( 'current-site/stale-cart-notice' ) && (
 					<AsyncLoad require="my-sites/current-site/stale-cart-items-notice" placeholder={ null } />
 				) }
-				{ isEnabled( 'current-site/notice' ) && (
+				{ selectedSite && isEnabled( 'current-site/notice' ) && (
 					<AsyncLoad
 						require="my-sites/current-site/notice"
 						placeholder={ null }

--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -21,8 +21,6 @@ import getSelectedOrAllSites from 'state/selectors/get-selected-or-all-sites';
 import { getCurrentUserSiteCount } from 'state/current-user/selectors';
 import { recordGoogleEvent } from 'state/analytics/actions';
 import { hasAllSitesList } from 'state/sites/selectors';
-import { getCurrentRoute } from 'state/selectors/get-current-route';
-import { isUnderDomainManagementAll } from 'my-sites/domains/paths';
 
 /**
  * Style dependencies
@@ -36,6 +34,7 @@ class CurrentSite extends Component {
 		selectedSite: PropTypes.object,
 		translate: PropTypes.func.isRequired,
 		anySiteSelected: PropTypes.array,
+		forceAllSitesView: PropTypes.bool,
 	};
 
 	switchSites = ( event ) => {
@@ -104,14 +103,11 @@ class CurrentSite extends Component {
 }
 
 export default connect(
-	( state ) => {
-		const isAllDomainsView = isUnderDomainManagementAll( getCurrentRoute( state ) );
-		return {
-			selectedSite: isAllDomainsView ? null : getSelectedSite( state ),
-			anySiteSelected: getSelectedOrAllSites( state ),
-			siteCount: getCurrentUserSiteCount( state ),
-			hasAllSitesList: hasAllSitesList( state ),
-		};
-	},
+	( state, ownProps ) => ( {
+		selectedSite: ownProps.forceAllSitesView ? null : getSelectedSite( state ),
+		anySiteSelected: getSelectedOrAllSites( state ),
+		siteCount: getCurrentUserSiteCount( state ),
+		hasAllSitesList: hasAllSitesList( state ),
+	} ),
 	{ recordGoogleEvent, setLayoutFocus }
 )( localize( CurrentSite ) );

--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -22,7 +22,7 @@ import { getCurrentUserSiteCount } from 'state/current-user/selectors';
 import { recordGoogleEvent } from 'state/analytics/actions';
 import { hasAllSitesList } from 'state/sites/selectors';
 import { getCurrentRoute } from 'state/selectors/get-current-route';
-import { domainManagementAllRoot } from 'my-sites/domains/paths';
+import { isUnderDomainManagementAll } from 'my-sites/domains/paths';
 
 /**
  * Style dependencies
@@ -105,10 +105,9 @@ class CurrentSite extends Component {
 
 export default connect(
 	( state ) => {
-		const currentRoute = getCurrentRoute( state );
-		const isAllSitesDomainsView = currentRoute.startsWith( domainManagementAllRoot() + '/' );
+		const isAllDomainsView = isUnderDomainManagementAll( getCurrentRoute( state ) );
 		return {
-			selectedSite: isAllSitesDomainsView ? null : getSelectedSite( state ),
+			selectedSite: isAllDomainsView ? null : getSelectedSite( state ),
 			anySiteSelected: getSelectedOrAllSites( state ),
 			siteCount: getCurrentUserSiteCount( state ),
 			hasAllSitesList: hasAllSitesList( state ),

--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -21,6 +21,8 @@ import getSelectedOrAllSites from 'state/selectors/get-selected-or-all-sites';
 import { getCurrentUserSiteCount } from 'state/current-user/selectors';
 import { recordGoogleEvent } from 'state/analytics/actions';
 import { hasAllSitesList } from 'state/sites/selectors';
+import { getCurrentRoute } from 'state/selectors/get-current-route';
+import { domainManagementAllRoot } from 'my-sites/domains/paths';
 
 /**
  * Style dependencies
@@ -83,7 +85,7 @@ class CurrentSite extends Component {
 				) : (
 					<AllSites />
 				) }
-				{ isEnabled( 'current-site/domain-warning' ) && (
+				{ selectedSite && isEnabled( 'current-site/domain-warning' ) && (
 					<AsyncLoad require="my-sites/current-site/domain-warnings" placeholder={ null } />
 				) }
 				{ isEnabled( 'current-site/stale-cart-notice' ) && (
@@ -102,11 +104,15 @@ class CurrentSite extends Component {
 }
 
 export default connect(
-	( state ) => ( {
-		selectedSite: getSelectedSite( state ),
-		anySiteSelected: getSelectedOrAllSites( state ),
-		siteCount: getCurrentUserSiteCount( state ),
-		hasAllSitesList: hasAllSitesList( state ),
-	} ),
+	( state ) => {
+		const currentRoute = getCurrentRoute( state );
+		const isAllSitesDomainsView = currentRoute.startsWith( domainManagementAllRoot() + '/' );
+		return {
+			selectedSite: isAllSitesDomainsView ? null : getSelectedSite( state ),
+			anySiteSelected: getSelectedOrAllSites( state ),
+			siteCount: getCurrentUserSiteCount( state ),
+			hasAllSitesList: hasAllSitesList( state ),
+		};
+	},
 	{ recordGoogleEvent, setLayoutFocus }
 )( localize( CurrentSite ) );

--- a/client/my-sites/domains/domain-management/edit/index.jsx
+++ b/client/my-sites/domains/domain-management/edit/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { connect } from 'react-redux';
 import React from 'react';
 import page from 'page';
 import { includes } from 'lodash';
@@ -21,6 +22,7 @@ import WpcomDomainType from './domain-types/wpcom-domain-type';
 import RegisteredDomainType from './domain-types/registered-domain-type';
 import MappedDomainType from './domain-types/mapped-domain-type';
 import TransferInDomainType from './domain-types/transfer-in-domain-type';
+import { getCurrentRoute } from 'state/selectors/get-current-route';
 
 /**
  * Style dependencies
@@ -93,8 +95,12 @@ class Edit extends React.Component {
 	};
 
 	goToDomainManagement = () => {
-		page( domainManagementList( this.props.selectedSite.slug ) );
+		page( domainManagementList( this.props.selectedSite.slug, this.props.currentRoute ) );
 	};
 }
 
-export default localize( Edit );
+export default connect( ( state ) => {
+	return {
+		currentRoute: getCurrentRoute( state ),
+	};
+} )( localize( Edit ) );

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -460,7 +460,12 @@ export class List extends React.Component {
 				break;
 
 			default:
-				path = domainManagementEdit( selectedSite.slug, domain.name, null, this.props.currentRoute );
+				path = domainManagementEdit(
+					selectedSite.slug,
+					domain.name,
+					null,
+					this.props.currentRoute
+				);
 				break;
 		}
 

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -50,6 +50,7 @@ import { successNotice, errorNotice } from 'state/notices/actions';
 import getSites from 'state/selectors/get-sites';
 import { currentUserHasFlag, getCurrentUser } from 'state/current-user/selectors';
 import { NON_PRIMARY_DOMAINS_TO_FREE_USERS } from 'state/current-user/constants';
+import { getCurrentRoute } from 'state/selectors/get-current-route';
 /**
  * Style dependencies
  */
@@ -459,7 +460,7 @@ export class List extends React.Component {
 				break;
 
 			default:
-				path = domainManagementEdit( selectedSite.slug, domain.name );
+				path = domainManagementEdit( selectedSite.slug, domain.name, null, this.props.currentRoute );
 				break;
 		}
 
@@ -518,6 +519,7 @@ export default connect(
 		const siteCount = get( getSites( state ), 'length', 0 );
 
 		return {
+			currentRoute: getCurrentRoute( state ),
 			hasDomainCredit: !! ownProps.selectedSite && hasDomainCredit( state, siteId ),
 			isDomainOnly: isDomainOnlySite( state, siteId ),
 			isAtomicSite: isSiteAutomatedTransfer( state, siteId ),

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -189,13 +189,18 @@ export default function () {
 		clientRender
 	);
 
-	page(
-		paths.domainManagementEdit( ':site', ':domain' ),
-		...getCommonHandlers(),
-		domainManagementController.domainManagementEdit,
-		makeLayout,
-		clientRender
-	);
+	registerMultiPage( {
+		paths: [
+			paths.domainManagementEdit( ':site', ':domain' ),
+			paths.domainManagementEdit( ':site', ':domain', null, paths.domainManagementRoot() ),
+		],
+		handlers: [
+			...getCommonHandlers(),
+			domainManagementController.domainManagementEdit,
+			makeLayout,
+			clientRender,
+		],
+	} );
 
 	page(
 		paths.domainManagementSiteRedirect( ':site', ':domain' ),

--- a/client/my-sites/domains/paths.js
+++ b/client/my-sites/domains/paths.js
@@ -18,6 +18,10 @@ function resolveRootPath( relativeTo = null ) {
 	return domainManagementRoot();
 }
 
+export function isUnderDomainManagementAll( path ) {
+	return path.startsWith( domainManagementAllRoot() + '/' );
+}
+
 export function domainAddNew( siteName, searchTerm ) {
 	const path = `/domains/add/${ siteName }`;
 

--- a/client/my-sites/domains/paths.js
+++ b/client/my-sites/domains/paths.js
@@ -4,6 +4,20 @@
 import { filter, startsWith } from 'lodash';
 import { stringify } from 'qs';
 
+function resolveRootPath( relativeTo = null ) {
+	if ( relativeTo ) {
+		if ( relativeTo === domainManagementRoot() ) {
+			return domainManagementAllRoot();
+		}
+
+		if ( relativeTo.startsWith( domainManagementAllRoot() + '/' ) ) {
+			return domainManagementAllRoot();
+		}
+	}
+
+	return domainManagementRoot();
+}
+
 export function domainAddNew( siteName, searchTerm ) {
 	const path = `/domains/add/${ siteName }`;
 
@@ -14,15 +28,22 @@ export function domainAddNew( siteName, searchTerm ) {
 	return path;
 }
 
+export function domainManagementAllRoot() {
+	return '/domains/manage/all';
+}
+
 export function domainManagementRoot() {
 	return '/domains/manage';
 }
 
-export function domainManagementList( siteName ) {
+export function domainManagementList( siteName, relativeTo = null ) {
+	if ( relativeTo && relativeTo.startsWith( domainManagementAllRoot() + '/' ) ) {
+		return domainManagementRoot();
+	}
 	return domainManagementRoot() + '/' + siteName;
 }
 
-export function domainManagementEdit( siteName, domainName, slug ) {
+export function domainManagementEdit( siteName, domainName, slug, relativeTo = null ) {
 	slug = slug || 'edit';
 
 	// Encodes only real domain names and not parameter placeholders
@@ -32,7 +53,7 @@ export function domainManagementEdit( siteName, domainName, slug ) {
 		domainName = encodeURIComponent( encodeURIComponent( domainName ) );
 	}
 
-	return domainManagementRoot() + '/' + domainName + '/' + slug + '/' + siteName;
+	return resolveRootPath( relativeTo ) + '/' + domainName + '/' + slug + '/' + siteName;
 }
 
 export function domainManagementAddGSuiteUsers( siteName, domainName ) {

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -950,7 +950,7 @@ export class MySitesSidebar extends Component {
 		return (
 			<Sidebar>
 				<SidebarRegion>
-					<CurrentSite />
+					<CurrentSite forceAllSitesView={ this.props.forceAllSitesView } />
 					{ this.renderSidebarMenus() }
 				</SidebarRegion>
 				<SidebarFooter>{ this.addNewSite() }</SidebarFooter>
@@ -995,6 +995,7 @@ function mapStateToProps( state ) {
 		canUserUseCustomerHome: canCurrentUserUseCustomerHome( state, siteId ),
 		currentUser,
 		customizeUrl: getCustomizerUrl( state, selectedSiteId ),
+		forceAllSitesView: isAllDomainsView,
 		hasJetpackSites: hasJetpackSites( state ),
 		isDomainOnly: isDomainOnlySite( state, selectedSiteId ),
 		isJetpack,

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -1015,7 +1015,7 @@ function mapStateToProps( state ) {
 		siteId,
 		site,
 		siteSuffix: site ? '/' + site.slug : '',
-		canViewAtomicHosting: ! isAllSitesDomainsView && canSiteViewAtomicHosting( state ),
+		canViewAtomicHosting: ! isAllDomainsView && canSiteViewAtomicHosting( state ),
 		isSiteWPForTeams: isSiteWPForTeams( state, siteId ),
 		siteTasklist: getSiteTaskList( state, siteId ),
 		hideChecklistProgress:

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -79,7 +79,7 @@ import {
 import canSiteViewAtomicHosting from 'state/selectors/can-site-view-atomic-hosting';
 import isSiteWPForTeams from 'state/selectors/is-site-wpforteams';
 import { getCurrentRoute } from 'state/selectors/get-current-route';
-import { domainManagementAllRoot } from 'my-sites/domains/paths';
+import { isUnderDomainManagementAll } from 'my-sites/domains/paths';
 
 import { backupMainPath, backupActivityPath } from 'landing/jetpack-cloud/sections/backups/paths';
 
@@ -962,12 +962,11 @@ export class MySitesSidebar extends Component {
 function mapStateToProps( state ) {
 	const currentUser = getCurrentUser( state );
 
-	const currentRoute = getCurrentRoute( state );
-	const isAllSitesDomainsView = currentRoute.startsWith( domainManagementAllRoot() + '/' );
+	const isAllDomainsView = isUnderDomainManagementAll( getCurrentRoute( state ) );
 
-	const selectedSiteId = isAllSitesDomainsView ? null : getSelectedSiteId( state );
+	const selectedSiteId = isAllDomainsView ? null : getSelectedSiteId( state );
 	const isSingleSite = !! selectedSiteId || currentUser.site_count === 1;
-	const siteId = isAllSitesDomainsView
+	const siteId = isAllDomainsView
 		? null
 		: selectedSiteId || ( isSingleSite && getPrimarySiteId( state ) ) || null;
 	const site = getSite( state, siteId );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add new route for domain status screen that will be used for the all my sites domains view
* Fix the back button too

#### Testing instructions

* Open /domains/manage
* Click on any domain - the left navigation menu shouldn't change
* Click the back button - you should go back to the all my sites domains view

Details: p99Zz8-1em-p2