### PR TITLE
Domain Picker: Extract train tracks to calypso-analytics

### DIFF
--- a/client/landing/gutenboarding/components/domain-picker-button/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-button/index.tsx
@@ -15,11 +15,6 @@ import type { DomainSuggestions } from '@automattic/data-stores';
 import DomainPickerPopover from '../domain-picker-popover';
 import DomainPickerModal from '../domain-picker-modal';
 import { FLOW_ID } from '../../constants';
-import {
-	recordTrainTracksEvent,
-	getNewRailcarId,
-	RecordTrainTracksEventProps,
-} from '../../lib/analytics';
 import { STORE_KEY } from '../../stores/onboard';
 import { useDomainSuggestions } from '../../hooks/use-domain-suggestions';
 import { DOMAIN_SUGGESTIONS_STORE } from '../../stores/domain-suggestions';
@@ -55,15 +50,6 @@ const DomainPickerButton: React.FunctionComponent< Props > = ( {
 		select( DOMAIN_SUGGESTIONS_STORE ).getCategories()
 	);
 
-	const [ railcarId, setRailcarId ] = React.useState< string | undefined >();
-
-	React.useEffect( () => {
-		// Only generate a railcarId when the domain suggestions change and are not empty.
-		if ( domainSuggestions ) {
-			setRailcarId( getNewRailcarId() );
-		}
-	}, [ domainSuggestions, setRailcarId ] );
-
 	const { domainSearch, domainCategory } = useSelect( ( select ) =>
 		select( STORE_KEY ).getState()
 	);
@@ -87,10 +73,6 @@ const DomainPickerButton: React.FunctionComponent< Props > = ( {
 	const handleMoreOptions = () => {
 		setDomainPopoverVisibility( false );
 		setDomainModalVisibility( true );
-	};
-
-	const recordAnalytics = ( event: RecordTrainTracksEventProps ) => {
-		recordTrainTracksEvent( `/${ FLOW_ID }/domain-popover`, event );
 	};
 
 	return (
@@ -125,8 +107,6 @@ const DomainPickerButton: React.FunctionComponent< Props > = ( {
 				onDomainSelect={ onDomainSelect }
 				onMoreOptions={ handleMoreOptions }
 				onClose={ handlePopoverClose }
-				recordAnalytics={ recordAnalytics }
-				railcarId={ railcarId }
 				domainSuggestionVendor={ DOMAIN_SUGGESTION_VENDOR }
 			/>
 			<DomainPickerModal
@@ -143,8 +123,6 @@ const DomainPickerButton: React.FunctionComponent< Props > = ( {
 				currentDomain={ currentDomain }
 				onDomainSelect={ onDomainSelect }
 				onClose={ handleModalClose }
-				recordAnalytics={ recordAnalytics }
-				railcarId={ railcarId }
 				domainSuggestionVendor={ DOMAIN_SUGGESTION_VENDOR }
 			/>
 		</>

--- a/client/landing/gutenboarding/components/domain-picker-button/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-button/index.tsx
@@ -108,6 +108,7 @@ const DomainPickerButton: React.FunctionComponent< Props > = ( {
 				onMoreOptions={ handleMoreOptions }
 				onClose={ handlePopoverClose }
 				domainSuggestionVendor={ DOMAIN_SUGGESTION_VENDOR }
+				analyticsUiAlgo="domain_popover"
 			/>
 			<DomainPickerModal
 				analyticsFlowId={ FLOW_ID }
@@ -124,6 +125,7 @@ const DomainPickerButton: React.FunctionComponent< Props > = ( {
 				onDomainSelect={ onDomainSelect }
 				onClose={ handleModalClose }
 				domainSuggestionVendor={ DOMAIN_SUGGESTION_VENDOR }
+				analyticsUiAlgo="domain_modal"
 			/>
 		</>
 	);

--- a/client/landing/gutenboarding/components/domain-picker-modal/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-modal/index.tsx
@@ -4,11 +4,11 @@
 import * as React from 'react';
 import Modal from 'react-modal';
 import { select } from '@wordpress/data';
+import DomainPicker, { Props as DomainPickerProps } from '@automattic/domain-picker';
 
 /**
  * Internal dependencies
  */
-import DomainPicker, { Props as DomainPickerProps } from '@automattic/domain-picker';
 import { recordEnterModal, recordCloseModal } from '../../lib/analytics';
 import { STORE_KEY } from '../../stores/onboard';
 
@@ -19,7 +19,6 @@ import './style.scss';
 
 interface Props extends DomainPickerProps {
 	isOpen: boolean;
-	onMoreOptions?: () => void;
 }
 
 const DomainPickerModal: React.FunctionComponent< Props > = ( { isOpen, onClose, ...props } ) => {

--- a/client/landing/gutenboarding/components/domain-picker-popover/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-popover/index.tsx
@@ -5,11 +5,11 @@ import * as React from 'react';
 import { Popover } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { select } from '@wordpress/data';
+import DomainPicker, { Props as DomainPickerProps } from '@automattic/domain-picker';
 
 /**
  * Internal dependencies
  */
-import DomainPicker, { Props as DomainPickerProps } from '@automattic/domain-picker';
 import { recordEnterModal, recordCloseModal } from '../../lib/analytics';
 import { STORE_KEY } from '../../stores/onboard';
 

--- a/client/landing/gutenboarding/lib/analytics/index.ts
+++ b/client/landing/gutenboarding/lib/analytics/index.ts
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { v4 as uuid } from 'uuid';
 
 /**
  * Internal dependencies
@@ -69,64 +68,6 @@ export function recordOnboardingError( params: ErrorParameters ): void {
 		error: params.error,
 		step: params.step,
 	} );
-}
-
-interface TrainTracksRenderProps {
-	trainTracksType: 'render';
-	railcarId: string;
-	uiAlgo: string;
-	uiPosition: number;
-	fetchAlgo: string;
-	result: string;
-	query: string;
-}
-
-interface TrainTracksInteractProps {
-	trainTracksType: 'interact';
-	railcarId: string;
-	action: string;
-}
-
-export function recordTrainTracksRender( {
-	railcarId,
-	uiAlgo,
-	uiPosition,
-	fetchAlgo,
-	result,
-	query,
-}: TrainTracksRenderProps ) {
-	recordTracksEvent( 'calypso_traintracks_render', {
-		railcar: railcarId,
-		ui_algo: uiAlgo,
-		ui_position: uiPosition,
-		fetch_algo: fetchAlgo,
-		rec_result: result,
-		fetch_query: query,
-	} );
-}
-
-export function recordTrainTracksInteract( { railcarId, action }: TrainTracksInteractProps ) {
-	recordTracksEvent( 'calypso_traintracks_interact', {
-		railcar: railcarId,
-		action,
-	} );
-}
-
-export type RecordTrainTracksEventProps =
-	| Omit< TrainTracksRenderProps, 'uiAlgo' >
-	| TrainTracksInteractProps;
-
-export function recordTrainTracksEvent( uiAlgo: string, event: RecordTrainTracksEventProps ) {
-	if ( event.trainTracksType === 'render' ) {
-		recordTrainTracksRender( { ...event, uiAlgo } );
-	}
-	if ( event.trainTracksType === 'interact' ) {
-		recordTrainTracksInteract( event );
-	}
-}
-
-export function getNewRailcarId( suffix = 'suggestion' ) {
-	return `${ uuid().replace( /-/g, '' ) }-${ suffix }`;
 }
 
 /**

--- a/packages/calypso-analytics/src/index.ts
+++ b/packages/calypso-analytics/src/index.ts
@@ -14,3 +14,8 @@ export {
 	analyticsEvents,
 	pushEventToTracksQueue,
 } from './tracks';
+export {
+	recordTrainTracksRender,
+	recordTrainTracksInteract,
+	getNewRailcarId,
+} from './train-tracks';

--- a/packages/calypso-analytics/src/train-tracks.ts
+++ b/packages/calypso-analytics/src/train-tracks.ts
@@ -1,0 +1,52 @@
+/**
+ * External Dependencies
+ */
+import { v4 as uuid } from 'uuid';
+
+/**
+ * Internal Dependencies
+ */
+import { recordTracksEvent } from './tracks';
+
+interface TrainTracksRenderProps {
+	railcarId: string;
+	uiAlgo: string;
+	uiPosition: number;
+	fetchAlgo: string;
+	result: string;
+	query: string;
+}
+
+interface TrainTracksInteractProps {
+	railcarId: string;
+	action: string;
+}
+
+export function recordTrainTracksRender( {
+	railcarId,
+	uiAlgo,
+	uiPosition,
+	fetchAlgo,
+	result,
+	query,
+}: TrainTracksRenderProps ) {
+	recordTracksEvent( 'calypso_traintracks_render', {
+		railcar: railcarId,
+		ui_algo: uiAlgo,
+		ui_position: uiPosition,
+		fetch_algo: fetchAlgo,
+		rec_result: result,
+		fetch_query: query,
+	} );
+}
+
+export function recordTrainTracksInteract( { railcarId, action }: TrainTracksInteractProps ) {
+	recordTracksEvent( 'calypso_traintracks_interact', {
+		railcar: railcarId,
+		action,
+	} );
+}
+
+export function getNewRailcarId( suffix = 'recommendation' ) {
+	return `${ uuid().replace( /-/g, '' ) }-${ suffix }`;
+}

--- a/packages/domain-picker/package.json
+++ b/packages/domain-picker/package.json
@@ -32,6 +32,7 @@
 	"dependencies": {
 		"@automattic/data-stores": "^1.0.0-alpha.1",
 		"@automattic/react-i18n": "^1.0.0-alpha.0",
+		"@automattic/calypso-analytics": "^1.0.0-alpha.1",
 		"@wordpress/components": "^9.6.0",
 		"@wordpress/icons": "^2.0.0",
 		"classnames": "^2.2.6",

--- a/packages/domain-picker/src/domain-picker/suggestion-item.tsx
+++ b/packages/domain-picker/src/domain-picker/suggestion-item.tsx
@@ -6,10 +6,9 @@ import { useI18n } from '@automattic/react-i18n';
 import classnames from 'classnames';
 import { sprintf } from '@wordpress/i18n';
 import { v4 as uuid } from 'uuid';
+import { recordTrainTracksRender, recordTrainTracksInteract } from '@automattic/calypso-analytics';
 
 type DomainSuggestion = import('@automattic/data-stores').DomainSuggestions.DomainSuggestion;
-
-import type { RecordsAnalyticsHandler } from '.';
 
 interface Props {
 	suggestion: DomainSuggestion;
@@ -18,7 +17,6 @@ interface Props {
 	categorySlug?: string;
 	onSelect: ( domainSuggestion: DomainSuggestion ) => void;
 	railcarId: string | undefined;
-	recordAnalytics?: RecordsAnalyticsHandler;
 	uiPosition: number;
 	domainSearch: string;
 	analyticsFlowId: string;
@@ -32,7 +30,6 @@ const DomainPickerSuggestionItem: FunctionComponent< Props > = ( {
 	categorySlug = null,
 	onSelect,
 	railcarId,
-	recordAnalytics,
 	uiPosition,
 	domainSearch,
 	analyticsFlowId,
@@ -56,14 +53,9 @@ const DomainPickerSuggestionItem: FunctionComponent< Props > = ( {
 	useEffect( () => {
 		// Only record TrainTracks render event when the domain name and railcarId change.
 		// This effectively records the render event only once for each set of search results.
-		if (
-			domain !== previousDomain &&
-			previousRailcarId !== railcarId &&
-			railcarId &&
-			recordAnalytics
-		) {
-			recordAnalytics( {
-				trainTracksType: 'render',
+		if ( domain !== previousDomain && previousRailcarId !== railcarId && railcarId ) {
+			recordTrainTracksRender( {
+				uiAlgo: `/${ analyticsFlowId }/domain-popover`,
 				fetchAlgo,
 				query: domainSearch,
 				railcarId,
@@ -82,14 +74,13 @@ const DomainPickerSuggestionItem: FunctionComponent< Props > = ( {
 		previousRailcarId,
 		railcarId,
 		uiPosition,
-		recordAnalytics,
+		analyticsFlowId,
 	] );
 
 	const onDomainSelect = () => {
 		// Use previousRailcarId to make sure the select action matches the last rendered railcarId.
-		if ( previousRailcarId && recordAnalytics ) {
-			recordAnalytics( {
-				trainTracksType: 'interact',
+		if ( previousRailcarId ) {
+			recordTrainTracksInteract( {
 				action: 'domain_selected',
 				railcarId: previousRailcarId,
 			} );

--- a/packages/domain-picker/src/domain-picker/suggestion-item.tsx
+++ b/packages/domain-picker/src/domain-picker/suggestion-item.tsx
@@ -6,34 +6,26 @@ import { useI18n } from '@automattic/react-i18n';
 import classnames from 'classnames';
 import { sprintf } from '@wordpress/i18n';
 import { v4 as uuid } from 'uuid';
-import { recordTrainTracksRender, recordTrainTracksInteract } from '@automattic/calypso-analytics';
+import { recordTrainTracksInteract } from '@automattic/calypso-analytics';
 
 type DomainSuggestion = import('@automattic/data-stores').DomainSuggestions.DomainSuggestion;
 
 interface Props {
 	suggestion: DomainSuggestion;
-	isRecommended?: boolean;
-	isSelected?: boolean;
-	categorySlug?: string;
-	onSelect: ( domainSuggestion: DomainSuggestion ) => void;
 	railcarId: string | undefined;
-	uiPosition: number;
-	domainSearch: string;
-	analyticsFlowId: string;
-	domainSuggestionVendor: string;
+	isSelected?: boolean;
+	isRecommended?: boolean;
+	onRender: () => void;
+	onSelect: ( domainSuggestion: DomainSuggestion ) => void;
 }
 
 const DomainPickerSuggestionItem: FunctionComponent< Props > = ( {
 	suggestion,
-	isRecommended = false,
-	isSelected = false,
-	categorySlug = null,
-	onSelect,
 	railcarId,
-	uiPosition,
-	domainSearch,
-	analyticsFlowId,
-	domainSuggestionVendor,
+	isSelected = false,
+	isRecommended = false,
+	onSelect,
+	onRender,
 } ) => {
 	const { __ } = useI18n();
 
@@ -42,9 +34,6 @@ const DomainPickerSuggestionItem: FunctionComponent< Props > = ( {
 	const domainName = domain.slice( 0, dotPos );
 	const domainTld = domain.slice( dotPos );
 
-	const fetchAlgo = `/domains/search/${ domainSuggestionVendor }/${ analyticsFlowId }${
-		categorySlug ? '/' + categorySlug : ''
-	}`;
 	const [ previousDomain, setPreviousDomain ] = useState< string | undefined >();
 	const [ previousRailcarId, setPreviousRailcarId ] = useState< string | undefined >();
 
@@ -54,28 +43,11 @@ const DomainPickerSuggestionItem: FunctionComponent< Props > = ( {
 		// Only record TrainTracks render event when the domain name and railcarId change.
 		// This effectively records the render event only once for each set of search results.
 		if ( domain !== previousDomain && previousRailcarId !== railcarId && railcarId ) {
-			recordTrainTracksRender( {
-				uiAlgo: `/${ analyticsFlowId }/domain-popover`,
-				fetchAlgo,
-				query: domainSearch,
-				railcarId,
-				result: isRecommended ? domain + '#recommended' : domain,
-				uiPosition,
-			} );
+			onRender();
 			setPreviousDomain( domain );
 			setPreviousRailcarId( railcarId );
 		}
-	}, [
-		domain,
-		domainSearch,
-		fetchAlgo,
-		isRecommended,
-		previousDomain,
-		previousRailcarId,
-		railcarId,
-		uiPosition,
-		analyticsFlowId,
-	] );
+	}, [ domain, previousDomain, previousRailcarId, railcarId, onRender ] );
 
 	const onDomainSelect = () => {
 		// Use previousRailcarId to make sure the select action matches the last rendered railcarId.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Move `railcarId` generation and state handling to `DomainPicker`.
* Remove `railcarId` and `recordAnalytics` from `DomainPicker` props.
* Call `recordTrainTracksRender` from  `DomainPicker`
* Remove most of the analytics related props from `SuggestionItem`
* Call `recordTrainTracksInteract` from `SuggestionItem`
* Partial cleanup of `gutenboarding/lib`.
* Allow `ui_algo` to be set by the wrapper UI component.

#### Testing instructions

* When recording `calypso_traintracks_render` event from DomainModal, `ui_algo` prop should have the value `/gutenboarding/domain_modal` instead of `/gutenboarding/domain_popover` which is the value recorded from DomainPopover.
* Nothing else should change in UI or Analytics events fired.

#### To do
- [ ] Fix unit tests (could be done in a follow-up: https://github.com/Automattic/wp-calypso/issues/42638)

Part of https://github.com/Automattic/wp-calypso/issues/42639
