### PR TITLE
My Home Help Search - fix to only show "searching" UI for valid queries

### DIFF
--- a/client/state/inline-help/actions.js
+++ b/client/state/inline-help/actions.js
@@ -33,11 +33,6 @@ export function requestInlineHelpSearchResults( searchQuery = '' ) {
 	return ( dispatch, getState ) => {
 		const contextualResults = getContextualHelpResults( getState() );
 
-		dispatch( {
-			type: INLINE_HELP_SEARCH_REQUEST,
-			searchQuery,
-		} );
-
 		// Ensure empty strings are removed as valid searches.
 		searchQuery = searchQuery.trim();
 
@@ -57,6 +52,11 @@ export function requestInlineHelpSearchResults( searchQuery = '' ) {
 			// Exit early
 			return;
 		}
+
+		dispatch( {
+			type: INLINE_HELP_SEARCH_REQUEST,
+			searchQuery,
+		} );
 
 		wpcom
 			.undocumented()


### PR DESCRIPTION
Currently, when interacting with the `HelpSearch` card on "My Home" (requires patching `code-D43941` to view) if you enter an empty string as the search query (ie: a load of `SPACE` chars) the UI will go into a "loading" state and stay that way.

This PR fixes the action creator to only dispatch the `INLINE_HELP_SEARCH_REQUEST` action if the search is considered valid -that is it should not be an empty string. 

One thing to note is that we do seem to be leaning heavily on actions happening in a certain order in order to have a valid UI state. I wonder whether:

* Dispatching actions one after another can cause UI components to become out of sync.
* This would be better fixed at the component level rather than changing the order of actions.

## Testing instructions

#### Before applying PR

* Apply `code-D43941` to your sandbox.
* Sandbox the API and your test site.
* Go to the "My Home" screen.
* Enter an empty search string into the search input field.
* See infinite loading state.

#### After applying PR

* Checkout this PR's branch.
* Apply `code-D43941` to your sandbox.
* Sandbox the API and your test site.
* Go to the "My Home" screen.
* Enter an empty search string into the search input field.
* See no search is performed and no "loading" UI state is shown.

Fixes https://github.com/Automattic/wp-calypso/issues/42713
