### PR TITLE
Jetpack Cloud: quick fix that disable the metaDiff information

### DIFF
--- a/client/landing/jetpack-cloud/components/daily-backup-status/backup-changes.jsx
+++ b/client/landing/jetpack-cloud/components/daily-backup-status/backup-changes.jsx
@@ -14,22 +14,22 @@ import { useTranslate } from 'i18n-calypso';
  */
 import mediaImage from 'assets/images/illustrations/media.svg';
 
-const renderMetaDiff = ( metaDiff ) => {
-	const metas = [];
+// const renderMetaDiff = ( metaDiff ) => {
+// 	const metas = [];
+//
+// 	metaDiff.forEach( ( meta ) => {
+// 		if ( meta.num > 0 || meta.num < 0 ) {
+// 			const operator = meta.num < 0 ? '' : '+';
+// 			const plural = meta.num > 1 || meta.num < -1 ? 's' : '';
+// 			// TBD: How do we deal with translating these strings?
+// 			metas.push( `${ operator }${ meta.num } ${ meta.type }${ plural }` );
+// 		}
+// 	} );
+//
+// 	return <div className="daily-backup-status__metas">{ metas.join( ', ' ) }</div>;
+// };
 
-	metaDiff.forEach( ( meta ) => {
-		if ( meta.num > 0 || meta.num < 0 ) {
-			const operator = meta.num < 0 ? '' : '+';
-			const plural = meta.num > 1 || meta.num < -1 ? 's' : '';
-			// TBD: How do we deal with translating these strings?
-			metas.push( `${ operator }${ meta.num } ${ meta.type }${ plural }` );
-		}
-	} );
-
-	return <div className="daily-backup-status__metas">{ metas.join( ', ' ) }</div>;
-};
-
-const BackupChanges = ( { deltas, metaDiff } ) => {
+const BackupChanges = ( { deltas } ) => {
 	const translate = useTranslate();
 
 	const mediaCreated = deltas.mediaCreated.map( ( item ) => (
@@ -135,11 +135,13 @@ const BackupChanges = ( { deltas, metaDiff } ) => {
 	} );
 
 	const hasChanges = !! (
-		deltas.mediaCreated.length ||
-		deltas.posts.length ||
-		deltas.plugins.length ||
-		deltas.themes.length ||
-		!! metaDiff.filter( ( diff ) => 0 !== diff.num ).length
+		(
+			deltas.mediaCreated.length ||
+			deltas.posts.length ||
+			deltas.plugins.length ||
+			deltas.themes.length
+		)
+		//|| !! metaDiff.filter( ( diff ) => 0 !== diff.num ).length
 	);
 
 	return (
@@ -184,7 +186,7 @@ const BackupChanges = ( { deltas, metaDiff } ) => {
 					<div className="daily-backup-status__section-plugins">{ themes }</div>
 				</>
 			) }
-			{ renderMetaDiff( metaDiff ) }
+			{ /*{ renderMetaDiff( metaDiff ) }*/ }
 		</div>
 	);
 };

--- a/client/landing/jetpack-cloud/components/daily-backup-status/index.jsx
+++ b/client/landing/jetpack-cloud/components/daily-backup-status/index.jsx
@@ -90,7 +90,7 @@ class DailyBackupStatus extends Component {
 			hasRealtimeBackups,
 			siteSlug,
 			deltas,
-			metaDiff,
+			// metaDiff,
 			translate,
 		} = this.props;
 		const displayDate = this.getDisplayDate( backup.activityTs );
@@ -123,7 +123,8 @@ class DailyBackupStatus extends Component {
 					dispatchRecordTracksEvent={ dispatchRecordTracksEvent }
 				/>
 				{ showBackupDetails && this.renderBackupDetails( backup ) }
-				{ ! hasRealtimeBackups && <BackupChanges { ...{ deltas, metaDiff } } /> }
+				{ /*{ ! hasRealtimeBackups && <BackupChanges { ...{ deltas, metaDiff } } /> }*/ }
+				{ ! hasRealtimeBackups && <BackupChanges { ...{ deltas } } /> }
 			</>
 		);
 	}

--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -15,7 +15,7 @@ import DocumentHead from 'components/data/document-head';
 import { updateFilter, setFilter } from 'state/activity-log/actions';
 import {
 	getDailyBackupDeltas,
-	getMetaDiffForDailyBackup,
+	// getMetaDiffForDailyBackup,
 	isActivityBackup,
 	isSuccessfulRealtimeBackup,
 } from './utils';
@@ -156,7 +156,9 @@ class BackupsPage extends Component {
 		const selectedDateString = moment.parseZone( this.getSelectedDate() ).toISOString( true );
 		const today = applySiteOffset( moment(), { timezone, gmtOffset } );
 		const deltas = getDailyBackupDeltas( logs, selectedDateString );
-		const metaDiff = getMetaDiffForDailyBackup( logs, selectedDateString );
+		// todo: commented as a quick fix before Jetpack Cloud launch. All the non-english account break here.
+		// See: 1169345694087188-as-1176670093007897
+		// const metaDiff = getMetaDiffForDailyBackup( logs, selectedDateString );
 		const hasRealtimeBackups = includes( siteCapabilities, 'backup-realtime' );
 		const isToday = today.isSame( this.getSelectedDate(), 'day' );
 
@@ -202,7 +204,7 @@ class BackupsPage extends Component {
 										hasRealtimeBackups,
 										onDateChange: this.onDateChange,
 										deltas,
-										metaDiff,
+										// metaDiff, todo: commented because the non-english account issue
 										doesRewindNeedCredentials,
 										dispatchRecordTracksEvent,
 									} }
@@ -220,7 +222,6 @@ class BackupsPage extends Component {
 								allowRestore,
 								moment,
 								siteSlug,
-								metaDiff,
 								isToday,
 							} }
 						/>

--- a/client/landing/jetpack-cloud/sections/backups/utils.js
+++ b/client/landing/jetpack-cloud/sections/backups/utils.js
@@ -102,7 +102,7 @@ export const getMetaDiffForDailyBackup = ( logs, date ) => {
 
 	return [
 		{ type: 'Plugin', num: thisMeta.plugins.val - lastMeta.plugins.val },
-		{ type: 'Theme', num: thisMeta.themes.val - lastMeta.themes.val },
+		{ type: 'Theme', num: thisMeta.themes?.val - lastMeta.themes?.val },
 		{ type: 'Upload', num: thisMeta.uploads.val - lastMeta.uploads.val },
 		{ type: 'Post', num: thisMeta.posts.val - lastMeta.posts.val },
 	];


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The issue was breaking the Backup section for the non-English accounts. The problem is that our metaDiff calculation is based on the received text string which is translated, so it breaks the expected tokens (in English). To solve it, simply we disable temporally the metaDiff calculation for the daily backups and comment the code that uses it.

You can reproduce the current issue by changing your account languages to a non-English language. Select a site with a bunch of backups. Go to the Backup section and try to navigate to previous dates. You should have a Javascript error that freezes the app. It happens for Daily and Real-time Backup products.

**Next:**

To solve this issue well, we need a data object with all the info directly from the API, instead of trying to extract it from a text string that could change which is a very fragile method.

#### Testing instructions

- Apply the changes
- Try to reproduce again the issue explained before.
- Check that everything works as expected, for sites with Daily Backup and also for Real-time Backup.
