### PR TITLE
Modularise active promotions state

### DIFF
--- a/client/state/active-promotions/actions.js
+++ b/client/state/active-promotions/actions.js
@@ -1,7 +1,6 @@
 /**
  * Internal dependencies
  */
-
 import {
 	ACTIVE_PROMOTIONS_RECEIVE,
 	ACTIVE_PROMOTIONS_REQUEST,
@@ -10,6 +9,7 @@ import {
 } from 'state/action-types';
 
 import 'state/data-layer/wpcom/active-promotions';
+import 'state/active-promotions/init';
 
 /**
  * Action creator function: RECEIVE
@@ -17,21 +17,21 @@ import 'state/data-layer/wpcom/active-promotions';
  * @param {Array} activePromotions - WordPress.com activePromotions list
  * @returns {object} action object
  */
-export const activePromotionsReceiveAction = ( activePromotions ) => {
+export function activePromotionsReceiveAction( activePromotions ) {
 	return {
 		type: ACTIVE_PROMOTIONS_RECEIVE,
 		activePromotions,
 	};
-};
+}
 
 /**
  * Action creator function: REQUEST_SUCCESS
  *
  * @returns {object} action object
  */
-export const activePromotionsRequestSuccessAction = () => {
+export function activePromotionsRequestSuccessAction() {
 	return { type: ACTIVE_PROMOTIONS_REQUEST_SUCCESS };
-};
+}
 
 /**
  * Action creator function: REQUEST_FAILURE
@@ -39,18 +39,16 @@ export const activePromotionsRequestSuccessAction = () => {
  * @param {string} error - error message
  * @returns {object} action object
  */
-export const activePromotionsRequestFailureAction = ( error ) => {
+export function activePromotionsRequestFailureAction( error ) {
 	return {
 		type: ACTIVE_PROMOTIONS_REQUEST_FAILURE,
 		error: error,
 	};
-};
+}
 
 /**
  * Action creator to request WordPress.com activePromotions: REQUEST
  *
  * @returns {object} action object
  */
-export const requestActivePromotions = () => ( {
-	type: ACTIVE_PROMOTIONS_REQUEST,
-} );
+export const requestActivePromotions = () => ( { type: ACTIVE_PROMOTIONS_REQUEST } );

--- a/client/state/active-promotions/init.js
+++ b/client/state/active-promotions/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'state/redux-store';
+import activePromotionsReducer from './reducer';
+
+registerReducer( [ 'activePromotions' ], activePromotionsReducer );

--- a/client/state/active-promotions/package.json
+++ b/client/state/active-promotions/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/active-promotions/reducer.js
+++ b/client/state/active-promotions/reducer.js
@@ -7,7 +7,7 @@ import {
 	ACTIVE_PROMOTIONS_REQUEST_SUCCESS,
 	ACTIVE_PROMOTIONS_REQUEST_FAILURE,
 } from 'state/action-types';
-import { combineReducers, withSchemaValidation } from 'state/utils';
+import { combineReducers, withSchemaValidation, withStorageKey } from 'state/utils';
 import { itemsSchema } from './schema';
 
 /**
@@ -69,8 +69,11 @@ export const error = ( state = false, action ) => {
 	return state;
 };
 
-export default combineReducers( {
+const combinedReducer = combineReducers( {
 	items,
 	requesting,
 	error,
 } );
+
+const activePromotionsReducer = withStorageKey( 'activePromotions', combinedReducer );
+export default activePromotionsReducer;

--- a/client/state/active-promotions/selectors.js
+++ b/client/state/active-promotions/selectors.js
@@ -1,23 +1,28 @@
 /**
+ * Internal dependencies
+ */
+import 'state/active-promotions/init';
+
+/**
  * Return WordPress activePromotions getting from state object
  *
  * @param {object} state - current state object
  * @returns {Array} WordPress activePromotions
  */
-export const getActivePromotions = ( state ) => {
+export function getActivePromotions( state ) {
 	return state.activePromotions.items;
-};
+}
 
 /**
  * Return if promotion is active
  *
  * @param {object} state - current state object
  * @param {string} name - promotion name
- * @returns {bool} Is promotion active?
+ * @returns {boolean} Is promotion active?
  */
-export const hasActivePromotion = ( state, name ) => {
+export function hasActivePromotion( state, name ) {
 	return getActivePromotions( state ).indexOf( name ) !== -1;
-};
+}
 
 /**
  * Return requesting state
@@ -25,6 +30,6 @@ export const hasActivePromotion = ( state, name ) => {
  * @param {object} state - current state object
  * @returns {boolean} is activePromotions requesting?
  */
-export const isRequestingActivePromotions = ( state ) => {
+export function isRequestingActivePromotions( state ) {
 	return state.activePromotions.requesting;
-};
+}

--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -22,7 +22,6 @@ import { reducer as httpData } from 'state/data-layer/http-data';
  */
 import account from './account/reducer';
 import accountRecovery from './account-recovery/reducer';
-import activePromotions from './active-promotions/reducer';
 import activityLog from './activity-log/reducer';
 import application from './application/reducer';
 import applicationPasswords from './application-passwords/reducer';
@@ -106,7 +105,6 @@ import wordads from './wordads/reducer';
 const reducers = {
 	account,
 	accountRecovery,
-	activePromotions,
 	activityLog,
 	application,
 	applicationPasswords,


### PR DESCRIPTION
This PR is one of many working on modularising state in Calypso. This one handles active promotions.

For more details on state modularisation, see the [modularised state documentation](https://github.com/Automattic/wp-calypso/blob/master/docs/modularized-state.md) and p4TIVU-9lM-p2.

Note: I added all the reviewers that GitHub suggested. Please feel free to ignore the review request or pull in someone else if you're not comfortable reviewing this PR. Thank you!

Fixes #42419.

#### Changes proposed in this Pull Request

* Modularise active promotions state
* Change some arrow function constants to plain functions

#### Testing instructions

* Install [Redux DevTools](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en).
* Open DevTools and switch to the Redux tab.
* Open `/read` on the live branch or your local copy of this branch.
* Click `State` on the top right to ensure you see all state, and not just the diff for the last action: 
![image](https://user-images.githubusercontent.com/409615/73774406-d3e87d80-477b-11ea-9f59-3e42cc00101f.png)
* Analyse the tree and note that there's no `activePromotions` key, even if you expand the list of keys. This indicates that the active promotions state hasn't been loaded yet.
* Click `My Sites` on the masterbar.
* Verify that a `activePromotions` key is added with the active promotions state. This indicates that the active promotions state has now been loaded.
* Verify that active promotion-related functionality works normally. This indicates that I didn't mess up.