### PR TITLE
Premium content: Add paid flag

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/index.js
@@ -1,9 +1,15 @@
+/* eslint-disable wpcalypso/import-docblock */
 /**
  * WordPress dependencies
  */
-import { registerBlockType } from '@wordpress/blocks';
+import apiFetch from '@wordpress/api-fetch';
+import { getBlockType, registerBlockType, unregisterBlockType } from '@wordpress/blocks';
+import { _x } from '@wordpress/i18n';
+/* eslint-enable wpcalypso/import-docblock */
 
-// Register Blocks
+/**
+ * Internal dependencies
+ */
 import * as container from './blocks/container';
 import * as subscriberView from './blocks/subscriber-view';
 import * as loggedOutView from './blocks/logged-out-view';
@@ -13,7 +19,7 @@ import * as loggedOutView from './blocks/logged-out-view';
  *
  * @typedef {import('@wordpress/blocks').BlockConfiguration} BlockConfiguration
  *
- * @typedef {Object} Block
+ * @typedef {object} Block
  * @property {string} name
  * @property {string} category
  * @property {BlockConfiguration} settings
@@ -34,10 +40,39 @@ const registerBlock = ( block ) => {
 };
 
 /**
+ * Appends a "paid" tag to the Premium Content block title if site requires an upgrade.
+ */
+const addPaidBlockFlags = async () => {
+	const membershipsStatus = await apiFetch( { path: '/wpcom/v2/memberships/status' } );
+	const shouldUpgrade = membershipsStatus.should_upgrade_to_access_memberships;
+	if ( shouldUpgrade ) {
+		const premiumContentBlock = getBlockType( container.name );
+		if ( ! premiumContentBlock ) {
+			return;
+		}
+
+		const paidFlag = _x(
+			'paid',
+			'Short label appearing near a block requiring a paid plan',
+			'premium-content'
+		);
+
+		unregisterBlockType( container.name );
+		registerBlockType( container.name, {
+			...premiumContentBlock,
+			title: `${ premiumContentBlock.title } (${ paidFlag })`,
+		} );
+	}
+};
+
+/**
  * Function to register blocks provided by CoBlocks.
  */
 export const registerPremiumContentBlocks = () => {
 	[ container, loggedOutView, subscriberView ].forEach( registerBlock );
+
+	// Done after blocks are registered so the status API request doesn't suspend the execution.
+	addPaidBlockFlags();
 };
 
 registerPremiumContentBlocks();

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/index.js
@@ -43,7 +43,13 @@ const registerBlock = ( block ) => {
  * Appends a "paid" tag to the Premium Content block title if site requires an upgrade.
  */
 const addPaidBlockFlags = async () => {
-	const membershipsStatus = await apiFetch( { path: '/wpcom/v2/memberships/status' } );
+	let membershipsStatus;
+	try {
+		membershipsStatus = await apiFetch( { path: '/wpcom/v2/memberships/status' } );
+	} catch {
+		// Do not add any flag if request fails.
+		return;
+	}
 	const shouldUpgrade = membershipsStatus.should_upgrade_to_access_memberships;
 	if ( shouldUpgrade ) {
 		const premiumContentBlock = getBlockType( container.name );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Appends a "paid" flag to the Premium Content block title displayed on the block inserter when the site requires a upgrade.

<img width="350" alt="Screen Shot 2020-05-28 at 16 03 44" src="https://user-images.githubusercontent.com/1233880/83152024-9da18600-a0fd-11ea-8d49-ce3fee6b8e09.png">
<img width="331" alt="Screen Shot 2020-05-28 at 16 04 52" src="https://user-images.githubusercontent.com/1233880/83152025-9e3a1c80-a0fd-11ea-9927-7fa93ab2194b.png">


#### Testing instructions

* Apply D44086-code or `cd apps/full-site-editing; yarn dev --sync`.
* Sandbox the API.
* Switch to a sandboxed site under a Free plan.
* Add a new post.
* Open the block inserter and search the Premium Content block.
* Make sure the title contains a "paid" flag at the end.
* Upgrade to a paid plan or switch to a sandboxed site under a paid plan.
* Add a new post.
* Open the block inserter and search the Premium Content block.
* Make sure the title does not contain a "paid" flag at the end.

Fixes #41584
