### PR TITLE
Modularise acount state

### DIFF
--- a/client/state/account/actions.js
+++ b/client/state/account/actions.js
@@ -5,6 +5,7 @@ import userFactory from 'lib/user';
 import { ACCOUNT_CLOSE, ACCOUNT_CLOSE_SUCCESS } from 'state/action-types';
 
 import 'state/data-layer/wpcom/me/account/close';
+import 'state/account/init';
 
 const user = userFactory();
 

--- a/client/state/account/init.js
+++ b/client/state/account/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'state/redux-store';
+import accountReducer from './reducer';
+
+registerReducer( [ 'account' ], accountReducer );

--- a/client/state/account/package.json
+++ b/client/state/account/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/account/reducer.js
+++ b/client/state/account/reducer.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import { ACCOUNT_CLOSE_SUCCESS } from 'state/action-types';
-import { combineReducers, withoutPersistence } from 'state/utils';
+import { combineReducers, withoutPersistence, withStorageKey } from 'state/utils';
 
 export const isClosed = withoutPersistence( ( state = false, action ) => {
 	switch ( action.type ) {
@@ -14,4 +14,5 @@ export const isClosed = withoutPersistence( ( state = false, action ) => {
 	return state;
 } );
 
-export default combineReducers( { isClosed } );
+const combinedReducer = combineReducers( { isClosed } );
+export default withStorageKey( 'account', combinedReducer );

--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -20,7 +20,6 @@ import { reducer as httpData } from 'state/data-layer/http-data';
 /**
  * Reducers
  */
-import account from './account/reducer';
 import accountRecovery from './account-recovery/reducer';
 import activePromotions from './active-promotions/reducer';
 import activityLog from './activity-log/reducer';
@@ -104,7 +103,6 @@ import wordads from './wordads/reducer';
 // The reducers in this list are not modularized, and are always loaded on boot.
 // Please do not add to this list. See #39261 and p4TIVU-9lM-p2 for more details.
 const reducers = {
-	account,
 	accountRecovery,
 	activePromotions,
 	activityLog,

--- a/client/state/selectors/is-account-closed.js
+++ b/client/state/selectors/is-account-closed.js
@@ -3,6 +3,11 @@
  */
 import { get } from 'lodash';
 
+/**
+ * Internal dependencies
+ */
+import 'state/account/init';
+
 export default function isAccountClosed( state ) {
 	return get( state, [ 'account', 'isClosed' ], false );
 }


### PR DESCRIPTION
This PR is one of many working on modularising state in Calypso. This one handles account state.

For more details on state modularisation, see the [modularised state documentation](https://github.com/Automattic/wp-calypso/blob/master/docs/modularized-state.md) and p4TIVU-9lM-p2.

Note: I added reviewers that GitHub suggested. Please feel free to ignore the review request or pull in someone else if you're not comfortable reviewing this PR. Thank you!

Fixes #42417.

#### Changes proposed in this Pull Request

* Modularise account state

#### Testing instructions

* Install [Redux DevTools](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en).
* Open DevTools and switch to the Redux tab.
* Open `/read` on the live branch or your local copy of this branch.
* Click `State` on the top right to ensure you see all state, and not just the diff for the last action: 
![image](https://user-images.githubusercontent.com/409615/73774406-d3e87d80-477b-11ea-9f59-3e42cc00101f.png)
* Analyse the tree and note that there's no `account` key, even if you expand the list of keys. This indicates that the account state hasn't been loaded yet.
* Click your avatar on the masterbar, followed by `Account Settings` on the sidebar.
* Click "Close your account permanently" to open the account closure dialog. Don't actually close your account, though!
* Verify that a `account` key is added with the account state. This indicates that the account state has now been loaded.
* Verify that account-related functionality works normally. This indicates that I didn't mess up.