### PR TITLE
My Home: Try updating card mapping for Support card

### DIFF
--- a/client/my-sites/customer-home/cards/constants.js
+++ b/client/my-sites/customer-home/cards/constants.js
@@ -7,7 +7,6 @@ export const FEATURE_GO_MOBILE = 'home-feature-go-mobile';
 export const FEATURE_QUICK_START = 'home-feature-quick-start';
 export const FEATURE_STATS = 'home-feature-stats';
 export const FEATURE_SUPPORT = 'home-feature-support';
-export const FEATURE_HELP_SEARCH = 'home-feature-help-search';
 export const NOTICE_CELEBRATE_SITE_CREATION = 'home-notice-celebrate-site-creation';
 export const NOTICE_CELEBRATE_SITE_LAUNCH = 'home-notice-celebrate-site-launch';
 export const NOTICE_CELEBRATE_SITE_MIGRATION = 'home-notice-celebrate-site-migration';

--- a/client/my-sites/customer-home/locations/tertiary/manage-site/index.jsx
+++ b/client/my-sites/customer-home/locations/tertiary/manage-site/index.jsx
@@ -9,7 +9,6 @@ import { useTranslate } from 'i18n-calypso';
  * Internal dependencies
  */
 import GoMobile from 'my-sites/customer-home/cards/features/go-mobile';
-import Support from 'my-sites/customer-home/cards/features/support';
 import QuickStart from 'my-sites/customer-home/cards/features/quick-start';
 import QuickLinks from 'my-sites/customer-home/cards/actions/quick-links';
 import HelpSearch from 'my-sites/customer-home/cards/features/help-search';
@@ -22,13 +21,11 @@ import {
 	FEATURE_GO_MOBILE,
 	FEATURE_QUICK_START,
 	FEATURE_SUPPORT,
-	FEATURE_HELP_SEARCH,
 } from 'my-sites/customer-home/cards/constants';
 
 const cardComponents = {
 	[ FEATURE_GO_MOBILE ]: GoMobile,
-	[ FEATURE_SUPPORT ]: Support,
-	[ FEATURE_HELP_SEARCH ]: HelpSearch,
+	[ FEATURE_SUPPORT ]: HelpSearch,
 	[ ACTION_QUICK_LINKS ]: QuickLinks,
 	[ FEATURE_QUICK_START ]: QuickStart,
 	[ ACTION_WP_FOR_TEAMS_QUICK_LINKS ]: WpForTeamsQuickLinks,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Explores the approach suggested in paYJgx-GU-p2 #comment-899 as an alternative to D43941-code.

This way, we re-use the existing `FEATURE_SUPPORT` card UID so the new Support Search card will be also used in future versions of the desktop app while keeping backwards compatibility with current and previous versions.

#### Testing instructions

Verify the Support Search shows up for all views, including the ones used on the desktop app. See https://github.com/Automattic/wp-calypso/pull/42752#issuecomment-635412097 for instructions about how to build a new desktop app version that includes the new Support Search card (I already generated it and confirmed it works as expected).
