### PR TITLE
Jetpack Cloud: truncate long translation strings in sidebar items

### DIFF
--- a/client/landing/jetpack-cloud/components/sidebar/style.scss
+++ b/client/landing/jetpack-cloud/components/sidebar/style.scss
@@ -11,6 +11,16 @@
 		}
 	}
 
+	.sidebar__menu-link-text {
+		line-height: 1.2em;
+
+		@include breakpoint-deprecated( '<960px' ) {
+			white-space: nowrap;
+			overflow: hidden;
+			text-overflow: ellipsis;
+		}
+	}
+
 	// Expandables
 	.sidebar__menu.is-togglable {
 		.sidebar__heading {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Truncate long translation strings in sidebar items and add ellipsis at the end.

#### Before / After
Before | After
--|--
![image](https://user-images.githubusercontent.com/390760/83159403-d8a3b980-a0fd-11ea-8705-603af6de02ad.png) | ![image](https://user-images.githubusercontent.com/390760/83159408-db9eaa00-a0fd-11ea-824c-0d610f95255a.png)


#### Testing instructions

* Set your language in Calypso to Spanish (works better).
* Fire up this PR.
* Open Jetpack Cloud.
* Expand the Backup section.
* Make sure “Latest backups” appears truncated.

