### PR TITLE
i18n: Fix `Sign Up` link not being translated on login page

### DIFF
--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -21,6 +21,7 @@ import getCurrentQueryArguments from 'state/selectors/get-current-query-argument
 import getCurrentRoute from 'state/selectors/get-current-route';
 import { login } from 'lib/paths';
 import { isDomainConnectAuthorizePath } from 'lib/domains/utils';
+import { isDefaultLocale, addLocaleToPath } from 'lib/i18n-utils';
 
 class MasterbarLoggedOut extends React.Component {
 	static propTypes = {
@@ -78,7 +79,7 @@ class MasterbarLoggedOut extends React.Component {
 	}
 
 	renderSignupItem() {
-		const { currentQuery, currentRoute, sectionName, translate } = this.props;
+		const { currentQuery, currentRoute, locale, sectionName, translate } = this.props;
 
 		// Hide for some sections
 		if ( includes( [ 'signup' ], sectionName ) ) {
@@ -134,6 +135,10 @@ class MasterbarLoggedOut extends React.Component {
 			signupUrl = '/jetpack/new';
 		} else if ( signupFlow ) {
 			signupUrl += '/' + signupFlow;
+		}
+
+		if ( ! isDefaultLocale( locale ) ) {
+			signupUrl = addLocaleToPath( signupUrl, locale );
 		}
 
 		return (

--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -3,7 +3,7 @@
  */
 
 import PropTypes from 'prop-types';
-import React, { PureComponent } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
 import { getLocaleSlug, localize } from 'i18n-calypso';
 import { get, includes, startsWith } from 'lodash';
@@ -22,7 +22,7 @@ import getCurrentRoute from 'state/selectors/get-current-route';
 import { login } from 'lib/paths';
 import { isDomainConnectAuthorizePath } from 'lib/domains/utils';
 
-class MasterbarLoggedOut extends PureComponent {
+class MasterbarLoggedOut extends React.Component {
 	static propTypes = {
 		redirectUri: PropTypes.string,
 		sectionName: PropTypes.string,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Replace `PureComponent` with `Component` for `MasterbarLoggedOut`, because PureComponent is skipping the re-render when i18n changes

**Before:**
![image](https://user-images.githubusercontent.com/2722412/83160481-efeba280-a10f-11ea-920f-e16d487a454c.png)

**After:**
![image](https://user-images.githubusercontent.com/2722412/83160546-03970900-a110-11ea-86ba-d9770fff55b1.png)

#### Testing instructions

1. Boot Calypso with `BUILD_TRANSLATION_CHUNKS=true ENABLE_FEATURES=use-translation-chunks yarn start`
2. Open http://calypso.localhost:3000/log-in/de
3. Confirm Sign Up link in the upper-right corner gets translated
