### PR TITLE
i18n: Use localized date format for post editor deprication date

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/deprecate-editor/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/deprecate-editor/index.jsx
@@ -26,12 +26,16 @@ import blockEditorImage from 'assets/images/illustrations/block-editor-fade.svg'
 import FormattedDate from 'components/formatted-date';
 import { localizeUrl } from 'lib/i18n-utils';
 import InlineSupportLink from 'components/inline-support-link';
+import { useLocalizedMoment } from 'components/localized-moment';
 
 const DeprecateEditor = ( { siteId, gutenbergUrl, optIn } ) => {
 	const translate = useTranslate();
+	const moment = useLocalizedMoment();
 	const actionCallback = () => {
 		optIn( siteId, gutenbergUrl );
 	};
+	const dateFormat = moment.localeData().longDateFormat( 'LL' );
+
 	return (
 		<Task
 			title={ translate( 'The new WordPress editor is coming.' ) }
@@ -42,7 +46,7 @@ const DeprecateEditor = ( { siteId, gutenbergUrl, optIn } ) => {
 						components: {
 							date: (
 								<strong>
-									<FormattedDate date="2020-06-01" format="MMMM D" />
+									<FormattedDate date="2020-06-01" format={ dateFormat } />
 								</strong>
 							),
 							support: (

--- a/client/post-editor/editor-deprecation-dialog/index.jsx
+++ b/client/post-editor/editor-deprecation-dialog/index.jsx
@@ -26,6 +26,7 @@ import getGutenbergEditorUrl from 'state/selectors/get-gutenberg-editor-url';
 import InlineSupportLink from 'components/inline-support-link';
 import { localizeUrl } from 'lib/i18n-utils';
 import FormattedDate from 'components/formatted-date';
+import { withLocalizedMoment } from 'components/localized-moment';
 
 /**
  * Style dependencies
@@ -64,6 +65,8 @@ class EditorDeprecationDialog extends Component {
 			return null;
 		}
 
+		const dateFormat = this.props.moment.localeData().longDateFormat( 'LL' );
+
 		return (
 			<Modal
 				title={ translate( 'The new WordPress editor is coming.' ) }
@@ -81,7 +84,7 @@ class EditorDeprecationDialog extends Component {
 							components: {
 								date: (
 									<strong>
-										<FormattedDate date="2020-06-01" format="MMMM D" />
+										<FormattedDate date="2020-06-01" format={ dateFormat } />
 									</strong>
 								),
 								support: (
@@ -150,4 +153,4 @@ export default connect( ( state ) => {
 		isDialogShowing,
 		gutenbergUrl: gutenbergUrl,
 	};
-}, mapDispatchToProps )( localize( EditorDeprecationDialog ) );
+}, mapDispatchToProps )( localize( withLocalizedMoment( EditorDeprecationDialog ) ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use localized long date format `LL` from moment.js for post editor deprication date

**Before:**
![image](https://user-images.githubusercontent.com/2722412/83170492-46131280-a11d-11ea-9d7f-c1bd7ec0cb70.png)

**After:**
![image](https://user-images.githubusercontent.com/2722412/83170518-53300180-a11d-11ea-9d02-87a9b89f126a.png)


#### Testing instructions

1. Boot Calypso
2. Open http://calypso.localhost:3000/home/{site} and http://calypso.localhost:3000/post/{site}/{postId}
3. Confirm that date in post editor deprication notice is using localized long date format

Ref: p1590682280002300-slack-i18n-chatter