### PR TITLE
Jetpack Cloud: Refine ActivityCard Time Styles

### DIFF
--- a/client/landing/jetpack-cloud/components/activity-card-list/style.scss
+++ b/client/landing/jetpack-cloud/components/activity-card-list/style.scss
@@ -57,8 +57,8 @@
 		background: var( --color-neutral-5 );
 		content: '';
 		height: 100%;
-		// center on the icons ( they render @ 1.1rem, so half that )
-		left: 0.55rem;
+		// center on the icons ( they render @ 16px, so half that )
+		left: 8px;
 		position: absolute;
 		top: 0;
 		width: 1px;
@@ -70,7 +70,7 @@
 .activity-card-list {
 	.activity-card {
 		margin-bottom: 32px;
-		.activity-card__time-icon.gridicon {
+		.activity-card__time {
 			background: var( --color-surface-backdrop );
 		}
 	}
@@ -92,7 +92,7 @@
 		content: '';
 		height: 16px;
 		// center on the icons ( they render @ 1.1rem, so half that )
-		left: 0.55rem;
+		left: 8px;
 		position: absolute;
 		top: 100%;
 		width: 1px;
@@ -105,7 +105,7 @@
 		// make sure we stay in our element
 		height: 9px;
 		width: 9px;
-		left: calc( 0.55rem - 4px );
+		left: calc( 8px - 4px );
 		position: absolute;
 		// immediately after the existing horizontal line draw on over the top of it
 		top: calc( 100% + 16px );
@@ -135,10 +135,10 @@
 			background: var( --color-neutral-5 );
 			content: '';
 			height: 1px;
-			left: calc( 0.55rem - 32px );
+			left: calc( 8px - 32px );
 			position: absolute;
 			top: 50%;
-			width: calc( 32px - 0.55rem );
+			width: calc( 32px - 8px );
 			z-index: -2;
 		}
 	}
@@ -153,7 +153,7 @@
 				content: '';
 				// make sure we stay in our element
 				height: calc( 50% - 1px );
-				left: calc( 0.55rem - 32px );
+				left: calc( 8px - 32px );
 				position: absolute;
 				// immediately after the existing horizontal line draw on over the top of it
 				top: calc( 50% + 1px );
@@ -175,7 +175,7 @@
 				// make sure we stay in our element
 				height: 9px;
 				width: 9px;
-				left: calc( 0.55rem - 32px - 4px );
+				left: calc( 8px - 32px - 4px );
 				position: absolute;
 				// immediately after the existing horizontal line draw on over the top of it
 				top: calc( 100% - 9px );

--- a/client/landing/jetpack-cloud/components/activity-card/style.scss
+++ b/client/landing/jetpack-cloud/components/activity-card/style.scss
@@ -41,23 +41,23 @@
 }
 
 .activity-card__time {
-	margin: 1.5rem 0 0.5rem;
+	align-items: center;
+	display: flex;
+	flex-direction: row;
+	margin: 24px 0 8px;
 }
 
 .activity-card__time-icon {
-	width: 1.1rem;
-	height: 1.1rem;
 	fill: var( --color-neutral-40 );
+	height: 17px;
+	width: 17px;
 }
 
 .activity-card__time-text {
-	position: relative;
-	display: inline-block;
-	top: -0.2rem;
-	left: 0.2rem;
-	color: #a7aaad;
-	font-size: 0.7rem;
-	margin-left: 0.2rem;
+	color: var( --color-neutral-40 );
+	font-size: 17px;
+	line-height: 17px;
+	margin-left: 4px;
 }
 
 .activity-card__activity-description {

--- a/client/landing/jetpack-cloud/components/activity-card/style.scss
+++ b/client/landing/jetpack-cloud/components/activity-card/style.scss
@@ -55,7 +55,7 @@
 
 .activity-card__time-text {
 	color: var( --color-neutral-40 );
-	font-size: 17px;
+	font-size: 12px;
 	line-height: 17px;
 	margin-left: 4px;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Realign the activity time icons, use colors and sizes from design

#### Testing instructions

1. Navigate to `/backup/activity-log` and check out the design
