### PR TITLE
FSE: Add Block Pattern Categories

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/class-block-patterns.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/class-block-patterns.php
@@ -47,6 +47,15 @@ class Block_Patterns {
 	 * @return array Filtered editor settings.
 	 */
 	public function register_patterns( $settings ) {
+		// Register Block Pattern Categories.
+		if ( class_exists( 'WP_Block_Pattern_Categories_Registry' ) ) {
+			register_block_pattern_category( 'blog', array( 'label' => _x( 'Blog', 'Block pattern category', 'gutenberg' ) ) );
+			register_block_pattern_category( 'call-to-action', array( 'label' => _x( 'Call to Action', 'Block pattern category', 'gutenberg' ) ) );
+			register_block_pattern_category( 'contact', array( 'label' => _x( 'Contact', 'Block pattern category', 'gutenberg' ) ) );
+			register_block_pattern_category( 'images', array( 'label' => _x( 'Images', 'Block pattern category', 'gutenberg' ) ) );
+			register_block_pattern_category( 'menu', array( 'label' => _x( 'Menu', 'Block pattern category', 'gutenberg' ) ) );
+		}
+
 		// Remove core patterns except 'Two Columns of Text'.
 		$settings['__experimentalBlockPatterns'] = wp_list_filter(
 			$settings['__experimentalBlockPatterns'],

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/class-block-patterns.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/class-block-patterns.php
@@ -52,7 +52,6 @@ class Block_Patterns {
 			register_block_pattern_category( 'call-to-action', array( 'label' => _x( 'Call to Action', 'Block pattern category', 'full-site-editing' ) ) );
 			register_block_pattern_category( 'contact', array( 'label' => _x( 'Contact', 'Block pattern category', 'full-site-editing' ) ) );
 			register_block_pattern_category( 'images', array( 'label' => _x( 'Images', 'Block pattern category', 'full-site-editing' ) ) );
-			register_block_pattern_category( 'menu', array( 'label' => _x( 'Menu', 'Block pattern category', 'full-site-editing' ) ) );
 		}
 
 		if ( class_exists( 'WP_Block_Patterns_Registry' ) ) {

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/class-block-patterns.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/class-block-patterns.php
@@ -12,6 +12,8 @@ namespace A8C\FSE;
  */
 class Block_Patterns {
 
+	const PATTERN_NAMESPACE = 'a8c/';
+
 	/**
 	 * Class instance.
 	 *
@@ -24,7 +26,7 @@ class Block_Patterns {
 	 * Block_Patterns constructor.
 	 */
 	private function __construct() {
-		add_filter( 'block_editor_settings', array( $this, 'register_patterns' ), 11 );
+		$this->register_patterns();
 	}
 
 	/**
@@ -41,12 +43,9 @@ class Block_Patterns {
 	}
 
 	/**
-	 * Extends block editor settings to include FSE block patterns.
-	 *
-	 * @param array $settings Default editor settings.
-	 * @return array Filtered editor settings.
+	 * Register FSE block patterns and categories.
 	 */
-	public function register_patterns( $settings ) {
+	public function register_patterns() {
 		// Register Block Pattern Categories.
 		if ( class_exists( 'WP_Block_Pattern_Categories_Registry' ) ) {
 			register_block_pattern_category( 'blog', array( 'label' => _x( 'Blog', 'Block pattern category', 'gutenberg' ) ) );
@@ -56,21 +55,20 @@ class Block_Patterns {
 			register_block_pattern_category( 'menu', array( 'label' => _x( 'Menu', 'Block pattern category', 'gutenberg' ) ) );
 		}
 
-		// Remove core patterns except 'Two Columns of Text'.
-		$settings['__experimentalBlockPatterns'] = wp_list_filter(
-			$settings['__experimentalBlockPatterns'],
-			array(
-				'title' => 'Two Columns of Text',
-			)
-		);
+		if ( class_exists( 'WP_Block_Patterns_Registry' ) && ! \WP_Block_Patterns_Registry::get_instance()->is_registered( 'text-two-columns' ) ) {
+			// Remove core patterns except 'Two Columns of Text'.
+			// Unfortunately, \WP_Block_Patterns_Registry::get_instance()->get_all_registered() doesn't return the pattern names as keys.
+			foreach ( \WP_Block_Patterns_Registry::get_instance()->get_all_registered() as $pattern ) {
+				if ( 'core/' === substr( $pattern['name'], 0, 5 ) && 'core/text-two-columns' !== $pattern['name'] ) {
+					unregister_block_pattern( $pattern['name'] );
+				}
+			}
 
-		// Add our patterns.
-		$settings['__experimentalBlockPatterns'] = array_merge(
-			$this->get_patterns(),
-			$settings['__experimentalBlockPatterns']
-		);
-
-		return $settings;
+			// Add our patterns.
+			foreach ( $this->get_patterns() as $name => $pattern ) {
+				register_block_pattern( $name, $pattern );
+			}
+		}
 	}
 
 	/**
@@ -133,7 +131,8 @@ class Block_Patterns {
 		// Get the pattern files contents.
 		foreach ( $pattern_files as $pattern_file ) {
 			if ( substr( $pattern_file, -5 ) === '.json' ) {
-				$patterns[] = json_decode(
+				$pattern_name              = self::PATTERN_NAMESPACE . substr( $pattern_file, 0, -5 );
+				$patterns[ $pattern_name ] = json_decode(
 					// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 					file_get_contents( $patterns_dir . $pattern_file ),
 					true
@@ -141,7 +140,8 @@ class Block_Patterns {
 			}
 
 			if ( substr( $pattern_file, -4 ) === '.php' ) {
-				$patterns[] = include_once $patterns_dir . $pattern_file;
+				$pattern_name              = self::PATTERN_NAMESPACE . substr( $pattern_file, 0, -4 );
+				$patterns[ $pattern_name ] = include $patterns_dir . $pattern_file;
 			}
 		}
 

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/class-block-patterns.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/class-block-patterns.php
@@ -55,7 +55,7 @@ class Block_Patterns {
 			register_block_pattern_category( 'menu', array( 'label' => _x( 'Menu', 'Block pattern category', 'full-site-editing' ) ) );
 		}
 
-		if ( class_exists( 'WP_Block_Patterns_Registry' ) && ! \WP_Block_Patterns_Registry::get_instance()->is_registered( 'text-two-columns' ) ) {
+		if ( class_exists( 'WP_Block_Patterns_Registry' ) ) {
 			// Remove core patterns except 'Two Columns of Text'.
 			// Unfortunately, \WP_Block_Patterns_Registry::get_instance()->get_all_registered() doesn't return the pattern names as keys.
 			foreach ( \WP_Block_Patterns_Registry::get_instance()->get_all_registered() as $pattern ) {

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/class-block-patterns.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/class-block-patterns.php
@@ -48,11 +48,11 @@ class Block_Patterns {
 	public function register_patterns() {
 		// Register Block Pattern Categories.
 		if ( class_exists( 'WP_Block_Pattern_Categories_Registry' ) ) {
-			register_block_pattern_category( 'blog', array( 'label' => _x( 'Blog', 'Block pattern category', 'gutenberg' ) ) );
-			register_block_pattern_category( 'call-to-action', array( 'label' => _x( 'Call to Action', 'Block pattern category', 'gutenberg' ) ) );
-			register_block_pattern_category( 'contact', array( 'label' => _x( 'Contact', 'Block pattern category', 'gutenberg' ) ) );
-			register_block_pattern_category( 'images', array( 'label' => _x( 'Images', 'Block pattern category', 'gutenberg' ) ) );
-			register_block_pattern_category( 'menu', array( 'label' => _x( 'Menu', 'Block pattern category', 'gutenberg' ) ) );
+			register_block_pattern_category( 'blog', array( 'label' => _x( 'Blog', 'Block pattern category', 'full-site-editing' ) ) );
+			register_block_pattern_category( 'call-to-action', array( 'label' => _x( 'Call to Action', 'Block pattern category', 'full-site-editing' ) ) );
+			register_block_pattern_category( 'contact', array( 'label' => _x( 'Contact', 'Block pattern category', 'full-site-editing' ) ) );
+			register_block_pattern_category( 'images', array( 'label' => _x( 'Images', 'Block pattern category', 'full-site-editing' ) ) );
+			register_block_pattern_category( 'menu', array( 'label' => _x( 'Menu', 'Block pattern category', 'full-site-editing' ) ) );
 		}
 
 		if ( class_exists( 'WP_Block_Patterns_Registry' ) && ! \WP_Block_Patterns_Registry::get_instance()->is_registered( 'text-two-columns' ) ) {

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/class-block-patterns.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/class-block-patterns.php
@@ -52,6 +52,10 @@ class Block_Patterns {
 			register_block_pattern_category( 'call-to-action', array( 'label' => _x( 'Call to Action', 'Block pattern category', 'full-site-editing' ) ) );
 			register_block_pattern_category( 'contact', array( 'label' => _x( 'Contact', 'Block pattern category', 'full-site-editing' ) ) );
 			register_block_pattern_category( 'images', array( 'label' => _x( 'Images', 'Block pattern category', 'full-site-editing' ) ) );
+
+			// The 'Two Columns of Text' pattern is in the 'columns' and 'text' categories.
+			// Removing 'columns' so it doesn't appear as a category with only a single item.
+			unregister_block_pattern_category( 'columns' );
 		}
 
 		if ( class_exists( 'WP_Block_Patterns_Registry' ) ) {

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/call-to-action-02.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/call-to-action-02.php
@@ -37,7 +37,8 @@ $markup = '
 ';
 
 return array(
-	'__file'  => 'wp_block',
-	'title'   => esc_html__( 'Call to Action', 'full-site-editing' ),
-	'content' => $markup,
+	'__file'     => 'wp_block',
+	'title'      => esc_html__( 'Call to Action', 'full-site-editing' ),
+	'categories' => array( 'call-to-action' ),
+	'content'    => $markup,
 );

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/call-to-action-02.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/call-to-action-02.php
@@ -37,7 +37,6 @@ $markup = '
 ';
 
 return array(
-	'__file'     => 'wp_block',
 	'title'      => esc_html__( 'Call to Action', 'full-site-editing' ),
 	'categories' => array( 'call-to-action' ),
 	'content'    => $markup,

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/collage-gallery.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/collage-gallery.php
@@ -12,8 +12,8 @@ $markup = '
 ';
 
 return array(
-	'__file'  => 'wp_block',
-	'title'   => esc_html__( 'Collage gallery', 'full-site-editing' ),
-	'content' => $markup,
+	'__file'     => 'wp_block',
+	'title'      => esc_html__( 'Collage gallery', 'full-site-editing' ),
+	'categories' => array( 'gallery' ),
+	'content'    => $markup,
 );
-

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/collage-gallery.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/collage-gallery.php
@@ -12,7 +12,6 @@ $markup = '
 ';
 
 return array(
-	'__file'     => 'wp_block',
 	'title'      => esc_html__( 'Collage gallery', 'full-site-editing' ),
 	'categories' => array( 'gallery' ),
 	'content'    => $markup,

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/contact-02.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/contact-02.php
@@ -44,9 +44,10 @@ $markup = '
 ';
 
 return array(
-	'__file'  => 'wp_block',
-	'title'   => esc_html__( 'Contact', 'full-site-editing' ),
-	'content' => sprintf(
+	'__file'     => 'wp_block',
+	'title'      => esc_html__( 'Contact', 'full-site-editing' ),
+	'categories' => array( 'contact' ),
+	'content'    => sprintf(
 		$markup,
 		esc_html__( 'Contact', 'full-site-editing' ),
 		esc_html__( 'Jennifer Dolan Photography', 'full-site-editing' ),

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/contact-02.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/contact-02.php
@@ -44,7 +44,6 @@ $markup = '
 ';
 
 return array(
-	'__file'     => 'wp_block',
 	'title'      => esc_html__( 'Contact', 'full-site-editing' ),
 	'categories' => array( 'contact' ),
 	'content'    => sprintf(

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/contact-03.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/contact-03.php
@@ -5,6 +5,7 @@
  * @package A8C\FSE
  */
 
+// phpcs:disable WordPress.WP.CapitalPDangit.Misspelled
 $markup = '
 <!-- wp:group {"align":"full","style":{"color":{"background":"#2b2729"}}} -->
 <div class="wp-block-group alignfull has-background" style="background-color:#2b2729"><div class="wp-block-group__inner-container"><!-- wp:spacer {"height":60} -->
@@ -26,7 +27,7 @@ $markup = '
 <!-- /wp:paragraph -->
 
 <!-- wp:social-links {"align":"center","className":"margin-top-half"} -->
-<ul class="wp-block-social-links aligncenter margin-top-half"><!-- wp:social-link {"url":"","service":"WordPress"} /-->
+<ul class="wp-block-social-links aligncenter margin-top-half"><!-- wp:social-link {"url":"","service":"wordpress"} /-->
 
 <!-- wp:social-link {"url":"https://facebook.com/","service":"facebook"} /-->
 
@@ -46,6 +47,7 @@ $markup = '
 <!-- /wp:spacer --></div></div>
 <!-- /wp:group -->
 ';
+// phpcs:enable WordPress.WP.CapitalPDangit.Misspelled
 
 return array(
 	'__file'     => 'wp_block',

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/contact-03.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/contact-03.php
@@ -26,7 +26,7 @@ $markup = '
 <!-- /wp:paragraph -->
 
 <!-- wp:social-links {"align":"center","className":"margin-top-half"} -->
-<ul class="wp-block-social-links aligncenter margin-top-half"><!-- wp:social-link {"url":"","service":"wordpress"} /-->
+<ul class="wp-block-social-links aligncenter margin-top-half"><!-- wp:social-link {"url":"","service":"WordPress"} /-->
 
 <!-- wp:social-link {"url":"https://facebook.com/","service":"facebook"} /-->
 
@@ -48,9 +48,10 @@ $markup = '
 ';
 
 return array(
-	'__file'  => 'wp_block',
-	'title'   => esc_html__( 'Contact', 'full-site-editing' ),
-	'content' => sprintf(
+	'__file'     => 'wp_block',
+	'title'      => esc_html__( 'Contact', 'full-site-editing' ),
+	'categories' => array( 'contact' ),
+	'content'    => sprintf(
 		$markup,
 		esc_html__( 'Jennifer Dolan Photography', 'full-site-editing' ),
 		esc_html__( 'San Francisco, California', 'full-site-editing' ),

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/contact-03.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/contact-03.php
@@ -50,7 +50,6 @@ $markup = '
 // phpcs:enable WordPress.WP.CapitalPDangit.Misspelled
 
 return array(
-	'__file'     => 'wp_block',
 	'title'      => esc_html__( 'Contact', 'full-site-editing' ),
 	'categories' => array( 'contact' ),
 	'content'    => sprintf(

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/contact.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/contact.php
@@ -50,9 +50,10 @@ $markup = '
 ';
 
 return array(
-	'__file'  => 'wp_block',
-	'title'   => esc_html__( 'Contact', 'full-site-editing' ),
-	'content' => sprintf(
+	'__file'     => 'wp_block',
+	'title'      => esc_html__( 'Contact', 'full-site-editing' ),
+	'categories' => array( 'contact' ),
+	'content'    => sprintf(
 		$markup,
 		esc_html__( 'Get in touch', 'full-site-editing' ),
 		esc_html__( 'Jennifer Dolan Photography', 'full-site-editing' ),

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/contact.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/contact.php
@@ -50,7 +50,6 @@ $markup = '
 ';
 
 return array(
-	'__file'     => 'wp_block',
 	'title'      => esc_html__( 'Contact', 'full-site-editing' ),
 	'categories' => array( 'contact' ),
 	'content'    => sprintf(

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/description-and-image.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/description-and-image.php
@@ -30,9 +30,10 @@ $markup = '
 ';
 
 return array(
-	'__file'  => 'wp_block',
-	'title'   => esc_html__( 'Description and Image', 'full-site-editing' ),
-	'content' => sprintf(
+	'__file'     => 'wp_block',
+	'title'      => esc_html__( 'Description and Image', 'full-site-editing' ),
+	'categories' => array( 'images' ),
+	'content'    => sprintf(
 		$markup,
 		esc_html__( 'The artist is the creator of beautiful things. To reveal art and conceal the artist is art&#8217;s aim. The critic is he who can translate into another manner or a new material his impression of beautiful things.', 'full-site-editing' ),
 		esc_url( 'https://dotcompatterns.files.wordpress.com/2020/03/leaf.jpg' )

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/description-and-image.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/description-and-image.php
@@ -30,7 +30,6 @@ $markup = '
 ';
 
 return array(
-	'__file'     => 'wp_block',
 	'title'      => esc_html__( 'Description and Image', 'full-site-editing' ),
 	'categories' => array( 'images' ),
 	'content'    => sprintf(

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/food-menu.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/food-menu.php
@@ -56,9 +56,10 @@ $markup = '
 ';
 
 return array(
-	'__file'  => 'wp_block',
-	'title'   => esc_html__( 'Food Menu', 'full-site-editing' ),
-	'content' => sprintf(
+	'__file'     => 'wp_block',
+	'title'      => esc_html__( 'Food Menu', 'full-site-editing' ),
+	'categories' => array( 'text', 'menu' ),
+	'content'    => sprintf(
 		$markup,
 		esc_html__( 'Awesome Burger', 'full-site-editing' ),
 		esc_html__( 'The burger that made us famous. 100% pure lean beef grilled to perfection.', 'full-site-editing' ),
@@ -71,4 +72,3 @@ return array(
 		esc_html__( 'Fresh greens with cheddar cheese diced tomatoes, and honey mustard dressing.', 'full-site-editing' )
 	),
 );
-

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/food-menu.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/food-menu.php
@@ -57,7 +57,7 @@ $markup = '
 
 return array(
 	'title'      => esc_html__( 'Food Menu', 'full-site-editing' ),
-	'categories' => array( 'text', 'menu' ),
+	'categories' => array( 'text' ),
 	'content'    => sprintf(
 		$markup,
 		esc_html__( 'Awesome Burger', 'full-site-editing' ),

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/food-menu.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/food-menu.php
@@ -56,7 +56,6 @@ $markup = '
 ';
 
 return array(
-	'__file'     => 'wp_block',
 	'title'      => esc_html__( 'Food Menu', 'full-site-editing' ),
 	'categories' => array( 'text', 'menu' ),
 	'content'    => sprintf(

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/headline-02.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/headline-02.php
@@ -24,9 +24,10 @@ $markup = '
 ';
 
 return array(
-	'__file'  => 'wp_block',
-	'title'   => esc_html__( 'Headline', 'full-site-editing' ),
-	'content' => sprintf(
+	'__file'     => 'wp_block',
+	'title'      => esc_html__( 'Headline', 'full-site-editing' ),
+	'categories' => array( 'text' ),
+	'content'    => sprintf(
 		$markup,
 		esc_html__( 'Eat Dessert First is for my love of food and sharing my favorites with you.', 'full-site-editing' ),
 		esc_html__( 'Hi, I’m Lillie. Previously a magazine editor, I became a full-time mother and freelance writer in 2017. I spend most of my time with my kids and husband over at The Brown Bear Family.', 'full-site-editing' )

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/headline-02.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/headline-02.php
@@ -24,7 +24,6 @@ $markup = '
 ';
 
 return array(
-	'__file'     => 'wp_block',
 	'title'      => esc_html__( 'Headline', 'full-site-editing' ),
 	'categories' => array( 'text' ),
 	'content'    => sprintf(

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/headline.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/headline.php
@@ -40,9 +40,10 @@ $markup = '
 ';
 
 return array(
-	'__file'  => 'wp_block',
-	'title'   => esc_html__( 'Headline', 'full-site-editing' ),
-	'content' => sprintf(
+	'__file'     => 'wp_block',
+	'title'      => esc_html__( 'Headline', 'full-site-editing' ),
+	'categories' => array( 'blog' ),
+	'content'    => sprintf(
 		$markup,
 		esc_url( 'https://dotcompatterns.files.wordpress.com/2020/03/cayla1-w6ftfbpcs9i-unsplash.jpg' ),
 		esc_html__( 'Weekly Recipe', 'full-site-editing' ),

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/headline.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/headline.php
@@ -17,15 +17,15 @@ $markup = '
 			</a>
 		</figure>
 		<!-- /wp:image -->
-		
+
 		<!-- wp:paragraph {"align":"center","textColor":"foreground-light","className":"margin-bottom-half"} -->
 		<p class="has-text-color has-text-align-center has-foreground-light-color margin-bottom-half"><strong>%2$s</strong></p>
 		<!-- /wp:paragraph -->
-		
+
 		<!-- wp:heading {"align":"center","className":"margin-top-half entry-title"} -->
 		<h2 class="has-text-align-center margin-top-half entry-title"><a href="#">%3$s</a></h2>
 		<!-- /wp:heading -->
-		
+
 		<!-- wp:buttons {"align":"center"} -->
 		<div class="wp-block-buttons aligncenter">
 			<!-- wp:button {"borderRadius":0,"className":"is-style-outline"} -->
@@ -40,7 +40,6 @@ $markup = '
 ';
 
 return array(
-	'__file'     => 'wp_block',
 	'title'      => esc_html__( 'Headline', 'full-site-editing' ),
 	'categories' => array( 'blog' ),
 	'content'    => sprintf(

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/image-and-description.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/image-and-description.php
@@ -30,9 +30,10 @@ $markup = '
 ';
 
 return array(
-	'__file'  => 'wp_block',
-	'title'   => esc_html__( 'Image and Description', 'full-site-editing' ),
-	'content' => sprintf(
+	'__file'     => 'wp_block',
+	'title'      => esc_html__( 'Image and Description', 'full-site-editing' ),
+	'categories' => array( 'images' ),
+	'content'    => sprintf(
 		$markup,
 		esc_url( 'https://dotcompatterns.files.wordpress.com/2020/03/lollipop.jpg' ),
 		esc_html__( 'The artist is the creator of beautiful things. To reveal art and conceal the artist is art&#8217;s aim. The critic is he who can translate into another manner or a new material his impression of beautiful things.', 'full-site-editing' )

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/image-and-description.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/image-and-description.php
@@ -30,7 +30,6 @@ $markup = '
 ';
 
 return array(
-	'__file'     => 'wp_block',
 	'title'      => esc_html__( 'Image and Description', 'full-site-editing' ),
 	'categories' => array( 'images' ),
 	'content'    => sprintf(

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/image-and-text.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/image-and-text.php
@@ -32,9 +32,10 @@ $markup = '
 ';
 
 return array(
-	'__file'  => 'wp_block',
-	'title'   => esc_html__( 'Image and Text', 'full-site-editing' ),
-	'content' => sprintf(
+	'__file'     => 'wp_block',
+	'title'      => esc_html__( 'Image and Text', 'full-site-editing' ),
+	'categories' => array( 'images' ),
+	'content'    => sprintf(
 		$markup,
 		esc_html__( 'His latest work is A Life Well-Lived, a selection of photos and stories of people across Nebraska highlighting their stories from the past 70 years. These are photographs and stories of those who might be forgotten in the rush of history.', 'full-site-editing' )
 	),

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/image-and-text.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/image-and-text.php
@@ -32,7 +32,6 @@ $markup = '
 ';
 
 return array(
-	'__file'     => 'wp_block',
 	'title'      => esc_html__( 'Image and Text', 'full-site-editing' ),
 	'categories' => array( 'images' ),
 	'content'    => sprintf(

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/masonry-gallery.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/masonry-gallery.php
@@ -12,10 +12,8 @@ $markup = '
 ';
 
 return array(
-	'__file'  => 'wp_block',
-	'title'   => esc_html__( 'Masonry gallery', 'full-site-editing' ),
-	'content' => $markup,
+	'__file'     => 'wp_block',
+	'title'      => esc_html__( 'Masonry gallery', 'full-site-editing' ),
+	'categories' => array( 'gallery' ),
+	'content'    => $markup,
 );
-
-
-

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/masonry-gallery.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/masonry-gallery.php
@@ -12,7 +12,6 @@ $markup = '
 ';
 
 return array(
-	'__file'     => 'wp_block',
 	'title'      => esc_html__( 'Masonry gallery', 'full-site-editing' ),
 	'categories' => array( 'gallery' ),
 	'content'    => $markup,

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/numbers.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/numbers.php
@@ -40,9 +40,10 @@ $markup = '
 ';
 
 return array(
-	'__file'  => 'wp_block',
-	'title'   => esc_html__( 'Numbers', 'full-site-editing' ),
-	'content' => sprintf(
+	'__file'     => 'wp_block',
+	'title'      => esc_html__( 'Numbers', 'full-site-editing' ),
+	'categories' => array( 'text' ),
+	'content'    => sprintf(
 		$markup,
 		esc_html__( '1,652', 'full-site-editing' ),
 		esc_html__( 'Volunteers available', 'full-site-editing' ),

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/numbers.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/numbers.php
@@ -40,7 +40,6 @@ $markup = '
 ';
 
 return array(
-	'__file'     => 'wp_block',
 	'title'      => esc_html__( 'Numbers', 'full-site-editing' ),
 	'categories' => array( 'text' ),
 	'content'    => sprintf(

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/recent-posts-02.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/recent-posts-02.php
@@ -20,9 +20,10 @@ $markup = '
 ';
 
 return array(
-	'__file'  => 'wp_block',
-	'title'   => esc_html__( 'Recent Posts', 'full-site-editing' ),
-	'content' => sprintf(
+	'__file'     => 'wp_block',
+	'title'      => esc_html__( 'Recent Posts', 'full-site-editing' ),
+	'categories' => array( 'blog' ),
+	'content'    => sprintf(
 		$markup,
 		esc_html__( 'Latest Posts', 'full-site-editing' )
 	),

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/recent-posts-02.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/recent-posts-02.php
@@ -20,7 +20,6 @@ $markup = '
 ';
 
 return array(
-	'__file'     => 'wp_block',
 	'title'      => esc_html__( 'Recent Posts', 'full-site-editing' ),
 	'categories' => array( 'blog' ),
 	'content'    => sprintf(

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/recent-posts.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/recent-posts.php
@@ -14,7 +14,8 @@ $markup = '
 ';
 
 return array(
-	'__file'  => 'wp_block',
-	'title'   => esc_html__( 'Recent Posts', 'full-site-editing' ),
-	'content' => $markup,
+	'__file'     => 'wp_block',
+	'title'      => esc_html__( 'Recent Posts', 'full-site-editing' ),
+	'categories' => array( 'blog' ),
+	'content'    => $markup,
 );

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/recent-posts.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/recent-posts.php
@@ -14,7 +14,6 @@ $markup = '
 ';
 
 return array(
-	'__file'     => 'wp_block',
 	'title'      => esc_html__( 'Recent Posts', 'full-site-editing' ),
 	'categories' => array( 'blog' ),
 	'content'    => $markup,

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/three-columns-and-image.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/three-columns-and-image.php
@@ -66,9 +66,10 @@ $markup = '
 ';
 
 return array(
-	'__file'  => 'wp_block',
-	'title'   => esc_html__( 'Three columns', 'full-site-editing' ),
-	'content' => sprintf(
+	'__file'     => 'wp_block',
+	'title'      => esc_html__( 'Three columns', 'full-site-editing' ),
+	'categories' => array( 'images' ),
+	'content'    => sprintf(
 		$markup,
 		esc_html__( 'Salainis', 'full-site-editing' ),
 		esc_html__( 'I had learned already many of the Outland methods of communicating by forest notes rather than trust to the betraying, high-pitched human voice.', 'full-site-editing' ),

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/three-columns-and-image.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/three-columns-and-image.php
@@ -17,7 +17,7 @@ $markup = '
 	<!-- /wp:jetpack/layout-grid-column -->
 </div>
 <!-- /wp:jetpack/layout-grid -->
-	
+
 <!-- wp:jetpack/layout-grid {"column1DesktopSpan":3,"column1DesktopOffset":3,"column1TabletSpan":4,"column1MobileSpan":4,"column2DesktopSpan":3,"column2TabletSpan":4,"column2MobileSpan":4,"column3DesktopSpan":3,"column3TabletSpan":4,"column3MobileSpan":4,"column4DesktopOffset":2,"column4TabletOffset":4,"className":"column1-desktop-grid__span-3 column1-desktop-grid__start-4 column1-desktop-grid__row-1 column2-desktop-grid__span-3 column2-desktop-grid__start-7 column2-desktop-grid__row-1 column3-desktop-grid__span-3 column3-desktop-grid__start-10 column3-desktop-grid__row-1 column1-tablet-grid__span-4 column1-tablet-grid__row-1 column2-tablet-grid__span-4 column2-tablet-grid__start-5 column2-tablet-grid__row-1 column3-tablet-grid__span-4 column3-tablet-grid__row-2 column1-mobile-grid__span-4 column1-mobile-grid__row-1 column2-mobile-grid__span-4 column2-mobile-grid__row-2 column3-mobile-grid__span-4 column3-mobile-grid__row-3"} -->
 <div class="wp-block-jetpack-layout-grid alignfull column1-desktop-grid__span-3 column1-desktop-grid__start-4 column1-desktop-grid__row-1 column2-desktop-grid__span-3 column2-desktop-grid__start-7 column2-desktop-grid__row-1 column3-desktop-grid__span-3 column3-desktop-grid__start-10 column3-desktop-grid__row-1 column1-tablet-grid__span-4 column1-tablet-grid__row-1 column2-tablet-grid__span-4 column2-tablet-grid__start-5 column2-tablet-grid__row-1 column3-tablet-grid__span-4 column3-tablet-grid__row-2 column1-mobile-grid__span-4 column1-mobile-grid__row-1 column2-mobile-grid__span-4 column2-mobile-grid__row-2 column3-mobile-grid__span-4 column3-mobile-grid__row-3">
 	<!-- wp:jetpack/layout-grid-column -->
@@ -27,7 +27,7 @@ $markup = '
 		<!-- /wp:paragraph -->
 	</div>
 	<!-- /wp:jetpack/layout-grid-column -->
-	
+
 	<!-- wp:jetpack/layout-grid-column -->
 	<div class="wp-block-jetpack-layout-grid-column wp-block-jetpack-layout-grid__padding-none">
 		<!-- wp:paragraph {"customFontSize":14} -->
@@ -35,7 +35,7 @@ $markup = '
 		<!-- /wp:paragraph -->
 	</div>
 	<!-- /wp:jetpack/layout-grid-column -->
-	
+
 	<!-- wp:jetpack/layout-grid-column -->
 	<div class="wp-block-jetpack-layout-grid-column wp-block-jetpack-layout-grid__padding-none">
 		<!-- wp:paragraph {"customFontSize":14} -->
@@ -45,11 +45,11 @@ $markup = '
 	<!-- /wp:jetpack/layout-grid-column -->
 </div>
 <!-- /wp:jetpack/layout-grid -->
-	
+
 <!-- wp:spacer {"height":32} -->
 <div style="height:32px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
-	
+
 <!-- wp:jetpack/layout-grid {"addGutterEnds":false,"column1DesktopSpan":12,"column1TabletSpan":8,"column1MobileSpan":4,"className":"column1-desktop-grid__span-12 column1-desktop-grid__row-1 column1-tablet-grid__span-8 column1-tablet-grid__row-1 column1-mobile-grid__span-4 column1-mobile-grid__row-1"} -->
 <div class="wp-block-jetpack-layout-grid alignfull column1-desktop-grid__span-12 column1-desktop-grid__row-1 column1-tablet-grid__span-8 column1-tablet-grid__row-1 column1-mobile-grid__span-4 column1-mobile-grid__row-1 wp-block-jetpack-layout-gutter__nowrap">
 	<!-- wp:jetpack/layout-grid-column -->
@@ -66,7 +66,6 @@ $markup = '
 ';
 
 return array(
-	'__file'     => 'wp_block',
 	'title'      => esc_html__( 'Three columns', 'full-site-editing' ),
 	'categories' => array( 'images' ),
 	'content'    => sprintf(

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/three-images-side-by-side.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/three-images-side-by-side.php
@@ -42,7 +42,8 @@ $markup = '
 ';
 
 return array(
-	'__file'  => 'wp_block',
-	'title'   => esc_html__( 'Three images side-by-side', 'full-site-editing' ),
-	'content' => $markup,
+	'__file'     => 'wp_block',
+	'title'      => esc_html__( 'Three images side-by-side', 'full-site-editing' ),
+	'categories' => array( 'images' ),
+	'content'    => $markup,
 );

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/three-images-side-by-side.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/three-images-side-by-side.php
@@ -43,6 +43,6 @@ $markup = '
 
 return array(
 	'title'      => esc_html__( 'Three images side-by-side', 'full-site-editing' ),
-	'categories' => array( 'images' ),
+	'categories' => array( 'gallery', 'images' ),
 	'content'    => $markup,
 );

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/three-images-side-by-side.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/three-images-side-by-side.php
@@ -42,7 +42,6 @@ $markup = '
 ';
 
 return array(
-	'__file'     => 'wp_block',
 	'title'      => esc_html__( 'Three images side-by-side', 'full-site-editing' ),
 	'categories' => array( 'images' ),
 	'content'    => $markup,

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/two-images-and-quote.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/two-images-and-quote.php
@@ -40,9 +40,10 @@ $markup = '
 ';
 
 return array(
-	'__file'  => 'wp_block',
-	'title'   => esc_html__( 'Two images and quote', 'full-site-editing' ),
-	'content' => sprintf(
+	'__file'     => 'wp_block',
+	'title'      => esc_html__( 'Two images and quote', 'full-site-editing' ),
+	'categories' => array( 'images' ),
+	'content'    => sprintf(
 		$markup,
 		esc_url( 'https://dotcompatterns.files.wordpress.com/2020/03/bianca-berg-l4-sra8ii80-unsplash-2.jpg' ),
 		esc_url( 'https://dotcompatterns.files.wordpress.com/2020/03/bianca-berg-pyvtnjcwc-g-unsplash.jpg' ),

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/two-images-and-quote.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/two-images-and-quote.php
@@ -17,19 +17,19 @@ $markup = '
 		<!-- /wp:image -->
 	</div>
 	<!-- /wp:jetpack/layout-grid-column -->
-	
+
 	<!-- wp:jetpack/layout-grid-column -->
 	<div class="wp-block-jetpack-layout-grid-column wp-block-jetpack-layout-grid__padding-none">
 		<!-- wp:spacer {"height":64} -->
 		<div style="height:64px" aria-hidden="true" class="wp-block-spacer"></div>
 		<!-- /wp:spacer -->
-		
+
 		<!-- wp:image {"sizeSlug":"full","className":"margin-bottom-half"} -->
 		<figure class="wp-block-image size-full margin-bottom-half">
 			<img src="%2$s" alt=""/>
 		</figure>
 		<!-- /wp:image -->
-		
+
 		<!-- wp:paragraph {"fontSize":"small","className":"margin-top-half"} -->
 		<p class="has-small-font-size margin-top-half"><em>%3$s</em></p>
 		<!-- /wp:paragraph -->
@@ -40,7 +40,6 @@ $markup = '
 ';
 
 return array(
-	'__file'     => 'wp_block',
 	'title'      => esc_html__( 'Two images and quote', 'full-site-editing' ),
 	'categories' => array( 'images' ),
 	'content'    => sprintf(

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/two-images-side-by-side.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/two-images-side-by-side.php
@@ -32,7 +32,8 @@ $markup = '
 ';
 
 return array(
-	'__file'  => 'wp_block',
-	'title'   => esc_html__( 'Two images side-by-side', 'full-site-editing' ),
-	'content' => $markup,
+	'__file'     => 'wp_block',
+	'title'      => esc_html__( 'Two images side-by-side', 'full-site-editing' ),
+	'categories' => array( 'images' ),
+	'content'    => $markup,
 );

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/two-images-side-by-side.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/two-images-side-by-side.php
@@ -33,6 +33,6 @@ $markup = '
 
 return array(
 	'title'      => esc_html__( 'Two images side-by-side', 'full-site-editing' ),
-	'categories' => array( 'images' ),
+	'categories' => array( 'gallery', 'images' ),
 	'content'    => $markup,
 );

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/two-images-side-by-side.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/two-images-side-by-side.php
@@ -32,7 +32,6 @@ $markup = '
 ';
 
 return array(
-	'__file'     => 'wp_block',
 	'title'      => esc_html__( 'Two images side-by-side', 'full-site-editing' ),
 	'categories' => array( 'images' ),
 	'content'    => $markup,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes #41936. That issue [categorized](https://github.com/Automattic/wp-calypso/issues/41936#issuecomment-625396787) block patterns as follows:

<img width="1506" alt="Screenshot 2020-05-07 at 18 22 12" src="https://user-images.githubusercontent.com/908665/81326195-5fcab800-9091-11ea-9daf-340ec1890097.png">

#### Notes (relevant when reviewing)

##### Design notes:

- Available block patterns seem to have changed since that image was created, so I had to apply my own best guess for some patterns. 
-  Keep [this comment](https://github.com/Automattic/wp-calypso/issues/41936#issuecomment-635243412) in mind:

> These categories were designed to afford overlaps, so I think some of the "images" and "list" ones should also be in "gallery", for example. The category navigation is going to eventually allow drilling down, so there will be less cases of seeing duplicated content.

- While [some pattern categories were readily available in Gutenberg](https://github.com/WordPress/gutenberg/blob/ac22829574d187b96773afb5e95eeda67eb69470/lib/client-assets.php#L712-L720), I had to [add a few more](https://github.com/Automattic/wp-calypso/pull/42761/files#diff-84ccdb78eb53921f409c71134e3fbe11R50-R58). Please have a look if any of the newly added ones seem redundant, and if we should fall back to Gutenberg's.
- For some pattern categories, I've changed plural to singular, in a way I hoped was consistent with [Gutenberg's pattern categories](https://github.com/WordPress/gutenberg/blob/ac22829574d187b96773afb5e95eeda67eb69470/lib/client-assets.php#L712-L720). Let me know if you think I should change this.

##### Engineering notes:

We were previously adding block patterns by modifying the `$settings` variable that is passed to the client (rather than using the [block pattern registration API](https://github.com/WordPress/gutenberg/blob/a105007ab71d33f64067878e9892a02d6a7297d8/docs/designers-developers/developers/block-api/block-patterns.md#patterns-registration)). This means however that registration of block pattern _categories_ through the [corresponding API](https://github.com/WordPress/gutenberg/blob/a105007ab71d33f64067878e9892a02d6a7297d8/docs/designers-developers/developers/block-api/block-patterns.md#pattern-categories) wouldn't take effect. Consequently, I changed the block pattern registration code to also use the pattern registration API. This ensures that block pattern category registration works properly.

If needed, I can move that fix to a separate PR for clarity and exposure. (That other PR would then  block this one.)

#### Testing instructions

- Apply the corresponding WP.com diff (D44100-code) to your sandbox.
- Sandbox the REST API, and a test site.
- On that test site, start a new post, open the inserter, and open the Patterns tab.

Please let me know if any of these patterns should be categorized differently (ideally by adding a comment below the relevant `'categories' =>` line in the diff).

#### Screenshot

![image](https://user-images.githubusercontent.com/96308/83194061-51c00280-a138-11ea-85c0-296f3c7739ff.png)
