### PR TITLE
composite-checkout: Disable the form when the paypal button is clicked

### DIFF
--- a/packages/composite-checkout/src/lib/payment-methods/paypal.js
+++ b/packages/composite-checkout/src/lib/payment-methods/paypal.js
@@ -48,7 +48,7 @@ export function PaypalLabel() {
 
 export function PaypalSubmitButton( { disabled } ) {
 	useTransactionStatusHandler();
-	const { formStatus } = useFormStatus();
+	const { formStatus, setFormSubmitting } = useFormStatus();
 	const onEvent = useEvents();
 	const { setTransactionRedirecting, setTransactionError } = useTransactionStatus();
 	const submitTransaction = usePaymentProcessor( 'paypal' );
@@ -56,6 +56,7 @@ export function PaypalSubmitButton( { disabled } ) {
 
 	const onClick = () => {
 		onEvent( { type: 'PAYPAL_TRANSACTION_BEGIN' } );
+		setFormSubmitting();
 		submitTransaction( {
 			items,
 		} )


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes a bug wherein the paypal submit button isn't disabled when you click it.

#### Testing instructions

Submit a paypal transaction and make sure that as soon as you click the button it becomes disabled. Then verify that the rest of the transaction works correctly.