### PR TITLE
Jetpack Cloud: Display a prompt to authorize if no access token is returned

### DIFF
--- a/client/landing/jetpack-cloud/sections/auth/connect/index.tsx
+++ b/client/landing/jetpack-cloud/sections/auth/connect/index.tsx
@@ -1,0 +1,43 @@
+/**
+ * External dependencies
+ */
+import { useTranslate } from 'i18n-calypso';
+import React, { FunctionComponent } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { Button } from '@automattic/components';
+import JetpackLogo from 'components/jetpack-logo';
+import Main from 'components/main';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+interface Props {
+	authUrl: string;
+}
+
+const Connect: FunctionComponent< Props > = ( { authUrl } ) => {
+	const translate = useTranslate();
+
+	return (
+		<Main className="connect">
+			<div className="connect__content">
+				<JetpackLogo full monochrome={ false } size={ 72 } />
+				<p>
+					{ translate(
+						'Welcome to Jetpack Cloud. Authorize with your WordPress.com credentials to get started.'
+					) }
+				</p>
+				<Button primary href={ authUrl }>
+					{ translate( 'Authorize Jetpack Cloud' ) }
+				</Button>
+			</div>
+		</Main>
+	);
+};
+
+export default Connect;

--- a/client/landing/jetpack-cloud/sections/auth/connect/style.scss
+++ b/client/landing/jetpack-cloud/sections/auth/connect/style.scss
@@ -1,0 +1,16 @@
+.connect.main {
+	margin: auto;
+	max-width: 480px;
+}
+
+.connect__content {
+	align-items: center;
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	text-align: center;
+
+	& > * {
+		margin-bottom: 32px;
+	}
+}

--- a/client/landing/jetpack-cloud/sections/auth/controller.tsx
+++ b/client/landing/jetpack-cloud/sections/auth/controller.tsx
@@ -11,6 +11,7 @@ import debugFactory from 'debug';
  * Internal dependencies
  */
 import config from 'config';
+import Connect from './connect';
 import GetToken from './get-token';
 import userModule from 'lib/user';
 import wpcom from 'lib/wp';
@@ -47,14 +48,21 @@ export const connect: PageJS.Callback = ( context, next ) => {
 };
 
 export const tokenRedirect: PageJS.Callback = ( context, next ) => {
-	if ( context.hash && context.hash.access_token ) {
+	// We didn't get an auth token; take a step back
+	// and ask for authorization from the user again
+	if ( context.hash?.error ) {
+		context.primary = <Connect authUrl={ authTokenRedirectPath() } />;
+		return next();
+	}
+
+	if ( context.hash?.access_token ) {
 		debug( 'setting user token' );
 		store.set( 'wpcom_token', context.hash.access_token );
 		// this does not work!
 		wpcom.loadToken( context.hash.access_token );
 	}
 
-	if ( context.hash && context.hash.expires_in ) {
+	if ( context.hash?.expires_in ) {
 		debug( 'setting user token_expires_in' );
 		store.set( 'wpcom_token_expires_in', context.hash.expires_in );
 	}


### PR DESCRIPTION

#### Changes proposed in this Pull Request

* If the Jetpack Cloud OAuth deny/approve prompt fails, add a separate prompt directing the user to authorize, instead of redirecting them to the same prompt over and over.


Fixes `1169345694087188-as-1177874941283937`

#### Testing instructions

* Open a new browser window with no existing Jetpack Cloud auth data in storage (i.e., incognito or cleared storage) and an account that has not authorized Jetpack Cloud (previously revoked, or never authorized to begin with).
* Observe that you're asked to authenticate via WordPress.com credentials. Enter a valid WordPress.com username/email and password, then **Continue**.
* When presented with the Deny/Approve prompt, click **Deny**.
* Observe that you are forwarded to a page with copy that says "Welcome to Jetpack Cloud. Authorize with your WordPress.com credentials to get started." and a button to **Authorize Jetpack Cloud.**
* Observe that clicking the button brings you back to the Deny/Approve prompt.

#### Screenshot

![Kapture 2020-05-28 at 13 37 11](https://user-images.githubusercontent.com/670067/83180009-67a5d700-a0e8-11ea-9383-a84c59857006.gif)
