### PR TITLE
Jetpack Cloud: Restore Google Social Login

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -395,12 +395,13 @@ export class LoginForm extends Component {
 							</Button>
 						</div>
 
-						{ config.isEnabled( 'signup/social' ) && ! isJetpackCloudOAuth2Client( oauth2Client ) && (
+						{ config.isEnabled( 'signup/social' ) && (
 							<div className="login__form-social">
 								<div className="login__form-social-divider">
 									<span>{ this.props.translate( 'or' ) }</span>
 								</div>
 								<SocialLoginForm
+									googleSocialOnly={ isJetpackCloudOAuth2Client( oauth2Client ) }
 									onSuccess={ this.onWooCommerceSocialSuccess }
 									socialService={ this.props.socialService }
 									socialServiceResponse={ this.props.socialServiceResponse }
@@ -639,16 +640,17 @@ export class LoginForm extends Component {
 					) }
 				</Card>
 
-				{ config.isEnabled( 'signup/social' ) && ! isJetpackCloudOAuth2Client( oauth2Client ) && (
+				{ config.isEnabled( 'signup/social' ) && (
 					<Fragment>
 						<Divider>{ this.props.translate( 'or' ) }</Divider>
 						<SocialLoginForm
-							onSuccess={ this.props.onSuccess }
-							socialService={ this.props.socialService }
-							socialServiceResponse={ this.props.socialServiceResponse }
+							googleSocialOnly={ isJetpackCloudOAuth2Client( oauth2Client ) }
 							linkingSocialService={
 								this.props.socialAccountIsLinking ? this.props.socialAccountLinkService : null
 							}
+							onSuccess={ this.props.onSuccess }
+							socialService={ this.props.socialService }
+							socialServiceResponse={ this.props.socialServiceResponse }
 							uxMode={ this.shouldUseRedirectLoginFlow() ? 'redirect' : 'popup' }
 						/>
 					</Fragment>

--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -44,10 +44,12 @@ class SocialLoginForm extends Component {
 		linkingSocialService: PropTypes.string,
 		socialService: PropTypes.string,
 		socialServiceResponse: PropTypes.object,
+		googleSocialOnly: PropTypes.bool,
 	};
 
 	static defaultProps = {
 		linkingSocialService: '',
+		googleSocialOnly: false,
 	};
 
 	handleGoogleResponse = ( response, triggeredByUser = true ) => {
@@ -183,7 +185,7 @@ class SocialLoginForm extends Component {
 	};
 
 	render() {
-		const { redirectTo, uxMode } = this.props;
+		const { googleSocialOnly, redirectTo, uxMode } = this.props;
 		const uxModeApple = config.isEnabled( 'sign-in-with-apple/redirect' ) ? 'redirect' : uxMode;
 
 		return (
@@ -200,34 +202,53 @@ class SocialLoginForm extends Component {
 						}
 					/>
 
-					<AppleLoginButton
-						clientId={ config( 'apple_oauth_client_id' ) }
-						responseHandler={ this.handleAppleResponse }
-						uxMode={ uxModeApple }
-						redirectUri={ this.getRedirectUrl( 'apple' ) }
-						onClick={ this.trackLoginAndRememberRedirect.bind( null, 'apple' ) }
-						socialServiceResponse={
-							this.props.socialService === 'apple' ? this.props.socialServiceResponse : null
-						}
-					/>
+					{ ! googleSocialOnly && (
+						<AppleLoginButton
+							clientId={ config( 'apple_oauth_client_id' ) }
+							responseHandler={ this.handleAppleResponse }
+							uxMode={ uxModeApple }
+							redirectUri={ this.getRedirectUrl( 'apple' ) }
+							onClick={ this.trackLoginAndRememberRedirect.bind( null, 'apple' ) }
+							socialServiceResponse={
+								this.props.socialService === 'apple' ? this.props.socialServiceResponse : null
+							}
+						/>
+					) }
 
 					<p className="login__social-tos">
-						{ this.props.translate(
-							"If you continue with Google or Apple and don't already have a WordPress.com account, you" +
-								' are creating an account and you agree to our' +
-								' {{a}}Terms of Service{{/a}}.',
-							{
-								components: {
-									a: (
-										<a
-											href={ localizeUrl( 'https://wordpress.com/tos/' ) }
-											target="_blank"
-											rel="noopener noreferrer"
-										/>
-									),
-								},
-							}
-						) }
+						{ googleSocialOnly
+							? this.props.translate(
+									"If you continue with Google and don't already have a WordPress.com account, you" +
+										' are creating an account and you agree to our' +
+										' {{a}}Terms of Service{{/a}}.',
+									{
+										components: {
+											a: (
+												<a
+													href={ localizeUrl( 'https://wordpress.com/tos/' ) }
+													target="_blank"
+													rel="noopener noreferrer"
+												/>
+											),
+										},
+									}
+							  )
+							: this.props.translate(
+									"If you continue with Google or Apple and don't already have a WordPress.com account, you" +
+										' are creating an account and you agree to our' +
+										' {{a}}Terms of Service{{/a}}.',
+									{
+										components: {
+											a: (
+												<a
+													href={ localizeUrl( 'https://wordpress.com/tos/' ) }
+													target="_blank"
+													rel="noopener noreferrer"
+												/>
+											),
+										},
+									}
+							  ) }
 					</p>
 				</div>
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add property to social form to suppress "Continue with Apple" login
* Use this property to restore "Continue with Google" social login for Jetpack Cloud authorization flow

<img width="1204" alt="Screen Shot 2020-05-28 at 12 39 37 PM" src="https://user-images.githubusercontent.com/2810519/83185843-76888b80-a0e0-11ea-96e3-7a80f9008b40.png">

#### Testing instructions

##### Getting Started

* Run this PR with `yarn start` (we want to start Calypso, not Jetpack Cloud)
* Visit wordpress.com and log out from your current session
* Visit cloud.jetpack.com
* You should see Jetpack Cloud login page (stage enviroment)
* Copy everything after `https://wordpress.com/` of the URL
* Replace the current URL with `http://calypso.localhost:3000/` and paste what was copied in the previous step
* You should see Jetpack Cloud login page (dev environment), which should match the above screenshot

##### Test Cases

1. Continue with Google, create new Google account, verify you return to "Authorize your WordPress.com to sign into Jetpack.com." page
2. Click "Log in with a different account" and click "Continue with Google" again, but reuse the same account you created in step 1. Verify you return to the "Authorize your WordPress.com to sign into Jetpack.com." page


##### Known Issues
Logging in with a Google account with an email of an existing WordPress.com will trigger a different flow:
<img width="1204" alt="Screen Shot 2020-05-28 at 12 40 01 PM" src="https://user-images.githubusercontent.com/2810519/83186999-4c37cd80-a0e2-11ea-8331-145e2d50af69.png">
that is currently broken

