### PR TITLE
Jetpack Cloud: incorporate the lost password flow to Jetpack Cloud

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -290,6 +290,18 @@ class Login extends Component {
 						<JetpackPlusWpComLogo className="login__jetpack-plus-wpcom-logo" size={ 24 } />
 					</div>
 				);
+
+				// If users arrived here from the lost password flow, show them a specific message about it
+				const currentUrl = new URL( window.location.href );
+				const displayLostPasswordConfirmation =
+					currentUrl.searchParams.get( 'lostpassword_flow' ) === 'true';
+				postHeader = displayLostPasswordConfirmation && (
+					<p className="login__form-post-header">
+						{ translate(
+							'Check your e-mail address linked to the account for the confirmation link, including the spam or junk folder.'
+						) }
+					</p>
+				);
 			}
 
 			if ( isCrowdsignalOAuth2Client( oauth2Client ) ) {

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -749,6 +749,10 @@
 		text-align: center;
 	}
 
+	.login__form-post-header {
+		margin-top: 24px;
+	}
+
 	input:focus:hover[type],
 	input:focus[type] {
 		box-shadow: 0 0 0 2px var( --studio-jetpack-green-10 );

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -247,14 +247,18 @@ export class LoginLinks extends React.Component {
 			return null;
 		}
 
-		// jetpack cloud needs to keep users in the flow
+		const queryArgs = { action: 'lostpassword' };
+		// If we got here coming from Jetpack Cloud login page, we want to go back
+		// to it after we finish the process
 		if ( isJetpackCloudOAuth2Client( this.props.oauth2Client ) ) {
-			return null;
+			const currentUrl = new URL( window.location.href );
+			currentUrl.searchParams.append( 'lostpassword_flow', true );
+			queryArgs.redirect_to = currentUrl.toString();
 		}
 
 		return (
 			<a
-				href={ addQueryArgs( { action: 'lostpassword' }, login( { locale: this.props.locale } ) ) }
+				href={ addQueryArgs( queryArgs, login( { locale: this.props.locale } ) ) }
 				key="lost-password-link"
 				onClick={ this.recordResetPasswordLinkClick }
 				rel="external"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Make the reset password feature work in the context of Jetpack Cloud, so users aren't lost in the middle of the process.

#### Testing instructions

* Run this PR with `yarn start`
* Visit wordpress.com and log out from your current session
* Visit cloud.jetpack.com
* You should see Jetpack Cloud login page (stage enviroment)
* Copy everything after `https://wordpress.com/` of the URL
* Replace the current URL with `http://calypso.localhost:3000/` and paste what was copied in the previous step
* You should see Jetpack Cloud login page (dev environment)
* Verify the "Lost your password?" link appears at the bottom
* Click the link "Lost your password?"
* You should land on `https://wordpress.com/wp-login.php?action=lostpassword`
* Enter your username or email
* Verify you're back in Jetpack Cloud login page
* Verify there is message right under the header that says: "Check your e-mail address linked to the account for the confirmation link, including the spam or junk folder."

Fixes 1169345694087188-as-1177336398998725

#### Demo
![Kapture 2020-05-28 at 17 40 01](https://user-images.githubusercontent.com/3418513/83191425-5bcb0c80-a10a-11ea-9ce3-56de86c6dbf9.gif)

