### PR TITLE
composite-checkout: Hide coupon field behind button

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -211,7 +211,6 @@ export default function CompositeCheckout( {
 		isLoading: isLoadingCart,
 		isPendingUpdate: isCartPendingUpdate,
 		allowedPaymentMethods: serverAllowedPaymentMethods,
-		variantRequestStatus,
 		variantSelectOverride,
 		responseCart,
 		addItem,
@@ -451,7 +450,6 @@ export default function CompositeCheckout( {
 					countriesList={ countriesList }
 					StateSelect={ StateSelect }
 					renderDomainContactFields={ renderDomainContactFields }
-					variantRequestStatus={ variantRequestStatus }
 					variantSelectOverride={ variantSelectOverride }
 					getItemVariants={ getItemVariants }
 					domainContactValidationCallback={ domainContactValidationCallback }

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/item-variation-picker.tsx
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/item-variation-picker.tsx
@@ -10,7 +10,6 @@ import { useTranslate } from 'i18n-calypso';
  */
 import { WPCOMCartItem } from '../types';
 import RadioButton from './radio-button';
-import { VariantRequestStatus } from '../hooks/use-shopping-cart';
 
 export type WPCOMProductSlug = string;
 
@@ -23,7 +22,6 @@ export type WPCOMProductVariant = {
 
 export type ItemVariationPickerProps = {
 	selectedItem: WPCOMCartItem;
-	variantRequestStatus: VariantRequestStatus;
 	variantSelectOverride: { uuid: string; overrideSelectedProductSlug: string }[];
 	getItemVariants: ( arg0: WPCOMProductSlug ) => WPCOMProductVariant[];
 	onChangeItemVariant: ( arg0: string, arg1: WPCOMProductSlug, arg2: number ) => void;

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-review.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-review.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { useLineItems, useFormStatus } from '@automattic/composite-checkout';
@@ -28,7 +28,6 @@ export default function WPCheckoutOrderReview( {
 } ) {
 	const translate = useTranslate();
 	const [ items, total ] = useLineItems();
-	const { formStatus } = useFormStatus();
 	const isPurchaseFree = total.amount.value === 0;
 
 	const firstDomainItem = items.find( isLineItemADomain );
@@ -50,14 +49,11 @@ export default function WPCheckoutOrderReview( {
 				/>
 			</WPOrderReviewSection>
 
-			{ ! isPurchaseFree && (
-				<CouponField
-					id="order-review-coupon"
-					disabled={ formStatus !== 'ready' }
-					couponStatus={ couponStatus }
-					couponFieldStateProps={ couponFieldStateProps }
-				/>
-			) }
+			<CouponFieldArea
+				isPurchaseFree={ isPurchaseFree }
+				couponStatus={ couponStatus }
+				couponFieldStateProps={ couponFieldStateProps }
+			/>
 		</div>
 	);
 }
@@ -75,6 +71,33 @@ WPCheckoutOrderReview.propTypes = {
 	variantSelectOverride: PropTypes.object,
 };
 
+function CouponFieldArea( { isPurchaseFree, couponStatus, couponFieldStateProps } ) {
+	const [ isCouponFieldVisible, setCouponFieldVisible ] = useState( false );
+	const { formStatus } = useFormStatus();
+	const translate = useTranslate();
+
+	if ( isPurchaseFree ) {
+		return null;
+	}
+
+	if ( isCouponFieldVisible ) {
+		return (
+			<CouponField
+				id="order-review-coupon"
+				disabled={ formStatus !== 'ready' }
+				couponStatus={ couponStatus }
+				couponFieldStateProps={ couponFieldStateProps }
+			/>
+		);
+	}
+
+	return (
+		<CouponEnableButton onClick={ () => setCouponFieldVisible( true ) }>
+			{ translate( 'Add a coupon code' ) }
+		</CouponEnableButton>
+	);
+}
+
 const DomainURL = styled.div`
 	color: ${ ( props ) => props.theme.colors.textColorLight };
 	font-size: 14px;
@@ -85,4 +108,9 @@ const DomainURL = styled.div`
 const CouponField = styled( Coupon )`
 	margin: 20px 30px 0 0;
 	border-bottom: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
+`;
+
+const CouponEnableButton = styled.button`
+	cursor: pointer;
+	text-decoration: underline;
 `;

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-review.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-review.js
@@ -105,25 +105,38 @@ function CouponFieldArea( {
 	}
 
 	return (
-		<CouponEnableButton onClick={ () => setCouponFieldVisible( true ) }>
-			{ translate( 'Add a coupon code' ) }
-		</CouponEnableButton>
+		<CouponLinkWrapper>
+			{ translate( 'Have a coupon? ' ) }
+			<CouponEnableButton onClick={ () => setCouponFieldVisible( true ) }>
+				{ translate( 'Add a coupon code' ) }
+			</CouponEnableButton>
+		</CouponLinkWrapper>
 	);
 }
 
 const DomainURL = styled.div`
-	color: ${ ( props ) => props.theme.colors.textColorLight };
+	color: ${( props ) => props.theme.colors.textColorLight};
 	font-size: 14px;
 	margin-top: -10px;
 	word-break: break-word;
 `;
 
+const CouponLinkWrapper = styled.div`
+	font-size: 14px;
+`;
+
 const CouponField = styled( Coupon )`
 	margin: 20px 30px 0 0;
-	border-bottom: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
+	border-bottom: 1px solid ${( props ) => props.theme.colors.borderColorLight};
 `;
 
 const CouponEnableButton = styled.button`
 	cursor: pointer;
 	text-decoration: underline;
+	color: ${( props ) => props.theme.colors.highlight};
+	font-size: 14px;
+
+	:hover {
+		text-decoration: none;
+	}
 `;

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-review.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-review.js
@@ -28,10 +28,16 @@ export default function WPCheckoutOrderReview( {
 } ) {
 	const translate = useTranslate();
 	const [ items, total ] = useLineItems();
+	const [ isCouponFieldVisible, setCouponFieldVisible ] = useState( false );
 	const isPurchaseFree = total.amount.value === 0;
 
 	const firstDomainItem = items.find( isLineItemADomain );
 	const domainUrl = firstDomainItem ? firstDomainItem.label : siteUrl;
+	const removeCouponAndClearField = ( uuid ) => {
+		removeCoupon( uuid );
+		couponFieldStateProps.setCouponFieldValue( '' );
+		setCouponFieldVisible( false );
+	};
 
 	return (
 		<div className={ joinClasses( [ className, 'checkout-review-order' ] ) }>
@@ -41,7 +47,7 @@ export default function WPCheckoutOrderReview( {
 				<WPOrderReviewLineItems
 					items={ items }
 					removeItem={ removeItem }
-					removeCoupon={ removeCoupon }
+					removeCoupon={ removeCouponAndClearField }
 					variantSelectOverride={ variantSelectOverride }
 					getItemVariants={ getItemVariants }
 					onChangePlanLength={ onChangePlanLength }
@@ -50,6 +56,8 @@ export default function WPCheckoutOrderReview( {
 			</WPOrderReviewSection>
 
 			<CouponFieldArea
+				isCouponFieldVisible={ isCouponFieldVisible }
+				setCouponFieldVisible={ setCouponFieldVisible }
 				isPurchaseFree={ isPurchaseFree }
 				couponStatus={ couponStatus }
 				couponFieldStateProps={ couponFieldStateProps }
@@ -71,8 +79,13 @@ WPCheckoutOrderReview.propTypes = {
 	variantSelectOverride: PropTypes.object,
 };
 
-function CouponFieldArea( { isPurchaseFree, couponStatus, couponFieldStateProps } ) {
-	const [ isCouponFieldVisible, setCouponFieldVisible ] = useState( false );
+function CouponFieldArea( {
+	isCouponFieldVisible,
+	setCouponFieldVisible,
+	isPurchaseFree,
+	couponStatus,
+	couponFieldStateProps,
+} ) {
 	const { formStatus } = useFormStatus();
 	const translate = useTranslate();
 

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-review.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-review.js
@@ -21,7 +21,6 @@ export default function WPCheckoutOrderReview( {
 	removeCoupon,
 	couponStatus,
 	couponFieldStateProps,
-	variantRequestStatus,
 	variantSelectOverride,
 	getItemVariants,
 	onChangePlanLength,
@@ -44,7 +43,6 @@ export default function WPCheckoutOrderReview( {
 					items={ items }
 					removeItem={ removeItem }
 					removeCoupon={ removeCoupon }
-					variantRequestStatus={ variantRequestStatus }
 					variantSelectOverride={ variantSelectOverride }
 					getItemVariants={ getItemVariants }
 					onChangePlanLength={ onChangePlanLength }

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-review.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-review.js
@@ -70,6 +70,9 @@ WPCheckoutOrderReview.propTypes = {
 	getItemVariants: PropTypes.func,
 	onChangePlanLength: PropTypes.func,
 	siteUrl: PropTypes.string,
+	couponStatus: PropTypes.string,
+	couponFieldStateProps: PropTypes.object,
+	variantSelectOverride: PropTypes.object,
 };
 
 const DomainURL = styled.div`

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -84,7 +84,6 @@ export default function WPCheckout( {
 	countriesList,
 	StateSelect,
 	renderDomainContactFields,
-	variantRequestStatus,
 	variantSelectOverride,
 	getItemVariants,
 	domainContactValidationCallback,
@@ -201,7 +200,6 @@ export default function WPCheckout( {
 							couponFieldStateProps={ couponFieldStateProps }
 							removeCoupon={ removeCouponAndResetActiveStep }
 							onChangePlanLength={ changePlanLength }
-							variantRequestStatus={ variantRequestStatus }
 							variantSelectOverride={ variantSelectOverride }
 							getItemVariants={ getItemVariants }
 							siteUrl={ siteUrl }

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
@@ -33,7 +33,6 @@ function WPLineItem( {
 	className,
 	hasDeleteButton,
 	removeItem,
-	variantRequestStatus,
 	variantSelectOverride,
 	getItemVariants,
 	onChangePlanLength,
@@ -147,7 +146,6 @@ function WPLineItem( {
 			{ shouldShowVariantSelector && (
 				<ItemVariationPicker
 					selectedItem={ item }
-					variantRequestStatus={ variantRequestStatus }
 					variantSelectOverride={ variantSelectOverride }
 					getItemVariants={ getItemVariants }
 					onChangeItemVariant={ onChangePlanLength }
@@ -290,7 +288,6 @@ export function WPOrderReviewLineItems( {
 	isSummaryVisible,
 	removeItem,
 	removeCoupon,
-	variantRequestStatus,
 	variantSelectOverride,
 	getItemVariants,
 	onChangePlanLength,
@@ -307,7 +304,6 @@ export function WPOrderReviewLineItems( {
 							item={ item }
 							hasDeleteButton={ canItemBeDeleted( item ) }
 							removeItem={ item.type === 'coupon' ? removeCoupon : removeItem }
-							variantRequestStatus={ variantRequestStatus }
 							variantSelectOverride={ variantSelectOverride }
 							getItemVariants={ getItemVariants }
 							onChangePlanLength={ onChangePlanLength }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This hides the coupon field by default in composite checkout and instead shows a button that will make the field visible.

This also makes it so that when a coupon is removed, the field is cleared and hidden.

![Screen Shot 2020-05-28 at 6 30 22 PM](https://user-images.githubusercontent.com/2036909/83200692-e2cfb300-a111-11ea-817c-85abeb9cb13c.png)

![Screen Shot 2020-05-28 at 6 30 29 PM](https://user-images.githubusercontent.com/2036909/83200701-e6fbd080-a111-11ea-9605-3ea5d3c9b05c.png)


#### Testing instructions

- Visit composite checkout and verify that you see the "Add a coupon" button (you will not see it if your purchase is free; that behavior remains the same).
- When you click the button, verify that the field appears.
- Enter a coupon value and press "Apply".
- Press the trash can icon next to the applied coupon and confirm removal.
- Verify that you see "Add a coupon" again and clicking it shows an empty coupon field.