### PR TITLE
Allow 2-years plan variants through CheckoutSystemDecider

### DIFF
--- a/client/my-sites/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout-system-decider.js
@@ -160,12 +160,19 @@ function shouldShowCompositeCheckout(
 	// so they do not need to go through this check.
 	const isRenewal = !! purchaseId;
 	const pseudoSlugsToAllow = [
-		'personal',
-		'premium',
 		'blogger',
-		'ecommerce',
+		'blogger-2-years',
 		'business',
+		'business-2-years',
+		'business-monthly',
 		'concierge-session',
+		'ecommerce',
+		'ecommerce-2-years',
+		'personal',
+		'personal-2-years',
+		'premium',
+		'premium-2-years',
+		'premium-monthly',
 	];
 	const slugPrefixesToAllow = [ 'domain-mapping:', 'theme:' ];
 	if (

--- a/client/my-sites/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout-system-decider.js
@@ -164,7 +164,6 @@ function shouldShowCompositeCheckout(
 		'blogger-2-years',
 		'business',
 		'business-2-years',
-		'business-monthly',
 		'concierge-session',
 		'ecommerce',
 		'ecommerce-2-years',
@@ -172,7 +171,6 @@ function shouldShowCompositeCheckout(
 		'personal-2-years',
 		'premium',
 		'premium-2-years',
-		'premium-monthly',
 	];
 	const slugPrefixesToAllow = [ 'domain-mapping:', 'theme:' ];
 	if (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This allows all the 2-year plan aliases through to composite checkout in `CheckoutSystemDecider`. These slug aliases (they are not real product slugs) are [defined here](https://github.com/Automattic/wp-calypso/blob/master/client/lib/plans/plans-list.js). This does not include jetpack plans because Jetpack sites are currently explicitly blocked, and we did not include `beginner` or `professional` or `professional-monthly`, since I don't believe those are enabled. Finally, we did not include `business-monthly` or `premium-monthly` because I'm not sure how those work (they seem to cause a fatal error in old checkout).

#### Testing instructions

Visit `http://calypso.localhost:3000/plans/[your-site-here]/[slug-alias-here]` for the following aliases and be sure that you are taken to the composite checkout page _and_ that the requested product is in your cart:

```
blogger
blogger-2-years
business
business-2-years
ecommerce
ecommerce-2-years
personal
personal-2-years
premium
premium-2-years
```