### PR TITLE
Jetpack Scan: Make it available on production to purchase

### DIFF
--- a/config/desktop.json
+++ b/config/desktop.json
@@ -41,7 +41,7 @@
 		"jetpack/concierge-sessions": false,
 		"jetpack/connect/remote-install": true,
 		"jetpack/personalPlan": true,
-		"jetpack/scan-product": false,
+		"jetpack/scan-product": true,
 		"jitms": false,
 		"lasagna": false,
 		"layout/app-banner": true,

--- a/config/production.json
+++ b/config/production.json
@@ -55,7 +55,7 @@
 		"jetpack/connect/remote-install": true,
 		"jetpack/connect/woocommerce": true,
 		"jetpack/happychat": true,
-		"jetpack/scan-product": false,
+		"jetpack/scan-product": true,
 		"jetpack/search-product": true,
 		"jitms": true,
 		"lasagna": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request
CUrrently Jetpack Scan is not a product that you can buy if you are on production or the desktop environments. 

This is intential since there was no interface in the wp-admin that would tell you that you had the product etc.

#### Testing instructions

* Deploy and test unproxied buying experiance or Jetpack Scan.

