### PR TITLE
Fix circular dependency in `wpcom-xhr-wrapper`

### DIFF
--- a/client/lib/wpcom-xhr-wrapper/index.js
+++ b/client/lib/wpcom-xhr-wrapper/index.js
@@ -8,15 +8,18 @@ import debugModule from 'debug';
  */
 const debug = debugModule( 'calypso:wpcom-xhr-wrapper' );
 
-export default function ( params, callback ) {
-	return import( /* webpackChunkName: "wpcom-xhr-request" */ 'wpcom-xhr-request' ).then( ( xhr ) =>
-		xhr.default( params, function ( error, response, headers ) {
-			if ( error && error.name === 'InvalidTokenError' ) {
-				debug( 'Invalid token error detected, authorisation probably revoked - logging out' );
-				require( 'lib/user/utils' ).logout();
-			}
+export default async function ( params, callback ) {
+	const xhr = ( await import( /* webpackChunkName: "wpcom-xhr-request" */ 'wpcom-xhr-request' ) )
+		.default;
+	const userUtils = ( await import( /* webpackChunkName: "lib-user-utils" */ 'lib/user/utils' ) )
+		.default;
 
-			callback( error, response, headers );
-		} )
-	);
+	return xhr( params, function ( error, response, headers ) {
+		if ( error && error.name === 'InvalidTokenError' ) {
+			debug( 'Invalid token error detected, authorisation probably revoked - logging out' );
+			userUtils.logout();
+		}
+
+		callback( error, response, headers );
+	} );
 }


### PR DESCRIPTION
`lib/wpcom-xhr-wrapper` was introducing a circular dependency for `lib/user/utils`:

```
client/lib/user/utils.js -> client/lib/user/index.js ->
client/lib/user/user.js -> client/lib/user/support-user-interop.js ->
client/lib/wp/browser.js -> client/lib/wpcom-xhr-wrapper/index.js ->
client/lib/user/utils.js
```

Since `lib/wpcom-xhr-wrapper` is all async anyway, we can load `lib/user/utils` dynamically, and avoid the circular dependency.

@cbauerman: Please ensure that Jetpack Cloud continues to work correctly with these changes.

#### Changes proposed in this Pull Request

* Load `lib/user/utils` dynamically in `lib/wpcom-xhr-wrapper`, instead of using a synchronous `require` (which we shouldn't be using in client code anyway).

#### Testing instructions

Ensure any code making use of `lib/wpcom-xhr-wrapper`, such as Jetpack Cloud, continues to work correctly. I believe everything is working, but I've only been able to perform very minimal testing.
