### PR TITLE
White glove: Modify product name in cart for the new checkout 

### DIFF
--- a/client/blocks/product-purchase-features-list/business-onboarding.jsx
+++ b/client/blocks/product-purchase-features-list/business-onboarding.jsx
@@ -16,12 +16,14 @@ import PurchaseDetail from 'components/purchase-detail';
  */
 import conciergeImage from 'assets/images/illustrations/jetpack-concierge.svg';
 
-export default localize( ( { isWpcomPlan, translate, link, onClick = noop } ) => {
+export default localize( ( { isWpcomPlan, translate, link, isWhiteGlove, onClick = noop } ) => {
+	const title = isWhiteGlove ? 'One-on-one session' : translate( 'Quick Start session' );
+
 	return (
 		<div className="product-purchase-features-list__item">
 			<PurchaseDetail
 				icon={ <img alt="" src={ conciergeImage } /> }
-				title={ translate( 'Quick Start session' ) }
+				title={ title }
 				description={
 					isWpcomPlan
 						? translate(

--- a/client/blocks/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features-list/index.jsx
@@ -44,6 +44,7 @@ import { hasDomainCredit } from 'state/sites/plans/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
 import isSiteUsingFullSiteEditing from 'state/selectors/is-site-using-full-site-editing';
+import isSiteWhiteGlove from 'state/selectors/is-site-white-glove';
 
 /**
  * Style dependencies
@@ -112,6 +113,7 @@ export class ProductPurchaseFeaturesList extends Component {
 					isWpcomPlan
 					onClick={ this.handleBusinessOnboardingClick }
 					link={ `/me/concierge/${ selectedSite.slug }/book` }
+					isWhiteGlove={ this.props.isWhiteGlove }
 				/>
 				{ isWordadsInstantActivationEligible( selectedSite ) && (
 					<MonetizeSite selectedSite={ selectedSite } />
@@ -329,6 +331,7 @@ export default connect(
 			selectedSite,
 			planHasDomainCredit: hasDomainCredit( state, selectedSiteId ),
 			showCustomizerFeature: ! isSiteUsingFullSiteEditing( state, selectedSiteId ),
+			isWhiteGlove: isSiteWhiteGlove( state, selectedSiteId ),
 		};
 	},
 	{

--- a/client/me/concierge/book/info-step.js
+++ b/client/me/concierge/book/info-step.js
@@ -33,6 +33,7 @@ import { getLanguage } from 'lib/i18n-utils';
 import getCountries from 'state/selectors/get-countries';
 import QuerySmsCountries from 'components/data/query-countries/sms';
 import FormInputValidation from 'components/forms/form-input-validation';
+import isSiteWhiteGlove from 'state/selectors/is-site-white-glove';
 
 class InfoStep extends Component {
 	static propTypes = {
@@ -126,6 +127,7 @@ class InfoStep extends Component {
 				phoneNumberWithoutCountryCode,
 			},
 			site,
+			isWhiteGlove,
 			translate,
 		} = this.props;
 		const language = getLanguage( currentUserLocale ).name;
@@ -137,7 +139,7 @@ class InfoStep extends Component {
 		return (
 			<div>
 				<IsRebrandCitiesSite onChange={ this.setRebrandCitiesValue } siteId={ site.ID } />
-				<PrimaryHeader />
+				<PrimaryHeader isWhiteGlove={ isWhiteGlove } />
 				{ ! isEnglish && <Notice showDismiss={ false } text={ noticeText } /> }
 				<CompactCard className="book__info-step-site-block">
 					<Site siteId={ site.ID } />
@@ -230,11 +232,12 @@ class InfoStep extends Component {
 }
 
 export default connect(
-	( state ) => ( {
+	( state, ownProps ) => ( {
 		currentUserLocale: getCurrentUserLocale( state ),
 		signupForm: getConciergeSignupForm( state ),
 		userSettings: getUserSettings( state ),
 		countriesList: getCountries( state, 'sms' ),
+		isWhiteGlove: isSiteWhiteGlove( state, ownProps.site.ID ),
 	} ),
 	{
 		updateConciergeSignupForm,

--- a/client/me/concierge/main.js
+++ b/client/me/concierge/main.js
@@ -99,7 +99,7 @@ export class ConciergeMain extends Component {
 		}
 
 		if ( isEmpty( availableTimes ) ) {
-			return <NoAvailableTimes />;
+			return <NoAvailableTimes site={ site } />;
 		}
 
 		// We have shift data and this is a business site — show the signup steps

--- a/client/me/concierge/shared/no-available-times.js
+++ b/client/me/concierge/shared/no-available-times.js
@@ -11,6 +11,7 @@ import { localize } from 'i18n-calypso';
 import { Card } from '@automattic/components';
 import PrimaryHeader from './primary-header';
 import { recordTracksEvent } from 'state/analytics/actions';
+import isSiteWhiteGlove from 'state/selectors/is-site-white-glove';
 
 class NoAvailableTimes extends Component {
 	componentDidMount() {
@@ -18,26 +19,38 @@ class NoAvailableTimes extends Component {
 	}
 
 	render() {
-		const { translate } = this.props;
+		const { isWhiteGlove, translate } = this.props;
+
 		return (
 			<div>
-				<PrimaryHeader />
+				<PrimaryHeader isWhiteGlove={ isWhiteGlove } />
 				<Card>
 					<h2 className="shared__no-available-times-heading">
 						{ translate( 'Sorry, there are no sessions available' ) }
 					</h2>
-					{ translate(
-						'We schedule Quick Start Sessions up to 24 hours in advance and all upcoming sessions are full. Please check back later or {{link}}contact us in Live Chat{{/link}}.',
-						{
-							components: {
-								link: <a href="https://wordpress.com/help/contact" />,
-							},
-						}
+					{ isWhiteGlove && (
+						<>
+							We schedule one-on-one sessions up to 24 hours in advance and all upcoming sessions
+							are full. Please check back later or{ ' ' }
+							<a href="https://wordpress.com/help/contact">contact us in Live Chat</a>.
+						</>
 					) }
+					{ ! isWhiteGlove &&
+						translate(
+							'We schedule Quick Start Sessions up to 24 hours in advance and all upcoming sessions are full. Please check back later or {{link}}contact us in Live Chat{{/link}}.',
+							{
+								components: {
+									link: <a href="https://wordpress.com/help/contact" />,
+								},
+							}
+						) }
 				</Card>
 			</div>
 		);
 	}
 }
 
-export default connect( null, { recordTracksEvent } )( localize( NoAvailableTimes ) );
+export default connect(
+	( state, ownProps ) => ( { isWhiteGlove: isSiteWhiteGlove( state, ownProps.site.ID ) } ),
+	{ recordTracksEvent }
+)( localize( NoAvailableTimes ) );

--- a/client/me/concierge/shared/primary-header.js
+++ b/client/me/concierge/shared/primary-header.js
@@ -16,7 +16,11 @@ import { CONCIERGE_SUPPORT } from 'lib/url/support';
 
 class PrimaryHeader extends Component {
 	render() {
-		const { translate } = this.props;
+		const { isWhiteGlove, translate } = this.props;
+
+		const headerText = isWhiteGlove
+			? 'WordPress.com one-on-one session scheduler'
+			: translate( 'WordPress.com Quick Start Session Scheduler' );
 
 		return (
 			<Fragment>
@@ -33,7 +37,7 @@ class PrimaryHeader extends Component {
 						src={ '/calypso/images/illustrations/illustration-start.svg' }
 					/>
 					<FormattedHeader
-						headerText={ translate( 'WordPress.com Quick Start Session Scheduler' ) }
+						headerText={ headerText }
 						subHeaderText={ translate(
 							'Use the tool below to book your in-depth support session.'
 						) }

--- a/client/my-sites/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout-system-decider.js
@@ -91,6 +91,7 @@ export default function CheckoutSystemDecider( {
 					feature={ selectedFeature }
 					plan={ plan }
 					cart={ cart }
+					isWhiteGloveOffer={ isWhiteGloveOffer }
 				/>
 			</StripeHookProvider>
 		);

--- a/client/my-sites/checkout/checkout-thank-you/business-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/business-plan-details.jsx
@@ -29,9 +29,21 @@ function trackOnboardingButtonClick() {
 	recordTracksEvent( 'calypso_checkout_thank_you_onboarding_click' );
 }
 
-const BusinessPlanDetails = ( { selectedSite, sitePlans, selectedFeature, purchases } ) => {
+const BusinessPlanDetails = ( {
+	selectedSite,
+	sitePlans,
+	selectedFeature,
+	purchases,
+	displayMode,
+} ) => {
 	const plan = find( sitePlans.data, isBusiness );
 	const googleAppsWasPurchased = purchases.some( isGoogleApps );
+	const whiteGloveQuickStartDescription =
+		'white-glove' === displayMode
+			? 'Schedule a one-on-one session with a Happiness Engineer to set up your site and learn more about WordPress.com.'
+			: i18n.translate(
+					'Schedule a Quick Start session with a Happiness Engineer to set up your site and learn more about WordPress.com.'
+			  );
 
 	return (
 		<div>
@@ -45,10 +57,7 @@ const BusinessPlanDetails = ( { selectedSite, sitePlans, selectedFeature, purcha
 			<PurchaseDetail
 				icon={ <img alt="" src={ conciergeImage } /> }
 				title={ i18n.translate( 'Get personalized help' ) }
-				description={ i18n.translate(
-					'Schedule a Quick Start session with a Happiness Engineer to set up ' +
-						'your site and learn more about WordPress.com.'
-				) }
+				description={ whiteGloveQuickStartDescription }
 				buttonText={ i18n.translate( 'Schedule a session' ) }
 				href={ `/me/concierge/${ selectedSite.slug }/book` }
 				onClick={ trackOnboardingButtonClick }

--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -97,12 +97,18 @@ export class CheckoutThankYouHeader extends PureComponent {
 		}
 
 		if ( isPlan( primaryPurchase ) ) {
+			let productName = primaryPurchase.productName;
+
+			if ( 'white-glove' === displayMode ) {
+				productName = `${ productName } (White glove edition)`;
+			}
+
 			return preventWidows(
 				translate(
 					'Your site is now on the {{strong}}%(productName)s{{/strong}} plan. ' +
 						"It's doing somersaults in excitement!",
 					{
-						args: { productName: primaryPurchase.productName },
+						args: { productName: productName },
 						components: { strong: <strong /> },
 					}
 				)

--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -625,6 +625,7 @@ export class CheckoutThankYou extends React.Component {
 								selectedSite={ selectedSite }
 								selectedFeature={ getFeatureByKey( this.props.selectedFeature ) }
 								sitePlans={ sitePlans }
+								displayMode={ displayMode }
 							/>
 						</div>
 					) }

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -590,6 +590,10 @@ export class Checkout extends React.Component {
 			displayModeParam = { d: 'concierge' };
 		}
 
+		if ( this.props.isWhiteGloveOffer ) {
+			displayModeParam = { d: 'white-glove' };
+		}
+
 		if ( this.props.isEligibleForSignupDestination ) {
 			return this.getUrlWithQueryParam( signupDestination, displayModeParam );
 		}

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -515,7 +515,8 @@ export default function CompositeCheckout( {
 			card: stripeCardProcessor,
 			'full-credits': fullCreditsProcessor,
 			'existing-card': existingCardProcessor,
-			paypal: ( transactionData ) => payPalProcessor( transactionData, getThankYouUrl, couponItem ),
+			paypal: ( transactionData ) =>
+				payPalProcessor( transactionData, getThankYouUrl, couponItem, isWhiteGloveOffer ),
 		} ),
 		[ couponItem, getThankYouUrl ]
 	);

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -244,6 +244,7 @@ export default function CompositeCheckout( {
 		isJetpackNotAtomic,
 		product,
 		siteId,
+		isWhiteGloveOffer,
 	} );
 
 	const moment = useLocalizedMoment();

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -133,6 +133,7 @@ export default function CompositeCheckout( {
 	purchaseId,
 	cart,
 	couponCode: couponCodeFromUrl,
+	isWhiteGloveOffer,
 } ) {
 	const translate = useTranslate();
 	const isJetpackNotAtomic = useSelector(
@@ -562,6 +563,7 @@ export default function CompositeCheckout( {
 					subtotal={ subtotal }
 					isCartPendingUpdate={ isCartPendingUpdate }
 					CheckoutTerms={ CheckoutTerms }
+					isWhiteGloveOffer={ isWhiteGloveOffer }
 				/>
 			</CheckoutProvider>
 		</React.Fragment>

--- a/client/my-sites/checkout/composite-checkout/payment-method-processors.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-processors.js
@@ -136,8 +136,9 @@ export async function fullCreditsProcessor( submitData ) {
 	return pending;
 }
 
-export async function payPalProcessor( submitData, getThankYouUrl, couponItem ) {
+export async function payPalProcessor( submitData, getThankYouUrl, couponItem, isWhiteGloveOffer ) {
 	const { protocol, hostname, port, pathname } = parseUrl( window.location.href, true );
+	const query = isWhiteGloveOffer ? { type: 'white-glove' } : {};
 	const successUrl = formatUrl( {
 		protocol,
 		hostname,
@@ -149,6 +150,7 @@ export async function payPalProcessor( submitData, getThankYouUrl, couponItem ) 
 		hostname,
 		port,
 		pathname,
+		query,
 	} );
 
 	const pending = submitPayPalExpressRequest(

--- a/client/my-sites/checkout/composite-checkout/types/paypal-express.ts
+++ b/client/my-sites/checkout/composite-checkout/types/paypal-express.ts
@@ -24,6 +24,7 @@ export type PayPalExpressEndpointRequestPayload = {
 	domainDetails: WPCOMTransactionEndpointDomainDetails;
 	country: string;
 	postalCode: string;
+	isWhiteGloveOffer: boolean;
 };
 
 export function createPayPalExpressEndpointRequestPayloadFromLineItems( {
@@ -47,6 +48,9 @@ export function createPayPalExpressEndpointRequestPayloadFromLineItems( {
 	domainDetails: WPCOMTransactionEndpointDomainDetails;
 	items: WPCOMCartItem[];
 } ): PayPalExpressEndpointRequestPayload {
+	const urlParams = new URLSearchParams( window.location.search );
+	const isWhiteGlove = urlParams.get( 'type' ) === 'white-glove';
+
 	return {
 		successUrl,
 		cancelUrl,
@@ -61,6 +65,7 @@ export function createPayPalExpressEndpointRequestPayloadFromLineItems( {
 		country,
 		postalCode,
 		domainDetails,
+		isWhiteGloveOffer: isWhiteGlove,
 	};
 }
 

--- a/client/my-sites/checkout/composite-checkout/types/transaction-endpoint.ts
+++ b/client/my-sites/checkout/composite-checkout/types/transaction-endpoint.ts
@@ -22,6 +22,7 @@ export type WPCOMTransactionEndpointRequestPayload = {
 	cart: WPCOMTransactionEndpointCart;
 	payment: WPCOMTransactionEndpointPaymentDetails;
 	domainDetails?: WPCOMTransactionEndpointDomainDetails;
+	isWhiteGloveOffer: boolean;
 };
 
 export type WPCOMTransactionEndpointPaymentDetails = {
@@ -153,6 +154,9 @@ export function createTransactionEndpointRequestPayloadFromLineItems( {
 	storedDetailsId: string;
 	name: string;
 } ): WPCOMTransactionEndpointRequestPayload {
+	const urlParams = new URLSearchParams( window.location.search );
+	const isWhiteGlove = urlParams.get( 'type' ) === 'white-glove';
+
 	return {
 		cart: createTransactionEndpointCartFromLineItems( {
 			siteId,
@@ -173,6 +177,7 @@ export function createTransactionEndpointRequestPayloadFromLineItems( {
 			postalCode,
 			zip: postalCode, // TODO: do we need this in addition to postalCode?
 		},
+		isWhiteGloveOffer: isWhiteGlove,
 	};
 }
 

--- a/client/my-sites/checkout/composite-checkout/use-get-thank-you-url.js
+++ b/client/my-sites/checkout/composite-checkout/use-get-thank-you-url.js
@@ -50,6 +50,7 @@ export function getThankYouPageUrl( {
 	saveUrlToCookie = persistSignupDestination,
 	previousRoute,
 	isEligibleForSignupDestinationResult,
+	isWhiteGloveOffer,
 } ) {
 	debug( 'starting getThankYouPageUrl' );
 	// If we're given an explicit `redirectTo` query arg, make sure it's either internal
@@ -149,7 +150,9 @@ export function getThankYouPageUrl( {
 
 	// Display mode is used to show purchase specific messaging, for e.g. the Schedule Session button
 	// when purchasing a concierge session.
-	const displayModeParam = getDisplayModeParamFromCart( cart );
+	const displayModeParam = isWhiteGloveOffer
+		? { d: 'white-glove' }
+		: getDisplayModeParamFromCart( cart );
 	if ( isEligibleForSignupDestinationResult && signupDestination ) {
 		debug( 'is elligible for signup destination', signupDestination );
 		return getUrlWithQueryParam( signupDestination, displayModeParam );
@@ -299,6 +302,7 @@ export function useGetThankYouUrl( {
 	isJetpackNotAtomic,
 	product,
 	siteId,
+	isWhiteGloveOffer,
 } ) {
 	const selectedSiteData = useSelector( ( state ) => getSelectedSite( state ) );
 	const adminUrl = selectedSiteData?.options?.admin_url;
@@ -340,6 +344,7 @@ export function useGetThankYouUrl( {
 			product,
 			previousRoute,
 			isEligibleForSignupDestinationResult,
+			isWhiteGloveOffer,
 		} );
 		debug( 'getThankYouUrl returned', url );
 		return url;

--- a/client/my-sites/checkout/composite-checkout/use-prepare-product-for-cart.js
+++ b/client/my-sites/checkout/composite-checkout/use-prepare-product-for-cart.js
@@ -102,12 +102,13 @@ function useAddRenewalItems( { originalPurchaseId, productAlias, setState } ) {
 
 function useAddPlanFromSlug( { planSlug, setState, isJetpackNotAtomic, originalPurchaseId } ) {
 	const isFetchingPlans = useSelector( ( state ) => isRequestingPlans( state ) );
+	const plans = useSelector( ( state ) => getPlans( state ) );
 	const plan = useSelector( ( state ) => getPlanBySlug( state, planSlug ) );
 	useEffect( () => {
-		if ( ! planSlug || isFetchingPlans ) {
+		if ( ! planSlug ) {
 			return;
 		}
-		if ( isFetchingPlans ) {
+		if ( isFetchingPlans || plans?.length < 1 ) {
 			debug( 'waiting on plans fetch' );
 			return;
 		}
@@ -136,7 +137,7 @@ function useAddPlanFromSlug( { planSlug, setState, isJetpackNotAtomic, originalP
 			cartProduct
 		);
 		setState( { productsForCart: [ cartProduct ], canInitializeCart: true } );
-	}, [ originalPurchaseId, isFetchingPlans, planSlug, plan, isJetpackNotAtomic, setState ] );
+	}, [ plans, originalPurchaseId, isFetchingPlans, planSlug, plan, isJetpackNotAtomic, setState ] );
 }
 
 function useAddProductFromSlug( {
@@ -147,7 +148,9 @@ function useAddProductFromSlug( {
 	originalPurchaseId,
 } ) {
 	const isFetchingPlans = useSelector( ( state ) => isRequestingPlans( state ) );
+	const plans = useSelector( ( state ) => getPlans( state ) );
 	const isFetchingProducts = useSelector( ( state ) => isProductsListFetching( state ) );
+	const products = useSelector( ( state ) => getProductsList( state ) );
 	const product = useSelector( ( state ) =>
 		getProductBySlug( state, getProductSlugFromAlias( productAlias ) )
 	);
@@ -164,7 +167,12 @@ function useAddProductFromSlug( {
 			// If this is a renewal, another hook will handle this
 			return;
 		}
-		if ( isFetchingPlans || isFetchingProducts ) {
+		if (
+			isFetchingPlans ||
+			isFetchingProducts ||
+			plans?.length < 1 ||
+			Object.keys( products || {} ).length < 1
+		) {
 			debug( 'waiting on products/plans fetch' );
 			return;
 		}
@@ -190,6 +198,8 @@ function useAddProductFromSlug( {
 		);
 		setState( { productsForCart: [ cartProduct ], canInitializeCart: true } );
 	}, [
+		plans,
+		products,
 		originalPurchaseId,
 		isFetchingPlans,
 		planSlug,

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-review.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-review.js
@@ -26,6 +26,7 @@ export default function WPCheckoutOrderReview( {
 	getItemVariants,
 	onChangePlanLength,
 	siteUrl,
+	isWhiteGloveOffer,
 } ) {
 	const translate = useTranslate();
 	const [ items, total ] = useLineItems();
@@ -49,6 +50,7 @@ export default function WPCheckoutOrderReview( {
 					getItemVariants={ getItemVariants }
 					onChangePlanLength={ onChangePlanLength }
 					couponStatus={ couponStatus }
+					isWhiteGloveOffer={ isWhiteGloveOffer }
 				/>
 			</WPOrderReviewSection>
 

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -93,6 +93,7 @@ export default function WPCheckout( {
 	addItemToCart,
 	subtotal,
 	isCartPendingUpdate,
+	isWhiteGloveOffer,
 } ) {
 	const translate = useTranslate();
 	const couponFieldStateProps = useCouponFieldState( submitCoupon );
@@ -205,6 +206,7 @@ export default function WPCheckout( {
 							variantSelectOverride={ variantSelectOverride }
 							getItemVariants={ getItemVariants }
 							siteUrl={ siteUrl }
+							isWhiteGloveOffer={ isWhiteGloveOffer }
 						/>
 					}
 					titleContent={ <OrderReviewTitle /> }

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
@@ -38,6 +38,7 @@ function WPLineItem( {
 	getItemVariants,
 	onChangePlanLength,
 	couponStatus,
+	isWhiteGloveOffer,
 } ) {
 	const translate = useTranslate();
 	const hasDomainsInCart = useHasDomainsInCart();
@@ -77,10 +78,11 @@ function WPLineItem( {
 	} else {
 		sublabelAndIntervalPriceBreakdown = item.sublabel;
 	}
+	const productName = isWhiteGloveOffer ? `${ item.label } (White glove edition)` : item.label;
 
 	return (
 		<div className={ joinClasses( [ className, 'checkout-line-item' ] ) }>
-			<LineItemTitle id={ itemSpanId }>{ item.label }</LineItemTitle>
+			<LineItemTitle id={ itemSpanId }>{ productName }</LineItemTitle>
 			<span aria-labelledby={ itemSpanId }>
 				<LineItemPrice item={ item } />
 			</span>
@@ -295,6 +297,7 @@ export function WPOrderReviewLineItems( {
 	getItemVariants,
 	onChangePlanLength,
 	couponStatus,
+	isWhiteGloveOffer,
 } ) {
 	return (
 		<WPOrderReviewList className={ joinClasses( [ className, 'order-review-line-items' ] ) }>
@@ -305,6 +308,7 @@ export function WPOrderReviewLineItems( {
 						<LineItemUI
 							isSummaryVisible={ isSummaryVisible }
 							item={ item }
+							isWhiteGloveOffer={ isWhiteGloveOffer }
 							hasDeleteButton={ canItemBeDeleted( item ) }
 							removeItem={ item.type === 'coupon' ? removeCoupon : removeItem }
 							variantRequestStatus={ variantRequestStatus }

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
@@ -19,6 +19,7 @@ import joinClasses from './join-classes';
 import Button from './button';
 import { useHasDomainsInCart } from '../hooks/has-domains';
 import { ItemVariationPicker } from './item-variation-picker';
+import { isBusinessPlan } from 'lib/plans';
 
 export function WPOrderReviewSection( { children, className } ) {
 	return <div className={ joinClasses( [ className, 'order-review-section' ] ) }>{ children }</div>;
@@ -78,7 +79,13 @@ function WPLineItem( {
 	} else {
 		sublabelAndIntervalPriceBreakdown = item.sublabel;
 	}
-	const productName = isWhiteGloveOffer ? `${ item.label } (White glove edition)` : item.label;
+
+	const productSlug = item.wpcom_meta?.product_slug;
+	const isBusinessPlanProduct = productSlug && isBusinessPlan( productSlug );
+	const productName =
+		isBusinessPlanProduct && isWhiteGloveOffer
+			? `${ item.label } (White glove edition)`
+			: item.label;
 
 	return (
 		<div className={ joinClasses( [ className, 'checkout-line-item' ] ) }>

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -40,6 +40,8 @@ import AsyncLoad from 'components/async-load';
 import UpsellNudge from 'blocks/upsell-nudge';
 import { preventWidows } from 'lib/formatting';
 import isSiteWPForTeams from 'state/selectors/is-site-wpforteams';
+import getSiteOptions from 'state/selectors/get-site-options';
+import { abtest } from 'lib/abtest';
 
 const DOMAIN_UPSELL_NUDGE_DISMISS_KEY = 'domain_upsell_nudge_dismiss';
 
@@ -244,6 +246,34 @@ export class SiteNotice extends React.Component {
 		return moment( now ).format( format ) === moment( endsAt ).format( format );
 	}
 
+	isEligibleForWhiteGlove() {
+		const createdAt = get( this.props.siteOptions, 'created_at', '' );
+		const HOURS_IN_MS = 60 * 60 * 1000;
+		const isSiteNew = Date.now() - new Date( createdAt ) < 24 * HOURS_IN_MS; // less than 24 hours
+
+		if ( isSiteNew && 'variantShowOffer' === abtest( 'whiteGloveUpsell' ) ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	showWhiteGloveNudge() {
+		const { translate } = this.props;
+		return (
+			<UpsellNudge
+				event={ 'white-glove' }
+				forceHref={ true }
+				callToAction={ translate( 'Upgrade' ) }
+				compact
+				href={ `/checkout/${ this.props.site.slug }/offer-white-glove` }
+				title={ 'White Glove Offer' }
+				tracksClickName={ 'calypso_upgrade_nudge_cta_click' }
+				tracksImpressionName={ 'calypso_upgrade_nudge_impression' }
+			/>
+		);
+	}
+
 	render() {
 		const { site, isMigrationInProgress, messagePath, hasJITM } = this.props;
 		if ( ! site || isMigrationInProgress ) {
@@ -253,8 +283,14 @@ export class SiteNotice extends React.Component {
 		const discountOrFreeToPaid = this.activeDiscountNotice();
 		const siteRedirectNotice = this.getSiteRedirectNotice( site );
 		const domainCreditNotice = this.domainCreditNotice();
+		const isEligibleForWhiteGlove = this.isEligibleForWhiteGlove();
+
+		if ( isEligibleForWhiteGlove ) {
+			return this.showWhiteGloveNudge();
+		}
 
 		const showJitms =
+			! this.isEligibleForWhiteGlove() &&
 			! ( isEnabled( 'signup/wpforteams' ) && this.props.isSiteWPForTeams ) &&
 			( discountOrFreeToPaid || config.isEnabled( 'jitms' ) );
 
@@ -284,7 +320,6 @@ export default connect(
 		const siteId = ownProps.site && ownProps.site.ID ? ownProps.site.ID : null;
 		const sectionName = getSectionName( state );
 		const messagePath = `calypso:${ sectionName }:sidebar_notice`;
-
 		const isMigrationInProgress =
 			isSiteMigrationInProgress( state, siteId ) || isSiteMigrationActiveRoute( state );
 
@@ -303,6 +338,7 @@ export default connect(
 			isMigrationInProgress,
 			hasJITM: getTopJITM( state, messagePath ),
 			messagePath,
+			siteOptions: getSiteOptions( state, siteId ),
 		};
 	},
 	( dispatch ) => {

--- a/client/state/selectors/is-site-white-glove.js
+++ b/client/state/selectors/is-site-white-glove.js
@@ -1,0 +1,21 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import getRawSite from 'state/selectors/get-raw-site';
+
+/**
+ * Checks if a site is a white glove purchase
+ *
+ * @param {object} state  Global state tree
+ * @param {object} siteId Site ID
+ * @returns {boolean} True if the site is a white glove purchase, otherwise false
+ */
+export default function isSiteWhiteGlove( state, siteId ) {
+	const site = getRawSite( state, siteId );
+	return get( site, 'is_white_glove', false );
+}

--- a/client/state/selectors/test/is-site-white-glove.js
+++ b/client/state/selectors/test/is-site-white-glove.js
@@ -1,0 +1,54 @@
+/**
+ * Internal dependencies
+ */
+import isSiteWhiteGlove from '../is-site-white-glove';
+
+describe( 'isSiteWhiteGlove', () => {
+	test( 'returns false if site does not exist', () => {
+		const state = { sites: { items: {} } };
+		const isWhiteGlove = isSiteWhiteGlove( state, 1 );
+		expect( isWhiteGlove ).toBe( false );
+	} );
+
+	test( 'returns true if site exists and has is_white_glove true', () => {
+		const state = {
+			sites: {
+				items: {
+					123: {
+						is_white_glove: true,
+					},
+				},
+			},
+		};
+		const isWhiteGlove = isSiteWhiteGlove( state, 123 );
+		expect( isWhiteGlove ).toBe( true );
+	} );
+
+	test( 'returns false if site exists and has is_white_glove false', () => {
+		const state = {
+			sites: {
+				items: {
+					123: {
+						is_white_glove: false,
+					},
+				},
+			},
+		};
+		const isWhiteGlove = isSiteWhiteGlove( state, 123 );
+		expect( isWhiteGlove ).toBe( false );
+	} );
+
+	test( 'returns false if site exists and has no is_white_glove prop', () => {
+		const state = {
+			sites: {
+				items: {
+					123: {
+						someKey: 'someValue',
+					},
+				},
+			},
+		};
+		const isWhiteGlove = isSiteWhiteGlove( state, 123 );
+		expect( isWhiteGlove ).toBe( false );
+	} );
+} );

--- a/client/state/sites/constants.js
+++ b/client/state/sites/constants.js
@@ -20,6 +20,7 @@ export const SITE_REQUEST_FIELDS = [
 	'is_fse_active',
 	'is_fse_eligible',
 	'is_core_site_editor_enabled',
+	'is_white_glove',
 ].join();
 
 export const SITE_REQUEST_OPTIONS = [


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR is a part of the larger PR that implements the white glove A/B test. Please check #41618 for more context.

* This PR is similar to https://github.com/Automattic/wp-calypso/pull/42788, and makes the change for the new checkout.
* If a user clicks "Buy now" on the white glove offer page, then we add a Business plan in cart with the product name modified to indicate that it's a white glove product.
<img src="https://user-images.githubusercontent.com/1269602/83154973-5e376180-a11e-11ea-905f-f9616b3d095f.png" />
* Completing the purchase will send a receipt to the email inbox with the name "white glove" mentioned in the receipt.

<img src="https://user-images.githubusercontent.com/1269602/83155499-ed447980-a11e-11ea-8358-5fa6ddf206b6.png" />

* Rename "Quick Start" to "one-on-one" in the email that asks to schedule a concierge session:

<img src="https://user-images.githubusercontent.com/1269602/83159763-f97f0580-a123-11ea-8257-0939186c6635.png">

#### Testing instructions

**Note**: Make sure you only see the new checkout for testing this PR. For this, you need a US IP address and assigned to `composite` variation of the `showCompositeCheckout` A/B test.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Depends on D42624-code. Please apply patch in your sandbox.

* Assign yourself to the whiteGloveUpsell test's variant and begin signup flow. Apply D42624-code to sandbox.
* Select free plan and free domain, you should now see the offer page.
* Click "No thanks" on the offer should take you to Customer Home
* Click "Buy now" on the offer should take you to the checkout page.
* Verify that the product name in cart says "WordPress.com Business (White glove edition)"
* Complete purchase and check the receipt email sent to the user's inbox. Verify that the receipt mentions the product as "WordPress.com Business (White glove edition)" as shown in the screenshot in PR description.

**Scenario 2**
* Try purchasing the product via other payment options, like PayPal, and verify that the purchase completes successfully.