### PR TITLE
Make the plans store tree-shakable

### DIFF
--- a/client/landing/gutenboarding/components/plans/plans-button/index.tsx
+++ b/client/landing/gutenboarding/components/plans/plans-button/index.tsx
@@ -18,7 +18,7 @@ import { useSelectedPlan } from '../../../hooks/use-selected-plan';
 import { useCurrentStep, Step } from '../../../path';
 import { Plans } from '@automattic/data-stores';
 
-const PLANS = Plans.STORE_KEY;
+const PLANS = Plans.register();
 
 /**
  * Style dependencies

--- a/client/landing/gutenboarding/components/plans/plans-button/index.tsx
+++ b/client/landing/gutenboarding/components/plans/plans-button/index.tsx
@@ -16,9 +16,7 @@ import JetpackLogo from 'components/jetpack-logo'; // @TODO: extract to @automat
 import PlansModal from '../plans-modal';
 import { useSelectedPlan } from '../../../hooks/use-selected-plan';
 import { useCurrentStep, Step } from '../../../path';
-import { Plans } from '@automattic/data-stores';
-
-const PLANS = Plans.register();
+import { PLANS_STORE } from '../../../stores/plans';
 
 /**
  * Style dependencies
@@ -27,7 +25,7 @@ import './style.scss';
 
 const PlansButton: React.FunctionComponent< Button.ButtonProps > = ( { ...buttonProps } ) => {
 	const { __ } = useI18n();
-	const selectedPlan = useSelect( ( select ) => select( PLANS ).getSelectedPlan() );
+	const selectedPlan = useSelect( ( select ) => select( PLANS_STORE ).getSelectedPlan() );
 	const currentStep = useCurrentStep();
 
 	// mobile first to match SCSS media query https://github.com/Automattic/wp-calypso/pull/41471#discussion_r415678275

--- a/client/landing/gutenboarding/components/plans/plans-details/index.tsx
+++ b/client/landing/gutenboarding/components/plans/plans-details/index.tsx
@@ -12,7 +12,7 @@ import { useSelect } from '@wordpress/data';
  */
 import './style.scss';
 
-const PLANS_STORE = Plans.STORE_KEY;
+const PLANS_STORE = Plans.register();
 
 const PlansDetails: React.FunctionComponent = ( props ) => {
 	const plansDetails = useSelect( ( select ) => select( PLANS_STORE ).getPlansDetails() );

--- a/client/landing/gutenboarding/components/plans/plans-details/index.tsx
+++ b/client/landing/gutenboarding/components/plans/plans-details/index.tsx
@@ -5,14 +5,13 @@ import React from 'react';
 import { useI18n } from '@automattic/react-i18n';
 import { Path, SVG } from '@wordpress/primitives';
 import { Icon } from '@wordpress/icons';
-import { Plans } from '@automattic/data-stores';
 import { useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import './style.scss';
 
-const PLANS_STORE = Plans.register();
+import { PLANS_STORE } from '../../../stores/plans';
+import './style.scss';
 
 const PlansDetails: React.FunctionComponent = ( props ) => {
 	const plansDetails = useSelect( ( select ) => select( PLANS_STORE ).getPlansDetails() );

--- a/client/landing/gutenboarding/components/plans/plans-grid/index.tsx
+++ b/client/landing/gutenboarding/components/plans/plans-grid/index.tsx
@@ -23,7 +23,7 @@ import PlansDetails from '../plans-details';
 import './style.scss';
 import { useSelectedPlan } from 'landing/gutenboarding/hooks/use-selected-plan';
 
-const PLANS_STORE = Plans.STORE_KEY;
+const PLANS_STORE = Plans.register();
 
 // https://developer.mozilla.org/en-US/docs/Web/HTTP/Browser_detection_using_the_user_agent#Mobile_Tablet_or_Desktop
 const isMobile = window.navigator.userAgent.indexOf( 'Mobi' ) > -1;

--- a/client/landing/gutenboarding/components/plans/plans-grid/index.tsx
+++ b/client/landing/gutenboarding/components/plans/plans-grid/index.tsx
@@ -7,11 +7,11 @@ import { Icon, chevronDown } from '@wordpress/icons';
 import { useDispatch } from '@wordpress/data';
 import { useI18n } from '@automattic/react-i18n';
 import classNames from 'classnames';
-import { Plans } from '@automattic/data-stores';
 
 /**
  * Internal dependencies
  */
+import { PLANS_STORE } from '../../../stores/plans';
 import { Title, SubTitle } from '../../titles';
 import ActionButtons from '../../action-buttons';
 import PlansTable from '../plans-table';
@@ -22,8 +22,6 @@ import PlansDetails from '../plans-details';
  */
 import './style.scss';
 import { useSelectedPlan } from 'landing/gutenboarding/hooks/use-selected-plan';
-
-const PLANS_STORE = Plans.register();
 
 // https://developer.mozilla.org/en-US/docs/Web/HTTP/Browser_detection_using_the_user_agent#Mobile_Tablet_or_Desktop
 const isMobile = window.navigator.userAgent.indexOf( 'Mobi' ) > -1;

--- a/client/landing/gutenboarding/components/plans/plans-modal/index.tsx
+++ b/client/landing/gutenboarding/components/plans/plans-modal/index.tsx
@@ -6,11 +6,11 @@ import Modal from 'react-modal';
 import { useDispatch } from '@wordpress/data';
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { Plans } from '@automattic/data-stores';
 
 /**
  * Internal dependencies
  */
+import { PLANS_STORE } from '../../../stores/plans';
 import PlansGrid, { Props as PlansGridProps } from '../plans-grid';
 import { useTrackModal } from '../../../hooks/use-track-modal';
 import { useSelectedPlan } from '../../../hooks/use-selected-plan';
@@ -19,8 +19,6 @@ import { useSelectedPlan } from '../../../hooks/use-selected-plan';
  * Style dependencies
  */
 import './style.scss';
-
-const PLANS_STORE = Plans.register();
 
 interface Props extends Partial< PlansGridProps > {
 	onClose: () => void;

--- a/client/landing/gutenboarding/components/plans/plans-modal/index.tsx
+++ b/client/landing/gutenboarding/components/plans/plans-modal/index.tsx
@@ -20,7 +20,7 @@ import { useSelectedPlan } from '../../../hooks/use-selected-plan';
  */
 import './style.scss';
 
-const PLANS_STORE = Plans.STORE_KEY;
+const PLANS_STORE = Plans.register();
 
 interface Props extends Partial< PlansGridProps > {
 	onClose: () => void;

--- a/client/landing/gutenboarding/components/plans/plans-table/index.tsx
+++ b/client/landing/gutenboarding/components/plans/plans-table/index.tsx
@@ -2,21 +2,23 @@
  * External dependencies
  */
 import React from 'react';
-import { Plans as PlansStore } from '@automattic/data-stores';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
-import './style.scss';
+import { PLANS_STORE } from '../../../stores/plans';
 import PlanItem from './plan-item';
-import { useSelect } from '@wordpress/data';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
 
 export interface Props {
 	selectedPlanSlug: string;
 	onPlanSelect: ( planSlug: string ) => void;
 }
-
-const PLANS_STORE = PlansStore.register();
 
 const Plans: React.FunctionComponent< Props > = ( { selectedPlanSlug, onPlanSelect } ) => {
 	const supportedPlans = useSelect( ( select ) => select( PLANS_STORE ).getSupportedPlans() );

--- a/client/landing/gutenboarding/components/plans/plans-table/index.tsx
+++ b/client/landing/gutenboarding/components/plans/plans-table/index.tsx
@@ -16,7 +16,7 @@ export interface Props {
 	onPlanSelect: ( planSlug: string ) => void;
 }
 
-const PLANS_STORE = PlansStore.STORE_KEY;
+const PLANS_STORE = PlansStore.register();
 
 const Plans: React.FunctionComponent< Props > = ( { selectedPlanSlug, onPlanSelect } ) => {
 	const supportedPlans = useSelect( ( select ) => select( PLANS_STORE ).getSupportedPlans() );

--- a/client/landing/gutenboarding/hooks/use-on-site-creation.ts
+++ b/client/landing/gutenboarding/hooks/use-on-site-creation.ts
@@ -9,13 +9,11 @@ import wp from '../../../lib/wp';
  * Internal dependencies
  */
 import { STORE_KEY as ONBOARD_STORE } from '../stores/onboard';
-import { Plans } from '@automattic/data-stores';
+import { PLANS_STORE } from '../stores/plans';
 import { USER_STORE } from '../stores/user';
 import { SITE_STORE } from '../stores/site';
 import { recordOnboardingComplete } from '../lib/analytics';
 import { useSelectedPlan, useIsSelectedPlanEcommerce } from './use-selected-plan';
-
-const PLANS_STORE = Plans.register();
 
 const wpcom = wp.undocumented();
 

--- a/client/landing/gutenboarding/hooks/use-on-site-creation.ts
+++ b/client/landing/gutenboarding/hooks/use-on-site-creation.ts
@@ -15,7 +15,7 @@ import { SITE_STORE } from '../stores/site';
 import { recordOnboardingComplete } from '../lib/analytics';
 import { useSelectedPlan, useIsSelectedPlanEcommerce } from './use-selected-plan';
 
-const PLANS_STORE = Plans.STORE_KEY;
+const PLANS_STORE = Plans.register();
 
 const wpcom = wp.undocumented();
 

--- a/client/landing/gutenboarding/hooks/use-selected-plan.ts
+++ b/client/landing/gutenboarding/hooks/use-selected-plan.ts
@@ -2,15 +2,13 @@
  * External dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { Plans } from '@automattic/data-stores';
 
 /**
  * Internal dependencies
  */
 import { STORE_KEY as ONBOARD_STORE } from '../stores/onboard';
+import { PLANS_STORE } from '../stores/plans';
 import { usePlanRouteParam } from '../path';
-
-const PLANS_STORE = Plans.register();
 
 export function useSelectedPlan() {
 	const selectedPlan = useSelect( ( select ) => select( PLANS_STORE ).getSelectedPlan() );

--- a/client/landing/gutenboarding/hooks/use-selected-plan.ts
+++ b/client/landing/gutenboarding/hooks/use-selected-plan.ts
@@ -10,7 +10,7 @@ import { Plans } from '@automattic/data-stores';
 import { STORE_KEY as ONBOARD_STORE } from '../stores/onboard';
 import { usePlanRouteParam } from '../path';
 
-const PLANS_STORE = Plans.STORE_KEY;
+const PLANS_STORE = Plans.register();
 
 export function useSelectedPlan() {
 	const selectedPlan = useSelect( ( select ) => select( PLANS_STORE ).getSelectedPlan() );

--- a/client/landing/gutenboarding/onboarding-block/style-preview/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/index.tsx
@@ -18,7 +18,7 @@ import FontSelect from './font-select';
 import { Title, SubTitle } from '../../components/titles';
 import * as T from './types';
 import { STORE_KEY as ONBOARD_STORE } from '../../stores/onboard';
-import { Plans } from '@automattic/data-stores';
+import { PLANS_STORE } from '../../stores/plans';
 import { USER_STORE } from '../../stores/user';
 import { useFreeDomainSuggestion } from '../../hooks/use-free-domain-suggestion';
 import SignupForm from '../../components/signup-form';
@@ -26,8 +26,6 @@ import { useTrackStep } from '../../hooks/use-track-step';
 import { useShouldSiteBePublicOnSelectedPlan } from '../../hooks/use-selected-plan';
 import BottomBarMobile from '../../components/bottom-bar-mobile';
 import './style.scss';
-
-const PLANS_STORE = Plans.register();
 
 const StylePreview: React.FunctionComponent = () => {
 	const { getSelectedFonts } = useSelect( ( select ) => select( ONBOARD_STORE ) );

--- a/client/landing/gutenboarding/onboarding-block/style-preview/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/index.tsx
@@ -27,7 +27,7 @@ import { useShouldSiteBePublicOnSelectedPlan } from '../../hooks/use-selected-pl
 import BottomBarMobile from '../../components/bottom-bar-mobile';
 import './style.scss';
 
-const PLANS_STORE = Plans.STORE_KEY;
+const PLANS_STORE = Plans.register();
 
 const StylePreview: React.FunctionComponent = () => {
 	const { getSelectedFonts } = useSelect( ( select ) => select( ONBOARD_STORE ) );

--- a/client/landing/gutenboarding/stores/plans/index.ts
+++ b/client/landing/gutenboarding/stores/plans/index.ts
@@ -1,0 +1,6 @@
+/**
+ * External dependencies
+ */
+import { Plans } from '@automattic/data-stores';
+
+export const PLANS_STORE = Plans.register();

--- a/packages/data-stores/README.md
+++ b/packages/data-stores/README.md
@@ -4,6 +4,8 @@ This package contains a collection of `@wordpress/data`-based stores that can be
 
 It is meant to be helpful for projects developed inside the [Calypso monorepo](https://github.com/Automattic/wp-calypso) that don't want to use Calypso's (monolithic) Redux state tree.
 
+## Usage
+
 To use stores from the package, import and register the relevant store to obtain its key:
 
 ```tsx
@@ -28,6 +30,25 @@ const VerticalSelect = () => ( {
 } );
 
 ```
+
+## A note about store `register` functions
+
+Stores are not registered in their module code. Instead, they expose `register` functions. This is an important technical consideration to avoid [side effects and allow tree-shaking](https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free).
+
+When implementing a store, registration on evaluation should be avoided. Please, follow the pattern of exporting a `register` function.
+
+When an application needs to use a store that should be configured, it may be helpful to expose that store from a wrapper module:
+
+```ts
+// vertical-store.ts
+import { DomainSuggestions } from '@automattic/data-stores';
+export const DOMAIN_SUGGESTIONS_STORE = DomainsSuggestions.register( { /* …my application configuration… */ );
+// elsewhere…
+import { DOMAIN_SUGGESTIONS_STORE } from './vertical-store';
+select( DOMAIN_SUGGESTIONS_STORE ).getCategories();
+```
+
+## Types
 
 The stores in this package are written in TypeScript, and type definitions are generated as part of the build process. Furthermore, we're injecting type information for available selectors and actions into the `@wordpress/data` module, which means that you'll get handy autocomplete suggestions, if you're writing your project in TypeScript and you've enabled your editor's TypeScript feature or plugin.
 

--- a/packages/data-stores/src/plans/index.ts
+++ b/packages/data-stores/src/plans/index.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { controls } from '@wordpress/data-controls';
-import { plugins, registerStore, use } from '@wordpress/data';
+import { registerStore } from '@wordpress/data';
 import type { SelectFromMap, DispatchFromMap } from '../mapped-types';
 
 /**
@@ -14,14 +14,11 @@ import * as actions from './actions';
 import * as selectors from './selectors';
 import * as resolvers from './resolvers';
 import { plansPaths } from './plans-data';
-import persistOptions from './persist';
 
 let isRegistered = false;
 
 export function register(): typeof STORE_KEY {
 	if ( ! isRegistered ) {
-		use( plugins.persistence, persistOptions );
-
 		isRegistered = true;
 		registerStore< State >( STORE_KEY, {
 			resolvers,

--- a/packages/data-stores/src/plans/index.ts
+++ b/packages/data-stores/src/plans/index.ts
@@ -15,23 +15,34 @@ import * as selectors from './selectors';
 import * as resolvers from './resolvers';
 import { plansPaths } from './plans-data';
 import persistOptions from './persist';
+import type { Plan, PlanSlug } from './types';
 
-use( plugins.persistence, persistOptions );
+let isRegistered = false;
 
-registerStore< State >( STORE_KEY, {
-	resolvers,
-	actions,
-	controls,
-	reducer: reducer as any,
-	selectors,
-	persist: [ 'selectedPlanSlug' ],
-} );
+export function register(): typeof STORE_KEY {
+	if ( ! isRegistered ) {
+		use( plugins.persistence, persistOptions );
+
+		isRegistered = true;
+		registerStore< State >( STORE_KEY, {
+			resolvers,
+			actions,
+			controls,
+			reducer: reducer as any,
+			selectors,
+			persist: [ 'selectedPlanSlug' ],
+		} );
+	}
+	return STORE_KEY;
+}
 
 declare module '@wordpress/data' {
 	function dispatch( key: typeof STORE_KEY ): DispatchFromMap< typeof actions >;
 	function select( key: typeof STORE_KEY ): SelectFromMap< typeof selectors >;
 }
 
+export type { Plan, PlanSlug };
 export type State = import('./reducer').State;
-export { STORE_KEY };
+
+// used to construct the route that accepts plan slugs like (/beginner, /business, etc..)
 export { plansPaths };

--- a/packages/data-stores/src/plans/index.ts
+++ b/packages/data-stores/src/plans/index.ts
@@ -9,13 +9,12 @@ import type { SelectFromMap, DispatchFromMap } from '../mapped-types';
  * Internal dependencies
  */
 import { STORE_KEY } from './constants';
-import reducer from './reducer';
+import reducer, { State } from './reducer';
 import * as actions from './actions';
 import * as selectors from './selectors';
 import * as resolvers from './resolvers';
 import { plansPaths } from './plans-data';
 import persistOptions from './persist';
-import type { Plan, PlanSlug } from './types';
 
 let isRegistered = false;
 
@@ -41,8 +40,7 @@ declare module '@wordpress/data' {
 	function select( key: typeof STORE_KEY ): SelectFromMap< typeof selectors >;
 }
 
-export type { Plan, PlanSlug };
-export type State = import('./reducer').State;
+export type { Plan, PlanSlug } from './types';
 
 // used to construct the route that accepts plan slugs like (/beginner, /business, etc..)
-export { plansPaths };
+export { plansPaths, State };

--- a/packages/data-stores/src/plans/persist.ts
+++ b/packages/data-stores/src/plans/persist.ts
@@ -1,5 +1,0 @@
-/**
- * Internal dependencies
- */
-import createPersistenceConfig from '../persistence-config-factory';
-export default createPersistenceConfig( 'WP_ONBOARD_PLANS' );

--- a/packages/data-stores/tsconfig-cjs.json
+++ b/packages/data-stores/tsconfig-cjs.json
@@ -3,6 +3,7 @@
 	"compilerOptions": {
 		"module": "commonjs",
 		"declaration": false,
+		"declarationMap": false,
 		"declarationDir": null,
 		"outDir": "dist/cjs",
 		"composite": false,

--- a/packages/data-stores/tsconfig.json
+++ b/packages/data-stores/tsconfig.json
@@ -6,6 +6,7 @@
 		"allowJs": false,
 		"jsx": "react",
 		"declaration": true,
+		"declarationMap": true,
 		"declarationDir": "dist/types",
 		"rootDir": "src",
 		"outDir": "dist/esm",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Instead of registering the plans store on module evaluation, now the Plans store module exports a registrar function that allows you to register it where you need it. This prevents the module from creating side effects unless they're explicitly asked for. 

#### Testing instructions

Use Gutenboarding to create a site. All steps of the flow depend on the plans store in a way or another. 
