### PR TITLE
FSE: update tips to the new blocks list design

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/block-inserter-modifications/contextual-tips/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/block-inserter-modifications/contextual-tips/style.scss
@@ -1,3 +1,3 @@
-.block-editor-inserter__panel-content .contextual-tip {
-	margin-top: 20px;
+.contextual-tip {
+	margin: 20px;
 }

--- a/apps/full-site-editing/full-site-editing-plugin/block-inserter-modifications/contextual-tips/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/block-inserter-modifications/contextual-tips/style.scss
@@ -1,3 +1,3 @@
 .contextual-tip {
-	margin: 20px;
+	margin: 16px;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR tweaks the margin of the contextual tip container to the new design of the blocks list

**before**

<img src="https://user-images.githubusercontent.com/77539/83256674-392c0880-a189-11ea-9481-6ec391ee11c7.png" width="400px" />

**after**
<img src="https://user-images.githubusercontent.com/77539/83256479-e05c7000-a188-11ea-97bf-f9021a93f970.png" width="400px" />

#### Testing instructions

Apply these changes. Confirm that the margin of the contextual tip container looks as expected.

Fixes #
