### PR TITLE
White glove: Show sidebar nudge

### DIFF
--- a/client/blocks/product-purchase-features-list/business-onboarding.jsx
+++ b/client/blocks/product-purchase-features-list/business-onboarding.jsx
@@ -16,12 +16,14 @@ import PurchaseDetail from 'components/purchase-detail';
  */
 import conciergeImage from 'assets/images/illustrations/jetpack-concierge.svg';
 
-export default localize( ( { isWpcomPlan, translate, link, onClick = noop } ) => {
+export default localize( ( { isWpcomPlan, translate, link, isWhiteGlove, onClick = noop } ) => {
+	const title = isWhiteGlove ? 'One-on-one session' : translate( 'Quick Start session' );
+
 	return (
 		<div className="product-purchase-features-list__item">
 			<PurchaseDetail
 				icon={ <img alt="" src={ conciergeImage } /> }
-				title={ translate( 'Quick Start session' ) }
+				title={ title }
 				description={
 					isWpcomPlan
 						? translate(

--- a/client/blocks/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features-list/index.jsx
@@ -44,6 +44,7 @@ import { hasDomainCredit } from 'state/sites/plans/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
 import isSiteUsingFullSiteEditing from 'state/selectors/is-site-using-full-site-editing';
+import isSiteWhiteGlove from 'state/selectors/is-site-white-glove';
 
 /**
  * Style dependencies
@@ -112,6 +113,7 @@ export class ProductPurchaseFeaturesList extends Component {
 					isWpcomPlan
 					onClick={ this.handleBusinessOnboardingClick }
 					link={ `/me/concierge/${ selectedSite.slug }/book` }
+					isWhiteGlove={ this.props.isWhiteGlove }
 				/>
 				{ isWordadsInstantActivationEligible( selectedSite ) && (
 					<MonetizeSite selectedSite={ selectedSite } />
@@ -329,6 +331,7 @@ export default connect(
 			selectedSite,
 			planHasDomainCredit: hasDomainCredit( state, selectedSiteId ),
 			showCustomizerFeature: ! isSiteUsingFullSiteEditing( state, selectedSiteId ),
+			isWhiteGlove: isSiteWhiteGlove( state, selectedSiteId ),
 		};
 	},
 	{

--- a/client/me/concierge/book/info-step.js
+++ b/client/me/concierge/book/info-step.js
@@ -33,6 +33,7 @@ import { getLanguage } from 'lib/i18n-utils';
 import getCountries from 'state/selectors/get-countries';
 import QuerySmsCountries from 'components/data/query-countries/sms';
 import FormInputValidation from 'components/forms/form-input-validation';
+import isSiteWhiteGlove from 'state/selectors/is-site-white-glove';
 
 class InfoStep extends Component {
 	static propTypes = {
@@ -126,6 +127,7 @@ class InfoStep extends Component {
 				phoneNumberWithoutCountryCode,
 			},
 			site,
+			isWhiteGlove,
 			translate,
 		} = this.props;
 		const language = getLanguage( currentUserLocale ).name;
@@ -137,7 +139,7 @@ class InfoStep extends Component {
 		return (
 			<div>
 				<IsRebrandCitiesSite onChange={ this.setRebrandCitiesValue } siteId={ site.ID } />
-				<PrimaryHeader />
+				<PrimaryHeader isWhiteGlove={ isWhiteGlove } />
 				{ ! isEnglish && <Notice showDismiss={ false } text={ noticeText } /> }
 				<CompactCard className="book__info-step-site-block">
 					<Site siteId={ site.ID } />
@@ -230,11 +232,12 @@ class InfoStep extends Component {
 }
 
 export default connect(
-	( state ) => ( {
+	( state, ownProps ) => ( {
 		currentUserLocale: getCurrentUserLocale( state ),
 		signupForm: getConciergeSignupForm( state ),
 		userSettings: getUserSettings( state ),
 		countriesList: getCountries( state, 'sms' ),
+		isWhiteGlove: isSiteWhiteGlove( state, ownProps.site.ID ),
 	} ),
 	{
 		updateConciergeSignupForm,

--- a/client/me/concierge/main.js
+++ b/client/me/concierge/main.js
@@ -99,7 +99,7 @@ export class ConciergeMain extends Component {
 		}
 
 		if ( isEmpty( availableTimes ) ) {
-			return <NoAvailableTimes />;
+			return <NoAvailableTimes site={ site } />;
 		}
 
 		// We have shift data and this is a business site — show the signup steps

--- a/client/me/concierge/shared/no-available-times.js
+++ b/client/me/concierge/shared/no-available-times.js
@@ -11,6 +11,7 @@ import { localize } from 'i18n-calypso';
 import { Card } from '@automattic/components';
 import PrimaryHeader from './primary-header';
 import { recordTracksEvent } from 'state/analytics/actions';
+import isSiteWhiteGlove from 'state/selectors/is-site-white-glove';
 
 class NoAvailableTimes extends Component {
 	componentDidMount() {
@@ -18,26 +19,38 @@ class NoAvailableTimes extends Component {
 	}
 
 	render() {
-		const { translate } = this.props;
+		const { isWhiteGlove, translate } = this.props;
+
 		return (
 			<div>
-				<PrimaryHeader />
+				<PrimaryHeader isWhiteGlove={ isWhiteGlove } />
 				<Card>
 					<h2 className="shared__no-available-times-heading">
 						{ translate( 'Sorry, there are no sessions available' ) }
 					</h2>
-					{ translate(
-						'We schedule Quick Start Sessions up to 24 hours in advance and all upcoming sessions are full. Please check back later or {{link}}contact us in Live Chat{{/link}}.',
-						{
-							components: {
-								link: <a href="https://wordpress.com/help/contact" />,
-							},
-						}
+					{ isWhiteGlove && (
+						<>
+							We schedule one-on-one sessions up to 24 hours in advance and all upcoming sessions
+							are full. Please check back later or{ ' ' }
+							<a href="https://wordpress.com/help/contact">contact us in Live Chat</a>.
+						</>
 					) }
+					{ ! isWhiteGlove &&
+						translate(
+							'We schedule Quick Start Sessions up to 24 hours in advance and all upcoming sessions are full. Please check back later or {{link}}contact us in Live Chat{{/link}}.',
+							{
+								components: {
+									link: <a href="https://wordpress.com/help/contact" />,
+								},
+							}
+						) }
 				</Card>
 			</div>
 		);
 	}
 }
 
-export default connect( null, { recordTracksEvent } )( localize( NoAvailableTimes ) );
+export default connect(
+	( state, ownProps ) => ( { isWhiteGlove: isSiteWhiteGlove( state, ownProps.site.ID ) } ),
+	{ recordTracksEvent }
+)( localize( NoAvailableTimes ) );

--- a/client/me/concierge/shared/primary-header.js
+++ b/client/me/concierge/shared/primary-header.js
@@ -16,7 +16,11 @@ import { CONCIERGE_SUPPORT } from 'lib/url/support';
 
 class PrimaryHeader extends Component {
 	render() {
-		const { translate } = this.props;
+		const { isWhiteGlove, translate } = this.props;
+
+		const headerText = isWhiteGlove
+			? 'WordPress.com one-on-one session scheduler'
+			: translate( 'WordPress.com Quick Start Session Scheduler' );
 
 		return (
 			<Fragment>
@@ -33,7 +37,7 @@ class PrimaryHeader extends Component {
 						src={ '/calypso/images/illustrations/illustration-start.svg' }
 					/>
 					<FormattedHeader
-						headerText={ translate( 'WordPress.com Quick Start Session Scheduler' ) }
+						headerText={ headerText }
 						subHeaderText={ translate(
 							'Use the tool below to book your in-depth support session.'
 						) }

--- a/client/my-sites/checkout/checkout-thank-you/business-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/business-plan-details.jsx
@@ -29,9 +29,21 @@ function trackOnboardingButtonClick() {
 	recordTracksEvent( 'calypso_checkout_thank_you_onboarding_click' );
 }
 
-const BusinessPlanDetails = ( { selectedSite, sitePlans, selectedFeature, purchases } ) => {
+const BusinessPlanDetails = ( {
+	selectedSite,
+	sitePlans,
+	selectedFeature,
+	purchases,
+	displayMode,
+} ) => {
 	const plan = find( sitePlans.data, isBusiness );
 	const googleAppsWasPurchased = purchases.some( isGoogleApps );
+	const whiteGloveQuickStartDescription =
+		'white-glove' === displayMode
+			? 'Schedule a one-on-one session with a Happiness Engineer to set up your site and learn more about WordPress.com.'
+			: i18n.translate(
+					'Schedule a Quick Start session with a Happiness Engineer to set up your site and learn more about WordPress.com.'
+			  );
 
 	return (
 		<div>
@@ -45,10 +57,7 @@ const BusinessPlanDetails = ( { selectedSite, sitePlans, selectedFeature, purcha
 			<PurchaseDetail
 				icon={ <img alt="" src={ conciergeImage } /> }
 				title={ i18n.translate( 'Get personalized help' ) }
-				description={ i18n.translate(
-					'Schedule a Quick Start session with a Happiness Engineer to set up ' +
-						'your site and learn more about WordPress.com.'
-				) }
+				description={ whiteGloveQuickStartDescription }
 				buttonText={ i18n.translate( 'Schedule a session' ) }
 				href={ `/me/concierge/${ selectedSite.slug }/book` }
 				onClick={ trackOnboardingButtonClick }

--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -97,12 +97,18 @@ export class CheckoutThankYouHeader extends PureComponent {
 		}
 
 		if ( isPlan( primaryPurchase ) ) {
+			let productName = primaryPurchase.productName;
+
+			if ( 'white-glove' === displayMode ) {
+				productName = `${ productName } (White glove edition)`;
+			}
+
 			return preventWidows(
 				translate(
 					'Your site is now on the {{strong}}%(productName)s{{/strong}} plan. ' +
 						"It's doing somersaults in excitement!",
 					{
-						args: { productName: primaryPurchase.productName },
+						args: { productName: productName },
 						components: { strong: <strong /> },
 					}
 				)

--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -625,6 +625,7 @@ export class CheckoutThankYou extends React.Component {
 								selectedSite={ selectedSite }
 								selectedFeature={ getFeatureByKey( this.props.selectedFeature ) }
 								sitePlans={ sitePlans }
+								displayMode={ displayMode }
 							/>
 						</div>
 					) }

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -590,6 +590,10 @@ export class Checkout extends React.Component {
 			displayModeParam = { d: 'concierge' };
 		}
 
+		if ( this.props.isWhiteGloveOffer ) {
+			displayModeParam = { d: 'white-glove' };
+		}
+
 		if ( this.props.isEligibleForSignupDestination ) {
 			return this.getUrlWithQueryParam( signupDestination, displayModeParam );
 		}

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -244,6 +244,7 @@ export default function CompositeCheckout( {
 		isJetpackNotAtomic,
 		product,
 		siteId,
+		isWhiteGloveOffer,
 	} );
 
 	const moment = useLocalizedMoment();

--- a/client/my-sites/checkout/composite-checkout/use-get-thank-you-url.js
+++ b/client/my-sites/checkout/composite-checkout/use-get-thank-you-url.js
@@ -50,6 +50,7 @@ export function getThankYouPageUrl( {
 	saveUrlToCookie = persistSignupDestination,
 	previousRoute,
 	isEligibleForSignupDestinationResult,
+	isWhiteGloveOffer,
 } ) {
 	debug( 'starting getThankYouPageUrl' );
 	// If we're given an explicit `redirectTo` query arg, make sure it's either internal
@@ -149,7 +150,9 @@ export function getThankYouPageUrl( {
 
 	// Display mode is used to show purchase specific messaging, for e.g. the Schedule Session button
 	// when purchasing a concierge session.
-	const displayModeParam = getDisplayModeParamFromCart( cart );
+	const displayModeParam = isWhiteGloveOffer
+		? { d: 'white-glove' }
+		: getDisplayModeParamFromCart( cart );
 	if ( isEligibleForSignupDestinationResult && signupDestination ) {
 		debug( 'is elligible for signup destination', signupDestination );
 		return getUrlWithQueryParam( signupDestination, displayModeParam );
@@ -299,6 +302,7 @@ export function useGetThankYouUrl( {
 	isJetpackNotAtomic,
 	product,
 	siteId,
+	isWhiteGloveOffer,
 } ) {
 	const selectedSiteData = useSelector( ( state ) => getSelectedSite( state ) );
 	const adminUrl = selectedSiteData?.options?.admin_url;
@@ -340,6 +344,7 @@ export function useGetThankYouUrl( {
 			product,
 			previousRoute,
 			isEligibleForSignupDestinationResult,
+			isWhiteGloveOffer,
 		} );
 		debug( 'getThankYouUrl returned', url );
 		return url;

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -40,6 +40,8 @@ import AsyncLoad from 'components/async-load';
 import UpsellNudge from 'blocks/upsell-nudge';
 import { preventWidows } from 'lib/formatting';
 import isSiteWPForTeams from 'state/selectors/is-site-wpforteams';
+import getSiteOptions from 'state/selectors/get-site-options';
+import { abtest } from 'lib/abtest';
 
 const DOMAIN_UPSELL_NUDGE_DISMISS_KEY = 'domain_upsell_nudge_dismiss';
 
@@ -244,6 +246,34 @@ export class SiteNotice extends React.Component {
 		return moment( now ).format( format ) === moment( endsAt ).format( format );
 	}
 
+	isEligibleForWhiteGlove() {
+		const createdAt = get( this.props.siteOptions, 'created_at', '' );
+		const HOURS_IN_MS = 60 * 60 * 1000;
+		const isSiteNew = Date.now() - new Date( createdAt ) < 24 * HOURS_IN_MS; // less than 24 hours
+
+		if ( isSiteNew && 'variantShowOffer' === abtest( 'whiteGloveUpsell' ) ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	showWhiteGloveNudge() {
+		const { translate, siteSlug } = this.props;
+		return (
+			<UpsellNudge
+				event={ 'white-glove' }
+				forceHref={ true }
+				callToAction={ translate( 'Upgrade' ) }
+				compact
+				href={ '/checkout/' + siteSlug + '/offer-white-glove' }
+				title={ translate( 'White Glove Offer' ) }
+				tracksClickName={ 'calypso_upgrade_nudge_cta_click' }
+				tracksImpressionName={ 'calypso_upgrade_nudge_impression' }
+			/>
+		);
+	}
+
 	render() {
 		const { site, isMigrationInProgress, messagePath, hasJITM } = this.props;
 		if ( ! site || isMigrationInProgress ) {
@@ -253,8 +283,14 @@ export class SiteNotice extends React.Component {
 		const discountOrFreeToPaid = this.activeDiscountNotice();
 		const siteRedirectNotice = this.getSiteRedirectNotice( site );
 		const domainCreditNotice = this.domainCreditNotice();
+		const isEligibleForWhiteGlove = this.isEligibleForWhiteGlove();
+
+		if ( isEligibleForWhiteGlove ) {
+			return this.showWhiteGloveNudge();
+		}
 
 		const showJitms =
+			! this.isEligibleForWhiteGlove() &&
 			! ( isEnabled( 'signup/wpforteams' ) && this.props.isSiteWPForTeams ) &&
 			( discountOrFreeToPaid || config.isEnabled( 'jitms' ) );
 
@@ -284,7 +320,7 @@ export default connect(
 		const siteId = ownProps.site && ownProps.site.ID ? ownProps.site.ID : null;
 		const sectionName = getSectionName( state );
 		const messagePath = `calypso:${ sectionName }:sidebar_notice`;
-
+		const siteSlug = get( ownProps, 'site.slug', '' );
 		const isMigrationInProgress =
 			isSiteMigrationInProgress( state, siteId ) || isSiteMigrationActiveRoute( state );
 
@@ -303,6 +339,8 @@ export default connect(
 			isMigrationInProgress,
 			hasJITM: getTopJITM( state, messagePath ),
 			messagePath,
+			siteOptions: getSiteOptions( state, siteId ),
+			siteSlug,
 		};
 	},
 	( dispatch ) => {

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -259,15 +259,15 @@ export class SiteNotice extends React.Component {
 	}
 
 	showWhiteGloveNudge() {
-		const { translate, siteSlug } = this.props;
+		const { translate } = this.props;
 		return (
 			<UpsellNudge
 				event={ 'white-glove' }
 				forceHref={ true }
 				callToAction={ translate( 'Upgrade' ) }
 				compact
-				href={ '/checkout/' + siteSlug + '/offer-white-glove' }
-				title={ translate( 'White Glove Offer' ) }
+				href={ `/checkout/${ this.props.site.slug }/offer-white-glove` }
+				title={ 'White Glove Offer' }
 				tracksClickName={ 'calypso_upgrade_nudge_cta_click' }
 				tracksImpressionName={ 'calypso_upgrade_nudge_impression' }
 			/>
@@ -320,7 +320,6 @@ export default connect(
 		const siteId = ownProps.site && ownProps.site.ID ? ownProps.site.ID : null;
 		const sectionName = getSectionName( state );
 		const messagePath = `calypso:${ sectionName }:sidebar_notice`;
-		const siteSlug = get( ownProps, 'site.slug', '' );
 		const isMigrationInProgress =
 			isSiteMigrationInProgress( state, siteId ) || isSiteMigrationActiveRoute( state );
 
@@ -340,7 +339,6 @@ export default connect(
 			hasJITM: getTopJITM( state, messagePath ),
 			messagePath,
 			siteOptions: getSiteOptions( state, siteId ),
-			siteSlug,
 		};
 	},
 	( dispatch ) => {

--- a/client/state/selectors/is-site-white-glove.js
+++ b/client/state/selectors/is-site-white-glove.js
@@ -1,0 +1,21 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import getRawSite from 'state/selectors/get-raw-site';
+
+/**
+ * Checks if a site is a white glove purchase
+ *
+ * @param {object} state  Global state tree
+ * @param {object} siteId Site ID
+ * @returns {boolean} True if the site is a white glove purchase, otherwise false
+ */
+export default function isSiteWhiteGlove( state, siteId ) {
+	const site = getRawSite( state, siteId );
+	return get( site, 'is_white_glove', false );
+}

--- a/client/state/selectors/test/is-site-white-glove.js
+++ b/client/state/selectors/test/is-site-white-glove.js
@@ -1,0 +1,54 @@
+/**
+ * Internal dependencies
+ */
+import isSiteWhiteGlove from '../is-site-white-glove';
+
+describe( 'isSiteWhiteGlove', () => {
+	test( 'returns false if site does not exist', () => {
+		const state = { sites: { items: {} } };
+		const isWhiteGlove = isSiteWhiteGlove( state, 1 );
+		expect( isWhiteGlove ).toBe( false );
+	} );
+
+	test( 'returns true if site exists and has is_white_glove true', () => {
+		const state = {
+			sites: {
+				items: {
+					123: {
+						is_white_glove: true,
+					},
+				},
+			},
+		};
+		const isWhiteGlove = isSiteWhiteGlove( state, 123 );
+		expect( isWhiteGlove ).toBe( true );
+	} );
+
+	test( 'returns false if site exists and has is_white_glove false', () => {
+		const state = {
+			sites: {
+				items: {
+					123: {
+						is_white_glove: false,
+					},
+				},
+			},
+		};
+		const isWhiteGlove = isSiteWhiteGlove( state, 123 );
+		expect( isWhiteGlove ).toBe( false );
+	} );
+
+	test( 'returns false if site exists and has no is_white_glove prop', () => {
+		const state = {
+			sites: {
+				items: {
+					123: {
+						someKey: 'someValue',
+					},
+				},
+			},
+		};
+		const isWhiteGlove = isSiteWhiteGlove( state, 123 );
+		expect( isWhiteGlove ).toBe( false );
+	} );
+} );

--- a/client/state/sites/constants.js
+++ b/client/state/sites/constants.js
@@ -20,6 +20,7 @@ export const SITE_REQUEST_FIELDS = [
 	'is_fse_active',
 	'is_fse_eligible',
 	'is_core_site_editor_enabled',
+	'is_white_glove',
 ].join();
 
 export const SITE_REQUEST_OPTIONS = [


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR is a part of the larger PR that implements the white glove A/B test. Please check #41618 for more context.

* This PR implements a sidebar nudge for the white glove offer.
* Users who select a free plan and free domain and decline on the white glove offer page will see the sidebar nudge for the first 24 hours after signup.

<img src="https://user-images.githubusercontent.com/1269602/83155202-a0f93980-a11e-11ea-865c-a5d6e02c8bd6.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Depends on D42624-code. Please apply this patch.

* Assign yourself to the whiteGloveUpsell test's variant and begin signup flow. 
* Select free plan and free domain, you should now see the offer page.
* Click "No thanks" on the offer should take you to Customer Home
* Notice the sidebar nudge. Verify it shows for the first 24 hours after site creation
* Click on the nudge and purchase a white glove product. The shopping cart and receipt email should mention white glove. The sidebar nudge should no longer be seen after purchase completes.
* Cancel the white glove product. The sidebar nudge should show up once again.