### PR TITLE
White glove: Rename 'Quick Start' in the concierge booking form

### DIFF
--- a/client/blocks/product-purchase-features-list/business-onboarding.jsx
+++ b/client/blocks/product-purchase-features-list/business-onboarding.jsx
@@ -16,12 +16,14 @@ import PurchaseDetail from 'components/purchase-detail';
  */
 import conciergeImage from 'assets/images/illustrations/jetpack-concierge.svg';
 
-export default localize( ( { isWpcomPlan, translate, link, onClick = noop } ) => {
+export default localize( ( { isWpcomPlan, translate, link, isWhiteGlove, onClick = noop } ) => {
+	const title = isWhiteGlove ? 'One-on-one session' : translate( 'Quick Start session' );
+
 	return (
 		<div className="product-purchase-features-list__item">
 			<PurchaseDetail
 				icon={ <img alt="" src={ conciergeImage } /> }
-				title={ translate( 'Quick Start session' ) }
+				title={ title }
 				description={
 					isWpcomPlan
 						? translate(

--- a/client/blocks/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features-list/index.jsx
@@ -44,6 +44,7 @@ import { hasDomainCredit } from 'state/sites/plans/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
 import isSiteUsingFullSiteEditing from 'state/selectors/is-site-using-full-site-editing';
+import isSiteWhiteGlove from 'state/selectors/is-site-white-glove';
 
 /**
  * Style dependencies
@@ -112,6 +113,7 @@ export class ProductPurchaseFeaturesList extends Component {
 					isWpcomPlan
 					onClick={ this.handleBusinessOnboardingClick }
 					link={ `/me/concierge/${ selectedSite.slug }/book` }
+					isWhiteGlove={ this.props.isWhiteGlove }
 				/>
 				{ isWordadsInstantActivationEligible( selectedSite ) && (
 					<MonetizeSite selectedSite={ selectedSite } />
@@ -329,6 +331,7 @@ export default connect(
 			selectedSite,
 			planHasDomainCredit: hasDomainCredit( state, selectedSiteId ),
 			showCustomizerFeature: ! isSiteUsingFullSiteEditing( state, selectedSiteId ),
+			isWhiteGlove: isSiteWhiteGlove( state, selectedSiteId ),
 		};
 	},
 	{

--- a/client/me/concierge/book/info-step.js
+++ b/client/me/concierge/book/info-step.js
@@ -33,6 +33,7 @@ import { getLanguage } from 'lib/i18n-utils';
 import getCountries from 'state/selectors/get-countries';
 import QuerySmsCountries from 'components/data/query-countries/sms';
 import FormInputValidation from 'components/forms/form-input-validation';
+import isSiteWhiteGlove from 'state/selectors/is-site-white-glove';
 
 class InfoStep extends Component {
 	static propTypes = {
@@ -126,6 +127,7 @@ class InfoStep extends Component {
 				phoneNumberWithoutCountryCode,
 			},
 			site,
+			isWhiteGlove,
 			translate,
 		} = this.props;
 		const language = getLanguage( currentUserLocale ).name;
@@ -137,7 +139,7 @@ class InfoStep extends Component {
 		return (
 			<div>
 				<IsRebrandCitiesSite onChange={ this.setRebrandCitiesValue } siteId={ site.ID } />
-				<PrimaryHeader />
+				<PrimaryHeader isWhiteGlove={ isWhiteGlove } />
 				{ ! isEnglish && <Notice showDismiss={ false } text={ noticeText } /> }
 				<CompactCard className="book__info-step-site-block">
 					<Site siteId={ site.ID } />
@@ -230,11 +232,12 @@ class InfoStep extends Component {
 }
 
 export default connect(
-	( state ) => ( {
+	( state, ownProps ) => ( {
 		currentUserLocale: getCurrentUserLocale( state ),
 		signupForm: getConciergeSignupForm( state ),
 		userSettings: getUserSettings( state ),
 		countriesList: getCountries( state, 'sms' ),
+		isWhiteGlove: isSiteWhiteGlove( state, ownProps.site.ID ),
 	} ),
 	{
 		updateConciergeSignupForm,

--- a/client/me/concierge/main.js
+++ b/client/me/concierge/main.js
@@ -99,7 +99,7 @@ export class ConciergeMain extends Component {
 		}
 
 		if ( isEmpty( availableTimes ) ) {
-			return <NoAvailableTimes />;
+			return <NoAvailableTimes site={ site } />;
 		}
 
 		// We have shift data and this is a business site — show the signup steps

--- a/client/me/concierge/shared/no-available-times.js
+++ b/client/me/concierge/shared/no-available-times.js
@@ -11,6 +11,7 @@ import { localize } from 'i18n-calypso';
 import { Card } from '@automattic/components';
 import PrimaryHeader from './primary-header';
 import { recordTracksEvent } from 'state/analytics/actions';
+import isSiteWhiteGlove from 'state/selectors/is-site-white-glove';
 
 class NoAvailableTimes extends Component {
 	componentDidMount() {
@@ -18,26 +19,38 @@ class NoAvailableTimes extends Component {
 	}
 
 	render() {
-		const { translate } = this.props;
+		const { isWhiteGlove, translate } = this.props;
+
 		return (
 			<div>
-				<PrimaryHeader />
+				<PrimaryHeader isWhiteGlove={ isWhiteGlove } />
 				<Card>
 					<h2 className="shared__no-available-times-heading">
 						{ translate( 'Sorry, there are no sessions available' ) }
 					</h2>
-					{ translate(
-						'We schedule Quick Start Sessions up to 24 hours in advance and all upcoming sessions are full. Please check back later or {{link}}contact us in Live Chat{{/link}}.',
-						{
-							components: {
-								link: <a href="https://wordpress.com/help/contact" />,
-							},
-						}
+					{ isWhiteGlove && (
+						<>
+							We schedule one-on-one sessions up to 24 hours in advance and all upcoming sessions
+							are full. Please check back later or{ ' ' }
+							<a href="https://wordpress.com/help/contact">contact us in Live Chat</a>.
+						</>
 					) }
+					{ ! isWhiteGlove &&
+						translate(
+							'We schedule Quick Start Sessions up to 24 hours in advance and all upcoming sessions are full. Please check back later or {{link}}contact us in Live Chat{{/link}}.',
+							{
+								components: {
+									link: <a href="https://wordpress.com/help/contact" />,
+								},
+							}
+						) }
 				</Card>
 			</div>
 		);
 	}
 }
 
-export default connect( null, { recordTracksEvent } )( localize( NoAvailableTimes ) );
+export default connect(
+	( state, ownProps ) => ( { isWhiteGlove: isSiteWhiteGlove( state, ownProps.site.ID ) } ),
+	{ recordTracksEvent }
+)( localize( NoAvailableTimes ) );

--- a/client/me/concierge/shared/primary-header.js
+++ b/client/me/concierge/shared/primary-header.js
@@ -16,7 +16,11 @@ import { CONCIERGE_SUPPORT } from 'lib/url/support';
 
 class PrimaryHeader extends Component {
 	render() {
-		const { translate } = this.props;
+		const { isWhiteGlove, translate } = this.props;
+
+		const headerText = isWhiteGlove
+			? 'WordPress.com one-on-one session scheduler'
+			: translate( 'WordPress.com Quick Start Session Scheduler' );
 
 		return (
 			<Fragment>
@@ -33,7 +37,7 @@ class PrimaryHeader extends Component {
 						src={ '/calypso/images/illustrations/illustration-start.svg' }
 					/>
 					<FormattedHeader
-						headerText={ translate( 'WordPress.com Quick Start Session Scheduler' ) }
+						headerText={ headerText }
 						subHeaderText={ translate(
 							'Use the tool below to book your in-depth support session.'
 						) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR is a part of the larger PR that implements the white glove A/B test. Please check #41618 for more context.

* Rename 'Quick Start' to 'one-on-one' in the concierge booking form if the site is a white glove site i.e purchased via a white glove upsell offer.

<img src="https://user-images.githubusercontent.com/1269602/83160134-70b49980-a124-11ea-931c-08478783ab0c.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Assign yourself to the variant of the whiteGloveUpsell test, and go through signup flow. Select a free plan and free domain.
* Purchase via the white glove upsell offer page
* Now go to schedule session page at /me/concierge. Verify that the title says "one-on-one" scheduler instead of Quick Start scheduler.

Fixes #
