### PR TITLE
White glove: Rename 'Quick Start' in plan features.

### DIFF
--- a/client/blocks/product-purchase-features-list/business-onboarding.jsx
+++ b/client/blocks/product-purchase-features-list/business-onboarding.jsx
@@ -16,12 +16,14 @@ import PurchaseDetail from 'components/purchase-detail';
  */
 import conciergeImage from 'assets/images/illustrations/jetpack-concierge.svg';
 
-export default localize( ( { isWpcomPlan, translate, link, onClick = noop } ) => {
+export default localize( ( { isWpcomPlan, translate, link, isWhiteGlove, onClick = noop } ) => {
+	const title = isWhiteGlove ? 'One-on-one session' : translate( 'Quick Start session' );
+
 	return (
 		<div className="product-purchase-features-list__item">
 			<PurchaseDetail
 				icon={ <img alt="" src={ conciergeImage } /> }
-				title={ translate( 'Quick Start session' ) }
+				title={ title }
 				description={
 					isWpcomPlan
 						? translate(

--- a/client/blocks/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features-list/index.jsx
@@ -44,6 +44,7 @@ import { hasDomainCredit } from 'state/sites/plans/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
 import isSiteUsingFullSiteEditing from 'state/selectors/is-site-using-full-site-editing';
+import isSiteWhiteGlove from 'state/selectors/is-site-white-glove';
 
 /**
  * Style dependencies
@@ -112,6 +113,7 @@ export class ProductPurchaseFeaturesList extends Component {
 					isWpcomPlan
 					onClick={ this.handleBusinessOnboardingClick }
 					link={ `/me/concierge/${ selectedSite.slug }/book` }
+					isWhiteGlove={ this.props.isWhiteGlove }
 				/>
 				{ isWordadsInstantActivationEligible( selectedSite ) && (
 					<MonetizeSite selectedSite={ selectedSite } />
@@ -329,6 +331,7 @@ export default connect(
 			selectedSite,
 			planHasDomainCredit: hasDomainCredit( state, selectedSiteId ),
 			showCustomizerFeature: ! isSiteUsingFullSiteEditing( state, selectedSiteId ),
+			isWhiteGlove: isSiteWhiteGlove( state, selectedSiteId ),
 		};
 	},
 	{


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR is a part of the larger PR that implements the white glove A/B test. Please check #41618 for more context.

* Rename 'Quick Start' to 'one-on-one' in the plan features list in /plans page if the site is a white glove site.

<img src="https://user-images.githubusercontent.com/1269602/83157346-1cf48100-a121-11ea-8383-fed4fd60a49c.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Assign yourself to the variant of the whiteGloveUpsell test, and go through signup flow. Select a free plan and free domain.
* Purchase via the white glove upsell offer page
* Go to /plans page and verify that "Quick Start" is not mentioned.
