### PR TITLE
i18n: Use localized long date format for media section group labels

### DIFF
--- a/client/my-sites/media-library/list.jsx
+++ b/client/my-sites/media-library/list.jsx
@@ -147,14 +147,7 @@ export class MediaLibraryList extends React.Component {
 	};
 
 	getGroupLabel = ( date ) => {
-		const itemDate = new Date( date );
-		const currentDate = new Date();
-
-		if ( itemDate.getFullYear() === currentDate.getFullYear() ) {
-			return this.props.moment( date ).format( 'MMM D' );
-		}
-
-		return this.props.moment( date ).format( 'MMM D, YYYY' );
+		return this.props.moment( date ).format( 'LL' );
 	};
 
 	getItemGroup = ( item ) =>


### PR DESCRIPTION
This PR changes the group labels in media section from static date format to [locale aware format](https://momentjs.com/docs/#/parsing/string-format/).
The downside is that it will always display the year, even for dates from the current year.
As an alterntive approach, we can try switching to [Date.prototype.toLocaleString()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleString), which would allow us to exclude the year when not needed. We could fallback to moment.js for browsers that don't support `toLocaleString`.

#### Changes proposed in this Pull Request

* Use localized long date format `LL` for media section group labels

**Before:**
![image](https://user-images.githubusercontent.com/2722412/83263341-191b3a00-a1c7-11ea-88f7-da19cb53c741.png)

**After:**
![image](https://user-images.githubusercontent.com/2722412/83263055-a6aa5a00-a1c6-11ea-9f90-6cb4a8277a48.png)


#### Testing instructions

* Open http://calypso.localhost:3000/media/ and cofirm group labels are in localized date format
