### PR TITLE
Jetpack Cloud: redirect the user back to where they were before going through the OAuth flow

### DIFF
--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -138,6 +138,23 @@ const oauthTokenMiddleware = () => {
 					'jetpack-cloud-production',
 				].includes( config( 'env_id' ) );
 				const redirectPath = isDesktop || isJetpackCloud ? config( 'login_url' ) : '/authorize';
+
+				const currentPath = window.location.pathname;
+				// In the context of Jetpack Cloud, if the user isn't authorized, we want
+				// to save the current path (/<product>/<site-slug>) so we can redirect
+				// the user back to it once the login flow is finished. We also set an expiration
+				// to this because we don't want to redirect by mistake a user with an old path
+				// stored in their session.
+				if ( isJetpackCloud && currentPath !== '/' ) {
+					const EXPIRATION_IN_SECONDS = 300;
+					const SESSION_STORAGE_PATH_KEY = 'jetpack_cloud_redirect_path';
+					const SESSION_STORAGE_PATH_KEY_EXPIRES_IN = 'jetpack_cloud_redirect_path_expires_in';
+					window.sessionStorage.setItem( SESSION_STORAGE_PATH_KEY, currentPath );
+					window.sessionStorage.setItem(
+						SESSION_STORAGE_PATH_KEY_EXPIRES_IN,
+						parseInt( new Date().getTime() / 1000 ) + EXPIRATION_IN_SECONDS
+					);
+				}
 				page( redirectPath );
 				return;
 			}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Currently, if an unauthorized user goes to `https://cloud.jetpack.com/<product>/<site>` they won't be redirected back to that URL once the OAuth flow is finished. To solve this issue, I rely on Session Storage to store the path the user wants to go before going to the authorization step. Once the authorization is finished, we redirect the user back to where they wanted to go by reading what we stored in the Session Storage.

#### Implementation notes

I added an expiration of 300 seconds to the Session variable because we don't want to redirect users to an old route that the user may not want to visit now.

Also, I would very much appreciate ideas about how to do everything inside the `controller.tsx` file so we can remove the changes I introduced in the `common.js` file. My initial idea was to store the path inside the `connect` controller but I couldn't make it work because at that point we no longer have access to the previous route (the one the user wanted to visit in the first place) and I don't really know how to fix that. It seems that the redirection that happens in the `common.js` cleans up the browser history and we can't access previous routes.

#### Questions

* Does this approach sounds safe to you?

#### Testing instructions

* Go to `http://jetpack.cloud.localhost:3000/` and log out from your account
* Go directly to product and site using a URL like http://jetpack.cloud.localhost:3000/<product>/<site-slug>
* Go through the authorization flow
* Verify you're redirect back to the route you wanted to visit in the first place

Fixes 1169345694087188-as-1177535752041097

#### Demo
![Kapture 2020-05-29 at 10 24 42](https://user-images.githubusercontent.com/3418513/83264637-c0cc4400-a196-11ea-9829-ed8079c747b2.gif)

