### PR TITLE
Earn: Fix Plans Displayed after Clicking Nudges

### DIFF
--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -21,7 +21,11 @@ import { isRequestingWordAdsApprovalForSite } from 'state/wordads/approve/select
 import PromoSection, { Props as PromoSectionProps } from 'components/promo-section';
 import QueryMembershipsSettings from 'components/data/query-memberships-settings';
 import QueryWordadsStatus from 'components/data/query-wordads-status';
-import { FEATURE_WORDADS_INSTANT, FEATURE_SIMPLE_PAYMENTS } from 'lib/plans/constants';
+import {
+	FEATURE_WORDADS_INSTANT,
+	FEATURE_SIMPLE_PAYMENTS,
+	PLAN_PREMIUM,
+} from 'lib/plans/constants';
 import { bumpStat, composeAnalytics, recordTracksEvent } from 'state/analytics/actions';
 import ClipboardButtonInput from 'components/clipboard-button-input';
 import { CtaButton } from 'components/promo-section/promo-card/cta';
@@ -100,7 +104,9 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 					text: translate( 'Unlock this feature' ),
 					action: () => {
 						trackUpgrade( 'plans', 'simple-payments' );
-						page( `/plans/${ selectedSiteSlug }` );
+						page(
+							`/plans/${ selectedSiteSlug }?feature=${ FEATURE_SIMPLE_PAYMENTS }&plan=${ PLAN_PREMIUM }`
+						);
 					},
 			  };
 		const learnMoreLink = hasSimplePayments
@@ -267,7 +273,9 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 						text: translate( 'Unlock this feature' ),
 						action: () => {
 							trackUpgrade( 'plans', 'ads' );
-							page( `/plans/${ selectedSiteSlug }` );
+							page(
+								`/plans/${ selectedSiteSlug }?feature=${ FEATURE_WORDADS_INSTANT }&plan=${ PLAN_PREMIUM }`
+							);
 						},
 				  };
 		const title = hasSetupAds ? translate( 'View ad dashboard' ) : translate( 'Earn ad revenue' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Similar to #41682, this fixes two nudges on the Earn page so that they display the plans necessary to access those features and highlight the features in the table. 

#### Testing instructions

Visit `/earn/site` and click the "Collect one-time payments" and "Earn ad revenue" nudge, both of which are features that the boxes make clear require at least a Premium plan to access. 

Verify that this ensures the Plans page makes that clear too, as is the case with other nudges, and also highlights the feature.

<img width="1140" alt="Screenshot 2020-05-29 at 15 17 06" src="https://user-images.githubusercontent.com/43215253/83269778-7d3a0000-a1bf-11ea-9088-b6c4006bcd80.png">

cc @artpi, @mmtr 
