### PR TITLE
Data stores: Dissallow importsNotUsedAsValues

### DIFF
--- a/packages/data-stores/src/auth/actions.ts
+++ b/packages/data-stores/src/auth/actions.ts
@@ -7,7 +7,7 @@ import { stringify } from 'qs';
 /**
  * Internal dependencies
  */
-import {
+import type {
 	AuthOptionsSuccessResponse,
 	AuthOptionsErrorResponse,
 	WpLoginSuccessResponse,
@@ -27,7 +27,7 @@ import {
 	wait,
 } from '../wpcom-request-controls';
 import { remoteLoginUser } from './controls';
-import { WpcomClientCredentials } from '../shared-types';
+import type { WpcomClientCredentials } from '../shared-types';
 import { getNextTaskId } from './utils';
 
 export interface ActionsConfig extends WpcomClientCredentials {

--- a/packages/data-stores/src/auth/index.ts
+++ b/packages/data-stores/src/auth/index.ts
@@ -13,7 +13,7 @@ import reducer, { State } from './reducer';
 import { createActions, ActionsConfig } from './actions';
 import { controls } from './controls';
 import * as selectors from './selectors';
-import { DispatchFromMap, SelectFromMap } from '../mapped-types';
+import type { DispatchFromMap, SelectFromMap } from '../mapped-types';
 import { controls as wpcomRequestControls } from '../wpcom-request-controls';
 
 export * from './types';

--- a/packages/data-stores/src/auth/reducer.ts
+++ b/packages/data-stores/src/auth/reducer.ts
@@ -1,14 +1,14 @@
 /**
  * External dependencies
  */
-import { Reducer } from 'redux';
+import type { Reducer } from 'redux';
 import { combineReducers } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
-import { LoginFlowState } from './types';
-import { Action } from './actions';
+import type { LoginFlowState } from './types';
+import type { Action } from './actions';
 import { getNextTaskId } from './utils';
 
 export const loginFlowState: Reducer< LoginFlowState, Action > = (

--- a/packages/data-stores/src/auth/selectors.ts
+++ b/packages/data-stores/src/auth/selectors.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { State } from './reducer';
+import type { State } from './reducer';
 
 export const getErrors = ( state: State ) => state.errors;
 

--- a/packages/data-stores/src/domain-suggestions/actions.ts
+++ b/packages/data-stores/src/domain-suggestions/actions.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { DomainSuggestion, DomainSuggestionQuery, DomainCategory } from './types';
+import type { DomainSuggestion, DomainSuggestionQuery, DomainCategory } from './types';
 
 export const receiveCategories = ( categories: DomainCategory[] ) =>
 	( {

--- a/packages/data-stores/src/domain-suggestions/index.ts
+++ b/packages/data-stores/src/domain-suggestions/index.ts
@@ -11,7 +11,7 @@ import reducer, { State } from './reducer';
 import * as actions from './actions';
 import * as resolvers from './resolvers';
 import createSelectors, { Selectors } from './selectors';
-import { DispatchFromMap, SelectFromMap } from '../mapped-types';
+import type { DispatchFromMap, SelectFromMap } from '../mapped-types';
 import { controls } from '../wpcom-request-controls';
 
 export * from './types';

--- a/packages/data-stores/src/domain-suggestions/reducer.ts
+++ b/packages/data-stores/src/domain-suggestions/reducer.ts
@@ -1,14 +1,14 @@
 /**
  * External dependencies
  */
-import { Reducer } from 'redux';
+import type { Reducer } from 'redux';
 import { combineReducers } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
-import { DomainSuggestion, DomainCategory } from './types';
-import { Action } from './actions';
+import type { DomainSuggestion, DomainCategory } from './types';
+import type { Action } from './actions';
 import { stringifyDomainQueryObject } from './utils';
 
 const domainSuggestions: Reducer< Record< string, DomainSuggestion[] | undefined >, Action > = (

--- a/packages/data-stores/src/domain-suggestions/resolvers.ts
+++ b/packages/data-stores/src/domain-suggestions/resolvers.ts
@@ -8,6 +8,7 @@ import { stringify } from 'qs';
  */
 import { receiveCategories, receiveDomainSuggestions } from './actions';
 import { fetchAndParse, wpcomRequest } from '../wpcom-request-controls';
+import type { Selectors } from './selectors';
 
 export function* getCategories() {
 	const categories = yield fetchAndParse(
@@ -18,9 +19,7 @@ export function* getCategories() {
 
 export function* __internalGetDomainSuggestions(
 	// Resolver has the same signature as corresponding selector without the initial state argument
-	queryObject: Parameters<
-		import('./selectors').Selectors[ '__internalGetDomainSuggestions' ]
-	>[ 1 ]
+	queryObject: Parameters< Selectors[ '__internalGetDomainSuggestions' ] >[ 1 ]
 ) {
 	// If normalized search string (`query`) contains no alphanumerics, endpoint 404s
 	if ( ! queryObject.query ) {

--- a/packages/data-stores/src/domain-suggestions/selectors.ts
+++ b/packages/data-stores/src/domain-suggestions/selectors.ts
@@ -85,8 +85,6 @@ const createSelectors = ( vendor: string ) => {
 	/**
 	 * Do not use this selector. It is for internal use.
 	 *
-	 * @private
-	 *
 	 * @param state Store state
 	 * @param queryObject Normalized object representing the query
 	 * @returns suggestions

--- a/packages/data-stores/src/domain-suggestions/selectors.ts
+++ b/packages/data-stores/src/domain-suggestions/selectors.ts
@@ -7,8 +7,8 @@ import { select } from '@wordpress/data';
  * Internal dependencies
  */
 import { STORE_KEY } from './constants';
-import { DomainSuggestionQuery } from './types';
-import { State } from './reducer';
+import type { DomainSuggestionQuery } from './types';
+import type { State } from './reducer';
 import { stringifyDomainQueryObject } from './utils';
 
 type DomainSuggestionSelectorOptions = Partial< Exclude< DomainSuggestionQuery, 'query' > >;

--- a/packages/data-stores/src/domain-suggestions/utils.ts
+++ b/packages/data-stores/src/domain-suggestions/utils.ts
@@ -6,7 +6,7 @@ import deterministicStringify from 'fast-json-stable-stringify';
 /**
  * Internal dependencies
  */
-import { DomainSuggestionQuery } from './types';
+import type { DomainSuggestionQuery } from './types';
 
 /**
  * Stable transform to an object key for storage and access.

--- a/packages/data-stores/src/mapped-types.ts
+++ b/packages/data-stores/src/mapped-types.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { FunctionKeys } from 'utility-types';
+import type { FunctionKeys } from 'utility-types';
 
 /**
  * Mapped types

--- a/packages/data-stores/src/plans/resolvers.ts
+++ b/packages/data-stores/src/plans/resolvers.ts
@@ -8,7 +8,7 @@ import { apiFetch } from '@wordpress/data-controls';
  */
 import { supportedPlanSlugs } from './reducer';
 import { setPrices } from './actions';
-import { APIPlan, PlanSlug } from './types';
+import type { APIPlan, PlanSlug } from './types';
 import { currenciesFormats } from './constants';
 
 /**

--- a/packages/data-stores/src/plans/selectors.ts
+++ b/packages/data-stores/src/plans/selectors.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { State } from './reducer';
+import type { State } from './reducer';
 import { planDetails, PLANS_LIST } from './plans-data';
 import { DEFAULT_PAID_PLAN, PLAN_FREE, PLAN_ECOMMERCE } from './constants';
 import type { PlanSlug } from './types';

--- a/packages/data-stores/src/plans/types.ts
+++ b/packages/data-stores/src/plans/types.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { PLANS_LIST } from './plans-data';
+import type { PLANS_LIST } from './plans-data';
 
 export type PlanSlug = keyof typeof PLANS_LIST;
 

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -1,14 +1,14 @@
 /**
  * Internal dependencies
  */
-import {
+import type {
 	CreateSiteParams,
 	NewSiteErrorResponse,
 	NewSiteSuccessResponse,
 	SiteDetails,
 	SiteError,
 } from './types';
-import { WpcomClientCredentials } from '../shared-types';
+import type { WpcomClientCredentials } from '../shared-types';
 import { wpcomRequest } from '../wpcom-request-controls';
 
 export function createActions( clientCreds: WpcomClientCredentials ) {

--- a/packages/data-stores/src/site/index.ts
+++ b/packages/data-stores/src/site/index.ts
@@ -11,8 +11,8 @@ import reducer, { State } from './reducer';
 import { createActions } from './actions';
 import * as resolvers from './resolvers';
 import * as selectors from './selectors';
-import { DispatchFromMap, SelectFromMap } from '../mapped-types';
-import { WpcomClientCredentials } from '../shared-types';
+import type { DispatchFromMap, SelectFromMap } from '../mapped-types';
+import type { WpcomClientCredentials } from '../shared-types';
 import { controls } from '../wpcom-request-controls';
 
 export * from './types';

--- a/packages/data-stores/src/site/reducer.ts
+++ b/packages/data-stores/src/site/reducer.ts
@@ -1,14 +1,14 @@
 /**
  * External dependencies
  */
-import { Reducer } from 'redux';
+import type { Reducer } from 'redux';
 import { combineReducers } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
-import { NewSiteBlogDetails, NewSiteErrorResponse, SiteDetails } from './types';
-import { Action } from './actions';
+import type { NewSiteBlogDetails, NewSiteErrorResponse, SiteDetails } from './types';
+import type { Action } from './actions';
 
 export const newSiteData: Reducer< NewSiteBlogDetails | undefined, Action > = ( state, action ) => {
 	if ( action.type === 'RECEIVE_NEW_SITE' ) {

--- a/packages/data-stores/src/site/selectors.ts
+++ b/packages/data-stores/src/site/selectors.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { State } from './reducer';
+import type { State } from './reducer';
 
 export const getState = ( state: State ) => state;
 

--- a/packages/data-stores/src/user/actions.ts
+++ b/packages/data-stores/src/user/actions.ts
@@ -6,14 +6,14 @@ import { stringify } from 'qs';
 /**
  * Internal dependencies
  */
-import {
+import type {
 	CurrentUser,
 	CreateAccountParams,
 	NewUserErrorResponse,
 	NewUserSuccessResponse,
 } from './types';
 import { wpcomRequest, requestAllBlogsAccess, reloadProxy } from '../wpcom-request-controls';
-import { WpcomClientCredentials } from '../shared-types';
+import type { WpcomClientCredentials } from '../shared-types';
 
 export function createActions( clientCreds: WpcomClientCredentials ) {
 	const receiveCurrentUser = ( currentUser: CurrentUser ) => ( {

--- a/packages/data-stores/src/user/index.ts
+++ b/packages/data-stores/src/user/index.ts
@@ -12,8 +12,8 @@ import { createActions } from './actions';
 import { createResolvers } from './resolvers';
 import * as selectors from './selectors';
 import { controls } from '../wpcom-request-controls';
-import { DispatchFromMap, SelectFromMap } from '../mapped-types';
-import { WpcomClientCredentials } from '../shared-types';
+import type { DispatchFromMap, SelectFromMap } from '../mapped-types';
+import type { WpcomClientCredentials } from '../shared-types';
 
 export * from './types';
 export { State };

--- a/packages/data-stores/src/user/reducer.ts
+++ b/packages/data-stores/src/user/reducer.ts
@@ -1,14 +1,14 @@
 /**
  * External dependencies
  */
-import { Reducer } from 'redux';
+import type { Reducer } from 'redux';
 import { combineReducers } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
-import { CurrentUser, NewUser, NewUserErrorResponse } from './types';
-import { Action } from './actions';
+import type { CurrentUser, NewUser, NewUserErrorResponse } from './types';
+import type { Action } from './actions';
 
 export const currentUser: Reducer< CurrentUser | null | undefined, Action > = ( state, action ) => {
 	switch ( action.type ) {

--- a/packages/data-stores/src/user/resolvers.ts
+++ b/packages/data-stores/src/user/resolvers.ts
@@ -3,7 +3,7 @@
  */
 import { wpcomRequest } from '../wpcom-request-controls';
 import { createActions } from './actions';
-import { WpcomClientCredentials } from '../shared-types';
+import type { WpcomClientCredentials } from '../shared-types';
 
 export function createResolvers( clientCreds: WpcomClientCredentials ) {
 	const { receiveCurrentUser, receiveCurrentUserFailed } = createActions( clientCreds );

--- a/packages/data-stores/src/user/selectors.ts
+++ b/packages/data-stores/src/user/selectors.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { State } from './reducer';
+import type { State } from './reducer';
 
 export const getState = ( state: State ) => state;
 

--- a/packages/data-stores/src/user/types.ts
+++ b/packages/data-stores/src/user/types.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { Action } from 'redux';
+import type { Action } from 'redux';
 
 export interface CurrentUser {
 	ID: number;

--- a/packages/data-stores/src/verticals-templates/actions.ts
+++ b/packages/data-stores/src/verticals-templates/actions.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { Template } from './types';
+import type { Template } from './types';
 
 export const receiveTemplates = ( verticalId: string, templates: Template[] ) => ( {
 	type: 'RECEIVE_TEMPLATES' as const,

--- a/packages/data-stores/src/verticals-templates/index.ts
+++ b/packages/data-stores/src/verticals-templates/index.ts
@@ -12,7 +12,7 @@ import reducer, { State } from './reducer';
 import * as actions from './actions';
 import * as resolvers from './resolvers';
 import * as selectors from './selectors';
-import { DispatchFromMap, SelectFromMap } from '../mapped-types';
+import type { DispatchFromMap, SelectFromMap } from '../mapped-types';
 
 export * from './types';
 export { State };

--- a/packages/data-stores/src/verticals-templates/reducer.ts
+++ b/packages/data-stores/src/verticals-templates/reducer.ts
@@ -1,14 +1,14 @@
 /**
  * External dependencies
  */
-import { Reducer } from 'redux';
+import type { Reducer } from 'redux';
 import { combineReducers } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
-import { Template } from './types';
-import { Action } from './actions';
+import type { Template } from './types';
+import type { Action } from './actions';
 
 const templates: Reducer< Record< string, Template[] | undefined >, Action > = (
 	state = {},

--- a/packages/data-stores/src/verticals-templates/resolvers.ts
+++ b/packages/data-stores/src/verticals-templates/resolvers.ts
@@ -7,10 +7,11 @@ import { apiFetch } from '@wordpress/data-controls';
  * Internal dependencies
  */
 import { receiveTemplates } from './actions';
+import type { getTemplates as getTemplatesSelector } from './selectors';
 
 export function* getTemplates(
 	// Resolver has the same signature as corresponding selector without the initial state argument
-	verticalId: Parameters< typeof import('./selectors')[ 'getTemplates' ] >[ 1 ]
+	verticalId: Parameters< typeof getTemplatesSelector >[ 1 ]
 ) {
 	const resp = yield apiFetch( {
 		url: `https://public-api.wordpress.com/wpcom/v2/verticals/${ verticalId }/templates`,

--- a/packages/data-stores/src/verticals-templates/selectors.ts
+++ b/packages/data-stores/src/verticals-templates/selectors.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { State } from './reducer';
+import type { State } from './reducer';
 
 /**
  * Get template suggestions

--- a/packages/data-stores/src/verticals/actions.ts
+++ b/packages/data-stores/src/verticals/actions.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { Vertical } from './types';
+import type { Vertical } from './types';
 
 export const receiveVerticals = ( verticals: Vertical[] ) => ( {
 	type: 'RECEIVE_VERTICALS' as const,

--- a/packages/data-stores/src/verticals/index.ts
+++ b/packages/data-stores/src/verticals/index.ts
@@ -12,10 +12,10 @@ import reducer, { State } from './reducer';
 import * as actions from './actions';
 import * as resolvers from './resolvers';
 import * as selectors from './selectors';
-import { DispatchFromMap, SelectFromMap } from '../mapped-types';
+import type { DispatchFromMap, SelectFromMap } from '../mapped-types';
 
-export * from './types';
-export { State };
+export type { Vertical } from './types';
+export type { State };
 
 let isRegistered = false;
 export function register(): typeof STORE_KEY {

--- a/packages/data-stores/src/verticals/reducer.ts
+++ b/packages/data-stores/src/verticals/reducer.ts
@@ -1,14 +1,14 @@
 /**
  * External dependencies
  */
-import { Reducer } from 'redux';
+import type { Reducer } from 'redux';
 import { combineReducers } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
-import { Vertical } from './types';
-import { Action } from './actions';
+import type { Vertical } from './types';
+import type { Action } from './actions';
 
 const verticals: Reducer< Vertical[], Action > = ( state = [], action ) => {
 	if ( action.type === 'RECEIVE_VERTICALS' ) {

--- a/packages/data-stores/src/verticals/selectors.ts
+++ b/packages/data-stores/src/verticals/selectors.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { State } from './reducer';
+import type { State } from './reducer';
 
 export const getState = ( state: State ) => state;
 export const getVerticals = ( state: State ) => state.verticals;

--- a/packages/data-stores/tsconfig.json
+++ b/packages/data-stores/tsconfig.json
@@ -22,6 +22,8 @@
 
 		"forceConsistentCasingInFileNames": true,
 
+		"importsNotUsedAsValues": "error",
+
 		"typeRoots": [ "../../node_modules/@types" ],
 		"types": [],
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Make `importsNotUsedAsValues` error. This comes along with type only imports. [See the announcement post.](https://devblogs.microsoft.com/typescript/announcing-typescript-3-8-beta/#type-only-imports-exports).

This change should help to encourage the use of `import type` to import types, and discourage `import { MyType }` otherwise. This is helpful for tree shaking and bundlers, as well as programmers 🙃 

#### Testing instructions

`data-stores` compiles as before without error. `typecheck-strict` confirms the types remain compatible where they're used in Gutenboarding.

[`/new`](https://calypso.live/new?branch=fix/data-stores-type-imports) (the most significant usage of data-stores) continues to work as expected.