### PR TITLE
Gutenboarding: Standardize import type

### DIFF
--- a/client/gravatar/types.ts
+++ b/client/gravatar/types.ts
@@ -1,7 +1,7 @@
 /**
  * Internal Dependencies
  */
-import { URL } from '../types';
+import type { URL } from '../types';
 
 export type GravatarOptions = Partial< {
 	s: number;

--- a/client/landing/gutenboarding/components/domain-picker-button/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-button/index.tsx
@@ -1,13 +1,13 @@
 /**
  * External dependencies
  */
-import React, { createRef, FunctionComponent, useState, useEffect } from 'react';
+import * as React from 'react';
 import { Button } from '@wordpress/components';
 import { Icon, chevronDown } from '@wordpress/icons';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useI18n } from '@automattic/react-i18n';
-
 import classnames from 'classnames';
+import type { DomainSuggestions } from '@automattic/data-stores';
 
 /**
  * Internal dependencies
@@ -32,7 +32,7 @@ const DOMAIN_SUGGESTION_VENDOR = getSuggestionsVendor( true );
  */
 import './style.scss';
 
-type DomainSuggestion = import('@automattic/data-stores').DomainSuggestions.DomainSuggestion;
+type DomainSuggestion = DomainSuggestions.DomainSuggestion;
 
 interface Props extends Button.BaseProps {
 	className?: string;
@@ -40,14 +40,14 @@ interface Props extends Button.BaseProps {
 	onDomainSelect: ( domainSuggestion: DomainSuggestion ) => void;
 }
 
-const DomainPickerButton: FunctionComponent< Props > = ( {
+const DomainPickerButton: React.FunctionComponent< Props > = ( {
 	children,
 	className,
 	onDomainSelect,
 	currentDomain,
 	...buttonProps
 } ) => {
-	const buttonRef = createRef< HTMLButtonElement >();
+	const buttonRef = React.createRef< HTMLButtonElement >();
 
 	const domainSuggestions = useDomainSuggestions( { locale: useI18n().i18nLocale, quantity: 10 } );
 
@@ -55,9 +55,9 @@ const DomainPickerButton: FunctionComponent< Props > = ( {
 		select( DOMAIN_SUGGESTIONS_STORE ).getCategories()
 	);
 
-	const [ railcarId, setRailcarId ] = useState< string | undefined >();
+	const [ railcarId, setRailcarId ] = React.useState< string | undefined >();
 
-	useEffect( () => {
+	React.useEffect( () => {
 		// Only generate a railcarId when the domain suggestions change and are not empty.
 		if ( domainSuggestions ) {
 			setRailcarId( getNewRailcarId() );
@@ -69,8 +69,8 @@ const DomainPickerButton: FunctionComponent< Props > = ( {
 	);
 	const { setDomainSearch, setDomainCategory } = useDispatch( STORE_KEY );
 
-	const [ isDomainPopoverVisible, setDomainPopoverVisibility ] = useState( false );
-	const [ isDomainModalVisible, setDomainModalVisibility ] = useState( false );
+	const [ isDomainPopoverVisible, setDomainPopoverVisibility ] = React.useState( false );
+	const [ isDomainModalVisible, setDomainModalVisibility ] = React.useState( false );
 
 	const handlePopoverClose = ( e?: React.FocusEvent ) => {
 		// Don't collide with button toggling

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -9,6 +9,7 @@ import { Icon, wordpress } from '@wordpress/icons';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useHistory } from 'react-router-dom';
 import classnames from 'classnames';
+import type { DomainSuggestions } from '@automattic/data-stores';
 
 /**
  * Internal dependencies
@@ -31,7 +32,7 @@ import { PAID_DOMAINS_TO_SHOW } from '../../constants';
 import { usePath, useCurrentStep, Step } from '../../path';
 import { trackEventWithFlow } from '../../lib/analytics';
 
-type DomainSuggestion = import('@automattic/data-stores').DomainSuggestions.DomainSuggestion;
+type DomainSuggestion = DomainSuggestions.DomainSuggestion;
 
 const Header: React.FunctionComponent = () => {
 	const { __, i18nLocale } = useI18n();

--- a/client/landing/gutenboarding/components/link/index.tsx
+++ b/client/landing/gutenboarding/components/link/index.tsx
@@ -4,7 +4,7 @@
 import { Button } from '@wordpress/components';
 import { Link as RouterLink, LinkProps } from 'react-router-dom';
 import React, { forwardRef, FunctionComponent } from 'react';
-import { Assign } from 'utility-types';
+import type { Assign } from 'utility-types';
 
 interface LinkButtonProps extends Button.AnchorProps {
 	navigate: () => void;

--- a/client/landing/gutenboarding/constants.ts
+++ b/client/landing/gutenboarding/constants.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { ValuesType } from 'utility-types';
+import type { ValuesType } from 'utility-types';
 
 /**
  * An ID that identifies the onboarding flow to analytics and other services.

--- a/client/landing/gutenboarding/hooks/use-track-modal.ts
+++ b/client/landing/gutenboarding/hooks/use-track-modal.ts
@@ -8,7 +8,7 @@ import { useEffect } from 'react';
  */
 import { useOnUnmount } from './use-on-unmount';
 import { recordEnterModal, recordCloseModal } from '../lib/analytics';
-import { TracksEventProperties } from '../lib/analytics/types';
+import type { TracksEventProperties } from '../lib/analytics/types';
 
 /**
  * Records events in tracks on opening and closing the modal

--- a/client/landing/gutenboarding/hooks/use-track-step.ts
+++ b/client/landing/gutenboarding/hooks/use-track-step.ts
@@ -7,9 +7,9 @@ import { useEffect } from 'react';
  * Internal dependencies
  */
 import { useOnUnmount } from './use-on-unmount';
-import { StepNameType } from '../path';
 import { recordEnterStep, recordLeaveStep } from '../lib/analytics';
-import { TracksEventProperties } from '../lib/analytics/types';
+import type { StepNameType } from '../path';
+import type { TracksEventProperties } from '../lib/analytics/types';
 
 /**
  * Records an event in tracks on entering and leaving the step.

--- a/client/landing/gutenboarding/index.tsx
+++ b/client/landing/gutenboarding/index.tsx
@@ -18,6 +18,7 @@ import { BrowserRouter, Route, Switch, Redirect } from 'react-router-dom';
 import config from '../../config';
 import { subscribe, select, dispatch } from '@wordpress/data';
 import { initializeAnalytics } from '@automattic/calypso-analytics';
+import type { Site, User } from '@automattic/data-stores';
 
 /**
  * Internal dependencies
@@ -55,8 +56,8 @@ const USE_TRANSLATION_CHUNKS: string =
 	config.isEnabled( 'use-translation-chunks' ) ||
 	getUrlParts( document.location.href ).searchParams.has( 'useTranslationChunks' );
 
-type User = import('@automattic/data-stores').User.CurrentUser;
-type Site = import('@automattic/data-stores').Site.SiteDetails;
+type User = User.CurrentUser;
+type Site = Site.SiteDetails;
 
 interface AppWindow extends Window {
 	currentUser?: User;

--- a/client/landing/gutenboarding/index.tsx
+++ b/client/landing/gutenboarding/index.tsx
@@ -18,7 +18,7 @@ import { BrowserRouter, Route, Switch, Redirect } from 'react-router-dom';
 import config from '../../config';
 import { subscribe, select, dispatch } from '@wordpress/data';
 import { initializeAnalytics } from '@automattic/calypso-analytics';
-import type { Site, User } from '@automattic/data-stores';
+import type { Site as SiteStore, User as UserStore } from '@automattic/data-stores';
 
 /**
  * Internal dependencies
@@ -56,8 +56,8 @@ const USE_TRANSLATION_CHUNKS: string =
 	config.isEnabled( 'use-translation-chunks' ) ||
 	getUrlParts( document.location.href ).searchParams.has( 'useTranslationChunks' );
 
-type User = User.CurrentUser;
-type Site = Site.SiteDetails;
+type User = UserStore.CurrentUser;
+type Site = SiteStore.SiteDetails;
 
 interface AppWindow extends Window {
 	currentUser?: User;

--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -18,9 +18,8 @@ import Badge from '../../components/badge';
 import designs, { getDesignImageUrl } from '../../available-designs';
 import JetpackLogo from 'components/jetpack-logo'; // @TODO: extract to @automattic package
 import Link from '../../components/link';
+import type { Design } from '../../stores/onboard/types';
 import './style.scss';
-
-type Design = import('../../stores/onboard/types').Design;
 
 const makeOptionId = ( { slug }: Design ): string => `design-selector__option-name__${ slug }`;
 

--- a/client/landing/gutenboarding/onboarding-block/edit.tsx
+++ b/client/landing/gutenboarding/onboarding-block/edit.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { BlockEditProps } from '@wordpress/blocks';
+import type { BlockEditProps } from '@wordpress/blocks';
 import { useDispatch, useSelect } from '@wordpress/data';
 import React, { FunctionComponent, useEffect, useCallback } from 'react';
 import { Redirect, Switch, Route, useLocation } from 'react-router-dom';
@@ -14,7 +14,7 @@ import { SITE_STORE } from '../stores/site';
 import { USER_STORE } from '../stores/user';
 import DesignSelector from './design-selector';
 import CreateSite from './create-site';
-import { Attributes } from './types';
+import type { Attributes } from './types';
 import { Step, usePath, useNewQueryParam } from '../path';
 import AcquireIntent from './acquire-intent';
 import StylePreview from './style-preview';

--- a/client/landing/gutenboarding/onboarding-block/index.ts
+++ b/client/landing/gutenboarding/onboarding-block/index.ts
@@ -1,12 +1,12 @@
 /**
  * External dependencies
  */
-import { BlockConfiguration } from '@wordpress/blocks';
+import type { BlockConfiguration } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
  */
-import { Attributes } from './types';
+import type { Attributes } from './types';
 import edit from './edit';
 
 export const name = 'automattic/onboarding';

--- a/client/landing/gutenboarding/onboarding-block/style-preview/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/index.tsx
@@ -16,7 +16,6 @@ import { usePath, Step } from '../../path';
 import ViewportSelect from './viewport-select';
 import FontSelect from './font-select';
 import { Title, SubTitle } from '../../components/titles';
-import * as T from './types';
 import { STORE_KEY as ONBOARD_STORE } from '../../stores/onboard';
 import { Plans } from '@automattic/data-stores';
 import { USER_STORE } from '../../stores/user';
@@ -25,6 +24,8 @@ import SignupForm from '../../components/signup-form';
 import { useTrackStep } from '../../hooks/use-track-step';
 import { useShouldSiteBePublicOnSelectedPlan } from '../../hooks/use-selected-plan';
 import BottomBarMobile from '../../components/bottom-bar-mobile';
+import type { Viewport } from './types';
+
 import './style.scss';
 
 const PLANS_STORE = Plans.STORE_KEY;
@@ -46,7 +47,7 @@ const StylePreview: React.FunctionComponent = () => {
 	const { __ } = useI18n();
 	const history = useHistory();
 	const makePath = usePath();
-	const [ selectedViewport, setSelectedViewport ] = React.useState< T.Viewport >( 'desktop' );
+	const [ selectedViewport, setSelectedViewport ] = React.useState< Viewport >( 'desktop' );
 
 	const { createSite } = useDispatch( ONBOARD_STORE );
 

--- a/client/landing/gutenboarding/onboarding-block/style-preview/preview.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/preview.tsx
@@ -9,14 +9,10 @@ import { useSelect } from '@wordpress/data';
  * Internal dependencies
  */
 import { STORE_KEY } from '../../stores/onboard';
-import * as T from './types';
 import { useLangRouteParam } from '../../path';
 import { isEnabled } from 'config';
-
-type Design = import('../../stores/onboard/types').Design;
-type Font = import('../../constants').Font;
-type SiteVertical = import('../../stores/onboard/types').SiteVertical;
 import { fontPairings } from '../../constants';
+import type { Viewport } from './types';
 
 function getFontsLoadingHTML() {
 	const baseURL = 'https://fonts.googleapis.com/css2';
@@ -57,7 +53,7 @@ function getFontsLoadingHTML() {
 }
 
 interface Props {
-	viewport: T.Viewport;
+	viewport: Viewport;
 }
 const Preview: React.FunctionComponent< Props > = ( { viewport } ) => {
 	const [ previewHtml, setPreviewHtml ] = React.useState< string >();

--- a/client/landing/gutenboarding/onboarding-block/style-preview/viewport-select.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/viewport-select.tsx
@@ -8,15 +8,15 @@ import classnames from 'classnames';
 /**
  * Internal dependencies
  */
-import * as T from './types';
 import { useI18n } from '@automattic/react-i18n';
+import type { Viewport } from './types';
 
 // TODO FIXME: React elements are a poor choice for static svgs.
 // Refactor, external svg with use?
 
 interface Props {
-	onSelect: ( selection: T.Viewport ) => void;
-	selected: T.Viewport;
+	onSelect: ( selection: Viewport ) => void;
+	selected: Viewport;
 }
 const ViewportSelect: React.FunctionComponent< Props > = ( { onSelect, selected } ) => {
 	const { __ } = useI18n();

--- a/client/landing/gutenboarding/path.ts
+++ b/client/landing/gutenboarding/path.ts
@@ -4,7 +4,7 @@
 import { findKey } from 'lodash';
 import { generatePath, useLocation, useRouteMatch } from 'react-router-dom';
 import { Plans } from '@automattic/data-stores';
-import { ValuesType } from 'utility-types';
+import type { ValuesType } from 'utility-types';
 
 import { getLanguageRouteParam } from '../../lib/i18n-utils';
 

--- a/client/landing/gutenboarding/stores/onboard/actions.ts
+++ b/client/landing/gutenboarding/stores/onboard/actions.ts
@@ -1,20 +1,20 @@
 /**
  * External dependencies
  */
-import { DomainSuggestions, VerticalsTemplates } from '@automattic/data-stores';
+import type { DomainSuggestions, Site, VerticalsTemplates } from '@automattic/data-stores';
 import { dispatch, select } from '@wordpress/data-controls';
 import guessTimezone from '../../../../lib/i18n-utils/guess-timezone';
 
 /**
  * Internal dependencies
  */
-import { Design, SiteVertical } from './types';
+import type { Design, SiteVertical } from './types';
 import { STORE_KEY as ONBOARD_STORE } from './constants';
 import { SITE_STORE } from '../site';
 import type { State } from '.';
 import type { FontPair } from '../../constants';
 
-type CreateSiteParams = import('@automattic/data-stores').Site.CreateSiteParams;
+type CreateSiteParams = Site.CreateSiteParams;
 type DomainSuggestion = DomainSuggestions.DomainSuggestion;
 type Template = VerticalsTemplates.Template;
 

--- a/client/landing/gutenboarding/stores/onboard/index.ts
+++ b/client/landing/gutenboarding/stores/onboard/index.ts
@@ -12,7 +12,7 @@ import reducer from './reducer';
 import * as actions from './actions';
 import * as selectors from './selectors';
 import persistOptions from './persist';
-import { SelectFromMap, DispatchFromMap } from '@automattic/data-stores';
+import type { SelectFromMap, DispatchFromMap } from '@automattic/data-stores';
 
 export type State = import('./reducer').State;
 export { STORE_KEY };

--- a/client/landing/gutenboarding/stores/onboard/index.ts
+++ b/client/landing/gutenboarding/stores/onboard/index.ts
@@ -8,13 +8,13 @@ import { plugins, registerStore, use } from '@wordpress/data';
  * Internal dependencies
  */
 import { STORE_KEY } from './constants';
-import reducer from './reducer';
+import reducer, { State } from './reducer';
 import * as actions from './actions';
 import * as selectors from './selectors';
 import persistOptions from './persist';
 import type { SelectFromMap, DispatchFromMap } from '@automattic/data-stores';
 
-export type State = import('./reducer').State;
+export type { State };
 export { STORE_KEY };
 
 use( plugins.persistence, persistOptions );

--- a/client/landing/gutenboarding/stores/onboard/reducer.ts
+++ b/client/landing/gutenboarding/stores/onboard/reducer.ts
@@ -3,6 +3,7 @@
  */
 import type { Reducer } from 'redux';
 import { combineReducers } from '@wordpress/data';
+import type { DomainSuggestions } from '@automattic/data-stores';
 
 /**
  * Internal dependencies
@@ -11,10 +12,10 @@ import type { SiteVertical, Design } from './types';
 import type { OnboardAction } from './actions';
 import type { FontPair } from '../../constants';
 
-const domain: Reducer<
-	import('@automattic/data-stores').DomainSuggestions.DomainSuggestion | undefined,
-	OnboardAction
-> = ( state, action ) => {
+const domain: Reducer< DomainSuggestions.DomainSuggestion | undefined, OnboardAction > = (
+	state,
+	action
+) => {
 	if ( action.type === 'SET_DOMAIN' ) {
 		return action.domain;
 	}

--- a/client/landing/gutenboarding/stores/onboard/selectors.ts
+++ b/client/landing/gutenboarding/stores/onboard/selectors.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { State } from './reducer';
+import type { State } from './reducer';
 
 export const getIsRedirecting = ( state: State ) => state.isRedirecting;
 export const getState = ( state: State ) => state;

--- a/client/landing/gutenboarding/stores/onboard/types.ts
+++ b/client/landing/gutenboarding/stores/onboard/types.ts
@@ -1,4 +1,7 @@
-type FontPair = import('../../constants').FontPair;
+/**
+ * Internal dependencies
+ */
+import type { FontPair } from '../../constants';
 
 export interface SiteVertical {
 	/**

--- a/client/landing/gutenboarding/tsconfig.json
+++ b/client/landing/gutenboarding/tsconfig.json
@@ -4,7 +4,8 @@
 		"composite": false,
 		"noEmit": true,
 		"emitDeclarationOnly": false,
-		"tsBuildInfoFile": null
+		"tsBuildInfoFile": null,
+		"importsNotUsedAsValues": "error"
 	},
 	"files": [ "index.tsx" ],
 	"include": []

--- a/client/landing/gutenboarding/utils/domain-suggestions.ts
+++ b/client/landing/gutenboarding/utils/domain-suggestions.ts
@@ -1,4 +1,9 @@
-type DomainSuggestion = import('@automattic/data-stores').DomainSuggestions.DomainSuggestion;
+/**
+ * External dependencies
+ */
+import type { DomainSuggestions } from '@automattic/data-stores';
+
+type DomainSuggestion = DomainSuggestions.DomainSuggestion;
 
 export function getFreeDomainSuggestions( allSuggestions: DomainSuggestion[] | undefined ) {
 	return allSuggestions?.filter( ( suggestion ) => suggestion.is_free );

--- a/client/lib/interval/use-interval.ts
+++ b/client/lib/interval/use-interval.ts
@@ -6,7 +6,7 @@ import { useEffect, useRef } from 'react';
 /**
  * Internal dependencies
  */
-import { TimeoutMS } from 'types';
+import type { TimeoutMS } from 'types';
 
 /**
  * useInterval implementation from @see https://overreacted.io/making-setinterval-declarative-with-react-hooks/

--- a/client/lib/url/url-parts.ts
+++ b/client/lib/url/url-parts.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { URL as URLString } from 'types';
+import type { URL as URLString } from 'types';
 
 /**
  * Internal dependencies

--- a/client/lib/url/url-type.ts
+++ b/client/lib/url/url-type.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { URL as URLString } from 'types';
+import type { URL as URLString } from 'types';
 
 // For complete definitions of these classifications, see:
 // https://url.spec.whatwg.org/#urls

--- a/client/types.ts
+++ b/client/types.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { NonUndefined } from 'utility-types';
+import type { NonUndefined } from 'utility-types';
 
 // Web stuff
 export type URL = string;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Make `importsNotUsedAsValues` error. This comes along with type only imports. [See the announcement post](https://devblogs.microsoft.com/typescript/announcing-typescript-3-8-beta/#type-only-imports-exports).

This change should help to encourage the use of `import type` to import types, and discourage `import { MyType }` otherwise. This is helpful for tree shaking and bundlers, as well as programmers 🙃 

#### Testing instructions

`typecheck-strict` job passes

[`/new`](https://calypso.live/new?branch=gutenboarding/import-type) works without regressions