### PR TITLE
composite-checkout: Jump to payment method step if contact details are prefilled

### DIFF
--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -153,10 +153,12 @@ export default function WPCheckout( {
 	const validateContactDetails = async () => {
 		debug( 'validating contact details' );
 		if ( isDomainFieldsVisible ) {
-			const validationResult = getDomainValidationResult( items, contactInfo );
+			const validationResult = await getDomainValidationResult( items, contactInfo );
+			debug( 'validating contact details result', validationResult );
 			return isContactValidationResponseValid( validationResult, contactInfo );
 		} else if ( isGSuiteInCart ) {
-			const validationResult = getGSuiteValidationResult( items, contactInfo );
+			const validationResult = await getGSuiteValidationResult( items, contactInfo );
+			debug( 'validating contact details result', validationResult );
 			return isContactValidationResponseValid( validationResult, contactInfo );
 		}
 		return isCompleteAndValid( contactInfo );

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -150,6 +150,17 @@ export default function WPCheckout( {
 		}
 		return isCompleteAndValid( contactInfo );
 	};
+	const validateContactDetails = async () => {
+		debug( 'validating contact details' );
+		if ( isDomainFieldsVisible ) {
+			const validationResult = getDomainValidationResult( items, contactInfo );
+			return isContactValidationResponseValid( validationResult, contactInfo );
+		} else if ( isGSuiteInCart ) {
+			const validationResult = getGSuiteValidationResult( items, contactInfo );
+			return isContactValidationResponseValid( validationResult, contactInfo );
+		}
+		return isCompleteAndValid( contactInfo );
+	};
 
 	const [ isSummaryVisible, setIsSummaryVisible ] = useState( false );
 
@@ -232,7 +243,7 @@ export default function WPCheckout( {
 									shouldShowContactDetailsValidationErrors={
 										shouldShowContactDetailsValidationErrors
 									}
-									contactValidationCallback={ contactValidationCallback }
+									contactValidationCallback={ validateContactDetails }
 								/>
 							}
 							completeStepContent={

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
+import { useSelector } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
 import styled from '@emotion/styled';
 import {
@@ -29,6 +30,7 @@ import debugFactory from 'debug';
  */
 import { areDomainsInLineItems, isLineItemADomain } from '../hooks/has-domains';
 import useCouponFieldState from '../hooks/use-coupon-field-state';
+import getContactDetailsCache from 'state/selectors/get-contact-details-cache';
 import WPCheckoutOrderReview from './wp-checkout-order-review';
 import WPCheckoutOrderSummary from './wp-checkout-order-summary';
 import WPContactForm from './wp-contact-form';
@@ -150,6 +152,23 @@ export default function WPCheckout( {
 		}
 		return isCompleteAndValid( contactInfo );
 	};
+
+	const cachedContactDetails = useSelector( getContactDetailsCache );
+	const shouldValidateCachedContactDetails = useRef( true );
+
+	useEffect( () => {
+		if ( shouldValidateCachedContactDetails.current && cachedContactDetails ) {
+			shouldValidateCachedContactDetails.current = false;
+			// disable editing here?
+			contactValidationCallback().then( ( areDetailsCompleteAndValid ) => {
+				// If the details are already populated and valid, jump to payment method step
+				if ( areDetailsCompleteAndValid ) {
+					debug( 'Contact details are already populated; skipping to payment method step' );
+					// skip to payment step here
+				}
+			} );
+		}
+	}, [ cachedContactDetails, contactValidationCallback ] );
 
 	const [ isSummaryVisible, setIsSummaryVisible ] = useState( false );
 

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -417,17 +417,29 @@ function useSkipToLastStepIfFormComplete( contactValidationCallback ) {
 	const cachedContactDetails = useSelector( getContactDetailsCache );
 	const shouldValidateCachedContactDetails = useRef( true );
 
+	// TODO: if form has been edited, don't do this
 	useEffect( () => {
 		if ( shouldValidateCachedContactDetails.current && cachedContactDetails ) {
 			shouldValidateCachedContactDetails.current = false;
-			// disable editing here?
 			contactValidationCallback().then( ( areDetailsCompleteAndValid ) => {
 				// If the details are already populated and valid, jump to payment method step
 				if ( areDetailsCompleteAndValid ) {
 					debug( 'Contact details are already populated; skipping to payment method step' );
-					// skip to payment step here
+					saveStepNumberToUrl( 2 ); // TODO: can we do this dynamically somehow in case the step numbers change?
 				}
 			} );
 		}
 	}, [ cachedContactDetails, contactValidationCallback ] );
+}
+
+function saveStepNumberToUrl( stepNumber ) {
+	if ( ! window?.location ) {
+		return;
+	}
+	const newHash = stepNumber > 1 ? `#step${ stepNumber }` : '';
+	if ( window.location.hash === newHash ) {
+		return;
+	}
+	window.location.hash = newHash;
+	debug( 'updating url to', window.location.href );
 }

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useEffect, useState, useRef } from 'react';
-import { useSelector } from 'react-redux';
+import React, { useEffect, useState } from 'react';
 import { useTranslate } from 'i18n-calypso';
 import styled from '@emotion/styled';
 import {
@@ -30,7 +29,6 @@ import debugFactory from 'debug';
  */
 import { areDomainsInLineItems, isLineItemADomain } from '../hooks/has-domains';
 import useCouponFieldState from '../hooks/use-coupon-field-state';
-import getContactDetailsCache from 'state/selectors/get-contact-details-cache';
 import WPCheckoutOrderReview from './wp-checkout-order-review';
 import WPCheckoutOrderSummary from './wp-checkout-order-summary';
 import WPContactForm from './wp-contact-form';
@@ -152,8 +150,6 @@ export default function WPCheckout( {
 		}
 		return isCompleteAndValid( contactInfo );
 	};
-
-	useSkipToLastStepIfFormComplete( contactValidationCallback );
 
 	const [ isSummaryVisible, setIsSummaryVisible ] = useState( false );
 
@@ -412,34 +408,3 @@ const CheckoutTermsUI = styled.div`
 		text-decoration: none;
 	}
 `;
-
-function useSkipToLastStepIfFormComplete( contactValidationCallback ) {
-	const cachedContactDetails = useSelector( getContactDetailsCache );
-	const shouldValidateCachedContactDetails = useRef( true );
-
-	// TODO: if form has been edited, don't do this
-	useEffect( () => {
-		if ( shouldValidateCachedContactDetails.current && cachedContactDetails ) {
-			shouldValidateCachedContactDetails.current = false;
-			contactValidationCallback().then( ( areDetailsCompleteAndValid ) => {
-				// If the details are already populated and valid, jump to payment method step
-				if ( areDetailsCompleteAndValid ) {
-					debug( 'Contact details are already populated; skipping to payment method step' );
-					saveStepNumberToUrl( 2 ); // TODO: can we do this dynamically somehow in case the step numbers change?
-				}
-			} );
-		}
-	}, [ cachedContactDetails, contactValidationCallback ] );
-}
-
-function saveStepNumberToUrl( stepNumber ) {
-	if ( ! window?.location ) {
-		return;
-	}
-	const newHash = stepNumber > 1 ? `#step${ stepNumber }` : '';
-	if ( window.location.hash === newHash ) {
-		return;
-	}
-	window.location.hash = newHash;
-	debug( 'updating url to', window.location.href );
-}

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -153,22 +153,7 @@ export default function WPCheckout( {
 		return isCompleteAndValid( contactInfo );
 	};
 
-	const cachedContactDetails = useSelector( getContactDetailsCache );
-	const shouldValidateCachedContactDetails = useRef( true );
-
-	useEffect( () => {
-		if ( shouldValidateCachedContactDetails.current && cachedContactDetails ) {
-			shouldValidateCachedContactDetails.current = false;
-			// disable editing here?
-			contactValidationCallback().then( ( areDetailsCompleteAndValid ) => {
-				// If the details are already populated and valid, jump to payment method step
-				if ( areDetailsCompleteAndValid ) {
-					debug( 'Contact details are already populated; skipping to payment method step' );
-					// skip to payment step here
-				}
-			} );
-		}
-	}, [ cachedContactDetails, contactValidationCallback ] );
+	useSkipToLastStepIfFormComplete( contactValidationCallback );
 
 	const [ isSummaryVisible, setIsSummaryVisible ] = useState( false );
 
@@ -427,3 +412,22 @@ const CheckoutTermsUI = styled.div`
 		text-decoration: none;
 	}
 `;
+
+function useSkipToLastStepIfFormComplete( contactValidationCallback ) {
+	const cachedContactDetails = useSelector( getContactDetailsCache );
+	const shouldValidateCachedContactDetails = useRef( true );
+
+	useEffect( () => {
+		if ( shouldValidateCachedContactDetails.current && cachedContactDetails ) {
+			shouldValidateCachedContactDetails.current = false;
+			// disable editing here?
+			contactValidationCallback().then( ( areDetailsCompleteAndValid ) => {
+				// If the details are already populated and valid, jump to payment method step
+				if ( areDetailsCompleteAndValid ) {
+					debug( 'Contact details are already populated; skipping to payment method step' );
+					// skip to payment step here
+				}
+			} );
+		}
+	}, [ cachedContactDetails, contactValidationCallback ] );
+}

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -232,6 +232,7 @@ export default function WPCheckout( {
 									shouldShowContactDetailsValidationErrors={
 										shouldShowContactDetailsValidationErrors
 									}
+									contactValidationCallback={ contactValidationCallback }
 								/>
 							}
 							completeStepContent={

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-contact-form.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-contact-form.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import {
@@ -10,8 +10,11 @@ import {
 	useFormStatus,
 	useIsStepActive,
 	useLineItems,
+	useSetStepComplete,
 } from '@automattic/composite-checkout';
 import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
+import debugFactory from 'debug';
 
 /**
  * Internal dependencies
@@ -21,6 +24,9 @@ import Field from './field';
 import { SummaryLine, SummaryDetails } from './summary-details';
 import { LeftColumn, RightColumn } from './ie-fallback';
 import { prepareDomainContactDetails, prepareDomainContactDetailsErrors, isValid } from '../types';
+import getContactDetailsCache from 'state/selectors/get-contact-details-cache';
+
+const debug = debugFactory( 'calypso:composite-checkout:wp-contact-form' );
 
 export default function WPContactForm( {
 	summary,
@@ -30,6 +36,7 @@ export default function WPContactForm( {
 	countriesList,
 	renderDomainContactFields,
 	shouldShowContactDetailsValidationErrors,
+	contactValidationCallback,
 } ) {
 	const translate = useTranslate();
 	const [ items ] = useLineItems();
@@ -41,6 +48,7 @@ export default function WPContactForm( {
 	const { formStatus } = useFormStatus();
 	const isStepActive = useIsStepActive();
 	const isDisabled = ! isStepActive || formStatus !== 'ready';
+	useSkipToLastStepIfFormComplete( contactValidationCallback );
 
 	if ( summary && isComplete ) {
 		return (
@@ -339,3 +347,39 @@ const ContactDetailsFormDescription = styled.p`
 	color: ${ ( props ) => props.theme.colors.textColor };
 	margin: 0 0 16px;
 `;
+
+function useSkipToLastStepIfFormComplete( contactValidationCallback ) {
+	const cachedContactDetails = useSelector( getContactDetailsCache );
+	const shouldValidateCachedContactDetails = useRef( true );
+	const setStepCompleteStatus = useSetStepComplete();
+
+	useEffect( () => {
+		if ( ! contactValidationCallback ) {
+			debug( 'Cannot validate contact details; no validation callback' );
+			return;
+		}
+		if ( shouldValidateCachedContactDetails.current && cachedContactDetails ) {
+			shouldValidateCachedContactDetails.current = false;
+			contactValidationCallback().then( ( areDetailsCompleteAndValid ) => {
+				// If the details are already populated and valid, jump to payment method step
+				if ( areDetailsCompleteAndValid ) {
+					debug( 'Contact details are already populated; skipping to payment method step' );
+					saveStepNumberToUrl( 2 ); // TODO: can we do this dynamically somehow in case the step numbers change?
+					setStepCompleteStatus( 1, true ); // TODO: can we do this dynamically somehow in case the step numbers change?
+				}
+			} );
+		}
+	}, [ cachedContactDetails, contactValidationCallback, setStepCompleteStatus ] );
+}
+
+function saveStepNumberToUrl( stepNumber ) {
+	if ( ! window?.location ) {
+		return;
+	}
+	const newHash = stepNumber > 1 ? `#step${ stepNumber }` : '';
+	if ( window.location.hash === newHash ) {
+		return;
+	}
+	window.location.hash = newHash;
+	debug( 'updating url to', window.location.href );
+}

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-contact-form.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-contact-form.js
@@ -227,7 +227,8 @@ function ContactFormSummary( { isDomainFieldsVisible, isGSuiteInCart } ) {
 					) }
 
 					{ ( isGSuiteInCart || showDomainContactSummary ) &&
-						contactInfo.alternateEmail.value?.length > 0 && (
+						contactInfo.alternateEmail.value?.length > 0 &&
+						contactInfo.alternateEmail.value !== contactInfo.email.value && (
 							<SummaryLine>{ contactInfo.alternateEmail.value }</SummaryLine>
 						) }
 

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-contact-form.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-contact-form.js
@@ -366,7 +366,9 @@ function useSkipToLastStepIfFormComplete( contactValidationCallback ) {
 					debug( 'Contact details are already populated; skipping to payment method step' );
 					saveStepNumberToUrl( 2 ); // TODO: can we do this dynamically somehow in case the step numbers change?
 					setStepCompleteStatus( 1, true ); // TODO: can we do this dynamically somehow in case the step numbers change?
+					return;
 				}
+				debug( 'Contact details are already populated but not valid' );
 			} );
 		}
 	}, [ cachedContactDetails, contactValidationCallback, setStepCompleteStatus ] );

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -59,7 +59,7 @@ The [Checkout](#checkout) component creates a wrapper for Checkout. Within the c
 
 Each `CheckoutStep` has an `isCompleteCallback` prop, which will be called when the "Continue" button is pressed. It can perform validation on that step's contents to determine if the form should continue to the next step. If the function returns true, the form continues to the next step, otherwise it remains on the same step. If the function returns a `Promise`, then the "Continue" button will change to "Please wait…" until the Promise resolves allowing for async operations. The value resolved by the Promise must be a boolean; true to continue, false to stay on the current step.
 
-Any component within a `CheckoutStep` gets access to the custom hooks above as well as [useIsStepActive](#useIsStepActive) and [useIsStepComplete](#useIsStepComplete).
+Any component within a `CheckoutStep` gets access to the custom hooks above as well as [useIsStepActive](#useIsStepActive), [useIsStepComplete](#useIsStepComplete), and [useSetStepComplete](#useSetStepComplete).
 
 ## Submitting the form
 
@@ -394,6 +394,10 @@ A React Hook that returns the `@wordpress/data` registry being used. Only works 
 ### useSelect
 
 A React Hook that accepts a callback which is provided the `select` function from the [Data store](#data-stores). The `select()` function can be called with the name of a store and will return the bound selectors for that store. Only works within [CheckoutProvider](#CheckoutProvider).
+
+### useSetStepComplete
+
+A React Hook that will return a function to set a step to "complete". Only works within a step. The function looks like `( stepNumber: number, isComplete: boolean ) => void;`.
 
 ### useTotal
 

--- a/packages/composite-checkout/src/components/checkout-steps.js
+++ b/packages/composite-checkout/src/components/checkout-steps.js
@@ -521,6 +521,19 @@ export function useIsStepComplete() {
 	return !! stepCompleteStatus[ stepNumber ];
 }
 
+export function useSetStepComplete() {
+	const { setStepCompleteStatus } = useContext( CheckoutStepDataContext );
+	const setTargetStepCompleteStatus = useCallback(
+		( stepNumber, newStatus ) =>
+			setStepCompleteStatus( ( stepCompleteStatus ) => ( {
+				...stepCompleteStatus,
+				[ stepNumber ]: newStatus,
+			} ) ),
+		[ setStepCompleteStatus ]
+	);
+	return setTargetStepCompleteStatus;
+}
+
 const StepWrapperUI = styled.div`
 	padding-bottom: ${ ( props ) => ( props.isFinalStep ? '0' : '32px' ) };
 	position: relative;

--- a/packages/composite-checkout/src/public-api.js
+++ b/packages/composite-checkout/src/public-api.js
@@ -12,6 +12,7 @@ import {
 	CheckoutSummaryCard,
 	useIsStepActive,
 	useIsStepComplete,
+	useSetStepComplete,
 } from './components/checkout-steps';
 import CheckoutPaymentMethods from './components/checkout-payment-methods';
 import {
@@ -105,6 +106,7 @@ export {
 	useRegisterStore,
 	useRegistry,
 	useSelect,
+	useSetStepComplete,
 	useTotal,
 	useTransactionStatus,
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This adds code such that if you load checkout when the contact details form fields are valid, we skip the contact details step and go directly to the review step (step 2 in the current flow).

#### Testing instructions

- Enter checkout as an established user with stored domain details. Verify that the contact details step is collapsed on page load, displaying the summary and green checkmark, and that you can complete the purchase.
- Enter checkout as a user with an existing plan only (stored zip and country, but not complete domain details) to purchase a domain. Verify that the contact details step is not collapsed on page load and that you can complete the purchase.
- Enter checkout as a user with no previous purchases with a domain in the cart. Verify that the contact details step is not collapsed and that you can complete the purchase.