### PR TITLE
i18n: Set response encoding in `build-languages` script

### DIFF
--- a/bin/build-languages.js
+++ b/bin/build-languages.js
@@ -205,6 +205,7 @@ async function downloadLanguages() {
 					const translationUrl = `${ LANGUAGES_BASE_URL }/${ filename }`;
 
 					https.get( translationUrl, ( response ) => {
+						response.setEncoding( 'utf8' );
 						let body = '';
 
 						files.forEach( ( file ) => response.pipe( file ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds missing `response.setEncoding( 'utf8' );` to avoid randomly getting broken 2 byte sequence characters.

#### Testing instructions

* Boot Calypso with `BUILD_TRANSLATION_CHUNKS=true ENABLE_FEATURES=use-translation-chunks yarn start`
* Confirm that none of the generated translation chunk files includes the `'REPLACEMENT CHARACTER' (U+FFFD)`

