### PR TITLE
Redirect users to Cloud after checking out

### DIFF
--- a/client/lib/products-values/index.js
+++ b/client/lib/products-values/index.js
@@ -234,6 +234,12 @@ export function isJetpackScan( product ) {
 	return isJetpackScanSlug( product.product_slug );
 }
 
+export function isJetpackCloudProductSlug( productSlug ) {
+	return (
+		JETPACK_SCAN_PRODUCTS.includes( productSlug ) || JETPACK_BACKUP_PRODUCTS.includes( productSlug )
+	);
+}
+
 export function isJetpackProductSlug( productSlug ) {
 	return includes( JETPACK_PRODUCTS_LIST, productSlug );
 }

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -38,7 +38,12 @@ import {
 	hasTransferProduct,
 	jetpackProductItem,
 } from 'lib/cart-values/cart-items';
-import { isJetpackProductSlug } from 'lib/products-values';
+import {
+	isJetpackProductSlug,
+	isJetpackScanSlug,
+	isJetpackBackupSlug,
+	isJetpackCloudProductSlug,
+} from 'lib/products-values';
 import PendingPaymentBlocker from './pending-payment-blocker';
 import { clearSitePlans } from 'state/sites/plans/actions';
 import { clearPurchases } from 'state/purchases/actions';
@@ -92,7 +97,7 @@ import {
 	retrieveSignupDestination,
 	clearSignupDestinationCookie,
 } from 'signup/utils';
-import { isExternal } from 'lib/url';
+import { isExternal, addQueryArgs } from 'lib/url';
 import { withLocalizedMoment } from 'components/localized-moment';
 import { abtest } from 'lib/abtest';
 
@@ -495,6 +500,7 @@ export class Checkout extends React.Component {
 			selectedSite,
 			selectedSiteSlug,
 			transaction: { step: { data: stepResult = null } = {} } = {},
+			isJetpackNotAtomic,
 		} = this.props;
 
 		const adminUrl = get( selectedSite, [ 'options', 'admin_url' ] );
@@ -541,14 +547,25 @@ export class Checkout extends React.Component {
 
 		this.setDestinationIfEcommPlan( pendingOrReceiptId );
 
-		// if it is one of the Jetpack products, use product info as a parameter.
-		// We want to be product-specific, as the same path will likely be used for
-		// WP.com sites purchasing Search.
-		if (
-			startsWith( product, 'jetpack_backup' ) ||
-			startsWith( product, 'jetpack_search' ) ||
-			startsWith( product, 'jetpack_scan' )
-		) {
+		// If it is a Jetpack Cloud products, use the redirection lib.
+		// For other Jetpack products, use the fallback logic to send to Calypso.
+		if ( isJetpackCloudProductSlug( product ) && isJetpackNotAtomic ) {
+			let source = '';
+			if ( isJetpackBackupSlug( product ) ) {
+				source = 'jetpack-backup-post-purchase';
+			} else if ( isJetpackScanSlug( product ) ) {
+				source = 'jetpack-scan-post-purchase';
+			}
+			if ( source ) {
+				return addQueryArgs(
+					{
+						source,
+						site: selectedSiteSlug,
+					},
+					'https://jetpack.com/redirect'
+				);
+			}
+		} else if ( isJetpackProductSlug( product ) ) {
 			signupDestination = this.getFallbackDestination( pendingOrReceiptId );
 		} else {
 			signupDestination =

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -638,6 +638,11 @@ export class Checkout extends React.Component {
 
 		this.props.clearPurchases();
 
+		// If the redirect is an external URL, send them out early.
+		if ( isExternal( redirectPath ) ) {
+			this.handleCheckoutExternalRedirect( redirectPath );
+		}
+
 		// Removes the destination cookie only if redirecting to the signup destination.
 		// (e.g. if the destination is an upsell nudge, it does not remove the cookie).
 		if ( redirectPath.includes( destinationFromCookie ) ) {

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -552,9 +552,9 @@ export class Checkout extends React.Component {
 		if ( isJetpackCloudProductSlug( product ) && isJetpackNotAtomic ) {
 			let source = '';
 			if ( isJetpackBackupSlug( product ) ) {
-				source = 'jetpack-backup-post-purchase';
+				source = 'calypso-backups';
 			} else if ( isJetpackScanSlug( product ) ) {
-				source = 'jetpack-scan-post-purchase';
+				source = 'calypso-scanner';
 			}
 			if ( source ) {
 				return addQueryArgs(

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -640,7 +640,7 @@ export class Checkout extends React.Component {
 
 		// If the redirect is an external URL, send them out early.
 		if ( isExternal( redirectPath ) ) {
-			this.handleCheckoutExternalRedirect( redirectPath );
+			return this.handleCheckoutExternalRedirect( redirectPath );
 		}
 
 		// Removes the destination cookie only if redirecting to the signup destination.

--- a/client/my-sites/checkout/checkout/secure-payment-form.jsx
+++ b/client/my-sites/checkout/checkout/secure-payment-form.jsx
@@ -50,6 +50,7 @@ import { displayError, clear } from './notices';
 import { isEbanxCreditCardProcessingEnabledForCountry } from 'lib/checkout/processor-specific';
 import { isWpComEcommercePlan } from 'lib/plans';
 import { recordTransactionAnalytics } from 'lib/analytics/store-transactions';
+import { isExternal } from 'lib/url';
 
 /**
  * Module variables
@@ -175,7 +176,8 @@ export class SecurePaymentForm extends Component {
 		const { cart, transaction } = this.props;
 
 		const origin = getLocationOrigin( window.location );
-		const successUrl = origin + this.props.redirectTo();
+		const successPath = this.props.redirectTo();
+		const successUrl = isExternal( successPath ) ? successPath : origin + successPath;
 		const cancelUrl = origin + '/checkout/' + get( this.props.selectedSite, 'slug', 'no-site' );
 
 		const cardDetailsCountry = get( transaction, 'payment.newCardDetails.country', null );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Redirects users to the appropriate place after purchasing a Cloud product.
* Ensures external redirects work correctly for checkouts.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out with Jetpack Backup or Scan.
2. See where you are directed after checkout.
