### PR TITLE
Signup: Pass new site data information to the shopping cart and checkout

### DIFF
--- a/client/lib/cart-values/index.js
+++ b/client/lib/cart-values/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import url from 'url';
-import { extend, get, isArray, invert } from 'lodash';
+import { extend, get, isArray, invert, isEmpty } from 'lodash';
 import update, { extend as extendImmutabilityHelper } from 'immutability-helper';
 import { translate } from 'i18n-calypso';
 import config from 'config';
@@ -59,6 +59,7 @@ export function preprocessCartForServer( {
 	extra,
 	products,
 	tax,
+	new_site_data,
 } ) {
 	const needsUrlCoupon = ! (
 		coupon ||
@@ -68,31 +69,24 @@ export function preprocessCartForServer( {
 	);
 	const urlCoupon = needsUrlCoupon ? url.parse( document.URL, true ).query.coupon : '';
 
-	return Object.assign(
-		{
-			coupon,
-			is_coupon_applied,
-			is_coupon_removed,
-			currency,
-			tax,
-			temporary,
-			extra,
-			products: products.map(
-				( { product_id, meta, free_trial, volume, extra: productExtra } ) => ( {
-					product_id,
-					meta,
-					free_trial,
-					volume,
-					extra: productExtra,
-				} )
-			),
-		},
-		needsUrlCoupon &&
-			urlCoupon && {
-				coupon: urlCoupon,
-				is_coupon_applied: false,
-			}
-	);
+	return {
+		coupon,
+		is_coupon_applied,
+		is_coupon_removed,
+		currency,
+		tax,
+		temporary,
+		extra,
+		products: products.map( ( { product_id, meta, free_trial, volume, extra: productExtra } ) => ( {
+			product_id,
+			meta,
+			free_trial,
+			volume,
+			extra: productExtra,
+		} ) ),
+		...( needsUrlCoupon && urlCoupon && { coupon: urlCoupon, is_coupon_applied: false } ),
+		...( ! isEmpty( new_site_data ) && { new_site_data } ),
+	};
 }
 
 /**

--- a/client/lib/signup/cart.js
+++ b/client/lib/signup/cart.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { forEach } from 'lodash';
+import { forEach, isEmpty } from 'lodash';
 
 /**
  * Internal dependencies
@@ -25,6 +25,15 @@ function addProductsToCart( cart, newCartItems ) {
 	return cart;
 }
 
+function addNewCartData( cart, newCartData ) {
+	return {
+		...cart,
+		...( ! isEmpty( newCartData.createNewSiteData ) && {
+			new_site_data: newCartData.createNewSiteData,
+		} ),
+	};
+}
+
 export default {
 	createCart: function ( cartKey, newCartItems, callback ) {
 		let newCart = {
@@ -40,7 +49,7 @@ export default {
 			callback( postError );
 		} );
 	},
-	addToCart: function ( cartKey, newCartItems, callback ) {
+	addToCart: function ( cartKey, newCartItems, newCartData, callback ) {
 		wpcom.undocumented().getCart( cartKey, function ( error, data ) {
 			if ( error ) {
 				return callback( error );
@@ -51,6 +60,7 @@ export default {
 			}
 
 			let newCart = addProductsToCart( data, newCartItems );
+			newCart = addNewCartData( newCart, newCartData );
 			newCart = preprocessCartForServer( newCart );
 
 			wpcom.undocumented().setCart( cartKey, newCart, callback );

--- a/client/lib/signup/cart.js
+++ b/client/lib/signup/cart.js
@@ -10,6 +10,7 @@ import wpcom from 'lib/wp';
 import productsListFactory from 'lib/products-list';
 const productsList = productsListFactory();
 import { preprocessCartForServer, fillInAllCartItemAttributes } from 'lib/cart-values';
+import { isDomainRegistration } from 'lib/products-values';
 import { addCartItem } from 'lib/cart-values/cart-items';
 
 function addProductsToCart( cart, newCartItems ) {
@@ -19,6 +20,9 @@ function addProductsToCart( cart, newCartItems ) {
 		} );
 		const addFunction = addCartItem( cartItem );
 
+		if ( isDomainRegistration( cartItem ) ) {
+			cart.products = cart.products.filter( ( item ) => ! isDomainRegistration( item ) );
+		}
 		cart = fillInAllCartItemAttributes( addFunction( cart ), productsList.get() );
 	} );
 

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -658,22 +658,11 @@ function shouldExcludeStep( stepName, fulfilledDependencies ) {
 	return isEmpty( dependenciesNotProvided );
 }
 
-function excludeDomainStep(
-	stepName,
-	tracksEventValue,
-	submitSignupStep,
-	{ isSiteless = false } = {}
-) {
+function excludeDomainStep( stepName, tracksEventValue, submitSignupStep ) {
 	let fulfilledDependencies = [];
 	const domainItem = undefined;
 
-	submitSignupStep(
-		{ stepName, domainItem },
-		{
-			domainItem,
-			...( isSiteless && { siteId: null, siteSlug: 'no-site' } ),
-		}
-	);
+	submitSignupStep( { stepName, domainItem }, { domainItem } );
 	recordExcludeStepEvent( stepName, tracksEventValue );
 
 	fulfilledDependencies = [ 'domainItem' ];
@@ -695,7 +684,6 @@ export function isDomainFulfilled( stepName, defaultDependencies, nextProps ) {
 export function removeDomainStepForPaidPlans( stepName, defaultDependencies, nextProps ) {
 	const { submitSignupStep, flowName, lastKnownFlow } = nextProps;
 	const flowToCheck = flowName || lastKnownFlow;
-	const isSiteless = isSitelessCheckoutEnabledForFlow( flowToCheck );
 	// This is for domainStepPlanStepSwap A/B test.
 	// Remove the domain step if a paid plan is selected, check https://wp.me/pbxNRc-cj#comment-277
 	// Exit if not in the right flow.
@@ -707,7 +695,7 @@ export function removeDomainStepForPaidPlans( stepName, defaultDependencies, nex
 
 	if ( ! isEmpty( cartItem ) ) {
 		const tracksEventValue = null;
-		excludeDomainStep( stepName, tracksEventValue, submitSignupStep, { isSiteless } );
+		excludeDomainStep( stepName, tracksEventValue, submitSignupStep );
 	}
 }
 

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -260,7 +260,7 @@ export function createSiteWithCart( callback, dependencies, stepData, reduxStore
 				siteSlug,
 				isFreeThemePreselected,
 				themeSlugWithRepo,
-				{ isSiteless }
+				{ isSiteless, createNewSiteData: newSiteParams }
 			)
 		);
 	}
@@ -368,15 +368,17 @@ function processItemCart(
 	siteSlug,
 	isFreeThemePreselected,
 	themeSlugWithRepo,
-	{ isSiteless = false } = {}
+	{ isSiteless = false, createNewSiteData } = {}
 ) {
 	const addToCartAndProceed = () => {
 		const newCartItemsToAdd = newCartItems.map( ( item ) =>
 			addPrivacyProtectionIfSupported( item, reduxStore )
 		);
 
-		if ( newCartItemsToAdd.length ) {
-			SignupCart.addToCart( siteSlug, newCartItemsToAdd, function ( cartError ) {
+		if ( newCartItemsToAdd.length || createNewSiteData ) {
+			SignupCart.addToCart( siteSlug, newCartItemsToAdd, { createNewSiteData }, function (
+				cartError
+			) {
 				callback( cartError, providedDependencies );
 			} );
 		} else {

--- a/client/lib/signup/test/cart.js
+++ b/client/lib/signup/test/cart.js
@@ -1,0 +1,236 @@
+/**
+ * Internal dependencies
+ */
+import wpcom from 'lib/wp';
+import SignupCart from 'lib/signup/cart';
+
+jest.mock( 'lib/wp', () => {
+	const undocumentedMock = { getCart: jest.fn(), setCart: jest.fn() };
+	return {
+		undocumented: () => undocumentedMock,
+	};
+} );
+jest.mock( 'lib/products-list', () => () => ( {
+	get: () => ( {
+		dotlive_domain: {
+			available: true,
+			cost: 12,
+			cost_display: '$12.00',
+			currency_code: 'USD',
+			description: '',
+			is_domain_registration: true,
+			is_privacy_protection_product_purchase_allowed: true,
+			price_tier_slug: null,
+			price_tier_usage_quantity: null,
+			prices: { USD: 12 },
+			product_id: 74,
+			product_name: '.live Domain Registration',
+			product_slug: 'dotlive_domain',
+			sale_cost: 12.5,
+			tld: 'live',
+		},
+	} ),
+} ) );
+
+describe( '.addToCart()', () => {
+	beforeEach( () => {
+		wpcom.undocumented().getCart.mockRestore();
+		wpcom.undocumented().setCart.mockRestore();
+	} );
+
+	test( 'adds the new products to the cart', () => {
+		return new Promise( ( done ) => {
+			const cartKey = 'siteSlug';
+			const newCartItems = [
+				{
+					is_domain_registration: true,
+					meta: 'domain.live',
+					product_slug: 'dotlive_domain',
+				},
+			];
+			const newCartData = {};
+
+			const existingCart = {
+				products: [
+					{
+						bill_period: '365',
+						cost: 96,
+						currency: 'USD',
+						extra: { context: 'signup' },
+						free_trial: false,
+						is_bundled: false,
+						is_domain_registration: false,
+						is_renewal: false,
+						is_sale_coupon_applied: false,
+						meta: '',
+						product_cost: 96,
+						product_cost_display: '$96',
+						product_cost_integer: 9600,
+						product_id: 1003,
+						product_name: 'WordPress.com Premium',
+						product_name_en: 'WordPress.com Premium',
+						product_slug: 'value_bundle',
+						subscription_id: 0,
+						volume: 1,
+					},
+				],
+			};
+
+			wpcom
+				.undocumented()
+				.getCart.mockImplementation( ( key, callback ) => callback( null, existingCart ) );
+			wpcom.undocumented().setCart.mockImplementation( ( key, data, callback ) => callback() );
+
+			SignupCart.addToCart( cartKey, newCartItems, newCartData, () => {
+				expect( wpcom.undocumented().setCart ).toHaveBeenCalledWith(
+					cartKey,
+					expect.objectContaining( {
+						products: [
+							{
+								extra: { context: 'signup' },
+								free_trial: false,
+								meta: '',
+								product_id: 1003,
+								volume: 1,
+							},
+							{
+								extra: { context: 'signup' },
+								free_trial: undefined,
+								meta: 'domain.live',
+								product_id: 74,
+								volume: undefined,
+							},
+						],
+					} ),
+					expect.any( Function )
+				);
+				done();
+			} );
+		} );
+	} );
+
+	test( 'does not allow more than one domain registration at a time', () => {
+		return new Promise( ( done ) => {
+			const cartKey = 'siteSlug';
+			const newCartItems = [
+				{
+					is_domain_registration: true,
+					meta: 'domain.live',
+					product_slug: 'dotlive_domain',
+				},
+			];
+			const newCartData = {};
+
+			const existingCart = {
+				products: [
+					{
+						bill_period: '365',
+						cost: 15,
+						currency: 'USD',
+						extra: { context: 'signup' },
+						free_trial: false,
+						is_bundled: false,
+						is_domain_registration: true,
+						is_renewal: false,
+						is_sale_coupon_applied: false,
+						meta: 'existing-domain.live',
+						product_cost: 15,
+						product_cost_display: '$15',
+						product_cost_integer: 1500,
+						product_id: 74,
+						product_slug: 'dotlive_domain',
+						subscription_id: 0,
+						volume: 1,
+					},
+				],
+			};
+
+			wpcom
+				.undocumented()
+				.getCart.mockImplementation( ( key, callback ) => callback( null, existingCart ) );
+			wpcom.undocumented().setCart.mockImplementation( ( key, data, callback ) => callback() );
+
+			SignupCart.addToCart( cartKey, newCartItems, newCartData, () => {
+				expect( wpcom.undocumented().setCart ).toHaveBeenCalledWith(
+					cartKey,
+					expect.objectContaining( {
+						products: [
+							{
+								extra: { context: 'signup' },
+								free_trial: undefined,
+								meta: 'domain.live',
+								product_id: 74,
+								volume: undefined,
+							},
+						],
+					} ),
+					expect.any( Function )
+				);
+				done();
+			} );
+		} );
+	} );
+
+	test( 'sets the corresponding `newCartData` in the cart', () => {
+		return new Promise( ( done ) => {
+			const cartKey = 'siteSlug';
+			const newCartItems = [];
+			const newCartData = {
+				createNewSiteData: {
+					blog_name: 'blog_name_wordpress_com',
+				},
+			};
+
+			const existingCart = {
+				products: [
+					{
+						bill_period: '365',
+						cost: 96,
+						currency: 'USD',
+						extra: { context: 'signup' },
+						free_trial: false,
+						is_bundled: false,
+						is_domain_registration: false,
+						is_renewal: false,
+						is_sale_coupon_applied: false,
+						meta: '',
+						product_cost: 96,
+						product_cost_display: '$96',
+						product_cost_integer: 9600,
+						product_id: 1003,
+						product_name: 'WordPress.com Premium',
+						product_name_en: 'WordPress.com Premium',
+						product_slug: 'value_bundle',
+						subscription_id: 0,
+						volume: 1,
+					},
+				],
+			};
+
+			wpcom
+				.undocumented()
+				.getCart.mockImplementation( ( key, callback ) => callback( null, existingCart ) );
+			wpcom.undocumented().setCart.mockImplementation( ( key, data, callback ) => callback() );
+
+			SignupCart.addToCart( cartKey, newCartItems, newCartData, () => {
+				expect( wpcom.undocumented().setCart ).toHaveBeenCalledWith(
+					cartKey,
+					expect.objectContaining( {
+						products: [
+							{
+								extra: { context: 'signup' },
+								free_trial: false,
+								meta: '',
+								product_id: 1003,
+								volume: 1,
+							},
+						],
+						new_site_data: newCartData.createNewSiteData,
+					} ),
+					expect.any( Function )
+				);
+				done();
+			} );
+		} );
+	} );
+} );

--- a/client/lib/signup/test/step-actions.js
+++ b/client/lib/signup/test/step-actions.js
@@ -249,7 +249,9 @@ describe( 'createSiteWithCart()', () => {
 			isSitelessCheckoutEnabledForFlow.mockImplementation( ( flow ) => flow === 'onboarding' );
 		} );
 		test( 'adds the domain registration to the cart without creating a site', () => {
-			SignupCart.addToCart.mockImplementation( ( cartKey, newCartItems, callback ) => callback() );
+			SignupCart.addToCart.mockImplementation( ( cartKey, newCartItems, newCartData, callback ) =>
+				callback()
+			);
 			return new Promise( ( done ) => {
 				const fakeStore = {
 					getState: () => ( {
@@ -268,13 +270,19 @@ describe( 'createSiteWithCart()', () => {
 						expect( SignupCart.addToCart ).toHaveBeenCalledWith(
 							'no-site',
 							[ expect.objectContaining( { meta: 'sitelessdomain.live' } ) ],
+							{
+								createNewSiteData: expect.objectContaining( {
+									blog_name: 'sitelessdomain.live',
+									find_available_url: false,
+								} ),
+							},
 							expect.any( Function )
 						);
 						done();
 					},
 					[],
 					{
-						siteUrl: undefined,
+						siteUrl: 'sitelessdomain.live',
 						flowName: 'onboarding',
 						domainItem: {
 							product_slug: 'dotlive_domain',

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -215,6 +215,7 @@ export default function CompositeCheckout( {
 		variantSelectOverride,
 		responseCart,
 		addItem,
+		createNewSiteData,
 	} = useShoppingCart(
 		siteSlug,
 		canInitializeCart && ! isLoadingCartSynchronizer && ! isFetchingProducts,
@@ -408,14 +409,18 @@ export default function CompositeCheckout( {
 
 	const paymentProcessors = useMemo(
 		() => ( {
-			'apple-pay': applePayProcessor,
-			'free-purchase': freePurchaseProcessor,
-			card: stripeCardProcessor,
-			'full-credits': fullCreditsProcessor,
-			'existing-card': existingCardProcessor,
-			paypal: ( transactionData ) => payPalProcessor( transactionData, getThankYouUrl, couponItem ),
+			'apple-pay': ( transactionData ) => applePayProcessor( transactionData, createNewSiteData ),
+			'free-purchase': ( transactionData ) =>
+				freePurchaseProcessor( transactionData, createNewSiteData ),
+			card: ( transactionData ) => stripeCardProcessor( transactionData, createNewSiteData ),
+			'full-credits': ( transactionData ) =>
+				fullCreditsProcessor( transactionData, createNewSiteData ),
+			'existing-card': ( transactionData ) =>
+				existingCardProcessor( transactionData, createNewSiteData ),
+			paypal: ( transactionData ) =>
+				payPalProcessor( transactionData, getThankYouUrl, couponItem, createNewSiteData ),
 		} ),
-		[ couponItem, getThankYouUrl ]
+		[ couponItem, getThankYouUrl, createNewSiteData ]
 	);
 
 	return (
@@ -747,7 +752,7 @@ function getPlanProductSlugs(
 }
 
 const Discount = styled.span`
-	color: ${ ( props ) => props.theme.colors.discount };
+	color: ${( props ) => props.theme.colors.discount};
 	margin-right: 8px;
 `;
 

--- a/client/my-sites/checkout/composite-checkout/payment-method-processors.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-processors.js
@@ -22,10 +22,11 @@ import { createStripePaymentMethod } from 'lib/stripe';
 
 const { select, dispatch } = defaultRegistry;
 
-export function applePayProcessor( submitData ) {
+export function applePayProcessor( submitData, createNewSiteData ) {
 	const pending = submitApplePayPayment(
 		{
 			...submitData,
+			createNewSiteData,
 			siteId: select( 'wpcom' )?.getSiteId?.(),
 			domainDetails: getDomainDetails( select ),
 			country: select( 'wpcom' )?.getContactInfo?.()?.countryCode?.value,
@@ -41,7 +42,7 @@ export function applePayProcessor( submitData ) {
 	return pending;
 }
 
-export async function stripeCardProcessor( submitData ) {
+export async function stripeCardProcessor( submitData, createNewSiteData ) {
 	const paymentMethodToken = await createStripePaymentMethodToken( {
 		...submitData,
 		country: select( 'wpcom' )?.getContactInfo?.()?.countryCode?.value,
@@ -50,6 +51,7 @@ export async function stripeCardProcessor( submitData ) {
 	const pending = submitStripeCardTransaction(
 		{
 			...submitData,
+			createNewSiteData,
 			country: select( 'wpcom' )?.getContactInfo?.()?.countryCode?.value,
 			postalCode: select( 'wpcom' )?.getContactInfo?.()?.postalCode?.value,
 			subdivisionCode: select( 'wpcom' )?.getContactInfo?.()?.state?.value,
@@ -67,10 +69,11 @@ export async function stripeCardProcessor( submitData ) {
 	return pending;
 }
 
-export async function existingCardProcessor( submitData ) {
+export async function existingCardProcessor( submitData, createNewSiteData ) {
 	const pending = submitExistingCardPayment(
 		{
 			...submitData,
+			createNewSiteData,
 			country: select( 'wpcom' )?.getContactInfo?.()?.countryCode?.value,
 			postalCode: select( 'wpcom' )?.getContactInfo?.()?.postalCode?.value,
 			subdivisionCode: select( 'wpcom' )?.getContactInfo?.()?.state?.value,
@@ -97,10 +100,11 @@ function createStripePaymentMethodToken( { stripe, name, country, postalCode } )
 	} );
 }
 
-export async function freePurchaseProcessor( submitData ) {
+export async function freePurchaseProcessor( submitData, createNewSiteData ) {
 	const pending = submitFreePurchaseTransaction(
 		{
 			...submitData,
+			createNewSiteData,
 			siteId: select( 'wpcom' )?.getSiteId?.(),
 			domainDetails: getDomainDetails( select ),
 			// this data is intentionally empty so we do not charge taxes
@@ -116,10 +120,11 @@ export async function freePurchaseProcessor( submitData ) {
 	return pending;
 }
 
-export async function fullCreditsProcessor( submitData ) {
+export async function fullCreditsProcessor( submitData, createNewSiteData ) {
 	const pending = submitCreditsTransaction(
 		{
 			...submitData,
+			createNewSiteData,
 			siteId: select( 'wpcom' )?.getSiteId?.(),
 			domainDetails: getDomainDetails( select ),
 			// this data is intentionally empty so we do not charge taxes
@@ -136,7 +141,7 @@ export async function fullCreditsProcessor( submitData ) {
 	return pending;
 }
 
-export async function payPalProcessor( submitData, getThankYouUrl, couponItem ) {
+export async function payPalProcessor( submitData, getThankYouUrl, couponItem, createNewSiteData ) {
 	const { protocol, hostname, port, pathname } = parseUrl( window.location.href, true );
 	const successUrl = formatUrl( {
 		protocol,
@@ -154,6 +159,7 @@ export async function payPalProcessor( submitData, getThankYouUrl, couponItem ) 
 	const pending = submitPayPalExpressRequest(
 		{
 			...submitData,
+			createNewSiteData,
 			successUrl,
 			cancelUrl,
 			siteId: select( 'wpcom' )?.getSiteId?.() ?? '',

--- a/client/my-sites/checkout/composite-checkout/types/paypal-express.ts
+++ b/client/my-sites/checkout/composite-checkout/types/paypal-express.ts
@@ -12,6 +12,7 @@ import {
 	WPCOMTransactionEndpointDomainDetails,
 	createTransactionEndpointCartFromLineItems,
 } from './transaction-endpoint';
+import { NewSiteParams } from '../wpcom/types/checkout-cart';
 
 export type PayPalExpressEndpoint = (
 	_: PayPalExpressEndpointRequestPayload
@@ -27,6 +28,7 @@ export type PayPalExpressEndpointRequestPayload = {
 };
 
 export function createPayPalExpressEndpointRequestPayloadFromLineItems( {
+	createNewSiteData,
 	successUrl,
 	cancelUrl,
 	siteId,
@@ -46,6 +48,7 @@ export function createPayPalExpressEndpointRequestPayloadFromLineItems( {
 	subdivisionCode: string;
 	domainDetails: WPCOMTransactionEndpointDomainDetails;
 	items: WPCOMCartItem[];
+	createNewSiteData?: NewSiteParams;
 } ): PayPalExpressEndpointRequestPayload {
 	return {
 		successUrl,
@@ -56,6 +59,7 @@ export function createPayPalExpressEndpointRequestPayloadFromLineItems( {
 			country,
 			postalCode,
 			subdivisionCode,
+			createNewSiteData,
 			items: items.filter( ( item ) => ! getNonProductWPCOMCartItemTypes().includes( item.type ) ),
 		} ),
 		country,

--- a/client/my-sites/checkout/composite-checkout/types/transaction-endpoint.ts
+++ b/client/my-sites/checkout/composite-checkout/types/transaction-endpoint.ts
@@ -9,6 +9,7 @@ import debugFactory from 'debug';
 import { getNonProductWPCOMCartItemTypes } from 'my-sites/checkout/composite-checkout/wpcom';
 import { WPCOMCartItem } from 'my-sites/checkout/composite-checkout/wpcom/types';
 import type { CartItemExtra } from 'lib/cart-values/types';
+import { NewSiteParams } from '../wpcom/types/checkout-cart';
 
 const debug = debugFactory( 'calypso:transaction-endpoint' );
 
@@ -57,6 +58,7 @@ export type WPCOMTransactionEndpointCart = {
 			subdivision_code?: string;
 		};
 	};
+	new_site_data?: NewSiteParams;
 };
 
 export type WPCOMTransactionEndpointDomainDetails = {
@@ -74,6 +76,7 @@ export type WPCOMTransactionEndpointDomainDetails = {
 // Create cart object as required by the WPCOM transactions endpoint
 // '/me/transactions/': WPCOM_JSON_API_Transactions_Endpoint
 export function createTransactionEndpointCartFromLineItems( {
+	createNewSiteData,
 	siteId,
 	couponId,
 	country,
@@ -81,6 +84,7 @@ export function createTransactionEndpointCartFromLineItems( {
 	subdivisionCode,
 	items,
 }: {
+	createNewSiteData?: NewSiteParams;
 	siteId: string;
 	couponId?: string;
 	country: string;
@@ -123,10 +127,12 @@ export function createTransactionEndpointCartFromLineItems( {
 				subdivision_code: subdivisionCode,
 			},
 		},
+		new_site_data: createNewSiteData,
 	};
 }
 
 export function createTransactionEndpointRequestPayloadFromLineItems( {
+	createNewSiteData,
 	siteId,
 	couponId,
 	country,
@@ -140,6 +146,7 @@ export function createTransactionEndpointRequestPayloadFromLineItems( {
 	storedDetailsId,
 	name,
 }: {
+	createNewSiteData?: NewSiteParams;
 	siteId: string;
 	couponId?: string;
 	country: string;
@@ -155,6 +162,7 @@ export function createTransactionEndpointRequestPayloadFromLineItems( {
 } ): WPCOMTransactionEndpointRequestPayload {
 	return {
 		cart: createTransactionEndpointCartFromLineItems( {
+			createNewSiteData,
 			siteId,
 			couponId: couponId || getCouponIdFromProducts( items ),
 			country,

--- a/client/my-sites/checkout/composite-checkout/wpcom/hooks/use-shopping-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/hooks/use-shopping-cart.ts
@@ -28,6 +28,7 @@ import {
 	CartLocation,
 } from '../types';
 import { translateResponseCartToWPCOMCart } from '../lib/translate-cart';
+import { NewSiteParams } from '../types/checkout-cart';
 
 const debug = debugFactory( 'composite-checkout-wpcom:shopping-cart-manager' );
 
@@ -308,6 +309,7 @@ export interface ShoppingCartManager {
 	variantRequestStatus: VariantRequestStatus;
 	variantSelectOverride: { uuid: string; overrideSelectedProductSlug: string }[];
 	responseCart: ResponseCart;
+	createNewSiteData: NewSiteParams;
 }
 
 /**
@@ -504,6 +506,7 @@ export function useShoppingCart(
 		variantRequestStatus,
 		variantSelectOverride,
 		responseCart,
+		createNewSiteData: cart.createNewSiteData,
 	} as ShoppingCartManager;
 }
 

--- a/client/my-sites/checkout/composite-checkout/wpcom/lib/translate-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/lib/translate-cart.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { translate } from 'i18n-calypso';
+import { isEmpty } from 'lodash';
 
 /**
  * Internal dependencies
@@ -44,6 +45,7 @@ export function translateResponseCartToWPCOMCart( serverCart: ResponseCart ): WP
 		coupon,
 		is_coupon_applied,
 		tax,
+		new_site_data,
 	} = serverCart;
 
 	const taxLineItem: CheckoutCartItem = {
@@ -113,6 +115,7 @@ export function translateResponseCartToWPCOMCart( serverCart: ResponseCart ): WP
 			.map( translateWpcomPaymentMethodToCheckoutPaymentMethod )
 			.filter( Boolean ),
 		couponCode: coupon,
+		...( ! isEmpty( new_site_data ) && { createNewSiteData: new_site_data } ),
 	};
 }
 

--- a/client/my-sites/checkout/composite-checkout/wpcom/types/backend/shopping-cart-endpoint.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/types/backend/shopping-cart-endpoint.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { isEmpty } from 'lodash';
+
+/**
  * Internal dependencies
  */
 import type { CartItemExtra } from 'lib/cart-values/types';
@@ -42,6 +47,7 @@ export interface RequestCart {
 	temporary: false;
 	extra: string;
 	is_update?: boolean;
+	new_site_data?: NewSiteParams;
 }
 
 /**
@@ -190,6 +196,7 @@ export function convertResponseCartToRequestCart( {
 	coupon,
 	is_coupon_applied,
 	tax,
+	new_site_data,
 }: ResponseCart ): RequestCart {
 	return {
 		products: products.map( convertResponseCartProductToRequestCartProduct ),
@@ -200,6 +207,7 @@ export function convertResponseCartToRequestCart( {
 		temporary: false,
 		tax,
 		extra: '', // TODO: fix this
+		...( ! isEmpty( new_site_data ) && { new_site_data } ),
 	} as RequestCart;
 }
 

--- a/client/my-sites/checkout/composite-checkout/wpcom/types/backend/shopping-cart-endpoint.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/types/backend/shopping-cart-endpoint.ts
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import type { CartItemExtra } from 'lib/cart-values/types';
+import { NewSiteParams } from '../checkout-cart';
 
 /**
  * There are three different concepts of "cart" relevant to the shopping cart endpoint:
@@ -84,6 +85,7 @@ export interface ResponseCart {
 		};
 		display_taxes: boolean;
 	};
+	new_site_data?: NewSiteParams;
 }
 
 export interface ResponseCartError {

--- a/client/my-sites/checkout/composite-checkout/wpcom/types/checkout-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/types/checkout-cart.ts
@@ -55,6 +55,34 @@ export type WPCOMCartCouponItem = CheckoutCartItem & {
 	};
 };
 
+export interface NewSiteParams {
+	blog_title: string;
+	options: {
+		designType?: string;
+		theme: 'pub/hever';
+		use_theme_annotation: false;
+		default_annotation_as_primary_fallback: true;
+		siteGoals?: string;
+		site_style?: string;
+		site_segment?: number;
+		site_vertical?: number;
+		site_vertical_name?: string;
+		site_information: {
+			title: string;
+		};
+		site_creation_flow: string;
+		timezone_string: string;
+		wpcom_coming_soon: 1 | 0;
+		in_page_builder?: boolean;
+		nux_import_engine?: string;
+		nux_import_from_url?: string;
+	};
+	public: 1 | -1;
+	validate: boolean;
+	blog_name: string;
+	find_available_url: boolean;
+}
+
 export interface WPCOMCart {
 	items: WPCOMCartItem[];
 	tax: CheckoutCartItem | null;
@@ -64,6 +92,7 @@ export interface WPCOMCart {
 	allowedPaymentMethods: CheckoutPaymentMethodSlug[];
 	credits: CheckoutCartItem;
 	couponCode: string | null;
+	createNewSiteData?: NewSiteParams;
 }
 
 export const emptyWPCOMCart = {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Persist the `new_site_data` property to the shopping cart when the siteless checkout feature is on.
* Pass  the `new_site_data` property to the transactions endpoint when the user completes the checkout.
* Does not allow to have more than 1 domain in the signup cart at a time
* Continuation of #42665

#### Testing instructions

* Requires some backend changes that are not already in place, this will be updated once the changes are ready.