### PR TITLE
Jetpack Cloud: track new events

### DIFF
--- a/client/landing/jetpack-cloud/components/log-item/index.tsx
+++ b/client/landing/jetpack-cloud/components/log-item/index.tsx
@@ -22,6 +22,7 @@ export interface Props {
 	summary?: string | ReactNode;
 	expandedSummary?: string | ReactNode;
 	clickableHeader?: boolean;
+	onClick?: Function;
 }
 
 class LogItem extends React.PureComponent< Props > {
@@ -47,6 +48,7 @@ class LogItem extends React.PureComponent< Props > {
 			className,
 			expandedSummary,
 			summary,
+			onClick,
 		} = this.props;
 		return (
 			<FoldableCard
@@ -56,6 +58,7 @@ class LogItem extends React.PureComponent< Props > {
 				expandedSummary={ expandedSummary }
 				summary={ summary }
 				clickableHeader={ clickableHeader }
+				onClick={ onClick }
 			>
 				{ children }
 			</FoldableCard>

--- a/client/landing/jetpack-cloud/components/masterbar/index.jsx
+++ b/client/landing/jetpack-cloud/components/masterbar/index.jsx
@@ -61,7 +61,7 @@ const JetpackCloudMasterBar = () => {
 			<Item
 				tipTarget="me"
 				url="#" // @todo: add a correct URL
-				onClick={ ( e ) => trackedToggle( e ) }
+				onClick={ trackedToggle }
 				icon="user-circle"
 				className={ classnames( 'masterbar__item-me', {
 					'masterbar__item-me--open': isOpen,

--- a/client/landing/jetpack-cloud/components/masterbar/index.jsx
+++ b/client/landing/jetpack-cloud/components/masterbar/index.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-import { useSelector } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
 import classnames from 'classnames';
 
@@ -11,11 +10,14 @@ import classnames from 'classnames';
  */
 import { getDocumentHeadTitle } from 'state/document-head/selectors';
 import getCurrentRoute from 'state/selectors/get-current-route';
+import { useSelector } from 'react-redux';
 import Item from 'layout/masterbar/item';
 import JetpackLogo from 'components/jetpack-logo';
 import Masterbar from 'layout/masterbar/masterbar';
 import ProfileDropdown from 'landing/jetpack-cloud/components/profile-dropdown';
 import { useBreakpoint } from '@automattic/viewport-react';
+import useTrackCallback from 'landing/jetpack-cloud/lib/use-track-callback';
+
 /**
  * Style dependencies
  */
@@ -39,6 +41,9 @@ const JetpackCloudMasterBar = () => {
 	const isNarrow = useBreakpoint( '<660px' );
 	const isExteriorPage = /^\/(?:backup|scan)\/[^/]*$/.test( currentRoute );
 	const { isOpen, close, toggle } = useOpenClose();
+	const trackedToggle = useTrackCallback( 'calypso_jetpack_masterbar_profile_toggle', toggle );
+	const trackedClose = useTrackCallback( 'calypso_jetpack_masterbar_profile_close', close );
+
 	return (
 		<Masterbar
 			className="is-jetpack-cloud-masterbar" // eslint-disable-line wpcalypso/jsx-classname-namespace
@@ -56,14 +61,14 @@ const JetpackCloudMasterBar = () => {
 			<Item
 				tipTarget="me"
 				url="#" // @todo: add a correct URL
-				onClick={ toggle }
+				onClick={ ( e ) => trackedToggle( e ) }
 				icon="user-circle"
 				className={ classnames( 'masterbar__item-me', {
 					'masterbar__item-me--open': isOpen,
 				} ) }
 				tooltip={ translate( 'Log out of Jetpack Cloud' ) }
 			>
-				<ProfileDropdown isOpen={ isOpen } close={ close } />
+				<ProfileDropdown isOpen={ isOpen } close={ trackedClose } />
 			</Item>
 		</Masterbar>
 	);

--- a/client/landing/jetpack-cloud/components/masterbar/index.jsx
+++ b/client/landing/jetpack-cloud/components/masterbar/index.jsx
@@ -41,8 +41,8 @@ const JetpackCloudMasterBar = () => {
 	const isNarrow = useBreakpoint( '<660px' );
 	const isExteriorPage = /^\/(?:backup|scan)\/[^/]*$/.test( currentRoute );
 	const { isOpen, close, toggle } = useOpenClose();
-	const trackedToggle = useTrackCallback( 'calypso_jetpack_masterbar_profile_toggle', toggle );
-	const trackedClose = useTrackCallback( 'calypso_jetpack_masterbar_profile_close', close );
+	const trackedToggle = useTrackCallback( toggle, 'calypso_jetpack_masterbar_profile_toggle' );
+	const trackedClose = useTrackCallback( close, 'calypso_jetpack_masterbar_profile_close' );
 
 	return (
 		<Masterbar

--- a/client/landing/jetpack-cloud/components/profile-dropdown/index.tsx
+++ b/client/landing/jetpack-cloud/components/profile-dropdown/index.tsx
@@ -12,6 +12,7 @@ import { Button } from '@automattic/components';
 import Gravatar from 'components/gravatar';
 import userUtilities from 'lib/user/utils';
 import { getCurrentUser } from 'state/current-user/selectors';
+import useTrackCallback from 'landing/jetpack-cloud/lib/use-track-callback';
 
 /**
  * Style dependencies
@@ -66,11 +67,12 @@ interface Props {
 const ProfileDropdown: React.FC< Props > = ( { isOpen, close } ) => {
 	const translate = useTranslate();
 	const user = useSelector( getCurrentUser );
-	// @todo: track event (what type?)
 	const logOut = ( e: MouseEvent ) => {
 		e.preventDefault();
+		e.stopPropagation();
 		userUtilities.logout();
 	};
+	const trackedLogOut = useTrackCallback( 'calypso_jetpack_settings_masterbar_logout', logOut );
 	const ref = React.useRef( null );
 	useCallIfOutOfContext( ref, close );
 
@@ -97,7 +99,7 @@ const ProfileDropdown: React.FC< Props > = ( { isOpen, close } ) => {
 
 						<div className="profile-dropdown__logout-username">
 							<span>{ user.username }</span>
-							<Button borderless onClick={ logOut }>
+							<Button borderless onClick={ trackedLogOut }>
 								{ translate( 'Log out' ) }
 							</Button>
 						</div>

--- a/client/landing/jetpack-cloud/components/profile-dropdown/index.tsx
+++ b/client/landing/jetpack-cloud/components/profile-dropdown/index.tsx
@@ -72,7 +72,7 @@ const ProfileDropdown: React.FC< Props > = ( { isOpen, close } ) => {
 		e.stopPropagation();
 		userUtilities.logout();
 	};
-	const trackedLogOut = useTrackCallback( 'calypso_jetpack_settings_masterbar_logout', logOut );
+	const trackedLogOut = useTrackCallback( logOut, 'calypso_jetpack_settings_masterbar_logout' );
 	const ref = React.useRef( null );
 	// We don't want to call close if it's already closed because we would
 	// track unnecessary events.

--- a/client/landing/jetpack-cloud/components/profile-dropdown/index.tsx
+++ b/client/landing/jetpack-cloud/components/profile-dropdown/index.tsx
@@ -74,7 +74,12 @@ const ProfileDropdown: React.FC< Props > = ( { isOpen, close } ) => {
 	};
 	const trackedLogOut = useTrackCallback( 'calypso_jetpack_settings_masterbar_logout', logOut );
 	const ref = React.useRef( null );
-	useCallIfOutOfContext( ref, close );
+	// We don't want to call close if it's already closed because we would
+	// track unnecessary events.
+	const closeOnlyIfIsOpen = React.useCallback( () => {
+		isOpen && close();
+	}, [ close, isOpen ] );
+	useCallIfOutOfContext( ref, closeOnlyIfIsOpen );
 
 	return (
 		<div className="profile-dropdown" ref={ ref }>

--- a/client/landing/jetpack-cloud/components/scan-threats/index.tsx
+++ b/client/landing/jetpack-cloud/components/scan-threats/index.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { useDispatch } from 'react-redux';
 import { numberFormat, translate } from 'i18n-calypso';
 import { Button } from '@automattic/components';
+import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -23,6 +24,7 @@ import { recordTracksEvent } from 'state/analytics/actions';
 import contactSupportUrl from 'landing/jetpack-cloud/lib/contact-support-url';
 import { useThreats } from 'landing/jetpack-cloud/lib/use-threats';
 import { triggerScanRun } from 'landing/jetpack-cloud/lib/trigger-scan-run';
+import useTrackCallback from 'landing/jetpack-cloud/lib/use-track-callback';
 
 /**
  * Style dependencies
@@ -159,13 +161,7 @@ const ScanThreats = ( { error, site, threats }: Props ) => {
 		[ updatingThreats ]
 	);
 
-	const onOpenTrackEvent = React.useCallback( () => {
-		dispatch(
-			recordTracksEvent( `calypso_jetpack_scan_threat_itemtoggle`, {
-				site_id: site.ID,
-			} )
-		);
-	}, [ dispatch, site ] );
+	const onOpenTrackEvent = useTrackCallback( 'calypso_jetpack_scan_threat_itemtoggle', noop );
 
 	return (
 		<>

--- a/client/landing/jetpack-cloud/components/scan-threats/index.tsx
+++ b/client/landing/jetpack-cloud/components/scan-threats/index.tsx
@@ -159,6 +159,14 @@ const ScanThreats = ( { error, site, threats }: Props ) => {
 		[ updatingThreats ]
 	);
 
+	const onOpenTrackEvent = React.useCallback( () => {
+		dispatch(
+			recordTracksEvent( `calypso_jetpack_scan_threat_itemtoggle`, {
+				site_id: site.ID,
+			} )
+		);
+	}, [ dispatch, site ] );
+
 	return (
 		<>
 			<SecurityIcon icon="error" />
@@ -217,6 +225,7 @@ const ScanThreats = ( { error, site, threats }: Props ) => {
 						isFixing={ isFixing( threat ) }
 						contactSupportUrl={ contactSupportUrl( site.URL ) }
 						isPlaceholder={ false }
+						onOpen={ onOpenTrackEvent }
 					/>
 				) ) }
 			</div>
@@ -243,7 +252,6 @@ const ScanThreats = ( { error, site, threats }: Props ) => {
 					showDialog={ showThreatDialog }
 					onCloseDialog={ closeDialog }
 					onConfirmation={ confirmAction }
-					siteId={ site.ID }
 					siteName={ site.name }
 					threat={ selectedThreat }
 					action={ actionToPerform }
@@ -252,7 +260,6 @@ const ScanThreats = ( { error, site, threats }: Props ) => {
 			<FixAllThreatsDialog
 				threats={ allFixableThreats }
 				showDialog={ showFixAllThreatsDialog }
-				siteId={ site.ID }
 				onCloseDialog={ () => setShowFixAllThreatsDialog( false ) }
 				onConfirmation={ confirmFixAllThreats }
 			/>

--- a/client/landing/jetpack-cloud/components/scan-threats/index.tsx
+++ b/client/landing/jetpack-cloud/components/scan-threats/index.tsx
@@ -5,7 +5,6 @@ import React from 'react';
 import { useDispatch } from 'react-redux';
 import { numberFormat, translate } from 'i18n-calypso';
 import { Button } from '@automattic/components';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -24,7 +23,6 @@ import { recordTracksEvent } from 'state/analytics/actions';
 import contactSupportUrl from 'landing/jetpack-cloud/lib/contact-support-url';
 import { useThreats } from 'landing/jetpack-cloud/lib/use-threats';
 import { triggerScanRun } from 'landing/jetpack-cloud/lib/trigger-scan-run';
-import useTrackCallback from 'landing/jetpack-cloud/lib/use-track-callback';
 
 /**
  * Style dependencies
@@ -161,8 +159,6 @@ const ScanThreats = ( { error, site, threats }: Props ) => {
 		[ updatingThreats ]
 	);
 
-	const onOpenTrackEvent = useTrackCallback( 'calypso_jetpack_scan_threat_itemtoggle', noop );
-
 	return (
 		<>
 			<SecurityIcon icon="error" />
@@ -221,7 +217,6 @@ const ScanThreats = ( { error, site, threats }: Props ) => {
 						isFixing={ isFixing( threat ) }
 						contactSupportUrl={ contactSupportUrl( site.URL ) }
 						isPlaceholder={ false }
-						onOpen={ onOpenTrackEvent }
 					/>
 				) ) }
 			</div>

--- a/client/landing/jetpack-cloud/components/threat-item/index.tsx
+++ b/client/landing/jetpack-cloud/components/threat-item/index.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { translate } from 'i18n-calypso';
 import classnames from 'classnames';
 import { Button } from '@automattic/components';
+import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -15,6 +16,7 @@ import ThreatItemHeader from 'landing/jetpack-cloud/components/threat-item-heade
 import ThreatItemSubheader from 'landing/jetpack-cloud/components/threat-item-subheader';
 import { Threat } from 'landing/jetpack-cloud/components/threat-item/types';
 import { getThreatFix } from 'landing/jetpack-cloud/components/threat-item/utils';
+import useTrackCallback from 'landing/jetpack-cloud/lib/use-track-callback';
 
 /**
  * Style dependencies
@@ -28,7 +30,6 @@ interface Props {
 	onIgnoreThreat?: Function;
 	isFixing: boolean;
 	contactSupportUrl?: string;
-	onOpen?: Function;
 }
 
 const ThreatItem: React.FC< Props > = ( {
@@ -38,7 +39,6 @@ const ThreatItem: React.FC< Props > = ( {
 	onIgnoreThreat,
 	isFixing,
 	contactSupportUrl,
-	onOpen,
 } ) => {
 	/**
 	 * Render a CTA button. Currently, this button is rendered three
@@ -93,6 +93,11 @@ const ThreatItem: React.FC< Props > = ( {
 		[ threat ]
 	);
 
+	const onOpenTrackEvent = useTrackCallback( noop, 'calypso_jetpack_scan_threat_itemtoggle', {
+		threat_signature: threat.signature,
+		section: window.location.pathname.includes( '/scan/history' ) ? 'History' : 'Scanner',
+	} );
+
 	if ( isPlaceholder ) {
 		return (
 			<LogItem
@@ -121,7 +126,7 @@ const ThreatItem: React.FC< Props > = ( {
 				: {} ) }
 			{ ...( threat.status === 'current' ? { highlight: 'error' } : {} ) }
 			clickableHeader={ true }
-			onClick={ onOpen }
+			onClick={ onOpenTrackEvent }
 		>
 			<ThreatDescription
 				status={ threat.status }

--- a/client/landing/jetpack-cloud/components/threat-item/index.tsx
+++ b/client/landing/jetpack-cloud/components/threat-item/index.tsx
@@ -28,6 +28,7 @@ interface Props {
 	onIgnoreThreat?: Function;
 	isFixing: boolean;
 	contactSupportUrl?: string;
+	onOpen?: Function;
 }
 
 const ThreatItem: React.FC< Props > = ( {
@@ -37,6 +38,7 @@ const ThreatItem: React.FC< Props > = ( {
 	onIgnoreThreat,
 	isFixing,
 	contactSupportUrl,
+	onOpen,
 } ) => {
 	/**
 	 * Render a CTA button. Currently, this button is rendered three
@@ -119,6 +121,7 @@ const ThreatItem: React.FC< Props > = ( {
 				: {} ) }
 			{ ...( threat.status === 'current' ? { highlight: 'error' } : {} ) }
 			clickableHeader={ true }
+			onClick={ onOpen }
 		>
 			<ThreatDescription
 				status={ threat.status }

--- a/client/landing/jetpack-cloud/lib/use-track-callback.ts
+++ b/client/landing/jetpack-cloud/lib/use-track-callback.ts
@@ -11,7 +11,7 @@ import { noop } from 'lodash';
 import { recordTracksEvent } from 'state/analytics/actions';
 import getSelectedSiteId from 'state/ui/selectors/get-selected-site-id';
 
-const useTrackCallback = ( eventName: string, callback: Function = noop ) => {
+const useTrackCallback = ( callback: Function = noop, eventName: string, eventProps = {} ) => {
 	const dispatch = useDispatch();
 	const siteId = useSelector( getSelectedSiteId );
 	const trackedCallback = React.useCallback(
@@ -19,6 +19,7 @@ const useTrackCallback = ( eventName: string, callback: Function = noop ) => {
 			dispatch(
 				recordTracksEvent( eventName, {
 					site_id: siteId,
+					...eventProps,
 				} )
 			);
 			callback( ...rest );

--- a/client/landing/jetpack-cloud/lib/use-track-callback.ts
+++ b/client/landing/jetpack-cloud/lib/use-track-callback.ts
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { recordTracksEvent } from 'state/analytics/actions';
+import getSelectedSiteId from 'state/ui/selectors/get-selected-site-id';
+
+const useTrackCallback = ( eventName: string, callback: Function ) => {
+	const dispatch = useDispatch();
+	const siteId = useSelector( getSelectedSiteId );
+	const trackedCallback = React.useCallback(
+		( ...rest ) => {
+			dispatch(
+				recordTracksEvent( eventName, {
+					site_id: siteId,
+				} )
+			);
+			callback( ...rest );
+		},
+		[ callback, eventName, dispatch, siteId ]
+	);
+	return trackedCallback;
+};
+
+export default useTrackCallback;

--- a/client/landing/jetpack-cloud/lib/use-track-callback.ts
+++ b/client/landing/jetpack-cloud/lib/use-track-callback.ts
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -10,7 +11,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { recordTracksEvent } from 'state/analytics/actions';
 import getSelectedSiteId from 'state/ui/selectors/get-selected-site-id';
 
-const useTrackCallback = ( eventName: string, callback: Function ) => {
+const useTrackCallback = ( eventName: string, callback: Function = noop ) => {
 	const dispatch = useDispatch();
 	const siteId = useSelector( getSelectedSiteId );
 	const trackedCallback = React.useCallback(

--- a/client/landing/jetpack-cloud/sections/backups/rewind-flow/download.tsx
+++ b/client/landing/jetpack-cloud/sections/backups/rewind-flow/download.tsx
@@ -4,6 +4,7 @@
 import { useDispatch, useSelector } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
 import React, { FunctionComponent, useCallback, useState } from 'react';
+import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -52,8 +53,8 @@ const BackupDownloadFlow: FunctionComponent< Props > = ( {
 		[ dispatch, rewindConfig, rewindId, siteId ]
 	);
 	const trackedRequestDownload = useTrackCallback(
-		'calypso_jetpack_backup_download_click',
-		requestDownload
+		requestDownload,
+		'calypso_jetpack_backup_download_click'
 	);
 
 	const renderConfirm = () => (
@@ -153,7 +154,7 @@ const BackupDownloadFlow: FunctionComponent< Props > = ( {
 					}
 			  );
 
-	const trackFileDownload = useTrackCallback( 'calypso_jetpack_backup_file_download' );
+	const trackFileDownload = useTrackCallback( noop, 'calypso_jetpack_backup_file_download' );
 	const renderReady = () => (
 		<>
 			<div className="rewind-flow__header">

--- a/client/landing/jetpack-cloud/sections/backups/rewind-flow/download.tsx
+++ b/client/landing/jetpack-cloud/sections/backups/rewind-flow/download.tsx
@@ -20,6 +20,7 @@ import ProgressBar from './progress-bar';
 import QueryRewindBackupStatus from 'components/data/query-rewind-backup-status';
 import RewindConfigEditor from './rewind-config-editor';
 import RewindFlowNotice, { RewindFlowNoticeLevel } from './rewind-flow-notice';
+import useTrackCallback from 'landing/jetpack-cloud/lib/use-track-callback';
 
 interface Props {
 	backupDisplayDate: string;
@@ -49,6 +50,10 @@ const BackupDownloadFlow: FunctionComponent< Props > = ( {
 	const requestDownload = useCallback(
 		() => dispatch( rewindBackup( siteId, rewindId, rewindConfig ) ),
 		[ dispatch, rewindConfig, rewindId, siteId ]
+	);
+	const trackedRequestDownload = useTrackCallback(
+		'calypso_jetpack_backup_download_click',
+		requestDownload
 	);
 
 	const renderConfirm = () => (
@@ -84,7 +89,7 @@ const BackupDownloadFlow: FunctionComponent< Props > = ( {
 			<Button
 				className="rewind-flow__primary-button"
 				primary
-				onClick={ requestDownload }
+				onClick={ trackedRequestDownload }
 				disabled={ Object.values( rewindConfig ).every( ( setting ) => ! setting ) }
 			>
 				{ translate( 'Create downloadable file' ) }
@@ -148,6 +153,7 @@ const BackupDownloadFlow: FunctionComponent< Props > = ( {
 					}
 			  );
 
+	const trackFileDownload = useTrackCallback( 'calypso_jetpack_backup_file_download' );
 	const renderReady = () => (
 		<>
 			<div className="rewind-flow__header">
@@ -160,7 +166,12 @@ const BackupDownloadFlow: FunctionComponent< Props > = ( {
 				{ translate( 'Your backup is now available for download.' ) }
 			</h3>
 			<p className="rewind-flow__info">{ getReadyCopy() }</p>
-			<Button href={ downloadUrl } primary className="rewind-flow__primary-button">
+			<Button
+				href={ downloadUrl }
+				primary
+				className="rewind-flow__primary-button"
+				onClick={ trackFileDownload }
+			>
 				{ translate( 'Download file' ) }
 			</Button>
 			<CheckYourEmail
@@ -185,7 +196,10 @@ const BackupDownloadFlow: FunctionComponent< Props > = ( {
 					{
 						components: {
 							button: (
-								<Button className="rewind-flow__error-retry-button" onClick={ requestDownload } />
+								<Button
+									className="rewind-flow__error-retry-button"
+									onClick={ trackedRequestDownload }
+								/>
 							),
 						},
 					}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The goal is to track events that we aren't currently tracking.

New events:

- `calypso_jetpack_settings_masterbar_logout`: happens when a user logs out of Jetpack Cloud 
![image](https://user-images.githubusercontent.com/3418513/83302976-a31cd000-a1d2-11ea-988a-68a3ca076185.png)

- `calypso_jetpack_masterbar_profile_toggle`: happens when a user clicks its profile avatar to open the log out dropdown 
![image](https://user-images.githubusercontent.com/3418513/83303011-b7f96380-a1d2-11ea-9f67-9284947a93db.png)

- `calypso_jetpack_masterbar_profile_close`: happens when the profile dropdown gets closed because the user clicked outside of it or because it hit the Escape key 
![image](https://user-images.githubusercontent.com/3418513/83303056-d0697e00-a1d2-11ea-9862-4f11dc7e8277.png)

- `calypso_jetpack_scan_threat_itemtoggle`: happens when the user clicks on the header of a threat item 
![image](https://user-images.githubusercontent.com/3418513/83303137-e70fd500-a1d2-11ea-9fb5-75013999811c.png)

- `calypso_jetpack_backup_download_click`: happens when the user clicks the `[Create downloadable file]` button 
![image](https://user-images.githubusercontent.com/3418513/83303172-f5f68780-a1d2-11ea-8940-e7126a0e687d.png)

- `calypso_jetpack_backup_file_download`: happens when the user clicks the `[Download file]` button to actually download the backup file 
![image](https://user-images.githubusercontent.com/3418513/83303201-0575d080-a1d3-11ea-92b9-f4236ab91b9c.png)


#### Testing instructions

* Go to `http://jetpack.cloud.localhost:3000/` and select a site that has Scan (with at least one threat) and Backup enabled
* Go to Scan -> Scanner 
* Click on the header of a threat item
* Verify the `calypso_jetpack_scan_threat_itemtoggle` event was tracked
* Go to Backup -> Latest backups
* Select any day with a backup
* Click on "Download backup"
* Click on the `[Create downloadable file]` button
* Verify the `calypso_jetpack_backup_download_click` event was tracked
* Wait for the process to finish and then click on the `[Download file]` button
* Verify the `calypso_jetpack_backup_file_download` event was tracked
* Click on the profile avatar
* Verify the `calypso_jetpack_masterbar_profile_toggle` event was tracked
* Click outside of the profile (it should be closed)
* Verify the `calypso_jetpack_masterbar_profile_close` event was tracked
* Click again outside
* Verify the `calypso_jetpack_masterbar_profile_close` event was **not** tracked this time
* Open the profile dropdown again
* Click on Log out
* Verify the `calypso_jetpack_settings_masterbar_logout` event was tracked

Fixes 1169345694087188-as-1178050840715001
