### PR TITLE
Changes link in My Plan depending on Cloud eligibility

### DIFF
--- a/client/my-sites/plans/current-plan/purchases-listing.jsx
+++ b/client/my-sites/plans/current-plan/purchases-listing.jsx
@@ -264,7 +264,7 @@ class PurchasesListing extends Component {
 		let serviceButton = null;
 		if ( isJetpackBackup( purchase ) ) {
 			const target = isCloudEligible
-				? `https://cloud.jetpack.com/backups/${ site }`
+				? `https://cloud.jetpack.com/backup/${ site }`
 				: `/activity-log/${ site }?group=rewind`;
 			serviceButton = (
 				<Button href={ target } compact>

--- a/client/my-sites/plans/current-plan/purchases-listing.jsx
+++ b/client/my-sites/plans/current-plan/purchases-listing.jsx
@@ -18,6 +18,7 @@ import {
 } from 'state/sites/plans/selectors';
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { getSitePurchases } from 'state/purchases/selectors';
+import isJetpackCloudEligible from 'state/selectors/is-jetpack-cloud-eligible';
 import { Button, Card } from '@automattic/components';
 import MyPlanCard from './my-plan-card';
 import QuerySites from 'components/data/query-sites';
@@ -46,6 +47,8 @@ import {
 	PRODUCT_JETPACK_SCAN,
 	PRODUCT_JETPACK_BACKUP_REALTIME,
 } from 'lib/products-values/constants';
+import Gridicon from 'components/gridicon';
+import QueryRewindState from 'components/data/query-rewind-state';
 
 class PurchasesListing extends Component {
 	static propTypes = {
@@ -66,9 +69,9 @@ class PurchasesListing extends Component {
 	};
 
 	isLoading() {
-		const { currentPlan, selectedSite, isRequestingPlans } = this.props;
+		const { currentPlan, selectedSite, isRequestingPlans, isCloudEligible } = this.props;
 
-		return ! currentPlan || ! selectedSite || isRequestingPlans;
+		return ! currentPlan || ! selectedSite || isRequestingPlans || undefined === isCloudEligible;
 	}
 
 	isFreePlan( purchase ) {
@@ -248,20 +251,35 @@ class PurchasesListing extends Component {
 	}
 
 	getProductActionButtons( purchase ) {
-		const { translate, selectedSiteSlug: site } = this.props;
+		const { translate, selectedSiteSlug: site, isCloudEligible } = this.props;
 		const actionButton = this.getActionButton( purchase );
+
+		const maybeExternalIcon = isCloudEligible && (
+			<>
+				&nbsp;
+				<Gridicon icon="external" />
+			</>
+		);
 
 		let serviceButton = null;
 		if ( isJetpackBackup( purchase ) ) {
+			const target = isCloudEligible
+				? `https://cloud.jetpack.com/backups/${ site }`
+				: `/activity-log/${ site }?group=rewind`;
 			serviceButton = (
-				<Button href={ `/activity-log/${ site }?group=rewind` } compact>
+				<Button href={ target } compact>
 					{ translate( 'View backups' ) }
+					{ maybeExternalIcon }
 				</Button>
 			);
 		} else if ( isJetpackScan( purchase ) ) {
+			const target = isCloudEligible
+				? `https://cloud.jetpack.com/scan/${ site }`
+				: `/activity-log/${ site }`;
 			serviceButton = (
-				<Button href={ `/activity-log/${ site }` } compact>
+				<Button href={ target } compact>
 					{ translate( 'View scan results' ) }
+					{ maybeExternalIcon }
 				</Button>
 			);
 		}
@@ -337,6 +355,7 @@ class PurchasesListing extends Component {
 				<QuerySites siteId={ selectedSiteId } />
 				<QuerySitePlans siteId={ selectedSiteId } />
 				<QuerySitePurchases siteId={ selectedSiteId } />
+				<QueryRewindState siteId={ selectedSiteId } />
 
 				{ this.renderPlan() }
 				{ this.renderProducts() }
@@ -357,5 +376,6 @@ export default connect( ( state ) => {
 		selectedSite: getSelectedSite( state ),
 		selectedSiteId,
 		selectedSiteSlug: getSelectedSiteSlug( state ),
+		isCloudEligible: isJetpackCloudEligible( state, selectedSiteId ),
 	};
 } )( localize( withLocalizedMoment( PurchasesListing ) ) );

--- a/client/state/data-layer/wpcom/sites/rewind/api-transformer.js
+++ b/client/state/data-layer/wpcom/sites/rewind/api-transformer.js
@@ -64,6 +64,7 @@ export function transformApi( data ) {
 					? Date.parse( data.last_updated )
 					: data.last_updated * 1000
 			),
+			hasCloud: data.has_cloud,
 		},
 		data.can_autoconfigure && { canAutoconfigure: !! data.can_autoconfigure },
 		data.credentials && { credentials: data.credentials.map( transformCredential ) },

--- a/client/state/data-layer/wpcom/sites/rewind/schema.js
+++ b/client/state/data-layer/wpcom/sites/rewind/schema.js
@@ -79,6 +79,9 @@ export const unavailable = stateSchema( 'unavailable', {
 			type: 'string',
 		},
 		last_updated: { oneOf: [ { type: 'integer' }, { type: 'string', format: 'date-time' } ] },
+		has_cloud: {
+			type: 'boolean',
+		},
 	},
 	required: [ 'state', 'last_updated' ],
 } );
@@ -95,6 +98,9 @@ export const inactive = stateSchema( 'inactive', {
 			items: credential,
 		},
 		last_updated: { oneOf: [ { type: 'integer' }, { type: 'string', format: 'date-time' } ] },
+		has_cloud: {
+			type: 'boolean',
+		},
 	},
 	required: [ 'state', 'last_updated' ],
 } );
@@ -107,6 +113,9 @@ export const awaitingCredentials = stateSchema( 'awaiting_credentials', {
 			pattern: '^awaiting_credentials$',
 		},
 		last_updated: { oneOf: [ { type: 'integer' }, { type: 'string', format: 'date-time' } ] },
+		has_cloud: {
+			type: 'boolean',
+		},
 	},
 	required: [ 'state', 'last_updated' ],
 } );
@@ -123,6 +132,9 @@ export const provisioning = stateSchema( 'provisioning', {
 			items: credential,
 		},
 		last_updated: { oneOf: [ { type: 'integer' }, { type: 'string', format: 'date-time' } ] },
+		has_cloud: {
+			type: 'boolean',
+		},
 	},
 	required: [ 'state', 'last_updated' ],
 } );
@@ -150,6 +162,9 @@ export const active = stateSchema( 'active', {
 			},
 		},
 		last_updated: { oneOf: [ { type: 'integer' }, { type: 'string', format: 'date-time' } ] },
+		has_cloud: {
+			type: 'boolean',
+		},
 	},
 	required: [ 'state', 'last_updated' ],
 } );

--- a/client/state/selectors/is-jetpack-cloud-eligible.js
+++ b/client/state/selectors/is-jetpack-cloud-eligible.js
@@ -1,0 +1,10 @@
+/**
+ * Indicates whether a site is eligible for Jetpack Cloud.
+ *
+ * @param {object} state Global state tree
+ * @param {number|string} siteId the site ID
+ * @returns {boolean|undefined} true is the site is eligible, undefined if still loading.
+ */
+export default function isJetpackCloudEligible( state, siteId ) {
+	return state.rewind?.[ siteId ]?.state?.hasCloud;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Pulls field added in D44110 into Redux state and switches the link URL based on that.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to a site's My Plan page that has Backup or Scan.
* Check link for site that is and is not eligible.

Expected: Site that is eligible has an external link to Cloud, site that doesn't goes to Activity Log.

<img width="315" alt="Screen Shot 2020-05-29 at 4 29 38 PM" src="https://user-images.githubusercontent.com/1760168/83303138-854b6d00-a1ca-11ea-8e99-6d099c691434.png">

Fixes 1169345694087188-as-1177440981073469
