### PR TITLE
composite-checkout: Refactor contact validation to separate out side effects

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -73,7 +73,6 @@ import {
 } from './payment-method-processors';
 import { useGetThankYouUrl } from './use-get-thank-you-url';
 import createAnalyticsEventHandler from './record-analytics';
-import createContactValidationCallback from './contact-validation';
 import { fillInSingleCartItemAttributes } from 'lib/cart-values';
 import {
 	hasGoogleApps,
@@ -109,23 +108,6 @@ const wpcom = wp.undocumented();
 const wpcomGetCart = ( ...args ) => wpcom.getCart( ...args );
 const wpcomSetCart = ( ...args ) => wpcom.setCart( ...args );
 const wpcomGetStoredCards = ( ...args ) => wpcom.getStoredCards( ...args );
-const wpcomValidateDomainContactInformation = ( ...args ) =>
-	new Promise( ( resolve, reject ) => {
-		// Promisify this function
-		wpcom.validateDomainContactInformation(
-			...args,
-			( httpErrors, data ) => {
-				if ( httpErrors ) {
-					return reject( httpErrors );
-				}
-				resolve( data );
-			},
-			{ apiVersion: '1.2' }
-		);
-	} );
-
-const wpcomValidateGSuiteContactInformation = ( ...args ) =>
-	wpcom.validateGoogleAppsContactInformation( ...args );
 
 export default function CompositeCheckout( {
 	siteSlug,
@@ -134,7 +116,6 @@ export default function CompositeCheckout( {
 	getCart,
 	setCart,
 	getStoredCards,
-	validateDomainContactDetails,
 	allowedPaymentMethods,
 	onlyLoadPaymentMethods,
 	overrideCountryList,
@@ -405,20 +386,6 @@ export default function CompositeCheckout( {
 				serverAllowedPaymentMethods,
 		  } );
 
-	const domainContactValidationCallback = createContactValidationCallback( {
-		type: 'domains',
-		validateContactFunction: validateDomainContactDetails || wpcomValidateDomainContactInformation,
-		recordEvent,
-		showErrorMessage: showErrorMessageBriefly,
-	} );
-
-	const gSuiteContactValidationCallback = createContactValidationCallback( {
-		type: 'gsuite',
-		validateContactFunction: wpcomValidateGSuiteContactInformation,
-		recordEvent,
-		showErrorMessage: showErrorMessageBriefly,
-	} );
-
 	const renderDomainContactFields = (
 		domainNames,
 		contactDetails,
@@ -566,13 +533,12 @@ export default function CompositeCheckout( {
 					renderDomainContactFields={ renderDomainContactFields }
 					variantSelectOverride={ variantSelectOverride }
 					getItemVariants={ getItemVariants }
-					domainContactValidationCallback={ domainContactValidationCallback }
-					gSuiteContactValidationCallback={ gSuiteContactValidationCallback }
 					responseCart={ responseCart }
 					addItemToCart={ addItemWithEssentialProperties }
 					subtotal={ subtotal }
 					isCartPendingUpdate={ isCartPendingUpdate }
 					CheckoutTerms={ CheckoutTerms }
+					showErrorMessageBriefly={ showErrorMessageBriefly }
 				/>
 			</CheckoutProvider>
 		</React.Fragment>

--- a/client/my-sites/checkout/composite-checkout/contact-validation.js
+++ b/client/my-sites/checkout/composite-checkout/contact-validation.js
@@ -90,7 +90,7 @@ export async function getDomainValidationResult( items, contactInfo ) {
 		.filter( isLineItemADomain )
 		.map( ( domainItem ) => domainItem.wpcom_meta?.meta ?? '' );
 	const formattedContactDetails = prepareContactDetailsForValidation( 'domains', contactInfo );
-	return await wpcomValidateDomainContactInformation( formattedContactDetails, domainNames );
+	return wpcomValidateDomainContactInformation( formattedContactDetails, domainNames );
 }
 
 export async function getGSuiteValidationResult( items, contactInfo ) {
@@ -98,5 +98,5 @@ export async function getGSuiteValidationResult( items, contactInfo ) {
 		.filter( ( item ) => !! item.wpcom_meta?.extra?.google_apps_users?.length )
 		.map( ( item ) => item.wpcom_meta?.meta ?? '' );
 	const formattedContactDetails = prepareContactDetailsForValidation( 'gsuite', contactInfo );
-	return await wpcomValidateGSuiteContactInformation( formattedContactDetails, domainNames );
+	return wpcomValidateGSuiteContactInformation( formattedContactDetails, domainNames );
 }

--- a/client/my-sites/checkout/composite-checkout/contact-validation.js
+++ b/client/my-sites/checkout/composite-checkout/contact-validation.js
@@ -19,7 +19,7 @@ export default function createContactValidationCallback( {
 	recordEvent,
 	showErrorMessage,
 } ) {
-	// Resolves to true if there are errors
+	// Resolves to false if there are errors
 	return async function contactValidationCallback(
 		paymentMethodId,
 		contactDetails,
@@ -38,7 +38,7 @@ export default function createContactValidationCallback( {
 				data,
 				applyDomainContactValidationResults,
 			} );
-			return ! isContactValidationResponseValid( data, contactDetails );
+			return isContactValidationResponseValid( data, contactDetails );
 		} catch ( error ) {
 			debug( 'contact info validation error:', error );
 			showErrorMessage(
@@ -46,7 +46,7 @@ export default function createContactValidationCallback( {
 					'There was an error validating your contact information. Please contact support.'
 				)
 			);
-			return true;
+			return false;
 		}
 	};
 }

--- a/client/my-sites/checkout/composite-checkout/contact-validation.js
+++ b/client/my-sites/checkout/composite-checkout/contact-validation.js
@@ -14,106 +14,33 @@ import { translate } from 'i18n-calypso';
 const debug = debugFactory( 'calypso:composite-checkout:contact-validation' );
 
 export default function createContactValidationCallback( {
-	validateDomainContact,
+	type,
+	validateContactFunction,
 	recordEvent,
 	showErrorMessage,
 } ) {
-	return function contactValidationCallback(
-		paymentMethodId,
-		contactDetails,
-		domainNames,
-		applyDomainContactValidationResults
-	) {
-		return new Promise( ( resolve ) => {
-			const { contact_information, domain_names } = prepareDomainContactValidationRequest(
-				domainNames,
-				contactDetails
-			);
-			validateDomainContact(
-				contact_information,
-				domain_names,
-				( httpErrors, data ) => {
-					recordEvent( {
-						type: 'VALIDATE_DOMAIN_CONTACT_INFO',
-						payload: {
-							credits: null,
-							payment_method: translateCheckoutPaymentMethodToWpcomPaymentMethod( paymentMethodId ),
-						},
-					} );
-					debug(
-						'Domain contact info validation for domains',
-						domainNames,
-						'and contact info',
-						contactDetails,
-						'result:',
-						data
-					);
-					if ( ! data ) {
-						showErrorMessage(
-							translate(
-								'There was an error validating your contact information. Please contact support.'
-							)
-						);
-					}
-					if ( data && data.messages ) {
-						showErrorMessage(
-							translate(
-								'We could not validate your contact information. Please review and update all the highlighted fields.'
-							)
-						);
-					}
-					applyDomainContactValidationResults(
-						formatDomainContactValidationResponse( data ?? {} )
-					);
-					resolve( ! ( data && data.success && areRequiredFieldsNotEmpty( contactDetails ) ) );
-				},
-				{ apiVersion: '1.2' }
-			);
-		} );
-	};
-}
-
-export function createGSuiteContactValidationCallback( {
-	validateGSuiteContact,
-	recordEvent,
-	showErrorMessage,
-} ) {
+	// Resolves to true if there are errors
 	return async function contactValidationCallback(
 		paymentMethodId,
 		contactDetails,
 		domainNames,
 		applyDomainContactValidationResults
 	) {
-		const { contact_information } = prepareGSuiteContactValidationRequest( contactDetails );
+		const contact_information = prepareContactDetailsForValidation( type, contactDetails );
 		try {
-			debug( 'GSuite contact info validation for', contact_information, domainNames );
-			recordEvent( {
-				type: 'VALIDATE_DOMAIN_CONTACT_INFO',
-				payload: {
-					credits: null,
-					payment_method: translateCheckoutPaymentMethodToWpcomPaymentMethod( paymentMethodId ),
-				},
+			debug( 'contact info validation for', contact_information, domainNames );
+			const data = await validateContactFunction( contact_information, domainNames );
+			debug( 'contact info validation result', data );
+			handleContactValidationResult( {
+				recordEvent,
+				showErrorMessage,
+				paymentMethodId,
+				data,
+				applyDomainContactValidationResults,
 			} );
-			const data = await validateGSuiteContact( contact_information, domainNames );
-			debug( 'GSuite contact info validation result', data );
-			if ( ! data ) {
-				showErrorMessage(
-					translate(
-						'There was an error validating your contact information. Please contact support.'
-					)
-				);
-			}
-			if ( data && data.messages ) {
-				showErrorMessage(
-					translate(
-						'We could not validate your contact information. Please review and update all the highlighted fields.'
-					)
-				);
-			}
-			applyDomainContactValidationResults( formatDomainContactValidationResponse( data ?? {} ) );
-			return ! ( data && data.success && areRequiredFieldsNotEmpty( contactDetails ) );
+			return ! isContactValidationResponseValid( data, contactDetails );
 		} catch ( error ) {
-			debug( 'GSuite contact info validation error:', error );
+			debug( 'contact info validation error:', error );
 			showErrorMessage(
 				translate(
 					'There was an error validating your contact information. Please contact support.'
@@ -122,4 +49,49 @@ export function createGSuiteContactValidationCallback( {
 			return true;
 		}
 	};
+}
+
+function handleContactValidationResult( {
+	recordEvent,
+	showErrorMessage,
+	paymentMethodId,
+	data,
+	applyDomainContactValidationResults,
+} ) {
+	recordEvent( {
+		type: 'VALIDATE_DOMAIN_CONTACT_INFO',
+		payload: {
+			credits: null,
+			payment_method: translateCheckoutPaymentMethodToWpcomPaymentMethod( paymentMethodId ),
+		},
+	} );
+	if ( ! data ) {
+		showErrorMessage(
+			translate( 'There was an error validating your contact information. Please contact support.' )
+		);
+	}
+	if ( data && data.messages ) {
+		showErrorMessage(
+			translate(
+				'We could not validate your contact information. Please review and update all the highlighted fields.'
+			)
+		);
+	}
+	applyDomainContactValidationResults( formatDomainContactValidationResponse( data ?? {} ) );
+}
+
+function isContactValidationResponseValid( data, contactDetails ) {
+	return data && data.success && areRequiredFieldsNotEmpty( contactDetails );
+}
+
+function prepareContactDetailsForValidation( type, contactDetails ) {
+	if ( type === 'domains' ) {
+		const { contact_information } = prepareDomainContactValidationRequest( contactDetails );
+		return contact_information;
+	}
+	if ( type === 'gsuite' ) {
+		const { contact_information } = prepareGSuiteContactValidationRequest( contactDetails );
+		return contact_information;
+	}
+	throw new Error( `Unknown validation type: ${ type }` );
 }

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-review.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-review.js
@@ -76,7 +76,7 @@ WPCheckoutOrderReview.propTypes = {
 	siteUrl: PropTypes.string,
 	couponStatus: PropTypes.string,
 	couponFieldStateProps: PropTypes.object,
-	variantSelectOverride: PropTypes.object,
+	variantSelectOverride: PropTypes.array,
 };
 
 function CouponFieldArea( {
@@ -115,7 +115,7 @@ function CouponFieldArea( {
 }
 
 const DomainURL = styled.div`
-	color: ${( props ) => props.theme.colors.textColorLight};
+	color: ${ ( props ) => props.theme.colors.textColorLight };
 	font-size: 14px;
 	margin-top: -10px;
 	word-break: break-word;
@@ -127,13 +127,13 @@ const CouponLinkWrapper = styled.div`
 
 const CouponField = styled( Coupon )`
 	margin: 20px 30px 0 0;
-	border-bottom: 1px solid ${( props ) => props.theme.colors.borderColorLight};
+	border-bottom: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
 `;
 
 const CouponEnableButton = styled.button`
 	cursor: pointer;
 	text-decoration: underline;
-	color: ${( props ) => props.theme.colors.highlight};
+	color: ${ ( props ) => props.theme.colors.highlight };
 	font-size: 14px;
 
 	:hover {

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -123,10 +123,11 @@ export default function WPCheckout( {
 		setShouldShowContactDetailsValidationErrors,
 	] = useState( false );
 
-	const contactValidationCallback = async () => {
-		debug( 'validating contact details' );
+	const validateContactDetailsAndDisplayErrors = async () => {
+		debug( 'validating contact details with side effects' );
 		if ( isDomainFieldsVisible ) {
-			const validationResult = getDomainValidationResult( items, contactInfo );
+			const validationResult = await getDomainValidationResult( items, contactInfo );
+			debug( 'validating contact details result', validationResult );
 			handleContactValidationResult( {
 				recordEvent: onEvent,
 				showErrorMessage: showErrorMessageBriefly,
@@ -136,7 +137,8 @@ export default function WPCheckout( {
 			} );
 			return isContactValidationResponseValid( validationResult, contactInfo );
 		} else if ( isGSuiteInCart ) {
-			const validationResult = getGSuiteValidationResult( items, contactInfo );
+			const validationResult = await getGSuiteValidationResult( items, contactInfo );
+			debug( 'validating contact details result', validationResult );
 			handleContactValidationResult( {
 				recordEvent: onEvent,
 				showErrorMessage: showErrorMessageBriefly,
@@ -146,7 +148,6 @@ export default function WPCheckout( {
 			} );
 			return isContactValidationResponseValid( validationResult, contactInfo );
 		}
-
 		return isCompleteAndValid( contactInfo );
 	};
 
@@ -217,7 +218,7 @@ export default function WPCheckout( {
 									subdivisionCode: contactInfo.state.value,
 								} );
 
-								return contactValidationCallback();
+								return validateContactDetailsAndDisplayErrors();
 							} }
 							activeStepContent={
 								<WPContactForm

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -117,12 +117,7 @@ export default function WPCheckout( {
 	] = useState( false );
 
 	const contactValidationCallback = async () => {
-		updateLocation( {
-			countryCode: contactInfo.countryCode.value,
-			postalCode: contactInfo.postalCode.value,
-			subdivisionCode: contactInfo.state.value,
-		} );
-
+		debug( 'validating contact details' );
 		if ( isDomainFieldsVisible ) {
 			const domainNames = items
 				.filter( isLineItemADomain )
@@ -213,6 +208,13 @@ export default function WPCheckout( {
 								setShouldShowContactDetailsValidationErrors( true );
 								// Touch the fields so they display validation errors
 								touchContactFields();
+								// Update tax location in cart
+								updateLocation( {
+									countryCode: contactInfo.countryCode.value,
+									postalCode: contactInfo.postalCode.value,
+									subdivisionCode: contactInfo.state.value,
+								} );
+
 								return contactValidationCallback();
 							} }
 							activeStepContent={

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -123,26 +123,23 @@ export default function WPCheckout( {
 				.filter( isLineItemADomain )
 				.map( ( domainItem ) => domainItem.wpcom_meta?.meta ?? '' );
 
-			const hasValidationErrors = await domainContactValidationCallback(
+			return await domainContactValidationCallback(
 				activePaymentMethod.id,
 				contactInfo,
 				domainNames,
 				applyDomainContactValidationResults
 			);
-			return ! hasValidationErrors;
 		} else if ( isGSuiteInCart ) {
 			const domainNames = items
 				.filter( ( item ) => !! item.wpcom_meta?.extra?.google_apps_users?.length )
 				.map( ( item ) => item.wpcom_meta?.meta ?? '' );
 
-			const hasValidationErrors = await gSuiteContactValidationCallback(
+			return await gSuiteContactValidationCallback(
 				activePaymentMethod.id,
 				contactInfo,
 				domainNames,
 				applyDomainContactValidationResults
 			);
-			debug( 'gSuiteContactValidationCallback returned', hasValidationErrors );
-			return ! hasValidationErrors;
 		}
 
 		return isCompleteAndValid( contactInfo );

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -122,8 +122,6 @@ export default function WPCheckout( {
 			postalCode: contactInfo.postalCode.value,
 			subdivisionCode: contactInfo.state.value,
 		} );
-		// Touch the fields so they display validation errors
-		touchContactFields();
 
 		if ( isDomainFieldsVisible ) {
 			const domainNames = items
@@ -213,6 +211,8 @@ export default function WPCheckout( {
 							stepId={ 'contact-form' }
 							isCompleteCallback={ () => {
 								setShouldShowContactDetailsValidationErrors( true );
+								// Touch the fields so they display validation errors
+								touchContactFields();
 								return contactValidationCallback();
 							} }
 							activeStepContent={

--- a/client/my-sites/checkout/composite-checkout/wpcom/types/backend/domain-contact-validation-endpoint.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/types/backend/domain-contact-validation-endpoint.ts
@@ -4,7 +4,6 @@
  * @see WPCOM_JSON_API_Domains_Validate_Contact_Information_Endpoint
  */
 export type DomainContactValidationRequest = {
-	domain_names: string[];
 	contact_information: {
 		firstName?: string;
 		lastName?: string;

--- a/client/my-sites/checkout/composite-checkout/wpcom/types/wpcom-store-state.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/types/wpcom-store-state.ts
@@ -544,7 +544,6 @@ function prepareFrDomainContactExtraDetailsErrors(
 }
 
 export function prepareDomainContactValidationRequest(
-	domainNames: string[],
 	details: ManagedContactDetails
 ): DomainContactValidationRequest {
 	const extra: DomainContactValidationRequestExtraFields = {};
@@ -573,7 +572,6 @@ export function prepareDomainContactValidationRequest(
 	}
 
 	return {
-		domain_names: domainNames,
 		contact_information: {
 			firstName: details.firstName?.value,
 			lastName: details.lastName?.value,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR refactors contact (domain, G Suite, and tax) validation to separate out the validation itself from the error saving and reporting. By itself, it should have no noticeable effect.

This was extracted from https://github.com/Automattic/wp-calypso/pull/42806 and will be useful there so that we can easily do the contact validation without also reporting errors.

#### Testing instructions

Visit composite checkout with these carts:

- [x] Cart with just a plan (should just see "tax" fields: postal code and country).
- [x] Cart with a domain (should see full domain contact fields).
- [x] Cart with just G Suite (should see G Suite fields).
- [x] Cart with a special TLD domain like `.ca` (should see domain contact fields and also special fields).

Then verify that the contact details validation works correctly by checking the following:

- The form initially display no errors.
- If you press "Continue" with empty contact fields, all the empty contact fields display an error.
- If you press "Continue" with contact fields that contain invalid characters (eg: `$%^&*#@` in the name fields), all the invalid contact fields display an error. Note: this will not happen for "tax" fields.
- If you press "Continue" with valid fields, the step completes and moves to the next step.
- If you move to the next step successfully and then press "Edit" on the contact step, no fields have errors.
