### PR TITLE
Cloud: Enable on-demand scan for production

### DIFF
--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -19,7 +19,7 @@
 		"jetpack-cloud": true,
 		"jetpack-cloud/backups-restore": true,
 		"jetpack-cloud/backups": true,
-		"jetpack-cloud/on-demand-scan": false,
+		"jetpack-cloud/on-demand-scan": true,
 		"jetpack-cloud/scan-history": true,
 		"jetpack-cloud/scan": true,
 		"jetpack-cloud/settings": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This enables performing on-demand scans for prod in Cloud.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit prod Jetpack Cloud and go to a site that has Scan.
* See that scan button appears.

