### PR TITLE
Jetpack Cloud: Use full connect url for login_url in config

### DIFF
--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -8,7 +8,7 @@
 	"i18n_default_locale_slug": "en",
 	"port": 3000,
 	"rtl": false,
-	"login_url": "/connect",
+	"login_url": "https://cloud.jetpack.com/connect",
 	"logout_url": "https://jetpack.com",
 	"site_name": "Jetpack.com",
 	"oauth_client_id": 68663,
@@ -41,7 +41,7 @@
 		"jetpack-cloud-settings": true,
 		"jetpack-cloud-auth": true
 	},
-	"site_filter": [ "jetpack" ],
+	"site_filter": ["jetpack"],
 	"theme": "jetpack-cloud",
 	"restricted_me_access": false,
 	"theme_color": "#2fb41f"

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -6,7 +6,7 @@
 	"hostname": "cloud.jetpack.com",
 	"i18n_default_locale_slug": "en",
 	"rtl": false,
-	"login_url": "https://wordpress.com/wp-login.php",
+	"login_url": "https://cloud.jetpack.com/connect",
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
 	"site_name": "Jetpack.com",
 	"features": {
@@ -37,6 +37,6 @@
 		"jetpack-cloud-settings": true,
 		"jetpack-cloud-auth": false
 	},
-	"site_filter": [ "jetpack" ],
+	"site_filter": ["jetpack"],
 	"theme": "jetpack-cloud"
 }

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -6,7 +6,7 @@
 	"hostname": "cloud.jetpack.com",
 	"i18n_default_locale_slug": "en",
 	"rtl": false,
-	"login_url": "/connect",
+	"login_url": "https://cloud.jetpack.com/connect",
 	"logout_url": "https://jetpack.com",
 	"site_name": "Jetpack.com",
 	"oauth_client_id": 69041,
@@ -40,7 +40,7 @@
 		"jetpack-cloud-settings": true,
 		"jetpack-cloud-auth": true
 	},
-	"site_filter": [ "jetpack" ],
+	"site_filter": ["jetpack"],
 	"theme": "jetpack-cloud",
 	"restricted_me_access": false,
 	"theme_color": "#2fb41f"

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -6,7 +6,7 @@
 	"hostname": "cloud.jetpack.com",
 	"i18n_default_locale_slug": "en",
 	"rtl": false,
-	"login_url": "/connect",
+	"login_url": "https://cloud.jetpack.com/connect",
 	"logout_url": "https://jetpack.com",
 	"site_name": "Jetpack.com",
 	"oauth_client_id": 69040,
@@ -39,7 +39,7 @@
 		"jetpack-cloud-settings": true,
 		"jetpack-cloud-auth": true
 	},
-	"site_filter": [ "jetpack" ],
+	"site_filter": ["jetpack"],
 	"theme": "jetpack-cloud",
 	"restricted_me_access": false,
 	"theme_color": "#2fb41f"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR replaces the relative `/connect` path with a full absolute URL for the login_url in our envirnoment configs.

#### Testing instructions

* Attempt to connect/login in staging. If it works, this should be good to go.

