### PR TITLE
Add spacing to coupon error

### DIFF
--- a/client/my-sites/checkout/composite-checkout/wpcom/components/coupon.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/coupon.js
@@ -107,7 +107,9 @@ const ApplyButton = styled( Button )`
 
 function getCouponErrorMessageFromStatus( translate, status, isFreshOrEdited ) {
 	if ( status === 'invalid' && ! isFreshOrEdited ) {
-		return translate( "We couldn't find your coupon. Please check your code and try again." );
+		return translate(
+			"We couldn't find your coupon. Please check your coupon code and try again."
+		);
 	}
 	if ( status === 'rejected' ) {
 		return translate( 'This coupon does not apply to any items in the cart.' );

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/coupon.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/coupon.js
@@ -89,6 +89,10 @@ const CouponWrapper = styled.form`
 	margin: ${ ( props ) => props.marginTop } 0 0 0;
 	padding-top: 0;
 	position: relative;
+
+	p {
+		margin-bottom: 16px;
+	}
 `;
 
 const ApplyButton = styled( Button )`


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes a spacing and orphan (single word on a line) issue for coupon errors in the new composite checkout. Thanks @nbloomf for finding this one.

**Before**
![image](https://user-images.githubusercontent.com/6981253/83335879-b5a01380-a27d-11ea-87b8-4e88f3a0730d.png)


**After**
![image](https://user-images.githubusercontent.com/6981253/83335936-26dfc680-a27e-11ea-9d48-7bb758544bff.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load up calypso or visit Calypso live.
* Add a product to your cart and go to checkout and append `?flags=composite-checkout-force` to the URL to see the new checkout.
* Add any string to the coupon field to see if the spacing is fixed. 
