### PR TITLE
Disable PostCSS-custom-properties in development

### DIFF
--- a/client/postcss.config.js
+++ b/client/postcss.config.js
@@ -1,8 +1,19 @@
-module.exports = () => ( {
-	plugins: {
-		'postcss-custom-properties': {
-			importFrom: [ require.resolve( '@automattic/calypso-color-schemes' ) ],
+const config = require( './server/config' );
+const bundleEnv = config( 'env' );
+
+if ( bundleEnv === 'development' ) {
+	module.exports = () => ( {
+		plugins: {
+			autoprefixer: {},
 		},
-		autoprefixer: {},
-	},
-} );
+	} );
+} else {
+	module.exports = () => ( {
+		plugins: {
+			'postcss-custom-properties': {
+				importFrom: [ require.resolve( '@automattic/calypso-color-schemes' ) ],
+			},
+			autoprefixer: {},
+		},
+	} );
+}

--- a/client/postcss.config.js
+++ b/client/postcss.config.js
@@ -1,19 +1,9 @@
-const config = require( './server/config' );
-const bundleEnv = config( 'env' );
-
-if ( bundleEnv === 'development' ) {
-	module.exports = () => ( {
-		plugins: {
-			autoprefixer: {},
-		},
-	} );
-} else {
-	module.exports = () => ( {
-		plugins: {
-			'postcss-custom-properties': {
-				importFrom: [ require.resolve( '@automattic/calypso-color-schemes' ) ],
-			},
-			autoprefixer: {},
-		},
-	} );
-}
+module.exports = ( { options } ) => {
+	const plugins = { autoprefixer: {} };
+	if ( options.transformCssProperties ) {
+		plugins[ 'postcss-custom-properties' ] = {
+			importFrom: [ require.resolve( '@automattic/calypso-color-schemes' ) ],
+		};
+	}
+	return { plugins };
+};

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -195,7 +195,12 @@ const webpackConfig = {
 			} ),
 			SassConfig.loader( {
 				includePaths: [ __dirname ],
-				postCssConfig: { path: __dirname },
+				postCssConfig: {
+					path: __dirname,
+					ctx: {
+						transformCssProperties: browserslistEnv === 'fallback',
+					},
+				},
 				prelude: `@import '${ path.join( __dirname, 'assets/stylesheets/shared/_utils.scss' ) }';`,
 			} ),
 			{

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -198,7 +198,7 @@ const webpackConfig = {
 				postCssConfig: {
 					path: __dirname,
 					ctx: {
-						transformCssProperties: browserslistEnv === 'fallback',
+						transformCssProperties: browserslistEnv === 'defaults',
 					},
 				},
 				prelude: `@import '${ path.join( __dirname, 'assets/stylesheets/shared/_utils.scss' ) }';`,


### PR DESCRIPTION
#### Build performance improvement

Yesterday, using Webpack ProfilingPlugin, I did an audit for our build performance to look for low hanging fruits, and did I find one.

It turns out there is [a single line in `postcss-custom-properties`](https://github.com/postcss/postcss-custom-properties/blob/master/src/lib/is-ignored.js#L5) that is more than **doubling** our `yarn start` time 🤯 . 

Ironically, we never make any use of this line. It detects `postcss-custom-properties: ignore next|off` CSS comments to disable the plugin for the block that contains this comment. We don't have any of these comments so we're wasting a lot of time for nothing.

I spent some time trying to make the package faster by using some crafted string manipulation logic instead of a regex. But it never got considerably faster. The `isBlockIgnored` is called a lot, it seems.  

After a second thought, it occured to me that CSS custom properties are supported everywhere now except in IE11. IE11 is not supported in our development build anyways, so compiling CSS custom properties down to static values is a total waste of time in development, with the only benefit of shrinking the difference between our prod and development builds. I think slashing the time by half is more than worth this sacrifice.  

#### Testing instructions

#### The perf difference

1. Run `yarn start` on master and time it until you see `Ready! You can load http://calypso.localhost:3000/ now. Have fun!`. 
2. Do the same in this branch and the time should be less than half 🎊 

On my machine it went down from 2:46 to 1:01. 

#### The CSS outcome 

1. Delete your /public folder to make sure no CSS remnants are there. 
2. Run yarn start. 
3. Play with /new, /read, etc... everything should be styled normally. 

