### PR TITLE
Domains: Adds mgmt routes that differentiates between domains of different types but same name

### DIFF
--- a/client/lib/domains/get-selection-domain.js
+++ b/client/lib/domains/get-selection-domain.js
@@ -8,16 +8,21 @@ import { find } from 'lodash';
  */
 import { type as domainTypes } from './constants';
 
-export function getSelectedDomain( { domains, selectedDomainName, isTransfer } ) {
+export function getSelectedDomain( { domains, selectedDomainName, isTransfer, isSiteRedirect } ) {
 	return find( domains, ( domain ) => {
+		const isType = ( type ) => domain.type === type;
+
 		if ( domain.name !== selectedDomainName ) {
 			return false;
 		}
 
-		if ( isTransfer && domain.type === domainTypes.TRANSFER ) {
+		if (
+			( isTransfer && isType( domainTypes.TRANSFER ) ) ||
+			( isSiteRedirect && isType( domainTypes.SITE_REDIRECT ) )
+		) {
 			return true;
 		}
 
-		return domain.type !== domainTypes.TRANSFER;
+		return ! ( isType( domainTypes.TRANSFER ) || isType( domainTypes.SITE_REDIRECT ) );
 	} );
 }

--- a/client/my-sites/domains/domain-management/controller.jsx
+++ b/client/my-sites/domains/domain-management/controller.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { includes } from 'lodash';
 import page from 'page';
 import React from 'react';
 
@@ -20,6 +19,7 @@ import {
 	domainManagementNameServers,
 	domainManagementRedirectSettings,
 	domainManagementSecurity,
+	domainManagementSiteRedirect,
 	domainManagementTransfer,
 	domainManagementTransferIn,
 	domainManagementTransferOut,
@@ -60,18 +60,47 @@ export default {
 	},
 
 	domainManagementEdit( pageContext, next ) {
-		const isTransfer = includes( pageContext.path, '/transfer/in/' );
-		const component = isTransfer ? DomainManagement.TransferIn : DomainManagement.Edit;
-
 		pageContext.primary = (
 			<DomainManagementData
-				analyticsPath={
-					isTransfer
-						? domainManagementTransferIn( ':site', ':domain' )
-						: domainManagementEdit( ':site', ':domain' )
-				}
+				analyticsPath={ domainManagementEdit( ':site', ':domain' ) }
 				analyticsTitle="Domain Management > Edit"
-				component={ component }
+				component={ DomainManagement.Edit }
+				context={ pageContext }
+				needsCart
+				needsContactDetails
+				needsDomains
+				needsPlans
+				needsProductsList
+				selectedDomainName={ decodeURIComponentIfValid( pageContext.params.domain ) }
+			/>
+		);
+		next();
+	},
+
+	domainManagementSiteRedirect( pageContext, next ) {
+		pageContext.primary = (
+			<DomainManagementData
+				analyticsPath={ domainManagementSiteRedirect( ':site', ':domain' ) }
+				analyticsTitle="Domain Management > Edit"
+				component={ DomainManagement.SiteRedirect }
+				context={ pageContext }
+				needsCart
+				needsContactDetails
+				needsDomains
+				needsPlans
+				needsProductsList
+				selectedDomainName={ decodeURIComponentIfValid( pageContext.params.domain ) }
+			/>
+		);
+		next();
+	},
+
+	domainManagementTransferIn( pageContext, next ) {
+		pageContext.primary = (
+			<DomainManagementData
+				analyticsPath={ domainManagementTransferIn( ':site', ':domain' ) }
+				analyticsTitle="Domain Management > Edit"
+				component={ DomainManagement.TransferIn }
 				context={ pageContext }
 				needsCart
 				needsContactDetails

--- a/client/my-sites/domains/domain-management/edit/site-redirect.jsx
+++ b/client/my-sites/domains/domain-management/edit/site-redirect.jsx
@@ -1,92 +1,19 @@
 /**
  * External dependencies
+ *
  */
+
 import React from 'react';
-import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import { CompactCard as Card } from '@automattic/components';
-import Header from './card/header';
-import Property from './card/property';
-import SubscriptionSettings from './card/subscription-settings';
-import VerticalNav from 'components/vertical-nav';
-import VerticalNavItem from 'components/vertical-nav/item';
-import { withLocalizedMoment } from 'components/localized-moment';
-import { domainManagementRedirectSettings } from 'my-sites/domains/paths';
-import { recordPaymentSettingsClick } from './payment-settings-analytics';
+import Edit from './index';
 
-class SiteRedirect extends React.Component {
-	getAutoRenewalOrExpirationDate() {
-		const { domain, translate, moment } = this.props;
-
-		if ( domain.isAutoRenewing ) {
-			return (
-				<Property label={ translate( 'Redirect renews on' ) }>
-					{ moment( domain.autoRenewalDate ).format( 'LL' ) }
-				</Property>
-			);
-		}
-
-		return (
-			<Property label={ translate( 'Redirect expires on' ) }>
-				{ moment( domain.expiry ).format( 'LL' ) }
-			</Property>
-		);
-	}
-
-	handlePaymentSettingsClick = () => {
-		this.props.recordPaymentSettingsClick( this.props.domain );
-	};
-
+class SiteRedirect extends React.PureComponent {
 	render() {
-		const { domain, translate } = this.props;
-
-		/* eslint-disable wpcalypso/jsx-classname-namespace */
-		return (
-			<div>
-				{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace*/ }
-				<div className="domain-details-card">
-					<Header { ...this.props } />
-
-					<Card>
-						<Property label={ translate( 'Type', { context: 'A type of domain.' } ) }>
-							{ translate( 'Site Redirect' ) }
-						</Property>
-
-						{ this.getAutoRenewalOrExpirationDate() }
-
-						<SubscriptionSettings
-							type={ domain.type }
-							subscriptionId={ domain.subscriptionId }
-							siteSlug={ this.props.selectedSite.slug }
-							onClick={ this.handlePaymentSettingsClick }
-						/>
-					</Card>
-				</div>
-
-				<VerticalNav>{ this.siteRedirectNavItem() }</VerticalNav>
-			</div>
-		);
-		/* eslint-enable wpcalypso/jsx-classname-namespace */
-	}
-
-	siteRedirectNavItem() {
-		return (
-			<VerticalNavItem
-				path={ domainManagementRedirectSettings(
-					this.props.selectedSite.slug,
-					this.props.domain.name
-				) }
-			>
-				{ this.props.translate( 'Redirect Settings' ) }
-			</VerticalNavItem>
-		);
+		return <Edit { ...this.props } isSiteRedirect={ true } />;
 	}
 }
 
-export default connect( null, { recordPaymentSettingsClick } )(
-	localize( withLocalizedMoment( SiteRedirect ) )
-);
+export default SiteRedirect;

--- a/client/my-sites/domains/domain-management/index.jsx
+++ b/client/my-sites/domains/domain-management/index.jsx
@@ -11,7 +11,7 @@ import List from './list';
 import ManageConsent from './manage-consent';
 import NameServers from './name-servers';
 import Security from './security';
-import SiteRedirect from './site-redirect';
+import SiteRedirect from './edit/site-redirect';
 import Transfer from './transfer';
 import TransferIn from './edit/transfer-in';
 import TransferOut from './transfer/transfer-out';

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -23,6 +23,7 @@ import Main from 'components/main';
 import {
 	domainManagementEdit,
 	domainManagementList,
+	domainManagementSiteRedirect,
 	domainManagementTransferIn,
 } from 'my-sites/domains/paths';
 import SectionHeader from 'components/section-header';
@@ -429,12 +430,23 @@ export class List extends React.Component {
 	}
 
 	goToEditDomainRoot = ( domain ) => {
-		const slug = this.props.selectedSite.slug;
-		const path =
-			{
-				[ type.TRANSFER ]: domainManagementTransferIn( slug, domain.name ),
-				[ type.SITE_REDIRECT ]: domainManagementEdit( slug, domain.name, 'redirect' ),
-			}[ domain.type ] ?? domainManagementEdit( slug, domain.name );
+		const { selectedSite } = this.props;
+		let path;
+
+		switch ( domain.type ) {
+			case type.TRANSFER:
+				path = domainManagementTransferIn( selectedSite.slug, domain.name );
+				break;
+
+			case type.SITE_REDIRECT:
+				path = domainManagementSiteRedirect( selectedSite.slug, domain.name );
+				break;
+
+			default:
+				path = domainManagementEdit( selectedSite.slug, domain.name );
+				break;
+		}
+
 		page( path );
 	};
 

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -429,11 +429,13 @@ export class List extends React.Component {
 	}
 
 	goToEditDomainRoot = ( domain ) => {
-		if ( domain.type !== type.TRANSFER ) {
-			page( domainManagementEdit( this.props.selectedSite.slug, domain.name ) );
-		} else {
-			page( domainManagementTransferIn( this.props.selectedSite.slug, domain.name ) );
-		}
+		const slug = this.props.selectedSite.slug;
+		const path =
+			{
+				[ type.TRANSFER ]: domainManagementTransferIn( slug, domain.name ),
+				[ type.SITE_REDIRECT ]: domainManagementEdit( slug, domain.name, 'redirect' ),
+			}[ domain.type ] ?? domainManagementEdit( slug, domain.name );
+		page( path );
 	};
 
 	goToPlans = () => {

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -189,18 +189,29 @@ export default function () {
 		clientRender
 	);
 
-	registerMultiPage( {
-		paths: [
-			paths.domainManagementEdit( ':site', ':domain' ),
-			paths.domainManagementTransferIn( ':site', ':domain' ),
-		],
-		handlers: [
-			...getCommonHandlers(),
-			domainManagementController.domainManagementEdit,
-			makeLayout,
-			clientRender,
-		],
-	} );
+	page(
+		paths.domainManagementEdit( ':site', ':domain' ),
+		...getCommonHandlers(),
+		domainManagementController.domainManagementEdit,
+		makeLayout,
+		clientRender
+	);
+
+	page(
+		paths.domainManagementSiteRedirect( ':site', ':domain' ),
+		...getCommonHandlers(),
+		domainManagementController.domainManagementSiteRedirect,
+		makeLayout,
+		clientRender
+	);
+
+	page(
+		paths.domainManagementTransferIn( ':site', ':domain' ),
+		...getCommonHandlers(),
+		domainManagementController.domainManagementTransferIn,
+		makeLayout,
+		clientRender
+	);
 
 	if ( config.isEnabled( 'upgrades/domain-search' ) ) {
 		page(

--- a/client/my-sites/domains/paths.js
+++ b/client/my-sites/domains/paths.js
@@ -97,6 +97,10 @@ export function domainManagementSecurity( siteName, domainName ) {
 	return domainManagementEdit( siteName, domainName, 'security' );
 }
 
+export function domainManagementSiteRedirect( siteName, domainName ) {
+	return domainManagementEdit( siteName, domainName, 'redirect' );
+}
+
 export function domainManagementTransfer( siteName, domainName, transferType = '' ) {
 	return domainManagementEdit(
 		siteName,


### PR DESCRIPTION
### Summary

This is related to and works in concert with the fix implemented in D44220-code as a result of an issue that was raised in p2MSmN-7RI-p2.

The site specific domains list in [/domains/manage/](https://wordpress.com/domains/manage/) becomes confusing when you have both a mapping and a site-redirect with the same domain name.

<img width="1044" alt="Screenshot 2020-06-01 at 5 17 18 PM" src="https://user-images.githubusercontent.com/277661/83429346-d60dd080-a42b-11ea-83c2-f7d191b10fd0.png">

#### Changes proposed in this Pull Request

* Adds a new route `/domains/manage/{domain-name}/redirect/{site}/` to differentiate for site-redirects
* Adds a new component `<SiteRedirect>` with prop `isSiteRedirect` to differentiate when rendering domain status for site redirects

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow test instructions in D44220-code

OR

* Create a site-redirect to a domain.
* Create a domain mapping/ register a custom domain with the same name as domain in previous step.
* Visit the domains list [page](https://wordpress.com/domains/manage/). Navigate to the relevant site.
* Confirm that the right domain is selected as the primary domain even though two domains are listed with the same name.
