### PR TITLE
Revert "Domains: Update TXT record error to be clearer"

### DIFF
--- a/client/my-sites/domains/domain-management/dns/txt-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/txt-record.jsx
@@ -24,25 +24,12 @@ class TxtRecord extends React.Component {
 		show: PropTypes.bool.isRequired,
 	};
 
-	getValidationErrorMessage( value ) {
-		const { translate } = this.props;
-
-		if ( value.length === 0 ) {
-			return translate( 'TXT records may not be empty' );
-		} else if ( value.length > 255 ) {
-			return translate( 'TXT records may not exceed 255 characters' );
-		}
-
-		return null;
-	}
-
 	render() {
 		const { fieldValues, isValid, onChange, selectedDomainName, show, translate } = this.props;
 		const classes = classnames( { 'is-hidden': ! show } );
 		const isNameValid = isValid( 'name' );
 		const isDataValid = isValid( 'data' );
 		const hasNonAsciiData = /[^\u0000-\u007f]/.test( fieldValues.data );
-		const validationError = this.getValidationErrorMessage( fieldValues.data );
 
 		return (
 			<div className={ classes }>
@@ -75,8 +62,8 @@ class TxtRecord extends React.Component {
 					{ hasNonAsciiData && (
 						<FormInputValidation text={ translate( 'TXT Record has non-ASCII data' ) } isWarning />
 					) }
-					{ ! isDataValid && validationError && (
-						<FormInputValidation text={ validationError } isError />
+					{ ! isDataValid && (
+						<FormInputValidation text={ translate( 'Invalid TXT Record' ) } isError />
 					) }
 				</FormFieldset>
 			</div>


### PR DESCRIPTION
Reverts Automattic/wp-calypso#42721

The PR this reverts appears to be causing problems with adding SRV records to domains.

Note: this PR will need to be merged with failing lint checks, as #42721 was also merged with failing lint checks. 