### PR TITLE
"Recurring Payments" -> "Payments"

### DIFF
--- a/client/components/promo-section/docs/example.tsx
+++ b/client/components/promo-section/docs/example.tsx
@@ -39,14 +39,14 @@ const PromoSectionExample = () => {
 				},
 			},
 			{
-				title: 'Collect recurring payments',
+				title: 'Collect payments',
 				body:
-					'Charge for services, collect membership dues, or take recurring donations. Automate recurring payments, and use your site to earn reliable revenue. Available to any site with a paid plan.',
+					'Charge for services, collect membership dues, or take one-time or recurring donations. Automate recurring payments, and use your site to earn reliable revenue. Available to any site with a paid plan.',
 				image: {
 					path: recurringImage,
 				},
 				cta: {
-					text: 'Collect Recurring Payments',
+					text: 'Collect Payments',
 					url: '/',
 				},
 			},

--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -11,6 +11,7 @@ import { invoke } from 'lodash';
 import * as constants from './constants';
 import { DOMAIN_PRICING_AND_AVAILABLE_TLDS } from 'lib/url/support';
 import ExternalLinkWithTracking from 'components/external-link/with-tracking';
+import { isEnabled } from 'config';
 
 export const FEATURES_LIST = {
 	[ constants.FEATURE_BLANK ]: {
@@ -532,9 +533,13 @@ export const FEATURES_LIST = {
 		getSlug: () => constants.FEATURE_WORDADS_INSTANT,
 		getTitle: () => i18n.translate( 'Site monetization' ),
 		getDescription: () =>
-			i18n.translate(
-				'Earn money on your site by displaying ads and collecting recurring payments or donations.'
-			),
+			isEnabled( 'earn/rename-payment-blocks' )
+				? i18n.translate(
+						'Earn money on your site by displaying ads and collecting payments or donations.'
+				  )
+				: i18n.translate(
+						'Earn money on your site by displaying ads and collecting recurring payments or donations.'
+				  ),
 	},
 
 	[ constants.FEATURE_WP_SUBDOMAIN ]: {

--- a/client/me/memberships/main.jsx
+++ b/client/me/memberships/main.jsx
@@ -20,7 +20,7 @@ import { CompactCard } from '@automattic/components';
 import EmptyContent from 'components/empty-content';
 import { withLocalizedMoment } from 'components/localized-moment';
 import { getAllSubscriptions } from 'state/memberships/subscriptions/selectors';
-
+import { isEnabled } from 'config';
 /**
  * Style dependencies
  */
@@ -84,7 +84,13 @@ const MembershipsHistory = ( { translate, subscriptions, moment } ) => {
 	if ( subscriptions && subscriptions.length ) {
 		content = (
 			<>
-				<SectionHeader label={ translate( 'Active Recurring Payments plans' ) } />
+				<SectionHeader
+					label={
+						isEnabled( 'earn/rename-payment-blocks' )
+							? translate( 'Active payments plans' )
+							: translate( 'Active Recurring Payments plans' )
+					}
+				/>
 				{ subscriptions.map(
 					( subscription ) => (
 						<MembershipItem
@@ -102,7 +108,11 @@ const MembershipsHistory = ( { translate, subscriptions, moment } ) => {
 		content = (
 			<CompactCard className="memberships__no-content">
 				<EmptyContent
-					title={ translate( 'No Recurring Payments found.' ) }
+					title={
+						isEnabled( 'earn/rename-payment-blocks' )
+							? translate( 'No payments found.' )
+							: translate( 'No Recurring Payments found.' )
+					}
 					illustration={ noMembershipsImage }
 				/>
 			</CompactCard>

--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -30,6 +30,7 @@ import { bumpStat, composeAnalytics, recordTracksEvent } from 'state/analytics/a
 import ClipboardButtonInput from 'components/clipboard-button-input';
 import { CtaButton } from 'components/promo-section/promo-card/cta';
 import { localizeUrl } from 'lib/i18n-utils';
+import { isEnabled } from 'config';
 
 /**
  * Image dependencies
@@ -145,6 +146,7 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 	 * @returns {object} Object with props to render a PromoCard.
 	 */
 	const getRecurringPaymentsCard = () => {
+		const isPayments = isEnabled( 'earn/rename-payment-blocks' );
 		const cta = isFreePlan
 			? {
 					text: translate( 'Unlock this feature' ),
@@ -154,27 +156,48 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 					},
 			  }
 			: {
-					text: translate( 'Collect payments' ),
+					text: isPayments
+						? translate( 'Collect payments' )
+						: translate( 'Collect recurring payments' ),
 					action: () => {
 						trackCtaButton( 'recurring-payments' );
 						page( `/earn/payments/${ selectedSiteSlug }` );
 					},
 			  };
-		const title = hasConnectedAccount
-			? translate( 'Manage Payments' )
-			: translate( 'Collect Payments' );
-		const body = hasConnectedAccount
+		const hasConnectionTitle = isPayments
+			? translate( 'Manage payments' )
+			: translate( 'Manage recurring payments' );
+		const noConnectionTitle = isPayments
+			? translate( 'Collect payments' )
+			: translate( 'Collect recurring payments' );
+		const title = hasConnectedAccount ? hasConnectionTitle : noConnectionTitle;
+
+		const hasConnectionBody = isPayments
 			? translate(
 					"Manage your customers and subscribers, or your current subscription options and review the total revenue that you've made from payments."
 			  )
 			: translate(
-					'Collect Payments / Accept one-time and recurring credit card payments for digital goods, physical products, services, memberships, subscriptions, and donations. {{em}}Available with any paid plan{{/em}}.',
+					"Manage your subscribers, or your current subscription options and review the total revenue that you've made from recurring payments."
+			  );
+		const noConnectionBody = isPayments
+			? translate(
+					'Collect payments / Accept one-time and recurring credit card payments for digital goods, physical products, services, memberships, subscriptions, and donations. {{em}}Available with any paid plan{{/em}}.',
+					{
+						components: {
+							em: <em />,
+						},
+					}
+			  )
+			: translate(
+					'Accept ongoing and automated credit card payments for subscriptions, memberships, services, and donations. {{em}}Available with any paid plan{{/em}}.',
 					{
 						components: {
 							em: <em />,
 						},
 					}
 			  );
+
+		const body = hasConnectedAccount ? hasConnectionBody : noConnectionBody;
 
 		const learnMoreLink = isFreePlan
 			? {

--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -154,21 +154,21 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 					},
 			  }
 			: {
-					text: translate( 'Collect recurring payments' ),
+					text: translate( 'Collect payments' ),
 					action: () => {
 						trackCtaButton( 'recurring-payments' );
 						page( `/earn/payments/${ selectedSiteSlug }` );
 					},
 			  };
 		const title = hasConnectedAccount
-			? translate( 'Manage recurring payments' )
-			: translate( 'Collect recurring payments' );
+			? translate( 'Manage Payments' )
+			: translate( 'Collect Payments' );
 		const body = hasConnectedAccount
 			? translate(
-					"Manage your subscribers, or your current subscription options and review the total revenue that you've made from recurring payments."
+					"Manage your customers and subscribers, or your current subscription options and review the total revenue that you've made from payments."
 			  )
 			: translate(
-					'Accept ongoing and automated credit card payments for subscriptions, memberships, services, and donations. {{em}}Available with any paid plan{{/em}}.',
+					'Collect Payments / Accept one-time and recurring credit card payments for digital goods, physical products, services, memberships, subscriptions, and donations. {{em}}Available with any paid plan{{/em}}.',
 					{
 						components: {
 							em: <em />,

--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -181,7 +181,7 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 			  );
 		const noConnectionBody = isPayments
 			? translate(
-					'Collect payments / Accept one-time and recurring credit card payments for digital goods, physical products, services, memberships, subscriptions, and donations. {{em}}Available with any paid plan{{/em}}.',
+					'Accept one-time and recurring credit card payments for digital goods, physical products, services, memberships, subscriptions, and donations. {{em}}Available with any paid plan{{/em}}.',
 					{
 						components: {
 							em: <em />,

--- a/client/my-sites/earn/main.jsx
+++ b/client/my-sites/earn/main.jsx
@@ -29,6 +29,7 @@ import MembershipsSection from './memberships';
 import MembershipsProductsSection from './memberships/products';
 import ReferAFriendSection from './refer-a-friend';
 import { canAccessAds } from 'lib/ads/utils';
+import { isEnabled } from 'config';
 
 class EarningsMain extends Component {
 	static propTypes = {
@@ -124,7 +125,9 @@ class EarningsMain extends Component {
 
 		switch ( this.props.section ) {
 			case 'payments':
-				return translate( 'Payments' );
+				return isEnabled( 'earn/rename-payment-blocks' )
+					? translate( 'Payments' )
+					: translate( 'Recurring Payments' );
 
 			case 'ads-earnings':
 			case 'ads-settings':

--- a/client/my-sites/earn/main.jsx
+++ b/client/my-sites/earn/main.jsx
@@ -124,7 +124,7 @@ class EarningsMain extends Component {
 
 		switch ( this.props.section ) {
 			case 'payments':
-				return translate( 'Recurring Payments' );
+				return translate( 'Payments' );
 
 			case 'ads-earnings':
 			case 'ads-settings':

--- a/client/my-sites/earn/memberships/add-edit-plan-modal.jsx
+++ b/client/my-sites/earn/memberships/add-edit-plan-modal.jsx
@@ -189,7 +189,7 @@ const RecurringPaymentsPlanAddEditModal = ( {
 					welcome_email_content: editedCustomConfirmationMessage,
 					subscribe_as_site_subscriber: editedPostsEmail,
 				},
-				translate( 'Added "%s" product.', { args: editedProductName } )
+				translate( 'Added "%s" payment plan.', { args: editedProductName } )
 			);
 		} else if ( reason === 'submit' && product ) {
 			updateProduct(
@@ -205,7 +205,7 @@ const RecurringPaymentsPlanAddEditModal = ( {
 					welcome_email_content: editedCustomConfirmationMessage,
 					subscribe_as_site_subscriber: editedPostsEmail,
 				},
-				translate( 'Updated "%s" product.', { args: editedProductName } )
+				translate( 'Updated "%s" payment plan.', { args: editedProductName } )
 			);
 		}
 		closeDialog();
@@ -216,9 +216,9 @@ const RecurringPaymentsPlanAddEditModal = ( {
 			<>
 				<p>
 					{ product
-						? translate( 'Edit your existing Recurring Payments plan.' )
+						? translate( 'Edit your existing payment plan.' )
 						: translate(
-								'Each amount you add will create a separate Recurring Payments plan. You can create multiple plans.'
+								'Each amount you add will create a separate payment plan. You can create many of them.'
 						  ) }
 				</p>
 				<FormFieldset>
@@ -226,7 +226,7 @@ const RecurringPaymentsPlanAddEditModal = ( {
 					{ product && (
 						<Notice
 							text={ translate(
-								'Updating the price will not affect existing subscribers, who will pay what they were originally charged.'
+								'Updating the price will not affect existing recurring subscribers, who will pay what they were originally charged. Existing subscribers will pay the price they were originally charged when they renew'
 							) }
 							showDismiss={ false }
 						/>
@@ -257,19 +257,21 @@ const RecurringPaymentsPlanAddEditModal = ( {
 				</FormFieldset>
 				<FormFieldset>
 					<FormLabel htmlFor="renewal_schedule">
-						{ translate( 'Select renewal schedule' ) }
+						{ translate( 'Select renewal frequency' ) }
 					</FormLabel>
 					<FormSelect id="renewal_schedule" value={ editedSchedule } onChange={ onSelectSchedule }>
-						<option value="1 month">{ translate( 'Monthly' ) }</option>
-						<option value="1 year">{ translate( 'Yearly' ) }</option>
+						<option value="1 month">{ translate( 'Renew Monthly' ) }</option>
+						<option value="1 year">{ translate( 'Renew Yearly' ) }</option>
+						<option value="one-time">{ translate( 'One time sale' ) }</option>
 					</FormSelect>
 				</FormFieldset>
 				<FormFieldset>
 					<FormLabel htmlFor="title">
-						{ translate( 'Please describe your subscription' ) }
+						{ translate( 'Please describe your payment plan' ) }
 					</FormLabel>
 					<FormTextInput
 						id="title"
+						placeholder={ translate( 'Example: Cats are Awesome T-shirt' ) }
 						value={ editedProductName }
 						onChange={ onNameChange }
 						onBlur={ () => setFocusedName( true ) }
@@ -285,7 +287,9 @@ const RecurringPaymentsPlanAddEditModal = ( {
 				</FormFieldset>
 				<FormFieldset>
 					<FormToggle onChange={ handleMultiplePerUser } checked={ editedMultiplePerUser }>
-						{ translate( 'Allow the same customer to sign up multiple times to the same plan.' ) }
+						{ translate(
+							'Allow the same customer to purchase or sign up to this plan multiple times.'
+						) }
 					</FormToggle>
 				</FormFieldset>
 			</>
@@ -299,7 +303,7 @@ const RecurringPaymentsPlanAddEditModal = ( {
 					<h6 className="memberships__dialog-form-header">{ translate( 'Posts via email' ) }</h6>
 					<p>
 						{ translate(
-							'Allow members of this recurring payment plan to opt into receiving new posts via email.'
+							'Allow members of this payment plan to opt into receiving new posts via email.'
 						) }{ ' ' }
 						<InlineSupportLink
 							supportPostId={ 154624 }
@@ -312,9 +316,7 @@ const RecurringPaymentsPlanAddEditModal = ( {
 						onChange={ ( newValue ) => setEditedPostsEmail( newValue ) }
 						checked={ editedPostsEmail }
 					>
-						{ translate(
-							'Email newly published posts to members of this recurring payment plan who have opted in.'
-						) }
+						{ translate( 'Email newly published posts to your customers.' ) }
 					</FormToggle>
 				</FormFieldset>
 				<FormFieldset>
@@ -323,7 +325,7 @@ const RecurringPaymentsPlanAddEditModal = ( {
 					</h6>
 					<p>
 						{ translate(
-							'Add a custom message to the confirmation email that is sent out for this recurring payment plan.'
+							'Add a custom message to the confirmation email that is sent out after the purchase. For example, you can thank your customers.'
 						) }
 					</p>
 					<CountedTextArea
@@ -356,9 +358,7 @@ const RecurringPaymentsPlanAddEditModal = ( {
 			] }
 		>
 			<FormSectionHeading>
-				{ product
-					? translate( 'Edit Recurring Payment plan' )
-					: translate( 'Add new Recurring Payment plan' ) }
+				{ product ? translate( 'Edit a payment plan' ) : translate( 'Add a new payment plan' ) }
 			</FormSectionHeading>
 			<SectionNav
 				className="memberships__dialog-nav"

--- a/client/my-sites/earn/memberships/add-edit-plan-modal.jsx
+++ b/client/my-sites/earn/memberships/add-edit-plan-modal.jsx
@@ -28,6 +28,7 @@ import { requestAddProduct, requestUpdateProduct } from 'state/memberships/produ
 import SectionNav from 'components/section-nav';
 import SectionNavTabs from 'components/section-nav/tabs';
 import SectionNavTabItem from 'components/section-nav/item';
+import { isEnabled } from 'config';
 
 /**
  * @typedef {[string, number] CurrencyMinimum
@@ -189,7 +190,9 @@ const RecurringPaymentsPlanAddEditModal = ( {
 					welcome_email_content: editedCustomConfirmationMessage,
 					subscribe_as_site_subscriber: editedPostsEmail,
 				},
-				translate( 'Added "%s" payment plan.', { args: editedProductName } )
+				isEnabled( 'earn/rename-payment-blocks' )
+					? translate( 'Added "%s" payment plan.', { args: editedProductName } )
+					: translate( 'Added "%s" product.', { args: editedProductName } )
 			);
 		} else if ( reason === 'submit' && product ) {
 			updateProduct(
@@ -205,29 +208,42 @@ const RecurringPaymentsPlanAddEditModal = ( {
 					welcome_email_content: editedCustomConfirmationMessage,
 					subscribe_as_site_subscriber: editedPostsEmail,
 				},
-				translate( 'Updated "%s" payment plan.', { args: editedProductName } )
+				isEnabled( 'earn/rename-payment-blocks' )
+					? translate( 'Updated "%s" payment plan.', { args: editedProductName } )
+					: translate( 'Updated "%s" product.', { args: editedProductName } )
 			);
 		}
 		closeDialog();
 	};
 
 	const renderGeneralTab = () => {
+		const isPayments = isEnabled( 'earn/rename-payment-blocks' );
+		const editProduct = isPayments
+			? translate( 'Edit your existing payment plan.' )
+			: translate( 'Edit your existing Recurring Payments plan.' );
+		const noProduct = isPayments
+			? translate(
+					'Each amount you add will create a separate payment plan. You can create many of them.'
+			  )
+			: translate(
+					'Each amount you add will create a separate Recurring Payments plan. You can create multiple plans.'
+			  );
 		return (
 			<>
-				<p>
-					{ product
-						? translate( 'Edit your existing payment plan.' )
-						: translate(
-								'Each amount you add will create a separate payment plan. You can create many of them.'
-						  ) }
-				</p>
+				<p>{ product ? editProduct : noProduct }</p>
 				<FormFieldset>
 					<FormLabel htmlFor="currency">{ translate( 'Select price' ) }</FormLabel>
 					{ product && (
 						<Notice
-							text={ translate(
-								'Updating the price will not affect existing recurring subscribers, who will pay what they were originally charged. Existing subscribers will pay the price they were originally charged when they renew'
-							) }
+							text={
+								isPayments
+									? translate(
+											'Updating the price will not affect existing subscribers, who will pay what they were originally charged on renewal.'
+									  )
+									: translate(
+											'Updating the price will not affect existing subscribers, who will pay what they were originally charged.'
+									  )
+							}
 							showDismiss={ false }
 						/>
 					) }
@@ -257,21 +273,27 @@ const RecurringPaymentsPlanAddEditModal = ( {
 				</FormFieldset>
 				<FormFieldset>
 					<FormLabel htmlFor="renewal_schedule">
-						{ translate( 'Select renewal frequency' ) }
+						{ isPayments
+							? translate( 'Select renewal frequency' )
+							: translate( 'Select renewal schedule' ) }
 					</FormLabel>
 					<FormSelect id="renewal_schedule" value={ editedSchedule } onChange={ onSelectSchedule }>
-						<option value="1 month">{ translate( 'Renew Monthly' ) }</option>
-						<option value="1 year">{ translate( 'Renew Yearly' ) }</option>
-						<option value="one-time">{ translate( 'One time sale' ) }</option>
+						<option value="1 month">
+							{ isPayments ? translate( 'Renew monthly' ) : translate( 'Monthly' ) }
+						</option>
+						<option value="1 year">
+							{ isPayments ? translate( 'Renew yearly' ) : translate( 'Yearly' ) }
+						</option>
 					</FormSelect>
 				</FormFieldset>
 				<FormFieldset>
 					<FormLabel htmlFor="title">
-						{ translate( 'Please describe your payment plan' ) }
+						{ isPayments
+							? translate( 'Please describe your payment plan' )
+							: translate( 'Please describe your subscription' ) }
 					</FormLabel>
 					<FormTextInput
 						id="title"
-						placeholder={ translate( 'Example: Cats are Awesome T-shirt' ) }
 						value={ editedProductName }
 						onChange={ onNameChange }
 						onBlur={ () => setFocusedName( true ) }
@@ -287,9 +309,11 @@ const RecurringPaymentsPlanAddEditModal = ( {
 				</FormFieldset>
 				<FormFieldset>
 					<FormToggle onChange={ handleMultiplePerUser } checked={ editedMultiplePerUser }>
-						{ translate(
-							'Allow the same customer to purchase or sign up to this plan multiple times.'
-						) }
+						{ isPayments
+							? translate(
+									'Allow the same customer to purchase or sign up to this plan multiple times.'
+							  )
+							: translate( 'Allow the same customer to sign up multiple times to the same plan.' ) }
 					</FormToggle>
 				</FormFieldset>
 			</>
@@ -297,14 +321,19 @@ const RecurringPaymentsPlanAddEditModal = ( {
 	};
 
 	const renderEmailTab = () => {
+		const isPayments = isEnabled( 'earn/rename-payment-blocks' );
 		return (
 			<>
 				<FormFieldset>
 					<h6 className="memberships__dialog-form-header">{ translate( 'Posts via email' ) }</h6>
 					<p>
-						{ translate(
-							'Allow members of this payment plan to opt into receiving new posts via email.'
-						) }{ ' ' }
+						{ isPayments
+							? translate(
+									'Allow members of this payment plan to opt into receiving new posts via email.'
+							  )
+							: translate(
+									'Allow members of this recurring payment plan to opt into receiving new posts via email.'
+							  ) }{ ' ' }
 						<InlineSupportLink
 							supportPostId={ 154624 }
 							supportLink="https://wordpress.com/support/wordpress-editor/blocks/recurring-payments-button/" // TODO: Link to specific section once article is update
@@ -316,7 +345,11 @@ const RecurringPaymentsPlanAddEditModal = ( {
 						onChange={ ( newValue ) => setEditedPostsEmail( newValue ) }
 						checked={ editedPostsEmail }
 					>
-						{ translate( 'Email newly published posts to your customers.' ) }
+						{ isPayments
+							? translate( 'Email newly published posts to your customers.' )
+							: translate(
+									'Email newly published posts to members of this recurring payment plan who have opted in.'
+							  ) }
 					</FormToggle>
 				</FormFieldset>
 				<FormFieldset>
@@ -324,9 +357,13 @@ const RecurringPaymentsPlanAddEditModal = ( {
 						{ translate( 'Custom confirmation message' ) }
 					</h6>
 					<p>
-						{ translate(
-							'Add a custom message to the confirmation email that is sent out after the purchase. For example, you can thank your customers.'
-						) }
+						{ isPayments
+							? translate(
+									'Add a custom message to the confirmation email that is sent after purchase. For example, you can thank your customers.'
+							  )
+							: translate(
+									'Add a custom message to the confirmation email that is sent out for this recurring payment plan.'
+							  ) }
 					</p>
 					<CountedTextArea
 						value={ editedCustomConfirmationMessage }
@@ -340,6 +377,13 @@ const RecurringPaymentsPlanAddEditModal = ( {
 		);
 	};
 
+	const isPayments = isEnabled( 'earn/rename-payment-blocks' );
+	const editPlan = isPayments
+		? translate( 'Edit a payment plan' )
+		: translate( 'Edit Recurring Payment plan' );
+	const addPlan = isPayments
+		? translate( 'Add a new payment plan' )
+		: translate( 'Add new Recurring Payment plan' );
 	return (
 		<Dialog
 			isVisible={ true }
@@ -357,9 +401,7 @@ const RecurringPaymentsPlanAddEditModal = ( {
 				},
 			] }
 		>
-			<FormSectionHeading>
-				{ product ? translate( 'Edit a payment plan' ) : translate( 'Add a new payment plan' ) }
-			</FormSectionHeading>
+			<FormSectionHeading>{ product ? editPlan : addPlan }</FormSectionHeading>
 			<SectionNav
 				className="memberships__dialog-nav"
 				selectedText={ getTabName( currentDialogTab ) }

--- a/client/my-sites/earn/memberships/index.jsx
+++ b/client/my-sites/earn/memberships/index.jsx
@@ -487,7 +487,6 @@ class MembershipsSection extends Component {
 	}
 
 	renderStripeConnected() {
-		const isPayments = isEnabled( 'earn/rename-payment-blocks' );
 		return (
 			<div>
 				{ this.props.query.stripe_connect_success === 'earn' && (
@@ -507,15 +506,9 @@ class MembershipsSection extends Component {
 					<Notice
 						status="is-success"
 						showDismiss={ false }
-						text={
-							isPayments
-								? this.props.translate(
-										'Congrats! Your site is now connected to Stripe. You can now close this window, click "Re-check connection" and add your first product.'
-								  )
-								: this.props.translate(
-										'Congrats! Your site is now connected to Stripe. You can now close this window, click "Re-check connection" and add your first payment plan.'
-								  )
-						}
+						text={ this.props.translate(
+							'Congrats! Your site is now connected to Stripe. You can now close this window, click "Re-check connection" and add your first payment plan.'
+						) }
 					>
 						<NoticeAction
 							href={ localizeUrl(

--- a/client/my-sites/earn/memberships/index.jsx
+++ b/client/my-sites/earn/memberships/index.jsx
@@ -218,11 +218,11 @@ class MembershipsSection extends Component {
 	renderSubscriberList() {
 		return (
 			<div>
-				<SectionHeader label={ this.props.translate( 'Subscribers' ) } />
+				<SectionHeader label={ this.props.translate( 'Customers and Subscribers' ) } />
 				{ Object.values( this.props.subscribers ).length === 0 && (
 					<Card>
 						{ this.props.translate(
-							"You haven't added any subscribers. {{a}}Learn more{{/a}} about recurring payments.",
+							"You haven't added any customers. {{a}}Learn more{{/a}} about payments.",
 							{
 								components: {
 									a: (
@@ -304,7 +304,7 @@ class MembershipsSection extends Component {
 				<CompactCard href={ '/earn/payments-plans/' + this.props.siteSlug }>
 					<QueryMembershipProducts siteId={ this.props.siteId } />
 					<div className="memberships__module-products-title">
-						{ this.props.translate( 'Recurring Payments plans' ) }
+						{ this.props.translate( 'Payment plans' ) }
 					</div>
 					<div className="memberships__module-products-list">
 						<Gridicon icon="tag" size={ 12 } className="memberships__module-products-list-icon" />
@@ -324,7 +324,7 @@ class MembershipsSection extends Component {
 							{ this.props.translate( 'Disconnect Stripe Account' ) }
 						</p>
 						<p className="memberships__settings-section-desc">
-							{ this.props.translate( 'Disconnect Recurring Payments from your Stripe account' ) }
+							{ this.props.translate( 'Disconnect Payments from your Stripe account' ) }
 						</p>
 					</div>
 				</CompactCard>
@@ -336,7 +336,7 @@ class MembershipsSection extends Component {
 							action: 'cancel',
 						},
 						{
-							label: this.props.translate( 'Disconnect Recurring Payments from Stripe' ),
+							label: this.props.translate( 'Disconnect Payments from Stripe' ),
 							isPrimary: true,
 							action: 'disconnect',
 						},
@@ -346,12 +346,12 @@ class MembershipsSection extends Component {
 					<h1>{ this.props.translate( 'Confirmation' ) }</h1>
 					<p>
 						{ this.props.translate(
-							'Do you want to disconnect Recurring Payments from your Stripe account?'
+							'Do you want to disconnect Payments from your Stripe account?'
 						) }
 					</p>
 					<Notice
 						text={ this.props.translate(
-							'Once you disconnect Recurring Payments from Stripe, new subscribers won’t be able to sign up and existing subscriptions will stop working.{{br/}}{{strong}}Disconnecting your Stripe account here will remove it from all your WordPress.com and Jetpack sites.{{/strong}}',
+							'Once you disconnect Payments from Stripe, new subscribers won’t be able to sign up and existing subscriptions will stop working.{{br/}}{{strong}}Disconnecting your Stripe account here will remove it from all your WordPress.com and Jetpack sites.{{/strong}}',
 							{
 								components: {
 									br: <br />,
@@ -450,7 +450,7 @@ class MembershipsSection extends Component {
 						) }
 					>
 						<NoticeAction href={ `/earn/payments-plans/${ this.props.siteSlug }` } icon="create">
-							{ this.props.translate( 'Add a Payment Plan' ) }
+							{ this.props.translate( 'Add a payment plan' ) }
 						</NoticeAction>
 					</Notice>
 				) }
@@ -459,7 +459,7 @@ class MembershipsSection extends Component {
 						status="is-success"
 						showDismiss={ false }
 						text={ this.props.translate(
-							'Congrats! Your site is now connected to Stripe. You can now close this window, click "Re-check connection" and add your first payment plan.'
+							'Congrats! Your site is now connected to Stripe. You can now close this window, click "Re-check connection" and add your first product.'
 						) }
 					>
 						<NoticeAction
@@ -484,11 +484,11 @@ class MembershipsSection extends Component {
 			<div className="memberships__onboarding-wrapper">
 				<div className="memberships__onboarding-column-info">
 					<div className="memberships__onboarding-header">
-						{ this.props.translate( 'Introducing Recurring Payments.' ) }
+						{ this.props.translate( 'Introducing Payments.' ) }
 					</div>
 					<p className="memberships__onboarding-paragraph">
 						{ this.props.translate(
-							'Start collecting subscription payments! Recurring Payments is a feature inside the block editor. When editing a post or a page you can insert a button that will allow you to collect paying subscribers.'
+							'Start selling and collecting subscription payments! Payments is a feature inside the block editor. When editing a post or a page you can insert a button that will allow you to sell products or collect paying subscribers.'
 						) }{ ' ' }
 						<ExternalLink
 							href="https://wordpress.com/support/recurring-payments-button/"
@@ -501,7 +501,11 @@ class MembershipsSection extends Component {
 					<div className="memberships__onboarding-benefits">
 						<div>
 							<Gridicon size={ 18 } icon="checkmark" />
-							{ this.props.translate( 'Add multiple subscription options' ) }
+							{ this.props.translate( 'Add multiple payment plans' ) }
+						</div>
+						<div>
+							<Gridicon size={ 18 } icon="checkmark" />
+							{ this.props.translate( 'Collect recurring revenue' ) }
 						</div>
 						<div>
 							<Gridicon size={ 18 } icon="checkmark" />
@@ -553,7 +557,7 @@ class MembershipsSection extends Component {
 					shouldDisplay={ () => true }
 					feature={ FEATURE_MEMBERSHIPS }
 					title={ this.props.translate( 'Upgrade to the Personal plan' ) }
-					description={ this.props.translate( 'Upgrade to start earning recurring revenue.' ) }
+					description={ this.props.translate( 'Upgrade to start selling.' ) }
 					showIcon={ true }
 					event="calypso_memberships_upsell_nudge"
 					tracksImpressionName="calypso_upgrade_nudge_impression"
@@ -566,9 +570,7 @@ class MembershipsSection extends Component {
 			return this.renderOnboarding(
 				<Notice
 					status="is-warning"
-					text={ this.props.translate(
-						'Only site administrators can edit Recurring Payments settings.'
-					) }
+					text={ this.props.translate( 'Only site administrators can edit Payments settings.' ) }
 					showDismiss={ false }
 				/>
 			);

--- a/client/my-sites/earn/memberships/index.jsx
+++ b/client/my-sites/earn/memberships/index.jsx
@@ -45,6 +45,7 @@ import {
 	getConnectUrlForSiteId,
 } from 'state/memberships/settings/selectors';
 import { getProductsForSiteId } from 'state/memberships/product-list/selectors';
+import { isEnabled } from 'config';
 
 /**
  * Style dependencies
@@ -216,27 +217,45 @@ class MembershipsSection extends Component {
 	}
 
 	renderSubscriberList() {
+		const isPayments = isEnabled( 'earn/rename-payment-blocks' );
 		return (
 			<div>
 				<SectionHeader label={ this.props.translate( 'Customers and Subscribers' ) } />
 				{ Object.values( this.props.subscribers ).length === 0 && (
 					<Card>
-						{ this.props.translate(
-							"You haven't added any customers. {{a}}Learn more{{/a}} about payments.",
-							{
-								components: {
-									a: (
-										<a
-											href={ localizeUrl(
-												'https://wordpress.com/support/recurring-payments-button/'
-											) }
-											target="_blank"
-											rel="noreferrer noopener"
-										/>
-									),
-								},
-							}
-						) }
+						{ isPayments
+							? this.props.translate(
+									"You haven't added any customers. {{a}}Learn more{{/a}} about payments.",
+									{
+										components: {
+											a: (
+												<a
+													href={ localizeUrl(
+														'https://wordpress.com/support/recurring-payments-button/'
+													) }
+													target="_blank"
+													rel="noreferrer noopener"
+												/>
+											),
+										},
+									}
+							  )
+							: this.props.translate(
+									"You haven't added any subscribers. {{a}}Learn more{{/a}} about recurring payments.",
+									{
+										components: {
+											a: (
+												<a
+													href={ localizeUrl(
+														'https://wordpress.com/support/recurring-payments-button/'
+													) }
+													target="_blank"
+													rel="noreferrer noopener"
+												/>
+											),
+										},
+									}
+							  ) }
 					</Card>
 				) }
 				{ Object.values( this.props.subscribers ).length > 0 && (
@@ -298,13 +317,16 @@ class MembershipsSection extends Component {
 	}
 
 	renderSettings() {
+		const isPayments = isEnabled( 'earn/rename-payment-blocks' );
 		return (
 			<div>
 				<SectionHeader label={ this.props.translate( 'Settings' ) } />
 				<CompactCard href={ '/earn/payments-plans/' + this.props.siteSlug }>
 					<QueryMembershipProducts siteId={ this.props.siteId } />
 					<div className="memberships__module-products-title">
-						{ this.props.translate( 'Payment plans' ) }
+						{ isPayments
+							? this.props.translate( 'Payment plans' )
+							: this.props.translate( 'Recurring Payments plans' ) }
 					</div>
 					<div className="memberships__module-products-list">
 						<Gridicon icon="tag" size={ 12 } className="memberships__module-products-list-icon" />
@@ -324,7 +346,9 @@ class MembershipsSection extends Component {
 							{ this.props.translate( 'Disconnect Stripe Account' ) }
 						</p>
 						<p className="memberships__settings-section-desc">
-							{ this.props.translate( 'Disconnect Payments from your Stripe account' ) }
+							{ isPayments
+								? this.props.translate( 'Disconnect Payments from your Stripe account' )
+								: this.props.translate( 'Disconnect Recurring Payments from your Stripe account' ) }
 						</p>
 					</div>
 				</CompactCard>
@@ -336,7 +360,9 @@ class MembershipsSection extends Component {
 							action: 'cancel',
 						},
 						{
-							label: this.props.translate( 'Disconnect Payments from Stripe' ),
+							label: isPayments
+								? this.props.translate( 'Disconnect Payments from Stripe' )
+								: this.props.translate( 'Disconnect Recurring Payments from Stripe' ),
 							isPrimary: true,
 							action: 'disconnect',
 						},
@@ -345,20 +371,36 @@ class MembershipsSection extends Component {
 				>
 					<h1>{ this.props.translate( 'Confirmation' ) }</h1>
 					<p>
-						{ this.props.translate(
-							'Do you want to disconnect Payments from your Stripe account?'
-						) }
+						{ isPayments
+							? this.props.translate(
+									'Do you want to disconnect Payments from your Stripe account?'
+							  )
+							: this.props.translate(
+									'Do you want to disconnect Recurring Payments from your Stripe account?'
+							  ) }
 					</p>
 					<Notice
-						text={ this.props.translate(
-							'Once you disconnect Payments from Stripe, new subscribers won’t be able to sign up and existing subscriptions will stop working.{{br/}}{{strong}}Disconnecting your Stripe account here will remove it from all your WordPress.com and Jetpack sites.{{/strong}}',
-							{
-								components: {
-									br: <br />,
-									strong: <strong />,
-								},
-							}
-						) }
+						text={
+							isPayments
+								? this.props.translate(
+										'Once you disconnect Payments from Stripe, new subscribers won’t be able to sign up and existing subscriptions will stop working.{{br/}}{{strong}}Disconnecting your Stripe account here will remove it from all your WordPress.com and Jetpack sites.{{/strong}}',
+										{
+											components: {
+												br: <br />,
+												strong: <strong />,
+											},
+										}
+								  )
+								: this.props.translate(
+										'Once you disconnect Recurring Payments from Stripe, new subscribers won’t be able to sign up and existing subscriptions will stop working.{{br/}}{{strong}}Disconnecting your Stripe account here will remove it from all your WordPress.com and Jetpack sites.{{/strong}}',
+										{
+											components: {
+												br: <br />,
+												strong: <strong />,
+											},
+										}
+								  )
+						}
 						showDismiss={ false }
 					/>
 				</Dialog>
@@ -439,6 +481,7 @@ class MembershipsSection extends Component {
 	}
 
 	renderStripeConnected() {
+		const isPayments = isEnabled( 'earn/rename-payment-blocks' );
 		return (
 			<div>
 				{ this.props.query.stripe_connect_success === 'earn' && (
@@ -458,9 +501,15 @@ class MembershipsSection extends Component {
 					<Notice
 						status="is-success"
 						showDismiss={ false }
-						text={ this.props.translate(
-							'Congrats! Your site is now connected to Stripe. You can now close this window, click "Re-check connection" and add your first product.'
-						) }
+						text={
+							isPayments
+								? this.props.translate(
+										'Congrats! Your site is now connected to Stripe. You can now close this window, click "Re-check connection" and add your first product.'
+								  )
+								: this.props.translate(
+										'Congrats! Your site is now connected to Stripe. You can now close this window, click "Re-check connection" and add your first payment plan.'
+								  )
+						}
 					>
 						<NoticeAction
 							href={ localizeUrl(
@@ -480,16 +529,23 @@ class MembershipsSection extends Component {
 	}
 
 	renderOnboarding( cta ) {
+		const isPayments = isEnabled( 'earn/rename-payment-blocks' );
 		return (
 			<div className="memberships__onboarding-wrapper">
 				<div className="memberships__onboarding-column-info">
 					<div className="memberships__onboarding-header">
-						{ this.props.translate( 'Introducing Payments.' ) }
+						{ isPayments
+							? this.props.translate( 'Introducing Payments.' )
+							: this.props.translate( 'Introducing Recurring Payments.' ) }
 					</div>
 					<p className="memberships__onboarding-paragraph">
-						{ this.props.translate(
-							'Start selling and collecting subscription payments! Payments is a feature inside the block editor. When editing a post or a page you can insert a button that will allow you to sell products or collect paying subscribers.'
-						) }{ ' ' }
+						{ isPayments
+							? this.props.translate(
+									'Start selling and collecting subscription payments! Payments is a feature inside the block editor. When editing a post or a page you can insert a button that will allow you to sell products or collect paying subscribers.'
+							  )
+							: this.props.translate(
+									'Start collecting subscription payments! Recurring Payments is a feature inside the block editor. When editing a post or a page you can insert a button that will allow you to collect paying subscribers.'
+							  ) }{ ' ' }
 						<ExternalLink
 							href="https://wordpress.com/support/recurring-payments-button/"
 							icon={ true }
@@ -501,7 +557,9 @@ class MembershipsSection extends Component {
 					<div className="memberships__onboarding-benefits">
 						<div>
 							<Gridicon size={ 18 } icon="checkmark" />
-							{ this.props.translate( 'Add multiple payment plans' ) }
+							{ isPayments
+								? this.props.translate( 'Add multiple payment plans' )
+								: this.props.translate( 'Add multiple subscription options' ) }
 						</div>
 						<div>
 							<Gridicon size={ 18 } icon="checkmark" />
@@ -557,7 +615,11 @@ class MembershipsSection extends Component {
 					shouldDisplay={ () => true }
 					feature={ FEATURE_MEMBERSHIPS }
 					title={ this.props.translate( 'Upgrade to the Personal plan' ) }
-					description={ this.props.translate( 'Upgrade to start selling.' ) }
+					description={
+						isEnabled( 'earn/rename-payment-blocks' )
+							? this.props.translate( 'Upgrade to start selling.' )
+							: this.props.translate( 'Upgrade to start earning recurring revenue.' )
+					}
 					showIcon={ true }
 					event="calypso_memberships_upsell_nudge"
 					tracksImpressionName="calypso_upgrade_nudge_impression"
@@ -570,7 +632,13 @@ class MembershipsSection extends Component {
 			return this.renderOnboarding(
 				<Notice
 					status="is-warning"
-					text={ this.props.translate( 'Only site administrators can edit Payments settings.' ) }
+					text={
+						isEnabled( 'earn/rename-payment-blocks' )
+							? this.props.translate( 'Only site administrators can edit Payments settings.' )
+							: this.props.translate(
+									'Only site administrators can edit Recurring Payments settings.'
+							  )
+					}
 					showDismiss={ false }
 				/>
 			);
@@ -585,7 +653,7 @@ class MembershipsSection extends Component {
 		);
 	}
 }
-
+//Used to avoid re-renders. Do not mutate!
 const emptyArray = [];
 
 const mapStateToProps = ( state ) => {

--- a/client/my-sites/earn/memberships/index.jsx
+++ b/client/my-sites/earn/memberships/index.jsx
@@ -220,7 +220,13 @@ class MembershipsSection extends Component {
 		const isPayments = isEnabled( 'earn/rename-payment-blocks' );
 		return (
 			<div>
-				<SectionHeader label={ this.props.translate( 'Customers and Subscribers' ) } />
+				<SectionHeader
+					label={
+						isPayments
+							? this.props.translate( 'Customers and Subscribers' )
+							: this.props.translate( 'Subscribers' )
+					}
+				/>
 				{ Object.values( this.props.subscribers ).length === 0 && (
 					<Card>
 						{ isPayments

--- a/client/my-sites/earn/memberships/products.jsx
+++ b/client/my-sites/earn/memberships/products.jsx
@@ -67,12 +67,12 @@ class MembershipsProductsSection extends Component {
 			<div>
 				<QueryMembershipProducts siteId={ this.props.siteId } />
 				<HeaderCake backHref={ '/earn/payments/' + this.props.siteSlug }>
-					{ this.props.translate( 'Recurring Payments plans' ) }
+					{ this.props.translate( 'Payment plans' ) }
 				</HeaderCake>
 
 				<SectionHeader>
 					<Button primary compact onClick={ () => this.openAddEditDialog( null ) }>
-						{ this.props.translate( 'Add new plan' ) }
+						{ this.props.translate( 'Add a new payment plan' ) }
 					</Button>
 				</SectionHeader>
 				{ this.props.products.map( ( product ) => (

--- a/client/my-sites/earn/memberships/products.jsx
+++ b/client/my-sites/earn/memberships/products.jsx
@@ -21,6 +21,7 @@ import PopoverMenuItem from 'components/popover/menu-item';
 import Gridicon from 'components/gridicon';
 import RecurringPaymentsPlanAddEditModal from './add-edit-plan-modal';
 import RecurringPaymentsPlanDeleteModal from './delete-plan-modal';
+import { isEnabled } from 'config';
 
 class MembershipsProductsSection extends Component {
 	state = {
@@ -67,12 +68,16 @@ class MembershipsProductsSection extends Component {
 			<div>
 				<QueryMembershipProducts siteId={ this.props.siteId } />
 				<HeaderCake backHref={ '/earn/payments/' + this.props.siteSlug }>
-					{ this.props.translate( 'Payment plans' ) }
+					{ isEnabled( 'earn/rename-payment-blocks' )
+						? this.props.translate( 'Payment plans' )
+						: this.props.translate( 'Recurring Payments plans' ) }
 				</HeaderCake>
 
 				<SectionHeader>
 					<Button primary compact onClick={ () => this.openAddEditDialog( null ) }>
-						{ this.props.translate( 'Add a new payment plan' ) }
+						{ isEnabled( 'earn/rename-payment-blocks' )
+							? this.props.translate( 'Add a new payment plan' )
+							: this.props.translate( 'Add new plan' ) }
 					</Button>
 				</SectionHeader>
 				{ this.props.products.map( ( product ) => (


### PR DESCRIPTION
This PR:
- Renames "Recurring Payments" to "Payments"
<img width="524" alt="Zrzut ekranu 2020-06-8 o 15 29 32" src="https://user-images.githubusercontent.com/3775068/84036238-402ef400-a99d-11ea-8878-f6d03eeb4aa6.png">
<img width="538" alt="Screen Shot 2020-06-17 at 3 49 55 PM" src="https://user-images.githubusercontent.com/1270189/84958429-35b5de00-b0b2-11ea-9976-76ff7d248fd5.png">
<img width="1037" alt="Zrzut ekranu 2020-06-8 o 15 29 53" src="https://user-images.githubusercontent.com/3775068/84036247-42914e00-a99d-11ea-816b-471e647a7fe5.png">
<img width="1038" alt="Zrzut ekranu 2020-06-8 o 15 30 06" src="https://user-images.githubusercontent.com/3775068/84036255-44f3a800-a99d-11ea-8f2c-8120d36009c1.png">
<img width="948" alt="Screen Shot 2020-06-17 at 3 52 37 PM" src="https://user-images.githubusercontent.com/1270189/84958653-aceb7200-b0b2-11ea-8ac0-a1201c50e956.png">
<img width="957" alt="Screen Shot 2020-06-17 at 3 52 44 PM" src="https://user-images.githubusercontent.com/1270189/84958655-ae1c9f00-b0b2-11ea-9172-6b1291b36afd.png">

### Notes
* I'll handle the one-time payment option in a seperate PR
* Modifying the copy in the following card, will be handled by the Simple Payments rename PR

<img width="542" alt="Screen Shot 2020-06-17 at 3 53 35 PM" src="https://user-images.githubusercontent.com/1270189/84958741-df956a80-b0b2-11ea-8ac7-07db978e3765.png">


## Testing instructions
- Sandbox, Set-up recurring payments
- Check out this PR
- Verify no copy changes in non-production environment, or add `?flags=-earn/rename-payment-blocks` and refresh
- Verify that copy changes make sense in development


