### PR TITLE
Jetpack Cloud: Collapse the sidebar 'threats' badge on narrower layouts

### DIFF
--- a/client/landing/jetpack-cloud/components/scan-badge/index.tsx
+++ b/client/landing/jetpack-cloud/components/scan-badge/index.tsx
@@ -8,7 +8,9 @@ import { isNumber } from 'lodash';
 /**
  * Internal dependencies
  */
+import { ScreenReaderText } from '@automattic/components';
 import Badge from 'components/badge';
+import './style.scss';
 
 interface Props {
 	numberOfThreatsFound: number;
@@ -34,14 +36,33 @@ const ScanBadge: FunctionComponent< Props > = ( { numberOfThreatsFound, progress
 	}
 
 	if ( numberOfThreatsFound ) {
+		// We selectively hide the word "threats" based on screen width,
+		// but it should always remain visible to screen readers
 		return (
 			<Badge type="error">
-				{ translate( '%(number)d threat', '%(number)d threats', {
-					count: numberOfThreatsFound,
-					args: {
-						number: numberOfThreatsFound,
-					},
-				} ) }
+				<span aria-hidden="true">
+					{ translate(
+						'%(number)d {{span}}threat{{/span}}',
+						'%(number)d {{span}}threats{{/span}}',
+						{
+							count: numberOfThreatsFound,
+							args: {
+								number: numberOfThreatsFound,
+							},
+							components: {
+								span: <span className="scan-badge__words" />,
+							},
+						}
+					) }
+				</span>
+				<ScreenReaderText>
+					{ translate( '%(number)d threat', '%(number)d threats', {
+						count: numberOfThreatsFound,
+						args: {
+							number: numberOfThreatsFound,
+						},
+					} ) }
+				</ScreenReaderText>
 			</Badge>
 		);
 	}

--- a/client/landing/jetpack-cloud/components/scan-badge/style.scss
+++ b/client/landing/jetpack-cloud/components/scan-badge/style.scss
@@ -1,0 +1,5 @@
+.scan-badge__words {
+	@include breakpoint-deprecated( '660px-960px' ) {
+		display: none;
+	}
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* In the Scanner's side bar 'threats' badge, enclose all visible text in an ARIA-hidden span
* Re-add invisible text for screen readers, so the threats badge is always fully readable
* Enclose the visible word 'threats' in its own span; this span is hidden for screen widths between 661 and 960px, where the sidebar is too small for wording in some languages, but visible otherwise

Fixes #42756, `1169345694087188-as-1177874941247940`

#### Testing instructions

(Note: In practice, testing each of these sets independently should be fine. For absolute 100% coverage, feel free to test all permutations.)
**Test cases (threat count):** no threats, singular threat, plural threats
**Test cases (screen width):** 660px or less, 661-960px, 961px or more
**Test cases (page state):** Scan menu open, Scan menu closed

**Most critical path:**
* Open Jetpack Cloud for a site with Scan and at least one threat detected.
* Verify that as you change the width of the browser screen, the word "threats" appears at first in narrow/mobile layouts, then disappears in mid-width layouts, and re-appears again in full-width layouts.
* Verify the badge shows and behaves as it did before; i.e., it is visible and clickable both when the Scan menu is closed and when it is open.
* Inspect the badge in the sidebar showing "X" or "X threats" using your browser's DevTools.
* Verify that you can see an element with the text "X threats" for screen readers that is not visible on the page, and that it is always present no matter the width of the screen or state of the Scan sidebar menu.
* Verify that when viewing Jetpack Cloud for sites with no threats detected, the badge is not shown and no screen reader text for it is present in the page DOM.

#### Screenshots

##### 660px or narrower

<img width="672" alt="Screen Shot 2020-06-01 at 12 31 20" src="https://user-images.githubusercontent.com/670067/83437625-afd53a00-a405-11ea-9a38-25961e66dfa6.png">

##### 660-960px (pictured with screen reader text in DevTools)

<img width="788" alt="Screen Shot 2020-06-01 at 12 33 11" src="https://user-images.githubusercontent.com/670067/83437802-02aef180-a406-11ea-9afa-c98c8899c8bb.png">

##### Wider than 960px

<img width="516" alt="Screen Shot 2020-06-01 at 12 46 35" src="https://user-images.githubusercontent.com/670067/83437783-fa56b680-a405-11ea-9002-bce04d7346ac.png">
