### PR TITLE
Remove reference to Cloud in auth screen

### DIFF
--- a/client/landing/jetpack-cloud/sections/auth/connect/index.tsx
+++ b/client/landing/jetpack-cloud/sections/auth/connect/index.tsx
@@ -29,11 +29,11 @@ const Connect: FunctionComponent< Props > = ( { authUrl } ) => {
 				<JetpackLogo full monochrome={ false } size={ 72 } />
 				<p>
 					{ translate(
-						'Welcome to Jetpack Cloud. Authorize with your WordPress.com credentials to get started.'
+						'Welcome to Jetpack. Authorize with your WordPress.com credentials to get started.'
 					) }
 				</p>
 				<Button primary href={ authUrl }>
-					{ translate( 'Authorize Jetpack Cloud' ) }
+					{ translate( 'Authorize Jetpack' ) }
 				</Button>
 			</div>
 		</Main>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes a reference to Cloud in authorization screen, just using "Jetpack".

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In an incognito window, attempt to authorize Cloud but deny the request on WP.com.
* Screen should now be like this:

<img width="588" alt="Screen Shot 2020-06-01 at 2 02 32 PM" src="https://user-images.githubusercontent.com/1760168/83439464-30e5fe80-a411-11ea-9dbc-95c2536aa734.png">

Fixes 1143508703416848-as-1178316841543721.