### PR TITLE
Checkout: add summary business plan features

### DIFF
--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
@@ -26,7 +26,7 @@ import getSupportVariation, {
 	SUPPORT_DIRECTLY,
 } from 'state/selectors/get-inline-help-support-variation';
 import { useHasDomainsInCart, useDomainsInCart } from '../hooks/has-domains';
-import { useHasPlanInCart } from '../hooks/has-plan';
+import { useHasPlanInCart, usePlanInCart } from '../hooks/has-plan';
 import { isWpComBusinessPlan, isWpComEcommercePlan } from 'lib/plans';
 import isPresalesChatAvailable from 'state/happychat/selectors/is-presales-chat-available';
 import isHappychatAvailable from 'state/happychat/selectors/is-happychat-available';
@@ -110,6 +110,7 @@ function CheckoutSummaryFeaturesList() {
 				domains.map( ( domain ) => {
 					return <CheckoutSummaryFeaturesListDomainItem domain={ domain } key={ domain.id } />;
 				} ) }
+			{ hasPlanInCart && <CheckoutSummaryPlanFeatures /> }
 			<CheckoutSummaryFeaturesListItem>
 				<WPCheckoutCheckIcon />
 				{ supportText }
@@ -134,7 +135,7 @@ function CheckoutSummaryFeaturesListDomainItem( { domain } ) {
 					},
 					args: {
 						domain: domain.wpcom_meta.meta,
-						bundled: translate( 'free with plan' ),
+						bundled: translate( 'free for a year with your plan' ),
 					},
 					comment: 'domain name and bundling message, separated by a dash',
 				} )
@@ -143,6 +144,42 @@ function CheckoutSummaryFeaturesListDomainItem( { domain } ) {
 			) }
 		</CheckoutSummaryFeaturesListItem>
 	);
+}
+
+function CheckoutSummaryPlanFeatures() {
+	const translate = useTranslate();
+	const hasDomainsInCart = useHasDomainsInCart();
+	const planInCart = usePlanInCart();
+	const planFeatures = getPlanFeatures( planInCart, translate, hasDomainsInCart );
+
+	return (
+		<>
+			{ planFeatures &&
+				planFeatures.map( ( feature ) => {
+					return (
+						<CheckoutSummaryFeaturesListItem>
+							<WPCheckoutCheckIcon />
+							{ feature }
+						</CheckoutSummaryFeaturesListItem>
+					);
+				} ) }
+		</>
+	);
+}
+
+function getPlanFeatures( plan, translate, hasDomainsInCart ) {
+	if (
+		'business-bundle' === plan.wpcom_meta?.product_slug ||
+		'business-bundle-2y' === plan.wpcom_meta?.product_slug
+	) {
+		return [
+			! hasDomainsInCart && translate( 'Free domain for one year' ),
+			translate( 'Install plugins and themes' ),
+			translate( 'Drive traffic to your site with our advanced SEO tools' ),
+			translate( 'Track your stats with Google Analytics' ),
+		];
+	}
+	return false;
 }
 
 function CheckoutSummaryHelp() {

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
@@ -155,9 +155,9 @@ function CheckoutSummaryPlanFeatures() {
 	return (
 		<>
 			{ planFeatures &&
-				planFeatures.map( ( feature ) => {
+				planFeatures.map( ( feature, index ) => {
 					return (
-						<CheckoutSummaryFeaturesListItem>
+						<CheckoutSummaryFeaturesListItem key={ index }>
 							<WPCheckoutCheckIcon />
 							{ feature }
 						</CheckoutSummaryFeaturesListItem>
@@ -179,7 +179,7 @@ function getPlanFeatures( plan, translate, hasDomainsInCart ) {
 			translate( 'Track your stats with Google Analytics' ),
 		];
 	}
-	return false;
+	return [];
 }
 
 function CheckoutSummaryHelp() {

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
@@ -174,7 +174,7 @@ function getPlanFeatures( plan, translate, hasDomainsInCart ) {
 	) {
 		return [
 			! hasDomainsInCart && translate( 'Free domain for one year' ),
-			translate( 'Install plugins and themes' ),
+			translate( 'Install custom plugins and themes' ),
 			translate( 'Drive traffic to your site with our advanced SEO tools' ),
 			translate( 'Track your stats with Google Analytics' ),
 		];

--- a/client/my-sites/checkout/composite-checkout/wpcom/hooks/has-plan.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/hooks/has-plan.js
@@ -8,6 +8,15 @@ export function useHasPlanInCart() {
 	return isPlanInLineItems( items );
 }
 
+export function usePlanInCart() {
+	const [ items ] = useLineItems();
+	return items.find( isLineItemAPlan );
+}
+
 export function isPlanInLineItems( items ) {
-	return items.some( ( item ) => 'plan' === item.type );
+	return items.some( isLineItemAPlan );
+}
+
+export function isLineItemAPlan( item ) {
+	return 'plan' === item.type;
 }


### PR DESCRIPTION
This is a first step towards adding plan-specific features to the Checkout summary. It adds the following features to the summary when a 1- or 2-year business plan is in the cart:

- Free domain for one year (when a domain isn't in the cart)
- Install plugins and themes
- Drive traffic to your site with our advanced SEO tools
- Track your stats with Google Analytics

<img width="1352" alt="Screen Shot 2020-06-01 at 1 59 19 PM" src="https://user-images.githubusercontent.com/942359/83439363-fda36f80-a410-11ea-8852-6a78268e2abc.png">

**To test:**
- add a business plan to your cart and visit Checkout with `?flags=composite-checkout-testing`
- verify that the checkout summary has the added features
- switch plan variation and verify that the features remain
- add a domain and verify that the "Free domain for one year" feature is removed (a separate domain item should be seen)
