### PR TITLE
Sidebar: Don't show addtl domain upsell notice for Jetpack sites

### DIFF
--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -31,6 +31,7 @@ import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
 import { getUnformattedDomainPrice, getUnformattedDomainSalePrice } from 'lib/domains';
 import formatCurrency from '@automattic/format-currency/src';
 import { getPreference } from 'state/preferences/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
 import { savePreference } from 'state/preferences/actions';
 import isSiteMigrationInProgress from 'state/selectors/is-site-migration-in-progress';
 import isSiteMigrationActiveRoute from 'state/selectors/is-site-migration-active-route';
@@ -111,6 +112,10 @@ export class SiteNotice extends React.Component {
 
 	domainUpsellNudge() {
 		if ( ! this.props.isPlanOwner || this.props.domainUpsellNudgeDismissedDate ) {
+			return null;
+		}
+
+		if ( this.props.isJetpack ) {
 			return null;
 		}
 
@@ -291,6 +296,7 @@ export default connect(
 		return {
 			isDomainOnly: isDomainOnlySite( state, siteId ),
 			isEligibleForFreeToPaidUpsell: isEligibleForFreeToPaidUpsell( state, siteId ),
+			isJetpack: isJetpackSite( state, siteId ),
 			activeDiscount: getActiveDiscount( state ),
 			hasDomainCredit: hasDomainCredit( state, siteId ),
 			canManageOptions: canCurrentUser( state, siteId, 'manage_options' ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This was reported by @jeherve in Slack
* We're setting `forceDisplay` on this nudge, but it still should not show for Jetpack sites. Make sure we check if we're seeing a Jetpack site and bail before calling `UpsellNudge` if so.

**Before**

![image](https://user-images.githubusercontent.com/2124984/83441061-e74ae300-a413-11ea-8210-e681964c5252.png)

**After**

#### Testing instructions

* Switch to this PR
* Make sure the additional domains nudge does not appear on a Jetpack site.
* Make sure the nudge correctly appears on a WP.com site