### PR TITLE
Adds tracks event for threat item chevron

### DIFF
--- a/client/landing/jetpack-cloud/components/log-item/index.tsx
+++ b/client/landing/jetpack-cloud/components/log-item/index.tsx
@@ -22,6 +22,7 @@ export interface Props {
 	summary?: string | ReactNode;
 	expandedSummary?: string | ReactNode;
 	clickableHeader?: boolean;
+	onClick?: Function;
 }
 
 class LogItem extends React.PureComponent< Props > {
@@ -47,6 +48,7 @@ class LogItem extends React.PureComponent< Props > {
 			className,
 			expandedSummary,
 			summary,
+			onClick,
 		} = this.props;
 		return (
 			<FoldableCard
@@ -56,6 +58,7 @@ class LogItem extends React.PureComponent< Props > {
 				expandedSummary={ expandedSummary }
 				summary={ summary }
 				clickableHeader={ clickableHeader }
+				onClick={ onClick }
 			>
 				{ children }
 			</FoldableCard>

--- a/client/landing/jetpack-cloud/components/threat-item/index.tsx
+++ b/client/landing/jetpack-cloud/components/threat-item/index.tsx
@@ -26,6 +26,7 @@ interface Props {
 	isPlaceholder: boolean;
 	onFixThreat?: Function;
 	onIgnoreThreat?: Function;
+	onClickHeader?: Function;
 	isFixing: boolean;
 	contactSupportUrl?: string;
 }
@@ -37,6 +38,7 @@ const ThreatItem: React.FC< Props > = ( {
 	onIgnoreThreat,
 	isFixing,
 	contactSupportUrl,
+	onClickHeader,
 } ) => {
 	/**
 	 * Render a CTA button. Currently, this button is rendered three
@@ -119,6 +121,7 @@ const ThreatItem: React.FC< Props > = ( {
 				: {} ) }
 			{ ...( threat.status === 'current' ? { highlight: 'error' } : {} ) }
 			clickableHeader={ true }
+			onClick={ onClickHeader }
 		>
 			<ThreatDescription
 				status={ threat.status }

--- a/client/landing/jetpack-cloud/sections/scan/history/index.jsx
+++ b/client/landing/jetpack-cloud/sections/scan/history/index.jsx
@@ -75,6 +75,19 @@ const ScanHistoryPage = ( {
 		[ dispatchRecordTracksEvent, siteId, siteSlug ]
 	);
 
+	const clickHeader = React.useCallback(
+		( { signature } ) => {
+			const eventName = 'calypso_jetpack_scan_threatitem_headertoggle';
+			dispatch(
+				recordTracksEvent( eventName, {
+					site_id: siteId,
+					threat_signature: signature,
+				} )
+			);
+		},
+		[ dispatch, siteId ]
+	);
+
 	const openDialog = React.useCallback(
 		( threat ) => {
 			const eventName = 'calypso_jetpack_scan_fixthreat_dialogopen';
@@ -143,6 +156,7 @@ const ScanHistoryPage = ( {
 						isFixing={ !! updatingThreats.find( ( threatId ) => threatId === threat.id ) }
 						contactSupportUrl={ contactSupportUrl( siteSlug ) }
 						isPlaceholder={ isRequestingHistory }
+						onClickHeader={ () => clickHeader( threat ) }
 					/>
 				) ) }
 				{ selectedThreat && (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This adds tracking for toggling the threat item chevron with the name `calypso_jetpack_scan_threatitem_headertoggle`.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit a site with threats in the history on Cloud.
* Open dev tools and watch for `t.gif` in network traffic.
* Toggle threat item headers.

Fixes 1169345694087188-as-1178122806736476.
