### PR TITLE
Standardize (external) media libraries labels

### DIFF
--- a/client/components/tinymce/plugins/insert-menu/menu-items.jsx
+++ b/client/components/tinymce/plugins/insert-menu/menu-items.jsx
@@ -37,7 +37,7 @@ export const menuItems = [
 		item: (
 			<GridiconButton
 				icon={ <Gridicon icon="image" /> }
-				label={ i18n.translate( 'Media' ) }
+				label={ i18n.translate( 'Media library' ) }
 				e2e="media"
 			/>
 		),
@@ -52,7 +52,7 @@ if ( config.isEnabled( 'external-media' ) ) {
 			item: (
 				<GridiconButton
 					icon={ <Gridicon icon="shutter" /> }
-					label={ i18n.translate( 'Google Photos library' ) }
+					label={ i18n.translate( 'Google Photos' ) }
 					e2e="google-media"
 				/>
 			),
@@ -66,7 +66,7 @@ if ( config.isEnabled( 'external-media' ) ) {
 			item: (
 				<GridiconButton
 					icon={ <Gridicon icon="image-multiple" /> }
-					label={ i18n.translate( 'Free photo library' ) }
+					label={ i18n.translate( 'Pexels free photos' ) }
 					e2e="stock-media-pexels"
 				/>
 			),

--- a/client/my-sites/media-library/data-source.jsx
+++ b/client/my-sites/media-library/data-source.jsx
@@ -54,21 +54,21 @@ export class MediaLibraryDataSource extends Component {
 		const sources = [
 			{
 				value: '',
-				label: translate( 'WordPress library' ),
+				label: translate( 'Media library' ),
 				icon: <Gridicon icon="image" size={ 24 } />,
 			},
 		];
 		if ( config.isEnabled( 'external-media/google-photos' ) && includeExternalMedia ) {
 			sources.push( {
 				value: 'google_photos',
-				label: translate( 'Google Photos library' ),
+				label: translate( 'Google Photos' ),
 				icon: <GooglePhotosIcon />,
 			} );
 		}
 		if ( config.isEnabled( 'external-media/free-photo-library' ) && includeExternalMedia ) {
 			sources.push( {
 				value: 'pexels',
-				label: translate( 'Free photo library' ),
+				label: translate( 'Pexels free photos' ),
 				icon: <Gridicon icon="image-multiple" size={ 24 } />,
 			} );
 		}

--- a/client/post-editor/editor-html-toolbar/index.jsx
+++ b/client/post-editor/editor-html-toolbar/index.jsx
@@ -517,7 +517,7 @@ export class EditorHtmlToolbar extends Component {
 					onClick={ this.openMediaModal }
 				>
 					<Gridicon icon="image" />
-					<span data-e2e-insert-type="media">{ translate( 'Media' ) }</span>
+					<span data-e2e-insert-type="media">{ translate( 'Media library' ) }</span>
 				</button>
 
 				{ config.isEnabled( 'external-media/google-photos' ) && canUserUploadFiles && (
@@ -526,9 +526,7 @@ export class EditorHtmlToolbar extends Component {
 						onClick={ this.openGoogleModal }
 					>
 						<Gridicon icon="shutter" />
-						<span data-e2e-insert-type="google-media">
-							{ translate( 'Google Photos library' ) }
-						</span>
+						<span data-e2e-insert-type="google-media">{ translate( 'Google Photos' ) }</span>
 					</button>
 				) }
 
@@ -538,7 +536,7 @@ export class EditorHtmlToolbar extends Component {
 						onClick={ this.openPexelsModal }
 					>
 						<Gridicon icon="image-multiple" />
-						<span data-e2e-insert-type="pexels">{ translate( 'Free photo library' ) }</span>
+						<span data-e2e-insert-type="pexels">{ translate( 'Pexels free photos' ) }</span>
 					</button>
 				) }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates labels of media libraries to be standardized between Jetpack and WP.com.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/media` and click on the top left logo to open the libraries dropdown
* Make sure that everything still works and the labels are updated.
* (Optional) Find a site that doesn't have the block editor active
* Create a post and click the "Add" media button to bring up the libraries dropdown with updated labels.

Fixes 66-gh-dotcom-manage
