### PR TITLE
Update title on editor close button to match its destination

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -13,6 +13,7 @@ import { addQueryArgs, getQueryArg } from '@wordpress/url';
 import { Component } from 'react';
 import tinymce from 'tinymce/tinymce';
 import debugFactory from 'debug';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -560,6 +561,7 @@ function handleInsertClassicBlockMedia( calypsoPort ) {
 /**
  * Prevents the default closing flow and sends a message to the parent frame to
  * perform the navigation on the client side.
+ * Also changes the title on the button to match wpcom's close behavior
  *
  * @param {MessagePort} calypsoPort Port used for communication with parent frame.
  */
@@ -567,6 +569,7 @@ function handleCloseEditor( calypsoPort ) {
 	const legacySelector = '.edit-post-fullscreen-mode-close__toolbar a'; // maintain support for Gutenberg plugin < v7.7
 	const selector = '.edit-post-header .edit-post-fullscreen-mode-close';
 	const siteEditorSelector = '.edit-site-header .edit-site-fullscreen-mode-close';
+	const closeModalButtonTitle = __( 'Home' );
 
 	addAction( 'a8c.wpcom-block-editor.closeEditor', 'a8c/wpcom-block-editor/closeEditor', () => {
 		const { port2 } = new MessageChannel();
@@ -593,6 +596,7 @@ function handleCloseEditor( calypsoPort ) {
 
 	$( '#editor' ).on( 'click', `${ legacySelector }, ${ selector }`, dispatchAction );
 	$( '#edit-site-editor' ).on( 'click', `${ siteEditorSelector }`, dispatchAction );
+	$( `#edit-site-editor ${ siteEditorSelector }` ).title( closeModalButtonTitle );
 }
 
 /**


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Currently the close button title says "View Pages" when it actually takes you to the site home.
We intercept and override the click handler in the wpcom-block-editor app but did not change the button title along with it. see #42707

#### Testing instructions
DRAFT: I currently haven't tested this myself :blush: but:

Upload the wpcom-block-editor app to your sandbox with `cd apps/wpcom-block-editor && yarn dev --sync`
Visit a sandboxed test site.
Open the gutenberg editor
Mouse over the wordpress icon button in the top left corner of the screen
The title should now say "Home"


Fixes #42707
