### PR TITLE
P2: Invite Link feature

### DIFF
--- a/client/lib/invites/actions.js
+++ b/client/lib/invites/actions.js
@@ -79,9 +79,13 @@ export function generateInviteLinks( siteId ) {
 	debug( 'generateInviteLinks', siteId );
 
 	return ( dispatch ) => {
-		wpcom.undocumented().generateInviteLinks( siteId, () => {
-			dispatch( requestSiteInvites( siteId ) );
-		} );
+		wpcom
+			.undocumented()
+			.site( siteId )
+			.generateInviteLinks()
+			.then( () => {
+				dispatch( requestSiteInvites( siteId ) );
+			} );
 	};
 }
 
@@ -89,9 +93,13 @@ export function disableInviteLinks( siteId ) {
 	debug( 'disableInviteLinks', siteId );
 
 	return ( dispatch ) => {
-		wpcom.undocumented().disableInviteLinks( siteId, () => {
-			dispatch( requestSiteInvites( siteId ) );
-		} );
+		wpcom
+			.undocumented()
+			.site( siteId )
+			.disableInviteLinks()
+			.then( () => {
+				dispatch( requestSiteInvites( siteId ) );
+			} );
 	};
 }
 

--- a/client/lib/invites/actions.js
+++ b/client/lib/invites/actions.js
@@ -85,6 +85,16 @@ export function generateInviteLinks( siteId ) {
 	};
 }
 
+export function disableInviteLinks( siteId ) {
+	debug( 'disableInviteLinks', siteId );
+
+	return ( dispatch ) => {
+		wpcom.undocumented().disableInviteLinks( siteId, () => {
+			dispatch( requestSiteInvites( siteId ) );
+		} );
+	};
+}
+
 export function acceptInvite( invite, callback ) {
 	return ( dispatch ) => {
 		Dispatcher.handleViewAction( {

--- a/client/lib/invites/actions.js
+++ b/client/lib/invites/actions.js
@@ -16,6 +16,7 @@ import { recordTracksEvent } from 'lib/analytics/tracks';
 import { errorNotice, successNotice } from 'state/notices/actions';
 import { acceptedNotice } from 'my-sites/invites/utils';
 import { requestSites, receiveSites } from 'state/sites/actions';
+import { requestSiteInvites } from 'state/invites/actions';
 
 /**
  * Module variables
@@ -71,6 +72,16 @@ export function createAccount( userData, invite, callback ) {
 					callback( error, bearerToken );
 				}
 			);
+	};
+}
+
+export function generateInviteLinks( siteId ) {
+	debug( 'generateInviteLinks', siteId );
+
+	return ( dispatch ) => {
+		wpcom.undocumented().generateInviteLinks( siteId, () => {
+			dispatch( requestSiteInvites( siteId ) );
+		} );
 	};
 }
 

--- a/client/lib/wpcom-undocumented/lib/site.js
+++ b/client/lib/wpcom-undocumented/lib/site.js
@@ -69,12 +69,12 @@ resources.forEach( function ( resource ) {
 /**
  * Create an UndocumentedSite instance
  *
- * @param {[int]}   id          Site ID
- * @param {[WPCOM]} wpcom       WPCOM instance
+ * @param {number}   id          Site ID
+ * @param {object} wpcom       WPCOM instance
  *
- * @returns {{UndocumentedSite}} UndocumentedSite instance
+ * @returns {UndocumentedSite} UndocumentedSite instance
  *
- * @api public
+ * @public
  */
 function UndocumentedSite( id, wpcom ) {
 	debug( 'UndocumentedSite', id );

--- a/client/lib/wpcom-undocumented/lib/site.js
+++ b/client/lib/wpcom-undocumented/lib/site.js
@@ -416,6 +416,36 @@ UndocumentedSite.prototype.deleteInvites = function ( inviteIds ) {
 		}
 	);
 };
+/**
+ * Generate invite links
+ *
+ * @returns {Promise}             A Promise to resolve when complete.
+ */
+UndocumentedSite.prototype.generateInviteLinks = function () {
+	return this.wpcom.req.post(
+		{
+			path: `/sites/${ this._id }/invites/links/generate`,
+			apiNamespace: 'wpcom/v2',
+		},
+		{}
+	);
+};
+
+/**
+ * Disable invite links
+ *
+ * @returns {Promise}             A Promise to resolve when complete.
+ */
+
+UndocumentedSite.prototype.disableInviteLinks = function () {
+	return this.wpcom.req.post(
+		{
+			path: `/sites/${ this._id }/invites/links/disable`,
+			apiNamespace: 'wpcom/v2',
+		},
+		{}
+	);
+};
 
 /**
  * Expose `UndocumentedSite` module

--- a/client/lib/wpcom-undocumented/lib/site.js
+++ b/client/lib/wpcom-undocumented/lib/site.js
@@ -66,6 +66,7 @@ resources.forEach( function ( resource ) {
 	UndocumentedSite.prototype[ name ] = list.call( this, resourceOptions );
 } );
 
+/* eslint-disable jsdoc/no-undefined-types */
 /**
  * Create an UndocumentedSite instance
  *

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -263,16 +263,6 @@ Undocumented.prototype.scheduleJetpackFullysync = function ( siteId, fn ) {
 	return this.wpcom.req.post( { path: endpointPath }, {}, fn );
 };
 
-Undocumented.prototype.generateInviteLinks = function ( siteId, fn ) {
-	debug( '/sites/:site_id:/invites/links/generate query', siteId );
-	return this.wpcom.req.post( '/sites/' + siteId + '/invites/links/generate', {}, fn );
-};
-
-Undocumented.prototype.disableInviteLinks = function ( siteId, fn ) {
-	debug( '/sites/:site_id:/invites/links/disable query', siteId );
-	return this.wpcom.req.post( '/sites/' + siteId + '/invites/links/disable', {}, fn );
-};
-
 Undocumented.prototype.invitesList = function ( siteId, data = {}, fn ) {
 	debug( '/sites/:site_id:/invites query', siteId, data );
 	return this.wpcom.req.get( '/sites/' + siteId + '/invites', data, fn );

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -264,8 +264,13 @@ Undocumented.prototype.scheduleJetpackFullysync = function ( siteId, fn ) {
 };
 
 Undocumented.prototype.generateInviteLinks = function ( siteId, fn ) {
-	debug( '/sites/:site_id:/invites/newlinks query', siteId );
+	debug( '/sites/:site_id:/invites/links/generate query', siteId );
 	return this.wpcom.req.post( '/sites/' + siteId + '/invites/links/generate', {}, fn );
+};
+
+Undocumented.prototype.disableInviteLinks = function ( siteId, fn ) {
+	debug( '/sites/:site_id:/invites/links/disable query', siteId );
+	return this.wpcom.req.post( '/sites/' + siteId + '/invites/links/disable', {}, fn );
 };
 
 Undocumented.prototype.invitesList = function ( siteId, data = {}, fn ) {

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -263,6 +263,11 @@ Undocumented.prototype.scheduleJetpackFullysync = function ( siteId, fn ) {
 	return this.wpcom.req.post( { path: endpointPath }, {}, fn );
 };
 
+Undocumented.prototype.generateInviteLinks = function ( siteId, fn ) {
+	debug( '/sites/:site_id:/invites/newlinks query', siteId );
+	return this.wpcom.req.post( '/sites/' + siteId + '/invites/links/generate', {}, fn );
+};
+
 Undocumented.prototype.invitesList = function ( siteId, data = {}, fn ) {
 	debug( '/sites/:site_id:/invites query', siteId, data );
 	return this.wpcom.req.get( '/sites/' + siteId + '/invites', data, fn );

--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -459,7 +459,11 @@ class InvitePeople extends React.Component {
 	disableInviteLinks = () => {
 		accept(
 			<div>
-				<p>{ this.props.translate( 'Are you sure you wish to disable the invite link?' ) }</p>
+				<p>
+					{ this.props.translate(
+						'Once this invite link is disabled, nobody will be able to use it to join your team. Are you sure?'
+					) }
+				</p>
 			</div>,
 			( accepted ) => {
 				if ( accepted ) {

--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -58,6 +58,7 @@ import FormSelect from 'components/forms/form-select';
 import FormTextInput from 'components/forms/form-text-input';
 import ClipboardButton from 'components/forms/clipboard-button';
 import SectionHeader from 'components/section-header';
+import accept from 'lib/accept';
 
 /**
  * Style dependencies
@@ -456,13 +457,17 @@ class InvitePeople extends React.Component {
 	};
 
 	disableInviteLinks = () => {
-		if (
-			window.confirm(
-				this.props.translate( 'Are you sure you wish to disable these invite links?' )
-			)
-		) {
-			return this.props.disableInviteLinks( this.props.siteId );
-		}
+		accept(
+			<div>
+				<p>{ this.props.translate( 'Are you sure you wish to disable the invite link?' ) }</p>
+			</div>,
+			( accepted ) => {
+				if ( accepted ) {
+					this.props.disableInviteLinks( this.props.siteId );
+				}
+			},
+			this.props.translate( 'Disable', { context: 'Disable invite link.' } )
+		);
 	};
 
 	showInviteLinkForRole = ( event ) => {

--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -495,7 +495,7 @@ class InvitePeople extends React.Component {
 		}, 4000 );
 	};
 
-	renderCopyButton( link ) {
+	renderCopyLinkButton = ( link, className ) => {
 		const { translate } = this.props;
 
 		let label;
@@ -506,21 +506,19 @@ class InvitePeople extends React.Component {
 		}
 
 		return (
-			<ClipboardButton text={ link } onCopy={ this.onInviteLinkCopy } compact>
+			<ClipboardButton
+				className={ className }
+				text={ link }
+				onCopy={ this.onInviteLinkCopy }
+				compact
+			>
 				{ label }
 			</ClipboardButton>
 		);
-	}
+	};
 
-	renderInviteLinkForm = () => {
-		const {
-			//site,
-			siteRoles,
-			translate,
-			//needsVerification,
-			//isJetpack,
-			//showSSONotice,
-		} = this.props;
+	renderInviteLinkRoleSelector = ( activeInviteLink ) => {
+		const { siteRoles, translate } = this.props;
 
 		const roleOptions =
 			siteRoles &&
@@ -529,9 +527,61 @@ class InvitePeople extends React.Component {
 					{ role.display_name }
 				</option>
 			) );
+		const inviteUrlRef = React.createRef();
+
+		return (
+			<React.Fragment>
+				<div className="invite-people__link-selector">
+					<FormSelect
+						id="invite-people__link-selector-role"
+						className="invite-people__link-selector-role"
+						onChange={ this.showInviteLinkForRole }
+					>
+						{ roleOptions }
+					</FormSelect>
+
+					<FormTextInput
+						id="invite-people__link-selector-text"
+						className="invite-people__link-selector-text"
+						value={ activeInviteLink.link }
+						readOnly
+						ref={ inviteUrlRef }
+					/>
+					{ this.renderCopyLinkButton(
+						activeInviteLink.link,
+						'invite-people__link-selector-copy'
+					) }
+				</div>
+
+				<div className="invite-people__link-footer">
+					<span className="invite-people__link-expiry">
+						Expires on { new Date( activeInviteLink.expiry * 1000 ).toLocaleDateString() }{ ' ' }
+					</span>
+					<span>
+						(
+						<button className="invite-people__link-disable" onClick={ this.disableInviteLinks }>
+							{ translate( 'Disable invite links' ) }
+						</button>
+						)
+					</span>
+				</div>
+			</React.Fragment>
+		);
+	};
+
+	renderInviteLinkGenerateButton = () => {
+		const { translate } = this.props;
+		return (
+			<Button onClick={ this.generateInviteLinks } className="invite-people__link-generate">
+				{ translate( 'Generate new links' ) }
+			</Button>
+		);
+	};
+
+	renderInviteLinkForm = () => {
+		const { translate } = this.props;
 
 		const activeInviteLink = this.getActiveInviteLink( this.state.activeInviteLink );
-		const inviteUrlRef = React.createRef();
 
 		const inviteLinkForm = (
 			<Card>
@@ -550,40 +600,11 @@ class InvitePeople extends React.Component {
 						) }
 					</FormSettingExplanation>
 
-					{ ! activeInviteLink && (
-						<Button onClick={ this.generateInviteLinks } className="invite-people__generate-links">
-							{ translate( 'Generate new links' ) }
-						</Button>
-					) }
-
-					{ activeInviteLink && (
-						<React.Fragment>
-							<div>
-								<FormSelect
-									id="invite-people__link-role-select"
-									className="invite-people__link-role"
-									onChange={ this.showInviteLinkForRole }
-								>
-									{ roleOptions }
-								</FormSelect>
-
-								<FormTextInput
-									id="invite-people__link-display"
-									className="invite-people__link-display"
-									value={ activeInviteLink.link }
-									readOnly
-									ref={ inviteUrlRef }
-								/>
-
-								{ this.renderCopyButton( activeInviteLink.link ) }
-
-								<p>Expires on { new Date( activeInviteLink.expiry * 1000 ).toISOString() }</p>
-							</div>
-							<Button onClick={ this.disableInviteLinks } className="invite-people__disable-links">
-								{ translate( 'Disable links' ) }
-							</Button>
-						</React.Fragment>
-					) }
+					<div className="invite-people__link">
+						{ activeInviteLink
+							? this.renderInviteLinkRoleSelector( activeInviteLink )
+							: this.renderInviteLinkGenerateButton() }
+					</div>
 				</EmailVerificationGate>
 			</Card>
 		);

--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -56,6 +56,7 @@ import { getInviteLinksForSite } from 'state/invites/selectors';
 import { getSiteRoles } from 'state/site-roles/selectors';
 import FormSelect from 'components/forms/form-select';
 import FormTextInput from 'components/forms/form-text-input';
+import ClipboardButton from 'components/forms/clipboard-button';
 
 /**
  * Style dependencies
@@ -96,6 +97,7 @@ class InvitePeople extends React.Component {
 			errors: {},
 			success: [],
 			activeInviteLink: false,
+			showCopyConfirmation: false,
 		};
 	};
 
@@ -480,6 +482,36 @@ class InvitePeople extends React.Component {
 		return false;
 	};
 
+	onInviteLinkCopy = () => {
+		this.setState( {
+			showCopyConfirmation: true,
+		} );
+
+		clearTimeout( this.dismissCopyConfirmation );
+		this.dismissCopyConfirmation = setTimeout( () => {
+			this.setState( {
+				showCopyConfirmation: false,
+			} );
+		}, 4000 );
+	};
+
+	renderCopyButton( link ) {
+		const { translate } = this.props;
+
+		let label;
+		if ( this.state.showCopyConfirmation ) {
+			label = translate( 'Copied!' );
+		} else {
+			label = translate( 'Copy', { context: 'verb' } );
+		}
+
+		return (
+			<ClipboardButton text={ link } onCopy={ this.onInviteLinkCopy } compact>
+				{ label }
+			</ClipboardButton>
+		);
+	}
+
 	renderInviteLinkForm = () => {
 		const {
 			//site,
@@ -499,6 +531,7 @@ class InvitePeople extends React.Component {
 			) );
 
 		const activeInviteLink = this.getActiveInviteLink( this.state.activeInviteLink );
+		const inviteUrlRef = React.createRef();
 
 		const inviteLinkForm = (
 			<Card>
@@ -533,12 +566,17 @@ class InvitePeople extends React.Component {
 								>
 									{ roleOptions }
 								</FormSelect>
+
 								<FormTextInput
 									id="invite-people__link-display"
 									className="invite-people__link-display"
 									value={ activeInviteLink.link }
 									readOnly
+									ref={ inviteUrlRef }
 								/>
+
+								{ this.renderCopyButton( activeInviteLink.link ) }
+
 								<p>Expires on { new Date( activeInviteLink.expiry * 1000 ).toISOString() }</p>
 							</div>
 							<Button onClick={ this.disableInviteLinks } className="invite-people__disable-links">

--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -20,8 +20,13 @@ import FormButton from 'components/forms/form-button';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
-import { sendInvites, createInviteValidation, generateInviteLinks } from 'lib/invites/actions';
-import { Card } from '@automattic/components';
+import {
+	sendInvites,
+	createInviteValidation,
+	generateInviteLinks,
+	disableInviteLinks,
+} from 'lib/invites/actions';
+import { Card, Button } from '@automattic/components';
 import Main from 'components/main';
 import HeaderCake from 'components/header-cake';
 import CountedTextarea from 'components/forms/counted-textarea';
@@ -453,6 +458,16 @@ class InvitePeople extends React.Component {
 		return this.props.generateInviteLinks( this.props.siteId );
 	};
 
+	disableInviteLinks = () => {
+		if (
+			window.confirm(
+				this.props.translate( 'Are you sure you wish to disable these invite links?' )
+			)
+		) {
+			return this.props.disableInviteLinks( this.props.siteId );
+		}
+	};
+
 	renderInviteLinkForm = () => {
 		const {
 			//site,
@@ -481,22 +496,28 @@ class InvitePeople extends React.Component {
 					</FormSettingExplanation>
 
 					{ ! this.isInviteLinksComplete( inviteLinks ) && (
-						<FormButton
-							isPrimary={ true }
-							onClick={ this.generateInviteLinks }
-							className="invite-people__generate-link"
-						>
-							{ translate( 'Generate new link' ) }
-						</FormButton>
+						<Button onClick={ this.generateInviteLinks } className="invite-people__generate-links">
+							{ translate( 'Generate new links' ) }
+						</Button>
 					) }
 
 					{ this.isInviteLinksComplete( inviteLinks ) && (
-						<div>
-							<div>{ inviteLinks.administrator.link }</div>
-							<div>{ inviteLinks.editor.link }</div>
-							<div>{ inviteLinks.author.link }</div>
-							<div>{ inviteLinks.contributor.link }</div>
-						</div>
+						<React.Fragment>
+							<div>
+								<div>administrator: { inviteLinks.administrator.link }</div>
+								<div>editor: { inviteLinks.editor.link }</div>
+								<div>author: { inviteLinks.author.link }</div>
+								<div>contributor: { inviteLinks.contributor.link }</div>
+							</div>
+							<Button
+								onClick={ this.disableInviteLinks }
+								isSecondary
+								isLarge
+								className="invite-people__disable-links"
+							>
+								{ translate( 'Disable links' ) }
+							</Button>
+						</React.Fragment>
 					) }
 				</EmailVerificationGate>
 			</Card>
@@ -566,6 +587,7 @@ const connectComponent = connect(
 				sendInvites,
 				activateModule,
 				generateInviteLinks,
+				disableInviteLinks,
 			},
 			dispatch
 		),

--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -57,6 +57,7 @@ import { getSiteRoles } from 'state/site-roles/selectors';
 import FormSelect from 'components/forms/form-select';
 import FormTextInput from 'components/forms/form-text-input';
 import ClipboardButton from 'components/forms/clipboard-button';
+import SectionHeader from 'components/section-header';
 
 /**
  * Style dependencies
@@ -502,7 +503,7 @@ class InvitePeople extends React.Component {
 		if ( this.state.showCopyConfirmation ) {
 			label = translate( 'Copied!' );
 		} else {
-			label = translate( 'Copy', { context: 'verb' } );
+			label = translate( 'Copy link', { context: 'verb' } );
 		}
 
 		return (
@@ -560,7 +561,7 @@ class InvitePeople extends React.Component {
 					<span>
 						(
 						<button className="invite-people__link-disable" onClick={ this.disableInviteLinks }>
-							{ translate( 'Disable invite links' ) }
+							{ translate( 'Disable invite link' ) }
 						</button>
 						)
 					</span>
@@ -573,7 +574,7 @@ class InvitePeople extends React.Component {
 		const { translate } = this.props;
 		return (
 			<Button onClick={ this.generateInviteLinks } className="invite-people__link-generate">
-				{ translate( 'Generate new links' ) }
+				{ translate( 'Generate new link' ) }
 			</Button>
 		);
 	};
@@ -584,9 +585,9 @@ class InvitePeople extends React.Component {
 		const activeInviteLink = this.getActiveInviteLink( this.state.activeInviteLink );
 
 		const inviteLinkForm = (
-			<Card>
+			<Card className="invite-people__link">
 				<EmailVerificationGate>
-					<FormSettingExplanation>
+					<div class="invite-people__link-instructions">
 						{ translate(
 							'Use this link to onboard your team members without having to invite them one by one. '
 						) }
@@ -598,13 +599,11 @@ class InvitePeople extends React.Component {
 						{ translate(
 							'even if they received the link from somebody else, so make sure that you share it with trusted people.'
 						) }
-					</FormSettingExplanation>
-
-					<div className="invite-people__link">
-						{ activeInviteLink
-							? this.renderInviteLinkRoleSelector( activeInviteLink )
-							: this.renderInviteLinkGenerateButton() }
 					</div>
+
+					{ activeInviteLink
+						? this.renderInviteLinkRoleSelector( activeInviteLink )
+						: this.renderInviteLinkGenerateButton() }
 				</EmailVerificationGate>
 			</Card>
 		);
@@ -640,9 +639,7 @@ class InvitePeople extends React.Component {
 				{ this.renderInviteForm() }
 				{ isWPForTeamsSite && (
 					<React.Fragment>
-						<HeaderCake isCompact onClick={ this.goBack }>
-							{ translate( 'Invite Link' ) }
-						</HeaderCake>
+						<SectionHeader label={ translate( 'Invite Link' ) } />
 						{ this.renderInviteLinkForm() }
 					</React.Fragment>
 				) }

--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -503,7 +503,7 @@ class InvitePeople extends React.Component {
 		if ( this.state.showCopyConfirmation ) {
 			label = translate( 'Copied!' );
 		} else {
-			label = translate( 'Copy link', { context: 'verb' } );
+			label = translate( 'Copy link' );
 		}
 
 		return (

--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -478,6 +478,7 @@ class InvitePeople extends React.Component {
 		const { inviteLinks } = this.props;
 		const role = event.target.value || 'administrator';
 		this.setState( { activeInviteLink: inviteLinks[ role ] } );
+		this.setState( { showCopyConfirmation: false } );
 	};
 
 	getActiveInviteLink = ( activeInviteLink ) => {

--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -466,7 +466,7 @@ class InvitePeople extends React.Component {
 					this.props.disableInviteLinks( this.props.siteId );
 				}
 			},
-			this.props.translate( 'Disable', { context: 'Disable invite link.' } )
+			this.props.translate( 'Disable' )
 		);
 	};
 

--- a/client/my-sites/people/invite-people/style.scss
+++ b/client/my-sites/people/invite-people/style.scss
@@ -12,37 +12,50 @@
 }
 
 .invite-people__link {
-	margin-top: 24px;
+
+	.invite-people__link-generate {
+		float: right;
+	}
+
+	.invite-people__link-instructions {
+		font-size: 14px;
+		margin-bottom: 28px;
+	}
 
 	.invite-people__link-selector {
 		display: flex;
+		font-size: 14px;
 
 		.invite-people__link-selector-role {
 			flex: 1 0 auto;
-			margin-right: 5px;
+			font-size: inherit;
+			margin-right: 16px;
 		}
 		.invite-people__link-selector-text {
 			flex: 1 1 auto;
-			font-size: 13px;
-			margin-right: 5px;
+			font-size: inherit;
+			margin-right: 16px;
 		}
 		.invite-people__link-selector-copy {
 			flex: 1 0 auto;
+			font-size: inherit;
+			min-width: 100px;
+			padding: 7px 14px;
 		}
 	}
 
 	.invite-people__link-footer {
-		color: #acabab;
-		margin-top: 6px;
+		color: var( --color-text-subtle );
 		font-size: 12px;
 		font-style: italic;
+		margin-top: 8px;
 
 		.invite-people__link-expiry {
-			color: #acabab;
+			color: var( --color-text-subtle );
 		}
 
 		.invite-people__link-disable {
-			color: #c71616;
+			color: var( --color-error );
 			cursor: pointer;
 			font-size: inherit;
 			font-style: inherit;

--- a/client/my-sites/people/invite-people/style.scss
+++ b/client/my-sites/people/invite-people/style.scss
@@ -37,6 +37,7 @@
 			margin-right: 16px;
 		}
 		.invite-people__link-selector-copy {
+			color: var( --color-neutral-70 );
 			flex: 1 0 auto;
 			font-size: inherit;
 			min-width: 100px;

--- a/client/my-sites/people/invite-people/style.scss
+++ b/client/my-sites/people/invite-people/style.scss
@@ -10,3 +10,43 @@
 .invite-people__action-required .notice {
 	margin-bottom: 0;
 }
+
+.invite-people__link {
+	margin-top: 24px;
+
+	.invite-people__link-selector {
+		display: flex;
+
+		.invite-people__link-selector-role {
+			flex: 1 0 auto;
+			margin-right: 5px;
+		}
+		.invite-people__link-selector-text {
+			flex: 1 1 auto;
+			font-size: 13px;
+			margin-right: 5px;
+		}
+		.invite-people__link-selector-copy {
+			flex: 1 0 auto;
+		}
+	}
+
+	.invite-people__link-footer {
+		color: #acabab;
+		margin-top: 6px;
+		font-size: 12px;
+		font-style: italic;
+
+		.invite-people__link-expiry {
+			color: #acabab;
+		}
+
+		.invite-people__link-disable {
+			color: #c71616;
+			cursor: pointer;
+			font-size: inherit;
+			font-style: inherit;
+			text-decoration: underline;
+		}
+	}
+}

--- a/client/state/invites/actions.js
+++ b/client/state/invites/actions.js
@@ -36,12 +36,13 @@ export function requestSiteInvites( siteId ) {
 		wpcom
 			.undocumented()
 			.invitesList( siteId, { status: 'all', number: 100 } )
-			.then( ( { found, invites } ) => {
+			.then( ( { found, invites, links } ) => {
 				dispatch( {
 					type: INVITES_REQUEST_SUCCESS,
 					siteId,
 					found,
 					invites,
+					links,
 				} );
 			} )
 			.catch( ( error ) => {

--- a/client/state/invites/reducer.js
+++ b/client/state/invites/reducer.js
@@ -108,6 +108,7 @@ export const links = withSchemaValidation( inviteLinksSchema, ( state = {}, acti
 					link: link.link,
 					role: link.role,
 					inviteDate: link.invite_date,
+					expiry: link.expiry,
 				};
 
 				inviteLinks = {

--- a/client/state/invites/reducer.js
+++ b/client/state/invites/reducer.js
@@ -19,7 +19,7 @@ import {
 	INVITE_RESEND_REQUEST_FAILURE,
 	INVITE_RESEND_REQUEST_SUCCESS,
 } from 'state/action-types';
-import { inviteItemsSchema } from './schema';
+import { inviteItemsSchema, inviteLinksSchema } from './schema';
 
 /**
  * Returns the updated site invites requests state after an action has been
@@ -91,6 +91,33 @@ export const items = withSchemaValidation( inviteItemsSchema, ( state = {}, acti
 					accepted: deleteInvites( state[ action.siteId ].accepted, action.inviteIds ),
 					pending: deleteInvites( state[ action.siteId ].pending, action.inviteIds ),
 				},
+			};
+		}
+	}
+
+	return state;
+} );
+
+export const links = withSchemaValidation( inviteLinksSchema, ( state = {}, action ) => {
+	switch ( action.type ) {
+		case INVITES_REQUEST_SUCCESS: {
+			let inviteLinks = {};
+			action.links.forEach( ( link ) => {
+				const linkForState = {
+					key: link.invite_key,
+					role: link.role,
+					inviteDate: link.invite_date,
+				};
+
+				inviteLinks = {
+					...inviteLinks,
+					[ link.role ]: linkForState,
+				};
+			} );
+
+			return {
+				...state,
+				[ action.siteId ]: inviteLinks,
 			};
 		}
 	}
@@ -214,4 +241,11 @@ export function deleting( state = {}, action ) {
 	return state;
 }
 
-export default combineReducers( { requesting, items, counts, requestingResend, deleting } );
+export default combineReducers( {
+	requesting,
+	items,
+	counts,
+	requestingResend,
+	deleting,
+	links,
+} );

--- a/client/state/invites/reducer.js
+++ b/client/state/invites/reducer.js
@@ -105,6 +105,7 @@ export const links = withSchemaValidation( inviteLinksSchema, ( state = {}, acti
 			action.links.forEach( ( link ) => {
 				const linkForState = {
 					key: link.invite_key,
+					link: link.link,
 					role: link.role,
 					inviteDate: link.invite_date,
 				};

--- a/client/state/invites/schema.js
+++ b/client/state/invites/schema.js
@@ -47,3 +47,30 @@ export const inviteItemsSchema = {
 		},
 	},
 };
+
+const inviteLinksArraySchema = {
+	type: 'array',
+	items: {
+		type: 'object',
+		properties: {
+			key: { type: 'string' },
+			role: { type: 'string' },
+			inviteDate: { type: 'string' },
+		},
+		additionalProperties: false,
+	},
+};
+
+export const inviteLinksSchema = {
+	type: 'object',
+	patternProperties: {
+		// Site ID
+		'^\\d+$': {
+			type: 'object',
+			properties: {
+				'^\\[a-zA-Z]+$': inviteLinksArraySchema,
+			},
+			additionalProperties: false,
+		},
+	},
+};

--- a/client/state/invites/schema.js
+++ b/client/state/invites/schema.js
@@ -54,8 +54,10 @@ const inviteLinksArraySchema = {
 		type: 'object',
 		properties: {
 			key: { type: 'string' },
+			link: { type: 'string' },
 			role: { type: 'string' },
 			inviteDate: { type: 'string' },
+			expiry: { type: 'string' },
 		},
 		additionalProperties: false,
 	},
@@ -70,7 +72,7 @@ export const inviteLinksSchema = {
 			properties: {
 				'^\\[a-zA-Z]+$': inviteLinksArraySchema,
 			},
-			additionalProperties: false,
+			additionalProperties: true,
 		},
 	},
 };

--- a/client/state/invites/selectors.js
+++ b/client/state/invites/selectors.js
@@ -53,6 +53,22 @@ export function getAcceptedInvitesForSite( state, siteId ) {
 }
 
 /**
+ * Returns an array of all invite links for the given site, or
+ * `null` if there are none.
+ *
+ * @param  {object} state  Global state tree
+ * @param  {number} siteId Site ID
+ * @returns {?Array}       The list of invite links for the given site
+ */
+export function getInviteLinksForSite( state, siteId ) {
+	const inviteLinks = state.invites.links[ siteId ];
+	if ( ! inviteLinks ) {
+		return null;
+	}
+	return inviteLinks;
+}
+
+/**
  * Returns the total number of invites found for the given site, or `null`.
  *
  * @param  {object}  state  Global state tree
@@ -144,7 +160,7 @@ export function didInviteDeletionSucceed( state, siteId, inviteId ) {
  *
  * @param  {object}  state    Global state tree
  * @param  {number}  siteId   Site ID
-
+ *
  * @returns {boolean}          Whether an invite is being deleted
  */
 export function isDeletingAnyInvite( state, siteId ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adds an Invite Link feature inside the Invite page.  The feature request can be found in 264-gh-p2.

<img width="753" alt="Screen Shot 2020-06-02 at 3 35 07 PM" src="https://user-images.githubusercontent.com/730823/83493119-e59e1f80-a4e6-11ea-97ed-b6e53cfb25ea.png">

_Figure 1. There are no active links for the site so a button for generating links is displayed._


<img width="772" alt="Screen Shot 2020-06-02 at 12 25 42 AM" src="https://user-images.githubusercontent.com/730823/83492316-afac6b80-a4e5-11ea-87fd-c66131a5e66b.png">

_Figure 2. The invite link for the selected role is displayed inside a readonly text box, and can be copied using the provided clipboard button._


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. First apply D44159-code to your sandbox, and sandbox `public-api`.
2. On a P2 site, go to the Invite People page via `http://calypso.localhost:3000/people/new/<your-test-P2-site>`, or click **People** from the sidebar, then click the **Invite** button near the top right corner of the page.
3. Generate new links: Click the **Generate new links** button to generate invite links.
4. Optionally, use one of the invite links to join a test blog, and verify that the correct role is assigned. The accept-invite flow is no different from a regular invite via mail, except that invite links are not single-use.
5. Disable invite links: verify that disabling the links will render the previous invite links invalid. UI-wise, the generate button will be displayed instead of the role selector.
6. Go to `http://calypso.localhost:3000/people/invites/<your-test-P2-site>`. You should not see any weird invites listed (i.e. invite links should not be listed with single-user invitations).


