### PR TITLE
FSE: Gutenboarding launch save on exit

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/editor-gutenboarding-launch/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-gutenboarding-launch/index.php
@@ -15,12 +15,6 @@ namespace A8C\FSE\EditorGutenboardingLaunchButton;
  * Enqueue assets
  */
 function enqueue_script_and_style() {
-	// @TODO: Remove this block to enable in production
-	// Constant to disable the feature for development.
-	if ( ! ( defined( 'A8C_FSE_DOMAIN_PICKER_ENABLE' ) && A8C_FSE_DOMAIN_PICKER_ENABLE ) ) {
-		return;
-	}
-
 	// Avoid loading assets if possible.
 	if ( ! \A8C\FSE\Common\is_block_editor_screen() ) {
 		return;

--- a/apps/full-site-editing/full-site-editing-plugin/editor-gutenboarding-launch/index.ts
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-gutenboarding-launch/index.ts
@@ -4,6 +4,9 @@
 import { __ } from '@wordpress/i18n';
 import domReady from '@wordpress/dom-ready';
 import { addAction } from '@wordpress/hooks';
+import { dispatch } from '@wordpress/data';
+// Depend on `core/editor` store.
+import '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -52,11 +55,24 @@ function updateEditor() {
 
 		// Wrap 'Launch' button link to frankenflow.
 		const launchLink = document.createElement( 'a' );
-		launchLink.href = window?.calypsoifyGutenberg?.frankenflowUrl as string;
+
+		// Assert reason: We have an early return above with optional and falsy values. This should be a string.
+		const launchHref = window?.calypsoifyGutenberg?.frankenflowUrl as string;
+
+		launchLink.href = launchHref;
 		launchLink.target = '_top';
 		launchLink.className = 'editor-gutenberg-launch__launch-button components-button is-primary';
 		const textContent = document.createTextNode( __( 'Launch' ) );
 		launchLink.appendChild( textContent );
+
+		const saveAndNavigate = async ( e: Event ) => {
+			// Disable href navigation
+			e.preventDefault();
+			await dispatch( 'core/editor' ).autosave();
+			// Using window.top to escape from the editor iframe on WordPress.com
+			window.top.location.href = launchHref;
+		};
+		launchLink.addEventListener( 'click', saveAndNavigate );
 
 		// Put 'Launch' and 'Save' back on bar in desired order.
 		settingsBar.prepend( launchLink );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Trigger auto-save before navigating to the launch URL when clicking the "Launch" button as part of the [`/new`](https://wordpress.com/new) flow.

![Screen Shot 2020-06-03 at 13 52 34](https://user-images.githubusercontent.com/841763/83634003-1c853b80-a5a2-11ea-8ca2-9c663084062f.png)

![demo](https://user-images.githubusercontent.com/841763/83634008-1f802c00-a5a2-11ea-977a-4d158292ebb7.gif)


Known issues:

I've observed a warning in the browser about unsaved content when navigation occurs. This is a pre-existing issue.

#### Testing instructions

* Sandbox `widgets.wp.com` and `example.wordpress.com`.
* Apply D44333-code (wpcom-block-editor changes to enable this change)
* Apply D44258-code (these changes to FSE plugin)
* https://wordpress.com/block-editor/post works without regressions.
* Go through the  [`/new`](https://wordpress.com/new) flow.
* When you reach the editor from the new flow, the `Launch` button should be injected.
* Modify the post content.
* Click the "Launch" button. The post should autosave (indicated in the header) then you should be navigated to a launch flow. There may be a browser warning about unsaved content.

You can apply this patch below in local Calypso to force the Gutenboarding flow:

```patch
diff --git a/client/gutenberg/editor/calypsoify-iframe.tsx b/client/gutenberg/editor/calypsoify-iframe.tsx
index 022af07f59..887cf04922 100644
--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -295,8 +295,7 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 		}
 
 		if ( EditorActions.GetGutenboardingStatus === action ) {
-			const isGutenboarding =
-				this.props.siteCreationFlow === 'gutenboarding' && this.props.isSiteUnlaunched;
+			const isGutenboarding = true;
 			ports[ 0 ].postMessage( {
 				isGutenboarding,
 				frankenflowUrl: `${ window.location.origin }/start/new-launch?siteSlug=${ this.props.siteSlug }&source=editor`,
```

Fixes #42655 
