### PR TITLE
Deduplicate w3c-hr-time

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -6864,11 +6864,6 @@ browser-pack@^6.0.1:
     through2 "^2.0.0"
     umd "^3.0.0"
 
-browser-process-hrtime@^0.1.2:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz#616f00faef1df7ec1b5bf9cfe2bdc3170f26c7b4"
-  integrity sha512-bRFnI4NnjO6cnyLmOV/7PVoDEMJChlcfN0z4s1YMBY989/SvlfMI1lgCnkFUs53e9gQF+w7qu7XdllSTiSl8Aw==
-
 browser-process-hrtime@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz#3c9b4b7d782c8121e56f10106d84c0d0ffc94626"
@@ -25774,14 +25769,7 @@ vm-browserify@^1.0.0, vm-browserify@^1.0.1:
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
   integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
 
-w3c-hr-time@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz#82ac2bff63d950ea9e3189a58a65625fedf19045"
-  integrity sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=
-  dependencies:
-    browser-process-hrtime "^0.1.2"
-
-w3c-hr-time@^1.0.2:
+w3c-hr-time@^1.0.1, w3c-hr-time@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz#0a89cdf5cc15822df9c360543676963e0cc308cd"
   integrity sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `w3c-hr-time` (done automatically with `npx yarn-deduplicate --packages w3c-hr-time`)

Changelog: https://github.com/jsdom/w3c-hr-time/blob/master/CHANGELOG.md

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
< Before
> After
---
< wp-calypso-monorepo@0.17.0 -> @automattic/calypso-build@6.1.0 -> ... -> w3c-hr-time@1.0.1
< wp-calypso-monorepo@0.17.0 -> @automattic/full-site-editing@1.6.0 -> ... -> w3c-hr-time@1.0.1
< wp-calypso-monorepo@0.17.0 -> @wordpress/scripts@9.1.0 -> ... -> w3c-hr-time@1.0.1
< wp-calypso-monorepo@0.17.0 -> jest-enzyme@7.1.2 -> ... -> w3c-hr-time@1.0.1
> wp-calypso-monorepo@0.17.0 -> @automattic/calypso-build@6.1.0 -> ... -> w3c-hr-time@1.0.2
> wp-calypso-monorepo@0.17.0 -> @automattic/full-site-editing@1.6.0 -> ... -> w3c-hr-time@1.0.2
> wp-calypso-monorepo@0.17.0 -> @wordpress/scripts@9.1.0 -> ... -> w3c-hr-time@1.0.2
> wp-calypso-monorepo@0.17.0 -> jest-enzyme@7.1.2 -> ... -> w3c-hr-time@1.0.2
```