### PR TITLE
Mailerlite subscriber popup widget

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -291,6 +291,14 @@ function load_block_inserter_modifications() {
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_block_inserter_modifications' );
 
 /**
+ * Load Mailerlite module
+ */
+function load_mailerlite() {
+	require_once __DIR__ . '/mailerlite/subscriber-popup.php';
+}
+add_action( 'plugins_loaded', __NAMESPACE__ . '\load_mailerlite' );
+
+/**
  * Load WPCOM block editor nav sidebar
  */
 function load_wpcom_block_editor_sidebar() {

--- a/apps/full-site-editing/full-site-editing-plugin/mailerlite/subscriber-popup.js
+++ b/apps/full-site-editing/full-site-editing-plugin/mailerlite/subscriber-popup.js
@@ -1,0 +1,10 @@
+/* global ml,jetpackMailerliteSettings */
+
+( function () {
+	window.ml_account = ml(
+		'accounts',
+		jetpackMailerliteSettings.account,
+		jetpackMailerliteSettings.uuid,
+		'load'
+	);
+} )();

--- a/apps/full-site-editing/full-site-editing-plugin/mailerlite/subscriber-popup.php
+++ b/apps/full-site-editing/full-site-editing-plugin/mailerlite/subscriber-popup.php
@@ -35,7 +35,7 @@ class WPCOM_Widget_Mailerlite extends \WP_Widget {
 
 		if ( empty( $instance['account'] ) || empty( $instance['uuid'] ) ) {
 			if ( current_user_can( 'edit_theme_options' ) ) {
-				echo esc_js( $args['before_widget'] );
+				echo $args['before_widget']; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				echo '<p>' . sprintf(
 					wp_kses(
 						/* translators: %1$s - URL to manage the widget, %2$s - documentation URL. */
@@ -48,9 +48,9 @@ class WPCOM_Widget_Mailerlite extends \WP_Widget {
 						)
 					),
 					esc_url( admin_url( 'widgets.php' ) ),
-					'https://support.wordpress.com/widgets/mailerlite'
+					'https://wordpress.com/support/widgets/mailerlite'
 				) . '</p>';
-				echo esc_js( $args['after_widget'] );
+				echo $args['after_widget']; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			}
 			return;
 		}
@@ -110,7 +110,7 @@ class WPCOM_Widget_Mailerlite extends \WP_Widget {
 		echo '
 		<p><label for="' . esc_attr( $this->get_field_id( 'account' ) ) . '">';
 		/* translators: link to documentation */
-		printf( wp_kses_post( __( 'Account ID <a href="%s" target="_blank">(instructions)</a>:', 'jetpack' ) ), 'https://en.support.wordpress.com/widgets/mailerlite' );
+		printf( wp_kses_post( __( 'Account ID <a href="%s" target="_blank">(instructions)</a>:', 'jetpack' ) ), 'https://wordpress.com/support/widgets/mailerlite' );
 		echo '<input class="widefat" id="' . esc_attr( $this->get_field_id( 'account' ) ) . '" name="' . esc_attr( $this->get_field_name( 'account' ) ) . '" type="text" value="' . esc_attr( $instance['account'] ) . '" />
 		</label></p>
 		<p><label for="' . esc_attr( $this->get_field_id( 'shelf' ) ) . '">' . esc_html__( 'UUID:', 'jetpack' );
@@ -119,10 +119,12 @@ class WPCOM_Widget_Mailerlite extends \WP_Widget {
 		';
 	}
 }
-add_action(
-	'widgets_init',
-	function () {
-		register_widget( '\A8C\FSE\Mailerlite\WPCOM_Widget_Mailerlite' );
-	}
-);
+
+/**
+ * Registers the widget via widgets_init hook.
+ */
+function mailerlite_register_widget() {
+	register_widget( '\A8C\FSE\Mailerlite\WPCOM_Widget_Mailerlite' );
+}
+add_action( 'widgets_init', '\A8C\FSE\Mailerlite\mailerlite_register_widget' );
 

--- a/apps/full-site-editing/full-site-editing-plugin/mailerlite/subscriber-popup.php
+++ b/apps/full-site-editing/full-site-editing-plugin/mailerlite/subscriber-popup.php
@@ -1,0 +1,128 @@
+<?php //phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+namespace A8C\FSE\Mailerlite;
+
+/**
+ * Mailerlite widget class
+ * Display a subscriber popup for Mailerlite.
+ */
+class WPCOM_Widget_Mailerlite extends \WP_Widget {
+
+	/**
+	 * WPCOM_Widget_Mailerlite constructor.
+	 */
+	public function __construct() {
+		parent::__construct(
+			'wpcom-mailerlite',
+			/** This filter is documented in modules/widgets/facebook-likebox.php */
+			apply_filters( 'jetpack_widget_name', __( 'Mailerlite subscriber popup', 'jetpack' ) ),
+			array(
+				'classname'                   => 'widget_mailerlite',
+				'description'                 => __( 'Display Mailerlite subscriber popup', 'jetpack' ),
+				'customize_selective_refresh' => true,
+			)
+		);
+	}
+
+	/**
+	 * Output the widget.
+	 *
+	 * @param array $args Display arguments including 'before_title', 'after_title', 'before_widget', and 'after_widget'.
+	 * @param array $instance - The settings for the particular instance of the widget.
+	 */
+	public function widget( $args, $instance ) {
+		/** This action is documented in modules/widgets/gravatar-profile.php */
+		do_action( 'jetpack_stats_extra', 'widget_view', 'mailerlite' );
+
+		if ( empty( $instance['account'] ) || empty( $instance['uuid'] ) ) {
+			if ( current_user_can( 'edit_theme_options' ) ) {
+				echo esc_js( $args['before_widget'] );
+				echo '<p>' . sprintf(
+					wp_kses(
+						/* translators: %1$s - URL to manage the widget, %2$s - documentation URL. */
+						__( 'You need to enter your numeric account ID and UUID for the <a href="%1$s">Mailerlite Widget</a> to work correctly. <a href="%2$s" target="_blank">Full instructions</a>.', 'jetpack' ),
+						array(
+							'a' => array(
+								'href'  => array(),
+								'title' => array(),
+							),
+						)
+					),
+					esc_url( admin_url( 'widgets.php' ) ),
+					'https://support.wordpress.com/widgets/mailerlite'
+				) . '</p>';
+				echo esc_js( $args['after_widget'] );
+			}
+			return;
+		}
+
+		if ( wp_script_is( 'mailerlite-subscriber-popup', 'enqueued' ) ) {
+			return;
+		}
+
+		wp_register_script( 'mailerlite-universal', 'https://static.mailerlite.com/js/universal.js', array(), '20200521', true );
+		wp_enqueue_script(
+			'mailerlite-subscriber-popup',
+			plugins_url( 'subscriber-popup.js', __FILE__ ),
+			array( 'mailerlite-universal' ),
+			'20200521',
+			true
+		);
+		wp_localize_script(
+			'mailerlite-subscriber-popup',
+			'jetpackMailerliteSettings',
+			array(
+				'account' => esc_attr( $instance['account'] ),
+				'uuid'    => esc_attr( $instance['uuid'] ),
+			)
+		);
+
+	}
+
+	/**
+	 * Updates a particular instance of a widget.
+	 *
+	 * @param array $new_instance New settings for this instance as input by the user via WP_Widget::form().
+	 * @param array $old_instance   Old settings for this instance.
+	 *
+	 * @return mixed
+	 */
+	public function update( $new_instance, $old_instance ) { // @phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundInExtendedClassAfterLastUsed
+		$instance['account'] = wp_kses( stripslashes( $new_instance['account'] ), array() );
+		$instance['uuid']    = wp_kses( stripslashes( $new_instance['uuid'] ), array() );
+
+		return $instance;
+	}
+
+	/**
+	 * Editable form in WP-admin.
+	 *
+	 * @param array $instance - settings.
+	 */
+	public function form( $instance ) {
+		$instance = wp_parse_args(
+			(array) $instance,
+			array(
+				'account' => '',
+				'uuid'    => '',
+			)
+		);
+
+		echo '
+		<p><label for="' . esc_attr( $this->get_field_id( 'account' ) ) . '">';
+		/* translators: link to documentation */
+		printf( wp_kses_post( __( 'Account ID <a href="%s" target="_blank">(instructions)</a>:', 'jetpack' ) ), 'https://en.support.wordpress.com/widgets/mailerlite' );
+		echo '<input class="widefat" id="' . esc_attr( $this->get_field_id( 'account' ) ) . '" name="' . esc_attr( $this->get_field_name( 'account' ) ) . '" type="text" value="' . esc_attr( $instance['account'] ) . '" />
+		</label></p>
+		<p><label for="' . esc_attr( $this->get_field_id( 'shelf' ) ) . '">' . esc_html__( 'UUID:', 'jetpack' );
+		echo '<input class="widefat" id="' . esc_attr( $this->get_field_id( 'uuid' ) ) . '" name="' . esc_attr( $this->get_field_name( 'uuid' ) ) . '" type="text" value="' . esc_attr( $instance['uuid'] ) . '" />';
+		echo '</label></p>
+		';
+	}
+}
+add_action(
+	'widgets_init',
+	function () {
+		register_widget( '\A8C\FSE\Mailerlite\WPCOM_Widget_Mailerlite' );
+	}
+);
+


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This introduces a Mailerlite (https://www.mailerlite.com/)  subscriber widget.
Mailchimp subscriber popup has issues (93-gh-dotcom-manage)
Mailerlite is a (cheaper and simpler) mailchimp competitor that I personally use on my blog https://deliber.at . My other blog - https://piszek.com is hosted on WPCOM simple (on purpose). I have no way of introducing mailerlite signup on that blog.

This solves this problem.

![obraz](https://user-images.githubusercontent.com/3775068/83507361-c09ab400-a4c8-11ea-8b63-8ee15ac98059.png)

![Zrzut ekranu 2020-06-2 o 12 02 48](https://user-images.githubusercontent.com/3775068/83507570-048db900-a4c9-11ea-855d-27fa887cc562.png)


#### Testing instructions

- Check out D44264-code 
- If you don't want to set up Mailerlite account, you can use my email list (continue)
- Go to widgets, select mailerlite subscriber popup and drop it into a widget area
- You can use my popup ( account 1726876 , uuid o6h6c1w0c9 )
- Publish the widget
- Go see it in incognito, Scroll a bit, observe popup as in the screenshot.

**Using your account**

- Register on mailerlite.com
- Create a form in https://app.mailerlite.com/forms/
- Scroll down, look at 'Universal tracking script'
- Copy values from JS: var ml_account = ml('accounts', '1726876', 'o6h6c1w0c9', 'load'); - second argument is 'account' shortcode param, third is 'uuid'

