### PR TITLE
Disable automatic `yarn deduplicate` in Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -51,7 +51,6 @@
 			"groupName": "Newspack Blog Posts Block Update"
 		}
 	],
-	"postUpdateOptions": [ "yarnDedupeHighest" ],
 	"statusCheckVerify": true,
 	"rangeStrategy": "bump",
 	"ignoreDeps": [ "jquery" ],


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Disables running `yarn deduplicate` in Renovate PRs.

Renovate runs `yarn deduplicate` for the whole file, without limiting it to the updated package. Because we have 147 duplications over 58 different packages this will result in a massive deduplicate that will change many codepaths all at once.

I think it is safer to deduplicate them package by package (eg: #42883, #42884) for now. Once we reach a duplicate-free `yarn.lock`, we can re-enable this option to keep it that way.

#### Testing instructions

N/A
