### PR TITLE
G Suite: Improves the logic for `hasGSuiteWithUs` to consider the default value as a negative case

### DIFF
--- a/client/lib/gsuite/index.js
+++ b/client/lib/gsuite/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import formatCurrency from '@automattic/format-currency';
-import { endsWith, get, isNumber, isString, sortBy } from 'lodash';
+import { endsWith, get, isNumber, isString, sortBy, includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -166,9 +166,9 @@ function getMonthlyPrice( cost, currencyCode, defaultValue = '-' ) {
  * @returns {boolean} - true if the domain is under our management, false otherwise
  */
 function hasGSuiteWithUs( domain ) {
-	const domainStatus = get( domain, 'googleAppsSubscription.status', '' );
-
-	return 'no_subscription' !== domainStatus && 'other_provider' !== domainStatus;
+	const defaultValue = '';
+	const domainStatus = get( domain, 'googleAppsSubscription.status', defaultValue );
+	return ! includes( [ defaultValue, 'no_subscription', 'other_provider' ], domainStatus );
 }
 
 /**

--- a/client/lib/gsuite/test/index.js
+++ b/client/lib/gsuite/test/index.js
@@ -121,8 +121,19 @@ describe( 'index', () => {
 			);
 		} );
 
-		test( 'Returns primary domain if no selected domain', () => {
-			expect( getEligibleGSuiteDomain( '', domains ) ).toEqual( 'primary-domain.blog' );
+		test( 'Returns primary domain if no selected domain and the primary domain is eligible', () => {
+			const domainsWithEligiblePrimaryDomain = domains.map( ( domain ) =>
+				domain.isPrimary ? { ...domain, hasWpcomNameservers: true } : domain
+			);
+			expect( getEligibleGSuiteDomain( '', domainsWithEligiblePrimaryDomain ) ).toEqual(
+				'primary-domain.blog'
+			);
+		} );
+
+		test( 'Returns the first eligible domain if no selected domain and the primary domain is not eligible', () => {
+			expect( getEligibleGSuiteDomain( '', domains ) ).toEqual(
+				'mapped-domain-with-wpcom-nameservers.blog'
+			);
 		} );
 
 		test( 'Returns first non-primary domain if no selected domain and no primary domain in domains', () => {


### PR DESCRIPTION
### Summary

The [email page](http://calypso.localhost:3000/email) is blank for sites with no custom domains after changes from D43447-code. This happens because no subscription information is sent for G Suite on subdomains. This is okay because sub-domains can't have G Suite for now.

#### Changes proposed in this Pull Request

* `hasGSuiteWithUs` now considers the scenario where no value is found for the subscription status. 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to [domains/email](http://calypso.localhost:3000/email)
* Ensure that the page isn't blank
* It should show a G Suite upsell for a site with a custom ( i.e. G Suite compatible ) domain.
* It should an email management screen if a subscription already exists
* It should show empty content prompting custom domain purchase if none exists.


