### PR TITLE
Fix add payment method button when no selected site

### DIFF
--- a/client/me/purchases/manage-purchase/auto-renew-toggle/index.jsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/index.jsx
@@ -242,12 +242,12 @@ class AutoRenewToggle extends Component {
 }
 
 export default connect(
-	( state, { purchase } ) => ( {
+	( state, { purchase, siteSlug } ) => ( {
 		fetchingUserPurchases: isFetchingUserPurchases( state ),
 		isEnabled: ! isExpiring( purchase ),
 		currentUserId: getCurrentUserId( state ),
 		isAtomicSite: isSiteAtomic( state, purchase.siteId ),
-		siteSlug: getSelectedSiteSlug( state ),
+		siteSlug: siteSlug || getSelectedSiteSlug( state ),
 	} ),
 	{
 		fetchUserPurchases,

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -363,6 +363,7 @@ class PurchaseMeta extends Component {
 							<AutoRenewToggle
 								planName={ site.plan.product_name_short }
 								siteDomain={ site.domain }
+								siteSlug={ site.slug }
 								purchase={ purchase }
 								toggleSource="manage-purchase"
 							/>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes an issue with the add payment method button that shows when enabling auto renew for a purchase without a payment method.

#### Testing instructions

* Go to /me/purchases
* Select a purchase made with credits
* Try to enable auto-renew
* Click on `Add a payment method`
* After applying the fix, you should be sent to the payment method form, whereas before the fix nothing happens
* Verify that existing functionality isn't broken
