### PR TITLE
FSE: Bump to 1.7

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Full Site Editing
  * Description: Enhances your page creation workflow within the Block Editor.
- * Version: 1.6
+ * Version: 1.7
  * Author: Automattic
  * Author URI: https://automattic.com/wordpress-plugins/
  * License: GPLv2 or later

--- a/apps/full-site-editing/full-site-editing-plugin/readme.txt
+++ b/apps/full-site-editing/full-site-editing-plugin/readme.txt
@@ -3,7 +3,7 @@ Contributors: alexislloyd, allancole, automattic, bartkalisz, codebykat, copons,
 Tags: block, blocks, editor, gutenberg, page
 Requires at least: 5.0
 Tested up to: 5.4
-Stable tag: 1.6
+Stable tag: 1.7
 Requires PHP: 5.6.20
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -39,6 +39,9 @@ This plugin is experimental, so we don't provide any support for it outside of w
 
 
 == Changelog ==
+
+= 1.7 =
+* Add handling for site launch on WordPree.com
 
 = 1.6 =
 * Remove the "Edit as HTML" options for the inner blocks of the Premium Content Block.

--- a/apps/full-site-editing/full-site-editing-plugin/readme.txt
+++ b/apps/full-site-editing/full-site-editing-plugin/readme.txt
@@ -41,6 +41,7 @@ This plugin is experimental, so we don't provide any support for it outside of w
 == Changelog ==
 
 = 1.7 =
+* Save the post before navigation when launching a WordPress.com site.
 * Add handling for site launch on WordPree.com.
 * Performance improvements in the block editor.
 

--- a/apps/full-site-editing/full-site-editing-plugin/readme.txt
+++ b/apps/full-site-editing/full-site-editing-plugin/readme.txt
@@ -42,7 +42,7 @@ This plugin is experimental, so we don't provide any support for it outside of w
 
 = 1.7 =
 * Save the post before navigation when launching a WordPress.com site.
-* Add handling for site launch on WordPree.com.
+* Add handling for site launch on WordPress.com.
 * Performance improvements in the block editor.
 
 = 1.6 =

--- a/apps/full-site-editing/full-site-editing-plugin/readme.txt
+++ b/apps/full-site-editing/full-site-editing-plugin/readme.txt
@@ -41,7 +41,8 @@ This plugin is experimental, so we don't provide any support for it outside of w
 == Changelog ==
 
 = 1.7 =
-* Add handling for site launch on WordPree.com
+* Add handling for site launch on WordPree.com.
+* Performance improvements in the block editor.
 
 = 1.6 =
 * Remove the "Edit as HTML" options for the inner blocks of the Premium Content Block.

--- a/apps/full-site-editing/package.json
+++ b/apps/full-site-editing/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/full-site-editing",
-	"version": "1.6.0",
+	"version": "1.7.0",
 	"description": "Plugin for full site editing with the block editor.",
 	"sideEffects": true,
 	"repository": {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

FSE Verion bump - includes #42850
Part of Part of #42847

#### For inclusion: 
- [x] https://github.com/Automattic/wp-calypso/pull/42878

#### Testing instructions

It's important to test with and without D44333-code patch applied to your sandbox.

From #42850:

Sandbox `widgets.wp.com` and `example.wordpress.com` (Simple site).

1. Apply D44298-code (these changes). It should result in no changes in the block editor.
1. https://wordpress.com/block-editor should work as before.
1. Starting from [`/new`](https://wordpress.com/new), follow the flow through site creation to the editor.
1. Make a change to the post content.
1. In the editor, the publish button should be replaced with "Launch."
1. The launch button should link to a URL like https://wordpress.com/start/new-launch?siteSlug=example.wordpress.com&source=editor

Repeat the steps with D44333-code (be sure to clear your browser caches). The wpcom-block-editor should Launch button should not be applied, it should be applied from the FSE plugin. One notable difference is that the FSE version will perform an autosave before navigation from the editor.

All of the testing is to ensure there are no regressions.