### PR TITLE
Jetpack Cloud: fix the section property of the threat toggle event

### DIFF
--- a/client/landing/jetpack-cloud/components/threat-item/index.tsx
+++ b/client/landing/jetpack-cloud/components/threat-item/index.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import { useSelector } from 'react-redux';
 import { translate } from 'i18n-calypso';
 import classnames from 'classnames';
 import { Button } from '@automattic/components';
@@ -17,6 +18,7 @@ import ThreatItemSubheader from 'landing/jetpack-cloud/components/threat-item-su
 import { Threat } from 'landing/jetpack-cloud/components/threat-item/types';
 import { getThreatFix } from 'landing/jetpack-cloud/components/threat-item/utils';
 import useTrackCallback from 'landing/jetpack-cloud/lib/use-track-callback';
+import getCurrentRoute from 'state/selectors/get-current-route';
 
 /**
  * Style dependencies
@@ -93,9 +95,10 @@ const ThreatItem: React.FC< Props > = ( {
 		[ threat ]
 	);
 
+	const currentRoute = useSelector( getCurrentRoute );
 	const onOpenTrackEvent = useTrackCallback( noop, 'calypso_jetpack_scan_threat_itemtoggle', {
 		threat_signature: threat.signature,
-		section: window.location.pathname.includes( '/scan/history' ) ? 'History' : 'Scanner',
+		section: currentRoute && currentRoute.includes( '/scan/history' ) ? 'History' : 'Scanner',
 	} );
 
 	if ( isPlaceholder ) {

--- a/client/landing/jetpack-cloud/components/threat-item/index.tsx
+++ b/client/landing/jetpack-cloud/components/threat-item/index.tsx
@@ -95,10 +95,16 @@ const ThreatItem: React.FC< Props > = ( {
 		[ threat ]
 	);
 
+	// We want to track which section are this toggles coming from
 	const currentRoute = useSelector( getCurrentRoute );
+	const currentRouteProp = React.useMemo( () => {
+		return currentRoute
+			? { section: currentRoute.includes( '/scan/history' ) ? 'History' : 'Scanner' }
+			: {};
+	}, [ currentRoute ] );
 	const onOpenTrackEvent = useTrackCallback( noop, 'calypso_jetpack_scan_threat_itemtoggle', {
 		threat_signature: threat.signature,
-		section: currentRoute && currentRoute.includes( '/scan/history' ) ? 'History' : 'Scanner',
+		...currentRouteProp,
 	} );
 
 	if ( isPlaceholder ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The name of the section isn't always being tracked correctly. This is because we are using [`window.location.href` to get the current section](https://github.com/Automattic/wp-calypso/pull/42819/files#diff-c23e1d50bbefb88d4546c95f5d3d902aR98). This PR fixes this by using a state selector to fetch the current section.

#### Testing instructions

* Go to `http://jetpack.cloud.localhost:3000/` and select a site that has Scan (with at least one threat)
* Go to Scan -> Scanner 
* Click on the header of a threat item
* Verify the `calypso_jetpack_scan_threat_itemtoggle` event was tracked and that it included a property called `section` with `Scanner` as its value.
* Go to Scan -> History 
* Click on the header of a threat item
* Verify the `calypso_jetpack_scan_threat_itemtoggle` event was tracked and that it included a property called `section` with `History` as its value.

Fixes 1169345694087188-as-1178539912392265

#### Demo
**Scan -> Scanner**
![image](https://user-images.githubusercontent.com/3418513/83547871-3a3a9e00-a4d9-11ea-8695-7f8bcc689d9e.png)

**Scan -> History**
![image](https://user-images.githubusercontent.com/3418513/83547922-4fafc800-a4d9-11ea-8b5a-7ce3850177a2.png)
