### PR TITLE
composite-checkout: Show/hide taxes when payment method is free

### DIFF
--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
@@ -753,7 +753,7 @@ async function mockSetCartEndpoint( _, requestCart ) {
 		coupon: requestCoupon,
 		is_coupon_applied: true,
 		coupon_discounts_integer: [],
-		tax: {},
+		tax: { location: {}, display_taxes: true },
 	};
 }
 

--- a/client/my-sites/checkout/composite-checkout/wpcom/test/shopping-cart-endpoint.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/test/shopping-cart-endpoint.js
@@ -184,6 +184,14 @@ describe( 'doesCartLocationDifferFromResponseCartLocation', function () {
 		},
 	};
 
+	it( 'returns true if new values are empty strings that differ', function () {
+		const result = doesCartLocationDifferFromResponseCartLocation( cartWithLocation, {
+			countryCode: '',
+			subdivisionCode: '',
+			postalCode: '',
+		} );
+		expect( result ).toBe( true );
+	} );
 	it( 'returns true if countryCode differs', function () {
 		const result = doesCartLocationDifferFromResponseCartLocation( cartWithLocation, {
 			countryCode: 'CA',

--- a/client/my-sites/checkout/composite-checkout/wpcom/types/backend/shopping-cart-endpoint.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/types/backend/shopping-cart-endpoint.ts
@@ -255,13 +255,14 @@ export function doesCartLocationDifferFromResponseCartLocation(
 	location: CartLocation
 ): boolean {
 	const { countryCode, postalCode, subdivisionCode } = location;
-	if ( countryCode && cart.tax.location.country_code !== countryCode ) {
+	const isMissing = ( value ) => value === null || value === undefined;
+	if ( ! isMissing( countryCode ) && cart.tax.location.country_code !== countryCode ) {
 		return true;
 	}
-	if ( postalCode && cart.tax.location.postal_code !== postalCode ) {
+	if ( ! isMissing( postalCode ) && cart.tax.location.postal_code !== postalCode ) {
 		return true;
 	}
-	if ( subdivisionCode && cart.tax.location.subdivision_code !== subdivisionCode ) {
+	if ( ! isMissing( subdivisionCode ) && cart.tax.location.subdivision_code !== subdivisionCode ) {
 		return true;
 	}
 	return false;

--- a/client/my-sites/checkout/composite-checkout/wpcom/types/backend/shopping-cart-endpoint.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/types/backend/shopping-cart-endpoint.ts
@@ -109,7 +109,7 @@ export const emptyResponseCart = {
 	is_coupon_applied: false,
 	coupon_discounts_integer: [],
 	locale: 'en-us',
-	tax: { location: [], display_taxes: false },
+	tax: { location: {}, display_taxes: false },
 	is_signup: false,
 } as ResponseCart;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Purchases which use free payment methods (full-credits and free-payment) are not currently charged taxes for locations which require them. However, we still submit those locations to the shopping cart endpoint which means that if taxes should be shown for that location, they are shown regardless of if they will be charged.

This PR modifies the process so that:

1. The cart location is updated any time the active payment method changes.
2. When the cart location is updated, we set it to empty if the payment method is free.

Fixes #40016

#### Testing instructions

- Add credits to your account sufficient to cover a plan completely.
- Visit composite checkout with a plan in the cart.
- Fill out the contact form with a non-taxable location (eg: 90210).
- When you reach the payment method step, the active payment method should be credits.
- Verify that no taxes are displayed.
- Change the payment method to a card or PayPal.
- Verify that the taxes line appears, but it is $0.
- Edit the contact form and change to a taxable location (eg: 10001).
- Return to the payment method step.
- Verify that the taxes line shows a positive amount.
- Change the payment method to credits.
- Verify that no taxes are displayed.
