### PR TITLE
Comments: fix max height of excerpt and prevent clipping

### DIFF
--- a/client/blocks/comments/post-comment-content.scss
+++ b/client/blocks/comments/post-comment-content.scss
@@ -4,12 +4,12 @@
 
 	&.is-single-line,
 	&.is-single-line .comments__comment-content {
-		max-height: 15px * 1.6;
+		max-height: $font-body * 1.6;
 	}
 
 	&.is-excerpt,
 	&.is-excerpt .comments__comment-content {
-		max-height: 16px * 1.4375 * 3; // Needs to be exactly 69px so a 3-liner only and 3-liner excerpt align
+		max-height: $font-body * 1.6 * 3; // 3 lines
 	}
 
 	&.is-single-line .comments__comment-content,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Recent changes to body font sizes in https://github.com/Automattic/wp-calypso/pull/42629 have led to comment excerpts being cropped at the bottom in comments. You can see this happening in Reader Conversations.

This PR changes the max-height to be based on the new body font variables.

Before:

<img width="277" alt="Screen Shot 2020-06-03 at 16 10 35" src="https://user-images.githubusercontent.com/17325/83595108-16e52100-a5b5-11ea-8cfd-f01b531523a0.png">

After:

<img width="247" alt="Screen Shot 2020-06-05 at 14 38 31" src="https://user-images.githubusercontent.com/17325/83830860-3f4a5800-a73a-11ea-911d-cc039836410c.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Check out http://calypso.localhost:3000/read/conversations and make sure comment excerpts are not clipped at the bottom.

You can also check the `PostComment` block in Devdocs and look for evidence of clipping:

http://calypso.localhost:3000/devdocs/blocks/post-comment


