### PR TITLE
Pausing Plans-Domains swap AB test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -109,8 +109,8 @@ export default {
 	domainStepPlanStepSwap: {
 		datestamp: '20200513',
 		variations: {
-			variantShowSwapped: 50,
-			control: 50,
+			variantShowSwapped: 0,
+			control: 100,
 		},
 		defaultVariation: 'control',
 		allowExistingUsers: true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Pausing Plans-Domains with domain-fwd swap test (100% traffic goes to control). Check pbxNRc-iQ-p2

#### Testing instructions

* Go through the signup flow at /start
* Domain step should appear first. Then Plans.