### PR TITLE
FSE: Remove function args trailing comma

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/editor-gutenboarding-launch/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-gutenboarding-launch/index.php
@@ -43,7 +43,7 @@ function enqueue_script_and_style() {
 		'a8c-fse-editor-gutenboarding-launch-style',
 		plugins_url( 'dist/editor-gutenboarding-launch.css', __FILE__ ),
 		array(),
-		$style_version,
+		$style_version
 	);
 }
 add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\enqueue_script_and_style' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Remove a trailing comma in function arguments. This is valid PHP 7.3 but we should support at least 7.2.

Via @obenland / https://github.com/Automattic/wp-calypso/pull/42850#discussion_r434216848

#### Testing instructions

From #42850

> Sandbox ~`widgets.wp.com` and~ `example.wordpress.com` (Simple site).
> 
> * Test D44327-code in isolation. It should result in no changes in the block editor.
> * [Already deployed ✅ ] ~Test in combination with D44258-code. It should result in no changes in the block editor.~
> 
> 1. https://wordpress.com/block-editor should work as before.
> 2. Starting from [`/new`](https://wordpress.com/new), follow the flow through site creation to the editor.
> 3. In the editor, the publish button should be replaced with "Launch."
> 4. The launch button should link to a URL like https://wordpress.com/start/new-launch?siteSlug=example.wordpress.com&source=editor
> 
> All of the testing is to ensure there are no regressions.
