### PR TITLE
Use error code for media uploads instead of message matching

### DIFF
--- a/client/state/media/reducer.js
+++ b/client/state/media/reducer.js
@@ -84,13 +84,13 @@ export const errors = ( state = {}, action ) => {
 				switch ( error.error ) {
 					case 'http_404':
 						return MediaValidationErrors.UPLOAD_VIA_URL_404;
+					case 'rest_upload_limited_space':
+						return MediaValidationErrors.NOT_ENOUGH_SPACE;
+					case 'rest_upload_file_too_big':
+						return MediaValidationErrors.EXCEEDS_MAX_UPLOAD_SIZE;
+					case 'rest_upload_user_quota_exceeded':
+						return MediaValidationErrors.EXCEEDS_PLAN_STORAGE_LIMIT;
 					case 'upload_error':
-						if ( error.message.startsWith( 'Not enough space to upload' ) ) {
-							return MediaValidationErrors.NOT_ENOUGH_SPACE;
-						}
-						if ( error.message.startsWith( 'You have used your space quota' ) ) {
-							return MediaValidationErrors.EXCEEDS_PLAN_STORAGE_LIMIT;
-						}
 						return MediaValidationErrors.SERVER_ERROR;
 					case 'keyring_token_error':
 						return MediaValidationErrors.SERVICE_AUTH_FAILED;

--- a/client/state/media/test/reducer.js
+++ b/client/state/media/test/reducer.js
@@ -94,7 +94,7 @@ describe( 'reducer', () => {
 
 		test( 'should return an error when there is not enough space to upload during external media request', () => {
 			const error = {
-				error: 'upload_error',
+				error: 'rest_upload_limited_space',
 				message: 'Not enough space to upload',
 			};
 			const state = errors( {}, failMediaRequest( siteId, {}, error ) );
@@ -108,7 +108,7 @@ describe( 'reducer', () => {
 
 		test( 'should return an error when the space quota has been exceeded during external media request', () => {
 			const error = {
-				error: 'upload_error',
+				error: 'rest_upload_user_quota_exceeded',
 				message: 'You have used your space quota',
 			};
 			const state = errors( {}, failMediaRequest( siteId, {}, error ) );
@@ -191,7 +191,7 @@ describe( 'reducer', () => {
 
 		test( 'should return an error when there is not enough space to upload', () => {
 			const error = {
-				error: 'upload_error',
+				error: 'rest_upload_limited_space',
 				message: 'Not enough space to upload',
 			};
 			const state = errors( {}, failMediaItemRequest( siteId, mediaItem.ID, error ) );
@@ -205,7 +205,7 @@ describe( 'reducer', () => {
 
 		test( 'should return an error when the space quota has been exceeded', () => {
 			const error = {
-				error: 'upload_error',
+				error: 'rest_upload_user_quota_exceeded',
 				message: 'You have used your space quota',
 			};
 			const state = errors( {}, failMediaItemRequest( siteId, mediaItem.ID, error ) );
@@ -213,6 +213,20 @@ describe( 'reducer', () => {
 			expect( state ).to.eql( {
 				[ siteId ]: {
 					[ mediaItem.ID ]: [ MediaValidationErrors.EXCEEDS_PLAN_STORAGE_LIMIT ],
+				},
+			} );
+		} );
+
+		test( 'should return an error when file is too big to upload', () => {
+			const error = {
+				error: 'rest_upload_file_too_big',
+				message: 'This file is too big',
+			};
+			const state = errors( {}, failMediaItemRequest( siteId, mediaItem.ID, error ) );
+
+			expect( state ).to.eql( {
+				[ siteId ]: {
+					[ mediaItem.ID ]: [ MediaValidationErrors.EXCEEDS_MAX_UPLOAD_SIZE ],
 				},
 			} );
 		} );


### PR DESCRIPTION
We are currently using the error message to get the media upload error type, which doesn't work for non-English, because the error message in the response payload is localized.

#### Changes proposed in this Pull Request

* Use upload error code instead of error message matching to set the error state for media upload request failures.
* Added missing exceeded file size error handling

**Before:**
![image](https://user-images.githubusercontent.com/2722412/83614053-56981280-a58d-11ea-8697-6a88d318f2d4.png)

**After:**
![image](https://user-images.githubusercontent.com/2722412/83613999-41bb7f00-a58d-11ea-863d-9452165beaba.png)


#### Testing instructions

* Boot Calypso and open http://calypso.localhost:3000/media
* Try to upload media for a site that exceeds plan storage limit
* Confirm that you get the storage limit error message instead of generic server error message.
* Confirm that error message gets translated for non-English UI

Related D44299-code
