### PR TITLE
FSE: Add PHPCS for 7.2+ version compatibility

### DIFF
--- a/apps/phpcs.xml
+++ b/apps/phpcs.xml
@@ -7,6 +7,10 @@
 	<rule ref="WordPress-Docs"/>
 	<rule ref="Generic.CodeAnalysis.UnusedFunctionParameter"/>
 
+	<!-- Check for cross-version support for PHP 7.2 and higher. -->
+	<rule ref="PHPCompatibility"/>
+	<config name="testVersion" value="7.2-"/>
+
 	<arg name="extensions" value="php"/>
 
 	<!-- Strip the file paths down to the relevant bit. -->

--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
 	"require": {
 		"squizlabs/php_codesniffer": "^3.5",
 		"wp-coding-standards/wpcs": "^2.2",
-		"dealerdirect/phpcodesniffer-composer-installer": "^0.6.0"
+		"dealerdirect/phpcodesniffer-composer-installer": "^0.6.0",
+		"phpcompatibility/php-compatibility": "^9.3"
 	}
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f0d596b22caf239fd3cbd94f731b3051",
+    "content-hash": "7f8634168ce8105ecae4bfeffca514b9",
     "packages": [
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
@@ -71,6 +71,64 @@
                 "tests"
             ],
             "time": "2020-01-19T15:35:03+00:00"
+        },
+        {
+            "name": "phpcompatibility/php-compatibility",
+            "version": "9.3.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
+                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/9fb324479acf6f39452e0655d2429cc0d3914243",
+                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.3 || ^3.0.2"
+            },
+            "conflict": {
+                "squizlabs/php_codesniffer": "2.6.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "homepage": "https://github.com/wimg",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCompatibility/PHPCompatibility/graphs/contributors"
+                }
+            ],
+            "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP cross-version compatibility.",
+            "homepage": "http://techblog.wimgodden.be/tag/codesniffer/",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards"
+            ],
+            "time": "2019-12-27T09:44:58+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -176,5 +234,6 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "1.1.0"
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add PHP sniff to ensure PHP 7.2 compatibility.

Prevent unsupported syntax from being introducted, e.g. #42918.

See https://github.com/PHPCompatibility/PHPCompatibility#using-a-custom-ruleset

#### Testing instructions

Add some newer syntax not supported in PHP 7.2, for example trailing comma in function calls:

```patch
diff --git a/apps/full-site-editing/full-site-editing-plugin/editor-gutenboarding-launch/index.php b/apps/full-site-editing/full-site-editing-plugin/editor-gutenboarding-launch/index.php
index e39fdc1244..597447a914 100644
--- a/apps/full-site-editing/full-site-editing-plugin/editor-gutenboarding-launch/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-gutenboarding-launch/index.php
@@ -36,7 +36,7 @@ function enqueue_script_and_style() {
 		plugins_url( 'dist/editor-gutenboarding-launch.js', __FILE__ ),
 		$script_dependencies,
 		$script_version,
-		true
+		true,
 	);
 
 	wp_enqueue_style(
```

1. Stage the changed file
1. Run the pre-commit script: `node bin/pre-commit-hook.js`
1. You should get an error report.

```
FILE: full-site-editing/full-site-editing-plugin/editor-gutenboarding-launch/index.php
------------------------------------------------------------------------------------------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
------------------------------------------------------------------------------------------------------------------------------------------------------------------
 39 | ERROR | Trailing comma's are not allowed in function calls in PHP 7.2 or earlier
    |       | (PHPCompatibility.Syntax.NewFunctionCallTrailingComma.FoundInFunctionCall)
------------------------------------------------------------------------------------------------------------------------------------------------------------------
```
