### PR TITLE
FSE: Include style overrides for gutenboarding launch

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/editor-gutenboarding-launch/index.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-gutenboarding-launch/index.scss
@@ -1,3 +1,24 @@
+// Added to body to allow general overrides
+.editor-gutenberg-launch__fse-overrides {
+	.editor-post-switch-to-draft {
+		display: none;
+	}
+
+	// Override 'Save' button to have tertiary styles.
+	.edit-post-header__settings {
+		.editor-post-publish-button__button {
+			color: #007cba !important;
+			background: none !important;
+			border: none !important;
+			box-shadow: none !important;
+
+			&[aria-disabled='true'] {
+				opacity: 0.3 !important;
+			}
+		}
+	}
+}
+
 .editor-gutenberg-launch__launch-button {
 	padding: 0 12px;
 	margin: 0 12px 0 3px;

--- a/apps/full-site-editing/full-site-editing-plugin/editor-gutenboarding-launch/index.ts
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-gutenboarding-launch/index.ts
@@ -43,6 +43,8 @@ function updateEditor() {
 			return;
 		}
 		clearInterval( awaitSettingsBar );
+		const body = document.querySelector( 'body' );
+		body.classList.add( 'editor-gutenberg-launch__fse-overrides' );
 
 		// 'Update'/'Publish' primary button to become 'Save' tertiary button.
 		const saveButton = settingsBar.querySelector( '.editor-post-publish-button__button' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This moves some Gutenboarding Style overrides into FSE so that the feature can be completely removed from wpcom-block-editor

Part of https://github.com/Automattic/wp-calypso/pull/42847

#### Testing instructions

* Apply D44333-code (wpcom-block-editor changes to enable this change)
* Apply this patch D44334-code 
* Sandbox `example.wordpress.com` and `widgets.wp.com` - You'll need to sandbox your newly created site to test these changes.
* Starting from [`/new`](https://wordpress.com/new), go through the site creation flow.
* When you reach the editor, sandbox the new site and refresh (clear caches).
* You should see the launch button styled. Body classes from both wpcom-block-editor and this PR will be applied and they'll apply the same CSS overrides to a few elements. This is acceptable. The wpcom-block-editor overrides will be removed and deployed separately. (https://github.com/Automattic/wp-calypso/pull/42934)

