### PR TITLE
p2: remove ContractorSelect

### DIFF
--- a/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
+++ b/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
@@ -26,6 +26,7 @@ import {
 	requestExternalContributorsAddition,
 	requestExternalContributorsRemoval,
 } from 'state/data-getters';
+import isSiteWPForTeams from 'state/selectors/is-site-wpforteams';
 
 /**
  * Style dependencies
@@ -159,12 +160,14 @@ class EditUserForm extends Component {
 							onChange={ this.handleChange }
 							onFocus={ this.recordFieldFocus( 'roles' ) }
 						/>
-						{ ! this.props.isVip && this.isExternalRole( this.state.roles ) && (
-							<ContractorSelect
-								onChange={ this.handleExternalChange }
-								checked={ this.state.isExternalContributor }
-							/>
-						) }
+						{ ! this.props.isVip &&
+							! this.props.isWPForTeamsSite &&
+							this.isExternalRole( this.state.roles ) && (
+								<ContractorSelect
+									onChange={ this.handleExternalChange }
+									checked={ this.state.isExternalContributor }
+								/>
+							) }
 					</Fragment>
 				);
 				break;
@@ -273,6 +276,7 @@ export default localize(
 					undefined !== linkedUserId ? linkedUserId : userId
 				),
 				isVip: isVipSite( state, siteId ),
+				isWPForTeamsSite: isSiteWPForTeams( state, siteId ),
 			};
 		},
 		{

--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -64,6 +64,7 @@ import accept from 'lib/accept';
  * Style dependencies
  */
 import './style.scss';
+import isSiteWPForTeams from '../../../state/selectors/is-site-wpforteams';
 
 /**
  * Module variables
@@ -375,7 +376,7 @@ class InvitePeople extends React.Component {
 							explanation={ this.renderRoleExplanation() }
 						/>
 
-						{ this.isExternalRole( this.state.role ) && (
+						{ ! this.props.isWPForTeamsSite && this.isExternalRole( this.state.role ) && (
 							<ContractorSelect
 								onChange={ this.onExternalChange }
 								checked={ this.state.isExternal }

--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -64,7 +64,6 @@ import accept from 'lib/accept';
  * Style dependencies
  */
 import './style.scss';
-import isSiteWPForTeams from '../../../state/selectors/is-site-wpforteams';
 
 /**
  * Module variables


### PR DESCRIPTION
In this PR, we remove the "This user is a contractor, freelancer, consultant, or agency." checkbox on user invitation screen for P2 sites.

## Testing instructions

Create a new P2 site through the wordpress.com/start/wp-for-teams signup flow. Go to the user invitation screen and select a role like "editor". You should not see the contractor checkbox. The same for editing a user. Now, using a non-P2 site, you should see that field in both places.