### PR TITLE
Domains: Add Personal plan to cart when upgrade is clicked

### DIFF
--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -35,6 +35,9 @@ import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
 import { makeLayout, render as clientRender } from 'controller';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import { canUserPurchaseGSuite } from 'lib/gsuite';
+import { addItem } from 'lib/cart/actions';
+import { planItem } from 'lib/cart-values/cart-items';
+import { PLAN_PERSONAL } from 'lib/plans/constants';
 
 const domainsAddHeader = ( context, next ) => {
 	context.getSiteSelectionHeaderText = () => {
@@ -62,6 +65,11 @@ const domainSearch = ( context, next ) => {
 	// Scroll to the top
 	if ( typeof window !== 'undefined' ) {
 		window.scrollTo( 0, 0 );
+	}
+
+	if ( 'upgrade' === context.query.ref ) {
+		addItem( planItem( PLAN_PERSONAL, {} ) );
+		return page.replace( context.pathname );
 	}
 
 	context.primary = (

--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -21,6 +21,7 @@ import Main from 'components/main';
 import { addItem, removeItem } from 'lib/cart/actions';
 import { canDomainAddGSuite } from 'lib/gsuite';
 import {
+	hasPlan,
 	hasDomainInCart,
 	domainMapping,
 	domainTransfer,
@@ -49,6 +50,7 @@ class DomainSearch extends Component {
 		basePath: PropTypes.string.isRequired,
 		context: PropTypes.object.isRequired,
 		domainsWithPlansOnly: PropTypes.bool.isRequired,
+		hasPlanInCart: PropTypes.bool,
 		isSiteUpgradeable: PropTypes.bool,
 		productsList: PropTypes.object.isRequired,
 		selectedSite: PropTypes.object,
@@ -182,7 +184,7 @@ class DomainSearch extends Component {
 							noticeText={ translate( 'You must verify your email to register new domains.' ) }
 							noticeStatus="is-info"
 						>
-							<NewDomainsRedirectionNoticeUpsell />
+							{ ! this.props.hasPlanInCart && <NewDomainsRedirectionNoticeUpsell /> }
 							<RegisterDomainStep
 								suggestion={ suggestion }
 								domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
@@ -215,7 +217,7 @@ class DomainSearch extends Component {
 }
 
 export default connect(
-	( state ) => {
+	( state, ownProps ) => {
 		const siteId = getSelectedSiteId( state );
 
 		return {
@@ -226,6 +228,7 @@ export default connect(
 			domainsWithPlansOnly: currentUserHasFlag( state, DOMAINS_WITH_PLANS_ONLY ),
 			isSiteUpgradeable: isSiteUpgradeable( state, siteId ),
 			productsList: getProductsList( state ),
+			hasPlanInCart: hasPlan( ownProps.cart ),
 		};
 	},
 	{


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes the upgrade banner, adding the Personal plan to cart when the "Upgrade" button is clicked.

Depends on D44337-code

#### Testing instructions

- Switch to a site on a free plan
- You should see the "Free domain with a plan" banner. Click on Upgrade
- Verify the Personal plan was added to cart