### PR TITLE
Gutenboarding: Add desktop preview min-height

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
@@ -346,6 +346,13 @@
 	width: 100%;
 	margin: 0 auto;
 	height: 100%;
+	@include break-small {
+		min-height: 400px;
+	}
+
+	@include break-wide {
+		min-height: 600px;
+	}
 
 	.is-viewport-mobile &,
 	.is-viewport-tablet & {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes #42944 

Adds min-height to the preview container. Mobile view remains untouched (>600px vw).

The preview pane would previously scale down with the viewport. Now it has fixed minimums and will cause the window to scroll.

600px - 1280px

<kbd>![Screen Shot 2020-06-03 at 17 25 22](https://user-images.githubusercontent.com/841763/83656154-7ea06980-a5bf-11ea-8ac6-43c3d8c233c1.png)</kbd>

\>=1280px 

<kbd>![Screen Shot 2020-06-03 at 17 24 58](https://user-images.githubusercontent.com/841763/83656161-7fd19680-a5bf-11ea-81fc-77bb7ce31a2d.png)</kbd>





#### Testing instructions

* [`/new`](https://calypso.live/new?branch=gutenboarding/desktop-preview-min-height)

