### PR TITLE
Instrument reader pages

### DIFF
--- a/client/blocks/conversations/empty.jsx
+++ b/client/blocks/conversations/empty.jsx
@@ -9,6 +9,7 @@ import { localize } from 'i18n-calypso';
  */
 import EmptyContent from 'components/empty-content';
 import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
+import { withPerformanceTrackerStop } from 'lib/performance-tracking';
 
 /**
  * Image dependencies
@@ -57,4 +58,4 @@ class ConversationsEmptyContent extends React.Component {
 	/* eslint-enable wpcalypso/jsx-classname-namespace */
 }
 
-export default localize( ConversationsEmptyContent );
+export default withPerformanceTrackerStop( localize( ConversationsEmptyContent ) );

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -67,6 +67,7 @@ import { setViewingFullPostKey, unsetViewingFullPostKey } from 'state/reader/vie
 import { getNextItem, getPreviousItem } from 'state/reader/streams/selectors';
 import { requestMarkAsSeen } from 'state/reader/seen-posts/actions';
 import { SOURCE_READER_WEB } from 'state/reader/seen-posts/constants';
+import { PerformanceTrackerStop } from 'lib/performance-tracking';
 
 /**
  * Style dependencies
@@ -427,6 +428,8 @@ export class FullPostView extends React.Component {
 								onCommentClick={ this.handleCommentClick }
 								fullPost={ true }
 							/>
+
+							{ ! isLoading && <PerformanceTrackerStop /> }
 
 							{ showRelatedPosts && (
 								<RelatedPostsFromSameSite

--- a/client/reader/liked-stream/empty.jsx
+++ b/client/reader/liked-stream/empty.jsx
@@ -10,6 +10,7 @@ import { localize } from 'i18n-calypso';
 import EmptyContent from 'components/empty-content';
 import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
 import { isDiscoverEnabled } from 'reader/discover/helper';
+import { withPerformanceTrackerStop } from 'lib/performance-tracking';
 
 class TagEmptyContent extends React.Component {
 	shouldComponentUpdate() {
@@ -63,4 +64,4 @@ class TagEmptyContent extends React.Component {
 	}
 }
 
-export default localize( TagEmptyContent );
+export default withPerformanceTrackerStop( localize( TagEmptyContent ) );

--- a/client/reader/search-stream/empty.jsx
+++ b/client/reader/search-stream/empty.jsx
@@ -11,6 +11,7 @@ import { localize } from 'i18n-calypso';
 import EmptyContent from 'components/empty-content';
 import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
 import { isDiscoverEnabled } from 'reader/discover/helper';
+import { withPerformanceTrackerStop } from 'lib/performance-tracking';
 
 class SearchEmptyContent extends React.Component {
 	static propTypes = {
@@ -75,4 +76,4 @@ class SearchEmptyContent extends React.Component {
 	}
 }
 
-export default localize( SearchEmptyContent );
+export default withPerformanceTrackerStop( localize( SearchEmptyContent ) );

--- a/client/reader/stream/empty.jsx
+++ b/client/reader/stream/empty.jsx
@@ -9,6 +9,7 @@ import { localize } from 'i18n-calypso';
  */
 import EmptyContent from 'components/empty-content';
 import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
+import { withPerformanceTrackerStop } from 'lib/performance-tracking';
 
 /**
  * Image dependencies
@@ -54,4 +55,4 @@ class FollowingEmptyContent extends React.Component {
 	}
 }
 
-export default localize( FollowingEmptyContent );
+export default withPerformanceTrackerStop( localize( FollowingEmptyContent ) );

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -48,6 +48,7 @@ import { getPostByKey } from 'state/reader/posts/selectors';
 import { viewStream } from 'state/reader/watermarks/actions';
 import { Interval, EVERY_MINUTE } from 'lib/interval';
 import { PER_FETCH, INITIAL_FETCH } from 'state/data-layer/wpcom/read/streams';
+import { PerformanceTrackerStop } from 'lib/performance-tracking';
 
 /**
  * Style dependencies
@@ -370,26 +371,28 @@ class ReaderStream extends React.Component {
 			} );
 
 		return (
-			<PostLifecycle
-				key={ itemKey }
-				ref={ itemKey /* The ref is stored into `InfiniteList`'s `this.ref` map */ }
-				isSelected={ isSelected }
-				handleClick={ showPost }
-				postKey={ postKey }
-				suppressSiteNameLink={ this.props.suppressSiteNameLink }
-				showPostHeader={ this.props.showPostHeader }
-				showFollowInHeader={ this.props.showFollowInHeader }
-				showPrimaryFollowButtonOnCards={ this.props.showPrimaryFollowButtonOnCards }
-				isDiscoverStream={ this.props.isDiscoverStream }
-				showSiteName={ this.props.showSiteNameOnCards }
-				selectedPostKey={ postKey.isCombination ? selectedPostKey : undefined }
-				followSource={ this.props.followSource }
-				blockedSites={ this.props.blockedSites }
-				streamKey={ streamKey }
-				recsStreamKey={ this.props.recsStreamKey }
-				index={ index }
-				compact={ this.props.useCompactCards }
-			/>
+			<React.Fragment key={ itemKey }>
+				<PostLifecycle
+					ref={ itemKey /* The ref is stored into `InfiniteList`'s `this.ref` map */ }
+					isSelected={ isSelected }
+					handleClick={ showPost }
+					postKey={ postKey }
+					suppressSiteNameLink={ this.props.suppressSiteNameLink }
+					showPostHeader={ this.props.showPostHeader }
+					showFollowInHeader={ this.props.showFollowInHeader }
+					showPrimaryFollowButtonOnCards={ this.props.showPrimaryFollowButtonOnCards }
+					isDiscoverStream={ this.props.isDiscoverStream }
+					showSiteName={ this.props.showSiteNameOnCards }
+					selectedPostKey={ postKey.isCombination ? selectedPostKey : undefined }
+					followSource={ this.props.followSource }
+					blockedSites={ this.props.blockedSites }
+					streamKey={ streamKey }
+					recsStreamKey={ this.props.recsStreamKey }
+					index={ index }
+					compact={ this.props.useCompactCards }
+				/>
+				{ index === 0 && <PerformanceTrackerStop /> }
+			</React.Fragment>
 		);
 	};
 

--- a/client/reader/tag-stream/empty.jsx
+++ b/client/reader/tag-stream/empty.jsx
@@ -11,6 +11,7 @@ import { localize } from 'i18n-calypso';
 import EmptyContent from 'components/empty-content';
 import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
 import { isDiscoverEnabled } from 'reader/discover/helper';
+import { withPerformanceTrackerStop } from 'lib/performance-tracking';
 
 class TagEmptyContent extends React.Component {
 	static propTypes = {
@@ -79,4 +80,4 @@ class TagEmptyContent extends React.Component {
 	}
 }
 
-export default localize( TagEmptyContent );
+export default withPerformanceTrackerStop( localize( TagEmptyContent ) );

--- a/client/sections.js
+++ b/client/sections.js
@@ -298,6 +298,7 @@ const sections = [
 		module: 'reader',
 		secondary: true,
 		group: 'reader',
+		trackLoadPerformance: true,
 	},
 	{
 		name: 'reader',
@@ -305,6 +306,7 @@ const sections = [
 		module: 'reader',
 		secondary: true,
 		group: 'reader',
+		trackLoadPerformance: true,
 	},
 	{
 		name: 'reader',
@@ -312,6 +314,7 @@ const sections = [
 		module: 'reader/full-post',
 		secondary: false,
 		group: 'reader',
+		trackLoadPerformance: true,
 	},
 	{
 		name: 'reader',
@@ -319,6 +322,7 @@ const sections = [
 		module: 'reader/discover',
 		secondary: true,
 		group: 'reader',
+		trackLoadPerformance: true,
 	},
 	{
 		name: 'reader',
@@ -333,6 +337,7 @@ const sections = [
 		module: 'reader/tag-stream',
 		secondary: true,
 		group: 'reader',
+		trackLoadPerformance: true,
 	},
 	{
 		name: 'reader',
@@ -340,6 +345,7 @@ const sections = [
 		module: 'reader/liked-stream',
 		secondary: true,
 		group: 'reader',
+		trackLoadPerformance: true,
 	},
 	{
 		name: 'reader',
@@ -347,6 +353,7 @@ const sections = [
 		module: 'reader/search',
 		secondary: true,
 		group: 'reader',
+		trackLoadPerformance: true,
 	},
 	{
 		name: 'reader',
@@ -361,6 +368,7 @@ const sections = [
 		module: 'reader/conversations',
 		secondary: true,
 		group: 'reader',
+		trackLoadPerformance: true,
 	},
 	{
 		name: 'help',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Instruments Reader pages to collecdt RUM data.

#### Testing instructions

* Opt-in the abtest `rumDataCollection` with the variant `collectData`
* Navigate to the following pages (doing full reloads, clicking on the nav and/or using the browser's back button):
    * Reader > Followed sites
    * Reader > Followed sites and click on the title of a site (url should be /read/feeds/xxxx)
    * Reader > Followed sites (using an account with no followed sites)
    * Reader > Conversations
    * Reader > Conversations (using an account with no conversations)
    * Reader > Automattic
    * Reader > A8C Conversations
    * Reader > Conversations
    * Reader > Discover
    * Reader > Discover and click on a suggested post
    * Reader > Search
    * Reader > Search and click on a suggested post
    * Reader > Search and search for something with no results
    * Reader > My likes
    * Reader > Tags > A tag with posts
    * Reader > Tags > A tag that doesn't have any post
* For all the above interations, verify there is a call to `/logstash` for each one of them.

Fixes #42890
