### PR TITLE
Jetpack Checklist Modal: Start Progress Bar at 10%

### DIFF
--- a/client/my-sites/plans/current-plan/current-plan-thank-you/paid-plan-thank-you.js
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you/paid-plan-thank-you.js
@@ -137,8 +137,12 @@ export class PaidPlanThankYou extends Component {
 								)
 							) }
 						</p>
-
-						<ProgressBar isPulsing total={ 100 } value={ installProgress || 0 } />
+						{ /* Make the progress bar more visibile by starting at 10% */ }
+						<ProgressBar
+							isPulsing
+							total={ 100 }
+							value={ installProgress < 10 ? 10 : installProgress }
+						/>
 					</ThankYou>
 				) }
 				{ installState === INSTALL_STATE_COMPLETE && (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Makes the progress bar on the Jetpack checklist modal begin at 10%

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

I tested with these steps, but it's probably worth actually doing it properly with a purchase if possible!

1. Remove these lines

https://github.com/Automattic/wp-calypso/blob/d8079b0738117bda3c43ba7400196a26fa61491b/client/my-sites/plans/current-plan/index.jsx#L97-L99

2. Visit `/plans/my-plan/site.ninja?thank-you=` and verify the modal starts at 10%

<img width="841" alt="Screenshot 2020-06-03 at 15 47 59" src="https://user-images.githubusercontent.com/43215253/83651650-a12b8600-a5b1-11ea-9131-256326ca6241.png">

3. Replace `getJetpackProductInstallProgress( state, siteId )` with a random number above 10

https://github.com/Automattic/wp-calypso/blob/d8079b0738117bda3c43ba7400196a26fa61491b/client/my-sites/plans/current-plan/current-plan-thank-you/paid-plan-thank-you.js#L172

4. Verify the Progress Bar status updates

<img width="830" alt="Screenshot 2020-06-03 at 15 52 48" src="https://user-images.githubusercontent.com/43215253/83652227-49d9e580-a5b2-11ea-951a-cc87176129b9.png">

cc @jeherve, @simison, @beaulebens 

Fixes #41685
