### PR TITLE
Typography: Update 13px and 14px font size to use vars

### DIFF
--- a/client/assets/stylesheets/_main.scss
+++ b/client/assets/stylesheets/_main.scss
@@ -68,7 +68,7 @@ body {
 }
 
 button {
-	font-size: 14px;
+	font-size: $font-body-small;
 }
 
 body,

--- a/client/blocks/app-banner/style.scss
+++ b/client/blocks/app-banner/style.scss
@@ -48,6 +48,6 @@
 	padding: 7px 0 9px 14px;
 	text-decoration: none;
 	font-weight: 600;
-	font-size: 14px;
+	font-size: $font-body-small;
 	line-height: 24px;
 }

--- a/client/blocks/author-compact-profile/style.scss
+++ b/client/blocks/author-compact-profile/style.scss
@@ -1,7 +1,7 @@
 
 
 .author-compact-profile {
-	font-size: 14px;
+	font-size: $font-body-small;
 	display: flex;
 	flex-direction: column;
 	width: 100%;

--- a/client/blocks/author-selector/style.scss
+++ b/client/blocks/author-selector/style.scss
@@ -42,7 +42,7 @@
 	}
 
 	.user__name {
-		font-size: 13px;
+		font-size: $font-body-small;
 	}
 }
 

--- a/client/blocks/author-selector/style.scss
+++ b/client/blocks/author-selector/style.scss
@@ -70,7 +70,7 @@
 	padding: 8px 16px;
 	line-height: 26px;
 	width: 168px;
-	font-size: 14px;
+	font-size: $font-body-small;
 	font-style: italic;
 	color: var( --color-text-subtle );
 }

--- a/client/blocks/comment-button/style.scss
+++ b/client/blocks/comment-button/style.scss
@@ -26,7 +26,7 @@
 }
 
 .comment-button__label {
-	font-size: 14px;
+	font-size: $font-body-small;
 	margin-left: 4px;
 }
 

--- a/client/blocks/comments/comment-actions.scss
+++ b/client/blocks/comments/comment-actions.scss
@@ -1,7 +1,7 @@
 // Actions for Individual Comments
 .comments__comment-actions {
 	color: var( --color-text-subtle );
-	font-size: 14px;
+	font-size: $font-body-small;
 	list-style: none;
 	margin-top: -6px;
 
@@ -12,7 +12,7 @@
 		margin-right: 8px;
 		margin-top: 0;
 		cursor: pointer;
-		font-size: 14px;
+		font-size: $font-body-small;
 
 		.gridicon {
 			position: relative;

--- a/client/blocks/comments/comment-count.scss
+++ b/client/blocks/comments/comment-count.scss
@@ -1,6 +1,6 @@
 .comments__comment-count {
 	color: var( --color-text-subtle );
-	font-size: 14px;
+	font-size: $font-body-small;
 	font-weight: 600;
 	line-height: 1;
 	margin: 8px 0 17px;

--- a/client/blocks/comments/comment-edit-form.scss
+++ b/client/blocks/comments/comment-edit-form.scss
@@ -5,7 +5,7 @@
 	margin-top: 5px;
 
 	input {
-		font-size: 14px;
+		font-size: $font-body-small;
 		padding: 5px 10px;
 	}
 
@@ -20,7 +20,7 @@
 			min-height: 33px;
 			margin: 0;
 			padding: 5px 60px 5px 5px;
-			font-size: 14px;
+			font-size: $font-body-small;
 			font-family: $serif;
 			line-height: 21px;
 

--- a/client/blocks/comments/form.scss
+++ b/client/blocks/comments/form.scss
@@ -12,7 +12,7 @@
 	}
 
 	input {
-		font-size: 14px;
+		font-size: $font-body-small;
 		padding: 5px 10px;
 	}
 
@@ -27,7 +27,7 @@
 			min-height: 33px;
 			margin: 0;
 			padding: 5px 60px 5px 5px;
-			font-size: 14px;
+			font-size: $font-body-small;
 			font-family: $serif;
 			line-height: 21px;
 
@@ -97,5 +97,5 @@
 	text-align: center;
 	border-top: 1px solid var( --color-neutral-0 );
 	padding-top: 22px;
-	font-size: 14px;
+	font-size: $font-body-small;
 }

--- a/client/blocks/comments/post-comment-list.scss
+++ b/client/blocks/comments/post-comment-list.scss
@@ -28,7 +28,7 @@
 	color: var( --color-text-subtle );
 	cursor: pointer;
 	display: block !important; // to overwrite inline-block rule
-	font-size: 14px;
+	font-size: $font-body-small;
 	line-height: 1;
 	margin-bottom: 15px !important; // to overwrite 10px value
 

--- a/client/blocks/comments/post-comment.scss
+++ b/client/blocks/comments/post-comment.scss
@@ -59,7 +59,7 @@
 	color: var( --color-text );
 	display: flex;
 	flex-wrap: wrap;
-	font-size: 14px;
+	font-size: $font-body-small;
 	font-weight: 600;
 
 	.gravatar {

--- a/client/blocks/conversation-caterpillar/style.scss
+++ b/client/blocks/conversation-caterpillar/style.scss
@@ -9,7 +9,7 @@
 	display: flex;
 	margin-left: 8px;
 	flex: 1 1 auto;
-	font-size: 14px;
+	font-size: $font-body-small;
 	font-weight: 400;
 	overflow: hidden;
 	position: relative;

--- a/client/blocks/daily-post-button/style.scss
+++ b/client/blocks/daily-post-button/style.scss
@@ -2,7 +2,7 @@
 	background: none;
 	border: 0;
 	color: var( --color-primary );
-	font-size: 14px;
+	font-size: $font-body-small;
 	line-height: normal;
 	margin: 9px 0 6px;
 	padding: 0;

--- a/client/blocks/disconnect-jetpack/style.scss
+++ b/client/blocks/disconnect-jetpack/style.scss
@@ -22,7 +22,7 @@
 .disconnect-jetpack__feature {
 	padding: 14px 24px 14px 44px;
 	text-align: left;
-	font-size: 13px;
+	font-size: $font-body-small;
 	border-bottom: 1px solid var( --color-neutral-5 );
 
 	&:first-of-type {
@@ -57,7 +57,7 @@
 }
 
 .disconnect-jetpack__more-info-link {
-	font-size: 13px;
+	font-size: $font-body-small;
 }
 
 // Dialog

--- a/client/blocks/edit-gravatar/style.scss
+++ b/client/blocks/edit-gravatar/style.scss
@@ -87,7 +87,7 @@
 
 .edit-gravatar__explanation {
 	color: var( --color-text-subtle );
-	font-size: 13px;
+	font-size: $font-body-small;
 	font-style: italic;
 	font-weight: 400;
 	display: inline-block;

--- a/client/blocks/eligibility-warnings/style.scss
+++ b/client/blocks/eligibility-warnings/style.scss
@@ -1,6 +1,6 @@
 .eligibility-warnings {
 	margin-top: 16px;
-	font-size: 14px;
+	font-size: $font-body-small;
 }
 
 .eligibility-warnings--with-indent {

--- a/client/blocks/get-apps/style.scss
+++ b/client/blocks/get-apps/style.scss
@@ -29,7 +29,7 @@
 }
 
 .get-apps__description {
-	font-size: 13px;
+	font-size: $font-body-small;
 	margin-bottom: 4px;
 
 	@include breakpoint-deprecated('>480px') {
@@ -185,7 +185,7 @@
 
 .get-apps__also-available {
 	color: var( --color-text-subtle );
-	font-size: 13px;
+	font-size: $font-body-small;
 	font-style: italic;
 }
 

--- a/client/blocks/get-apps/style.scss
+++ b/client/blocks/get-apps/style.scss
@@ -173,7 +173,7 @@
 	padding: 0 24px;
 
 	@include breakpoint-deprecated('>480px') {
-		font-size: 14px;
+		font-size: $font-body-small;
 	}
 }
 

--- a/client/blocks/image-selector/style.scss
+++ b/client/blocks/image-selector/style.scss
@@ -198,7 +198,7 @@
 		}
 
 		p {
-			font-size: 14px;
+			font-size: $font-body-small;
 			margin-top: 12px;
 			margin-bottom: 0;
 		}

--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -125,7 +125,7 @@
 		font-size: 12px;
 
 		@include breakpoint-deprecated( '>660px' ) {
-			font-size: 14px;
+			font-size: $font-body-small;
 		}
 	}
 
@@ -134,7 +134,7 @@
 		font-size: 12px;
 
 		@include breakpoint-deprecated( '>660px' ) {
-			font-size: 14px;
+			font-size: $font-body-small;
 		}
 	}
 
@@ -218,7 +218,7 @@
 
 .inline-help__view-heading {
 	display: block;
-	font-size: 14px;
+	font-size: $font-body-small;
 	font-weight: 600;
 	margin-bottom: 5px;
 }
@@ -228,7 +228,7 @@
 
 	.inline-help__richresult__title {
 		display: block;
-		font-size: 14px;
+		font-size: $font-body-small;
 		font-weight: 600;
 		margin-bottom: 5px;
 	}
@@ -351,7 +351,7 @@
 
 .inline-help__results-item {
 	margin: 0;
-	font-size: 14px;
+	font-size: $font-body-small;
 
 	@include breakpoint-deprecated( '>660px' ) {
 		font-size: 18px;
@@ -400,7 +400,7 @@
 .inline-help__empty-results {
 	padding: 16px 0 0;
 	margin: 0;
-	font-size: 14px;
+	font-size: $font-body-small;
 	color: var( --color-text-subtle );
 	font-style: italic;
 

--- a/client/blocks/like-button/style.scss
+++ b/client/blocks/like-button/style.scss
@@ -71,6 +71,6 @@
 .like-button__label {
 	// this keeps the label from collapsing and making the icon drop down
 	margin-left: 1px;
-	font-size: 14px;
+	font-size: $font-body-small;
 	min-width: 10px;
 }

--- a/client/blocks/login/continue-as-user.scss
+++ b/client/blocks/login/continue-as-user.scss
@@ -5,7 +5,7 @@
 	justify-content: center;
 	flex-direction: column;
 	color: var( --color-text-subtle );
-	font-size: 14px;
+	font-size: $font-body-small;
 	text-align: center;
 
 	.continue-as-user__gravatar-link {

--- a/client/blocks/login/divider.scss
+++ b/client/blocks/login/divider.scss
@@ -8,7 +8,7 @@
 	span {
 		background: var( --color-surface );
 		color: var( --color-text-subtle );
-		font-size: 14px;
+		font-size: $font-body-small;
 		padding-left: 8px;
 		padding-right: 8px;
 		position: relative;

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -120,7 +120,7 @@
 	label {
 		color: var( --color-neutral-70 );
 		display: block;
-		font-size: 14px;
+		font-size: $font-body-small;
 		line-height: 1.5;
 		font-weight: 600;
 		margin-bottom: 5px;

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -201,7 +201,7 @@
 
 .login__form-signup-link {
 	clear: both;
-	font-size: 13px;
+	font-size: $font-body-small;
 	padding-top: 20px;
 
 	&.disabled {

--- a/client/blocks/login/two-factor-authentication/push-notification-illustration.scss
+++ b/client/blocks/login/two-factor-authentication/push-notification-illustration.scss
@@ -19,7 +19,7 @@
 	top: 66px;
 	left: calc( 50% - 126px ); // (100% - 352px) / 2 + 50px
 	color: var( --color-text-inverted );
-	font-size: 13px;
+	font-size: $font-body-small;
 	font-weight: 600;
 	line-height: 1em;
 }

--- a/client/blocks/post-edit-button/style.scss
+++ b/client/blocks/post-edit-button/style.scss
@@ -36,7 +36,7 @@
 }
 
 .post-edit-button__label {
-	font-size: 14px;
+	font-size: $font-body-small;
 	margin-left: 4px;
 
 	@include breakpoint-deprecated( '<480px' ) {

--- a/client/blocks/post-likes/style.scss
+++ b/client/blocks/post-likes/style.scss
@@ -1,7 +1,7 @@
 @import './variables.scss';
 
 .post-likes {
-	font-size: 13px;
+	font-size: $font-body-small;
 
 	.post-likes__item {
 		display: inline-block;

--- a/client/blocks/privacy-policy-banner/privacy-policy-dialog.scss
+++ b/client/blocks/privacy-policy-banner/privacy-policy-dialog.scss
@@ -1,7 +1,7 @@
 // dialog
 .dialog.card.privacy-policy-banner__dialog {
 	max-width: 700px;
-	font-size: 14px;
+	font-size: $font-body-small;
 	overflow: hidden;
 
 	ol {

--- a/client/blocks/reader-combined-card/style.scss
+++ b/client/blocks/reader-combined-card/style.scss
@@ -1,5 +1,5 @@
 .reader-combined-card__header {
-	font-size: 13px;
+	font-size: $font-body-small;
 	display: flex;
 	max-height: 32px;
 	margin-bottom: 20px;
@@ -169,7 +169,7 @@
 }
 
 .reader-combined-card__post-author-and-time {
-	font-size: 13px;
+	font-size: $font-body-small;
 	color: var( --color-text-subtle );
 	font-family: $sans;
 	overflow: hidden;

--- a/client/blocks/reader-export-button/style.scss
+++ b/client/blocks/reader-export-button/style.scss
@@ -18,7 +18,7 @@
 }
 
 .reader-export-button__label {
-	font-size: 14px;
+	font-size: $font-body-small;
 	color: var( --color-text-subtle );
 	padding-left: 4px;
 }

--- a/client/blocks/reader-feed-header/style.scss
+++ b/client/blocks/reader-feed-header/style.scss
@@ -101,7 +101,7 @@
 
 	.reader-feed-header__follow-count {
 		color: var( --color-text-subtle );
-		font-size: 14px;
+		font-size: $font-body-small;
 		margin-right: 15px;
 
 		@include breakpoint-deprecated( '<960px' ) {
@@ -142,7 +142,7 @@
 
 	.reader-feed-header__details {
 		align-self: stretch;
-		font-size: 14px;
+		font-size: $font-body-small;
 		overflow: hidden;
 		text-align: center;
 		position: relative;

--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -58,7 +58,7 @@
 		margin: 0;
 		border: none;
 		background: none;
-		font-size: 13px;
+		font-size: $font-body-small;
 	}
 
 	hr {
@@ -179,7 +179,7 @@
 	.wp-caption .wp-media-credit {
 		padding: 12px;
 		margin: 0;
-		font-size: 13px;
+		font-size: $font-body-small;
 		text-align: center;
 		color: var( --color-neutral-40 );
 	}
@@ -280,7 +280,7 @@
 		padding: 16px;
 		border: none;
 		background: none;
-		font-size: 13px;
+		font-size: $font-body-small;
 		width: 175px;
 
 		&.left,
@@ -328,7 +328,7 @@
 		padding: 0;
 		border: none;
 		background: none;
-		font-size: 13px;
+		font-size: $font-body-small;
 		width: 175px;
 		position: relative;
 

--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -192,7 +192,7 @@
 		border-radius: 1px;
 		background: var( --color-neutral-0 );
 		box-sizing: border-box;
-		font-size: 14px;
+		font-size: $font-body-small;
 		line-height: 1.4285;
 		animation: appear 0.3s ease-in-out;
 

--- a/client/blocks/reader-full-post/gutenberg-gallery.scss
+++ b/client/blocks/reader-full-post/gutenberg-gallery.scss
@@ -1,5 +1,5 @@
 $grid-size-large: 16px;
-$default-font-size: 13px;
+$default-font-size: $font-body-small;
 $content-width: 610px;
 $break-small: 600px;
 $black: #000;

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -361,7 +361,7 @@
 
 .reader-full-post__sidebar .comment-button__label,
 .reader-full-post__sidebar .like-button__label {
-	font-size: 14px;
+	font-size: $font-body-small;
 }
 
 .reader-full-post__sidebar .comment-button {

--- a/client/blocks/reader-import-button/style.scss
+++ b/client/blocks/reader-import-button/style.scss
@@ -18,7 +18,7 @@
 }
 
 .reader-import-button__label {
-	font-size: 14px;
+	font-size: $font-body-small;
 	color: var( --color-text-subtle );
 	padding-left: 4px;
 }

--- a/client/blocks/reader-list-item/style.scss
+++ b/client/blocks/reader-list-item/style.scss
@@ -1,7 +1,7 @@
 .reader-list-item {
 	display: flex;
 	flex-flow: row wrap;
-	font-size: 14px;
+	font-size: $font-body-small;
 	height: 100%;
 
 	@include breakpoint-deprecated( '<660px' ) {

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -254,7 +254,7 @@
 
 .reader-post-card__byline {
 	display: flex;
-	font-size: 13px;
+	font-size: $font-body-small;
 }
 
 .reader-post-card__author::after {

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -503,7 +503,7 @@
 
 // Action buttons in post card
 .reader-post-card.card .reader-post-actions__item {
-	font-size: 14px;
+	font-size: $font-body-small;
 	height: 22px;
 
 	&.reader-post-actions__visit .gridicon {

--- a/client/blocks/reader-recommended-sites/style.scss
+++ b/client/blocks/reader-recommended-sites/style.scss
@@ -6,7 +6,7 @@
 
 .reader-recommended-sites__header {
 	color: var( --color-text-subtle );
-	font-size: 14px;
+	font-size: $font-body-small;
 	letter-spacing: 0.01em;
 	font-weight: 600;
 	margin: 8px 0;

--- a/client/blocks/reader-related-card/style.scss
+++ b/client/blocks/reader-related-card/style.scss
@@ -1,6 +1,6 @@
 .reader-related-card__heading {
 	color: var( --color-text-subtle );
-	font-size: 14px;
+	font-size: $font-body-small;
 	font-weight: 600;
 	margin-bottom: 20px;
 	display: -webkit-box;
@@ -219,7 +219,7 @@
 	display: flex;
 	flex: 1 1 auto;
 	flex-direction: column;
-	font-size: 14px;
+	font-size: $font-body-small;
 	margin-top: 3px;
 	min-height: 38px;
 }

--- a/client/blocks/reader-site-notification-settings/style.scss
+++ b/client/blocks/reader-site-notification-settings/style.scss
@@ -7,7 +7,7 @@
 }
 
 .reader-site-notification-settings__button-label {
-	font-size: 14px;
+	font-size: $font-body-small;
 
 	@include breakpoint-deprecated( '<660px' ) {
 		display: none;
@@ -58,7 +58,7 @@
 .reader-site-notification-settings__popout-instructions {
 	border-top: 1px solid var( --color-neutral-10 );
 	color:var( --color-neutral-70 );
-	font-size: 14px;
+	font-size: $font-body-small;
 	padding: 10px 15px;
 	text-align: left;
 

--- a/client/blocks/reader-subscription-list-item/style.scss
+++ b/client/blocks/reader-subscription-list-item/style.scss
@@ -61,7 +61,7 @@
 
 .reader-subscription-list-item {
 	display: flex;
-	font-size: 14px;
+	font-size: $font-body-small;
 	padding: 15px 0;
 
 	@include breakpoint-deprecated( '<660px' ) {

--- a/client/blocks/signup-form/style.scss
+++ b/client/blocks/signup-form/style.scss
@@ -34,7 +34,7 @@
 	box-sizing: border-box;
 
 	p {
-		font-size: 13px;
+		font-size: $font-body-small;
 		color: var( --color-text-inverted );
 		margin: 0 0 12px;
 		text-align: center;
@@ -76,7 +76,7 @@
 .signup-form__recaptcha-tos {
 	display: none;
 	padding: 20px 10px 10px;
-	font-size: 13px;
+	font-size: $font-body-small;
 	color: var( --studio-blue-5 );
 	text-align: center;
 

--- a/client/blocks/site/style.scss
+++ b/client/blocks/site/style.scss
@@ -112,7 +112,7 @@
 .site__title {
 	color: var( --color-text );
 	display: block;
-	font-size: 13px;
+	font-size: $font-body-small;
 	font-weight: 400;
 	line-height: 1.3;
 }

--- a/client/blocks/support-article-dialog/content.scss
+++ b/client/blocks/support-article-dialog/content.scss
@@ -166,7 +166,7 @@
 	.wp-caption .wp-media-credit {
 		padding: 12px;
 		margin: 0;
-		font-size: 13px;
+		font-size: $font-body-small;
 		text-align: center;
 		color: var( --color-neutral-40 );
 	}

--- a/client/blocks/support-article-dialog/content.scss
+++ b/client/blocks/support-article-dialog/content.scss
@@ -179,7 +179,7 @@
 		border-radius: 1px;
 		background: var( --color-neutral-0 );
 		box-sizing: border-box;
-		font-size: 14px;
+		font-size: $font-body-small;
 		line-height: 1.4285;
 		animation: appear 0.3s ease-in-out;
 

--- a/client/blocks/term-tree-selector/search.scss
+++ b/client/blocks/term-tree-selector/search.scss
@@ -14,7 +14,7 @@
 		padding: 4px 8px 4px 30px;
 		border-width: 0 0 1px;
 		background: var( --color-surface );
-		font-size: 13px;
+		font-size: $font-body-small;
 		-webkit-appearance: none;
 	}
 }

--- a/client/blocks/term-tree-selector/terms.scss
+++ b/client/blocks/term-tree-selector/terms.scss
@@ -44,7 +44,7 @@ input[type='checkbox'].term-tree-selector__input {
 .term-tree-selector__list-item {
 	position: relative;
 	padding: 4px 8px;
-	font-size: 13px;
+	font-size: $font-body-small;
 
 	.term-tree-selector.is-compact.is-small & {
 		padding-left: 0;

--- a/client/blocks/visit-site/style.scss
+++ b/client/blocks/visit-site/style.scss
@@ -1,4 +1,4 @@
 .visit-site {
 	color: var( --color-text-subtle );
-	font-size: 14px;
+	font-size: $font-body-small;
 }

--- a/client/components/accordion/style.scss
+++ b/client/components/accordion/style.scss
@@ -86,7 +86,7 @@ $accordion-background-expanded: var( --color-surface );
 .accordion__title,
 .accordion__subtitle {
 	display: block;
-	font-size: 13px;
+	font-size: $font-body-small;
 	font-weight: 600;
 	line-height: $accordion-subtitle-height;
 	transition: all 150ms ease-in;

--- a/client/components/action-panel/style.scss
+++ b/client/components/action-panel/style.scss
@@ -16,7 +16,7 @@
 
 // Body
 .action-panel__body {
-	font-size: 14px;
+	font-size: $font-body-small;
 	line-height: 20px;
 	color: var( --color-text-subtle );
 	overflow: hidden;
@@ -80,7 +80,7 @@ a.action-panel__body-text-link {
 	width: 100%;
 	padding: 12px 16px;
 	border-top: solid 1px var( --color-neutral-10 );
-	font-size: 14px;
+	font-size: $font-body-small;
 	line-height: 18px;
 	color: var( --color-neutral-70 );
 

--- a/client/components/badge/style.scss
+++ b/client/components/badge/style.scss
@@ -2,7 +2,7 @@
 	display: inline-block;
 	border-radius: 1000px; // A number large enough to exceed height of any badge to make it look like a pill
 	padding: $badge-padding-y $badge-padding-x;
-	font-size: 14px;
+	font-size: $font-body-small;
 	line-height: 17px;
 	height: 18px;
 }

--- a/client/components/banner/style.scss
+++ b/client/components/banner/style.scss
@@ -144,7 +144,7 @@
 	}
 
 	.banner__title {
-		font-size: 14px;
+		font-size: $font-body-small;
 		font-weight: 600;
 	}
 

--- a/client/components/card-heading/style.scss
+++ b/client/components/card-heading/style.scss
@@ -38,7 +38,7 @@
 }
 
 .card-heading-14 {
-	font-size: 14px;
+	font-size: $font-body-small;
 }
 
 .card-heading-11 {

--- a/client/components/checklist/style.scss
+++ b/client/components/checklist/style.scss
@@ -141,7 +141,7 @@ $chevron-animation: transform 0.15s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
 
 	.checklist__task-description {
 		word-break: break-word;
-		font-size: 14px;
+		font-size: $font-body-small;
 		margin-bottom: 16px;
 	}
 
@@ -151,7 +151,7 @@ $chevron-animation: transform 0.15s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
 	}
 
 	.checklist__task-duration {
-		font-size: 14px;
+		font-size: $font-body-small;
 		color: var( --color-neutral-dark );
 	}
 
@@ -202,7 +202,7 @@ $chevron-animation: transform 0.15s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
 
 		.checklist__task-title-button.button {
 			font-weight: 600;
-			font-size: 14px;
+			font-size: $font-body-small;
 			padding-top: 8px;
 
 			.checklist__toggle-icon {
@@ -222,7 +222,7 @@ $chevron-animation: transform 0.15s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
 
 		&.is-completed .checklist__task-title {
 			padding: 8px $task-right-padding 8px $task-left-padding;
-			font-size: 14px;
+			font-size: $font-body-small;
 		}
 	}
 
@@ -232,7 +232,7 @@ $chevron-animation: transform 0.15s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
 		.checklist__task-title,
 		.checklist__task-title-button {
 			color: var( --color-text-subtle );
-			font-size: 14px;
+			font-size: $font-body-small;
 		}
 
 		.spinner {

--- a/client/components/community-translator/style.scss
+++ b/client/components/community-translator/style.scss
@@ -52,14 +52,14 @@
 	.community-translator__string-description {
 		margin-right: 7px;
 		flex-basis: 15%;
-		font-size: 14px;
+		font-size: $font-body-small;
 		font-style: italic;
 		color: var( --color-neutral-20 );
 	}
 	dfn {
 		margin-bottom: 5px;
 		display: block;
-		font-size: 14px;
+		font-size: $font-body-small;
 	}
 	textarea {
 		min-height: auto;

--- a/client/components/date-range/style.scss
+++ b/client/components/date-range/style.scss
@@ -181,7 +181,7 @@
 	}
 
 	input {
-		font-size: 13px;
+		font-size: $font-body-small;
 		padding: 3px 10px;
 	}
 }

--- a/client/components/domains/domain-product-price/style.scss
+++ b/client/components/domains/domain-product-price/style.scss
@@ -1,7 +1,7 @@
 .domain-product-price {
 	color: var( --color-text );
 	font-weight: 400;
-	font-size: 14px;
+	font-size: $font-body-small;
 	line-height: 1;
 	display: flex;
 	flex-direction: column;
@@ -36,7 +36,7 @@
 
 	@include breakpoint-deprecated( '<660px' ) {
 		display: inline-block;
-		font-size: 14px;
+		font-size: $font-body-small;
 		text-align: left;
 	}
 

--- a/client/components/domains/domain-transfer-suggestion/style.scss
+++ b/client/components/domains/domain-transfer-suggestion/style.scss
@@ -4,7 +4,7 @@
 
 	& .button.domain-suggestion__action.is-borderless {
 	  flex: 1 0 auto;
-	  font-size: 14px;
+	  font-size: $font-body-small;
 	  text-align: left;
 	  width: 100%;
 

--- a/client/components/domains/search-filters/style.scss
+++ b/client/components/domains/search-filters/style.scss
@@ -116,7 +116,7 @@
 	body.is-section-signup .layout & {
 		button.search-filters__tld-button,
 		button.search-filters__popover-button {
-			font-size: 14px;
+			font-size: $font-body-small;
 			padding-top: 0.5em;
 			padding-bottom: 0.5em;
 		}

--- a/client/components/domains/transfer-domain-step/style.scss
+++ b/client/components/domains/transfer-domain-step/style.scss
@@ -244,7 +244,7 @@
 
 	p {
 		color: var( --color-neutral-40 );
-		font-size: 14px;
+		font-size: $font-body-small;
 	}
 }
 
@@ -284,7 +284,7 @@ input {
 
 	legend {
 		small {
-			font-size: 14px;
+			font-size: $font-body-small;
 			padding-left: 10px;
 			color: var( --color-primary );
 		}

--- a/client/components/drop-zone/style.scss
+++ b/client/components/drop-zone/style.scss
@@ -40,7 +40,7 @@
 	z-index: z-index( 'root', '.drop-zone__content' );
 	transform: translateY( -50% );
 	width: 100%;
-	font-size: 14px;
+	font-size: $font-body-small;
 	font-weight: 600;
 	text-align: center;
 	color: var( --color-text-inverted );

--- a/client/components/email-verification/email-verification-dialog/style.scss
+++ b/client/components/email-verification/email-verification-dialog/style.scss
@@ -41,7 +41,7 @@
 
 .email-verification-dialog__confirmation-dialog-reasoning {
 	color: var( --color-neutral-40 );
-	font-size: 14px;
+	font-size: $font-body-small;
 	margin-bottom: 24px;
 }
 

--- a/client/components/faq/style.scss
+++ b/client/components/faq/style.scss
@@ -28,7 +28,7 @@ $faq-gutter-width: 24px;
 .faq__item {
 	width: 100%;
 	margin-bottom: 16px;
-	font-size: 14px;
+	font-size: $font-body-small;
 	line-height: 21px;
 	box-sizing: border-box;
 	padding-left: ($faq-gutter-width / 2);

--- a/client/components/formatted-header/style.scss
+++ b/client/components/formatted-header/style.scss
@@ -49,7 +49,7 @@
 
 .formatted-header__subtitle {
 	color: var( --color-neutral-50 );
-	font-size: 14px;
+	font-size: $font-body-small;
 	padding: 0 20px 24px;
 
 	@include breakpoint-deprecated( '>480px' ) {

--- a/client/components/forms/form-input-validation/style.scss
+++ b/client/components/forms/form-input-validation/style.scss
@@ -4,7 +4,7 @@
 	padding: 6px 24px 11px 34px;
 	border-radius: 1px;
 	box-sizing: border-box;
-	font-size: 14px;
+	font-size: $font-body-small;
 	animation: appear 0.3s ease-in-out;
 	font-weight: normal;
 

--- a/client/components/forms/form-label/style.scss
+++ b/client/components/forms/form-label/style.scss
@@ -1,6 +1,6 @@
 .form-label {
 	display: block;
-	font-size: 14px;
+	font-size: $font-body-small;
 	font-weight: 600;
 	margin-bottom: 5px;
 

--- a/client/components/forms/form-legend/style.scss
+++ b/client/components/forms/form-legend/style.scss
@@ -1,5 +1,5 @@
 .form-legend {
-	font-size: 14px;
+	font-size: $font-body-small;
 	font-weight: 600;
 	margin-bottom: 5px;
 }

--- a/client/components/forms/form-setting-explanation/style.scss
+++ b/client/components/forms/form-setting-explanation/style.scss
@@ -1,7 +1,7 @@
 .form-setting-explanation {
 	color: var( --color-text-subtle );
 	display: block;
-	font-size: 13px;
+	font-size: $font-body-small;
 	font-style: italic;
 	font-weight: 400;
 	margin: 5px 0 -5px;

--- a/client/components/gsuite/gsuite-price/style.scss
+++ b/client/components/gsuite/gsuite-price/style.scss
@@ -26,13 +26,13 @@
 
 	span {
 		color: var( --color-text-subtle );
-		font-size: 13px;
+		font-size: $font-body-small;
 		font-weight: normal;
 	}
 }
 
 .gsuite-price__price-per-user-per-year {
 	color: var( --color-text-subtle );
-	font-size: 13px;
+	font-size: $font-body-small;
 	font-style: italic;
 }

--- a/client/components/happychat/composer.scss
+++ b/client/components/happychat/composer.scss
@@ -19,7 +19,7 @@
 		padding: 12px;
 		border: none;
 		background: transparent;
-		font-size: 14px;
+		font-size: $font-body-small;
 		min-height: initial;
 		align-self: stretch;
 		resize: none;

--- a/client/components/happychat/style.scss
+++ b/client/components/happychat/style.scss
@@ -7,7 +7,7 @@
 	position: fixed;
 	bottom: 0;
 	right: 12px;
-	font-size: 14px;
+	font-size: $font-body-small;
 	display: none;		/* disabled */
 	box-sizing: border-box;
 

--- a/client/components/happychat/timeline.scss
+++ b/client/components/happychat/timeline.scss
@@ -26,7 +26,7 @@
 	}
 }
 .happychat__message-text {
-	font-size: 14px;
+	font-size: $font-body-small;
 	flex: 1;
 	padding: 8px 12px;
 	border-radius: 8px 8px 8px 0;

--- a/client/components/header-cake/style.scss
+++ b/client/components/header-cake/style.scss
@@ -8,7 +8,7 @@
 .header-cake.card {
 	display: flex;
 	align-items: center;
-	font-size: 14px;
+	font-size: $font-body-small;
 	line-height: 18px;
 	padding-top: 11px;
 	padding-bottom: 11px;

--- a/client/components/hr-with-text/style.scss
+++ b/client/components/hr-with-text/style.scss
@@ -8,7 +8,7 @@
 	> div {
 		position: relative;
 		display: inline-block;
-		font-size: 14px;
+		font-size: $font-body-small;
 		line-height: 14px;
 		color: #c8d7e1;
 		max-width: 80%;

--- a/client/components/info-popover/style.scss
+++ b/client/components/info-popover/style.scss
@@ -16,7 +16,7 @@
 .popover.info-popover__tooltip {
 	.popover__inner {
 		color: var( --color-neutral-50 );
-		font-size: 13px;
+		font-size: $font-body-small;
 		max-width: 220px;
 		padding: 16px;
 		text-align: left;

--- a/client/components/keyed-suggestions/style.scss
+++ b/client/components/keyed-suggestions/style.scss
@@ -8,7 +8,7 @@
 	border: 1px solid var( --color-neutral-5 );
 	border-top: 0;
 	padding: 4px 8px;
-	font-size: 13px;
+	font-size: $font-body-small;
 	display: flex;
 	align-items: center;
 
@@ -25,7 +25,7 @@
 	}
 
 	.keyed-suggestions__category-show-all {
-		font-size: 13px;
+		font-size: $font-body-small;
 		cursor: pointer;
 	}
 }
@@ -74,7 +74,7 @@
 	margin-left: 0.5em;
 	padding-top: 3px;
 	color: var( --color-text-subtle );
-	font-size: 13px;
+	font-size: $font-body-small;
 	height: 19px; /* font-size + 2*padding */
 	overflow: hidden;
 

--- a/client/components/language-picker/modal.scss
+++ b/client/components/language-picker/modal.scss
@@ -6,7 +6,7 @@
 		right: 0;
 		bottom: 0;
 		max-width: none;
-		font-size: 14px;
+		font-size: $font-body-small;
 		display: flex;
 		flex-direction: column;
 

--- a/client/components/language-picker/style.scss
+++ b/client/components/language-picker/style.scss
@@ -5,7 +5,7 @@
 	width: 300px;
 	display: flex;
 	flex: 1 0 auto;
-	font-size: 14px;
+	font-size: $font-body-small;
 	height: 64px;
 	align-items: stretch;
 	cursor: pointer;

--- a/client/components/legend-item/style.scss
+++ b/client/components/legend-item/style.scss
@@ -18,7 +18,7 @@
 .legend-item__placeholder-detail-value,
 .legend-item__title-name,
 .legend-item__placeholder-title-name {
-	font-size: 14px;
+	font-size: $font-body-small;
 }
 
 .legend-item__title-sample-drawing,

--- a/client/components/logged-out-form/link-item.scss
+++ b/client/components/logged-out-form/link-item.scss
@@ -2,7 +2,7 @@
 	color: var( --color-neutral-50 );
 	display: block;
 	font-family: $sans;
-	font-size: 13px;
+	font-size: $font-body-small;
 	padding: 8px 16px;
 	cursor: pointer;
 	text-decoration: underline;

--- a/client/components/mini-site-preview/style.scss
+++ b/client/components/mini-site-preview/style.scss
@@ -12,7 +12,7 @@
 
 		padding-left: 12px;
 
-		font-size: 14px;
+		font-size: $font-body-small;
 		letter-spacing: 2px;
 
 		/* Used to center the dots vertically */

--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -156,7 +156,7 @@
 	}
 
 	@include breakpoint-deprecated( '>480px' ) {
-		font-size: 14px;
+		font-size: $font-body-small;
 	}
 }
 
@@ -213,7 +213,7 @@ a.notice__action {
 			flex-grow: 0;
 		align-items: center;
 		border-radius: 0;
-		font-size: 14px;
+		font-size: $font-body-small;
 		margin: 0 0 0 auto; // forces the element to the right;
 		padding: 13px 16px;
 

--- a/client/components/pagination/style.scss
+++ b/client/components/pagination/style.scss
@@ -38,7 +38,7 @@
 		background-color: var( --color-surface );
 		border: solid 1px var( --color-neutral-10 );
 		border-right: none;
-		font-size: 14px;
+		font-size: $font-body-small;
 		line-height: 18px;
 		color: var( --color-text-subtle );
 		text-align: center;

--- a/client/components/popover/style.scss
+++ b/client/components/popover/style.scss
@@ -148,7 +148,7 @@
 	border-radius: 0;
 	cursor: pointer;
 	display: block;
-	font-size: 14px;
+	font-size: $font-body-small;
 	font-weight: 400;
 	margin: 0;
 	padding: 8px 16px;

--- a/client/components/post-schedule/style.scss
+++ b/client/components/post-schedule/style.scss
@@ -104,7 +104,7 @@ input[type='text'].post-schedule__clock-time {
 	width: 42px;
 	text-align: center;
 	padding: 0;
-	font-size: 13px;
+	font-size: $font-body-small;
 }
 
 .post-schedule__clock-divisor {

--- a/client/components/product-card/style.scss
+++ b/client/components/product-card/style.scss
@@ -109,7 +109,7 @@
 }
 
 .product-card__billing-timeframe {
-	font-size: 13px;
+	font-size: $font-body-small;
 	font-weight: 400;
 	line-height: 13px;
 	color: var( --color-text-subtle );

--- a/client/components/product-card/style.scss
+++ b/client/components/product-card/style.scss
@@ -81,7 +81,7 @@
 }
 
 .product-card__subtitle {
-	font-size: 14px;
+	font-size: $font-body-small;
 	line-height: 20px;
 	font-style: italic;
 	color: var( --color-text-subtle );
@@ -101,7 +101,7 @@
 		&,
 		& * {
 			@include breakpoint-deprecated( '>660px' ) {
-				font-size: 14px;
+				font-size: $font-body-small;
 				vertical-align: baseline;
 			}
 		}
@@ -152,7 +152,7 @@
 		vertical-align: baseline;
 
 		@include breakpoint-deprecated( '>960px' ) {
-			font-size: 14px;
+			font-size: $font-body-small;
 		}
 	}
 
@@ -168,7 +168,7 @@
 
 // Description
 .product-card__description {
-	font-size: 14px;
+	font-size: $font-body-small;
 	line-height: 20px;
 	color: var( --color-text-subtle );
 
@@ -191,7 +191,7 @@
 
 .product-card__options-label {
 	margin-top: 16px;
-	font-size: 14px;
+	font-size: $font-body-small;
 	text-align: center;
 	color: var( --color-text-subtle );
 
@@ -262,7 +262,7 @@
 
 .product-card__option-name {
 	margin-bottom: 2px;
-	font-size: 14px;
+	font-size: $font-body-small;
 	font-weight: 600;
 	line-height: 20px;
 	text-align: center;
@@ -276,7 +276,7 @@
 
 .product-card__action-intro {
 	margin-bottom: 12px;
-	font-size: 14px;
+	font-size: $font-body-small;
 	font-weight: 600;
 	color: var( --color-neutral-90 );
 }
@@ -312,7 +312,7 @@
 	color: var( --studio-white );
 	background: url( '/calypso/images/illustrations/promo-star.svg' ) no-repeat center;
 	background-size: contain;
-	font-size: 14px;
+	font-size: $font-body-small;
 	font-weight: 600;
 	line-height: 17px;
 	text-align: center;
@@ -332,7 +332,7 @@
 	strong {
 		display: block;
 		color: var( --color-text );
-		font-size: 14px;
+		font-size: $font-body-small;
 		font-weight: 600;
 		text-transform: none;
 	}

--- a/client/components/purchase-detail/style.scss
+++ b/client/components/purchase-detail/style.scss
@@ -158,7 +158,7 @@
 .purchase-detail__required-notice {
 	background-color: var( --color-warning );
 	color: var( --color-text );
-	font-size: 14px;
+	font-size: $font-body-small;
 	padding: 8px;
 	text-align: center;
 }

--- a/client/components/purchase-detail/tip-info.scss
+++ b/client/components/purchase-detail/tip-info.scss
@@ -1,6 +1,6 @@
 .purchase-detail__info {
 	color: var( --color-text-subtle );
-	font-size: 13px;
+	font-size: $font-body-small;
 	font-style: italic;
 	font-weight: 400;
 	margin-left: 8px;

--- a/client/components/section-header/style.scss
+++ b/client/components/section-header/style.scss
@@ -48,7 +48,7 @@
 
 .section-header__label {
 	color: var( --color-neutral-70 );
-	font-size: 14px;
+	font-size: $font-body-small;
 }
 
 .section-header__actions {

--- a/client/components/section-nav/item.scss
+++ b/client/components/section-nav/item.scss
@@ -33,7 +33,7 @@
 	box-sizing: border-box;
 	padding: 15px;
 	width: 100%;
-	font-size: 14px;
+	font-size: $font-body-small;
 	font-weight: 600;
 	line-height: 18px;
 	color: var( --color-neutral-70 );
@@ -136,7 +136,7 @@
 	box-sizing: border-box;
 	padding: 15px;
 	width: 100%;
-	font-size: 14px;
+	font-size: $font-body-small;
 	line-height: 18px;
 	color: var( --color-neutral-70 );
 }

--- a/client/components/section-nav/style.scss
+++ b/client/components/section-nav/style.scss
@@ -39,7 +39,7 @@
 	display: flex;
 	width: 100%;
 	padding: 15px;
-	font-size: 14px;
+	font-size: $font-body-small;
 	line-height: 16px;
 	height: 46px;
 	box-sizing: border-box;

--- a/client/components/segmented-control/style.scss
+++ b/client/components/segmented-control/style.scss
@@ -36,7 +36,7 @@
 	padding: 8px 12px;
 	border: solid 1px var( --color-neutral-10 );
 	border-right: none;
-	font-size: 14px;
+	font-size: $font-body-small;
 	line-height: 18px;
 	color: var( --color-text-subtle );
 	text-align: center;

--- a/client/components/segmented-control/style.scss
+++ b/client/components/segmented-control/style.scss
@@ -70,7 +70,7 @@
 
 .segmented-control.is-compact {
 	.segmented-control__link {
-		font-size: 13px;
+		font-size: $font-body-small;
 		padding: 4px 8px;
 	}
 }

--- a/client/components/select-dropdown/style.scss
+++ b/client/components/select-dropdown/style.scss
@@ -69,7 +69,7 @@ $compact-header-height: 35;
 	border-radius: 2px;
 	background-color: var( --color-surface );
 
-	font-size: 14px;
+	font-size: $font-body-small;
 	font-weight: 600;
 	color: var( --color-neutral-70 );
 	transition: background-color 0.2s ease;
@@ -190,7 +190,7 @@ $compact-header-height: 35;
 	padding: 0 #{$side-margin + 46}px 0 #{$side-margin}px;
 
 	color: var( --color-neutral-70 );
-	font-size: 14px;
+	font-size: $font-body-small;
 	font-weight: 400;
 	white-space: nowrap;
 	overflow: hidden;

--- a/client/components/seo/facebook-preview/style.scss
+++ b/client/components/seo/facebook-preview/style.scss
@@ -104,7 +104,7 @@
 
 		& img {
 			display: block;
-			font-size: 14px;
+			font-size: $font-body-small;
 			height: auto;
 			width: 100%;
 		}

--- a/client/components/seo/meta-title-editor/style.scss
+++ b/client/components/seo/meta-title-editor/style.scss
@@ -15,7 +15,7 @@
 	padding: 4px 2px;
 
 	@include breakpoint-deprecated( '>660px' ) {
-		font-size: 14px;
+		font-size: $font-body-small;
 		line-height: 18px;
 		padding: 8px 12px;
 	}

--- a/client/components/seo/search-preview/style.scss
+++ b/client/components/seo/search-preview/style.scss
@@ -52,7 +52,7 @@
 
 .search-preview__snippet {
 	color: #545454; // matching Google results
-	font-size: 13px;
+	font-size: $font-body-small;
 	line-height: 1.4;
 	max-width: 616px;
 }

--- a/client/components/seo/search-preview/style.scss
+++ b/client/components/seo/search-preview/style.scss
@@ -44,7 +44,7 @@
 
 .search-preview__url {
 	color: #006621; // matching Google results
-	font-size: 14px;
+	font-size: $font-body-small;
 	height: 17px;
 	line-height: 16px;
 	max-width: 616px;

--- a/client/components/seo/twitter-preview/style.scss
+++ b/client/components/seo/twitter-preview/style.scss
@@ -57,7 +57,7 @@
 	padding: 0.75em;
 	text-decoration: none;
 	font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
-	font-size: 14px;
+	font-size: $font-body-small;
 	color: black;
 	text-align: left;
 	line-height: 1.3em;

--- a/client/components/share/facebook-share-preview/style.scss
+++ b/client/components/share/facebook-share-preview/style.scss
@@ -51,7 +51,7 @@
 
 .facebook-share-preview__profile-line,
 .facebook-share-preview__body {
-	font-size: 14px;
+	font-size: $font-body-small;
 	line-height: 1.38;
 }
 

--- a/client/components/share/linkedin-share-preview/style.scss
+++ b/client/components/share/linkedin-share-preview/style.scss
@@ -38,7 +38,7 @@
 
 .linkedin-share-preview__meta-line {
 	color: rgba( 0, 0, 0, 0.55 );
-    font-size: 13px;
+    font-size: $font-body-small;
     line-height: 16px;
 }
 
@@ -84,7 +84,7 @@
 
 .linkedin-share-preview__site-url {
 	color: rgba( 0, 0, 0, 0.55 );
-	font-size: 13px;
+	font-size: $font-body-small;
 	font-weight: 400;
 	line-height: 16px;
 	overflow: hidden;

--- a/client/components/share/style.scss
+++ b/client/components/share/style.scss
@@ -92,7 +92,7 @@
 
 		& img {
 			display: block;
-			font-size: 14px;
+			font-size: $font-body-small;
 			height: auto;
 			width: 100%;
 		}
@@ -162,7 +162,7 @@
 	padding: 0.75em;
 	text-decoration: none;
 	font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
-	font-size: 14px;
+	font-size: $font-body-small;
 	color: black;
 	text-align: left;
 	line-height: 1.3em;

--- a/client/components/share/tumblr-share-preview/style.scss
+++ b/client/components/share/tumblr-share-preview/style.scss
@@ -34,7 +34,7 @@
 
 .tumblr-share-preview__profile-line {
 	display: flex;
-	font-size: 13px;
+	font-size: $font-body-small;
 	justify-content: space-between;
 	line-height: 20px;
 	margin-bottom: 13px;

--- a/client/components/share/tumblr-share-preview/style.scss
+++ b/client/components/share/tumblr-share-preview/style.scss
@@ -67,7 +67,7 @@
 .tumblr-share-preview__message,
 .tumblr-share-preview__summery,
 .tumblr-share-preview__article-link-line {
-	font-size: 14px;
+	font-size: $font-body-small;
 	line-height: 21px;
 }
 

--- a/client/components/share/twitter-share-preview/style.scss
+++ b/client/components/share/twitter-share-preview/style.scss
@@ -3,7 +3,7 @@
 	border: 1px solid #e6ecf0;
 	color: #14171a;
 	font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
-	font-size: 14px;
+	font-size: $font-body-small;
 	line-height: 1.375;
 	margin: 0 auto;
 	max-width: 565px;

--- a/client/components/share/twitter-share-preview/style.scss
+++ b/client/components/share/twitter-share-preview/style.scss
@@ -38,7 +38,7 @@
 
 .twitter-share-preview__profile-handle {
 	color: #657786;
-	font-size: 13px;
+	font-size: $font-body-small;
 }
 
 .twitter-share-preview__message,

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -115,7 +115,7 @@
 	}
 
 	.search__input[type='search'] {
-		font-size: 13px;
+		font-size: $font-body-small;
 	}
 
 	.search__open-icon,

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -36,7 +36,7 @@
 // Styles for Site elements within the Selector
 .site-selector .site,
 .site-selector .all-sites {
-	font-size: 14px;
+	font-size: $font-body-small;
 
 	// Highlight selected site
 	&.is-selected {

--- a/client/components/stripe-connect-button/style.scss
+++ b/client/components/stripe-connect-button/style.scss
@@ -46,7 +46,7 @@ We dont want to lint this file, since it's copied verbatim.
 	background-image: -ms-linear-gradient(#7DC5EE, #008CDD 85%, #30A2E4);
 	background-image: linear-gradient(#7DC5EE, #008CDD 85%, #30A2E4);
 
-	font-size: 14px;
+	font-size: $font-body-small;
 	line-height: 30px;
 	color: white;
 	font-weight: bold;

--- a/client/components/sub-masterbar-nav/style.scss
+++ b/client/components/sub-masterbar-nav/style.scss
@@ -83,7 +83,7 @@
 	border: 0;
 	outline: 0;
 	color: var( --color-masterbar-text );
-	font-size: 14px;
+	font-size: $font-body-small;
 	cursor: pointer;
 	transition: all 200ms ease-in;
 

--- a/client/components/sub-masterbar-nav/style.scss
+++ b/client/components/sub-masterbar-nav/style.scss
@@ -124,7 +124,7 @@
 		width: 100px;
 		height: 62px;
 		margin: 0 10px 10px 0;
-		font-size: 13px;
+		font-size: $font-body-small;
 		text-align: center;
 		border-radius: 5px;
 	}

--- a/client/components/thank-you-card/style.scss
+++ b/client/components/thank-you-card/style.scss
@@ -96,7 +96,7 @@
 }
 
 .thank-you-card__description {
-	font-size: 13px;
+	font-size: $font-body-small;
 	font-weight: 400;
 	width: 280px;
 	max-width: 100%;

--- a/client/components/thank-you-card/style.scss
+++ b/client/components/thank-you-card/style.scss
@@ -113,7 +113,7 @@
 	display: inline-block;
 	border-radius: 4px;
 	background-color: var( --color-surface );
-	font-size: 14px;
+	font-size: $font-body-small;
 	max-width: 280px;
 	padding: 8px 24px;
 	margin: 0 auto;

--- a/client/components/theme/style.scss
+++ b/client/components/theme/style.scss
@@ -65,7 +65,7 @@ $theme-info-height: 54px;
 	flex: 1 1 auto;
 	position: relative;
 	color: var( --color-neutral-70 );
-	font-size: 14px;
+	font-size: $font-body-small;
 	font-weight: 600;
 	padding: 16px 14px;
 	margin: inherit;

--- a/client/components/theme/style.scss
+++ b/client/components/theme/style.scss
@@ -82,7 +82,7 @@ $theme-info-height: 54px;
 	flex: 0 0 auto;
 	padding: 18px 10px 0;
 	color: var( --color-success );
-	font-size: 13px;
+	font-size: $font-body-small;
 	font-weight: 600;
 }
 

--- a/client/components/tile-grid/style.scss
+++ b/client/components/tile-grid/style.scss
@@ -135,7 +135,7 @@
 .tile-grid__item-description {
 	margin: 0;
 	color: var( --color-neutral-light );
-	font-size: 13px;
+	font-size: $font-body-small;
 	line-height: 1.5;
 
 	@include breakpoint-deprecated( '>480px' ) {

--- a/client/components/timeline/style.scss
+++ b/client/components/timeline/style.scss
@@ -105,7 +105,7 @@
 
 		.timeline-event__detail {
 			width: 100%;
-			font-size: 14px;
+			font-size: $font-body-small;
 			color: var( --color-text-subtle );
 		}
 	}

--- a/client/components/tinymce/iframe.scss
+++ b/client/components/tinymce/iframe.scss
@@ -108,7 +108,7 @@ a img {
 .wp-caption-dd {
 	background: var( --color-neutral-0 );
 	color: var( --color-neutral-50 );
-	font-size: 14px;
+	font-size: $font-body-small;
 	line-height: 1.7;
 	padding: 16px;
 }

--- a/client/components/tinymce/plugins/insert-menu/style.scss
+++ b/client/components/tinymce/plugins/insert-menu/style.scss
@@ -43,7 +43,7 @@
 	color: var( --color-neutral-50 );
 	display: inline-block;
 	font-family: $sans;
-	font-size: 13px;
+	font-size: $font-body-small;
 	margin-left: 4px;
 	margin-top: 3px;
 }

--- a/client/components/tinymce/plugins/simple-payments/style.scss
+++ b/client/components/tinymce/plugins/simple-payments/style.scss
@@ -120,7 +120,7 @@
 		flex-direction: column;
 		background-color: var( --color-neutral-0 );
 		box-shadow: inset 0 0 0 1px var( --color-neutral-5 );
-		font-size: 14px;
+		font-size: $font-body-small;
 		overflow: hidden;
 
 		&:hover {

--- a/client/components/tinymce/style.scss
+++ b/client/components/tinymce/style.scss
@@ -253,7 +253,7 @@
 
 .mce-toolbar .mce-btn-group .mce-wpcom-icon-button.mce-media button {
 	@include breakpoint-deprecated( '>660px' ) {
-		font-size: 13px;
+		font-size: $font-body-small;
 	}
 }
 
@@ -737,7 +737,7 @@ div.mce-path {
 	padding: 0;
 	color: var( --color-neutral-50 );
 	font-family: $sans;
-	font-size: 13px;
+	font-size: $font-body-small;
 	text-overflow: initial;
 
 	&:hover {
@@ -887,7 +887,7 @@ div.mce-menu .mce-menu-item-sep,
 	color: #555;
 	background: #f7f7f7;
 	text-decoration: none;
-	font-size: 13px;
+	font-size: $font-body-small;
 	line-height: 26px;
 	height: 28px;
 	margin: 0;
@@ -1246,7 +1246,7 @@ i.mce-i-wp_code::before {
 
 .wp-editor-area {
 	font-family: Consolas, Monaco, monospace;
-	font-size: 13px;
+	font-size: $font-body-small;
 	padding: 10px;
 	margin: 1px 0 0;
 	line-height: 150%;

--- a/client/components/title-format-editor/style.scss
+++ b/client/components/title-format-editor/style.scss
@@ -86,5 +86,5 @@
 	color: var( --color-neutral-light );
 	font-style: italic;
 	margin-top: 5px;
-	font-size: 13px;
+	font-size: $font-body-small;
 }

--- a/client/components/title-format-editor/style.scss
+++ b/client/components/title-format-editor/style.scss
@@ -29,7 +29,7 @@
 
 .title-format-editor__title {
 	font-weight: 600;
-	font-size: 14px;
+	font-size: $font-body-small;
 	flex: 1;
 	margin-right: auto;
 }

--- a/client/components/token-field/style.scss
+++ b/client/components/token-field/style.scss
@@ -175,7 +175,7 @@ input[type='text'].token-field__input {
 .token-field__suggestion {
 	color: var( --color-neutral-light );
 	display: block;
-	font-size: 13px;
+	font-size: $font-body-small;
 	padding: 4px 8px;
 	cursor: pointer;
 

--- a/client/components/token-field/style.scss
+++ b/client/components/token-field/style.scss
@@ -46,7 +46,7 @@ input[type='text'].token-field__input {
 	border: 0;
 	outline: none;
 	font-family: inherit;
-	font-size: 14px;
+	font-size: $font-body-small;
 	color: var( --color-neutral-70 );
 
 	&:focus {
@@ -56,7 +56,7 @@ input[type='text'].token-field__input {
 
 // Tokens
 .token-field__token {
-	font-size: 14px;
+	font-size: $font-body-small;
 	display: flex;
 	margin: 2px 0 2px 8px;
 	color: var( --color-text-inverted );

--- a/client/components/vertical-menu/items/style.scss
+++ b/client/components/vertical-menu/items/style.scss
@@ -5,8 +5,8 @@
 	border-top: 1px solid var( --color-neutral-10 );
 	border-left: 3px solid transparent;
 	color: var( --color-text-subtle );
-	font-size: 13px;
-	font-weight: 200;
+	font-size: $font-body-small;
+	font-weight: 400;
 
 	cursor: pointer;
 

--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -147,7 +147,7 @@ a.web-preview__external.button {
 
 	.form-text-input {
 		color: var( --color-text-subtle );
-		font-size: 14px;
+		font-size: $font-body-small;
 		height: 35px;
 		border-color: transparent;
 		text-overflow: ellipsis;

--- a/client/devdocs/style.scss
+++ b/client/devdocs/style.scss
@@ -23,7 +23,7 @@ $devdocs-max-width: 720px;
 	}
 
 	.devdocs__result-path {
-		font-size: 14px;
+		font-size: $font-body-small;
 		font-family: $code;
 		color: var( --color-text-subtle );
 	}
@@ -319,7 +319,7 @@ $devdocs-max-width: 720px;
 		}
 
 		.docs-selectors__param-type {
-			font-size: 14px;
+			font-size: $font-body-small;
 		}
 
 		p {

--- a/client/devdocs/style.scss
+++ b/client/devdocs/style.scss
@@ -76,7 +76,7 @@ $devdocs-max-width: 720px;
 
 .design__instance-links-label {
 	display: block;
-	font-size: 13px;
+	font-size: $font-body-small;
 	font-weight: 600;
 	margin: 8px;
 	color: var( --color-text-subtle );

--- a/client/extensions/woocommerce/app/dashboard/widgets/stats-widget/style.scss
+++ b/client/extensions/woocommerce/app/dashboard/widgets/stats-widget/style.scss
@@ -45,7 +45,7 @@
 
 		span {
 			color: var( --color-text-subtle );
-			font-size: 14px;
+			font-size: $font-body-small;
 		}
 	}
 
@@ -66,7 +66,7 @@
 	}
 
 	.table.is-compact-table .table-item {
-		font-size: 14px;
+		font-size: $font-body-small;
 		color: var( --color-neutral-50 );
 	}
 
@@ -172,7 +172,7 @@
 	.stats-widget__more {
 		text-align: left;
 		padding: 0 8px 0 16px;
-		font-size: 14px;
+		font-size: $font-body-small;
 		margin-top: -14px;
 	}
 

--- a/client/extensions/woocommerce/app/order/order-activity-log/style.scss
+++ b/client/extensions/woocommerce/app/order/order-activity-log/style.scss
@@ -109,7 +109,7 @@
 		border-color: var( --color-border-inverted );
 		resize: vertical;
 		display: block;
-		font-size: 14px;
+		font-size: $font-body-small;
 
 		&::placeholder {
 			color: var( --color-text-subtle );

--- a/client/extensions/woocommerce/app/order/order-created/style.scss
+++ b/client/extensions/woocommerce/app/order/order-created/style.scss
@@ -5,6 +5,6 @@
 	padding-bottom: 16px;
 
 	.order-created__label {
-		font-size: 14px;
+		font-size: $font-body-small;
 	}
 }

--- a/client/extensions/woocommerce/app/order/order-details/style.scss
+++ b/client/extensions/woocommerce/app/order/order-details/style.scss
@@ -108,7 +108,7 @@
 	}
 
 	.table-item {
-		font-size: 14px;
+		font-size: $font-body-small;
 	}
 
 	.order-details__coupon-list {

--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -295,19 +295,19 @@
 .products__product-form-details-basic-sku {
 	margin-top: 0;
 	margin-bottom: 12px;
-	font-size: 13px;
+	font-size: $font-body-small;
 
 	.form-label {
 		display: inline;
 		margin-right: 4px;
 		color: var( --color-neutral-70 );
-		font-size: 13px;
+		font-size: $font-body-small;
 		line-height: 35px;
 	}
 
 	input {
 		width: 65%;
-		font-size: 13px;
+		font-size: $font-body-small;
 	}
 
 	.form-click-to-edit-input__wrapper {
@@ -435,7 +435,7 @@
 }
 
 .products__all-variations {
-	font-size: 13px;
+	font-size: $font-body-small;
 }
 
 .products__product-form-variation-table-wrapper {
@@ -591,7 +591,7 @@
 }
 
 .products__product-name {
-	font-size: 13px;
+	font-size: $font-body-small;
 	text-align: left;
 }
 
@@ -788,7 +788,7 @@
 	border: 1px solid var( --color-neutral-10 );
 	padding: 16px 16px 4px;
 	margin-top: 4px;
-	font-size: 13px;
+	font-size: $font-body-small;
 	color: var( --color-neutral-40 );
 }
 

--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -425,7 +425,7 @@
 }
 
 .products__product-form-variation-table th {
-	font-size: 14px;
+	font-size: $font-body-small;
 	vertical-align: bottom;
 	min-width: 122px;
 

--- a/client/extensions/woocommerce/app/reviews/style.scss
+++ b/client/extensions/woocommerce/app/reviews/style.scss
@@ -131,7 +131,7 @@
 
 	.reviews__date {
 		color: var( --color-text-subtle );
-		font-size: 13px;
+		font-size: $font-body-small;
 	}
 
 	.reviews__rating {

--- a/client/extensions/woocommerce/app/reviews/style.scss
+++ b/client/extensions/woocommerce/app/reviews/style.scss
@@ -17,7 +17,7 @@
 }
 
 .reviews__list {
-	font-size: 14px;
+	font-size: $font-body-small;
 	.pagination {
 		margin-top: 16px;
 	}
@@ -322,7 +322,7 @@
 	border-top: 1px solid var( --color-neutral-0 );
 
 	textarea {
-		font-size: 14px;
+		font-size: $font-body-small;
 		border-color: transparent;
 		margin: 2px;
 		width: calc( 100% - 4px );
@@ -424,7 +424,7 @@
 
 		.button {
 			margin-left: 16px;
-			font-size: 14px;
+			font-size: $font-body-small;
 			font-weight: 400;
 		}
 	}

--- a/client/extensions/woocommerce/app/settings/email/mailchimp/style.scss
+++ b/client/extensions/woocommerce/app/settings/email/mailchimp/style.scss
@@ -385,7 +385,7 @@
 	border: 1px solid var( --color-neutral-10 );
 	padding: 12px;
 	margin-top: 4px;
-	font-size: 13px;
+	font-size: $font-body-small;
 	color: var( --color-neutral-40 );
 
 	.form-label {

--- a/client/extensions/woocommerce/app/settings/email/mailchimp/style.scss
+++ b/client/extensions/woocommerce/app/settings/email/mailchimp/style.scss
@@ -70,7 +70,7 @@
 	color: var( --color-text-subtle );
 	list-style: none;
 	margin: 0 0 16px;
-	font-size: 14px;
+	font-size: $font-body-small;
 
 	li {
 		margin: 6px 0;

--- a/client/extensions/woocommerce/app/settings/payments/stripe/style.scss
+++ b/client/extensions/woocommerce/app/settings/payments/stripe/style.scss
@@ -1,6 +1,6 @@
 .stripe__connect-account {
 	.stripe__connect-account-heading {
-		font-size: 14px;
+		font-size: $font-body-small;
 		font-weight: 600;
 		margin-bottom: 8px;
 	}
@@ -32,7 +32,7 @@
 			flex-direction: column;
 
 			.stripe__connect-account-name {
-				font-size: 14px;
+				font-size: $font-body-small;
 				font-weight: 400;
 				margin-bottom: 1px;
 				margin-right: 4px;

--- a/client/extensions/woocommerce/app/settings/payments/style.scss
+++ b/client/extensions/woocommerce/app/settings/payments/style.scss
@@ -78,7 +78,7 @@
 	justify-content: flex-start;
 	background: var( --color-neutral-0 );
 	font-weight: 600;
-	font-size: 14px;
+	font-size: $font-body-small;
 
 	.list-item-field {
 		padding-top: 12px;
@@ -103,7 +103,7 @@
 	}
 
 	p.payments__method-information p.payments__method-name {
-		font-size: 14px;
+		font-size: $font-body-small;
 	}
 
 	.payments__method-name-paypal,
@@ -131,7 +131,7 @@
 	}
 
 	.payments__method-information {
-		font-size: 14px;
+		font-size: $font-body-small;
 	}
 
 	.payments__method-method-suggested-container,

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/style.scss
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/style.scss
@@ -52,7 +52,7 @@
 	.list-header {
 		background: var( --color-neutral-0 );
 		font-weight: 600;
-		font-size: 14px;
+		font-size: $font-body-small;
 
 		.list-item-field {
 			padding-top: 12px;
@@ -118,7 +118,7 @@
 	}
 
 	.shipping-zone__method-title {
-		font-size: 14px;
+		font-size: $font-body-small;
 		width: 50%;
 
 		@include breakpoint-deprecated( '>660px' ) {
@@ -127,7 +127,7 @@
 	}
 
 	.shipping-zone__method-summary {
-		font-size: 14px;
+		font-size: $font-body-small;
 		width: 30%;
 
 		@include breakpoint-deprecated( '<660px' ) {
@@ -178,7 +178,7 @@
 	}
 
 	.shipping-zone__location-title {
-		font-size: 14px;
+		font-size: $font-body-small;
 		width: 100%;
 
 		@include breakpoint-deprecated( '>660px' ) {
@@ -187,7 +187,7 @@
 	}
 
 	.shipping-zone__location-summary {
-		font-size: 14px;
+		font-size: $font-body-small;
 		width: 70%;
 
 		@include breakpoint-deprecated( '<660px' ) {

--- a/client/extensions/woocommerce/app/settings/shipping/style.scss
+++ b/client/extensions/woocommerce/app/settings/shipping/style.scss
@@ -156,7 +156,7 @@
 .shipping__card-name {
 	margin-bottom: 0;
 	color: var( --color-text-subtle );
-	font-size: 13px;
+	font-size: $font-body-small;
 	line-height: 22px;
 }
 

--- a/client/extensions/woocommerce/app/settings/shipping/style.scss
+++ b/client/extensions/woocommerce/app/settings/shipping/style.scss
@@ -10,7 +10,7 @@
 	margin-bottom: 4px;
 	color: var( --color-text-subtle );
 	padding-bottom: 8px;
-	font-size: 14px;
+	font-size: $font-body-small;
 	line-height: 18px;
 }
 
@@ -108,7 +108,7 @@
 
 .shipping__zones-header {
 	padding: 12px 0;
-	font-size: 14px;
+	font-size: $font-body-small;
 	border-top: 0;
 	background: var( --color-neutral-0 );
 }
@@ -134,7 +134,7 @@
 
 .shipping__zones-row-location-name {
 	margin-bottom: 0;
-	font-size: 14px;
+	font-size: $font-body-small;
 }
 
 .shipping__zones-row-location-name {
@@ -142,7 +142,7 @@
 }
 
 .shipping__zones-row-method {
-	font-size: 14px;
+	font-size: $font-body-small;
 	display: flex;
 	flex-direction: column;
 

--- a/client/extensions/woocommerce/app/settings/taxes/style.scss
+++ b/client/extensions/woocommerce/app/settings/taxes/style.scss
@@ -1,7 +1,7 @@
 .taxes__taxes-rates {
 	.form-toggle__label-content {
 		float: left;
-		font-size: 14px;
+		font-size: $font-body-small;
 		margin-right: 8px;
 	}
 

--- a/client/extensions/woocommerce/components/action-header/style.scss
+++ b/client/extensions/woocommerce/components/action-header/style.scss
@@ -63,7 +63,7 @@
 	}
 
 	.action-header__breadcrumbs {
-		font-size: 13px;
+		font-size: $font-body-small;
 
 		span {
 			display: inline-block;

--- a/client/extensions/woocommerce/components/dashboard-widget/style.scss
+++ b/client/extensions/woocommerce/components/dashboard-widget/style.scss
@@ -31,7 +31,7 @@
 
 	p {
 		color: var( --color-text-subtle );
-		font-size: 14px;
+		font-size: $font-body-small;
 
 		&:last-child {
 			margin-bottom: 0;

--- a/client/extensions/woocommerce/components/delta/style.scss
+++ b/client/extensions/woocommerce/components/delta/style.scss
@@ -64,7 +64,7 @@
 		.delta__value {
 			color: var( --color-neutral-light );
 			display: inline-block;
-			font-size: 13px;
+			font-size: $font-body-small;
 			font-weight: 400;
 			line-height: 13px;
 			text-align: left;

--- a/client/extensions/woocommerce/components/list/list-header/style.scss
+++ b/client/extensions/woocommerce/components/list/list-header/style.scss
@@ -2,7 +2,7 @@
 	border-bottom: 1px solid var( --color-neutral-10 );
 	display: flex;
 	flex-direction: row;
-	font-size: 13px;
+	font-size: $font-body-small;
 	justify-content: space-between;
 	font-weight: 600;
 

--- a/client/extensions/woocommerce/components/product-image-uploader/style.scss
+++ b/client/extensions/woocommerce/components/product-image-uploader/style.scss
@@ -49,7 +49,7 @@
 		}
 
 		p {
-			font-size: 14px;
+			font-size: $font-body-small;
 		}
 
 		&:hover {

--- a/client/extensions/woocommerce/components/product-reviews-widget/style.scss
+++ b/client/extensions/woocommerce/components/product-reviews-widget/style.scss
@@ -18,7 +18,7 @@
 	}
 
 	a {
-		font-size: 13px;
+		font-size: $font-body-small;
 		line-height: 1.25;
 	}
 }

--- a/client/extensions/woocommerce/components/product-reviews-widget/style.scss
+++ b/client/extensions/woocommerce/components/product-reviews-widget/style.scss
@@ -8,7 +8,7 @@
 	.product-reviews-widget__label {
 		color: var( --color-neutral-70 );
 		display: block;
-		font-size: 14px;
+		font-size: $font-body-small;
 		font-weight: 600;
 		margin-bottom: 4px;
 	}

--- a/client/extensions/woocommerce/components/reading-widget/style.scss
+++ b/client/extensions/woocommerce/components/reading-widget/style.scss
@@ -12,7 +12,7 @@
 		}
 
 		p {
-			font-size: 14px;
+			font-size: $font-body-small;
 		}
 	}
 
@@ -64,7 +64,7 @@
 
 		.reading-widget__subscription-form-explanation {
 			flex: 1 0 0;
-			font-size: 14px;
+			font-size: $font-body-small;
 			margin-bottom: 24px;
 
 			@include breakpoint-deprecated( '>660px' ) {

--- a/client/extensions/woocommerce/components/reading-widget/style.scss
+++ b/client/extensions/woocommerce/components/reading-widget/style.scss
@@ -93,7 +93,7 @@
 
 			.multi-checkbox {
 				margin-bottom: 8px;
-				font-size: 13px;
+				font-size: $font-body-small;
 				display: flex;
 				flex-wrap: wrap;
 

--- a/client/extensions/woocommerce/components/table/style.scss
+++ b/client/extensions/woocommerce/components/table/style.scss
@@ -166,7 +166,7 @@
 
 .table-heading,
 .table-item {
-	font-size: 14px;
+	font-size: $font-body-small;
 	padding: 16px;
 	vertical-align: middle;
 

--- a/client/extensions/woocommerce/woocommerce-services/components/text/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/components/text/style.scss
@@ -1,5 +1,5 @@
 .form-text-body-copy {
-	font-size: 14px;
+	font-size: $font-body-small;
 	font-weight: 400;
 	line-height: 1.5;
 }

--- a/client/extensions/woocommerce/woocommerce-services/views/packages/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/packages/style.scss
@@ -144,7 +144,7 @@
 .packages__packages-header {
 	font-weight: 600;
 	padding: 12px 0;
-	font-size: 14px;
+	font-size: $font-body-small;
 	border-top: 0;
 	background: var( --color-neutral-0 );
 }
@@ -166,7 +166,7 @@
 
 .packages__packages-row-details-name {
 	margin-bottom: 0;
-	font-size: 14px;
+	font-size: $font-body-small;
 }
 
 .packages__packages-row-actions {
@@ -221,7 +221,7 @@
 
 .packages__packages-row-dimensions {
 	width: 30%;
-	font-size: 14px;
+	font-size: $font-body-small;
 
 	@include breakpoint-deprecated( '<660px' ) {
 		font-size: 11px;

--- a/client/extensions/woocommerce/woocommerce-services/views/packages/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/packages/style.scss
@@ -230,7 +230,7 @@
 
 .packages__setting-explanation {
 	display: block;
-	font-size: 13px;
+	font-size: $font-body-small;
 	font-style: italic;
 	font-weight: 400;
 	margin: 5px 0 0;

--- a/client/extensions/woocommerce/woocommerce-services/views/service-settings/shipping-services/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/service-settings/shipping-services/style.scss
@@ -80,14 +80,14 @@
 
 	.shipping-services__entry-title {
 		flex-basis: 70%;
-		font-size: 13px;
+		font-size: $font-body-small;
 	}
 
 	.form-text-input {
 		flex-basis: 10%;
 		margin: 8px;
 		padding: 6px 12px;
-		font-size: 13px;
+		font-size: $font-body-small;
 		min-width: 42px;
 	}
 
@@ -95,7 +95,7 @@
 		flex-basis: 20%;
 		padding: 6px 32px 5px 14px;
 		line-height: 22px;
-		font-size: 13px;
+		font-size: $font-body-small;
 		box-shadow: none;
 
 		&:disabled {

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/customs-step/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/customs-step/style.scss
@@ -49,7 +49,7 @@
 	}
 
 	span {
-		font-size: 14px;
+		font-size: $font-body-small;
 		font-weight: 600;
 		margin-bottom: 8px;
 	}

--- a/client/extensions/wp-super-cache/style.scss
+++ b/client/extensions/wp-super-cache/style.scss
@@ -2,7 +2,7 @@
 	display: flex;
 	align-items: center;
 	margin-bottom: 5px;
-	font-size: 14px;
+	font-size: $font-body-small;
 }
 
 .wp-super-cache__main .form-toggle__switch {
@@ -96,7 +96,7 @@
 
 .wp-super-cache__cache-stat-label {
 	display: block;
-	font-size: 14px;
+	font-size: $font-body-small;
 	font-weight: 600;
 	margin-bottom: 5px;
 }
@@ -133,7 +133,7 @@
 .wp-super-cache__stat {
 	border-bottom: 1px solid var( --color-neutral-0 );
 	color: var( --color-neutral-70 );
-	font-size: 14px;
+	font-size: $font-body-small;
 	height: 30px;
 
 	&:last-child {

--- a/client/extensions/zoninator/components/forms/zone-content-form/style.scss
+++ b/client/extensions/zoninator/components/forms/zone-content-form/style.scss
@@ -35,7 +35,7 @@
 
 
 .zoninator__zone-text {
-	font-size: 14px;
+	font-size: $font-body-small;
 	font-weight: 400;
 	line-height: 1.5;
 }

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -377,7 +377,7 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 
 .example-components__connect-jetpack {
 	.example-components__content-wp-admin-plugin-name {
-		font-size: 14px;
+		font-size: $font-body-small;
 		margin-bottom: 8px;
 	}
 
@@ -1046,7 +1046,7 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 			text-align: center;
 			text-decoration: underline;
 			color: var( --color-neutral-60 );
-			font-size: 14px;
+			font-size: $font-body-small;
 		}
 
 		.signup-form__social {
@@ -1197,7 +1197,7 @@ body.is-section-jetpack-connect .layout.is-jetpack-woocommerce-flow {
 	}
 
 	.product-card__billing-timeframe {
-		font-size: 14px;
+		font-size: $font-body-small;
 	}
 
 	.product-card__header {

--- a/client/landing/gutenboarding/components/header/style.scss
+++ b/client/landing/gutenboarding/components/header/style.scss
@@ -55,7 +55,7 @@ $padding--gutenboarding__header: $grid-unit-10;
 	display: flex;
 	width: 100%;
 	align-items: center;
-	font-size: 14px;
+	font-size: $font-body-small;
 }
 
 .gutenboarding__header-section-item {

--- a/client/landing/gutenboarding/components/modal-submit-button/style.scss
+++ b/client/landing/gutenboarding/components/modal-submit-button/style.scss
@@ -5,7 +5,7 @@
 	width: 100%;
 	min-width: 170px;
 	text-align: center;
-	font-size: 14px;
+	font-size: $font-body-small;
 	line-height: 14px;
 	height: 42px;
 

--- a/client/landing/gutenboarding/mixins.scss
+++ b/client/landing/gutenboarding/mixins.scss
@@ -31,7 +31,7 @@
 }
 
 @mixin onboarding-medium-text {
-	font-size: 14px;
+	font-size: $font-body-small;
 	line-height: 17px;
 }
 

--- a/client/landing/jetpack-cloud/components/fix-all-threats-dialog/style.scss
+++ b/client/landing/jetpack-cloud/components/fix-all-threats-dialog/style.scss
@@ -50,7 +50,7 @@
 
 	&__warning-message {
 		color: var( --color-text-subtle );
-		font-size: 14px;
+		font-size: $font-body-small;
 	}
 
 	&__btn {

--- a/client/landing/jetpack-cloud/components/server-credentials-wizard-dialog/style.scss
+++ b/client/landing/jetpack-cloud/components/server-credentials-wizard-dialog/style.scss
@@ -36,12 +36,12 @@
 
 		&__warning-message {
 			color: var( --color-text-subtle );
-			font-size: 14px;
+			font-size: $font-body-small;
 		}
 
 		&__link-external {
 			display: inline-block;
-			font-size: 14px;
+			font-size: $font-body-small;
 			font-style: italic;
 			margin-left: 30px;
 			padding-top: 8px;

--- a/client/landing/jetpack-cloud/components/stats-footer/style.scss
+++ b/client/landing/jetpack-cloud/components/stats-footer/style.scss
@@ -15,7 +15,7 @@
 
 .stats-footer__header {
 	color: var( --color-neutral-50 );
-	font-size: 13px;
+	font-size: $font-body-small;
 	font-weight: normal;
 	text-transform: uppercase;
 	margin: 0 0 20px;

--- a/client/landing/jetpack-cloud/components/threat-description/style.scss
+++ b/client/landing/jetpack-cloud/components/threat-description/style.scss
@@ -9,7 +9,7 @@
 
 	&__section-text {
 		color: var( --studio-gray-60 );
-		font-size: 14px;
+		font-size: $font-body-small;
 		line-height: 21px;
 	}
 }

--- a/client/landing/jetpack-cloud/components/threat-dialog/style.scss
+++ b/client/landing/jetpack-cloud/components/threat-dialog/style.scss
@@ -22,7 +22,7 @@
 
 		&__threat-description {
 			color: var( --color-text-subtle );
-			font-size: 14px;
+			font-size: $font-body-small;
 		}
 
 		&__warning {
@@ -46,7 +46,7 @@
 
 		&__warning-message {
 			color: var( --color-text-subtle );
-			font-size: 14px;
+			font-size: $font-body-small;
 		}
 
 		&__btn {

--- a/client/landing/jetpack-cloud/components/threat-item-subheader/style.scss
+++ b/client/landing/jetpack-cloud/components/threat-item-subheader/style.scss
@@ -1,7 +1,7 @@
 .threat-item-subheader {
 	&__subheader {
 		color: var( --color-threat-ignored );
-		font-size: 14px;
+		font-size: $font-body-small;
 		display: flex;
 		flex-direction: column;
 		align-items: flex-start;

--- a/client/landing/jetpack-cloud/components/threat-item/style.scss
+++ b/client/landing/jetpack-cloud/components/threat-item/style.scss
@@ -17,7 +17,7 @@
 
 	.log-item__subheader {
 		color: var( --studio-gray-60 );
-		font-size: 14px;
+		font-size: $font-body-small;
 	}
 
 	&.is-current {

--- a/client/layout/community-translator/style.scss
+++ b/client/layout/community-translator/style.scss
@@ -6,7 +6,7 @@
 	background: var( --color-primary );
 	cursor: pointer;
 	padding: 4px;
-	font-size: 13px;
+	font-size: $font-body-small;
 	z-index: z-index( 'root', '.community-translator' );
 
 	&.is-active {

--- a/client/layout/guided-tours/style.scss
+++ b/client/layout/guided-tours/style.scss
@@ -10,7 +10,7 @@
 	padding-top: 19px;
 	margin-left: 5px;
 	margin-right: 5px;
-	font-size: 14px;
+	font-size: $font-body-small;
 	animation-duration: 0.15s;
 	animation-name: guided-tours__step-fadein;
 	animation-timing-function: ease-in-out;

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -106,7 +106,7 @@
 		border-width: 1px 1px 2px;
 		box-shadow: none;
 		box-sizing: border-box;
-		font-size: 14px;
+		font-size: $font-body-small;
 		font-weight: 600;
 		height: 45px;
 		line-height: normal;
@@ -790,7 +790,7 @@
 	}
 
 	.login__form-terms {
-		font-size: 14px;
+		font-size: $font-body-small;
 		line-height: 24px;
 		margin-top: 8px;
 	}
@@ -904,7 +904,7 @@
 	}
 
 	.login__social-tos {
-		font-size: 14px;
+		font-size: $font-body-small;
 		line-height: 24px;
 	}
 

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -90,7 +90,7 @@ $autobar-height: 20px;
 	align-items: center;
 	position: relative;
 	color: var( --color-masterbar-text );
-	font-size: 14px;
+	font-size: $font-body-small;
 	height: $masterbar-height;
 	line-height: $masterbar-height;
 	padding: 0 15px;

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -478,7 +478,7 @@ $autobar-height: 20px;
 }
 
 .masterbar__recent-drafts-heading {
-	font-size: 13px;
+	font-size: $font-body-small;
 	box-sizing: border-box;
 	z-index: 1;
 	padding: 0 16px;

--- a/client/layout/offline-status/style.scss
+++ b/client/layout/offline-status/style.scss
@@ -2,7 +2,7 @@
 	background: var( --color-masterbar-item-active-background );
 	color: var( --color-masterbar-text );
 	border-radius: 24px;
-	font-size: 13px;
+	font-size: $font-body-small;
 	height: auto;
 	padding: 6px 16px;
 	position: fixed;

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -66,7 +66,7 @@
 .magic-login__form-label {
 	color: var( --color-neutral-70 );
 	display: block;
-	font-size: 14px;
+	font-size: $font-body-small;
 	line-height: 1.5;
 	font-weight: 600;
 	margin-bottom: 5px;
@@ -87,7 +87,7 @@
 		color: var( --color-neutral-50 );
 		display: block;
 		line-height: 4em;
-		font-size: 14px;
+		font-size: $font-body-small;
 		font-weight: 600;
 		padding: 0 24px;
 		text-align: center;

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -75,7 +75,7 @@ $image-height: 47px;
 		box-sizing: border-box;
 		cursor: pointer;
 		display: block;
-		font-size: 14px;
+		font-size: $font-body-small;
 		font-weight: 600;
 		line-height: 4em;
 		padding: 0 24px;
@@ -246,7 +246,7 @@ $image-height: 47px;
 		border-bottom: none;
 		line-height: 3.4em;
 		color: var( --color-neutral-60 );
-		font-size: 14px;
+		font-size: $font-body-small;
 		text-decoration: underline;
 		font-weight: normal;
 	}
@@ -375,7 +375,7 @@ $image-height: 47px;
 		width: auto;
 		min-width: 100%;
 		text-align: center;
-		font-size: 14px;
+		font-size: $font-body-small;
 		line-height: 24px;
 		height: 42px;
 		display: block;
@@ -416,7 +416,7 @@ $image-height: 47px;
 	.two-factor-authentication__verification-code-form input,
 	.login__form input {
 		padding: 18px 14px;
-		font-size: 14px;
+		font-size: $font-body-small;
 	}
 
 	.wp-login__main {

--- a/client/me/account-close/closed.scss
+++ b/client/me/account-close/closed.scss
@@ -3,7 +3,7 @@
 	text-align: center;
 
 	.account-close__spinner-text {
-		font-size: 14px;
+		font-size: $font-body-small;
 		font-weight: 400;
 		margin-top: 8px;
 	}

--- a/client/me/account/close-link.scss
+++ b/client/me/account/close-link.scss
@@ -1,6 +1,6 @@
 .account__close-section-title {
 	margin-bottom: 4px;
-	font-size: 14px;
+	font-size: $font-body-small;
 	line-height: 18px;
 	color: var( --color-neutral-70 );
 

--- a/client/me/account/close-link.scss
+++ b/client/me/account/close-link.scss
@@ -11,7 +11,7 @@
 
 .account__close-section-desc {
 	margin-bottom: 0;
-	font-size: 13px;
+	font-size: $font-body-small;
 	color: var( --color-text-subtle );
 	font-style: italic;
 }

--- a/client/me/billing-history/style.scss
+++ b/client/me/billing-history/style.scss
@@ -33,7 +33,7 @@
 
 .billing-history__search_terms {
 	display: inline-block;
-	font-size: 13px;
+	font-size: $font-body-small;
 	margin-top: 2px;
 	margin-right: 12px;
 	text-align: left;
@@ -183,7 +183,7 @@
 
 	.billing-history__transaction-date {
 		color: var( --color-neutral );
-		font-size: 13px;
+		font-size: $font-body-small;
 		font-style: italic;
 		padding: 5px 0 0;
 
@@ -210,7 +210,7 @@ textarea.billing-history__billing-details-editable {
 .billing-history__billing-details-editable {
 	border: 1px solid var( --color-neutral-20 );
 	margin-top: 5px;
-	font-size: 13px;
+	font-size: $font-body-small;
 }
 
 .billing-history__receipt-details {
@@ -226,7 +226,7 @@ textarea.billing-history__billing-details-editable {
 
 	li {
 		color: var( --color-neutral-70 );
-		font-size: 13px;
+		font-size: $font-body-small;
 		margin: 0 0 15px;
 		padding: 0;
 
@@ -297,14 +297,14 @@ textarea.billing-history__billing-details-editable {
 		.billing-history__receipt-item-name {
 			small {
 				color: var( --color-text-subtle );
-				font-size: 13px;
+				font-size: $font-body-small;
 				margin-left: 5px;
 				text-transform: lowercase;
 			}
 			em {
 				color: var( --color-text-subtle );
 				display: block;
-				font-size: 13px;
+				font-size: $font-body-small;
 			}
 		}
 

--- a/client/me/billing-history/style.scss
+++ b/client/me/billing-history/style.scss
@@ -58,7 +58,7 @@
 // Table Body
 .billing-history__transaction {
 	color: var( --color-neutral-70 );
-	font-size: 14px;
+	font-size: $font-body-small;
 	height: 66px;
 	border-bottom: 1px solid var( --color-neutral-0 );
 

--- a/client/me/help/contact-form-notice/style.scss
+++ b/client/me/help/contact-form-notice/style.scss
@@ -1,6 +1,6 @@
 .contact-form-notice {
 	color: var( --color-neutral-70 );
-	font-size: 14px;
+	font-size: $font-body-small;
 	&.card.is-compact {
 		margin: 0 0 16px;
 		font-size: 12px;

--- a/client/me/help/gm-closure-notice/style.scss
+++ b/client/me/help/gm-closure-notice/style.scss
@@ -2,7 +2,7 @@
 
 .gm-closure-notice {
 	color: var( --color-neutral-700 );
-	font-size: 14px;
+	font-size: $font-body-small;
 	&.card.is-compact {
 		margin: 0 0 16px;
 		font-size: 12px;

--- a/client/me/help/help-contact-form/style.scss
+++ b/client/me/help/help-contact-form/style.scss
@@ -37,7 +37,7 @@
 		}
 
 		.segmented-control__text {
-			font-size: 14px;
+			font-size: $font-body-small;
 			line-height: 18px;
 		}
 
@@ -56,7 +56,7 @@
 
 .help-contact-form__title {
 	display: block;
-	font-size: 14px;
+	font-size: $font-body-small;
 	font-weight: 600;
 	margin-bottom: 5px;
 }

--- a/client/me/help/help-courses/style.scss
+++ b/client/me/help/help-courses/style.scss
@@ -92,7 +92,7 @@
 	color: var( --color-neutral-0 );
 	padding: 5px 12px;
 	cursor: default;
-	font-size: 14px;
+	font-size: $font-body-small;
 	white-space: nowrap;
 }
 

--- a/client/me/help/help-courses/style.scss
+++ b/client/me/help/help-courses/style.scss
@@ -65,7 +65,7 @@
 }
 
 .help-courses__course-schedule-item-date {
-	font-size: 13px;
+	font-size: $font-body-small;
 	display: inline-block;
 	margin: 0 10px 0 0;
 	white-space: normal;
@@ -102,7 +102,7 @@
 
 .help-courses__course-video-date {
 	color: var( --color-neutral-light );
-	font-size: 13px;
+	font-size: $font-body-small;
 }
 
 .help-courses__course-video-embed {

--- a/client/me/help/help-teaser-button.scss
+++ b/client/me/help/help-teaser-button.scss
@@ -27,7 +27,7 @@
 
 .help__help-teaser-button-title {
 	color: var( --color-neutral-70 );
-	font-size: 14px;
+	font-size: $font-body-small;
 	font-weight: 600;
 	padding-right: 15px;
 }

--- a/client/me/help/style.scss
+++ b/client/me/help/style.scss
@@ -53,7 +53,7 @@
 
 .help__support-link-content {
 	margin-bottom: 0;
-	font-size: 14px;
+	font-size: $font-body-small;
 	color: var( --color-neutral-70 );
 }
 

--- a/client/me/memberships/subscription.scss
+++ b/client/me/memberships/subscription.scss
@@ -1,6 +1,6 @@
 .memberships__subscription-meta {
 	padding: 0;
-	font-size: 13px;
+	font-size: $font-body-small;
 }
 
 .memberships__subscription-inner-meta {
@@ -18,7 +18,7 @@
 
 	li {
 		color: var( --color-neutral-60 );
-		font-size: 13px;
+		font-size: $font-body-small;
 
 		@include breakpoint-deprecated( '<660px' ) {
 			clear: both;

--- a/client/me/memberships/subscription.scss
+++ b/client/me/memberships/subscription.scss
@@ -29,7 +29,7 @@
 		@include breakpoint-deprecated( '>660px' ) {
 			box-sizing: border-box;
 			flex: 1 1 auto;
-			font-size: 14px;
+			font-size: $font-body-small;
 			text-align: center;
 			padding: 15px 8px 12px;
 

--- a/client/me/notification-settings/push-notification-settings/style.scss
+++ b/client/me/notification-settings/push-notification-settings/style.scss
@@ -102,7 +102,7 @@
 }
 
 .notification-settings-push-notification-settings__settings-state {
-	font-size: 13px;
+	font-size: $font-body-small;
 	font-weight: 600;
 	margin-left: 8px;
 	text-transform: uppercase;

--- a/client/me/pending-payments/style.scss
+++ b/client/me/pending-payments/style.scss
@@ -21,7 +21,7 @@
 .pending-payments__list-item-title {
 	color: var( --color-primary );
 	display: block;
-	font-size: 14px;
+	font-size: $font-body-small;
 	line-height: 1.2em;
 	margin: 4px 20px 4px 0;
 	overflow: hidden;

--- a/client/me/profile-gravatar/style.scss
+++ b/client/me/profile-gravatar/style.scss
@@ -8,7 +8,7 @@
 .profile-gravatar__user-secondary-info {
 	margin-bottom: 30px;
 	text-align: center;
-	font-size: 14px;
+	font-size: $font-body-small;
 
 	.profile-gravatar.is-in-sidebar & {
 		color: var( --color-sidebar-text-alternative );

--- a/client/me/profile-link/style.scss
+++ b/client/me/profile-link/style.scss
@@ -50,7 +50,7 @@
 .profile-link__title {
 	color: var( --color-neutral-70 );
 	float: left;
-	font-size: 13px;
+	font-size: $font-body-small;
 	font-weight: 400;
 	line-height: 1.4;
 	overflow: hidden;

--- a/client/me/purchases/cancel-purchase/style.scss
+++ b/client/me/purchases/cancel-purchase/style.scss
@@ -27,7 +27,7 @@
 	p {
 		color: var( --color-neutral-light );
 		display: block;
-		font-size: 13px;
+		font-size: $font-body-small;
 		line-height: 150%;
 		margin-top: 5px;
 	}

--- a/client/me/purchases/cancel-purchase/style.scss
+++ b/client/me/purchases/cancel-purchase/style.scss
@@ -8,7 +8,7 @@
 
 	p {
 		color: var( --color-neutral-40 );
-		font-size: 14px;
+		font-size: $font-body-small;
 	}
 
 	hr {
@@ -38,7 +38,7 @@
 }
 
 .cancel-purchase__product-information .product-link {
-	font-size: 14px;
+	font-size: $font-body-small;
 }
 
 .cancel-purchase__purchase-name {
@@ -48,7 +48,7 @@
 
 .cancel-purchase__refund-information,
 .cancel-purchase__support-information {
-	font-size: 14px;
+	font-size: $font-body-small;
 }
 
 .cancel-purchase__site-title {
@@ -80,7 +80,7 @@
 
 .cancel-purchase__refund-amount {
 	color: var( --color-success );
-	font-size: 14px;
+	font-size: $font-body-small;
 	margin: 0;
 	padding: 0 10px 5px 0;
 }

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -3,7 +3,7 @@
 	padding: 0;
 
 	@include breakpoint-deprecated( '>660px' ) {
-		font-size: 14px;
+		font-size: $font-body-small;
 		padding: 0;
 	}
 
@@ -202,7 +202,7 @@
 		@include breakpoint-deprecated( '>660px' ) {
 			box-sizing: border-box;
 			flex: 1 1 auto;
-			font-size: 14px;
+			font-size: $font-body-small;
 			text-align: center;
 			padding: 15px 8px 12px;
 

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -1,5 +1,5 @@
 .manage-purchase__info {
-	font-size: 13px;
+	font-size: $font-body-small;
 	padding: 0;
 
 	@include breakpoint-deprecated( '>660px' ) {
@@ -191,7 +191,7 @@
 
 	li {
 		color: var( --color-neutral-60 );
-		font-size: 13px;
+		font-size: $font-body-small;
 
 		@include breakpoint-deprecated( '<660px' ) {
 			clear: both;

--- a/client/me/purchases/purchase-item/style.scss
+++ b/client/me/purchases/purchase-item/style.scss
@@ -79,7 +79,7 @@
 .purchase-item__title {
 	color: var( --color-text );
 	display: block;
-	font-size: 14px;
+	font-size: $font-body-small;
 	line-height: 1.2em;
 	margin: 4px 20px 4px 0;
 	overflow: hidden;

--- a/client/me/purchases/upcoming-renewals/style.scss
+++ b/client/me/purchases/upcoming-renewals/style.scss
@@ -18,7 +18,7 @@
 		margin-bottom: 0;
 	}
 	&__subheader {
-		font-size: 14px;
+		font-size: $font-body-small;
 		color: var( --color-neutral-50 );
 		margin-bottom: 16px;
 	}
@@ -40,7 +40,7 @@
 		font-size: $font-body;
 	}
 	&__detail {
-		font-size: 14px;
+		font-size: $font-body-small;
 		color: var( --color-neutral-50 );
 		.expired {
 			color: var( --color-error-dark );
@@ -53,7 +53,7 @@
 		font-size: $font-body;
 	}
 	&__renewal-settings-link a {
-		font-size: 14px;
+		font-size: $font-body-small;
 		color: var( --color-neutral-50 );
 		text-decoration: underline;
 	}

--- a/client/me/security-2fa-enable/style.scss
+++ b/client/me/security-2fa-enable/style.scss
@@ -19,7 +19,7 @@
 
 .security-2fa-enable__app-options {
 	font-color: var( --color-neutral-0 );
-	font-size: 13px;
+	font-size: $font-body-small;
 	font-style: italic;
 	margin-top: 10px;
 }

--- a/client/me/security-2fa-progress/style.scss
+++ b/client/me/security-2fa-progress/style.scss
@@ -90,7 +90,7 @@
 			label {
 				color: var( --color-neutral-10 );
 				display: inline-block;
-				font-size: 14px;
+				font-size: $font-body-small;
 				line-height: 1;
 				margin-top: 8px;
 				max-width: 112px;

--- a/client/my-sites/activity/activity-log-banner/intro-banner.scss
+++ b/client/my-sites/activity/activity-log-banner/intro-banner.scss
@@ -24,6 +24,6 @@
 
 .activity-log-banner__intro-description {
 	p {
-		font-size: 14px;
+		font-size: $font-body-small;
 	}
 }

--- a/client/my-sites/activity/activity-log-confirm-dialog/style.scss
+++ b/client/my-sites/activity/activity-log-confirm-dialog/style.scss
@@ -87,7 +87,7 @@
 .activity-log-confirm-dialog__line {
 	padding: 14px 24px 14px 44px;
 	text-align: left;
-	font-size: 13px;
+	font-size: $font-body-small;
 	border-bottom: 1px solid var( --color-neutral-5 );
 
 	&:first-of-type {

--- a/client/my-sites/activity/activity-log-item/style.scss
+++ b/client/my-sites/activity/activity-log-item/style.scss
@@ -339,7 +339,7 @@
 .activity-log-item__help-action {
 	color: var( --color-neutral-20 );
 	font-weight: 400;
-	font-size: 13px;
+	font-size: $font-body-small;
 	white-space: nowrap;
 	padding: 2px 7px 3px;
 
@@ -354,7 +354,7 @@
 }
 
 .button.activity-log-item__quick-action {
-	font-size: 13px;
+	font-size: $font-body-small;
 	white-space: nowrap;
 
 	@include breakpoint-deprecated( '<480px' ) {

--- a/client/my-sites/activity/activity-log-item/style.scss
+++ b/client/my-sites/activity/activity-log-item/style.scss
@@ -157,7 +157,7 @@
 
 	.foldable-card__content {
 		padding: 16px;
-		font-size: 14px;
+		font-size: $font-body-small;
 	}
 
 	.is-loading & {
@@ -257,7 +257,7 @@
 }
 
 .activity-log-item__actor-name {
-	font-size: 14px;
+	font-size: $font-body-small;
 	overflow-wrap: break-word;
 	word-wrap: break-word;
 
@@ -286,13 +286,13 @@
 	color: var( --color-text-subtle );
 
 	@include breakpoint-deprecated( '<480px' ) {
-		font-size: 14px;
+		font-size: $font-body-small;
 	}
 }
 
 .activity-log-item__description {
 	flex: 1 1 50%;
-	font-size: 14px;
+	font-size: $font-body-small;
 	word-break: break-word;
 
 	@include breakpoint-deprecated( '<960px' ) {

--- a/client/my-sites/activity/activity-log-switch/style.scss
+++ b/client/my-sites/activity/activity-log-switch/style.scss
@@ -42,7 +42,7 @@
 .activity-log-switch__no-thanks {
 	display: inline-block;
 	margin-top: 8px;
-	font-size: 14px;
+	font-size: $font-body-small;
 }
 
 .activity-log-switch__features-header {

--- a/client/my-sites/activity/activity-log-tasklist/style.scss
+++ b/client/my-sites/activity/activity-log-tasklist/style.scss
@@ -1,6 +1,6 @@
 .card.activity-log-tasklist {
 	padding-bottom: 4px;
-	font-size: 14px;
+	font-size: $font-body-small;
 
 	.activity-log-tasklist__heading {
 		display: flex;

--- a/client/my-sites/activity/activity-log/rewind-alerts.scss
+++ b/client/my-sites/activity/activity-log/rewind-alerts.scss
@@ -3,7 +3,7 @@
 	font-size: 13px;
 
 	@include breakpoint-deprecated( '>480px' ) {
-		font-size: 14px;
+		font-size: $font-body-small;
 	}
 }
 

--- a/client/my-sites/activity/activity-log/rewind-alerts.scss
+++ b/client/my-sites/activity/activity-log/rewind-alerts.scss
@@ -1,6 +1,6 @@
 .card.activity-log__threats {
 	padding-bottom: 4px;
-	font-size: 13px;
+	font-size: $font-body-small;
 
 	@include breakpoint-deprecated( '>480px' ) {
 		font-size: $font-body-small;

--- a/client/my-sites/activity/activity-log/threat-alert.scss
+++ b/client/my-sites/activity/activity-log/threat-alert.scss
@@ -1,6 +1,6 @@
 .activity-log__threat-alert {
 	padding: 8px 0;
-	font-size: 13px;
+	font-size: $font-body-small;
 	box-shadow: 0 -1px 0 rbga( var( --color-neutral-10 ), 0.5 );
 
 	@include breakpoint-deprecated( '>480px' ) {
@@ -72,7 +72,7 @@
 
 	.activity-log__threat-alert-filename {
 		padding: 0 2px;
-		font-size: 13px;
+		font-size: $font-body-small;
 		font-weight: 600;
 	}
 }
@@ -87,7 +87,7 @@
 
 .activity-log__threat-alert-filename {
 	padding: 4px;
-	font-size: 13px;
+	font-size: $font-body-small;
 	font-weight: 600;
 
 	@include breakpoint-deprecated( '>480px' ) {

--- a/client/my-sites/activity/activity-log/threat-alert.scss
+++ b/client/my-sites/activity/activity-log/threat-alert.scss
@@ -4,7 +4,7 @@
 	box-shadow: 0 -1px 0 rbga( var( --color-neutral-10 ), 0.5 );
 
 	@include breakpoint-deprecated( '>480px' ) {
-		font-size: 14px;
+		font-size: $font-body-small;
 	}
 
 	.foldable-card__main {
@@ -91,7 +91,7 @@
 	font-weight: 600;
 
 	@include breakpoint-deprecated( '>480px' ) {
-		font-size: 14px;
+		font-size: $font-body-small;
 	}
 }
 

--- a/client/my-sites/activity/filterbar/style.scss
+++ b/client/my-sites/activity/filterbar/style.scss
@@ -112,7 +112,7 @@
 
 		@include breakpoint-deprecated( '>660px' ) {
 			margin-bottom: 5px;
-			font-size: 14px;
+			font-size: $font-body-small;
 		}
 	}
 

--- a/client/my-sites/checkout/cart/style.scss
+++ b/client/my-sites/checkout/cart/style.scss
@@ -53,7 +53,7 @@
 		.product-price {
 			color: var( --color-text-subtle );
 			display: block;
-			font-size: 13px;
+			font-size: $font-body-small;
 		}
 
 		.cart__free-with-plan {

--- a/client/my-sites/checkout/cart/style.scss
+++ b/client/my-sites/checkout/cart/style.scss
@@ -33,7 +33,7 @@
 		.product-name {
 			color: var( --color-neutral-70 );
 			display: block;
-			font-size: 14px;
+			font-size: $font-body-small;
 			padding-right: 30px;
 		}
 
@@ -210,7 +210,7 @@
 .cart-empty {
 	padding: 30px;
 	text-align: center;
-	font-size: 14px;
+	font-size: $font-body-small;
 }
 
 .cart__cart-ad {

--- a/client/my-sites/checkout/checkout-thank-you/google-voucher/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/google-voucher/style.scss
@@ -25,7 +25,7 @@
 // dialog
 .dialog.card.google-voucher__dialog {
 	max-width: 530px;
-	font-size: 13px;
+	font-size: $font-body-small;
 	overflow: hidden;
 
 	ol {

--- a/client/my-sites/checkout/checkout-thank-you/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/style.scss
@@ -295,7 +295,7 @@
 
 .checkout-thank-you__jetpack-error-explanation {
 	color: var( --color-text-subtle );
-	font-size: 14px;
+	font-size: $font-body-small;
 	font-style: italic;
 	font-weight: 400;
 }

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -340,7 +340,7 @@
 		.checkout__payment-box-section .checkout__new-card-toggle {
 			box-shadow: none;
 			cursor: pointer;
-			font-size: 13px;
+			font-size: $font-body-small;
 			position: absolute;
 		}
 
@@ -597,7 +597,7 @@
 	// -----------------------------------
 	.supporting-text {
 		border-top: 1px solid var( --color-neutral-10 );
-		font-size: 13px;
+		font-size: $font-body-small;
 		list-style: none;
 		margin: 0;
 		padding: 15px 0;

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -292,7 +292,7 @@
 	.cart__coupon {
 		cursor: pointer;
 		display: none;
-		font-size: 14px;
+		font-size: $font-body-small;
 		margin: 0;
 		padding: 10px 0;
 
@@ -379,7 +379,7 @@
 	.checkout__summary-toggle {
 		cursor: pointer;
 		display: block;
-		font-size: 14px;
+		font-size: $font-body-small;
 		padding: 10px;
 		margin: 0 auto;
 
@@ -625,7 +625,7 @@
 
 			h6 {
 				color: var( --color-neutral-50 );
-				font-size: 14px;
+				font-size: $font-body-small;
 				font-weight: 600;
 			}
 
@@ -694,7 +694,7 @@
 
 	strong {
 		display: block;
-		font-size: 14px;
+		font-size: $font-body-small;
 		font-weight: normal;
 		line-height: 130%;
 	}

--- a/client/my-sites/checkout/checkout/subscription-text.scss
+++ b/client/my-sites/checkout/checkout/subscription-text.scss
@@ -1,8 +1,8 @@
 .checkout__subscription-text {
 	color: var( --color-neutral-light );
-	font-size: 14px;
+	font-size: $font-body-small;
 	font-style: italic;
-	font-weight: 200;
+	font-weight: 400;
 	line-height: 40px;
 	margin: 0 0 0 10px;
 	white-space: nowrap;

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -142,7 +142,7 @@
 
 	.popover__inner {
 		color: var( --color-text-subtle );
-		font-size: 13px;
+		font-size: $font-body-small;
 		max-width: 220px;
 		padding: 16px;
 		text-align: left;

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -1,7 +1,7 @@
 // Comment Base Style
 
 .card.comment {
-	font-size: 14px;
+	font-size: $font-body-small;
 	margin: 0 auto;
 	padding: 0;
 
@@ -385,7 +385,7 @@
 }
 
 .comment__reply-textarea {
-	font-size: 14px;
+	font-size: $font-body-small;
 	height: 47px; // 1 line
 	line-height: 21px;
 	min-height: 47px; // 1 line
@@ -458,7 +458,7 @@
 
 	input[type='text'],
 	textarea {
-		font-size: 14px;
+		font-size: $font-body-small;
 	}
 
 	.info-popover {

--- a/client/my-sites/comments/style.scss
+++ b/client/my-sites/comments/style.scss
@@ -94,7 +94,7 @@
 }
 
 .comment-list__header-date {
-	font-size: 13px;
+	font-size: $font-body-small;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;

--- a/client/my-sites/customer-home/cards/actions/quick-links/style.scss
+++ b/client/my-sites/customer-home/cards/actions/quick-links/style.scss
@@ -53,7 +53,7 @@
 
 	.quick-links__action-box-subtitle {
 		color: var( --color-text-subtle );
-		font-size: 14px;
+		font-size: $font-body-small;
 		display: none;
 
 		@include breakpoint-deprecated( '>480px' ) {

--- a/client/my-sites/customer-home/cards/features/help-search/style.scss
+++ b/client/my-sites/customer-home/cards/features/help-search/style.scss
@@ -87,7 +87,7 @@ $min_results_height: 175px;
 
 			.search__input {
 				padding: 11px 0;
-				font-size: 14px;
+				font-size: $font-body-small;
 				color: var( --color-text );
 			}
 
@@ -169,7 +169,7 @@ $min_results_height: 175px;
 	.help-search__empty-results {
 		padding: 16px 0 0;
 		margin: 0;
-		font-size: 14px;
+		font-size: $font-body-small;
 		color: var( --color-text-subtle );
 		font-style: italic;
 

--- a/client/my-sites/customer-home/cards/features/quick-start/style.scss
+++ b/client/my-sites/customer-home/cards/features/quick-start/style.scss
@@ -6,7 +6,7 @@
 
 .quick-start th {
 	color: var( --color-text-subtle );
-	font-size: 14px;
+	font-size: $font-body-small;
 	font-weight: 400;
 }
 

--- a/client/my-sites/customer-home/cards/features/stats/style.scss
+++ b/client/my-sites/customer-home/cards/features/stats/style.scss
@@ -95,7 +95,7 @@
 }
 
 .stats__data-label {
-	font-size: 14px;
+	font-size: $font-body-small;
 	color: var( --color-text-subtle );
 	margin-bottom: 4px;
 }
@@ -107,5 +107,5 @@
 }
 
 .stats__all {
-	font-size: 14px;
+	font-size: $font-body-small;
 }

--- a/client/my-sites/customer-home/cards/tasks/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/style.scss
@@ -32,7 +32,7 @@
 		margin-bottom: 10px;
 		align-items: center;
 		color: var( --color-text-subtle );
-		font-size: 14px;
+		font-size: $font-body-small;
 
 		.gridicon {
 			margin-right: 4px;
@@ -75,7 +75,7 @@
 		display: flex;
 		padding-top: 0;
 		margin-top: auto;
-		font-size: 14px;
+		font-size: $font-body-small;
 	}
 
 	.task__skip {

--- a/client/my-sites/domains/domain-management/components/designated-agent-notice/style.scss
+++ b/client/my-sites/domains/domain-management/components/designated-agent-notice/style.scss
@@ -10,7 +10,7 @@
 }
 
 .designated-agent-notice__copy {
-	font-size: 13px;
+	font-size: $font-body-small;
 	font-weight: 400;
 	margin-left: 24px;
 }

--- a/client/my-sites/domains/domain-management/components/domain/new-domains-redirection-notice-upsell.scss
+++ b/client/my-sites/domains/domain-management/components/domain/new-domains-redirection-notice-upsell.scss
@@ -6,6 +6,6 @@
 	}
 
 	.banner__description {
-		font-size: 14px;
+		font-size: $font-body-small;
 	}
 }

--- a/client/my-sites/domains/domain-management/components/email-verification/style.scss
+++ b/client/my-sites/domains/domain-management/components/email-verification/style.scss
@@ -28,7 +28,7 @@
 
 .email-verification__sent-to {
 	color: var( --color-neutral-50 );
-	font-size: 14px;
+	font-size: $font-body-small;
 }
 
 .email-verification__heading {

--- a/client/my-sites/domains/domain-management/contacts-privacy/style.scss
+++ b/client/my-sites/domains/domain-management/contacts-privacy/style.scss
@@ -32,7 +32,7 @@
 	.contacts-privacy__settings-explanation {
 		color: var( --color-text-subtle );
 		display: block;
-		font-size: 13px;
+		font-size: $font-body-small;
 		font-style: italic;
 		margin: 5px 0;
 	}

--- a/client/my-sites/domains/domain-management/dns/domain-connect-record.scss
+++ b/client/my-sites/domains/domain-management/dns/domain-connect-record.scss
@@ -9,7 +9,7 @@
 .dns__domain-connect-explanation {
 	display: block;
 	margin: 5px 0;
-	font-size: 13px;
+	font-size: $font-body-small;
 	font-style: italic;
 	color: var( --color-text-subtle );
 }

--- a/client/my-sites/domains/domain-management/edit-contact-info/privacy-enabled-card.scss
+++ b/client/my-sites/domains/domain-management/edit-contact-info/privacy-enabled-card.scss
@@ -1,7 +1,7 @@
 .edit-contact-info__privacy-enabled-card-settings-explanation {
 	color: var( --color-text-subtle );
 	display: block;
-	font-size: 13px;
+	font-size: $font-body-small;
 	font-style: italic;
 	margin: 5px 0;
 }

--- a/client/my-sites/domains/domain-management/edit/card/property/style.scss
+++ b/client/my-sites/domains/domain-management/edit/card/property/style.scss
@@ -1,5 +1,5 @@
 .domain-details-card__property {
-	font-size: 13px;
+	font-size: $font-body-small;
 	margin-bottom: 10px;
 	@include clear-fix;
 

--- a/client/my-sites/domains/domain-management/edit/style.scss
+++ b/client/my-sites/domains/domain-management/edit/style.scss
@@ -131,7 +131,7 @@
 		}
 
 		.mapped-domain-type__small-message {
-			font-size: 14px;
+			font-size: $font-body-small;
 		}
 
 

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -37,7 +37,7 @@
 .domain-management-list-item__title {
 	display: block;
 	color: var( --color-neutral-70 );
-	font-size: 14px;
+	font-size: $font-body-small;
 	font-weight: 600;
 	white-space: pre;
 	font-family: $serif;

--- a/client/my-sites/domains/domain-management/name-servers/style.scss
+++ b/client/my-sites/domains/domain-management/name-servers/style.scss
@@ -13,7 +13,7 @@
 	.name-servers__explanation {
 		animation: appear 0.5s ease-in-out;
 		color: var( --color-text-subtle );
-		font-size: 13px;
+		font-size: $font-body-small;
 		font-style: italic;
 		margin-bottom: 0;
 	}
@@ -59,7 +59,7 @@
 .name-servers__custom-nameservers-form-explanation {
 	display: block;
 	margin-top: 5px;
-	font-size: 13px;
+	font-size: $font-body-small;
 	font-style: italic;
 	color: var( --color-text-subtle );
 }

--- a/client/my-sites/domains/domain-management/primary-domain/style.scss
+++ b/client/my-sites/domains/domain-management/primary-domain/style.scss
@@ -2,14 +2,14 @@
 	.primary-domain-explanation {
 		color: var( --color-text-subtle );
 		display: block;
-		font-size: 13px;
+		font-size: $font-body-small;
 		font-style: italic;
 		margin: 5px 0;
 	}
 
 	.primary-domain-notice {
 		background: var( --color-neutral-0 );
-		font-size: 13px;
+		font-size: $font-body-small;
 		color: var( --color-neutral-70 );
 		&::before {
 			line-height: 1.5em;

--- a/client/my-sites/domains/domain-management/site-redirect/style.scss
+++ b/client/my-sites/domains/domain-management/site-redirect/style.scss
@@ -13,7 +13,7 @@
 	display: block;
 	margin-top: 5px;
 	margin-bottom: 0;
-	font-size: 13px;
+	font-size: $font-body-small;
 	font-style: italic;
 	color: var( --color-text-subtle );
 }

--- a/client/my-sites/domains/domain-search/site-redirect-step.scss
+++ b/client/my-sites/domains/domain-search/site-redirect-step.scss
@@ -14,7 +14,7 @@
 
 	p {
 		color: var( --color-neutral-70 );
-		font-size: 13px;
+		font-size: $font-body-small;
 		font-weight: 600;
 		margin-bottom: 0;
 		opacity: 0.7;

--- a/client/my-sites/draft/style.scss
+++ b/client/my-sites/draft/style.scss
@@ -49,7 +49,7 @@
 }
 
 .draft__time {
-	font-size: 13px;
+	font-size: $font-body-small;
 	color: var( --color-text-subtle );
 }
 

--- a/client/my-sites/earn/ads/style.scss
+++ b/client/my-sites/earn/ads/style.scss
@@ -54,7 +54,7 @@
 	text-transform: uppercase;
 
 	@include breakpoint-deprecated( '<480px' ) {
-		font-size: 14px;
+		font-size: $font-body-small;
 		line-height: 1.8;
 	}
 }

--- a/client/my-sites/earn/memberships/style.scss
+++ b/client/my-sites/earn/memberships/style.scss
@@ -64,7 +64,7 @@
 
 .memberships__earnings-breakdown-label {
 	color: var( --color-neutral-60 );
-	font-size: 14px;
+	font-size: $font-body-small;
 	letter-spacing: 0.1em;
 	line-height: 1.8;
 	text-transform: uppercase;
@@ -92,7 +92,7 @@
 
 .memberships__earnings-breakdown-label {
 	color: var( --color-neutral-60 );
-	font-size: 14px;
+	font-size: $font-body-small;
 	letter-spacing: 0.1em;
 	line-height: 1.8;
 	text-transform: uppercase;
@@ -202,7 +202,7 @@
 
 .memberships__module-products-list {
 	color: var( --color-neutral );
-	font-size: 14px;
+	font-size: $font-body-small;
 }
 .memberships__module-products-list-icon {
 	margin-right: 6px;
@@ -221,7 +221,7 @@
 }
 .memberships__products-product-title {
 	color: var( --color-text-subtle );
-	font-size: 14px;
+	font-size: $font-body-small;
 }
 .memberships__earnings-breakdown-notes {
 	clear: both;
@@ -260,7 +260,7 @@
 }
 
 .memberships__dialog-form-header {
-	font-size: 14px;
+	font-size: $font-body-small;
 	font-weight: 600;
 	margin-bottom: 1.5em;
 }
@@ -272,7 +272,7 @@
 
 .memberships__settings-section-title {
 	margin-bottom: 4px;
-	font-size: 14px;
+	font-size: $font-body-small;
 	line-height: 18px;
 	color: var( --color-neutral-70 );
 

--- a/client/my-sites/earn/memberships/style.scss
+++ b/client/my-sites/earn/memberships/style.scss
@@ -177,7 +177,7 @@
 
 .memberships__subscriber-email {
 	color: var( --color-text-subtle );
-	font-size: 13px;
+	font-size: $font-body-small;
 
 	@include breakpoint-deprecated( '>480px' ) {
 		font-size: $font-body;
@@ -283,7 +283,7 @@
 
 .memberships__settings-section-desc {
 	margin-bottom: 0;
-	font-size: 13px;
+	font-size: $font-body-small;
 	color: var( --color-text-subtle );
 	font-style: italic;
 }

--- a/client/my-sites/email/email-forwarding/style.scss
+++ b/client/my-sites/email/email-forwarding/style.scss
@@ -49,7 +49,7 @@ ul.email-forwarding__list {
 		position: relative;
 
 		span {
-			font-size: 14px;
+			font-size: $font-body-small;
 			line-height: 40px;
 
 			@include breakpoint-deprecated( '<660px' ) {

--- a/client/my-sites/email/email-management/gsuite-user-item/style.scss
+++ b/client/my-sites/email/email-management/gsuite-user-item/style.scss
@@ -17,6 +17,6 @@
 	a.gsuite-user-item,
 	.gsuite-user-item__fix {
 		float: right;
-		font-size: 13px;
+		font-size: $font-body-small;
 	}
 }

--- a/client/my-sites/email/gsuite-purchase-cta/style.scss
+++ b/client/my-sites/email/gsuite-purchase-cta/style.scss
@@ -105,7 +105,7 @@
 
 	h5 {
 		color: var( --color-text-subtle );
-		font-size: 13px;
+		font-size: $font-body-small;
 		font-style: normal;
 	}
 

--- a/client/my-sites/email/gsuite-purchase-cta/style.scss
+++ b/client/my-sites/email/gsuite-purchase-cta/style.scss
@@ -32,7 +32,7 @@
 	box-sizing: border-box;
 	display: flex;
 	flex-direction: column;
-	font-size: 14px;
+	font-size: $font-body-small;
 
 	@include breakpoint-deprecated( '>1040px' ) {
 		flex-basis: 100%;

--- a/client/my-sites/exporter/guided-transfer-card/style.scss
+++ b/client/my-sites/exporter/guided-transfer-card/style.scss
@@ -1,6 +1,6 @@
 .guided-transfer-card__options {
 	display: flex;
-	font-size: 14px;
+	font-size: $font-body-small;
 }
 
 .guided-transfer-card__options-header-title-container {
@@ -20,7 +20,7 @@
 .guided-transfer-card__subtitle {
 	color: var( --color-text-subtle );
 	font-style: italic;
-	font-size: 14px;
+	font-size: $font-body-small;
 }
 
 .guided-transfer-card__price {
@@ -30,7 +30,7 @@
 
 .guided-transfer-card__details {
 	background-color: var( --color-neutral-0 );
-	font-size: 14px;
+	font-size: $font-body-small;
 }
 
 .guided-transfer-card__details-container {

--- a/client/my-sites/exporter/style.scss
+++ b/client/my-sites/exporter/style.scss
@@ -13,7 +13,7 @@
 
 .export-card__subtitle,
 .export-media-card__subtitle {
-	font-size: 14px;
+	font-size: $font-body-small;
 	color: var( --color-neutral-70 );
 }
 
@@ -41,7 +41,7 @@
 }
 
 .export-card__advanced-settings-description {
-	font-size: 14px;
+	font-size: $font-body-small;
 }
 
 .export-card__advanced-settings-row {
@@ -61,7 +61,7 @@
 }
 
 .export-card__option-fieldset-description {
-	font-size: 14px;
+	font-size: $font-body-small;
 	color: var( --color-text-subtle );
 	padding-left: 24px;
 	padding-right: 24px;

--- a/client/my-sites/feature-upsell/style.scss
+++ b/client/my-sites/feature-upsell/style.scss
@@ -422,7 +422,7 @@ $feature-upsell-break-at: '1040px';
 	position: relative;
 	margin-top: 15px;
 	padding-left: 20px;
-	font-size: 13px;
+	font-size: $font-body-small;
 	line-height: 1.2;
 	color: var( --color-neutral-50 );
 

--- a/client/my-sites/feature-upsell/style.scss
+++ b/client/my-sites/feature-upsell/style.scss
@@ -500,7 +500,7 @@ $feature-upsell-break-at: '1040px';
 	}
 
 	&-description {
-		font-size: 14px;
+		font-size: $font-body-small;
 		line-height: 1.6;
 		margin: 11px 0 0;
 

--- a/client/my-sites/hosting/phpmyadmin-card/style.scss
+++ b/client/my-sites/hosting/phpmyadmin-card/style.scss
@@ -12,7 +12,7 @@
 .phpmyadmin-card__restore-password {
 	margin-top: 16px;
 	color: var( --color-text-subtle );
-	font-size: 13px;
+	font-size: $font-body-small;
 
 	button.is-compact.is-borderless {
 		text-decoration: underline;

--- a/client/my-sites/hosting/site-backup-card/style.scss
+++ b/client/my-sites/hosting/site-backup-card/style.scss
@@ -9,7 +9,7 @@
 
 	&__warning {
 		color: var( --color-text-subtle );
-		font-size: 13px;
+		font-size: $font-body-small;
 		margin-bottom: 0;
 	}
 

--- a/client/my-sites/importer/author-mapping-item.scss
+++ b/client/my-sites/importer/author-mapping-item.scss
@@ -35,7 +35,7 @@
 	text-overflow: ellipsis;
 	overflow: hidden;
 	white-space: nowrap;
-	font-size: 14px;
+	font-size: $font-body-small;
 	font-weight: 600;
 
 	@include breakpoint-deprecated( '<480px' ) {

--- a/client/my-sites/importer/author-mapping-pane.scss
+++ b/client/my-sites/importer/author-mapping-pane.scss
@@ -10,7 +10,7 @@
 }
 
 .importer__mapping-description {
-	font-size: 14px;
+	font-size: $font-body-small;
 	margin-bottom: 1.5em;
 
 	strong {

--- a/client/my-sites/importer/importing-pane.scss
+++ b/client/my-sites/importer/importing-pane.scss
@@ -32,7 +32,7 @@
 }
 
 .importer__status-message {
-	font-size: 14px;
+	font-size: $font-body-small;
 	color: var( --color-text-subtle );
 	text-align: center;
 }

--- a/client/my-sites/importer/site-importer/site-importer-site-preview.scss
+++ b/client/my-sites/importer/site-importer/site-importer-site-preview.scss
@@ -27,7 +27,7 @@
 	display: flex;
 	flex-direction: column;
 	margin-right: 10px;
-	font-size: 14px;
+	font-size: $font-body-small;
 }
 
 .site-importer__source-url {

--- a/client/my-sites/importer/uploading-pane.scss
+++ b/client/my-sites/importer/uploading-pane.scss
@@ -5,7 +5,7 @@
 
 	border: 5px solid var( --color-neutral-0 );
 	fill: var( --color-neutral-20 );
-	font-size: 14px;
+	font-size: $font-body-small;
 	font-weight: 600;
 	color: var( --color-neutral-light );
 	text-align: center;
@@ -20,7 +20,7 @@
 }
 
 .importer__uploading-pane-description {
-	font-size: 14px;
+	font-size: $font-body-small;
 }
 
 .importer__upload-content {

--- a/client/my-sites/invites/invite-form-header/style.scss
+++ b/client/my-sites/invites/invite-form-header/style.scss
@@ -9,7 +9,7 @@
 .invite-form-header__explanation {
 	color: var( --color-neutral-70 );
 	font-family: $sans;
-	font-size: 14px;
+	font-size: $font-body-small;
 	line-height: 21px;
 	margin-bottom: 16px;
 }

--- a/client/my-sites/marketing/style.scss
+++ b/client/my-sites/marketing/style.scss
@@ -598,7 +598,7 @@
 .sharing-buttons__fieldset-detail {
 	display: block;
 	margin: 5px 0;
-	font-size: 13px;
+	font-size: $font-body-small;
 	font-style: italic;
 	color: var( --color-neutral-light );
 }

--- a/client/my-sites/marketing/style.scss
+++ b/client/my-sites/marketing/style.scss
@@ -148,7 +148,7 @@
 
 	.connections__sharing-service-tip {
 		margin-top: 16px;
-		font-size: 14px;
+		font-size: $font-body-small;
 		color: var( --color-neutral-40 );
 
 		.gridicons-info {
@@ -284,7 +284,7 @@
 .sharing-service__description {
 	margin: 0;
 	color: var( --color-neutral-50 );
-	font-size: 14px;
+	font-size: $font-body-small;
 
 	@include breakpoint-deprecated( '<480px' ) {
 		display: none;

--- a/client/my-sites/marketing/traffic/style.scss
+++ b/client/my-sites/marketing/traffic/style.scss
@@ -1,5 +1,5 @@
 .site-settings {
-	font-size: 14px;
+	font-size: $font-body-small;
 
 	fieldset {
 		clear: both;
@@ -40,7 +40,7 @@
 	legend,
 	label {
 		margin-bottom: 5px;
-		font-size: 14px;
+		font-size: $font-body-small;
 		font-weight: 600;
 	}
 

--- a/client/my-sites/marketing/traffic/style.scss
+++ b/client/my-sites/marketing/traffic/style.scss
@@ -80,7 +80,7 @@
 	p.form-setting-explanation {
 		display: block;
 		margin: 5px 0;
-		font-size: 13px;
+		font-size: $font-body-small;
 		font-style: italic;
 		font-weight: 400;
 		color: var( --color-text-subtle );

--- a/client/my-sites/media-library/list-item.scss
+++ b/client/my-sites/media-library/list-item.scss
@@ -18,7 +18,7 @@
 		box-shadow: 0 0 8px rgba( var( --color-neutral-70-rgb ), 0.4 );
 		background: var( --color-accent );
 		border-radius: 50%;
-		font-size: 14px;
+		font-size: $font-body-small;
 		line-height: 28px;
 		text-align: center;
 		color: var( --color-text-inverted );

--- a/client/my-sites/migrate/section-migrate.scss
+++ b/client/my-sites/migrate/section-migrate.scss
@@ -181,7 +181,7 @@
 
 .migrate__card-footer {
 	color: var( --color-text-subtle );
-	font-size: 13px;
+	font-size: $font-body-small;
 
 	a {
 		color: var( --color-text-subtle );

--- a/client/my-sites/migrate/section-migrate.scss
+++ b/client/my-sites/migrate/section-migrate.scss
@@ -145,7 +145,7 @@
 
 .migrate__plan-feature-header {
 	font-weight: 600;
-	font-size: 14px;
+	font-size: $font-body-small;
 }
 
 .migrate__plan-upsell-item {
@@ -204,7 +204,7 @@
 	li {
 		list-style-type: none;
 		line-height: 30px;
-		font-size: 14px;
+		font-size: $font-body-small;
 	}
 }
 
@@ -259,7 +259,7 @@
 	height: 1.5rem;
 	margin-bottom: 8px;
 	color: var( --color-text-subtle );
-	font-size: 14px;
+	font-size: $font-body-small;
 }
 
 .migrate__progress-item {
@@ -267,7 +267,7 @@
 	list-style-type: none;
 	margin-left: 8px;
 	margin-bottom: 8px;
-	font-size: 14px;
+	font-size: $font-body-small;
 	line-height: 24px;
 	display: flex;
 }

--- a/client/my-sites/people/people-invites/style.scss
+++ b/client/my-sites/people/people-invites/style.scss
@@ -5,6 +5,6 @@
 .people-invites__max-items-notice {
 	text-align: center;
 	margin: 16px 0;
-	font-size: 14px;
+	font-size: $font-body-small;
 	color: var( --color-text-subtle );
 }

--- a/client/my-sites/people/people-profile/style.scss
+++ b/client/my-sites/people/people-profile/style.scss
@@ -63,7 +63,7 @@
 
 .people-profile__login {
 	color: var( --color-text-subtle );
-	font-size: 13px;
+	font-size: $font-body-small;
 
 	@include breakpoint-deprecated( '>480px' ) {
 		font-size: $font-body;

--- a/client/my-sites/plan-compare-card/style.scss
+++ b/client/my-sites/plan-compare-card/style.scss
@@ -12,7 +12,7 @@
 
 .plan-compare-card__features {
 	padding: 16px 24px;
-	font-size: 14px;
+	font-size: $font-body-small;
 	color: var( --color-text-subtle );
 }
 

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -48,7 +48,7 @@ $plan-features-sidebar-width: 272px;
 
 	.plan-features__item {
 		border-bottom: solid 1px var( --color-neutral-5 );
-		font-size: 14px;
+		font-size: $font-body-small;
 	}
 
 	.plan-features__item:last-child {
@@ -78,7 +78,7 @@ $plan-features-sidebar-width: 272px;
 }
 
 .plan-features__mobile-plan {
-	font-size: 14px;
+	font-size: $font-body-small;
 	border: solid 1px var( --color-neutral-5 );
 	background-color: var( --color-surface );
 	margin-bottom: 24px;
@@ -92,7 +92,7 @@ $plan-features-sidebar-width: 272px;
 }
 
 .plan-features__table {
-	font-size: 14px;
+	font-size: $font-body-small;
 	color: var( --color-text-subtle );
 	border-spacing: 16px 0;
 	margin-top: -16px;
@@ -442,7 +442,7 @@ $plan-features-sidebar-width: 272px;
 	display: flex;
 	margin: 0 24px;
 	padding: 12px 0;
-	font-size: 14px;
+	font-size: $font-body-small;
 	color: var( --color-neutral-70 );
 
 	@include breakpoint-deprecated( '<960px' ) {

--- a/client/my-sites/plans-features-main/gutenboarding-header/style.scss
+++ b/client/my-sites/plans-features-main/gutenboarding-header/style.scss
@@ -8,7 +8,7 @@
 		color: var( --color-neutral );
 		text-decoration: underline;
 		cursor: pointer;
-		font-size: 14px !important;
+		font-size: $font-body-small !important;
 	}
 
 	@include breakpoint-deprecated( '>480px' ) {

--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -96,7 +96,7 @@
 
 .plans-features-main__subhead {
 	margin: 0;
-	font-size: 14px;
+	font-size: $font-body-small;
 	line-height: 1.35;
 	color: var( --color-text-subtle );
 }

--- a/client/my-sites/plans/current-plan/current-plan-thank-you/style.scss
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you/style.scss
@@ -18,7 +18,7 @@
 	}
 
 	&__link {
-		font-size: 14px;
+		font-size: $font-body-small;
 	}
 
 	.progress-bar {

--- a/client/my-sites/plans/current-plan/my-plan-card/style.scss
+++ b/client/my-sites/plans/current-plan/my-plan-card/style.scss
@@ -44,7 +44,7 @@
 }
 
 .my-plan-card__tagline {
-	font-size: 14px;
+	font-size: $font-body-small;
 	font-weight: 400;
 	line-height: 21px;
 	margin: 0 0 24px;

--- a/client/my-sites/plugins/plugin-item/style.scss
+++ b/client/my-sites/plugins/plugin-item/style.scss
@@ -140,7 +140,7 @@
 
 .plugin-item__last-updated {
 	color: var( --color-text-subtle );
-	font-size: 13px;
+	font-size: $font-body-small;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;

--- a/client/my-sites/plugins/plugin-sections/style.scss
+++ b/client/my-sites/plugins/plugin-sections/style.scss
@@ -9,7 +9,7 @@
 
 .plugin-sections__content {
 	font-family: $sans;
-	font-size: 14px;
+	font-size: $font-body-small;
 	font-weight: 400;
 	line-height: 21px;
 	word-wrap: break-word;
@@ -23,7 +23,7 @@
 	h4,
 	h5,
 	h6 {
-		font-size: 14px;
+		font-size: $font-body-small;
 		font-weight: 600;
 		margin-bottom: 16px;
 	}
@@ -51,7 +51,7 @@
 		}
 	}
 	code {
-		font-size: 14px;
+		font-size: $font-body-small;
 		padding: 1px 4px;
 		border-radius: 2px;
 		background: var( --color-neutral-0 );

--- a/client/my-sites/plugins/plugins-browser-item/style.scss
+++ b/client/my-sites/plugins/plugins-browser-item/style.scss
@@ -81,7 +81,7 @@
 
 .plugins-browser-item__author {
 	color: var( --color-text-subtle );
-	font-size: 13px;
+	font-size: $font-body-small;
 }
 
 .plugins-browser-item .plugin-icon {

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -81,7 +81,7 @@
 }
 
 .plugins__more-header {
-	font-size: 14px;
+	font-size: $font-body-small;
 	line-height: 2;
 	margin: 40px 0 20px;
 	padding: 0 15px;

--- a/client/my-sites/post-selector/style.scss
+++ b/client/my-sites/post-selector/style.scss
@@ -66,7 +66,7 @@ input[type=checkbox].post-selector__input {
 .post-selector__list-item {
 	position: relative;
 	padding: 2px 8px;
-	font-size: 13px;
+	font-size: $font-body-small;
 
 	&.is-empty {
 		padding-top: 4px;

--- a/client/my-sites/post-selector/style.scss
+++ b/client/my-sites/post-selector/style.scss
@@ -27,7 +27,7 @@
 	border-width: 0;
 	border-bottom-width: 1px;
 	background: var( --color-surface );
-	font-size: 14px;
+	font-size: $font-body-small;
 	-webkit-appearance: none;
 }
 
@@ -90,7 +90,7 @@ input[type=checkbox].post-selector__input {
 	}
 
 	.post-selector.is-compact & {
-		font-size: 14px;
+		font-size: $font-body-small;
 		margin-top: 0;
 	}
 

--- a/client/my-sites/post-type-list/max-pages-notice.scss
+++ b/client/my-sites/post-type-list/max-pages-notice.scss
@@ -1,7 +1,7 @@
 .post-type-list__max-pages-notice {
 	text-align: center;
 	margin: 16px 0;
-	font-size: 14px;
+	font-size: $font-body-small;
 	color: var( --color-text-subtle );
 }
 

--- a/client/my-sites/post-type-list/post-type-post-author/style.scss
+++ b/client/my-sites/post-type-list/post-type-post-author/style.scss
@@ -7,6 +7,6 @@
 	padding-bottom: 2px;
 	line-height: 16px;
 	vertical-align: middle;
-	font-size: 13px;
+	font-size: $font-body-small;
 	color: var( --color-text-subtle );
 }

--- a/client/my-sites/post-type-list/post-type-site-info/style.scss
+++ b/client/my-sites/post-type-list/post-type-site-info/style.scss
@@ -13,6 +13,6 @@
 	padding-bottom: 2px;
 	line-height: 16px;
 	vertical-align: middle;
-	font-size: 13px;
+	font-size: $font-body-small;
 	color: var( --color-neutral-70 );
 }

--- a/client/my-sites/resume-editing/style.scss
+++ b/client/my-sites/resume-editing/style.scss
@@ -45,7 +45,7 @@
 	max-width: 25vw;
 	white-space: nowrap;
 	font-family: $serif;
-	font-size: 14px;
+	font-size: $font-body-small;
 	line-height: 1.1;
 
 	&::after {

--- a/client/my-sites/site-settings/date-time-format/style.scss
+++ b/client/my-sites/site-settings/date-time-format/style.scss
@@ -16,7 +16,7 @@
 
 	.date-time-format__info {
 		color: var( --color-text-subtle );
-		font-size: 13px;
+		font-size: $font-body-small;
 		font-style: italic;
 	}
 }

--- a/client/my-sites/site-settings/delete-site/style.scss
+++ b/client/my-sites/site-settings/delete-site/style.scss
@@ -25,7 +25,7 @@
 	width: 100%;
 	padding: 12px 16px;
 	border-top: solid 1px var( --color-neutral-10 );
-	font-size: 14px;
+	font-size: $font-body-small;
 	line-height: 18px;
 	color: var( --color-neutral-70 );
 

--- a/client/my-sites/site-settings/podcast-cover-image-setting/style.scss
+++ b/client/my-sites/site-settings/podcast-cover-image-setting/style.scss
@@ -35,7 +35,7 @@
 .podcast-cover-image-setting__placeholder {
 	color: var( --color-text-subtle );
 	display: block;
-	font-size: 13px;
+	font-size: $font-body-small;
 	font-style: italic;
 	font-weight: 400;
 	margin: 0 7px;

--- a/client/my-sites/site-settings/podcasting-details/style.scss
+++ b/client/my-sites/site-settings/podcasting-details/style.scss
@@ -45,7 +45,7 @@
 	border-radius: 4px;
 	align-self: stretch;
 	padding: 6px;
-	font-size: 14px;
+	font-size: $font-body-small;
 	text-align: left;
 	// Center contents vertically
 	// Note this element contains a <span> container to ensure normal

--- a/client/my-sites/site-settings/press-this/style.scss
+++ b/client/my-sites/site-settings/press-this/style.scss
@@ -16,7 +16,7 @@
 			cursor: move;
 			padding: 10px;
 			font-style: normal;
-			font-size: 14px;
+			font-size: $font-body-small;
 			text-decoration: none;
 			color: var( --color-neutral-70 );
 			background:var( --color-neutral-0 );

--- a/client/my-sites/site-settings/site-tools/style.scss
+++ b/client/my-sites/site-settings/site-tools/style.scss
@@ -15,7 +15,7 @@
 
 .site-tools__section-desc {
 	margin-bottom: 0;
-	font-size: 13px;
+	font-size: $font-body-small;
 	color: var( --color-text-subtle );
 	font-style: italic;
 }

--- a/client/my-sites/site-settings/site-tools/style.scss
+++ b/client/my-sites/site-settings/site-tools/style.scss
@@ -4,7 +4,7 @@
 
 .site-tools__section-title {
 	margin-bottom: 4px;
-	font-size: 14px;
+	font-size: $font-body-small;
 	line-height: 18px;
 	color: var( --color-neutral-70 );
 

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -1,5 +1,5 @@
 .site-settings {
-	font-size: 14px;
+	font-size: $font-body-small;
 
 	fieldset {
 		clear: both;
@@ -40,7 +40,7 @@
 	legend,
 	label {
 		margin-bottom: 5px;
-		font-size: 14px;
+		font-size: $font-body-small;
 		font-weight: 700;
 	}
 

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -80,7 +80,7 @@
 	p.form-setting-explanation {
 		display: block;
 		margin: 5px 0;
-		font-size: 13px;
+		font-size: $font-body-small;
 		font-style: italic;
 		font-weight: 400;
 		color: var( --color-text-subtle );

--- a/client/my-sites/site-settings/taxonomies/style.scss
+++ b/client/my-sites/site-settings/taxonomies/style.scss
@@ -13,7 +13,7 @@
 
 .taxonomies__card-content {
 	color: var( --color-text-subtle );
-	font-size: 13px;
+	font-size: $font-body-small;
 	white-space: nowrap;
 	overflow: hidden;
 

--- a/client/my-sites/stats/annual-site-stats/style.scss
+++ b/client/my-sites/stats/annual-site-stats/style.scss
@@ -48,7 +48,7 @@
 
 	@include breakpoint-deprecated( '<480px' ) {
 		color: var( --color-neutral-70 );
-		font-size: 14px;
+		font-size: $font-body-small;
 		text-transform: capitalize;
 		width: 50%;
 	}
@@ -58,7 +58,7 @@
 	font-size: 18px;
 
 	@include breakpoint-deprecated( '<480px' ) {
-		font-size: 14px;
+		font-size: $font-body-small;
 		text-align: right;
 		width: 50%;
 
@@ -68,7 +68,7 @@
 	}
 
 	&.is-large {
-		font-size: 14px;
+		font-size: $font-body-small;
 
 		@include breakpoint-deprecated( '>480px' ) {
 			font-size: 30px;

--- a/client/my-sites/stats/most-popular/style.scss
+++ b/client/my-sites/stats/most-popular/style.scss
@@ -40,7 +40,7 @@
 	color: var( --color-neutral-light );
 	display: block;
 	margin-top: -1em;
-	font-size: 14px;
+	font-size: $font-body-small;
 	letter-spacing: 0.01em;
 }
 

--- a/client/my-sites/stats/stats-chart-tabs/style.scss
+++ b/client/my-sites/stats/stats-chart-tabs/style.scss
@@ -67,7 +67,7 @@ ul.module-tabs {
 			text-transform: uppercase;
 
 			@include breakpoint-deprecated( '<480px' ) {
-				font-size: 14px;
+				font-size: $font-body-small;
 				line-height: 24px;
 				float: left;
 			}
@@ -197,7 +197,7 @@ ul.module-tabs {
 		}
 
 		.label {
-			font-size: 14px;
+			font-size: $font-body-small;
 			line-height: 24px;
 			float: left;
 		}

--- a/client/my-sites/stats/stats-date-picker/style.scss
+++ b/client/my-sites/stats/stats-date-picker/style.scss
@@ -4,7 +4,7 @@
 	.stats-date-picker__update-date {
 		color: var( --color-text-subtle );
 		display: inline-block;
-		font-size: 13px;
+		font-size: $font-body-small;
 
 		.gridicon {
 			padding: 0 5px;

--- a/client/my-sites/stats/stats-list/style.scss
+++ b/client/my-sites/stats/stats-list/style.scss
@@ -20,7 +20,7 @@
 
 .module-content-list-item {
 	// Smaller font-size for narrower, two-column modules
-	font-size: 14px;
+	font-size: $font-body-small;
 	line-height: 40px;
 
 	// List item height shorter on 2-column modules
@@ -84,7 +84,7 @@
 	padding: 0 24px;
 
 	span {
-		font-size: 14px;
+		font-size: $font-body-small;
 		// Always let child elements inherit line heights
 		line-height: inherit;
 	}

--- a/client/my-sites/stats/stats-module/expand.scss
+++ b/client/my-sites/stats/stats-module/expand.scss
@@ -15,7 +15,7 @@
 		@extend %mobile-link-element;
 		border-top: 1px solid var( --color-border-subtle );
 		display: block;
-		font-size: 14px;
+		font-size: $font-body-small;
 		padding: 0 24px;
 		position: relative;
 

--- a/client/my-sites/stats/stats-module/style.scss
+++ b/client/my-sites/stats/stats-module/style.scss
@@ -85,7 +85,7 @@
 		@extend %mobile-link-element;
 		border-top: 1px solid var( --color-border-subtle );
 		display: block;
-		font-size: 14px;
+		font-size: $font-body-small;
 		padding: 0 24px;
 		position: relative;
 
@@ -337,7 +337,7 @@ ul.module-header-actions {
 		list-style: none;
 
 		li {
-			font-size: 14px;
+			font-size: $font-body-small;
 			line-height: 2em;
 
 			@include breakpoint-deprecated( '>960px' ) {
@@ -580,7 +580,7 @@ ul.module-header-actions {
 }
 
 .stats-module__availability-warning-message {
-	font-size: 14px;
+	font-size: $font-body-small;
 	margin-left: 8px;
 	margin-bottom: 0;
 	color: var( --color-text-subtle );

--- a/client/my-sites/stats/stats-module/style.scss
+++ b/client/my-sites/stats/stats-module/style.scss
@@ -264,7 +264,7 @@ ul.module-header-actions {
 .module-content-text {
 	box-sizing: border-box;
 	color: var( --color-neutral-70 );
-	font-size: 13px;
+	font-size: $font-body-small;
 	padding: 16px 16px 0;
 	min-height: 1em;
 	width: 100%;

--- a/client/my-sites/stats/stats-tabs/style.scss
+++ b/client/my-sites/stats/stats-tabs/style.scss
@@ -32,7 +32,7 @@
 			float: none;
 			width: 100%;
 			text-align: left;
-			font-size: 14px;
+			font-size: $font-body-small;
 
 			&:first-child {
 				border-top: none;
@@ -50,7 +50,7 @@
 				float: left;
 				text-transform: none;
 				letter-spacing: 0;
-				font-size: 14px;
+				font-size: $font-body-small;
 			}
 
 			.gridicon {
@@ -236,7 +236,7 @@
 		}
 
 		.label {
-			font-size: 14px;
+			font-size: $font-body-small;
 			line-height: 24px;
 			float: left;
 		}

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -164,7 +164,7 @@
 	margin: 0 auto;
 	padding: 10px;
 	color: var( --color-primary );
-	font-size: 14px;
+	font-size: $font-body-small;
 	cursor: pointer;
 	transition: all ease-in-out 100ms;
 
@@ -198,7 +198,7 @@
 
 .theme__sheet-content {
 	padding: 20px;
-	font-size: 14px;
+	font-size: $font-body-small;
 
 	min-height: 400px; // whilst loading
 
@@ -252,7 +252,7 @@
 
 	h2 {
 		color: var( --color-neutral-light );
-		font-size: 14px;
+		font-size: $font-body-small;
 		font-weight: 400;
 
 		margin: -20px -20px 20px;
@@ -296,20 +296,20 @@
 	}
 
 	h6 {
-		font-size: 14px;
+		font-size: $font-body-small;
 		font-weight: 400;
 		margin: 40px 0 10px;
 	}
 
 	pre {
 		font-family: $code;
-		font-size: 14px;
+		font-size: $font-body-small;
 		white-space: pre-wrap;
 		padding: 8px;
 	}
 
 	code {
-		font-size: 14px;
+		font-size: $font-body-small;
 		background: var( --color-neutral-0 );
 		padding: 1px 4px;
 		border-radius: 2px;

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -328,7 +328,7 @@
 		border-bottom: 1px solid #e9eff3;
 		padding: 20px;
 
-		font-size: 13px;
+		font-size: $font-body-small;
 		line-height: 21px;
 
 		& > p:first-child {

--- a/client/my-sites/themes/theme-upload/style.scss
+++ b/client/my-sites/themes/theme-upload/style.scss
@@ -1,6 +1,6 @@
 // View : theme successfully uploaded
 .theme-upload__theme-sheet {
-	font-size: 14px;
+	font-size: $font-body-small;
 }
 
 .theme-upload__theme-name {

--- a/client/my-sites/themes/themes-magic-search-card/style.scss
+++ b/client/my-sites/themes/themes-magic-search-card/style.scss
@@ -77,6 +77,7 @@
  */
 .themes-magic-search-card__token {
 	/* These are required to make token alignment work */
+	/* stylelint-disable-next-line */
 	font: inherit;
 	pointer-events: none;
 	position: relative;
@@ -123,6 +124,7 @@
 
 .themes-magic-search-card__search-text {
 	/* These are required to make token alignment work */
+	/* stylelint-disable-next-line */
 	font: inherit;
 	pointer-events: none;
 	color: transparent;
@@ -130,6 +132,7 @@
 
 .themes-magic-search-card__search-white-space {
 	/* These are required to make token alignment work */
+	/* stylelint-disable-next-line */
 	font: inherit;
 	pointer-events: none;
 	white-space: pre;
@@ -152,7 +155,7 @@
 	border-bottom: 1px solid var( --color-neutral-5 );
 	border-top: 0;
 	padding: 4px 8px;
-	font-size: 13px;
+	font-size: $font-body-small;
 
 	text-transform: uppercase;
 	color: var( --color-neutral-70 );
@@ -175,7 +178,7 @@
 	overflow: hidden;
 	padding: 10px 6px;
 	margin: 0;
-	font-size: 13px;
+	font-size: $font-body-small;
 	line-height: 16px;
 	cursor: pointer;
 	color: var( --color-neutral-70 );

--- a/client/post-editor/edit-post-status/style.scss
+++ b/client/post-editor/edit-post-status/style.scss
@@ -14,7 +14,7 @@
 
 .edit-post-status__label-text {
 	color: var( --color-text );
-	font-size: 13px;
+	font-size: $font-body-small;
 	line-height: 1.7;
 
 	@include breakpoint-deprecated( '>660px' ) {
@@ -41,7 +41,7 @@
 
 .edit-post-status__full-date {
 	color: var( --color-text );
-	font-size: 13px;
+	font-size: $font-body-small;
 	display: flex;
 	margin-bottom: 4px;
 	padding-right: 5px;

--- a/client/post-editor/editor-author/style.scss
+++ b/client/post-editor/editor-author/style.scss
@@ -14,7 +14,7 @@
 
 .editor-author__name {
 	color: var( --color-neutral-40 );
-	font-size: 13px;
+	font-size: $font-body-small;
 	margin: 0 8px;
 
 	@include breakpoint-deprecated( '<480px' ) {

--- a/client/post-editor/editor-diff-viewer/style.scss
+++ b/client/post-editor/editor-diff-viewer/style.scss
@@ -63,7 +63,7 @@
 	cursor: pointer;
 	padding: 0 16px 0 8px;
 	color: #fff;
-	font-size: 13px;
+	font-size: $font-body-small;
 
 	@include breakpoint-deprecated( '<660px' ) {
 		display: none;

--- a/client/post-editor/editor-drawer/style.scss
+++ b/client/post-editor/editor-drawer/style.scss
@@ -1,5 +1,5 @@
 .editor-drawer {
-	font-size: 13px;
+	font-size: $font-body-small;
 	background: white;
 }
 
@@ -35,7 +35,7 @@
 }
 
 .editor-drawer .form-textarea {
-	font-size: 13px;
+	font-size: $font-body-small;
 	font-family: $serif;
 	resize: vertical;
 	-webkit-appearance: none;

--- a/client/post-editor/editor-ground-control/style.scss
+++ b/client/post-editor/editor-ground-control/style.scss
@@ -153,7 +153,7 @@
 
 .editor-ground-control__toggle-sidebar.button.is-borderless,
 .editor-ground-control__preview-button.button.is-borderless {
-	font-size: 13px;
+	font-size: $font-body-small;
 }
 
 .editor-ground-control__publish-button {
@@ -188,7 +188,7 @@
 .editor-ground-control__history-button.button.is-link,
 .editor-ground-control__save.button.is-link,
 .editor-ground-control__save-status {
-	font-size: 13px;
+	font-size: $font-body-small;
 }
 
 .editor-ground-control__save-status {
@@ -208,7 +208,7 @@
 }
 
 .editor-ground-control__email-verification-notice {
-	font-size: 13px;
+	font-size: $font-body-small;
 	padding: 8px 8px 8px 40px;
 	background: white;
 	color: var( --color-primary );

--- a/client/post-editor/editor-html-toolbar/style.scss
+++ b/client/post-editor/editor-html-toolbar/style.scss
@@ -150,7 +150,7 @@
 		}
 
 		span {
-			font-size: 13px;
+			font-size: $font-body-small;
 			font-weight: 400;
 		}
 
@@ -192,7 +192,7 @@
 		span {
 			color: var( --color-text-subtle );
 			display: inline-block;
-			font-size: 13px;
+			font-size: $font-body-small;
 			margin-left: 8px;
 			margin-top: 2px;
 			vertical-align: top;

--- a/client/post-editor/editor-location/style.scss
+++ b/client/post-editor/editor-location/style.scss
@@ -30,7 +30,7 @@
 	border: 1px solid var( --color-neutral-0 );
 	border-top-width: 0;
 	border-bottom-width: 0;
-	font-size: 13px;
+	font-size: $font-body-small;
 
 	&:hover {
 		background-color: var( --color-accent );

--- a/client/post-editor/editor-more-options/slug.scss
+++ b/client/post-editor/editor-more-options/slug.scss
@@ -8,6 +8,6 @@
 
 .editor-slug.editor-more-options__slug-field input[type='text'].form-text-input {
 	@extend %form-field;
-	font-size: 13px;
+	font-size: $font-body-small;
 }
 

--- a/client/post-editor/editor-page-order/style.scss
+++ b/client/post-editor/editor-page-order/style.scss
@@ -12,7 +12,7 @@
 
 input[type='number'].editor-page-order__input {
 	-moz-appearance: textfield;
-	font-size: 13px;
+	font-size: $font-body-small;
 	width: 50px;
 
 	&::-webkit-outer-spin-button,

--- a/client/post-editor/editor-page-parent/style.scss
+++ b/client/post-editor/editor-page-parent/style.scss
@@ -23,7 +23,7 @@
 .editor-page-parent__top-level-description,
 .editor-page-parent__parent-tree-selector .form-legend {
 	color: var( --color-neutral-40 );
-	font-size: 13px;
+	font-size: $font-body-small;
 }
 
 .editor-page-parent__top-level-description {

--- a/client/post-editor/editor-page-templates/style.scss
+++ b/client/post-editor/editor-page-templates/style.scss
@@ -1,5 +1,5 @@
 .editor-page-templates__help-link {
-	font-size: 14px;
+	font-size: $font-body-small;
 	display: inline-block;
 	margin-bottom: 6px;
 }

--- a/client/post-editor/editor-permalink/style.scss
+++ b/client/post-editor/editor-permalink/style.scss
@@ -27,7 +27,7 @@
 .editor-permalink__popover .editor-slug .form-text-input {
 	border: none;
 	color: var( --color-neutral-40 );
-	font-size: 13px;
+	font-size: $font-body-small;
 	padding: 4px 0;
 	min-width: 100px;
 	width: 160px;
@@ -39,7 +39,7 @@
 
 .editor-permalink__url-path {
 	color: var( --color-neutral-20 );
-	font-size: 13px;
+	font-size: $font-body-small;
 	margin-right: 0;
 }
 

--- a/client/post-editor/editor-publish-date/style.scss
+++ b/client/post-editor/editor-publish-date/style.scss
@@ -28,7 +28,7 @@ $side-margin: 16;
 	line-height: #{$option-height}px;
 
 	color: var( --color-neutral-70 );
-	font-size: 14px;
+	font-size: $font-body-small;
 	font-weight: 600;
 	white-space: nowrap;
 	overflow: hidden;
@@ -110,7 +110,7 @@ $side-margin: 16;
 .editor-publish-date__choose-header {
 	text-align: center;
 	margin: 4px auto 0;
-	font-size: 14px;
+	font-size: $font-body-small;
 	line-height: 21px;
 	padding-top: 7px;
 	padding-bottom: 9px;

--- a/client/post-editor/editor-revisions-list/style.scss
+++ b/client/post-editor/editor-revisions-list/style.scss
@@ -271,14 +271,14 @@
 }
 
 .editor-revisions-list__author {
-	font-size: 13px;
+	font-size: $font-body-small;
 	display: block;
 	margin-bottom: 4px;
 	color: var( --color-text-subtle );
 }
 
 .editor-revisions-list__changes {
-	font-size: 13px;
+	font-size: $font-body-small;
 	display: block;
 }
 

--- a/client/post-editor/editor-revisions-list/style.scss
+++ b/client/post-editor/editor-revisions-list/style.scss
@@ -292,7 +292,7 @@
 		border-radius: 12px;
 		padding: 0;
 		line-height: 12px;
-		font-size: 14px;
+		font-size: $font-body-small;
 		height: 14px;
 		width: 14px;
 		color: white;

--- a/client/post-editor/editor-revisions/style.scss
+++ b/client/post-editor/editor-revisions/style.scss
@@ -39,7 +39,7 @@
 	color: var( --color-text );
 	cursor: pointer;
 	display: block;
-	font-size: 13px;
+	font-size: $font-body-small;
 	margin: 0 0 -16px;
 	padding: 16px 0;
 	text-align: left;

--- a/client/post-editor/editor-sidebar/style.scss
+++ b/client/post-editor/editor-sidebar/style.scss
@@ -71,7 +71,7 @@
 	color: var( --color-neutral-70 );
 	display: flex;
 	flex-shrink: 0;
-	font-size: 13px;
+	font-size: $font-body-small;
 	font-weight: 600;
 	justify-content: space-between;
 	padding: 11px 15px 11px 16px;
@@ -103,7 +103,7 @@
 
 .editor-sidebar__header-title {
 	padding: 0;
-	font-size: 13px;
+	font-size: $font-body-small;
 	line-height: inherit;
 
 	// Needed for extra specificity over .button style

--- a/client/post-editor/editor-slug/style.scss
+++ b/client/post-editor/editor-slug/style.scss
@@ -18,7 +18,7 @@
 .editor-slug .form-text-input {
 	border: none;
 	color: var( --color-neutral-40 );
-	font-size: 13px;
+	font-size: $font-body-small;
 	padding: 4px 0;
 	width: 200px;
 	&:focus {
@@ -29,7 +29,7 @@
 
 .editor-slug__url-path {
 	color: var( --color-neutral-20 );
-	font-size: 13px;
+	font-size: $font-body-small;
 	margin-right: 0;
 	cursor: pointer;
 

--- a/client/post-editor/editor-visibility/style.scss
+++ b/client/post-editor/editor-visibility/style.scss
@@ -1,6 +1,6 @@
 .editor-visibility {
 	display: flex;
-	font-size: 13px;
+	font-size: $font-body-small;
 	justify-content: space-between;
 	align-items: center;
 	margin: 8px 0;
@@ -26,7 +26,7 @@
 	}
 
 	.form-text-input {
-		font-size: 13px;
+		font-size: $font-body-small;
 		margin-top: 8px;
 	}
 
@@ -86,7 +86,7 @@
 	padding: 20px;
 
 	.form-text-input {
-		font-size: 13px;
+		font-size: $font-body-small;
 	}
 
 	.form-input-validation {

--- a/client/post-editor/media-modal/fieldset.scss
+++ b/client/post-editor/media-modal/fieldset.scss
@@ -5,7 +5,7 @@
 .editor-media-modal__fieldset,
 .editor-media-modal__fieldset .form-text-input,
 .editor-media-modal__fieldset textarea {
-	font-size: 13px;
+	font-size: $font-body-small;
 }
 
 .editor-media-modal__fieldset textarea {

--- a/client/post-editor/media-modal/gallery/style.scss
+++ b/client/post-editor/media-modal/gallery/style.scss
@@ -292,7 +292,7 @@ input[type].editor-media-modal-gallery__input-width-auto {
 .editor-media-modal-gallery__preview-individual .wp-caption-dd {
 	background: var( --color-neutral-0 );
 	color: var( --color-neutral-50 );
-	font-size: 14px;
+	font-size: $font-body-small;
 	line-height: 1.7;
 	padding: 16px;
 }

--- a/client/post-editor/media-modal/index.scss
+++ b/client/post-editor/media-modal/index.scss
@@ -42,7 +42,7 @@
 .editor-media-modal__gallery-help-remember-dismiss {
 	float: left;
 	margin-top: 4px;
-	font-size: 13px;
+	font-size: $font-body-small;
 }
 
 .editor-media-modal__gallery-help-remember-dismiss .form-checkbox {

--- a/client/post-editor/style.scss
+++ b/client/post-editor/style.scss
@@ -156,7 +156,7 @@
 
 	// typography for HTML view
 	font-family: $monospace;
-	font-size: 14px;
+	font-size: $font-body-small;
 	margin-bottom: 64px;
 
 	@include breakpoint-deprecated( '<480px' ) {

--- a/client/reader/components/reader-blank-suggestions/style.scss
+++ b/client/reader/components/reader-blank-suggestions/style.scss
@@ -1,7 +1,7 @@
 // Search term suggestions
 .reader-blank-suggestions {
 	border-bottom: 1px solid var( --color-neutral-10 );
-	font-size: 13px;
+	font-size: $font-body-small;
 	color: var( --color-text-subtle );
 	padding: 16px 0;
 	text-align: left;

--- a/client/reader/components/reader-popover/style.scss
+++ b/client/reader/components/reader-popover/style.scss
@@ -63,7 +63,7 @@
 	border-bottom: 1px solid var( --color-neutral-10 );
 	color: var( --color-neutral-70 );
 	display: flex;
-	font-size: 14px;
+	font-size: $font-body-small;
 	justify-content: flex-start;
 	padding: 10px 0 10px 15px;
 }

--- a/client/reader/discover/site-attribution.scss
+++ b/client/reader/discover/site-attribution.scss
@@ -2,7 +2,7 @@
 	align-items: flex-start;
 	display: flex;
 	color: var( --color-text-subtle );
-	font-size: 13px;
+	font-size: $font-body-small;
 	font-family: $sans;
 	margin-bottom: 8px;
 	margin-top: 13px;
@@ -61,7 +61,7 @@
 		border: 0;
 		color: var( --color-neutral-20 );
 		float: none;
-		font-size: 13px;
+		font-size: $font-body-small;
 		padding: 0;
 		position: relative;
 		top: -1px;

--- a/client/reader/post-excerpt-link/style.scss
+++ b/client/reader/post-excerpt-link/style.scss
@@ -44,7 +44,7 @@
 .post-excerpt-link__helper {
 	max-height: 0;
 	overflow: hidden;
-	font-size: 14px;
+	font-size: $font-body-small;
 	color: var( --color-text-subtle );
 	margin: 0;
 	transition: all 0.15s ease-in-out;

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -260,7 +260,7 @@
 
 	.section-nav-tab__text {
 		font-weight: 600;
-		font-size: 13px;
+		font-size: $font-body-small;
 		letter-spacing: 0.04em;
 		text-transform: uppercase;
 		width: 100%;

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -185,7 +185,7 @@
 .search-stream__headers {
 	color: var( --color-text-subtle );
 	display: flex;
-	font-size: 14px;
+	font-size: $font-body-small;
 	font-weight: 600;
 	list-style-type: none;
 	margin: 17px 0 0;

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -81,7 +81,7 @@
 	.reader-post-byline {
 		margin: 8px 0;
 		padding: 0;
-		font-size: 14px;
+		font-size: $font-body-small;
 		color: var( --color-neutral-20 );
 
 		.gravatar {
@@ -112,7 +112,7 @@
 
 		.reader__post-time-placeholder {
 			position: relative;
-			font-size: 14px;
+			font-size: $font-body-small;
 
 			@include breakpoint-deprecated( '<480px' ) {
 				font-size: 13px;
@@ -422,7 +422,7 @@
 
 .reader-stream__recommended-posts-header {
 	color: var( --color-neutral-20 );
-	font-size: 14px;
+	font-size: $font-body-small;
 	font-weight: 600;
 	letter-spacing: 0.01em;
 	margin: 13px 0 17px;

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -115,7 +115,7 @@
 			font-size: $font-body-small;
 
 			@include breakpoint-deprecated( '<480px' ) {
-				font-size: 13px;
+				font-size: $font-body-small;
 			}
 		}
 	}
@@ -202,7 +202,7 @@
 
 		.reader-post-byline {
 			margin: 0;
-			font-size: 13px;
+			font-size: $font-body-small;
 			position: absolute;
 				top: 34px;
 				left: 44px;
@@ -369,7 +369,7 @@
 
 .reader__x-post,
 .reader__x-post-to {
-	font-size: 13px;
+	font-size: $font-body-small;
 	font-family: $sans;
 	color: var( --color-text-subtle );
 	position: relative;

--- a/client/reader/style.scss
+++ b/client/reader/style.scss
@@ -55,7 +55,7 @@
 	}
 
 	@include breakpoint-deprecated( '<480px' ) {
-		font-size: 13px;
+		font-size: $font-body-small;
 		max-width: 180px;
 	}
 }

--- a/client/reader/style.scss
+++ b/client/reader/style.scss
@@ -38,7 +38,7 @@
 .reader__site-name {
 	clear: none;
 	color: var( --color-neutral-50 );
-	font-size: 14px;
+	font-size: $font-body-small;
 	line-height: 1.3;
 	display: inline-block;
 	white-space: nowrap;
@@ -189,7 +189,7 @@
 	padding: 0;
 	margin: 16px 0 0 -4px;
 	list-style: none;
-	font-size: 14px;
+	font-size: $font-body-small;
 	color: var( --color-text-subtle );
 	display: flex;
 	align-items: center;
@@ -283,7 +283,7 @@
 	background: linear-gradient( to bottom, transparent, rgba( 0, 0, 0, 0.2 ) 73%, rgba( 0, 0, 0, 0.5 ) 100% );
 	color: var( --color-text-inverted );
 	font-family: $sans;
-	font-size: 14px;
+	font-size: $font-body-small;
 	text-shadow: 0 1px rgba( 0, 0, 0, 0.3 );
 	font-weight: 400;
 	overflow: hidden;

--- a/client/signup/flow-progress-indicator/style.scss
+++ b/client/signup/flow-progress-indicator/style.scss
@@ -1,6 +1,6 @@
 .flow-progress-indicator {
 	color: var( --color-text-inverted );
-	font-size: 14px;
+	font-size: $font-body-small;
 	font-weight: 600;
 }
 

--- a/client/signup/navigation-link/style.scss
+++ b/client/signup/navigation-link/style.scss
@@ -1,7 +1,7 @@
 .button.is-borderless.navigation-link {
 	padding: 0;
 	color: var( --color-text-inverted );
-	font-size: 14px;
+	font-size: $font-body-small;
 	font-weight: 600;
 
 	svg {

--- a/client/signup/site-mockup/style.scss
+++ b/client/signup/site-mockup/style.scss
@@ -27,7 +27,7 @@
 .site-mockup__help-tip {
 	color: var( --color-primary-5 );
 	text-align: center;
-	font-size: 13px;
+	font-size: $font-body-small;
 	margin: 24px 16px -8px;
 	transition: all 300ms cubic-bezier( 0.08, 0.74, 0.44, 1.07 );
 	transition-delay: 200ms;

--- a/client/signup/steps/clone-cloning/style.scss
+++ b/client/signup/steps/clone-cloning/style.scss
@@ -16,7 +16,7 @@
 
 .clone-cloning__description {
 	color: var( --color-text-subtle );
-	font-size: 14px;
+	font-size: $font-body-small;
 }
 .clone-cloning__button {
 	margin-top: 24px;

--- a/client/signup/steps/clone-ready/style.scss
+++ b/client/signup/steps/clone-ready/style.scss
@@ -15,7 +15,7 @@
 
 .clone-ready__description {
 	color: var( --color-text-subtle );
-	font-size: 14px;
+	font-size: $font-body-small;
 }
 .clone-ready__button {
 	margin-top: 24px;

--- a/client/signup/steps/clone-start/style.scss
+++ b/client/signup/steps/clone-start/style.scss
@@ -27,7 +27,7 @@
 
 .clone-start__description {
 	color: var( --color-text-subtle );
-	font-size: 14px;
+	font-size: $font-body-small;
 }
 
 .clone-start__button {

--- a/client/signup/steps/import-url-onboarding/style.scss
+++ b/client/signup/steps/import-url-onboarding/style.scss
@@ -11,7 +11,7 @@
 	.button.is-borderless {
 		padding: 0;
 		color: var( --color-text-inverted );
-		font-size: 14px;
+		font-size: $font-body-small;
 		font-weight: 600;
 		text-decoration: underline;
 	}

--- a/client/signup/steps/import-url/style.scss
+++ b/client/signup/steps/import-url/style.scss
@@ -66,7 +66,7 @@
 
 	&__example-url {
 		font-family: monospace;
-		font-size: 14px;
+		font-size: $font-body-small;
 		color: var( --color-text-inverted );
 
 		&:first-of-type {

--- a/client/signup/steps/site-type/style.scss
+++ b/client/signup/steps/site-type/style.scss
@@ -46,7 +46,7 @@
 	}
 
 	.site-type__option-description {
-		font-size: 14px;
+		font-size: $font-body-small;
 		color: var( --color-text-subtle );
 	}
 
@@ -92,7 +92,7 @@
 	.button.is-borderless {
 		padding: 0;
 		color: var( --color-text-inverted );
-		font-size: 14px;
+		font-size: $font-body-small;
 		font-weight: 600;
 		text-decoration: underline;
 	}

--- a/client/signup/steps/survey/style.scss
+++ b/client/signup/steps/survey/style.scss
@@ -10,7 +10,7 @@
 
 .survey-step__question {
 	text-align: center;
-	font-size: 14px;
+	font-size: $font-body-small;
 	font-weight: 600;
 }
 

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -266,7 +266,7 @@ body.is-section-signup .layout.gravatar .formatted-header {
 		text-align: center;
 		text-decoration: underline;
 		color: var( --studio-gray-60 );
-		font-size: 14px;
+		font-size: $font-body-small;
 	}
 
 	.signup-form__terms-of-service-link {

--- a/packages/plans-grid/src/plans-details/style.scss
+++ b/packages/plans-grid/src/plans-details/style.scss
@@ -33,7 +33,7 @@
 .plans-details__header-row {
 	th {
 		font-weight: 600;
-		font-size: 14px;
+		font-size: $font-body-small;
 		line-height: 20px;
 		text-transform: uppercase;
 		color: var( --studio-gray-20 );
@@ -46,7 +46,7 @@
 .plans-details__feature-row {
 	th,
 	td {
-		font-size: 14px;
+		font-size: $font-body-small;
 		line-height: 17px;
 		letter-spacing: 0.2px;
 		border-bottom: 1px solid #eaeaeb;

--- a/packages/plans-grid/src/plans-table/style.scss
+++ b/packages/plans-grid/src/plans-table/style.scss
@@ -81,7 +81,7 @@
 }
 
 .plan-item__domain-summary {
-	font-size: 14px;
+	font-size: $font-body-small;
 	line-height: 22px;
 	min-height: 44px; // temporary until domain picker is in
 }
@@ -107,7 +107,7 @@
 }
 
 .plan-item__domain-picker-button.components-button {
-	font-size: 14px;
+	font-size: $font-body-small;
 	line-height: 19px;
 	letter-spacing: 0.2px;
 	word-break: break-word;
@@ -137,7 +137,7 @@
 }
 
 .plan-item__feature-item {
-	font-size: 14px;
+	font-size: $font-body-small;
 	line-height: 22px;
 	letter-spacing: 0.2px;
 	margin: 4px 0;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates all uses of `font-size: 14px` to use a variable for easier manipulation down the road.
* Also updates instances of 13px to 14px to standardize with our type scale. Added a couple before/after visuals to give an idea of what the new size looks like.

**Before**

<img width="746" alt="Screen Shot 2020-06-04 at 10 57 27 AM" src="https://user-images.githubusercontent.com/2124984/83773340-66c5f580-a652-11ea-8f7d-3ee9e8f4110f.png">

<img width="502" alt="Screen Shot 2020-06-04 at 11 10 46 AM" src="https://user-images.githubusercontent.com/2124984/83774819-3717ed00-a654-11ea-8e13-d9a59d123047.png">

<img width="735" alt="Screen Shot 2020-06-04 at 11 18 55 AM" src="https://user-images.githubusercontent.com/2124984/83775787-595e3a80-a655-11ea-9a58-b8d4299ecced.png">


**After**

<img width="746" alt="Screen Shot 2020-06-04 at 10 56 53 AM" src="https://user-images.githubusercontent.com/2124984/83773356-6af21300-a652-11ea-814d-409654109976.png">

<img width="501" alt="Screen Shot 2020-06-04 at 11 10 55 AM" src="https://user-images.githubusercontent.com/2124984/83774838-3d0dce00-a654-11ea-9bed-e8c352a42289.png">

<img width="746" alt="Screen Shot 2020-06-04 at 11 18 45 AM" src="https://user-images.githubusercontent.com/2124984/83775756-519e9600-a655-11ea-9770-d353b9f48e19.png">

#### Testing instructions

* Switch to this PR
* Browse Calypso and note the font size changes, note any visual bugs.