### PR TITLE
i18n: Use `ltr` direction for example domain browser always

### DIFF
--- a/client/components/domains/example-domain-browser/style.scss
+++ b/client/components/domains/example-domain-browser/style.scss
@@ -4,6 +4,8 @@
 	svg {
 		position: relative;
 		top: 15px;
+		/*rtl:ignore*/
+		direction: ltr;
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Set example domain browser direction to `ltr` to avoid URL text misalignment with RTL locales.

**Before:**
![image](https://user-images.githubusercontent.com/2722412/83657568-adbbd880-a5c9-11ea-886a-abca0b3d9817.png)

**After:**
![image](https://user-images.githubusercontent.com/2722412/83657502-9b419f00-a5c9-11ea-943f-5c6b8c4afbc9.png)


#### Testing instructions

* Boot Calypso
* Open http://calypso.localhost:3000/start/domains and confirm example domain browser's URL is aligned correctly.
