### PR TITLE
CartStore: Replace reload update with fetch

### DIFF
--- a/client/lib/cart/store/index.js
+++ b/client/lib/cart/store/index.js
@@ -132,6 +132,12 @@ function disable() {
 	_cartKey = null;
 }
 
+function fetch() {
+	if ( _synchronizer ) {
+		_synchronizer.fetch();
+	}
+}
+
 CartStore.dispatchToken = Dispatcher.register( ( payload ) => {
 	const { action } = payload;
 
@@ -233,7 +239,7 @@ CartStore.dispatchToken = Dispatcher.register( ( payload ) => {
 			break;
 
 		case CART_RELOAD:
-			update( ( value ) => value );
+			fetch();
 			break;
 	}
 } );


### PR DESCRIPTION

#### Changes proposed in this Pull Request

This fixes a regression added in https://github.com/Automattic/wp-calypso/pull/42676 

The identity update triggered by the new "reload" action causes the cached version of the cart (which may be incorrect) to be sent to the server, replacing whatever is there. In this PR we change the "reload" action to simply fetch the current cart instead.

#### Testing instructions

- Add a plan to your cart.
- Visit composite checkout and remove the plan.
- You should be redirected to the plans page.
- Verify that the cart icon in the upper-right does not display a number (it may display one very briefly before it updates).