### PR TITLE
Jetpack cloud: Prevent failed prop type warning in ExpandableSidebarHeading

### DIFF
--- a/client/layout/sidebar/expandable-heading.jsx
+++ b/client/layout/sidebar/expandable-heading.jsx
@@ -46,7 +46,7 @@ const ExpandableSidebarHeading = ( {
 };
 
 ExpandableSidebarHeading.propTypes = {
-	title: TranslatableString.isRequired,
+	title: PropTypes.oneOfType( [ TranslatableString, PropTypes.element ] ).isRequired,
 	count: PropTypes.number,
 	onClick: PropTypes.func,
 	icon: PropTypes.string,

--- a/client/layout/sidebar/expandable.jsx
+++ b/client/layout/sidebar/expandable.jsx
@@ -9,6 +9,7 @@ import { get, uniqueId } from 'lodash';
 /**
  * Internal dependencies
  */
+import TranslatableString from 'components/translatable/proptype';
 import ExpandableSidebarHeading from './expandable-heading';
 import SidebarMenu from 'layout/sidebar/menu';
 
@@ -75,7 +76,7 @@ export const ExpandableSidebarMenu = ( props ) => {
 };
 
 ExpandableSidebarMenu.propTypes = {
-	title: PropTypes.oneOfType( [ PropTypes.string, PropTypes.element ] ).isRequired,
+	title: PropTypes.oneOfType( [ TranslatableString, PropTypes.element ] ).isRequired,
 	count: PropTypes.number,
 	onClick: PropTypes.func,
 	icon: PropTypes.string,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes a failed prop type warning thrown in `ExpandableSidebarHeading`. See capture below.

#### Implementation details

`title` prop types in `ExpandableSidebarMenu` and `ExpandableSidebarHeading` didn't match. I've updated both to take into account that the title can be a translatable string or a component.

#### Testing instructions

1. Go to Jetpack cloud and select a site
2. Open the browser console
3. The error shouldn't be present anymore

#### Screenshots

<img width="1235" alt="Screen Shot 2020-05-20 at 10 43 21 AM" src="https://user-images.githubusercontent.com/1620183/83680257-bb179980-a5ae-11ea-91a2-6b5bb8245845.png">
