### PR TITLE
Checkout: bump the date for the composite checkout test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -38,7 +38,7 @@ export default {
 		allowExistingUsers: true,
 	},
 	showCompositeCheckout: {
-		datestamp: '20200508',
+		datestamp: '20200603',
 		variations: {
 			composite: 50,
 			regular: 50,


### PR DESCRIPTION
After our most recent bug-fixes and design updates around simplifying the new Checkout flow, this bumps the AB test date gauge the effect of the changes.

Ref: pbOQVh-fY-p2

**To test:**
- visual check to make sure the timestamp is correct