### PR TITLE
Earn Page: fix premium content link

### DIFF
--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -212,7 +212,7 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 					text: translate( 'Add premium content subscriptions' ),
 					action: () => {
 						trackCtaButton( 'premium-content' );
-						page( '/earn/payments-plans/${ selectedSiteSlug }' );
+						page( `/earn/payments-plans/${ selectedSiteSlug }` );
 					},
 			  };
 		const title = hasConnectedAccount


### PR DESCRIPTION
The site slug variable isn't being parsed in the premium content card introduced in #42541.