### PR TITLE
Jetpack Cloud: Refine Logic for Home Redirect

### DIFF
--- a/client/landing/jetpack-cloud/sections/home.tsx
+++ b/client/landing/jetpack-cloud/sections/home.tsx
@@ -35,9 +35,9 @@ function Home( props: Props ) {
 		if ( primarySiteIsEligible === null || siteCapabilities === undefined ) {
 			return;
 		} else if ( primarySiteIsEligible && includes( siteCapabilities, 'backup' ) ) {
-			redirectUrl.pathname = `/backup/${ siteSlug }`;
+			redirectUrl.pathname = `/backup/${ siteSlug ?? '' }`;
 		} else if ( primarySiteIsEligible && includes( siteCapabilities, 'scan' ) ) {
-			redirectUrl.pathname = `/scan/${ siteSlug }`;
+			redirectUrl.pathname = `/scan/${ siteSlug ?? '' }`;
 		}
 
 		page.redirect( redirectUrl.toString() );
@@ -56,7 +56,6 @@ export default connect( ( state ) => {
 
 	const primarySiteIsEligible = siteId
 		? getPrimarySiteIsJetpack( state ) &&
-		  !! siteSlug &&
 		  ! isSiteAtomic( state, siteId ) &&
 		  ! isJetpackSiteMultiSite( state, siteId )
 		: null;

--- a/client/landing/jetpack-cloud/sections/home.tsx
+++ b/client/landing/jetpack-cloud/sections/home.tsx
@@ -1,9 +1,10 @@
 /**
  * External dependencies
  */
-import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
+import { includes } from 'lodash';
 import page from 'page';
+import React, { useEffect } from 'react';
 
 /**
  * Internal dependencies
@@ -12,46 +13,35 @@ import QueryRewindCapabilities from 'components/data/query-rewind-capabilities';
 import getRewindCapabilities from 'state/selectors/get-rewind-capabilities';
 import getPrimarySiteId from 'state/selectors/get-primary-site-id';
 import getPrimarySiteIsJetpack from 'state/selectors/get-primary-site-is-jetpack';
-import config from 'config';
 import getPrimarySiteSlug from 'state/selectors/get-primary-site-slug';
 import isSiteAtomic from 'state/selectors/is-site-wpcom-atomic';
 import isJetpackSiteMultiSite from 'state/sites/selectors/is-jetpack-site-multi-site';
 
 type Props = {
-	siteId?: number | null;
-	siteSlug?: string | null;
-	siteCapabilities?: string[];
+	primarySiteIsEligible: boolean | null;
+	siteCapabilities: string[];
+	siteId: number | null;
+	siteSlug: string | null;
 };
 
 function Home( props: Props ) {
-	const { siteId, siteSlug, siteCapabilities } = props;
+	const { primarySiteIsEligible, siteSlug, siteCapabilities, siteId } = props;
 
 	useEffect( () => {
-		const redirectUrl = new URL( '/error', window.location.href );
+		const redirectUrl = new URL( '/backup', window.location.href );
 		redirectUrl.search = window.location.search;
 
-		if ( config.isEnabled( 'jetpack-cloud/backups' ) ) {
-			redirectUrl.pathname = '/backup';
-		} else if ( config.isEnabled( 'jetpack-cloud/scan' ) ) {
-			redirectUrl.pathname = '/scan';
-		}
-		if ( ! siteId ) {
-			return page.redirect( redirectUrl.toString() );
-		}
-
-		if ( ! siteSlug || ! Array.isArray( siteCapabilities ) ) {
+		// early return while we wait to retrieve information
+		if ( primarySiteIsEligible === null || siteCapabilities === undefined ) {
 			return;
-		}
-
-		// From capabilities, build proper URL.
-		if ( config.isEnabled( 'jetpack-cloud/backups' ) && siteCapabilities.includes( 'backup' ) ) {
+		} else if ( primarySiteIsEligible && includes( siteCapabilities, 'backup' ) ) {
 			redirectUrl.pathname = `/backup/${ siteSlug }`;
-		} else if ( config.isEnabled( 'jetpack-cloud/scan' ) && siteCapabilities.includes( 'scan' ) ) {
+		} else if ( primarySiteIsEligible && includes( siteCapabilities, 'scan' ) ) {
 			redirectUrl.pathname = `/scan/${ siteSlug }`;
 		}
 
 		page.redirect( redirectUrl.toString() );
-	}, [ siteId, siteSlug, siteCapabilities ] );
+	}, [ primarySiteIsEligible, siteSlug, siteCapabilities ] );
 
 	return (
 		<>
@@ -62,20 +52,17 @@ function Home( props: Props ) {
 
 export default connect( ( state ) => {
 	const siteId = getPrimarySiteId( state );
-	if (
-		! siteId ||
-		! getPrimarySiteIsJetpack( state ) ||
-		isSiteAtomic( state, siteId ) ||
-		isJetpackSiteMultiSite( state, siteId ) // TODO: Remove once multisites become Rewind compatible.
-	) {
-		return {
-			siteId: null,
-		};
-	}
+
+	const primarySiteIsEligible = siteId
+		? getPrimarySiteIsJetpack( state ) &&
+		  ! isSiteAtomic( state, siteId ) &&
+		  ! isJetpackSiteMultiSite( state, siteId )
+		: null;
 
 	return {
-		siteId,
+		primarySiteIsEligible,
+		siteCapabilities: primarySiteIsEligible ? getRewindCapabilities( state, siteId ) : null,
+		siteId: primarySiteIsEligible === false ? null : siteId,
 		siteSlug: getPrimarySiteSlug( state ),
-		siteCapabilities: getRewindCapabilities( state, siteId ),
 	};
 } )( Home );

--- a/client/landing/jetpack-cloud/sections/home.tsx
+++ b/client/landing/jetpack-cloud/sections/home.tsx
@@ -52,9 +52,11 @@ function Home( props: Props ) {
 
 export default connect( ( state ) => {
 	const siteId = getPrimarySiteId( state );
+	const siteSlug = getPrimarySiteSlug( state );
 
 	const primarySiteIsEligible = siteId
 		? getPrimarySiteIsJetpack( state ) &&
+		  !! siteSlug &&
 		  ! isSiteAtomic( state, siteId ) &&
 		  ! isJetpackSiteMultiSite( state, siteId )
 		: null;
@@ -63,6 +65,6 @@ export default connect( ( state ) => {
 		primarySiteIsEligible,
 		siteCapabilities: primarySiteIsEligible ? getRewindCapabilities( state, siteId ) : null,
 		siteId: primarySiteIsEligible === false ? null : siteId,
-		siteSlug: getPrimarySiteSlug( state ),
+		siteSlug,
 	};
 } )( Home );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change the logic on `/` to redirect more reliably
   * if non-eligible primary site, redirect to `/backup`
   * if primary site has backups, redirect to `/backup/:siteSlug` 
   * if primary site does not have backups and does have backups, redirect to `/scan/:siteSlug`
   * finally if none of the above redirect to `/backup`


#### Testing instructions

1. Navigate to `/` for various primary sites, testing the logic