### PR TITLE
Fixing premium content block link in Earn

### DIFF
--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -212,7 +212,7 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 					text: translate( 'Add premium content subscriptions' ),
 					action: () => {
 						trackCtaButton( 'premium-content' );
-						page( `/earn/payments-plans/${ selectedSiteSlug }` );
+						page( `/earn/payments/${ selectedSiteSlug }` );
 					},
 			  };
 		const title = hasConnectedAccount


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Fixing the Premium Content Block link for users who have access to Premium Content Blocks but aren't yet connected to Stripe.

#### Testing instructions
* Confirm that the Premium Content block link works properly for users on any paid plan but who are not yet connected to Stripe.

Fixes #
* Pointing users to /earn/payments/${ selectedSiteSlug } rather than /earn/payments-plans/${ selectedSiteSlug }