### PR TITLE
Editor: Remove 1 June date from deprecation notices

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/deprecate-editor/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/deprecate-editor/index.jsx
@@ -37,7 +37,7 @@ const DeprecateEditor = ( { siteId, gutenbergUrl, optIn } ) => {
 			title={ translate( 'The new WordPress editor is coming.' ) }
 			description={ preventWidows(
 				translate(
-					'Get a head start before we activate it for everyone on in the near future. {{support}}Read more{{/support}}.',
+					'Get a head start before we activate it for everyone in the near future. {{support}}Read more{{/support}}.',
 					{
 						components: {
 							support: (

--- a/client/my-sites/customer-home/cards/tasks/deprecate-editor/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/deprecate-editor/index.jsx
@@ -23,32 +23,23 @@ import {
 } from 'state/analytics/actions';
 import getGutenbergEditorUrl from 'state/selectors/get-gutenberg-editor-url';
 import blockEditorImage from 'assets/images/illustrations/block-editor-fade.svg';
-import FormattedDate from 'components/formatted-date';
 import { localizeUrl } from 'lib/i18n-utils';
 import InlineSupportLink from 'components/inline-support-link';
-import { useLocalizedMoment } from 'components/localized-moment';
 
 const DeprecateEditor = ( { siteId, gutenbergUrl, optIn } ) => {
 	const translate = useTranslate();
-	const moment = useLocalizedMoment();
 	const actionCallback = () => {
 		optIn( siteId, gutenbergUrl );
 	};
-	const dateFormat = moment.localeData().longDateFormat( 'LL' );
 
 	return (
 		<Task
 			title={ translate( 'The new WordPress editor is coming.' ) }
 			description={ preventWidows(
 				translate(
-					'Get a head start before we activate it for everyone on {{date/}}. {{support}}Read more{{/support}}.',
+					'Get a head start before we activate it for everyone on in the near future. {{support}}Read more{{/support}}.',
 					{
 						components: {
-							date: (
-								<strong>
-									<FormattedDate date="2020-06-01" format={ dateFormat } />
-								</strong>
-							),
 							support: (
 								<InlineSupportLink
 									supportPostId={ 167510 }

--- a/client/post-editor/editor-deprecation-dialog/index.jsx
+++ b/client/post-editor/editor-deprecation-dialog/index.jsx
@@ -25,8 +25,6 @@ import { getEditedPostValue } from 'state/posts/selectors';
 import getGutenbergEditorUrl from 'state/selectors/get-gutenberg-editor-url';
 import InlineSupportLink from 'components/inline-support-link';
 import { localizeUrl } from 'lib/i18n-utils';
-import FormattedDate from 'components/formatted-date';
-import { withLocalizedMoment } from 'components/localized-moment';
 
 /**
  * Style dependencies
@@ -65,8 +63,6 @@ class EditorDeprecationDialog extends Component {
 			return null;
 		}
 
-		const dateFormat = this.props.moment.localeData().longDateFormat( 'LL' );
-
 		return (
 			<Modal
 				title={ translate( 'The new WordPress editor is coming.' ) }
@@ -79,14 +75,9 @@ class EditorDeprecationDialog extends Component {
 
 				<p className="editor-deprecation-dialog__subhead">
 					{ translate(
-						'Get a head start before we activate it for everyone on {{date/}}. {{support}}Read more{{/support}}.',
+						'Get a head start before we activate it for everyone in the near future. {{support}}Read more{{/support}}.',
 						{
 							components: {
-								date: (
-									<strong>
-										<FormattedDate date="2020-06-01" format={ dateFormat } />
-									</strong>
-								),
 								support: (
 									<InlineSupportLink
 										supportPostId={ 167510 }
@@ -153,4 +144,4 @@ export default connect( ( state ) => {
 		isDialogShowing,
 		gutenbergUrl: gutenbergUrl,
 	};
-}, mapDispatchToProps )( localize( withLocalizedMoment( EditorDeprecationDialog ) ) );
+}, mapDispatchToProps )( localize( EditorDeprecationDialog ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes the June 1 date from Editor deprecation notice and replaces it with a temporary 'In the near future' while new dates are finalised. Exact wording still to be finalised, feel free to comment on options.

#### Testing instructions

* In a site with classic editor set check that deprecation notices displays on Customer home as follows:

<img width="1067" alt="Screen Shot 2020-06-04 at 11 30 01 AM" src="https://user-images.githubusercontent.com/3629020/83698920-c8885e80-a656-11ea-8677-e7f341018a59.png">

and as dialog on loading editor as follows:

<img width="999" alt="Screen Shot 2020-06-04 at 11 19 27 AM" src="https://user-images.githubusercontent.com/3629020/83698802-70e9f300-a656-11ea-8d89-17702c8c351f.png">

