### PR TITLE
Prevent getSiteFragment from thinking plugin name is site

### DIFF
--- a/client/lib/route/path.ts
+++ b/client/lib/route/path.ts
@@ -59,8 +59,8 @@ export function getSiteFragment( path: URLString ): SiteSlug | SiteId | false {
 	// Check last and second-to-last piece for numeric site ID
 	for ( let i = 2; i > 0; i-- ) {
 		const piece = pieces[ pieces.length - i ];
-		// We can't just do parseInt because some string look like numbers, eg: '404-hello'
-		const isNumber = String( piece ).match( /\D/ ) === null;
+		// We can't just do parseInt because some strings look like numbers, eg: '404-hello'
+		const isNumber = /^\d+$/.test( piece );
 		const intPiece = parseInt( piece, 10 );
 		if ( isNumber && Number.isSafeInteger( intPiece ) ) {
 			return intPiece;

--- a/client/lib/route/path.ts
+++ b/client/lib/route/path.ts
@@ -58,9 +58,12 @@ export function getSiteFragment( path: URLString ): SiteSlug | SiteId | false {
 
 	// Check last and second-to-last piece for numeric site ID
 	for ( let i = 2; i > 0; i-- ) {
-		const piece = parseInt( pieces[ pieces.length - i ], 10 );
-		if ( Number.isSafeInteger( piece ) ) {
-			return piece;
+		const piece = pieces[ pieces.length - i ];
+		// We can't just do parseInt because some string look like numbers, eg: '404-hello'
+		const isNumber = String( piece ).match( /\D/ ) === null;
+		const intPiece = parseInt( piece, 10 );
+		if ( isNumber && Number.isSafeInteger( intPiece ) ) {
+			return intPiece;
 		}
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This fixes a bug which caused calypso routing to believe that plugin names which start with a number are site IDs.

The underlying cause is that when looking for a site ID in the URL, `getSiteFragment` uses `parseInt` on the url fragment before testing to see if it's an integer. However, `parseInt('404-hello')` will return `404`, so this test is not very helpful.

In this PR I add a regexp test as well that looks to see if the url fragment contains any non-numeric characters before letting us test the number.

#### Testing instructions

- Visit http://calypso.localhost:3000/plugins/404-to-301
- Make sure the page loads successfully and you see a single plugin
- Visit http://calypso.localhost:3000/plugins
- Make sure the page loads successfully and you see a list of plugins
- Visit http://calypso.localhost:3000/plugins/example.com (but replace example.com with your site id)
- Make sure the page loads successfully and you see a list of plugins

Fixes https://github.com/Automattic/wp-calypso/issues/42971