### PR TITLE
Jetpack Checklist Modal: Improve ProgressBar Value Readability

### DIFF
--- a/client/my-sites/plans/current-plan/current-plan-thank-you/paid-plan-thank-you.js
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you/paid-plan-thank-you.js
@@ -138,11 +138,7 @@ export class PaidPlanThankYou extends Component {
 							) }
 						</p>
 						{ /* Make the progress bar more visibile by starting at 10% */ }
-						<ProgressBar
-							isPulsing
-							total={ 100 }
-							value={ Math.max( installProgress, 10 ) }
-						/>
+						<ProgressBar isPulsing total={ 100 } value={ Math.max( installProgress, 10 ) } />
 					</ThankYou>
 				) }
 				{ installState === INSTALL_STATE_COMPLETE && (

--- a/client/my-sites/plans/current-plan/current-plan-thank-you/paid-plan-thank-you.js
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you/paid-plan-thank-you.js
@@ -141,7 +141,7 @@ export class PaidPlanThankYou extends Component {
 						<ProgressBar
 							isPulsing
 							total={ 100 }
-							value={ installProgress < 10 ? 10 : installProgress }
+							value={ Math.max( installProgress, 10 ) }
 						/>
 					</ThankYou>
 				) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

From https://github.com/Automattic/wp-calypso/pull/42940#pullrequestreview-423941358:

> Personally, I think that I'd prefer something like Math.max( installProgress, 10 ) to improve readability. But, that's not a blocker.

@ebinnion Not sure by if "not a blocker", you meant it was worth following up in another PR, but I agree that's a more readable approach than the chiamus-like structure used previously. :) 

#### Testing instructions

See #42940 - the detailed steps laid out there are identical.

<img width="841" alt="Screenshot 2020-06-03 at 15 47 59" src="https://user-images.githubusercontent.com/43215253/83651650-a12b8600-a5b1-11ea-9131-256326ca6241.png">
