### PR TITLE
Build: generate a manifest chunk also for wp-desktop and use it

### DIFF
--- a/client/document/desktop.jsx
+++ b/client/document/desktop.jsx
@@ -89,7 +89,6 @@ class Desktop extends React.Component {
 							__html: manifest,
 						} }
 					/>
-					) }
 					{ entrypoint.js.map( ( asset ) => (
 						<script key={ asset } src={ asset } />
 					) ) }

--- a/client/document/desktop.jsx
+++ b/client/document/desktop.jsx
@@ -20,6 +20,7 @@ class Desktop extends React.Component {
 		const {
 			app,
 			entrypoint,
+			manifest,
 			faviconURL,
 			i18nLocaleScript,
 			isRTL,
@@ -66,7 +67,6 @@ class Desktop extends React.Component {
 							{ devDocs && <DevDocsLink url={ devDocsURL } /> }
 						</EnvironmentBadge>
 					) }
-
 					{ app && (
 						<script
 							type="text/javascript"
@@ -83,7 +83,13 @@ class Desktop extends React.Component {
 							} }
 						/>
 					) }
-
+					<script
+						type="text/javascript"
+						dangerouslySetInnerHTML={ {
+							__html: manifest,
+						} }
+					/>
+					) }
 					{ entrypoint.js.map( ( asset ) => (
 						<script key={ asset } src={ asset } />
 					) ) }

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -107,7 +107,7 @@ let outputChunkFilename = '[name].[chunkhash].min.js'; // ditto
 // we should not use chunkhash in development: https://github.com/webpack/webpack-dev-server/issues/377#issuecomment-241258405
 // also we don't minify so dont name them .min.js
 //
-// Desktop: no chunks or dll here, just one big file for the desktop app
+// Desktop app bundles a specific version of Calypso and doesn't need the chunk hashes in file names.
 if ( isDevelopment || isDesktop ) {
 	outputFilename = '[name].js';
 	outputChunkFilename = '[name].js';
@@ -162,7 +162,7 @@ const webpackConfig = {
 			maxAsyncRequests: 20,
 			maxInitialRequests: 5,
 		},
-		runtimeChunk: isDesktop ? false : { name: 'manifest' },
+		runtimeChunk: { name: 'manifest' },
 		moduleIds: 'named',
 		chunkIds: isDevelopment || shouldEmitStats ? 'named' : 'natural',
 		minimize: shouldMinify,


### PR DESCRIPTION
Just like in the web version of the Calypso build, generate a `manifest` chunk (common for all entrypoints) and use it in the `wp-desktop` renderer app.

This should fix #42898

If `runtimeChunk` is set to `false`, the runtime will be bundled with each entrypoint separately, each one optimized for the entrypoint and therefore not identical.

The `runtimeChunk: { name: 'manifest' }` creates a common runtime for all entrypoints.

I believe that webpack has a bug in the code that generates the entrypoint-specific runtimes, but it proved very hard to isolate a simple reproduction case. I don't know yet what's going on. But I already know what's the fix 🙂 

**How to test:**
Does the `wp-desktop` build get green again and does the app work?