### PR TITLE
Gutenboarding: Fix welcome modal styling issues on Gutenberg 8.2.

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nux/src/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nux/src/style.scss
@@ -21,7 +21,7 @@ $wpcom-modal-padding-v: 40px;
 $wpcom-modal-padding-h: 50px;
 $wpcom-modal-content-min-height: 350px;
 $wpcom-modal-footer-padding-v: 20px;
-$wpcom-modal-footer-height: 30px + ( $wpcom-modal-footer-padding-v * 2 ); /* 30px button + 20px top padding + 20px bottom padding */
+$wpcom-modal-footer-height: 30px + ( $wpcom-modal-footer-padding-v * 2 );
 
 // Core modal style overrides
 .wpcom-block-editor-nux {
@@ -68,7 +68,6 @@ $wpcom-modal-footer-height: 30px + ( $wpcom-modal-footer-padding-v * 2 ); /* 30p
 		margin: 0 auto;
 		z-index: 2;
 
-		//
 		&::before {
 			display: inline-block;
 			content: '';

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nux/src/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nux/src/style.scss
@@ -26,10 +26,22 @@ $wpcom-modal-footer-height: 30px + ( $wpcom-modal-footer-padding-v * 2 );
 // Core modal style overrides
 .wpcom-block-editor-nux {
 	&.components-modal__frame {
-		width: 720px;
-		height: $wpcom-modal-content-min-height;
 		overflow: visible;
-		top: calc( 50% - #{$wpcom-modal-footer-height / 2} );
+		height: 65vh;
+		top: calc( 17.5vh - #{$wpcom-modal-footer-height / 2} );
+
+		@media ( max-width: $wpcom-modal-breakpoint ) {
+			width: 90vw;
+			min-width: 90vw;
+			left: 5vw;
+			right: 5vw;
+		}
+
+		@media ( min-width: $wpcom-modal-breakpoint ) {
+			width: 720px;
+			height: $wpcom-modal-content-min-height;
+			top: calc( 50% - #{$wpcom-modal-footer-height / 2} );
+		}
 	}
 
 	.components-modal__header {
@@ -51,6 +63,11 @@ $wpcom-modal-footer-height: 30px + ( $wpcom-modal-footer-padding-v * 2 );
 		display: flex;
 		justify-content: center;
 		background: white;
+		border-top: 1px solid #dcdcde;
+
+		@media ( min-width: $wpcom-modal-breakpoint ) {
+			border-top: none;
+		}
 	}
 
 	.components-guide__page {
@@ -79,15 +96,30 @@ $wpcom-modal-footer-height: 30px + ( $wpcom-modal-footer-padding-v * 2 );
 			vertical-align: middle;
 			margin-bottom: 0;
 		}
+
+		// Temporarily disable dots on mobile as alignment is wonky.
+		display: none;
+		@media ( min-width: $wpcom-modal-breakpoint ) {
+			display: block;
+		}
 	}
 }
 
 .wpcom-block-editor-nux__page {
 	display: flex;
-	min-height: $wpcom-modal-content-min-height;
-	bottom: 0;
-	position: absolute;
+	flex-direction: column-reverse;
+	justify-content: flex-end;
 	background: white;
+	width: 100%;
+	height: 100%;
+
+	@media ( min-width: $wpcom-modal-breakpoint ) {
+		flex-direction: row;
+		justify-content: flex-start;
+		position: absolute;
+		min-height: $wpcom-modal-content-min-height;
+		bottom: 0;
+	}
 }
 
 .wpcom-block-editor-nux__text,
@@ -99,16 +131,21 @@ $wpcom-modal-footer-height: 30px + ( $wpcom-modal-footer-padding-v * 2 );
 }
 
 .wpcom-block-editor-nux__text {
+	padding: 0 25px 25px;
+	height: 60%;
+
 	@media ( min-width: $wpcom-modal-breakpoint ) {
+		height: auto;
 		padding: $wpcom-modal-padding-v $wpcom-modal-padding-h;
 	}
 }
 .wpcom-block-editor-nux__visual {
-	display: none;
+	height: 40%;
 	background: #1381d8;
+	text-align: center;
 
 	@media ( min-width: $wpcom-modal-breakpoint ) {
-		display: flex;
+		height: auto;
 	}
 }
 
@@ -117,7 +154,7 @@ $wpcom-modal-footer-height: 30px + ( $wpcom-modal-footer-padding-v * 2 );
 	/* Gray / Gray 90 */
 	color: #1d2327;
 
-	font-size: 36px;
+	font-size: 32px;
 	line-height: 1.19;
 
 	@media ( min-width: $wpcom-modal-breakpoint ) {
@@ -126,11 +163,16 @@ $wpcom-modal-footer-height: 30px + ( $wpcom-modal-footer-padding-v * 2 );
 }
 
 .wpcom-block-editor-nux__description {
-	font-size: 17px;
-	line-height: 26px;
+	font-size: 15px;
+	line-height: 22px;
 
 	/* Gray / Gray 60 */
 	color: #50575e;
+
+	@media ( min-width: $wpcom-modal-breakpoint ) {
+		font-size: 17px;
+		line-height: 26px;
+	}
 }
 
 .wpcom-block-editor-nux__image {
@@ -141,5 +183,11 @@ $wpcom-modal-footer-height: 30px + ( $wpcom-modal-footer-padding-v * 2 );
 
 	&.align-bottom {
 		align-self: flex-end;
+	}
+
+	max-height: 100%;
+
+	@media ( min-width: $wpcom-modal-breakpoint ) {
+		max-height: none;
 	}
 }

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nux/src/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nux/src/style.scss
@@ -19,9 +19,19 @@ $wpcom-modal-breakpoint: 660px;
 
 $wpcom-modal-padding-v: 40px;
 $wpcom-modal-padding-h: 50px;
+$wpcom-modal-content-min-height: 350px;
+$wpcom-modal-footer-padding-v: 20px;
+$wpcom-modal-footer-height: 30px + ( $wpcom-modal-footer-padding-v * 2 ); /* 30px button + 20px top padding + 20px bottom padding */
 
 // Core modal style overrides
 .wpcom-block-editor-nux {
+	&.components-modal__frame {
+		width: 720px;
+		height: $wpcom-modal-content-min-height;
+		overflow: visible;
+		top: calc( 50% - $wpcom-modal-footer-height );
+	}
+
 	.components-modal__header {
 		display: none;
 	}
@@ -30,17 +40,55 @@ $wpcom-modal-padding-h: 50px;
 		margin-top: 0;
 	}
 
-	.components-modal__content {
-		padding: $wpcom-modal-padding-v $wpcom-modal-padding-h;
+	.components-guide__footer {
+		position: absolute;
+		width: 100%;
+		height: $wpcom-modal-footer-height;
+		bottom: $wpcom-modal-footer-height * -1;
+		left: 0;
+		padding: $wpcom-modal-footer-padding-v 0;
+		margin: 0;
+		display: flex;
+		justify-content: center;
+		background: white;
 	}
 
-	//  .components-guide__footer {
-	//  	padding: 0 24px 24px;
-	//  }
+	.components-guide__page {
+		position: absolute;
+		width: 100%;
+		height: 100%;
+		justify-content: start;
+	}
+
+	.components-guide__page-control {
+		position: relative;
+		height: 0;
+		top: 100%;
+		overflow: visible;
+		margin: 0 auto;
+		z-index: 2;
+
+		//
+		&::before {
+			display: inline-block;
+			content: '';
+			height: $wpcom-modal-footer-height;
+			vertical-align: middle;
+		}
+
+		li {
+			vertical-align: middle;
+			margin-bottom: 0;
+		}
+	}
 }
 
 .wpcom-block-editor-nux__page {
 	display: flex;
+	min-height: $wpcom-modal-content-min-height;
+	bottom: 0;
+	position: absolute;
+	background: white;
 }
 
 .wpcom-block-editor-nux__text,
@@ -53,17 +101,13 @@ $wpcom-modal-padding-h: 50px;
 
 .wpcom-block-editor-nux__text {
 	@media ( min-width: $wpcom-modal-breakpoint ) {
-		padding-right: $wpcom-modal-padding-h * 1.1;
+		padding: $wpcom-modal-padding-v $wpcom-modal-padding-h;
 	}
 }
 .wpcom-block-editor-nux__visual {
 	display: none;
-
 	background: #1381d8;
-	// Fill to right, over container's padding
-	margin-right: -$wpcom-modal-padding-h;
-	margin-top: -$wpcom-modal-padding-v;
-	// padding: 0 $wpcom-modal-padding-h;
+
 	@media ( min-width: $wpcom-modal-breakpoint ) {
 		display: flex;
 	}
@@ -83,7 +127,7 @@ $wpcom-modal-padding-h: 50px;
 }
 
 .wpcom-block-editor-nux__description {
-	font-size: 18px;
+	font-size: 17px;
 	line-height: 26px;
 
 	/* Gray / Gray 60 */

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nux/src/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nux/src/style.scss
@@ -29,7 +29,7 @@ $wpcom-modal-footer-height: 30px + ( $wpcom-modal-footer-padding-v * 2 ); /* 30p
 		width: 720px;
 		height: $wpcom-modal-content-min-height;
 		overflow: visible;
-		top: calc( 50% - $wpcom-modal-footer-height );
+		top: calc( 50% - #{$wpcom-modal-footer-height / 2} );
 	}
 
 	.components-modal__header {


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR fixes the welcome modal styling issues on Gutenberg 8.2.

This PR also fixes the welcome modal styling on mobile view. Following closely to this design https://github.com/Automattic/wp-calypso/issues/42141#issuecomment-627881326 but without the dots at the bottom (due to alignment issues on tight spaces) which I temporarily just hide it for now til design is finalized. See https://github.com/Automattic/wp-calypso/issues/42141#issuecomment-638884014.

This PR also adds a bit of UX improvement by ensuring the footer position always stay consistent. This is so user does not have to reposition the cursor to click on the Next/Previous button when user goes to a different slide on the welcome modal.

## Testing instructions

Run `yarn dev --sync` on folder `apps/full-site-editing` and test on the block editor on the sandbox.

To ensure you always see the gutenboarding welcome modal on the block editor (without having to go through the launch flow:

Comment out these lines in `wpcom-nux.js`.
```
if ( ! isWpcomNuxEnabled || isSPTOpen ) {
    return null;
}
```

And also locate and replace the value of `isGutenboarding` in `wpcom-nux.js`.
```
const isGutenboarding = true;
```

## Screenshot

![2020-06-04_12-18-05 (1)](https://user-images.githubusercontent.com/1287077/83745404-cb3a8200-a65d-11ea-800b-f5d9f4c0b4d8.gif)

The gif below simulates what happens (by reducing modal height) when text from different language takes up more content height. It will just expands the content height upwards while keeping the footer position consistent, so user does not have to move the cursor again to click on the next/previous button.

![2020-06-04_12-18-51 (1)](https://user-images.githubusercontent.com/1287077/83745423-d1306300-a65d-11ea-9ead-c38e7e4f8436.gif)

Here's the mobile view (without the dots for now).

![2020-06-04_15-37-05 (1)](https://user-images.githubusercontent.com/1287077/83765136-1a42e000-a67b-11ea-9a43-6649d7dec357.gif)

Fixes https://github.com/Automattic/wp-calypso/issues/42946
