### PR TITLE
My Home Support search card - aligns search results and focus state to heading

### DIFF
--- a/client/my-sites/customer-home/cards/features/help-search/style.scss
+++ b/client/my-sites/customer-home/cards/features/help-search/style.scss
@@ -122,9 +122,15 @@ $min_results_height: 175px;
 		min-height: $min_results_height;
 		list-style: none;
 		text-align: left;
-		margin: $search_results_top_spacing 0 0;
+		margin: #{$search_results_top_spacing + 1px } #{-$card_padding_small} 0;
 		padding: #{$search_results_top_spacing / 2 - 1px } 0 0 0;
 		border-top: 1px solid var( --color-border-subtle );
+
+
+		@include break-mobile {
+			margin-left: -$card_padding_large;
+			margin-right: -$card_padding_large;
+		}
 	}
 
 	.help-search__results-item {
@@ -135,7 +141,7 @@ $min_results_height: 175px;
 			font-weight: normal;
 			line-height: 1;
 			display: block;
-			padding: 10px 15px;
+			padding: 10px $card_padding_small;
 
 			// Ellipsis overflow handling
 			flex: 1;
@@ -147,6 +153,11 @@ $min_results_height: 175px;
 			&:hover,
 			&:focus {
 				cursor: pointer;
+			}
+
+			@include break-mobile {
+				padding-left: $card_padding_large;
+				padding-right: $card_padding_large;
 			}
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adjusts the design of the (yet to be launched) "Get help" support search card on Calypso "My Home" to [match Design by @olesyabrk](https://github.com/Automattic/wp-calypso/issues/42743#issuecomment-635606611).

#### Screenshot

<img width="329" alt="Screenshot 2020-06-04 at 11 53 36" src="https://user-images.githubusercontent.com/444434/83748419-0fc41e80-a65a-11ea-80c8-3c140ccf8f78.png">


#### Testing instructions

~Until https://github.com/Automattic/wp-calypso/pull/42752 is merged you'll need to apply `D43941` to your sandbox in order to see the card.~ It's now merged and the card is enabled on production.

* ~Sandbox the API and your test site.~
* ~Ensure you have applied `D43941` (unless https://github.com/Automattic/wp-calypso/pull/42752 is merged).~
* Checkout this PR and build Calypso.
* Go to the "My Home" via the Calypso UI and look for the "Get help" card.
* You should see it match the design above. Specifically note the required changes:
  - aligning the search results to the heading
   - expanding the search result item focus state to the edges of the card. 

Fixes https://github.com/Automattic/wp-calypso/issues/42743
