### PR TITLE
Modularise country states state

### DIFF
--- a/client/state/country-states/actions.js
+++ b/client/state/country-states/actions.js
@@ -1,7 +1,6 @@
 /**
  * Internal dependencies
  */
-
 import wpcom from 'lib/wp';
 import {
 	COUNTRY_STATES_RECEIVE,
@@ -9,6 +8,8 @@ import {
 	COUNTRY_STATES_REQUEST_FAILURE,
 	COUNTRY_STATES_REQUEST_SUCCESS,
 } from 'state/action-types';
+
+import 'state/country-states/init';
 
 export function receiveCountryStates( countryStates, countryCode ) {
 	countryCode = countryCode.toLowerCase();

--- a/client/state/country-states/init.js
+++ b/client/state/country-states/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'state/redux-store';
+import countryStatesReducer from './reducer';
+
+registerReducer( [ 'countryStates' ], countryStatesReducer );

--- a/client/state/country-states/package.json
+++ b/client/state/country-states/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/country-states/reducer.js
+++ b/client/state/country-states/reducer.js
@@ -7,7 +7,12 @@ import {
 	COUNTRY_STATES_REQUEST_FAILURE,
 	COUNTRY_STATES_REQUEST_SUCCESS,
 } from 'state/action-types';
-import { combineReducers, withSchemaValidation, withoutPersistence } from 'state/utils';
+import {
+	combineReducers,
+	withoutPersistence,
+	withSchemaValidation,
+	withStorageKey,
+} from 'state/utils';
 import { itemSchema } from './schema';
 
 // Stores the complete list of states, indexed by locale key
@@ -55,7 +60,9 @@ export const isFetching = withoutPersistence( ( state = {}, action ) => {
 	return state;
 } );
 
-export default combineReducers( {
+const combinedReducer = combineReducers( {
 	isFetching,
 	items,
 } );
+
+export default withStorageKey( 'countryStates', combinedReducer );

--- a/client/state/country-states/selectors.js
+++ b/client/state/country-states/selectors.js
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import 'state/country-states/init';
 
 /**
  * Returns an array of states objects for the specified country code, or null

--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -31,7 +31,6 @@ import atomicTransfer from './atomic-transfer/reducer';
 import billingTransactions from './billing-transactions/reducer';
 import checklist from './checklist/reducer';
 import connectedApplications from './connected-applications/reducer';
-import countryStates from './country-states/reducer';
 import currentUser from './current-user/reducer';
 import { reducer as dataRequests } from './data-layer/wpcom-http/utils';
 import documentHead from './document-head/reducer';
@@ -114,7 +113,6 @@ const reducers = {
 	billingTransactions,
 	checklist,
 	connectedApplications,
-	countryStates,
 	currentUser,
 	dataRequests,
 	documentHead,


### PR DESCRIPTION
This PR is one of many working on modularising state in Calypso. This one handles country states.

For more details on state modularisation, see the [modularised state documentation](https://github.com/Automattic/wp-calypso/blob/master/docs/modularized-state.md) and p4TIVU-9lM-p2.

Note: I added all the reviewers that GitHub suggested. Please feel free to ignore the review request or pull in someone else if you're not comfortable reviewing this PR. Thank you!

Fixes #42429.

#### Changes proposed in this Pull Request

* Modularise countries state

#### Testing instructions

* Install [Redux DevTools](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en).
* Open DevTools and switch to the Redux tab.
* Open `/read` on the live branch or your local copy of this branch.
* Click `State` on the top right to ensure you see all state, and not just the diff for the last action: 
![image](https://user-images.githubusercontent.com/409615/73774406-d3e87d80-477b-11ea-9f59-3e42cc00101f.png)
* Analyse the tree and note that there's no `country-states` key, even if you expand the list of keys. This indicates that the country states state hasn't been loaded yet.
* Click `My Sites` on the masterbar, followed by `Manage` and `Domains` on the sidebar.
* Verify that a `country-states` key is added with the country states state. This indicates that the country states state has now been loaded.
* Verify that country states-related functionality works normally. This indicates that I didn't mess up.