### PR TITLE
Modularise atomic hosting state

### DIFF
--- a/client/state/hosting/actions.js
+++ b/client/state/hosting/actions.js
@@ -12,10 +12,12 @@ import {
 	HOSTING_PHP_VERSION_SET_REQUEST,
 	HOSTING_CLEAR_CACHE_REQUEST,
 } from 'state/action-types';
+
 import 'state/data-layer/wpcom/sites/hosting/restore-database-password';
 import 'state/data-layer/wpcom/sites/hosting/sftp-user';
 import 'state/data-layer/wpcom/sites/hosting/php-version';
 import 'state/data-layer/wpcom/sites/hosting/clear-cache';
+import 'state/hosting/init';
 
 export const restoreDatabasePassword = ( siteId ) => ( {
 	type: HOSTING_RESTORE_DATABASE_PASSWORD,

--- a/client/state/hosting/init.js
+++ b/client/state/hosting/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'state/redux-store';
+import hostingReducer from './reducer';
+
+registerReducer( [ 'atomicHosting' ], hostingReducer );

--- a/client/state/hosting/package.json
+++ b/client/state/hosting/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/hosting/reducer.js
+++ b/client/state/hosting/reducer.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { keyedReducer, combineReducers } from 'state/utils';
+import { combineReducers, keyedReducer, withStorageKey } from 'state/utils';
 import {
 	HOSTING_PHP_VERSION_SET,
 	HOSTING_SFTP_USER_UPDATE,
@@ -40,4 +40,5 @@ const atomicHostingReducer = combineReducers( {
 	sftpUsers,
 } );
 
-export default keyedReducer( 'siteId', atomicHostingReducer );
+const reducer = keyedReducer( 'siteId', atomicHostingReducer );
+export default withStorageKey( 'atomicHosting', reducer );

--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -21,7 +21,6 @@ import activePromotions from './active-promotions/reducer';
 import activityLog from './activity-log/reducer';
 import application from './application/reducer';
 import applicationPasswords from './application-passwords/reducer';
-import atomicHosting from './hosting/reducer';
 import atomicTransfer from './atomic-transfer/reducer';
 import billingTransactions from './billing-transactions/reducer';
 import checklist from './checklist/reducer';
@@ -100,7 +99,6 @@ const reducers = {
 	activityLog,
 	application,
 	applicationPasswords,
-	atomicHosting,
 	atomicTransfer,
 	billingTransactions,
 	checklist,

--- a/client/state/selectors/get-atomic-hosting-php-version.js
+++ b/client/state/selectors/get-atomic-hosting-php-version.js
@@ -1,4 +1,9 @@
 /**
+ * Internal dependencies
+ */
+import 'state/hosting/init';
+
+/**
  * Returns the PHP version used for given siteId
  *
  * @param  {object}  state   Global state tree

--- a/client/state/selectors/get-atomic-hosting-sftp-users.js
+++ b/client/state/selectors/get-atomic-hosting-sftp-users.js
@@ -1,4 +1,9 @@
 /**
+ * Internal dependencies
+ */
+import 'state/hosting/init';
+
+/**
  * Returns the sftp users details for given site.
  *
  * @param  {object}  state   Global state tree


### PR DESCRIPTION
This PR is one of many working on modularising state in Calypso. This one handles atomic hosting.

For more details on state modularisation, see the [modularised state documentation](https://github.com/Automattic/wp-calypso/blob/master/docs/modularized-state.md) and p4TIVU-9lM-p2.

Note: I added all the reviewers that GitHub suggested. Please feel free to ignore the review request or pull in someone else if you're not comfortable reviewing this PR. Thank you!

Fixes #42423.

#### Changes proposed in this Pull Request

* Modularise atomic hosting state

#### Testing instructions

* Install [Redux DevTools](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en).
* Open DevTools and switch to the Redux tab.
* Open `/read` on the live branch or your local copy of this branch.
* Click `State` on the top right to ensure you see all state, and not just the diff for the last action: 
![image](https://user-images.githubusercontent.com/409615/73774406-d3e87d80-477b-11ea-9f59-3e42cc00101f.png)
* Analyse the tree and note that there's no `atomicHosting` key, even if you expand the list of keys. This indicates that the atomic hosting state hasn't been loaded yet.
* Click `My Sites` on the masterbar, followed by `Manage` and `Hosting Configuration` on the sidebar.
* Verify that a `atomicHosting` key is added with the atomic hosting state. This indicates that the atomic hosting state has now been loaded.
* Verify that atomic hosting-related functionality works normally. This indicates that I didn't mess up.