### PR TITLE
Modularise shortcodes state

### DIFF
--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -72,7 +72,6 @@ import receipts from './receipts/reducer';
 import rewind from './rewind/reducer';
 import selectedEditor from './selected-editor/reducer';
 import sharing from './sharing/reducer';
-import shortcodes from './shortcodes/reducer';
 import simplePayments from './simple-payments/reducer';
 import siteAddressChange from './site-address-change/reducer';
 import siteKeyrings from './site-keyrings/reducer';
@@ -150,7 +149,6 @@ const reducers = {
 	rewind,
 	selectedEditor,
 	sharing,
-	shortcodes,
 	simplePayments,
 	siteAddressChange,
 	siteKeyrings,

--- a/client/state/shortcodes/actions.js
+++ b/client/state/shortcodes/actions.js
@@ -1,7 +1,6 @@
 /**
  * Internal dependencies
  */
-
 import wpcom from 'lib/wp';
 import {
 	SHORTCODE_RECEIVE,
@@ -9,6 +8,8 @@ import {
 	SHORTCODE_REQUEST_FAILURE,
 	SHORTCODE_REQUEST_SUCCESS,
 } from 'state/action-types';
+
+import 'state/shortcodes/init';
 
 export function fetchShortcode( siteId, shortcode ) {
 	return ( dispatch ) => {

--- a/client/state/shortcodes/init.js
+++ b/client/state/shortcodes/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'state/redux-store';
+import shortcodesReducer from './reducer';
+
+registerReducer( [ 'shortcodes' ], shortcodesReducer );

--- a/client/state/shortcodes/package.json
+++ b/client/state/shortcodes/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/shortcodes/reducer.js
+++ b/client/state/shortcodes/reducer.js
@@ -7,7 +7,12 @@ import { intersection, merge, pickBy } from 'lodash';
  * Internal dependencies
  */
 import { shortcodesSchema } from './schema';
-import { combineReducers, withSchemaValidation, withoutPersistence } from 'state/utils';
+import {
+	combineReducers,
+	withoutPersistence,
+	withSchemaValidation,
+	withStorageKey,
+} from 'state/utils';
 import {
 	SHORTCODE_RECEIVE,
 	SHORTCODE_REQUEST,
@@ -109,7 +114,8 @@ export const items = withSchemaValidation( shortcodesSchema, ( state = {}, actio
 	return state;
 } );
 
-export default combineReducers( {
+const combinedReducer = combineReducers( {
 	requesting,
 	items,
 } );
+export default withStorageKey( 'shortcodes', combinedReducer );

--- a/client/state/shortcodes/selectors.js
+++ b/client/state/shortcodes/selectors.js
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import 'state/shortcodes/init';
 
 /**
  * Returns true if currently requesting that shortcode for the specified site ID, or


### PR DESCRIPTION
This PR is one of many working on modularising state in Calypso. This one handles shortcodes.

For more details on state modularisation, see the [modularised state documentation](https://github.com/Automattic/wp-calypso/blob/master/docs/modularized-state.md) and p4TIVU-9lM-p2.

Note: I added all the reviewers that GitHub suggested. Please feel free to ignore the review request or pull in someone else if you're not comfortable reviewing this PR. Thank you!

Fixes #42476.

#### Changes proposed in this Pull Request

* Modularise shortcodes state

#### Testing instructions

* Switch to the classic editor
* Install [Redux DevTools](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en).
* Open DevTools and switch to the Redux tab.
* Open `/read` on the live branch or your local copy of this branch.
* Click `State` on the top right to ensure you see all state, and not just the diff for the last action: 
![image](https://user-images.githubusercontent.com/409615/73774406-d3e87d80-477b-11ea-9f59-3e42cc00101f.png)
* Analyse the tree and note that there's no `shortcodes` key, even if you expand the list of keys. This indicates that the shortcodes state hasn't been loaded yet.
* Click `Write` on the masterbar, to start a post.
* Verify that a `shortcodes` key is added with the shortcodes state. This indicates that the shortcodes state has now been loaded.
* Verify that shortcodes-related functionality works normally. This indicates that I didn't mess up.