### PR TITLE
Adds PageVisibility info to RUM data

### DIFF
--- a/packages/browser-data-collector/README.md
+++ b/packages/browser-data-collector/README.md
@@ -15,8 +15,7 @@ stop('my-page');
 ```
 
 This will send a report to `Logstash` including (but not limited to):
-	- `start`: always 0
-	- `end`: when `stop()` was called relative to when `start()` was called. If `fullPageLoad:true`, then it is relative to when the navigation started.
+	- `duration`: when `stop()` was called relative to when `start()` was called. If `fullPageLoad:true`, then it is relative to when the navigation started.
 	- `id`: name of the report, `"my-page"` in this case
 	- Environment data like Calypso version or build target
 	- Data from the Performance Timing API

--- a/packages/browser-data-collector/src/collectors/full-page-start.ts
+++ b/packages/browser-data-collector/src/collectors/full-page-start.ts
@@ -1,0 +1,10 @@
+/**
+ * Internal dependencies
+ */
+import { getNavigationStart } from '../api/performance-timing';
+
+export const collector: Collector = ( report ) => {
+	report.beginning = getNavigationStart();
+	report.data.set( 'fullPage', true );
+	return report;
+};

--- a/packages/browser-data-collector/src/collectors/index.ts
+++ b/packages/browser-data-collector/src/collectors/index.ts
@@ -5,3 +5,9 @@ export { collector as deviceMemory } from './device-memory';
 export { collector as performanceTiming } from './performance-timing';
 export { collector as environment } from './environment';
 export { collector as networkInformation } from './network-information';
+export { collector as fullPageStart } from './full-page-start';
+export { collector as inlineStart } from './inline-start';
+export {
+	collectorStart as pageVisibilityStart,
+	collectorStop as pageVisibilityStop,
+} from './page-visibility';

--- a/packages/browser-data-collector/src/collectors/inline-start.ts
+++ b/packages/browser-data-collector/src/collectors/inline-start.ts
@@ -1,0 +1,5 @@
+export const collector: Collector = ( report ) => {
+	report.beginning = Date.now();
+	report.data.set( 'fullPage', false );
+	return report;
+};

--- a/packages/browser-data-collector/src/collectors/page-visibility.ts
+++ b/packages/browser-data-collector/src/collectors/page-visibility.ts
@@ -3,7 +3,7 @@
  * It doesn't care about the current state or when it becomes 'visible', that's why we don't listen for that
  * state change.
  *
- * It is not perfect because it can't detect if the tab/window was hidden between the page laod and when the
+ * It is not perfect because it can't detect if the tab/window was hidden between the page load and when the
  * start collector is called.
  *
  * It also assumes there is only one report running. If we ever have more than one, we may have problems when

--- a/packages/browser-data-collector/src/collectors/page-visibility.ts
+++ b/packages/browser-data-collector/src/collectors/page-visibility.ts
@@ -1,0 +1,35 @@
+/**
+ * This set of reporters try to detect if the tab/window was 'hidden' at any point during the report duration.
+ * It doesn't care about the current state or when it becomes 'visible', that's why we don't listen for that
+ * state change.
+ *
+ * It is not perfect because it can't detect if the tab/window was hidden between the page laod and when the
+ * start collector is called.
+ *
+ * It also assumes there is only one report running. If we ever have more than one, we may have problems when
+ * unsubscribing from the `visibilitychange` event.
+ */
+
+// Assume it is visible by default. If the Page Visiblity API is not supported by the browser, it will be reported as visible.
+let wasHidden = false;
+
+const handleVisibilityChange = () => {
+	if ( document.visibilityState === 'hidden' ) {
+		wasHidden = true;
+	}
+};
+
+export const collectorStart: Collector = ( report ) => {
+	if ( document.visibilityState === 'hidden' ) {
+		wasHidden = true;
+	} else {
+		document.addEventListener( 'visibilitychange', handleVisibilityChange );
+	}
+	return report;
+};
+
+export const collectorStop: Collector = ( report ) => {
+	document.removeEventListener( 'visibilitychange', handleVisibilityChange );
+	report.data.set( 'hidden', wasHidden );
+	return report;
+};

--- a/packages/browser-data-collector/src/collectors/performance-timing.ts
+++ b/packages/browser-data-collector/src/collectors/performance-timing.ts
@@ -34,32 +34,35 @@ const normalize = ( value: number, start: number ): number => {
 
 export const collector: Collector = ( report ) => {
 	// Ensure these values are relative to the beginning of the report
-	report.data.set( 'navigationStart', normalize( getNavigationStart(), report.start ) );
-	report.data.set( 'unloadEventStart', normalize( getUnloadEventStart(), report.start ) );
-	report.data.set( 'unloadEventEnd', normalize( getUunloadEventEnd(), report.start ) );
-	report.data.set( 'redirectStart', normalize( getRedirectStart(), report.start ) );
-	report.data.set( 'redirectEnd', normalize( getRedirectEnd(), report.start ) );
-	report.data.set( 'fetchStart', normalize( getFetchStart(), report.start ) );
-	report.data.set( 'domainLookupStart', normalize( getDomainLookupStart(), report.start ) );
-	report.data.set( 'domainLookupEnd', normalize( getDomainLookupEnd(), report.start ) );
-	report.data.set( 'connectStart', normalize( getConnectStart(), report.start ) );
-	report.data.set( 'connectEnd', normalize( getConnectEnd(), report.start ) );
-	report.data.set( 'secureConnectionStart', normalize( getSecureConnectionStart(), report.start ) );
-	report.data.set( 'requestStart', normalize( getRequestStart(), report.start ) );
-	report.data.set( 'responseStart', normalize( getResponseStart(), report.start ) );
-	report.data.set( 'responseEnd', normalize( getResponseEnd(), report.start ) );
-	report.data.set( 'domLoading', normalize( getDomLoading(), report.start ) );
-	report.data.set( 'domInteractive', normalize( getDomInteractive(), report.start ) );
+	report.data.set( 'navigationStart', normalize( getNavigationStart(), report.beginning ) );
+	report.data.set( 'unloadEventStart', normalize( getUnloadEventStart(), report.beginning ) );
+	report.data.set( 'unloadEventEnd', normalize( getUunloadEventEnd(), report.beginning ) );
+	report.data.set( 'redirectStart', normalize( getRedirectStart(), report.beginning ) );
+	report.data.set( 'redirectEnd', normalize( getRedirectEnd(), report.beginning ) );
+	report.data.set( 'fetchStart', normalize( getFetchStart(), report.beginning ) );
+	report.data.set( 'domainLookupStart', normalize( getDomainLookupStart(), report.beginning ) );
+	report.data.set( 'domainLookupEnd', normalize( getDomainLookupEnd(), report.beginning ) );
+	report.data.set( 'connectStart', normalize( getConnectStart(), report.beginning ) );
+	report.data.set( 'connectEnd', normalize( getConnectEnd(), report.beginning ) );
+	report.data.set(
+		'secureConnectionStart',
+		normalize( getSecureConnectionStart(), report.beginning )
+	);
+	report.data.set( 'requestStart', normalize( getRequestStart(), report.beginning ) );
+	report.data.set( 'responseStart', normalize( getResponseStart(), report.beginning ) );
+	report.data.set( 'responseEnd', normalize( getResponseEnd(), report.beginning ) );
+	report.data.set( 'domLoading', normalize( getDomLoading(), report.beginning ) );
+	report.data.set( 'domInteractive', normalize( getDomInteractive(), report.beginning ) );
 	report.data.set(
 		'domContentLoadedEventStart',
-		normalize( getDomContentLoadedEventStart(), report.start )
+		normalize( getDomContentLoadedEventStart(), report.beginning )
 	);
 	report.data.set(
 		'domContentLoadedEventEnd',
-		normalize( getDomContentLoadedEventEnd(), report.start )
+		normalize( getDomContentLoadedEventEnd(), report.beginning )
 	);
-	report.data.set( 'domComplete', normalize( getDomComplete(), report.start ) );
-	report.data.set( 'loadEventStart', normalize( getLoadEventStart(), report.start ) );
-	report.data.set( 'loadEventEnd', normalize( getloadEventEnd(), report.start ) );
+	report.data.set( 'domComplete', normalize( getDomComplete(), report.beginning ) );
+	report.data.set( 'loadEventStart', normalize( getLoadEventStart(), report.beginning ) );
+	report.data.set( 'loadEventEnd', normalize( getloadEventEnd(), report.beginning ) );
 	return report;
 };

--- a/packages/browser-data-collector/src/types.d.ts
+++ b/packages/browser-data-collector/src/types.d.ts
@@ -27,9 +27,8 @@ declare type ReportData = Map< string, number | string | boolean >;
 interface Report {
 	id: string;
 	data: ReportData;
-	start: number;
+	beginning: number;
 	end?: number;
-	toJSON: () => object;
 }
 
 declare type Collector = ( report: Report ) => Promise< Report > | Report;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change the implementation of `Reporter` to allow async start collectors. The external API has not changed, so it should be fine.

* Added a new pair of collectors to detect if the tab/window becomes hidden during the duration of the report. This should allow us to filter out unreliable reports because the tab was hidden.

#### Testing instructions

* Load calypso.live and opt-in `rumDataCollection` ab test.
* Go to one of the instrumented pages (/plans, /home, /stats or /read). 
* Refresh the page and find the request to `/logstash` in the network tab. They payload should contain `hidden:false`.
* Refresh the page and while it is loading, switch to another tab and back. The payload should now contain `hidden:true`.
* Refresh the page and minimize the browser while it is loading. The payload should now contain `hidden:true`.
* Repeat the above steps for Chrome, Firefox, Safari and IE.

