### PR TITLE
FSE: Fix 1.7 version number

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -35,7 +35,7 @@ namespace A8C\FSE;
  *
  * @var string
  */
-define( 'PLUGIN_VERSION', '1.6' );
+define( 'PLUGIN_VERSION', '1.7' );
 
 // Always include these helper files for dotcom FSE.
 require_once __DIR__ . '/dotcom-fse/helpers.php';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is a follow up of https://github.com/Automattic/wp-calypso/pull/42895. It fixes a the plugin's version number in the PHP file so it matches the plugin's version.

