### PR TITLE
P2: signup: refactor start/wp-for-teams to start/p2

### DIFF
--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -385,6 +385,10 @@ export function createAccount(
 	},
 	reduxStore
 ) {
+	if ( flowName === 'p2' ) {
+		flowName = 'wp-for-teams';
+	}
+
 	const state = reduxStore.getState();
 
 	const siteVertical = getSiteVertical( state );

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -385,6 +385,7 @@ export function createAccount(
 	},
 	reduxStore
 ) {
+	// See client/signup/config/flows-pure.js p2 flow for more info.
 	if ( flowName === 'p2' ) {
 		flowName = 'wp-for-teams';
 	}

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -250,12 +250,18 @@ export function generateFlows( {
 	}
 
 	if ( isEnabled( 'signup/wpforteams' ) ) {
-		flows.p2 = {
+		flows[ 'wp-for-teams' ] = {
 			steps: [ 'p2-site', 'user' ],
 			destination: ( dependencies ) => `https://${ dependencies.siteSlug }`,
 			description: 'P2 signup flow',
 			lastModified: '2020-06-04',
 		};
+
+		// Original name for the project was "WP for Teams". Since then, we've renamed it to "P2".
+		// However, backend and Marketing is expecting `wp-for-teams` as the `signup_flow_name` var
+		// so we force it in client/lib/signup/step-actions/index.js `createAccount` function.
+		// Keeping both flows for clarity.
+		flows.p2 = { ...flows[ 'wp-for-teams' ] };
 	}
 
 	flows.domain = {

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -250,11 +250,11 @@ export function generateFlows( {
 	}
 
 	if ( isEnabled( 'signup/wpforteams' ) ) {
-		flows[ 'wp-for-teams' ] = {
-			steps: [ 'team-site', 'user' ],
+		flows.p2 = {
+			steps: [ 'p2-site', 'user' ],
 			destination: ( dependencies ) => `https://${ dependencies.siteSlug }`,
-			description: 'WordPress for Teams signup flow',
-			lastModified: '2020-03-23',
+			description: 'P2 signup flow',
+			lastModified: '2020-06-04',
 		};
 	}
 

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -63,14 +63,14 @@ const stepNameToModuleName = {
 	'domains-with-preview': 'domains',
 	'site-title-with-preview': 'site-title',
 	passwordless: 'passwordless',
-	'team-site': 'wp-for-teams-site',
+	'p2-site': 'p2-site',
 	'upsell-plan': 'upsell',
 };
 
 export async function getStepComponent( stepName ) {
 	const moduleName = stepNameToModuleName[ stepName ];
 	const module = await import(
-		/* webpackChunkName: "async-load-signup-steps-[request]", webpackInclude: /signup\/steps\/[a-z-]+\/index.jsx$/ */ `signup/steps/${ moduleName }`
+		/* webpackChunkName: "async-load-signup-steps-[request]", webpackInclude: /signup\/steps\/[0-9a-z-]+\/index.jsx$/ */ `signup/steps/${ moduleName }`
 	);
 	return module.default;
 }

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -644,8 +644,8 @@ export function generateSteps( {
 			unstorableDependencies: [ 'bearer_token' ],
 		},
 
-		'team-site': {
-			stepName: 'team-site',
+		'p2-site': {
+			stepName: 'p2-site',
 			apiRequestFunction: createWpForTeamsSite,
 			providesDependencies: [ 'siteSlug' ],
 		},

--- a/client/signup/steps/p2-site/index.jsx
+++ b/client/signup/steps/p2-site/index.jsx
@@ -29,7 +29,7 @@ import { saveSignupStep, submitSignupStep } from 'state/signup/progress/actions'
  */
 import './style.scss';
 
-const debug = debugFactory( 'calypso:steps:wp-for-teams-site' );
+const debug = debugFactory( 'calypso:steps:p2-site' );
 
 /**
  * Constants
@@ -43,8 +43,8 @@ const ERROR_CODE_MISSING_SITE_TITLE = 123; // Random number, we don't need it.
 let siteUrlsSearched = [],
 	timesValidationFailed = 0;
 
-class WpForTeamsSite extends React.Component {
-	static displayName = 'WpForTeamsSite';
+class P2Site extends React.Component {
+	static displayName = 'P2Site';
 
 	constructor( props ) {
 		super( props );
@@ -191,7 +191,7 @@ class WpForTeamsSite extends React.Component {
 
 	save = () => {
 		this.props.saveSignupStep( {
-			stepName: 'wp-for-teams-site',
+			stepName: 'p2-site',
 			form: this.state.form,
 		} );
 	};
@@ -250,7 +250,7 @@ class WpForTeamsSite extends React.Component {
 			<>
 				<ValidationFieldset
 					errorMessages={ this.getErrorMessagesWithLogin( 'siteTitle' ) }
-					className="wp-for-teams-site__validation-site-title"
+					className="p2-site__validation-site-title"
 				>
 					<FormLabel htmlFor="site-title-input">
 						{ this.props.translate( "What's the name of your team or project?" ) }
@@ -259,7 +259,7 @@ class WpForTeamsSite extends React.Component {
 						id="site-title-input"
 						autoFocus={ true } // eslint-disable-line jsx-a11y/no-autofocus
 						autoCapitalize={ 'off' }
-						className="wp-for-teams-site__site-title"
+						className="p2-site__site-title"
 						disabled={ fieldDisabled }
 						type="text"
 						name="site-title"
@@ -271,7 +271,7 @@ class WpForTeamsSite extends React.Component {
 				</ValidationFieldset>
 				<ValidationFieldset
 					errorMessages={ this.getErrorMessagesWithLogin( 'site' ) }
-					className="wp-for-teams-site__validation-site"
+					className="p2-site__validation-site"
 				>
 					<FormLabel htmlFor="site-address-input">
 						{ this.props.translate( 'Choose a site address' ) }
@@ -279,7 +279,7 @@ class WpForTeamsSite extends React.Component {
 					<FormTextInput
 						id="site-address-input"
 						autoCapitalize={ 'off' }
-						className="wp-for-teams-site__site-url"
+						className="p2-site__site-url"
 						disabled={ fieldDisabled }
 						type="text"
 						name="site"
@@ -289,7 +289,7 @@ class WpForTeamsSite extends React.Component {
 						onBlur={ this.handleBlur }
 						onChange={ this.handleChangeEvent }
 					/>
-					<span className="wp-for-teams-site__wordpress-domain-suffix">.wordpress.com</span>
+					<span className="p2-site__wordpress-domain-suffix">.wordpress.com</span>
 				</ValidationFieldset>
 			</>
 		);
@@ -335,4 +335,4 @@ class WpForTeamsSite extends React.Component {
 	}
 }
 
-export default connect( null, { saveSignupStep, submitSignupStep } )( localize( WpForTeamsSite ) );
+export default connect( null, { saveSignupStep, submitSignupStep } )( localize( P2Site ) );

--- a/client/signup/steps/p2-site/style.scss
+++ b/client/signup/steps/p2-site/style.scss
@@ -1,8 +1,8 @@
-.wp-for-teams-site__site-url.form-text-input {
+.p2-site__site-url.form-text-input {
 	padding-right: 122px;
 }
 
-.wp-for-teams-site__wordpress-domain-suffix {
+.p2-site__wordpress-domain-suffix {
 	color: var( --color-neutral-light );
 	line-height: 40px;
 	margin-left: -122px;
@@ -10,13 +10,13 @@
 	position: absolute;
 }
 
-.wp-for-teams-site__validation-site,
-.wp-for-teams-site__validation-site-title {
+.p2-site__validation-site,
+.p2-site__validation-site-title {
 	.validation-fieldset__validation-message {
 		min-height: 0;
 	}
 }
 
-.wp-for-teams-site__validation-site-title.validation-fieldset {
+.p2-site__validation-site-title.validation-fieldset {
 	margin-bottom: 20px;
 }


### PR DESCRIPTION
Part of introducing the revamped signup flow for the P2 project.

In this PR, we refactor the `start/wp-for-teams` signup flow to `start/p2` to better match the product branding.

## Testing instructions

In an incognito window, navigate to `start/p2`. You should be able to go through the P2 (formerly WP for Teams) signup flow without a problem.