### PR TITLE
composite-checkout: add missing calypso checkout events

### DIFF
--- a/client/lib/analytics/cart.js
+++ b/client/lib/analytics/cart.js
@@ -22,7 +22,7 @@ function removeNestedProperties( cartItem ) {
 	return omit( cartItem, [ 'extra' ] );
 }
 
-function recordAddEvent( cartItem ) {
+export function recordAddEvent( cartItem ) {
 	recordTracksEvent( 'calypso_cart_product_add', removeNestedProperties( cartItem ) );
 	recordAddToCart( { cartItem } );
 }

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -499,6 +499,7 @@ export default function CompositeCheckout( {
 	useRecordCheckoutLoaded(
 		recordEvent,
 		isApplePayAvailable,
+		isApplePayLoading,
 		responseCart,
 		storedCards,
 		isLoadingStoredCards,
@@ -634,13 +635,14 @@ function useCountryList( overrideCountryList ) {
 function useRecordCheckoutLoaded(
 	recordEvent,
 	isApplePayAvailable,
+	isApplePayLoading,
 	responseCart,
 	storedCards,
 	isLoadingStoredCards,
 	product
 ) {
 	const hasRecordedCheckoutLoad = useRef( false );
-	if ( ! isLoadingStoredCards && ! hasRecordedCheckoutLoad.current ) {
+	if ( ! isLoadingStoredCards && ! isApplePayLoading && ! hasRecordedCheckoutLoad.current ) {
 		debug( 'composite checkout has loaded' );
 		recordEvent( {
 			type: 'CHECKOUT_LOADED',

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -3,7 +3,7 @@
  */
 import page from 'page';
 import wp from 'lib/wp';
-import React, { useEffect, useState, useCallback, useMemo } from 'react';
+import React, { useEffect, useState, useCallback, useMemo, useRef } from 'react';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -496,18 +496,14 @@ export default function CompositeCheckout( {
 		[ couponItem, getThankYouUrl ]
 	);
 
-	useEffect( () => {
-		debug( 'composite checkout has loaded' );
-		recordEvent( {
-			type: 'CHECKOUT_LOADED',
-			payload: {
-				saved_cards: 0, // TODO: get this
-				apple_pay_available: isApplePayAvailable,
-				product_slug: product,
-				is_renewal: hasRenewalItem( responseCart ),
-			},
-		} );
-	}, [ recordEvent ] );
+	useRecordCheckoutLoaded(
+		recordEvent,
+		isApplePayAvailable,
+		responseCart,
+		storedCards,
+		isLoadingStoredCards,
+		product
+	);
 
 	return (
 		<React.Fragment>
@@ -633,6 +629,30 @@ function useCountryList( overrideCountryList ) {
 	}, [ shouldFetchList, isListFetched, globalCountryList, reduxDispatch ] );
 
 	return countriesList;
+}
+
+function useRecordCheckoutLoaded(
+	recordEvent,
+	isApplePayAvailable,
+	responseCart,
+	storedCards,
+	isLoadingStoredCards,
+	product
+) {
+	const hasRecordedCheckoutLoad = useRef( false );
+	if ( ! isLoadingStoredCards && ! hasRecordedCheckoutLoad.current ) {
+		debug( 'composite checkout has loaded' );
+		recordEvent( {
+			type: 'CHECKOUT_LOADED',
+			payload: {
+				saved_cards: storedCards.length,
+				apple_pay_available: isApplePayAvailable,
+				product_slug: product,
+				is_renewal: hasRenewalItem( responseCart ),
+			},
+		} );
+		hasRecordedCheckoutLoad.current = true;
+	}
 }
 
 function CountrySelectMenu( {

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -138,11 +138,6 @@ export default function CompositeCheckout( {
 	const reduxDispatch = useDispatch();
 	const recordEvent = useCallback( createAnalyticsEventHandler( reduxDispatch ), [] );
 
-	useEffect( () => {
-		debug( 'composite checkout has loaded' );
-		recordEvent( { type: 'CHECKOUT_LOADED' } );
-	}, [ recordEvent ] );
-
 	const showErrorMessage = useCallback(
 		( error ) => {
 			debug( 'error', error );
@@ -500,6 +495,19 @@ export default function CompositeCheckout( {
 		} ),
 		[ couponItem, getThankYouUrl ]
 	);
+
+	useEffect( () => {
+		debug( 'composite checkout has loaded' );
+		recordEvent( {
+			type: 'CHECKOUT_LOADED',
+			payload: {
+				saved_cards: 0, // TODO: get this
+				apple_pay_available: isApplePayAvailable,
+				product_slug: product,
+				is_renewal: hasRenewalItem( responseCart ),
+			},
+		} );
+	}, [ recordEvent ] );
 
 	return (
 		<React.Fragment>

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -498,6 +498,7 @@ export default function CompositeCheckout( {
 
 	useRecordCheckoutLoaded(
 		recordEvent,
+		isLoadingCart,
 		isApplePayAvailable,
 		isApplePayLoading,
 		responseCart,
@@ -634,6 +635,7 @@ function useCountryList( overrideCountryList ) {
 
 function useRecordCheckoutLoaded(
 	recordEvent,
+	isLoadingCart,
 	isApplePayAvailable,
 	isApplePayLoading,
 	responseCart,
@@ -642,7 +644,12 @@ function useRecordCheckoutLoaded(
 	product
 ) {
 	const hasRecordedCheckoutLoad = useRef( false );
-	if ( ! isLoadingStoredCards && ! isApplePayLoading && ! hasRecordedCheckoutLoad.current ) {
+	if (
+		! isLoadingCart &&
+		! isLoadingStoredCards &&
+		! isApplePayLoading &&
+		! hasRecordedCheckoutLoad.current
+	) {
 		debug( 'composite checkout has loaded' );
 		recordEvent( {
 			type: 'CHECKOUT_LOADED',

--- a/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
@@ -17,7 +17,7 @@ import {
 
 const debug = debugFactory( 'calypso:composite-checkout:payment-method-helpers' );
 
-export function useStoredCards( getStoredCards ) {
+export function useStoredCards( getStoredCards, onEvent ) {
 	const [ state, dispatch ] = useReducer( storedCardsReducer, {
 		storedCards: [],
 		isLoading: true,
@@ -30,13 +30,19 @@ export function useStoredCards( getStoredCards ) {
 		}
 
 		// TODO: handle errors
-		fetchStoredCards().then( ( cards ) => {
-			debug( 'stored cards fetched', cards );
-			isSubscribed && dispatch( { type: 'FETCH_END', payload: cards } );
-		} );
+		fetchStoredCards()
+			.then( ( cards ) => {
+				debug( 'stored cards fetched', cards );
+				isSubscribed && dispatch( { type: 'FETCH_END', payload: cards } );
+			} )
+			.catch( ( error ) => {
+				debug( 'stored cards failed to load', error );
+				onEvent( { type: 'STORED_CARD_ERROR', payload: error.message } );
+				isSubscribed && dispatch( { type: 'FETCH_END', payload: [] } );
+			} );
 
 		return () => ( isSubscribed = false );
-	}, [ getStoredCards ] );
+	}, [ getStoredCards, onEvent ] );
 	return state;
 }
 

--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -22,6 +22,16 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 		debug( 'heard checkout event', action );
 		switch ( action.type ) {
 			case 'CHECKOUT_LOADED':
+				reduxDispatch(
+					recordTracksEvent( 'calypso_checkout_page_view', {
+						saved_cards: [],
+						is_renewal: action.payload?.is_renewal,
+						apple_pay_available: null,
+						product_slug: action.payload?.product_slug,
+						is_composite: true,
+					} )
+				);
+
 				return reduxDispatch( recordTracksEvent( 'calypso_checkout_composite_loaded', {} ) );
 
 			case 'PAYMENT_COMPLETE': {

--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -24,9 +24,9 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 			case 'CHECKOUT_LOADED':
 				reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_page_view', {
-						saved_cards: [],
+						saved_cards: action.payload?.saved_cards,
 						is_renewal: action.payload?.is_renewal,
-						apple_pay_available: null,
+						apple_pay_available: action.payload?.apple_pay_available,
 						product_slug: action.payload?.product_slug,
 						is_composite: true,
 					} )

--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -5,6 +5,7 @@ import debugFactory from 'debug';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { translateCheckoutPaymentMethodToWpcomPaymentMethod } from 'my-sites/checkout/composite-checkout/wpcom';
 import { defaultRegistry } from '@automattic/composite-checkout';
+import { snakeCase, startsWith } from 'lodash';
 
 /**
  * Internal dependencies
@@ -102,6 +103,27 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 					recordTracksEvent( 'calypso_checkout_composite_payment_method_load_error', {
 						error_message: String( action.payload ),
 					} )
+				);
+
+			case 'PAYMENT_METHOD_SELECT':
+				reduxDispatch( logStashEventAction( 'payment_method_select', String( action.payload ) ) );
+
+				// Need to convert to the slug format used in old checkout so events are comparable
+				const rawPaymentMethodSlug = String( action.payload ); // eslint-disable-line no-case-declarations
+				let legacyPaymentMethodSlug = ''; // eslint-disable-line no-case-declarations
+				if (
+					rawPaymentMethodSlug === 'card' ||
+					startsWith( rawPaymentMethodSlug, 'existingCard' )
+				) {
+					legacyPaymentMethodSlug = 'credit_card';
+				} else if ( rawPaymentMethodSlug === 'apple-pay' ) {
+					legacyPaymentMethodSlug = 'web_payment';
+				} else {
+					legacyPaymentMethodSlug = snakeCase( String( action.payload ) );
+				}
+
+				return reduxDispatch(
+					recordTracksEvent( 'calypso_checkout_switch_to_' + legacyPaymentMethodSlug )
 				);
 
 			case 'PAGE_LOAD_ERROR':

--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -11,6 +11,7 @@ import { snakeCase } from 'lodash';
  * Internal dependencies
  */
 import { recordPurchase } from 'lib/analytics/record-purchase';
+import { recordAddEvent } from 'lib/analytics/cart';
 import { logToLogstash } from 'state/logstash/actions';
 import config from 'config';
 
@@ -371,6 +372,10 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 				return reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_composite_summary_help_click' )
 				);
+			}
+
+			case 'CART_ADD_ITEM': {
+				return reduxDispatch( recordAddEvent( action.payload ) );
 			}
 
 			default:

--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -384,7 +384,7 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 			}
 
 			case 'CART_ADD_ITEM': {
-				return reduxDispatch( recordAddEvent( action.payload ) );
+				return recordAddEvent( action.payload );
 			}
 
 			default:

--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -123,7 +123,7 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 				let legacyPaymentMethodSlug = ''; // eslint-disable-line no-case-declarations
 				if (
 					rawPaymentMethodSlug === 'card' ||
-					startsWith( rawPaymentMethodSlug, 'existingCard' )
+				rawPaymentMethodSlug.startsWith( 'existingCard' )
 				) {
 					legacyPaymentMethodSlug = 'credit_card';
 				} else if ( rawPaymentMethodSlug === 'apple-pay' ) {

--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -5,7 +5,7 @@ import debugFactory from 'debug';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { translateCheckoutPaymentMethodToWpcomPaymentMethod } from 'my-sites/checkout/composite-checkout/wpcom';
 import { defaultRegistry } from '@automattic/composite-checkout';
-import { snakeCase, startsWith } from 'lodash';
+import { snakeCase } from 'lodash';
 
 /**
  * Internal dependencies
@@ -115,15 +115,15 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 					} )
 				);
 
-			case 'PAYMENT_METHOD_SELECT':
+			case 'PAYMENT_METHOD_SELECT': {
 				reduxDispatch( logStashEventAction( 'payment_method_select', String( action.payload ) ) );
 
 				// Need to convert to the slug format used in old checkout so events are comparable
-				const rawPaymentMethodSlug = String( action.payload ); // eslint-disable-line no-case-declarations
-				let legacyPaymentMethodSlug = ''; // eslint-disable-line no-case-declarations
+				const rawPaymentMethodSlug = String( action.payload );
+				let legacyPaymentMethodSlug = '';
 				if (
 					rawPaymentMethodSlug === 'card' ||
-				rawPaymentMethodSlug.startsWith( 'existingCard' )
+					rawPaymentMethodSlug.startsWith( 'existingCard' )
 				) {
 					legacyPaymentMethodSlug = 'credit_card';
 				} else if ( rawPaymentMethodSlug === 'apple-pay' ) {
@@ -135,6 +135,7 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 				return reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_switch_to_' + legacyPaymentMethodSlug )
 				);
+			}
 
 			case 'PAGE_LOAD_ERROR':
 				reduxDispatch( logStashEventAction( 'page_load', String( action.payload ) ) );

--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -129,7 +129,7 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 				} else if ( rawPaymentMethodSlug === 'apple-pay' ) {
 					legacyPaymentMethodSlug = 'web_payment';
 				} else {
-					legacyPaymentMethodSlug = snakeCase( String( action.payload ) );
+					legacyPaymentMethodSlug = snakeCase( rawPaymentMethodSlug );
 				}
 
 				return reduxDispatch(

--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -406,7 +406,7 @@ function logStashEventAction( type, payload, additionalData = {}, message ) {
 		extra: {
 			env: config( 'env_id' ),
 			type,
-			payload,
+			message: payload,
 			...additionalData,
 		},
 	} );

--- a/client/my-sites/checkout/composite-checkout/wpcom/hooks/use-shopping-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/hooks/use-shopping-cart.ts
@@ -552,10 +552,13 @@ function useInitializeCartFromServer(
 					);
 					let responseCart = convertRawResponseCartToResponseCart( response );
 					if ( productsToAdd?.length ) {
-						responseCart = productsToAdd.reduce(
-							( updatedCart, productToAdd ) => addItemToResponseCart( updatedCart, productToAdd ),
-							responseCart
-						);
+						responseCart = productsToAdd.reduce( ( updatedCart, productToAdd ) => {
+							onEvent?.( {
+								type: 'CART_ADD_ITEM',
+								payload: productToAdd,
+							} );
+							return addItemToResponseCart( updatedCart, productToAdd );
+						}, responseCart );
 					}
 					if ( couponToAdd ) {
 						responseCart = addCouponToResponseCart( responseCart, couponToAdd );

--- a/client/my-sites/checkout/composite-checkout/wpcom/hooks/use-shopping-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/hooks/use-shopping-cart.ts
@@ -454,6 +454,10 @@ export function useShoppingCart(
 	const addItem: ( arg0: RequestCartProduct ) => void = useCallback(
 		( requestCartProductToAdd ) => {
 			hookDispatch( { type: 'ADD_CART_ITEM', requestCartProductToAdd } );
+			onEvent?.( {
+				type: 'CART_ADD_ITEM',
+				payload: requestCartProductToAdd,
+			} );
 		},
 		[]
 	);

--- a/client/my-sites/checkout/composite-checkout/wpcom/index.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/index.js
@@ -10,6 +10,7 @@ import { areDomainsInLineItems } from './hooks/has-domains';
 import {
 	prepareDomainContactDetails,
 	translateCheckoutPaymentMethodToWpcomPaymentMethod,
+	translateCheckoutPaymentMethodToTracksPaymentMethod,
 	emptyManagedContactDetails,
 	applyContactDetailsRequiredMask,
 	domainRequiredContactDetails,
@@ -30,6 +31,7 @@ export {
 	prepareDomainContactDetails,
 	getNonProductWPCOMCartItemTypes,
 	translateCheckoutPaymentMethodToWpcomPaymentMethod,
+	translateCheckoutPaymentMethodToTracksPaymentMethod,
 	emptyManagedContactDetails,
 	applyContactDetailsRequiredMask,
 	domainRequiredContactDetails,

--- a/client/my-sites/checkout/composite-checkout/wpcom/types.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/types.ts
@@ -5,7 +5,10 @@
 /**
  * Internal dependencies
  */
-import type { CheckoutPaymentMethodSlug } from './types/checkout-payment-method-slug';
+import type {
+	CheckoutPaymentMethodSlug,
+	translateCheckoutPaymentMethodToTracksPaymentMethod,
+} from './types/checkout-payment-method-slug';
 import type { WPCOMPaymentMethodClass } from './types/backend/payment-method';
 import {
 	readWPCOMPaymentMethodClass,
@@ -70,6 +73,7 @@ import {
 
 export type {
 	CheckoutPaymentMethodSlug,
+	translateCheckoutPaymentMethodToTracksPaymentMethod,
 	WPCOMPaymentMethodClass,
 	RequestCart,
 	RequestCartProduct,

--- a/client/my-sites/checkout/composite-checkout/wpcom/types.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/types.ts
@@ -5,10 +5,8 @@
 /**
  * Internal dependencies
  */
-import type {
-	CheckoutPaymentMethodSlug,
-	translateCheckoutPaymentMethodToTracksPaymentMethod,
-} from './types/checkout-payment-method-slug';
+import type { CheckoutPaymentMethodSlug } from './types/checkout-payment-method-slug';
+import { translateCheckoutPaymentMethodToTracksPaymentMethod } from './types/checkout-payment-method-slug';
 import type { WPCOMPaymentMethodClass } from './types/backend/payment-method';
 import {
 	readWPCOMPaymentMethodClass,
@@ -73,7 +71,6 @@ import {
 
 export type {
 	CheckoutPaymentMethodSlug,
-	translateCheckoutPaymentMethodToTracksPaymentMethod,
 	WPCOMPaymentMethodClass,
 	RequestCart,
 	RequestCartProduct,
@@ -98,6 +95,7 @@ export {
 	readWPCOMPaymentMethodClass,
 	translateWpcomPaymentMethodToCheckoutPaymentMethod,
 	translateCheckoutPaymentMethodToWpcomPaymentMethod,
+	translateCheckoutPaymentMethodToTracksPaymentMethod,
 	emptyResponseCart,
 	convertResponseCartToRequestCart,
 	removeItemFromResponseCart,

--- a/client/my-sites/checkout/composite-checkout/wpcom/types/checkout-payment-method-slug.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/types/checkout-payment-method-slug.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { snakeCase } from 'lodash';
+
+/**
  * Payment method slugs as expected by composite-checkout.
  * If the composite-checkout package used typescript, this
  * would belong there.
@@ -21,3 +26,19 @@ export type CheckoutPaymentMethodSlug =
 	| 'full-credits'
 	| 'stripe-three-d-secure'
 	| 'wechat';
+
+export function translateCheckoutPaymentMethodToTracksPaymentMethod(
+	paymentMethod: CheckoutPaymentMethodSlug
+): string {
+	// existing cards have unique paymentMethodIds
+	if ( paymentMethod.startsWith( 'existingCard' ) ) {
+		paymentMethod = 'credit_card';
+	}
+	switch ( paymentMethod ) {
+		case 'card':
+			return 'credit_card';
+		case 'apple-pay':
+			return 'web_payment';
+	}
+	return snakeCase( paymentMethod );
+}

--- a/packages/composite-checkout/src/components/checkout-payment-methods.js
+++ b/packages/composite-checkout/src/components/checkout-payment-methods.js
@@ -38,6 +38,7 @@ export default function CheckoutPaymentMethods( { summary, isComplete, className
 	const [ , setPaymentMethod ] = usePaymentMethodId();
 	const onClickPaymentMethod = ( newMethod ) => {
 		debug( 'setting payment method to', newMethod );
+		onEvent( { type: 'PAYMENT_METHOD_SELECT', payload: newMethod } );
 		setPaymentMethod( newMethod );
 	};
 	const paymentMethods = useAllPaymentMethods();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Includes three additional events from old checkout in composite checkout:

- `calypso_checkout_switch_to_{payment_method}`, which fires when the user selects a different payment method
- `calypso_checkout_page_view`, which fires exactly once, simultaneously with the `CHECKOUT_LOADED` event
- `calypso_cart_product_add`, which fires simultaneously with the `ADD_CART_ITEM` event

#### Testing instructions

We need to verify that these events are recorded correctly to tracks. The relevant behavior is triggered by:
- Entering composite checkout, for `calypso_checkout_page_view`
- Switching between several different payment methods, for `calypso_checkout_switch_to_{payment_method}`. Also need to check that the payment method slugs here agree with those used in old checkout
- Entering checkout with a product added in the URL, for `calypso_cart_product_add`
