### PR TITLE
Revert "My Home: Try updating card mapping for Support card"

### DIFF
--- a/client/my-sites/customer-home/cards/constants.js
+++ b/client/my-sites/customer-home/cards/constants.js
@@ -7,6 +7,7 @@ export const FEATURE_GO_MOBILE = 'home-feature-go-mobile';
 export const FEATURE_QUICK_START = 'home-feature-quick-start';
 export const FEATURE_STATS = 'home-feature-stats';
 export const FEATURE_SUPPORT = 'home-feature-support';
+export const FEATURE_HELP_SEARCH = 'home-feature-help-search';
 export const NOTICE_CELEBRATE_SITE_CREATION = 'home-notice-celebrate-site-creation';
 export const NOTICE_CELEBRATE_SITE_LAUNCH = 'home-notice-celebrate-site-launch';
 export const NOTICE_CELEBRATE_SITE_MIGRATION = 'home-notice-celebrate-site-migration';

--- a/client/my-sites/customer-home/locations/tertiary/manage-site/index.jsx
+++ b/client/my-sites/customer-home/locations/tertiary/manage-site/index.jsx
@@ -9,6 +9,7 @@ import { useTranslate } from 'i18n-calypso';
  * Internal dependencies
  */
 import GoMobile from 'my-sites/customer-home/cards/features/go-mobile';
+import Support from 'my-sites/customer-home/cards/features/support';
 import QuickStart from 'my-sites/customer-home/cards/features/quick-start';
 import QuickLinks from 'my-sites/customer-home/cards/actions/quick-links';
 import HelpSearch from 'my-sites/customer-home/cards/features/help-search';
@@ -21,11 +22,13 @@ import {
 	FEATURE_GO_MOBILE,
 	FEATURE_QUICK_START,
 	FEATURE_SUPPORT,
+	FEATURE_HELP_SEARCH,
 } from 'my-sites/customer-home/cards/constants';
 
 const cardComponents = {
 	[ FEATURE_GO_MOBILE ]: GoMobile,
-	[ FEATURE_SUPPORT ]: HelpSearch,
+	[ FEATURE_SUPPORT ]: Support,
+	[ FEATURE_HELP_SEARCH ]: HelpSearch,
 	[ ACTION_QUICK_LINKS ]: QuickLinks,
 	[ FEATURE_QUICK_START ]: QuickStart,
 	[ ACTION_WP_FOR_TEAMS_QUICK_LINKS ]: WpForTeamsQuickLinks,


### PR DESCRIPTION
The new Support Card feature opens a websocket connection to Happy Chat on a very prominent page. As a result, Happy Chat's connection volume has spiked well beyond tested levels and the system is unstable and crashing.

<img width="1164" alt="Screen Shot 2020-06-04 at 12 45 36 PM" src="https://user-images.githubusercontent.com/518059/83793560-57e73f00-a662-11ea-82c7-e28caf9fb726.png">

After a revert, we can look together at how we can implement this feature without impacting Happy Chat like this.