### PR TITLE
Help Search: Don't query for available support types

### DIFF
--- a/client/my-sites/customer-home/cards/constants.js
+++ b/client/my-sites/customer-home/cards/constants.js
@@ -7,7 +7,6 @@ export const FEATURE_GO_MOBILE = 'home-feature-go-mobile';
 export const FEATURE_QUICK_START = 'home-feature-quick-start';
 export const FEATURE_STATS = 'home-feature-stats';
 export const FEATURE_SUPPORT = 'home-feature-support';
-export const FEATURE_HELP_SEARCH = 'home-feature-help-search';
 export const NOTICE_CELEBRATE_SITE_CREATION = 'home-notice-celebrate-site-creation';
 export const NOTICE_CELEBRATE_SITE_LAUNCH = 'home-notice-celebrate-site-launch';
 export const NOTICE_CELEBRATE_SITE_MIGRATION = 'home-notice-celebrate-site-migration';

--- a/client/my-sites/customer-home/cards/features/help-search/index.jsx
+++ b/client/my-sites/customer-home/cards/features/help-search/index.jsx
@@ -19,7 +19,6 @@ import { openSupportArticleDialog } from 'state/inline-support-article/actions';
 import HelpSearchCard from './search-card';
 import HelpSearchResults from './search-results';
 
-import QuerySupportTypes from 'blocks/inline-help/inline-help-query-support-types';
 import { RESULT_POST_ID, RESULT_LINK } from 'blocks/inline-help/constants';
 
 /**
@@ -63,7 +62,6 @@ const HelpSearch = ( props ) => {
 
 	return (
 		<>
-			<QuerySupportTypes />
 			<Card className="help-search">
 				<div className="help-search__inner">
 					<CardHeading>{ translate( 'Get help' ) }</CardHeading>

--- a/client/my-sites/customer-home/locations/tertiary/manage-site/index.jsx
+++ b/client/my-sites/customer-home/locations/tertiary/manage-site/index.jsx
@@ -9,7 +9,6 @@ import { useTranslate } from 'i18n-calypso';
  * Internal dependencies
  */
 import GoMobile from 'my-sites/customer-home/cards/features/go-mobile';
-import Support from 'my-sites/customer-home/cards/features/support';
 import QuickStart from 'my-sites/customer-home/cards/features/quick-start';
 import QuickLinks from 'my-sites/customer-home/cards/actions/quick-links';
 import HelpSearch from 'my-sites/customer-home/cards/features/help-search';
@@ -22,13 +21,11 @@ import {
 	FEATURE_GO_MOBILE,
 	FEATURE_QUICK_START,
 	FEATURE_SUPPORT,
-	FEATURE_HELP_SEARCH,
 } from 'my-sites/customer-home/cards/constants';
 
 const cardComponents = {
 	[ FEATURE_GO_MOBILE ]: GoMobile,
-	[ FEATURE_SUPPORT ]: Support,
-	[ FEATURE_HELP_SEARCH ]: HelpSearch,
+	[ FEATURE_SUPPORT ]: HelpSearch,
 	[ ACTION_QUICK_LINKS ]: QuickLinks,
 	[ FEATURE_QUICK_START ]: QuickStart,
 	[ ACTION_WP_FOR_TEAMS_QUICK_LINKS ]: WpForTeamsQuickLinks,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Removes a Query component that I think isn't necessary. It looks like it was mistakenly held over from [the Inline Help component](https://github.com/Automattic/wp-calypso/blob/master/client/blocks/inline-help/popover.jsx#L169) this card was based on.

That `< QuerySupportTypes />` component is necessary in the Inline Help widget because it prepares the contact form by running a few API calls and loading some assets — e.g. it opens a Happy Chat connection to see if Chat is available, pulls in Directly JS/CSS so that's ready to go... But from what I can tell, this new Help Search card doesn't offer any direct access to the Contact form, it simply links to the Help page. So it doesn't need to make any of those API calls.

This change is necessary because Happy Chat is not set up to handle a ton of idle connections, so adding a connection on such a prominent page caused the system to spike and start crashing.

<img width="1180" alt="Screen Shot 2020-06-04 at 2 23 02 PM" src="https://user-images.githubusercontent.com/518059/83801720-40628300-a66f-11ea-9680-ead42e71ea20.png">

(I'll add that this Happy Chat limitation is completely non-obvious so it's 100% understandable that it was missed in pre-deploy checks. Ideally the system would be efficient and resilient enough to handle this kind of load, but it just isn't right now. **For reference, the general rule should be that we don't open a connection to Happy Chat unless there's a good chance the customer will actually use it.** :tmyk:)

[The Help Search card was deployed here](https://github.com/Automattic/wp-calypso/pull/42752) and [I reverted it in this PR](https://github.com/Automattic/wp-calypso/pull/42992). After this change, we should be good to deploy it again 🙌 

#### Testing instructions

Along with generally making sure the Help Search card still does everything it's supposed to, here's how to validate the Happy Chat fix:

##### Verify the bug
In `master`, ensure that the card appears by changing [this line](https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/customer-home/locations/tertiary/manage-site/index.jsx#L30) to:
```
[ FEATURE_SUPPORT ]: HelpSearch,
```
Then go to http://calypso.localhost:3000/home, pick a site, and check that this Help Search card shows. Open the Network inspector and look for a websocket connection to `https://happychat-io-staging.go-vip.co/customer`. This indicates that you've made a connection to Happy Chat.

##### Verify the fix
In this branch (`update/remove-support-query-from-help-search`) 

~~do the same, change [this line](https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/customer-home/locations/tertiary/manage-site/index.jsx#L30) to:~~ Now handled in the PR itself.

Go to http://calypso.localhost:3000/home, pick a site, and check that this Help Search card shows. 

Open the Network inspector and look for a **websocket** (`WS`) connection to `https://happychat-io-staging.go-vip.co/customer`. 

You _**shouldn't**_ see one!

---

/cc @mmtr @frontdevde @getdave @gwwar @retrofox (sorry for the mass ping, not 100% sure who owns this and needs to see this but you all were involved in previous related PRs)

/cc @Automattic/lighthouse I'm not sure there's much followup for you to do here, but worth grokking what happened and how to diagnose for future possible instances.