### PR TITLE
Gutenboarding: update default plan pre-selection

### DIFF
--- a/client/landing/gutenboarding/components/plans-button/index.tsx
+++ b/client/landing/gutenboarding/components/plans-button/index.tsx
@@ -4,7 +4,6 @@
 import * as React from 'react';
 import { Button } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
-import { useSelect } from '@wordpress/data';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@automattic/react-i18n';
 import classnames from 'classnames';
@@ -16,7 +15,6 @@ import JetpackLogo from 'components/jetpack-logo'; // @TODO: extract to @automat
 import PlansModal from '../plans-modal';
 import { useSelectedPlan } from '../../hooks/use-selected-plan';
 import { useCurrentStep, Step } from '../../path';
-import { PLANS_STORE } from '../../stores/plans';
 
 /**
  * Style dependencies
@@ -25,7 +23,6 @@ import './style.scss';
 
 const PlansButton: React.FunctionComponent< Button.ButtonProps > = ( { ...buttonProps } ) => {
 	const { __ } = useI18n();
-	const selectedPlan = useSelect( ( select ) => select( PLANS_STORE ).getSelectedPlan() );
 	const currentStep = useCurrentStep();
 
 	// mobile first to match SCSS media query https://github.com/Automattic/wp-calypso/pull/41471#discussion_r415678275
@@ -41,11 +38,9 @@ const PlansButton: React.FunctionComponent< Button.ButtonProps > = ( { ...button
 	// This accounts for plans that may come from e.g. selecting a domain or adding a plan via URL
 	const plan = useSelectedPlan();
 
-	const isPlanUserSelectedOrPaid = selectedPlan || ! plan?.isFree;
-
-	const planLabel = isPlanUserSelectedOrPaid
+	const planLabel = plan
 		? /* translators: Button label where %s is the WordPress.com plan name (eg: Personal, Premium, Business) */
-		  sprintf( __( '%s Plan' ), plan?.title )
+		  sprintf( __( '%s Plan' ), plan.title )
 		: __( 'View plans' );
 
 	return (
@@ -54,7 +49,7 @@ const PlansButton: React.FunctionComponent< Button.ButtonProps > = ( { ...button
 				onClick={ handleButtonClick }
 				label={ __( planLabel ) }
 				disabled={ Step[ currentStep ] === 'plans' }
-				className={ classnames( 'plans-button', { 'is-highlighted': isPlanUserSelectedOrPaid } ) }
+				className={ classnames( 'plans-button', { 'is-highlighted': !! plan } ) }
 				{ ...buttonProps }
 			>
 				{ isDesktop && planLabel }

--- a/client/landing/gutenboarding/components/plans-modal/index.tsx
+++ b/client/landing/gutenboarding/components/plans-modal/index.tsx
@@ -65,7 +65,7 @@ const PlansGridModal: React.FunctionComponent< Props > = ( { onClose } ) => {
 			</div>
 			<ActionButtons
 				primaryButton={
-					<Button isPrimary onClick={ handleConfirm }>
+					<Button isPrimary disabled={ ! plan } onClick={ handleConfirm }>
 						{ __( 'Confirm' ) }
 					</Button>
 				}

--- a/client/landing/gutenboarding/onboarding-block/plans/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/plans/index.tsx
@@ -70,6 +70,7 @@ export default function PlansStep() {
 				primaryButton={
 					<Button
 						isPrimary
+						disabled={ ! plan }
 						onClick={ () => {
 							currentUser ? handleCreateSite( currentUser.username ) : setShowSignupDialog( true );
 						} }

--- a/packages/data-stores/src/plans/selectors.ts
+++ b/packages/data-stores/src/plans/selectors.ts
@@ -3,7 +3,7 @@
  */
 import type { State } from './reducer';
 import { planDetails, PLANS_LIST } from './plans-data';
-import { DEFAULT_PAID_PLAN, PLAN_FREE, PLAN_ECOMMERCE } from './constants';
+import { DEFAULT_PAID_PLAN, PLAN_ECOMMERCE } from './constants';
 import type { PlanSlug } from './types';
 
 function getPlan( slug: PlanSlug ) {
@@ -14,7 +14,7 @@ export const getSelectedPlan = ( state: State ) =>
 	state.selectedPlanSlug ? getPlan( state.selectedPlanSlug ) : null;
 
 export const getDefaultPlan = ( _: State, hasPaidDomain: boolean, hasPaidDesign: boolean ) =>
-	hasPaidDomain || hasPaidDesign ? getPlan( DEFAULT_PAID_PLAN ) : getPlan( PLAN_FREE );
+	hasPaidDomain || hasPaidDesign ? getPlan( DEFAULT_PAID_PLAN ) : undefined;
 
 export const getSupportedPlans = ( state: State ) => state.supportedPlanSlugs.map( getPlan );
 

--- a/packages/plans-grid/src/plans-grid/index.tsx
+++ b/packages/plans-grid/src/plans-grid/index.tsx
@@ -28,7 +28,7 @@ const isMobile = window.navigator.userAgent.indexOf( 'Mobi' ) > -1;
 
 export interface Props {
 	header: React.ReactElement;
-	currentPlan: Plans.Plan;
+	currentPlan?: Plans.Plan;
 }
 
 const PlansGrid: React.FunctionComponent< Props > = ( { header, currentPlan } ) => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Without having a selected or implicit (because of paid domain/design selection) plan, when top-right _View plans_ button label is visible, PlansGrid shouldn't have any preselected column.

#### Testing instructions
* Go to [/new](https://calypso.live/new?branch=update/plans-grid-remove-default-selection) with an empty state.
* Open Plans Grid (by using Plans Button or by advancing to Plans Step).
* No plan should be selected and Confirm/Continue button should be disabled.
* Plan selection, checkout and analytics should work as before.

#### Screenshot
<img width="1319" alt="Screenshot 2020-06-04 at 22 26 37" src="https://user-images.githubusercontent.com/14192054/83803000-737b3580-a6b4-11ea-9a43-43cf27c82938.png">


Fixes #42328
