### PR TITLE
FSE: Fix typo in contributor usernames

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/readme.txt
+++ b/apps/full-site-editing/full-site-editing-plugin/readme.txt
@@ -1,5 +1,5 @@
 === Full Site Editing ===
-Contributors: alexislloyd, allancole, automattic, bartkalisz, codebykat, copons, dmsnell, get_dave, glendaviesnz, gwwar, iamtakashi, jeryj, Joen, jonsurrell, kwight, marekhrabe, mattwiebe, mkaz, mmtr86, mppfeiffer, noahtallen, nrqsnchz, nosolosw, obenland, okenobi, owolski, themeshaper, vindl
+Contributors: alexislloyd, allancole, automattic, bartkalisz, codebykat, copons, dmsnell, get_dave, glendaviesnz, gwwar, iamtakashi, jeryj, Joen, jonsurrell, kwight, marekhrabe, mattwiebe, mkaz, mmtr86, mppfeiffer, noahtallen, nrqsnchz, nosolosw, obenland, okenobi, owolski, iandstewart, vindl
 Tags: block, blocks, editor, gutenberg, page
 Requires at least: 5.0
 Tested up to: 5.4


### PR DESCRIPTION
This PR just fixes a typo for my username in the FSE Plugin. I'm iandstewart in core. :)
