### PR TITLE
State: Add transient media items reducer

### DIFF
--- a/client/state/media/test/reducer.js
+++ b/client/state/media/test/reducer.js
@@ -13,6 +13,7 @@ import reducer, {
 	queryRequests,
 	mediaItemRequests,
 	selectedItems,
+	transientItems,
 } from '../reducer';
 import MediaQueryManager from 'lib/query-manager/media';
 import {

--- a/client/state/media/utils/test/transientItems.js
+++ b/client/state/media/utils/test/transientItems.js
@@ -1,0 +1,83 @@
+/**
+ * Internal dependencies
+ */
+import { transformSite } from '../transientItems';
+
+describe( 'transientItems utils', () => {
+	describe( 'transformSite', () => {
+		const site1State = Object.freeze( {
+			transientItems: Symbol( 'site 1 transientItems' ),
+			transientIdsToServerIds: Symbol( 'site 1 transientIdsToServerIds' ),
+		} );
+		const site2State = Symbol( 'site 2 state' );
+
+		let state;
+		beforeEach( () => {
+			state = {
+				1: site1State,
+				2: site2State,
+			};
+		} );
+
+		test( 'should preserve other sites', () => {
+			const site1NextState = Symbol( 'site 1 next state' );
+			const result = transformSite( state, 1, () => site1NextState );
+
+			// assert only site 1 state changed and site 2 was preserved
+			expect( result ).toEqual( {
+				1: site1NextState,
+				2: site2State,
+			} );
+		} );
+
+		test( 'should map the state using the mapping fn', () => {
+			const map = jest.fn();
+			transformSite( state, 1, map );
+
+			expect( map ).toHaveBeenCalledWith( site1State );
+		} );
+
+		test( 'should handle non-existant site by passing safe defaults ', () => {
+			const map = jest.fn( () => site1State );
+			const result = transformSite( { 2: site2State }, 1, map );
+
+			expect( map ).toHaveBeenCalledWith( {
+				transientItems: {},
+				transientIdsToServerIds: {},
+			} );
+
+			expect( result ).toEqual( {
+				1: {
+					transientItems: site1State.transientItems,
+					transientIdsToServerIds: site1State.transientIdsToServerIds,
+				},
+				2: site2State,
+			} );
+		} );
+
+		test( 'should handle empty site state by passing safe defaults', () => {
+			const map = jest.fn( () => site1State );
+			const result = transformSite(
+				{
+					1: {},
+					2: site2State,
+				},
+				1,
+				map
+			);
+
+			expect( map ).toHaveBeenCalledWith( {
+				transientItems: {},
+				transientIdsToServerIds: {},
+			} );
+
+			expect( result ).toEqual( {
+				1: {
+					transientItems: site1State.transientItems,
+					transientIdsToServerIds: site1State.transientIdsToServerIds,
+				},
+				2: site2State,
+			} );
+		} );
+	} );
+} );

--- a/client/state/media/utils/transientItems.ts
+++ b/client/state/media/utils/transientItems.ts
@@ -1,0 +1,36 @@
+type TransientItemSiteState = {
+	transientItems: { [ transientId: string ]: object };
+	transientIdsToServerIds: { [ transientId: string ]: number };
+};
+
+type TransientItemsState = {
+	[ siteId: number ]: TransientItemSiteState;
+};
+
+/**
+ * Wraps the transformation of a site's transientItems state. This cuts down
+ * on boilerplate in the reducer, especially when it comes to null-safe defaults.
+ *
+ * @param state The full `transientItems` state
+ * @param siteId The ID of the site being transformed
+ * @param map A function accepting the transient items state for a site and returning a new state for the site
+ */
+export const transformSite = (
+	state: TransientItemsState,
+	siteId: number,
+	map: ( previousState: TransientItemSiteState ) => TransientItemSiteState
+): TransientItemsState => {
+	const {
+		[ siteId ]: {
+			transientItems: siteTransientItems = {},
+			transientIdsToServerIds: siteTransientIdsToServerIds = {},
+		} = {},
+	} = state;
+	return {
+		...state,
+		[ siteId ]: map( {
+			transientItems: siteTransientItems,
+			transientIdsToServerIds: siteTransientIdsToServerIds,
+		} ),
+	};
+};

--- a/client/state/selectors/get-media-item-server-id-from-transient-id.js
+++ b/client/state/selectors/get-media-item-server-id-from-transient-id.js
@@ -1,0 +1,11 @@
+/**
+ * Retrieves the server ID for a given transient ID and site ID.
+ *
+ * @param {object} state The current state
+ * @param {number} siteId The site ID
+ * @param {(number|string)} transientId The transient ID of the media item to get the server ID for
+ * @returns {(number|null)} The `number` server ID if it exists, null otherwise.
+ */
+export default function getMediaItemServerIdFromTransientId( state, siteId, transientId ) {
+	return state?.media?.transientItems?.[ siteId ]?.transientIdsToServerIds?.[ transientId ] ?? null;
+}

--- a/client/state/selectors/get-media-item-server-id-from-transient-id.js
+++ b/client/state/selectors/get-media-item-server-id-from-transient-id.js
@@ -4,8 +4,8 @@
  * @param {object} state The current state
  * @param {number} siteId The site ID
  * @param {(number|string)} transientId The transient ID of the media item to get the server ID for
- * @returns {(number|null)} The `number` server ID if it exists, null otherwise.
+ * @returns {?number} The `number` server ID if it exists, null otherwise.
  */
 export default function getMediaItemServerIdFromTransientId( state, siteId, transientId ) {
-	return state?.media?.transientItems?.[ siteId ]?.transientIdsToServerIds?.[ transientId ] ?? null;
+	return state?.media?.transientItems?.[ siteId ]?.transientIdsToServerIds?.[ transientId ];
 }

--- a/client/state/selectors/get-media-item.js
+++ b/client/state/selectors/get-media-item.js
@@ -1,19 +1,43 @@
 /**
- * Returns a media object by site ID, media ID, or null if not known
- *
+ * External dependencies
+ */
+import isNil from 'lodash/isNil';
+
+/**
+ * Internal dependencies
+ */
+import getTransientMediaItem from 'state/selectors/get-transient-media-item';
+import getMediaItemServerIdFromTransientId from 'state/selectors/get-media-item-server-id-from-transient-id';
+
+/**
+ * Returns a media object by site ID, media ID, or null if not known.
+ * Also ensures that if the passed in media ID is a transient ID that
+ * the transient item or the corresponding saved media item is correctly
+ * returned.
  *
  * @param {number}  mediaId Media ID
  * @returns {?object}         Media object, if known
  */
 
 export default function getMediaItem( state, siteId, mediaId ) {
+	const transientMediaItem = getTransientMediaItem( state, siteId, mediaId );
+	if ( ! isNil( transientMediaItem ) ) {
+		// if a transient media item existed by this ID then that means the item isn't saved yet
+		// so we should continue to use the transient item
+		return transientMediaItem;
+	}
+
+	// if the selector returns null then the `mediaId` we have is confirmed to already
+	// be a server ID rather than a transient ID
+	const serverId = getMediaItemServerIdFromTransientId( state, siteId, mediaId ) ?? mediaId;
+
 	const queries = state.media.queries[ siteId ];
 
 	if ( ! queries ) {
 		return null;
 	}
 
-	const media = queries.getItem( mediaId ) || null;
+	const media = queries.getItem( serverId ) || null;
 	if ( media === null ) {
 		return null;
 	}

--- a/client/state/selectors/get-transient-media-item.js
+++ b/client/state/selectors/get-transient-media-item.js
@@ -1,0 +1,11 @@
+/**
+ * Retrieves a transient media item by ID for a given site.
+ *
+ * @param {object} state The current state.
+ * @param {number} siteId The site ID for which to retrieve the transient media item.
+ * @param {string} transientMediaId The ID of the transient media to retrieve
+ * @returns {(object|null)} Returns the transient media item if it exists for the site; otherwise null.
+ */
+export default function getTransientMediaItem( state, siteId, transientMediaId ) {
+	return state?.media?.transientItems?.[ siteId ]?.transientItems?.[ transientMediaId ] ?? null;
+}

--- a/client/state/selectors/get-transient-media-item.js
+++ b/client/state/selectors/get-transient-media-item.js
@@ -4,8 +4,8 @@
  * @param {object} state The current state.
  * @param {number} siteId The site ID for which to retrieve the transient media item.
  * @param {string} transientMediaId The ID of the transient media to retrieve
- * @returns {(object|null)} Returns the transient media item if it exists for the site; otherwise null.
+ * @returns {?object} Returns the transient media item if it exists for the site; otherwise null.
  */
 export default function getTransientMediaItem( state, siteId, transientMediaId ) {
-	return state?.media?.transientItems?.[ siteId ]?.transientItems?.[ transientMediaId ] ?? null;
+	return state?.media?.transientItems?.[ siteId ]?.transientItems?.[ transientMediaId ];
 }

--- a/client/state/selectors/test/get-media-item-server-id-from-transient-id.js
+++ b/client/state/selectors/test/get-media-item-server-id-from-transient-id.js
@@ -1,0 +1,43 @@
+/**
+ * Internal dependencies
+ */
+import getMediaItemServerIdFromTransientId from 'state/selectors/get-media-item-server-id-from-transient-id';
+
+describe( 'getMediaItemServerIdFromTransientId()', () => {
+	const siteId = 443234;
+	const transientId = 1;
+	const serverId = Symbol( 'server id' );
+	const state = {
+		media: {
+			transientItems: {
+				[ siteId ]: {
+					transientIdsToServerIds: {
+						[ transientId ]: serverId,
+					},
+				},
+			},
+		},
+	};
+
+	it( 'should return the server id for the passed in transient ID', () => {
+		expect( getMediaItemServerIdFromTransientId( state, siteId, transientId ) ).toBe( serverId );
+	} );
+
+	describe( 'null safety', () => {
+		const nullObjects = [
+			{ media: { transientItems: { [ siteId ]: { transientIdsToServerIds: {} } } } },
+			{ media: { transientItems: { [ siteId ]: {} } } },
+			{ media: { transientItems: {} } },
+			{ media: {} },
+			{},
+		];
+
+		it.each( nullObjects )( 'should be null safe for %s', ( nullState ) => {
+			expect( getMediaItemServerIdFromTransientId( nullState, siteId ) ).toBeNull();
+		} );
+
+		it( 'should be null safe when the site is not present', () => {
+			expect( getMediaItemServerIdFromTransientId( state, 'not a site ID' ) ).toBeNull();
+		} );
+	} );
+} );

--- a/client/state/selectors/test/get-media-item-server-id-from-transient-id.js
+++ b/client/state/selectors/test/get-media-item-server-id-from-transient-id.js
@@ -33,11 +33,11 @@ describe( 'getMediaItemServerIdFromTransientId()', () => {
 		];
 
 		it.each( nullObjects )( 'should be null safe for %s', ( nullState ) => {
-			expect( getMediaItemServerIdFromTransientId( nullState, siteId ) ).toBeNull();
+			expect( getMediaItemServerIdFromTransientId( nullState, siteId ) ).toBeUndefined();
 		} );
 
 		it( 'should be null safe when the site is not present', () => {
-			expect( getMediaItemServerIdFromTransientId( state, 'not a site ID' ) ).toBeNull();
+			expect( getMediaItemServerIdFromTransientId( state, 'not a site ID' ) ).toBeUndefined();
 		} );
 	} );
 } );

--- a/client/state/selectors/test/get-media-item.js
+++ b/client/state/selectors/test/get-media-item.js
@@ -10,6 +10,7 @@ import getMediaItem from 'state/selectors/get-media-item';
 import MediaQueryManager from 'lib/query-manager/media';
 
 describe( 'getMediaItem()', () => {
+	const siteId = 2916284;
 	const item = {
 		ID: 42,
 		title: 'flowers',
@@ -19,7 +20,7 @@ describe( 'getMediaItem()', () => {
 	const state = {
 		media: {
 			queries: {
-				2916284: new MediaQueryManager( {
+				[ siteId ]: new MediaQueryManager( {
 					items: {
 						42: item,
 					},
@@ -38,5 +39,62 @@ describe( 'getMediaItem()', () => {
 
 	test( 'should return the media item', () => {
 		expect( getMediaItem( state, 2916284, 42 ) ).to.eql( item );
+	} );
+
+	describe( 'transient media', () => {
+		const transientItem = {
+			ID: 'transient-id-1',
+			title: 'transient flowers',
+			URL: 'http://example.com',
+		};
+
+		// represents the state before a transient media item has been promoted
+		const transientStatePreSave = {
+			media: {
+				...state.media,
+				transientItems: {
+					[ siteId ]: {
+						transientItems: {
+							[ transientItem.ID ]: transientItem,
+						},
+						transientIdsToServerIds: {},
+					},
+				},
+			},
+		};
+
+		// represents the state after a transient media item has been promoted
+		const transientStatePostSave = {
+			media: {
+				...state.media,
+				transientItems: {
+					[ siteId ]: {
+						transientItems: {},
+						transientIdsToServerIds: {
+							[ transientItem.ID ]: item.ID,
+						},
+					},
+				},
+			},
+		};
+
+		describe( 'before promotion', () => {
+			test( 'should return the transient media item', () => {
+				const result = getMediaItem( transientStatePreSave, siteId, transientItem.ID );
+				expect( result ).to.eql( transientItem );
+			} );
+		} );
+
+		describe( 'after promotion', () => {
+			test( 'should return the actual media item when given the transient ID', () => {
+				const result = getMediaItem( transientStatePostSave, siteId, transientItem.ID );
+				expect( result ).to.eql( item );
+			} );
+
+			test( 'should return the actual media item when given the server ID', () => {
+				const result = getMediaItem( transientStatePostSave, siteId, item.ID );
+				expect( result ).to.eql( item );
+			} );
+		} );
 	} );
 } );

--- a/client/state/selectors/test/get-transient-media-item.js
+++ b/client/state/selectors/test/get-transient-media-item.js
@@ -1,0 +1,43 @@
+/**
+ * Internal dependencies
+ */
+import getTransientMediaItem from 'state/selectors/get-transient-media-item';
+
+describe( 'getTransientMediaItem()', () => {
+	const siteId = 443234;
+	const transientId = 1;
+	const transientMediaItem = Symbol( 'transient media item' );
+	const state = {
+		media: {
+			transientItems: {
+				[ siteId ]: {
+					transientItems: {
+						[ transientId ]: transientMediaItem,
+					},
+				},
+			},
+		},
+	};
+
+	it( 'should return the transient media item corresponding to the passed in ID', () => {
+		expect( getTransientMediaItem( state, siteId, transientId ) ).toBe( transientMediaItem );
+	} );
+
+	describe( 'null safety', () => {
+		const nullObjects = [
+			{ media: { transientItems: { [ siteId ]: { transientItems: {} } } } },
+			{ media: { transientItems: { [ siteId ]: {} } } },
+			{ media: { transientItems: {} } },
+			{ media: {} },
+			{},
+		];
+
+		it.each( nullObjects )( 'should be null safe for %s', ( nullState ) => {
+			expect( getTransientMediaItem( nullState, siteId ) ).toBeNull();
+		} );
+
+		it( 'should be null safe when the site is not present', () => {
+			expect( getTransientMediaItem( state, 'not a site ID' ) ).toBeNull();
+		} );
+	} );
+} );

--- a/client/state/selectors/test/get-transient-media-item.js
+++ b/client/state/selectors/test/get-transient-media-item.js
@@ -33,11 +33,11 @@ describe( 'getTransientMediaItem()', () => {
 		];
 
 		it.each( nullObjects )( 'should be null safe for %s', ( nullState ) => {
-			expect( getTransientMediaItem( nullState, siteId ) ).toBeNull();
+			expect( getTransientMediaItem( nullState, siteId ) ).toBeUndefined();
 		} );
 
 		it( 'should be null safe when the site is not present', () => {
-			expect( getTransientMediaItem( state, 'not a site ID' ) ).toBeNull();
+			expect( getTransientMediaItem( state, 'not a site ID' ) ).toBeUndefined();
 		} );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a new `transientItems` reducer which duplicates the transient media item handling in the `media/store` flux reducer while de-duplicating media item tracking which is handled by the `queries` reducer and the `MediaQueryManager`.

#### Testing instructions

While there are changes to selectors, the reducer is not added to the store, so transient items will not be being tracked and the existing logic of the `getMediaItem` selector will continue to work, ignoring transient items. This is provable by the fact that the existing unit tests for that selector, which do not add transient items to the tested state, continued to work without modification.

* Ensure all unit tests pass

Note: This PR is part of an iteration to remove the `media/store` flux reducer. It is the first of a series of 4 PRs. Also, see #39379 for the complete media reduxification effort.