### PR TITLE
Add tracks event to collect domain searches

### DIFF
--- a/client/landing/gutenboarding/components/domain-picker-button/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-button/index.tsx
@@ -26,6 +26,7 @@ const DomainPickerButton: React.FunctionComponent< Props > = ( {
 	...buttonProps
 } ) => {
 	const makePath = usePath();
+
 	return (
 		<>
 			<Link

--- a/client/landing/gutenboarding/onboarding-block/domains/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/domains/index.tsx
@@ -80,6 +80,13 @@ const DomainsStep: React.FunctionComponent< Props > = ( { isModal } ) => {
 		</div>
 	);
 
+	const trackDomainSearchInteraction = ( query: string ) => {
+		trackEventWithFlow( 'calypso_newsite_domain_search_blur', {
+			query,
+			where: 'domain_step',
+		} );
+	};
+
 	return (
 		<div className="gutenboarding-page domains">
 			<DomainPicker
@@ -87,6 +94,7 @@ const DomainsStep: React.FunctionComponent< Props > = ( { isModal } ) => {
 				analyticsFlowId={ FLOW_ID }
 				initialDomainSearch={ domainSearch }
 				onSetDomainSearch={ setDomainSearch }
+				onDomainSearchBlur={ trackDomainSearchInteraction }
 				currentDomain={ domain?.domain_name }
 				onDomainSelect={ onDomainSelect }
 				analyticsUiAlgo={ isModal ? 'domain_modal' : 'domain_page' }

--- a/client/landing/gutenboarding/onboarding-block/domains/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/domains/index.tsx
@@ -83,7 +83,7 @@ const DomainsStep: React.FunctionComponent< Props > = ( { isModal } ) => {
 	const trackDomainSearchInteraction = ( query: string ) => {
 		trackEventWithFlow( 'calypso_newsite_domain_search_blur', {
 			query,
-			where: 'domain_step',
+			where: isModal ? 'domain_modal' : 'domain_page',
 		} );
 	};
 

--- a/packages/domain-picker/src/domain-picker/index.tsx
+++ b/packages/domain-picker/src/domain-picker/index.tsx
@@ -48,6 +48,9 @@ export interface Props {
 	/** Domain suggestions to show when the picker is expanded */
 	quantityExpanded?: number;
 
+	/** Called when the user leaves the search box */
+	onDomainSearchBlur: ( value: string ) => void;
+
 	currentDomain?: string;
 
 	/** The flow where the Domain Picker is used. Eg: Gutenboarding */
@@ -69,6 +72,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 	onDomainSelect,
 	quantity = PAID_DOMAINS_TO_SHOW,
 	quantityExpanded = PAID_DOMAINS_TO_SHOW_EXPANDED,
+	onDomainSearchBlur,
 	analyticsFlowId,
 	analyticsUiAlgo,
 	initialDomainSearch = '',
@@ -99,6 +103,12 @@ const DomainPicker: FunctionComponent< Props > = ( {
 		0,
 		isExpanded ? quantityExpanded : quantity
 	);
+
+	const onDomainSearchBlurValue = ( event: React.FormEvent< HTMLInputElement > ) => {
+		if ( onDomainSearchBlur ) {
+			onDomainSearchBlur( event.currentTarget.value );
+		}
+	};
 
 	// Reset expansion state after every search
 	useEffect( () => {
@@ -156,6 +166,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 					label={ label }
 					placeholder={ label }
 					onChange={ handleInputChange }
+					onBlur={ onDomainSearchBlurValue }
 					value={ domainSearch }
 				/>
 			</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add `calypso_newsite_domain_search` track events for domain searches on gutenboarding
* Differentiate between modal/popover ui's through a `where` property
* Search term is recoreded via the `query` property

#### Testing instructions

* Visit http://calypso.localhost:3000/new
* Enable debugging `localStorage.setItem( 'debug','calypso:analytics');`
* Click the domain picker dropdown, enter a search term
* You should see the new events firing for `calypso_newsite_domain_search`

Fixes #42892 (partial)
