### PR TITLE
Reader: ensure that sidebar is hidden in full post

### DIFF
--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -330,7 +330,7 @@ export class FullPostView extends React.Component {
 		/*eslint-disable react/no-danger */
 		/*eslint-disable react/jsx-no-target-blank */
 		return (
-			<ReaderMain className={ classNames( classes ) }>
+			<ReaderMain className={ classNames( classes ) } isFullPost={ true }>
 				{ site && <QueryPostLikes siteId={ post.site_ID } postId={ post.ID } /> }
 				{ ! post || post._state === 'pending' ? (
 					<DocumentHead title={ translate( 'Loading' ) } />

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -1,5 +1,3 @@
-
-
 // Styles targeted at story content
 @import './_content.scss';
 
@@ -9,6 +7,16 @@
 			display: none; // Hides masterbar in fullpost mobile
 		}
 	}
+}
+
+// Workaround to make absolutely sure we're not displaying the sidebar here.
+//
+// The hasSidebar selector should take care of this, but state.ui.section sometimes unhelpfully
+// reports full post as in being the 'reader' section, not 'reader/full-post' which means the sidebar is displayed.
+//
+// The .is-reader-full-post class is added dynamically in <ReaderMain>.
+.is-reader-full-post .layout__secondary {
+	display: none;
 }
 
 .reader-full-post.main {

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -10,7 +10,7 @@
  *
  */
 
-// Set transitons for layout elements
+// Set transitions for layout elements
 .layout__primary .main,
 .layout__secondary,
 .layout__secondary .sidebar,

--- a/client/reader/components/reader-main/index.jsx
+++ b/client/reader/components/reader-main/index.jsx
@@ -35,6 +35,14 @@ const setIsReaderPage = ( add ) => {
 	}
 };
 
+const setIsReaderFullPost = ( add ) => {
+	if ( add ) {
+		document.querySelector( 'body' ).classList.add( 'is-reader-full-post' );
+	} else if ( activeReaderMainRefCount === 0 ) {
+		document.querySelector( 'body' ).classList.remove( 'is-reader-full-post' );
+	}
+};
+
 /**
  * A specialization of `Main` that adds a class to the body of the document
  *
@@ -45,11 +53,19 @@ export default class ReaderMain extends React.Component {
 	componentDidMount() {
 		activeReaderMainRefCount++;
 		setIsReaderPage( true );
+
+		if ( this.props.isFullPost ) {
+			setIsReaderFullPost( true );
+		}
 	}
 
 	componentWillUnmount() {
 		activeReaderMainRefCount--;
 		setIsReaderPage( false );
+
+		if ( this.props.isFullPost ) {
+			setIsReaderFullPost( false );
+		}
 	}
 
 	render() {


### PR DESCRIPTION
I noticed that the right border of the sidebar was sporadically appearing in Reader full post:

<img width="1047" alt="Screen Shot 2020-06-05 at 14 42 19" src="https://user-images.githubusercontent.com/17325/83834522-a23fed00-a742-11ea-9d90-52659a0f5db4.png">

This is odd, because the sections.js file says `secondary: false` for Reader full post, meaning that the sidebar area shouldn't be displayed at all.

On further investigation, I found that `state.ui.section` (which powers the `hasSidebar` selector) sometimes correctly returns 'reader/full-post' as the current section, and hides the sidebar. However, sometimes it incorrectly returns 'reader' as the current section, and the right border shown in the screenshot above is present. 

#### Changes proposed in this Pull Request

After a fair bit of digging I couldn't find out why the section in `state.ui.section` is different on different visits.

This PR proposes a simple workaround: dynamically add a class name for Reader full post in `<ReaderMain>`, and hide the secondary region with CSS.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Visit a Reader full post like:

http://calypso.localhost:3000/read/blogs/70135762/posts/140264

Ensure that you don't see the right border of the sidebar appear (as shown in the screenshot).
