### PR TITLE
Adds responseStart to Performance API data collector

### DIFF
--- a/packages/browser-data-collector/src/api/performance-timing.ts
+++ b/packages/browser-data-collector/src/api/performance-timing.ts
@@ -15,6 +15,7 @@ export const getConnectEnd = (): number => window?.performance?.timing?.connectE
 export const getSecureConnectionStart = (): number =>
 	window?.performance?.timing?.secureConnectionStart;
 export const getRequestStart = (): number => window?.performance?.timing?.requestStart;
+export const getResponseStart = (): number => window?.performance?.timing?.responseStart;
 export const getResponseEnd = (): number => window?.performance?.timing?.responseEnd;
 export const getDomLoading = (): number => window?.performance?.timing?.domLoading;
 export const getDomInteractive = (): number => window?.performance?.timing?.domInteractive;

--- a/packages/browser-data-collector/src/collectors/performance-timing.ts
+++ b/packages/browser-data-collector/src/collectors/performance-timing.ts
@@ -14,6 +14,7 @@ import {
 	getConnectEnd,
 	getSecureConnectionStart,
 	getRequestStart,
+	getResponseStart,
 	getResponseEnd,
 	getDomLoading,
 	getDomInteractive,
@@ -45,6 +46,7 @@ export const collector: Collector = ( report ) => {
 	report.data.set( 'connectEnd', normalize( getConnectEnd(), report.start ) );
 	report.data.set( 'secureConnectionStart', normalize( getSecureConnectionStart(), report.start ) );
 	report.data.set( 'requestStart', normalize( getRequestStart(), report.start ) );
+	report.data.set( 'responseStart', normalize( getResponseStart(), report.start ) );
 	report.data.set( 'responseEnd', normalize( getResponseEnd(), report.start ) );
 	report.data.set( 'domLoading', normalize( getDomLoading(), report.start ) );
 	report.data.set( 'domInteractive', normalize( getDomInteractive(), report.start ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds `responseStart` to the data sent to RUM

#### Testing instructions

1) Load Calypso and opt-in abtest `rumDataCollection`
2) Navigate to /read
3) Check the network tab for a request to `/logstash` and verify the payload has `responseStart`
