### PR TITLE
Add NetworkInformation API

### DIFF
--- a/packages/browser-data-collector/src/api/network-information.ts
+++ b/packages/browser-data-collector/src/api/network-information.ts
@@ -1,0 +1,3 @@
+export const getEffectiveType = (): EffectiveConnectionType => {
+	return window.navigator?.connection?.effectiveType;
+};

--- a/packages/browser-data-collector/src/collectors/index.ts
+++ b/packages/browser-data-collector/src/collectors/index.ts
@@ -4,3 +4,4 @@
 export { collector as deviceMemory } from './device-memory';
 export { collector as performanceTiming } from './performance-timing';
 export { collector as environment } from './environment';
+export { collector as networkInformation } from './network-information';

--- a/packages/browser-data-collector/src/collectors/network-information.ts
+++ b/packages/browser-data-collector/src/collectors/network-information.ts
@@ -1,0 +1,9 @@
+/**
+ * Internal dependencies
+ */
+import { getEffectiveType } from '../api/network-information';
+
+export const collector: Collector = ( report ) => {
+	report.data.set( 'network', getEffectiveType() );
+	return report;
+};

--- a/packages/browser-data-collector/src/report.ts
+++ b/packages/browser-data-collector/src/report.ts
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import { getNavigationStart } from './api/performance-timing';
-import { deviceMemory, performanceTiming, environment } from './collectors';
+import { deviceMemory, performanceTiming, environment, networkInformation } from './collectors';
 
 export class ReportImpl implements Report {
 	id: string;
@@ -24,13 +24,13 @@ export class ReportImpl implements Report {
 	private initializeFromFullPage() {
 		this.start = getNavigationStart();
 		this.data.set( 'fullPage', true );
-		this.collectors = [ deviceMemory, performanceTiming, environment ];
+		this.collectors = [ deviceMemory, performanceTiming, environment, networkInformation ];
 	}
 
 	private initializeFromSPANavigation() {
 		this.start = Date.now();
 		this.data.set( 'fullPage', false );
-		this.collectors = [ deviceMemory, environment ];
+		this.collectors = [ deviceMemory, environment, networkInformation ];
 	}
 
 	async stop() {

--- a/packages/browser-data-collector/src/types.d.ts
+++ b/packages/browser-data-collector/src/types.d.ts
@@ -1,5 +1,15 @@
 interface Navigator {
 	deviceMemory: number;
+	connection: {
+		effectiveType: EffectiveConnectionType;
+	};
+}
+
+declare enum EffectiveConnectionType {
+	'2g',
+	'3g',
+	'4g',
+	'slow-2g',
 }
 
 interface Window {
@@ -12,7 +22,7 @@ interface Window {
 
 declare module 'wpcom-xhr-request';
 
-type ReportData = Map< string, number | string | boolean >;
+declare type ReportData = Map< string, number | string | boolean >;
 
 interface Report {
 	id: string;
@@ -22,4 +32,4 @@ interface Report {
 	toJSON: () => object;
 }
 
-type Collector = ( report: Report ) => Promise< Report > | Report;
+declare type Collector = ( report: Report ) => Promise< Report > | Report;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add RUM collector for [Network Information API](https://developer.mozilla.org/en-US/docs/Web/API/Network_Information_API) [effectiveType](https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation/effectiveType)

#### Testing instructions

* Load Calypso and opt-in into abtest rumDataCollection
* Go to /read
* Check the network tab for a request to `/logstash`. Verify the payload contains `network:"4g"` (or your network type)
