### PR TITLE
Active tests: new slug for gutenboarding

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -127,7 +127,7 @@ export default {
 		allowExistingUsers: true,
 	},
 	newSiteGutenbergOnboarding: {
-		datestamp: '20200520',
+		datestamp: '20200605',
 		variations: {
 			gutenberg: 10,
 			control: 90,


### PR DESCRIPTION
Bump Gutenboarding A/B test date because of https://github.com/Automattic/wp-calypso/pull/42995
