### PR TITLE
Add missing peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -313,6 +313,7 @@
 		"mkdirp": "^1.0.4",
 		"mock-fs": "^4.11.0",
 		"mockdate": "^2.0.5",
+		"moment-timezone": "^0.5.16",
 		"moment-timezone-data-webpack-plugin": "^1.3.0",
 		"ncp": "^2.0.0",
 		"nock": "^12.0.3",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Declares an explicit dependency on `moment-timezone` to satisfy peer dependencies of `moment-timezone-data-webpack-plugin`.

We were already pulling in `moment-timezone` as part of `@wordpress/date` so nothing should really change. There are no changes in `yarn.lock` because there are no actual changes in the dependency tree.

This should fix the warning

```
warning " > moment-timezone-data-webpack-plugin@1.3.0" has unmet peer dependency "moment-timezone@>= 0.1.0"
```


#### Testing instructions

* Checkout the branch, run `yarn` and verify it doesn't output the warning indicated above.
