### PR TITLE
Gutenboarding: use default redirect after launch

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -60,9 +60,6 @@ function getSignupDestination( dependencies ) {
 }
 
 function getLaunchDestination( dependencies ) {
-	if ( dependencies.source === 'editor' ) {
-		return `/block-editor/page/${ dependencies.siteSlug }/home`;
-	}
 	return `/home/${ dependencies.siteSlug }`;
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Stop redirecting to editor after launching a site from editor and use the default redirect.

#### Testing instructions
* Go to [/new](https://calypso.live/?branch=update/launch-destination) and create a site
* Launch the site straight from the editor
* You should land in customer home and see this celebration notice:
<img width="993" alt="Screenshot 2020-06-05 at 13 16 11" src="https://user-images.githubusercontent.com/14192054/83866723-e4f8c980-a730-11ea-9f04-8e8c93b83bfd.png">
