### PR TITLE
Remove async loading of lib/user/utils as it confuses webpack

### DIFF
--- a/client/lib/wpcom-xhr-wrapper/index.js
+++ b/client/lib/wpcom-xhr-wrapper/index.js
@@ -4,14 +4,17 @@
 import debugModule from 'debug';
 
 /**
+ * Internal dependencies
+ */
+import userUtils from 'lib/user/utils';
+
+/**
  * Module variables
  */
 const debug = debugModule( 'calypso:wpcom-xhr-wrapper' );
 
 export default async function ( params, callback ) {
 	const xhr = ( await import( /* webpackChunkName: "wpcom-xhr-request" */ 'wpcom-xhr-request' ) )
-		.default;
-	const userUtils = ( await import( /* webpackChunkName: "lib-user-utils" */ 'lib/user/utils' ) )
 		.default;
 
 	return xhr( params, function ( error, response, headers ) {


### PR DESCRIPTION
Remove async loading of `lib/user/utils` because it triggers a webpack bug (https://github.com/webpack/webpack/issues/11005) in the `wp-desktop` build.

We'll need to break the circular dependency some other way.

Also, it keeps the issue mentioned by @ChaosExAnima in https://github.com/Automattic/wp-calypso/pull/42763#pullrequestreview-420493883 fixed: the problem with `require( 'lib/user/utils' ).logout` wasn't a circular dependency, but the fact we were `require`-ing (CJS) an ESM module with default export. `require( ... ).default.logout` is necessary in such case.

**How to test:**
- verify that desktop app build is fixed
- verify that Jetpack Cloud behaves well when the OAuth token expires