### PR TITLE
Gutenboarding: fix back button on checkout in launch flow

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -268,9 +268,7 @@ export default connect( ( state ) => {
 	const oauth2Client = getCurrentOAuth2Client( state );
 	const wccomFrom = get( getCurrentQueryArguments( state ), 'wccom-from' );
 	const isEligibleForJITM = [ 'stats', 'plans', 'themes', 'plugins' ].indexOf( sectionName ) >= 0;
-	const isNewLaunchFlow =
-		startsWith( currentRoute, '/start/new-launch' ) ||
-		startsWith( currentRoute, '/start/prelaunch' );
+	const isNewLaunchFlow = startsWith( currentRoute, '/start/new-launch' );
 
 	return {
 		masterbarIsHidden:

--- a/client/my-sites/checkout/checkout/checkout-container.jsx
+++ b/client/my-sites/checkout/checkout/checkout-container.jsx
@@ -62,6 +62,14 @@ class CheckoutContainer extends React.Component {
 		);
 	}
 
+	handleBack = () => {
+		if ( this.props.isGutenboardingCreate ) {
+			window.history.go( -1 );
+		} else {
+			window.location.href = `/home/${ this.props.selectedSite.slug }`;
+		}
+	};
+
 	render() {
 		const {
 			product,
@@ -87,7 +95,7 @@ class CheckoutContainer extends React.Component {
 					<Button
 						borderless
 						className="navigation-link back" // eslint-disable-line wpcalypso/jsx-classname-namespace
-						onClick={ () => window.history.go( this.props.isGutenboardingCreate ? -1 : -2 ) } // going back to signup flow and skipping '/launch' step
+						onClick={ this.handleBack }
 					>
 						<Gridicon icon="arrow-left" size={ 18 } />
 						{ this.props.translate( 'Back' ) }

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -17,7 +17,6 @@ export function generateFlows( {
 	getLaunchDestination = noop,
 	getThankYouNoSiteDestination = noop,
 	getChecklistThemeDestination = noop,
-	getEditorDestination = noop,
 } = {} ) {
 	const flows = {
 		account: {
@@ -359,15 +358,6 @@ export function generateFlows( {
 		lastModified: '2020-04-28',
 		pageTitle: translate( 'Launch your site' ),
 		providesDependenciesInQuery: [ 'siteSlug', 'source' ],
-	};
-
-	flows.prelaunch = {
-		steps: [ 'plans-with-domain' ],
-		destination: getEditorDestination,
-		description: 'Flow for creating a site with a paid domain from /new',
-		lastModified: '2020-04-08',
-		pageTitle: translate( 'Get a domain for your site' ),
-		providesDependenciesInQuery: [ 'siteSlug' ],
 	};
 
 	return flows;

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -29,7 +29,6 @@ const stepNameToModuleName = {
 	'plans-personal': 'plans',
 	'plans-premium': 'plans',
 	'plans-site-selected': 'plans',
-	'plans-with-domain': 'plans',
 	'plans-store-nux': 'plans-atomic-store',
 	site: 'site',
 	'rebrand-cities-welcome': 'rebrand-cities-welcome',

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import React from 'react';
 import { noop } from 'lodash';
 import i18n from 'i18n-calypso';
 
@@ -275,25 +274,6 @@ export function generateSteps( {
 			apiRequestFunction: addPlanToCart,
 			dependencies: [ 'siteSlug', 'domainItem' ],
 			providesDependencies: [ 'cartItem' ],
-		},
-
-		'plans-with-domain': {
-			stepName: 'plans-with-domain',
-			apiRequestFunction: addPlanToCart,
-			fulfilledStepCallback: isPlanFulfilled,
-			dependencies: [ 'siteSlug' ],
-			providesDependencies: [ 'cartItem', 'isPreLaunch', 'isGutenboardingCreate' ],
-			props: {
-				headerText: i18n.translate( 'Choose a plan' ),
-				subHeaderText: i18n.translate(
-					'Pick a plan that’s right for you. Switch plans as your needs change. {{br/}} There’s no risk, you can cancel for a full refund within 30 days.',
-					{
-						components: { br: <br /> },
-						comment:
-							'Subheader of the plans page where users land from onboarding after they picked a paid domain',
-					}
-				),
-			},
 		},
 
 		domains: {

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -79,12 +79,6 @@ export class PlansStep extends Component {
 
 		this.props.submitSignupStep( step, {
 			cartItem,
-			// dependencies used only for 'plans-with-domain' step in Gutenboarding pre-launch flow
-			...( this.isGutenboarding() &&
-				! this.props.isLaunchPage && {
-					isPreLaunch: true,
-					isGutenboardingCreate: true,
-				} ),
 		} );
 		this.props.goToNextStep();
 	};
@@ -116,11 +110,9 @@ export class PlansStep extends Component {
 		this.onSelectPlan( null ); // onUpgradeClick expects a cart item -- null means Free Plan.
 	};
 
-	isGutenboarding = () =>
-		this.props.flowName === 'new-launch' || this.props.flowName === 'prelaunch'; // signup flows coming from Gutenboarding
-
 	getGutenboardingHeader() {
-		if ( this.isGutenboarding() ) {
+		// launch flow coming from Gutenboarding
+		if ( this.props.flowName === 'new-launch' ) {
 			const { headerText, subHeaderText } = this.props;
 
 			return (
@@ -218,7 +210,7 @@ export class PlansStep extends Component {
 				allowBackFirstStep={ !! hasInitializedSitesBackUrl }
 				backUrl={ backUrl }
 				backLabelText={ backLabelText }
-				hideFormattedHeader={ this.isGutenboarding() }
+				hideFormattedHeader={ !! this.getGutenboardingHeader() }
 			/>
 		);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Redirect from to my home when pressing Back button on _/checkout_ while launching a site created in Gutenboarding.

#### Testing instructions
* Go to [/new](https://calypso.live/new?branch=fix/gutenboarding-checkout-back-button) and create a site.
* Try to launch the site using paid domain/paid plan.
* On _/checkout_ page, press back button.
* You should land in _/home_ instead of a white screen.

#### Follow up
* Fix browser back button behaviour on `/checkout` page in launch flow.

Fixes part of #42510 
