### PR TITLE
Editor: Temporarily use a 1 July date in old translations of the deprecation notice

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/deprecate-editor/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/deprecate-editor/index.jsx
@@ -23,14 +23,18 @@ import {
 } from 'state/analytics/actions';
 import getGutenbergEditorUrl from 'state/selectors/get-gutenberg-editor-url';
 import blockEditorImage from 'assets/images/illustrations/block-editor-fade.svg';
+import FormattedDate from 'components/formatted-date';
 import { localizeUrl } from 'lib/i18n-utils';
 import InlineSupportLink from 'components/inline-support-link';
+import { useLocalizedMoment } from 'components/localized-moment';
 
 const DeprecateEditor = ( { siteId, gutenbergUrl, optIn } ) => {
 	const translate = useTranslate();
+	const moment = useLocalizedMoment();
 	const actionCallback = () => {
 		optIn( siteId, gutenbergUrl );
 	};
+	const dateFormat = moment.localeData().longDateFormat( 'LL' );
 
 	return (
 		<Task
@@ -40,6 +44,11 @@ const DeprecateEditor = ( { siteId, gutenbergUrl, optIn } ) => {
 					'Get a head start before we activate it for everyone in the near future. {{support}}Read more{{/support}}.',
 					{
 						components: {
+							date: (
+								<strong>
+									<FormattedDate date="2020-07-01" format={ dateFormat } />
+								</strong>
+							),
 							support: (
 								<InlineSupportLink
 									supportPostId={ 167510 }

--- a/client/post-editor/editor-deprecation-dialog/index.jsx
+++ b/client/post-editor/editor-deprecation-dialog/index.jsx
@@ -25,6 +25,8 @@ import { getEditedPostValue } from 'state/posts/selectors';
 import getGutenbergEditorUrl from 'state/selectors/get-gutenberg-editor-url';
 import InlineSupportLink from 'components/inline-support-link';
 import { localizeUrl } from 'lib/i18n-utils';
+import FormattedDate from 'components/formatted-date';
+import { withLocalizedMoment } from 'components/localized-moment';
 
 /**
  * Style dependencies
@@ -63,6 +65,8 @@ class EditorDeprecationDialog extends Component {
 			return null;
 		}
 
+		const dateFormat = this.props.moment.localeData().longDateFormat( 'LL' );
+
 		return (
 			<Modal
 				title={ translate( 'The new WordPress editor is coming.' ) }
@@ -78,6 +82,11 @@ class EditorDeprecationDialog extends Component {
 						'Get a head start before we activate it for everyone in the near future. {{support}}Read more{{/support}}.',
 						{
 							components: {
+								date: (
+									<strong>
+										<FormattedDate date="2020-07-01" format={ dateFormat } />
+									</strong>
+								),
 								support: (
 									<InlineSupportLink
 										supportPostId={ 167510 }
@@ -144,4 +153,4 @@ export default connect( ( state ) => {
 		isDialogShowing,
 		gutenbergUrl: gutenbergUrl,
 	};
-}, mapDispatchToProps )( localize( EditorDeprecationDialog ) );
+}, mapDispatchToProps )( localize( withLocalizedMoment( EditorDeprecationDialog ) ) );


### PR DESCRIPTION
Fixup for #42970 when old translations are used.

Since we continue to use fuzzy translations for the string `Get a head start before we activate it for everyone in the near future. {{support}}Read more{{/support}}.` we still have a `{{date/}}` string in the translation. In a case where a component appears in the string that is not accounted for in the `components` object, [`interpolateComponents` will return the string without any interpolated components](https://github.com/Automattic/interpolate-components/blob/master/src/index.es6#L53), thus we see the components displayed to the user:

![Saved Image 2020-06-05 at 2 10 02 PM](https://user-images.githubusercontent.com/203408/83874741-45d6d080-a736-11ea-8da6-84ac58d8d4b8.png)

In this particular instance I have fixed the translation [but other languages still use the old version](https://translate.wordpress.com/projects/wpcom/-all-translated/273185/), so we need to bring back the date component.

# Testing instructions
Append `?set-editor=classic` to a Gutenberg URL to bring up the notice.
