### PR TITLE
Gutenboarding: update disabled primary button style in plans grid

### DIFF
--- a/client/landing/gutenboarding/components/action-buttons/style.scss
+++ b/client/landing/gutenboarding/components/action-buttons/style.scss
@@ -1,4 +1,5 @@
 @import 'assets/stylesheets/gutenberg-base-styles';
+@import '../../mixins.scss';
 @import '../../variables.scss';
 @import '../../_z-index.scss';
 
@@ -15,6 +16,21 @@
 	display: flex;
 	align-items: center;
 	z-index: gutenboarding-z-index( '.gutenboarding__footer' );
+
+	.components-button.is-link {
+		@include onboarding-medium-text;
+		color: var( --studio-gray-40 );
+		white-space: nowrap;
+	}
+	.components-button.is-primary {
+		height: auto;
+		padding: 13px 29px;
+
+		&[disabled] {
+			background: var( --studio-gray-10 );
+			color: $white;
+		}
+	}
 
 	@include break-small {
 		padding: 0;

--- a/packages/plans-grid/src/plans-grid/style.scss
+++ b/packages/plans-grid/src/plans-grid/style.scss
@@ -9,18 +9,6 @@
 	@include break-small {
 		margin-bottom: 0;
 	}
-
-	.action-buttons {
-		.components-button.is-link {
-			@include onboarding-medium-text;
-			color: var( --studio-gray-40 );
-			white-space: nowrap;
-		}
-		.components-button.is-primary {
-			height: auto;
-			padding: 13px 29px;
-		}
-	}
 }
 
 .plans-grid__header {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use grey background and white color for disabled button

#### Testing instructions

* Go to [/new](https://calypso.live/new?branch=update/plans-grid-disabled-button-style) with an empty state
* Open plans grid using the plans button or advancing to plans step
* Continue/Confirm button should be grey until a plan selection is made

#### Screenshot
<img width="264" alt="Screenshot 2020-06-05 at 18 19 10" src="https://user-images.githubusercontent.com/14192054/83893790-14bbc780-a759-11ea-8919-8927bd0420b5.png">
