### PR TITLE
Domains: Add link to manage site on domain settings page

### DIFF
--- a/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
+++ b/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies
@@ -39,10 +40,11 @@ import { hasGSuiteWithUs, getGSuiteMailboxCount } from 'lib/gsuite';
 import './style.scss';
 
 const DomainManagementNavigationItemContents = function ( props ) {
-	const { materialIcon, text, description } = props;
+	const { gridicon, materialIcon, text, description } = props;
 	return (
 		<React.Fragment>
-			<MaterialIcon icon={ materialIcon } className="navigation__icon" />
+			{ gridicon && <Gridicon className="navigation__icon" icon={ gridicon } /> }
+			{ ! gridicon && <MaterialIcon icon={ materialIcon } className="navigation__icon" /> }
 			<div>
 				<div>{ text }</div>
 				<small>{ description }</small>
@@ -52,7 +54,7 @@ const DomainManagementNavigationItemContents = function ( props ) {
 };
 
 const DomainManagementNavigationItem = function ( props ) {
-	const { path, onClick, external, materialIcon, text, description } = props;
+	const { path, onClick, external, gridicon, materialIcon, text, description } = props;
 
 	return (
 		<VerticalNavItem
@@ -63,6 +65,7 @@ const DomainManagementNavigationItem = function ( props ) {
 		>
 			<DomainManagementNavigationItemContents
 				materialIcon={ materialIcon }
+				gridicon={ gridicon }
 				text={ text }
 				description={ description }
 			/>
@@ -298,6 +301,24 @@ class DomainManagementNavigationEnhanced extends React.Component {
 		);
 	}
 
+	getManageSite() {
+		if ( ! config.isEnabled( 'manage/all-domains' ) ) {
+			return null;
+		}
+
+		const { selectedSite, translate } = this.props;
+		const wpcomUrl = withoutHttp( getUnmappedUrl( selectedSite ) );
+
+		return (
+			<DomainManagementNavigationItem
+				path={ `/home/${ selectedSite.slug }` }
+				gridicon="my-sites"
+				text={ translate( 'Manage your site' ) }
+				description={ wpcomUrl }
+			/>
+		);
+	}
+
 	handleChangeSiteAddressClick = () => {
 		const { domain } = this.props;
 		const domainType = getDomainTypeText( domain );
@@ -528,6 +549,7 @@ class DomainManagementNavigationEnhanced extends React.Component {
 	renderRegisteredDomainNavigation() {
 		return (
 			<React.Fragment>
+				{ this.getManageSite() }
 				{ this.getNameServers() }
 				{ this.getEmail() }
 				{ this.getContactsAndPrivacy() }
@@ -542,6 +564,7 @@ class DomainManagementNavigationEnhanced extends React.Component {
 	renderSiteRedirectNavigation() {
 		return (
 			<React.Fragment>
+				{ this.getManageSite() }
 				{ this.getRedirectSettings() }
 				{ this.getDeleteDomain() }
 			</React.Fragment>
@@ -551,6 +574,7 @@ class DomainManagementNavigationEnhanced extends React.Component {
 	renderMappedDomainNavigation() {
 		return (
 			<React.Fragment>
+				{ this.getManageSite() }
 				{ this.getDnsRecords() }
 				{ this.getEmail() }
 				{ this.getDomainConnectMapping() }
@@ -563,12 +587,18 @@ class DomainManagementNavigationEnhanced extends React.Component {
 	}
 
 	renderTransferInDomainNavigation() {
-		return <React.Fragment>{ this.getDeleteDomain() }</React.Fragment>;
+		return (
+			<React.Fragment>
+				{ this.getManageSite() }
+				{ this.getDeleteDomain() }
+			</React.Fragment>
+		);
 	}
 
 	renderWpcomDomainNavigation() {
 		return (
 			<React.Fragment>
+				{ this.getManageSite() }
 				{ this.getSiteAddressChange() }
 				{ this.getPickCustomDomain() }
 			</React.Fragment>

--- a/client/my-sites/domains/domain-management/edit/navigation/style.scss
+++ b/client/my-sites/domains/domain-management/edit/navigation/style.scss
@@ -8,6 +8,9 @@
 			height: 32px;
 			margin-right: 16px;
 		}
+		> .gridicons-my-sites {
+			position: static;
+		}
 		div {
 			color: var( --color-neutral-90 );
 			small {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a link from the domain settings view to manage the site it belongs to.

<img width="726" alt="Screenshot 2020-06-05 at 4 15 56 PM" src="https://user-images.githubusercontent.com/13062352/83886899-fbf6e600-a747-11ea-9343-d4bccb54baf4.png">

#### Testing instructions

You might need to enable the `manage/all-domains` flag by appending `?flags=manage/all-domains` to the URL. Verify that the change does not affect anything when the flag is disabled (prepend a `-` sign before the flag's name to disable it: `?flags=-manage/all-domains`)

For any site you own, visit the domain settings for a domain you own, and the first item you see in the navigation links below, should be the link to manage your site. This should appear for all types of domains.

Verify that clicking the item sends you to the appropriate page.
