### PR TITLE
Revert "Remove async loading of lib/user/utils as it confuses webpack"

### DIFF
--- a/client/lib/wpcom-xhr-wrapper/index.js
+++ b/client/lib/wpcom-xhr-wrapper/index.js
@@ -4,17 +4,14 @@
 import debugModule from 'debug';
 
 /**
- * Internal dependencies
- */
-import userUtils from 'lib/user/utils';
-
-/**
  * Module variables
  */
 const debug = debugModule( 'calypso:wpcom-xhr-wrapper' );
 
 export default async function ( params, callback ) {
 	const xhr = ( await import( /* webpackChunkName: "wpcom-xhr-request" */ 'wpcom-xhr-request' ) )
+		.default;
+	const userUtils = ( await import( /* webpackChunkName: "lib-user-utils" */ 'lib/user/utils' ) )
 		.default;
 
 	return xhr( params, function ( error, response, headers ) {


### PR DESCRIPTION
Reverts Automattic/wp-calypso#43012