### PR TITLE
Remove async loading of lib/user/utils as it confuses webpack (try # 2)

### DIFF
--- a/client/lib/user/utils.js
+++ b/client/lib/user/utils.js
@@ -8,18 +8,12 @@ import debugModule from 'debug';
  * Internal dependencies
  */
 import config from 'config';
-import userModule from 'lib/user';
-import { once } from 'lib/memoize-last';
+import user from 'lib/user';
 
 /**
  * Module Variables
  */
 const debug = debugModule( 'calypso:user:utilities' );
-
-// Delay initialisation of `user`, to avoid circular dependency issues.
-// `user` becomes a function that runs `userModule()` when it's first invoked,
-// saves the return value, and simply returns it on subsequent calls.
-const user = once( () => userModule() );
 
 const userUtils = {
 	getLogoutUrl( redirect ) {

--- a/client/lib/user/utils.js
+++ b/client/lib/user/utils.js
@@ -16,6 +16,9 @@ import { once } from 'lib/memoize-last';
  */
 const debug = debugModule( 'calypso:user:utilities' );
 
+// Delay initialisation of `user`, to avoid circular dependency issues.
+// `user` becomes a function that runs `userModule()` when it's first invoked,
+// saves the return value, and simply returns it on subsequent calls.
 const user = once( () => userModule() );
 
 const userUtils = {

--- a/client/lib/user/utils.js
+++ b/client/lib/user/utils.js
@@ -9,23 +9,18 @@ import debugModule from 'debug';
  */
 import config from 'config';
 import userModule from 'lib/user';
+import { once } from 'lib/memoize-last';
 
 /**
  * Module Variables
  */
-let user;
 const debug = debugModule( 'calypso:user:utilities' );
 
-function initUser() {
-	user = user || userModule();
-	return user;
-}
+const user = once( () => userModule() );
 
 const userUtils = {
 	getLogoutUrl( redirect ) {
-		initUser();
-
-		const userData = user.get();
+		const userData = user().get();
 		let url = '/logout',
 			subdomain = '';
 
@@ -54,23 +49,22 @@ const userUtils = {
 	},
 
 	logout( redirect ) {
-		initUser();
 		const logoutUrl = userUtils.getLogoutUrl( redirect );
 
 		// Clear any data stored locally within the user data module or localStorage
-		user.clear().then( () => {
-			window.location.href = logoutUrl;
-		} );
+		user()
+			.clear()
+			.then( () => {
+				window.location.href = logoutUrl;
+			} );
 	},
 
 	getLocaleSlug() {
-		initUser();
-		return user.get().localeSlug;
+		return user().get().localeSlug;
 	},
 
 	isLoggedIn() {
-		initUser();
-		return Boolean( user.data );
+		return Boolean( user().data );
 	},
 };
 

--- a/client/lib/user/utils.js
+++ b/client/lib/user/utils.js
@@ -13,11 +13,18 @@ import userModule from 'lib/user';
 /**
  * Module Variables
  */
-const user = userModule();
+let user;
 const debug = debugModule( 'calypso:user:utilities' );
+
+function initUser() {
+	user = user || userModule();
+	return user;
+}
 
 const userUtils = {
 	getLogoutUrl( redirect ) {
+		initUser();
+
 		const userData = user.get();
 		let url = '/logout',
 			subdomain = '';
@@ -47,6 +54,7 @@ const userUtils = {
 	},
 
 	logout( redirect ) {
+		initUser();
 		const logoutUrl = userUtils.getLogoutUrl( redirect );
 
 		// Clear any data stored locally within the user data module or localStorage
@@ -56,10 +64,12 @@ const userUtils = {
 	},
 
 	getLocaleSlug() {
+		initUser();
 		return user.get().localeSlug;
 	},
 
 	isLoggedIn() {
+		initUser();
 		return Boolean( user.data );
 	},
 };

--- a/client/lib/wpcom-xhr-wrapper/index.js
+++ b/client/lib/wpcom-xhr-wrapper/index.js
@@ -4,14 +4,17 @@
 import debugModule from 'debug';
 
 /**
+ * Internal dependencies
+ */
+import userUtils from 'lib/user/utils';
+
+/**
  * Module variables
  */
 const debug = debugModule( 'calypso:wpcom-xhr-wrapper' );
 
 export default async function ( params, callback ) {
 	const xhr = ( await import( /* webpackChunkName: "wpcom-xhr-request" */ 'wpcom-xhr-request' ) )
-		.default;
-	const userUtils = ( await import( /* webpackChunkName: "lib-user-utils" */ 'lib/user/utils' ) )
 		.default;
 
 	return xhr( params, function ( error, response, headers ) {


### PR DESCRIPTION
The previous attempt (#43012) broke `/new` because of the circular dependency it reintroduced.

This PR reintroduces the same fix, but fixes the circular dependency issue by delaying the initialisation of the `user` object in `lib/user/utils`, so that it happens when one of its methods gets called rather than on module initialisation.

This should keep the benefits of the previous fix (such as solving a `wp-desktop` issue) while working correctly for `/new` and the rest of Calypso as well.

#### Changes proposed in this Pull Request

* Reintroduce fix from #43012
* Delay initialisation of `user` object in `lib/user/utils`

#### Testing instructions

* verify that Jetpack Cloud continues to work correctly
* verify that `/new` continues to work correctly