### PR TITLE
Checkout: pass locale to Stripe

### DIFF
--- a/client/lib/stripe/index.js
+++ b/client/lib/stripe/index.js
@@ -379,11 +379,44 @@ export function withStripeProps( WrappedComponent ) {
  * @returns {string} A stripe-supported locale string like 'en'
  */
 function getStripeLocaleForLocale( locale ) {
+	const stripeSupportedLocales = [
+		'ar',
+		'bg',
+		'cs',
+		'da',
+		'de',
+		'el',
+		'et',
+		'en',
+		'es',
+		'fi',
+		'fr',
+		'he',
+		'id',
+		'it',
+		'ja',
+		'lt',
+		'lv',
+		'ms',
+		'nb',
+		'nl',
+		'pl',
+		'pt',
+		'ru',
+		'sk',
+		'sl',
+		'sv',
+		'zh',
+	];
 	if ( ! locale ) {
 		return 'auto';
 	}
 	if ( locale.toLowerCase() === 'pt-br' ) {
 		return 'pt-BR';
 	}
-	return locale.toLowerCase().substring( 0, 2 );
+	const stripeLocale = locale.toLowerCase().substring( 0, 2 );
+	if ( ! stripeSupportedLocales.includes( stripeLocale ) ) {
+		return 'auto';
+	}
+	return stripeLocale;
 }

--- a/client/lib/stripe/index.js
+++ b/client/lib/stripe/index.js
@@ -252,7 +252,7 @@ function useStripeJs( stripeConfiguration ) {
 		} );
 
 		return () => ( isSubscribed = false );
-	}, [ stripeConfiguration, stripeJs ] );
+	}, [ stripeConfiguration, stripeJs, stripeLocale ] );
 	return { stripeJs, isStripeLoading, stripeLoadingError };
 }
 

--- a/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
@@ -545,7 +545,6 @@ function CreditCardLoading() {
 				id="credit-card-number"
 				type="Number"
 				label={ __( 'Card number' ) }
-				placeholder="1234 1234 1234 1234"
 				icon={ <LockIcon /> }
 				isIconVisible={ true }
 				autoComplete="cc-number"
@@ -558,7 +557,6 @@ function CreditCardLoading() {
 						id="card-expiry"
 						type="Number"
 						label={ __( 'Expiry date' ) }
-						placeholder="MM / YY"
 						autoComplete="cc-exp"
 						value={ '' }
 						disabled={ true }
@@ -572,7 +570,6 @@ function CreditCardLoading() {
 								<Field
 									id="card-cvc"
 									type="Number"
-									placeholder="CVC"
 									autoComplete="cc-csc"
 									value={ '' }
 									disabled={ true }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This passes the current locale string to Stripe when initializing stripe.js which powers our Credit card forms in both old and new checkout.

This will localize the error messages that Stripe returns as well as the form field placeholders.

Fixes https://github.com/Automattic/wp-calypso/issues/38439

#### Testing instructions

- Visit http://calypso.localhost:3000/me/account and change your language to French.
- Add a plan to your cart and visit old checkout. 
- Verify that the placeholder for the credit card expiration field reads `MM/AA`.
- Enter an invalid credit card number and press submit. Verify that the displayed error is localized to French.

<img width="293" alt="Screen Shot 2020-06-05 at 12 33 24 PM" src="https://user-images.githubusercontent.com/2036909/83901493-da3a3680-a728-11ea-9b10-91357a41b800.png">

- Visit new checkout. You'll need to add `?flags=composite-checkout-force` to the URL to override the locale detection that blocks it for now.
- Verify that the placeholder for the credit card expiration field reads `MM/AA`. (Note that the form labels won't be translated.)

