### PR TITLE
Reader: Tweak spacing and sizing around bylines

### DIFF
--- a/client/blocks/reader-avatar/style.scss
+++ b/client/blocks/reader-avatar/style.scss
@@ -3,7 +3,7 @@
 	max-height: 105px;
 
 	&.is-compact {
-		max-height: 32px;
+		max-height: 34px;
 	}
 }
 

--- a/client/blocks/reader-combined-card/style.scss
+++ b/client/blocks/reader-combined-card/style.scss
@@ -1,7 +1,7 @@
 .reader-combined-card__header {
 	font-size: $font-body-small;
 	display: flex;
-	max-height: 32px;
+	max-height: 34px;
 	margin-bottom: 20px;
 }
 
@@ -14,7 +14,7 @@
 	display: flex;
 	flex-direction: column;
 	justify-content: space-between;
-	max-height: 32px;
+	max-height: 34px;
 }
 
 .reader-combined-card__site-link {
@@ -173,7 +173,7 @@
 	color: var( --color-text-subtle );
 	font-family: $sans;
 	overflow: hidden;
-	max-height: 13px * 1.4 * 1;
+	max-height: 14px * 1.4 * 1;
 	word-wrap: break-word;
 	position: relative;
 	margin-top: 3px;

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -349,6 +349,7 @@
 	fill: var( --color-neutral-light );
 	flex: 0 0 15px;
 	margin-right: 5px;
+	margin-top: 3px;
 }
 
 .reader-post-card__byline .reader-avatar {
@@ -361,7 +362,7 @@
 	.gravatar {
 		float: left;
 		height: 32px;
-		margin: 2px 6px 0 0;
+		margin: 4px 6px 0 0;
 		vertical-align: text-top;
 		width: 32px;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* I noticed after I deployed the changes to font sizing from 13px to 14px in #42941 that spacing around the bylines looked off. This PR fixes instances where descenders might get cut off due to max-height/overflow hidden on the container, and vertically aligns avatars and the tag icon.

| Before | After |
| -------- | ------- |
| <img width="307" alt="Screen Shot 2020-06-05 at 1 13 04 PM" src="https://user-images.githubusercontent.com/2124984/83905653-0d33f880-a730-11ea-8542-e7005837623d.png"> | <img width="317" alt="Screen Shot 2020-06-05 at 1 12 48 PM" src="https://user-images.githubusercontent.com/2124984/83905654-0dcc8f00-a730-11ea-9ed5-9effd7bce148.png"> |
| <img width="327" alt="Screen Shot 2020-06-05 at 1 14 44 PM" src="https://user-images.githubusercontent.com/2124984/83905651-0c9b6200-a730-11ea-88e9-518524531363.png"> | <img width="417" alt="Screen Shot 2020-06-05 at 1 14 29 PM" src="https://user-images.githubusercontent.com/2124984/83905652-0d33f880-a730-11ea-8495-793bdc18f5ee.png"> |
| <img width="309" alt="Screen Shot 2020-06-05 at 1 07 22 PM" src="https://user-images.githubusercontent.com/2124984/83905809-5126fd80-a730-11ea-923a-af77dd21e4c2.png"> | <img width="226" alt="Screen Shot 2020-06-05 at 1 28 36 PM" src="https://user-images.githubusercontent.com/2124984/83905888-7a478e00-a730-11ea-9421-848e1d9a8c6f.png"> |

#### Testing instructions

* Switch to this PR
* Navigate to `/read` and browse around, particularly in listings of posts.
* Note changes around the bylines/gravatars; are there any visual regressions? Any conditions I haven't accounted for?
