### PR TITLE
Typography: Update instances of 10px, 11px, 12px to use $font-body-extra-small

### DIFF
--- a/client/blocks/app-banner/style.scss
+++ b/client/blocks/app-banner/style.scss
@@ -27,7 +27,7 @@
 }
 
 .app-banner__copy {
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	font-weight: 400;
 }
 

--- a/client/blocks/app-promo/style.scss
+++ b/client/blocks/app-promo/style.scss
@@ -33,7 +33,7 @@
 	padding: 8px 34px 8px 50px;
 	background-color: var( --color-surface );
 	color: var( --color-primary );
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	box-shadow: 0 0 0 1px rgba( var( --color-neutral-10-rgb ), 0.5 ),
 		0 1px 2px var( --color-neutral-0 );
 

--- a/client/blocks/comments/comment-edit-form.scss
+++ b/client/blocks/comments/comment-edit-form.scss
@@ -54,7 +54,7 @@
 		top: 4px;
 		right: 16px;
 		padding: 4px;
-		font-size: 12px;
+		font-size: $font-body-extra-small;
 		font-weight: 600;
 		text-transform: uppercase;
 	color: var( --color-text-subtle );
@@ -76,7 +76,7 @@
 	}
 
 	.comments__cancel-reply {
-		font-size: 12px;
+		font-size: $font-body-extra-small;
 		cursor: pointer;
 	}
 }

--- a/client/blocks/comments/form.scss
+++ b/client/blocks/comments/form.scss
@@ -62,7 +62,7 @@
 		top: 4px;
 		right: 16px;
 		padding: 4px;
-		font-size: 12px;
+		font-size: $font-body-extra-small;
 		font-weight: 600;
 		text-transform: uppercase;
 	color: var( --color-text-subtle );
@@ -84,7 +84,7 @@
 	}
 
 	.comments__cancel-reply {
-		font-size: 12px;
+		font-size: $font-body-extra-small;
 		cursor: pointer;
 	}
 }

--- a/client/blocks/comments/post-comment.scss
+++ b/client/blocks/comments/post-comment.scss
@@ -155,5 +155,5 @@ a.comments__comment-username {
 	color: var( --color-text-subtle );
 	margin-top: 0.5em;
 	margin-bottom: 0.5em;
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 }

--- a/client/blocks/credit-card-form/style.scss
+++ b/client/blocks/credit-card-form/style.scss
@@ -14,7 +14,7 @@
 	}
 
 	p {
-		font-size: 12px;
+		font-size: $font-body-extra-small;
 		margin: 0;
 
 		@include breakpoint-deprecated( '>660px' ) {

--- a/client/blocks/get-apps/style.scss
+++ b/client/blocks/get-apps/style.scss
@@ -168,7 +168,7 @@
 }
 
 .get-apps__illustration-tagline {
-	font-size: 11px;
+	font-size: $font-body-extra-small;
 	margin-bottom: 0;
 	padding: 0 24px;
 

--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -122,7 +122,7 @@
 	}
 
 	p {
-		font-size: 12px;
+		font-size: $font-body-extra-small;
 
 		@include breakpoint-deprecated( '>660px' ) {
 			font-size: $font-body-small;
@@ -131,7 +131,7 @@
 
 	a,
 	button {
-		font-size: 12px;
+		font-size: $font-body-extra-small;
 
 		@include breakpoint-deprecated( '>660px' ) {
 			font-size: $font-body-small;

--- a/client/blocks/jitm/templates/sidebar-banner.scss
+++ b/client/blocks/jitm/templates/sidebar-banner.scss
@@ -1,5 +1,5 @@
 .sidebar-banner {
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 
 	.sidebar-banner__link {
 		background-color: var( --color-success );

--- a/client/blocks/login/social.scss
+++ b/client/blocks/login/social.scss
@@ -12,7 +12,7 @@
 }
 
 .login__social-tos {
-	font-size: 11px;
+	font-size: $font-body-extra-small;
 	margin: 1.5em 0 0;
 	text-align: center;
 }

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -192,7 +192,7 @@
 
 .login__form-terms,
 .login__form-signup-link {
-	font-size: 11px;
+	font-size: $font-body-extra-small;
 	text-align: center;
 
 	a {

--- a/client/blocks/login/two-factor-authentication/verification-code-form.scss
+++ b/client/blocks/login/two-factor-authentication/verification-code-form.scss
@@ -1,6 +1,6 @@
 .two-factor-authentication__small-print {
 	clear: both;
-	font-size: 11px;
+	font-size: $font-body-extra-small;
 	padding: 1em 0;
 }
 

--- a/client/blocks/plan-storage/style.scss
+++ b/client/blocks/plan-storage/style.scss
@@ -13,7 +13,7 @@
 
 .plan-storage__storage-label,
 .plan-storage__storage-link {
-	font-size: 11px;
+	font-size: $font-body-extra-small;
 	line-height: 1;
 	margin-top: 6px;
 }

--- a/client/blocks/post-item/style.scss
+++ b/client/blocks/post-item/style.scss
@@ -106,7 +106,7 @@ a.post-item__title-link:visited {
 }
 
 .post-item__meta {
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	color: var( --color-text-subtle );
 }
 

--- a/client/blocks/post-likes/style.scss
+++ b/client/blocks/post-likes/style.scss
@@ -57,7 +57,7 @@
 		color: var( --color-text-subtle );
 		padding: 1px 6px;
 		font-weight: 600;
-		font-size: 11px;
+		font-size: $font-body-extra-small;
 
 		&.is-loading {
 			border-color: transparent;

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -47,7 +47,7 @@
 .reader-full-post__visit-site-container {
 	background: var( --color-surface );
 	border-bottom: 1px solid var( --color-neutral-0 );
-	font-size: 11px;
+	font-size: $font-body-extra-small;
 	font-weight: 600;
 	height: 46px;
 	margin: 0;

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -88,7 +88,7 @@
 			.reader-post-card__title .reader-post-card__title-link {
 				color: var( --color-text-inverted );
 				display: inline;
-				font-size: 12px;
+				font-size: $font-body-extra-small;
 				letter-spacing: 0.01em;
 			}
 

--- a/client/blocks/reader-site-notification-settings/style.scss
+++ b/client/blocks/reader-site-notification-settings/style.scss
@@ -70,7 +70,7 @@
 .reader-site-notification-settings__popout-hint,
 .reader-site-notification-settings__popout-instructions-hint {
 	color: var( --color-text-subtle );
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	margin-bottom: 0;
 }
 

--- a/client/blocks/sharing-preview-pane/style.scss
+++ b/client/blocks/sharing-preview-pane/style.scss
@@ -122,7 +122,7 @@
 	}
 
 	.sharing-preview-pane__description {
-		font-size: 12px;
+		font-size: $font-body-extra-small;
 	}
 
 	@include breakpoint-deprecated( '>660px' ) {

--- a/client/blocks/signup-form/crowdsignal.scss
+++ b/client/blocks/signup-form/crowdsignal.scss
@@ -191,7 +191,7 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 }
 
 .signup-form__crowdsignal-learn-more {
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	margin-bottom: -10px;
 	margin-top: 20px;
 	text-align: center;

--- a/client/blocks/signup-form/crowdsignal.scss
+++ b/client/blocks/signup-form/crowdsignal.scss
@@ -303,7 +303,7 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 
 .signup-form__crowdsignal-footer-text {
 	display: none;
-	font-size: 10px;
+	font-size: $font-body-extra-small;
 	flex: 1;
 	height: 18px;
 	letter-spacing: 0.8px;

--- a/client/blocks/signup-form/style.scss
+++ b/client/blocks/signup-form/style.scss
@@ -16,7 +16,7 @@
 }
 
 .signup-form__terms-of-service-link {
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	margin: 0 0 20px;
 	text-align: center;
 

--- a/client/blocks/site/style.scss
+++ b/client/blocks/site/style.scss
@@ -169,7 +169,7 @@
 .site__badge {
 	background: var( --color-sidebar-menu-hover-background );
 	color: var( --color-sidebar-menu-hover-text );
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	border-radius: 12px;
 	clear: both;
 	display: inline-block;

--- a/client/blocks/site/style.scss
+++ b/client/blocks/site/style.scss
@@ -121,7 +121,7 @@
 	color: var( --color-text-subtle );
 	display: block;
 	max-width: 95%;
-	font-size: 11px;
+	font-size: $font-body-extra-small;
 	line-height: 1.4;
 	margin-top: 2px;
 }

--- a/client/blocks/subscription-length-picker/style.scss
+++ b/client/blocks/subscription-length-picker/style.scss
@@ -122,7 +122,7 @@
 	.subscription-length-picker__option-tax {
 		color: var( --color-text-subtle );
 		vertical-align: super;
-		font-size: 12px;
+		font-size: $font-body-extra-small;
 		margin-left: 1px;
 	}
 

--- a/client/blocks/taxonomy-manager/style.scss
+++ b/client/blocks/taxonomy-manager/style.scss
@@ -81,7 +81,7 @@
 		.taxonomy-manager__default-label {
 			text-transform: uppercase;
 			color: var( --color-accent );
-			font-size: 12px;
+			font-size: $font-body-extra-small;
 			margin-left: 10px;
 		}
 

--- a/client/blocks/term-tree-selector/terms.scss
+++ b/client/blocks/term-tree-selector/terms.scss
@@ -13,7 +13,7 @@
 	}
 
 	&.is-compact .term-tree-selector__search input[type='search'] {
-		font-size: 12px;
+		font-size: $font-body-extra-small;
 	}
 }
 
@@ -67,7 +67,7 @@ input[type='checkbox'].term-tree-selector__input {
 	margin-top: 2px;
 
 	.term-tree-selector.is-compact & {
-		font-size: 12px;
+		font-size: $font-body-extra-small;
 		margin-top: 0;
 	}
 

--- a/client/blocks/upload-drop-zone/style.scss
+++ b/client/blocks/upload-drop-zone/style.scss
@@ -35,7 +35,7 @@
 
 .upload-drop-zone__instructions {
 	font-style: italic;
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 }
 
 

--- a/client/blocks/user-mentions/suggestion.scss
+++ b/client/blocks/user-mentions/suggestion.scss
@@ -24,7 +24,7 @@ $user-mentions-avatar-margin: 10px;
 .user-mentions__fullname {
 	clear: left;
 	margin-left: $user-mentions-avatar-size + $user-mentions-avatar-margin;
-	font-size: 11px;
+	font-size: $font-body-extra-small;
 
 	@include breakpoint-deprecated( '>480px' ) {
 		float: right;

--- a/client/components/accordion/style.scss
+++ b/client/components/accordion/style.scss
@@ -101,7 +101,7 @@ $accordion-background-expanded: var( --color-surface );
 }
 
 .accordion__subtitle {
-	font-size: 11px;
+	font-size: $font-body-extra-small;
 	color: var( --color-text-subtle );
 	font-weight: 400;
 	white-space: nowrap;

--- a/client/components/action-panel/style.scss
+++ b/client/components/action-panel/style.scss
@@ -60,7 +60,7 @@ a.action-panel__body-text-link {
 
 .action-panel__figure-header {
 	margin-bottom: 8px;
-	font-size: 11px;
+	font-size: $font-body-extra-small;
 	line-height: 16px;
 	text-transform: uppercase;
 	text-align: left;

--- a/client/components/activity-card/style.scss
+++ b/client/components/activity-card/style.scss
@@ -53,7 +53,7 @@
 
 .activity-card__time-text {
 	color: var( --color-neutral-40 );
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	line-height: 17px;
 	margin-left: 4px;
 }
@@ -87,7 +87,7 @@
 	a,
 	button.button.is-borderless.is-compact {
 		font-weight: 400;
-		font-size: 12px;
+		font-size: $font-body-extra-small;
 		display: flex;
 		align-items: center;
 		@include breakpoint-deprecated( '>660px' ) {
@@ -158,7 +158,7 @@
 
 .activity-card__streams-item-title {
 	margin-bottom: 12px;
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	text-align: left;
 }
 

--- a/client/components/banner/style.scss
+++ b/client/components/banner/style.scss
@@ -11,7 +11,7 @@
 
 	&.is-compact {
 		border-left-width: 4px;
-		font-size: 12px;
+		font-size: $font-body-extra-small;
 		margin-bottom: 8px;
 		padding: 8px 12px 8px 8px;
 	}
@@ -149,12 +149,12 @@
 	}
 
 	.banner__description {
-		font-size: 12px;
+		font-size: $font-body-extra-small;
 		margin-top: 3px;
 	}
 
 	.banner__list {
-		font-size: 12px;
+		font-size: $font-body-extra-small;
 		list-style: none;
 		margin: 0;
 		li {
@@ -178,12 +178,12 @@
 }
 
 .banner.is-compact .banner__title {
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 }
 
 .banner__action {
 	align-self: center;
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	margin: 8px 0 0;
 	text-align: left;
 	width: 100%;

--- a/client/components/card-heading/style.scss
+++ b/client/components/card-heading/style.scss
@@ -42,5 +42,5 @@
 }
 
 .card-heading-11 {
-	font-size: 11px;
+	font-size: $font-body-extra-small;
 }

--- a/client/components/chart/style.scss
+++ b/client/components/chart/style.scss
@@ -58,7 +58,7 @@ $y-axis-padding: 0 20px 0 10px;
 	float: right;
 	height: 200px;
 	padding: $y-axis-padding;
-	font-size: 11px;
+	font-size: $font-body-extra-small;
 	color: var( --color-neutral-40 );
 	margin-bottom: 30px;
 }
@@ -90,7 +90,7 @@ $y-axis-padding: 0 20px 0 10px;
 	position: absolute;
 	display: inline-block;
 	vertical-align: top;
-	font-size: 11px;
+	font-size: $font-body-extra-small;
 	text-align: center;
 }
 
@@ -225,7 +225,7 @@ $y-axis-padding: 0 20px 0 10px;
 	color: var( --color-neutral );
 	list-style-type: none;
 	margin: 0;
-	font-size: 11px;
+	font-size: $font-body-extra-small;
 	text-transform: uppercase;
 	letter-spacing: 0.1em;
 
@@ -330,7 +330,7 @@ $y-axis-padding: 0 20px 0 10px;
 			padding: 0;
 
 			li {
-				font-size: 11px;
+				font-size: $font-body-extra-small;
 				text-transform: uppercase;
 				font-weight: 400;
 				height: 24px;
@@ -379,7 +379,7 @@ $y-axis-padding: 0 20px 0 10px;
 					text-align: center;
 
 					.rtl & {
-						font-size: 11px;
+						font-size: $font-body-extra-small;
 					}
 
 					.post-count {
@@ -396,7 +396,7 @@ $y-axis-padding: 0 20px 0 10px;
 
 .chart__tooltip .module-content-list-item {
 	&.is-date-label {
-		font-size: 11px;
+		font-size: $font-body-extra-small;
 		margin-bottom: 2px;
 		text-transform: uppercase;
 		font-weight: 600;

--- a/client/components/community-translator/style.scss
+++ b/client/components/community-translator/style.scss
@@ -33,7 +33,7 @@
 }
 
 .community-translator__dialog-content {
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 }
 
 .community-translator__string-container {
@@ -65,7 +65,7 @@
 		min-height: auto;
 		padding: 7px;
 		line-height: 1;
-		font-size: 12px;
+		font-size: $font-body-extra-small;
 	}
 	&.placeholder > span {
 		animation: pulse-light 800ms ease-in-out infinite;

--- a/client/components/count/style.scss
+++ b/client/components/count/style.scss
@@ -3,7 +3,7 @@
 	padding: 1px 6px;
 	border: solid 1px var( --color-border );
 	border-radius: 12px;
-	font-size: 11px;
+	font-size: $font-body-extra-small;
 	font-weight: 600;
 	line-height: 14px;
 	color: var( --color-text );

--- a/client/components/date-picker/style.scss
+++ b/client/components/date-picker/style.scss
@@ -147,7 +147,7 @@ $date-picker_nav_button_size: 20px;
 .DayPicker-Weekday {
 	display: table-cell;
 	padding: 15px 0 10px;
-	font-size: 11px;
+	font-size: $font-body-extra-small;
 	text-align: center;
 	font-weight: 600;
 	color: var( --color-neutral-50 );
@@ -186,7 +186,7 @@ $date-picker_nav_button_size: 20px;
 	line-height: 34px;
 	vertical-align: middle;
 	text-align: center;
-	font-size: 11px;
+	font-size: $font-body-extra-small;
 	font-weight: 600;
 }
 

--- a/client/components/date-picker/style.scss
+++ b/client/components/date-picker/style.scss
@@ -67,7 +67,7 @@ $date-picker_nav_button_size: 20px;
 .date-picker__next-month {
 	float: right;
 	padding: 1px 8px;
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	text-transform: capitalize;
 	cursor: pointer;
 	z-index: 2;

--- a/client/components/date-range/style.scss
+++ b/client/components/date-range/style.scss
@@ -175,7 +175,7 @@
 	flex: 1;
 
 	.form-label {
-		font-size: 10px;
+		font-size: $font-body-extra-small;
 		text-transform: uppercase;
 		margin-bottom: 0;
 	}

--- a/client/components/date-range/style.scss
+++ b/client/components/date-range/style.scss
@@ -92,7 +92,7 @@
 	&,
 	.button {
 		padding: 0;
-		font-size: 12px;
+		font-size: $font-body-extra-small;
 		font-weight: 600;
     	line-height: 18px;
 	}
@@ -124,7 +124,7 @@
 	}
 
 	.DayPicker-Caption {
-		font-size: 12px;
+		font-size: $font-body-extra-small;
 	}
 }
 

--- a/client/components/domains/contact-details-form-fields/style.scss
+++ b/client/components/domains/contact-details-form-fields/style.scss
@@ -80,7 +80,7 @@
 
 	.form__hidden-input a {
 		display: block;
-		font-size: 12px;
+		font-size: $font-body-extra-small;
 		margin-top: 5px;
 	}
 

--- a/client/components/domains/domain-skip-suggestion/style.scss
+++ b/client/components/domains/domain-skip-suggestion/style.scss
@@ -20,7 +20,7 @@
 
 	p {
 		color: var( --color-neutral-70 );
-		font-size: 12px;
+		font-size: $font-body-extra-small;
 		margin-bottom: 0;
 
 		@include breakpoint-deprecated( '>960px' ) {

--- a/client/components/domains/domain-transfer-suggestion/style.scss
+++ b/client/components/domains/domain-transfer-suggestion/style.scss
@@ -35,7 +35,7 @@
 
 	> p {
 		color: var( --color-neutral-70 );
-		font-size: 12px;
+		font-size: $font-body-extra-small;
 		margin-bottom: 0;
 
 		@include breakpoint-deprecated( '>960px' ) {

--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -104,7 +104,7 @@
 	.domain-registration-suggestion__progress-bar {
 		align-items: center;
 		display: flex;
-		font-size: 12px;
+		font-size: $font-body-extra-small;
 		margin-top: 10px;
 		order: 2;
 
@@ -120,7 +120,7 @@
 
 	.domain-registration-suggestion__match-reason {
 		color: var( --color-text-subtle );
-		font-size: 12px;
+		font-size: $font-body-extra-small;
 		padding: 0.125em 0;
 		display: flex;
 		align-items: center;

--- a/client/components/domains/transfer-domain-step/style.scss
+++ b/client/components/domains/transfer-domain-step/style.scss
@@ -198,7 +198,7 @@
 }
 
 .transfer-domain-step__lock-status {
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	display: flex;
 	align-items: center;
 	margin-left: 10px;

--- a/client/components/foldable-card/style.scss
+++ b/client/components/foldable-card/style.scss
@@ -145,7 +145,7 @@ button.foldable-card__action {
 .foldable-card__summary-expanded {
 	margin-right: 40px;
 	color: var( --color-text-subtle );
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	transition: opacity 0.2s linear;
 	display: inline-block;
 

--- a/client/components/forms/counted-textarea/style.scss
+++ b/client/components/forms/counted-textarea/style.scss
@@ -21,6 +21,6 @@
 
 .counted-textarea__count-panel {
 	padding: 8px;
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	color: var( --color-neutral-50 );
 }

--- a/client/components/gauge/style.scss
+++ b/client/components/gauge/style.scss
@@ -13,7 +13,7 @@
 		display: block;
 		color: var( --color-neutral-50 );
 		text-transform: uppercase;
-		font-size: 10px;
+		font-size: $font-body-extra-small;
 		letter-spacing: 0.1em;
 		font-weight: 600;
 		line-height: 0.7;

--- a/client/components/input-chrono/style.scss
+++ b/client/components/input-chrono/style.scss
@@ -13,7 +13,7 @@
 	box-sizing: border-box;
 	background-color: rgba( var( --color-surface-rgb ), 0 );
 	color: var( --color-text-subtle );
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	text-align: left;
 	position: relative;
 	z-index: z-index( '.popover', '.input-chrono__input' );

--- a/client/components/jetpack/log-item/style.scss
+++ b/client/components/jetpack/log-item/style.scss
@@ -21,7 +21,7 @@
 		padding: 2px 6px;
 		border-radius: 3px;
 		background-color: var( --color-log-item );
-		font-size: 10px;
+		font-size: $font-body-extra-small;
 		color: var( --color-text-inverted );
 		text-transform: uppercase;
 		text-align: center;

--- a/client/components/line-chart/style.scss
+++ b/client/components/line-chart/style.scss
@@ -98,7 +98,7 @@
 
 .line-chart__x-axis,
 .line-chart__y-axis {
-	font-size: 11px;
+	font-size: $font-body-extra-small;
 
 	.domain,
 	line {

--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -118,7 +118,7 @@
 
 .notice__content {
 	padding: 13px;
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	flex-grow: 1;
 
 	.notice__text {
@@ -199,7 +199,7 @@
 // specificity for general `a` elements within notice is too great
 a.notice__action {
 	cursor: pointer;
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	font-weight: 400;
 	text-decoration: none;
 	white-space: nowrap;
@@ -255,7 +255,7 @@ a.notice__action {
 	line-height: 1.5;
 
 	.notice__content {
-		font-size: 12px;
+		font-size: $font-body-extra-small;
 		padding: 6px 10px;
 	}
 
@@ -293,7 +293,7 @@ a.notice__action {
 		background: transparent;
 		display: inline-block;
 		margin: 0;
-		font-size: 12px;
+		font-size: $font-body-extra-small;
 		align-self: center;
 		margin-left: 16px;
 		padding: 0 10px;

--- a/client/components/plans/plan-pill/style.scss
+++ b/client/components/plans/plan-pill/style.scss
@@ -8,7 +8,7 @@
 	border-radius: 3px;
 	background: var( --color-accent );
 	
-	font-size: 11px;
+	font-size: $font-body-extra-small;
 	text-align: center;
 	line-height: 1;
 	color: var( --color-text-inverted );

--- a/client/components/popover/style.scss
+++ b/client/components/popover/style.scss
@@ -3,7 +3,7 @@
  */
 
 .popover {
-	font-size: 11px;
+	font-size: $font-body-extra-small;
 	z-index: z-index( 'root', '.popover' );
 	position: absolute;
 	top: 0;

--- a/client/components/post-schedule/style.scss
+++ b/client/components/post-schedule/style.scss
@@ -88,7 +88,7 @@
 .post-schedule__clock {
 	text-align: center;
 	margin: 15px auto 10px;
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 }
 
 hr.post-schedule__hr {
@@ -141,7 +141,7 @@ input[type='text'].post-schedule__clock-time {
 	margin-left: 0;
 
 	.popover__inner {
-		font-size: 12px;
+		font-size: $font-body-extra-small;
 		max-width: 250px;
 	}
 }

--- a/client/components/product-card/style.scss
+++ b/client/components/product-card/style.scss
@@ -119,7 +119,7 @@
 	}
 
 	@include breakpoint-deprecated( '>960px' ) {
-		font-size: 12px;
+		font-size: $font-body-extra-small;
 	}
 }
 
@@ -137,7 +137,7 @@
 
 		@include breakpoint-deprecated( '>660px' ) {
 			width: auto;
-			font-size: 12px;
+			font-size: $font-body-extra-small;
 			font-weight: 600;
 		}
 	}
@@ -324,7 +324,7 @@
 	border-radius: 16px;
 	background-color: var( --color-neutral-0 );
 	color: var( --color-text-subtle );
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	line-height: 18px;
 	text-align: left;
 	text-transform: uppercase;

--- a/client/components/search/style.scss
+++ b/client/components/search/style.scss
@@ -65,7 +65,7 @@
 		height: 36px;
 		.search__input {
 			height: 36px;
-			font-size: 12px;
+			font-size: $font-body-extra-small;
 		}
 
 		.search__open-icon {

--- a/client/components/section-nav/style.scss
+++ b/client/components/section-nav/style.scss
@@ -81,7 +81,7 @@
 
 	small {
 		margin-left: 5px;
-		font-size: 11px;
+		font-size: $font-body-extra-small;
 		color: var( --color-neutral-light );
 		font-weight: 600;
 		text-transform: uppercase;
@@ -162,7 +162,7 @@
 	display: none;
 	margin-bottom: 8px;
 	padding: 0 15px;
-	font-size: 11px;
+	font-size: $font-body-extra-small;
 	color: var( --color-neutral-light );
 	font-weight: 600;
 	text-transform: uppercase;

--- a/client/components/select-dropdown/style.scss
+++ b/client/components/select-dropdown/style.scss
@@ -90,7 +90,7 @@ $compact-header-height: 35;
 		height: #{$compact-header-height}px;
 		line-height: #{$compact-header-height - 3}px;
 		padding-right: #{$side-margin / 2}px;
-		font-size: 12px;
+		font-size: $font-body-extra-small;
 
 		.count {
 			border-width: 0;
@@ -279,7 +279,7 @@ $compact-header-height: 35;
 	line-height: 20px;
 
 	label {
-		font-size: 12px;
+		font-size: $font-body-extra-small;
 		padding: 0 #{$side-margin}px;
 	}
 }

--- a/client/components/seo-preview-pane/style.scss
+++ b/client/components/seo-preview-pane/style.scss
@@ -74,7 +74,7 @@
 	}
 
 	.seo-preview-pane__description {
-		font-size: 12px;
+		font-size: $font-body-extra-small;
 		color: var( --color-neutral-light );
 	}
 

--- a/client/components/seo/facebook-preview/style.scss
+++ b/client/components/seo/facebook-preview/style.scss
@@ -44,7 +44,7 @@
 	color: #1d2129;
 	flex-grow: 1;
 	font-family: helvetica, arial, sans-serif;
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	line-height: 16px;
 	overflow-y: hidden;
 }
@@ -52,7 +52,7 @@
 .facebook-preview__url {
 	color: #606770;
 	font-family: helvetica, arial, sans-serif;
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	line-height: 12px;
 	text-transform: uppercase;
 	text-overflow: ellipsis;

--- a/client/components/seo/meta-title-editor/style.scss
+++ b/client/components/seo/meta-title-editor/style.scss
@@ -10,7 +10,7 @@
 */
 
 .meta-title-editor .segmented-control__link {
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	line-height: 16px;
 	padding: 4px 2px;
 

--- a/client/components/seo/search-preview/style.scss
+++ b/client/components/seo/search-preview/style.scss
@@ -15,7 +15,7 @@
 	background-color: var( --color-neutral-0 );
 	border: 1px solid var( --color-neutral-0 );
 	border-bottom: 0;
-	font-size: 11px;
+	font-size: $font-body-extra-small;
 	line-height: 1;
 	font-weight: bold;
 	text-transform: uppercase;

--- a/client/components/share/facebook-share-preview/style.scss
+++ b/client/components/share/facebook-share-preview/style.scss
@@ -67,7 +67,7 @@
 
 .facebook-share-preview__meta-line {
 	color: #616770;
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	line-height: 1.34;
 }
 

--- a/client/components/share/style.scss
+++ b/client/components/share/style.scss
@@ -33,7 +33,7 @@
 	color: #4b4f56;
 	flex-grow: 1;
 	font-family: helvetica, arial, sans-serif;
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	line-height: 16px;
 	overflow-y: hidden;
 }

--- a/client/components/share/style.scss
+++ b/client/components/share/style.scss
@@ -41,7 +41,7 @@
 .facebook-share-preview__url {
 	color: #90949c;
 	font-family: helvetica, arial, sans-serif;
-	font-size: 11px;
+	font-size: $font-body-extra-small;
 	line-height: 11px;
 	text-transform: uppercase;
 	text-overflow: ellipsis;

--- a/client/components/signup-site-preview/style.scss
+++ b/client/components/signup-site-preview/style.scss
@@ -125,7 +125,7 @@
 		right: 0;
 		left: 0;
 		margin: 0 auto;
-		font-size: 11px;
+		font-size: $font-body-extra-small;
 		text-align: center;
 		text-transform: uppercase;
 		font-weight: 600;
@@ -151,7 +151,7 @@
 		position: relative;
 		top: 6px;
 		margin: 0 auto;
-		font-size: 11px;
+		font-size: $font-body-extra-small;
 		text-align: center;
 		text-transform: uppercase;
 		font-weight: 600;

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -199,7 +199,7 @@
 .site-selector__hidden-sites-message {
 	color: var( --color-text-subtle );
 	display: block;
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	padding: 16px 16px 24px;
 
 	.site-selector__manage-hidden-sites {

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -156,7 +156,7 @@
 	box-sizing: border-box;
 	display: inline-block;
 	text-transform: uppercase;
-	font-size: 11px;
+	font-size: $font-body-extra-small;
 	font-weight: 600;
 	padding: 8px;
 	color: var( --color-neutral-40 );

--- a/client/components/site-verticals-suggestion-search/style.scss
+++ b/client/components/site-verticals-suggestion-search/style.scss
@@ -6,7 +6,7 @@
 }
 
 .site-verticals-suggestion-search__heading {
-	font-size: 10px;
+	font-size: $font-body-extra-small;
 	font-weight: 600;
 	text-transform: uppercase;
 	padding: 12px 24px 8px 42px;

--- a/client/components/sites-popover/style.scss
+++ b/client/components/sites-popover/style.scss
@@ -24,7 +24,7 @@
 .sites-popover.has-header .sites-popover__header {
 	border-bottom: 1px solid var( --color-neutral-0 );
 	color: var( --color-neutral-40 );
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	font-weight: 600;
 	padding: 10px 10px 8px 8px;
 }

--- a/client/components/sorted-grid/style.scss
+++ b/client/components/sorted-grid/style.scss
@@ -12,7 +12,7 @@
 	padding: 6px 0;
 	margin: 0 10px 0 0;
 	color: var( --color-neutral-light );
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	font-weight: 600;
 	line-height: 18px;
 	text-transform: uppercase;

--- a/client/components/theme/style.scss
+++ b/client/components/theme/style.scss
@@ -130,7 +130,7 @@ $theme-info-height: 54px;
 	padding: 18px 10px 0;
 	color: var( --color-primary-0 );
 	text-transform: uppercase;
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	font-weight: 600;
 }
 

--- a/client/components/theme/style.scss
+++ b/client/components/theme/style.scss
@@ -167,7 +167,7 @@ $theme-info-height: 54px;
 
 		color: var( --color-neutral-70 );
 		text-transform: uppercase;
-		font-size: 11px;
+		font-size: $font-body-extra-small;
 		font-weight: 600;
 	}
 }

--- a/client/components/tinymce/plugins/wpcom-view/views/simple-payments/style.scss
+++ b/client/components/tinymce/plugins/wpcom-view/views/simple-payments/style.scss
@@ -121,7 +121,7 @@
 	top: 50%;
 	width: 43px;
 	font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
-	font-size: 10px;
+	font-size: $font-body-extra-small;
 	font-style: normal;
 	font-weight: 600;
 	line-height: normal;

--- a/client/components/tinymce/style.scss
+++ b/client/components/tinymce/style.scss
@@ -587,7 +587,7 @@ div.mce-path {
 .mce-path,
 .mce-path-item,
 .mce-path .mce-divider {
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	line-height: 18px;
 }
 
@@ -983,7 +983,7 @@ div.mce-menu .mce-menu-item-sep,
 .mce-tooltip-inner {
 	box-shadow: 0 3px 5px rgba( 0, 0, 0, 0.2 );
 	color: #fff;
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 }
 
 /* TinyMCE icons */
@@ -1347,7 +1347,7 @@ i.mce-i-wp_code::before {
 .wp-media-buttons a {
 	text-decoration: none;
 	color: #464646;
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 }
 
 .wp-media-buttons img {
@@ -1474,7 +1474,7 @@ i.mce-i-wp_code::before {
 @include breakpoint-deprecated( '<660px' ) {
 	.wp-core-ui .quicktags-toolbar input.button.button-small {
 		/* .button-small is normaly 11px, but a bit too small for these buttons. */
-		font-size: 12px;
+		font-size: $font-body-extra-small;
 		height: 26px;
 		line-height: 24px;
 	}

--- a/client/components/title-format-editor/style.scss
+++ b/client/components/title-format-editor/style.scss
@@ -42,7 +42,7 @@
 	padding: 3px 8px;
 	margin-left: 10px;
 	margin-top: 3px;
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	font-weight: 600;
 	cursor: pointer;
 

--- a/client/components/title-format-editor/style.scss
+++ b/client/components/title-format-editor/style.scss
@@ -79,7 +79,7 @@
 .title-format-editor__token-close {
 	margin-left: 10px;
 	color: var( --color-neutral-20 );
-	font-size: 10px;
+	font-size: $font-body-extra-small;
 }
 
 .title-format-editor__preview {

--- a/client/components/tooltip/style.scss
+++ b/client/components/tooltip/style.scss
@@ -124,7 +124,7 @@
 		border-radius: 2px;
 		color: var( --color-text-inverted );
 		background: var( --color-neutral-60 );
-		font-size: 12px;
+		font-size: $font-body-extra-small;
 		padding: 6px 10px;
 		text-align: left;
 	}
@@ -154,7 +154,7 @@
 
 		li {
 			font-size: 11px;
-			font-weight: 100;
+			font-weight: 400;
 			border: 0;
 			padding: 2px 0;
 		}

--- a/client/components/tooltip/style.scss
+++ b/client/components/tooltip/style.scss
@@ -153,7 +153,7 @@
 		padding: 0;
 
 		li {
-			font-size: 11px;
+			font-size: $font-body-extra-small;
 			font-weight: 400;
 			border: 0;
 			padding: 2px 0;

--- a/client/components/translator-invite/style.scss
+++ b/client/components/translator-invite/style.scss
@@ -1,6 +1,6 @@
 .translator-invite__content {
 	margin: 15px auto;
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	font-style: italic;
 	max-width: 75%;
 	text-align: center;

--- a/client/components/version/style.scss
+++ b/client/components/version/style.scss
@@ -1,6 +1,6 @@
 .version {
 	text-transform: uppercase;
-	font-size: 11px;
+	font-size: $font-body-extra-small;
 	color: var( --color-text-subtle );
 	line-height: 18px;
 	@include clear-fix;

--- a/client/components/wizard/progress-indicator.scss
+++ b/client/components/wizard/progress-indicator.scss
@@ -3,7 +3,7 @@
 	align-items: center;
 	justify-content: center;
 	color: var( --color-text-subtle );
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	margin-bottom: 8px;
 	text-align: center;
 

--- a/client/extensions/woocommerce/app/order/order-activity-log/style.scss
+++ b/client/extensions/woocommerce/app/order/order-activity-log/style.scss
@@ -66,7 +66,7 @@
 
 	.order-activity-log__note-time {
 		display: block;
-		font-size: 12px;
+		font-size: $font-body-extra-small;
 		background: white;
 	}
 
@@ -80,7 +80,7 @@
 	}
 
 	.order-activity-log__note-type {
-		font-size: 12px;
+		font-size: $font-body-extra-small;
 		color: var( --color-text-subtle );
 		text-transform: uppercase;
 	}

--- a/client/extensions/woocommerce/app/order/order-customer/style.scss
+++ b/client/extensions/woocommerce/app/order/order-customer/style.scss
@@ -33,7 +33,7 @@
 .order-customer__shipping-details {
 	margin-bottom: 16px;
 	color: var( --color-text-subtle );
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	text-transform: uppercase;
 	font-weight: 600;
 	display: flex;

--- a/client/extensions/woocommerce/app/order/order-details/style.scss
+++ b/client/extensions/woocommerce/app/order/order-details/style.scss
@@ -7,7 +7,7 @@
 		display: block;
 		margin-top: 6px;
 		color: var( --color-text-subtle );
-		font-size: 11px;
+		font-size: $font-body-extra-small;
 		text-transform: uppercase;
 	}
 

--- a/client/extensions/woocommerce/app/order/order-payment/style.scss
+++ b/client/extensions/woocommerce/app/order/order-payment/style.scss
@@ -86,7 +86,7 @@
 	}
 
 	.order-payment__method h3 {
-		font-size: 11px;
+		font-size: $font-body-extra-small;
 		text-transform: uppercase;
 		margin-bottom: 8px;
 		color: var( --color-text-subtle );

--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -774,7 +774,7 @@
 
 .products__additional-details-preview-label {
 	text-transform: uppercase;
-	font-size: 11px;
+	font-size: $font-body-extra-small;
 	color: var( --color-text-subtle );
 }
 

--- a/client/extensions/woocommerce/app/reviews/style.scss
+++ b/client/extensions/woocommerce/app/reviews/style.scss
@@ -363,7 +363,7 @@
 
 	.reviews__reply-submit {
 		color: var( --color-neutral-light );
-		font-size: 12px;
+		font-size: $font-body-extra-small;
 		font-weight: 600;
 		position: absolute;
 		right: -70px;

--- a/client/extensions/woocommerce/app/settings/email/mailchimp/style.scss
+++ b/client/extensions/woocommerce/app/settings/email/mailchimp/style.scss
@@ -36,7 +36,7 @@
 
 .mailchimp__getting-started-subtitle-text {
 	color: var( --color-text-subtle );
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	line-height: 18px;
 	padding-bottom: 4px;
 }
@@ -235,7 +235,7 @@
 		0 1px 2px var( --color-neutral-0 );
 	flex-grow: 0;
 	width: 255px;
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	background: var( --color-surface );
 
 	@include breakpoint-deprecated( '<960px' ) {
@@ -288,7 +288,7 @@
 
 .mailchimp__header-description {
 	color: var( --color-text-subtle );
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	line-height: 18px;
 }
 

--- a/client/extensions/woocommerce/app/settings/email/mailchimp/style.scss
+++ b/client/extensions/woocommerce/app/settings/email/mailchimp/style.scss
@@ -402,7 +402,7 @@
 
 .mailchimp__dashboard-settings-preview-heading {
 	text-transform: uppercase;
-	font-size: 11px;
+	font-size: $font-body-extra-small;
 	color: var( --color-text-subtle );
 }
 

--- a/client/extensions/woocommerce/app/settings/payments/stripe/style.scss
+++ b/client/extensions/woocommerce/app/settings/payments/stripe/style.scss
@@ -45,7 +45,7 @@
 			.stripe__connect-account-status {
 				border-radius: 3px;
 				color: var( --color-text-inverted );
-				font-size: 12px;
+				font-size: $font-body-extra-small;
 				margin-right: 8px;
 				padding: 3px 8px;
 
@@ -59,7 +59,7 @@
 			}
 
 			.stripe__connect-account-disconnect {
-				font-size: 12px;
+				font-size: $font-body-extra-small;
 				padding-top: 3px;
 				padding-bottom: 0;
 			}

--- a/client/extensions/woocommerce/app/settings/payments/style.scss
+++ b/client/extensions/woocommerce/app/settings/payments/style.scss
@@ -89,7 +89,7 @@
 // PAYMENT-METHOD-ROW
 .payments__type-container {
 	p.payments__method-suggested {
-		font-size: 11px;
+		font-size: $font-body-extra-small;
 		text-transform: uppercase;
 		color: var( --color-text-subtle );
 		display: none;
@@ -180,7 +180,7 @@
 		.payments__method-enable .form-label {
 			display: inline-block;
 			color: var( --color-neutral-light );
-			font-size: 11px;
+			font-size: $font-body-extra-small;
 			font-weight: 400;
 			line-height: 16px;
 			margin-top: 6px;

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/style.scss
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/style.scss
@@ -140,7 +140,7 @@
 	.shipping-zone__enable-container {
 		width: 30%;
 		color: var( --color-neutral-light );
-		font-size: 11px;
+		font-size: $font-body-extra-small;
 		font-weight: 400;
 		line-height: 16px;
 		vertical-align: top;
@@ -292,7 +292,7 @@
 	span {
 		margin-left: 6px;
 		color: var( --color-neutral-light );
-		font-size: 11px;
+		font-size: $font-body-extra-small;
 		line-height: 16px;
 		vertical-align: top;
 		text-transform: uppercase;

--- a/client/extensions/woocommerce/app/store-stats/referrers/chart/style.scss
+++ b/client/extensions/woocommerce/app/store-stats/referrers/chart/style.scss
@@ -1,6 +1,6 @@
 
 .chart__title {
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 
 	.chart__title-label {
 		font-weight: 600;

--- a/client/extensions/woocommerce/components/action-header/style.scss
+++ b/client/extensions/woocommerce/components/action-header/style.scss
@@ -53,7 +53,7 @@
 	}
 
 	.action-header__site-title {
-		font-size: 10px;
+		font-size: $font-body-extra-small;
 		color: var( --color-neutral-40 );
 		margin: 2px 0 -3px;
 

--- a/client/extensions/woocommerce/components/extended-header/style.scss
+++ b/client/extensions/woocommerce/components/extended-header/style.scss
@@ -13,7 +13,7 @@
 
 	.extended-header__header-description {
 		color: var( --color-text-subtle );
-		font-size: 12px;
+		font-size: $font-body-extra-small;
 		line-height: 18px;
 		padding-bottom: 8px;
 	}

--- a/client/extensions/woocommerce/components/reading-widget/style.scss
+++ b/client/extensions/woocommerce/components/reading-widget/style.scss
@@ -37,7 +37,7 @@
 
 			span {
 				color: var( --color-neutral-70 );
-				font-size: 12px;
+				font-size: $font-body-extra-small;
 			}
 		}
 	}

--- a/client/extensions/woocommerce/components/table/style.scss
+++ b/client/extensions/woocommerce/components/table/style.scss
@@ -59,7 +59,7 @@
 			text-align: right;
 			padding: 0 8px;
 			white-space: nowrap;
-			font-size: 12px;
+			font-size: $font-body-extra-small;
 
 			&:first-child {
 				padding: 0 8px 0 16px;

--- a/client/extensions/woocommerce/components/text-control/style.scss
+++ b/client/extensions/woocommerce/components/text-control/style.scss
@@ -34,7 +34,7 @@
 		left: 16px;
 		display: initial;
 
-		font-size: 12px;
+		font-size: $font-body-extra-small;
 		line-height: 16px;
 		color: var( --color-text );
 	}

--- a/client/extensions/woocommerce/woocommerce-services/views/packages/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/packages/style.scss
@@ -224,7 +224,7 @@
 	font-size: $font-body-small;
 
 	@include breakpoint-deprecated( '<660px' ) {
-		font-size: 11px;
+		font-size: $font-body-extra-small;
 	}
 }
 

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/packages-step/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/packages-step/style.scss
@@ -65,7 +65,7 @@
 	padding: 1px 6px;
 	border: solid 1px var( --color-neutral-20 );
 	border-radius: 12px;
-	font-size: 11px;
+	font-size: $font-body-extra-small;
 	font-weight: 600;
 	line-height: 14px;
 	color: var( --color-text );

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/style.scss
@@ -10,7 +10,7 @@
 		text-align: left;
 
 		&.shipping-label__item-tracking {
-			font-size: 12px;
+			font-size: $font-body-extra-small;
 
 			a:focus {
 				outline: none;
@@ -34,7 +34,7 @@
 
 		a {
 			display: inline-block;
-			font-size: 12px;
+			font-size: $font-body-extra-small;
 		}
 
 		span svg,

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -208,7 +208,7 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 }
 
 .jetpack-connect__note {
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	text-align: center;
 }
 
@@ -274,7 +274,7 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 
 .jetpack-connect__install-step-text {
 	color: var( --color-neutral-light );
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	margin: 8px 0 16px;
 	flex-grow: 2;
 }
@@ -338,7 +338,7 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 
 .example-components__install-plugin-footer-button {
 	display: inline-block;
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	padding: 7px 14px;
 	line-height: 1;
 	color: var( --color-text-inverted );
@@ -390,7 +390,7 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 
 	.example-components__content-wp-admin-connect-button {
 		display: inline-block;
-		font-size: 12px;
+		font-size: $font-body-extra-small;
 		padding: 7px 14px;
 		line-height: 1;
 		color: var( --color-text-inverted );
@@ -412,7 +412,7 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 
 	.example-components__content-wp-admin-connect-button {
 		display: inline-block;
-		font-size: 12px;
+		font-size: $font-body-extra-small;
 		line-height: 1;
 		padding: 11px 10px;
 		color: var( --color-text-inverted );
@@ -431,11 +431,11 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 }
 
 .example-components__content-wp-admin-plugin-name {
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 }
 
 .example-components__content-wp-admin-plugin-activate-link {
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	color: var( --studio-blue-50 );
 }
 
@@ -444,7 +444,7 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 }
 
 .example-components__content-wp-admin-activate-link {
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	display: inline-block;
 	padding: 7px 14px;
 	line-height: 1;
@@ -458,7 +458,7 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 	.example-components__site-address-container
 	.example-components__browser-chrome-url {
 	height: 40px;
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	color: var( --color-neutral-light );
 }
 
@@ -1058,7 +1058,7 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 			padding-bottom: 0;
 			margin-top: 16px;
 			p {
-				font-size: 12px;
+				font-size: $font-body-extra-small;
 			}
 
 			.signup-form__social-buttons-tos {
@@ -1126,7 +1126,7 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 			.jetpack-connect__tos-link,
 			.jetpack-connect__tos-link a {
 				color: var( --color-neutral-60 );
-				font-size: 12px;
+				font-size: $font-body-extra-small;
 			}
 		}
 

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -508,7 +508,7 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 }
 
 .jetpack-connect__tos-link {
-	font-size: 11px;
+	font-size: $font-body-extra-small;
 	margin: 0 0 16px;
 	text-align: center;
 }

--- a/client/landing/gutenboarding/mixins.scss
+++ b/client/landing/gutenboarding/mixins.scss
@@ -41,7 +41,7 @@
 }
 
 @mixin onboarding-x-small-text {
-	font-size: 11px;
+	font-size: $font-body-extra-small;
 	line-height: 13px;
 }
 

--- a/client/landing/gutenboarding/mixins.scss
+++ b/client/landing/gutenboarding/mixins.scss
@@ -36,7 +36,7 @@
 }
 
 @mixin onboarding-small-text {
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	line-height: 14px;
 }
 

--- a/client/layout/masterbar/crowdsignal.scss
+++ b/client/layout/masterbar/crowdsignal.scss
@@ -63,7 +63,7 @@
 .masterbar__crowdsignal-text {
 	display: flex;
 	flex-direction: column;
-	font-size: 10px;
+	font-size: $font-body-extra-small;
 	justify-content: center;
 	margin: auto 15px;
 	padding: 0 0 0 50px;

--- a/client/layout/masterbar/crowdsignal.scss
+++ b/client/layout/masterbar/crowdsignal.scss
@@ -72,7 +72,7 @@
 	width: 100%;
 
 	@include breakpoint-deprecated( '>480px' ) {
-		font-size: 12px;
+		font-size: $font-body-extra-small;
 	}
 }
 

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -362,7 +362,7 @@
 
 		.wp-login__crowdsignal-footer-text {
 			display: none;
-			font-size: 10px;
+			font-size: $font-body-extra-small;
 			flex: 1;
 			height: 18px;
 			letter-spacing: 0.8px;

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -78,7 +78,7 @@
 	width: 80px;
 
 	.sidebar__checklist-progress-text {
-		font-size: 12px;
+		font-size: $font-body-extra-small;
 		margin: 0;
 		white-space: normal;
 		text-overflow: ellipsis;
@@ -190,7 +190,7 @@
 	margin-right: 8px;
 	align-self: center;
 	font-weight: 600;
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	position: absolute;
 	right: 0;
 	z-index: 1;

--- a/client/lib/abtest/test-helper/style.scss
+++ b/client/lib/abtest/test-helper/style.scss
@@ -27,7 +27,7 @@
 	bottom: 100%;
 	right: 0;
 	margin: 0;
-	font-size: 11px;
+	font-size: $font-body-extra-small;
 }
 
 .test-helper__list {

--- a/client/lib/keyboard-shortcuts/menu.scss
+++ b/client/lib/keyboard-shortcuts/menu.scss
@@ -35,7 +35,7 @@
 .keyboard-shortcuts__list {
 	list-style: none;
 	margin: 0;
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 }
 
 .keyboard-shortcuts__list li {

--- a/client/lib/preferences-helper/style.scss
+++ b/client/lib/preferences-helper/style.scss
@@ -38,5 +38,5 @@
 	bottom: 100%;
 	right: 0;
 	margin: 0;
-	font-size: 11px;
+	font-size: $font-body-extra-small;
 }

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -280,7 +280,7 @@ $image-height: 47px;
 	.login__form-terms a:hover {
 		text-align: left;
 		color: var( --color-neutral-60 );
-		font-size: 12px;
+		font-size: $font-body-extra-small;
 	}
 
 	.login__social {
@@ -314,7 +314,7 @@ $image-height: 47px;
 		.text-control__label,
 		.components-base-control__label {
 			color: var( --color-neutral-50 );
-			font-size: 12px;
+			font-size: $font-body-extra-small;
 			font-weight: normal;
 		}
 

--- a/client/me/account-close/style.scss
+++ b/client/me/account-close/style.scss
@@ -28,7 +28,7 @@
 
 		span {
 			display: block;
-			font-size: 10px;
+			font-size: $font-body-extra-small;
 			margin-left: 3px;
 			overflow: hidden;
 			text-overflow: ellipsis;

--- a/client/me/billing-history/style.scss
+++ b/client/me/billing-history/style.scss
@@ -81,7 +81,7 @@
 
 .billing-history__transaction-tax-amount {
 	color: var( --color-text-subtle );
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	white-space: nowrap;
 }
 
@@ -122,7 +122,7 @@
 	small {
 		color: var( --color-text-subtle );
 		display: block;
-		font-size: 12px;
+		font-size: $font-body-extra-small;
 		font-style: italic;
 
 		@include breakpoint-deprecated( '660px-800px' ) {
@@ -138,7 +138,7 @@
 }
 
 .billing-history__transaction-links {
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	margin: 4px 0 0;
 
 	a {
@@ -237,7 +237,7 @@ textarea.billing-history__billing-details-editable {
 		strong {
 			color: var( --color-neutral-50 );
 			display: block;
-			font-size: 12px;
+			font-size: $font-body-extra-small;
 			font-weight: 600;
 			margin: 0 5px 0 0;
 			text-transform: uppercase;
@@ -273,7 +273,7 @@ textarea.billing-history__billing-details-editable {
 		th {
 			border-bottom: 2px solid var( --color-border-subtle );
 			color: var( --color-text-subtle );
-			font-size: 12px;
+			font-size: $font-body-extra-small;
 			font-weight: 400;
 			text-transform: uppercase;
 			width: auto;

--- a/client/me/connected-application-item/style.scss
+++ b/client/me/connected-application-item/style.scss
@@ -36,7 +36,7 @@
 }
 
 .connected-application-item__meta {
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	display: inline-block;
 	padding: 4px 8px;
 	margin-left: 8px;

--- a/client/me/help/contact-form-notice/style.scss
+++ b/client/me/help/contact-form-notice/style.scss
@@ -3,7 +3,7 @@
 	font-size: $font-body-small;
 	&.card.is-compact {
 		margin: 0 0 16px;
-		font-size: 12px;
+		font-size: $font-body-extra-small;
 		.foldable-card__content > *:last-child {
 			margin-bottom: 0;
 		}

--- a/client/me/help/gm-closure-notice/style.scss
+++ b/client/me/help/gm-closure-notice/style.scss
@@ -5,7 +5,7 @@
 	font-size: $font-body-small;
 	&.card.is-compact {
 		margin: 0 0 16px;
-		font-size: 12px;
+		font-size: $font-body-extra-small;
 
 		a {
 			font-size: 1em;

--- a/client/me/help/help-contact-form/style.scss
+++ b/client/me/help/help-contact-form/style.scss
@@ -50,7 +50,7 @@
 
 .help-contact-form__selection-subtext {
 	display: block;
-	font-size: 11px;
+	font-size: $font-body-extra-small;
 	line-height: 16px;
 }
 

--- a/client/me/help/help-teaser-button.scss
+++ b/client/me/help/help-teaser-button.scss
@@ -34,7 +34,7 @@
 
 .help__help-teaser-button-description {
 	color: var( --color-text-subtle );
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	display: block;
 	padding-right: 15px;
 }

--- a/client/me/memberships/main.scss
+++ b/client/me/memberships/main.scss
@@ -11,13 +11,13 @@
 	small {
 		color: var( --color-neutral-light );
 		display: block;
-		font-size: 12px;
+		font-size: $font-body-extra-small;
 		font-style: italic;
 	}
 }
 
 .memberships__list-sub {
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	margin: 4px 0 0;
 	color: var( --color-neutral-light );
 }

--- a/client/me/memberships/subscription.scss
+++ b/client/me/memberships/subscription.scss
@@ -68,7 +68,7 @@
 		color: var( --color-text-subtle );
 		display: block;
 		font-family: $sans;
-		font-size: 12px;
+		font-size: $font-body-extra-small;
 		font-weight: 400;
 		margin: 0 0 12px;
 	}

--- a/client/me/notification-settings/settings-form/style.scss
+++ b/client/me/notification-settings/settings-form/style.scss
@@ -53,7 +53,7 @@
 	text-transform: uppercase;
 	justify-content: center;
 	color: var( --color-text-subtle );
-	font-size: 11px;
+	font-size: $font-body-extra-small;
 	padding: 10px;
 
 	.form-select {

--- a/client/me/pending-payments/style.scss
+++ b/client/me/pending-payments/style.scss
@@ -13,7 +13,7 @@
 
 .pending-payments__list-item-product,
 .pending-payments__list-item-payment {
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	line-height: 14px;
 	margin-bottom: 4px;
 }

--- a/client/me/profile-link/style.scss
+++ b/client/me/profile-link/style.scss
@@ -64,7 +64,7 @@
 }
 
 .profile-link__url {
-	font-size: 11px;
+	font-size: $font-body-extra-small;
 	line-height: 1.4;
 	color: var( --color-neutral-light );
 	float: left;

--- a/client/me/profile-links-add-wordpress/style.scss
+++ b/client/me/profile-links-add-wordpress/style.scss
@@ -9,7 +9,7 @@
 
 .profile-links-add-wordpress__domain {
 	color: var( --color-neutral-light );
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	margin-left: 24px;
 }
 

--- a/client/me/purchases/cancel-purchase/style.scss
+++ b/client/me/purchases/cancel-purchase/style.scss
@@ -52,7 +52,7 @@
 }
 
 .cancel-purchase__site-title {
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	text-transform: uppercase;
 }
 

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -245,7 +245,7 @@
 		color: var( --color-text-subtle );
 		display: block;
 		font-family: $sans;
-		font-size: 12px;
+		font-size: $font-body-extra-small;
 		font-weight: 400;
 		margin: 0 0 12px;
 	}

--- a/client/me/purchases/purchase-item/style.scss
+++ b/client/me/purchases/purchase-item/style.scss
@@ -99,7 +99,7 @@
 .purchase-item__term-label,
 .purchase-item__purchase-type, {
 	color: var( --color-text-subtle );
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	margin: 0 0 4px;
 	overflow: hidden;
 	text-overflow: ellipsis;
@@ -107,5 +107,5 @@
 
 .purchase-item__purchase-date {
 	color: var( --color-neutral-70 );
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 }

--- a/client/me/purchases/purchases-site/style.scss
+++ b/client/me/purchases/purchases-site/style.scss
@@ -10,7 +10,7 @@
 
 .purchases-site__slug {
 	color: var( --color-neutral );
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 }
 
 .purchases-site__slug {

--- a/client/my-sites/activity/activity-log-confirm-dialog/style.scss
+++ b/client/my-sites/activity/activity-log-confirm-dialog/style.scss
@@ -138,7 +138,7 @@
 
 	@include breakpoint-deprecated( '<480px' ) {
 		margin-bottom: 4px;
-		font-size: 12px;
+		font-size: $font-body-extra-small;
 	}
 
 	.gridicon {

--- a/client/my-sites/activity/activity-log-item/style.scss
+++ b/client/my-sites/activity/activity-log-item/style.scss
@@ -282,7 +282,7 @@
 
 .activity-log-item__actor-role,
 .activity-log-item__description-summary {
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	color: var( --color-text-subtle );
 
 	@include breakpoint-deprecated( '<480px' ) {

--- a/client/my-sites/activity/activity-log-item/style.scss
+++ b/client/my-sites/activity/activity-log-item/style.scss
@@ -81,7 +81,7 @@
 }
 
 .activity-log-item__time {
-	font-size: 11px;
+	font-size: $font-body-extra-small;
 	color: var( --color-text-subtle );
 	text-transform: uppercase;
 	white-space: nowrap;

--- a/client/my-sites/activity/filterbar/style.scss
+++ b/client/my-sites/activity/filterbar/style.scss
@@ -174,7 +174,7 @@
 	}
 
 	.filterbar__date-range-info {
-		font-size: 12px;
+		font-size: $font-body-extra-small;
 
 		.button.is-borderless {
 			margin-top: 2px;

--- a/client/my-sites/backup/rewind-flow/style.scss
+++ b/client/my-sites/backup/rewind-flow/style.scss
@@ -134,7 +134,7 @@ a.rewind-flow-notice__title-warning:visited {
 
 	p {
 		color: var( --color-neutral-light );
-		font-size: 12px;
+		font-size: $font-body-extra-small;
 		margin: 0;
 	}
 }

--- a/client/my-sites/checkout/cart/style.scss
+++ b/client/my-sites/checkout/cart/style.scss
@@ -41,7 +41,7 @@
 		.product-domain-renewal-date {
 			color: var( --color-text-subtle );
 			display: block;
-			font-size: 12px;
+			font-size: $font-body-extra-small;
 			text-overflow: ellipsis;
 			overflow: hidden;
 		}
@@ -186,13 +186,13 @@
 			padding: 15px 15px 0;
 
 			input[type='text'] {
-				font-size: 12px;
+				font-size: $font-body-extra-small;
 				margin: 0 4% 0 0;
 				width: 70%;
 			}
 
 			.button {
-				font-size: 12px;
+				font-size: $font-body-extra-small;
 				height: 34px;
 				padding: 4px;
 				width: 26%;
@@ -204,7 +204,7 @@
 .cart-items__expander {
 	color: var( --color-primary );
 	text-decoration: none;
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 }
 
 .cart-empty {
@@ -218,7 +218,7 @@
 	border: 1px solid var( --color-neutral-0 );
 	border-radius: 4px;
 	color: var( --color-text );
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	margin: 15px 15px 0;
 	padding: 10px;
 

--- a/client/my-sites/checkout/cart/style.scss
+++ b/client/my-sites/checkout/cart/style.scss
@@ -87,7 +87,7 @@
 		.product-monthly-price {
 			color: var( --color-text-subtle );
 			display: block;
-			font-size: 11px;
+			font-size: $font-body-extra-small;
 			font-style: italic;
 		}
 
@@ -168,7 +168,7 @@
 	}
 
 	.cart__coupon {
-		font-size: 11px;
+		font-size: $font-body-extra-small;
 
 		@include breakpoint-deprecated( '<660px' ) {
 			display: none;

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -253,7 +253,7 @@
 	}
 
 	.checkout__recent-renewals li {
-		font-size: 12px;
+		font-size: $font-body-extra-small;
 	}
 
 	.checkout__terms,
@@ -272,7 +272,7 @@
 		}
 
 		p {
-			font-size: 12px;
+			font-size: $font-body-extra-small;
 			margin: 0;
 
 			@include breakpoint-deprecated( '>660px' ) {
@@ -567,7 +567,7 @@
 			}
 			.checkout__wechat-qrcode-redirect {
 				color: var( --color-text-subtle );
-				font-size: 12px;
+				font-size: $font-body-extra-small;
 			}
 		}
 
@@ -630,7 +630,7 @@
 			}
 
 			p {
-				font-size: 12px;
+				font-size: $font-body-extra-small;
 				font-weight: 400;
 				margin: 10px 0 0;
 			}
@@ -733,7 +733,7 @@
 	line-height: 40px;
 	display: block;
 	clear: both;
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	padding-bottom: 5px;
 
 	img {
@@ -865,7 +865,7 @@
 
 .checkout__credit-card-payment-box-progress-bar {
 	color: var( --color-neutral-light );
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	padding-bottom: 1em;
 	text-align: center;
 }
@@ -1115,7 +1115,7 @@
 	}
 	.form__hidden-input a {
 		display: block;
-		font-size: 12px;
+		font-size: $font-body-extra-small;
 		margin-left: 15px;
 	}
 	select {
@@ -1130,7 +1130,7 @@
 	margin-left: 15px;
 	color: var( --color-neutral-20 );
 	display: block;
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	font-style: italic;
 }
 

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -701,7 +701,7 @@
 
 	p {
 		color: #7096af;
-		font-size: 11px;
+		font-size: $font-body-extra-small;
 		margin-bottom: 0;
 		margin-top: 5px;
 	}

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -105,7 +105,7 @@
 
 	.comment__date,
 	.comment__author-url {
-		font-size: 12px;
+		font-size: $font-body-extra-small;
 	}
 
 	.comment__author-url-separator {
@@ -194,7 +194,7 @@
 	.comment__status-label {
 		border-radius: 9px;
 		float: right;
-		font-size: 12px;
+		font-size: $font-body-extra-small;
 		margin-left: 8px;
 		padding: 0 10px;
 

--- a/client/my-sites/current-site/sidebar-banner/style.scss
+++ b/client/my-sites/current-site/sidebar-banner/style.scss
@@ -1,5 +1,5 @@
 .sidebar-banner {
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 
 	.sidebar-banner__link {
 		background-color: var( --color-success );

--- a/client/my-sites/domains/domain-management/contacts-privacy/style.scss
+++ b/client/my-sites/domains/domain-management/contacts-privacy/style.scss
@@ -11,7 +11,7 @@
 			}
 
 			p {
-				font-size: 12px;
+				font-size: $font-body-extra-small;
 				margin: 0;
 
 				@include breakpoint-deprecated( '>660px' ) {
@@ -39,7 +39,7 @@
 
 	.notice {
 		clear: both;
-		font-size: 12px;
+		font-size: $font-body-extra-small;
 		margin-top: 10px;
 		margin-bottom: 10px;
 	}
@@ -48,7 +48,7 @@
 		.contact-display__content {
 			background-color: var( --color-neutral-0 );
 			color: var( --color-neutral );
-			font-size: 12px;
+			font-size: $font-body-extra-small;
 			line-height: 140%;
 			margin: 0;
 			padding: 16px;

--- a/client/my-sites/domains/domain-management/dns-records/item.scss
+++ b/client/my-sites/domains/domain-management/dns-records/item.scss
@@ -33,7 +33,7 @@
 		em {
 			color: var( --color-text-subtle );
 			display: block;
-			font-size: 11px;
+			font-size: $font-body-extra-small;
 		}
 	}
 

--- a/client/my-sites/domains/domain-management/dns-records/item.scss
+++ b/client/my-sites/domains/domain-management/dns-records/item.scss
@@ -14,7 +14,7 @@
 			border-radius: 2px;
 			color: var( --color-text-inverted );
 			display: block;
-			font-size: 12px;
+			font-size: $font-body-extra-small;
 			margin: 0 10px 0 0;
 			padding: 10px 5px;
 			text-align: center;

--- a/client/my-sites/domains/domain-management/edit/style.scss
+++ b/client/my-sites/domains/domain-management/edit/style.scss
@@ -1,6 +1,6 @@
 .domain-details-card {
 	.flag {
-		font-size: 11px;
+		font-size: $font-body-extra-small;
 		padding: 3px 10px 3px 5px;
 		white-space: nowrap;
 

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -53,7 +53,7 @@
 }
 
 .domain-management-list-item__meta {
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	color: var( --color-text-subtle );
 	min-height: 20px;
 	text-overflow: ellipsis;
@@ -126,7 +126,7 @@ input[type='radio'].domain-management-list-item__radio {
 	text-transform: uppercase;
 	color: var( --color-neutral-50 );
 	font-weight: 600;
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	text-overflow: ellipsis;
 	overflow: hidden;
 	margin-top: 5px;

--- a/client/my-sites/domains/domain-management/name-servers/style.scss
+++ b/client/my-sites/domains/domain-management/name-servers/style.scss
@@ -1,5 +1,5 @@
 .name-servers .notice {
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	margin-top: 10px;
 	padding-right: 15px;
 }

--- a/client/my-sites/earn/ads/style.scss
+++ b/client/my-sites/earn/ads/style.scss
@@ -48,7 +48,7 @@
 
 .ads__earnings-breakdown-label {
 	color: var( --color-neutral-60 );
-	font-size: 10px;
+	font-size: $font-body-extra-small;
 	letter-spacing: 0.1em;
 	line-height: 1.6;
 	text-transform: uppercase;

--- a/client/my-sites/earn/ads/style.scss
+++ b/client/my-sites/earn/ads/style.scss
@@ -108,7 +108,7 @@
 	border: 1px solid var( --color-neutral-0 );
 	border-left: none;
 	border-right: none;
-	font-size: 11px;
+	font-size: $font-body-extra-small;
 	line-height: 50px;
 	justify-content: center;
 	text-transform: uppercase;

--- a/client/my-sites/earn/ads/style.scss
+++ b/client/my-sites/earn/ads/style.scss
@@ -121,7 +121,7 @@
 
 	@include breakpoint-deprecated( '<480px' ) {
 		&:first-child, &:last-child {
-			font-size: 12px;
+			font-size: $font-body-extra-small;
 		}
 	}
 }

--- a/client/my-sites/earn/memberships/style.scss
+++ b/client/my-sites/earn/memberships/style.scss
@@ -187,7 +187,7 @@
 
 .memberships__subscriber-subscribed {
 	color: var( --color-text-subtle );
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	margin-top: 4px;
 }
 
@@ -228,7 +228,7 @@
 	color: var( --color-neutral-30 );
 	padding-bottom: 12px;
 	padding-top: 24px;
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	line-height: 1.6;
 	font-style: italic;
 	text-align: center;

--- a/client/my-sites/earn/memberships/style.scss
+++ b/client/my-sites/earn/memberships/style.scss
@@ -70,7 +70,7 @@
 	text-transform: uppercase;
 
 	@include breakpoint-deprecated( '>480px' ) {
-		font-size: 10px;
+		font-size: $font-body-extra-small;
 		line-height: 1.6;
 	}
 }
@@ -98,7 +98,7 @@
 	text-transform: uppercase;
 
 	@include breakpoint-deprecated( '>480px' ) {
-		font-size: 10px;
+		font-size: $font-body-extra-small;
 		line-height: 1.6;
 	}
 }

--- a/client/my-sites/email/email-forwarding/style.scss
+++ b/client/my-sites/email/email-forwarding/style.scss
@@ -53,7 +53,7 @@ ul.email-forwarding__list {
 			line-height: 40px;
 
 			@include breakpoint-deprecated( '<660px' ) {
-				font-size: 12px;
+				font-size: $font-body-extra-small;
 				line-height: 150%;
 			}
 

--- a/client/my-sites/importer/author-mapping-item.scss
+++ b/client/my-sites/importer/author-mapping-item.scss
@@ -21,7 +21,7 @@
 		width: 100%;
 
 		@include breakpoint-deprecated( '<480px' ) {
-			font-size: 12px;
+			font-size: $font-body-extra-small;
 		}
 	}
 }

--- a/client/my-sites/importer/author-mapping-pane.scss
+++ b/client/my-sites/importer/author-mapping-pane.scss
@@ -3,7 +3,7 @@
 	margin-bottom: 0;
 	padding-bottom: 0.5em;
 
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	color: var( --color-text-subtle );
 
 	@include clear-fix;

--- a/client/my-sites/importer/site-importer/site-importer-importable-content.scss
+++ b/client/my-sites/importer/site-importer/site-importer-importable-content.scss
@@ -4,6 +4,6 @@
 
 	.site-importer__site-preview-import-content {
 		clear: both;
-		font-size: 12px;
+		font-size: $font-body-extra-small;
 	}
 }

--- a/client/my-sites/marketing/connections/account-dialog.scss
+++ b/client/my-sites/marketing/connections/account-dialog.scss
@@ -19,7 +19,7 @@
 	overflow: hidden;
 	margin: 14px 0;
 	padding: 2px 0;
-	font-size: 10px;
+	font-size: $font-body-extra-small;
 	text-transform: uppercase;
 	color: var( --color-neutral-light );
 

--- a/client/my-sites/marketing/style.scss
+++ b/client/my-sites/marketing/style.scss
@@ -828,7 +828,7 @@
 	display: inline-block;
 	margin: 8px 8px 0 0;
 	cursor: default;
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	border-radius: 2px;
 	color: #777;
 	background: #f8f8f8;

--- a/client/my-sites/marketing/style.scss
+++ b/client/my-sites/marketing/style.scss
@@ -395,7 +395,7 @@
 .sharing-connection__keyring-user {
 	display: inline-block;
 	margin-left: 8px;
-	font-size: 11px;
+	font-size: $font-body-extra-small;
 	font-weight: 600;
 	text-transform: uppercase;
 	color: var( --color-neutral-light );
@@ -648,7 +648,7 @@
 
 .sharing-buttons-preview__fake-like {
 	color: var( --color-neutral-40 );
-	font-size: 11px;
+	font-size: $font-body-extra-small;
 }
 
 .sharing-buttons-preview .sortable-list__navigation {
@@ -784,7 +784,7 @@
 	background-color: var( --color-neutral-0 );
 	border: 1px solid var( --color-neutral-0 );
 	border-bottom: 0;
-	font-size: 11px;
+	font-size: $font-body-extra-small;
 	line-height: 1;
 	font-weight: 600;
 	text-transform: uppercase;
@@ -802,7 +802,7 @@
 .sharing-buttons-preview__label {
 	display: block;
 	margin: 8px 0;
-	font-size: 11px;
+	font-size: $font-body-extra-small;
 	font-weight: 600;
 	line-height: 1.2;
 	text-transform: uppercase;

--- a/client/my-sites/marketing/tools/style.scss
+++ b/client/my-sites/marketing/tools/style.scss
@@ -139,7 +139,7 @@
 
 	.google-voucher__initial-step .purchase-detail__button {
 		float: right;
-		font-size: 12px;
+		font-size: $font-body-extra-small;
 		line-height: 1;
 		padding: 7px;
 	}

--- a/client/my-sites/migrate/components/sites-block/style.scss
+++ b/client/my-sites/migrate/components/sites-block/style.scss
@@ -36,7 +36,7 @@
 		width: auto;
 
 		.badge {
-			font-size: 12px;
+			font-size: $font-body-extra-small;
 		}
 	}
 

--- a/client/my-sites/migrate/section-migrate.scss
+++ b/client/my-sites/migrate/section-migrate.scss
@@ -301,7 +301,7 @@
 	background-color: lightgrey;
 	border-radius: 10px;
 	padding: 2px 5px;
-	font-size: 10px;
+	font-size: $font-body-extra-small;
 	color: darkgray;
 	margin: 5px 3px 5px 0;
 }

--- a/client/my-sites/pages/blog-posts-page/style.scss
+++ b/client/my-sites/pages/blog-posts-page/style.scss
@@ -36,7 +36,7 @@
 
 .blog-posts-page__info {
 	color: var( --color-text-subtle );
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	margin: 0 33px 0 0;
 
 	&.is-disabled {

--- a/client/my-sites/pages/page-card-info/style.scss
+++ b/client/my-sites/pages/page-card-info/style.scss
@@ -1,6 +1,6 @@
 .page-card-info {
 	color: var( --color-text-subtle );
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	vertical-align: middle;
 }
 

--- a/client/my-sites/pages/style.scss
+++ b/client/my-sites/pages/style.scss
@@ -154,7 +154,7 @@
 .page__popover-more-info {
 	color: var( --color-neutral-light );
 	padding: 4px 16px 8px;
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	max-width: 150px;
 	text-align: left;
 }

--- a/client/my-sites/pages/style.scss
+++ b/client/my-sites/pages/style.scss
@@ -16,7 +16,7 @@
 	background: var( --color-neutral-0 );
 	box-shadow: 0 0 0 1px rgba( var( --color-neutral-10-rgb ), 0.5 ), 0 1px 2px var( --color-neutral-0 );
 	color: var( --color-neutral-light );
-	font-size: 11px;
+	font-size: $font-body-extra-small;
 	padding: 6px 11px;
 	text-transform: uppercase;
 

--- a/client/my-sites/people/people-profile/style.scss
+++ b/client/my-sites/people/people-profile/style.scss
@@ -88,7 +88,7 @@
 	border: 1px solid var( --color-neutral-light );
 	border-radius: 2px;
 	color: var( --color-text-subtle );
-	font-size: 11px;
+	font-size: $font-body-extra-small;
 	margin-left: 8px;
 	padding: 2px 6px;
 	white-space: pre;

--- a/client/my-sites/people/people-profile/style.scss
+++ b/client/my-sites/people/people-profile/style.scss
@@ -78,7 +78,7 @@
 
 .people-profile__subscribed {
 	color: var( --color-text-subtle );
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	margin-top: 4px;
 }
 

--- a/client/my-sites/people/role-select/style.scss
+++ b/client/my-sites/people/role-select/style.scss
@@ -12,6 +12,6 @@
 .role-select__role-name-description {
 	font-style: italic;
 	font-weight: normal;
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	color: var( --color-text-subtle );
 }

--- a/client/my-sites/plan-compare-card/style.scss
+++ b/client/my-sites/plan-compare-card/style.scss
@@ -32,7 +32,7 @@
 }
 
 .plan-compare-card__line {
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	font-weight: 400;
 	color: var( --color-text-subtle );
 	font-style: italic;

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -303,7 +303,7 @@ $plan-features-sidebar-width: 272px;
 }
 
 .plan-features__header-credit-label {
-	font-size: 11px;
+	font-size: $font-body-extra-small;
 	line-height: 20px;
 	height: 20px;
 	border-radius: 10px;

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -409,7 +409,7 @@ $plan-features-sidebar-width: 272px;
 	transform: translateY( -21px );
 	padding: 0 8px;
 	background: var( --color-neutral-70 );
-	font-size: 10px;
+	font-size: $font-body-extra-small;
 	line-height: $plan-features-header-banner-height;
 	text-align: center;
 	text-transform: uppercase;

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -324,7 +324,7 @@ $plan-features-sidebar-width: 272px;
 
 .plan-features__header-timeframe {
 	margin-bottom: 1.4em;
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	font-style: italic;
 	font-weight: 400;
 	color: var( --color-text-subtle );
@@ -446,7 +446,7 @@ $plan-features-sidebar-width: 272px;
 	color: var( --color-neutral-70 );
 
 	@include breakpoint-deprecated( '<960px' ) {
-		font-size: 12px;
+		font-size: $font-body-extra-small;
 	}
 
 	@include breakpoint-deprecated( '<1040px' ) {

--- a/client/my-sites/plan-price/style.scss
+++ b/client/my-sites/plan-price/style.scss
@@ -51,7 +51,7 @@
 .plan-price__fraction,
 .plan-price__tax-amount {
 	vertical-align: super;
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 }
 
 .plan-price.is-discounted .plan-price__currency-symbol {

--- a/client/my-sites/plugins/jetpack-plugins-setup/style.scss
+++ b/client/my-sites/plugins/jetpack-plugins-setup/style.scss
@@ -42,7 +42,7 @@
 
 .jetpack-plugins-setup .plugin-item__finished {
 	color: var( --color-neutral-light );
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	line-height: 1;
 	padding: 6px 0;
 }

--- a/client/my-sites/plugins/plugin-action/style.scss
+++ b/client/my-sites/plugins/plugin-action/style.scss
@@ -48,7 +48,7 @@
 	display: flex;
 	flex-direction: row-reverse;
 	align-items: center;
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	line-height: 16px;
 	margin-right: 8px;
 	cursor: pointer;

--- a/client/my-sites/plugins/plugin-activate-toggle/style.scss
+++ b/client/my-sites/plugins/plugin-activate-toggle/style.scss
@@ -2,7 +2,7 @@
 .plugin-activate-toggle__link {
 	display: inline-flex;
 	flex-direction: row-reverse;
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	line-height: 16px;
 }
 

--- a/client/my-sites/plugins/plugin-information/style.scss
+++ b/client/my-sites/plugins/plugin-information/style.scss
@@ -47,7 +47,7 @@
 }
 
 .plugin-information__version-info {
-	font-size: 11px;
+	font-size: $font-body-extra-small;
 	color: var( --color-text-subtle );
 	text-transform: uppercase;
 	width: 100%;

--- a/client/my-sites/plugins/plugin-install-button/style.scss
+++ b/client/my-sites/plugins/plugin-install-button/style.scss
@@ -37,7 +37,7 @@
 		align-content: space-between;
 
 		a {
-			font-size: 11px;
+			font-size: $font-body-extra-small;
 			text-transform: uppercase;
 		}
 	}
@@ -45,7 +45,7 @@
 
 .plugin-install-button__warning {
 	margin-right: 8px;
-	font-size: 11px;
+	font-size: $font-body-extra-small;
 	color:  var( --color-neutral-light );
 	text-transform: uppercase;
 	white-space: nowrap;

--- a/client/my-sites/plugins/plugin-install-button/style.scss
+++ b/client/my-sites/plugins/plugin-install-button/style.scss
@@ -26,7 +26,7 @@
 	}
 
 	.plugin-install-button__installing {
-		font-size: 10px;
+		font-size: $font-body-extra-small;
 		color: var( --color-neutral-light );
 		text-transform: uppercase;
 		display: block;

--- a/client/my-sites/plugins/plugin-item/style.scss
+++ b/client/my-sites/plugins/plugin-item/style.scss
@@ -112,7 +112,7 @@
 }
 
 .plugin-item__count {
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	line-height: 18px;
 	color: var( --color-text-subtle );
 }

--- a/client/my-sites/plugins/plugin-meta/style.scss
+++ b/client/my-sites/plugins/plugin-meta/style.scss
@@ -140,7 +140,7 @@
 	.plugin-action__label {
 		@include breakpoint-deprecated( '<480px' ) {
 			flex-flow: row;
-			font-size: 11px;
+			font-size: $font-body-extra-small;
 			margin-right: auto;
 		}
 	}

--- a/client/my-sites/plugins/plugin-ratings/style.scss
+++ b/client/my-sites/plugins/plugin-ratings/style.scss
@@ -18,7 +18,7 @@
 }
 
 .plugin-ratings__rating-text {
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	color: var( --color-neutral-light );
 	margin-bottom: 16px;
 
@@ -31,7 +31,7 @@
 
 .plugin-ratings__rating-tier-text,
 .plugin-ratings__downloads {
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	color: var( --color-neutral-light );
 	white-space: pre;
 	text-overflow: ellipsis;

--- a/client/my-sites/plugins/plugin-remove-button/style.scss
+++ b/client/my-sites/plugins/plugin-remove-button/style.scss
@@ -1,6 +1,6 @@
 .plugin-remove-button__remove {
 	color: var( --color-neutral-light );
-	font-size: 11px;
+	font-size: $font-body-extra-small;
 	line-height: 16px;
 	margin-right: 10px;
 	vertical-align: top;

--- a/client/my-sites/plugins/plugin-sections/style.scss
+++ b/client/my-sites/plugins/plugin-sections/style.scss
@@ -80,7 +80,7 @@
 	background: var( --color-surface );
 	color: var( --color-neutral-light );
 	cursor: pointer;
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	text-transform: uppercase;
 
 	&:focus {

--- a/client/my-sites/plugins/plugin-site-jetpack/style.scss
+++ b/client/my-sites/plugins/plugin-site-jetpack/style.scss
@@ -60,7 +60,7 @@
 
 .plugin-site-jetpack__automanage-notice {
 	color: var( --color-neutral-light );
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	line-height: 1;
 	padding: 6px 0;
 }

--- a/client/my-sites/plugins/plugins-browser-item/style.scss
+++ b/client/my-sites/plugins/plugins-browser-item/style.scss
@@ -100,7 +100,7 @@
 		bottom: 16px;
 		right: 16px;
 	color: var( --color-success );
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	font-weight: 600;
 	animation: appear 0.15s ease-in;
 

--- a/client/my-sites/plugins/plugins-browser-list/style.scss
+++ b/client/my-sites/plugins/plugins-browser-list/style.scss
@@ -19,7 +19,7 @@
 	display: inline-block;
 	padding: 5px 0;
 	color: var( --color-neutral-70 );
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	line-height: 1.5;
 
 	&.is-expanded {

--- a/client/my-sites/post-selector/style.scss
+++ b/client/my-sites/post-selector/style.scss
@@ -105,7 +105,7 @@ input[type=checkbox].post-selector__input {
 	display: none;
 	margin-left: 8px;
 	flex-shrink: 0;
-	font-size: 11px;
+	font-size: $font-body-extra-small;
 	text-transform: uppercase;
 	color: var( --color-neutral-light );
 

--- a/client/my-sites/resume-editing/style.scss
+++ b/client/my-sites/resume-editing/style.scss
@@ -31,7 +31,7 @@
 
 .resume-editing__label {
 	color: var( --color-text-inverted );
-	font-size: 10px;
+	font-size: $font-body-extra-small;
 	font-weight: 600;
 	opacity: 0.7;
 	text-transform: uppercase;

--- a/client/my-sites/site-indicator/style.scss
+++ b/client/my-sites/site-indicator/style.scss
@@ -80,7 +80,7 @@
 // Displayed on top of a Site element once the user clicks on the button
 .site-indicator__message {
 	color: var( --color-text-inverted );
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	line-height: 1.4;
 	padding: 5px 16px;
 	position: absolute;

--- a/client/my-sites/site-settings/delete-site/style.scss
+++ b/client/my-sites/site-settings/delete-site/style.scss
@@ -5,7 +5,7 @@
 
 .delete-site__content-list-header {
 	margin-bottom: 8px;
-	font-size: 11px;
+	font-size: $font-body-extra-small;
 	line-height: 16px;
 	text-transform: uppercase;
 	text-align: left;

--- a/client/my-sites/site-settings/jetpack-sync-panel/style.scss
+++ b/client/my-sites/site-settings/jetpack-sync-panel/style.scss
@@ -9,5 +9,5 @@
 
 .jetpack-sync-panel__status-notice {
 	color: var( --color-text-subtle );
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 }

--- a/client/my-sites/site-settings/related-posts/style.scss
+++ b/client/my-sites/site-settings/related-posts/style.scss
@@ -20,7 +20,7 @@
 
 .related-posts__preview-headline {
 		margin: 0 0 1em 8px;
-		font-size: 11px;
+		font-size: $font-body-extra-small;
 		font-weight: 600;
 	}
 

--- a/client/my-sites/stats/all-time/style.scss
+++ b/client/my-sites/stats/all-time/style.scss
@@ -9,7 +9,7 @@
 
 		.all-time__best-day {
 			color: var( --color-text-subtle );
-			font-size: 12px;
+			font-size: $font-body-extra-small;
 			box-sizing: border-box;
 			display: block;
 			padding: 24px 0 10px 58px;

--- a/client/my-sites/stats/annual-site-stats/style.scss
+++ b/client/my-sites/stats/annual-site-stats/style.scss
@@ -43,7 +43,7 @@
 
 .annual-site-stats__stat-title {
 	color: var( --color-neutral-light );
-	font-size: 11px;
+	font-size: $font-body-extra-small;
 	text-transform: uppercase;
 
 	@include breakpoint-deprecated( '<480px' ) {

--- a/client/my-sites/stats/most-popular/style.scss
+++ b/client/my-sites/stats/most-popular/style.scss
@@ -32,7 +32,7 @@
 
 .most-popular__label {
 	text-transform: uppercase;
-	font-size: 11px;
+	font-size: $font-body-extra-small;
 	letter-spacing: 0.1em;
 }
 

--- a/client/my-sites/stats/post-trends/style.scss
+++ b/client/my-sites/stats/post-trends/style.scss
@@ -114,7 +114,7 @@ client/my-sites/stats/post-trends/style.scss
 
 .post-trends__label {
 	text-align: center;
-	font-size: 11px;
+	font-size: $font-body-extra-small;
 	color: var( --color-neutral-40 );
 	margin-top: 10px;
 	text-transform: uppercase;
@@ -201,7 +201,7 @@ client/my-sites/stats/post-trends/style.scss
 }
 
 .post-trends__key-label {
-	font-size: 11px;
+	font-size: $font-body-extra-small;
 	color: var( --color-neutral );
 	letter-spacing: 0.1em;
 	text-transform: uppercase;

--- a/client/my-sites/stats/stats-chart-tabs/style.scss
+++ b/client/my-sites/stats/stats-chart-tabs/style.scss
@@ -61,7 +61,7 @@ ul.module-tabs {
 		}
 
 		.label {
-			font-size: 11px;
+			font-size: $font-body-extra-small;
 			letter-spacing: 0.1em;
 			line-height: inherit;
 			text-transform: uppercase;

--- a/client/my-sites/stats/stats-list/style.scss
+++ b/client/my-sites/stats/stats-list/style.scss
@@ -26,7 +26,7 @@
 	// List item height shorter on 2-column modules
 	@include breakpoint-deprecated( '>960px' ) {
 		.stats__module-list & {
-			font-size: 12px;
+			font-size: $font-body-extra-small;
 			line-height: 28px;
 		}
 	}
@@ -94,7 +94,7 @@
 			line-height: 28px;
 
 			span {
-				font-size: 12px;
+				font-size: $font-body-extra-small;
 				// Always let child elements inherit line heights
 				line-height: inherit;
 			}

--- a/client/my-sites/stats/stats-module/expand.scss
+++ b/client/my-sites/stats/stats-module/expand.scss
@@ -35,7 +35,7 @@
 
 		@include breakpoint-deprecated( '>960px' ) {
 			.stats__module-list & {
-				font-size: 12px;
+				font-size: $font-body-extra-small;
 			}
 		}
 	}

--- a/client/my-sites/stats/stats-module/style.scss
+++ b/client/my-sites/stats/stats-module/style.scss
@@ -512,7 +512,7 @@ ul.module-header-actions {
 
 	.stats-detail-weeks__date {
 		display: block;
-		font-size: 11px;
+		font-size: $font-body-extra-small;
 		letter-spacing: 0.1em;
 		text-transform: uppercase;
 	}

--- a/client/my-sites/stats/stats-module/style.scss
+++ b/client/my-sites/stats/stats-module/style.scss
@@ -105,7 +105,7 @@
 
 		@include breakpoint-deprecated( '>960px' ) {
 			.stats__module-list & {
-				font-size: 12px;
+				font-size: $font-body-extra-small;
 			}
 		}
 	}
@@ -280,7 +280,7 @@ ul.module-header-actions {
 
 	@include breakpoint-deprecated( '>960px' ) {
 		.stats__module-list & {
-			font-size: 12px;
+			font-size: $font-body-extra-small;
 		}
 	}
 
@@ -342,7 +342,7 @@ ul.module-header-actions {
 
 			@include breakpoint-deprecated( '>960px' ) {
 				.stats__module-list & {
-					font-size: 12px;
+					font-size: $font-body-extra-small;
 				}
 			}
 
@@ -399,7 +399,7 @@ ul.module-header-actions {
 	th {
 		border-bottom: 1px solid var( --color-border-subtle );
 		border-right: 1px solid var( --color-border-subtle );
-		font-size: 12px;
+		font-size: $font-body-extra-small;
 		padding: 8px 12px;
 		white-space: nowrap; // 1
 
@@ -479,7 +479,7 @@ ul.module-header-actions {
 
 	.stats-detail-weeks__value {
 		display: block;
-		font-size: 12px;
+		font-size: $font-body-extra-small;
 
 		&.is-rising {
 			color: var( --color-success );
@@ -587,5 +587,5 @@ ul.module-header-actions {
 }
 
 .stats__module-list .stats-module__availability-warning-message {
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 }

--- a/client/my-sites/stats/stats-tabs/style.scss
+++ b/client/my-sites/stats/stats-tabs/style.scss
@@ -107,7 +107,7 @@
 			letter-spacing: 0.1em;
 
 			@include breakpoint-deprecated( '>480px' ) {
-				font-size: 11px;
+				font-size: $font-body-extra-small;
 				line-height: inherit;
 				float: none;
 			}

--- a/client/my-sites/stats/stats-views/style.scss
+++ b/client/my-sites/stats/stats-views/style.scss
@@ -19,7 +19,7 @@
 	}
 
 	th {
-		font-size: 11px;
+		font-size: $font-body-extra-small;
 		color: var( --color-neutral-40 );
 	}
 }
@@ -31,7 +31,7 @@
 	&.is-year {
 		background: none;
 		text-align: left;
-		font-size: 11px;
+		font-size: $font-body-extra-small;
 		color: var( --color-neutral-40 );
 	}
 
@@ -87,7 +87,7 @@
 }
 
 .stats-views__key-label {
-	font-size: 11px;
+	font-size: $font-body-extra-small;
 	color: var( --color-neutral );
 	letter-spacing: 0.1em;
 	text-transform: uppercase;

--- a/client/my-sites/stats/stats-views/style.scss
+++ b/client/my-sites/stats/stats-views/style.scss
@@ -13,7 +13,7 @@
 		cursor: pointer;
 		user-select: none;
 		font-weight: normal;
-		font-size: 12px;
+		font-size: $font-body-extra-small;
 		text-transform: uppercase;
 		letter-spacing: 0.1em;
 	}

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -246,7 +246,7 @@
 
 	.wp-caption-text {
 		color: var( --color-neutral-50 );
-		font-size: 12px;
+		font-size: $font-body-extra-small;
 		padding: 3px 8px 6px;
 	}
 

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -188,7 +188,7 @@
 			padding: 2px 8px 3px;
 			background-color: var( --color-neutral-0 );
 			color: var( --color-text-subtle );
-			font-size: 11px;
+			font-size: $font-body-extra-small;
 			font-weight: 600;
 			border-radius: 3px;
 			border: 1px solid var( --color-neutral-5 );
@@ -342,7 +342,7 @@
 		}
 
 		code {
-			font-size: 11px;
+			font-size: $font-body-extra-small;
 			background: #ffffff;
 			padding: 2px 4px;
 			border-radius: 4px;

--- a/client/post-editor/edit-post-status/style.scss
+++ b/client/post-editor/edit-post-status/style.scss
@@ -60,7 +60,7 @@
 	border-radius: 2px;
 	color: var( --color-text-inverted );
 	display: inline-block;
-	font-size: 10px;
+	font-size: $font-body-extra-small;
 	margin-right: 4px;
 	overflow: hidden;
 	padding: 2px 6px;

--- a/client/post-editor/editor-action-bar/style.scss
+++ b/client/post-editor/editor-action-bar/style.scss
@@ -19,7 +19,7 @@
 		margin-right: 2px;
 		background-color: rgba( var( --color-surface-rgb ), 0.92 );
 		text-transform: uppercase;
-		font-size: 11px;
+		font-size: $font-body-extra-small;
 		line-height: 1;
 		color: var( --color-neutral-20 );
 		pointer-events: none;

--- a/client/post-editor/editor-drawer/label.scss
+++ b/client/post-editor/editor-drawer/label.scss
@@ -5,7 +5,7 @@
 .editor-drawer__label-text {
 	color: var( --color-text );
 	display: block;
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	line-height: 18px;
 	margin-bottom: 4px;
 }

--- a/client/post-editor/editor-drawer/style.scss
+++ b/client/post-editor/editor-drawer/style.scss
@@ -30,7 +30,7 @@
 
 .editor-drawer__heading {
 	font-weight: 400;
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	margin-bottom: 4px;
 }
 

--- a/client/post-editor/editor-fieldset/style.scss
+++ b/client/post-editor/editor-fieldset/style.scss
@@ -13,11 +13,11 @@
 .editor-fieldset__legend,
 .editor-fieldset__option {
 	margin: 4px 0;
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 }
 
 .editor-fieldset__legend {
 	color: var( --color-text );
 	display: block;
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 }

--- a/client/post-editor/editor-ground-control/style.scss
+++ b/client/post-editor/editor-ground-control/style.scss
@@ -204,7 +204,7 @@
 }
 
 .editor-ground-control__view-site-tooltip {
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 }
 
 .editor-ground-control__email-verification-notice {

--- a/client/post-editor/editor-location/style.scss
+++ b/client/post-editor/editor-location/style.scss
@@ -8,7 +8,7 @@
 
 .editor-location__public-warning {
 	color: var( --color-text-subtle );
-	font-size: 11px;
+	font-size: $font-body-extra-small;
 	font-weight: 400;
 }
 

--- a/client/post-editor/editor-page-order/style.scss
+++ b/client/post-editor/editor-page-order/style.scss
@@ -5,7 +5,7 @@
 .editor-page-order__label-text {
 	color: var( --color-neutral-light );
 	display: block;
-	font-size: 11px;
+	font-size: $font-body-extra-small;
 	margin-bottom: 4px;
 	text-transform: uppercase;
 }

--- a/client/post-editor/editor-page-parent/style.scss
+++ b/client/post-editor/editor-page-parent/style.scss
@@ -14,7 +14,7 @@
 .editor-page-parent__label-text {
 	color: var( --color-neutral-light );
 	display: block;
-	font-size: 11px;
+	font-size: $font-body-extra-small;
 	margin-bottom: 4px;
 	text-transform: uppercase;
 }

--- a/client/post-editor/editor-post-formats/style.scss
+++ b/client/post-editor/editor-post-formats/style.scss
@@ -9,7 +9,7 @@
 
 .editor-post-formats__format-label {
 	color: var( --color-text );
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	position: relative;
 	padding-left: 26px;
 	cursor: pointer;
@@ -29,5 +29,5 @@
 }
 
 .editor-post-formats__help-link {
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 }

--- a/client/post-editor/editor-publish-date/style.scss
+++ b/client/post-editor/editor-publish-date/style.scss
@@ -119,7 +119,7 @@ $side-margin: 16;
 .editor-publish-date__header-chrono {
 	position: absolute;
 	top: 16px;
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	line-height: 18px;
 	color: var( --color-neutral-70 );
 }

--- a/client/post-editor/editor-publish-date/style.scss
+++ b/client/post-editor/editor-publish-date/style.scss
@@ -89,7 +89,7 @@ $side-margin: 16;
 	.editor-publish-date__header.is-back-dated &,
 	.editor-publish-date__header.is-published & {
 		top: 6px;
-		font-size: 10px;
+		font-size: $font-body-extra-small;
 		line-height: 12px;
 	}
 }

--- a/client/post-editor/editor-sharing/publicize-options.scss
+++ b/client/post-editor/editor-sharing/publicize-options.scss
@@ -20,5 +20,5 @@
 
 .editor-sharing__publicize-options-description {
 	color: var( --color-neutral-light );
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 }

--- a/client/post-editor/editor-sharing/publicize-services.scss
+++ b/client/post-editor/editor-sharing/publicize-services.scss
@@ -8,6 +8,6 @@
 }
 
 .editor-sharing__publicize-service-heading {
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	font-weight: 400;
 }

--- a/client/post-editor/editor-sharing/style.scss
+++ b/client/post-editor/editor-sharing/style.scss
@@ -9,7 +9,7 @@
 .editor-sharing__shortlink {
 	border-top: 1px solid var( --color-neutral-0 );
 	color: var( --color-neutral-light );
-	font-size: 11px;
+	font-size: $font-body-extra-small;
 	margin: 16px -16px 0;
 	padding: 8px 16px 0;
 	text-align: left;

--- a/client/post-editor/editor-sharing/style.scss
+++ b/client/post-editor/editor-sharing/style.scss
@@ -31,7 +31,7 @@ input[type='text'].editor-sharing__shortlink-field {
 	background: var( --color-neutral-0 );
 	color: var( --color-neutral-70 );
 	flex-grow: 1;
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	width: 100%;
 	line-height: 1;
 	vertical-align: bottom;
@@ -39,7 +39,7 @@ input[type='text'].editor-sharing__shortlink-field {
 
 .editor-sharing__publicize-connection {
 	display: block;
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	padding: 2px 0;
 
 	label input[disabled] + span {

--- a/client/post-editor/editor-status-label/style.scss
+++ b/client/post-editor/editor-status-label/style.scss
@@ -2,7 +2,7 @@
 	color: var( --color-neutral-light );
 	cursor: pointer;
 	display: block;
-	font-size: 11px;
+	font-size: $font-body-extra-small;
 	line-height: 1.65;
 	padding-left: 18px;
 	text-align: left;

--- a/client/post-editor/editor-sticky/style.scss
+++ b/client/post-editor/editor-sticky/style.scss
@@ -14,7 +14,7 @@
 
 .editor-sticky__explanation {
 	display: block;
-	font-size: 11px;
+	font-size: $font-body-extra-small;
 }
 
 .editor-sticky__tooltip .popover__inner {

--- a/client/post-editor/editor-word-count/style.scss
+++ b/client/post-editor/editor-word-count/style.scss
@@ -5,7 +5,7 @@
 	padding: 6px 8px 8px;
 	background-color: rgba( var( --color-surface-rgb ), 0.92 );
 	text-transform: uppercase;
-	font-size: 11px;
+	font-size: $font-body-extra-small;
 	line-height: 1;
 	color: var( --color-neutral-20 );
 	pointer-events: none;

--- a/client/post-editor/media-modal/detail/style.scss
+++ b/client/post-editor/media-modal/detail/style.scss
@@ -177,7 +177,7 @@
 .editor-media-modal-detail__file-info th {
 	color: var( --color-neutral-light );
 	display: block;
-	font-size: 11px;
+	font-size: $font-body-extra-small;
 	margin-bottom: 4px;
 	text-transform: uppercase;
 }

--- a/client/post-editor/media-modal/gallery/style.scss
+++ b/client/post-editor/media-modal/gallery/style.scss
@@ -123,7 +123,7 @@
 }
 
 input.editor-media-modal-gallery__caption[type='text'] {
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 
 	&:focus {
 		box-shadow: none;

--- a/client/reader/following-manage/style.scss
+++ b/client/reader/following-manage/style.scss
@@ -100,7 +100,7 @@
 
 	.following-manage__subscriptions-sort .following-manage__sort-controls {
 		color: var( --color-text-subtle );
-		font-size: 12px;
+		font-size: $font-body-extra-small;
 		font-weight: normal;
 		padding-top: 8px;
 		width: 100%;

--- a/client/reader/following-manage/style.scss
+++ b/client/reader/following-manage/style.scss
@@ -33,7 +33,7 @@
 	border-top-left-radius: 0;
 	border-top-right-radius: 0;
 	color: var( --color-text-subtle );
-	font-size: 11px;
+	font-size: $font-body-extra-small;
 	padding: 2px 9px 6px 11px;
 	position: relative;
 	top: -1px;

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -406,7 +406,7 @@
 	flex-flow: row nowrap;
 	align-items: baseline;
 	color: var( --color-neutral-20 );
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	line-height: 1;
 }
 

--- a/client/reader/style.scss
+++ b/client/reader/style.scss
@@ -295,7 +295,7 @@
 }
 
 .tiled-gallery .tiled-gallery-item-small .tiled-gallery-caption { /* Smaller captions */
-	font-size: 11px;
+	font-size: $font-body-extra-small;
 }
 
 /* Hide galleries in widgets until they've been resized to fit.

--- a/client/reader/tag-stream/style.scss
+++ b/client/reader/tag-stream/style.scss
@@ -74,7 +74,7 @@
 
 .tag-stream__header-image-byline {
 	color: var( --color-text-inverted );
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	font-weight: 600;
 	padding-top: 24px;
 	text-align: right;

--- a/client/signup/steps/clone-destination/style.scss
+++ b/client/signup/steps/clone-destination/style.scss
@@ -33,7 +33,7 @@
 .clone-destination__tos {
 	text-align: center;
 	margin: 24px auto;
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 }
 
 .clone-destination__tos-link {

--- a/client/signup/steps/import-preview/style.scss
+++ b/client/signup/steps/import-preview/style.scss
@@ -33,7 +33,7 @@
 }
 
 .import-preview__url {
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	color: var( --color-neutral-40 );
 }
 

--- a/client/signup/steps/plans-atomic-store/style.scss
+++ b/client/signup/steps/plans-atomic-store/style.scss
@@ -29,7 +29,7 @@
 .plans-step__compare-plans-link {
 	clear: both;
 	display: block;
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	margin: 20px 0 0;
 	text-align: center;
 

--- a/client/signup/steps/plans/style.scss
+++ b/client/signup/steps/plans/style.scss
@@ -21,7 +21,7 @@
 .plans-step__compare-plans-link {
 	clear: both;
 	display: block;
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	margin: 20px 0 0;
 	text-align: center;
 

--- a/client/signup/steps/rewind-migrate/style.scss
+++ b/client/signup/steps/rewind-migrate/style.scss
@@ -55,7 +55,7 @@
 	p {
 		max-width: 600px;
 		font-style: italic;
-		font-size: 12px;
+		font-size: $font-body-extra-small;
 		color: var( --color-text-inverted );
 	}
 }

--- a/client/signup/steps/site-type/style.scss
+++ b/client/signup/steps/site-type/style.scss
@@ -51,7 +51,7 @@
 	}
 
 	.site-type__option-badge {
-		font-size: 12px;
+		font-size: $font-body-extra-small;
 		margin-top: 6px;
 		// Offset .badge padding-left to vertically align badge text with site type description.
 		margin-left: -( $badge-padding-x );

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -209,7 +209,7 @@ body.is-section-signup .layout.gravatar .formatted-header {
 		.text-control__label,
 		.components-base-control__label {
 			color: var( --color-neutral-50 );
-			font-size: 12px;
+			font-size: $font-body-extra-small;
 			font-weight: normal;
 		}
 
@@ -301,7 +301,7 @@ body.is-section-signup .layout.gravatar .formatted-header {
 		padding-bottom: 0;
 		margin-top: 16px;
 		p {
-			font-size: 12px;
+			font-size: $font-body-extra-small;
 			color: var( --studio-gray-60 );
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update instances of 10px, 11px, and 12px fonts to use `$font-body-extra-small` which works out to 12px.
* There are a few instances of 10px and 11px that will get slightly larger with this change. So far, all instances I've found are an improvement for readability!

Some examples, not exhaustive:

| Before | After |
| ------- |------ |
| <img width="669" alt="before" src="https://user-images.githubusercontent.com/2124984/84698188-5e589f00-af1d-11ea-9d00-104e65b66928.png"> | <img width="667" alt="Screen Shot 2020-06-15 at 2 41 48 PM" src="https://user-images.githubusercontent.com/2124984/84698201-63b5e980-af1d-11ea-9676-2721a87c5d42.png"> |
| <img width="1059" alt="before2" src="https://user-images.githubusercontent.com/2124984/84698210-687a9d80-af1d-11ea-8161-57191c4d649f.png"> | <img width="1060" alt="Screen Shot 2020-06-15 at 3 06 19 PM" src="https://user-images.githubusercontent.com/2124984/84698220-6d3f5180-af1d-11ea-8235-8262f393e3b8.png"> |
| <img width="1680" alt="before3" src="https://user-images.githubusercontent.com/2124984/84698226-729c9c00-af1d-11ea-9f0e-41791463e4a9.png"> | <img width="1680" alt="Screen Shot 2020-06-15 at 2 31 48 PM" src="https://user-images.githubusercontent.com/2124984/84698235-78927d00-af1d-11ea-86d8-b4097230e6f5.png"> |
| <img width="396" alt="before4" src="https://user-images.githubusercontent.com/2124984/84698263-81834e80-af1d-11ea-9f5c-a0c9676e47e4.png"> | <img width="397" alt="Screen Shot 2020-06-15 at 3 23 38 PM" src="https://user-images.githubusercontent.com/2124984/84698274-86e09900-af1d-11ea-80d3-554896c4ac24.png"> |
| <img width="350" alt="before5" src="https://user-images.githubusercontent.com/2124984/84698322-9bbd2c80-af1d-11ea-84f5-e9f0eecd6ac5.png"> | <img width="343" alt="Screen Shot 2020-06-15 at 2 57 06 PM" src="https://user-images.githubusercontent.com/2124984/84698329-9f50b380-af1d-11ea-8090-24a813dc73e5.png"> |
| <img width="533" alt="before6" src="https://user-images.githubusercontent.com/2124984/84698341-a5469480-af1d-11ea-81f4-0ddeab5d4287.png"> | <img width="817" alt="Screen Shot 2020-06-15 at 3 14 37 PM" src="https://user-images.githubusercontent.com/2124984/84698350-a972b200-af1d-11ea-8362-879324ee6478.png"> | 
| <img width="380" alt="before7" src="https://user-images.githubusercontent.com/2124984/84698363-aecffc80-af1d-11ea-9dc8-ad18dd4aefb5.png"> | <img width="389" alt="Screen Shot 2020-06-15 at 3 24 43 PM" src="https://user-images.githubusercontent.com/2124984/84698373-b394b080-af1d-11ea-86ea-c24646126d56.png"> |
| <img width="1040" alt="before8" src="https://user-images.githubusercontent.com/2124984/84698383-b8f1fb00-af1d-11ea-980f-63f775c0adc7.png"> | <img width="1043" alt="Screen Shot 2020-06-15 at 3 25 49 PM" src="https://user-images.githubusercontent.com/2124984/84698393-bd1e1880-af1d-11ea-8bc3-9868decdf523.png"> |

#### Testing instructions

* Switch to this PR
* Check out screens across Calypso to look for instances of extra small fonts. Look for visual bugs or regressions. 
