### PR TITLE
Add scaffolding for reader list editing

### DIFF
--- a/client/reader/list-manage/index.jsx
+++ b/client/reader/list-manage/index.jsx
@@ -1,0 +1,12 @@
+/**
+ * External dependencies
+ */
+import * as React from 'react';
+
+export default function ReaderListEdit( props ) {
+	return (
+		<div>
+			Editing the list { props.owner } / { props.slug }
+		</div>
+	);
+}

--- a/client/reader/list-stream/index.jsx
+++ b/client/reader/list-stream/index.jsx
@@ -9,6 +9,7 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
+import config from 'config';
 import Stream from 'reader/stream';
 import EmptyContent from './empty';
 import DocumentHead from 'components/data/document-head';
@@ -112,6 +113,8 @@ class ListStream extends React.Component {
 					showFollow={ shouldShowFollow }
 					following={ this.props.isSubscribed }
 					onFollowToggle={ this.toggleFollowing }
+					showEdit={ config.isEnabled( 'reader/list-management' ) && list && list.is_owner }
+					editUrl={ window.location.href + '/edit' }
 				/>
 			</Stream>
 		);

--- a/client/reader/list/controller.js
+++ b/client/reader/list/controller.js
@@ -12,43 +12,59 @@ import AsyncLoad from 'components/async-load';
 
 const analyticsPageTitle = 'Reader';
 
-const exported = {
-	listListing( context, next ) {
-		const basePath = '/read/list/:owner/:slug';
-		const fullAnalyticsPageTitle =
-			analyticsPageTitle + ' > List > ' + context.params.user + ' - ' + context.params.list;
-		const mcKey = 'list';
-		const streamKey =
-			'list:' + JSON.stringify( { owner: context.params.user, slug: context.params.list } );
+export const listListing = ( context, next ) => {
+	const basePath = '/read/list/:owner/:slug';
+	const fullAnalyticsPageTitle =
+		analyticsPageTitle + ' > List > ' + context.params.user + ' - ' + context.params.list;
+	const mcKey = 'list';
+	const streamKey =
+		'list:' + JSON.stringify( { owner: context.params.user, slug: context.params.list } );
 
-		trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
-		recordTrack( 'calypso_reader_list_loaded', {
-			list_owner: context.params.user,
-			list_slug: context.params.list,
-		} );
+	trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
+	recordTrack( 'calypso_reader_list_loaded', {
+		list_owner: context.params.user,
+		list_slug: context.params.list,
+	} );
 
-		context.primary = (
-			<AsyncLoad
-				require="reader/list-stream"
-				key={ 'tag-' + context.params.user + '-' + context.params.list }
-				streamKey={ streamKey }
-				owner={ encodeURIComponent( context.params.user ) }
-				slug={ encodeURIComponent( context.params.list ) }
-				showPrimaryFollowButtonOnCards={ false }
-				trackScrollPage={ trackScrollPage.bind(
-					null,
-					basePath,
-					fullAnalyticsPageTitle,
-					analyticsPageTitle,
-					mcKey
-				) }
-				onUpdatesShown={ trackUpdatesLoaded.bind( null, mcKey ) }
-			/>
-		);
-		next();
-	},
+	context.primary = (
+		<AsyncLoad
+			require="reader/list-stream"
+			key={ 'tag-' + context.params.user + '-' + context.params.list }
+			streamKey={ streamKey }
+			owner={ encodeURIComponent( context.params.user ) }
+			slug={ encodeURIComponent( context.params.list ) }
+			showPrimaryFollowButtonOnCards={ false }
+			trackScrollPage={ trackScrollPage.bind(
+				null,
+				basePath,
+				fullAnalyticsPageTitle,
+				analyticsPageTitle,
+				mcKey
+			) }
+			onUpdatesShown={ trackUpdatesLoaded.bind( null, mcKey ) }
+		/>
+	);
+	next();
 };
 
-export default exported;
+export const editList = ( context, next ) => {
+	const basePath = '/read/list/:owner/:slug/edit';
+	const fullAnalyticsPageTitle = `${ analyticsPageTitle } > List > ${ context.params.user } - ${ context.params.list } > Edit`;
+	const mcKey = 'list';
 
-export const { listListing } = exported;
+	trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
+	recordTrack( 'calypso_reader_list_loaded', {
+		list_owner: context.params.user,
+		list_slug: context.params.list,
+	} );
+
+	context.primary = (
+		<AsyncLoad
+			require="reader/list-manage"
+			key="list-manage"
+			owner={ encodeURIComponent( context.params.user ) }
+			slug={ encodeURIComponent( context.params.list ) }
+		/>
+	);
+	next();
+};

--- a/client/reader/list/index.js
+++ b/client/reader/list/index.js
@@ -6,10 +6,18 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import { listListing } from './controller';
+import { editList, listListing } from './controller';
 import { sidebar, updateLastRoute } from 'reader/controller';
 import { makeLayout, render as clientRender } from 'controller';
 
 export default function () {
+	page(
+		'/read/list/:user/:list/edit',
+		updateLastRoute,
+		sidebar,
+		editList,
+		makeLayout,
+		clientRender
+	);
 	page( '/read/list/:user/:list', updateLastRoute, sidebar, listListing, makeLayout, clientRender );
 }

--- a/config/development.json
+++ b/config/development.json
@@ -147,6 +147,7 @@
 		"reader": true,
 		"reader/comment-polling": false,
 		"reader/full-errors": true,
+		"reader/list-management": true,
 		"reader/seen-posts": true,
 		"reader/user-mention-suggestions": true,
 		"recommend-plugins": true,


### PR DESCRIPTION
Adds in a new route handler for /read/list/:owner/:slug/edit, a config setting to control the feature, re-enables the settings cog and edit URL, and a small placeholder UI for the manage page

