### PR TITLE
composite-checkout: Display "Redirecting to PayPal…" when paypal is redirecting

### DIFF
--- a/packages/composite-checkout/src/lib/payment-methods/paypal.js
+++ b/packages/composite-checkout/src/lib/payment-methods/paypal.js
@@ -49,6 +49,7 @@ export function PaypalSubmitButton( { disabled } ) {
 	const { formStatus } = useFormStatus();
 	const onEvent = useEvents();
 	const {
+		transactionStatus,
 		setTransactionPending,
 		setTransactionRedirecting,
 		setTransactionError,
@@ -87,13 +88,16 @@ export function PaypalSubmitButton( { disabled } ) {
 			isBusy={ 'submitting' === formStatus }
 			fullWidth
 		>
-			<PayPalButtonContents formStatus={ formStatus } />
+			<PayPalButtonContents formStatus={ formStatus } transactionStatus={ transactionStatus } />
 		</Button>
 	);
 }
 
-function PayPalButtonContents( { formStatus } ) {
+function PayPalButtonContents( { formStatus, transactionStatus } ) {
 	const { __ } = useI18n();
+	if ( transactionStatus === 'redirecting' ) {
+		return __( 'Redirecting to PayPal…' );
+	}
 	if ( formStatus === 'submitting' ) {
 		return __( 'Processing…' );
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This modifies the PayPal submit button in composite checkout so that when the transaction is in the 'redirecting' status, it displays "Redirecting to PayPal…".

![redirecting](https://user-images.githubusercontent.com/2036909/83916551-60fc0d00-a743-11ea-8979-dcb48c9d2a5c.png)


#### Testing instructions

Attempt a PayPal transaction and make sure the text of the button changes as described above.