### PR TITLE
Gutenboarding: fix font-size

### DIFF
--- a/client/assets/stylesheets/gutenboarding.scss
+++ b/client/assets/stylesheets/gutenboarding.scss
@@ -27,5 +27,5 @@
 html,
 body {
 	font-family: $default-font;
-	font-size: $default-font-size;
+	font-size: $font-body;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* use `$font-body` variable on Gutenboarding body to get correct font-size when it is defined relatively.

#### Before/After
**Before - intent capture**
<img width="1211" alt="Screenshot 2020-06-05 at 23 53 47" src="https://user-images.githubusercontent.com/14192054/83921916-118c0000-a788-11ea-88aa-eb6d868b3565.png">
**After - intent capture**
<img width="1211" alt="Screenshot 2020-06-05 at 23 54 00" src="https://user-images.githubusercontent.com/14192054/83921953-2799c080-a788-11ea-9915-397626a3b82c.png">

**Before - plans grid**
<img width="1211" alt="Screenshot 2020-06-05 at 23 54 26" src="https://user-images.githubusercontent.com/14192054/83921934-1e105880-a788-11ea-9b1a-e72320b5223f.png">
**After - plans grid**
<img width="1210" alt="Screenshot 2020-06-05 at 23 54 44" src="https://user-images.githubusercontent.com/14192054/83921999-46985280-a788-11ea-86ad-a2fbfc0d1609.png">

#### Testing instructions

* go to [/new](https://calypso.live/new?branch=fix/gutenboarding-font-size) and advance through the flow
* Open domain popover/modal
* Font should be consistent and not small as in _Before_ screens
