### PR TITLE
composite-checkout: Use replaceState rather than hash when skipping contact step (1)

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -171,7 +171,7 @@ class MasterbarLoggedIn extends React.Component {
 
 		if ( isCheckout === true ) {
 			let closeUrl = siteSlug ? '/plans/' + siteSlug : '/plans';
-			if ( '' !== previousPath ) {
+			if ( '' !== previousPath && previousPath !== window.location.href ) {
 				closeUrl = previousPath;
 			}
 

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-contact-form.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-contact-form.js
@@ -398,13 +398,22 @@ function useSkipToLastStepIfFormComplete( contactValidationCallback ) {
 }
 
 function saveStepNumberToUrl( stepNumber ) {
-	if ( ! window?.location ) {
+	if ( ! window?.history || ! window?.location ) {
 		return;
 	}
 	const newHash = stepNumber > 1 ? `#step${ stepNumber }` : '';
 	if ( window.location.hash === newHash ) {
 		return;
 	}
-	window.location.hash = newHash;
-	debug( 'updating url to', window.location.href );
+	const newUrl = window.location.hash
+		? window.location.href.replace( window.location.hash, newHash )
+		: window.location.href + newHash;
+	debug( 'updating url to', newUrl );
+	window.history.replaceState( null, '', newUrl );
+	// Modifying history does not trigger a hashchange event which is what
+	// composite-checkout uses to change its current step, so we must fire one
+	// manually. (HashChangeEvent is part of the web API so I'm not sure why
+	// eslint reports this as undefined.)
+	const event = new HashChangeEvent( 'hashchange' ); // eslint-disable-line no-undef
+	window.dispatchEvent( event );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In https://github.com/Automattic/wp-calypso/pull/42806 we added code which skips the contact details step in new checkout if the contact data is prefilled and valid. The way we skip to the step is to modify the `hash` of the current URL. This triggers the `hashchange` event listener in the `composite-checkout` package which will change the current active step.

This works, but it has a shortcoming: changing the URL directly pushes a state onto the window's history, meaning that if the user presses the Back button (or more seriously, tries to use the "X" in the header), the page is returned to its state before the hash was added. This feels broken since the action of adding the hash was not user-initiated and is part of the page load.

In this PR we switch to using `window.history.replaceState` instead of setting the `hash`, causing the current URL to by overwritten on the stack rather than pushed. This neatly solves the above issue, although it does require us to manually trigger a `hashchange` event because using the history API explicitly does not trigger that event.

#### Testing instructions

- Make sure you have valid saved contact details. This requires having made a successful purchase.
- Add a product to your cart and visit checkout.
- Press the "X" in the upper-left of the page.
- Verify that you are redirected to the Plans page, or somewhere else outside of checkout (depending on where you originated).