### PR TITLE
Remove duration from StaleCartItemsNotice

### DIFF
--- a/client/my-sites/current-site/stale-cart-items-notice.js
+++ b/client/my-sites/current-site/stale-cart-items-notice.js
@@ -20,9 +20,6 @@ const staleCartItemNoticeId = 'stale-cart-item-notice';
 
 class StaleCartItemsNotice extends React.Component {
 	showStaleCartItemsNotice = () => {
-		// Remove any existing stale cart notice
-		this.props.removeNotice( staleCartItemNoticeId );
-
 		// Don't show on the checkout page?
 		if ( this.props.sectionName === 'upgrades' ) {
 			return null;
@@ -39,6 +36,9 @@ class StaleCartItemsNotice extends React.Component {
 			! cart.hasPendingServerUpdates
 		) {
 			this.props.recordTracksEvent( 'calypso_cart_abandonment_notice_view' );
+
+			// Remove any existing stale cart notice
+			this.props.removeNotice( staleCartItemNoticeId );
 
 			this.props.infoNotice( this.props.translate( 'Your cart is awaiting payment.' ), {
 				id: staleCartItemNoticeId,

--- a/client/my-sites/current-site/stale-cart-items-notice.js
+++ b/client/my-sites/current-site/stale-cart-items-notice.js
@@ -22,6 +22,8 @@ class StaleCartItemsNotice extends React.Component {
 	showStaleCartItemsNotice = () => {
 		// Don't show on the checkout page?
 		if ( this.props.sectionName === 'upgrades' ) {
+			// Remove any existing stale cart notice
+			this.props.removeNotice( staleCartItemNoticeId );
 			return null;
 		}
 

--- a/client/my-sites/current-site/stale-cart-items-notice.js
+++ b/client/my-sites/current-site/stale-cart-items-notice.js
@@ -42,8 +42,6 @@ class StaleCartItemsNotice extends React.Component {
 
 			this.props.infoNotice( this.props.translate( 'Your cart is awaiting payment.' ), {
 				id: staleCartItemNoticeId,
-				isPersistent: false,
-				duration: 10000,
 				button: this.props.translate( 'View your cart' ),
 				href: '/checkout/' + this.props.selectedSiteSlug,
 				onClick: this.clickStaleCartItemsNotice,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

`StaleCartItemsNotice` displays a message for abandoned carts to prompt the user to visit checkout. It currently is configured to disappear after a brief amount of time, but user testing has found this to be annoying because it's hard to get back (it will not display if it has shown up in the past 10 minutes) and some of the places it is shown do not have another easy way to get to checkout (this is a separate issue).

In this PR we make the notice remain until it is dismissed or a page navigation occurs.

![cart-message](https://user-images.githubusercontent.com/2036909/83926857-11c0d700-a759-11ea-8ab6-8966ae78034d.png)


#### Testing instructions

- Add a product to your cart and visit checkout.
- Close calypso and wait 10 minutes.
- Visit the Plans page: http://calypso.localhost:3000/plans
- Hopefully the notice will appear. If it doesn't, wait longer and try again.
- Once the notice appears, make sure it does not disappear until you navigate away.