### PR TITLE
Adapt to new domain-picker API changes

### DIFF
--- a/client/landing/gutenboarding/components/domain-picker-button/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-button/index.tsx
@@ -4,10 +4,13 @@
 import * as React from 'react';
 import { Button } from '@wordpress/components';
 import { Icon, chevronDown } from '@wordpress/icons';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
+import { USER_STORE } from '../../stores/user';
+
 import { useI18n } from '@automattic/react-i18n';
 import classnames from 'classnames';
 import type { DomainSuggestions } from '@automattic/data-stores';
+import DomainPicker from '@automattic/domain-picker';
 
 /**
  * Internal dependencies
@@ -16,8 +19,7 @@ import DomainPickerPopover from '../domain-picker-popover';
 import DomainPickerModal from '../domain-picker-modal';
 import { FLOW_ID } from '../../constants';
 import { STORE_KEY } from '../../stores/onboard';
-import { useDomainSuggestions } from '../../hooks/use-domain-suggestions';
-import { DOMAIN_SUGGESTIONS_STORE } from '../../stores/domain-suggestions';
+import { useCurrentStep } from '../../path';
 import { getSuggestionsVendor } from 'lib/domains/suggestions';
 
 const DOMAIN_SUGGESTION_VENDOR = getSuggestionsVendor( true );
@@ -44,89 +46,86 @@ const DomainPickerButton: React.FunctionComponent< Props > = ( {
 } ) => {
 	const buttonRef = React.createRef< HTMLButtonElement >();
 
-	const domainSuggestions = useDomainSuggestions( { locale: useI18n().i18nLocale, quantity: 10 } );
+	const [ domainSearch, setDomainSearch ] = React.useState< string >( '' );
 
-	const domainCategories = useSelect( ( select ) =>
-		select( DOMAIN_SUGGESTIONS_STORE ).getCategories()
-	);
+	const [ domainPickerMode, setDomainPickerMode ] = React.useState<
+		'popover' | 'modal' | undefined
+	>();
 
-	const { domainSearch, domainCategory } = useSelect( ( select ) =>
-		select( STORE_KEY ).getState()
-	);
-	const { setDomainSearch, setDomainCategory } = useDispatch( STORE_KEY );
-
-	const [ isDomainPopoverVisible, setDomainPopoverVisibility ] = React.useState( false );
-	const [ isDomainModalVisible, setDomainModalVisibility ] = React.useState( false );
-
-	const handlePopoverClose = ( e?: React.FocusEvent ) => {
-		// Don't collide with button toggling
-		if ( e?.relatedTarget === buttonRef.current ) {
-			return;
-		}
-		setDomainPopoverVisibility( false );
+	const handlePopoverToggle = () => {
+		setDomainPickerMode( ( mode ) => ( mode ? undefined : 'popover' ) );
 	};
 
-	const handleModalClose = () => {
-		setDomainModalVisibility( false );
+	const handleClose = () => {
+		setDomainPickerMode( undefined );
 	};
 
 	const handleMoreOptions = () => {
-		setDomainPopoverVisibility( false );
-		setDomainModalVisibility( true );
+		setDomainPickerMode( 'modal' );
 	};
+
+	const { __ } = useI18n();
+
+	const currentStep = useCurrentStep();
+
+	const { siteTitle, siteVertical } = useSelect( ( select ) => select( STORE_KEY ).getState() );
+	const currentUser = useSelect( ( select ) => select( USER_STORE ).getCurrentUser() );
+
+	const prioritisedSearch = domainSearch.trim() || siteTitle;
+	let searchVal;
+
+	if ( currentStep !== 'IntentGathering' ) {
+		searchVal =
+			prioritisedSearch ||
+			siteVertical?.label.trim() ||
+			currentUser?.username ||
+			__( 'My new site' );
+	} else {
+		searchVal = prioritisedSearch || '';
+	}
+
+	const domainPicker = (
+		<DomainPicker
+			analyticsFlowId={ FLOW_ID }
+			domainSearch={ searchVal }
+			onSetDomainSearch={ setDomainSearch }
+			onMoreOptions={ handleMoreOptions }
+			showDomainConnectButton={ domainPickerMode === 'modal' }
+			onClose={ handleClose }
+			showDomainCategories={ domainPickerMode === 'modal' }
+			currentDomain={ currentDomain }
+			onDomainSelect={ onDomainSelect }
+			domainSuggestionVendor={ DOMAIN_SUGGESTION_VENDOR }
+			analyticsUiAlgo={ domainPickerMode === 'modal' ? 'popover_popover' : 'domain_popover' }
+		></DomainPicker>
+	);
 
 	return (
 		<>
 			<Button
 				{ ...buttonProps }
-				aria-expanded={ isDomainPopoverVisible }
+				aria-expanded={ !! domainPickerMode }
 				aria-haspopup="menu"
-				aria-pressed={ isDomainPopoverVisible }
+				aria-pressed={ !! domainPickerMode }
 				className={ classnames( 'domain-picker-button', className, {
-					'is-open': isDomainPopoverVisible,
-					'is-modal-open': isDomainModalVisible,
+					'is-open': !! domainPickerMode,
+					'is-modal-open': domainPickerMode === 'modal',
 				} ) }
-				onClick={ () => setDomainPopoverVisibility( ( s ) => ! s ) }
+				onClick={ handlePopoverToggle }
 				ref={ buttonRef }
 			>
 				<span className="domain-picker-button__label">{ children }</span>
 				<Icon icon={ chevronDown } size={ 22 } />
 			</Button>
 			<DomainPickerPopover
-				analyticsFlowId={ FLOW_ID }
-				domainSuggestions={ domainSuggestions }
-				domainCategory={ domainCategory }
-				domainCategories={ domainCategories }
-				onSetDomainCategory={ setDomainCategory }
-				domainSearch={ domainSearch }
-				onSetDomainSearch={ setDomainSearch }
-				isOpen={ isDomainPopoverVisible }
-				showDomainConnectButton={ false }
-				showDomainCategories={ false }
-				currentDomain={ currentDomain }
-				onDomainSelect={ onDomainSelect }
-				onMoreOptions={ handleMoreOptions }
-				onClose={ handlePopoverClose }
-				domainSuggestionVendor={ DOMAIN_SUGGESTION_VENDOR }
-				analyticsUiAlgo="domain_popover"
-			/>
-			<DomainPickerModal
-				analyticsFlowId={ FLOW_ID }
-				domainSuggestions={ domainSuggestions }
-				domainCategory={ domainCategory }
-				domainCategories={ domainCategories }
-				onSetDomainCategory={ setDomainCategory }
-				domainSearch={ domainSearch }
-				onSetDomainSearch={ setDomainSearch }
-				isOpen={ isDomainModalVisible }
-				showDomainConnectButton
-				showDomainCategories
-				currentDomain={ currentDomain }
-				onDomainSelect={ onDomainSelect }
-				onClose={ handleModalClose }
-				domainSuggestionVendor={ DOMAIN_SUGGESTION_VENDOR }
-				analyticsUiAlgo="domain_modal"
-			/>
+				isOpen={ domainPickerMode === 'popover' }
+				onClose={ handlePopoverToggle }
+			>
+				{ domainPicker }
+			</DomainPickerPopover>
+			<DomainPickerModal isOpen={ domainPickerMode === 'modal' } onClose={ handleClose }>
+				{ domainPicker }
+			</DomainPickerModal>
 		</>
 	);
 };

--- a/client/landing/gutenboarding/components/domain-picker-button/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-button/index.tsx
@@ -96,7 +96,7 @@ const DomainPickerButton: React.FunctionComponent< Props > = ( {
 			currentDomain={ currentDomain }
 			onDomainSelect={ onDomainSelect }
 			domainSuggestionVendor={ DOMAIN_SUGGESTION_VENDOR }
-			analyticsUiAlgo={ domainPickerMode === 'modal' ? 'popover_popover' : 'domain_popover' }
+			analyticsUiAlgo={ domainPickerMode === 'modal' ? 'domain_modal' : 'domain_popover' }
 		></DomainPicker>
 	);
 

--- a/client/landing/gutenboarding/components/domain-picker-button/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-button/index.tsx
@@ -60,7 +60,7 @@ const DomainPickerButton: React.FunctionComponent< Props > = ( {
 		setDomainPickerMode( undefined );
 	};
 
-	const handleMoreOptions = () => {
+	const onClickMoreOptions = () => {
 		setDomainPickerMode( 'modal' );
 	};
 
@@ -89,7 +89,7 @@ const DomainPickerButton: React.FunctionComponent< Props > = ( {
 			analyticsFlowId={ FLOW_ID }
 			domainSearch={ searchVal }
 			onSetDomainSearch={ setDomainSearch }
-			onMoreOptions={ handleMoreOptions }
+			onMoreOptions={ onClickMoreOptions }
 			showDomainConnectButton={ domainPickerMode === 'modal' }
 			onClose={ handleClose }
 			showDomainCategories={ domainPickerMode === 'modal' }
@@ -97,7 +97,7 @@ const DomainPickerButton: React.FunctionComponent< Props > = ( {
 			onDomainSelect={ onDomainSelect }
 			domainSuggestionVendor={ DOMAIN_SUGGESTION_VENDOR }
 			analyticsUiAlgo={ domainPickerMode === 'modal' ? 'domain_modal' : 'domain_popover' }
-		></DomainPicker>
+		/>
 	);
 
 	return (

--- a/client/landing/gutenboarding/components/domain-picker-modal/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-modal/index.tsx
@@ -4,7 +4,6 @@
 import * as React from 'react';
 import Modal from 'react-modal';
 import { select } from '@wordpress/data';
-import DomainPicker, { Props as DomainPickerProps } from '@automattic/domain-picker';
 
 /**
  * Internal dependencies
@@ -17,11 +16,13 @@ import { STORE_KEY } from '../../stores/onboard';
  */
 import './style.scss';
 
-interface Props extends DomainPickerProps {
+interface Props {
+	onClose: Function;
 	isOpen: boolean;
+	children: any;
 }
 
-const DomainPickerModal: React.FunctionComponent< Props > = ( { isOpen, onClose, ...props } ) => {
+const DomainPickerModal: React.FunctionComponent< Props > = ( { isOpen, onClose, children } ) => {
 	if ( ! isOpen ) {
 		return null;
 	}
@@ -54,13 +55,7 @@ const DomainPickerModal: React.FunctionComponent< Props > = ( { isOpen, onClose,
 			overlayClassName="domain-picker-modal-overlay"
 			bodyOpenClassName="has-domain-picker-modal"
 		>
-			<DomainPicker
-				showDomainConnectButton
-				showDomainCategories
-				quantity={ 10 }
-				onClose={ handleClose }
-				{ ...props }
-			/>
+			{ children }
 		</Modal>
 	);
 };

--- a/client/landing/gutenboarding/components/domain-picker-popover/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-popover/index.tsx
@@ -5,7 +5,6 @@ import * as React from 'react';
 import { Popover } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { select } from '@wordpress/data';
-import DomainPicker, { Props as DomainPickerProps } from '@automattic/domain-picker';
 
 /**
  * Internal dependencies
@@ -18,11 +17,13 @@ import { STORE_KEY } from '../../stores/onboard';
  */
 import './style.scss';
 
-interface Props extends DomainPickerProps {
+interface Props {
+	onClose: Function;
 	isOpen: boolean;
+	children: any;
 }
 
-const DomainPickerPopover: React.FunctionComponent< Props > = ( { isOpen, onClose, ...props } ) => {
+const DomainPickerPopover: React.FunctionComponent< Props > = ( { isOpen, onClose, children } ) => {
 	// Popover expands at medium viewport width
 	const isMobile = useViewportMatch( 'medium', '<' );
 
@@ -59,7 +60,7 @@ const DomainPickerPopover: React.FunctionComponent< Props > = ( { isOpen, onClos
 				position={ 'bottom center' }
 				expandOnMobile={ true }
 			>
-				<DomainPicker onClose={ handleClose } { ...props } />
+				{ children }
 			</Popover>
 		</div>
 	);


### PR DESCRIPTION
Depends on https://github.com/Automattic/wp-calypso/pull/43045. 

#### Changes proposed in this Pull Request

https://github.com/Automattic/wp-calypso/pull/43045 introduces some changes to DomainPicker API. This PR adapts Gutenboarding to those changes. 

#### Testing instructions

1. Open [/new](https://calypso.live/new?branch=update/use-new-domain-picker-api) of this branch
2. Open [/new](http://wordpress.com/new) of production
3. Test as many interactions as possible with Domain Picker
4. UX should be 1:1 with no regressions
