### PR TITLE
Jetpack Connect: remove Plans placeholder when purchasing Search product.

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -56,6 +56,7 @@ import {
 	isCalypsoStartedConnection,
 	isSsoApproved,
 	retrieveMobileRedirect,
+	retrievePlan,
 } from './persistence-utils';
 import {
 	authorize as authorizeAction,
@@ -615,6 +616,13 @@ export class JetpackAuthorize extends Component {
 			return `/start/pressable-nux?blogid=${ clientId }`;
 		}
 
+		// If the redirect is part of the Jetpack Search purchase flow
+		const isSearch = this.props.selectedPlanSlug === 'jetpack_search';
+
+		if ( isSearch ) {
+			return '/checkout/' + urlToSlug( homeUrl ) + '/' + this.props.selectedPlanSlug;
+		}
+
 		return addQueryArgs(
 			{ redirect: redirectAfterAuth },
 			`${ JPC_PATH_PLANS }/${ urlToSlug( homeUrl ) }`
@@ -784,6 +792,7 @@ const connectComponent = connect(
 		// so any change in value will not execute connect().
 		const mobileAppRedirect = retrieveMobileRedirect();
 		const isMobileAppFlow = !! mobileAppRedirect;
+		const selectedPlanSlug = retrievePlan();
 
 		return {
 			authAttempts: getAuthAttempts( state, urlToSlug( authQuery.site ) ),
@@ -801,6 +810,7 @@ const connectComponent = connect(
 			mobileAppRedirect,
 			partnerID: getPartnerIdFromQuery( state ),
 			partnerSlug: getPartnerSlugFromQuery( state ),
+			selectedPlanSlug,
 			user: getCurrentUser( state ),
 			userAlreadyConnected: getUserAlreadyConnected( state ),
 		};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Goal: shorten the purchase flow that includes Jetpack connection.
At the moment, before checkout, the connection flow includes plans placeholder. This is obsolete when the flow is focused on purchasing a preselected product.
Here, we remove this step.

#### Testing instructions
- `http://calypso.localhost:3000/jetpack/connect/jetpack_search`
- input site with Jetpack inactive/uninstalled and verify that after authorizing the connection, the flow lands at checkout
- input site with Jetpack installed and activated, the redirect to checkout should be immediate. 