### PR TITLE
Themes: Display Nudge for WP.org Themes for Non-Business Sites

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -61,7 +61,12 @@ import { recordTracksEvent } from 'state/analytics/actions';
 import { setThemePreviewOptions } from 'state/themes/actions';
 import ThemeNotFoundError from './theme-not-found-error';
 import ThemeFeaturesCard from './theme-features-card';
-import { FEATURE_UNLIMITED_PREMIUM_THEMES, PLAN_PREMIUM } from 'lib/plans/constants';
+import {
+	FEATURE_UNLIMITED_PREMIUM_THEMES,
+	FEATURE_UPLOAD_THEMES,
+	PLAN_PREMIUM,
+	PLAN_BUSINESS,
+} from 'lib/plans/constants';
 import { hasFeature } from 'state/sites/plans/selectors';
 import getPreviousRoute from 'state/selectors/get-previous-route';
 
@@ -611,9 +616,11 @@ class ThemeSheet extends React.Component {
 			retired,
 			isPremium,
 			isJetpack,
+			isWpcomTheme,
 			isVip,
 			translate,
 			hasUnlimitedPremiumThemes,
+			canUserUploadThemes,
 			previousRoute,
 		} = this.props;
 
@@ -657,9 +664,13 @@ class ThemeSheet extends React.Component {
 		}
 
 		let pageUpsellBanner, previewUpsellBanner;
-		const hasUpsellBanner =
+		const hasWpComThemeUpsellBanner =
 			! isJetpack && isPremium && ! hasUnlimitedPremiumThemes && ! isVip && ! retired;
-		if ( hasUpsellBanner ) {
+		const hasWpOrgThemeUpsellBanner =
+			! isWpcomTheme && ( ! siteId || ( ! isJetpack && ! canUserUploadThemes ) );
+		const hasUpsellBanner = hasWpComThemeUpsellBanner || hasWpOrgThemeUpsellBanner;
+
+		if ( hasWpComThemeUpsellBanner ) {
 			pageUpsellBanner = (
 				<UpsellNudge
 					plan={ PLAN_PREMIUM }
@@ -676,10 +687,34 @@ class ThemeSheet extends React.Component {
 					showIcon={ true }
 				/>
 			);
+		}
+
+		if ( hasWpOrgThemeUpsellBanner ) {
+			pageUpsellBanner = (
+				<UpsellNudge
+					plan={ PLAN_BUSINESS }
+					className="theme__page-upsell-banner"
+					title={ translate( 'Access this theme for FREE with a Business plan!' ) }
+					description={ preventWidows(
+						translate(
+							'Instantly unlock thousands of different themes and install your own when you upgrade.'
+						)
+					) }
+					forceHref
+					feature={ FEATURE_UPLOAD_THEMES }
+					forceDisplay
+					href={ ! siteId ? '/plans' : null }
+					showIcon
+				/>
+			);
+		}
+
+		if ( hasUpsellBanner ) {
 			previewUpsellBanner = React.cloneElement( pageUpsellBanner, {
 				className: 'theme__preview-upsell-banner',
 			} );
 		}
+
 		const className = classNames( 'theme__sheet', { 'is-with-upsell-banner': hasUpsellBanner } );
 
 		const links = [ { rel: 'canonical', href: canonicalUrl } ];
@@ -706,7 +741,7 @@ class ThemeSheet extends React.Component {
 					backText={ previousRoute ? i18n.translate( 'Back' ) : i18n.translate( 'All Themes' ) }
 					onClick={ this.goBack }
 				>
-					{ ! retired && this.renderButton() }
+					{ ! retired && ! hasWpOrgThemeUpsellBanner && this.renderButton() }
 				</HeaderCake>
 				<div className="theme__sheet-columns">
 					<div className="theme__sheet-column-left">
@@ -806,6 +841,7 @@ export default connect(
 			isPurchased: isPremiumThemeAvailable( state, id, siteId ),
 			forumUrl: getThemeForumUrl( state, id, siteId ),
 			hasUnlimitedPremiumThemes: hasFeature( state, siteId, FEATURE_UNLIMITED_PREMIUM_THEMES ),
+			canUserUploadThemes: hasFeature( state, siteId, FEATURE_UPLOAD_THEMES ),
 			// No siteId specified since we want the *canonical* URL :-)
 			canonicalUrl: 'https://wordpress.com' + getThemeDetailsUrl( state, id ),
 			previousRoute: getPreviousRoute( state ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

I should prefix this by saying that the list of bugs with displaying WP.org themes through Calypso is extensive, and I suspect people may run into others while testing this PR. 

This change is _very_ limited in dealing with just one of these bugs: when a user sees a theme that they'd need a Business plan for, warn them of that and hide the "Activate" button. 

Discussion of this is in **p8HJWS-vD-p2**

#### Testing instructions

Things should only change for a non-WordPress.com theme when there is a site without a Business or eCommerce Plan. You can test this by going to `/theme/petals/` and `/theme/petals/site`.

**Before:**
Note: clicking "Activate" would just cause an error - it's probably better to hide the button now because clicking the screenshot links to the demo instead of opening the usual modal. 

<img width="1824" alt="Screenshot 2020-06-07 at 11 15 14" src="https://user-images.githubusercontent.com/43215253/83966135-48f5cc00-a8b0-11ea-9913-866b34f534a3.png">

**After:**
Note the nudge and the removal of the "Activate" button.

<img width="1818" alt="Screenshot 2020-06-07 at 11 16 24" src="https://user-images.githubusercontent.com/43215253/83966143-590dab80-a8b0-11ea-9cad-6033b0309b54.png">

Clicking the nudge when logged in should show you the Business and eCommerce plans. If you're not logged in, you would be directed to pricing (though Plans on Calypso).

<img width="1212" alt="Screenshot 2020-06-07 at 11 17 12" src="https://user-images.githubusercontent.com/43215253/83966168-865a5980-a8b0-11ea-93e0-2ec172f4f15c.png">

(cc @sixhours)
