### PR TITLE
Export CSS props as JS from calypso-color-schemes

### DIFF
--- a/apps/notifications/postcss.config.js
+++ b/apps/notifications/postcss.config.js
@@ -1,7 +1,7 @@
 module.exports = () => ( {
 	plugins: {
 		'postcss-custom-properties': {
-			importFrom: [ require.resolve( '@automattic/calypso-color-schemes' ) ],
+			importFrom: [ require.resolve( '@automattic/calypso-color-schemes/js' ) ],
 			// @TODO: Drop `preserve: false` workaround if possible
 			// See https://github.com/Automattic/jetpack/pull/13854#issuecomment-550898168
 			preserve: false,

--- a/client/postcss.config.js
+++ b/client/postcss.config.js
@@ -3,9 +3,7 @@ module.exports = ( { options } ) => {
 	if ( options.transformCssProperties ) {
 		plugins[ 'postcss-custom-properties' ] = {
 			preserve: false, // remove custom props from fallback browsers' CSS
-			importFrom: {
-				customProperties: options.customProperties,
-			},
+			importFrom: [ options.customProperties ],
 		};
 	}
 	return { plugins };

--- a/client/postcss.config.js
+++ b/client/postcss.config.js
@@ -2,7 +2,10 @@ module.exports = ( { options } ) => {
 	const plugins = { autoprefixer: {} };
 	if ( options.transformCssProperties ) {
 		plugins[ 'postcss-custom-properties' ] = {
-			importFrom: [ require.resolve( '@automattic/calypso-color-schemes' ) ],
+			preserve: false, // remove custom props from fallback browsers' CSS
+			importFrom: {
+				customProperties: options.customProperties,
+			},
 		};
 	}
 	return { plugins };

--- a/client/postcss.config.js
+++ b/client/postcss.config.js
@@ -2,7 +2,6 @@ module.exports = ( { options } ) => {
 	const plugins = { autoprefixer: {} };
 	if ( options.transformCssProperties ) {
 		plugins[ 'postcss-custom-properties' ] = {
-			preserve: false, // remove custom props from fallback browsers' CSS
 			importFrom: [ options.customProperties ],
 		};
 	}

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -20,6 +20,7 @@ const MomentTimezoneDataPlugin = require( 'moment-timezone-data-webpack-plugin' 
 const InlineConstantExportsPlugin = require( '@automattic/webpack-inline-constant-exports-plugin' );
 const Minify = require( '@automattic/calypso-build/webpack/minify' );
 const SassConfig = require( '@automattic/calypso-build/webpack/sass' );
+const calypsoColorSchemes = require( '@automattic/calypso-color-schemes/js' );
 const TranspileConfig = require( '@automattic/calypso-build/webpack/transpile' );
 const {
 	cssNameFromFilename,
@@ -199,6 +200,7 @@ const webpackConfig = {
 					path: __dirname,
 					ctx: {
 						transformCssProperties: browserslistEnv === 'defaults',
+						customProperties: calypsoColorSchemes,
 					},
 				},
 				prelude: `@import '${ path.join( __dirname, 'assets/stylesheets/shared/_utils.scss' ) }';`,

--- a/packages/calypso-color-schemes/.gitignore
+++ b/packages/calypso-color-schemes/.gitignore
@@ -1,1 +1,3 @@
 src/__color-studio
+css
+js

--- a/packages/calypso-color-schemes/README.md
+++ b/packages/calypso-color-schemes/README.md
@@ -12,5 +12,34 @@ yarn add @automattic/calypso-color-schemes
 
 ## Usage
 
-Add this packages CSS from `dist/calypso-color-schemes.css` in order to access the CSS custom
+### Using the CSS output
+
+Add this packages CSS from `css/calypso-color-schemes.css` in order to access the CSS custom
 properties.
+
+When importing, you can do
+
+```js
+import '@automattic/calypso-color-schemes'
+```
+And this will give you the CSS.
+
+### Using the JS output
+
+Sometimes, calypso-color-schemes properties are consumed in JavaScript. To avoid parsing them on your own, or to help `postcss-custom-properties` use them without parsing them (much faster), use the JS output as follows:
+
+```js
+import { customProperties } import '@automattic/calypso-color-schemes/js' // mind the js suffix
+```
+
+Then your `postcss.config.js` can look like this:
+
+```js
+module.exports = () => ( {
+	plugins: {
+		'postcss-custom-properties': {
+            importFrom: [ require.resolve( '@automattic/calypso-color-schemes/js' ) ],
+        }
+    }
+});
+```

--- a/packages/calypso-color-schemes/README.md
+++ b/packages/calypso-color-schemes/README.md
@@ -26,13 +26,13 @@ And this will give you the CSS.
 
 ### Using the JS output
 
-Sometimes, calypso-color-schemes properties are consumed in JavaScript. To avoid parsing them on your own, or to help `postcss-custom-properties` use them without parsing them (much faster), use the JS output as follows:
+Sometimes, `calypso-color-schemes` properties are consumed in JavaScript. To avoid parsing CSS syntax on your own, or to help `postcss-custom-properties` use them without parsing the CSS (much faster), use the JS output as follows:
 
 ```js
 import { customProperties } import '@automattic/calypso-color-schemes/js' // mind the js suffix
 ```
 
-Then your `postcss.config.js` can look like this:
+Or with `postcss-custom-properties`, and `postcss.config.js` can look like this:
 
 ```js
 module.exports = () => ( {
@@ -43,3 +43,7 @@ module.exports = () => ( {
     }
 });
 ```
+
+### Note on using the JS output
+
+The CSS files include variable definitions for all Calypso color schemes (Classic Blue, Contrast, Midnight, ...), but the JS exports include only variables from the `:root` selector, i.e., only the fallback default theme.

--- a/packages/calypso-color-schemes/bin/build-css.js
+++ b/packages/calypso-color-schemes/bin/build-css.js
@@ -21,12 +21,15 @@ const output = renderSync( { file: INPUT_FILE } );
 
 writeFileSync( OUTPUT_FILE, output.css );
 
-// export CSS properties into a JavaScript file, so whoever uses it doesn't need to parse it over and over
-( async function () {
-	await postcss( [
-		postcssCustomProperties( {
-			importFrom: OUTPUT_FILE,
-			exportTo: [ OUTPUT_JS_FILE ],
-		} ),
-	] ).process( output.css, { from: INPUT_FILE } );
-} )();
+// export CSS properties into a JavaScript file, so whoever uses it doesn't need to parse CSS over and over
+postcss( [
+	postcssCustomProperties( {
+		importFrom: OUTPUT_FILE,
+		exportTo: [ OUTPUT_JS_FILE ],
+	} ),
+] )
+	.process( output.css, { from: INPUT_FILE } )
+	.catch( ( e ) => {
+		// eslint-disable-next-line no-console
+		console.error( 'calypso-color-schemes', e );
+	} );

--- a/packages/calypso-color-schemes/bin/build-css.js
+++ b/packages/calypso-color-schemes/bin/build-css.js
@@ -2,13 +2,31 @@
 const { dirname, join } = require( 'path' );
 const { existsSync, mkdirSync, writeFileSync } = require( 'fs' );
 const { renderSync } = require( 'node-sass' );
+const postcss = require( 'postcss' );
+const postcssCustomProperties = require( 'postcss-custom-properties' );
 
 const INPUT_FILE = join( __dirname, '..', 'src', 'calypso-color-schemes.scss' );
-const OUTPUT_FILE = join( __dirname, '..', 'dist', 'calypso-color-schemes.css' );
+const OUTPUT_FILE = join( __dirname, '..', 'css', 'index.css' );
+const OUTPUT_JS_FILE = join( __dirname, '..', 'js', 'index.js' );
 
 if ( ! existsSync( dirname( OUTPUT_FILE ) ) ) {
 	mkdirSync( dirname( OUTPUT_FILE ), { recursive: true } );
 }
 
+if ( ! existsSync( dirname( OUTPUT_JS_FILE ) ) ) {
+	mkdirSync( dirname( OUTPUT_JS_FILE ), { recursive: true } );
+}
+
 const output = renderSync( { file: INPUT_FILE } );
+
 writeFileSync( OUTPUT_FILE, output.css );
+
+// export CSS properties into a JavaScript file, so whoever uses it doesn't need to parse it over and over
+( async function () {
+	await postcss( [
+		postcssCustomProperties( {
+			importFrom: OUTPUT_FILE,
+			exportTo: [ OUTPUT_JS_FILE ],
+		} ),
+	] ).process( output.css, { from: INPUT_FILE } );
+} )();

--- a/packages/calypso-color-schemes/package.json
+++ b/packages/calypso-color-schemes/package.json
@@ -24,12 +24,12 @@
 		"access": "public"
 	},
 	"scripts": {
-		"clean": "check-npm-client && npx rimraf dist src/__color-studio",
+		"clean": "check-npm-client && npx rimraf js css src/__color-studio",
 		"prepare": "check-npm-client && node bin/prepare-sass-assets.js && node bin/build-css.js"
 	},
 	"devDependencies": {
 		"postcss": "7.0.32",
-		"postcss-custom-properties": "9.1.1",
+		"postcss-custom-properties": "^9.1.1",
 		"node-sass": "^4.13.0"
 	}
 }

--- a/packages/calypso-color-schemes/package.json
+++ b/packages/calypso-color-schemes/package.json
@@ -19,12 +19,17 @@
 	"bugs": {
 		"url": "https://github.com/Automattic/wp-calypso/issues"
 	},
-	"main": "dist/calypso-color-schemes.css",
+	"main": "css/index.css",
 	"publishConfig": {
 		"access": "public"
 	},
 	"scripts": {
 		"clean": "check-npm-client && npx rimraf dist src/__color-studio",
 		"prepare": "check-npm-client && node bin/prepare-sass-assets.js && node bin/build-css.js"
+	},
+	"devDependencies": {
+		"postcss": "7.0.32",
+		"postcss-custom-properties": "9.1.1",
+		"node-sass": "^4.13.0"
 	}
 }

--- a/packages/calypso-color-schemes/package.json
+++ b/packages/calypso-color-schemes/package.json
@@ -28,7 +28,7 @@
 		"prepare": "check-npm-client && node bin/prepare-sass-assets.js && node bin/build-css.js"
 	},
 	"devDependencies": {
-		"postcss": "7.0.32",
+		"postcss": "^7.0.32",
 		"postcss-custom-properties": "^9.1.1",
 		"node-sass": "^4.13.0"
 	}

--- a/yarn.lock
+++ b/yarn.lock
@@ -20061,15 +20061,6 @@ postcss-values-parser@^3.0.5, postcss-values-parser@^3.1.1:
     postcss "^7.0.5"
     url-regex "^5.0.0"
 
-postcss@7.0.32:
-  version "7.0.32"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.32.tgz#4310d6ee347053da3433db2be492883d62cec59d"
-  integrity sha512-03eXong5NLnNCD05xscnGKGDZ98CyzoqPSMjOe6SuoQY7Z2hIj0Ld1g/O/UQRuOle2aRtiIRDg9tDcTGAkLfKw==
-  dependencies:
-    chalk "^2.4.2"
-    source-map "^0.6.1"
-    supports-color "^6.1.0"
-
 postcss@^5.0.21:
   version "5.2.18"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-5.2.18.tgz#badfa1497d46244f6390f58b319830d9107853c5"
@@ -20102,6 +20093,15 @@ postcss@^7.0.18:
   version "7.0.29"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.29.tgz#d3a903872bd52280b83bce38cdc83ce55c06129e"
   integrity sha512-ba0ApvR3LxGvRMMiUa9n0WR4HjzcYm7tS+ht4/2Nd0NLtHpPIH77fuB9Xh1/yJVz9O/E/95Y/dn8ygWsyffXtw==
+  dependencies:
+    chalk "^2.4.2"
+    source-map "^0.6.1"
+    supports-color "^6.1.0"
+
+postcss@^7.0.32:
+  version "7.0.32"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.32.tgz#4310d6ee347053da3433db2be492883d62cec59d"
+  integrity sha512-03eXong5NLnNCD05xscnGKGDZ98CyzoqPSMjOe6SuoQY7Z2hIj0Ld1g/O/UQRuOle2aRtiIRDg9tDcTGAkLfKw==
   dependencies:
     chalk "^2.4.2"
     source-map "^0.6.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3744,7 +3744,7 @@
     jest-diff "^25.2.1"
     pretty-format "^25.2.1"
 
-"@types/json-schema@^7.0.3", "@types/json-schema@^7.0.4":
+"@types/json-schema@^7.0.3":
   version "7.0.4"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.4.tgz#38fd73ddfd9b55abb1e1b2ed578cb55bd7b7d339"
   integrity sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==
@@ -5449,7 +5449,7 @@ ajv-keywords@^3.1.0, ajv-keywords@^3.4.1:
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.4.1.tgz#ef916e271c64ac12171fd8384eaae6b2345854da"
   integrity sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==
 
-ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.0, ajv@^6.12.2, ajv@^6.5.5:
+ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.0, ajv@^6.5.5:
   version "6.12.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.2.tgz#c629c5eced17baf314437918d2da88c99d5958cd"
   integrity sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==
@@ -7113,11 +7113,6 @@ buffer-indexof@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-indexof/-/buffer-indexof-1.1.1.tgz#52fabcc6a606d1a00302802648ef68f639da268c"
   integrity sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g==
 
-buffer-json@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/buffer-json/-/buffer-json-2.0.0.tgz#f73e13b1e42f196fe2fd67d001c7d7107edd7c23"
-  integrity sha512-+jjPFVqyfF1esi9fvfUs3NqM0pH1ziZ36VP4hmA/y/Ssfo/5w5xHKfTw9BwQjoJ1w/oVtpLomqwUHKdefGyuHw==
-
 buffer-xor@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/buffer-xor/-/buffer-xor-1.0.3.tgz#26e61ed1422fb70dd42e6e36729ed51d855fe8d9"
@@ -7288,18 +7283,6 @@ cache-base@^1.0.1:
     to-object-path "^0.3.0"
     union-value "^1.0.0"
     unset-value "^1.0.0"
-
-cache-loader@4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/cache-loader/-/cache-loader-4.1.0.tgz#9948cae353aec0a1fcb1eafda2300816ec85387e"
-  integrity sha512-ftOayxve0PwKzBF/GLsZNC9fJBXl8lkZE3TOsjkboHfVHVkL39iUEs1FO07A33mizmci5Dudt38UZrrYXDtbhw==
-  dependencies:
-    buffer-json "^2.0.0"
-    find-cache-dir "^3.0.0"
-    loader-utils "^1.2.3"
-    mkdirp "^0.5.1"
-    neo-async "^2.6.1"
-    schema-utils "^2.0.0"
 
 cacheable-lookup@^2.0.0:
   version "2.0.1"
@@ -16766,7 +16749,7 @@ mamacro@^0.0.3:
   resolved "https://registry.yarnpkg.com/mamacro/-/mamacro-0.0.3.tgz#ad2c9576197c9f1abf308d0787865bd975a3f3e4"
   integrity sha512-qMEwh+UujcQ+kbz3T6V+wAmO2U8veoq2w+3wY8MquqwVA3jChfwY+Tk52GZKDfACEPjuZ7r2oJLejwpt8jtwTA==
 
-map-age-cleaner@^0.1.1, map-age-cleaner@^0.1.3:
+map-age-cleaner@^0.1.1:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz#7d583a7306434c055fe474b0f45078e6e1b4b92a"
   integrity sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==
@@ -16952,14 +16935,6 @@ media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
   integrity sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=
-
-mem@6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/mem/-/mem-6.1.0.tgz#846eca0bd4708a8f04b9c3f3cd769e194ae63c5c"
-  integrity sha512-RlbnLQgRHk5lwqTtpEkBTQ2ll/CG/iB+J4Hy2Wh97PjgZgXgWJWrFF+XXujh3UUVLvR4OOTgZzcWMMwnehlEUg==
-  dependencies:
-    map-age-cleaner "^0.1.3"
-    mimic-fn "^3.0.0"
 
 mem@^1.1.0:
   version "1.1.0"
@@ -17192,11 +17167,6 @@ mimic-fn@^2.0.0, mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
-
-mimic-fn@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-3.0.0.tgz#76044cfa8818bbf6999c5c9acadf2d3649b14b4b"
-  integrity sha512-PiVO95TKvhiwgSwg1IdLYlCTdul38yZxZMIcnDSFIBUm4BNZha2qpQ4GpJ++15bHoKDtrW2D69lMfFwdFYtNZQ==
 
 mimic-response@^1.0.0, mimic-response@^1.0.1:
   version "1.0.1"
@@ -22574,15 +22544,6 @@ schema-utils@^1.0.0:
     ajv "^6.1.0"
     ajv-errors "^1.0.0"
     ajv-keywords "^3.1.0"
-
-schema-utils@^2.0.0:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-2.7.0.tgz#17151f76d8eae67fbbf77960c33c676ad9f4efc7"
-  integrity sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==
-  dependencies:
-    "@types/json-schema" "^7.0.4"
-    ajv "^6.12.2"
-    ajv-keywords "^3.4.1"
 
 schema-utils@^2.0.1, schema-utils@^2.1.0, schema-utils@^2.5.0, schema-utils@^2.6.0, schema-utils@^2.6.1, schema-utils@^2.6.4:
   version "2.6.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3744,7 +3744,7 @@
     jest-diff "^25.2.1"
     pretty-format "^25.2.1"
 
-"@types/json-schema@^7.0.3":
+"@types/json-schema@^7.0.3", "@types/json-schema@^7.0.4":
   version "7.0.4"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.4.tgz#38fd73ddfd9b55abb1e1b2ed578cb55bd7b7d339"
   integrity sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==
@@ -5449,7 +5449,7 @@ ajv-keywords@^3.1.0, ajv-keywords@^3.4.1:
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.4.1.tgz#ef916e271c64ac12171fd8384eaae6b2345854da"
   integrity sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==
 
-ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.0, ajv@^6.5.5:
+ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.0, ajv@^6.12.2, ajv@^6.5.5:
   version "6.12.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.2.tgz#c629c5eced17baf314437918d2da88c99d5958cd"
   integrity sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==
@@ -7113,6 +7113,11 @@ buffer-indexof@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-indexof/-/buffer-indexof-1.1.1.tgz#52fabcc6a606d1a00302802648ef68f639da268c"
   integrity sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g==
 
+buffer-json@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/buffer-json/-/buffer-json-2.0.0.tgz#f73e13b1e42f196fe2fd67d001c7d7107edd7c23"
+  integrity sha512-+jjPFVqyfF1esi9fvfUs3NqM0pH1ziZ36VP4hmA/y/Ssfo/5w5xHKfTw9BwQjoJ1w/oVtpLomqwUHKdefGyuHw==
+
 buffer-xor@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/buffer-xor/-/buffer-xor-1.0.3.tgz#26e61ed1422fb70dd42e6e36729ed51d855fe8d9"
@@ -7283,6 +7288,18 @@ cache-base@^1.0.1:
     to-object-path "^0.3.0"
     union-value "^1.0.0"
     unset-value "^1.0.0"
+
+cache-loader@4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/cache-loader/-/cache-loader-4.1.0.tgz#9948cae353aec0a1fcb1eafda2300816ec85387e"
+  integrity sha512-ftOayxve0PwKzBF/GLsZNC9fJBXl8lkZE3TOsjkboHfVHVkL39iUEs1FO07A33mizmci5Dudt38UZrrYXDtbhw==
+  dependencies:
+    buffer-json "^2.0.0"
+    find-cache-dir "^3.0.0"
+    loader-utils "^1.2.3"
+    mkdirp "^0.5.1"
+    neo-async "^2.6.1"
+    schema-utils "^2.0.0"
 
 cacheable-lookup@^2.0.0:
   version "2.0.1"
@@ -16749,7 +16766,7 @@ mamacro@^0.0.3:
   resolved "https://registry.yarnpkg.com/mamacro/-/mamacro-0.0.3.tgz#ad2c9576197c9f1abf308d0787865bd975a3f3e4"
   integrity sha512-qMEwh+UujcQ+kbz3T6V+wAmO2U8veoq2w+3wY8MquqwVA3jChfwY+Tk52GZKDfACEPjuZ7r2oJLejwpt8jtwTA==
 
-map-age-cleaner@^0.1.1:
+map-age-cleaner@^0.1.1, map-age-cleaner@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz#7d583a7306434c055fe474b0f45078e6e1b4b92a"
   integrity sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==
@@ -16935,6 +16952,14 @@ media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
   integrity sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=
+
+mem@6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/mem/-/mem-6.1.0.tgz#846eca0bd4708a8f04b9c3f3cd769e194ae63c5c"
+  integrity sha512-RlbnLQgRHk5lwqTtpEkBTQ2ll/CG/iB+J4Hy2Wh97PjgZgXgWJWrFF+XXujh3UUVLvR4OOTgZzcWMMwnehlEUg==
+  dependencies:
+    map-age-cleaner "^0.1.3"
+    mimic-fn "^3.0.0"
 
 mem@^1.1.0:
   version "1.1.0"
@@ -17167,6 +17192,11 @@ mimic-fn@^2.0.0, mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
+
+mimic-fn@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-3.0.0.tgz#76044cfa8818bbf6999c5c9acadf2d3649b14b4b"
+  integrity sha512-PiVO95TKvhiwgSwg1IdLYlCTdul38yZxZMIcnDSFIBUm4BNZha2qpQ4GpJ++15bHoKDtrW2D69lMfFwdFYtNZQ==
 
 mimic-response@^1.0.0, mimic-response@^1.0.1:
   version "1.0.1"
@@ -19429,6 +19459,14 @@ postcss-custom-media@^7.0.8:
   dependencies:
     postcss "^7.0.14"
 
+postcss-custom-properties@9.1.1:
+  version "9.1.1"
+  resolved "https://registry.yarnpkg.com/postcss-custom-properties/-/postcss-custom-properties-9.1.1.tgz#55822d70ff48004f6d307a338ba64a7fb0a4bfff"
+  integrity sha512-GVu+j7vwMTKUGhGXckYAFAAG5tTJUkSt8LuSyimtZdVVmdAEZYYqserkAgX8vwMhgGDPA4vJtWt7VgFxgiooDA==
+  dependencies:
+    postcss "^7.0.17"
+    postcss-values-parser "^3.0.5"
+
 postcss-custom-properties@^8.0.11:
   version "8.0.11"
   resolved "https://registry.yarnpkg.com/postcss-custom-properties/-/postcss-custom-properties-8.0.11.tgz#2d61772d6e92f22f5e0d52602df8fae46fa30d97"
@@ -20060,6 +20098,15 @@ postcss-values-parser@^3.0.5, postcss-values-parser@^3.1.1:
     is-url-superb "^3.0.0"
     postcss "^7.0.5"
     url-regex "^5.0.0"
+
+postcss@7.0.32:
+  version "7.0.32"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.32.tgz#4310d6ee347053da3433db2be492883d62cec59d"
+  integrity sha512-03eXong5NLnNCD05xscnGKGDZ98CyzoqPSMjOe6SuoQY7Z2hIj0Ld1g/O/UQRuOle2aRtiIRDg9tDcTGAkLfKw==
+  dependencies:
+    chalk "^2.4.2"
+    source-map "^0.6.1"
+    supports-color "^6.1.0"
 
 postcss@^5.0.21:
   version "5.2.18"
@@ -22527,6 +22574,15 @@ schema-utils@^1.0.0:
     ajv "^6.1.0"
     ajv-errors "^1.0.0"
     ajv-keywords "^3.1.0"
+
+schema-utils@^2.0.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-2.7.0.tgz#17151f76d8eae67fbbf77960c33c676ad9f4efc7"
+  integrity sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==
+  dependencies:
+    "@types/json-schema" "^7.0.4"
+    ajv "^6.12.2"
+    ajv-keywords "^3.4.1"
 
 schema-utils@^2.0.1, schema-utils@^2.1.0, schema-utils@^2.5.0, schema-utils@^2.6.0, schema-utils@^2.6.1, schema-utils@^2.6.4:
   version "2.6.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -19429,14 +19429,6 @@ postcss-custom-media@^7.0.8:
   dependencies:
     postcss "^7.0.14"
 
-postcss-custom-properties@9.1.1:
-  version "9.1.1"
-  resolved "https://registry.yarnpkg.com/postcss-custom-properties/-/postcss-custom-properties-9.1.1.tgz#55822d70ff48004f6d307a338ba64a7fb0a4bfff"
-  integrity sha512-GVu+j7vwMTKUGhGXckYAFAAG5tTJUkSt8LuSyimtZdVVmdAEZYYqserkAgX8vwMhgGDPA4vJtWt7VgFxgiooDA==
-  dependencies:
-    postcss "^7.0.17"
-    postcss-values-parser "^3.0.5"
-
 postcss-custom-properties@^8.0.11:
   version "8.0.11"
   resolved "https://registry.yarnpkg.com/postcss-custom-properties/-/postcss-custom-properties-8.0.11.tgz#2d61772d6e92f22f5e0d52602df8fae46fa30d97"


### PR DESCRIPTION
#### The Problem

As beautifully and thoroughly explained by @jsnajdr [here](https://github.com/Automattic/wp-calypso/pull/42829#issuecomment-637416134): 

> We use the `importFrom` option that loads some common CSS variables from a file in the `calypso-color-schemes` package. The `postcss-custom-properties` plugin reads and parses that file every time when creating an instance of the plugin.
And every CSS file needs its own instance of the plugin, because the PostCSS configuration is dynamic: every file can have a different chain of directory-local `postcss.config.js` files, and the config can be a function that returns a different config for each file.
Calypso webpack build creates 850 instances of the plugin, as that's the number of *.scss files to process.

One solution to this problem is memoizing the repetitive parts of `postcss-custom-properties` and sending a PR. I tried this solution and it does the job. But a problem arises in Webpack watch mode. As the memoization cache will need to check files' paths **_and_** contents instead of only paths; given that any file might change while Webpack is watching. Granted we don't run `postcss-custom-properties` in watch mode, but someone might.

#### Another simpler solution
Since the bottleneck is parsing the CSS properties that come from our own `calypso-color-schemes`, why not output them parsed and ready for consumption as-is? This is even faster than memoization, since it doesn't need a slow first pass.

This PR is that solution. I think it's a good solution but surely any feedback is welcome.

#### Changing `calypso-color-schemes` 

This PR changes `calypso-color-schemes` package two ways:

1. Changes the built files directory from `dist` to two dirs: `css` and `js`. But keeps the `package.json.main` pointing to the CSS file (as it was). This means that files that import `calypso-color-schemes` package as `import '@automattic/calypso-color-schemes'` will not have any issues and won't need to change anything. I searched our whole codebase and in no parts `calypso-color-schemes/dist` folder was touched. 

2. It makes the package output the CSS props in a JS file under `calypso-color-schemes/js`. This adds the ability to import the parsed CSS properties like `const { customProperties } = require('@automattic/calypso-color-schemes/js')`. Which we can use in `postcss-custom-properties` config without paying for parsing ✨ 

With this setup
```sh
yarn run build-client-fallback 
```
Time went from 122s to 57s 🐎 

### Testing
I tested in Chrome and IE and CSS props seem to work in both 

Fixes https://github.com/Automattic/wp-calypso/issues/42929
