### PR TITLE
Disable `save-exact` in NPM config

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
-save-exact = true
-
+save-prefix = ^

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-save-prefix = ^


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Disable `save-exact` since it seems [we're no longer doing that](https://github.com/Automattic/wp-calypso/blob/5d025f99cb306063e646e250f23afcd1d0494711/package.json) by removing the config file.

`save-prefix = ^` is default anyway unless overriden in developer's configs, and hence we don't even need to add that here.

https://docs.npmjs.com/misc/config#save-exact
https://docs.npmjs.com/misc/config#save-prefix

#### Testing

`--save` dependency and see it appear with carret.