### PR TITLE
Signup test: Use Passwordless signup after Plans step

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -860,18 +860,14 @@ class SignupForm extends Component {
 			? this.getLoginLink()
 			: localizeUrl( config( 'login_url' ), this.props.locale );
 
-		const loginTextByFlowName =
+		const footerLoginText =
 			flowName === 'onboarding'
 				? translate( 'Log in to create a site for your existing account.' )
 				: translate( 'Already have a WordPress.com account?' );
 
-		const footerLoginText = this.props.footerLoginText || loginTextByFlowName;
 		return (
 			<>
 				<LoggedOutFormLinks>
-					{ this.props.footerText && (
-						<div className="signup-form__footer-text">{ this.props.footerText }</div>
-					) }
 					<LoggedOutFormLinkItem href={ logInUrl }>{ footerLoginText }</LoggedOutFormLinkItem>
 					{ this.props.oauth2Client && (
 						<LoggedOutFormBackLink

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -859,11 +859,12 @@ class SignupForm extends Component {
 			? this.getLoginLink()
 			: localizeUrl( config( 'login_url' ), this.props.locale );
 
-		const footerLoginText =
+		const loginTextByFlowName =
 			flowName === 'onboarding'
 				? translate( 'Log in to create a site for your existing account.' )
 				: translate( 'Already have a WordPress.com account?' );
 
+		const footerLoginText = this.props.footerLoginText || loginTextByFlowName;
 		return (
 			<>
 				<LoggedOutFormLinks>

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -976,29 +976,16 @@ class SignupForm extends Component {
 				</div>
 			);
 		}
-
 		/*
+			AB Test: passwordlessAfterPlans
 
-			AB Test 1: passwordlessSignup
-
-			`<PasswordlessSignupForm />` is for the `onboarding` flow.
-
-			We are testing whether a passwordless account creation and login improves signup rate in the `onboarding` flow
-		*/
-		const isPasswordlessSignup =
-			( 'onboarding' === this.props.flowName || 'test-fse' === this.props.flowName ) &&
-			'passwordless' === abtest( 'passwordlessSignup' );
-
-		/*
-			AB Test 2: passwordlessAfterPlans
-
-			`<PasswordlessSignupForm />` is for the `onboarding-domains-passwordless` flow.
+			`<PasswordlessSignupForm />` is for the `onboarding-passwordless` flow.
 
 			We are testing whether a having a passwordless account creation after domain and plans, improves signup rate in the `onboarding` flow
 		*/
 		const isPasswordlessAfterPlans = 'onboarding-passwordless' === this.props.flowName;
 
-		if ( isPasswordlessSignup || isPasswordlessAfterPlans ) {
+		if ( isPasswordlessAfterPlans ) {
 			const logInUrl = config.isEnabled( 'login/native-login-links' )
 				? this.getLoginLink()
 				: localizeUrl( config( 'login_url' ), this.props.locale );

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -770,6 +770,14 @@ class SignupForm extends Component {
 		return <p className="signup-form__terms-of-service-link">{ tosText }</p>;
 	};
 
+	getExplanation = () => {
+		return (
+			<p className="signup-form__terms-of-service-link signup-form__terms-of-service-link-is-explanation-text">
+				{ this.props.explanationText }
+			</p>
+		);
+	};
+
 	getNotice() {
 		if ( this.props.step && 'invalid' === this.props.step.status ) {
 			return this.globalNotice( this.props.step.errors[ 0 ] );
@@ -852,14 +860,19 @@ class SignupForm extends Component {
 			? this.getLoginLink()
 			: localizeUrl( config( 'login_url' ), this.props.locale );
 
+		const loginTextByFlowName =
+			flowName === 'onboarding'
+				? translate( 'Log in to create a site for your existing account.' )
+				: translate( 'Already have a WordPress.com account?' );
+
+		const footerLoginText = this.props.footerLoginText || loginTextByFlowName;
 		return (
 			<>
 				<LoggedOutFormLinks>
-					<LoggedOutFormLinkItem href={ logInUrl }>
-						{ flowName === 'onboarding'
-							? translate( 'Log in to create a site for your existing account.' )
-							: translate( 'Already have a WordPress.com account?' ) }
-					</LoggedOutFormLinkItem>
+					{ this.props.footerText && (
+						<div className="signup-form__footer-text">{ this.props.footerText }</div>
+					) }
+					<LoggedOutFormLinkItem href={ logInUrl }>{ footerLoginText }</LoggedOutFormLinkItem>
 					{ this.props.oauth2Client && (
 						<LoggedOutFormBackLink
 							oauth2Client={ this.props.oauth2Client }
@@ -989,11 +1002,30 @@ class SignupForm extends Component {
 			const logInUrl = config.isEnabled( 'login/native-login-links' )
 				? this.getLoginLink()
 				: localizeUrl( config( 'login_url' ), this.props.locale );
+			const textProps = pick( this.props, [
+				'submittingButtonText',
+				'defaultButtonText',
+				'headerText',
+				'subHeaderText',
+				'emailInputLabel',
+			] );
+
+			const socialTextProps = pick( this.props, [
+				'socialAlternativeText',
+				'socialTosText',
+				'socialGoogleLabel',
+				'socialAppleLabel',
+			] );
+
+			const renderTerms = this.props.explanationText
+				? this.getExplanation
+				: this.termsOfServiceLink;
 
 			return (
 				<div
 					className={ classNames( 'signup-form', this.props.className, {
 						'is-showing-recaptcha-tos': this.props.showRecaptchaToS,
+						'is-passwordless-after-plans': isPasswordlessAfterPlans,
 					} ) }
 				>
 					{ this.getNotice() }
@@ -1002,17 +1034,19 @@ class SignupForm extends Component {
 						stepName={ this.props.stepName }
 						flowName={ this.props.flowName }
 						goToNextStep={ this.props.goToNextStep }
-						renderTerms={ this.termsOfServiceLink }
+						renderTerms={ renderTerms }
 						logInUrl={ logInUrl }
 						disabled={ this.props.disabled }
 						disableSubmitButton={ this.props.disableSubmitButton }
 						recaptchaClientId={ this.props.recaptchaClientId }
+						{ ...textProps }
 					/>
 					{ this.props.isSocialSignupEnabled && ! this.userCreationComplete() && (
 						<SocialSignupForm
 							handleResponse={ this.props.handleSocialResponse }
 							socialService={ this.props.socialService }
 							socialServiceResponse={ this.props.socialServiceResponse }
+							{ ...socialTextProps }
 						/>
 					) }
 

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -23,7 +23,6 @@ import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
-import { abtest } from 'lib/abtest';
 
 /**
  * Internal dependencies

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -966,16 +966,26 @@ class SignupForm extends Component {
 
 		/*
 
-			AB Test: passwordlessSignup
+			AB Test 1: passwordlessSignup
 
 			`<PasswordlessSignupForm />` is for the `onboarding` flow.
 
 			We are testing whether a passwordless account creation and login improves signup rate in the `onboarding` flow
 		*/
-		if (
-			( this.props.flowName === 'onboarding' || this.props.flowName === 'test-fse' ) &&
-			'passwordless' === abtest( 'passwordlessSignup' )
-		) {
+		const isPasswordlessSignup =
+			( 'onboarding' === this.props.flowName || 'test-fse' === this.props.flowName ) &&
+			'passwordless' === abtest( 'passwordlessSignup' );
+
+		/*
+			AB Test 2: passwordlessAfterPlans
+
+			`<PasswordlessSignupForm />` is for the `onboarding-domains-passwordless` flow.
+
+			We are testing whether a having a passwordless account creation after domain and plans, improves signup rate in the `onboarding` flow
+		*/
+		const isPasswordlessAfterPlans = 'onboarding-plans-passwordless' === this.props.flowName;
+
+		if ( isPasswordlessSignup || isPasswordlessAfterPlans ) {
 			const logInUrl = config.isEnabled( 'login/native-login-links' )
 				? this.getLoginLink()
 				: localizeUrl( config( 'login_url' ), this.props.locale );

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -996,7 +996,7 @@ class SignupForm extends Component {
 
 			We are testing whether a having a passwordless account creation after domain and plans, improves signup rate in the `onboarding` flow
 		*/
-		const isPasswordlessAfterPlans = 'onboarding-plans-passwordless' === this.props.flowName;
+		const isPasswordlessAfterPlans = 'onboarding-passwordless' === this.props.flowName;
 
 		if ( isPasswordlessSignup || isPasswordlessAfterPlans ) {
 			const logInUrl = config.isEnabled( 'login/native-login-links' )

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -1010,6 +1010,14 @@ class SignupForm extends Component {
 				'emailInputLabel',
 			] );
 
+			const isFreePlan = this.props.signupDependencies && ! this.props.signupDependencies.cartItem;
+			if ( isFreePlan ) {
+				textProps.submittingButtonText =
+					this.props.freeSubmittingButtonText || textProps.submittingButtonText;
+				textProps.defaultButtonText =
+					this.props.freeDefaultButtonText || textProps.defaultButtonText;
+			}
+
 			const socialTextProps = pick( this.props, [
 				'socialAlternativeText',
 				'socialTosText',

--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -155,6 +155,7 @@ class PasswordlessSignupForm extends Component {
 		this.submitStep( {
 			username,
 			bearer_token: response.bearer_token,
+			marketing_price_group: response?.marketing_price_group ?? '',
 		} );
 	};
 

--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -238,9 +238,13 @@ class PasswordlessSignupForm extends Component {
 				</LoggedOutFormFooter>
 			);
 		}
-		const submitButtonText = isSubmitting
-			? this.props.translate( 'Creating Your Account…' )
-			: this.props.translate( 'Create your account' );
+
+		const defaultButtonText =
+			this.props.defaultButtonText || this.props.translate( 'Create your account' );
+		const submittingButtonText =
+			this.props.submittingButtonText || this.props.translate( 'Creating Your Account…' );
+
+		const submitButtonText = isSubmitting ? submittingButtonText : defaultButtonText;
 		return (
 			<LoggedOutFormFooter>
 				<Button
@@ -264,11 +268,12 @@ class PasswordlessSignupForm extends Component {
 		const { translate } = this.props;
 		const { errorMessages, isSubmitting } = this.state;
 
+		const emailInputLabel = this.props.emailInputLabel || translate( 'Enter your email address' );
 		return (
 			<div className="signup-form__passwordless-form-wrapper">
 				<LoggedOutForm onSubmit={ this.onFormSubmit } noValidate>
 					<ValidationFieldset errorMessages={ errorMessages }>
-						<FormLabel htmlFor="email">{ translate( 'Enter your email address' ) }</FormLabel>
+						<FormLabel htmlFor="email">{ emailInputLabel }</FormLabel>
 						<FormTextInput
 							autoCapitalize={ 'off' }
 							className="signup-form__passwordless-email"

--- a/client/blocks/signup-form/social.jsx
+++ b/client/blocks/signup-form/social.jsx
@@ -88,12 +88,11 @@ class SocialSignupForm extends Component {
 		const host = typeof window !== 'undefined' && window.location.host;
 		const redirectUri = `https://${ host }/start/user`;
 		const uxModeApple = config.isEnabled( 'sign-in-with-apple/redirect' ) ? 'redirect' : uxMode;
-
+		const alternativeText =
+			this.props.socialAlternativeText || this.props.translate( 'Or create an account using:' );
 		return (
 			<div className="signup-form__social">
-				{ ! this.props.compact && (
-					<p>{ preventWidows( this.props.translate( 'Or create an account using:' ) ) }</p>
-				) }
+				{ ! this.props.compact && <p>{ preventWidows( alternativeText ) }</p> }
 
 				<div className="signup-form__social-buttons">
 					<GoogleLoginButton
@@ -102,6 +101,7 @@ class SocialSignupForm extends Component {
 						uxMode={ uxMode }
 						redirectUri={ redirectUri }
 						onClick={ () => this.trackSocialLogin( 'google' ) }
+						label={ this.props.socialGoogleLabel }
 						socialServiceResponse={
 							this.props.socialService === 'google' ? this.props.socialServiceResponse : null
 						}
@@ -113,28 +113,30 @@ class SocialSignupForm extends Component {
 						uxMode={ uxModeApple }
 						redirectUri={ redirectUri }
 						onClick={ () => this.trackSocialLogin( 'apple' ) }
+						label={ this.props.socialAppleLabel }
 						socialServiceResponse={
 							this.props.socialService === 'apple' ? this.props.socialServiceResponse : null
 						}
 					/>
 
 					<p className="signup-form__social-buttons-tos">
-						{ this.props.translate(
-							"If you continue with Google or Apple and don't already have a WordPress.com account, you" +
-								' are creating an account and you agree to our' +
-								' {{a}}Terms of Service{{/a}}.',
-							{
-								components: {
-									a: (
-										<a
-											href={ localizeUrl( 'https://wordpress.com/tos/' ) }
-											target="_blank"
-											rel="noopener noreferrer"
-										/>
-									),
-								},
-							}
-						) }
+						{ this.props.socialTosText ||
+							this.props.translate(
+								"If you continue with Google or Apple and don't already have a WordPress.com account, you" +
+									' are creating an account and you agree to our' +
+									' {{a}}Terms of Service{{/a}}.',
+								{
+									components: {
+										a: (
+											<a
+												href={ localizeUrl( 'https://wordpress.com/tos/' ) }
+												target="_blank"
+												rel="noopener noreferrer"
+											/>
+										),
+									},
+								}
+							) }
 					</p>
 				</div>
 			</div>

--- a/client/blocks/signup-form/style.scss
+++ b/client/blocks/signup-form/style.scss
@@ -91,6 +91,36 @@
 	}
 }
 
+.signup-form__footer-text {
+	color: var( --color-text-inverted );
+	font-size: 14px;
+	margin: 15px 0 0;
+}
+
+.signup-form.is-showing-recaptcha-tos {
+	.signup-form__terms-of-service-link {
+		margin: 25px 0 0;
+	}
+}
+
+.signup-form.is-passwordless-after-plans {
+	.social-buttons__button {
+		background: none;
+		border: none;
+		width: 50%;
+		box-shadow: none;
+		float: left;
+		color: var( --color-text-inverted );
+		text-decoration: underline;
+		margin-bottom: 30px;
+	}
+	.signup-form__social-buttons-tos {
+		font-size: 12px;
+		margin: 5px 0;
+		clear: both;
+	}
+}
+
 // Replace recaptcha badge with ToS text and space
 // everything out a little more.
 @media ( max-width: 660px ) {

--- a/client/blocks/signup-form/style.scss
+++ b/client/blocks/signup-form/style.scss
@@ -91,12 +91,6 @@
 	}
 }
 
-.signup-form__footer-text {
-	color: var( --color-text-inverted );
-	font-size: 14px;
-	margin: 15px 0 0;
-}
-
 .signup-form.is-showing-recaptcha-tos {
 	.signup-form__terms-of-service-link {
 		margin: 25px 0 0;

--- a/client/components/social-buttons/apple.js
+++ b/client/components/social-buttons/apple.js
@@ -36,12 +36,14 @@ class AppleLoginButton extends Component {
 		scope: PropTypes.string,
 		uxMode: PropTypes.oneOf( [ 'redirect', 'popup' ] ),
 		socialServiceResponse: PropTypes.object,
+		label: PropTypes.string,
 	};
 
 	static defaultProps = {
 		onClick: noop,
 		scope: 'name email',
 		uxMode: 'popup',
+		label: '',
 	};
 
 	appleClient = null;
@@ -151,11 +153,12 @@ class AppleLoginButton extends Component {
 						<AppleIcon isDisabled={ isDisabled } />
 
 						<span className="social-buttons__service-name">
-							{ this.props.translate( 'Continue with %(service)s', {
-								args: { service: 'Apple' },
-								comment:
-									'%(service)s is the name of a third-party authentication provider, e.g. "Google", "Facebook", "Apple" ...',
-							} ) }
+							{ this.props.label ||
+								this.props.translate( 'Continue with %(service)s', {
+									args: { service: 'Apple' },
+									comment:
+										'%(service)s is the name of a third-party authentication provider, e.g. "Google", "Facebook", "Apple" ...',
+								} ) }
 						</span>
 					</button>
 				) }

--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -37,12 +37,14 @@ class GoogleLoginButton extends Component {
 		scope: PropTypes.string,
 		translate: PropTypes.func.isRequired,
 		uxMode: PropTypes.string,
+		label: PropTypes.string,
 	};
 
 	static defaultProps = {
 		scope: 'https://www.googleapis.com/auth/userinfo.profile',
 		fetchBasicProfile: true,
 		onClick: noop,
+		label: '',
 	};
 
 	state = {
@@ -220,11 +222,12 @@ class GoogleLoginButton extends Component {
 						<GoogleIcon isDisabled={ isDisabled } />
 
 						<span className="social-buttons__service-name">
-							{ this.props.translate( 'Continue with %(service)s', {
-								args: { service: 'Google' },
-								comment:
-									'%(service)s is the name of a third-party authentication provider, e.g. "Google", "Facebook", "Apple" ...',
-							} ) }
+							{ this.props.label ||
+								this.props.translate( 'Continue with %(service)s', {
+									args: { service: 'Google' },
+									comment:
+										'%(service)s is the name of a third-party authentication provider, e.g. "Google", "Facebook", "Apple" ...',
+								} ) }
 						</span>
 					</button>
 				) }

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -158,4 +158,15 @@ export default {
 		allowExistingUsers: false,
 		countryCodeTargets: [ 'US' ],
 	},
+	passwordlessAfterPlans: {
+		datestamp: '20200608',
+		variations: {
+			variantPasswordless: 50,
+			control: 50,
+		},
+		defaultVariation: 'control',
+		allowExistingUsers: true,
+		localeTargets: [ 'en' ],
+		countryCodeTargets: [ 'US' ],
+	},
 };

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -159,7 +159,7 @@ export default {
 		countryCodeTargets: [ 'US' ],
 	},
 	passwordlessAfterPlans: {
-		datestamp: '20200608',
+		datestamp: '20200618',
 		variations: {
 			variantPasswordless: 50,
 			control: 50,

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -166,7 +166,6 @@ export default {
 		},
 		defaultVariation: 'control',
 		allowExistingUsers: true,
-		localeTargets: [ 'en' ],
 		countryCodeTargets: [ 'US' ],
 	},
 };

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -126,7 +126,7 @@ export function generateFlows( {
 		},
 
 		'onboarding-plans-passwordless': {
-			steps: [ 'domains', 'plans', 'user-simple' ],
+			steps: [ 'domains', 'plans', 'user-plans-passwordless' ],
 			destination: getSignupDestination,
 			description: 'Abridged version of the onboarding flow. Read more in https://wp.me/pbxNRc-m0',
 			lastModified: '2020-03-03',

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -125,8 +125,8 @@ export function generateFlows( {
 			showRecaptcha: true,
 		},
 
-		'onboarding-plans-passwordless': {
-			steps: [ 'domains', 'plans', 'user-plans-passwordless' ],
+		'onboarding-passwordless': {
+			steps: [ 'domains', 'plans', 'user-passwordless' ],
 			destination: getSignupDestination,
 			description: 'Abridged version of the onboarding flow. Read more in https://wp.me/pbxNRc-m0',
 			lastModified: '2020-03-03',

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -128,8 +128,9 @@ export function generateFlows( {
 		'onboarding-passwordless': {
 			steps: [ 'domains', 'plans', 'user-passwordless' ],
 			destination: getSignupDestination,
-			description: 'Abridged version of the onboarding flow. Read more in https://wp.me/pbxNRc-m0',
-			lastModified: '2020-03-03',
+			description:
+				'Simplify the User step (account creation step) and move it right before the Checkout, after Plans/Domains steps. Read more in https://wp.me/pbxNRc-m0',
+			lastModified: '2020-06-17',
 			showRecaptcha: true,
 		},
 

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -126,7 +126,7 @@ export function generateFlows( {
 		},
 
 		'onboarding-plans-passwordless': {
-			steps: [ 'domains', 'plans', 'user' ],
+			steps: [ 'domains', 'plans', 'user-simple' ],
 			destination: getSignupDestination,
 			description: 'Abridged version of the onboarding flow. Read more in https://wp.me/pbxNRc-m0',
 			lastModified: '2020-03-03',

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -125,6 +125,14 @@ export function generateFlows( {
 			showRecaptcha: true,
 		},
 
+		'onboarding-plans-passwordless': {
+			steps: [ 'domains', 'plans', 'user' ],
+			destination: getSignupDestination,
+			description: 'Abridged version of the onboarding flow. Read more in https://wp.me/pbxNRc-m0',
+			lastModified: '2020-03-03',
+			showRecaptcha: true,
+		},
+
 		desktop: {
 			steps: [ 'about', 'themes', 'domains', 'plans', 'user' ],
 			destination: getSignupDestination,

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -52,7 +52,7 @@ const stepNameToModuleName = {
 	'template-first-themes': 'theme-selection',
 	'fse-themes': 'theme-selection',
 	user: 'user',
-	'user-simple': 'user',
+	'user-plans-passwordless': 'user',
 	'oauth2-user': 'user',
 	'oauth2-name': 'user',
 	displayname: 'user',

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -52,7 +52,7 @@ const stepNameToModuleName = {
 	'template-first-themes': 'theme-selection',
 	'fse-themes': 'theme-selection',
 	user: 'user',
-	'user-plans-passwordless': 'user',
+	'user-passwordless': 'user',
 	'oauth2-user': 'user',
 	'oauth2-name': 'user',
 	displayname: 'user',

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -52,6 +52,7 @@ const stepNameToModuleName = {
 	'template-first-themes': 'theme-selection',
 	'fse-themes': 'theme-selection',
 	user: 'user',
+	'user-simple': 'user',
 	'oauth2-user': 'user',
 	'oauth2-name': 'user',
 	displayname: 'user',

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -183,6 +183,7 @@ export function generateSteps( {
 						},
 					}
 				),
+				footerLoginText: 'Already have an account? Log in',
 				socialGoogleLabel: 'Google',
 				socialAppleLabel: 'Apple',
 			},

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -161,20 +161,17 @@ export function generateSteps( {
 			props: {
 				isSocialSignupEnabled: config.isEnabled( 'signup/social' ),
 				// Flow is to be use on English locale only, no need to translate labels
-				fallbackHeaderText: "Let's get started",
+				fallbackHeaderText: "Let's do this",
 				fallbackSubHeaderText: "You're one step away to get going with your site",
 				submittingButtonText: 'Go to Checkout »',
 				defaultButtonText: 'Go to Checkout »',
+				freeSubmittingButtonText: 'Continue »',
+				freeDefaultButtonText: 'Continue »',
 				emailInputLabel: 'Your email address',
 
 				// Used translations to insert html
-				explanationText: i18n.translate(
-					"You'll be able to log in to your account using this address.{{br/}}" +
-						'You can also set a password later.',
-					{
-						components: { br: <br /> },
-					}
-				),
+				explanationText:
+					"You'll be able to log in to your account using this address. You can also set a password later.",
 				socialAlternativeText: 'Or continue using:',
 
 				// Used translations to insert html
@@ -188,8 +185,6 @@ export function generateSteps( {
 				),
 				socialGoogleLabel: 'Google',
 				socialAppleLabel: 'Apple',
-				footerText: 'Do you already have a WordPress.com account?',
-				footerLoginText: 'Log in here',
 			},
 		},
 

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -153,8 +153,8 @@ export function generateSteps( {
 			},
 		},
 
-		'user-plans-passwordless': {
-			stepName: 'user-plans-passwordless',
+		'user-passwordless': {
+			stepName: 'user-passwordless',
 			apiRequestFunction: createAccount,
 			providesToken: true,
 			providesDependencies: [ 'bearer_token', 'username' ],

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -152,6 +152,16 @@ export function generateSteps( {
 			},
 		},
 
+		'user-simple': {
+			stepName: 'user-simple',
+			apiRequestFunction: createAccount,
+			providesToken: true,
+			providesDependencies: [ 'bearer_token', 'username' ],
+			props: {
+				isSocialSignupEnabled: config.isEnabled( 'signup/social' ),
+			},
+		},
+
 		'site-title': {
 			stepName: 'site-title',
 			providesDependencies: [ 'siteTitle' ],

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -151,14 +151,44 @@ export function generateSteps( {
 				isSocialSignupEnabled: config.isEnabled( 'signup/social' ),
 			},
 		},
-
-		'user-simple': {
-			stepName: 'user-simple',
+		'user-plans-passwordless': {
+			stepName: 'user-plans-passwordless',
 			apiRequestFunction: createAccount,
 			providesToken: true,
 			providesDependencies: [ 'bearer_token', 'username' ],
 			props: {
 				isSocialSignupEnabled: config.isEnabled( 'signup/social' ),
+				// Flow is to be use on English locale only, no need to translate labels
+				fallbackHeaderText: "Let's get started",
+				fallbackSubHeaderText: "You're one step away to get going with your site",
+				hasInitializedSitesBackUrl: '',
+				submittingButtonText: 'Go to Checkout »',
+				defaultButtonText: 'Go to Checkout »',
+				emailInputLabel: 'Your email address',
+
+				// Used translations to insert html
+				explanationText: i18n.translate(
+					"You'll be able to log in to your account using this address.{{br/}}" +
+						'You can also set a password later.',
+					{
+						components: { br: <br /> },
+					}
+				),
+				socialAlternativeText: 'Or continue using:',
+
+				// Used translations to insert html
+				socialTosText: i18n.translate(
+					'By proceeding, you agree to our {{a}}Terms of Service{{/a}}.',
+					{
+						components: {
+							a: <a href="https://wordpress.com/tos/" target="_blank" rel="noopener noreferrer" />,
+						},
+					}
+				),
+				socialGoogleLabel: 'Google',
+				socialAppleLabel: 'Apple',
+				footerText: 'Do you already have a WordPress.com account?',
+				footerLoginText: 'Log in here',
 			},
 		},
 

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import React from 'react';
 import { noop } from 'lodash';
 import i18n from 'i18n-calypso';
 
@@ -151,6 +152,7 @@ export function generateSteps( {
 				isSocialSignupEnabled: config.isEnabled( 'signup/social' ),
 			},
 		},
+
 		'user-plans-passwordless': {
 			stepName: 'user-plans-passwordless',
 			apiRequestFunction: createAccount,
@@ -161,7 +163,6 @@ export function generateSteps( {
 				// Flow is to be use on English locale only, no need to translate labels
 				fallbackHeaderText: "Let's get started",
 				fallbackSubHeaderText: "You're one step away to get going with your site",
-				hasInitializedSitesBackUrl: '',
 				submittingButtonText: 'Go to Checkout »',
 				defaultButtonText: 'Go to Checkout »',
 				emailInputLabel: 'Your email address',

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -157,7 +157,7 @@ export function generateSteps( {
 			stepName: 'user-passwordless',
 			apiRequestFunction: createAccount,
 			providesToken: true,
-			providesDependencies: [ 'bearer_token', 'username' ],
+			providesDependencies: [ 'bearer_token', 'username', 'marketing_price_group' ],
 			props: {
 				isSocialSignupEnabled: config.isEnabled( 'signup/social' ),
 				// Flow is to be use on English locale only, no need to translate labels

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -113,7 +113,14 @@ export default {
 					const countryCode = geo.data.body.country_short;
 					if ( 'gutenberg' === abtest( 'newSiteGutenbergOnboarding', countryCode ) ) {
 						window.location.replace( window.location.origin + '/new' + window.location.search );
-					} else if ( 'variantPasswordless' === abtest( 'passwordlessAfterPlans', countryCode ) ) {
+					} else if (
+						-1 === context.pathname.indexOf( 'free' ) &&
+						-1 === context.pathname.indexOf( 'personal' ) &&
+						-1 === context.pathname.indexOf( 'premium' ) &&
+						-1 === context.pathname.indexOf( 'business' ) &&
+						-1 === context.pathname.indexOf( 'ecommerce' ) &&
+						'variantPasswordless' === abtest( 'passwordlessAfterPlans', countryCode )
+					) {
 						const stepName = getStepName( context.params );
 						const stepSectionName = getStepSectionName( context.params );
 						const urlWithoutLocale = getStepUrl(

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -112,6 +112,15 @@ export default {
 					const countryCode = geo.data.body.country_short;
 					if ( 'gutenberg' === abtest( 'newSiteGutenbergOnboarding', countryCode ) ) {
 						window.location.replace( window.location.origin + '/new' + window.location.search );
+					} else if ( 'variantPasswordless' === abtest( 'passwordlessAfterPlans', countryCode ) ) {
+						const stepName = getStepName( context.params );
+						const stepSectionName = getStepSectionName( context.params );
+						const urlWithoutLocale = getStepUrl(
+							'onboarding-plans-passwordless',
+							stepName,
+							stepSectionName
+						);
+						window.location = urlWithoutLocale;
 					} else {
 						removeWhiteBackground();
 						next();

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -84,6 +84,7 @@ export default {
 		} else if (
 			context.pathname.indexOf( 'domain' ) >= 0 ||
 			context.pathname.indexOf( 'plan' ) >= 0 ||
+			context.pathname.indexOf( 'onboarding-passwordless' ) >= 0 ||
 			context.pathname.indexOf( 'wpcc' ) >= 0 ||
 			context.pathname.indexOf( 'launch-site' ) >= 0 ||
 			context.params.flowName === 'user' ||
@@ -116,7 +117,7 @@ export default {
 						const stepName = getStepName( context.params );
 						const stepSectionName = getStepSectionName( context.params );
 						const urlWithoutLocale = getStepUrl(
-							'onboarding-plans-passwordless',
+							'onboarding-passwordless',
 							stepName,
 							stepSectionName
 						);

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -662,7 +662,7 @@ class DomainsStep extends React.Component {
 		const showSkip = isDomainStepSkippable( flowName );
 
 		let hideBack;
-		if ( 'onboarding-plans-passwordless' === flowName && ! this.props.stepSectionName ) {
+		if ( 'onboarding-passwordless' === flowName && ! this.props.stepSectionName ) {
 			hideBack = true;
 		}
 		return (

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -662,7 +662,7 @@ class DomainsStep extends React.Component {
 		const showSkip = isDomainStepSkippable( flowName );
 
 		let hideBack;
-		if ( 'onboarding-plans-passwordless' === this.props.flowName && ! this.props.stepSectionName ) {
+		if ( 'onboarding-plans-passwordless' === flowName && ! this.props.stepSectionName ) {
 			hideBack = true;
 		}
 		return (

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -125,7 +125,7 @@ class DomainsStep extends React.Component {
 		this.showTestCopy = false;
 
 		const isEligibleFlowForDomainTest = includes(
-			[ 'onboarding', 'onboarding-plan-first' ],
+			[ 'onboarding', 'onboarding-plan-first', 'onboarding-passwordless' ],
 			props.flowName
 		);
 

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -661,6 +661,10 @@ class DomainsStep extends React.Component {
 		const fallbackSubHeaderText = this.getSubHeaderText();
 		const showSkip = isDomainStepSkippable( flowName );
 
+		let hideBack;
+		if ( 'onboarding-plans-passwordless' === this.props.flowName && ! this.props.stepSectionName ) {
+			hideBack = true;
+		}
 		return (
 			<StepWrapper
 				flowName={ this.props.flowName }
@@ -681,6 +685,7 @@ class DomainsStep extends React.Component {
 				allowBackFirstStep={ !! backUrl }
 				backLabelText={ backLabelText }
 				hideSkip={ ! showSkip }
+				hideBack={ hideBack }
 				isTopButtons={ showSkip }
 				goToNextStep={ this.handleSkip }
 				skipHeadingText={ translate( 'Not sure yet?' ) }

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -439,9 +439,12 @@ export class UserStep extends Component {
 				flowName={ this.props.flowName }
 				stepName={ this.props.stepName }
 				headerText={ this.getHeaderText() }
+				fallbackHeaderText={
+					this.props.fallbackHeaderText || this.props.translate( 'Create your account.' )
+				}
 				subHeaderText={ this.state.subHeaderText }
+				fallbackSubHeaderText={ this.props.fallbackSubHeaderText }
 				positionInFlow={ this.props.positionInFlow }
-				fallbackHeaderText={ this.props.translate( 'Create your account.' ) }
 				stepContent={ this.renderSignupForm() }
 			/>
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Check pbxNRc-m0-p2. The screens for the new flow can be seen in [Figma](https://www.figma.com/file/0hUWErRWnMytiVvViKAMLu/Simplified-Account-step-AB-test)

- change flow order and
  - **Control** - right now the control funnel looks like:
    **Account -> Domain -> Plans -> Checkout**
  - **Variant** - in this variant, we want to test this:
   **Domain -> Plans -> Simplified Account -> Checkout**

**Control** Account step
<img width="1024" alt="screen-shot-2020-06-02-at-16 58 12" src="https://user-images.githubusercontent.com/2749938/84029558-41f7b800-a99b-11ea-9e76-40dcb63f5982.png">

**Variant** Simplified account step (passwordless)
<img width="1024" alt="screen-shot-2020-06-02-at-17 06 59" src="https://user-images.githubusercontent.com/2749938/84029573-49b75c80-a99b-11ea-88a6-816a7fd4e70d.png">


#### Testing instructions
ℹ️ AB test is set to 50/50 chances and only for US. 

1. Go to /start
2. Select the 'variantPasswordless' AB test variant and make sure newSiteGutenbergOnboarding is on 'control' (the latter takes precedence):
![Screenshot on 2020-06-15 at 17-01-49](https://user-images.githubusercontent.com/2749938/84667768-73d4c580-af2b-11ea-95ae-13f0aafd8b7d.png)
or 
```
localStorage.setItem( 'ABTests', '{"newSiteGutenbergOnboarding_20200612":"control","passwordlessAfterPlans_20200608":"variantPasswordless"}' );
```
3. This should redirect to the Domains page `/start/onboarding-plans-passwordless/domains`
4. Go through Domains and Plans, and select a paid plan.
5. On the passwordless signup form, in order to get redirected to the checkout:
- don't use an a8c email - this will force you to activate the account and log in manually.
- make sure 3rd party cookie blocking is not one - this affects non-production environment (calypso not on wordpress.com) and will also involve manual login.
6. You should land on checkout page.