### PR TITLE
P2: Show loading indicator when generating invite links

### DIFF
--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -9,6 +9,7 @@ import debugModule from 'debug';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { localize } from 'i18n-calypso';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -100,6 +101,7 @@ class InvitePeople extends React.Component {
 			success: [],
 			activeInviteLink: false,
 			showCopyConfirmation: false,
+			isGeneratingInviteLinks: false,
 		};
 	};
 
@@ -453,6 +455,9 @@ class InvitePeople extends React.Component {
 	};
 
 	generateInviteLinks = () => {
+		this.setState( {
+			isGeneratingInviteLinks: true,
+		} );
 		return this.props.generateInviteLinks( this.props.siteId );
 	};
 
@@ -582,8 +587,12 @@ class InvitePeople extends React.Component {
 
 	renderInviteLinkGenerateButton = () => {
 		const { translate } = this.props;
+		const classNames = classnames( 'invite-people__link-generate', {
+			'is-busy': this.state.isGeneratingInviteLinks,
+		} );
+
 		return (
-			<Button onClick={ this.generateInviteLinks } className="invite-people__link-generate">
+			<Button onClick={ this.generateInviteLinks } className={ classNames }>
 				{ translate( 'Generate new link' ) }
 			</Button>
 		);

--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -606,7 +606,7 @@ class InvitePeople extends React.Component {
 		const inviteLinkForm = (
 			<Card className="invite-people__link">
 				<EmailVerificationGate>
-					<div class="invite-people__link-instructions">
+					<div className="invite-people__link-instructions">
 						{ translate(
 							'Use this link to onboard your team members without having to invite them one by one. '
 						) }

--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -9,7 +9,6 @@ import debugModule from 'debug';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { localize } from 'i18n-calypso';
-import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -587,12 +586,13 @@ class InvitePeople extends React.Component {
 
 	renderInviteLinkGenerateButton = () => {
 		const { translate } = this.props;
-		const classNames = classnames( 'invite-people__link-generate', {
-			'is-busy': this.state.isGeneratingInviteLinks,
-		} );
 
 		return (
-			<Button onClick={ this.generateInviteLinks } className={ classNames }>
+			<Button
+				onClick={ this.generateInviteLinks }
+				className="invite-people__link-generate"
+				busy={ this.state.isGeneratingInviteLinks }
+			>
 				{ translate( 'Generate new link' ) }
 			</Button>
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* For the Invite Links feature on P2 sites: show a loading indicator (by using `is-busy` button class) when user is generating invite links.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to http://calypso.localhost:3000/people/new/< YOUR-P2-TEST-SITE > or **People > Invite**
* Click **Generate new link** and verify that the button has a "busy" animation, as the page waits to refresh

