### PR TITLE
composite-checkout: Clarify label for full credit payment method

### DIFF
--- a/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
@@ -148,8 +148,9 @@ export function WordPressCreditsLabel( { credits } ) {
 	return (
 		<React.Fragment>
 			<div>
-				{ translate( 'WordPress.com Credits: %(amount)s', {
+				{ translate( 'WordPress.com Credits: %(amount)s available', {
 					args: { amount: credits.amount.displayValue },
+					comment: "The total value of credits on the user's account",
 				} ) }
 			</div>
 			<WordPressLogo />


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change the label on the full credits payment method from "WordPress.com Credits: X" to "WordPress.com Credits: X available", to help clarify what that number means.

At the moment it's easy to misunderstand the full credits payment method as changing the product price or using all credits on the account.

#### Testing instructions

Enter checkout with enough credits to cover the purchase (to trigger the full credits payment method) and inspect the label:

![Screen Shot 2020-06-08 at 8 36 24 AM](https://user-images.githubusercontent.com/9310939/84036868-70f23780-a963-11ea-9a3c-83082138014d.png)

