### PR TITLE
composite-checkout: Add key prop to ListItemMeta inside GSuiteUsersList

### DIFF
--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
@@ -392,7 +392,7 @@ function GSuiteUsersList( { users, gsuiteDiscountCallout } ) {
 		<>
 			{ users.map( ( user, index ) => {
 				return (
-					<LineItemMeta singleLine={ true }>
+					<LineItemMeta singleLine={ true } key={ user.email }>
 						<div key={ user.email }>{ user.email }</div>
 						{ index === 0 && gsuiteDiscountCallout }
 					</LineItemMeta>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Somehow I missed the warnings about this missing `key` prop when I refactored this component in #42908

#### Testing instructions

* Enter checkout with a gsuite product; verify that no warnings are shown in the console.
