### PR TITLE
Don't instantiate user at module level

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/setup/store-location.js
+++ b/client/extensions/woocommerce/app/dashboard/setup/store-location.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
@@ -34,10 +33,8 @@ import { doInitialSetup } from 'woocommerce/state/sites/settings/actions';
 import QueryContactDetailsCache from 'components/data/query-contact-details-cache';
 import QueryLocations from 'woocommerce/components/query-locations';
 import QuerySettingsGeneral from 'woocommerce/components/query-settings-general';
-import userFactory from 'lib/user';
+import user from 'lib/user';
 import VerifyEmailDialog from 'components/email-verification/email-verification-dialog';
-
-const user = userFactory();
 
 class StoreLocationSetupView extends Component {
 	constructor( props ) {
@@ -275,9 +272,9 @@ class StoreLocationSetupView extends Component {
 	closeVerifyEmailDialog = () => {
 		this.setState( { showEmailVerificationDialog: false } );
 		// Re-fetch the user to see if they actually took care of things
-		user.fetch();
+		user().fetch();
 		this.setState( { isFetchingUser: true } );
-		user.once( 'change', () => this.setState( { isFetchingUser: false } ) );
+		user().once( 'change', () => this.setState( { isFetchingUser: false } ) );
 	};
 
 	render = () => {

--- a/client/lib/abtest/index.js
+++ b/client/lib/abtest/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import debugFactory from 'debug';
-import { every, get, includes, isArray, keys, reduce, some } from 'lodash';
+import { every, includes, isArray, keys, reduce, some } from 'lodash';
 import store from 'store';
 import { getLocaleSlug } from 'i18n-calypso';
 
@@ -11,13 +11,12 @@ import { getLocaleSlug } from 'i18n-calypso';
  */
 import activeTests from 'lib/abtest/active-tests';
 import { recordTracksEvent } from 'lib/analytics/tracks';
-import userFactory from 'lib/user';
+import user from 'lib/user';
 import wpcom from 'lib/wp';
 import { ABTEST_LOCALSTORAGE_KEY } from 'lib/abtest/utility';
 import { getLanguageSlugs } from 'lib/i18n-utils/utils';
 
 const debug = debugFactory( 'calypso:abtests' );
-const user = userFactory();
 
 function ABTest( name, geoLocation ) {
 	if ( ! ( this instanceof ABTest ) ) {
@@ -64,7 +63,7 @@ export const saveABTestVariation = ( name, variation ) =>
 
 export const getAllTests = () => keys( activeTests ).map( ABTest );
 
-const isUserSignedIn = () => user && user.get() !== false;
+const isUserSignedIn = () => user().get() !== false;
 
 const parseDateStamp = ( datestamp ) => {
 	const format = 'YYYYMMDD';
@@ -209,7 +208,7 @@ export const isUsingGivenLocales = ( localeTargets, experimentId = null ) => {
 		client.languages && client.languages.length ? client.languages[ 0 ] : 'en';
 	const localeFromSession = getLocaleSlug() || 'en';
 	const localeMatcher = new RegExp( '^(' + localeTargets.join( '|' ) + ')', 'i' );
-	const userLocale = user.get().localeSlug || 'en';
+	const userLocale = user().get().localeSlug || 'en';
 
 	if ( isUserSignedIn() && ! userLocale.match( localeMatcher ) ) {
 		debug( '%s: User has a %s locale', experimentId, userLocale );
@@ -300,7 +299,7 @@ ABTest.prototype.hasBeenInPreviousSeriesTest = function () {
 };
 
 ABTest.prototype.hasRegisteredBeforeTestBegan = function () {
-	return user && user.get() && new Date( user.get().date ) < new Date( this.startDate );
+	return user().get() && new Date( user().get().date ) < new Date( this.startDate );
 };
 
 ABTest.prototype.getSavedVariation = function () {
@@ -311,7 +310,7 @@ ABTest.prototype.assignVariation = function () {
 	let variationName, randomAllocationAmount;
 	let sum = 0;
 
-	const userId = get( user, 'data.ID' );
+	const userId = user().data?.ID;
 	const allocationsTotal = reduce(
 		this.variationDetails,
 		( allocations, allocation ) => {
@@ -321,7 +320,7 @@ ABTest.prototype.assignVariation = function () {
 	);
 
 	if ( this.assignmentMethod === 'userId' && ! isNaN( +userId ) ) {
-		randomAllocationAmount = Number( user.data.ID ) % allocationsTotal;
+		randomAllocationAmount = Number( userId ) % allocationsTotal;
 	} else {
 		randomAllocationAmount = Math.random() * allocationsTotal;
 	}

--- a/client/lib/abtest/index.js
+++ b/client/lib/abtest/index.js
@@ -63,7 +63,7 @@ export const saveABTestVariation = ( name, variation ) =>
 
 export const getAllTests = () => keys( activeTests ).map( ABTest );
 
-const isUserSignedIn = () => user().get() !== false;
+const isUserSignedIn = () => user() && user().get() !== false;
 
 const parseDateStamp = ( datestamp ) => {
 	const format = 'YYYYMMDD';
@@ -299,7 +299,7 @@ ABTest.prototype.hasBeenInPreviousSeriesTest = function () {
 };
 
 ABTest.prototype.hasRegisteredBeforeTestBegan = function () {
-	return user().get() && new Date( user().get().date ) < new Date( this.startDate );
+	return user() && user().get() && new Date( user().get().date ) < new Date( this.startDate );
 };
 
 ABTest.prototype.getSavedVariation = function () {
@@ -310,7 +310,7 @@ ABTest.prototype.assignVariation = function () {
 	let variationName, randomAllocationAmount;
 	let sum = 0;
 
-	const userId = user().data?.ID;
+	const userId = user()?.data?.ID;
 	const allocationsTotal = reduce(
 		this.variationDetails,
 		( allocations, allocation ) => {

--- a/client/lib/abtest/index.js
+++ b/client/lib/abtest/index.js
@@ -310,7 +310,7 @@ ABTest.prototype.assignVariation = function () {
 	let variationName, randomAllocationAmount;
 	let sum = 0;
 
-	const userId = user()?.data?.ID;
+	const userId = user()?.get()?.ID;
 	const allocationsTotal = reduce(
 		this.variationDetails,
 		( allocations, allocation ) => {

--- a/client/lib/desktop/index.js
+++ b/client/lib/desktop/index.js
@@ -3,14 +3,11 @@
  */
 import debugFactory from 'debug';
 
-const debug = debugFactory( 'calypso:desktop' );
-
 /**
  * Internal dependencies
  */
 import { newPost } from 'lib/paths';
-import userFactory from 'lib/user';
-const user = userFactory();
+import user from 'lib/user';
 import { ipcRenderer as ipc } from 'electron'; // eslint-disable-line import/no-extraneous-dependencies
 import * as oAuthToken from 'lib/oauth-token';
 import userUtilities from 'lib/user/utils';
@@ -32,6 +29,7 @@ import { requestSite } from 'state/sites/actions';
 /**
  * Module variables
  */
+const debug = debugFactory( 'calypso:desktop' );
 
 const Desktop = {
 	/**
@@ -104,14 +102,14 @@ const Desktop = {
 	sendUserLoginStatus: function () {
 		let status = true;
 
-		if ( user.data === false || user.data instanceof Array ) {
+		if ( user().data === false || user().data instanceof Array ) {
 			status = false;
 		}
 
 		debug( 'Sending logged-in = ' + status );
 
 		ipc.send( 'user-login-status', status );
-		ipc.send( 'user-auth', user, oAuthToken.getToken() );
+		ipc.send( 'user-auth', user(), oAuthToken.getToken() );
 	},
 
 	onToggleNotifications: function () {

--- a/client/lib/desktop/index.js
+++ b/client/lib/desktop/index.js
@@ -102,7 +102,7 @@ const Desktop = {
 	sendUserLoginStatus: function () {
 		let status = true;
 
-		if ( user().data === false || user().data instanceof Array ) {
+		if ( user().get() === false ) {
 			status = false;
 		}
 

--- a/client/lib/signup/step-actions/fetch-sites-and-user.js
+++ b/client/lib/signup/step-actions/fetch-sites-and-user.js
@@ -6,7 +6,7 @@ import debugFactory from 'debug';
 /**
  * Internal dependencies
  */
-import userFactory from 'lib/user';
+import user from 'lib/user';
 
 // State actions and selectors
 import getSiteId from 'state/selectors/get-site-id';
@@ -16,7 +16,6 @@ import { promisify } from 'utils';
 /**
  * Constants
  */
-const user = userFactory();
 const debug = debugFactory( 'calypso:signup:step-actions:fetch-sites-and-user' );
 
 function fetchSitesUntilSiteAppears( siteSlug, reduxStore, callback ) {
@@ -38,8 +37,8 @@ export function fetchSitesAndUser( siteSlug, onComplete, reduxStore ) {
 	Promise.all( [
 		promisify( fetchSitesUntilSiteAppears )( siteSlug, reduxStore ),
 		new Promise( ( resolve ) => {
-			user.once( 'change', resolve );
-			user.fetch();
+			user().once( 'change', resolve );
+			user().fetch();
 		} ),
 	] ).then( onComplete );
 }

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -24,9 +24,7 @@ import { parse as parseURL } from 'url';
 // Libraries
 import wpcom from 'lib/wp';
 import guessTimezone from 'lib/i18n-utils/guess-timezone';
-
-/* eslint-enable no-restricted-imports */
-import userFactory from 'lib/user';
+import user from 'lib/user';
 import { getSavedVariations } from 'lib/abtest';
 import { recordTracksEvent } from 'lib/analytics/tracks';
 import { recordRegistration } from 'lib/analytics/signup';
@@ -67,7 +65,6 @@ import { fetchSitesAndUser } from 'lib/signup/step-actions/fetch-sites-and-user'
 /**
  * Constants
  */
-const user = userFactory();
 const debug = debugFactory( 'calypso:signup:step-actions' );
 
 export function createSiteOrDomain( callback, dependencies, data, reduxStore ) {
@@ -205,7 +202,7 @@ export function createSiteWithCart( callback, dependencies, stepData, reduxStore
 
 	if ( shouldSkipDomainStep || shouldHideFreePlan || shouldHideDomainStep ) {
 		newSiteParams.blog_name =
-			get( user.get(), 'username' ) ||
+			get( user().get(), 'username' ) ||
 			get( signupDependencies, 'username' ) ||
 			siteTitle ||
 			siteType ||
@@ -332,15 +329,15 @@ function processItemCart(
 		}
 	};
 
-	if ( ! user.get() && isFreeThemePreselected ) {
+	if ( ! user().get() && isFreeThemePreselected ) {
 		setThemeOnSite( addToCartAndProceed, { siteSlug, themeSlugWithRepo } );
-	} else if ( user.get() && isFreeThemePreselected ) {
+	} else if ( user().get() && isFreeThemePreselected ) {
 		fetchSitesAndUser(
 			siteSlug,
 			setThemeOnSite.bind( null, addToCartAndProceed, { siteSlug, themeSlugWithRepo } ),
 			reduxStore
 		);
-	} else if ( user.get() ) {
+	} else if ( user().get() ) {
 		fetchSitesAndUser( siteSlug, addToCartAndProceed, reduxStore );
 	} else {
 		addToCartAndProceed();
@@ -534,7 +531,7 @@ export function createSite( callback, dependencies, stepData, reduxStore ) {
 			providedDependencies = { siteSlug };
 		}
 
-		if ( user.get() && isEmpty( errors ) ) {
+		if ( user().get() && isEmpty( errors ) ) {
 			fetchSitesAndUser( siteSlug, () => callback( undefined, providedDependencies ), reduxStore );
 		} else {
 			callback( isEmpty( errors ) ? undefined : [ errors ], providedDependencies );
@@ -571,7 +568,7 @@ export function createWpForTeamsSite( callback, dependencies, stepData, reduxSto
 			providedDependencies = { siteSlug };
 		}
 
-		if ( user.get() && isEmpty( errors ) ) {
+		if ( user().get() && isEmpty( errors ) ) {
 			fetchSitesAndUser( siteSlug, () => callback( undefined, providedDependencies ), reduxStore );
 		} else {
 			callback( isEmpty( errors ) ? undefined : [ errors ], providedDependencies );

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -202,7 +202,7 @@ export function createSiteWithCart( callback, dependencies, stepData, reduxStore
 
 	if ( shouldSkipDomainStep || shouldHideFreePlan || shouldHideDomainStep ) {
 		newSiteParams.blog_name =
-			get( user().get(), 'username' ) ||
+			user().get()?.username ||
 			get( signupDependencies, 'username' ) ||
 			siteTitle ||
 			siteType ||

--- a/client/lib/translator-jumpstart/index.js
+++ b/client/lib/translator-jumpstart/index.js
@@ -187,7 +187,7 @@ const communityTranslatorJumpstart = {
 			languageJson[ '' ][ 'Plural-Forms' ] ||
 			languageJson[ '' ][ 'plural-forms' ] ||
 			translationDataFromPage.pluralForms;
-		translationDataFromPage.currentUserId = user().data.ID;
+		translationDataFromPage.currentUserId = user().get().ID;
 
 		const currentLocale = find( languages, ( lang ) => lang.langSlug === localeCode );
 		if ( currentLocale ) {
@@ -322,7 +322,7 @@ export function trackTranslatorStatus( isTranslatorEnabled ) {
 
 	if ( changed && _isTranslatorEnabled !== undefined ) {
 		debug( tracksEvent );
-		recordTracksEvent( tracksEvent, { locale: user().data.localeSlug } );
+		recordTracksEvent( tracksEvent, { locale: user().get().localeSlug } );
 	}
 
 	_isTranslatorEnabled = newSetting;

--- a/client/lib/translator-jumpstart/index.js
+++ b/client/lib/translator-jumpstart/index.js
@@ -12,14 +12,13 @@ import { find, isUndefined } from 'lodash';
  */
 import { languages } from 'languages';
 import { loadjQueryDependentScriptDesktopWrapper } from 'lib/load-jquery-dependent-script-desktop-wrapper';
-import User from 'lib/user';
+import user from 'lib/user';
 import { recordTracksEvent } from 'lib/analytics/tracks';
 import { canBeTranslated } from 'lib/i18n-utils';
 
 const debug = debugModule( 'calypso:community-translator' );
 
-const user = new User(),
-	communityTranslatorBaseUrl = 'https://widgets.wp.com/community-translator/',
+const communityTranslatorBaseUrl = 'https://widgets.wp.com/community-translator/',
 	communityTranslatorVersion = '1.160729',
 	// lookup for the translation set slug on GP
 	translateSetSlugs = {
@@ -54,7 +53,7 @@ let injectUrl,
  */
 const communityTranslatorJumpstart = {
 	isEnabled() {
-		const currentUser = user.get();
+		const currentUser = user().get();
 
 		// disable for locales
 		if (
@@ -188,7 +187,7 @@ const communityTranslatorJumpstart = {
 			languageJson[ '' ][ 'Plural-Forms' ] ||
 			languageJson[ '' ][ 'plural-forms' ] ||
 			translationDataFromPage.pluralForms;
-		translationDataFromPage.currentUserId = user.data.ID;
+		translationDataFromPage.currentUserId = user().data.ID;
 
 		const currentLocale = find( languages, ( lang ) => lang.langSlug === localeCode );
 		if ( currentLocale ) {
@@ -323,7 +322,7 @@ export function trackTranslatorStatus( isTranslatorEnabled ) {
 
 	if ( changed && _isTranslatorEnabled !== undefined ) {
 		debug( tracksEvent );
-		recordTracksEvent( tracksEvent, { locale: user.data.localeSlug } );
+		recordTracksEvent( tracksEvent, { locale: user().data.localeSlug } );
 	}
 
 	_isTranslatorEnabled = newSetting;

--- a/client/lib/user-settings/index.js
+++ b/client/lib/user-settings/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import { assign, isEmpty, keys, merge, has, get, set, unset } from 'lodash';
 import debugFactory from 'debug';
 const debug = debugFactory( 'calypso:user:settings' );
@@ -11,8 +10,7 @@ import { decodeEntities } from 'lib/formatting';
  * Internal dependencies
  */
 import emitterClass from 'lib/mixins/emitter';
-import userFactory from 'lib/user';
-const user = userFactory();
+import user from 'lib/user';
 import userUtils from 'lib/user/utils';
 import wp from 'lib/wp';
 
@@ -178,7 +176,7 @@ UserSettings.prototype.saveSettings = function ( callback, settingsOverride ) {
 					this.emit( 'change' );
 
 					// Refetch the user data after saving user settings
-					user.fetch();
+					user().fetch();
 				}
 
 				// Let the form know whether the save was successful or not

--- a/client/lib/user/README.md
+++ b/client/lib/user/README.md
@@ -5,8 +5,11 @@ This component is a wrapper module for interacting with the wpcom.js `/me` endpo
 
 ## User
 ```es6
-import userFactory from 'lib/user';
-const user = userFactory();
+import user from 'lib/user';
+
+function clearUser() {
+  user().clear();
+}
 ```
 
 ### `User#get()`
@@ -30,6 +33,6 @@ import user from 'lib/user/utilities';
 This is a small module that logs a user out by clearing user stored data by calling `User#clear()` and redirects user to WordPress.com to be logged out.
 
 ### `UserUtilities#getLogoutUrl()`
-Returns a localized logout URL based on the current user's language. 
+Returns a localized logout URL based on the current user's language.
 
 For example, an English speaking user be redirected to `wordpress.com` after being logged, but a Spanish speaking user will be redirected to `es.wordpress.com`.;

--- a/client/lib/username/index.js
+++ b/client/lib/username/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import i18n from 'i18n-calypso';
 
 /**
@@ -9,8 +8,7 @@ import i18n from 'i18n-calypso';
  */
 import Emitter from 'lib/mixins/emitter';
 import wpcom from 'lib/wp';
-import userFactory from 'lib/user';
-const user = userFactory();
+import user from 'lib/user';
 
 /**
  * Initialize Username with defaults
@@ -27,7 +25,7 @@ function Username() {
 Emitter( Username.prototype );
 
 Username.prototype.validate = function ( username ) {
-	if ( username !== user.get().username ) {
+	if ( username !== user().get().username ) {
 		if ( username.length < 4 ) {
 			this.validation = {
 				error: 'invalid_input',
@@ -80,7 +78,7 @@ Username.prototype.change = function ( username, action, callback ) {
 					this.validation = error;
 					this.emit( 'change' );
 				} else {
-					user.fetch();
+					user().fetch();
 				}
 
 				if ( callback ) {

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -47,12 +47,17 @@ import { successNotice, errorNotice } from 'state/notices/actions';
 import { getLanguage, isLocaleVariant, canBeTranslated } from 'lib/i18n-utils';
 import isRequestingMissingSites from 'state/selectors/is-requesting-missing-sites';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
-import user from 'lib/user';
 import { canDisplayCommunityTranslator } from 'components/community-translator/utils';
 import { ENABLE_TRANSLATOR_KEY } from 'lib/i18n-utils/constants';
 import AccountSettingsCloseLink from './close-link';
 import { requestGeoLocation } from 'state/data-getters';
 import { withLocalizedMoment } from 'components/localized-moment';
+import {
+	getCurrentUserDate,
+	getCurrentUserDisplayName,
+	getCurrentUserName,
+	getCurrentUserVisibleSiteCount,
+} from 'state/current-user/selectors';
 
 /**
  * Style dependencies
@@ -397,8 +402,8 @@ const Account = createReactClass( {
 	},
 
 	renderJoinDate() {
-		const { translate, moment } = this.props;
-		const dateMoment = moment( user().get().date );
+		const { currentUserDate, translate, moment } = this.props;
+		const dateMoment = moment( currentUserDate );
 
 		return (
 			<span>
@@ -487,9 +492,9 @@ const Account = createReactClass( {
 	},
 
 	renderPrimarySite() {
-		const { requestingMissingSites, translate } = this.props;
+		const { requestingMissingSites, translate, visibleSiteCount } = this.props;
 
-		if ( ! user().get().visible_site_count ) {
+		if ( ! visibleSiteCount ) {
 			return (
 				<Button
 					href={ config( 'signup_url' ) }
@@ -670,7 +675,7 @@ const Account = createReactClass( {
 	 * These form fields are displayed when a username change is in progress.
 	 */
 	renderUsernameFields() {
-		const { translate, username } = this.props;
+		const { currentUserDisplayName, currentUserName, translate, username } = this.props;
 
 		const isSaveButtonDisabled =
 			this.getUserSetting( 'user_login' ) !== this.state.userLoginConfirm ||
@@ -709,7 +714,7 @@ const Account = createReactClass( {
 							'You will not be able to change your username back.',
 						{
 							args: {
-								username: user().get().username,
+								username: currentUserName,
 							},
 							components: {
 								strong: <strong />,
@@ -724,7 +729,7 @@ const Account = createReactClass( {
 							'you can do so under {{myProfileLink}}My Profile{{/myProfileLink}}.',
 						{
 							args: {
-								displayName: user().get().display_name,
+								displayName: currentUserDisplayName,
 							},
 							components: {
 								myProfileLink: (
@@ -834,6 +839,10 @@ export default compose(
 		( state ) => ( {
 			requestingMissingSites: isRequestingMissingSites( state ),
 			countryCode: requestGeoLocation().data,
+			currentUserDate: getCurrentUserDate( state ),
+			currentUserDisplayName: getCurrentUserDisplayName( state ),
+			currentUserName: getCurrentUserName( state ),
+			visibleSiteCount: getCurrentUserVisibleSiteCount( state ),
 		} ),
 		{ bumpStat, errorNotice, recordGoogleEvent, recordTracksEvent, successNotice }
 	),

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -47,7 +47,7 @@ import { successNotice, errorNotice } from 'state/notices/actions';
 import { getLanguage, isLocaleVariant, canBeTranslated } from 'lib/i18n-utils';
 import isRequestingMissingSites from 'state/selectors/is-requesting-missing-sites';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
-import _user from 'lib/user';
+import user from 'lib/user';
 import { canDisplayCommunityTranslator } from 'components/community-translator/utils';
 import { ENABLE_TRANSLATOR_KEY } from 'lib/i18n-utils/constants';
 import AccountSettingsCloseLink from './close-link';
@@ -59,7 +59,6 @@ import { withLocalizedMoment } from 'components/localized-moment';
  */
 import './style.scss';
 
-const user = _user();
 const colorSchemeKey = 'calypso_preferences.colorScheme';
 
 /**
@@ -399,7 +398,7 @@ const Account = createReactClass( {
 
 	renderJoinDate() {
 		const { translate, moment } = this.props;
-		const dateMoment = moment( user.get().date );
+		const dateMoment = moment( user().get().date );
 
 		return (
 			<span>
@@ -490,7 +489,7 @@ const Account = createReactClass( {
 	renderPrimarySite() {
 		const { requestingMissingSites, translate } = this.props;
 
-		if ( ! user.get().visible_site_count ) {
+		if ( ! user().get().visible_site_count ) {
 			return (
 				<Button
 					href={ config( 'signup_url' ) }
@@ -710,7 +709,7 @@ const Account = createReactClass( {
 							'You will not be able to change your username back.',
 						{
 							args: {
-								username: user.get().username,
+								username: user().get().username,
 							},
 							components: {
 								strong: <strong />,
@@ -725,7 +724,7 @@ const Account = createReactClass( {
 							'you can do so under {{myProfileLink}}My Profile{{/myProfileLink}}.',
 						{
 							args: {
-								displayName: user.get().display_name,
+								displayName: user().get().display_name,
 							},
 							components: {
 								myProfileLink: (

--- a/client/me/form-base/index.js
+++ b/client/me/form-base/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import debugFactory from 'debug';
 
 const debug = debugFactory( 'calypso:me:form-base' );
@@ -10,9 +9,7 @@ const debug = debugFactory( 'calypso:me:form-base' );
  * Internal dependencies
  */
 import notices from 'notices';
-import userFactory from 'lib/user';
-
-const user = userFactory();
+import user from 'lib/user';
 
 export default {
 	componentDidMount: function () {
@@ -91,11 +88,13 @@ export default {
 					this.props.markSaved && this.props.markSaved();
 
 					if ( this.state && this.state.redirect ) {
-						user.clear().then( () => {
-							// Sometimes changes in settings require a url refresh to update the UI.
-							// For example when the user changes the language.
-							window.location = this.state.redirect + '?updated=success';
-						} );
+						user()
+							.clear()
+							.then( () => {
+								// Sometimes changes in settings require a url refresh to update the UI.
+								// For example when the user changes the language.
+								window.location = this.state.redirect + '?updated=success';
+							} );
 						return;
 					}
 					// if we set submittingForm too soon the UI updates before the response is handled

--- a/client/me/help/help-unverified-warning/index.jsx
+++ b/client/me/help/help-unverified-warning/index.jsx
@@ -1,10 +1,9 @@
 /**
  * External dependencies
  */
-
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
-import userFactory from 'lib/user';
+import user from 'lib/user';
 
 /**
  * Internal dependencies
@@ -17,8 +16,6 @@ import notices from 'notices';
  * Style dependencies
  */
 import './style.scss';
-
-const user = userFactory();
 
 const RESEND_IDLE = 0,
 	RESEND_IN_PROGRESS = 1,
@@ -60,7 +57,7 @@ class HelpUnverifiedWarning extends Component {
 				resendState: RESEND_IN_PROGRESS,
 			} );
 
-			user
+			user()
 				.sendVerificationEmail()
 				.then( () => {
 					const nextResendState = RESEND_SUCCESS;

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -20,16 +20,16 @@ import PurchasesList from './purchases-list';
 import { concatTitle } from 'lib/react-helpers';
 import { setDocumentHeadTitle } from 'state/document-head/actions';
 import titles from './titles';
-import user from 'lib/user';
 import { makeLayout, render as clientRender } from 'controller';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
+import { getCurrentUserSiteCount } from 'state/current-user/selectors';
 
 // FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 function setTitle( context, ...title ) {
 	context.store.dispatch( setDocumentHeadTitle( concatTitle( titles.purchases, ...title ) ) );
 }
 
-const userHasNoSites = () => user().get().site_count <= 0;
+const userHasNoSites = ( state ) => getCurrentUserSiteCount( state ) <= 0;
 
 function noSites( context, analyticsPath ) {
 	setTitle( context );
@@ -45,7 +45,9 @@ function noSites( context, analyticsPath ) {
 }
 
 export function addCardDetails( context, next ) {
-	if ( userHasNoSites() ) {
+	const state = context.store.getState();
+
+	if ( userHasNoSites( state ) ) {
 		return noSites( context, '/me/purchases/:site/:purchaseId/payment/add' );
 	}
 

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import { noop } from 'lodash';
 import React from 'react';
 
@@ -21,18 +20,16 @@ import PurchasesList from './purchases-list';
 import { concatTitle } from 'lib/react-helpers';
 import { setDocumentHeadTitle } from 'state/document-head/actions';
 import titles from './titles';
-import userFactory from 'lib/user';
+import user from 'lib/user';
 import { makeLayout, render as clientRender } from 'controller';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
-
-const user = userFactory();
 
 // FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 function setTitle( context, ...title ) {
 	context.store.dispatch( setDocumentHeadTitle( concatTitle( titles.purchases, ...title ) ) );
 }
 
-const userHasNoSites = () => user.get().site_count <= 0;
+const userHasNoSites = () => user().get().site_count <= 0;
 
 function noSites( context, analyticsPath ) {
 	setTitle( context );

--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -26,7 +26,7 @@ import SidebarHeading from 'layout/sidebar/heading';
 import SidebarItem from 'layout/sidebar/item';
 import SidebarMenu from 'layout/sidebar/menu';
 import SidebarRegion from 'layout/sidebar/region';
-import userFactory from 'lib/user';
+import user from 'lib/user';
 import userUtilities from 'lib/user/utils';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { logoutUser } from 'state/logout/actions';
@@ -37,11 +37,6 @@ import { setNextLayoutFocus } from 'state/ui/layout-focus/actions';
  * Style dependencies
  */
 import './style.scss';
-
-/**
- * Module variables
- */
-const user = userFactory();
 
 class MeSidebar extends React.Component {
 	onNavigate = () => {
@@ -64,7 +59,7 @@ class MeSidebar extends React.Component {
 		if ( config.isEnabled( 'login/wp-login' ) ) {
 			try {
 				const { redirect_to } = await this.props.logoutUser( redirectTo );
-				await user.clear();
+				await user().clear();
 				window.location.href = redirect_to || '/';
 			} catch {
 				// The logout endpoint might fail if the nonce has expired.

--- a/client/me/social-login/action-button.jsx
+++ b/client/me/social-login/action-button.jsx
@@ -15,9 +15,7 @@ import { connectSocialUser, disconnectSocialUser } from 'state/login/actions';
 import FormButton from 'components/forms/form-button';
 import GoogleLoginButton from 'components/social-buttons/google';
 import AppleLoginButton from 'components/social-buttons/apple';
-import userFactory from 'lib/user';
-
-const user = userFactory();
+import user from 'lib/user';
 
 class SocialLoginActionButton extends Component {
 	static propTypes = {
@@ -36,11 +34,11 @@ class SocialLoginActionButton extends Component {
 	};
 
 	refreshUser = () => {
-		user.fetch();
+		user().fetch();
 
 		this.setState( { fetchingUser: true } );
 
-		user.once( 'change', () => this.setState( { fetchingUser: false } ) );
+		user().once( 'change', () => this.setState( { fetchingUser: false } ) );
 	};
 
 	handleSocialServiceResponse = ( response ) => {

--- a/client/my-sites/checkout/checkout-thank-you/atomic-store-thank-you-card.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/atomic-store-thank-you-card.jsx
@@ -17,15 +17,13 @@ import { getCurrentPlan } from 'state/sites/plans/selectors';
 import { getPlanClass } from 'lib/plans';
 import { getCurrentUserEmail, isCurrentUserEmailVerified } from 'state/current-user/selectors';
 import { errorNotice, removeNotice } from 'state/notices/actions';
-import userFactory from 'lib/user';
+import user from 'lib/user';
 
 const VERIFY_EMAIL_ERROR_NOTICE = 'ecommerce-verify-email-error';
 const RESEND_ERROR = 'RESEND_ERROR';
 const RESEND_NOT_SENT = 'RESEND_NOT_SENT';
 const RESEND_PENDING = 'RESEND_PENDING';
 const RESEND_SUCCESS = 'RESEND_SUCCESS';
-
-const user = userFactory();
 
 class AtomicStoreThankYouCard extends Component {
 	state = { resendStatus: RESEND_NOT_SENT };
@@ -40,7 +38,7 @@ class AtomicStoreThankYouCard extends Component {
 		}
 	}
 
-	checkVerification = () => user.fetch();
+	checkVerification = () => user().fetch();
 
 	resendEmail = () => {
 		const { translate } = this.props;
@@ -54,7 +52,7 @@ class AtomicStoreThankYouCard extends Component {
 
 		this.setState( { resendStatus: RESEND_PENDING } );
 
-		user.sendVerificationEmail( ( error ) => {
+		user().sendVerificationEmail( ( error ) => {
 			if ( error ) {
 				this.props.errorNotice(
 					translate( "Couldn't resend verification email. Please try again." ),

--- a/client/my-sites/checkout/checkout-thank-you/google-apps-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/google-apps-details.jsx
@@ -9,9 +9,12 @@ import i18n from 'i18n-calypso';
  */
 import { GOOGLE_APPS_LEARNING_CENTER } from 'lib/url/support';
 import PurchaseDetail from 'components/purchase-detail';
-import user from 'lib/user';
+import { useSelector } from 'react-redux';
+import { getCurrentUserEmail } from 'state/current-user/selectors';
 
 const GoogleAppsDetails = () => {
+	const email = useSelector( getCurrentUserEmail );
+
 	return (
 		<PurchaseDetail
 			icon="mail"
@@ -33,7 +36,7 @@ const GoogleAppsDetails = () => {
 						),
 					},
 					args: {
-						email: user().get().email,
+						email,
 					},
 				}
 			) }

--- a/client/my-sites/checkout/checkout-thank-you/google-apps-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/google-apps-details.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
 import i18n from 'i18n-calypso';
 
@@ -10,9 +9,7 @@ import i18n from 'i18n-calypso';
  */
 import { GOOGLE_APPS_LEARNING_CENTER } from 'lib/url/support';
 import PurchaseDetail from 'components/purchase-detail';
-import userFactory from 'lib/user';
-
-const user = userFactory();
+import user from 'lib/user';
 
 const GoogleAppsDetails = () => {
 	return (
@@ -36,7 +33,7 @@ const GoogleAppsDetails = () => {
 						),
 					},
 					args: {
-						email: user.get().email,
+						email: user().get().email,
 					},
 				}
 			) }

--- a/client/my-sites/checkout/checkout-thank-you/jetpack-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-plan-details.jsx
@@ -9,11 +9,10 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import PurchaseDetail from 'components/purchase-detail';
-import userFactory from 'lib/user';
+import user from 'lib/user';
 import { getSiteFileModDisableReason } from 'lib/site/utils';
 import { recordTracksEvent } from 'state/analytics/actions';
 import config from 'config';
-const user = userFactory();
 import { localizeUrl } from 'lib/i18n-utils';
 
 const BasicDetails = ( { translate } ) => (
@@ -23,7 +22,7 @@ const BasicDetails = ( { translate } ) => (
 		description={ translate(
 			'We emailed you at %(email)s with information for setting up Akismet and VaultPress on your site. ' +
 				'Follow the instructions in the email to get started.',
-			{ args: { email: user.get().email } }
+			{ args: { email: user().get().email } }
 		) }
 	/>
 );

--- a/client/my-sites/checkout/checkout-thank-you/jetpack-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-plan-details.jsx
@@ -2,30 +2,33 @@
  * External dependencies
  */
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
+import { connect, useSelector } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import PurchaseDetail from 'components/purchase-detail';
-import user from 'lib/user';
 import { getSiteFileModDisableReason } from 'lib/site/utils';
 import { recordTracksEvent } from 'state/analytics/actions';
 import config from 'config';
 import { localizeUrl } from 'lib/i18n-utils';
+import { getCurrentUserEmail } from 'state/current-user/selectors';
 
-const BasicDetails = ( { translate } ) => (
-	<PurchaseDetail
-		icon="cog"
-		title={ translate( 'Set up your VaultPress and Akismet accounts' ) }
-		description={ translate(
-			'We emailed you at %(email)s with information for setting up Akismet and VaultPress on your site. ' +
-				'Follow the instructions in the email to get started.',
-			{ args: { email: user().get().email } }
-		) }
-	/>
-);
+const BasicDetails = ( { translate } ) => {
+	const email = useSelector( getCurrentUserEmail );
+	return (
+		<PurchaseDetail
+			icon="cog"
+			title={ translate( 'Set up your VaultPress and Akismet accounts' ) }
+			description={ translate(
+				'We emailed you at %(email)s with information for setting up Akismet and VaultPress on your site. ' +
+					'Follow the instructions in the email to get started.',
+				{ args: { email } }
+			) }
+		/>
+	);
+};
 
 class EnhancedDetails extends Component {
 	componentDidMount() {

--- a/client/my-sites/invites/controller.js
+++ b/client/my-sites/invites/controller.js
@@ -16,17 +16,16 @@ import InviteAccept from 'my-sites/invites/invite-accept';
 import { hideSidebar } from 'state/ui/actions';
 import { getRedirectAfterAccept } from 'my-sites/invites/utils';
 import { acceptInvite as acceptInviteAction } from 'lib/invites/actions';
-import _user from 'lib/user';
+import user from 'lib/user';
 import { getLocaleFromPath, removeLocaleFromPath } from 'lib/i18n-utils';
 
 /**
  * Module variables
  */
-const user = _user();
 const debug = debugModule( 'calypso:invite-accept:controller' );
 
 export function redirectWithoutLocaleifLoggedIn( context, next ) {
-	if ( user.get() && getLocaleFromPath( context.path ) ) {
+	if ( user().get() && getLocaleFromPath( context.path ) ) {
 		return page.redirect( removeLocaleFromPath( context.path ) );
 	}
 
@@ -42,9 +41,9 @@ export function acceptInvite( context, next ) {
 	const acceptedInvite = store.get( 'invite_accepted' );
 	if ( acceptedInvite ) {
 		debug( 'invite_accepted is set in localStorage' );
-		if ( user.get().email === acceptedInvite.sentTo ) {
+		if ( user().get().email === acceptedInvite.sentTo ) {
 			debug( 'Setting email_verified in user object' );
-			user.set( { email_verified: true } );
+			user().set( { email_verified: true } );
 		}
 		store.remove( 'invite_accepted' );
 		const acceptInviteCallback = ( error ) => {

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -143,7 +143,7 @@ const Flows = {
 			return flow;
 		}
 
-		if ( user().get() ) {
+		if ( user() && user().get() ) {
 			flow = removeUserStepFromFlow( flow );
 		}
 

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -9,12 +9,10 @@ import cookie from 'cookie';
  */
 import config from 'config';
 import stepConfig from './steps';
-import userFactory from 'lib/user';
+import user from 'lib/user';
 import { generateFlows } from 'signup/config/flows-pure';
 import { addQueryArgs } from 'lib/url';
 import { abtest } from 'lib/abtest';
-
-const user = userFactory();
 
 function getCheckoutUrl( dependencies ) {
 	return addQueryArgs(
@@ -145,7 +143,7 @@ const Flows = {
 			return flow;
 		}
 
-		if ( user && user.get() ) {
+		if ( user().get() ) {
 			flow = removeUserStepFromFlow( flow );
 		}
 

--- a/client/signup/utils.js
+++ b/client/signup/utils.js
@@ -20,7 +20,7 @@ function isEligibleForSwapStepsTest() {
 	const countryCodeFromCookie = cookies.country_code;
 	const isUserFromUS = 'US' === countryCodeFromCookie;
 
-	if ( user().get() && isUserFromUS && 'onboarding' === defaultFlowName ) {
+	if ( user() && user().get() && isUserFromUS && 'onboarding' === defaultFlowName ) {
 		return true;
 	}
 

--- a/client/signup/utils.js
+++ b/client/signup/utils.js
@@ -10,10 +10,8 @@ import { translate } from 'i18n-calypso';
  */
 import steps from 'signup/config/steps-pure';
 import flows from 'signup/config/flows';
-import userFactory from 'lib/user';
+import user from 'lib/user';
 import { abtest } from 'lib/abtest';
-
-const user = userFactory();
 
 const { defaultFlowName } = flows;
 
@@ -22,7 +20,7 @@ function isEligibleForSwapStepsTest() {
 	const countryCodeFromCookie = cookies.country_code;
 	const isUserFromUS = 'US' === countryCodeFromCookie;
 
-	if ( user && user.get() && isUserFromUS && 'onboarding' === defaultFlowName ) {
+	if ( user().get() && isUserFromUS && 'onboarding' === defaultFlowName ) {
 		return true;
 	}
 
@@ -73,7 +71,7 @@ export function getStepUrl( flowName, stepName, stepSectionName, localeSlug ) {
 		// when the user is logged in, the locale slug is meaningless in a
 		// signup URL, as the page will be translated in the language the user
 		// has in their settings.
-		locale = localeSlug && ! user.get() ? `/${ localeSlug }` : '';
+		locale = localeSlug && ! user().get() ? `/${ localeSlug }` : '';
 
 	if ( flowName === defaultFlowName ) {
 		// we don't include the default flow name in the route

--- a/client/state/account/actions.js
+++ b/client/state/account/actions.js
@@ -1,12 +1,10 @@
 /**
  * Internal dependencies
  */
-import userFactory from 'lib/user';
+import user from 'lib/user';
 import { ACCOUNT_CLOSE, ACCOUNT_CLOSE_SUCCESS } from 'state/action-types';
 
 import 'state/data-layer/wpcom/me/account/close';
-
-const user = userFactory();
 
 export function closeAccount() {
 	return {
@@ -16,7 +14,7 @@ export function closeAccount() {
 
 export function closeAccountSuccess() {
 	return async ( dispatch ) => {
-		await user.clear();
+		await user().clear();
 		dispatch( {
 			type: ACCOUNT_CLOSE_SUCCESS,
 		} );

--- a/client/state/current-user/selectors.js
+++ b/client/state/current-user/selectors.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
 
 /**
@@ -48,7 +47,7 @@ export function getCurrentUser( state ) {
  * Returns a selector that fetches a property from the current user object
  *
  * @param {string} path Path to the property in the user object
- * @param {?Any} otherwise A default value that is returned if no user or property is found
+ * @param {?any} otherwise A default value that is returned if no user or property is found
  * @returns {Function} A selector which takes the state as a parameter
  */
 export const createCurrentUserSelector = ( path, otherwise = null ) => ( state ) => {
@@ -143,6 +142,14 @@ export const getCurrentUserName = createCurrentUserSelector( 'username' );
  *  @returns {?string} The primary email of the current user.
  */
 export const getCurrentUserEmail = createCurrentUserSelector( 'email' );
+
+/**
+ *  Returns the primary email of the current user.
+ *
+ *  @param {object} state Global state tree
+ *  @returns {?string} The primary email of the current user.
+ */
+export const getCurrentUserDisplayName = createCurrentUserSelector( 'display_name' );
 
 /**
  * Returns true if the capability name is valid for the current user on a given

--- a/client/state/initial-state.js
+++ b/client/state/initial-state.js
@@ -11,13 +11,12 @@ import { APPLY_STORED_STATE, SERIALIZE, DESERIALIZE } from 'state/action-types';
 import { getAllStoredItems, setStoredItem, clearStorage } from 'lib/browser-storage';
 import { isSupportSession } from 'lib/user/support-user-interop';
 import config from 'config';
-import User from 'lib/user';
+import user from 'lib/user';
 
 /**
  * Module variables
  */
 const debug = debugModule( 'calypso:state' );
-const user = User();
 
 const DAY_IN_HOURS = 24;
 const HOUR_IN_MS = 3600000;
@@ -95,7 +94,7 @@ function shouldAddSympathy() {
 // scenario where state data may have been stored without this
 // check being performed.
 function verifyStoredRootState( state ) {
-	const currentUserId = user?.get()?.ID ?? null;
+	const currentUserId = user().get()?.ID ?? null;
 	const storedUserId = state?.currentUser?.id ?? null;
 
 	if ( currentUserId !== storedUserId ) {
@@ -160,7 +159,7 @@ export function getStateFromCache( reducer, subkey, forceLoggedOutUser = false )
 }
 
 function getReduxStateKey( forceLoggedOutUser = false ) {
-	return getReduxStateKeyForUserId( forceLoggedOutUser ? null : user?.get()?.ID ?? null );
+	return getReduxStateKeyForUserId( forceLoggedOutUser ? null : user().get()?.ID ?? null );
 }
 
 function getReduxStateKeyForUserId( userId ) {

--- a/client/state/initial-state.js
+++ b/client/state/initial-state.js
@@ -94,7 +94,7 @@ function shouldAddSympathy() {
 // scenario where state data may have been stored without this
 // check being performed.
 function verifyStoredRootState( state ) {
-	const currentUserId = user().get()?.ID ?? null;
+	const currentUserId = user()?.get()?.ID ?? null;
 	const storedUserId = state?.currentUser?.id ?? null;
 
 	if ( currentUserId !== storedUserId ) {
@@ -159,7 +159,7 @@ export function getStateFromCache( reducer, subkey, forceLoggedOutUser = false )
 }
 
 function getReduxStateKey( forceLoggedOutUser = false ) {
-	return getReduxStateKeyForUserId( forceLoggedOutUser ? null : user().get()?.ID ?? null );
+	return getReduxStateKeyForUserId( forceLoggedOutUser ? null : user()?.get()?.ID ?? null );
 }
 
 function getReduxStateKeyForUserId( userId ) {

--- a/client/state/lib/middleware.js
+++ b/client/state/lib/middleware.js
@@ -18,7 +18,7 @@ import {
 	SITE_RECEIVE,
 	SITES_RECEIVE,
 } from 'state/action-types';
-import userFactory from 'lib/user';
+import user from 'lib/user';
 import hasSitePendingAutomatedTransfer from 'state/selectors/has-site-pending-automated-transfer';
 import { isFetchingAutomatedTransferStatus } from 'state/automated-transfer/selectors';
 import isNotificationsOpen from 'state/selectors/is-notifications-open';
@@ -32,8 +32,6 @@ import {
 	createPathWithoutImmediateLoginInformation,
 } from 'state/immediate-login/utils';
 import { saveImmediateLoginInformation } from 'state/immediate-login/actions';
-
-const user = userFactory();
 
 /**
  * Module variables
@@ -165,7 +163,7 @@ const handler = ( dispatch, action, getState ) => {
 
 		case SITE_DELETE_RECEIVE:
 		case JETPACK_DISCONNECT_RECEIVE:
-			user.decrementSiteCount();
+			user().decrementSiteCount();
 			return;
 	}
 };

--- a/client/state/login/actions/reboot-after-login.ts
+++ b/client/state/login/actions/reboot-after-login.ts
@@ -6,11 +6,9 @@ import type { Dispatch } from 'redux';
 /**
  * Internal dependencies
  */
-import userFactory from 'lib/user';
+import user from 'lib/user';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
 import { getRedirectToSanitized, isTwoFactorEnabled } from 'state/login/selectors';
-
-const user = userFactory();
 
 export const rebootAfterLogin = ( tracksEventArgs: object ) => async (
 	dispatch: Dispatch,
@@ -29,8 +27,8 @@ export const rebootAfterLogin = ( tracksEventArgs: object ) => async (
 	// user data is persisted in localstorage at `lib/user/user` line 157
 	// therefore we need to reset it before we redirect, otherwise we'll get
 	// mixed data from old and new user
-	if ( user.get() ) {
-		await user.clear();
+	if ( user().get() ) {
+		await user().clear();
 	}
 
 	// We want to differentiate users going to `/oauth2/authorize` that are coming from


### PR DESCRIPTION
`lib/user` is part of several circular dependencies, so instantiation at the top level can lead to hard-to-find initialisation order problems.

Since `lib/user` follows a singleton pattern anyway, there's no need for performance considerations, and we can just invoke the default export as often as needed.

This PR is a follow-up to #43022, where @jsnajdr proposed this janitorial task.

#### Changes proposed in this Pull Request

* Remove top-level instantiation of the default export from `lib/user` across Calypso
* Update documentation to use preferred idiom

#### Testing instructions

This one is a bit hard to provide instructions for, since it touches several parts of Calypso. The unit tests + the E2E tests should provide a reasonable measure of safety.