### PR TITLE
Fix missing yarn dependency for the eslint plugin

### DIFF
--- a/apps/full-site-editing/bin/sync-newspack-blocks.sh
+++ b/apps/full-site-editing/bin/sync-newspack-blocks.sh
@@ -125,7 +125,7 @@ cp -R $CODE/src/shared $TARGET/
 cp -R $CODE/src/components $TARGET/
 
 # Fix the text domain
-npx eslint . --fix
+npx eslint . --fix > /dev/null 2>&1
 
 if [ "$MODE" = "npm" ] ; then
 	# Finds and prints the version of newspack from package.json

--- a/apps/full-site-editing/full-site-editing-plugin/editor-gutenboarding-launch/index.ts
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-gutenboarding-launch/index.ts
@@ -64,7 +64,7 @@ function updateEditor() {
 		launchLink.href = launchHref;
 		launchLink.target = '_top';
 		launchLink.className = 'editor-gutenberg-launch__launch-button components-button is-primary';
-		const textContent = document.createTextNode( __( 'Launch' ) );
+		const textContent = document.createTextNode( __( 'Launch', 'full-site-editing' ) );
 		launchLink.appendChild( textContent );
 
 		const saveAndNavigate = async ( e: Event ) => {

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/index.js
@@ -60,7 +60,7 @@ const addPaidBlockFlags = async () => {
 		const paidFlag = _x(
 			'paid',
 			'Short label appearing near a block requiring a paid plan',
-			'premium-content'
+			'full-site-editing'
 		);
 
 		unregisterBlockType( container.name );

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/wpcom-block-editor-nav-sidebar.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/wpcom-block-editor-nav-sidebar.tsx
@@ -61,7 +61,7 @@ export default function WpcomBlockEditorNavSidebar() {
 	let closeUrl = addQueryArgs( 'edit.php', { post_type: postType.slug } );
 	closeUrl = applyFilters( 'a8c.WpcomBlockEditorNavSidebar.closeUrl', closeUrl );
 
-	let closeLabel = get( postType, [ 'labels', 'all_items' ], __( 'Back' ) );
+	let closeLabel = get( postType, [ 'labels', 'all_items' ], __( 'Back', 'full-site-editing' ) );
 	closeLabel = applyFilters( 'a8c.WpcomBlockEditorNavSidebar.closeLabel', closeLabel );
 
 	const handleClose = ( e: React.WPSyntheticEvent ) => {

--- a/apps/full-site-editing/package.json
+++ b/apps/full-site-editing/package.json
@@ -82,9 +82,9 @@
 		"prepare": "check-npm-client && yarn run sync:newspack-blocks --nodemodules"
 	},
 	"dependencies": {
-		"@automattic/format-currency": "^1.0.0-alpha.0",
-		"@automattic/data-stores": "^1.0.0-alpha.1",
 		"@automattic/calypso-build": "*",
+		"@automattic/data-stores": "^1.0.0-alpha.1",
+		"@automattic/format-currency": "^1.0.0-alpha.0",
 		"@wordpress/api-fetch": "*",
 		"@wordpress/block-editor": "*",
 		"@wordpress/blocks": "*",
@@ -109,5 +109,8 @@
 		"lodash": "*",
 		"moment": "*",
 		"newspack-blocks": "github:Automattic/newspack-blocks#v1.7.0"
+	},
+	"devDependencies": {
+		"@wordpress/eslint-plugin": "^6.0.0"
 	}
 }


### PR DESCRIPTION
Unbreaks a yarn build with an empty cache.

```
@automattic/full-site-editing: $ check-npm-client && ./bin/sync-newspack-blocks.sh --nodemodules
@automattic/full-site-editing: Syncing files to FSE…
@automattic/full-site-editing: Oops! Something went wrong! :(
@automattic/full-site-editing: ESLint: 7.1.0
@automattic/full-site-editing: ESLint couldn't find the plugin "@wordpress/eslint-plugin".
```

Props @scinos 

Also adds some text domain modifications that should have maded it in via #42583