### PR TITLE
Fix order of stripe hook provider in composite checkout test

### DIFF
--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
@@ -209,8 +209,8 @@ describe( 'CompositeCheckout', () => {
 		} );
 
 		MyCheckout = ( { cartChanges, additionalProps } ) => (
-			<StripeHookProvider fetchStripeConfiguration={ fetchStripeConfiguration }>
-				<ReduxProvider store={ store }>
+			<ReduxProvider store={ store }>
+				<StripeHookProvider fetchStripeConfiguration={ fetchStripeConfiguration }>
 					<CompositeCheckout
 						siteSlug={ 'foo.com' }
 						setCart={ mockSetCartEndpoint }
@@ -221,8 +221,8 @@ describe( 'CompositeCheckout', () => {
 						overrideCountryList={ countryList }
 						{ ...additionalProps }
 					/>
-				</ReduxProvider>
-			</StripeHookProvider>
+				</StripeHookProvider>
+			</ReduxProvider>
 		);
 	} );
 


### PR DESCRIPTION
Fixes regression added in
https://github.com/Automattic/wp-calypso/pull/43026