### PR TITLE
Reader: build a static CSS to be used by WordPress iOS and Android

### DIFF
--- a/client/assets/stylesheets/reader-mobile.scss
+++ b/client/assets/stylesheets/reader-mobile.scss
@@ -1,0 +1,3 @@
+@import 'shared/utils';
+
+@import 'blocks/reader-full-post/style';

--- a/client/assets/stylesheets/reader-mobile.scss
+++ b/client/assets/stylesheets/reader-mobile.scss
@@ -1,3 +1,6 @@
+// CSS used by both WordPress iOS and Android to display Reader Content
+// Adding styles here will only affect the apps.
+//
 @import 'shared/utils';
 
 @import 'blocks/reader-full-post/style';

--- a/client/assets/stylesheets/reader-mobile.scss
+++ b/client/assets/stylesheets/reader-mobile.scss
@@ -3,4 +3,4 @@
 //
 @import 'shared/utils';
 
-@import 'blocks/reader-full-post/style';
+@import 'blocks/reader-full-post/_content';

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
 		"build-css": "check-npm-client && run-p -s build-css:*",
 		"build-css:directly": "check-npm-client && node-sass --importer node_modules/node-sass-package-importer/dist/cli.js --include-path client client/assets/stylesheets/directly.scss public/directly.css --output-style compressed && yarn run -s postcss public/directly.css",
 		"build-css:editor": "check-npm-client && node-sass --importer node_modules/node-sass-package-importer/dist/cli.js --include-path client client/assets/stylesheets/editor.scss public/editor.css --output-style compressed && yarn run -s postcss public/editor.css",
+		"build-css:reader-mobile": "check-npm-client && node-sass --importer node_modules/node-sass-package-importer/dist/cli.js --include-path client client/assets/stylesheets/reader-mobile.scss public/reader-mobile.css --output-style compressed && yarn run -s postcss public/reader-mobile.css",
 		"build-devdocs:search-index": "check-npm-client && node bin/generate-devdocs-search-index.js",
 		"build-docker": "check-npm-client && node bin/build-docker.js",
 		"build-static": "check-npm-client && npx ncp static public",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* A static CSS containing the Reader styles is build to be consumed by the apps

More information about the above: we're changing the way we render blocks in the Reader inside the apps and the idea is to take advantage of having a style that we can easily change without the need of submitting the app again.

#### Testing instructions

* `yarn start`
* Then access http://calypso.localhost:3000/calypso/reader-mobile.css (or test it live using the link below)
