### PR TITLE
composite-checkout: Use domain country list for plan-only checkout form (1)

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -51,7 +51,7 @@ import {
 import { FormCountrySelect } from 'components/forms/form-country-select';
 import RegistrantExtraInfoForm from 'components/domains/registrant-extra-info';
 import getCountries from 'state/selectors/get-countries';
-import { fetchPaymentCountries } from 'state/countries/actions';
+import { fetchDomainCountries } from 'state/countries/actions';
 import { StateSelect } from 'my-sites/domains/components/form';
 import ManagedContactDetailsFormFields from 'components/domains/contact-details-form-fields/managed-contact-details-form-fields';
 import { getPlan, findPlansKeys } from 'lib/plans';
@@ -608,7 +608,7 @@ function useCountryList( overrideCountryList ) {
 	const [ countriesList, setCountriesList ] = useState( overrideCountryList );
 
 	const reduxDispatch = useDispatch();
-	const globalCountryList = useSelector( ( state ) => getCountries( state, 'payments' ) );
+	const globalCountryList = useSelector( ( state ) => getCountries( state, 'domains' ) );
 
 	// Has the global list been populated?
 	const isListFetched = globalCountryList?.length > 0;
@@ -619,7 +619,7 @@ function useCountryList( overrideCountryList ) {
 				setCountriesList( globalCountryList );
 			} else {
 				debug( 'countries list is empty; dispatching request for data' );
-				reduxDispatch( fetchPaymentCountries() );
+				reduxDispatch( fetchDomainCountries() );
 			}
 		}
 	}, [ shouldFetchList, isListFetched, globalCountryList, reduxDispatch ] );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

**Edit**: Looks like this has already been fixed. I'm not sure how!

* We have several different country lists in state. The `domains` list is ordered such that the most common selections appear at the top, while the `payments` list is not. This just switches the plan-only contact form to use the domains country list. (The name is not important here, both lists contain the same entries.)

#### Testing instructions

Enter composite checkout with a plan only. Verify that the country drop-down menu is populated, and the most common options are shown at the top.

![Screen Shot 2020-06-08 at 1 28 17 PM](https://user-images.githubusercontent.com/9310939/84067075-7f087e00-a98c-11ea-9e14-751a28527b30.png)
