### PR TITLE
Checkout: add summary features for each of the WP.com plans

### DIFF
--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
@@ -169,6 +169,24 @@ function CheckoutSummaryPlanFeatures() {
 
 function getPlanFeatures( plan, translate, hasDomainsInCart ) {
 	if (
+		'personal-bundle' === plan.wpcom_meta?.product_slug ||
+		'personal-bundle-2y' === plan.wpcom_meta?.product_slug
+	) {
+		return [
+			! hasDomainsInCart && translate( 'Free domain for one year' ),
+			translate( 'Remove WordPress.com ads' ),
+			translate( 'Limit your content to paying subscribers.' ),
+		];
+	} else if (
+		'value_bundle' === plan.wpcom_meta?.product_slug ||
+		'value_bundle-2y' === plan.wpcom_meta?.product_slug
+	) {
+		return [
+			! hasDomainsInCart && translate( 'Free domain for one year' ),
+			translate( 'Unlimited access to our library of Premium Themes' ),
+			translate( 'Track your stats with Google Analytics' ),
+		];
+	} else if (
 		'business-bundle' === plan.wpcom_meta?.product_slug ||
 		'business-bundle-2y' === plan.wpcom_meta?.product_slug
 	) {
@@ -177,6 +195,18 @@ function getPlanFeatures( plan, translate, hasDomainsInCart ) {
 			translate( 'Install custom plugins and themes' ),
 			translate( 'Drive traffic to your site with our advanced SEO tools' ),
 			translate( 'Track your stats with Google Analytics' ),
+		];
+	} else if (
+		'ecommerce-bundle' === plan.wpcom_meta?.product_slug ||
+		'ecommerce-bundle-2y' === plan.wpcom_meta?.product_slug
+	) {
+		return [
+			! hasDomainsInCart && translate( 'Free domain for one year' ),
+			translate( 'Install custom plugins and themes' ),
+			translate( 'Accept payments in 60+ countries' ),
+			translate( 'Integrations with top shipping carriers' ),
+			translate( 'Unlimited products or services' ),
+			translate( 'eCommerce marketing tools' ),
 		];
 	}
 	return [];

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
@@ -184,6 +184,7 @@ function getPlanFeatures( plan, translate, hasDomainsInCart ) {
 		return [
 			! hasDomainsInCart && translate( 'Free domain for one year' ),
 			translate( 'Unlimited access to our library of Premium Themes' ),
+			translate( 'Subscriber-only content and simple payment buttons' ),
 			translate( 'Track your stats with Google Analytics' ),
 		];
 	} else if (
@@ -195,6 +196,7 @@ function getPlanFeatures( plan, translate, hasDomainsInCart ) {
 			translate( 'Install custom plugins and themes' ),
 			translate( 'Drive traffic to your site with our advanced SEO tools' ),
 			translate( 'Track your stats with Google Analytics' ),
+			translate( 'Real-time backups and activity logs' ),
 		];
 	} else if (
 		'ecommerce-bundle' === plan.wpcom_meta?.product_slug ||
@@ -205,8 +207,8 @@ function getPlanFeatures( plan, translate, hasDomainsInCart ) {
 			translate( 'Install custom plugins and themes' ),
 			translate( 'Accept payments in 60+ countries' ),
 			translate( 'Integrations with top shipping carriers' ),
-			translate( 'Unlimited products or services' ),
-			translate( 'eCommerce marketing tools' ),
+			translate( 'Unlimited products or services for your online store' ),
+			translate( 'eCommerce marketing tools for emails and social networks' ),
 		];
 	}
 	return [];


### PR DESCRIPTION
In #42854 we added plan features to the Checkout summary for the business plan. This adds features for all active WordPress.com plans.

**All Plans:**
- "Free domain for one year" unless a domain is in the cart, then the bundling message will be on the domain line item

**Personal:**
- Remove WordPress.com ads
- Limit your content to paying subscribers

**Premium:**
- Unlimited access to our library of Premium Themes
- Subscriber-only content and simple payment buttons
- Track your stats with Google Analytics

**Business:**
- Install custom plugins and themes
- Drive traffic to your site with our advanced SEO tools
- Track your stats with Google Analytics
- Real-time backups and activity logs

**Ecommerce:**
- Install custom plugins and themes
- Accept payments in 60+ countries
- Integrations with top shipping carriers
- Unlimited products or services for your online store
- eCommerce marketing tools

**To test:**
- add a plan to your cart and visit Checkout with `?flags=composite-checkout-testing`
- verify that the checkout summary has the correct features
- switch plan variation and verify that the features remain
- add a domain and verify that the "Free domain for one year" feature is removed (a separate domain item should be seen)
- repeat for other plans