### PR TITLE
Render sites inside reader lists

### DIFF
--- a/client/components/data/query-reader-list-items/index.jsx
+++ b/client/components/data/query-reader-list-items/index.jsx
@@ -9,12 +9,12 @@ import { useDispatch } from 'react-redux';
  */
 import { requestReaderListItems } from 'state/reader/lists/actions';
 
-export default function QueryReaderListItems( { listOwner, listSlug } ) {
+export default function QueryReaderListItems( { owner, slug } ) {
 	const dispatch = useDispatch();
 
 	React.useEffect( () => {
-		dispatch( requestReaderListItems( listOwner, listSlug ) );
-	}, [ dispatch, listOwner, listSlug ] );
+		dispatch( requestReaderListItems( owner, slug ) );
+	}, [ dispatch, owner, slug ] );
 
 	return null;
 }

--- a/client/reader/list-manage/index.jsx
+++ b/client/reader/list-manage/index.jsx
@@ -2,11 +2,108 @@
  * External dependencies
  */
 import * as React from 'react';
+import { connect } from 'react-redux';
 
-export default function ReaderListEdit( props ) {
+/**
+ * Internal dependencies
+ */
+import { Button, Card } from '@automattic/components';
+import { getListByOwnerAndSlug } from 'state/reader/lists/selectors';
+import FormattedHeader from 'components/formatted-header';
+import FormButtonsBar from 'components/forms/form-buttons-bar';
+import FormButton from 'components/forms/form-button';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormLabel from 'components/forms/form-label';
+import FormLegend from 'components/forms/form-legend';
+import FormRadio from 'components/forms/form-radio';
+import FormSectionHeading from 'components/forms/form-section-heading';
+import FormSettingExplanation from 'components/forms/form-setting-explanation';
+import FormTextInput from 'components/forms/form-text-input';
+import FormTextarea from 'components/forms/form-textarea';
+import QueryReaderList from 'components/data/query-reader-list';
+import SectionNav from 'components/section-nav';
+import NavTabs from 'components/section-nav/tabs';
+import NavItem from 'components/section-nav/item';
+import Main from 'components/main';
+
+function ReaderListEdit( props ) {
+	const list = props.list;
 	return (
-		<div>
-			Editing the list { props.owner } / { props.slug }
-		</div>
+		<>
+			<QueryReaderList owner={ props.owner } slug={ props.slug } />
+			<Main>
+				<FormattedHeader headerText={ `Manage ${ list?.title || props.slug }` } />
+				{ ! list && <Card>Loading...</Card> }
+				{ list && (
+					<>
+						<SectionNav>
+							<NavTabs>
+								<NavItem selected={ true }>Details</NavItem>
+								<NavItem count={ 69 }>Sites</NavItem>
+							</NavTabs>
+						</SectionNav>
+						<Card>
+							<FormSectionHeading>List Details</FormSectionHeading>
+
+							<FormFieldset>
+								<FormLabel htmlFor="list-name">Name</FormLabel>
+								<FormTextInput id="list-name" name="list-name" value={ list.title } />
+								<FormSettingExplanation>The name of the list.</FormSettingExplanation>
+							</FormFieldset>
+
+							<FormFieldset>
+								<FormLabel htmlFor="list-slug">Slug</FormLabel>
+								<FormTextInput id="list-slug" name="list-slug" value={ list.slug } />
+								<FormSettingExplanation>
+									The slug for the list. This is used to build the URL to the list.
+								</FormSettingExplanation>
+							</FormFieldset>
+
+							<FormFieldset>
+								<FormLegend>Visibility</FormLegend>
+								<FormLabel>
+									<FormRadio value="public" checked={ list.is_public } />
+									<span>Everyone can view this list</span>
+								</FormLabel>
+
+								<FormLabel>
+									<FormRadio value="private" checked={ ! list.is_public } />
+									<span>Only I can view this list</span>
+								</FormLabel>
+								<FormSettingExplanation>
+									Don't worry, posts from private sites will only appear to those with access.
+									Adding a private site to a public list will not make posts from that site
+									accessible to everyone.
+								</FormSettingExplanation>
+							</FormFieldset>
+
+							<FormFieldset>
+								<FormLabel htmlFor="list-description">Description</FormLabel>
+								<FormTextarea
+									name="list-description"
+									id="list-description"
+									placeholder="What's your list about?"
+									value={ list.description }
+								/>
+							</FormFieldset>
+							<FormButtonsBar>
+								<FormButton primary>Save</FormButton>
+							</FormButtonsBar>
+						</Card>
+
+						<Card>
+							<FormSectionHeading>DANGER!!</FormSectionHeading>
+							<Button scary primary>
+								DELETE LIST FOREVER
+							</Button>
+						</Card>
+					</>
+				) }
+			</Main>
+		</>
 	);
 }
+
+export default connect( ( state, ownProps ) => ( {
+	list: getListByOwnerAndSlug( state, ownProps.owner, ownProps.slug ),
+} ) )( ReaderListEdit );

--- a/client/reader/list-manage/index.jsx
+++ b/client/reader/list-manage/index.jsx
@@ -8,7 +8,7 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import { Button, Card } from '@automattic/components';
-import { getListByOwnerAndSlug } from 'state/reader/lists/selectors';
+import { getListByOwnerAndSlug, getListItems } from 'state/reader/lists/selectors';
 import FormattedHeader from 'components/formatted-header';
 import FormButtonsBar from 'components/forms/form-buttons-bar';
 import FormButton from 'components/forms/form-button';
@@ -21,16 +21,18 @@ import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import FormTextInput from 'components/forms/form-text-input';
 import FormTextarea from 'components/forms/form-textarea';
 import QueryReaderList from 'components/data/query-reader-list';
+import QueryReaderListItems from 'components/data/query-reader-list-items';
 import SectionNav from 'components/section-nav';
 import NavTabs from 'components/section-nav/tabs';
 import NavItem from 'components/section-nav/item';
 import Main from 'components/main';
 
 function ReaderListEdit( props ) {
-	const list = props.list;
+	const { list, listItems } = props;
 	return (
 		<>
-			<QueryReaderList owner={ props.owner } slug={ props.slug } />
+			{ ! list && <QueryReaderList owner={ props.owner } slug={ props.slug } /> }
+			{ ! listItems && list && <QueryReaderListItems owner={ props.owner } slug={ props.slug } /> }
 			<Main>
 				<FormattedHeader headerText={ `Manage ${ list?.title || props.slug }` } />
 				{ ! list && <Card>Loading...</Card> }
@@ -92,6 +94,15 @@ function ReaderListEdit( props ) {
 						</Card>
 
 						<Card>
+							<FormSectionHeading>Sites in List</FormSectionHeading>
+							<pre>
+								{ ! listItems && 'Loading...' }
+								{ listItems &&
+									listItems.map( ( item ) => JSON.stringify( item, null, 2 ) + '\n\n' ) }
+							</pre>
+						</Card>
+
+						<Card>
 							<FormSectionHeading>DANGER!!</FormSectionHeading>
 							<Button scary primary>
 								DELETE LIST FOREVER
@@ -104,6 +115,11 @@ function ReaderListEdit( props ) {
 	);
 }
 
-export default connect( ( state, ownProps ) => ( {
-	list: getListByOwnerAndSlug( state, ownProps.owner, ownProps.slug ),
-} ) )( ReaderListEdit );
+export default connect( ( state, ownProps ) => {
+	const list = getListByOwnerAndSlug( state, ownProps.owner, ownProps.slug );
+	const listItems = list ? getListItems( state, list.ID ) : undefined;
+	return {
+		list,
+		listItems,
+	};
+} )( ReaderListEdit );

--- a/client/reader/list-manage/style.scss
+++ b/client/reader/list-manage/style.scss
@@ -1,0 +1,8 @@
+.list-manage__site-card {
+	display: flex;
+
+	.button {
+		align-self: center;
+		margin-left: 1em;
+	}
+}

--- a/client/state/data-layer/wpcom/read/lists/items/index.js
+++ b/client/state/data-layer/wpcom/read/lists/items/index.js
@@ -16,10 +16,12 @@ registerHandlers( 'state/data-layer/wpcom/read/lists/items/index.js', {
 					{
 						method: 'GET',
 						path: `/read/lists/${ action.listOwner }/${ action.listSlug }/items`,
+						apiVersion: '1.2',
 					},
 					action
 				),
-			onSuccess: ( action, { listId, listItems } ) => receiveReaderListItems( listId, listItems ),
+			onSuccess: ( action, apiResponse ) =>
+				receiveReaderListItems( apiResponse.list_ID, apiResponse.items ),
 			onError: ( action, error ) => errorNotice( error ),
 		} ),
 	],

--- a/client/state/reader/lists/actions.js
+++ b/client/state/reader/lists/actions.js
@@ -26,6 +26,7 @@ import {
 	READER_LISTS_UNFOLLOW_FAILURE,
 } from 'state/reader/action-types';
 
+import 'state/data-layer/wpcom/read/lists/items';
 import 'state/reader/init';
 
 /**

--- a/client/state/reader/lists/reducer.js
+++ b/client/state/reader/lists/reducer.js
@@ -22,6 +22,7 @@ import {
 	READER_LISTS_REQUEST_FAILURE,
 	READER_LISTS_FOLLOW_SUCCESS,
 	READER_LISTS_UNFOLLOW_SUCCESS,
+	READER_LIST_ITEMS_RECEIVE,
 } from 'state/reader/action-types';
 import { combineReducers, withSchemaValidation } from 'state/utils';
 import { itemsSchema, subscriptionsSchema, updatedListsSchema, errorsSchema } from './schema';
@@ -57,6 +58,17 @@ export const items = withSchemaValidation( itemsSchema, ( state = {}, action ) =
 	}
 	return state;
 } );
+
+export const listItems = ( state = {}, action ) => {
+	switch ( action.type ) {
+		case READER_LIST_ITEMS_RECEIVE:
+			return {
+				...state,
+				[ action.listId ]: action.listItems,
+			};
+	}
+	return state;
+};
 
 /**
  * Tracks which list IDs the current user is subscribed to.
@@ -201,6 +213,7 @@ export function missingLists( state = [], action ) {
 
 export default combineReducers( {
 	items,
+	listItems,
 	subscribedLists,
 	updatedLists,
 	isRequestingList,

--- a/client/state/reader/lists/selectors.js
+++ b/client/state/reader/lists/selectors.js
@@ -100,6 +100,10 @@ export function getListByOwnerAndSlug( state, owner, slug ) {
 	} );
 }
 
+export function getListItems( state, listId ) {
+	return state.reader?.lists?.listItems?.[ listId ];
+}
+
 /**
  * Check if the user is subscribed to the specified list
  *


### PR DESCRIPTION
<img width="758" alt="WordPress_com" src="https://user-images.githubusercontent.com/4044428/84078309-f098fa00-a995-11ea-9135-cb7d30e87668.png">

#### Changes proposed in this Pull Request

* Adds functionality to `NavItem`s.
* Renders the site associated with each list item.

#### Testing instructions
* Navigate to `/read/list/:owner/:slug/edit`.
* Ensure that the nav items work.
* Ensure that the list items render.

