### PR TITLE
FSE plugin: Ignore dist directories in eslint config

### DIFF
--- a/apps/full-site-editing/.eslintrc.js
+++ b/apps/full-site-editing/.eslintrc.js
@@ -11,6 +11,7 @@ module.exports = {
 			},
 		],
 	},
+	ignorePatterns: [ '**/dist/*' ],
 	overrides: [
 		{
 			files: [ './**/?(*.)spec.[jt]s?(x)', './full-site-editing-plugin/e2e-test-helpers/**' ],


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Adds `dist` directories to eslint ignore in FSE plugin. I realized that the eslint command in the newspack sync script was taking a very long time to complete (>5 minutes) (since this is run during `yarn install`, I thought yarn was broken). After removing the error suppression code, I noticed it was reporting thousands of errors in the dist files. 

After making this fix, yarn install completes much more quickly.

#### Testing instructions
1. `yarn install` should still work
2. `yarn run prepare` from apps/full-site-editing should be much more quick

