### PR TITLE
Home: add generic tracking events for educational cards

### DIFF
--- a/client/my-sites/customer-home/cards/education/earn/index.jsx
+++ b/client/my-sites/customer-home/cards/education/earn/index.jsx
@@ -10,6 +10,7 @@ import { connect } from 'react-redux';
  */
 import EducationalContent from '../educational-content';
 import { getSelectedSiteSlug } from 'state/ui/selectors';
+export const EDUCATION_EARN = 'home-education-earn';
 
 /**
  * Image dependencies
@@ -34,6 +35,7 @@ const EducationEarn = ( { siteSlug } ) => {
 				},
 			] }
 			illustration={ earnCardPrompt }
+			cardName={ EDUCATION_EARN }
 		/>
 	);
 };

--- a/client/my-sites/customer-home/cards/education/educational-content/index.jsx
+++ b/client/my-sites/customer-home/cards/education/educational-content/index.jsx
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import { isDesktop } from '@automattic/viewport';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -10,13 +11,28 @@ import { isDesktop } from '@automattic/viewport';
 import ExternalLink from 'components/external-link';
 import InlineSupportLink from 'components/inline-support-link';
 import Gridicon from 'components/gridicon';
+import {
+	bumpStat,
+	composeAnalytics,
+	recordTracksEvent,
+	withAnalytics,
+} from 'state/analytics/actions';
+import { navigate } from 'state/ui/actions';
 
 /**
  * Style dependencies
  */
 import './style.scss';
 
-const EducationalContent = ( { title, description, links, illustration } ) => {
+const EducationalContent = ( {
+	title,
+	description,
+	links,
+	illustration,
+	cardName,
+	calypsoNavigation,
+	trackExternalClick,
+} ) => {
 	return (
 		<div className="educational-content">
 			<div className="educational-content__wrapper">
@@ -25,30 +41,48 @@ const EducationalContent = ( { title, description, links, illustration } ) => {
 					{ description }
 				</p>
 				<div className="educational-content__links">
-					{ links.map(
-						( { postId, url, calypsoLink, externalLink, text, icon, tracksEvent, statsName } ) => (
-							<div className="educational-content__link" key={ url }>
-								{ icon && <Gridicon icon={ icon } size={ 18 } /> }
-								{ postId && (
-									<InlineSupportLink
-										supportPostId={ postId }
-										supportLink={ url }
-										showIcon={ false }
-										text={ text }
-										tracksEvent={ tracksEvent }
-										statsGroup="calypso_customer_home"
-										statsName={ statsName }
-									/>
-								) }
-								{ externalLink && (
-									<ExternalLink href={ url } icon>
-										{ text }
-									</ExternalLink>
-								) }
-								{ calypsoLink && <a href={ url }>{ text }</a> }
-							</div>
-						)
-					) }
+					{ links.map( ( { postId, url, calypsoLink, externalLink, text, icon } ) => (
+						<div className="educational-content__link" key={ url }>
+							{ icon && <Gridicon icon={ icon } size={ 18 } /> }
+							{ postId && (
+								<InlineSupportLink
+									supportPostId={ postId }
+									supportLink={ url }
+									showIcon={ false }
+									text={ text }
+									tracksEvent="calypso_customer_home_education"
+									statsGroup="calypso_customer_home"
+									tracksOptions={ {
+										url,
+										card_name: cardName,
+									} }
+									statsName={ cardName }
+								/>
+							) }
+							{ externalLink && (
+								<ExternalLink
+									href={ url }
+									onClick={ () => {
+										trackExternalClick( url, cardName );
+									} }
+									icon
+								>
+									{ text }
+								</ExternalLink>
+							) }
+							{ calypsoLink && (
+								<a
+									href={ url }
+									onClick={ ( event ) => {
+										event.preventDefault();
+										calypsoNavigation( url, cardName );
+									} }
+								>
+									{ text }
+								</a>
+							) }
+						</div>
+					) ) }
 				</div>
 			</div>
 			{ isDesktop() && (
@@ -60,4 +94,24 @@ const EducationalContent = ( { title, description, links, illustration } ) => {
 	);
 };
 
-export default EducationalContent;
+const calypsoNavigation = ( url, cardName ) => {
+	return withAnalytics(
+		composeAnalytics(
+			recordTracksEvent( 'calypso_customer_home_education', { url, card_name: cardName } ),
+			bumpStat( 'calypso_customer_home', cardName )
+		),
+		navigate( url )
+	);
+};
+
+const trackExternalClick = ( url, cardName ) => {
+	return composeAnalytics(
+		recordTracksEvent( 'calypso_customer_home_education', { url, card_name: cardName } ),
+		bumpStat( 'calypso_customer_home', cardName )
+	);
+};
+
+export default connect( null, {
+	calypsoNavigation,
+	trackExternalClick,
+} )( EducationalContent );

--- a/client/my-sites/customer-home/cards/education/free-photo-library/index.jsx
+++ b/client/my-sites/customer-home/cards/education/free-photo-library/index.jsx
@@ -9,6 +9,7 @@ import { useTranslate } from 'i18n-calypso';
  */
 import { localizeUrl } from 'lib/i18n-utils';
 import EducationalContent from '../educational-content';
+import { EDUCATION_FREE_PHOTO_LIBRARY } from 'my-sites/customer-home/cards/constants';
 
 /**
  * Image dependencies
@@ -30,11 +31,10 @@ const FreePhotoLibrary = () => {
 					url: localizeUrl( 'https://wordpress.com/support/free-photo-library/' ),
 					text: translate( 'Learn more' ),
 					icon: 'video',
-					tracksEvent: 'calypso_customer_home_free_photo_library_video_support_page_view',
-					statsName: 'view_free_photo_library_video',
 				},
 			] }
 			illustration={ freePhotoLibraryVideoPrompt }
+			cardName={ EDUCATION_FREE_PHOTO_LIBRARY }
 		/>
 	);
 };

--- a/client/my-sites/customer-home/cards/education/mastering-gutenberg/index.jsx
+++ b/client/my-sites/customer-home/cards/education/mastering-gutenberg/index.jsx
@@ -9,6 +9,7 @@ import { useTranslate } from 'i18n-calypso';
  */
 import { localizeUrl } from 'lib/i18n-utils';
 import EducationalContent from '../educational-content';
+import { EDUCATION_GUTENBERG } from 'my-sites/customer-home/cards/constants';
 
 /**
  * Image dependencies
@@ -30,19 +31,16 @@ const MasteringGutenberg = () => {
 					url: localizeUrl( 'https://wordpress.com/support/wordpress-editor/#blocks' ),
 					text: translate( 'Adding and moving blocks' ),
 					icon: 'video',
-					tracksEvent: 'calypso_customer_home_customizing_with_blocks_support_page_view',
-					statsName: 'view_customizing_with_blocks_video',
 				},
 				{
 					postId: 147594,
 					url: localizeUrl( 'https://wordpress.com/support/wordpress-editor/#configuring-a-block' ),
 					text: translate( 'Adjust settings of blocks' ),
 					icon: 'video',
-					tracksEvent: 'calypso_customer_home_adjust_blocks_support_page_view',
-					statsName: 'view_adjust_blocks_video',
 				},
 			] }
 			illustration={ gutenbergIllustration }
+			cardName={ EDUCATION_GUTENBERG }
 		/>
 	);
 };


### PR DESCRIPTION
This PR adds generic analytics tracking to the Education card in Customer Home, making it easier for folks to add new cards.

New events are `calypso_customer_home_education` for tracks, passing through the `url` and `card_name`. We also still track a stats event of card name under the grouping `calypso_customer_home`

<img width="654" alt="Screen Shot 2020-06-08 at 4 34 41 PM" src="https://user-images.githubusercontent.com/1270189/84092298-cbaf8180-a9ab-11ea-806a-5172cd9160a0.png">

### Testing Instructions
- Visit /home and select a site
- Dismiss all task cards to get to the default view
- In development console type: ```localStorage.debug = 'calypso:analytics*'```
- Refresh the page
- Click on the educational card links. We should see the following events fire in console:
<img width="1158" alt="Screen Shot 2020-06-08 at 4 33 14 PM" src="https://user-images.githubusercontent.com/1270189/84092292-c81bfa80-a9ab-11ea-9aa1-babf32bddf21.png">
<img width="1182" alt="Screen Shot 2020-06-08 at 4 33 51 PM" src="https://user-images.githubusercontent.com/1270189/84092295-c94d2780-a9ab-11ea-94f3-46c62bf20cba.png">
<img width="1175" alt="Screen Shot 2020-06-08 at 4 34 10 PM" src="https://user-images.githubusercontent.com/1270189/84092296-ca7e5480-a9ab-11ea-8114-10ea50ff7e6d.png">
<img width="1404" alt="Screen Shot 2020-06-08 at 5 07 06 PM" src="https://user-images.githubusercontent.com/1270189/84092299-cbaf8180-a9ab-11ea-8502-6231648a0290.png">
- When clicking on the earn card, we should see one redux event firing with expected analytics meta
<img width="1005" alt="Screen Shot 2020-06-08 at 5 08 05 PM" src="https://user-images.githubusercontent.com/1270189/84092301-cc481800-a9ab-11ea-864d-c51bec05dc2a.png">

### Note

I still need to test the external link option. If I didn't get this right, @mmtr or anyone else who's interested feel free to hop into the branch to update directly.

Fixes https://github.com/Automattic/wp-calypso/issues/42811