### PR TITLE
Earn: Add a plans check to the Donations block.

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/donations/donations-tabs.js
+++ b/apps/full-site-editing/full-site-editing-plugin/donations/donations-tabs.js
@@ -10,10 +10,6 @@ import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 
-/**
- * Internal dependencies
- */
-
 const DonationsTabs = () => {
 	const [ activeTab, setActiveTab ] = useState( 'one-time' );
 

--- a/apps/full-site-editing/full-site-editing-plugin/donations/donations-tabs.js
+++ b/apps/full-site-editing/full-site-editing-plugin/donations/donations-tabs.js
@@ -1,0 +1,55 @@
+/**
+ * External dependencies
+ */
+import classNames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+
+const DonationsTabs = () => {
+	const [ activeTab, setActiveTab ] = useState( 'one-time' );
+
+	const isActive = ( button ) => ( activeTab === button ? 'active' : null );
+
+	return (
+		<div className="donations__container">
+			<Button className={ isActive( 'one-time' ) } onClick={ () => setActiveTab( 'one-time' ) }>
+				{ __( 'One-Time', 'full-site-editing' ) }
+			</Button>
+			<Button className={ isActive( 'monthly' ) } onClick={ () => setActiveTab( 'monthly' ) }>
+				{ __( 'Monthly', 'full-site-editing' ) }
+			</Button>
+			<Button className={ isActive( 'annually' ) } onClick={ () => setActiveTab( 'annually' ) }>
+				{ __( 'Annually', 'full-site-editing' ) }
+			</Button>
+			<div
+				id="donations__tab-one-time"
+				className={ classNames( 'donations__tab', { active: isActive( 'one-time' ) } ) }
+			>
+				{ __( 'One time', 'full-site-editing' ) }
+			</div>
+			<div
+				id="donations__tab-monthly"
+				className={ classNames( 'donations__tab', { active: isActive( 'monthly' ) } ) }
+			>
+				{ __( 'Monthly', 'full-site-editing' ) }
+			</div>
+			<div
+				id="donations__tab-annually"
+				className={ classNames( 'donations__tab', { active: isActive( 'annually' ) } ) }
+			>
+				{ __( 'Annually', 'full-site-editing' ) }
+			</div>
+		</div>
+	);
+};
+
+export default DonationsTabs;

--- a/apps/full-site-editing/full-site-editing-plugin/donations/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/donations/edit.js
@@ -1,8 +1,4 @@
 /**
- * External dependencies
- */
-
-/**
  * WordPress dependencies
  */
 import { useState, useEffect } from '@wordpress/element';

--- a/apps/full-site-editing/full-site-editing-plugin/donations/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/donations/edit.js
@@ -39,11 +39,10 @@ const Edit = () => {
 		setIsLoading( false );
 	};
 
-	const updateData = () => {
-		fetchStatus().then( mapStatusToState, apiError );
-	};
-
-	useEffect( () => updateData() );
+	useEffect( () => {
+		const updateData = () => fetchStatus().then( mapStatusToState, apiError );
+		updateData();
+	}, [] );
 
 	if ( isLoading ) {
 		return <LoadingStatus />;

--- a/apps/full-site-editing/full-site-editing-plugin/donations/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/donations/edit.js
@@ -1,55 +1,57 @@
 /**
  * External dependencies
  */
-import classNames from 'classnames';
 
 /**
  * WordPress dependencies
  */
-import { useState } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
-import { Button } from '@wordpress/components';
+import { useState, useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
+import DonationsTabs from './donations-tabs';
+import LoadingError from './loading-error';
+import LoadingStatus from './loading-status';
+import UpgradePlan from './upgrade-plan';
+import fetchStatus from './fetch-status';
 
 const Edit = () => {
-	const [ activeTab, setActiveTab ] = useState( 'one-time' );
+	const [ isLoading, setIsLoading ] = useState( true );
+	const [ loadingError, setLoadingError ] = useState( '' );
+	const [ shouldUpgrade, setShouldUpgrade ] = useState( false );
+	const [ upgradeUrl, setUpgradeUrl ] = useState( '' );
 
-	const isActive = ( button ) => ( activeTab === button ? 'active' : null );
+	const mapStatusToState = ( result ) => {
+		setShouldUpgrade( result.should_upgrade_to_access_memberships );
+		setUpgradeUrl( result.upgrade_url );
+		setIsLoading( false );
+	};
 
-	return (
-		<div className="donations__container">
-			<Button className={ isActive( 'one-time' ) } onClick={ () => setActiveTab( 'one-time' ) }>
-				{ __( 'One-Time', 'full-site-editing' ) }
-			</Button>
-			<Button className={ isActive( 'monthly' ) } onClick={ () => setActiveTab( 'monthly' ) }>
-				{ __( 'Monthly', 'full-site-editing' ) }
-			</Button>
-			<Button className={ isActive( 'annually' ) } onClick={ () => setActiveTab( 'annually' ) }>
-				{ __( 'Annually', 'full-site-editing' ) }
-			</Button>
-			<div
-				id="donations__tab-one-time"
-				className={ classNames( 'donations__tab', { active: isActive( 'one-time' ) } ) }
-			>
-				{ __( 'One time', 'full-site-editing' ) }
-			</div>
-			<div
-				id="donations__tab-monthly"
-				className={ classNames( 'donations__tab', { active: isActive( 'monthly' ) } ) }
-			>
-				{ __( 'Monthly', 'full-site-editing' ) }
-			</div>
-			<div
-				id="donations__tab-annually"
-				className={ classNames( 'donations__tab', { active: isActive( 'annually' ) } ) }
-			>
-				{ __( 'Annually', 'full-site-editing' ) }
-			</div>
-		</div>
-	);
+	const apiError = ( message ) => {
+		setLoadingError( message );
+		setIsLoading( false );
+	};
+
+	const updateData = () => {
+		fetchStatus().then( mapStatusToState, apiError );
+	};
+
+	useEffect( () => updateData() );
+
+	if ( isLoading ) {
+		return <LoadingStatus />;
+	}
+
+	if ( loadingError ) {
+		return <LoadingError error={ loadingError } />;
+	}
+
+	if ( shouldUpgrade ) {
+		return <UpgradePlan upgradeUrl={ upgradeUrl } />;
+	}
+
+	return <DonationsTabs />;
 };
 
 export default Edit;

--- a/apps/full-site-editing/full-site-editing-plugin/donations/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/donations/edit.js
@@ -6,6 +6,7 @@
  * WordPress dependencies
  */
 import { useState, useEffect } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -23,8 +24,13 @@ const Edit = () => {
 	const [ upgradeUrl, setUpgradeUrl ] = useState( '' );
 
 	const mapStatusToState = ( result ) => {
-		setShouldUpgrade( result.should_upgrade_to_access_memberships );
-		setUpgradeUrl( result.upgrade_url );
+		if ( ( ! result && typeof result !== 'object' ) || result.errors ) {
+			setLoadingError( __( 'Could not load data from WordPress.com.', 'full-site-editing' ) );
+		} else {
+			setShouldUpgrade( result.should_upgrade_to_access_memberships );
+			setUpgradeUrl( result.upgrade_url );
+		}
+
 		setIsLoading( false );
 	};
 

--- a/apps/full-site-editing/full-site-editing-plugin/donations/fetch-status.js
+++ b/apps/full-site-editing/full-site-editing-plugin/donations/fetch-status.js
@@ -1,0 +1,26 @@
+/**
+ * External dependencies
+ */
+
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Internal dependencies
+ */
+
+const fetchStatus = async () => {
+	try {
+		const result = await apiFetch( {
+			path: '/wpcom/v2/memberships/status',
+			method: 'GET',
+		} );
+		return result;
+	} catch ( error ) {
+		return Promise.reject( error.message );
+	}
+};
+
+export default fetchStatus;

--- a/apps/full-site-editing/full-site-editing-plugin/donations/fetch-status.js
+++ b/apps/full-site-editing/full-site-editing-plugin/donations/fetch-status.js
@@ -1,15 +1,8 @@
-/**
- * External dependencies
- */
-
+/* eslint-disable wpcalypso/import-docblock */
 /**
  * WordPress dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
-
-/**
- * Internal dependencies
- */
 
 const fetchStatus = async () => {
 	try {

--- a/apps/full-site-editing/full-site-editing-plugin/donations/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/donations/index.js
@@ -1,4 +1,3 @@
-/* eslint-disable wpcalypso/import-docblock */
 /**
  * WordPress dependencies
  */

--- a/apps/full-site-editing/full-site-editing-plugin/donations/loading-error.js
+++ b/apps/full-site-editing/full-site-editing-plugin/donations/loading-error.js
@@ -1,16 +1,9 @@
-/**
- * External dependencies
- */
-
+/* eslint-disable wpcalypso/import-docblock */
 /**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { Placeholder } from '@wordpress/components';
-
-/**
- * Internal dependencies
- */
 
 const LoadingError = ( { error } ) => {
 	return (

--- a/apps/full-site-editing/full-site-editing-plugin/donations/loading-error.js
+++ b/apps/full-site-editing/full-site-editing-plugin/donations/loading-error.js
@@ -1,0 +1,27 @@
+/**
+ * External dependencies
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Placeholder } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+
+const LoadingError = ( { error } ) => {
+	return (
+		<div className="donations__loading-status">
+			<Placeholder
+				icon="lock"
+				label={ __( 'Donations', 'full-site-editing' ) }
+				instructions={ error }
+			></Placeholder>
+		</div>
+	);
+};
+
+export default LoadingError;

--- a/apps/full-site-editing/full-site-editing-plugin/donations/loading-status.js
+++ b/apps/full-site-editing/full-site-editing-plugin/donations/loading-status.js
@@ -1,16 +1,9 @@
-/**
- * External dependencies
- */
-
+/* eslint-disable wpcalypso/import-docblock */
 /**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { Placeholder, Spinner } from '@wordpress/components';
-
-/**
- * Internal dependencies
- */
 
 const LoadingStatus = () => {
 	return (

--- a/apps/full-site-editing/full-site-editing-plugin/donations/loading-status.js
+++ b/apps/full-site-editing/full-site-editing-plugin/donations/loading-status.js
@@ -1,0 +1,29 @@
+/**
+ * External dependencies
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Placeholder, Spinner } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+
+const LoadingStatus = () => {
+	return (
+		<div className="donations__loading-status">
+			<Placeholder
+				icon="lock"
+				label={ __( 'Donations', 'full-site-editing' ) }
+				instructions={ __( 'Loading data…', 'full-site-editing' ) }
+			>
+				<Spinner />
+			</Placeholder>
+		</div>
+	);
+};
+
+export default LoadingStatus;

--- a/apps/full-site-editing/full-site-editing-plugin/donations/upgrade-plan.js
+++ b/apps/full-site-editing/full-site-editing-plugin/donations/upgrade-plan.js
@@ -1,16 +1,9 @@
-/**
- * External dependencies
- */
-
+/* eslint-disable wpcalypso/import-docblock */
 /**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { Button, ExternalLink, Placeholder } from '@wordpress/components';
-
-/**
- * Internal dependencies
- */
 
 const UpgradePlan = ( { upgradeUrl } ) => {
 	return (

--- a/apps/full-site-editing/full-site-editing-plugin/donations/upgrade-plan.js
+++ b/apps/full-site-editing/full-site-editing-plugin/donations/upgrade-plan.js
@@ -24,10 +24,6 @@ const UpgradePlan = ( { upgradeUrl } ) => {
 				) }
 			>
 				<Button
-					/**
-					 * @see https://github.com/DefinitelyTyped/DefinitelyTyped/pull/42883
-					 */
-					// @ts-ignore isSecondary is missing from the type definition
 					isSecondary
 					isLarge
 					href={ upgradeUrl }

--- a/apps/full-site-editing/full-site-editing-plugin/donations/upgrade-plan.js
+++ b/apps/full-site-editing/full-site-editing-plugin/donations/upgrade-plan.js
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Button, ExternalLink, Placeholder } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+
+const UpgradePlan = ( { upgradeUrl } ) => {
+	return (
+		<div className={ 'donations__upgrade-plan' }>
+			<Placeholder
+				icon="lock"
+				label={ __( 'Donations', 'full-site-editing' ) }
+				instructions={ __(
+					"You'll need to upgrade your plan to use the Donations block.",
+					'full-site-editing'
+				) }
+			>
+				<Button
+					/**
+					 * @see https://github.com/DefinitelyTyped/DefinitelyTyped/pull/42883
+					 */
+					// @ts-ignore isSecondary is missing from the type definition
+					isSecondary
+					isLarge
+					href={ upgradeUrl }
+					target="_blank"
+					className="donations__button plan-nudge__button"
+				>
+					{ __( 'Upgrade Your Plan', 'full-site-editing' ) }
+				</Button>
+				<div className="donations__disclaimer membership-button__disclaimer">
+					<ExternalLink href="https://wordpress.com/support/donations-block/">
+						{ __( 'Read more about Donations and related fees.', 'full-site-editing' ) }
+					</ExternalLink>
+				</div>
+			</Placeholder>
+		</div>
+	);
+};
+
+export default UpgradePlan;


### PR DESCRIPTION
This PR adds a check for a valid plan when inserting the Donations block, and displays a prompt to upgrade if the user is required to do so. Based on the Premium Content block process.

<img width="826" alt="Screen Shot 2020-06-10 at 3 35 51 PM" src="https://user-images.githubusercontent.com/349751/84325681-2a9e0380-ab30-11ea-9a4d-0fe490ac27d9.png">
<img width="886" alt="Screen Shot 2020-06-10 at 3 34 42 PM" src="https://user-images.githubusercontent.com/349751/84325689-2f62b780-ab30-11ea-8660-82acc6eb49b1.png">

See: #42856 

#### Testing instructions

* On this branch locally, run `yarn dev --sync` to sync the changes to your sandbox.
* Sandbox the API, and a test site that has no plan.
* On that test site, start a new post at `/wp-admin/post-new.php`.
* Add a Donations block.
* Verify the Donations block loads with a spinner while making a call to `https://public-api.wordpress.com/wpcom/v2/sites/:site_id/memberships/status`.
* When the API call completes, the block should display the upgrade prompt.
* Check the API error state by misspelling the endpoint – this should trigger it properly.
* Click the upgrade button and complete the upgrade process for a Personal plan.
* Back in the editor tab, reload the editor.
* Verify the empty Donations tabs display after the network call/spinner display.
