### PR TITLE
Add error handling for new site creation failure modes

### DIFF
--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -50,6 +50,7 @@ const Header: React.FunctionComponent = () => {
 		'DomainsModal',
 		'Plans',
 		'PlansModal',
+		'CreateSite',
 	].includes( currentStep );
 
 	return (

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -53,6 +53,9 @@ const Header: React.FunctionComponent = () => {
 		'CreateSite',
 	].includes( currentStep );
 
+	// CreateSite step clears state before redirecting, don't show the default text in this case
+	const siteTitleDefault = 'CreateSite' === currentStep ? '' : __( 'Start your website' );
+
 	return (
 		<div
 			className="gutenboarding__header"
@@ -72,7 +75,7 @@ const Header: React.FunctionComponent = () => {
 				</div>
 				<div className="gutenboarding__header-section-item gutenboarding__header-site-title-section">
 					<div className="gutenboarding__header-site-title">
-						{ siteTitle ? siteTitle : __( 'Start your website' ) }
+						{ siteTitle ? siteTitle : siteTitleDefault }
 					</div>
 				</div>
 				<div className="gutenboarding__header-section-item gutenboarding__header-domain-section">

--- a/client/landing/gutenboarding/onboarding-block/colors.scss
+++ b/client/landing/gutenboarding/onboarding-block/colors.scss
@@ -7,7 +7,9 @@
 	.design-selector,
 	.style-preview,
 	.plans,
-	.domains {
+	.domains,
+	.create-site,
+	.create-site-error {
 		--contrastColor: var( --studio-white );
 		// TODO: This should be Gutenberg's main color
 		--mainColor: var( --studio-gray-100 );

--- a/client/landing/gutenboarding/onboarding-block/create-site-error/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/create-site-error/index.tsx
@@ -1,0 +1,58 @@
+/**
+ * External dependencies
+ */
+import { createInterpolateElement } from '@wordpress/element';
+import { ExternalLink } from '@wordpress/components';
+import React, { FunctionComponent, useEffect } from 'react';
+import { useDispatch } from '@wordpress/data';
+import { useI18n } from '@automattic/react-i18n';
+
+/**
+ * Internal dependencies
+ */
+import Link from '../../components/link';
+import { localizeUrl } from 'lib/i18n-utils';
+import { SITE_STORE } from '../../stores/site';
+import { Title, SubTitle } from '../../components/titles';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+interface Props {
+	linkTo: string;
+}
+
+const CreateSiteError: FunctionComponent< Props > = ( { linkTo } ) => {
+	const { __ } = useI18n();
+
+	const { resetNewSiteFailed } = useDispatch( SITE_STORE );
+
+	useEffect( () => resetNewSiteFailed );
+
+	return (
+		<div className="create-site-error">
+			<Title>{ __( 'Something went wrong…' ) }</Title>
+			<SubTitle>
+				{ createInterpolateElement(
+					__(
+						'Please go back and try again. If the problem continues, <link_to_support>please contact our support team.</link_to_support>'
+					),
+					{
+						link_to_support: (
+							<ExternalLink href={ localizeUrl( 'https://wordpress.com/support/contact/' ) } />
+						),
+					}
+				) }
+			</SubTitle>
+			<div className="create-site-error__links">
+				<Link isPrimary to={ linkTo }>
+					{ __( 'Go Back' ) }
+				</Link>
+			</div>
+		</div>
+	);
+};
+
+export default CreateSiteError;

--- a/client/landing/gutenboarding/onboarding-block/create-site-error/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/create-site-error/style.scss
@@ -1,0 +1,24 @@
+@import 'assets/stylesheets/gutenberg-base-styles';
+@import '../../mixins';
+
+.create-site-error {
+	max-width: 540px;
+
+	// Match margin of plans grid title
+	margin: 44px 0 50px;
+
+	// desktop: Match height alignment of CreateSite
+	@include break-mobile {
+		margin: 30vh auto auto 10vw;
+	}
+
+	// Match link to error text color, prevent purple links
+	.components-external-link {
+		color: var( --studio-gray-60 );
+	}
+
+	// Space between link and Subtitle
+	.create-site-error__links {
+		margin: 1em 0;
+	}
+}

--- a/client/landing/gutenboarding/onboarding-block/create-site/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/create-site/index.tsx
@@ -4,7 +4,6 @@
 import * as React from 'react';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@automattic/react-i18n';
-import { Icon, wordpress } from '@wordpress/icons';
 import { useSelect } from '@wordpress/data';
 import { useInterval } from '../../../../lib/interval/use-interval';
 
@@ -14,6 +13,10 @@ import { useInterval } from '../../../../lib/interval/use-interval';
 import { useSelectedPlan } from '../../hooks/use-selected-plan';
 import { useTrackStep } from '../../hooks/use-track-step';
 import { STORE_KEY } from '../../stores/onboard';
+
+/**
+ * Style dependencies
+ */
 import './style.scss';
 
 // Total time to perform "loading"
@@ -58,40 +61,25 @@ const CreateSite: React.FunctionComponent = () => {
 	}, [] );
 
 	return (
-		<div className="gutenboarding-page create-site__background">
-			<div className="create-site__layout">
-				<div className="create-site__header">
-					<div className="gutenboarding__header-wp-logo">
-						<Icon icon={ wordpress } size={ 28 } />
-					</div>
-				</div>
-				<div className="create-site__content">
-					<div className="create-site__progress">
-						<div className="create-site__progress-steps">
-							<div className="create-site__progress-step">{ steps.current[ currentStep ] }</div>
-						</div>
-					</div>
-					<div
-						className="create-site__progress-bar"
-						style={
-							{
-								'--progress': ! hasStarted ? /* initial 10% progress */ 0.1 : progress,
-							} as React.CSSProperties
-						}
-					/>
-					<div className="create-site__progress-numbered-steps">
-						<p>
-							{
-								// translators: these are progress steps. Eg: step 1 of 4.
-								sprintf( __( 'Step %(currentStep)d of %(totalSteps)d' ), {
-									currentStep: currentStep + 1,
-									totalSteps,
-								} )
-							}
-						</p>
-					</div>
-				</div>
-			</div>
+		<div className="create-site">
+			<h1 className="create-site__progress-step">{ steps.current[ currentStep ] }</h1>
+			<div
+				className="create-site__progress-bar"
+				style={
+					{
+						'--progress': ! hasStarted ? /* initial 10% progress */ 0.1 : progress,
+					} as React.CSSProperties
+				}
+			/>
+			<p className="create-site__progress-numbered-steps">
+				{
+					// translators: these are progress steps. Eg: step 1 of 4.
+					sprintf( __( 'Step %(currentStep)d of %(totalSteps)d' ), {
+						currentStep: currentStep + 1,
+						totalSteps,
+					} )
+				}
+			</p>
 		</div>
 	);
 };

--- a/client/landing/gutenboarding/onboarding-block/create-site/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/create-site/style.scss
@@ -1,83 +1,48 @@
 @import 'assets/stylesheets/gutenberg-base-styles';
 @import '../../mixins';
+@import '../colors';
 
-$progress-step-title-height: 40px;
-$progress-step-number-step-height: 45px;
 $progress-duration: 800ms;
-$progress-widget-height: 300px;
 
-.create-site__background {
-	position: fixed;
-	top: 0;
-	left: 0;
-	right: 0;
-	bottom: 0;
-	z-index: 50;
-	background-color: $white;
+.create-site {
+	padding: 1em;
+	max-width: 540px;
 
-	&.gutenboarding-page {
-		max-width: none;
+	margin: 32vh auto;
+
+	.create-site__progress-bar {
+		position: relative;
+		overflow: hidden;
+		height: 6px;
+		margin-top: 1em;
+		background: var( --studio-gray-10 );
+		--progress: 0;
+
+		&::before {
+			background: var( --studio-blue-40 );
+			transform: translateX( calc( -100% * min( 1 - var( --progress, 0 ), 1 ) ) );
+			position: absolute;
+			content: '';
+			top: 0;
+			left: 0;
+			right: 0;
+			bottom: 0;
+			transition: transform $progress-duration ease-out;
+		}
 	}
 
-	.create-site__header {
-		display: flex;
-		justify-content: space-between;
-		align-items: center;
-		height: 56px;
-		padding: 8px;
+	.create-site__progress-step {
+		@include onboarding-heading-text-mobile;
+
+		text-align: center;
+		vertical-align: middle;
+		margin: 0;
 	}
 
-	.create-site__content {
-		position: absolute;
-		top: calc( 50% - #{$progress-widget-height / 4} );
-		left: 50%;
-		width: 100%;
-		max-width: 540px;
-		height: $progress-widget-height;
-		transform: translateX( -50% );
-		// for mobiles
+	.create-site__progress-numbered-steps {
+		margin-top: 0.7em;
 		padding: 1em;
-
-		.create-site__progress {
-			margin-bottom: 20px;
-		}
-
-		.create-site__progress-bar {
-			position: relative;
-			overflow: hidden;
-			height: 6px;
-			margin-top: 1em;
-			background: var( --studio-gray-10 );
-			--progress: 0;
-
-			&::before {
-				background: var( --studio-blue-40 );
-				transform: translateX( calc( -100% * min( 1 - var( --progress, 0 ), 1 ) ) );
-				position: absolute;
-				content: '';
-				top: 0;
-				left: 0;
-				right: 0;
-				bottom: 0;
-				transition: transform $progress-duration ease-out;
-			}
-		}
-
-		.create-site__progress-step {
-			@include onboarding-heading-text-mobile;
-			text-align: center;
-			vertical-align: middle;
-			margin: 0;
-		}
-
-		.create-site__progress-numbered-steps {
-			margin-top: 0.7em;
-
-			> p {
-				padding: 1em;
-				text-align: center;
-				color: var( --studio-gray-40 );
-			}
-		}
+		text-align: center;
+		color: var( --studio-gray-40 );
 	}
 }

--- a/client/landing/gutenboarding/onboarding-block/edit.tsx
+++ b/client/landing/gutenboarding/onboarding-block/edit.tsx
@@ -14,6 +14,7 @@ import { SITE_STORE } from '../stores/site';
 import { USER_STORE } from '../stores/user';
 import DesignSelector from './design-selector';
 import CreateSite from './create-site';
+import CreateSiteError from './create-site-error';
 import type { Attributes } from './types';
 import { Step, usePath, useNewQueryParam } from '../path';
 import AcquireIntent from './acquire-intent';
@@ -30,6 +31,7 @@ const OnboardingEdit: FunctionComponent< BlockEditProps< Attributes > > = () => 
 	const { createSite } = useDispatch( STORE_KEY );
 	const isRedirecting = useSelect( ( select ) => select( STORE_KEY ).getIsRedirecting() );
 	const isCreatingSite = useSelect( ( select ) => select( SITE_STORE ).isFetchingSite() );
+	const newSiteError = useSelect( ( select ) => select( SITE_STORE ).getNewSiteError() );
 	const newSite = useSelect( ( select ) => select( SITE_STORE ).getNewSite() );
 	const currentUser = useSelect( ( select ) => select( USER_STORE ).getCurrentUser() );
 	const shouldTriggerCreate = useNewQueryParam();
@@ -89,6 +91,16 @@ const OnboardingEdit: FunctionComponent< BlockEditProps< Attributes > > = () => 
 
 	const redirectToLatestStep = <Redirect to={ getLatestStepPath() } />;
 
+	function createSiteOrError() {
+		if ( newSiteError ) {
+			return <CreateSiteError linkTo={ getLatestStepPath() } />;
+		} else if ( canUseCreateSiteStep() ) {
+			return <CreateSite />;
+		}
+
+		return redirectToLatestStep;
+	}
+
 	return (
 		<div className="onboarding-block">
 			{ isCreatingSite && (
@@ -126,9 +138,7 @@ const OnboardingEdit: FunctionComponent< BlockEditProps< Attributes > > = () => 
 					<Plans isModal />
 				</Route>
 
-				<Route path={ makePath( Step.CreateSite ) }>
-					{ canUseCreateSiteStep() ? <CreateSite /> : redirectToLatestStep }
-				</Route>
+				<Route path={ makePath( Step.CreateSite ) }>{ createSiteOrError() }</Route>
 			</Switch>
 		</div>
 	);

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -79,10 +79,15 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		type: 'RESET_SITE_STORE' as const,
 	} );
 
+	const resetNewSiteFailed = () => ( {
+		type: 'RESET_RECEIVE_NEW_SITE_FAILED' as const,
+	} );
+
 	return {
 		fetchNewSite,
 		receiveNewSite,
 		receiveNewSiteFailed,
+		resetNewSiteFailed,
 		createSite,
 		receiveSite,
 		receiveSiteFailed,
@@ -100,6 +105,7 @@ export type Action =
 			| ActionCreators[ 'receiveSite' ]
 			| ActionCreators[ 'receiveSiteFailed' ]
 			| ActionCreators[ 'reset' ]
+			| ActionCreators[ 'resetNewSiteFailed' ]
 	  >
 	// Type added so we can dispatch actions in tests, but has no runtime cost
 	| { type: 'TEST_ACTION' };

--- a/packages/data-stores/src/site/reducer.ts
+++ b/packages/data-stores/src/site/reducer.ts
@@ -30,6 +30,7 @@ export const newSiteError: Reducer< NewSiteErrorResponse | undefined, Action > =
 		case 'FETCH_NEW_SITE':
 		case 'RECEIVE_NEW_SITE':
 		case 'RESET_SITE_STORE':
+		case 'RESET_RECEIVE_NEW_SITE_FAILED':
 			return undefined;
 		case 'RECEIVE_NEW_SITE_FAILED':
 			return {
@@ -50,6 +51,7 @@ export const isFetchingSite: Reducer< boolean | undefined, Action > = ( state = 
 		case 'RECEIVE_NEW_SITE':
 		case 'RECEIVE_NEW_SITE_FAILED':
 		case 'RESET_SITE_STORE':
+		case 'RESET_RECEIVE_NEW_SITE_FAILED':
 			return false;
 	}
 	return state;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Displays an error message if create site returns with an error.

#### Testing instructions

Full flow:
* Apply D44621-code
* Attempt to create a site using http://calypso.localhost:3000/new
* Clicking `Continue` on the `/new/plans` step should begin showing `<CreateSite />` before transitioning to the error message showing a "Go Back" button to return to the last known good step.

Error only:
* `ENTRY_LIMIT=entry-gutenboarding yarn start`
* Visit http://calypso.localhost:3000/new/error (I'll remove this route before merge)

Mobile:
![Peek 2020-06-15 13-57-mobile](https://user-images.githubusercontent.com/811776/84618126-94455580-af14-11ea-8541-8e62c541122c.gif)

Desktop:
![Peek 2020-06-15 13-54](https://user-images.githubusercontent.com/811776/84618118-8f80a180-af14-11ea-9cf0-cc0ce8387d1f.gif)

Fixes #41067