### PR TITLE
Reader: Add Link to Manage Comments

### DIFF
--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -228,7 +228,7 @@ class PostCommentList extends React.Component {
 	};
 
 	renderCommentManageLink = () => {
-		const { siteId, postId, translate } = this.props;
+		const { siteId, postId } = this.props;
 
 		if ( ! siteId || ! postId ) {
 			return null;

--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -228,8 +228,11 @@ class PostCommentList extends React.Component {
 	};
 
 	renderCommentManageLink = () => {
-		const siteId = get( this.props, 'post.site_ID' );
-		const postId = get( this.props, 'post.ID' );
+		const { siteId, postId, translate } = this.props;
+
+		if ( ! siteId || ! postId ) {
+			return null;
+		}
 
 		return (
 			<Button
@@ -238,7 +241,7 @@ class PostCommentList extends React.Component {
 				borderless
 			>
 				<Gridicon icon="chat" />
-				<span>{ this.props.translate( 'Manage', { context: 'manage comments' } ) }</span>
+				<span>{ translate( 'Manage', { context: 'manage comments' } ) }</span>
 			</Button>
 		);
 	};

--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -241,7 +241,7 @@ class PostCommentList extends React.Component {
 				borderless
 			>
 				<Gridicon icon="chat" />
-				<span>{ translate( 'Manage comments', { context: 'links to Comments' } ) }</span>
+				<span>{ translate( 'Manage comments' ) }</span>
 			</Button>
 		);
 	};

--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -241,7 +241,7 @@ class PostCommentList extends React.Component {
 				borderless
 			>
 				<Gridicon icon="chat" />
-				<span>{ translate( 'Manage', { context: 'manage comments' } ) }</span>
+				<span>{ translate( 'Manage comments', { context: 'links to Comments' } ) }</span>
 			</Button>
 		);
 	};
@@ -418,18 +418,6 @@ class PostCommentList extends React.Component {
 
 		return (
 			<div className="comments__comment-list">
-				<div>
-					{ showConversationFollowButton && (
-						<ConversationFollowButton
-							className="comments__conversation-follow-button"
-							siteId={ siteId }
-							postId={ postId }
-							post={ this.props.post }
-							followSource={ followSource }
-						/>
-					) }
-					{ showManageCommentsButton && this.renderCommentManageLink() }
-				</div>
 				{ ( this.props.showCommentCount || showViewMoreComments ) && (
 					<div className="comments__info-bar">
 						{ this.props.showCommentCount && <CommentCount count={ actualCommentsCount } /> }
@@ -445,6 +433,18 @@ class PostCommentList extends React.Component {
 						) }
 					</div>
 				) }
+				<div className="comments__actions-wrapper">
+					{ showConversationFollowButton && (
+						<ConversationFollowButton
+							className="comments__conversation-follow-button"
+							siteId={ siteId }
+							postId={ postId }
+							post={ this.props.post }
+							followSource={ followSource }
+						/>
+					) }
+					{ showManageCommentsButton && this.renderCommentManageLink() }
+				</div>
 				{ showFilters && (
 					<SegmentedControl compact primary>
 						<SegmentedControl.Item

--- a/client/blocks/comments/post-comment-list.scss
+++ b/client/blocks/comments/post-comment-list.scss
@@ -13,6 +13,20 @@
 		float: right;
 		margin-top: 4px;
 	}
+
+	.button.comments__manage-comments-button {
+		color: inherit;
+		float: right;
+		margin-top: -2px;
+		margin-right: 14px;
+		padding: 0;
+
+		@include breakpoint-deprecated( '<660px' ) {
+			span {
+				display: none;
+			}
+		}
+	}
 }
 
 .comments__info-bar {

--- a/client/blocks/comments/post-comment-list.scss
+++ b/client/blocks/comments/post-comment-list.scss
@@ -12,14 +12,23 @@
 	.comments__conversation-follow-button {
 		float: right;
 		margin-top: 4px;
+		margin-left: 14px;
+		text-align: right;
+	}
+
+	.comments__actions-wrapper {
+		text-align: right;
+		width: 100%;
 	}
 
 	.button.comments__manage-comments-button {
 		color: inherit;
-		float: right;
 		margin-top: -2px;
-		margin-right: 14px;
 		padding: 0;
+
+		.gridicon {
+			top: 8px;
+		}
 
 		@include breakpoint-deprecated( '<660px' ) {
 			span {
@@ -30,8 +39,8 @@
 }
 
 .comments__info-bar {
-	margin: 0 24px -24px 0;
-	overflow: auto;
+	margin: 0 8px -8px 0;
+	width: 100%;
 
 	&.is-no-comments {
 		display: none;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This adds a link to the Comments page from the Reader

#### Testing instructions

Verify that button's design is okay and that it appears only for sites which the user is able to manage comments for and on posts where there are actually comments to manage. 

<img width="955" alt="Screenshot 2020-06-09 at 08 33 15" src="https://user-images.githubusercontent.com/43215253/84119421-3c967e00-aa2c-11ea-912b-4ec536a52f22.png">

cc @bluefuton, @gwwar, @jancavan (based on the initial issue - sorry if wrong people!)

Fixes #19720
