### PR TITLE
Remove modularised application from login store

### DIFF
--- a/client/landing/login/store.js
+++ b/client/landing/login/store.js
@@ -11,7 +11,6 @@ import wpcomApiMiddleware from 'state/data-layer/wpcom-api-middleware';
 import analyticsMiddleware from 'state/analytics/middleware';
 import { reducer as httpData, enhancer as httpDataEnhancer } from 'state/data-layer/http-data';
 import { combineReducers, addReducerEnhancer } from 'state/utils';
-import application from 'state/application/reducer';
 import documentHead from 'state/document-head/reducer';
 import language from 'state/ui/language/reducer';
 import route from 'state/ui/route/reducer';
@@ -27,7 +26,6 @@ import oauth2Clients from 'state/oauth2-clients/reducer';
 // Legacy reducers
 // The reducers in this list are not modularized, and are always loaded on boot.
 const rootReducer = combineReducers( {
-	application,
 	documentHead,
 	httpData,
 	notices,


### PR DESCRIPTION
This was an oversight, and should have been removed with the application modularisation PR (#42753).

It does not appear to cause any issues in production, but it should be fixed as soon as possible.

#### Changes proposed in this Pull Request

* Remove `application` reducer from login Redux store

#### Testing instructions

Ensure that basic login functionality continues to work correctly.
