### PR TITLE
Remove server aliasing of `lib/user`

### DIFF
--- a/client/lib/abtest/index.js
+++ b/client/lib/abtest/index.js
@@ -63,7 +63,7 @@ export const saveABTestVariation = ( name, variation ) =>
 
 export const getAllTests = () => keys( activeTests ).map( ABTest );
 
-const isUserSignedIn = () => user() && user().get() !== false;
+const isUserSignedIn = () => user().get() !== false;
 
 const parseDateStamp = ( datestamp ) => {
 	const format = 'YYYYMMDD';
@@ -299,7 +299,7 @@ ABTest.prototype.hasBeenInPreviousSeriesTest = function () {
 };
 
 ABTest.prototype.hasRegisteredBeforeTestBegan = function () {
-	return user() && user().get() && new Date( user().get().date ) < new Date( this.startDate );
+	return user().get() && new Date( user().get().date ) < new Date( this.startDate );
 };
 
 ABTest.prototype.getSavedVariation = function () {
@@ -310,7 +310,7 @@ ABTest.prototype.assignVariation = function () {
 	let variationName, randomAllocationAmount;
 	let sum = 0;
 
-	const userId = user()?.get()?.ID;
+	const userId = user().get()?.ID;
 	const allocationsTotal = reduce(
 		this.variationDetails,
 		( allocations, allocation ) => {

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -143,7 +143,7 @@ const Flows = {
 			return flow;
 		}
 
-		if ( user() && user().get() ) {
+		if ( user().get() ) {
 			flow = removeUserStepFromFlow( flow );
 		}
 

--- a/client/signup/utils.js
+++ b/client/signup/utils.js
@@ -20,7 +20,7 @@ function isEligibleForSwapStepsTest() {
 	const countryCodeFromCookie = cookies.country_code;
 	const isUserFromUS = 'US' === countryCodeFromCookie;
 
-	if ( user() && user().get() && isUserFromUS && 'onboarding' === defaultFlowName ) {
+	if ( user().get() && isUserFromUS && 'onboarding' === defaultFlowName ) {
 		return true;
 	}
 

--- a/client/state/initial-state.js
+++ b/client/state/initial-state.js
@@ -94,7 +94,7 @@ function shouldAddSympathy() {
 // scenario where state data may have been stored without this
 // check being performed.
 function verifyStoredRootState( state ) {
-	const currentUserId = user()?.get()?.ID ?? null;
+	const currentUserId = user().get()?.ID ?? null;
 	const storedUserId = state?.currentUser?.id ?? null;
 
 	if ( currentUserId !== storedUserId ) {
@@ -159,7 +159,7 @@ export function getStateFromCache( reducer, subkey, forceLoggedOutUser = false )
 }
 
 function getReduxStateKey( forceLoggedOutUser = false ) {
-	return getReduxStateKeyForUserId( forceLoggedOutUser ? null : user()?.get()?.ID ?? null );
+	return getReduxStateKeyForUserId( forceLoggedOutUser ? null : user().get()?.ID ?? null );
 }
 
 function getReduxStateKeyForUserId( userId ) {

--- a/client/webpack.config.node.js
+++ b/client/webpack.config.node.js
@@ -135,7 +135,6 @@ const webpackConfig = {
 		} ),
 		new webpack.NormalModuleReplacementPlugin( /^lib[/\\]abtest$/, 'lodash/noop' ), // Depends on BOM
 		new webpack.NormalModuleReplacementPlugin( /^lib[/\\]analytics$/, 'lodash/noop' ), // Depends on BOM
-		new webpack.NormalModuleReplacementPlugin( /^lib[/\\]user$/, 'lodash/noop' ), // Depends on BOM
 		new webpack.NormalModuleReplacementPlugin(
 			/^my-sites[/\\]themes[/\\]theme-upload$/,
 			'components/empty-component'


### PR DESCRIPTION
This should no longer be necessary, as `lib/user` no longer has any browser-specific code on load.

This is a follow-up to #43069.

#### Changes proposed in this Pull Request

* Stop aliasing `lib/user` on the server build
* Update code to assume that `user()` always returns an object

#### Testing instructions

Ensure that server-side Calypso does not break.
