### PR TITLE
Modularise application passwords state

### DIFF
--- a/client/state/application-passwords/actions.js
+++ b/client/state/application-passwords/actions.js
@@ -14,6 +14,7 @@ import {
 import 'state/data-layer/wpcom/me/two-step/application-passwords';
 import 'state/data-layer/wpcom/me/two-step/application-passwords/delete';
 import 'state/data-layer/wpcom/me/two-step/application-passwords/new';
+import 'state/application-passwords/init';
 
 /**
  * Returns an action object to signal the request of the user's application passwords.

--- a/client/state/application-passwords/init.js
+++ b/client/state/application-passwords/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'state/redux-store';
+import reducer from './reducer';
+
+registerReducer( [ 'applicationPasswords' ], reducer );

--- a/client/state/application-passwords/package.json
+++ b/client/state/application-passwords/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/application-passwords/reducer.js
+++ b/client/state/application-passwords/reducer.js
@@ -12,7 +12,7 @@ import {
 	APPLICATION_PASSWORD_NEW_CLEAR,
 	APPLICATION_PASSWORDS_RECEIVE,
 } from 'state/action-types';
-import { combineReducers, withSchemaValidation } from 'state/utils';
+import { combineReducers, withSchemaValidation, withStorageKey } from 'state/utils';
 import { itemsSchema } from './schema';
 
 export const items = withSchemaValidation( itemsSchema, ( state = [], action ) => {
@@ -37,7 +37,9 @@ export const newPassword = ( state = null, action ) => {
 	}
 };
 
-export default combineReducers( {
+const combinedReducer = combineReducers( {
 	items,
 	newPassword,
 } );
+
+export default withStorageKey( 'applicationPasswords', combinedReducer );

--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -19,7 +19,6 @@ import account from './account/reducer';
 import accountRecovery from './account-recovery/reducer';
 import activePromotions from './active-promotions/reducer';
 import activityLog from './activity-log/reducer';
-import applicationPasswords from './application-passwords/reducer';
 import atomicTransfer from './atomic-transfer/reducer';
 import billingTransactions from './billing-transactions/reducer';
 import checklist from './checklist/reducer';
@@ -95,7 +94,6 @@ const reducers = {
 	accountRecovery,
 	activePromotions,
 	activityLog,
-	applicationPasswords,
 	atomicTransfer,
 	billingTransactions,
 	checklist,

--- a/client/state/selectors/get-application-passwords.js
+++ b/client/state/selectors/get-application-passwords.js
@@ -4,6 +4,11 @@
 import { get } from 'lodash';
 
 /**
+ * Internal dependencies
+ */
+import 'state/application-passwords/init';
+
+/**
  * Returns the application passwords of the current user.
  *
  * @param  {object} state Global state tree

--- a/client/state/selectors/get-new-application-password.js
+++ b/client/state/selectors/get-new-application-password.js
@@ -4,6 +4,11 @@
 import { get } from 'lodash';
 
 /**
+ * Internal dependencies
+ */
+import 'state/application-passwords/init';
+
+/**
  * Returns the application password that the user just created.
  *
  * @param  {object}  state Global state tree


### PR DESCRIPTION
This PR is one of many working on modularising state in Calypso. This one handles application passwords.

For more details on state modularisation, see the [modularised state documentation](https://github.com/Automattic/wp-calypso/blob/master/docs/modularized-state.md) and p4TIVU-9lM-p2.

Note: I added all the reviewers that GitHub suggested. Please feel free to ignore the review request or pull in someone else if you're not comfortable reviewing this PR. Thank you!

Fixes #42422.

#### Changes proposed in this Pull Request

* Modularise application passwords state

#### Testing instructions

* Install [Redux DevTools](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en).
* Open DevTools and switch to the Redux tab.
* Open `/read` on the live branch or your local copy of this branch.
* Click `State` on the top right to ensure you see all state, and not just the diff for the last action: 
![image](https://user-images.githubusercontent.com/409615/73774406-d3e87d80-477b-11ea-9f59-3e42cc00101f.png)
* Analyse the tree and note that there's no `applicationPasswords` key, even if you expand the list of keys. This indicates that the application passwords state hasn't been loaded yet.
* Click your avatar on the masterbar, followed by `Security` on the sidebar.
* Open the `Two-Step Authentications` tab.
* Verify that a `applicationPasswords` key is added with the application passwords state. This indicates that the application passwords state has now been loaded.
* Verify that application passwords-related functionality works normally. This indicates that I didn't mess up.