### PR TITLE
Initial work on a new Security Checkup feature.

### DIFF
--- a/client/me/security-checkup/index.jsx
+++ b/client/me/security-checkup/index.jsx
@@ -1,0 +1,417 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { Card } from '@automattic/components';
+import DocumentHead from 'components/data/document-head';
+import getConnectedApplications from 'state/selectors/get-connected-applications';
+import Main from 'components/main';
+import MaterialIcon from 'components/material-icon';
+import MeSidebarNavigation from 'me/sidebar-navigation';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
+import QueryAccountRecoverySettings from 'components/data/query-account-recovery-settings';
+import QueryConnectedApplications from 'components/data/query-connected-applications';
+import ReauthRequired from 'me/reauth-required';
+import SecuritySectionNav from 'me/security-section-nav';
+import twoStepAuthorization from 'lib/two-step-authorization';
+import VerticalNav from 'components/vertical-nav';
+import VerticalNavItem from 'components/vertical-nav/item';
+import {
+	getAccountRecoveryEmail,
+	getAccountRecoveryPhone,
+	isAccountRecoveryEmailActionInProgress,
+	isAccountRecoveryEmailValidated,
+	isAccountRecoveryPhoneActionInProgress,
+	isAccountRecoveryPhoneValidated,
+} from '../../state/account-recovery/settings/selectors';
+import {
+	getCurrentUserEmail,
+	isCurrentUserEmailVerified,
+} from '../../state/current-user/selectors';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+const SecurityCheckupNavigationItemContents = function ( props ) {
+	const { materialIcon, text, description } = props;
+	return (
+		<React.Fragment>
+			<MaterialIcon icon={ materialIcon } className="security-checkup__nav-item-icon" />
+			<div>
+				<div>{ text }</div>
+				<small>{ description }</small>
+			</div>
+		</React.Fragment>
+	);
+};
+
+const SecurityCheckupNavigationItem = function ( props ) {
+	const { path, onClick, external, materialIcon, text, description } = props;
+
+	return (
+		<VerticalNavItem
+			path={ path }
+			onClick={ onClick }
+			external={ external }
+			className="security-checkup__nav-item"
+		>
+			<SecurityCheckupNavigationItemContents
+				materialIcon={ materialIcon }
+				text={ text }
+				description={ description }
+			/>
+		</VerticalNavItem>
+	);
+};
+
+class SecurityCheckupComponent extends React.Component {
+	static propTypes = {
+		accountRecoveryEmail: PropTypes.oneOfType( [ PropTypes.bool, PropTypes.string ] ),
+		accountRecoveryEmailActionInProgress: PropTypes.bool,
+		accountRecoveryEmailValidated: PropTypes.bool,
+		accountRecoveryPhone: PropTypes.object,
+		accountRecoveryPhoneActionInProgress: PropTypes.bool,
+		accountRecoveryPhoneValidated: PropTypes.bool,
+		path: PropTypes.string,
+		primaryEmail: PropTypes.string,
+		primaryEmailVerified: PropTypes.bool,
+		translate: PropTypes.func.isRequired,
+		userSettings: PropTypes.object,
+	};
+
+	state = {
+		initialized: false,
+	};
+
+	componentDidMount() {
+		this.props.userSettings.on( 'change', this.onUserSettingsChange );
+		this.props.userSettings.fetchSettings();
+	}
+
+	componentWillUnmount() {
+		this.props.userSettings.off( 'change', this.onUserSettingsChange );
+	}
+
+	getOKIcon() {
+		return 'check_circle';
+	}
+
+	getWarningIcon() {
+		return 'info';
+	}
+
+	onUserSettingsChange = () => {
+		if ( ! this.state.initialized ) {
+			this.setState( {
+				initialized: true,
+			} );
+			return;
+		}
+
+		this.forceUpdate();
+	};
+
+	renderTitleCard() {
+		const { translate } = this.props;
+		return (
+			<Card compact={ true } className="security-checkup__title-card">
+				<h2>{ translate( 'Security Checkup' ) }</h2>
+				<div className="security-checkup__title-text">
+					{ translate(
+						'Please review this summary of your account security and recovery settings'
+					) }
+				</div>
+			</Card>
+		);
+	}
+
+	renderPlaceholderNavItem() {
+		return <VerticalNavItem isPlaceholder={ true } />;
+	}
+
+	renderConnectedApps() {
+		const { connectedApps, translate } = this.props;
+		if ( connectedApps === null ) {
+			return this.renderPlaceholderNavItem();
+		}
+
+		let connectedAppsDescription;
+		if ( ! connectedApps.length ) {
+			connectedAppsDescription = translate( 'You do not have any connected applications.' );
+		} else {
+			connectedAppsDescription = translate(
+				'You currently have %(numberOfApps)d connected application.',
+				'You currently have %(numberOfApps)d connected applications.',
+				{
+					count: connectedApps.length,
+					args: {
+						numberOfApps: connectedApps.length,
+					},
+				}
+			);
+		}
+
+		return (
+			<SecurityCheckupNavigationItem
+				path={ '/me/security/connected-applications' }
+				materialIcon={ this.getWarningIcon() }
+				text={ translate( 'Connected Apps' ) }
+				description={ connectedAppsDescription }
+			/>
+		);
+	}
+
+	renderAccountEmail() {
+		const { primaryEmail, primaryEmailVerified, translate } = this.props;
+
+		let icon, description;
+
+		if ( ! primaryEmailVerified ) {
+			icon = this.getWarningIcon();
+			description = translate(
+				'Your account email address is set to {{strong}}%(emailAddress)s{{/strong}}, but is not verified yet.',
+				{
+					args: {
+						emailAddress: primaryEmail,
+					},
+					components: {
+						strong: <strong />,
+					},
+				}
+			);
+		} else {
+			icon = this.getOKIcon();
+			description = translate(
+				'Your account email address is set to {{strong}}%(emailAddress)s{{/strong}}.',
+				{
+					args: {
+						emailAddress: primaryEmail,
+					},
+					components: {
+						strong: <strong />,
+					},
+				}
+			);
+		}
+
+		return (
+			<SecurityCheckupNavigationItem
+				path={ '/me/account' }
+				materialIcon={ icon }
+				text={ translate( 'Account Email' ) }
+				description={ description }
+			/>
+		);
+	}
+
+	renderRecoveryEmail() {
+		const {
+			accountRecoveryEmail,
+			accountRecoveryEmailActionInProgress,
+			accountRecoveryEmailValidated,
+			translate,
+		} = this.props;
+
+		if ( accountRecoveryEmailActionInProgress ) {
+			return this.renderPlaceholderNavItem();
+		}
+
+		let icon, description;
+
+		if ( ! accountRecoveryEmail ) {
+			icon = this.getWarningIcon();
+			description = translate( 'You do not have a recovery email address.' );
+		} else if ( ! accountRecoveryEmailValidated ) {
+			icon = this.getWarningIcon();
+			description = translate(
+				'You still need to validate your recovery email address: {{strong}}%(recoveryEmailAddress)s{{/strong}}',
+				{
+					args: {
+						recoveryEmailAddress: accountRecoveryEmail,
+					},
+					components: {
+						strong: <strong />,
+					},
+				}
+			);
+		} else {
+			icon = this.getOKIcon();
+			description = translate(
+				'You have set {{strong}}%(recoveryEmailAddress)s{{/strong}} as your recovery email address.',
+				{
+					args: {
+						recoveryEmailAddress: accountRecoveryEmail,
+					},
+					components: {
+						strong: '<strong>',
+					},
+				}
+			);
+		}
+
+		return (
+			<SecurityCheckupNavigationItem
+				path={ '/me/security/account-recovery' }
+				materialIcon={ icon }
+				text={ translate( 'Recovery Email' ) }
+				description={ description }
+			/>
+		);
+	}
+
+	renderRecoveryPhone() {
+		const {
+			accountRecoveryPhone,
+			accountRecoveryPhoneActionInProgress,
+			accountRecoveryPhoneValidated,
+			translate,
+		} = this.props;
+
+		if ( accountRecoveryPhoneActionInProgress ) {
+			return this.renderPlaceholderNavItem();
+		}
+
+		let icon, description;
+
+		if ( ! accountRecoveryPhone ) {
+			icon = this.getWarningIcon();
+			description = translate( 'You do not have a recovery SMS number.' );
+		} else if ( ! accountRecoveryPhoneValidated ) {
+			icon = this.getWarningIcon();
+			description = translate(
+				'You still need to validate your recovery SMS number: {{strong}}%(recoveryPhoneNumber)s{{/strong}}',
+				{
+					args: {
+						recoveryPhoneNumber: accountRecoveryPhone.numberFull,
+					},
+					components: {
+						strong: <strong />,
+					},
+				}
+			);
+		} else {
+			icon = this.getOKIcon();
+			description = translate(
+				'You have set {{strong}}%(recoveryPhoneNumber)s{{/strong}} as your recovery SMS number.',
+				{
+					args: {
+						recoveryPhoneNumber: accountRecoveryPhone,
+					},
+					components: {
+						strong: <strong />,
+					},
+				}
+			);
+		}
+
+		return (
+			<SecurityCheckupNavigationItem
+				path={ '/me/security/account-recovery' }
+				materialIcon={ icon }
+				text={ translate( 'Recovery SMS Number' ) }
+				description={ description }
+			/>
+		);
+	}
+
+	renderTwoFactorAuthentication() {
+		const { translate, userSettings } = this.props;
+
+		if ( ! userSettings.initialized || userSettings.fetchingData ) {
+			return this.renderPlaceholderNavItem();
+		}
+
+		let icon, description;
+		if ( userSettings.settings.two_step_enabled ) {
+			icon = this.getOKIcon();
+			description = translate(
+				'You have two-step authentication {{strong}}enabled{{/strong}} using an app.',
+				{
+					components: {
+						strong: <strong />,
+					},
+				}
+			);
+		} else if ( userSettings.settings.two_step_sms_enabled ) {
+			icon = this.getOKIcon();
+			description = translate(
+				'You have two-step authentication {{strong}}enabled{{/strong}} using SMS messages to {{strong}}%(phoneNumber)s{{/strong}}.',
+				{
+					args: {
+						phoneNumber: userSettings.settings.two_step_sms_phone_number,
+					},
+					components: {
+						strong: <strong />,
+					},
+				}
+			);
+		} else {
+			icon = this.getWarningIcon();
+			description = translate( 'You do not have two-step authentication enabled.' );
+		}
+
+		return (
+			<SecurityCheckupNavigationItem
+				path={ '/me/security/two-step' }
+				materialIcon={ icon }
+				text={ translate( 'Two-Step Authentication' ) }
+				description={ description }
+			/>
+		);
+	}
+
+	renderVerticalNav() {
+		return (
+			<VerticalNav>
+				{ this.renderAccountEmail() }
+				{ this.renderTwoFactorAuthentication() }
+				{ this.renderRecoveryEmail() }
+				{ this.renderRecoveryPhone() }
+				{ this.renderConnectedApps() }
+			</VerticalNav>
+		);
+	}
+
+	render() {
+		const { path, translate } = this.props;
+
+		return (
+			<Main className="security security-checkup">
+				<QueryAccountRecoverySettings />
+				<QueryConnectedApplications />
+
+				<PageViewTracker path="/me/security/security-checkup" title="Me > Security Checkup" />
+				<ReauthRequired twoStepAuthorization={ twoStepAuthorization } />
+				<MeSidebarNavigation />
+
+				<DocumentHead title={ translate( 'Security Checkup' ) } />
+
+				<SecuritySectionNav path={ path } />
+
+				{ this.renderTitleCard() }
+				{ this.renderVerticalNav() }
+			</Main>
+		);
+	}
+}
+
+export default connect( ( state ) => ( {
+	accountRecoveryEmail: getAccountRecoveryEmail( state ),
+	accountRecoveryEmailActionInProgress: isAccountRecoveryEmailActionInProgress( state ),
+	accountRecoveryEmailValidated: isAccountRecoveryEmailValidated( state ),
+	accountRecoveryPhone: getAccountRecoveryPhone( state ),
+	accountRecoveryPhoneActionInProgress: isAccountRecoveryPhoneActionInProgress( state ),
+	accountRecoveryPhoneValidated: isAccountRecoveryPhoneValidated( state ),
+	connectedApps: getConnectedApplications( state ),
+	primaryEmail: getCurrentUserEmail( state ),
+	primaryEmailVerified: isCurrentUserEmailVerified( state ),
+} ) )( localize( SecurityCheckupComponent ) );

--- a/client/me/security-checkup/style.scss
+++ b/client/me/security-checkup/style.scss
@@ -1,0 +1,25 @@
+.security-checkup__title-card {
+	h2 {
+		font-size: $font-title-medium;
+	}
+}
+
+.security-checkup__nav-item {
+	span {
+		display: flex;
+		align-items: center;
+		> .security-checkup__nav-item-icon {
+			fill: var( --color-neutral-60 );
+			width: 32px;
+			height: 32px;
+			margin-right: 16px;
+		}
+		div {
+			color: var( --color-neutral-90 );
+			small {
+				color: var( --color-neutral-50 );
+				font-size: $font-body-small;
+			}
+		}
+	}
+}

--- a/client/me/security-section-nav/index.jsx
+++ b/client/me/security-section-nav/index.jsx
@@ -49,6 +49,12 @@ export default class extends React.Component {
 				title: i18n.translate( 'Account Recovery' ),
 				path: '/me/security/account-recovery',
 			},
+			config.isEnabled( 'security/security-checkup' )
+				? {
+						title: i18n.translate( 'Security Checkup' ),
+						path: '/me/security/security-checkup',
+				  }
+				: null,
 		].filter( ( tab ) => tab !== null );
 
 		return tabs;
@@ -60,8 +66,8 @@ export default class extends React.Component {
 	};
 
 	getSelectedText = () => {
-		let text = '',
-			filteredPath = this.getFilteredPath(),
+		let text = '';
+		const filteredPath = this.getFilteredPath(),
 			found = find( this.getNavtabs(), { path: filteredPath } );
 
 		if ( 'undefined' !== typeof found ) {

--- a/client/me/security/controller.js
+++ b/client/me/security/controller.js
@@ -15,6 +15,7 @@ import accountPasswordData from 'lib/account-password-data';
 import SocialLoginComponent from 'me/social-login';
 import ConnectedAppsComponent from 'me/connected-applications';
 import AccountRecoveryComponent from 'me/security-account-recovery';
+import SecurityCheckupComponent from 'me/security-checkup';
 import { getSocialServiceFromClientId } from 'lib/login';
 
 export function password( context, next ) {
@@ -54,6 +55,14 @@ export function connectedApplications( context, next ) {
 
 export function accountRecovery( context, next ) {
 	context.primary = React.createElement( AccountRecoveryComponent, {
+		userSettings: userSettings,
+		path: context.path,
+	} );
+	next();
+}
+
+export function securityCheckup( context, next ) {
+	context.primary = React.createElement( SecurityCheckupComponent, {
 		userSettings: userSettings,
 		path: context.path,
 	} );

--- a/client/me/security/index.js
+++ b/client/me/security/index.js
@@ -13,6 +13,7 @@ import {
 	accountRecovery,
 	connectedApplications,
 	password,
+	securityCheckup,
 	socialLogin,
 	twoStep,
 } from './controller';
@@ -35,4 +36,8 @@ export default function () {
 	);
 
 	page( '/me/security/account-recovery', sidebar, accountRecovery, makeLayout, clientRender );
+
+	if ( config.isEnabled( 'security/security-checkup' ) ) {
+		page( '/me/security/security-checkup', sidebar, securityCheckup, makeLayout, clientRender );
+	}
 }

--- a/config/development.json
+++ b/config/development.json
@@ -155,6 +155,7 @@
 		"rubberband-scroll-disable": false,
 		"rum-tracking/logstash": true,
 		"safari-idb-mitigation": true,
+		"security/security-checkup": true,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
 		"settings/security/monitor/wp-note": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR sets the groundwork for a new Security Checkup feature (described [here](https://wp.me/p99Zz8-1gb)), which is currently set up behind the `security/security-checkup` feature flag, which is limited to dev environments for now.

The goal is to show a quick overview of a user's security and account recovery settings. For now, this initial PR does not represent a wrapped product, but a basic skeleton to support further iteration.

At present, this PR includes the following items:
 * Create `SecurityCheckupComponent` with basic styling and wire it into the security nav
 * Wire in the following links and basic assessments:
   - Account email
   - 2FA configuration
   - Recovery email
   - Recovery phone/SMS number
   - Connected apps

<img width="1009" alt="security_checkup_i1" src="https://user-images.githubusercontent.com/3376401/84154944-04ad2c00-aa68-11ea-9a66-649156838da7.png">

##### Open issues 

I'll address these in subsequent iterations/PRs.

* The security nav is now using a dropdown instead of a tab-like view due to the additional menu item
* The wording almost certainly needs additional love/attention
* Maybe add in a row for password details -- not quite sure what ought to go in here
* Add in a row for social logins
* Consider using different/better icons, possibly with colours - I just picked some existing icons as a starting point
* Clean up the use of `userSettings` and the 2FA logic, including expanding the assessment to include backup codes
* General event tracking/logging
* Most bugs! 😁 I suspect there are some with the 2FA handling, as that seemed the most likely to be buggy.

Side note: A huge 🎩 to @fditrapani! I cribbed his designs for the new domain settings UI for the basic layout, as the core UX in the two screens is very similar.

#### Testing instructions

* Verify that the feature flag is working and does **not** expose the new UI when not in a dev environment.
* With the feature flag *on*, verify that the following work:
  - All of the rows render correct information and an appropriate icon
  - Clicking on each row navigates to the correct target UI

Relates to #26874, though it doesn't directly address all of the items in the issue yet.