### PR TITLE
Sidebar: Set Plan icon to a star, Jetpack icon to its logo

### DIFF
--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -377,7 +377,7 @@ export class MySitesSidebar extends Component {
 		return (
 			<ExpandableSidebarMenu
 				expanded={ isJetpackSectionOpen }
-				materialIcon="jetpack"
+				customIcon={ <JetpackLogo size={ 24 } className="sidebar__menu-icon" /> }
 				onClick={ this.toggleSection( SIDEBAR_SECTION_JETPACK ) }
 				title={ translate( 'Jetpack' ) }
 			>
@@ -556,13 +556,15 @@ export class MySitesSidebar extends Component {
 
 		let planLink = '/plans' + this.props.siteSuffix;
 
+		const isUpgraded =
+			site &&
+			( isPersonal( site.plan ) ||
+				isPremium( site.plan ) ||
+				isBusiness( site.plan ) ||
+				isEcommerce( site.plan ) );
+
 		// Show plan details for upgraded sites
-		if (
-			isPersonal( site.plan ) ||
-			isPremium( site.plan ) ||
-			isBusiness( site.plan ) ||
-			isEcommerce( site.plan )
-		) {
+		if ( isUpgraded ) {
 			planLink = '/plans/my-plan' + this.props.siteSuffix;
 		}
 
@@ -583,11 +585,13 @@ export class MySitesSidebar extends Component {
 		// Hide the plan name only for Jetpack sites that are not Atomic or VIP.
 		const displayPlanName = ! ( isJetpack && ! isAtomicSite && ! isVip );
 
+		const icon = isUpgraded ? 'star' : 'star-outline';
+
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
 			<li className={ linkClass } data-tip-target={ tipTarget }>
 				<a className="sidebar__menu-link" onClick={ this.trackPlanClick } href={ planLink }>
-					<JetpackLogo className="sidebar__menu-icon" size={ 24 } />
+					<Gridicon icon={ icon } className="sidebar__menu-icon" size={ 24 } />
 					<span className="menu-link-text" data-e2e-sidebar="Plan">
 						{ translate( 'Plan', { context: 'noun' } ) }
 					</span>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update the **Plan** section icon to be a star Gridicon. (For Free users, the star is outlined/unfilled; for users with an upgraded plan or trial, the star is filled.)
* Make the icon for the **Jetpack** section the Jetpack logo.

#### Testing instructions

* Start Calypso in your local environment, or use the Calypso live branch.
* Add `?flags=jetpack/features-section` to your URL so that the Jetpack section is visible to you.
* Verify the Jetpack section has the Jetpack logo as its icon.
* Verify the Plan section has a star as its icon.
* Verify that for sites with a named plan (Free, Personal, etc.), the name of the plan is visible beside the Plan section link.
* Switch between sites that have purchased upgrades, plans, and no upgrades at all. Verify the star icon is outlined for non-upgraded sites and filled for upgraded sites.

Fixes `1179060693083348-as-1179411497904280`

#### Screenshots

##### Free plan

<img width="280" alt="image" src="https://user-images.githubusercontent.com/670067/84163978-a6685500-aa37-11ea-8519-22c9a20928e2.png">

##### Upgrades purchased

<img width="277" alt="image" src="https://user-images.githubusercontent.com/670067/84164050-b7b16180-aa37-11ea-8605-432f536d96e3.png">

##### Named plan purchased

<img width="282" alt="image" src="https://user-images.githubusercontent.com/670067/84164188-dca5d480-aa37-11ea-863b-1aa1f087714d.png">
