### PR TITLE
Jetpack Cloud: Move Activity Log menu item under Jetpack section

### DIFF
--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -286,6 +286,12 @@ export class MySitesSidebar extends Component {
 			return null;
 		}
 
+		// When the new Jetpack section is active,
+		// Activity Log goes there instead of here
+		if ( isEnabled( 'jetpack/features-section' ) ) {
+			return null;
+		}
+
 		let activityLink = '/activity-log' + siteSuffix,
 			activityLabel = translate( 'Activity' );
 
@@ -372,7 +378,12 @@ export class MySitesSidebar extends Component {
 	}
 
 	jetpack() {
-		const { isJetpackSectionOpen, site, translate } = this.props;
+		const { isJetpack, isJetpackSectionOpen, site, siteSuffix, path, translate } = this.props;
+
+		let activityLogUrl = '/activity-log' + siteSuffix;
+		if ( isJetpack && isEnabled( 'manage/themes-jetpack' ) ) {
+			activityLogUrl += '?group=rewind';
+		}
 
 		return (
 			<ExpandableSidebarMenu
@@ -385,9 +396,10 @@ export class MySitesSidebar extends Component {
 					label={ translate( 'Activity Log', {
 						comment: 'Jetpack Cloud / Activity Log status sidebar navigation item',
 					} ) }
-					link={ backupActivityPath( site.slug ) }
-					onNavigate={ this.onNavigate( 'Jetpack Cloud Backup / Activity Log' ) }
-					selected={ itemLinkMatches( backupActivityPath(), this.props.path ) }
+					link={ activityLogUrl }
+					onNavigate={ this.trackActivityClick }
+					selected={ itemLinkMatches( [ '/activity-log' ], path ) }
+					expandSection={ this.expandJetpackSection }
 				/>
 				<SidebarItem
 					label={ translate( 'Backup', {
@@ -396,8 +408,8 @@ export class MySitesSidebar extends Component {
 					link={ backupMainPath( site.slug ) }
 					onNavigate={ this.onNavigate( 'Jetpack Cloud Backup / Latest backups' ) }
 					selected={
-						itemLinkMatches( backupMainPath(), this.props.path ) &&
-						! itemLinkMatches( backupActivityPath(), this.props.path )
+						itemLinkMatches( backupMainPath(), path ) &&
+						! itemLinkMatches( backupActivityPath(), path )
 					}
 				/>
 				<SidebarItem
@@ -407,8 +419,7 @@ export class MySitesSidebar extends Component {
 					link={ site?.slug ? `/scan/${ site.slug }` : '/scan' }
 					onNavigate={ this.onNavigate( 'Jetpack Cloud Scan / Scanner' ) }
 					selected={
-						itemLinkMatches( '/scan', this.props.path ) &&
-						! itemLinkMatches( '/scan/history', this.props.path )
+						itemLinkMatches( '/scan', path ) && ! itemLinkMatches( '/scan/history', path )
 					}
 				></SidebarItem>
 			</ExpandableSidebarMenu>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* When the Jetpack features section is enabled/active, move the Activity Log menu item from the Tools section to the Jetpack section.
* Change the URL for the Activity Log item in the Jetpack section so that it points to WordPress.com's activity log (`/activity-log`) instead of the Jetpack Cloud activity log (`/backup/activity-log`).

Fixes `1179060693083348-as-1179411497904288`

#### Testing instructions

* Open Calypso in your local environment or by using the Calypso Live branch.
* Note that the **Activity Log** (or **Activity & Backups**) menu item is under the **Tools** section. Verify that the link works correctly and points to `/activity-log`.
* Check that Tracks events are sent when the **Activity Log** item is clicked.
* Enable the Jetpack menu section by appending `?flags=jetpack/features-section` to your URL.
* After applying the above flag, note that **Activity Log** is now located under the **Jetpack** section and no longer exists in the **Tools** section. Verify that the link still works and points to the same place (`/activity-log`, as opposed to `/backup/activity-log`).
* Check again that the same Tracks events are still sent when the **Activity Log** item is clicked.

#### Screenshots

##### `jetpack/features-section` disabled

<img width="281" alt="image" src="https://user-images.githubusercontent.com/670067/84168743-62784e80-aa3d-11ea-947d-44908a6157fc.png">

##### `jetpack/features-section` enabled

<img width="274" alt="image" src="https://user-images.githubusercontent.com/670067/84168705-542a3280-aa3d-11ea-8430-ffdf9eec78ea.png">