### PR TITLE
Jetpack Cloud: Break out threat history list and use on scan page on wpcom

### DIFF
--- a/client/components/jetpack/threat-history-list/index.jsx
+++ b/client/components/jetpack/threat-history-list/index.jsx
@@ -1,0 +1,183 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect, useDispatch } from 'react-redux';
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+import QueryJetpackScanHistory from 'components/data/query-jetpack-scan-history';
+import ThreatDialog from 'components/jetpack/threat-dialog';
+import ThreatItem from 'components/jetpack/threat-item';
+import SimplifiedSegmentedControl from 'components/segmented-control/simplified';
+import { recordTracksEvent } from 'state/analytics/actions';
+import { getSelectedSiteSlug, getSelectedSite } from 'state/ui/selectors';
+import isRequestingJetpackScanHistory from 'state/selectors/is-requesting-jetpack-scan-history';
+import getSiteScanHistory from 'state/selectors/get-site-scan-history';
+import contactSupportUrl from 'lib/jetpack/contact-support-url';
+import { withLocalizedMoment } from 'components/localized-moment';
+import { useThreats } from 'lib/jetpack/use-threats';
+import config from 'config';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+const filterOptions = [
+	{ value: 'all', label: 'All' },
+	{ value: 'fixed', label: 'Fixed' },
+	{ value: 'ignored', label: 'Ignored' },
+];
+
+const ThreatStatusFilter = ( { isPlaceholder, onSelect } ) => {
+	return isPlaceholder ? (
+		<div className="threat-history-list__filters is-placeholder"></div>
+	) : (
+		<SimplifiedSegmentedControl
+			className="threat-history-list__filters"
+			options={ filterOptions }
+			onSelect={ onSelect }
+		/>
+	);
+};
+
+const ThreatHistoryList = ( {
+	siteId,
+	siteName,
+	siteSlug,
+	isRequestingHistory,
+	threats,
+	filter,
+	dispatchRecordTracksEvent,
+} ) => {
+	const { selectedThreat, setSelectedThreat, updateThreat, updatingThreats } = useThreats( siteId );
+	const [ showThreatDialog, setShowThreatDialog ] = React.useState( false );
+	const isJetpackCom = !! config( 'env_id' ).includes( 'jetpack-cloud' );
+	const dispatch = useDispatch();
+	const handleOnFilterChange = React.useCallback(
+		( filterEntry ) => {
+			let filterValue = filterEntry.value;
+			if ( 'all' === filterValue ) {
+				filterValue = '';
+			}
+			dispatchRecordTracksEvent( 'calypso_jetpack_scan_history_filter', {
+				site_id: siteId,
+				filter: filterValue,
+			} );
+			if ( isJetpackCom ) {
+				page.show( `/scan/history/${ siteSlug }/${ filterValue }` );
+			} else {
+				page.show( `/scan/${ siteSlug }/${ filterValue }` );
+			}
+		},
+		[ dispatchRecordTracksEvent, siteId, siteSlug ]
+	);
+
+	const openDialog = React.useCallback(
+		( threat ) => {
+			const eventName = 'calypso_jetpack_scan_fixthreat_dialogopen';
+			dispatch(
+				recordTracksEvent( eventName, {
+					site_id: siteId,
+					threat_signature: threat.signature,
+				} )
+			);
+			setSelectedThreat( threat );
+			setShowThreatDialog( true );
+		},
+		[ dispatch, setSelectedThreat, siteId ]
+	);
+
+	const closeDialog = React.useCallback( () => {
+		setShowThreatDialog( false );
+	}, [ setShowThreatDialog ] );
+
+	const fixThreat = React.useCallback( () => {
+		closeDialog();
+		updateThreat( 'fix' );
+	}, [ closeDialog, updateThreat ] );
+
+	const currentFilter = React.useMemo( () => {
+		if ( filter ) {
+			return filterOptions.find( ( { value } ) => value === filter ) || filterOptions[ 0 ];
+		}
+		return filterOptions[ 0 ];
+	}, [ filter ] );
+
+	const filteredEntries = React.useMemo( () => {
+		const { value: filterValue } = currentFilter;
+		if ( filterValue === 'all' ) {
+			return threats;
+		}
+		return threats.filter( ( entry ) => entry.status === filterValue );
+	}, [ currentFilter, threats ] );
+
+	return (
+		<div className="threat-history-list">
+			<QueryJetpackScanHistory siteId={ siteId } />
+			{ threats.length > 0 && (
+				<div className="threat-history-list__filters-wrapper">
+					<ThreatStatusFilter
+						isPlaceholder={ isRequestingHistory }
+						onSelect={ handleOnFilterChange }
+					/>
+				</div>
+			) }
+			<div className="threat-history-list__entries">
+				{ filteredEntries.map( ( threat ) => (
+					<ThreatItem
+						key={ threat.id }
+						threat={ threat }
+						onFixThreat={ () => openDialog( threat ) }
+						isFixing={ !! updatingThreats.find( ( threatId ) => threatId === threat.id ) }
+						contactSupportUrl={ contactSupportUrl( siteSlug ) }
+						isPlaceholder={ isRequestingHistory }
+					/>
+				) ) }
+				{ selectedThreat && (
+					<ThreatDialog
+						showDialog={ showThreatDialog }
+						onCloseDialog={ closeDialog }
+						onConfirmation={ fixThreat }
+						siteId={ siteId }
+						siteName={ siteName }
+						threat={ selectedThreat }
+						action={ 'fix' }
+					/>
+				) }
+			</div>
+		</div>
+	);
+};
+
+export default connect(
+	( state ) => {
+		const site = getSelectedSite( state );
+		const siteId = site.ID;
+		const siteName = site.name;
+		const siteSlug = getSelectedSiteSlug( state );
+		const isRequestingHistory = isRequestingJetpackScanHistory( state, siteId );
+		const siteLogEntries = getSiteScanHistory( state, siteId );
+
+		const showPlaceholders = isRequestingHistory && 0 === siteLogEntries.length;
+		const logEntries = showPlaceholders
+			? [
+					{ id: 1, status: 'fixed' },
+					{ id: 2, status: 'ignored' },
+					{ id: 3, status: 'fixed' },
+					{ id: 4, status: 'ignored' },
+			  ]
+			: siteLogEntries;
+		return {
+			siteId,
+			siteName,
+			siteSlug,
+			isRequestingHistory: showPlaceholders,
+			threats: logEntries,
+		};
+	},
+	{ dispatchRecordTracksEvent: recordTracksEvent }
+)( withLocalizedMoment( ThreatHistoryList ) );

--- a/client/components/jetpack/threat-history-list/style.scss
+++ b/client/components/jetpack/threat-history-list/style.scss
@@ -1,0 +1,22 @@
+.threat-history-list {
+	&__filters-wrapper {
+		text-align: center;
+	}
+
+	&__filters.is-placeholder {
+		@include placeholder( --color-neutral-10 );
+		height: 36px;
+		width: 175px;
+		border-radius: 4px;
+	}
+
+	&__filters {
+		margin: 8px 0 24px;
+		display: inline-flex;
+
+		.segmented-control__item.is-selected a {
+			background: var( --color-neutral-30 );
+			color: #fff;
+		}
+	}
+}

--- a/client/landing/jetpack-cloud/sections/scan/controller.js
+++ b/client/landing/jetpack-cloud/sections/scan/controller.js
@@ -26,7 +26,8 @@ export function showUpsellIfNoScanHistory( context, next ) {
 }
 
 export function scan( context, next ) {
-	context.primary = <ScanPage />;
+	const { filter } = context.params;
+	context.primary = <ScanPage filter={ filter } />;
 	next();
 }
 

--- a/client/landing/jetpack-cloud/sections/scan/history/index.jsx
+++ b/client/landing/jetpack-cloud/sections/scan/history/index.jsx
@@ -2,118 +2,26 @@
  * External dependencies
  */
 import React from 'react';
-import { connect, useDispatch } from 'react-redux';
-import { translate } from 'i18n-calypso';
-import page from 'page';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import DocumentHead from 'components/data/document-head';
 import QueryJetpackScanHistory from 'components/data/query-jetpack-scan-history';
-import ThreatDialog from 'components/jetpack/threat-dialog';
-import ThreatItem from 'components/jetpack/threat-item';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
-import SimplifiedSegmentedControl from 'components/segmented-control/simplified';
-import { recordTracksEvent } from 'state/analytics/actions';
-import { getSelectedSiteSlug, getSelectedSite } from 'state/ui/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
 import Main from 'components/main';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
-import isRequestingJetpackScanHistory from 'state/selectors/is-requesting-jetpack-scan-history';
-import getSiteScanHistory from 'state/selectors/get-site-scan-history';
-import contactSupportUrl from 'lib/jetpack/contact-support-url';
-import { withLocalizedMoment } from 'components/localized-moment';
-import { useThreats } from 'lib/jetpack/use-threats';
+import ThreatHistoryList from 'components/jetpack/threat-history-list';
 
 /**
  * Style dependencies
  */
 import './style.scss';
 
-const filterOptions = [
-	{ value: 'all', label: 'All' },
-	{ value: 'fixed', label: 'Fixed' },
-	{ value: 'ignored', label: 'Ignored' },
-];
-
-const ThreatStatusFilter = ( { isPlaceholder, onSelect } ) => {
-	return isPlaceholder ? (
-		<div className="history__filters is-placeholder"></div>
-	) : (
-		<SimplifiedSegmentedControl
-			className="history__filters"
-			options={ filterOptions }
-			onSelect={ onSelect }
-		/>
-	);
-};
-
-const ScanHistoryPage = ( {
-	siteId,
-	siteName,
-	siteSlug,
-	isRequestingHistory,
-	threats,
-	filter,
-	dispatchRecordTracksEvent,
-} ) => {
-	const { selectedThreat, setSelectedThreat, updateThreat, updatingThreats } = useThreats( siteId );
-	const [ showThreatDialog, setShowThreatDialog ] = React.useState( false );
-	const dispatch = useDispatch();
-	const handleOnFilterChange = React.useCallback(
-		( filterEntry ) => {
-			let filterValue = filterEntry.value;
-			if ( 'all' === filterValue ) {
-				filterValue = '';
-			}
-			dispatchRecordTracksEvent( 'calypso_jetpack_scan_history_filter', {
-				site_id: siteId,
-				filter: filterValue,
-			} );
-			page.show( `/scan/history/${ siteSlug }/${ filterValue }` );
-		},
-		[ dispatchRecordTracksEvent, siteId, siteSlug ]
-	);
-
-	const openDialog = React.useCallback(
-		( threat ) => {
-			const eventName = 'calypso_jetpack_scan_fixthreat_dialogopen';
-			dispatch(
-				recordTracksEvent( eventName, {
-					site_id: siteId,
-					threat_signature: threat.signature,
-				} )
-			);
-			setSelectedThreat( threat );
-			setShowThreatDialog( true );
-		},
-		[ dispatch, setSelectedThreat, siteId ]
-	);
-
-	const closeDialog = React.useCallback( () => {
-		setShowThreatDialog( false );
-	}, [ setShowThreatDialog ] );
-
-	const fixThreat = React.useCallback( () => {
-		closeDialog();
-		updateThreat( 'fix' );
-	}, [ closeDialog, updateThreat ] );
-
-	const currentFilter = React.useMemo( () => {
-		if ( filter ) {
-			return filterOptions.find( ( { value } ) => value === filter ) || filterOptions[ 0 ];
-		}
-		return filterOptions[ 0 ];
-	}, [ filter ] );
-
-	const filteredEntries = React.useMemo( () => {
-		const { value: filterValue } = currentFilter;
-		if ( filterValue === 'all' ) {
-			return threats;
-		}
-		return threats.filter( ( entry ) => entry.status === filterValue );
-	}, [ currentFilter, threats ] );
-
+const ScanHistoryPage = ( { filter, siteId, translate } ) => {
 	return (
 		<Main className="history">
 			<DocumentHead title={ translate( 'History' ) } />
@@ -126,66 +34,11 @@ const ScanHistoryPage = ( {
 					'The scanning history contains a record of all previously active threats on your site.'
 				) }
 			</p>
-			{ threats.length > 0 && (
-				<div className="history__filters-wrapper">
-					<ThreatStatusFilter
-						isPlaceholder={ isRequestingHistory }
-						onSelect={ handleOnFilterChange }
-					/>
-				</div>
-			) }
-			<div className="history__entries">
-				{ filteredEntries.map( ( threat ) => (
-					<ThreatItem
-						key={ threat.id }
-						threat={ threat }
-						onFixThreat={ () => openDialog( threat ) }
-						isFixing={ !! updatingThreats.find( ( threatId ) => threatId === threat.id ) }
-						contactSupportUrl={ contactSupportUrl( siteSlug ) }
-						isPlaceholder={ isRequestingHistory }
-					/>
-				) ) }
-				{ selectedThreat && (
-					<ThreatDialog
-						showDialog={ showThreatDialog }
-						onCloseDialog={ closeDialog }
-						onConfirmation={ fixThreat }
-						siteId={ siteId }
-						siteName={ siteName }
-						threat={ selectedThreat }
-						action={ 'fix' }
-					/>
-				) }
-			</div>
+			<ThreatHistoryList { ...{ filter } } />
 		</Main>
 	);
 };
 
-export default connect(
-	( state ) => {
-		const site = getSelectedSite( state );
-		const siteId = site.ID;
-		const siteName = site.name;
-		const siteSlug = getSelectedSiteSlug( state );
-		const isRequestingHistory = isRequestingJetpackScanHistory( state, siteId );
-		const siteLogEntries = getSiteScanHistory( state, siteId );
-
-		const showPlaceholders = isRequestingHistory && 0 === siteLogEntries.length;
-		const logEntries = showPlaceholders
-			? [
-					{ id: 1, status: 'fixed' },
-					{ id: 2, status: 'ignored' },
-					{ id: 3, status: 'fixed' },
-					{ id: 4, status: 'ignored' },
-			  ]
-			: siteLogEntries;
-		return {
-			siteId,
-			siteName,
-			siteSlug,
-			isRequestingHistory: showPlaceholders,
-			threats: logEntries,
-		};
-	},
-	{ dispatchRecordTracksEvent: recordTracksEvent }
-)( withLocalizedMoment( ScanHistoryPage ) );
+export default connect( ( state ) => ( {
+	siteId: getSelectedSiteId( state ),
+} ) )( localize( ScanHistoryPage ) );

--- a/client/landing/jetpack-cloud/sections/scan/history/style.scss
+++ b/client/landing/jetpack-cloud/sections/scan/history/style.scss
@@ -12,27 +12,6 @@
 		}
 	}
 
-	&__filters-wrapper {
-		text-align: center;
-	}
-
-	&__filters.is-placeholder {
-		@include placeholder( --color-neutral-10 );
-		height: 36px;
-		width: 175px;
-		border-radius: 4px;
-	}
-
-	&__filters {
-		margin: 8px 0 24px;
-		display: inline-flex;
-
-		.segmented-control__item.is-selected a {
-			background: var( --color-neutral-30 );
-			color: #fff;
-		}
-	}
-
 	p {
 		font-size: 18px;
 		margin-bottom: 16px;

--- a/client/landing/jetpack-cloud/sections/scan/index.js
+++ b/client/landing/jetpack-cloud/sections/scan/index.js
@@ -42,6 +42,17 @@ export default function () {
 			makeLayout,
 			clientRender
 		);
+
+		page(
+			'/scan/:site/:filter?',
+			siteSelection,
+			navigation,
+			scan,
+			wrapInSiteOffsetProvider,
+			showUpsellIfNoScan,
+			makeLayout,
+			clientRender
+		);
 	} else {
 		page( '/scan*', () => page.redirect( '/' ) );
 	}

--- a/client/landing/jetpack-cloud/sections/scan/main.tsx
+++ b/client/landing/jetpack-cloud/sections/scan/main.tsx
@@ -7,6 +7,7 @@ import { Button, ProgressBar } from '@automattic/components';
 import { translate } from 'i18n-calypso';
 import { flowRight as compose } from 'lodash';
 import config, { isEnabled } from 'config';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -235,7 +236,14 @@ class ScanPage extends Component< Props > {
 
 		const isJetpackCom = !! config( 'env_id' ).includes( 'jetpack-cloud' );
 
-		return ! isJetpackCom && <ThreatHistoryList { ...{ filter } } />;
+		return (
+			! isJetpackCom && (
+				<div className="scan__history">
+					{ this.renderHeader( 'History' ) }
+					<ThreatHistoryList { ...{ filter } } />
+				</div>
+			)
+		);
 	}
 
 	render() {
@@ -243,8 +251,14 @@ class ScanPage extends Component< Props > {
 		if ( ! siteId ) {
 			return;
 		}
+		const isJetpackCom = !! config( 'env_id' ).includes( 'jetpack-cloud' );
 		return (
-			<Main className="scan__main">
+			<Main
+				classNames={ classNames( {
+					scan__main: true,
+					is_jetpackcom: isJetpackCom,
+				} ) }
+			>
 				<DocumentHead title="Scanner" />
 				<SidebarNavigation />
 				<QueryJetpackScan siteId={ siteId } />

--- a/client/landing/jetpack-cloud/sections/scan/main.tsx
+++ b/client/landing/jetpack-cloud/sections/scan/main.tsx
@@ -6,6 +6,7 @@ import { connect } from 'react-redux';
 import { Button, ProgressBar } from '@automattic/components';
 import { translate } from 'i18n-calypso';
 import { flowRight as compose } from 'lodash';
+import config, { isEnabled } from 'config';
 
 /**
  * Internal dependencies
@@ -16,7 +17,6 @@ import SecurityIcon from 'components/jetpack/security-icon';
 import ScanPlaceholder from 'components/jetpack/scan-placeholder';
 import ScanThreats from 'components/jetpack/scan-threats';
 import { Scan, Site } from 'landing/jetpack-cloud/sections/scan/types';
-import { isEnabled } from 'config';
 import Gridicon from 'components/gridicon';
 import Main from 'components/main';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
@@ -31,6 +31,7 @@ import contactSupportUrl from 'lib/jetpack/contact-support-url';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { triggerScanRun } from 'lib/jetpack/trigger-scan-run';
 import { withApplySiteOffset, applySiteOffsetType } from 'components/jetpack/site-offset';
+import ThreatHistoryList from 'components/jetpack/threat-history-list';
 
 /**
  * Style dependencies
@@ -229,6 +230,14 @@ class ScanPage extends Component< Props > {
 		return this.renderScanOkay();
 	}
 
+	maybeRenderHistory() {
+		const { filter } = this.props;
+
+		const isJetpackCom = !! config( 'env_id' ).includes( 'jetpack-cloud' );
+
+		return ! isJetpackCom && <ThreatHistoryList { ...{ filter } } />;
+	}
+
 	render() {
 		const { siteId } = this.props;
 		if ( ! siteId ) {
@@ -241,6 +250,7 @@ class ScanPage extends Component< Props > {
 				<QueryJetpackScan siteId={ siteId } />
 				<PageViewTracker path="/scan/:site" title="Scanner" />
 				<div className="scan__content">{ this.renderScanState() }</div>
+				{ this.maybeRenderHistory() }
 			</Main>
 		);
 	}

--- a/client/landing/jetpack-cloud/sections/scan/style.scss
+++ b/client/landing/jetpack-cloud/sections/scan/style.scss
@@ -6,6 +6,9 @@
 	display: flex;
 	flex-direction: column;
 	justify-content: space-between;
+}
+
+.scan__main.is_jetpackcom {
 	min-height: calc( 100vh - 111px ); // Padding of .layout__content: 79px + 32px;
 }
 

--- a/config/development.json
+++ b/config/development.json
@@ -83,7 +83,7 @@
 		"jetpack/connect/woocommerce": true,
 		"jetpack/happychat": true,
 		"jetpack/search-product": true,
-		"jetpack/features-section": true,
+		"jetpack/features-section": false,
 		"jetpack/scan-product": true,
 		"jetpack/backups-restore": true,
 		"jetpack/on-demand-scan": true,

--- a/config/development.json
+++ b/config/development.json
@@ -83,7 +83,7 @@
 		"jetpack/connect/woocommerce": true,
 		"jetpack/happychat": true,
 		"jetpack/search-product": true,
-		"jetpack/features-section": false,
+		"jetpack/features-section": true,
 		"jetpack/scan-product": true,
 		"jetpack/backups-restore": true,
 		"jetpack/on-demand-scan": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Extract scan history logic from scan page and create a new `ThreatHistoryList` component which can be used in multiple places
* If on WordPress.com instead of Jetpack.com, display the `ThreatHistoryList` component on the scan root page
* Adds a new `/scan/:site/:filter?` route to accommodate the history filter on the scan root page
* Move styles around as appropriate

#### Testing instructions

* Boot this PR locally on jetpack cloud dev environment. Check that the scan page, and scan history page all works normally. Threats should be displayed and filterable as usual. Threats should be fixable as usual. A page for "Scan" and a page for "History" should still work normally.
* Now boot this PR locally in calypso dev environment. Check that the scan page contains the threat history list below the normal scan page elements. Ensure that the list is filterable and that threats are fixable.

Fixes # 1179060693083348-as-1179576078115825
