### PR TITLE
Jetpack Section: Add start-jetpack-section script for development purposes

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
 		"poststart": "check-npm-client && run-p -s start-build-if-web start-build-if-desktop build-packages:watch",
 		"start-fallback": "check-npm-client && DEV_TARGET=fallback yarn run start",
 		"start-jetpack-cloud": "check-npm-client && CALYPSO_ENV=jetpack-cloud-development yarn start",
+		"start-jetpack-section": "check-npm-client && ENABLE_FEATURES=jetpack/features-section yarn start",
 		"reformat-files": "check-npm-client && ./node_modules/.bin/prettier --ignore-path .eslintignore --write \"**/*.{js,jsx,json,ts,tsx}\"",
 		"start-build-do": "check-npm-client && node ${NODE_ARGS:---max_old_space_size=8192} build/bundle.js",
 		"start-build-fallback": "check-npm-client && BROWSERSLIST_ENV=defaults yarn run start-build-do",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add the `start-jetpack-section` script for development purposes, so we won't need to put the `flag` query on each page.

#### Testing instructions

- Apply this change
- Run Calypso with this command: `yarn start-jetpack-section`
- You will see the Jetpack section activated