### PR TITLE
composite-checkout: Use CalypsoI18nProvider to translate Continue buttons

### DIFF
--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -294,7 +294,6 @@ export default function WPCheckout( {
 							titleContent={ <ContactFormTitle /> }
 							editButtonText={ translate( 'Edit' ) }
 							editButtonAriaLabel={ translate( 'Edit the contact details' ) }
-							nextStepButtonText={ translate( 'Continue' ) }
 							nextStepButtonAriaLabel={ translate( 'Continue with the entered contact details' ) }
 							validatingButtonText={
 								isCartPendingUpdate ? translate( 'Updating cart…' ) : translate( 'Please wait…' )
@@ -317,7 +316,6 @@ export default function WPCheckout( {
 						titleContent={ paymentMethodStep.titleContent }
 						editButtonText={ translate( 'Edit' ) }
 						editButtonAriaLabel={ translate( 'Edit the payment method' ) }
-						nextStepButtonText={ translate( 'Continue' ) }
 						nextStepButtonAriaLabel={ translate( 'Continue with the selected payment method' ) }
 						validatingButtonText={
 							isCartPendingUpdate ? translate( 'Updating cart…' ) : translate( 'Please wait…' )


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR is mostly to test the changes in https://github.com/Automattic/wp-calypso/pull/42997 which add a new i18n provider to Calypso.

This is part of #42831

#### Testing instructions

- Visit http://calypso.localhost:3000/me/account and change your language to French.
- Add a plan to your cart and visit checkout. You'll need to add `?flags=composite-checkout-force` to the URL to override the locale detection that blocks it for now.
- Verify that the "Continue" buttons read "Continuer". These strings are localized _inside_ the `composite-checkout` package and not in Calypso.

![Screen Shot 2020-06-04 at 5 33 25 PM](https://user-images.githubusercontent.com/2036909/83813425-4fefc500-a68b-11ea-8356-31143e12ac05.png)