### PR TITLE
Gutenframe: Fix media modal opened through inline image reopening when cancelled.

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -763,7 +763,8 @@ function initPort( message ) {
 
 	class MediaUpload extends Component {
 		openModal = () => {
-			const mediaChannel = new MessageChannel();
+			const mediaSelectChannel = new MessageChannel();
+			const mediaCancelChannel = new MessageChannel();
 
 			calypsoPort.postMessage(
 				{
@@ -775,16 +776,25 @@ function initPort( message ) {
 						value: this.props.value,
 					},
 				},
-				[ mediaChannel.port2 ]
+				[ mediaSelectChannel.port2, mediaCancelChannel.port2 ]
 			);
 
-			mediaChannel.port1.onmessage = ( { data } ) => {
+			mediaSelectChannel.port1.onmessage = ( { data } ) => {
 				this.props.onSelect( data );
 
 				// this is a once-only port
 				// to send more messages we have to re-open the
 				// modal and create a new channel
-				mediaChannel.port1.close();
+				mediaSelectChannel.port1.close();
+			};
+
+			mediaCancelChannel.port1.onmessage = () => {
+				this.props.onClose();
+
+				// this is a once-only port
+				// to send more messages we have to re-open the
+				// modal and create a new channel
+				mediaCancelChannel.port1.close();
 			};
 		};
 

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -119,6 +119,7 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 	iframePort: MessagePort | null = null;
 	conversionPort: MessagePort | null = null;
 	mediaSelectPort: MessagePort | null = null;
+	mediaCancelPort: MessagePort | null = null;
 	revisionsPort: MessagePort | null = null;
 	successfulIframeLoad = false;
 
@@ -202,6 +203,7 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 			// the kind of assignment which causes re-renders and we
 			// want it set immediately
 			this.mediaSelectPort = ports[ 0 ];
+			this.mediaCancelPort = ports[ 1 ];
 
 			if ( value ) {
 				const ids = Array.isArray( value )
@@ -377,6 +379,12 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 			// and prevent sending more messages (which will be ignored)
 			this.mediaSelectPort.close();
 			this.mediaSelectPort = null;
+		}
+
+		if ( ! this.state.classicBlockEditorId && ! media && this.mediaCancelPort ) {
+			this.mediaCancelPort.postMessage( true );
+			this.mediaCancelPort.close();
+			this.mediaCancelPort = null;
 		}
 
 		this.setState( { classicBlockEditorId: null, isMediaModalVisible: false } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix media modal opened through inline image reopening when cancelled.

Explanation why this is happening in https://github.com/Automattic/wp-calypso/issues/40934#issuecomment-641460747.

#### Testing instructions

* Follow the steps mentioned in https://github.com/Automattic/wp-calypso/issues/40934.
* The modal should not reopen again.

Fixes #40934
