### PR TITLE
Jetpack cloud: prevent primary and recent sites fetching

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -175,7 +175,7 @@ class Layout extends Component {
 				/>
 				<HtmlIsIframeClassname />
 				<DocumentHead />
-				<QuerySites primaryAndRecent />
+				<QuerySites primaryAndRecent={ ! config.isEnabled( 'jetpack-cloud' ) } />
 				{ this.props.shouldQueryAllSites && <QuerySites allSites /> }
 				<QueryPreferences />
 				{ config.isEnabled( 'layout/query-selected-editor' ) && (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The site selector in Jetpack cloud requests the primary and recent sites. They may not have the Jetpack plugin enabled, in which case calls to `public-api.wordpress.com/rest/v1.2/sites/:id?filters=jetpack` return a 404 error. These errors have no consequence on the experience, but pollute the console.

It seems to me that in the context of Jetpack cloud requesting the primary and recent sites brings little value (would cloud users even have them?). Let me know if my assumption is incorrect.

#### Implementation notes

I used the same condition that's already in use in the component.

#### Testing instructions

1. In the WordPress.com admin, go to your list of blogs (alternatively, go to https://wordpress.com/home and click _Change_).
2. Select a non Jetpack site as your primary site.
3. Run the PR locally.
4. Go to http://jetpack.cloud.localhost:3000/.
5. Check in the console or network panel that this site is not requested (if it does you'll probably see a 404).