### PR TITLE
Use function for Jetpack Components settings links

### DIFF
--- a/client/components/jetpack/activity-card/index.jsx
+++ b/client/components/jetpack/activity-card/index.jsx
@@ -10,7 +10,8 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import { backupDownloadPath, backupRestorePath, settingsPath } from 'my-sites/backup/paths';
+import { backupDownloadPath, backupRestorePath } from 'my-sites/backup/paths';
+import { settingsPath } from 'lib/jetpack/paths';
 import { Card } from '@automattic/components';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { withApplySiteOffset } from 'components/jetpack/site-offset';

--- a/client/components/jetpack/daily-backup-status/index.jsx
+++ b/client/components/jetpack/daily-backup-status/index.jsx
@@ -8,24 +8,20 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
-import { withLocalizedMoment } from 'components/localized-moment';
-import Button from 'components/forms/form-button';
+import { applySiteOffset } from 'lib/site/timezone';
+import { backupDownloadPath, backupRestorePath, backupMainPath } from 'my-sites/backup/paths';
+import { Card } from '@automattic/components';
 import {
 	isSuccessfulDailyBackup,
 	isSuccessfulRealtimeBackup,
 	INDEX_FORMAT,
 } from 'lib/jetpack/backup-utils';
-import {
-	backupDownloadPath,
-	backupRestorePath,
-	backupMainPath,
-	settingsPath,
-} from 'my-sites/backup/paths';
-import { applySiteOffset } from 'lib/site/timezone';
-import { Card } from '@automattic/components';
+import { settingsPath } from 'lib/jetpack/paths';
+import { withLocalizedMoment } from 'components/localized-moment';
 import ActivityCard from 'components/jetpack/activity-card';
-import ExternalLink from 'components/external-link';
 import BackupChanges from './backup-changes';
+import Button from 'components/forms/form-button';
+import ExternalLink from 'components/external-link';
 
 /**
  * Style dependencies

--- a/client/components/jetpack/sidebar/index.jsx
+++ b/client/components/jetpack/sidebar/index.jsx
@@ -11,28 +11,29 @@ import { format as formatUrl, parse as parseUrl } from 'url';
 /**
  * Internal dependencies
  */
-import QueryJetpackScan from 'components/data/query-jetpack-scan';
-import getSiteAdminUrl from 'state/sites/selectors/get-site-admin-url';
+import { backupMainPath, backupActivityPath } from 'my-sites/backup/paths';
+import {
+	expandMySitesSidebarSection as expandSection,
+	toggleMySitesSidebarSection as toggleSection,
+} from 'state/my-sites/sidebar/actions';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
-import getSiteScanThreats from 'state/selectors/get-site-scan-threats';
-import getSiteScanProgress from 'state/selectors/get-site-scan-progress';
+import { isSidebarSectionOpen } from 'state/my-sites/sidebar/selectors';
+import { itemLinkMatches } from 'my-sites/sidebar/utils';
+import { recordTracksEvent } from 'state/analytics/actions';
+import { settingsPath } from 'lib/jetpack/paths';
 import CurrentSite from 'my-sites/current-site';
 import ExpandableSidebarMenu from 'layout/sidebar/expandable';
+import getSiteAdminUrl from 'state/sites/selectors/get-site-admin-url';
+import getSiteScanProgress from 'state/selectors/get-site-scan-progress';
+import getSiteScanThreats from 'state/selectors/get-site-scan-threats';
 import Gridicon from 'components/gridicon';
-import { itemLinkMatches } from 'my-sites/sidebar/utils';
+import QueryJetpackScan from 'components/data/query-jetpack-scan';
 import ScanBadge from 'components/jetpack/scan-badge';
 import Sidebar from 'layout/sidebar';
 import SidebarFooter from 'layout/sidebar/footer';
 import SidebarItem from 'layout/sidebar/item';
 import SidebarMenu from 'layout/sidebar/menu';
 import SidebarRegion from 'layout/sidebar/region';
-import { recordTracksEvent } from 'state/analytics/actions';
-import { isSidebarSectionOpen } from 'state/my-sites/sidebar/selectors';
-import {
-	expandMySitesSidebarSection as expandSection,
-	toggleMySitesSidebarSection as toggleSection,
-} from 'state/my-sites/sidebar/actions';
-import { backupMainPath, backupActivityPath } from 'my-sites/backup/paths';
 
 // Lowercase because these are used as keys for sidebar state.
 export const SIDEBAR_SECTION_SCAN = 'scan';
@@ -181,11 +182,11 @@ class JetpackCloudSidebar extends Component {
 						label={ translate( 'Settings', {
 							comment: 'Jetpack Cloud / Backups sidebar navigation item',
 						} ) }
-						link={ selectedSiteSlug ? `/settings/${ selectedSiteSlug }` : '/settings' }
+						link={ selectedSiteSlug ? settingsPath( selectedSiteSlug ) : settingsPath() }
 						onNavigate={ this.onNavigate( 'Jetpack Cloud / Settings' ) }
 						materialIcon="settings"
 						materialIconStyle="filled"
-						selected={ this.isSelected( '/settings' ) }
+						selected={ this.isSelected( settingsPath() ) }
 					/>
 				</SidebarRegion>
 				<SidebarFooter>

--- a/client/landing/jetpack-cloud/sections/settings/index.js
+++ b/client/landing/jetpack-cloud/sections/settings/index.js
@@ -6,15 +6,15 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import config from 'config';
-
-import { navigation, siteSelection, sites } from 'my-sites/controller';
 import { makeLayout, render as clientRender } from 'controller';
+import { navigation, siteSelection, sites } from 'my-sites/controller';
 import { settings } from 'landing/jetpack-cloud/sections/settings/controller';
+import { settingsPath } from 'lib/jetpack/paths';
+import isJetpackCloud from 'lib/jetpack/is-jetpack-cloud';
 
 export default function () {
-	if ( config.isEnabled( 'jetpack-cloud' ) ) {
-		page( '/settings', siteSelection, sites, navigation, makeLayout, clientRender );
-		page( '/settings/:site', siteSelection, navigation, settings, makeLayout, clientRender );
+	if ( isJetpackCloud() ) {
+		page( settingsPath(), siteSelection, sites, navigation, makeLayout, clientRender );
+		page( settingsPath( ':site' ), siteSelection, navigation, settings, makeLayout, clientRender );
 	}
 }

--- a/client/lib/jetpack/is-jetpack-cloud.ts
+++ b/client/lib/jetpack/is-jetpack-cloud.ts
@@ -1,0 +1,15 @@
+/**
+ * Internal dependencies
+ */
+import config from 'config';
+
+const jetpackCloudEnvironments = [
+	'jetpack-cloud-development',
+	'jetpack-cloud-stage',
+	'jetpack-cloud-horizon',
+	'jetpack-cloud-production',
+];
+
+const isJetpackCloud = () => jetpackCloudEnvironments.includes( config( 'env_id' ) );
+
+export default isJetpackCloud;

--- a/client/lib/jetpack/paths.ts
+++ b/client/lib/jetpack/paths.ts
@@ -1,0 +1,9 @@
+/**
+ * Internal dependencies
+ */
+import isJetpackCloud from 'lib/jetpack/is-jetpack-cloud';
+
+const settingsBasePath = () => ( isJetpackCloud() ? '/settings' : '/settings/security' );
+
+export const settingsPath = ( siteName: string ) =>
+	siteName ? `${ settingsBasePath() }/${ siteName }` : settingsBasePath();

--- a/client/my-sites/backup/paths.ts
+++ b/client/my-sites/backup/paths.ts
@@ -23,6 +23,3 @@ export const backupRestorePath = ( siteName: string, rewindId: string ) =>
 
 export const backupDownloadPath = ( siteName: string, rewindId: string ) =>
 	backupSubSectionPath( siteName, 'download', rewindId );
-
-export const settingsPath = ( siteName: string ) =>
-	siteName ? `/settings/${ siteName }` : '/settings';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use function to build settings path for jetpack components, conditionally linking to different places depending on if used in Jetpack.com or WordPress.com
* Update all settings path uses in jetpack components to use the new function
* New approach to detecting jetpack.com/jetpack cloud

#### Testing instructions

1. Boot Jetpack Cloud
2. Navigate to `/backup`
3. Activate needs credentials state by setting the `doesRewindNeedCredentials` on the `DailyBackupStatus` component to true
4. Click "Activate restores" and verify you are taken to `/settings/:siteSlug`
5. Navigate to `/backup/activity-log`
6. Activate needs credentials state by setting the `doesRewindNeedCredentials` on a `ActivityCard` component to true
7. Click "Actions", then "Enter Server Credentials" on that Activity Card. Verify you are taken to  `/settings/:siteSlug`
8. Reboot into Blue Calypso, navigate to `/backup?flags=jetpack/features-section`
9. Activate needs credentials state by setting the `doesRewindNeedCredentials` on the `DailyBackupStatus` component to true
10. Click "Activate restores" and verify you are taken to `/settings/security/:siteSlug`