### PR TITLE
Jetpack Scan: Update history after ignore or fix

### DIFF
--- a/client/lib/jetpack/use-threats.ts
+++ b/client/lib/jetpack/use-threats.ts
@@ -11,6 +11,7 @@ import { recordTracksEvent } from 'state/analytics/actions';
 import { fixAllThreats, fixThreat, ignoreThreat } from 'state/jetpack-scan/threats/actions';
 import { FixableThreat, Threat } from 'components/jetpack/threat-item/types';
 import getSiteScanUpdatingThreats from 'state/selectors/get-site-scan-updating-threats';
+import { requestJetpackScanHistory } from 'state/jetpack-scan/history/actions';
 
 export const useThreats = ( siteId: number ) => {
 	const [ selectedThreat, setSelectedThreat ] = React.useState< Threat >();
@@ -32,6 +33,7 @@ export const useThreats = ( siteId: number ) => {
 				);
 				const actionCreator = action === 'fix' ? fixThreat : ignoreThreat;
 				dispatch( actionCreator( siteId, selectedThreat.id ) );
+				dispatch( requestJetpackScanHistory( siteId ) );
 			}
 		},
 		[ dispatch, selectedThreat, siteId ]

--- a/client/lib/jetpack/use-threats.ts
+++ b/client/lib/jetpack/use-threats.ts
@@ -11,7 +11,6 @@ import { recordTracksEvent } from 'state/analytics/actions';
 import { fixAllThreats, fixThreat, ignoreThreat } from 'state/jetpack-scan/threats/actions';
 import { FixableThreat, Threat } from 'components/jetpack/threat-item/types';
 import getSiteScanUpdatingThreats from 'state/selectors/get-site-scan-updating-threats';
-import { requestJetpackScanHistory } from 'state/jetpack-scan/history/actions';
 
 export const useThreats = ( siteId: number ) => {
 	const [ selectedThreat, setSelectedThreat ] = React.useState< Threat >();
@@ -33,7 +32,6 @@ export const useThreats = ( siteId: number ) => {
 				);
 				const actionCreator = action === 'fix' ? fixThreat : ignoreThreat;
 				dispatch( actionCreator( siteId, selectedThreat.id ) );
-				dispatch( requestJetpackScanHistory( siteId ) );
 			}
 		},
 		[ dispatch, selectedThreat, siteId ]

--- a/client/state/data-layer/wpcom/sites/scan/threats/ignore.js
+++ b/client/state/data-layer/wpcom/sites/scan/threats/ignore.js
@@ -5,6 +5,7 @@ import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { JETPACK_SCAN_THREAT_IGNORE } from 'state/action-types';
 import { registerHandlers } from 'state/data-layer/handler-registry';
 import { requestScanStatus } from 'state/jetpack-scan/actions';
+import { requestJetpackScanHistory } from 'state/jetpack-scan/history/actions';
 import { updateThreat, updateThreatCompleted } from 'state/jetpack-scan/threats/actions';
 import * as sitesAlertsIgnoreHandlers from 'state/data-layer/wpcom/sites/alerts/ignore';
 
@@ -15,7 +16,11 @@ export const request = ( action ) => {
 
 export const success = ( action, rewindState ) => {
 	const defaultActions = sitesAlertsIgnoreHandlers.success( action, rewindState );
-	return [ ...defaultActions, requestScanStatus( action.siteId, false ) ];
+	return [
+		...defaultActions,
+		requestScanStatus( action.siteId, false ),
+		requestJetpackScanHistory( action.siteId ),
+	];
 };
 
 export const failure = ( action ) => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR simply dispatches `requestJetpackScanHistory` after a threat fix or ignore request completes. This ensures that the history grid is updated with the latest threat.

Shortcoming, not necessarily fixable here - When a fix takes a long amount of time, it does not immediately show up in the history, since it's not yet in the proper MySQL table. There's no great way around this now, but due to possible changes to the API in the near future, I'm not putting a lot of thought into that scenario. For now, I think this is fine.

#### Testing instructions

* Boot this branch in calypso dev and find your way to the scan page with `?flags=jetpack/features-section` on the end of the URL. Follow through with the "ignore threat" flow. Immediately after ignoring, a request should go to the history endpoint and the history list should update with the new data when the request resolves.
