### PR TITLE
Jetpack Cloud: replace the credentials with a Banner when Jetpack section is enabled

### DIFF
--- a/client/my-sites/site-settings/settings-security/main.jsx
+++ b/client/my-sites/site-settings/settings-security/main.jsx
@@ -9,6 +9,8 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import config from 'config';
+import Banner from 'components/banner';
 import DocumentHead from 'components/data/document-head';
 import FormSecurity from 'my-sites/site-settings/form-security';
 import getRewindState from 'state/selectors/get-rewind-state';
@@ -53,7 +55,10 @@ const SiteSettingsSecurity = ( {
 	);
 	const hasScanProduct = sitePurchases.some( ( p ) => p.productSlug.includes( 'jetpack_scan' ) );
 
-	const showCredentials = isRewindActive || hasScanProduct;
+	// If Jetpack section is enabled, we no longer display the credentials here, instead we
+	// display a Banner with a CTA that points to their new location (Settings > Jetpack).
+	const isJetpackSectionEnabled = config.isEnabled( 'jetpack/features-section' );
+	const showCredentials = ( isRewindActive || hasScanProduct ) && ! isJetpackSectionEnabled;
 
 	return (
 		<Main className="settings-security site-settings">
@@ -69,6 +74,20 @@ const SiteSettingsSecurity = ( {
 			/>
 			<SiteSettingsNavigation site={ site } section="security" />
 			{ showCredentials && <JetpackCredentials /> }
+			{ isJetpackSectionEnabled && (
+				<Banner
+					callToAction="Take me there!"
+					title={ translate( 'Looking for Jetpack backups and security scans settings?' ) }
+					description={ translate(
+						"In order to simplify your experience we've moved these to their dedicated section under the Jetpack settings tab."
+					) }
+					dismissPreferenceName="backup-scan-security-settings-moved"
+					dismissTemporary
+					horizontal
+					href="/settings/jetpack"
+					jetpack
+				/>
+			) }
 			<JetpackMonitor />
 			<FormSecurity />
 		</Main>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The goal is to remove the server credentials from the Security tab and add a Banner in its place. This Banner contains a CTA to the server credentials new location at the Jetpack tab (no yet implement).

#### Testing instructions

* Run this PR with `yarn start`.
* Go to `http://calypso.localhost:3000/settings/security/<youSiteSlug>?flags=jetpack/features-section`.
* Verify that the server credentials aren't visible.
* Verify that there is a Banner with a CTA that points to `/settings/jetpack` (broken link for the moment).
* Go to `http://calypso.localhost:3000/settings/security/<youSiteSlug>`.
* Verify that the server credentials are visible.
* Verify that there is no Banner.

#### Demo
![image](https://user-images.githubusercontent.com/3418513/84200509-51e7c880-aa7d-11ea-8d6c-28eed1c8301e.png)


Fixes 1179060693083348-as-1179378358843971
