### PR TITLE
composite-checkout: Fix discounted price in variant picker

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -400,12 +400,6 @@ export default function CompositeCheckout( {
 
 		return (
 			<React.Fragment>
-				<QuerySitePlans siteId={ siteId } />
-				<QueryPlans />
-				<QueryProducts />
-				<QueryContactDetailsCache />
-				<QueryStoredCards />
-
 				<ManagedContactDetailsFormFields
 					needsOnlyGoogleAppsDetails={ needsOnlyGoogleAppsDetails }
 					contactDetails={ contactDetails }
@@ -509,6 +503,12 @@ export default function CompositeCheckout( {
 
 	return (
 		<React.Fragment>
+			<QuerySitePlans siteId={ siteId } />
+			<QueryPlans />
+			<QueryProducts />
+			<QueryContactDetailsCache />
+			<QueryStoredCards />
+
 			<PageViewTracker path={ analyticsPath } title="Checkout" properties={ analyticsProps } />
 			<CheckoutProvider
 				items={ itemsForCheckout }

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -4,7 +4,6 @@
 import page from 'page';
 import wp from 'lib/wp';
 import React, { useEffect, useState, useCallback, useMemo, useRef } from 'react';
-import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import debugFactory from 'debug';
@@ -26,12 +25,7 @@ import { flatten } from 'lodash';
 /**
  * Internal dependencies
  */
-import { requestPlans } from 'state/plans/actions';
-import {
-	computeProductsWithPrices,
-	getProductsList,
-	isProductsListFetching,
-} from 'state/products-list/selectors';
+import { getProductsList, isProductsListFetching } from 'state/products-list/selectors';
 import {
 	useStoredCards,
 	useIsApplePayAvailable,
@@ -54,10 +48,8 @@ import getCountries from 'state/selectors/get-countries';
 import { fetchPaymentCountries } from 'state/countries/actions';
 import { StateSelect } from 'my-sites/domains/components/form';
 import ManagedContactDetailsFormFields from 'components/domains/contact-details-form-fields/managed-contact-details-form-fields';
-import { getPlan, findPlansKeys } from 'lib/plans';
+import { getPlan } from 'lib/plans';
 import { getTld } from 'lib/domains';
-import { GROUP_WPCOM, TERM_ANNUALLY, TERM_BIENNIALLY, TERM_MONTHLY } from 'lib/plans/constants';
-import { requestProductsList } from 'state/products-list/actions';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import { useStripe } from 'lib/stripe';
 import CheckoutTerms from '../checkout/checkout-terms.jsx';
@@ -96,6 +88,7 @@ import { AUTO_RENEWAL } from 'lib/url/support';
 import { useLocalizedMoment } from 'components/localized-moment';
 import isDomainOnlySite from 'state/selectors/is-domain-only-site';
 import { retrieveSignupDestination, clearSignupDestinationCookie } from 'signup/utils';
+import { useWpcomProductVariants } from './wpcom/hooks/product-variants';
 
 const debug = debugFactory( 'calypso:composite-checkout' );
 
@@ -487,7 +480,7 @@ export default function CompositeCheckout( {
 			paypal: ( transactionData ) =>
 				payPalProcessor( transactionData, getThankYouUrl, couponItem, isWhiteGloveOffer ),
 		} ),
-		[ couponItem, getThankYouUrl ]
+		[ couponItem, getThankYouUrl, isWhiteGloveOffer ]
 	);
 
 	useRecordCheckoutLoaded(
@@ -705,136 +698,6 @@ function CountrySelectMenu( {
 	);
 }
 
-function getTermText( term, translate ) {
-	switch ( term ) {
-		case TERM_BIENNIALLY:
-			return translate( 'Two years' );
-
-		case TERM_ANNUALLY:
-			return translate( 'One year' );
-
-		case TERM_MONTHLY:
-			return translate( 'One month' );
-	}
-}
-
-// TODO: replace this with a real localize function
-function localizeCurrency( amount ) {
-	const decimalAmount = ( amount / 100 ).toFixed( 2 );
-	return `$${ decimalAmount }`;
-}
-
-function useWpcomProductVariants( { siteId, productSlug, credits, couponDiscounts } ) {
-	const translate = useTranslate();
-	const reduxDispatch = useDispatch();
-
-	const availableVariants = useVariantWpcomPlanProductSlugs( productSlug );
-
-	const productsWithPrices = useSelector( ( state ) => {
-		return computeProductsWithPrices(
-			state,
-			siteId,
-			availableVariants, // : WPCOMProductSlug[]
-			credits || 0, // : number
-			couponDiscounts || {} // object of product ID / absolute amount pairs
-		);
-	} );
-
-	const [ haveFetchedProducts, setHaveFetchedProducts ] = useState( false );
-	const shouldFetchProducts = ! productsWithPrices;
-
-	useEffect( () => {
-		// Trigger at most one HTTP request
-		debug( 'deciding whether to request product variant data' );
-		if ( shouldFetchProducts && ! haveFetchedProducts ) {
-			debug( 'dispatching request for product variant data' );
-			reduxDispatch( requestPlans() );
-			reduxDispatch( requestProductsList() );
-			setHaveFetchedProducts( true );
-		}
-	}, [ shouldFetchProducts, haveFetchedProducts, reduxDispatch ] );
-
-	return ( anyProductSlug ) => {
-		if ( anyProductSlug !== productSlug ) {
-			return [];
-		}
-
-		const highestMonthlyPrice = Math.max(
-			...productsWithPrices.map( ( variant ) => {
-				return variant.priceMonthly;
-			} )
-		);
-
-		const percentSavings = ( monthlyPrice ) => {
-			const savings = Math.round( 100 * ( 1 - monthlyPrice / highestMonthlyPrice ) );
-			return savings > 0 ? <Discount>-{ savings.toString() }%</Discount> : null;
-		};
-
-		// What the customer would pay if using the
-		// most expensive schedule
-		const highestTermPrice = ( term ) => {
-			if ( term !== TERM_BIENNIALLY ) {
-				return;
-			}
-			const annualPrice = Math.round( 100 * 24 * highestMonthlyPrice );
-			return <DoNotPayThis>{ localizeCurrency( annualPrice, 'USD' ) }</DoNotPayThis>;
-		};
-
-		return productsWithPrices.map( ( variant ) => {
-			const label = getTermText( variant.plan.term, translate );
-			const price = (
-				<React.Fragment>
-					{ percentSavings( variant.priceMonthly ) }
-					{ highestTermPrice( variant.plan.term ) }
-					{ variant.product.cost_display }
-				</React.Fragment>
-			);
-
-			return {
-				variantLabel: label,
-				variantDetails: price,
-				productSlug: variant.planSlug,
-				productId: variant.product.product_id,
-			};
-		} );
-	};
-}
-
-function useVariantWpcomPlanProductSlugs( productSlug ) {
-	const reduxDispatch = useDispatch();
-
-	const chosenPlan = getPlan( productSlug );
-
-	const [ haveFetchedPlans, setHaveFetchedPlans ] = useState( false );
-	const shouldFetchPlans = ! chosenPlan;
-
-	useEffect( () => {
-		// Trigger at most one HTTP request
-		debug( 'deciding whether to request plan variant data' );
-		if ( shouldFetchPlans && ! haveFetchedPlans ) {
-			debug( 'dispatching request for plan variant data' );
-			reduxDispatch( requestPlans() );
-			reduxDispatch( requestProductsList() );
-			setHaveFetchedPlans( true );
-		}
-	}, [ haveFetchedPlans, shouldFetchPlans, reduxDispatch ] );
-
-	if ( ! chosenPlan ) {
-		return [];
-	}
-
-	// Only construct variants for WP.com plans
-	if ( chosenPlan.group !== GROUP_WPCOM ) {
-		return [];
-	}
-
-	// : WPCOMProductSlug[]
-	return findPlansKeys( {
-		group: chosenPlan.group,
-		type: chosenPlan.type,
-	} );
-}
-
 function useCachedDomainContactDetails() {
 	const reduxDispatch = useDispatch();
 	const [ haveRequestedCachedDetails, setHaveRequestedCachedDetails ] = useState( false );
@@ -863,16 +726,6 @@ function getPlanProductSlugs(
 		} )
 		.map( ( item ) => item.wpcom_meta.product_slug );
 }
-
-const Discount = styled.span`
-	color: ${ ( props ) => props.theme.colors.discount };
-	margin-right: 8px;
-`;
-
-const DoNotPayThis = styled.span`
-	text-decoration: line-through;
-	margin-right: 8px;
-`;
 
 function getAnalyticsPath( purchaseId, product, selectedSiteSlug, selectedFeature, plan ) {
 	debug( 'getAnalyticsPath', { purchaseId, product, selectedSiteSlug, selectedFeature, plan } );

--- a/client/my-sites/checkout/composite-checkout/wpcom/hooks/product-variants.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/hooks/product-variants.js
@@ -15,6 +15,7 @@ import { computeProductsWithPrices } from 'state/products-list/selectors';
 import { getPlan, findPlansKeys } from 'lib/plans';
 import { GROUP_WPCOM, TERM_ANNUALLY, TERM_BIENNIALLY, TERM_MONTHLY } from 'lib/plans/constants';
 import { requestProductsList } from 'state/products-list/actions';
+import { myFormatCurrency } from 'blocks/subscription-length-picker';
 
 const debug = debugFactory( 'calypso:composite-checkout:product-variants' );
 
@@ -68,10 +69,10 @@ function VariantPrice( { variant } ) {
 			{ isDiscounted && <VariantPriceDiscount variant={ variant } /> }
 			{ isDiscounted && (
 				<DoNotPayThis>
-					{ localizeCurrency( variant.priceFullBeforeDiscount, variant.product.currency_code ) }
+					{ myFormatCurrency( variant.priceFullBeforeDiscount, variant.product.currency_code ) }
 				</DoNotPayThis>
 			) }
-			{ localizeCurrency( variant.priceFinal, variant.product.currency_code ) }
+			{ myFormatCurrency( variant.priceFinal, variant.product.currency_code ) }
 		</React.Fragment>
 	);
 }
@@ -129,16 +130,6 @@ function getTermText( term, translate ) {
 		case TERM_MONTHLY:
 			return translate( 'One month' );
 	}
-}
-
-// TODO: replace this with a real localize function
-function localizeCurrency( amount, currency ) {
-	if ( currency !== 'USD' ) {
-		debug( 'cannot localize non-USD currency', currency );
-		return amount;
-	}
-	const decimalAmount = Number.parseFloat( amount ).toFixed( 2 );
-	return `$${ decimalAmount }`;
 }
 
 const Discount = styled.span`

--- a/client/my-sites/checkout/composite-checkout/wpcom/hooks/product-variants.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/hooks/product-variants.js
@@ -63,7 +63,8 @@ export function useWpcomProductVariants( { siteId, productSlug, credits, couponD
 }
 
 function VariantPrice( { variant } ) {
-	const isDiscounted = variant.priceFinal !== variant.priceFullBeforeDiscount;
+	const currentPrice = variant.priceFinal || variant.priceFull;
+	const isDiscounted = currentPrice !== variant.priceFullBeforeDiscount;
 	return (
 		<React.Fragment>
 			{ isDiscounted && <VariantPriceDiscount variant={ variant } /> }
@@ -72,7 +73,7 @@ function VariantPrice( { variant } ) {
 					{ myFormatCurrency( variant.priceFullBeforeDiscount, variant.product.currency_code ) }
 				</DoNotPayThis>
 			) }
-			{ myFormatCurrency( variant.priceFinal, variant.product.currency_code ) }
+			{ myFormatCurrency( currentPrice, variant.product.currency_code ) }
 		</React.Fragment>
 	);
 }

--- a/client/my-sites/checkout/composite-checkout/wpcom/hooks/product-variants.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/hooks/product-variants.js
@@ -79,10 +79,19 @@ function VariantPrice( { variant } ) {
 }
 
 function VariantPriceDiscount( { variant } ) {
+	const translate = useTranslate();
 	const discountPercentage = Math.round(
 		100 - ( variant.priceFinal / variant.priceFullBeforeDiscount ) * 100
 	);
-	return <Discount>{ discountPercentage }%</Discount>;
+	return (
+		<Discount>
+			{ translate( 'Save %(percent)s%%', {
+				args: {
+					percent: discountPercentage,
+				},
+			} ) }
+		</Discount>
+	);
 }
 
 function useVariantWpcomPlanProductSlugs( productSlug ) {

--- a/client/my-sites/checkout/composite-checkout/wpcom/hooks/product-variants.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/hooks/product-variants.js
@@ -1,0 +1,157 @@
+/**
+ * External dependencies
+ */
+import React, { useEffect, useState } from 'react';
+import styled from '@emotion/styled';
+import { useTranslate } from 'i18n-calypso';
+import { useSelector, useDispatch } from 'react-redux';
+import debugFactory from 'debug';
+
+/**
+ * Internal dependencies
+ */
+import { requestPlans } from 'state/plans/actions';
+import { computeProductsWithPrices } from 'state/products-list/selectors';
+import { getPlan, findPlansKeys } from 'lib/plans';
+import { GROUP_WPCOM, TERM_ANNUALLY, TERM_BIENNIALLY, TERM_MONTHLY } from 'lib/plans/constants';
+import { requestProductsList } from 'state/products-list/actions';
+
+const debug = debugFactory( 'calypso:composite-checkout:product-variants' );
+
+export function useWpcomProductVariants( { siteId, productSlug, credits, couponDiscounts } ) {
+	const translate = useTranslate();
+	const reduxDispatch = useDispatch();
+
+	const variantProductSlugs = useVariantWpcomPlanProductSlugs( productSlug );
+
+	const productsWithPrices = useSelector( ( state ) => {
+		return computeProductsWithPrices(
+			state,
+			siteId,
+			variantProductSlugs, // : WPCOMProductSlug[]
+			credits || 0, // : number
+			couponDiscounts || {} // object of product ID / absolute amount pairs
+		);
+	} );
+
+	const [ haveFetchedProducts, setHaveFetchedProducts ] = useState( false );
+	const shouldFetchProducts = ! productsWithPrices;
+
+	useEffect( () => {
+		debug( 'deciding whether to request product variant data' );
+		if ( shouldFetchProducts && ! haveFetchedProducts ) {
+			debug( 'dispatching request for product variant data' );
+			reduxDispatch( requestPlans() );
+			reduxDispatch( requestProductsList() );
+			setHaveFetchedProducts( true );
+		}
+	}, [ shouldFetchProducts, haveFetchedProducts, reduxDispatch ] );
+
+	return ( anyProductSlug ) => {
+		if ( anyProductSlug !== productSlug ) {
+			return [];
+		}
+
+		return productsWithPrices.map( ( variant ) => ( {
+			variantLabel: getTermText( variant.plan.term, translate ),
+			variantDetails: (
+				<VariantPrice variant={ variant } productsWithPrices={ productsWithPrices } />
+			),
+			productSlug: variant.planSlug,
+			productId: variant.product.product_id,
+		} ) );
+	};
+}
+
+function VariantPrice( { variant, productsWithPrices } ) {
+	const highestMonthlyPrice = Math.max(
+		...productsWithPrices.map( ( product ) => {
+			return product.priceMonthly;
+		} )
+	);
+
+	const percentSavings = ( monthlyPrice ) => {
+		const savings = Math.round( 100 * ( 1 - monthlyPrice / highestMonthlyPrice ) );
+		return savings > 0 ? <Discount>-{ savings.toString() }%</Discount> : null;
+	};
+
+	const highestTermPrice = ( term ) => {
+		if ( term !== TERM_BIENNIALLY ) {
+			return;
+		}
+		const annualPrice = Math.round( 100 * 24 * highestMonthlyPrice );
+		return <DoNotPayThis>{ localizeCurrency( annualPrice, 'USD' ) }</DoNotPayThis>;
+	};
+
+	return (
+		<React.Fragment>
+			{ percentSavings( variant.priceMonthly ) }
+			{ highestTermPrice( variant.plan.term ) }
+			{ variant.product.cost_display }
+		</React.Fragment>
+	);
+}
+
+function useVariantWpcomPlanProductSlugs( productSlug ) {
+	const reduxDispatch = useDispatch();
+
+	const chosenPlan = getPlan( productSlug );
+
+	const [ haveFetchedPlans, setHaveFetchedPlans ] = useState( false );
+	const shouldFetchPlans = ! chosenPlan;
+
+	useEffect( () => {
+		// Trigger at most one HTTP request
+		debug( 'deciding whether to request plan variant data' );
+		if ( shouldFetchPlans && ! haveFetchedPlans ) {
+			debug( 'dispatching request for plan variant data' );
+			reduxDispatch( requestPlans() );
+			reduxDispatch( requestProductsList() );
+			setHaveFetchedPlans( true );
+		}
+	}, [ haveFetchedPlans, shouldFetchPlans, reduxDispatch ] );
+
+	if ( ! chosenPlan ) {
+		return [];
+	}
+
+	// Only construct variants for WP.com plans
+	if ( chosenPlan.group !== GROUP_WPCOM ) {
+		return [];
+	}
+
+	// : WPCOMProductSlug[]
+	return findPlansKeys( {
+		group: chosenPlan.group,
+		type: chosenPlan.type,
+	} );
+}
+
+function getTermText( term, translate ) {
+	switch ( term ) {
+		case TERM_BIENNIALLY:
+			return translate( 'Two years' );
+
+		case TERM_ANNUALLY:
+			return translate( 'One year' );
+
+		case TERM_MONTHLY:
+			return translate( 'One month' );
+	}
+}
+
+// TODO: replace this with a real localize function
+function localizeCurrency( amount ) {
+	const decimalAmount = ( amount / 100 ).toFixed( 2 );
+	return `$${ decimalAmount }`;
+}
+
+const Discount = styled.span`
+	color: ${ ( props ) => props.theme.colors.discount };
+	margin-right: 8px;
+`;
+
+const DoNotPayThis = styled.span`
+	text-decoration: line-through;
+	margin-right: 8px;
+`;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In https://github.com/Automattic/wp-calypso/pull/42723 I added a bunch of query components from old checkout to new checkout, including `QuerySitePlans`, but I accidentally added them to `renderContactDetails` instead of the output of `CompositeCheckout`. One result of this is that the `state.sites.plans` Redux state was not populated, which meant that the local data used to determine if a plan should receive a prorated discount was not available. In new checkout, that data is used only for the plan variant selector (all the rest of the prices come from the shopping cart endpoint) and so the selector is showing the un-discounted price for each plan variant.

![Screen Shot 2020-06-09 at 4 35 08 PM](https://user-images.githubusercontent.com/2036909/84206259-cb32eb80-aa7c-11ea-9623-3dac7bfe2068.png)

This PR moves the Query components to their correct location, but even though that makes the data available, we were still not using the discounted price in the variant selector. This PR also modifies the logic for displaying the price in the selector to take the discount into account.

![Screen Shot 2020-06-10 at 2 16 24 PM](https://user-images.githubusercontent.com/2036909/84303456-fffa7d80-ab24-11ea-86f0-8f4ab31afc61.png)


Fixes #43122

#### Testing instructions

- Use a site which already has a plan (eg: Personal).
- Add a higher-priced plan to the cart (eg: Premium).
- Visit composite checkout.
- Click the "Edit" button for the review step (the first step at the top of checkout).
- Verify that the discounted price for the plan in the cart matches the price in the one-and-two-year variant selector.