### PR TITLE
Block Editor: Don't try to load the block editor in an iframe in Safari.

### DIFF
--- a/client/state/selectors/should-redirect-gutenberg.js
+++ b/client/state/selectors/should-redirect-gutenberg.js
@@ -1,9 +1,24 @@
 /**
+ * External dependencies
+ */
+import UserAgent from 'express-useragent';
+
+/**
  * Internal dependencies
  */
 import { getSelectedEditor } from 'state/selectors/get-selected-editor';
+import versionCompare from 'lib/version-compare';
 
 export const shouldRedirectGutenberg = ( state, siteId ) => {
+	if ( window && window.navigator ) {
+		// Safari 13 implemented strict cross-site cookie restrictions,
+		// which cause the editor iframe to fail loading. Always redirect Safari 13+.
+		const { isSafari, version } = UserAgent.parse( window.navigator.userAgent );
+		if ( isSafari && versionCompare( version, 13, '>=' ) ) {
+			return true;
+		}
+	}
+
 	const validEditors = [ 'gutenberg-redirect', 'gutenberg-redirect-and-style' ];
 	const selectedEditor = getSelectedEditor( state, siteId );
 	return validEditors.indexOf( selectedEditor ) > -1;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As described in #43068, Safari's cross-site cookie blocking is causing the block editor iframe to never load.

This PR skips trying to load the iframe, and redirects to wp-admin.

#### Testing instructions

Due to this being a fix for Safari behaviour with third party cookies disallowed, it's a little tricky to test, since neither `calypso.localhost` nor `calypso.live` are the same domain as `wordpress.com`, which means the auth cookie won't be sent to `public-api.wordpress.com`.

Since this fix is based on the browser UA string, a reasonable test method is to set your UA in Firefox/Chrome to ` Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.1.1 Safari/605.1.15`, imitating Safari 13.1.1.

Fixes #43068.
