### PR TITLE
Fix AMP analytics URL parser.

### DIFF
--- a/client/lib/analytics/utils/url-parse-amp-compatible.js
+++ b/client/lib/analytics/utils/url-parse-amp-compatible.js
@@ -58,7 +58,7 @@ export default function urlParseAmpCompatible( url ) {
 		debug( 'urlParseAmpCompatible: original query:', parsedUrl.search );
 
 		if ( parsedUrl.searchParams.has( 'tk_amp' ) ) {
-			const tk_amp = parseAmpEncodedParams( parsedUrl.searchParams.tk_amp );
+			const tk_amp = parseAmpEncodedParams( parsedUrl.searchParams.get( 'tk_amp' ) );
 			debug( 'urlParseAmpCompatible: tk_amp:', tk_amp );
 			for ( const key of Object.keys( tk_amp ) ) {
 				if ( ! parsedUrl.searchParams.has( key ) ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use `.get()` method of `URLSearchParams` object to acquire `tk_amp`.
  * Fixes an issue first introduced in https://github.com/Automattic/wp-calypso/commit/b2cc20b1e854136a4d4b38f0ee898ef5114f3b10 by @sgomes. Property access on `URLSearchParams` object doesn't work as one would expect. Must use `.get()`.

#### Testing instructions

Run Calypso locally and visit this URL: http://calypso.localhost:3000/start/user?ref=alp-lp&tk_amp=1*s4a2cn*amp_client_id*YW1wLWQzY3J6b2JOMmpXazhSZ3NkRnhJelE.*aff*MzAxMDI.*sid*RU4tMTU0NTkwMzg.&_gl=1*1ptehrf*_ga*YW1wLVRvYXBDT2R0WHZKVnV3WG0tQTlEc2c.

- Filter Network requests by `refer.wordpress.com` and confirm a 200 status.

---

Try without this fix and confirm broken w/ no `refer.wordpress.com` connection.