### PR TITLE
Gutenboarding: Fix domain picker button toggle behaviour

### DIFF
--- a/client/landing/gutenboarding/components/domain-picker-button/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-button/index.tsx
@@ -48,7 +48,11 @@ const DomainPickerButton: React.FunctionComponent< Props > = ( {
 		'popover' | 'modal' | undefined
 	>();
 
-	const handlePopoverToggle = () => {
+	const handlePopoverToggle = ( e?: React.FocusEvent ) => {
+		// Don't collide with button toggling
+		if ( e?.relatedTarget === buttonRef.current ) {
+			return;
+		}
 		setDomainPickerMode( ( mode ) => ( mode ? undefined : 'popover' ) );
 	};
 

--- a/client/landing/gutenboarding/components/domain-picker-button/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-button/index.tsx
@@ -42,18 +42,20 @@ const DomainPickerButton: React.FunctionComponent< Props > = ( {
 } ) => {
 	const { __ } = useI18n();
 
-	const buttonRef = React.createRef< HTMLButtonElement >();
+	const containerRef = React.createRef< HTMLDivElement >();
 
 	const [ domainPickerMode, setDomainPickerMode ] = React.useState<
 		'popover' | 'modal' | undefined
 	>();
 
-	const handlePopoverToggle = ( e?: React.FocusEvent ) => {
-		// Don't collide with button toggling
-		if ( e?.relatedTarget === buttonRef.current ) {
-			return;
-		}
+	const handlePopoverToggle = () => {
 		setDomainPickerMode( ( mode ) => ( mode ? undefined : 'popover' ) );
+	};
+
+	const handlePopoverFocusOutside = () => {
+		if ( ! containerRef?.current?.contains( document.activeElement ) ) {
+			handlePopoverToggle();
+		}
 	};
 
 	const handleClose = () => {
@@ -84,7 +86,7 @@ const DomainPickerButton: React.FunctionComponent< Props > = ( {
 	);
 
 	return (
-		<>
+		<div ref={ containerRef } className="domain-picker-button__container" tabIndex={ -1 }>
 			<Button
 				{ ...buttonProps }
 				aria-expanded={ !! domainPickerMode }
@@ -95,7 +97,6 @@ const DomainPickerButton: React.FunctionComponent< Props > = ( {
 					'is-modal-open': domainPickerMode === 'modal',
 				} ) }
 				onClick={ handlePopoverToggle }
-				ref={ buttonRef }
 			>
 				<span className="domain-picker-button__label">{ children }</span>
 				<Icon icon={ chevronDown } size={ 22 } />
@@ -103,13 +104,14 @@ const DomainPickerButton: React.FunctionComponent< Props > = ( {
 			<DomainPickerPopover
 				isOpen={ domainPickerMode === 'popover' }
 				onClose={ handlePopoverToggle }
+				onFocusOutside={ handlePopoverFocusOutside }
 			>
 				{ domainPicker }
 			</DomainPickerPopover>
 			<DomainPickerModal isOpen={ domainPickerMode === 'modal' } onClose={ handleClose }>
 				{ domainPicker }
 			</DomainPickerModal>
-		</>
+		</div>
 	);
 };
 

--- a/client/landing/gutenboarding/components/domain-picker-button/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker-button/style.scss
@@ -18,6 +18,10 @@
 	}
 }
 
+.domain-picker-button__container {
+	display: inline-flex;
+}
+
 .domain-picker-button {
 	&.components-button {
 		@include onboarding-medium-text;

--- a/client/landing/gutenboarding/components/domain-picker-popover/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-popover/index.tsx
@@ -35,11 +35,11 @@ const DomainPickerPopover: React.FunctionComponent< Props > = ( { isOpen, onClos
 		}
 	}, [ isOpen ] );
 
-	const handleClose = () => {
+	const handleClose = ( e?: React.FocusEvent ) => {
 		recordCloseModal( tracksName, {
 			selected_domain: select( STORE_KEY ).getSelectedDomain()?.domain_name,
 		} );
-		onClose?.();
+		onClose?.( e );
 	};
 
 	// Don't render popover when isOpen is false.

--- a/client/landing/gutenboarding/components/domain-picker-popover/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-popover/index.tsx
@@ -19,11 +19,17 @@ import './style.scss';
 
 interface Props {
 	onClose: Function;
+	onFocusOutside: Function;
 	isOpen: boolean;
 	children: any;
 }
 
-const DomainPickerPopover: React.FunctionComponent< Props > = ( { isOpen, onClose, children } ) => {
+const DomainPickerPopover: React.FunctionComponent< Props > = ( {
+	isOpen,
+	onClose,
+	onFocusOutside,
+	children,
+} ) => {
 	// Popover expands at medium viewport width
 	const isMobile = useViewportMatch( 'medium', '<' );
 
@@ -35,11 +41,18 @@ const DomainPickerPopover: React.FunctionComponent< Props > = ( { isOpen, onClos
 		}
 	}, [ isOpen ] );
 
-	const handleClose = ( e?: React.FocusEvent ) => {
+	const handleClose = () => {
 		recordCloseModal( tracksName, {
 			selected_domain: select( STORE_KEY ).getSelectedDomain()?.domain_name,
 		} );
-		onClose?.( e );
+		onClose?.();
+	};
+
+	const handleFocusOutside = () => {
+		recordCloseModal( tracksName, {
+			selected_domain: select( STORE_KEY ).getSelectedDomain()?.domain_name,
+		} );
+		onFocusOutside?.();
 	};
 
 	// Don't render popover when isOpen is false.
@@ -56,7 +69,7 @@ const DomainPickerPopover: React.FunctionComponent< Props > = ( { isOpen, onClos
 				focusOnMount={ isMobile ? 'container' : 'firstElement' }
 				noArrow
 				onClose={ handleClose }
-				onFocusOutside={ handleClose }
+				onFocusOutside={ handleFocusOutside }
 				position={ 'bottom center' }
 				expandOnMobile={ true }
 			>


### PR DESCRIPTION
It looks like the domain picker refactor in https://github.com/Automattic/wp-calypso/pull/42657/ stopped the focus event from the popover from being passed up to the domain picker button, so if you clicked the domain button picker button while the domain popover was visible, it'd close and then re-open the domain picker.

This change adds in a container div to the button, along with a ref, and a `handlePopoverFocusOutside` function that checks to see if the `containerRef` contains the currently active element before allowing the focus outside to toggle the button. This is a workaround for Firefox and Safari's `button` focus support ([more info here](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Clicking_and_focus)), and this approach mirrors how the [WordPress `DropDown` component](https://github.com/wordpress/gutenberg/blob/master/packages/components/src/dropdown/index.js#L60) deals with toggling behaviour and clicking outside.

#### Changes proposed in this Pull Request

* Add a container div to the domain-picker-button (required to get focus behaviour working cross-browser)
* Add a `closeIfFocusOutside` function to deal with the PopOver's onFocus behaviour — this checks that the active element is within the container, and if it isn't, then allows the toggle to proceed.

![domain-picker-button-toggle-small](https://user-images.githubusercontent.com/14988353/84222447-f409be00-ab1a-11ea-92dc-78ae80305281.gif)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/new` and enter a site title
* When the domain picker button appears, click it to open the domain picker popover.
* Click it again and it should hide without immediately reopening again
* Check across Safari, FF, Chrome and Edge
* Ensure that the `recordCloseModal` Tracks event still fires when you close the popover with this button (`DomainPickerPopover`)

Fixes #

