### PR TITLE
Jetpack section:  Add Jetpack tab to Settings section

### DIFF
--- a/client/my-sites/site-settings/navigation.jsx
+++ b/client/my-sites/site-settings/navigation.jsx
@@ -30,6 +30,7 @@ export class SiteSettingsNavigation extends Component {
 			writing: translate( 'Writing', { context: 'settings screen' } ),
 			discussion: translate( 'Discussion', { context: 'settings screen' } ),
 			security: translate( 'Security', { context: 'settings screen' } ),
+			jetpack: 'Jetpack',
 		};
 	}
 
@@ -87,6 +88,16 @@ export class SiteSettingsNavigation extends Component {
 					>
 						{ strings.discussion }
 					</NavItem>
+
+					{ config.isEnabled( 'jetpack/features-section' ) && site.jetpack && (
+						<NavItem
+							path={ `/settings/jetpack/${ site.slug }` }
+							preloadSectionName="settings-jetpack"
+							selected={ section === 'jetpack' }
+						>
+							{ strings.jetpack }
+						</NavItem>
+					) }
 				</NavTabs>
 			</SectionNav>
 		);

--- a/client/my-sites/site-settings/settings-jetpack/controller.js
+++ b/client/my-sites/site-settings/settings-jetpack/controller.js
@@ -1,0 +1,15 @@
+/**
+ * External dependencies
+ */
+
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import JetpackMain from 'my-sites/site-settings/settings-jetpack/main';
+
+export function jetpack( context, next ) {
+	context.primary = React.createElement( JetpackMain );
+	next();
+}

--- a/client/my-sites/site-settings/settings-jetpack/index.js
+++ b/client/my-sites/site-settings/settings-jetpack/index.js
@@ -1,0 +1,25 @@
+/**
+ * External dependencies
+ */
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+import { makeLayout, render as clientRender } from 'controller';
+import { navigation, siteSelection } from 'my-sites/controller';
+import { jetpack } from './controller';
+import { setScroll, siteSettings } from 'my-sites/site-settings/settings-controller';
+
+export default function () {
+	page(
+		'/settings/jetpack/:site_id',
+		siteSelection,
+		navigation,
+		setScroll,
+		siteSettings,
+		jetpack,
+		makeLayout,
+		clientRender
+	);
+}

--- a/client/my-sites/site-settings/settings-jetpack/main.jsx
+++ b/client/my-sites/site-settings/settings-jetpack/main.jsx
@@ -1,0 +1,91 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import DocumentHead from 'components/data/document-head';
+import getRewindState from 'state/selectors/get-rewind-state';
+import JetpackCredentials from 'my-sites/site-settings/jetpack-credentials';
+import JetpackDevModeNotice from 'my-sites/site-settings/jetpack-dev-mode-notice';
+//import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
+import Main from 'components/main';
+import QueryRewindState from 'components/data/query-rewind-state';
+import QuerySitePurchases from 'components/data/query-site-purchases';
+import SidebarNavigation from 'my-sites/sidebar-navigation';
+import FormattedHeader from 'components/formatted-header';
+import SiteSettingsNavigation from 'my-sites/site-settings/navigation';
+import { getSitePurchases } from 'state/purchases/selectors';
+import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
+//import SettingsSectionHeader from '../settings-section-header';
+//import SpamFilteringSettings from '../spam-filtering-settings';
+
+const SiteSettingsJetpack = ( { rewindState, sitePurchases, site, siteId, translate } ) => {
+	// if ( ! siteIsJetpack ) {
+	// 	return (
+	// 		<JetpackManageErrorPage
+	// 			action={ translate( 'Manage general settings for %(site)s', {
+	// 				args: { site: site.name },
+	// 			} ) }
+	// 			actionURL={ '/settings/general/' + site.slug }
+	// 			title={ translate( 'No security configuration is required.' ) }
+	// 			line={ translate( 'Security management is automatic for WordPress.com sites.' ) }
+	// 			illustration="/calypso/images/illustrations/illustration-jetpack.svg"
+	// 		/>
+	// 	);
+	// }
+
+	const isRewindActive = [ 'awaitingCredentials', 'provisioning', 'active' ].includes(
+		rewindState.state
+	);
+	const hasScanProduct = sitePurchases.some( ( p ) => p.productSlug.includes( 'jetpack_scan' ) );
+
+	const showCredentials = isRewindActive || hasScanProduct;
+
+	return (
+		<Main className="settings-jetpack site-settings">
+			<QueryRewindState siteId={ siteId } />
+			<QuerySitePurchases siteId={ siteId } />
+			<DocumentHead title={ translate( 'Site Settings' ) } />
+			<JetpackDevModeNotice />
+			<SidebarNavigation />
+			<FormattedHeader
+				className="settings-jetpack__page-heading"
+				headerText={ translate( 'Settings' ) }
+				align="left"
+			/>
+			<SiteSettingsNavigation site={ site } section="jetpack" />
+
+			{ showCredentials && <JetpackCredentials /> }
+		</Main>
+	);
+};
+
+SiteSettingsJetpack.propTypes = {
+	rewindState: PropTypes.bool,
+	sitePurchases: PropTypes.array,
+	site: PropTypes.object,
+	siteId: PropTypes.number,
+	siteIsJetpack: PropTypes.bool,
+};
+
+export default connect( ( state ) => {
+	const site = getSelectedSite( state );
+	const siteId = getSelectedSiteId( state );
+	const rewindState = getRewindState( state, siteId );
+	const sitePurchases = getSitePurchases( state, siteId );
+
+	return {
+		rewindState,
+		sitePurchases,
+		site,
+		siteId,
+		siteIsJetpack: isJetpackSite( state, siteId ),
+	};
+} )( localize( SiteSettingsJetpack ) );

--- a/client/my-sites/site-settings/settings-security/main.jsx
+++ b/client/my-sites/site-settings/settings-security/main.jsx
@@ -84,7 +84,7 @@ const SiteSettingsSecurity = ( {
 					dismissPreferenceName="backup-scan-security-settings-moved"
 					dismissTemporary
 					horizontal
-					href="/settings/jetpack"
+					href={ `/settings/jetpack/${ site.slug }` }
 					jetpack
 				/>
 			) }

--- a/client/sections.js
+++ b/client/sections.js
@@ -161,6 +161,13 @@ const sections = [
 		group: 'sites',
 	},
 	{
+		name: 'settings-jetpack',
+		paths: [ '/settings/jetpack' ],
+		module: 'my-sites/site-settings/settings-jetpack',
+		secondary: true,
+		group: 'sites',
+	},
+	{
 		name: 'settings',
 		paths: [ '/settings' ],
 		module: 'my-sites/site-settings',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add a new Jetpack subsection-tab to the Settings sections in Calypso and move the Credential block to it. 

(note: in this PR the Credential block is the Credential component from Calypso and not from cloud. On an upcoming PR we'll set the Credential component from cloud.

#### Testing instructions

- Apply this change
1. `yarn start-jetpack-section` if not, use the flags query `?flags=jetpack/features-section`
2. Select a Jetpack site and go to the Settings section, you'll see the new Jetpack tab
3. Click on the Jetpack tab and you should see the Credential block (with a connected or disconnected status)
4. Click on the Security tab, you shouldn't see the Credential block and you'll see a banner with a CTA that will take you to the Jetpack tab, click on that CTA and check if it takes you to the Jetpack tab.
- Now deactivate the Jetpack features-section with this query: `?flags=-jetpack/features-section`
- Check again the point 2: now you shouldn't see the Jetpack tab 
- Check again the point 4: now you should see the Credential block as always.