### PR TITLE
i18n: Use correct locale for fetching translation chunks on demand

### DIFF
--- a/client/boot/locale.js
+++ b/client/boot/locale.js
@@ -47,7 +47,7 @@ const setupTranslationChunks = async ( localeSlug, reduxStore ) => {
 			return;
 		}
 
-		return getTranslationChunkFile( chunkId, localeSlug, window.BUILD_TARGET ).then(
+		return getTranslationChunkFile( chunkId, i18n.getLocaleSlug(), window.BUILD_TARGET ).then(
 			( translations ) => {
 				i18n.addTranslations( { ...translations, ...userTranslations } );
 				loadedTranslationChunks[ chunkId ] = true;

--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -226,7 +226,10 @@ export function getTranslationChunkFileUrl( {
  * @returns {Promise} Translation chunk json content
  */
 export function getTranslationChunkFile( chunkId, localeSlug, targetBuild = 'evergreen' ) {
-	if ( window?.i18nTranslationChunks?.[ chunkId ] ) {
+	if (
+		window?.i18nLanguageManifest?.locale?.[ '' ]?.localeSlug === localeSlug &&
+		window?.i18nTranslationChunks?.[ chunkId ]
+	) {
 		return Promise.resolve( window.i18nTranslationChunks[ chunkId ] );
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use current i18n `localeSlug` to fetch translation chunks on demand. Previously, it was always using the localeSlug Calypso was booted with.
* Restrict resolving translation chunks using `window.i18nTranslationChunks` to only when `window.i18nLanguageManifest` is for the requested locale.

#### Testing instructions

* Boot Calypso with `BUILD_TRANSLATION_CHUNKS=true ENABLE_FEATURES=use-translation-chunks,wpcom-user-bootstrap yarn start`
* Change interface language to any of the Magnificent 16 languages (e.g. German)
* Open http://calypso.localhost:3000/?flags=quick-language-switcher 
* Switch to a language with lower translation coverage (e.g. Bulgarian) from the quick langugage switcher and check if any of the missing strings will render in the language that page was initially loaded with (e.g. German).

