### PR TITLE
Refactor code to manage Security Checkup items in dedicated components

### DIFF
--- a/client/me/security-checkup/account-email.jsx
+++ b/client/me/security-checkup/account-email.jsx
@@ -1,0 +1,70 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { getCurrentUserEmail, isCurrentUserEmailVerified } from 'state/current-user/selectors';
+import { getOKIcon, getWarningIcon } from './icons.js';
+import SecurityCheckupNavigationItem from './navigation-item';
+
+class SecurityCheckupAccountEmail extends React.Component {
+	static propTypes = {
+		primaryEmail: PropTypes.string,
+		primaryEmailVerified: PropTypes.bool,
+		translate: PropTypes.func.isRequired,
+	};
+
+	render() {
+		const { primaryEmail, primaryEmailVerified, translate } = this.props;
+
+		let icon, description;
+
+		if ( ! primaryEmailVerified ) {
+			icon = getWarningIcon();
+			description = translate(
+				'Your account email address is {{strong}}%(emailAddress)s{{/strong}}, but is not verified yet.',
+				{
+					args: {
+						emailAddress: primaryEmail,
+					},
+					components: {
+						strong: <strong />,
+					},
+				}
+			);
+		} else {
+			icon = getOKIcon();
+			description = translate(
+				'Your account email address is {{strong}}%(emailAddress)s{{/strong}}.',
+				{
+					args: {
+						emailAddress: primaryEmail,
+					},
+					components: {
+						strong: <strong />,
+					},
+				}
+			);
+		}
+
+		return (
+			<SecurityCheckupNavigationItem
+				path={ '/me/account' }
+				materialIcon={ icon }
+				text={ translate( 'Account Email' ) }
+				description={ description }
+			/>
+		);
+	}
+}
+
+export default connect( ( state ) => ( {
+	primaryEmail: getCurrentUserEmail( state ),
+	primaryEmailVerified: isCurrentUserEmailVerified( state ),
+} ) )( localize( SecurityCheckupAccountEmail ) );

--- a/client/me/security-checkup/account-recovery-email.jsx
+++ b/client/me/security-checkup/account-recovery-email.jsx
@@ -51,7 +51,7 @@ class SecurityCheckupAccountRecoveryEmail extends React.Component {
 		} else if ( ! accountRecoveryEmailValidated ) {
 			icon = getWarningIcon();
 			description = translate(
-				'You still need to validate your recovery email address: {{strong}}%(recoveryEmailAddress)s{{/strong}}',
+				'You still need to verify your recovery email address: {{strong}}%(recoveryEmailAddress)s{{/strong}}',
 				{
 					args: {
 						recoveryEmailAddress: accountRecoveryEmail,

--- a/client/me/security-checkup/account-recovery-email.jsx
+++ b/client/me/security-checkup/account-recovery-email.jsx
@@ -1,0 +1,94 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import {
+	getAccountRecoveryEmail,
+	isAccountRecoveryEmailActionInProgress,
+	isAccountRecoveryEmailValidated,
+} from 'state/account-recovery/settings/selectors';
+import { getOKIcon, getWarningIcon } from './icons.js';
+import QueryAccountRecoverySettings from 'components/data/query-account-recovery-settings';
+import SecurityCheckupNavigationItem from './navigation-item';
+
+class SecurityCheckupAccountRecoveryEmail extends React.Component {
+	static propTypes = {
+		accountRecoveryEmail: PropTypes.oneOfType( [ PropTypes.bool, PropTypes.string ] ),
+		accountRecoveryEmailActionInProgress: PropTypes.bool,
+		accountRecoveryEmailValidated: PropTypes.bool,
+		translate: PropTypes.func.isRequired,
+	};
+
+	render() {
+		const {
+			accountRecoveryEmail,
+			accountRecoveryEmailActionInProgress,
+			accountRecoveryEmailValidated,
+			translate,
+		} = this.props;
+
+		if ( accountRecoveryEmailActionInProgress ) {
+			return (
+				<React.Fragment>
+					<QueryAccountRecoverySettings />
+					<SecurityCheckupNavigationItem isPlaceholder={ true } />;
+				</React.Fragment>
+			);
+		}
+
+		let icon, description;
+
+		if ( ! accountRecoveryEmail ) {
+			icon = getWarningIcon();
+			description = translate( 'You do not have a recovery email address.' );
+		} else if ( ! accountRecoveryEmailValidated ) {
+			icon = getWarningIcon();
+			description = translate(
+				'You still need to validate your recovery email address: {{strong}}%(recoveryEmailAddress)s{{/strong}}',
+				{
+					args: {
+						recoveryEmailAddress: accountRecoveryEmail,
+					},
+					components: {
+						strong: <strong />,
+					},
+				}
+			);
+		} else {
+			icon = getOKIcon();
+			description = translate(
+				'You have set {{strong}}%(recoveryEmailAddress)s{{/strong}} as your recovery email address.',
+				{
+					args: {
+						recoveryEmailAddress: accountRecoveryEmail,
+					},
+					components: {
+						strong: '<strong>',
+					},
+				}
+			);
+		}
+
+		return (
+			<SecurityCheckupNavigationItem
+				path={ '/me/security/account-recovery' }
+				materialIcon={ icon }
+				text={ translate( 'Recovery Email' ) }
+				description={ description }
+			/>
+		);
+	}
+}
+
+export default connect( ( state ) => ( {
+	accountRecoveryEmail: getAccountRecoveryEmail( state ),
+	accountRecoveryEmailActionInProgress: isAccountRecoveryEmailActionInProgress( state ),
+	accountRecoveryEmailValidated: isAccountRecoveryEmailValidated( state ),
+} ) )( localize( SecurityCheckupAccountRecoveryEmail ) );

--- a/client/me/security-checkup/account-recovery-phone.jsx
+++ b/client/me/security-checkup/account-recovery-phone.jsx
@@ -51,7 +51,7 @@ class SecurityCheckupAccountRecoveryPhone extends React.Component {
 		} else if ( ! accountRecoveryPhoneValidated ) {
 			icon = getWarningIcon();
 			description = translate(
-				'You still need to validate your recovery SMS number: {{strong}}%(recoveryPhoneNumber)s{{/strong}}',
+				'You still need to verify your recovery SMS number: {{strong}}%(recoveryPhoneNumber)s{{/strong}}',
 				{
 					args: {
 						recoveryPhoneNumber: accountRecoveryPhone.numberFull,

--- a/client/me/security-checkup/account-recovery-phone.jsx
+++ b/client/me/security-checkup/account-recovery-phone.jsx
@@ -1,0 +1,94 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import {
+	getAccountRecoveryPhone,
+	isAccountRecoveryPhoneActionInProgress,
+	isAccountRecoveryPhoneValidated,
+} from 'state/account-recovery/settings/selectors';
+import { getOKIcon, getWarningIcon } from './icons.js';
+import QueryAccountRecoverySettings from 'components/data/query-account-recovery-settings';
+import SecurityCheckupNavigationItem from './navigation-item';
+
+class SecurityCheckupAccountRecoveryPhone extends React.Component {
+	static propTypes = {
+		accountRecoveryPhone: PropTypes.object,
+		accountRecoveryPhoneActionInProgress: PropTypes.bool,
+		accountRecoveryPhoneValidated: PropTypes.bool,
+		translate: PropTypes.func.isRequired,
+	};
+
+	render() {
+		const {
+			accountRecoveryPhone,
+			accountRecoveryPhoneActionInProgress,
+			accountRecoveryPhoneValidated,
+			translate,
+		} = this.props;
+
+		if ( accountRecoveryPhoneActionInProgress ) {
+			return (
+				<React.Fragment>
+					<QueryAccountRecoverySettings />
+					<SecurityCheckupNavigationItem isPlaceholder={ true } />;
+				</React.Fragment>
+			);
+		}
+
+		let icon, description;
+
+		if ( ! accountRecoveryPhone ) {
+			icon = getWarningIcon();
+			description = translate( 'You do not have a recovery SMS number.' );
+		} else if ( ! accountRecoveryPhoneValidated ) {
+			icon = getWarningIcon();
+			description = translate(
+				'You still need to validate your recovery SMS number: {{strong}}%(recoveryPhoneNumber)s{{/strong}}',
+				{
+					args: {
+						recoveryPhoneNumber: accountRecoveryPhone.numberFull,
+					},
+					components: {
+						strong: <strong />,
+					},
+				}
+			);
+		} else {
+			icon = getOKIcon();
+			description = translate(
+				'You have set {{strong}}%(recoveryPhoneNumber)s{{/strong}} as your recovery SMS number.',
+				{
+					args: {
+						recoveryPhoneNumber: accountRecoveryPhone,
+					},
+					components: {
+						strong: <strong />,
+					},
+				}
+			);
+		}
+
+		return (
+			<SecurityCheckupNavigationItem
+				path={ '/me/security/account-recovery' }
+				materialIcon={ icon }
+				text={ translate( 'Recovery SMS Number' ) }
+				description={ description }
+			/>
+		);
+	}
+}
+
+export default connect( ( state ) => ( {
+	accountRecoveryPhone: getAccountRecoveryPhone( state ),
+	accountRecoveryPhoneActionInProgress: isAccountRecoveryPhoneActionInProgress( state ),
+	accountRecoveryPhoneValidated: isAccountRecoveryPhoneValidated( state ),
+} ) )( localize( SecurityCheckupAccountRecoveryPhone ) );

--- a/client/me/security-checkup/connected-applications.jsx
+++ b/client/me/security-checkup/connected-applications.jsx
@@ -1,0 +1,74 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import getConnectedApplications from 'state/selectors/get-connected-applications';
+import { getOKIcon, getWarningIcon } from './icons.js';
+import QueryConnectedApplications from 'components/data/query-connected-applications';
+import SecurityCheckupNavigationItem from './navigation-item';
+
+class SecurityCheckupConnectedApplications extends React.Component {
+	static propTypes = {
+		connectedApps: PropTypes.array,
+		translate: PropTypes.func.isRequired,
+	};
+
+	renderConnectedApplications() {
+		const { connectedApps, translate } = this.props;
+		let connectedAppsDescription, icon;
+
+		if ( ! connectedApps.length ) {
+			connectedAppsDescription = translate( 'You do not have any connected applications.' );
+			icon = getOKIcon();
+		} else {
+			connectedAppsDescription = translate(
+				'You currently have %(numberOfApps)d connected application.',
+				'You currently have %(numberOfApps)d connected applications.',
+				{
+					count: connectedApps.length,
+					args: {
+						numberOfApps: connectedApps.length,
+					},
+				}
+			);
+			icon = getWarningIcon();
+		}
+
+		return (
+			<SecurityCheckupNavigationItem
+				path={ '/me/security/connected-applications' }
+				materialIcon={ icon }
+				text={ translate( 'Connected Apps' ) }
+				description={ connectedAppsDescription }
+			/>
+		);
+	}
+
+	render() {
+		const { connectedApps } = this.props;
+		let content;
+		if ( connectedApps === null ) {
+			content = <SecurityCheckupNavigationItem isPlaceholder={ true } />;
+		} else {
+			content = this.renderConnectedApplications();
+		}
+
+		return (
+			<React.Fragment>
+				<QueryConnectedApplications />
+				{ content }
+			</React.Fragment>
+		);
+	}
+}
+
+export default connect( ( state ) => ( {
+	connectedApps: getConnectedApplications( state ),
+} ) )( localize( SecurityCheckupConnectedApplications ) );

--- a/client/me/security-checkup/icons.js
+++ b/client/me/security-checkup/icons.js
@@ -1,0 +1,7 @@
+export function getOKIcon() {
+	return 'check_circle';
+}
+
+export function getWarningIcon() {
+	return 'info';
+}

--- a/client/me/security-checkup/index.jsx
+++ b/client/me/security-checkup/index.jsx
@@ -3,7 +3,6 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -11,113 +10,30 @@ import { localize } from 'i18n-calypso';
  */
 import { Card } from '@automattic/components';
 import DocumentHead from 'components/data/document-head';
-import getConnectedApplications from 'state/selectors/get-connected-applications';
 import Main from 'components/main';
-import MaterialIcon from 'components/material-icon';
 import MeSidebarNavigation from 'me/sidebar-navigation';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
-import QueryAccountRecoverySettings from 'components/data/query-account-recovery-settings';
-import QueryConnectedApplications from 'components/data/query-connected-applications';
 import ReauthRequired from 'me/reauth-required';
+import SecurityCheckupAccountEmail from './account-email';
+import SecurityCheckupAccountRecoveryEmail from './account-recovery-email';
+import SecurityCheckupAccountRecoveryPhone from './account-recovery-phone';
+import SecurityCheckupConnectedApplications from './connected-applications';
+import SecurityCheckupTwoFactorAuthentication from './two-factor-authentication';
+import SecurityCheckupTwoFactorBackupCodes from './two-factor-backup-codes';
 import SecuritySectionNav from 'me/security-section-nav';
 import twoStepAuthorization from 'lib/two-step-authorization';
 import VerticalNav from 'components/vertical-nav';
-import VerticalNavItem from 'components/vertical-nav/item';
-import {
-	getAccountRecoveryEmail,
-	getAccountRecoveryPhone,
-	isAccountRecoveryEmailActionInProgress,
-	isAccountRecoveryEmailValidated,
-	isAccountRecoveryPhoneActionInProgress,
-	isAccountRecoveryPhoneValidated,
-} from '../../state/account-recovery/settings/selectors';
-import {
-	getCurrentUserEmail,
-	isCurrentUserEmailVerified,
-} from '../../state/current-user/selectors';
 
 /**
  * Style dependencies
  */
 import './style.scss';
 
-const SecurityCheckupNavigationItemContents = function ( props ) {
-	const { materialIcon, text, description } = props;
-	return (
-		<React.Fragment>
-			<MaterialIcon icon={ materialIcon } className="security-checkup__nav-item-icon" />
-			<div>
-				<div>{ text }</div>
-				<small>{ description }</small>
-			</div>
-		</React.Fragment>
-	);
-};
-
-const SecurityCheckupNavigationItem = function ( props ) {
-	const { path, onClick, external, materialIcon, text, description } = props;
-
-	return (
-		<VerticalNavItem
-			path={ path }
-			onClick={ onClick }
-			external={ external }
-			className="security-checkup__nav-item"
-		>
-			<SecurityCheckupNavigationItemContents
-				materialIcon={ materialIcon }
-				text={ text }
-				description={ description }
-			/>
-		</VerticalNavItem>
-	);
-};
-
 class SecurityCheckupComponent extends React.Component {
 	static propTypes = {
-		accountRecoveryEmail: PropTypes.oneOfType( [ PropTypes.bool, PropTypes.string ] ),
-		accountRecoveryEmailActionInProgress: PropTypes.bool,
-		accountRecoveryEmailValidated: PropTypes.bool,
-		accountRecoveryPhone: PropTypes.object,
-		accountRecoveryPhoneActionInProgress: PropTypes.bool,
-		accountRecoveryPhoneValidated: PropTypes.bool,
 		path: PropTypes.string,
-		primaryEmail: PropTypes.string,
-		primaryEmailVerified: PropTypes.bool,
 		translate: PropTypes.func.isRequired,
 		userSettings: PropTypes.object,
-	};
-
-	state = {
-		initialized: false,
-	};
-
-	componentDidMount() {
-		this.props.userSettings.on( 'change', this.onUserSettingsChange );
-		this.props.userSettings.fetchSettings();
-	}
-
-	componentWillUnmount() {
-		this.props.userSettings.off( 'change', this.onUserSettingsChange );
-	}
-
-	getOKIcon() {
-		return 'check_circle';
-	}
-
-	getWarningIcon() {
-		return 'info';
-	}
-
-	onUserSettingsChange = () => {
-		if ( ! this.state.initialized ) {
-			this.setState( {
-				initialized: true,
-			} );
-			return;
-		}
-
-		this.forceUpdate();
 	};
 
 	renderTitleCard() {
@@ -134,261 +50,11 @@ class SecurityCheckupComponent extends React.Component {
 		);
 	}
 
-	renderPlaceholderNavItem() {
-		return <VerticalNavItem isPlaceholder={ true } />;
-	}
-
-	renderConnectedApps() {
-		const { connectedApps, translate } = this.props;
-		if ( connectedApps === null ) {
-			return this.renderPlaceholderNavItem();
-		}
-
-		let connectedAppsDescription;
-		if ( ! connectedApps.length ) {
-			connectedAppsDescription = translate( 'You do not have any connected applications.' );
-		} else {
-			connectedAppsDescription = translate(
-				'You currently have %(numberOfApps)d connected application.',
-				'You currently have %(numberOfApps)d connected applications.',
-				{
-					count: connectedApps.length,
-					args: {
-						numberOfApps: connectedApps.length,
-					},
-				}
-			);
-		}
-
-		return (
-			<SecurityCheckupNavigationItem
-				path={ '/me/security/connected-applications' }
-				materialIcon={ this.getWarningIcon() }
-				text={ translate( 'Connected Apps' ) }
-				description={ connectedAppsDescription }
-			/>
-		);
-	}
-
-	renderAccountEmail() {
-		const { primaryEmail, primaryEmailVerified, translate } = this.props;
-
-		let icon, description;
-
-		if ( ! primaryEmailVerified ) {
-			icon = this.getWarningIcon();
-			description = translate(
-				'Your account email address is set to {{strong}}%(emailAddress)s{{/strong}}, but is not verified yet.',
-				{
-					args: {
-						emailAddress: primaryEmail,
-					},
-					components: {
-						strong: <strong />,
-					},
-				}
-			);
-		} else {
-			icon = this.getOKIcon();
-			description = translate(
-				'Your account email address is set to {{strong}}%(emailAddress)s{{/strong}}.',
-				{
-					args: {
-						emailAddress: primaryEmail,
-					},
-					components: {
-						strong: <strong />,
-					},
-				}
-			);
-		}
-
-		return (
-			<SecurityCheckupNavigationItem
-				path={ '/me/account' }
-				materialIcon={ icon }
-				text={ translate( 'Account Email' ) }
-				description={ description }
-			/>
-		);
-	}
-
-	renderRecoveryEmail() {
-		const {
-			accountRecoveryEmail,
-			accountRecoveryEmailActionInProgress,
-			accountRecoveryEmailValidated,
-			translate,
-		} = this.props;
-
-		if ( accountRecoveryEmailActionInProgress ) {
-			return this.renderPlaceholderNavItem();
-		}
-
-		let icon, description;
-
-		if ( ! accountRecoveryEmail ) {
-			icon = this.getWarningIcon();
-			description = translate( 'You do not have a recovery email address.' );
-		} else if ( ! accountRecoveryEmailValidated ) {
-			icon = this.getWarningIcon();
-			description = translate(
-				'You still need to validate your recovery email address: {{strong}}%(recoveryEmailAddress)s{{/strong}}',
-				{
-					args: {
-						recoveryEmailAddress: accountRecoveryEmail,
-					},
-					components: {
-						strong: <strong />,
-					},
-				}
-			);
-		} else {
-			icon = this.getOKIcon();
-			description = translate(
-				'You have set {{strong}}%(recoveryEmailAddress)s{{/strong}} as your recovery email address.',
-				{
-					args: {
-						recoveryEmailAddress: accountRecoveryEmail,
-					},
-					components: {
-						strong: '<strong>',
-					},
-				}
-			);
-		}
-
-		return (
-			<SecurityCheckupNavigationItem
-				path={ '/me/security/account-recovery' }
-				materialIcon={ icon }
-				text={ translate( 'Recovery Email' ) }
-				description={ description }
-			/>
-		);
-	}
-
-	renderRecoveryPhone() {
-		const {
-			accountRecoveryPhone,
-			accountRecoveryPhoneActionInProgress,
-			accountRecoveryPhoneValidated,
-			translate,
-		} = this.props;
-
-		if ( accountRecoveryPhoneActionInProgress ) {
-			return this.renderPlaceholderNavItem();
-		}
-
-		let icon, description;
-
-		if ( ! accountRecoveryPhone ) {
-			icon = this.getWarningIcon();
-			description = translate( 'You do not have a recovery SMS number.' );
-		} else if ( ! accountRecoveryPhoneValidated ) {
-			icon = this.getWarningIcon();
-			description = translate(
-				'You still need to validate your recovery SMS number: {{strong}}%(recoveryPhoneNumber)s{{/strong}}',
-				{
-					args: {
-						recoveryPhoneNumber: accountRecoveryPhone.numberFull,
-					},
-					components: {
-						strong: <strong />,
-					},
-				}
-			);
-		} else {
-			icon = this.getOKIcon();
-			description = translate(
-				'You have set {{strong}}%(recoveryPhoneNumber)s{{/strong}} as your recovery SMS number.',
-				{
-					args: {
-						recoveryPhoneNumber: accountRecoveryPhone,
-					},
-					components: {
-						strong: <strong />,
-					},
-				}
-			);
-		}
-
-		return (
-			<SecurityCheckupNavigationItem
-				path={ '/me/security/account-recovery' }
-				materialIcon={ icon }
-				text={ translate( 'Recovery SMS Number' ) }
-				description={ description }
-			/>
-		);
-	}
-
-	renderTwoFactorAuthentication() {
-		const { translate, userSettings } = this.props;
-
-		if ( ! userSettings.initialized || userSettings.fetchingData ) {
-			return this.renderPlaceholderNavItem();
-		}
-
-		let icon, description;
-		if ( userSettings.settings.two_step_enabled ) {
-			icon = this.getOKIcon();
-			description = translate(
-				'You have two-step authentication {{strong}}enabled{{/strong}} using an app.',
-				{
-					components: {
-						strong: <strong />,
-					},
-				}
-			);
-		} else if ( userSettings.settings.two_step_sms_enabled ) {
-			icon = this.getOKIcon();
-			description = translate(
-				'You have two-step authentication {{strong}}enabled{{/strong}} using SMS messages to {{strong}}%(phoneNumber)s{{/strong}}.',
-				{
-					args: {
-						phoneNumber: userSettings.settings.two_step_sms_phone_number,
-					},
-					components: {
-						strong: <strong />,
-					},
-				}
-			);
-		} else {
-			icon = this.getWarningIcon();
-			description = translate( 'You do not have two-step authentication enabled.' );
-		}
-
-		return (
-			<SecurityCheckupNavigationItem
-				path={ '/me/security/two-step' }
-				materialIcon={ icon }
-				text={ translate( 'Two-Step Authentication' ) }
-				description={ description }
-			/>
-		);
-	}
-
-	renderVerticalNav() {
-		return (
-			<VerticalNav>
-				{ this.renderAccountEmail() }
-				{ this.renderTwoFactorAuthentication() }
-				{ this.renderRecoveryEmail() }
-				{ this.renderRecoveryPhone() }
-				{ this.renderConnectedApps() }
-			</VerticalNav>
-		);
-	}
-
 	render() {
 		const { path, translate } = this.props;
 
 		return (
 			<Main className="security security-checkup">
-				<QueryAccountRecoverySettings />
-				<QueryConnectedApplications />
-
 				<PageViewTracker path="/me/security/security-checkup" title="Me > Security Checkup" />
 				<ReauthRequired twoStepAuthorization={ twoStepAuthorization } />
 				<MeSidebarNavigation />
@@ -398,20 +64,17 @@ class SecurityCheckupComponent extends React.Component {
 				<SecuritySectionNav path={ path } />
 
 				{ this.renderTitleCard() }
-				{ this.renderVerticalNav() }
+				<VerticalNav>
+					<SecurityCheckupAccountEmail />
+					<SecurityCheckupTwoFactorAuthentication />
+					<SecurityCheckupTwoFactorBackupCodes />
+					<SecurityCheckupAccountRecoveryEmail />
+					<SecurityCheckupAccountRecoveryPhone />
+					<SecurityCheckupConnectedApplications />
+				</VerticalNav>
 			</Main>
 		);
 	}
 }
 
-export default connect( ( state ) => ( {
-	accountRecoveryEmail: getAccountRecoveryEmail( state ),
-	accountRecoveryEmailActionInProgress: isAccountRecoveryEmailActionInProgress( state ),
-	accountRecoveryEmailValidated: isAccountRecoveryEmailValidated( state ),
-	accountRecoveryPhone: getAccountRecoveryPhone( state ),
-	accountRecoveryPhoneActionInProgress: isAccountRecoveryPhoneActionInProgress( state ),
-	accountRecoveryPhoneValidated: isAccountRecoveryPhoneValidated( state ),
-	connectedApps: getConnectedApplications( state ),
-	primaryEmail: getCurrentUserEmail( state ),
-	primaryEmailVerified: isCurrentUserEmailVerified( state ),
-} ) )( localize( SecurityCheckupComponent ) );
+export default localize( SecurityCheckupComponent );

--- a/client/me/security-checkup/navigation-item.jsx
+++ b/client/me/security-checkup/navigation-item.jsx
@@ -1,0 +1,59 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import MaterialIcon from 'components/material-icon';
+import VerticalNavItem from 'components/vertical-nav/item';
+
+const SecurityCheckupNavigationItemContents = function ( props ) {
+	const { materialIcon, text, description } = props;
+	return (
+		<React.Fragment>
+			<MaterialIcon icon={ materialIcon } className="security-checkup__nav-item-icon" />
+			<div>
+				<div>{ text }</div>
+				<small>{ description }</small>
+			</div>
+		</React.Fragment>
+	);
+};
+
+class SecurityCheckupNavigationItem extends React.Component {
+	static propTypes = {
+		description: PropTypes.oneOfType( [ PropTypes.string, PropTypes.node ] ),
+		external: PropTypes.bool,
+		isPlaceholder: PropTypes.bool,
+		materialIcon: PropTypes.string,
+		onClick: PropTypes.func,
+		path: PropTypes.string,
+		text: PropTypes.string,
+	};
+
+	render() {
+		if ( this.props.isPlaceholder ) {
+			return <VerticalNavItem isPlaceholder={ true } />;
+		}
+
+		return (
+			<VerticalNavItem
+				path={ this.props.path }
+				onClick={ this.props.onClick }
+				external={ this.props.external }
+				className="security-checkup__nav-item"
+			>
+				<SecurityCheckupNavigationItemContents
+					materialIcon={ this.props.materialIcon }
+					text={ this.props.text }
+					description={ this.props.description }
+				/>
+			</VerticalNavItem>
+		);
+	}
+}
+
+export default SecurityCheckupNavigationItem;

--- a/client/me/security-checkup/two-factor-authentication.jsx
+++ b/client/me/security-checkup/two-factor-authentication.jsx
@@ -1,0 +1,93 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { getOKIcon, getWarningIcon } from './icons.js';
+import getUserSetting from 'state/selectors/get-user-setting';
+import hasUserSettings from 'state/selectors/has-user-settings';
+import isTwoStepEnabled from 'state/selectors/is-two-step-enabled';
+import isTwoStepSmsEnabled from 'state/selectors/is-two-step-sms-enabled';
+import QueryUserSettings from 'components/data/query-user-settings';
+import SecurityCheckupNavigationItem from './navigation-item';
+
+class SecurityCheckupTwoFactorAuthentication extends React.Component {
+	static propTypes = {
+		areUserSettingsLoaded: PropTypes.bool,
+		hasTwoStepEnabled: PropTypes.bool,
+		hasTwoStepSmsEnabled: PropTypes.bool,
+		translate: PropTypes.func.isRequired,
+		twoStepSmsPhoneNumber: PropTypes.string,
+	};
+
+	render() {
+		const {
+			areUserSettingsLoaded,
+			hasTwoStepEnabled,
+			hasTwoStepSmsEnabled,
+			translate,
+			twoStepSmsPhoneNumber,
+		} = this.props;
+
+		if ( ! areUserSettingsLoaded ) {
+			return (
+				<React.Fragment>
+					<QueryUserSettings />
+					<SecurityCheckupNavigationItem isPlaceholder={ true } />
+				</React.Fragment>
+			);
+		}
+
+		let icon, description;
+
+		if ( hasTwoStepSmsEnabled ) {
+			icon = getOKIcon();
+			description = translate(
+				'You have two-step authentication {{strong}}enabled{{/strong}} using SMS messages to {{strong}}%(phoneNumber)s{{/strong}}.',
+				{
+					args: {
+						phoneNumber: twoStepSmsPhoneNumber,
+					},
+					components: {
+						strong: <strong />,
+					},
+				}
+			);
+		} else if ( hasTwoStepEnabled ) {
+			icon = getOKIcon();
+			description = translate(
+				'You have two-step authentication {{strong}}enabled{{/strong}} using an app.',
+				{
+					components: {
+						strong: <strong />,
+					},
+				}
+			);
+		} else {
+			icon = getWarningIcon();
+			description = translate( 'You do not have two-step authentication enabled.' );
+		}
+
+		return (
+			<SecurityCheckupNavigationItem
+				path={ '/me/security/two-step' }
+				materialIcon={ icon }
+				text={ translate( 'Two-Step Authentication' ) }
+				description={ description }
+			/>
+		);
+	}
+}
+
+export default connect( ( state ) => ( {
+	areUserSettingsLoaded: hasUserSettings( state ),
+	hasTwoStepEnabled: isTwoStepEnabled( state ),
+	hasTwoStepSmsEnabled: isTwoStepSmsEnabled( state ),
+	twoStepSmsPhoneNumber: getUserSetting( state, 'two_step_sms_phone_number' ),
+} ) )( localize( SecurityCheckupTwoFactorAuthentication ) );

--- a/client/me/security-checkup/two-factor-backup-codes.jsx
+++ b/client/me/security-checkup/two-factor-backup-codes.jsx
@@ -1,0 +1,81 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { getOKIcon, getWarningIcon } from './icons.js';
+import getUserSetting from 'state/selectors/get-user-setting';
+import hasUserSettings from 'state/selectors/has-user-settings';
+import isTwoStepEnabled from 'state/selectors/is-two-step-enabled';
+import QueryUserSettings from 'components/data/query-user-settings';
+import SecurityCheckupNavigationItem from './navigation-item';
+
+class SecurityCheckupTwoFactorBackupCodes extends React.Component {
+	static propTypes = {
+		areBackupCodesPrinted: PropTypes.bool,
+		areUserSettingsLoaded: PropTypes.bool,
+		hasTwoStepEnabled: PropTypes.bool,
+		translate: PropTypes.func.isRequired,
+	};
+
+	render() {
+		const {
+			areBackupCodesPrinted,
+			areUserSettingsLoaded,
+			hasTwoStepEnabled,
+			translate,
+		} = this.props;
+
+		if ( ! areUserSettingsLoaded ) {
+			return (
+				<React.Fragment>
+					<QueryUserSettings />
+					<SecurityCheckupNavigationItem isPlaceholder={ true } />
+				</React.Fragment>
+			);
+		}
+
+		// Don't show this item if the user doesn't have 2FA enabled.
+		if ( ! hasTwoStepEnabled ) {
+			return null;
+		}
+
+		let icon, description;
+
+		if ( areBackupCodesPrinted ) {
+			icon = getOKIcon();
+			description = translate( 'You have verified your backup codes for two-step authentication.' );
+		} else {
+			icon = getWarningIcon();
+			description = translate(
+				'You have {{strong}}not verified your backup codes{{/strong}} for two-step authentication.',
+				{
+					components: {
+						strong: <strong />,
+					},
+				}
+			);
+		}
+
+		return (
+			<SecurityCheckupNavigationItem
+				path={ '/me/security/two-step' }
+				materialIcon={ icon }
+				text={ translate( 'Two-Step Backup Codes' ) }
+				description={ description }
+			/>
+		);
+	}
+}
+
+export default connect( ( state ) => ( {
+	areBackupCodesPrinted: getUserSetting( state, 'two_step_backup_codes_printed' ),
+	areUserSettingsLoaded: hasUserSettings( state ),
+	hasTwoStepEnabled: isTwoStepEnabled( state ),
+} ) )( localize( SecurityCheckupTwoFactorBackupCodes ) );


### PR DESCRIPTION
In addition to the above, I pushed all the state/querying dependencies into the components themselves, as per @klimeryk's suggestion in [this comment](https://github.com/Automattic/wp-calypso/pull/43101#discussion_r437612292) on #43101.

The largest change in this area was for Two Factor Authentication, where we're now accessing user settings in a cleaner fashion instead of interacting directly with the passed-in UserSettings object.

I also added a check for Two Factor backup code verification that is only performed when 2FA is enabled.

#### Changes proposed in this Pull Request

* Move all the row-specific logic out of `SecurityCheckupComponent`, and push it into row-specific components
* Re-implement the 2FA row logic to use helper functions for the user settings
* Add a row/check for whether the user has verified their 2FA backup codes
* Simplified the email language as per @wensco's suggestion in #43101

![](https://user-images.githubusercontent.com/3392497/84434015-cad25600-ac1e-11ea-8c22-f7c4a63ac885.png)

![](https://user-images.githubusercontent.com/3392497/84434017-cd34b000-ac1e-11ea-95d8-f64c49d30c6a.png)

#### Testing instructions

Using calypso.live with `?flags=security/security-checkup` added after the build loads, or a local build of Calypso, check the following:
* Inspect the UI and make sure it loads and shows the 5 rows/options from #43101, with the "set to" removed from the account email item.
* If you have 2FA enabled, make sure that a row appears for "Two-Step Backup Codes"