### PR TITLE
Fix confirmCancelDomain and editCardDetails controllers

### DIFF
--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -80,7 +80,9 @@ export function cancelPurchase( context, next ) {
 }
 
 export function confirmCancelDomain( context, next ) {
-	if ( userHasNoSites() ) {
+	const state = context.store.getState();
+
+	if ( userHasNoSites( state ) ) {
 		return noSites( context, '/me/purchases/:site/:purchaseId/confirm-cancel-domain' );
 	}
 
@@ -96,7 +98,9 @@ export function confirmCancelDomain( context, next ) {
 }
 
 export function editCardDetails( context, next ) {
-	if ( userHasNoSites() ) {
+	const state = context.store.getState();
+
+	if ( userHasNoSites( state ) ) {
 		return noSites( context, '/me/purchases/:site/:purchaseId/payment/edit/:cardId' );
 	}
 


### PR DESCRIPTION
Fix `confirmCancelDomain` and `editCardDetails` controllers to properly pass the state to `userHasNoSites`

#### Changes proposed in this Pull Request

* We got a bug report that people can't update their credit card information. Seems like it was a regression introduced in https://github.com/Automattic/wp-calypso/pull/43069 . I've updated the code and tested it - it works properly now.

see: pNPgK-56M-p2

#### Testing instructions

* Try and change the payment method for purchase that already has payment method associated with it. It should work with this patch - without it an "You don't have any WordPress websites" screen is shown.
