### PR TITLE
Sidebar: Put new Plans icon behind jetpack/features-section flag

### DIFF
--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -597,13 +597,22 @@ export class MySitesSidebar extends Component {
 		// Hide the plan name only for Jetpack sites that are not Atomic or VIP.
 		const displayPlanName = ! ( isJetpack && ! isAtomicSite && ! isVip );
 
-		const icon = isUpgraded ? 'star' : 'star-outline';
+		let icon = <JetpackLogo size={ 24 } className="sidebar__menu-icon" />;
+		if ( isEnabled( 'jetpack/features-section' ) ) {
+			icon = (
+				<Gridicon
+					icon={ isUpgraded ? 'star' : 'star-outline' }
+					className="sidebar__menu-icon"
+					size={ 24 }
+				/>
+			);
+		}
 
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
 			<li className={ linkClass } data-tip-target={ tipTarget }>
 				<a className="sidebar__menu-link" onClick={ this.trackPlanClick } href={ planLink }>
-					<Gridicon icon={ icon } className="sidebar__menu-icon" size={ 24 } />
+					{ icon }
 					<span className="menu-link-text" data-e2e-sidebar="Plan">
 						{ translate( 'Plan', { context: 'noun' } ) }
 					</span>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Put the new "star" Plan icon behind the jetpack/features-section flag, to minimize changes to our existing sidebar UI.

#### Testing instructions

* Start Calypso.
* Note that for all sites, the icon for the Plan sidebar item is the Jetpack logo.
* Enable the flag `jetpack/features-section` by appending `?flags=jetpack/features-section` to your URL.
* Note that the Plan icon has changed to a star.