### PR TITLE
FSE: Release 1.9

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Full Site Editing
  * Description: Enhances your page creation workflow within the Block Editor.
- * Version: 1.8
+ * Version: 1.9
  * Author: Automattic
  * Author URI: https://automattic.com/wordpress-plugins/
  * License: GPLv2 or later
@@ -35,7 +35,7 @@ namespace A8C\FSE;
  *
  * @var string
  */
-define( 'PLUGIN_VERSION', '1.8' );
+define( 'PLUGIN_VERSION', '1.9' );
 
 // Always include these helper files for dotcom FSE.
 require_once __DIR__ . '/dotcom-fse/helpers.php';

--- a/apps/full-site-editing/full-site-editing-plugin/readme.txt
+++ b/apps/full-site-editing/full-site-editing-plugin/readme.txt
@@ -41,8 +41,11 @@ This plugin is experimental, so we don't provide any support for it outside of w
 == Changelog ==
 
 = 1.9 =
+* Add Mailerlite subscriber widget.
 * When launching a site created via `/new`, save the post content.
   Prevent lost content alert.
+* Update block pattern categories.
+* Fix text-domain of translated strings.
 
 = 1.8 =
 * Fix issue with Newspack blocks not loading assets.

--- a/apps/full-site-editing/full-site-editing-plugin/readme.txt
+++ b/apps/full-site-editing/full-site-editing-plugin/readme.txt
@@ -1,5 +1,5 @@
 === Full Site Editing ===
-Contributors: alexislloyd, allancole, automattic, bartkalisz, codebykat, copons, dmsnell, get_dave, glendaviesnz, gwwar, iamtakashi, jeryj, Joen, jonsurrell, kwight, marekhrabe, mattwiebe, mkaz, mmtr86, mppfeiffer, noahtallen, nrqsnchz, nosolosw, obenland, okenobi, owolski, iandstewart, vindl
+Contributors: alexislloyd, allancole, automattic, bartkalisz, codebykat, copons, dmsnell, get_dave, glendaviesnz, gwwar, iamtakashi, iandstewart, jeryj, Joen, jonsurrell, kwight, marekhrabe, mattwiebe, mkaz, mmtr86, mppfeiffer, noahtallen, nosolosw, nrqsnchz, obenland, okenobi, owolski, philipmjackson, vindl
 Tags: block, blocks, editor, gutenberg, page
 Requires at least: 5.0
 Tested up to: 5.4

--- a/apps/full-site-editing/full-site-editing-plugin/readme.txt
+++ b/apps/full-site-editing/full-site-editing-plugin/readme.txt
@@ -3,7 +3,7 @@ Contributors: alexislloyd, allancole, automattic, bartkalisz, codebykat, copons,
 Tags: block, blocks, editor, gutenberg, page
 Requires at least: 5.0
 Tested up to: 5.4
-Stable tag: 1.8
+Stable tag: 1.9
 Requires PHP: 5.6.20
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -39,6 +39,10 @@ This plugin is experimental, so we don't provide any support for it outside of w
 
 
 == Changelog ==
+
+= 1.9 =
+* When launching a site created via `/new`, save the post content.
+  Prevent lost content alert.
 
 = 1.8 =
 * Fix issue with Newspack blocks not loading assets.

--- a/apps/full-site-editing/package.json
+++ b/apps/full-site-editing/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/full-site-editing",
-	"version": "1.8.0",
+	"version": "1.9.0",
 	"description": "Plugin for full site editing with the block editor.",
 	"sideEffects": true,
 	"repository": {


### PR DESCRIPTION
Bump FSE plugin for 1.9 release.

Includes:
- https://github.com/Automattic/wp-calypso/pull/43084 (@noahtallen)
- https://github.com/Automattic/wp-calypso/pull/42911 (@kwight)
- https://github.com/Automattic/wp-calypso/pull/39328 (@noahtallen)
- https://github.com/Automattic/wp-calypso/pull/43070 (@akirk)
- https://github.com/Automattic/wp-calypso/pull/42885 (@artpi)
- https://github.com/Automattic/wp-calypso/pull/42583 (@akirk)
- https://github.com/Automattic/wp-calypso/pull/42996 (@ianstewart)
- https://github.com/Automattic/wp-calypso/pull/42761 (@ockham / @p-jackson)
- https://github.com/Automattic/wp-calypso/pull/43116 (@sirreal)

Testing:
- Apply D44727-code to sandbox
- Test editor
- Check features in release notes are present