### PR TITLE
Add empty state UI and "View more results" button and hide categories

### DIFF
--- a/client/landing/gutenboarding/hooks/use-domain-suggestions.ts
+++ b/client/landing/gutenboarding/hooks/use-domain-suggestions.ts
@@ -3,45 +3,29 @@
  */
 import { useDebounce } from 'use-debounce';
 import { useSelect } from '@wordpress/data';
-import { useI18n } from '@automattic/react-i18n';
 
 /**
  * Internal dependencies
  */
 import { DOMAIN_SUGGESTIONS_STORE } from '../stores/domain-suggestions';
 import { STORE_KEY as ONBOARD_STORE } from '../stores/onboard';
-import { USER_STORE } from '../stores/user';
 import { PAID_DOMAINS_TO_SHOW, selectorDebounce } from '../constants';
-import { useCurrentStep } from '../path';
 import { getSuggestionsVendor } from 'lib/domains/suggestions';
 
 const DOMAIN_SUGGESTION_VENDOR = getSuggestionsVendor( true );
 
+// @TODO: remove this once use-on-login hook is using the hook from packages
 export function useDomainSuggestions( {
 	searchOverride = '',
 	locale = 'en',
 	quantity = PAID_DOMAINS_TO_SHOW,
 } ) {
-	const { __ } = useI18n();
-	const { siteTitle, siteVertical, domainSearch, domainCategory } = useSelect( ( select ) =>
-		select( ONBOARD_STORE ).getState()
-	);
-	const currentUser = useSelect( ( select ) => select( USER_STORE ).getCurrentUser() );
-	const currentStep = useCurrentStep();
-	const prioritisedSearch = searchOverride.trim() || domainSearch.trim() || siteTitle;
-	let searchVal;
+	const { domainCategory } = useSelect( ( select ) => select( ONBOARD_STORE ).getState() );
+	const domainSearch = useSelect( ( select ) => select( ONBOARD_STORE ).getDomainSearch() );
 
-	if ( currentStep !== 'IntentGathering' ) {
-		searchVal =
-			prioritisedSearch ||
-			siteVertical?.label.trim() ||
-			currentUser?.username ||
-			__( 'My new site' );
-	} else {
-		searchVal = prioritisedSearch || '';
-	}
+	const prioritisedSearch = searchOverride.trim() || domainSearch;
 
-	const [ searchTerm ] = useDebounce( searchVal, selectorDebounce );
+	const [ searchTerm ] = useDebounce( prioritisedSearch, selectorDebounce );
 
 	return useSelect(
 		( select ) => {
@@ -58,6 +42,6 @@ export function useDomainSuggestions( {
 				category_slug: domainCategory,
 			} );
 		},
-		[ searchTerm, siteVertical, domainCategory, quantity ]
+		[ searchTerm, domainCategory, quantity ]
 	);
 }

--- a/client/landing/gutenboarding/hooks/use-on-login.ts
+++ b/client/landing/gutenboarding/hooks/use-on-login.ts
@@ -12,14 +12,14 @@ import { STORE_KEY as ONBOARD_STORE } from '../stores/onboard';
 import { USER_STORE } from '../stores/user';
 import { SITE_STORE } from '../stores/site';
 import { getFreeDomainSuggestions } from '../utils/domain-suggestions';
-import { useDomainSuggestions } from './use-domain-suggestions';
+import { useDomainSuggestions } from './use-domain-suggestions'; // @TODO: get this from packages and remove hook from Gutenboarding
 import { useShouldSiteBePublicOnSelectedPlan } from './use-selected-plan';
 
 /**
  * After signup or login a site is automatically created using the username and bearerToken
  **/
 
-export default function useSignup() {
+export default function useOnLogin() {
 	const { i18nLocale } = useI18n();
 
 	const { siteTitle } = useSelect( ( select ) => select( ONBOARD_STORE ).getState() );

--- a/client/landing/gutenboarding/onboarding-block/domains/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/domains/index.tsx
@@ -88,7 +88,7 @@ const DomainsStep: React.FunctionComponent< Props > = ( { isModal } ) => {
 			<DomainPicker
 				header={ header }
 				analyticsFlowId={ FLOW_ID }
-				initialDomainSearch={ domainSearch || __( 'My new site' ) }
+				initialDomainSearch={ domainSearch }
 				onSetDomainSearch={ setDomainSearch }
 				currentDomain={ domain }
 				onDomainSelect={ onDomainSelect }

--- a/client/landing/gutenboarding/stores/onboard/selectors.ts
+++ b/client/landing/gutenboarding/stores/onboard/selectors.ts
@@ -1,13 +1,7 @@
 /**
- * External dependencies
- */
-import { select } from '@wordpress/data';
-
-/**
  * Internal dependencies
  */
 import type { State } from './reducer';
-import { USER_STORE } from '../user';
 
 export const getIsRedirecting = ( state: State ) => state.isRedirecting;
 export const getState = ( state: State ) => state;
@@ -30,7 +24,4 @@ export const getSelectedVertical = ( state: State ) => state.siteVertical;
 export const getSelectedDomain = ( state: State ) => state.domain;
 export const getSelectedSiteTitle = ( state: State ) => state.siteTitle;
 export const getDomainSearch = ( state: State ) =>
-	state.domainSearch ||
-	getSelectedSiteTitle( state ) ||
-	getSelectedVertical( state )?.label.trim() ||
-	select( USER_STORE ).getCurrentUser()?.username;
+	state.domainSearch || getSelectedSiteTitle( state );

--- a/packages/domain-picker/src/constants.ts
+++ b/packages/domain-picker/src/constants.ts
@@ -1,5 +1,5 @@
-export const PAID_DOMAINS_TO_SHOW_WITH_CATEGORIES_MODE = 10;
-export const PAID_DOMAINS_TO_SHOW_WITHOUT_CATEGORIES_MODE = 5;
+export const PAID_DOMAINS_TO_SHOW = 5;
+export const PAID_DOMAINS_TO_SHOW_EXPANDED = 10;
 export const DOMAIN_SEARCH_DEBOUNCE_INTERVAL = 300;
 export const DOMAIN_SUGGESTION_VENDOR = 'variation4_front';
 export const DOMAIN_SUGGESTIONS_STORE = 'automattic/domains/suggestions';

--- a/packages/domain-picker/src/domain-name-explanation/index.tsx
+++ b/packages/domain-picker/src/domain-name-explanation/index.tsx
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import React, { FunctionComponent } from 'react';
+
+export const DomainNameExplanationImage: FunctionComponent = () => {
+	return (
+		<svg
+			version="1.1"
+			xmlns="http://www.w3.org/2000/svg"
+			xmlnsXlink="http://www.w3.org/1999/xlink"
+			x="0px"
+			y="0px"
+			viewBox="0 0 300 40"
+			xmlSpace="preserve"
+			width="300"
+		>
+			<rect x="0" width="310" height="50" rx="10" fill="#D8D8D8" />
+			<rect x="8" y="8" width="25" height="25" rx="5" fill="#fff" />
+			<rect x="40" y="8" width="25" height="25" rx="5" fill="#fff" />
+			<rect x="72" y="8" width="300" height="25" rx="5" fill="#fff" />
+			<text x="80" y="26" fontFamily="roboto" fill="#999">
+				https://
+			</text>
+			<text x="133" y="26" fontFamily="roboto" fill="#515151">
+				example.com
+			</text>
+		</svg>
+	);
+};

--- a/packages/domain-picker/src/domain-picker/index.tsx
+++ b/packages/domain-picker/src/domain-picker/index.tsx
@@ -3,7 +3,7 @@
  */
 import React, { FunctionComponent, useState, useEffect } from 'react';
 import { times } from 'lodash';
-import { TextControl } from '@wordpress/components';
+import { Button, TextControl } from '@wordpress/components';
 import { Icon, search } from '@wordpress/icons';
 import { getNewRailcarId, recordTrainTracksRender } from '@automattic/calypso-analytics';
 import { useI18n } from '@automattic/react-i18n';
@@ -21,10 +21,7 @@ import {
 	getRecommendedDomainSuggestion,
 } from '../utils/domain-suggestions';
 import DomainCategories from '../domain-categories';
-import {
-	PAID_DOMAINS_TO_SHOW_WITH_CATEGORIES_MODE,
-	PAID_DOMAINS_TO_SHOW_WITHOUT_CATEGORIES_MODE,
-} from '../constants';
+import { PAID_DOMAINS_TO_SHOW, PAID_DOMAINS_TO_SHOW_EXPANDED } from '../constants';
 import { DomainNameExplanationImage } from '../domain-name-explanation/';
 /**
  * Style dependencies
@@ -45,7 +42,11 @@ export interface Props {
 	 */
 	onDomainSelect: ( domainSuggestion: DomainSuggestion ) => void;
 
+	/** Paid omain suggestions to show when the picker isn't expanded */
 	quantity?: number;
+
+	/** Domain suggestions to show when the picker is expanded */
+	quantityExpanded?: number;
 
 	currentDomain?: DomainSuggestion;
 
@@ -68,9 +69,8 @@ const DomainPicker: FunctionComponent< Props > = ( {
 	header,
 	showDomainCategories,
 	onDomainSelect,
-	quantity = showDomainCategories
-		? PAID_DOMAINS_TO_SHOW_WITH_CATEGORIES_MODE
-		: PAID_DOMAINS_TO_SHOW_WITHOUT_CATEGORIES_MODE,
+	quantity = PAID_DOMAINS_TO_SHOW,
+	quantityExpanded = PAID_DOMAINS_TO_SHOW_EXPANDED,
 	currentDomain,
 	analyticsFlowId,
 	analyticsUiAlgo,
@@ -83,6 +83,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 
 	// We're not keeping the current selection in local state at the moment
 	//const [ currentSelection, setCurrentSelection ] = useState( currentDomain );
+	const [ isExpanded, setIsExpanded ] = useState( false );
 
 	// keep domain query in local state to allow free editing of the input value while the modal is open
 	const [ domainSearch, setDomainSearch ] = useState< string >( initialDomainSearch );
@@ -90,14 +91,17 @@ const DomainPicker: FunctionComponent< Props > = ( {
 
 	const domainSuggestions = useDomainSuggestions(
 		domainSearch.trim(),
+		quantityExpanded,
 		domainCategory,
-		useI18n().i18nLocale,
-		quantity
+		useI18n().i18nLocale
 	);
 
 	const allSuggestions = domainSuggestions;
 	const freeSuggestions = getFreeDomainSuggestions( allSuggestions );
-	const paidSuggestions = getPaidDomainSuggestions( allSuggestions );
+	const paidSuggestions = getPaidDomainSuggestions( allSuggestions )?.slice(
+		0,
+		isExpanded ? quantityExpanded : quantity
+	);
 	const recommendedSuggestion = getRecommendedDomainSuggestion( paidSuggestions );
 
 	// We're not using auto-selection right now.
@@ -220,6 +224,13 @@ const DomainPicker: FunctionComponent< Props > = ( {
 							) : (
 								<SuggestionNone />
 							) ) }
+						{ ! isExpanded && (
+							<div className="domain-picker__show-more">
+								<Button onClick={ () => setIsExpanded( true ) }>
+									{ __( 'View more results' ) }
+								</Button>
+							</div>
+						) }
 					</div>
 				</div>
 			) : (

--- a/packages/domain-picker/src/domain-picker/index.tsx
+++ b/packages/domain-picker/src/domain-picker/index.tsx
@@ -25,7 +25,7 @@ import {
 	PAID_DOMAINS_TO_SHOW_WITH_CATEGORIES_MODE,
 	PAID_DOMAINS_TO_SHOW_WITHOUT_CATEGORIES_MODE,
 } from '../constants';
-
+import { DomainNameExplanationImage } from '../domain-name-explanation/';
 /**
  * Style dependencies
  */
@@ -177,50 +177,63 @@ const DomainPicker: FunctionComponent< Props > = ( {
 					value={ domainSearch }
 				/>
 			</div>
-			<div className="domain-picker__body">
-				{ showDomainCategories && (
-					<div className="domain-picker__aside">
-						<DomainCategories selected={ domainCategory } onSelect={ setDomainCategory } />
-					</div>
-				) }
-				<div className="domain-picker__suggestion-item-group">
-					{ ! freeSuggestions && <SuggestionItemPlaceholder /> }
-					{ freeSuggestions &&
-						( freeSuggestions.length ? (
-							<SuggestionItem
-								suggestion={ freeSuggestions[ 0 ] }
-								railcarId={ baseRailcarId ? `${ baseRailcarId }0` : undefined }
-								isSelected={ currentDomain?.domain_name === freeSuggestions[ 0 ].domain_name }
-								onRender={ () =>
-									handleItemRender( freeSuggestions[ 0 ], `${ baseRailcarId }0`, 0 )
-								}
-								onSelect={ onDomainSelect }
-							/>
-						) : (
-							<SuggestionNone />
-						) ) }
-					{ ! paidSuggestions &&
-						times( quantity, ( i ) => <SuggestionItemPlaceholder key={ i } /> ) }
-					{ paidSuggestions &&
-						( paidSuggestions?.length ? (
-							paidSuggestions.map( ( suggestion, i ) => (
+			{ domainSearch.trim() ? (
+				<div className="domain-picker__body">
+					{ showDomainCategories && (
+						<div className="domain-picker__aside">
+							<DomainCategories selected={ domainCategory } onSelect={ setDomainCategory } />
+						</div>
+					) }
+					<div className="domain-picker__suggestion-item-group">
+						{ ! freeSuggestions && <SuggestionItemPlaceholder /> }
+						{ freeSuggestions &&
+							( freeSuggestions.length ? (
 								<SuggestionItem
-									key={ suggestion.domain_name }
-									suggestion={ suggestion }
-									railcarId={ baseRailcarId ? `${ baseRailcarId }${ i + 1 }` : undefined }
-									isSelected={ currentDomain?.domain_name === suggestion.domain_name }
-									isRecommended={ isRecommended( suggestion ) }
+									suggestion={ freeSuggestions[ 0 ] }
+									railcarId={ baseRailcarId ? `${ baseRailcarId }0` : undefined }
+									isSelected={ currentDomain?.domain_name === freeSuggestions[ 0 ].domain_name }
 									onRender={ () =>
-										handleItemRender( suggestion, `${ baseRailcarId }${ i + 1 }`, i + 1 )
+										handleItemRender( freeSuggestions[ 0 ], `${ baseRailcarId }0`, 0 )
 									}
 									onSelect={ onDomainSelect }
 								/>
-							) )
-						) : (
-							<SuggestionNone />
-						) ) }
+							) : (
+								<SuggestionNone />
+							) ) }
+						{ ! paidSuggestions &&
+							times( quantity, ( i ) => <SuggestionItemPlaceholder key={ i } /> ) }
+						{ paidSuggestions &&
+							( paidSuggestions?.length ? (
+								paidSuggestions.map( ( suggestion, i ) => (
+									<SuggestionItem
+										key={ suggestion.domain_name }
+										suggestion={ suggestion }
+										railcarId={ baseRailcarId ? `${ baseRailcarId }${ i + 1 }` : undefined }
+										isSelected={ currentDomain?.domain_name === suggestion.domain_name }
+										isRecommended={ isRecommended( suggestion ) }
+										onRender={ () =>
+											handleItemRender( suggestion, `${ baseRailcarId }${ i + 1 }`, i + 1 )
+										}
+										onSelect={ onDomainSelect }
+									/>
+								) )
+							) : (
+								<SuggestionNone />
+							) ) }
+					</div>
 				</div>
-			</div>
+			) : (
+				<div className="domain-picker__empty-state">
+					<p className="domain-picker__empty-state--text">
+						{ __(
+							'A domain name is the site address people type in their browser to visit your site.'
+						) }
+					</p>
+					<div>
+						<DomainNameExplanationImage />
+					</div>
+				</div>
+			) }
 		</div>
 	);
 };

--- a/packages/domain-picker/src/domain-picker/index.tsx
+++ b/packages/domain-picker/src/domain-picker/index.tsx
@@ -96,6 +96,11 @@ const DomainPicker: FunctionComponent< Props > = ( {
 		useI18n().i18nLocale
 	);
 
+	// Reset expansion state after every search
+	useEffect( () => {
+		setIsExpanded( false );
+	}, [ domainSearch ] );
+
 	const allSuggestions = domainSuggestions;
 	const freeSuggestions = getFreeDomainSuggestions( allSuggestions );
 	const paidSuggestions = getPaidDomainSuggestions( allSuggestions )?.slice(

--- a/packages/domain-picker/src/domain-picker/style.scss
+++ b/packages/domain-picker/src/domain-picker/style.scss
@@ -83,6 +83,23 @@ $domain-picker__suggestion-item-height: 24px;
 		margin-top: -1px;
 	}
 
+	// animate the added domains after you click expand
+	@for $i from 7 through 14 {
+		&:nth-child( #{$i} ) {
+			transform: translateY( 20px );
+			opacity: 0;
+			animation: domain-picker-item-slide-up 0.1s ease-in forwards;
+			animation-delay: #{( $i - 7 ) * 40ms};
+		}
+	}
+
+	@keyframes domain-picker-item-slide-up {
+		100% {
+			transform: translateY( 0 );
+			opacity: 1;
+		}
+	}
+
 	&.components-button {
 		&.is-tertiary {
 			color: var( --color-text );

--- a/packages/domain-picker/src/domain-picker/style.scss
+++ b/packages/domain-picker/src/domain-picker/style.scss
@@ -16,6 +16,11 @@ $domain-picker__suggestion-item-height: 24px;
 	}
 }
 
+.domain-picker__show-more {
+	padding: 10px;
+	text-align: center;
+}
+
 .domain-picker__search {
 	position: relative;
 	margin-bottom: 20px;

--- a/packages/domain-picker/src/domain-picker/style.scss
+++ b/packages/domain-picker/src/domain-picker/style.scss
@@ -3,6 +3,19 @@
 
 $domain-picker__suggestion-item-height: 24px;
 
+.domain-picker__empty-state {
+	display: flex;
+	justify-content: center;
+	align-items: center;
+
+	&--text {
+		max-width: 320px;
+		font-size: 0.9em;
+		margin: 0 10px;
+		color: $dark-gray-500;
+	}
+}
+
 .domain-picker__search {
 	position: relative;
 	margin-bottom: 20px;

--- a/packages/domain-picker/src/hooks/use-domain-suggestions.ts
+++ b/packages/domain-picker/src/hooks/use-domain-suggestions.ts
@@ -9,16 +9,15 @@ import { useDebounce } from 'use-debounce';
  */
 import {
 	DOMAIN_SUGGESTION_VENDOR,
-	PAID_DOMAINS_TO_SHOW_WITHOUT_CATEGORIES_MODE,
 	DOMAIN_SUGGESTIONS_STORE,
 	DOMAIN_SEARCH_DEBOUNCE_INTERVAL,
 } from '../constants';
 
 export function useDomainSuggestions(
 	searchTerm = '',
+	quantity: number,
 	domainCategory?: string,
-	locale = 'en',
-	quantity = PAID_DOMAINS_TO_SHOW_WITHOUT_CATEGORIES_MODE
+	locale = 'en'
 ) {
 	const [ domainSearch ] = useDebounce( searchTerm, DOMAIN_SEARCH_DEBOUNCE_INTERVAL );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

**Note: It's much easier to review with whitespace ignored (add w=1 param to the diff URL).**

From https://github.com/Automattic/wp-calypso/issues/43133:

- [x] Show an empty state when search is empty. From domain-picker side of things, this is done, you can test it by manually emptying the search field.
- [x] Add a button to expand the list of domain suggestions.
- [x] Display 6 domains by default (5+1) and 11 domains (10 + 1) in expanded mode.
- [x] Hide domain categories sidebar.

#### Testing instructions

1. Visit [/new](https://calypso.live/new?branch=updte/handle-empty-state-gracefully). 
2. Test against the changes above.

Related to: https://github.com/Automattic/wp-calypso/issues/43133


