### PR TITLE
Jetpack Cloud: Unify sidebar items into one shared component

### DIFF
--- a/client/components/jetpack/sidebar-menu-items/index.jsx
+++ b/client/components/jetpack/sidebar-menu-items/index.jsx
@@ -71,7 +71,6 @@ const JetpackSidebarMenuItems = ( { path, showIcons, tracksPrefix } ) => {
 	const scanProgress = useSelector( ( state ) => getSiteScanProgress( state, siteId ) );
 	const scanThreats = useSelector( ( state ) => getSiteScanThreats( state, siteId ) );
 
-	// TODO: Make sure Tracks events are named correctly
 	const onNavigate = ( event, params ) =>
 		trackClickAndNavigate( dispatch, tracksPrefix, event, params );
 

--- a/client/components/jetpack/sidebar-menu-items/index.jsx
+++ b/client/components/jetpack/sidebar-menu-items/index.jsx
@@ -1,0 +1,116 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { useTranslate } from 'i18n-calypso';
+import { itemLinkMatches } from 'my-sites/sidebar/utils';
+import { recordTracksEvent } from 'state/analytics/actions';
+import { expandMySitesSidebarSection } from 'state/my-sites/sidebar/actions';
+import { setNextLayoutFocus } from 'state/ui/layout-focus/actions';
+import { SIDEBAR_SECTION_JETPACK } from 'my-sites/sidebar/constants';
+import getSelectedSiteId from 'state/ui/selectors/get-selected-site-id';
+import getSelectedSiteSlug from 'state/ui/selectors/get-selected-site-slug';
+import getSiteScanProgress from 'state/selectors/get-site-scan-progress';
+import getSiteScanThreats from 'state/selectors/get-site-scan-threats';
+import QueryScanState from 'components/data/query-jetpack-scan';
+import SidebarItem from 'layout/sidebar/item';
+import ScanBadge from 'components/jetpack/scan-badge';
+
+const trackClickAndNavigate = ( dispatch, prefix, event, params ) => () => {
+	dispatch( recordTracksEvent( `${ prefix }_${ event }`, params ) );
+
+	setNextLayoutFocus( 'content' );
+	window.scrollTo( 0, 0 );
+};
+
+export const CalypsoJetpackSidebarMenuItems = ( { path } ) => (
+	<JetpackSidebarMenuItems
+		path={ path }
+		showIcons={ false }
+		tracksPrefix="calypso_mysites_jetpack_sidebar"
+	/>
+);
+
+export const JetpackCloudSidebarMenuItems = ( { path } ) => {
+	const dispatch = useDispatch();
+	const translate = useTranslate();
+	const siteSlug = useSelector( getSelectedSiteSlug );
+
+	const TRACKS_PREFIX = 'calypso_jetpack_sidebar';
+
+	const onNavigate = trackClickAndNavigate( dispatch, TRACKS_PREFIX, 'settings_clicked' );
+
+	return (
+		<>
+			<JetpackSidebarMenuItems path={ path } showIcons={ true } tracksPrefix={ TRACKS_PREFIX } />
+			<SidebarItem
+				materialIcon="settings"
+				materialIconStyle="filled"
+				label={ translate( 'Settings', {
+					comment: 'Jetpack sidebar navigation item',
+				} ) }
+				link={ `/settings/${ siteSlug }` }
+				onNavigate={ onNavigate }
+				selected={ itemLinkMatches( [ '/settings' ], path ) }
+			/>
+		</>
+	);
+};
+
+const JetpackSidebarMenuItems = ( { path, showIcons, tracksPrefix } ) => {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+	const siteId = useSelector( getSelectedSiteId );
+	const siteSlug = useSelector( getSelectedSiteSlug ) ?? '';
+
+	const scanProgress = useSelector( ( state ) => getSiteScanProgress( state, siteId ) );
+	const scanThreats = useSelector( ( state ) => getSiteScanThreats( state, siteId ) );
+
+	// TODO: Make sure Tracks events are named correctly
+	const onNavigate = ( event, params ) =>
+		trackClickAndNavigate( dispatch, tracksPrefix, event, params );
+
+	const currentPathMatches = ( url ) => itemLinkMatches( [ url ], path );
+	const expandSection = () => expandMySitesSidebarSection( SIDEBAR_SECTION_JETPACK );
+
+	return (
+		<>
+			<QueryScanState siteId={ siteId } />
+			<SidebarItem
+				icon={ showIcons ? 'clipboard' : undefined }
+				label={ translate( 'Activity Log', {
+					comment: 'Jetpack sidebar menu item',
+				} ) }
+				link={ `/activity-log/${ siteSlug }` }
+				onNavigate={ onNavigate( 'activity_clicked' ) }
+				selected={ currentPathMatches( '/activity-log' ) }
+				expandSection={ expandSection }
+			/>
+			<SidebarItem
+				materialIcon={ showIcons ? 'backup' : undefined }
+				materialIconStyle="filled"
+				label="Backup"
+				link={ `/backup/${ siteSlug }` }
+				onNavigate={ onNavigate( 'item_clicked', { menu_item: 'backup' } ) }
+				selected={ currentPathMatches( '/backup' ) }
+				expandSection={ expandSection }
+			/>
+			<SidebarItem
+				materialIcon={ showIcons ? 'security' : undefined }
+				materialIconStyle="filled"
+				label="Scan"
+				link={ `/scan/${ siteSlug }` }
+				onNavigate={ onNavigate( 'item_clicked', { menu_item: 'scan' } ) }
+				selected={ currentPathMatches( '/scan' ) }
+				expandSection={ expandSection }
+			>
+				<ScanBadge progress={ scanProgress } numberOfThreatsFound={ scanThreats?.length ?? 0 } />
+			</SidebarItem>
+		</>
+	);
+};

--- a/client/components/jetpack/sidebar-menu-items/index.jsx
+++ b/client/components/jetpack/sidebar-menu-items/index.jsx
@@ -9,6 +9,7 @@ import { useDispatch, useSelector } from 'react-redux';
  */
 import { useTranslate } from 'i18n-calypso';
 import { itemLinkMatches } from 'my-sites/sidebar/utils';
+import { activityLogPath, backupPath, scanPath, settingsPath } from 'lib/jetpack/paths';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { expandMySitesSidebarSection } from 'state/my-sites/sidebar/actions';
 import { setNextLayoutFocus } from 'state/ui/layout-focus/actions';
@@ -54,9 +55,9 @@ export const JetpackCloudSidebarMenuItems = ( { path } ) => {
 				label={ translate( 'Settings', {
 					comment: 'Jetpack sidebar navigation item',
 				} ) }
-				link={ `/settings/${ siteSlug }` }
+				link={ settingsPath( siteSlug ) }
 				onNavigate={ onNavigate }
-				selected={ itemLinkMatches( [ '/settings' ], path ) }
+				selected={ itemLinkMatches( [ settingsPath( siteSlug ) ], path ) }
 			/>
 		</>
 	);
@@ -85,27 +86,27 @@ const JetpackSidebarMenuItems = ( { path, showIcons, tracksPrefix } ) => {
 				label={ translate( 'Activity Log', {
 					comment: 'Jetpack sidebar menu item',
 				} ) }
-				link={ `/activity-log/${ siteSlug }` }
+				link={ activityLogPath( siteSlug ) }
 				onNavigate={ onNavigate( 'activity_clicked' ) }
-				selected={ currentPathMatches( '/activity-log' ) }
+				selected={ currentPathMatches( activityLogPath( siteSlug ) ) }
 				expandSection={ expandSection }
 			/>
 			<SidebarItem
 				materialIcon={ showIcons ? 'backup' : undefined }
 				materialIconStyle="filled"
 				label="Backup"
-				link={ `/backup/${ siteSlug }` }
+				link={ backupPath( siteSlug ) }
 				onNavigate={ onNavigate( 'item_clicked', { menu_item: 'backup' } ) }
-				selected={ currentPathMatches( '/backup' ) }
+				selected={ currentPathMatches( backupPath( siteSlug ) ) }
 				expandSection={ expandSection }
 			/>
 			<SidebarItem
 				materialIcon={ showIcons ? 'security' : undefined }
 				materialIconStyle="filled"
 				label="Scan"
-				link={ `/scan/${ siteSlug }` }
+				link={ scanPath( siteSlug ) }
 				onNavigate={ onNavigate( 'item_clicked', { menu_item: 'scan' } ) }
-				selected={ currentPathMatches( '/scan' ) }
+				selected={ currentPathMatches( scanPath( siteSlug ) ) }
 				expandSection={ expandSection }
 			>
 				<ScanBadge progress={ scanProgress } numberOfThreatsFound={ scanThreats?.length ?? 0 } />

--- a/client/components/jetpack/sidebar/index.jsx
+++ b/client/components/jetpack/sidebar/index.jsx
@@ -11,33 +11,36 @@ import { format as formatUrl, parse as parseUrl } from 'url';
 /**
  * Internal dependencies
  */
-import { backupMainPath, backupActivityPath } from 'my-sites/backup/paths';
-import {
-	expandMySitesSidebarSection as expandSection,
-	toggleMySitesSidebarSection as toggleSection,
-} from 'state/my-sites/sidebar/actions';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
-import { isSidebarSectionOpen } from 'state/my-sites/sidebar/selectors';
-import { itemLinkMatches } from 'my-sites/sidebar/utils';
 import { recordTracksEvent } from 'state/analytics/actions';
-import { settingsPath } from 'lib/jetpack/paths';
 import CurrentSite from 'my-sites/current-site';
-import ExpandableSidebarMenu from 'layout/sidebar/expandable';
 import getSiteAdminUrl from 'state/sites/selectors/get-site-admin-url';
-import getSiteScanProgress from 'state/selectors/get-site-scan-progress';
-import getSiteScanThreats from 'state/selectors/get-site-scan-threats';
-import Gridicon from 'components/gridicon';
-import QueryJetpackScan from 'components/data/query-jetpack-scan';
-import ScanBadge from 'components/jetpack/scan-badge';
 import Sidebar from 'layout/sidebar';
 import SidebarFooter from 'layout/sidebar/footer';
 import SidebarItem from 'layout/sidebar/item';
 import SidebarMenu from 'layout/sidebar/menu';
 import SidebarRegion from 'layout/sidebar/region';
+import { JetpackCloudSidebarMenuItems as SidebarMenuItems } from 'components/jetpack/sidebar-menu-items';
 
+// To be removed after jetpack/features-section flag is permanently enabled
+import { isEnabled } from 'config';
+import ExpandableSidebarMenu from 'layout/sidebar/expandable';
+import QueryJetpackScan from 'components/data/query-jetpack-scan';
+import { backupMainPath, backupActivityPath } from 'my-sites/backup/paths';
+import { itemLinkMatches } from 'my-sites/sidebar/utils';
+import { settingsPath } from 'lib/jetpack/paths';
+import {
+	expandMySitesSidebarSection as expandSection,
+	toggleMySitesSidebarSection as toggleSection,
+} from 'state/my-sites/sidebar/actions';
+import { isSidebarSectionOpen } from 'state/my-sites/sidebar/selectors';
+import getSiteScanProgress from 'state/selectors/get-site-scan-progress';
+import getSiteScanThreats from 'state/selectors/get-site-scan-threats';
+import ScanBadge from 'components/jetpack/scan-badge';
 // Lowercase because these are used as keys for sidebar state.
 export const SIDEBAR_SECTION_SCAN = 'scan';
 export const SIDEBAR_SECTION_BACKUP = 'backup';
+// End to-be-removed
 
 /**
  * Style dependencies
@@ -55,6 +58,15 @@ class JetpackCloudSidebar extends Component {
 		threats: PropTypes.array,
 	};
 
+	onNavigate = memoize( ( menuItem ) => () => {
+		this.props.dispatchRecordTracksEvent( 'calypso_jetpack_sidebar_menu_click', {
+			menu_item: menuItem,
+		} );
+
+		window.scrollTo( 0, 0 );
+	} );
+
+	// To be removed after jetpack/features-section flag is permanently enabled
 	/**
 	 * Check if a menu item is selected.
 	 *
@@ -64,32 +76,23 @@ class JetpackCloudSidebar extends Component {
 	isSelected( path ) {
 		return this.props.path === path || this.props.path.startsWith( path );
 	}
-
 	expandScanSection = () => this.props.expandSection( SIDEBAR_SECTION_SCAN );
 	expandBackupSection = () => this.props.expandSection( SIDEBAR_SECTION_BACKUP );
-
 	toggleSection = memoize( ( id ) => () => this.props.toggleSection( id ) );
+	// End to-be-removed
 
-	scrollToTop() {
-		window.scrollTo( 0, 0 );
-	}
+	sidebarItems() {
+		if ( isEnabled( 'jetpack/features-section' ) ) {
+			return (
+				<SidebarMenu>
+					<SidebarMenuItems path={ this.props.path } />
+				</SidebarMenu>
+			);
+		}
 
-	onNavigate = memoize( ( menuItem ) => () => {
-		this.props.dispatchRecordTracksEvent( 'calypso_jetpack_sidebar_menu_click', {
-			menu_item: menuItem,
-		} );
-		this.scrollToTop();
-	} );
-
-	render() {
-		const {
-			selectedSiteSlug,
-			translate,
-			threats,
-			siteId,
-			jetpackAdminUrl,
-			scanProgress,
-		} = this.props;
+		// To be removed after jetpack/features-section flag
+		// is permanently enabled: here thru end of method
+		const { selectedSiteSlug, translate, threats, siteId, scanProgress } = this.props;
 		const numberOfThreatsFound = threats.length;
 
 		const backupTitle = 'Backup';
@@ -100,94 +103,104 @@ class JetpackCloudSidebar extends Component {
 		);
 
 		return (
+			<>
+				<ExpandableSidebarMenu
+					onClick={ this.toggleSection( SIDEBAR_SECTION_BACKUP ) }
+					expanded={ this.props.isBackupSectionOpen }
+					title={ backupTitle }
+					materialIcon="backup"
+					materialIconStyle="filled"
+				>
+					<ul>
+						<SidebarItem
+							expandSection={ this.expandBackupSection }
+							label={ translate( 'Latest backups', {
+								comment: 'Jetpack Cloud / Backup sidebar navigation item',
+							} ) }
+							link={ backupMainPath( selectedSiteSlug ) }
+							onNavigate={ this.onNavigate( 'Jetpack Cloud Backup / Latest backups' ) }
+							selected={
+								itemLinkMatches( backupMainPath(), this.props.path ) &&
+								! itemLinkMatches( backupActivityPath(), this.props.path )
+							}
+						/>
+						<SidebarItem
+							expandSection={ this.expandBackupSection }
+							label={ translate( 'Activity log', {
+								comment: 'Jetpack Cloud / Activity Log status sidebar navigation item',
+							} ) }
+							link={ backupActivityPath( selectedSiteSlug ) }
+							onNavigate={ this.onNavigate( 'Jetpack Cloud Backup / Activity Log' ) }
+							selected={ itemLinkMatches( backupActivityPath(), this.props.path ) }
+						/>
+					</ul>
+				</ExpandableSidebarMenu>
+
+				<QueryJetpackScan siteId={ siteId } />
+				<ExpandableSidebarMenu
+					onClick={ this.toggleSection( SIDEBAR_SECTION_SCAN ) }
+					expanded={ this.props.isScanSectionOpen }
+					title={
+						this.props.isScanSectionOpen ? (
+							scanTitle
+						) : (
+							<a href={ selectedSiteSlug ? `/scan/${ selectedSiteSlug }` : '/scan' }>
+								{ scanTitle } { scanBadge }{ ' ' }
+							</a>
+						)
+					}
+					materialIcon="security" // @todo: The Scan logo differs from the Material Icon used here
+					materialIconStyle="filled"
+				>
+					<ul>
+						<SidebarItem
+							expandSection={ this.expandScanSection }
+							label={ translate( 'Scanner', {
+								comment: 'Jetpack Cloud / Scanner sidebar navigation item',
+							} ) }
+							link={ selectedSiteSlug ? `/scan/${ selectedSiteSlug }` : '/scan' }
+							onNavigate={ this.onNavigate( 'Jetpack Cloud Scan / Scanner' ) }
+							selected={
+								itemLinkMatches( '/scan', this.props.path ) &&
+								! itemLinkMatches( '/scan/history', this.props.path )
+							}
+						>
+							{ scanBadge }
+						</SidebarItem>
+						<SidebarItem
+							expandSection={ this.expandScanSection }
+							label={ translate( 'History', {
+								comment: 'Jetpack Cloud / Scan History sidebar navigation item',
+							} ) }
+							link={ selectedSiteSlug ? `/scan/history/${ selectedSiteSlug }` : '/scan/history' }
+							onNavigate={ this.onNavigate( 'Jetpack Cloud Scan / History' ) }
+							selected={ itemLinkMatches( '/scan/history', this.props.path ) }
+						/>
+					</ul>
+				</ExpandableSidebarMenu>
+
+				<SidebarItem
+					label={ translate( 'Settings', {
+						comment: 'Jetpack Cloud / Backups sidebar navigation item',
+					} ) }
+					link={ selectedSiteSlug ? settingsPath( selectedSiteSlug ) : settingsPath() }
+					onNavigate={ this.onNavigate( 'Jetpack Cloud / Settings' ) }
+					materialIcon="settings"
+					materialIconStyle="filled"
+					selected={ this.isSelected( settingsPath() ) }
+				/>
+			</>
+		);
+	}
+
+	render() {
+		const { translate, jetpackAdminUrl } = this.props;
+
+		return (
 			<Sidebar className="sidebar__jetpack-cloud">
 				<SidebarRegion>
 					<CurrentSite />
-					<ExpandableSidebarMenu
-						onClick={ this.toggleSection( SIDEBAR_SECTION_BACKUP ) }
-						expanded={ this.props.isBackupSectionOpen }
-						title={ backupTitle }
-						materialIcon="backup"
-						materialIconStyle="filled"
-					>
-						<ul>
-							<SidebarItem
-								expandSection={ this.expandBackupSection }
-								label={ translate( 'Latest backups', {
-									comment: 'Jetpack Cloud / Backup sidebar navigation item',
-								} ) }
-								link={ backupMainPath( selectedSiteSlug ) }
-								onNavigate={ this.onNavigate( 'Jetpack Cloud Backup / Latest backups' ) }
-								selected={
-									itemLinkMatches( backupMainPath(), this.props.path ) &&
-									! itemLinkMatches( backupActivityPath(), this.props.path )
-								}
-							/>
-							<SidebarItem
-								expandSection={ this.expandBackupSection }
-								label={ translate( 'Activity log', {
-									comment: 'Jetpack Cloud / Activity Log status sidebar navigation item',
-								} ) }
-								link={ backupActivityPath( selectedSiteSlug ) }
-								onNavigate={ this.onNavigate( 'Jetpack Cloud Backup / Activity Log' ) }
-								selected={ itemLinkMatches( backupActivityPath(), this.props.path ) }
-							/>
-						</ul>
-					</ExpandableSidebarMenu>
-
-					<QueryJetpackScan siteId={ siteId } />
-					<ExpandableSidebarMenu
-						onClick={ this.toggleSection( SIDEBAR_SECTION_SCAN ) }
-						expanded={ this.props.isScanSectionOpen }
-						title={
-							this.props.isScanSectionOpen ? (
-								scanTitle
-							) : (
-								<a href={ selectedSiteSlug ? `/scan/${ selectedSiteSlug }` : '/scan' }>
-									{ scanTitle } { scanBadge }{ ' ' }
-								</a>
-							)
-						}
-						materialIcon="security" // @todo: The Scan logo differs from the Material Icon used here
-						materialIconStyle="filled"
-					>
-						<ul>
-							<SidebarItem
-								expandSection={ this.expandScanSection }
-								label={ translate( 'Scanner', {
-									comment: 'Jetpack Cloud / Scanner sidebar navigation item',
-								} ) }
-								link={ selectedSiteSlug ? `/scan/${ selectedSiteSlug }` : '/scan' }
-								onNavigate={ this.onNavigate( 'Jetpack Cloud Scan / Scanner' ) }
-								selected={
-									itemLinkMatches( '/scan', this.props.path ) &&
-									! itemLinkMatches( '/scan/history', this.props.path )
-								}
-							>
-								{ scanBadge }
-							</SidebarItem>
-							<SidebarItem
-								expandSection={ this.expandScanSection }
-								label={ translate( 'History', {
-									comment: 'Jetpack Cloud / Scan History sidebar navigation item',
-								} ) }
-								link={ selectedSiteSlug ? `/scan/history/${ selectedSiteSlug }` : '/scan/history' }
-								onNavigate={ this.onNavigate( 'Jetpack Cloud Scan / History' ) }
-								selected={ itemLinkMatches( '/scan/history', this.props.path ) }
-							/>
-						</ul>
-					</ExpandableSidebarMenu>
-
-					<SidebarItem
-						label={ translate( 'Settings', {
-							comment: 'Jetpack Cloud / Backups sidebar navigation item',
-						} ) }
-						link={ selectedSiteSlug ? settingsPath( selectedSiteSlug ) : settingsPath() }
-						onNavigate={ this.onNavigate( 'Jetpack Cloud / Settings' ) }
-						materialIcon="settings"
-						materialIconStyle="filled"
-						selected={ this.isSelected( settingsPath() ) }
-					/>
+					{ this.sidebarItems() }
 				</SidebarRegion>
 				<SidebarFooter>
 					<SidebarMenu>
@@ -199,16 +212,13 @@ class JetpackCloudSidebar extends Component {
 							materialIcon="help"
 							materialIconStyle="filled"
 							onNavigate={ this.onNavigate( 'Jetpack Cloud / Support' ) }
-							selected={ this.isSelected( '/support' ) }
 						/>
 						<SidebarItem
 							label={ translate( 'WP Admin', {
 								comment: 'Jetpack Cloud sidebar navigation item',
 							} ) }
 							link={ jetpackAdminUrl }
-							customIcon={
-								<Gridicon className={ 'sidebar__menu-icon' } icon="my-sites" size={ 24 } />
-							}
+							icon="my-sites"
 						/>
 					</SidebarMenu>
 				</SidebarFooter>
@@ -228,24 +238,31 @@ export default connect(
 	( state ) => {
 		const siteId = getSelectedSiteId( state );
 		const jetpackAdminUrl = getJetpackAdminUrl( state, siteId );
+
+		// To be removed after jetpack/features-section flag is permanently enabled
 		const isBackupSectionOpen = isSidebarSectionOpen( state, SIDEBAR_SECTION_BACKUP );
 		const isScanSectionOpen = isSidebarSectionOpen( state, SIDEBAR_SECTION_SCAN );
 		const threats = getSiteScanThreats( state, siteId );
 		const scanProgress = getSiteScanProgress( state, siteId );
+		// End to-be-removed
 
 		return {
-			siteId,
 			jetpackAdminUrl,
+			selectedSiteSlug: getSelectedSiteSlug( state ),
+
+			// To be removed after jetpack/features-section flag is permanently enabled
+			siteId,
 			isBackupSectionOpen,
 			isScanSectionOpen,
-			selectedSiteSlug: getSelectedSiteSlug( state ),
 			threats,
 			scanProgress,
 		};
 	},
 	{
+		dispatchRecordTracksEvent: recordTracksEvent,
+
+		// To be removed after jetpack/features-section flag is permanently enabled
 		expandSection,
 		toggleSection,
-		dispatchRecordTracksEvent: recordTracksEvent,
 	}
 )( localize( JetpackCloudSidebar ) );

--- a/client/components/jetpack/sidebar/index.jsx
+++ b/client/components/jetpack/sidebar/index.jsx
@@ -20,7 +20,7 @@ import SidebarFooter from 'layout/sidebar/footer';
 import SidebarItem from 'layout/sidebar/item';
 import SidebarMenu from 'layout/sidebar/menu';
 import SidebarRegion from 'layout/sidebar/region';
-import { JetpackCloudSidebarMenuItems as SidebarMenuItems } from 'components/jetpack/sidebar-menu-items';
+import JetpackCloudSidebarMenuItems from './menu-items/jetpack-cloud';
 
 // To be removed after jetpack/features-section flag is permanently enabled
 import { isEnabled } from 'config';
@@ -85,7 +85,7 @@ class JetpackCloudSidebar extends Component {
 		if ( isEnabled( 'jetpack/features-section' ) ) {
 			return (
 				<SidebarMenu>
-					<SidebarMenuItems path={ this.props.path } />
+					<JetpackCloudSidebarMenuItems path={ this.props.path } />
 				</SidebarMenu>
 			);
 		}

--- a/client/components/jetpack/sidebar/menu-items/calypso.jsx
+++ b/client/components/jetpack/sidebar/menu-items/calypso.jsx
@@ -1,0 +1,24 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import JetpackSidebarMenuItems from '.';
+
+export default ( { path, expandSection } ) => {
+	return (
+		<JetpackSidebarMenuItems
+			path={ path }
+			showIcons={ false }
+			tracksEventNames={ {
+				activityClicked: 'calypso_mysites_jetpack_sidebar_activity_clicked',
+				backupClicked: 'calypso_mysites_jetpack_sidebar_backup_clicked',
+				scanClicked: 'calypso_mysites_jetpack_sidebar_scan_clicked',
+			} }
+			expandSection={ expandSection }
+		/>
+	);
+};

--- a/client/components/jetpack/sidebar/menu-items/index.jsx
+++ b/client/components/jetpack/sidebar/menu-items/index.jsx
@@ -9,11 +9,9 @@ import { useDispatch, useSelector } from 'react-redux';
  */
 import { useTranslate } from 'i18n-calypso';
 import { itemLinkMatches } from 'my-sites/sidebar/utils';
-import { activityLogPath, backupPath, scanPath, settingsPath } from 'lib/jetpack/paths';
+import { activityLogPath, backupPath, scanPath } from 'lib/jetpack/paths';
 import { recordTracksEvent } from 'state/analytics/actions';
-import { expandMySitesSidebarSection } from 'state/my-sites/sidebar/actions';
 import { setNextLayoutFocus } from 'state/ui/layout-focus/actions';
-import { SIDEBAR_SECTION_JETPACK } from 'my-sites/sidebar/constants';
 import getSelectedSiteId from 'state/ui/selectors/get-selected-site-id';
 import getSelectedSiteSlug from 'state/ui/selectors/get-selected-site-slug';
 import getSiteScanProgress from 'state/selectors/get-site-scan-progress';
@@ -22,48 +20,7 @@ import QueryScanState from 'components/data/query-jetpack-scan';
 import SidebarItem from 'layout/sidebar/item';
 import ScanBadge from 'components/jetpack/scan-badge';
 
-const trackClickAndNavigate = ( dispatch, prefix, event, params ) => () => {
-	dispatch( recordTracksEvent( `${ prefix }_${ event }`, params ) );
-
-	setNextLayoutFocus( 'content' );
-	window.scrollTo( 0, 0 );
-};
-
-export const CalypsoJetpackSidebarMenuItems = ( { path } ) => (
-	<JetpackSidebarMenuItems
-		path={ path }
-		showIcons={ false }
-		tracksPrefix="calypso_mysites_jetpack_sidebar"
-	/>
-);
-
-export const JetpackCloudSidebarMenuItems = ( { path } ) => {
-	const dispatch = useDispatch();
-	const translate = useTranslate();
-	const siteSlug = useSelector( getSelectedSiteSlug );
-
-	const TRACKS_PREFIX = 'calypso_jetpack_sidebar';
-
-	const onNavigate = trackClickAndNavigate( dispatch, TRACKS_PREFIX, 'settings_clicked' );
-
-	return (
-		<>
-			<JetpackSidebarMenuItems path={ path } showIcons={ true } tracksPrefix={ TRACKS_PREFIX } />
-			<SidebarItem
-				materialIcon="settings"
-				materialIconStyle="filled"
-				label={ translate( 'Settings', {
-					comment: 'Jetpack sidebar navigation item',
-				} ) }
-				link={ settingsPath( siteSlug ) }
-				onNavigate={ onNavigate }
-				selected={ itemLinkMatches( [ settingsPath( siteSlug ) ], path ) }
-			/>
-		</>
-	);
-};
-
-const JetpackSidebarMenuItems = ( { path, showIcons, tracksPrefix } ) => {
+export default ( { path, showIcons, tracksEventNames, expandSection } ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const siteId = useSelector( getSelectedSiteId );
@@ -72,11 +29,13 @@ const JetpackSidebarMenuItems = ( { path, showIcons, tracksPrefix } ) => {
 	const scanProgress = useSelector( ( state ) => getSiteScanProgress( state, siteId ) );
 	const scanThreats = useSelector( ( state ) => getSiteScanThreats( state, siteId ) );
 
-	const onNavigate = ( event, params ) =>
-		trackClickAndNavigate( dispatch, tracksPrefix, event, params );
+	const onNavigate = ( event ) => () => {
+		dispatch( recordTracksEvent( event ) );
 
+		setNextLayoutFocus( 'content' );
+		window.scrollTo( 0, 0 );
+	};
 	const currentPathMatches = ( url ) => itemLinkMatches( [ url ], path );
-	const expandSection = () => expandMySitesSidebarSection( SIDEBAR_SECTION_JETPACK );
 
 	return (
 		<>
@@ -87,7 +46,7 @@ const JetpackSidebarMenuItems = ( { path, showIcons, tracksPrefix } ) => {
 					comment: 'Jetpack sidebar menu item',
 				} ) }
 				link={ activityLogPath( siteSlug ) }
-				onNavigate={ onNavigate( 'activity_clicked' ) }
+				onNavigate={ onNavigate( tracksEventNames.activityClicked ) }
 				selected={ currentPathMatches( activityLogPath( siteSlug ) ) }
 				expandSection={ expandSection }
 			/>
@@ -96,7 +55,7 @@ const JetpackSidebarMenuItems = ( { path, showIcons, tracksPrefix } ) => {
 				materialIconStyle="filled"
 				label="Backup"
 				link={ backupPath( siteSlug ) }
-				onNavigate={ onNavigate( 'item_clicked', { menu_item: 'backup' } ) }
+				onNavigate={ onNavigate( tracksEventNames.backupClicked ) }
 				selected={ currentPathMatches( backupPath( siteSlug ) ) }
 				expandSection={ expandSection }
 			/>
@@ -105,7 +64,7 @@ const JetpackSidebarMenuItems = ( { path, showIcons, tracksPrefix } ) => {
 				materialIconStyle="filled"
 				label="Scan"
 				link={ scanPath( siteSlug ) }
-				onNavigate={ onNavigate( 'item_clicked', { menu_item: 'scan' } ) }
+				onNavigate={ onNavigate( tracksEventNames.scanClicked ) }
 				selected={ currentPathMatches( scanPath( siteSlug ) ) }
 				expandSection={ expandSection }
 			>

--- a/client/components/jetpack/sidebar/menu-items/jetpack-cloud.jsx
+++ b/client/components/jetpack/sidebar/menu-items/jetpack-cloud.jsx
@@ -1,0 +1,54 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { useTranslate } from 'i18n-calypso';
+import getSelectedSiteSlug from 'state/ui/selectors/get-selected-site-slug';
+import { recordTracksEvent } from 'state/analytics/actions';
+import { setNextLayoutFocus } from 'state/ui/layout-focus/actions';
+import { settingsPath } from 'lib/jetpack/paths';
+import { itemLinkMatches } from 'my-sites/sidebar/utils';
+import SidebarItem from 'layout/sidebar/item';
+import JetpackSidebarMenuItems from '.';
+
+export default ( { path } ) => {
+	const dispatch = useDispatch();
+	const translate = useTranslate();
+	const siteSlug = useSelector( getSelectedSiteSlug );
+
+	const onNavigate = () => {
+		dispatch( recordTracksEvent( 'calypso_jetpack_sidebar_settings_clicked' ) );
+
+		setNextLayoutFocus( 'content' );
+		window.scrollTo( 0, 0 );
+	};
+
+	return (
+		<>
+			<JetpackSidebarMenuItems
+				path={ path }
+				showIcons={ true }
+				tracksEventNames={ {
+					activityClicked: 'calypso_jetpack_sidebar_activity_clicked',
+					backupClicked: 'calypso_jetpack_sidebar_backup_clicked',
+					scanClicked: 'calypso_jetpack_sidebar_scan_clicked',
+				} }
+			/>
+			<SidebarItem
+				materialIcon="settings"
+				materialIconStyle="filled"
+				label={ translate( 'Settings', {
+					comment: 'Jetpack sidebar navigation item',
+				} ) }
+				link={ settingsPath( siteSlug ) }
+				onNavigate={ onNavigate }
+				selected={ itemLinkMatches( [ settingsPath( siteSlug ) ], path ) }
+			/>
+		</>
+	);
+};

--- a/client/lib/jetpack/paths.ts
+++ b/client/lib/jetpack/paths.ts
@@ -2,8 +2,22 @@
  * Internal dependencies
  */
 import isJetpackCloud from 'lib/jetpack/is-jetpack-cloud';
+import { addQueryArgs } from 'lib/url';
+
+const activityLogBasePath = () => ( isJetpackCloud() ? '/backup/activity' : '/activity-log' );
+export const activityLogPath = ( siteSlug?: string ) =>
+	siteSlug ? `${ activityLogBasePath() }/${ siteSlug }` : activityLogBasePath();
+
+const backupBasePath = () => '/backup';
+export const backupPath = ( siteSlug?: string, query = {} ) => {
+	const path = siteSlug ? `${ backupBasePath() }/${ siteSlug }` : backupBasePath();
+	return addQueryArgs( query, path );
+};
+
+const scanBasePath = () => '/scan';
+export const scanPath = ( siteSlug?: string ) =>
+	siteSlug ? `${ scanBasePath() }/${ siteSlug }` : scanBasePath();
 
 const settingsBasePath = () => ( isJetpackCloud() ? '/settings' : '/settings/security' );
-
-export const settingsPath = ( siteName: string ) =>
-	siteName ? `${ settingsBasePath() }/${ siteName }` : settingsBasePath();
+export const settingsPath = ( siteSlug?: string ) =>
+	siteSlug ? `${ settingsBasePath() }/${ siteSlug }` : settingsBasePath();

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -80,7 +80,7 @@ import canSiteViewAtomicHosting from 'state/selectors/can-site-view-atomic-hosti
 import isSiteWPForTeams from 'state/selectors/is-site-wpforteams';
 import { getCurrentRoute } from 'state/selectors/get-current-route';
 import { isUnderDomainManagementAll } from 'my-sites/domains/paths';
-import { CalypsoJetpackSidebarMenuItems as JetpackSidebarMenuItems } from 'components/jetpack/sidebar-menu-items';
+import JetpackSidebarMenuItems from 'components/jetpack/sidebar/menu-items/calypso';
 
 /**
  * Style dependencies
@@ -388,7 +388,11 @@ export class MySitesSidebar extends Component {
 				onClick={ this.toggleSection( SIDEBAR_SECTION_JETPACK ) }
 				title="Jetpack"
 			>
-				<JetpackSidebarMenuItems path={ path } showIcons={ false } tracksPrefix="calypso" />
+				<JetpackSidebarMenuItems
+					path={ path }
+					showIcons={ false }
+					expandSection={ this.expandJetpackSection }
+				/>
 			</ExpandableSidebarMenu>
 		);
 	}

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -78,9 +78,9 @@ import {
 } from './constants';
 import canSiteViewAtomicHosting from 'state/selectors/can-site-view-atomic-hosting';
 import isSiteWPForTeams from 'state/selectors/is-site-wpforteams';
-import { backupMainPath, backupActivityPath } from 'my-sites/backup/paths';
 import { getCurrentRoute } from 'state/selectors/get-current-route';
 import { isUnderDomainManagementAll } from 'my-sites/domains/paths';
+import { CalypsoJetpackSidebarMenuItems as JetpackSidebarMenuItems } from 'components/jetpack/sidebar-menu-items';
 
 /**
  * Style dependencies
@@ -379,12 +379,7 @@ export class MySitesSidebar extends Component {
 	}
 
 	jetpack() {
-		const { isJetpack, isJetpackSectionOpen, site, siteSuffix, path, translate } = this.props;
-
-		let activityLogUrl = '/activity-log' + siteSuffix;
-		if ( isJetpack && isEnabled( 'manage/themes-jetpack' ) ) {
-			activityLogUrl += '?group=rewind';
-		}
+		const { isJetpackSectionOpen, path } = this.props;
 
 		return (
 			<ExpandableSidebarMenu
@@ -393,32 +388,7 @@ export class MySitesSidebar extends Component {
 				onClick={ this.toggleSection( SIDEBAR_SECTION_JETPACK ) }
 				title="Jetpack"
 			>
-				<SidebarItem
-					label={ translate( 'Activity Log', {
-						comment: 'Jetpack Cloud / Activity Log status sidebar navigation item',
-					} ) }
-					link={ activityLogUrl }
-					onNavigate={ this.trackActivityClick }
-					selected={ itemLinkMatches( [ '/activity-log' ], path ) }
-					expandSection={ this.expandJetpackSection }
-				/>
-				<SidebarItem
-					label="Backup"
-					link={ backupMainPath( site.slug ) }
-					onNavigate={ this.onNavigate() }
-					selected={
-						itemLinkMatches( backupMainPath(), path ) &&
-						! itemLinkMatches( backupActivityPath(), path )
-					}
-				/>
-				<SidebarItem
-					label="Scan"
-					link={ site?.slug ? `/scan/${ site.slug }` : '/scan' }
-					onNavigate={ this.onNavigate() }
-					selected={
-						itemLinkMatches( '/scan', path ) && ! itemLinkMatches( '/scan/history', path )
-					}
-				/>
+				<JetpackSidebarMenuItems path={ path } showIcons={ false } tracksPrefix="calypso" />
 			</ExpandableSidebarMenu>
 		);
 	}


### PR DESCRIPTION
**NOTE: Due to the nature of the changes involved, this PR is quite large. Review with care!**

#### Changes proposed in this Pull Request

* Create a common `JetpackSidebarMenuItems` component to hold sidebar menu items for both Jetpack Cloud and the Jetpack sidebar section in Calypso.
* Change the My Sites sidebar and Jetpack Cloud sidebar to use this new component.
* Slightly change Tracks event names for the following actions, to bring Cloud in line with Calypso and make unifying the two easier:
  * Activity Log (event name change in both Calypso and Cloud)
  * Backup (`menu_item` param change)
  * Scan (`menu_item` param change)
  * Settings (event name change in Cloud only)

Fixes `1179060693083348-as-1179545706707209`

##### Implementation notes / Calls for feedback

* This is a pretty large PR, so I'm assuming there'll be lots of little revisions to make before it's ready to go.
* Instead of having its own folder, should `sidebar-menu-items/index.jsx` instead be `components/jetpack/sidebar/menu-items.jsx`?
* How do people feel about exporting Calypso and Cloud-specific implementations of `JetpackSidebarMenuItems` instead of directly exporting the component itself and trusting downstream consumers to roll their own logic?
* How do we feel about distinguishing Tracks events only by prefix, but the same otherwise? Is this setup too rigid?
* Does anything need to be done about my changes to the Tracks event names/params? If so, what?

#### Testing instructions

**NOTE: This PR has some wide-ranging changes. Please test thoroughly.**

##### Calypso

* Start Calypso with the `jetpack/features-section` flag disabled.
* Note that the sidebar interface's appearance matches production.
* Note that the following Tracks events still fire and their parameters have not changed:
  * Tools > Activity Log clicked
  * Manage > Settings clicked
* Enable the `jetpack/features-section` flag by adding `?flags=jetpack/features-section` to your URL.
* Note that the Jetpack sidebar section is now visible.
* Note that the Activity Log link is no longer visible in the Manage section and has moved to the Jetpack section.
* Note that menu items in the Jetpack section do not have their own icons.
* Check that all links point to the correct URLs.
* Check that the threat badge next to Scan is still functional for sites with and without threats.
* Check that the text for Jetpack, Backup, and Scan are still not translated, since they're product names.
* Check that when you navigate directly to the page for any of the menu items, the Jetpack sidebar menu is automatically opened
* Check that the correct Tracks events fire for clicks on the following links:
  * Jetpack > Activity Log
  * Jetpack > Backup
  * Jetpack > Scan
  * Manage > Settings

##### Jetpack Cloud

* Start Jetpack Cloud with the `jetpack/features-section` flag disabled.
* Note that the sidebar interface appears and works exactly as it does in production, including all links, badges, and copy.
* Note that all Tracks events fire correctly and are formed exactly as they are in production.
* Enable the `jetpack/features-section` flag by adding `?flags=jetpack/features-section` to your URL.
* Note the sidebar's appearance has changed to match our new design specification.
* Check that menu items still have icons beside them.
* Check that all existing links still work.
* Check that the threat badge next to Scan is still functional for sites with and without threats.
* Check that the text for Backup and Scan are still not translated, since they're product names.
* Check that the correct Tracks events fire for clicks on the following links:
  * Activity Log
  * Backup
  * Scan
  * Settings

#### Screenshots

##### Calypso (left: flag disabled / right: flag enabled)

<img width="262" alt="image" src="https://user-images.githubusercontent.com/670067/84288006-3d034780-ab06-11ea-825a-9c9410895441.png"> <img width="276" alt="image" src="https://user-images.githubusercontent.com/670067/84286583-7d61c600-ab04-11ea-9290-60051df5282e.png">

##### Jetpack Cloud (left: flag disabled / right: flag enabled)

<img width="265" alt="image" src="https://user-images.githubusercontent.com/670067/84286859-d9c4e580-ab04-11ea-8d38-9a35332ad13b.png"> <img width="262" alt="image" src="https://user-images.githubusercontent.com/670067/84286926-ea755b80-ab04-11ea-9df6-4603dd25a382.png">