### PR TITLE
composite-checkout: Access `name` property of wpcom payment method in error handler (1)

### DIFF
--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -209,13 +209,12 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 						reason: String( action.payload.message ),
 					} )
 				);
-				const payment_method = translateCheckoutPaymentMethodToWpcomPaymentMethod(
-					action.payload.paymentMethodId
-				);
 				reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_composite_payment_error', {
 						error_code: null,
-						payment_method,
+						payment_method:
+							translateCheckoutPaymentMethodToWpcomPaymentMethod( action.payload.paymentMethodId )
+								?.name || '',
 						reason: String( action.payload.message ),
 					} )
 				);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This fixes a bug in the error handling for transaction failures in composite checkout.

#### Testing instructions

- Trigger a transaction error for a payment (eg: use the test card `4000000000009995`).
- Verify that there are no errors in the console.