### PR TITLE
composite-checkout: Add iDEAL payment method (2)

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -61,6 +61,7 @@ import {
 	fullCreditsProcessor,
 	existingCardProcessor,
 	payPalProcessor,
+	idealProcessor,
 } from './payment-method-processors';
 import { useGetThankYouUrl } from './use-get-thank-you-url';
 import createAnalyticsEventHandler from './record-analytics';
@@ -468,6 +469,8 @@ export default function CompositeCheckout( {
 			'apple-pay': applePayProcessor,
 			'free-purchase': freePurchaseProcessor,
 			card: stripeCardProcessor,
+			ideal: ( transactionData ) =>
+				idealProcessor( transactionData, getThankYouUrl, isWhiteGloveOffer ),
 			'full-credits': fullCreditsProcessor,
 			'existing-card': existingCardProcessor,
 			paypal: ( transactionData ) =>

--- a/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
@@ -104,6 +104,16 @@ export async function submitStripeCardTransaction( transactionData, submit ) {
 	return submit( formattedTransactionData );
 }
 
+export async function submitStripeIdealTransaction( transactionData, submit ) {
+	const formattedTransactionData = createTransactionEndpointRequestPayloadFromLineItems( {
+		...transactionData,
+		paymentMethodType: 'WPCOM_Billing_Stripe_Source_Ideal',
+		paymentPartnerProcessorId: transactionData.stripeConfiguration.processor_id,
+	} );
+	debug( 'sending stripe ideal transaction', formattedTransactionData );
+	return submit( formattedTransactionData );
+}
+
 export function submitCreditsTransaction( transactionData, submit ) {
 	debug( 'formatting full credits transaction', transactionData );
 	const formattedTransactionData = createTransactionEndpointRequestPayloadFromLineItems( {

--- a/client/my-sites/checkout/composite-checkout/payment-method-processors.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-processors.js
@@ -13,6 +13,7 @@ import {
 	wpcomPayPalExpress,
 	submitApplePayPayment,
 	submitStripeCardTransaction,
+	submitStripeIdealTransaction,
 	submitFreePurchaseTransaction,
 	submitCreditsTransaction,
 	submitExistingCardPayment,
@@ -21,6 +22,43 @@ import {
 import { createStripePaymentMethod } from 'lib/stripe';
 
 const { select, dispatch } = defaultRegistry;
+
+export function idealProcessor( submitData, getThankYouUrl, isWhiteGloveOffer ) {
+	const { protocol, hostname, port, pathname } = parseUrl( window.location.href, true );
+	const query = isWhiteGloveOffer ? { type: 'white-glove' } : {};
+	const successUrl = formatUrl( {
+		protocol,
+		hostname,
+		port,
+		pathname: getThankYouUrl(),
+	} );
+	const cancelUrl = formatUrl( {
+		protocol,
+		hostname,
+		port,
+		pathname,
+		query,
+	} );
+	const pending = submitStripeIdealTransaction(
+		{
+			...submitData,
+			successUrl,
+			cancelUrl,
+			country: select( 'wpcom' )?.getContactInfo?.()?.countryCode?.value,
+			postalCode: select( 'wpcom' )?.getContactInfo?.()?.postalCode?.value,
+			subdivisionCode: select( 'wpcom' )?.getContactInfo?.()?.state?.value,
+			siteId: select( 'wpcom' )?.getSiteId?.(),
+			domainDetails: getDomainDetails( select ),
+		},
+		wpcomTransaction
+	);
+	// save result so we can get receipt_id and failed_purchases in getThankYouPageUrl
+	pending.then( ( result ) => {
+		// TODO: do this automatically when calling setTransactionComplete
+		dispatch( 'wpcom' ).setTransactionResponse( result );
+	} );
+	return pending;
+}
 
 export function applePayProcessor( submitData ) {
 	const pending = submitApplePayPayment(

--- a/client/my-sites/checkout/composite-checkout/types/transaction-endpoint.ts
+++ b/client/my-sites/checkout/composite-checkout/types/transaction-endpoint.ts
@@ -27,13 +27,16 @@ export type WPCOMTransactionEndpointRequestPayload = {
 
 export type WPCOMTransactionEndpointPaymentDetails = {
 	paymentMethod: string;
-	paymentKey: string;
+	paymentKey?: string;
 	paymentPartner: string;
-	storedDetailsId: string;
+	storedDetailsId?: string;
 	name: string;
 	zip: string;
 	postalCode: string;
 	country: string;
+	successUrl?: string;
+	cancelUrl?: string;
+	idealBank?: string;
 };
 
 export type WPCOMTransactionEndpointCart = {
@@ -140,6 +143,9 @@ export function createTransactionEndpointRequestPayloadFromLineItems( {
 	paymentPartnerProcessorId,
 	storedDetailsId,
 	name,
+	cancelUrl,
+	successUrl,
+	idealBank,
 }: {
 	siteId: string;
 	couponId?: string;
@@ -149,10 +155,13 @@ export function createTransactionEndpointRequestPayloadFromLineItems( {
 	domainDetails?: WPCOMTransactionEndpointDomainDetails;
 	items: WPCOMCartItem[];
 	paymentMethodType: string;
-	paymentMethodToken: string;
+	paymentMethodToken?: string;
 	paymentPartnerProcessorId: string;
-	storedDetailsId: string;
+	storedDetailsId?: string;
 	name: string;
+	successUrl?: string;
+	cancelUrl?: string;
+	idealBank?: string;
 } ): WPCOMTransactionEndpointRequestPayload {
 	const urlParams = new URLSearchParams( window.location.search );
 	const isWhiteGlove = urlParams.get( 'type' ) === 'white-glove';
@@ -176,6 +185,9 @@ export function createTransactionEndpointRequestPayloadFromLineItems( {
 			country,
 			postalCode,
 			zip: postalCode, // TODO: do we need this in addition to postalCode?
+			successUrl,
+			cancelUrl,
+			idealBank,
 		},
 		isWhiteGloveOffer: isWhiteGlove,
 	};

--- a/client/my-sites/checkout/composite-checkout/use-create-payment-methods.js
+++ b/client/my-sites/checkout/composite-checkout/use-create-payment-methods.js
@@ -6,6 +6,8 @@ import {
 	createPayPalMethod,
 	createStripePaymentMethodStore,
 	createStripeMethod,
+	createIdealMethod,
+	createIdealPaymentMethodStore,
 	createFullCreditsMethod,
 	createFreePaymentMethod,
 	createApplePayMethod,
@@ -60,6 +62,32 @@ function useCreateStripe( {
 		[ shouldLoadStripeMethod, stripePaymentMethodStore, stripe, stripeConfiguration ]
 	);
 	return stripeMethod;
+}
+
+function useCreateIdeal( {
+	onlyLoadPaymentMethods,
+	isStripeLoading,
+	stripeLoadingError,
+	stripeConfiguration,
+	stripe,
+} ) {
+	// If this PM is allowed by props, allowed by the cart, stripe is not loading, and there is no stripe error, then create the PM.
+	const isMethodAllowed = onlyLoadPaymentMethods
+		? onlyLoadPaymentMethods.includes( 'ideal' )
+		: true;
+	const shouldLoad = isMethodAllowed && ! isStripeLoading && ! stripeLoadingError;
+	const paymentMethodStore = useMemo( () => createIdealPaymentMethodStore(), [] );
+	return useMemo(
+		() =>
+			shouldLoad
+				? createIdealMethod( {
+						store: paymentMethodStore,
+						stripe,
+						stripeConfiguration,
+				  } )
+				: null,
+		[ shouldLoad, paymentMethodStore, stripe, stripeConfiguration ]
+	);
 }
 
 function useCreateFullCredits( { onlyLoadPaymentMethods, credits } ) {
@@ -174,6 +202,14 @@ export default function useCreatePaymentMethods( {
 		onlyLoadPaymentMethods,
 	} );
 
+	const idealMethod = useCreateIdeal( {
+		onlyLoadPaymentMethods,
+		isStripeLoading,
+		stripeLoadingError,
+		stripeConfiguration,
+		stripe,
+	} );
+
 	const stripeMethod = useCreateStripe( {
 		onlyLoadPaymentMethods,
 		isStripeLoading,
@@ -212,5 +248,6 @@ export default function useCreatePaymentMethods( {
 		...existingCardMethods,
 		stripeMethod,
 		paypalMethod,
+		idealMethod,
 	].filter( Boolean );
 }

--- a/packages/composite-checkout/src/lib/payment-methods/ideal.js
+++ b/packages/composite-checkout/src/lib/payment-methods/ideal.js
@@ -1,0 +1,321 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import styled from '@emotion/styled';
+import debugFactory from 'debug';
+import { sprintf } from '@wordpress/i18n';
+import { useI18n } from '@automattic/react-i18n';
+
+/**
+ * Internal dependencies
+ */
+import Field from '../../components/field';
+import Button from '../../components/button';
+import {
+	usePaymentProcessor,
+	useTransactionStatus,
+	useLineItems,
+	renderDisplayValueMarkdown,
+	useEvents,
+} from '../../public-api';
+import { SummaryLine, SummaryDetails } from '../styled-components/summary-details';
+import { useFormStatus } from '../form-status';
+import { registerStore, useSelect, useDispatch } from '../../lib/registry';
+
+const debug = debugFactory( 'composite-checkout:ideal-payment-method' );
+
+export function createIdealPaymentMethodStore() {
+	debug( 'creating a new ideal payment method store' );
+	const actions = {
+		changeCustomerName( payload ) {
+			return { type: 'CUSTOMER_NAME_SET', payload };
+		},
+		changeCustomerBank( payload ) {
+			return { type: 'CUSTOMER_BANK_SET', payload };
+		},
+	};
+
+	const selectors = {
+		getCustomerName( state ) {
+			return state.customerName || '';
+		},
+		getCustomerBank( state ) {
+			return state.customerBank || '';
+		},
+	};
+
+	const store = registerStore( 'ideal', {
+		reducer(
+			state = {
+				customerName: { value: '', isTouched: false },
+				customerBank: { value: '', isTouched: false },
+			},
+			action
+		) {
+			switch ( action.type ) {
+				case 'CUSTOMER_NAME_SET':
+					return { ...state, customerName: { value: action.payload, isTouched: true } };
+				case 'CUSTOMER_BANK_SET':
+					return { ...state, customerBank: { value: action.payload, isTouched: true } };
+			}
+			return state;
+		},
+		actions,
+		selectors,
+	} );
+
+	return { ...store, actions, selectors };
+}
+
+export function createIdealMethod( { store, stripe, stripeConfiguration } ) {
+	return {
+		id: 'ideal',
+		label: <IdealLabel />,
+		activeContent: <IdealFields stripe={ stripe } stripeConfiguration={ stripeConfiguration } />,
+		submitButton: (
+			<IdealPayButton
+				store={ store }
+				stripe={ stripe }
+				stripeConfiguration={ stripeConfiguration }
+			/>
+		),
+		inactiveContent: <IdealSummary />,
+		getAriaLabel: ( __ ) => __( 'iDEAL' ),
+	};
+}
+
+function IdealFields() {
+	const { __ } = useI18n();
+
+	const customerName = useSelect( ( select ) => select( 'ideal' ).getCustomerName() );
+	const customerBank = useSelect( ( select ) => select( 'ideal' ).getCustomerBank() );
+	const { changeCustomerName, changeCustomerBank } = useDispatch( 'ideal' );
+	const { formStatus } = useFormStatus();
+	const isDisabled = formStatus !== 'ready';
+
+	return (
+		<IdealFormWrapper>
+			<IdealField
+				id="cardholderName"
+				type="Text"
+				autoComplete="cc-name"
+				label={ __( 'Your name' ) }
+				value={ customerName?.value ?? '' }
+				onChange={ changeCustomerName }
+				isError={ customerName?.isTouched && customerName?.value.length === 0 }
+				errorMessage={ __( 'This field is required' ) }
+				disabled={ isDisabled }
+			/>
+			<BankSelector
+				id="bank-selector"
+				value={ customerBank?.value ?? '' }
+				onChange={ changeCustomerBank }
+				label={ __( 'Bank' ) }
+				isError={ customerBank?.isTouched && customerBank?.value.length === 0 }
+				errorMessage={ __( 'This field is required' ) }
+				disabled={ isDisabled }
+			/>
+		</IdealFormWrapper>
+	);
+}
+
+function BankSelector( { id, value, onChange, label, isError, errorMessage, disabled } ) {
+	const { __ } = useI18n();
+	const bankOptions = getBankOptions( __ );
+	/* eslint-disable jsx-a11y/no-onchange */
+	return (
+		<SelectWrapper>
+			<label htmlFor={ id } disabled={ disabled }>
+				{ label }
+			</label>
+			<select
+				id={ id }
+				value={ value }
+				onChange={ ( event ) => onChange( event.target.value ) }
+				disabled={ disabled }
+			>
+				{ bankOptions.map( ( bank ) => (
+					<BankOption key={ bank.value } value={ bank.value } label={ bank.label } />
+				) ) }
+			</select>
+			<ErrorMessage isError={ isError } errorMessage={ errorMessage } />
+		</SelectWrapper>
+	);
+	/* eslint-enable jsx-a11y/no-onchange */
+}
+
+function BankOption( { value, label } ) {
+	return <option value={ value }>{ label }</option>;
+}
+
+function ErrorMessage( { isError, errorMessage } ) {
+	if ( isError ) {
+		return <Description isError={ isError }>{ errorMessage }</Description>;
+	}
+	return null;
+}
+
+const Description = styled.p`
+	margin: 8px 0 0 0;
+	color: ${ ( props ) =>
+		props.isError ? props.theme.colors.error : props.theme.colors.textColorLight };
+	font-style: italic;
+	font-size: 14px;
+`;
+
+const IdealFormWrapper = styled.div`
+	padding: 16px;
+	position: relative;
+
+	:after {
+		display: block;
+		width: calc( 100% - 6px );
+		height: 1px;
+		content: '';
+		background: ${ ( props ) => props.theme.colors.borderColorLight };
+		position: absolute;
+		top: 0;
+		left: 3px;
+	}
+`;
+
+const IdealField = styled( Field )`
+	margin-top: 16px;
+
+	:first-of-type {
+		margin-top: 0;
+	}
+`;
+
+const SelectWrapper = styled.div`
+	margin-top: 16px;
+
+	select {
+		width: 100%;
+	}
+`;
+
+function IdealPayButton( { disabled, store, stripe, stripeConfiguration } ) {
+	const { __ } = useI18n();
+	const [ items, total ] = useLineItems();
+	const { formStatus } = useFormStatus();
+	const {
+		setTransactionRedirecting,
+		setTransactionError,
+		setTransactionPending,
+	} = useTransactionStatus();
+	const submitTransaction = usePaymentProcessor( 'ideal' );
+	const onEvent = useEvents();
+	const customerName = useSelect( ( select ) => select( 'ideal' ).getCustomerName() );
+	const customerBank = useSelect( ( select ) => select( 'ideal' ).getCustomerBank() );
+
+	return (
+		<Button
+			disabled={ disabled }
+			onClick={ () => {
+				if ( isFormValid( store ) ) {
+					debug( 'submitting ideal payment' );
+					setTransactionPending();
+					onEvent( { type: 'IDEAL_TRANSACTION_BEGIN' } );
+					submitTransaction( {
+						stripe,
+						name: customerName?.value,
+						idealBank: customerBank?.value,
+						items,
+						total,
+						stripeConfiguration,
+					} )
+						.then( ( stripeResponse ) => {
+							if ( ! stripeResponse?.redirect_url ) {
+								setTransactionError(
+									__(
+										'There was an error processing your payment. Please try again or contact support.'
+									)
+								);
+								return;
+							}
+							debug( 'ideal transaction requires redirect', stripeResponse.redirect_url );
+							setTransactionRedirecting( stripeResponse.redirect_url );
+						} )
+						.catch( ( error ) => {
+							setTransactionError( error.message );
+						} );
+				}
+			} }
+			buttonType="primary"
+			isBusy={ 'submitting' === formStatus }
+			fullWidth
+		>
+			<ButtonContents formStatus={ formStatus } total={ total } />
+		</Button>
+	);
+}
+
+function ButtonContents( { formStatus, total } ) {
+	const { __ } = useI18n();
+	if ( formStatus === 'submitting' ) {
+		return __( 'Processing…' );
+	}
+	if ( formStatus === 'ready' ) {
+		return sprintf( __( 'Pay %s' ), renderDisplayValueMarkdown( total.amount.displayValue ) );
+	}
+	return __( 'Please wait…' );
+}
+
+function IdealSummary() {
+	const customerName = useSelect( ( select ) => select( 'ideal' ).getCustomerName() );
+	const customerBank = useSelect( ( select ) => select( 'ideal' ).getCustomerBank() );
+
+	return (
+		<SummaryDetails>
+			<SummaryLine>{ customerName?.value }</SummaryLine>
+			<SummaryLine>{ customerBank?.value }</SummaryLine>
+		</SummaryDetails>
+	);
+}
+
+function isFormValid( store ) {
+	const customerName = store.selectors.getCustomerName( store.getState() );
+	const customerBank = store.selectors.getCustomerBank( store.getState() );
+
+	if ( ! customerName?.value.length ) {
+		// Touch the field so it displays a validation error
+		store.dispatch( store.actions.changeCustomerName( '' ) );
+	}
+	if ( ! customerBank?.value.length ) {
+		// Touch the field so it displays a validation error
+		store.dispatch( store.actions.changeCustomerBank( '' ) );
+	}
+	if ( ! customerName?.value.length || ! customerBank?.value.length ) {
+		return false;
+	}
+	return true;
+}
+
+function IdealLabel() {
+	const { __ } = useI18n();
+	// TODO: add icon
+	return (
+		<React.Fragment>
+			<span>{ __( 'iDEAL' ) }</span>
+		</React.Fragment>
+	);
+}
+
+function getBankOptions( __ ) {
+	// Source https://stripe.com/docs/sources/ideal
+	const banks = [
+		{ value: 'abn_amro', label: 'ABN AMRO' },
+		{ value: 'asn_bank', label: 'ASN Bank' },
+		{ value: 'bunq', label: 'Bunq' },
+		{ value: 'ing', label: 'ING' },
+		{ value: 'knab', label: 'Knab' },
+		{ value: 'rabobank', label: 'Rabobank' },
+		{ value: 'regiobank', label: 'RegioBank' },
+		{ value: 'sns_bank', label: 'SNS Bank' },
+		{ value: 'triodos_bank', label: 'Triodos Bank' },
+		{ value: 'van_lanschot', label: 'Van Lanschot' },
+	];
+	return [ { value: '', label: __( 'Please select your bank.' ) }, ...banks ];
+}

--- a/packages/composite-checkout/src/lib/payment-methods/ideal.js
+++ b/packages/composite-checkout/src/lib/payment-methods/ideal.js
@@ -22,6 +22,7 @@ import {
 import { SummaryLine, SummaryDetails } from '../styled-components/summary-details';
 import { useFormStatus } from '../form-status';
 import { registerStore, useSelect, useDispatch } from '../../lib/registry';
+import { PaymentMethodLogos } from '../styled-components/payment-method-logos';
 
 const debug = debugFactory( 'composite-checkout:ideal-payment-method' );
 
@@ -295,11 +296,36 @@ function isFormValid( store ) {
 
 function IdealLabel() {
 	const { __ } = useI18n();
-	// TODO: add icon
 	return (
 		<React.Fragment>
 			<span>{ __( 'iDEAL' ) }</span>
+			<PaymentMethodLogos className="ideal__logo payment-logos">
+				<IdealLogoUI />
+			</PaymentMethodLogos>
 		</React.Fragment>
+	);
+}
+
+const IdealLogoUI = styled( IdealLogo )`
+	width: 28px;
+`;
+
+function IdealLogo( { className } ) {
+	return (
+		<svg
+			className={ className }
+			enable-background="new 0 0 52.4 45.4"
+			viewBox="0 0 52.4 45.4"
+			xmlns="http://www.w3.org/2000/svg"
+		>
+			<path d="m5.8 39.2h8.6v-13.6h-8.6zm39.1-34.8c-6.4-4.7-15.1-4.4-15.1-4.4h-29.8v45.4h29.8s9.2.6 16.1-5.1c5.6-4.7 6.5-13.2 6.5-18.1 0-4.8-1.7-13.4-7.5-17.8zm0 32.5c-5.6 5.9-14.4 5.5-14.4 5.5h-27.4v-39.3h27.4s7.5-.3 13 4.4c5.3 4.5 5.8 10.6 5.8 15 .1 4-.5 10.3-4.4 14.4zm-34.8-22.9c-2.6 0-4.6 2.1-4.6 4.6s2.1 4.6 4.6 4.6c2.6 0 4.6-2.1 4.6-4.6s-2-4.6-4.6-4.6z" />
+			<path
+				clip-rule="evenodd"
+				d="m34.4 19.5h1.5l-.8-2zm5.9-4.8h2.1v6.5h3.8c-.2-3.4-1.5-8.4-4.8-10.9-4.3-3.4-11-3.8-11-3.8h-12.7v8.2h2.4s2.7.2 2.7 4.1c0 4-2.7 4.1-2.7 4.1h-2.4v16h12.7s7.5 0 12-4.1c2.9-2.7 3.6-8.3 3.8-11.9h-5.8v-8.2zm-9.9 1.7h-4.5v1.4h4.1v1.7h-4.1v1.7h4.5v1.7h-6.2v-8.2h6.2zm6.8 6.5-.6-1.7h-2.8l-.6 1.7h-2.2l3.1-8.2h2.1l3.4 8.2zm-16.4-4.1c0-2.2-1.4-2.4-1.4-2.4h-1.7v4.8h1.7s1.4 0 1.4-2.4z"
+				fill="#cc2e74"
+				fill-rule="evenodd"
+			/>
+		</svg>
 	);
 }
 

--- a/packages/composite-checkout/src/lib/payment-processors.js
+++ b/packages/composite-checkout/src/lib/payment-processors.js
@@ -11,7 +11,7 @@ import CheckoutContext from '../lib/checkout-context';
 export function usePaymentProcessor( key ) {
 	const { paymentProcessors } = useContext( CheckoutContext );
 	if ( ! paymentProcessors[ key ] ) {
-		throw new Error( 'No payment processor found with key', key );
+		throw new Error( `No payment processor found with key: ${ key }` );
 	}
 	return paymentProcessors[ key ];
 }

--- a/packages/composite-checkout/src/public-api.js
+++ b/packages/composite-checkout/src/public-api.js
@@ -37,6 +37,7 @@ import {
 } from './lib/registry';
 import { createFullCreditsMethod } from './lib/payment-methods/full-credits';
 import { createFreePaymentMethod } from './lib/payment-methods/free-purchase';
+import { createIdealPaymentMethodStore, createIdealMethod } from './lib/payment-methods/ideal';
 import {
 	createStripeMethod,
 	createStripePaymentMethodStore,
@@ -84,6 +85,8 @@ export {
 	createExistingCardMethod,
 	createFreePaymentMethod,
 	createFullCreditsMethod,
+	createIdealMethod,
+	createIdealPaymentMethodStore,
 	createPayPalMethod,
 	createRegistry,
 	createStripeMethod,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This adds the iDEAL payment method to composite checkout.

#### Screenshots

Old checkout:

![Screen Shot 2020-06-16 at 4 25 16 PM](https://user-images.githubusercontent.com/2036909/84824489-08076100-afee-11ea-9b4a-eb7e71c5cbd1.png)

New checkout:

![Screen Shot 2020-06-22 at 12 04 38 PM](https://user-images.githubusercontent.com/2036909/85309439-9a8d8180-b480-11ea-9034-18c85be23dce.png)

#### Testing instructions

- Set your currency to `EUR`.
- Apply D45029-code to force iDEAL to be allowed even if you are outside the `NL` country code.
- Add a plan to your cart and visit checkout with the query string `?flags=composite-checkout-force` added to the url because non-USD currencies are blocked for now.
- Choose `iDEAL` as the payment method, fill in your name and choose a bank.
- Press the "Pay" button.
- You'll be redirected to an iDEAL test page. Press "fail".
- Verify that you are redirected back to checkout with a failure message.
- Check out again in the same way (you'll probably have to re-add the `flags` query string).
- You'll be redirected to an iDEAL test page. Press "authorize".
- Verify that you are redirected to a thank-you page and that the plan was bought successfully.
