### PR TITLE
Stop composite checkout abtest and enable variant

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -37,15 +37,6 @@ export default {
 		defaultVariation: 'hide',
 		allowExistingUsers: true,
 	},
-	showCompositeCheckout: {
-		datestamp: '20200603',
-		variations: {
-			composite: 50,
-			regular: 50,
-		},
-		defaultVariation: 'regular',
-		allowExistingUsers: true,
-	},
 	skipThemesSelectionModal: {
 		datestamp: '20170904',
 		variations: {

--- a/client/my-sites/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout-system-decider.js
@@ -17,7 +17,6 @@ import config from 'config';
 import { getCurrentUserLocale, getCurrentUserCountryCode } from 'state/current-user/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
-import { abtest } from 'lib/abtest';
 import { logToLogstash } from 'state/logstash/actions';
 
 const debug = debugFactory( 'calypso:checkout-system-decider' );
@@ -209,13 +208,8 @@ function getCheckoutVariant(
 		return 'composite-checkout';
 	}
 
-	if ( abtest( 'showCompositeCheckout' ) === 'composite' ) {
-		debug( 'shouldShowCompositeCheckout true because user is in abtest' );
-		return 'composite-checkout';
-	}
-
-	debug( 'shouldShowCompositeCheckout false because test not enabled' );
-	return 'test-not-enabled';
+	debug( 'shouldShowCompositeCheckout true' );
+	return 'composite-checkout';
 }
 
 function fetchStripeConfigurationWpcom( args ) {

--- a/client/my-sites/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout-system-decider.js
@@ -203,11 +203,6 @@ function getCheckoutVariant(
 		return 'disallowed-product';
 	}
 
-	if ( config.isEnabled( 'composite-checkout-testing' ) ) {
-		debug( 'shouldShowCompositeCheckout true because testing config is enabled' );
-		return 'composite-checkout';
-	}
-
 	debug( 'shouldShowCompositeCheckout true' );
 	return 'composite-checkout';
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This removes the composite checkout abtest and sends 100% of page loads to new checkout versus old if they pass our other conditions, which are currently:

- Site is not jetpack (atomic sites are fine).
- Cart contains no jetpack plans.
- URL contains no unknown products (just to protect against things we haven't tested).
- Country code is US.
- Locale is EN.
- Currency is USD.

#### Testing instructions

Visit checkout with the above conditions met, and verify that you see new checkout.