### PR TITLE
Composite checkout: layout design tweaks

### DIFF
--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
@@ -259,13 +259,13 @@ function CheckoutSummaryHelp() {
 				supportVariationDetermined && (
 					<CheckoutSummaryHelpButton onClick={ handleHelpButtonClicked }>
 						{ isSupportChatUser
-							? translate( 'Questions? {{underline}}Ask a Happiness Engineer.{{/underline}}', {
+							? translate( 'Questions? {{underline}}Ask a Happiness Engineer{{/underline}}', {
 									components: {
 										underline: <span />,
 									},
 							  } )
 							: translate(
-									'Questions? {{underline}}Read more about plans and purchases.{{/underline}}',
+									'Questions? {{underline}}Read more about plans and purchases{{/underline}}',
 									{
 										components: {
 											underline: <span />,
@@ -333,6 +333,10 @@ const CheckoutSummaryHelpButton = styled.button`
 	span {
 		cursor: pointer;
 		text-decoration: underline;
+
+		&:hover {
+			text-decoration: none;
+		}
 	}
 `;
 

--- a/packages/composite-checkout/src/components/checkout-steps.js
+++ b/packages/composite-checkout/src/components/checkout-steps.js
@@ -434,7 +434,7 @@ const MainContentUI = styled.div`
 	width: 100%;
 
 	@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
-		margin: 32px auto;
+		margin: 0 auto 32px;
 	}
 
 	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Some minor UI fixes which include:
- Remove unnecessary space at the top of the screen
- Cleanup some punctuation in the help text
- Add interactivity to help text link text

**Before**
![image](https://user-images.githubusercontent.com/6981253/84335208-5df98600-ab62-11ea-83c4-7226a0501946.png)


**After**
![image](https://user-images.githubusercontent.com/6981253/84335167-43271180-ab62-11ea-880c-dad2fbd0094b.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

You can review the screenshots or load up the checkout and inspect manually.
