### PR TITLE
Reader recommended sites: only show dismiss button once we have a recommendation to show

### DIFF
--- a/client/blocks/reader-recommended-sites/index.jsx
+++ b/client/blocks/reader-recommended-sites/index.jsx
@@ -1,5 +1,5 @@
 /**
- * External Dependencies
+ * External dependencies
  */
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -7,8 +7,9 @@ import { map, partial, isEmpty } from 'lodash';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'components/gridicon';
 import { connect } from 'react-redux';
+
 /**
- * Internal Dependencies
+ * Internal dependencies
  */
 import { recordAction, recordTrackWithRailcar, recordTracksRailcarRender } from 'reader/stats';
 import { Button } from '@automattic/components';
@@ -71,15 +72,17 @@ export class RecommendedSites extends React.PureComponent {
 								className="reader-recommended-sites__site-list-item card is-compact"
 								key={ `site-rec-${ index }` }
 							>
-								<div className="reader-recommended-sites__recommended-site-dismiss">
-									<Button
-										borderless
-										title={ this.props.translate( 'Dismiss this recommendation' ) }
-										onClick={ partial( this.handleSiteDismiss, siteId, index ) }
-									>
-										<Gridicon icon="cross" size={ 18 } />
-									</Button>
-								</div>
+								{ siteId && (
+									<div className="reader-recommended-sites__recommended-site-dismiss">
+										<Button
+											borderless
+											title={ this.props.translate( 'Dismiss this recommendation' ) }
+											onClick={ partial( this.handleSiteDismiss, siteId, index ) }
+										>
+											<Gridicon icon="cross" size={ 18 } />
+										</Button>
+									</div>
+								) }
 								<ConnectedListItem
 									siteId={ siteId }
 									railcar={ site.railcar }


### PR DESCRIPTION
In p5PDj3-4ML-p2, @hacchism reported that a user can click on a recommendation 'dismiss' icon before the recommendation has loaded. This results in an error because we don't have a site to dismiss yet.

#### Changes proposed in this Pull Request

This PR adds a check to see if we have a recommendation before displaying the dismiss icon.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Go to http://calypso.localhost:3000/following/manage and refresh the page.

While the recommendations are initially loading, there should be no dismiss icon visible. 

(The dismiss icon may still appear a moment or two before the text, but that's fine - the dismiss will work as it has a site ID.)

Loading - no dismiss icons:

<img width="950" alt="Screen Shot 2020-06-11 at 17 21 46" src="https://user-images.githubusercontent.com/17325/84348057-31984500-ac08-11ea-8c69-d4099a2eeaae.png">

After loading:

<img width="781" alt="Screen Shot 2020-06-11 at 17 22 00" src="https://user-images.githubusercontent.com/17325/84348080-3b21ad00-ac08-11ea-9f67-2c1cabee231d.png">
