### PR TITLE
Add the all sites domain management paths

### DIFF
--- a/client/my-sites/domains/domain-management/change-site-address/index.jsx
+++ b/client/my-sites/domains/domain-management/change-site-address/index.jsx
@@ -1,11 +1,10 @@
-/** @format */
-
 /**
  * External dependencies
  */
 
 import PropTypes from 'prop-types';
 import React from 'react';
+import { connect } from 'react-redux';
 import page from 'page';
 import { localize, translate } from 'i18n-calypso';
 import { get } from 'lodash';
@@ -18,6 +17,7 @@ import Main from 'components/main';
 import SiteAddressChanger from 'blocks/site-address-changer';
 import { getSelectedDomain, isRegisteredDomain } from 'lib/domains';
 import { domainManagementEdit, domainManagementNameServers } from 'my-sites/domains/paths';
+import getCurrentRoute from 'state/selectors/get-current-route';
 
 /**
  * Style dependencies
@@ -40,7 +40,9 @@ class ChangeSiteAddress extends React.Component {
 			path = domainManagementEdit;
 		}
 
-		page( path( this.props.selectedSite.slug, this.props.selectedDomainName ) );
+		page(
+			path( this.props.selectedSite.slug, this.props.selectedDomainName, this.props.currentRoute )
+		);
 	};
 
 	render() {
@@ -60,4 +62,6 @@ class ChangeSiteAddress extends React.Component {
 	}
 }
 
-export default localize( ChangeSiteAddress );
+export default connect( ( state ) => ( {
+	currentRoute: getCurrentRoute( state ),
+} ) )( localize( ChangeSiteAddress ) );

--- a/client/my-sites/domains/domain-management/contacts-privacy/index.jsx
+++ b/client/my-sites/domains/domain-management/contacts-privacy/index.jsx
@@ -24,6 +24,7 @@ import {
 } from 'my-sites/domains/paths';
 import { getSelectedDomain } from 'lib/domains';
 import isRequestingWhois from 'state/selectors/is-requesting-whois';
+import getCurrentRoute from 'state/selectors/get-current-route';
 
 /**
  * Style dependencies
@@ -75,7 +76,8 @@ class ContactsPrivacy extends React.PureComponent {
 					<VerticalNavItem
 						path={ domainManagementEditContactInfo(
 							this.props.selectedSite.slug,
-							this.props.selectedDomainName
+							this.props.selectedDomainName,
+							this.props.currentRoute
 						) }
 					>
 						{ translate( 'Edit contact info' ) }
@@ -85,7 +87,8 @@ class ContactsPrivacy extends React.PureComponent {
 						<VerticalNavItem
 							path={ domainManagementManageConsent(
 								this.props.selectedSite.slug,
-								this.props.selectedDomainName
+								this.props.selectedDomainName,
+								this.props.currentRoute
 							) }
 						>
 							{ translate( 'Manage Consent for Personal Data Use' ) }
@@ -101,12 +104,20 @@ class ContactsPrivacy extends React.PureComponent {
 	}
 
 	goToEdit = () => {
-		page( domainManagementEdit( this.props.selectedSite.slug, this.props.selectedDomainName ) );
+		page(
+			domainManagementEdit(
+				this.props.selectedSite.slug,
+				this.props.selectedDomainName,
+				null,
+				this.props.currentRoute
+			)
+		);
 	};
 }
 
 export default connect( ( state, ownProps ) => {
 	return {
+		currentRoute: getCurrentRoute( state ),
 		isRequestingWhois: isRequestingWhois( state, ownProps.selectedDomainName ),
 	};
 } )( localize( ContactsPrivacy ) );

--- a/client/my-sites/domains/domain-management/contacts-privacy/index.jsx
+++ b/client/my-sites/domains/domain-management/contacts-privacy/index.jsx
@@ -108,7 +108,6 @@ class ContactsPrivacy extends React.PureComponent {
 			domainManagementEdit(
 				this.props.selectedSite.slug,
 				this.props.selectedDomainName,
-				null,
 				this.props.currentRoute
 			)
 		);

--- a/client/my-sites/domains/domain-management/controller.jsx
+++ b/client/my-sites/domains/domain-management/controller.jsx
@@ -236,7 +236,7 @@ export default {
 			<DomainManagementData
 				analyticsPath={ domainManagementRedirectSettings( ':site', ':domain' ) }
 				analyticsTitle="Domain Management > Redirect Settings"
-				component={ DomainManagement.SiteRedirect }
+				component={ DomainManagement.SiteRedirectSettings }
 				context={ pageContext }
 				selectedDomainName={ decodeURIComponentIfValid( pageContext.params.domain ) }
 			/>

--- a/client/my-sites/domains/domain-management/dns/index.jsx
+++ b/client/my-sites/domains/domain-management/dns/index.jsx
@@ -30,6 +30,7 @@ import { getDomainDns } from 'state/domains/dns/selectors';
 import { getDomainsBySiteId, isRequestingSiteDomains } from 'state/sites/domains/selectors';
 import QuerySiteDomains from 'components/data/query-site-domains';
 import QueryDomainDns from 'components/data/query-domain-dns';
+import getCurrentRoute from 'state/selectors/get-current-route';
 
 /**
  * Style dependencies
@@ -113,15 +114,16 @@ class Dns extends React.Component {
 	}
 
 	goBack = () => {
+		const { selectedSite, selectedDomainName, currentRoute } = this.props;
 		let path;
 
 		if ( isRegisteredDomain( getSelectedDomain( this.props ) ) ) {
-			path = domainManagementNameServers;
+			path = domainManagementNameServers( selectedSite.slug, selectedDomainName, currentRoute );
 		} else {
-			path = domainManagementEdit;
+			path = domainManagementEdit( selectedSite.slug, selectedDomainName, null, currentRoute );
 		}
 
-		page( path( this.props.selectedSite.slug, this.props.selectedDomainName ) );
+		page( path );
 	};
 }
 
@@ -132,5 +134,11 @@ export default connect( ( state, { selectedDomainName } ) => {
 	const dns = getDomainDns( state, selectedDomainName );
 	const showPlaceholder = ! dns.hasLoadedFromServer || isRequestingDomains;
 
-	return { selectedSite, domains, dns, showPlaceholder };
+	return {
+		selectedSite,
+		domains,
+		dns,
+		showPlaceholder,
+		currentRoute: getCurrentRoute( state ),
+	};
 } )( localize( Dns ) );

--- a/client/my-sites/domains/domain-management/dns/index.jsx
+++ b/client/my-sites/domains/domain-management/dns/index.jsx
@@ -120,7 +120,7 @@ class Dns extends React.Component {
 		if ( isRegisteredDomain( getSelectedDomain( this.props ) ) ) {
 			path = domainManagementNameServers( selectedSite.slug, selectedDomainName, currentRoute );
 		} else {
-			path = domainManagementEdit( selectedSite.slug, selectedDomainName, null, currentRoute );
+			path = domainManagementEdit( selectedSite.slug, selectedDomainName, currentRoute );
 		}
 
 		page( path );

--- a/client/my-sites/domains/domain-management/domain-connect-mapping/index.jsx
+++ b/client/my-sites/domains/domain-management/domain-connect-mapping/index.jsx
@@ -218,7 +218,6 @@ class DomainConnectMapping extends React.Component {
 			domainManagementEdit(
 				this.props.selectedSite.slug,
 				this.props.selectedDomainName,
-				null,
 				this.props.currentRoute
 			)
 		);

--- a/client/my-sites/domains/domain-management/domain-connect-mapping/index.jsx
+++ b/client/my-sites/domains/domain-management/domain-connect-mapping/index.jsx
@@ -7,6 +7,7 @@ import React from 'react';
 import page from 'page';
 import { get } from 'lodash';
 import { parse } from 'qs';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -21,6 +22,7 @@ import { getSelectedDomain } from 'lib/domains';
 import SectionHeader from 'components/section-header';
 import wp from 'lib/wp';
 import { externalRedirect } from 'lib/route';
+import getCurrentRoute from 'state/selectors/get-current-route';
 
 const wpcom = wp.undocumented();
 
@@ -212,8 +214,17 @@ class DomainConnectMapping extends React.Component {
 	};
 
 	goToDomainManagementEdit = () => {
-		page( domainManagementEdit( this.props.selectedSite.slug, this.props.selectedDomainName ) );
+		page(
+			domainManagementEdit(
+				this.props.selectedSite.slug,
+				this.props.selectedDomainName,
+				null,
+				this.props.currentRoute
+			)
+		);
 	};
 }
 
-export default localize( DomainConnectMapping );
+export default connect( ( state ) => ( {
+	currentRoute: getCurrentRoute( state ),
+} ) )( localize( DomainConnectMapping ) );

--- a/client/my-sites/domains/domain-management/edit-contact-info/index.jsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info/index.jsx
@@ -21,6 +21,7 @@ import Main from 'components/main';
 import { domainManagementContactsPrivacy } from 'my-sites/domains/paths';
 import { getSelectedDomain } from 'lib/domains';
 import isRequestingWhois from 'state/selectors/is-requesting-whois';
+import getCurrentRoute from 'state/selectors/get-current-route';
 
 class EditContactInfo extends React.Component {
 	static propTypes = {
@@ -85,13 +86,18 @@ class EditContactInfo extends React.Component {
 
 	goToContactsPrivacy = () => {
 		page(
-			domainManagementContactsPrivacy( this.props.selectedSite.slug, this.props.selectedDomainName )
+			domainManagementContactsPrivacy(
+				this.props.selectedSite.slug,
+				this.props.selectedDomainName,
+				this.props.currentRoute
+			)
 		);
 	};
 }
 
 export default connect( ( state, ownProps ) => {
 	return {
+		currentRoute: getCurrentRoute( state ),
 		isRequestingWhois: isRequestingWhois( state, ownProps.selectedDomainName ),
 	};
 } )( localize( EditContactInfo ) );

--- a/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
+++ b/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
@@ -389,7 +389,7 @@ class DomainManagementNavigationEnhanced extends React.Component {
 	}
 
 	getSiteAddressChange() {
-		const { domain, selectedSite, translate } = this.props;
+		const { domain, selectedSite, translate, currentRoute } = this.props;
 		const { isWpcomStagingDomain } = domain;
 
 		if ( isWpcomStagingDomain ) {
@@ -398,7 +398,7 @@ class DomainManagementNavigationEnhanced extends React.Component {
 
 		return (
 			<DomainManagementNavigationItem
-				path={ domainManagementChangeSiteAddress( selectedSite.slug, domain.name ) }
+				path={ domainManagementChangeSiteAddress( selectedSite.slug, domain.name, currentRoute ) }
 				onClick={ this.handleChangeSiteAddressClick }
 				materialIcon="create"
 				text={ translate( 'Change site address' ) }

--- a/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
+++ b/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
@@ -549,11 +549,11 @@ class DomainManagementNavigationEnhanced extends React.Component {
 	}
 
 	getRedirectSettings() {
-		const { domain, selectedSite, translate } = this.props;
+		const { domain, selectedSite, currentRoute, translate } = this.props;
 
 		return (
 			<DomainManagementNavigationItem
-				path={ domainManagementRedirectSettings( selectedSite.slug, domain.name ) }
+				path={ domainManagementRedirectSettings( selectedSite.slug, domain.name, currentRoute ) }
 				materialIcon="language"
 				text={ translate( 'Redirect settings' ) }
 				description={ translate( 'Update your site redirect' ) }

--- a/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
+++ b/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
@@ -231,7 +231,7 @@ class DomainManagementNavigationEnhanced extends React.Component {
 	}
 
 	getTransferDomain() {
-		const { moment, selectedSite, translate, domain } = this.props;
+		const { moment, selectedSite, translate, domain, currentRoute } = this.props;
 		const { expired, isLocked, transferAwayEligibleAt } = domain;
 
 		if ( expired && ! this.isDomainInGracePeriod() ) {
@@ -255,7 +255,7 @@ class DomainManagementNavigationEnhanced extends React.Component {
 
 		return (
 			<DomainManagementNavigationItem
-				path={ domainManagementTransfer( selectedSite.slug, domain.name ) }
+				path={ domainManagementTransfer( selectedSite.slug, domain.name, currentRoute ) }
 				materialIcon="sync_alt"
 				text={ translate( 'Transfer domain' ) }
 				description={ description }

--- a/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
+++ b/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
@@ -170,7 +170,7 @@ class DomainManagementNavigationEnhanced extends React.Component {
 	}
 
 	getNameServers() {
-		const { translate, domain, selectedSite } = this.props;
+		const { translate, domain, currentRoute, selectedSite } = this.props;
 
 		if ( ! this.isDomainInNormalState() && ! this.isDomainInGracePeriod() ) {
 			return null;
@@ -180,7 +180,7 @@ class DomainManagementNavigationEnhanced extends React.Component {
 
 		return (
 			<DomainManagementNavigationItem
-				path={ domainManagementNameServers( selectedSite.slug, domain.name ) }
+				path={ domainManagementNameServers( selectedSite.slug, domain.name, currentRoute ) }
 				materialIcon="language"
 				text={ translate( 'Change your name servers & DNS records' ) }
 				description={ description }
@@ -189,13 +189,13 @@ class DomainManagementNavigationEnhanced extends React.Component {
 	}
 
 	getDnsRecords() {
-		const { selectedSite, translate, domain } = this.props;
+		const { selectedSite, translate, currentRoute, domain } = this.props;
 
 		const description = this.getDestinationText();
 
 		return (
 			<DomainManagementNavigationItem
-				path={ domainManagementDns( selectedSite.slug, domain.name ) }
+				path={ domainManagementDns( selectedSite.slug, domain.name, currentRoute ) }
 				materialIcon="language"
 				text={ translate( 'Update your DNS records' ) }
 				description={ description }
@@ -638,8 +638,10 @@ class DomainManagementNavigationEnhanced extends React.Component {
 
 export default connect(
 	( state ) => {
+		const currentRoute = getCurrentRoute( state );
 		return {
-			isManagingAllSites: isUnderDomainManagementAll( getCurrentRoute( state ) ),
+			currentRoute,
+			isManagingAllSites: isUnderDomainManagementAll( currentRoute ),
 		};
 	},
 	{ recordTracksEvent, recordGoogleEvent }

--- a/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
+++ b/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
@@ -204,7 +204,7 @@ class DomainManagementNavigationEnhanced extends React.Component {
 	}
 
 	getContactsAndPrivacy() {
-		const { selectedSite, translate, domain } = this.props;
+		const { selectedSite, translate, currentRoute, domain } = this.props;
 		const { privateDomain, privacyAvailable } = domain;
 
 		if ( ! this.isDomainInNormalState() && ! this.isDomainInGracePeriod() ) {
@@ -222,7 +222,7 @@ class DomainManagementNavigationEnhanced extends React.Component {
 
 		return (
 			<DomainManagementNavigationItem
-				path={ domainManagementContactsPrivacy( selectedSite.slug, domain.name ) }
+				path={ domainManagementContactsPrivacy( selectedSite.slug, domain.name, currentRoute ) }
 				materialIcon="chrome_reader_mode"
 				text={ translate( 'Update your contact information' ) }
 				description={ description }

--- a/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
+++ b/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
@@ -440,7 +440,7 @@ class DomainManagementNavigationEnhanced extends React.Component {
 	}
 
 	getSecurity() {
-		const { selectedSite, domain, translate } = this.props;
+		const { selectedSite, domain, currentRoute, translate } = this.props;
 
 		const shouldRenderDomainSecurity = config.isEnabled(
 			'domains/new-status-design/security-option'
@@ -477,7 +477,7 @@ class DomainManagementNavigationEnhanced extends React.Component {
 
 		return (
 			<DomainManagementNavigationItem
-				path={ domainManagementSecurity( selectedSite.slug, domain.name ) }
+				path={ domainManagementSecurity( selectedSite.slug, domain.name, currentRoute ) }
 				onClick={ this.handleDomainSecurityClick }
 				materialIcon="security"
 				text={ translate( 'Review your domain security' ) }

--- a/client/my-sites/domains/domain-management/index.jsx
+++ b/client/my-sites/domains/domain-management/index.jsx
@@ -12,6 +12,7 @@ import ManageConsent from './manage-consent';
 import NameServers from './name-servers';
 import Security from './security';
 import SiteRedirect from './edit/site-redirect';
+import SiteRedirectSettings from './site-redirect';
 import Transfer from './transfer';
 import TransferIn from './edit/transfer-in';
 import TransferOut from './transfer/transfer-out';
@@ -32,6 +33,7 @@ export default {
 	NameServers,
 	Security,
 	SiteRedirect,
+	SiteRedirectSettings,
 	TransferIn,
 	TransferOut,
 	TransferToOtherSite,

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -460,7 +460,7 @@ export class List extends React.Component {
 				break;
 
 			default:
-				path = domainManagementEdit( selectedSite.slug, domain.name, null, currentRoute );
+				path = domainManagementEdit( selectedSite.slug, domain.name, currentRoute );
 				break;
 		}
 

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -447,16 +447,24 @@ export class List extends React.Component {
 	}
 
 	goToEditDomainRoot = ( domain ) => {
-		const { selectedSite } = this.props;
+		const { selectedSite, currentRoute } = this.props;
 		let path;
 
 		switch ( domain.type ) {
 			case type.TRANSFER:
-				path = domainManagementTransferIn( selectedSite.slug, domain.name );
+				path = domainManagementTransferIn(
+					selectedSite.slug,
+					domain.name,
+					currentRoute
+				);
 				break;
 
 			case type.SITE_REDIRECT:
-				path = domainManagementSiteRedirect( selectedSite.slug, domain.name );
+				path = domainManagementSiteRedirect(
+					selectedSite.slug,
+					domain.name,
+					currentRoute
+				);
 				break;
 
 			default:
@@ -464,7 +472,7 @@ export class List extends React.Component {
 					selectedSite.slug,
 					domain.name,
 					null,
-					this.props.currentRoute
+					currentRoute
 				);
 				break;
 		}

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -452,28 +452,15 @@ export class List extends React.Component {
 
 		switch ( domain.type ) {
 			case type.TRANSFER:
-				path = domainManagementTransferIn(
-					selectedSite.slug,
-					domain.name,
-					currentRoute
-				);
+				path = domainManagementTransferIn( selectedSite.slug, domain.name, currentRoute );
 				break;
 
 			case type.SITE_REDIRECT:
-				path = domainManagementSiteRedirect(
-					selectedSite.slug,
-					domain.name,
-					currentRoute
-				);
+				path = domainManagementSiteRedirect( selectedSite.slug, domain.name, currentRoute );
 				break;
 
 			default:
-				path = domainManagementEdit(
-					selectedSite.slug,
-					domain.name,
-					null,
-					currentRoute
-				);
+				path = domainManagementEdit( selectedSite.slug, domain.name, null, currentRoute );
 				break;
 		}
 

--- a/client/my-sites/domains/domain-management/manage-consent/index.jsx
+++ b/client/my-sites/domains/domain-management/manage-consent/index.jsx
@@ -5,6 +5,7 @@
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
+import { connect } from 'react-redux';
 import page from 'page';
 
 /**
@@ -18,6 +19,7 @@ import Main from 'components/main';
 import { domainManagementContactsPrivacy } from 'my-sites/domains/paths';
 import { getSelectedDomain, requestGdprConsentManagementLink } from 'lib/domains';
 import SectionHeader from 'components/section-header';
+import getCurrentRoute from 'state/selectors/get-current-route';
 
 class ManageConsent extends React.Component {
 	static propTypes = {
@@ -112,9 +114,15 @@ class ManageConsent extends React.Component {
 
 	goToContactsPrivacy = () => {
 		page(
-			domainManagementContactsPrivacy( this.props.selectedSite.slug, this.props.selectedDomainName )
+			domainManagementContactsPrivacy(
+				this.props.selectedSite.slug,
+				this.props.selectedDomainName,
+				this.props.currentRoute
+			)
 		);
 	};
 }
 
-export default localize( ManageConsent );
+export default connect( ( state ) => ( {
+	currentRoute: getCurrentRoute( state ),
+} ) )( localize( ManageConsent ) );

--- a/client/my-sites/domains/domain-management/name-servers/index.jsx
+++ b/client/my-sites/domains/domain-management/name-servers/index.jsx
@@ -233,7 +233,6 @@ class NameServers extends React.Component {
 			domainManagementEdit(
 				this.props.selectedSite.slug,
 				this.props.selectedDomainName,
-				null,
 				this.props.currentRoute
 			)
 		);

--- a/client/my-sites/domains/domain-management/name-servers/index.jsx
+++ b/client/my-sites/domains/domain-management/name-servers/index.jsx
@@ -30,6 +30,7 @@ import FetchError from './fetch-error';
 import Notice from 'components/notice';
 import { CHANGE_NAME_SERVERS } from 'lib/url/support';
 import { composeAnalytics, recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
+import getCurrentRoute from 'state/selectors/get-current-route';
 
 /**
  * Style dependencies
@@ -228,7 +229,14 @@ class NameServers extends React.Component {
 	}
 
 	back = () => {
-		page( domainManagementEdit( this.props.selectedSite.slug, this.props.selectedDomainName ) );
+		page(
+			domainManagementEdit(
+				this.props.selectedSite.slug,
+				this.props.selectedDomainName,
+				null,
+				this.props.currentRoute
+			)
+		);
 	};
 
 	customNameservers() {
@@ -297,7 +305,11 @@ class NameServers extends React.Component {
 		return (
 			<VerticalNavItem
 				isPlaceholder={ this.isLoading() }
-				path={ domainManagementDns( this.props.selectedSite.slug, this.props.selectedDomainName ) }
+				path={ domainManagementDns(
+					this.props.selectedSite.slug,
+					this.props.selectedDomainName,
+					this.props.currentRoute
+				) }
 			>
 				{ this.props.translate( 'DNS records' ) }
 			</VerticalNavItem>
@@ -319,8 +331,13 @@ const customNameServersLearnMoreClick = ( domainName ) =>
 		)
 	);
 
-export default connect( null, {
-	customNameServersLearnMoreClick,
-	errorNotice,
-	successNotice,
-} )( localize( NameServers ) );
+export default connect(
+	( state ) => ( {
+		currentRoute: getCurrentRoute( state ),
+	} ),
+	{
+		customNameServersLearnMoreClick,
+		errorNotice,
+		successNotice,
+	}
+)( localize( NameServers ) );

--- a/client/my-sites/domains/domain-management/security/index.jsx
+++ b/client/my-sites/domains/domain-management/security/index.jsx
@@ -31,6 +31,7 @@ import VerticalNav from 'components/vertical-nav';
 import { ECOMMERCE, FORMS } from 'lib/url/support';
 import { showInlineHelpPopover } from 'state/inline-help/actions';
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import getCurrentRoute from 'state/selectors/get-current-route';
 
 import './style.scss';
 
@@ -44,7 +45,13 @@ class Security extends React.Component {
 	}
 
 	back = () => {
-		page( domainManagementEdit( this.props.selectedSite.slug, this.props.selectedDomainName ) );
+		page(
+			domainManagementEdit(
+				this.props.selectedSite.slug,
+				this.props.selectedDomainName,
+				this.props.currentRoute
+			)
+		);
 	};
 
 	getSSLStatusIcon( domain ) {
@@ -195,6 +202,7 @@ export default connect(
 		const { subscriptionId } = domain || {};
 
 		return {
+			currentRoute: getCurrentRoute( state ),
 			domain,
 			purchase: subscriptionId ? getByPurchaseId( state, parseInt( subscriptionId, 10 ) ) : null,
 			isLoadingPurchase:

--- a/client/my-sites/domains/domain-management/site-redirect/index.jsx
+++ b/client/my-sites/domains/domain-management/site-redirect/index.jsx
@@ -21,7 +21,10 @@ import FormTextInputWithAffixes from 'components/forms/form-text-input-with-affi
 import Main from 'components/main';
 import Notice from 'components/notice';
 import notices from 'notices';
-import { domainManagementEdit, domainManagementRedirectSettings } from 'my-sites/domains/paths';
+import {
+	domainManagementSiteRedirect,
+	domainManagementRedirectSettings,
+} from 'my-sites/domains/paths';
 import {
 	closeSiteRedirectNotice,
 	fetchSiteRedirect,
@@ -172,7 +175,7 @@ class SiteRedirect extends React.Component {
 		const { selectedDomainName, selectedSite } = this.props;
 
 		this.props.recordCancelClick( selectedDomainName );
-		page( domainManagementEdit( selectedSite.slug, selectedDomainName ) );
+		page( domainManagementSiteRedirect( selectedSite.slug, selectedDomainName ) );
 	};
 }
 

--- a/client/my-sites/domains/domain-management/site-redirect/index.jsx
+++ b/client/my-sites/domains/domain-management/site-redirect/index.jsx
@@ -36,6 +36,7 @@ import { composeAnalytics, recordGoogleEvent, recordTracksEvent } from 'state/an
 import { getSelectedSite } from 'state/ui/selectors';
 import { getSiteRedirectLocation } from 'state/domains/site-redirect/selectors';
 import { withoutHttp } from 'lib/url';
+import getCurrentRoute from 'state/selectors/get-current-route';
 
 /**
  * Style dependencies
@@ -93,7 +94,8 @@ class SiteRedirect extends React.Component {
 					page(
 						domainManagementRedirectSettings(
 							this.props.selectedSite.slug,
-							trim( trimEnd( this.state.redirectUrl, '/' ) )
+							trim( trimEnd( this.state.redirectUrl, '/' ) ),
+							this.props.currentRoute
 						)
 					);
 				}
@@ -172,10 +174,10 @@ class SiteRedirect extends React.Component {
 	}
 
 	goToEdit = () => {
-		const { selectedDomainName, selectedSite } = this.props;
+		const { selectedDomainName, selectedSite, currentRoute } = this.props;
 
 		this.props.recordCancelClick( selectedDomainName );
-		page( domainManagementSiteRedirect( selectedSite.slug, selectedDomainName ) );
+		page( domainManagementSiteRedirect( selectedSite.slug, selectedDomainName, currentRoute ) );
 	};
 }
 
@@ -224,7 +226,8 @@ export default connect(
 	( state ) => {
 		const selectedSite = getSelectedSite( state );
 		const location = getSiteRedirectLocation( state, selectedSite.domain );
-		return { selectedSite, location };
+		const currentRoute = getCurrentRoute( state );
+		return { selectedSite, location, currentRoute };
 	},
 	{
 		fetchSiteRedirect,

--- a/client/my-sites/domains/domain-management/transfer/index.jsx
+++ b/client/my-sites/domains/domain-management/transfer/index.jsx
@@ -24,6 +24,7 @@ import {
 } from 'my-sites/domains/paths';
 import VerticalNav from 'components/vertical-nav';
 import VerticalNavItem from 'components/vertical-nav/item';
+import getCurrentRoute from 'state/selectors/get-current-route';
 
 function Transfer( props ) {
 	const {
@@ -32,6 +33,7 @@ function Transfer( props ) {
 		isPrimaryDomain,
 		selectedSite,
 		selectedDomainName,
+		currentRoute,
 		translate,
 	} = props;
 
@@ -41,24 +43,28 @@ function Transfer( props ) {
 		<Main>
 			<Header
 				selectedDomainName={ selectedDomainName }
-				backHref={ domainManagementEdit( slug, selectedDomainName ) }
+				backHref={ domainManagementEdit( slug, selectedDomainName, currentRoute ) }
 			>
 				{ translate( 'Transfer Domain' ) }
 			</Header>
 			<VerticalNav>
-				<VerticalNavItem path={ domainManagementTransferOut( slug, selectedDomainName ) }>
+				<VerticalNavItem
+					path={ domainManagementTransferOut( slug, selectedDomainName, currentRoute ) }
+				>
 					{ translate( 'Transfer to another registrar' ) }
 				</VerticalNavItem>
 				{ ! isDomainOnly && (
 					<VerticalNavItem
-						path={ domainManagementTransferToAnotherUser( slug, selectedDomainName ) }
+						path={ domainManagementTransferToAnotherUser( slug, selectedDomainName, currentRoute ) }
 					>
 						{ translate( 'Transfer to another user' ) }
 					</VerticalNavItem>
 				) }
 
 				{ ( ( isAtomic && ! isPrimaryDomain ) || ! isAtomic ) && ( // Simple and Atomic (not primary domain )
-					<VerticalNavItem path={ domainManagementTransferToOtherSite( slug, selectedDomainName ) }>
+					<VerticalNavItem
+						path={ domainManagementTransferToOtherSite( slug, selectedDomainName, currentRoute ) }
+					>
 						{ translate( 'Transfer to another WordPress.com site' ) }
 					</VerticalNavItem>
 				) }
@@ -74,5 +80,6 @@ export default connect( ( state, ownProps ) => {
 		isDomainOnly: isDomainOnlySite( state, siteId ),
 		primaryDomain: getPrimaryDomainBySiteId( state, siteId ),
 		isPrimaryDomain: isPrimaryDomainBySiteId( state, siteId, ownProps.selectedDomainName ),
+		currentRoute: getCurrentRoute( state ),
 	};
 } )( localize( Transfer ) );

--- a/client/my-sites/domains/domain-management/transfer/transfer-out/index.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-out/index.jsx
@@ -4,6 +4,7 @@
 import page from 'page';
 import PropTypes from 'prop-types';
 import React from 'react';
+import { connect } from 'react-redux';
 import { omit } from 'lodash';
 import { localize } from 'i18n-calypso';
 import moment from 'moment';
@@ -23,7 +24,7 @@ import Unlocked from './unlocked.jsx';
 import SelectIpsTag from './select-ips-tag.jsx';
 import TransferProhibited from './transfer-prohibited.jsx';
 import TransferLock from './transfer-lock.jsx';
-
+import getCurrentRoute from 'state/selectors/get-current-route';
 /**
  * Style dependencies
  */
@@ -82,7 +83,13 @@ class Transfer extends React.Component {
 	}
 
 	goToEdit = () => {
-		page( domainManagementTransfer( this.props.selectedSite.slug, this.props.selectedDomainName ) );
+		page(
+			domainManagementTransfer(
+				this.props.selectedSite.slug,
+				this.props.selectedDomainName,
+				this.props.currentRoute
+			)
+		);
 	};
 
 	isDataLoading() {
@@ -90,4 +97,6 @@ class Transfer extends React.Component {
 	}
 }
 
-export default localize( Transfer );
+export default connect( ( state ) => ( {
+	currentRoute: getCurrentRoute( state ),
+} ) )( localize( Transfer ) );

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/index.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/index.jsx
@@ -28,6 +28,7 @@ import { successNotice, errorNotice } from 'state/notices/actions';
 import wp from 'lib/wp';
 import { isWpComFreePlan } from 'lib/plans';
 import { requestSites } from 'state/sites/actions';
+import getCurrentRoute from 'state/selectors/get-current-route';
 
 const wpcom = wp.undocumented();
 
@@ -119,14 +120,14 @@ export class TransferToOtherSite extends React.Component {
 			return <DomainMainPlaceholder goBack={ this.goToEdit } />;
 		}
 
-		const { selectedSite, selectedDomainName } = this.props;
+		const { selectedSite, selectedDomainName, currentRoute } = this.props;
 		const { slug } = selectedSite;
 
 		return (
 			<Main className="transfer-to-other-site">
 				<Header
 					selectedDomainName={ selectedDomainName }
-					backHref={ domainManagementTransfer( slug, selectedDomainName ) }
+					backHref={ domainManagementTransfer( slug, selectedDomainName, currentRoute ) }
 				>
 					{ this.props.translate( 'Transfer Domain To Another Site' ) }
 				</Header>
@@ -187,6 +188,7 @@ export default connect(
 		domainsWithPlansOnly: currentUserHasFlag( state, DOMAINS_WITH_PLANS_ONLY ),
 		isDomainOnly: isDomainOnlySite( state, get( ownProps, 'selectedSite.ID', null ) ),
 		sites: getSites( state ),
+		currentRoute: getCurrentRoute( state ),
 	} ),
 	{
 		errorNotice,

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/index.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/index.jsx
@@ -27,6 +27,7 @@ import { successNotice, errorNotice } from 'state/notices/actions';
 import DesignatedAgentNotice from 'my-sites/domains/domain-management/components/designated-agent-notice';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import { hasLoadedSiteDomains } from 'state/sites/domains/selectors';
+import getCurrentRoute from 'state/selectors/get-current-route';
 
 /**
  * Style dependencies
@@ -117,7 +118,11 @@ class TransferOtherUser extends React.Component {
 					this.props.successNotice( successMessage, { duration: 4000, isPersistent: true } );
 					closeDialog();
 					page(
-						domainManagementEdit( this.props.selectedSite.slug, this.props.selectedDomainName )
+						domainManagementEdit(
+							this.props.selectedSite.slug,
+							this.props.selectedDomainName,
+							this.props.currentRoute
+						)
 					);
 				},
 				( err ) => {
@@ -156,14 +161,14 @@ class TransferOtherUser extends React.Component {
 			return <DomainMainPlaceholder goBack={ this.goToEdit } />;
 		}
 
-		const { selectedSite, selectedDomainName } = this.props,
+		const { selectedSite, selectedDomainName, currentRoute } = this.props,
 			{ slug } = selectedSite;
 
 		return (
 			<Main>
 				<Header
 					selectedDomainName={ selectedDomainName }
-					backHref={ domainManagementTransfer( slug, selectedDomainName ) }
+					backHref={ domainManagementTransfer( slug, selectedDomainName, currentRoute ) }
 				>
 					{ this.props.translate( 'Transfer Domain To Another User' ) }
 				</Header>
@@ -298,6 +303,7 @@ export default connect(
 		currentUser: getCurrentUser( state ),
 		isAtomic: isSiteAutomatedTransfer( state, ownProps.selectedSite.ID ),
 		hasSiteDomainsLoaded: hasLoadedSiteDomains( state, ownProps.selectedSite.ID ),
+		currentRoute: getCurrentRoute( state ),
 	} ),
 	{
 		successNotice,

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -75,12 +75,9 @@ export default function () {
 		domainManagementController.domainManagementEmailForwardingRedirect
 	);
 
-	page(
-		paths.domainManagementChangeSiteAddress( ':site', ':domain' ),
-		...getCommonHandlers(),
-		domainManagementController.domainManagementChangeSiteAddress,
-		makeLayout,
-		clientRender
+	registerStandardDomainManagementPages(
+		paths.domainManagementChangeSiteAddress,
+		domainManagementController.domainManagementChangeSiteAddress
 	);
 
 	registerStandardDomainManagementPages(

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -18,6 +18,16 @@ function registerMultiPage( { paths: givenPaths, handlers } ) {
 	givenPaths.forEach( ( path ) => page( path, ...handlers ) );
 }
 
+function registerStandardDomainManagementPages( pathFunction, controller ) {
+	registerMultiPage( {
+		paths: [
+			pathFunction( ':site', ':domain' ),
+			pathFunction( ':site', ':domain', paths.domainManagementRoot() ),
+		],
+		handlers: [ ...getCommonHandlers(), controller, makeLayout, clientRender ],
+	} );
+}
+
 function getCommonHandlers( {
 	noSitePath = paths.domainManagementRoot(),
 	warnIfJetpack = true,
@@ -81,86 +91,40 @@ export default function () {
 		clientRender
 	);
 
-	page(
-		paths.domainManagementRedirectSettings( ':site', ':domain' ),
-		...getCommonHandlers(),
-		domainManagementController.domainManagementRedirectSettings,
-		makeLayout,
-		clientRender
+	registerStandardDomainManagementPages(
+		paths.domainManagementRedirectSettings,
+		domainManagementController.domainManagementRedirectSettings
 	);
 
-	registerMultiPage( {
-		paths: [
-			paths.domainManagementContactsPrivacy( ':site', ':domain' ),
-			paths.domainManagementContactsPrivacy( ':site', ':domain', paths.domainManagementRoot() ),
-		],
-		handlers: [
-			...getCommonHandlers(),
-			domainManagementController.domainManagementContactsPrivacy,
-			makeLayout,
-			clientRender,
-		],
-	} );
-
-	registerMultiPage( {
-		paths: [
-			paths.domainManagementEditContactInfo( ':site', ':domain' ),
-			paths.domainManagementEditContactInfo( ':site', ':domain', paths.domainManagementRoot() ),
-		],
-		handlers: [
-			...getCommonHandlers(),
-			domainManagementController.domainManagementEditContactInfo,
-			makeLayout,
-			clientRender,
-		],
-	} );
-
-	registerMultiPage( {
-		paths: [
-			paths.domainManagementManageConsent( ':site', ':domain' ),
-			paths.domainManagementManageConsent( ':site', ':domain', paths.domainManagementRoot() ),
-		],
-		handlers: [
-			...getCommonHandlers(),
-			domainManagementController.domainManagementManageConsent,
-			makeLayout,
-			clientRender,
-		],
-	} );
-
-	page(
-		paths.domainManagementDomainConnectMapping( ':site', ':domain' ),
-		...getCommonHandlers(),
-		domainManagementController.domainManagementDomainConnectMapping,
-		makeLayout,
-		clientRender
+	registerStandardDomainManagementPages(
+		paths.domainManagementContactsPrivacy,
+		domainManagementController.domainManagementContactsPrivacy
 	);
 
-	registerMultiPage( {
-		paths: [
-			paths.domainManagementDns( ':site', ':domain' ),
-			paths.domainManagementDns( ':site', ':domain', paths.domainManagementRoot() ),
-		],
-		handlers: [
-			...getCommonHandlers(),
-			domainManagementController.domainManagementDns,
-			makeLayout,
-			clientRender,
-		],
-	} );
+	registerStandardDomainManagementPages(
+		paths.domainManagementEditContactInfo,
+		domainManagementController.domainManagementEditContactInfo
+	);
 
-	registerMultiPage( {
-		paths: [
-			paths.domainManagementNameServers( ':site', ':domain' ),
-			paths.domainManagementNameServers( ':site', ':domain', paths.domainManagementRoot() ),
-		],
-		handlers: [
-			...getCommonHandlers(),
-			domainManagementController.domainManagementNameServers,
-			makeLayout,
-			clientRender,
-		],
-	} );
+	registerStandardDomainManagementPages(
+		paths.domainManagementManageConsent,
+		domainManagementController.domainManagementManageConsent
+	);
+
+	registerStandardDomainManagementPages(
+		paths.domainManagementDomainConnectMapping,
+		domainManagementController.domainManagementDomainConnectMapping
+	);
+
+	registerStandardDomainManagementPages(
+		paths.domainManagementDns,
+		domainManagementController.domainManagementDns
+	);
+
+	registerStandardDomainManagementPages(
+		paths.domainManagementNameServers,
+		domainManagementController.domainManagementNameServers
+	);
 
 	page(
 		paths.domainManagementTransfer( ':site', ':domain' ),
@@ -214,44 +178,20 @@ export default function () {
 		clientRender
 	);
 
-	registerMultiPage( {
-		paths: [
-			paths.domainManagementEdit( ':site', ':domain' ),
-			paths.domainManagementEdit( ':site', ':domain', null, paths.domainManagementRoot() ),
-		],
-		handlers: [
-			...getCommonHandlers(),
-			domainManagementController.domainManagementEdit,
-			makeLayout,
-			clientRender,
-		],
-	} );
+	registerStandardDomainManagementPages(
+		paths.domainManagementEdit,
+		domainManagementController.domainManagementEdit
+	);
 
-	registerMultiPage( {
-		paths: [
-			paths.domainManagementSiteRedirect( ':site', ':domain' ),
-			paths.domainManagementSiteRedirect( ':site', ':domain', paths.domainManagementRoot() ),
-		],
-		handlers: [
-			...getCommonHandlers(),
-			domainManagementController.domainManagementSiteRedirect,
-			makeLayout,
-			clientRender,
-		],
-	} );
+	registerStandardDomainManagementPages(
+		paths.domainManagementSiteRedirect,
+		domainManagementController.domainManagementSiteRedirect
+	);
 
-	registerMultiPage( {
-		paths: [
-			paths.domainManagementTransferIn( ':site', ':domain' ),
-			paths.domainManagementTransferIn( ':site', ':domain', paths.domainManagementRoot() ),
-		],
-		handlers: [
-			...getCommonHandlers(),
-			domainManagementController.domainManagementTransferIn,
-			makeLayout,
-			clientRender,
-		],
-	} );
+	registerStandardDomainManagementPages(
+		paths.domainManagementTransferIn,
+		domainManagementController.domainManagementTransferIn
+	);
 
 	if ( config.isEnabled( 'upgrades/domain-search' ) ) {
 		page(

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -83,12 +83,9 @@ export default function () {
 		clientRender
 	);
 
-	page(
-		paths.domainManagementSecurity( ':site', ':domain' ),
-		...getCommonHandlers(),
-		domainManagementController.domainManagementSecurity,
-		makeLayout,
-		clientRender
+	registerStandardDomainManagementPages(
+		paths.domainManagementSecurity,
+		domainManagementController.domainManagementSecurity
 	);
 
 	registerStandardDomainManagementPages(

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -202,21 +202,31 @@ export default function () {
 		],
 	} );
 
-	page(
-		paths.domainManagementSiteRedirect( ':site', ':domain' ),
-		...getCommonHandlers(),
-		domainManagementController.domainManagementSiteRedirect,
-		makeLayout,
-		clientRender
-	);
+	registerMultiPage( {
+		paths: [
+			paths.domainManagementSiteRedirect( ':site', ':domain' ),
+			paths.domainManagementSiteRedirect( ':site', ':domain', paths.domainManagementRoot() ),
+		],
+		handlers: [
+			...getCommonHandlers(),
+			domainManagementController.domainManagementSiteRedirect,
+			makeLayout,
+			clientRender
+		],
+	} );
 
-	page(
-		paths.domainManagementTransferIn( ':site', ':domain' ),
-		...getCommonHandlers(),
-		domainManagementController.domainManagementTransferIn,
-		makeLayout,
-		clientRender
-	);
+	registerMultiPage( {
+		paths: [
+			paths.domainManagementTransferIn( ':site', ':domain' ),
+			paths.domainManagementTransferIn( ':site', ':domain', paths.domainManagementRoot()  ),
+		],
+		handlers: [
+			...getCommonHandlers(),
+			domainManagementController.domainManagementTransferIn,
+			makeLayout,
+			clientRender
+		],
+	} );
 
 	if ( config.isEnabled( 'upgrades/domain-search' ) ) {
 		page(

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -89,29 +89,44 @@ export default function () {
 		clientRender
 	);
 
-	page(
-		paths.domainManagementContactsPrivacy( ':site', ':domain' ),
-		...getCommonHandlers(),
-		domainManagementController.domainManagementContactsPrivacy,
-		makeLayout,
-		clientRender
-	);
+	registerMultiPage( {
+		paths: [
+			paths.domainManagementContactsPrivacy( ':site', ':domain' ),
+			paths.domainManagementContactsPrivacy( ':site', ':domain', paths.domainManagementRoot() ),
+		],
+		handlers: [
+			...getCommonHandlers(),
+			domainManagementController.domainManagementContactsPrivacy,
+			makeLayout,
+			clientRender,
+		],
+	} );
 
-	page(
-		paths.domainManagementEditContactInfo( ':site', ':domain' ),
-		...getCommonHandlers(),
-		domainManagementController.domainManagementEditContactInfo,
-		makeLayout,
-		clientRender
-	);
+	registerMultiPage( {
+		paths: [
+			paths.domainManagementEditContactInfo( ':site', ':domain' ),
+			paths.domainManagementEditContactInfo( ':site', ':domain', paths.domainManagementRoot() ),
+		],
+		handlers: [
+			...getCommonHandlers(),
+			domainManagementController.domainManagementEditContactInfo,
+			makeLayout,
+			clientRender,
+		],
+	} );
 
-	page(
-		paths.domainManagementManageConsent( ':site', ':domain' ),
-		...getCommonHandlers(),
-		domainManagementController.domainManagementManageConsent,
-		makeLayout,
-		clientRender
-	);
+	registerMultiPage( {
+		paths: [
+			paths.domainManagementManageConsent( ':site', ':domain' ),
+			paths.domainManagementManageConsent( ':site', ':domain', paths.domainManagementRoot() ),
+		],
+		handlers: [
+			...getCommonHandlers(),
+			domainManagementController.domainManagementManageConsent,
+			makeLayout,
+			clientRender,
+		],
+	} );
 
 	page(
 		paths.domainManagementDomainConnectMapping( ':site', ':domain' ),

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -121,21 +121,31 @@ export default function () {
 		clientRender
 	);
 
-	page(
-		paths.domainManagementDns( ':site', ':domain' ),
-		...getCommonHandlers(),
-		domainManagementController.domainManagementDns,
-		makeLayout,
-		clientRender
-	);
+	registerMultiPage( {
+		paths: [
+			paths.domainManagementDns( ':site', ':domain' ),
+			paths.domainManagementDns( ':site', ':domain', paths.domainManagementRoot() ),
+		],
+		handlers: [
+			...getCommonHandlers(),
+			domainManagementController.domainManagementDns,
+			makeLayout,
+			clientRender,
+		],
+	} );
 
-	page(
-		paths.domainManagementNameServers( ':site', ':domain' ),
-		...getCommonHandlers(),
-		domainManagementController.domainManagementNameServers,
-		makeLayout,
-		clientRender
-	);
+	registerMultiPage( {
+		paths: [
+			paths.domainManagementNameServers( ':site', ':domain' ),
+			paths.domainManagementNameServers( ':site', ':domain', paths.domainManagementRoot() ),
+		],
+		handlers: [
+			...getCommonHandlers(),
+			domainManagementController.domainManagementNameServers,
+			makeLayout,
+			clientRender,
+		],
+	} );
 
 	page(
 		paths.domainManagementTransfer( ':site', ':domain' ),
@@ -211,20 +221,20 @@ export default function () {
 			...getCommonHandlers(),
 			domainManagementController.domainManagementSiteRedirect,
 			makeLayout,
-			clientRender
+			clientRender,
 		],
 	} );
 
 	registerMultiPage( {
 		paths: [
 			paths.domainManagementTransferIn( ':site', ':domain' ),
-			paths.domainManagementTransferIn( ':site', ':domain', paths.domainManagementRoot()  ),
+			paths.domainManagementTransferIn( ':site', ':domain', paths.domainManagementRoot() ),
 		],
 		handlers: [
 			...getCommonHandlers(),
 			domainManagementController.domainManagementTransferIn,
 			makeLayout,
-			clientRender
+			clientRender,
 		],
 	} );
 

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -123,36 +123,24 @@ export default function () {
 		domainManagementController.domainManagementNameServers
 	);
 
-	page(
-		paths.domainManagementTransfer( ':site', ':domain' ),
-		...getCommonHandlers(),
-		domainManagementController.domainManagementTransfer,
-		makeLayout,
-		clientRender
+	registerStandardDomainManagementPages(
+		paths.domainManagementTransfer,
+		domainManagementController.domainManagementTransfer
 	);
 
-	page(
-		paths.domainManagementTransferOut( ':site', ':domain' ),
-		...getCommonHandlers(),
-		domainManagementController.domainManagementTransferOut,
-		makeLayout,
-		clientRender
+	registerStandardDomainManagementPages(
+		paths.domainManagementTransferOut,
+		domainManagementController.domainManagementTransferOut
 	);
 
-	page(
-		paths.domainManagementTransferToAnotherUser( ':site', ':domain' ),
-		...getCommonHandlers(),
-		domainManagementController.domainManagementTransferToOtherUser,
-		makeLayout,
-		clientRender
+	registerStandardDomainManagementPages(
+		paths.domainManagementTransferToAnotherUser,
+		domainManagementController.domainManagementTransferToOtherUser
 	);
 
-	page(
-		paths.domainManagementTransferToOtherSite( ':site', ':domain' ),
-		...getCommonHandlers(),
-		domainManagementController.domainManagementTransferToOtherSite,
-		makeLayout,
-		clientRender
+	registerStandardDomainManagementPages(
+		paths.domainManagementTransferToOtherSite,
+		domainManagementController.domainManagementTransferToOtherSite
 	);
 
 	if ( config.isEnabled( 'manage/all-domains' ) ) {

--- a/client/my-sites/domains/paths.js
+++ b/client/my-sites/domains/paths.js
@@ -122,8 +122,8 @@ export function domainManagementRedirectSettings( siteName, domainName, relative
 	return domainManagementEditBase( siteName, domainName, 'redirect-settings', relativeTo );
 }
 
-export function domainManagementSecurity( siteName, domainName ) {
-	return domainManagementEditBase( siteName, domainName, 'security' );
+export function domainManagementSecurity( siteName, domainName, relativeTo = null ) {
+	return domainManagementEditBase( siteName, domainName, 'security', relativeTo );
 }
 
 export function domainManagementSiteRedirect( siteName, domainName, relativeTo = null ) {

--- a/client/my-sites/domains/paths.js
+++ b/client/my-sites/domains/paths.js
@@ -31,6 +31,20 @@ function domainManagementEditBase( siteName, domainName, slug, relativeTo = null
 	return resolveRootPath( relativeTo ) + '/' + domainName + '/' + slug + '/' + siteName;
 }
 
+function domainManagementTransferBase(
+	siteName,
+	domainName,
+	transferType = '',
+	relativeTo = null
+) {
+	return domainManagementEditBase(
+		siteName,
+		domainName,
+		filter( [ 'transfer', transferType ] ).join( '/' ),
+		relativeTo
+	);
+}
+
 export function isUnderDomainManagementAll( path ) {
 	return path.startsWith( domainManagementAllRoot() + '/' );
 }
@@ -130,38 +144,28 @@ export function domainManagementSiteRedirect( siteName, domainName, relativeTo =
 	return domainManagementEditBase( siteName, domainName, 'redirect', relativeTo );
 }
 
-export function domainManagementTransfer(
-	siteName,
-	domainName,
-	transferType = '',
-	relativeTo = null
-) {
-	return domainManagementEditBase(
-		siteName,
-		domainName,
-		filter( [ 'transfer', transferType ] ).join( '/' ),
-		relativeTo
-	);
+export function domainManagementTransfer( siteName, domainName, relativeTo = null ) {
+	return domainManagementTransferBase( siteName, domainName, '', relativeTo );
 }
 
-export function domainManagementTransferIn( siteName, domainName, relativeTo = null ) {
-	return domainManagementTransfer( siteName, domainName, 'in', relativeTo );
+export function domainManagementTransferIn( siteName, domainName ) {
+	return domainManagementTransferBase( siteName, domainName, 'in' );
 }
 
 export function domainManagementTransferInPrecheck( siteName, domainName ) {
-	return domainManagementTransfer( siteName, domainName, 'precheck' );
+	return domainManagementTransferBase( siteName, domainName, 'precheck' );
 }
 
-export function domainManagementTransferOut( siteName, domainName ) {
-	return domainManagementTransfer( siteName, domainName, 'out' );
+export function domainManagementTransferOut( siteName, domainName, relativeTo = null ) {
+	return domainManagementTransferBase( siteName, domainName, 'out', relativeTo );
 }
 
-export function domainManagementTransferToAnotherUser( siteName, domainName ) {
-	return domainManagementTransfer( siteName, domainName, 'other-user' );
+export function domainManagementTransferToAnotherUser( siteName, domainName, relativeTo = null ) {
+	return domainManagementTransferBase( siteName, domainName, 'other-user', relativeTo );
 }
 
-export function domainManagementTransferToOtherSite( siteName, domainName ) {
-	return domainManagementTransfer( siteName, domainName, 'other-site' );
+export function domainManagementTransferToOtherSite( siteName, domainName, relativeTo = null ) {
+	return domainManagementTransferBase( siteName, domainName, 'other-site', relativeTo );
 }
 
 export function domainMapping( siteName, domain = '' ) {

--- a/client/my-sites/domains/paths.js
+++ b/client/my-sites/domains/paths.js
@@ -120,8 +120,8 @@ export function domainManagementEmailForwarding( siteName, domainName ) {
 	return domainManagementEditBase( siteName, domainName, 'email-forwarding' );
 }
 
-export function domainManagementChangeSiteAddress( siteName, domainName ) {
-	return domainManagementEditBase( siteName, domainName, 'change-site-address' );
+export function domainManagementChangeSiteAddress( siteName, domainName, relativeTo = null ) {
+	return domainManagementEditBase( siteName, domainName, 'change-site-address', relativeTo );
 }
 
 export function domainManagementNameServers( siteName, domainName, relativeTo = null ) {

--- a/client/my-sites/domains/paths.js
+++ b/client/my-sites/domains/paths.js
@@ -122,20 +122,21 @@ export function domainManagementSecurity( siteName, domainName ) {
 	return domainManagementEdit( siteName, domainName, 'security' );
 }
 
-export function domainManagementSiteRedirect( siteName, domainName ) {
-	return domainManagementEdit( siteName, domainName, 'redirect' );
+export function domainManagementSiteRedirect( siteName, domainName, relativeTo = null ) {
+	return domainManagementEdit( siteName, domainName, 'redirect', relativeTo );
 }
 
-export function domainManagementTransfer( siteName, domainName, transferType = '' ) {
+export function domainManagementTransfer( siteName, domainName, transferType = '', relativeTo = null ) {
 	return domainManagementEdit(
 		siteName,
 		domainName,
-		filter( [ 'transfer', transferType ] ).join( '/' )
+		filter( [ 'transfer', transferType ] ).join( '/' ),
+		relativeTo
 	);
 }
 
-export function domainManagementTransferIn( siteName, domainName ) {
-	return domainManagementTransfer( siteName, domainName, 'in' );
+export function domainManagementTransferIn( siteName, domainName, relativeTo = null ) {
+	return domainManagementTransfer( siteName, domainName, 'in', relativeTo );
 }
 
 export function domainManagementTransferInPrecheck( siteName, domainName ) {

--- a/client/my-sites/domains/paths.js
+++ b/client/my-sites/domains/paths.js
@@ -114,8 +114,8 @@ export function domainManagementDns( siteName, domainName, relativeTo = null ) {
 	return domainManagementEdit( siteName, domainName, 'dns', relativeTo );
 }
 
-export function domainManagementRedirectSettings( siteName, domainName ) {
-	return domainManagementEdit( siteName, domainName, 'redirect-settings' );
+export function domainManagementRedirectSettings( siteName, domainName, relativeTo = null ) {
+	return domainManagementEdit( siteName, domainName, 'redirect-settings', relativeTo );
 }
 
 export function domainManagementSecurity( siteName, domainName ) {
@@ -214,6 +214,6 @@ export function getSectionName( pathname ) {
 	return matches ? matches[ 1 ] : null;
 }
 
-export function domainManagementDomainConnectMapping( siteName, domainName ) {
-	return domainManagementEdit( siteName, domainName, 'domain-connect-mapping' );
+export function domainManagementDomainConnectMapping( siteName, domainName, relativeTo = null ) {
+	return domainManagementEdit( siteName, domainName, 'domain-connect-mapping', relativeTo );
 }

--- a/client/my-sites/domains/paths.js
+++ b/client/my-sites/domains/paths.js
@@ -72,16 +72,16 @@ export function domainManagementAddGSuiteUsers( siteName, domainName ) {
 	return path;
 }
 
-export function domainManagementContactsPrivacy( siteName, domainName ) {
-	return domainManagementEdit( siteName, domainName, 'contacts-privacy' );
+export function domainManagementContactsPrivacy( siteName, domainName, relativeTo = null ) {
+	return domainManagementEdit( siteName, domainName, 'contacts-privacy', relativeTo );
 }
 
-export function domainManagementEditContactInfo( siteName, domainName ) {
-	return domainManagementEdit( siteName, domainName, 'edit-contact-info' );
+export function domainManagementEditContactInfo( siteName, domainName, relativeTo = null ) {
+	return domainManagementEdit( siteName, domainName, 'edit-contact-info', relativeTo );
 }
 
-export function domainManagementManageConsent( siteName, domainName ) {
-	return domainManagementEdit( siteName, domainName, 'manage-consent' );
+export function domainManagementManageConsent( siteName, domainName, relativeTo = null ) {
+	return domainManagementEdit( siteName, domainName, 'manage-consent', relativeTo );
 }
 
 export function domainManagementEmail( siteName, domainName ) {

--- a/client/my-sites/domains/paths.js
+++ b/client/my-sites/domains/paths.js
@@ -18,6 +18,19 @@ function resolveRootPath( relativeTo = null ) {
 	return domainManagementRoot();
 }
 
+function domainManagementEditBase( siteName, domainName, slug, relativeTo = null ) {
+	slug = slug || 'edit';
+
+	// Encodes only real domain names and not parameter placeholders
+	if ( ! startsWith( domainName, ':' ) ) {
+		// Encodes domain names so addresses with slashes in the path (e.g. used in site redirects) don't break routing.
+		// Note they are encoded twice since page.js decodes the path by default.
+		domainName = encodeURIComponent( encodeURIComponent( domainName ) );
+	}
+
+	return resolveRootPath( relativeTo ) + '/' + domainName + '/' + slug + '/' + siteName;
+}
+
 export function isUnderDomainManagementAll( path ) {
 	return path.startsWith( domainManagementAllRoot() + '/' );
 }
@@ -47,24 +60,15 @@ export function domainManagementList( siteName, relativeTo = null ) {
 	return domainManagementRoot() + '/' + siteName;
 }
 
-export function domainManagementEdit( siteName, domainName, slug, relativeTo = null ) {
-	slug = slug || 'edit';
-
-	// Encodes only real domain names and not parameter placeholders
-	if ( ! startsWith( domainName, ':' ) ) {
-		// Encodes domain names so addresses with slashes in the path (e.g. used in site redirects) don't break routing.
-		// Note they are encoded twice since page.js decodes the path by default.
-		domainName = encodeURIComponent( encodeURIComponent( domainName ) );
-	}
-
-	return resolveRootPath( relativeTo ) + '/' + domainName + '/' + slug + '/' + siteName;
+export function domainManagementEdit( siteName, domainName, relativeTo ) {
+	return domainManagementEditBase( siteName, domainName, 'edit', relativeTo );
 }
 
 export function domainManagementAddGSuiteUsers( siteName, domainName ) {
 	let path;
 
 	if ( domainName ) {
-		path = domainManagementEdit( siteName, domainName, 'add-gsuite-users' );
+		path = domainManagementEditBase( siteName, domainName, 'add-gsuite-users' );
 	} else {
 		path = domainManagementRoot() + '/add-gsuite-users/' + siteName;
 	}
@@ -73,22 +77,22 @@ export function domainManagementAddGSuiteUsers( siteName, domainName ) {
 }
 
 export function domainManagementContactsPrivacy( siteName, domainName, relativeTo = null ) {
-	return domainManagementEdit( siteName, domainName, 'contacts-privacy', relativeTo );
+	return domainManagementEditBase( siteName, domainName, 'contacts-privacy', relativeTo );
 }
 
 export function domainManagementEditContactInfo( siteName, domainName, relativeTo = null ) {
-	return domainManagementEdit( siteName, domainName, 'edit-contact-info', relativeTo );
+	return domainManagementEditBase( siteName, domainName, 'edit-contact-info', relativeTo );
 }
 
 export function domainManagementManageConsent( siteName, domainName, relativeTo = null ) {
-	return domainManagementEdit( siteName, domainName, 'manage-consent', relativeTo );
+	return domainManagementEditBase( siteName, domainName, 'manage-consent', relativeTo );
 }
 
 export function domainManagementEmail( siteName, domainName ) {
 	let path;
 
 	if ( domainName ) {
-		path = domainManagementEdit( siteName, domainName, 'email' );
+		path = domainManagementEditBase( siteName, domainName, 'email' );
 	} else if ( siteName ) {
 		path = domainManagementRoot() + '/email/' + siteName;
 	} else {
@@ -99,31 +103,31 @@ export function domainManagementEmail( siteName, domainName ) {
 }
 
 export function domainManagementEmailForwarding( siteName, domainName ) {
-	return domainManagementEdit( siteName, domainName, 'email-forwarding' );
+	return domainManagementEditBase( siteName, domainName, 'email-forwarding' );
 }
 
 export function domainManagementChangeSiteAddress( siteName, domainName ) {
-	return domainManagementEdit( siteName, domainName, 'change-site-address' );
+	return domainManagementEditBase( siteName, domainName, 'change-site-address' );
 }
 
 export function domainManagementNameServers( siteName, domainName, relativeTo = null ) {
-	return domainManagementEdit( siteName, domainName, 'name-servers', relativeTo );
+	return domainManagementEditBase( siteName, domainName, 'name-servers', relativeTo );
 }
 
 export function domainManagementDns( siteName, domainName, relativeTo = null ) {
-	return domainManagementEdit( siteName, domainName, 'dns', relativeTo );
+	return domainManagementEditBase( siteName, domainName, 'dns', relativeTo );
 }
 
 export function domainManagementRedirectSettings( siteName, domainName, relativeTo = null ) {
-	return domainManagementEdit( siteName, domainName, 'redirect-settings', relativeTo );
+	return domainManagementEditBase( siteName, domainName, 'redirect-settings', relativeTo );
 }
 
 export function domainManagementSecurity( siteName, domainName ) {
-	return domainManagementEdit( siteName, domainName, 'security' );
+	return domainManagementEditBase( siteName, domainName, 'security' );
 }
 
 export function domainManagementSiteRedirect( siteName, domainName, relativeTo = null ) {
-	return domainManagementEdit( siteName, domainName, 'redirect', relativeTo );
+	return domainManagementEditBase( siteName, domainName, 'redirect', relativeTo );
 }
 
 export function domainManagementTransfer(
@@ -132,7 +136,7 @@ export function domainManagementTransfer(
 	transferType = '',
 	relativeTo = null
 ) {
-	return domainManagementEdit(
+	return domainManagementEditBase(
 		siteName,
 		domainName,
 		filter( [ 'transfer', transferType ] ).join( '/' ),
@@ -215,5 +219,5 @@ export function getSectionName( pathname ) {
 }
 
 export function domainManagementDomainConnectMapping( siteName, domainName, relativeTo = null ) {
-	return domainManagementEdit( siteName, domainName, 'domain-connect-mapping', relativeTo );
+	return domainManagementEditBase( siteName, domainName, 'domain-connect-mapping', relativeTo );
 }

--- a/client/my-sites/domains/paths.js
+++ b/client/my-sites/domains/paths.js
@@ -106,12 +106,12 @@ export function domainManagementChangeSiteAddress( siteName, domainName ) {
 	return domainManagementEdit( siteName, domainName, 'change-site-address' );
 }
 
-export function domainManagementNameServers( siteName, domainName ) {
-	return domainManagementEdit( siteName, domainName, 'name-servers' );
+export function domainManagementNameServers( siteName, domainName, relativeTo = null ) {
+	return domainManagementEdit( siteName, domainName, 'name-servers', relativeTo );
 }
 
-export function domainManagementDns( siteName, domainName ) {
-	return domainManagementEdit( siteName, domainName, 'dns' );
+export function domainManagementDns( siteName, domainName, relativeTo = null ) {
+	return domainManagementEdit( siteName, domainName, 'dns', relativeTo );
 }
 
 export function domainManagementRedirectSettings( siteName, domainName ) {
@@ -126,7 +126,12 @@ export function domainManagementSiteRedirect( siteName, domainName, relativeTo =
 	return domainManagementEdit( siteName, domainName, 'redirect', relativeTo );
 }
 
-export function domainManagementTransfer( siteName, domainName, transferType = '', relativeTo = null ) {
+export function domainManagementTransfer(
+	siteName,
+	domainName,
+	transferType = '',
+	relativeTo = null
+) {
 	return domainManagementEdit(
 		siteName,
 		domainName,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* In order to keep the context when managing your domain via the all sites view we need to duplicate every domain management route.

Don't panic - the PR looks bigger than it actually is.

#### Testing instructions

From an all sites domains view (/domains/manage) you should be able to navigate all the domain management screens without this changing the left navigation bar. In more details this PR handles:

* Site redirect domain status page and it's back button
* Incoming transfer domain status page and the back button
* Dns settings for mapped domain and the back button
* Name servers and dns for registered domains and the back button
* Update your contact information, Edit contact info and Manage consent and all back buttons
* Connect your domain for mapped domain with Domain Connect
* Review your domain security
* Transfer domain and all screens in that section
* Change site address

The thing that is missing in this PR is the email routes since they're a bit different than the rest.
