### PR TITLE
Jetpack Backup: fix Backup layout in small screens

### DIFF
--- a/client/components/jetpack/backup-date-picker/style.scss
+++ b/client/components/jetpack/backup-date-picker/style.scss
@@ -118,7 +118,3 @@
 	height: 24px;
 	color: var( --studio-gray-70 );
 }
-
-.backup-date-picker__search-icon.gridicon {
-	fill: var( --studio-jetpack-green-40 );
-}

--- a/client/components/jetpack/daily-backup-status/style.scss
+++ b/client/components/jetpack/daily-backup-status/style.scss
@@ -80,7 +80,6 @@
 
 .daily-backup-status__download-button {
 	margin: 24px 0 1rem;
-	color: var( --studio-jetpack-green-60 );
 }
 
 .daily-backup-status__title {

--- a/client/landing/jetpack-cloud/style.scss
+++ b/client/landing/jetpack-cloud/style.scss
@@ -252,3 +252,7 @@ html {
 .backup-date-picker__search-icon.gridicon {
 	fill: var( --studio-jetpack-green-40 );
 }
+
+.daily-backup-status__download-button {
+	color: var( --studio-jetpack-green-60 );
+}

--- a/client/landing/jetpack-cloud/style.scss
+++ b/client/landing/jetpack-cloud/style.scss
@@ -238,3 +238,17 @@ html {
 .empty-content__illustration {
 	filter: hue-rotate( -80deg ) saturate( 1.5 );
 }
+
+.backup__main-wrap {
+	margin-left: -16px;
+	margin-right: -16px;
+
+	@include breakpoint-deprecated( '>660px' ) {
+		margin-left: 0;
+		margin-right: 0;
+	}
+}
+
+.backup-date-picker__search-icon.gridicon {
+	fill: var( --studio-jetpack-green-40 );
+}

--- a/client/my-sites/backup/style.scss
+++ b/client/my-sites/backup/style.scss
@@ -28,12 +28,11 @@
 	display: flex;
 	flex-direction: column;
 	height: calc( 100vh - 120px );
-	margin-left: -16px;
-	margin-right: -16px;
 
 	div:last-child {
 		flex-grow: 1;
 	}
+
 	@include breakpoint-deprecated( '>660px' ) {
 		height: auto;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix Backup layout in small screens for dotcom, by moving Jetpack cloud-specific styles to their own file.
* This also fixes some styling issues, mostly colors.


#### Before/After

Before | After
--|--
![image](https://user-images.githubusercontent.com/390760/84379132-398ebf80-abdd-11ea-8152-c36afa983a47.png) | ![image](https://user-images.githubusercontent.com/390760/84379745-3d6f1180-abde-11ea-8b94-67c9f68ec2d4.png)
![image](https://user-images.githubusercontent.com/390760/84379236-63e07d00-abdd-11ea-926b-7a611de60e7e.png) | ![image](https://user-images.githubusercontent.com/390760/84379702-2f20f580-abde-11ea-9f87-bfc236910925.png)



#### Testing instructions

* Spin up this PR and open wordpress.com.
* Add `?flags=jetpack/features-section` to your URL.
* Select a Jetpack site.
* Inside the new Jetpack menu, select Backup.
* Ensure the layout looks good in all screen widths.

Fixes 1179060693083348-asana-1179894482111961