### PR TITLE
Fix credentials update error response interpretation

### DIFF
--- a/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
+++ b/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
@@ -134,8 +134,8 @@ export const failure = ( action, error ) => ( dispatch, getState ) => {
 	const spreadHappiness = ( message ) => {
 		const tracksEvent = recordTracksEvent( 'calypso_rewind_creds_update_failure', {
 			site_id: action.siteId,
-			error: error.error,
-			status_code: error.statusCode,
+			error: error.code,
+			status_code: error.data ?? error.statusCode,
 			host: action.credentials.host,
 			kpri: action.credentials.krpi ? 'provided but [omitted here]' : 'not provided',
 			pass: action.credentials.pass ? 'provided but [omitted here]' : 'not provided',
@@ -152,7 +152,7 @@ export const failure = ( action, error ) => ( dispatch, getState ) => {
 		);
 	};
 
-	switch ( error.error ) {
+	switch ( error.code ) {
 		case 'service_unavailable':
 			announce(
 				i18n.translate(


### PR DESCRIPTION
#### Changes proposed

This pull request fixes a bug where all credentials update errors would yield the same generic user-facing notice, and internal error codes weren’t correctly being recorded in the tracks event. I suspect the shape of the error objects changed at some point:

![shape screenshot](https://user-images.githubusercontent.com/465303/84383932-8d76c400-ac30-11ea-940c-a85299e9cdf7.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Try to save SSH credentials that are correct except for an incorrect password or private key.
2. Verify that the “couldn’t connect” error message (or localised equivalent) is shown.

##### Before

![before screenshot](https://user-images.githubusercontent.com/465303/84379500-433e1480-ac29-11ea-97b8-b1f7250b3ddb.png)

##### After

![after screenshot](https://user-images.githubusercontent.com/465303/84379511-4802c880-ac29-11ea-9320-237c867ef3de.png)

Partially addresses 5409-gh-jpop-issues