### PR TITLE
Jetpack: makes stats the landing page for Jetpack non-Atomic sites

### DIFF
--- a/client/root.js
+++ b/client/root.js
@@ -10,7 +10,8 @@ import config from 'config';
 import userFactory from 'lib/user';
 import canCurrentUserUseCustomerHome from 'state/sites/selectors/can-current-user-use-customer-home';
 import getPrimarySiteId from 'state/selectors/get-primary-site-id';
-import { getSiteSlug } from 'state/sites/selectors';
+import { getSiteSlug, isJetpackSite } from 'state/sites/selectors';
+import isAtomicSite from 'state/selectors/is-site-automated-transfer';
 
 export default function () {
 	const user = userFactory();
@@ -51,6 +52,10 @@ function setupLoggedIn() {
 		const isCustomerHomeEnabled = canCurrentUserUseCustomerHome( state, primarySiteId );
 		const siteSlug = getSiteSlug( state, primarySiteId );
 		let redirectPath = siteSlug && isCustomerHomeEnabled ? `/home/${ siteSlug }` : '/read';
+
+		if ( isJetpackSite( state, primarySiteId ) && ! isAtomicSite( state, primarySiteId ) ) {
+			redirectPath = `/stats/${ siteSlug }`;
+		}
 
 		if ( context.querystring ) {
 			redirectPath += `?${ context.querystring }`;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates the landing page for Jetpack non-Atomic sites from Reader (`/read`) to Stats (`/stats`).

#### Testing instructions

* Spin up this PR.
* Set your primary site as a Jetpack non-Atomic site on https://wordpress.com/me/account.
* Open wordpress.com.
* Ensure you see your site stats for your primary site.
* Confirm that the landing page doesn't change for other site types.

See full context on p6TEKc-3Jb-p2
