### PR TITLE
Renaming Simple Payments to Pay with PayPal Button

### DIFF
--- a/client/blocks/inline-help/contextual-help.js
+++ b/client/blocks/inline-help/contextual-help.js
@@ -9,6 +9,7 @@ import i18n, { translate } from 'i18n-calypso';
  */
 import { RESULT_TOUR, RESULT_VIDEO } from './constants';
 import { localizeUrl } from 'lib/i18n-utils';
+import { isEnabled } from 'config';
 
 /**
  * Module variables
@@ -1207,7 +1208,9 @@ const getVideosForSection = () => ( {
 		{
 			type: RESULT_VIDEO,
 			link: 'https://www.youtube.com/embed/V8UToJoSf4Q',
-			title: translate( 'Add a Pay with PayPal Button' ),
+			title: isEnabled( 'earn/pay-with-paypal' )
+				? translate( 'Add a Pay with PayPal Button' )
+				: translate( 'Add a Simple Payment Button' ),
 			description: translate(
 				'Find out how to add a payment button to your WordPress.com website.'
 			),

--- a/client/blocks/inline-help/contextual-help.js
+++ b/client/blocks/inline-help/contextual-help.js
@@ -1207,7 +1207,7 @@ const getVideosForSection = () => ( {
 		{
 			type: RESULT_VIDEO,
 			link: 'https://www.youtube.com/embed/V8UToJoSf4Q',
-			title: translate( 'Add a Simple Payment Button' ),
+			title: translate( 'Add a Pay with PayPal Button' ),
 			description: translate(
 				'Find out how to add a payment button to your WordPress.com website.'
 			),

--- a/client/blocks/inline-help/contextual-help.js
+++ b/client/blocks/inline-help/contextual-help.js
@@ -1208,8 +1208,8 @@ const getVideosForSection = () => ( {
 		{
 			type: RESULT_VIDEO,
 			link: 'https://www.youtube.com/embed/V8UToJoSf4Q',
-			title: isEnabled( 'earn/pay-with-paypal' )
-				? translate( 'Add a Pay with PayPal Button' )
+			title: isEnabled( 'earn/rename-payment-blocks' )
+				? translate( 'Add a Pay with PayPal button' )
 				: translate( 'Add a Simple Payment Button' ),
 			description: translate(
 				'Find out how to add a payment button to your WordPress.com website.'

--- a/client/blocks/product-purchase-features-list/sell-online-paypal.jsx
+++ b/client/blocks/product-purchase-features-list/sell-online-paypal.jsx
@@ -10,6 +10,7 @@ import { localize } from 'i18n-calypso';
  */
 import PurchaseDetail from 'components/purchase-detail';
 import { localizeUrl } from 'lib/i18n-utils';
+import { isEnabled } from 'config';
 
 /**
  * Image dependencies
@@ -17,18 +18,34 @@ import { localizeUrl } from 'lib/i18n-utils';
 import paymentsImage from 'assets/images/illustrations/payments.svg';
 
 export default localize( ( { isJetpack, translate } ) => {
+	let supportDocLink;
+	if ( isEnabled( 'earn/rename-payment-blocks' ) ) {
+		supportDocLink = localizeUrl(
+			isJetpack
+				? 'https://jetpack.com/support/pay-with-paypal/'
+				: 'https://wordpress.com/support/pay-with-paypal/'
+		);
+	} else {
+		supportDocLink = localizeUrl(
+			isJetpack
+				? 'https://jetpack.com/support/simple-payment-button/'
+				: 'https://wordpress.com/support/simple-payments/'
+		);
+	}
 	return (
 		<div className="product-purchase-features-list__item">
 			<PurchaseDetail
-				buttonText={ translate( 'Collect payments' ) }
-				description={ translate(
-					'Add a payment button to any post or page to collect PayPal payments for physical products, digital goods, services, or donations.'
-				) }
-				href={ localizeUrl(
-					isJetpack
-						? 'https://jetpack.com/support/simple-payment-button/'
-						: 'https://wordpress.com/support/simple-payments/'
-				) }
+				buttonText={ translate( 'Collect PayPal payments' ) }
+				description={
+					isEnabled( 'earn/rename-payment-blocks' )
+						? translate(
+								'Add a button to any post or page to collect PayPal payments for physical products, digital goods, services, or donations.'
+						  )
+						: translate(
+								'Add a payment button to any post or page to collect PayPal payments for physical products, digital goods, services, or donations.'
+						  )
+				}
+				href={ supportDocLink }
 				icon={ <img alt="" src={ paymentsImage } /> }
 				target="_blank"
 				title={ translate( 'Sell online with PayPal' ) }

--- a/client/blocks/product-purchase-features-list/sell-online-paypal.jsx
+++ b/client/blocks/product-purchase-features-list/sell-online-paypal.jsx
@@ -35,7 +35,11 @@ export default localize( ( { isJetpack, translate } ) => {
 	return (
 		<div className="product-purchase-features-list__item">
 			<PurchaseDetail
-				buttonText={ translate( 'Collect PayPal payments' ) }
+				buttonText={
+					isEnabled( 'earn/rename-payment-blocks' )
+						? translate( 'Collect PayPal payments' )
+						: translate( 'Collect payments' )
+				}
 				description={
 					isEnabled( 'earn/rename-payment-blocks' )
 						? translate(

--- a/client/components/tinymce/plugins/insert-menu/menu-items.jsx
+++ b/client/components/tinymce/plugins/insert-menu/menu-items.jsx
@@ -93,7 +93,7 @@ menuItems.push( {
 	item: (
 		<GridiconButton
 			icon={ <Gridicon icon="money" /> }
-			label={ i18n.translate( 'Payment button' ) }
+			label={ i18n.translate( 'Pay with PayPal' ) }
 			e2e="payment-button"
 		/>
 	),

--- a/client/components/tinymce/plugins/insert-menu/menu-items.jsx
+++ b/client/components/tinymce/plugins/insert-menu/menu-items.jsx
@@ -93,7 +93,11 @@ menuItems.push( {
 	item: (
 		<GridiconButton
 			icon={ <Gridicon icon="money" /> }
-			label={ i18n.translate( 'Pay with PayPal' ) }
+			label={
+				config.isEnabled( 'earn/rename-payment-blocks' )
+					? i18n.translate( 'Pay with PayPal' )
+					: i18n.translate( 'Payment button' )
+			}
 			e2e="payment-button"
 		/>
 	),

--- a/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
@@ -13,6 +13,7 @@ import { find, isNumber, pick, noop, get, isEmpty } from 'lodash';
 /**
  * Internal dependencies
  */
+import { isEnabled } from 'config';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import getSimplePayments from 'state/selectors/get-simple-payments';
 import QuerySimplePayments from 'components/data/query-simple-payments';
@@ -479,9 +480,15 @@ class SimplePaymentsDialog extends Component {
 						<UpsellNudge
 							className="editor-simple-payments-modal__nudge-nudge"
 							title={ translate( 'Upgrade your plan to our Premium or Business plan!' ) }
-							description={ translate(
-								'Get Pay with PayPal button, advanced social media tools, your own domain, and more.'
-							) }
+							description={
+								isEnabled( 'earn/pay-with-paypal' )
+									? translate(
+											'Get Pay with PayPal button, advanced social media tools, your own domain, and more.'
+									  )
+									: translate(
+											'Get simple payments, advanced social media tools, your own domain, and more.'
+									  )
+							}
 							feature={ FEATURE_SIMPLE_PAYMENTS }
 							event="editor_simple_payments_modal_nudge"
 							tracksImpressionName="calypso_upgrade_nudge_impression"
@@ -492,9 +499,15 @@ class SimplePaymentsDialog extends Component {
 					secondaryAction={
 						<a
 							className="empty-content__action button"
-							href={ localizeUrl( 'https://wordpress.com/support/pay-with-paypal-button/' ) }
+							href={
+								isEnabled( 'earn/pay-with-paypal' )
+									? localizeUrl( 'https://wordpress.com/support/pay-with-paypal-button/' )
+									: localizeUrl( 'https://wordpress.com/support/simple-payments/' )
+							}
 						>
-							{ translate( 'Learn more about Pay with PayPal buttons' ) }
+							{ isEnabled( 'earn/pay-with-paypal' )
+								? translate( 'Learn more about Pay with PayPal buttons' )
+								: translate( 'Learn more about Simple Payments' ) }
 						</a>
 					}
 				/>,

--- a/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
@@ -538,9 +538,15 @@ class SimplePaymentsDialog extends Component {
 					secondaryAction={
 						<a
 							className="empty-content__action button"
-							href={ localizeUrl( 'https://wordpress.com/support/pay-with-paypal-button/' ) }
+							href={
+								isEnabled( 'earn/pay-with-paypal' )
+									? localizeUrl( 'https://wordpress.com/support/pay-with-paypal-button/' )
+									: localizeUrl( 'https://wordpress.com/support/simple-payments/' )
+							}
 						>
-							{ translate( 'Learn more about Pay with PayPal buttons' ) }
+							{ isEnabled( 'earn/pay-with-paypal' )
+								? translate( 'Learn more about Pay with PayPal buttons' )
+								: translate( 'Learn more about Simple Payments' ) }
 						</a>
 					}
 				/>,

--- a/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
@@ -480,7 +480,7 @@ class SimplePaymentsDialog extends Component {
 							className="editor-simple-payments-modal__nudge-nudge"
 							title={ translate( 'Upgrade your plan to our Premium or Business plan!' ) }
 							description={ translate(
-								'Get simple payments, advanced social media tools, your own domain, and more.'
+								'Get Pay with PayPal button, advanced social media tools, your own domain, and more.'
 							) }
 							feature={ FEATURE_SIMPLE_PAYMENTS }
 							event="editor_simple_payments_modal_nudge"
@@ -492,9 +492,9 @@ class SimplePaymentsDialog extends Component {
 					secondaryAction={
 						<a
 							className="empty-content__action button"
-							href={ localizeUrl( 'https://wordpress.com/support/simple-payments/' ) }
+							href={ localizeUrl( 'https://wordpress.com/support/pay-with-paypal-button/' ) }
 						>
-							{ translate( 'Learn more about Simple Payments' ) }
+							{ translate( 'Learn more about Pay with PayPal buttons' ) }
 						</a>
 					}
 				/>,
@@ -525,9 +525,9 @@ class SimplePaymentsDialog extends Component {
 					secondaryAction={
 						<a
 							className="empty-content__action button"
-							href={ localizeUrl( 'https://wordpress.com/support/simple-payments/' ) }
+							href={ localizeUrl( 'https://wordpress.com/support/pay-with-paypal-button/' ) }
 						>
-							{ translate( 'Learn more about Simple Payments' ) }
+							{ translate( 'Learn more about Pay with PayPal buttons' ) }
 						</a>
 					}
 				/>,

--- a/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
@@ -481,9 +481,9 @@ class SimplePaymentsDialog extends Component {
 							className="editor-simple-payments-modal__nudge-nudge"
 							title={ translate( 'Upgrade your plan to our Premium or Business plan!' ) }
 							description={
-								isEnabled( 'earn/pay-with-paypal' )
+								isEnabled( 'earn/rename-payment-blocks' )
 									? translate(
-											'Get Pay with PayPal button, advanced social media tools, your own domain, and more.'
+											'Get Pay with PayPal buttons, advanced social media tools, your own domain, and more.'
 									  )
 									: translate(
 											'Get simple payments, advanced social media tools, your own domain, and more.'
@@ -500,13 +500,13 @@ class SimplePaymentsDialog extends Component {
 						<a
 							className="empty-content__action button"
 							href={
-								isEnabled( 'earn/pay-with-paypal' )
-									? localizeUrl( 'https://wordpress.com/support/pay-with-paypal-button/' )
+								isEnabled( 'earn/rename-payment-blocks' )
+									? localizeUrl( 'https://wordpress.com/support/pay-with-paypal/' )
 									: localizeUrl( 'https://wordpress.com/support/simple-payments/' )
 							}
 						>
-							{ isEnabled( 'earn/pay-with-paypal' )
-								? translate( 'Learn more about Pay with PayPal buttons' )
+							{ isEnabled( 'earn/rename-payment-blocks' )
+								? translate( 'Learn more about Pay with PayPal' )
 								: translate( 'Learn more about Simple Payments' ) }
 						</a>
 					}
@@ -539,13 +539,13 @@ class SimplePaymentsDialog extends Component {
 						<a
 							className="empty-content__action button"
 							href={
-								isEnabled( 'earn/pay-with-paypal' )
-									? localizeUrl( 'https://wordpress.com/support/pay-with-paypal-button/' )
+								isEnabled( 'earn/rename-payment-blocks' )
+									? localizeUrl( 'https://wordpress.com/support/pay-with-paypal/' )
 									: localizeUrl( 'https://wordpress.com/support/simple-payments/' )
 							}
 						>
-							{ isEnabled( 'earn/pay-with-paypal' )
-								? translate( 'Learn more about Pay with PayPal buttons' )
+							{ isEnabled( 'earn/rename-payment-blocks' )
+								? translate( 'Learn more about Pay with PayPal' )
 								: translate( 'Learn more about Simple Payments' ) }
 						</a>
 					}

--- a/client/components/tinymce/plugins/wpcom-view/views/simple-payments/index.jsx
+++ b/client/components/tinymce/plugins/wpcom-view/views/simple-payments/index.jsx
@@ -22,6 +22,7 @@ import QuerySitePlans from 'components/data/query-site-plans';
 import QueryMedia from 'components/data/query-media';
 import { getCurrentPlan, hasFeature } from 'state/sites/plans/selectors';
 import { FEATURE_SIMPLE_PAYMENTS } from 'lib/plans/constants';
+import { isEnabled } from 'config';
 
 class SimplePaymentsView extends Component {
 	render() {
@@ -51,7 +52,9 @@ class SimplePaymentsView extends Component {
 						<Gridicon icon="cross" />
 					</div>
 					<p className="wpview-type-simple-payments__unsupported-message">
-						{ translate( "Your plan doesn't include Pay with PayPal buttons." ) }
+						{ isEnabled( 'earn/pay-with-paypal' )
+							? translate( "Your plan doesn't include Pay with PayPal" )
+							: translate( "Your plan doesn't include Simple Payments" ) }
 					</p>
 				</div>
 			);

--- a/client/components/tinymce/plugins/wpcom-view/views/simple-payments/index.jsx
+++ b/client/components/tinymce/plugins/wpcom-view/views/simple-payments/index.jsx
@@ -51,7 +51,7 @@ class SimplePaymentsView extends Component {
 						<Gridicon icon="cross" />
 					</div>
 					<p className="wpview-type-simple-payments__unsupported-message">
-						{ translate( "Your plan doesn't include Simple Payments." ) }
+						{ translate( "Your plan doesn't include Pay with PayPal buttons." ) }
 					</p>
 				</div>
 			);

--- a/client/components/tinymce/plugins/wpcom-view/views/simple-payments/index.jsx
+++ b/client/components/tinymce/plugins/wpcom-view/views/simple-payments/index.jsx
@@ -52,7 +52,7 @@ class SimplePaymentsView extends Component {
 						<Gridicon icon="cross" />
 					</div>
 					<p className="wpview-type-simple-payments__unsupported-message">
-						{ isEnabled( 'earn/pay-with-paypal' )
+						{ isEnabled( 'earn/rename-payment-blocks' )
 							? translate( "Your plan doesn't include Pay with PayPal" )
 							: translate( "Your plan doesn't include Simple Payments" ) }
 					</p>
@@ -107,7 +107,7 @@ class SimplePaymentsView extends Component {
 	}
 }
 
-SimplePaymentsView = connect( ( state, props ) => {
+const EnhancedSimplePaymentsView = connect( ( state, props ) => {
 	const { content: shortcode } = props;
 
 	const shortcodeData = deserialize( shortcode );
@@ -128,7 +128,7 @@ SimplePaymentsView = connect( ( state, props ) => {
 	};
 } )( localize( SimplePaymentsView ) );
 
-SimplePaymentsView.match = ( content ) => {
+EnhancedSimplePaymentsView.match = ( content ) => {
 	const match = next( 'simple-payment', content );
 
 	if ( match ) {
@@ -142,12 +142,12 @@ SimplePaymentsView.match = ( content ) => {
 	}
 };
 
-SimplePaymentsView.serialize = ( content ) => {
+EnhancedSimplePaymentsView.serialize = ( content ) => {
 	return encodeURIComponent( content );
 };
 
-SimplePaymentsView.edit = ( editor, content ) => {
+EnhancedSimplePaymentsView.edit = ( editor, content ) => {
 	editor.execCommand( 'simplePaymentsButton', content );
 };
 
-export default SimplePaymentsView;
+export default EnhancedSimplePaymentsView;

--- a/client/layout/guided-tours/docs/examples/tours/simple-payments-end-of-year-guide.js
+++ b/client/layout/guided-tours/docs/examples/tours/simple-payments-end-of-year-guide.js
@@ -21,6 +21,8 @@ import {
 	Link,
 } from 'layout/guided-tours/config-elements';
 import { hasSelectedSitePremiumOrBusinessPlan } from '../selectors/has-selected-site-premium-or-business-plan';
+import { isEnabled } from 'config';
+import { localizeUrl } from 'lib/i18n-utils';
 
 export const SimplePaymentsEndOfYearGuide = makeTour(
 	<Tour
@@ -67,8 +69,12 @@ export const SimplePaymentsEndOfYearGuide = makeTour(
 						<Next step="add-new-page">{ translate( 'Get started!' ) }</Next>
 						<Quit>{ translate( 'No thanks.' ) }</Quit>
 					</ButtonRow>
-					<Link href="https://wordpress.com/support/pay-with-paypal-button/">
-						{ translate( 'Learn more about Pay with PayPal buttons.' ) }
+					<Link href={ isEnabled( 'earn/pay-with-paypal' ) ?
+						localizeUrl( 'https://wordpress.com/support/pay-with-paypal-button/' ) :
+						localizeUrl( 'https://wordpress.com/support/simple-payments/' ) }>
+						{ isEnabled( 'earn/pay-with-paypal' ) ?
+							translate( 'Learn more about Pay with PayPal.' ) :
+							translate( 'Learn more about Simple Payments.' ) }
 					</Link>
 				</Fragment>
 			) }

--- a/client/layout/guided-tours/docs/examples/tours/simple-payments-end-of-year-guide.js
+++ b/client/layout/guided-tours/docs/examples/tours/simple-payments-end-of-year-guide.js
@@ -67,8 +67,8 @@ export const SimplePaymentsEndOfYearGuide = makeTour(
 						<Next step="add-new-page">{ translate( 'Get started!' ) }</Next>
 						<Quit>{ translate( 'No thanks.' ) }</Quit>
 					</ButtonRow>
-					<Link href="https://wordpress.com/support/simple-payments/">
-						{ translate( 'Learn more about Simple Payments.' ) }
+					<Link href="https://wordpress.com/support/pay-with-paypal-button/">
+						{ translate( 'Learn more about Pay with PayPal buttons.' ) }
 					</Link>
 				</Fragment>
 			) }

--- a/client/layout/guided-tours/docs/examples/tours/simple-payments-end-of-year-guide.js
+++ b/client/layout/guided-tours/docs/examples/tours/simple-payments-end-of-year-guide.js
@@ -69,12 +69,16 @@ export const SimplePaymentsEndOfYearGuide = makeTour(
 						<Next step="add-new-page">{ translate( 'Get started!' ) }</Next>
 						<Quit>{ translate( 'No thanks.' ) }</Quit>
 					</ButtonRow>
-					<Link href={ isEnabled( 'earn/pay-with-paypal' ) ?
-						localizeUrl( 'https://wordpress.com/support/pay-with-paypal-button/' ) :
-						localizeUrl( 'https://wordpress.com/support/simple-payments/' ) }>
-						{ isEnabled( 'earn/pay-with-paypal' ) ?
-							translate( 'Learn more about Pay with PayPal.' ) :
-							translate( 'Learn more about Simple Payments.' ) }
+					<Link
+						href={
+							isEnabled( 'earn/rename-payment-blocks' )
+								? localizeUrl( 'https://wordpress.com/support/pay-with-paypal/' )
+								: localizeUrl( 'https://wordpress.com/support/simple-payments/' )
+						}
+					>
+						{ isEnabled( 'earn/rename-payment-blocks' )
+							? translate( 'Learn more about Pay with PayPal.' )
+							: translate( 'Learn more about Simple Payments.' ) }
 					</Link>
 				</Fragment>
 			) }

--- a/client/layout/guided-tours/tours/simple-payments-email-tour/index.js
+++ b/client/layout/guided-tours/tours/simple-payments-email-tour/index.js
@@ -21,6 +21,8 @@ import {
 import { AddContentButton } from 'layout/guided-tours/button-labels';
 import { getSectionName, hasSidebar } from 'state/ui/selectors';
 import { targetForSlug } from 'layout/guided-tours/positioning';
+import { isEnabled } from 'config';
+import { localizeUrl } from 'lib/i18n-utils';
 
 const sectionHasSidebar = ( state ) =>
 	hasSidebar( state ) && ! includes( [ 'customize' ], getSectionName( state ) );
@@ -141,8 +143,12 @@ export const SimplePaymentsEmailTour = makeTour(
 							{ translate( 'Got it, thanks!' ) }
 						</DelegatingQuit>
 					</ButtonRow>
-					<Link href="https://wordpress.com/support/pay-with-paypal-button/">
-						{ translate( 'Learn more about Pay with PayPal buttons.' ) }
+					<Link href={ isEnabled( 'earn/pay-with-paypal' ) ?
+						localizeUrl( 'https://wordpress.com/support/pay-with-paypal-button/' ) :
+						localizeUrl( 'https://wordpress.com/support/simple-payments/' ) }>
+						{ isEnabled( 'earn/pay-with-paypal' ) ?
+							translate( 'Learn more about Pay with PayPal.' ) :
+							translate( 'Learn more about Simple Payments.' ) }
 					</Link>
 				</Fragment>
 			) }

--- a/client/layout/guided-tours/tours/simple-payments-email-tour/index.js
+++ b/client/layout/guided-tours/tours/simple-payments-email-tour/index.js
@@ -141,8 +141,8 @@ export const SimplePaymentsEmailTour = makeTour(
 							{ translate( 'Got it, thanks!' ) }
 						</DelegatingQuit>
 					</ButtonRow>
-					<Link href="https://wordpress.com/support/simple-payments">
-						{ translate( 'Learn more about Simple Payments.' ) }
+					<Link href="https://wordpress.com/support/pay-with-paypal-button/">
+						{ translate( 'Learn more about Pay with PayPal buttons.' ) }
 					</Link>
 				</Fragment>
 			) }

--- a/client/layout/guided-tours/tours/simple-payments-email-tour/index.js
+++ b/client/layout/guided-tours/tours/simple-payments-email-tour/index.js
@@ -143,12 +143,16 @@ export const SimplePaymentsEmailTour = makeTour(
 							{ translate( 'Got it, thanks!' ) }
 						</DelegatingQuit>
 					</ButtonRow>
-					<Link href={ isEnabled( 'earn/pay-with-paypal' ) ?
-						localizeUrl( 'https://wordpress.com/support/pay-with-paypal-button/' ) :
-						localizeUrl( 'https://wordpress.com/support/simple-payments/' ) }>
-						{ isEnabled( 'earn/pay-with-paypal' ) ?
-							translate( 'Learn more about Pay with PayPal.' ) :
-							translate( 'Learn more about Simple Payments.' ) }
+					<Link
+						href={
+							isEnabled( 'earn/rename-payment-blocks' )
+								? localizeUrl( 'https://wordpress.com/support/pay-with-paypal/' )
+								: localizeUrl( 'https://wordpress.com/support/simple-payments/' )
+						}
+					>
+						{ isEnabled( 'earn/rename-payment-blocks' )
+							? translate( 'Learn more about Pay with PayPal.' )
+							: translate( 'Learn more about Simple Payments.' ) }
 					</Link>
 				</Fragment>
 			) }

--- a/client/layout/guided-tours/tours/simple-payments-tour/index.js
+++ b/client/layout/guided-tours/tours/simple-payments-tour/index.js
@@ -17,6 +17,8 @@ import {
 	Link,
 	Quit,
 } from 'layout/guided-tours/config-elements';
+import { isEnabled } from 'config';
+import { localizeUrl } from 'lib/i18n-utils';
 
 export const SimplePaymentsTour = makeTour(
 	<Tour { ...meta }>
@@ -53,8 +55,12 @@ export const SimplePaymentsTour = makeTour(
 							<span>{ translate( 'Upgrade' ) }</span>
 						</SiteLink>
 					</ButtonRow>
-					<Link href=" https://wordpress.com/support/pay-with-paypal-button/">
-						{ translate( 'Learn more about Pay with PayPal buttons.' ) }
+					<Link href={ isEnabled( 'earn/pay-with-paypal' ) ?
+						localizeUrl( 'https://wordpress.com/support/pay-with-paypal-button/' ) :
+						localizeUrl( 'https://wordpress.com/support/simple-payments/' ) }>
+						{ isEnabled( 'earn/pay-with-paypal' ) ?
+							translate( 'Learn more about Pay with PayPal.' ) :
+							translate( 'Learn more about Simple Payments.' ) }
 					</Link>
 				</Fragment>
 			) }

--- a/client/layout/guided-tours/tours/simple-payments-tour/index.js
+++ b/client/layout/guided-tours/tours/simple-payments-tour/index.js
@@ -53,8 +53,8 @@ export const SimplePaymentsTour = makeTour(
 							<span>{ translate( 'Upgrade' ) }</span>
 						</SiteLink>
 					</ButtonRow>
-					<Link href="https://wordpress.com/support/simple-payments">
-						{ translate( 'Learn more about Simple Payments.' ) }
+					<Link href=" https://wordpress.com/support/pay-with-paypal-button/">
+						{ translate( 'Learn more about Pay with PayPal buttons.' ) }
 					</Link>
 				</Fragment>
 			) }

--- a/client/layout/guided-tours/tours/simple-payments-tour/index.js
+++ b/client/layout/guided-tours/tours/simple-payments-tour/index.js
@@ -55,12 +55,16 @@ export const SimplePaymentsTour = makeTour(
 							<span>{ translate( 'Upgrade' ) }</span>
 						</SiteLink>
 					</ButtonRow>
-					<Link href={ isEnabled( 'earn/pay-with-paypal' ) ?
-						localizeUrl( 'https://wordpress.com/support/pay-with-paypal-button/' ) :
-						localizeUrl( 'https://wordpress.com/support/simple-payments/' ) }>
-						{ isEnabled( 'earn/pay-with-paypal' ) ?
-							translate( 'Learn more about Pay with PayPal.' ) :
-							translate( 'Learn more about Simple Payments.' ) }
+					<Link
+						href={
+							isEnabled( 'earn/rename-payment-blocks' )
+								? localizeUrl( 'https://wordpress.com/support/pay-with-paypal-button/' )
+								: localizeUrl( 'https://wordpress.com/support/simple-payments/' )
+						}
+					>
+						{ isEnabled( 'earn/rename-payment-blocks' )
+							? translate( 'Learn more about Pay with PayPal.' )
+							: translate( 'Learn more about Simple Payments.' ) }
 					</Link>
 				</Fragment>
 			) }

--- a/client/lib/discounts/active-discounts.js
+++ b/client/lib/discounts/active-discounts.js
@@ -11,9 +11,13 @@ import {
 } from 'lib/plans/constants';
 import { isEnabled } from 'config';
 
-const simplePaymentsNoticeText = isEnabled( 'earn/pay-with-paypal' ) ?
-	'Upgrade to a Premium or Business plan today and start collecting payments with Pay with PayPal!' :
-	'Upgrade to a Premium or Business plan today and start collecting payments with Simple Payments!';
+const simplePaymentsNoticeTextWPCOM = isEnabled( 'earn/pay-with-paypal' ) ?
+	'Upgrade to a Premium or Business plan today and start collecting payments with the Pay with PayPal button!' :
+	'Upgrade to a Premium or Business plan today and start collecting payments with the Simple Payments button!';
+
+const simplePaymentsNoticeTextJetpack = isEnabled( 'earn/pay-with-paypal' ) ?
+	'Upgrade to a Premium or Professional plan today and start collecting payments with the Pay with PayPal button!' :
+	'Upgrade to a Premium or Professional plan today and start collecting payments with the Simple Payments button!';
 
 /**
  * No translate() used on some of these since we're launching those promotions just for the EN audience
@@ -23,7 +27,7 @@ export default [
 		name: 'simple_payments_wpcom',
 		startsAt: new Date( 2018, 6, 9, 0, 0, 0 ),
 		endsAt: new Date( 2018, 8, 9, 23, 59, 59 ),
-		plansPageNoticeText: simplePaymentsNoticeText,
+		plansPageNoticeText: simplePaymentsNoticeTextWPCOM,
 		targetPlans: [
 			{ type: TYPE_FREE, group: GROUP_WPCOM },
 			{ type: TYPE_PERSONAL, group: GROUP_WPCOM },
@@ -33,7 +37,7 @@ export default [
 		name: 'simple_payments_jetpack',
 		startsAt: new Date( 2018, 6, 9, 0, 0, 0 ),
 		endsAt: new Date( 2018, 8, 9, 23, 59, 59 ),
-		plansPageNoticeText: simplePaymentsNoticeText,
+		plansPageNoticeText: simplePaymentsNoticeTextJetpack,
 		targetPlans: [
 			{ type: TYPE_FREE, group: GROUP_JETPACK },
 			{ type: TYPE_PERSONAL, group: GROUP_JETPACK },

--- a/client/lib/discounts/active-discounts.js
+++ b/client/lib/discounts/active-discounts.js
@@ -9,6 +9,11 @@ import {
 	TYPE_PERSONAL,
 	TYPE_PREMIUM,
 } from 'lib/plans/constants';
+import { isEnabled } from 'config';
+
+const simplePaymentsNoticeText = isEnabled( 'earn/pay-with-paypal' ) ?
+	'Upgrade to a Premium or Business plan today and start collecting payments with Pay with PayPal!' :
+	'Upgrade to a Premium or Business plan today and start collecting payments with Simple Payments!';
 
 /**
  * No translate() used on some of these since we're launching those promotions just for the EN audience
@@ -18,8 +23,7 @@ export default [
 		name: 'simple_payments_wpcom',
 		startsAt: new Date( 2018, 6, 9, 0, 0, 0 ),
 		endsAt: new Date( 2018, 8, 9, 23, 59, 59 ),
-		plansPageNoticeText:
-			'Upgrade to a Premium or Business plan today and start collecting payments with the Pay with PayPal button!',
+		plansPageNoticeText: simplePaymentsNoticeText,
 		targetPlans: [
 			{ type: TYPE_FREE, group: GROUP_WPCOM },
 			{ type: TYPE_PERSONAL, group: GROUP_WPCOM },
@@ -29,8 +33,7 @@ export default [
 		name: 'simple_payments_jetpack',
 		startsAt: new Date( 2018, 6, 9, 0, 0, 0 ),
 		endsAt: new Date( 2018, 8, 9, 23, 59, 59 ),
-		plansPageNoticeText:
-			'Upgrade to a Premium or Professional plan today and start collecting payments with the Pay with PayPal button!',
+		plansPageNoticeText: simplePaymentsNoticeText,
 		targetPlans: [
 			{ type: TYPE_FREE, group: GROUP_JETPACK },
 			{ type: TYPE_PERSONAL, group: GROUP_JETPACK },

--- a/client/lib/discounts/active-discounts.js
+++ b/client/lib/discounts/active-discounts.js
@@ -19,7 +19,7 @@ export default [
 		startsAt: new Date( 2018, 6, 9, 0, 0, 0 ),
 		endsAt: new Date( 2018, 8, 9, 23, 59, 59 ),
 		plansPageNoticeText:
-			'Upgrade to a Premium or Business plan today and start collecting payments with the Simple Payments button!',
+			'Upgrade to a Premium or Business plan today and start collecting payments with the Pay with PayPal button!',
 		targetPlans: [
 			{ type: TYPE_FREE, group: GROUP_WPCOM },
 			{ type: TYPE_PERSONAL, group: GROUP_WPCOM },
@@ -30,7 +30,7 @@ export default [
 		startsAt: new Date( 2018, 6, 9, 0, 0, 0 ),
 		endsAt: new Date( 2018, 8, 9, 23, 59, 59 ),
 		plansPageNoticeText:
-			'Upgrade to a Premium or Professional plan today and start collecting payments with the Simple Payments button!',
+			'Upgrade to a Premium or Professional plan today and start collecting payments with the Pay with PayPal button!',
 		targetPlans: [
 			{ type: TYPE_FREE, group: GROUP_JETPACK },
 			{ type: TYPE_PERSONAL, group: GROUP_JETPACK },

--- a/client/lib/discounts/active-discounts.js
+++ b/client/lib/discounts/active-discounts.js
@@ -11,13 +11,13 @@ import {
 } from 'lib/plans/constants';
 import { isEnabled } from 'config';
 
-const simplePaymentsNoticeTextWPCOM = isEnabled( 'earn/pay-with-paypal' ) ?
-	'Upgrade to a Premium or Business plan today and start collecting payments with the Pay with PayPal button!' :
-	'Upgrade to a Premium or Business plan today and start collecting payments with the Simple Payments button!';
+const simplePaymentsNoticeTextWPCOM = isEnabled( 'earn/rename-payment-blocks' )
+	? 'Upgrade to a Premium or Business plan today and start collecting payments with the Pay with PayPal button!'
+	: 'Upgrade to a Premium or Business plan today and start collecting payments with the Simple Payments button!';
 
-const simplePaymentsNoticeTextJetpack = isEnabled( 'earn/pay-with-paypal' ) ?
-	'Upgrade to a Premium or Professional plan today and start collecting payments with the Pay with PayPal button!' :
-	'Upgrade to a Premium or Professional plan today and start collecting payments with the Simple Payments button!';
+const simplePaymentsNoticeTextJetpack = isEnabled( 'earn/rename-payment-blocks' )
+	? 'Upgrade to a Premium or Professional plan today and start collecting payments with the Pay with PayPal button!'
+	: 'Upgrade to a Premium or Professional plan today and start collecting payments with the Simple Payments button!';
 
 /**
  * No translate() used on some of these since we're launching those promotions just for the EN audience

--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -478,7 +478,7 @@ export const FEATURES_LIST = {
 	},
 	[ constants.FEATURE_SIMPLE_PAYMENTS ]: {
 		getSlug: () => constants.FEATURE_SIMPLE_PAYMENTS,
-		getTitle: () => i18n.translate( 'Pay with PayPal Button' ),
+		getTitle: () => i18n.translate( 'Pay with PayPal' ),
 		getDescription: () => i18n.translate( 'Sell anything with a simple PayPal button.' ),
 	},
 	[ constants.FEATURE_NO_BRANDING ]: {

--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -105,7 +105,7 @@ export const FEATURES_LIST = {
 		getTitle: () => i18n.translate( 'All Premium features' ),
 		getDescription: () =>
 			i18n.translate(
-				'Including unlimited premium themes, advanced design and monetization options, simple payment buttons, and a custom domain name for one year.'
+				'Including unlimited premium themes, advanced design and monetization options, Pay with PayPal buttons, and a custom domain name for one year.'
 			),
 	},
 
@@ -478,7 +478,7 @@ export const FEATURES_LIST = {
 	},
 	[ constants.FEATURE_SIMPLE_PAYMENTS ]: {
 		getSlug: () => constants.FEATURE_SIMPLE_PAYMENTS,
-		getTitle: () => i18n.translate( 'Simple Payments' ),
+		getTitle: () => i18n.translate( 'Pay with PayPal Button' ),
 		getDescription: () => i18n.translate( 'Sell anything with a simple PayPal button.' ),
 	},
 	[ constants.FEATURE_NO_BRANDING ]: {

--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -104,13 +104,13 @@ export const FEATURES_LIST = {
 		getSlug: () => constants.FEATURE_ALL_PREMIUM_FEATURES,
 		getTitle: () => i18n.translate( 'All Premium features' ),
 		getDescription: () => {
-			isEnabled( 'earn/pay-with-paypal' ) ?
-				i18n.translate(
-					'Including unlimited premium themes, advanced design and monetization options, Pay with PayPal buttons, and a custom domain name for one year.'
-				) :
-				i18n.translate(
-					'Including unlimited premium themes, advanced design and monetization options, simple payment buttons, and a custom domain name for one year.'
-				)
+			isEnabled( 'earn/rename-payment-blocks' )
+				? i18n.translate(
+						'Including unlimited premium themes, advanced design and monetization options, Pay with PayPal buttons, and a custom domain name for one year.'
+				  )
+				: i18n.translate(
+						'Including unlimited premium themes, advanced design and monetization options, simple payment buttons, and a custom domain name for one year.'
+				  );
 		},
 	},
 
@@ -484,9 +484,9 @@ export const FEATURES_LIST = {
 	[ constants.FEATURE_SIMPLE_PAYMENTS ]: {
 		getSlug: () => constants.FEATURE_SIMPLE_PAYMENTS,
 		getTitle: () => {
-			isEnabled( 'earn/pay-with-paypal' ) ?
-				i18n.translate( 'Pay with PayPal' ) :
-				i18n.translate( 'Simple Payments' )
+			isEnabled( 'earn/rename-payment-blocks' )
+				? i18n.translate( 'Pay with PayPal' )
+				: i18n.translate( 'Simple Payments' );
 		},
 		getDescription: () => i18n.translate( 'Sell anything with a simple PayPal button.' ),
 	},

--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -483,11 +483,10 @@ export const FEATURES_LIST = {
 	},
 	[ constants.FEATURE_SIMPLE_PAYMENTS ]: {
 		getSlug: () => constants.FEATURE_SIMPLE_PAYMENTS,
-		getTitle: () => {
+		getTitle: () =>
 			isEnabled( 'earn/rename-payment-blocks' )
 				? i18n.translate( 'Pay with PayPal' )
-				: i18n.translate( 'Simple Payments' );
-		},
+				: i18n.translate( 'Simple Payments' ),
 		getDescription: () => i18n.translate( 'Sell anything with a simple PayPal button.' ),
 	},
 	[ constants.FEATURE_NO_BRANDING ]: {

--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -103,10 +103,15 @@ export const FEATURES_LIST = {
 	[ constants.FEATURE_ALL_PREMIUM_FEATURES ]: {
 		getSlug: () => constants.FEATURE_ALL_PREMIUM_FEATURES,
 		getTitle: () => i18n.translate( 'All Premium features' ),
-		getDescription: () =>
-			i18n.translate(
-				'Including unlimited premium themes, advanced design and monetization options, Pay with PayPal buttons, and a custom domain name for one year.'
-			),
+		getDescription: () => {
+			isEnabled( 'earn/pay-with-paypal' ) ?
+				i18n.translate(
+					'Including unlimited premium themes, advanced design and monetization options, Pay with PayPal buttons, and a custom domain name for one year.'
+				) :
+				i18n.translate(
+					'Including unlimited premium themes, advanced design and monetization options, simple payment buttons, and a custom domain name for one year.'
+				)
+		},
 	},
 
 	[ constants.FEATURE_ADVANCED_CUSTOMIZATION ]: {
@@ -478,7 +483,11 @@ export const FEATURES_LIST = {
 	},
 	[ constants.FEATURE_SIMPLE_PAYMENTS ]: {
 		getSlug: () => constants.FEATURE_SIMPLE_PAYMENTS,
-		getTitle: () => i18n.translate( 'Pay with PayPal' ),
+		getTitle: () => {
+			isEnabled( 'earn/pay-with-paypal' ) ?
+				i18n.translate( 'Pay with PayPal' ) :
+				i18n.translate( 'Simple Payments' )
+		},
 		getDescription: () => i18n.translate( 'Sell anything with a simple PayPal button.' ),
 	},
 	[ constants.FEATURE_NO_BRANDING ]: {

--- a/client/lib/simple-payments/constants.js
+++ b/client/lib/simple-payments/constants.js
@@ -5,7 +5,7 @@ export const NUMBER_OF_POSTS_BY_REQUEST = 100;
 export const DEFAULT_CURRENCY = 'USD';
 
 // https://developer.paypal.com/docs/integration/direct/rest/currency-codes/
-// If this list changes, Simple Payments in Jetpack must be updated as well.
+// If this list changes, Pay with PayPal Button in Jetpack must be updated as well.
 // See https://github.com/Automattic/jetpack/blob/master/modules/simple-payments/simple-payments.php
 
 /**

--- a/client/lib/simple-payments/constants.js
+++ b/client/lib/simple-payments/constants.js
@@ -5,7 +5,7 @@ export const NUMBER_OF_POSTS_BY_REQUEST = 100;
 export const DEFAULT_CURRENCY = 'USD';
 
 // https://developer.paypal.com/docs/integration/direct/rest/currency-codes/
-// If this list changes, Pay with PayPal Button in Jetpack must be updated as well.
+// If this list changes, Pay with PayPal in Jetpack must be updated as well.
 // See https://github.com/Automattic/jetpack/blob/master/modules/simple-payments/simple-payments.php
 
 /**

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
@@ -189,7 +189,7 @@ function getPlanFeatures( plan, translate, hasDomainsInCart, hasRenewalInCart ) 
 		return [
 			showFreeDomainFeature && translate( 'Free domain for one year' ),
 			translate( 'Unlimited access to our library of Premium Themes' ),
-			translate( 'Subscriber-only content and simple payment buttons' ),
+			translate( 'Subscriber-only content and Pay with PayPal buttons' ),
 			translate( 'Track your stats with Google Analytics' ),
 		];
 	} else if (

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
@@ -33,6 +33,7 @@ import isPresalesChatAvailable from 'state/happychat/selectors/is-presales-chat-
 import isHappychatAvailable from 'state/happychat/selectors/is-happychat-available';
 import QuerySupportTypes from 'blocks/inline-help/inline-help-query-support-types';
 import isSupportVariationDetermined from 'state/selectors/is-support-variation-determined';
+import { isEnabled } from 'config';
 
 export default function WPCheckoutOrderSummary() {
 	const translate = useTranslate();
@@ -189,7 +190,9 @@ function getPlanFeatures( plan, translate, hasDomainsInCart, hasRenewalInCart ) 
 		return [
 			showFreeDomainFeature && translate( 'Free domain for one year' ),
 			translate( 'Unlimited access to our library of Premium Themes' ),
-			translate( 'Subscriber-only content and payment buttons' ),
+			isEnabled( 'earn/pay-with-paypal' )
+				? translate( 'Subscriber-only content and Pay with PayPal buttons' )
+				: translate( 'Subscriber-only content and payment buttons' ),
 			translate( 'Track your stats with Google Analytics' ),
 		];
 	} else if (

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
@@ -189,7 +189,7 @@ function getPlanFeatures( plan, translate, hasDomainsInCart, hasRenewalInCart ) 
 		return [
 			showFreeDomainFeature && translate( 'Free domain for one year' ),
 			translate( 'Unlimited access to our library of Premium Themes' ),
-			translate( 'Subscriber-only content and Pay with PayPal buttons' ),
+			translate( 'Subscriber-only content and payment buttons' ),
 			translate( 'Track your stats with Google Analytics' ),
 		];
 	} else if (

--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -97,8 +97,11 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 	 * @returns {object} Object with props to render a PromoCard.
 	 */
 	const getSimplePaymentsCard = () => {
-		const supportLink =
-			'https://wordpress.com/support/wordpress-editor/blocks/simple-payments-block/';
+		const supportLink = isEnabled( 'earn/rename-payment-blocks' )
+			? localizeUrl( 'https://wordpress.com/support/wordpress-editor/blocks/pay-with-paypal/' )
+			: localizeUrl(
+					'https://wordpress.com/support/wordpress-editor/blocks/simple-payments-block/'
+			  );
 		const cta = hasSimplePayments
 			? {
 					text: translate( 'Add one-time payments' ),
@@ -116,9 +119,24 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 		const learnMoreLink = hasSimplePayments
 			? null
 			: { url: supportLink, onClick: () => trackLearnLink( 'simple-payments' ) };
-		return {
-			title: translate( 'Collect one-time payments' ),
-			body: hasSimplePayments
+		let title, body;
+		if ( isEnabled( 'earn/rename-payment-blocks' ) ) {
+			title = translate( 'Collect PayPal payments' );
+			body = hasSimplePayments
+				? translate(
+						'Accept credit card payments via PayPal for physical products, digital goods, services, donations, or support of your creative work.'
+				  )
+				: translate(
+						'Accept credit card payments via PayPal for physical products, digital goods, services, donations, or support of your creative work. {{em}}Available with a Premium, Business, or eCommerce plan{{/em}}.',
+						{
+							components: {
+								em: <em />,
+							},
+						}
+				  );
+		} else {
+			title = translate( 'Collect one-time payments' );
+			body = hasSimplePayments
 				? translate(
 						'Accept credit card payments for physical products, digital goods, services, donations, or support of your creative work.'
 				  )
@@ -129,7 +147,11 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 								em: <em />,
 							},
 						}
-				  ),
+				  );
+		}
+		return {
+			title,
+			body,
 			image: {
 				path: simplePaymentsImage,
 			},

--- a/client/my-sites/feature-upsell/ads-upsell.jsx
+++ b/client/my-sites/feature-upsell/ads-upsell.jsx
@@ -194,7 +194,7 @@ class WordAdsUpsellComponent extends Component {
 					<div className="feature-upsell__features-list-item">
 						<Feature
 							icon={ <Gridicon icon="money" size={ 48 } /> }
-							title={ 'Pay with PayPal button' }
+							title={ 'Pay with PayPal' }
 							description={
 								'Accept credit card payments on your site with the click of a button! Sell products, take donations, ' +
 								'sell tickets - add payment buttons to any page right from the WordPress editor'

--- a/client/my-sites/feature-upsell/ads-upsell.jsx
+++ b/client/my-sites/feature-upsell/ads-upsell.jsx
@@ -31,6 +31,7 @@ import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
 import { isRequestingActivePromotions } from 'state/active-promotions/selectors';
 import { getUpsellPlanPrice, redirectUnlessCanUpgradeSite } from './utils';
 import redirectIf from './redirect-if';
+import { isEnabled } from 'config';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
@@ -194,7 +195,7 @@ class WordAdsUpsellComponent extends Component {
 					<div className="feature-upsell__features-list-item">
 						<Feature
 							icon={ <Gridicon icon="money" size={ 48 } /> }
-							title={ 'Pay with PayPal' }
+							title={ isEnabled( 'earn/pay-with-paypal' ) ? 'Pay with PayPal' : 'Simple Payments' }
 							description={
 								'Accept credit card payments on your site with the click of a button! Sell products, take donations, ' +
 								'sell tickets - add payment buttons to any page right from the WordPress editor'

--- a/client/my-sites/feature-upsell/ads-upsell.jsx
+++ b/client/my-sites/feature-upsell/ads-upsell.jsx
@@ -194,7 +194,7 @@ class WordAdsUpsellComponent extends Component {
 					<div className="feature-upsell__features-list-item">
 						<Feature
 							icon={ <Gridicon icon="money" size={ 48 } /> }
-							title={ 'Simple Payments' }
+							title={ 'Pay with PayPal button' }
 							description={
 								'Accept credit card payments on your site with the click of a button! Sell products, take donations, ' +
 								'sell tickets - add payment buttons to any page right from the WordPress editor'

--- a/client/my-sites/feature-upsell/ads-upsell.jsx
+++ b/client/my-sites/feature-upsell/ads-upsell.jsx
@@ -195,7 +195,9 @@ class WordAdsUpsellComponent extends Component {
 					<div className="feature-upsell__features-list-item">
 						<Feature
 							icon={ <Gridicon icon="money" size={ 48 } /> }
-							title={ isEnabled( 'earn/pay-with-paypal' ) ? 'Pay with PayPal' : 'Simple Payments' }
+							title={
+								isEnabled( 'earn/rename-payment-blocks' ) ? 'Pay with PayPal' : 'Simple Payments'
+							}
 							description={
 								'Accept credit card payments on your site with the click of a button! Sell products, take donations, ' +
 								'sell tickets - add payment buttons to any page right from the WordPress editor'

--- a/client/my-sites/feature-upsell/features.jsx
+++ b/client/my-sites/feature-upsell/features.jsx
@@ -150,7 +150,7 @@ class FeaturesComponent extends Component {
 				<div className="product-purchase-features-list__item">
 					<PurchaseDetail
 						icon={ <img alt="" src={ wordAdsImage } /> }
-						title={ 'Pay with PayPal button' }
+						title={ 'Pay with PayPal' }
 						description={
 							'Accept credit card payments on your site with the click of a button! Sell products, take donations, ' +
 							'sell tickets - add payment buttons to any page right from the WordPress editor'

--- a/client/my-sites/feature-upsell/features.jsx
+++ b/client/my-sites/feature-upsell/features.jsx
@@ -18,6 +18,7 @@ import { getSiteSlug } from 'state/sites/selectors';
 import { getCurrentPlan } from 'state/sites/plans/selectors';
 import DocumentHead from 'components/data/document-head';
 import TipInfo from '../../components/purchase-detail/tip-info';
+import { isEnabled } from 'config';
 
 /**
  * Image dependencies
@@ -150,7 +151,7 @@ class FeaturesComponent extends Component {
 				<div className="product-purchase-features-list__item">
 					<PurchaseDetail
 						icon={ <img alt="" src={ wordAdsImage } /> }
-						title={ 'Pay with PayPal' }
+						title={ isEnabled( 'earn/pay-with-paypal' ) ? 'Pay with PayPal' : 'Simple Payments' }
 						description={
 							'Accept credit card payments on your site with the click of a button! Sell products, take donations, ' +
 							'sell tickets - add payment buttons to any page right from the WordPress editor'

--- a/client/my-sites/feature-upsell/features.jsx
+++ b/client/my-sites/feature-upsell/features.jsx
@@ -150,7 +150,7 @@ class FeaturesComponent extends Component {
 				<div className="product-purchase-features-list__item">
 					<PurchaseDetail
 						icon={ <img alt="" src={ wordAdsImage } /> }
-						title={ 'Simple payments' }
+						title={ 'Pay with PayPal button' }
 						description={
 							'Accept credit card payments on your site with the click of a button! Sell products, take donations, ' +
 							'sell tickets - add payment buttons to any page right from the WordPress editor'

--- a/client/my-sites/feature-upsell/features.jsx
+++ b/client/my-sites/feature-upsell/features.jsx
@@ -151,7 +151,9 @@ class FeaturesComponent extends Component {
 				<div className="product-purchase-features-list__item">
 					<PurchaseDetail
 						icon={ <img alt="" src={ wordAdsImage } /> }
-						title={ isEnabled( 'earn/pay-with-paypal' ) ? 'Pay with PayPal' : 'Simple Payments' }
+						title={
+							isEnabled( 'earn/rename-payment-blocks' ) ? 'Pay with PayPal' : 'Simple Payments'
+						}
 						description={
 							'Accept credit card payments on your site with the click of a button! Sell products, take donations, ' +
 							'sell tickets - add payment buttons to any page right from the WordPress editor'

--- a/client/my-sites/feature-upsell/plugins-upsell.jsx
+++ b/client/my-sites/feature-upsell/plugins-upsell.jsx
@@ -29,6 +29,7 @@ import RefundAsterisk from 'my-sites/feature-upsell/refund-asterisk';
 import { getUpsellPlanPrice, redirectUnlessCanUpgradeSite } from './utils';
 import { hasFeature } from 'state/sites/plans/selectors';
 import redirectIf from './redirect-if';
+import { isEnabled } from 'config';
 
 /*
  * This is just for english audience and is not translated on purpose, remember to add
@@ -72,6 +73,7 @@ class PluginsUpsellComponent extends Component {
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	render() {
 		const { price } = this.props;
+		const simplePaymentsName = isEnabled( 'earn/pay-with-paypal' ) ? 'Pay with PayPal' : 'Simple Payments';
 		return (
 			<div role="main" className="main is-wide-layout feature-upsell__main is-plugins">
 				{ ! price && (
@@ -146,10 +148,10 @@ class PluginsUpsellComponent extends Component {
 					<div className="feature-upsell__features-list-item">
 						<Feature
 							icon={ <Gridicon icon="money" size={ 48 } /> }
-							title="Easily Accept Credit Card Payments with a Pay with PayPal button"
+							title={ 'Easily Accept Credit Card Payments with ' + simplePaymentsName }
 							description={
 								<span>
-									The <i>Pay with PayPal</i> button lets you accept credit card payments right on
+									The <i>{ simplePaymentsName }</i> button lets you accept credit card payments right on
 									your site. Whether you’re selling products or services, collecting membership
 									fees, or receiving donations, you’ll have a secure checkout process that you can
 									turn on with the click of a button.

--- a/client/my-sites/feature-upsell/plugins-upsell.jsx
+++ b/client/my-sites/feature-upsell/plugins-upsell.jsx
@@ -146,10 +146,10 @@ class PluginsUpsellComponent extends Component {
 					<div className="feature-upsell__features-list-item">
 						<Feature
 							icon={ <Gridicon icon="money" size={ 48 } /> }
-							title="Easily Accept Credit Card Payments with Simple Payments"
+							title="Easily Accept Credit Card Payments with a Pay with PayPal button"
 							description={
 								<span>
-									The <i>Simple Payments</i> feature lets you accept credit card payments right on
+									The <i>Pay with PayPal</i> button lets you accept credit card payments right on
 									your site. Whether you’re selling products or services, collecting membership
 									fees, or receiving donations, you’ll have a secure checkout process that you can
 									turn on with the click of a button.

--- a/client/my-sites/feature-upsell/plugins-upsell.jsx
+++ b/client/my-sites/feature-upsell/plugins-upsell.jsx
@@ -73,7 +73,9 @@ class PluginsUpsellComponent extends Component {
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	render() {
 		const { price } = this.props;
-		const simplePaymentsName = isEnabled( 'earn/pay-with-paypal' ) ? 'Pay with PayPal' : 'Simple Payments';
+		const simplePaymentsName = isEnabled( 'earn/rename-payment-blocks' )
+			? 'Pay with PayPal'
+			: 'Simple Payments';
 		return (
 			<div role="main" className="main is-wide-layout feature-upsell__main is-plugins">
 				{ ! price && (
@@ -151,8 +153,8 @@ class PluginsUpsellComponent extends Component {
 							title={ 'Easily Accept Credit Card Payments with ' + simplePaymentsName }
 							description={
 								<span>
-									The <i>{ simplePaymentsName }</i> button lets you accept credit card payments right on
-									your site. Whether you’re selling products or services, collecting membership
+									The <i>{ simplePaymentsName }</i> button lets you accept credit card payments
+									right on your site. Whether you’re selling products or services, collecting fees,
 									fees, or receiving donations, you’ll have a secure checkout process that you can
 									turn on with the click of a button.
 								</span>

--- a/client/my-sites/feature-upsell/themes-upsell.jsx
+++ b/client/my-sites/feature-upsell/themes-upsell.jsx
@@ -149,7 +149,7 @@ class ThemesUpsellComponent extends Component {
 							title="Easily Accept Credit Card Payments with a Pay with PayPal button"
 							description={
 								<span>
-									The <i>Pay with PayPall</i> button lets you accept credit card payments right on
+									The <i>Pay with PayPal</i> button lets you accept credit card payments right on
 									your site. Whether you’re selling products or services, collecting membership
 									fees, or receiving donations, you’ll have a secure checkout process that you can
 									turn on with the click of a button.

--- a/client/my-sites/feature-upsell/themes-upsell.jsx
+++ b/client/my-sites/feature-upsell/themes-upsell.jsx
@@ -29,6 +29,7 @@ import RefundAsterisk from 'my-sites/feature-upsell/refund-asterisk';
 import { getUpsellPlanPrice, redirectUnlessCanUpgradeSite } from './utils';
 import { hasFeature } from 'state/sites/plans/selectors';
 import redirectIf from './redirect-if';
+import { isEnabled } from 'config';
 
 /*
  * This is just for english audience and is not translated on purpose, remember to add
@@ -72,6 +73,7 @@ class ThemesUpsellComponent extends Component {
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	render() {
 		const { price } = this.props;
+		const simplePaymentsName = isEnabled( 'earn/pay-with-paypal' ) ? 'Simple Payments' : 'Pay with PayPal';
 		return (
 			<div role="main" className="main is-wide-layout feature-upsell__main is-themes">
 				{ ! price && (
@@ -146,10 +148,10 @@ class ThemesUpsellComponent extends Component {
 					<div className="feature-upsell__features-list-item">
 						<Feature
 							icon={ <Gridicon icon="money" size={ 48 } /> }
-							title="Easily Accept Credit Card Payments with a Pay with PayPal button"
+							title={ 'Easily Accept Credit Card Payments with a ' + simplePaymentsName + ' button' }
 							description={
 								<span>
-									The <i>Pay with PayPal</i> button lets you accept credit card payments right on
+									The <i>{ simplePaymentsName }</i> button lets you accept credit card payments right on
 									your site. Whether you’re selling products or services, collecting membership
 									fees, or receiving donations, you’ll have a secure checkout process that you can
 									turn on with the click of a button.

--- a/client/my-sites/feature-upsell/themes-upsell.jsx
+++ b/client/my-sites/feature-upsell/themes-upsell.jsx
@@ -73,7 +73,7 @@ class ThemesUpsellComponent extends Component {
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	render() {
 		const { price } = this.props;
-		const simplePaymentsName = isEnabled( 'earn/pay-with-paypal' ) ? 'Simple Payments' : 'Pay with PayPal';
+		const simplePaymentsName = isEnabled( 'earn/pay-with-paypal' ) ? 'Pay with PayPal' : 'Simple Payments';
 		return (
 			<div role="main" className="main is-wide-layout feature-upsell__main is-themes">
 				{ ! price && (
@@ -148,7 +148,7 @@ class ThemesUpsellComponent extends Component {
 					<div className="feature-upsell__features-list-item">
 						<Feature
 							icon={ <Gridicon icon="money" size={ 48 } /> }
-							title={ 'Easily Accept Credit Card Payments with a ' + simplePaymentsName + ' button' }
+							title={ 'Easily Accept Credit Card Payments with ' + simplePaymentsName }
 							description={
 								<span>
 									The <i>{ simplePaymentsName }</i> button lets you accept credit card payments right on

--- a/client/my-sites/feature-upsell/themes-upsell.jsx
+++ b/client/my-sites/feature-upsell/themes-upsell.jsx
@@ -146,10 +146,10 @@ class ThemesUpsellComponent extends Component {
 					<div className="feature-upsell__features-list-item">
 						<Feature
 							icon={ <Gridicon icon="money" size={ 48 } /> }
-							title="Easily Accept Credit Card Payments with Simple Payments"
+							title="Easily Accept Credit Card Payments with a Pay with PayPal button"
 							description={
 								<span>
-									The <i>Simple Payments</i> feature lets you accept credit card payments right on
+									The <i>Pay with PayPall</i> button lets you accept credit card payments right on
 									your site. Whether you’re selling products or services, collecting membership
 									fees, or receiving donations, you’ll have a secure checkout process that you can
 									turn on with the click of a button.

--- a/client/my-sites/feature-upsell/themes-upsell.jsx
+++ b/client/my-sites/feature-upsell/themes-upsell.jsx
@@ -73,7 +73,9 @@ class ThemesUpsellComponent extends Component {
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	render() {
 		const { price } = this.props;
-		const simplePaymentsName = isEnabled( 'earn/pay-with-paypal' ) ? 'Pay with PayPal' : 'Simple Payments';
+		const simplePaymentsName = isEnabled( 'earn/rename-payment-blocks' )
+			? 'Pay with PayPal'
+			: 'Simple Payments';
 		return (
 			<div role="main" className="main is-wide-layout feature-upsell__main is-themes">
 				{ ! price && (
@@ -151,7 +153,7 @@ class ThemesUpsellComponent extends Component {
 							title={ 'Easily Accept Credit Card Payments with ' + simplePaymentsName }
 							description={
 								<span>
-									The <i>{ simplePaymentsName }</i> button lets you accept credit card payments right on
+									The <i>{ simplePaymentsName }</i> button lets you accept credit card payments your
 									your site. Whether you’re selling products or services, collecting membership
 									fees, or receiving donations, you’ll have a secure checkout process that you can
 									turn on with the click of a button.

--- a/client/state/data-layer/wpcom/sites/simple-payments/index.js
+++ b/client/state/data-layer/wpcom/sites/simple-payments/index.js
@@ -32,6 +32,7 @@ import {
 } from 'state/simple-payments/product-list/actions';
 
 import { registerHandlers } from 'state/data-layer/handler-registry';
+import { isEnabled } from 'config';
 
 /**
  * Convert custom post metadata array to product attributes
@@ -69,7 +70,8 @@ function customPostMetadataToProductAttributes( metadata ) {
  */
 export function customPostToProduct( customPost ) {
 	if ( ! isValidSimplePaymentsProduct( customPost ) ) {
-		throw new TransformerError( 'Custom post is not a valid Pay with PayPal button product', customPost );
+		const simplePaymentsName = isEnabled( 'earn/pay-with-paypal' ) ? 'Pay with PayPal' : 'Simple Payments';
+		throw new TransformerError( 'Custom post is not a valid ' + simplePaymentsName + ' product', customPost );
 	}
 
 	const metadataAttributes = customPostMetadataToProductAttributes( customPost.metadata );

--- a/client/state/data-layer/wpcom/sites/simple-payments/index.js
+++ b/client/state/data-layer/wpcom/sites/simple-payments/index.js
@@ -69,7 +69,7 @@ function customPostMetadataToProductAttributes( metadata ) {
  */
 export function customPostToProduct( customPost ) {
 	if ( ! isValidSimplePaymentsProduct( customPost ) ) {
-		throw new TransformerError( 'Custom post is not a valid simple payment product', customPost );
+		throw new TransformerError( 'Custom post is not a valid Pay with PayPal button product', customPost );
 	}
 
 	const metadataAttributes = customPostMetadataToProductAttributes( customPost.metadata );

--- a/client/state/data-layer/wpcom/sites/simple-payments/index.js
+++ b/client/state/data-layer/wpcom/sites/simple-payments/index.js
@@ -70,8 +70,13 @@ function customPostMetadataToProductAttributes( metadata ) {
  */
 export function customPostToProduct( customPost ) {
 	if ( ! isValidSimplePaymentsProduct( customPost ) ) {
-		const simplePaymentsName = isEnabled( 'earn/pay-with-paypal' ) ? 'Pay with PayPal' : 'Simple Payments';
-		throw new TransformerError( 'Custom post is not a valid ' + simplePaymentsName + ' product', customPost );
+		const simplePaymentsName = isEnabled( 'earn/rename-payment-blocks' )
+			? 'Pay with PayPal'
+			: 'Simple Payments';
+		throw new TransformerError(
+			'Custom post is not a valid ' + simplePaymentsName + ' product',
+			customPost
+		);
 	}
 
 	const metadataAttributes = customPostMetadataToProductAttributes( customPost.metadata );

--- a/client/state/selectors/test/get-simple-payments.js
+++ b/client/state/selectors/test/get-simple-payments.js
@@ -41,7 +41,7 @@ describe( 'getSimplePayments()', () => {
 		expect( simplePayments ).to.eql( null );
 	} );
 
-	test( "should return null if siteId can't be found in Simple Payments", () => {
+	test( "should return null if siteId can't be found in Pay with PayPal Button", () => {
 		const state = {
 			simplePayments: {
 				productList: {
@@ -57,7 +57,7 @@ describe( 'getSimplePayments()', () => {
 		expect( simplePayments ).to.eql( null );
 	} );
 
-	test( 'should return empty array if there are no simple payments', () => {
+	test( 'should return empty array if there are no Pay with PayPal Button', () => {
 		const state = {
 			simplePayments: {
 				productList: {
@@ -73,7 +73,7 @@ describe( 'getSimplePayments()', () => {
 		expect( simplePayments ).to.eql( [] );
 	} );
 
-	test( 'should return all Simple Payments for a given siteId ordered by ID DESC', () => {
+	test( 'should return all Pay with PayPal Button for a given siteId ordered by ID DESC', () => {
 		const simplePaymentsInState = [ simplePayment2, simplePayment3, simplePayment1 ];
 
 		const state = {

--- a/client/state/selectors/test/get-simple-payments.js
+++ b/client/state/selectors/test/get-simple-payments.js
@@ -41,7 +41,7 @@ describe( 'getSimplePayments()', () => {
 		expect( simplePayments ).to.eql( null );
 	} );
 
-	test( "should return null if siteId can't be found in Pay with PayPal Button", () => {
+	test( "should return null if siteId can't be found in Pay with PayPal", () => {
 		const state = {
 			simplePayments: {
 				productList: {
@@ -57,7 +57,7 @@ describe( 'getSimplePayments()', () => {
 		expect( simplePayments ).to.eql( null );
 	} );
 
-	test( 'should return empty array if there are no Pay with PayPal Button', () => {
+	test( 'should return empty array if there are no Pay with PayPal buttons', () => {
 		const state = {
 			simplePayments: {
 				productList: {
@@ -73,7 +73,7 @@ describe( 'getSimplePayments()', () => {
 		expect( simplePayments ).to.eql( [] );
 	} );
 
-	test( 'should return all Pay with PayPal Button for a given siteId ordered by ID DESC', () => {
+	test( 'should return all Pay with PayPal buttons for a given siteId ordered by ID DESC', () => {
 		const simplePaymentsInState = [ simplePayment2, simplePayment3, simplePayment1 ];
 
 		const state = {

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -226,7 +226,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 				prefix = 'jetpack-';
 				blockClass = 'contact-form';
 				break;
-			case 'Pay with PayPal Button':
+			case 'Pay with PayPal':
 				prefix = 'jetpack-';
 				blockClass = 'simple-payments';
 				break;

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -226,7 +226,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 				prefix = 'jetpack-';
 				blockClass = 'contact-form';
 				break;
-			case 'Simple Payments':
+			case 'Pay with PayPal Button':
 				prefix = 'jetpack-';
 				blockClass = 'simple-payments';
 				break;

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -226,6 +226,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 				prefix = 'jetpack-';
 				blockClass = 'contact-form';
 				break;
+			case 'Simple Payments':
 			case 'Pay with PayPal':
 				prefix = 'jetpack-';
 				blockClass = 'simple-payments';

--- a/test/e2e/specs/wp-calypso-gutenberg-page-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-page-editor-spec.js
@@ -540,7 +540,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 		step( 'Can insert the payment button', async function () {
 			const pageTitle = 'Payment Button Page: ' + dataHelper.randomPhrase();
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
-			const blockId = await gEditorComponent.addBlock( 'Pay with PayPal Button' );
+			const blockId = await gEditorComponent.addBlock( 'Pay with PayPal' );
 
 			const gPaymentComponent = await SimplePaymentsBlockComponent.Expect( driver, blockId );
 			await gPaymentComponent.insertPaymentButtonDetails( paymentButtonDetails );

--- a/test/e2e/specs/wp-calypso-gutenberg-page-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-page-editor-spec.js
@@ -540,7 +540,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 		step( 'Can insert the payment button', async function () {
 			const pageTitle = 'Payment Button Page: ' + dataHelper.randomPhrase();
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
-			const blockId = await gEditorComponent.addBlock( 'Simple Payments' );
+			const blockId = await gEditorComponent.addBlock( 'Pay with PayPal Button' );
 
 			const gPaymentComponent = await SimplePaymentsBlockComponent.Expect( driver, blockId );
 			await gPaymentComponent.insertPaymentButtonDetails( paymentButtonDetails );

--- a/test/e2e/specs/wp-calypso-gutenberg-page-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-page-editor-spec.js
@@ -540,7 +540,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 		step( 'Can insert the payment button', async function () {
 			const pageTitle = 'Payment Button Page: ' + dataHelper.randomPhrase();
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
-			const blockId = await gEditorComponent.addBlock( 'Pay with PayPal' );
+			const blockId = await gEditorComponent.addBlock( 'Simple Payments' );
 
 			const gPaymentComponent = await SimplePaymentsBlockComponent.Expect( driver, blockId );
 			await gPaymentComponent.insertPaymentButtonDetails( paymentButtonDetails );

--- a/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -1026,7 +1026,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		step( 'Can insert the payment button', async function () {
 			const blogPostTitle = 'Payment Button: ' + dataHelper.randomPhrase();
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
-			const blockId = await gEditorComponent.addBlock( 'Pay with PayPal Button' );
+			const blockId = await gEditorComponent.addBlock( 'Pay with PayPal' );
 
 			const gPaymentComponent = await SimplePaymentsBlockComponent.Expect( driver, blockId );
 			await gPaymentComponent.insertPaymentButtonDetails( paymentButtonDetails );

--- a/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -1026,7 +1026,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		step( 'Can insert the payment button', async function () {
 			const blogPostTitle = 'Payment Button: ' + dataHelper.randomPhrase();
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
-			const blockId = await gEditorComponent.addBlock( 'Simple Payments' );
+			const blockId = await gEditorComponent.addBlock( 'Pay with PayPal Button' );
 
 			const gPaymentComponent = await SimplePaymentsBlockComponent.Expect( driver, blockId );
 			await gPaymentComponent.insertPaymentButtonDetails( paymentButtonDetails );

--- a/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -1026,7 +1026,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		step( 'Can insert the payment button', async function () {
 			const blogPostTitle = 'Payment Button: ' + dataHelper.randomPhrase();
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
-			const blockId = await gEditorComponent.addBlock( 'Pay with PayPal' );
+			const blockId = await gEditorComponent.addBlock( 'Simple Payments' );
 
 			const gPaymentComponent = await SimplePaymentsBlockComponent.Expect( driver, blockId );
 			await gPaymentComponent.insertPaymentButtonDetails( paymentButtonDetails );


### PR DESCRIPTION
We are looking to rename the Simple Payments block to Pay with PayPal button - p2y3YZ-43P

This change shouldn't affect the simple payments block behaviour. The changes here are only intended to change the use of public facing `Simple Payments` terminology to `Pay with PayPal button`.

Page | Before | After
--- | --- | ---
`/plans/:site` | <img width="987" src="https://user-images.githubusercontent.com/1233880/85399040-6ab0ad80-b556-11ea-8856-c2d4d287d984.png"> | <img width="987" alt="Screen Shot 2020-06-23 at 13 35 48" src="https://user-images.githubusercontent.com/1233880/85399098-8ae06c80-b556-11ea-83b2-95018555aef8.png">
`/post/:site` |  <img width="214" alt="Screen Shot 2020-06-23 at 13 43 48" src="https://user-images.githubusercontent.com/1233880/85399790-aa2bc980-b557-11ea-93e2-c5bf779fd970.png"> | <img width="211" alt="Screen Shot 2020-06-23 at 13 46 06" src="https://user-images.githubusercontent.com/1233880/85399937-e9f2b100-b557-11ea-95bb-238115c6cb83.png">
`/post/:site` | <img width="769" alt="Screen Shot 2020-06-23 at 13 43 57" src="https://user-images.githubusercontent.com/1233880/85399806-b4e65e80-b557-11ea-9cdf-cf2dda35d859.png"> | <img width="713" alt="Screen Shot 2020-06-23 at 13 44 21" src="https://user-images.githubusercontent.com/1233880/85399814-b9ab1280-b557-11ea-9dc3-2a98dd9523e0.png">
`/earn/:site` | <img width="540" alt="Screen Shot 2020-06-23 at 16 02 53" src="https://user-images.githubusercontent.com/1233880/85413387-0e0bbd80-b56b-11ea-9c85-ad00b13fed59.png"> | <img width="531" alt="Screen Shot 2020-06-23 at 16 05 45" src="https://user-images.githubusercontent.com/1233880/85413701-6cd13700-b56b-11ea-941d-e6fb3c298c43.png">
`/plans/my-plan/:site` | <img width="555" alt="Screen Shot 2020-06-23 at 16 13 34" src="https://user-images.githubusercontent.com/1233880/85414545-88890d00-b56c-11ea-80a3-e29c7b15c834.png"> | <img width="534" alt="Screen Shot 2020-06-23 at 16 18 25" src="https://user-images.githubusercontent.com/1233880/85415081-2ed51280-b56d-11ea-9db9-f75cfa8bd575.png">

#### Testing instructions

Go through the list of screenshots above and make sure the new copy is used only when the `earn/rename-payment-blocks` flag is enabled.
