### PR TITLE
Add more details to credentials error notices

### DIFF
--- a/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
+++ b/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
@@ -134,8 +134,8 @@ export const failure = ( action, error ) => ( dispatch, getState ) => {
 	const spreadHappiness = ( message ) => {
 		const tracksEvent = recordTracksEvent( 'calypso_rewind_creds_update_failure', {
 			site_id: action.siteId,
-			error: error.error,
-			status_code: error.statusCode,
+			error: error.code,
+			status_code: error.data ?? error.statusCode,
 			host: action.credentials.host,
 			kpri: action.credentials.krpi ? 'provided but [omitted here]' : 'not provided',
 			pass: action.credentials.pass ? 'provided but [omitted here]' : 'not provided',
@@ -152,7 +152,7 @@ export const failure = ( action, error ) => ( dispatch, getState ) => {
 		);
 	};
 
-	switch ( error.error ) {
+	switch ( error.code ) {
 		case 'service_unavailable':
 			announce(
 				i18n.translate(

--- a/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
+++ b/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import React from 'react';
 import i18n from 'i18n-calypso';
 import page from 'page';
 
@@ -126,10 +127,10 @@ export const failure = ( action, error ) => ( dispatch, getState ) => {
 		return canChat ? dispatch( openChat() ) : navigateTo( '/help' );
 	};
 
-	const baseOptions = { duration: 10000, id: action.noticeId };
+	const baseOptions = { id: action.noticeId };
 
-	const announce = ( message, options ) =>
-		dispatch( errorNotice( message, options ? { ...baseOptions, ...options } : baseOptions ) );
+	const announce = ( children, options = {} ) =>
+		dispatch( errorNotice( null, { ...baseOptions, children, ...options } ) );
 
 	const spreadHappiness = ( message ) => {
 		const tracksEvent = recordTracksEvent( 'calypso_rewind_creds_update_failure', {
@@ -185,7 +186,8 @@ export const failure = ( action, error ) => ( dispatch, getState ) => {
 		case 'invalid_credentials':
 			announce(
 				i18n.translate(
-					"We couldn't connect to your site. Please verify your credentials and give it another try."
+					'{{p}}We couldn’t connect to your site. Please verify your credentials and give it another try. More details:{{/p}}{{p}}%(data)s: %(message)s{{/p}}',
+					{ args: error, components: { p: <p /> } }
 				)
 			);
 			spreadHappiness( 'Restore Credentials: invalid credentials' );

--- a/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
+++ b/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
@@ -14,6 +14,7 @@ import hasActiveHappychatSession from 'state/happychat/selectors/has-active-happ
 import isHappychatAvailable from 'state/happychat/selectors/is-happychat-available';
 import isHappychatConnectionUninitialized from 'state/happychat/selectors/is-happychat-connection-uninitialized';
 import { initConnection, sendEvent } from 'state/happychat/connection/actions';
+import notices from 'notices';
 import { openChat } from 'state/happychat/ui/actions';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
@@ -24,7 +25,7 @@ import {
 	JETPACK_CREDENTIALS_STORE,
 	REWIND_STATE_UPDATE,
 } from 'state/action-types';
-import { successNotice, errorNotice } from 'state/notices/actions';
+import { successNotice } from 'state/notices/actions';
 import { transformApi } from 'state/data-layer/wpcom/sites/rewind/api-transformer';
 
 import { registerHandlers } from 'state/data-layer/handler-registry';
@@ -129,8 +130,7 @@ export const failure = ( action, error ) => ( dispatch, getState ) => {
 
 	const baseOptions = { id: action.noticeId };
 
-	const announce = ( children, options = {} ) =>
-		dispatch( errorNotice( null, { ...baseOptions, children, ...options } ) );
+	const announce = ( text, options = {} ) => notices.error( text, { ...baseOptions, ...options } );
 
 	const spreadHappiness = ( message ) => {
 		const tracksEvent = recordTracksEvent( 'calypso_rewind_creds_update_failure', {


### PR DESCRIPTION
#### Changes proposed

* Remove the dismiss timeout, to make error details easier to read and copy
* Expose the “internal” error message from the credentials update response

#### Screenshot

![screenshot](https://user-images.githubusercontent.com/465303/84868638-59802080-b0c0-11ea-8862-91358f7fdc01.png)

Partially addresses 5409-gh-jpop-issues