### PR TITLE
AB Test for Business bump offer

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -168,4 +168,13 @@ export default {
 		allowExistingUsers: true,
 		countryCodeTargets: [ 'US' ],
 	},
+	showBusinessPlanBump: {
+		datestamp: '20200618',
+		variations: {
+			variantShowPlanBump: 50,
+			control: 50,
+		},
+		defaultVariation: 'control',
+		allowExistingUsers: true,
+	},
 };

--- a/client/my-sites/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout-system-decider.js
@@ -33,6 +33,7 @@ export default function CheckoutSystemDecider( {
 	isComingFromSignup,
 	isComingFromGutenboarding,
 	isGutenboardingCreate,
+	isComingFromUpsell,
 	plan,
 	selectedSite,
 	reduxStore,
@@ -129,6 +130,7 @@ export default function CheckoutSystemDecider( {
 						plan={ plan }
 						cart={ cart }
 						isWhiteGloveOffer={ isWhiteGloveOffer }
+						isComingFromUpsell={ isComingFromUpsell }
 					/>
 				</StripeHookProvider>
 			</CheckoutErrorBoundary>
@@ -144,6 +146,7 @@ export default function CheckoutSystemDecider( {
 			isComingFromSignup={ isComingFromSignup }
 			isComingFromGutenboarding={ isComingFromGutenboarding }
 			isGutenboardingCreate={ isGutenboardingCreate }
+			isComingFromUpsell={ isComingFromUpsell }
 			plan={ plan }
 			selectedSite={ selectedSite }
 			reduxStore={ reduxStore }

--- a/client/my-sites/checkout/checkout/checkout-container.jsx
+++ b/client/my-sites/checkout/checkout/checkout-container.jsx
@@ -86,6 +86,7 @@ class CheckoutContainer extends React.Component {
 			isComingFromGutenboarding,
 			isGutenboardingCreate,
 			isWhiteGloveOffer,
+			isComingFromUpsell,
 		} = this.props;
 
 		const TransactionData = clearTransaction ? CartData : CheckoutData;
@@ -120,7 +121,7 @@ class CheckoutContainer extends React.Component {
 							reduxStore={ reduxStore }
 							redirectTo={ redirectTo }
 							upgradeIntent={ upgradeIntent }
-							hideNudge={ isComingFromGutenboarding }
+							hideNudge={ isComingFromGutenboarding || isComingFromUpsell }
 							returnToBlockEditor={ isComingFromGutenboarding || isGutenboardingCreate }
 							isWhiteGloveOffer={ isWhiteGloveOffer }
 						>

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -459,9 +459,9 @@ export class Checkout extends React.Component {
 	maybeShowPlanBumpOfferConcierge( receiptId, stepResult ) {
 		const { cart, selectedSiteSlug } = this.props;
 
-		if ( hasPersonalPlan( cart ) && stepResult && isEmpty( stepResult.failed_purchases ) ) {
-			if ( 'variantShowPlanBump' === abtest( 'showPremiumPlanBump' ) ) {
-				return `/checkout/${ selectedSiteSlug }/offer-plan-upgrade/premium/${ receiptId }`;
+		if ( hasPremiumPlan( cart ) && stepResult && isEmpty( stepResult.failed_purchases ) ) {
+			if ( 'variantShowPlanBump' === abtest( 'showBusinessPlanBump' ) ) {
+				return `/checkout/${ selectedSiteSlug }/offer-plan-upgrade/business/${ receiptId }`;
 			}
 		}
 

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -371,10 +371,6 @@ export class Checkout extends React.Component {
 		return true;
 	}
 
-	emptyOutCart() {
-		replaceCartWithItems( [] );
-	}
-
 	/**
 	 * Purchases are of the format { [siteId]: [ { productId: ... } ] }
 	 * so we need to flatten them to get a list of purchases
@@ -505,7 +501,7 @@ export class Checkout extends React.Component {
 		}
 	}
 
-	getCheckoutCompleteRedirectPath = ( shouldHideUpsellNudges = false, shouldEmptyCart = false ) => {
+	getCheckoutCompleteRedirectPath = ( shouldHideUpsellNudges = false ) => {
 		// TODO: Cleanup and simplify this function.
 		// I wouldn't be surprised if it doesn't work as intended in some scenarios.
 		// Especially around the Concierge / Checklist logic.
@@ -616,8 +612,6 @@ export class Checkout extends React.Component {
 			return `${ signupDestination }/${ pendingOrReceiptId }`;
 		}
 
-		shouldEmptyCart && this.emptyOutCart();
-
 		const redirectPathForConciergeUpsell = this.maybeRedirectToConciergeNudge(
 			pendingOrReceiptId,
 			stepResult,
@@ -651,7 +645,7 @@ export class Checkout extends React.Component {
 		window.location.href = redirectUrl;
 	}
 
-	handleCheckoutCompleteRedirect = ( shouldHideUpsellNudges = false, shouldEmptyCart = false ) => {
+	handleCheckoutCompleteRedirect = ( shouldHideUpsellNudges = false ) => {
 		let product, purchasedProducts, renewalItem;
 
 		const {
@@ -663,10 +657,7 @@ export class Checkout extends React.Component {
 			translate,
 		} = this.props;
 
-		const redirectPath = this.getCheckoutCompleteRedirectPath(
-			shouldHideUpsellNudges,
-			shouldEmptyCart
-		);
+		const redirectPath = this.getCheckoutCompleteRedirectPath( shouldHideUpsellNudges );
 		const destinationFromCookie = retrieveSignupDestination();
 
 		this.props.clearPurchases();

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -89,7 +89,6 @@ import { isRequestingPlans } from 'state/plans/selectors';
 import { isApplePayAvailable } from 'lib/web-payment';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import isAtomicSite from 'state/selectors/is-site-automated-transfer';
-import getPreviousPath from 'state/selectors/get-previous-path.js';
 import config from 'config';
 import { loadTrackingTool } from 'state/analytics/actions';
 import {
@@ -464,7 +463,7 @@ export class Checkout extends React.Component {
 			return;
 		}
 
-		const { cart, selectedSiteSlug, previousRoute } = this.props;
+		const { cart, selectedSiteSlug } = this.props;
 
 		// If the user has upgraded a plan from seeing our upsell (we find this by checking the previous route is /offer-plan-upgrade),
 		// then skip this section so that we do not show further upsells.
@@ -472,8 +471,7 @@ export class Checkout extends React.Component {
 			config.isEnabled( 'upsell/concierge-session' ) &&
 			! hasConciergeSession( cart ) &&
 			! hasJetpackPlan( cart ) &&
-			( hasBloggerPlan( cart ) || hasPersonalPlan( cart ) || hasPremiumPlan( cart ) ) &&
-			! previousRoute.includes( `/checkout/${ selectedSiteSlug }/offer-plan-upgrade` )
+			( hasBloggerPlan( cart ) || hasPersonalPlan( cart ) || hasPremiumPlan( cart ) )
 		) {
 			// A user just purchased one of the qualifying plans
 			// Show them the concierge session upsell page
@@ -972,7 +970,6 @@ export default connect(
 			isPlansListFetching: isRequestingPlans( state ),
 			isSitePlansListFetching: isRequestingSitePlans( state, selectedSiteId ),
 			planSlug: getUpgradePlanSlugFromPath( state, selectedSiteId, props.product ),
-			previousRoute: getPreviousPath( state ),
 			isJetpackNotAtomic:
 				isJetpackSite( state, selectedSiteId ) && ! isAtomicSite( state, selectedSiteId ),
 		};

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -446,7 +446,19 @@ export class Checkout extends React.Component {
 		}
 	}
 
-	maybeRedirectToConciergeNudge( pendingOrReceiptId ) {
+	maybeShowPlanBumpOfferConcierge( receiptId, stepResult ) {
+		const { cart, selectedSiteSlug } = this.props;
+
+		if ( hasPersonalPlan( cart ) && stepResult && isEmpty( stepResult.failed_purchases ) ) {
+			if ( 'variantShowPlanBump' === abtest( 'showPremiumPlanBump' ) ) {
+				return `/checkout/${ selectedSiteSlug }/offer-plan-upgrade/premium/${ receiptId }`;
+			}
+		}
+
+		return;
+	}
+
+	maybeRedirectToConciergeNudge( pendingOrReceiptId, stepResult ) {
 		// Using hideNudge prop will disable any redirect to Nudge
 		if ( this.props.hideNudge ) {
 			return;
@@ -465,6 +477,11 @@ export class Checkout extends React.Component {
 		) {
 			// A user just purchased one of the qualifying plans
 			// Show them the concierge session upsell page
+
+			const upgradePath = this.maybeShowPlanBumpOfferConcierge( pendingOrReceiptId, stepResult );
+			if ( upgradePath ) {
+				return upgradePath;
+			}
 
 			// The conciergeUpsellDial test is used when we need to quickly dial back the volume of concierge sessions
 			// being offered and so sold, to be inline with HE availability.
@@ -586,7 +603,10 @@ export class Checkout extends React.Component {
 			return `${ signupDestination }/${ pendingOrReceiptId }`;
 		}
 
-		const redirectPathForConciergeUpsell = this.maybeRedirectToConciergeNudge( pendingOrReceiptId );
+		const redirectPathForConciergeUpsell = this.maybeRedirectToConciergeNudge(
+			pendingOrReceiptId,
+			stepResult
+		);
 		if ( redirectPathForConciergeUpsell ) {
 			return redirectPathForConciergeUpsell;
 		}

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -463,6 +463,8 @@ export class Checkout extends React.Component {
 			if ( 'variantShowPlanBump' === abtest( 'showBusinessPlanBump' ) ) {
 				return `/checkout/${ selectedSiteSlug }/offer-plan-upgrade/business/${ receiptId }`;
 			}
+
+			return `/checkout/offer-quickstart-session/${ receiptId }/${ selectedSiteSlug }`;
 		}
 
 		return;

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -371,17 +371,6 @@ export class Checkout extends React.Component {
 		return true;
 	}
 
-	/**
-	 * Purchases are of the format { [siteId]: [ { productId: ... } ] }
-	 * so we need to flatten them to get a list of purchases
-	 *
-	 * @param {object} purchases keyed by siteId { [siteId]: [ { productId: ... } ] }
-	 * @returns {Array} of product objects [ { productId: ... }, ... ]
-	 */
-	flattenPurchases( purchases ) {
-		return flatten( Object.values( purchases ) );
-	}
-
 	getUrlWithQueryParam( url, queryParams ) {
 		const { protocol, hostname, port, pathname, query } = parseUrl( url, true );
 

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -118,6 +118,7 @@ export default function CompositeCheckout( {
 	cart,
 	couponCode: couponCodeFromUrl,
 	isWhiteGloveOffer,
+	isComingFromUpsell,
 } ) {
 	const translate = useTranslate();
 	const isJetpackNotAtomic = useSelector(
@@ -126,7 +127,7 @@ export default function CompositeCheckout( {
 	const { stripe, stripeConfiguration, isStripeLoading, stripeLoadingError } = useStripe();
 	const isLoadingCartSynchronizer =
 		cart && ( ! cart.hasLoadedFromServer || cart.hasPendingServerUpdates );
-
+	const hideNudge = isComingFromUpsell;
 	const reduxDispatch = useDispatch();
 	const recordEvent = useCallback( createAnalyticsEventHandler( reduxDispatch ), [] );
 
@@ -223,6 +224,7 @@ export default function CompositeCheckout( {
 		product,
 		siteId,
 		isWhiteGloveOffer,
+		hideNudge,
 	} );
 
 	const moment = useLocalizedMoment();

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
@@ -518,4 +518,23 @@ describe( 'getThankYouPageUrl', () => {
 		} );
 		expect( url ).toBe( '/checkout/thank-you/foo.bar/1234abcd' );
 	} );
+
+	it( 'redirects to thank you page if concierge and jetpack are not in the cart, personal is in the cart, but hideNudge is true', () => {
+		isEnabled.mockImplementation( flag => flag === 'upsell/concierge-session' );
+		const cart = {
+			products: [
+				{
+					product_slug: 'personal-bundle',
+				},
+			],
+		};
+		const url = getThankYouPageUrl( {
+			...defaultArgs,
+			siteSlug: 'foo.bar',
+			cart,
+			receiptId: '1234abcd',
+			hideNudge: true,
+		} );
+		expect( url ).toBe( '/checkout/thank-you/foo.bar/1234abcd' );
+	} );
 } );

--- a/client/my-sites/checkout/composite-checkout/use-get-thank-you-url.js
+++ b/client/my-sites/checkout/composite-checkout/use-get-thank-you-url.js
@@ -32,7 +32,6 @@ import { JETPACK_BACKUP_PRODUCTS } from 'lib/products-values/constants';
 import { persistSignupDestination, retrieveSignupDestination } from 'signup/utils';
 import { getSelectedSite } from 'state/ui/selectors';
 import isEligibleForSignupDestination from 'state/selectors/is-eligible-for-signup-destination';
-import getPreviousPath from 'state/selectors/get-previous-path.js';
 import { abtest } from 'lib/abtest';
 
 export function getThankYouPageUrl( {
@@ -48,9 +47,10 @@ export function getThankYouPageUrl( {
 	product,
 	getUrlFromCookie = retrieveSignupDestination,
 	saveUrlToCookie = persistSignupDestination,
-	previousRoute,
 	isEligibleForSignupDestinationResult,
 	isWhiteGloveOffer,
+	hideNudge,
+	didPurchaseFail,
 } ) {
 	debug( 'starting getThankYouPageUrl' );
 	// If we're given an explicit `redirectTo` query arg, make sure it's either internal
@@ -141,7 +141,7 @@ export function getThankYouPageUrl( {
 		pendingOrReceiptId,
 		cart,
 		siteSlug,
-		previousRoute,
+		hideNudge,
 		didPurchaseFail,
 	} );
 	if ( redirectPathForConciergeUpsell ) {
@@ -234,17 +234,20 @@ function getRedirectUrlForConciergeNudge( {
 	pendingOrReceiptId,
 	cart,
 	siteSlug,
-	previousRoute,
+	hideNudge,
 	didPurchaseFail,
 } ) {
+	if ( hideNudge ) {
+		return;
+	}
+
 	// If the user has upgraded a plan from seeing our upsell(we find this by checking the previous route is /offer-plan-upgrade),
 	// then skip this section so that we do not show further upsells.
 	if (
 		config.isEnabled( 'upsell/concierge-session' ) &&
 		! hasConciergeSession( cart ) &&
 		! hasJetpackPlan( cart ) &&
-		( hasBloggerPlan( cart ) || hasPersonalPlan( cart ) || hasPremiumPlan( cart ) ) &&
-		! previousRoute?.includes( `/checkout/${ siteSlug }/offer-plan-upgrade` )
+		( hasBloggerPlan( cart ) || hasPersonalPlan( cart ) || hasPremiumPlan( cart ) )
 	) {
 		// A user just purchased one of the qualifying plans
 		// Show them the concierge session upsell page
@@ -253,7 +256,6 @@ function getRedirectUrlForConciergeNudge( {
 			pendingOrReceiptId,
 			cart,
 			siteSlug,
-			previousRoute,
 			didPurchaseFail,
 		} );
 		if ( upgradePath ) {
@@ -336,6 +338,7 @@ export function useGetThankYouUrl( {
 	product,
 	siteId,
 	isWhiteGloveOffer,
+	hideNudge,
 } ) {
 	const selectedSiteData = useSelector( ( state ) => getSelectedSite( state ) );
 	const adminUrl = selectedSiteData?.options?.admin_url;
@@ -347,6 +350,7 @@ export function useGetThankYouUrl( {
 	const getThankYouUrl = useCallback( () => {
 		const transactionResult = select( 'wpcom' ).getTransactionResult();
 		debug( 'for getThankYouUrl, transactionResult is', transactionResult );
+		const didPurchaseFail = Object.keys( transactionResult.failed_purchases ?? {} ).length > 0;
 		const receiptId = transactionResult.receipt_id;
 		const orderId = transactionResult.order_id;
 
@@ -361,8 +365,9 @@ export function useGetThankYouUrl( {
 			cart,
 			isJetpackNotAtomic,
 			product,
-			previousRoute,
 			isEligibleForSignupDestinationResult,
+			hideNudge,
+			didPurchaseFail,
 		} );
 		const url = getThankYouPageUrl( {
 			siteSlug,
@@ -375,14 +380,14 @@ export function useGetThankYouUrl( {
 			cart,
 			isJetpackNotAtomic,
 			product,
-			previousRoute,
 			isEligibleForSignupDestinationResult,
 			isWhiteGloveOffer,
+			hideNudge,
+			didPurchaseFail,
 		} );
 		debug( 'getThankYouUrl returned', url );
 		return url;
 	}, [
-		previousRoute,
 		isEligibleForSignupDestinationResult,
 		siteSlug,
 		adminUrl,
@@ -392,6 +397,7 @@ export function useGetThankYouUrl( {
 		feature,
 		purchaseId,
 		cart,
+		hideNudge,
 	] );
 	return getThankYouUrl;
 }

--- a/client/my-sites/checkout/composite-checkout/use-get-thank-you-url.js
+++ b/client/my-sites/checkout/composite-checkout/use-get-thank-you-url.js
@@ -225,9 +225,9 @@ function maybeShowPlanBumpOfferConcierge( {
 	didPurchaseFail,
 	isTransactionResultEmpty,
 } ) {
-	if ( hasPersonalPlan( cart ) && ! isTransactionResultEmpty && ! didPurchaseFail ) {
-		if ( 'variantShowPlanBump' === abtest( 'showPremiumPlanBump' ) ) {
-			return `/checkout/${ siteSlug }/offer-plan-upgrade/premium/${ pendingOrReceiptId }`;
+	if ( hasPremiumPlan( cart ) && ! isTransactionResultEmpty && ! didPurchaseFail ) {
+		if ( 'variantShowPlanBump' === abtest( 'showBusinessPlanBump' ) ) {
+			return `/checkout/${ siteSlug }/offer-plan-upgrade/business/${ pendingOrReceiptId }`;
 		}
 	}
 

--- a/client/my-sites/checkout/composite-checkout/use-get-thank-you-url.js
+++ b/client/my-sites/checkout/composite-checkout/use-get-thank-you-url.js
@@ -142,6 +142,7 @@ export function getThankYouPageUrl( {
 		cart,
 		siteSlug,
 		previousRoute,
+		didPurchaseFail,
 	} );
 	if ( redirectPathForConciergeUpsell ) {
 		debug( 'redirect for concierge exists, so returning', redirectPathForConciergeUpsell );
@@ -214,7 +215,28 @@ function getFallbackDestination( {
 	return '/';
 }
 
-function getRedirectUrlForConciergeNudge( { pendingOrReceiptId, cart, siteSlug, previousRoute } ) {
+function maybeShowPlanBumpOfferConcierge( {
+	pendingOrReceiptId,
+	cart,
+	siteSlug,
+	didPurchaseFail,
+} ) {
+	if ( hasPersonalPlan( cart ) && ! didPurchaseFail ) {
+		if ( 'variantShowPlanBump' === abtest( 'showPremiumPlanBump' ) ) {
+			return `/checkout/${ siteSlug }/offer-plan-upgrade/premium/${ pendingOrReceiptId }`;
+		}
+	}
+
+	return;
+}
+
+function getRedirectUrlForConciergeNudge( {
+	pendingOrReceiptId,
+	cart,
+	siteSlug,
+	previousRoute,
+	didPurchaseFail,
+} ) {
 	// If the user has upgraded a plan from seeing our upsell(we find this by checking the previous route is /offer-plan-upgrade),
 	// then skip this section so that we do not show further upsells.
 	if (
@@ -226,6 +248,17 @@ function getRedirectUrlForConciergeNudge( { pendingOrReceiptId, cart, siteSlug, 
 	) {
 		// A user just purchased one of the qualifying plans
 		// Show them the concierge session upsell page
+
+		const upgradePath = maybeShowPlanBumpOfferConcierge( {
+			pendingOrReceiptId,
+			cart,
+			siteSlug,
+			previousRoute,
+			didPurchaseFail,
+		} );
+		if ( upgradePath ) {
+			return upgradePath;
+		}
 
 		// The conciergeUpsellDial test is used when we need to quickly dial back the volume of concierge sessions
 		// being offered and so sold, to be inline with HE availability.

--- a/client/my-sites/checkout/composite-checkout/use-get-thank-you-url.js
+++ b/client/my-sites/checkout/composite-checkout/use-get-thank-you-url.js
@@ -6,6 +6,7 @@ import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import { defaultRegistry } from '@automattic/composite-checkout';
 import debugFactory from 'debug';
+import { isEmpty } from 'lodash';
 
 const { select } = defaultRegistry;
 const debug = debugFactory( 'calypso:composite-checkout-thank-you' );
@@ -51,6 +52,7 @@ export function getThankYouPageUrl( {
 	isWhiteGloveOffer,
 	hideNudge,
 	didPurchaseFail,
+	isTransactionResultEmpty,
 } ) {
 	debug( 'starting getThankYouPageUrl' );
 	// If we're given an explicit `redirectTo` query arg, make sure it's either internal
@@ -143,6 +145,7 @@ export function getThankYouPageUrl( {
 		siteSlug,
 		hideNudge,
 		didPurchaseFail,
+		isTransactionResultEmpty,
 	} );
 	if ( redirectPathForConciergeUpsell ) {
 		debug( 'redirect for concierge exists, so returning', redirectPathForConciergeUpsell );
@@ -220,8 +223,9 @@ function maybeShowPlanBumpOfferConcierge( {
 	cart,
 	siteSlug,
 	didPurchaseFail,
+	isTransactionResultEmpty,
 } ) {
-	if ( hasPersonalPlan( cart ) && ! didPurchaseFail ) {
+	if ( hasPersonalPlan( cart ) && ! isTransactionResultEmpty && ! didPurchaseFail ) {
 		if ( 'variantShowPlanBump' === abtest( 'showPremiumPlanBump' ) ) {
 			return `/checkout/${ siteSlug }/offer-plan-upgrade/premium/${ pendingOrReceiptId }`;
 		}
@@ -236,6 +240,7 @@ function getRedirectUrlForConciergeNudge( {
 	siteSlug,
 	hideNudge,
 	didPurchaseFail,
+	isTransactionResultEmpty,
 } ) {
 	if ( hideNudge ) {
 		return;
@@ -257,6 +262,7 @@ function getRedirectUrlForConciergeNudge( {
 			cart,
 			siteSlug,
 			didPurchaseFail,
+			isTransactionResultEmpty,
 		} );
 		if ( upgradePath ) {
 			return upgradePath;
@@ -353,6 +359,7 @@ export function useGetThankYouUrl( {
 		const didPurchaseFail = Object.keys( transactionResult.failed_purchases ?? {} ).length > 0;
 		const receiptId = transactionResult.receipt_id;
 		const orderId = transactionResult.order_id;
+		const isTransactionResultEmpty = isEmpty( transactionResult );
 
 		debug( 'getThankYouUrl called with', {
 			siteSlug,
@@ -368,6 +375,7 @@ export function useGetThankYouUrl( {
 			isEligibleForSignupDestinationResult,
 			hideNudge,
 			didPurchaseFail,
+			isTransactionResultEmpty,
 		} );
 		const url = getThankYouPageUrl( {
 			siteSlug,
@@ -384,6 +392,7 @@ export function useGetThankYouUrl( {
 			isWhiteGloveOffer,
 			hideNudge,
 			didPurchaseFail,
+			isTransactionResultEmpty,
 		} );
 		debug( 'getThankYouUrl returned', url );
 		return url;

--- a/client/my-sites/checkout/composite-checkout/use-get-thank-you-url.js
+++ b/client/my-sites/checkout/composite-checkout/use-get-thank-you-url.js
@@ -229,6 +229,7 @@ function maybeShowPlanBumpOfferConcierge( {
 		if ( 'variantShowPlanBump' === abtest( 'showBusinessPlanBump' ) ) {
 			return `/checkout/${ siteSlug }/offer-plan-upgrade/business/${ pendingOrReceiptId }`;
 		}
+		return `/checkout/offer-quickstart-session/${ pendingOrReceiptId }/${ siteSlug }`;
 	}
 
 	return;

--- a/client/my-sites/checkout/composite-checkout/use-get-thank-you-url.js
+++ b/client/my-sites/checkout/composite-checkout/use-get-thank-you-url.js
@@ -351,7 +351,6 @@ export function useGetThankYouUrl( {
 	const isEligibleForSignupDestinationResult = useSelector( ( state ) =>
 		isEligibleForSignupDestination( state, siteId, cart )
 	);
-	const previousRoute = useSelector( ( state ) => getPreviousPath( state ) );
 
 	const getThankYouUrl = useCallback( () => {
 		const transactionResult = select( 'wpcom' ).getTransactionResult();

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -64,6 +64,7 @@ export function checkout( context, next ) {
 				isComingFromSignup={ !! context.query.signup }
 				isComingFromGutenboarding={ !! context.query.preLaunch }
 				isGutenboardingCreate={ !! context.query.isGutenboardingCreate }
+				isComingFromUpsell={ !! context.query.upgrade }
 				plan={ plan }
 				selectedSite={ selectedSite }
 				reduxStore={ context.store }

--- a/client/my-sites/checkout/upsell-nudge/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/index.jsx
@@ -189,12 +189,11 @@ export class UpsellNudge extends React.Component {
 			url
 		);
 	}
-
-	handleClickDecline = () => {
+	handleClickDecline = ( shouldHideUpsellNudges = true, shouldEmptyCart = false ) => {
 		const { trackUpsellButtonClick, upsellType, handleCheckoutCompleteRedirect } = this.props;
 
 		trackUpsellButtonClick( `calypso_${ upsellType.replace( /-/g, '_' ) }_decline_button_click` );
-		handleCheckoutCompleteRedirect();
+		handleCheckoutCompleteRedirect( shouldHideUpsellNudges, shouldEmptyCart );
 	};
 
 	handleClickAccept = ( buttonAction ) => {

--- a/client/my-sites/checkout/upsell-nudge/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/index.jsx
@@ -181,6 +181,7 @@ export class UpsellNudge extends React.Component {
 		}
 	}
 
+
 	getUrl( url, args ) {
 		return addQueryArgs(
 			{
@@ -189,12 +190,13 @@ export class UpsellNudge extends React.Component {
 			url
 		);
 	}
-	handleClickDecline = ( shouldHideUpsellNudges = true, shouldEmptyCart = false ) => {
+	handleClickDecline = ( shouldHideUpsellNudges = true ) => {
 		const { trackUpsellButtonClick, upsellType, handleCheckoutCompleteRedirect } = this.props;
 
 		trackUpsellButtonClick( `calypso_${ upsellType.replace( /-/g, '_' ) }_decline_button_click` );
-		handleCheckoutCompleteRedirect( shouldHideUpsellNudges, shouldEmptyCart );
+		handleCheckoutCompleteRedirect( shouldHideUpsellNudges );
 	};
+
 
 	handleClickAccept = ( buttonAction ) => {
 		const { trackUpsellButtonClick, upsellType, siteSlug, upgradeItem, extra } = this.props;

--- a/client/my-sites/checkout/upsell-nudge/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/index.jsx
@@ -181,7 +181,6 @@ export class UpsellNudge extends React.Component {
 		}
 	}
 
-
 	getUrl( url, args ) {
 		return addQueryArgs(
 			{
@@ -190,13 +189,13 @@ export class UpsellNudge extends React.Component {
 			url
 		);
 	}
+
 	handleClickDecline = ( shouldHideUpsellNudges = true ) => {
 		const { trackUpsellButtonClick, upsellType, handleCheckoutCompleteRedirect } = this.props;
 
 		trackUpsellButtonClick( `calypso_${ upsellType.replace( /-/g, '_' ) }_decline_button_click` );
 		handleCheckoutCompleteRedirect( shouldHideUpsellNudges );
 	};
-
 
 	handleClickAccept = ( buttonAction ) => {
 		const { trackUpsellButtonClick, upsellType, siteSlug, upgradeItem, extra } = this.props;

--- a/client/my-sites/checkout/upsell-nudge/plan-upgrade-upsell/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/plan-upgrade-upsell/index.jsx
@@ -62,7 +62,7 @@ export class PlanUpgradeUpsell extends PureComponent {
 
 	body() {
 		const { translate, planRawPrice, planDiscountedRawPrice, currencyCode } = this.props;
-		const bundleValue = planRawPrice * 77;
+		const bundleValue = planRawPrice * 14.33;
 		const premiumThemePriceLow = planRawPrice * 0.73;
 		const premiumThemePriceHigh = planRawPrice * 1.045;
 		return (

--- a/client/my-sites/checkout/upsell-nudge/plan-upgrade-upsell/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/plan-upgrade-upsell/index.jsx
@@ -54,7 +54,7 @@ export class PlanUpgradeUpsell extends PureComponent {
 		return (
 			<header className="plan-upgrade-upsell__small-header">
 				<h2 className="plan-upgrade-upsell__title">
-					{ translate( 'Hold tight, your site is being upgraded.' ) }
+					{ translate( 'This is a one time offer just for you' ) }
 				</h2>
 			</header>
 		);
@@ -63,21 +63,13 @@ export class PlanUpgradeUpsell extends PureComponent {
 	body() {
 		const { translate, planRawPrice, planDiscountedRawPrice, currencyCode } = this.props;
 		const bundleValue = planRawPrice * 14.33;
-		const premiumThemePriceLow = planRawPrice * 0.73;
-		const premiumThemePriceHigh = planRawPrice * 1.045;
 		return (
 			<>
 				<h2 className="plan-upgrade-upsell__header">
 					{ translate(
-						'Add {{u}}%(bundleValue)s worth{{/u}} of Premium designs to your order {{br/}}{{u}}for just %(discountPrice)s more{{/u}}!',
+						'Upgrade your account to our most powerful plan ever {{br/}} with this special offer',
 						{
-							args: {
-								bundleValue: formatCurrency( bundleValue, currencyCode, { precision: 0 } ),
-								discountPrice: formatCurrency( planDiscountedRawPrice, currencyCode, {
-									precision: 0,
-								} ),
-							},
-							components: { u: <u />, br: <br /> },
+							components: { br: <br /> },
 						}
 					) }
 				</h2>
@@ -87,29 +79,106 @@ export class PlanUpgradeUpsell extends PureComponent {
 						<p>
 							<b>
 								{ translate(
-									'According to Google, design is possibly the best investment you can make for your website.'
+									'Did you know that WordPress.com Business plan customers can now upload any WordPress plugins they want?'
 								) }
 							</b>
 						</p>
 						<p>
 							{ translate(
-								'Why? Based on their research, 50% of the people visiting your site decide to leave or stay within the first three seconds.'
+								'If you’re familiar with WordPress plugins, you know why that’s exciting. Installing plugins on your site is like downloading an app on your phone. Except, instead of getting a new game or productivity tool, you get new features and functionality for your site.'
 							) }
 						</p>
 						<p>
-							{ translate( '{{i}}Three seconds!{{/i}}', {
-								components: { i: <i /> },
-							} ) }
-						</p>
-						<p>
 							{ translate(
-								"Wouldn't you like to make a great first impression in those three seconds?"
+								'There are more than 50,000 WordPress plugins available to help turn your site into any powerful platform you imagine.'
 							) }
 						</p>
-						<p>{ translate( "Thankfully, there's a way." ) }</p>
+						<p>{ translate( 'With the power of plugins you can:' ) }</p>
+						<ul className="plan-upgrade-upsell__checklist">
+							<li className="plan-upgrade-upsell__checklist-item">
+								<Gridicon icon="checkmark" className="plan-upgrade-upsell__checklist-item-icon" />
+								<span className="plan-upgrade-upsell__checklist-item-text">
+									{ translate(
+										'Transform your site into a mobile app, a job board, a wiki, or a coupon site.',
+										{
+											comment: "This is a benefit listed on a 'Upgrade your plan' page",
+										}
+									) }
+								</span>
+							</li>
+							<li className="plan-upgrade-upsell__checklist-item">
+								<Gridicon icon="checkmark" className="plan-upgrade-upsell__checklist-item-icon" />
+								<span className="plan-upgrade-upsell__checklist-item-text">
+									{ translate( 'Create a private, customer-only section.', {
+										comment: "This is a benefit listed on a 'Upgrade your plan' page",
+									} ) }
+								</span>
+							</li>
+							<li className="plan-upgrade-upsell__checklist-item">
+								<Gridicon icon="checkmark" className="plan-upgrade-upsell__checklist-item-icon" />
+								<span className="plan-upgrade-upsell__checklist-item-text">
+									{ translate( 'Let your customers book and pay for appointments by themselves.', {
+										comment: "This is a benefit listed on a 'Upgrade your plan' page",
+									} ) }
+								</span>
+							</li>
+							<li className="plan-upgrade-upsell__checklist-item">
+								<Gridicon icon="checkmark" className="plan-upgrade-upsell__checklist-item-icon" />
+								<span className="plan-upgrade-upsell__checklist-item-text">
+									{ translate(
+										'Fully optimize your site for search engines with advanced options.',
+										{
+											comment: "This is a benefit listed on a 'Upgrade your plan' page",
+										}
+									) }
+								</span>
+							</li>
+							<li className="plan-upgrade-upsell__checklist-item">
+								<Gridicon icon="checkmark" className="plan-upgrade-upsell__checklist-item-icon" />
+								<span className="plan-upgrade-upsell__checklist-item-text">
+									{ translate(
+										'Build a professional photography site with beautiful photo galleries.',
+										{
+											comment: "This is a benefit listed on a 'Upgrade your plan' page",
+										}
+									) }
+								</span>
+							</li>
+							<li className="plan-upgrade-upsell__checklist-item">
+								<Gridicon icon="checkmark" className="plan-upgrade-upsell__checklist-item-icon" />
+								<span className="plan-upgrade-upsell__checklist-item-text">
+									{ translate( 'Turn your site into a lead-generation powerhouse.', {
+										comment: "This is a benefit listed on a 'Upgrade your plan' page",
+									} ) }
+								</span>
+							</li>
+							<li className="plan-upgrade-upsell__checklist-item">
+								<Gridicon icon="checkmark" className="plan-upgrade-upsell__checklist-item-icon" />
+								<span className="plan-upgrade-upsell__checklist-item-text">
+									{ translate( 'Grow your email list with opt-in forms on your site.', {
+										comment: "This is a benefit listed on a 'Upgrade your plan' page",
+									} ) }
+								</span>
+							</li>
+						</ul>
 						<p>
 							{ translate(
-								'Great looking sites {{b}}always{{/b}} create great first impressions and leave people wanting to know more about you.',
+								'And access to the plugin library is just one of many benefits included with the Business plan.'
+							) }
+						</p>
+						<p>
+							{ translate(
+								'With our Business plan you can upload any custom theme you want, have full access to your site with SFTP, and have full control of your data directly with phpMyAdmin.'
+							) }
+						</p>
+						<p>
+							{ translate(
+								'You’ll also get automated backups and one-click rewind for your site. Those powerful tools mean you’ll never need to worry about losing data, or breaking your site during updates.'
+							) }
+						</p>
+						<p>
+							{ translate(
+								'{{b}}But please note:{{/b}} you don’t currently have access to all these amazing features because they are only available to Business plan customers and you haven’t upgraded yet.',
 								{
 									components: { b: <b /> },
 								}
@@ -117,40 +186,23 @@ export class PlanUpgradeUpsell extends PureComponent {
 						</p>
 						<p>
 							{ translate(
-								"That's exactly why we've partnered with some of the world's greatest designers to offer high-end designs that you can use to make your site look incredible."
-							) }
-						</p>
-						<p>
-							{ translate(
-								'These premium themes are beautiful and optimized for mobile and search engines. Most importantly, they are ready to use regardless of your goals.'
-							) }
-						</p>
-						<p>
-							{ translate(
-								"From small businesses to blogs, wedding sites to designer portfolios, you'll find the perfect theme for your needs."
-							) }
-						</p>
-						<p>
-							{ translate(
-								'Typically, this type of high-end WordPress theme {{b}}costs an average of %(premiumThemePriceLow)s, with some going as high as %(premiumThemePriceHigh)s and more{{/b}}.',
+								'The good news is that you can upgrade your plan today and try the Business plan risk-free thanks to our {{b}}30-day money-back guarantee{{/b}}.',
 								{
-									args: {
-										premiumThemePriceLow: formatCurrency( premiumThemePriceLow, currencyCode, {
-											precision: 0,
-										} ),
-										premiumThemePriceHigh: formatCurrency( premiumThemePriceHigh, currencyCode, {
-											precision: 0,
-										} ),
+									components: { b: <b /> },
+								}
+							) }
+						</p>
+						<p>
+							{ translate(
+								'Simply click the link below and select the Business plan option to upgrade today {{b}}for just {{del}}%(fullPrice)s{{/del}} %(discountPrice)s more{{/b}}. Once you upgrade, you’ll have 30 days to evaluate the plan and decide if it’s right for you.',
+								{
+									components: {
+										del: <del />,
+										b: <b />,
 									},
-									components: { b: <b /> },
-								}
-							) }
-						</p>
-						<p>
-							{ translate(
-								'But if you upgrade to a Premium plan with this special offer, you will get our full collection premium themes for just an additional %(discountPrice)s!',
-								{
 									args: {
+										bundleValue: formatCurrency( bundleValue, currencyCode, { precision: 0 } ),
+										fullPrice: formatCurrency( planRawPrice, currencyCode, { stripZeros: true } ),
 										discountPrice: formatCurrency( planDiscountedRawPrice, currencyCode, {
 											stripZeros: true,
 										} ),
@@ -158,76 +210,7 @@ export class PlanUpgradeUpsell extends PureComponent {
 								}
 							) }
 						</p>
-						<p>
-							{ translate(
-								"You'll also gain access to some of the most powerful features on WordPress.com:"
-							) }
-						</p>
-
-						<ul className="plan-upgrade-upsell__checklist">
-							<li className="plan-upgrade-upsell__checklist-item">
-								<Gridicon icon="checkmark" className="plan-upgrade-upsell__checklist-item-icon" />
-								<span className="plan-upgrade-upsell__checklist-item-text">
-									{ translate(
-										'{{b}}More ways to monetize your site.{{/b}} You can sell stuff on your site without any hassle. Or earn through our special advertising program. Or why not both?',
-										{
-											components: { b: <b /> },
-											comment: "This is a benefit listed on a 'Upgrade your plan' page",
-										}
-									) }
-								</span>
-							</li>
-							<li className="plan-upgrade-upsell__checklist-item">
-								<Gridicon icon="checkmark" className="plan-upgrade-upsell__checklist-item-icon" />
-								<span className="plan-upgrade-upsell__checklist-item-text">
-									{ translate(
-										'{{b}}Advanced tools to become a social media pro.{{/b}} Schedule posts in advance, resurface your older content, or share multiple social posts at a time.',
-										{
-											components: { b: <b /> },
-											comment: "This is a benefit listed on a 'Upgrade your plan' page",
-										}
-									) }
-								</span>
-							</li>
-							<li className="plan-upgrade-upsell__checklist-item">
-								<Gridicon icon="checkmark" className="plan-upgrade-upsell__checklist-item-icon" />
-								<span className="plan-upgrade-upsell__checklist-item-text">
-									{ translate(
-										'{{b}}Customize your premium theme to your exact needs.{{/b}} With advanced design features, you can make your site stand out and never be the same as others.',
-										{
-											components: { b: <b /> },
-											comment: "This is a benefit listed on a 'Upgrade your plan' page",
-										}
-									) }
-								</span>
-							</li>
-						</ul>
-
-						<p>
-							{ translate(
-								'Give the Premium plan a risk-free test drive with our {{u}}30-day Money Back Guarantee{{/u}}.',
-								{
-									components: { u: <u /> },
-								}
-							) }
-						</p>
-						<p>
-							<b>
-								{ translate(
-									'Upgrade to the Premium plan and access our full collection of premium themes for just {{del}}%(fullPrice)s{{/del}} %(discountPrice)s more.',
-									{
-										components: { del: <del /> },
-										args: {
-											bundleValue: formatCurrency( bundleValue, currencyCode, { precision: 0 } ),
-											fullPrice: formatCurrency( planRawPrice, currencyCode, { stripZeros: true } ),
-											discountPrice: formatCurrency( planDiscountedRawPrice, currencyCode, {
-												stripZeros: true,
-											} ),
-										},
-									}
-								) }
-							</b>
-						</p>
+						<p>{ translate( 'So are you ready to explore our most powerful plan ever?' ) }</p>
 					</div>
 					<div className="plan-upgrade-upsell__column-doodle">
 						<img
@@ -249,14 +232,14 @@ export class PlanUpgradeUpsell extends PureComponent {
 					className="plan-upgrade-upsell__decline-offer-button"
 					onClick={ handleClickDecline }
 				>
-					{ translate( "No thanks, I'll stick with the free themes" ) }
+					{ translate( "No thanks, I don't need plugins" ) }
 				</Button>
 				<Button
 					primary
 					className="plan-upgrade-upsell__accept-offer-button"
 					onClick={ () => handleClickAccept( 'accept' ) }
 				>
-					{ translate( "Yes, I'd love to try those Premium designs!" ) }
+					{ translate( 'Yes, I need plugins for my site!' ) }
 				</Button>
 			</footer>
 		);

--- a/client/my-sites/checkout/upsell-nudge/plan-upgrade-upsell/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/plan-upgrade-upsell/index.jsx
@@ -62,7 +62,6 @@ export class PlanUpgradeUpsell extends PureComponent {
 
 	body() {
 		const { translate, planRawPrice, planDiscountedRawPrice, currencyCode } = this.props;
-		const bundleValue = planRawPrice * 14.33;
 		return (
 			<>
 				<h2 className="plan-upgrade-upsell__header">
@@ -201,7 +200,6 @@ export class PlanUpgradeUpsell extends PureComponent {
 										b: <b />,
 									},
 									args: {
-										bundleValue: formatCurrency( bundleValue, currencyCode, { precision: 0 } ),
 										fullPrice: formatCurrency( planRawPrice, currencyCode, { stripZeros: true } ),
 										discountPrice: formatCurrency( planDiscountedRawPrice, currencyCode, {
 											stripZeros: true,

--- a/client/my-sites/checkout/upsell-nudge/plan-upgrade-upsell/style.scss
+++ b/client/my-sites/checkout/upsell-nudge/plan-upgrade-upsell/style.scss
@@ -89,8 +89,8 @@ main.plan-upgrade-upsell.main {
 		font-weight: 600;
 		text-align: center;
 		line-height: 1.4;
-		margin-top: 0.5em;
-		margin-bottom: 0.4em;
+		margin-top: 0.7em;
+		margin-bottom: 1em;
 
 		@include breakpoint-deprecated( '<660px' ) {
 			font-size: 21px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR implements the test plan explained here pbxNRc-lW-p2

#### Testing instructions

**Scenario 1** _(Testing behavior of `showBusinessPlanBump` A/B test)_

* Signup for a new account from http://calypso.localhost:3000/start.
* Add a Premium plan to cart and complete the purchase
* Verify the following:
    - That you are shown the Business upgrade upsell if on the `variantShowPlanBump` variation of `showBusinessPlanBump` test.
    - That you are shown the concierge upsell if on the `control` variation of `showBusinessPlanBump` test (no matter if you're in the `offer` or `noOffer`group for the `conciergeUpsellDial` test).

If on the plan upsell nudge, verify the following:
- Clicking the `No thanks ...` button should take you to the checklist page.
- Clicking the `Yes, I'd love to try ....` button should take you to the checkout page with the Business plan added to cart and **credits applied**. Verify that after you complete the purchase, you are **not shown the concierge upsell** but instead taken to the checklist/customer home page.

If on the concierge upsell nudge, verify the following:
- Clicking Skip on the nudge should take you to the checklist.
- Clicking Accept on the nudge, and completing the concierge session purchase should take you the checklist. _**No more upsell nudges should be shown**_.

**Scenario 2** _(Test that an invalid card(checkout error) does not lead to a test assignment)_
* Go through the signup flow and checkout with a Premium plan. 
* In the Checkout page, use an invalid visa card number and click the Purchase button(I used `4539747991309129 `).
* You should get a Transaction declined message.
* In your browser console, type `localStorage.ABTests;`. The object should not include the `showBusinessPlanBump` test.
* Now complete the purchase with a valid credit card(which can just be the store sandbox credit card number).
* In your browser console, type `localStorage.ABTests;`. The object _should include_ the `showBusinessPlanBump` test.

**Scenario 3** _(Test that the offer is shown when upgrading from a lower-tier plan to Premium)_
* Login to a site having a Free or Blogger or Personal plan, go to /plans page and upgrade to Premium
* After purchase completes, verify the following:
    - That you are shown the Business upgrade upsell if on the `variantShowPlanBump` variation of `showBusinessPlanBump` test.
    - That you are shown the concierge upsell if on the `control` variation of `showBusinessPlanBump` test (no matter if you're in the `offer` or `noOffer` group for the `conciergeUpsellDial` test).
In both cases above, complete the upsell purchase and verify that you are not shown any more upsell nudges.

**Scenario 4** 
* Verify status quo i.e current behavior is maintained for non-Premium plan purchases.
* Add a Personal plan to cart and complete signup. Verify that only the concierge upsell nudge is shown (no matter if you're in the `offer` or `noOffer` group for the `conciergeUpsellDial` test). 
* In browser console, type `localStorage.ABTests;` and verify that it does not list the `showBusinessPlanBump` test. 


**Scenario 5** _(Test that a failed purchase does not lead to a test assignment)_
* Go through the signup flow and checkout with a Premium plan. 
* In the Checkout page, click on PayPal as your payment method.
* After you're redirected to paypal.com, click the `Cancel and return to WordPress.com` link (if sandboxed, this will appear with different wording).
* In your browser console, type `localStorage.ABTests;`. The object should not include the `showBusinessPlanBump` test.
* Now try PayPal again and this time, complete the purchase
* You should still not be assigned to the test. Since we don't have a reliable way to know if a redirect payment type failed before determining the `successUrl`, we will exclude all redirect payment types from this test.

**Scenario 6** _(Test that a GiroPay purchase does not lead to a test assignment)_
* Go through signup flow while you are proxied through Europe. Pay for a Premium plan through Giropay and verify that you see the Concierge nudge. 
* Also verify that typing localstorage.ABTests in your browser console should not show the `showBusinessPlanBump` test in the list of assigned tests.

**Scenario 7** _(Test that that going Back doesn't show another offer)_
* When presented with the Business bump, click "Yes" but then when presented the Checkout click back in the browser and this time click "No" in the offer. You should be taken directly to Calypso.


**Test in the composite checkout**
* Where relevant, repeat all the cases listed above for the composite checkout flow - proxy through a US IP and assign yourself to `composite` variation of `showCompositeCheckout` test.

