### PR TITLE
Jetpack: normalize colors on cloud components

### DIFF
--- a/client/components/jetpack/log-item/style.scss
+++ b/client/components/jetpack/log-item/style.scss
@@ -2,7 +2,7 @@
 	border-radius: 3px;
 	--color-log-item: var( --color-text );
 
-	$highlights: ( 'info': 'primary-20', 'success': 'success-20', 'error': 'error-20', 'warning': 'warning-20' );
+	$highlights: ( 'info': 'primary-20', 'success': 'success-20', 'error': 'error-50', 'warning': 'warning-20' );
 	@each $type, $color in $highlights {
 		&.is-#{$type} {
 			--color-log-item: var( --color-#{$color} );

--- a/client/components/jetpack/server-credentials-wizard-dialog/style.scss
+++ b/client/components/jetpack/server-credentials-wizard-dialog/style.scss
@@ -31,7 +31,7 @@
 		}
 
 		&__icon--warning {
-			fill: var( --color-threat-found );
+			fill: var( --color-error-50 );
 		}
 
 		&__warning-message {

--- a/client/components/jetpack/threat-dialog/style.scss
+++ b/client/components/jetpack/threat-dialog/style.scss
@@ -12,7 +12,7 @@
 		}
 
 		&__header--ignore-threat {
-			color: var( --color-threat-found );
+			color: var( --color-error-50 );
 		}
 
 		&__threat-title {
@@ -41,7 +41,7 @@
 		}
 
 		&__warning-icon--ignore-threat {
-			fill: var( --color-threat-found );
+			fill: var( --color-error-50 );
 		}
 
 		&__warning-message {

--- a/client/components/jetpack/threat-history-list/index.jsx
+++ b/client/components/jetpack/threat-history-list/index.jsx
@@ -40,6 +40,7 @@ const ThreatStatusFilter = ( { isPlaceholder, onSelect } ) => {
 			className="threat-history-list__filters"
 			options={ filterOptions }
 			onSelect={ onSelect }
+			primary
 		/>
 	);
 };

--- a/client/components/jetpack/threat-history-list/style.scss
+++ b/client/components/jetpack/threat-history-list/style.scss
@@ -1,22 +1,19 @@
 .threat-history-list {
 	&__filters-wrapper {
+		margin: 8px 0 24px;
 		text-align: center;
 	}
 
 	&__filters.is-placeholder {
 		@include placeholder( --color-neutral-10 );
 		height: 36px;
-		width: 175px;
+		max-width: 230px;
+		margin: 0 auto;
 		border-radius: 4px;
 	}
 
 	&__filters {
-		margin: 8px 0 24px;
-		display: inline-flex;
-
-		.segmented-control__item.is-selected a {
-			background: var( --color-neutral-30 );
-			color: #fff;
-		}
+		max-width: 230px;
+		margin: 0 auto;
 	}
 }

--- a/client/components/jetpack/threat-item-subheader/style.scss
+++ b/client/components/jetpack/threat-item-subheader/style.scss
@@ -7,7 +7,7 @@
 		align-items: flex-start;
 		margin-top: 4px;
 
-		@include breakpoint-deprecated( '>1280px' ) {
+		@include breakpoint-deprecated( '>1040px' ) {
 			flex-direction: row;
 			align-items: center;
 		}
@@ -24,7 +24,7 @@
 	&__date-separator {
 		display: none;
 
-		@include breakpoint-deprecated( '>1280px' ) {
+		@include breakpoint-deprecated( '>1040px' ) {
 			display: inline-block;
 			background: var( --color-threat-ignored );
 			margin: 0 12px;

--- a/client/components/jetpack/threat-item-subheader/style.scss
+++ b/client/components/jetpack/threat-item-subheader/style.scss
@@ -1,6 +1,6 @@
 .threat-item-subheader {
 	&__subheader {
-		color: var( --color-threat-ignored );
+		color: var( --studio-gray-50 );
 		font-size: $font-body-small;
 		display: flex;
 		flex-direction: column;
@@ -17,7 +17,7 @@
 		white-space: nowrap;
 
 		&.is-fixed {
-			color: var( --color-threat-fixed );
+			color: var( --studio-jetpack-green-40 );
 		}
 	}
 
@@ -26,7 +26,7 @@
 
 		@include breakpoint-deprecated( '>1040px' ) {
 			display: inline-block;
-			background: var( --color-threat-ignored );
+			background: var( --studio-gray-50 );
 			margin: 0 12px;
 			width: 4px;
 			height: 4px;
@@ -45,11 +45,11 @@
 		color: #fff;
 
 		&.is-fixed {
-			background-color: var( --color-threat-fixed );
+			background-color: var( --studio-jetpack-green-40 );
 		}
 
 		&.is-ignored {
-			background-color: var( --color-threat-ignored );
+			background-color: var( --studio-gray-50 );
 		}
 	}
 

--- a/client/components/jetpack/threat-item/style.scss
+++ b/client/components/jetpack/threat-item/style.scss
@@ -21,7 +21,7 @@
 	}
 
 	&.is-current {
-		border-left: 3px solid var( --color-threat-found );
+		border-left: 3px solid var( --color-error-50 );
 	}
 
 	&.is-fixed {

--- a/client/components/jetpack/threat-item/style.scss
+++ b/client/components/jetpack/threat-item/style.scss
@@ -1,6 +1,4 @@
 .threat-item {
-	// Override the error color to a slightly different red.
-	--color-error-20: var( --color-threat-found );
 	.foldable-card__main {
 		flex: auto;
 	}

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_jetpack-cloud.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_jetpack-cloud.scss
@@ -129,8 +129,4 @@
 	--color-scary-40: var( --studio-red-40 );
 	--color-scary-50: var( --studio-red-50 );
 	--color-scary-60: var( --studio-red-60 );
-
-	--color-threat-found: var( --studio-red-50 );
-	--color-threat-fixed: var( --studio-jetpack-green-40 );
-	--color-threat-ignored: var( --studio-gray-50 );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Normalize colors on Jetpack cloud components so that components are compatible with both the cloud and dotcom.
* Remove unsused variables from the Jetpack color scheme.
* Set Scan history segmentControl as primary and update its styling.
* Reduce the screen width needed to unwrap date/times on Scan history

#### Before/After

Before | After
--|--
![image](https://user-images.githubusercontent.com/390760/84397852-140eaf80-abf7-11ea-950f-6cc73f0824cf.png) | ![image](https://user-images.githubusercontent.com/390760/84399687-0c500a80-abf9-11ea-9973-1487fc22f102.png)
![image](https://user-images.githubusercontent.com/390760/84397780-ffcab280-abf6-11ea-8336-501dfbcb78ef.png) | ![image](https://user-images.githubusercontent.com/390760/84397788-01947600-abf7-11ea-8fc4-0b24ad55feab.png)


#### Testing instructions

* Spin up this PR and open wordpress.com.
* Add `?flags=jetpack/features-section` to your URL.
* Select a Jetpack site.
* Inside the new Jetpack menu, select Scan.
* Ensure the layout looks good in all screen widths.
* Repeat the process above for the cloud and confirm that changes do not break the existing layout.
