### PR TITLE
Jetpack cloud: test settings page components

### DIFF
--- a/client/landing/jetpack-cloud/sections/settings/hooks.ts
+++ b/client/landing/jetpack-cloud/sections/settings/hooks.ts
@@ -1,0 +1,18 @@
+/**
+ * External dependencies
+ */
+import { useSelector } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import getRewindState from 'state/selectors/get-rewind-state';
+import { getSelectedSiteId } from 'state/ui/selectors';
+
+export function useSelectedSiteId() {
+	return useSelector( getSelectedSiteId );
+}
+
+export function useRewindState( siteId: number | string | null ) {
+	return useSelector( ( state ) => getRewindState( state, siteId ) );
+}

--- a/client/landing/jetpack-cloud/sections/settings/main.jsx
+++ b/client/landing/jetpack-cloud/sections/settings/main.jsx
@@ -2,23 +2,21 @@
  * External dependencies
  */
 import React, { useEffect, useState } from 'react';
-import { useSelector } from 'react-redux';
 import { localize, useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import DocumentHead from 'components/data/document-head';
-import { getSelectedSiteId } from 'state/ui/selectors';
 import ServerCredentialsForm from 'components/jetpack/server-credentials-form';
 import { Card } from '@automattic/components';
 import FoldableCard from 'components/foldable-card';
-import getRewindState from 'state/selectors/get-rewind-state';
 import QueryRewindState from 'components/data/query-rewind-state';
 import Main from 'components/main';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import ExternalLink from 'components/external-link';
+import { useSelectedSiteId, useRewindState } from './hooks';
 
 /**
  * Style dependencies
@@ -54,7 +52,7 @@ const disconnectedProps = ( translate ) => ( {
 	),
 } );
 
-const ConnectionStatus = ( { isConnected } ) => {
+export const ConnectionStatus = ( { isConnected } ) => {
 	const translate = useTranslate();
 	const cardProps = isConnected ? connectedProps( translate ) : disconnectedProps( translate );
 
@@ -69,11 +67,10 @@ const ConnectionStatus = ( { isConnected } ) => {
 	);
 };
 
-const SettingsPage = () => {
+export const SettingsPage = () => {
 	const translate = useTranslate();
-	const siteId = useSelector( getSelectedSiteId );
-
-	const rewind = useSelector( ( state ) => getRewindState( state, siteId ) );
+	const siteId = useSelectedSiteId();
+	const rewind = useRewindState( siteId );
 	const isInitialized = rewind.state !== 'uninitialized';
 	const isConnected = rewind.state === 'active';
 

--- a/client/landing/jetpack-cloud/sections/settings/test/__snapshots__/main.js.snap
+++ b/client/landing/jetpack-cloud/sections/settings/test/__snapshots__/main.js.snap
@@ -1,0 +1,186 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ConnectionStatus should render as expected 1`] = `
+<Card
+  className="settings_disconnected"
+  compact={true}
+>
+  <img
+    alt=""
+    className="settings__icon"
+    src="server-disconnected.svg"
+  />
+  <div
+    className="settings__details"
+  >
+    <div
+      className="settings__details-head"
+    >
+       
+      Server status: Not connected
+       
+    </div>
+    <div>
+      Enter your server credentials to enable one-click restores for Backups. 
+      <ExternalLink
+        className="settings__link-external"
+        href="https://jetpack.com/support/adding-credentials-to-jetpack/"
+        icon={true}
+        iconSize={18}
+        key="interpolation-child-1/.0"
+        showIconFirst={false}
+      >
+        Need help? Find your server credentials
+      </ExternalLink>
+    </div>
+  </div>
+</Card>
+`;
+
+exports[`ConnectionStatus should render as expected when connected 1`] = `
+<Card
+  className="settings_connected"
+  compact={true}
+>
+  <img
+    alt=""
+    className="settings__icon"
+    src="server-connected.svg"
+  />
+  <div
+    className="settings__details"
+  >
+    <div
+      className="settings__details-head"
+    >
+       
+      Server status: Connected
+       
+    </div>
+    <div>
+      One-click restores are enabled.
+    </div>
+  </div>
+</Card>
+`;
+
+exports[`SettingsPage should render as expected 1`] = `
+<Main
+  className="settings"
+>
+  <Connect(DocumentHead)
+    title="Settings"
+  />
+  <Connect(MySitesSidebarNavigation) />
+  <Connect(QueryRewindState)
+    siteId={1}
+  />
+  <Connect(PageViewTracker)
+    path="/settings/:site"
+    title="Settings"
+  />
+  <div
+    className="settings__title"
+  >
+    <h2>
+      Server connection details
+    </h2>
+  </div>
+  <ConnectionStatus
+    isConnected={true}
+  />
+  <Localized(FoldableCard)
+    className="settings__form-card"
+    expanded={false}
+    header="Show connection details"
+    onClick={[Function]}
+  >
+    <Connect(ServerCredentialsForm)
+      labels={
+        Object {
+          "save": "Save credentials",
+        }
+      }
+      role="main"
+      showCancelButton={false}
+      siteId={1}
+    />
+  </Localized(FoldableCard)>
+</Main>
+`;
+
+exports[`SettingsPage should render as expected when not connected 1`] = `
+<Main
+  className="settings"
+>
+  <Connect(DocumentHead)
+    title="Settings"
+  />
+  <Connect(MySitesSidebarNavigation) />
+  <Connect(QueryRewindState)
+    siteId={1}
+  />
+  <Connect(PageViewTracker)
+    path="/settings/:site"
+    title="Settings"
+  />
+  <div
+    className="settings__title"
+  >
+    <h2>
+      Server connection details
+    </h2>
+  </div>
+  <ConnectionStatus
+    isConnected={false}
+  />
+  <Localized(FoldableCard)
+    className="settings__form-card"
+    expanded={false}
+    header="Show connection details"
+    onClick={[Function]}
+  >
+    <Connect(ServerCredentialsForm)
+      labels={
+        Object {
+          "save": "Save credentials",
+        }
+      }
+      role="main"
+      showCancelButton={false}
+      siteId={1}
+    />
+  </Localized(FoldableCard)>
+</Main>
+`;
+
+exports[`SettingsPage should render as expected when not initialized 1`] = `
+<Main
+  className="settings"
+>
+  <Connect(DocumentHead)
+    title="Settings"
+  />
+  <Connect(MySitesSidebarNavigation) />
+  <Connect(QueryRewindState)
+    siteId={1}
+  />
+  <Connect(PageViewTracker)
+    path="/settings/:site"
+    title="Settings"
+  />
+  <div
+    className="settings__title"
+  >
+    <h2>
+      Server connection details
+    </h2>
+  </div>
+  <div
+    className="settings__status-uninitialized"
+  />
+  <div
+    className="settings__form-uninitialized"
+  />
+</Main>
+`;

--- a/client/landing/jetpack-cloud/sections/settings/test/main.js
+++ b/client/landing/jetpack-cloud/sections/settings/test/main.js
@@ -1,0 +1,64 @@
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import * as hooks from '../hooks';
+import { SettingsPage, ConnectionStatus } from '../main';
+
+/**
+ * Mocks
+ */
+jest.mock( '../hooks' );
+
+describe( 'SettingsPage', () => {
+	beforeEach( () => {
+		jest.spyOn( hooks, 'useSelectedSiteId' ).mockReturnValue( 1 );
+	} );
+
+	afterAll( () => {
+		jest.restoreAllMocks();
+	} );
+
+	test( 'should render as expected', () => {
+		jest.spyOn( hooks, 'useRewindState' ).mockReturnValue( { state: 'active' } );
+
+		const wrapper = shallow( <SettingsPage /> );
+
+		expect( wrapper ).toMatchSnapshot();
+	} );
+
+	test( 'should render as expected when not connected', () => {
+		jest.spyOn( hooks, 'useRewindState' ).mockReturnValue( { state: 'inactive' } );
+
+		const wrapper = shallow( <SettingsPage /> );
+
+		expect( wrapper ).toMatchSnapshot();
+	} );
+
+	test( 'should render as expected when not initialized', () => {
+		jest.spyOn( hooks, 'useRewindState' ).mockReturnValue( { state: 'uninitialized' } );
+
+		const wrapper = shallow( <SettingsPage /> );
+
+		expect( wrapper ).toMatchSnapshot();
+	} );
+} );
+
+describe( 'ConnectionStatus', () => {
+	test( 'should render as expected', () => {
+		const wrapper = shallow( <ConnectionStatus /> );
+
+		expect( wrapper ).toMatchSnapshot();
+	} );
+
+	test( 'should render as expected when connected', () => {
+		const wrapper = shallow( <ConnectionStatus isConnected /> );
+
+		expect( wrapper ).toMatchSnapshot();
+	} );
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add snapshot testing to the main components of the settings page in Jetpack cloud. Snapshots are useful to make sure a component was not changed inadvertently

#### Implementation notes

* Initial tests couldn't run because `SettingsPage` uses the `useSelector` hook and required to be connected to the state.
* Wrapping the component inside a Redux `Provider` in the tests doesn't allow us to do snapshot testing with [shallow rendering](https://enzymejs.github.io/enzyme/docs/api/shallow.html), since the root component is now the `Provider`.
* [Full DOM rendering](https://enzymejs.github.io/enzyme/docs/api/mount.html) to do snapshot testing is not an option: it makes the tests much more slower and complicated (lots of children components need to be mocked).
* The easiest solution seems to be mocking the access to the state.
* I moved selector hooks in their own file so that they could be mocked (you can't have function you want to test and functions you want to mock in the same module with Jest).
* Using `jest.spyOn( hooks, 'useRewindState' )` instead of `hooks.useRewindState = ...` allows us to use `jest.restoreAllMocks()`. The latter option also triggers linting errors.

#### Testing instructions

1. Download the PR
2. Run `yarn run test-client client/landing/jetpack-cloud/sections/settings/test/main.js`
3. Check that the tests pass
4. Check that the settings page still works as expected
