### PR TITLE
Revert "Stop composite checkout abtest and enable variant" but enable 100% variant

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -37,6 +37,15 @@ export default {
 		defaultVariation: 'hide',
 		allowExistingUsers: true,
 	},
+	showCompositeCheckout: {
+		datestamp: '20200603',
+		variations: {
+			composite: 50,
+			regular: 50,
+		},
+		defaultVariation: 'regular',
+		allowExistingUsers: true,
+	},
 	skipThemesSelectionModal: {
 		datestamp: '20170904',
 		variations: {

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -40,8 +40,8 @@ export default {
 	showCompositeCheckout: {
 		datestamp: '20200603',
 		variations: {
-			composite: 50,
-			regular: 50,
+			composite: 100,
+			regular: 0,
 		},
 		defaultVariation: 'regular',
 		allowExistingUsers: true,

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -38,7 +38,7 @@ export default {
 		allowExistingUsers: true,
 	},
 	showCompositeCheckout: {
-		datestamp: '20200603',
+		datestamp: '20200611',
 		variations: {
 			composite: 100,
 			regular: 0,

--- a/client/my-sites/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout-system-decider.js
@@ -17,6 +17,7 @@ import config from 'config';
 import { getCurrentUserLocale, getCurrentUserCountryCode } from 'state/current-user/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
+import { abtest } from 'lib/abtest';
 import { logToLogstash } from 'state/logstash/actions';
 
 const debug = debugFactory( 'calypso:checkout-system-decider' );
@@ -203,8 +204,18 @@ function getCheckoutVariant(
 		return 'disallowed-product';
 	}
 
-	debug( 'shouldShowCompositeCheckout true' );
-	return 'composite-checkout';
+	if ( config.isEnabled( 'composite-checkout-testing' ) ) {
+		debug( 'shouldShowCompositeCheckout true because testing config is enabled' );
+		return 'composite-checkout';
+	}
+
+	if ( abtest( 'showCompositeCheckout' ) === 'composite' ) {
+		debug( 'shouldShowCompositeCheckout true because user is in abtest' );
+		return 'composite-checkout';
+	}
+
+	debug( 'shouldShowCompositeCheckout false because test not enabled' );
+	return 'test-not-enabled';
 }
 
 function fetchStripeConfigurationWpcom( args ) {


### PR DESCRIPTION
Reverts Automattic/wp-calypso#43163

Also bumps the test date and changes the mix to 100% composite checkout. This should allow e2e tests to continue to run until we update them for composite checkout.