### PR TITLE
Jetpack Cloud: Enable feature flags in jetpack-cloud-stage

### DIFF
--- a/client/config/index.js
+++ b/client/config/index.js
@@ -49,7 +49,13 @@ function applyFlags( flagsString, modificationMethod ) {
 	} );
 }
 
-if ( process.env.NODE_ENV === 'development' || configData.env_id === 'stage' || isCalypsoLive() ) {
+const flagEnvironments = [ 'stage', 'jetpack-cloud-stage' ];
+
+if (
+	process.env.NODE_ENV === 'development' ||
+	flagEnvironments.includes( configData.env_id ) ||
+	isCalypsoLive()
+) {
 	const cookies = cookie.parse( document.cookie );
 
 	if ( cookies.flags ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Allow feature flags to be turned on and off in Jetpack.com's staging environment.

#### Testing instructions

* Verify that feature flags are still functional for your development environment.
* **POST-DEPLOY:** Verify that feature flags are still functional for Calypso staging.
* **POST-DEPLOY:** Verify that feature flags are now also functional for Jetpack.com staging.