### PR TITLE
Account Closure: Warn of Alternative Options

### DIFF
--- a/client/me/account-close/confirm-dialog.jsx
+++ b/client/me/account-close/confirm-dialog.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { Fragment } from 'react';
+import React from 'react';
 import { localize } from 'i18n-calypso';
 import { noop } from 'lodash';
 import { connect } from 'react-redux';
@@ -11,6 +11,7 @@ import page from 'page';
  * Internal dependencies
  */
 import { Dialog, Button } from '@automattic/components';
+import Gridicon from 'components/gridicon';
 import FormLabel from 'components/forms/form-label';
 import InlineSupportLink from 'components/inline-support-link';
 import { getCurrentUser } from 'state/current-user/selectors';
@@ -63,10 +64,44 @@ class AccountCloseConfirmDialog extends React.Component {
 		const { isVisible, currentUsername, translate } = this.props;
 		const isDeleteButtonDisabled = currentUsername && this.state.inputValue !== currentUsername;
 
+		const alternativeOptions = [
+			{
+				text: translate( 'Start a new site' ),
+				href: '/jetpack/new',
+				supportLink:
+					'https://wordpress.com/support/create-a-blog/#adding-a-new-site-or-blog-to-an-existing-account',
+				supportPostId: 3991,
+			},
+			{
+				text: translate( "Change your site's address" ),
+				href: '/settings/general',
+				supportLink: 'https://wordpress.com/support/changing-site-address/',
+				supportPostId: 11280,
+			},
+			{
+				text: translate( 'Change your username' ),
+				href: '/me/account',
+				supportLink: 'https://wordpress.com/support/change-your-username',
+				supportPostId: 2116,
+			},
+			{
+				text: translate( 'Change your password' ),
+				href: '/me/security',
+				supportLink: 'https://wordpress.com/support/passwords/#change-your-password',
+				supportPostId: 89,
+			},
+			{
+				text: translate( 'Delete a site' ),
+				href: '/settings/delete-site',
+				supportLink: 'https://wordpress.com/support/delete-site/',
+				supportPostId: 14411,
+			},
+		];
+
 		const alternativeOptionsButtons = [
 			<Button onClick={ this.handleCancel }>{ translate( 'Cancel' ) }</Button>,
 			<Button primary onClick={ this.handleProceedingToConfirmation }>
-				{ translate( 'Proceed' ) }
+				{ translate( 'Continue' ) }
 			</Button>,
 		];
 
@@ -77,9 +112,6 @@ class AccountCloseConfirmDialog extends React.Component {
 			</Button>,
 		];
 
-		const guideLinkText = translate( 'View a guide' );
-		const actionLinkText = translate( 'Try it' );
-
 		return (
 			<Dialog
 				isVisible={ isVisible }
@@ -88,13 +120,11 @@ class AccountCloseConfirmDialog extends React.Component {
 			>
 				<h1 className="account-close__confirm-dialog-header">
 					{ this.state.displayAlternativeOptions
-						? translate(
-								'Before you close your account, were you looking to do the following instead?'
-						  )
+						? translate( 'Are you sure?' )
 						: translate( 'Confirm account closure' ) }
 				</h1>
 				{ ! this.state.displayAlternativeOptions && (
-					<Fragment>
+					<>
 						<FormLabel
 							htmlFor="confirmAccountCloseInput"
 							className="account-close__confirm-dialog-label"
@@ -121,75 +151,32 @@ class AccountCloseConfirmDialog extends React.Component {
 							aria-required="true"
 							id="confirmAccountCloseInput"
 						/>
-					</Fragment>
+					</>
 				) }
 				{ this.state.displayAlternativeOptions && (
-					<div>
-						<div className="account-close__confirm-dialog-alternative">
-							<p>{ translate( 'Start a new site' ) }</p>
-							<div className="account-close__confirm-dialog-alternative-actions">
-								<InlineSupportLink
-									supportPostId={ 3991 }
-									supportLink="https://wordpress.com/support/create-a-blog/#adding-a-new-site-or-blog-to-an-existing-account"
-									showIcon={ false }
-									text={ guideLinkText }
-								/>
-								<a href="/jetpack/new/">{ actionLinkText }</a>
-							</div>
-						</div>
+					<>
+						<p>
+							{ translate(
+								"Here's a few options to try before you permanently delete your account."
+							) }
+						</p>
 
-						<div className="account-close__confirm-dialog-alternative">
-							<p>{ translate( "Change your site's address" ) }</p>
-							<div className="account-close__confirm-dialog-alternative-actions">
+						{ alternativeOptions.map( ( { text, href, supportLink, supportPostId } ) => (
+							<div className="account-close__confirm-dialog-alternative" key={ href }>
+								<Button href={ href } className="account-close__confirm-dialog-alternative-action">
+									{ text }
+									<Gridicon icon="chevron-right" />
+								</Button>
 								<InlineSupportLink
-									supportPostId={ 11280 }
-									supportLink="https://wordpress.com/support/changing-site-address/"
-									showIcon={ false }
-									text={ guideLinkText }
+									supportPostId={ supportPostId }
+									supportLink={ supportLink }
+									showText={ false }
+									iconSize={ 20 }
+									tracksEvent="calypso_close_account_alternative_clicked"
 								/>
-								<a href="/settings/general">{ actionLinkText }</a>
 							</div>
-						</div>
-
-						<div className="account-close__confirm-dialog-alternative">
-							<p>{ translate( 'Change your username' ) }</p>
-							<div className="account-close__confirm-dialog-alternative-actions">
-								<InlineSupportLink
-									supportPostId={ 2116 }
-									supportLink="https://wordpress.com/support/change-your-username"
-									showIcon={ false }
-									text={ guideLinkText }
-								/>
-								<a href="/me/account">{ actionLinkText }</a>
-							</div>
-						</div>
-
-						<div className="account-close__confirm-dialog-alternative">
-							<p>{ translate( 'Change your password' ) }</p>
-							<div className="account-close__confirm-dialog-alternative-actions">
-								<InlineSupportLink
-									supportPostId={ 89 }
-									supportLink="https://wordpress.com/support/passwords/#change-your-password"
-									showIcon={ false }
-									text={ guideLinkText }
-								/>
-								<a href="/me/security">{ actionLinkText }</a>
-							</div>
-						</div>
-
-						<div className="account-close__confirm-dialog-alternative">
-							<p>{ translate( 'Delete a site' ) }</p>
-							<div className="account-close__confirm-dialog-alternative-actions">
-								<InlineSupportLink
-									supportPostId={ 14411 }
-									supportLink="https://wordpress.com/support/delete-site/"
-									showIcon={ false }
-									text={ guideLinkText }
-								/>
-								<a href="/settings/delete-site">{ actionLinkText }</a>
-							</div>
-						</div>
-					</div>
+						) ) }
+					</>
 				) }
 			</Dialog>
 		);

--- a/client/me/account-close/confirm-dialog.jsx
+++ b/client/me/account-close/confirm-dialog.jsx
@@ -10,6 +10,7 @@ import page from 'page';
 /**
  * Internal dependencies
  */
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Dialog, Button } from '@automattic/components';
 import Gridicon from 'components/gridicon';
 import FormLabel from 'components/forms/form-label';
@@ -60,12 +61,20 @@ class AccountCloseConfirmDialog extends React.Component {
 		page( '/me/account/closed' );
 	};
 
+	handleAlternaticeActionClick = ( evt ) => {
+		recordTracksEvent( 'calypso_close_account_alternative_clicked', {
+			type: 'Action Link',
+			label: evt.target.dataset.tracksLabel,
+		} );
+	};
+
 	render() {
 		const { isVisible, currentUsername, translate } = this.props;
 		const isDeleteButtonDisabled = currentUsername && this.state.inputValue !== currentUsername;
 
 		const alternativeOptions = [
 			{
+				englishText: 'Start a new site',
 				text: translate( 'Start a new site' ),
 				href: '/jetpack/new',
 				supportLink:
@@ -73,24 +82,28 @@ class AccountCloseConfirmDialog extends React.Component {
 				supportPostId: 3991,
 			},
 			{
+				englishText: "Change your site's address",
 				text: translate( "Change your site's address" ),
 				href: '/settings/general',
 				supportLink: 'https://wordpress.com/support/changing-site-address/',
 				supportPostId: 11280,
 			},
 			{
+				englishText: 'Change your username',
 				text: translate( 'Change your username' ),
 				href: '/me/account',
 				supportLink: 'https://wordpress.com/support/change-your-username',
 				supportPostId: 2116,
 			},
 			{
+				englishText: 'Change your password',
 				text: translate( 'Change your password' ),
 				href: '/me/security',
 				supportLink: 'https://wordpress.com/support/passwords/#change-your-password',
 				supportPostId: 89,
 			},
 			{
+				englishText: 'Delete a site',
 				text: translate( 'Delete a site' ),
 				href: '/settings/delete-site',
 				supportLink: 'https://wordpress.com/support/delete-site/',
@@ -161,21 +174,32 @@ class AccountCloseConfirmDialog extends React.Component {
 							) }
 						</p>
 
-						{ alternativeOptions.map( ( { text, href, supportLink, supportPostId } ) => (
-							<div className="account-close__confirm-dialog-alternative" key={ href }>
-								<Button href={ href } className="account-close__confirm-dialog-alternative-action">
-									{ text }
-									<Gridicon icon="chevron-right" />
-								</Button>
-								<InlineSupportLink
-									supportPostId={ supportPostId }
-									supportLink={ supportLink }
-									showText={ false }
-									iconSize={ 20 }
-									tracksEvent="calypso_close_account_alternative_clicked"
-								/>
-							</div>
-						) ) }
+						{ alternativeOptions.map(
+							( { englishText, text, href, supportLink, supportPostId } ) => (
+								<div className="account-close__confirm-dialog-alternative" key={ href }>
+									<Button
+										href={ href }
+										className="account-close__confirm-dialog-alternative-action"
+										onClick={ this.handleAlternaticeActionClick }
+										data-tracks-label={ englishText }
+									>
+										{ text }
+										<Gridicon icon="chevron-right" />
+									</Button>
+									<InlineSupportLink
+										supportPostId={ supportPostId }
+										supportLink={ supportLink }
+										showText={ false }
+										iconSize={ 20 }
+										tracksEvent="calypso_close_account_alternative_clicked"
+										tracksOptions={ {
+											type: 'Support Doc',
+											label: englishText,
+										} }
+									/>
+								</div>
+							)
+						) }
 					</>
 				) }
 			</Dialog>

--- a/client/me/account-close/confirm-dialog.jsx
+++ b/client/me/account-close/confirm-dialog.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Fragment } from 'react';
 import { localize } from 'i18n-calypso';
 import { noop } from 'lodash';
 import { connect } from 'react-redux';
@@ -12,6 +12,7 @@ import page from 'page';
  */
 import { Dialog, Button } from '@automattic/components';
 import FormLabel from 'components/forms/form-label';
+import InlineSupportLink from 'components/inline-support-link';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { closeAccount } from 'state/account/actions';
 
@@ -22,6 +23,7 @@ import './confirm-dialog.scss';
 
 class AccountCloseConfirmDialog extends React.Component {
 	state = {
+		displayAlternativeOptions: true,
 		inputValue: '',
 	};
 
@@ -48,6 +50,10 @@ class AccountCloseConfirmDialog extends React.Component {
 		}
 	};
 
+	handleProceedingToConfirmation = () => {
+		this.setState( { displayAlternativeOptions: false } );
+	};
+
 	handleConfirm = () => {
 		this.props.closeAccount();
 		page( '/me/account/closed' );
@@ -55,50 +61,136 @@ class AccountCloseConfirmDialog extends React.Component {
 
 	render() {
 		const { isVisible, currentUsername, translate } = this.props;
-		const isButtonDisabled = currentUsername && this.state.inputValue !== currentUsername;
+		const isDeleteButtonDisabled = currentUsername && this.state.inputValue !== currentUsername;
+
+		const alternativeOptionsButtons = [
+			<Button onClick={ this.handleCancel }>{ translate( 'Cancel' ) }</Button>,
+			<Button primary onClick={ this.handleProceedingToConfirmation }>
+				{ translate( 'Proceed' ) }
+			</Button>,
+		];
+
 		const deleteButtons = [
 			<Button onClick={ this.handleCancel }>{ translate( 'Cancel' ) }</Button>,
-			<Button primary scary disabled={ isButtonDisabled } onClick={ this.handleConfirm }>
+			<Button primary scary disabled={ isDeleteButtonDisabled } onClick={ this.handleConfirm }>
 				{ translate( 'Close your account' ) }
 			</Button>,
 		];
 
+		const guideLinkText = translate( 'View a guide' );
+		const actionLinkText = translate( 'Try it' );
+
 		return (
 			<Dialog
 				isVisible={ isVisible }
-				buttons={ deleteButtons }
+				buttons={ this.state.displayAlternativeOptions ? alternativeOptionsButtons : deleteButtons }
 				className="account-close__confirm-dialog"
 			>
 				<h1 className="account-close__confirm-dialog-header">
-					{ translate( 'Confirm account closure' ) }
+					{ this.state.displayAlternativeOptions
+						? translate(
+								'Before you close your account, were you looking to do the following instead?'
+						  )
+						: translate( 'Confirm account closure' ) }
 				</h1>
-				<FormLabel
-					htmlFor="confirmAccountCloseInput"
-					className="account-close__confirm-dialog-label"
-				>
-					{ translate(
-						'Please type {{warn}}%(currentUsername)s{{/warn}} in the field below to confirm. ' +
-							'Your account will then be gone forever.',
-						{
-							components: {
-								warn: <span className="account-close__confirm-dialog-target-username" />,
-							},
-							args: {
-								currentUsername,
-							},
-						}
-					) }
-				</FormLabel>
+				{ ! this.state.displayAlternativeOptions && (
+					<Fragment>
+						<FormLabel
+							htmlFor="confirmAccountCloseInput"
+							className="account-close__confirm-dialog-label"
+						>
+							{ translate(
+								'Please type {{warn}}%(currentUsername)s{{/warn}} in the field below to confirm. ' +
+									'Your account will then be gone forever.',
+								{
+									components: {
+										warn: <span className="account-close__confirm-dialog-target-username" />,
+									},
+									args: {
+										currentUsername,
+									},
+								}
+							) }
+						</FormLabel>
+						<input
+							autoCapitalize="off"
+							className="account-close__confirm-dialog-confirm-input"
+							type="text"
+							onChange={ this.handleInputChange }
+							value={ this.state.inputValue }
+							aria-required="true"
+							id="confirmAccountCloseInput"
+						/>
+					</Fragment>
+				) }
+				{ this.state.displayAlternativeOptions && (
+					<div>
+						<div className="account-close__confirm-dialog-alternative">
+							<p>{ translate( 'Start a new site' ) }</p>
+							<div className="account-close__confirm-dialog-alternative-actions">
+								<InlineSupportLink
+									supportPostId={ 3991 }
+									supportLink="https://wordpress.com/support/create-a-blog/#adding-a-new-site-or-blog-to-an-existing-account"
+									showIcon={ false }
+									text={ guideLinkText }
+								/>
+								<a href="/jetpack/new/">{ actionLinkText }</a>
+							</div>
+						</div>
 
-				<input
-					autoCapitalize="off"
-					className="account-close__confirm-dialog-confirm-input"
-					type="text"
-					onChange={ this.handleInputChange }
-					value={ this.state.inputValue }
-					aria-required="true"
-					id="confirmAccountCloseInput"
-				/>
+						<div className="account-close__confirm-dialog-alternative">
+							<p>{ translate( "Change your site's address" ) }</p>
+							<div className="account-close__confirm-dialog-alternative-actions">
+								<InlineSupportLink
+									supportPostId={ 11280 }
+									supportLink="https://wordpress.com/support/changing-site-address/"
+									showIcon={ false }
+									text={ guideLinkText }
+								/>
+								<a href="/settings/general">{ actionLinkText }</a>
+							</div>
+						</div>
+
+						<div className="account-close__confirm-dialog-alternative">
+							<p>{ translate( 'Change your username' ) }</p>
+							<div className="account-close__confirm-dialog-alternative-actions">
+								<InlineSupportLink
+									supportPostId={ 2116 }
+									supportLink="https://wordpress.com/support/change-your-username"
+									showIcon={ false }
+									text={ guideLinkText }
+								/>
+								<a href="/me/account">{ actionLinkText }</a>
+							</div>
+						</div>
+
+						<div className="account-close__confirm-dialog-alternative">
+							<p>{ translate( 'Change your password' ) }</p>
+							<div className="account-close__confirm-dialog-alternative-actions">
+								<InlineSupportLink
+									supportPostId={ 89 }
+									supportLink="https://wordpress.com/support/passwords/#change-your-password"
+									showIcon={ false }
+									text={ guideLinkText }
+								/>
+								<a href="/me/security">{ actionLinkText }</a>
+							</div>
+						</div>
+
+						<div className="account-close__confirm-dialog-alternative">
+							<p>{ translate( 'Delete a site' ) }</p>
+							<div className="account-close__confirm-dialog-alternative-actions">
+								<InlineSupportLink
+									supportPostId={ 14411 }
+									supportLink="https://wordpress.com/support/delete-site/"
+									showIcon={ false }
+									text={ guideLinkText }
+								/>
+								<a href="/settings/delete-site">{ actionLinkText }</a>
+							</div>
+						</div>
+					</div>
+				) }
 			</Dialog>
 		);
 	}

--- a/client/me/account-close/confirm-dialog.scss
+++ b/client/me/account-close/confirm-dialog.scss
@@ -14,16 +14,23 @@ h1.account-close__confirm-dialog-header {
 }
 
 .account-close__confirm-dialog-alternative {
-	margin-bottom: 14px;
+	margin-bottom: 8px;
+	display: flex;
+	align-items: center;
 
-	p {
-		margin-bottom: 0;
+	.inline-support-link {
+		font-size: $font-body-small;
+		margin-left: 12px;
 	}
 }
 
-.account-close__confirm-dialog-alternative-actions a {
-	font-size: $font-body-small;
-	margin-right: 8px;
+.account-close__confirm-dialog-alternative-action {
+	flex: 1;
+	display: flex;
+
+	.gridicon {
+		margin-left: auto;
+	}
 }
 
 .account-close__confirm-dialog-label {

--- a/client/me/account-close/confirm-dialog.scss
+++ b/client/me/account-close/confirm-dialog.scss
@@ -13,6 +13,19 @@ h1.account-close__confirm-dialog-header {
 	color: var( --color-neutral-70 );
 }
 
+.account-close__confirm-dialog-alternative {
+	margin-bottom: 14px;
+
+	p {
+		margin-bottom: 0;
+	}
+}
+
+.account-close__confirm-dialog-alternative-actions a {
+	font-size: $font-body-small;
+	margin-right: 8px;
+}
+
 .account-close__confirm-dialog-label {
 	margin-bottom: 8px;
 	line-height: 24px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Provides a series of alternatives in the dialog confirming the deletion of your account

#### Testing instructions

Visit `/me/account/close` and trigger the dialog to close your account. Verify that the dialog looks okay, and that the links work for each option by either triggering a support dialog or redirecting you to the page where you can "try it". 

Clicking the "Proceed" primary button should take you to the current screen where you can enter your username to confirm account deletion. 

<img width="1223" alt="Screenshot 2020-06-11 at 21 03 59" src="https://user-images.githubusercontent.com/43215253/84434104-52bc5e00-ac27-11ea-9c15-63fa5a0aaf68.png">

cc @bluefuton

Fixes #43211
