### PR TITLE
Composite checkout: Fix missing border

### DIFF
--- a/packages/composite-checkout/src/components/button.js
+++ b/packages/composite-checkout/src/components/button.js
@@ -38,7 +38,7 @@ const CallToAction = styled.button`
 	border-radius: ${ ( props ) => ( props.buttonType === 'paypal' ? '50px' : '2px' ) };
 	padding: ${ ( props ) => ( props.buttonType === 'text-button' ? '0' : '10px 15px' ) };
 	border: ${ ( props ) =>
-		! props.buttonType ? '1px solid ' + props.theme.colors.borderColor : '0' };
+		! props.buttonType || props.disabled ? '1px solid ' + props.theme.colors.borderColor : '0' };
 	background: ${ getBackgroundColor };
 	color: ${ getTextColor };
 	font-weight: ${ getFontWeight };
@@ -47,7 +47,7 @@ const CallToAction = styled.button`
 	:hover {
 		background: ${ getRollOverColor };
 		border-color: ${ ( props ) =>
-			! props.buttonType ? props.theme.colors.borderColorDark : 'transparent' };
+			! props.buttonType ? props.theme.colors.borderColorDark : 'inherit' };
 		text-decoration: none;
 		color: ${ getTextColor };
 		cursor: ${ ( props ) => ( props.disabled ? 'not-allowed' : 'pointer' ) };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes a missing border on the disabled checkout button.

Before:

![image](https://user-images.githubusercontent.com/6981253/84438756-10822500-ac05-11ea-81f1-ae769686041d.png)


After:
![image](https://user-images.githubusercontent.com/6981253/84438738-08c28080-ac05-11ea-84f8-6fceee1bf8df.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load up the new composite checkout
* Check that the pay button has a border when disabled.


