### PR TITLE
FSE: Add Newspack assets unit tests

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/phpunit/bootstrap.php
+++ b/apps/full-site-editing/full-site-editing-plugin/phpunit/bootstrap.php
@@ -12,7 +12,6 @@ require_once dirname( dirname( __FILE__ ) ) . '/vendor/autoload.php';
 
 $_tests_dir = getenv( 'WP_PHPUNIT__DIR' );
 
-
 if ( ! $_tests_dir ) {
 	throw new Exception( 'Could not find the WordPress test lib.' );
 }
@@ -59,3 +58,6 @@ require $_tests_dir . '/includes/bootstrap.php';
 
 // Use existing behavior for wp_die during actual test execution.
 remove_filter( 'wp_die_handler', 'fail_if_died' );
+
+// Don't let deprecation notices cause tests to fail.
+PHPUnit\Framework\Error\Deprecated::$enabled = false;

--- a/apps/full-site-editing/full-site-editing-plugin/phpunit/class-newspack-test.php
+++ b/apps/full-site-editing/full-site-editing-plugin/phpunit/class-newspack-test.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Newspack Tests file.
+ *
+ * @package full-site-editing-plugin
+ */
+
+namespace A8C\FSE;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class NewsPack_Test.
+ */
+class NewsPack_Test extends TestCase {
+
+	/**
+	 * Tests that required block assets are enqueued.
+	 */
+	public function test_carousel_assets_enqueued() {
+		ob_start();
+		newspack_blocks_render_block_carousel(
+			array(
+				'postsToShow' => 3,
+			)
+		);
+		ob_end_flush();
+
+		$this->assertTrue( wp_script_is( 'carousel-block-view' ) );
+		$this->assertTrue( wp_style_is( 'carousel-block-view' ) );
+	}
+
+	/**
+	 * Tests that required block assets are enqueued.
+	 */
+	public function test_blog_posts_assets_enqueued() {
+		ob_start();
+		newspack_blocks_render_block_homepage_articles(
+			array(
+				'customTextColor' => '',
+				'postsToShow'     => 3,
+				'showCaption'     => false,
+				'showCategory'    => false,
+				'showImage'       => false,
+				'specificMode'    => 0,
+				'textColor'       => '',
+			)
+		);
+		ob_end_flush();
+
+		$this->assertTrue( wp_script_is( 'blog-posts-block-view' ) );
+		$this->assertTrue( wp_style_is( 'blog-posts-block-view' ) );
+	}
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Adds unit tests to make sure Newspack assets are enqueued when needed.

These tests would have caught the missing assets in FSE 1.7 (/cc @jmdodd)

#### Testing instructions
To run phpunit tests:
```sh
# First, make sure you've installed composer deps in wp-calypso root:
composer install

# Make sure other deps are up to date
yarn

# Go to FSE plugin:
cd apps/full-site-editing

# Build required assets.
yarn run build

# Start wp-env
npx wp-env start
 
# Run test command
yarn test:php
```


