### PR TITLE
Donations: Add a Tracks event for plan upgrades.

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/delegate-event-tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/delegate-event-tracking.js
@@ -8,6 +8,7 @@ import debugFactory from 'debug';
  */
 import wpcomBlockEditorCloseClick from './wpcom-block-editor-close-click';
 import wpcomInserterInlineSearchTerm from './wpcom-inserter-inline-search-term';
+import wpcomBlockDonationsPlanUpgrade from './wpcom-block-donations-plan-upgrade';
 import wpcomBlockPremiumContentPlanUpgrade from './wpcom-block-premium-content-plan-upgrade';
 import wpcomBlockPremiumContentStripeConnect from './wpcom-block-premium-content-stripe-connect';
 
@@ -23,6 +24,7 @@ const debug = debugFactory( 'wpcom-block-editor:tracking' );
 const EVENTS_MAPPING = [
 	wpcomBlockEditorCloseClick(),
 	wpcomInserterInlineSearchTerm(),
+	wpcomBlockDonationsPlanUpgrade(),
 	wpcomBlockPremiumContentPlanUpgrade(),
 	wpcomBlockPremiumContentStripeConnect(),
 ];

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-donations-plan-upgrade.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-donations-plan-upgrade.js
@@ -1,0 +1,15 @@
+/**
+ * Internal dependencies
+ */
+import tracksRecordEvent from './track-record-event';
+
+/**
+ * Return the event definition object to track `wpcom_block_donations_upgrade_click`.
+ *
+ * @returns {{handler: Function, selector: string, type: string}} event object definition.
+ */
+export default () => ( {
+	selector: '.wp-block[data-type="a8c/donations"] .plan-nudge__button',
+	type: 'click',
+	handler: () => tracksRecordEvent( 'wpcom_block_donations_plan_upgrade_click' ),
+} );


### PR DESCRIPTION
Let's add a Tracks event for when users of the Donations block click on the "upgrade plan" button.

#### Testing instructions

* Create a new free Simple site, and sticker it with `fse-donations-block` (can also be done from the site's blog RC).
* Apply this branch to your local Calypso install. You do _not_ need Calypso running to test this PR.
* Sandbox the following: the API, `widgets.wp.com`, and your new test site.
* Sync the FSE plugin to your sandbox: run `yarn dev --sync` from `/apps/full-site-editing`.
* Build the WP.com block editor app: `npx lerna run build --scope='@automattic/wpcom-block-editor'`
* Sync the block editor app build to your sandbox (`scp -rp apps/wpcom-block-editor/dist/* <sandbox-hostname>:public_html/widgets.wp.com/wpcom-block-editor/` from the Calypso root should work – make sure to use a valid hostname or IP for your sandbox).
* Open a new tab and open DevTools.
* Enable console monitoring of our Tracks events with `localStorage.setItem( 'debug', 'wpcom-block-editor:*' );`.
* Check "Preserve log" in the Console panel settings.
* Open `/wp-admin/post-new.php` on your new test site.
* Add the Donations block.
* Click the "Upgrade your plan" button and complete the process.
* Back in the editor tab, verify a Tracks event for `wpcom_block_donations_plan_upgrade_click`.

