### PR TITLE
Add placeholder to site title input

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
@@ -28,9 +28,6 @@ interface Props {
 	onSubmit: () => void;
 }
 
-const translationContext =
-	'This is an example of a site name, feel free to create your own but please keep it under 22 characters';
-
 const SiteTitle: React.FunctionComponent< Props > = ( { skipButton, onSubmit } ) => {
 	const { __ } = useI18n();
 	const { siteTitle } = useSelect( ( select ) => select( STORE_KEY ).getState() );
@@ -57,11 +54,26 @@ const SiteTitle: React.FunctionComponent< Props > = ( { skipButton, onSubmit } )
 
 	const placeHolder = useTyper(
 		[
-			_x( 'In Focus Photographers', translationContext ),
-			_x( 'Cortado Coffee SF', 'This is an example of a site name', translationContext ),
-			_x( 'Leah Rand', 'This is an example of a site name', translationContext ),
-			_x( 'Ava Young', 'This is an example of a site name', translationContext ),
-			_x( 'Mighty Leaf Tea Room', 'This is an example of a site name', translationContext ),
+			_x(
+				'In Focus Photographers',
+				'This is an example of a site name, feel free to create your own but please keep it under 22 characters'
+			),
+			_x(
+				'Cortado Coffee SF',
+				'This is an example of a site name, feel free to create your own but please keep it under 22 characters'
+			),
+			_x(
+				'Leah Rand',
+				'This is an example of a site name, feel free to create your own but please keep it under 22 characters'
+			),
+			_x(
+				'Ava Young',
+				'This is an example of a site name, feel free to create your own but please keep it under 22 characters'
+			),
+			_x(
+				'Mighty Leaf Tea Room',
+				'This is an example of a site name, feel free to create your own but please keep it under 22 characters'
+			),
 		],
 		! siteTitle,
 		{

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
@@ -47,26 +47,21 @@ const SiteTitle: React.FunctionComponent< Props > = ( { onSubmit } ) => {
 
 	const placeHolder = useTyper(
 		[
-			_x(
-				'In Focus Photographers',
-				'This is an example of a site name, feel free to create your own but please keep it under 22 characters'
-			),
-			_x(
-				'Cortado Coffee SF',
-				'This is an example of a site name, feel free to create your own but please keep it under 22 characters'
-			),
-			_x(
-				'Leah Rand',
-				'This is an example of a site name, feel free to create your own but please keep it under 22 characters'
-			),
-			_x(
-				'Ava Young',
-				'This is an example of a site name, feel free to create your own but please keep it under 22 characters'
-			),
-			_x(
-				'Mighty Leaf Tea Room',
-				'This is an example of a site name, feel free to create your own but please keep it under 22 characters'
-			),
+			/* translators: This is an example of a site name,
+			   feel free to create your own but please keep it under 22 characters */
+			_x( 'In Focus Photographers', 'sample site title' ),
+			/* translators: This is an example of a site name,
+			   feel free to create your own but please keep it under 22 characters */
+			_x( 'Cortado Coffee SF', 'sample site title' ),
+			/* translators: This is an example of a site name,
+			   feel free to create your own but please keep it under 22 characters */
+			_x( 'Leah Rand', 'sample site title' ),
+			/* translators: This is an example of a site name,
+			   feel free to create your own but please keep it under 22 characters */
+			_x( 'Ava Young', 'sample site title' ),
+			/* translators: This is an example of a site name,
+			   feel free to create your own but please keep it under 22 characters */
+			_x( 'Mighty Leaf Tea Room', 'sample site title' ),
 		],
 		! siteTitle,
 		{

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
@@ -5,30 +5,23 @@ import * as React from 'react';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { TextControl } from '@wordpress/components';
 import { useI18n } from '@automattic/react-i18n';
-<<<<<<< HEAD
 import { Icon } from '@wordpress/icons';
 import classnames from 'classnames';
-=======
 import { _x } from '@wordpress/i18n';
->>>>>>> Add placeholder to site title input
 
 /**
  * Internal dependencies
  */
 import { STORE_KEY } from '../../stores/onboard';
 import { recordSiteTitleSelection } from '../../lib/analytics';
-<<<<<<< HEAD
 import tip from './tip';
 
-=======
 import useTyper from '../../hooks/use-typer';
->>>>>>> Add placeholder to site title input
 interface Props {
-	skipButton: React.ReactNode;
 	onSubmit: () => void;
 }
 
-const SiteTitle: React.FunctionComponent< Props > = ( { skipButton, onSubmit } ) => {
+const SiteTitle: React.FunctionComponent< Props > = ( { onSubmit } ) => {
 	const { __ } = useI18n();
 	const { siteTitle } = useSelect( ( select ) => select( STORE_KEY ).getState() );
 	const { setSiteTitle } = useDispatch( STORE_KEY );

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
@@ -49,19 +49,19 @@ const SiteTitle: React.FunctionComponent< Props > = ( { onSubmit } ) => {
 		[
 			/* translators: This is an example of a site name,
 			   feel free to create your own but please keep it under 22 characters */
-			_x( 'In Focus Photographers', 'sample site title' ),
+			_x( 'Paul’s Tennis Blog', 'sample site title' ),
 			/* translators: This is an example of a site name,
 			   feel free to create your own but please keep it under 22 characters */
-			_x( 'Cortado Coffee SF', 'sample site title' ),
+			_x( 'Colorado Consulting', 'sample site title' ),
 			/* translators: This is an example of a site name,
 			   feel free to create your own but please keep it under 22 characters */
-			_x( 'Leah Rand', 'sample site title' ),
+			_x( 'Mumbai Bites', 'sample site title' ),
 			/* translators: This is an example of a site name,
 			   feel free to create your own but please keep it under 22 characters */
-			_x( 'Ava Young', 'sample site title' ),
+			_x( 'Ava’s Photography', 'sample site title' ),
 			/* translators: This is an example of a site name,
 			   feel free to create your own but please keep it under 22 characters */
-			_x( 'Mighty Leaf Tea Room', 'sample site title' ),
+			_x( 'Ray’s Top Toy Store', 'sample site title' ),
 		],
 		! siteTitle,
 		{

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
@@ -21,6 +21,58 @@ interface Props {
 	onSubmit: () => void;
 }
 
+/**
+ * Shuffles an array in place
+ *
+ * @param arr the array to shuffle
+ */
+function shuffle( arr: string[] ) {
+	return arr.sort( () => ( Math.random() > 0.5 ? -1 : 1 ) );
+}
+
+/* we have them outside ot the component to avoid re-shuffling on every render */
+const siteTitleExamples = shuffle( [
+	/* translators: This is an example of a site name,
+	   feel free to create your own but please keep it under 22 characters */
+	_x( 'The Local Latest', 'sample site title' ),
+	/* translators: This is an example of a site name,
+	   feel free to create your own but please keep it under 22 characters */
+	_x( 'North Peak Cycling', 'sample site title' ),
+	/* translators: This is an example of a site name,
+	   feel free to create your own but please keep it under 22 characters */
+	_x( 'Sunshine Daycare', 'sample site title' ),
+	/* translators: This is an example of a site name,
+	   feel free to create your own but please keep it under 22 characters */
+	_x( 'Quick Wins Consulting', 'sample site title' ),
+	/* translators: This is an example of a site name,
+	   feel free to create your own but please keep it under 22 characters */
+	_x( 'Puns and Pedantry', 'sample site title' ),
+	/* translators: This is an example of a site name,
+	   feel free to create your own but please keep it under 22 characters */
+	_x( 'Yoga For Everyone', 'sample site title' ),
+	/* translators: This is an example of a site name,
+	   feel free to create your own but please keep it under 22 characters */
+	_x( 'Pugs Wearing Bowties', 'sample site title' ),
+	/* translators: This is an example of a site name,
+	   feel free to create your own but please keep it under 22 characters */
+	_x( 'Behind the Lens', 'sample site title' ),
+	/* translators: This is an example of a site name,
+	   feel free to create your own but please keep it under 22 characters */
+	_x( 'Marketing Magic', 'sample site title' ),
+	/* translators: This is an example of a site name,
+	   feel free to create your own but please keep it under 22 characters */
+	_x( 'Cortado Coffee', 'sample site title' ),
+	/* translators: This is an example of a site name,
+	   feel free to create your own but please keep it under 22 characters */
+	_x( 'Mumbai Bites', 'sample site title' ),
+	/* translators: This is an example of a site name,
+	   feel free to create your own but please keep it under 22 characters */
+	_x( 'RPM Motors', 'sample site title' ),
+	/* translators: This is an example of a site name,
+	   feel free to create your own but please keep it under 22 characters */
+	_x( 'Max’s Burger Bar', 'sample site title' ),
+] );
+
 const SiteTitle: React.FunctionComponent< Props > = ( { onSubmit } ) => {
 	const { __ } = useI18n();
 	const { siteTitle } = useSelect( ( select ) => select( STORE_KEY ).getState() );
@@ -45,29 +97,9 @@ const SiteTitle: React.FunctionComponent< Props > = ( { onSubmit } ) => {
 	// translators: label for site title input in Gutenboarding
 	const inputLabel = __( 'My site is called' );
 
-	const placeHolder = useTyper(
-		[
-			/* translators: This is an example of a site name,
-			   feel free to create your own but please keep it under 22 characters */
-			_x( 'Paul’s Tennis Blog', 'sample site title' ),
-			/* translators: This is an example of a site name,
-			   feel free to create your own but please keep it under 22 characters */
-			_x( 'Colorado Consulting', 'sample site title' ),
-			/* translators: This is an example of a site name,
-			   feel free to create your own but please keep it under 22 characters */
-			_x( 'Mumbai Bites', 'sample site title' ),
-			/* translators: This is an example of a site name,
-			   feel free to create your own but please keep it under 22 characters */
-			_x( 'Ava’s Photography', 'sample site title' ),
-			/* translators: This is an example of a site name,
-			   feel free to create your own but please keep it under 22 characters */
-			_x( 'Ray’s Top Toy Store', 'sample site title' ),
-		],
-		! siteTitle,
-		{
-			delayBetweenCharacters: 70,
-		}
-	);
+	const placeHolder = useTyper( siteTitleExamples, ! siteTitle, {
+		delayBetweenCharacters: 70,
+	} );
 
 	return (
 		<form

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
@@ -5,21 +5,33 @@ import * as React from 'react';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { TextControl } from '@wordpress/components';
 import { useI18n } from '@automattic/react-i18n';
+<<<<<<< HEAD
 import { Icon } from '@wordpress/icons';
 import classnames from 'classnames';
+=======
+import { _x } from '@wordpress/i18n';
+>>>>>>> Add placeholder to site title input
 
 /**
  * Internal dependencies
  */
 import { STORE_KEY } from '../../stores/onboard';
 import { recordSiteTitleSelection } from '../../lib/analytics';
+<<<<<<< HEAD
 import tip from './tip';
 
+=======
+import useTyper from '../../hooks/use-typer';
+>>>>>>> Add placeholder to site title input
 interface Props {
+	skipButton: React.ReactNode;
 	onSubmit: () => void;
 }
 
-const SiteTitle: React.FunctionComponent< Props > = ( { onSubmit } ) => {
+const translationContext =
+	'This is an example of a site name, feel free to create your own but please keep it under 22 characters';
+
+const SiteTitle: React.FunctionComponent< Props > = ( { skipButton, onSubmit } ) => {
 	const { __ } = useI18n();
 	const { siteTitle } = useSelect( ( select ) => select( STORE_KEY ).getState() );
 	const { setSiteTitle } = useDispatch( STORE_KEY );
@@ -43,6 +55,20 @@ const SiteTitle: React.FunctionComponent< Props > = ( { onSubmit } ) => {
 	// translators: label for site title input in Gutenboarding
 	const inputLabel = __( 'My site is called' );
 
+	const placeHolder = useTyper(
+		[
+			_x( 'In Focus Photographers', translationContext ),
+			_x( 'Cortado Coffee SF', 'This is an example of a site name', translationContext ),
+			_x( 'Leah Rand', 'This is an example of a site name', translationContext ),
+			_x( 'Ava Young', 'This is an example of a site name', translationContext ),
+			_x( 'Mighty Leaf Tea Room', 'This is an example of a site name', translationContext ),
+		],
+		! siteTitle,
+		{
+			delayBetweenCharacters: 70,
+		}
+	);
+
 	return (
 		<form
 			className={ classnames( 'site-title', { 'is-focused': isFocused, 'is-empty': ! siteTitle } ) }
@@ -52,7 +78,12 @@ const SiteTitle: React.FunctionComponent< Props > = ( { onSubmit } ) => {
 				{ inputLabel }
 			</label>
 			<div className="site-title__input-wrapper">
+				{ /* Adding key makes it more performant
+					because without it the element is recreated
+					for every letter in the typing animation
+					*/ }
 				<TextControl
+					key="site-title__input"
 					id="site-title__input"
 					className="site-title__input"
 					onChange={ setSiteTitle }
@@ -62,6 +93,7 @@ const SiteTitle: React.FunctionComponent< Props > = ( { onSubmit } ) => {
 					autoFocus // eslint-disable-line jsx-a11y/no-autofocus
 					spellCheck={ false }
 					autoComplete="off"
+					placeholder={ placeHolder }
 					autoCorrect="off"
 					data-hj-whitelist
 				></TextControl>

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
@@ -142,6 +142,10 @@
 			outline: none;
 		}
 
+		&::-ms-clear {
+			display: none;
+		}
+
 		@include break-small {
 			@include onboarding-heading-text;
 		}

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
@@ -59,7 +59,7 @@
 
 	@include break-medium {
 		height: 80px;
-		max-width: 500px;
+		max-width: 750px;
 	}
 }
 

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
@@ -37,6 +37,8 @@
 }
 
 .site-title__input-label {
+	line-height: 1.4em;
+	
 	@include break-small {
 		// stylelint-disable-next-line unit-whitelist
 		margin-right: 0.4ch;
@@ -150,6 +152,11 @@
 
 		@include break-medium {
 			font-size: 64px;
+		}
+
+		&::placeholder {
+			color: $light-gray-700;
+			line-height: normal;
 		}
 	}
 }

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
@@ -25,7 +25,6 @@
 		margin: 0 -88px; // override block margins
 		padding: 12px 170px 0;
 		font-size: 64px;
-		line-height: 80px;
 	}
 }
 
@@ -130,7 +129,6 @@
 
 	input[type='text'].components-text-control__input {
 		@include onboarding-heading-text-mobile;
-		line-height: 1em;
 		height: auto;
 		background: transparent;
 		border: none;
@@ -152,7 +150,6 @@
 
 		@include break-medium {
 			font-size: 64px;
-			line-height: 80px;
 		}
 	}
 }

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
@@ -142,10 +142,6 @@
 			outline: none;
 		}
 
-		&::-ms-clear {
-			display: none;
-		}
-
 		@include break-small {
 			@include onboarding-heading-text;
 		}
@@ -157,6 +153,10 @@
 		&::placeholder {
 			color: $light-gray-700;
 			line-height: normal;
+		}
+
+		&::-ms-clear {
+			display: none;
 		}
 	}
 }

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
@@ -38,7 +38,7 @@
 
 .site-title__input-label {
 	line-height: 1.4em;
-	
+
 	@include break-small {
 		// stylelint-disable-next-line unit-whitelist
 		margin-right: 0.4ch;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- [x] Add back site title placeholder
- [x] Test in mobiles
- [x] Randomize 

#### Testing results
- ✅  Safari and Chrome on iOS 13
- ✅  IE11
- ✅  FF desktop and FF Android
- ✅  Samsung Internet

Worth noting that this is pretty robust since it just uses "placeholder" prop that is natively supported pretty much everywhere.

Fixes https://github.com/Automattic/wp-calypso/issues/43191
