### PR TITLE
Add social login information to security checkup

### DIFF
--- a/client/me/security-checkup/index.jsx
+++ b/client/me/security-checkup/index.jsx
@@ -18,6 +18,7 @@ import SecurityCheckupAccountEmail from './account-email';
 import SecurityCheckupAccountRecoveryEmail from './account-recovery-email';
 import SecurityCheckupAccountRecoveryPhone from './account-recovery-phone';
 import SecurityCheckupConnectedApplications from './connected-applications';
+import SecurityCheckupSocialLogins from './social-logins';
 import SecurityCheckupTwoFactorAuthentication from './two-factor-authentication';
 import SecurityCheckupTwoFactorBackupCodes from './two-factor-backup-codes';
 import SecuritySectionNav from 'me/security-section-nav';
@@ -70,6 +71,7 @@ class SecurityCheckupComponent extends React.Component {
 					<SecurityCheckupTwoFactorBackupCodes />
 					<SecurityCheckupAccountRecoveryEmail />
 					<SecurityCheckupAccountRecoveryPhone />
+					<SecurityCheckupSocialLogins />
 					<SecurityCheckupConnectedApplications />
 				</VerticalNav>
 			</Main>

--- a/client/me/security-checkup/social-logins.jsx
+++ b/client/me/security-checkup/social-logins.jsx
@@ -1,0 +1,64 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { getCurrentUser } from 'state/current-user/selectors';
+import SecurityCheckupNavigationItem from './navigation-item';
+import { getOKIcon, getWarningIcon } from './icons.js';
+
+class SecurityCheckupSocialLogins extends React.Component {
+	static propTypes = {
+		socialConnections: PropTypes.number.isRequired,
+		translate: PropTypes.func.isRequired,
+	};
+
+	render() {
+		const { socialConnectionCount, translate } = this.props;
+
+		let description, icon;
+
+		if ( socialConnectionCount === 0 ) {
+			icon = getOKIcon();
+			description = translate( 'You do not have any social logins enabled.' );
+		} else {
+			icon = getWarningIcon();
+			description = translate(
+				'You have {{strong}}%(socialLoginCount)d social login enabled{{/strong}}.',
+				'You have {{strong}}%(socialLoginCount)d social logins enabled{{/strong}}.',
+				{
+					count: socialConnectionCount,
+					args: {
+						socialLoginCount: socialConnectionCount,
+					},
+					components: {
+						strong: <strong />,
+					},
+				}
+			);
+		}
+
+		return (
+			<SecurityCheckupNavigationItem
+				description={ description }
+				materialIcon={ icon }
+				path="/me/security/social-login"
+				text={ translate( 'Social Logins' ) }
+			/>
+		);
+	}
+}
+
+export default connect( ( state ) => {
+	const currentUser = getCurrentUser( state );
+	const connections = currentUser.social_login_connections || [];
+	return {
+		socialConnectionCount: connections.length,
+	};
+} )( localize( SecurityCheckupSocialLogins ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR expands on the work from #43101 and #43142 and adds a basic list of the number of social logins that a user has enabled.

<img width="944" alt="Screenshot 2020-06-12 at 13 52 20" src="https://user-images.githubusercontent.com/3376401/84500175-4e8a5200-acb4-11ea-9929-57905bc4c996.png">


#### Testing instructions

* Open the UI via a local build or calypso.live and navigate to `/me/security`.
* If you're using calypso.live, manually add `?flags=security/security-checkup` to the URL.
* Select the "Security Checkup" option in the nav dropdown/menu.
* Verify that the "Social Logins" item appears and shows the correct number of connected logins.
* Click on the "Social Logins" row and ensure that you end up in the Social Login UI.

Part of the work for #26874.