### PR TITLE
Fetch up to 2000 list items, refactor list edit components

### DIFF
--- a/client/blocks/reader-export-button/index.jsx
+++ b/client/blocks/reader-export-button/index.jsx
@@ -25,6 +25,7 @@ import './style.scss';
 
 class ReaderExportButton extends React.Component {
 	static propTypes = {
+		disabled: PropTypes.bool,
 		exportType: PropTypes.oneOf( [ READER_EXPORT_TYPE_SUBSCRIPTIONS, READER_EXPORT_TYPE_LIST ] ),
 		filename: PropTypes.string,
 		listId: PropTypes.number, // only when exporting a list
@@ -33,6 +34,7 @@ class ReaderExportButton extends React.Component {
 	static defaultProps = {
 		filename: 'reader-export.opml',
 		exportType: READER_EXPORT_TYPE_SUBSCRIPTIONS,
+		disabled: false,
 	};
 
 	state = { disabled: false };
@@ -72,7 +74,11 @@ class ReaderExportButton extends React.Component {
 
 	render() {
 		return (
-			<button className="reader-export-button" onClick={ this.onClick }>
+			<button
+				className="reader-export-button"
+				onClick={ this.onClick }
+				disabled={ this.props.disabled || this.state.disabled }
+			>
 				<Gridicon icon="cloud-download" className="reader-export-button__icon" />
 				<span className="reader-export-button__label">{ this.props.translate( 'Export' ) }</span>
 			</button>

--- a/client/blocks/reader-export-button/index.jsx
+++ b/client/blocks/reader-export-button/index.jsx
@@ -6,6 +6,7 @@ import React from 'react';
 import { saveAs } from 'browser-filesaver';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -41,7 +42,7 @@ class ReaderExportButton extends React.Component {
 
 	onClick = () => {
 		// Don't kick off a new export request if there's one in progress
-		if ( this.state.disabled ) {
+		if ( this.props.disabled || this.state.disabled ) {
 			return;
 		}
 
@@ -75,7 +76,10 @@ class ReaderExportButton extends React.Component {
 	render() {
 		return (
 			<button
-				className="reader-export-button"
+				className={ classnames( {
+					'reader-export-button': true,
+					'is-disabled': this.props.disabled || this.state.disabled,
+				} ) }
 				onClick={ this.onClick }
 				disabled={ this.props.disabled || this.state.disabled }
 			>

--- a/client/blocks/reader-export-button/style.scss
+++ b/client/blocks/reader-export-button/style.scss
@@ -1,7 +1,7 @@
 .reader-export-button {
 	cursor: pointer;
 
-	&:hover {
+	&:hover:not( .is-disabled ) {
 		.reader-export-button__icon {
 			fill: var( --color-accent );
 		}
@@ -9,6 +9,10 @@
 		.reader-export-button__label {
 			color: var( --color-accent );
 		}
+	}
+
+	&.is-disabled {
+		cursor: default;
 	}
 }
 

--- a/client/reader/list-manage/index.jsx
+++ b/client/reader/list-manage/index.jsx
@@ -106,11 +106,15 @@ function Items( { list, listItems, owner } ) {
 	) );
 }
 
-function Export( { list } ) {
+function Export( { list, listItems } ) {
 	return (
 		<Card>
 			<p>You can export this list to use on other services. The file will be in OPML format.</p>
-			<ReaderExportButton exportType={ READER_EXPORT_TYPE_LIST } listId={ list.ID } />
+			<ReaderExportButton
+				exportType={ READER_EXPORT_TYPE_LIST }
+				listId={ list.ID }
+				disabled={ ! listItems }
+			/>
 		</Card>
 	);
 }
@@ -142,14 +146,12 @@ function ReaderListEdit( props ) {
 									{ translate( 'Sites' ) }
 								</NavItem>
 
-								{ listItems && (
-									<NavItem
-										selected={ selectedSection === 'export' }
-										path={ `/read/list/${ props.owner }/${ props.slug }/export` }
-									>
-										{ translate( 'Export' ) }
-									</NavItem>
-								) }
+								<NavItem
+									selected={ selectedSection === 'export' }
+									path={ `/read/list/${ props.owner }/${ props.slug }/export` }
+								>
+									{ translate( 'Export' ) }
+								</NavItem>
 							</NavTabs>
 						</SectionNav>
 						{ selectedSection === 'details' && <Details { ...props } /> }

--- a/client/reader/list-manage/index.jsx
+++ b/client/reader/list-manage/index.jsx
@@ -14,29 +14,29 @@ import {
 	getListItems,
 	isCreatingList as isCreatingListSelector,
 	isMissingByOwnerAndSlug,
-} from 'state/reader/lists/selectors';
-import FormattedHeader from 'components/formatted-header';
-import FormButtonsBar from 'components/forms/form-buttons-bar';
-import FormButton from 'components/forms/form-button';
-import FormFieldset from 'components/forms/form-fieldset';
-import FormLabel from 'components/forms/form-label';
-import FormLegend from 'components/forms/form-legend';
-import FormRadio from 'components/forms/form-radio';
-import FormSectionHeading from 'components/forms/form-section-heading';
-import FormSettingExplanation from 'components/forms/form-setting-explanation';
-import FormTextInput from 'components/forms/form-text-input';
-import FormTextarea from 'components/forms/form-textarea';
-import QueryReaderList from 'components/data/query-reader-list';
-import QueryReaderListItems from 'components/data/query-reader-list-items';
-import SectionNav from 'components/section-nav';
-import NavTabs from 'components/section-nav/tabs';
-import NavItem from 'components/section-nav/item';
-import Main from 'components/main';
-import { createReaderList } from 'state/reader/lists/actions';
-import ReaderExportButton from 'blocks/reader-export-button';
-import { READER_EXPORT_TYPE_LIST } from 'blocks/reader-export-button/constants';
+} from 'calypso/state/reader/lists/selectors';
+import FormattedHeader from 'calypso/components/formatted-header';
+import FormButtonsBar from 'calypso/components/forms/form-buttons-bar';
+import FormButton from 'calypso/components/forms/form-button';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormLegend from 'calypso/components/forms/form-legend';
+import FormRadio from 'calypso/components/forms/form-radio';
+import FormSectionHeading from 'calypso/components/forms/form-section-heading';
+import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
+import FormTextInput from 'calypso/components/forms/form-text-input';
+import FormTextarea from 'calypso/components/forms/form-textarea';
+import QueryReaderList from 'calypso/components/data/query-reader-list';
+import QueryReaderListItems from 'calypso/components/data/query-reader-list-items';
+import SectionNav from 'calypso/components/section-nav';
+import NavTabs from 'calypso/components/section-nav/tabs';
+import NavItem from 'calypso/components/section-nav/item';
+import Main from 'calypso/components/main';
+import { createReaderList } from 'calypso/state/reader/lists/actions';
+import ReaderExportButton from 'calypso/blocks/reader-export-button';
+import { READER_EXPORT_TYPE_LIST } from 'calypso/blocks/reader-export-button/constants';
 import ListItem from './list-item';
-import Missing from 'reader/list-stream/missing';
+import Missing from 'calypso/reader/list-stream/missing';
 
 /**
  * Style dependencies

--- a/client/reader/list-manage/index.jsx
+++ b/client/reader/list-manage/index.jsx
@@ -113,7 +113,7 @@ function Export( { list, listItems } ) {
 			<ReaderExportButton
 				exportType={ READER_EXPORT_TYPE_LIST }
 				listId={ list.ID }
-				disabled={ ! listItems }
+				disabled={ ! listItems || listItems.length === 0 }
 			/>
 		</Card>
 	);

--- a/client/state/data-layer/wpcom/read/lists/index.js
+++ b/client/state/data-layer/wpcom/read/lists/index.js
@@ -37,8 +37,8 @@ registerHandlers( 'state/data-layer/wpcom/read/lists/index.js', {
 					action
 				),
 			onSuccess: ( action, response ) => [
-				receiveReaderList( { list: response.list } ),
-				navigate( `/read/list/${ response.list.owner }/${ response.list.slug }/edit` ),
+				receiveReaderList( { list: response } ),
+				navigate( `/read/list/${ response.owner }/${ response.slug }/edit` ),
 			],
 			onError: ( action, error ) => [
 				errorNotice( String( error ) ),

--- a/client/state/data-layer/wpcom/read/lists/items/index.js
+++ b/client/state/data-layer/wpcom/read/lists/items/index.js
@@ -16,7 +16,7 @@ registerHandlers( 'state/data-layer/wpcom/read/lists/items/index.js', {
 					{
 						method: 'GET',
 						path: `/read/lists/${ action.listOwner }/${ action.listSlug }/items`,
-						query: { meta: 'site,feed,tag' },
+						query: { meta: 'site,feed,tag', number: 2000 },
 						apiVersion: '1.2',
 					},
 					action


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fetch up to 2000 list items in the initial pass
* Refactor the list edit components into functional components and add a loading indicator for the list items
* Always show the export tab, disable the button if we have not loaded the list items yet

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load a list with more than 10 items. Verify that all 10 items appear. 
* Verify that a loading indicator appears on the `/items` section while loading the items
* Verify the export tab appears instantly along with the Sites and Details tabs
* Load the export tab directly on a long list and a slow network. Verify that the button is disabled while the list items load and enabled once loaded if there are items in the list.