### PR TITLE
Remove composite checkout abtest (take 2) (1)

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -37,15 +37,6 @@ export default {
 		defaultVariation: 'hide',
 		allowExistingUsers: true,
 	},
-	showCompositeCheckout: {
-		datestamp: '20200611',
-		variations: {
-			composite: 100,
-			regular: 0,
-		},
-		defaultVariation: 'regular',
-		allowExistingUsers: true,
-	},
 	skipThemesSelectionModal: {
 		datestamp: '20170904',
 		variations: {

--- a/client/my-sites/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout-system-decider.js
@@ -164,6 +164,11 @@ function getCheckoutVariant(
 	isJetpack,
 	isAtomic
 ) {
+	if ( config.isEnabled( 'old-checkout-force' ) ) {
+		debug( 'shouldShowCompositeCheckout false because old-checkout-force flag is set' );
+		return 'old-checkout';
+	}
+
 	if ( config.isEnabled( 'composite-checkout-force' ) ) {
 		debug( 'shouldShowCompositeCheckout true because force config is enabled' );
 		return 'composite-checkout';

--- a/client/my-sites/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout-system-decider.js
@@ -19,7 +19,6 @@ import config from 'config';
 import { getCurrentUserLocale, getCurrentUserCountryCode } from 'state/current-user/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
-import { abtest } from 'lib/abtest';
 import { logToLogstash } from 'state/logstash/actions';
 
 const debug = debugFactory( 'calypso:checkout-system-decider' );
@@ -228,18 +227,8 @@ function getCheckoutVariant(
 		return 'disallowed-product';
 	}
 
-	if ( config.isEnabled( 'composite-checkout-testing' ) ) {
-		debug( 'shouldShowCompositeCheckout true because testing config is enabled' );
-		return 'composite-checkout';
-	}
-
-	if ( abtest( 'showCompositeCheckout' ) === 'composite' ) {
-		debug( 'shouldShowCompositeCheckout true because user is in abtest' );
-		return 'composite-checkout';
-	}
-
-	debug( 'shouldShowCompositeCheckout false because test not enabled' );
-	return 'test-not-enabled';
+	debug( 'shouldShowCompositeCheckout true' );
+	return 'composite-checkout';
 }
 
 function fetchStripeConfigurationWpcom( args ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is a second attempt at https://github.com/Automattic/wp-calypso/pull/43163 That PR was reverted because the e2e tests were not set up to handle composite checkout.

A combination of https://github.com/Automattic/wp-calypso/pull/43241 and https://github.com/Automattic/wp-calypso/pull/43223 should fix those tests, which are currently included here for convenience of testing but all those commits will be rebased out of this PR when they are merged.

This removes the composite checkout abtest and sends 100% of page loads to new checkout versus old if they pass our other conditions, which are currently:

- Site is not jetpack (atomic sites are fine).
- Cart contains no jetpack plans.
- URL contains no unknown products (just to protect against things we haven't tested).
- Country code is US.
- Locale is EN.
- Currency is USD.

#### Testing instructions

Visit checkout with the above conditions met, and verify that you see new checkout.
