### PR TITLE
composite-checkout: Add classNames and other attributes to make e2e testing easier

### DIFF
--- a/client/my-sites/checkout/composite-checkout/wpcom/components/coupon.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/coupon.js
@@ -47,6 +47,7 @@ export default function Coupon( { id, className, disabled, couponStatus, couponF
 		>
 			<Field
 				id={ id }
+				inputClassName="coupon-code"
 				value={ couponFieldValue }
 				disabled={ disabled || isPending }
 				placeholder={ translate( 'Enter your coupon code' ) }

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/field.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/field.js
@@ -10,6 +10,7 @@ export default function Field( {
 	type,
 	id,
 	className,
+	inputClassName,
 	isError,
 	onChange,
 	label,
@@ -46,6 +47,7 @@ export default function Field( {
 
 			<InputWrapper>
 				<Input
+					className={ inputClassName }
 					id={ id }
 					icon={ icon }
 					value={ value }
@@ -73,6 +75,7 @@ Field.propTypes = {
 	type: PropTypes.string,
 	id: PropTypes.string.isRequired,
 	className: PropTypes.string,
+	inputClassName: PropTypes.string,
 	isError: PropTypes.bool,
 	onChange: PropTypes.func,
 	label: PropTypes.string,

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-review.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-review.js
@@ -113,7 +113,10 @@ function CouponFieldArea( {
 	return (
 		<CouponLinkWrapper>
 			{ translate( 'Have a coupon? ' ) }
-			<CouponEnableButton onClick={ () => setCouponFieldVisible( true ) }>
+			<CouponEnableButton
+				className="wp-checkout-order-review__show-coupon-field-button"
+				onClick={ () => setCouponFieldVisible( true ) }
+			>
 				{ translate( 'Add a coupon code' ) }
 			</CouponEnableButton>
 		</CouponLinkWrapper>

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
@@ -70,7 +70,9 @@ export default function WPCheckoutOrderSummary() {
 				) ) }
 				<CheckoutSummaryTotal>
 					<span>{ translate( 'Total' ) }</span>
-					<span>{ renderDisplayValueMarkdown( total.amount.displayValue ) }</span>
+					<span className="wp-checkout-order-summary__total-price">
+						{ renderDisplayValueMarkdown( total.amount.displayValue ) }
+					</span>
 				</CheckoutSummaryTotal>
 			</CheckoutSummaryAmountWrapper>
 		</CheckoutSummaryCardUI>

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -209,7 +209,7 @@ export default function WPCheckout( {
 						{ translate( 'Purchase Details' ) }
 						<CheckoutSummaryTitleToggle icon="keyboard_arrow_down" />
 					</CheckoutSummaryTitle>
-					<CheckoutSummaryTitlePrice>
+					<CheckoutSummaryTitlePrice className="wp-checkout__total-price">
 						{ renderDisplayValueMarkdown( total.amount.displayValue ) }
 					</CheckoutSummaryTitlePrice>
 				</CheckoutSummaryTitleLink>

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -220,6 +220,7 @@ export default function WPCheckout( {
 			</CheckoutSummaryArea>
 			<CheckoutStepArea>
 				<CheckoutStepBody
+					className="wp-checkout__review-order-step"
 					stepId="review-order-step"
 					isStepActive={ isOrderReviewActive }
 					isStepComplete={ true }

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
@@ -75,6 +75,7 @@ function WPLineItem( {
 			? `${ item.label } (with Expert guidance)`
 			: item.label;
 
+	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
 		<div
 			className={ joinClasses( [ className, 'checkout-line-item' ] ) }
@@ -83,7 +84,7 @@ function WPLineItem( {
 			<LineItemTitle id={ itemSpanId } isSummary={ isSummary }>
 				{ productName }
 			</LineItemTitle>
-			<span aria-labelledby={ itemSpanId }>
+			<span aria-labelledby={ itemSpanId } className="checkout-line-item__price">
 				<LineItemPrice item={ item } isSummary={ isSummary } />
 			</span>
 			{ item.sublabel && (

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
@@ -482,10 +482,10 @@ function SavingsList( { item } ) {
 		return null;
 	}
 	return (
-		<React.Fragment>
+		<LineItemMeta className="savings-list">
 			{ savingsItems.map( ( savingsItem ) => (
 				<LineItemMeta key={ savingsItem }>{ savingsItem }</LineItemMeta>
 			) ) }
-		</React.Fragment>
+		</LineItemMeta>
 	);
 }

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
@@ -80,6 +80,7 @@ function WPLineItem( {
 		<div
 			className={ joinClasses( [ className, 'checkout-line-item' ] ) }
 			data-e2e-product-slug={ productSlug }
+			data-product-type={ item.type }
 		>
 			<LineItemTitle id={ itemSpanId } isSummary={ isSummary }>
 				{ productName }
@@ -476,7 +477,10 @@ function SavingsList( { item } ) {
 	const translate = useTranslate();
 	const savingsItems = [];
 	if ( item.wpcom_meta?.couponCode ) {
-		savingsItems.push( translate( 'Coupon: %s', { args: item.wpcom_meta?.couponCode } ) );
+		savingsItems.push( {
+			type: 'coupon',
+			label: translate( 'Coupon: %s', { args: item.wpcom_meta?.couponCode } ),
+		} );
 	}
 	if ( savingsItems.length < 1 ) {
 		return null;
@@ -484,7 +488,13 @@ function SavingsList( { item } ) {
 	return (
 		<LineItemMeta className="savings-list">
 			{ savingsItems.map( ( savingsItem ) => (
-				<LineItemMeta key={ savingsItem }>{ savingsItem }</LineItemMeta>
+				<LineItemMeta
+					className="savings-list__item"
+					key={ savingsItem.label }
+					data-savings-type={ savingsItem.type }
+				>
+					{ savingsItem.label }
+				</LineItemMeta>
 			) ) }
 		</LineItemMeta>
 	);

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
@@ -76,7 +76,10 @@ function WPLineItem( {
 			: item.label;
 
 	return (
-		<div className={ joinClasses( [ className, 'checkout-line-item' ] ) }>
+		<div
+			className={ joinClasses( [ className, 'checkout-line-item' ] ) }
+			data-e2e-product-slug={ productSlug }
+		>
 			<LineItemTitle id={ itemSpanId } isSummary={ isSummary }>
 				{ productName }
 			</LineItemTitle>

--- a/packages/composite-checkout/src/components/checkout-steps.js
+++ b/packages/composite-checkout/src/components/checkout-steps.js
@@ -554,6 +554,7 @@ const StepWrapperUI = styled.div`
 	}
 `;
 
+/* eslint-disable wpcalypso/jsx-classname-namespace */
 function CheckoutStepHeader( {
 	id,
 	className,
@@ -582,6 +583,7 @@ function CheckoutStepHeader( {
 			</StepTitle>
 			{ shouldShowEditButton && (
 				<HeaderEditButton
+					className="checkout-step__edit-button"
 					buttonType="text-button"
 					onClick={ onEdit }
 					aria-label={ editButtonAriaLabel }

--- a/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
@@ -199,14 +199,15 @@ function StripeCreditCardFields() {
 		},
 	};
 
+	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
-		<StripeFields>
+		<StripeFields className="credit-card-form-fields">
 			{ ! isStripeFullyLoaded && <LoadingFields /> }
 
 			<CreditCardFieldsWrapper isLoaded={ isStripeFullyLoaded }>
 				<Label>
 					<LabelText>{ __( 'Card number' ) }</LabelText>
-					<StripeFieldWrapper hasError={ cardNumberError }>
+					<StripeFieldWrapper className="number" hasError={ cardNumberError }>
 						<CardNumberElement
 							style={ cardNumberStyle }
 							onReady={ () => {
@@ -225,7 +226,7 @@ function StripeCreditCardFields() {
 					<LeftColumn>
 						<Label>
 							<LabelText>{ __( 'Expiry date' ) }</LabelText>
-							<StripeFieldWrapper hasError={ cardExpiryError }>
+							<StripeFieldWrapper className="expiration-date" hasError={ cardExpiryError }>
 								<CardExpiryElement
 									style={ cardNumberStyle }
 									onChange={ ( input ) => {
@@ -241,7 +242,7 @@ function StripeCreditCardFields() {
 							<LabelText>{ __( 'Security code' ) }</LabelText>
 							<GridRow gap="4%" columnWidths="67% 29%">
 								<LeftColumn>
-									<StripeFieldWrapper hasError={ cardCvcError }>
+									<StripeFieldWrapper className="cvv" hasError={ cardCvcError }>
 										<CardCvcElement
 											style={ cardNumberStyle }
 											onChange={ ( input ) => {
@@ -260,7 +261,7 @@ function StripeCreditCardFields() {
 				</FieldRow>
 
 				<CreditCardField
-					id="cardholderName"
+					id="cardholder-name"
 					type="Text"
 					autoComplete="cc-name"
 					label={ __( 'Cardholder name' ) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is extracted from https://github.com/Automattic/wp-calypso/pull/43223 which fixes the e2e tests for composite checkout. This is all the changes to composite checkout needed for those tests to pass.

#### Testing instructions

- This should not cause any user-visible effects.
- Visit composite checkout and verify that everything works as expected. Notable changes: savings sublabels (eg: a coupon code), credit card fields.