### PR TITLE
composite-checkout: Do not show free domain as a feature on renewals

### DIFF
--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
@@ -27,6 +27,7 @@ import getSupportVariation, {
 } from 'state/selectors/get-inline-help-support-variation';
 import { useHasDomainsInCart, useDomainsInCart } from '../hooks/has-domains';
 import { useHasPlanInCart, usePlanInCart } from '../hooks/has-plan';
+import { useHasRenewalInCart } from '../hooks/has-renewal';
 import { isWpComBusinessPlan, isWpComEcommercePlan } from 'lib/plans';
 import isPresalesChatAvailable from 'state/happychat/selectors/is-presales-chat-available';
 import isHappychatAvailable from 'state/happychat/selectors/is-happychat-available';
@@ -150,7 +151,8 @@ function CheckoutSummaryPlanFeatures() {
 	const translate = useTranslate();
 	const hasDomainsInCart = useHasDomainsInCart();
 	const planInCart = usePlanInCart();
-	const planFeatures = getPlanFeatures( planInCart, translate, hasDomainsInCart );
+	const hasRenewalInCart = useHasRenewalInCart();
+	const planFeatures = getPlanFeatures( planInCart, translate, hasDomainsInCart, hasRenewalInCart );
 
 	return (
 		<>
@@ -167,13 +169,14 @@ function CheckoutSummaryPlanFeatures() {
 	);
 }
 
-function getPlanFeatures( plan, translate, hasDomainsInCart ) {
+function getPlanFeatures( plan, translate, hasDomainsInCart, hasRenewalInCart ) {
+	const showFreeDomainFeature = ! hasDomainsInCart && ! hasRenewalInCart;
 	if (
 		'personal-bundle' === plan.wpcom_meta?.product_slug ||
 		'personal-bundle-2y' === plan.wpcom_meta?.product_slug
 	) {
 		return [
-			! hasDomainsInCart && translate( 'Free domain for one year' ),
+			showFreeDomainFeature && translate( 'Free domain for one year' ),
 			translate( 'Remove WordPress.com ads' ),
 			translate( 'Limit your content to paying subscribers.' ),
 		];
@@ -182,7 +185,7 @@ function getPlanFeatures( plan, translate, hasDomainsInCart ) {
 		'value_bundle-2y' === plan.wpcom_meta?.product_slug
 	) {
 		return [
-			! hasDomainsInCart && translate( 'Free domain for one year' ),
+			showFreeDomainFeature && translate( 'Free domain for one year' ),
 			translate( 'Unlimited access to our library of Premium Themes' ),
 			translate( 'Subscriber-only content and simple payment buttons' ),
 			translate( 'Track your stats with Google Analytics' ),
@@ -192,7 +195,7 @@ function getPlanFeatures( plan, translate, hasDomainsInCart ) {
 		'business-bundle-2y' === plan.wpcom_meta?.product_slug
 	) {
 		return [
-			! hasDomainsInCart && translate( 'Free domain for one year' ),
+			showFreeDomainFeature && translate( 'Free domain for one year' ),
 			translate( 'Install custom plugins and themes' ),
 			translate( 'Drive traffic to your site with our advanced SEO tools' ),
 			translate( 'Track your stats with Google Analytics' ),
@@ -203,7 +206,7 @@ function getPlanFeatures( plan, translate, hasDomainsInCart ) {
 		'ecommerce-bundle-2y' === plan.wpcom_meta?.product_slug
 	) {
 		return [
-			! hasDomainsInCart && translate( 'Free domain for one year' ),
+			showFreeDomainFeature && translate( 'Free domain for one year' ),
 			translate( 'Install custom plugins and themes' ),
 			translate( 'Accept payments in 60+ countries' ),
 			translate( 'Integrations with top shipping carriers' ),

--- a/client/my-sites/checkout/composite-checkout/wpcom/hooks/has-renewal.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/hooks/has-renewal.ts
@@ -1,0 +1,17 @@
+/**
+ * External dependencies
+ */
+import { useLineItems } from '@automattic/composite-checkout';
+
+export function useHasRenewalInCart() {
+	const [ items ] = useLineItems();
+	return isRenewalInLineItems( items );
+}
+
+export function isRenewalInLineItems( items ) {
+	return items.some( isLineItemARenewal );
+}
+
+export function isLineItemARenewal( item ) {
+	return 'renewal' === ( item.wpcom_meta?.extra?.purchaseType ?? '' );
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* We added plan-specific feature lists in #43080 but forgot to prevent the free domain feature from being displayed on renewals; this PR fixes that.

#### Testing instructions

* Enter composite checkout with a plan renewal in the cart, using `?flags=composite-checkout-force` if needed. Verify that the "free domain for one year" feature is not listed in the sidebar.
* Enter composite checkout with a new plan purchase in the cart, but not a domain; check that the "free domain for one year" feature is listed.
* Enter composite checkout with a new plan purchase and a domain in the cart. Check that the "$domain free for a year with your plan" feature is listed.

![Screen Shot 2020-06-12 at 2 08 17 PM](https://user-images.githubusercontent.com/9310939/84538219-e1c48700-acb6-11ea-96c9-98e0cb10533d.png)
