### PR TITLE
Update/concierge booking webinar callout

### DIFF
--- a/client/me/concierge/book/calendar-step.js
+++ b/client/me/concierge/book/calendar-step.js
@@ -23,6 +23,7 @@ import {
 	CONCIERGE_STATUS_BOOKING_ERROR,
 } from '../constants';
 import { recordTracksEvent } from 'state/analytics/actions';
+import ExternalLinkWithTracking from 'components/external-link/with-tracking';
 
 class CalendarStep extends Component {
 	static propTypes = {
@@ -79,7 +80,26 @@ class CalendarStep extends Component {
 		return (
 			<div>
 				<HeaderCake onClick={ onBack }>{ translate( 'Choose Session' ) }</HeaderCake>
-				<CompactCard>{ translate( 'Please select a day to have your session.' ) }</CompactCard>
+				<CompactCard>
+					<p>
+						<strong>{ translate( 'Please select from the available sessions below.' ) }</strong>
+					</p>
+					<p>
+						<em>
+							{ translate(
+								'If you don’t see a day or time that works for you, please check back soon for more options! In the meantime, consider attending one of our expert webinars on a wide variety of topics designed to help you build and grow your site.'
+							) }
+						</em>{ ' ' }
+						<ExternalLinkWithTracking
+							icon={ true }
+							href="https://wordpress.com/webinars/"
+							onClick={ () => {} }
+							tracksEventName="calypso_concierge_book_view_webinars"
+						>
+							{ translate( 'View webinars.' ) }
+						</ExternalLinkWithTracking>
+					</p>
+				</CompactCard>
 
 				<AvailableTimePicker
 					actionText={ translate( 'Book this session' ) }

--- a/client/me/concierge/book/calendar-step.js
+++ b/client/me/concierge/book/calendar-step.js
@@ -87,16 +87,20 @@ class CalendarStep extends Component {
 					<p>
 						<em>
 							{ translate(
-								'If you don’t see a day or time that works for you, please check back soon for more options! In the meantime, consider attending one of our expert webinars on a wide variety of topics designed to help you build and grow your site.'
+								'If you don’t see a day or time that works for you, please check back soon for more options! In the meantime, consider attending one of our expert webinars on a wide variety of topics designed to help you build and grow your site. {{externalLink}}View webinars{{/externalLink}}.',
+								{
+									components: {
+										externalLink: (
+											<ExternalLinkWithTracking
+												icon={ false }
+												href="https://wordpress.com/webinars/"
+												tracksEventName="calypso_concierge_book_view_webinars"
+											/>
+										),
+									},
+								}
 							) }
-						</em>{ ' ' }
-						<ExternalLinkWithTracking
-							icon={ true }
-							href="https://wordpress.com/webinars/"
-							tracksEventName="calypso_concierge_book_view_webinars"
-						>
-							{ translate( 'View webinars.' ) }
-						</ExternalLinkWithTracking>
+						</em>
 					</p>
 				</CompactCard>
 

--- a/client/me/concierge/book/calendar-step.js
+++ b/client/me/concierge/book/calendar-step.js
@@ -93,7 +93,7 @@ class CalendarStep extends Component {
 										externalLink: (
 											<ExternalLinkWithTracking
 												icon={ false }
-												href="https://wordpress.com/webinars/"
+												href="/webinars"
 												tracksEventName="calypso_concierge_book_view_webinars"
 											/>
 										),

--- a/client/me/concierge/book/calendar-step.js
+++ b/client/me/concierge/book/calendar-step.js
@@ -93,7 +93,6 @@ class CalendarStep extends Component {
 						<ExternalLinkWithTracking
 							icon={ true }
 							href="https://wordpress.com/webinars/"
-							onClick={ () => {} }
 							tracksEventName="calypso_concierge_book_view_webinars"
 						>
 							{ translate( 'View webinars.' ) }

--- a/client/me/concierge/shared/no-available-times.js
+++ b/client/me/concierge/shared/no-available-times.js
@@ -12,6 +12,8 @@ import { Card } from '@automattic/components';
 import PrimaryHeader from './primary-header';
 import { recordTracksEvent } from 'state/analytics/actions';
 import isSiteWhiteGlove from 'state/selectors/is-site-white-glove';
+import ExternalLinkWithTracking from 'components/external-link/with-tracking';
+import { stubFalse } from 'lodash';
 
 class NoAvailableTimes extends Component {
 	componentDidMount() {
@@ -26,24 +28,58 @@ class NoAvailableTimes extends Component {
 				<PrimaryHeader isWhiteGlove={ isWhiteGlove } />
 				<Card>
 					<h2 className="shared__no-available-times-heading">
-						{ translate( 'Sorry, there are no sessions available' ) }
+						{ translate( 'Sorry, all upcoming sessions are full' ) }
 					</h2>
 					{ isWhiteGlove && (
 						<>
-							We schedule one-on-one sessions up to 24 hours in advance and all upcoming sessions
-							are full. Please check back later or{ ' ' }
-							<a href="https://wordpress.com/help/contact">contact us in Live Chat</a>.
+							We add new sessions daily, so please check back soon for more options. In the
+							meantime, consider attending one of our expert webinars on a wide variety of topics
+							designed to help you build and grow your site.{ ' ' }
+							<ExternalLinkWithTracking
+								icon={ false }
+								href="https://wordpress.com/webinars/"
+								onClick={ () => {} }
+								tracksEventName="calypso_concierge_book_view_webinars"
+							>
+								{ translate( 'View webinars.' ) }
+							</ExternalLinkWithTracking>
+							or
+							<ExternalLinkWithTracking
+								icon={ false }
+								href="https://wordpress.com/help/contact"
+								onClick={ () => {} }
+								tracksEventName="calypso_concierge_book_view_contact_us"
+							>
+								contact us in Live Chat
+							</ExternalLinkWithTracking>
+							.
 						</>
 					) }
-					{ ! isWhiteGlove &&
-						translate(
-							'We schedule Quick Start Sessions up to 24 hours in advance and all upcoming sessions are full. Please check back later or {{link}}contact us in Live Chat{{/link}}.',
-							{
-								components: {
-									link: <a href="https://wordpress.com/help/contact" />,
-								},
-							}
-						) }
+					{ ! isWhiteGlove && (
+						<>
+							{ translate(
+								'We add new sessions daily, so please check back soon for more options. In the meantime, consider attending one of our expert webinars on a wide variety of topics designed to help you build and grow your site.'
+							) }{ ' ' }
+							<ExternalLinkWithTracking
+								icon={ false }
+								href="https://wordpress.com/webinars/"
+								onClick={ () => {} }
+								tracksEventName="calypso_concierge_book_view_webinars"
+							>
+								{ translate( 'View webinars.' ) }
+							</ExternalLinkWithTracking>
+							{ translate( ' or ' ) }
+							<ExternalLinkWithTracking
+								icon={ false }
+								href="https://wordpress.com/help/contact"
+								onClick={ () => {} }
+								tracksEventName="calypso_concierge_book_contact_us"
+							>
+								{ translate( 'contact us in Live Chat' ) }
+							</ExternalLinkWithTracking>
+							.
+						</>
+					) }
 				</Card>
 			</div>
 		);

--- a/client/me/concierge/shared/no-available-times.js
+++ b/client/me/concierge/shared/no-available-times.js
@@ -36,14 +36,14 @@ class NoAvailableTimes extends Component {
 								externalLink1: (
 									<ExternalLinkWithTracking
 										icon={ false }
-										href="https://wordpress.com/webinars/"
+										href="/webinars"
 										tracksEventName="calypso_concierge_book_view_webinars"
 									/>
 								),
 								externalLink2: (
 									<ExternalLinkWithTracking
 										icon={ false }
-										href="https://wordpress.com/help/contact"
+										href="/help/contact"
 										tracksEventName="calypso_concierge_book_contact_us"
 									/>
 								),

--- a/client/me/concierge/shared/no-available-times.js
+++ b/client/me/concierge/shared/no-available-times.js
@@ -13,7 +13,6 @@ import PrimaryHeader from './primary-header';
 import { recordTracksEvent } from 'state/analytics/actions';
 import isSiteWhiteGlove from 'state/selectors/is-site-white-glove';
 import ExternalLinkWithTracking from 'components/external-link/with-tracking';
-import { stubFalse } from 'lodash';
 
 class NoAvailableTimes extends Component {
 	componentDidMount() {

--- a/client/me/concierge/shared/no-available-times.js
+++ b/client/me/concierge/shared/no-available-times.js
@@ -27,57 +27,28 @@ class NoAvailableTimes extends Component {
 				<PrimaryHeader isWhiteGlove={ isWhiteGlove } />
 				<Card>
 					<h2 className="shared__no-available-times-heading">
-						{ translate( 'Sorry, all upcoming sessions are full' ) }
+						{ translate( 'Sorry, all upcoming sessions are full.' ) }
 					</h2>
-					{ isWhiteGlove && (
-						<>
-							We add new sessions daily, so please check back soon for more options. In the
-							meantime, consider attending one of our expert webinars on a wide variety of topics
-							designed to help you build and grow your site.{ ' ' }
-							<ExternalLinkWithTracking
-								icon={ false }
-								href="https://wordpress.com/webinars/"
-								onClick={ () => {} }
-								tracksEventName="calypso_concierge_book_view_webinars"
-							>
-								{ translate( 'View webinars.' ) }
-							</ExternalLinkWithTracking>
-							or
-							<ExternalLinkWithTracking
-								icon={ false }
-								href="https://wordpress.com/help/contact"
-								onClick={ () => {} }
-								tracksEventName="calypso_concierge_book_view_contact_us"
-							>
-								contact us in Live Chat
-							</ExternalLinkWithTracking>
-							.
-						</>
-					) }
-					{ ! isWhiteGlove && (
-						<>
-							{ translate(
-								'We add new sessions daily, so please check back soon for more options. In the meantime, consider attending one of our expert webinars on a wide variety of topics designed to help you build and grow your site.'
-							) }{ ' ' }
-							<ExternalLinkWithTracking
-								icon={ false }
-								href="https://wordpress.com/webinars/"
-								onClick={ () => {} }
-								tracksEventName="calypso_concierge_book_view_webinars"
-							>
-								{ translate( 'View webinars.' ) }
-							</ExternalLinkWithTracking>
-							{ translate( ' or ' ) }
-							<ExternalLinkWithTracking
-								icon={ false }
-								href="https://wordpress.com/help/contact"
-								onClick={ () => {} }
-								tracksEventName="calypso_concierge_book_contact_us"
-							>
-								{ translate( 'contact us in Live Chat' ) }
-							</ExternalLinkWithTracking>
-							.
-						</>
+					{ translate(
+						'We add new sessions daily, so please check back soon for more options. In the meantime, consider attending one of our expert webinars on a wide variety of topics designed to help you build and grow your site. {{externalLink1}}View webinars{{/externalLink1}} or {{externalLink2}}contact us in Live Chat{{/externalLink2}}.',
+						{
+							components: {
+								externalLink1: (
+									<ExternalLinkWithTracking
+										icon={ false }
+										href="https://wordpress.com/webinars/"
+										tracksEventName="calypso_concierge_book_view_webinars"
+									/>
+								),
+								externalLink2: (
+									<ExternalLinkWithTracking
+										icon={ false }
+										href="https://wordpress.com/help/contact"
+										tracksEventName="calypso_concierge_book_contact_us"
+									/>
+								),
+							},
+						}
 					) }
 				</Card>
 			</div>


### PR DESCRIPTION
This PR adds messaging about, and links to, the webinar content on two Quick Start Session booking screens. Context for this update is in the comments of pbBQWj-cj-p2.

The PR also adds tracking to the links.

**Use case 1: no available sessions:**
If no sessions are available, the user will see this message:
_While you wait for availability to open up, consider attending one of our expert webinars on a wide variety of topics designed to help you build and grow your site. View webinars or contact us in Live Chat._

Before:
<img width="733" alt="Screen Shot 2020-06-12 at 2 58 27 PM" src="https://user-images.githubusercontent.com/35781181/84537148-379c2d80-acbd-11ea-97f9-a5c65bc295f7.png">

After:
<img width="747" alt="Screen Shot 2020-06-12 at 12 22 50 PM" src="https://user-images.githubusercontent.com/35781181/84537182-44208600-acbd-11ea-9471-fd3e6b526f7d.png">

**User case 2: sessions available**
Before:
<img width="742" alt="Screen Shot 2020-06-12 at 3 04 32 PM" src="https://user-images.githubusercontent.com/35781181/84537605-12f48580-acbe-11ea-9c49-1272db0b7136.png">

After:
<img width="737" alt="Screen Shot 2020-06-12 at 12 46 10 PM" src="https://user-images.githubusercontent.com/35781181/84537334-877af480-acbd-11ea-9449-138793195e5e.png">

#### Testing instructions
* Checkout branch: git checkout update/concierge-booking-webinar-callout
* Run calypso
* Point your browser to http://calypso.localhost:3000/me/concierge
* Select a Business plan site.
* Verify that the updated strings are properly displayed.
* To force either screen to load,  tweak the isEmpty(availableTimes) check in main.js
* Click the links. Confirm that the appropriate pages load and that the Tracks events fire.

Fixes #
