### PR TITLE
fix: Add key to DomainRefundPolicy list items

### DIFF
--- a/client/my-sites/checkout/checkout/domain-refund-policy.jsx
+++ b/client/my-sites/checkout/checkout/domain-refund-policy.jsx
@@ -111,8 +111,8 @@ class DomainRefundPolicy extends React.Component {
 
 		return (
 			<>
-				{ policies.map( ( policy ) => (
-					<div className="checkout__domain-refund-policy">
+				{ policies.map( ( policy, index ) => (
+					<div className="checkout__domain-refund-policy" key={ index }>
 						<Gridicon icon="info-outline" size={ 18 } />
 						<p>{ policy }</p>
 					</div>

--- a/client/my-sites/checkout/checkout/domain-refund-policy.jsx
+++ b/client/my-sites/checkout/checkout/domain-refund-policy.jsx
@@ -111,8 +111,8 @@ class DomainRefundPolicy extends React.Component {
 
 		return (
 			<>
-				{ policies.map( ( policy, index ) => (
-					<div className="checkout__domain-refund-policy" key={ index }>
+				{ policies.map( ( policy ) => (
+					<div className="checkout__domain-refund-policy" key={ policy }>
 						<Gridicon icon="info-outline" size={ 18 } />
 						<p>{ policy }</p>
 					</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* It is possible to have more than one domain refund policy, causing the `DomainRefundPolicy` component to throw a warning. This PR just uses the `index` parameter as a key attribute to avoid this.

![image](https://user-images.githubusercontent.com/9310939/84541424-fefc5400-acbc-11ea-8662-9fa317ee96e2.png)

#### Testing instructions

* Enter composite checkout with domain items involving more than one refund policy and check the console for warnings. (I'm not sure exactly how to trigger this!)
