### PR TITLE
Add reader list update form functionality

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1318,21 +1318,6 @@ Undocumented.prototype.readLists = function ( fn ) {
 	return this.wpcom.req.get( '/read/lists', { apiVersion: '1.2' }, fn );
 };
 
-Undocumented.prototype.readListsUpdate = function ( query, fn ) {
-	const params = omit( query, [ 'owner', 'slug' ] );
-	debug( '/read/lists/:list/update' );
-	return this.wpcom.req.post(
-		'/read/lists/' +
-			encodeURIComponent( query.owner ) +
-			'/' +
-			encodeURIComponent( query.slug ) +
-			'/update',
-		{ apiVersion: '1.2' },
-		params,
-		fn
-	);
-};
-
 Undocumented.prototype.followList = function ( query, fn ) {
 	const params = omit( query, [ 'owner', 'slug' ] );
 	debug( '/read/lists/:owner/:slug/follow' );

--- a/client/reader/list-manage/index.jsx
+++ b/client/reader/list-manage/index.jsx
@@ -27,7 +27,7 @@ import { createReaderList, updateReaderList } from 'state/reader/lists/actions';
 import ReaderExportButton from 'blocks/reader-export-button';
 import { READER_EXPORT_TYPE_LIST } from 'blocks/reader-export-button/constants';
 import ListItem from './list-item';
-import ListForm from './list-form.jsx';
+import ListForm from './list-form';
 
 /**
  * Style dependencies

--- a/client/reader/list-manage/index.jsx
+++ b/client/reader/list-manage/index.jsx
@@ -13,149 +13,38 @@ import {
 	getListByOwnerAndSlug,
 	getListItems,
 	isCreatingList as isCreatingListSelector,
+	isUpdatingList as isUpdatingListSelector,
 } from 'state/reader/lists/selectors';
 import FormattedHeader from 'components/formatted-header';
-import FormButtonsBar from 'components/forms/form-buttons-bar';
-import FormButton from 'components/forms/form-button';
-import FormFieldset from 'components/forms/form-fieldset';
-import FormLabel from 'components/forms/form-label';
-import FormLegend from 'components/forms/form-legend';
-import FormRadio from 'components/forms/form-radio';
 import FormSectionHeading from 'components/forms/form-section-heading';
-import FormSettingExplanation from 'components/forms/form-setting-explanation';
-import FormTextInput from 'components/forms/form-text-input';
-import FormTextarea from 'components/forms/form-textarea';
 import QueryReaderList from 'components/data/query-reader-list';
 import QueryReaderListItems from 'components/data/query-reader-list-items';
 import SectionNav from 'components/section-nav';
 import NavTabs from 'components/section-nav/tabs';
 import NavItem from 'components/section-nav/item';
 import Main from 'components/main';
-import { createReaderList } from 'state/reader/lists/actions';
+import { createReaderList, updateReaderList } from 'state/reader/lists/actions';
 import ReaderExportButton from 'blocks/reader-export-button';
 import { READER_EXPORT_TYPE_LIST } from 'blocks/reader-export-button/constants';
 import ListItem from './list-item';
+import ListForm from './list-form.jsx';
 
 /**
  * Style dependencies
  */
 import './style.scss';
 
-function ListForm( { isCreateForm, isSubmissionDisabled, list, onChange, onSubmit } ) {
-	const translate = useTranslate();
-	const isNameValid = typeof list.title === 'string' && list.title.length > 0;
-	const isSlugValid = isCreateForm || ( typeof list.slug === 'string' && list.slug.length > 0 );
-	return (
-		<Card>
-			<FormFieldset>
-				<FormLabel htmlFor="list-name">{ translate( 'Name (Required)' ) }</FormLabel>
-				<FormTextInput
-					data-key="title"
-					id="list-name"
-					isValid={ isNameValid }
-					name="list-name"
-					onChange={ onChange }
-					value={ list.title }
-				/>
-				<FormSettingExplanation>{ translate( 'The name of the list.' ) }</FormSettingExplanation>
-			</FormFieldset>
-
-			{ ! isCreateForm && (
-				<FormFieldset>
-					<FormLabel htmlFor="list-slug">{ translate( 'Slug (Required)' ) }</FormLabel>
-					<FormTextInput
-						data-key="slug"
-						id="list-slug"
-						isValid={ isSlugValid }
-						name="list-slug"
-						onChange={ onChange }
-						value={ list.slug }
-					/>
-					<FormSettingExplanation>
-						{ translate( 'The slug for the list. This is used to build the URL to the list.' ) }
-					</FormSettingExplanation>
-				</FormFieldset>
-			) }
-
-			<FormFieldset>
-				<FormLegend>{ translate( 'Visibility' ) }</FormLegend>
-				<FormLabel>
-					<FormRadio
-						checked={ list.is_public }
-						data-key="is_public"
-						onChange={ onChange }
-						value="public"
-					/>
-					<span>{ translate( 'Everyone can view this list' ) }</span>
-				</FormLabel>
-
-				<FormLabel>
-					<FormRadio
-						checked={ ! list.is_public }
-						data-key="is_public"
-						onChange={ onChange }
-						value="private"
-					/>
-					<span>{ translate( 'Only I can view this list' ) }</span>
-				</FormLabel>
-				<FormSettingExplanation>
-					{ translate(
-						"Don't worry, posts from private sites will only appear to those with access. " +
-							'Adding a private site to a public list will not make posts from that site accessible to everyone.'
-					) }
-				</FormSettingExplanation>
-			</FormFieldset>
-
-			<FormFieldset>
-				<FormLabel htmlFor="list-description">{ translate( 'Description' ) }</FormLabel>
-				<FormTextarea
-					data-key="description"
-					id="list-description"
-					name="list-description"
-					onChange={ onChange }
-					placeholder={ translate( "What's your list about?" ) }
-					value={ list.description }
-				/>
-			</FormFieldset>
-			<FormButtonsBar>
-				<FormButton
-					primary
-					disabled={ isSubmissionDisabled || ! isNameValid || ! isSlugValid }
-					onClick={ onSubmit }
-				>
-					{ translate( 'Save' ) }
-				</FormButton>
-			</FormButtonsBar>
-		</Card>
-	);
-}
-
 function ReaderListCreate() {
-	const translate = useTranslate();
 	const dispatch = useDispatch();
+	const translate = useTranslate();
 	const isCreatingList = useSelector( isCreatingListSelector );
-	const [ list, updateList ] = React.useState( {
-		description: '',
-		is_public: true,
-		slug: '',
-		title: '',
-	} );
-	const onChange = ( event ) => {
-		const update = { [ event.target.dataset.key ]: event.target.value };
-		if ( 'is_public' in update ) {
-			update.is_public = update.is_public === 'public';
-		}
-		updateList( { ...list, ...update } );
-	};
 	return (
 		<Main>
 			<FormattedHeader headerText={ translate( 'Create List' ) } />
 			<ListForm
 				isCreateForm
 				isSubmissionDisabled={ isCreatingList }
-				list={ list }
-				onChange={ onChange }
-				onSubmit={ () => dispatch( createReaderList( list ) ) }
+				onSubmit={ ( list ) => dispatch( createReaderList( list ) ) }
 			/>
 		</Main>
 	);
@@ -163,7 +52,9 @@ function ReaderListCreate() {
 
 function ReaderListEdit( props ) {
 	const { selectedSection } = props;
+	const dispatch = useDispatch();
 	const translate = useTranslate();
+	const isUpdatingList = useSelector( isUpdatingListSelector );
 	const list = useSelector( ( state ) => getListByOwnerAndSlug( state, props.owner, props.slug ) );
 	const listItems = useSelector( ( state ) =>
 		list ? getListItems( state, list.ID ) : undefined
@@ -209,7 +100,11 @@ function ReaderListEdit( props ) {
 						</SectionNav>
 						{ selectedSection === 'details' && (
 							<>
-								<ListForm list={ list } />
+								<ListForm
+									list={ list }
+									isSubmissionDisabled={ isUpdatingList }
+									onSubmit={ ( formList ) => dispatch( updateReaderList( formList ) ) }
+								/>
 
 								<Card>
 									<FormSectionHeading>DANGER!!</FormSectionHeading>

--- a/client/reader/list-manage/list-form.jsx
+++ b/client/reader/list-manage/list-form.jsx
@@ -1,0 +1,129 @@
+/**
+ * External dependencies
+ */
+import * as React from 'react';
+import { useTranslate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { Card } from '@automattic/components';
+import FormButtonsBar from 'components/forms/form-buttons-bar';
+import FormButton from 'components/forms/form-button';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormLabel from 'components/forms/form-label';
+import FormLegend from 'components/forms/form-legend';
+import FormRadio from 'components/forms/form-radio';
+import FormSettingExplanation from 'components/forms/form-setting-explanation';
+import FormTextInput from 'components/forms/form-text-input';
+import FormTextarea from 'components/forms/form-textarea';
+
+const INITIAL_UPDATE_FORM_STATE = {
+	description: '',
+	is_public: true,
+	title: '',
+};
+const INITIAL_CREATE_FORM_STATE = {
+	...INITIAL_UPDATE_FORM_STATE,
+	slug: '',
+};
+
+export default function ListForm( { isCreateForm, isSubmissionDisabled, list, onSubmit } ) {
+	const translate = useTranslate();
+	const isNameValid = typeof list.title === 'string' && list.title.length > 0;
+	const isSlugValid = isCreateForm || ( typeof list.slug === 'string' && list.slug.length > 0 );
+	const [ formList, updateFormList ] = React.useState(
+		isCreateForm ? INITIAL_CREATE_FORM_STATE : { ...INITIAL_UPDATE_FORM_STATE, ...list }
+	);
+	const onChange = ( event ) => {
+		const update = { [ event.target.dataset.key ]: event.target.value };
+		if ( 'is_public' in update ) {
+			update.is_public = update.is_public === 'public';
+		}
+		updateFormList( { ...formList, ...update } );
+	};
+
+	return (
+		<Card>
+			<FormFieldset>
+				<FormLabel htmlFor="list-name">{ translate( 'Name (Required)' ) }</FormLabel>
+				<FormTextInput
+					data-key="title"
+					id="list-name"
+					isValid={ isNameValid }
+					name="list-name"
+					onChange={ onChange }
+					value={ formList.title }
+				/>
+				<FormSettingExplanation>{ translate( 'The name of the list.' ) }</FormSettingExplanation>
+			</FormFieldset>
+
+			{ ! isCreateForm && (
+				<FormFieldset>
+					<FormLabel htmlFor="list-slug">{ translate( 'Slug (Required)' ) }</FormLabel>
+					<FormTextInput
+						data-key="slug"
+						id="list-slug"
+						isValid={ isSlugValid }
+						name="list-slug"
+						onChange={ onChange }
+						value={ formList.slug }
+					/>
+					<FormSettingExplanation>
+						{ translate( 'The slug for the list. This is used to build the URL to the list.' ) }
+					</FormSettingExplanation>
+				</FormFieldset>
+			) }
+
+			<FormFieldset>
+				<FormLegend>{ translate( 'Visibility' ) }</FormLegend>
+				<FormLabel>
+					<FormRadio
+						checked={ formList.is_public }
+						data-key="is_public"
+						onChange={ onChange }
+						value="public"
+					/>
+					<span>{ translate( 'Everyone can view this list' ) }</span>
+				</FormLabel>
+
+				<FormLabel>
+					<FormRadio
+						checked={ ! formList.is_public }
+						data-key="is_public"
+						onChange={ onChange }
+						value="private"
+					/>
+					<span>{ translate( 'Only I can view this list' ) }</span>
+				</FormLabel>
+				<FormSettingExplanation>
+					{ translate(
+						"Don't worry, posts from private sites will only appear to those with access. " +
+							'Adding a private site to a public list will not make posts from that site accessible to everyone.'
+					) }
+				</FormSettingExplanation>
+			</FormFieldset>
+
+			<FormFieldset>
+				<FormLabel htmlFor="list-description">{ translate( 'Description' ) }</FormLabel>
+				<FormTextarea
+					data-key="description"
+					id="list-description"
+					name="list-description"
+					onChange={ onChange }
+					placeholder={ translate( "What's your list about?" ) }
+					value={ formList.description }
+				/>
+			</FormFieldset>
+			<FormButtonsBar>
+				<FormButton
+					primary
+					disabled={ isSubmissionDisabled || ! isNameValid || ! isSlugValid }
+					onClick={ () => onSubmit( formList ) }
+				>
+					{ translate( 'Save' ) }
+				</FormButton>
+			</FormButtonsBar>
+		</Card>
+	);
+}

--- a/client/state/data-layer/wpcom/read/lists/index.js
+++ b/client/state/data-layer/wpcom/read/lists/index.js
@@ -1,11 +1,21 @@
 /**
+ * External dependencies
+ */
+import { translate } from 'i18n-calypso';
+
+/**
  * Internal dependencies
  */
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
-import { errorNotice } from 'state/notices/actions';
-import { READER_LIST_CREATE } from 'state/reader/action-types';
-import { receiveReaderList, handleReaderListRequestFailure } from 'state/reader/lists/actions';
+import { errorNotice, successNotice } from 'state/notices/actions';
+import { READER_LIST_CREATE, READER_LIST_UPDATE } from 'state/reader/action-types';
+import {
+	handleReaderListRequestFailure,
+	handleUpdateListDetailsError,
+	receiveReaderList,
+	receiveUpdatedListDetails,
+} from 'state/reader/lists/actions';
 import { registerHandlers } from 'state/data-layer/handler-registry';
 import { navigate } from 'state/ui/actions';
 
@@ -33,6 +43,29 @@ registerHandlers( 'state/data-layer/wpcom/read/lists/index.js', {
 			onError: ( action, error ) => [
 				errorNotice( String( error ) ),
 				handleReaderListRequestFailure( error ),
+			],
+		} ),
+	],
+	[ READER_LIST_UPDATE ]: [
+		dispatchRequest( {
+			fetch: ( action ) => {
+				return http(
+					{
+						method: 'POST',
+						path: `/read/lists/${ action.list.owner }/${ action.list.slug }/update`,
+						apiVersion: '1.2',
+						body: action.list,
+					},
+					action
+				);
+			},
+			onSuccess: ( action, response ) => [
+				receiveUpdatedListDetails( response ),
+				successNotice( translate( 'List updated successfully!' ) ),
+			],
+			onError: ( action, error ) => [
+				errorNotice( String( error ) ),
+				handleUpdateListDetailsError( error ),
 			],
 		} ),
 	],

--- a/client/state/reader/lists/actions.js
+++ b/client/state/reader/lists/actions.js
@@ -214,43 +214,43 @@ export function unfollowList( owner, slug ) {
 /**
  * Triggers a network request to update a list's details.
  *
- * @param  {object}  list List details to save
- * @returns {Function} Action promise
+ * @param   {object} list List details to save
+ * @returns {object} Action object
  */
-export function updateListDetails( list ) {
+export function updateReaderList( list ) {
 	if ( ! list || ! list.owner || ! list.slug || ! list.title ) {
 		throw new Error( 'List owner, slug and title are required' );
 	}
 
-	const preparedOwner = decodeURIComponent( list.owner );
-	const preparedSlug = decodeURIComponent( list.slug );
-	const preparedList = Object.assign( {}, list, { owner: preparedOwner, slug: preparedSlug } );
+	return {
+		type: READER_LIST_UPDATE,
+		list,
+	};
+}
 
-	return ( dispatch ) => {
-		dispatch( {
-			type: READER_LIST_UPDATE,
-			list,
-		} );
+/**
+ * Handle updated list object from the API.
+ *
+ * @param   {object} data List to save
+ * @returns {object} Action object
+ */
+export function receiveUpdatedListDetails( data ) {
+	return {
+		type: READER_LIST_UPDATE_SUCCESS,
+		data,
+	};
+}
 
-		return new Promise( ( resolve, reject ) => {
-			wpcom.undocumented().readListsUpdate( preparedList, ( error, data ) => {
-				if ( error ) {
-					dispatch( {
-						type: READER_LIST_UPDATE_FAILURE,
-						list,
-						error,
-					} );
-					reject( error );
-				} else {
-					dispatch( {
-						type: READER_LIST_UPDATE_SUCCESS,
-						list,
-						data,
-					} );
-					resolve();
-				}
-			} );
-		} );
+/**
+ * Handle an error from the list update API.
+ *
+ * @param   {Error}  error Error during the list update process
+ * @returns {object} Action object
+ */
+export function handleUpdateListDetailsError( error ) {
+	return {
+		type: READER_LIST_UPDATE_FAILURE,
+		error,
 	};
 }
 

--- a/client/state/reader/lists/reducer.js
+++ b/client/state/reader/lists/reducer.js
@@ -13,6 +13,7 @@ import {
 	READER_LIST_REQUEST,
 	READER_LIST_REQUEST_SUCCESS,
 	READER_LIST_REQUEST_FAILURE,
+	READER_LIST_UPDATE,
 	READER_LIST_UPDATE_SUCCESS,
 	READER_LIST_UPDATE_FAILURE,
 	READER_LIST_UPDATE_TITLE,
@@ -183,6 +184,24 @@ export function isCreatingList( state = false, action ) {
 }
 
 /**
+ * Records if there is a pending list update request.
+ *
+ * @param  {object} state  Current state
+ * @param  {object} action Action payload
+ * @returns {object}        Updated state
+ */
+export function isUpdatingList( state = false, action ) {
+	switch ( action.type ) {
+		case READER_LIST_UPDATE:
+		case READER_LIST_UPDATE_SUCCESS:
+		case READER_LIST_UPDATE_FAILURE:
+			return READER_LIST_UPDATE === action.type;
+	}
+
+	return state;
+}
+
+/**
  * Returns the updated requests state after an action has been dispatched.
  *
  * @param  {object} state  Current state
@@ -260,6 +279,7 @@ export default combineReducers( {
 	isCreatingList,
 	isRequestingList,
 	isRequestingLists,
+	isUpdatingList,
 	errors,
 	missingLists,
 } );

--- a/client/state/reader/lists/selectors.js
+++ b/client/state/reader/lists/selectors.js
@@ -43,6 +43,16 @@ export function isCreatingList( state ) {
 }
 
 /**
+ * Returns true if currently updating a Reader list.
+ *
+ * @param  {object}  state  Global state tree
+ * @returns {boolean}        Whether lists are being requested
+ */
+export function isUpdatingList( state ) {
+	return !! state.reader.lists.isUpdatingList;
+}
+
+/**
  * Returns the user's subscribed Reader lists.
  *
  * @param  {object}  state  Global state tree

--- a/client/state/reader/lists/test/actions.js
+++ b/client/state/reader/lists/test/actions.js
@@ -13,7 +13,6 @@ import {
 	requestSubscribedLists,
 	followList,
 	unfollowList,
-	updateListDetails,
 	dismissListNotice,
 	updateTitle,
 	updateDescription,
@@ -21,7 +20,6 @@ import {
 import {
 	READER_LIST_DISMISS_NOTICE,
 	READER_LIST_REQUEST,
-	READER_LIST_UPDATE,
 	READER_LISTS_RECEIVE,
 	READER_LISTS_REQUEST,
 	READER_LISTS_FOLLOW,
@@ -142,26 +140,6 @@ describe( 'actions', () => {
 				type: READER_LISTS_UNFOLLOW,
 				owner: 'restapitests',
 				slug: 'testlist',
-			} );
-		} );
-	} );
-
-	describe( '#updateListDetails()', () => {
-		useNock( ( nock ) => {
-			nock( 'https://public-api.wordpress.com:443' )
-				.post( '/rest/v1.2/read/lists/restapitests/testlist/update' )
-				.reply( 200, {
-					following: false,
-				} );
-		} );
-
-		test( 'should dispatch fetch action when thunk triggered', () => {
-			const list = { owner: 'restapitests', slug: 'testlist', title: 'Banana' };
-			updateListDetails( list )( spy );
-
-			expect( spy ).to.have.been.calledWith( {
-				type: READER_LIST_UPDATE,
-				list,
 			} );
 		} );
 	} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Implements data layer logic for updating reader lists.
* Removes a now-unused wpcom-undocumented function.
* Makes the update form at `/read/list/:user/:slug/edit` functional.

#### Testing instructions

* Open a list at `/read/list/:user/:slug/edit`.
* Try updating the name, slug, privacy settings, and description.