### PR TITLE
Invites: fix e2e fails

### DIFF
--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -83,8 +83,16 @@ class InvitePeople extends React.Component {
 		InvitesSentStore.off( 'change', this.refreshFormState );
 	}
 
-	UNSAFE_componentWillReceiveProps() {
-		this.setState( this.resetState() );
+	UNSAFE_componentWillReceiveProps( nextProps ) {
+		if (
+			this.props.siteId !== nextProps.siteId ||
+			this.props.needsVerification !== nextProps.needsVerification ||
+			this.props.showSSONotice !== nextProps.showSSONotice ||
+			this.props.isJetpack !== nextProps.isJetpack ||
+			this.props.isSiteAutomatedTransfer !== nextProps.isSiteAutomatedTransfer
+		) {
+			this.setState( this.resetState() );
+		}
 	}
 
 	resetState = () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Exclude updates to certain props (props for Invite Links we're sure are unrelated to the Invite People form) from triggering the `this.setState( this.resetState() );` inside `UNSAFE_componentWillReceiveProps( nextProps )`

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* e2e tests should pass
* smoke test: Invite page should work the same

Fixes #43247 
