### PR TITLE
Reader: Fix Comments Form Overlap with Button

### DIFF
--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -6,6 +6,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { translate } from 'i18n-calypso';
 import { get, size, takeRight, delay } from 'lodash';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -417,7 +418,11 @@ class PostCommentList extends React.Component {
 		const showManageCommentsButton = this.props.canUserModerateComments && commentCount > 0;
 
 		return (
-			<div className="comments__comment-list">
+			<div
+				className={ classnames( 'comments__comment-list', {
+					'has-double-actions': showManageCommentsButton && showConversationFollowButton,
+				} ) }
+			>
 				{ ( this.props.showCommentCount || showViewMoreComments ) && (
 					<div className="comments__info-bar">
 						{ this.props.showCommentCount && <CommentCount count={ actualCommentsCount } /> }
@@ -434,6 +439,7 @@ class PostCommentList extends React.Component {
 					</div>
 				) }
 				<div className="comments__actions-wrapper">
+					{ showManageCommentsButton && this.renderCommentManageLink() }
 					{ showConversationFollowButton && (
 						<ConversationFollowButton
 							className="comments__conversation-follow-button"
@@ -443,7 +449,6 @@ class PostCommentList extends React.Component {
 							followSource={ followSource }
 						/>
 					) }
-					{ showManageCommentsButton && this.renderCommentManageLink() }
 				</div>
 				{ showFilters && (
 					<SegmentedControl compact primary>

--- a/client/blocks/comments/post-comment-list.scss
+++ b/client/blocks/comments/post-comment-list.scss
@@ -10,7 +10,6 @@
 	}
 
 	.comments__conversation-follow-button {
-		float: right;
 		margin-top: 4px;
 		margin-left: 14px;
 		text-align: right;
@@ -39,8 +38,12 @@
 }
 
 .comments__info-bar {
-	margin: 0 8px -8px 0;
+	margin: 0 36px -36px 0;
 	width: 100%;
+
+	.comments__comment-list.has-double-actions & {
+		margin: 0 8px -8px 0; // move to a separate line to prevent an overlap
+	}
 
 	&.is-no-comments {
 		display: none;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Sorry, this is a defect caused by #43093 which I didn't spot: on a post with no comments, the Submit Comments form overlaps with the "Follow Conversation" button.

<img width="820" alt="Screenshot 2020-06-13 at 08 20 09" src="https://user-images.githubusercontent.com/43215253/84562880-6e228880-ad4f-11ea-8126-016154cc2f09.png">

#### Testing instructions

This PR reverts back to how it was before #43093; when there's a single action, keep things in the same line.

<img width="792" alt="Screenshot 2020-06-13 at 08 20 24" src="https://user-images.githubusercontent.com/43215253/84562888-81355880-ad4f-11ea-8899-7e3f5fba1123.png">

A second row is still necessary when there's two actions in order to prevent an overlap, and that should still work fine.

<img width="873" alt="Screenshot 2020-06-13 at 08 20 36" src="https://user-images.githubusercontent.com/43215253/84562899-97431900-ad4f-11ea-938a-04db817956f2.png">

cc @gwwar, @bluefuton 
