### PR TITLE
composite-checkout: Add error boundary around top level

### DIFF
--- a/client/my-sites/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout-system-decider.js
@@ -5,7 +5,7 @@ import React, { useEffect, useCallback } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import debugFactory from 'debug';
 import wp from 'lib/wp';
-import CheckoutErrorBoundary from '@automattic/composite-checkout';
+import { CheckoutErrorBoundary } from '@automattic/composite-checkout';
 import { useTranslate } from 'i18n-calypso';
 
 /**

--- a/client/my-sites/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout-system-decider.js
@@ -1,10 +1,12 @@
 /**
  * External dependencies
  */
-import React, { useEffect } from 'react';
+import React, { useEffect, useCallback } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import debugFactory from 'debug';
 import wp from 'lib/wp';
+import CheckoutErrorBoundary from '@automattic/composite-checkout';
+import { useTranslate } from 'i18n-calypso';
 
 /**
  * Internal Dependencies
@@ -55,6 +57,7 @@ export default function CheckoutSystemDecider( {
 		isJetpack,
 		isAtomic
 	);
+	const translate = useTranslate();
 
 	useEffect( () => {
 		if ( product ) {
@@ -86,7 +89,23 @@ export default function CheckoutSystemDecider( {
 		}
 	}, [ reduxDispatch, checkoutVariant, product ] );
 
-	// TODO: fetch the current cart, ideally without using CartData, and use that to pass to shouldShowCompositeCheckout
+	const logCheckoutError = useCallback(
+		( error ) => {
+			reduxDispatch(
+				logToLogstash( {
+					feature: 'calypso_client',
+					message: 'composite checkout load error',
+					severity: config( 'env_id' ) === 'production' ? 'error' : 'debug',
+					extra: {
+						env: config( 'env_id' ),
+						type: 'checkout_system_decider',
+						message: String( error.message ),
+					},
+				} )
+			);
+		},
+		[ reduxDispatch ]
+	);
 
 	if ( ! cart || ! cart.currency ) {
 		debug( 'not deciding yet; cart has not loaded' );
@@ -95,20 +114,25 @@ export default function CheckoutSystemDecider( {
 
 	if ( 'composite-checkout' === checkoutVariant ) {
 		return (
-			<StripeHookProvider fetchStripeConfiguration={ fetchStripeConfigurationWpcom }>
-				<CompositeCheckout
-					siteSlug={ selectedSite?.slug }
-					siteId={ selectedSite?.ID }
-					product={ product }
-					purchaseId={ purchaseId }
-					couponCode={ couponCode }
-					redirectTo={ redirectTo }
-					feature={ selectedFeature }
-					plan={ plan }
-					cart={ cart }
-					isWhiteGloveOffer={ isWhiteGloveOffer }
-				/>
-			</StripeHookProvider>
+			<CheckoutErrorBoundary
+				errorMessage={ translate( 'Sorry. there was an error loading this page' ) }
+				onError={ logCheckoutError }
+			>
+				<StripeHookProvider fetchStripeConfiguration={ fetchStripeConfigurationWpcom }>
+					<CompositeCheckout
+						siteSlug={ selectedSite?.slug }
+						siteId={ selectedSite?.ID }
+						product={ product }
+						purchaseId={ purchaseId }
+						couponCode={ couponCode }
+						redirectTo={ redirectTo }
+						feature={ selectedFeature }
+						plan={ plan }
+						cart={ cart }
+						isWhiteGloveOffer={ isWhiteGloveOffer }
+					/>
+				</StripeHookProvider>
+			</CheckoutErrorBoundary>
 		);
 	}
 

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -57,6 +57,7 @@ The [Checkout](#checkout) component creates a wrapper for Checkout. Within the c
  - [CheckoutSteps](#CheckoutSteps) (with [CheckoutStep](#CheckoutStep) children) can be used to create a series of steps that are joined by "Continue" buttons which are hidden and displayed as needed.
  - [CheckoutStep](#CheckoutStep) (optional) children of `CheckoutSteps` can be used to create a series of steps that are joined by "Continue" buttons which are hidden and displayed as needed.
  - [Button](#Button) (optional) a generic button component that can be used to match the button styles of those buttons used inside the package (like the continue button on each step).
+ - [CheckoutErrorBoundary](#CheckoutErrorBoundary) (optional) a [React error boundary](https://reactjs.org/docs/error-boundaries.html) that can be used to wrap any components you like.
 
 Each `CheckoutStep` has an `isCompleteCallback` prop, which will be called when the "Continue" button is pressed. It can perform validation on that step's contents to determine if the form should continue to the next step. If the function returns true, the form continues to the next step, otherwise it remains on the same step. If the function returns a `Promise`, then the "Continue" button will change to "Please wait…" until the Promise resolves allowing for async operations. The value resolved by the Promise must be a boolean; true to continue, false to stay on the current step.
 
@@ -141,6 +142,14 @@ The main wrapper component for Checkout. It has the following props.
 
 - `className?: string`. The className for the component.
 
+### CheckoutErrorBoundary
+
+A [React error boundary](https://reactjs.org/docs/error-boundaries.html) that can be used to wrap any components you like. There are several layers of these already built-in to `CheckoutProvider` and its children, but you may use this to manually wrap components. It has the following props.
+
+
+- `errorMessage: React.ReactNode`. The error message to display to the user if there is a problem; typically a string but can also be a component.
+- `onError?: (Error) => void`. A function to be called when there is an error. Can be used for logging.
+
 ### CheckoutProvider
 
 Renders its `children` prop and acts as a React Context provider. All of checkout should be wrapped in this.
@@ -155,8 +164,8 @@ It has the following props.
 - `showInfoMessage: (string) => null`. A function that will display a message with an "info" type.
 - `showSuccessMessage: (string) => null`. A function that will display a message with a "success" type.
 - `onEvent?: (action) => null`. A function called for all sorts of events in the code. The callback will be called with a [Flux Standard Action](https://github.com/redux-utilities/flux-standard-action).
-- `paymentMethods: object[]`: An array of [Payment Method objects](#payment-methods).
-- `paymentProcessors: object`: A key-value map of payment processor functions (see [Payment Methods](#payment-methods)).
+- `paymentMethods: object[]`. An array of [Payment Method objects](#payment-methods).
+- `paymentProcessors: object`. A key-value map of payment processor functions (see [Payment Methods](#payment-methods)).
 - `registry?: object`. An object returned by [createRegistry](#createRegistry). If not provided, the default registry will be used.
 - `isLoading?: boolean`. If set and true, the form will be replaced with a loading placeholder and the form status will be set to 'loading' (see [useFormStatus](#useFormStatus)).
 - `isValidating?: boolean`. If set and true, the form status will be set to 'validating' (see [useFormStatus](#useFormStatus)).

--- a/packages/composite-checkout/src/components/checkout-error-boundary.js
+++ b/packages/composite-checkout/src/components/checkout-error-boundary.js
@@ -34,7 +34,7 @@ export default class CheckoutErrorBoundary extends React.Component {
 }
 
 CheckoutErrorBoundary.propTypes = {
-	errorMessage: PropTypes.string.isRequired,
+	errorMessage: PropTypes.node.isRequired,
 	onError: PropTypes.func,
 };
 

--- a/packages/composite-checkout/src/public-api.js
+++ b/packages/composite-checkout/src/public-api.js
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import Button from './components/button';
+import CheckoutErrorBoundary from './components/checkout-error-boundary';
 import { CheckoutProvider, useEvents, useMessages } from './components/checkout-provider';
 import {
 	Checkout,
@@ -63,6 +64,7 @@ export {
 	Button,
 	Checkout,
 	CheckoutCheckIcon,
+	CheckoutErrorBoundary,
 	CheckoutModal,
 	CheckoutOrderSummary,
 	CheckoutOrderSummaryStep,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This adds a [React error boundary](https://reactjs.org/docs/error-boundaries.html) around the entire component tree of composite checkout starting at `CheckoutSystemDecider`. Hopefully this will never be hit because composite checkout already has several layers of error boundaries within `CheckoutProvider` but it will give us the opportunity to:

1. Prevent the user from seeing a blank screen if something at the top level fails.
2. Record such errors and report them to logstash where they will ping us in Slack.

#### Testing instructions

- Trigger a fatal error inside the `CompositeCheckout` component itself.
- Verify that the logstash logs for the string `composite checkout load error` get a new entry.