### PR TITLE
Fix social account creation on the WooCommerce and WooDNA flows

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -635,7 +635,7 @@ class SignupForm extends Component {
 
 	handleWooCommerceSocialConnect = ( ...args ) => {
 		this.recordWooCommerceSignupTracks( 'social' );
-		this.props.handleSocialResponse( args );
+		this.props.handleSocialResponse( ...args );
 	};
 
 	handleWooCommerceSubmit = ( event ) => {


### PR DESCRIPTION
This PR fixes an error when creating a Social (Google) account in the WooDNA flow. It probably also affects the existing WooCommerce onboarding flow.

### Testing instructions
- Go into the Woo DNA connection flow, logged out.
- Input a GMail email that you haven't used for WordPress.com.
- On the signup form, click "Continue with Google", and continue with the process.
- On `master`, you'll get [this error](https://cloudup.com/cXPGtrSWpIv). On this PR it will work.