### PR TITLE
Fix the UI/state logic transitions on the WooDNA flow

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -635,7 +635,7 @@ class SignupForm extends Component {
 
 	handleWooCommerceSocialConnect = ( ...args ) => {
 		this.recordWooCommerceSignupTracks( 'social' );
-		this.props.handleSocialResponse( args );
+		this.props.handleSocialResponse( ...args );
 	};
 
 	handleWooCommerceSubmit = ( event ) => {

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -66,14 +66,12 @@ export class JetpackSignup extends Component {
 		translate: PropTypes.func.isRequired,
 	};
 
-	static initialState = Object.freeze( {
+	state = {
 		isCreatingAccount: false,
 		newUsername: null,
 		bearerToken: null,
 		wooDnaFormType: 'login',
-	} );
-
-	state = this.constructor.initialState;
+	};
 
 	UNSAFE_componentWillMount() {
 		const { from, clientId } = this.props.authQuery;

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -75,10 +75,6 @@ export class JetpackSignup extends Component {
 
 	state = this.constructor.initialState;
 
-	resetState() {
-		this.setState( this.constructor.initialState );
-	}
-
 	UNSAFE_componentWillMount() {
 		const { from, clientId } = this.props.authQuery;
 		this.props.recordTracksEvent( 'calypso_jpc_authorize_form_view', {
@@ -114,6 +110,7 @@ export class JetpackSignup extends Component {
 	showWooDnaSignupView = () => {
 		this.setState( {
 			wooDnaFormType: 'signup',
+			signUpUsernameOrEmail: null,
 		} );
 		this.props.resetAuthAccountType();
 	};
@@ -202,7 +199,11 @@ export class JetpackSignup extends Component {
 	handleUserCreationError = ( error ) => {
 		const { errorNotice, translate, warningNotice } = this.props;
 		debug( 'Signup error: %o', error );
-		this.resetState();
+		this.setState( {
+			newUsername: null,
+			bearerToken: null,
+			isCreatingAccount: false,
+		} );
 		if ( error && 'user_exists' === error.code ) {
 			const text =
 				error.data && error.data.email


### PR DESCRIPTION
I found some weird behaviours in the Woo DNA flow while doing further testing, this PR solves them.

### To reproduce

#### Case 1
- Use the Woo DNA flow as usual, logged out.
- Go create a new account.
- On the signup form, set your password to be the same as your username.
- On `master`, you'll see an error notice and you'll get back to the initial "screen" of the flow. On this branch, you'll see the error notice but you won't be moved from the signup form.

#### Case 2
- Use the Woo DNA flow as usual, logged out.
- Input an existing username.
- On the full login form, instead of putting the password, click "Create new account". The username should be prefilled.
- Click "Create your account". Because the username is taken error will appear with a link to the "log in" form.
- Back on the "email-only" login form, put an username that doesn't exist. You'll be redirected to the signup form again.
- On `master`, the wrong username will be prefilled. That's fixed in this PR.