### PR TITLE
Gutenboarding: Fix font style preview position on mobile by removing height attribute

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
@@ -59,10 +59,10 @@
 .style-preview__content {
 	padding-bottom: $gutenboarding-footer-height + 28px;
 	display: flex; // needed for IE
-	height: 100%; // needed for IE
 
 	@include break-small {
 		padding-bottom: 0;
+		height: 100%; // needed for IE
 	}
 }
 


### PR DESCRIPTION
This PR fixes a CSS issue on Safari on mobile devices at narrow viewports where there is extra whitespace between the font options button and the preview on the style step in Gutenboarding.

#### Changes proposed in this Pull Request

* The `height: 100%` attribute was extending the font options area too far on mobile in Safari iOS, specifically, so this change moves it to only apply to the desktop layout.

#### Screenshots

##### Before (Safari mobile view)

![image](https://user-images.githubusercontent.com/14988353/84616985-f0a67600-af10-11ea-8a0c-482a4f9e3470.png)

##### After (Safari mobile view)

![image](https://user-images.githubusercontent.com/14988353/84617008-0a47bd80-af11-11ea-9d81-24f7369e979a.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On Safari on iOS mobile:
* Go to `/new` and complete steps until you reach the font selection / style step.
* The preview should appear directly below the font selection button, as in the screenshots above

* Test that this doesn't introduce a visual regression: on desktop (e.g. Safari, FF, Chrome), ensure that the preview still extends to the bottom of the onboarding block.

Fixes #
