### PR TITLE
Gutenboarding: Remove max-width override on the Design step

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -8,10 +8,6 @@
 	color: var( --mainColor );
 	padding-bottom: $gutenboarding-footer-height;
 
-	&.gutenboarding-page {
-		max-width: none;
-	}
-
 	.design-selector__header {
 		@include onboarding-heading-padding;
 


### PR DESCRIPTION
This is a bit of a speculative PR based on my personal preference. It removes the `max-width: none` override on the Design step in Gutenboarding so that the step has the same width as all the other steps (currently `1440px`).

I found it a bit jarring at a wide screen width moving between the design step and other steps, so thought I'd whip this up. Happy to throw it away if the consensus is to go in another direction!

#### Changes proposed in this Pull Request

* Remove `max-width: none` override on the Design step in Gutenboarding

#### Screenshots

![image](https://user-images.githubusercontent.com/14988353/84617885-c0aca200-af13-11ea-852c-29230c394898.png)

##### Animated gif (before)

Note the wide Design step after selecting a domain:

![design-width-before-small](https://user-images.githubusercontent.com/14988353/84618064-4deff680-af14-11ea-8db1-aa3166db83d6.gif)

##### Animated gif (after)

Note the Design step is the same width as the other steps after selecting a domain:

![design-width-after-small](https://user-images.githubusercontent.com/14988353/84618073-55af9b00-af14-11ea-9b9a-c2685e30bbfb.gif)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/new` in full screen on a large monitor (e.g. greater than 1440px wide).
* Enter a site title and select a domain.
* The width of the Design step should be the same as the other steps.

Fixes #
