### PR TITLE
Comments: style Gutenberg captions

### DIFF
--- a/client/blocks/comments/post-comment-content.scss
+++ b/client/blocks/comments/post-comment-content.scss
@@ -59,5 +59,12 @@
 	pre {
 		white-space: pre-wrap;
 	}
-}
 
+	figure figcaption {
+		padding: 12px;
+		margin: 0;
+		font-size: $font-body-small;
+		text-align: center;
+		color: var( --color-neutral-40 );
+	}
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When a Gutenberg editor is used to create comments, image captions use the `figcaption` element without a class name. Currently no styling is applied to these captions. This PR adds the same styling as the caption would receive in Reader full post.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Before:
 
<img width="799" alt="Screen Shot 2020-06-15 at 17 21 48" src="https://user-images.githubusercontent.com/17325/84620675-bc40b300-af2c-11ea-83ae-265ac36db83a.png">

After:

<img width="806" alt="Screen Shot 2020-06-15 at 17 21 14" src="https://user-images.githubusercontent.com/17325/84620686-c19dfd80-af2c-11ea-9a1a-ddd0877f92bc.png">



