### PR TITLE
Gutenboarding: Prevent autofocus on email field in signup on mobile

### DIFF
--- a/client/landing/gutenboarding/components/signup-form/index.tsx
+++ b/client/landing/gutenboarding/components/signup-form/index.tsx
@@ -196,7 +196,7 @@ const SignupForm = ( { onRequestClose }: Props ) => {
 							onChange={ setEmailVal }
 							placeholder={ __( 'Email address' ) }
 							required
-							autoFocus={ isMobile ? false : true } // eslint-disable-line jsx-a11y/no-autofocus
+							autoFocus={ ! isMobile } // eslint-disable-line jsx-a11y/no-autofocus
 						/>
 
 						<TextControl

--- a/client/landing/gutenboarding/components/signup-form/index.tsx
+++ b/client/landing/gutenboarding/components/signup-form/index.tsx
@@ -3,6 +3,7 @@
  */
 import React, { useState, useEffect } from 'react';
 import { Button, ExternalLink, TextControl, Modal, Notice } from '@wordpress/components';
+import { useViewportMatch } from '@wordpress/compose';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
 import { useI18n } from '@automattic/react-i18n';
@@ -42,6 +43,7 @@ const SignupForm = ( { onRequestClose }: Props ) => {
 	const langParam = useLangRouteParam();
 	const makePath = usePath();
 	const currentStep = useCurrentStep();
+	const isMobile = useViewportMatch( 'small', '<' );
 
 	const closeModal = () => {
 		clearErrors();
@@ -194,7 +196,7 @@ const SignupForm = ( { onRequestClose }: Props ) => {
 							onChange={ setEmailVal }
 							placeholder={ __( 'Email address' ) }
 							required
-							autoFocus={ true } // eslint-disable-line jsx-a11y/no-autofocus
+							autoFocus={ isMobile ? false : true } // eslint-disable-line jsx-a11y/no-autofocus
 						/>
 
 						<TextControl


### PR DESCRIPTION
Raised in pbAok1-11X-p2#comment-2074. Broadly the idea is:

Autofocusing the email field on the signup step in Gutenboarding prevents the user from seeing the rest of the step / context for entering their info. This change only sets the `autofocus` attribute on the field if the user is in a larger than `small` viewport (e.g. desktop).

#### Changes proposed in this Pull Request

* Set `autoFocus: false` on the email field in the Gutenboarding signup form if the viewport is `<` than `small`.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In an incognito / private browser window, go to `/new` and complete the flow until you get to the signup step
* On desktop, the email field should automatically be focused — you can start typing an email address without having to click the field
* On mobile, at this step the email field should not be focused, you will need to click the email to bring up the keyboard

Fixes #
