### PR TITLE
Add RUM collector for blocking scripts

### DIFF
--- a/packages/browser-data-collector/src/api/resources-timing.ts
+++ b/packages/browser-data-collector/src/api/resources-timing.ts
@@ -1,0 +1,2 @@
+export const getResources = (): PerformanceResourceTiming[] =>
+	( window?.performance?.getEntriesByType( 'resource' ) as PerformanceResourceTiming[] ) || [];

--- a/packages/browser-data-collector/src/collectors/blocking-resources.ts
+++ b/packages/browser-data-collector/src/collectors/blocking-resources.ts
@@ -1,0 +1,58 @@
+/**
+ * Internal dependencies
+ */
+import { getResources } from '../api/resources-timing';
+import { getDomContentLoadedEventStart, getNavigationStart } from '../api/performance-timing';
+
+export const collector: Collector = ( report ) => {
+	const domContentLoaded = getDomContentLoadedEventStart() - getNavigationStart();
+	if ( domContentLoaded <= 0 ) return report;
+
+	/**
+	 * Fetch resources that
+	 * 	- are scripts
+	 *  - finish downloading before domContentLoaded
+	 *  - have a size (to exclude resources form a different origin)
+	 */
+	const blockingResources = getResources().filter(
+		( r ) =>
+			r.initiatorType === 'script' && r.responseEnd <= domContentLoaded && r.decodedBodySize > 0
+	);
+
+	const resourcesCount = blockingResources.length;
+	const resourcesStart = blockingResources.sort( ( a, b ) => a.requestStart - b.requestStart )[ 0 ]
+		.requestStart;
+	const resourcesEnd = blockingResources.sort( ( a, b ) => b.requestStart - a.requestStart )[ 0 ]
+		.responseEnd;
+
+	const {
+		resourcesCompressed,
+		resourcesUncompressed,
+		resourcesTransferred,
+	} = blockingResources.reduce(
+		( acc, script ) => ( {
+			resourcesCompressed: acc.resourcesCompressed + script.encodedBodySize,
+			resourcesUncompressed: acc.resourcesUncompressed + script.decodedBodySize,
+			resourcesTransferred: acc.resourcesTransferred + script.transferSize,
+		} ),
+		{
+			resourcesCompressed: 0,
+			resourcesUncompressed: 0,
+			resourcesTransferred: 0,
+		}
+	);
+
+	// Hit ratio from 0 to 1 with two decimals (0=nothing was cached, 1=everything comes from the cache)
+	const resourcesCacheRatio =
+		1 - Math.round( ( resourcesTransferred / resourcesCompressed ) * 100 ) / 100;
+
+	report.data.set( 'resourcesCount', resourcesCount );
+	report.data.set( 'resourcesStart', resourcesStart );
+	report.data.set( 'resourcesEnd', resourcesEnd );
+	report.data.set( 'resourcesCompressed', resourcesCompressed );
+	report.data.set( 'resourcesUncompressed', resourcesUncompressed );
+	report.data.set( 'resourcesTransferred', resourcesTransferred );
+	report.data.set( 'resourcesCacheRatio', resourcesCacheRatio );
+
+	return report;
+};

--- a/packages/browser-data-collector/src/collectors/blocking-resources.ts
+++ b/packages/browser-data-collector/src/collectors/blocking-resources.ts
@@ -43,8 +43,10 @@ export const collector: Collector = ( report ) => {
 	);
 
 	// Hit ratio from 0 to 1 with two decimals (0=nothing was cached, 1=everything comes from the cache)
+	// resourcesTransferred includes the headers, but resourcesCompressed does not. So the division is a
+	// bit off and can return values higher than 1. We capped it to 1 to avoid sending negative numbers.
 	const resourcesCacheRatio =
-		1 - Math.round( ( resourcesTransferred / resourcesCompressed ) * 100 ) / 100;
+		1 - Math.max( 1, Math.round( ( resourcesTransferred / resourcesCompressed ) * 100 ) / 100 );
 
 	report.data.set( 'resourcesCount', resourcesCount );
 	report.data.set( 'resourcesStart', resourcesStart );

--- a/packages/browser-data-collector/src/collectors/index.ts
+++ b/packages/browser-data-collector/src/collectors/index.ts
@@ -11,3 +11,4 @@ export {
 	collectorStart as pageVisibilityStart,
 	collectorStop as pageVisibilityStop,
 } from './page-visibility';
+export { collector as blockingResources } from './blocking-resources';

--- a/packages/browser-data-collector/src/report.ts
+++ b/packages/browser-data-collector/src/report.ts
@@ -10,6 +10,7 @@ import {
 	inlineStart,
 	pageVisibilityStart,
 	pageVisibilityStop,
+	blockingResources,
 } from './collectors';
 
 export class ReportImpl implements Report {
@@ -42,6 +43,7 @@ export class ReportImpl implements Report {
 				environment,
 				pageVisibilityStop,
 				networkInformation,
+				blockingResources,
 			];
 		} else {
 			this.startCollectors = [ inlineStart, pageVisibilityStart ];


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Collects information about blocking scripts for RUM data

#### Testing instructions

Load calypso.live, opt-in abtest 'rumDataCollection', go to /read and refresh the page. Verify that there is a request to /logstash. It should contain the properties `resourcesCount`, `resourcesStart`, `resourcesEnd`, `resourcesCompressed`, `resourcesUncompressed`, `resourcesTransferred`, `resourcesCacheRatio`

To verify that the _values_ are correct, go to the Network tab, filter it by `/calypso` and type `JS`, enable 'Show overview' and select everything from the beginning to the page to the blue line  like this:

![image](https://user-images.githubusercontent.com/975703/84627346-11f26c80-aee7-11ea-833b-32e106146aca.png)

These are the values of the payload:

![image](https://user-images.githubusercontent.com/975703/84626850-27b36200-aee6-11ea-880d-38ed8284b2f5.png)

* For `resourcesTransferred` and `resourcesUncompressed` you can mouse over to get the value in bytes

* For `resourcesStart` mouse over **the first resource** and sum the values `Queued at` + `Queueing` + `Stalled`+ `Proxy negotiation`.

![image](https://user-images.githubusercontent.com/975703/84627124-9db7c900-aee6-11ea-8eb4-de07039c5b2a.png)

* For `resourcesEnd` mouse over **the resource that finish the last** (may not be the last entry in the network tab) and sum the values `Queued at` + the last number at the end, in bold.

![image](https://user-images.githubusercontent.com/975703/84627174-b1fbc600-aee6-11ea-95ba-f85e964e6140.png)

Try the above with full cache and disabled cache. You should see `resourcesCacheRatio=0` in the payload when there is no cache and `resourcesCacheRatio=1` when you have a full cache.
