### PR TITLE
Home: Hide setup progress on the desktop app

### DIFF
--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -1015,7 +1015,8 @@ function mapStateToProps( state ) {
 		hideChecklistProgress:
 			isSiteChecklistComplete( state, siteId ) ||
 			! getSiteChecklist( state, siteId ) ||
-			! isEligibleForDotcomChecklist( state, siteId ),
+			! isEligibleForDotcomChecklist( state, siteId ) ||
+			isEnabled( 'desktop' ),
 		scanState: getScanState( state, siteId ),
 		rewindState: getRewindState( state, siteId ),
 		isCloudEligible: isJetpackCloudEligible( state, siteId ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Hides the site setup progress indication from the sidebar when accessed from the WP Desktop app.

Before | After
--- | ---
<img width="698" alt="Screen Shot 2020-06-15 at 11 48 38" src="https://user-images.githubusercontent.com/1233880/84643487-3279f100-aefe-11ea-963e-ad91c2c1a154.png"> | <img width="701" alt="Screen Shot 2020-06-15 at 11 48 52" src="https://user-images.githubusercontent.com/1233880/84643494-3574e180-aefe-11ea-8ebf-ad4a67d4b72d.png">

To help stabilize accidental breakages, @Automattic/serenity added a simplified Home view just for WP-Desktop that doesn’t show any primary tasks (including the Site Setup List, which is considered a primary task): pbAPfg-sx-p2

We likely forgot to hide the setup progress indicator from the sidebar for WP-Desktop that’s causing an inconsistency as reported in https://github.com/Automattic/wp-calypso/issues/43235  

This is more a temporary workaround, I think that in the long term we should support the site setup on the desktop app (cc @Automattic/Create).

#### Testing instructions

- In the desktop repo, point the calypso submodule to this branch: `cd calypso && git fetch && git checkout update/home-hide-setup-progress-desktop && cd ..`.
- Generate  a new build: `make build` (this can take a few minutes).
- Open the built app in the `release/<YOUR_OS>` folder (i.e. `release/mac/WordPress.com.app`).
- Switch to a site with the setup incomplete. 
- Make sure the setup progress doesn't show up.

Fixes https://github.com/Automattic/wp-calypso/issues/43235 
Fixes https://github.com/Automattic/wp-desktop/issues/909