### PR TITLE
Jetpack: The upsell link should be self target

### DIFF
--- a/client/components/promo-section/promo-card/cta.tsx
+++ b/client/components/promo-section/promo-card/cta.tsx
@@ -22,6 +22,7 @@ type ClickCallback = () => void;
 interface CtaAction {
 	url: URL;
 	onClick: ClickCallback;
+	selfTarget?: boolean;
 }
 
 export interface CtaButton {
@@ -62,11 +63,12 @@ function buttonProps( button: CtaButton, isPrimary: boolean ) {
 		? {
 				href: button.action.url,
 				onClick: button.action.onClick,
+				selfTarget: button.action.selfTarget,
 		  }
 		: {
 				[ typeof button.action === 'string' ? 'href' : 'onClick' ]: button.action,
 		  };
-	if ( undefined !== actionProps.href ) {
+	if ( undefined !== actionProps.href && ! actionProps.selfTarget ) {
 		actionProps.target = '_blank';
 	}
 	return {

--- a/client/my-sites/scan/wpcom-upsell.tsx
+++ b/client/my-sites/scan/wpcom-upsell.tsx
@@ -77,7 +77,11 @@ export default function WPCOMScanUpsellPage(): ReactElement {
 				<PromoCardCTA
 					cta={ {
 						text: translate( 'Upgrade to Business Plan' ),
-						action: { url: `/checkout/${ siteSlug }/premium`, onClick: onUpgradeClick },
+						action: {
+							url: `/checkout/${ siteSlug }/business`,
+							onClick: onUpgradeClick,
+							selfTarget: true,
+						},
 					} }
 				/>
 			</PromoCard>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The upsell links should be `self` target instead of `_blank`. This PR update the PromoCardCta component to allow us to select if the link is self target.

#### Testing instructions

- Selected an AT site without Jetpack
- Go to the Jetpack Scan section and click on Upgrade to Business Plan. It'll take you to the checkout page in the same tab.
