### PR TITLE
Jetpack: Improve styles on WPCOMScanUpsell +added WhatIsJetpack

### DIFF
--- a/client/components/jetpack/what-is-jetpack/index.tsx
+++ b/client/components/jetpack/what-is-jetpack/index.tsx
@@ -1,0 +1,44 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { translate } from 'i18n-calypso';
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import JetpackLogo from 'components/jetpack-logo';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+interface Props {
+	className?: string;
+}
+
+const WhatIsJetpack: React.FC< Props > = ( { className } ) => {
+	return (
+		<div className={ classnames( 'what-is-jetpack', className ) }>
+			<div className="what-is-jetpack__jetpack-logo">
+				<JetpackLogo size={ 36 } full />
+			</div>
+			<div>
+				<h4 className="what-is-jetpack__question">{ translate( 'What is Jetpack?' ) }</h4>
+				<p className="what-is-jetpack__answer">
+					{ translate(
+						'Jetpack is a feature-rich plugin for WordPress sites. Because your site is hosted with us at WordPress.com, you already have access to most Jetpack’s features.'
+					) }
+					<br />
+					<a href="https://jetpack.com/" target="_blank" rel="noopener noreferrer">
+						{ translate( 'Find out more about Jetpack.' ) }
+					</a>
+				</p>
+			</div>
+		</div>
+	);
+};
+
+export default WhatIsJetpack;

--- a/client/components/jetpack/what-is-jetpack/style.scss
+++ b/client/components/jetpack/what-is-jetpack/style.scss
@@ -1,0 +1,30 @@
+.what-is-jetpack {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	font-size: $font-body-small;
+	line-height: 21px;
+	padding: 16px;
+
+	@include breakpoint-deprecated( '>480px' ) {
+		flex-direction: row;
+	}
+
+	&__jetpack-logo {
+		margin: 0 32px 24px;
+	}
+
+	&__question {
+		margin-bottom: 12px;
+		font-weight: 600;
+		color: var( --color-neutral-40 );
+	}
+
+	&__answer {
+		color: var( --color-neutral-50 );
+
+		a {
+			text-decoration: underline;
+		}
+	}
+}

--- a/client/my-sites/scan/style.scss
+++ b/client/my-sites/scan/style.scss
@@ -46,7 +46,7 @@
 	}
 }
 
-.scan__header {
+header.scan__header.is-left-align {
 	color: var( --studio-black );
 	font-size: 28px;
 	line-height: 1;
@@ -55,7 +55,7 @@
 	@include breakpoint-deprecated( '>660px' ) {
 		font-size: 36px;
 		font-weight: 600;
-		margin: 32px 0 24px;
+		margin: 40px 0 18px;
 	}
 	&.is-placeholder {
 		display: block;
@@ -89,5 +89,11 @@
 }
 
 .scan__upsell-icon {
-	color: var( --color-accent-20 );
+	color: #7bb1cd;
+}
+
+.scan__wpcom-upsell {
+	.what-is-jetpack {
+		margin-top: 64px;
+	}
 }

--- a/client/my-sites/scan/wpcom-upsell.tsx
+++ b/client/my-sites/scan/wpcom-upsell.tsx
@@ -19,6 +19,7 @@ import PromoCardCTA from 'components/promo-section/promo-card/cta';
 import useTrackCallback from 'lib/jetpack/use-track-callback';
 import Gridicon from 'components/gridicon';
 import { getSelectedSiteSlug } from 'state/ui/selectors';
+import WhatIsJetpack from 'components/jetpack/what-is-jetpack';
 
 /**
  * Asset dependencies
@@ -51,7 +52,7 @@ export default function WPCOMScanUpsellPage(): ReactElement {
 	const siteSlug = useSelector( getSelectedSiteSlug );
 
 	return (
-		<Main className="scan__main scan__wpcom-upsell">
+		<Main className="scan__main scan__wpcom-upsell is-wide-layout">
 			<DocumentHead title="Scanner" />
 			<SidebarNavigation />
 			<PageViewTracker path="/scan/:site" title="Scanner" />
@@ -91,6 +92,8 @@ export default function WPCOMScanUpsellPage(): ReactElement {
 			/>
 
 			<PromoSection { ...promos } />
+
+			<WhatIsJetpack />
 		</Main>
 	);
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Improve some styles on WPCOMScanUpsell component and add to the bottom WhatIsJetpack component.

Before:
![image](https://user-images.githubusercontent.com/9832440/84665364-aa084a00-af17-11ea-9646-34efccdd25ea.png)

After:
![image](https://user-images.githubusercontent.com/9832440/84665671-05d2d300-af18-11ea-9434-e8676f5d8f60.png)

#### Testing instructions

- Apply these changes and active Jetpack section with `?flags=jetpack/features-section`
- Select AT site without Jetpack
- Go to Scan section and see the new What is Jetpack block and the styles applied like the screenshot