### PR TITLE
Lasagna: update to 0.7.0

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -21,7 +21,7 @@
 		"@automattic/data-stores": "^1.0.0-alpha.1",
 		"@automattic/domain-picker": "^1.0.0-alpha.0",
 		"@automattic/format-currency": "^1.0.0-alpha.0",
-		"@automattic/lasagna": "^0.6.1",
+		"@automattic/lasagna": "^0.7.0",
 		"@automattic/load-script": "^1.0.0",
 		"@automattic/material-design-icons": "^1.0.0",
 		"@automattic/plans-grid": "^1.0.0-alpha.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,10 +16,10 @@
   resolved "https://registry.yarnpkg.com/@automattic/color-studio/-/color-studio-2.3.0.tgz#6549e77f823514bdcf520cb2c48932c2c9db379f"
   integrity sha512-GRMV4PMtn2iE+30+RP33LyJSe4Qp8oILFNvk+iF8zd0LzUUaErZu86rk8YpEcLvFJzOU2BTXSewSdwyGc/sa1g==
 
-"@automattic/lasagna@^0.6.1":
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/@automattic/lasagna/-/lasagna-0.6.1.tgz#98984f268e3186c3d4455f7f2bc324d509910f0c"
-  integrity sha512-FRnXPp0C6m8cL70Xcgpn2qLX+ML7YH41YTrkQwmfQa5GaR4n9XwJtTvzdoo1TdBGb27dAwL0TAio8+m3lyN6fg==
+"@automattic/lasagna@^0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@automattic/lasagna/-/lasagna-0.7.0.tgz#da7a24af00b0dcd3f0705fa899f4e5d44fa00486"
+  integrity sha512-1DXu24oDBaQq4gK50t/qY8keIx/fayAP3i64s8rlZMIygwdtMCn0Ht3D76ziVpOr1AUDnex5PmkkHEjHPlMaog==
   dependencies:
     jwt-decode "^2.2.0"
     phoenix "^1.5.1"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update `lasagna.js` client to `0.7.0`.

#### Testing instructions

Mostly, boot Calypso and smoke test in reader.

If you want to test the specific underlying issue:

1. Set a short `cxp` with `wp_post` signing in your sandbox.
2. Open a private post in the Reader in two tabs.
3. Comment back and forth on it, particularly sure to span past the `cxp` you set so the client is forced to use a new channel instantiation.

Fixes custom event handler rebinding issue (https://github.com/Automattic/lasagna.js/pull/59).