### PR TITLE
Typography: Fix overflowing sidebar links

### DIFF
--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -182,7 +182,6 @@
 }
 
 .sidebar__menu.is-togglable .sidebar__menu-link {
-	font-size: $font-body-small;
 	line-height: 1.5;
 	padding: 7px 16px 7px 20px;
 }

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -107,9 +107,9 @@
 // various sections of Calypso.
 .sidebar__menu-link {
 	font-size: $font-body;
-	line-height: 1.5;
+	line-height: 1.2;
 	position: relative;
-	padding: 7px 16px 7px 20px;
+	padding: 10px 16px 10px 20px;
 	box-sizing: border-box;
 	overflow: hidden;
 	display: flex;
@@ -183,6 +183,8 @@
 
 .sidebar__menu.is-togglable .sidebar__menu-link {
 	font-size: $font-body-small;
+	line-height: 1.5;
+	padding: 7px 16px 7px 20px;
 }
 
 .sidebar__menu-link-text {

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -111,7 +111,6 @@
 	position: relative;
 	padding: 7px 16px 7px 20px;
 	box-sizing: border-box;
-	/*white-space: nowrap;*/
 	overflow: hidden;
 	display: flex;
 	align-items: center;

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -106,7 +106,7 @@
 // Menu links: The actual anchor tags that contain links to
 // various sections of Calypso.
 .sidebar__menu-link {
-	font-size: $font-body;
+	font-size: $font-body-small;
 	line-height: 1.5;
 	position: relative;
 	padding: 7px 16px 7px 20px;

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -106,7 +106,7 @@
 // Menu links: The actual anchor tags that contain links to
 // various sections of Calypso.
 .sidebar__menu-link {
-	font-size: $font-body-small;
+	font-size: $font-body;
 	line-height: 1.5;
 	position: relative;
 	padding: 7px 16px 7px 20px;
@@ -179,6 +179,10 @@
 		right: 21px;
 		top: auto;
 	}
+}
+
+.sidebar__menu.is-togglable .sidebar__menu-link {
+	font-size: $font-body-small;
 }
 
 .sidebar__menu-link-text {

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -107,11 +107,11 @@
 // various sections of Calypso.
 .sidebar__menu-link {
 	font-size: $font-body;
-	line-height: 1;
+	line-height: 1.5;
 	position: relative;
-	padding: 10px 16px 10px 20px;
+	padding: 7px 16px 7px 20px;
 	box-sizing: border-box;
-	white-space: nowrap;
+	/*white-space: nowrap;*/
 	overflow: hidden;
 	display: flex;
 	align-items: center;

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -65,6 +65,7 @@
 .sidebar__menu-icon {
 	fill: var( --color-sidebar-gridicon-fill );
 	margin-right: 11px;
+	flex-shrink: 0;
 }
 
 // Checklist progress


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Increasing the font size in the sidebar in #42629 causes overflow in some languages
* This PR removes the `nowrap` property so long links can break to two or more lines on submenu links to give them more breathing room.

**Before**

<img width="276" alt="Screen Shot 2020-06-15 at 10 51 19 AM" src="https://user-images.githubusercontent.com/2124984/84672135-2db13f00-aef6-11ea-8f6c-10b5a60274ff.png">

**After**

<img width="283" alt="Screen Shot 2020-06-23 at 1 50 17 PM" src="https://user-images.githubusercontent.com/2124984/85437870-44404180-b559-11ea-8543-8e3c3bf85092.png">


#### Testing instructions

* Switch to this PR
* Check out the sidebar navigation at different screen sizes and with various languages; do the links wrap properly? Do they look OK?

Fixes #43153
