### PR TITLE
Receipts: Flatten purchases/failed_purchases inside createReceiptObject

### DIFF
--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import { flatten, find, get, isEmpty, isEqual, reduce, startsWith } from 'lodash';
+import { find, get, isEmpty, isEqual, reduce, startsWith } from 'lodash';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
@@ -372,17 +372,6 @@ export class Checkout extends React.Component {
 		return true;
 	}
 
-	/**
-	 * Purchases are of the format { [siteId]: [ { productId: ... } ] }
-	 * so we need to flatten them to get a list of purchases
-	 *
-	 * @param {object} purchases keyed by siteId { [siteId]: [ { productId: ... } ] }
-	 * @returns {Array} of product objects [ { productId: ... }, ... ]
-	 */
-	flattenPurchases( purchases ) {
-		return flatten( Object.values( purchases ) );
-	}
-
 	getUrlWithQueryParam( url, queryParams ) {
 		const { protocol, hostname, port, pathname, query } = parseUrl( url, true );
 
@@ -715,8 +704,8 @@ export class Checkout extends React.Component {
 
 			this.props.fetchReceiptCompleted( receiptId, {
 				...receipt,
-				purchases: this.flattenPurchases( this.props.transaction.step.data.purchases ),
-				failedPurchases: this.flattenPurchases( this.props.transaction.step.data.failed_purchases ),
+				purchases: this.props.transaction.step.data.purchases,
+				failed_purchases: this.props.transaction.step.data.failed_purchases,
 			} );
 		}
 

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -20,7 +20,6 @@ import {
 	taxRequiredContactDetails,
 } from 'my-sites/checkout/composite-checkout/wpcom';
 import { CheckoutProvider, defaultRegistry } from '@automattic/composite-checkout';
-import { flatten } from 'lodash';
 
 /**
  * Internal dependencies
@@ -260,13 +259,7 @@ export default function CompositeCheckout( {
 
 			if ( receiptId && transactionResult?.purchases && transactionResult?.failed_purchases ) {
 				debug( 'fetching receipt' );
-				reduxDispatch(
-					fetchReceiptCompleted( receiptId, {
-						...transactionResult,
-						purchases: flattenPurchases( transactionResult.purchases ),
-						failedPurchases: flattenPurchases( transactionResult.failed_purchases ),
-					} )
-				);
+				reduxDispatch( fetchReceiptCompleted( receiptId, transactionResult ) );
 			}
 
 			if ( siteId ) {
@@ -809,15 +802,4 @@ function displayRenewalSuccessNotice( responseCart, purchases, translate, moment
 		),
 		{ persistent: true }
 	);
-}
-
-/**
- * Purchases are of the format { [siteId]: [ { productId: ... } ] }
- * so we need to flatten them to get a list of purchases
- *
- * @param {object} purchases keyed by siteId { [siteId]: [ { productId: ... } ] }
- * @returns {Array} of product objects [ { productId: ... }, ... ]
- */
-function flattenPurchases( purchases ) {
-	return flatten( Object.values( purchases ) );
 }

--- a/client/state/receipts/assembler.js
+++ b/client/state/receipts/assembler.js
@@ -1,3 +1,10 @@
+// @ts-check
+
+/**
+ * External dependencies
+ */
+import { flatten } from 'lodash';
+
 /**
  * @typedef RawPurchase
  * @type {object}
@@ -57,9 +64,19 @@
  * @type {object}
  * @property {string} receipt_id
  * @property {string} display_price
- * @property {RawPurchase[]} purchases
- * @property {RawFailedPurchase[]} failed_purchases
+ * @property {RawPurchases|string[]} purchases - will only be an array if it is empty
+ * @property {RawFailedPurchases|string[]} failed_purchases - will only be an array if it is empty
  */
+
+/* eslint-disable jsdoc/no-undefined-types */
+/**
+ * @typedef {Record<string, RawFailedPurchase[]>} RawFailedPurchases
+ */
+
+/**
+ * @typedef {Record<string, RawPurchase[]>} RawPurchases
+ */
+/* eslint-enable jsdoc/no-undefined-types */
 
 /**
  * @typedef ReceiptData
@@ -80,7 +97,7 @@ export function createReceiptObject( data ) {
 	return {
 		receiptId: data.receipt_id,
 		displayPrice: data.display_price,
-		purchases: data.purchases.map( ( purchase ) => {
+		purchases: flattenPurchases( data.purchases || {} ).map( ( purchase ) => {
 			return {
 				delayedProvisioning: Boolean( purchase.delayed_provisioning ),
 				freeTrial: purchase.free_trial,
@@ -96,7 +113,7 @@ export function createReceiptObject( data ) {
 				isRootDomainWithUs: Boolean( purchase.is_root_domain_with_us ),
 			};
 		} ),
-		failedPurchases: ( data.failed_purchases || [] ).map( ( purchase ) => {
+		failedPurchases: flattenFailedPurchases( data.failed_purchases || {} ).map( ( purchase ) => {
 			return {
 				meta: purchase.product_meta,
 				productId: purchase.product_id,
@@ -106,4 +123,26 @@ export function createReceiptObject( data ) {
 			};
 		} ),
 	};
+}
+
+/**
+ * Purchases are of the format { [siteId]: [ { productId: ... } ] }
+ * so we need to flatten them to get a list of purchases
+ *
+ * @param {object} purchases keyed by siteId { [siteId]: [ { productId: ... } ] }
+ * @returns {Array<RawPurchase>} of product objects [ { productId: ... }, ... ]
+ */
+function flattenPurchases( purchases ) {
+	return flatten( Object.values( purchases ) );
+}
+
+/**
+ * Purchases are of the format { [siteId]: [ { productId: ... } ] }
+ * so we need to flatten them to get a list of purchases
+ *
+ * @param {object} purchases keyed by siteId { [siteId]: [ { productId: ... } ] }
+ * @returns {Array<RawFailedPurchase>} of product objects [ { productId: ... }, ... ]
+ */
+function flattenFailedPurchases( purchases ) {
+	return flatten( Object.values( purchases ) );
 }


### PR DESCRIPTION
There are three places in the code where `createReceiptObject` is called. One is in old `Checkout`, one is in `CompositeCheckout`, and one is in the Redux `fetchReceipt` action thunk which is used by `CheckoutThankYou` after checkout.

In the first two locations, the raw transaction endpoint data returned from the server for the `purchases` and `failed_purchases` properties is flattened from an object-of-arrays-of-objects keyed by blog_id into a single array. `createReceiptObject` expects both to be arrays which it then maps into a specific schema. (They were actually flattening `failed_purchases` into a new property called `failedPurchases` and leaving the old `failed_purchases` property untouched, which caused part of the confusion in my first attempt to fix this.)

In the third location, the data was not flattened, which could cause either the data to be ignored or a fatal error as the code tries to map an object.

Since the data from the server is unlikely to change, this PR moves the flattening of those two properties into `createReceiptObject` itself. That way it can always expect the server-defined schema and can perform its own transformations.

One of the three calls was already broken (the calls to `fetchReceipt()` in `CheckoutThankYou`), but I made the issue worse in https://github.com/Automattic/wp-calypso/pull/42723

#### Testing instructions

This is tricky to test.

- Complete a purchase using either new or old checkout.
- You should be redirected to the checkout "thank you" page.
- Make sure that when fetching the receipt from the `/me/billing-history/receipt/${ receiptId }` endpoint returns a receipt with `failed_purchases`.
- Verify there are no fatal errors.
- Then try again with no `failed_purchases`.
- Verify there are no fatal errors.