### PR TITLE
Sets path to point to new Jetpack settings page

### DIFF
--- a/client/lib/jetpack/paths.ts
+++ b/client/lib/jetpack/paths.ts
@@ -18,6 +18,6 @@ const scanBasePath = () => '/scan';
 export const scanPath = ( siteSlug?: string ) =>
 	siteSlug ? `${ scanBasePath() }/${ siteSlug }` : scanBasePath();
 
-const settingsBasePath = () => ( isJetpackCloud() ? '/settings' : '/settings/security' );
+const settingsBasePath = () => ( isJetpackCloud() ? '/settings' : '/settings/jetpack' );
 export const settingsPath = ( siteSlug?: string ) =>
 	siteSlug ? `${ settingsBasePath() }/${ siteSlug }` : settingsBasePath();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates paths for Backup and Scan to point to the new Jetpack settings page. 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Get Backup for a Jetpack site.
* Go to WP.com with the section feature flag.
* In Jetpack -> Backup, click "Activate Restores".

Fixes 1179060693083348-as-1179705725205698.
