### PR TITLE
Jetpack.Backup section: Add upsell from Free to Business plan

### DIFF
--- a/client/my-sites/backup/index.js
+++ b/client/my-sites/backup/index.js
@@ -19,7 +19,8 @@ import {
 	backups,
 	showUpsellIfNoBackup,
 } from 'my-sites/backup/controller';
-import WPCOMUpsell from 'landing/jetpack-cloud/sections/wpcom-upsell';
+import WPCOMUpsellPage from 'my-sites/backup/wpcom-upsell';
+
 import { backupMainPath, backupActivityPath, backupRestorePath, backupDownloadPath } from './paths';
 
 export default function () {
@@ -35,7 +36,7 @@ export default function () {
 			backupActivity,
 			wrapInSiteOffsetProvider,
 			showUpsellIfNoBackup,
-			wpcomUpsellController( WPCOMUpsell ),
+			wpcomUpsellController( WPCOMUpsellPage ),
 			makeLayout,
 			clientRender
 		);
@@ -47,7 +48,7 @@ export default function () {
 			navigation,
 			backupDownload,
 			wrapInSiteOffsetProvider,
-			wpcomUpsellController( WPCOMUpsell ),
+			wpcomUpsellController( WPCOMUpsellPage ),
 			makeLayout,
 			clientRender
 		);
@@ -60,7 +61,7 @@ export default function () {
 				navigation,
 				backupRestore,
 				wrapInSiteOffsetProvider,
-				wpcomUpsellController( WPCOMUpsell ),
+				wpcomUpsellController( WPCOMUpsellPage ),
 				makeLayout,
 				clientRender
 			);
@@ -74,7 +75,7 @@ export default function () {
 			backups,
 			wrapInSiteOffsetProvider,
 			showUpsellIfNoBackup,
-			wpcomUpsellController( WPCOMUpsell ),
+			wpcomUpsellController( WPCOMUpsellPage ),
 			makeLayout,
 			clientRender
 		);

--- a/client/my-sites/backup/style.scss
+++ b/client/my-sites/backup/style.scss
@@ -88,3 +88,37 @@
 		}
 	}
 }
+
+.backup__upsell-icon {
+	fill: #7bb1cd;
+}
+
+.backup__wpcom-upsell {
+	.what-is-jetpack {
+		margin-top: 64px;
+	}
+}
+
+.backup__main {
+	.action-panel__body {
+		margin-left: 30px;
+	}
+}
+
+header.backup__header.is-left-align {
+	color: var( --studio-black );
+	font-size: 28px;
+	line-height: 1;
+	margin: 32px 0 16px;
+
+	@include breakpoint-deprecated( '>660px' ) {
+		font-size: 36px;
+		font-weight: 600;
+		margin: 40px 0 18px;
+	}
+	&.is-placeholder {
+		display: block;
+		max-width: 60%;
+		@include placeholder( --color-neutral-10 );
+	}
+}

--- a/client/my-sites/backup/style.scss
+++ b/client/my-sites/backup/style.scss
@@ -95,13 +95,19 @@
 
 .backup__wpcom-upsell {
 	.what-is-jetpack {
-		margin-top: 64px;
+		margin-top: 32px;
+
+		@include breakpoint-deprecated( '>660px' ) {
+			margin-top: 64px;
+		}
 	}
 }
 
 .backup__main {
-	.action-panel__body {
-		margin-left: 30px;
+	@include breakpoint-deprecated( '>660px' ) {
+		.action-panel__body {
+			margin-left: 30px;
+		}
 	}
 }
 
@@ -109,12 +115,14 @@ header.backup__header.is-left-align {
 	color: var( --studio-black );
 	font-size: 28px;
 	line-height: 1;
-	margin: 32px 0 16px;
+	margin-top: 32px;
+	margin-bottom: 16px;
 
 	@include breakpoint-deprecated( '>660px' ) {
 		font-size: 36px;
 		font-weight: 600;
-		margin: 40px 0 18px;
+		margin-top: 40px;
+		margin-bottom: 18px;
 	}
 	&.is-placeholder {
 		display: block;

--- a/client/my-sites/backup/wpcom-upsell.tsx
+++ b/client/my-sites/backup/wpcom-upsell.tsx
@@ -1,0 +1,104 @@
+/**
+ * External dependencies
+ */
+import React, { ReactElement } from 'react';
+import { translate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import DocumentHead from 'components/data/document-head';
+import Main from 'components/main';
+import SidebarNavigation from 'my-sites/sidebar-navigation';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
+import FormattedHeader from 'components/formatted-header';
+import PromoSection, { Props as PromoSectionProps } from 'components/promo-section';
+import PromoCard from 'components/promo-section/promo-card';
+import PromoCardCTA from 'components/promo-section/promo-card/cta';
+import useTrackCallback from 'lib/jetpack/use-track-callback';
+import Gridicon from 'components/gridicon';
+import { getSelectedSiteSlug } from 'state/ui/selectors';
+import MaterialIcon from 'components/material-icon';
+import WhatIsJetpack from 'components/jetpack/what-is-jetpack';
+
+/**
+ * Asset dependencies
+ */
+import JetpackBackupSVG from 'assets/images/illustrations/jetpack-backup.svg';
+import './style.scss';
+
+const trackEventName = 'calypso_jetpack_backup_business_upsell';
+
+const promos: PromoSectionProps = {
+	promos: [
+		{
+			title: translate( 'Jetpack Scan' ),
+			body: translate(
+				'Automated scanning and one-click fixes to keep your site ahead of security threats.'
+			),
+			image: <MaterialIcon icon="security" className="backup__upsell-icon" />,
+		},
+		{
+			title: translate( 'Activity Log' ),
+			body: translate(
+				'A complete record of everything that happens on your site, with history that spans over 30 days.'
+			),
+			image: <Gridicon icon="history" className="backup__upsell-icon" />,
+		},
+	],
+};
+
+export default function WPCOMUpsellPage(): ReactElement {
+	const onUpgradeClick = useTrackCallback( undefined, trackEventName );
+	const siteSlug = useSelector( getSelectedSiteSlug );
+
+	return (
+		<Main className="backup__main backup__wpcom-upsell is-wide-layout">
+			<DocumentHead title="Jetpack Backup" />
+			<SidebarNavigation />
+			<PageViewTracker path="/backup/:site" title="Backup" />
+
+			<FormattedHeader
+				headerText={ translate( 'Jetpack Backup' ) }
+				className="backup__header"
+				id="backup-header"
+				align="left"
+			/>
+
+			<PromoCard
+				title={ translate( 'Get time travel for your site with Jetpack Backup' ) }
+				image={ { path: JetpackBackupSVG } }
+				isPrimary
+			>
+				<p>
+					{ translate(
+						'Backup gives you granular control over your site, with the ability to restore it to any previous state, and export it at any time.'
+					) }
+				</p>
+				<PromoCardCTA
+					cta={ {
+						text: translate( 'Upgrade to Business Plan' ),
+						action: {
+							url: `/checkout/${ siteSlug }/business`,
+							onClick: onUpgradeClick,
+							selfTarget: true,
+						},
+					} }
+				/>
+			</PromoCard>
+
+			<FormattedHeader
+				headerText={ translate( 'Also included in the Business Plan' ) }
+				className="backup__header"
+				id="backup-subheader"
+				align="left"
+				isSecondary
+			/>
+
+			<PromoSection { ...promos } />
+
+			<WhatIsJetpack />
+		</Main>
+	);
+}

--- a/client/my-sites/backup/wpcom-upsell.tsx
+++ b/client/my-sites/backup/wpcom-upsell.tsx
@@ -35,7 +35,7 @@ const promos: PromoSectionProps = {
 		{
 			title: translate( 'Jetpack Scan' ),
 			body: translate(
-				'Automated scanning and one-click fixes to keep your site ahead of security threats.'
+				'Scan gives you automated scanning and one-click fixes to keep your site ahead of security threats.'
 			),
 			image: <MaterialIcon icon="security" className="backup__upsell-icon" />,
 		},

--- a/client/my-sites/scan/style.scss
+++ b/client/my-sites/scan/style.scss
@@ -89,11 +89,17 @@ header.scan__header.is-left-align {
 }
 
 .scan__upsell-icon {
-	color: #7bb1cd;
+	fill: #7bb1cd;
 }
 
 .scan__wpcom-upsell {
 	.what-is-jetpack {
 		margin-top: 64px;
+	}
+}
+
+.scan__main {
+	.action-panel__body {
+		margin-left: 30px;
 	}
 }

--- a/client/my-sites/scan/style.scss
+++ b/client/my-sites/scan/style.scss
@@ -50,12 +50,14 @@ header.scan__header.is-left-align {
 	color: var( --studio-black );
 	font-size: 28px;
 	line-height: 1;
-	margin: 32px 0 16px;
+	margin-top: 32px;
+	margin-bottom: 16px;
 
 	@include breakpoint-deprecated( '>660px' ) {
 		font-size: 36px;
 		font-weight: 600;
-		margin: 40px 0 18px;
+		margin-top: 40px;
+		margin-bottom: 18px;
 	}
 	&.is-placeholder {
 		display: block;
@@ -94,12 +96,18 @@ header.scan__header.is-left-align {
 
 .scan__wpcom-upsell {
 	.what-is-jetpack {
-		margin-top: 64px;
+		margin-top: 32px;
+
+		@include breakpoint-deprecated( '>660px' ) {
+			margin-top: 64px;
+		}
 	}
 }
 
 .scan__main {
-	.action-panel__body {
-		margin-left: 30px;
+	@include breakpoint-deprecated( '>660px' ) {
+		.action-panel__body {
+			margin-left: 30px;
+		}
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add Backup upsell from Free to Business plan in the Backup section. 

**Case:** from Free to Business plan

The design:
![image](https://user-images.githubusercontent.com/9832440/84692174-5c9ed380-af3d-11ea-8109-6f4f94ce433e.png)

In Calypso:
![image](https://user-images.githubusercontent.com/9832440/84691992-0af64900-af3d-11ea-9ab4-8c7daf9fd268.png)

#### Testing instructions

- Apply these changes and select an AT without Jetpack
- Go to the Backup section and you will see the Upsell page. Click on the CTA button and it'll take you to the Business plan checkout.
- Review the copy.
