### PR TITLE
Jetpack Cloud: Fill the Plan sidebar icon for paids plan or products

### DIFF
--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -30,7 +30,9 @@ import QuerySiteChecklist from 'components/data/query-site-checklist';
 import QueryRewindState from 'components/data/query-rewind-state';
 import QueryScanState from 'components/data/query-jetpack-scan';
 import ToolsMenu from './tools-menu';
-import { isFreeTrial, isPersonal, isPremium, isBusiness, isEcommerce } from 'lib/products-values';
+import isCurrentPlanPaid from 'state/sites/selectors/is-current-plan-paid';
+import { siteHasJetpackProductPurchase } from 'state/purchases/selectors';
+import { isFreeTrial, isEcommerce } from 'lib/products-values';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isSidebarSectionOpen } from 'state/my-sites/sidebar/selectors';
@@ -516,6 +518,8 @@ export class MySitesSidebar extends Component {
 	plan() {
 		const {
 			canUserManageOptions,
+			hasPaidJetpackPlan,
+			hasPurchasedJetpackProduct,
 			isAtomicSite,
 			isJetpack,
 			isVip,
@@ -538,15 +542,8 @@ export class MySitesSidebar extends Component {
 
 		let planLink = '/plans' + this.props.siteSuffix;
 
-		const isUpgraded =
-			site &&
-			( isPersonal( site.plan ) ||
-				isPremium( site.plan ) ||
-				isBusiness( site.plan ) ||
-				isEcommerce( site.plan ) );
-
 		// Show plan details for upgraded sites
-		if ( isUpgraded ) {
+		if ( hasPaidJetpackPlan || hasPurchasedJetpackProduct ) {
 			planLink = '/plans/my-plan' + this.props.siteSuffix;
 		}
 
@@ -565,13 +562,13 @@ export class MySitesSidebar extends Component {
 		}
 
 		// Hide the plan name only for Jetpack sites that are not Atomic or VIP.
-		const displayPlanName = ! ( isJetpack && ! isAtomicSite && ! isVip );
+		const displayPlanName = ! isJetpack || isAtomicSite || isVip;
 
 		let icon = <JetpackLogo size={ 24 } className="sidebar__menu-icon" />;
 		if ( isEnabled( 'jetpack/features-section' ) ) {
 			icon = (
 				<Gridicon
-					icon={ isUpgraded ? 'star' : 'star-outline' }
+					icon={ hasPaidJetpackPlan || hasPurchasedJetpackProduct ? 'star' : 'star-outline' }
 					className="sidebar__menu-icon"
 					size={ 24 }
 				/>
@@ -990,6 +987,8 @@ function mapStateToProps( state ) {
 		customizeUrl: getCustomizerUrl( state, selectedSiteId ),
 		forceAllSitesView: isAllDomainsView,
 		hasJetpackSites: hasJetpackSites( state ),
+		hasPaidJetpackPlan: isCurrentPlanPaid( state, siteId ),
+		hasPurchasedJetpackProduct: siteHasJetpackProductPurchase( state, siteId ),
 		isDomainOnly: isDomainOnlySite( state, selectedSiteId ),
 		isJetpack,
 		isSiteSectionOpen,

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -26,6 +26,7 @@ import SidebarMenu from 'layout/sidebar/menu';
 import SidebarRegion from 'layout/sidebar/region';
 import SiteMenu from './site-menu';
 import StatsSparkline from 'blocks/stats-sparkline';
+import QuerySitePurchases from 'components/data/query-site-purchases';
 import QuerySiteChecklist from 'components/data/query-site-checklist';
 import QueryRewindState from 'components/data/query-rewind-state';
 import QueryScanState from 'components/data/query-jetpack-scan';
@@ -864,6 +865,8 @@ export class MySitesSidebar extends Component {
 
 		return (
 			<div className="sidebar__menu-wrapper">
+				<QuerySitePurchases siteId={ this.props.siteId } />
+
 				<SidebarMenu>
 					<ul>
 						{ this.customerHome() }

--- a/client/state/purchases/selectors.js
+++ b/client/state/purchases/selectors.js
@@ -14,6 +14,7 @@ import {
 	isDomainRegistration,
 	isDomainMapping,
 	isJetpackBackup,
+	isJetpackProduct,
 } from 'lib/products-values';
 import { getPlan, findPlansKeys } from 'lib/plans';
 import { TYPE_PERSONAL } from 'lib/plans/constants';
@@ -85,6 +86,20 @@ export const getRenewableSitePurchases = createSelector(
 	( state, siteId ) => getSitePurchases( state, siteId ).filter( needsToRenewSoon ),
 	( state, siteId ) => [ state.purchases.data, siteId ]
 );
+
+/**
+ * Returns whether or not a Site has an active purchase of a Jetpack product.
+ *
+ * @param {object} state global state
+ * @param {number} siteId the site id
+ * @returns {boolean} True if the site has an active Jetpack purchase, false otherwise.
+ */
+export const siteHasJetpackProductPurchase = ( state, siteId ) => {
+	return some(
+		getSitePurchases( state, siteId ),
+		( purchase ) => purchase.active && isJetpackProduct( purchase )
+	);
+};
 
 /**
  * Whether a site has an active Jetpack backup purchase.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* When the `jetpack/features-section` flag is enabled, fill the **Plan** star icon in the sidebar for any site with a paid plan or active Jetpack product purchase; otherwise, leave it unfilled/outlined.

Fixes `1179060693083348-as-1179608945635681`

#### Testing instructions

* Start Calypso and enable the `jetpack/features-section` feature flag.
* With respect to the star-shaped **Plan** icon in the sidebar, verify the following scenarios:
  * For non-Jetpack sites, the icon is **unfilled**.
  * For Jetpack sites with a Free plan and no purchased Jetpack products, the icon is **unfilled**.
  * For Jetpack sites with a paid plan, the icon is **filled**. (This includes Atomic sites.)
  * For Jetpack sites with no paid plan but an active purchase for Backup, Scan, or Search, the icon is **filled**.

#### Screenshots

##### WordPress.com site with no upgrades

<img width="984" alt="image" src="https://user-images.githubusercontent.com/670067/84693422-129df980-af0d-11ea-9375-921d53dc971f.png">

##### WordPress.com eCommerce site

<img width="787" alt="image" src="https://user-images.githubusercontent.com/670067/84693501-33664f00-af0d-11ea-9a2c-08962c0e28d9.png">

##### Jetpack site with no purchases

<img width="761" alt="image" src="https://user-images.githubusercontent.com/670067/84693339-f26e3a80-af0c-11ea-8c84-cb953dbc4115.png">

##### Jetpack site with Backup purchased

<img width="837" alt="image" src="https://user-images.githubusercontent.com/670067/84693216-c9e64080-af0c-11ea-908d-6573b49c0ecc.png">
