### PR TITLE
Thank you page: Use snake_case in property name

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -252,7 +252,7 @@ export class CheckoutThankYouHeader extends PureComponent {
 
 		this.props.recordTracksEvent( 'calypso_thank_you_view_site', {
 			product: primaryPurchase.productName,
-			singleDomain: true,
+			single_domain: true,
 		} );
 
 		page( domainManagementEdit( selectedSite.slug, primaryPurchase.meta ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use snake case for tracks event property on the checkout thank you page.

Came across this console error while testing something else:

![Screen Shot 2020-06-15 at 4 21 43 PM](https://user-images.githubusercontent.com/9310939/84707506-6f58de80-af24-11ea-8a19-1f31ab4504eb.png)

#### Testing instructions

Complete a checkout and verify that the above error is not thrown on the thank you page.