### PR TITLE
Donations: Avoid enqueuing scripts and styles when they're not needed.

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/donations/donations.php
+++ b/apps/full-site-editing/full-site-editing-plugin/donations/donations.php
@@ -8,9 +8,9 @@
 namespace A8C\FSE\Earn\Donations;
 
 /**
- * Initialize the Donations block.
+ * Initialize the Donations block for the editor.
  */
-function fse_donations_block() {
+function fse_donations_enqueue_for_editor() {
 	$gate = apply_filters( 'wpcom_donations_block_init', false );
 	if ( ! $gate ) {
 		return;
@@ -25,6 +25,24 @@ function fse_donations_block() {
 		$asset_file['version'],
 		true
 	);
+}
+
+add_action( 'enqueue_block_editor_assets', 'A8C\FSE\Earn\Donations\fse_donations_enqueue_for_editor' );
+
+/**
+ * Enqueue Donations styles in the editor and on the front-end when a Donations block is present.
+ */
+function fse_donations_enqueue_styles() {
+	$gate = apply_filters( 'wpcom_donations_block_init', false );
+	if ( ! $gate ) {
+		return;
+	}
+
+	if ( ! is_admin() && ! has_block( 'a8c/donations' ) ) {
+		return;
+	}
+
+	$asset_file = include plugin_dir_path( __FILE__ ) . 'dist/donations.asset.php';
 
 	wp_enqueue_style(
 		'a8c-donations',
@@ -34,4 +52,4 @@ function fse_donations_block() {
 	);
 }
 
-add_action( 'init', 'A8C\FSE\Earn\Donations\fse_donations_block' );
+add_action( 'enqueue_block_assets', 'A8C\FSE\Earn\Donations\fse_donations_enqueue_styles' );


### PR DESCRIPTION
This PR ensures that the Donations block scripts and styles are only enqueued when they're needed: in the editor, or on the front-end when displaying a Donations block (checked with `has_block`).

**Testing instructions**

* On this branch locally, run `yarn dev --sync` to sync the changes to your sandbox.
* Sticker your Simple test site with the `fse-donations-block` sticker (can be done on the site's blog RC).
* On that test site, start a new post at `/wp-admin/post-new.php`.
* Add a Donations block, and you should see a prompt to upgrade the plan (this should confirm proper enqueuing for the editor).
* Save the post, and view it on the front-end.
* Confirm the stylesheet is loaded (`https://:site.wordpress.com/wp-content/plugins/full-site-editing-plugin/dev/donations/dist/donations.css`).
* Remove the block, update the post, and reload it on the front-end.
* Verify the stylesheet is not loaded.

