### PR TITLE
Prevent package watcher from rebuilding color-schemes infinite loop (1)

### DIFF
--- a/bin/watch-packages-and-rebuild.js
+++ b/bin/watch-packages-and-rebuild.js
@@ -7,7 +7,8 @@ const promiseExecFile = util.promisify( require( 'child_process' ).execFile );
 const debounce = require( 'lodash/debounce' );
 const debouncedProcessRebuildQueue = debounce( processRebuildQueue, 100 );
 
-const ignoredPaths = [ 'dist', 'test', 'tests' ];
+const ignoredPathPieces = [ 'dist', 'test', 'tests' ];
+const ignoredPathRegexps = [ /packages\/calypso-color-schemes\/js\/index\.js/ ];
 const ignoredExtensions = [ '.css', '.md', '.d.ts' ];
 
 const packagesDirectoryPath = path.join( '.', 'packages' );
@@ -43,10 +44,13 @@ function isPathIgnored( filePath ) {
 	if ( filePathPieces.length < 2 ) {
 		return true;
 	}
-	if ( ignoredPaths.find( ( ignored ) => filePathPieces.includes( ignored ) ) ) {
+	if ( ignoredPathPieces.find( ( ignored ) => filePathPieces.includes( ignored ) ) ) {
 		return true;
 	}
 	if ( ignoredExtensions.find( ( ignored ) => filePath.endsWith( ignored ) ) ) {
+		return true;
+	}
+	if ( ignoredPathRegexps.find( ( ignored ) => ignored.test( filePath ) ) ) {
 		return true;
 	}
 	return false;


### PR DESCRIPTION
The file `calypso-color-schemes/js/index.js` is a dist file created
during the build process for that package, but it is not in a dist
directory, so every time it is recreated, the watcher notices it as a
change and triggers the build again.

```
heard change in packages/calypso-color-schemes/src/calypso-color-schemes.scss
rebuilding package: packages/calypso-color-schemes
$ check-npm-client && node bin/prepare-sass-assets.js && node bin/build-css.js

rebuild complete: packages/calypso-color-schemes
heard change in packages/calypso-color-schemes/js/index.js
rebuilding package: packages/calypso-color-schemes
$ check-npm-client && node bin/prepare-sass-assets.js && node bin/build-css.js

rebuild complete: packages/calypso-color-schemes
heard change in packages/calypso-color-schemes/js/index.js
rebuilding package: packages/calypso-color-schemes
$ check-npm-client && node bin/prepare-sass-assets.js && node bin/build-css.js

rebuild complete: packages/calypso-color-schemes
heard change in packages/calypso-color-schemes/js/index.js
rebuilding package: packages/calypso-color-schemes
```

This change adds a regexp to the watcher script and uses it to ignore
that file.

#### Testing instructions

- Run `yarn build-packages:watch` to start the watcher.
- Modify some files in packages to be sure those packages are rebuilt (eg: `touch packages/composite-checkout/src/components/field.js packages/load-script/src/index.js packages/composite-checkout/src/public-api.js`).
- Modify a file in `calypso-color-schemes` and be sure that package is rebuilt (eg: `touch packages/calypso-color-schemes/src/calypso-color-schemes.scss`), but only one time.