### PR TITLE
Update the font size of the domain navigation item subtitle

### DIFF
--- a/client/my-sites/domains/domain-management/edit/navigation/style.scss
+++ b/client/my-sites/domains/domain-management/edit/navigation/style.scss
@@ -15,7 +15,7 @@
 			color: var( --color-neutral-90 );
 			small {
 				color: var( --color-neutral-50 );
-				font-size: 14px;
+				font-size: $font-body-small;
 			}
 		}
 	}

--- a/client/my-sites/domains/domain-management/edit/navigation/style.scss
+++ b/client/my-sites/domains/domain-management/edit/navigation/style.scss
@@ -15,7 +15,7 @@
 			color: var( --color-neutral-90 );
 			small {
 				color: var( --color-neutral-50 );
-				font-size: 100%;
+				font-size: 14px;
 			}
 		}
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update the font-size of the domain navigation item subtitle to be 14px

before:
<img width="750" alt="Screenshot 2020-06-16 at 12 04 16" src="https://user-images.githubusercontent.com/1355045/84754814-90bfd600-afc9-11ea-8db3-97d863dc5be6.png">

after:
<img width="745" alt="Screenshot 2020-06-16 at 12 03 57" src="https://user-images.githubusercontent.com/1355045/84754840-97e6e400-afc9-11ea-9dfe-ab965c0cc984.png">


#### Testing instructions

* Verify that the font-size of the domain navigation subtitles is smaller (14px)
