### PR TITLE
Gutenboarding: Add hesitation nudge on intent gathering.

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
@@ -57,6 +57,7 @@ const SiteTitle: React.FunctionComponent< Props > = ( { onSubmit } ) => {
 				/>
 				<p className={ classnames( 'site-title__input-hint', { 'has-site-title': !! siteTitle } ) }>
 					<Icon icon={ tip } size={ 14 } />
+					{ /* translators: The "it" here refers to the site title. */ }
 					<span>{ __( "Don't worry, you can change it later." ) }</span>
 				</p>
 			</div>

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
@@ -5,12 +5,15 @@ import * as React from 'react';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { TextControl } from '@wordpress/components';
 import { useI18n } from '@automattic/react-i18n';
+import { Icon } from '@wordpress/icons';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
  */
 import { STORE_KEY } from '../../stores/onboard';
 import { recordSiteTitleSelection } from '../../lib/analytics';
+import tip from './tip';
 
 interface Props {
 	onSubmit: () => void;
@@ -52,7 +55,10 @@ const SiteTitle: React.FunctionComponent< Props > = ( { onSubmit } ) => {
 					autoCorrect="off"
 					data-hj-whitelist
 				/>
-				{ /* @TODO: add info tip here */ }
+				<p className={ classnames( 'site-title__input-hint', { 'has-site-title': !! siteTitle } ) }>
+					<Icon icon={ tip } size={ 14 } />
+					<span>{ __( "Don't worry, you can change it later." ) }</span>
+				</p>
 			</div>
 		</form>
 	);

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
@@ -23,6 +23,7 @@ const SiteTitle: React.FunctionComponent< Props > = ( { onSubmit } ) => {
 	const { __ } = useI18n();
 	const { siteTitle } = useSelect( ( select ) => select( STORE_KEY ).getState() );
 	const { setSiteTitle } = useDispatch( STORE_KEY );
+	const [ isFocused, setIsFocused ] = React.useState( false );
 
 	const handleFormSubmit = ( e: React.FormEvent< HTMLFormElement > ) => {
 		// hitting 'Enter' when focused on the input field should direct to next step.
@@ -32,13 +33,21 @@ const SiteTitle: React.FunctionComponent< Props > = ( { onSubmit } ) => {
 
 	const handleBlur = () => {
 		recordSiteTitleSelection( !! siteTitle );
+		setIsFocused( false );
+	};
+
+	const handleFocus = () => {
+		setIsFocused( true );
 	};
 
 	// translators: label for site title input in Gutenboarding
 	const inputLabel = __( 'My site is called' );
 
 	return (
-		<form className="site-title" onSubmit={ handleFormSubmit }>
+		<form
+			className={ classnames( 'site-title', { 'is-focused': isFocused, 'is-empty': ! siteTitle } ) }
+			onSubmit={ handleFormSubmit }
+		>
 			<label htmlFor="site-title__input" className="site-title__input-label">
 				{ inputLabel }
 			</label>
@@ -47,6 +56,7 @@ const SiteTitle: React.FunctionComponent< Props > = ( { onSubmit } ) => {
 					id="site-title__input"
 					className="site-title__input"
 					onChange={ setSiteTitle }
+					onFocus={ handleFocus }
 					onBlur={ handleBlur }
 					value={ siteTitle }
 					autoFocus // eslint-disable-line jsx-a11y/no-autofocus
@@ -54,8 +64,8 @@ const SiteTitle: React.FunctionComponent< Props > = ( { onSubmit } ) => {
 					autoComplete="off"
 					autoCorrect="off"
 					data-hj-whitelist
-				/>
-				<p className={ classnames( 'site-title__input-hint', { 'has-site-title': !! siteTitle } ) }>
+				></TextControl>
+				<p className="site-title__input-hint">
 					<Icon icon={ tip } size={ 14 } />
 					{ /* translators: The "it" here refers to the site title. */ }
 					<span>{ __( "Don't worry, you can change it later." ) }</span>

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
@@ -63,8 +63,28 @@
 	}
 }
 
+.site-title__input-hint {
+	display: flex;
+	color: var( --studio-gray-20 );
+	font-family: $default-font;
+	font-size: $default-font-size;
+	line-height: 14px;
+	transition: opacity 200ms $acquire-intent-transition-duration $acquire-intent-transition-algorithm;
+
+	svg {
+		align-self: center;
+		fill: var( --studio-yellow-30 );
+		flex-shrink: 0;
+		margin-right: $grid-unit-10;
+	}
+
+	&.has-site-title {
+		opacity: 0;
+	}
+}
+
 .acquire-intent__footer {
-	margin-top: 25px;
+	margin-top: 40px;
 	display: flex;
 	justify-content: flex-end;
 
@@ -127,6 +147,5 @@
 			font-size: 64px;
 			line-height: 80px;
 		}
-
 	}
 }

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
@@ -70,26 +70,16 @@
 	font-size: $default-font-size;
 	line-height: 14px;
 	opacity: 0;
-	animation: site-title-input-hint-fade-in $acquire-intent-transition-duration
-		$acquire-intent-transition-algorithm forwards;
-	animation-delay: 3s;
+	transition: opacity $acquire-intent-transition-duration $acquire-intent-transition-algorithm;
 
-	&.has-site-title {
+	.site-title.is-focused.is-empty & {
 		opacity: 1;
-		animation-name: site-title-input-hint-fade-out;
-		animation-delay: 1s;
+		transition-delay: 3s;
 	}
 
-	@keyframes site-title-input-hint-fade-in {
-		to {
-			opacity: 1;
-		}
-	}
-
-	@keyframes site-title-input-hint-fade-out {
-		to {
-			opacity: 0;
-		}
+	.site-title:not( .is-empty ) & {
+		opacity: 0;
+		transition-delay: 1s;
 	}
 
 	svg {

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
@@ -69,17 +69,34 @@
 	font-family: $default-font;
 	font-size: $default-font-size;
 	line-height: 14px;
-	transition: opacity 200ms $acquire-intent-transition-duration $acquire-intent-transition-algorithm;
+	opacity: 0;
+	animation: site-title-input-hint-fade-in $acquire-intent-transition-duration
+		$acquire-intent-transition-algorithm forwards;
+	animation-delay: 3s;
+
+	&.has-site-title {
+		opacity: 1;
+		animation-name: site-title-input-hint-fade-out;
+		animation-delay: 1s;
+	}
+
+	@keyframes site-title-input-hint-fade-in {
+		to {
+			opacity: 1;
+		}
+	}
+
+	@keyframes site-title-input-hint-fade-out {
+		to {
+			opacity: 0;
+		}
+	}
 
 	svg {
 		align-self: center;
 		fill: var( --studio-yellow-30 );
 		flex-shrink: 0;
 		margin-right: $grid-unit-10;
-	}
-
-	&.has-site-title {
-		opacity: 0;
 	}
 }
 

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/tip.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/tip.tsx
@@ -1,0 +1,13 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { SVG, Path } from '@wordpress/components';
+
+const tip = (
+	<SVG viewBox="0 0 24 24">
+		<Path d="M12 15.8c-3.7 0-6.8-3-6.8-6.8s3-6.8 6.8-6.8c3.7 0 6.8 3 6.8 6.8s-3.1 6.8-6.8 6.8zm0-12C9.1 3.8 6.8 6.1 6.8 9s2.4 5.2 5.2 5.2c2.9 0 5.2-2.4 5.2-5.2S14.9 3.8 12 3.8zM8 17.5h8V19H8zM10 20.5h4V22h-4z" />
+	</SVG>
+);
+
+export default tip;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add the input hint "Don't worry, you can change it later." under the site title input.
* 3s fade-in delay, 1s fade-out delay.

#### Testing instructions

* Go to `/new`
* After 3s delay, you should see the input hint "Don't worry, you can change it later." under the site title input.
* Enter a site title.
* After 1s delay from first keystroke, the message should fade out.
* Erase the site title.
* After 3s delay from the time site title is empty, the message should fade in.

#### Screenshot

![2020-06-17_11-50-51 (2)](https://user-images.githubusercontent.com/1287077/84884705-5bcb8600-b092-11ea-8d3c-e410693e575d.gif)


Fixes https://github.com/Automattic/wp-calypso/issues/42943
