### PR TITLE
Use chromedriver from the system

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,12 +4,16 @@ orbs:
   slack: circleci/slack@3.4.2
 
 references:
-  shared-environment: &shared-environment
-    CIRCLE_ARTIFACTS: /tmp/artifacts
-    CIRCLE_TEST_REPORTS: /tmp/test_results
-
-  docker-image: &docker-image
-    - image: circleci/node:12.16.2-browsers
+  defaults: &defaults
+    working_directory: ~/wp-calypso
+    docker:
+      - image: circleci/node:12.16.2-browsers
+    environment:
+      CIRCLE_ARTIFACTS: /tmp/artifacts
+      CIRCLE_TEST_REPORTS: /tmp/test_results
+      PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: 'true'
+      CHROMEDRIVER_SKIP_DOWNLOAD: 'true'
+      CHROMEDRIVER_FILEPATH: /usr/local/bin/chromedriver
 
   setup-results-and-artifacts: &setup-results-and-artifacts
     name: Create Directories for Results and Artifacts
@@ -118,10 +122,6 @@ references:
 
   yarn-install: &yarn-install
     environment:
-      PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: 'true'
-      # circleci images already provide a valid chromedriver binary, no need to install it again here
-      CHROMEDRIVER_SKIP_DOWNLOAD: 'true'
-      CHROMEDRIVER_FILEPATH: '/usr/local/bin/chromedriver'
     name: Install dependencies
     command: yarn install --frozen-lockfile
 
@@ -166,11 +166,6 @@ references:
     command: |
       cp -r ./reports $CIRCLE_TEST_REPORTS/e2ereports &&
       cp -r ./screenshots $CIRCLE_ARTIFACTS/screenshots
-
-  defaults: &defaults
-    working_directory: ~/wp-calypso
-    docker: *docker-image
-    environment: *shared-environment
 
 commands:
   prepare:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,8 +119,17 @@ references:
   yarn-install: &yarn-install
     environment:
       PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: 'true'
+      # circleci images already provide a valid chromedriver binary, no need to install it again here
+      CHROMEDRIVER_SKIP_DOWNLOAD: 'true'
     name: Install dependencies
-    command: CHROMEDRIVER_VERSION=$(<.chromedriver_version) yarn install --frozen-lockfile
+    command: yarn install --frozen-lockfile
+
+  # This is used later to send a custom UA string. `google-chrome` is in the PATH in all circleci-browser images
+  save-chrome-version: &save-chrome-version
+    name: Save chrome version
+    command: |
+      google-chrome --version > .chromedriver_version
+      echo -n "Google Chrome version: " && cat .chromedriver_version
 
   save-yarn-cache: &save-yarn-cache
     name: 'Save yarn cache'
@@ -480,6 +489,7 @@ jobs:
     steps:
       - prepare
       - run: *set-e2e-variables
+      - run: *save-chrome-version
       - run: yarn run decryptconfig
       - run: ./scripts/randomize.sh specs
       - run: ./scripts/run-wrapper.sh
@@ -507,6 +517,7 @@ jobs:
     steps:
       - prepare
       - run: *set-e2e-variables
+      - run: *save-chrome-version
       - run: sudo apt-get install -y fonts-ipafont-gothic xfonts-100dpi xfonts-75dpi xfonts-scalable xfonts-cyrillic fonts-wqy-zenhei
       - run:
           name: Skip Jetpack Tests if needed

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,6 +121,7 @@ references:
       PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: 'true'
       # circleci images already provide a valid chromedriver binary, no need to install it again here
       CHROMEDRIVER_SKIP_DOWNLOAD: 'true'
+      CHROMEDRIVER_FILEPATH: '/usr/local/bin/chromedriver'
     name: Install dependencies
     command: yarn install --frozen-lockfile
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ references:
       CIRCLE_ARTIFACTS: /tmp/artifacts
       CIRCLE_TEST_REPORTS: /tmp/test_results
       PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: 'true'
-      CHROMEDRIVER_SKIP_DOWNLOAD: 'true'
+      DETECT_CHROMEDRIVER_VERSION: 'false'
       CHROMEDRIVER_FILEPATH: /usr/local/bin/chromedriver
 
   setup-results-and-artifacts: &setup-results-and-artifacts

--- a/test/e2e/docs/config.md
+++ b/test/e2e/docs/config.md
@@ -92,4 +92,3 @@ These environment variables are intended for use inside CircleCI, to control whi
 | SKIP_TEST_REGEX | The value of this variable will be used in the `-i -g *****` parameter, to skip any tests that match the given RegEx.  List multiple keywords separated by a `|` (i.e. `Invite|Domain|Theme`) | `Empty String` | No |
 | SKIP_DOMAIN_TESTS | If this value is set to `true`, the tests that attempt domain registration with be skipped.  | false | No |
 | SKIP_JETPACK | If this value is set to `true`, the Jetpack tests with be skipped. Useful to disable scheduled tests without modifying circleCI config  | false | No |
-| CHROMEDRIVER_VERSION | This specifies the actual version of the Chromedriver binary that is used. It needs to be set to a version compatible with the version of Chrome installed | null | No


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Uses `chromedriver` binary present on the system instead of downloading it again. Because both `chromedriver` and Chrome come from the base circleci image this should guarantee we always use compatible versions.

Related PRs:
* https://github.com/Automattic/wp-e2e-tests-for-branches/pull/58
* https://github.com/Automattic/wp-e2e-tests-canary/pull/26

#### Testing instructions

* Verify e2e test pasess
