### PR TITLE
G Suite: Refine Add G Suite page

### DIFF
--- a/client/components/gsuite/gsuite-new-user-list/index.tsx
+++ b/client/components/gsuite/gsuite-new-user-list/index.tsx
@@ -23,6 +23,7 @@ import {
 import './style.scss';
 
 interface Props {
+	autoFocus?: boolean;
 	children?: ReactNode;
 	domains?: string[];
 	extraValidation: ( user: NewUser ) => NewUser;
@@ -40,6 +41,7 @@ const GSuiteNewUserList: FunctionComponent< Props > = ( {
 	onUsersChange,
 	users,
 	onReturnKeyPress,
+	autoFocus = false,
 } ) => {
 	const translate = useTranslate();
 
@@ -80,6 +82,7 @@ const GSuiteNewUserList: FunctionComponent< Props > = ( {
 			{ users.map( ( user ) => (
 				<Fragment key={ user.uuid }>
 					<GSuiteNewUser
+						autoFocus={ autoFocus } // eslint-disable-line jsx-a11y/no-autofocus
 						domains={ domains ? domains.map( ( domain ) => domain.name ) : [ selectedDomainName ] }
 						user={ user }
 						onUserValueChange={ onUserValueChange( user.uuid ) }

--- a/client/components/gsuite/gsuite-new-user-list/index.tsx
+++ b/client/components/gsuite/gsuite-new-user-list/index.tsx
@@ -10,7 +10,12 @@ import { useTranslate } from 'i18n-calypso';
  */
 import { Button } from '@automattic/components';
 import GSuiteNewUser from './new-user';
-import { newUser, GSuiteNewUser as NewUser, validateUsers } from 'lib/gsuite/new-users';
+import {
+	newUser,
+	GSuiteNewUser as NewUser,
+	sanitizeEmail,
+	validateUsers,
+} from 'lib/gsuite/new-users';
 
 /**
  * Style dependencies
@@ -38,16 +43,26 @@ const GSuiteNewUserList: FunctionComponent< Props > = ( {
 } ) => {
 	const translate = useTranslate();
 
-	const onUserValueChange = ( uuid: string ) => ( fieldName: string, fieldValue: string ) => {
-		const modifiedUserList = users.map( ( user ) => {
+	const onUserValueChange = ( uuid: string ) => (
+		fieldName: string,
+		fieldValue: string,
+		mailBoxFieldTouched = false
+	) => {
+		const changedUsers = users.map( ( user ) => {
 			if ( user.uuid !== uuid ) {
 				return user;
 			}
 
-			return { ...user, [ fieldName ]: { value: fieldValue, error: null } };
+			const changedUser = { ...user, [ fieldName ]: { value: fieldValue, error: null } };
+
+			if ( 'firstName' === fieldName && ! mailBoxFieldTouched ) {
+				return { ...changedUser, mailBox: { value: sanitizeEmail( fieldValue ), error: null } };
+			}
+
+			return changedUser;
 		} );
 
-		onUsersChange( validateUsers( modifiedUserList, extraValidation ) );
+		onUsersChange( validateUsers( changedUsers, extraValidation ) );
 	};
 
 	const onUserAdd = () => {

--- a/client/components/gsuite/gsuite-new-user-list/new-user.tsx
+++ b/client/components/gsuite/gsuite-new-user-list/new-user.tsx
@@ -115,7 +115,7 @@ const GSuiteNewUser: FunctionComponent< Props > = ( {
 							maxLength={ 60 }
 							isError={ hasFirstNameError }
 							onChange={ ( event: ChangeEvent< HTMLInputElement > ) => {
-								onUserValueChange( 'firstName', event.target.value );
+								onUserValueChange( 'firstName', event.target.value, mailBoxFieldTouched );
 							} }
 							onBlur={ () => {
 								setFirstNameFieldTouched( wasValidated );

--- a/client/components/gsuite/gsuite-new-user-list/new-user.tsx
+++ b/client/components/gsuite/gsuite-new-user-list/new-user.tsx
@@ -17,6 +17,7 @@ import FormInputValidation from 'components/forms/form-input-validation';
 import { GSuiteNewUser as NewUser } from 'lib/gsuite/new-users';
 
 interface Props {
+	autoFocus: boolean;
 	domains: string[];
 	onUserRemove: () => void;
 	onUserValueChange: ( field: string, value: string ) => void;
@@ -25,6 +26,7 @@ interface Props {
 }
 
 const GSuiteNewUser: FunctionComponent< Props > = ( {
+	autoFocus,
 	domains,
 	onUserRemove,
 	onUserValueChange,
@@ -110,6 +112,7 @@ const GSuiteNewUser: FunctionComponent< Props > = ( {
 				<div className="gsuite-new-user-list__new-user-name">
 					<div className="gsuite-new-user-list__new-user-name-container">
 						<FormTextInput
+							autoFocus={ autoFocus } // eslint-disable-line jsx-a11y/no-autofocus
 							placeholder={ translate( 'First name' ) }
 							value={ firstName }
 							maxLength={ 60 }

--- a/client/components/gsuite/gsuite-new-user-list/new-user.tsx
+++ b/client/components/gsuite/gsuite-new-user-list/new-user.tsx
@@ -106,13 +106,6 @@ const GSuiteNewUser: FunctionComponent< Props > = ( {
 
 	return (
 		<div>
-			<FormFieldset className="gsuite-new-user-list__new-user-email-fieldset">
-				<div className="gsuite-new-user-list__new-user-email">
-					{ domains.length > 1 ? renderMultiDomain() : renderSingleDomain() }
-				</div>
-				{ hasMailBoxError && <FormInputValidation text={ mailBoxError } isError /> }
-			</FormFieldset>
-
 			<FormFieldset className="gsuite-new-user-list__new-user-name-fieldset">
 				<div className="gsuite-new-user-list__new-user-name">
 					<div className="gsuite-new-user-list__new-user-name-container">
@@ -161,6 +154,14 @@ const GSuiteNewUser: FunctionComponent< Props > = ( {
 						</Button>
 					</div>
 				</div>
+			</FormFieldset>
+
+			<FormFieldset className="gsuite-new-user-list__new-user-email-fieldset">
+				<div className="gsuite-new-user-list__new-user-email">
+					{ domains.length > 1 ? renderMultiDomain() : renderSingleDomain() }
+				</div>
+
+				{ hasMailBoxError && <FormInputValidation text={ mailBoxError } isError /> }
 			</FormFieldset>
 		</div>
 	);

--- a/client/components/gsuite/gsuite-new-user-list/new-user.tsx
+++ b/client/components/gsuite/gsuite-new-user-list/new-user.tsx
@@ -66,7 +66,7 @@ const GSuiteNewUser: FunctionComponent< Props > = ( {
 				value={ mailBox }
 				isError={ hasMailBoxError }
 				onChange={ ( event: ChangeEvent< HTMLInputElement > ) => {
-					onUserValueChange( 'mailBox', event.target.value );
+					onUserValueChange( 'mailBox', event.target.value.toLowerCase() );
 				} }
 				onBlur={ () => {
 					setMailBoxFieldTouched( wasValidated );
@@ -85,13 +85,14 @@ const GSuiteNewUser: FunctionComponent< Props > = ( {
 					value={ mailBox }
 					isError={ hasMailBoxError }
 					onChange={ ( event: ChangeEvent< HTMLInputElement > ) => {
-						onUserValueChange( 'mailBox', event.target.value );
+						onUserValueChange( 'mailBox', event.target.value.toLowerCase() );
 					} }
 					onBlur={ () => {
 						setMailBoxFieldTouched( wasValidated );
 					} }
 					onKeyUp={ onReturnKeyPress }
 				/>
+
 				<GSuiteDomainsSelect
 					domains={ domains }
 					onChange={ ( event ) => {
@@ -128,8 +129,10 @@ const GSuiteNewUser: FunctionComponent< Props > = ( {
 							} }
 							onKeyUp={ onReturnKeyPress }
 						/>
+
 						{ hasFirstNameError && <FormInputValidation text={ firstNameError } isError /> }
 					</div>
+
 					<div className="gsuite-new-user-list__new-user-name-container">
 						<FormTextInput
 							placeholder={ translate( 'Last name' ) }
@@ -144,8 +147,10 @@ const GSuiteNewUser: FunctionComponent< Props > = ( {
 							} }
 							onKeyUp={ onReturnKeyPress }
 						/>
+
 						{ hasLastNameError && <FormInputValidation text={ lastNameError } isError /> }
 					</div>
+
 					<div>
 						<Button
 							className="gsuite-new-user-list__new-user-remove-user-button"

--- a/client/lib/gsuite/new-users.ts
+++ b/client/lib/gsuite/new-users.ts
@@ -54,7 +54,7 @@ const mapFieldValues = ( user: GSuiteNewUser, callback: Function ): GSuiteNewUse
 	);
 
 /*
- * Clear all previous errors from a field
+ * Clears all previous errors from the specified field.
  */
 const removePreviousErrors = ( { value }: GSuiteNewUserField ): GSuiteNewUserField => ( {
 	value,
@@ -62,7 +62,7 @@ const removePreviousErrors = ( { value }: GSuiteNewUserField ): GSuiteNewUserFie
 } );
 
 /*
- * Add a new error if field has no errors and value is empty
+ * Adds a new error to the specified field if it has no errors and its value is empty.
  */
 const requiredField = ( { value, error }: GSuiteNewUserField ): GSuiteNewUserField => ( {
 	value,
@@ -73,7 +73,7 @@ const requiredField = ( { value, error }: GSuiteNewUserField ): GSuiteNewUserFie
 } );
 
 /*
- * Add a new error if field has no errors and is more than sixty characters
+ * Adds a new error to the specified field if it has no errors and is more than sixty characters.
  */
 const sixtyCharacterField = ( { value, error }: GSuiteNewUserField ): GSuiteNewUserField => ( {
 	value,
@@ -86,7 +86,7 @@ const sixtyCharacterField = ( { value, error }: GSuiteNewUserField ): GSuiteNewU
 } );
 
 /*
- * Add a new error if field has no errors and contains invalid characters
+ * Adds a new error to the specified email field if it has no errors and contains invalid characters.
  */
 const validEmailCharacterField = ( { value, error }: GSuiteNewUserField ): GSuiteNewUserField => ( {
 	value,
@@ -98,8 +98,16 @@ const validEmailCharacterField = ( { value, error }: GSuiteNewUserField ): GSuit
 			: error,
 } );
 
+/**
+ * Sanitizes the specified email address by removing any character that is not allowed, and converting it to lowercase.
+ *
+ * @param {string} email - email address
+ */
+const sanitizeEmail = ( email: string ): string =>
+	email.replace( /[^0-9a-z_'.-]/gi, '' ).toLowerCase();
+
 /*
- * Add a new error if the mailBox field has no errors and the full email failed the emailValidator
+ * Adds a new error if the mailbox has no errors and the email address is invalid.
  */
 const validateOverallEmail = (
 	{ value: mailBox, error: mailBoxError }: GSuiteNewUserField,
@@ -113,12 +121,12 @@ const validateOverallEmail = (
 } );
 
 /*
- * Add a new error if the mailBox field has no errors and the existing mailboxes matches the field
+ * Adds a new error if the mailbox has no errors and matches an existing email address.
  */
 const validateOverallEmailAgainstExistingEmails = (
 	{ value: mailBox, error: mailBoxError }: GSuiteNewUserField,
 	{ value: domain }: GSuiteNewUserField,
-	existingGSuiteUsers: any[]
+	existingGSuiteUsers: []
 ): GSuiteNewUserField => ( {
 	value: mailBox,
 	error:
@@ -129,7 +137,7 @@ const validateOverallEmailAgainstExistingEmails = (
 } );
 
 /*
- * Clears all previous errors from all fields for the specfied user.
+ * Clears all previous errors from all fields for the specified user.
  */
 const clearPreviousErrors = ( users: GSuiteNewUser[] ) => {
 	return users.map( ( user ) =>
@@ -138,7 +146,7 @@ const clearPreviousErrors = ( users: GSuiteNewUser[] ) => {
 };
 
 /*
- *  Add a new error if the mailBox field has no errors and the mailBox appear more than once in the map
+ *  Adds a new error if the specified mailbox field has no errors and appears more than once in the provided map.
  */
 const validateNewUserMailboxIsUnique = (
 	{ value: mailBox, error: previousError }: GSuiteNewUserField,
@@ -208,7 +216,7 @@ const validateUsers = (
 
 const validateAgainstExistingUsers = (
 	{ uuid, domain, mailBox, firstName, lastName }: GSuiteNewUser,
-	existingGSuiteUsers: any[]
+	existingGSuiteUsers: []
 ) => ( {
 	uuid,
 	firstName,
@@ -297,6 +305,7 @@ export {
 	isUserValid,
 	newUser,
 	newUsers,
+	sanitizeEmail,
 	validateAgainstExistingUsers,
 	validateNewUsersAreUnique,
 	validateUser,

--- a/client/my-sites/email/gsuite-add-users/index.jsx
+++ b/client/my-sites/email/gsuite-add-users/index.jsx
@@ -188,13 +188,17 @@ class GSuiteAddUsers extends React.Component {
 				) : (
 					''
 				) }
+
 				{ selectedDomainInfo.map( ( domain ) => {
 					return <QueryEmailForwards key={ domain.domain } domainName={ domain.domain } />;
 				} ) }
+
 				<SectionHeader label={ translate( 'Add G Suite' ) } />
+
 				{ gsuiteUsers && selectedDomainInfo && ! isRequestingDomains ? (
 					<Card>
 						<GSuiteNewUserList
+							autoFocus
 							extraValidation={ ( user ) => validateAgainstExistingUsers( user, gsuiteUsers ) }
 							domains={ selectedDomainInfo }
 							onUsersChange={ this.handleUsersChange }
@@ -226,8 +230,10 @@ class GSuiteAddUsers extends React.Component {
 		return (
 			<Fragment>
 				<PageViewTracker path={ analyticsPath } title="Domain Management > Add G Suite Users" />
+
 				{ selectedSite && <QuerySiteDomains siteId={ selectedSite.ID } /> }
 				{ selectedSite && <QueryGSuiteUsers siteId={ selectedSite.ID } /> }
+
 				<Main>
 					<DomainManagementHeader
 						onClick={ this.goToEmail }


### PR DESCRIPTION
This pull request seeks to refine the user experience on the `Add G Suite` page by:

* Moving the first and last name fields above the mailbox field
* Prefilling the mailbox from the first name
* Enforcing lowercase for the mailbox
* Putting focus on the first name field upon page loading, or when adding/removing a user

![screenshot](https://user-images.githubusercontent.com/594356/85408834-558f4b00-b565-11ea-9f41-fdc4ed1eb571.png)


#### Testing instructions

1. Run `git checkout update/gsuite-add-user-form` and start your server, or open a [live branch](https://calypso.live/?branch=fix/update/gsuite-add-user-form)
2. Open the [`Email` page](http://calypso.localhost:3000/email) for a site with a G Suite account
3. Click the `Add New User` button
4. Assert that the email field is now presented below the two other fields
5. Assert that the first name field has focus
6. Enter anything in that field
7. Assert that the email field is automatically updated (and sanitized)
8. Assert that once the email field had focus, it is now longer updated automatically
9. Click the trash icon of the first user
10. Assert that the first name field has focus again
11. Click the `Add another user` button
12. Assert that the first name field of that new user has focus