### PR TITLE
Add tracks event to the delete domain button

### DIFF
--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -63,6 +63,7 @@ class RemovePurchase extends Component {
 		setAllSitesSelected: PropTypes.func.isRequired,
 		userId: PropTypes.number.isRequired,
 		useVerticalNavItem: PropTypes.bool,
+		onClickTracks: PropTypes.func,
 	};
 
 	state = {
@@ -89,6 +90,9 @@ class RemovePurchase extends Component {
 	openDialog = ( event ) => {
 		event.preventDefault();
 
+		if ( this.props.onClickTracks ) {
+			this.props.onClickTracks( event );
+		}
 		if (
 			this.shouldShowNonPrimaryDomainWarning() &&
 			! this.state.isShowingNonPrimaryDomainWarning

--- a/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
+++ b/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
@@ -374,6 +374,15 @@ class DomainManagementNavigationEnhanced extends React.Component {
 		} );
 	};
 
+	handleDomainDeleteClick = () => {
+		const { domain, purchase } = this.props;
+
+		this.props.recordTracksEvent( 'calypso_domain_management_delete_click', {
+			section: domain.type,
+			is_cancelable: purchase && isCancelable( purchase ),
+		} );
+	};
+
 	getPickCustomDomain() {
 		const { selectedSite, translate } = this.props;
 
@@ -529,7 +538,14 @@ class DomainManagementNavigationEnhanced extends React.Component {
 		if ( isCancelable( purchase ) ) {
 			const link = cancelPurchase( selectedSite.slug, purchase.id );
 
-			return <DomainManagementNavigationItem path={ link } materialIcon="delete" text={ title } />;
+			return (
+				<DomainManagementNavigationItem
+					path={ link }
+					onClick={ this.handleDomainDeleteClick }
+					materialIcon="delete"
+					text={ title }
+				/>
+			);
 		}
 
 		return (
@@ -540,6 +556,7 @@ class DomainManagementNavigationEnhanced extends React.Component {
 				purchase={ purchase }
 				useVerticalNavItem={ true }
 				className="navigation__nav-item is-clickable"
+				onClickTracks={ this.handleDomainDeleteClick }
 			>
 				<span>
 					<DomainManagementNavigationItemContents materialIcon="delete" text={ title } />


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* We want to track the use of the delete domain button in the domain status screen so we're adding a new tracks event to track it

#### Testing instructions

* Click on the "Delete your domain permanently" button and verify that the tracks event is fired
