### PR TITLE
Gutenboarding: update plans and domains behaviour

### DIFF
--- a/client/landing/gutenboarding/hooks/use-selected-plan.ts
+++ b/client/landing/gutenboarding/hooks/use-selected-plan.ts
@@ -15,12 +15,20 @@ export function useSelectedPlan() {
 
 	const planPath = usePlanRouteParam();
 	const planFromPath = useSelect( ( select ) => select( PLANS_STORE ).getPlanByPath( planPath ) );
+	const isPlanFree = useSelect( ( select ) => select( PLANS_STORE ).isPlanFree );
 
 	const hasPaidDomain = useSelect( ( select ) => select( ONBOARD_STORE ).hasPaidDomain() );
 	const hasPaidDesign = useSelect( ( select ) => select( ONBOARD_STORE ).hasPaidDesign() );
 	const defaultPlan = useSelect( ( select ) =>
 		select( PLANS_STORE ).getDefaultPlan( hasPaidDomain, hasPaidDesign )
 	);
+
+	// If the selected plan is not a paid plan
+	// and the user selects a premium domain
+	// return the default paid plan.
+	if ( hasPaidDomain && isPlanFree( selectedPlan?.storeSlug ) ) {
+		return defaultPlan;
+	}
 
 	/**
 	 * Plan is decided in this order

--- a/client/landing/gutenboarding/onboarding-block/plans/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/plans/index.tsx
@@ -6,6 +6,7 @@ import { useHistory } from 'react-router-dom';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useI18n } from '@automattic/react-i18n';
 import PlansGrid from '@automattic/plans-grid';
+import type { Plans } from '@automattic/data-stores';
 
 /**
  * Internal dependencies
@@ -14,9 +15,13 @@ import { useSelectedPlan } from '../../hooks/use-selected-plan';
 import { useTrackStep } from '../../hooks/use-track-step';
 import useStepNavigation from '../../hooks/use-step-navigation';
 import { STORE_KEY as ONBOARD_STORE } from '../../stores/onboard';
+import { PLANS_STORE } from '../../stores/plans';
 import ActionButtons, { BackButton } from '../../components/action-buttons';
 import { Title, SubTitle } from '../../components/titles';
 import { Step, usePath } from '../../path';
+import { useFreeDomainSuggestion } from '../../hooks/use-free-domain-suggestion';
+
+type PlanSlug = Plans.PlanSlug;
 
 interface Props {
 	isModal?: boolean;
@@ -30,9 +35,10 @@ const PlansStep: React.FunctionComponent< Props > = ( { isModal } ) => {
 
 	const plan = useSelectedPlan();
 	const domain = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedDomain() );
+	const isPlanFree = useSelect( ( select ) => select( PLANS_STORE ).isPlanFree );
 
 	//@TODO: do the same for domains step
-	const { setHasUsedPlansStep } = useDispatch( ONBOARD_STORE );
+	const { setDomain, setHasUsedPlansStep } = useDispatch( ONBOARD_STORE );
 	React.useEffect( () => {
 		! isModal && setHasUsedPlansStep( true );
 	}, [] );
@@ -47,8 +53,14 @@ const PlansStep: React.FunctionComponent< Props > = ( { isModal } ) => {
 		selected_plan: selectedPlanRef.current,
 	} ) );
 
+	const freeDomainSuggestion = useFreeDomainSuggestion();
+
 	const handleBack = () => ( isModal ? history.goBack() : goBack() );
-	const handlePlanSelect = () => {
+	const handlePlanSelect = ( planSlug: PlanSlug ) => {
+		if ( isPlanFree( planSlug ) ) {
+			setDomain( freeDomainSuggestion );
+		}
+
 		if ( isModal ) {
 			history.goBack();
 		} else {

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -118,7 +118,7 @@ export default {
 		allowExistingUsers: true,
 	},
 	newSiteGutenbergOnboarding: {
-		datestamp: '20200612',
+		datestamp: '20200617',
 		variations: {
 			gutenberg: 10,
 			control: 90,

--- a/packages/data-stores/src/plans/selectors.ts
+++ b/packages/data-stores/src/plans/selectors.ts
@@ -3,7 +3,7 @@
  */
 import type { State } from './reducer';
 import { planDetails, PLANS_LIST } from './plans-data';
-import { DEFAULT_PAID_PLAN, PLAN_ECOMMERCE } from './constants';
+import { DEFAULT_PAID_PLAN, PLAN_ECOMMERCE, PLAN_FREE } from './constants';
 import type { PlanSlug } from './types';
 
 function getPlan( slug: PlanSlug ) {
@@ -30,4 +30,8 @@ export const getPrices = ( state: State ) => state.prices;
 
 export const isPlanEcommerce = ( _: State, planSlug?: PlanSlug ) => {
 	return planSlug === PLAN_ECOMMERCE;
+};
+
+export const isPlanFree = ( _: State, planSlug?: PlanSlug ) => {
+	return planSlug === PLAN_FREE;
 };

--- a/packages/plans-grid/src/plans-grid/index.tsx
+++ b/packages/plans-grid/src/plans-grid/index.tsx
@@ -24,7 +24,7 @@ type PlansSlug = Plans.PlanSlug;
 export interface Props {
 	header: React.ReactElement;
 	currentPlan?: Plans.Plan;
-	onPlanSelect?: () => void;
+	onPlanSelect?: ( plan: PlansSlug ) => void;
 	onPickDomainClick?: () => void;
 	currentDomain?: DomainSuggestions.DomainSuggestion;
 }
@@ -42,7 +42,7 @@ const PlansGrid: React.FunctionComponent< Props > = ( {
 
 	const handlePlanSelect = ( plan: PlansSlug ) => {
 		setPlan( plan );
-		onPlanSelect?.();
+		onPlanSelect?.( plan );
 	};
 
 	return (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Automatically change the domain to be the wp.com subdomain when selecting _Free Plan_.
* Automatically switch to _Premium Plan_ if the selected plan is _Free Plan_ and user picks a paid domain.

Demo: https://cloudup.com/cz6txa0y85x

Note: This change has been made possible after the [Plans Grid design update](https://github.com/Automattic/wp-calypso/pull/43206) which clarify the direct relation between free/paid plans and free/paid domains. 

#### Testing instructions

* Go to [/new](https://calypso.live/new?branch=update/gutenboarding-plans-and-domains-behaviour)
* Open Domains Modal and select a paid domain => plan = _Premium Plan_
* Open the Plans Modal and select _Free Plan_ => domain = wp.com subdomain
* Open Domains Modal and select a paid domain => plan = _Premium Plan_

Fixes #43253 and partly #42601
Related: #42607
