### PR TITLE
Remove the space between the icon and the card title

### DIFF
--- a/client/my-sites/backup/style.scss
+++ b/client/my-sites/backup/style.scss
@@ -103,14 +103,6 @@
 	}
 }
 
-.backup__main {
-	@include breakpoint-deprecated( '>660px' ) {
-		.action-panel__body {
-			margin-left: 30px;
-		}
-	}
-}
-
 header.backup__header.is-left-align {
 	color: var( --studio-black );
 	font-size: 28px;

--- a/client/my-sites/scan/style.scss
+++ b/client/my-sites/scan/style.scss
@@ -103,11 +103,3 @@ header.scan__header.is-left-align {
 		}
 	}
 }
-
-.scan__main {
-	@include breakpoint-deprecated( '>660px' ) {
-		.action-panel__body {
-			margin-left: 30px;
-		}
-	}
-}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Remove the space between the icon and the card title on the Upsell page

#### Testing instructions

- Apply this change
- Select a simple wpcom site without plans. Active `?flags=jetpack/features-section`
- Check if the odd space between the icon and the title is removed
