### PR TITLE
e2e: Add invites cleanup after tests

### DIFF
--- a/test/e2e/lib/pages/people-page.js
+++ b/test/e2e/lib/pages/people-page.js
@@ -142,7 +142,7 @@ export default class PeoplePage extends AsyncBaseContainer {
 				driver,
 				By.css( `.people-invites__pending .people-profile__username[title="${ emailAddress }"]` )
 			);
-		}, this.explicitWaitMS * 2 );
+		}, this.explicitWaitMS * 4 );
 	}
 
 	async goToRevokeInvitePage( emailAddress ) {

--- a/test/e2e/lib/pages/people-page.js
+++ b/test/e2e/lib/pages/people-page.js
@@ -152,6 +152,13 @@ export default class PeoplePage extends AsyncBaseContainer {
 		);
 	}
 
+	async goToClearAcceptedInvitePage( username ) {
+		return await DriverHelper.clickWhenClickable(
+			this.driver,
+			By.css( `.people-invites__accepted .people-profile__login[data-e2e-login="${ username }"]` )
+		);
+	}
+
 	async removeOnlyEmailFollowerDisplayed() {
 		await DriverHelper.clickWhenClickable(
 			this.driver,

--- a/test/e2e/lib/pages/people-page.js
+++ b/test/e2e/lib/pages/people-page.js
@@ -142,7 +142,7 @@ export default class PeoplePage extends AsyncBaseContainer {
 				driver,
 				By.css( `.people-invites__pending .people-profile__username[title="${ emailAddress }"]` )
 			);
-		}, this.explicitWaitMS * 4 );
+		}, this.explicitWaitMS * 2 );
 	}
 
 	async goToRevokeInvitePage( emailAddress ) {

--- a/test/e2e/specs/wp-invite-users-spec.js
+++ b/test/e2e/specs/wp-invite-users-spec.js
@@ -147,6 +147,16 @@ describe( `[${ host }] Invites:  (${ screenSize })`, function () {
 			await navBarComponent.clickMySites();
 			return await NoSitesComponent.Expect( driver );
 		} );
+
+		after( async function () {
+			await new LoginFlow( driver ).loginAndSelectPeople();
+			const peoplePage = await PeoplePage.Expect( driver );
+			await peoplePage.selectInvites();
+			await peoplePage.goToClearAcceptedInvitePage( newUserName );
+
+			const revokePage = await RevokePage.Expect( driver );
+			await revokePage.revokeUser();
+		} );
 	} );
 
 	describe( 'Inviting new user as an Editor and revoke invite: @parallel @jetpack', function () {
@@ -225,7 +235,7 @@ describe( `[${ host }] Invites:  (${ screenSize })`, function () {
 			return await peoplePage.inviteUser();
 		} );
 
-		step( 'Can invite a new user as an editor and see its pending', async function () {
+		step( 'Can invite a new user as a viewer and see its pending', async function () {
 			const invitePeoplePage = await InvitePeoplePage.Expect( driver );
 			await invitePeoplePage.inviteNewUser(
 				newInviteEmailAddress,
@@ -301,6 +311,19 @@ describe( `[${ host }] Invites:  (${ screenSize })`, function () {
 				false,
 				`The username of '${ newUserName }' was still displayed as a site viewer`
 			);
+		} );
+
+		step( 'Can clear accepted invite', async function () {
+			await new LoginFlow( driver, 'privateSiteUser' ).loginAndSelectPeople();
+			const peoplePage = await PeoplePage.Expect( driver );
+			await peoplePage.selectInvites();
+			await peoplePage.goToClearAcceptedInvitePage( newUserName );
+
+			const noticesComponent = await NoticesComponent.Expect( driver );
+			const revokePage = await RevokePage.Expect( driver );
+			await revokePage.revokeUser();
+			const sent = await noticesComponent.isSuccessNoticeDisplayed();
+			return assert( sent, 'The Invite deleted confirmation message was not displayed' );
 		} );
 
 		step( 'Can not see the site - see the private site log in page', async function () {

--- a/test/e2e/specs/wp-invite-users-spec.js
+++ b/test/e2e/specs/wp-invite-users-spec.js
@@ -49,7 +49,7 @@ describe( `[${ host }] Invites:  (${ screenSize })`, function () {
 	this.timeout( mochaTimeOut );
 
 	describe( 'Inviting new user as an Editor: @parallel @jetpack', function () {
-		const newUserName = 'e2eflowtestingeditor' + new Date().getTime().toString();
+		const newUserName = 'e2eflowtestingeditora' + new Date().getTime().toString();
 		const newInviteEmailAddress = dataHelper.getEmailAddress( newUserName, inviteInboxId );
 		let acceptInviteURL = '';
 
@@ -160,7 +160,7 @@ describe( `[${ host }] Invites:  (${ screenSize })`, function () {
 	} );
 
 	describe( 'Inviting new user as an Editor and revoke invite: @parallel @jetpack', function () {
-		const newUserName = 'e2eflowtestingeditor' + new Date().getTime().toString();
+		const newUserName = 'e2eflowtestingeditorb' + new Date().getTime().toString();
 		const newInviteEmailAddress = dataHelper.getEmailAddress( newUserName, inviteInboxId );
 		let acceptInviteURL = '';
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Clear sent invites after running the tests, to avoid blowing up the invites table.  Discussion in pMz3w-bzd-p2
    - added a cleanup `after` hook for `Inviting new user as an Editor` 
    - added a cleanup `after` hook for `Inviting New User as a Viewer of a WordPress.com Private Site`
    - added a/b suffix to `newInviteEmailAddress` inside the two editor invite tests, to ensure uniqueness between them (runs in my local end up using the same timestamp suffix)
    - fixed a description typo

Partial fix for #43247 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Invites e2e tests should pass, specifically the additions described above.