### PR TITLE
Checkout: update error boundary messages for consistency

### DIFF
--- a/client/my-sites/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout-system-decider.js
@@ -115,7 +115,7 @@ export default function CheckoutSystemDecider( {
 	if ( 'composite-checkout' === checkoutVariant ) {
 		return (
 			<CheckoutErrorBoundary
-				errorMessage={ translate( 'Sorry. there was an error loading this page' ) }
+				errorMessage={ translate( 'Sorry, there was an error loading this page.' ) }
 				onError={ logCheckoutError }
 			>
 				<StripeHookProvider fetchStripeConfiguration={ fetchStripeConfigurationWpcom }>

--- a/packages/composite-checkout/src/components/checkout-provider.js
+++ b/packages/composite-checkout/src/components/checkout-provider.js
@@ -100,8 +100,8 @@ export const CheckoutProvider = ( props ) => {
 		]
 	);
 
-	// This error message cannot be translated because translation hasn't loaded yet.
-	const errorMessage = 'Sorry, there was an error loading this page.';
+	const { __ } = useI18n();
+	const errorMessage = __( 'Sorry, there was an error loading this page.' );
 	const onError = useCallback(
 		( error ) => onEvent?.( { type: 'PAGE_LOAD_ERROR', payload: error.message } ),
 		[ onEvent ]

--- a/packages/composite-checkout/src/components/checkout-provider.js
+++ b/packages/composite-checkout/src/components/checkout-provider.js
@@ -101,7 +101,7 @@ export const CheckoutProvider = ( props ) => {
 	);
 
 	// This error message cannot be translated because translation hasn't loaded yet.
-	const errorMessage = 'Sorry, there was an error loading this page';
+	const errorMessage = 'Sorry, there was an error loading this page.';
 	const onError = useCallback(
 		( error ) => onEvent?.( { type: 'PAGE_LOAD_ERROR', payload: error.message } ),
 		[ onEvent ]


### PR DESCRIPTION
I missed a typo in the review of #43268. This updates the error boundary messages in Checkout for consistency (and shared translations).