### PR TITLE
P2 signup: use .p2.blog domain

### DIFF
--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -552,7 +552,7 @@ export function createWpForTeamsSite( callback, dependencies, stepData, reduxSto
 	const themeSlugWithRepo = 'pub/p2020';
 
 	const data = {
-		blog_name: site,
+		blog_name: `${ site }.p2.blog`,
 		blog_title: siteTitle,
 		public: -1, // wp for teams sites are not supposed to be public
 		options: {

--- a/client/signup/steps/p2-site/index.jsx
+++ b/client/signup/steps/p2-site/index.jsx
@@ -111,7 +111,7 @@ class P2Site extends React.Component {
 
 		wpcom.undocumented().sitesNew(
 			{
-				blog_name: fields.site,
+				blog_name: `${ fields.site }.p2.blog`,
 				blog_title: fields.siteTitle,
 				validate: true,
 			},
@@ -288,7 +288,7 @@ class P2Site extends React.Component {
 						onBlur={ this.handleBlur }
 						onChange={ this.handleChangeEvent }
 					/>
-					<span className="p2-site__wordpress-domain-suffix">.wordpress.com</span>
+					<span className="p2-site__wordpress-domain-suffix">.p2.blog</span>
 				</ValidationFieldset>
 			</>
 		);


### PR DESCRIPTION
In this PR, we change the default domain for new P2 sites to .p2.blog.

## Testing instructions

Navigate to http://calypso.localhost:3000/start/p2 and go through the signup flow. You should end up with a new P2 site on a .p2.blog domain.