### PR TITLE
Jetpack section: hide Activity Log promo from the upsell page for Personal and Premium plan owners

### DIFF
--- a/client/my-sites/backup/wpcom-upsell.tsx
+++ b/client/my-sites/backup/wpcom-upsell.tsx
@@ -12,13 +12,15 @@ import DocumentHead from 'components/data/document-head';
 import Main from 'components/main';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
+import { isPersonalPlan, isPremiumPlan } from 'lib/plans';
 import FormattedHeader from 'components/formatted-header';
 import PromoSection, { Props as PromoSectionProps } from 'components/promo-section';
 import PromoCard from 'components/promo-section/promo-card';
 import PromoCardCTA from 'components/promo-section/promo-card/cta';
 import useTrackCallback from 'lib/jetpack/use-track-callback';
 import Gridicon from 'components/gridicon';
-import { getSelectedSiteSlug } from 'state/ui/selectors';
+import { getSitePlan } from 'state/sites/selectors';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import MaterialIcon from 'components/material-icon';
 import WhatIsJetpack from 'components/jetpack/what-is-jetpack';
 
@@ -30,28 +32,36 @@ import './style.scss';
 
 const trackEventName = 'calypso_jetpack_backup_business_upsell';
 
-const promos: PromoSectionProps = {
-	promos: [
-		{
-			title: translate( 'Jetpack Scan' ),
-			body: translate(
-				'Scan gives you automated scanning and one-click fixes to keep your site ahead of security threats.'
-			),
-			image: <MaterialIcon icon="security" className="backup__upsell-icon" />,
-		},
-		{
-			title: translate( 'Activity Log' ),
-			body: translate(
-				'A complete record of everything that happens on your site, with history that spans over 30 days.'
-			),
-			image: <Gridicon icon="history" className="backup__upsell-icon" />,
-		},
-	],
-};
+const promos = [
+	{
+		title: translate( 'Jetpack Scan' ),
+		body: translate(
+			'Scan gives you automated scanning and one-click fixes to keep your site ahead of security threats.'
+		),
+		image: <MaterialIcon icon="security" className="backup__upsell-icon" />,
+	},
+	{
+		title: translate( 'Activity Log' ),
+		body: translate(
+			'A complete record of everything that happens on your site, with history that spans over 30 days.'
+		),
+		image: <Gridicon icon="history" className="backup__upsell-icon" />,
+	},
+];
 
 export default function WPCOMUpsellPage(): ReactElement {
 	const onUpgradeClick = useTrackCallback( undefined, trackEventName );
 	const siteSlug = useSelector( getSelectedSiteSlug );
+	const siteId = useSelector( getSelectedSiteId );
+	const { product_slug: planSlug } = useSelector( ( state ) => getSitePlan( state, siteId ) );
+
+	// Don't show the Activity Log promo for Personal or Premium plan owners.
+	const filteredPromos: PromoSectionProps = React.useMemo( () => {
+		if ( isPersonalPlan( planSlug ) || isPremiumPlan( planSlug ) ) {
+			return { promos: [ promos[ 0 ] ] };
+		}
+		return { promos };
+	}, [ planSlug ] );
 
 	return (
 		<Main className="backup__main backup__wpcom-upsell is-wide-layout">
@@ -96,7 +106,7 @@ export default function WPCOMUpsellPage(): ReactElement {
 				isSecondary
 			/>
 
-			<PromoSection { ...promos } />
+			<PromoSection { ...filteredPromos } />
 
 			<WhatIsJetpack />
 		</Main>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Hide the AL promo card when the site has a Personal or Premium plan.

#### Question

* Should we merge this two components into one?

#### Testing instructions

* Prerequisite: 1) WPCOM site with a free plan, 2) Jetpack section enabled.
* Run this PR.
* Go to `http://calypso.localhost:3000/backup/<your-site-slug>?flag=jetpack/features-section`. 
* Verify that the Activity Log promo card appears at the bottom.
* Go to `http://calypso.localhost:3000/scan/<your-site-slug>?flag=jetpack/features-section`. 
* Verify that the Activity Log promo card appears at the bottom.
* Upgrade your site's plan to either Personal or Premium.
* Go to `http://calypso.localhost:3000/backup/<your-site-slug>?flag=jetpack/features-section`. 
* Verify that the Activity Log promo card **doesn't** appear at the bottom.
* Go to `http://calypso.localhost:3000/scan/<your-site-slug>?flag=jetpack/features-section`. 
* Verify that the Activity Log promo card **doesn't** appear at the bottom.

Fixes 1179060693083348-as-1180559801574125 and 1179060693083348-as-1180559801574127.

#### Demo
##### Free plan - Backup
![image](https://user-images.githubusercontent.com/3418513/84792093-db415280-afc9-11ea-9782-a83d02a8ff0e.png)

##### Free plan - Scan
![image](https://user-images.githubusercontent.com/3418513/84792054-cfee2700-afc9-11ea-9859-6f1db97c4975.png)

##### Personal/Premium - Backup
![image](https://user-images.githubusercontent.com/3418513/84792177-f2804000-afc9-11ea-9bdd-dc62752064c3.png)

##### Personal/Premium - Scan
![image](https://user-images.githubusercontent.com/3418513/84792226-fdd36b80-afc9-11ea-8d35-41793eac086c.png)


