### PR TITLE
composite-checkout: Add "Free with your plan" copy to (free) domain mapping line items

### DIFF
--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
@@ -511,4 +511,6 @@ function DomainDiscountCallout( { item } ) {
 	if ( isFreeDomainMapping ) {
 		return <DiscountCalloutUI>{ translate( 'Free with your plan' ) }</DiscountCalloutUI>;
 	}
+
+	return null;
 }

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
@@ -57,19 +57,6 @@ function WPLineItem( {
 	const isGSuite = !! item.wpcom_meta?.extra?.google_apps_users?.length;
 	const isSavings = item.type === 'coupon';
 
-	let domainDiscountCallout = null;
-	if ( item.wpcom_meta?.is_bundled && item.amount.value === 0 ) {
-		// Bundled domain registrations
-		domainDiscountCallout = (
-			<DiscountCalloutUI>{ translate( 'First year free' ) }</DiscountCalloutUI>
-		);
-	} else if ( item.wpcom_meta?.product_slug === 'domain_map' && item.amount.value === 0 ) {
-		// Free domain mappings
-		domainDiscountCallout = (
-			<DiscountCalloutUI>{ translate( 'Free with your plan' ) }</DiscountCalloutUI>
-		);
-	}
-
 	let gsuiteDiscountCallout = null;
 	if (
 		isGSuite &&
@@ -104,7 +91,7 @@ function WPLineItem( {
 			{ item.sublabel && (
 				<LineItemMeta>
 					<LineItemSublabelAndPrice item={ item } />
-					{ domainDiscountCallout }
+					<DomainDiscountCallout item={ item } />
 				</LineItemMeta>
 			) }
 			{ isSavings && <SavingsList item={ item } /> }
@@ -509,4 +496,19 @@ function SavingsList( { item } ) {
 			) ) }
 		</LineItemMeta>
 	);
+}
+
+function DomainDiscountCallout( { item } ) {
+	const translate = useTranslate();
+
+	const isFreeBundledDomainRegistration = item.wpcom_meta?.is_bundled && item.amount.value === 0;
+	if ( isFreeBundledDomainRegistration ) {
+		return <DiscountCalloutUI>{ translate( 'First year free' ) }</DiscountCalloutUI>;
+	}
+
+	const isFreeDomainMapping =
+		item.wpcom_meta?.product_slug === 'domain_map' && item.amount.value === 0;
+	if ( isFreeDomainMapping ) {
+		return <DiscountCalloutUI>{ translate( 'Free with your plan' ) }</DiscountCalloutUI>;
+	}
 }

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
@@ -57,6 +57,19 @@ function WPLineItem( {
 	const isGSuite = !! item.wpcom_meta?.extra?.google_apps_users?.length;
 	const isSavings = item.type === 'coupon';
 
+	let domainDiscountCallout = null;
+	if ( item.wpcom_meta?.is_bundled && item.amount.value === 0 ) {
+		// Bundled domain registrations
+		domainDiscountCallout = (
+			<DiscountCalloutUI>{ translate( 'First year free' ) }</DiscountCalloutUI>
+		);
+	} else if ( item.wpcom_meta?.product_slug === 'domain_map' && item.amount.value === 0 ) {
+		// Free domain mappings
+		domainDiscountCallout = (
+			<DiscountCalloutUI>{ translate( 'Free with your plan' ) }</DiscountCalloutUI>
+		);
+	}
+
 	let gsuiteDiscountCallout = null;
 	if (
 		isGSuite &&
@@ -91,9 +104,7 @@ function WPLineItem( {
 			{ item.sublabel && (
 				<LineItemMeta>
 					<LineItemSublabelAndPrice item={ item } />
-					{ item.wpcom_meta?.is_bundled && item.amount.value === 0 && (
-						<DiscountCalloutUI>{ translate( 'First year free' ) }</DiscountCalloutUI>
-					) }
+					{ domainDiscountCallout }
 				</LineItemMeta>
 			) }
 			{ isSavings && <SavingsList item={ item } /> }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add "Free with your plan" callout to domain mappings when added to a site with a plan.

![Screen Shot 2020-06-16 at 10 47 54 AM](https://user-images.githubusercontent.com/9310939/84797631-a92af300-afbf-11ea-819a-de93cc86bbe9.png)

#### Testing instructions

- Enter checkout with a domain mapping on a site that already has a plan (Domains -> add a domain to this site -> I already own a domain -> Map a domain). Verify that in checkout there is a "Free with your plan" callout on the mapping line item.
- Enter checkout with a domain _registration_ on a site that already has a plan. Verify that there is a "First year free" callout on the registration line item - this is existing behavior that should not change.

Fixes #43329
