### PR TITLE
Updates settings page paths

### DIFF
--- a/client/blocks/jetpack-backup-creds-banner/index.jsx
+++ b/client/blocks/jetpack-backup-creds-banner/index.jsx
@@ -9,6 +9,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import { settingsPath } from 'lib/jetpack/paths';
 import Banner from 'components/banner';
 import getRewindState from 'state/selectors/get-rewind-state';
 import QueryRewindState from 'components/data/query-rewind-state';
@@ -44,7 +45,7 @@ class JetpackBackupCredsBanner extends Component {
 						href={
 							rewindState.canAutoconfigure
 								? `/start/rewind-auto-config/?blogid=${ siteId }&siteSlug=${ siteSlug }`
-								: `/settings/security/${ siteSlug }#credentials`
+								: `${ settingsPath( siteSlug ) }#credentials`
 						}
 						title={ translate( 'Add your server credentials' ) }
 						description={ translate(

--- a/client/lib/jetpack/paths.ts
+++ b/client/lib/jetpack/paths.ts
@@ -3,6 +3,7 @@
  */
 import isJetpackCloud from 'lib/jetpack/is-jetpack-cloud';
 import { addQueryArgs } from 'lib/url';
+import { isEnabled } from 'config';
 
 const activityLogBasePath = () => ( isJetpackCloud() ? '/backup/activity' : '/activity-log' );
 export const activityLogPath = ( siteSlug?: string ) =>
@@ -18,6 +19,8 @@ const scanBasePath = () => '/scan';
 export const scanPath = ( siteSlug?: string ) =>
 	siteSlug ? `${ scanBasePath() }/${ siteSlug }` : scanBasePath();
 
-const settingsBasePath = () => ( isJetpackCloud() ? '/settings' : '/settings/jetpack' );
+const calypsoBasePath = () =>
+	isEnabled( 'jetpack/features-section' ) ? '/settings/jetpack' : '/settings/security';
+const settingsBasePath = () => ( isJetpackCloud() ? '/settings' : calypsoBasePath() );
 export const settingsPath = ( siteSlug?: string ) =>
 	siteSlug ? `${ settingsBasePath() }/${ siteSlug }` : settingsBasePath();

--- a/client/my-sites/activity/activity-log-item/index.jsx
+++ b/client/my-sites/activity/activity-log-item/index.jsx
@@ -13,6 +13,7 @@ import { flowRight as compose } from 'lodash';
  * Internal dependencies
  */
 import scrollTo from 'lib/scroll-to';
+import { settingsPath } from 'lib/jetpack/paths';
 import { applySiteOffset } from 'lib/site/timezone';
 import ActivityActor from './activity-actor';
 import ActivityDescription from './activity-description';
@@ -265,7 +266,7 @@ class ActivityLogItem extends Component {
 							href={
 								canAutoconfigure
 									? `/start/rewind-auto-config/?blogid=${ siteId }&siteSlug=${ siteSlug }`
-									: `/settings/security/${ siteSlug }#credentials`
+									: `${ settingsPath( siteSlug ) }#credentials`
 							}
 							onClick={ trackAddCreds }
 						>

--- a/client/my-sites/plans/current-plan/current-plan-thank-you/thank-you.js
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you/thank-you.js
@@ -11,6 +11,7 @@ import React, { Component } from 'react';
  * Internal dependencies
  */
 import { preventWidows } from 'lib/formatting';
+import { settingsPath } from 'lib/jetpack/paths';
 import { requestGuidedTour } from 'state/ui/guided-tours/actions';
 import { Button } from '@automattic/components';
 import getCurrentQueryArguments from 'state/selectors/get-current-query-arguments';
@@ -126,7 +127,7 @@ export class ThankYouCard extends Component {
 					) }
 					{ showScanCTAs && (
 						<p className="current-plan-thank-you__followup">
-							<Button href={ `/settings/security/${ selectedSiteSlug }#credentials` } primary>
+							<Button href={ `${ settingsPath( selectedSiteSlug ) }#credentials` } primary>
 								{ translate( 'Add server credentials now' ) }
 							</Button>
 							<Button href={ dismissUrl } onClick={ this.startChecklistTour }>

--- a/client/my-sites/plans/current-plan/jetpack-checklist/index.tsx
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/index.tsx
@@ -31,6 +31,7 @@ import withTrackingTool from 'lib/analytics/with-tracking-tool';
 import { Button, Card } from '@automattic/components';
 import JetpackProductInstall from 'my-sites/plans/current-plan/jetpack-product-install';
 import { getTaskList } from 'lib/checklist';
+import { settingsPath } from 'lib/jetpack/paths';
 
 /**
  * Style dependencies
@@ -175,7 +176,7 @@ class JetpackChecklist extends PureComponent< Props & LocalizeProps > {
 							completedTitle={ translate( 'You turned on Backup and Scan.' ) }
 							duration={ this.getDuration( 3 ) }
 							completed={ isRewindActive }
-							href={ `/settings/security/${ siteSlug }` }
+							href={ settingsPath( siteSlug ) }
 							onClick={ this.handleTaskStart( {
 								taskId: 'jetpack_backups',
 								tourId: isRewindActive ? undefined : 'jetpackBackupsRewind',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR updates the path we send users based on the `jetpack/features-section` flag in the following locations:
  * Activity log item.
  * Backup credentials banner.
  * Scan thank you notice.
  * Backup and Scan checklist item.

#### Testing instructions

Load this PR and test the following on a Jetpack site with and without the `jetpack/features-section` flag enabled:

* Activity log item: Purchase Backup and wait for full backup to complete, then check Activity Log and click three dots next to backup item.
* Backup credentials banner: Same as above, but click the banner.
* Scan thank you notice: Purchase Scan and navigate to `/plans/my-plan/[site]?thank-you&product=jetpack_scan` then click Add Server Credentials Now.
* Backup and Scan checklist item: Purchase a non-free plan and navigate to `/plans/my-plan/[site]` and click Try it under Backup and Scan header.


#### Screenshots
<img width="1072" alt="Screen Shot 2020-06-16 at 11 45 48 AM" src="https://user-images.githubusercontent.com/1760168/84798946-92899980-afc9-11ea-9f6a-4913d780cefb.png">
<img width="348" alt="Screen Shot 2020-06-16 at 11 45 53 AM" src="https://user-images.githubusercontent.com/1760168/84798947-93223000-afc9-11ea-9921-c31f76dc7afe.png">
<img width="786" alt="Screen Shot 2020-06-16 at 11 59 58 AM" src="https://user-images.githubusercontent.com/1760168/84798948-93223000-afc9-11ea-8ce2-937a209b6ef3.png">
<img width="1045" alt="Screen Shot 2020-06-16 at 12 03 05 PM" src="https://user-images.githubusercontent.com/1760168/84798952-93bac680-afc9-11ea-9f42-83c8cd8630f9.png">





Fixes 1179060693083348-as-1179705725205698.
