### PR TITLE
Config: Allow setting feature flags thru a qarg in wpcalypso and horizon

### DIFF
--- a/client/config/index.js
+++ b/client/config/index.js
@@ -49,7 +49,7 @@ function applyFlags( flagsString, modificationMethod ) {
 	} );
 }
 
-const flagEnvironments = [ 'stage', 'jetpack-cloud-stage' ];
+const flagEnvironments = [ 'wpcalypso', 'horizon', 'stage', 'jetpack-cloud-stage' ];
 
 if (
 	process.env.NODE_ENV === 'development' ||


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Setting feature flags by appending a `?flags=` query arg to a Calypso URL has been possible for the `development`, `stage`, and `jetpack-cloud-stage` environments already. It only makes sense to also enable this in the other environments that we use for internal and beta testing, `wpcalypso` and `horizon`.

The concrete motivation for this PR is the flag added in #43246 which we'd like to test in those environments.

#### Testing instructions

Can't really test in the `development` environment :man_shrugging: 
