### PR TITLE
DomainPicker: Show select button on hover and other UX-related changes.

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/domains/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/domains/index.tsx
@@ -17,7 +17,7 @@ import { trackEventWithFlow } from '../../lib/analytics';
 import { STORE_KEY as ONBOARD_STORE } from '../../stores/onboard';
 import { getSuggestionsVendor } from 'lib/domains/suggestions';
 import { FLOW_ID } from '../../constants';
-import ActionButtons, { BackButton, NextButton, SkipButton } from '../../components/action-buttons';
+import ActionButtons, { BackButton } from '../../components/action-buttons';
 import { Title, SubTitle } from '../../components/titles';
 
 /**
@@ -53,10 +53,6 @@ const DomainsStep: React.FunctionComponent< Props > = ( { isModal } ) => {
 		selected_domain: selectedDomainRef.current,
 	} ) );
 
-	const onDomainSelect = ( suggestion: DomainSuggestion | undefined ) => {
-		setDomain( suggestion );
-	};
-
 	const handleBack = () => ( isModal ? history.goBack() : goBack() );
 	const handleNext = () => {
 		trackEventWithFlow( 'calypso_newsite_domain_select', {
@@ -68,7 +64,11 @@ const DomainsStep: React.FunctionComponent< Props > = ( { isModal } ) => {
 			goNext();
 		}
 	};
-	const handleSkip = () => ( isModal ? history.goBack() : goNext() );
+
+	const onDomainSelect = ( suggestion: DomainSuggestion | undefined ) => {
+		setDomain( suggestion );
+		handleNext();
+	};
 
 	const header = (
 		<div className="domains__header">
@@ -78,7 +78,6 @@ const DomainsStep: React.FunctionComponent< Props > = ( { isModal } ) => {
 			</div>
 			<ActionButtons>
 				<BackButton onClick={ handleBack } />
-				{ domain ? <NextButton onClick={ handleNext } /> : <SkipButton onClick={ handleSkip } /> }
 			</ActionButtons>
 		</div>
 	);

--- a/packages/domain-picker/src/domain-picker/index.tsx
+++ b/packages/domain-picker/src/domain-picker/index.tsx
@@ -65,7 +65,6 @@ const DomainPicker: FunctionComponent< Props > = ( {
 	onDomainSelect,
 	quantity = PAID_DOMAINS_TO_SHOW,
 	quantityExpanded = PAID_DOMAINS_TO_SHOW_EXPANDED,
-	currentDomain,
 	analyticsFlowId,
 	analyticsUiAlgo,
 	domainSuggestionVendor,
@@ -176,7 +175,6 @@ const DomainPicker: FunctionComponent< Props > = ( {
 								key={ suggestion.domain_name }
 								suggestion={ suggestion }
 								railcarId={ baseRailcarId ? `${ baseRailcarId }${ i }` : undefined }
-								isSelected={ currentDomain?.domain_name === suggestion.domain_name }
 								isRecommended={ i === 0 }
 								onRender={ () =>
 									handleItemRender( suggestion, `${ baseRailcarId }${ i }`, i, i === 0 )

--- a/packages/domain-picker/src/domain-picker/style.scss
+++ b/packages/domain-picker/src/domain-picker/style.scss
@@ -206,7 +206,7 @@
 	@include break-small {
 		// We're mocking the look of a button,
 		// this is not an actual button.
-		background: #007cba;
+		background: $blue-medium-focus;
 		color: var( --studio-white );
 		border-radius: 2px;
 		padding: 0 12px;
@@ -218,7 +218,7 @@
 		right: 14px;
 
 		&:hover {
-			background: #0070a7;
+			background: mix( black, $blue-medium-focus, 10% );
 		}
 
 		span {

--- a/packages/domain-picker/src/domain-picker/style.scss
+++ b/packages/domain-picker/src/domain-picker/style.scss
@@ -113,7 +113,6 @@
 	flex-grow: 1;
 	margin-right: 24px;
 	letter-spacing: 0.4px;
-	// min-height: $domain-picker__suggestion-item-height;
 
 	.domain-picker__domain-name {
 		word-break: break-word; // use hyphens if any to break domain name
@@ -177,11 +176,17 @@
 	}
 }
 
-.domain-picker__price-text {
+.domain-picker__price-long {
 	display: none;
-
 	@include break-small {
 		display: inline;
+	}
+}
+
+.domain-picker__price-short {
+	display: inline;
+	@include break-small {
+		display: none;
 	}
 }
 

--- a/packages/domain-picker/src/domain-picker/style.scss
+++ b/packages/domain-picker/src/domain-picker/style.scss
@@ -176,11 +176,17 @@
 	}
 }
 
-.domain-picker__price-text {
+.domain-picker__price-long {
 	display: none;
-
 	@include break-small {
 		display: inline;
+	}
+}
+
+.domain-picker__price-short {
+	display: inline;
+	@include break-small {
+		display: none;
 	}
 }
 

--- a/packages/domain-picker/src/domain-picker/style.scss
+++ b/packages/domain-picker/src/domain-picker/style.scss
@@ -113,6 +113,7 @@
 	flex-grow: 1;
 	margin-right: 24px;
 	letter-spacing: 0.4px;
+	// min-height: $domain-picker__suggestion-item-height;
 
 	.domain-picker__domain-name {
 		word-break: break-word; // use hyphens if any to break domain name
@@ -176,17 +177,11 @@
 	}
 }
 
-.domain-picker__price-long {
+.domain-picker__price-text {
 	display: none;
+
 	@include break-small {
 		display: inline;
-	}
-}
-
-.domain-picker__price-short {
-	display: inline;
-	@include break-small {
-		display: none;
 	}
 }
 

--- a/packages/domain-picker/src/domain-picker/style.scss
+++ b/packages/domain-picker/src/domain-picker/style.scss
@@ -1,8 +1,6 @@
 @import '../styles/placeholder.scss'; // Contains the placeholder mixin
 @import '../styles/mixins';
 
-$domain-picker__suggestion-item-height: 24px;
-
 .domain-picker__empty-state {
 	display: flex;
 	justify-content: center;
@@ -48,36 +46,46 @@ $domain-picker__suggestion-item-height: 24px;
 	}
 }
 
-.domain-picker__free-text {
-	color: var( --studio-green-40 );
-}
-
 .domain-picker__suggestion-item-group {
 	flex-grow: 1;
 }
 
-.domain-picker__suggestion-none {
+.domain-picker__suggestion-item {
 	@include domain-picker-package-medium-text;
-	line-height: 20px; // matching design
 	display: flex;
 	justify-content: space-between;
-	align-items: flex-start;
+	align-items: center;
 	width: 100%;
-	border-radius: 0;
-	padding: 10px 0;
-	margin-bottom: 7px;
-	cursor: pointer;
-}
-
-.domain-picker__suggestion-item {
-	// Increasing specificity because @wordpress/components stylesheets are loaded after gutenboarding stylesheets.
-	// See https://github.com/Automattic/wp-calypso/pull/38554/commits/e1f9673bcfd9eaa6469a0cfecda9b915a520961a
-	// See https://github.com/WordPress/gutenberg/pull/19535
-	@extend .domain-picker__suggestion-none;
-
+	min-height: 36px + ( 10px * 2 ) + ( 1px * 2 ); // button height + padding height + border height
 	border: 1px solid var( --studio-gray-5 );
-	padding: 14px;
-	margin-bottom: 0;
+	padding: 10px 14px;
+	position: relative;
+	z-index: 1;
+	text-align: left;
+	cursor: pointer;
+
+	&.placeholder {
+		cursor: default;
+	}
+
+	&:hover,
+	&:focus {
+		&:not( .placeholder ) {
+			background: var( --studio-blue-0 );
+			border-color: var( --studio-blue-40 );
+			z-index: 2;
+		}
+
+		// Fade between price and select button only happens on desktop view.
+		@include break-small {
+			.domain-picker__suggestion-item-select-button {
+				opacity: 1;
+			}
+			.domain-picker__price {
+				opacity: 0;
+			}
+		}
+	}
 
 	+ .domain-picker__suggestion-item {
 		margin-top: -1px;
@@ -99,61 +107,13 @@ $domain-picker__suggestion-item-height: 24px;
 			opacity: 1;
 		}
 	}
-
-	&.components-button {
-		&.is-tertiary {
-			color: var( --color-text );
-
-			&:not( :disabled ):not( [aria-disabled='true'] ):hover {
-				background: var( --color-surface-backdrop );
-				color: var( --color-text );
-			}
-		}
-	}
-
-	input[type='radio'].domain-picker__suggestion-radio-button {
-		width: 16px;
-		height: 16px;
-		margin: 3px 12px 0 0; // 3px cosmetic alignment
-		min-width: 16px; // prevents long domain from squishing the radio button
-		padding: 0;
-		vertical-align: middle;
-		position: relative;
-
-		&:checked {
-			border-color: var( --studio-blue-30 );
-			background-color: var( --studio-blue-30 );
-
-			&::before {
-				content: '';
-				width: 12px;
-				height: 12px;
-				border: 2px solid white;
-				border-radius: 50%;
-				position: absolute;
-				margin: 0;
-				background: transparent;
-			}
-
-			&:focus {
-				border-color: var( --studio-blue-30 );
-				box-shadow: 0 0 0 1px var( --studio-blue-30 );
-			}
-		}
-
-		&:not( :disabled ):focus,
-		&:not( :disabled ):hover {
-			border-color: var( --studio-blue-30 );
-			box-shadow: 0 0 0 1px var( --studio-blue-30 );
-		}
-	}
 }
 
 .domain-picker__suggestion-item-name {
 	flex-grow: 1;
 	margin-right: 24px;
 	letter-spacing: 0.4px;
-	min-height: $domain-picker__suggestion-item-height;
+	// min-height: $domain-picker__suggestion-item-height;
 
 	.domain-picker__domain-name {
 		word-break: break-word; // use hyphens if any to break domain name
@@ -196,11 +156,19 @@ $domain-picker__suggestion-item-height: 24px;
 .domain-picker__price {
 	color: var( --studio-gray-40 );
 	text-align: right;
-	min-height: $domain-picker__suggestion-item-height;
 	flex-basis: 0;
+	transition: opacity 200ms ease-in-out;
+	// Don't show free text on mobile view
+	&:not( .is-paid ) {
+		display: none;
+	}
 
 	@include break-small {
 		flex-basis: auto;
+
+		&:not( .is-paid ) {
+			display: inline;
+		}
 	}
 
 	&.placeholder {
@@ -209,8 +177,59 @@ $domain-picker__suggestion-item-height: 24px;
 	}
 }
 
-.domain-picker__price-is-paid {
+.domain-picker__price-text {
+	display: none;
+
+	@include break-small {
+		display: inline;
+	}
+}
+
+.domain-picker__price-cost {
 	text-decoration: line-through;
+}
+
+.domain-picker__suggestion-item-select-button {
+	display: flex;
+	align-items: center;
+	height: 36px;
+
+	span {
+		display: none;
+	}
+
+	svg {
+		fill: var( --studio-blue-50 );
+		margin-left: 10px;
+		margin-right: -2px;
+	}
+
+	@include break-small {
+		// We're mocking the look of a button,
+		// this is not an actual button.
+		background: #007cba;
+		color: var( --studio-white );
+		border-radius: 2px;
+		padding: 0 12px;
+		opacity: 0;
+		transition: opacity 200ms ease-in-out;
+
+		// Overlaps price for transition purpose
+		position: absolute;
+		right: 14px;
+
+		&:hover {
+			background: #0070a7;
+		}
+
+		span {
+			display: inline-block;
+		}
+
+		svg {
+			display: none;
+		}
+	}
 }
 
 .domain-picker__body {

--- a/packages/domain-picker/src/domain-picker/style.scss
+++ b/packages/domain-picker/src/domain-picker/style.scss
@@ -113,7 +113,6 @@
 	flex-grow: 1;
 	margin-right: 24px;
 	letter-spacing: 0.4px;
-	// min-height: $domain-picker__suggestion-item-height;
 
 	.domain-picker__domain-name {
 		word-break: break-word; // use hyphens if any to break domain name

--- a/packages/domain-picker/src/domain-picker/style.scss
+++ b/packages/domain-picker/src/domain-picker/style.scss
@@ -143,14 +143,9 @@
 	align-items: center;
 	font-size: 10px;
 	text-transform: uppercase;
-
+	vertical-align: middle;
 	background-color: var( --studio-blue-50 );
 	color: var( --color-text-inverted );
-
-	&.is-selected {
-		color: var( --color-text-inverted );
-		background-color: var( --color-success );
-	}
 }
 
 .domain-picker__price {

--- a/packages/domain-picker/src/domain-picker/style.scss
+++ b/packages/domain-picker/src/domain-picker/style.scss
@@ -59,6 +59,7 @@
 	min-height: 36px + ( 10px * 2 ) + ( 1px * 2 ); // button height + padding height + border height
 	border: 1px solid var( --studio-gray-5 );
 	padding: 10px 14px;
+	margin: 0;
 	position: relative;
 	z-index: 1;
 	text-align: left;

--- a/packages/domain-picker/src/domain-picker/suggestion-item-placeholder.tsx
+++ b/packages/domain-picker/src/domain-picker/suggestion-item-placeholder.tsx
@@ -5,8 +5,7 @@ import React, { FunctionComponent } from 'react';
 
 const DomainPickerSuggestionItemPlaceholder: FunctionComponent = () => {
 	return (
-		<div className="domain-picker__suggestion-item">
-			<input disabled className="domain-picker__suggestion-radio-button" type="radio" />
+		<div className="domain-picker__suggestion-item placeholder">
 			<div className="domain-picker__suggestion-item-name placeholder" />
 			<div className="domain-picker__price placeholder"></div>
 		</div>

--- a/packages/domain-picker/src/domain-picker/suggestion-item.tsx
+++ b/packages/domain-picker/src/domain-picker/suggestion-item.tsx
@@ -79,23 +79,32 @@ const DomainPickerSuggestionItem: FunctionComponent< Props > = ( {
 					'is-paid': ! suggestion.is_free,
 				} ) }
 			>
-				{ suggestion.is_free
-					? __( 'Free' )
-					: createInterpolateElement(
-							/* translators: An example would be "Included in paid plan, $15/year", where in mobile view it will only be "$15/year". */
-							__( '<price_text>Included in paid plan,</price_text> <price_cost></price_cost>' ),
+				{ suggestion.is_free ? (
+					__( 'Free' )
+				) : (
+					<>
+						<span className="domain-picker__price-long">
 							{
-								price_text: <span className="domain-picker__price-text"></span>,
-								price_cost: (
-									<span className="domain-picker__price-cost">
-										{
-											/* translators: %s is the price with currency. Eg: $15/year. */
-											sprintf( __( '%s/year' ), suggestion.cost )
-										}{ ' ' }
-									</span>
-								),
+								/* translators: %s is the price with currency. Eg: $15/year. */
+								createInterpolateElement(
+									sprintf(
+										__( 'Included in paid plan, <strikethrough>%s/year</strikethrough>' ),
+										suggestion.cost
+									),
+									{
+										strikethrough: <span className="domain-picker__price-cost"></span>,
+									}
+								)
 							}
-					  ) }
+						</span>
+						<span className="domain-picker__price-short domain-picker__price-cost">
+							{
+								/* translators: %s is the price with currency. Eg: $15/year. */
+								sprintf( __( '%s/year' ), suggestion.cost )
+							}
+						</span>
+					</>
+				) }
 			</div>
 			<div className="domain-picker__suggestion-item-select-button">
 				<span>{ __( 'Select' ) }</span>

--- a/packages/domain-picker/src/domain-picker/suggestion-item.tsx
+++ b/packages/domain-picker/src/domain-picker/suggestion-item.tsx
@@ -83,11 +83,10 @@ const DomainPickerSuggestionItem: FunctionComponent< Props > = ( {
 				) : (
 					<>
 						<span className="domain-picker__price-long">
-							Included in paid plan,{ ' ' }
 							<span className="domain-picker__price-cost">
 								{
 									/* translators: %s is the price with currency. Eg: $15/year. */
-									sprintf( __( '%s/year' ), suggestion.cost )
+									sprintf( __( 'Included in paid plan, %s/year' ), suggestion.cost )
 								}
 							</span>
 						</span>

--- a/packages/domain-picker/src/domain-picker/suggestion-item.tsx
+++ b/packages/domain-picker/src/domain-picker/suggestion-item.tsx
@@ -7,13 +7,14 @@ import classnames from 'classnames';
 import { sprintf } from '@wordpress/i18n';
 import { v4 as uuid } from 'uuid';
 import { recordTrainTracksInteract } from '@automattic/calypso-analytics';
+import { Icon, arrowRight } from '@wordpress/icons';
+import { createInterpolateElement } from '@wordpress/element';
 
 type DomainSuggestion = import('@automattic/data-stores').DomainSuggestions.DomainSuggestion;
 
 interface Props {
 	suggestion: DomainSuggestion;
 	railcarId: string | undefined;
-	isSelected?: boolean;
 	isRecommended?: boolean;
 	onRender: () => void;
 	onSelect: ( domainSuggestion: DomainSuggestion ) => void;
@@ -22,7 +23,6 @@ interface Props {
 const DomainPickerSuggestionItem: FunctionComponent< Props > = ( {
 	suggestion,
 	railcarId,
-	isSelected = false,
 	isRecommended = false,
 	onSelect,
 	onRender,
@@ -61,16 +61,13 @@ const DomainPickerSuggestionItem: FunctionComponent< Props > = ( {
 	};
 
 	return (
-		<label className="domain-picker__suggestion-item">
-			<input
-				aria-labelledby={ labelId }
-				className="domain-picker__suggestion-radio-button"
-				type="radio"
-				name="domain-picker-suggestion-option"
-				onChange={ onDomainSelect }
-				checked={ isSelected }
-			/>
-			<div className="domain-picker__suggestion-item-name" id={ labelId }>
+		<button
+			type="button"
+			className="domain-picker__suggestion-item"
+			onClick={ onDomainSelect }
+			id={ labelId }
+		>
+			<div className="domain-picker__suggestion-item-name">
 				<span className="domain-picker__domain-name">{ domainName }</span>
 				<span className="domain-picker__domain-tld">{ domainTld }</span>
 				{ isRecommended && (
@@ -82,21 +79,29 @@ const DomainPickerSuggestionItem: FunctionComponent< Props > = ( {
 					'is-paid': ! suggestion.is_free,
 				} ) }
 			>
-				{ suggestion.is_free ? (
-					__( 'Free' )
-				) : (
-					<>
-						<span className="domain-picker__free-text"> { __( 'Included in plans' ) } </span>
-						<span className="domain-picker__price-is-paid">
+				{ suggestion.is_free
+					? __( 'Free' )
+					: createInterpolateElement(
+							/* translators: An example would be "Included in paid plan, $15/year", where in mobile view it will only be "$15/year". */
+							__( '<price_text>Included in paid plan,</price_text> <price_cost></price_cost>' ),
 							{
-								/* translators: %s is the price with currency. Eg: $15/year. */
-								sprintf( __( '%s/year' ), suggestion.cost )
-							}{ ' ' }
-						</span>
-					</>
-				) }
+								price_text: <span className="domain-picker__price-text"></span>,
+								price_cost: (
+									<span className="domain-picker__price-cost">
+										{
+											/* translators: %s is the price with currency. Eg: $15/year. */
+											sprintf( __( '%s/year' ), suggestion.cost )
+										}{ ' ' }
+									</span>
+								),
+							}
+					  ) }
 			</div>
-		</label>
+			<div className="domain-picker__suggestion-item-select-button">
+				<span>{ __( 'Select' ) }</span>
+				<Icon icon={ arrowRight } size={ 18 } />
+			</div>
+		</button>
 	);
 };
 

--- a/packages/domain-picker/src/domain-picker/suggestion-item.tsx
+++ b/packages/domain-picker/src/domain-picker/suggestion-item.tsx
@@ -83,10 +83,11 @@ const DomainPickerSuggestionItem: FunctionComponent< Props > = ( {
 				) : (
 					<>
 						<span className="domain-picker__price-long">
+							Included in paid plan,{ ' ' }
 							<span className="domain-picker__price-cost">
 								{
 									/* translators: %s is the price with currency. Eg: $15/year. */
-									sprintf( __( 'Included in paid plan, %s/year' ), suggestion.cost )
+									sprintf( __( '%s/year' ), suggestion.cost )
 								}
 							</span>
 						</span>

--- a/packages/domain-picker/src/domain-picker/suggestion-item.tsx
+++ b/packages/domain-picker/src/domain-picker/suggestion-item.tsx
@@ -8,6 +8,7 @@ import { sprintf } from '@wordpress/i18n';
 import { v4 as uuid } from 'uuid';
 import { recordTrainTracksInteract } from '@automattic/calypso-analytics';
 import { Icon, arrowRight } from '@wordpress/icons';
+import { createInterpolateElement } from '@wordpress/element';
 
 type DomainSuggestion = import('@automattic/data-stores').DomainSuggestions.DomainSuggestion;
 
@@ -78,29 +79,23 @@ const DomainPickerSuggestionItem: FunctionComponent< Props > = ( {
 					'is-paid': ! suggestion.is_free,
 				} ) }
 			>
-				{ suggestion.is_free ? (
-					__( 'Free' )
-				) : (
-					<>
-						<span className="domain-picker__price-long">
-							Included in paid plan,{ ' ' }
-							<span className="domain-picker__price-cost">
-								{
-									/* translators: %s is the price with currency. Eg: $15/year. */
-									sprintf( __( '%s/year' ), suggestion.cost )
-								}
-							</span>
-						</span>
-						<span className="domain-picker__price-short">
-							<span className="domain-picker__price-cost">
-								{
-									/* translators: %s is the price with currency. Eg: $15/year. */
-									sprintf( __( '%s/year' ), suggestion.cost )
-								}
-							</span>
-						</span>
-					</>
-				) }
+				{ suggestion.is_free
+					? __( 'Free' )
+					: createInterpolateElement(
+							/* translators: An example would be "Included in paid plan, $15/year", where in mobile view it will only be "$15/year". */
+							__( '<price_text>Included in paid plan,</price_text> <price_cost></price_cost>' ),
+							{
+								price_text: <span className="domain-picker__price-text"></span>,
+								price_cost: (
+									<span className="domain-picker__price-cost">
+										{
+											/* translators: %s is the price with currency. Eg: $15/year. */
+											sprintf( __( '%s/year' ), suggestion.cost )
+										}{ ' ' }
+									</span>
+								),
+							}
+					  ) }
 			</div>
 			<div className="domain-picker__suggestion-item-select-button">
 				<span>{ __( 'Select' ) }</span>

--- a/packages/domain-picker/src/domain-picker/suggestion-item.tsx
+++ b/packages/domain-picker/src/domain-picker/suggestion-item.tsx
@@ -8,7 +8,6 @@ import { sprintf } from '@wordpress/i18n';
 import { v4 as uuid } from 'uuid';
 import { recordTrainTracksInteract } from '@automattic/calypso-analytics';
 import { Icon, arrowRight } from '@wordpress/icons';
-import { createInterpolateElement } from '@wordpress/element';
 
 type DomainSuggestion = import('@automattic/data-stores').DomainSuggestions.DomainSuggestion;
 
@@ -79,23 +78,29 @@ const DomainPickerSuggestionItem: FunctionComponent< Props > = ( {
 					'is-paid': ! suggestion.is_free,
 				} ) }
 			>
-				{ suggestion.is_free
-					? __( 'Free' )
-					: createInterpolateElement(
-							/* translators: An example would be "Included in paid plan, $15/year", where in mobile view it will only be "$15/year". */
-							__( '<price_text>Included in paid plan,</price_text> <price_cost></price_cost>' ),
-							{
-								price_text: <span className="domain-picker__price-text"></span>,
-								price_cost: (
-									<span className="domain-picker__price-cost">
-										{
-											/* translators: %s is the price with currency. Eg: $15/year. */
-											sprintf( __( '%s/year' ), suggestion.cost )
-										}{ ' ' }
-									</span>
-								),
-							}
-					  ) }
+				{ suggestion.is_free ? (
+					__( 'Free' )
+				) : (
+					<>
+						<span className="domain-picker__price-long">
+							Included in paid plan,{ ' ' }
+							<span className="domain-picker__price-cost">
+								{
+									/* translators: %s is the price with currency. Eg: $15/year. */
+									sprintf( __( '%s/year' ), suggestion.cost )
+								}
+							</span>
+						</span>
+						<span className="domain-picker__price-short">
+							<span className="domain-picker__price-cost">
+								{
+									/* translators: %s is the price with currency. Eg: $15/year. */
+									sprintf( __( '%s/year' ), suggestion.cost )
+								}
+							</span>
+						</span>
+					</>
+				) }
 			</div>
 			<div className="domain-picker__suggestion-item-select-button">
 				<span>{ __( 'Select' ) }</span>

--- a/packages/domain-picker/src/domain-picker/suggestion-item.tsx
+++ b/packages/domain-picker/src/domain-picker/suggestion-item.tsx
@@ -84,18 +84,16 @@ const DomainPickerSuggestionItem: FunctionComponent< Props > = ( {
 				) : (
 					<>
 						<span className="domain-picker__price-long">
-							{
-								/* translators: %s is the price with currency. Eg: $15/year. */
-								createInterpolateElement(
-									sprintf(
-										__( 'Included in paid plan, <strikethrough>%s/year</strikethrough>' ),
-										suggestion.cost
-									),
-									{
-										strikethrough: <span className="domain-picker__price-cost"></span>,
-									}
-								)
-							}
+							{ createInterpolateElement(
+								sprintf(
+									/* translators: %s is the price with currency. Eg: $15/year. */
+									__( 'Included in paid plan, <strikethrough>%s/year</strikethrough>' ),
+									suggestion.cost
+								),
+								{
+									strikethrough: <span className="domain-picker__price-cost"></span>,
+								}
+							) }
 						</span>
 						<span className="domain-picker__price-short domain-picker__price-cost">
 							{


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Show select button when hovering on suggestion item.
* Show select button when focusing on (by tabbing) suggestion item.
* When select button is shown, hide price description.
* Price description is now has a comma "Included in paid plans, $15/year".
* On mobile view, "Free" text is hidden.
* On mobile view, price description "Included in paid plans, " is hidden.
* On mobile view, an arrow "→" is shown instead of the select button.
* Remove "Confirm" & "Skip for now" button on domain page.

#### Testing instructions

* Go to `/new/domains`.
* Test all of the above on mobile & desktop view.
* Also test long domain names.

#### Screenshot

![image](https://user-images.githubusercontent.com/1287077/84802027-4279f980-b000-11ea-8f1a-3c1613208556.png)

![2020-06-16_18-15-54 (1)](https://user-images.githubusercontent.com/1287077/84802034-44dc5380-b000-11ea-8961-b78c2f3d227c.gif)

#### Addtional Notes
Domain suggestion items is now a list of `<button>` (used to be a list of `<label>`). The select button inside the `<button>` is mock button, it only looks like a button visually. The reason why it is done this way is primarily to enable keyboard navigation (tab + enter) without doing all the hacky workarounds.

Fixes https://github.com/Automattic/wp-calypso/issues/43290
