### PR TITLE
Domains: Use new component for domain notices

### DIFF
--- a/client/my-sites/domains/domain-management/components/domain-notice/index.jsx
+++ b/client/my-sites/domains/domain-management/components/domain-notice/index.jsx
@@ -1,0 +1,36 @@
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import React from 'react';
+import Gridicon from 'components/gridicon';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+export default class DomainNotice extends React.Component {
+	static propTypes = {
+		text: PropTypes.string,
+		status: PropTypes.oneOf( [ 'info', 'warning', 'alert' ] ),
+	};
+
+	static defaultProps = {
+		status: 'info',
+	};
+
+	render() {
+		const { status, text } = this.props;
+
+		const className = `domain-notice domain-notice__${ status }`;
+		const icon = status === 'info' ? 'time' : 'notice-outline';
+
+		return (
+			<span className={ className }>
+				<Gridicon icon={ icon } size={ 18 } />
+				{ text }
+			</span>
+		);
+	}
+}

--- a/client/my-sites/domains/domain-management/components/domain-notice/style.scss
+++ b/client/my-sites/domains/domain-management/components/domain-notice/style.scss
@@ -14,7 +14,7 @@
 }
 
 .domain-notice__warning {
-	color: var( --color-warning-30 );
+	color: var( --color-warning-40 );
 }
 
 .domain-notice__alert {

--- a/client/my-sites/domains/domain-management/components/domain-notice/style.scss
+++ b/client/my-sites/domains/domain-management/components/domain-notice/style.scss
@@ -1,7 +1,6 @@
 .domain-notice {
 	text-transform: none;
 	font-size: 12px;
-	vertical-align: middle;
 
 	.gridicon {
 		transform: translateY( 3.5px );

--- a/client/my-sites/domains/domain-management/components/domain-notice/style.scss
+++ b/client/my-sites/domains/domain-management/components/domain-notice/style.scss
@@ -1,0 +1,22 @@
+.domain-notice {
+	text-transform: none;
+	font-size: 12px;
+	vertical-align: middle;
+
+	.gridicon {
+		transform: translateY( 3.5px );
+		margin-right: 4px;
+	}
+}
+
+.domain-notice__info {
+	color: var( --color-success-50 );
+}
+
+.domain-notice__warning {
+	color: var( --color-warning-30 );
+}
+
+.domain-notice__alert {
+	color: var( --color-error );
+}

--- a/client/my-sites/domains/domain-management/list/item.jsx
+++ b/client/my-sites/domains/domain-management/list/item.jsx
@@ -15,11 +15,11 @@ import { noop } from 'lodash';
 import { Button, CompactCard } from '@automattic/components';
 import DomainPrimaryFlag from 'my-sites/domains/domain-management/components/domain/primary-flag';
 import DomainTransferFlag from 'my-sites/domains/domain-management/components/domain/transfer-flag';
-import Notice from 'components/notice';
 import { type as domainTypes, gdprConsentStatus } from 'lib/domains/constants';
 import Spinner from 'components/spinner';
 import { withLocalizedMoment } from 'components/localized-moment';
 import TrackComponentView from 'lib/analytics/track-component-view';
+import DomainNotice from 'my-sites/domains/domain-management/components/domain-notice';
 
 class ListItem extends React.PureComponent {
 	static propTypes = {
@@ -159,29 +159,30 @@ class ListItem extends React.PureComponent {
 
 		if ( domain.expired ) {
 			return (
-				<Notice isCompact status="is-error" icon="spam">
-					{ translate( 'Expired %(timeSinceExpiry)s', {
+				<DomainNotice
+					status="alert"
+					text={ translate( 'Expired %(timeSinceExpiry)s', {
 						args: {
 							timeSinceExpiry: moment( domain.expiry ).fromNow(),
 						},
 						context:
-							'timeSinceExpiry is of the form "[number] [time-period] ago" i.e. "3 days ago"',
+							'timeSinceExpiry is of the form "[number] [time-period] ago" e.g. "3 days ago"',
 					} ) }
-				</Notice>
+				/>
 			);
 		}
 
 		if ( domain.expiry && moment( domain.expiry ) < this.props.moment().add( 30, 'days' ) ) {
 			return (
-				<Notice isCompact status="is-error" icon="spam">
-					{ translate( 'Expires %(timeUntilExpiry)s', {
+				<DomainNotice
+					status="warning"
+					text={ translate( 'Expires %(timeUntilExpiry)s', {
 						args: {
 							timeUntilExpiry: moment( domain.expiry ).fromNow(),
 						},
-						context:
-							'timeUntilExpiry is of the form "[number] [time-period] ago" i.e. "3 days ago"',
+						context: 'timeUntilExpiry is of the form "in [number] [time-period]" e.g. "in 3 days"',
 					} ) }
-				</Notice>
+				/>
 			);
 		}
 	}
@@ -192,11 +193,7 @@ class ListItem extends React.PureComponent {
 			domain.gdprConsentStatus &&
 			gdprConsentStatus.PENDING_ASYNC === domain.gdprConsentStatus
 		) {
-			return (
-				<Notice isCompact status="is-error" icon="spam">
-					{ translate( 'Action Required' ) }
-				</Notice>
-			);
+			return <DomainNotice status="alert" text={ translate( 'Action Required' ) } />;
 		}
 	}
 

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -64,7 +64,7 @@
 		text-transform: uppercase;
 	}
 
-	.notice {
+	.domain-notice {
 		margin: 0 0 0 8px;
 	}
 }

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -69,10 +69,6 @@
 	}
 }
 
-.domain-management-list-item__type {
-	vertical-align: middle;
-}
-
 .domain-management-list-item.is-placeholder {
 	.domain-management-list-item__link {
 		cursor: default;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a new component to use for domain notices, instead of the old `Notice` component.

<img width="419" alt="Screenshot 2020-06-16 at 7 17 12 PM" src="https://user-images.githubusercontent.com/13062352/84806532-28431a00-b006-11ea-8e52-042f7d9b22ff.png">

#### Testing instructions

For a domain of yours that has expired or is near expiration, a notice similar to the attached screenshot above should be shown.
