### PR TITLE
Domains: Update multi level TLD list

### DIFF
--- a/client/lib/domains/tlds/wpcom-multi-level-tlds.json
+++ b/client/lib/domains/tlds/wpcom-multi-level-tlds.json
@@ -1,10 +1,14 @@
 {
 	"co.in": 1,
+	"co.uk": 1,
 	"com.br": 0,
+	"com.mx": 1,
 	"firm.in": 1,
 	"gen.in": 1,
 	"ind.in": 1,
+	"me.uk": 1,
 	"net.br": 0,
 	"net.in": 1,
-	"org.in": 1
+	"org.in": 1,
+	"org.uk": 1
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Originally introduced in https://github.com/Automattic/wp-calypso/pull/18648. Looks like we did not update this list as we onboarded other second level TLDs. As a result, users buying domains via `/domains` got the wrong product assigned.

#### Testing instructions

* Go to `/domains`. Search for a `.co.uk` domain. Verify that the `is-available` endpoint returns the correct product ID (327, product slug: `dotcodotuk_domain`).
* Now, select the domain and choose "Just buy a domain".
* A request to `https://public-api.wordpress.com/rest/v1.1/me/shopping-cart/no-site` should fire. Before the patch, the product ID would be wrong (ID 326), with the patch it should be correct.

Check other TLDs added to the list as well - plus double-check me if I missed any.