### PR TITLE
Revert "Gutenboarding: Add feature flag to redirect to Site Editor upon Site Creation"

### DIFF
--- a/client/landing/gutenboarding/hooks/use-on-site-creation.ts
+++ b/client/landing/gutenboarding/hooks/use-on-site-creation.ts
@@ -14,7 +14,6 @@ import { USER_STORE } from '../stores/user';
 import { SITE_STORE } from '../stores/site';
 import { recordOnboardingComplete } from '../lib/analytics';
 import { useSelectedPlan, useIsSelectedPlanEcommerce } from './use-selected-plan';
-import { isEnabled } from '../../../config';
 
 const wpcom = wp.undocumented();
 
@@ -125,9 +124,7 @@ export default function useOnSiteCreation() {
 			resetOnboardStore();
 			setSelectedSite( newSite.blogid );
 
-			window.location.href = isEnabled( 'gutenboarding/site-editor' )
-				? `/site-editor/${ newSite.site_slug }/`
-				: `/block-editor/page/${ newSite.site_slug }/home`;
+			window.location.href = `/block-editor/page/${ newSite.site_slug }/home`;
 		}
 	}, [
 		domain,

--- a/client/landing/gutenboarding/stores/onboard/actions.ts
+++ b/client/landing/gutenboarding/stores/onboard/actions.ts
@@ -13,7 +13,6 @@ import { STORE_KEY as ONBOARD_STORE } from './constants';
 import { SITE_STORE } from '../site';
 import type { State } from '.';
 import type { FontPair } from '../../constants';
-import { isEnabled } from '../../../../config';
 
 type CreateSiteParams = Site.CreateSiteParams;
 type DomainSuggestion = DomainSuggestions.DomainSuggestion;
@@ -122,9 +121,7 @@ export function* createSite(
 			site_information: {
 				title: siteTitle,
 			},
-			site_creation_flow: isEnabled( 'gutenboarding/site-editor' )
-				? 'gutenboarding-site-editor'
-				: 'gutenboarding',
+			site_creation_flow: 'gutenboarding',
 			theme: `pub/${ selectedDesign?.theme || 'twentytwenty' }`,
 			timezone_string: guessTimezone(),
 			...( selectedDesign?.template && { template: selectedDesign.template } ),

--- a/client/state/sites/launch/actions.js
+++ b/client/state/sites/launch/actions.js
@@ -35,9 +35,8 @@ export const launchSiteOrRedirectToLaunchSignupFlow = ( siteId ) => ( dispatch, 
 
 	// TODO: consider using the `page` library instead of calling using `location.href` here
 
-	const isGutenboarding = [ 'gutenboarding', 'gutenboarding-site-editor' ].includes(
-		getSiteOption( getState(), siteId, 'site_creation_flow' )
-	);
+	const isGutenboarding =
+		getSiteOption( getState(), siteId, 'site_creation_flow' ) === 'gutenboarding';
 	if ( isGutenboarding ) {
 		window.location.href = `/start/new-launch?siteSlug=${ siteSlug }&source=home`;
 	} else {


### PR DESCRIPTION
Reverts Automattic/wp-calypso#43246

I was [getting](https://app.circleci.com/pipelines/github/Automattic/wp-e2e-tests-canary/675/workflows/f15044af-fedc-4c64-a247-095598106c38/jobs/18583) `Looks like creating account is taking to long( 150000ms ). Please try again in a while. ` after merging #43246. I re-ran tests and still saw the same error. Reverting for now.