### PR TITLE
Earn: add feature flag for safe rename of Simple Payments and Recurring Payments blocks

### DIFF
--- a/config/desktop.json
+++ b/config/desktop.json
@@ -29,6 +29,7 @@
 		"domains/gdpr-consent-page": true,
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/pagination": true,
+		"earn/rename-payment-blocks": false,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,

--- a/config/development.json
+++ b/config/development.json
@@ -58,6 +58,7 @@
 		"domains/new-status-design/auto-renew": true,
 		"domains/new-status-design/new-options": true,
 		"domains/new-status-design/security-option": true,
+		"earn/rename-payment-blocks": true,
 		"editor/after-deprecation": true,
 		"editor/before-deprecation": true,
 		"email-accounts/enabled": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -36,6 +36,7 @@
 		"domains/new-status-design/auto-renew": true,
 		"domains/new-status-design/new-options": true,
 		"domains/new-status-design/security-option": true,
+		"earn/rename-payment-blocks": false,
 		"editor/before-deprecation": true,
 		"external-media": true,
 		"external-media/google-photos": true,

--- a/config/production.json
+++ b/config/production.json
@@ -35,6 +35,7 @@
 		"domains/new-status-design/auto-renew": true,
 		"domains/new-status-design/new-options": true,
 		"domains/new-status-design/security-option": true,
+		"earn/rename-payment-blocks": false,
 		"editor/before-deprecation": true,
 		"external-media": true,
 		"external-media/google-photos": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -38,6 +38,7 @@
 		"domains/new-status-design/auto-renew": true,
 		"domains/new-status-design/new-options": true,
 		"domains/new-status-design/security-option": true,
+		"earn/rename-payment-blocks": false,
 		"editor/before-deprecation": true,
 		"external-media": true,
 		"external-media/google-photos": true,

--- a/config/test.json
+++ b/config/test.json
@@ -36,6 +36,7 @@
 		"desktop-promo": true,
 		"devdocs": true,
 		"devdocs/redirect-loggedout-homepage": true,
+		"earn/rename-payment-blocks": false,
 		"editor/before-deprecation": true,
 		"gdpr-banner": false,
 		"google-my-business": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -43,6 +43,7 @@
 		"domains/new-status-design/auto-renew": true,
 		"domains/new-status-design/new-options": true,
 		"domains/new-status-design/security-option": true,
+		"earn/rename-payment-blocks": false,
 		"editor/before-deprecation": true,
 		"email-accounts/enabled": true,
 		"external-media": true,


### PR DESCRIPTION
Part of https://github.com/Automattic/wp-calypso/issues/43249 this adds a feature flag to calypso so we can safely land rename PRs in Calypso

Once this lands, let's update https://github.com/Automattic/wp-calypso/pull/42848 and https://github.com/Automattic/wp-calypso/pull/43192 to use this feature flag.

### Testing instructions

No changes on development or production

