### PR TITLE
Reader Lists: include the list slug in the export filename

### DIFF
--- a/client/blocks/reader-export-button/index.jsx
+++ b/client/blocks/reader-export-button/index.jsx
@@ -26,10 +26,12 @@ import './style.scss';
 class ReaderExportButton extends React.Component {
 	static propTypes = {
 		exportType: PropTypes.oneOf( [ READER_EXPORT_TYPE_SUBSCRIPTIONS, READER_EXPORT_TYPE_LIST ] ),
+		filename: PropTypes.string,
 		listId: PropTypes.number, // only when exporting a list
 	};
 
 	static defaultProps = {
+		filename: 'reader-export.opml',
 		exportType: READER_EXPORT_TYPE_SUBSCRIPTIONS,
 	};
 
@@ -64,15 +66,8 @@ class ReaderExportButton extends React.Component {
 			return;
 		}
 
-		let filename;
-		if ( this.props.exportType === READER_EXPORT_TYPE_LIST ) {
-			filename = 'wpcom-reader-list.opml';
-		} else {
-			filename = 'wpcom-subscriptions.opml';
-		}
-
 		const blob = new Blob( [ data.opml ], { type: 'text/xml;charset=utf-8' } ); // eslint-disable-line no-undef
-		saveAs( blob, filename );
+		saveAs( blob, this.props.filename );
 	};
 
 	render() {

--- a/client/reader/list-manage/index.jsx
+++ b/client/reader/list-manage/index.jsx
@@ -130,7 +130,7 @@ function ReaderListEdit( props ) {
 									exportType={ READER_EXPORT_TYPE_LIST }
 									listId={ list.ID }
 									filename={ `reader-list-${ props.slug
-										.replace( /[^a-z0-9]/gi, '_' )
+										.replace( /[^a-z0-9]/gi, '-' )
 										.toLowerCase() }.opml` }
 								/>
 							</Card>

--- a/client/reader/list-manage/index.jsx
+++ b/client/reader/list-manage/index.jsx
@@ -126,7 +126,13 @@ function ReaderListEdit( props ) {
 										'You can export this list to use on other services. The file will be in OPML format.'
 									) }
 								</p>
-								<ReaderExportButton exportType={ READER_EXPORT_TYPE_LIST } listId={ list.ID } />
+								<ReaderExportButton
+									exportType={ READER_EXPORT_TYPE_LIST }
+									listId={ list.ID }
+									filename={ `reader-list-${ props.slug
+										.replace( /[^a-z0-9]/gi, '_' )
+										.toLowerCase() }.opml` }
+								/>
 							</Card>
 						) }
 					</>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

For users with more than one list, it can be confusing to export lists as they all have the same filename. I found this when working on p5PDj3-4Q5-p2, in which the user has 15 lists.

This PR incorporates the slug (with some additional characters stripped out) in the export filename.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Visit one of your Reader lists, click the 'Edit' cog icon and go to the Export tab. Export the file. It should contain the current list slug.
