### PR TITLE
Modify Block Pattern Preview Viewport

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/call-to-action-02.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/call-to-action-02.php
@@ -37,7 +37,8 @@ $markup = '
 ';
 
 return array(
-	'title'      => esc_html__( 'Call to Action', 'full-site-editing' ),
-	'categories' => array( 'call-to-action' ),
-	'content'    => $markup,
+	'title'         => esc_html__( 'Call to Action', 'full-site-editing' ),
+	'categories'    => array( 'call-to-action' ),
+	'content'       => $markup,
+	'viewportWidth' => 1280,
 );

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/call-to-action-03.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/call-to-action-03.php
@@ -50,10 +50,10 @@ $markup = '
 ';
 
 return array(
-	'__file'     => 'wp_block',
-	'title'      => esc_html__( 'Call to Action', 'full-site-editing' ),
-	'categories' => array( 'call-to-action' ),
-	'content'    => sprintf(
+	'__file'        => 'wp_block',
+	'title'         => esc_html__( 'Call to Action', 'full-site-editing' ),
+	'categories'    => array( 'call-to-action' ),
+	'content'       => sprintf(
 		$markup,
 		esc_html__( 'Want to volunteer?', 'full-site-editing' ),
 		esc_html__( 'We’ve had an incredible response so far, and are doing everything we can to respond to everyone who wants to volunteer in one of our community programmes.', 'full-site-editing' ),
@@ -61,4 +61,5 @@ return array(
 		esc_html__( 'Are you a business?', 'full-site-editing' ),
 		esc_html__( 'We are uniting our resources around this challenge, and we are combining our resources and asks to make it easy for people to support their communities.', 'full-site-editing' )
 	),
+	'viewportWidth' => 1280,
 );

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/collage-gallery.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/collage-gallery.php
@@ -12,7 +12,8 @@ $markup = '
 ';
 
 return array(
-	'title'      => esc_html__( 'Collage gallery', 'full-site-editing' ),
-	'categories' => array( 'gallery' ),
-	'content'    => $markup,
+	'title'         => esc_html__( 'Collage gallery', 'full-site-editing' ),
+	'categories'    => array( 'gallery' ),
+	'content'       => $markup,
+	'viewportWidth' => 1280,
 );

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/coming-soon.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/coming-soon.php
@@ -30,10 +30,10 @@ $markup = '
 ';
 
 return array(
-	'__file'     => 'wp_block',
-	'title'      => esc_html__( 'Coming Soon', 'full-site-editing' ),
-	'categories' => array( 'call-to-action' ),
-	'content'    => sprintf(
+	'__file'        => 'wp_block',
+	'title'         => esc_html__( 'Coming Soon', 'full-site-editing' ),
+	'categories'    => array( 'call-to-action' ),
+	'content'       => sprintf(
 		$markup,
 		esc_html__( 'Coming Soon', 'full-site-editing' ),
 		esc_html__( 'Come back here when our journey begins.', 'full-site-editing' ),
@@ -41,4 +41,5 @@ return array(
 		esc_html__( 'CA 12345-6789', 'full-site-editing' ),
 		esc_html__( 'hello@example.com', 'full-site-editing' )
 	),
+	'viewportWidth' => 1280,
 );

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/contact-02.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/contact-02.php
@@ -44,13 +44,14 @@ $markup = '
 ';
 
 return array(
-	'title'      => esc_html__( 'Contact', 'full-site-editing' ),
-	'categories' => array( 'contact' ),
-	'content'    => sprintf(
+	'title'         => esc_html__( 'Contact', 'full-site-editing' ),
+	'categories'    => array( 'contact' ),
+	'content'       => sprintf(
 		$markup,
 		esc_html__( 'Contact', 'full-site-editing' ),
 		esc_html__( 'Jennifer Dolan Photography', 'full-site-editing' ),
 		esc_html__( 'San Francisco, California', 'full-site-editing' ),
 		esc_html__( 'hello@example.com', 'full-site-editing' )
 	),
+	'viewportWidth' => 1280,
 );

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/contact-03.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/contact-03.php
@@ -50,13 +50,14 @@ $markup = '
 // phpcs:enable WordPress.WP.CapitalPDangit.Misspelled
 
 return array(
-	'title'      => esc_html__( 'Contact', 'full-site-editing' ),
-	'categories' => array( 'contact' ),
-	'content'    => sprintf(
+	'title'         => esc_html__( 'Contact', 'full-site-editing' ),
+	'categories'    => array( 'contact' ),
+	'content'       => sprintf(
 		$markup,
 		esc_html__( 'Jennifer Dolan Photography', 'full-site-editing' ),
 		esc_html__( 'San Francisco, California', 'full-site-editing' ),
 		esc_html__( '123-456-7890', 'full-site-editing' ),
 		esc_html__( 'hello@example.com', 'full-site-editing' )
 	),
+	'viewportWidth' => 1280,
 );

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/contact-04.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/contact-04.php
@@ -58,10 +58,10 @@ $markup = '
 // phpcs:enable WordPress.WP.CapitalPDangit.Misspelled
 
 return array(
-	'__file'     => 'wp_block',
-	'title'      => esc_html__( 'Contact', 'full-site-editing' ),
-	'categories' => array( 'contact' ),
-	'content'    => sprintf(
+	'__file'        => 'wp_block',
+	'title'         => esc_html__( 'Contact', 'full-site-editing' ),
+	'categories'    => array( 'contact' ),
+	'content'       => sprintf(
 		$markup,
 		esc_html__( 'Burger Brothers', 'full-site-editing' ),
 		esc_html__( '123 Example St, San Francisco,', 'full-site-editing' ),
@@ -77,4 +77,5 @@ return array(
 		esc_html__( 'Sunday:', 'full-site-editing' ),
 		esc_html__( 'Closed', 'full-site-editing' )
 	),
+	'viewportWidth' => 1280,
 );

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/contact.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/contact.php
@@ -50,13 +50,14 @@ $markup = '
 ';
 
 return array(
-	'title'      => esc_html__( 'Contact', 'full-site-editing' ),
-	'categories' => array( 'contact' ),
-	'content'    => sprintf(
+	'title'         => esc_html__( 'Contact', 'full-site-editing' ),
+	'categories'    => array( 'contact' ),
+	'content'       => sprintf(
 		$markup,
 		esc_html__( 'Get in touch', 'full-site-editing' ),
 		esc_html__( 'Jennifer Dolan Photography', 'full-site-editing' ),
 		esc_html__( 'San Francisco, California', 'full-site-editing' ),
 		esc_html__( 'hello@example.com', 'full-site-editing' )
 	),
+	'viewportWidth' => 1280,
 );

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/description-and-image.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/description-and-image.php
@@ -30,11 +30,12 @@ $markup = '
 ';
 
 return array(
-	'title'      => esc_html__( 'Description and Image', 'full-site-editing' ),
-	'categories' => array( 'images' ),
-	'content'    => sprintf(
+	'title'         => esc_html__( 'Description and Image', 'full-site-editing' ),
+	'categories'    => array( 'images' ),
+	'content'       => sprintf(
 		$markup,
 		esc_html__( 'The artist is the creator of beautiful things. To reveal art and conceal the artist is art&#8217;s aim. The critic is he who can translate into another manner or a new material his impression of beautiful things.', 'full-site-editing' ),
 		esc_url( 'https://dotcompatterns.files.wordpress.com/2020/03/leaf.jpg' )
 	),
+	'viewportWidth' => 1280,
 );

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/food-menu.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/food-menu.php
@@ -56,9 +56,9 @@ $markup = '
 ';
 
 return array(
-	'title'      => esc_html__( 'Food Menu', 'full-site-editing' ),
-	'categories' => array( 'text' ),
-	'content'    => sprintf(
+	'title'         => esc_html__( 'Food Menu', 'full-site-editing' ),
+	'categories'    => array( 'text' ),
+	'content'       => sprintf(
 		$markup,
 		esc_html__( 'Awesome Burger', 'full-site-editing' ),
 		esc_html__( 'The burger that made us famous. 100% pure lean beef grilled to perfection.', 'full-site-editing' ),
@@ -70,4 +70,5 @@ return array(
 		esc_html__( 'Garden Salad', 'full-site-editing' ),
 		esc_html__( 'Fresh greens with cheddar cheese diced tomatoes, and honey mustard dressing.', 'full-site-editing' )
 	),
+	'viewportWidth' => 1280,
 );

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/headline-02.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/headline-02.php
@@ -24,11 +24,12 @@ $markup = '
 ';
 
 return array(
-	'title'      => esc_html__( 'Headline', 'full-site-editing' ),
-	'categories' => array( 'text' ),
-	'content'    => sprintf(
+	'title'         => esc_html__( 'Headline', 'full-site-editing' ),
+	'categories'    => array( 'text' ),
+	'content'       => sprintf(
 		$markup,
 		esc_html__( 'Eat Dessert First is for my love of food and sharing my favorites with you.', 'full-site-editing' ),
 		esc_html__( 'Hi, I’m Lillie. Previously a magazine editor, I became a full-time mother and freelance writer in 2017. I spend most of my time with my kids and husband over at The Brown Bear Family.', 'full-site-editing' )
 	),
+	'viewportWidth' => 1280,
 );

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/headline.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/headline.php
@@ -40,13 +40,14 @@ $markup = '
 ';
 
 return array(
-	'title'      => esc_html__( 'Headline', 'full-site-editing' ),
-	'categories' => array( 'blog' ),
-	'content'    => sprintf(
+	'title'         => esc_html__( 'Headline', 'full-site-editing' ),
+	'categories'    => array( 'blog' ),
+	'content'       => sprintf(
 		$markup,
 		esc_url( 'https://dotcompatterns.files.wordpress.com/2020/03/cayla1-w6ftfbpcs9i-unsplash.jpg' ),
 		esc_html__( 'Weekly Recipe', 'full-site-editing' ),
 		esc_html__( 'Stay Warm in Autumn: Roasted Pumpkin Soup', 'full-site-editing' ),
 		esc_html__( 'More Recipes', 'full-site-editing' )
 	),
+	'viewportWidth' => 1280,
 );

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/image-and-description.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/image-and-description.php
@@ -30,11 +30,12 @@ $markup = '
 ';
 
 return array(
-	'title'      => esc_html__( 'Image and Description', 'full-site-editing' ),
-	'categories' => array( 'images' ),
-	'content'    => sprintf(
+	'title'         => esc_html__( 'Image and Description', 'full-site-editing' ),
+	'categories'    => array( 'images' ),
+	'content'       => sprintf(
 		$markup,
 		esc_url( 'https://dotcompatterns.files.wordpress.com/2020/03/lollipop.jpg' ),
 		esc_html__( 'The artist is the creator of beautiful things. To reveal art and conceal the artist is art&#8217;s aim. The critic is he who can translate into another manner or a new material his impression of beautiful things.', 'full-site-editing' )
 	),
+	'viewportWidth' => 1280,
 );

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/image-and-text.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/image-and-text.php
@@ -32,10 +32,11 @@ $markup = '
 ';
 
 return array(
-	'title'      => esc_html__( 'Image and Text', 'full-site-editing' ),
-	'categories' => array( 'images' ),
-	'content'    => sprintf(
+	'title'         => esc_html__( 'Image and Text', 'full-site-editing' ),
+	'categories'    => array( 'images' ),
+	'content'       => sprintf(
 		$markup,
 		esc_html__( 'His latest work is A Life Well-Lived, a selection of photos and stories of people across Nebraska highlighting their stories from the past 70 years. These are photographs and stories of those who might be forgotten in the rush of history.', 'full-site-editing' )
 	),
+	'viewportWidth' => 1280,
 );

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/images-with-titles.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/images-with-titles.php
@@ -60,14 +60,15 @@ $markup = '
 ';
 
 return array(
-	'__file'     => 'wp_block',
-	'title'      => esc_html__( 'Image with Titles', 'full-site-editing' ),
-	'categories' => array( 'gallery', 'list' ),
-	'content'    => sprintf(
+	'__file'        => 'wp_block',
+	'title'         => esc_html__( 'Image with Titles', 'full-site-editing' ),
+	'categories'    => array( 'gallery', 'list' ),
+	'content'       => sprintf(
 		$markup,
 		esc_html__( 'Brice - 2020', 'full-site-editing' ),
 		esc_html__( 'Vesta Magazine - 2019', 'full-site-editing' ),
 		esc_html__( 'Easley Magazine - 2019', 'full-site-editing' ),
 		esc_html__( 'Overton - 2018', 'full-site-editing' )
 	),
+	'viewportWidth' => 1280,
 );

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/list.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/list.php
@@ -26,10 +26,10 @@ $markup = '
 ';
 
 return array(
-	'__file'     => 'wp_block',
-	'title'      => esc_html__( 'List', 'full-site-editing' ),
-	'categories' => array( 'list' ),
-	'content'    => sprintf(
+	'__file'        => 'wp_block',
+	'title'         => esc_html__( 'List', 'full-site-editing' ),
+	'categories'    => array( 'list' ),
+	'content'       => sprintf(
 		$markup,
 		esc_html__( 'Beth Silva', 'full-site-editing' ),
 		esc_html__( 'Christine Russell', 'full-site-editing' ),
@@ -43,4 +43,5 @@ return array(
 		esc_html__( 'Emily Fry', 'full-site-editing' ),
 		esc_html__( 'Lucie Avila', 'full-site-editing' )
 	),
+	'viewportWidth' => 1280,
 );

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/masonry-gallery.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/masonry-gallery.php
@@ -12,7 +12,8 @@ $markup = '
 ';
 
 return array(
-	'title'      => esc_html__( 'Masonry gallery', 'full-site-editing' ),
-	'categories' => array( 'gallery' ),
-	'content'    => $markup,
+	'title'         => esc_html__( 'Masonry gallery', 'full-site-editing' ),
+	'categories'    => array( 'gallery' ),
+	'content'       => $markup,
+	'viewportWidth' => 1280,
 );

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/numbered-list.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/numbered-list.php
@@ -82,10 +82,10 @@ $markup = '
 ';
 
 return array(
-	'__file'     => 'wp_block',
-	'title'      => esc_html__( 'Numbered List', 'full-site-editing' ),
-	'categories' => array( 'list' ),
-	'content'    => sprintf(
+	'__file'        => 'wp_block',
+	'title'         => esc_html__( 'Numbered List', 'full-site-editing' ),
+	'categories'    => array( 'list' ),
+	'content'       => sprintf(
 		$markup,
 		esc_html__( '01', 'full-site-editing' ),
 		esc_html__( 'Strategy', 'full-site-editing' ),
@@ -100,4 +100,5 @@ return array(
 		esc_html__( 'Grow', 'full-site-editing' ),
 		esc_html__( 'Look at the sunset. Surround yourself with angels, positive energy, beautiful people, beautiful souls, clean heart, angel.', 'full-site-editing' )
 	),
+	'viewportWidth' => 1280,
 );

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/numbers.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/numbers.php
@@ -40,9 +40,9 @@ $markup = '
 ';
 
 return array(
-	'title'      => esc_html__( 'Numbers', 'full-site-editing' ),
-	'categories' => array( 'text' ),
-	'content'    => sprintf(
+	'title'         => esc_html__( 'Numbers', 'full-site-editing' ),
+	'categories'    => array( 'text' ),
+	'content'       => sprintf(
 		$markup,
 		esc_html__( '1,652', 'full-site-editing' ),
 		esc_html__( 'Volunteers available', 'full-site-editing' ),
@@ -51,4 +51,5 @@ return array(
 		esc_html__( '1,927', 'full-site-editing' ),
 		esc_html__( 'Matches last year', 'full-site-editing' )
 	),
+	'viewportWidth' => 1280,
 );

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/portraits-and-text.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/portraits-and-text.php
@@ -74,10 +74,10 @@ $markup = '
 ';
 
 return array(
-	'__file'     => 'wp_block',
-	'title'      => esc_html__( 'Portraits and Text', 'full-site-editing' ),
-	'categories' => array( 'gallery', 'list' ),
-	'content'    => sprintf(
+	'__file'        => 'wp_block',
+	'title'         => esc_html__( 'Portraits and Text', 'full-site-editing' ),
+	'categories'    => array( 'gallery', 'list' ),
+	'content'       => sprintf(
 		$markup,
 		esc_html__( 'Natsuho Kishi', 'full-site-editing' ),
 		esc_html__( 'Design Director at EJ Solutions focusing on raising the standard of communication online. She has been leading several award-winning branding projects. including Strn.', 'full-site-editing' ),
@@ -88,4 +88,5 @@ return array(
 		esc_html__( 'Elise Pratt', 'full-site-editing' ),
 		esc_html__( 'Senior Product Designer at Idea. Previously Senior Design Director at Minova, UX Design Manager at Ryman. Elise’s work has been featured as pioneer in CX as best practice.', 'full-site-editing' )
 	),
+	'viewportWidth' => 1280,
 );

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/recent-posts-02.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/recent-posts-02.php
@@ -20,10 +20,11 @@ $markup = '
 ';
 
 return array(
-	'title'      => esc_html__( 'Recent Posts', 'full-site-editing' ),
-	'categories' => array( 'blog' ),
-	'content'    => sprintf(
+	'title'         => esc_html__( 'Recent Posts', 'full-site-editing' ),
+	'categories'    => array( 'blog' ),
+	'content'       => sprintf(
 		$markup,
 		esc_html__( 'Latest Posts', 'full-site-editing' )
 	),
+	'viewportWidth' => 1280,
 );

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/recent-posts.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/recent-posts.php
@@ -14,7 +14,8 @@ $markup = '
 ';
 
 return array(
-	'title'      => esc_html__( 'Recent Posts', 'full-site-editing' ),
-	'categories' => array( 'blog' ),
-	'content'    => $markup,
+	'title'         => esc_html__( 'Recent Posts', 'full-site-editing' ),
+	'categories'    => array( 'blog' ),
+	'content'       => $markup,
+	'viewportWidth' => 1280,
 );

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/three-columns-and-image.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/three-columns-and-image.php
@@ -66,9 +66,9 @@ $markup = '
 ';
 
 return array(
-	'title'      => esc_html__( 'Three columns', 'full-site-editing' ),
-	'categories' => array( 'images' ),
-	'content'    => sprintf(
+	'title'         => esc_html__( 'Three columns', 'full-site-editing' ),
+	'categories'    => array( 'images' ),
+	'content'       => sprintf(
 		$markup,
 		esc_html__( 'Salainis', 'full-site-editing' ),
 		esc_html__( 'I had learned already many of the Outland methods of communicating by forest notes rather than trust to the betraying, high-pitched human voice.', 'full-site-editing' ),
@@ -76,4 +76,5 @@ return array(
 		esc_html__( 'Then whoever was on his way from that placed hurried, and whoever was coming toward it stayed where he was until he had permission to move on.', 'full-site-editing' ),
 		esc_url( 'https://dotcompatterns.files.wordpress.com/2020/03/kristaps-ungurs-trgv9atxume-unsplash-1.jpg' )
 	),
+	'viewportWidth' => 1280,
 );

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/three-images-side-by-side.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/three-images-side-by-side.php
@@ -42,7 +42,8 @@ $markup = '
 ';
 
 return array(
-	'title'      => esc_html__( 'Three images side-by-side', 'full-site-editing' ),
-	'categories' => array( 'gallery', 'images' ),
-	'content'    => $markup,
+	'title'         => esc_html__( 'Three images side-by-side', 'full-site-editing' ),
+	'categories'    => array( 'gallery', 'images' ),
+	'content'       => $markup,
+	'viewportWidth' => 1280,
 );

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/tiled-mosaic-gallery.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/tiled-mosaic-gallery.php
@@ -12,8 +12,9 @@ $markup = '
 ';
 
 return array(
-	'__file'     => 'wp_block',
-	'title'      => esc_html__( 'Tiled Mosaic Gallery', 'full-site-editing' ),
-	'categories' => array( 'gallery' ),
-	'content'    => $markup,
+	'__file'        => 'wp_block',
+	'title'         => esc_html__( 'Tiled Mosaic Gallery', 'full-site-editing' ),
+	'categories'    => array( 'gallery' ),
+	'content'       => $markup,
+	'viewportWidth' => 1280,
 );

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/two-column-text-and-image.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/two-column-text-and-image.php
@@ -42,12 +42,13 @@ $markup = '
 ';
 
 return array(
-	'__file'     => 'wp_block',
-	'title'      => esc_html__( 'Two Column Text and Image', 'full-site-editing' ),
-	'categories' => array( 'images' ),
-	'content'    => sprintf(
+	'__file'        => 'wp_block',
+	'title'         => esc_html__( 'Two Column Text and Image', 'full-site-editing' ),
+	'categories'    => array( 'images' ),
+	'content'       => sprintf(
 		$markup,
 		esc_html__( 'Some still say its organic shapes were a reflection of the constant movement of thoughts on his never-ending ideas. It was remarkable but prudent, complex but minimal, and it&rsquo;s geometrical lines contrasted beautifully with the curly waves that defined it.', 'full-site-editing' ),
 		esc_html__( 'It was his sanctuary, the place where he would go to rest, but also to celebrate. Those that were once there always highlight the Peace they felt around the building. Was it the endless organic shapes? Was it the assurance they felt from the precision of its geometrical lines? Or was it him?', 'full-site-editing' )
 	),
+	'viewportWidth' => 1280,
 );

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/two-images-and-quote.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/two-images-and-quote.php
@@ -40,12 +40,13 @@ $markup = '
 ';
 
 return array(
-	'title'      => esc_html__( 'Two images and quote', 'full-site-editing' ),
-	'categories' => array( 'images' ),
-	'content'    => sprintf(
+	'title'         => esc_html__( 'Two images and quote', 'full-site-editing' ),
+	'categories'    => array( 'images' ),
+	'content'       => sprintf(
 		$markup,
 		esc_url( 'https://dotcompatterns.files.wordpress.com/2020/03/bianca-berg-l4-sra8ii80-unsplash-2.jpg' ),
 		esc_url( 'https://dotcompatterns.files.wordpress.com/2020/03/bianca-berg-pyvtnjcwc-g-unsplash.jpg' ),
 		esc_html__( '&#8220;The artist is the creator of beautiful things. To reveal art and conceal the artist is art&#8217;s aim. The critic is he who can translate into another manner or a new material his impression of beautiful things.&#8221;', 'full-site-editing' )
 	),
+	'viewportWidth' => 1280,
 );

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/two-images-side-by-side.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/two-images-side-by-side.php
@@ -32,7 +32,8 @@ $markup = '
 ';
 
 return array(
-	'title'      => esc_html__( 'Two images side-by-side', 'full-site-editing' ),
-	'categories' => array( 'gallery', 'images' ),
-	'content'    => $markup,
+	'title'         => esc_html__( 'Two images side-by-side', 'full-site-editing' ),
+	'categories'    => array( 'gallery', 'images' ),
+	'content'       => $markup,
+	'viewportWidth' => 1280,
 );


### PR DESCRIPTION
### Changes proposed in this Pull Request
Fixes #42165. Increase viewport width of block pattern previews for better preview scaling

### Screenshots
#### Before Example
<img width="323" alt="Screen Shot 2020-06-16 at 10 08 14 PM" src="https://user-images.githubusercontent.com/5414230/84857454-f6d64880-b01d-11ea-99eb-30eea26c1100.png">

#### After Example
<img width="337" alt="Screen Shot 2020-06-16 at 10 07 42 PM" src="https://user-images.githubusercontent.com/5414230/84857467-fd64c000-b01d-11ea-874e-dd9f4fd83873.png">

### Testing
#### Instructions
- Set up sandbox
  - simple site with block pattern preview updates
    1. Sandbox simple site
    2. Checkout this branch in wp-calypso repo
    3. Sync the local dev environment with `cd apps/full-site-editing; yarn dev --sync` More info in PCYsg-ly5-p2 #build-scripts
  - atomic site with block pattern preview updates
    1. Create ephemeral atomic site
    2. Checkout this branch in your local wp-calypso repo
    2. Sync full site editing plugin updates with atomic site. More info in PCYsg-ly5-p2 #atomic-testng
- Navigate to my sites -> posts -> Add new post
- Open Gutenberg Inserter
- Click on Block Patterns Tab
- Review scaled block pattern previews
#### Requirements
- Editor loads without white screen of death
  - [ ] With the Gutenberg plugin enabled and the FSE plugin enabled.
  - [ ] With the Gutenberg plugin disabled and the FSE plugin enabled.
- All block pattern previews are scaled properly
  - [ ] On atomic sites
  - [ ] On simple sites

#### Browsers
- [ ] Firefox
- [ ] Safari
- [ ] Chrome
- [ ] Edge