### PR TITLE
Search: focus back on input when clicking close

### DIFF
--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -251,10 +251,12 @@ class Search extends Component {
 		} );
 
 		this.searchInput.value = ''; // will not trigger onChange
-		this.searchInput.blur();
 
 		if ( this.props.pinned ) {
+			this.searchInput.blur();
 			this.openIcon.focus();
+		} else {
+			this.searchInput.focus();
 		}
 
 		this.props.onSearchClose( event );


### PR DESCRIPTION
This PR resolves #42656

#### Changes proposed in this Pull Request

* clicking the X button in the search component should focus back to the input field

**Before**

![84782527-cc21cb00-aff0-11ea-8bcb-e12c12a4ef88](https://user-images.githubusercontent.com/12430020/84861603-1b600e00-b07a-11ea-9c28-47f6f4a74d5a.gif)


**After**

![CleanShot 2020-06-17 at 09 06 57](https://user-images.githubusercontent.com/12430020/84861566-fd92a900-b079-11ea-9991-8e45b0d4626e.gif)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Open State**
* Go to http://calypso.localhost:3000/read/search?q=test&focus=1
* Click the X button
* Input field should be focused and you should be able to write a term

**Pinned State**
* Go to http://calypso.localhost:3000/plugins?s=test
* Click the X button
* Input Field should collapse and lose focus