### PR TITLE
Update node on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,8 +128,12 @@ references:
     name: Update node
     command: |
       set +e
-      curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.5/install.sh | bash
-      . "${HOME}/.nvm/nvm.sh"
+      set +x
+      export NVM_DIR="$HOME/.nvm" && (
+        git clone https://github.com/nvm-sh/nvm.git "$NVM_DIR"
+        cd "$NVM_DIR"
+        git checkout v0.35.3
+      ) && \. "$NVM_DIR/nvm.sh" --no-use
       nvm install
       nvm use
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,9 +121,17 @@ references:
       - v{{ .Environment.GLOBAL_CACHE_PREFIX }}-yarn-modules-{{ checksum ".nvmrc" }}
 
   yarn-install: &yarn-install
-    environment:
     name: Install dependencies
     command: yarn install --frozen-lockfile
+
+  update-node: &update-node
+    name: Update node
+    command: |
+      set +e
+      curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.5/install.sh | bash
+      . "${HOME}/.nvm/nvm.sh"
+      nvm install
+      nvm use
 
   # This is used later to send a custom UA string. `google-chrome` is in the PATH in all circleci-browser images
   save-chrome-version: &save-chrome-version
@@ -175,6 +183,7 @@ commands:
       - run: *setup-results-and-artifacts
       - attach_workspace:
           at: '~'
+      - update-node: *update-node
   store-artifacts-and-test-results:
     description: Stores artifacts and test results
     steps:
@@ -194,6 +203,7 @@ jobs:
       - checkout
       - run: *update-git-master
       - save_cache: *save-git-cache
+      - update-node: *update-node
       # npm dependencies
       - restore_cache: *restore-yarn-cache
       - run: *yarn-install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,7 +183,7 @@ commands:
       - run: *setup-results-and-artifacts
       - attach_workspace:
           at: '~'
-      - update-node: *update-node
+      - run: *yarn-install
   store-artifacts-and-test-results:
     description: Stores artifacts and test results
     steps:
@@ -203,7 +203,7 @@ jobs:
       - checkout
       - run: *update-git-master
       - save_cache: *save-git-cache
-      - update-node: *update-node
+      - run: *yarn-install
       # npm dependencies
       - restore_cache: *restore-yarn-cache
       - run: *yarn-install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,7 +183,7 @@ commands:
       - run: *setup-results-and-artifacts
       - attach_workspace:
           at: '~'
-      - run: *yarn-install
+      - run: *update-node
   store-artifacts-and-test-results:
     description: Stores artifacts and test results
     steps:
@@ -203,12 +203,11 @@ jobs:
       - checkout
       - run: *update-git-master
       - save_cache: *save-git-cache
-      - run: *yarn-install
+      - run: *update-node
       # npm dependencies
       - restore_cache: *restore-yarn-cache
       - run: *yarn-install
       - save_cache: *save-yarn-cache
-      - run: yarn run build-packages
       - persist_to_workspace:
           root: '~'
           paths:


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Uses [nvm](https://github.com/nvm-sh/nvm) in our builds so we use the version of node specified in `.nvmrc` and not whatever version happens to be installed in the base image.

It adds an overhead to each job, but it is quite small:
![image](https://user-images.githubusercontent.com/975703/84883572-f88d2400-b090-11ea-851f-35059e9a808a.png)
![image](https://user-images.githubusercontent.com/975703/84883619-03e04f80-b091-11ea-8e4e-4534c9d043f1.png)

#### Testing instructions

* Verify all tests passes
