### PR TITLE
Deduplicate yargs-parser

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -26842,15 +26842,7 @@ yargs-parser@^13.1.0, yargs-parser@^13.1.1:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
-yargs-parser@^15.0.0:
-  version "15.0.0"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-15.0.0.tgz#cdd7a97490ec836195f59f3f4dbe5ea9e8f75f08"
-  integrity sha512-xLTUnCMc4JhxrPEPUYD5IBR1mWCK/aT6+RJ/K29JY2y1vD+FhtgKK0AXRWvI262q3QSffAQuTouFIKUuHX89wQ==
-  dependencies:
-    camelcase "^5.0.0"
-    decamelize "^1.2.0"
-
-yargs-parser@^15.0.1:
+yargs-parser@^15.0.0, yargs-parser@^15.0.1:
   version "15.0.1"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-15.0.1.tgz#54786af40b820dcb2fb8025b11b4d659d76323b3"
   integrity sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `yargs-parser` (done automatically with `npx yarn-deduplicate --packages yargs-parser`)

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
< Before
> After
---
< wp-calypso-monorepo@0.17.0 -> @automattic/full-site-editing@1.9.0 -> ... -> yargs-parser@15.0.0
< wp-calypso-monorepo@0.17.0 -> @automattic/o2-blocks@1.0.0 -> ... -> yargs-parser@15.0.0
< wp-calypso-monorepo@0.17.0 -> @wordpress/block-directory@1.9.0 -> ... -> yargs-parser@15.0.0
< wp-calypso-monorepo@0.17.0 -> @wordpress/block-editor@3.11.0 -> ... -> yargs-parser@15.0.0
< wp-calypso-monorepo@0.17.0 -> @wordpress/block-library@2.18.0 -> ... -> yargs-parser@15.0.0
< wp-calypso-monorepo@0.17.0 -> @wordpress/blocks@6.16.0 -> ... -> yargs-parser@15.0.0
< wp-calypso-monorepo@0.17.0 -> @wordpress/core-data@2.16.0 -> ... -> yargs-parser@15.0.0
< wp-calypso-monorepo@0.17.0 -> @wordpress/edit-post@3.17.0 -> ... -> yargs-parser@15.0.0
< wp-calypso-monorepo@0.17.0 -> @wordpress/editor@9.16.0 -> ... -> yargs-parser@15.0.0
< wp-calypso-monorepo@0.17.0 -> @wordpress/format-library@1.18.0 -> ... -> yargs-parser@15.0.0
< wp-calypso-monorepo@0.17.0 -> lerna@3.20.2 -> ... -> yargs-parser@15.0.0
< wp-calypso-monorepo@0.17.0 -> wp-calypso@0.17.0 -> ... -> yargs-parser@15.0.0
> wp-calypso-monorepo@0.17.0 -> @automattic/full-site-editing@1.9.0 -> ... -> yargs-parser@15.0.1
> wp-calypso-monorepo@0.17.0 -> @automattic/o2-blocks@1.0.0 -> ... -> yargs-parser@15.0.1
> wp-calypso-monorepo@0.17.0 -> @wordpress/block-directory@1.9.0 -> ... -> yargs-parser@15.0.1
> wp-calypso-monorepo@0.17.0 -> @wordpress/block-editor@3.11.0 -> ... -> yargs-parser@15.0.1
> wp-calypso-monorepo@0.17.0 -> @wordpress/block-library@2.18.0 -> ... -> yargs-parser@15.0.1
> wp-calypso-monorepo@0.17.0 -> @wordpress/blocks@6.16.0 -> ... -> yargs-parser@15.0.1
> wp-calypso-monorepo@0.17.0 -> @wordpress/core-data@2.16.0 -> ... -> yargs-parser@15.0.1
> wp-calypso-monorepo@0.17.0 -> @wordpress/edit-post@3.17.0 -> ... -> yargs-parser@15.0.1
> wp-calypso-monorepo@0.17.0 -> @wordpress/editor@9.16.0 -> ... -> yargs-parser@15.0.1
> wp-calypso-monorepo@0.17.0 -> @wordpress/format-library@1.18.0 -> ... -> yargs-parser@15.0.1
> wp-calypso-monorepo@0.17.0 -> lerna@3.20.2 -> ... -> yargs-parser@15.0.1
> wp-calypso-monorepo@0.17.0 -> wp-calypso@0.17.0 -> ... -> yargs-parser@15.0.1
```

Unfortunately, their [CHANGELOG](https://github.com/yargs/yargs-parser/blob/master/CHANGELOG.md) don't mention 15.0.1 and it is not tagged in their [repo](https://github.com/yargs/yargs-parser). Looks like the change is [backporting](https://github.com/yargs/yargs-parser/commit/c893d3072f7d31243b750b1d599b0826b8aaefa4) a [security fix](https://github.com/yargs/yargs-parser/blob/master/CHANGELOG.md#bug-fixes-2) related to prototype pollution