### PR TITLE
Deduplicate schema-utils

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -22728,15 +22728,7 @@ schema-utils@^1.0.0:
     ajv-errors "^1.0.0"
     ajv-keywords "^3.1.0"
 
-schema-utils@^2.0.1, schema-utils@^2.1.0, schema-utils@^2.5.0, schema-utils@^2.6.0, schema-utils@^2.6.1, schema-utils@^2.6.4:
-  version "2.6.4"
-  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-2.6.4.tgz#a27efbf6e4e78689d91872ee3ccfa57d7bdd0f53"
-  integrity sha512-VNjcaUxVnEeun6B2fiiUDjXXBtD4ZSH7pdbfIu1pOFwgptDPLMo/z9jr4sUfsjFVPqDCEin/F7IYlq7/E6yDbQ==
-  dependencies:
-    ajv "^6.10.2"
-    ajv-keywords "^3.4.1"
-
-schema-utils@^2.6.5, schema-utils@^2.6.6:
+schema-utils@^2.0.1, schema-utils@^2.1.0, schema-utils@^2.5.0, schema-utils@^2.6.0, schema-utils@^2.6.1, schema-utils@^2.6.4, schema-utils@^2.6.5, schema-utils@^2.6.6:
   version "2.6.6"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-2.6.6.tgz#299fe6bd4a3365dc23d99fd446caff8f1d6c330c"
   integrity sha512-wHutF/WPSbIi9x6ctjGGk2Hvl0VOz5l3EKEuKbjPlB30mKZUzb9A5k9yEXRX3pwyqVLPvpfZZEllaFq/M718hA==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `schema-utils` (done automatically with `npx yarn-deduplicate --packages schema-utils`)

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
< Before
> After
---
< wp-calypso-monorepo@0.17.0 -> @automattic/calypso-build@6.1.0 -> ... -> schema-utils@2.6.4
< wp-calypso-monorepo@0.17.0 -> @automattic/full-site-editing@1.9.0 -> ... -> schema-utils@2.6.4
< wp-calypso-monorepo@0.17.0 -> @storybook/react@5.3.18 -> ... -> schema-utils@2.6.4
< wp-calypso-monorepo@0.17.0 -> @wordpress/scripts@9.1.0 -> ... -> schema-utils@2.6.4
> wp-calypso-monorepo@0.17.0 -> @automattic/calypso-build@6.1.0 -> ... -> schema-utils@2.6.6
> wp-calypso-monorepo@0.17.0 -> @automattic/full-site-editing@1.9.0 -> ... -> schema-utils@2.6.6
> wp-calypso-monorepo@0.17.0 -> @storybook/react@5.3.18 -> ... -> schema-utils@2.6.6
> wp-calypso-monorepo@0.17.0 -> @wordpress/scripts@9.1.0 -> ... -> schema-utils@2.6.6
```

[CHANGELOG](https://github.com/webpack/schema-utils/blob/master/CHANGELOG.md)