### PR TITLE
Add email routes for the all sites views

### DIFF
--- a/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
+++ b/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
@@ -90,7 +90,7 @@ class DomainManagementNavigationEnhanced extends React.Component {
 	}
 
 	getEmail() {
-		const { selectedSite, translate, domain } = this.props;
+		const { selectedSite, translate, currentRoute, domain } = this.props;
 		const { emailForwardsCount } = domain;
 
 		if ( ! this.isDomainInNormalState() ) {
@@ -136,7 +136,7 @@ class DomainManagementNavigationEnhanced extends React.Component {
 
 		return (
 			<DomainManagementNavigationItem
-				path={ emailManagement( selectedSite.slug, domain.name ) }
+				path={ emailManagement( selectedSite.slug, domain.name, currentRoute ) }
 				materialIcon="email"
 				text={ navigationText }
 				description={ navigationDescription }

--- a/client/my-sites/domains/paths.js
+++ b/client/my-sites/domains/paths.js
@@ -47,7 +47,7 @@ function domainManagementTransferBase(
 }
 
 export function isUnderDomainManagementAll( path ) {
-	return path && path.startsWith( domainManagementAllRoot() + '/' );
+	return path?.startsWith( domainManagementAllRoot() + '/' );
 }
 
 export function domainAddNew( siteName, searchTerm ) {

--- a/client/my-sites/domains/paths.js
+++ b/client/my-sites/domains/paths.js
@@ -69,7 +69,7 @@ export function domainManagementRoot() {
 }
 
 export function domainManagementList( siteName, relativeTo = null ) {
-	if ( relativeTo && relativeTo.startsWith( domainManagementAllRoot() + '/' ) ) {
+	if ( isUnderDomainManagementAll( relativeTo ) ) {
 		return domainManagementRoot();
 	}
 	return domainManagementRoot() + '/' + siteName;

--- a/client/my-sites/domains/paths.js
+++ b/client/my-sites/domains/paths.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { filter, startsWith } from 'lodash';
+import { filter } from 'lodash';
 import { stringify } from 'qs';
 import { isUnderEmailManagementAll } from 'my-sites/email/paths';
 
@@ -23,7 +23,7 @@ function domainManagementEditBase( siteName, domainName, slug, relativeTo = null
 	slug = slug || 'edit';
 
 	// Encodes only real domain names and not parameter placeholders
-	if ( ! startsWith( domainName, ':' ) ) {
+	if ( ! domainName.startsWith( ':' ) ) {
 		// Encodes domain names so addresses with slashes in the path (e.g. used in site redirects) don't break routing.
 		// Note they are encoded twice since page.js decodes the path by default.
 		domainName = encodeURIComponent( encodeURIComponent( domainName ) );

--- a/client/my-sites/domains/paths.js
+++ b/client/my-sites/domains/paths.js
@@ -3,6 +3,7 @@
  */
 import { filter, startsWith } from 'lodash';
 import { stringify } from 'qs';
+import { isUnderEmailManagementAll } from 'my-sites/email/paths';
 
 function resolveRootPath( relativeTo = null ) {
 	if ( relativeTo ) {
@@ -10,7 +11,7 @@ function resolveRootPath( relativeTo = null ) {
 			return domainManagementAllRoot();
 		}
 
-		if ( relativeTo.startsWith( domainManagementAllRoot() + '/' ) ) {
+		if ( isUnderDomainManagementAll( relativeTo ) || isUnderEmailManagementAll( relativeTo ) ) {
 			return domainManagementAllRoot();
 		}
 	}
@@ -46,7 +47,7 @@ function domainManagementTransferBase(
 }
 
 export function isUnderDomainManagementAll( path ) {
-	return path.startsWith( domainManagementAllRoot() + '/' );
+	return path && path.startsWith( domainManagementAllRoot() + '/' );
 }
 
 export function domainAddNew( siteName, searchTerm ) {

--- a/client/my-sites/email/email-forwarding/index.jsx
+++ b/client/my-sites/email/email-forwarding/index.jsx
@@ -26,6 +26,7 @@ import getEmailForwardingType from 'state/selectors/get-email-forwarding-type';
 import { getEmailForwards } from 'state/selectors/get-email-forwards';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import QueryEmailForwards from 'components/data/query-email-forwards';
+import getCurrentRoute from 'state/selectors/get-current-route';
 
 /**
  * Style dependencies
@@ -103,7 +104,9 @@ class EmailForwarding extends Component {
 	}
 
 	goToEditEmail = () => {
-		page( emailManagement( this.props.siteSlug, this.props.selectedDomainName ) );
+		page(
+			emailManagement( this.props.siteSlug, this.props.selectedDomainName, this.props.currentRoute )
+		);
 	};
 }
 
@@ -111,6 +114,7 @@ export default connect( ( state, ownProps ) => {
 	const siteId = getSelectedSiteId( state );
 	const { selectedDomainName } = ownProps;
 	return {
+		currentRoute: getCurrentRoute( state ),
 		emailForwards: getEmailForwards( state, selectedDomainName ),
 		emailForwardingLimit: getEmailForwardingLimit( state, siteId ),
 		emailForwardingType: getEmailForwardingType( state, selectedDomainName ),

--- a/client/my-sites/email/email-management/index.jsx
+++ b/client/my-sites/email/email-management/index.jsx
@@ -43,6 +43,7 @@ import QueryEmailAccounts from 'components/data/query-email-accounts';
 import QueryGSuiteUsers from 'components/data/query-gsuite-users';
 import QuerySiteDomains from 'components/data/query-site-domains';
 import { localizeUrl } from 'lib/i18n-utils';
+import getCurrentRoute from 'state/selectors/get-current-route';
 
 /**
  * Style dependencies
@@ -53,7 +54,6 @@ import './style.scss';
  * Image dependencies
  */
 import customDomainImage from 'assets/images/illustrations/custom-domain.svg';
-import getCurrentRoute from '../../../state/selectors/get-current-route';
 
 class EmailManagement extends React.Component {
 	static propTypes = {

--- a/client/my-sites/email/email-management/index.jsx
+++ b/client/my-sites/email/email-management/index.jsx
@@ -53,6 +53,7 @@ import './style.scss';
  * Image dependencies
  */
 import customDomainImage from 'assets/images/illustrations/custom-domain.svg';
+import getCurrentRoute from '../../../state/selectors/get-current-route';
 
 class EmailManagement extends React.Component {
 	static propTypes = {
@@ -260,10 +261,10 @@ class EmailManagement extends React.Component {
 	}
 
 	goToEditOrList = () => {
-		const { selectedDomainName, selectedSiteSlug } = this.props;
+		const { selectedDomainName, selectedSiteSlug, currentRoute } = this.props;
 
 		if ( selectedDomainName ) {
-			page( domainManagementEdit( selectedSiteSlug, selectedDomainName ) );
+			page( domainManagementEdit( selectedSiteSlug, selectedDomainName, currentRoute ) );
 		} else {
 			page( domainManagementList( selectedSiteSlug ) );
 		}
@@ -273,6 +274,7 @@ class EmailManagement extends React.Component {
 export default connect( ( state ) => {
 	const selectedSiteId = getSelectedSiteId( state );
 	return {
+		currentRoute: getCurrentRoute( state ),
 		canManageSite: canCurrentUser( state, selectedSiteId, 'manage_options' ),
 		domains: getDomainsBySiteId( state, selectedSiteId ),
 		gsuiteUsers: getGSuiteUsers( state, selectedSiteId ),

--- a/client/my-sites/email/email-management/index.jsx
+++ b/client/my-sites/email/email-management/index.jsx
@@ -249,11 +249,13 @@ class EmailManagement extends React.Component {
 	}
 
 	addEmailForwardingCard( domain ) {
-		const { selectedSiteSlug, translate } = this.props;
+		const { selectedSiteSlug, currentRoute, translate } = this.props;
 
 		return (
 			<VerticalNav>
-				<VerticalNavItem path={ emailManagementForwarding( selectedSiteSlug, domain ) }>
+				<VerticalNavItem
+					path={ emailManagementForwarding( selectedSiteSlug, domain, currentRoute ) }
+				>
 					{ translate( 'Email Forwarding' ) }
 				</VerticalNavItem>
 			</VerticalNav>

--- a/client/my-sites/email/gsuite-add-users/index.jsx
+++ b/client/my-sites/email/gsuite-add-users/index.jsx
@@ -42,12 +42,12 @@ import QueryEmailForwards from 'components/data/query-email-forwards';
 import QueryGSuiteUsers from 'components/data/query-gsuite-users';
 import getGSuiteUsers from 'state/selectors/get-gsuite-users';
 import { recordTracksEvent as recordTracksEventAction } from 'state/analytics/actions';
+import getCurrentRoute from 'state/selectors/get-current-route';
 
 /**
  * Style dependencies
  */
 import './style.scss';
-import getCurrentRoute from '../../../state/selectors/get-current-route';
 
 class GSuiteAddUsers extends React.Component {
 	state = {

--- a/client/my-sites/email/gsuite-add-users/index.jsx
+++ b/client/my-sites/email/gsuite-add-users/index.jsx
@@ -205,7 +205,7 @@ class GSuiteAddUsers extends React.Component {
 				{ gsuiteUsers && selectedDomainInfo && ! isRequestingDomains ? (
 					<Card>
 						<GSuiteNewUserList
-							autoFocus
+							autoFocus // eslint-disable-line jsx-a11y/no-autofocus
 							extraValidation={ ( user ) => validateAgainstExistingUsers( user, gsuiteUsers ) }
 							domains={ selectedDomainInfo }
 							onUsersChange={ this.handleUsersChange }

--- a/client/my-sites/email/gsuite-add-users/index.jsx
+++ b/client/my-sites/email/gsuite-add-users/index.jsx
@@ -47,6 +47,7 @@ import { recordTracksEvent as recordTracksEventAction } from 'state/analytics/ac
  * Style dependencies
  */
 import './style.scss';
+import getCurrentRoute from '../../../state/selectors/get-current-route';
 
 class GSuiteAddUsers extends React.Component {
 	state = {
@@ -152,7 +153,13 @@ class GSuiteAddUsers extends React.Component {
 	}
 
 	goToEmail = () => {
-		page( emailManagement( this.props.selectedSite.slug, this.props.selectedDomainName ) );
+		page(
+			emailManagement(
+				this.props.selectedSite.slug,
+				this.props.selectedDomainName,
+				this.props.currentRoute
+			)
+		);
 	};
 
 	renderAddGSuite() {
@@ -272,6 +279,7 @@ export default connect(
 		const siteId = get( selectedSite, 'ID', null );
 		const domains = getDomainsBySiteId( state, siteId );
 		return {
+			currentRoute: getCurrentRoute( state ),
 			domains,
 			domainsWithForwards: getDomainsWithForwards( state, domains ),
 			gsuiteUsers: getGSuiteUsers( state, siteId ),

--- a/client/my-sites/email/gsuite-purchase-cta/index.jsx
+++ b/client/my-sites/email/gsuite-purchase-cta/index.jsx
@@ -42,7 +42,7 @@ export const GSuitePurchaseCta = ( {
 		recordEvent( 'calypso_email_gsuite_purchase_cta_view', {
 			domain_name: domainName,
 		} );
-	}, [ domainName ] );
+	}, [ domainName ] ); // eslint-disable-line react-hooks/exhaustive-deps
 
 	const goToAddGSuiteUsers = ( planType ) => {
 		recordEvent( 'calypso_email_gsuite_purchase_cta_get_gsuite_click', {

--- a/client/my-sites/email/gsuite-purchase-cta/index.jsx
+++ b/client/my-sites/email/gsuite-purchase-cta/index.jsx
@@ -23,6 +23,7 @@ import GSuiteLearnMore from 'components/gsuite/gsuite-learn-more';
 import GSuitePrice from 'components/gsuite/gsuite-price';
 import { recordTracksEvent } from 'state/analytics/actions';
 import QueryProductsList from 'components/data/query-products-list';
+import getCurrentRoute from 'state/selectors/get-current-route';
 
 /**
  * Style dependencies
@@ -31,6 +32,7 @@ import './style.scss';
 
 export const GSuitePurchaseCta = ( {
 	currencyCode,
+	currentRoute,
 	domainName,
 	product,
 	recordTracksEvent: recordEvent,
@@ -48,7 +50,7 @@ export const GSuitePurchaseCta = ( {
 			plan_type: planType,
 		} );
 
-		page( emailManagementNewGSuiteAccount( selectedSiteSlug, domainName, planType ) );
+		page( emailManagementNewGSuiteAccount( selectedSiteSlug, domainName, planType, currentRoute ) );
 	};
 
 	const handleLearnMoreClick = () => {
@@ -130,6 +132,7 @@ GSuitePurchaseCta.propTypes = {
 
 export default connect(
 	( state ) => ( {
+		currentRoute: getCurrentRoute( state ),
 		currencyCode: getCurrentUserCurrencyCode( state ),
 		product: getProductBySlug( state, GSUITE_BASIC_SLUG ),
 		selectedSiteSlug: getSelectedSiteSlug( state ),

--- a/client/my-sites/email/index.js
+++ b/client/my-sites/email/index.js
@@ -31,6 +31,11 @@ export default function () {
 
 	registerMultiPage( {
 		paths: [
+			paths.emailManagementAddGSuiteUsers(
+				':site',
+				':domain',
+				paths.emailManagementAllSitesPrefix
+			),
 			paths.emailManagementAddGSuiteUsers( ':site', ':domain' ),
 			paths.emailManagementAddGSuiteUsers( ':site' ),
 		],
@@ -58,11 +63,11 @@ export default function () {
 		clientRender
 	);
 
-	page(
-		paths.emailManagementForwarding( ':site', ':domain' ),
-		...commonHandlers,
-		controller.emailManagementForwarding,
-		makeLayout,
-		clientRender
-	);
+	registerMultiPage( {
+		paths: [
+			paths.emailManagementForwarding( ':site', ':domain', paths.emailManagementAllSitesPrefix ),
+			paths.emailManagementForwarding( ':site', ':domain' ),
+		],
+		handlers: [ ...commonHandlers, controller.emailManagementForwarding, makeLayout, clientRender ],
+	} );
 }

--- a/client/my-sites/email/index.js
+++ b/client/my-sites/email/index.js
@@ -21,7 +21,11 @@ export default function () {
 	page( paths.emailManagement(), siteSelection, sites, makeLayout, clientRender );
 
 	registerMultiPage( {
-		paths: [ paths.emailManagement( ':site', ':domain' ), paths.emailManagement( ':site' ) ],
+		paths: [
+			paths.emailManagement( ':site', ':domain', paths.emailManagementAllSitesPrefix ),
+			paths.emailManagement( ':site', ':domain' ),
+			paths.emailManagement( ':site' ),
+		],
 		handlers: [ ...commonHandlers, controller.emailManagement, makeLayout, clientRender ],
 	} );
 

--- a/client/my-sites/email/index.js
+++ b/client/my-sites/email/index.js
@@ -55,13 +55,23 @@ export default function () {
 		handlers: [ controller.emailManagementAddGSuiteUsersLegacyRedirect ],
 	} );
 
-	page(
-		paths.emailManagementNewGSuiteAccount( ':site', ':domain', ':planType' ),
-		...commonHandlers,
-		controller.emailManagementNewGSuiteAccount,
-		makeLayout,
-		clientRender
-	);
+	registerMultiPage( {
+		paths: [
+			paths.emailManagementNewGSuiteAccount(
+				':site',
+				':domain',
+				':planType',
+				paths.emailManagementAllSitesPrefix
+			),
+			paths.emailManagementNewGSuiteAccount( ':site', ':domain', ':planType' ),
+		],
+		handlers: [
+			...commonHandlers,
+			controller.emailManagementNewGSuiteAccount,
+			makeLayout,
+			clientRender,
+		],
+	} );
 
 	registerMultiPage( {
 		paths: [

--- a/client/my-sites/email/paths.js
+++ b/client/my-sites/email/paths.js
@@ -2,16 +2,16 @@
  * External dependencies
  */
 import { startsWith } from 'lodash';
+import { isUnderDomainManagementAll } from 'my-sites/domains/paths';
 
 export const emailManagementPrefix = '/email';
 export const emailManagementAllSitesPrefix = '/email/all';
 
 function resolveRootPath( relativeTo ) {
-	if (
-		relativeTo &&
-		( relativeTo === emailManagementAllSitesPrefix ||
-			relativeTo.startsWith( emailManagementAllSitesPrefix + '/' ) )
-	) {
+	if ( relativeTo === emailManagementAllSitesPrefix ) {
+		return emailManagementAllSitesPrefix;
+	}
+	if ( isUnderEmailManagementAll( relativeTo ) || isUnderDomainManagementAll( relativeTo ) ) {
 		return emailManagementAllSitesPrefix;
 	}
 	return emailManagementPrefix;
@@ -77,5 +77,5 @@ export function emailManagementEdit( siteName, domainName, slug, relativeTo = nu
 }
 
 export function isUnderEmailManagementAll( path ) {
-	return path.startsWith( emailManagementAllSitesPrefix + '/' );
+	return path && path.startsWith( emailManagementAllSitesPrefix + '/' );
 }

--- a/client/my-sites/email/paths.js
+++ b/client/my-sites/email/paths.js
@@ -77,5 +77,5 @@ export function emailManagementEdit( siteName, domainName, slug, relativeTo = nu
 }
 
 export function isUnderEmailManagementAll( path ) {
-	return path && path.startsWith( emailManagementAllSitesPrefix + '/' );
+	return path?.startsWith( emailManagementAllSitesPrefix + '/' );
 }

--- a/client/my-sites/email/paths.js
+++ b/client/my-sites/email/paths.js
@@ -3,11 +3,25 @@
  */
 import { startsWith } from 'lodash';
 
-export function emailManagementAddGSuiteUsers( siteName, domainName ) {
+export const emailManagementPrefix = '/email';
+export const emailManagementAllSitesPrefix = '/email/all';
+
+function resolveRootPath( relativeTo ) {
+	if (
+		relativeTo &&
+		( relativeTo === emailManagementAllSitesPrefix ||
+			relativeTo.startsWith( emailManagementAllSitesPrefix + '/' ) )
+	) {
+		return emailManagementAllSitesPrefix;
+	}
+	return emailManagementPrefix;
+}
+
+export function emailManagementAddGSuiteUsers( siteName, domainName, relativeTo = null ) {
 	let path;
 
 	if ( domainName ) {
-		path = emailManagementEdit( siteName, domainName, 'gsuite/add-users' );
+		path = emailManagementEdit( siteName, domainName, 'gsuite/add-users', relativeTo );
 	} else {
 		path = '/email/gsuite/add-users/' + siteName;
 	}
@@ -31,11 +45,11 @@ export function emailManagementNewGSuiteAccount( siteName, domainName, planType 
 	return emailManagementEdit( siteName, domainName, 'gsuite/new/' + planType );
 }
 
-export function emailManagement( siteName, domainName ) {
+export function emailManagement( siteName, domainName, relativeTo = null ) {
 	let path;
 
 	if ( domainName ) {
-		path = emailManagementEdit( siteName, domainName, 'manage' );
+		path = emailManagementEdit( siteName, domainName, 'manage', relativeTo );
 	} else if ( siteName ) {
 		path = '/email/' + siteName;
 	} else {
@@ -45,11 +59,11 @@ export function emailManagement( siteName, domainName ) {
 	return path;
 }
 
-export function emailManagementForwarding( siteName, domainName ) {
-	return emailManagementEdit( siteName, domainName, 'forwarding' );
+export function emailManagementForwarding( siteName, domainName, relativeTo = null ) {
+	return emailManagementEdit( siteName, domainName, 'forwarding', relativeTo );
 }
 
-export function emailManagementEdit( siteName, domainName, slug ) {
+export function emailManagementEdit( siteName, domainName, slug, relativeTo = null ) {
 	slug = slug || 'manage';
 
 	// Encodes only real domain names and not parameter placeholders
@@ -59,5 +73,9 @@ export function emailManagementEdit( siteName, domainName, slug ) {
 		domainName = encodeURIComponent( encodeURIComponent( domainName ) );
 	}
 
-	return '/email/' + domainName + '/' + slug + '/' + siteName;
+	return resolveRootPath( relativeTo ) + '/' + domainName + '/' + slug + '/' + siteName;
+}
+
+export function isUnderEmailManagementAll( path ) {
+	return path.startsWith( emailManagementAllSitesPrefix + '/' );
 }

--- a/client/my-sites/email/paths.js
+++ b/client/my-sites/email/paths.js
@@ -41,8 +41,13 @@ export function emailManagementAddGSuiteUsersLegacy( siteName, domainName ) {
 	return path;
 }
 
-export function emailManagementNewGSuiteAccount( siteName, domainName, planType ) {
-	return emailManagementEdit( siteName, domainName, 'gsuite/new/' + planType );
+export function emailManagementNewGSuiteAccount(
+	siteName,
+	domainName,
+	planType,
+	relativeTo = null
+) {
+	return emailManagementEdit( siteName, domainName, 'gsuite/new/' + planType, relativeTo );
 }
 
 export function emailManagement( siteName, domainName, relativeTo = null ) {

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -84,6 +84,7 @@ import canSiteViewAtomicHosting from 'state/selectors/can-site-view-atomic-hosti
 import isSiteWPForTeams from 'state/selectors/is-site-wpforteams';
 import { getCurrentRoute } from 'state/selectors/get-current-route';
 import { isUnderDomainManagementAll } from 'my-sites/domains/paths';
+import { isUnderEmailManagementAll } from 'my-sites/email/paths';
 import JetpackSidebarMenuItems from 'components/jetpack/sidebar/menu-items/calypso';
 
 /**
@@ -970,8 +971,10 @@ export class MySitesSidebar extends Component {
 
 function mapStateToProps( state ) {
 	const currentUser = getCurrentUser( state );
+	const currentRoute = getCurrentRoute( state );
 
-	const isAllDomainsView = isUnderDomainManagementAll( getCurrentRoute( state ) );
+	const isAllDomainsView =
+		isUnderDomainManagementAll( currentRoute ) || isUnderEmailManagementAll( currentRoute );
 
 	const selectedSiteId = isAllDomainsView ? null : getSelectedSiteId( state );
 	const isSingleSite = !! selectedSiteId || currentUser.site_count === 1;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add email routes for the all sites views

#### Testing instructions

* Open the all sites domains view and then click through the "Set up your email" nav item and sub items and verify that the sidebar is not changing to the site specific view