### PR TITLE
Remember reader feed and sidebar selection

### DIFF
--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -406,8 +406,6 @@ export class FullPostView extends React.Component {
 							/>
 						) }
 						<div className="reader-full-post__sidebar-comment-like">
-							{ config.isEnabled( 'reader/seen-posts' ) && this.renderMarkAsSenButton() }
-
 							{ shouldShowComments( post ) && (
 								<CommentButton
 									key="comment-button"
@@ -416,6 +414,7 @@ export class FullPostView extends React.Component {
 									tagName="div"
 								/>
 							) }
+
 							{ shouldShowLikes( post ) && (
 								<LikeButton
 									siteId={ +post.site_ID }
@@ -425,6 +424,8 @@ export class FullPostView extends React.Component {
 									likeSource={ 'reader' }
 								/>
 							) }
+
+							{ config.isEnabled( 'reader/seen-posts' ) && this.renderMarkAsSenButton() }
 						</div>
 					</div>
 					<Emojify>

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -126,7 +126,6 @@
 }
 
 .reader-full-post__seen-button {
-	margin-right: 25px;
 	align-items: center;
 	box-sizing: border-box;
 	color: #646970;
@@ -136,6 +135,10 @@
 	padding: 4px;
 	position: relative;
 	user-select: none;
+
+	@include breakpoint-deprecated( '<660px' ) {
+		top: 12px;
+	}
 }
 
 .reader-full-post__story {
@@ -354,7 +357,7 @@
 		height: 47px;
 		justify-content: flex-end;
 		position: fixed;
-		left: 0;
+		right: 60px;
 		top: 0;
 		width: 100%;
 		z-index: z-index( 'root', '.reader-full-post__sidebar-comment-like' );
@@ -362,8 +365,9 @@
 }
 
 .reader-full-post__sidebar .like-button {
+	margin-right: 18px;
+
 	@include breakpoint-deprecated( '<660px' ) {
-		margin-right: 60px;
 		top: 9px;
 	}
 

--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -29,6 +29,8 @@ import { isFollowingOpen } from 'state/reader-ui/sidebar/selectors';
 import { toggleReaderSidebarFollowing } from 'state/reader-ui/sidebar/actions';
 import { getLastPath } from 'state/reader-ui/selectors';
 import { getSection } from 'state/ui/selectors';
+import { isAutomatticTeamMember } from 'reader/lib/teams';
+import { getReaderTeams } from 'state/reader/teams/selectors';
 
 const analyticsPageTitle = 'Reader';
 
@@ -137,18 +139,22 @@ const exported = {
 		const mcKey = 'following';
 		const startDate = getStartDate( context );
 
-		// select last reader path if available, otherwise just open following
 		const state = context.store.getState();
-		const currentSection = getSection( state );
-		const lastPath = getLastPath( state );
-		if ( lastPath && lastPath !== '/read' && currentSection.name !== 'reader' ) {
-			return page.redirect( lastPath );
-		}
+		// only for a8c for now
+		if ( isAutomatticTeamMember( getReaderTeams( state ) ) ) {
+			// select last reader path if available, otherwise just open following
+			const currentSection = getSection( state );
+			const lastPath = getLastPath( state );
 
-		// if we have no last path, default to Following/All and expand following
-		const isOpen = isFollowingOpen( state );
-		if ( ! isOpen ) {
-			context.store.dispatch( toggleReaderSidebarFollowing() );
+			if ( lastPath && lastPath !== '/read' && currentSection.name !== 'reader' ) {
+				return page.redirect( lastPath );
+			}
+
+			// if we have no last path, default to Following/All and expand following
+			const isOpen = isFollowingOpen( state );
+			if ( ! isOpen ) {
+				context.store.dispatch( toggleReaderSidebarFollowing() );
+			}
 		}
 
 		trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );

--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -27,6 +27,8 @@ import { waitForData } from 'state/data-layer/http-data';
 import AsyncLoad from 'components/async-load';
 import { isFollowingOpen } from 'state/reader-ui/sidebar/selectors';
 import { toggleReaderSidebarFollowing } from 'state/reader-ui/sidebar/actions';
+import { getLastPath } from 'state/reader-ui/selectors';
+import { getSection } from 'state/ui/selectors';
 
 const analyticsPageTitle = 'Reader';
 
@@ -135,8 +137,15 @@ const exported = {
 		const mcKey = 'following';
 		const startDate = getStartDate( context );
 
-		// toggle read
+		// select last reader path if available, otherwise just open following
 		const state = context.store.getState();
+		const currentSection = getSection( state );
+		const lastPath = getLastPath( state );
+		if ( lastPath && lastPath !== '/read' && currentSection.name !== 'reader' ) {
+			return page.redirect( lastPath );
+		}
+
+		// if we have no last path, default to Following/All and expand following
 		const isOpen = isFollowingOpen( state );
 		if ( ! isOpen ) {
 			context.store.dispatch( toggleReaderSidebarFollowing() );

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -105,7 +105,7 @@ class ReaderStream extends React.Component {
 	componentDidUpdate( { selectedPostKey, streamKey } ) {
 		if ( streamKey !== this.props.streamKey ) {
 			this.props.resetCardExpansions();
-			this.props.viewStream( { streamKey } );
+			this.props.viewStream( { streamKey, path: window.location.pathname } );
 			this.fetchNextPage( {} );
 		}
 
@@ -152,7 +152,7 @@ class ReaderStream extends React.Component {
 	componentDidMount() {
 		const { streamKey } = this.props;
 		this.props.resetCardExpansions();
-		this.props.viewStream( { streamKey } );
+		this.props.viewStream( { streamKey, path: window.location.pathname } );
 		this.fetchNextPage( {} );
 
 		KeyboardShortcuts.on( 'move-selection-down', this.selectNextItem );

--- a/client/state/reader-ui/reducer.js
+++ b/client/state/reader-ui/reducer.js
@@ -6,6 +6,32 @@ import sidebar from './sidebar/reducer';
 import { combineReducers, withStorageKey } from 'state/utils';
 import cardExpansions from './card-expansions/reducer';
 import hasUnseenPosts from './seen-posts/reducer';
+import { DESERIALIZE, SERIALIZE } from 'state/action-types';
+
+/**
+ * Keep the last reader stream path selected by the user, for the purpose of autoselecting it
+ * when user navigates back to Reader
+ *
+ * @param state redux state
+ * @param action redux action
+ *
+ * @returns {null|string} last path selected
+ */
+export const lastPath = ( state = null, action ) => {
+	switch ( action.type ) {
+		case SERIALIZE:
+		case DESERIALIZE:
+			return state;
+
+		case READER_VIEW_STREAM:
+			if ( action.path && action.path.startsWith( '/read' ) ) {
+				return action.path;
+			}
+			break;
+	}
+	return state;
+};
+lastPath.hasCustomPersistence = true;
 
 /*
  * Holds the last viewed stream for the purposes of keyboard navigation
@@ -16,6 +42,7 @@ export const currentStream = ( state = null, action ) =>
 const combinedReducer = combineReducers( {
 	sidebar,
 	cardExpansions,
+	lastPath,
 	currentStream,
 	hasUnseenPosts,
 } );

--- a/client/state/reader-ui/selectors.js
+++ b/client/state/reader-ui/selectors.js
@@ -6,5 +6,5 @@
  * @returns string|null {lastPath} last feed path visited in the reader
  */
 export function getLastPath( state ) {
-	return state.ui.reader.lastPath;
+	return state.readerUi.lastPath;
 }

--- a/client/state/reader-ui/selectors.js
+++ b/client/state/reader-ui/selectors.js
@@ -1,0 +1,10 @@
+/**
+ * Get reader last path selected
+ *
+ * @param state redux state
+ *
+ * @returns string|null {lastPath} last feed path visited in the reader
+ */
+export function getLastPath( state ) {
+	return state.ui.reader.lastPath;
+}

--- a/client/state/reader-ui/sidebar/reducer.js
+++ b/client/state/reader-ui/sidebar/reducer.js
@@ -13,43 +13,64 @@ import {
 	READER_SIDEBAR_FOLLOWING_TOGGLE,
 } from 'state/reader/action-types';
 import { combineReducers } from 'state/utils';
+import { DESERIALIZE, SERIALIZE } from 'state/action-types';
 
-export function isListsOpen( state = false, action ) {
+export const isListsOpen = ( state = false, action ) => {
 	switch ( action.type ) {
+		case SERIALIZE:
+		case DESERIALIZE:
+			return state;
+
 		case READER_SIDEBAR_LISTS_TOGGLE:
 			return ! state;
 	}
 
 	return state;
-}
+};
+isListsOpen.hasCustomPersistence = true;
 
-export function isTagsOpen( state = false, action ) {
+export const isTagsOpen = ( state = false, action ) => {
 	switch ( action.type ) {
+		case SERIALIZE:
+		case DESERIALIZE:
+			return state;
+
 		case READER_SIDEBAR_TAGS_TOGGLE:
 			return ! state;
 	}
 
 	return state;
-}
+};
+isTagsOpen.hasCustomPersistence = true;
 
-export function isFollowingOpen( state = false, action ) {
+export const isFollowingOpen = ( state = false, action ) => {
 	switch ( action.type ) {
+		case SERIALIZE:
+		case DESERIALIZE:
+			return state;
+
 		case READER_SIDEBAR_FOLLOWING_TOGGLE:
 			return ! state;
 	}
 
 	return state;
-}
+};
+isFollowingOpen.hasCustomPersistence = true;
 
-export function openOrganizations( state = [], action ) {
+export const openOrganizations = ( state = [], action ) => {
 	switch ( action.type ) {
+		case SERIALIZE:
+		case DESERIALIZE:
+			return state;
+
 		case READER_SIDEBAR_ORGANIZATIONS_TOGGLE: {
 			return xor( state, [ action.organizationId ] );
 		}
 	}
 
 	return state;
-}
+};
+openOrganizations.hasCustomPersistence = true;
 
 export default combineReducers( {
 	isListsOpen,

--- a/client/state/reader/watermarks/actions.js
+++ b/client/state/reader/watermarks/actions.js
@@ -10,14 +10,16 @@ import 'state/reader/init';
  * My hope is that we'll be able to reuse this same action-type for many other functionalities.
  * i.e. unexpanding all photos/videos when opening a stream.
  *
+ * @param {string} path  - current window location path
  * @param {Date} mark  - date last viewed
  * @param {string} streamKey - stream being viewed
  * @returns {object} action object for dispatch
  */
 
-export const viewStream = ( { mark, streamKey } ) => {
+export const viewStream = ( { path, mark, streamKey } ) => {
 	return {
 		type: READER_VIEW_STREAM,
+		path,
 		mark,
 		streamKey,
 	};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Reader sidebar expanded/collpased sections will be persisted
- Reader selected stream will also be persisted, that way if a user navigates outside of the Reader when they come back the previously selected stream with be showed
- Fixed https://github.com/Automattic/wp-calypso/issues/43309

#### Testing instructions
- Go to reader, expand/collapse section, refresh, the same sections should be collapsed/expanded
- Go to reader select a stream, go to my sites, go back to Reader the previous stream should be selected
