### PR TITLE
Gutenboarding: Add feature flag to redirect to Site Editor upon Site Creation (take two)

### DIFF
--- a/client/landing/gutenboarding/hooks/use-on-site-creation.ts
+++ b/client/landing/gutenboarding/hooks/use-on-site-creation.ts
@@ -14,6 +14,7 @@ import { USER_STORE } from '../stores/user';
 import { SITE_STORE } from '../stores/site';
 import { recordOnboardingComplete } from '../lib/analytics';
 import { useSelectedPlan, useIsSelectedPlanEcommerce } from './use-selected-plan';
+import { isEnabled } from '../../../config';
 
 const wpcom = wp.undocumented();
 
@@ -124,7 +125,9 @@ export default function useOnSiteCreation() {
 			resetOnboardStore();
 			setSelectedSite( newSite.blogid );
 
-			window.location.href = `/block-editor/page/${ newSite.site_slug }/home`;
+			window.location.href = isEnabled( 'gutenboarding/site-editor' )
+				? `/site-editor/${ newSite.site_slug }/`
+				: `/block-editor/page/${ newSite.site_slug }/home`;
 		}
 	}, [
 		domain,

--- a/client/landing/gutenboarding/stores/onboard/actions.ts
+++ b/client/landing/gutenboarding/stores/onboard/actions.ts
@@ -13,6 +13,7 @@ import { STORE_KEY as ONBOARD_STORE } from './constants';
 import { SITE_STORE } from '../site';
 import type { State } from '.';
 import type { FontPair } from '../../constants';
+import { isEnabled } from '../../../../config';
 
 type CreateSiteParams = Site.CreateSiteParams;
 type DomainSuggestion = DomainSuggestions.DomainSuggestion;
@@ -121,7 +122,9 @@ export function* createSite(
 			site_information: {
 				title: siteTitle,
 			},
-			site_creation_flow: 'gutenboarding',
+			site_creation_flow: isEnabled( 'gutenboarding/site-editor' )
+				? 'gutenboarding-site-editor'
+				: 'gutenboarding',
 			theme: `pub/${ selectedDesign?.theme || 'twentytwenty' }`,
 			timezone_string: guessTimezone(),
 			...( selectedDesign?.template && { template: selectedDesign.template } ),

--- a/client/state/sites/launch/actions.js
+++ b/client/state/sites/launch/actions.js
@@ -35,8 +35,9 @@ export const launchSiteOrRedirectToLaunchSignupFlow = ( siteId ) => ( dispatch, 
 
 	// TODO: consider using the `page` library instead of calling using `location.href` here
 
-	const isGutenboarding =
-		getSiteOption( getState(), siteId, 'site_creation_flow' ) === 'gutenboarding';
+	const isGutenboarding = [ 'gutenboarding', 'gutenboarding-site-editor' ].includes(
+		getSiteOption( getState(), siteId, 'site_creation_flow' )
+	);
 	if ( isGutenboarding ) {
 		window.location.href = `/start/new-launch?siteSlug=${ siteSlug }&source=home`;
 	} else {


### PR DESCRIPTION
Take Two of #43246, which I accidentally reverted last night (when I really meant to revert #43345 after I got e2e errors in staging) :man_facepalming: 

Reverts Automattic/wp-calypso#43357

