### PR TITLE
Remove isCalypsoClient variable from webpack.config.js

### DIFF
--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -306,10 +306,6 @@ const webpackConfig = {
 		! config.isEnabled( 'desktop' ) &&
 			new webpack.NormalModuleReplacementPlugin( /^lib[/\\]desktop$/, 'lodash-es/noop' ),
 		/*
-		 * Replace `lodash` with `lodash-es`
-		 */
-		new ExtensiveLodashReplacementPlugin(),
-		/*
 		 * Forcibly remove dashicon while we wait for better tree-shaking in `@wordpress/*`.
 		 */
 		new webpack.NormalModuleReplacementPlugin( /dashicon/, ( res ) => {
@@ -333,6 +329,10 @@ const webpackConfig = {
 				/^lib[/\\]local-storage-polyfill$/,
 				'lodash-es/noop'
 			),
+		/*
+		 * Replace `lodash` with `lodash-es`
+		 */
+		new ExtensiveLodashReplacementPlugin(),
 	].filter( Boolean ),
 	externals: [ 'electron' ],
 };

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -56,10 +56,9 @@ const shouldConcatenateModules = process.env.CONCATENATE_MODULES !== 'false';
 const shouldBuildChunksMap =
 	process.env.BUILD_TRANSLATION_CHUNKS === 'true' ||
 	process.env.ENABLE_FEATURES === 'use-translation-chunks';
-const isCalypsoClient = process.env.BROWSERSLIST_ENV !== 'server';
 const isDesktop = calypsoEnv === 'desktop' || calypsoEnv === 'desktop-development';
 
-const defaultBrowserslistEnv = isCalypsoClient && ! isDesktop ? 'evergreen' : 'defaults';
+const defaultBrowserslistEnv = isDesktop ? 'defaults' : 'evergreen';
 const browserslistEnv = process.env.BROWSERSLIST_ENV || defaultBrowserslistEnv;
 const extraPath = browserslistEnv === 'defaults' ? 'fallback' : browserslistEnv;
 
@@ -254,21 +253,20 @@ const webpackConfig = {
 			global: 'window',
 		} ),
 		new webpack.NormalModuleReplacementPlugin( /^path$/, 'path-browserify' ),
-		isCalypsoClient && new webpack.IgnorePlugin( /^\.\/locale$/, /moment$/ ),
+		new webpack.IgnorePlugin( /^\.\/locale$/, /moment$/ ),
 		...SassConfig.plugins( {
 			chunkFilename: cssChunkFilename,
 			filename: cssFilename,
 			minify: ! isDevelopment,
 		} ),
-		isCalypsoClient &&
-			new AssetsWriter( {
-				filename:
-					browserslistEnv === 'defaults'
-						? 'assets-fallback.json'
-						: `assets-${ browserslistEnv }.json`,
-				path: path.join( __dirname, 'server', 'bundler' ),
-				assetExtraPath: extraPath,
-			} ),
+		new AssetsWriter( {
+			filename:
+				browserslistEnv === 'defaults'
+					? 'assets-fallback.json'
+					: `assets-${ browserslistEnv }.json`,
+			path: path.join( __dirname, 'server', 'bundler' ),
+			assetExtraPath: extraPath,
+		} ),
 		new DuplicatePackageCheckerPlugin(),
 		shouldCheckForCycles &&
 			new CircularDependencyPlugin( {
@@ -298,55 +296,45 @@ const webpackConfig = {
 		new ConfigFlagPlugin( {
 			flags: { desktop: config.isEnabled( 'desktop' ) },
 		} ),
-		isCalypsoClient && new InlineConstantExportsPlugin( /\/client\/state\/action-types.js$/ ),
+		new InlineConstantExportsPlugin( /\/client\/state\/action-types.js$/ ),
 		shouldBuildChunksMap &&
 			new GenerateChunksMapPlugin( {
 				output: path.resolve( '.', `chunks-map.${ extraPath }.json` ),
 			} ),
-		isCalypsoClient && new RequireChunkCallbackPlugin(),
+		new RequireChunkCallbackPlugin(),
 		isDevelopment && new webpack.HotModuleReplacementPlugin(),
-	].filter( Boolean ),
-	externals: [ 'electron' ],
-};
-
-if ( ! config.isEnabled( 'desktop' ) ) {
-	webpackConfig.plugins.push(
-		new webpack.NormalModuleReplacementPlugin( /^lib[/\\]desktop$/, 'lodash-es/noop' )
-	);
-}
-
-// Replace `lodash` with `lodash-es`.
-if ( isCalypsoClient ) {
-	webpackConfig.plugins.push( new ExtensiveLodashReplacementPlugin() );
-}
-
-// Forcibly remove dashicon while we wait for better tree-shaking in `@wordpress/*`.
-if ( isCalypsoClient ) {
-	webpackConfig.plugins.push(
+		! config.isEnabled( 'desktop' ) &&
+			new webpack.NormalModuleReplacementPlugin( /^lib[/\\]desktop$/, 'lodash-es/noop' ),
+		/*
+		 * Replace `lodash` with `lodash-es`
+		 */
+		new ExtensiveLodashReplacementPlugin(),
+		/*
+		 * Forcibly remove dashicon while we wait for better tree-shaking in `@wordpress/*`.
+		 */
 		new webpack.NormalModuleReplacementPlugin( /dashicon/, ( res ) => {
 			if ( res.context.includes( '@wordpress/components/' ) ) {
 				res.request = 'components/empty-component';
 			}
-		} )
-	);
-}
-
-if ( isCalypsoClient && browserslistEnv === 'evergreen' ) {
-	// Use "evergreen" polyfill config, rather than fallback.
-	webpackConfig.plugins.push(
-		new webpack.NormalModuleReplacementPlugin(
-			/^@automattic\/calypso-polyfills$/,
-			'@automattic/calypso-polyfills/browser-evergreen'
-		)
-	);
-
-	// Local storage used to throw errors in Safari private mode, but that's no longer the case in Safari >=11.
-	webpackConfig.plugins.push(
-		new webpack.NormalModuleReplacementPlugin(
-			/^lib[/\\]local-storage-polyfill$/,
-			'lodash-es/noop'
-		)
-	);
-}
+		} ),
+		/*
+		 * Use "evergreen" polyfill config, rather than fallback.
+		 */
+		browserslistEnv === 'evergreen' &&
+			new webpack.NormalModuleReplacementPlugin(
+				/^@automattic\/calypso-polyfills$/,
+				'@automattic/calypso-polyfills/browser-evergreen'
+			),
+		/*
+		 * Local storage used to throw errors in Safari private mode, but that's no longer the case in Safari >=11.
+		 */
+		browserslistEnv === 'evergreen' &&
+			new webpack.NormalModuleReplacementPlugin(
+				/^lib[/\\]local-storage-polyfill$/,
+				'lodash-es/noop'
+			),
+	].filter( Boolean ),
+	externals: [ 'electron' ],
+};
 
 module.exports = webpackConfig;


### PR DESCRIPTION
When working on the `wp-desktop` repo migration in #43324 I noticed that the `isCalypsoClient` condition in the _webpack.config.js_ file is redundant and can be removed. This webpack config is used _only_ to build the client app, so the condition is always `true`. The server apps (both Node.js and Electron) have their own webpack configs.

The variable was originally introduced by @samouri in Babel 7 migration in #23424. Then the code was refactored by @blowery in #26476 and by @ockham in #31838, becoming gradually meaningless.

The Babel config still uses the variable, because it's shared by both server and client builds.

**How to test:**
Are all kinds of builds OK?

@sgomes Is there a reason why webpack plugins would be order-dependent? Like the module replacement by `lodash-es/noop` and the `ExtensiveLodashReplacementPlugin`? I think changing the order shouldn't matter, but not 100% sure.

I removed all the `webpackConfig.plugins.push` calls and unified everything to use the
```js
[
  condition && plugin
].filter( Boolean )
```
pattern.