### PR TITLE
Add basic e2e tests to cover FAB support search instance

### DIFF
--- a/test/e2e/lib/components/inline-help-component.js
+++ b/test/e2e/lib/components/inline-help-component.js
@@ -72,6 +72,13 @@ class InlineHelpComponent extends AsyncBaseContainer {
 		const val = await this.getSearchInputValue();
 		assert.equal( val, '', `Failed to correctly clear search input using clear UI` );
 	}
+
+	async hasNoResultsMessage() {
+		return await driverHelper.isElementPresent(
+			this.driver,
+			By.css( '.inline-help__popover .inline-help__empty-results' )
+		);
+	}
 }
 
 export default InlineHelpComponent;

--- a/test/e2e/lib/components/inline-help-component.js
+++ b/test/e2e/lib/components/inline-help-component.js
@@ -41,6 +41,13 @@ class InlineHelpComponent extends AsyncBaseContainer {
 		return await this.driver.findElement( By.css( '.inline-help__popover' ) );
 	}
 
+	async isRequestingSearchResults() {
+		return await driverHelper.isElementPresent(
+			this.driver,
+			By.css( '.inline-help__results-placeholder' )
+		);
+	}
+
 	async toggleOpen() {
 		await this.isToggleVisible();
 		await driverHelper.clickWhenClickable( this.driver, By.css( '.inline-help__button' ) );

--- a/test/e2e/lib/components/inline-help-component.js
+++ b/test/e2e/lib/components/inline-help-component.js
@@ -60,6 +60,11 @@ class InlineHelpComponent extends AsyncBaseContainer {
 		);
 	}
 
+	async getSearchResultsCount() {
+		const results = await this.getSearchResults();
+		return results.length;
+	}
+
 	async searchFor( query = '' ) {
 		await driverHelper.setWhenSettable( this.driver, searchInputSelector, query );
 		const val = await this.getSearchInputValue();

--- a/test/e2e/lib/components/inline-help-component.js
+++ b/test/e2e/lib/components/inline-help-component.js
@@ -1,0 +1,68 @@
+/**
+ * External dependencies
+ */
+import { By } from 'selenium-webdriver';
+import assert from 'assert';
+
+/**
+ * Internal dependencies
+ */
+import AsyncBaseContainer from '../async-base-container';
+import * as driverHelper from '../driver-helper.js';
+
+const searchInputSelector = By.css( '.inline-help__popover input[type="search"]' );
+
+class InlineHelpComponent extends AsyncBaseContainer {
+	constructor( driver ) {
+		super( driver, By.css( '.inline-help' ) );
+	}
+
+	async waitForResults() {
+		const driver = this.driver;
+		const resultsLoadingSelector = By.css( '.inline-help__results-placeholder' );
+		return await driver.wait(
+			function () {
+				return driverHelper
+					.isElementPresent( driver, resultsLoadingSelector )
+					.then( function ( present ) {
+						return ! present;
+					} );
+			},
+			this.explicitWaitMS * 2,
+			'The support search loading element was still present when it should have disappeared by now.'
+		);
+	}
+
+	async isToggleVisible() {
+		return await this.driver.findElement( By.css( '.inline-help__button' ) );
+	}
+
+	async isPopoverVisible() {
+		return await this.driver.findElement( By.css( '.inline-help__popover' ) );
+	}
+
+	async toggleOpen() {
+		await this.isToggleVisible();
+		await driverHelper.clickWhenClickable( this.driver, By.css( '.inline-help__button' ) );
+		return await this.isPopoverVisible();
+	}
+
+	async getSearchResults() {
+		return await this.driver.findElements(
+			By.css( '.inline-help__results-list .inline-help__results-item' )
+		);
+	}
+
+	async searchFor( query = '' ) {
+		await driverHelper.setWhenSettable( this.driver, searchInputSelector, query );
+		const val = await this.getSearchInputValue();
+		assert.strictEqual( val, query, `Failed to correctly set search input value to ${ query }` );
+		return await this.waitForResults();
+	}
+
+	async getSearchInputValue() {
+		return await this.driver.findElement( searchInputSelector ).getAttribute( 'value' );
+	}
+}
+
+export default InlineHelpComponent;

--- a/test/e2e/lib/components/inline-help-component.js
+++ b/test/e2e/lib/components/inline-help-component.js
@@ -34,11 +34,11 @@ class InlineHelpComponent extends AsyncBaseContainer {
 	}
 
 	async isToggleVisible() {
-		return await this.driver.findElement( By.css( '.inline-help__button' ) );
+		return await driverHelper.isElementPresent( this.driver, By.css( '.inline-help__button' ) );
 	}
 
 	async isPopoverVisible() {
-		return await this.driver.findElement( By.css( '.inline-help__popover' ) );
+		return await driverHelper.isElementPresent( this.driver, By.css( '.inline-help__popover' ) );
 	}
 
 	async isRequestingSearchResults() {
@@ -51,7 +51,12 @@ class InlineHelpComponent extends AsyncBaseContainer {
 	async toggleOpen() {
 		await this.isToggleVisible();
 		await driverHelper.clickWhenClickable( this.driver, By.css( '.inline-help__button' ) );
-		return await this.isPopoverVisible();
+	}
+
+	async toggleClosed() {
+		await this.isPopoverVisible();
+		await this.isToggleVisible();
+		await driverHelper.clickWhenClickable( this.driver, By.css( '.inline-help__button' ) );
 	}
 
 	async getSearchResults() {

--- a/test/e2e/lib/components/inline-help-component.js
+++ b/test/e2e/lib/components/inline-help-component.js
@@ -12,25 +12,10 @@ import * as driverHelper from '../driver-helper.js';
 
 const searchInputSelector = By.css( '.inline-help__popover input[type="search"]' );
 
+
 class InlineHelpComponent extends AsyncBaseContainer {
 	constructor( driver ) {
 		super( driver, By.css( '.inline-help' ) );
-	}
-
-	async waitForResults() {
-		const driver = this.driver;
-		const resultsLoadingSelector = By.css( '.inline-help__results-placeholder' );
-		return await driver.wait(
-			function () {
-				return driverHelper
-					.isElementPresent( driver, resultsLoadingSelector )
-					.then( function ( present ) {
-						return ! present;
-					} );
-			},
-			this.explicitWaitMS * 2,
-			'The support search loading element was still present when it should have disappeared by now.'
-		);
 	}
 
 	async isToggleVisible() {
@@ -39,13 +24,6 @@ class InlineHelpComponent extends AsyncBaseContainer {
 
 	async isPopoverVisible() {
 		return await driverHelper.isElementPresent( this.driver, By.css( '.inline-help__popover' ) );
-	}
-
-	async isRequestingSearchResults() {
-		return await driverHelper.isElementPresent(
-			this.driver,
-			By.css( '.inline-help__results-placeholder' )
-		);
 	}
 
 	async toggleOpen() {
@@ -57,44 +35,6 @@ class InlineHelpComponent extends AsyncBaseContainer {
 		await this.isPopoverVisible();
 		await this.isToggleVisible();
 		await driverHelper.clickWhenClickable( this.driver, By.css( '.inline-help__button' ) );
-	}
-
-	async getSearchResults() {
-		return await this.driver.findElements(
-			By.css( '.inline-help__results-list .inline-help__results-item' )
-		);
-	}
-
-	async getSearchResultsCount() {
-		const results = await this.getSearchResults();
-		return results.length;
-	}
-
-	async searchFor( query = '' ) {
-		await driverHelper.setWhenSettable( this.driver, searchInputSelector, query );
-		const val = await this.getSearchInputValue();
-		assert.strictEqual( val, query, `Failed to correctly set search input value to ${ query }` );
-		return await this.waitForResults();
-	}
-
-	async getSearchInputValue() {
-		return await this.driver.findElement( searchInputSelector ).getAttribute( 'value' );
-	}
-
-	async clearSearchField() {
-		await driverHelper.clickWhenClickable(
-			this.driver,
-			By.css( '.inline-help__popover [role="search"] [aria-label="Close Search"]' )
-		);
-		const val = await this.getSearchInputValue();
-		assert.equal( val, '', `Failed to correctly clear search input using clear UI` );
-	}
-
-	async hasNoResultsMessage() {
-		return await driverHelper.isElementPresent(
-			this.driver,
-			By.css( '.inline-help__popover .inline-help__empty-results' )
-		);
 	}
 }
 

--- a/test/e2e/lib/components/inline-help-component.js
+++ b/test/e2e/lib/components/inline-help-component.js
@@ -63,6 +63,15 @@ class InlineHelpComponent extends AsyncBaseContainer {
 	async getSearchInputValue() {
 		return await this.driver.findElement( searchInputSelector ).getAttribute( 'value' );
 	}
+
+	async clearSearchField() {
+		await driverHelper.clickWhenClickable(
+			this.driver,
+			By.css( '.inline-help__popover [role="search"] [aria-label="Close Search"]' )
+		);
+		const val = await this.getSearchInputValue();
+		assert.equal( val, '', `Failed to correctly clear search input using clear UI` );
+	}
 }
 
 export default InlineHelpComponent;

--- a/test/e2e/lib/components/inline-help-component.js
+++ b/test/e2e/lib/components/inline-help-component.js
@@ -10,9 +10,6 @@ import assert from 'assert';
 import AsyncBaseContainer from '../async-base-container';
 import * as driverHelper from '../driver-helper.js';
 
-const searchInputSelector = By.css( '.inline-help__popover input[type="search"]' );
-
-
 class InlineHelpComponent extends AsyncBaseContainer {
 	constructor( driver ) {
 		super( driver, By.css( '.inline-help' ) );

--- a/test/e2e/lib/components/inline-help-popover-component.js
+++ b/test/e2e/lib/components/inline-help-popover-component.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { By } from 'selenium-webdriver';
-import assert from 'assert';
 
 /**
  * Internal dependencies
@@ -10,7 +9,7 @@ import assert from 'assert';
 import AsyncBaseContainer from '../async-base-container';
 import * as driverHelper from '../driver-helper.js';
 
-class InlineHelpComponent extends AsyncBaseContainer {
+class InlineHelpPopoverComponent extends AsyncBaseContainer {
 	constructor( driver ) {
 		super( driver, By.css( '.inline-help' ) );
 	}
@@ -35,4 +34,4 @@ class InlineHelpComponent extends AsyncBaseContainer {
 	}
 }
 
-export default InlineHelpComponent;
+export default InlineHelpPopoverComponent;

--- a/test/e2e/lib/components/sidebar-component.js
+++ b/test/e2e/lib/components/sidebar-component.js
@@ -15,6 +15,9 @@ export default class SidebarComponent extends AsyncBaseContainer {
 		super( driver, By.css( '.sidebar' ) );
 		this.storeSelector = By.css( '.menu-link-text[data-e2e-sidebar="Store"]' );
 	}
+	async _postInit(){
+		return await this.ensureSidebarMenuVisible();
+	}
 
 	async expandDrawerItem( itemName ) {
 		const selector = await driverHelper.getElementByText(

--- a/test/e2e/lib/components/support-search-component.js
+++ b/test/e2e/lib/components/support-search-component.js
@@ -1,0 +1,82 @@
+/**
+ * External dependencies
+ */
+import { By } from 'selenium-webdriver';
+import assert from 'assert';
+
+/**
+ * Internal dependencies
+ */
+import AsyncBaseContainer from '../async-base-container';
+import * as driverHelper from '../driver-helper.js';
+
+const searchInputSelector = By.css( '.inline-help__search input[type="search"]' );
+
+class SupportSearchComponent extends AsyncBaseContainer {
+	constructor( driver ) {
+		super( driver, By.css( '.inline-help__search' ) );
+	}
+
+	async waitForResults() {
+		const driver = this.driver;
+		const resultsLoadingSelector = By.css( '.inline-help__results-placeholder' );
+		return await driver.wait(
+			function () {
+				return driverHelper
+					.isElementPresent( driver, resultsLoadingSelector )
+					.then( function ( present ) {
+						return ! present;
+					} );
+			},
+			this.explicitWaitMS * 2,
+			'The support search loading element was still present when it should have disappeared by now.'
+		);
+	}
+
+	async isRequestingSearchResults() {
+		return await driverHelper.isElementPresent(
+			this.driver,
+			By.css( '.inline-help__results-placeholder' )
+		);
+	}
+
+	async getSearchResults() {
+		return await this.driver.findElements(
+			By.css( '.inline-help__results-list .inline-help__results-item' )
+		);
+	}
+
+	async getSearchResultsCount() {
+		const results = await this.getSearchResults();
+		return results.length;
+	}
+
+	async searchFor( query = '' ) {
+		await driverHelper.setWhenSettable( this.driver, searchInputSelector, query );
+		const val = await this.getSearchInputValue();
+		assert.strictEqual( val, query, `Failed to correctly set search input value to ${ query }` );
+		return await this.waitForResults();
+	}
+
+	async getSearchInputValue() {
+		return await this.driver.findElement( searchInputSelector ).getAttribute( 'value' );
+	}
+
+	async clearSearchField() {
+		await driverHelper.clickWhenClickable(
+			this.driver,
+			By.css( '.inline-help__search [role="search"] [aria-label="Close Search"]' )
+		);
+		const val = await this.getSearchInputValue();
+		assert.equal( val, '', `Failed to correctly clear search input using clear UI` );
+	}
+
+	async hasNoResultsMessage() {
+		return await driverHelper.isElementPresent(
+			this.driver,
+			By.css( '.inline-help__empty-results' )
+		);
+	}
+}
+
+export default SupportSearchComponent;

--- a/test/e2e/lib/components/support-search-component.js
+++ b/test/e2e/lib/components/support-search-component.js
@@ -20,16 +20,11 @@ class SupportSearchComponent extends AsyncBaseContainer {
 	async waitForResults() {
 		const driver = this.driver;
 		const resultsLoadingSelector = By.css( '.inline-help__results-placeholder' );
-		return await driver.wait(
-			function () {
-				return driverHelper
-					.isElementPresent( driver, resultsLoadingSelector )
-					.then( function ( present ) {
-						return ! present;
-					} );
-			},
-			this.explicitWaitMS * 2,
-			'The support search loading element was still present when it should have disappeared by now.'
+
+		return driverHelper.waitTillNotPresent(
+			driver,
+			resultsLoadingSelector,
+			this.explicitWaitMS * 2
 		);
 	}
 

--- a/test/e2e/specs/wp-support-search.js
+++ b/test/e2e/specs/wp-support-search.js
@@ -1,0 +1,69 @@
+/**
+ * External dependencies
+ */
+import config from 'config';
+import assert from 'assert';
+
+/**
+ * Internal dependencies
+ */
+import * as driverManager from '../lib/driver-manager.js';
+
+import LoginFlow from '../lib/flows/login-flow.js';
+import * as dataHelper from '../lib/data-helper';
+import InlineHelpComponent from '../lib/components/inline-help-component';
+const mochaTimeOut = config.get( 'mochaTimeoutMS' );
+const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
+const screenSize = driverManager.currentScreenSize();
+const host = dataHelper.getJetpackHost();
+
+let driver;
+
+before( async function () {
+	this.timeout( startBrowserTimeoutMS );
+	driver = await driverManager.startBrowser();
+} );
+
+describe( `[${ host }] Accessing support search: (${ screenSize })`, function () {
+	this.timeout( mochaTimeOut );
+
+	describe( 'Inline Help FAB popover', function () {
+		step( 'Login and select a non My Home page', async function () {
+			const loginFlow = new LoginFlow( driver );
+			await loginFlow.loginAndSelectThemes();
+		} );
+		step( 'Check help toggle is visible', async function () {
+			const inlineHelpComponent = await InlineHelpComponent.Expect( driver );
+			await inlineHelpComponent.isToggleVisible();
+		} );
+
+		step( 'Open Inline Help popover', async function () {
+			const inlineHelpComponent = await InlineHelpComponent.Expect( driver );
+			await inlineHelpComponent.toggleOpen();
+		} );
+
+		step( 'Displays contextual search results by default', async function () {
+			const inlineHelpComponent = await InlineHelpComponent.Expect( driver );
+			const results = await inlineHelpComponent.getSearchResults();
+			assert.strictEqual( results.length, 5, 'There are no contextual results displayed' );
+		} );
+
+		step( 'Returns search results for valid search query', async function () {
+			const inlineHelpComponent = await InlineHelpComponent.Expect( driver );
+			await inlineHelpComponent.searchFor( 'Podcast' );
+			const results = await inlineHelpComponent.getSearchResults();
+			const resultsLength = results.length;
+
+			assert.equal(
+				resultsLength <= 5,
+				true,
+				`Too many search results displayed. Should be less than or equal to 5 (was ${ resultsLength }).`
+			);
+			assert.equal(
+				resultsLength >= 1,
+				true,
+				`Too few search results displayed. Should be more than or equal to 1 (was ${ resultsLength }).`
+			);
+		} );
+	} );
+} );

--- a/test/e2e/specs/wp-support-search.js
+++ b/test/e2e/specs/wp-support-search.js
@@ -44,25 +44,24 @@ describe( `[${ host }] Accessing support search: (${ screenSize })`, function ()
 
 		step( 'Displays contextual search results by default', async function () {
 			const inlineHelpComponent = await InlineHelpComponent.Expect( driver );
-			const results = await inlineHelpComponent.getSearchResults();
-			assert.equal( results.length, 5, 'There are no contextual results displayed' );
+			const resultsCount = await inlineHelpComponent.getSearchResultsCount();
+			assert.equal( resultsCount, 5, 'There are no contextual results displayed' );
 		} );
 
 		step( 'Returns search results for valid search query', async function () {
 			const inlineHelpComponent = await InlineHelpComponent.Expect( driver );
 			await inlineHelpComponent.searchFor( 'Podcast' );
-			const results = await inlineHelpComponent.getSearchResults();
-			const resultsLength = results.length;
+			const resultsCount = await inlineHelpComponent.getSearchResultsCount();
 
 			assert.equal(
-				resultsLength <= 5,
+				resultsCount <= 5,
 				true,
-				`Too many search results displayed. Should be less than or equal to 5 (was ${ resultsLength }).`
+				`Too many search results displayed. Should be less than or equal to 5 (was ${ resultsCount }).`
 			);
 			assert.equal(
-				resultsLength >= 1,
+				resultsCount >= 1,
 				true,
-				`Too few search results displayed. Should be more than or equal to 1 (was ${ resultsLength }).`
+				`Too few search results displayed. Should be more than or equal to 1 (was ${ resultsCount }).`
 			);
 		} );
 
@@ -81,14 +80,13 @@ describe( `[${ host }] Accessing support search: (${ screenSize })`, function ()
 				const invalidSearchQueryReturningNoResults = ';;;ppp;;;';
 				const inlineHelpComponent = await InlineHelpComponent.Expect( driver );
 				await inlineHelpComponent.searchFor( invalidSearchQueryReturningNoResults );
-				const results = await inlineHelpComponent.getSearchResults();
-				const resultsLength = results.length;
+				const resultsCount = await inlineHelpComponent.getSearchResultsCount();
 
 				const hasNoResultsMessage = await inlineHelpComponent.hasNoResultsMessage();
 
 				assert.equal( hasNoResultsMessage, true, 'The "No results" message was not displayed.' );
 
-				assert.equal( resultsLength, 5, 'There are no contextual results displayed.' );
+				assert.equal( resultsCount, 5, 'There are no contextual results displayed.' );
 			}
 		);
 

--- a/test/e2e/specs/wp-support-search.js
+++ b/test/e2e/specs/wp-support-search.js
@@ -65,5 +65,14 @@ describe( `[${ host }] Accessing support search: (${ screenSize })`, function ()
 				`Too few search results displayed. Should be more than or equal to 1 (was ${ resultsLength }).`
 			);
 		} );
+
+		step( 'Resets search UI to default state when search input is cleared ', async function () {
+			const inlineHelpComponent = await InlineHelpComponent.Expect( driver );
+			await inlineHelpComponent.clearSearchField();
+
+			// Once https://github.com/Automattic/wp-calypso/pull/43323 is merged this will work again
+			// const results = await inlineHelpComponent.getSearchResults();
+			// assert.strictEqual( results.length, 5, 'There are no contextual results displayed' );
+		} );
 	} );
 } );

--- a/test/e2e/specs/wp-support-search.js
+++ b/test/e2e/specs/wp-support-search.js
@@ -45,7 +45,7 @@ describe( `[${ host }] Accessing support search: (${ screenSize })`, function ()
 		step( 'Displays contextual search results by default', async function () {
 			const inlineHelpComponent = await InlineHelpComponent.Expect( driver );
 			const results = await inlineHelpComponent.getSearchResults();
-			assert.strictEqual( results.length, 5, 'There are no contextual results displayed' );
+			assert.equal( results.length, 5, 'There are no contextual results displayed' );
 		} );
 
 		step( 'Returns search results for valid search query', async function () {
@@ -74,5 +74,22 @@ describe( `[${ host }] Accessing support search: (${ screenSize })`, function ()
 			// const results = await inlineHelpComponent.getSearchResults();
 			// assert.strictEqual( results.length, 5, 'There are no contextual results displayed' );
 		} );
+
+		step(
+			'Shows "No results" indicator and re-displays contextual results for search queries which return no results',
+			async function () {
+				const invalidSearchQueryReturningNoResults = ';;;ppp;;;';
+				const inlineHelpComponent = await InlineHelpComponent.Expect( driver );
+				await inlineHelpComponent.searchFor( invalidSearchQueryReturningNoResults );
+				const results = await inlineHelpComponent.getSearchResults();
+				const resultsLength = results.length;
+
+				const hasNoResultsMessage = await inlineHelpComponent.hasNoResultsMessage();
+
+				assert.equal( hasNoResultsMessage, true, 'The "No results" message was not displayed.' );
+
+				assert.equal( resultsLength, 5, 'There are no contextual results displayed.' );
+			}
+		);
 	} );
 } );

--- a/test/e2e/specs/wp-support-search.js
+++ b/test/e2e/specs/wp-support-search.js
@@ -91,5 +91,22 @@ describe( `[${ host }] Accessing support search: (${ screenSize })`, function ()
 				assert.equal( resultsLength, 5, 'There are no contextual results displayed.' );
 			}
 		);
+
+		step( 'Does not request search results for empty search queries', async function () {
+			const inlineHelpComponent = await InlineHelpComponent.Expect( driver );
+			await inlineHelpComponent.clearSearchField();
+
+			const emptyWhitespaceQuery = '         ';
+
+			await inlineHelpComponent.searchFor( emptyWhitespaceQuery );
+
+			const searchPerformed = await inlineHelpComponent.isRequestingSearchResults();
+
+			assert.equal(
+				searchPerformed,
+				false,
+				'A search was unexpectedly performed for an empty search query.'
+			);
+		} );
 	} );
 } );

--- a/test/e2e/specs/wp-support-search.js
+++ b/test/e2e/specs/wp-support-search.js
@@ -18,35 +18,40 @@ const screenSize = driverManager.currentScreenSize();
 const host = dataHelper.getJetpackHost();
 
 let driver;
+let inlineHelpComponent;
 
 before( async function () {
 	this.timeout( startBrowserTimeoutMS );
 	driver = await driverManager.startBrowser();
 } );
 
-describe( `[${ host }] Accessing support search: (${ screenSize })`, function () {
+describe( `[${ host }] Accessing support search: (${ screenSize })`, async function () {
 	this.timeout( mochaTimeOut );
 
 	describe( 'Inline Help FAB popover', function () {
 		step( 'Login and select a non My Home page', async function () {
 			const loginFlow = new LoginFlow( driver );
+
+			// The "inline help" FAB sholuld not appear on the My Home
+			// because there is already a support search "Card" on that
+			// page. Therefore we select the "Themes" page for our tests.
 			await loginFlow.loginAndSelectThemes();
+
+			// Initialize the helper component
+			inlineHelpComponent = await InlineHelpComponent.Expect( driver );
 		} );
 
 		describe( 'Popover UI visibility and interactions', function () {
 			step( 'Check help toggle is visible', async function () {
-				const inlineHelpComponent = await InlineHelpComponent.Expect( driver );
 				await inlineHelpComponent.isToggleVisible();
 			} );
 
 			step( 'Open Inline Help popover', async function () {
-				const inlineHelpComponent = await InlineHelpComponent.Expect( driver );
 				await inlineHelpComponent.toggleOpen();
 				return await inlineHelpComponent.isPopoverVisible();
 			} );
 
 			step( 'Close Inline Help popover', async function () {
-				const inlineHelpComponent = await InlineHelpComponent.Expect( driver );
 				await inlineHelpComponent.toggleClosed();
 				const isPopoverVisible = await inlineHelpComponent.isPopoverVisible();
 				assert.equal( isPopoverVisible, false, 'Popover was not closed correctly.' );
@@ -55,18 +60,15 @@ describe( `[${ host }] Accessing support search: (${ screenSize })`, function ()
 
 		describe( 'Performing searches', function () {
 			step( 'Re-open Inline Help popover', async function () {
-				const inlineHelpComponent = await InlineHelpComponent.Expect( driver );
 				await inlineHelpComponent.toggleOpen();
 			} );
 
 			step( 'Displays contextual search results by default', async function () {
-				const inlineHelpComponent = await InlineHelpComponent.Expect( driver );
 				const resultsCount = await inlineHelpComponent.getSearchResultsCount();
 				assert.equal( resultsCount, 5, 'There are no contextual results displayed' );
 			} );
 
 			step( 'Returns search results for valid search query', async function () {
-				const inlineHelpComponent = await InlineHelpComponent.Expect( driver );
 				await inlineHelpComponent.searchFor( 'Podcast' );
 				const resultsCount = await inlineHelpComponent.getSearchResultsCount();
 
@@ -83,7 +85,6 @@ describe( `[${ host }] Accessing support search: (${ screenSize })`, function ()
 			} );
 
 			step( 'Resets search UI to default state when search input is cleared ', async function () {
-				const inlineHelpComponent = await InlineHelpComponent.Expect( driver );
 				await inlineHelpComponent.clearSearchField();
 
 				// Once https://github.com/Automattic/wp-calypso/pull/43323 is merged this will work again
@@ -95,7 +96,7 @@ describe( `[${ host }] Accessing support search: (${ screenSize })`, function ()
 				'Shows "No results" indicator and re-displays contextual results for search queries which return no results',
 				async function () {
 					const invalidSearchQueryReturningNoResults = ';;;ppp;;;';
-					const inlineHelpComponent = await InlineHelpComponent.Expect( driver );
+
 					await inlineHelpComponent.searchFor( invalidSearchQueryReturningNoResults );
 					const resultsCount = await inlineHelpComponent.getSearchResultsCount();
 
@@ -108,7 +109,6 @@ describe( `[${ host }] Accessing support search: (${ screenSize })`, function ()
 			);
 
 			step( 'Does not request search results for empty search queries', async function () {
-				const inlineHelpComponent = await InlineHelpComponent.Expect( driver );
 				await inlineHelpComponent.clearSearchField();
 
 				const emptyWhitespaceQuery = '         ';

--- a/test/e2e/specs/wp-support-search.js
+++ b/test/e2e/specs/wp-support-search.js
@@ -3,15 +3,18 @@
  */
 import config from 'config';
 import assert from 'assert';
+import { By } from 'selenium-webdriver';
 
 /**
  * Internal dependencies
  */
 import * as driverManager from '../lib/driver-manager.js';
+import * as driverHelper from '../lib/driver-helper.js';
 
 import LoginFlow from '../lib/flows/login-flow.js';
 import * as dataHelper from '../lib/data-helper';
 import InlineHelpComponent from '../lib/components/inline-help-component';
+import SidebarComponent from '../lib/components/sidebar-component.js';
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
 const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
@@ -123,6 +126,24 @@ describe( `[${ host }] Accessing support search: (${ screenSize })`, async funct
 					'A search was unexpectedly performed for an empty search query.'
 				);
 			} );
+		} );
+	} );
+
+	describe( 'My Home support search card', function () {
+		// before( async function () {
+		// 	return await driverManager.ensureNotLoggedIn( driver );
+		// } );
+		step( 'Select the My Home page', async function () {
+			// const loginFlow = new LoginFlow( driver );
+
+			const sidebarComponent = await SidebarComponent.Expect( driver );
+			// The "inline help" FAB sholuld not appear on the My Home
+			// because there is already a support search "Card" on that
+			// page. Therefore we select the "Themes" page for our tests.
+			// await loginFlow.loginAndSelectMySite();
+			await sidebarComponent.selectMyHome();
+
+			return await driverHelper.isElementPresent( driver, By.css( '.card help-search' ) );
 		} );
 	} );
 } );

--- a/test/e2e/specs/wp-support-search.js
+++ b/test/e2e/specs/wp-support-search.js
@@ -14,6 +14,7 @@ import * as driverHelper from '../lib/driver-helper.js';
 import LoginFlow from '../lib/flows/login-flow.js';
 import * as dataHelper from '../lib/data-helper';
 import InlineHelpComponent from '../lib/components/inline-help-component';
+import SupportSearchComponent from '../lib/components/support-search-component';
 import SidebarComponent from '../lib/components/sidebar-component.js';
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
 const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
@@ -21,6 +22,7 @@ const screenSize = driverManager.currentScreenSize();
 const host = dataHelper.getJetpackHost();
 
 let driver;
+let supportSearchComponent;
 let inlineHelpComponent;
 
 before( async function () {
@@ -41,6 +43,7 @@ describe( `[${ host }] Accessing support search: (${ screenSize })`, async funct
 			await loginFlow.loginAndSelectThemes();
 
 			// Initialize the helper component
+
 			inlineHelpComponent = await InlineHelpComponent.Expect( driver );
 		} );
 
@@ -64,16 +67,17 @@ describe( `[${ host }] Accessing support search: (${ screenSize })`, async funct
 		describe( 'Performing searches', function () {
 			step( 'Re-open Inline Help popover', async function () {
 				await inlineHelpComponent.toggleOpen();
+				supportSearchComponent = await SupportSearchComponent.Expect( driver );
 			} );
 
 			step( 'Displays contextual search results by default', async function () {
-				const resultsCount = await inlineHelpComponent.getSearchResultsCount();
+				const resultsCount = await supportSearchComponent.getSearchResultsCount();
 				assert.equal( resultsCount, 5, 'There are no contextual results displayed' );
 			} );
 
 			step( 'Returns search results for valid search query', async function () {
-				await inlineHelpComponent.searchFor( 'Podcast' );
-				const resultsCount = await inlineHelpComponent.getSearchResultsCount();
+				await supportSearchComponent.searchFor( 'Podcast' );
+				const resultsCount = await supportSearchComponent.getSearchResultsCount();
 
 				assert.equal(
 					resultsCount <= 5,
@@ -88,10 +92,10 @@ describe( `[${ host }] Accessing support search: (${ screenSize })`, async funct
 			} );
 
 			step( 'Resets search UI to default state when search input is cleared ', async function () {
-				await inlineHelpComponent.clearSearchField();
+				await supportSearchComponent.clearSearchField();
 
 				// Once https://github.com/Automattic/wp-calypso/pull/43323 is merged this will work again
-				// const results = await inlineHelpComponent.getSearchResults();
+				// const results = await supportSearchComponent.getSearchResults();
 				// assert.strictEqual( results.length, 5, 'There are no contextual results displayed' );
 			} );
 
@@ -100,10 +104,10 @@ describe( `[${ host }] Accessing support search: (${ screenSize })`, async funct
 				async function () {
 					const invalidSearchQueryReturningNoResults = ';;;ppp;;;';
 
-					await inlineHelpComponent.searchFor( invalidSearchQueryReturningNoResults );
-					const resultsCount = await inlineHelpComponent.getSearchResultsCount();
+					await supportSearchComponent.searchFor( invalidSearchQueryReturningNoResults );
+					const resultsCount = await supportSearchComponent.getSearchResultsCount();
 
-					const hasNoResultsMessage = await inlineHelpComponent.hasNoResultsMessage();
+					const hasNoResultsMessage = await supportSearchComponent.hasNoResultsMessage();
 
 					assert.equal( hasNoResultsMessage, true, 'The "No results" message was not displayed.' );
 
@@ -112,13 +116,13 @@ describe( `[${ host }] Accessing support search: (${ screenSize })`, async funct
 			);
 
 			step( 'Does not request search results for empty search queries', async function () {
-				await inlineHelpComponent.clearSearchField();
+				await supportSearchComponent.clearSearchField();
 
 				const emptyWhitespaceQuery = '         ';
 
-				await inlineHelpComponent.searchFor( emptyWhitespaceQuery );
+				await supportSearchComponent.searchFor( emptyWhitespaceQuery );
 
-				const searchPerformed = await inlineHelpComponent.isRequestingSearchResults();
+				const searchPerformed = await supportSearchComponent.isRequestingSearchResults();
 
 				assert.equal(
 					searchPerformed,
@@ -129,21 +133,21 @@ describe( `[${ host }] Accessing support search: (${ screenSize })`, async funct
 		} );
 	} );
 
-	describe( 'My Home support search card', function () {
-		// before( async function () {
-		// 	return await driverManager.ensureNotLoggedIn( driver );
-		// } );
-		step( 'Select the My Home page', async function () {
-			// const loginFlow = new LoginFlow( driver );
+	// describe( 'My Home support search card', function () {
+	// 	// before( async function () {
+	// 	// 	return await driverManager.ensureNotLoggedIn( driver );
+	// 	// } );
+	// 	step( 'Select the My Home page', async function () {
+	// 		// const loginFlow = new LoginFlow( driver );
 
-			const sidebarComponent = await SidebarComponent.Expect( driver );
-			// The "inline help" FAB sholuld not appear on the My Home
-			// because there is already a support search "Card" on that
-			// page. Therefore we select the "Themes" page for our tests.
-			// await loginFlow.loginAndSelectMySite();
-			await sidebarComponent.selectMyHome();
+	// 		const sidebarComponent = await SidebarComponent.Expect( driver );
+	// 		// The "inline help" FAB sholuld not appear on the My Home
+	// 		// because there is already a support search "Card" on that
+	// 		// page. Therefore we select the "Themes" page for our tests.
+	// 		// await loginFlow.loginAndSelectMySite();
+	// 		await sidebarComponent.selectMyHome();
 
-			return await driverHelper.isElementPresent( driver, By.css( '.card help-search' ) );
-		} );
-	} );
+	// 		return await driverHelper.isElementPresent( driver, By.css( '.card help-search' ) );
+	// 	} );
+	// } );
 } );

--- a/test/e2e/specs/wp-support-search.js
+++ b/test/e2e/specs/wp-support-search.js
@@ -94,9 +94,9 @@ describe( `[${ host }] Accessing support search: (${ screenSize })`, async funct
 			step( 'Resets search UI to default state when search input is cleared ', async function () {
 				await supportSearchComponent.clearSearchField();
 
-				// Once https://github.com/Automattic/wp-calypso/pull/43323 is merged this will work again
-				// const results = await supportSearchComponent.getSearchResults();
-				// assert.strictEqual( results.length, 5, 'There are no contextual results displayed' );
+				const resultsCount = await supportSearchComponent.getSearchResultsCount();
+
+				assert.equal( resultsCount, 5, 'There are no contextual results displayed' );
 			} );
 
 			step(

--- a/test/e2e/specs/wp-support-search.js
+++ b/test/e2e/specs/wp-support-search.js
@@ -11,7 +11,7 @@ import * as driverManager from '../lib/driver-manager.js';
 
 import LoginFlow from '../lib/flows/login-flow.js';
 import * as dataHelper from '../lib/data-helper';
-import InlineHelpComponent from '../lib/components/inline-help-component';
+import InlineHelpPopoverComponent from '../lib/components/inline-help-popover-component';
 import SupportSearchComponent from '../lib/components/support-search-component';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
@@ -21,7 +21,7 @@ const host = dataHelper.getJetpackHost();
 
 let driver;
 let supportSearchComponent;
-let inlineHelpComponent;
+let inlineHelpPopoverComponent;
 
 before( async function () {
 	this.timeout( startBrowserTimeoutMS );
@@ -42,29 +42,29 @@ describe( `[${ host }] Accessing support search: (${ screenSize })`, async funct
 
 			// Initialize the helper component
 
-			inlineHelpComponent = await InlineHelpComponent.Expect( driver );
+			inlineHelpPopoverComponent = await InlineHelpPopoverComponent.Expect( driver );
 		} );
 
 		describe( 'Popover UI visibility and interactions', function () {
 			step( 'Check help toggle is visible', async function () {
-				await inlineHelpComponent.isToggleVisible();
+				await inlineHelpPopoverComponent.isToggleVisible();
 			} );
 
 			step( 'Open Inline Help popover', async function () {
-				await inlineHelpComponent.toggleOpen();
-				return await inlineHelpComponent.isPopoverVisible();
+				await inlineHelpPopoverComponent.toggleOpen();
+				return await inlineHelpPopoverComponent.isPopoverVisible();
 			} );
 
 			step( 'Close Inline Help popover', async function () {
-				await inlineHelpComponent.toggleClosed();
-				const isPopoverVisible = await inlineHelpComponent.isPopoverVisible();
+				await inlineHelpPopoverComponent.toggleClosed();
+				const isPopoverVisible = await inlineHelpPopoverComponent.isPopoverVisible();
 				assert.equal( isPopoverVisible, false, 'Popover was not closed correctly.' );
 			} );
 		} );
 
 		describe( 'Performing searches', function () {
 			step( 'Re-open Inline Help popover', async function () {
-				await inlineHelpComponent.toggleOpen();
+				await inlineHelpPopoverComponent.toggleOpen();
 				supportSearchComponent = await SupportSearchComponent.Expect( driver );
 			} );
 

--- a/test/e2e/specs/wp-support-search.js
+++ b/test/e2e/specs/wp-support-search.js
@@ -35,7 +35,7 @@ describe( `[${ host }] Accessing support search: (${ screenSize })`, async funct
 		step( 'Login and select a non My Home page', async function () {
 			const loginFlow = new LoginFlow( driver );
 
-			// The "inline help" FAB sholuld not appear on the My Home
+			// The "inline help" FAB should not appear on the My Home
 			// because there is already a support search "Card" on that
 			// page. Therefore we select the "Themes" page for our tests.
 			await loginFlow.loginAndSelectThemes();

--- a/test/e2e/specs/wp-support-search.js
+++ b/test/e2e/specs/wp-support-search.js
@@ -132,22 +132,4 @@ describe( `[${ host }] Accessing support search: (${ screenSize })`, async funct
 			} );
 		} );
 	} );
-
-	// describe( 'My Home support search card', function () {
-	// 	// before( async function () {
-	// 	// 	return await driverManager.ensureNotLoggedIn( driver );
-	// 	// } );
-	// 	step( 'Select the My Home page', async function () {
-	// 		// const loginFlow = new LoginFlow( driver );
-
-	// 		const sidebarComponent = await SidebarComponent.Expect( driver );
-	// 		// The "inline help" FAB sholuld not appear on the My Home
-	// 		// because there is already a support search "Card" on that
-	// 		// page. Therefore we select the "Themes" page for our tests.
-	// 		// await loginFlow.loginAndSelectMySite();
-	// 		await sidebarComponent.selectMyHome();
-
-	// 		return await driverHelper.isElementPresent( driver, By.css( '.card help-search' ) );
-	// 	} );
-	// } );
 } );

--- a/test/e2e/specs/wp-support-search.js
+++ b/test/e2e/specs/wp-support-search.js
@@ -3,19 +3,17 @@
  */
 import config from 'config';
 import assert from 'assert';
-import { By } from 'selenium-webdriver';
 
 /**
  * Internal dependencies
  */
 import * as driverManager from '../lib/driver-manager.js';
-import * as driverHelper from '../lib/driver-helper.js';
 
 import LoginFlow from '../lib/flows/login-flow.js';
 import * as dataHelper from '../lib/data-helper';
 import InlineHelpComponent from '../lib/components/inline-help-component';
 import SupportSearchComponent from '../lib/components/support-search-component';
-import SidebarComponent from '../lib/components/sidebar-component.js';
+
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
 const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();

--- a/test/e2e/specs/wp-support-search.js
+++ b/test/e2e/specs/wp-support-search.js
@@ -52,7 +52,9 @@ describe( `[${ host }] Accessing support search: (${ screenSize })`, async funct
 
 			step( 'Open Inline Help popover', async function () {
 				await inlineHelpPopoverComponent.toggleOpen();
-				return await inlineHelpPopoverComponent.isPopoverVisible();
+
+				const isPopoverVisible = await inlineHelpPopoverComponent.isPopoverVisible();
+				assert.equal( isPopoverVisible, true, 'Popover was not opened correctly.' );
 			} );
 
 			step( 'Close Inline Help popover', async function () {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We do not currently have any tests to cover the support search functionality in:

* the "FAB" inline help popover.
* the "Get help" card on My Home.

This PR will **add e2e tests to cover the basic mechanics of the "FAB" inline search _only_**. This provides us with a solid foundation upon which to:

- refactor the "Get help" card to share components with the FAB implementation.
- refactor other aspects of the search components.
- add new functionality (such as being able to search site settings).

**Please note**: this only covers the FAB version as the My Home version is being refactored to use the same components we will wait until they are normalised before adding tests for My Home.

#### Testing instructions

* Configure the Calypso local e2e testing environment [as per the docs](https://github.com/Automattic/wp-calypso/blob/f35d4cc98655259e379fe220be9b9ecee6bac647/test/e2e/README.md).
* Boot Calypso locally - `yarn && yarn start`. Make sure it's running at `http://calypso.localhost:3000/`.
* Run the individual e2e test 
  - `cd` to the `test/e2e` directory.
  - run `./node_modules/.bin/mocha specs/wp-support-search`
* See tests run and verify they all pass.
* Do the same against tablet and mobile using following command syntax - `env BROWSERSIZE=mobile ./node_modules/.bin/mocha specs/wp-support-search`.
* Read through tests and check there are no missing scenarios that might be helpful to cover.

Fixes https://github.com/Automattic/wp-calypso/issues/43135
