### PR TITLE
Revert "Domains: Update multi level TLD list"

### DIFF
--- a/client/lib/domains/tlds/wpcom-multi-level-tlds.json
+++ b/client/lib/domains/tlds/wpcom-multi-level-tlds.json
@@ -1,14 +1,10 @@
 {
 	"co.in": 1,
-	"co.uk": 1,
 	"com.br": 0,
-	"com.mx": 1,
 	"firm.in": 1,
 	"gen.in": 1,
 	"ind.in": 1,
-	"me.uk": 1,
 	"net.br": 0,
 	"net.in": 1,
-	"org.in": 1,
-	"org.uk": 1
+	"org.in": 1
 }


### PR DESCRIPTION
Reverts Automattic/wp-calypso#43351

Looks like there's a bigger issue going on - this change prevented the .uk-specific extra contact form from showing up for .co.uk domains.