### PR TITLE
Fix wrong key being used for preferences state.

### DIFF
--- a/client/state/preferences/reducer.js
+++ b/client/state/preferences/reducer.js
@@ -99,5 +99,5 @@ const combinedReducer = combineReducers( {
 	fetching,
 	lastFetchedTimestamp,
 } );
-const preferencesReducer = withStorageKey( 'reader', combinedReducer );
+const preferencesReducer = withStorageKey( 'preferences', combinedReducer );
 export default preferencesReducer;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix wrong key being used for preferences state.

#### Testing instructions

Ensure preferences state gets serialised to its own key in IndexedDB.
