### PR TITLE
Remove is-wide-layout from the Backup/Scan upsell pages

### DIFF
--- a/client/my-sites/backup/wpcom-upsell.tsx
+++ b/client/my-sites/backup/wpcom-upsell.tsx
@@ -64,7 +64,7 @@ export default function WPCOMUpsellPage(): ReactElement {
 	}, [ planSlug ] );
 
 	return (
-		<Main className="backup__main backup__wpcom-upsell is-wide-layout">
+		<Main className="backup__main backup__wpcom-upsell">
 			<DocumentHead title="Jetpack Backup" />
 			<SidebarNavigation />
 			<PageViewTracker path="/backup/:site" title="Backup" />

--- a/client/my-sites/scan/wpcom-upsell.tsx
+++ b/client/my-sites/scan/wpcom-upsell.tsx
@@ -62,7 +62,7 @@ export default function WPCOMScanUpsellPage(): ReactElement {
 	}, [ planSlug ] );
 
 	return (
-		<Main className="scan__main scan__wpcom-upsell is-wide-layout">
+		<Main className="scan__main scan__wpcom-upsell">
 			<DocumentHead title="Scanner" />
 			<SidebarNavigation />
 			<PageViewTracker path="/scan/:site" title="Scanner" />


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Remove` is-wide-layout` class from the Backup/Scan upsell pages

Before:
![image](https://user-images.githubusercontent.com/9832440/84912001-d60b0300-b0b0-11ea-8276-7613e9b64624.png)

After:
![image](https://user-images.githubusercontent.com/9832440/84911914-bd9ae880-b0b0-11ea-8892-f6d6a98346c1.png)


#### Testing instructions

- Apply the changes and activate the flag `?flags=jetpack/features-section`
- Select a simple site with Free plan
- Go to Backup/Scan section and see that both upsell pages aren't wide.