### PR TITLE
i18n: Remove empathy mode control from site language picker

### DIFF
--- a/client/components/language-picker/index.jsx
+++ b/client/components/language-picker/index.jsx
@@ -12,6 +12,7 @@ import { find, isString, noop } from 'lodash';
 /**
  * Internal dependencies
  */
+import config from 'config';
 import LanguagePickerModal from './modal';
 import { requestGeoLocation } from 'state/data-getters';
 import { getLanguageCodeLabels } from './utils';
@@ -29,6 +30,7 @@ export class LanguagePicker extends PureComponent {
 		onChange: PropTypes.func,
 		onClick: PropTypes.func,
 		countryCode: PropTypes.string,
+		showEmpathyModeControl: PropTypes.bool,
 		empathyMode: PropTypes.bool,
 	};
 
@@ -38,6 +40,7 @@ export class LanguagePicker extends PureComponent {
 		onChange: noop,
 		onClick: noop,
 		countryCode: '',
+		showEmpathyModeControl: config.isEnabled( 'i18n/empathy-mode' ),
 		empathyMode: false,
 	};
 
@@ -131,7 +134,7 @@ export class LanguagePicker extends PureComponent {
 		if ( ! this.state.open ) {
 			return null;
 		}
-		const { countryCode, languages } = this.props;
+		const { countryCode, languages, showEmpathyModeControl } = this.props;
 		return (
 			<LanguagePickerModal
 				isVisible
@@ -140,6 +143,7 @@ export class LanguagePicker extends PureComponent {
 				onSelected={ this.selectLanguage }
 				selected={ selectedLanguageSlug }
 				countryCode={ countryCode }
+				showEmpathyModeControl={ showEmpathyModeControl }
 				empathyMode={ this.state.empathyMode }
 			/>
 		);

--- a/client/components/language-picker/modal.jsx
+++ b/client/components/language-picker/modal.jsx
@@ -51,6 +51,7 @@ export class LanguagePickerModal extends PureComponent {
 		languages: PropTypes.array.isRequired,
 		selected: PropTypes.string,
 		countryCode: PropTypes.string,
+		showEmpathyModeControl: PropTypes.bool,
 		empathyMode: PropTypes.bool,
 	};
 
@@ -61,6 +62,7 @@ export class LanguagePickerModal extends PureComponent {
 		isVisible: false,
 		selected: 'en',
 		countryCode: '',
+		showEmpathyModeControl: config.isEnabled( 'i18n/empathy-mode' ),
 		empathyMode: false,
 	};
 
@@ -459,7 +461,9 @@ export class LanguagePickerModal extends PureComponent {
 	}
 
 	renderEmpathyModeCheckbox() {
-		if ( ! config.isEnabled( 'i18n/empathy-mode' ) ) {
+		const { showEmpathyModeControl } = this.props;
+
+		if ( ! showEmpathyModeControl ) {
 			return null;
 		}
 

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -264,6 +264,7 @@ export class SiteSettingsFormGeneral extends Component {
 					onChange={ onChangeField( 'lang_id' ) }
 					disabled={ isRequestingSettings || ( siteIsJetpack && errorNotice ) }
 					onClick={ eventTracker( 'Clicked Language Field' ) }
+					showEmpathyModeControl={ false }
 				/>
 				<FormSettingExplanation>
 					{ translate( "The site's primary language." ) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove **Empathy mode** checkbox control from language picker modal in Site Settings section.

**Before:**
![image](https://user-images.githubusercontent.com/2722412/84912077-add7d000-b0c1-11ea-845b-d14ee72415dd.png)

**After:**
![image](https://user-images.githubusercontent.com/2722412/84912098-b3cdb100-b0c1-11ea-9b73-0233abd17c9b.png)

#### Testing instructions

1. Boot Calypso with `yarn start`
2. Confirm that language picker modal in [Account Settings](http://calypso.localhost:3000/me) shows **Empathy mode** checkbox.
3. Confirm that language picker modal in [Site Settings](http://calypso.localhost:3000/settings/general/) doesn't show **Empathy mode** checkbox.
