### PR TITLE
Domain Picker: Nudge hint tweaking.

### DIFF
--- a/client/landing/gutenboarding/components/action-buttons/style.scss
+++ b/client/landing/gutenboarding/components/action-buttons/style.scss
@@ -46,7 +46,7 @@ button.action_buttons__button.components-button {
 	}
 
 	&.action-buttons__back {
-		color: var( --studio-gray-60 );
+		color: var( --studio-gray-50 );
 		white-space: nowrap;
 		min-width: 0;
 		height: auto;

--- a/client/landing/gutenboarding/components/action-buttons/style.scss
+++ b/client/landing/gutenboarding/components/action-buttons/style.scss
@@ -46,7 +46,7 @@ button.action_buttons__button.components-button {
 	}
 
 	&.action-buttons__back {
-		color: var( --studio-gray-40 );
+		color: var( --studio-gray-60 );
 		white-space: nowrap;
 		min-width: 0;
 		height: auto;
@@ -56,15 +56,16 @@ button.action_buttons__button.components-button {
 		color: var( --studio-white );
 		box-shadow: 0 0 0 1px var( --studio-blue-40 );
 	}
+
 	&.action-buttons__skip {
-		color: var( --studio-gray-20 );
-		box-shadow: inset 0 0 0 1px var( --studio-gray-20 );
+		color: var( --studio-gray-50 );
+		box-shadow: inset 0 0 0 1px var( --studio-gray-50 );
 
 		&:active,
 		&:hover,
 		&:focus {
-			color: var( --studio-gray-30 );
-			box-shadow: inset 0 0 0 1px var( --studio-gray-30 );
+			color: var( --studio-gray-60 );
+			box-shadow: inset 0 0 0 1px var( --studio-gray-60 );
 		}
 	}
 

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
@@ -44,7 +44,7 @@ const SiteTitle: React.FunctionComponent< Props > = ( { onSubmit } ) => {
 
 	return (
 		<form
-			className={ classnames( 'site-title', { 'is-touched': isTouched, 'is-empty': ! siteTitle } ) }
+			className={ classnames( 'site-title', { 'is-touched': isTouched } ) }
 			onSubmit={ handleFormSubmit }
 		>
 			<label htmlFor="site-title__input" className="site-title__input-label">

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
@@ -23,7 +23,7 @@ const SiteTitle: React.FunctionComponent< Props > = ( { onSubmit } ) => {
 	const { __ } = useI18n();
 	const { siteTitle } = useSelect( ( select ) => select( STORE_KEY ).getState() );
 	const { setSiteTitle } = useDispatch( STORE_KEY );
-	const [ isFocused, setIsFocused ] = React.useState( false );
+	const [ isTouched, setIsTouched ] = React.useState( false );
 
 	const handleFormSubmit = ( e: React.FormEvent< HTMLFormElement > ) => {
 		// hitting 'Enter' when focused on the input field should direct to next step.
@@ -33,11 +33,10 @@ const SiteTitle: React.FunctionComponent< Props > = ( { onSubmit } ) => {
 
 	const handleBlur = () => {
 		recordSiteTitleSelection( !! siteTitle );
-		setIsFocused( false );
 	};
 
 	const handleFocus = () => {
-		setIsFocused( true );
+		setIsTouched( true );
 	};
 
 	// translators: label for site title input in Gutenboarding
@@ -45,7 +44,7 @@ const SiteTitle: React.FunctionComponent< Props > = ( { onSubmit } ) => {
 
 	return (
 		<form
-			className={ classnames( 'site-title', { 'is-focused': isFocused, 'is-empty': ! siteTitle } ) }
+			className={ classnames( 'site-title', { 'is-touched': isTouched, 'is-empty': ! siteTitle } ) }
 			onSubmit={ handleFormSubmit }
 		>
 			<label htmlFor="site-title__input" className="site-title__input-label">
@@ -66,7 +65,7 @@ const SiteTitle: React.FunctionComponent< Props > = ( { onSubmit } ) => {
 					data-hj-whitelist
 				></TextControl>
 				<p className="site-title__input-hint">
-					<Icon icon={ tip } size={ 14 } />
+					<Icon icon={ tip } size={ 18 } />
 					{ /* translators: The "it" here refers to the site title. */ }
 					<span>{ __( "Don't worry, you can change it later." ) }</span>
 				</p>

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
@@ -65,14 +65,14 @@
 
 .site-title__input-hint {
 	display: flex;
-	color: var( --studio-gray-20 );
+	color: var( --studio-gray-50 );
 	font-family: $default-font;
-	font-size: $default-font-size;
+	font-size: 14px;
 	line-height: 14px;
 	opacity: 0;
 	transition: opacity $acquire-intent-transition-duration $acquire-intent-transition-algorithm;
 
-	.site-title.is-focused.is-empty & {
+	.site-title.is-touched.is-empty & {
 		opacity: 1;
 		transition-delay: 3s;
 	}
@@ -83,10 +83,9 @@
 	}
 
 	svg {
-		align-self: center;
 		fill: var( --studio-yellow-30 );
-		flex-shrink: 0;
 		margin-right: $grid-unit-10;
+		margin-top: -2px;
 	}
 }
 

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
@@ -72,14 +72,9 @@
 	opacity: 0;
 	transition: opacity $acquire-intent-transition-duration $acquire-intent-transition-algorithm;
 
-	.site-title.is-touched.is-empty & {
+	.site-title.is-touched & {
 		opacity: 1;
 		transition-delay: 3s;
-	}
-
-	.site-title:not( .is-empty ) & {
-		opacity: 0;
-		transition-delay: 1s;
 	}
 
 	svg {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Nudge hint text color should be `studio-gray-50`.
* Nudge hint font size should be `14px`.
* Nudge hint icon should be `18px`.
* "Skip for now" button should be `studio-gray-50` on border and text color.
* "Skip for now" button should be `studio-gray-60` on border and text color on hover.
* "Go back" text link color should be `studio-gray-50` (to make it consistent with Skip button).
*  The nudge hint appears after 3 seconds of delay after loading the page. Doesn't matter if the input is focused or blurred.
* The nudge hint will not disappear after entering a site title value.

#### Testing instructions

Test if all the above requirements are met on `/new`.

Fixes https://github.com/Automattic/wp-calypso/issues/43383
