### PR TITLE
Choose the correct additional info TLD form for second level TLDs

### DIFF
--- a/client/components/domains/registrant-extra-info/index.jsx
+++ b/client/components/domains/registrant-extra-info/index.jsx
@@ -26,7 +26,7 @@ const tldSpecificForms = {
 	uk,
 };
 
-export const getApplicableAdditionalDetailsForms = ( tlds ) => {
+export const getApplicableTldsWithAdditionalDetailsForms = ( tlds ) => {
 	const topLevelTlds = tlds.map( getTopLevelOfTld );
 	return filter( keys( tldSpecificForms ), ( tldFormName ) => {
 		return (

--- a/client/components/domains/registrant-extra-info/index.jsx
+++ b/client/components/domains/registrant-extra-info/index.jsx
@@ -13,6 +13,7 @@ import config from 'config';
 import ca from './ca-form';
 import fr from './fr-form';
 import uk from './uk-form';
+import { getTopLevelOfTld } from 'lib/domains';
 
 /**
  * Style dependencies
@@ -25,17 +26,19 @@ const tldSpecificForms = {
 	uk,
 };
 
-const enabledTldForms = filter( keys( tldSpecificForms ), ( tld ) =>
-	config.isEnabled( `domains/cctlds/${ tld }` )
-);
-
-export const tldsWithAdditionalDetailsForms = enabledTldForms;
+export const getApplicableAdditionalDetailsForms = ( tlds ) => {
+	const topLevelTlds = tlds.map( getTopLevelOfTld );
+	return filter( keys( tldSpecificForms ), ( tldFormName ) => {
+		return (
+			config.isEnabled( `domains/cctlds/${ tldFormName }` ) && topLevelTlds.includes( tldFormName )
+		);
+	} );
+};
 
 export default class DomainDetailsForm extends PureComponent {
 	render() {
 		const { tld, ...props } = this.props;
-		const topLevelOfTld = tld.substring( tld.lastIndexOf( '.' ) + 1 );
-		const TldSpecificForm = tldSpecificForms[ topLevelOfTld ];
+		const TldSpecificForm = tldSpecificForms[ getTopLevelOfTld( tld ) ];
 
 		if ( ! TldSpecificForm ) {
 			throw new Error( 'unrecognized tld in extra info form:', tld );

--- a/client/lib/domains/tlds/wpcom-multi-level-tlds.json
+++ b/client/lib/domains/tlds/wpcom-multi-level-tlds.json
@@ -1,10 +1,14 @@
 {
 	"co.in": 1,
+	"co.uk": 1,
 	"com.br": 0,
+	"com.mx": 1,
 	"firm.in": 1,
 	"gen.in": 1,
 	"ind.in": 1,
+	"me.uk": 1,
 	"net.br": 0,
 	"net.in": 1,
-	"org.in": 1
+	"org.in": 1,
+	"org.uk": 1
 }

--- a/client/my-sites/checkout/checkout/domain-details-form.jsx
+++ b/client/my-sites/checkout/checkout/domain-details-form.jsx
@@ -21,7 +21,7 @@ import wp from 'lib/wp';
 import config from 'config';
 import ContactDetailsFormFields from 'components/domains/contact-details-form-fields';
 import ExtraInfoForm, {
-	getApplicableAdditionalDetailsForms,
+	getApplicableTldsWithAdditionalDetailsForms,
 } from 'components/domains/registrant-extra-info';
 import { setDomainDetails } from 'lib/transaction/actions';
 import { addGoogleAppsRegistrationData } from 'lib/cart/actions';
@@ -156,7 +156,7 @@ export class DomainDetailsForm extends PureComponent {
 			// All we need to do to disable everything is not show the .FR form
 			return [];
 		}
-		return getApplicableAdditionalDetailsForms( getTlds( this.props.cart ) );
+		return getApplicableTldsWithAdditionalDetailsForms( getTlds( this.props.cart ) );
 	}
 
 	needsFax() {
@@ -237,7 +237,7 @@ export class DomainDetailsForm extends PureComponent {
 
 	renderCurrentForm() {
 		const { currentStep } = this.state;
-		return ! isEmpty( getApplicableAdditionalDetailsForms( [ currentStep ] ) )
+		return ! isEmpty( getApplicableTldsWithAdditionalDetailsForms( [ currentStep ] ) )
 			? this.renderExtraDetailsForm( this.state.currentStep )
 			: this.renderDetailsForm();
 	}

--- a/client/my-sites/checkout/checkout/domain-details-form.jsx
+++ b/client/my-sites/checkout/checkout/domain-details-form.jsx
@@ -6,7 +6,7 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
 import debugFactory from 'debug';
-import { first, includes, indexOf, intersection, isEqual, last, map, merge } from 'lodash';
+import { first, indexOf, isEmpty, isEqual, last, map, merge } from 'lodash';
 import emailValidator from 'email-validator';
 
 /**
@@ -21,7 +21,7 @@ import wp from 'lib/wp';
 import config from 'config';
 import ContactDetailsFormFields from 'components/domains/contact-details-form-fields';
 import ExtraInfoForm, {
-	tldsWithAdditionalDetailsForms,
+	getApplicableAdditionalDetailsForms,
 } from 'components/domains/registrant-extra-info';
 import { setDomainDetails } from 'lib/transaction/actions';
 import { addGoogleAppsRegistrationData } from 'lib/cart/actions';
@@ -156,7 +156,7 @@ export class DomainDetailsForm extends PureComponent {
 			// All we need to do to disable everything is not show the .FR form
 			return [];
 		}
-		return intersection( getTlds( this.props.cart ), tldsWithAdditionalDetailsForms );
+		return getApplicableAdditionalDetailsForms( getTlds( this.props.cart ) );
 	}
 
 	needsFax() {
@@ -237,7 +237,7 @@ export class DomainDetailsForm extends PureComponent {
 
 	renderCurrentForm() {
 		const { currentStep } = this.state;
-		return includes( tldsWithAdditionalDetailsForms, currentStep )
+		return ! isEmpty( getApplicableAdditionalDetailsForms( [ currentStep ] ) )
 			? this.renderExtraDetailsForm( this.state.currentStep )
 			: this.renderDetailsForm();
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This fixes what https://github.com/Automattic/wp-calypso/pull/43351 was aiming to, as well as the bug that was uncovered because of it (and probably dating all the way back to https://github.com/Automattic/wp-calypso/pull/20750?), which was the reason for the revert in https://github.com/Automattic/wp-calypso/pull/43384

#### Testing instructions

Go to Domain Managment -> Add domain. Try with a regular gTLD, like .com and .blog, you should have normal checkout.
Now, try with a ccTLD that requires additional info, like `.uk`, `.co.uk`, `.ca`, `.fr` - you should have an additional step in the checkout process.

Please also follow the testing instructions from https://github.com/Automattic/wp-calypso/pull/43351 to make sure that issue is fixed as well.
