### PR TITLE
Check for domain connect record with or without double-quotes

### DIFF
--- a/client/my-sites/domains/domain-management/dns/dns-list.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-list.jsx
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 import React, { Fragment } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import { trim } from 'lodash';
 
 /**
  * Internal dependencies
@@ -106,7 +107,7 @@ class DnsList extends React.Component {
 	isDomainConnectRecord( dnsRecord ) {
 		return (
 			domainConnect.DISCOVERY_TXT_RECORD_NAME === dnsRecord.name &&
-			domainConnect.API_URL === dnsRecord.data &&
+			domainConnect.API_URL === trim( dnsRecord.data, '"' ) &&
 			'TXT' === dnsRecord.type
 		);
 	}

--- a/client/my-sites/domains/domain-management/dns/index.jsx
+++ b/client/my-sites/domains/domain-management/dns/index.jsx
@@ -68,11 +68,17 @@ class Dns extends React.Component {
 		const { dns, selectedDomainName, selectedSite, translate } = this.props;
 		const domain = getSelectedDomain( this.props );
 		const hasWpcomNameservers = domain?.hasWpcomNameservers ?? false;
-		const domainConnectEnabled = some( dns.records, {
-			name: domainConnect.DISCOVERY_TXT_RECORD_NAME,
-			data: domainConnect.API_URL,
-			type: 'TXT',
-		} );
+		const domainConnectEnabled =
+			some( dns.records, {
+				name: domainConnect.DISCOVERY_TXT_RECORD_NAME,
+				data: domainConnect.API_URL,
+				type: 'TXT',
+			} ) ||
+			some( dns.records, {
+				name: domainConnect.DISCOVERY_TXT_RECORD_NAME,
+				data: '"' + domainConnect.API_URL + '"',
+				type: 'TXT',
+			} );
 
 		return (
 			<Main className="dns">


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When checking for the presence of the domain connect TXT record, we need to allow for the case where the rdata is surrounded by double-quotes and where it is not. This is due to changes being made on the back-end of WPCOM: p3topS-L4-p2

#### Testing instructions

TBD
