### PR TITLE
Move `ui/comments` state to `comments/ui`

### DIFF
--- a/client/state/comments/reducer.js
+++ b/client/state/comments/reducer.js
@@ -47,6 +47,7 @@ import {
 	POST_COMMENT_DISPLAY_TYPES,
 } from './constants';
 import trees from './trees/reducer';
+import ui from './ui/reducer';
 import { getStateKey, getErrorKey, commentHasLink, getCommentDate } from './utils';
 
 const isCommentManagementEdit = ( newProperties ) =>
@@ -539,6 +540,7 @@ const combinedReducer = combineReducers( {
 	trees,
 	treesInitialized,
 	activeReplies,
+	ui,
 } );
 const commentsReducer = withStorageKey( 'comments', combinedReducer );
 export default commentsReducer;

--- a/client/state/comments/ui/actions.js
+++ b/client/state/comments/ui/actions.js
@@ -3,6 +3,8 @@
  */
 import { COMMENTS_QUERY_UPDATE } from 'state/action-types';
 
+import 'state/comments/init';
+
 /**
  * Creates an action that updates the comments pagination for the given site and filters.
  *

--- a/client/state/comments/ui/reducer.js
+++ b/client/state/comments/ui/reducer.js
@@ -14,7 +14,7 @@ import {
 	COMMENTS_TREE_SITE_REQUEST,
 } from 'state/action-types';
 import { combineReducers, keyedReducer } from 'state/utils';
-import { getFiltersKey } from 'state/ui/comments/utils';
+import { getFiltersKey } from 'state/comments/ui/utils';
 import { getRequestKey } from 'state/data-layer/wpcom-http/utils';
 
 const deepUpdateComments = ( state, comments, query ) => {
@@ -60,7 +60,7 @@ const sortAscending = function ( a, b ) {
 export const queries = ( state = {}, action ) => {
 	switch ( action.type ) {
 		case COMMENTS_CHANGE_STATUS:
-		case COMMENTS_DELETE:
+		case COMMENTS_DELETE: {
 			const query = action.refreshCommentListQuery
 				? action.refreshCommentListQuery
 				: get( action, 'meta.comment.commentsListQuery' );
@@ -93,6 +93,7 @@ export const queries = ( state = {}, action ) => {
 				return deepUpdateComments( state, sortedList, query );
 			}
 			return deepUpdateComments( state, without( comments, action.commentId ), query );
+		}
 		case COMMENTS_QUERY_UPDATE:
 			return isUndefined( get( action, 'query.page' ) )
 				? state
@@ -105,12 +106,13 @@ export const queries = ( state = {}, action ) => {
 export const pendingActions = function ( state = [], action ) {
 	switch ( action.type ) {
 		case COMMENTS_CHANGE_STATUS:
-		case COMMENTS_DELETE:
+		case COMMENTS_DELETE: {
 			const key = getRequestKey( action );
 			if ( has( action, 'meta.dataLayer.trackRequest' ) && state.indexOf( key ) === -1 ) {
 				return [ ...state, key ];
 			}
 			return state;
+		}
 		case COMMENTS_LIST_REQUEST:
 		case COMMENTS_TREE_SITE_REQUEST:
 			//ignore pending requests if we're looking at a fresh view

--- a/client/state/comments/ui/test/actions.js
+++ b/client/state/comments/ui/test/actions.js
@@ -7,7 +7,7 @@ import { expect } from 'chai';
  * Internal dependencies
  */
 import { COMMENTS_QUERY_UPDATE } from 'state/action-types';
-import { updateCommentsQuery } from 'state/ui/comments/actions';
+import { updateCommentsQuery } from 'state/comments/ui/actions';
 
 describe( 'actions', () => {
 	describe( '#updateCommentsQuery()', () => {

--- a/client/state/comments/ui/test/reducer.js
+++ b/client/state/comments/ui/test/reducer.js
@@ -12,7 +12,7 @@ import {
 	COMMENTS_QUERY_UPDATE,
 	COMMENTS_LIST_REQUEST,
 } from 'state/action-types';
-import { queries, pendingActions } from 'state/ui/comments/reducer';
+import { queries, pendingActions } from 'state/comments/ui/reducer';
 import { getRequestKey } from 'state/data-layer/wpcom-http/utils';
 
 const siteId = 12345678;

--- a/client/state/comments/ui/utils.js
+++ b/client/state/comments/ui/utils.js
@@ -4,8 +4,8 @@
 import { includes } from 'lodash';
 
 /**
- * Creates a filters key to be used in the `ui.comments.queries` state.
- * E.g. `ui.comments.queries.${ siteId }.${ postId }.${ 'approved?s=foo' }.${ page }`
+ * Creates a filters key to be used in the `comments.ui.queries` state.
+ * E.g. `comments.ui.queries.${ siteId }.${ postId }.${ 'approved?s=foo' }.${ page }`
  *
  * @param {object} query Filter parameters.
  * @param {string} [query.order] Query order ('ASC' or 'DESC').
@@ -18,6 +18,6 @@ export const getFiltersKey = ( { order = 'DESC', search, status = 'all' } ) => {
 	const orderFilter = includes( [ 'ASC', 'DESC' ], caseInsensitiveOrder )
 		? caseInsensitiveOrder
 		: 'DESC';
-	const searchFilter = !! search ? `&s=${ search }` : '';
+	const searchFilter = search ? `&s=${ search }` : '';
 	return `${ status }?order=${ orderFilter }${ searchFilter }`;
 };

--- a/client/state/data-layer/wpcom/sites/comments/index.js
+++ b/client/state/data-layer/wpcom/sites/comments/index.js
@@ -31,7 +31,7 @@ import {
 	requestComment as requestCommentAction,
 	requestCommentsList,
 } from 'state/comments/actions';
-import { updateCommentsQuery } from 'state/ui/comments/actions';
+import { updateCommentsQuery } from 'state/comments/ui/actions';
 import { noRetry } from 'state/data-layer/wpcom-http/pipeline/retry-on-failure/policies';
 
 import { registerHandlers } from 'state/data-layer/handler-registry';

--- a/client/state/selectors/get-comments-page.js
+++ b/client/state/selectors/get-comments-page.js
@@ -1,13 +1,14 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import { getFiltersKey } from 'state/ui/comments/utils';
+import { getFiltersKey } from 'state/comments/ui/utils';
+
+import 'state/comments/init';
 
 /**
  * Returns a list of comment IDs for the requested page and filters.
@@ -26,7 +27,7 @@ export const getCommentsPage = ( state, siteId, query ) => {
 	const { page = 1, postId } = query;
 	const parent = postId || 'site';
 	const filter = getFiltersKey( query );
-	return get( state, [ 'ui', 'comments', 'queries', siteId, parent, filter, page ] );
+	return get( state, [ 'comments', 'ui', 'queries', siteId, parent, filter, page ] );
 };
 
 export default getCommentsPage;

--- a/client/state/selectors/has-pending-comment-requests.js
+++ b/client/state/selectors/has-pending-comment-requests.js
@@ -4,13 +4,18 @@
 import { get, some } from 'lodash';
 
 /**
+ * Internal dependencies
+ */
+import 'state/comments/init';
+
+/**
  * Returns true if we have any pending comment actions that we are tracking.
  *
  * @param {object} state - global application state
  * @returns {boolean} - true if we have pending actions
  */
 export default ( state ) => {
-	const pendingActions = get( state, 'ui.comments.pendingActions' );
+	const pendingActions = get( state, [ 'comments', 'ui', 'pendingActions' ] );
 	return some( pendingActions, ( requestKey ) => {
 		return get( state, [ 'dataRequests', requestKey, 'status' ] ) === 'pending';
 	} );

--- a/client/state/selectors/test/get-comments-page.js
+++ b/client/state/selectors/test/get-comments-page.js
@@ -13,8 +13,8 @@ const POST_ID = 1234;
 
 describe( 'getCommentsPage()', () => {
 	const state = {
-		ui: {
-			comments: {
+		comments: {
+			ui: {
 				queries: {
 					[ SITE_ID ]: {
 						site: {

--- a/client/state/selectors/test/has-pending-comment-requests.js
+++ b/client/state/selectors/test/has-pending-comment-requests.js
@@ -34,7 +34,7 @@ const actionKey2 = getRequestKey( {
 describe( 'hasPendingCommentRequests()', () => {
 	test( 'should return true if we have pending actions', () => {
 		const state = deepFreeze( {
-			ui: { comments: { pendingActions: [ actionKey, actionKey2 ] } },
+			comments: { ui: { pendingActions: [ actionKey, actionKey2 ] } },
 			dataRequests: {
 				[ actionKey ]: { status: 'success' },
 				[ actionKey2 ]: { status: 'pending' },
@@ -44,7 +44,7 @@ describe( 'hasPendingCommentRequests()', () => {
 	} );
 	test( 'should return false if do not have pending actions', () => {
 		const state = deepFreeze( {
-			ui: { comments: { pendingActions: [ actionKey, actionKey2 ] } },
+			comments: { ui: { pendingActions: [ actionKey, actionKey2 ] } },
 			dataRequests: {
 				[ actionKey ]: { status: 'success' },
 				[ actionKey2 ]: { status: 'success' },
@@ -54,7 +54,7 @@ describe( 'hasPendingCommentRequests()', () => {
 	} );
 	test( 'only checks against actions we track in ui state', () => {
 		const state = deepFreeze( {
-			ui: { comments: { pendingActions: [ actionKey ] } },
+			comments: { ui: { pendingActions: [ actionKey ] } },
 			dataRequests: {
 				[ actionKey ]: { status: 'success' },
 				[ actionKey2 ]: { status: 'pending' },

--- a/client/state/ui/reducer.js
+++ b/client/state/ui/reducer.js
@@ -10,7 +10,6 @@ import {
 import { combineReducers, withoutPersistence } from 'state/utils';
 import actionLog from './action-log/reducer';
 import checkout from './checkout/reducer';
-import comments from './comments/reducer';
 import guidedTour from './guided-tours/reducer';
 import editorDeprecationDialog from './editor-deprecation-dialog/reducer';
 import gutenbergOptInDialog from './gutenberg-opt-in-dialog/reducer';
@@ -94,7 +93,6 @@ export const isNotificationsOpen = function ( state = false, { type } ) {
 const reducer = combineReducers( {
 	actionLog,
 	checkout,
-	comments,
 	editorDeprecationDialog,
 	guidedTour,
 	gutenbergOptInDialog,


### PR DESCRIPTION
There's no good reason for placing comment-related UI code under the `ui` sub-tree anymore. With modularisation, it now makes more sense for it to live with the rest of comments state.

Note: I added all the reviewers that GitHub suggested. Please feel free to ignore the review request or pull in someone else if you're not comfortable reviewing this PR. Thank you!

#### Changes proposed in this Pull Request

* Move `ui/comments` state to `comments/ui`
* Update all consumers accordingly
* Minor lint fixes

#### Testing instructions

Ensure that comments functionality continues to work correctly, in `My Sites` -> `Site` -> `Comments`.
