### PR TITLE
Remove jetpack/scan from WPCOM sites

### DIFF
--- a/client/components/jetpack/sidebar/menu-items/index.jsx
+++ b/client/components/jetpack/sidebar/menu-items/index.jsx
@@ -16,6 +16,8 @@ import getSelectedSiteId from 'state/ui/selectors/get-selected-site-id';
 import getSelectedSiteSlug from 'state/ui/selectors/get-selected-site-slug';
 import getSiteScanProgress from 'state/selectors/get-site-scan-progress';
 import getSiteScanThreats from 'state/selectors/get-site-scan-threats';
+import isJetpackSite from 'state/sites/selectors/is-jetpack-site';
+import isWpcomAtomic from 'state/selectors/is-site-wpcom-atomic';
 import QueryScanState from 'components/data/query-jetpack-scan';
 import ScanBadge from 'components/jetpack/scan-badge';
 import SidebarItem from 'layout/sidebar/item';
@@ -26,8 +28,12 @@ export default ( { path, showIcons, tracksEventNames, expandSection } ) => {
 	const siteId = useSelector( getSelectedSiteId );
 	const siteSlug = useSelector( getSelectedSiteSlug ) ?? '';
 
+	const isAtomic = useSelector( ( state ) => isWpcomAtomic( state, siteId ) );
+	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
 	const scanProgress = useSelector( ( state ) => getSiteScanProgress( state, siteId ) );
 	const scanThreats = useSelector( ( state ) => getSiteScanThreats( state, siteId ) );
+
+	const isWPCOM = ! isJetpack || isAtomic;
 
 	const onNavigate = ( event ) => () => {
 		dispatch( recordTracksEvent( event ) );
@@ -59,17 +65,19 @@ export default ( { path, showIcons, tracksEventNames, expandSection } ) => {
 				selected={ currentPathMatches( backupPath( siteSlug ) ) }
 				expandSection={ expandSection }
 			/>
-			<SidebarItem
-				materialIcon={ showIcons ? 'security' : undefined }
-				materialIconStyle="filled"
-				label="Scan"
-				link={ scanPath( siteSlug ) }
-				onNavigate={ onNavigate( tracksEventNames.scanClicked ) }
-				selected={ currentPathMatches( scanPath( siteSlug ) ) }
-				expandSection={ expandSection }
-			>
-				<ScanBadge progress={ scanProgress } numberOfThreatsFound={ scanThreats?.length ?? 0 } />
-			</SidebarItem>
+			{ ! isWPCOM && (
+				<SidebarItem
+					materialIcon={ showIcons ? 'security' : undefined }
+					materialIconStyle="filled"
+					label="Scan"
+					link={ scanPath( siteSlug ) }
+					onNavigate={ onNavigate( tracksEventNames.scanClicked ) }
+					selected={ currentPathMatches( scanPath( siteSlug ) ) }
+					expandSection={ expandSection }
+				>
+					<ScanBadge progress={ scanProgress } numberOfThreatsFound={ scanThreats?.length ?? 0 } />
+				</SidebarItem>
+			) }
 		</>
 	);
 };

--- a/client/components/jetpack/sidebar/menu-items/index.jsx
+++ b/client/components/jetpack/sidebar/menu-items/index.jsx
@@ -16,8 +16,7 @@ import getSelectedSiteId from 'state/ui/selectors/get-selected-site-id';
 import getSelectedSiteSlug from 'state/ui/selectors/get-selected-site-slug';
 import getSiteScanProgress from 'state/selectors/get-site-scan-progress';
 import getSiteScanThreats from 'state/selectors/get-site-scan-threats';
-import isJetpackSite from 'state/sites/selectors/is-jetpack-site';
-import isWpcomAtomic from 'state/selectors/is-site-wpcom-atomic';
+import getIsSiteWPCOM from 'state/selectors/is-site-wpcom';
 import QueryScanState from 'components/data/query-jetpack-scan';
 import ScanBadge from 'components/jetpack/scan-badge';
 import SidebarItem from 'layout/sidebar/item';
@@ -28,12 +27,9 @@ export default ( { path, showIcons, tracksEventNames, expandSection } ) => {
 	const siteId = useSelector( getSelectedSiteId );
 	const siteSlug = useSelector( getSelectedSiteSlug ) ?? '';
 
-	const isAtomic = useSelector( ( state ) => isWpcomAtomic( state, siteId ) );
-	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
+	const isWPCOM = useSelector( ( state ) => getIsSiteWPCOM( state, siteId ) );
 	const scanProgress = useSelector( ( state ) => getSiteScanProgress( state, siteId ) );
 	const scanThreats = useSelector( ( state ) => getSiteScanThreats( state, siteId ) );
-
-	const isWPCOM = ! isJetpack || isAtomic;
 
 	const onNavigate = ( event ) => () => {
 		dispatch( recordTracksEvent( event ) );

--- a/client/my-sites/scan/index.js
+++ b/client/my-sites/scan/index.js
@@ -21,13 +21,15 @@ import {
 } from 'my-sites/scan/controller';
 import WPCOMScanUpsellPage from 'my-sites/scan/wpcom-upsell';
 import WPCOMBusinessAT from 'components/jetpack/wpcom-business-at';
+import getIsSiteWPCOM from 'state/selectors/is-site-wpcom';
 
 const notFoundIfNotEnabled = ( context, next ) => {
 	const state = context.store.getState();
 	const siteId = getSelectedSiteId( state );
 	const showJetpackSection = isJetpackSectionEnabledForSite( state, siteId );
+	const isWPCOMSite = getIsSiteWPCOM( state, siteId );
 
-	if ( ! isJetpackCloud() && ! showJetpackSection ) {
+	if ( isWPCOMSite || ( ! isJetpackCloud() && ! showJetpackSection ) ) {
 		return notFound( context, next );
 	}
 

--- a/client/state/selectors/is-site-wpcom.js
+++ b/client/state/selectors/is-site-wpcom.js
@@ -16,5 +16,8 @@ import isJetpackSite from 'state/sites/selectors/is-jetpack-site';
 export default createSelector(
 	( state, siteId = getSelectedSiteId( state ) ) =>
 		! isJetpackSite( state, siteId ) || isAtomicSite( state, siteId ),
-	[ isAtomicSite, isJetpackSite ]
+	( state, siteId = getSelectedSiteId( state ) ) => [
+		isJetpackSite( state, siteId ),
+		isAtomicSite( state, siteId ),
+	]
 );

--- a/client/state/selectors/is-site-wpcom.js
+++ b/client/state/selectors/is-site-wpcom.js
@@ -1,0 +1,20 @@
+/**
+ * Internal dependencies
+ */
+import createSelector from 'lib/create-selector';
+import getSelectedSiteId from 'state/ui/selectors/get-selected-site-id';
+import isAtomicSite from 'state/selectors/is-site-automated-transfer';
+import isJetpackSite from 'state/sites/selectors/is-jetpack-site';
+
+/**
+ * Return true if the questioned site is a WPCOM site ( Atomic or Simple ).
+ *
+ * @param {object} state the global state tree
+ * @param {number} siteId the questioned site ID.
+ * @returns {boolean} Whether the site is a WPCOM site ( Atomic or Simple ).
+ */
+export default createSelector(
+	( state, siteId = getSelectedSiteId( state ) ) =>
+		! isJetpackSite( state, siteId ) || isAtomicSite( state, siteId ),
+	[ isAtomicSite, isJetpackSite ]
+);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Hide scan section in new jetpack menu for WPCOM sites

#### Testing instructions

* Navigate to Calypso & activate the jetpack features section
* Verify the scan section does not appear for any WPCOM site 
