### PR TITLE
Typography: Update devdocs with recent changes

### DIFF
--- a/client/assets/stylesheets/shared/_typography.scss
+++ b/client/assets/stylesheets/shared/_typography.scss
@@ -45,9 +45,13 @@ $root-font-size: 16px;
 
 // Typography size variables
 
+$font-headline-large: rem( 54px );
+$font-headline-medium: rem( 48px );
+$font-headline-small: rem( 36px );
 $font-title-large: rem( 32px );
 $font-title-medium: rem( 24px );
 $font-title-small: rem( 20px );
 $font-body: rem( 16px );
 $font-body-small: rem( 14px );
 $font-body-extra-small: rem( 12px );
+$font-code: rem( 15px );

--- a/client/devdocs/design/typography.jsx
+++ b/client/devdocs/design/typography.jsx
@@ -21,8 +21,8 @@ export default class Typography extends React.PureComponent {
 
 				<div className="design__typography-content devdocs__doc-content">
 					<h1>Typography</h1>
-					<h2>Interface Typography</h2>
 
+					<h2>Interface Typography</h2>
 					<p>
 						We use sans-serif system fonts with weights of 400 or greater as the default for UI.
 						This includes UI elements like buttons, notices, and navigation. System fonts improve
@@ -57,7 +57,7 @@ export default class Typography extends React.PureComponent {
 							{ '\n\t' }
 							font-family: $sans;
 							{ '\n\t' }
-							font-size: 16px;
+							font-size: $font-body;
 							{ '\n\t' }
 							font-weight: 400;
 							{ '\n\t' }
@@ -70,8 +70,8 @@ export default class Typography extends React.PureComponent {
 					<h2>Content Typography</h2>
 					<p>
 						We mostly use <code>Noto Serif</code> with weights of 400 or greater in reading and
-						writing contexts, like the Reader and the editor. Use your best judgment when using Noto
-						Serif for a UI element. Does it add valuable context for the person using our products?
+						writing contexts, like the Reader. Use your best judgment when using Noto Serif for a UI
+						element. Does it add valuable context for the person using our products?
 					</p>
 
 					<Card className="design__typography-content-example">
@@ -100,6 +100,38 @@ export default class Typography extends React.PureComponent {
 						</code>
 					</pre>
 
+					<h2>Brand Typography</h2>
+
+					<p>
+						We use Recoleta sparingly to add our brand's flavor to select headings. Since this font
+						is not compatible with some languages, we use a special class that targets specific
+						locales, and falls back to the <code>$serif</code> stack when necessary.
+					</p>
+
+					<h3>How to use:</h3>
+
+					<p>
+						Extend the <code>.wp-brand-font</code> selector in your SCSS:
+					</p>
+
+					<pre>
+						<code>
+							.design__typography-branded &#123;
+							{ '\n\t' }
+							@extend .wp-brand-font;
+							{ '\n\t' }
+							font-size: $font-title-medium;
+							{ '\n' }
+							&#125;
+						</code>
+					</pre>
+
+					<p>Or add the class directly to the element on which you want the brand font to show:</p>
+
+					<pre>
+						<code>&#60;h1 className="wp-brand-font"&#62;Branded heading&#60;/h1&#62;</code>
+					</pre>
+
 					<h2>Code Typography</h2>
 
 					<p>We use monospace fonts for code blocks, sized at 15px.</p>
@@ -122,66 +154,96 @@ export default class Typography extends React.PureComponent {
 							{ '\n\t' }
 							font-family: $code;
 							{ '\n\t' }
-							font-size: 15px;
+							font-size: $font-code;
 							{ '\n' }
 							&#125;
 						</code>
 					</pre>
 
-					<h2>Typographic Modular Scale</h2>
+					<h2>Typographic Scale</h2>
 
 					<p>
 						A harmonic ratio helps in creating a more harmonious design. If we use the same scale
 						across WordPress.com, things feel more cohesive — it’s as much about consistency as it
-						is about harmony. Instead of using arbitrary numbers, we conform to a harmonic scale.
+						is about harmony. Instead of using arbitrary numbers, we conform to the WordPress core
+						typescale.
 					</p>
 
+					<h3>How to use:</h3>
+
 					<p>
-						We use a double-stranded Perfect Fifth scale, based on the ideal text size of 16px and a
-						secondary important number of 14px. We round the values to the nearest pixel for ease of
-						use. That gives us the following scale:
+						The following variables adhere to the type scale and save you from having to calculate
+						the corresponding ems or rems:
 					</p>
 
 					<table className="design__typography-modular-scale">
 						<tbody>
 							<tr>
+								<th>Sass Variable</th>
 								<th>Pixels</th>
-								<th>Ems</th>
+								<th>Rems</th>
 							</tr>
 							<tr>
+								<td>
+									<code>$font-headline-large</code>
+								</td>
 								<td>54</td>
 								<td>3.375</td>
 							</tr>
 							<tr>
-								<td>47</td>
-								<td>2.953</td>
+								<td>
+									<code>$font-headline-medium</code>
+								</td>
+								<td>48</td>
+								<td>3</td>
 							</tr>
 							<tr>
+								<td>
+									<code>$font-headline-small</code>
+								</td>
 								<td>36</td>
 								<td>2.25</td>
 							</tr>
 							<tr>
+								<td>
+									<code>$font-title-large</code>
+								</td>
 								<td>32</td>
-								<td>1.969</td>
+								<td>2</td>
 							</tr>
 							<tr>
+								<td>
+									<code>$font-title-medium</code>
+								</td>
 								<td>24</td>
 								<td>1.5</td>
 							</tr>
 							<tr>
-								<td>21</td>
+								<td>
+									<code>$font-title-small</code>
+								</td>
+								<td>20</td>
 								<td>1.313</td>
 							</tr>
 							<tr>
+								<td>
+									<code>$font-body</code>
+								</td>
 								<td>16</td>
 								<td>1</td>
 							</tr>
 							<tr>
+								<td>
+									<code>$font-body-small</code>
+								</td>
 								<td>14</td>
 								<td>0.875</td>
 							</tr>
 							<tr>
-								<td>11</td>
+								<td>
+									<code>$font-body-extra-small</code>
+								</td>
+								<td>12</td>
 								<td>0.667</td>
 							</tr>
 						</tbody>

--- a/client/devdocs/style.scss
+++ b/client/devdocs/style.scss
@@ -472,7 +472,16 @@ $devdocs-max-width: 720px;
 }
 
 .design__typography-modular-scale {
-	max-width: 150px;
+	max-width: 400px;
+
+	th {
+		padding: 5px 0;
+	}
+
+	td {
+		border-top: 1px solid var( --color-neutral-10 );
+		padding: 5px 0;
+	}
 }
 
 // At the top of documentation and readme's


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update `/devdocs/typography` to address recent addition of brand font, font size variables.
* Also adds font size variables for larger font sizes to be converted in the future, as well as the code font size.

Before

<img width="826" alt="Screen Shot 2020-06-17 at 3 40 02 PM" src="https://user-images.githubusercontent.com/2124984/84942442-d6a39980-b0b0-11ea-9437-8571e4d2106a.png">

After

<img width="792" alt="Screen Shot 2020-06-17 at 3 45 27 PM" src="https://user-images.githubusercontent.com/2124984/84942917-97297d00-b0b1-11ea-8818-bb5a26385f63.png">
<img width="840" alt="Screen Shot 2020-06-17 at 3 45 09 PM" src="https://user-images.githubusercontent.com/2124984/84942923-998bd700-b0b1-11ea-8f97-63bd980cfe40.png">

#### Testing instructions

* Switch to this PR
* Navigate to `/devdocs/typography` and check out the changes
