### PR TITLE
Checkout: Make sure PayPalButtonContents always returns a component

### DIFF
--- a/packages/composite-checkout/src/lib/payment-methods/paypal.js
+++ b/packages/composite-checkout/src/lib/payment-methods/paypal.js
@@ -95,15 +95,15 @@ export function PaypalSubmitButton( { disabled } ) {
 function PayPalButtonContents( { formStatus, transactionStatus } ) {
 	const { __ } = useI18n();
 	if ( transactionStatus === 'redirecting' ) {
-		return __( 'Redirecting to PayPal…' );
+		return <span>{ __( 'Redirecting to PayPal…' ) }</span>;
 	}
 	if ( formStatus === 'submitting' ) {
-		return __( 'Processing…' );
+		return <span>{ __( 'Processing…' ) }</span>;
 	}
 	if ( formStatus === 'ready' ) {
 		return <ButtonPayPalIcon />;
 	}
-	return __( 'Please wait…' );
+	return <span>{ __( 'Please wait…' ) }</span>;
 }
 
 const ButtonPayPalIcon = styled( PaypalLogo )`


### PR DESCRIPTION
This may not be necessary, but we have seen strange errors where React
seems to be getting confused about the contents of the DOM when removing
nodes. It's possible this is because PayPalButtonContents sometimes
returns a string and sometimes returns a component.

#### Testing instructions

- Visit composite checkout and choose the PayPal payment method.
- Verify that the submit button looks ok when loading/disabled, when enabled, and that it changes correctly when clicked.