### PR TITLE
Show alternateEmail in contact summary if email is not shown

### DIFF
--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -52,7 +52,7 @@ const ContactFormTitle = () => {
 	const isActive = useIsStepActive();
 	const isComplete = useIsStepComplete();
 	const [ items ] = useLineItems();
-	const isGSuiteInCart = items.find(
+	const isGSuiteInCart = items.some(
 		( item ) => !! item.wpcom_meta?.extra?.google_apps_users?.length
 	);
 
@@ -110,7 +110,7 @@ export default function WPCheckout( {
 	const [ items ] = useLineItems();
 	const firstDomainItem = items.find( isLineItemADomain );
 	const isDomainFieldsVisible = !! firstDomainItem;
-	const isGSuiteInCart = items.find(
+	const isGSuiteInCart = items.some(
 		( item ) => !! item.wpcom_meta?.extra?.google_apps_users?.length
 	);
 	const shouldShowContactStep = isDomainFieldsVisible || total.amount.value > 0;

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-contact-form.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-contact-form.js
@@ -226,11 +226,11 @@ function ContactFormSummary( { isDomainFieldsVisible, isGSuiteInCart } ) {
 						<SummaryLine>{ contactInfo.email.value }</SummaryLine>
 					) }
 
-					{ ( isGSuiteInCart || showDomainContactSummary ) &&
-						contactInfo.alternateEmail.value?.length > 0 &&
-						contactInfo.alternateEmail.value !== contactInfo.email.value && (
-							<SummaryLine>{ contactInfo.alternateEmail.value }</SummaryLine>
-						) }
+					<AlternateEmailSummary
+						contactInfo={ contactInfo }
+						showDomainContactSummary={ showDomainContactSummary }
+						isGSuiteInCart={ isGSuiteInCart }
+					/>
 
 					{ showDomainContactSummary && contactInfo.phone.value?.length > 0 && (
 						<SummaryLine>{ contactInfo.phone.value }</SummaryLine>
@@ -341,6 +341,19 @@ function RenderContactDetails( {
 			{ requiresVatId && <VatIdField /> }
 		</React.Fragment>
 	);
+}
+
+function AlternateEmailSummary( { contactInfo, showDomainContactSummary, isGSuiteInCart } ) {
+	if ( ! isGSuiteInCart && ! showDomainContactSummary ) {
+		return null;
+	}
+	if ( ! contactInfo.alternateEmail.value?.length ) {
+		return null;
+	}
+	if ( contactInfo.alternateEmail.value === contactInfo.email.value && showDomainContactSummary ) {
+		return null;
+	}
+	return <SummaryLine>{ contactInfo.alternateEmail.value }</SummaryLine>;
 }
 
 const ContactDetailsFormDescription = styled.p`

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-contact-form.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-contact-form.js
@@ -41,7 +41,7 @@ export default function WPContactForm( {
 	const translate = useTranslate();
 	const [ items ] = useLineItems();
 	const isDomainFieldsVisible = useHasDomainsInCart();
-	const isGSuiteInCart = items.find(
+	const isGSuiteInCart = items.some(
 		( item ) => !! item.wpcom_meta?.extra?.google_apps_users?.length
 	);
 	const contactInfo = useSelect( ( select ) => select( 'wpcom' ).getContactInfo() );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

If the email field is not displayed because only the G Suite form is being used, and the alternateEmail is the same as the email value, the current logic hides the alternateEmail from the summary. This change shows it instead.

Before:

![before-gsuite](https://user-images.githubusercontent.com/2036909/84931763-41e56f80-b0a1-11ea-807d-a08f8dd89e1d.png)

After:

![after-gsuite](https://user-images.githubusercontent.com/2036909/84931770-4578f680-b0a1-11ea-8bd7-cedd0f10bf71.png)


#### Testing instructions

- Add G Suite to your cart for an existing domain (you cannot have the domain in your cart for this to work).
- Complete the contact form, leaving the email address identical to your registered email address for that domain (it should be the default).
- Verify that the contact summary shows the email address.