### PR TITLE
Buttons: Center text vertically

### DIFF
--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -21,7 +21,7 @@
 	font-weight: 600;
 	line-height: 22px;
 	border-radius: 2px;
-	padding: 7px 14px 9px;
+	padding: 8px 14px;
 	appearance: none;
 
 	.rtl & {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates to flatten the buttons did not update the padding to vertically center the text; this PR addresses that by evening out the top and bottom padding.

Before

<img width="1095" alt="Screen Shot 2020-06-17 at 1 58 48 PM" src="https://user-images.githubusercontent.com/2124984/84932713-b7057480-b0a2-11ea-9f92-945c5a78054b.png">

After

<img width="1099" alt="Screen Shot 2020-06-17 at 1 57 12 PM" src="https://user-images.githubusercontent.com/2124984/84932632-950bf200-b0a2-11ea-9ca8-32e78d3656a3.png">


#### Testing instructions

* Switch to this PR
* Check out button styles across Calypso; top and bottom padding on buttons should be the same, text should be vertically centered
