### PR TITLE
Jetpack: fix and standardize headings styles in backup and scan

### DIFF
--- a/client/my-sites/backup/style.scss
+++ b/client/my-sites/backup/style.scss
@@ -24,6 +24,16 @@
 		overflow-y: visible;
 	}
 }
+
+.backup__main .formatted-header.is-left-align {
+	margin-top: 20px;
+
+	@include breakpoint-deprecated( '>660px' ) {
+		margin-top: 4px;
+		margin-bottom: 18px;
+	}
+}
+
 .backup__main-wrap {
 	display: flex;
 	flex-direction: column;
@@ -58,6 +68,17 @@
 	margin: 2rem 1rem;
 	height: 245px;
 	@include placeholder( --color-neutral-10 );
+}
+
+.backup__subheader {
+	margin: 20px 16px 8px;
+
+	font-family: 'Recoleta', Georgia, 'Times New Roman', Times, serif;
+	font-size: rem( 21px );
+
+	@include breakpoint-deprecated( '>660px' ) {
+		margin: 36px 0 4px;
+	}
 }
 
 /* WordPress.com-only styles */
@@ -100,25 +121,5 @@
 		@include breakpoint-deprecated( '>660px' ) {
 			margin-top: 64px;
 		}
-	}
-}
-
-header.backup__header.is-left-align {
-	color: var( --studio-black );
-	font-size: 28px;
-	line-height: 1;
-	margin-top: 32px;
-	margin-bottom: 16px;
-
-	@include breakpoint-deprecated( '>660px' ) {
-		font-size: 36px;
-		font-weight: 600;
-		margin-top: 40px;
-		margin-bottom: 18px;
-	}
-	&.is-placeholder {
-		display: block;
-		max-width: 60%;
-		@include placeholder( --color-neutral-10 );
 	}
 }

--- a/client/my-sites/backup/wpcom-upsell.tsx
+++ b/client/my-sites/backup/wpcom-upsell.tsx
@@ -71,7 +71,6 @@ export default function WPCOMUpsellPage(): ReactElement {
 
 			<FormattedHeader
 				headerText={ translate( 'Jetpack Backup' ) }
-				className="backup__header"
 				id="backup-header"
 				align="left"
 			/>
@@ -98,13 +97,7 @@ export default function WPCOMUpsellPage(): ReactElement {
 				/>
 			</PromoCard>
 
-			<FormattedHeader
-				headerText={ translate( 'Also included in the Business Plan' ) }
-				className="backup__header"
-				id="backup-subheader"
-				align="left"
-				isSecondary
-			/>
+			<h2 className="backup__subheader">{ translate( 'Also included in the Business Plan' ) }</h2>
 
 			<PromoSection { ...filteredPromos } />
 

--- a/client/my-sites/scan/style.scss
+++ b/client/my-sites/scan/style.scss
@@ -10,6 +10,15 @@
 	}
 }
 
+.scan__main .formatted-header.is-left-align {
+	margin-top: 20px;
+
+	@include breakpoint-deprecated( '>660px' ) {
+		margin-top: 4px;
+		margin-bottom: 18px;
+	}
+}
+
 .scan__content p {
 	font-size: 18px;
 	margin-bottom: 16px;
@@ -46,18 +55,16 @@
 	}
 }
 
-header.scan__header.is-left-align {
+.scan__header {
 	color: var( --studio-black );
-	font-size: 28px;
+	font-size: rem( 28px );
 	line-height: 1;
-	margin-top: 32px;
-	margin-bottom: 16px;
+	margin: 32px 0 16px;
 
 	@include breakpoint-deprecated( '>660px' ) {
-		font-size: 36px;
+		font-size: rem( 36px );
 		font-weight: 600;
-		margin-top: 40px;
-		margin-bottom: 18px;
+		margin: 32px 0 24px;
 	}
 	&.is-placeholder {
 		display: block;
@@ -65,6 +72,18 @@ header.scan__header.is-left-align {
 		@include placeholder( --color-neutral-10 );
 	}
 }
+
+.scan__subheader {
+	margin: 20px 16px 8px;
+
+	font-family: 'Recoleta', Georgia, 'Times New Roman', Times, serif;
+	font-size: rem( 21px );
+
+	@include breakpoint-deprecated( '>660px' ) {
+		margin: 36px 0 4px;
+	}
+}
+
 .scan__content.is-placeholder {
 	display: block;
 	max-width: 80%;

--- a/client/my-sites/scan/wpcom-upsell.tsx
+++ b/client/my-sites/scan/wpcom-upsell.tsx
@@ -67,12 +67,7 @@ export default function WPCOMScanUpsellPage(): ReactElement {
 			<SidebarNavigation />
 			<PageViewTracker path="/scan/:site" title="Scanner" />
 
-			<FormattedHeader
-				headerText={ translate( 'Jetpack Scan' ) }
-				className="scan__header"
-				id="scan-header"
-				align="left"
-			/>
+			<FormattedHeader headerText={ translate( 'Jetpack Scan' ) } id="scan-header" align="left" />
 
 			<PromoCard
 				title={ translate( 'We guard your site. You run your business.' ) }
@@ -97,13 +92,7 @@ export default function WPCOMScanUpsellPage(): ReactElement {
 				/>
 			</PromoCard>
 
-			<FormattedHeader
-				headerText={ translate( 'Also included in the Business Plan' ) }
-				className="scan__header"
-				id="scan-subheader"
-				align="left"
-				isSecondary
-			/>
+			<h2 className="scan__subheader">{ translate( 'Also included in the Business Plan' ) }</h2>
 
 			<PromoSection { ...filteredPromos } />
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

Heading in the _Scan > Scanner_ section didn't look like a heading anymore (both in Calypso and cloud). This PR fixes this issue. Additionally, it standardizes how headers and subheaders are displayed in the _Backup_ and _Scan_ sections (see screenshots below).

### Implementation notes

* The issue was introduced because the `scan__header` class was used to style headers (`FormattedHeader`) in the scan upsell section
* In this fix, we revert to the previous styles of `scan__header` and upsell headers are styled separately
* The PR reflects the changes in the scan section to backup as well
* This part of the code could benefit from some refactoring to avoid styles duplication and standardize class names according to the guidelines mentioned in [the components documentation](https://github.com/Automattic/wp-calypso/blob/master/docs/components.md). A sub formatted header component could be created as well, since it's reused in various places in Calypso. This would be a different PR.

### Testing instructions

#### Upsells

1. Download the PR and run Calypso with the `jetpack/features-section` flag enabled
2. Select a site with a free plan
3. Go to the _Backup_ section
4. Check that the header and subheader match the mockups (or the _After_ screenshot below)
5. Check that it looks good on mobile as well
6. Go to the _Scan_ section
7. Repeat the same steps as above

#### Scanner

1. Select a Jetpack site with Scan activated
2. Visit the _Scan > Scanner_ section
3. Check that the title (below the shield icon) looks like a title (or check the _After_ screenshot below)
4. Check that it looks good on mobile as well
5. Check that it looks the same on cloud

### Screenshots

#### Backup upsell
Before
<img width="777" alt="Screen Shot 2020-06-17 at 2 25 34 PM" src="https://user-images.githubusercontent.com/1620183/84937431-bcb28880-b0a9-11ea-8479-f044823ac868.png">

After
<img width="799" alt="Screen Shot 2020-06-17 at 2 50 18 PM" src="https://user-images.githubusercontent.com/1620183/84937564-f71c2580-b0a9-11ea-8dc2-93c58627cba3.png">


#### Scan upsell
Before
<img width="686" alt="Screen Shot 2020-06-17 at 2 26 39 PM" src="https://user-images.githubusercontent.com/1620183/84937461-c6d48700-b0a9-11ea-8c78-9ae76f8a93b0.png">

After
<img width="802" alt="Screen Shot 2020-06-17 at 2 50 23 PM" src="https://user-images.githubusercontent.com/1620183/84937548-eff51780-b0a9-11ea-8c3d-e692a44c8657.png">


#### Scanner
Before
<img width="690" alt="Screen Shot 2020-06-17 at 2 27 04 PM" src="https://user-images.githubusercontent.com/1620183/84937492-d48a0c80-b0a9-11ea-9140-56ea7c65401c.png">

After
<img width="691" alt="Screen Shot 2020-06-17 at 2 50 32 PM" src="https://user-images.githubusercontent.com/1620183/84937539-ec619080-b0a9-11ea-9dde-7d044a0b29c1.png">

