### PR TITLE
Customer Home: Change strings for dismissing a task

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/task.jsx
+++ b/client/my-sites/customer-home/cards/tasks/task.jsx
@@ -134,7 +134,7 @@ const Task = ( {
 						ref={ skipButtonRef }
 						onClick={ () => ( enableSkipOptions ? setSkipOptionsVisible( true ) : skipTask() ) }
 					>
-						{ enableSkipOptions ? translate( 'Remind me' ) : translate( 'Dismiss' ) }
+						{ enableSkipOptions ? translate( 'Hide this' ) : translate( 'Dismiss' ) }
 						{ enableSkipOptions && <Gridicon icon="dropdown" size={ 18 } /> }
 					</Button>
 					{ enableSkipOptions && areSkipOptionsVisible && (
@@ -146,13 +146,13 @@ const Task = ( {
 							className="task__skip-popover"
 						>
 							<PopoverMenuItem onClick={ () => skipTask( '1d' ) }>
-								{ translate( 'Tomorrow' ) }
+								{ translate( 'For a day' ) }
 							</PopoverMenuItem>
 							<PopoverMenuItem onClick={ () => skipTask( '1w' ) }>
-								{ translate( 'Next week' ) }
+								{ translate( 'For a week' ) }
 							</PopoverMenuItem>
 							<PopoverMenuItem onClick={ () => skipTask() }>
-								{ translate( 'Never' ) }
+								{ translate( 'Forever' ) }
 							</PopoverMenuItem>
 						</PopoverMenu>
 					) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update strings from "Remind me" to "Hide this" to be clearer about how to dismiss a task card

**Before**

<img width="1123" alt="Screen Shot 2020-06-17 at 3 36 27 PM" src="https://user-images.githubusercontent.com/2124984/84942116-5f6e0580-b0b0-11ea-9a1e-5254c89de5d3.png">

**After**

<img width="1116" alt="Screen Shot 2020-06-17 at 3 36 45 PM" src="https://user-images.githubusercontent.com/2124984/84942133-6432b980-b0b0-11ea-97f3-778b262d7bf4.png">

#### Testing instructions

*  Switch to this PR on a site that has an active task card (must have gone through the checklist and launched)
* Go to `/home` and note copy changes

Fixes #43342 
