### PR TITLE
Jetpack section: add switch to control when we display the Business AT

### DIFF
--- a/client/components/jetpack/business-at-switch/index.tsx
+++ b/client/components/jetpack/business-at-switch/index.tsx
@@ -1,0 +1,99 @@
+/**
+ * External dependencies
+ */
+import React, { FC, ReactElement, useState, useEffect } from 'react';
+import { useSelector } from 'react-redux';
+import { isEmpty } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import Main from 'components/main';
+import FormattedHeader from 'components/formatted-header';
+import QueryEligibility from 'components/data/query-atat-eligibility';
+import WPCOMBusinessAT from 'components/jetpack/wpcom-business-at';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import {
+	getAutomatedTransfer,
+	isEligibleForAutomatedTransfer,
+} from 'state/automated-transfer/selectors';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+type Props = {
+	context: PageJS.Context;
+};
+
+const Placeholder = () => (
+	<>
+		<FormattedHeader
+			id="business-at-switch"
+			className="business-at-switch placeholder__header"
+			headerText="Loading..."
+			align="left"
+		/>
+
+		<div className="business-at-switch placeholder__primary-promo"></div>
+	</>
+);
+
+/**
+ * This component selects the right view for Business plan sites that
+ * are not Atomic. If we don't know if the site is eligible for Automated
+ * Transfer, it renders a placeholder and an instance of <QueryEligibility />.
+ * Once we have an answer, we either display the Automated Transfer view or
+ * we display whatever comes next in the middleware stack.
+ */
+const BusinessATSwitch: FC< Props > = ( { context } ): ReactElement => {
+	const siteId = useSelector( getSelectedSiteId );
+	const isEligibleForAT = useSelector( ( state ) =>
+		isEligibleForAutomatedTransfer( state, siteId )
+	);
+	const automatedTransferStatus = useSelector( ( state ) => getAutomatedTransfer( state, siteId ) );
+	const [ { showATComponent, isLoading }, setState ] = useState( {
+		showATComponent: true,
+		isLoading: true,
+	} );
+
+	useEffect( () => {
+		if ( isEmpty( automatedTransferStatus ) ) {
+			return setState( {
+				isLoading: true,
+				showATComponent: true,
+			} );
+		}
+		if ( isEligibleForAT ) {
+			return setState( {
+				isLoading: false,
+				showATComponent: true,
+			} );
+		}
+		return setState( {
+			isLoading: false,
+			showATComponent: false,
+		} );
+	}, [ automatedTransferStatus, isEligibleForAT ] );
+
+	if ( isLoading ) {
+		return (
+			<Main className="business-at-switch__loading">
+				<QueryEligibility siteId={ siteId } />
+				<Placeholder />
+			</Main>
+		);
+	}
+
+	// In the future, we could add another view for the case in which the AT was done
+	// but the Jetpack sync process hasn't finish.
+	if ( showATComponent ) {
+		const primaryProduct = context.path.includes( '/backup/' ) ? 'backup' : 'scan';
+		return <WPCOMBusinessAT product={ primaryProduct } />;
+	}
+
+	return context.primary;
+};
+
+export default BusinessATSwitch;

--- a/client/components/jetpack/business-at-switch/index.tsx
+++ b/client/components/jetpack/business-at-switch/index.tsx
@@ -24,7 +24,8 @@ import {
 import './style.scss';
 
 type Props = {
-	context: PageJS.Context;
+	fallbackDisplay: ReactElement;
+	path: string;
 };
 
 const Placeholder = () => (
@@ -47,7 +48,7 @@ const Placeholder = () => (
  * Once we have an answer, we either display the Automated Transfer view or
  * we display whatever comes next in the middleware stack.
  */
-const BusinessATSwitch: FC< Props > = ( { context } ): ReactElement => {
+const BusinessATSwitch: FC< Props > = ( { fallbackDisplay, path } ): ReactElement => {
 	const siteId = useSelector( getSelectedSiteId );
 	const isEligibleForAT = useSelector( ( state ) =>
 		isEligibleForAutomatedTransfer( state, siteId )
@@ -89,7 +90,7 @@ const BusinessATSwitch: FC< Props > = ( { context } ): ReactElement => {
 	// In the future, we could add another view for the case in which the AT was done
 	// but the Jetpack sync process hasn't finish.
 	if ( showATComponent ) {
-		const primaryProduct = context.path.includes( '/backup/' ) ? 'backup' : 'scan';
+		const primaryProduct = path.includes( '/backup/' ) ? 'backup' : 'scan';
 		return (
 			<WPCOMBusinessAT
 				automatedTransferStatus={ automatedTransferStatus }
@@ -98,7 +99,7 @@ const BusinessATSwitch: FC< Props > = ( { context } ): ReactElement => {
 		);
 	}
 
-	return context.primary;
+	return fallbackDisplay;
 };
 
 export default BusinessATSwitch;

--- a/client/components/jetpack/business-at-switch/index.tsx
+++ b/client/components/jetpack/business-at-switch/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { FC, ReactElement, useState, useEffect } from 'react';
+import React, { FC, ReactNode, ReactElement, useState, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { isEmpty } from 'lodash';
 
@@ -24,7 +24,7 @@ import {
 import './style.scss';
 
 type Props = {
-	fallbackDisplay: ReactElement;
+	fallbackDisplay: ReactNode;
 	path: string;
 };
 

--- a/client/components/jetpack/business-at-switch/index.tsx
+++ b/client/components/jetpack/business-at-switch/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { FC, ReactNode, ReactElement, useState, useEffect } from 'react';
+import React, { FC, ReactElement, ReactNode, useState, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { isEmpty } from 'lodash';
 
@@ -17,6 +17,7 @@ import {
 	getAutomatedTransfer,
 	isEligibleForAutomatedTransfer,
 } from 'state/automated-transfer/selectors';
+import { transferStates } from 'state/automated-transfer/constants';
 
 /**
  * Style dependencies
@@ -48,7 +49,7 @@ const Placeholder = () => (
  * Once we have an answer, we either display the Automated Transfer view or
  * we display whatever comes next in the middleware stack.
  */
-const BusinessATSwitch: FC< Props > = ( { fallbackDisplay, path } ): ReactElement => {
+const BusinessATSwitch: FC< Props > = ( { fallbackDisplay, path } ): ReactElement | ReactNode => {
 	const siteId = useSelector( getSelectedSiteId );
 	const isEligibleForAT = useSelector( ( state ) =>
 		isEligibleForAutomatedTransfer( state, siteId )
@@ -66,7 +67,7 @@ const BusinessATSwitch: FC< Props > = ( { fallbackDisplay, path } ): ReactElemen
 				showATComponent: true,
 			} );
 		}
-		if ( isEligibleForAT ) {
+		if ( isEligibleForAT && automatedTransferStatus?.status !== transferStates.COMPLETE ) {
 			return setState( {
 				isLoading: false,
 				showATComponent: true,

--- a/client/components/jetpack/business-at-switch/index.tsx
+++ b/client/components/jetpack/business-at-switch/index.tsx
@@ -90,7 +90,12 @@ const BusinessATSwitch: FC< Props > = ( { context } ): ReactElement => {
 	// but the Jetpack sync process hasn't finish.
 	if ( showATComponent ) {
 		const primaryProduct = context.path.includes( '/backup/' ) ? 'backup' : 'scan';
-		return <WPCOMBusinessAT product={ primaryProduct } />;
+		return (
+			<WPCOMBusinessAT
+				automatedTransferStatus={ automatedTransferStatus }
+				product={ primaryProduct }
+			/>
+		);
 	}
 
 	return context.primary;

--- a/client/components/jetpack/business-at-switch/style.scss
+++ b/client/components/jetpack/business-at-switch/style.scss
@@ -1,0 +1,16 @@
+.business-at-switch {
+	&.placeholder__header {
+		display: block;
+		@include placeholder( --color-neutral-10 );
+	}
+
+	&.placeholder__primary-promo {
+		display: block;
+		height: 400px;
+		@include placeholder( --color-neutral-10 );
+
+		@include breakpoint-deprecated( '>480px' ) {
+			height: 250px;
+		}
+	}
+}

--- a/client/components/jetpack/wpcom-business-at/index.tsx
+++ b/client/components/jetpack/wpcom-business-at/index.tsx
@@ -107,7 +107,7 @@ export default function WPCOMBusinessAT( { product }: Props ): ReactElement {
 		<Main className="wpcom-business-at">
 			<DocumentHead title={ content.documentHeadTitle } />
 			<SidebarNavigation />
-			<PageViewTracker path={ `/${ product }/:site` } title="Business Plan Upsell" />
+			<PageViewTracker path={ `/${ product }/:site` } title="Business Plan Automated Transfer" />
 
 			<FormattedHeader
 				id="wpcom-business-at-header"

--- a/client/components/jetpack/wpcom-business-at/index.tsx
+++ b/client/components/jetpack/wpcom-business-at/index.tsx
@@ -18,7 +18,7 @@ import WhatIsJetpack from 'components/jetpack/what-is-jetpack';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import useTrackCallback from 'lib/jetpack/use-track-callback';
-import { getAutomatedTransferStatus } from 'state/automated-transfer/selectors';
+import { EligibilityData, getAutomatedTransferStatus } from 'state/automated-transfer/selectors';
 import { initiateThemeTransfer } from 'state/themes/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { transferStates } from 'state/automated-transfer/constants';
@@ -36,6 +36,11 @@ import JetpackScanSVG from 'assets/images/illustrations/jetpack-scan.svg';
 
 interface Props {
 	product: 'backup' | 'scan';
+	automatedTransferStatus: {
+		eligibility: EligibilityData;
+		fetchingStatus: boolean;
+		status: string;
+	};
 }
 
 const contentPerPrimaryProduct = {

--- a/client/components/jetpack/wpcom-business-at/index.tsx
+++ b/client/components/jetpack/wpcom-business-at/index.tsx
@@ -39,7 +39,7 @@ interface Props {
 	automatedTransferStatus: {
 		eligibility: EligibilityData;
 		fetchingStatus: boolean;
-		status: string;
+		status: typeof transferStates[ keyof typeof transferStates ];
 	};
 }
 

--- a/client/lib/jetpack/wpcom-upsell-controller.tsx
+++ b/client/lib/jetpack/wpcom-upsell-controller.tsx
@@ -9,15 +9,12 @@ import React from 'react';
 import { isEnabled } from 'config';
 import type { Context } from './types';
 import { isBusinessPlan } from 'lib/plans';
-import { isEligibleForAutomatedTransfer } from 'state/automated-transfer/selectors';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import { getSitePlan, isJetpackSite } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
+import BusinessATSwitch from 'components/jetpack/business-at-switch';
 
-export default function upsellSwitch(
-	UpsellComponent: typeof React.Component,
-	BusinessATComponent: typeof React.Component
-): Function {
+export default function upsellSwitch( UpsellComponent: typeof React.Component ): Function {
 	return ( context: Context, next: Function ) => {
 		const getState = context.store.getState;
 		const siteId = getSelectedSiteId( getState() );
@@ -37,12 +34,10 @@ export default function upsellSwitch(
 		}
 
 		const isAtomic = isSiteAutomatedTransfer( getState(), siteId );
-		const isEligibleForAT = isEligibleForAutomatedTransfer( getState(), siteId );
 		// Show the Automated Transfer for sites with a Business plan that are not
-		// Atomic sites. These sites must be eligible as well.
-		if ( isBusiness && ! isAtomic && isEligibleForAT ) {
-			const primaryProduct = context.path.includes( '/backup/' ) ? 'backup' : 'scan';
-			context.primary = <BusinessATComponent product={ primaryProduct } />;
+		// Atomic sites.
+		if ( isBusiness && ! isAtomic ) {
+			context.primary = <BusinessATSwitch context={ context } />;
 		}
 
 		next();

--- a/client/lib/jetpack/wpcom-upsell-controller.tsx
+++ b/client/lib/jetpack/wpcom-upsell-controller.tsx
@@ -37,7 +37,9 @@ export default function upsellSwitch( UpsellComponent: typeof React.Component ):
 		// Show the Automated Transfer for sites with a Business plan that are not
 		// Atomic sites.
 		if ( isBusiness && ! isAtomic ) {
-			context.primary = <BusinessATSwitch context={ context } />;
+			context.primary = (
+				<BusinessATSwitch fallbackDisplay={ context.primary } path={ context.path } />
+			);
 		}
 
 		next();

--- a/client/my-sites/backup/index.js
+++ b/client/my-sites/backup/index.js
@@ -19,7 +19,6 @@ import { navigation, siteSelection, sites } from 'my-sites/controller';
 import { notFound, makeLayout, render as clientRender } from 'controller';
 import isJetpackCloud from 'lib/jetpack/is-jetpack-cloud';
 import isJetpackSectionEnabledForSite from 'state/selectors/is-jetpack-section-enabled-for-site';
-import WPCOMBusinessAT from 'components/jetpack/wpcom-business-at';
 import wpcomUpsellController from 'lib/jetpack/wpcom-upsell-controller';
 import WPCOMUpsellPage from 'my-sites/backup/wpcom-upsell';
 import wrapInSiteOffsetProvider from 'lib/wrap-in-site-offset';
@@ -44,7 +43,7 @@ export default function () {
 		navigation,
 		backupDownload,
 		wrapInSiteOffsetProvider,
-		wpcomUpsellController( WPCOMUpsellPage, WPCOMBusinessAT ),
+		wpcomUpsellController( WPCOMUpsellPage ),
 		notFoundIfNotEnabled,
 		makeLayout,
 		clientRender
@@ -58,7 +57,7 @@ export default function () {
 			navigation,
 			backupRestore,
 			wrapInSiteOffsetProvider,
-			wpcomUpsellController( WPCOMUpsellPage, WPCOMBusinessAT ),
+			wpcomUpsellController( WPCOMUpsellPage ),
 			notFoundIfNotEnabled,
 			makeLayout,
 			clientRender
@@ -73,7 +72,7 @@ export default function () {
 		backups,
 		wrapInSiteOffsetProvider,
 		showUpsellIfNoBackup,
-		wpcomUpsellController( WPCOMUpsellPage, WPCOMBusinessAT ),
+		wpcomUpsellController( WPCOMUpsellPage ),
 		notFoundIfNotEnabled,
 		makeLayout,
 		clientRender

--- a/client/my-sites/scan/index.js
+++ b/client/my-sites/scan/index.js
@@ -20,7 +20,6 @@ import {
 	scanHistory,
 } from 'my-sites/scan/controller';
 import WPCOMScanUpsellPage from 'my-sites/scan/wpcom-upsell';
-import WPCOMBusinessAT from 'components/jetpack/wpcom-business-at';
 import getIsSiteWPCOM from 'state/selectors/is-site-wpcom';
 
 const notFoundIfNotEnabled = ( context, next ) => {
@@ -45,7 +44,7 @@ export default function () {
 		scan,
 		wrapInSiteOffsetProvider,
 		showUpsellIfNoScan,
-		wpcomUpsellController( WPCOMScanUpsellPage, WPCOMBusinessAT ),
+		wpcomUpsellController( WPCOMScanUpsellPage ),
 		notFoundIfNotEnabled,
 		makeLayout,
 		clientRender
@@ -58,7 +57,7 @@ export default function () {
 		scanHistory,
 		wrapInSiteOffsetProvider,
 		showUpsellIfNoScanHistory,
-		wpcomUpsellController( WPCOMScanUpsellPage, WPCOMBusinessAT ),
+		wpcomUpsellController( WPCOMScanUpsellPage ),
 		notFoundIfNotEnabled,
 		makeLayout,
 		clientRender
@@ -71,7 +70,7 @@ export default function () {
 		scan,
 		wrapInSiteOffsetProvider,
 		showUpsellIfNoScan,
-		wpcomUpsellController( WPCOMScanUpsellPage, WPCOMBusinessAT ),
+		wpcomUpsellController( WPCOMScanUpsellPage ),
 		notFoundIfNotEnabled,
 		makeLayout,
 		clientRender

--- a/client/state/automated-transfer/constants.ts
+++ b/client/state/automated-transfer/constants.ts
@@ -10,7 +10,7 @@ export const transferStates = {
 	BACKFILLING: 'backfilling',
 	COMPLETE: 'complete',
 	ERROR: 'error',
-};
+} as const;
 
 export const eligibilityHolds = {
 	BLOCKED_ATOMIC_TRANSFER: 'BLOCKED_ATOMIC_TRANSFER',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Knowing if a site is eligible for Automated Transfer is key if we want to show users a screen to trigger the process. For that reason, this PR adds a switch component that controls when and which users should see the Automated Transfer page based on the result of querying the eligibility of the current site. While the query is in progress, we display a loading page using placeholder components.

#### Testing instructions

* Prerequisite: non-Atomic Business site plan.
* Run this PR with the `jetpack/features-section` flag enabled.
* Go to Jetpack > Backup or visit `http://calypso.localhost:3000/backup/[site]`.
* Verify that you see the placeholder/loading page (you might not be able to see this if the eligibility query/request happens too fast).
* Verify that you see the Automated Transfer page.

Fixes 1179060693083348-as-1180812991302177

#### Demo

![Kapture 2020-06-17 at 16 51 07](https://user-images.githubusercontent.com/3418513/84943572-ecb65780-b0ba-11ea-904e-56362b508400.gif)

