### PR TITLE
Add way to set site options on a design level

### DIFF
--- a/client/landing/gutenboarding/stores/onboard/actions.ts
+++ b/client/landing/gutenboarding/stores/onboard/actions.ts
@@ -132,6 +132,7 @@ export function* createSite(
 				font_base: selectedFonts.base,
 				font_headings: selectedFonts.headings,
 			} ),
+			...( selectedDesign?.site_options ?? {} ),
 		},
 		...( bearerToken && { authToken: bearerToken } ),
 	};

--- a/client/landing/gutenboarding/stores/onboard/types.ts
+++ b/client/landing/gutenboarding/stores/onboard/types.ts
@@ -38,4 +38,7 @@ export interface Design {
 	fonts: FontPair;
 	categories: Array< string >;
 	is_premium: boolean;
+	site_options?: {
+		[ option: string ]: string | number | boolean;
+	};
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Adds a way to set site options for a particular design.

Along with D45075-code, this could let us apply stickers for an individual design.

This looking at an alternative way to apply FSE on an individual-design basis.

#### Testing instructions

1. Apply D45075-code to your sandbox and sandbox public-api
2. Add this to one of the design options in `available-designs-config.json`
```
"site_options": {
	"stickers": [ "gutenberg-edge", "core-site-editor-enabled" ]
}
```

3. Run calypso.localhost/new and pick that design in the flow.
4. Those two stickers should be added to your new site.