### PR TITLE
Gutenboarding: Add separate style for focus state of skip buttons so that it's more visible

### DIFF
--- a/client/landing/gutenboarding/components/action-buttons/style.scss
+++ b/client/landing/gutenboarding/components/action-buttons/style.scss
@@ -62,10 +62,14 @@ button.action_buttons__button.components-button {
 		box-shadow: inset 0 0 0 1px var( --studio-gray-50 );
 
 		&:active,
-		&:hover,
-		&:focus {
+		&:hover {
 			color: var( --studio-gray-60 );
 			box-shadow: inset 0 0 0 1px var( --studio-gray-60 );
+		}
+
+		&:focus {
+			color: var( --studio-gray-60 );
+			box-shadow: inset 0 0 0 1px #fff, 0 0 0 1.5px var( --highlightColor );
 		}
 	}
 


### PR DESCRIPTION
As raised in pbAok1-15f-p2 the skip buttons only show a subtle colour change if you tab to them via the keyboard. This change adds a more prominent blue box-shadow to show when it's focused.

#### Changes proposed in this Pull Request

* Add focus styling for the skip action button so that it uses a highlight colour box-shadow, using that same styling as we're using on the primary buttons (e.g. if you tab to the Continue button on the Style step)

#### Screenshot

![image](https://user-images.githubusercontent.com/14988353/84969714-94d02d00-b15c-11ea-84ff-565f3549e55e.png)

![skip-for-now-animated-small](https://user-images.githubusercontent.com/14988353/84969832-d660d800-b15c-11ea-97a2-c686f8b0ba64.gif)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/new`.
* Don't enter a site title, but tab on the keyboard to the "Skip for now" button. It should be highlighted blue.
* Check across browsers that it looks okay.

Fixes #
