### PR TITLE
Reader: fix recommendation title font size

### DIFF
--- a/client/blocks/reader-list-item/README.md
+++ b/client/blocks/reader-list-item/README.md
@@ -1,0 +1,3 @@
+# Reader List Item
+
+Used by the reader-recommended-sites block to display information about a single recommendation.

--- a/client/blocks/reader-list-item/style.scss
+++ b/client/blocks/reader-list-item/style.scss
@@ -114,7 +114,6 @@
 
 .reader-list-item__site-title {
 	font-weight: 600;
-	font-size: $font-body;
 }
 
 .reader-list-item__site-url-timestamp {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Another small fix following the recent changes to body font size (including https://github.com/Automattic/wp-calypso/pull/42629). 

I noticed that the titles of Reader recommendations in Manage Following were too large and were being clipped when they went to two lines:

<img width="774" alt="Screen Shot 2020-06-18 at 16 26 06" src="https://user-images.githubusercontent.com/17325/84978778-e8a13d00-b181-11ea-8a83-93dd3eaf2d9e.png">

This PR fixes it:

<img width="756" alt="Screen Shot 2020-06-18 at 16 25 38" src="https://user-images.githubusercontent.com/17325/84978796-f1920e80-b181-11ea-870c-d72ba40491e1.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Visit http://calypso.localhost:3000/following/manage and ensure the recommendation titles appear at the correct size.
