### PR TITLE
Customer Home: Fix bug with notice not dismissing if option 'never' set

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/task.jsx
+++ b/client/my-sites/customer-home/cards/tasks/task.jsx
@@ -85,7 +85,7 @@ const Task = ( {
 					} ),
 					bumpStat( 'calypso_customer_home', 'task_skip' )
 				),
-				dispatch( skipCurrentViewHomeLayout( siteId, reminder ) )
+				skipCurrentViewHomeLayout( siteId, reminder )
 			)
 		);
 	};
@@ -132,9 +132,7 @@ const Task = ( {
 					<Button
 						className="task__skip is-link"
 						ref={ skipButtonRef }
-						onClick={ () =>
-							enableSkipOptions ? setSkipOptionsVisible( true ) : skipTask( 'never' )
-						}
+						onClick={ () => ( enableSkipOptions ? setSkipOptionsVisible( true ) : skipTask() ) }
 					>
 						{ enableSkipOptions ? translate( 'Remind me' ) : translate( 'Dismiss' ) }
 						{ enableSkipOptions && <Gridicon icon="dropdown" size={ 18 } /> }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes issues with withAnalytics dispatch and /skip endpoint param

#### Testing instructions

* Checkout PR in local Calypso dev env
* Go to Customer home that has a notice  'Remind Me' and another that has a 'Dismiss' link (eg. editor deprecation notice)
* Make sure the dismiss option works in both cases

There were two issues here - one with the withAnalytics dispatch that affected all uses of `skipTask` call, and a second issue with the Dismiss link that was setting `reminder` to `never` which was rejected by REST endpoint.

Before:
![notice-before](https://user-images.githubusercontent.com/3629020/84979966-daa0eb80-b184-11ea-9137-e70cfaf81141.gif)

After:
![notice-after](https://user-images.githubusercontent.com/3629020/84979971-df659f80-b184-11ea-80be-e684dd1fafdd.gif)

Fixes #42815
