### PR TITLE
e2e Invites cleanup: Handle case when signup step fails

### DIFF
--- a/test/e2e/lib/pages/people-page.js
+++ b/test/e2e/lib/pages/people-page.js
@@ -142,7 +142,7 @@ export default class PeoplePage extends AsyncBaseContainer {
 				driver,
 				By.css( `.people-invites__pending .people-profile__username[title="${ emailAddress }"]` )
 			);
-		}, this.explicitWaitMS * 2 );
+		}, this.explicitWaitMS * 4 );
 	}
 
 	async goToRevokeInvitePage( emailAddress ) {

--- a/test/e2e/specs/wp-invite-users-spec.js
+++ b/test/e2e/specs/wp-invite-users-spec.js
@@ -154,20 +154,25 @@ describe( `[${ host }] Invites:  (${ screenSize })`, function () {
 
 		after( async function () {
 			if ( inviteCreated ) {
-				await new LoginFlow( driver ).loginAndSelectPeople();
-				const peoplePage = await PeoplePage.Expect( driver );
-				await peoplePage.selectInvites();
+				try {
+					await new LoginFlow( driver ).loginAndSelectPeople();
+					const peoplePage = await PeoplePage.Expect( driver );
+					await peoplePage.selectInvites();
 
-				// Sometimes, the 'accept invite' step fails. In these cases, we perform cleanup
-				//    by revoking, instead of clearing accepted invite.
-				if ( inviteAccepted ) {
-					await peoplePage.goToClearAcceptedInvitePage( newUserName );
-				} else {
-					await peoplePage.goToRevokeInvitePage( newInviteEmailAddress );
+					// Sometimes, the 'accept invite' step fails. In these cases, we perform cleanup
+					//    by revoking, instead of clearing accepted invite.
+					if ( inviteAccepted ) {
+						await peoplePage.goToClearAcceptedInvitePage( newUserName );
+					} else {
+						await peoplePage.goToRevokeInvitePage( newInviteEmailAddress );
+					}
+
+					const clearOrRevokeInvitePage = await RevokePage.Expect( driver );
+					await clearOrRevokeInvitePage.revokeUser();
+				} catch {
+					console.log( 'Invites cleanup failed for (Inviting new user as an Editor)' );
+					return;
 				}
-
-				const clearOrRevokeInvitePage = await RevokePage.Expect( driver );
-				await clearOrRevokeInvitePage.revokeUser();
 			}
 		} );
 	} );
@@ -340,20 +345,27 @@ describe( `[${ host }] Invites:  (${ screenSize })`, function () {
 
 		after( async function () {
 			if ( inviteCreated ) {
-				await new LoginFlow( driver, 'privateSiteUser' ).loginAndSelectPeople();
-				const peoplePageCleanup = await PeoplePage.Expect( driver );
-				await peoplePageCleanup.selectInvites();
+				try {
+					await new LoginFlow( driver, 'privateSiteUser' ).loginAndSelectPeople();
+					const peoplePageCleanup = await PeoplePage.Expect( driver );
+					await peoplePageCleanup.selectInvites();
 
-				// Sometimes, the 'accept invite' step fails. In these cases, we perform cleanup
-				//    by revoking, instead of clearing accepted invite.
-				if ( inviteAccepted ) {
-					await peoplePageCleanup.goToClearAcceptedInvitePage( newUserName );
-				} else {
-					await peoplePageCleanup.goToRevokeInvitePage( newInviteEmailAddress );
+					// Sometimes, the 'accept invite' step fails. In these cases, we perform cleanup
+					//    by revoking, instead of clearing accepted invite.
+					if ( inviteAccepted ) {
+						await peoplePageCleanup.goToClearAcceptedInvitePage( newUserName );
+					} else {
+						await peoplePageCleanup.goToRevokeInvitePage( newInviteEmailAddress );
+					}
+
+					const clearOrRevokeInvitePage = await RevokePage.Expect( driver );
+					await clearOrRevokeInvitePage.revokeUser();
+				} catch {
+					console.log(
+						'Invites cleanup failed for (Inviting New User as a Viewer of a WordPress.com Private Site)'
+					);
+					return;
 				}
-
-				const clearOrRevokeInvitePage = await RevokePage.Expect( driver );
-				await clearOrRevokeInvitePage.revokeUser();
 			}
 
 			if ( ! removedViewerFlag ) {

--- a/test/e2e/specs/wp-invite-users-spec.js
+++ b/test/e2e/specs/wp-invite-users-spec.js
@@ -296,7 +296,7 @@ describe( `[${ host }] Invites:  (${ screenSize })`, function () {
 		} );
 
 		step( 'Can see user has been added as a Viewer', async function () {
-			inviteAccepted = false;
+			inviteAccepted = true;
 			const noticesComponent = await NoticesComponent.Expect( driver );
 			const followMessageDisplayed = await noticesComponent.getNoticeContent();
 			assert.strictEqual(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add logic to still perform cleanup for created invites even when the signup step fails
    - currently, cleanup consists of looking for the invite among the list of accepted ones. However, if the signup step fails like in this scenario(p5TWut-qv-p2), the invite would still be in the list of pending ones.
* I temporarily increased wait time to twice its original setting, until e2eflowtestingprivate gets a table cleanup. I will set it back before merge, or leave it as is until cleanup is done.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Invites e2e tests, specifically the cleanup after hooks, should pass.
