### PR TITLE
Deduplicate run-async

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -22524,14 +22524,7 @@ rtlcss@2.4.0, rtlcss@^2.4.0:
     postcss "^6.0.14"
     strip-json-comments "^2.0.0"
 
-run-async@^2.2.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.3.0.tgz#0371ab4ae0bdd720d4166d7dfda64ff7a445a6c0"
-  integrity sha1-A3GrSuC91yDUFm19/aZP96RFpsA=
-  dependencies:
-    is-promise "^2.1.0"
-
-run-async@^2.4.0:
+run-async@^2.2.0, run-async@^2.4.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.4.1.tgz#8440eccf99ea3e70bd409d49aab88e10c189a455"
   integrity sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `run-async` (done automatically with `npx yarn-deduplicate --packages run-async`)

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
< Before
> After
---
< wp-calypso-monorepo@0.17.0 -> @storybook/react@5.3.18 -> ... -> run-async@2.3.0
< wp-calypso-monorepo@0.17.0 -> @wordpress/scripts@9.1.0 -> ... -> run-async@2.3.0
< wp-calypso-monorepo@0.17.0 -> calypso-codemods@0.1.6 -> ... -> run-async@2.3.0
< wp-calypso-monorepo@0.17.0 -> eslint@7.1.0 -> ... -> run-async@2.3.0
< wp-calypso-monorepo@0.17.0 -> lerna@3.20.2 -> ... -> run-async@2.3.0
> wp-calypso-monorepo@0.17.0 -> @storybook/react@5.3.18 -> ... -> run-async@2.4.1
> wp-calypso-monorepo@0.17.0 -> @wordpress/scripts@9.1.0 -> ... -> run-async@2.4.1
> wp-calypso-monorepo@0.17.0 -> calypso-codemods@0.1.6 -> ... -> run-async@2.4.1
> wp-calypso-monorepo@0.17.0 -> eslint@7.1.0 -> ... -> run-async@2.4.1
> wp-calypso-monorepo@0.17.0 -> lerna@3.20.2 -> ... -> run-async@2.4.1
```

[CHANGELOG](https://github.com/SBoudrias/run-async/releases)