### PR TITLE
Deduplicate resolve

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -22327,17 +22327,10 @@ resolve@1.1.7, resolve@~1.1.0:
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
   integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
 
-resolve@^1.1.4, resolve@^1.1.7, resolve@^1.15.1, resolve@^1.17.0, resolve@^1.4.0:
+resolve@^1.1.4, resolve@^1.1.6, resolve@^1.1.7, resolve@^1.10.0, resolve@^1.10.1, resolve@^1.11.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.15.1, resolve@^1.17.0, resolve@^1.3.2, resolve@^1.4.0, resolve@^1.8.1:
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
   integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==
-  dependencies:
-    path-parse "^1.0.6"
-
-resolve@^1.1.6, resolve@^1.10.0, resolve@^1.10.1, resolve@^1.11.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.3.2, resolve@^1.8.1:
-  version "1.16.0"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.16.0.tgz#063dc704fa3413e13ac1d0d1756a7cbfe95dd1a7"
-  integrity sha512-LarL/PIKJvc09k1jaeT4kQb/8/7P+qV4qSnN2K80AES+OHdfZELAKVOBjxsvtToT/uLOfFbvYvKfZmV8cee7nA==
   dependencies:
     path-parse "^1.0.6"
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `resolve` (done automatically with `npx yarn-deduplicate --packages resolve`)

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
< Before
> After
---
< wp-calypso-monorepo@0.17.0 -> @automattic/calypso-build@6.1.0 -> ... -> resolve@1.16.0
< wp-calypso-monorepo@0.17.0 -> @automattic/composite-checkout@1.0.0 -> ... -> resolve@1.16.0
< wp-calypso-monorepo@0.17.0 -> @automattic/full-site-editing@1.9.0 -> ... -> resolve@1.16.0
< wp-calypso-monorepo@0.17.0 -> @automattic/o2-blocks@1.0.0 -> ... -> resolve@1.16.0
< wp-calypso-monorepo@0.17.0 -> @babel/core@7.9.0 -> ... -> resolve@1.16.0
< wp-calypso-monorepo@0.17.0 -> @storybook/addon-actions@5.3.18 -> ... -> resolve@1.16.0
< wp-calypso-monorepo@0.17.0 -> @storybook/react@5.3.18 -> ... -> resolve@1.16.0
< wp-calypso-monorepo@0.17.0 -> @wordpress/block-directory@1.9.0 -> ... -> resolve@1.16.0
< wp-calypso-monorepo@0.17.0 -> @wordpress/block-editor@3.11.0 -> ... -> resolve@1.16.0
< wp-calypso-monorepo@0.17.0 -> @wordpress/block-library@2.18.0 -> ... -> resolve@1.16.0
< wp-calypso-monorepo@0.17.0 -> @wordpress/components@9.6.0 -> ... -> resolve@1.16.0
< wp-calypso-monorepo@0.17.0 -> @wordpress/edit-post@3.17.0 -> ... -> resolve@1.16.0
< wp-calypso-monorepo@0.17.0 -> @wordpress/editor@9.16.0 -> ... -> resolve@1.16.0
< wp-calypso-monorepo@0.17.0 -> @wordpress/format-library@1.18.0 -> ... -> resolve@1.16.0
< wp-calypso-monorepo@0.17.0 -> @wordpress/jest-preset-default@6.0.0 -> ... -> resolve@1.16.0
< wp-calypso-monorepo@0.17.0 -> @wordpress/nux@3.16.0 -> ... -> resolve@1.16.0
< wp-calypso-monorepo@0.17.0 -> @wordpress/scripts@9.1.0 -> ... -> resolve@1.16.0
< wp-calypso-monorepo@0.17.0 -> @wordpress/server-side-render@1.12.0 -> ... -> resolve@1.16.0
< wp-calypso-monorepo@0.17.0 -> babel-eslint@10.0.3 -> ... -> resolve@1.16.0
< wp-calypso-monorepo@0.17.0 -> babel-jest@26.0.1 -> ... -> resolve@1.16.0
< wp-calypso-monorepo@0.17.0 -> calypso-codemods@0.1.6 -> ... -> resolve@1.16.0
< wp-calypso-monorepo@0.17.0 -> concurrently@5.1.0 -> ... -> resolve@1.16.0
< wp-calypso-monorepo@0.17.0 -> eslint-plugin-import@2.20.0 -> ... -> resolve@1.16.0
< wp-calypso-monorepo@0.17.0 -> jest-enzyme@7.1.2 -> ... -> resolve@1.16.0
< wp-calypso-monorepo@0.17.0 -> jest@26.0.1 -> ... -> resolve@1.16.0
< wp-calypso-monorepo@0.17.0 -> lerna@3.20.2 -> ... -> resolve@1.16.0
< wp-calypso-monorepo@0.17.0 -> node-sass-package-importer@5.3.2 -> ... -> resolve@1.16.0
< wp-calypso-monorepo@0.17.0 -> node-sass@4.13.0 -> ... -> resolve@1.16.0
< wp-calypso-monorepo@0.17.0 -> npm-package-json-lint@5.0.0 -> ... -> resolve@1.16.0
< wp-calypso-monorepo@0.17.0 -> npm-run-all@4.1.5 -> ... -> resolve@1.16.0
< wp-calypso-monorepo@0.17.0 -> stylelint@9.10.1 -> ... -> resolve@1.16.0
< wp-calypso-monorepo@0.17.0 -> whybundled@1.4.2 -> ... -> resolve@1.16.0
< wp-calypso-monorepo@0.17.0 -> wp-calypso@0.17.0 -> ... -> resolve@1.16.0
< wp-calypso-monorepo@0.17.0 -> wp-e2e-tests@0.0.1 -> ... -> resolve@1.16.0
> wp-calypso-monorepo@0.17.0 -> @automattic/calypso-build@6.1.0 -> ... -> resolve@1.17.0
> wp-calypso-monorepo@0.17.0 -> @automattic/composite-checkout@1.0.0 -> ... -> resolve@1.17.0
> wp-calypso-monorepo@0.17.0 -> @automattic/full-site-editing@1.9.0 -> ... -> resolve@1.17.0
> wp-calypso-monorepo@0.17.0 -> @automattic/o2-blocks@1.0.0 -> ... -> resolve@1.17.0
> wp-calypso-monorepo@0.17.0 -> @babel/core@7.9.0 -> ... -> resolve@1.17.0
> wp-calypso-monorepo@0.17.0 -> @storybook/addon-actions@5.3.18 -> ... -> resolve@1.17.0
> wp-calypso-monorepo@0.17.0 -> @storybook/react@5.3.18 -> ... -> resolve@1.17.0
> wp-calypso-monorepo@0.17.0 -> @wordpress/block-directory@1.9.0 -> ... -> resolve@1.17.0
> wp-calypso-monorepo@0.17.0 -> @wordpress/block-editor@3.11.0 -> ... -> resolve@1.17.0
> wp-calypso-monorepo@0.17.0 -> @wordpress/block-library@2.18.0 -> ... -> resolve@1.17.0
> wp-calypso-monorepo@0.17.0 -> @wordpress/components@9.6.0 -> ... -> resolve@1.17.0
> wp-calypso-monorepo@0.17.0 -> @wordpress/edit-post@3.17.0 -> ... -> resolve@1.17.0
> wp-calypso-monorepo@0.17.0 -> @wordpress/editor@9.16.0 -> ... -> resolve@1.17.0
> wp-calypso-monorepo@0.17.0 -> @wordpress/format-library@1.18.0 -> ... -> resolve@1.17.0
> wp-calypso-monorepo@0.17.0 -> @wordpress/jest-preset-default@6.0.0 -> ... -> resolve@1.17.0
> wp-calypso-monorepo@0.17.0 -> @wordpress/nux@3.16.0 -> ... -> resolve@1.17.0
> wp-calypso-monorepo@0.17.0 -> @wordpress/scripts@9.1.0 -> ... -> resolve@1.17.0
> wp-calypso-monorepo@0.17.0 -> @wordpress/server-side-render@1.12.0 -> ... -> resolve@1.17.0
> wp-calypso-monorepo@0.17.0 -> babel-eslint@10.0.3 -> ... -> resolve@1.17.0
> wp-calypso-monorepo@0.17.0 -> babel-jest@26.0.1 -> ... -> resolve@1.17.0
> wp-calypso-monorepo@0.17.0 -> calypso-codemods@0.1.6 -> ... -> resolve@1.17.0
> wp-calypso-monorepo@0.17.0 -> concurrently@5.1.0 -> ... -> resolve@1.17.0
> wp-calypso-monorepo@0.17.0 -> eslint-plugin-import@2.20.0 -> ... -> resolve@1.17.0
> wp-calypso-monorepo@0.17.0 -> jest-enzyme@7.1.2 -> ... -> resolve@1.17.0
> wp-calypso-monorepo@0.17.0 -> jest@26.0.1 -> ... -> resolve@1.17.0
> wp-calypso-monorepo@0.17.0 -> lerna@3.20.2 -> ... -> resolve@1.17.0
> wp-calypso-monorepo@0.17.0 -> node-sass-package-importer@5.3.2 -> ... -> resolve@1.17.0
> wp-calypso-monorepo@0.17.0 -> node-sass@4.13.0 -> ... -> resolve@1.17.0
> wp-calypso-monorepo@0.17.0 -> npm-package-json-lint@5.0.0 -> ... -> resolve@1.17.0
> wp-calypso-monorepo@0.17.0 -> npm-run-all@4.1.5 -> ... -> resolve@1.17.0
> wp-calypso-monorepo@0.17.0 -> stylelint@9.10.1 -> ... -> resolve@1.17.0
> wp-calypso-monorepo@0.17.0 -> whybundled@1.4.2 -> ... -> resolve@1.17.0
> wp-calypso-monorepo@0.17.0 -> wp-calypso@0.17.0 -> ... -> resolve@1.17.0
> wp-calypso-monorepo@0.17.0 -> wp-e2e-tests@0.0.1 -> ... -> resolve@1.17.0
```

[CHANGELOG](https://github.com/browserify/resolve/releases)