### PR TITLE
Post List Block: make sure button doesn't shrink beyond its content

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/posts-list-block/blocks/posts-list/editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/posts-list-block/blocks/posts-list/editor.scss
@@ -6,4 +6,8 @@ div.posts-list__notice {
 		align-items: center;
 		justify-content: space-between;
 	}
+
+	.components-notice__action {
+		flex-shrink: 0;
+	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* FSE Post List Block is now deprecated. WordPress.com installations that have already used it are now getting a notice message to update to the new Block. In that case, this PR resolves #41658 by making sure that the button content doesn't get cut out.

**Before**
![image](https://user-images.githubusercontent.com/12430020/84984609-df917b00-b143-11ea-8629-3361bc1dd098.png)

**After**
![image](https://user-images.githubusercontent.com/12430020/84990093-50896080-b14d-11ea-88d8-65e4e0c7a26c.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In Calypso root folder run
```
cd apps/full-site-editing
yarn build
```
* Setup https://github.com/Automattic/ajax-env with FSE plugin
* Go to http://localhost:4759/wp-admin/admin.php?import=wordpress
* Import [sitetitle.wordpress.2020-06-17.001.xml.zip](https://github.com/Automattic/wp-calypso/files/4797222/sitetitle.wordpress.2020-06-17.001.xml.zip) (extract first)
* Edit the Homepage of the imported content
* Your editor should load with the imported content of a site that used the deprecated Post List Block

Manually tested in Chrome, Safari, Firefox and IE11

IE11 results
![image](https://user-images.githubusercontent.com/12430020/84998337-5e90ae80-b158-11ea-94e6-2ca837fe7798.png)


