### PR TITLE
Add/gutenberg editor rum instrumentation

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -850,7 +850,15 @@ function handleUncaughtErrors( calypsoPort ) {
 
 function handleEditorLoaded( calypsoPort ) {
 	const unsubscribe = subscribe( () => {
-		const isReady = select( 'core/editor' ).__unstableIsEditorReady();
+		const store = select( 'core/editor' );
+
+		if ( typeof store.__unstableIsEditorReady !== 'function' ) {
+			// This is probably a very old veresion of the plugin, bail out.
+			unsubscribe();
+			return;
+		}
+
+		const isReady = store.__unstableIsEditorReady();
 		if ( isReady ) {
 			requestAnimationFrame( () => {
 				calypsoPort.postMessage( {

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -46,7 +46,7 @@ import ConvertToBlocksDialog from 'components/convert-to-blocks';
 import config from 'config';
 import EditorDocumentHead from 'post-editor/editor-document-head';
 import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
-
+import { stopPerformanceTracking } from 'lib/performance-tracking';
 /**
  * Types
  */
@@ -107,6 +107,7 @@ enum EditorActions {
 	GetGutenboardingStatus = 'getGutenboardingStatus',
 	GetNavSidebarLabels = 'getNavSidebarLabels',
 	GetCalypsoUrlInfo = 'getCalypsoUrlInfo',
+	TrackPerformance = 'trackPerformance',
 }
 
 class CalypsoifyIframe extends Component<
@@ -347,6 +348,13 @@ class CalypsoifyIframe extends Component<
 		if ( EditorActions.PostStatusChange === action ) {
 			const { status } = payload;
 			this.handlePostStatusChange( status );
+		}
+
+		if ( EditorActions.TrackPerformance === action ) {
+			if ( payload.mark === 'editor.ready' ) {
+				// This name must match the section name
+				stopPerformanceTracking( 'gutenberg-editor' );
+			}
 		}
 	};
 

--- a/client/lib/performance-tracking/README.md
+++ b/client/lib/performance-tracking/README.md
@@ -5,22 +5,31 @@ This lib provides wrappers around `@automattic/browser-data-collector`
 
 ### Start
 
-It provides a middleware expected to be used with Page router.
+#### Generic function
 
+It provides a function `startPerformanceTracking()` that accepts the name of the page being tracked and a flag for full page loads. It is a simple
+wrapper around the `start` method in `@automattic/browser-data-collector` with an additional check to validate that the performance tracking is
+enabled for this environment (by checking the feature flag `rum-tracking/logstash`) and user (by checking the abtest `rumDataCollection`).
+
+Unless there is a specialized wrapper (eg: middleware `performanceTrackerStart`), using this function is the recommended approach to track performance
+of loading pages in Calypso.
+
+#### Middleware
+It provides a middleware expected to be used with Page router.
 
 Example:
 ```jsx
 page('/my-page/*', performanceTrackerStart('my-page'), /*...*/);
 ```
 
-The id provided to `performanceTrackerStart` must match the id provided by the hook `usePerformanceTrackerStop`, which equals to the name of the section loaded.
-
-This middleware function will check the status of the feature flag `rum-tracking/logstash`. If disabled, it is a noop.
-
-It will also pass the option `{fullPageLoad: true}` to `@automattic/browser-data-collector` if the route hit comes from a full page load.
-
+The id provided to `performanceTrackerStart` must match the id provided by the hook `usePerformanceTrackerStop`, which equals to the name of the section
+loaded. It will also pass the option `{fullPageLoad: true}` to `@automattic/browser-data-collector` if the route hit comes from a full page load.
 
 ### Stop
+
+#### Generic function
+
+The counterpart of the generic start function.
 
 #### Hook
 
@@ -35,8 +44,6 @@ function MyComponent() {
 	);
 }
 ```
-
-This hook will check the status of the feature flag `rum-tracking/logstash`. If disabled, it is a noop.
 
 It will also get the current section name from the Redux store and use it as the `id` of the performance tracker report to stop.
 

--- a/client/lib/performance-tracking/index.js
+++ b/client/lib/performance-tracking/index.js
@@ -3,3 +3,5 @@ export { performanceTrackerStart } from './performance-tracker-start';
 export { usePerformanceTrackerStop } from './use-performance-tracker-stop';
 export { withPerformanceTrackerStop } from './with-performance-tracker-stop';
 export { default as PerformanceTrackerStop } from './performance-tracker-stop';
+
+export { startPerformanceTracking, stopPerformanceTracking } from './lib';

--- a/client/lib/performance-tracking/lib.js
+++ b/client/lib/performance-tracking/lib.js
@@ -1,0 +1,29 @@
+/**
+ * External dependencies
+ */
+import { start, stop } from '@automattic/browser-data-collector';
+
+/**
+ * Internal dependencies
+ */
+import config from 'config';
+import { abtest } from 'lib/abtest';
+import { CONFIG_NAME, AB_NAME, AB_VARIATION_ON } from './const';
+
+const isPerformanceTrackingEnabled = () => {
+	const isEnabledForEnvironment = config.isEnabled( CONFIG_NAME );
+	const isEnabledForCurrentInteraction = abtest( AB_NAME ) === AB_VARIATION_ON;
+	return isEnabledForEnvironment && isEnabledForCurrentInteraction;
+};
+
+export const startPerformanceTracking = ( name, fullPageLoad = false ) => {
+	if ( isPerformanceTrackingEnabled() ) {
+		start( name, { fullPageLoad } );
+	}
+};
+
+export const stopPerformanceTracking = ( name ) => {
+	if ( isPerformanceTrackingEnabled() ) {
+		stop( name );
+	}
+};

--- a/client/lib/performance-tracking/performance-tracker-start.js
+++ b/client/lib/performance-tracking/performance-tracker-start.js
@@ -1,24 +1,11 @@
 /**
- * External dependencies
- */
-import { start } from '@automattic/browser-data-collector';
-
-/**
  * Internal dependencies
  */
-import config from 'config';
-import { abtest } from 'lib/abtest';
-import { CONFIG_NAME, AB_NAME, AB_VARIATION_ON } from './const';
+import { startPerformanceTracking } from './lib';
 
 export const performanceTrackerStart = ( pageName ) => {
 	return ( context, next ) => {
-		const isEnabledForEnvironment = config.isEnabled( CONFIG_NAME );
-		const isEnabledForCurrentInteraction = abtest( AB_NAME ) === AB_VARIATION_ON;
-		if ( isEnabledForEnvironment && isEnabledForCurrentInteraction ) {
-			start( pageName || 'calypso', {
-				fullPageLoad: context.init || false,
-			} );
-		}
+		startPerformanceTracking( pageName, context.init );
 		next();
 	};
 };

--- a/client/lib/performance-tracking/performance-tracker-start.js
+++ b/client/lib/performance-tracking/performance-tracker-start.js
@@ -5,7 +5,7 @@ import { startPerformanceTracking } from './lib';
 
 export const performanceTrackerStart = ( pageName ) => {
 	return ( context, next ) => {
-		startPerformanceTracking( pageName, context.init );
+		startPerformanceTracking( pageName, context.init ?? false );
 		next();
 	};
 };

--- a/client/lib/performance-tracking/test/lib.js
+++ b/client/lib/performance-tracking/test/lib.js
@@ -1,0 +1,128 @@
+/**
+ * External dependencies
+ */
+import { start, stop } from '@automattic/browser-data-collector';
+
+/**
+ * Internal dependencies
+ */
+import config from 'config';
+import { startPerformanceTracking, stopPerformanceTracking } from '../lib';
+import { abtest } from 'lib/abtest';
+
+jest.mock( 'config', () => ( {
+	isEnabled: jest.fn(),
+} ) );
+jest.mock( '@automattic/browser-data-collector', () => ( {
+	start: jest.fn(),
+	stop: jest.fn(),
+} ) );
+jest.mock( 'lib/abtest', () => ( {
+	abtest: jest.fn(),
+} ) );
+
+const withFeatureEnabled = () =>
+	config.isEnabled.mockImplementation( ( key ) => key === 'rum-tracking/logstash' );
+const withFeatureDisabled = () =>
+	config.isEnabled.mockImplementation( ( key ) => key !== 'rum-tracking/logstash' );
+const withABTestEnabled = () =>
+	abtest.mockImplementation( ( test ) =>
+		test === 'rumDataCollection' ? 'collectData' : 'noData'
+	);
+const withABTestDisabled = () => abtest.mockImplementation( () => 'noData' );
+
+describe( 'startPerformanceTracking', () => {
+	beforeEach( () => {
+		withFeatureEnabled();
+		withABTestEnabled();
+	} );
+
+	afterEach( () => {
+		jest.resetAllMocks();
+	} );
+
+	it( 'starts measuring when the feature is enabled', () => {
+		startPerformanceTracking( 'pageName' );
+
+		expect( start ).toHaveBeenCalled();
+	} );
+
+	it( 'do not start measuring when the config flag is off', () => {
+		withFeatureDisabled();
+
+		startPerformanceTracking( 'pageName' );
+
+		expect( start ).not.toHaveBeenCalled();
+	} );
+
+	it( 'do not start measuring when the abtest is disabled', () => {
+		withABTestDisabled();
+
+		startPerformanceTracking( 'pageName' );
+
+		expect( start ).not.toHaveBeenCalled();
+	} );
+
+	it( 'uses the name of the page', () => {
+		startPerformanceTracking( 'pageName' );
+
+		expect( start ).toHaveBeenCalledWith( 'pageName', expect.anything() );
+	} );
+
+	it( 'measures fullPageLoad if the page is an initial navigation', () => {
+		startPerformanceTracking( 'pageName', true );
+
+		expect( start ).toHaveBeenCalledWith( expect.anything(), { fullPageLoad: true } );
+	} );
+
+	it( 'does not measure fullPageLoad if the page is not an initial navigation', () => {
+		startPerformanceTracking( 'pageName', false );
+
+		expect( start ).toHaveBeenCalledWith( expect.anything(), { fullPageLoad: false } );
+	} );
+
+	it( 'does not measure fullPageLoad by default', () => {
+		startPerformanceTracking( 'pageName' );
+
+		expect( start ).toHaveBeenCalledWith( expect.anything(), { fullPageLoad: false } );
+	} );
+} );
+
+describe( 'stopPerformanceTracking', () => {
+	beforeEach( () => {
+		withFeatureEnabled();
+		withABTestEnabled();
+	} );
+
+	afterEach( () => {
+		jest.resetAllMocks();
+	} );
+
+	it( 'stops measuring when the feature is enabled', () => {
+		stopPerformanceTracking( 'pageName' );
+
+		expect( stop ).toHaveBeenCalled();
+	} );
+
+	it( 'do not stop measuring when the config flag is off', () => {
+		withFeatureDisabled();
+
+		stopPerformanceTracking( 'pageName' );
+
+		expect( stop ).not.toHaveBeenCalled();
+	} );
+
+	it( 'do not stop measuring when the abtest is disabled', () => {
+		withABTestDisabled();
+
+		stopPerformanceTracking( 'pageName' );
+
+		expect( stop ).not.toHaveBeenCalled();
+	} );
+
+	it( 'uses the name of the page', () => {
+		stopPerformanceTracking( 'pageName' );
+
+		expect( stop ).toHaveBeenCalledWith( 'pageName' );
+	} );
+} );

--- a/client/lib/performance-tracking/test/performance-tracker-start.js
+++ b/client/lib/performance-tracking/test/performance-tracker-start.js
@@ -1,41 +1,14 @@
-/**
- * External dependencies
- */
-import { start } from '@automattic/browser-data-collector';
+jest.mock( '../lib', () => ( {
+	startPerformanceTracking: jest.fn(),
+} ) );
 
 /**
  * Internal dependencies
  */
-import config from 'config';
 import { performanceTrackerStart } from '../performance-tracker-start';
-import { abtest } from 'lib/abtest';
-
-jest.mock( 'config', () => ( {
-	isEnabled: jest.fn(),
-} ) );
-jest.mock( '@automattic/browser-data-collector', () => ( {
-	start: jest.fn(),
-} ) );
-jest.mock( 'lib/abtest', () => ( {
-	abtest: jest.fn(),
-} ) );
-
-const withFeatureEnabled = () =>
-	config.isEnabled.mockImplementation( ( key ) => key === 'rum-tracking/logstash' );
-const withFeatureDisabled = () =>
-	config.isEnabled.mockImplementation( ( key ) => key !== 'rum-tracking/logstash' );
-const withABTestEnabled = () =>
-	abtest.mockImplementation( ( test ) =>
-		test === 'rumDataCollection' ? 'collectData' : 'noData'
-	);
-const withABTestDisabled = () => abtest.mockImplementation( () => 'noData' );
+import { startPerformanceTracking } from '../lib';
 
 describe( 'performance-tracker-start', () => {
-	beforeEach( () => {
-		withFeatureEnabled();
-		withABTestEnabled();
-	} );
-
 	afterEach( () => {
 		jest.resetAllMocks();
 	} );
@@ -49,55 +22,21 @@ describe( 'performance-tracker-start', () => {
 		expect( next ).toHaveBeenCalled();
 	} );
 
-	it( 'starts measuring when the feature is enabled', () => {
-		performanceTrackerStart( 'pageName' )( {}, jest.fn() );
-
-		expect( start ).toHaveBeenCalled();
-	} );
-
-	it( 'do not start measuring when the config flag is off', () => {
-		withFeatureDisabled();
-
-		performanceTrackerStart( 'pageName' )( {}, jest.fn() );
-
-		expect( start ).not.toHaveBeenCalled();
-	} );
-
-	it( 'do not start measuring when the abtest is disabled', () => {
-		withABTestDisabled();
-
-		performanceTrackerStart( 'pageName' )( {}, jest.fn() );
-
-		expect( start ).not.toHaveBeenCalled();
-	} );
-
 	it( 'uses the name of the page', () => {
 		performanceTrackerStart( 'pageName' )( {}, jest.fn() );
 
-		expect( start ).toHaveBeenCalledWith( 'pageName', expect.anything() );
-	} );
-
-	it( 'if the page name is not provided, uses "calypso" as the name', () => {
-		performanceTrackerStart()( {}, jest.fn() );
-
-		expect( start ).toHaveBeenCalledWith( 'calypso', expect.anything() );
+		expect( startPerformanceTracking ).toHaveBeenCalledWith( 'pageName', expect.anything() );
 	} );
 
 	it( 'measures fullPageLoad if the page is an initial navigation', () => {
 		performanceTrackerStart( 'pageName' )( { init: true }, jest.fn() );
 
-		expect( start ).toHaveBeenCalledWith( expect.anything(), { fullPageLoad: true } );
+		expect( startPerformanceTracking ).toHaveBeenCalledWith( expect.anything(), true );
 	} );
 
 	it( 'does not measure fullPageLoad if the page is not an initial navigation', () => {
 		performanceTrackerStart( 'pageName' )( { init: false }, jest.fn() );
 
-		expect( start ).toHaveBeenCalledWith( expect.anything(), { fullPageLoad: false } );
-	} );
-
-	it( 'does not measure fullPageLoad by default', () => {
-		performanceTrackerStart( 'pageName' )( {}, jest.fn() );
-
-		expect( start ).toHaveBeenCalledWith( expect.anything(), { fullPageLoad: false } );
+		expect( startPerformanceTracking ).toHaveBeenCalledWith( expect.anything(), false );
 	} );
 } );

--- a/client/lib/performance-tracking/test/use-performance-tracker-stop.js
+++ b/client/lib/performance-tracking/test/use-performance-tracker-stop.js
@@ -3,15 +3,13 @@
  */
 import { useLayoutEffect } from 'react';
 import { useSelector } from 'react-redux';
-import { stop } from '@automattic/browser-data-collector';
 
 /**
  * Internal dependencies
  */
 import { getSectionName } from 'state/ui/selectors';
-import config from 'config';
 import { usePerformanceTrackerStop } from '../use-performance-tracker-stop';
-import { getABTestVariation } from 'lib/abtest';
+import { stopPerformanceTracking } from '../lib';
 
 jest.mock( 'react', () => ( {
 	useLayoutEffect: jest.fn(),
@@ -19,28 +17,12 @@ jest.mock( 'react', () => ( {
 jest.mock( 'react-redux', () => ( {
 	useSelector: jest.fn(),
 } ) );
-jest.mock( '@automattic/browser-data-collector', () => ( {
-	stop: jest.fn(),
+jest.mock( '../lib', () => ( {
+	stopPerformanceTracking: jest.fn(),
 } ) );
 jest.mock( 'state/ui/selectors', () => ( {
 	getSectionName: jest.fn(),
 } ) );
-jest.mock( 'config', () => ( {
-	isEnabled: jest.fn(),
-} ) );
-jest.mock( 'lib/abtest', () => ( {
-	getABTestVariation: jest.fn(),
-} ) );
-
-const withFeatureEnabled = () =>
-	config.isEnabled.mockImplementation( ( key ) => key === 'rum-tracking/logstash' );
-const withFeatureDisabled = () =>
-	config.isEnabled.mockImplementation( ( key ) => key !== 'rum-tracking/logstash' );
-const withABTestEnabled = () =>
-	getABTestVariation.mockImplementation( ( test ) =>
-		test === 'rumDataCollection' ? 'collectData' : 'noData'
-	);
-const withABTestDisabled = () => getABTestVariation.mockImplementation( () => 'noData' );
 
 describe( 'usePerfomranceTrackerStop hook', () => {
 	let originalRequestAnimationFrame;
@@ -50,8 +32,6 @@ describe( 'usePerfomranceTrackerStop hook', () => {
 		global.requestAnimationFrame = jest.fn( ( fn ) => fn() );
 		useLayoutEffect.mockImplementation( ( fn ) => fn() );
 		useSelector.mockImplementation( ( selector ) => selector() );
-		withFeatureEnabled();
-		withABTestEnabled();
 	} );
 
 	afterEach( () => {
@@ -59,28 +39,12 @@ describe( 'usePerfomranceTrackerStop hook', () => {
 		global.requestAnimationFrame = originalRequestAnimationFrame;
 	} );
 
-	it( 'does not stop measuring if the feature is off', () => {
-		withFeatureDisabled();
-
-		usePerformanceTrackerStop();
-
-		expect( stop ).not.toHaveBeenCalled();
-	} );
-
-	it( 'does not stop measuring if the abtest is disabled', () => {
-		withABTestDisabled();
-
-		usePerformanceTrackerStop();
-
-		expect( stop ).not.toHaveBeenCalled();
-	} );
-
 	it( 'gets the page name from the state', () => {
 		getSectionName.mockImplementation( () => 'pageName' );
 
 		usePerformanceTrackerStop();
 
-		expect( stop ).toHaveBeenCalledWith( 'pageName' );
+		expect( stopPerformanceTracking ).toHaveBeenCalledWith( 'pageName' );
 	} );
 
 	it( 'calls stop using useLayoutEffect and requestAnimationFrame', () => {

--- a/client/lib/performance-tracking/use-performance-tracker-stop.js
+++ b/client/lib/performance-tracking/use-performance-tracker-stop.js
@@ -4,27 +4,20 @@
  */
 import { useLayoutEffect } from 'react';
 import { useSelector } from 'react-redux';
-import { stop } from '@automattic/browser-data-collector';
 
 /**
  * Internal dependencies
  */
+import { stopPerformanceTracking } from './lib';
 import { getSectionName } from 'state/ui/selectors';
-import config from 'config';
-import { getABTestVariation } from 'lib/abtest';
-import { CONFIG_NAME, AB_NAME, AB_VARIATION_ON } from './const';
 
 export function usePerformanceTrackerStop() {
 	const sectionName = useSelector( getSectionName );
-	const isEnabledForEnvironment = config.isEnabled( CONFIG_NAME );
-	const isEnabledForCurrentInteraction = getABTestVariation( AB_NAME ) === AB_VARIATION_ON;
 
 	// Use `useLayoutEffect` + rAF to be as close as possible to the actual rendering
 	useLayoutEffect( () => {
 		requestAnimationFrame( () => {
-			if ( isEnabledForEnvironment && isEnabledForCurrentInteraction ) {
-				stop( sectionName );
-			}
+			stopPerformanceTracking( sectionName );
 		} );
-	}, [ sectionName, isEnabledForEnvironment, isEnabledForCurrentInteraction ] );
+	}, [ sectionName ] );
 }

--- a/client/sections.js
+++ b/client/sections.js
@@ -432,6 +432,7 @@ const sections = [
 		module: 'gutenberg/editor',
 		group: 'gutenberg',
 		secondary: false,
+		trackLoadPerformance: true,
 	},
 	{
 		name: 'import',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* [Calypso] Refactors `lib/performance-trackign` to expose generic `startPerformanceTracking` and `stopPerformanceTracking` methods
* [Calypso] Refactors the iframe bridge to listen for `TrackPerformance` messages from the iframe
* [wpcom-block-editor] Triggers `TrackPerformance` messages when the editor is ready

#### Testing instructions

Deploy changes in `wpcom-block-editor` (requires sandbox aliased to `wpcom-sandbox`):
* `cd apps/wpcom-block-editor`
* Run `yarn wpcom-sync` and leave it running.
* In a separate terminal, run `yarn build:prod`. This should update the changes in `wpcom-block-editor` to your sandbox.
* Redirect `widgets.wp.com` to your sandbox IP address.

Test Calypso:
* Start calypso with `yarn start`
* Go to your posts/pages and edit one of them.
* Check the network tab for requests to `/logstash`. Inspect the payload, it should say `id:gutenberg-editor`. Verify that the `duration` makes sense.
* Click on `Write` in the top bar and check for `/logstash` requests again.
* While in the editor, reload the page and check for `/logstash` requests again.
