### PR TITLE
Disable email check for "Launch" buttons in Customer home ad Site settings

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
@@ -28,18 +28,6 @@ const getTaskDescription = ( task, { isDomainUnverified } ) => {
 					</>
 				);
 			}
-			/*
-			if ( isEmailUnverified ) {
-				return (
-					<>
-						{ task.description }
-						<br />
-						<br />
-						{ translate( 'Confirm your email address before launching your site.' ) }
-					</>
-				);
-			}
-			*/
 			return task.description;
 		default:
 			return task.description;

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
@@ -15,7 +15,7 @@ import { localizeUrl } from 'calypso/lib/i18n-utils';
 import { verifyEmail } from 'calypso/state/current-user/email-verification/actions';
 import { CHECKLIST_KNOWN_TASKS } from 'calypso/state/data-layer/wpcom/checklist/index.js';
 
-const getTaskDescription = ( task, { isDomainUnverified, isEmailUnverified } ) => {
+const getTaskDescription = ( task, { isDomainUnverified } ) => {
 	switch ( task.id ) {
 		case CHECKLIST_KNOWN_TASKS.SITE_LAUNCHED:
 			if ( isDomainUnverified ) {
@@ -28,6 +28,7 @@ const getTaskDescription = ( task, { isDomainUnverified, isEmailUnverified } ) =
 					</>
 				);
 			}
+			/*
 			if ( isEmailUnverified ) {
 				return (
 					<>
@@ -38,6 +39,7 @@ const getTaskDescription = ( task, { isDomainUnverified, isEmailUnverified } ) =
 					</>
 				);
 			}
+			*/
 			return task.description;
 		default:
 			return task.description;
@@ -52,7 +54,7 @@ const isTaskDisabled = (
 		case CHECKLIST_KNOWN_TASKS.EMAIL_VERIFIED:
 			return 'requesting' === emailVerificationStatus || ! isEmailUnverified;
 		case CHECKLIST_KNOWN_TASKS.SITE_LAUNCHED:
-			return isDomainUnverified || isEmailUnverified;
+			return isDomainUnverified;
 		default:
 			return false;
 	}

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -41,7 +41,6 @@ import { preventWidows } from 'calypso/lib/formatting';
 import scrollTo from 'calypso/lib/scroll-to';
 import isUnlaunchedSite from 'calypso/state/selectors/is-unlaunched-site';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
-import { isCurrentUserEmailVerified } from 'calypso/state/current-user/selectors';
 import { launchSite } from 'calypso/state/sites/launch/actions';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
@@ -698,7 +697,6 @@ const connectComponent = connect(
 		return {
 			isUnlaunchedSite: isUnlaunchedSite( state, siteId ),
 			isComingSoon: isSiteComingSoon( state, siteId ),
-			needsVerification: ! isCurrentUserEmailVerified( state ),
 			siteIsJetpack,
 			siteIsVip: isVipSite( state, siteId ),
 			siteSlug: getSelectedSiteSlug( state ),

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -12,7 +12,6 @@ import { flowRight, get, has } from 'lodash';
  */
 import wrapSettingsForm from './wrap-settings-form';
 import { Card, CompactCard, Button } from '@automattic/components';
-import EmailVerificationGate from 'calypso/components/email-verification/email-verification-gate';
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
 import LanguagePicker from 'calypso/components/language-picker';
@@ -581,15 +580,6 @@ export class SiteSettingsFormGeneral extends Component {
 
 	privacySettingsWrapper() {
 		if ( this.props.isUnlaunchedSite ) {
-			if ( this.props.needsVerification ) {
-				return (
-					<EmailVerificationGate>
-						{ this.renderLaunchSite() }
-						{ this.privacySettings() }
-					</EmailVerificationGate>
-				);
-			}
-
 			return (
 				<>
 					{ this.renderLaunchSite() }


### PR DESCRIPTION
Convo pbAPfg-ym-p2

**Update (16.12.2020):** There is now also a persistent Launch button in editor ( p9Jlb4-1SN-p2 ) for all sites. And that one is also enabled without having a confirmed email address.

There's another launch-flow for Gutenboarding sites (directly from the editor) and that doesn't require email confirmation either. This makes things more consistent.

There likely are more launch flows that we need to follow-up with same change.

## Changes proposed in this Pull Request

* Remove client-side email-verification restriction at customer home for site-launching

Changes in the same direction have also been applied to the "launch banner" in D54592-code. Please also review that patch when reviewing this PR.

## Testing instructions

- As a user who has not verified their email, create a new site
- At customer home (`/home/[SITE_ID].wordpress.com`), open "Launch" task
  - [x] Test that you can now launch without verifying your email
- Visit site settings (`/settings/general/[SITE_ID].wordpress.com`)
  - [x] Test that you can now launch without verifying your email
- [x] Check if there are other pages in Calypso (Eg: in Settings) where Launch button is disabled if the email is not verified.

## Screenshots

|  Before  | After  
|---|---|
| <img width="1106" alt="Screenshot 2020-06-18 at 15 23 21" src="https://user-images.githubusercontent.com/87168/85019732-ee922080-b177-11ea-8e6b-5cfbc1378039.png">  |  <img width="1090" alt="Screenshot 2020-06-18 at 15 23 53" src="https://user-images.githubusercontent.com/87168/85019734-efc34d80-b177-11ea-9802-9d3d7cbf99d6.png"> |
| <img width="1904" alt="Screenshot 2020-12-17 at 12 57 52" src="https://user-images.githubusercontent.com/1083581/102485806-64643f80-4068-11eb-92dc-a0a59a3210da.png"> | <img width="1904" alt="Screenshot 2020-12-17 at 12 57 52" src="https://user-images.githubusercontent.com/1083581/102485843-6fb76b00-4068-11eb-8e37-426eae6b738f.png"> |



Fixes https://github.com/Automattic/wp-calypso/issues/42085