### PR TITLE
P2: preselect 'editor' role in Invite People

### DIFF
--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -95,8 +95,8 @@ class InvitePeople extends React.Component {
 		}
 	}
 
-	resetState = ( nextProps = {} ) => {
-		const { isWPForTeamsSite } = nextProps;
+	resetState = ( props = this.props ) => {
+		const { isWPForTeamsSite } = props;
 
 		const defaultRole = isWPForTeamsSite ? 'editor' : 'follower';
 

--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -91,15 +91,19 @@ class InvitePeople extends React.Component {
 			this.props.isJetpack !== nextProps.isJetpack ||
 			this.props.isSiteAutomatedTransfer !== nextProps.isSiteAutomatedTransfer
 		) {
-			this.setState( this.resetState() );
+			this.setState( this.resetState( nextProps ) );
 		}
 	}
 
-	resetState = () => {
+	resetState = ( nextProps = {} ) => {
+		const { isWPForTeamsSite } = nextProps;
+
+		const defaultRole = isWPForTeamsSite ? 'editor' : 'follower';
+
 		return {
 			isExternal: false,
 			usernamesOrEmails: [],
-			role: 'follower',
+			role: defaultRole,
 			message: '',
 			sendingInvites: false,
 			getTokenStatus: () => {},


### PR DESCRIPTION
In this PR, we make the `editor` role as default one for the P2 sites on the Invite People screen.

## Testing instructions

Navigate to `http://calypso.localhost:3000/people/new/` with a non-p2 site. You should get `follower` selected by default. Now, from the sidebar, select a P2 site. The default selection should switch to `editor`. Try switching to some other non-p2 site — it should change to `follower` again.