### PR TITLE
P2: remove Footer Credit option from Settings menu

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -44,6 +44,7 @@ import { getDomainsBySiteId } from 'state/sites/domains/selectors';
 import QuerySiteDomains from 'components/data/query-site-domains';
 import FormInputCheckbox from 'components/forms/form-checkbox';
 import { hasLocalizedText } from 'blocks/eligibility-warnings/has-localized-text';
+import isSiteWPForTeams from 'state/selectors/is-site-wpforteams';
 
 export class SiteSettingsFormGeneral extends Component {
 	componentDidMount() {
@@ -550,6 +551,7 @@ export class SiteSettingsFormGeneral extends Component {
 			siteIsVip,
 			siteSlug,
 			translate,
+			isWPForTeamsSite,
 		} = this.props;
 
 		const classes = classNames( 'site-settings__general-settings', {
@@ -580,7 +582,7 @@ export class SiteSettingsFormGeneral extends Component {
 
 				{ this.privacySettingsWrapper() }
 
-				{ ! siteIsJetpack && (
+				{ ! isWPForTeamsSite && ! siteIsJetpack && (
 					<div className="site-settings__footer-credit-container">
 						<SettingsSectionHeader title={ translate( 'Footer credit' ) } />
 						<CompactCard className="site-settings__footer-credit-explanation">
@@ -645,6 +647,7 @@ const connectComponent = connect(
 			selectedSite,
 			isPaidPlan: isCurrentPlanPaid( state, siteId ),
 			siteDomains: getDomainsBySiteId( state, siteId ),
+			isWPForTeamsSite: isSiteWPForTeams( state, siteId ),
 		};
 	},
 	mapDispatchToProps,


### PR DESCRIPTION
In this PR, we remove the "Change footer credit" section from the Settings page for P2 sites.

![image](https://user-images.githubusercontent.com/4988512/85022662-e46e2300-b173-11ea-8ae6-a2e51728523b.png)

## Testing instructions

Navigate to `http://calypso.localhost:3000/settings/general/` with a non-p2 site. You should see the option to change footer credit. Now, switch to a P2 site. That section should disappear.