### PR TITLE
E2E: Fix Gutenberg editor test

### DIFF
--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -168,15 +168,12 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 			By.css( '.block-editor-writing-flow' ),
 			'start'
 		);
-		// @TODO: Remove `.edit-post-header .block-editor-inserter__toggle` selector in favor of the `.edit-post-header-toolbar__inserter-toggle` selector when Gutenberg 8.0.0 is deployed.
 		const inserterToggleSelector = By.css(
-			'.edit-post-header .block-editor-inserter__toggle, .edit-post-header .edit-post-header-toolbar__inserter-toggle'
+			'.edit-post-header .edit-post-header-toolbar__inserter-toggle'
 		);
 		const inserterMenuSelector = By.css( '.block-editor-inserter__menu' );
-		// @TODO: Remove `input.block-editor-inserter__search` selector in favor of the `input.block-editor-inserter__search-input` selector when Gutenberg 8.0.0 is deployed.
-		const inserterSearchInputSelector = By.css(
-			'input.block-editor-inserter__search, input.block-editor-inserter__search-input'
-		);
+		const inserterSearchInputSelector = By.css( 'input.block-editor-inserter__search-input' );
+
 		if ( await driverHelper.elementIsNotPresent( this.driver, inserterMenuSelector ) ) {
 			await driverHelper.waitTillPresentAndDisplayed( this.driver, inserterToggleSelector );
 			await driverHelper.clickWhenClickable( this.driver, inserterToggleSelector );

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -176,7 +176,14 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 
 		if ( await driverHelper.elementIsNotPresent( this.driver, inserterMenuSelector ) ) {
 			await driverHelper.waitTillPresentAndDisplayed( this.driver, inserterToggleSelector );
+
 			await driverHelper.clickWhenClickable( this.driver, inserterToggleSelector );
+			// "Click" twice - the first click seems to trigger a tooltip, the second opens the menu
+			// See https://github.com/Automattic/wp-calypso/issues/43179
+			if ( ! ( await driverHelper.elementIsNotPresent( this.driver, inserterMenuSelector ) ) ) {
+				await driverHelper.clickWhenClickable( this.driver, inserterToggleSelector );
+			}
+
 			await driverHelper.waitTillPresentAndDisplayed( this.driver, inserterMenuSelector );
 		}
 		await driverHelper.setWhenSettable( this.driver, inserterSearchInputSelector, searchTerm );

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -180,7 +180,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 			await driverHelper.clickWhenClickable( this.driver, inserterToggleSelector );
 			// "Click" twice - the first click seems to trigger a tooltip, the second opens the menu
 			// See https://github.com/Automattic/wp-calypso/issues/43179
-			if ( ! ( await driverHelper.elementIsNotPresent( this.driver, inserterMenuSelector ) ) ) {
+			if ( await driverHelper.elementIsNotPresent( this.driver, inserterMenuSelector ) ) {
 				await driverHelper.clickWhenClickable( this.driver, inserterToggleSelector );
 			}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The e2e "click" seems to display a tooltip rather than trigger the menu-opening click. Adding a second click if necessary triggers the menu to display.

#### Testing instructions

* Full e2e should pass.
* Locally run the failing spec: `./node_modules/.bin/mocha specs/wp-calypso-gutenberg-post-editor-spec.js` (see PCYsg-7p3-p2)

Fixes #43179 
