### PR TITLE
Fix Happychat/Lasagna network request failing in support session

### DIFF
--- a/client/state/happychat/utils.js
+++ b/client/state/happychat/utils.js
@@ -8,29 +8,9 @@ import { getCurrentUser, getCurrentUserLocale } from 'state/current-user/selecto
 import { getHelpSelectedSite } from 'state/help/selectors';
 import getSkills from 'state/happychat/selectors/get-skills';
 
-// Promise based interface for wpcom.request
-const request = ( ...args ) =>
-	new Promise( ( resolve, reject ) => {
-		wpcom.request( ...args, ( error, response ) => {
-			if ( error ) {
-				return reject( error );
-			}
-			resolve( response );
-		} );
-	} );
+const sign = ( payload ) => wpcom.req.post( '/jwt/sign', { payload: JSON.stringify( payload ) } );
 
-const sign = ( payload ) =>
-	request( {
-		method: 'POST',
-		path: '/jwt/sign',
-		body: { payload: JSON.stringify( payload ) },
-	} );
-
-const startSession = () =>
-	request( {
-		method: 'POST',
-		path: '/happychat/session',
-	} );
+const startSession = () => wpcom.req.post( '/happychat/session' );
 
 export const getHappychatAuth = ( state ) => () => {
 	const url = config( 'happychat_url' );

--- a/client/state/lasagna/middleware.js
+++ b/client/state/lasagna/middleware.js
@@ -13,10 +13,9 @@ import postChannelMiddleware from './post-channel/middleware';
 import userChannelMiddleware from './user-channel/middleware';
 
 const jwtFetcher = ( jwtType, { params } ) => {
-	return wpcom
-		.request( {
+	return wpcom.req
+		.post( {
 			apiNamespace: 'wpcom/v2',
-			method: 'POST',
 			path: '/lasagna/jwt/sign',
 			body: { jwt_type: jwtType, payload: params },
 		} )


### PR DESCRIPTION
Fixes a JS crash that I noticed while being in a support session for a user:
<img width="1071" alt="Screenshot 2020-06-17 at 09 16 18" src="https://user-images.githubusercontent.com/664258/85025288-7cb9d700-b177-11ea-8d9d-0ba5500ec594.png">

This is caused by the Lasagna middleware `jwtFetcher` using `wpcom.request` function to issue REST requests, and not passing a callback in favor of using the returned promise.

`wpcom.request`, however, is:
- an internal function, used to register request handlers (custom "middlewares" that can modify the request and response)
- primarily callback-based. The promise support is there almost by accident and not all our handlers support them

The handler that intercepts requests in a support session mode is such a handler that works correctly only with callbacks.

**Solution 1:**
Make the `lib/wp/support` handler compatible with promises, too. I spend some time refactoring the handler, but then I figured that the resulting code is too complex and abandoned the idea. The result is only the refactoring in first commit that makes the code more readable.

**Solution 2:**
Don't use the `wpcom.request` internal API, and replace the usages with `wpcom.req.post`, the proper public API of the `wpcom` lib.

That's what I did in the Lasagna and Happychat code, the two places where I found `wpcom.request` usages. That's the second and third commit.

**How to test:**
- verify that Lasagna and HappyChat continue to work correctly and the `jwt/sign` endpoints return the expected result
- verify that Calypso doesn't crash any more in support session (I'm afraid we'll need to test that in `staging`, unless @brandonpayton can recommend some better steps)
