### PR TITLE
Customer Home: Add edit site button on home heading.

### DIFF
--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -38,13 +38,17 @@
 		margin: 0;
 	}
 
-	.customer-home__view-site-button {
+	.customer-home__heading-actions {
 		margin: auto;
 		margin-right: 0;
 
 		.button {
 			text-align: center;
 			white-space: nowrap;
+
+			+ .button {
+				margin-left: 8px;
+			}
 		}
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add edit site button on home headng.

#### Testing instructions

* Go to `/home`.
* You should see **Edit Site** button on the home heading on WP sites that has a static home page.
* You should not see **Edit Site** button on the home heading on WP sites that doesn't have a static home page.
* Clicking on **Edit Site** button should navigate to the block editor with the home page loaded in the editor.
* Clicking on **Edit Site** button should log an analytics event.

You can see analytics event in your console using by setting `localStorage.debug = 'calypso.analytics'`.

#### Screenshot

![image](https://user-images.githubusercontent.com/1287077/85031179-a7f3f480-b17e-11ea-9cc3-43b881aa1e2e.png)

![image](https://user-images.githubusercontent.com/1287077/85031161-a1657d00-b17e-11ea-9b37-49a75be6a144.png)

