### PR TITLE
P2: enable the P2 signup flow on every platform

### DIFF
--- a/config/desktop.json
+++ b/config/desktop.json
@@ -100,6 +100,7 @@
 		"signup/social": false,
 		"signup/social-management": true,
 		"signup/wpcc": true,
+		"signup/wpforteams": true,
 		"site-indicator": true,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -125,6 +125,7 @@
 		"signup/atomic-store-flow": true,
 		"signup/ecommerce-flow": false,
 		"signup/wpcc": true,
+		"signup/wpforteams": true,
 		"site-indicator": true,
 		"memberships": true,
 		"support-user": true,

--- a/config/production.json
+++ b/config/production.json
@@ -133,6 +133,7 @@
 		"signup/social-management": true,
 		"signup/atomic-store-flow": true,
 		"signup/wpcc": true,
+		"signup/wpforteams": true,
 		"site-indicator": true,
 		"memberships": true,
 		"ssr/sample-log-cache-misses": true,

--- a/config/test.json
+++ b/config/test.json
@@ -103,6 +103,7 @@
 		"settings/security/monitor": true,
 		"settings/theme-setup": false,
 		"signup/social": true,
+		"signup/wpforteams": true,
 		"site-indicator": true,
 		"support-user": true,
 		"upgrades/checkout": true,


### PR DESCRIPTION
We've forgot to enable the P2 signup flow and features for all platforms, especially prod!

In this PR, we enable it.

## Testing instructions

Unproxy yourself and navigate to `wordpress.com`. Select a P2 site. It should behave the same way as on a proxied `wordpress.com` (ie no upsell nudges, a few menu items are hidden, etc).