### PR TITLE
Customer Home: Resize help icon to use 24px size

### DIFF
--- a/client/my-sites/customer-home/cards/features/help-search/style.scss
+++ b/client/my-sites/customer-home/cards/features/help-search/style.scss
@@ -48,8 +48,8 @@ $min_results_height: 175px;
 
 	.help-search__help-icon {
 		display: block;
-		width: 27px;
-		height: 27px;
+		width: 26px;
+		height: 26px;
 		margin-right: 12px;
 
 		background: var( --color-primary );
@@ -60,8 +60,8 @@ $min_results_height: 175px;
 		.gridicon {
 			fill: var( --color-text-inverted );
 			margin: 1px 0 0 1px;
-			height: 25px;
-			width: 25px;
+			height: 24px;
+			width: 24px;
 		}
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* I noticed this while looking into #43169. Gridicons are designed to be displayed at 24px, or certain multiples of 6px in a pinch: https://github.com/Automattic/gridicons
* The help icon was sized at 25px; this PR resizes it and the surrounding circle container to 24px / 26px for a sharper icon.

**Before**

<img width="349" alt="Screen Shot 2020-06-18 at 1 10 40 PM" src="https://user-images.githubusercontent.com/2124984/85051519-9baf6d80-b165-11ea-9fc7-1af013d875ef.png">

**After**

<img width="348" alt="Screen Shot 2020-06-18 at 1 10 26 PM" src="https://user-images.githubusercontent.com/2124984/85051534-a23de500-b165-11ea-9cb8-20859e061a12.png">


#### Testing instructions

* Switch to this PR
* Visit `/home` and note the visual changes in the icon next to "More help".
