### PR TITLE
Domains: Strip random number from the WPCOM subdomain for suggestions

### DIFF
--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -142,6 +142,18 @@ class DomainSearch extends Component {
 		);
 	}
 
+	getInitialSuggestion() {
+		const { context, selectedSite } = this.props;
+		if ( context.query.suggestion ) {
+			return context.query.suggestion;
+		}
+
+		const wpcomSubdomainWithRandomNumberSuffix = /^(.+?)([0-9]{5,})\.wordpress\.com$/i;
+		const [ , strippedHostname ] =
+			selectedSite.domain.match( wpcomSubdomainWithRandomNumberSuffix ) || [];
+		return strippedHostname ?? selectedSite.domain.split( '.' )[ 0 ];
+	}
+
 	render() {
 		const { selectedSite, selectedSiteSlug, translate } = this.props;
 		const classes = classnames( 'main-column', {
@@ -173,8 +185,6 @@ class DomainSearch extends Component {
 				/>
 			);
 		} else {
-			const suggestion =
-				this.props.context.query.suggestion ?? selectedSite.domain.split( '.' )[ 0 ];
 			content = (
 				<span>
 					<div className="domain-search__content">
@@ -186,7 +196,7 @@ class DomainSearch extends Component {
 						>
 							{ ! this.props.hasPlanInCart && <NewDomainsRedirectionNoticeUpsell /> }
 							<RegisterDomainStep
-								suggestion={ suggestion }
+								suggestion={ this.getInitialSuggestion() }
 								domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
 								onDomainsAvailabilityChange={ this.handleDomainsAvailabilityChange }
 								onAddDomain={ this.handleAddRemoveDomain }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As suggested in #43118, we can do a better job with the default suggestions in Domains Management for sites with WPCOM subdomains with randomly generated numbers (which can come from a number of flows, but most notably Gutenboarding).

#### Testing instructions

Create or rename a WPCOM site making sure to try to choose a very generic name, like `test`. You should get a suggestion like `test521265196`.wordpress.com. Now, on your site go to Manage -> Domains -> Add domain to this site. The default suggestion should be `test` (in this case):

<img width="1062" alt="Screenshot 2020-06-18 at 17 18 46" src="https://user-images.githubusercontent.com/3392497/85052035-cf9b8a80-b187-11ea-9944-5de06e276b1f.png">

Which are much more attractive than previously:
<img width="1061" alt="Screenshot 2020-06-18 at 17 18 57" src="https://user-images.githubusercontent.com/3392497/85052053-d7f3c580-b187-11ea-9548-135381defd0e.png">

Fixes #43118
