### PR TITLE
Domains: Move GSuite TOS notice to domain card

### DIFF
--- a/client/my-sites/domains/components/domain-warnings/pending-gsuite-tos-notice-action.js
+++ b/client/my-sites/domains/components/domain-warnings/pending-gsuite-tos-notice-action.js
@@ -52,7 +52,7 @@ PendingGSuiteTosNoticeAction.propTypes = {
 };
 
 PendingGSuiteTosNoticeAction.defaultProps = {
-	compact: true,
+	isCompact: true,
 };
 
 export default PendingGSuiteTosNoticeAction;

--- a/client/my-sites/domains/components/domain-warnings/pending-gsuite-tos-notice-action.js
+++ b/client/my-sites/domains/components/domain-warnings/pending-gsuite-tos-notice-action.js
@@ -25,8 +25,8 @@ function PendingGSuiteTosNoticeAction( props ) {
 
 	return (
 		<Fragment>
-			<Button primary={ true } compact={ true } onClick={ onFixClickHandler }>
-				{ translate( 'Finish Setup' ) }
+			<Button primary={ true } compact={ props.isCompact } onClick={ onFixClickHandler }>
+				{ props.cta || translate( 'Finish Setup' ) }
 			</Button>
 			<PendingGSuiteTosNoticeDialog
 				domainName={ props.domainName }
@@ -47,6 +47,12 @@ PendingGSuiteTosNoticeAction.propTypes = {
 	severity: PropTypes.string.isRequired,
 	siteSlug: PropTypes.string.isRequired,
 	user: PropTypes.string.isRequired,
+	cta: PropTypes.string,
+	isCompact: PropTypes.bool,
+};
+
+PendingGSuiteTosNoticeAction.defaultProps = {
+	compact: true,
 };
 
 export default PendingGSuiteTosNoticeAction;

--- a/client/my-sites/domains/components/domain-warnings/pending-gsuite-tos-notice.jsx
+++ b/client/my-sites/domains/components/domain-warnings/pending-gsuite-tos-notice.jsx
@@ -28,10 +28,12 @@ class PendingGSuiteTosNotice extends React.PureComponent {
 		domains: PropTypes.array.isRequired,
 		section: PropTypes.string.isRequired,
 		isCompact: PropTypes.bool,
+		showDomainStatusNotice: PropTypes.bool,
 	};
 
 	static defaultProps = {
 		isCompact: false,
+		showDomainStatusNotice: false,
 	};
 
 	componentDidMount() {
@@ -106,6 +108,64 @@ class PendingGSuiteTosNotice extends React.PureComponent {
 					{ this.props.translate( 'Finish Setup' ) }
 				</NoticeAction>
 			</Notice>
+		);
+	}
+
+	domainStatusNotice() {
+		const { domains, translate } = this.props;
+		const domainName = domains[ 0 ].name;
+		const users = domains[ 0 ].googleAppsSubscription.pendingUsers;
+		const emails = users.join( ', ' );
+
+		const button = (
+			<PendingGSuiteTosNoticeAction
+				domainName={ domainName }
+				isMultipleDomains={ false }
+				section={ this.props.section }
+				severity={ null }
+				siteSlug={ this.props.siteSlug }
+				user={ users[ 0 ] }
+				isCompact={ false }
+				cta={ translate( 'Get started' ) }
+			/>
+		);
+
+		if ( users.length === 1 ) {
+			return (
+				<>
+					<p>
+						{ translate(
+							'%(email)s is almost ready! Complete the setup to activate your new email address.',
+							{
+								args: {
+									email: emails,
+									comment: '%(email)s will be an email address',
+								},
+							}
+						) }
+					</p>
+					{ button }
+				</>
+			);
+		}
+
+		return (
+			<>
+				<p>
+					{ translate(
+						'%(emails)s are almost ready! Complete the setup to activate your new email addresses.',
+						{
+							args: {
+								emails: emails,
+							},
+							comment:
+								'%(emails)s will be a list of email addresses separated by a comma, ' +
+								'e.g. test@example.com, test2@example.com',
+						}
+					) }
+				</p>
+				{ button }
+			</>
 		);
 	}
 
@@ -188,6 +248,10 @@ class PendingGSuiteTosNotice extends React.PureComponent {
 	}
 
 	render() {
+		if ( this.props.showDomainStatusNotice ) {
+			return this.domainStatusNotice();
+		}
+
 		if ( this.props.isCompact ) {
 			return this.compactNotice();
 		}

--- a/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
@@ -34,6 +34,8 @@ import ExpiringSoon from '../card/notices/expiring-soon';
 import DomainManagementNavigation from '../navigation';
 import DomainManagementNavigationEnhanced from '../navigation/enhanced';
 import { WrapDomainStatusButtons } from './helpers';
+import { hasPendingGSuiteUsers } from 'lib/gsuite';
+import PendingGSuiteTosNotice from 'my-sites/domains/components/domain-warnings/pending-gsuite-tos-notice';
 
 class MappedDomainType extends React.Component {
 	resolveStatus() {
@@ -67,6 +69,14 @@ class MappedDomainType extends React.Component {
 			return {
 				statusText: translate( 'Action required' ),
 				statusClass: 'status-error',
+				icon: 'info',
+			};
+		}
+
+		if ( hasPendingGSuiteUsers( domain ) ) {
+			return {
+				statusText: translate( 'Action required' ),
+				statusClass: 'status-warning',
 				icon: 'info',
 			};
 		}
@@ -142,6 +152,28 @@ class MappedDomainType extends React.Component {
 				</div>
 				<div className="mapped-domain-type__small-message">{ secondaryMessage }</div>
 			</React.Fragment>
+		);
+	}
+
+	renderPendingGSuiteTosNotice() {
+		const { domain, selectedSite } = this.props;
+
+		if (
+			! hasPendingGSuiteUsers( domain ) ||
+			( ( ! this.props.isJetpackSite || this.props.isSiteAutomatedTransfer ) &&
+				! domain.pointsToWpcom ) ||
+			isExpiringSoon( domain, 30 )
+		) {
+			return null;
+		}
+
+		return (
+			<PendingGSuiteTosNotice
+				siteSlug={ selectedSite.slug }
+				domains={ [ domain ] }
+				section="domain-management"
+				showDomainStatusNotice
+			/>
 		);
 	}
 
@@ -277,6 +309,7 @@ class MappedDomainType extends React.Component {
 						domain={ domain }
 					/>
 					{ this.renderSettingUpNameservers() }
+					{ this.renderPendingGSuiteTosNotice() }
 					<ExpiringSoon
 						selectedSite={ selectedSite }
 						purchase={ purchase }

--- a/client/my-sites/domains/domain-management/edit/domain-types/registered-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/registered-domain-type.jsx
@@ -41,6 +41,8 @@ import DomainManagementNavigation from '../navigation';
 import DomainManagementNavigationEnhanced from '../navigation/enhanced';
 import { WrapDomainStatusButtons } from './helpers';
 import OutboundTransferConfirmation from '../../components/outbound-transfer-confirmation';
+import { hasPendingGSuiteUsers } from 'lib/gsuite';
+import PendingGSuiteTosNotice from 'my-sites/domains/components/domain-warnings/pending-gsuite-tos-notice';
 
 class RegisteredDomainType extends React.Component {
 	resolveStatus() {
@@ -106,6 +108,14 @@ class RegisteredDomainType extends React.Component {
 				statusText: translate( 'Activating' ),
 				statusClass: 'status-pending',
 				icon: 'cloud_upload',
+			};
+		}
+
+		if ( hasPendingGSuiteUsers( domain ) ) {
+			return {
+				statusText: translate( 'Action required' ),
+				statusClass: 'status-warning',
+				icon: 'info',
 			};
 		}
 
@@ -237,6 +247,23 @@ class RegisteredDomainType extends React.Component {
 		);
 	}
 
+	renderPendingGSuiteTosNotice() {
+		const { domain, selectedSite } = this.props;
+
+		if ( ! hasPendingGSuiteUsers( domain ) ) {
+			return null;
+		}
+
+		return (
+			<PendingGSuiteTosNotice
+				siteSlug={ selectedSite.slug }
+				domains={ [ domain ] }
+				section="domain-management"
+				showDomainStatusNotice
+			/>
+		);
+	}
+
 	renderOutboundTransferInProgress() {
 		const { domain, selectedSite } = this.props;
 		return <OutboundTransferConfirmation domain={ domain } siteId={ selectedSite.ID } />;
@@ -321,11 +348,7 @@ class RegisteredDomainType extends React.Component {
 				domain={ this.props.domain }
 				position="registered-domain"
 				selectedSite={ this.props.selectedSite }
-				ruleWhiteList={ [
-					'pendingGSuiteTosAcceptanceDomains',
-					'newTransfersWrongNS',
-					'pendingConsent',
-				] }
+				ruleWhiteList={ [ 'newTransfersWrongNS', 'pendingConsent' ] }
 			/>
 		);
 	}
@@ -378,6 +401,7 @@ class RegisteredDomainType extends React.Component {
 					{ this.renderExpired() }
 					{ this.renderRecentlyRegistered() }
 					{ this.renderOutboundTransferInProgress() }
+					{ this.renderPendingGSuiteTosNotice() }
 				</DomainStatus>
 				<Card compact={ true } className="domain-types__expiration-row">
 					<div>

--- a/client/my-sites/domains/domain-management/edit/domain-types/registered-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/registered-domain-type.jsx
@@ -248,9 +248,17 @@ class RegisteredDomainType extends React.Component {
 	}
 
 	renderPendingGSuiteTosNotice() {
-		const { domain, selectedSite } = this.props;
+		const { domain, purchase, selectedSite } = this.props;
 
-		if ( ! hasPendingGSuiteUsers( domain ) ) {
+		if (
+			! hasPendingGSuiteUsers( domain ) ||
+			domain.pendingTransfer ||
+			domain.expired ||
+			domain.isPendingIcannVerification ||
+			isExpiringSoon( domain, 30 ) ||
+			isRecentlyRegistered( domain ) ||
+			( purchase && shouldRenderExpiringCreditCard( purchase ) )
+		) {
 			return null;
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This moves the GSuite TOS notice to the domain card to have a similar look and feel to the rest of domain notices.

Single email address:
<img width="725" alt="Screenshot 2020-06-18 at 8 28 57 PM" src="https://user-images.githubusercontent.com/13062352/85060158-0df37280-b1a5-11ea-9eab-88e5ddf65b7b.png">

Multiple email addresses:
<img width="724" alt="Screenshot 2020-06-18 at 8 22 22 PM" src="https://user-images.githubusercontent.com/13062352/85060165-10ee6300-b1a5-11ea-8ec2-149eb746e111.png">


#### Testing instructions

* Purchase G Suite for a mapped or registered domain of yours
* Verify that one of the messages from the screenshots above is shown according to the number of email addresses
* Make sure the 'Get started' button works as expected
