### PR TITLE
Fix missing key attribute warning for Manage All Domains link

### DIFF
--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -441,7 +441,7 @@ export class List extends React.Component {
 
 		return [
 			...domainListItems,
-			<CompactCard href={ domainManagementRoot() }>
+			<CompactCard key="manage-all-domains" href={ domainManagementRoot() }>
 				{ translate( 'Manage all your domains' ) }
 			</CompactCard>,
 		];


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This fixes a [development mode warning](https://github.com/Automattic/wp-calypso/pull/42954#discussion_r442379372) for the 'Manage all your domains' link.

#### Testing instructions

Should be fairly trivial, but spin Calypso locally, go to /domains/manage/<site_slug> and verify no errors are shown in the console regarding the missing key.
