### PR TITLE
Marketing: Update marketing cards to use similar styling to Earn cards

### DIFF
--- a/client/my-sites/marketing/tools/feature-button-with-plan-gate.tsx
+++ b/client/my-sites/marketing/tools/feature-button-with-plan-gate.tsx
@@ -57,15 +57,11 @@ const MarketingToolsFeatureButtonWithPlanGate: FunctionComponent<
 	};
 
 	if ( hasPlanFeature ) {
-		return (
-			<Button compact onClick={ onDefaultButtonClick }>
-				{ buttonText }
-			</Button>
-		);
+		return <Button onClick={ onDefaultButtonClick }>{ buttonText }</Button>;
 	}
 
 	return (
-		<Button compact onClick={ handleUpgradeClick }>
+		<Button onClick={ handleUpgradeClick }>
 			{ translate( 'Upgrade to %(plan)s', {
 				args: {
 					plan: planTitle,

--- a/client/my-sites/marketing/tools/google-adwords.tsx
+++ b/client/my-sites/marketing/tools/google-adwords.tsx
@@ -60,7 +60,7 @@ export const MarketingToolsGoogleAdwordsFeature: FunctionComponent< ConnectedPro
 			return <GoogleVoucherDetails />;
 		}
 		return (
-			<Button className="tools__upgrade-button" compact onClick={ handleUpgradeClick }>
+			<Button className="tools__upgrade-button" onClick={ handleUpgradeClick }>
 				{ translate( 'Upgrade to Premium' ) }
 			</Button>
 		);

--- a/client/my-sites/marketing/tools/index.tsx
+++ b/client/my-sites/marketing/tools/index.tsx
@@ -75,7 +75,6 @@ export const MarketingTools: FunctionComponent< Props > = ( {
 					imagePath="/calypso/images/marketing/looka-logo.svg"
 				>
 					<Button
-						compact
 						onClick={ handleCreateALogoClick }
 						href="https://wp.me/logo-maker"
 						target="_blank"
@@ -91,9 +90,7 @@ export const MarketingTools: FunctionComponent< Props > = ( {
 					) }
 					imagePath="/calypso/images/marketing/social-media-logos.svg"
 				>
-					<Button compact onClick={ handleStartSharingClick }>
-						{ translate( 'Start sharing' ) }
-					</Button>
+					<Button onClick={ handleStartSharingClick }>{ translate( 'Start sharing' ) }</Button>
 				</MarketingToolsFeature>
 
 				<MarketingToolsGoogleMyBusinessFeature />
@@ -108,7 +105,6 @@ export const MarketingTools: FunctionComponent< Props > = ( {
 					imagePath="/calypso/images/marketing/upwork-logo.png"
 				>
 					<Button
-						compact
 						onClick={ handleFindYourExpertClick }
 						href={ '/experts/upwork?source=marketingtools' }
 						target="_blank"

--- a/client/my-sites/marketing/tools/style.scss
+++ b/client/my-sites/marketing/tools/style.scss
@@ -99,6 +99,8 @@
 	width: 100%;
 
 	> p {
+		color: var( --color-text-subtle );
+		font-size: $font-body-small;
 		margin-bottom: 0;
 	}
 
@@ -129,6 +131,7 @@
 
 	.button {
 		margin: 0;
+		margin-left: calc( 15% + 20px );
 		text-align: center;
 		width: auto;
 	}
@@ -152,24 +155,18 @@
 
 	@include breakpoint-deprecated( '>480px' ) {
 		flex-direction: row;
-		justify-content: flex-end;
+		justify-content: flex-start;
 
 		.google-voucher__initial-step {
 			display: block;
 		}
 
 		.button {
-			margin: 0 1em 0 0;
 			width: auto;
 		}
 	}
 
 	@include breakpoint-deprecated( '>1040px' ) {
-
-		.button {
-			margin: 0 0 0 1em;
-		}
-
 		.purchase-detail__button {
 			float: right;
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Aiming for a more consistent look and feel between Earn and Marketing (since the screens look so similar), this PR moves the buttons to the left, makes them non-compact, and updates the font size/color of the explanatory copy in each card.
* Obviously there's more we can do to bring these two similar screens into alignment -- thinking we could right-align the illustration in the larger card at the top, and swap it out for one of our updated versions, and apply the same typography treatments. That could easily be another PR, though.
* I'd welcome thoughts from Marketing folks on this one!

**Before**

![screencapture-wordpress-marketing-tools-calobeetesting87-wordpress-com-2020-06-18-15_07_26](https://user-images.githubusercontent.com/2124984/85062526-a292ac00-b176-11ea-9291-35527c1da6c8.png)

**After**

![screencapture-calypso-localhost-3000-marketing-tools-calobeetesting87-wordpress-com-2020-06-18-15_04_03](https://user-images.githubusercontent.com/2124984/85062538-a8888d00-b176-11ea-87ee-9ca7999a4b54.png)

Earn screen for comparison

![screencapture-calypso-localhost-3000-earn-calobeetesting87-wordpress-com-2020-06-18-15_13_05](https://user-images.githubusercontent.com/2124984/85062650-d79efe80-b176-11ea-8980-5de9eee60bd3.png)

#### Testing instructions

* Switch to this PR
* Navigate to `/marketing` and note visual changes. Make sure there are no bugs or visual regressions.

See #42058