### PR TITLE
Jetpack section: add Jetpack Backup/Scan upsell pages in WPCOM for Jetpack sites

### DIFF
--- a/client/my-sites/backup/controller.js
+++ b/client/my-sites/backup/controller.js
@@ -9,14 +9,17 @@ import React from 'react';
 import BackupRewindFlow, { RewindFlowPurpose } from './rewind-flow';
 import BackupsPage from './main';
 import UpsellSwitch from 'components/jetpack/upsell-switch';
-import BackupsUpsell from './backup-upsell';
+import BackupUpsell from './backup-upsell';
+import WPCOMBackupUpsell from './wpcom-backup-upsell';
 import getRewindState from 'state/selectors/get-rewind-state';
 import QueryRewindState from 'components/data/query-rewind-state';
+import isJetpackCloud from 'lib/jetpack/is-jetpack-cloud';
 
 export function showUpsellIfNoBackup( context, next ) {
+	const UpsellComponent = isJetpackCloud() ? BackupUpsell : WPCOMBackupUpsell;
 	context.primary = (
 		<UpsellSwitch
-			UpsellComponent={ BackupsUpsell }
+			UpsellComponent={ UpsellComponent }
 			display={ context.primary }
 			getStateForSite={ getRewindState }
 			QueryComponent={ QueryRewindState }

--- a/client/my-sites/backup/style.scss
+++ b/client/my-sites/backup/style.scss
@@ -122,4 +122,16 @@
 			margin-top: 64px;
 		}
 	}
+
+	.backup__wpcom-ctas {
+		margin: 16px 0;
+	}
+
+	.backup__wpcom-cta {
+		margin-top: 8px;
+	}
+
+	.backup__wpcom-realtime-cta {
+		margin-right: 16px;
+	}
 }

--- a/client/my-sites/backup/wpcom-backup-upsell.tsx
+++ b/client/my-sites/backup/wpcom-backup-upsell.tsx
@@ -1,0 +1,78 @@
+/**
+ * External dependencies
+ */
+import React, { ReactElement } from 'react';
+import { translate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { Button } from '@automattic/components';
+import DocumentHead from 'components/data/document-head';
+import Main from 'components/main';
+import SidebarNavigation from 'my-sites/sidebar-navigation';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
+import FormattedHeader from 'components/formatted-header';
+import PromoCard from 'components/promo-section/promo-card';
+import useTrackCallback from 'lib/jetpack/use-track-callback';
+import { getSelectedSiteSlug } from 'state/ui/selectors';
+
+/**
+ * Asset dependencies
+ */
+import JetpackBackupSVG from 'assets/images/illustrations/jetpack-backup.svg';
+import './style.scss';
+
+const trackEventName = 'calypso_jetpack_backup_upsell';
+
+export default function WPCOMUpsellPage(): ReactElement {
+	const onUpgradeClick = useTrackCallback( undefined, trackEventName );
+	const siteSlug = useSelector( getSelectedSiteSlug );
+
+	return (
+		<Main className="backup__main backup__wpcom-upsell">
+			<DocumentHead title="Jetpack Backup" />
+			<SidebarNavigation />
+			<PageViewTracker path="/backup/:site" title="Backup" />
+
+			<FormattedHeader
+				headerText={ translate( 'Jetpack Backup' ) }
+				id="backup-header"
+				align="left"
+			/>
+
+			<PromoCard
+				title={ translate( 'Get time travel for your site with Jetpack Backup' ) }
+				image={ { path: JetpackBackupSVG } }
+				isPrimary
+			>
+				<p>
+					{ translate(
+						'Backup gives you granular control over your site, with the ability to restore it to any previous state, and export it at any time.'
+					) }
+				</p>
+
+				<div className="backup__wpcom-ctas">
+					<Button
+						className="backup__wpcom-cta backup__wpcom-realtime-cta"
+						href={ `/checkout/${ siteSlug }/jetpack_backup_realtime` }
+						onClick={ onUpgradeClick }
+						selfTarget={ true }
+						primary
+					>
+						{ translate( 'Get real-time backups' ) }
+					</Button>
+					<Button
+						className="backup__wpcom-cta backup__wpcom-daily-cta"
+						href={ `/checkout/${ siteSlug }/jetpack_backup_daily` }
+						onClick={ onUpgradeClick }
+						selfTarget={ true }
+					>
+						{ translate( 'Get daily backups' ) }
+					</Button>
+				</div>
+			</PromoCard>
+		</Main>
+	);
+}

--- a/client/my-sites/scan/controller.js
+++ b/client/my-sites/scan/controller.js
@@ -10,10 +10,12 @@ import UpsellSwitch from 'components/jetpack/upsell-switch';
 import ScanPage from './main';
 import ScanHistoryPage from './history';
 import ScanUpsellPage from './upsell';
+import WPCOMScanUpsellPage from './wpcom-scan-upsell';
 import getSiteScanState from 'state/selectors/get-site-scan-state';
 import QueryJetpackScan from 'components/data/query-jetpack-scan';
 import ScanPlaceholder from 'components/jetpack/scan-placeholder';
 import ScanHistoryPlaceholder from 'components/jetpack/scan-history-placeholder';
+import isJetpackCloud from 'lib/jetpack/is-jetpack-cloud';
 
 export function showUpsellIfNoScan( context, next ) {
 	context.primary = scanUpsellSwitcher( <ScanPlaceholder />, context.primary );
@@ -38,9 +40,10 @@ export function scanHistory( context, next ) {
 }
 
 function scanUpsellSwitcher( placeholder, primary ) {
+	const UpsellComponent = isJetpackCloud() ? ScanUpsellPage : WPCOMScanUpsellPage;
 	return (
 		<UpsellSwitch
-			UpsellComponent={ ScanUpsellPage }
+			UpsellComponent={ UpsellComponent }
 			display={ primary }
 			getStateForSite={ getSiteScanState }
 			QueryComponent={ QueryJetpackScan }

--- a/client/my-sites/scan/wpcom-scan-upsell.tsx
+++ b/client/my-sites/scan/wpcom-scan-upsell.tsx
@@ -1,0 +1,63 @@
+/**
+ * External dependencies
+ */
+import React, { ReactElement } from 'react';
+import { translate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import DocumentHead from 'components/data/document-head';
+import Main from 'components/main';
+import SidebarNavigation from 'my-sites/sidebar-navigation';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
+import FormattedHeader from 'components/formatted-header';
+import PromoCard from 'components/promo-section/promo-card';
+import PromoCardCTA from 'components/promo-section/promo-card/cta';
+import useTrackCallback from 'lib/jetpack/use-track-callback';
+import { getSelectedSiteSlug } from 'state/ui/selectors';
+
+/**
+ * Asset dependencies
+ */
+import JetpackScanSVG from 'assets/images/illustrations/jetpack-scan.svg';
+import './style.scss';
+
+export default function WPCOMScanUpsellPage(): ReactElement {
+	const onUpgradeClick = useTrackCallback( undefined, 'calypso_jetpack_scan_upsell' );
+	const siteSlug = useSelector( getSelectedSiteSlug );
+
+	return (
+		<Main className="scan__main scan__wpcom-upsell">
+			<DocumentHead title="Scanner" />
+			<SidebarNavigation />
+			<PageViewTracker path="/scan/:site" title="Scanner" />
+
+			<FormattedHeader headerText={ translate( 'Jetpack Scan' ) } id="scan-header" align="left" />
+
+			<PromoCard
+				title={ translate( 'We guard your site. You run your business.' ) }
+				image={ { path: JetpackScanSVG } }
+				isPrimary
+			>
+				<p>
+					{ translate(
+						'Scan gives you automated scanning and one-click fixes ' +
+							'to keep your site ahead of security threats.'
+					) }
+				</p>
+				<PromoCardCTA
+					cta={ {
+						text: translate( 'Get daily scans' ),
+						action: {
+							url: `/checkout/${ siteSlug }/jetpack_scan`,
+							onClick: onUpgradeClick,
+							selfTarget: true,
+						},
+					} }
+				/>
+			</PromoCard>
+		</Main>
+	);
+}

--- a/client/my-sites/scan/wpcom-scan-upsell.tsx
+++ b/client/my-sites/scan/wpcom-scan-upsell.tsx
@@ -49,7 +49,7 @@ export default function WPCOMScanUpsellPage(): ReactElement {
 				</p>
 				<PromoCardCTA
 					cta={ {
-						text: translate( 'Get daily scans' ),
+						text: translate( 'Get daily scanning' ),
 						action: {
 							url: `/checkout/${ siteSlug }/jetpack_scan`,
 							onClick: onUpgradeClick,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add Jetpack Backup/Scan upsell pages in WPCOM for Jetpack sites.

#### Testing instructions

* Prerequisite: Jetpack site without Backup and Scan.
* Run this PR with `flags=jetpack/features-section'  enabled.
* Go to `http://jetpack.cloud.localhost:3000/backup/[site]`.
* Verify that you see the new Jetpack Backup upsell page.
* Verify that both CTAs take you to the right checkout pages.
* Go to `http://jetpack.cloud.localhost:3000/scan/[site]`.
* Verify that you see the new Jetpack Scan upsell page.
* Verify that the CTA takes you to the right checkout page.

#### Other things to tests

* Make sure that you still see the Business upsell when the selected site is a Simple site.
* Make sure that Jetpack cloud upsell pages look the same as in cloud.jetpack.com.

Fixes 1179060693083348-as-1180644091306241

#### Demo

##### Backup
![image](https://user-images.githubusercontent.com/3418513/85069520-a4666a80-b18a-11ea-8057-fc641e125299.png)

##### Scan
![image](https://user-images.githubusercontent.com/3418513/85069539-af20ff80-b18a-11ea-8fd0-7b95c5ef857f.png)

