### PR TITLE
update pick plan page to find correct plan

### DIFF
--- a/test/e2e/lib/pages/signup/pick-a-plan-page.js
+++ b/test/e2e/lib/pages/signup/pick-a-plan-page.js
@@ -87,14 +87,15 @@ export default class PickAPlanPage extends AsyncBaseContainer {
 		// Defaults to showing business plan first, so we need to move to correct plan
 		if ( driverManager.currentScreenSize() === 'mobile' ) {
 			switch ( level ) {
-				case 'premium':
-					await this.clickDirectionArrow( 'left' );
+				case 'business':
+					await this.clickDirectionArrow( 'right' );
 					break;
 				case 'personal':
 					await this.clickDirectionArrow( 'left' );
 					await this.clickDirectionArrow( 'left' );
 					break;
 				case 'ecommerce':
+					await this.clickDirectionArrow( 'right' );
 					await this.clickDirectionArrow( 'right' );
 					break;
 				default:


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This change updates the plan selection page on mobile. The default plan changed so the tests weren't always able to find the correct page, especially if the tests ran a little slow.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Fixes #
