### PR TITLE
Reader CSS: moves Youtube and Vimeo classes to _content.scss

### DIFF
--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -407,3 +407,25 @@
 .is-reader-page .reader-full-post__story-content {
 	padding-top: 0 !important;
 }
+
+.reader-full-post .embed-youtube,
+.reader-full-post .embed-vimeo {
+	display: block;
+	margin-bottom: 25px;
+	position: relative;
+	padding: 25px 0 56.25%;
+	// We currently have to use !important here to override the inline style on the Youtube embed
+	// - see https://github.com/Automattic/wp-calypso/issues/9615
+	text-align: initial !important;
+
+	iframe {
+		height: 100%;
+		position: absolute;
+		top: 0;
+		width: 100%;
+	}
+}
+
+.reader-full-post .embed-vimeo {
+	margin-bottom: 0;
+}

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -559,28 +559,6 @@
 	margin: 28px 0 26px;
 }
 
-.reader-full-post .embed-youtube,
-.reader-full-post .embed-vimeo {
-	display: block;
-	margin-bottom: 25px;
-	position: relative;
-	padding: 25px 0 56.25%;
-	// We currently have to use !important here to override the inline style on the Youtube embed
-	// - see https://github.com/Automattic/wp-calypso/issues/9615
-	text-align: initial !important;
-
-	iframe {
-		height: 100%;
-		position: absolute;
-		top: 0;
-		width: 100%;
-	}
-}
-
-.reader-full-post .embed-vimeo {
-	margin-bottom: 0;
-}
-
 .reader-full-post__unavailable-body {
 	margin-top: 2em;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Moves the Youtube and Vimeo classes to the `_content.scss`. The reason for this change is because the CSS for the native apps are grabbed from the `_content.scss`, not the `style.scss` (which contains a lot of other styles related to Calypso itself, not rendering content).

#### Testing instructions

* Open the following post and compare to the current Reader in production, nothing should change: https://wordpress.com/read/blogs/159889361/posts/1025