### PR TITLE
Nav Sidebar: clicking nav items opens that item in the block editor

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/create-page/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/create-page/index.tsx
@@ -13,7 +13,7 @@ import { addQueryArgs } from '@wordpress/url';
 import './style.scss';
 
 interface Props {
-	postType: any;
+	postType: { slug: string };
 }
 
 export default function CreatePage( { postType }: Props ) {

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/create-page/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/create-page/index.tsx
@@ -3,7 +3,6 @@
  */
 import { get } from 'lodash';
 import { Button } from '@wordpress/components';
-import React from '@wordpress/element';
 import { applyFilters } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-item/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-item/index.tsx
@@ -4,6 +4,8 @@
 import classNames from 'classnames';
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
+import { applyFilters } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -13,11 +15,12 @@ import './style.scss';
 
 interface NavItemProps {
 	item: Post;
+	postType: { slug: string };
 	selected: boolean;
 	statusLabel?: string;
 }
 
-export default function NavItem( { item, selected, statusLabel }: NavItemProps ) {
+export default function NavItem( { item, postType, selected, statusLabel }: NavItemProps ) {
 	const buttonClasses = classNames( 'wpcom-block-editor-nav-item', {
 		'is-selected': selected,
 	} );
@@ -26,9 +29,21 @@ export default function NavItem( { item, selected, statusLabel }: NavItemProps )
 		'is-untitled': ! item.title?.raw,
 	} );
 
+	const defaultEditUrl = addQueryArgs( 'post.php', { post: item.id, action: 'edit' } );
+	const editUrl = applyFilters(
+		'a8c.WpcomBlockEditorNavSidebar.editPostUrl',
+		defaultEditUrl,
+		item.id,
+		postType.slug
+	);
+
 	return (
 		<li>
-			<Button className={ buttonClasses }>
+			<Button
+				className={ buttonClasses }
+				href={ editUrl }
+				target={ applyFilters( 'a8c.WpcomBlockEditorNavSidebar.linkTarget', undefined ) }
+			>
 				<div className="wpcom-block-editor-nav-item__title-container">
 					<div className={ titleClasses }>
 						{ item.title?.raw || __( 'Untitled', 'full-site-editing' ) }

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-item/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-item/index.tsx
@@ -1,0 +1,44 @@
+/**
+ * External dependencies
+ */
+import classNames from 'classnames';
+import { Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { Post } from '../../types';
+import './style.scss';
+
+interface NavItemProps {
+	item: Post;
+	selected: boolean;
+	statusLabel?: string;
+}
+
+export default function NavItem( { item, selected, statusLabel }: NavItemProps ) {
+	const buttonClasses = classNames( 'wpcom-block-editor-nav-item', {
+		'is-selected': selected,
+	} );
+
+	const titleClasses = classNames( 'wpcom-block-editor-nav-item__title', {
+		'is-untitled': ! item.title?.raw,
+	} );
+
+	return (
+		<li>
+			<Button className={ buttonClasses }>
+				<div className="wpcom-block-editor-nav-item__title-container">
+					<div className={ titleClasses }>
+						{ item.title?.raw || __( 'Untitled', 'full-site-editing' ) }
+					</div>
+					{ item.slug && (
+						<div className="wpcom-block-editor-nav-item__slug">{ `/${ item.slug }/` }</div>
+					) }
+				</div>
+				{ statusLabel && <div className="wpcom-block-editor-nav-item__label">{ statusLabel }</div> }
+			</Button>
+		</li>
+	);
+}

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-item/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-item/index.tsx
@@ -3,7 +3,7 @@
  */
 import classNames from 'classnames';
 import { Button } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { _x } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { applyFilters } from '@wordpress/hooks';
 
@@ -46,7 +46,8 @@ export default function NavItem( { item, postType, selected, statusLabel }: NavI
 			>
 				<div className="wpcom-block-editor-nav-item__title-container">
 					<div className={ titleClasses }>
-						{ item.title?.raw || __( 'Untitled', 'full-site-editing' ) }
+						{ item.title?.raw ||
+							_x( 'Untitled', 'post title for posts with no title', 'full-site-editing' ) }
 					</div>
 					{ item.slug && (
 						<div className="wpcom-block-editor-nav-item__slug">{ `/${ item.slug }/` }</div>

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-item/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-item/style.scss
@@ -1,0 +1,55 @@
+@import '~@wordpress/base-styles/colors';
+@import '~@wordpress/base-styles/variables';
+
+.wpcom-block-editor-nav-item {
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	width: 100%;
+	height: auto;
+	margin: 0;
+	padding: ($panel-padding / 2) $panel-padding;
+	border-radius: $radius-block-ui;
+	text-align: initial;
+
+	&.is-selected {
+		background: $black;
+		color: $white;
+
+		.wpcom-block-editor-nav-item__label {
+			background: $dark-gray-500;
+		}
+	}
+
+	&:not( .is-selected ):hover {
+		background: $light-gray-400;
+	}
+
+	&:not( .is-selected ) .wpcom-block-editor-nav-item__slug {
+		color: $dark-gray-300;
+	}
+}
+
+.wpcom-block-editor-nav-item__title-container {
+	flex: 1;
+}
+
+.wpcom-block-editor-nav-item__title {
+	&.is-untitled {
+		font-style: italic;
+		color: $medium-gray-text;
+	}
+}
+
+.wpcom-block-editor-nav-item__slug {
+	font-size: $default-font-size - 2;
+	padding-top: 4px;
+}
+
+.wpcom-block-editor-nav-item__label {
+	display: inline-block;
+	padding: 4px;
+	border-radius: $radius-round-rectangle;
+	background: $light-gray-600;
+	font-weight: 600;
+}

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
@@ -117,6 +117,7 @@ export default function WpcomBlockEditorNavSidebar() {
 						<NavItem
 							key={ item.id }
 							item={ item }
+							postType={ postType } // We know the post type of this item is always the same as the post type of the current editor
 							selected={ item.id === selectedItemId }
 							statusLabel={ statusLabels[ item.status ] }
 						/>

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
@@ -1,8 +1,7 @@
-/* eslint-disable import/no-extraneous-dependencies */
 /**
  * External dependencies
  */
-import React, { useState, useEffect, useRef } from '@wordpress/element';
+import { useState, useEffect, useRef, WPSyntheticEvent } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { Button as OriginalButton } from '@wordpress/components';
 import { chevronLeft, wordpress } from '@wordpress/icons';
@@ -18,14 +17,9 @@ import classNames from 'classnames';
 import { STORE_KEY } from '../../constants';
 import CreatePage from '../create-page';
 import ViewAllPosts from '../view-all-posts';
+import NavItem from '../nav-item';
+import { Post } from '../../types';
 import './style.scss';
-
-interface Post {
-	id: number;
-	slug: string;
-	status: string;
-	title: { raw: string; rendered: string };
-}
 
 const Button = ( {
 	children,
@@ -69,7 +63,7 @@ export default function WpcomBlockEditorNavSidebar() {
 	let closeLabel = get( postType, [ 'labels', 'all_items' ], __( 'Back', 'full-site-editing' ) );
 	closeLabel = applyFilters( 'a8c.WpcomBlockEditorNavSidebar.closeLabel', closeLabel );
 
-	const handleClose = ( e: React.WPSyntheticEvent ) => {
+	const handleClose = ( e: WPSyntheticEvent ) => {
 		if ( hasAction( 'a8c.wpcom-block-editor.closeEditor' ) ) {
 			e.preventDefault();
 			doAction( 'a8c.wpcom-block-editor.closeEditor' );
@@ -132,40 +126,6 @@ export default function WpcomBlockEditorNavSidebar() {
 				<ViewAllPosts postType={ postType } />
 			</div>
 		</div>
-	);
-}
-
-interface NavItemProps {
-	item: Post;
-	selected: boolean;
-	statusLabel?: string;
-}
-
-function NavItem( { item, selected, statusLabel }: NavItemProps ) {
-	const buttonClasses = classNames( 'wpcom-block-editor-nav-sidebar__item-button', {
-		'is-selected': selected,
-	} );
-
-	const titleClasses = classNames( 'wpcom-block-editor-nav-sidebar__title', {
-		'is-untitled': ! item.title?.raw,
-	} );
-
-	return (
-		<li>
-			<Button className={ buttonClasses }>
-				<div className="wpcom-block-editor-nav-sidebar__title-container">
-					<div className={ titleClasses }>
-						{ item.title?.raw || __( 'Untitled', 'full-site-editing' ) }
-					</div>
-					{ item.slug && (
-						<div className="wpcom-block-editor-nav-sidebar__slug">{ `/${ item.slug }/` }</div>
-					) }
-				</div>
-				{ statusLabel && (
-					<div className="wpcom-block-editor-nav-sidebar__label">{ statusLabel }</div>
-				) }
-			</Button>
-		</li>
 	);
 }
 

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/style.scss
@@ -114,60 +114,6 @@ $transition-period: 200ms;
 	padding: 0;
 }
 
-.wpcom-block-editor-nav-sidebar__item-button {
-	display: flex;
-	flex-direction: row;
-	align-items: center;
-	width: 100%;
-	height: auto;
-	margin: 0;
-	padding: ($panel-padding / 2) $panel-padding;
-	border-radius: $radius-block-ui;
-	text-align: initial;
-
-	&.is-selected {
-		background: $black;
-		color: $white;
-
-		.wpcom-block-editor-nav-sidebar__label {
-			background: $dark-gray-500;
-	}
-	}
-
-	&:not( .is-selected ):hover {
-		background: $light-gray-400;
-	}
-
-	&:not( .is-selected ) .wpcom-block-editor-nav-sidebar__slug {
-		color: $dark-gray-300;
-	}
-}
-
-.wpcom-block-editor-nav-sidebar__title-container {
-	flex: 1;
-}
-
-.wpcom-block-editor-nav-sidebar__title {
-	&.is-untitled {
-		font-style: italic;
-		color: $medium-gray-text;
-	}
-}
-
-.wpcom-block-editor-nav-sidebar__slug {
-	font-size: $default-font-size - 2;
-	padding-top: 4px;
-}
-
-.wpcom-block-editor-nav-sidebar__label {
-	display: inline-block;
-	padding: 4px;
-	border-radius: $radius-round-rectangle;
-	background: $light-gray-600;
-	font-weight: 600;
-}
-
-
 @keyframes wpcom-block-editor-nav-sidebar__shrink {
 	0% {
 		transform: scale( 1 );

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/view-all-posts/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/view-all-posts/index.tsx
@@ -3,7 +3,6 @@
  */
 import { get } from 'lodash';
 import { Button as OriginalButton } from '@wordpress/components';
-import React from '@wordpress/element';
 import { applyFilters } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/view-all-posts/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/view-all-posts/index.tsx
@@ -13,7 +13,7 @@ import { addQueryArgs } from '@wordpress/url';
 import './style.scss';
 
 interface Props {
-	postType: any;
+	postType: { slug: string };
 }
 
 const Button = ( { children, ...rest }: OriginalButton.Props & { isSecondary?: boolean } ) => (

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/types.ts
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/types.ts
@@ -1,0 +1,6 @@
+export interface Post {
+	id: number;
+	slug: string;
+	status: string;
+	title: { raw: string; rendered: string };
+}

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -819,6 +819,18 @@ function getCalypsoUrlInfo( calypsoPort ) {
 		}
 	);
 
+	addFilter(
+		'a8c.WpcomBlockEditorNavSidebar.editPostUrl',
+		'wpcom-block-editor/getSiteSlug',
+		( url, postId, postType ) => {
+			if ( origin && siteSlug && ( postType === 'page' || postType === 'post' ) ) {
+				return `${ origin }/block-editor/${ postType }/${ siteSlug }/${ postId }`;
+			}
+
+			return url;
+		}
+	);
+
 	// All links should open outside the iframe
 	addFilter(
 		'a8c.WpcomBlockEditorNavSidebar.linkTarget',


### PR DESCRIPTION
**_Note to anyone reading this while preparing a release of the FSE plugin_**

This change doesn't require any release notes. We're developing a new feature which is currently hidden behind a flag.

#### Changes proposed in this Pull Request

The last major piece of functionality, clicking a page/post opens that item in the block editor.

* Clicking nav item will open that item in the block editor
* If calypsoify is present then ensure item is opened in an iframe'd block editor
* Refactor `<NavItem>` component to its own file to make space for more complicated filtery things
* Small TypeScript tidyup

The navigation takes a long time when iframe'd, which I guess is pretty normal. We could potentially speed this up by only navigating the iframe and leaving the parent frame alone (we'd have to see if `<CalypsoifyIframe>` would support this). Perhaps there's even a way to dispatch a gutenberg event to change what post in the editor! That'd be a nice thing to check for a later PR.

![Jun-19-2020 16-53-15](https://user-images.githubusercontent.com/1500769/85098361-91b56980-b24e-11ea-8bab-f80ff2001ef4.gif)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Test on dotorg site**

* Checkout branch
* `cd apps/full-site-editing`
* `yarn build` or `yarn dev`
* Define `WPCOM_BLOCK_EDITOR_SIDEBAR` in [`.wp-env.override.json`](https://developer.wordpress.org/block-editor/packages/packages-env/#wp-env-override-json)
* `npx wp-env start`
* Test the editor at `http://localhost:4013` (username: `admin`, password: `password`)
* Clicking posts/pages in the sidebar should open that item in the editor

**Test on dotcom site**

* Sandbox `widgets.wp.com` and your favourite 
* Define `WPCOM_BLOCK_EDITOR_SIDEBAR` in sandbox
* Apply D45181-code to sandbox
* Apply `wpcom-block-editor` build 780563 to your sandbox (see "Automatic" section of PCYsg-l4k-p2)
* Test the editor in your sandboxed site
* Clicking posts/pages in the sidebar should open that item in the editor
