### PR TITLE
Nav Sidebar: use the official slot API to replace close button

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/attach-sidebar.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/attach-sidebar.tsx
@@ -1,98 +1,66 @@
 /**
  * External dependencies
  */
-import { dispatch, select, subscribe } from '@wordpress/data';
-import React, { render } from '@wordpress/element';
-import { addFilter } from '@wordpress/hooks';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
+import { __experimentalMainDashboardButton as MainDashboardButton } from '@wordpress/interface';
+import { registerPlugin as originalRegisterPlugin, PluginSettings } from '@wordpress/plugins';
 
 /**
  * Internal dependencies
  */
 import { STORE_KEY } from './constants';
-import WpcomBlockEditorNavSidebar, { selectNavItems } from './components/nav-sidebar';
+import WpcomBlockEditorNavSidebar from './components/nav-sidebar';
+import ToggleSidebarButton from './components/toggle-sidebar-button';
 
-async function findElement( selector: string, timeoutMs = 5000 ) {
-	let pendingQuery;
-	const pollForLoadedFlag = new Promise< HTMLElement >( ( resolve ) => {
-		const runQuery = () => {
-			const element = document.querySelector( selector ) as HTMLElement;
+const registerPlugin = ( name: string, settings: Omit< PluginSettings, 'icon' > ) =>
+	originalRegisterPlugin( name, settings as any );
 
-			if ( ! element ) {
-				pendingQuery = setTimeout( runQuery, 200 );
-				return;
+registerPlugin( 'a8c-full-site-editing-nav-sidebar', {
+	render: function NavSidebar() {
+		const { addEntities } = useDispatch( 'core' );
+		const isSidebarOpened = useSelect( ( select ) => select( STORE_KEY ).isSidebarOpened() );
+
+		useEffect( () => {
+			// Teach core data about the status entity so we can use selectors like `getEntityRecords()`
+			addEntities( [
+				{
+					baseURL: '/wp/v2/statuses',
+					key: 'slug',
+					kind: 'root',
+					name: 'status',
+					plural: 'statuses',
+				},
+			] );
+
+			// Only register entity once
+			// eslint-disable-next-line react-hooks/exhaustive-deps
+		}, [] );
+
+		// TODO: remove this effect once sidebar opens over the editor and doesn't
+		// squish the editor content.
+		useEffect( () => {
+			// Classes need to be attached to elements that aren't controlled by React,
+			// otherwise our alterations will be removed when React re-renders. So attach
+			// to <body> element.
+			document.body.classList.add( 'is-wpcom-block-editor-nav-sidebar-attached' );
+		}, [] );
+
+		// TODO: remove this effect once sidebar opens over the editor and doesn't
+		// squish the editor content.
+		useEffect( () => {
+			if ( isSidebarOpened ) {
+				document.body.classList.add( 'is-wpcom-block-editor-nav-sidebar-opened' );
+			} else {
+				document.body.classList.remove( 'is-wpcom-block-editor-nav-sidebar-opened' );
 			}
+		}, [ isSidebarOpened ] );
 
-			resolve( element );
-		};
-
-		runQuery();
-	} );
-
-	const timeout = new Promise< 'timeout' >( ( resolve ) =>
-		setTimeout( resolve, timeoutMs, 'timeout' )
-	);
-
-	const finishCondition = await Promise.race( [ pollForLoadedFlag, timeout ] );
-	clearTimeout( pendingQuery );
-
-	if ( finishCondition === 'timeout' ) {
-		return undefined;
-	}
-
-	return finishCondition;
-}
-
-async function attachSidebar() {
-	const closePostButton = await findElement( '.edit-post-fullscreen-mode-close' );
-	if ( ! closePostButton ) {
-		return;
-	}
-
-	addFilter( 'a8c.wpcom-block-editor.shouldCloseEditor', 'a8c/fse/attachSidebar', () => false );
-
-	// Teach core data about the status entity so we can use selectors like `getEntityRecords()`
-	dispatch( 'core' ).addEntities( [
-		{
-			baseURL: '/wp/v2/statuses',
-			key: 'slug',
-			kind: 'root',
-			name: 'status',
-			plural: 'statuses',
-		},
-	] );
-
-	// Classes need to be attached to elements that aren't controlled by React,
-	// otherwise our alterations will be removed when React re-renders. So attach
-	// to <body> element.
-	document.body.classList.add( 'is-wpcom-block-editor-nav-sidebar-attached' );
-
-	closePostButton.addEventListener( 'click', ( ev ) => {
-		ev.preventDefault();
-		dispatch( STORE_KEY ).toggleSidebar();
-	} );
-
-	let sidebarExpanded = false;
-	subscribe( () => {
-		const newSidebarState = select( STORE_KEY ).isSidebarOpened();
-		if ( sidebarExpanded === newSidebarState ) {
-			return;
-		}
-
-		sidebarExpanded = newSidebarState;
-
-		if ( sidebarExpanded ) {
-			document.body.classList.add( 'is-wpcom-block-editor-nav-sidebar-opened' );
-		} else {
-			document.body.classList.remove( 'is-wpcom-block-editor-nav-sidebar-opened' );
-		}
-	} );
-
-	const sidebarContainer = document.createElement( 'div' );
-	document.body.appendChild( sidebarContainer );
-	render( <WpcomBlockEditorNavSidebar />, sidebarContainer );
-
-	// Start pre-loading sidebar content
-	selectNavItems( select );
-}
-
-attachSidebar();
+		return (
+			<MainDashboardButton>
+				<ToggleSidebarButton />
+				<WpcomBlockEditorNavSidebar />
+			</MainDashboardButton>
+		);
+	},
+} );

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/toggle-sidebar-button/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/toggle-sidebar-button/index.tsx
@@ -1,0 +1,32 @@
+/**
+ * External dependencies
+ */
+import { Button as OriginalButton } from '@wordpress/components';
+import { wordpress } from '@wordpress/icons';
+import { useDispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { STORE_KEY } from '../../constants';
+import './style.scss';
+
+const Button = ( {
+	children,
+	...rest
+}: OriginalButton.Props & { icon?: any; iconSize?: number } ) => (
+	<OriginalButton { ...rest }>{ children }</OriginalButton>
+);
+
+export default function ToggleSidebarButton() {
+	const { toggleSidebar } = useDispatch( STORE_KEY );
+
+	return (
+		<Button
+			className="edit-post-fullscreen-mode-close a8c-full-site-editing__close-button"
+			icon={ wordpress }
+			iconSize={ 36 }
+			onClick={ toggleSidebar }
+		></Button>
+	);
+}

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/toggle-sidebar-button/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/toggle-sidebar-button/style.scss
@@ -1,0 +1,5 @@
+@import '~@wordpress/base-styles/variables';
+
+.a8c-full-site-editing__close-button {
+	height: $header-height !important;
+}

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/wp-interface-types.d.ts
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/wp-interface-types.d.ts
@@ -1,0 +1,3 @@
+declare module '@wordpress/interface' {
+	export const __experimentalMainDashboardButton: React.ComponentType;
+}

--- a/apps/full-site-editing/package.json
+++ b/apps/full-site-editing/package.json
@@ -95,8 +95,8 @@
 		"@automattic/calypso-build": "*",
 		"@automattic/data-stores": "^1.0.0-alpha.1",
 		"@automattic/domain-picker": "^1.0.0-alpha.0",
-		"@automattic/plans-grid": "^1.0.0-alpha.0",
 		"@automattic/format-currency": "^1.0.0-alpha.0",
+		"@automattic/plans-grid": "^1.0.0-alpha.0",
 		"@wordpress/api-fetch": "*",
 		"@wordpress/base-styles": "1.9.0",
 		"@wordpress/block-editor": "*",
@@ -115,6 +115,7 @@
 		"@wordpress/html-entities": "*",
 		"@wordpress/i18n": "*",
 		"@wordpress/icons": "*",
+		"@wordpress/interface": "^0.6.0",
 		"@wordpress/keycodes": "*",
 		"@wordpress/plugins": "*",
 		"@wordpress/rich-text": "*",
@@ -128,6 +129,7 @@
 		"utility-types": "^3.10.0"
 	},
 	"devDependencies": {
+		"@types/wordpress__plugins": "^2.3.6",
 		"@wordpress/eslint-plugin": "^6.0.0"
 	}
 }

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -8,7 +8,7 @@ import $ from 'jquery';
 import { filter, find, forEach, get, map, partialRight } from 'lodash';
 import { dispatch, select, subscribe, use } from '@wordpress/data';
 import { createBlock, parse, rawHandler } from '@wordpress/blocks';
-import { addAction, addFilter, applyFilters, doAction, removeAction } from '@wordpress/hooks';
+import { addAction, addFilter, doAction, removeAction } from '@wordpress/hooks';
 import { addQueryArgs, getQueryArg } from '@wordpress/url';
 import { registerPlugin } from '@wordpress/plugins';
 import { __experimentalMainDashboardButton as MainDashboardButton } from '@wordpress/interface';
@@ -582,12 +582,7 @@ function handleCloseEditor( calypsoPort ) {
 	} );
 
 	const dispatchAction = ( e ) => {
-		if ( ! applyFilters( 'a8c.wpcom-block-editor.shouldCloseEditor', true ) ) {
-			return;
-		}
-
 		e.preventDefault();
-
 		doAction( 'a8c.wpcom-block-editor.closeEditor' );
 	};
 

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -17,6 +17,7 @@ import { wordpress } from '@wordpress/icons';
 import { Component, useEffect, useState } from 'react';
 import tinymce from 'tinymce/tinymce';
 import debugFactory from 'debug';
+import { STORE_KEY as NAV_SIDEBAR_STORE_KEY } from '../../../../full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/constants';
 
 /**
  * Internal dependencies
@@ -586,6 +587,10 @@ function handleCloseEditor( calypsoPort ) {
 		doAction( 'a8c.wpcom-block-editor.closeEditor' );
 	};
 
+	if ( isNavSidebarPresent() ) {
+		return;
+	}
+
 	registerPlugin( 'a8c-wpcom-block-editor-close-button-override', {
 		render: function CloseWpcomBlockEditor() {
 			const [ closeUrl, setCloseUrl ] = useState( calypsoifyGutenberg.closeUrl );
@@ -622,6 +627,16 @@ function handleCloseEditor( calypsoPort ) {
 			);
 		},
 	} );
+}
+
+/**
+ * Uses presence of data store to detect whether the nav sidebar has been loaded.
+ * Could run into timing issues, but the nav sidebar's data store is currently
+ * loaded early enough that this works for our needs.
+ */
+function isNavSidebarPresent() {
+	const selectors = select( NAV_SIDEBAR_STORE_KEY );
+	return !! selectors;
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -4106,6 +4106,15 @@
     "@types/react" "*"
     "@types/wordpress__data" "*"
 
+"@types/wordpress__plugins@^2.3.6":
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/@types/wordpress__plugins/-/wordpress__plugins-2.3.6.tgz#414c8adc8873261c54e35a87ff2a625624cddfca"
+  integrity sha512-eovTsXat8dx7JhksTJ0QnQ4iJD3qz81Hxk9/mb+hAF0+aJ2qTpIrVJ5/V08PaHaX3wbnr0O/KHZiA2an+OsSHw==
+  dependencies:
+    "@types/react" "*"
+    "@types/wordpress__components" "*"
+    "@wordpress/element" "^2.14.0"
+
 "@types/wordpress__rich-text@*":
   version "3.4.4"
   resolved "https://registry.yarnpkg.com/@types/wordpress__rich-text/-/wordpress__rich-text-3.4.4.tgz#81e2778099eeb6c5466d78eda261535f54a214ac"


### PR DESCRIPTION
**_Note to anyone reading this while preparing a release of the FSE plugin_**

This change doesn't require any release notes. We're developing a new feature which is currently hidden behind a flag.

#### Changes proposed in this Pull Request

Related to #43313, this changes the method the nav sidebar is using to override the (W) button in the top-left corner. It replaces the hacky way of overriding the close button with a new API which was added in WordPress/gutenberg#22323.

* Use `<MainDashboardButton>` control to override the editors close button
* Sidebar code now initialised using Gutenberg's `registerPlugin()` function; no longer need to call `React.render()` ourselves
* Remove code that searched for close button using a selector
* Remove `a8c.wpcom-block-editor.shouldCloseEditor` hook which is no longer needed
* `wpcom-block-editor` detects whether the nav sidebar is active and doesn't override the close button if it's enabled. Otherwise the slot API would add two close buttons.

We have various other pieces of code at a8c that override the close button (e.g. Jetpack, wpcom). We don't need to worry about them interfering with the nav sidebar because using this slot API means the old button is completely removed.

By removing the `a8c.wpcom-block-editor.shouldCloseEditor` hook the nav sidebar is now entirely independent of wpcom 🎉 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Test on dotorg site**

* Checkout branch
* `cd apps/full-site-editing`
* `yarn build` or `yarn dev`
* Define `WPCOM_BLOCK_EDITOR_SIDEBAR` in [`.wp-env.override.json`](https://developer.wordpress.org/block-editor/packages/packages-env/#wp-env-override-json)
* `npx wp-env start`
* Test the editor at `http://localhost:4013` (username: `admin`, password: `password`)
* Sidebar can be opened/closed via the (W) button. Should work the same as before this PR.

**Test on dotcom site**

* Sandbox `widgets.wp.com` and your favourite 
* Define `WPCOM_BLOCK_EDITOR_SIDEBAR` in sandbox
* Apply D45184-code to sandbox
* Test the editor in your sandboxed site
* Sidebar can be opened/closed via the (W) button. Should work the same as before this PR.
