### PR TITLE
Deduplicate qs

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -20757,15 +20757,10 @@ qs@6.7.0:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
 
-qs@^6.1.0:
+qs@^6.1.0, qs@^6.4.0, qs@^6.5.1, qs@^6.5.2, qs@^6.6.0, qs@^6.9.1:
   version "6.9.4"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.4.tgz#9090b290d1f91728d3c22e54843ca44aea5ab687"
   integrity sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ==
-
-qs@^6.4.0, qs@^6.5.1, qs@^6.5.2, qs@^6.6.0, qs@^6.9.1:
-  version "6.9.1"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.1.tgz#20082c65cb78223635ab1a9eaca8875a29bf8ec9"
-  integrity sha512-Cxm7/SS/y/Z3MHWSxXb8lIFqgqBowP5JMlTUFyJN88y0SGQhVmZnqFK/PeuMX9LzUyWsqqhNxIyg0jlzq946yA==
 
 qs@~0.6.0:
   version "0.6.6"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `qs` (done automatically with `npx yarn-deduplicate --packages qs`)

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
< Before
> After
---
< wp-calypso-monorepo@0.17.0 ->  -> ... -> qs@6.9.1
< wp-calypso-monorepo@0.17.0 -> @automattic/data-stores@1.0.0-alpha.1 -> ... -> qs@6.9.1
< wp-calypso-monorepo@0.17.0 -> @automattic/full-site-editing@1.10.0 -> ... -> qs@6.9.1
< wp-calypso-monorepo@0.17.0 -> @automattic/o2-blocks@1.0.0 -> ... -> qs@6.9.1
< wp-calypso-monorepo@0.17.0 -> @storybook/addon-actions@5.3.18 -> ... -> qs@6.9.1
< wp-calypso-monorepo@0.17.0 -> @storybook/react@5.3.18 -> ... -> qs@6.9.1
< wp-calypso-monorepo@0.17.0 -> @wordpress/api-fetch@3.15.0 -> ... -> qs@6.9.1
< wp-calypso-monorepo@0.17.0 -> @wordpress/block-directory@1.9.0 -> ... -> qs@6.9.1
< wp-calypso-monorepo@0.17.0 -> @wordpress/block-editor@3.11.0 -> ... -> qs@6.9.1
< wp-calypso-monorepo@0.17.0 -> @wordpress/block-library@2.18.0 -> ... -> qs@6.9.1
< wp-calypso-monorepo@0.17.0 -> @wordpress/core-data@2.16.0 -> ... -> qs@6.9.1
< wp-calypso-monorepo@0.17.0 -> @wordpress/data-controls@1.12.0 -> ... -> qs@6.9.1
< wp-calypso-monorepo@0.17.0 -> @wordpress/e2e-test-utils@4.7.0 -> ... -> qs@6.9.1
< wp-calypso-monorepo@0.17.0 -> @wordpress/edit-post@3.17.0 -> ... -> qs@6.9.1
< wp-calypso-monorepo@0.17.0 -> @wordpress/editor@9.16.0 -> ... -> qs@6.9.1
< wp-calypso-monorepo@0.17.0 -> @wordpress/format-library@1.18.0 -> ... -> qs@6.9.1
< wp-calypso-monorepo@0.17.0 -> @wordpress/media-utils@1.11.0 -> ... -> qs@6.9.1
< wp-calypso-monorepo@0.17.0 -> @wordpress/scripts@9.1.0 -> ... -> qs@6.9.1
< wp-calypso-monorepo@0.17.0 -> @wordpress/server-side-render@1.12.0 -> ... -> qs@6.9.1
< wp-calypso-monorepo@0.17.0 -> @wordpress/url@2.15.0 -> ... -> qs@6.9.1
< wp-calypso-monorepo@0.17.0 -> supertest@4.0.2 -> ... -> qs@6.9.1
< wp-calypso-monorepo@0.17.0 -> wp-calypso@0.17.0 -> ... -> qs@6.9.1
< wp-calypso-monorepo@0.17.0 -> wpcom@6.0.0 -> ... -> qs@6.9.1
> wp-calypso-monorepo@0.17.0 ->  -> ... -> qs@6.9.4
> wp-calypso-monorepo@0.17.0 -> @automattic/data-stores@1.0.0-alpha.1 -> ... -> qs@6.9.4
> wp-calypso-monorepo@0.17.0 -> @automattic/full-site-editing@1.10.0 -> ... -> qs@6.9.4
> wp-calypso-monorepo@0.17.0 -> @automattic/o2-blocks@1.0.0 -> ... -> qs@6.9.4
> wp-calypso-monorepo@0.17.0 -> @storybook/addon-actions@5.3.18 -> ... -> qs@6.9.4
> wp-calypso-monorepo@0.17.0 -> @storybook/react@5.3.18 -> ... -> qs@6.9.4
> wp-calypso-monorepo@0.17.0 -> @wordpress/api-fetch@3.15.0 -> ... -> qs@6.9.4
> wp-calypso-monorepo@0.17.0 -> @wordpress/block-directory@1.9.0 -> ... -> qs@6.9.4
> wp-calypso-monorepo@0.17.0 -> @wordpress/block-editor@3.11.0 -> ... -> qs@6.9.4
> wp-calypso-monorepo@0.17.0 -> @wordpress/block-library@2.18.0 -> ... -> qs@6.9.4
> wp-calypso-monorepo@0.17.0 -> @wordpress/core-data@2.16.0 -> ... -> qs@6.9.4
> wp-calypso-monorepo@0.17.0 -> @wordpress/data-controls@1.12.0 -> ... -> qs@6.9.4
> wp-calypso-monorepo@0.17.0 -> @wordpress/e2e-test-utils@4.7.0 -> ... -> qs@6.9.4
> wp-calypso-monorepo@0.17.0 -> @wordpress/edit-post@3.17.0 -> ... -> qs@6.9.4
> wp-calypso-monorepo@0.17.0 -> @wordpress/editor@9.16.0 -> ... -> qs@6.9.4
> wp-calypso-monorepo@0.17.0 -> @wordpress/format-library@1.18.0 -> ... -> qs@6.9.4
> wp-calypso-monorepo@0.17.0 -> @wordpress/media-utils@1.11.0 -> ... -> qs@6.9.4
> wp-calypso-monorepo@0.17.0 -> @wordpress/scripts@9.1.0 -> ... -> qs@6.9.4
> wp-calypso-monorepo@0.17.0 -> @wordpress/server-side-render@1.12.0 -> ... -> qs@6.9.4
> wp-calypso-monorepo@0.17.0 -> @wordpress/url@2.15.0 -> ... -> qs@6.9.4
> wp-calypso-monorepo@0.17.0 -> supertest@4.0.2 -> ... -> qs@6.9.4
> wp-calypso-monorepo@0.17.0 -> wp-calypso@0.17.0 -> ... -> qs@6.9.4
> wp-calypso-monorepo@0.17.0 -> wpcom@6.0.0 -> ... -> qs@6.9.4
```

[CHANGELOG](https://github.com/ljharb/qs/blob/master/CHANGELOG.md)