### PR TITLE
Disables rendering of iframe if SEO preview pane is open

### DIFF
--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -316,20 +316,21 @@ export class WebPreviewContent extends Component {
 							<span className="web-preview__loading-message">{ this.props.loadingMessage }</span>
 						</div>
 					) }
-					<div
-						className={ classNames( 'web-preview__frame-wrapper', {
-							'is-resizable': ! this.props.isModalWindow,
-						} ) }
-						style={ { display: 'seo' === this.state.device ? 'none' : 'inherit' } }
-					>
-						<iframe
-							ref={ this.setIframeInstance }
-							className="web-preview__frame"
-							src="about:blank"
-							onLoad={ () => this.setLoaded( 'iframe-onload' ) }
-							title={ this.props.iframeTitle || translate( 'Preview' ) }
-						/>
-					</div>
+					{ 'seo' !== this.state.device && (
+						<div
+							className={ classNames( 'web-preview__frame-wrapper', {
+								'is-resizable': ! this.props.isModalWindow,
+							} ) }
+						>
+							<iframe
+								ref={ this.setIframeInstance }
+								className="web-preview__frame"
+								src="about:blank"
+								onLoad={ () => this.setLoaded( 'iframe-onload' ) }
+								title={ this.props.iframeTitle || translate( 'Preview' ) }
+							/>
+						</div>
+					) }
 					{ 'seo' === this.state.device && (
 						<SeoPreviewPane
 							overridePost={ this.props.overridePost }

--- a/test/e2e/lib/components/sidebar-component.js
+++ b/test/e2e/lib/components/sidebar-component.js
@@ -76,6 +76,11 @@ export default class SidebarComponent extends AsyncBaseContainer {
 		return await this._scrollToAndClickMenuItem( 'activity' );
 	}
 
+	async selectMarketing() {
+		await this.expandDrawerItem( 'Tools' );
+		return await this._scrollToAndClickMenuItem( 'marketing' );
+	}
+
 	async selectViewThisSite() {
 		return await this._scrollToAndClickMenuItem( 'sitePreview' );
 	}

--- a/test/e2e/lib/pages/marketing/traffic-page.js
+++ b/test/e2e/lib/pages/marketing/traffic-page.js
@@ -1,0 +1,39 @@
+/**
+ * External dependencies
+ */
+import { By } from 'selenium-webdriver';
+
+/**
+ * Internal dependencies
+ */
+import * as driverHelper from '../../driver-helper.js';
+import * as driverManager from '../../driver-manager.js';
+
+import AsyncBaseContainer from '../../async-base-container';
+
+const screenSize = driverManager.currentScreenSize();
+
+export default class TrafficPage extends AsyncBaseContainer {
+	constructor( driver ) {
+		super( driver, By.css( '.settings-traffic' ) );
+	}
+
+	async openTrafficTab() {
+		if ( screenSize === 'mobile' ) {
+			await driverHelper.clickWhenClickable( this.driver, By.css( '.section-nav__mobile-header' ) );
+		}
+		await driverHelper.clickWhenClickable(
+			this.driver,
+			By.css( '.section-nav-tab__link[href*="/marketing/traffic/"]' )
+		);
+	}
+
+	async enterFrontPageMetaAndClickPreviewButton() {
+		await driverHelper.setWhenSettable(
+			this.driver,
+			By.css( '#advanced_seo_front_page_description' ),
+			'test text'
+		);
+		await driverHelper.clickWhenClickable( this.driver, By.css( '.seo-settings__preview-button' ) );
+	}
+}

--- a/test/e2e/specs/wp-calypso-seo-preview.js
+++ b/test/e2e/specs/wp-calypso-seo-preview.js
@@ -1,0 +1,69 @@
+/**
+ * External dependencies
+ */
+import assert from 'assert';
+import config from 'config';
+import { By } from 'selenium-webdriver';
+
+/**
+ * Internal dependencies
+ */
+import * as driverManager from '../lib/driver-manager.js';
+import * as dataHelper from '../lib/data-helper';
+import * as driverHelper from '../lib/driver-helper';
+
+import LoginFlow from '../lib/flows/login-flow.js';
+
+import TrafficPage from '../lib/pages/marketing/traffic-page.js';
+
+import NavBarComponent from '../lib/components/nav-bar-component.js';
+import SidebarComponent from '../lib/components/sidebar-component.js';
+
+const mochaTimeOut = config.get( 'mochaTimeoutMS' );
+const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
+const screenSize = driverManager.currentScreenSize();
+const host = dataHelper.getJetpackHost();
+
+let driver;
+
+before( async function () {
+	this.timeout( startBrowserTimeoutMS );
+	driver = await driverManager.startBrowser();
+	await driverManager.clearCookiesAndDeleteLocalStorage( driver );
+} );
+
+describe( `[${ host }] SEO Preview page: (${ screenSize }) @parallel`, function () {
+	this.timeout( mochaTimeOut );
+	describe( 'SEO Preview page:', function () {
+		// Login as Business plan user and open the sidebar
+		step( 'Log In', async function () {
+			const loginFlow = new LoginFlow( driver, 'wooCommerceUser' );
+			await loginFlow.login();
+			const navBarComponent = await NavBarComponent.Expect( driver );
+			return await navBarComponent.clickMySites();
+		} );
+
+		step( 'Open the marketing page', async function () {
+			this.sidebarComponent = await SidebarComponent.Expect( driver );
+			return await this.sidebarComponent.selectMarketing();
+		} );
+
+		step( 'Enter front page meta description and click preview button ', async function () {
+			const trafficPage = new TrafficPage( driver );
+			await trafficPage.openTrafficTab();
+			await trafficPage.enterFrontPageMetaAndClickPreviewButton();
+		} );
+
+		step( 'Ensure site preview stays open for 10 seconds', async function () {
+			await driverHelper.waitTillPresentAndDisplayed( driver, By.css( '.web-preview.is-seo' ) );
+			const wait = async ( interval ) => {
+				return new Promise( ( resolve ) => {
+					setTimeout( resolve, interval );
+				} );
+			};
+			await wait( 10000 );
+			const previewPane = await driver.findElement( By.css( '.web-preview.is-seo' ) );
+			assert( previewPane, 'The site preview component has been closed.' );
+		} );
+	} );
+} );


### PR DESCRIPTION
### Issue Description

Opening the Preview for "Front Page Meta Description" in "Marketing->Traffic" results in the preview being automatically closed and the home page is opened in a new tab.

#### Changes proposed in this Pull Request

Fixes the above problem by disabling rendering of the iframe.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Please see issue #37334 description for steps to reproduce.
* Screen recording of bug: 
![Kapture 2020-06-24 at 11 38 09](https://user-images.githubusercontent.com/5436027/85507031-38af5200-b60f-11ea-9d52-996acb8d173c.gif)



Fixes #37904
Fixes #37334
