### PR TITLE
Gutenboarding: Add upload themes & install plugins to Business & eCommerce plans.

### DIFF
--- a/packages/data-stores/src/plans/plans-data.ts
+++ b/packages/data-stores/src/plans/plans-data.ts
@@ -19,6 +19,8 @@ const mainFeatures = [
 	'Upload videos',
 	'Google Analytics support',
 	'Business features (incl. SEO)',
+	'Upload themes',
+	'Install plugins',
 	'Accept Payments in 60+ Countries',
 ];
 
@@ -54,7 +56,7 @@ export const PLANS_LIST: Record< string, Plan > = {
 		productId: 1008,
 		storeSlug: PLAN_BUSINESS,
 		pathSlug: 'business',
-		features: [ '200 GB storage space', ...mainFeatures.slice( 0, 9 ) ],
+		features: [ '200 GB storage space', ...mainFeatures.slice( 0, 11 ) ],
 	},
 
 	[ PLAN_ECOMMERCE ]: {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add upload themes & install plugins to Business & eCommerce plans.

#### Testing instructions

* Go to `/new/plans-modal`.
* See if those "Upload themes" & "Install plugins" are there.

#### Screenshot

![image](https://user-images.githubusercontent.com/1287077/85108891-c6a2cb80-b210-11ea-9ce0-7c624562b60a.png)

Fixes #43461
