### PR TITLE
Change resourcesCacheRatio to range 0 to 100

### DIFF
--- a/packages/browser-data-collector/src/collectors/blocking-resources.ts
+++ b/packages/browser-data-collector/src/collectors/blocking-resources.ts
@@ -47,13 +47,11 @@ export const collector: Collector = ( report ) => {
 		}
 	);
 
-	// Hit ratio from 0 to 1 with two decimals (0=nothing was cached, 1=everything comes from the cache)
-	// resourcesTransferred includes the headers, but resourcesCompressed does not. So the division is a
+	// Hit ratio from 0 to 100 (0=nothing was cached, 100=everything comes from the cache).
+	// resourcesTransferred includes the headers, but resourcesCompressed does not, so the division is a
 	// bit off and can return values higher than 1. We cap it to 1 to avoid sending negative numbers
-	// and round the final result to 2 decimals.
-	const resourcesCacheRatio = Number(
-		( 1 - Math.min( 1, resourcesTransferred / resourcesCompressed ) ).toFixed( 2 )
-	);
+	const resourcesCacheRatio =
+		100 - Math.round( Math.min( 1, resourcesTransferred / resourcesCompressed ) * 100 );
 
 	report.data.set( 'resourcesCount', resourcesCount );
 	report.data.set( 'resourcesStart', Math.round( resourcesStart ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Change field `resourcesCacheRatio` to be an integer from 0 to 100 instead of a float.

Sending a float causes problems in Kibana, because if we send a `0` or a `1`, Kibana will map it to a `long` and lose all decimals send in future reports.

See https://www.elastic.co/guide/en/elasticsearch/reference/current/dynamic-templates.html#match-mapping-type for more info

#### Testing instructions

* Open the live branch, go to `/stats` and opt-in abtest `rumDataCollection `
* Open the Dev Tools , ensure caching is enabled and refresh the page
* Search for a request to `/logstash` in the Network tab. Check that the payload contains `resourcesCacheRatio:100`.
* Disable the cache, reload the page and check the payload now contains `resourcesCacheRatio:0`

