### PR TITLE
FSE: Don't run GitHub Action on yarn.lock change

### DIFF
--- a/.github/workflows/full-site-editing-plugin.yml
+++ b/.github/workflows/full-site-editing-plugin.yml
@@ -3,7 +3,6 @@ on:
     # only trigger this workflow if FSE plugin files have been modified, or if packages have been updated.
     paths:
     - 'apps/full-site-editing/**'
-    - 'yarn.lock'
 
 name: FSE plugin
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Addresses https://github.com/Automattic/wp-calypso/pull/43458#discussion_r442757015: In #43458, we added a job to PHPCS lint any changed files in the FSE plugin directory. Additionally, we started triggering that action (that's also in charge of creating the FSE diff for WP.com) upon changes to `yarn.lock`.

Turns out that this is too broad a criterion, since `yarn.lock` will change everytime e.g. a Renovate PR is created -- thus creating those FSE diffs too often. While we can consider triggering diff generation upon npm dependency changes, that is an orthogonal change to adding PHPCS linting, so IMO it's fine to remove it -- it's not a regression over the GH Action's state prior to #43458.

#### Testing instructions

Nothing to do really.