### PR TITLE
Deduplicate loader-utils

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -16318,7 +16318,7 @@ loader-runner@^2.3.1, loader-runner@^2.4.0:
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.4.0.tgz#ed47066bfe534d7e84c4c7b9998c2a75607d9357"
   integrity sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==
 
-loader-utils@1.2.3, loader-utils@^1.0.2, loader-utils@^1.1.0, loader-utils@^1.2.3:
+loader-utils@1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.2.3.tgz#1ff5dc6911c9f0a062531a4c04b609406108c2c7"
   integrity sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==
@@ -16337,7 +16337,7 @@ loader-utils@^0.2.16:
     json5 "^0.5.0"
     object-assign "^4.0.1"
 
-loader-utils@^1.4.0:
+loader-utils@^1.0.2, loader-utils@^1.1.0, loader-utils@^1.2.3, loader-utils@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.4.0.tgz#c579b5e34cb34b1a74edc6c1fb36bfa371d5a613"
   integrity sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `loader-utils` (done automatically with `npx yarn-deduplicate --packages loader-utils`)

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
< Before
> After
---
< wp-calypso-monorepo@0.17.0 ->  -> ... -> loader-utils@1.2.3
< wp-calypso-monorepo@0.17.0 -> @automattic/calypso-build@6.1.0 -> ... -> loader-utils@1.2.3
< wp-calypso-monorepo@0.17.0 -> @automattic/full-site-editing@1.10.0 -> ... -> loader-utils@1.2.3
< wp-calypso-monorepo@0.17.0 -> @storybook/react@5.3.18 -> ... -> loader-utils@1.2.3
< wp-calypso-monorepo@0.17.0 -> @wordpress/dependency-extraction-webpack-plugin@2.6.0 -> ... -> loader-utils@1.2.3
< wp-calypso-monorepo@0.17.0 -> @wordpress/scripts@9.1.0 -> ... -> loader-utils@1.2.3
< wp-calypso-monorepo@0.17.0 -> exports-loader@0.7.0 -> ... -> loader-utils@1.2.3
< wp-calypso-monorepo@0.17.0 -> html-loader@0.5.5 -> ... -> loader-utils@1.2.3
< wp-calypso-monorepo@0.17.0 -> imports-loader@0.8.0 -> ... -> loader-utils@1.2.3
< wp-calypso-monorepo@0.17.0 -> react-docgen-typescript-loader@3.6.0 -> ... -> loader-utils@1.2.3
< wp-calypso-monorepo@0.17.0 -> source-map-loader@0.2.4 -> ... -> loader-utils@1.2.3
< wp-calypso-monorepo@0.17.0 -> ts-loader@6.2.1 -> ... -> loader-utils@1.2.3
< wp-calypso-monorepo@0.17.0 -> webpack@4.42.0 -> ... -> loader-utils@1.2.3
> wp-calypso-monorepo@0.17.0 ->  -> ... -> loader-utils@1.4.0
> wp-calypso-monorepo@0.17.0 -> @automattic/calypso-build@6.1.0 -> ... -> loader-utils@1.4.0
> wp-calypso-monorepo@0.17.0 -> @automattic/full-site-editing@1.10.0 -> ... -> loader-utils@1.4.0
> wp-calypso-monorepo@0.17.0 -> @storybook/react@5.3.18 -> ... -> loader-utils@1.4.0
> wp-calypso-monorepo@0.17.0 -> @wordpress/dependency-extraction-webpack-plugin@2.6.0 -> ... -> loader-utils@1.4.0
> wp-calypso-monorepo@0.17.0 -> @wordpress/scripts@9.1.0 -> ... -> loader-utils@1.4.0
> wp-calypso-monorepo@0.17.0 -> exports-loader@0.7.0 -> ... -> loader-utils@1.4.0
> wp-calypso-monorepo@0.17.0 -> html-loader@0.5.5 -> ... -> loader-utils@1.4.0
> wp-calypso-monorepo@0.17.0 -> imports-loader@0.8.0 -> ... -> loader-utils@1.4.0
> wp-calypso-monorepo@0.17.0 -> react-docgen-typescript-loader@3.6.0 -> ... -> loader-utils@1.4.0
> wp-calypso-monorepo@0.17.0 -> source-map-loader@0.2.4 -> ... -> loader-utils@1.4.0
> wp-calypso-monorepo@0.17.0 -> ts-loader@6.2.1 -> ... -> loader-utils@1.4.0
> wp-calypso-monorepo@0.17.0 -> webpack@4.42.0 -> ... -> loader-utils@1.4.0
```

[CHANGELOG](https://github.com/webpack/loader-utils/blob/master/CHANGELOG.md)