### PR TITLE
Promo card cta: remove DOM element invalid prop

### DIFF
--- a/client/components/promo-section/promo-card/cta.tsx
+++ b/client/components/promo-section/promo-card/cta.tsx
@@ -68,9 +68,15 @@ function buttonProps( button: CtaButton, isPrimary: boolean ) {
 		: {
 				[ typeof button.action === 'string' ? 'href' : 'onClick' ]: button.action,
 		  };
+
 	if ( undefined !== actionProps.href && ! actionProps.selfTarget ) {
 		actionProps.target = '_blank';
 	}
+	// React doesn't recognize `selfTarget` as a valid prop of a DOM element. Removing it prevents a warning in the console.
+	if ( 'selfTarget' in actionProps ) {
+		delete actionProps.selfTarget;
+	}
+
 	return {
 		className: 'promo-card__cta-button',
 		primary: isPrimary,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In `PromoCardCta`, a lingering `selfTarget` prop passed as an attribute to an DOM element triggered a React warning in the console (`selfTarget` not being a valid attribute).

![image](https://user-images.githubusercontent.com/1620183/84817747-785cb500-afe3-11ea-98eb-8caa0685d01d.png)

This commit makes sure it's not passed anymore.

_Note: previously dealt with in #43354, but I had a git mishap and decided it was better to start a new PR_

#### Testing instructions

1. Make sure you've got a WP site with a Free plan
2. Download the PR and boot Calypso
3. Make sure to enable Jetpack sections with the flag `jetpack/features-section`
4. Select the free plan site
5. Go to the _Jetpack > Backup_ section
6. Check there's no React error in the console
7. Click on the _Upgrade to business plan_ button and check that you're still in the same tab
8. Repeat the operation with the _Jetpack > Scan_ section