### PR TITLE
Use server data in modularised state

### DIFF
--- a/client/state/initial-state.js
+++ b/client/state/initial-state.js
@@ -23,6 +23,10 @@ const HOUR_IN_MS = 3600000;
 export const SERIALIZE_THROTTLE = 5000;
 export const MAX_AGE = 7 * DAY_IN_HOURS * HOUR_IN_MS;
 
+// Store the timestamp at which the module loads as a proxy for the timestamp
+// when the server data (if any) was generated.
+const bootTimestamp = Date.now();
+
 /**
  * In-memory copy of persisted state.
  *
@@ -39,16 +43,6 @@ function serialize( state, reducer ) {
 function deserialize( state, reducer ) {
 	delete state._timestamp;
 	return reducer( state, { type: DESERIALIZE } );
-}
-
-// get bootstrapped state from a server-side render
-function getInitialServerState( initialReducer ) {
-	if ( typeof window !== 'object' || ! window.initialReduxState || isSupportSession() ) {
-		return null;
-	}
-
-	const serverState = deserialize( window.initialReduxState, initialReducer );
-	return pick( serverState, Object.keys( window.initialReduxState ) );
 }
 
 function shouldPersist() {
@@ -105,6 +99,13 @@ function verifyStoredRootState( state ) {
 	return true;
 }
 
+// Verifies that the server-provided Redux state isn't too old.
+// This is rarely a problem, and only comes up in extremely long-lived sessions.
+function verifyBootTimestamp() {
+	return bootTimestamp + MAX_AGE > Date.now();
+}
+
+// Verifies that the persisted Redux state isn't too old.
 function verifyStateTimestamp( state ) {
 	return state._timestamp && state._timestamp + MAX_AGE > Date.now();
 }
@@ -115,7 +116,7 @@ export async function loadAllState() {
 		debug( 'fetched stored Redux state from persistent storage', storedState );
 		stateCache = storedState ?? {};
 	} catch ( error ) {
-		debug( 'error while loading stored Redux state:', error );
+		debug( 'error while loading persisted Redux state:', error );
 	}
 }
 
@@ -124,38 +125,8 @@ export async function clearAllState() {
 	await clearStorage();
 }
 
-export function getStateFromCache( reducer, subkey, forceLoggedOutUser = false ) {
-	const reduxStateKey = getReduxStateKey( forceLoggedOutUser ) + ( subkey ? ':' + subkey : '' );
-
-	try {
-		const storedState = stateCache[ reduxStateKey ] ?? null;
-
-		if ( storedState === null ) {
-			debug( 'stored Redux state not found in cache' );
-			return null;
-		}
-
-		if ( ! verifyStateTimestamp( storedState ) ) {
-			debug( 'stored Redux state is too old, dropping' );
-			return null;
-		}
-
-		const deserializedState = deserialize( storedState, reducer );
-		if ( ! deserializedState ) {
-			debug( 'stored Redux state failed to deserialize, dropping' );
-			return null;
-		}
-
-		if ( ! subkey && ! verifyStoredRootState( deserializedState ) ) {
-			debug( 'stored root Redux state has invalid currentUser.id, dropping' );
-			return null;
-		}
-
-		return deserializedState;
-	} catch ( error ) {
-		debug( 'error while loading stored Redux state:', error );
-		return null;
-	}
+function getPersistenceKey( subkey, forceLoggedOutUser ) {
+	return getReduxStateKey( forceLoggedOutUser ) + ( subkey ? ':' + subkey : '' );
 }
 
 function getReduxStateKey( forceLoggedOutUser = false ) {
@@ -236,7 +207,31 @@ export function persistOnChange( reduxStore ) {
 	reduxStore.subscribe( throttledSaveState );
 }
 
-function getInitialStoredState( initialReducer ) {
+// Retrieve the initial state for the application, combining it from server and
+// local persistence (server data gets priority).
+// This function only handles legacy Redux state for the monolithic root reducer
+// `loadAllState` must have completed first.
+export function getInitialState( initialReducer ) {
+	const storedState = getInitialPersistedState( initialReducer );
+	const serverState = getInitialServerState( initialReducer );
+	return { ...storedState, ...serverState };
+}
+
+// Retrieve the initial bootstrapped state from a server-side render.
+// This function only handles legacy Redux state for the monolithic root reducer
+function getInitialServerState( initialReducer ) {
+	if ( typeof window !== 'object' || ! window.initialReduxState || isSupportSession() ) {
+		return null;
+	}
+
+	const serverState = deserialize( window.initialReduxState, initialReducer );
+	return pick( serverState, Object.keys( window.initialReduxState ) );
+}
+
+// Retrieve the initial persisted state from the cached local client data.
+// This function only handles legacy Redux state for the monolithic root reducer
+// `loadAllState` must have completed first.
+function getInitialPersistedState( initialReducer ) {
 	if ( ! shouldPersist() ) {
 		return null;
 	}
@@ -256,14 +251,14 @@ function getInitialStoredState( initialReducer ) {
 		}
 	}
 
-	let initialStoredState = getStateFromCache( initialReducer );
+	let initialStoredState = getStateFromPersistence( initialReducer );
 	const storageKeys = [ ...initialReducer.getStorageKeys() ];
 
 	function loadReducerState( { storageKey, reducer } ) {
-		let storedState = getStateFromCache( reducer, storageKey, false );
+		let storedState = getStateFromPersistence( reducer, storageKey, false );
 
 		if ( ! storedState && storageKey === 'signup' ) {
-			storedState = getStateFromCache( reducer, storageKey, true );
+			storedState = getStateFromPersistence( reducer, storageKey, true );
 			debug( 'fetched signup state from logged out state', storedState );
 		}
 
@@ -283,8 +278,79 @@ function getInitialStoredState( initialReducer ) {
 	return initialStoredState;
 }
 
-export function getInitialState( initialReducer ) {
-	const storedState = getInitialStoredState( initialReducer );
-	const serverState = getInitialServerState( initialReducer );
-	return { ...storedState, ...serverState };
+// Retrieve the initial state for a portion of state, from persisted data alone.
+// This function handles both legacy and modularized Redux state.
+// `loadAllState` must have completed first.
+function getStateFromPersistence( reducer, subkey, forceLoggedOutUser = false ) {
+	const reduxStateKey = getPersistenceKey( subkey, forceLoggedOutUser );
+
+	const state = stateCache[ reduxStateKey ] ?? null;
+	return deserializeState( subkey, state, reducer, false );
+}
+
+// Retrieve the initial state for a portion of state, choosing the freshest
+// between server and local persisted data.
+// This function handles both legacy and modularized Redux state.
+// `loadAllState` must have completed first.
+export function getStateFromCache( reducer, subkey, forceLoggedOutUser = false ) {
+	const reduxStateKey = getPersistenceKey( subkey, forceLoggedOutUser );
+
+	let serverState = null;
+
+	if ( subkey && typeof window !== 'undefined' ) {
+		serverState = window.initialReduxState?.[ subkey ] ?? null;
+	}
+
+	const persistedState = stateCache[ reduxStateKey ] ?? null;
+
+	// Default to server state, if it exists.
+	let useServerState = serverState !== null;
+
+	// Replace with persisted state if it's fresher.
+	if ( persistedState?._timestamp && persistedState._timestamp > bootTimestamp ) {
+		useServerState = false;
+	}
+
+	return deserializeState(
+		subkey,
+		useServerState ? serverState : persistedState,
+		reducer,
+		useServerState
+	);
+}
+
+// Deserialize a portion of state.
+// This function handles both legacy and modularized Redux state.
+function deserializeState( subkey, state, reducer, isServerState = false ) {
+	const origin = isServerState ? 'server' : 'persisted';
+
+	try {
+		if ( state === null ) {
+			debug( `Redux state for subkey '${ subkey }' not found in ${ origin } data` );
+			return null;
+		}
+
+		const validTimestamp = isServerState ? verifyBootTimestamp() : verifyStateTimestamp( state );
+
+		if ( ! validTimestamp ) {
+			debug( `${ origin } Redux state is too old, dropping` );
+			return null;
+		}
+
+		const deserializedState = deserialize( state, reducer );
+		if ( ! deserializedState ) {
+			debug( `${ origin } Redux state failed to deserialize, dropping` );
+			return null;
+		}
+
+		if ( ! subkey && ! verifyStoredRootState( deserializedState ) ) {
+			debug( `${ origin } root Redux state has invalid currentUser.id, dropping` );
+			return null;
+		}
+
+		return deserializedState;
+	} catch ( error ) {
+		debug( `error while loading ${ origin } Redux state:`, error );
+		return null;
+	}
 }


### PR DESCRIPTION
While legacy Redux state combines data retrieved from both the initial SSR and local persistence, modularised state was not doing the same. Instead, it only used persisted state, discarding server data.

This change fixes that, making use of server data as well.

#### Changes proposed in this Pull Request

* Use server data for modularised state initialisation
* Add some tests for this

#### Testing instructions

* Make sure you are logged out from wpcom (e.g. incognito window)
* Open DevTools and disable JS
* Load `/theme/barnsbury` on the live branch or your local copy of this branch
* Verify that it renders correctly on the server side
* Clear all IndexedDb data, by deleting the `calypso` database or just deleting all application data
* Re-enable JS in your browser
* Empty cache and hard reload
* Verify that there is no layout flicker; the client-side render matches the server-side render, with no placeholders being visible at any point.
