### PR TITLE
Refresh the site data when the automated transfer ends and reload

### DIFF
--- a/client/components/jetpack/wpcom-business-at/index.tsx
+++ b/client/components/jetpack/wpcom-business-at/index.tsx
@@ -223,7 +223,7 @@ export default function WPCOMBusinessAT( { product }: Props ): ReactElement {
 		dispatch(
 			successNotice(
 				translate( '%s is now active', {
-					args: content.documentHeadTitle,
+					args: content.header,
 					comment:
 						'%s is a Jetpack product name like: Jetpack Backup, Jetpack Scan, Jetpack Anti-spam',
 				} ),

--- a/client/components/jetpack/wpcom-business-at/index.tsx
+++ b/client/components/jetpack/wpcom-business-at/index.tsx
@@ -218,13 +218,13 @@ export default function WPCOMBusinessAT( { product }: Props ): ReactElement {
 			// Need to refresh the site data.
 			dispatch( requestSite( siteId ) );
 		}
-	}, [ automatedTransferStatus, COMPLETE, dispatch, siteId ] );
+	}, [ automatedTransferStatus ] );
 
 	useEffect( () => {
 		if ( automatedTransferStatus === COMPLETE && ! siteSlug.includes( 'wordpress.com' ) ) {
 			page( `/${ product }/${ siteSlug }` );
 		}
-	}, [ automatedTransferStatus, COMPLETE, product, siteSlug ] );
+	}, [ automatedTransferStatus, siteSlug ] );
 
 	// If there are any issues, show a dialog.
 	// Otherwise, kick off the transfer!

--- a/client/components/jetpack/wpcom-business-at/index.tsx
+++ b/client/components/jetpack/wpcom-business-at/index.tsx
@@ -28,7 +28,7 @@ import {
 	EligibilityData,
 } from 'state/automated-transfer/selectors';
 import { initiateThemeTransfer } from 'state/themes/actions';
-import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { transferStates } from 'state/automated-transfer/constants';
 import QueryAutomatedTransferEligibility from 'components/data/query-atat-eligibility';
 import {
@@ -166,6 +166,7 @@ function TransferFailureNotice( {
 export default function WPCOMBusinessAT( { product }: Props ): ReactElement {
 	const content = React.useMemo( () => contentPerPrimaryProduct[ product ], [ product ] );
 	const siteId = useSelector( getSelectedSiteId ) as number;
+	const siteSlug = useSelector( getSelectedSiteSlug ) as string;
 
 	// Gets the site eligibility data.
 	const isEligible = useSelector( ( state ) => isEligibleForAutomatedTransfer( state, siteId ) );
@@ -214,16 +215,16 @@ export default function WPCOMBusinessAT( { product }: Props ): ReactElement {
 					displayOnNextPage: true,
 				} )
 			);
-			// Redirect/reload the page to take the new site slug
-			page( '/' );
-
 			// Need to refresh the site data.
 			dispatch( requestSite( siteId ) );
-
-			// todo: Ideally, reload the section with the new siteSlug, but we don't have the new slug yet
-			// page( `/${product}/${siteSlug}`);
 		}
-	}, [ automatedTransferStatus ] );
+	}, [ automatedTransferStatus, COMPLETE, dispatch, siteId ] );
+
+	useEffect( () => {
+		if ( automatedTransferStatus === COMPLETE && ! siteSlug.includes( 'wordpress.com' ) ) {
+			page( `/${ product }/${ siteSlug }` );
+		}
+	}, [ automatedTransferStatus, COMPLETE, product, siteSlug ] );
 
 	// If there are any issues, show a dialog.
 	// Otherwise, kick off the transfer!

--- a/client/components/jetpack/wpcom-business-at/index.tsx
+++ b/client/components/jetpack/wpcom-business-at/index.tsx
@@ -179,7 +179,6 @@ export default function WPCOMBusinessAT( { product }: Props ): ReactElement {
 	);
 
 	const { COMPLETE, START } = transferStates;
-	// const [ isOnTransfer, setOnTransfer ] = useState( false );
 
 	// Check if there's a blocking hold.
 	const cannotInitiateTransfer =

--- a/client/components/jetpack/wpcom-business-at/index.tsx
+++ b/client/components/jetpack/wpcom-business-at/index.tsx
@@ -219,7 +219,7 @@ export default function WPCOMBusinessAT( { product }: Props ): ReactElement {
 	useEffect( () => {
 		if ( automatedTransferStatus === COMPLETE && isJetpack ) {
 			dispatch(
-				successNotice( translate( 'Jetpack features are now activated.' ), {
+				successNotice( translate( 'Jetpack Backup is now active' ), {
 					id: 'jetpack-features-on',
 					duration: 5000,
 					displayOnNextPage: true,
@@ -266,7 +266,10 @@ export default function WPCOMBusinessAT( { product }: Props ): ReactElement {
 					<SpinnerButton
 						text={ content.primaryPromo.promoCTA.text }
 						loadingText={ content.primaryPromo.promoCTA.loadingText }
-						loading={ automatedTransferStatus === START }
+						loading={
+							automatedTransferStatus === START ||
+							( automatedTransferStatus === COMPLETE && ! isJetpack )
+						}
 						onClick={ initiateATOrShowWarnings }
 						disabled={ cannotInitiateTransfer }
 					/>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When a user starts the automated transfer, to convert Simple site (Business plan) to Atomic site, we need to update the site data and redirect it to the new site slug.

#### Testing instructions

- Apply this change. Active the flag `?flags=jetpack/features-section`
- Get a site with Business plan that is non-Atomic yet.
- Go to the Backup section, see the Upsell page, and "Activate Jetpack Backup now". The transfer process will start.
- When the transfer ends, it'll reload the Backup page with the new site slug.
