### PR TITLE
Jetpack section: remove Scan promo card from Backup's Business upsell page

### DIFF
--- a/client/my-sites/backup/style.scss
+++ b/client/my-sites/backup/style.scss
@@ -134,4 +134,12 @@
 	.backup__wpcom-realtime-cta {
 		margin-right: 16px;
 	}
+
+	.promo-section__promos {
+		.promo-card {
+			@include breakpoint-deprecated( '>1280px' ) {
+				flex: 1 1 calc( 50% - 1em );
+			}
+		}
+	}
 }

--- a/client/my-sites/backup/wpcom-upsell.tsx
+++ b/client/my-sites/backup/wpcom-upsell.tsx
@@ -12,7 +12,7 @@ import DocumentHead from 'components/data/document-head';
 import Main from 'components/main';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
-import { isPersonalPlan, isPremiumPlan } from 'lib/plans';
+import { isFreePlan } from 'lib/plans';
 import FormattedHeader from 'components/formatted-header';
 import PromoSection, { Props as PromoSectionProps } from 'components/promo-section';
 import PromoCard from 'components/promo-section/promo-card';
@@ -21,7 +21,6 @@ import useTrackCallback from 'lib/jetpack/use-track-callback';
 import Gridicon from 'components/gridicon';
 import { getSitePlan } from 'state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
-import MaterialIcon from 'components/material-icon';
 import WhatIsJetpack from 'components/jetpack/what-is-jetpack';
 
 /**
@@ -32,36 +31,23 @@ import './style.scss';
 
 const trackEventName = 'calypso_jetpack_backup_business_upsell';
 
-const promos = [
-	{
-		title: translate( 'Jetpack Scan' ),
-		body: translate(
-			'Scan gives you automated scanning and one-click fixes to keep your site ahead of security threats.'
-		),
-		image: <MaterialIcon icon="security" className="backup__upsell-icon" />,
-	},
-	{
-		title: translate( 'Activity Log' ),
-		body: translate(
-			'A complete record of everything that happens on your site, with history that spans over 30 days.'
-		),
-		image: <Gridicon icon="history" className="backup__upsell-icon" />,
-	},
-];
+const promos: PromoSectionProps = {
+	promos: [
+		{
+			title: translate( 'Activity Log' ),
+			body: translate(
+				'A complete record of everything that happens on your site, with history that spans over 30 days.'
+			),
+			image: <Gridicon icon="history" className="backup__upsell-icon" />,
+		},
+	],
+};
 
 export default function WPCOMUpsellPage(): ReactElement {
 	const onUpgradeClick = useTrackCallback( undefined, trackEventName );
 	const siteSlug = useSelector( getSelectedSiteSlug );
 	const siteId = useSelector( getSelectedSiteId );
 	const { product_slug: planSlug } = useSelector( ( state ) => getSitePlan( state, siteId ) );
-
-	// Don't show the Activity Log promo for Personal or Premium plan owners.
-	const filteredPromos: PromoSectionProps = React.useMemo( () => {
-		if ( isPersonalPlan( planSlug ) || isPremiumPlan( planSlug ) ) {
-			return { promos: [ promos[ 0 ] ] };
-		}
-		return { promos };
-	}, [ planSlug ] );
 
 	return (
 		<Main className="backup__main backup__wpcom-upsell">
@@ -97,9 +83,15 @@ export default function WPCOMUpsellPage(): ReactElement {
 				/>
 			</PromoCard>
 
-			<h2 className="backup__subheader">{ translate( 'Also included in the Business Plan' ) }</h2>
+			{ isFreePlan( planSlug ) && (
+				<>
+					<h2 className="backup__subheader">
+						{ translate( 'Also included in the Business Plan' ) }
+					</h2>
 
-			<PromoSection { ...filteredPromos } />
+					<PromoSection { ...promos } />
+				</>
+			) }
 
 			<WhatIsJetpack />
 		</Main>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The Business plan upsell page in Jetpack > Backup shows a promo card for Scan. We no longer need to show that card.

#### Testing instructions

* Prerequisite: Simple site with a Free plan and Simple site with a Personal or Premium plan.
* Run this PR with the `jetpack/features-section` enabled.
* Select your Simple site with a Free plan.
* Go to the Jetpack > Backup section (url: `http://calypso.localhost:3000/backup/[site]`).
* Verify that you see only the Activity Log promo card at the bottom.
* Select your Simple site with a Personal or Premium plan (stay in the same page).
* Verify that there aren't promo cards at the bottom.

Fixes 1179060693083348-as-1180644091306255

#### Demo

##### Free plan
![image](https://user-images.githubusercontent.com/3418513/85164208-66c11a80-b23a-11ea-8090-bebb663d2141.png)

##### Personal/Premium plan
![image](https://user-images.githubusercontent.com/3418513/85164184-5d37b280-b23a-11ea-8b53-40c8a55a5169.png)

