### PR TITLE
Gutenboarding: Fix domain picker ui update e2e

### DIFF
--- a/client/landing/gutenboarding/components/action-buttons/index.tsx
+++ b/client/landing/gutenboarding/components/action-buttons/index.tsx
@@ -70,7 +70,6 @@ export const SkipButton: React.FunctionComponent< Button.ButtonProps > = ( {
 	return (
 		<Button
 			className={ classnames( 'action_buttons__button action-buttons__skip', className ) }
-			isDefault
 			isLarge
 			{ ...buttonProps }
 		>

--- a/client/landing/gutenboarding/onboarding-block/domains/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/domains/index.tsx
@@ -17,7 +17,7 @@ import { trackEventWithFlow } from '../../lib/analytics';
 import { STORE_KEY as ONBOARD_STORE } from '../../stores/onboard';
 import { getSuggestionsVendor } from 'lib/domains/suggestions';
 import { FLOW_ID } from '../../constants';
-import ActionButtons, { BackButton, NextButton, SkipButton } from '../../components/action-buttons';
+import ActionButtons, { BackButton } from '../../components/action-buttons';
 import { Title, SubTitle } from '../../components/titles';
 
 /**
@@ -53,10 +53,6 @@ const DomainsStep: React.FunctionComponent< Props > = ( { isModal } ) => {
 		selected_domain: selectedDomainRef.current,
 	} ) );
 
-	const onDomainSelect = ( suggestion: DomainSuggestion | undefined ) => {
-		setDomain( suggestion );
-	};
-
 	const handleBack = () => ( isModal ? history.goBack() : goBack() );
 	const handleNext = () => {
 		trackEventWithFlow( 'calypso_newsite_domain_select', {
@@ -68,7 +64,11 @@ const DomainsStep: React.FunctionComponent< Props > = ( { isModal } ) => {
 			goNext();
 		}
 	};
-	const handleSkip = () => ( isModal ? history.goBack() : goNext() );
+
+	const onDomainSelect = ( suggestion: DomainSuggestion | undefined ) => {
+		setDomain( suggestion );
+		handleNext();
+	};
 
 	const header = (
 		<div className="domains__header">
@@ -78,7 +78,6 @@ const DomainsStep: React.FunctionComponent< Props > = ( { isModal } ) => {
 			</div>
 			<ActionButtons>
 				<BackButton onClick={ handleBack } />
-				{ domain ? <NextButton onClick={ handleNext } /> : <SkipButton onClick={ handleSkip } /> }
 			</ActionButtons>
 		</div>
 	);

--- a/packages/domain-picker/src/domain-picker/index.tsx
+++ b/packages/domain-picker/src/domain-picker/index.tsx
@@ -65,7 +65,6 @@ const DomainPicker: FunctionComponent< Props > = ( {
 	onDomainSelect,
 	quantity = PAID_DOMAINS_TO_SHOW,
 	quantityExpanded = PAID_DOMAINS_TO_SHOW_EXPANDED,
-	currentDomain,
 	analyticsFlowId,
 	analyticsUiAlgo,
 	domainSuggestionVendor,
@@ -176,7 +175,6 @@ const DomainPicker: FunctionComponent< Props > = ( {
 								key={ suggestion.domain_name }
 								suggestion={ suggestion }
 								railcarId={ baseRailcarId ? `${ baseRailcarId }${ i }` : undefined }
-								isSelected={ currentDomain?.domain_name === suggestion.domain_name }
 								isRecommended={ i === 0 }
 								onRender={ () =>
 									handleItemRender( suggestion, `${ baseRailcarId }${ i }`, i, i === 0 )

--- a/packages/domain-picker/src/domain-picker/style.scss
+++ b/packages/domain-picker/src/domain-picker/style.scss
@@ -1,8 +1,6 @@
 @import '../styles/placeholder.scss'; // Contains the placeholder mixin
 @import '../styles/mixins';
 
-$domain-picker__suggestion-item-height: 24px;
-
 .domain-picker__empty-state {
 	display: flex;
 	justify-content: center;
@@ -48,36 +46,47 @@ $domain-picker__suggestion-item-height: 24px;
 	}
 }
 
-.domain-picker__free-text {
-	color: var( --studio-green-40 );
-}
-
 .domain-picker__suggestion-item-group {
 	flex-grow: 1;
 }
 
-.domain-picker__suggestion-none {
+.domain-picker__suggestion-item {
 	@include domain-picker-package-medium-text;
-	line-height: 20px; // matching design
 	display: flex;
 	justify-content: space-between;
-	align-items: flex-start;
+	align-items: center;
 	width: 100%;
-	border-radius: 0;
-	padding: 10px 0;
-	margin-bottom: 7px;
-	cursor: pointer;
-}
-
-.domain-picker__suggestion-item {
-	// Increasing specificity because @wordpress/components stylesheets are loaded after gutenboarding stylesheets.
-	// See https://github.com/Automattic/wp-calypso/pull/38554/commits/e1f9673bcfd9eaa6469a0cfecda9b915a520961a
-	// See https://github.com/WordPress/gutenberg/pull/19535
-	@extend .domain-picker__suggestion-none;
-
+	min-height: 36px + ( 10px * 2 ) + ( 1px * 2 ); // button height + padding height + border height
 	border: 1px solid var( --studio-gray-5 );
-	padding: 14px;
-	margin-bottom: 0;
+	padding: 10px 14px;
+	margin: 0;
+	position: relative;
+	z-index: 1;
+	text-align: left;
+	cursor: pointer;
+
+	&.placeholder {
+		cursor: default;
+	}
+
+	&:hover,
+	&:focus {
+		&:not( .placeholder ) {
+			background: var( --studio-blue-0 );
+			border-color: var( --studio-blue-40 );
+			z-index: 2;
+		}
+
+		// Fade between price and select button only happens on desktop view.
+		@include break-small {
+			.domain-picker__suggestion-item-select-button {
+				opacity: 1;
+			}
+			.domain-picker__price {
+				opacity: 0;
+			}
+		}
+	}
 
 	+ .domain-picker__suggestion-item {
 		margin-top: -1px;
@@ -99,61 +108,12 @@ $domain-picker__suggestion-item-height: 24px;
 			opacity: 1;
 		}
 	}
-
-	&.components-button {
-		&.is-tertiary {
-			color: var( --color-text );
-
-			&:not( :disabled ):not( [aria-disabled='true'] ):hover {
-				background: var( --color-surface-backdrop );
-				color: var( --color-text );
-			}
-		}
-	}
-
-	input[type='radio'].domain-picker__suggestion-radio-button {
-		width: 16px;
-		height: 16px;
-		margin: 3px 12px 0 0; // 3px cosmetic alignment
-		min-width: 16px; // prevents long domain from squishing the radio button
-		padding: 0;
-		vertical-align: middle;
-		position: relative;
-
-		&:checked {
-			border-color: var( --studio-blue-30 );
-			background-color: var( --studio-blue-30 );
-
-			&::before {
-				content: '';
-				width: 12px;
-				height: 12px;
-				border: 2px solid white;
-				border-radius: 50%;
-				position: absolute;
-				margin: 0;
-				background: transparent;
-			}
-
-			&:focus {
-				border-color: var( --studio-blue-30 );
-				box-shadow: 0 0 0 1px var( --studio-blue-30 );
-			}
-		}
-
-		&:not( :disabled ):focus,
-		&:not( :disabled ):hover {
-			border-color: var( --studio-blue-30 );
-			box-shadow: 0 0 0 1px var( --studio-blue-30 );
-		}
-	}
 }
 
 .domain-picker__suggestion-item-name {
 	flex-grow: 1;
 	margin-right: 24px;
 	letter-spacing: 0.4px;
-	min-height: $domain-picker__suggestion-item-height;
 
 	.domain-picker__domain-name {
 		word-break: break-word; // use hyphens if any to break domain name
@@ -183,24 +143,27 @@ $domain-picker__suggestion-item-height: 24px;
 	align-items: center;
 	font-size: 10px;
 	text-transform: uppercase;
-
+	vertical-align: middle;
 	background-color: var( --studio-blue-50 );
 	color: var( --color-text-inverted );
-
-	&.is-selected {
-		color: var( --color-text-inverted );
-		background-color: var( --color-success );
-	}
 }
 
 .domain-picker__price {
 	color: var( --studio-gray-40 );
 	text-align: right;
-	min-height: $domain-picker__suggestion-item-height;
 	flex-basis: 0;
+	transition: opacity 200ms ease-in-out;
+	// Don't show free text on mobile view
+	&:not( .is-paid ) {
+		display: none;
+	}
 
 	@include break-small {
 		flex-basis: auto;
+
+		&:not( .is-paid ) {
+			display: inline;
+		}
 	}
 
 	&.placeholder {
@@ -209,8 +172,65 @@ $domain-picker__suggestion-item-height: 24px;
 	}
 }
 
-.domain-picker__price-is-paid {
+.domain-picker__price-long {
+	display: none;
+	@include break-small {
+		display: inline;
+	}
+}
+
+.domain-picker__price-short {
+	display: inline;
+	@include break-small {
+		display: none;
+	}
+}
+
+.domain-picker__price-cost {
 	text-decoration: line-through;
+}
+
+.domain-picker__suggestion-item-select-button {
+	display: flex;
+	align-items: center;
+	height: 36px;
+
+	span {
+		display: none;
+	}
+
+	svg {
+		fill: var( --studio-blue-50 );
+		margin-left: 10px;
+		margin-right: -2px;
+	}
+
+	@include break-small {
+		// We're mocking the look of a button,
+		// this is not an actual button.
+		background: $blue-medium-focus;
+		color: var( --studio-white );
+		border-radius: 2px;
+		padding: 0 12px;
+		opacity: 0;
+		transition: opacity 200ms ease-in-out;
+
+		// Overlaps price for transition purpose
+		position: absolute;
+		right: 14px;
+
+		&:hover {
+			background: mix( black, $blue-medium-focus, 10% );
+		}
+
+		span {
+			display: inline-block;
+		}
+
+		svg {
+			display: none;
+		}
+	}
 }
 
 .domain-picker__body {

--- a/packages/domain-picker/src/domain-picker/suggestion-item-placeholder.tsx
+++ b/packages/domain-picker/src/domain-picker/suggestion-item-placeholder.tsx
@@ -5,8 +5,7 @@ import React, { FunctionComponent } from 'react';
 
 const DomainPickerSuggestionItemPlaceholder: FunctionComponent = () => {
 	return (
-		<div className="domain-picker__suggestion-item">
-			<input disabled className="domain-picker__suggestion-radio-button" type="radio" />
+		<div className="domain-picker__suggestion-item placeholder">
 			<div className="domain-picker__suggestion-item-name placeholder" />
 			<div className="domain-picker__price placeholder"></div>
 		</div>

--- a/packages/domain-picker/src/domain-picker/suggestion-item.tsx
+++ b/packages/domain-picker/src/domain-picker/suggestion-item.tsx
@@ -7,13 +7,14 @@ import classnames from 'classnames';
 import { sprintf } from '@wordpress/i18n';
 import { v4 as uuid } from 'uuid';
 import { recordTrainTracksInteract } from '@automattic/calypso-analytics';
+import { Icon, arrowRight } from '@wordpress/icons';
+import { createInterpolateElement } from '@wordpress/element';
 
 type DomainSuggestion = import('@automattic/data-stores').DomainSuggestions.DomainSuggestion;
 
 interface Props {
 	suggestion: DomainSuggestion;
 	railcarId: string | undefined;
-	isSelected?: boolean;
 	isRecommended?: boolean;
 	onRender: () => void;
 	onSelect: ( domainSuggestion: DomainSuggestion ) => void;
@@ -22,7 +23,6 @@ interface Props {
 const DomainPickerSuggestionItem: FunctionComponent< Props > = ( {
 	suggestion,
 	railcarId,
-	isSelected = false,
 	isRecommended = false,
 	onSelect,
 	onRender,
@@ -61,16 +61,13 @@ const DomainPickerSuggestionItem: FunctionComponent< Props > = ( {
 	};
 
 	return (
-		<label className="domain-picker__suggestion-item">
-			<input
-				aria-labelledby={ labelId }
-				className="domain-picker__suggestion-radio-button"
-				type="radio"
-				name="domain-picker-suggestion-option"
-				onChange={ onDomainSelect }
-				checked={ isSelected }
-			/>
-			<div className="domain-picker__suggestion-item-name" id={ labelId }>
+		<button
+			type="button"
+			className="domain-picker__suggestion-item"
+			onClick={ onDomainSelect }
+			id={ labelId }
+		>
+			<div className="domain-picker__suggestion-item-name">
 				<span className="domain-picker__domain-name">{ domainName }</span>
 				<span className="domain-picker__domain-tld">{ domainTld }</span>
 				{ isRecommended && (
@@ -86,17 +83,32 @@ const DomainPickerSuggestionItem: FunctionComponent< Props > = ( {
 					__( 'Free' )
 				) : (
 					<>
-						<span className="domain-picker__free-text"> { __( 'Included in plans' ) } </span>
-						<span className="domain-picker__price-is-paid">
+						<span className="domain-picker__price-long">
+							{ createInterpolateElement(
+								sprintf(
+									/* translators: %s is the price with currency. Eg: $15/year. */
+									__( 'Included in paid plan, <strikethrough>%s/year</strikethrough>' ),
+									suggestion.cost
+								),
+								{
+									strikethrough: <span className="domain-picker__price-cost"></span>,
+								}
+							) }
+						</span>
+						<span className="domain-picker__price-short domain-picker__price-cost">
 							{
 								/* translators: %s is the price with currency. Eg: $15/year. */
 								sprintf( __( '%s/year' ), suggestion.cost )
-							}{ ' ' }
+							}
 						</span>
 					</>
 				) }
 			</div>
-		</label>
+			<div className="domain-picker__suggestion-item-select-button">
+				<span>{ __( 'Select' ) }</span>
+				<Icon icon={ arrowRight } size={ 18 } />
+			</div>
+		</button>
 	);
 };
 

--- a/packages/domain-picker/src/domain-picker/suggestion-item.tsx
+++ b/packages/domain-picker/src/domain-picker/suggestion-item.tsx
@@ -63,7 +63,9 @@ const DomainPickerSuggestionItem: FunctionComponent< Props > = ( {
 	return (
 		<button
 			type="button"
-			className="domain-picker__suggestion-item"
+			className={ classnames( 'domain-picker__suggestion-item', {
+				'is-free': suggestion.is_free,
+			} ) }
 			onClick={ onDomainSelect }
 			id={ labelId }
 		>

--- a/test/e2e/lib/pages/gutenboarding/domains-page.js
+++ b/test/e2e/lib/pages/gutenboarding/domains-page.js
@@ -14,8 +14,8 @@ export default class DomainsPage extends AsyncBaseContainer {
 		super( driver, By.css( '.domains' ) );
 	}
 
-	async skipStep() {
-		const skipButtonSelector = By.css( '.action-buttons__skip' );
-		return await driverHelper.clickWhenClickable( this.driver, skipButtonSelector );
+	async clickFreeSuggestionItem() {
+		const freeSuggestionItemSelector = By.css( '.domain-picker__suggestion-item.is-free' );
+		return await driverHelper.clickWhenClickable( this.driver, freeSuggestionItemSelector );
 	}
 }

--- a/test/e2e/specs/wp-gutenboarding-spec.js
+++ b/test/e2e/specs/wp-gutenboarding-spec.js
@@ -50,9 +50,9 @@ describe( 'Gutenboarding: (' + screenSize + ')', function () {
 			await acquireIntentPage.goToNextStep();
 		} );
 
-		step( 'Can see Domains Page and skip selecting a domain', async function () {
+		step( 'Can see Domains Page and select free suggestion item', async function () {
 			const domainsPage = await DomainsPage.Expect( driver );
-			await domainsPage.skipStep();
+			await domainsPage.clickFreeSuggestionItem();
 		} );
 
 		step( 'Can see Design Selector and select a random free design', async function () {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR includes:
- Changes from https://github.com/Automattic/wp-calypso/pull/43346 which was merged then reverted due to E2E errors during deploy.
- Updates to E2E test where clicking "Skip for now" on Domains step is now replaced with clicking the Free domain suggestion item.

#### Testing instructions

* Run `cd test/e2e && NODE_CONFIG_ENV=development ./node_modules/.bin/mocha specs/wp-gutenboarding-spec.js` locally.
* Check the E2E test on CircleCI. https://app.circleci.com/pipelines/github/Automattic/wp-e2e-tests-for-branches/28031/workflows/e1c62fa0-8d41-4deb-a70f-400dd10368eb/jobs/80570/parallel-runs/1/steps/1-115
