### PR TITLE
Jetpack cloud: remove outdated style in Scan section

### DIFF
--- a/client/my-sites/scan/style.scss
+++ b/client/my-sites/scan/style.scss
@@ -1,7 +1,3 @@
-.theme-jetpack-cloud .main.sites {
-	margin-left: auto;
-}
-
 .scan.is_jetpackcom .section-nav {
 	margin-top: 16px;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The sites selector was applied an unnecessary override in `scan/styles.css`
- Override: `margin-left: auto`
- Overridden rule: `margin: auto`

_Note that the removed style targeted an element outside of the component, namely the site selector. This should be avoided, since in this case you might have seen a different layout for the site selector page before and after visiting the Scan section._

#### Testing instructions

- Download the PR and run Jetpack cloud
- Go to the site selector (e.g. `/backup/`)
- Notice it looks the same as in staging/production
- Go to the _Scan_ section
- Go back to the site selector
- Notice it still looks the same as in staging/production

#### Screenshots

Site selector
<img width="777" alt="Screen Shot 2020-06-19 at 4 47 03 PM" src="https://user-images.githubusercontent.com/1620183/85178459-87926b80-b24c-11ea-9991-16b34b641585.png">
