### PR TITLE
Revert: Editor - autoactivation of classic plugin on atomic sites

### DIFF
--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -3,7 +3,7 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component, Fragment } from 'react';
-import { flowRight as compose, noop, find } from 'lodash';
+import { flowRight as compose, noop } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
@@ -42,10 +42,6 @@ import isGutenbergOptInEnabled from 'state/selectors/is-gutenberg-opt-in-enabled
 import isGutenbergOptOutEnabled from 'state/selectors/is-gutenberg-opt-out-enabled';
 import getWpAdminClassicEditorRedirectionUrl from 'state/selectors/get-wp-admin-classic-editor-redirection-url';
 import { isEnabled } from 'config';
-import isAtomicSite from 'state/selectors/is-site-automated-transfer';
-import { activatePlugin, fetchPlugins } from 'state/plugins/installed/actions';
-import { getPlugins } from 'state/plugins/installed/selectors';
-import { errorNotice } from 'state/notices/actions';
 
 class InlineHelpPopover extends Component {
 	static propTypes = {
@@ -58,11 +54,6 @@ class InlineHelpPopover extends Component {
 		optIn: PropTypes.func,
 		redirect: PropTypes.func,
 		isEligibleForChecklist: PropTypes.bool.isRequired,
-		isAtomic: PropTypes.bool,
-		activatePlugin: PropTypes.func,
-		fetchAtomicPlugins: PropTypes.func,
-		classicPlugin: PropTypes.object,
-		showErrorNotice: PropTypes.func,
 	};
 
 	static defaultProps = {
@@ -72,26 +63,7 @@ class InlineHelpPopover extends Component {
 	state = {
 		showSecondaryView: false,
 		activeSecondaryView: '',
-		activatingClassicOnAtomic: false,
 	};
-
-	componentDidMount() {
-		const { siteId, isAtomic, fetchAtomicPlugins } = this.props;
-
-		if ( isAtomic ) {
-			fetchAtomicPlugins( [ siteId ] );
-		}
-	}
-
-	componentDidUpdate() {
-		const { classicPlugin } = this.props;
-
-		if ( this.state.activatingClassicOnAtomic ) {
-			if ( classicPlugin?.active ) {
-				this.redirectToClassicEditor();
-			}
-		}
-	}
 
 	openResultView = ( event ) => {
 		event.preventDefault();
@@ -239,49 +211,18 @@ class InlineHelpPopover extends Component {
 		);
 	};
 
-	checkForClassicEditorOnAtomic() {
-		const { siteId, classicPlugin, showErrorNotice, translate } = this.props;
-
-		if ( ! classicPlugin ) {
-			showErrorNotice(
-				translate(
-					'There was a problem activating the Classic editor on your site. Please go to the plugins page and activate the Classic Editor plugin there.'
-				)
-			);
-			return;
-		}
-
-		if ( ! classicPlugin.active ) {
-			this.setState( { activatingClassicOnAtomic: true } );
-			this.props.activatePlugin( siteId, classicPlugin );
-			return;
-		}
-
-		this.redirectToClassicEditor();
-	}
-
 	switchToClassicEditor = () => {
-		const { translate, isAtomic } = this.props;
+		const { siteId, onClose, optOut, classicUrl, translate } = this.props;
 
 		const proceed =
 			typeof window === 'undefined' ||
 			window.confirm( translate( 'Are you sure you wish to leave this page?' ) );
 
 		if ( proceed ) {
-			if ( isAtomic && isEnabled( 'editor/after-deprecation' ) ) {
-				this.checkForClassicEditorOnAtomic();
-				return;
-			}
-			this.redirectToClassicEditor();
+			optOut( siteId, classicUrl );
+			onClose();
 		}
 	};
-
-	redirectToClassicEditor() {
-		const { siteId, classicUrl, optOut, onClose } = this.props;
-		this.setState( { activatingClassicOnAtomic: false } );
-		optOut( siteId, classicUrl );
-		onClose();
-	}
 
 	switchToBlockEditor = () => {
 		const { siteId, onClose, optIn, gutenbergUrl } = this.props;
@@ -360,8 +301,6 @@ function mapStateToProps( state ) {
 	const postType = getEditedPostValue( state, siteId, postId, 'type' );
 	const gutenbergUrl = getGutenbergEditorUrl( state, siteId, postId, postType );
 	const showSwitchEditorButton = currentRoute.match( /^\/(block-editor|post|page)\// );
-	const isAtomic = isAtomicSite( state, siteId );
-	const sitePlugins = getPlugins( state, [ siteId ] );
 
 	return {
 		searchQuery: getSearchQuery( state ),
@@ -374,8 +313,6 @@ function mapStateToProps( state ) {
 		showOptIn: showSwitchEditorButton && optInEnabled && isCalypsoClassic,
 		gutenbergUrl,
 		isCheckout: section.name && section.name === 'checkout',
-		isAtomic,
-		classicPlugin: find( sitePlugins, { slug: 'classic-editor' } ),
 	};
 }
 
@@ -385,9 +322,6 @@ const mapDispatchToProps = {
 	recordTracksEvent,
 	selectResult,
 	resetContactForm: resetInlineHelpContactForm,
-	activatePlugin,
-	fetchAtomicPlugins: fetchPlugins,
-	showErrorNotice: errorNotice,
 };
 
 export default compose(

--- a/config/development.json
+++ b/config/development.json
@@ -59,7 +59,7 @@
 		"domains/new-status-design/new-options": true,
 		"domains/new-status-design/security-option": true,
 		"earn/rename-payment-blocks": true,
-		"editor/after-deprecation": true,
+		"editor/after-deprecation": false,
 		"editor/before-deprecation": true,
 		"email-accounts/enabled": true,
 		"external-media": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Reverts #41912 due to a change in approach to editor deprecation

#### Testing instructions

* Check in PR in local Calypso dev env
* Try switching editor from block to classic and back again in Atomic and Classic sites and check that everything works as expected.
