### PR TITLE
Nav sidebar: sidebar can be enabled by a filter

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -302,7 +302,10 @@ add_action( 'plugins_loaded', __NAMESPACE__ . '\load_mailerlite' );
  * Load WPCOM block editor nav sidebar
  */
 function load_wpcom_block_editor_sidebar() {
-	if ( defined( 'WPCOM_BLOCK_EDITOR_SIDEBAR' ) && WPCOM_BLOCK_EDITOR_SIDEBAR ) {
+	if (
+		( defined( 'WPCOM_BLOCK_EDITOR_SIDEBAR' ) && WPCOM_BLOCK_EDITOR_SIDEBAR ) ||
+		apply_filters( 'a8c_enable_nav_sidebar', false )
+	) {
 		require_once __DIR__ . '/wpcom-block-editor-nav-sidebar/class-wpcom-block-editor-nav-sidebar.php';
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Sidebar code is enabled if `a8c_enable_nav_sidebar` filter returns true

This leaves the `WPCOM_BLOCK_EDITOR_SIDEBAR` option so the plugin can still be run on dotorg sites.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**dotorg site**

* Checkout branch
* Run `npx wp-env start` in `apps/full-site-editing`
* Run `npx wp-env run cli wp config set WPCOM_BLOCK_EDITOR_SIDEBAR 0` to ensure feature is disabled
* Test site at `localhost:4013`, the sidebar shouldn't appear in the block editor

**dotcom site**

* Apply these changes `full-site-editing` changes to your sandbox
* Check `WPCOM_BLOCK_EDITOR_SIDEBAR` isn't defined in the sandbox
* Test that the nav sidebar isn't appearing in a sandboxed site (this is because no one is using this hook yet)
* Can do more testing if you follow instructions in D45264-code

