### PR TITLE
Nav sidebar: sidebar opens over the editor, behaves like a modal

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/actions.ts
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/actions.ts
@@ -3,8 +3,15 @@ const toggleSidebar = () =>
 		type: 'TOGGLE_SIDEBAR',
 	} as const );
 
+const setSidebarClosing = ( isClosing: boolean ) =>
+	( {
+		type: 'SET_SIDEBAR_CLOSING',
+		isClosing,
+	} as const );
+
 export const actions = {
 	toggleSidebar,
+	setSidebarClosing,
 };
 
-export type Action = ReturnType< typeof toggleSidebar >;
+export type Action = ReturnType< typeof toggleSidebar | typeof setSidebarClosing >;

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/attach-sidebar.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/attach-sidebar.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
 import { __experimentalMainDashboardButton as MainDashboardButton } from '@wordpress/interface';
 import { registerPlugin as originalRegisterPlugin, PluginSettings } from '@wordpress/plugins';
@@ -9,7 +9,6 @@ import { registerPlugin as originalRegisterPlugin, PluginSettings } from '@wordp
 /**
  * Internal dependencies
  */
-import { STORE_KEY } from './constants';
 import WpcomBlockEditorNavSidebar from './components/nav-sidebar';
 import ToggleSidebarButton from './components/toggle-sidebar-button';
 
@@ -19,7 +18,6 @@ const registerPlugin = ( name: string, settings: Omit< PluginSettings, 'icon' > 
 registerPlugin( 'a8c-full-site-editing-nav-sidebar', {
 	render: function NavSidebar() {
 		const { addEntities } = useDispatch( 'core' );
-		const isSidebarOpened = useSelect( ( select ) => select( STORE_KEY ).isSidebarOpened() );
 
 		useEffect( () => {
 			// Teach core data about the status entity so we can use selectors like `getEntityRecords()`
@@ -36,25 +34,6 @@ registerPlugin( 'a8c-full-site-editing-nav-sidebar', {
 			// Only register entity once
 			// eslint-disable-next-line react-hooks/exhaustive-deps
 		}, [] );
-
-		// TODO: remove this effect once sidebar opens over the editor and doesn't
-		// squish the editor content.
-		useEffect( () => {
-			// Classes need to be attached to elements that aren't controlled by React,
-			// otherwise our alterations will be removed when React re-renders. So attach
-			// to <body> element.
-			document.body.classList.add( 'is-wpcom-block-editor-nav-sidebar-attached' );
-		}, [] );
-
-		// TODO: remove this effect once sidebar opens over the editor and doesn't
-		// squish the editor content.
-		useEffect( () => {
-			if ( isSidebarOpened ) {
-				document.body.classList.add( 'is-wpcom-block-editor-nav-sidebar-opened' );
-			} else {
-				document.body.classList.remove( 'is-wpcom-block-editor-nav-sidebar-opened' );
-			}
-		}, [ isSidebarOpened ] );
 
 		return (
 			<MainDashboardButton>

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/attach-sidebar.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/attach-sidebar.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { useDispatch } from '@wordpress/data';
-import { useEffect } from '@wordpress/element';
+import { useEffect, createPortal, useState } from '@wordpress/element';
 import { __experimentalMainDashboardButton as MainDashboardButton } from '@wordpress/interface';
 import { registerPlugin as originalRegisterPlugin, PluginSettings } from '@wordpress/plugins';
 
@@ -35,10 +35,18 @@ registerPlugin( 'a8c-full-site-editing-nav-sidebar', {
 			// eslint-disable-next-line react-hooks/exhaustive-deps
 		}, [] );
 
+		const [ clickGuardRoot ] = useState( () => document.createElement( 'div' ) );
+		useEffect( () => {
+			document.body.appendChild( clickGuardRoot );
+			return () => {
+				document.body.removeChild( clickGuardRoot );
+			};
+		} );
+
 		return (
 			<MainDashboardButton>
 				<ToggleSidebarButton />
-				<WpcomBlockEditorNavSidebar />
+				{ createPortal( <WpcomBlockEditorNavSidebar />, clickGuardRoot ) }
 			</MainDashboardButton>
 		);
 	},

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
@@ -1,15 +1,14 @@
 /**
  * External dependencies
  */
-import { useState, useEffect, useRef, WPSyntheticEvent } from '@wordpress/element';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { WPSyntheticEvent } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
 import { Button as OriginalButton } from '@wordpress/components';
-import { chevronLeft, wordpress } from '@wordpress/icons';
+import { chevronLeft } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { applyFilters, doAction, hasAction } from '@wordpress/hooks';
 import { get } from 'lodash';
 import { addQueryArgs } from '@wordpress/url';
-import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -42,22 +41,6 @@ export default function WpcomBlockEditorNavSidebar() {
 	const items = useNavItems();
 	const statusLabels = usePostStatusLabels();
 
-	const prevIsOpen = useRef( isOpen );
-	const [ isClosing, setIsClosing ] = useState( false );
-
-	useEffect( () => {
-		if ( isOpen ) {
-			document.body.classList.add( 'is-wpcom-block-editor-nav-sidebar-close-hidden' );
-		} else if ( prevIsOpen.current ) {
-			// Check previous isOpen value so we don't set isClosing on first mount
-			setIsClosing( true );
-		}
-
-		prevIsOpen.current = isOpen;
-	}, [ isOpen, prevIsOpen, setIsClosing ] );
-
-	const { toggleSidebar } = useDispatch( STORE_KEY );
-
 	if ( ! postType ) {
 		// Still loading
 		return null;
@@ -77,62 +60,43 @@ export default function WpcomBlockEditorNavSidebar() {
 	};
 
 	return (
-		<div className="wpcom-block-editor-nav-sidebar-nav-sidebar__container" aria-hidden={ ! isOpen }>
-			{ ( isOpen || isClosing ) && (
-				<div className="wpcom-block-editor-nav-sidebar-nav-sidebar__header">
+		<>
+			<div
+				className="wpcom-block-editor-nav-sidebar-nav-sidebar__click-guard"
+				aria-hidden={ ! isOpen }
+			/>
+			<div
+				className="wpcom-block-editor-nav-sidebar-nav-sidebar__container"
+				aria-hidden={ ! isOpen }
+			>
+				<div className="wpcom-block-editor-nav-sidebar-nav-sidebar__header" />
+				<div className="wpcom-block-editor-nav-sidebar-nav-sidebar__home-button-container">
 					<Button
-						icon={ wordpress }
-						iconSize={ 36 }
-						className={ classNames( {
-							'is-shrinking': isOpen,
-							'is-growing': isClosing,
-						} ) }
-						onClick={ () => {
-							if ( isOpen ) {
-								// The `useEffect` above already takes care of setting isClose to true,
-								// but there's a flicker where isOpen and isClosing are both false for
-								// a brief moment in time. Setting isClose to true here too to avoid
-								// the flicker.
-								setIsClosing( true );
-							}
-							toggleSidebar();
-						} }
-						onAnimationEnd={ ( ev: any ) => {
-							if ( ev.animationName === 'wpcom-block-editor-nav-sidebar__grow' ) {
-								setIsClosing( false );
-								document.body.classList.remove( 'is-wpcom-block-editor-nav-sidebar-close-hidden' );
-							}
-						} }
-					/>
+						href={ closeUrl }
+						className="wpcom-block-editor-nav-sidebar-nav-sidebar__home-button"
+						icon={ chevronLeft }
+						onClick={ handleClose }
+					>
+						{ closeLabel }
+					</Button>
 				</div>
-			) }
-			<div className="wpcom-block-editor-nav-sidebar-nav-sidebar__header-space" />
-			<div className="wpcom-block-editor-nav-sidebar-nav-sidebar__home-button-container">
-				<Button
-					href={ closeUrl }
-					className="wpcom-block-editor-nav-sidebar-nav-sidebar__home-button"
-					icon={ chevronLeft }
-					onClick={ handleClose }
-				>
-					{ closeLabel }
-				</Button>
+				<div className="wpcom-block-editor-nav-sidebar-nav-sidebar__controls">
+					<ul className="wpcom-block-editor-nav-sidebar-nav-sidebar__page-list">
+						{ items.map( ( item ) => (
+							<NavItem
+								key={ item.id }
+								item={ item }
+								postType={ postType } // We know the post type of this item is always the same as the post type of the current editor
+								selected={ item.id === selectedItemId }
+								statusLabel={ statusLabels[ item.status ] }
+							/>
+						) ) }
+					</ul>
+					<CreatePage postType={ postType } />
+					<ViewAllPosts postType={ postType } />
+				</div>
 			</div>
-			<div className="wpcom-block-editor-nav-sidebar-nav-sidebar__controls">
-				<ul className="wpcom-block-editor-nav-sidebar-nav-sidebar__page-list">
-					{ items.map( ( item ) => (
-						<NavItem
-							key={ item.id }
-							item={ item }
-							postType={ postType } // We know the post type of this item is always the same as the post type of the current editor
-							selected={ item.id === selectedItemId }
-							statusLabel={ statusLabels[ item.status ] }
-						/>
-					) ) }
-				</ul>
-				<CreatePage postType={ postType } />
-				<ViewAllPosts postType={ postType } />
-			</div>
-		</div>
+		</>
 	);
 }
 

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
@@ -8,7 +8,7 @@ import {
 	IsolatedEventContainer,
 	withConstrainedTabbing,
 } from '@wordpress/components';
-import { chevronLeft } from '@wordpress/icons';
+import { chevronLeft, wordpress } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { applyFilters, doAction, hasAction } from '@wordpress/hooks';
 import { get } from 'lodash';
@@ -129,7 +129,20 @@ function WpcomBlockEditorNavSidebar() {
 				role="dialog"
 				tabIndex={ -1 }
 			>
-				<div className="wpcom-block-editor-nav-sidebar-nav-sidebar__header" />
+				<div className="wpcom-block-editor-nav-sidebar-nav-sidebar__header">
+					<Button
+						className={ classNames(
+							'edit-post-fullscreen-mode-close',
+							'wpcom-block-editor-nav-sidebar-nav-sidebar__dismiss-sidebar-button',
+							{
+								'is-growing': isClosing,
+							}
+						) }
+						icon={ wordpress }
+						iconSize={ 36 }
+						onClick={ dismissSidebar }
+					/>
+				</div>
 				<div className="wpcom-block-editor-nav-sidebar-nav-sidebar__home-button-container">
 					<Button
 						href={ closeUrl }

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useLayoutEffect, useRef, useState } from '@wordpress/element';
+import { useLayoutEffect, useRef } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import {
 	Button as OriginalButton,
@@ -35,12 +35,13 @@ const Button = ( {
 );
 
 function WpcomBlockEditorNavSidebar() {
-	const { toggleSidebar } = useDispatch( STORE_KEY );
-	const [ isOpen, postType, selectedItemId ] = useSelect( ( select ) => {
+	const { toggleSidebar, setSidebarClosing } = useDispatch( STORE_KEY );
+	const [ isOpen, isClosing, postType, selectedItemId ] = useSelect( ( select ) => {
 		const { getPostType } = select( 'core' ) as any;
 
 		return [
 			select( STORE_KEY ).isSidebarOpened(),
+			select( STORE_KEY ).isSidebarClosing(),
 			getPostType( select( 'core/editor' ).getCurrentPostType() ),
 			select( 'core/editor' ).getCurrentPostId(),
 		];
@@ -50,18 +51,17 @@ function WpcomBlockEditorNavSidebar() {
 	const statusLabels = usePostStatusLabels();
 
 	const prevIsOpen = useRef( isOpen );
-	const [ isClosing, setIsClosing ] = useState( false );
 
 	// Using layout effect to prevent a brief moment in time where both `isOpen` and `isClosing`
 	// are both false, causing a flicker during the fade out animation.
 	useLayoutEffect( () => {
 		if ( ! isOpen && prevIsOpen.current ) {
 			// Check current and previous isOpen value to see if we're closing
-			setIsClosing( true );
+			setSidebarClosing( true );
 		}
 
 		prevIsOpen.current = isOpen;
-	}, [ isOpen, prevIsOpen, setIsClosing ] );
+	}, [ isOpen, prevIsOpen, setSidebarClosing ] );
 
 	if ( ! postType ) {
 		// Still loading
@@ -115,7 +115,7 @@ function WpcomBlockEditorNavSidebar() {
 					ev.animationName === 'wpcom-block-editor-nav-sidebar-nav-sidebar__fade' &&
 					isClosing
 				) {
-					setIsClosing( false );
+					setSidebarClosing( false );
 				}
 			} }
 			onClick={ handleClickGuard }

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/style.scss
@@ -6,87 +6,48 @@ $sidebar-width: 272px;
 $border: 1px solid $light-gray-500;
 $transition-period: 200ms;
 
-.is-wpcom-block-editor-nav-sidebar-attached {
-	.edit-post-layout {
-		transition: margin-left $transition-period;
-		@include reduce-motion( 'transition' );
-	}
+.wpcom-block-editor-nav-sidebar-nav-sidebar__click-guard {
+	visibility: hidden;
+	position: fixed;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	background: $black;
+	opacity: 0;
+	transition: opacity $transition-period;
+	@include reduce-motion( 'transition' );
 
-	.edit-post-fullscreen-mode-close {
-		transition: width $transition-period;
-		@include reduce-motion( 'transition' );
-	}
-
-	.edit-post-fullscreen-mode-close {
-		min-width: 0;
-	}
-}
-
-.is-wpcom-block-editor-nav-sidebar-opened {
-	.edit-post-layout {
-		margin-left: $sidebar-width;
-	}
-
-	.edit-post-fullscreen-mode-close {
-		width: 0;
-	}
-}
-
-.is-wpcom-block-editor-nav-sidebar-close-hidden {
-	.edit-post-fullscreen-mode-close {
-		opacity: 0;
-		padding: 0;
-		pointer-events: none;
+	&:not( [aria-hidden=true] ) {
+		visibility: visible;
+		opacity: 0.44;
 	}
 }
 
 .wpcom-block-editor-nav-sidebar-nav-sidebar__container {
 	box-sizing: border-box;
 	position: fixed;
+	visibility: hidden;
 	top: 0;
 	left: -$sidebar-width;
 	bottom: 0;
 	width: $sidebar-width;
 	border-right: $border;
+	background: $white;
+	z-index: 1;
 	transition: left $transition-period;
 	@include reduce-motion( 'transition' );
 
 	&:not( [aria-hidden=true] ) {
+		visibility: visible;
 		left: 0;
 	}
 }
 
 .wpcom-block-editor-nav-sidebar-nav-sidebar__header {
-	top: 0;
-	left: 0;
-	position: fixed;
-	height: $header-height;
-
-	.components-button {
-		height: $header-height;
-		width: $header-height;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		border-radius: 0;
-		background: #32373d !important;
-		color: #fff !important;
-		box-shadow: none !important;
-
-		&.is-shrinking {
-			animation: wpcom-block-editor-nav-sidebar__shrink $transition-period normal forwards;
-			@include reduce-motion( 'animation' );
-		}
-		&.is-growing {
-			animation: wpcom-block-editor-nav-sidebar__grow $transition-period normal forwards;
-			@include reduce-motion( 'animation' );
-		}
-	}
-}
-
-.wpcom-block-editor-nav-sidebar-nav-sidebar__header-space {
 	height: $header-height;
 	border-bottom: $border;
+	box-sizing: content-box;
 }
 
 .wpcom-block-editor-nav-sidebar-nav-sidebar__home-button-container {

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/style.scss
@@ -12,6 +12,7 @@ $transition-period: 200ms;
 	left: 0;
 	right: 0;
 	bottom: 0;
+	z-index: 1;
 	animation: wpcom-block-editor-nav-sidebar-nav-sidebar__fade $transition-period ease-out forwards;
 	@include reduce-motion( 'animation' );
 
@@ -38,7 +39,6 @@ $transition-period: 200ms;
 	width: $sidebar-width;
 	border-right: $border;
 	background: $white;
-	z-index: 1;
 	animation: wpcom-block-editor-nav-sidebar-nav-sidebar__slide $transition-period ease-out;
 	@include reduce-motion( 'animation' );
 

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/style.scss
@@ -7,19 +7,26 @@ $border: 1px solid $light-gray-500;
 $transition-period: 200ms;
 
 .wpcom-block-editor-nav-sidebar-nav-sidebar__click-guard {
-	visibility: hidden;
 	position: fixed;
 	top: 0;
 	left: 0;
 	right: 0;
 	bottom: 0;
 	background: $black;
-	opacity: 0;
-	transition: opacity $transition-period;
-	@include reduce-motion( 'transition' );
+	animation: wpcom-block-editor-nav-sidebar-nav-sidebar__fade $transition-period ease-out forwards;
+	@include reduce-motion( 'animation' );
 
-	&:not( [aria-hidden=true] ) {
-		visibility: visible;
+	&.is-fading-out {
+		animation: wpcom-block-editor-nav-sidebar-nav-sidebar__fade $transition-period ease-in reverse;
+		@include reduce-motion( 'animation' );
+	}
+}
+
+@keyframes wpcom-block-editor-nav-sidebar-nav-sidebar__fade {
+	0% {
+		opacity: 0;
+	}
+	100% {
 		opacity: 0.44;
 	}
 }
@@ -27,19 +34,26 @@ $transition-period: 200ms;
 .wpcom-block-editor-nav-sidebar-nav-sidebar__container {
 	box-sizing: border-box;
 	position: fixed;
-	visibility: hidden;
 	top: 0;
-	left: -$sidebar-width;
 	bottom: 0;
 	width: $sidebar-width;
 	border-right: $border;
 	background: $white;
 	z-index: 1;
-	transition: left $transition-period;
-	@include reduce-motion( 'transition' );
+	animation: wpcom-block-editor-nav-sidebar-nav-sidebar__slide $transition-period ease-out;
+	@include reduce-motion( 'animation' );
 
-	&:not( [aria-hidden=true] ) {
-		visibility: visible;
+	&.is-sliding-left {
+		animation: wpcom-block-editor-nav-sidebar-nav-sidebar__slide $transition-period ease-in reverse;
+		@include reduce-motion( 'animation' );
+	}
+}
+
+@keyframes wpcom-block-editor-nav-sidebar-nav-sidebar__slide {
+	0% {
+		left: -$sidebar-width;
+	}
+	100% {
 		left: 0;
 	}
 }

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/style.scss
@@ -12,7 +12,7 @@ $transition-period: 200ms;
 	left: 0;
 	right: 0;
 	bottom: 0;
-	z-index: 1;
+	z-index: 2;
 	animation: wpcom-block-editor-nav-sidebar-nav-sidebar__fade $transition-period ease-out forwards;
 	@include reduce-motion( 'animation' );
 

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/style.scss
@@ -1,6 +1,7 @@
 @import '~@wordpress/base-styles/colors';
 @import '~@wordpress/base-styles/mixins';
 @import '~@wordpress/base-styles/variables';
+@import '~@wordpress/base-styles/z-index';
 
 $sidebar-width: 272px;
 $border: 1px solid $light-gray-500;
@@ -12,7 +13,8 @@ $transition-period: 200ms;
 	left: 0;
 	right: 0;
 	bottom: 0;
-	z-index: 2;
+	// Use the same z-index as the <Modal> component
+	z-index: z-index( '.components-modal__header' );
 	animation: wpcom-block-editor-nav-sidebar-nav-sidebar__fade $transition-period ease-out forwards;
 	@include reduce-motion( 'animation' );
 

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/style.scss
@@ -12,7 +12,6 @@ $transition-period: 200ms;
 	left: 0;
 	right: 0;
 	bottom: 0;
-	background: $black;
 	animation: wpcom-block-editor-nav-sidebar-nav-sidebar__fade $transition-period ease-out forwards;
 	@include reduce-motion( 'animation' );
 
@@ -24,10 +23,10 @@ $transition-period: 200ms;
 
 @keyframes wpcom-block-editor-nav-sidebar-nav-sidebar__fade {
 	0% {
-		opacity: 0;
+		background-color: rgba( $black, 0 );
 	}
 	100% {
-		opacity: 0.44;
+		background-color: rgba( $black, 0.7 );
 	}
 }
 

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/style.scss
@@ -63,6 +63,30 @@ $transition-period: 200ms;
 	height: $header-height;
 	border-bottom: $border;
 	box-sizing: content-box;
+	display: flex;
+}
+
+.wpcom-block-editor-nav-sidebar-nav-sidebar__dismiss-sidebar-button {
+	position: fixed;
+	top: 0;
+	left: 0;
+	height: $header-height !important;
+	animation: wpcom-block-editor-nav-sidebar-nav-sidebar__shrink $transition-period ease-in-out forwards;
+	@include reduce-motion( 'animation' );
+
+	&.is-growing {
+		animation: wpcom-block-editor-nav-sidebar-nav-sidebar__shrink $transition-period ease-in-out reverse;
+		@include reduce-motion( 'animation' );
+	}
+}
+
+@keyframes wpcom-block-editor-nav-sidebar-nav-sidebar__shrink {
+	0% {
+		transform: scale( 1 );
+	}
+	100% {
+		transform: scale( 0.55 );
+	}
 }
 
 .wpcom-block-editor-nav-sidebar-nav-sidebar__home-button-container {

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/toggle-sidebar-button/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/toggle-sidebar-button/index.tsx
@@ -3,7 +3,8 @@
  */
 import { Button as OriginalButton } from '@wordpress/components';
 import { wordpress } from '@wordpress/icons';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -20,13 +21,23 @@ const Button = ( {
 
 export default function ToggleSidebarButton() {
 	const { toggleSidebar } = useDispatch( STORE_KEY );
+	const isOpen = useSelect( ( select ) => select( STORE_KEY ).isSidebarOpened() );
 
 	return (
-		<Button
-			className="edit-post-fullscreen-mode-close a8c-full-site-editing__close-button"
-			icon={ wordpress }
-			iconSize={ 36 }
-			onClick={ toggleSidebar }
-		></Button>
+		<>
+			<Button
+				className={ classnames(
+					'edit-post-fullscreen-mode-close',
+					'wpcom-block-editor-nav-sidebar-toggle-sidebar-button__button',
+					{
+						'is-open': isOpen,
+					}
+				) }
+				icon={ wordpress }
+				iconSize={ 36 }
+				onClick={ toggleSidebar }
+			></Button>
+			<div className="wpcom-block-editor-nav-sidebar-toggle-sidebar-button__spacer" />
+		</>
 	);
 }

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/toggle-sidebar-button/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/toggle-sidebar-button/index.tsx
@@ -21,23 +21,21 @@ const Button = ( {
 
 export default function ToggleSidebarButton() {
 	const { toggleSidebar } = useDispatch( STORE_KEY );
-	const isOpen = useSelect( ( select ) => select( STORE_KEY ).isSidebarOpened() );
+	const isSidebarOpen = useSelect( ( select ) => select( STORE_KEY ).isSidebarOpened() );
+	const isSidebarClosing = useSelect( ( select ) => select( STORE_KEY ).isSidebarClosing() );
 
 	return (
-		<>
-			<Button
-				className={ classnames(
-					'edit-post-fullscreen-mode-close',
-					'wpcom-block-editor-nav-sidebar-toggle-sidebar-button__button',
-					{
-						'is-open': isOpen,
-					}
-				) }
-				icon={ wordpress }
-				iconSize={ 36 }
-				onClick={ toggleSidebar }
-			></Button>
-			<div className="wpcom-block-editor-nav-sidebar-toggle-sidebar-button__spacer" />
-		</>
+		<Button
+			className={ classnames(
+				'edit-post-fullscreen-mode-close',
+				'wpcom-block-editor-nav-sidebar-toggle-sidebar-button__button',
+				{
+					'is-hidden': isSidebarOpen || isSidebarClosing,
+				}
+			) }
+			icon={ wordpress }
+			iconSize={ 36 }
+			onClick={ toggleSidebar }
+		/>
 	);
 }

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/toggle-sidebar-button/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/toggle-sidebar-button/style.scss
@@ -1,5 +1,22 @@
+@import '~@wordpress/base-styles/mixins';
 @import '~@wordpress/base-styles/variables';
+@import '../nav-sidebar/style.scss';
 
-.a8c-full-site-editing__close-button {
+.wpcom-block-editor-nav-sidebar-toggle-sidebar-button__button {
 	height: $header-height !important;
+	position: fixed;
+	z-index: 2;
+	top: 0;
+	left: 0;
+	transition: transform $transition-period;
+	@include reduce-motion( 'transition' );
+
+	&.is-open {
+		transform: scale( 0.55 );
+	}
+}
+
+.wpcom-block-editor-nav-sidebar-toggle-sidebar-button__spacer {
+	height: $header-height;
+	width: $header-height;
 }

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/toggle-sidebar-button/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/toggle-sidebar-button/style.scss
@@ -1,22 +1,9 @@
-@import '~@wordpress/base-styles/mixins';
 @import '~@wordpress/base-styles/variables';
-@import '../nav-sidebar/style.scss';
 
 .wpcom-block-editor-nav-sidebar-toggle-sidebar-button__button {
 	height: $header-height !important;
-	position: fixed;
-	z-index: 3;
-	top: 0;
-	left: 0;
-	transition: transform $transition-period;
-	@include reduce-motion( 'transition' );
 
-	&.is-open {
-		transform: scale( 0.55 );
+	&.is-hidden {
+		visibility: hidden;
 	}
-}
-
-.wpcom-block-editor-nav-sidebar-toggle-sidebar-button__spacer {
-	height: $header-height;
-	width: $header-height;
 }

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/toggle-sidebar-button/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/toggle-sidebar-button/style.scss
@@ -5,7 +5,7 @@
 .wpcom-block-editor-nav-sidebar-toggle-sidebar-button__button {
 	height: $header-height !important;
 	position: fixed;
-	z-index: 2;
+	z-index: 3;
 	top: 0;
 	left: 0;
 	transition: transform $transition-period;

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/store.ts
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/store.ts
@@ -22,12 +22,23 @@ const opened: Reducer< boolean, Action > = ( state = false, action ) => {
 	}
 };
 
-const reducer = combineReducers( { opened } );
+const closing: Reducer< boolean, Action > = ( state = false, action ) => {
+	switch ( action.type ) {
+		case 'SET_SIDEBAR_CLOSING':
+			return action.isClosing;
+
+		default:
+			return state;
+	}
+};
+
+const reducer = combineReducers( { opened, closing } );
 
 type State = ReturnType< typeof reducer >;
 
 const selectors = {
 	isSidebarOpened: ( state: State ) => state.opened,
+	isSidebarClosing: ( state: State ) => state.closing,
 };
 
 registerStore( STORE_KEY, {


### PR DESCRIPTION
**_Note to anyone reading this while preparing a release of the FSE plugin_**

This change doesn't require any release notes. We're developing a new feature which is currently hidden behind a flag.

#### Changes proposed in this Pull Request

Changes to the sidebar to make it behave like a modal. Rather than shrinking the editing space so the sidebar can fit beside it, this opens the sidebar overtop. Matches the latest mockup.

The sidebar now does things like:
- keyboard focus (using TAB) is constrained to only inside the sidebar
- sidebar can be dismissed with ESC or clicking the dark background
- "dialog" aria role

This also removed the need of adding magic classes to the `<body>` so that we could shrink the editing space. We no longer need to touch DOM elements outside of our own plugin.

![Jul-02-2020 18-47-10](https://user-images.githubusercontent.com/1500769/86325648-7f96ea80-bc94-11ea-9085-57737cbb2ceb.gif)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Test on dotorg site**

* Checkout branch
* `cd apps/full-site-editing`
* `yarn build` or `yarn dev`
* Define `WPCOM_BLOCK_EDITOR_SIDEBAR` in [`.wp-env.override.json`](https://developer.wordpress.org/block-editor/packages/packages-env/#wp-env-override-json)
* `npx wp-env start`
* Test the editor at `http://localhost:4013` (username: `admin`, password: `password`)
* Sidebar can be opened/closed via the (W) button.

**Test on dotcom site**

* Sandbox your favourite test site
* Define `WPCOM_BLOCK_EDITOR_SIDEBAR` in sandbox (or add the `nav-sidebar-enabled` sticker to your test site)
* Apply D45268-code to sandbox
* Test the editor in your sandboxed site
* Sidebar can be opened/closed via the (W) button.
