### PR TITLE
Remove AB test for .jp domains in Japan

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -128,16 +128,6 @@ export default {
 		localeTargets: [ 'en' ],
 		countryCodeTargets: [ 'US', 'ID', 'NG', 'BD', 'NL', 'SE', 'SG', 'LK', 'NZ', 'IE', 'CA', 'AU' ],
 	},
-	domainShowJPResultsInJapan: {
-		datestamp: '20200506',
-		variations: {
-			variantShowJPResults: 50,
-			control: 50,
-		},
-		defaultVariation: 'control',
-		localeTargets: 'any',
-		countryCodeTargets: [ 'JP' ],
-	},
 	[ RUM_DATA_COLLECTION.AB_NAME ]: {
 		datestamp: '20200602',
 		variations: {

--- a/client/lib/domains/suggestions/index.js
+++ b/client/lib/domains/suggestions/index.js
@@ -1,26 +1,13 @@
 /**
- * Internal dependencies
- */
-import { abtest } from 'lib/abtest';
-
-/**
  * Get the suggestions vendor
  *
  * @param {boolean} [isSignup=false] Whether the query is part of a signup flow.
- * @param {string|null} [countryCodeForABTests=null] The country code to be used for A/B tests.
  *
  * @returns {string} Vendor string to pass as part of the domain suggestions query.
  */
-export const getSuggestionsVendor = ( isSignup = false, countryCodeForABTests = null ) => {
+export const getSuggestionsVendor = ( isSignup = false ) => {
 	if ( isSignup ) {
-		let vendor = 'variation4_front';
-		if (
-			countryCodeForABTests &&
-			abtest( 'domainShowJPResultsInJapan', countryCodeForABTests ) === 'variantShowJPResults'
-		) {
-			vendor = 'variation6_front';
-		}
-		return vendor;
+		return 'variation4_front';
 	}
 	return 'variation2_front';
 };

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -55,7 +55,6 @@ import { abtest } from 'lib/abtest';
  * Style dependencies
  */
 import './style.scss';
-import { requestGeoLocation } from '../../../state/data-getters';
 
 class DomainsStep extends React.Component {
 	static propTypes = {
@@ -72,7 +71,6 @@ class DomainsStep extends React.Component {
 		stepName: PropTypes.string.isRequired,
 		stepSectionName: PropTypes.string,
 		selectedSite: PropTypes.object,
-		userGeoCountryCode: PropTypes.string,
 		vertical: PropTypes.string,
 	};
 
@@ -742,7 +740,6 @@ export default connect(
 			selectedSite: getSite( state, ownProps.signupDependencies.siteSlug ),
 			isSitePreviewVisible: isSitePreviewVisible( state ),
 			hasInitializedSitesBackUrl: hasInitializedSites( state ) ? '/sites/' : false,
-			userGeoCountryCode: requestGeoLocation().data,
 		};
 	},
 	{

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -478,7 +478,7 @@ class DomainsStep extends React.Component {
 				isEligibleVariantForDomainTest={ this.isEligibleVariantForDomainTest() }
 				suggestion={ initialQuery }
 				designType={ this.getDesignType() }
-				vendor={ getSuggestionsVendor( true, this.props.userGeoCountryCode ) }
+				vendor={ getSuggestionsVendor( true ) }
 				deemphasiseTlds={ this.props.flowName === 'ecommerce' ? [ 'blog' ] : [] }
 				selectedSite={ this.props.selectedSite }
 				showSkipButton={ this.props.showSkipButton }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This change removes the A/B test for showing `.jp` domain suggestions to some users in Japan, and allows all users to see those domains.

Note that this should be merged after the back end is updated to allow `.jp` domains for both of the vendor strings currently in use - D45271-code

#### Testing instructions

* Verify that you can search for domains by starting the signup flows via `/start` and `/new`, as well as via the domains-only flow at `/domains`.
