### PR TITLE
[RUM] Default collector with user info

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -4,10 +4,9 @@
  */
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
-import { endsWith, get, map, partial, pickBy, startsWith, isArray } from 'lodash';
+import { endsWith, get, map, partial, pickBy, startsWith, isArray, flowRight } from 'lodash';
 import url from 'url';
 import { localize, LocalizeProps } from 'i18n-calypso';
-
 /**
  * Internal dependencies
  */
@@ -47,7 +46,8 @@ import ConvertToBlocksDialog from 'components/convert-to-blocks';
 import config from 'config';
 import EditorDocumentHead from 'post-editor/editor-document-head';
 import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
-import { stopPerformanceTracking } from 'lib/performance-tracking';
+import { withStopPerformanceTrackingProp, PerformanceTrackProps } from 'lib/performance-tracking';
+
 /**
  * Types
  */
@@ -113,7 +113,7 @@ enum EditorActions {
 }
 
 class CalypsoifyIframe extends Component<
-	Props & ConnectedProps & ProtectedFormProps & LocalizeProps,
+	Props & ConnectedProps & ProtectedFormProps & LocalizeProps & PerformanceTrackProps,
 	State
 > {
 	state: State = {
@@ -361,8 +361,7 @@ class CalypsoifyIframe extends Component<
 
 		if ( EditorActions.TrackPerformance === action ) {
 			if ( payload.mark === 'editor.ready' ) {
-				// This name must match the section name
-				stopPerformanceTracking( 'gutenberg-editor' );
+				this.props.stopPerformanceTracking();
 			}
 		}
 	};
@@ -798,7 +797,9 @@ const mapDispatchToProps = {
 
 type ConnectedProps = ReturnType< typeof mapStateToProps > & typeof mapDispatchToProps;
 
-export default connect(
-	mapStateToProps,
-	mapDispatchToProps
-)( localize( protectForm( CalypsoifyIframe ) ) );
+export default flowRight(
+	withStopPerformanceTrackingProp,
+	connect( mapStateToProps, mapDispatchToProps ),
+	localize,
+	protectForm
+)( CalypsoifyIframe );

--- a/client/lib/performance-tracking/index.ts
+++ b/client/lib/performance-tracking/index.ts
@@ -2,6 +2,9 @@ export { performanceTrackerStart } from './performance-tracker-start';
 
 export { usePerformanceTrackerStop } from './use-performance-tracker-stop';
 export { withPerformanceTrackerStop } from './with-performance-tracker-stop';
+export { withStopPerformanceTrackingProp } from './with-stop-performance-tracking-prop';
 export { default as PerformanceTrackerStop } from './performance-tracker-stop';
 
-export { startPerformanceTracking, stopPerformanceTracking } from './lib';
+export type PerformanceTrackProps = {
+	stopPerformanceTracking: () => void;
+};

--- a/client/lib/performance-tracking/lib.js
+++ b/client/lib/performance-tracking/lib.js
@@ -12,6 +12,10 @@ import { CONFIG_NAME, AB_NAME, AB_VARIATION_ON } from './const';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite, isSingleUserSite } from 'state/sites/selectors';
 import isSiteWpcomAtomic from 'state/selectors/is-site-wpcom-atomic';
+import {
+	getCurrentUserSiteCount,
+	getCurrentUserVisibleSiteCount,
+} from 'state/current-user/selectors';
 
 /**
  * These reporters are added to _all_ performance tracking metrics.
@@ -24,10 +28,15 @@ const getDefaultCollector = ( state ) => {
 	const siteIsJetpack = isJetpackSite( state, siteId );
 	const siteIsSingleUser = isSingleUserSite( state, siteId );
 	const siteIsAtomic = isSiteWpcomAtomic( state, siteId );
+	const sitesCount = getCurrentUserSiteCount( state );
+	const sitesVisibleCount = getCurrentUserVisibleSiteCount( state );
+
 	return ( report ) => {
 		report.data.set( 'siteIsJetpack', siteIsJetpack );
 		report.data.set( 'siteIsSingleUser', siteIsSingleUser );
 		report.data.set( 'siteIsAtomic', siteIsAtomic );
+		report.data.set( 'sitesCount', sitesCount );
+		report.data.set( 'sitesVisibleCount', sitesVisibleCount );
 	};
 };
 

--- a/client/lib/performance-tracking/lib.js
+++ b/client/lib/performance-tracking/lib.js
@@ -9,6 +9,27 @@ import { start, stop } from '@automattic/browser-data-collector';
 import config from 'config';
 import { abtest } from 'lib/abtest';
 import { CONFIG_NAME, AB_NAME, AB_VARIATION_ON } from './const';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { isJetpackSite, isSingleUserSite } from 'state/sites/selectors';
+import isSiteWpcomAtomic from 'state/selectors/is-site-wpcom-atomic';
+
+/**
+ * These reporters are added to _all_ performance tracking metrics.
+ * Be sure to add only reporters that make sense for all metrics and are always present.
+ *
+ * @param state the state
+ */
+const getDefaultCollector = ( state ) => {
+	const siteId = getSelectedSiteId( state );
+	const siteIsJetpack = isJetpackSite( state, siteId );
+	const siteIsSingleUser = isSingleUserSite( state, siteId );
+	const siteIsAtomic = isSiteWpcomAtomic( state, siteId );
+	return ( report ) => {
+		report.data.set( 'siteIsJetpack', siteIsJetpack );
+		report.data.set( 'siteIsSingleUser', siteIsSingleUser );
+		report.data.set( 'siteIsAtomic', siteIsAtomic );
+	};
+};
 
 const isPerformanceTrackingEnabled = () => {
 	const isEnabledForEnvironment = config.isEnabled( CONFIG_NAME );
@@ -16,14 +37,17 @@ const isPerformanceTrackingEnabled = () => {
 	return isEnabledForEnvironment && isEnabledForCurrentInteraction;
 };
 
-export const startPerformanceTracking = ( name, fullPageLoad = false ) => {
+export const startPerformanceTracking = (
+	name,
+	{ fullPageLoad = false, collectors = [] } = {}
+) => {
 	if ( isPerformanceTrackingEnabled() ) {
-		start( name, { fullPageLoad } );
+		start( name, { fullPageLoad, collectors } );
 	}
 };
 
-export const stopPerformanceTracking = ( name ) => {
+export const stopPerformanceTracking = ( name, state, { collectors = [] } = {} ) => {
 	if ( isPerformanceTrackingEnabled() ) {
-		stop( name );
+		stop( name, { collectors: [ getDefaultCollector( state ), ...collectors ] } );
 	}
 };

--- a/client/lib/performance-tracking/lib.js
+++ b/client/lib/performance-tracking/lib.js
@@ -17,7 +17,7 @@ import isSiteWpcomAtomic from 'state/selectors/is-site-wpcom-atomic';
  * These reporters are added to _all_ performance tracking metrics.
  * Be sure to add only reporters that make sense for all metrics and are always present.
  *
- * @param state the state
+ * @param state redux state
  */
 const getDefaultCollector = ( state ) => {
 	const siteId = getSelectedSiteId( state );

--- a/client/lib/performance-tracking/performance-tracker-start.js
+++ b/client/lib/performance-tracking/performance-tracker-start.js
@@ -5,7 +5,9 @@ import { startPerformanceTracking } from './lib';
 
 export const performanceTrackerStart = ( pageName ) => {
 	return ( context, next ) => {
-		startPerformanceTracking( pageName, context.init ?? false );
+		startPerformanceTracking( pageName, {
+			fullPageLoad: context.init ?? false,
+		} );
 		next();
 	};
 };

--- a/client/lib/performance-tracking/test/lib.js
+++ b/client/lib/performance-tracking/test/lib.js
@@ -9,6 +9,9 @@ import { start, stop } from '@automattic/browser-data-collector';
 import config from 'config';
 import { startPerformanceTracking, stopPerformanceTracking } from '../lib';
 import { abtest } from 'lib/abtest';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { isJetpackSite, isSingleUserSite } from 'state/sites/selectors';
+import isSiteWpcomAtomic from 'state/selectors/is-site-wpcom-atomic';
 
 jest.mock( 'config', () => ( {
 	isEnabled: jest.fn(),
@@ -20,6 +23,14 @@ jest.mock( '@automattic/browser-data-collector', () => ( {
 jest.mock( 'lib/abtest', () => ( {
 	abtest: jest.fn(),
 } ) );
+jest.mock( 'state/ui/selectors', () => ( {
+	getSelectedSiteId: jest.fn(),
+} ) );
+jest.mock( 'state/sites/selectors', () => ( {
+	isJetpackSite: jest.fn(),
+	isSingleUserSite: jest.fn(),
+} ) );
+jest.mock( 'state/selectors/is-site-wpcom-atomic', () => jest.fn() );
 
 const withFeatureEnabled = () =>
 	config.isEnabled.mockImplementation( ( key ) => key === 'rum-tracking/logstash' );
@@ -70,21 +81,40 @@ describe( 'startPerformanceTracking', () => {
 	} );
 
 	it( 'measures fullPageLoad if the page is an initial navigation', () => {
-		startPerformanceTracking( 'pageName', true );
+		startPerformanceTracking( 'pageName', { fullPageLoad: true } );
 
-		expect( start ).toHaveBeenCalledWith( expect.anything(), { fullPageLoad: true } );
+		expect( start ).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining( { fullPageLoad: true } )
+		);
 	} );
 
 	it( 'does not measure fullPageLoad if the page is not an initial navigation', () => {
-		startPerformanceTracking( 'pageName', false );
+		startPerformanceTracking( 'pageName', { fullPageLoad: false } );
 
-		expect( start ).toHaveBeenCalledWith( expect.anything(), { fullPageLoad: false } );
+		expect( start ).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining( { fullPageLoad: false } )
+		);
 	} );
 
 	it( 'does not measure fullPageLoad by default', () => {
 		startPerformanceTracking( 'pageName' );
 
-		expect( start ).toHaveBeenCalledWith( expect.anything(), { fullPageLoad: false } );
+		expect( start ).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining( { fullPageLoad: false } )
+		);
+	} );
+
+	it( 'passes the list of collectors', () => {
+		const collectors = [];
+		startPerformanceTracking( 'pageName', { collectors } );
+
+		expect( start ).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining( { collectors } )
+		);
 	} );
 } );
 
@@ -123,6 +153,39 @@ describe( 'stopPerformanceTracking', () => {
 	it( 'uses the name of the page', () => {
 		stopPerformanceTracking( 'pageName' );
 
-		expect( stop ).toHaveBeenCalledWith( 'pageName' );
+		expect( stop ).toHaveBeenCalledWith( 'pageName', expect.anything() );
+	} );
+
+	it( 'passes the list of collectors', () => {
+		const collector = () => {};
+		stopPerformanceTracking( 'pageName', {}, { collectors: [ collector ] } );
+
+		expect( stop ).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining( { collectors: expect.arrayContaining( [ collector ] ) } )
+		);
+	} );
+
+	it( 'uses the state to generate the default collector', () => {
+		const state = {};
+		const report = {
+			data: new Map(),
+		};
+		isJetpackSite.mockImplementation( () => false );
+		isSingleUserSite.mockImplementation( () => false );
+		isSiteWpcomAtomic.mockImplementation( () => false );
+		getSelectedSiteId.mockImplementation( () => 42 );
+
+		// Run the default collector
+		stopPerformanceTracking( 'pageName', state );
+		const defaultCollector = stop.mock.calls[ 0 ][ 1 ].collectors[ 0 ];
+		defaultCollector( report );
+
+		expect( isJetpackSite ).toHaveBeenCalledWith( state, 42 );
+		expect( isSingleUserSite ).toHaveBeenCalledWith( state, 42 );
+		expect( isSiteWpcomAtomic ).toHaveBeenCalledWith( state, 42 );
+		expect( report.data.get( 'siteIsJetpack' ) ).toBe( false );
+		expect( report.data.get( 'siteIsSingleUser' ) ).toBe( false );
+		expect( report.data.get( 'siteIsAtomic' ) ).toBe( false );
 	} );
 } );

--- a/client/lib/performance-tracking/test/performance-tracker-start.js
+++ b/client/lib/performance-tracking/test/performance-tracker-start.js
@@ -31,12 +31,16 @@ describe( 'performance-tracker-start', () => {
 	it( 'measures fullPageLoad if the page is an initial navigation', () => {
 		performanceTrackerStart( 'pageName' )( { init: true }, jest.fn() );
 
-		expect( startPerformanceTracking ).toHaveBeenCalledWith( expect.anything(), true );
+		expect( startPerformanceTracking ).toHaveBeenCalledWith( expect.anything(), {
+			fullPageLoad: true,
+		} );
 	} );
 
 	it( 'does not measure fullPageLoad if the page is not an initial navigation', () => {
 		performanceTrackerStart( 'pageName' )( { init: false }, jest.fn() );
 
-		expect( startPerformanceTracking ).toHaveBeenCalledWith( expect.anything(), false );
+		expect( startPerformanceTracking ).toHaveBeenCalledWith( expect.anything(), {
+			fullPageLoad: false,
+		} );
 	} );
 } );

--- a/client/lib/performance-tracking/test/use-performance-tracker-stop.js
+++ b/client/lib/performance-tracking/test/use-performance-tracker-stop.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { useLayoutEffect } from 'react';
-import { useSelector } from 'react-redux';
+import { useSelector, useStore } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -16,6 +16,7 @@ jest.mock( 'react', () => ( {
 } ) );
 jest.mock( 'react-redux', () => ( {
 	useSelector: jest.fn(),
+	useStore: jest.fn(),
 } ) );
 jest.mock( '../lib', () => ( {
 	stopPerformanceTracking: jest.fn(),
@@ -32,6 +33,9 @@ describe( 'usePerfomranceTrackerStop hook', () => {
 		global.requestAnimationFrame = jest.fn( ( fn ) => fn() );
 		useLayoutEffect.mockImplementation( ( fn ) => fn() );
 		useSelector.mockImplementation( ( selector ) => selector() );
+		useStore.mockImplementation( () => ( {
+			getState: jest.fn( () => ( {} ) ),
+		} ) );
 	} );
 
 	afterEach( () => {
@@ -44,7 +48,7 @@ describe( 'usePerfomranceTrackerStop hook', () => {
 
 		usePerformanceTrackerStop();
 
-		expect( stopPerformanceTracking ).toHaveBeenCalledWith( 'pageName' );
+		expect( stopPerformanceTracking ).toHaveBeenCalledWith( 'pageName', expect.anything() );
 	} );
 
 	it( 'calls stop using useLayoutEffect and requestAnimationFrame', () => {

--- a/client/lib/performance-tracking/use-performance-tracker-stop.js
+++ b/client/lib/performance-tracking/use-performance-tracker-stop.js
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import { useLayoutEffect } from 'react';
-import { useSelector } from 'react-redux';
+import { useSelector, useStore } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -13,11 +13,12 @@ import { getSectionName } from 'state/ui/selectors';
 
 export function usePerformanceTrackerStop() {
 	const sectionName = useSelector( getSectionName );
+	const store = useStore();
 
 	// Use `useLayoutEffect` + rAF to be as close as possible to the actual rendering
 	useLayoutEffect( () => {
 		requestAnimationFrame( () => {
-			stopPerformanceTracking( sectionName );
+			stopPerformanceTracking( sectionName, store.getState() );
 		} );
-	}, [ sectionName ] );
+	}, [ sectionName, store ] );
 }

--- a/client/lib/performance-tracking/with-stop-performance-tracking-prop.jsx
+++ b/client/lib/performance-tracking/with-stop-performance-tracking-prop.jsx
@@ -1,0 +1,29 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { stopPerformanceTracking } from './lib';
+import { getSectionName } from 'state/ui/selectors';
+
+export const withStopPerformanceTrackingProp = ( () => {
+	let capuredState;
+	return connect(
+		( state ) => {
+			capuredState = state;
+			// No need to pass anything as props, avoid messing with existing props
+			return {};
+		},
+		() => {
+			return {
+				stopPerformanceTracking: () => {
+					const sectionName = getSectionName( capuredState );
+					stopPerformanceTracking( sectionName, capuredState );
+				},
+			};
+		}
+	);
+} )();

--- a/client/lib/performance-tracking/with-stop-performance-tracking-prop.jsx
+++ b/client/lib/performance-tracking/with-stop-performance-tracking-prop.jsx
@@ -10,20 +10,11 @@ import { stopPerformanceTracking } from './lib';
 import { getSectionName } from 'state/ui/selectors';
 
 export const withStopPerformanceTrackingProp = ( () => {
-	let capuredState;
-	return connect(
-		( state ) => {
-			capuredState = state;
-			// No need to pass anything as props, avoid messing with existing props
-			return {};
+	return connect( null, {
+		stopPerformanceTracking: () => ( dispatch, getState ) => {
+			const state = getState();
+			const sectionName = getSectionName( state );
+			stopPerformanceTracking( sectionName, state );
 		},
-		() => {
-			return {
-				stopPerformanceTracking: () => {
-					const sectionName = getSectionName( capuredState );
-					stopPerformanceTracking( sectionName, capuredState );
-				},
-			};
-		}
-	);
+	} );
 } )();

--- a/packages/browser-data-collector/src/report.ts
+++ b/packages/browser-data-collector/src/report.ts
@@ -57,7 +57,7 @@ export class ReportImpl implements Report {
 				try {
 					collector( this );
 				} catch {
-					// Swallow the errore to make sure a single collector doesn't break the whole report
+					// Swallow the error to make sure a single collector doesn't break the whole report
 				}
 			} )
 		);

--- a/packages/browser-data-collector/src/report.ts
+++ b/packages/browser-data-collector/src/report.ts
@@ -21,15 +21,15 @@ export class ReportImpl implements Report {
 	startCollectors!: Collector[];
 	stopCollectors!: Collector[];
 
-	static async fromNow( id: string ) {
+	static async fromNow( id: string, collectors: Collector[] = [] ) {
 		const report = new ReportImpl( id, false );
-		await report.start();
+		await report.start( collectors );
 		return report;
 	}
 
-	static async fromPageStart( id: string ) {
+	static async fromPageStart( id: string, collectors: Collector[] = [] ) {
 		const report = new ReportImpl( id, true );
-		await report.start();
+		await report.start( collectors );
 		return report;
 	}
 
@@ -51,14 +51,26 @@ export class ReportImpl implements Report {
 		}
 	}
 
-	private async start() {
-		await Promise.all( this.startCollectors.map( ( collector ) => collector( this ) ) );
+	private async runCollectors( collectors: Collector[] ) {
+		return Promise.all(
+			collectors.map( ( collector ) => {
+				try {
+					collector( this );
+				} catch {
+					// Swallow the errore to make sure a single collector doesn't break the whole report
+				}
+			} )
+		);
+	}
+
+	private async start( collectors: Collector[] = [] ) {
+		await this.runCollectors( [ ...this.startCollectors, ...collectors ] );
 		return this;
 	}
 
-	async stop() {
+	async stop( collectors: Collector[] = [] ) {
 		this.end = Date.now();
-		await Promise.all( this.stopCollectors.map( ( collector ) => collector( this ) ) );
+		await this.runCollectors( [ ...this.stopCollectors, ...collectors ] );
 
 		// Transform this.data Map into a regular object
 		const data = Array.from( this.data.entries() ).reduce(

--- a/packages/browser-data-collector/src/report.ts
+++ b/packages/browser-data-collector/src/report.ts
@@ -53,11 +53,14 @@ export class ReportImpl implements Report {
 
 	private async runCollectors( collectors: Collector[] ) {
 		return Promise.all(
-			collectors.map( ( collector ) => {
+			collectors.map( ( collector, idx ) => {
 				try {
-					collector( this );
-				} catch {
+					return collector( this );
+				} catch ( err ) {
 					// Swallow the error to make sure a single collector doesn't break the whole report
+					// eslint-disable-next-line no-console
+					console.warn( `Collector #${ idx } for report ${ this.id } failed to run`, err );
+					return null;
 				}
 			} )
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Expands `@automattic/browser-data-collector` API to be able to pass a list of `Collector` functions when a Report is created, or when it is stopped.

* Change the API in the wrapper `client/lib/performance-tracking/` and exported components to be able to accept custom collectors. Future PRs will use this functionality to add custom data for each tracked page.

* Provide a HoC that creates an additional prop `stopPerformanceTracking`. This is meant to be used by components that wants to stop the performance tracking in an imperative way. It will pull the report name from the store. It will also pull other common pieces of data form the store to add to every report, to improve our user segmentation.

#### Testing instructions

* Load calypso.live and opt-in abtest `rumDataCollection`
* Go to /stats, /plans or /home for any of your sites
* Open the devtools. In the network panel you should see a request to `/logstash`. Verify these keys are in the payload with the value from your site: `siteIsJetpack`, `siteIsSingleUser`, `siteIsAtomic`
* Test with different sites and check the values for those tree keys make sense.

#### Questions

**Default collector for all reports:**

(https://github.com/Automattic/wp-calypso/pull/43516/files#diff-36fd7be1e4cd4babebc617b7b4696a12R22)

I picked three keys that sounded important to me but I don't know for sure if they are relevant for performance. Please let me know if you think I should any other key to the default collector.


**Default prop:**

(https://github.com/Automattic/wp-calypso/pull/43516/files#diff-cff8c624a7ff9065e1a22857edb8957cR12)

I don't like that hack at all. But I can't figure out a better way to provide a method (either in props or as an imported function) that fetches some values from the store, without asking every consumer to pass the whole store to that method or to pick the default values themselves.

What I need is a way to add data from the store to all reports, regardless of how the consumers chose to end the report (hook, HoC, imperative or component)