### PR TITLE
Do Not Merge: Testing GH Labels

### DIFF
--- a/test/e2e/specs/wp-gutenboarding-spec.js
+++ b/test/e2e/specs/wp-gutenboarding-spec.js
@@ -50,6 +50,7 @@ describe( 'Gutenboarding: (' + screenSize + ')', function () {
 			await acquireIntentPage.goToNextStep();
 		} );
 
+		// This is just a test comment.
 		step( 'Can see Domains Page and select free suggestion item', async function () {
 			const domainsPage = await DomainsPage.Expect( driver );
 			await domainsPage.clickFreeSuggestionItem();


### PR DESCRIPTION
Test PR just to test if after E2E test has completed, adding `[Status] Ready to Merge` would retrigger another E2E test.

The answer is no.
