### PR TITLE
Jetpack Cloud: Make Backup loading placeholder more detailed

### DIFF
--- a/client/components/jetpack/backup-placeholder/index.jsx
+++ b/client/components/jetpack/backup-placeholder/index.jsx
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import isJetpackCloud from 'lib/jetpack/is-jetpack-cloud';
+import SidebarNavigation from 'my-sites/sidebar-navigation';
+import FormattedHeader from 'components/formatted-header';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+export default function BackupPlaceholder() {
+	return (
+		<>
+			<SidebarNavigation />
+			{ ! isJetpackCloud() && (
+				<FormattedHeader brandFont headerText="Jetpack Backup" align="left" />
+			) }
+			<div className="backup-placeholder">
+				<div className="backup-placeholder__backup-date-picker" />
+				<div className="backup-placeholder__daily-backup-status" />
+			</div>
+		</>
+	);
+}

--- a/client/components/jetpack/backup-placeholder/index.jsx
+++ b/client/components/jetpack/backup-placeholder/index.jsx
@@ -4,28 +4,15 @@
 import React from 'react';
 
 /**
- * Internal dependencies
- */
-import isJetpackCloud from 'lib/jetpack/is-jetpack-cloud';
-import SidebarNavigation from 'my-sites/sidebar-navigation';
-import FormattedHeader from 'components/formatted-header';
-
-/**
  * Style dependencies
  */
 import './style.scss';
 
 export default function BackupPlaceholder() {
 	return (
-		<>
-			<SidebarNavigation />
-			{ ! isJetpackCloud() && (
-				<FormattedHeader brandFont headerText="Jetpack Backup" align="left" />
-			) }
-			<div className="backup-placeholder">
-				<div className="backup-placeholder__backup-date-picker" />
-				<div className="backup-placeholder__daily-backup-status" />
-			</div>
-		</>
+		<div className="backup-placeholder">
+			<div className="backup-placeholder__backup-date-picker" />
+			<div className="backup-placeholder__daily-backup-status" />
+		</div>
 	);
 }

--- a/client/components/jetpack/backup-placeholder/style.scss
+++ b/client/components/jetpack/backup-placeholder/style.scss
@@ -1,0 +1,50 @@
+.backup-placeholder {
+	&__backup-date-picker {
+		@include placeholder( --color-neutral-10 );
+
+		height: 32px;
+		margin-bottom: 16px;
+		padding: 16px;
+	}
+
+	&__daily-backup-status {
+		@include placeholder( --color-neutral-10 );
+
+		height: 208px;
+		padding: 32px;
+
+		@include breakpoint-deprecated( '<660px' ) {
+			height: 244px;
+			padding-bottom: 58px;
+		}
+	}
+}
+
+/* Jetpack.com-only changes */
+.is_jetpackcom .backup-placeholder {
+	margin-left: -16px;
+	margin-right: -16px;
+
+	@include breakpoint-deprecated( '<660px' ) {
+		background: var( --studio-white );
+		padding-top: 16px;
+	}
+
+	&__backup-date-picker {
+		height: 32px;
+		margin-top: 8px;
+		padding: 0;
+	}
+
+	&__daily-backup-status {
+		height: 208px;
+		padding: 24px;
+		margin-top: 32px;
+
+		@include breakpoint-deprecated( '<660px' ) {
+			height: 244px;
+			padding-top: 0;
+			padding-bottom: 26px;
+		}
+	}
+}

--- a/client/components/jetpack/upsell-switch/index.tsx
+++ b/client/components/jetpack/upsell-switch/index.tsx
@@ -3,10 +3,12 @@
  */
 import React, { ReactElement, useState, ReactNode, useEffect, ComponentType } from 'react';
 import { connect, DefaultRootState } from 'react-redux';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
  */
+import isJetpackCloud from 'lib/jetpack/is-jetpack-cloud';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import Main from 'components/main';
 
@@ -64,7 +66,9 @@ function UpsellSwitch( props: Props ): React.ReactElement {
 
 	if ( isLoading ) {
 		return (
-			<Main className="upsell-switch__loading">
+			<Main
+				className={ classNames( 'upsell-switch__loading', { is_jetpackcom: isJetpackCloud() } ) }
+			>
 				<QueryComponent siteId={ siteId } />
 				{ children }
 			</Main>

--- a/client/my-sites/backup/controller.js
+++ b/client/my-sites/backup/controller.js
@@ -11,6 +11,7 @@ import BackupsPage from './main';
 import UpsellSwitch from 'components/jetpack/upsell-switch';
 import BackupUpsell from './backup-upsell';
 import WPCOMBackupUpsell from './wpcom-backup-upsell';
+import BackupPlaceholder from 'components/jetpack/backup-placeholder';
 import getRewindState from 'state/selectors/get-rewind-state';
 import QueryRewindState from 'components/data/query-rewind-state';
 import isJetpackCloud from 'lib/jetpack/is-jetpack-cloud';
@@ -23,7 +24,9 @@ export function showUpsellIfNoBackup( context, next ) {
 			display={ context.primary }
 			getStateForSite={ getRewindState }
 			QueryComponent={ QueryRewindState }
-		/>
+		>
+			<BackupPlaceholder />
+		</UpsellSwitch>
 	);
 	next();
 }

--- a/client/my-sites/backup/controller.js
+++ b/client/my-sites/backup/controller.js
@@ -12,6 +12,8 @@ import UpsellSwitch from 'components/jetpack/upsell-switch';
 import BackupUpsell from './backup-upsell';
 import WPCOMBackupUpsell from './wpcom-backup-upsell';
 import BackupPlaceholder from 'components/jetpack/backup-placeholder';
+import FormattedHeader from 'components/formatted-header';
+import SidebarNavigation from 'my-sites/sidebar-navigation';
 import getRewindState from 'state/selectors/get-rewind-state';
 import QueryRewindState from 'components/data/query-rewind-state';
 import isJetpackCloud from 'lib/jetpack/is-jetpack-cloud';
@@ -19,14 +21,20 @@ import isJetpackCloud from 'lib/jetpack/is-jetpack-cloud';
 export function showUpsellIfNoBackup( context, next ) {
 	const UpsellComponent = isJetpackCloud() ? BackupUpsell : WPCOMBackupUpsell;
 	context.primary = (
-		<UpsellSwitch
-			UpsellComponent={ UpsellComponent }
-			display={ context.primary }
-			getStateForSite={ getRewindState }
-			QueryComponent={ QueryRewindState }
-		>
-			<BackupPlaceholder />
-		</UpsellSwitch>
+		<>
+			<UpsellSwitch
+				UpsellComponent={ UpsellComponent }
+				display={ context.primary }
+				getStateForSite={ getRewindState }
+				QueryComponent={ QueryRewindState }
+			>
+				<SidebarNavigation />
+				{ ! isJetpackCloud() && (
+					<FormattedHeader brandFont headerText="Jetpack Backup" align="left" />
+				) }
+				<BackupPlaceholder />
+			</UpsellSwitch>
+		</>
 	);
 	next();
 }

--- a/client/my-sites/backup/main.jsx
+++ b/client/my-sites/backup/main.jsx
@@ -25,6 +25,7 @@ import isJetpackCloud from 'lib/jetpack/is-jetpack-cloud';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { requestActivityLogs } from 'state/data-getters';
 import { withLocalizedMoment } from 'components/localized-moment';
+import BackupPlaceholder from 'components/jetpack/backup-placeholder';
 import FormattedHeader from 'components/formatted-header';
 import BackupDelta from 'components/jetpack/backup-delta';
 import DailyBackupStatus from 'components/jetpack/daily-backup-status';
@@ -174,60 +175,58 @@ class BackupsPage extends Component {
 				<QuerySiteSettings siteId={ siteId } />
 				<QueryRewindCapabilities siteId={ siteId } />
 
-				<div className="backup__main-wrap">
-					<div className="backup__last-backup-status">
-						<BackupDatePicker
-							{ ...{
-								onDateChange: this.onDateChange,
-								selectedDate: this.getSelectedDate(),
-								siteId,
-								oldestDateAvailable,
-								today,
-								siteSlug,
-								dispatchRecordTracksEvent,
-							} }
-						/>
+				{ isLoadingBackups && <BackupPlaceholder /> }
 
-						{ isLoadingBackups && <div className="backup__is-loading" /> }
+				{ ! isLoadingBackups && (
+					<div className="backup__main-wrap">
+						<div className="backup__last-backup-status">
+							<BackupDatePicker
+								{ ...{
+									onDateChange: this.onDateChange,
+									selectedDate: this.getSelectedDate(),
+									siteId,
+									oldestDateAvailable,
+									today,
+									siteSlug,
+									dispatchRecordTracksEvent,
+								} }
+							/>
 
-						{ ! isLoadingBackups && (
-							<>
-								<DailyBackupStatus
-									{ ...{
-										allowRestore,
-										siteUrl,
-										siteSlug,
-										backup: lastBackup,
-										lastDateAvailable,
-										selectedDate: this.getSelectedDate(),
-										timezone,
-										gmtOffset,
-										hasRealtimeBackups,
-										onDateChange: this.onDateChange,
-										deltas,
-										// metaDiff, todo: commented because the non-english account issue
-										doesRewindNeedCredentials,
-										dispatchRecordTracksEvent,
-									} }
-								/>
-							</>
+							<DailyBackupStatus
+								{ ...{
+									allowRestore,
+									siteUrl,
+									siteSlug,
+									backup: lastBackup,
+									lastDateAvailable,
+									selectedDate: this.getSelectedDate(),
+									timezone,
+									gmtOffset,
+									hasRealtimeBackups,
+									onDateChange: this.onDateChange,
+									deltas,
+									// metaDiff, todo: commented because the non-english account issue
+									doesRewindNeedCredentials,
+									dispatchRecordTracksEvent,
+								} }
+							/>
+						</div>
+
+						{ hasRealtimeBackups && lastBackup && (
+							<BackupDelta
+								{ ...{
+									deltas,
+									realtimeBackups,
+									doesRewindNeedCredentials,
+									allowRestore,
+									moment,
+									siteSlug,
+									isToday,
+								} }
+							/>
 						) }
 					</div>
-
-					{ ! isLoadingBackups && hasRealtimeBackups && lastBackup && (
-						<BackupDelta
-							{ ...{
-								deltas,
-								realtimeBackups,
-								doesRewindNeedCredentials,
-								allowRestore,
-								moment,
-								siteSlug,
-								isToday,
-							} }
-						/>
-					) }
-				</div>
+				) }
 			</>
 		);
 	}
@@ -261,7 +260,11 @@ class BackupsPage extends Component {
 					wordpressdotcom: ! isJetpackCloud(),
 				} ) }
 			>
-				<Main wideLayout={ ! isJetpackCloud() }>
+				<Main
+					className={ classNames( {
+						is_jetpackcom: isJetpackCloud(),
+					} ) }
+				>
 					<SidebarNavigation />
 					{ ! isJetpackCloud() && (
 						<FormattedHeader headerText="Jetpack Backup" align="left" brandFont />

--- a/client/my-sites/backup/style.scss
+++ b/client/my-sites/backup/style.scss
@@ -64,12 +64,6 @@
 	margin-bottom: 2rem;
 }
 
-.backup__is-loading {
-	margin: 2rem 1rem;
-	height: 245px;
-	@include placeholder( --color-neutral-10 );
-}
-
 .backup__subheader {
 	margin: 20px 16px 8px;
 
@@ -83,10 +77,6 @@
 
 /* WordPress.com-only styles */
 .wordpressdotcom.backup__page {
-	.backup__is-loading {
-		margin: 1rem 0;
-	}
-
 	.backup__main-wrap {
 		margin-left: initial;
 		margin-right: initial;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Create a new component called `BackupPlaceholder` that represents the way the Backup page should look while it is loading.
* Make the loading placeholder for the Backup page more closely match the elements of the loaded page.
* Add the loading placeholder to the children of the UpsellSwitch component in the Backup section controller, so that it's also shown while upsell logic is checked.
* Add `is_jetpackcom` conditional CSS class inside the UpsellSwitch component, so that Jetpack.com styles can be applied if needed or ignored if not.

Fixes `1179060693083348-as-1180955464399609`

#### Testing instructions

**NOTE:** Before testing, ensure that the `jetpack/features-section` flag is enabled.

Repeat for **WordPress.com** and **Jetpack.com** on both desktop and mobile layouts:
* Hard-reload the Backup page (i.e., Cmd+Shift+R) to see the full loading sequence.
* Verify that the loading screen is displayed while the page loads.
* Verify that the pulsing page elements match the size and position of the elements on the loaded page.
* Verify that the "Jetpack Backup" page header is displayed on WordPress.com and is hidden on Jetpack.com.
* Verify that if an upsell is triggered, the upsell page still looks the same as it does in production.

#### Screenshots

##### WordPress.com

![wordpress-mobile-combined](https://user-images.githubusercontent.com/670067/85293221-aa966880-b462-11ea-8ffe-7bff927a26e9.png)

![wordpress-desktop-loaded](https://user-images.githubusercontent.com/670067/85294672-8dfb3000-b464-11ea-957a-2f37d3358bdb.png)

![wordpress-desktop-loading](https://user-images.githubusercontent.com/670067/85294689-93587a80-b464-11ea-82b3-a9b2570c0ecd.png)

##### Jetpack.com

![jetpack-mobile-combined](https://user-images.githubusercontent.com/670067/85293400-e3ced880-b462-11ea-847e-6233c9bf52f8.png)

![jetpack-desktop-loaded](https://user-images.githubusercontent.com/670067/85294713-9bb0b580-b464-11ea-8d61-9d047a52ae0b.png)

![jetpack-desktop-loading](https://user-images.githubusercontent.com/670067/85294732-a0756980-b464-11ea-9190-c4487c09a9af.png)