### PR TITLE
Account Closure: Convey that Only the Owner's Site is Deleted

### DIFF
--- a/client/state/selectors/get-account-closure-sites.js
+++ b/client/state/selectors/get-account-closure-sites.js
@@ -12,8 +12,11 @@ import { userCan } from 'lib/site/utils';
  * @param {object} state  Global state tree
  * @returns {Array}        Array of site objects
  */
+
+// activate_wordads is the only capability that returns true exclusively for the site owner
+// See here: https://github.com/Automattic/jetpack/blob/2e190a1ffe33df32f19a0632d5e6f34589e79035/sal/class.json-api-site-base.php#L424
 export default createSelector( ( state ) =>
 	getSites( state ).filter(
-		( site ) => ! isJetpackSite( state, site.ID ) && userCan( 'manage_options', site )
+		( site ) => ! isJetpackSite( state, site.ID ) && userCan( 'activate_wordads', site )
 	)
 );

--- a/client/state/selectors/get-account-closure-sites.js
+++ b/client/state/selectors/get-account-closure-sites.js
@@ -8,15 +8,13 @@ import { userCan } from 'lib/site/utils';
 
 /**
  * Get all the sites which are deleted after account closure
+ * (WordPress.com sites which the user is the owner of)
  *
  * @param {object} state  Global state tree
  * @returns {Array}        Array of site objects
  */
-
-// activate_wordads is the only capability that returns true exclusively for the site owner
-// See here: https://github.com/Automattic/jetpack/blob/2e190a1ffe33df32f19a0632d5e6f34589e79035/sal/class.json-api-site-base.php#L424
 export default createSelector( ( state ) =>
 	getSites( state ).filter(
-		( site ) => ! isJetpackSite( state, site.ID ) && userCan( 'activate_wordads', site )
+		( site ) => ! isJetpackSite( state, site.ID ) && userCan( 'own_site', site )
 	)
 );

--- a/client/state/selectors/test/get-account-closure-sites.js
+++ b/client/state/selectors/test/get-account-closure-sites.js
@@ -27,7 +27,7 @@ describe( 'getAccountClosureSites()', () => {
 						name: 'WordPress.com Example Blog',
 						URL: 'http://example.com',
 						capabilities: {
-							activate_wordads: true,
+							own_site: true,
 						},
 					},
 				},
@@ -51,7 +51,7 @@ describe( 'getAccountClosureSites()', () => {
 						name: 'WordPress.com Example Blog',
 						URL: 'http://example.com',
 						capabilities: {
-							activate_wordads: false,
+							own_site: false,
 							publish_posts: true,
 						},
 					},
@@ -76,7 +76,7 @@ describe( 'getAccountClosureSites()', () => {
 						name: 'WordPress.com Example Blog',
 						URL: 'http://example.com',
 						capabilities: {
-							activate_wordads: true,
+							own_site: true,
 						},
 					},
 				},

--- a/client/state/selectors/test/get-account-closure-sites.js
+++ b/client/state/selectors/test/get-account-closure-sites.js
@@ -27,7 +27,7 @@ describe( 'getAccountClosureSites()', () => {
 						name: 'WordPress.com Example Blog',
 						URL: 'http://example.com',
 						capabilities: {
-							manage_options: true,
+							activate_wordads: true,
 						},
 					},
 				},
@@ -51,7 +51,7 @@ describe( 'getAccountClosureSites()', () => {
 						name: 'WordPress.com Example Blog',
 						URL: 'http://example.com',
 						capabilities: {
-							manage_options: false,
+							activate_wordads: false,
 							publish_posts: true,
 						},
 					},
@@ -76,7 +76,7 @@ describe( 'getAccountClosureSites()', () => {
 						name: 'WordPress.com Example Blog',
 						URL: 'http://example.com',
 						capabilities: {
-							manage_options: true,
+							activate_wordads: true,
 						},
 					},
 				},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is an issue from #37505 which I only realised now: if you're a person who has been invited to be an administrator on a site, the Account Closure screen indicates that site will be instantly deleted as soon as your account is closed. In reality, this is not the case; that site would only be deleted if the owner closed their account. 

#### Testing instructions

On a test account, invite yourself as an administrator of a site. On the Account Closure sites list, verify that the list no longer shows the site you are an administrator (but not an owner) on. 

Not sure how people feel about using `activate_wordads` for something that very clearly isn't related to WordAds, especially since the capability to activate WordAds could change in the future. However, it currently works and it's the only capability that does so, but I'm happy to try and open a PR to add another one if that would be preferential. 

cc @bluefuton 