### PR TITLE
Add unit tests to inline help reducer

### DIFF
--- a/client/state/inline-help/test/reducer.js
+++ b/client/state/inline-help/test/reducer.js
@@ -186,16 +186,16 @@ describe( 'reducer', () => {
 			const firstQuery = 'testQuery';
 			const secondQuery = 'anotherQuery';
 
-			let state = search(
-				{},
-				{
-					type: INLINE_HELP_SEARCH_REQUEST_SUCCESS,
-					searchQuery: firstQuery,
-					searchResults: API_RESULT_FIXTURE,
-				}
-			);
+			let state = search( undefined, {
+				type: INLINE_HELP_SEARCH_REQUEST_SUCCESS,
+				searchQuery: firstQuery,
+				searchResults: API_RESULT_FIXTURE,
+			} );
 
 			expect( state ).to.eql( {
+				searchQuery: '',
+				hasAPIResults: false,
+				shouldOpenSelectedResult: false,
 				selectedResult: -1,
 				items: {
 					[ firstQuery ]: API_RESULT_FIXTURE,
@@ -204,13 +204,16 @@ describe( 'reducer', () => {
 
 			// Also test results are appended to existing
 			// keyed by search term
-			state = search( state, {
+			state = search( deepFreeze( state ), {
 				type: INLINE_HELP_SEARCH_REQUEST_SUCCESS,
 				searchQuery: secondQuery,
 				searchResults: API_RESULT_FIXTURE,
 			} );
 
 			expect( state ).to.eql( {
+				searchQuery: '',
+				hasAPIResults: false,
+				shouldOpenSelectedResult: false,
 				selectedResult: -1,
 				items: {
 					[ firstQuery ]: API_RESULT_FIXTURE,
@@ -233,7 +236,7 @@ describe( 'reducer', () => {
 				hasAPIResults: true,
 			} );
 
-			state = search( state, {
+			state = search( deepFreeze( state ), {
 				type: INLINE_HELP_SEARCH_REQUEST_API_RESULTS,
 				hasAPIResults: false,
 			} );
@@ -262,7 +265,7 @@ describe( 'reducer', () => {
 					selectedResult: 2,
 				} );
 
-				state = search( state, {
+				state = search( deepFreeze( state ), {
 					type: INLINE_HELP_SELECT_RESULT,
 					resultIndex: 4,
 				} );
@@ -287,7 +290,7 @@ describe( 'reducer', () => {
 					};
 					let state;
 
-					state = search( initialState, {
+					state = search( deepFreeze( initialState ), {
 						type: INLINE_HELP_SELECT_NEXT_RESULT,
 					} );
 
@@ -299,7 +302,7 @@ describe( 'reducer', () => {
 						},
 					} );
 
-					state = search( state, {
+					state = search( deepFreeze( state ), {
 						type: INLINE_HELP_SELECT_NEXT_RESULT,
 					} );
 
@@ -321,7 +324,7 @@ describe( 'reducer', () => {
 						},
 					};
 
-					const state = search( initialState, {
+					const state = search( deepFreeze( initialState ), {
 						type: INLINE_HELP_SELECT_NEXT_RESULT,
 					} );
 
@@ -346,7 +349,7 @@ describe( 'reducer', () => {
 					};
 					let state;
 
-					state = search( initialState, {
+					state = search( deepFreeze( initialState ), {
 						type: INLINE_HELP_SELECT_PREVIOUS_RESULT,
 					} );
 
@@ -358,7 +361,7 @@ describe( 'reducer', () => {
 						},
 					} );
 
-					state = search( state, {
+					state = search( deepFreeze( state ), {
 						type: INLINE_HELP_SELECT_PREVIOUS_RESULT,
 					} );
 
@@ -380,7 +383,7 @@ describe( 'reducer', () => {
 						},
 					};
 
-					const state = search( initialState, {
+					const state = search( deepFreeze( initialState ), {
 						type: INLINE_HELP_SELECT_PREVIOUS_RESULT,
 					} );
 
@@ -406,7 +409,7 @@ describe( 'reducer', () => {
 							},
 						};
 
-						const state = search( initialState, {
+						const state = search( deepFreeze( initialState ), {
 							type: actionType,
 						} );
 
@@ -431,7 +434,7 @@ describe( 'reducer', () => {
 							},
 						};
 
-						const state = search( initialState, {
+						const state = search( deepFreeze( initialState ), {
 							type: actionType,
 						} );
 

--- a/client/state/inline-help/test/reducer.js
+++ b/client/state/inline-help/test/reducer.js
@@ -16,6 +16,7 @@ import {
 	INLINE_HELP_SEARCH_REQUEST,
 	INLINE_HELP_SEARCH_REQUEST_SUCCESS,
 	INLINE_HELP_SEARCH_REQUEST_FAILURE,
+	INLINE_HELP_SEARCH_REQUEST_API_RESULTS,
 } from 'state/action-types';
 
 describe( 'reducer', () => {
@@ -179,6 +180,26 @@ describe( 'reducer', () => {
 					[ firstQuery ]: results,
 					[ secondQuery ]: results,
 				},
+			} );
+		} );
+
+		test( 'should correctly set the boolean to indicate presence of results that are from the API', () => {
+			let state = search( null, {
+				type: INLINE_HELP_SEARCH_REQUEST_API_RESULTS,
+				hasAPIResults: true,
+			} );
+
+			expect( state ).to.eql( {
+				hasAPIResults: true,
+			} );
+
+			state = search( state, {
+				type: INLINE_HELP_SEARCH_REQUEST_API_RESULTS,
+				hasAPIResults: false,
+			} );
+
+			expect( state ).to.eql( {
+				hasAPIResults: false,
 			} );
 		} );
 	} );

--- a/client/state/inline-help/test/reducer.js
+++ b/client/state/inline-help/test/reducer.js
@@ -19,6 +19,7 @@ import {
 	INLINE_HELP_SEARCH_REQUEST_API_RESULTS,
 	INLINE_HELP_SELECT_RESULT,
 	INLINE_HELP_SELECT_NEXT_RESULT,
+	INLINE_HELP_SELECT_PREVIOUS_RESULT,
 } from 'state/action-types';
 
 const API_RESULT_FIXTURE = [
@@ -230,61 +231,174 @@ describe( 'reducer', () => {
 				} );
 			} );
 
-			test( 'should correctly move between selected result indices of the current search query', () => {
-				const initialState = {
-					searchQuery: 'testResultSet',
-					selectedResult: -1,
-					items: {
-						testResultSet: API_RESULT_FIXTURE,
-					},
-				};
-				let state;
+			describe( 'Selecting forwards', () => {
+				test( 'should correctly move forward between selected result indices of the current search query', () => {
+					const initialState = {
+						searchQuery: 'testResultSet',
+						selectedResult: -1,
+						items: {
+							testResultSet: API_RESULT_FIXTURE,
+						},
+					};
+					let state;
 
-				state = search( initialState, {
-					type: INLINE_HELP_SELECT_NEXT_RESULT,
+					state = search( initialState, {
+						type: INLINE_HELP_SELECT_NEXT_RESULT,
+					} );
+
+					expect( state ).to.eql( {
+						searchQuery: 'testResultSet',
+						selectedResult: 0,
+						items: {
+							testResultSet: API_RESULT_FIXTURE,
+						},
+					} );
+
+					state = search( state, {
+						type: INLINE_HELP_SELECT_NEXT_RESULT,
+					} );
+
+					expect( state ).to.eql( {
+						searchQuery: 'testResultSet',
+						selectedResult: 1,
+						items: {
+							testResultSet: API_RESULT_FIXTURE,
+						},
+					} );
 				} );
 
-				expect( state ).to.eql( {
-					searchQuery: 'testResultSet',
-					selectedResult: 0,
-					items: {
-						testResultSet: API_RESULT_FIXTURE,
-					},
-				} );
+				test( 'should correctly move the selected result index back to the lower bound when moving beyond the upper bound of search result items', () => {
+					const initialState = {
+						searchQuery: 'testResultSet',
+						selectedResult: 5,
+						items: {
+							testResultSet: API_RESULT_FIXTURE,
+						},
+					};
 
-				state = search( state, {
-					type: INLINE_HELP_SELECT_NEXT_RESULT,
-				} );
+					const state = search( initialState, {
+						type: INLINE_HELP_SELECT_NEXT_RESULT,
+					} );
 
-				expect( state ).to.eql( {
-					searchQuery: 'testResultSet',
-					selectedResult: 1,
-					items: {
-						testResultSet: API_RESULT_FIXTURE,
-					},
+					expect( state ).to.eql( {
+						searchQuery: 'testResultSet',
+						selectedResult: 0,
+						items: {
+							testResultSet: API_RESULT_FIXTURE,
+						},
+					} );
 				} );
 			} );
 
-			test( 'should correctly reset the selected result index to 0 when end of search result items is reached', () => {
-				const initialState = {
-					searchQuery: 'testResultSet',
-					selectedResult: 5,
-					items: {
-						testResultSet: API_RESULT_FIXTURE,
-					},
-				};
+			describe( 'Selecting backwards', () => {
+				test( 'should correctly move backward between selected result indices of the current search query', () => {
+					const initialState = {
+						searchQuery: 'testResultSet',
+						selectedResult: -1,
+						items: {
+							testResultSet: API_RESULT_FIXTURE,
+						},
+					};
+					let state;
 
-				const state = search( initialState, {
-					type: INLINE_HELP_SELECT_NEXT_RESULT,
+					state = search( initialState, {
+						type: INLINE_HELP_SELECT_PREVIOUS_RESULT,
+					} );
+
+					expect( state ).to.eql( {
+						searchQuery: 'testResultSet',
+						selectedResult: 5,
+						items: {
+							testResultSet: API_RESULT_FIXTURE,
+						},
+					} );
+
+					state = search( state, {
+						type: INLINE_HELP_SELECT_PREVIOUS_RESULT,
+					} );
+
+					expect( state ).to.eql( {
+						searchQuery: 'testResultSet',
+						selectedResult: 4,
+						items: {
+							testResultSet: API_RESULT_FIXTURE,
+						},
+					} );
 				} );
 
-				expect( state ).to.eql( {
-					searchQuery: 'testResultSet',
-					selectedResult: 0,
-					items: {
-						testResultSet: API_RESULT_FIXTURE,
-					},
+				test( 'should correctly move the selected result index back to the upper bound when moving beyond the lower bound of search result items', () => {
+					const initialState = {
+						searchQuery: 'testResultSet',
+						selectedResult: 0,
+						items: {
+							testResultSet: API_RESULT_FIXTURE,
+						},
+					};
+
+					const state = search( initialState, {
+						type: INLINE_HELP_SELECT_PREVIOUS_RESULT,
+					} );
+
+					expect( state ).to.eql( {
+						searchQuery: 'testResultSet',
+						selectedResult: 5,
+						items: {
+							testResultSet: API_RESULT_FIXTURE,
+						},
+					} );
 				} );
+			} );
+
+			describe( 'Invalid setting forwards or backwards', () => {
+				test.each( [ INLINE_HELP_SELECT_PREVIOUS_RESULT, INLINE_HELP_SELECT_NEXT_RESULT ] )(
+					'should reset the selected result index if there is no current search query for %s action',
+					( actionType ) => {
+						const initialState = {
+							searchQuery: null,
+							selectedResult: 3,
+							items: {
+								testResultSet: API_RESULT_FIXTURE,
+							},
+						};
+
+						const state = search( initialState, {
+							type: actionType,
+						} );
+
+						expect( state ).to.eql( {
+							searchQuery: null,
+							selectedResult: -1,
+							items: {
+								testResultSet: API_RESULT_FIXTURE,
+							},
+						} );
+					}
+				);
+
+				test.each( [ INLINE_HELP_SELECT_PREVIOUS_RESULT, INLINE_HELP_SELECT_NEXT_RESULT ] )(
+					'should reset the selected result index if there are no results for the current search query for %s action',
+					( actionType ) => {
+						const initialState = {
+							searchQuery: 'testResultSet',
+							selectedResult: 0,
+							items: {
+								testResultSet: [], // empty result set
+							},
+						};
+
+						const state = search( initialState, {
+							type: actionType,
+						} );
+
+						expect( state ).to.eql( {
+							searchQuery: 'testResultSet',
+							selectedResult: -1,
+							items: {
+								testResultSet: [], // empty result set
+							},
+						} );
+					}
+				);
 			} );
 		} );
 	} );

--- a/client/state/inline-help/test/reducer.js
+++ b/client/state/inline-help/test/reducer.js
@@ -51,8 +51,15 @@ const API_RESULT_FIXTURE = [
 
 describe( 'reducer', () => {
 	describe( '#popover()', () => {
+		test( 'should return the initial state', () => {
+			const state = popover( undefined, {} );
+
+			expect( state ).to.eql( {
+				isVisible: false,
+			} );
+		} );
 		test( 'should generate isVisible boolean prop', () => {
-			const state = popover( null, {
+			const state = popover( undefined, {
 				type: INLINE_HELP_POPOVER_SHOW,
 			} );
 
@@ -73,8 +80,15 @@ describe( 'reducer', () => {
 	} );
 
 	describe( '#ui()', () => {
+		test( 'should return the initial state', () => {
+			const state = ui( undefined, {} );
+
+			expect( state ).to.eql( {
+				isVisible: true,
+			} );
+		} );
 		test( 'should correct set isVisible prop to true', () => {
-			const state = ui( null, {
+			const state = ui( undefined, {
 				type: INLINE_HELP_SHOW,
 			} );
 
@@ -96,9 +110,13 @@ describe( 'reducer', () => {
 	} );
 
 	describe( '#requesting()', () => {
+		test( 'should return the initial state', () => {
+			const state = requesting( undefined, {} );
+			expect( state ).to.eql( {} );
+		} );
 		test( 'should correctly set boolean flag to true for query key', () => {
 			const testQuery = 'testQueryKey';
-			const state = requesting( null, {
+			const state = requesting( undefined, {
 				type: INLINE_HELP_SEARCH_REQUEST,
 				searchQuery: testQuery,
 			} );
@@ -136,16 +154,30 @@ describe( 'reducer', () => {
 	} );
 
 	describe( '#search()', () => {
+		test( 'should return the initial state', () => {
+			const state = search( undefined, {} );
+			expect( state ).to.eql( {
+				searchQuery: '',
+				items: {},
+				selectedResult: -1,
+				shouldOpenSelectedResult: false,
+				hasAPIResults: false,
+			} );
+		} );
 		test.each( [ 'testQueryKey', '' ] )(
 			'should correctly set the current search query text',
 			( testQuery ) => {
-				const state = search( null, {
+				const state = search( undefined, {
 					type: INLINE_HELP_SEARCH_REQUEST,
 					searchQuery: testQuery,
 				} );
 
 				expect( state ).to.eql( {
 					searchQuery: testQuery,
+					items: {},
+					selectedResult: -1,
+					shouldOpenSelectedResult: false,
+					hasAPIResults: false,
 				} );
 			}
 		);
@@ -188,12 +220,16 @@ describe( 'reducer', () => {
 		} );
 
 		test( 'should correctly set the boolean to indicate presence of results that are from the API', () => {
-			let state = search( null, {
+			let state = search( undefined, {
 				type: INLINE_HELP_SEARCH_REQUEST_API_RESULTS,
 				hasAPIResults: true,
 			} );
 
 			expect( state ).to.eql( {
+				searchQuery: '',
+				items: {},
+				selectedResult: -1,
+				shouldOpenSelectedResult: false,
 				hasAPIResults: true,
 			} );
 
@@ -203,30 +239,39 @@ describe( 'reducer', () => {
 			} );
 
 			expect( state ).to.eql( {
+				searchQuery: '',
+				items: {},
+				selectedResult: -1,
+				shouldOpenSelectedResult: false,
 				hasAPIResults: false,
 			} );
 		} );
 
 		describe( 'Search result selection', () => {
 			test( 'should correctly set index of selected result', () => {
-				let state = search( null, {
+				let state = search( undefined, {
 					type: INLINE_HELP_SELECT_RESULT,
 					resultIndex: 2,
 				} );
 
 				expect( state ).to.eql( {
+					searchQuery: '',
+					items: {},
+					shouldOpenSelectedResult: false,
+					hasAPIResults: false,
 					selectedResult: 2,
 				} );
 
-				state = search(
-					{},
-					{
-						type: INLINE_HELP_SELECT_RESULT,
-						resultIndex: 4,
-					}
-				);
+				state = search( state, {
+					type: INLINE_HELP_SELECT_RESULT,
+					resultIndex: 4,
+				} );
 
 				expect( state ).to.eql( {
+					searchQuery: '',
+					items: {},
+					shouldOpenSelectedResult: false,
+					hasAPIResults: false,
 					selectedResult: 4,
 				} );
 			} );

--- a/client/state/inline-help/test/reducer.js
+++ b/client/state/inline-help/test/reducer.js
@@ -7,7 +7,7 @@ import deepFreeze from 'deep-freeze';
 /**
  * Internal dependencies
  */
-import { popover, ui, requesting } from '../reducer';
+import { popover, ui, requesting, search } from '../reducer';
 import {
 	INLINE_HELP_POPOVER_SHOW,
 	INLINE_HELP_POPOVER_HIDE,
@@ -100,6 +100,85 @@ describe( 'reducer', () => {
 
 			expect( state ).to.eql( {
 				[ testQuery ]: false,
+			} );
+		} );
+	} );
+
+	describe( '#search()', () => {
+		test.each( [ 'testQueryKey', '' ] )(
+			'should correctly set the current search query text',
+			( testQuery ) => {
+				const state = search( null, {
+					type: INLINE_HELP_SEARCH_REQUEST,
+					searchQuery: testQuery,
+				} );
+
+				expect( state ).to.eql( {
+					searchQuery: testQuery,
+				} );
+			}
+		);
+
+		test( 'should correctly set search results keyed by search term', () => {
+			const firstQuery = 'testQuery';
+			const secondQuery = 'anotherQuery';
+			const results = [
+				{
+					id: 1,
+					title: 'Some result',
+				},
+				{
+					id: 2,
+					title: 'Some other result',
+				},
+				{
+					id: 3,
+					title: 'Another result',
+				},
+				{
+					id: 4,
+					title: 'Yet another result',
+				},
+				{
+					id: 5,
+					title: 'Can you imagine more results?',
+				},
+				{
+					id: 6,
+					title: 'Surely, not another result?',
+				},
+			];
+
+			let state = search(
+				{},
+				{
+					type: INLINE_HELP_SEARCH_REQUEST_SUCCESS,
+					searchQuery: firstQuery,
+					searchResults: results,
+				}
+			);
+
+			expect( state ).to.eql( {
+				selectedResult: -1,
+				items: {
+					[ firstQuery ]: results,
+				},
+			} );
+
+			// Also test results are appended to existing
+			// keyed by search term
+			state = search( state, {
+				type: INLINE_HELP_SEARCH_REQUEST_SUCCESS,
+				searchQuery: secondQuery,
+				searchResults: results,
+			} );
+
+			expect( state ).to.eql( {
+				selectedResult: -1,
+				items: {
+					[ firstQuery ]: results,
+					[ secondQuery ]: results,
+				},
 			} );
 		} );
 	} );

--- a/client/state/inline-help/test/reducer.js
+++ b/client/state/inline-help/test/reducer.js
@@ -7,8 +7,13 @@ import deepFreeze from 'deep-freeze';
 /**
  * Internal dependencies
  */
-import { popover } from '../reducer';
-import { INLINE_HELP_POPOVER_SHOW, INLINE_HELP_POPOVER_HIDE } from 'state/action-types';
+import { popover, ui } from '../reducer';
+import {
+	INLINE_HELP_POPOVER_SHOW,
+	INLINE_HELP_POPOVER_HIDE,
+	INLINE_HELP_SHOW,
+	INLINE_HELP_HIDE,
+} from 'state/action-types';
 
 describe( 'reducer', () => {
 	describe( '#popover()', () => {
@@ -25,6 +30,29 @@ describe( 'reducer', () => {
 			const original = deepFreeze( { isVisible: true } );
 			const state = popover( original, {
 				type: INLINE_HELP_POPOVER_HIDE,
+			} );
+
+			expect( state ).to.eql( {
+				isVisible: false,
+			} );
+		} );
+	} );
+
+	describe( '#ui()', () => {
+		test( 'should correct set isVisible prop to true', () => {
+			const state = ui( null, {
+				type: INLINE_HELP_SHOW,
+			} );
+
+			expect( state ).to.eql( {
+				isVisible: true,
+			} );
+		} );
+
+		test( 'should correct set isVisible prop to false', () => {
+			const original = deepFreeze( { isVisible: true } );
+			const state = ui( original, {
+				type: INLINE_HELP_HIDE,
 			} );
 
 			expect( state ).to.eql( {

--- a/client/state/inline-help/test/reducer.js
+++ b/client/state/inline-help/test/reducer.js
@@ -7,12 +7,15 @@ import deepFreeze from 'deep-freeze';
 /**
  * Internal dependencies
  */
-import { popover, ui } from '../reducer';
+import { popover, ui, requesting } from '../reducer';
 import {
 	INLINE_HELP_POPOVER_SHOW,
 	INLINE_HELP_POPOVER_HIDE,
 	INLINE_HELP_SHOW,
 	INLINE_HELP_HIDE,
+	INLINE_HELP_SEARCH_REQUEST,
+	INLINE_HELP_SEARCH_REQUEST_SUCCESS,
+	INLINE_HELP_SEARCH_REQUEST_FAILURE,
 } from 'state/action-types';
 
 describe( 'reducer', () => {
@@ -57,6 +60,46 @@ describe( 'reducer', () => {
 
 			expect( state ).to.eql( {
 				isVisible: false,
+			} );
+		} );
+	} );
+
+	describe( '#requesting()', () => {
+		test( 'should correctly set boolean flag to true for query key', () => {
+			const testQuery = 'testQueryKey';
+			const state = requesting( null, {
+				type: INLINE_HELP_SEARCH_REQUEST,
+				searchQuery: testQuery,
+			} );
+
+			expect( state ).to.eql( {
+				[ testQuery ]: true,
+			} );
+		} );
+
+		test( 'should correctly set boolean flag to false for query key on success', () => {
+			const testQuery = 'testQueryKey';
+			const original = deepFreeze( { [ testQuery ]: true } );
+			const state = requesting( original, {
+				type: INLINE_HELP_SEARCH_REQUEST_SUCCESS,
+				searchQuery: testQuery,
+			} );
+
+			expect( state ).to.eql( {
+				[ testQuery ]: false,
+			} );
+		} );
+
+		test( 'should correctly set boolean flag to false for query key on failure', () => {
+			const testQuery = 'testQueryKey';
+			const original = deepFreeze( { [ testQuery ]: true } );
+			const state = requesting( original, {
+				type: INLINE_HELP_SEARCH_REQUEST_FAILURE,
+				searchQuery: testQuery,
+			} );
+
+			expect( state ).to.eql( {
+				[ testQuery ]: false,
 			} );
 		} );
 	} );

--- a/client/state/inline-help/test/reducer.js
+++ b/client/state/inline-help/test/reducer.js
@@ -17,7 +17,36 @@ import {
 	INLINE_HELP_SEARCH_REQUEST_SUCCESS,
 	INLINE_HELP_SEARCH_REQUEST_FAILURE,
 	INLINE_HELP_SEARCH_REQUEST_API_RESULTS,
+	INLINE_HELP_SELECT_RESULT,
+	INLINE_HELP_SELECT_NEXT_RESULT,
 } from 'state/action-types';
+
+const API_RESULT_FIXTURE = [
+	{
+		id: 1,
+		title: 'Some result',
+	},
+	{
+		id: 2,
+		title: 'Some other result',
+	},
+	{
+		id: 3,
+		title: 'Another result',
+	},
+	{
+		id: 4,
+		title: 'Yet another result',
+	},
+	{
+		id: 5,
+		title: 'Can you imagine more results?',
+	},
+	{
+		id: 6,
+		title: 'Surely, not another result?',
+	},
+];
 
 describe( 'reducer', () => {
 	describe( '#popover()', () => {
@@ -123,46 +152,20 @@ describe( 'reducer', () => {
 		test( 'should correctly set search results keyed by search term', () => {
 			const firstQuery = 'testQuery';
 			const secondQuery = 'anotherQuery';
-			const results = [
-				{
-					id: 1,
-					title: 'Some result',
-				},
-				{
-					id: 2,
-					title: 'Some other result',
-				},
-				{
-					id: 3,
-					title: 'Another result',
-				},
-				{
-					id: 4,
-					title: 'Yet another result',
-				},
-				{
-					id: 5,
-					title: 'Can you imagine more results?',
-				},
-				{
-					id: 6,
-					title: 'Surely, not another result?',
-				},
-			];
 
 			let state = search(
 				{},
 				{
 					type: INLINE_HELP_SEARCH_REQUEST_SUCCESS,
 					searchQuery: firstQuery,
-					searchResults: results,
+					searchResults: API_RESULT_FIXTURE,
 				}
 			);
 
 			expect( state ).to.eql( {
 				selectedResult: -1,
 				items: {
-					[ firstQuery ]: results,
+					[ firstQuery ]: API_RESULT_FIXTURE,
 				},
 			} );
 
@@ -171,14 +174,14 @@ describe( 'reducer', () => {
 			state = search( state, {
 				type: INLINE_HELP_SEARCH_REQUEST_SUCCESS,
 				searchQuery: secondQuery,
-				searchResults: results,
+				searchResults: API_RESULT_FIXTURE,
 			} );
 
 			expect( state ).to.eql( {
 				selectedResult: -1,
 				items: {
-					[ firstQuery ]: results,
-					[ secondQuery ]: results,
+					[ firstQuery ]: API_RESULT_FIXTURE,
+					[ secondQuery ]: API_RESULT_FIXTURE,
 				},
 			} );
 		} );
@@ -200,6 +203,88 @@ describe( 'reducer', () => {
 
 			expect( state ).to.eql( {
 				hasAPIResults: false,
+			} );
+		} );
+
+		describe( 'Search result selection', () => {
+			test( 'should correctly set index of selected result', () => {
+				let state = search( null, {
+					type: INLINE_HELP_SELECT_RESULT,
+					resultIndex: 2,
+				} );
+
+				expect( state ).to.eql( {
+					selectedResult: 2,
+				} );
+
+				state = search(
+					{},
+					{
+						type: INLINE_HELP_SELECT_RESULT,
+						resultIndex: 4,
+					}
+				);
+
+				expect( state ).to.eql( {
+					selectedResult: 4,
+				} );
+			} );
+
+			test( 'should correctly move between selected result indices of the current search query', () => {
+				const initialState = {
+					searchQuery: 'testResultSet',
+					selectedResult: -1,
+					items: {
+						testResultSet: API_RESULT_FIXTURE,
+					},
+				};
+				let state;
+
+				state = search( initialState, {
+					type: INLINE_HELP_SELECT_NEXT_RESULT,
+				} );
+
+				expect( state ).to.eql( {
+					searchQuery: 'testResultSet',
+					selectedResult: 0,
+					items: {
+						testResultSet: API_RESULT_FIXTURE,
+					},
+				} );
+
+				state = search( state, {
+					type: INLINE_HELP_SELECT_NEXT_RESULT,
+				} );
+
+				expect( state ).to.eql( {
+					searchQuery: 'testResultSet',
+					selectedResult: 1,
+					items: {
+						testResultSet: API_RESULT_FIXTURE,
+					},
+				} );
+			} );
+
+			test( 'should correctly reset the selected result index to 0 when end of search result items is reached', () => {
+				const initialState = {
+					searchQuery: 'testResultSet',
+					selectedResult: 5,
+					items: {
+						testResultSet: API_RESULT_FIXTURE,
+					},
+				};
+
+				const state = search( initialState, {
+					type: INLINE_HELP_SELECT_NEXT_RESULT,
+				} );
+
+				expect( state ).to.eql( {
+					searchQuery: 'testResultSet',
+					selectedResult: 0,
+					items: {
+						testResultSet: API_RESULT_FIXTURE,
+					},
+				} );
 			} );
 		} );
 	} );


### PR DESCRIPTION
Previously the reducer for the `inline-help` state had no unit tests.

This PR adds basic tests to cover these.

#### Testing instructions

* `cd tests/client`.
* Run tests `yarn run test-client:watch client/state/inline-help`
* Verify all pass.

