### PR TITLE
Blog Posts Block: allow newspack-blocks installation from github

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -226,7 +226,7 @@ function load_blog_posts_block() {
 	$disable_block = (
 		( defined( 'WP_CLI' ) && WP_CLI ) ||
 		/* phpcs:ignore WordPress.Security.NonceVerification */
-		( isset( $_GET['action'], $_GET['plugin'] ) && 'activate' === $_GET['action'] && preg_match( $slug_regex, esc_url_raw( wp_unslash( $_GET['plugin'] ) ) ) ) ||
+		( isset( $_GET['action'], $_GET['plugin'] ) && 'activate' === $_GET['action'] && preg_match( $slug_regex, sanitize_text_field( wp_unslash( $_GET['plugin'] ) ) ) ) ||
 		preg_grep( $slug_regex, (array) get_option( 'active_plugins' ) ) ||
 		preg_grep( $slug_regex, (array) get_site_option( 'active_sitewide_plugins' ) )
 	);

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -221,13 +221,14 @@ add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_coblocks_gallery_scr
  * Load Blog Posts block.
  */
 function load_blog_posts_block() {
-	$slug          = 'newspack-blocks/newspack-blocks.php';
+	// Use regex instead of static slug in order to match plugin installation also from github, where slug may contain (HASH|branch-name).
+	$slug_regex    = '/newspack-blocks(-[A-Za-z0-9-]+)?\/newspack-blocks\.php/';
 	$disable_block = (
 		( defined( 'WP_CLI' ) && WP_CLI ) ||
 		/* phpcs:ignore WordPress.Security.NonceVerification */
 		( isset( $_GET['action'], $_GET['plugin'] ) && 'activate' === $_GET['action'] && $slug === $_GET['plugin'] ) ||
-		in_array( $slug, (array) get_option( 'active_plugins', array() ), true ) ||
-		in_array( $slug, (array) get_site_option( 'active_sitewide_plugins', array() ), true )
+		preg_grep( $slug_regex, (array) get_option( 'active_plugins' ) ) ||
+		preg_grep( $slug_regex, (array) get_option( 'active_sitewide_plugins' ) )
 	);
 
 	/**

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -225,8 +225,8 @@ function load_blog_posts_block() {
 	$slug_regex    = '/newspack-blocks(-[A-Za-z0-9-]+)?\/newspack-blocks\.php/';
 	$disable_block = (
 		( defined( 'WP_CLI' ) && WP_CLI ) ||
-		/* phpcs:ignore WordPress.Security.NonceVerification,WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized */
-		( isset( $_GET['action'], $_GET['plugin'] ) && 'activate' === $_GET['action'] && preg_match( $slug_regex, $_GET['plugin'] ) ) ||
+		/* phpcs:ignore WordPress.Security.NonceVerification */
+		( isset( $_GET['action'], $_GET['plugin'] ) && 'activate' === $_GET['action'] && preg_match( $slug_regex, esc_url_raw( wp_unslash( $_GET['plugin'] ) ) ) ) ||
 		preg_grep( $slug_regex, (array) get_option( 'active_plugins' ) ) ||
 		preg_grep( $slug_regex, (array) get_site_option( 'active_sitewide_plugins' ) )
 	);

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -226,7 +226,7 @@ function load_blog_posts_block() {
 	$disable_block = (
 		( defined( 'WP_CLI' ) && WP_CLI ) ||
 		/* phpcs:ignore WordPress.Security.NonceVerification */
-		( isset( $_GET['action'], $_GET['plugin'] ) && 'activate' === $_GET['action'] && $slug === $_GET['plugin'] ) ||
+		( isset( $_GET['action'], $_GET['plugin'] ) && 'activate' === $_GET['action'] && preg_match( $slug_regex, $_GET['plugin'] ) ) ||
 		preg_grep( $slug_regex, (array) get_option( 'active_plugins' ) ) ||
 		preg_grep( $slug_regex, (array) get_site_option( 'active_sitewide_plugins' ) )
 	);

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -228,7 +228,7 @@ function load_blog_posts_block() {
 		/* phpcs:ignore WordPress.Security.NonceVerification */
 		( isset( $_GET['action'], $_GET['plugin'] ) && 'activate' === $_GET['action'] && $slug === $_GET['plugin'] ) ||
 		preg_grep( $slug_regex, (array) get_option( 'active_plugins' ) ) ||
-		preg_grep( $slug_regex, (array) get_option( 'active_sitewide_plugins' ) )
+		preg_grep( $slug_regex, (array) get_site_option( 'active_sitewide_plugins' ) )
 	);
 
 	/**

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -225,7 +225,7 @@ function load_blog_posts_block() {
 	$slug_regex    = '/newspack-blocks(-[A-Za-z0-9-]+)?\/newspack-blocks\.php/';
 	$disable_block = (
 		( defined( 'WP_CLI' ) && WP_CLI ) ||
-		/* phpcs:ignore WordPress.Security.NonceVerification */
+		/* phpcs:ignore WordPress.Security.NonceVerification,WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized */
 		( isset( $_GET['action'], $_GET['plugin'] ) && 'activate' === $_GET['action'] && preg_match( $slug_regex, $_GET['plugin'] ) ) ||
 		preg_grep( $slug_regex, (array) get_option( 'active_plugins' ) ) ||
 		preg_grep( $slug_regex, (array) get_site_option( 'active_sitewide_plugins' ) )


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Disables Blog Posts Block when request indicates the newspack-blocks plugins is being installed and activated from github so that it resolves https://github.com/Automattic/newspack-blocks/issues/324

#### Testing instructions

* Setup https://github.com/Automattic/ajax-env with https://github.com/Automattic/newspack-blocks plugin (download the plugin from github and extract into your plugins folder)
* run `npm start`
* Visit http://localhost:4759/wp-admin/plugins.php
* You should not see any error like the below

```
Notice: Constant NEWSPACK_BLOCKS__BLOCKS_DIRECTORY already defined in /var/www/html/wp-content/plugins/full-site-editing-plugin/newspack-blocks/index.php on line 10 Notice: Constant NEWSPACK_BLOCKS__PLUGIN_DIR already defined in /var/www/html/wp-content/plugins/full-site-editing-plugin/newspack-blocks/index.php on line 11 Notice: Constant NEWSPACK_BLOCKS__VERSION already defined in /var/www/html/wp-content/plugins/full-site-editing-plugin/newspack-blocks/index.php on line 14 Fatal error: Cannot declare class Newspack_Blocks, because the name is already in use in /var/www/html/wp-content/plugins/full-site-editing-plugin/newspack-blocks/synced-newspack-blocks/class-newspack-blocks.php on line 11
There has been a critical error on your website. Please check your site admin email inbox for instructions.
```

* Newspack Blocks should be activated


Fixes https://github.com/Automattic/newspack-blocks/issues/324
* Use regex instead of static slug in order to match plugin installation also from github, where slug may contain (HASH|branch-name).