### PR TITLE
Enable new menu structure for `/me/security` in `wpcalypso` and `stage`

### DIFF
--- a/config/stage.json
+++ b/config/stage.json
@@ -127,6 +127,7 @@
 		"rubberband-scroll-disable": false,
 		"rum-tracking/logstash": true,
 		"safari-idb-mitigation": true,
+		"security/security-checkup": true,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
 		"settings/security/monitor/wp-note": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -137,6 +137,7 @@
 		"rubberband-scroll-disable": false,
 		"rum-tracking/logstash": true,
 		"safari-idb-mitigation": true,
+		"security/security-checkup": true,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
 		"settings/security/monitor/wp-note": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This change enables the new menu/nav UI for `/me/security` from #43234 in the `stage` and `wpcalypso` environments so we can get broader testing and feedback on the changes.

<img width="1088" alt="Screenshot 2020-06-22 at 18 54 28" src="https://user-images.githubusercontent.com/3376401/85314879-646cf380-b4ba-11ea-80f3-d85c8a542f45.png">

#### Testing instructions

* Verify that you get the new menu UI from #43234 shown when you navigate to `/me/security`. Verify that you can navigate to (and back from) the various items in the checklist and that the left nav updates appropriately.
