### PR TITLE
composite checkout: RTL support

### DIFF
--- a/client/my-sites/checkout/composite-checkout/wpcom/components/coupon.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/coupon.js
@@ -5,7 +5,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 import { keyframes } from '@emotion/core';
 import PropTypes from 'prop-types';
-import { useTranslate } from 'i18n-calypso';
+import { useTranslate, useRtl } from 'i18n-calypso';
 import { Button } from '@automattic/composite-checkout';
 
 /**
@@ -16,6 +16,7 @@ import Field from './field';
 
 export default function Coupon( { id, className, disabled, couponStatus, couponFieldStateProps } ) {
 	const translate = useTranslate();
+	const isRTL = useRtl();
 	const {
 		couponFieldValue,
 		setCouponFieldValue,
@@ -60,7 +61,7 @@ export default function Coupon( { id, className, disabled, couponStatus, couponF
 			/>
 
 			{ isApplyButtonActive && (
-				<ApplyButton disabled={ isPending } buttonType="secondary">
+				<ApplyButton disabled={ isPending } buttonType="secondary" isRTL={ isRTL }>
 					{ isPending ? translate( 'Processing…' ) : translate( 'Apply' ) }
 				</ApplyButton>
 			) }
@@ -95,7 +96,7 @@ const CouponWrapper = styled.form`
 const ApplyButton = styled( Button )`
 	position: absolute;
 	top: 5px;
-	right: 4px;
+	${ ( props ) => ( props.isRTL ? 'left: 4px;' : 'right: 4px;' ) }
 	padding: 8px;
 	animation: ${ animateIn } 0.2s ease-out;
 	animation-fill-mode: backwards;

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/coupon.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/coupon.js
@@ -114,7 +114,7 @@ const ApplyButton = styled( Button )`
 	margin: 0;
 
 	.rtl & {
-		animation-name: ${ animateInRTL }
+		animation-name: ${ animateInRTL };
 		left: 4px;
 		right: auto;
 	}

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/coupon.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/coupon.js
@@ -86,8 +86,20 @@ const animateIn = keyframes`
   }
 `;
 
+const animateInRTL = keyframes`
+  from {
+    opacity: 0;
+    transform: translateX(-8px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+`;
+
 const CouponWrapper = styled.form`
-	margin: ${ ( props ) => props.marginTop } 0 0 0;
+	margin: ${ ( props ) => props.marginTop } 0 0;
 	padding-top: 0;
 	position: relative;
 `;
@@ -102,6 +114,7 @@ const ApplyButton = styled( Button )`
 	margin: 0;
 
 	.rtl & {
+		animation-name: ${ animateInRTL }
 		left: 4px;
 		right: auto;
 	}

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/coupon.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/coupon.js
@@ -5,7 +5,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 import { keyframes } from '@emotion/core';
 import PropTypes from 'prop-types';
-import { useTranslate, useRtl } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { Button } from '@automattic/composite-checkout';
 
 /**
@@ -16,7 +16,6 @@ import Field from './field';
 
 export default function Coupon( { id, className, disabled, couponStatus, couponFieldStateProps } ) {
 	const translate = useTranslate();
-	const isRTL = useRtl();
 	const {
 		couponFieldValue,
 		setCouponFieldValue,
@@ -61,7 +60,7 @@ export default function Coupon( { id, className, disabled, couponStatus, couponF
 			/>
 
 			{ isApplyButtonActive && (
-				<ApplyButton disabled={ isPending } buttonType="secondary" isRTL={ isRTL }>
+				<ApplyButton disabled={ isPending } buttonType="secondary">
 					{ isPending ? translate( 'Processing…' ) : translate( 'Apply' ) }
 				</ApplyButton>
 			) }
@@ -96,11 +95,16 @@ const CouponWrapper = styled.form`
 const ApplyButton = styled( Button )`
 	position: absolute;
 	top: 5px;
-	${ ( props ) => ( props.isRTL ? 'left: 4px;' : 'right: 4px;' ) }
+	right: 4px;
 	padding: 8px;
 	animation: ${ animateIn } 0.2s ease-out;
 	animation-fill-mode: backwards;
 	margin: 0;
+
+	.rtl & {
+		left: 4px;
+		right: auto;
+	}
 `;
 
 function getCouponErrorMessageFromStatus( translate, status, isFreshOrEdited ) {

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/field.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/field.js
@@ -5,6 +5,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
 import { Button } from '@automattic/composite-checkout';
+import { useRtl } from 'i18n-calypso';
 
 export default function Field( {
 	type,
@@ -25,6 +26,7 @@ export default function Field( {
 	autoComplete,
 	disabled,
 } ) {
+	const isRTL = useRtl();
 	const fieldOnChange = ( event ) => {
 		if ( onChange ) {
 			onChange( event.target.value );
@@ -59,6 +61,7 @@ export default function Field( {
 					isError={ isError }
 					autoComplete={ autoComplete }
 					disabled={ disabled }
+					isRTL={ isRTL }
 				/>
 				<RenderedIcon icon={ icon } iconAction={ iconAction } isIconVisible={ isIconVisible } />
 			</InputWrapper>
@@ -110,11 +113,13 @@ const Input = styled.input`
 	font-size: 16px;
 	border: 1px solid
 		${ ( props ) => ( props.isError ? props.theme.colors.error : props.theme.colors.borderColor ) };
-	padding: 13px ${ ( props ) => ( props.icon ? '60px' : '10px' ) } 12px 10px;
+	padding: ${ ( props ) =>
+		props.isRTL
+			? `13px 10px 12px ${ props.icon ? '60px' : '10px' };`
+			: `13px ${ props.icon ? '60px' : '10px' } 12px 10px;` }
 
 	:focus {
-		outline: ${ ( props ) =>
-				props.isError ? props.theme.colors.error : props.theme.colors.outline }
+		outline: ${ ( props ) => ( props.isError ? props.theme.colors.error : props.theme.colors.outline ) }
 			solid 2px !important;
 	}
 
@@ -146,13 +151,13 @@ const FieldIcon = styled.div`
 	position: absolute;
 	top: 50%;
 	transform: translateY( -50% );
-	right: 10px;
+	${ ( props ) => ( props.isRTL ? 'left: 10px;' : 'right: 10px;' ) }
 `;
 
 const ButtonIconUI = styled.div`
 	position: absolute;
 	top: 0;
-	right: 0;
+	${ ( props ) => ( props.isRTL ? 'left: 0;' : 'right: 0;' ) }
 
 	button {
 		border: 1px solid transparent;
@@ -178,20 +183,21 @@ const Description = styled.p`
 `;
 
 function RenderedIcon( { icon, iconAction, isIconVisible } ) {
+	const isRTL = useRtl();
 	if ( ! isIconVisible ) {
 		return null;
 	}
 
 	if ( iconAction ) {
 		return (
-			<ButtonIconUI>
+			<ButtonIconUI isRTL={ isRTL }>
 				<Button onClick={ iconAction }>{ icon }</Button>
 			</ButtonIconUI>
 		);
 	}
 
 	if ( icon ) {
-		return <FieldIcon>{ icon }</FieldIcon>;
+		return <FieldIcon isRTL={ isRTL }>{ icon }</FieldIcon>;
 	}
 
 	return null;

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/field.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/field.js
@@ -184,7 +184,7 @@ const ButtonIconUI = styled.div`
 `;
 
 const Description = styled.p`
-	margin: 8px 0 0 0;
+	margin: 8px 0 0;
 	color: ${ ( props ) =>
 		props.isError ? props.theme.colors.error : props.theme.colors.textColorLight };
 	font-style: italic;

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/field.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/field.js
@@ -5,7 +5,6 @@ import React from 'react';
 import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
 import { Button } from '@automattic/composite-checkout';
-import { useRtl } from 'i18n-calypso';
 
 export default function Field( {
 	type,
@@ -26,7 +25,6 @@ export default function Field( {
 	autoComplete,
 	disabled,
 } ) {
-	const isRTL = useRtl();
 	const fieldOnChange = ( event ) => {
 		if ( onChange ) {
 			onChange( event.target.value );
@@ -61,7 +59,6 @@ export default function Field( {
 					isError={ isError }
 					autoComplete={ autoComplete }
 					disabled={ disabled }
-					isRTL={ isRTL }
 				/>
 				<RenderedIcon icon={ icon } iconAction={ iconAction } isIconVisible={ isIconVisible } />
 			</InputWrapper>
@@ -113,13 +110,15 @@ const Input = styled.input`
 	font-size: 16px;
 	border: 1px solid
 		${ ( props ) => ( props.isError ? props.theme.colors.error : props.theme.colors.borderColor ) };
-	padding: ${ ( props ) =>
-		props.isRTL
-			? `13px 10px 12px ${ props.icon ? '60px' : '10px' };`
-			: `13px ${ props.icon ? '60px' : '10px' } 12px 10px;` }
+	padding: 13px ${ ( props ) => ( props.icon ? '60px' : '10px' ) } 12px 10px;
+
+	.rtl & {
+		padding: 13px 10px 12px ${ ( props ) => ( props.icon ? '60px' : '10px' ) };
+	}
 
 	:focus {
-		outline: ${ ( props ) => ( props.isError ? props.theme.colors.error : props.theme.colors.outline ) }
+		outline: ${ ( props ) =>
+				props.isError ? props.theme.colors.error : props.theme.colors.outline }
 			solid 2px !important;
 	}
 
@@ -151,13 +150,23 @@ const FieldIcon = styled.div`
 	position: absolute;
 	top: 50%;
 	transform: translateY( -50% );
-	${ ( props ) => ( props.isRTL ? 'left: 10px;' : 'right: 10px;' ) }
+	right: 10px;
+
+	.rtl & {
+		right: auto;
+		left: 10px;
+	}
 `;
 
 const ButtonIconUI = styled.div`
 	position: absolute;
 	top: 0;
-	${ ( props ) => ( props.isRTL ? 'left: 0;' : 'right: 0;' ) }
+	right: 0;
+
+	.rtl & {
+		right: auto;
+		left: 0;
+	}
 
 	button {
 		border: 1px solid transparent;
@@ -183,21 +192,20 @@ const Description = styled.p`
 `;
 
 function RenderedIcon( { icon, iconAction, isIconVisible } ) {
-	const isRTL = useRtl();
 	if ( ! isIconVisible ) {
 		return null;
 	}
 
 	if ( iconAction ) {
 		return (
-			<ButtonIconUI isRTL={ isRTL }>
+			<ButtonIconUI>
 				<Button onClick={ iconAction }>{ icon }</Button>
 			</ButtonIconUI>
 		);
 	}
 
 	if ( icon ) {
-		return <FieldIcon isRTL={ isRTL }>{ icon }</FieldIcon>;
+		return <FieldIcon>{ icon }</FieldIcon>;
 	}
 
 	return null;

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/form-field-annotation.tsx
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/form-field-annotation.tsx
@@ -119,7 +119,7 @@ type DescriptionProps = {
 };
 
 const Description = styled.p< DescriptionProps >`
-	margin: 8px 0 0 0;
+	margin: 8px 0 0;
 	color: ${ ( props ) =>
 		props.isError ? props.theme.colors.error : props.theme.colors.textColorLight };
 	font-style: italic;

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/radio-button.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/radio-button.js
@@ -78,11 +78,11 @@ const RadioButtonWrapper = styled.div`
 		border: ${ getBorderWidth } solid ${ getBorderColor };
 		border-radius: 3px;
 		box-sizing: border-box;
-	}
 
-	.rtl &:before {
-		left: auto;
-		right: 0;
+		.rtl & {
+			left: auto;
+			right: 0;
+		}
 	}
 
 	:hover:before {

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/radio-button.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/radio-button.js
@@ -4,7 +4,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
-import { useRtl } from 'i18n-calypso';
 
 export default function RadioButton( {
 	checked,
@@ -17,16 +16,10 @@ export default function RadioButton( {
 	ariaLabel,
 	isDisabled,
 } ) {
-	const isRTL = useRtl();
 	const [ isFocused, changeFocus ] = useState( false );
 
 	return (
-		<RadioButtonWrapper
-			isDisabled={ isDisabled }
-			isFocused={ isFocused }
-			checked={ checked }
-			isRTL={ isRTL }
-		>
+		<RadioButtonWrapper isDisabled={ isDisabled } isFocused={ isFocused } checked={ checked }>
 			<Radio
 				type="radio"
 				name={ name }
@@ -43,7 +36,7 @@ export default function RadioButton( {
 				readOnly={ ! onChange }
 				aria-label={ ariaLabel }
 			/>
-			<Label checked={ checked } htmlFor={ id } isDisabled={ isDisabled } isRTL={ isRTL }>
+			<Label checked={ checked } htmlFor={ id } isDisabled={ isDisabled }>
 				{ label }
 			</Label>
 			{ children && <RadioButtonChildren checked={ checked }>{ children }</RadioButtonChildren> }
@@ -80,11 +73,16 @@ const RadioButtonWrapper = styled.div`
 		height: 100%;
 		position: absolute;
 		top: 0;
-		${ ( props ) => ( props.isRTL ? 'right: 0;' : 'left: 0;' ) }
+		left: 0;
 		content: '';
 		border: ${ getBorderWidth } solid ${ getBorderColor };
 		border-radius: 3px;
 		box-sizing: border-box;
+	}
+
+	.rtl &:before {
+		left: auto;
+		right: 0;
 	}
 
 	:hover:before {
@@ -124,7 +122,7 @@ const Radio = styled.input`
 
 const Label = styled.label`
 	position: relative;
-	padding: ${ ( props ) => ( props.isRTL ? '16px 40px 16px 14px;' : '16px 14px 16px 40px;' ) }
+	padding: 16px 14px 16px 40px;
 	border-radius: 3px;
 	box-sizing: border-box;
 	width: 100%;
@@ -147,7 +145,7 @@ const Label = styled.label`
 		border-radius: 100%;
 		top: 50%;
 		transform: translateY( -50% );
-		${ ( props ) => ( props.isRTL ? 'right: 16px;' : 'left: 16px;' ) }
+		left: 16px;
 		position: absolute;
 		background: ${ ( props ) => props.theme.colors.surface };
 		box-sizing: border-box;
@@ -162,11 +160,25 @@ const Label = styled.label`
 		border-radius: 100%;
 		top: 50%;
 		transform: translateY( -50% );
-		${ ( props ) => ( props.isRTL ? 'right: 20px;' : 'left: 20px;' ) }
+		left: 20px;
 		position: absolute;
 		background: ${ getRadioColor };
 		box-sizing: border-box;
 		z-index: 3;
+	}
+
+	.rtl & {
+		padding: 16px 40px 16px 14px;
+
+		:before {
+			right: 16px;
+			left: auto;
+		}
+
+		:after {
+			right: 20px;
+			left: auto;
+		}
 	}
 
 	${ handleLabelDisabled };
@@ -220,20 +232,20 @@ function handleLabelDisabled( { isDisabled } ) {
 	return `
 		color: lightgray;
 		font-style: italic;
-		
+
 		:hover {
 			cursor: default;
 		}
-		
+
 		:before {
 			border: 1px solid lightgray;
 			background: lightgray;
 		}
-		
+
 		:after {
 			background: white;
 		}
-		
+
 		span {
 			color: lightgray;
 		}

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/radio-button.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/radio-button.js
@@ -67,7 +67,7 @@ const RadioButtonWrapper = styled.div`
 		margin: 0;
 	}
 
-	:before {
+	::before {
 		display: block;
 		width: 100%;
 		height: 100%;
@@ -85,7 +85,7 @@ const RadioButtonWrapper = styled.div`
 		}
 	}
 
-	:hover:before {
+	:hover::before {
 		border: 3px solid ${ ( props ) => props.theme.colors.highlight };
 	}
 
@@ -132,11 +132,15 @@ const Label = styled.label`
 	align-items: center;
 	font-size: 14px;
 
+	.rtl & {
+		padding: 16px 40px 16px 14px;
+	}
+
 	:hover {
 		cursor: pointer;
 	}
 
-	:before {
+	::before {
 		display: block;
 		width: 16px;
 		height: 16px;
@@ -150,9 +154,14 @@ const Label = styled.label`
 		background: ${ ( props ) => props.theme.colors.surface };
 		box-sizing: border-box;
 		z-index: 2;
+
+		.rtl & {
+			right: 16px;
+			left: auto;
+		}
 	}
 
-	:after {
+	::after {
 		display: block;
 		width: 8px;
 		height: 8px;
@@ -165,17 +174,8 @@ const Label = styled.label`
 		background: ${ getRadioColor };
 		box-sizing: border-box;
 		z-index: 3;
-	}
 
-	.rtl & {
-		padding: 16px 40px 16px 14px;
-
-		:before {
-			right: 16px;
-			left: auto;
-		}
-
-		:after {
+		.rtl & {
 			right: 20px;
 			left: auto;
 		}
@@ -217,8 +217,8 @@ function handleWrapperDisabled( { isDisabled } ) {
 	}
 
 	return `
-		:before,
-		:hover:before {
+		::before,
+		:hover::before {
 			border: 1px solid lightgray;
 		}
 	`;
@@ -237,12 +237,12 @@ function handleLabelDisabled( { isDisabled } ) {
 			cursor: default;
 		}
 
-		:before {
+		::before {
 			border: 1px solid lightgray;
 			background: lightgray;
 		}
 
-		:after {
+		::after {
 			background: white;
 		}
 

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/radio-button.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/radio-button.js
@@ -4,6 +4,7 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
+import { useRtl } from 'i18n-calypso';
 
 export default function RadioButton( {
 	checked,
@@ -16,10 +17,16 @@ export default function RadioButton( {
 	ariaLabel,
 	isDisabled,
 } ) {
+	const isRTL = useRtl();
 	const [ isFocused, changeFocus ] = useState( false );
 
 	return (
-		<RadioButtonWrapper isDisabled={ isDisabled } isFocused={ isFocused } checked={ checked }>
+		<RadioButtonWrapper
+			isDisabled={ isDisabled }
+			isFocused={ isFocused }
+			checked={ checked }
+			isRTL={ isRTL }
+		>
 			<Radio
 				type="radio"
 				name={ name }
@@ -36,7 +43,7 @@ export default function RadioButton( {
 				readOnly={ ! onChange }
 				aria-label={ ariaLabel }
 			/>
-			<Label checked={ checked } htmlFor={ id } isDisabled={ isDisabled }>
+			<Label checked={ checked } htmlFor={ id } isDisabled={ isDisabled } isRTL={ isRTL }>
 				{ label }
 			</Label>
 			{ children && <RadioButtonChildren checked={ checked }>{ children }</RadioButtonChildren> }
@@ -73,7 +80,7 @@ const RadioButtonWrapper = styled.div`
 		height: 100%;
 		position: absolute;
 		top: 0;
-		left: 0;
+		${ ( props ) => ( props.isRTL ? 'right: 0;' : 'left: 0;' ) }
 		content: '';
 		border: ${ getBorderWidth } solid ${ getBorderColor };
 		border-radius: 3px;
@@ -117,7 +124,7 @@ const Radio = styled.input`
 
 const Label = styled.label`
 	position: relative;
-	padding: 16px 14px 16px 40px;
+	padding: ${ ( props ) => ( props.isRTL ? '16px 40px 16px 14px;' : '16px 14px 16px 40px;' ) }
 	border-radius: 3px;
 	box-sizing: border-box;
 	width: 100%;
@@ -140,7 +147,7 @@ const Label = styled.label`
 		border-radius: 100%;
 		top: 50%;
 		transform: translateY( -50% );
-		left: 16px;
+		${ ( props ) => ( props.isRTL ? 'right: 16px;' : 'left: 16px;' ) }
 		position: absolute;
 		background: ${ ( props ) => props.theme.colors.surface };
 		box-sizing: border-box;
@@ -155,7 +162,7 @@ const Label = styled.label`
 		border-radius: 100%;
 		top: 50%;
 		transform: translateY( -50% );
-		left: 20px;
+		${ ( props ) => ( props.isRTL ? 'right: 20px;' : 'left: 20px;' ) }
 		position: absolute;
 		background: ${ getRadioColor };
 		box-sizing: border-box;

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/summary-details.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/summary-details.js
@@ -4,7 +4,7 @@
 import styled from '@emotion/styled';
 
 export const SummaryDetails = styled.ul`
-	margin: 8px 0 0 0;
+	margin: 8px 0 0;
 	padding: 0;
 
 	:first-of-type {

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-review.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-review.js
@@ -5,7 +5,7 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { useLineItems, useFormStatus } from '@automattic/composite-checkout';
-import { useTranslate, useRtl } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -93,7 +93,6 @@ function CouponFieldArea( {
 } ) {
 	const { formStatus } = useFormStatus();
 	const translate = useTranslate();
-	const isRTL = useRtl();
 
 	if ( isPurchaseFree || couponStatus === 'applied' ) {
 		return null;
@@ -106,7 +105,6 @@ function CouponFieldArea( {
 				disabled={ formStatus !== 'ready' }
 				couponStatus={ couponStatus }
 				couponFieldStateProps={ couponFieldStateProps }
-				isRTL={ isRTL }
 			/>
 		);
 	}
@@ -145,7 +143,13 @@ const CouponLinkWrapper = styled.div`
 `;
 
 const CouponField = styled( Coupon )`
-	margin: ${ ( props ) => ( props.isRTL ? '20px 0 20px 30px' : '20px 30px 20px 0;' ) } .is-summary & {
+	margin: 20px 30px 20px 0;
+
+	.rtl & {
+		margin: 20px 0 20px 30px;
+	}
+
+	.is-summary & {
 		margin: 10px 0 0;
 	}
 `;

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-review.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-review.js
@@ -5,7 +5,7 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { useLineItems, useFormStatus } from '@automattic/composite-checkout';
-import { useTranslate } from 'i18n-calypso';
+import { useTranslate, useRtl } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -93,6 +93,7 @@ function CouponFieldArea( {
 } ) {
 	const { formStatus } = useFormStatus();
 	const translate = useTranslate();
+	const isRTL = useRtl();
 
 	if ( isPurchaseFree || couponStatus === 'applied' ) {
 		return null;
@@ -105,6 +106,7 @@ function CouponFieldArea( {
 				disabled={ formStatus !== 'ready' }
 				couponStatus={ couponStatus }
 				couponFieldStateProps={ couponFieldStateProps }
+				isRTL={ isRTL }
 			/>
 		);
 	}
@@ -143,9 +145,7 @@ const CouponLinkWrapper = styled.div`
 `;
 
 const CouponField = styled( Coupon )`
-	margin: 20px 30px 20px 0;
-
-	.is-summary & {
+	margin: ${ ( props ) => ( props.isRTL ? '20px 0 20px 30px' : '20px 30px 20px 0;' ) } .is-summary & {
 		margin: 10px 0 0;
 	}
 `;

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
@@ -14,7 +14,7 @@ import {
 	useLineItemsOfType,
 	useTotal,
 } from '@automattic/composite-checkout';
-import { useTranslate } from 'i18n-calypso';
+import { useTranslate, useRtl } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -82,11 +82,12 @@ export default function WPCheckoutOrderSummary() {
 }
 
 function LoadingCheckoutSummaryFeaturesList() {
+	const isRTL = useRtl();
 	return (
 		<>
-			<LoadingCopy />
-			<LoadingCopy />
-			<LoadingCopy />
+			<LoadingCopy isRTL={ isRTL } />
+			<LoadingCopy isRTL={ isRTL } />
+			<LoadingCopy isRTL={ isRTL } />
 		</>
 	);
 }
@@ -96,6 +97,7 @@ function CheckoutSummaryFeaturesList() {
 	const domains = useDomainsInCart();
 	const hasPlanInCart = useHasPlanInCart();
 	const translate = useTranslate();
+	const isRTL = useRtl();
 
 	const supportText = hasPlanInCart
 		? translate( 'Email and live chat support' )
@@ -115,12 +117,12 @@ function CheckoutSummaryFeaturesList() {
 					return <CheckoutSummaryFeaturesListDomainItem domain={ domain } key={ domain.id } />;
 				} ) }
 			{ hasPlanInCart && <CheckoutSummaryPlanFeatures /> }
-			<CheckoutSummaryFeaturesListItem>
-				<WPCheckoutCheckIcon />
+			<CheckoutSummaryFeaturesListItem isRTL={ isRTL }>
+				<WPCheckoutCheckIcon isRTL={ isRTL } />
 				{ supportText }
 			</CheckoutSummaryFeaturesListItem>
-			<CheckoutSummaryFeaturesListItem>
-				<WPCheckoutCheckIcon />
+			<CheckoutSummaryFeaturesListItem isRTL={ isRTL }>
+				<WPCheckoutCheckIcon isRTL={ isRTL } />
 				{ refundText }
 			</CheckoutSummaryFeaturesListItem>
 		</CheckoutSummaryFeaturesListUI>
@@ -129,9 +131,10 @@ function CheckoutSummaryFeaturesList() {
 
 function CheckoutSummaryFeaturesListDomainItem( { domain } ) {
 	const translate = useTranslate();
+	const isRTL = useRtl();
 	return (
-		<CheckoutSummaryFeaturesListItem>
-			<WPCheckoutCheckIcon />
+		<CheckoutSummaryFeaturesListItem isRTL={ isRTL }>
+			<WPCheckoutCheckIcon isRTL={ isRTL } />
 			{ domain.wpcom_meta.is_bundled ? (
 				translate( '{{strong}}%(domain)s{{/strong}} - %(bundled)s', {
 					components: {
@@ -152,6 +155,7 @@ function CheckoutSummaryFeaturesListDomainItem( { domain } ) {
 
 function CheckoutSummaryPlanFeatures() {
 	const translate = useTranslate();
+	const isRTL = useRtl();
 	const hasDomainsInCart = useHasDomainsInCart();
 	const planInCart = usePlanInCart();
 	const hasRenewalInCart = useHasRenewalInCart();
@@ -162,8 +166,8 @@ function CheckoutSummaryPlanFeatures() {
 			{ planFeatures &&
 				planFeatures.map( ( feature, index ) => {
 					return (
-						<CheckoutSummaryFeaturesListItem key={ index }>
-							<WPCheckoutCheckIcon />
+						<CheckoutSummaryFeaturesListItem key={ index } isRTL={ isRTL }>
+							<WPCheckoutCheckIcon isRTL={ isRTL } />
 							{ feature }
 						</CheckoutSummaryFeaturesListItem>
 					);
@@ -225,6 +229,7 @@ function getPlanFeatures( plan, translate, hasDomainsInCart, hasRenewalInCart ) 
 function CheckoutSummaryHelp() {
 	const reduxDispatch = useDispatch();
 	const translate = useTranslate();
+	const isRTL = useRtl();
 	const plans = useLineItemsOfType( 'plan' );
 
 	const supportVariationDetermined = useSelector( isSupportVariationDetermined );
@@ -260,7 +265,9 @@ function CheckoutSummaryHelp() {
 	return (
 		<>
 			<QuerySupportTypes />
-			{ ! shouldRenderPaymentChatButton && ! supportVariationDetermined && <LoadingButton /> }
+			{ ! shouldRenderPaymentChatButton && ! supportVariationDetermined && (
+				<LoadingButton isRTL={ isRTL } />
+			) }
 			{ shouldRenderPaymentChatButton ? (
 				<PaymentChatButton />
 			) : (
@@ -350,15 +357,15 @@ const CheckoutSummaryHelpButton = styled.button`
 
 const WPCheckoutCheckIcon = styled( CheckoutCheckIcon )`
 	fill: ${ ( props ) => props.theme.colors.success };
-	margin-right: 4px;
+	${ ( props ) => ( props.isRTL ? 'margin-left: 4px;' : 'margin-right: 4px;' ) }
 	position: absolute;
 	top: 0;
-	left: 0;
+	${ ( props ) => ( props.isRTL ? 'right: 0;' : 'left: 0;' ) }
 `;
 
 const CheckoutSummaryFeaturesListItem = styled.li`
 	margin-bottom: 4px;
-	padding-left: 24px;
+	${ ( props ) => ( props.isRTL ? 'padding-right: 24px;' : 'padding-left: 24px;' ) }
 	position: relative;
 `;
 
@@ -393,7 +400,7 @@ const LoadingCopy = styled.p`
 	content: '';
 	font-size: 14px;
 	height: 18px;
-	margin: 8px 0 0 26px;
+	margin: ${ ( props ) => ( props.isRTL ? '8px 26px 0 0;' : '8px 0 0 26px;' ) }
 	padding: 0;
 	position: relative;
 
@@ -401,7 +408,7 @@ const LoadingCopy = styled.p`
 		content: '';
 		display: block;
 		position: absolute;
-		left: -26px;
+		${ ( props ) => ( props.isRTL ? 'right: -26px;' : 'left: -26px;' ) }
 		top: 0;
 		width: 18px;
 		height: 18px;

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
@@ -430,7 +430,7 @@ const LoadingCopy = styled.p`
 
 		::before {
 			right: -26px;
-			left: 0;
+			left: auto;
 		}
 	}
 `;

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
@@ -413,7 +413,7 @@ const LoadingCopy = styled.p`
 	padding: 0;
 	position: relative;
 
-	:before {
+	::before {
 		content: '';
 		display: block;
 		position: absolute;
@@ -428,7 +428,7 @@ const LoadingCopy = styled.p`
 	.rtl & {
 		margin: 8px 26px 0 0;
 
-		:before {
+		::before {
 			right: -26px;
 			left: 0;
 		}
@@ -438,7 +438,7 @@ const LoadingCopy = styled.p`
 const LoadingButton = styled( LoadingCopy )`
 	margin: 16px 8px 0;
 
-	:before {
+	::before {
 		display: none;
 	}
 `;

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
@@ -14,7 +14,7 @@ import {
 	useLineItemsOfType,
 	useTotal,
 } from '@automattic/composite-checkout';
-import { useTranslate, useRtl } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -82,12 +82,11 @@ export default function WPCheckoutOrderSummary() {
 }
 
 function LoadingCheckoutSummaryFeaturesList() {
-	const isRTL = useRtl();
 	return (
 		<>
-			<LoadingCopy isRTL={ isRTL } />
-			<LoadingCopy isRTL={ isRTL } />
-			<LoadingCopy isRTL={ isRTL } />
+			<LoadingCopy />
+			<LoadingCopy />
+			<LoadingCopy />
 		</>
 	);
 }
@@ -97,7 +96,6 @@ function CheckoutSummaryFeaturesList() {
 	const domains = useDomainsInCart();
 	const hasPlanInCart = useHasPlanInCart();
 	const translate = useTranslate();
-	const isRTL = useRtl();
 
 	const supportText = hasPlanInCart
 		? translate( 'Email and live chat support' )
@@ -117,12 +115,12 @@ function CheckoutSummaryFeaturesList() {
 					return <CheckoutSummaryFeaturesListDomainItem domain={ domain } key={ domain.id } />;
 				} ) }
 			{ hasPlanInCart && <CheckoutSummaryPlanFeatures /> }
-			<CheckoutSummaryFeaturesListItem isRTL={ isRTL }>
-				<WPCheckoutCheckIcon isRTL={ isRTL } />
+			<CheckoutSummaryFeaturesListItem>
+				<WPCheckoutCheckIcon />
 				{ supportText }
 			</CheckoutSummaryFeaturesListItem>
-			<CheckoutSummaryFeaturesListItem isRTL={ isRTL }>
-				<WPCheckoutCheckIcon isRTL={ isRTL } />
+			<CheckoutSummaryFeaturesListItem>
+				<WPCheckoutCheckIcon />
 				{ refundText }
 			</CheckoutSummaryFeaturesListItem>
 		</CheckoutSummaryFeaturesListUI>
@@ -131,10 +129,9 @@ function CheckoutSummaryFeaturesList() {
 
 function CheckoutSummaryFeaturesListDomainItem( { domain } ) {
 	const translate = useTranslate();
-	const isRTL = useRtl();
 	return (
-		<CheckoutSummaryFeaturesListItem isRTL={ isRTL }>
-			<WPCheckoutCheckIcon isRTL={ isRTL } />
+		<CheckoutSummaryFeaturesListItem>
+			<WPCheckoutCheckIcon />
 			{ domain.wpcom_meta.is_bundled ? (
 				translate( '{{strong}}%(domain)s{{/strong}} - %(bundled)s', {
 					components: {
@@ -155,7 +152,6 @@ function CheckoutSummaryFeaturesListDomainItem( { domain } ) {
 
 function CheckoutSummaryPlanFeatures() {
 	const translate = useTranslate();
-	const isRTL = useRtl();
 	const hasDomainsInCart = useHasDomainsInCart();
 	const planInCart = usePlanInCart();
 	const hasRenewalInCart = useHasRenewalInCart();
@@ -166,8 +162,8 @@ function CheckoutSummaryPlanFeatures() {
 			{ planFeatures &&
 				planFeatures.map( ( feature, index ) => {
 					return (
-						<CheckoutSummaryFeaturesListItem key={ index } isRTL={ isRTL }>
-							<WPCheckoutCheckIcon isRTL={ isRTL } />
+						<CheckoutSummaryFeaturesListItem key={ index }>
+							<WPCheckoutCheckIcon />
 							{ feature }
 						</CheckoutSummaryFeaturesListItem>
 					);
@@ -229,7 +225,6 @@ function getPlanFeatures( plan, translate, hasDomainsInCart, hasRenewalInCart ) 
 function CheckoutSummaryHelp() {
 	const reduxDispatch = useDispatch();
 	const translate = useTranslate();
-	const isRTL = useRtl();
 	const plans = useLineItemsOfType( 'plan' );
 
 	const supportVariationDetermined = useSelector( isSupportVariationDetermined );
@@ -265,9 +260,7 @@ function CheckoutSummaryHelp() {
 	return (
 		<>
 			<QuerySupportTypes />
-			{ ! shouldRenderPaymentChatButton && ! supportVariationDetermined && (
-				<LoadingButton isRTL={ isRTL } />
-			) }
+			{ ! shouldRenderPaymentChatButton && ! supportVariationDetermined && <LoadingButton /> }
 			{ shouldRenderPaymentChatButton ? (
 				<PaymentChatButton />
 			) : (
@@ -345,6 +338,10 @@ const CheckoutSummaryHelpButton = styled.button`
 	margin-top: 16px;
 	text-align: left;
 
+	.rtl & {
+		text-align: right;
+	}
+
 	span {
 		cursor: pointer;
 		text-decoration: underline;
@@ -357,16 +354,28 @@ const CheckoutSummaryHelpButton = styled.button`
 
 const WPCheckoutCheckIcon = styled( CheckoutCheckIcon )`
 	fill: ${ ( props ) => props.theme.colors.success };
-	${ ( props ) => ( props.isRTL ? 'margin-left: 4px;' : 'margin-right: 4px;' ) }
+	margin-right: 4px;
 	position: absolute;
 	top: 0;
-	${ ( props ) => ( props.isRTL ? 'right: 0;' : 'left: 0;' ) }
+	left: 0;
+
+	.rtl & {
+		margin-right: 0;
+		margin-left: 4px;
+		right: 0;
+		left: auto;
+	}
 `;
 
 const CheckoutSummaryFeaturesListItem = styled.li`
 	margin-bottom: 4px;
-	${ ( props ) => ( props.isRTL ? 'padding-right: 24px;' : 'padding-left: 24px;' ) }
+	padding-left: 24px;
 	position: relative;
+
+	.rtl & {
+		padding-right: 24px;
+		padding-left: 0;
+	}
 `;
 
 const CheckoutSummaryAmountWrapper = styled.div`
@@ -400,7 +409,7 @@ const LoadingCopy = styled.p`
 	content: '';
 	font-size: 14px;
 	height: 18px;
-	margin: ${ ( props ) => ( props.isRTL ? '8px 26px 0 0;' : '8px 0 0 26px;' ) }
+	margin: 8px 0 0 26px;
 	padding: 0;
 	position: relative;
 
@@ -408,12 +417,21 @@ const LoadingCopy = styled.p`
 		content: '';
 		display: block;
 		position: absolute;
-		${ ( props ) => ( props.isRTL ? 'right: -26px;' : 'left: -26px;' ) }
+		left: -26px;
 		top: 0;
 		width: 18px;
 		height: 18px;
 		background: ${ ( props ) => props.theme.colors.borderColorLight };
 		border-radius: 100%;
+	}
+
+	.rtl & {
+		margin: 8px 26px 0 0;
+
+		:before {
+			right: -26px;
+			left: 0;
+		}
 	}
 `;
 

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -2,8 +2,9 @@
  * External dependencies
  */
 import React, { useEffect, useState, useRef, useCallback } from 'react';
-import { useTranslate } from 'i18n-calypso';
+import { useTranslate, useRtl } from 'i18n-calypso';
 import styled from '@emotion/styled';
+import isPropValid from '@emotion/is-prop-valid';
 import {
 	Checkout,
 	CheckoutStep,
@@ -102,6 +103,7 @@ export default function WPCheckout( {
 	isWhiteGloveOffer,
 } ) {
 	const translate = useTranslate();
+	const isRTL = useRtl();
 	const couponFieldStateProps = useCouponFieldState( submitCoupon );
 	const total = useTotal();
 	const activePaymentMethod = usePaymentMethod();
@@ -215,11 +217,14 @@ export default function WPCheckout( {
 	return (
 		<Checkout>
 			<CheckoutSummaryArea className={ isSummaryVisible ? 'is-visible' : '' }>
-				<CheckoutSummaryTitleLink onClick={ () => setIsSummaryVisible( ! isSummaryVisible ) }>
+				<CheckoutSummaryTitleLink
+					onClick={ () => setIsSummaryVisible( ! isSummaryVisible ) }
+					isRTL={ isRTL }
+				>
 					<CheckoutSummaryTitle>
 						<CheckoutSummaryTitleIcon icon="info-outline" size={ 20 } />
 						{ translate( 'Purchase Details' ) }
-						<CheckoutSummaryTitleToggle icon="keyboard_arrow_down" />
+						<CheckoutSummaryTitleToggle icon="keyboard_arrow_down" isRTL={ isRTL } />
 					</CheckoutSummaryTitle>
 					<CheckoutSummaryTitlePrice className="wp-checkout__total-price">
 						{ renderDisplayValueMarkdown( total.amount.displayValue ) }
@@ -353,7 +358,7 @@ const CheckoutSummaryTitleLink = styled.button`
 	font-size: 16px;
 	font-weight: ${ ( props ) => props.theme.weights.bold };
 	justify-content: space-between;
-	padding: 20px 23px 20px 14px;
+	padding: ${ ( props ) => ( props.isRTL ? '20px 14px 20px 23px' : '20px 23px 20px 14px;' ) }
 	width: 100%;
 
 	.is-visible & {
@@ -374,13 +379,13 @@ const CheckoutSummaryTitle = styled.span`
 	display: flex;
 `;
 
-const CheckoutSummaryTitleIcon = styled( Gridicon )`
-	margin-right: 4px;
+const CheckoutSummaryTitleIcon = styled( Gridicon, { shouldForwardProp: isPropValid } )`
+	${ ( props ) => ( props.isRTL ? 'margin-left: 4px;' : 'margin-right: 4px;' ) }
 `;
 
-const CheckoutSummaryTitleToggle = styled( MaterialIcon )`
+const CheckoutSummaryTitleToggle = styled( MaterialIcon, { shouldForwardProp: isPropValid } )`
 	fill: ${ ( props ) => props.theme.colors.textColor };
-	margin-left: 4px;
+	${ ( props ) => ( props.isRTL ? 'margin-right: 4px;' : 'margin-left: 4px;' ) }
 	transition: transform 0.1s linear;
 	width: 18px;
 	height: 18px;
@@ -416,12 +421,13 @@ const CheckoutSummaryBody = styled.div`
 
 function PaymentMethodStep( { CheckoutTerms, responseCart, subtotal } ) {
 	const [ items, total ] = useLineItems();
+	const isRTL = useRtl();
 	const taxes = items.filter( ( item ) => item.type === 'tax' );
 	return (
 		<>
 			{ paymentMethodStep.activeStepContent }
 
-			<CheckoutTermsUI>
+			<CheckoutTermsUI isRTL={ isRTL }>
 				<CheckoutTerms cart={ responseCart } />
 			</CheckoutTermsUI>
 
@@ -438,14 +444,14 @@ function PaymentMethodStep( { CheckoutTerms, responseCart, subtotal } ) {
 
 const CheckoutTermsUI = styled.div`
 	& > * {
-		margin: 16px 0 16px -24px;
-		padding-left: 24px;
+		margin: ${ ( props ) => ( props.isRTL ? '16px -24px 16px 0;' : '16px 0 16px -24px;' ) }
+		${ ( props ) => ( props.isRTL ? 'padding-right: 24px;' : 'padding-left: 24px;' ) }
 		position: relative;
 	}
 
 	& div:first-of-type {
-		padding-left: 0;
-		margin-left: 0;
+		${ ( props ) => ( props.isRTL ? 'padding-right: 0;' : 'padding-left: 0;' ) }
+		${ ( props ) => ( props.isRTL ? 'margin-right: 0;' : 'margin-left: 0;' ) }
 		margin-top: 32px;
 	}
 
@@ -454,7 +460,7 @@ const CheckoutTermsUI = styled.div`
 		height: 16px;
 		position: absolute;
 		top: 0;
-		left: 0;
+		${ ( props ) => ( props.isRTL ? 'right: 0;' : 'left: 0;' ) }
 	}
 
 	p {

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -2,9 +2,8 @@
  * External dependencies
  */
 import React, { useEffect, useState, useRef, useCallback } from 'react';
-import { useTranslate, useRtl } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import styled from '@emotion/styled';
-import isPropValid from '@emotion/is-prop-valid';
 import {
 	Checkout,
 	CheckoutStep,
@@ -103,7 +102,6 @@ export default function WPCheckout( {
 	isWhiteGloveOffer,
 } ) {
 	const translate = useTranslate();
-	const isRTL = useRtl();
 	const couponFieldStateProps = useCouponFieldState( submitCoupon );
 	const total = useTotal();
 	const activePaymentMethod = usePaymentMethod();
@@ -217,14 +215,11 @@ export default function WPCheckout( {
 	return (
 		<Checkout>
 			<CheckoutSummaryArea className={ isSummaryVisible ? 'is-visible' : '' }>
-				<CheckoutSummaryTitleLink
-					onClick={ () => setIsSummaryVisible( ! isSummaryVisible ) }
-					isRTL={ isRTL }
-				>
+				<CheckoutSummaryTitleLink onClick={ () => setIsSummaryVisible( ! isSummaryVisible ) }>
 					<CheckoutSummaryTitle>
 						<CheckoutSummaryTitleIcon icon="info-outline" size={ 20 } />
 						{ translate( 'Purchase Details' ) }
-						<CheckoutSummaryTitleToggle icon="keyboard_arrow_down" isRTL={ isRTL } />
+						<CheckoutSummaryTitleToggle icon="keyboard_arrow_down" />
 					</CheckoutSummaryTitle>
 					<CheckoutSummaryTitlePrice className="wp-checkout__total-price">
 						{ renderDisplayValueMarkdown( total.amount.displayValue ) }
@@ -358,8 +353,12 @@ const CheckoutSummaryTitleLink = styled.button`
 	font-size: 16px;
 	font-weight: ${ ( props ) => props.theme.weights.bold };
 	justify-content: space-between;
-	padding: ${ ( props ) => ( props.isRTL ? '20px 14px 20px 23px' : '20px 23px 20px 14px;' ) }
+	padding: 20px 23px 20px 14px;
 	width: 100%;
+
+	.rtl & {
+		padding: 20px 14px 20px 23px;
+	}
 
 	.is-visible & {
 		border-bottom: none;
@@ -379,17 +378,27 @@ const CheckoutSummaryTitle = styled.span`
 	display: flex;
 `;
 
-const CheckoutSummaryTitleIcon = styled( Gridicon, { shouldForwardProp: isPropValid } )`
-	${ ( props ) => ( props.isRTL ? 'margin-left: 4px;' : 'margin-right: 4px;' ) }
+const CheckoutSummaryTitleIcon = styled( Gridicon )`
+	margin-right: 4px;
+
+	.rtl & {
+		margin-right: 0;
+		margin-left: 4px;
+	}
 `;
 
-const CheckoutSummaryTitleToggle = styled( MaterialIcon, { shouldForwardProp: isPropValid } )`
+const CheckoutSummaryTitleToggle = styled( MaterialIcon )`
 	fill: ${ ( props ) => props.theme.colors.textColor };
-	${ ( props ) => ( props.isRTL ? 'margin-right: 4px;' : 'margin-left: 4px;' ) }
+	margin-left: 4px;
 	transition: transform 0.1s linear;
 	width: 18px;
 	height: 18px;
 	vertical-align: bottom;
+
+	.rtl & {
+		margin-right: 0;
+		margin-left: 4px;
+	}
 
 	.is-visible & {
 		transform: rotate( 180deg );
@@ -421,13 +430,12 @@ const CheckoutSummaryBody = styled.div`
 
 function PaymentMethodStep( { CheckoutTerms, responseCart, subtotal } ) {
 	const [ items, total ] = useLineItems();
-	const isRTL = useRtl();
 	const taxes = items.filter( ( item ) => item.type === 'tax' );
 	return (
 		<>
 			{ paymentMethodStep.activeStepContent }
 
-			<CheckoutTermsUI isRTL={ isRTL }>
+			<CheckoutTermsUI>
 				<CheckoutTerms cart={ responseCart } />
 			</CheckoutTermsUI>
 
@@ -444,14 +452,22 @@ function PaymentMethodStep( { CheckoutTerms, responseCart, subtotal } ) {
 
 const CheckoutTermsUI = styled.div`
 	& > * {
-		margin: ${ ( props ) => ( props.isRTL ? '16px -24px 16px 0;' : '16px 0 16px -24px;' ) }
-		${ ( props ) => ( props.isRTL ? 'padding-right: 24px;' : 'padding-left: 24px;' ) }
+		margin: 16px 0 16px -24px;
+		padding-left: 24px;
 		position: relative;
 	}
 
+	.rtl & > * {
+		margin: 16px -24px 16px 0;
+		padding-right: 24px;
+		padding-left: 0;
+	}
+
 	& div:first-of-type {
-		${ ( props ) => ( props.isRTL ? 'padding-right: 0;' : 'padding-left: 0;' ) }
-		${ ( props ) => ( props.isRTL ? 'margin-right: 0;' : 'margin-left: 0;' ) }
+		padding-right: 0;
+		padding-left: 0;
+		margin-right: 0;
+		margin-left: 0;
 		margin-top: 32px;
 	}
 
@@ -460,7 +476,12 @@ const CheckoutTermsUI = styled.div`
 		height: 16px;
 		position: absolute;
 		top: 0;
-		${ ( props ) => ( props.isRTL ? 'right: 0;' : 'left: 0;' ) }
+		left: 0;
+	}
+
+	.rtl & svg {
+		left: auto;
+		right: 0;
 	}
 
 	p {

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -477,11 +477,11 @@ const CheckoutTermsUI = styled.div`
 		position: absolute;
 		top: 0;
 		left: 0;
-	}
 
-	.rtl & svg {
-		left: auto;
-		right: 0;
+		.rtl & {
+			left: auto;
+			right: 0;
+		}
 	}
 
 	p {

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
@@ -365,13 +365,13 @@ const WPOrderReviewList = styled.ul`
 	box-sizing: border-box;
 	margin: 20px 30px 20px 0;
 
+	.rtl & {
+		margin: 20px 0 20px 30px;
+	}
+
 	.is-summary & {
 		border-top: 0;
 		margin: 0;
-	}
-
-	.rtl & {
-		margin: 20px 0 20px 30px;
 	}
 `;
 

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
@@ -41,7 +41,6 @@ function WPLineItem( {
 	isWhiteGloveOffer,
 } ) {
 	const translate = useTranslate();
-	const isRtl = useRtl();
 	const hasDomainsInCart = useHasDomainsInCart();
 	const { formStatus } = useFormStatus();
 	const itemSpanId = `checkout-line-item-${ item.id }`;
@@ -55,6 +54,7 @@ function WPLineItem( {
 	// Show the variation picker when this is not a renewal
 	const shouldShowVariantSelector = getItemVariants && item.wpcom_meta && ! isRenewal;
 	const isGSuite = !! item.wpcom_meta?.extra?.google_apps_users?.length;
+	const isRTL = useRtl();
 
 	let gsuiteDiscountCallout = null;
 	if (
@@ -63,7 +63,9 @@ function WPLineItem( {
 		item.wpcom_meta?.is_sale_coupon_applied
 	) {
 		gsuiteDiscountCallout = (
-			<DiscountCalloutUI>{ translate( 'Discount for first year' ) }</DiscountCalloutUI>
+			<DiscountCalloutUI isRTL={ isRTL }>
+				{ translate( 'Discount for first year' ) }
+			</DiscountCalloutUI>
 		);
 	}
 
@@ -113,7 +115,7 @@ function WPLineItem( {
 								},
 							} );
 						} }
-						isRtl={ isRtl }
+						isRTL={ isRTL }
 					>
 						<DeleteIcon uniqueID={ deleteButtonId } product={ item.label } />
 					</DeleteButton>
@@ -174,9 +176,9 @@ WPLineItem.propTypes = {
 };
 
 function LineItemPrice( { item, isSummary } ) {
-	const isRtl = useRtl();
+	const isRTL = useRtl();
 	return (
-		<LineItemPriceUI isSummary={ isSummary } isRtl={ isRtl }>
+		<LineItemPriceUI isSummary={ isSummary } isRTL={ isRTL }>
 			{ item.amount.value < item.wpcom_meta?.item_original_subtotal_integer ? (
 				<>
 					<s>{ item.wpcom_meta?.item_original_subtotal_display }</s> { item.amount.displayValue }
@@ -217,7 +219,7 @@ const LineItemMeta = styled.div`
 
 const DiscountCalloutUI = styled.div`
 	color: ${ ( props ) => props.theme.colors.success };
-	text-align: right;
+	text-align: ${ ( props ) => ( props.isRTL ? 'left;' : 'right;' ) };
 `;
 
 const LineItemTitle = styled.div`
@@ -227,14 +229,14 @@ const LineItemTitle = styled.div`
 `;
 
 const LineItemPriceUI = styled.span`
-	${ ( props ) => ( props.isRtl ? 'margin-right: 12px;' : 'margin-left: 12px;' ) }
+	${ ( props ) => ( props.isRTL ? 'margin-right: 12px;' : 'margin-left: 12px;' ) }
 	font-size: ${ ( { isSummary } ) => ( isSummary ? '14px' : '16px' ) };
 `;
 
 const DeleteButton = styled( Button )`
 	position: absolute;
 	padding: 10px;
-	${ ( props ) => ( props.isRtl ? 'left: 50px;' : 'right: -50px;' ) }
+	${ ( props ) => ( props.isRTL ? 'left: 50px;' : 'right: -50px;' ) }
 	top: 7px;
 
 	:hover rect {
@@ -304,11 +306,11 @@ export function WPOrderReviewLineItems( {
 	onChangePlanLength,
 	isWhiteGloveOffer,
 } ) {
-	const isRtl = useRtl();
+	const isRTL = useRtl();
 	return (
 		<WPOrderReviewList
 			className={ joinClasses( [ className, 'order-review-line-items' ] ) }
-			isRtl={ isRtl }
+			isRTL={ isRTL }
 		>
 			{ items
 				.filter( ( item ) => item.label ) // remove items without a label
@@ -356,7 +358,7 @@ WPOrderReviewLineItems.propTypes = {
 const WPOrderReviewList = styled.ul`
 	border-top: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
 	box-sizing: border-box;
-	margin: ${ ( props ) => ( props.isRtl ? '20px 0 20px 30px' : '20px 30px 20px 0' ) };
+	margin: ${ ( props ) => ( props.isRTL ? '20px 0 20px 30px' : '20px 30px 20px 0' ) };
 
 	.is-summary & {
 		border-top: 0;
@@ -468,16 +470,21 @@ function LineItemSublabelAndPrice( { item } ) {
 
 function DomainDiscountCallout( { item } ) {
 	const translate = useTranslate();
+	const isRTL = useRtl();
 
 	const isFreeBundledDomainRegistration = item.wpcom_meta?.is_bundled && item.amount.value === 0;
 	if ( isFreeBundledDomainRegistration ) {
-		return <DiscountCalloutUI>{ translate( 'First year free' ) }</DiscountCalloutUI>;
+		return (
+			<DiscountCalloutUI isRTL={ isRTL }>{ translate( 'First year free' ) }</DiscountCalloutUI>
+		);
 	}
 
 	const isFreeDomainMapping =
 		item.wpcom_meta?.product_slug === 'domain_map' && item.amount.value === 0;
 	if ( isFreeDomainMapping ) {
-		return <DiscountCalloutUI>{ translate( 'Free with your plan' ) }</DiscountCalloutUI>;
+		return (
+			<DiscountCalloutUI isRTL={ isRTL }>{ translate( 'Free with your plan' ) }</DiscountCalloutUI>
+		);
 	}
 
 	return null;

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
@@ -11,7 +11,7 @@ import {
 	useEvents,
 	Button,
 } from '@automattic/composite-checkout';
-import { useTranslate } from 'i18n-calypso';
+import { useTranslate, useRtl } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -41,6 +41,7 @@ function WPLineItem( {
 	isWhiteGloveOffer,
 } ) {
 	const translate = useTranslate();
+	const isRtl = useRtl();
 	const hasDomainsInCart = useHasDomainsInCart();
 	const { formStatus } = useFormStatus();
 	const itemSpanId = `checkout-line-item-${ item.id }`;
@@ -112,6 +113,7 @@ function WPLineItem( {
 								},
 							} );
 						} }
+						isRtl={ isRtl }
 					>
 						<DeleteIcon uniqueID={ deleteButtonId } product={ item.label } />
 					</DeleteButton>
@@ -172,8 +174,9 @@ WPLineItem.propTypes = {
 };
 
 function LineItemPrice( { item, isSummary } ) {
+	const isRtl = useRtl();
 	return (
-		<LineItemPriceUI isSummary={ isSummary }>
+		<LineItemPriceUI isSummary={ isSummary } isRtl={ isRtl }>
 			{ item.amount.value < item.wpcom_meta?.item_original_subtotal_integer ? (
 				<>
 					<s>{ item.wpcom_meta?.item_original_subtotal_display }</s> { item.amount.displayValue }
@@ -224,14 +227,14 @@ const LineItemTitle = styled.div`
 `;
 
 const LineItemPriceUI = styled.span`
-	margin-left: 12px;
+	${ ( props ) => ( props.isRtl ? 'margin-right: 12px;' : 'margin-left: 12px;' ) }
 	font-size: ${ ( { isSummary } ) => ( isSummary ? '14px' : '16px' ) };
 `;
 
 const DeleteButton = styled( Button )`
 	position: absolute;
 	padding: 10px;
-	right: -50px;
+	${ ( props ) => ( props.isRtl ? 'left: 50px;' : 'right: -50px;' ) }
 	top: 7px;
 
 	:hover rect {
@@ -301,8 +304,12 @@ export function WPOrderReviewLineItems( {
 	onChangePlanLength,
 	isWhiteGloveOffer,
 } ) {
+	const isRtl = useRtl();
 	return (
-		<WPOrderReviewList className={ joinClasses( [ className, 'order-review-line-items' ] ) }>
+		<WPOrderReviewList
+			className={ joinClasses( [ className, 'order-review-line-items' ] ) }
+			isRtl={ isRtl }
+		>
 			{ items
 				.filter( ( item ) => item.label ) // remove items without a label
 				.map( ( item ) => {
@@ -349,7 +356,7 @@ WPOrderReviewLineItems.propTypes = {
 const WPOrderReviewList = styled.ul`
 	border-top: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
 	box-sizing: border-box;
-	margin: 20px 30px 20px 0;
+	margin: ${ ( props ) => ( props.isRtl ? '20px 0 20px 30px' : '20px 30px 20px 0' ) };
 
 	.is-summary & {
 		border-top: 0;

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
@@ -11,7 +11,7 @@ import {
 	useEvents,
 	Button,
 } from '@automattic/composite-checkout';
-import { useTranslate, useRtl } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -54,7 +54,6 @@ function WPLineItem( {
 	// Show the variation picker when this is not a renewal
 	const shouldShowVariantSelector = getItemVariants && item.wpcom_meta && ! isRenewal;
 	const isGSuite = !! item.wpcom_meta?.extra?.google_apps_users?.length;
-	const isRTL = useRtl();
 
 	let gsuiteDiscountCallout = null;
 	if (
@@ -63,9 +62,7 @@ function WPLineItem( {
 		item.wpcom_meta?.is_sale_coupon_applied
 	) {
 		gsuiteDiscountCallout = (
-			<DiscountCalloutUI isRTL={ isRTL }>
-				{ translate( 'Discount for first year' ) }
-			</DiscountCalloutUI>
+			<DiscountCalloutUI>{ translate( 'Discount for first year' ) }</DiscountCalloutUI>
 		);
 	}
 
@@ -115,7 +112,6 @@ function WPLineItem( {
 								},
 							} );
 						} }
-						isRTL={ isRTL }
 					>
 						<DeleteIcon uniqueID={ deleteButtonId } product={ item.label } />
 					</DeleteButton>
@@ -176,9 +172,8 @@ WPLineItem.propTypes = {
 };
 
 function LineItemPrice( { item, isSummary } ) {
-	const isRTL = useRtl();
 	return (
-		<LineItemPriceUI isSummary={ isSummary } isRTL={ isRTL }>
+		<LineItemPriceUI isSummary={ isSummary }>
 			{ item.amount.value < item.wpcom_meta?.item_original_subtotal_integer ? (
 				<>
 					<s>{ item.wpcom_meta?.item_original_subtotal_display }</s> { item.amount.displayValue }
@@ -219,7 +214,11 @@ const LineItemMeta = styled.div`
 
 const DiscountCalloutUI = styled.div`
 	color: ${ ( props ) => props.theme.colors.success };
-	text-align: ${ ( props ) => ( props.isRTL ? 'left;' : 'right;' ) };
+	text-align: right;
+
+	.rtl & {
+		text-align: left;
+	}
 `;
 
 const LineItemTitle = styled.div`
@@ -229,14 +228,19 @@ const LineItemTitle = styled.div`
 `;
 
 const LineItemPriceUI = styled.span`
-	${ ( props ) => ( props.isRTL ? 'margin-right: 12px;' : 'margin-left: 12px;' ) }
+	margin-left: 12px;
 	font-size: ${ ( { isSummary } ) => ( isSummary ? '14px' : '16px' ) };
+
+	.rtl & {
+		margin-right: 12px;
+		margin-left: 0;
+	}
 `;
 
 const DeleteButton = styled( Button )`
 	position: absolute;
 	padding: 10px;
-	${ ( props ) => ( props.isRTL ? 'left: 50px;' : 'right: -50px;' ) }
+	right: -50px;
 	top: 7px;
 
 	:hover rect {
@@ -245,6 +249,11 @@ const DeleteButton = styled( Button )`
 
 	svg {
 		opacity: 1;
+	}
+
+	.rtl & {
+		right: auto;
+		left: -50px;
 	}
 `;
 
@@ -306,12 +315,8 @@ export function WPOrderReviewLineItems( {
 	onChangePlanLength,
 	isWhiteGloveOffer,
 } ) {
-	const isRTL = useRtl();
 	return (
-		<WPOrderReviewList
-			className={ joinClasses( [ className, 'order-review-line-items' ] ) }
-			isRTL={ isRTL }
-		>
+		<WPOrderReviewList className={ joinClasses( [ className, 'order-review-line-items' ] ) }>
 			{ items
 				.filter( ( item ) => item.label ) // remove items without a label
 				.map( ( item ) => {
@@ -358,11 +363,15 @@ WPOrderReviewLineItems.propTypes = {
 const WPOrderReviewList = styled.ul`
 	border-top: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
 	box-sizing: border-box;
-	margin: ${ ( props ) => ( props.isRTL ? '20px 0 20px 30px' : '20px 30px 20px 0' ) };
+	margin: 20px 30px 20px 0;
 
 	.is-summary & {
 		border-top: 0;
 		margin: 0;
+	}
+
+	.rtl & {
+		margin: 20px 0 20px 30px;
 	}
 `;
 
@@ -470,21 +479,16 @@ function LineItemSublabelAndPrice( { item } ) {
 
 function DomainDiscountCallout( { item } ) {
 	const translate = useTranslate();
-	const isRTL = useRtl();
 
 	const isFreeBundledDomainRegistration = item.wpcom_meta?.is_bundled && item.amount.value === 0;
 	if ( isFreeBundledDomainRegistration ) {
-		return (
-			<DiscountCalloutUI isRTL={ isRTL }>{ translate( 'First year free' ) }</DiscountCalloutUI>
-		);
+		return <DiscountCalloutUI>{ translate( 'First year free' ) }</DiscountCalloutUI>;
 	}
 
 	const isFreeDomainMapping =
 		item.wpcom_meta?.product_slug === 'domain_map' && item.amount.value === 0;
 	if ( isFreeDomainMapping ) {
-		return (
-			<DiscountCalloutUI isRTL={ isRTL }>{ translate( 'Free with your plan' ) }</DiscountCalloutUI>
-		);
+		return <DiscountCalloutUI>{ translate( 'Free with your plan' ) }</DiscountCalloutUI>;
 	}
 
 	return null;

--- a/client/my-sites/checkout/composite-checkout/wpcom/hooks/product-variants.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/hooks/product-variants.js
@@ -145,9 +145,19 @@ function getTermText( term, translate ) {
 const Discount = styled.span`
 	color: ${ ( props ) => props.theme.colors.discount };
 	margin-right: 8px;
+
+	.rtl & {
+		margin-right: 0;
+		margin-left: 8px;
+	}
 `;
 
 const DoNotPayThis = styled.span`
 	text-decoration: line-through;
 	margin-right: 8px;
+
+	.rtl & {
+		margin-right: 0;
+		margin-left: 8px;
+	}
 `;

--- a/packages/composite-checkout/src/components/checkout-modal.js
+++ b/packages/composite-checkout/src/components/checkout-modal.js
@@ -24,7 +24,7 @@ export default function CheckoutModal( {
 	buttonCTA,
 	cancelButtonCTA,
 } ) {
-	const { __, isRTL } = useI18n();
+	const { __ } = useI18n();
 	useModalScreen( isVisible, closeModal );
 
 	if ( ! isVisible ) {
@@ -35,7 +35,6 @@ export default function CheckoutModal( {
 		<CheckoutModalWrapper
 			className={ joinClasses( [ className, 'checkout-modal' ] ) }
 			onClick={ () => handleCancelAction( cancelAction, closeModal ) }
-			isRTL={ isRTL }
 		>
 			<CheckoutModalContent className="checkout-modal__content" onClick={ preventClose }>
 				<CheckoutModalTitle className="checkout-modal__title">{ title }</CheckoutModalTitle>
@@ -96,7 +95,7 @@ const animateIn = keyframes`
 const CheckoutModalWrapper = styled.div`
 	position: fixed;
 	top: 0;
-	${ ( props ) => ( props.isRTL ? 'right: 0;' : 'left: 0;' ) }
+	left: 0;
 	background: ${ ( props ) => props.theme.colors.modalBackground };
 	width: 100%;
 	height: 100vh;
@@ -109,6 +108,11 @@ const CheckoutModalWrapper = styled.div`
 	box-sizing: border-box;
 	margin: 0;
 	padding: 0;
+
+	.rtl & {
+		right: 0;
+		left: auto;
+	}
 `;
 
 const CheckoutModalContent = styled.div`
@@ -141,6 +145,11 @@ const CheckoutModalActions = styled.div`
 
 	button:first-of-type {
 		margin-right: 8px;
+
+		.rtl & {
+			margin-right: 0;
+			margin-left: 8px;
+		}
 	}
 `;
 

--- a/packages/composite-checkout/src/components/checkout-modal.js
+++ b/packages/composite-checkout/src/components/checkout-modal.js
@@ -24,7 +24,7 @@ export default function CheckoutModal( {
 	buttonCTA,
 	cancelButtonCTA,
 } ) {
-	const { __ } = useI18n();
+	const { __, isRTL } = useI18n();
 	useModalScreen( isVisible, closeModal );
 
 	if ( ! isVisible ) {
@@ -35,6 +35,7 @@ export default function CheckoutModal( {
 		<CheckoutModalWrapper
 			className={ joinClasses( [ className, 'checkout-modal' ] ) }
 			onClick={ () => handleCancelAction( cancelAction, closeModal ) }
+			isRTL={ isRTL }
 		>
 			<CheckoutModalContent className="checkout-modal__content" onClick={ preventClose }>
 				<CheckoutModalTitle className="checkout-modal__title">{ title }</CheckoutModalTitle>
@@ -95,7 +96,7 @@ const animateIn = keyframes`
 const CheckoutModalWrapper = styled.div`
 	position: fixed;
 	top: 0;
-	left: 0;
+	${ ( props ) => ( props.isRTL ? 'right: 0;' : 'left: 0;' ) }
 	background: ${ ( props ) => props.theme.colors.modalBackground };
 	width: 100%;
 	height: 100vh;

--- a/packages/composite-checkout/src/components/checkout-steps.js
+++ b/packages/composite-checkout/src/components/checkout-steps.js
@@ -49,7 +49,7 @@ export function Checkout( { children, className } ) {
 	const classNames = joinClasses( [
 		'composite-checkout',
 		...( className ? [ className ] : [] ),
-		...( isRTL ? [ 'rtl' ] : [] ),
+		...( isRTL() ? [ 'rtl' ] : [] ),
 	] );
 
 	if ( formStatus === 'loading' ) {

--- a/packages/composite-checkout/src/components/checkout-steps.js
+++ b/packages/composite-checkout/src/components/checkout-steps.js
@@ -653,8 +653,8 @@ const StepTitle = styled.span`
 		props.isActive ? props.theme.weights.bold : props.theme.weights.normal };
 	${ ( props ) =>
 		props.isRTL
-			? `margin-left: ${ ( props ) => ( props.fullWidth ? '0' : '8px' ) };`
-			: `margin-right: ${ ( props ) => ( props.fullWidth ? '0' : '8px' ) };` }
+			? `margin-left: ${ props.fullWidth ? '0' : '8px' };`
+			: `margin-right: ${ props.fullWidth ? '0' : '8px' };` }
 	flex: ${ ( props ) => ( props.fullWidth ? '1' : 'inherit' ) };
 `;
 

--- a/packages/composite-checkout/src/components/checkout-steps.js
+++ b/packages/composite-checkout/src/components/checkout-steps.js
@@ -122,8 +122,12 @@ function DefaultCheckoutSteps() {
 }
 
 export function CheckoutSummaryArea( { children, className } ) {
+	const { isRTL } = useI18n();
 	return (
-		<CheckoutSummaryUI className={ joinClasses( [ className, 'checkout__summary-area' ] ) }>
+		<CheckoutSummaryUI
+			className={ joinClasses( [ className, 'checkout__summary-area' ] ) }
+			isRTL={ isRTL }
+		>
 			{ children }
 		</CheckoutSummaryUI>
 	);
@@ -156,12 +160,13 @@ export function CheckoutStepArea( { children, className } ) {
 		( error ) => onEvent( { type: 'SUBMIT_BUTTON_LOAD_ERROR', payload: error } ),
 		[ onEvent ]
 	);
+	const { isRTL } = useI18n();
 
 	return (
 		<CheckoutStepAreaUI className={ joinClasses( [ className, 'checkout__step-wrapper' ] ) }>
 			{ children }
 
-			<SubmitButtonWrapperUI isLastStepActive={ ! isThereAnotherNumberedStep }>
+			<SubmitButtonWrapperUI isLastStepActive={ ! isThereAnotherNumberedStep } isRTL={ isRTL }>
 				<CheckoutErrorBoundary
 					errorMessage={ __( 'There was a problem with the submit button.' ) }
 					onError={ onSubmitButtonLoadError }
@@ -344,7 +349,7 @@ export function CheckoutStepBody( {
 	completeStepContent,
 	onError,
 } ) {
-	const { __ } = useI18n();
+	const { __, isRTL } = useI18n();
 	return (
 		<CheckoutErrorBoundary
 			errorMessage={ errorMessage || __( 'There was an error with this step.' ) }
@@ -369,7 +374,11 @@ export function CheckoutStepBody( {
 					editButtonText={ editButtonText || __( 'Edit' ) }
 					editButtonAriaLabel={ editButtonAriaLabel || __( 'Edit this step' ) }
 				/>
-				<StepContentUI isVisible={ isStepActive } className="checkout-steps__step-content">
+				<StepContentUI
+					isVisible={ isStepActive }
+					className="checkout-steps__step-content"
+					isRTL={ isRTL }
+				>
 					{ activeStepContent }
 					{ goToNextStep && isStepActive && (
 						<CheckoutNextStepButton
@@ -394,6 +403,7 @@ export function CheckoutStepBody( {
 					<StepSummaryUI
 						isVisible={ ! isStepActive }
 						className="checkout-steps__step-complete-content"
+						isRTL={ isRTL }
 					>
 						{ completeStepContent }
 					</StepSummaryUI>
@@ -456,8 +466,8 @@ const CheckoutSummaryUI = styled.div`
 	}
 
 	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
-		margin-left: 24px;
-		margin-right: 0;
+		${ ( props ) => ( props.isRTL ? 'margin-left: 0;' : 'margin-left: 24px;' ) }
+		${ ( props ) => ( props.isRTL ? 'margin-right: 24px;' : 'margin-right: 0;' ) }
 		order: 2;
 		width: 328px;
 	}
@@ -489,7 +499,7 @@ const SubmitButtonWrapperUI = styled.div`
 	padding: 24px;
 	position: ${ ( props ) => ( props.isLastStepActive ? 'fixed' : 'relative' ) };
 	bottom: 0;
-	left: 0;
+	${ ( props ) => ( props.isRTL ? 'right: 0;' : 'left: 0;' ) }
 	box-sizing: border-box;
 	width: 100%;
 	z-index: 10;
@@ -569,6 +579,7 @@ function CheckoutStepHeader( {
 } ) {
 	const { __ } = useI18n();
 	const shouldShowEditButton = !! onEdit;
+	const { isRTL } = useI18n();
 
 	return (
 		<StepHeader
@@ -579,7 +590,7 @@ function CheckoutStepHeader( {
 			<Stepper isComplete={ isComplete } isActive={ isActive } id={ id }>
 				{ stepNumber || null }
 			</Stepper>
-			<StepTitle fullWidth={ ! shouldShowEditButton } isActive={ isActive }>
+			<StepTitle fullWidth={ ! shouldShowEditButton } isActive={ isActive } isRTL={ isRTL }>
 				{ title }
 			</StepTitle>
 			{ shouldShowEditButton && (
@@ -610,13 +621,17 @@ CheckoutStepHeader.propTypes = {
 function Stepper( { isComplete, isActive, className, children, id } ) {
 	// Prevent showing complete stepper when active
 	const isCompleteAndInactive = isActive ? false : isComplete;
+	const { isRTL } = useI18n();
 	return (
-		<StepNumberOuterWrapper className={ joinClasses( [ className, 'checkout-step__stepper' ] ) }>
+		<StepNumberOuterWrapper
+			className={ joinClasses( [ className, 'checkout-step__stepper' ] ) }
+			isRTL={ isRTL }
+		>
 			<StepNumberInnerWrapper isComplete={ isCompleteAndInactive }>
-				<StepNumber isComplete={ isCompleteAndInactive } isActive={ isActive }>
+				<StepNumber isComplete={ isCompleteAndInactive } isActive={ isActive } isRTL={ isRTL }>
 					{ children }
 				</StepNumber>
-				<StepNumberCompleted>
+				<StepNumberCompleted isRTL={ isRTL }>
 					<CheckIcon id={ id } />
 				</StepNumberCompleted>
 			</StepNumberInnerWrapper>
@@ -636,7 +651,10 @@ const StepTitle = styled.span`
 		props.isActive ? props.theme.colors.textColorDark : props.theme.colors.textColor };
 	font-weight: ${ ( props ) =>
 		props.isActive ? props.theme.weights.bold : props.theme.weights.normal };
-	margin-right: ${ ( props ) => ( props.fullWidth ? '0' : '8px' ) };
+	${ ( props ) =>
+		props.isRTL
+			? `margin-left: ${ ( props ) => ( props.fullWidth ? '0' : '8px' ) };`
+			: `margin-right: ${ ( props ) => ( props.fullWidth ? '0' : '8px' ) };` }
 	flex: ${ ( props ) => ( props.fullWidth ? '1' : 'inherit' ) };
 `;
 
@@ -652,7 +670,7 @@ const StepNumberOuterWrapper = styled.div`
 	position: relative;
 	width: 27px;
 	height: 27px;
-	margin-right: 8px;
+	${ ( props ) => ( props.isRTL ? 'margin-left: 8px;' : 'margin-right: 8px;' ) }
 `;
 
 const StepNumberInnerWrapper = styled.div`
@@ -675,7 +693,7 @@ const StepNumber = styled.div`
 	color: ${ getStepNumberForegroundColor };
 	position: absolute;
 	top: 0;
-	left: 0;
+	${ ( props ) => ( props.isRTL ? 'right: 0;' : 'left: 0;' ) }
 	backface-visibility: hidden;
 	// Reason: The IE media query needs to not have spaces within brackets otherwise ie11 doesn't read them
 	// prettier-ignore
@@ -724,14 +742,14 @@ function getStepNumberForegroundColor( { isComplete, isActive, theme } ) {
 const StepContentUI = styled.div`
 	color: ${ ( props ) => props.theme.colors.textColor };
 	display: ${ ( props ) => ( props.isVisible ? 'block' : 'none' ) };
-	padding-left: 35px;
+	${ ( props ) => ( props.isRTL ? 'padding-right: 35px;' : 'padding-left: 35px;' ) }
 `;
 
 const StepSummaryUI = styled.div`
 	color: ${ ( props ) => props.theme.colors.textColorLight };
 	font-size: 14px;
 	display: ${ ( props ) => ( props.isVisible ? 'block' : 'none' ) };
-	padding-left: 35px;
+	${ ( props ) => ( props.isRTL ? 'padding-right: 35px;' : 'padding-left: 35px;' ) }
 `;
 
 function saveStepNumberToUrl( stepNumber ) {

--- a/packages/composite-checkout/src/components/checkout-steps.js
+++ b/packages/composite-checkout/src/components/checkout-steps.js
@@ -33,6 +33,7 @@ const CheckoutStepDataContext = React.createContext();
 const CheckoutSingleStepDataContext = React.createContext();
 
 export function Checkout( { children, className } ) {
+	const { isRTL } = useI18n();
 	const { formStatus } = useFormStatus();
 	const [ activeStepNumber, setActiveStepNumber ] = useState( 1 );
 	const [ stepCompleteStatus, setStepCompleteStatus ] = useState( {} );
@@ -45,9 +46,15 @@ export function Checkout( { children, className } ) {
 
 	const getDefaultCheckoutSteps = () => <DefaultCheckoutSteps />;
 
+	const classNames = joinClasses( [
+		'composite-checkout',
+		...( className ? [ className ] : [] ),
+		...( isRTL ? [ 'rtl' ] : [] ),
+	] );
+
 	if ( formStatus === 'loading' ) {
 		return (
-			<ContainerUI className={ joinClasses( [ className, 'composite-checkout' ] ) }>
+			<ContainerUI className={ classNames }>
 				<MainContentUI
 					className={ joinClasses( [ className, 'checkout__content' ] ) }
 					isLastStepActive={ false }
@@ -59,7 +66,7 @@ export function Checkout( { children, className } ) {
 	}
 
 	return (
-		<ContainerUI className={ joinClasses( [ className, 'composite-checkout' ] ) }>
+		<ContainerUI className={ classNames }>
 			<MainContentUI className={ joinClasses( [ className, 'checkout__content' ] ) }>
 				<CheckoutStepDataContext.Provider
 					value={ {
@@ -122,12 +129,8 @@ function DefaultCheckoutSteps() {
 }
 
 export function CheckoutSummaryArea( { children, className } ) {
-	const { isRTL } = useI18n();
 	return (
-		<CheckoutSummaryUI
-			className={ joinClasses( [ className, 'checkout__summary-area' ] ) }
-			isRTL={ isRTL }
-		>
+		<CheckoutSummaryUI className={ joinClasses( [ className, 'checkout__summary-area' ] ) }>
 			{ children }
 		</CheckoutSummaryUI>
 	);
@@ -160,13 +163,12 @@ export function CheckoutStepArea( { children, className } ) {
 		( error ) => onEvent( { type: 'SUBMIT_BUTTON_LOAD_ERROR', payload: error } ),
 		[ onEvent ]
 	);
-	const { isRTL } = useI18n();
 
 	return (
 		<CheckoutStepAreaUI className={ joinClasses( [ className, 'checkout__step-wrapper' ] ) }>
 			{ children }
 
-			<SubmitButtonWrapperUI isLastStepActive={ ! isThereAnotherNumberedStep } isRTL={ isRTL }>
+			<SubmitButtonWrapperUI isLastStepActive={ ! isThereAnotherNumberedStep }>
 				<CheckoutErrorBoundary
 					errorMessage={ __( 'There was a problem with the submit button.' ) }
 					onError={ onSubmitButtonLoadError }
@@ -349,7 +351,7 @@ export function CheckoutStepBody( {
 	completeStepContent,
 	onError,
 } ) {
-	const { __, isRTL } = useI18n();
+	const { __ } = useI18n();
 	return (
 		<CheckoutErrorBoundary
 			errorMessage={ errorMessage || __( 'There was an error with this step.' ) }
@@ -374,11 +376,7 @@ export function CheckoutStepBody( {
 					editButtonText={ editButtonText || __( 'Edit' ) }
 					editButtonAriaLabel={ editButtonAriaLabel || __( 'Edit this step' ) }
 				/>
-				<StepContentUI
-					isVisible={ isStepActive }
-					className="checkout-steps__step-content"
-					isRTL={ isRTL }
-				>
+				<StepContentUI isVisible={ isStepActive } className="checkout-steps__step-content">
 					{ activeStepContent }
 					{ goToNextStep && isStepActive && (
 						<CheckoutNextStepButton
@@ -403,7 +401,6 @@ export function CheckoutStepBody( {
 					<StepSummaryUI
 						isVisible={ ! isStepActive }
 						className="checkout-steps__step-complete-content"
-						isRTL={ isRTL }
 					>
 						{ completeStepContent }
 					</StepSummaryUI>
@@ -466,10 +463,15 @@ const CheckoutSummaryUI = styled.div`
 	}
 
 	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
-		${ ( props ) => ( props.isRTL ? 'margin-left: 0;' : 'margin-left: 24px;' ) }
-		${ ( props ) => ( props.isRTL ? 'margin-right: 24px;' : 'margin-right: 0;' ) }
+		margin-right: 0;
+		margin-left: 24px;
 		order: 2;
 		width: 328px;
+
+		.rtl & {
+			margin-right: 24px;
+			margin-left; 0;
+		}
 	}
 `;
 
@@ -499,7 +501,7 @@ const SubmitButtonWrapperUI = styled.div`
 	padding: 24px;
 	position: ${ ( props ) => ( props.isLastStepActive ? 'fixed' : 'relative' ) };
 	bottom: 0;
-	${ ( props ) => ( props.isRTL ? 'right: 0;' : 'left: 0;' ) }
+	left: 0;
 	box-sizing: border-box;
 	width: 100%;
 	z-index: 10;
@@ -509,6 +511,11 @@ const SubmitButtonWrapperUI = styled.div`
 
 	button {
 		width: ${ ( props ) => ( props.isLastStepActive ? 'calc( 100% - 60px )' : '100%' ) };
+	}
+
+	.rtl & {
+		right: 0;
+		left: auto;
 	}
 
 	@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
@@ -579,7 +586,6 @@ function CheckoutStepHeader( {
 } ) {
 	const { __ } = useI18n();
 	const shouldShowEditButton = !! onEdit;
-	const { isRTL } = useI18n();
 
 	return (
 		<StepHeader
@@ -590,7 +596,7 @@ function CheckoutStepHeader( {
 			<Stepper isComplete={ isComplete } isActive={ isActive } id={ id }>
 				{ stepNumber || null }
 			</Stepper>
-			<StepTitle fullWidth={ ! shouldShowEditButton } isActive={ isActive } isRTL={ isRTL }>
+			<StepTitle fullWidth={ ! shouldShowEditButton } isActive={ isActive }>
 				{ title }
 			</StepTitle>
 			{ shouldShowEditButton && (
@@ -621,17 +627,13 @@ CheckoutStepHeader.propTypes = {
 function Stepper( { isComplete, isActive, className, children, id } ) {
 	// Prevent showing complete stepper when active
 	const isCompleteAndInactive = isActive ? false : isComplete;
-	const { isRTL } = useI18n();
 	return (
-		<StepNumberOuterWrapper
-			className={ joinClasses( [ className, 'checkout-step__stepper' ] ) }
-			isRTL={ isRTL }
-		>
+		<StepNumberOuterWrapper className={ joinClasses( [ className, 'checkout-step__stepper' ] ) }>
 			<StepNumberInnerWrapper isComplete={ isCompleteAndInactive }>
-				<StepNumber isComplete={ isCompleteAndInactive } isActive={ isActive } isRTL={ isRTL }>
+				<StepNumber isComplete={ isCompleteAndInactive } isActive={ isActive }>
 					{ children }
 				</StepNumber>
-				<StepNumberCompleted isRTL={ isRTL }>
+				<StepNumberCompleted>
 					<CheckIcon id={ id } />
 				</StepNumberCompleted>
 			</StepNumberInnerWrapper>
@@ -651,11 +653,13 @@ const StepTitle = styled.span`
 		props.isActive ? props.theme.colors.textColorDark : props.theme.colors.textColor };
 	font-weight: ${ ( props ) =>
 		props.isActive ? props.theme.weights.bold : props.theme.weights.normal };
-	${ ( props ) =>
-		props.isRTL
-			? `margin-left: ${ props.fullWidth ? '0' : '8px' };`
-			: `margin-right: ${ props.fullWidth ? '0' : '8px' };` }
+	margin-right: ${ ( props ) => ( props.fullWidth ? '0' : '8px' ) };
 	flex: ${ ( props ) => ( props.fullWidth ? '1' : 'inherit' ) };
+
+	.rtl & {
+		margin-right: 0;
+		margin-left: ${ ( props ) => ( props.fullWidth ? '0' : '8px' ) };
+	}
 `;
 
 const StepHeader = styled.h2`
@@ -670,7 +674,12 @@ const StepNumberOuterWrapper = styled.div`
 	position: relative;
 	width: 27px;
 	height: 27px;
-	${ ( props ) => ( props.isRTL ? 'margin-left: 8px;' : 'margin-right: 8px;' ) }
+	margin-right: 8px;
+
+	.rtl & {
+		margin-right: 0;
+		margin-left: 8px;
+	}
 `;
 
 const StepNumberInnerWrapper = styled.div`
@@ -693,8 +702,14 @@ const StepNumber = styled.div`
 	color: ${ getStepNumberForegroundColor };
 	position: absolute;
 	top: 0;
-	${ ( props ) => ( props.isRTL ? 'right: 0;' : 'left: 0;' ) }
+	left: 0;
 	backface-visibility: hidden;
+
+	.rtl & {
+		right: 0;
+		left: auto;
+	}
+
 	// Reason: The IE media query needs to not have spaces within brackets otherwise ie11 doesn't read them
 	// prettier-ignore
 	@media all and (-ms-high-contrast:none), (-ms-high-contrast:active) {
@@ -742,14 +757,24 @@ function getStepNumberForegroundColor( { isComplete, isActive, theme } ) {
 const StepContentUI = styled.div`
 	color: ${ ( props ) => props.theme.colors.textColor };
 	display: ${ ( props ) => ( props.isVisible ? 'block' : 'none' ) };
-	${ ( props ) => ( props.isRTL ? 'padding-right: 35px;' : 'padding-left: 35px;' ) }
+	padding-left: 35px;
+
+	.rtl & {
+		padding-right: 35px;
+		padding-left: 0;
+	}
 `;
 
 const StepSummaryUI = styled.div`
 	color: ${ ( props ) => props.theme.colors.textColorLight };
 	font-size: 14px;
 	display: ${ ( props ) => ( props.isVisible ? 'block' : 'none' ) };
-	${ ( props ) => ( props.isRTL ? 'padding-right: 35px;' : 'padding-left: 35px;' ) }
+	padding-left: 35px;
+
+	.rtl & {
+		padding-right: 35px;
+		padding-left: 0;
+	}
 `;
 
 function saveStepNumberToUrl( stepNumber ) {

--- a/packages/composite-checkout/src/components/error-message.js
+++ b/packages/composite-checkout/src/components/error-message.js
@@ -3,21 +3,21 @@
  */
 import React from 'react';
 import styled from '@emotion/styled';
-import { useI18n } from '@automattic/react-i18n';
 
 export default function ErrorMessage( { children } ) {
-	const { isRTL } = useI18n();
-	return <Error isRTL={ isRTL }>{ children }</Error>;
+	return <Error>{ children }</Error>;
 }
 
 const Error = styled.div`
 	display: block;
 	padding: 24px 16px;
-	${ ( props ) =>
-		props.isRTL
-			? `border-right: 3px solid ${ props.theme.colors.error };`
-			: `border-left: 3px solid ${ props.theme.colors.error };` }
+	border-left: 3px solid ${ ( props ) => props.theme.colors.error };
 	background: ${ ( props ) => props.theme.colors.warningBackground };
 	box-sizing: border-box;
 	line-height: 1.2em;
+
+	.rtl & {
+		border-right: 3px solid ${ ( props ) => props.theme.colors.error };
+		border-left: 0 none;
+	}
 `;

--- a/packages/composite-checkout/src/components/error-message.js
+++ b/packages/composite-checkout/src/components/error-message.js
@@ -15,8 +15,8 @@ const Error = styled.div`
 	padding: 24px 16px;
 	${ ( props ) =>
 		props.isRTL
-			? `border-right: 3px solid ${ ( props ) => props.theme.colors.error };`
-			: `border-left: 3px solid ${ ( props ) => props.theme.colors.error };` }
+			? `border-right: 3px solid ${ props.theme.colors.error };`
+			: `border-left: 3px solid ${ props.theme.colors.error };` }
 	background: ${ ( props ) => props.theme.colors.warningBackground };
 	box-sizing: border-box;
 	line-height: 1.2em;

--- a/packages/composite-checkout/src/components/error-message.js
+++ b/packages/composite-checkout/src/components/error-message.js
@@ -3,15 +3,20 @@
  */
 import React from 'react';
 import styled from '@emotion/styled';
+import { useI18n } from '@automattic/react-i18n';
 
 export default function ErrorMessage( { children } ) {
-	return <Error>{ children }</Error>;
+	const { isRTL } = useI18n();
+	return <Error isRTL={ isRTL }>{ children }</Error>;
 }
 
 const Error = styled.div`
 	display: block;
 	padding: 24px 16px;
-	border-left: 3px solid ${ ( props ) => props.theme.colors.error };
+	${ ( props ) =>
+		props.isRTL
+			? `border-right: 3px solid ${ ( props ) => props.theme.colors.error };`
+			: `border-left: 3px solid ${ ( props ) => props.theme.colors.error };` }
 	background: ${ ( props ) => props.theme.colors.warningBackground };
 	box-sizing: border-box;
 	line-height: 1.2em;

--- a/packages/composite-checkout/src/components/field.js
+++ b/packages/composite-checkout/src/components/field.js
@@ -121,8 +121,8 @@ const Input = styled.input`
 				props.isError ? props.theme.colors.error : props.theme.colors.borderColor };
 		${ ( props ) =>
 			props.isRTL
-				? `padding: 13px 10px 11px ${ ( props ) => ( props.icon ? '60px' : '10px' ) };`
-				: `padding: 13px ${ ( props ) => ( props.icon ? '60px' : '10px' ) } 11px 10px;` }
+				? `padding: 13px 10px 11px ${ props.icon ? '60px' : '10px' };`
+				: `padding: 13px ${ props.icon ? '60px' : '10px' } 11px 10px;` }
 		line-height: 1.2;
 	}
 

--- a/packages/composite-checkout/src/components/field.js
+++ b/packages/composite-checkout/src/components/field.js
@@ -4,6 +4,7 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
+import { useI18n } from '@automattic/react-i18n';
 
 /**
  * Internal dependencies
@@ -28,6 +29,7 @@ export default function Field( {
 	autoComplete,
 	disabled,
 } ) {
+	const { isRTL } = useI18n();
 	const fieldOnChange = ( event ) => {
 		if ( onChange ) {
 			onChange( event.target.value );
@@ -61,6 +63,7 @@ export default function Field( {
 					isError={ isError }
 					autoComplete={ autoComplete }
 					disabled={ disabled }
+					isRTL={ isRTL }
 				/>
 				<RenderedIcon icon={ icon } iconAction={ iconAction } isIconVisible={ isIconVisible } />
 			</InputWrapper>
@@ -116,7 +119,10 @@ const Input = styled.input`
 		border: 1px solid
 			${ ( props ) =>
 				props.isError ? props.theme.colors.error : props.theme.colors.borderColor };
-		padding: 13px ${ ( props ) => ( props.icon ? '60px' : '10px' ) } 11px 10px;
+		${ ( props ) =>
+			props.isRTL
+				? `padding: 13px 10px 11px ${ ( props ) => ( props.icon ? '60px' : '10px' ) };`
+				: `padding: 13px ${ ( props ) => ( props.icon ? '60px' : '10px' ) } 11px 10px;` }
 		line-height: 1.2;
 	}
 

--- a/packages/composite-checkout/src/components/field.js
+++ b/packages/composite-checkout/src/components/field.js
@@ -4,7 +4,6 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
-import { useI18n } from '@automattic/react-i18n';
 
 /**
  * Internal dependencies
@@ -29,7 +28,6 @@ export default function Field( {
 	autoComplete,
 	disabled,
 } ) {
-	const { isRTL } = useI18n();
 	const fieldOnChange = ( event ) => {
 		if ( onChange ) {
 			onChange( event.target.value );
@@ -63,7 +61,6 @@ export default function Field( {
 					isError={ isError }
 					autoComplete={ autoComplete }
 					disabled={ disabled }
-					isRTL={ isRTL }
 				/>
 				<RenderedIcon icon={ icon } iconAction={ iconAction } isIconVisible={ isIconVisible } />
 			</InputWrapper>
@@ -119,11 +116,12 @@ const Input = styled.input`
 		border: 1px solid
 			${ ( props ) =>
 				props.isError ? props.theme.colors.error : props.theme.colors.borderColor };
-		${ ( props ) =>
-			props.isRTL
-				? `padding: 13px 10px 11px ${ props.icon ? '60px' : '10px' };`
-				: `padding: 13px ${ props.icon ? '60px' : '10px' } 11px 10px;` }
+		padding: 13px ${ ( props ) => ( props.icon ? '60px' : '10px' ) } 11px 10px;
 		line-height: 1.2;
+
+		.rtl & {
+			padding: 13px 10px 11px ${ ( props ) => ( props.icon ? '60px' : '10px' ) };
+		}
 	}
 
 	:focus {
@@ -165,12 +163,22 @@ const FieldIcon = styled.div`
 	top: 50%;
 	transform: translateY( -50% );
 	right: 10px;
+
+	.rtl & {
+		right: auto;
+		left: 10px;
+	}
 `;
 
 const ButtonIconUI = styled.div`
 	position: absolute;
 	top: 0;
 	right: 0;
+
+	.rtl & {
+		right: auto;
+		left: 0;
+	}
 
 	button {
 		border: 1px solid transparent;
@@ -188,7 +196,7 @@ const ButtonIconUI = styled.div`
 `;
 
 const Description = styled.p`
-	margin: 8px 0 0 0;
+	margin: 8px 0 0;
 	color: ${ ( props ) =>
 		props.isError ? props.theme.colors.error : props.theme.colors.textColorLight };
 	font-style: italic;

--- a/packages/composite-checkout/src/components/loading-content.js
+++ b/packages/composite-checkout/src/components/loading-content.js
@@ -7,25 +7,25 @@ import { keyframes } from '@emotion/core';
 import { useI18n } from '@automattic/react-i18n';
 
 export default function LoadingContent() {
-	const { __, isRTL } = useI18n();
+	const { __ } = useI18n();
 
 	return (
 		<LoadingContentWrapperUI>
 			<LoadingCard>
-				<LoadingTitle isRTL={ isRTL }>{ __( 'Loading checkout' ) }</LoadingTitle>
-				<LoadingCopy isRTL={ isRTL } />
-				<LoadingCopy isRTL={ isRTL } />
+				<LoadingTitle>{ __( 'Loading checkout' ) }</LoadingTitle>
+				<LoadingCopy />
+				<LoadingCopy />
 			</LoadingCard>
 			<LoadingCard>
-				<LoadingTitle isRTL={ isRTL } />
-				<LoadingCopy isRTL={ isRTL } />
-				<LoadingCopy isRTL={ isRTL } />
+				<LoadingTitle />
+				<LoadingCopy />
+				<LoadingCopy />
 			</LoadingCard>
 			<LoadingCard>
-				<LoadingTitle isRTL={ isRTL } />
+				<LoadingTitle />
 			</LoadingCard>
 			<LoadingCard>
-				<LoadingTitle isRTL={ isRTL } />
+				<LoadingTitle />
 			</LoadingCard>
 			<LoadingFooter />
 		</LoadingContentWrapperUI>
@@ -76,22 +76,31 @@ const LoadingTitle = styled.h1`
 	background: ${ ( props ) => props.theme.colors.borderColorLight };
 	color: ${ ( props ) => props.theme.colors.borderColorLight };
 	width: 40%;
-	margin: ${ ( props ) => ( props.isRTL ? '3px 35px 0 0' : '3px 0 0 35px' ) };
+	margin: 3px 0 0 35px;
 	padding: 0;
 	position: relative;
 	animation: ${ pulse } 2s ease-in-out infinite;
 	height: 20px;
 
+	.rtl & {
+		margin: 3px 35px 0 0;
+	}
+
 	:before {
 		content: '';
 		display: block;
 		position: absolute;
-		${ ( props ) => ( props.isRTL ? 'right: -35px;' : 'left: -35px;' ) }
+		left: -35px;
 		top: -3px;
 		width: 27px;
 		height: 27px;
 		background: ${ ( props ) => props.theme.colors.borderColorLight };
 		border-radius: 100%;
+
+		.rtl & {
+			right: -35px;
+			left: auto;
+		}
 	}
 `;
 const LoadingCopy = styled.p`
@@ -100,9 +109,13 @@ const LoadingCopy = styled.p`
 	content: '';
 	background: ${ ( props ) => props.theme.colors.borderColorLight };
 	color: ${ ( props ) => props.theme.colors.borderColorLight };
-	margin: ${ ( props ) => ( props.isRTL ? '8px 35px 0 0' : '8px 0 0 35px' ) };
+	margin: 8px 0 0 35px;
 	padding: 0;
 	animation: ${ pulse } 2s ease-in-out infinite;
+
+	.rtl & {
+		margin: 8px 35px 0 0;
+	}
 `;
 
 const LoadingFooter = styled.div`

--- a/packages/composite-checkout/src/components/loading-content.js
+++ b/packages/composite-checkout/src/components/loading-content.js
@@ -86,7 +86,7 @@ const LoadingTitle = styled.h1`
 		margin: 3px 35px 0 0;
 	}
 
-	:before {
+	::before {
 		content: '';
 		display: block;
 		position: absolute;
@@ -124,7 +124,7 @@ const LoadingFooter = styled.div`
 	border-top: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
 	padding: 24px;
 
-	:before {
+	::before {
 		content: '';
 		display: block;
 		border: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };

--- a/packages/composite-checkout/src/components/loading-content.js
+++ b/packages/composite-checkout/src/components/loading-content.js
@@ -7,25 +7,25 @@ import { keyframes } from '@emotion/core';
 import { useI18n } from '@automattic/react-i18n';
 
 export default function LoadingContent() {
-	const { __ } = useI18n();
+	const { __, isRTL } = useI18n();
 
 	return (
 		<LoadingContentWrapperUI>
 			<LoadingCard>
-				<LoadingTitle>{ __( 'Loading checkout' ) }</LoadingTitle>
-				<LoadingCopy />
-				<LoadingCopy />
+				<LoadingTitle isRTL={ isRTL }>{ __( 'Loading checkout' ) }</LoadingTitle>
+				<LoadingCopy isRTL={ isRTL } />
+				<LoadingCopy isRTL={ isRTL } />
 			</LoadingCard>
 			<LoadingCard>
-				<LoadingTitle />
-				<LoadingCopy />
-				<LoadingCopy />
+				<LoadingTitle isRTL={ isRTL } />
+				<LoadingCopy isRTL={ isRTL } />
+				<LoadingCopy isRTL={ isRTL } />
 			</LoadingCard>
 			<LoadingCard>
-				<LoadingTitle />
+				<LoadingTitle isRTL={ isRTL } />
 			</LoadingCard>
 			<LoadingCard>
-				<LoadingTitle />
+				<LoadingTitle isRTL={ isRTL } />
 			</LoadingCard>
 			<LoadingFooter />
 		</LoadingContentWrapperUI>
@@ -76,7 +76,7 @@ const LoadingTitle = styled.h1`
 	background: ${ ( props ) => props.theme.colors.borderColorLight };
 	color: ${ ( props ) => props.theme.colors.borderColorLight };
 	width: 40%;
-	margin: 3px 0 0 35px;
+	margin: ${ ( props ) => ( props.isRTL ? '3px 35px 0 0' : '3px 0 0 35px' ) };
 	padding: 0;
 	position: relative;
 	animation: ${ pulse } 2s ease-in-out infinite;
@@ -86,7 +86,7 @@ const LoadingTitle = styled.h1`
 		content: '';
 		display: block;
 		position: absolute;
-		left: -35px;
+		${ ( props ) => ( props.isRTL ? 'right: -35px;' : 'left: -35px;' ) }
 		top: -3px;
 		width: 27px;
 		height: 27px;
@@ -100,7 +100,7 @@ const LoadingCopy = styled.p`
 	content: '';
 	background: ${ ( props ) => props.theme.colors.borderColorLight };
 	color: ${ ( props ) => props.theme.colors.borderColorLight };
-	margin: 8px 0 0 35px;
+	margin: ${ ( props ) => ( props.isRTL ? '8px 35px 0 0' : '8px 0 0 35px' ) };
 	padding: 0;
 	animation: ${ pulse } 2s ease-in-out infinite;
 `;

--- a/packages/composite-checkout/src/components/payment-request-button.js
+++ b/packages/composite-checkout/src/components/payment-request-button.js
@@ -21,7 +21,7 @@ export default function PaymentRequestButton( {
 	disabled,
 	disabledReason,
 } ) {
-	const { __, isRTL } = useI18n();
+	const { __ } = useI18n();
 	const { formStatus, setFormReady, setFormSubmitting } = useFormStatus();
 	const onClick = ( event ) => {
 		event.persist();
@@ -50,7 +50,7 @@ export default function PaymentRequestButton( {
 	}
 
 	if ( paymentType === 'apple-pay' ) {
-		return <ApplePayButton disabled={ disabled } onClick={ onClick } isRTL={ isRTL } />;
+		return <ApplePayButton disabled={ disabled } onClick={ onClick } />;
 	}
 	return (
 		<Button disabled={ disabled } onClick={ onClick } fullWidth>
@@ -73,14 +73,19 @@ const ApplePayButton = styled.button`
 	width: 100%;
 	position: relative;
 
-	&::after {
+	&:after {
 		content: '';
 		position: ${ ( props ) => ( props.disabled ? 'absolute' : 'relative' ) };
 		top: 0;
-		${ ( props ) => ( props.isRTL ? 'right: 0;' : 'left: 0;' ) }
+		left: 0;
 		width: 100%;
 		height: 100%;
 		background-color: #ccc;
 		opacity: 0.7;
+
+		.rtl & {
+			right: 0;
+			left: auto;
+		}
 	}
 `;

--- a/packages/composite-checkout/src/components/payment-request-button.js
+++ b/packages/composite-checkout/src/components/payment-request-button.js
@@ -21,7 +21,7 @@ export default function PaymentRequestButton( {
 	disabled,
 	disabledReason,
 } ) {
-	const { __ } = useI18n();
+	const { __, isRTL } = useI18n();
 	const { formStatus, setFormReady, setFormSubmitting } = useFormStatus();
 	const onClick = ( event ) => {
 		event.persist();
@@ -50,7 +50,7 @@ export default function PaymentRequestButton( {
 	}
 
 	if ( paymentType === 'apple-pay' ) {
-		return <ApplePayButton disabled={ disabled } onClick={ onClick } />;
+		return <ApplePayButton disabled={ disabled } onClick={ onClick } isRTL={ isRTL } />;
 	}
 	return (
 		<Button disabled={ disabled } onClick={ onClick } fullWidth>
@@ -77,7 +77,7 @@ const ApplePayButton = styled.button`
 		content: '';
 		position: ${ ( props ) => ( props.disabled ? 'absolute' : 'relative' ) };
 		top: 0;
-		left: 0;
+		${ ( props ) => ( props.isRTL ? 'right: 0;' : 'left: 0;' ) }
 		width: 100%;
 		height: 100%;
 		background-color: #ccc;

--- a/packages/composite-checkout/src/components/payment-request-button.js
+++ b/packages/composite-checkout/src/components/payment-request-button.js
@@ -73,7 +73,7 @@ const ApplePayButton = styled.button`
 	width: 100%;
 	position: relative;
 
-	&:after {
+	&::after {
 		content: '';
 		position: ${ ( props ) => ( props.disabled ? 'absolute' : 'relative' ) };
 		top: 0;

--- a/packages/composite-checkout/src/components/radio-button.js
+++ b/packages/composite-checkout/src/components/radio-button.js
@@ -4,7 +4,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
-import { useI18n } from '@automattic/react-i18n';
 
 export default function RadioButton( {
 	checked,
@@ -18,15 +17,9 @@ export default function RadioButton( {
 	ariaLabel,
 } ) {
 	const [ isFocused, changeFocus ] = useState( false );
-	const { isRTL } = useI18n();
 
 	return (
-		<RadioButtonWrapper
-			disabled={ disabled }
-			isFocused={ isFocused }
-			checked={ checked }
-			isRTL={ isRTL }
-		>
+		<RadioButtonWrapper disabled={ disabled } isFocused={ isFocused } checked={ checked }>
 			<Radio
 				type="radio"
 				name={ name }
@@ -44,7 +37,7 @@ export default function RadioButton( {
 				readOnly={ ! onChange }
 				aria-label={ ariaLabel }
 			/>
-			<Label checked={ checked } htmlFor={ id } disabled={ disabled } isRTL={ isRTL }>
+			<Label checked={ checked } htmlFor={ id } disabled={ disabled }>
 				{ label }
 			</Label>
 			{ children && <RadioButtonChildren checked={ checked }>{ children }</RadioButtonChildren> }
@@ -81,11 +74,16 @@ const RadioButtonWrapper = styled.div`
 		height: 100%;
 		position: absolute;
 		top: 0;
-		${ ( props ) => ( props.isRTL ? 'right: 0;' : 'left: 0;' ) }
+		left: 0;
 		content: '';
 		border: ${ getBorderWidth } solid ${ getBorderColor };
 		border-radius: 3px;
 		box-sizing: border-box;
+
+		.rtl & {
+			right: 0;
+			left: auto;
+		}
 	}
 
 	:hover:before {
@@ -144,7 +142,7 @@ const Radio = styled.input`
 
 const Label = styled.label`
 	position: relative;
-	padding: ${ ( props ) => ( props.isRTL ? '16px 40px 16px 14px;' : '16px 14px 16px 40px;' ) }
+	padding: 16px 14px 16px 40px;
 	border-radius: 3px;
 	box-sizing: border-box;
 	width: 100%;
@@ -153,6 +151,10 @@ const Label = styled.label`
 	justify-content: space-between;
 	align-items: flex-start;
 	font-size: 14px;
+
+	.rtl & {
+		padding: 16px 40px 16px 14px;
+	}
 
 	:hover {
 		cursor: pointer;
@@ -166,11 +168,16 @@ const Label = styled.label`
 		border: 1px solid ${ ( props ) => props.theme.colors.borderColor };
 		border-radius: 100%;
 		top: 19px;
-		${ ( props ) => ( props.isRTL ? 'right: 16px;' : 'left: 16px;' ) }
+		left: 16px;
 		position: absolute;
 		background: ${ ( props ) => props.theme.colors.surface };
 		box-sizing: border-box;
 		z-index: 2;
+
+		.rtl & {
+			right: 16px;
+			left: auto;
+		}
 	}
 
 	:after {
@@ -180,11 +187,16 @@ const Label = styled.label`
 		content: '';
 		border-radius: 100%;
 		top: 23px;
-		${ ( props ) => ( props.isRTL ? 'right: 20px;' : 'left: 20px;' ) }
+		left: 20px;
 		position: absolute;
 		background: ${ getRadioColor };
 		box-sizing: border-box;
 		z-index: 3;
+
+		.rtl & {
+			right: 20px;
+			left: auto;
+		}
 	}
 
 	${ handleLabelDisabled };
@@ -198,20 +210,20 @@ function handleLabelDisabled( { disabled } ) {
 	return `
 		color: lightgray;
 		font-style: italic;
-		
+
 		:hover {
 			cursor: default;
 		}
-		
+
 		:before {
 			border: 1px solid lightgray;
 			background: lightgray;
 		}
-		
+
 		:after {
 			background: white;
 		}
-		
+
 		span {
 			color: lightgray;
 		}

--- a/packages/composite-checkout/src/components/radio-button.js
+++ b/packages/composite-checkout/src/components/radio-button.js
@@ -4,6 +4,7 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
+import { useI18n } from '@automattic/react-i18n';
 
 export default function RadioButton( {
 	checked,
@@ -17,9 +18,15 @@ export default function RadioButton( {
 	ariaLabel,
 } ) {
 	const [ isFocused, changeFocus ] = useState( false );
+	const { isRTL } = useI18n();
 
 	return (
-		<RadioButtonWrapper disabled={ disabled } isFocused={ isFocused } checked={ checked }>
+		<RadioButtonWrapper
+			disabled={ disabled }
+			isFocused={ isFocused }
+			checked={ checked }
+			isRTL={ isRTL }
+		>
 			<Radio
 				type="radio"
 				name={ name }
@@ -37,7 +44,7 @@ export default function RadioButton( {
 				readOnly={ ! onChange }
 				aria-label={ ariaLabel }
 			/>
-			<Label checked={ checked } htmlFor={ id } disabled={ disabled }>
+			<Label checked={ checked } htmlFor={ id } disabled={ disabled } isRTL={ isRTL }>
 				{ label }
 			</Label>
 			{ children && <RadioButtonChildren checked={ checked }>{ children }</RadioButtonChildren> }
@@ -74,7 +81,7 @@ const RadioButtonWrapper = styled.div`
 		height: 100%;
 		position: absolute;
 		top: 0;
-		left: 0;
+		${ ( props ) => ( props.isRTL ? 'right: 0;' : 'left: 0;' ) }
 		content: '';
 		border: ${ getBorderWidth } solid ${ getBorderColor };
 		border-radius: 3px;
@@ -137,7 +144,7 @@ const Radio = styled.input`
 
 const Label = styled.label`
 	position: relative;
-	padding: 16px 14px 16px 40px;
+	padding: ${ ( props ) => ( props.isRTL ? '16px 40px 16px 14px;' : '16px 14px 16px 40px;' ) }
 	border-radius: 3px;
 	box-sizing: border-box;
 	width: 100%;
@@ -159,7 +166,7 @@ const Label = styled.label`
 		border: 1px solid ${ ( props ) => props.theme.colors.borderColor };
 		border-radius: 100%;
 		top: 19px;
-		left: 16px;
+		${ ( props ) => ( props.isRTL ? 'right: 16px;' : 'left: 16px;' ) }
 		position: absolute;
 		background: ${ ( props ) => props.theme.colors.surface };
 		box-sizing: border-box;
@@ -173,7 +180,7 @@ const Label = styled.label`
 		content: '';
 		border-radius: 100%;
 		top: 23px;
-		left: 20px;
+		${ ( props ) => ( props.isRTL ? 'right: 20px;' : 'left: 20px;' ) }
 		position: absolute;
 		background: ${ getRadioColor };
 		box-sizing: border-box;

--- a/packages/composite-checkout/src/components/radio-button.js
+++ b/packages/composite-checkout/src/components/radio-button.js
@@ -68,7 +68,7 @@ const RadioButtonWrapper = styled.div`
 		margin: 0;
 	}
 
-	:before {
+	::before {
 		display: block;
 		width: 100%;
 		height: 100%;
@@ -86,7 +86,7 @@ const RadioButtonWrapper = styled.div`
 		}
 	}
 
-	:hover:before {
+	:hover::before {
 		border: 3px solid ${ ( props ) => props.theme.colors.highlight };
 	}
 
@@ -122,8 +122,8 @@ function handleWrapperDisabled( { disabled } ) {
 	}
 
 	return `
-		:before,
-		:hover:before {
+		::before,
+		:hover::before {
 			border: 1px solid lightgray;
 		}
 
@@ -160,7 +160,7 @@ const Label = styled.label`
 		cursor: pointer;
 	}
 
-	:before {
+	::before {
 		display: block;
 		width: 16px;
 		height: 16px;
@@ -180,7 +180,7 @@ const Label = styled.label`
 		}
 	}
 
-	:after {
+	::after {
 		display: block;
 		width: 8px;
 		height: 8px;
@@ -215,12 +215,12 @@ function handleLabelDisabled( { disabled } ) {
 			cursor: default;
 		}
 
-		:before {
+		::before {
 			border: 1px solid lightgray;
 			background: lightgray;
 		}
 
-		:after {
+		::after {
 			background: white;
 		}
 

--- a/packages/composite-checkout/src/components/spinner.js
+++ b/packages/composite-checkout/src/components/spinner.js
@@ -4,11 +4,9 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import { keyframes } from '@emotion/core';
-import { useI18n } from '@automattic/react-i18n';
 
 export default function Spinner( { className } ) {
-	const { isRTL } = useI18n();
-	return <SpinnerWrapper className={ className } isRTL={ isRTL } />;
+	return <SpinnerWrapper className={ className } />;
 }
 
 const rotate = keyframes`
@@ -32,7 +30,7 @@ const SpinnerWrapper = styled.div`
 	:after {
 		position: absolute;
 		top: 0;
-		${ ( props ) => ( props.isRTL ? 'right: -1px;' : 'left: -1px;' ) }
+		left: -1px;
 		width: 17px;
 		height: 17px;
 		border: 3px solid transparent;
@@ -44,5 +42,10 @@ const SpinnerWrapper = styled.div`
 		border-radius: 100%;
 		animation: ${ rotate } 3s linear infinite;
 		animation-fill-mode: backwards;
+
+		.rtl & {
+			right: -1px;
+			left: auto;
+		}
 	}
 `;

--- a/packages/composite-checkout/src/components/spinner.js
+++ b/packages/composite-checkout/src/components/spinner.js
@@ -27,7 +27,7 @@ const SpinnerWrapper = styled.div`
 	animation: ${ rotate } 3s linear infinite;
 	animation-fill-mode: backwards;
 
-	:after {
+	::after {
 		position: absolute;
 		top: 0;
 		left: -1px;

--- a/packages/composite-checkout/src/components/spinner.js
+++ b/packages/composite-checkout/src/components/spinner.js
@@ -44,6 +44,8 @@ const SpinnerWrapper = styled.div`
 		animation-fill-mode: backwards;
 
 		.rtl & {
+			border-right-color: transparent;
+			border-left-color: ${ ( props ) => props.theme.colors.highlight };
 			right: -1px;
 			left: auto;
 		}

--- a/packages/composite-checkout/src/components/spinner.js
+++ b/packages/composite-checkout/src/components/spinner.js
@@ -4,9 +4,11 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import { keyframes } from '@emotion/core';
+import { useI18n } from '@automattic/react-i18n';
 
 export default function Spinner( { className } ) {
-	return <SpinnerWrapper className={ className } />;
+	const { isRTL } = useI18n();
+	return <SpinnerWrapper className={ className } isRTL={ isRTL } />;
 }
 
 const rotate = keyframes`
@@ -30,7 +32,7 @@ const SpinnerWrapper = styled.div`
 	:after {
 		position: absolute;
 		top: 0;
-		left: -1px;
+		${ ( props ) => ( props.isRTL ? 'right: -1px;' : 'left: -1px;' ) }
 		width: 17px;
 		height: 17px;
 		border: 3px solid transparent;

--- a/packages/composite-checkout/src/lib/payment-methods/apple-pay.js
+++ b/packages/composite-checkout/src/lib/payment-methods/apple-pay.js
@@ -32,12 +32,12 @@ export function createApplePayMethod( stripe, stripeConfiguration ) {
 }
 
 export function ApplePayLabel() {
-	const { __, isRTL } = useI18n();
+	const { __ } = useI18n();
 
 	return (
 		<React.Fragment>
 			<span>{ __( 'Apple Pay' ) }</span>
-			<PaymentMethodLogos className="apple-pay__logo payment-logos" isRTL={ isRTL }>
+			<PaymentMethodLogos className="apple-pay__logo payment-logos">
 				<ApplePayIcon fill="black" />
 			</PaymentMethodLogos>
 		</React.Fragment>

--- a/packages/composite-checkout/src/lib/payment-methods/apple-pay.js
+++ b/packages/composite-checkout/src/lib/payment-methods/apple-pay.js
@@ -32,12 +32,12 @@ export function createApplePayMethod( stripe, stripeConfiguration ) {
 }
 
 export function ApplePayLabel() {
-	const { __ } = useI18n();
+	const { __, isRTL } = useI18n();
 
 	return (
 		<React.Fragment>
 			<span>{ __( 'Apple Pay' ) }</span>
-			<PaymentMethodLogos className="apple-pay__logo payment-logos">
+			<PaymentMethodLogos className="apple-pay__logo payment-logos" isRTL={ isRTL }>
 				<ApplePayIcon fill="black" />
 			</PaymentMethodLogos>
 		</React.Fragment>

--- a/packages/composite-checkout/src/lib/payment-methods/existing-credit-card.js
+++ b/packages/composite-checkout/src/lib/payment-methods/existing-credit-card.js
@@ -87,9 +87,9 @@ function formatDate( cardExpiry ) {
 }
 
 export function ExistingCardLabel( { last4, cardExpiry, cardholderName, brand } ) {
-	const { __ } = useI18n();
+	const { __, _x } = useI18n();
 
-	const maskedCardDetails = sprintf( __( '**** %s' ), last4 );
+	const maskedCardDetails = sprintf( _x( '**** %s', 'Masked credit card number' ), last4 );
 
 	return (
 		<React.Fragment>
@@ -219,9 +219,9 @@ function ButtonContents( { formStatus, total } ) {
 }
 
 function ExistingCardSummary( { cardholderName, cardExpiry, brand, last4 } ) {
-	const { __ } = useI18n();
+	const { __, _x } = useI18n();
 
-	const maskedCardDetails = '****'.concat( last4 );
+	const maskedCardDetails = sprintf( _x( '**** %s', 'Masked credit card number' ), last4 );
 
 	return (
 		<SummaryDetails>

--- a/packages/composite-checkout/src/lib/payment-methods/existing-credit-card.js
+++ b/packages/composite-checkout/src/lib/payment-methods/existing-credit-card.js
@@ -221,7 +221,7 @@ function ButtonContents( { formStatus, total } ) {
 function ExistingCardSummary( { cardholderName, cardExpiry, brand, last4 } ) {
 	const { __, isRTL } = useI18n();
 
-	const maskedCardDetails = '****&nbsp;'.last4;
+	const maskedCardDetails = '****'.concat( last4 );
 
 	return (
 		<SummaryDetails>

--- a/packages/composite-checkout/src/lib/payment-methods/existing-credit-card.js
+++ b/packages/composite-checkout/src/lib/payment-methods/existing-credit-card.js
@@ -87,7 +87,7 @@ function formatDate( cardExpiry ) {
 }
 
 export function ExistingCardLabel( { last4, cardExpiry, cardholderName, brand } ) {
-	const { __, isRTL } = useI18n();
+	const { __ } = useI18n();
 
 	const maskedCardDetails = sprintf( __( '**** %s' ), last4 );
 
@@ -95,7 +95,7 @@ export function ExistingCardLabel( { last4, cardExpiry, cardholderName, brand } 
 		<React.Fragment>
 			<div>
 				<CardHolderName>{ cardholderName }</CardHolderName>
-				<CardDetails isRTL={ isRTL }>{ maskedCardDetails }</CardDetails>
+				<CardDetails>{ maskedCardDetails }</CardDetails>
 				<span>{ `${ __( 'Expiry:' ) } ${ formatDate( cardExpiry ) }` }</span>
 			</div>
 			<div>
@@ -219,7 +219,7 @@ function ButtonContents( { formStatus, total } ) {
 }
 
 function ExistingCardSummary( { cardholderName, cardExpiry, brand, last4 } ) {
-	const { __, isRTL } = useI18n();
+	const { __ } = useI18n();
 
 	const maskedCardDetails = '****'.concat( last4 );
 
@@ -228,7 +228,7 @@ function ExistingCardSummary( { cardholderName, cardExpiry, brand, last4 } ) {
 			<SummaryLine>{ cardholderName }</SummaryLine>
 			<SummaryLine>
 				<PaymentLogo brand={ brand } isSummary={ true } />
-				<CardDetails isRTL={ isRTL }>{ maskedCardDetails }</CardDetails>
+				<CardDetails>{ maskedCardDetails }</CardDetails>
 				<span>{ `${ __( 'Expiry:' ) } ${ formatDate( cardExpiry ) }` }</span>
 			</SummaryLine>
 		</SummaryDetails>
@@ -237,5 +237,10 @@ function ExistingCardSummary( { cardholderName, cardExpiry, brand, last4 } ) {
 
 const CardDetails = styled.span`
 	display: inline-block;
-	${ ( props ) => ( props.isRTL ? 'margin-left: 8px;' : 'margin-right: 8px;' ) }
+	margin-right: 8px;
+
+	.rtl & {
+		margin-right: 0;
+		margin-left: 8px;
+	}
 `;

--- a/packages/composite-checkout/src/lib/payment-methods/existing-credit-card.js
+++ b/packages/composite-checkout/src/lib/payment-methods/existing-credit-card.js
@@ -87,14 +87,16 @@ function formatDate( cardExpiry ) {
 }
 
 export function ExistingCardLabel( { last4, cardExpiry, cardholderName, brand } ) {
-	const { __ } = useI18n();
+	const { __, isRTL } = useI18n();
+
+	const maskedCardDetails = sprintf( __( '**** %s' ), last4 );
 
 	return (
 		<React.Fragment>
 			<div>
 				<CardHolderName>{ cardholderName }</CardHolderName>
-				<CardDetails>**** { last4 }</CardDetails>
-				{ `${ __( 'Expiry:' ) }  ${ formatDate( cardExpiry ) }` }
+				<CardDetails isRTL={ isRTL }>{ maskedCardDetails }</CardDetails>
+				<span>{ `${ __( 'Expiry:' ) } ${ formatDate( cardExpiry ) }` }</span>
 			</div>
 			<div>
 				<PaymentLogo brand={ brand } isSummary={ true } />
@@ -217,20 +219,23 @@ function ButtonContents( { formStatus, total } ) {
 }
 
 function ExistingCardSummary( { cardholderName, cardExpiry, brand, last4 } ) {
-	const { __ } = useI18n();
+	const { __, isRTL } = useI18n();
+
+	const maskedCardDetails = '****&nbsp;'.last4;
 
 	return (
 		<SummaryDetails>
 			<SummaryLine>{ cardholderName }</SummaryLine>
 			<SummaryLine>
 				<PaymentLogo brand={ brand } isSummary={ true } />
-				<CardDetails>**** { last4 }</CardDetails>
-				{ `${ __( 'Expiry:' ) } ${ formatDate( cardExpiry ) }` }
+				<CardDetails isRTL={ isRTL }>{ maskedCardDetails }</CardDetails>
+				<span>{ `${ __( 'Expiry:' ) } ${ formatDate( cardExpiry ) }` }</span>
 			</SummaryLine>
 		</SummaryDetails>
 	);
 }
 
 const CardDetails = styled.span`
-	margin-right: 8px;
+	display: inline-block;
+	${ ( props ) => ( props.isRTL ? 'margin-left: 8px;' : 'margin-right: 8px;' ) }
 `;

--- a/packages/composite-checkout/src/lib/payment-methods/giropay.js
+++ b/packages/composite-checkout/src/lib/payment-methods/giropay.js
@@ -115,6 +115,11 @@ const GiropayFormWrapper = styled.div`
 		position: absolute;
 		top: 0;
 		left: 3px;
+
+		.rtl & {
+			right: 3px;
+			left: auto;
+		}
 	}
 `;
 

--- a/packages/composite-checkout/src/lib/payment-methods/ideal.js
+++ b/packages/composite-checkout/src/lib/payment-methods/ideal.js
@@ -169,7 +169,7 @@ const IdealFormWrapper = styled.div`
 	padding: 16px;
 	position: relative;
 
-	:after {
+	::after {
 		display: block;
 		width: calc( 100% - 6px );
 		height: 1px;

--- a/packages/composite-checkout/src/lib/payment-methods/ideal.js
+++ b/packages/composite-checkout/src/lib/payment-methods/ideal.js
@@ -87,7 +87,7 @@ export function createIdealMethod( { store, stripe, stripeConfiguration } ) {
 }
 
 function IdealFields() {
-	const { __, isRTL } = useI18n();
+	const { __ } = useI18n();
 
 	const customerName = useSelect( ( select ) => select( 'ideal' ).getCustomerName() );
 	const customerBank = useSelect( ( select ) => select( 'ideal' ).getCustomerBank() );
@@ -96,7 +96,7 @@ function IdealFields() {
 	const isDisabled = formStatus !== 'ready';
 
 	return (
-		<IdealFormWrapper isRTL={ isRTL }>
+		<IdealFormWrapper>
 			<IdealField
 				id="cardholderName"
 				type="Text"
@@ -158,7 +158,7 @@ function ErrorMessage( { isError, errorMessage } ) {
 }
 
 const Description = styled.p`
-	margin: 8px 0 0 0;
+	margin: 8px 0 0;
 	color: ${ ( props ) =>
 		props.isError ? props.theme.colors.error : props.theme.colors.textColorLight };
 	font-style: italic;
@@ -177,7 +177,12 @@ const IdealFormWrapper = styled.div`
 		background: ${ ( props ) => props.theme.colors.borderColorLight };
 		position: absolute;
 		top: 0;
-		${ ( props ) => ( props.isRTL ? 'right: 3px;' : 'left: 3px;' ) }
+		left: 3px;
+
+		.rtl & {
+			right: 3px;
+			left: auto;
+		}
 	}
 `;
 
@@ -295,11 +300,11 @@ function isFormValid( store ) {
 }
 
 function IdealLabel() {
-	const { __, isRTL } = useI18n();
+	const { __ } = useI18n();
 	return (
 		<React.Fragment>
 			<span>{ __( 'iDEAL' ) }</span>
-			<PaymentMethodLogos className="ideal__logo payment-logos" isRTL={ isRTL }>
+			<PaymentMethodLogos className="ideal__logo payment-logos">
 				<IdealLogoUI />
 			</PaymentMethodLogos>
 		</React.Fragment>

--- a/packages/composite-checkout/src/lib/payment-methods/ideal.js
+++ b/packages/composite-checkout/src/lib/payment-methods/ideal.js
@@ -87,7 +87,7 @@ export function createIdealMethod( { store, stripe, stripeConfiguration } ) {
 }
 
 function IdealFields() {
-	const { __ } = useI18n();
+	const { __, isRTL } = useI18n();
 
 	const customerName = useSelect( ( select ) => select( 'ideal' ).getCustomerName() );
 	const customerBank = useSelect( ( select ) => select( 'ideal' ).getCustomerBank() );
@@ -96,7 +96,7 @@ function IdealFields() {
 	const isDisabled = formStatus !== 'ready';
 
 	return (
-		<IdealFormWrapper>
+		<IdealFormWrapper isRTL={ isRTL }>
 			<IdealField
 				id="cardholderName"
 				type="Text"
@@ -177,7 +177,7 @@ const IdealFormWrapper = styled.div`
 		background: ${ ( props ) => props.theme.colors.borderColorLight };
 		position: absolute;
 		top: 0;
-		left: 3px;
+		${ ( props ) => ( props.isRTL ? 'right: 3px;' : 'left: 3px;' ) }
 	}
 `;
 
@@ -295,11 +295,11 @@ function isFormValid( store ) {
 }
 
 function IdealLabel() {
-	const { __ } = useI18n();
+	const { __, isRTL } = useI18n();
 	return (
 		<React.Fragment>
 			<span>{ __( 'iDEAL' ) }</span>
-			<PaymentMethodLogos className="ideal__logo payment-logos">
+			<PaymentMethodLogos className="ideal__logo payment-logos" isRTL={ isRTL }>
 				<IdealLogoUI />
 			</PaymentMethodLogos>
 		</React.Fragment>

--- a/packages/composite-checkout/src/lib/payment-methods/payment-logo.js
+++ b/packages/composite-checkout/src/lib/payment-methods/payment-logo.js
@@ -106,6 +106,10 @@ const LockIconGraphic = styled( LockIcon )`
 
 const SmallBrandLogo = styled( BrandLogo )`
 	transform: translate( ${ ( props ) => ( props.isSummary ? '-10px, 4px' : '10px, 0' ) } );
+
+	.rtl & {
+		transform: translate( ${ ( props ) => ( props.isSummary ? '10px, 4px' : '-10px, 0' ) } );
+	}
 `;
 
 function LockIcon( { className } ) {

--- a/packages/composite-checkout/src/lib/payment-methods/payment-logo.js
+++ b/packages/composite-checkout/src/lib/payment-methods/payment-logo.js
@@ -83,6 +83,11 @@ const BrandLogo = styled.span`
 	top: ${ ( props ) => ( props.isSummary ? '0' : '15px' ) };
 	right: ${ ( props ) => ( props.isSummary ? '0' : '10px' ) };
 	transform: translateY( ${ ( props ) => ( props.isSummary ? '4px' : '0' ) } );
+
+	.rtl & {
+		right: auto;
+		left: ${ ( props ) => ( props.isSummary ? '0' : '10px' ) };
+	}
 `;
 
 const LockIconGraphic = styled( LockIcon )`
@@ -92,6 +97,11 @@ const LockIconGraphic = styled( LockIcon )`
 	top: 14px;
 	width: 20px;
 	height: 20px;
+
+	.rtl & {
+		right: auto;
+		left: 10px;
+	}
 `;
 
 const SmallBrandLogo = styled( BrandLogo )`

--- a/packages/composite-checkout/src/lib/payment-methods/paypal.js
+++ b/packages/composite-checkout/src/lib/payment-methods/paypal.js
@@ -33,12 +33,12 @@ export function createPayPalMethod() {
 }
 
 export function PaypalLabel() {
-	const { __, isRTL } = useI18n();
+	const { __ } = useI18n();
 
 	return (
 		<React.Fragment>
 			<span>{ __( 'PayPal' ) }</span>
-			<PaymentMethodLogos className="paypal__logo payment-logos" isRTL={ isRTL }>
+			<PaymentMethodLogos className="paypal__logo payment-logos">
 				<PaypalLogo />
 			</PaymentMethodLogos>
 		</React.Fragment>

--- a/packages/composite-checkout/src/lib/payment-methods/paypal.js
+++ b/packages/composite-checkout/src/lib/payment-methods/paypal.js
@@ -33,12 +33,12 @@ export function createPayPalMethod() {
 }
 
 export function PaypalLabel() {
-	const { __ } = useI18n();
+	const { __, isRTL } = useI18n();
 
 	return (
 		<React.Fragment>
 			<span>{ __( 'PayPal' ) }</span>
-			<PaymentMethodLogos className="paypal__logo payment-logos">
+			<PaymentMethodLogos className="paypal__logo payment-logos" isRTL={ isRTL }>
 				<PaypalLogo />
 			</PaymentMethodLogos>
 		</React.Fragment>

--- a/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
@@ -286,7 +286,7 @@ const CreditCardFieldsWrapper = styled.div`
 	display: ${ ( props ) => ( props.isLoaded ? 'block' : 'none' ) };
 	position: relative;
 
-	:after {
+	::after {
 		display: block;
 		width: calc( 100% - 6px );
 		height: 1px;

--- a/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
@@ -294,13 +294,13 @@ const CreditCardFieldsWrapper = styled.div`
 		background: ${ ( props ) => props.theme.colors.borderColorLight };
 		position: absolute;
 		top: 0;
-		left: 3px;
+		${ ( props ) => ( props.isRtl ? 'right: 3px;' : 'left: 3px' ) };
 	}
 `;
 
 const LoadingIndicator = styled( Spinner )`
 	position: absolute;
-	right: 15px;
+	${ ( props ) => ( props.isRTL ? 'left: 15px;' : 'right: 15px;' ) }
 	top: 10px;
 `;
 
@@ -367,9 +367,11 @@ const StripeErrorMessage = styled.span`
 `;
 
 function LoadingFields() {
+	const { isRTL } = useI18n();
+
 	return (
 		<React.Fragment>
-			<LoadingIndicator />
+			<LoadingIndicator isRTL={ isRTL } />
 			<CreditCardLoading />
 		</React.Fragment>
 	);
@@ -527,9 +529,10 @@ function CreditCardLabel() {
 
 function CreditCardLogos() {
 	//TODO: Determine which logos to show
+	const { isRTL } = useI18n();
 
 	return (
-		<PaymentMethodLogos>
+		<PaymentMethodLogos isRTL={ isRTL }>
 			<VisaLogo />
 			<MastercardLogo />
 			<AmexLogo />
@@ -538,10 +541,10 @@ function CreditCardLogos() {
 }
 
 function CreditCardLoading() {
-	const { __ } = useI18n();
+	const { __, isRTL } = useI18n();
 
 	return (
-		<CreditCardFieldsWrapper isLoaded={ true }>
+		<CreditCardFieldsWrapper isLoaded={ true } isRTL={ isRTL }>
 			<CreditCardField
 				id="credit-card-number"
 				type="Number"

--- a/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
@@ -294,14 +294,24 @@ const CreditCardFieldsWrapper = styled.div`
 		background: ${ ( props ) => props.theme.colors.borderColorLight };
 		position: absolute;
 		top: 0;
-		${ ( props ) => ( props.isRtl ? 'right: 3px;' : 'left: 3px' ) };
+		left: 3px;
+
+		.rtl & {
+			right: 3px;
+			left: auto;
+		}
 	}
 `;
 
 const LoadingIndicator = styled( Spinner )`
 	position: absolute;
-	${ ( props ) => ( props.isRTL ? 'left: 15px;' : 'right: 15px;' ) }
+	right: 15px;
 	top: 10px;
+
+	.rtl & {
+		right: auto;
+		left: 15px;
+	}
 `;
 
 const CreditCardField = styled( Field )`
@@ -367,11 +377,9 @@ const StripeErrorMessage = styled.span`
 `;
 
 function LoadingFields() {
-	const { isRTL } = useI18n();
-
 	return (
 		<React.Fragment>
-			<LoadingIndicator isRTL={ isRTL } />
+			<LoadingIndicator />
 			<CreditCardLoading />
 		</React.Fragment>
 	);
@@ -529,10 +537,8 @@ function CreditCardLabel() {
 
 function CreditCardLogos() {
 	//TODO: Determine which logos to show
-	const { isRTL } = useI18n();
-
 	return (
-		<PaymentMethodLogos isRTL={ isRTL }>
+		<PaymentMethodLogos>
 			<VisaLogo />
 			<MastercardLogo />
 			<AmexLogo />
@@ -541,10 +547,10 @@ function CreditCardLogos() {
 }
 
 function CreditCardLoading() {
-	const { __, isRTL } = useI18n();
+	const { __ } = useI18n();
 
 	return (
-		<CreditCardFieldsWrapper isLoaded={ true } isRTL={ isRTL }>
+		<CreditCardFieldsWrapper isLoaded={ true }>
 			<CreditCardField
 				id="credit-card-number"
 				type="Number"

--- a/packages/composite-checkout/src/lib/styled-components/payment-method-logos.js
+++ b/packages/composite-checkout/src/lib/styled-components/payment-method-logos.js
@@ -5,8 +5,12 @@ import styled from '@emotion/styled';
 
 export const PaymentMethodLogos = styled.span`
 	flex: 1;
-	${ ( props ) => ( props.isRTL ? 'text-align: left;' : 'text-align: right;' ) }
 	transform: translateY( 3px );
+	text-align: right;
+
+	.rtl & {
+		text-align: left;
+	}
 
 	svg {
 		display: inline-block;

--- a/packages/composite-checkout/src/lib/styled-components/payment-method-logos.js
+++ b/packages/composite-checkout/src/lib/styled-components/payment-method-logos.js
@@ -5,7 +5,7 @@ import styled from '@emotion/styled';
 
 export const PaymentMethodLogos = styled.span`
 	flex: 1;
-	text-align: right;
+	${ ( props ) => ( props.isRTL ? 'text-align: left;' : 'text-align: right;' ) }
 	transform: translateY( 3px );
 
 	svg {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This adds RTL styles to `@automattic/composite-checkout` and its Calypso integration layer. There's discussion about using a [stylis plugin](https://github.com/emotion-js/emotion/issues/793) to automate RTL conversion for emotion styled components, but this PR just does it manually.

<img width="1256" alt="Screen Shot 2020-06-24 at 9 29 50 AM" src="https://user-images.githubusercontent.com/942359/85565582-478d0900-b5fd-11ea-98b7-5841d2bd904f.png">

#### Testing instructions

* If you're not already using local calypso in an RTL mode: in your `config/development.json`, change the line `"rtl": false,` to `"rtl": true,` and set your language in `me/account` to an RTL language such as Hebrew or Arabic. See also https://github.com/Automattic/wp-calypso/blob/master/docs/rtl.md
* Visit Checkout with a number of items in your cart (bundled, not bundled, renewals, etc.) using `?flags=composite-checkout-force`
* Click around the interface and verify that RTL styles are applied. Note spacing/padding between elements, icon alignment, text alignment, one-sided borders, etc. Add/remove coupons, remove items (to check the modal).
* Repeat using mobile styles
