### PR TITLE
Jetpack section: set brand font to headers in the Automated Transfer page

### DIFF
--- a/client/components/jetpack/wpcom-business-at/index.tsx
+++ b/client/components/jetpack/wpcom-business-at/index.tsx
@@ -219,6 +219,7 @@ export default function WPCOMBusinessAT( { product }: Props ): ReactElement {
 				className="wpcom-business-at__header"
 				headerText={ content.header }
 				align="left"
+				brandFont
 			/>
 			<BlockingHoldNotice siteId={ siteId } product={ product } />
 			<TransferFailureNotice product={ product } transferStatus={ automatedTransferStatus } />
@@ -245,6 +246,7 @@ export default function WPCOMBusinessAT( { product }: Props ): ReactElement {
 				headerText={ translate( 'Also included in the Business Plan' ) }
 				align="left"
 				isSecondary
+				brandFont
 			/>
 
 			<PromoCard


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Set our brand font to all headers in the Automated Transfer page.

#### Testing instructions

Prerequisite: non-Atomic Business plan site.
* Run this PR with the `jetpack/features-section` flag enabled.
* Go to Jetpack > Backup.
* Verify that you see headers configured with the right font.

Fixes 1179060693083348-as-1181410879631281

#### Demo
##### Before
![image](https://user-images.githubusercontent.com/3418513/85318218-f9112a80-b495-11ea-94f9-b5d2cf8a6988.png)

##### After
![image](https://user-images.githubusercontent.com/3418513/85318115-d2eb8a80-b495-11ea-8e10-f89c218e096d.png)
