### PR TITLE
Jetpack Cloud: Make the header for connxn info clickable to expand

### DIFF
--- a/client/landing/jetpack-cloud/sections/settings/main.jsx
+++ b/client/landing/jetpack-cloud/sections/settings/main.jsx
@@ -99,6 +99,7 @@ const SettingsPage = () => {
 			{ ! isInitialized && <div className="settings__form-uninitialized" /> }
 			{ isInitialized && (
 				<FoldableCard
+					clickableHeader
 					header={
 						formOpen
 							? translate( 'Hide connection details' )


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add the `clickableHeader` property to the **Show connection details** header in the Settings section on Jetpack.com, to make the entire header clickable to expand the connection details menu.

#### Testing instructions

* Open the Jetpack.com interface to the Settings page.
* Verify that you can click anywhere along the span of the "Show/hide connection details" header, including the arrow on the right, to expand or collapse the section.

#### Screen capture

![connxn-details-header](https://user-images.githubusercontent.com/670067/85324570-b3516380-b48f-11ea-9a7b-59a6b1f6aa9a.gif)
