### PR TITLE
Editor: Revert the switch to classic redirect to wpadmin

### DIFF
--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -41,7 +41,6 @@ import { getEditedPostValue } from 'state/posts/selectors';
 import QueryActiveTheme from 'components/data/query-active-theme';
 import isGutenbergOptInEnabled from 'state/selectors/is-gutenberg-opt-in-enabled';
 import isGutenbergOptOutEnabled from 'state/selectors/is-gutenberg-opt-out-enabled';
-import { isEnabled } from 'config';
 
 class InlineHelpPopover extends Component {
 	static propTypes = {

--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -41,7 +41,6 @@ import { getEditedPostValue } from 'state/posts/selectors';
 import QueryActiveTheme from 'components/data/query-active-theme';
 import isGutenbergOptInEnabled from 'state/selectors/is-gutenberg-opt-in-enabled';
 import isGutenbergOptOutEnabled from 'state/selectors/is-gutenberg-opt-out-enabled';
-import getWpAdminClassicEditorRedirectionUrl from 'state/selectors/get-wp-admin-classic-editor-redirection-url';
 import { isEnabled } from 'config';
 
 class InlineHelpPopover extends Component {
@@ -292,9 +291,7 @@ const optIn = ( siteId, gutenbergUrl ) => {
 function mapStateToProps( state ) {
 	const siteId = getSelectedSiteId( state );
 	const currentRoute = getCurrentRoute( state );
-	const classicUrl = isEnabled( 'editor/after-deprecation' )
-		? getWpAdminClassicEditorRedirectionUrl( state, siteId )
-		: `/${ currentRoute.replace( '/block-editor/', '' ) }`;
+	const classicRoute = currentRoute.replace( '/block-editor/', '' );
 	const section = getSection( state );
 	const isCalypsoClassic = section.group && section.group === 'editor';
 	const optInEnabled = isGutenbergOptInEnabled( state, siteId );
@@ -308,7 +305,7 @@ function mapStateToProps( state ) {
 		isEligibleForChecklist: isEligibleForDotcomChecklist( state, siteId ),
 		selectedSite: getHelpSelectedSite( state ),
 		selectedResult: getInlineHelpCurrentlySelectedResult( state ),
-		classicUrl,
+		classicUrl: `/${ classicRoute }`,
 		siteId,
 		showOptOut: showSwitchEditorButton && isGutenbergOptOutEnabled( state, siteId ),
 		showOptIn: showSwitchEditorButton && optInEnabled && isCalypsoClassic,

--- a/client/state/data-layer/wpcom/sites/gutenberg/index.js
+++ b/client/state/data-layer/wpcom/sites/gutenberg/index.js
@@ -3,7 +3,6 @@
  */
 
 import { has, noop } from 'lodash';
-import { isEnabled } from 'config';
 
 /**
  * Internal dependencies
@@ -69,13 +68,6 @@ const setSelectedEditorAndRedirect = (
 		return;
 	}
 	if ( has( window, 'location.replace' ) && -1 !== redirectUrl.indexOf( 'calypsoify=1' ) ) {
-		return window.location.replace( redirectUrl );
-	}
-	if (
-		isEnabled( 'editor/after-deprecation' ) &&
-		has( window, 'location.replace' ) &&
-		'classic' === editor
-	) {
 		return window.location.replace( redirectUrl );
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes the redirect to wpadmin for classic editor due to a change of approach for editor edpreication

#### Testing instructions

* Apply PR to local calypso dev env and check that browser is redirected to calypso editor for simple and atomic sites when using the 'switch to classic/switch to block' links in the editor help popover
