### PR TITLE
Revert "Editor: Pass editor/after-deprecation feature flag to iframed editor"

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -726,11 +726,6 @@ const mapStateToProps = (
 		queryArgs = wpcom.addSupportParams( queryArgs );
 	}
 
-	// Needed to pass through feature flag to iframed editor.
-	if ( window.location.href.indexOf( 'editor/after-deprecation' ) > -1 ) {
-		queryArgs[ 'editor-after-deprecation' ] = 1;
-	}
-
 	const siteAdminUrl =
 		editorType === 'site'
 			? getSiteAdminUrl( state, siteId, 'admin.php?page=gutenberg-edit-site' )


### PR DESCRIPTION
Reverts Automattic/wp-calypso#41920 due to a change in plan on how to deprecate editor

## Testing

Apply PR to local calypso dev and test that redirection to iframe editor still works correctly for atomic and simple sites