### PR TITLE
Jetpack Search: move the purchase flow to its new route

### DIFF
--- a/client/jetpack-connect/jetpack-connection.jsx
+++ b/client/jetpack-connect/jetpack-connection.jsx
@@ -180,8 +180,7 @@ const jetpackConnection = ( WrappedComponent ) => {
 			return ! this.isCurrentUrlFetching() &&
 				this.isCurrentUrlFetched() &&
 				! this.props.jetpackConnectSite.isDismissed &&
-				this.state.status &&
-				this.state.status !== IS_DOT_COM_GET_SEARCH ? (
+				this.state.status ? (
 				<JetpackConnectNotices
 					noticeType={ this.state.status }
 					onDismissClick={ IS_DOT_COM === this.state.status ? this.goBack : this.dismissUrl }

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -126,7 +126,8 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 	}
 }
 
-.jetpack-connect__site-url-entry-container {
+.jetpack-connect__site-url-entry-container,
+.purchase-product__site-url-entry-container {
 	margin: 0 auto;
 	max-width: 400px;
 
@@ -146,6 +147,7 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 }
 
 .jetpack-connect__site-url-input-container,
+.purchase-product__site-url-input-container,
 .example-components__site-url-input-container {
 	.jetpack-connect__site-address-container,
 	.example-components__site-address-container {

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -12,7 +12,8 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 	@include woocommerce-colors();
 }
 
-.is-section-jetpack-connect {
+.is-section-jetpack-connect,
+.is-section-purchase-product {
 
 	.layout__content {
 		position: static;
@@ -821,7 +822,8 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 /**
  * Onboarding styles
  **/
-.layout.is-section-jetpack-connect:not( .is-add-site-page ):not( .is-jetpack-mobile-flow ) {
+.layout.is-section-jetpack-connect:not( .is-add-site-page ):not( .is-jetpack-mobile-flow ),
+.layout.is-section-purchase-product {
 	background-color: var( --color-jetpack-onboarding-background );
 
 	&.layout {

--- a/client/lib/products-values/constants.js
+++ b/client/lib/products-values/constants.js
@@ -106,7 +106,6 @@ export const getJetpackProductsDisplayNames = () => {
 			} ) }{ ' ' }
 		</>
 	);
-
 	const backupRealtime = (
 		<>
 			{ ' ' }
@@ -117,9 +116,7 @@ export const getJetpackProductsDisplayNames = () => {
 			} ) }{ ' ' }
 		</>
 	);
-
 	const search = translate( 'Jetpack Search' );
-
 	const scanDaily = (
 		<>
 			{ translate( 'Jetpack Scan {{em}}Daily{{/em}}', {
@@ -129,7 +126,6 @@ export const getJetpackProductsDisplayNames = () => {
 			} ) }{ ' ' }
 		</>
 	);
-
 	return {
 		[ PRODUCT_JETPACK_BACKUP_DAILY ]: backupDaily,
 		[ PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY ]: backupDaily,
@@ -143,7 +139,6 @@ export const getJetpackProductsDisplayNames = () => {
 		[ PRODUCT_JETPACK_SCAN_MONTHLY ]: scanDaily,
 	};
 };
-
 export const getJetpackProductsTaglines = () => {
 	const searchTagline = translate( 'Search your site.' );
 	const scanTagline = 'Scan your site.';

--- a/client/my-sites/purchase-product/controller.js
+++ b/client/my-sites/purchase-product/controller.js
@@ -1,0 +1,98 @@
+/**
+ * External Dependencies
+ */
+import React from 'react';
+import Debug from 'debug';
+import { get, some } from 'lodash';
+
+/**
+ * Internal Dependencies
+ */
+import { recordPageView } from 'lib/analytics/page-view';
+import config from 'config';
+import SearchPurchase from './search';
+import { hideMasterbar, showMasterbar, hideSidebar } from 'state/ui/actions';
+import { MOBILE_APP_REDIRECT_URL_WHITELIST } from '../../jetpack-connect/constants';
+import {
+	persistMobileRedirect,
+	retrieveMobileRedirect,
+	storePlan,
+} from '../../jetpack-connect/persistence-utils';
+
+import {
+	PRODUCT_JETPACK_SEARCH,
+	PRODUCT_JETPACK_SEARCH_MONTHLY,
+} from 'lib/products-values/constants';
+
+/**
+ * Module variables
+ */
+const debug = new Debug( 'calypso:jetpack-connect:controller' );
+const analyticsPageTitleByType = {
+	jetpack_search: 'Jetpack Search',
+};
+
+const removeSidebar = ( context ) => context.store.dispatch( hideSidebar() );
+
+const getPlanSlugFromFlowType = ( type, interval = 'yearly' ) => {
+	const planSlugs = {
+		yearly: {
+			jetpack_search: PRODUCT_JETPACK_SEARCH,
+		},
+		monthly: {
+			jetpack_search: PRODUCT_JETPACK_SEARCH_MONTHLY,
+		},
+	};
+
+	return get( planSlugs, [ interval, type ], '' );
+};
+
+export function persistMobileAppFlow( context, next ) {
+	const { query } = context;
+	if ( config.isEnabled( 'jetpack/connect/mobile-app-flow' ) ) {
+		if (
+			some( MOBILE_APP_REDIRECT_URL_WHITELIST, ( pattern ) =>
+				pattern.test( query.mobile_redirect )
+			)
+		) {
+			debug( `In mobile app flow with redirect url: ${ query.mobile_redirect }` );
+			persistMobileRedirect( query.mobile_redirect );
+		} else {
+			persistMobileRedirect( '' );
+		}
+	}
+	next();
+}
+
+export function setMasterbar( context, next ) {
+	if ( config.isEnabled( 'jetpack/connect/mobile-app-flow' ) ) {
+		const masterbarToggle = retrieveMobileRedirect() ? hideMasterbar() : showMasterbar();
+		context.store.dispatch( masterbarToggle );
+	}
+	next();
+}
+
+// Purchase Jetpack Search
+export function purchase( context, next ) {
+	const { path, pathname, params, query } = context;
+	const { type = false, interval } = params;
+	const analyticsPageTitle = get( type, analyticsPageTitleByType, 'Jetpack Connect' );
+	const planSlug = getPlanSlugFromFlowType( type, interval );
+
+	planSlug && storePlan( planSlug );
+	recordPageView( pathname, analyticsPageTitle );
+
+	removeSidebar( context );
+
+	context.primary = (
+		<SearchPurchase
+			ctaFrom={ query.cta_from /* origin tracking params */ }
+			ctaId={ query.cta_id /* origin tracking params */ }
+			locale={ params.locale }
+			path={ path }
+			type={ type }
+			url={ query.url }
+		/>
+	);
+	next();
+}

--- a/client/my-sites/purchase-product/controller.js
+++ b/client/my-sites/purchase-product/controller.js
@@ -12,7 +12,7 @@ import { recordPageView } from 'lib/analytics/page-view';
 import config from 'config';
 import SearchPurchase from './search';
 import { hideMasterbar, showMasterbar, hideSidebar } from 'state/ui/actions';
-import { MOBILE_APP_REDIRECT_URL_WHITELIST } from '../../jetpack-connect/constants';
+import { ALLOWED_MOBILE_APP_REDIRECT_URL_LIST } from '../../jetpack-connect/constants';
 import {
 	persistMobileRedirect,
 	retrieveMobileRedirect,
@@ -29,7 +29,7 @@ import {
 /**
  * Module variables
  */
-const debug = new Debug( 'calypso:jetpack-connect:controller' );
+const debug = new Debug( 'calypso:purchase-product:controller' );
 const analyticsPageTitleByType = {
 	jetpack_search: 'Jetpack Search',
 };
@@ -55,7 +55,7 @@ export function persistMobileAppFlow( context, next ) {
 	const { query } = context;
 	if ( config.isEnabled( 'jetpack/connect/mobile-app-flow' ) ) {
 		if (
-			some( MOBILE_APP_REDIRECT_URL_WHITELIST, ( pattern ) =>
+			some( ALLOWED_MOBILE_APP_REDIRECT_URL_LIST, ( pattern ) =>
 				pattern.test( query.mobile_redirect )
 			)
 		) {

--- a/client/my-sites/purchase-product/controller.js
+++ b/client/my-sites/purchase-product/controller.js
@@ -22,6 +22,8 @@ import {
 import {
 	PRODUCT_JETPACK_SEARCH,
 	PRODUCT_JETPACK_SEARCH_MONTHLY,
+	PRODUCT_WPCOM_SEARCH,
+	PRODUCT_WPCOM_SEARCH_MONTHLY,
 } from 'lib/products-values/constants';
 
 /**
@@ -38,9 +40,11 @@ const getPlanSlugFromFlowType = ( type, interval = 'yearly' ) => {
 	const planSlugs = {
 		yearly: {
 			jetpack_search: PRODUCT_JETPACK_SEARCH,
+			wpcom_search: PRODUCT_WPCOM_SEARCH,
 		},
 		monthly: {
 			jetpack_search: PRODUCT_JETPACK_SEARCH_MONTHLY,
+			wpcom_search: PRODUCT_WPCOM_SEARCH_MONTHLY,
 		},
 	};
 

--- a/client/my-sites/purchase-product/index.js
+++ b/client/my-sites/purchase-product/index.js
@@ -21,12 +21,13 @@ export default function () {
 	const isLoggedOut = ! user.get();
 
 	if ( isLoggedOut ) {
-		page( '/purchase-product/:type(jetpack_search)/:interval(yearly|monthly)?', ( { path } ) =>
-			page( login( { isNative: true, isJetpack: true, redirectTo: path } ) )
+		page(
+			'/purchase-product/:type(jetpack_search|wpcom_search)/:interval(yearly|monthly)?',
+			( { path } ) => page( login( { isNative: true, isJetpack: true, redirectTo: path } ) )
 		);
 	} else {
 		page(
-			'/purchase-product/:type(jetpack_search)/:interval(yearly|monthly)?',
+			'/purchase-product/:type(jetpack_search|wpcom_search)/:interval(yearly|monthly)?',
 			controller.persistMobileAppFlow,
 			controller.setMasterbar,
 			controller.purchase,

--- a/client/my-sites/purchase-product/index.js
+++ b/client/my-sites/purchase-product/index.js
@@ -1,0 +1,37 @@
+/**
+ * External dependencies
+ */
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+import userFactory from 'lib/user';
+import * as controller from './controller';
+import { login } from 'lib/paths';
+import { makeLayout, render as clientRender } from 'controller';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+export default function () {
+	const user = userFactory();
+	const isLoggedOut = ! user.get();
+
+	if ( isLoggedOut ) {
+		page( '/purchase-product/:type(jetpack_search)/:interval(yearly|monthly)?', ( { path } ) =>
+			page( login( { isNative: true, isJetpack: true, redirectTo: path } ) )
+		);
+	} else {
+		page(
+			'/purchase-product/:type(jetpack_search)/:interval(yearly|monthly)?',
+			controller.persistMobileAppFlow,
+			controller.setMasterbar,
+			controller.purchase,
+			makeLayout,
+			clientRender
+		);
+	}
+}

--- a/client/my-sites/purchase-product/index.js
+++ b/client/my-sites/purchase-product/index.js
@@ -14,7 +14,7 @@ import { makeLayout, render as clientRender } from 'controller';
 /**
  * Style dependencies
  */
-import './style.scss';
+import '../../jetpack-connect/style.scss';
 
 export default function () {
 	const user = userFactory();

--- a/client/my-sites/purchase-product/search.jsx
+++ b/client/my-sites/purchase-product/search.jsx
@@ -1,0 +1,229 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { concat, flowRight } from 'lodash';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { Card } from '@automattic/components';
+import HelpButton from '../../jetpack-connect/help-button';
+import LocaleSuggestions from 'components/locale-suggestions';
+import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
+import LoggedOutFormLinks from 'components/logged-out-form/links';
+import MainHeader from '../../jetpack-connect/main-header';
+import MainWrapper from '../../jetpack-connect/main-wrapper';
+import page from 'page';
+import SiteUrlInput from '../../jetpack-connect/site-url-input';
+import { cleanUrl } from '../../jetpack-connect/utils';
+import { checkUrl, dismissUrl } from 'state/jetpack-connect/actions';
+import { FLOW_TYPES } from 'state/jetpack-connect/constants';
+import { getConnectingSite, getJetpackSiteByUrl } from 'state/jetpack-connect/selectors';
+import { getCurrentUserId } from 'state/current-user/selectors';
+import getSites from 'state/selectors/get-sites';
+import { isRequestingSites } from 'state/sites/selectors';
+import { persistSession, retrieveMobileRedirect } from '../../jetpack-connect/persistence-utils';
+import { recordTracksEvent } from 'state/analytics/actions';
+import { urlToSlug } from 'lib/url';
+import searchSites from 'components/search-sites';
+import jetpackConnection from '../../jetpack-connect/jetpack-connection';
+
+import { IS_DOT_COM_SEARCH, JPC_PATH_REMOTE_INSTALL } from '../../jetpack-connect/constants';
+
+import { ALREADY_CONNECTED } from '../../jetpack-connect/connection-notice-types';
+
+export class SearchPurchase extends Component {
+	static propTypes = {
+		locale: PropTypes.string,
+		path: PropTypes.string,
+		type: PropTypes.oneOf( concat( FLOW_TYPES, false ) ),
+		url: PropTypes.string,
+		processJpSite: PropTypes.func,
+	};
+
+	state = this.props.url
+		? {
+				currentUrl: cleanUrl( this.props.url ),
+				shownUrl: this.props.url,
+				waitingForSites: false,
+				candidateSites: this.props.searchSites( this.props.url ),
+		  }
+		: {
+				currentUrl: '',
+				shownUrl: '',
+				waitingForSites: false,
+				candidateSites: [],
+		  };
+
+	getCandidateSites( url ) {
+		this.props.searchSites( url );
+		let candidateSites = [];
+
+		if ( this.props.sitesFound ) {
+			candidateSites = this.props.sitesFound.map( ( site ) => ( {
+				label: site.URL,
+				category: this.props.translate( 'Choose site' ),
+			} ) );
+		}
+
+		this.setState( { candidateSites } );
+	}
+
+	UNSAFE_componentWillMount() {
+		if ( this.props.url ) {
+			this.checkUrl( cleanUrl( this.props.url ) );
+		}
+		if ( ! this.props.isLoggedIn ) {
+			this.goToRemoteInstall( JPC_PATH_REMOTE_INSTALL );
+		}
+	}
+
+	componentDidMount() {
+		this.props.recordTracksEvent( 'calypso_jpc_url_view', {
+			jpc_from: 'jp_lp',
+			cta_id: this.props.ctaId,
+			cta_from: this.props.ctaFrom,
+		} );
+	}
+
+	componentDidUpdate() {
+		const { status, processJpSite } = this.props;
+		const { currentUrl } = this.state;
+
+		if ( status === IS_DOT_COM_SEARCH || status === ALREADY_CONNECTED ) {
+			page.redirect( '/checkout/' + urlToSlug( this.state.currentUrl ) + '/' + 'jetpack_search' );
+		}
+
+		processJpSite( currentUrl );
+	}
+
+	handleUrlChange = ( url ) => {
+		this.setState( {
+			currentUrl: cleanUrl( url ),
+			shownUrl: url,
+		} );
+
+		this.getCandidateSites( url );
+	};
+
+	checkUrl( url ) {
+		return this.props.checkUrl( url, !! this.props.getJetpackSiteByUrl( url ) );
+	}
+
+	handleUrlSubmit = () => {
+		this.props.recordTracksEvent( 'calypso_jpc_url_submit', {
+			jetpack_url: this.state.currentUrl,
+		} );
+		// Track that connection was started by button-click, so we can auto-approve at auth step.
+		persistSession( this.state.currentUrl );
+
+		if ( this.props.isRequestingSites ) {
+			this.setState( { waitingForSites: true } );
+		} else {
+			this.checkUrl( this.state.currentUrl );
+		}
+	};
+
+	handleOnClickTos = () => this.props.recordTracksEvent( 'calypso_jpc_tos_link_click' );
+
+	renderFooter() {
+		const { translate } = this.props;
+		return (
+			<LoggedOutFormLinks>
+				<LoggedOutFormLinkItem href="https://jetpack.com/support/installing-jetpack/">
+					{ translate( 'Install Jetpack manually' ) }
+				</LoggedOutFormLinkItem>
+				<HelpButton />
+			</LoggedOutFormLinks>
+		);
+	}
+
+	renderSiteInput( status ) {
+		return (
+			<Card className="purchase-product__site-url-input-container">
+				{ this.props.renderNotices() }
+
+				<SiteUrlInput
+					url={ this.state.shownUrl }
+					onTosClick={ this.handleOnClickTos }
+					onChange={ this.handleUrlChange }
+					onSubmit={ this.handleUrlSubmit }
+					isError={ status }
+					isFetching={
+						this.props.isCurrentUrlFetching || this.state.redirecting || this.state.waitingForSites
+					}
+					isInstall={ true }
+					product={ 'jetpack_search' }
+					candidateSites={ this.state.candidateSites }
+				/>
+			</Card>
+		);
+	}
+
+	renderLocaleSuggestions() {
+		if ( this.props.isLoggedIn || ! this.props.locale ) {
+			return;
+		}
+
+		return <LocaleSuggestions path={ this.props.path } locale={ this.props.locale } />;
+	}
+
+	render() {
+		const { renderFooter, status } = this.props;
+
+		return (
+			<MainWrapper>
+				{ this.renderLocaleSuggestions() }
+				<div className="purchase-product__site-url-entry-container">
+					<MainHeader type={ 'jetpack_search' } />
+
+					{ this.renderSiteInput( status ) }
+					{ renderFooter() }
+				</div>
+			</MainWrapper>
+		);
+	}
+}
+
+const connectComponent = connect(
+	( state ) => {
+		// Note: reading from a cookie here rather than redux state,
+		// so any change in value will not execute connect().
+		const mobileAppRedirect = retrieveMobileRedirect();
+		const isMobileAppFlow = !! mobileAppRedirect;
+		const jetpackConnectSite = getConnectingSite( state );
+		const siteData = jetpackConnectSite.data || {};
+		const sites = getSites( state );
+
+		const skipRemoteInstall = siteData.skipRemoteInstall;
+
+		return {
+			// eslint-disable-next-line wpcalypso/redux-no-bound-selectors
+			getJetpackSiteByUrl: ( url ) => getJetpackSiteByUrl( state, url ),
+			isLoggedIn: !! getCurrentUserId( state ),
+			isMobileAppFlow,
+			isRequestingSites: isRequestingSites( state ),
+			jetpackConnectSite,
+			mobileAppRedirect,
+			skipRemoteInstall,
+			siteHomeUrl: siteData.urlAfterRedirects || jetpackConnectSite.url,
+			sites,
+		};
+	},
+	{
+		checkUrl,
+		dismissUrl,
+		recordTracksEvent,
+	}
+);
+
+export default flowRight(
+	jetpackConnection,
+	connectComponent,
+	searchSites,
+	localize
+)( SearchPurchase );

--- a/client/my-sites/purchase-product/search.jsx
+++ b/client/my-sites/purchase-product/search.jsx
@@ -148,11 +148,18 @@ export class SearchPurchase extends Component {
 	}
 
 	getProduct() {
-		// purchase-product/:product/:type
-		const product = window.location.pathname.split( '/' )[ 2 ];
-		const type = window.location.pathname.split( '/' )[ 3 ];
+		const type = window.location.pathname.includes( 'monthly' ) && 'monthly';
+		let product = '';
 
-		return type === 'monthly' ? product + '_' + type : product;
+		if ( window.location.pathname.includes( 'jetpack_search' ) ) {
+			product = type ? 'jetpack_search_monthly' : 'jetpack_search';
+		}
+
+		if ( window.location.pathname.includes( 'wpcom_search' ) ) {
+			product = type ? 'wpcom_search_monthly' : 'wpcom_search';
+		}
+
+		return product;
 	}
 
 	renderSiteInput( status ) {

--- a/client/my-sites/purchase-product/search.jsx
+++ b/client/my-sites/purchase-product/search.jsx
@@ -32,9 +32,12 @@ import { urlToSlug } from 'lib/url';
 import searchSites from 'components/search-sites';
 import jetpackConnection from '../../jetpack-connect/jetpack-connection';
 
-import { IS_DOT_COM_SEARCH, JPC_PATH_REMOTE_INSTALL } from '../../jetpack-connect/constants';
+import { JPC_PATH_REMOTE_INSTALL } from '../../jetpack-connect/constants';
 
-import { ALREADY_CONNECTED } from '../../jetpack-connect/connection-notice-types';
+import {
+	ALREADY_CONNECTED,
+	IS_DOT_COM_GET_SEARCH,
+} from '../../jetpack-connect/connection-notice-types';
 
 export class SearchPurchase extends Component {
 	static propTypes = {
@@ -94,7 +97,7 @@ export class SearchPurchase extends Component {
 		const { status, processJpSite } = this.props;
 		const { currentUrl } = this.state;
 
-		if ( status === IS_DOT_COM_SEARCH || status === ALREADY_CONNECTED ) {
+		if ( status === IS_DOT_COM_GET_SEARCH || status === ALREADY_CONNECTED ) {
 			page.redirect( '/checkout/' + urlToSlug( this.state.currentUrl ) + '/' + 'jetpack_search' );
 		}
 

--- a/client/my-sites/purchase-product/style.scss
+++ b/client/my-sites/purchase-product/style.scss
@@ -1,0 +1,45 @@
+.purchase-product__site-url-entry-container {
+	margin: 0 auto;
+	max-width: 400px;
+
+	.formatted-header {
+		text-align: center;
+	}
+}
+
+.purchase-product__site-url-input-container,
+.example-components__site-url-input-container {
+	.jetpack-connect__site-address-container,
+	.example-components__site-address-container {
+		position: relative;
+
+		.gridicons-user,
+		.gridicons-globe {
+			position: absolute;
+			top: 8px;
+			left: 8px;
+			color: var( --color-neutral-10 );
+		}
+
+		.form-text-input {
+			padding-left: 40px;
+		}
+
+		.spinner {
+			position: absolute;
+			right: 8px;
+			top: 10px;
+		}
+
+		.sites-dropdown__wrapper {
+			width: 100%;
+      margin-top: 20px;
+		}
+	}
+
+	.button {
+		width: 100%;
+		margin-top: 16px;
+		word-wrap: nowrap;
+	}
+}

--- a/client/sections.js
+++ b/client/sections.js
@@ -189,6 +189,13 @@ const sections = [
 		enableLoggedOut: true,
 	},
 	{
+		name: 'purchase-product',
+		paths: [ '/purchase-product' ],
+		module: 'my-sites/purchase-product',
+		secondary: false,
+		enableLoggedOut: true,
+	},
+	{
 		name: 'signup',
 		paths: [ '/start' ],
 		module: 'signup',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* add `purchase-product/:jetpack_search|wpcom_search` route and move functionality related to the Jetpack Search purchase to this new location

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* go to `purchase-product/jetpack_search` and purchase the product for Jetpack sites with different plugin statuses
* try logged in and logged out- for the latter, login should be called before the site input screen loads
* WP.com sites show relevant notice


