### PR TITLE
Customer Home: Fix Support Link to Domains

### DIFF
--- a/client/blocks/inline-help/contextual-help.js
+++ b/client/blocks/inline-help/contextual-help.js
@@ -33,8 +33,8 @@ const getFallbackLinks = () => [
 		),
 	},
 	{
-		link: localizeUrl( 'https://wordpress.com/support/all-about-domains/' ),
-		post_id: 41171,
+		link: localizeUrl( 'https://wordpress.com/support/domains/' ),
+		post_id: 1988,
 		title: translate( 'All About Domains' ),
 		description: translate(
 			'Set up your domain whether it’s registered with WordPress.com or elsewhere.'


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This updates the "All About Domains" link, following the existing pattern here, so that it works properly.

https://github.com/Automattic/wp-calypso/blob/931916f8f1fef0772577a18e23885f741cd4d090/client/blocks/inline-help/contextual-help.js#L1004-L1009

#### Testing instructions

Click "All About Domains" in Customer Home and verify that the dialog appears correctly instead of just a blank screen! 

<img width="421" alt="Screenshot 2020-06-22 at 22 29 28" src="https://user-images.githubusercontent.com/43215253/85337147-dc95e200-b4d7-11ea-84ad-a72b34bc5f2d.png">

cc @gwwar, @mmtr  

Fixes #43220
