### PR TITLE
Add/domains add a domain button to all site domains view

### DIFF
--- a/client/my-sites/domains/domain-management/list/domain-item.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-item.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
@@ -9,6 +10,11 @@ import React, { PureComponent } from 'react';
 import { CompactCard } from '@automattic/components';
 
 class DomainItem extends PureComponent {
+	static propTypes = {
+		domain: PropTypes.object.isRequired,
+		onClick: PropTypes.func.isRequired,
+	};
+
 	handleClick = () => {
 		this.props.onClick( this.props.domain );
 	};

--- a/client/my-sites/domains/domain-management/list/list-all.jsx
+++ b/client/my-sites/domains/domain-management/list/list-all.jsx
@@ -28,8 +28,11 @@ import ListItemPlaceholder from './item-placeholder';
 import Main from 'components/main';
 import PropTypes from 'prop-types';
 import QueryAllDomains from 'components/data/query-all-domains';
-import SectionHeader from 'components/section-header';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
+/**
+ * Style dependencies
+ */
+import './list-all.scss';
 
 class ListAll extends Component {
 	static propTypes = {
@@ -92,13 +95,15 @@ class ListAll extends Component {
 
 		return (
 			<Main wideLayout>
-				<FormattedHeader brandFont headerText={ translate( 'All Domains' ) } align="left" />
+				<div className="list-all__heading">
+					<FormattedHeader brandFont headerText={ translate( 'All Domains' ) } align="left" />
+					<div className="list-all__heading-buttons">{ this.headerButtons() }</div>
+				</div>
 				<div className="list-all__container">
 					<QueryAllDomains />
 					<Main wideLayout>
 						<DocumentHead title={ translate( 'Domains', { context: 'A navigation label.' } ) } />
 						<SidebarNavigation />
-						<SectionHeader>{ this.headerButtons() }</SectionHeader>
 						<div className="list-all__items">{ this.renderDomainsList() }</div>
 					</Main>
 				</div>

--- a/client/my-sites/domains/domain-management/list/list-all.scss
+++ b/client/my-sites/domains/domain-management/list/list-all.scss
@@ -2,6 +2,11 @@
 	display: flex;
 
 	.list-all__heading-buttons {
-		margin: 0 0 auto auto;
+		margin: auto 16px auto auto;
+
+		@include breakpoint-deprecated('>660px') {
+			margin-top: 0;
+			margin-right: 0;
+		}
 	}
 }

--- a/client/my-sites/domains/domain-management/list/list-all.scss
+++ b/client/my-sites/domains/domain-management/list/list-all.scss
@@ -1,0 +1,7 @@
+.list-all__heading {
+	display: flex;
+
+	.list-all__heading-buttons {
+		margin: 0 0 auto auto;
+	}
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* A button for adding new domains is added to the all sites domains view

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit the [all domains view ](http://calypso.localhost:3000/domains/manage)
* Confirm that the `Add a domain` button leads you to `/domains/add` route

<img width="1086" alt="Screenshot 2020-06-23 at 5 52 43 PM" src="https://user-images.githubusercontent.com/277661/85432101-5e3e4c00-b57a-11ea-87e3-3a6b5050842a.png">


