### PR TITLE
Fix block pattern previews with custom font size

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/call-to-action-02.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/call-to-action-02.php
@@ -13,7 +13,7 @@ $markup = '
       <div class="wp-block-jetpack-layout-grid alignfull column1-desktop-grid__span-10 column1-desktop-grid__start-2 column1-desktop-grid__row-1 column1-tablet-grid__span-8 column1-tablet-grid__row-1 column1-mobile-grid__span-4 column1-mobile-grid__row-1 wp-block-jetpack-layout-gutter__nowrap">
          <!-- wp:jetpack/layout-grid-column -->
          <div class="wp-block-jetpack-layout-grid-column wp-block-jetpack-layout-grid__padding-none">
-            <!-- wp:paragraph {"align":"center","customTextColor":"#ffffff","customFontSize":80,"className":"margin-bottom-none"} -->
+            <!-- wp:paragraph {"align":"center","customTextColor":"#ffffff","style":{"typography":{"fontSize":80}},"className":"margin-bottom-none"} -->
             <p style="color:#ffffff;font-size:80px" class="has-text-color has-text-align-center margin-bottom-none"><strong>' . esc_html__( 'Get it delivered', 'full-site-editing' ) . '</strong></p>
             <!-- /wp:paragraph -->
 

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/food-menu.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/food-menu.php
@@ -10,7 +10,7 @@ $markup = '
 <div class="wp-block-jetpack-layout-grid alignfull column1-desktop-grid__span-10 column1-desktop-grid__start-2 column1-desktop-grid__row-1 column1-tablet-grid__span-8 column1-tablet-grid__row-1 column1-mobile-grid__span-4 column1-mobile-grid__row-1">
    <!-- wp:jetpack/layout-grid-column -->
    <div class="wp-block-jetpack-layout-grid-column wp-block-jetpack-layout-grid__padding-none">
-      <!-- wp:paragraph {"customFontSize":71} -->
+      <!-- wp:paragraph {"style":{"typography":{"fontSize":71}}} -->
       <p style="font-size:71px"><strong>Menu</strong></p>
       <!-- /wp:paragraph -->
       <!-- wp:columns -->

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/numbers.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/numbers.php
@@ -8,7 +8,7 @@
 $markup = '
 <!-- wp:jetpack/layout-grid {"column1DesktopSpan":4,"column1TabletSpan":4,"column1MobileSpan":4,"column2DesktopSpan":4,"column2TabletSpan":4,"column2MobileSpan":4,"column3DesktopSpan":4,"column3TabletSpan":8,"column3MobileSpan":4,"className":"column1-desktop-grid__span-4 column1-desktop-grid__row-1 column2-desktop-grid__span-4 column2-desktop-grid__start-5 column2-desktop-grid__row-1 column3-desktop-grid__span-4 column3-desktop-grid__start-9 column3-desktop-grid__row-1 column1-tablet-grid__span-4 column1-tablet-grid__row-1 column2-tablet-grid__span-4 column2-tablet-grid__start-5 column2-tablet-grid__row-1 column3-tablet-grid__span-8 column3-tablet-grid__row-2 column1-mobile-grid__span-4 column1-mobile-grid__row-1 column2-mobile-grid__span-4 column2-mobile-grid__row-2 column3-mobile-grid__span-4 column3-mobile-grid__row-3"} -->
 <div class="wp-block-jetpack-layout-grid alignfull column1-desktop-grid__span-4 column1-desktop-grid__row-1 column2-desktop-grid__span-4 column2-desktop-grid__start-5 column2-desktop-grid__row-1 column3-desktop-grid__span-4 column3-desktop-grid__start-9 column3-desktop-grid__row-1 column1-tablet-grid__span-4 column1-tablet-grid__row-1 column2-tablet-grid__span-4 column2-tablet-grid__start-5 column2-tablet-grid__row-1 column3-tablet-grid__span-8 column3-tablet-grid__row-2 column1-mobile-grid__span-4 column1-mobile-grid__row-1 column2-mobile-grid__span-4 column2-mobile-grid__row-2 column3-mobile-grid__span-4 column3-mobile-grid__row-3"><!-- wp:jetpack/layout-grid-column -->
-<div class="wp-block-jetpack-layout-grid-column wp-block-jetpack-layout-grid__padding-none"><!-- wp:paragraph {"align":"center","customFontSize":70,"className":"margin-bottom-none"} -->
+<div class="wp-block-jetpack-layout-grid-column wp-block-jetpack-layout-grid__padding-none"><!-- wp:paragraph {"align":"center","style":{"typography":{"fontSize":70}},"className":"margin-bottom-none"} -->
 <p style="font-size:70px" class="has-text-align-center margin-bottom-none"><strong>%1$s</strong></p>
 <!-- /wp:paragraph -->
 
@@ -18,7 +18,7 @@ $markup = '
 <!-- /wp:jetpack/layout-grid-column -->
 
 <!-- wp:jetpack/layout-grid-column -->
-<div class="wp-block-jetpack-layout-grid-column wp-block-jetpack-layout-grid__padding-none"><!-- wp:paragraph {"align":"center","customFontSize":70,"className":"margin-bottom-none"} -->
+<div class="wp-block-jetpack-layout-grid-column wp-block-jetpack-layout-grid__padding-none"><!-- wp:paragraph {"align":"center","style":{"typography":{"fontSize":70}},"className":"margin-bottom-none"} -->
 <p style="font-size:70px" class="has-text-align-center margin-bottom-none"><strong>%3$s</strong></p>
 <!-- /wp:paragraph -->
 
@@ -28,7 +28,7 @@ $markup = '
 <!-- /wp:jetpack/layout-grid-column -->
 
 <!-- wp:jetpack/layout-grid-column -->
-<div class="wp-block-jetpack-layout-grid-column wp-block-jetpack-layout-grid__padding-none"><!-- wp:paragraph {"align":"center","customFontSize":70,"className":"margin-bottom-none"} -->
+<div class="wp-block-jetpack-layout-grid-column wp-block-jetpack-layout-grid__padding-none"><!-- wp:paragraph {"align":"center","style":{"typography":{"fontSize":70}},"className":"margin-bottom-none"} -->
 <p style="font-size:70px" class="has-text-align-center margin-bottom-none"><strong>%5$s</strong></p>
 <!-- /wp:paragraph -->
 

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/three-columns-and-image.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/three-columns-and-image.php
@@ -10,7 +10,7 @@ $markup = '
 <div class="wp-block-jetpack-layout-grid alignfull column1-desktop-grid__span-9 column1-desktop-grid__start-4 column1-desktop-grid__row-1 column1-tablet-grid__span-8 column1-tablet-grid__row-1 column1-mobile-grid__span-4 column1-mobile-grid__row-1">
 	<!-- wp:jetpack/layout-grid-column -->
 	<div class="wp-block-jetpack-layout-grid-column wp-block-jetpack-layout-grid__padding-none">
-		<!-- wp:paragraph {"customFontSize":50} -->
+		<!-- wp:paragraph {"style":{"typography":{"fontSize":50}}} -->
 		<p style="font-size:50px"><strong>%1$s</strong></p>
 		<!-- /wp:paragraph -->
 	</div>
@@ -22,7 +22,7 @@ $markup = '
 <div class="wp-block-jetpack-layout-grid alignfull column1-desktop-grid__span-3 column1-desktop-grid__start-4 column1-desktop-grid__row-1 column2-desktop-grid__span-3 column2-desktop-grid__start-7 column2-desktop-grid__row-1 column3-desktop-grid__span-3 column3-desktop-grid__start-10 column3-desktop-grid__row-1 column1-tablet-grid__span-4 column1-tablet-grid__row-1 column2-tablet-grid__span-4 column2-tablet-grid__start-5 column2-tablet-grid__row-1 column3-tablet-grid__span-4 column3-tablet-grid__row-2 column1-mobile-grid__span-4 column1-mobile-grid__row-1 column2-mobile-grid__span-4 column2-mobile-grid__row-2 column3-mobile-grid__span-4 column3-mobile-grid__row-3">
 	<!-- wp:jetpack/layout-grid-column -->
 	<div class="wp-block-jetpack-layout-grid-column wp-block-jetpack-layout-grid__padding-none">
-		<!-- wp:paragraph {"customFontSize":14} -->
+		<!-- wp:paragraph {"style":{"typography":{"fontSize":14}}} -->
 		<p style="font-size:14px">%2$s</p>
 		<!-- /wp:paragraph -->
 	</div>
@@ -30,7 +30,7 @@ $markup = '
 
 	<!-- wp:jetpack/layout-grid-column -->
 	<div class="wp-block-jetpack-layout-grid-column wp-block-jetpack-layout-grid__padding-none">
-		<!-- wp:paragraph {"customFontSize":14} -->
+		<!-- wp:paragraph {"style":{"typography":{"fontSize":14}}} -->
 		<p style="font-size:14px">%3$s</p>
 		<!-- /wp:paragraph -->
 	</div>
@@ -38,7 +38,7 @@ $markup = '
 
 	<!-- wp:jetpack/layout-grid-column -->
 	<div class="wp-block-jetpack-layout-grid-column wp-block-jetpack-layout-grid__padding-none">
-		<!-- wp:paragraph {"customFontSize":14} -->
+		<!-- wp:paragraph {"style":{"typography":{"fontSize":14}}} -->
 		<p style="font-size:14px">%4$s</p>
 		<!-- /wp:paragraph -->
 	</div>


### PR DESCRIPTION
### Changes proposed in this Pull Request
Fixes #43478. @Addison-Stavlo summed up the problem succintly [here](https://github.com/Automattic/wp-calypso/issues/43478#issuecomment-647722544).

> Some blocks in core have transitioned to the __experimentalFontSize hook. I think mainly paragraph and heading have this so far, but a handful of FSE blocks (site-title, post-author, etc.) will have these in the near future as well.
>
>Where these blocks may have had a customFontSize attribute, the custom sizes are now saved under what you noted: {"style":{"typography":{"fontSize":XX}}}. Named font sizes such as "large" etc. are still saved under the attribute fontSize as a string.

### Screenshots
### Before
<img width="1261" alt="Screen Shot 2020-06-22 at 4 23 54 PM" src="https://user-images.githubusercontent.com/5414230/85344583-efdb8a00-b4a4-11ea-9333-082c33a5dbc5.png">

<img width="1265" alt="Screen Shot 2020-06-22 at 4 23 09 PM" src="https://user-images.githubusercontent.com/5414230/85344703-3f21ba80-b4a5-11ea-93a3-c345bcc422a4.png">

<img width="1264" alt="Screen Shot 2020-06-22 at 4 24 08 PM" src="https://user-images.githubusercontent.com/5414230/85344643-1ac5de00-b4a5-11ea-84be-96f345b371f2.png">

### After
<img width="1342" alt="Screen Shot 2020-06-22 at 4 17 19 PM" src="https://user-images.githubusercontent.com/5414230/85344368-58763700-b4a4-11ea-8702-ba7876e4a134.png">

<img width="1344" alt="Screen Shot 2020-06-22 at 4 17 41 PM" src="https://user-images.githubusercontent.com/5414230/85344393-6a57da00-b4a4-11ea-8553-de5bb211b6cc.png">


<img width="1336" alt="Screen Shot 2020-06-22 at 4 17 08 PM" src="https://user-images.githubusercontent.com/5414230/85344350-4c8a7500-b4a4-11ea-847a-a65a8bb96a46.png">

### Testing
#### Instructions
- Set up sandbox
  - simple site with block pattern preview updates
    1. Sandbox simple site
    2. Checkout this branch in wp-calypso repo
    3. Sync the local dev environment with `cd apps/full-site-editing; yarn dev --sync` More info in PCYsg-ly5-p2 #build-scripts
  - atomic site with block pattern preview updates
    1. Create ephemeral atomic site
    2. Sync full site editing plugin updates with atomic site. More info in PCYsg-ly5-p2 #atomic-testng
- Navigate to my sites -> posts -> Add new post
- Open Gutenberg Inserter
- Click on Block Patterns Tab
- Review block pattern previews
#### Requirements
- Editor loads without white screen of death
  - [ ] With the Gutenberg plugin enabled and the FSE plugin enabled.
  - [ ] With the Gutenberg plugin disabled and the FSE plugin enabled.
- call-to-action-02 block pattern preview displays proper font sizes
  - [ ] On atomic sites
  - [ ] On simple sites
- food-menu block pattern preview displays proper font sizes
  - [ ] On atomic sites
  - [ ] On simple sites
- numbers block pattern preview displays proper font sizes
  - [ ] On atomic sites
  - [ ] On simple sites
- three-columns-and-image block pattern preview displays proper font sizes
  - [ ] On atomic sites
  - [ ] On simple sites

#### Browsers
- [ ] Firefox
- [ ] Safari
- [ ] Chrome
- [ ] Edge