### PR TITLE
Deduplicate yargs

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -26822,7 +26822,7 @@ yargs-parser@^13.1.0, yargs-parser@^13.1.1:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
-yargs-parser@^15.0.0, yargs-parser@^15.0.1:
+yargs-parser@^15.0.1:
   version "15.0.1"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-15.0.1.tgz#54786af40b820dcb2fb8025b11b4d659d76323b3"
   integrity sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==
@@ -26948,7 +26948,7 @@ yargs@^13.3.0:
     y18n "^4.0.0"
     yargs-parser "^13.1.1"
 
-yargs@^14.0.0:
+yargs@^14.0.0, yargs@^14.2, yargs@^14.2.2:
   version "14.2.3"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-14.2.3.tgz#1a1c3edced1afb2a2fea33604bc6d1d8d688a414"
   integrity sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==
@@ -26964,23 +26964,6 @@ yargs@^14.0.0:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^15.0.1"
-
-yargs@^14.2, yargs@^14.2.2:
-  version "14.2.2"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-14.2.2.tgz#2769564379009ff8597cdd38fba09da9b493c4b5"
-  integrity sha512-/4ld+4VV5RnrynMhPZJ/ZpOCGSCeghMykZ3BhdFBDa9Wy/RH6uEGNWDJog+aUlq+9OM1CFTgtYRW5Is1Po9NOA==
-  dependencies:
-    cliui "^5.0.0"
-    decamelize "^1.2.0"
-    find-up "^3.0.0"
-    get-caller-file "^2.0.1"
-    require-directory "^2.1.1"
-    require-main-filename "^2.0.0"
-    set-blocking "^2.0.0"
-    string-width "^3.0.0"
-    which-module "^2.0.0"
-    y18n "^4.0.0"
-    yargs-parser "^15.0.0"
 
 yargs@^15.3.1:
   version "15.3.1"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `yargs` (done automatically with `npx yarn-deduplicate --packages yargs`)

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
< Before
> After
---
< wp-calypso-monorepo@0.17.0 -> @automattic/full-site-editing@1.10.0 -> ... -> yargs@14.2.2
< wp-calypso-monorepo@0.17.0 -> @automattic/o2-blocks@1.0.0 -> ... -> yargs@14.2.2
< wp-calypso-monorepo@0.17.0 -> @wordpress/block-directory@1.9.0 -> ... -> yargs@14.2.2
< wp-calypso-monorepo@0.17.0 -> @wordpress/block-editor@3.11.0 -> ... -> yargs@14.2.2
< wp-calypso-monorepo@0.17.0 -> @wordpress/block-library@2.18.0 -> ... -> yargs@14.2.2
< wp-calypso-monorepo@0.17.0 -> @wordpress/blocks@6.16.0 -> ... -> yargs@14.2.2
< wp-calypso-monorepo@0.17.0 -> @wordpress/core-data@2.16.0 -> ... -> yargs@14.2.2
< wp-calypso-monorepo@0.17.0 -> @wordpress/edit-post@3.17.0 -> ... -> yargs@14.2.2
< wp-calypso-monorepo@0.17.0 -> @wordpress/editor@9.16.0 -> ... -> yargs@14.2.2
< wp-calypso-monorepo@0.17.0 -> @wordpress/format-library@1.18.0 -> ... -> yargs@14.2.2
< wp-calypso-monorepo@0.17.0 -> lerna@3.20.2 -> ... -> yargs@14.2.2
< wp-calypso-monorepo@0.17.0 -> wp-calypso@0.17.0 -> ... -> yargs@14.2.2
> wp-calypso-monorepo@0.17.0 -> @automattic/full-site-editing@1.10.0 -> ... -> yargs@14.2.3
> wp-calypso-monorepo@0.17.0 -> @automattic/o2-blocks@1.0.0 -> ... -> yargs@14.2.3
> wp-calypso-monorepo@0.17.0 -> @wordpress/block-directory@1.9.0 -> ... -> yargs@14.2.3
> wp-calypso-monorepo@0.17.0 -> @wordpress/block-editor@3.11.0 -> ... -> yargs@14.2.3
> wp-calypso-monorepo@0.17.0 -> @wordpress/block-library@2.18.0 -> ... -> yargs@14.2.3
> wp-calypso-monorepo@0.17.0 -> @wordpress/blocks@6.16.0 -> ... -> yargs@14.2.3
> wp-calypso-monorepo@0.17.0 -> @wordpress/core-data@2.16.0 -> ... -> yargs@14.2.3
> wp-calypso-monorepo@0.17.0 -> @wordpress/edit-post@3.17.0 -> ... -> yargs@14.2.3
> wp-calypso-monorepo@0.17.0 -> @wordpress/editor@9.16.0 -> ... -> yargs@14.2.3
> wp-calypso-monorepo@0.17.0 -> @wordpress/format-library@1.18.0 -> ... -> yargs@14.2.3
> wp-calypso-monorepo@0.17.0 -> lerna@3.20.2 -> ... -> yargs@14.2.3
> wp-calypso-monorepo@0.17.0 -> wp-calypso@0.17.0 -> ... -> yargs@14.2.3
```

I can't find either `14.2.2` or `14.2.3` in their [CHANGELOG](https://github.com/yargs/yargs/blob/master/CHANGELOG.md) or tagged in [their tags](https://github.com/yargs/yargs/tags), but this are the [differences](https://diff.intrinsic.com/yargs/14.2.2/14.2.3) between both versions