### PR TITLE
Deduplicate ws

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -26600,12 +26600,7 @@ ws@^6.0.0, ws@^6.2.1:
   dependencies:
     async-limiter "~1.0.0"
 
-ws@^7.0.0, ws@^7.1.2:
-  version "7.2.3"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-7.2.3.tgz#a5411e1fb04d5ed0efee76d26d5c46d830c39b46"
-  integrity sha512-HTDl9G9hbkNDk98naoR/cHDws7+EyYMOdL1BmjsZXRUjf7d+MficC4B7HLUPlSiho0vg+CWKrGIt/VJBd1xunQ==
-
-ws@^7.2.3:
+ws@^7.0.0, ws@^7.1.2, ws@^7.2.3:
   version "7.3.0"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.3.0.tgz#4b2f7f219b3d3737bc1a2fbf145d825b94d38ffd"
   integrity sha512-iFtXzngZVXPGgpTlP1rBqsUK82p9tKqsWRPg5L56egiljujJT3vGAYnHANvFxBieXrTFavhzhxW52jnaWV+w2w==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `ws` (done automatically with `npx yarn-deduplicate --packages ws`)

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
< Before
> After
---
< wp-calypso-monorepo@0.17.0 -> @wordpress/scripts@9.1.0 -> ... -> ws@7.2.3
< wp-calypso-monorepo@0.17.0 -> socket.io@2.3.0 -> ... -> ws@7.2.3
< wp-calypso-monorepo@0.17.0 -> wp-e2e-tests@0.0.1 -> ... -> ws@7.2.3
> wp-calypso-monorepo@0.17.0 -> @wordpress/scripts@9.1.0 -> ... -> ws@7.3.0
> wp-calypso-monorepo@0.17.0 -> socket.io@2.3.0 -> ... -> ws@7.3.0
> wp-calypso-monorepo@0.17.0 -> wp-e2e-tests@0.0.1 -> ... -> ws@7.3.0
```
[CHANGELOG](https://github.com/websockets/ws/releases)