### PR TITLE
Expert guidance A/B test: Increase exposure to 50/50

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -151,8 +151,8 @@ export default {
 	whiteGloveUpsell: {
 		datestamp: '20200608',
 		variations: {
-			variantShowOffer: 10,
-			control: 90,
+			variantShowOffer: 50,
+			control: 50,
 		},
 		defaultVariation: 'control',
 		allowExistingUsers: false,

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -149,7 +149,7 @@ export default {
 		allowExistingUsers: true,
 	},
 	whiteGloveUpsell: {
-		datestamp: '20200608',
+		datestamp: '20200623',
 		variations: {
 			variantShowOffer: 50,
 			control: 50,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Increases variant exposure to 50/50 for the test created in #42783.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Verify that code looks okay.
* Set your locale and geo to EN-US. Select a free plan during signup and verify that you see the expert guidance offer when assigned to variant.
