### PR TITLE
Deduplicate uuid

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -25824,12 +25824,7 @@ uuid@^3.0.1, uuid@^3.1.0, uuid@^3.3.2, uuid@^3.3.3:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
-uuid@^7.0.1:
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.2.tgz#7ff5c203467e91f5e0d85cfcbaaf7d2ebbca9be6"
-  integrity sha512-vy9V/+pKG+5ZTYKf+VcphF5Oc6EFiu3W8Nv3P3zIh0EqVI80ZxOzuPfe9EHjkFNvf8+xuTHVeei4Drydlx4zjw==
-
-uuid@^7.0.2, uuid@^7.0.3:
+uuid@^7.0.1, uuid@^7.0.2, uuid@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.3.tgz#c5c9f2c8cf25dc0a372c4df1441c41f5bd0c680b"
   integrity sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `uuid` (done automatically with `npx yarn-deduplicate --packages uuid`)

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
< Before
> After
---
< wp-calypso-monorepo@0.17.0 -> @automattic/data-stores@1.0.0-alpha.1 -> ... -> uuid@7.0.2
< wp-calypso-monorepo@0.17.0 -> @automattic/full-site-editing@1.10.0 -> ... -> uuid@7.0.2
< wp-calypso-monorepo@0.17.0 -> wp-calypso@0.17.0 -> ... -> uuid@7.0.2
< wp-calypso-monorepo@0.17.0 -> wpcom-proxy-request@6.0.0 -> ... -> uuid@7.0.2
> wp-calypso-monorepo@0.17.0 -> @automattic/data-stores@1.0.0-alpha.1 -> ... -> uuid@7.0.3
> wp-calypso-monorepo@0.17.0 -> @automattic/full-site-editing@1.10.0 -> ... -> uuid@7.0.3
> wp-calypso-monorepo@0.17.0 -> wp-calypso@0.17.0 -> ... -> uuid@7.0.3
> wp-calypso-monorepo@0.17.0 -> wpcom-proxy-request@6.0.0 -> ... -> uuid@7.0.3
```
[CHANGELOG](https://github.com/uuidjs/uuid/blob/master/CHANGELOG.md#703-2020-03-31)