### PR TITLE
Deduplicate sanitize-filename

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -22600,17 +22600,10 @@ sane@^4.0.3:
     minimist "^1.1.1"
     walker "~1.0.5"
 
-sanitize-filename@^1.5.3:
+sanitize-filename@^1.5.3, sanitize-filename@^1.6.0:
   version "1.6.3"
   resolved "https://registry.yarnpkg.com/sanitize-filename/-/sanitize-filename-1.6.3.tgz#755ebd752045931977e30b2025d340d7c9090378"
   integrity sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==
-  dependencies:
-    truncate-utf8-bytes "^1.0.0"
-
-sanitize-filename@^1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/sanitize-filename/-/sanitize-filename-1.6.0.tgz#8b009c7828e0b9ffc54e6a118f042be2ef00d6d8"
-  integrity sha1-iwCceCjguf/FTmoRjwQr4u8A1tg=
   dependencies:
     truncate-utf8-bytes "^1.0.0"
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `sanitize-filename` (done automatically with `npx yarn-deduplicate --packages sanitize-filename`)

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
< Before
> After
---
< wp-calypso-monorepo@0.17.0 -> wp-e2e-tests@0.0.1 -> ... -> sanitize-filename@1.6.0
> wp-calypso-monorepo@0.17.0 -> wp-e2e-tests@0.0.1 -> ... -> sanitize-filename@1.6.3
```

[CHANGELOG](https://github.com/parshap/node-sanitize-filename/compare/v1.6.0...v1.6.3)