### PR TITLE
Deduplicate rimraf

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -22449,14 +22449,7 @@ rimraf@2.6.3, rimraf@~2.6.2:
   dependencies:
     glob "^7.1.3"
 
-rimraf@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.0.tgz#614176d4b3010b75e5c390eb0ee96f6dc0cebb9b"
-  integrity sha512-NDGVxTsjqfunkds7CqsOiEnxln4Bo7Nddl3XhS4pXg5OzwkLqJ971ZVAAnB+DDLnF76N+VnDEiBHaVV8I06SUg==
-  dependencies:
-    glob "^7.1.3"
-
-rimraf@^3.0.2:
+rimraf@^3.0.0, rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `rimraf` (done automatically with `npx yarn-deduplicate --packages rimraf`)

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
< Before
> After
---
< wp-calypso-monorepo@0.17.0 ->  -> ... -> rimraf@3.0.0
< wp-calypso-monorepo@0.17.0 -> @wordpress/scripts@9.1.0 -> ... -> rimraf@3.0.0
< wp-calypso-monorepo@0.17.0 -> jest@26.0.1 -> ... -> rimraf@3.0.0
< wp-calypso-monorepo@0.17.0 -> wp-e2e-tests@0.0.1 -> ... -> rimraf@3.0.0
> wp-calypso-monorepo@0.17.0 ->  -> ... -> rimraf@3.0.2
> wp-calypso-monorepo@0.17.0 -> @wordpress/scripts@9.1.0 -> ... -> rimraf@3.0.2
> wp-calypso-monorepo@0.17.0 -> jest@26.0.1 -> ... -> rimraf@3.0.2
> wp-calypso-monorepo@0.17.0 -> wp-e2e-tests@0.0.1 -> ... -> rimraf@3.0.2
```
[CHANGELOG](https://github.com/isaacs/rimraf/compare/v3.0.0...v3.0.2)