### PR TITLE
Gutenboarding: Fix generate thumbnails script

### DIFF
--- a/bin/generate-gutenboarding-design-thumbnails.js
+++ b/bin/generate-gutenboarding-design-thumbnails.js
@@ -31,12 +31,19 @@ const viewportHeight = 800; // Browser height for capturing the screenshot
 const viewportScaleFactor = 2; // Browser pixel density for capturing the screenshot
 const viewportWidth = 1280; // Browser width for capturing the screenshot
 
+const designsEndpoint = 'https://public-api.wordpress.com/rest/v1/template/demo/';
+
 const getDesignUrl = ( design ) => {
-	return wpUrl.addQueryArgs( design.src, {
-		font_base: design.fonts.base,
-		font_headings: design.fonts.headings,
-		site_title: design.title,
-	} );
+	return wpUrl.addQueryArgs(
+		`${ designsEndpoint }${ encodeURIComponent( design.theme ) }/${ encodeURIComponent(
+			design.template
+		) }`,
+		{
+			font_base: design.fonts.base,
+			font_headings: design.fonts.headings,
+			site_title: design.title,
+		}
+	);
 };
 
 async function run() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Follow-up to #43513, where I missed one instance of `design.src`, as @alshakero [pointed out](https://github.com/Automattic/wp-calypso/pull/43513#pullrequestreview-435120343) (thanks!)

#### Testing instructions

Run `node ./bin/generate-gutenboarding-design-thumbnails.js`, verify that it works.
