### PR TITLE
Fix My Home support search missing reset button when searching

### DIFF
--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -338,7 +338,7 @@ class Search extends Component {
 				<Spinner />
 				<div
 					role="button"
-					className="search__icon-navigation"
+					className="search__icon-navigation search__icon-navigation--open"
 					ref={ this.setOpenIconRef }
 					onClick={ enableOpenIcon ? this.openSearch : this.focus }
 					tabIndex={ enableOpenIcon ? '0' : null }
@@ -394,7 +394,7 @@ class Search extends Component {
 			return (
 				<div
 					role="button"
-					className="search__icon-navigation"
+					className="search__icon-navigation search__icon-navigation--close search__icon-navigation--reset"
 					onClick={ this.closeSearch }
 					tabIndex="0"
 					onKeyDown={ this.closeListener }

--- a/client/my-sites/customer-home/cards/features/help-search/style.scss
+++ b/client/my-sites/customer-home/cards/features/help-search/style.scss
@@ -107,7 +107,7 @@ $min_results_height: 175px;
 				height: 24px;
 			}
 
-			&.is-searching .search__icon-navigation {
+			&.is-searching .search__icon-navigation--open {
 				display: none;
 			}
 


### PR DESCRIPTION
Previously when performing a search on the My Home support search the "reset" icon was hidden. This meant you could not stop the search without using backspace.

![Screen Shot 2020-06-18 at 15 04 06](https://user-images.githubusercontent.com/444434/85030314-36637880-b175-11ea-9e5f-ac49ee57fe52.png)

This PR adds additional classes to the underlying `Search` component that allows us to target the correct button to hide, leaving the "reset" button to be always visible.



## Testing instructions

#### On Master

* Go to My Home.
* Enter search into "Get help" support search input.
* See there is no "X" button shown whilst the search is running.
* Notice the "X" reappears once the search completes.

#### On this PR's branch

* Go to My Home.
* Enter search into "Get help" support search input.
* See that there _is_ now an "X" button shown when the search is running.
* Verify the "X" still remains once the search completes.


Fixes https://github.com/Automattic/wp-calypso/issues/43443
