### PR TITLE
Deduplicate postcss-value-parser

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -20206,12 +20206,7 @@ postcss-value-parser@^3.0.0, postcss-value-parser@^3.3.0:
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz#9ff822547e2893213cf1c30efa51ac5fd1ba8281"
   integrity sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==
 
-postcss-value-parser@^4.0.0, postcss-value-parser@^4.0.2:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.0.3.tgz#651ff4593aa9eda8d5d0d66593a2417aeaeb325d"
-  integrity sha512-N7h4pG+Nnu5BEIzyeaaIYWs0LI5XC40OrRh5L60z0QjFsqGWcHcbkBvpe1WYpcIS9yQ8sOi/vIPt1ejQCrMVrg==
-
-postcss-value-parser@^4.0.3:
+postcss-value-parser@^4.0.0, postcss-value-parser@^4.0.2, postcss-value-parser@^4.0.3:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz#443f6a20ced6481a2bda4fa8532a6e55d789a2cb"
   integrity sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `postcss-value-parser` (done automatically with `npx yarn-deduplicate --packages postcss-value-parser`)

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
< Before
> After
---
< wp-calypso-monorepo@0.17.0 -> @automattic/calypso-build@6.1.0 -> ... -> postcss-value-parser@4.0.3
< wp-calypso-monorepo@0.17.0 -> @automattic/full-site-editing@1.10.0 -> ... -> postcss-value-parser@4.0.3
< wp-calypso-monorepo@0.17.0 -> @storybook/react@5.3.18 -> ... -> postcss-value-parser@4.0.3
< wp-calypso-monorepo@0.17.0 -> @wordpress/scripts@9.1.0 -> ... -> postcss-value-parser@4.0.3
< wp-calypso-monorepo@0.17.0 -> stylelint@9.10.1 -> ... -> postcss-value-parser@4.0.3
> wp-calypso-monorepo@0.17.0 -> @automattic/calypso-build@6.1.0 -> ... -> postcss-value-parser@4.1.0
> wp-calypso-monorepo@0.17.0 -> @automattic/full-site-editing@1.10.0 -> ... -> postcss-value-parser@4.1.0
> wp-calypso-monorepo@0.17.0 -> @storybook/react@5.3.18 -> ... -> postcss-value-parser@4.1.0
> wp-calypso-monorepo@0.17.0 -> @wordpress/scripts@9.1.0 -> ... -> postcss-value-parser@4.1.0
> wp-calypso-monorepo@0.17.0 -> stylelint@9.10.1 -> ... -> postcss-value-parser@4.1.0
```
[CHANGELOG](https://github.com/TrySound/postcss-value-parser/releases)