### PR TITLE
P2 signup: fix error when site field is empty

### DIFF
--- a/client/signup/steps/p2-site/index.jsx
+++ b/client/signup/steps/p2-site/index.jsx
@@ -34,6 +34,7 @@ const debug = debugFactory( 'calypso:steps:p2-site' );
  */
 const VALIDATION_DELAY_AFTER_FIELD_CHANGES = 1500;
 const ERROR_CODE_MISSING_SITE_TITLE = 123; // Random number, we don't need it.
+const ERROR_CODE_MISSING_SITE = 321; // Random number, we don't need it.
 
 /**
  * Module variables
@@ -106,6 +107,12 @@ class P2Site extends React.Component {
 				[ ERROR_CODE_MISSING_SITE_TITLE ]: this.props.translate(
 					'Please enter your team or project name.'
 				),
+			};
+		}
+
+		if ( isEmpty( fields.site ) ) {
+			messages.site = {
+				[ ERROR_CODE_MISSING_SITE ]: this.props.translate( 'Please enter your site address.' ),
 			};
 		}
 


### PR DESCRIPTION
Fixes an error where if you left out the `site` field in the P2 signup flow (wp.com/start/p2), it would not show an error initially and "allow" you to create such site (the backend would actually prevent it).

In this PR, we fix the error messaging for those cases.

## Testing instructions

Go to `http://calypso.localhost:3000/start/p2` and input only site title and click Continue. You should be shown an error that you need to fill in the site address.

Props @klimeryk for the bug report!