### PR TITLE
Jetpack: update backup section styling

### DIFF
--- a/client/components/jetpack/backup-date-picker/style.scss
+++ b/client/components/jetpack/backup-date-picker/style.scss
@@ -3,7 +3,7 @@
 	align-items: center;
 	background: #fff;
 	padding-top: 0.5rem;
-	font-size: $font-body;
+	font-size: 0.875rem;
 
 	@include breakpoint-deprecated( '>660px' ) {
 		background: transparent;
@@ -126,7 +126,7 @@
 /* WordPress.com-only styles */
 .wordpressdotcom .backup-date-picker {
 	margin-bottom: 1rem;
-	padding: 1rem;
+	padding: 0.5rem;
 	background: #fff;
 	box-shadow: 0 0 0 1px #dcdcde;
 

--- a/client/components/jetpack/daily-backup-status/style.scss
+++ b/client/components/jetpack/daily-backup-status/style.scss
@@ -113,7 +113,6 @@
 .daily-backup-status__failed.card {
 	background: transparent;
 	box-shadow: none;
-	padding: 0;
 }
 
 .daily-backup-status__realtime-details {
@@ -129,7 +128,6 @@
 
 .daily-backup-status__realtime-details-card .activity-card .card {
 	margin: 0;
-	padding: 0;
 	background: transparent;
 	box-shadow: none;
 }
@@ -359,8 +357,6 @@
 }
 
 .daily-backup-status__daily {
-	margin: 32px -16px 0;
-	padding: 0 16px;
 	text-align: left;
 }
 
@@ -382,7 +378,6 @@
 	.daily-backup-status__failed.card {
 		background: #fff;
 		box-shadow: 0 0 0 1px #dcdcde;
-		padding: 1.5rem;
 	}
 
 	.daily-backup-status {
@@ -456,8 +451,4 @@
 	padding-top: initial;
 	margin-bottom: 1rem;
 	box-shadow: 0 0 0 1px #dcdcde;
-
-	&__success, &__failed {
-		padding: 2rem;
-	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes custom margins and paddings from the Backup card, making the transition between WordPress.com and Jetpack.com seamless and easier to maintain.
* Changes the Backup date picker a bit to make it match dotcom's styles.

#### Screenshots

Before | After
--|--
![image](https://user-images.githubusercontent.com/390760/85401873-a8133c00-b552-11ea-97ab-b6041325a82e.png) | ![image](https://user-images.githubusercontent.com/390760/85401895-afd2e080-b552-11ea-9af6-2847da1ff329.png)
![image](https://user-images.githubusercontent.com/390760/85401999-d98c0780-b552-11ea-9bd3-9474a17ba937.png) | ![image](https://user-images.githubusercontent.com/390760/85402025-e27cd900-b552-11ea-898b-25dba2adbd6c.png)
![image](https://user-images.githubusercontent.com/390760/85402152-1821c200-b553-11ea-86cc-589f9ac238a9.png) | ![image](https://user-images.githubusercontent.com/390760/85402181-22dc5700-b553-11ea-97a7-cadbe77ccdaf.png)

#### Testing instructions

* Spin up this PR and open wordpress.com.
* Add `?flags=jetpack/features-section` to your URL.
* Select a Jetpack site.
* Inside the new Jetpack menu, select Backup.
* Ensure the layout looks good in all screen widths.

Fixes 1179060693083348-asana-1181590984715097
