### PR TITLE
Menu: remove Backup and Scan links to cloud

### DIFF
--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -132,13 +132,21 @@ export class MySitesSidebar extends Component {
 	}
 
 	cloud() {
-		const { scanState, rewindState, isCloudEligible, site } = this.props;
+		const {
+			scanState,
+			rewindState,
+			isCloudEligible,
+			site,
+			shouldRenderJetpackSection,
+		} = this.props;
 		if (
 			! site ||
 			! isCloudEligible ||
 			! scanState ||
 			! rewindState ||
-			'uninitialized' === rewindState.state
+			'uninitialized' === rewindState.state ||
+			// Sections are already present in the Jetpack menu
+			shouldRenderJetpackSection
 		) {
 			return null;
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Since _Backup_ and _Scan_ sections are now accessible from the _Jetpack_ menu item, having a link to these sections in cloud (under the _Tools_ menu item) is redundant.

#### Testing instructions

- Download the PR and run Calypso
- Make sure Jetpack sections are enabled
- Select a Jetpack site with Backup and Scan activated
- Check that in the _Tools_ menu item, The _Backup_ and _Scan_ items are not shown

#### Screenshots

Before
<img width="265" alt="Screen Shot 2020-06-23 at 8 30 22 AM" src="https://user-images.githubusercontent.com/1620183/85404349-d0883f80-b52c-11ea-8dd8-db012ced784e.png">


After
<img width="265" alt="Screen Shot 2020-06-23 at 8 30 31 AM" src="https://user-images.githubusercontent.com/1620183/85404368-d7af4d80-b52c-11ea-8a32-bd77169476a7.png">
