### PR TITLE
Cannot access site flow: update copy

### DIFF
--- a/client/my-sites/site-settings/disconnect-site/down-flow.jsx
+++ b/client/my-sites/site-settings/disconnect-site/down-flow.jsx
@@ -57,7 +57,7 @@ function DownFlow( { confirmHref, backHref, site, recordTracksEvent: tracks } ) 
 					<FormattedHeader
 						isSecondary
 						align="left"
-						headerText={ translate( 'Confirm that your site loads.' ) }
+						headerText={ translate( 'Confirm that your site loads' ) }
 						subHeaderText={ translate(
 							'Visit your site to make sure it loads properly. If there’s an issue, fix your site before worrying about Jetpack! That may resolve this error.'
 						) }
@@ -76,7 +76,7 @@ function DownFlow( { confirmHref, backHref, site, recordTracksEvent: tracks } ) 
 					<FormattedHeader
 						isSecondary
 						align="left"
-						headerText={ translate( 'Troubleshoot Jetpack.' ) }
+						headerText={ translate( 'Troubleshoot Jetpack' ) }
 						subHeaderText={ translate(
 							'If your site is loading but you’re still seeing this error, this guide will help you troubleshoot the Jetpack connection.'
 						) }
@@ -93,7 +93,7 @@ function DownFlow( { confirmHref, backHref, site, recordTracksEvent: tracks } ) 
 					<FormattedHeader
 						isSecondary
 						align="left"
-						headerText={ translate( 'Disconnect Jetpack.' ) }
+						headerText={ translate( 'Disconnect Jetpack' ) }
 						subHeaderText={ translate(
 							'If you’re no longer using Jetpack and/or WordPress for your site, or you’ve taken your site down, it’s time to disconnect Jetpack.'
 						) }

--- a/client/my-sites/site-settings/disconnect-site/down-flow.jsx
+++ b/client/my-sites/site-settings/disconnect-site/down-flow.jsx
@@ -78,7 +78,7 @@ function DownFlow( { confirmHref, backHref, site, recordTracksEvent: tracks } ) 
 						align="left"
 						headerText={ translate( 'Troubleshoot Jetpack.' ) }
 						subHeaderText={ translate(
-							'If your site is working but you’re still seeing this error, let’s troubleshoot your Jetpack connection.'
+							'If your site is loading but you’re still seeing this error, this guide will help you troubleshoot the Jetpack connection.'
 						) }
 					/>
 				</CompactCard>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update copy on troubleshoot option as per the suggestion on p1HpG7-9wA-p2#comment-40220
* Remove trailing dots on option titles.

#### Screenshots

Before | After
--|--
![image](https://user-images.githubusercontent.com/390760/85407622-54592080-b55b-11ea-94f0-993e4ae4ccb1.png) | ![image](https://user-images.githubusercontent.com/390760/85407650-5c18c500-b55b-11ea-92e2-6d1435524adb.png)

#### Testing instructions

* Spin up this PR.
* Go to `https://wordpress.com/settings/disconnect-site/SITE_URL?type=down`.
* Ensure the copy on the page looks good.

