### PR TITLE
Gutenboarding: persist domain selection and search when site title is skipped

### DIFF
--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -4,7 +4,7 @@
 import * as React from 'react';
 import classnames from 'classnames';
 import { Icon, wordpress } from '@wordpress/icons';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { useI18n } from '@automattic/react-i18n';
 
 /**
@@ -26,14 +26,6 @@ const Header: React.FunctionComponent = () => {
 	const currentStep = useCurrentStep();
 
 	const { domain, siteTitle } = useSelect( ( select ) => select( ONBOARD_STORE ).getState() );
-
-	const { setDomain } = useDispatch( ONBOARD_STORE );
-
-	React.useEffect( () => {
-		if ( ! siteTitle ) {
-			setDomain( undefined );
-		}
-	}, [ siteTitle, setDomain ] );
 
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	const domainElement = domain ? (

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
@@ -23,7 +23,7 @@ import { NextButton, SkipButton } from 'landing/gutenboarding/components/action-
 
 const AcquireIntent: React.FunctionComponent = () => {
 	const { getSelectedSiteTitle } = useSelect( ( select ) => select( STORE_KEY ) );
-	const { setSiteTitle } = useDispatch( STORE_KEY );
+	const { setSiteTitle, setDomainSearch } = useDispatch( STORE_KEY );
 
 	const { goNext } = useStepNavigation();
 
@@ -35,10 +35,15 @@ const AcquireIntent: React.FunctionComponent = () => {
 
 	React.useEffect( prefetchDesignThumbs, [] );
 
+	const handleContinue = () => {
+		hasSiteTitle && setDomainSearch( getSelectedSiteTitle() );
+		goNext();
+	};
+
 	const handleSkip = () => {
 		setSiteTitle( '' ); // reset site title if there is no valid entry
 		recordSiteTitleSkip();
-		goNext();
+		handleContinue();
 	};
 
 	return (
@@ -47,9 +52,13 @@ const AcquireIntent: React.FunctionComponent = () => {
 				'acquire-intent--with-skip': ! hasSiteTitle,
 			} ) }
 		>
-			<SiteTitle onSubmit={ goNext } />
+			<SiteTitle onSubmit={ handleContinue } />
 			<div className="acquire-intent__footer">
-				{ hasSiteTitle ? <NextButton onClick={ goNext } /> : <SkipButton onClick={ handleSkip } /> }
+				{ hasSiteTitle ? (
+					<NextButton onClick={ handleContinue } />
+				) : (
+					<SkipButton onClick={ handleSkip } />
+				) }
 			</div>
 		</div>
 	);

--- a/client/landing/gutenboarding/stores/onboard/index.ts
+++ b/client/landing/gutenboarding/stores/onboard/index.ts
@@ -26,6 +26,7 @@ registerStore< State >( STORE_KEY, {
 	selectors,
 	persist: [
 		'domain',
+		'domainSearch',
 		'siteTitle',
 		'siteVertical',
 		'hasUsedPlansStep',

--- a/client/landing/gutenboarding/stores/onboard/reducer.ts
+++ b/client/landing/gutenboarding/stores/onboard/reducer.ts
@@ -29,9 +29,6 @@ const domainSearch: Reducer< string, OnboardAction > = ( state = '', action ) =>
 	if ( action.type === 'SET_DOMAIN_SEARCH_TERM' ) {
 		return action.domainSearch;
 	}
-	if ( action.type === 'SET_SITE_TITLE' ) {
-		return action.siteTitle;
-	}
 	if ( action.type === 'RESET_ONBOARD_STORE' ) {
 		return '';
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* When logging in at site creation step in Gutenboarding, the redirect to `/new/plans` shouldn't happen. Mentioned in https://github.com/Automattic/wp-calypso/issues/43569#issuecomment-648102697.
* When the site title step is skipped and user selects a domain, if the page is refreshed, the domain and last domain search should be persisted. Demo with the current behaviour: https://cloudup.com/cQsWe7fNGRK)
* Domain search should be now automatically changed by entering a new site title value only when advancing from Intent Capture step with a valid site title (at least 2 characters).

#### Testing instructions
* Go to [/new](https://calypso.live/new?branch=fix/gutenboarding-persist-domain-and-domain-search) as an existing logged out user.
* After skipping the site title step, at the end of the flow you enter a domain search query and select a domain.
* Refreshing the page shouldn't reset the search query and domain selection.
* After completing the flow, when logging in, you should be redirected to checkout or editor.

Fixes https://github.com/Automattic/wp-calypso/issues/43569#issuecomment-648102697
Possible fix for: https://github.com/Automattic/wp-calypso/issues/43569
