### PR TITLE
Domains: Do not show domain contact info for non owners

### DIFF
--- a/client/my-sites/domains/domain-management/contacts-privacy/index.jsx
+++ b/client/my-sites/domains/domain-management/contacts-privacy/index.jsx
@@ -25,6 +25,7 @@ import {
 import { getSelectedDomain } from 'lib/domains';
 import isRequestingWhois from 'state/selectors/is-requesting-whois';
 import getCurrentRoute from 'state/selectors/get-current-route';
+import NonOwnerCard from 'my-sites/domains/domain-management/components/domain/non-owner-card';
 
 /**
  * Style dependencies
@@ -38,11 +39,7 @@ class ContactsPrivacy extends React.PureComponent {
 		selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ).isRequired,
 	};
 
-	render() {
-		if ( this.isDataLoading() ) {
-			return <DomainMainPlaceholder goBack={ this.goToEdit } />;
-		}
-
+	renderForOwner() {
 		const { translate } = this.props;
 		const domain = getSelectedDomain( this.props );
 		const {
@@ -57,43 +54,63 @@ class ContactsPrivacy extends React.PureComponent {
 			config.isEnabled( 'domains/gdpr-consent-page' ) && domain.supportsGdprConsentManagement;
 
 		return (
+			<>
+				<ContactsPrivacyCard
+					selectedDomainName={ this.props.selectedDomainName }
+					selectedSite={ this.props.selectedSite }
+					privateDomain={ privateDomain }
+					privacyAvailable={ privacyAvailable }
+					contactInfoDisclosed={ contactInfoDisclosed }
+					contactInfoDisclosureAvailable={ contactInfoDisclosureAvailable }
+					isPendingIcannVerification={ isPendingIcannVerification }
+				/>
+
+				<VerticalNavItem
+					path={ domainManagementEditContactInfo(
+						this.props.selectedSite.slug,
+						this.props.selectedDomainName,
+						this.props.currentRoute
+					) }
+				>
+					{ translate( 'Edit contact info' ) }
+				</VerticalNavItem>
+
+				{ canManageConsent && (
+					<VerticalNavItem
+						path={ domainManagementManageConsent(
+							this.props.selectedSite.slug,
+							this.props.selectedDomainName,
+							this.props.currentRoute
+						) }
+					>
+						{ translate( 'Manage Consent for Personal Data Use' ) }
+					</VerticalNavItem>
+				) }
+			</>
+		);
+	}
+
+	renderForOthers() {
+		const { domains, selectedDomainName } = this.props;
+		return <NonOwnerCard domains={ domains } selectedDomainName={ selectedDomainName } />;
+	}
+
+	render() {
+		if ( this.isDataLoading() ) {
+			return <DomainMainPlaceholder goBack={ this.goToEdit } />;
+		}
+
+		const { translate } = this.props;
+		const domain = getSelectedDomain( this.props );
+
+		return (
 			<Main className="contacts-privacy">
 				<Header onClick={ this.goToEdit } selectedDomainName={ this.props.selectedDomainName }>
 					{ translate( 'Contacts and Privacy' ) }
 				</Header>
 
 				<VerticalNav>
-					<ContactsPrivacyCard
-						selectedDomainName={ this.props.selectedDomainName }
-						selectedSite={ this.props.selectedSite }
-						privateDomain={ privateDomain }
-						privacyAvailable={ privacyAvailable }
-						contactInfoDisclosed={ contactInfoDisclosed }
-						contactInfoDisclosureAvailable={ contactInfoDisclosureAvailable }
-						isPendingIcannVerification={ isPendingIcannVerification }
-					/>
-
-					<VerticalNavItem
-						path={ domainManagementEditContactInfo(
-							this.props.selectedSite.slug,
-							this.props.selectedDomainName,
-							this.props.currentRoute
-						) }
-					>
-						{ translate( 'Edit contact info' ) }
-					</VerticalNavItem>
-
-					{ canManageConsent && (
-						<VerticalNavItem
-							path={ domainManagementManageConsent(
-								this.props.selectedSite.slug,
-								this.props.selectedDomainName,
-								this.props.currentRoute
-							) }
-						>
-							{ translate( 'Manage Consent for Personal Data Use' ) }
-						</VerticalNavItem>
-					) }
+					{ domain.currentUserCanManage ? this.renderForOwner() : this.renderForOthers() }
 				</VerticalNav>
 			</Main>
 		);

--- a/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
+++ b/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
@@ -207,6 +207,10 @@ class DomainManagementNavigationEnhanced extends React.Component {
 		const { selectedSite, translate, currentRoute, domain } = this.props;
 		const { privateDomain, privacyAvailable } = domain;
 
+		if ( ! domain.currentUserCanManage ) {
+			return null;
+		}
+
 		if ( ! this.isDomainInNormalState() && ! this.isDomainInGracePeriod() ) {
 			return null;
 		}
@@ -233,6 +237,10 @@ class DomainManagementNavigationEnhanced extends React.Component {
 	getTransferDomain() {
 		const { moment, selectedSite, translate, domain, currentRoute } = this.props;
 		const { expired, isLocked, transferAwayEligibleAt } = domain;
+
+		if ( ! domain.currentUserCanManage ) {
+			return null;
+		}
 
 		if ( expired && ! this.isDomainInGracePeriod() ) {
 			return null;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This only allows the domain contact info to be viewed by the domain owners, and not other users of the same site.

<img width="739" alt="Screenshot 2020-06-23 at 3 52 12 PM" src="https://user-images.githubusercontent.com/13062352/85412100-83768e80-b569-11ea-9dbc-cb5d49f35117.png">


#### Testing instructions

* For a site you are a member of, go to a registered domain you do not own
* Click on 'Update your contact information' from the navigation menu
* You should see the error shown in the screenshot above
