### PR TITLE
FSE plugin: fix broken site editor page

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nux/src/disable-core-nux.js
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nux/src/disable-core-nux.js
@@ -8,7 +8,7 @@ import '@wordpress/nux'; //ensure nux store loads
 // Disable nux and welcome guide features from core.
 const unsubscribe = subscribe( () => {
 	dispatch( 'core/nux' ).disableTips();
-	if ( select( 'core/edit-post' ).isFeatureActive( 'welcomeGuide' ) ) {
+	if ( select( 'core/edit-post' )?.isFeatureActive( 'welcomeGuide' ) ) {
 		dispatch( 'core/edit-post' ).toggleFeature( 'welcomeGuide' );
 	}
 	unsubscribe();
@@ -20,7 +20,7 @@ subscribe( () => {
 		dispatch( 'core/nux' ).disableTips();
 		dispatch( 'automattic/nux' ).setWpcomNuxStatus( { isNuxEnabled: true } );
 	}
-	if ( select( 'core/edit-post' ).isFeatureActive( 'welcomeGuide' ) ) {
+	if ( select( 'core/edit-post' )?.isFeatureActive( 'welcomeGuide' ) ) {
 		dispatch( 'core/edit-post' ).toggleFeature( 'welcomeGuide' );
 		dispatch( 'automattic/nux' ).setWpcomNuxStatus( { isNuxEnabled: true } );
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Noticed this today while testing some unrelated FSE changes in Gutenberg. When this NUX code runs in `edit-site` context it breaks the site editor, since the `core/edit-post` store is not initialized there.

```
wpcom-block-editor-nux.js?ver=2abd647072b43030fb24f5d895691b61:1 Uncaught TypeError: Cannot read property 'isFeatureActive' of null
    at wpcom-block-editor-nux.js?ver=2abd647072b43030fb24f5d895691b61:1
    at registry.js:56
    at Array.forEach (<anonymous>)
    at globalListener (registry.js:56)
    at index.js:93
    at Object.dispatch (redux.js:221)
    at e (<anonymous>:1:40553)
    at promise-middleware.js:20
    at Object.dispatch (resolvers-cache-middleware.js:52)
    at Object.addFormatTypes (index.js:207)
```

#### Testing instructions

1. Use a local test site with Gutenberg and FSE plugin activated.
2. Activate the FSE experiment.
3. Delete local storage for the site. It's not reproducible if the NUX guide has already been dismissed in post editor.
4. Verify that the site editor loads correctly.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
