### PR TITLE
DomainPicker: Fix invalid color argument error.

### DIFF
--- a/packages/domain-picker/src/domain-picker/style.scss
+++ b/packages/domain-picker/src/domain-picker/style.scss
@@ -220,7 +220,7 @@
 		right: 14px;
 
 		&:hover {
-			background: mix( black, $blue-medium-focus, 10% );
+			background: mix( #000, $blue-medium-focus, 10% );
 		}
 
 		span {


### PR DESCRIPTION
Ignore this PR. See fix in https://github.com/Automattic/wp-calypso/pull/42835/commits/68018933e70284d5219aa90c9866fff90db72bf9.

Related: https://github.com/Automattic/wp-calypso/pull/42835#issuecomment-648222732