### PR TITLE
Prevent language picker search from opening on keydown while holding key modifier

### DIFF
--- a/client/components/language-picker/modal.jsx
+++ b/client/components/language-picker/modal.jsx
@@ -321,8 +321,10 @@ export class LanguagePickerModal extends PureComponent {
 			return;
 		}
 
+		const hasModifierKey = event.altKey || event.ctrlKey || event.metaKey;
+
 		// Handle character input
-		if ( isPrintableCharacter && ! isSearchOpen ) {
+		if ( ! hasModifierKey && isPrintableCharacter && ! isSearchOpen ) {
 			event.preventDefault();
 
 			this.handleSearch( event.key );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Prevent language picker search from opening on keydown while holding key modifier

#### Testing instructions

* Open language picker from http://calypso.localhost:3000/me/account.
* Hold key modifier and press a printable character, for example `Cmd + R`.
* Confirm that language search doesn't open.