### PR TITLE
Domains: Update header title depending on whether on a site or global level

### DIFF
--- a/client/my-sites/domains/domain-management/components/header/index.jsx
+++ b/client/my-sites/domains/domain-management/components/header/index.jsx
@@ -3,6 +3,7 @@
  */
 
 import React from 'react';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -11,14 +12,16 @@ import HeaderCake from 'components/header-cake';
 import DocumentHead from 'components/data/document-head';
 import FormattedHeader from 'components/formatted-header';
 import { useTranslate } from 'i18n-calypso';
+import getCurrentRoute from 'state/selectors/get-current-route';
+import { isUnderDomainManagementAll } from 'my-sites/domains/paths';
 
 /**
  * Style dependencies
  */
 import './style.scss';
 
-export default function DomainManagementHeader( props ) {
-	const { onClick, backHref, children } = props;
+const DomainManagementHeader = ( props ) => {
+	const { isManagingAllDomains, onClick, backHref, children } = props;
 	const translate = useTranslate();
 
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
@@ -27,7 +30,9 @@ export default function DomainManagementHeader( props ) {
 			<FormattedHeader
 				brandFont
 				className="stats__section-header"
-				headerText={ translate( 'Domains' ) }
+				headerText={
+					isManagingAllDomains ? translate( 'All Domains' ) : translate( 'Site Domains' )
+				}
 				align="left"
 			/>
 			<HeaderCake className="domain-management-header" onClick={ onClick } backHref={ backHref }>
@@ -39,4 +44,11 @@ export default function DomainManagementHeader( props ) {
 		</React.Fragment>
 	);
 	/* eslint-enable wpcalypso/jsx-classname-namespace */
-}
+};
+
+export default connect( ( state ) => {
+	const path = getCurrentRoute( state );
+	return {
+		isManagingAllDomains: isUnderDomainManagementAll( path ),
+	};
+} )( DomainManagementHeader );

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -192,7 +192,7 @@ export class List extends React.Component {
 					<FormattedHeader
 						brandFont
 						className="domain-management__page-heading"
-						headerText={ this.props.translate( 'Domains' ) }
+						headerText={ this.props.translate( 'Site Domains' ) }
 						align="left"
 					/>
 				) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Update the domains header to reflect whether the user is managing domains on a site level or on a global level.

<img width="521" alt="Screenshot 2020-06-23 at 5 13 07 PM" src="https://user-images.githubusercontent.com/13062352/85421619-ef122900-b574-11ea-95a2-aec46f9bb33b.png">
<img width="521" alt="Screenshot 2020-06-23 at 5 13 28 PM" src="https://user-images.githubusercontent.com/13062352/85421620-efaabf80-b574-11ea-870b-78948928b0c3.png">

#### Testing instructions

* Go to /domains/all
* Choose a domain
* Verify that the header title says "All Domains"

Then switch to a site:

* Navigate to Manage -> Domains
* Verify that the header title says "Site Domains"
* Verify the header title is the same after choosing a domain
