### PR TITLE
Jetpack: hide settings in Calypso if no Backup or Scan purchase

### DIFF
--- a/client/my-sites/site-settings/navigation.jsx
+++ b/client/my-sites/site-settings/navigation.jsx
@@ -1,11 +1,11 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
+
 /**
  * Internal dependencies
  */
@@ -13,8 +13,10 @@ import config from 'config';
 import SectionNav from 'components/section-nav';
 import NavTabs from 'components/section-nav/tabs';
 import NavItem from 'components/section-nav/item';
-import { getSelectedSite } from 'state/ui/selectors';
+import { siteHasScanProductPurchase } from 'state/purchases/selectors';
 import isJetpackSectionEnabledForSite from 'state/selectors/is-jetpack-section-enabled-for-site';
+import isRewindActive from 'state/selectors/is-rewind-active';
+import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 
 export class SiteSettingsNavigation extends Component {
 	static propTypes = {
@@ -108,10 +110,12 @@ export class SiteSettingsNavigation extends Component {
 
 export default connect( ( state ) => {
 	const site = getSelectedSite( state );
-	const shouldShowJetpackSettings = isJetpackSectionEnabledForSite( state, site.ID );
+	const siteId = getSelectedSiteId( state );
 
 	return {
 		site,
-		shouldShowJetpackSettings,
+		shouldShowJetpackSettings:
+			isJetpackSectionEnabledForSite( state, site.ID ) &&
+			( siteHasScanProductPurchase( state, siteId ) || isRewindActive( state, siteId ) ),
 	};
 } )( localize( SiteSettingsNavigation ) );

--- a/client/my-sites/site-settings/settings-jetpack/index.js
+++ b/client/my-sites/site-settings/settings-jetpack/index.js
@@ -7,9 +7,27 @@ import page from 'page';
  * Internal dependencies
  */
 import { makeLayout, render as clientRender } from 'controller';
-import { navigation, siteSelection } from 'my-sites/controller';
-import { jetpack } from './controller';
+import { navigation, siteSelection, notFound } from 'my-sites/controller';
 import { setScroll, siteSettings } from 'my-sites/site-settings/settings-controller';
+import { siteHasScanProductPurchase } from 'state/purchases/selectors';
+import isJetpackSectionEnabledForSite from 'state/selectors/is-jetpack-section-enabled-for-site';
+import isRewindActive from 'state/selectors/is-rewind-active';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { jetpack } from './controller';
+
+const notFoundIfNotEnabled = ( context, next ) => {
+	const state = context.store.getState();
+	const siteId = getSelectedSiteId( state );
+	const showJetpackSection = isJetpackSectionEnabledForSite( state, siteId );
+	const hasScanProduct = siteHasScanProductPurchase( state, siteId );
+	const hasActiveRewind = isRewindActive( state, siteId );
+
+	if ( ! showJetpackSection || ( ! hasScanProduct && ! hasActiveRewind ) ) {
+		return notFound( context, next );
+	}
+
+	next();
+};
 
 export default function () {
 	page(
@@ -19,6 +37,7 @@ export default function () {
 		setScroll,
 		siteSettings,
 		jetpack,
+		notFoundIfNotEnabled,
 		makeLayout,
 		clientRender
 	);

--- a/client/my-sites/site-settings/settings-jetpack/main.jsx
+++ b/client/my-sites/site-settings/settings-jetpack/main.jsx
@@ -10,7 +10,6 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import DocumentHead from 'components/data/document-head';
-import getRewindState from 'state/selectors/get-rewind-state';
 import JetpackCredentials from 'my-sites/site-settings/jetpack-credentials';
 import JetpackDevModeNotice from 'my-sites/site-settings/jetpack-dev-mode-notice';
 import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
@@ -20,18 +19,12 @@ import QuerySitePurchases from 'components/data/query-site-purchases';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import FormattedHeader from 'components/formatted-header';
 import SiteSettingsNavigation from 'my-sites/site-settings/navigation';
-import { getSitePurchases } from 'state/purchases/selectors';
-import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
+import { siteHasScanProductPurchase } from 'state/purchases/selectors';
+import isRewindActive from 'state/selectors/is-rewind-active';
 import { isJetpackSite } from 'state/sites/selectors';
+import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 
-const SiteSettingsJetpack = ( {
-	rewindState,
-	sitePurchases,
-	site,
-	siteId,
-	siteIsJetpack,
-	translate,
-} ) => {
+const SiteSettingsJetpack = ( { site, siteId, siteIsJetpack, showCredentials, translate } ) => {
 	//todo: this check makes sense in Jetpack section?
 	if ( ! siteIsJetpack ) {
 		return (
@@ -46,13 +39,6 @@ const SiteSettingsJetpack = ( {
 			/>
 		);
 	}
-
-	const isRewindActive = [ 'awaitingCredentials', 'provisioning', 'active' ].includes(
-		rewindState.state
-	);
-	const hasScanProduct = sitePurchases.some( ( p ) => p.productSlug.includes( 'jetpack_scan' ) );
-
-	const showCredentials = isRewindActive || hasScanProduct;
 
 	return (
 		<Main className="settings-jetpack site-settings">
@@ -75,24 +61,20 @@ const SiteSettingsJetpack = ( {
 };
 
 SiteSettingsJetpack.propTypes = {
-	rewindState: PropTypes.bool,
-	sitePurchases: PropTypes.array,
 	site: PropTypes.object,
 	siteId: PropTypes.number,
 	siteIsJetpack: PropTypes.bool,
+	showCredentials: PropTypes.bool,
 };
 
 export default connect( ( state ) => {
 	const site = getSelectedSite( state );
 	const siteId = getSelectedSiteId( state );
-	const rewindState = getRewindState( state, siteId );
-	const sitePurchases = getSitePurchases( state, siteId );
 
 	return {
-		rewindState,
-		sitePurchases,
 		site,
 		siteId,
 		siteIsJetpack: isJetpackSite( state, siteId ),
+		showCredentials: isRewindActive( state, siteId ) || siteHasScanProductPurchase( state, siteId ),
 	};
 } )( localize( SiteSettingsJetpack ) );

--- a/client/state/purchases/selectors.js
+++ b/client/state/purchases/selectors.js
@@ -14,6 +14,7 @@ import {
 	isDomainRegistration,
 	isDomainMapping,
 	isJetpackBackup,
+	isJetpackScan,
 	isJetpackProduct,
 } from 'lib/products-values';
 import { getPlan, findPlansKeys } from 'lib/plans';
@@ -112,6 +113,20 @@ export const siteHasBackupProductPurchase = ( state, siteId ) => {
 	return some(
 		getSitePurchases( state, siteId ),
 		( purchase ) => purchase.active && isJetpackBackup( purchase )
+	);
+};
+
+/**
+ * Whether a site has an active Jetpack Scan purchase.
+ *
+ * @param   {object} state       global state
+ * @param   {number} siteId      the site id
+ * @returns {boolean} True if the site has an active Jetpack Scan purchase, false otherwise.
+ */
+export const siteHasScanProductPurchase = ( state, siteId ) => {
+	return some(
+		getSitePurchases( state, siteId ),
+		( purchase ) => purchase.active && isJetpackScan( purchase )
 	);
 };
 

--- a/client/state/selectors/is-rewind-active.ts
+++ b/client/state/selectors/is-rewind-active.ts
@@ -1,0 +1,17 @@
+/**
+ * Internal dependencies
+ */
+import getRewindState from 'state/selectors/get-rewind-state';
+
+/**
+ * Indicates whether the Rewind feature is active
+ *
+ * @param {object} state Global state tree
+ * @param {number|string} siteId the site ID
+ * @returns {boolean} true if rewind is active
+ */
+export default function isRewindActive( state, siteId ): boolean {
+	return [ 'awaitingCredentials', 'provisioning', 'active' ].includes(
+		getRewindState( state, siteId ).state
+	);
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

A Jetpack site with no Backup or Scan purchase has an empty _Manage > Settings > Jetpack_ section (see screenshot below). This PR removes the section altogether in such cases.

#### Testing instructions

- Download the PR and run Calypso
- Make sure Jetpack sections are **not** enabled
- Select a Jetpack site with Backup and/or Scan
- Go to _Manage > Settings > Security_ and check that you see the credentials form
- Active Jetpack sections. The page refreshes.
- Still in _Settings > Security_, you should now see a banner with a link to _Settings > Jetpack_
- Click it and verify that you're brought to  _Settings > Jetpack_ and see the credentials form
- Select a Jetpack site with neither Backup nor Scan
- The _Jetpack_ item shouldn't be present in the tab navigation anymore
- `settings/jetpack/:site` should show a 404 error
- The banner should not be present at the top of the _Security_ section anymore

#### Screenshots

<img width="695" alt="Capture" src="https://user-images.githubusercontent.com/1620183/85426200-261e1580-b548-11ea-9323-89d00b9b6c78.png">

