### PR TITLE
Jetpack: Fix the status transfer issue with the recent reverted Atomic sites

### DIFF
--- a/client/components/jetpack/wpcom-business-at/index.tsx
+++ b/client/components/jetpack/wpcom-business-at/index.tsx
@@ -43,6 +43,7 @@ import { localizeUrl } from 'lib/i18n-utils';
 import { successNotice } from 'state/notices/actions';
 import { requestSite } from 'state/sites/actions';
 import isJetpackSite from 'state/sites/selectors/is-jetpack-site';
+import { fetchAutomatedTransferStatus } from 'state/automated-transfer/actions';
 
 /**
  * Style dependencies
@@ -163,6 +164,14 @@ export default function WPCOMBusinessAT(): ReactElement {
 	const trackInitiateAT = useTrackCallback( initiateAT, 'calypso_jetpack_backup_business_at' );
 
 	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
+
+	useEffect( () => {
+		// Check if a reverted site still has the COMPLETE status
+		if ( automatedTransferStatus === COMPLETE ) {
+			// Try to refresh the transfer state
+			dispatch( fetchAutomatedTransferStatus( siteId ) );
+		}
+	}, [] );
 
 	useEffect( () => {
 		if ( automatedTransferStatus !== COMPLETE ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes the status transfer issue when you revert an Atomic site and then go to the Backup section and see the upsell page but with the "Active Jetpack Backup now" disabled with the spinner animation.

#### Testing instructions

- Revert an Atomic site
- Reload the Backup section
- Check if you see the "Activate Jetpack Backup now" button enabled.
