### PR TITLE
Checkout: update translation strings and methods for consistency

### DIFF
--- a/packages/composite-checkout/src/components/checkout-order-summary.js
+++ b/packages/composite-checkout/src/components/checkout-order-summary.js
@@ -15,7 +15,6 @@ import {
 	useTotal,
 	renderDisplayValueMarkdown,
 } from '../public-api';
-import { useTranslate } from 'i18n-calypso';
 
 export default function CheckoutOrderSummaryStep() {
 	const [ items ] = useLineItems();
@@ -63,13 +62,13 @@ const CheckoutSummaryStepTotal = styled.span`
 `;
 
 export function CheckoutOrderSummary() {
-	const translate = useTranslate();
+	const { __ } = useI18n();
 	const taxes = useLineItemsOfType( 'tax' );
 	const total = useTotal();
 
 	return (
 		<CheckoutSummaryCard>
-			<CheckoutSummaryTitle>{ translate( 'Purchase Details' ) }</CheckoutSummaryTitle>
+			<CheckoutSummaryTitle>{ __( 'Purchase Details' ) }</CheckoutSummaryTitle>
 			<CheckoutSummaryAmountWrapper>
 				{ taxes.map( ( tax ) => (
 					<CheckoutSummaryLineItem key={ 'checkout-summary-line-item-' + tax.id }>
@@ -78,7 +77,7 @@ export function CheckoutOrderSummary() {
 					</CheckoutSummaryLineItem>
 				) ) }
 				<CheckoutSummaryTotal>
-					<span>{ translate( 'Total' ) }</span>
+					<span>{ __( 'Total' ) }</span>
 					<span>{ renderDisplayValueMarkdown( total.amount.displayValue ) }</span>
 				</CheckoutSummaryTotal>
 			</CheckoutSummaryAmountWrapper>

--- a/packages/composite-checkout/src/components/checkout-steps.js
+++ b/packages/composite-checkout/src/components/checkout-steps.js
@@ -366,8 +366,8 @@ export function CheckoutStepBody( {
 							? goToThisStep
 							: null
 					}
-					editButtonText={ editButtonText || 'Edit' }
-					editButtonAriaLabel={ editButtonAriaLabel || 'Edit this step' }
+					editButtonText={ editButtonText || __( 'Edit' ) }
+					editButtonAriaLabel={ editButtonAriaLabel || __( 'Edit this step' ) }
 				/>
 				<StepContentUI isVisible={ isStepActive } className="checkout-steps__step-content">
 					{ activeStepContent }
@@ -376,13 +376,13 @@ export function CheckoutStepBody( {
 							onClick={ goToNextStep }
 							value={
 								formStatus === 'validating'
-									? validatingButtonText || 'Please wait…'
-									: nextStepButtonText || 'Continue'
+									? validatingButtonText || __( 'Please wait…' )
+									: nextStepButtonText || __( 'Continue' )
 							}
 							ariaLabel={
 								formStatus === 'validating'
-									? validatingButtonAriaLabel || 'Please wait…'
-									: nextStepButtonAriaLabel || 'Continue to next step'
+									? validatingButtonAriaLabel || __( 'Please wait…' )
+									: nextStepButtonAriaLabel || __( 'Continue to next step' )
 							}
 							buttonType="primary"
 							disabled={ formStatus !== 'ready' }
@@ -407,6 +407,7 @@ CheckoutStepBody.propTypes = {
 	errorMessage: PropTypes.string,
 	onError: PropTypes.func,
 	editButtonAriaLabel: PropTypes.string,
+	editButtonText: PropTypes.string,
 	nextStepButtonText: PropTypes.string,
 	nextStepButtonAriaLabel: PropTypes.string,
 	isStepActive: PropTypes.bool.isRequired,
@@ -586,7 +587,7 @@ function CheckoutStepHeader( {
 					className="checkout-step__edit-button"
 					buttonType="text-button"
 					onClick={ onEdit }
-					aria-label={ editButtonAriaLabel }
+					aria-label={ editButtonAriaLabel || __( 'Edit this step' ) }
 				>
 					{ editButtonText || __( 'Edit' ) }
 				</HeaderEditButton>


### PR DESCRIPTION
This just cleans up some minor i18n inconsistencies, wrapping fallback strings in translation functions and replacing a missed instance of `calypso-i18n` with `react-i18n`.

**To Test:**
- visual should suffice