### PR TITLE
Fix display of account recovery email and phone when specified

### DIFF
--- a/client/me/security-checkup/account-recovery-email.jsx
+++ b/client/me/security-checkup/account-recovery-email.jsx
@@ -70,7 +70,7 @@ class SecurityCheckupAccountRecoveryEmail extends React.Component {
 						recoveryEmailAddress: accountRecoveryEmail,
 					},
 					components: {
-						strong: '<strong>',
+						strong: <strong />,
 					},
 				}
 			);

--- a/client/me/security-checkup/account-recovery-phone.jsx
+++ b/client/me/security-checkup/account-recovery-phone.jsx
@@ -67,7 +67,7 @@ class SecurityCheckupAccountRecoveryPhone extends React.Component {
 				'You have set {{strong}}%(recoveryPhoneNumber)s{{/strong}} as your recovery SMS number.',
 				{
 					args: {
-						recoveryPhoneNumber: accountRecoveryPhone,
+						recoveryPhoneNumber: accountRecoveryPhone.numberFull,
 					},
 					components: {
 						strong: <strong />,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix the `strong` element when the account recovery email is specified and verified
* Fix the account recovery phone number display

#### Testing instructions

* Set up your WordPress.com account to have a recovery email and a recovery phone number, and ensure that both are verified.
* Visit `/me/security`, either locally or at https://calypso.live/?branch=fix/me-security-menu-typos.
* The "Recovery Email" item should show descriptive text that does not include `{{strong}}` or `{{/strong}}`. In English, that text should be: You have set **email@example.com** as your recovery email address.
* The "Recovery SMS Number" item should show descriptive text that includes your recovery number and not `[Object object]`.