### PR TITLE
Move Jetpack sidebar item below the Site sidebar item

### DIFF
--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -885,8 +885,6 @@ export class MySitesSidebar extends Component {
 					</ul>
 				</SidebarMenu>
 
-				{ this.props.shouldRenderJetpackSection && this.jetpack() }
-
 				{ this.props.siteId && <QuerySiteChecklist siteId={ this.props.siteId } /> }
 				<ExpandableSidebarMenu
 					onClick={ this.toggleSection( SIDEBAR_SECTION_SITE ) }
@@ -896,6 +894,8 @@ export class MySitesSidebar extends Component {
 				>
 					{ this.site() }
 				</ExpandableSidebarMenu>
+
+				{ this.props.shouldRenderJetpackSection && this.jetpack() }
 
 				{ ! ( isEnabled( 'signup/wpforteams' ) && this.props.isSiteWPForTeams ) && this.design() ? (
 					<ExpandableSidebarMenu


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Move the Jetpack sidebar item below the Site sidebar item.

#### Testing instructions

* Load Calypso for a Jetpack site. Enable the Jetpack  Ensure that the "Jetpack" sidebar item appears below the "Site" sidebar item.

Fixes #
