### PR TITLE
Typography: Update sizes 19, 20, 21, 22px to use $font-title-small/20px

### DIFF
--- a/client/blocks/ecommerce-manage-nudge/style.scss
+++ b/client/blocks/ecommerce-manage-nudge/style.scss
@@ -27,7 +27,7 @@
 
 
 .ecommerce-manage-nudge__title {
-	font-size: 21px;
+	font-size: $font-title-small;
 	font-weight: 400;
 	margin: 0 0 5px;
 }

--- a/client/blocks/google-my-business-stats-nudge/style.scss
+++ b/client/blocks/google-my-business-stats-nudge/style.scss
@@ -28,7 +28,7 @@
 }
 
 .google-my-business-stats-nudge__title {
-	font-size: 21px;
+	font-size: $font-title-small;
 	font-weight: 400;
 	margin: 10px 0 5px;
 }

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -180,7 +180,7 @@
 }
 
 .login__form-header {
-	font-size: 22px;
+	font-size: $font-title-small;
 	margin-bottom: 24px;
 	margin-top: 16px;
 	text-align: center;

--- a/client/blocks/reader-feed-header/style.scss
+++ b/client/blocks/reader-feed-header/style.scss
@@ -44,7 +44,7 @@
 .reader-feed-header__site .reader-feed-header__site-title {
 	align-self: stretch;
 	font-family: $serif;
-	font-size: 21px;
+	font-size: $font-title-small;
 	font-weight: 600;
 	max-height: 16px * 4;
 	overflow: hidden;

--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -21,7 +21,7 @@
 	}
 
 	h3 {
-		font-size: 20px;
+		font-size: $font-title-small;
 		font-weight: 700;
 		margin: 0 0 8px;
 	}
@@ -291,7 +291,7 @@
 // Discover-Specific Full Post View Styles
 .blog-53424024 .reader-full-post__story-content {
 	.intro {
-		font-size: 20px;
+		font-size: $font-title-small;
 		font-weight: 700;
 		margin: 0 0 24px;
 

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -433,7 +433,7 @@
 .reader-post-card__title-link:visited {
 	color: var( --color-neutral-70 );
 	cursor: pointer;
-	font-size: 19px;
+	font-size: $font-title-small;
 	font-weight: 600;
 	display: block;
 
@@ -442,7 +442,7 @@
 	}
 
 	@include breakpoint-deprecated( '>480px' ) {
-		font-size: 19px;
+		font-size: $font-title-small;
 	}
 }
 

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -440,10 +440,6 @@
 	&:hover {
 		color: var( --color-neutral-70 );
 	}
-
-	@include breakpoint-deprecated( '>480px' ) {
-		font-size: $font-title-small;
-	}
 }
 
 .reader-post-card .reader-excerpt {

--- a/client/blocks/signup-form/crowdsignal.scss
+++ b/client/blocks/signup-form/crowdsignal.scss
@@ -145,7 +145,7 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 
 .signup-form__crowdsignal-card-header {
 	display: none;
-	font-size: 20px;
+	font-size: $font-title-small;
 	font-weight: 600;
 	margin: 0 0 30px;
 	text-align: center;

--- a/client/blocks/support-article-dialog/content.scss
+++ b/client/blocks/support-article-dialog/content.scss
@@ -21,7 +21,7 @@
 	}
 
 	h3 {
-		font-size: 20px;
+		font-size: $font-title-small;
 		font-weight: 700;
 		margin: 0 0 8px;
 	}

--- a/client/blocks/upwork-stats-nudge/style.scss
+++ b/client/blocks/upwork-stats-nudge/style.scss
@@ -24,7 +24,7 @@
 }
 
 .upwork-stats-nudge__title {
-	font-size: 21px;
+	font-size: $font-title-small;
 	font-weight: 400;
 	margin: 10px 0 5px;
 }

--- a/client/components/action-card/style.scss
+++ b/client/components/action-card/style.scss
@@ -46,7 +46,7 @@
 }
 
 .action-card__heading {
-	font-size: 21px;
+	font-size: $font-title-small;
 	margin: 5px 0;
 
 	@include breakpoint-deprecated( '>960px' ) {

--- a/client/components/action-panel/style.scss
+++ b/client/components/action-panel/style.scss
@@ -8,7 +8,7 @@
 // Title
 .action-panel__title {
 	margin-bottom: 16px;
-	font-size: 21px;
+	font-size: $font-title-small;
 	line-height: 24px;
 	color: var( --color-neutral-70 );
 	clear: none;

--- a/client/components/card-heading/docs/example.jsx
+++ b/client/components/card-heading/docs/example.jsx
@@ -20,8 +20,8 @@ export default class CardHeadingExample extends PureComponent {
 				<CardHeading tagName="h1" size={ 54 }>
 					This is a CardHeading, H1 at 54px
 				</CardHeading>
-				<CardHeading tagName="h2" size={ 47 }>
-					This is a CardHeading, H2 at 47px
+				<CardHeading tagName="h2" size={ 48 }>
+					This is a CardHeading, H2 at 48px
 				</CardHeading>
 				<CardHeading tagName="h3" size={ 36 }>
 					This is a CardHeading, H3 at 36px
@@ -32,8 +32,8 @@ export default class CardHeadingExample extends PureComponent {
 				<CardHeading tagName="h5" size={ 24 }>
 					This is a CardHeading, H5 at 24px
 				</CardHeading>
-				<CardHeading tagName="h6" size={ 21 }>
-					This is a CardHeading, H6 at 21px
+				<CardHeading tagName="h6" size={ 20 }>
+					This is a CardHeading, H6 at 20px
 				</CardHeading>
 			</Card>
 		);

--- a/client/components/card-heading/index.jsx
+++ b/client/components/card-heading/index.jsx
@@ -17,9 +17,10 @@ import { preventWidows } from 'lib/formatting';
  */
 import './style.scss';
 
-const validTypeSizes = [ 54, 47, 36, 32, 24, 21, 16, 14, 11 ];
+//Sizes 47, 21, and 11 are deprecated; use the nearest equivalent
+const validTypeSizes = [ 54, 48, 47, 36, 32, 24, 21, 20, 16, 14, 12, 11 ];
 
-function CardHeading( { tagName = 'h1', size = 21, children } ) {
+function CardHeading( { tagName = 'h1', size = 20, children } ) {
 	const classNameObject = {};
 	classNameObject[ 'card-heading-' + size ] = includes( validTypeSizes, size );
 	const classes = classNames( 'card-heading', classNameObject );

--- a/client/components/card-heading/style.scss
+++ b/client/components/card-heading/style.scss
@@ -13,7 +13,9 @@
 	font-size: 54px;
 }
 
-.card-heading-47 {
+/* 47px is deprecated, use .card-heading-48 */
+.card-heading-47,
+.card-heading-48 {
 	font-size: 47px;
 }
 

--- a/client/components/card-heading/style.scss
+++ b/client/components/card-heading/style.scss
@@ -30,7 +30,7 @@
 }
 
 .card-heading-21 {
-	font-size: 21px;
+	font-size: $font-title-small;
 }
 
 .card-heading-16 {

--- a/client/components/card-heading/style.scss
+++ b/client/components/card-heading/style.scss
@@ -29,7 +29,9 @@
 	font-size: 24px;
 }
 
-.card-heading-21 {
+/* 21px is deprecated, use .card-heading-20 */
+.card-heading-21,
+.card-heading-20 {
 	font-size: $font-title-small;
 }
 
@@ -41,6 +43,8 @@
 	font-size: $font-body-small;
 }
 
-.card-heading-11 {
+/* 11px is deprecated, use .card-heading-12 */
+.card-heading-11,
+.card-heading-12 {
 	font-size: $font-body-extra-small;
 }

--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -154,7 +154,7 @@
 			font-size: 1.6em;
 		}
 		.featured-domain-suggestions--title-in-14em & {
-			font-size: 1.4em;
+			font-size: $font-title-small;
 		}
 		.featured-domain-suggestions--title-in-12em & {
 			font-size: 1.2em;

--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -77,7 +77,7 @@
     }
 
     .domain-registration-suggestion__title {
-		font-size: 20px;
+		font-size: $font-title-small;
 		font-weight: 400;
 		line-height: 1.2;
 		margin-bottom: 0.25em;

--- a/client/components/domains/free-domain-explainer/style.scss
+++ b/client/components/domains/free-domain-explainer/style.scss
@@ -2,7 +2,7 @@
 
     color: var( --color-text );
     font-weight: 400;
-    font-size: 20px;
+    font-size: $font-title-small;
     line-height: 1.3;
     margin: 0;
     margin-bottom: 0.7em;

--- a/client/components/domains/use-your-domain-step/style.scss
+++ b/client/components/domains/use-your-domain-step/style.scss
@@ -57,7 +57,7 @@
 	}
 
 	.use-your-domain-step__option-title {
-		font-size: 1.4em;
+		font-size: $font-title-small;
 		font-weight: 400;
 		line-height: 1.4;
 		margin-bottom: 0.25em;

--- a/client/components/email-verification/email-verification-dialog/style.scss
+++ b/client/components/email-verification/email-verification-dialog/style.scss
@@ -9,7 +9,7 @@
 }
 
 .email-verification-dialog__confirmation-dialog-heading {
-	font-size: 22px;
+	font-size: $font-title-small;
 	line-height: 1.2;
 	margin: 0 0 4px;
 }

--- a/client/components/empty-content/style.scss
+++ b/client/components/empty-content/style.scss
@@ -29,7 +29,7 @@
 
 .empty-content__line {
 	color: var( --color-neutral-50 );
-	font-size: 22px;
+	font-size: $font-title-small;
 	margin-bottom: 40px;
 
 	@include breakpoint-deprecated( '<660px' ) {

--- a/client/components/formatted-header/style.scss
+++ b/client/components/formatted-header/style.scss
@@ -29,7 +29,7 @@
 }
 
 .formatted-header__title {
-	font-size: 20px;
+	font-size: $font-title-small;
 	margin-top: 24px;
 	padding: 0 10px;
 	line-height: 1.2em;

--- a/client/components/happiness-support/style.scss
+++ b/client/components/happiness-support/style.scss
@@ -34,7 +34,7 @@
 .happiness-support__heading {
 	color: var( --color-text-subtle );
 	clear: none;
-	font-size: 21px;
+	font-size: $font-title-small;
 }
 
 .happiness-support__description {

--- a/client/components/product-card/style.scss
+++ b/client/components/product-card/style.scss
@@ -69,10 +69,6 @@
 	font-size: $font-title-small;
 	line-height: 24px;
 
-	@include breakpoint-deprecated( '>960px' ) {
-		font-size: $font-title-small;
-	}
-
 	em,
 	strong,
 	span {

--- a/client/components/product-card/style.scss
+++ b/client/components/product-card/style.scss
@@ -70,7 +70,7 @@
 	line-height: 24px;
 
 	@include breakpoint-deprecated( '>960px' ) {
-		font-size: 22px;
+		font-size: $font-title-small;
 	}
 
 	em,

--- a/client/components/product-card/style.scss
+++ b/client/components/product-card/style.scss
@@ -66,7 +66,7 @@
 }
 
 .product-card__title {
-	font-size: 20px;
+	font-size: $font-title-small;
 	line-height: 24px;
 
 	@include breakpoint-deprecated( '>960px' ) {

--- a/client/components/promo-section/promo-card/style.scss
+++ b/client/components/promo-section/promo-card/style.scss
@@ -36,7 +36,7 @@
 
 		.action-panel__title {
 			@extend .wp-brand-font;
-			font-size: 20px;
+			font-size: $font-title-small;
 			line-height: 28px;
 			margin-bottom: 8px;
 		}

--- a/client/components/purchase-detail/style.scss
+++ b/client/components/purchase-detail/style.scss
@@ -132,7 +132,7 @@
 .purchase-detail__title {
 	clear: none;
 	color: var( --color-neutral-40 );
-	font-size: 21px;
+	font-size: $font-title-small;
 }
 
 .purchase-detail__description {

--- a/client/components/theme/style.scss
+++ b/client/components/theme/style.scss
@@ -235,7 +235,7 @@ $theme-info-height: 54px;
 		cursor: pointer;
 		color: var( --color-neutral-light );
 		padding: 15px 19px;
-		font-size: 20px;
+		font-size: $font-title-small;
 		font-weight: 600;
 		font-weight: 600;
 

--- a/client/devdocs/style.scss
+++ b/client/devdocs/style.scss
@@ -361,7 +361,7 @@ $devdocs-max-width: 720px;
 		font-weight: 600;
 		line-height: 1.2;
 		margin: 32px 0 16px;
-		font-size: 21px;
+		font-size: $font-title-small;
 		color: var( --color-neutral-60 );
 	}
 

--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -619,7 +619,7 @@
 	h2 {
 		margin-bottom: 0;
 		font-weight: 600;
-		font-size: 20px;
+		font-size: $font-title-small;
 	}
 
 	.products__product-form-variation-description {

--- a/client/extensions/woocommerce/app/store-stats/store-stats-orders-chart/style.scss
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-orders-chart/style.scss
@@ -37,7 +37,7 @@
 
 			.store-stats-orders-chart__value.value {
 				display: inline-block;
-				font-size: 20px;
+				font-size: $font-title-small;
 				font-weight: 400;
 				margin-top: 4px;
 			}

--- a/client/extensions/woocommerce/components/reading-widget/style.scss
+++ b/client/extensions/woocommerce/components/reading-widget/style.scss
@@ -7,7 +7,7 @@
 
 	.reading-widget__heading {
 		h2 {
-			font-size: 20px;
+			font-size: $font-title-small;
 			margin-bottom: 16px;
 		}
 

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -277,7 +277,7 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 }
 
 .jetpack-connect__install-step-title {
-	font-size: 21px;
+	font-size: $font-title-small;
 }
 
 .jetpack-connect__install-step-text {
@@ -481,7 +481,7 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 
 .jetpack-connect__sso-log-in-as {
 	font-family: $sans;
-	font-size: 21px;
+	font-size: $font-title-small;
 	text-align: center;
 }
 
@@ -1214,7 +1214,7 @@ body.is-section-jetpack-connect .layout {
 
 	.product-card__title,
 	.product-card__title:not( .is-purchased ) {
-		font-size: 20px;
+		font-size: $font-title-small;
 		color: var( --color-neutral-70 );
 	}
 

--- a/client/landing/domains/content-card/style.scss
+++ b/client/landing/domains/content-card/style.scss
@@ -14,7 +14,7 @@
 
 	.content-card__message {
 		color: var( --color-neutral-50 );
-		font-size: 22px;
+		font-size: $font-title-small;
 		font-weight: 400;
 		margin-bottom: 40px;
 		text-align: left;

--- a/client/landing/domains/header/style.scss
+++ b/client/landing/domains/header/style.scss
@@ -1,7 +1,7 @@
 .header {
 	text-align: center;
 	h2.header__title {
-		font-size: 20px;
+		font-size: $font-title-small;
 		font-weight: 400;
 		margin: 0;
 

--- a/client/landing/jetpack-cloud/sections/settings/style.scss
+++ b/client/landing/jetpack-cloud/sections/settings/style.scss
@@ -49,7 +49,7 @@
 }
 
 .settings__title {
-	font-size: 22px;
+	font-size: $font-title-small;
 	font-weight: 600;
 	margin: 16px 0 24px;
 

--- a/client/landing/jetpack-cloud/style.scss
+++ b/client/landing/jetpack-cloud/style.scss
@@ -192,7 +192,7 @@
 html {
 
 	h2 {
-		font-size: 22px;
+		font-size: $font-title-small;
 		font-weight: 600;
 		line-height: 32px;
 

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -742,7 +742,7 @@
 	.login__form-header,
 	.signup-form__jetpack-cloud-wrapper h3 {
 		font-weight: 600;
-		font-size: 22px;
+		font-size: $font-title-small;
 		line-height: 32px;
 		margin-top: 16px;
 		margin-bottom: 8px;

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -250,7 +250,7 @@
 			span {
 				background-color: transparent;
 				color: var( --color-text );
-				font-size: 20px;
+				font-size: $font-title-small;
 				font-weight: 600;
 			}
 		}
@@ -260,7 +260,7 @@
 
 			@include breakpoint-deprecated( '>660px' ) {
 				display: block;
-				font-size: 20px;
+				font-size: $font-title-small;
 				font-weight: 600;
 				margin: 0 0 30px;
 				text-align: center;

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -49,7 +49,7 @@
 }
 
 .magic-login__form-header {
-	font-size: 22px;
+	font-size: $font-title-small;
 	margin-bottom: 24px;
 	margin-top: 16px;
 	text-align: center;

--- a/client/me/account-close/confirm-dialog.scss
+++ b/client/me/account-close/confirm-dialog.scss
@@ -7,7 +7,7 @@
 h1.account-close__confirm-dialog-header {
 	height: auto;
 	margin-bottom: 16px;
-	font-size: 21px;
+	font-size: $font-title-small;
 	font-weight: 400;
 	line-height: 24px;
 	color: var( --color-neutral-70 );

--- a/client/me/account-close/style.scss
+++ b/client/me/account-close/style.scss
@@ -1,6 +1,6 @@
 .account-close__heading {
 	margin-bottom: 16px;
-	font-size: 21px;
+	font-size: $font-title-small;
 	font-weight: 400;
 	line-height: 24px;
 	color: var( --color-neutral-70 );

--- a/client/me/billing-history/style.scss
+++ b/client/me/billing-history/style.scss
@@ -258,7 +258,7 @@ textarea.billing-history__billing-details-editable {
 	}
 
 	h4 {
-		font-size: 20px;
+		font-size: $font-title-small;
 	}
 
 	.billing-history__receipt-loading {

--- a/client/me/help/help-courses/style.scss
+++ b/client/me/help/help-courses/style.scss
@@ -32,7 +32,7 @@
 	@extend %content-font;
 	color: var( --color-neutral-70 );
 	font-weight: 700;
-	font-size: 21px;
+	font-size: $font-title-small;
 	line-height: 1.3;
 
 	margin-bottom: 8px;

--- a/client/me/help/style.scss
+++ b/client/me/help/style.scss
@@ -47,7 +47,7 @@
 	font-size: $font-body;
 	color: var( --color-primary );
 	@include breakpoint-deprecated( '>660px' ) {
-		font-size: 21px;
+		font-size: $font-title-small;
 	}
 }
 

--- a/client/me/profile-gravatar/style.scss
+++ b/client/me/profile-gravatar/style.scss
@@ -16,7 +16,7 @@
 }
 
 .profile-gravatar__user-display-name {
-	font-size: 20px;
+	font-size: $font-title-small;
 	font-weight: 600;
 	line-height: 1.1;
 	margin: 16px 16px 4px;

--- a/client/me/purchases/cancel-purchase/style.scss
+++ b/client/me/purchases/cancel-purchase/style.scss
@@ -1,7 +1,7 @@
 .cancel-purchase__card {
 	h2 {
 		color: var( --color-neutral-70 );
-		font-size: 21px;
+		font-size: $font-title-small;
 		font-weight: 400;
 		margin-bottom: 20px;
 	}

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -148,7 +148,7 @@
 	clear: none;
 
 	@include breakpoint-deprecated( '>660px' ) {
-		font-size: 22px;
+		font-size: $font-title-small;
 		padding-right: 100px;
 	}
 }

--- a/client/my-sites/activity/activity-log-confirm-dialog/style.scss
+++ b/client/my-sites/activity/activity-log-confirm-dialog/style.scss
@@ -30,7 +30,7 @@
 }
 
 .activity-log-confirm-dialog__title {
-	font-size: 21px;
+	font-size: $font-title-small;
 	margin-bottom: 12px;
 	line-height: 1;
 }

--- a/client/my-sites/activity/activity-log-switch/style.scss
+++ b/client/my-sites/activity/activity-log-switch/style.scss
@@ -78,7 +78,7 @@
 
 .activity-log-switch__feature-heading {
 	color: var( --color-neutral-40 );
-	font-size: 21px;
+	font-size: $font-title-small;
 	margin-bottom: 8px;
 	width: 100%;
 

--- a/client/my-sites/backup/rewind-flow/style.scss
+++ b/client/my-sites/backup/rewind-flow/style.scss
@@ -18,7 +18,7 @@
 
 .rewind-flow__title {
 	text-align: center;
-	font-size: 22px;
+	font-size: $font-title-small;
 	font-weight: 600;
 	padding-bottom: 32px;
 
@@ -29,7 +29,7 @@
 
 .rewind-flow__title-placeholder {
 	@include placeholder( --color-neutral-light );
-	font-size: 22px;
+	font-size: $font-title-small;
 	font-weight: 600;
 }
 

--- a/client/my-sites/checkout/cart/style.scss
+++ b/client/my-sites/checkout/cart/style.scss
@@ -129,7 +129,7 @@
 	.cart__total {
 		color: var( --color-text-subtle );
 		display: table;
-		font-size: 20px;
+		font-size: $font-title-small;
 
 		.cart__total-row.grand-total {
 			display: table-footer-group;

--- a/client/my-sites/checkout/checkout-thank-you/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/style.scss
@@ -287,7 +287,7 @@
 }
 
 .checkout-thank-you__jetpack-error-heading {
-	font-size: 21px;
+	font-size: $font-title-small;
 	font-weight: 400;
 	line-height: 32px;
 	margin-top: 0;
@@ -621,7 +621,7 @@
 }
 
 .is-section-checkout-thank-you .empty-content__title {
-	font-size: 20px;
+	font-size: $font-title-small;
 	font-weight: normal;
 }
 

--- a/client/my-sites/checkout/upsell-nudge/concierge-quickstart-session/style.scss
+++ b/client/my-sites/checkout/upsell-nudge/concierge-quickstart-session/style.scss
@@ -62,7 +62,7 @@ main.concierge-quickstart-session.main {
 		margin-bottom: 1.4em;
 
 		@include breakpoint-deprecated( '<660px' ) {
-			font-size: 21px;
+			font-size: $font-title-small;
 		}
 	}
 

--- a/client/my-sites/checkout/upsell-nudge/concierge-support-session/style.scss
+++ b/client/my-sites/checkout/upsell-nudge/concierge-support-session/style.scss
@@ -89,7 +89,7 @@ main.concierge-support-session.main {
 	}
 
 	&__sub-header {
-		font-size: 21px;
+		font-size: $font-title-small;
 		font-weight: 400;
 		line-height: 1.4;
 		margin-top: 5px;

--- a/client/my-sites/checkout/upsell-nudge/plan-upgrade-upsell/style.scss
+++ b/client/my-sites/checkout/upsell-nudge/plan-upgrade-upsell/style.scss
@@ -93,11 +93,11 @@ main.plan-upgrade-upsell.main {
 		margin-bottom: 1em;
 
 		@include breakpoint-deprecated( '<660px' ) {
-			font-size: 21px;
+			font-size: $font-title-small;
 		}
 	}
 	&__sub-header {
-		font-size: 21px;
+		font-size: $font-title-small;
 		font-weight: normal;
 		text-align: center;
 		line-height: 1.4;

--- a/client/my-sites/checkout/upsell-nudge/white-glove/style.scss
+++ b/client/my-sites/checkout/upsell-nudge/white-glove/style.scss
@@ -141,7 +141,7 @@ main.white-glove.main {
 		}
 	}
 	&__sub-header {
-		font-size: 21px;
+		font-size: $font-title-small;
 		font-weight: 400;
 		text-align: center;
 		line-height: 1.4;

--- a/client/my-sites/domains/domain-management/components/email-verification/style.scss
+++ b/client/my-sites/domains/domain-management/components/email-verification/style.scss
@@ -32,7 +32,7 @@
 }
 
 .email-verification__heading {
-	font-size: 21px;
+	font-size: $font-title-small;
 	font-weight: 600;
 	line-height: 26px;
 	margin: 0 0 10px;

--- a/client/my-sites/domains/domain-management/components/inbound-transfer-verification/style.scss
+++ b/client/my-sites/domains/domain-management/components/inbound-transfer-verification/style.scss
@@ -1,5 +1,5 @@
 .inbound-transfer-verification__heading {
-  font-size: 21px;
+  font-size: $font-title-small;
   font-weight: 600;
   line-height: 26px;
   margin: 0 0 10px;

--- a/client/my-sites/domains/domain-management/domain-connect/domain-connect-authorize.scss
+++ b/client/my-sites/domains/domain-management/domain-connect/domain-connect-authorize.scss
@@ -1,6 +1,6 @@
 .domain-connect__main {
 	h2 {
-		font-size: 20px;
+		font-size: $font-title-small;
 		font-weight: 600;
 		margin-bottom: 1em;
 	}

--- a/client/my-sites/domains/domain-management/edit/style.scss
+++ b/client/my-sites/domains/domain-management/edit/style.scss
@@ -75,7 +75,7 @@
 					font-size: 24px;
 				}
 				&.mobile-xl {
-					font-size: 20px;
+					font-size: $font-title-small;
 				}
 				&.mobile-xxl {
 					font-size: $font-body;
@@ -90,7 +90,7 @@
 					font-size: 24px;
 				}
 				&.desktop-xl {
-					font-size: 20px;
+					font-size: $font-title-small;
 				}
 				&.desktop-xxl {
 					font-size: $font-body;

--- a/client/my-sites/earn/memberships/style.scss
+++ b/client/my-sites/earn/memberships/style.scss
@@ -167,7 +167,7 @@
 	overflow: hidden;
 
 	@include breakpoint-deprecated( '>480px' ) {
-		font-size: 21px;
+		font-size: $font-title-small;
 	}
 
 	&::before {

--- a/client/my-sites/exporter/guided-transfer-card/style.scss
+++ b/client/my-sites/exporter/guided-transfer-card/style.scss
@@ -12,7 +12,7 @@
 }
 
 .guided-transfer-card__title {
-	font-size: 21px;
+	font-size: $font-title-small;
 	color: var( --color-neutral-70 );
 	clear: left;
 }

--- a/client/my-sites/exporter/style.scss
+++ b/client/my-sites/exporter/style.scss
@@ -1,6 +1,6 @@
 .export-card__title,
 .export-media-card__title {
-	font-size: 21px;
+	font-size: $font-title-small;
 	color: var( --color-neutral-70 );
 	margin-bottom: 16px;
 	clear: left;
@@ -35,7 +35,7 @@
 }
 
 .export-card__advanced-settings-title {
-	font-size: 21px;
+	font-size: $font-title-small;
 	color: var( --color-neutral-70 );
 	margin-bottom: 16px;
 }

--- a/client/my-sites/feature-upsell/style.scss
+++ b/client/my-sites/feature-upsell/style.scss
@@ -78,7 +78,7 @@ $feature-upsell-break-at: '1040px';
 	}
 
 	&.is-h4 {
-		font-size: 20px;
+		font-size: $font-title-small;
 		@include breakpoint-deprecated( '<1280px' ) {
 			&.is-h4 {
 				font-size: 18px;
@@ -107,7 +107,7 @@ $feature-upsell-break-at: '1040px';
 		line-height: 1.2;
 
 		@include breakpoint-deprecated( '<1280px' ) {
-			font-size: 20px;
+			font-size: $font-title-small;
 		}
 
 		@include breakpoint-deprecated( '<660px' ) {
@@ -221,12 +221,12 @@ $feature-upsell-break-at: '1040px';
 		color: var( --color-neutral-60 );
 		margin-bottom: 20px;
 		@include breakpoint-deprecated( '<1280px' ) {
-			font-size: 20px;
+			font-size: $font-title-small;
 		}
 	}
 
 	&-header.is-sub {
-		font-size: 21px;
+		font-size: $font-title-small;
 		font-weight: 400;
 		color: var( --color-neutral-60 );
 		margin-bottom: 20px;
@@ -346,7 +346,7 @@ $feature-upsell-break-at: '1040px';
 		font-weight: 600;
 		color: var( --color-neutral-60 );
 		@include breakpoint-deprecated( '<1280px' ) {
-			font-size: 20px;
+			font-size: $font-title-small;
 		}
 	}
 
@@ -492,7 +492,7 @@ $feature-upsell-break-at: '1040px';
 
 	&-title {
 		font-weight: 600;
-		font-size: 21px;
+		font-size: $font-title-small;
 		line-height: 1.5;
 		color: var( --color-neutral-60 );
 		clear: none;

--- a/client/my-sites/feature-upsell/style.scss
+++ b/client/my-sites/feature-upsell/style.scss
@@ -162,7 +162,7 @@ $feature-upsell-break-at: '1040px';
 			font-size: 26px;
 			padding-right: 30px;
 			@include breakpoint-deprecated( '<1280px' ) {
-				font-size: 22px;
+				font-size: $font-title-small;
 			}
 		}
 		.feature-upsell__cta-button {

--- a/client/my-sites/importer/importer-header/style.scss
+++ b/client/my-sites/importer/importer-header/style.scss
@@ -25,7 +25,7 @@
 }
 
 .importer-header__service-title {
-	font-size: 21px;
+	font-size: $font-title-small;
 	color: var( --color-text-subtle );
 	clear: none;
 

--- a/client/my-sites/invites/invite-accept-logged-in/style.scss
+++ b/client/my-sites/invites/invite-accept-logged-in/style.scss
@@ -1,7 +1,7 @@
 .invite-accept-logged-in__join-as {
 	color: var( --color-neutral-60 );
 	font-family: $sans;
-	font-size: 21px;
+	font-size: $font-title-small;
 	line-height: 24px;
 	margin-bottom: 16px;
 	text-align: center;

--- a/client/my-sites/invites/invite-form-header/style.scss
+++ b/client/my-sites/invites/invite-form-header/style.scss
@@ -1,7 +1,7 @@
 .invite-form-header__title {
 	color: var( --color-neutral-60 );
 	font-family: $sans;
-	font-size: 21px;
+	font-size: $font-title-small;
 	line-height: 24px;
 	margin-bottom: 16px;
 }

--- a/client/my-sites/marketing/style.scss
+++ b/client/my-sites/marketing/style.scss
@@ -1027,7 +1027,7 @@
 }
 
 .sharing-buttons-preview__panel-heading {
-	font-size: 20px;
+	font-size: $font-title-small;
 	font-weight: normal;
 	color: var( --color-neutral-70 );
 }

--- a/client/my-sites/marketing/style.scss
+++ b/client/my-sites/marketing/style.scss
@@ -304,7 +304,7 @@
 	position: absolute;
 	right: 16px;
 	top: 30px;
-	font-size: 22px;
+	font-size: $font-title-small;
 	color: #aeb8be;
 
 	@include breakpoint-deprecated( '<480px' ) {

--- a/client/my-sites/marketing/tools/style.scss
+++ b/client/my-sites/marketing/tools/style.scss
@@ -15,7 +15,7 @@
 }
 
 .tools__header-title {
-	font-size: 21px;
+	font-size: $font-title-small;
 	font-weight: 400;
 	margin-bottom: 10px;
 	margin-top: 10px;

--- a/client/my-sites/people/followers-list/style.scss
+++ b/client/my-sites/people/followers-list/style.scss
@@ -1,4 +1,4 @@
 .is-section-people .empty-content .empty-content__title {
-	font-size: 22px;
+	font-size: $font-title-small;
 	margin-bottom: 16px;
 }

--- a/client/my-sites/people/people-profile/style.scss
+++ b/client/my-sites/people/people-profile/style.scss
@@ -53,7 +53,7 @@
 	overflow: hidden;
 
 	@include breakpoint-deprecated( '>480px' ) {
-		font-size: 21px;
+		font-size: $font-title-small;
 	}
 
 	&::before {

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -259,7 +259,7 @@ $plan-features-sidebar-width: 272px;
 }
 
 .plan-features__header-title {
-	font-size: 22px;
+	font-size: $font-title-small;
 	color: var( --color-primary );
 	line-height: 0.7;
 

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -262,10 +262,6 @@ $plan-features-sidebar-width: 272px;
 	font-size: $font-title-small;
 	color: var( --color-primary );
 	line-height: 0.7;
-
-	@include breakpoint-deprecated( '<960px' ) {
-		font-size: $font-title-small;
-	}
 }
 
 .plan-features__audience {

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -264,7 +264,7 @@ $plan-features-sidebar-width: 272px;
 	line-height: 0.7;
 
 	@include breakpoint-deprecated( '<960px' ) {
-		font-size: 20px;
+		font-size: $font-title-small;
 	}
 }
 

--- a/client/my-sites/plans/current-plan/my-plan-card/style.scss
+++ b/client/my-sites/plans/current-plan/my-plan-card/style.scss
@@ -32,7 +32,7 @@
 }
 
 .my-plan-card__title {
-	font-size: 21px;
+	font-size: $font-title-small;
 	font-weight: 400;
 	line-height: 29px;
 	margin: 8px 0;

--- a/client/my-sites/plugins/plugin-sections/style.scss
+++ b/client/my-sites/plugins/plugin-sections/style.scss
@@ -34,7 +34,7 @@
 		font-size: 24px;
 	}
 	h3 {
-		font-size: 21px;
+		font-size: $font-title-small;
 	}
 	li {
 		margin-bottom: 8px;

--- a/client/my-sites/site-settings/delete-site/style.scss
+++ b/client/my-sites/site-settings/delete-site/style.scss
@@ -43,7 +43,7 @@
 h1.delete-site__confirm-header {
 	height: auto;
 	margin-bottom: 16px;
-	font-size: 21px;
+	font-size: $font-title-small;
 	line-height: 24px;
 	color: var( --color-neutral-70 );
 }

--- a/client/my-sites/sites/style.scss
+++ b/client/my-sites/sites/style.scss
@@ -11,7 +11,7 @@
 }
 
 .sites__select-heading {
-	font-size: 22px;
+	font-size: $font-title-small;
 	margin-top: 16px;
 	margin-bottom: 24px;
 

--- a/client/my-sites/stats/most-popular/style.scss
+++ b/client/my-sites/stats/most-popular/style.scss
@@ -48,7 +48,7 @@
 .most-popular__hour {
 	display: block;
 	color: var( --color-neutral-70 );
-	font-size: 20px;
+	font-size: $font-title-small;
 	margin: 6px 0 22px;
 }
 

--- a/client/my-sites/stats/stats-list/style.scss
+++ b/client/my-sites/stats/stats-list/style.scss
@@ -256,7 +256,7 @@
 	// Icons smaller on 2col
 	@include breakpoint-deprecated( '>960px' ) {
 		.stats__module-list & .stats-list__icon {
-			font-size: 20px;
+			font-size: $font-title-small;
 			line-height: 1.3;
 		}
 

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -278,7 +278,7 @@
 	}
 
 	h3 {
-		font-size: 20px;
+		font-size: $font-title-small;
 		font-weight: 400;
 		margin: 40px 0 10px;
 	}
@@ -482,7 +482,7 @@
 	padding: 0 20px;
 
 	.theme__retired-theme-message-details-title {
-		font-size: 20px;
+		font-size: $font-title-small;
 	}
 }
 

--- a/client/signup/steps/import-url-onboarding/style.scss
+++ b/client/signup/steps/import-url-onboarding/style.scss
@@ -57,7 +57,7 @@
 }
 
 .import-url-onboarding__service-title {
-	font-size: 21px;
+	font-size: $font-title-small;
 	color: var( --color-text-subtle );
 	clear: none;
 }

--- a/client/signup/steps/upsell/style.scss
+++ b/client/signup/steps/upsell/style.scss
@@ -61,7 +61,7 @@
 		margin-bottom: 1.4em;
 
 		@include breakpoint-deprecated( '<660px' ) {
-			font-size: 21px;
+			font-size: $font-title-small;
 		}
     }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates font sizes of 19, 20, 21, and 22px to use `$font-title-small` variable, which corresponds to `20px`
* Updates the `CardHeading` component, which uses selectors corresponding to the font size in pixels, ie. `.card-heading-47` for a 47px font size; this requires adding the new values to the component's array of allowed values, and adding new selectors that map to the old ones.
* I've added notes in both places about deprecating the old values and which ones to use instead; eventually I can do a find-and-replace on the `card-heading-*` selectors to convert them all to the new values.

**Visuals (not exhaustive)**

| Before | After |
| ------ | ------ |
| <img width="678" alt="before1" src="https://user-images.githubusercontent.com/2124984/85616013-26431180-b62b-11ea-8d4c-5e7098bd12be.png"> | <img width="683" alt="after1" src="https://user-images.githubusercontent.com/2124984/85616020-2a6f2f00-b62b-11ea-9265-5baad85862ce.png"> |
| <img width="668" alt="before2" src="https://user-images.githubusercontent.com/2124984/85616052-31963d00-b62b-11ea-8e0c-a9d877704bf9.png"> | <img width="667" alt="after2" src="https://user-images.githubusercontent.com/2124984/85616064-35c25a80-b62b-11ea-8ed0-64f6723923bd.png"> |
| <img width="604" alt="before3" src="https://user-images.githubusercontent.com/2124984/85616100-3ce96880-b62b-11ea-8e3a-7ec2ffee6c0c.png"> | <img width="708" alt="Screen Shot 2020-06-24 at 4 50 30 PM" src="https://user-images.githubusercontent.com/2124984/85626323-e126db80-b63a-11ea-95ca-495850244df0.png"> |
| <img width="1086" alt="before4" src="https://user-images.githubusercontent.com/2124984/85616133-47a3fd80-b62b-11ea-9f17-47229a8d4542.png"> | <img width="1077" alt="after4" src="https://user-images.githubusercontent.com/2124984/85616143-4b378480-b62b-11ea-8572-2d003825c565.png"> |
| <img width="441" alt="before5" src="https://user-images.githubusercontent.com/2124984/85616180-54c0ec80-b62b-11ea-85bc-21a6bd5d57c9.png"> | <img width="428" alt="after5" src="https://user-images.githubusercontent.com/2124984/85616200-5a1e3700-b62b-11ea-92cd-3c082b5c8dfb.png"> |
| <img width="847" alt="before6" src="https://user-images.githubusercontent.com/2124984/85616227-630f0880-b62b-11ea-88c9-bf7d3a4f128c.png"> | <img width="886" alt="after6" src="https://user-images.githubusercontent.com/2124984/85616261-6e623400-b62b-11ea-9840-7ec2d620ab64.png"> |
| <img width="759" alt="before7" src="https://user-images.githubusercontent.com/2124984/85762302-99a75a80-b6e1-11ea-8030-25719b41e0b2.png"> | <img width="766" alt="after7" src="https://user-images.githubusercontent.com/2124984/85762300-990ec400-b6e1-11ea-9115-b59eb2313254.png"> |
| <img width="750" alt="before8" src="https://user-images.githubusercontent.com/2124984/85762306-9ad88780-b6e1-11ea-9be8-62037983549d.png"> | <img width="748" alt="after8" src="https://user-images.githubusercontent.com/2124984/85762304-9a3ff100-b6e1-11ea-8080-f368e2f953f2.png"> |
| <img width="743" alt="before9" src="https://user-images.githubusercontent.com/2124984/85762313-9b711e00-b6e1-11ea-9511-69194eae2ae8.png"> | <img width="737" alt="after9" src="https://user-images.githubusercontent.com/2124984/85762309-9b711e00-b6e1-11ea-82be-c6bf7cb8d49b.png"> |
| <img width="738" alt="before10" src="https://user-images.githubusercontent.com/2124984/85762317-9c09b480-b6e1-11ea-9b1c-82e6cfd9129b.png"> | <img width="739" alt="after10" src="https://user-images.githubusercontent.com/2124984/85762315-9c09b480-b6e1-11ea-97c4-4939c63629ce.png"> |
 
#### Testing instructions

* Switch to this PR
* Navigate around Calypso and note the font sizes; some examples included above
