### PR TITLE
Customer Home: Rename View site to Visit site to avoid confusion with the previewer

### DIFF
--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -67,7 +67,7 @@ const Home = ( {
 			/>
 			<div className="customer-home__view-site-button">
 				<Button href={ site.URL } onClick={ trackViewSiteAction }>
-					{ translate( 'View site' ) }
+					{ translate( 'Visit site' ) }
 				</Button>
 			</div>
 		</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Renames the "View site" button to "Visit site" to avoid confusion with the site previewer, since this button goes directly to the site's front page.
* See p1592949321000800-slack-dotcom-manage-design for context

**Before**

<img width="1082" alt="Screen Shot 2020-06-23 at 5 57 51 PM" src="https://user-images.githubusercontent.com/2124984/85469940-5384b680-b57c-11ea-9aca-2dc8fc239b95.png">

**After**

<img width="1081" alt="Screen Shot 2020-06-23 at 6 07 16 PM" src="https://user-images.githubusercontent.com/2124984/85469981-65fef000-b57c-11ea-810d-00f9be2854b6.png">


#### Testing instructions

* Switch to this PR
* Visit `/home` and check out the button in the top right corner. It should say "Visit site"