### PR TITLE
Gutenboarding: launch new designs

### DIFF
--- a/client/landing/gutenboarding/available-designs-config.json
+++ b/client/landing/gutenboarding/available-designs-config.json
@@ -11,7 +11,6 @@
 			},
 			"categories": [ "featured", "portfolio" ],
 			"is_premium": false,
-			"is_alpha": true,
 			"is_fse": true
 		},
 		{
@@ -25,7 +24,6 @@
 			},
 			"categories": [ "featured", "portfolio" ],
 			"is_premium": false,
-			"is_alpha": true,
 			"is_fse": true
 		},
 		{
@@ -158,8 +156,7 @@
 				"base": "Chivo"
 			},
 			"categories": [ "featured", "business" ],
-			"is_premium": false,
-			"is_alpha": true
+			"is_premium": false
 		},
 		{
 			"title": "Alves",
@@ -171,8 +168,7 @@
 				"base": "Montserrat"
 			},
 			"categories": [ "featured", "non-profit", "charity" ],
-			"is_premium": false,
-			"is_alpha": true
+			"is_premium": false
 		},
 		{
 			"title": "Mayland",
@@ -184,8 +180,7 @@
 				"base": "Cabin"
 			},
 			"categories": [ "featured", "portfolio" ],
-			"is_premium": false,
-			"is_alpha": true
+			"is_premium": false
 		},
 		{
 			"title": "Rivington",
@@ -197,8 +192,7 @@
 				"base": "Montserrat"
 			},
 			"categories": [ "featured", "real estate listing" ],
-			"is_premium": false,
-			"is_alpha": true
+			"is_premium": false
 		},
 		{
 			"title": "Maywood",
@@ -210,8 +204,7 @@
 				"base": "Fira Sans"
 			},
 			"categories": [ "featured", "restaurant, small business" ],
-			"is_premium": false,
-			"is_alpha": true
+			"is_premium": false
 		},
 		{
 			"title": "Balasana",
@@ -223,8 +216,7 @@
 				"base": "Chivo"
 			},
 			"categories": [ "featured", "restaurant, small business" ],
-			"is_premium": false,
-			"is_alpha": true
+			"is_premium": false
 		},
 		{
 			"title": "Stratford",
@@ -236,8 +228,7 @@
 				"base": "Open Sans"
 			},
 			"categories": [ "featured", "school" ],
-			"is_premium": false,
-			"is_alpha": true
+			"is_premium": false
 		},
 		{
 			"title": "Rockfield",
@@ -249,8 +240,7 @@
 				"base": "Fira Sans"
 			},
 			"categories": [ "featured", "restaurant", "small business" ],
-			"is_premium": false,
-			"is_alpha": true
+			"is_premium": false
 		},
 		{
 			"title": "Coutoire",
@@ -262,8 +252,7 @@
 				"base": "Fira Sans"
 			},
 			"categories": [ "featured", "portfolio" ],
-			"is_premium": false,
-			"is_alpha": true
+			"is_premium": false
 		},
 		{
 			"title": "Leven",
@@ -275,8 +264,7 @@
 				"base": "Open Sans"
 			},
 			"categories": [ "featured", "portfolio", "small business" ],
-			"is_premium": false,
-			"is_alpha": true
+			"is_premium": false
 		},
 		{
 			"title": "Gibbs",
@@ -288,8 +276,7 @@
 				"base": "Fira Sans"
 			},
 			"categories": [ "featured", "restaurant", "small business" ],
-			"is_premium": false,
-			"is_alpha": true
+			"is_premium": false
 		}
 	]
 }

--- a/client/landing/gutenboarding/available-designs.ts
+++ b/client/landing/gutenboarding/available-designs.ts
@@ -57,16 +57,28 @@ export function prefetchDesignThumbs() {
 }
 
 export function getAvailableDesigns(
+	includeEdgeDesigns: boolean = isEnabled( 'gutenboarding/edge-templates' ),
 	useFseDesigns: boolean = isEnabled( 'gutenboarding/site-editor' )
 ) {
+	let designs = availableDesigns;
+
+	if ( ! includeEdgeDesigns ) {
+		designs = {
+			...designs,
+			featured: designs.featured.filter( ( design ) => ! design.is_alpha ),
+		};
+	}
+
 	// If we are in the FSE flow, only show FSE designs. In normal flows, remove
 	// the FSE designs.
-	return {
-		...availableDesigns,
-		featured: availableDesigns.featured.filter( ( design ) =>
+	designs = {
+		...designs,
+		featured: designs.featured.filter( ( design ) =>
 			useFseDesigns ? design.is_fse : ! design.is_fse
 		),
 	};
+
+	return designs;
 }
 
 export default getAvailableDesigns();

--- a/client/landing/gutenboarding/available-designs.ts
+++ b/client/landing/gutenboarding/available-designs.ts
@@ -57,7 +57,7 @@ export function prefetchDesignThumbs() {
 }
 
 export function getAvailableDesigns(
-	includeEdgeDesigns: boolean = isEnabled( 'gutenboarding/edge-templates' ),
+	includeEdgeDesigns: boolean = isEnabled( 'gutenboarding/alpha-templates' ),
 	useFseDesigns: boolean = isEnabled( 'gutenboarding/site-editor' )
 ) {
 	let designs = availableDesigns;

--- a/client/landing/gutenboarding/available-designs.ts
+++ b/client/landing/gutenboarding/available-designs.ts
@@ -57,12 +57,12 @@ export function prefetchDesignThumbs() {
 }
 
 export function getAvailableDesigns(
-	includeEdgeDesigns: boolean = isEnabled( 'gutenboarding/alpha-templates' ),
+	includeAlphaDesigns: boolean = isEnabled( 'gutenboarding/alpha-templates' ),
 	useFseDesigns: boolean = isEnabled( 'gutenboarding/site-editor' )
 ) {
 	let designs = availableDesigns;
 
-	if ( ! includeEdgeDesigns ) {
+	if ( ! includeAlphaDesigns ) {
 		designs = {
 			...designs,
 			featured: designs.featured.filter( ( design ) => ! design.is_alpha ),

--- a/client/landing/gutenboarding/available-designs.ts
+++ b/client/landing/gutenboarding/available-designs.ts
@@ -57,17 +57,9 @@ export function prefetchDesignThumbs() {
 }
 
 export function getAvailableDesigns(
-	includeEdgeDesigns: boolean = isEnabled( 'gutenboarding/alpha-templates' ),
 	useFseDesigns: boolean = isEnabled( 'gutenboarding/site-editor' )
 ) {
 	let designs = availableDesigns;
-
-	if ( ! includeEdgeDesigns ) {
-		designs = {
-			...designs,
-			featured: designs.featured.filter( ( design ) => ! design.is_alpha ),
-		};
-	}
 
 	// If we are in the FSE flow, only show FSE designs. In normal flows, remove
 	// the FSE designs.

--- a/client/landing/gutenboarding/available-designs.ts
+++ b/client/landing/gutenboarding/available-designs.ts
@@ -59,18 +59,14 @@ export function prefetchDesignThumbs() {
 export function getAvailableDesigns(
 	useFseDesigns: boolean = isEnabled( 'gutenboarding/site-editor' )
 ) {
-	let designs = availableDesigns;
-
 	// If we are in the FSE flow, only show FSE designs. In normal flows, remove
 	// the FSE designs.
-	designs = {
-		...designs,
-		featured: designs.featured.filter( ( design ) =>
+	return {
+		...availableDesigns,
+		featured: availableDesigns.featured.filter( ( design ) =>
 			useFseDesigns ? design.is_fse : ! design.is_fse
 		),
 	};
-
-	return designs;
 }
 
 export default getAvailableDesigns();

--- a/config/development.json
+++ b/config/development.json
@@ -66,7 +66,7 @@
 		"gdpr-banner": false,
 		"google-my-business": true,
 		"google-drive": true,
-		"gutenboarding/edge-templates": true,
+		"gutenboarding/alpha-templates": true,
 		"help": true,
 		"help/courses": true,
 		"home/layout-dev": true,

--- a/config/development.json
+++ b/config/development.json
@@ -66,7 +66,6 @@
 		"gdpr-banner": false,
 		"google-my-business": true,
 		"google-drive": true,
-		"gutenboarding/alpha-templates": true,
 		"help": true,
 		"help/courses": true,
 		"home/layout-dev": true,

--- a/config/development.json
+++ b/config/development.json
@@ -66,6 +66,7 @@
 		"gdpr-banner": false,
 		"google-my-business": true,
 		"google-drive": true,
+		"gutenboarding/edge-templates": true,
 		"help": true,
 		"help/courses": true,
 		"home/layout-dev": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -42,7 +42,7 @@
 		"external-media/free-photo-library": true,
 		"gdpr-banner": true,
 		"google-my-business": false,
-		"gutenboarding/edge-templates": true,
+		"gutenboarding/alpha-templates": true,
 		"happychat": false,
 		"help": true,
 		"help/courses": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -42,6 +42,7 @@
 		"external-media/free-photo-library": true,
 		"gdpr-banner": true,
 		"google-my-business": false,
+		"gutenboarding/edge-templates": true,
 		"happychat": false,
 		"help": true,
 		"help/courses": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -42,7 +42,6 @@
 		"external-media/free-photo-library": true,
 		"gdpr-banner": true,
 		"google-my-business": false,
-		"gutenboarding/alpha-templates": true,
 		"happychat": false,
 		"help": true,
 		"help/courses": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -52,6 +52,7 @@
 		"google-my-business": true,
 		"gutenboarding/mshot-preview": false,
 		"gutenboarding/style-preview-verticals": false,
+		"gutenboarding/edge-templates": true,
 		"happychat": true,
 		"help": true,
 		"help/courses": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -52,7 +52,7 @@
 		"google-my-business": true,
 		"gutenboarding/mshot-preview": false,
 		"gutenboarding/style-preview-verticals": false,
-		"gutenboarding/edge-templates": true,
+		"gutenboarding/alpha-templates": true,
 		"happychat": true,
 		"help": true,
 		"help/courses": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -52,7 +52,6 @@
 		"google-my-business": true,
 		"gutenboarding/mshot-preview": false,
 		"gutenboarding/style-preview-verticals": false,
-		"gutenboarding/alpha-templates": true,
 		"happychat": true,
 		"help": true,
 		"help/courses": true,


### PR DESCRIPTION
## Changes proposed in this Pull Request

A small PR to remove the feature flag `is_alpha` for the new designs and fulfil their destiny of making it to prod.

You can view the new designs on horizon.wordpress.com/new right now.


<img width="500" alt="Screen Shot 2020-06-24 at 2 03 26 pm" src="https://user-images.githubusercontent.com/6458278/85498679-803fd900-b623-11ea-850c-e5cb92af75b0.png">

Questions for the division:

- [ ] Should we remove the inverse font pairing choice on Gutenberg font selector step before we launch https://github.com/Automattic/wp-calypso/pull/42354#issuecomment-644543795 cc @olaolusoga 
- [x] Is the order of the designs okay?
- [x] Should any of the new designs should be "premium". See: #42377
- [x] In my opinion, we should first land D45183-code, which generates sites from the design starter site annotations directly where there are variations on a theme. Requires https://github.com/Automattic/view-design/issues/54



## Testing instructions

(Optional) Apply D45183-code to your sandbox.

 D45183-code pulls preview content/headstarts sites using the design sites themselves, instead of their parent themes'

Fire up this branch. Check that the designs show at the design step.

Check for each design:

- the design thumbnail and preview
- the created site reflects what was promised in the preview :)

Fixes #43420
