### PR TITLE
P2 signup: fix site sanitization

### DIFF
--- a/client/signup/steps/p2-site/index.jsx
+++ b/client/signup/steps/p2-site/index.jsx
@@ -95,7 +95,7 @@ class P2Site extends React.Component {
 	sanitize = ( fields, onComplete ) => {
 		const sanitizedSubdomain = this.sanitizeSubdomain( fields.site );
 		if ( fields.site !== sanitizedSubdomain ) {
-			onComplete( { site: sanitizedSubdomain } );
+			onComplete( { site: sanitizedSubdomain, siteTitle: fields.siteTitle } );
 		}
 	};
 


### PR DESCRIPTION
In this PR, we fix a slight bug when creating a new P2 site through the `/start/p2` signup flow.

Props @klimeryk for the report:

![](https://user-images.githubusercontent.com/3392497/85325514-4653c300-b4bb-11ea-834d-a789414e6eee.gif)

## Testing instructions

Navigate to `/start/p2`. Fill in a random site name. Fill in an invalid site address like `my-site-address!!.p2.blog`. When you click outside of the input field, it should be corrected to `my-site-address.p2.blog` and the previously filled site name field should stay the same.
