### PR TITLE
Activity log: make circle styles more robust

### DIFF
--- a/client/my-sites/activity/activity-log-item/style.scss
+++ b/client/my-sites/activity/activity-log-item/style.scss
@@ -62,10 +62,10 @@
 	flex-direction: column;
 	align-content: center;
 	align-self: flex-start;
-	background: var( --color-surface-backdrop );
-	text-align: center;
 	margin: 1px 22px 0 10px;
 	padding: 4px 0 6px;
+	background: var( --color-surface-backdrop );
+	text-align: center;
 	z-index: 1;
 
 	@include breakpoint-deprecated( '<480px' ) {
@@ -96,21 +96,21 @@
 
 .activity-log-item__activity-icon {
 	// General notice
+	display: flex;
 	width: 24px;
 	height: 24px;
+	margin-top: 2px;
+	padding: 12px;
 	background: var( --color-neutral-20 );
 	color: var( --color-text-inverted );
-	display: flex;
 	border-radius: 50%;
-	padding: 12px;
-	margin-top: 2px;
 
 	@include breakpoint-deprecated( '<480px' ) {
-		padding: 7px;
 		box-sizing: border-box;
+		display: inline-block;
 		width: 32px;
 		height: 32px;
-		display: inline-block;
+		padding: 7px;
 
 		.gridicon {
 			width: 18px;

--- a/client/my-sites/activity/activity-log-item/style.scss
+++ b/client/my-sites/activity/activity-log-item/style.scss
@@ -60,7 +60,7 @@
 .activity-log-item__type {
 	display: flex;
 	flex-direction: column;
-	align-content: center;
+	align-items: center;
 	align-self: flex-start;
 	margin: 1px 22px 0 10px;
 	padding: 4px 0 6px;

--- a/client/my-sites/activity/activity-log-item/style.scss
+++ b/client/my-sites/activity/activity-log-item/style.scss
@@ -93,6 +93,8 @@
 
 .activity-log-item__activity-icon {
 	// General notice
+	width: 24px;
+	height: 24px;
 	background: var( --color-neutral-20 );
 	color: var( --color-text-inverted );
 	display: flex;

--- a/client/my-sites/activity/activity-log-item/style.scss
+++ b/client/my-sites/activity/activity-log-item/style.scss
@@ -58,6 +58,9 @@
 }
 
 .activity-log-item__type {
+	display: flex;
+	flex-direction: column;
+	align-content: center;
 	align-self: flex-start;
 	background: var( --color-surface-backdrop );
 	text-align: center;

--- a/client/my-sites/activity/activity-log-item/style.scss
+++ b/client/my-sites/activity/activity-log-item/style.scss
@@ -69,6 +69,7 @@
 	z-index: 1;
 
 	@include breakpoint-deprecated( '<480px' ) {
+		width: 40px;
 		margin: -2px 8px 0 0;
 	}
 

--- a/client/my-sites/activity/activity-log-item/style.scss
+++ b/client/my-sites/activity/activity-log-item/style.scss
@@ -62,6 +62,7 @@
 	flex-direction: column;
 	align-items: center;
 	align-self: flex-start;
+	width: 52px;
 	margin: 1px 22px 0 10px;
 	padding: 4px 0 6px;
 	background: var( --color-surface-backdrop );

--- a/client/my-sites/activity/activity-log/style.scss
+++ b/client/my-sites/activity/activity-log/style.scss
@@ -11,7 +11,7 @@
 		width: 2px;
 
 		@include breakpoint-deprecated( '<480px' ) {
-			left: 25px;
+			left: 27px;
 		}
 	}
 

--- a/client/my-sites/activity/activity-log/style.scss
+++ b/client/my-sites/activity/activity-log/style.scss
@@ -7,7 +7,7 @@
 	&::after {
 		content: '';
 		position: absolute;
-		left: 33px;
+		left: 35px;
 		width: 2px;
 
 		@include breakpoint-deprecated( '<480px' ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add a fixed width/height to circles that contain icons.
* Ensure the circles and timestamps are horizontally centered.
* Reorder styles for better readability.

#### Screenshots

Before | After
--|--
![image](https://user-images.githubusercontent.com/390760/85528407-bbcaab00-b603-11ea-9166-940746b57db5.png) | ![image](https://user-images.githubusercontent.com/390760/85528432-c38a4f80-b603-11ea-9629-7ce357a46245.png)
![image](https://user-images.githubusercontent.com/390760/85528551-f0d6fd80-b603-11ea-97e6-c0a3a25844aa.png) | ![image](https://user-images.githubusercontent.com/390760/85535397-0d763400-b60a-11ea-89e7-52de828a8df8.png)



#### Testing instructions

* Spin up this PR.
* Open the Activity Log on an active site.
* Confirm all circles are round and look consistent across multiple devices.

Fixes issue reported in p1HpG7-9xQ-p2#comment-40285
