### PR TITLE
Fix chunked translations in the /new flow

### DIFF
--- a/client/landing/gutenboarding/index.tsx
+++ b/client/landing/gutenboarding/index.tsx
@@ -63,10 +63,6 @@ interface AppWindow extends Window {
 	currentUser?: User;
 	i18nLocaleStrings?: string;
 	installedChunks?: string[];
-	__requireChunkCallback__?: {
-		add( callback: Function ): void;
-		getInstalledChunks(): string[];
-	};
 	BUILD_TARGET?: string;
 }
 declare const window: AppWindow;
@@ -266,10 +262,6 @@ function getLocaleFromUser( user: User ): string {
 }
 
 async function setupTranslationChunks( localeSlug: string, translatedChunks: string[] = [] ) {
-	if ( ! window.__requireChunkCallback__ ) {
-		return;
-	}
-
 	interface TranslationChunksCache {
 		[ propName: string ]: undefined | boolean;
 	}
@@ -297,17 +289,5 @@ async function setupTranslationChunks( localeSlug: string, translatedChunks: str
 		values.reduce( ( localeDataObj, chunk ) => Object.assign( {}, localeDataObj, chunk ) )
 	);
 
-	interface RequireChunkCallbackParameters {
-		publicPath: string;
-		scriptSrc: string;
-	}
-
-	window.__requireChunkCallback__.add(
-		( { publicPath, scriptSrc }: RequireChunkCallbackParameters, promises: any[] ) => {
-			const chunkId = scriptSrc.replace( publicPath, '' ).replace( /\.js$/, '' );
-
-			promises.push( loadTranslationForChunkIfNeeded( chunkId ) );
-		}
-	);
 	return localeData;
 }

--- a/client/landing/gutenboarding/index.tsx
+++ b/client/landing/gutenboarding/index.tsx
@@ -63,6 +63,10 @@ interface AppWindow extends Window {
 	currentUser?: User;
 	i18nLocaleStrings?: string;
 	installedChunks?: string[];
+	__requireChunkCallback__?: {
+		add( callback: Function ): void;
+		getInstalledChunks(): string[];
+	};
 	BUILD_TARGET?: string;
 }
 declare const window: AppWindow;
@@ -262,6 +266,10 @@ function getLocaleFromUser( user: User ): string {
 }
 
 async function setupTranslationChunks( localeSlug: string, translatedChunks: string[] = [] ) {
+	if ( ! window.__requireChunkCallback__ ) {
+		return;
+	}
+
 	interface TranslationChunksCache {
 		[ propName: string ]: undefined | boolean;
 	}


### PR DESCRIPTION
Chunked translations were broken in gutenboarding after implementing https://github.com/Automattic/wp-calypso/pull/39624.

more context: p1592907262460500-slack-gutenboarding

### Technical context

`@wordpress/i18n` used to work as a singleton, the `setLocaleData` function was used to update the global singleton with new translation strings.

However, after https://github.com/Automattic/wp-calypso/pull/39624, a new instance of i18n is created by the `createI18n()` function https://github.com/Automattic/wp-calypso/blob/master/packages/react-i18n/src/index.tsx#L72 and exposed to the react app via the `I18nContext` Provider. https://github.com/Automattic/wp-calypso/blob/master/packages/react-i18n/src/index.tsx#L27

Therefore when the Chunked translations code called `setLocaleData`, it was setting the translations for the unused `@wordpress/i18n` singleton.

#### Changes proposed in this Pull Request
This PR removes calls to the obsolete `setLocaleData` function and instead loads the translation chunks and passes them down into the `react-i18n` component, which passes them into the active `i18n` object https://github.com/Automattic/wp-calypso/blob/master/packages/react-i18n/src/index.tsx#L72.

#### Testing instructions
Chunked translations are disabled by default on branch builds!

**Enable chunked translations** with the following query string

`/new/ar?flags=use-translation-chunks`

in the network tab, you should observe a call to `<LANG>-language-manifest.json`

<img width="1142" alt="Screen Shot 2020-06-24 at 7 32 01 PM" src="https://user-images.githubusercontent.com/22446385/85530636-6f0dc100-b651-11ea-85a1-15426ef5a38e.png">

The page should be translated based on the locale slug in the URL
