### PR TITLE
i18n: Don't rewrite blog post URLs

### DIFF
--- a/client/lib/i18n-utils/test/utils.js
+++ b/client/lib/i18n-utils/test/utils.js
@@ -378,6 +378,15 @@ describe( 'utils', () => {
 			expect( localizeUrl( 'https://en.blog.wordpress.com/' ) ).toEqual(
 				'https://wordpress.com/blog/'
 			);
+			// Don't rewrite specific blog posts
+			getLocaleSlug.mockImplementationOnce( () => 'pt-br' );
+			expect( localizeUrl( 'https://en.blog.wordpress.com/2020/01/01/test/' ) ).toEqual(
+				'https://wordpress.com/blog/2020/01/01/test/'
+			);
+			getLocaleSlug.mockImplementationOnce( () => 'pt-br' );
+			expect( localizeUrl( 'https://wordpress.com/blog/2020/01/01/test/' ) ).toEqual(
+				'https://wordpress.com/blog/2020/01/01/test/'
+			);
 		} );
 
 		test( 'support url', () => {

--- a/client/lib/i18n-utils/utils.js
+++ b/client/lib/i18n-utils/utils.js
@@ -182,23 +182,44 @@ const setLocalizedUrlHost = ( hostname, validLocales = [] ) => ( urlParts, local
 	return urlParts;
 };
 
-const setLocalizedWpComPath = ( prefix, validLocales = [] ) => ( urlParts, localeSlug ) => {
+const setLocalizedWpComPath = ( prefix, validLocales = [], limitPathMatch = null ) => (
+	urlParts,
+	localeSlug
+) => {
 	urlParts.host = 'wordpress.com';
+	if (
+		typeof limitPathMatch === 'object' &&
+		limitPathMatch instanceof RegExp &&
+		! urlParts.pathname.match( limitPathMatch )
+	) {
+		validLocales = []; // only rewrite to English.
+	}
 	urlParts.pathname = prefix + urlParts.pathname;
 
 	if ( typeof validLocales === 'string' ) {
 		validLocales = config( validLocales );
 	}
+
 	if ( validLocales.includes( localeSlug ) && localeSlug !== 'en' ) {
 		urlParts.pathname = ( localesToSubdomains[ localeSlug ] || localeSlug ) + urlParts.pathname;
 	}
 	return urlParts;
 };
 
-const prefixLocalizedUrlPath = ( validLocales = [] ) => ( urlParts, localeSlug ) => {
+const prefixLocalizedUrlPath = ( validLocales = [], limitPathMatch = null ) => (
+	urlParts,
+	localeSlug
+) => {
 	if ( typeof validLocales === 'string' ) {
 		validLocales = config( validLocales );
 	}
+
+	if ( typeof limitPathMatch === 'object' && limitPathMatch instanceof RegExp ) {
+		if ( ! urlParts.pathname.match( limitPathMatch ) ) {
+			return urlParts; // No rewriting if not matches the path.
+		}
+	}
+
 	if ( validLocales.includes( localeSlug ) && localeSlug !== 'en' ) {
 		urlParts.pathname = ( localesToSubdomains[ localeSlug ] || localeSlug ) + urlParts.pathname;
 	}
@@ -207,11 +228,11 @@ const prefixLocalizedUrlPath = ( validLocales = [] ) => ( urlParts, localeSlug )
 
 const urlLocalizationMapping = {
 	'wordpress.com/support/': prefixLocalizedUrlPath( 'support_site_locales' ),
-	'wordpress.com/blog/': prefixLocalizedUrlPath( localesWithBlog ),
+	'wordpress.com/blog/': prefixLocalizedUrlPath( localesWithBlog, /^\/blog\/?$/ ),
 	'wordpress.com/tos/': setLocalizedUrlHost( 'wordpress.com', 'magnificent_non_en_locales' ),
 	'jetpack.com': setLocalizedUrlHost( 'jetpack.com', 'jetpack_com_locales' ),
 	'en.support.wordpress.com': setLocalizedWpComPath( '/support', 'support_site_locales' ),
-	'en.blog.wordpress.com': setLocalizedWpComPath( '/blog', localesWithBlog ),
+	'en.blog.wordpress.com': setLocalizedWpComPath( '/blog', localesWithBlog, /^\/$/ ),
 	'en.forums.wordpress.com': setLocalizedUrlHost( 'forums.wordpress.com', 'forum_locales' ),
 	'automattic.com/privacy/': prefixLocalizedUrlPath( localesWithPrivacyPolicy ),
 	'automattic.com/cookies/': prefixLocalizedUrlPath( localesWithCookiePolicy ),

--- a/client/lib/i18n-utils/utils.js
+++ b/client/lib/i18n-utils/utils.js
@@ -190,7 +190,7 @@ const setLocalizedWpComPath = ( prefix, validLocales = [], limitPathMatch = null
 	if (
 		typeof limitPathMatch === 'object' &&
 		limitPathMatch instanceof RegExp &&
-		! urlParts.pathname.match( limitPathMatch )
+		! limitPathMatch.test( urlParts.pathname )
 	) {
 		validLocales = []; // only rewrite to English.
 	}
@@ -215,7 +215,7 @@ const prefixLocalizedUrlPath = ( validLocales = [], limitPathMatch = null ) => (
 	}
 
 	if ( typeof limitPathMatch === 'object' && limitPathMatch instanceof RegExp ) {
-		if ( ! urlParts.pathname.match( limitPathMatch ) ) {
+		if ( ! limitPathMatch.test( urlParts.pathname ) ) {
 			return urlParts; // No rewriting if not matches the path.
 		}
 	}


### PR DESCRIPTION
The “Learn More” link on the Jetpack > Activity Log page 404’s when using a language that has a language WordPress.com blog.

![image-24](https://user-images.githubusercontent.com/203408/85533199-9d1ee100-b610-11ea-91bf-ba316070eb8b.png)

Fails: https://wordpress.com/es/blog/2018/10/30/introducing-activity/

Works: https://wordpress.com/blog/2018/10/30/introducing-activity/

props for discovering @cathymcbride 

#### Changes proposed in this Pull Request

* `localizeUrl()` should not rewrite blog post URLs since we don't have all posts translated and currently no english-slug redirects in place.

#### Testing instructions
* Covered by unit tests: `yarn run test-client lib/i18n-utils`
* Verify that the link above always links to the English blog post, no matter which language.
