### PR TITLE
Earn: Stop using "one-time" to describe the Pay with Paypal feature

### DIFF
--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -104,7 +104,9 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 			  );
 		const cta = hasSimplePayments
 			? {
-					text: translate( 'Add one-time payments' ),
+					text: isEnabled( 'earn/rename-payment-blocks' )
+						? translate( 'Learn how to get started' )
+						: translate( 'Add one-time payments' ),
 					action: { url: supportLink, onClick: () => trackCtaButton( 'simple-payments' ) },
 			  }
 			: {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR renames the button label used to describe the (soon-to-be renamed to) Pay with PayPal feature when the site is on an eligible plan (missed in https://github.com/Automattic/wp-calypso/pull/43192).

Since the button links to the support docs, I changed completely the message from "Add..." to "Learn how..." to set better the user expectations.

Before | After
--- | ---
<img width="541" alt="Screen Shot 2020-06-24 at 12 22 02" src="https://user-images.githubusercontent.com/1233880/85539807-8c716980-b616-11ea-9a1a-66e730608f45.png"> | <img width="540" alt="Screen Shot 2020-06-24 at 12 31 22" src="https://user-images.githubusercontent.com/1233880/85539904-a4e18400-b616-11ea-965a-1e89ee94ad61.png">

#### Testing instructions

* Switch to a site on a Premium or Business plan.
* Go to Earn.
* Make sure the button label displayed in the "Collect PayPal payments" reads as "Learn how to get started".
* Make sure the button label is still "Add one-time payments" when the `earn/rename-payment-blocks` flag is disabled.
