### PR TITLE
Turn missing export warnings into errors

### DIFF
--- a/client/my-sites/site-settings/settings-jetpack/index.js
+++ b/client/my-sites/site-settings/settings-jetpack/index.js
@@ -6,8 +6,8 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import { makeLayout, render as clientRender } from 'controller';
-import { navigation, siteSelection, notFound } from 'my-sites/controller';
+import { makeLayout, render as clientRender, notFound } from 'controller';
+import { navigation, siteSelection } from 'my-sites/controller';
 import { setScroll, siteSettings } from 'my-sites/site-settings/settings-controller';
 import { siteHasScanProductPurchase } from 'state/purchases/selectors';
 import isJetpackSectionEnabledForSite from 'state/selectors/is-jetpack-section-enabled-for-site';

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -178,6 +178,7 @@ const webpackConfig = {
 		} ),
 	},
 	module: {
+		strictExportPresence: true,
 		rules: [
 			TranspileConfig.loader( {
 				workerCount,


### PR DESCRIPTION
Missing exports are currently being presented as a warning during build:

```
WARNING in ./my-sites/site-settings/settings-jetpack/index.js 26:11-19
"export 'notFound' was not found in 'my-sites/controller'
```

Warnings are somewhat undiscoverable when not building locally, and too low a severity level for something that can easily break the application.

This PR turns those warnings into errors, while fixing the specific failure that prompted this change, introduced in #43588.

#### Changes proposed in this Pull Request

* Turn missing export warnings during build into errors
* Fix missing export error introduced in #43588

#### Testing instructions

* Check out this branch
* Build Calypso
* Ensure that there are no errors
* Introduce a missing export error anywhere (e.g. remove the fix to `client/my-sites/site-settings/settings-jetpack/index.js`)
* Ensure that the build produces an error
