### PR TITLE
Modularise inline help state

### DIFF
--- a/client/state/inline-help/actions.js
+++ b/client/state/inline-help/actions.js
@@ -20,6 +20,7 @@ import {
 } from 'state/action-types';
 
 import getContextualHelpResults from 'state/inline-help/selectors/get-contextual-help-results';
+import 'state/inline-help/init';
 
 /**
  * Fetches search results for a given query string.

--- a/client/state/inline-help/init.js
+++ b/client/state/inline-help/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'state/redux-store';
+import reducer from './reducer';
+
+registerReducer( [ 'inlineHelp' ], reducer );

--- a/client/state/inline-help/package.json
+++ b/client/state/inline-help/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/inline-help/reducer.js
+++ b/client/state/inline-help/reducer.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { combineReducers, withoutPersistence } from 'state/utils';
+import { combineReducers, withoutPersistence, withStorageKey } from 'state/utils';
 import {
 	INLINE_HELP_SEARCH_REQUEST,
 	INLINE_HELP_SEARCH_REQUEST_FAILURE,
@@ -165,9 +165,11 @@ export const contactForm = withoutPersistence(
 	}
 );
 
-export default combineReducers( {
+const combinedReducer = combineReducers( {
 	ui,
 	popover,
 	contactForm,
 	searchResults,
 } );
+
+export default withStorageKey( 'inlineHelp', combinedReducer );

--- a/client/state/inline-help/selectors/get-contextual-help-results.js
+++ b/client/state/inline-help/selectors/get-contextual-help-results.js
@@ -11,6 +11,8 @@ import pathToSection from 'lib/path-to-section';
 // @TODO: getContextResults should perhaps be moved to /state or /lib
 import { getContextResults } from 'blocks/inline-help/contextual-help';
 
+import 'state/inline-help/init';
+
 /**
  * Returns an array of contextual results
  *

--- a/client/state/inline-help/selectors/get-inline-help-currently-selected-link.js
+++ b/client/state/inline-help/selectors/get-inline-help-currently-selected-link.js
@@ -8,6 +8,8 @@ import { get } from 'lodash';
  */
 import getInlineHelpCurrentlySelectedResult from 'state/inline-help/selectors/get-inline-help-currently-selected-result';
 
+import 'state/inline-help/init';
+
 /**
  * Returns the link / href of the selected search result item
  *

--- a/client/state/inline-help/selectors/get-inline-help-currently-selected-result.js
+++ b/client/state/inline-help/selectors/get-inline-help-currently-selected-result.js
@@ -11,6 +11,8 @@ import getInlineHelpSearchResultsForQuery from 'state/inline-help/selectors/get-
 import getSelectedResultIndex from 'state/inline-help/selectors/get-selected-result-index';
 import getContextualHelpResults from 'state/inline-help/selectors/get-contextual-help-results';
 
+import 'state/inline-help/init';
+
 /**
  * Returns the selected search result item
  *

--- a/client/state/inline-help/selectors/get-inline-help-search-results-for-query.js
+++ b/client/state/inline-help/selectors/get-inline-help-search-results-for-query.js
@@ -4,6 +4,11 @@
 import { get } from 'lodash';
 
 /**
+ * Internal dependencies
+ */
+import 'state/inline-help/init';
+
+/**
  * Returns an array of all search results for a given search query or `null`
  * if there are no results for that query.
  *

--- a/client/state/inline-help/selectors/get-search-query.js
+++ b/client/state/inline-help/selectors/get-search-query.js
@@ -4,6 +4,11 @@
 import { get } from 'lodash';
 
 /**
+ * Internal dependencies
+ */
+import 'state/inline-help/init';
+
+/**
  * Returns the current search query.
  *
  * @param  {object}  state  Global state tree

--- a/client/state/inline-help/selectors/get-selected-result-index.js
+++ b/client/state/inline-help/selectors/get-selected-result-index.js
@@ -4,6 +4,11 @@
 import { get } from 'lodash';
 
 /**
+ * Internal dependencies
+ */
+import 'state/inline-help/init';
+
+/**
  * Returns the index of the currently selected search result.
  *
  * @param  {object}  state  Global state tree

--- a/client/state/inline-help/selectors/is-inline-help-popover-visible.js
+++ b/client/state/inline-help/selectors/is-inline-help-popover-visible.js
@@ -4,6 +4,11 @@
 import { get } from 'lodash';
 
 /**
+ * Internal dependencies
+ */
+import 'state/inline-help/init';
+
+/**
  * Returns a bool indicating if the inline help popover is currently showing.
  *
  * @param  {object}  state  Global state tree

--- a/client/state/inline-help/selectors/is-requesting-inline-help-search-results-for-query.js
+++ b/client/state/inline-help/selectors/is-requesting-inline-help-search-results-for-query.js
@@ -4,6 +4,11 @@
 import { get } from 'lodash';
 
 /**
+ * Internal dependencies
+ */
+import 'state/inline-help/init';
+
+/**
  * Returns true if currently requesting search results for a given query; false
  * otherwise.
  *

--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -35,7 +35,6 @@ import i18n from './i18n/reducer';
 import immediateLogin from './immediate-login/reducer';
 import importerNux from './importer-nux/reducer';
 import imports from './imports/reducer';
-import inlineHelp from './inline-help/reducer';
 import inlineSupportArticle from './inline-support-article/reducer';
 import invites from './invites/reducer';
 import jetpackProductInstall from './jetpack-product-install/reducer';
@@ -103,7 +102,6 @@ const reducers = {
 	immediateLogin,
 	importerNux,
 	imports,
-	inlineHelp,
 	inlineSupportArticle,
 	invites,
 	jetpackProductInstall,

--- a/client/state/selectors/has-inline-help-api-results.js
+++ b/client/state/selectors/has-inline-help-api-results.js
@@ -1,4 +1,9 @@
 /**
+ * Internal dependencies
+ */
+import 'state/inline-help/init';
+
+/**
  * Indicates whether the current search results came from the API or are
  * statically coded "contextual" results.
  * see: client/blocks/inline-help/contextual-help.js

--- a/client/state/selectors/is-inline-help-visible.js
+++ b/client/state/selectors/is-inline-help-visible.js
@@ -1,4 +1,9 @@
 /**
+ * Internal dependencies
+ */
+import 'state/inline-help/init';
+
+/**
  * Returns a bool indicating if the inline help ui should be visibile
  * or not. Note this is not hiding the popover. This means the UI will be
  * hidden entirely.

--- a/client/state/selectors/is-showing-q-and-a-inline-help-contact-form.js
+++ b/client/state/selectors/is-showing-q-and-a-inline-help-contact-form.js
@@ -4,6 +4,11 @@
 import { get } from 'lodash';
 
 /**
+ * Internal dependencies
+ */
+import 'state/inline-help/init';
+
+/**
  * Returns a bool indicating if the contact form UI is showing the Q&A suggestions.
  *
  * @param  {object}  state  Global state tree


### PR DESCRIPTION
This PR is one of many working on modularising state in Calypso. This one handles inline help.

For more details on state modularisation, see the [modularised state documentation](https://github.com/Automattic/wp-calypso/blob/master/docs/modularized-state.md) and p4TIVU-9lM-p2.

Fixes #42448.

#### Changes proposed in this Pull Request

* Modularise inline help state

#### Testing instructions

Inline help state is always loaded on (logged-in) boot, and that appears to be an intentional decision in order to make the help widget available everywhere. However, that makes it difficult to see the state going from unloaded to loaded, as it happens without user input on boot, so it's difficult to test the automatic state loading part of the PR. That's not a big concern, however; the important thing is to ensure that nothing is getting broken.

With that in mind, in order to verify that this change works correctly, please smoke test inline help functionality and ensure that it continues to work as before. I did some limited testing with the inline help block in `/home`, and everything appeared to work correctly.