### PR TITLE
Remove references to old pricing tests

### DIFF
--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -14,7 +14,6 @@ import page from 'page';
 import DocumentHead from 'components/data/document-head';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import canCurrentUser from 'state/selectors/can-current-user';
-import getCurrentUserMarketingPriceGroup from 'state/selectors/get-current-user-marketing-price-group';
 import Main from 'components/main';
 import EmptyContent from 'components/empty-content';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
@@ -194,6 +193,5 @@ export default connect( ( state ) => {
 		selectedSite: getSelectedSite( state ),
 		displayJetpackPlans: ! isSiteAutomatedTransfer && jetpackSite,
 		canAccessPlans: canCurrentUser( state, getSelectedSiteId( state ), 'manage_options' ),
-		marketingPriceGroup: getCurrentUserMarketingPriceGroup( state ),
 	};
 } )( localize( withTrackingTool( 'HotJar' )( Plans ) ) );

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -32,10 +32,6 @@ import QuerySitePurchases from 'components/data/query-site-purchases';
 import { getCurrentPlan } from 'state/sites/plans/selectors';
 import { isPartnerPurchase, getPartnerName } from 'lib/purchases';
 import CartData from 'components/data/cart';
-import {
-	MARKETING_PRICE_GROUP_2020_Q2_TEST_2,
-	MARKETING_PRICE_GROUP_2020_Q2_TEST_3,
-} from 'state/current-user/constants';
 import { PerformanceTrackerStop } from 'lib/performance-tracking';
 
 class Plans extends React.Component {
@@ -130,10 +126,8 @@ class Plans extends React.Component {
 			displayJetpackPlans,
 			canAccessPlans,
 			purchase,
-			marketingPriceGroup,
+			customerType,
 		} = this.props;
-
-		let { customerType } = this.props;
 
 		if ( ! selectedSite || this.isInvalidPlanInterval() ) {
 			return this.renderPlaceholder();
@@ -141,17 +135,6 @@ class Plans extends React.Component {
 
 		if ( purchase && isPartnerPurchase( purchase ) ) {
 			return this.renderPlanWithPartner();
-		}
-
-		let hidePersonalPlan = false,
-			hidePremiumPlan = false;
-
-		if ( marketingPriceGroup === MARKETING_PRICE_GROUP_2020_Q2_TEST_2 ) {
-			hidePersonalPlan = true;
-			customerType = 'business';
-		} else if ( marketingPriceGroup === MARKETING_PRICE_GROUP_2020_Q2_TEST_3 ) {
-			hidePersonalPlan = true;
-			hidePremiumPlan = true;
 		}
 
 		return (
@@ -179,8 +162,6 @@ class Plans extends React.Component {
 								<PlansFeaturesMain
 									displayJetpackPlans={ displayJetpackPlans }
 									hideFreePlan={ true }
-									hidePersonalPlan={ hidePersonalPlan }
-									hidePremiumPlan={ hidePremiumPlan }
 									customerType={ customerType }
 									intervalType={ this.props.intervalType }
 									selectedFeature={ this.props.selectedFeature }

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -27,7 +27,6 @@ import { getSiteTypePropertyValue } from 'lib/signup/site-type';
 import { saveSignupStep, submitSignupStep } from 'state/signup/progress/actions';
 import { recordTracksEvent } from 'state/analytics/actions';
 import hasInitializedSites from 'state/selectors/has-initialized-sites';
-import getCurrentUserMarketingPriceGroup from 'state/selectors/get-current-user-marketing-price-group';
 
 /**
  * Style dependencies
@@ -235,7 +234,7 @@ export const isDotBlogDomainRegistration = ( domainItem ) => {
 };
 
 export default connect(
-	( state, { path, signupDependencies: { siteSlug, domainItem, marketing_price_group } } ) => ( {
+	( state, { path, signupDependencies: { siteSlug, domainItem } } ) => ( {
 		// Blogger plan is only available if user chose either a free domain or a .blog domain registration
 		disableBloggerPlanWithNonBlogDomain:
 			domainItem && ! isSubdomain( domainItem.meta ) && ! isDotBlogDomainRegistration( domainItem ),
@@ -247,9 +246,6 @@ export default connect(
 		siteGoals: getSiteGoals( state ) || '',
 		siteType: getSiteType( state ),
 		hasInitializedSitesBackUrl: hasInitializedSites( state ) ? '/sites/' : false,
-
-		// the former is for signing up; the latter is for the logged-in case
-		marketingPriceGroup: marketing_price_group || getCurrentUserMarketingPriceGroup( state ),
 	} ),
 	{ recordTracksEvent, saveSignupStep, submitSignupStep }
 )( localize( PlansStep ) );

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -28,10 +28,6 @@ import { saveSignupStep, submitSignupStep } from 'state/signup/progress/actions'
 import { recordTracksEvent } from 'state/analytics/actions';
 import hasInitializedSites from 'state/selectors/has-initialized-sites';
 import getCurrentUserMarketingPriceGroup from 'state/selectors/get-current-user-marketing-price-group';
-import {
-	MARKETING_PRICE_GROUP_2020_Q2_TEST_2,
-	MARKETING_PRICE_GROUP_2020_Q2_TEST_3,
-} from 'state/current-user/constants';
 
 /**
  * Style dependencies
@@ -90,10 +86,6 @@ export class PlansStep extends Component {
 	}
 
 	getCustomerType() {
-		if ( this.props.marketingPriceGroup === MARKETING_PRICE_GROUP_2020_Q2_TEST_2 ) {
-			return 'business';
-		}
-
 		if ( this.props.customerType ) {
 			return this.props.customerType;
 		}
@@ -135,18 +127,7 @@ export class PlansStep extends Component {
 			selectedSite,
 			planTypes,
 			flowName,
-			marketingPriceGroup,
 		} = this.props;
-
-		let hidePersonalPlan = false,
-			hidePremiumPlan = false;
-
-		if ( marketingPriceGroup === MARKETING_PRICE_GROUP_2020_Q2_TEST_2 ) {
-			hidePersonalPlan = true;
-		} else if ( marketingPriceGroup === MARKETING_PRICE_GROUP_2020_Q2_TEST_3 ) {
-			hidePersonalPlan = true;
-			hidePremiumPlan = true;
-		}
 
 		return (
 			<div>
@@ -155,8 +136,6 @@ export class PlansStep extends Component {
 				<PlansFeaturesMain
 					site={ selectedSite || {} } // `PlanFeaturesMain` expects a default prop of `{}` if no site is provided
 					hideFreePlan={ hideFreePlan }
-					hidePersonalPlan={ hidePersonalPlan }
-					hidePremiumPlan={ hidePremiumPlan }
 					isInSignup={ true }
 					isLaunchPage={ isLaunchPage }
 					onUpgradeClick={ this.onSelectPlan }

--- a/client/state/current-user/constants.js
+++ b/client/state/current-user/constants.js
@@ -2,5 +2,3 @@ export const DOMAINS_WITH_PLANS_ONLY = 'calypso_domains_with_plans_only';
 export const NON_PRIMARY_DOMAINS_TO_FREE_USERS = 'calypso_allow_nonprimary_domains_without_plan';
 
 export const MARKETING_PRICE_GROUP_2020_Q2_TEST_1 = 'price_2020_q2_test_1';
-export const MARKETING_PRICE_GROUP_2020_Q2_TEST_2 = 'price_2020_q2_test_2';
-export const MARKETING_PRICE_GROUP_2020_Q2_TEST_3 = 'price_2020_q2_test_3';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Removes all references to marketing pricing tests 2 and 3.
Most changes from 4e3101b11641b79d8d2226a3bc0ee6661da5d65c are reversed, however the `marketingPriceGroup` selector and associated logic is preserved for future tests.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


1. Enforce a test account to the test pricing group 2.
    1. Go through the sign up flow and stop at the plans step.
    1. The Personal plan should be visible. Earlier, it would have been hidden.
    1. Stay logged-in, go through the site creation flow and stop at the plans step. The Personal plan should be visible. Earlier, it would have been hidden.
    1. Stay logged-in, go to `/plans`. The Personal plan should be visible. Earlier, it would have been hidden.
1. Enforce a test account to the test pricing group 3.
    1. Go through the sign up flow and stop at the plans step.
    1. The Personal plan and the Premium plan should be visible. Earlier, it would have been hidden.
    1. Stay logged-in, go through the site creation flow and stop at the plans step. The Personal plan and the Premium plan should be visible. Earlier, it would have been hidden.
    1. Stay logged-in, go to `/plans`. The Personal plan and the Premium plan should be visible. Earlier, it would have been hidden.