### PR TITLE
Marketing: Connections scrollIntoView only once

### DIFF
--- a/client/my-sites/marketing/connections/services-group.jsx
+++ b/client/my-sites/marketing/connections/services-group.jsx
@@ -53,7 +53,7 @@ const SharingServicesGroup = ( { isFetching, services, title, expandedService } 
 				serviceElement.scrollIntoView();
 			}
 		}
-	}, [ expandedService, services ] );
+	}, [ expandedService, isFetching ] );
 
 	if ( ! services.length && ! isFetching ) {
 		return null;

--- a/client/my-sites/marketing/connections/services-group.jsx
+++ b/client/my-sites/marketing/connections/services-group.jsx
@@ -45,7 +45,7 @@ const serviceWarningLevelToNoticeStatus = ( level ) => {
 
 const SharingServicesGroup = ( { isFetching, services, title, expandedService } ) => {
 	useEffect( () => {
-		if ( expandedService ) {
+		if ( expandedService && ! isFetching ) {
 			const serviceElement = document.querySelector(
 				'.sharing-service.' + expandedService.replace( /_/g, '-' )
 			);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* `scrollIntoView` should run only once to resolve #41424 and clicking an other tab doesn't result to a scroll
* used `[ expandedService, isFetching ]` as dependencies and not `[ expandedService, services ]` assuming that, while `isFetching === true`, there is not need to scroll and when `isFetching` changes to `false` we should only `scrollIntoView` once

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
- Starting at URL: /marketing/connection/facebook
- Scroll up page and click on traffic tab - notice that the page scrolls down to same point as on connections tab

**Before**
![scroll-bug](https://user-images.githubusercontent.com/3629020/80149973-a89f5d00-860b-11ea-870d-94633453511e.gif)

**After**
![SS 2020-06-24 at 17 44 44](https://user-images.githubusercontent.com/12430020/85578128-82fdf680-b642-11ea-9422-a5313678d82a.gif)
