### PR TITLE
[RUM] Capture post metadata

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -865,28 +865,20 @@ function handleUncaughtErrors( calypsoPort ) {
 	};
 }
 
-function handleEditorLoaded( calypsoPort ) {
-	const unsubscribe = subscribe( () => {
-		const store = select( 'core/editor' );
+async function handleEditorLoaded( calypsoPort ) {
+	await isEditorReadyWithBlocks();
+	const isNew = select( 'core/editor' ).isCleanNewPost();
+	const blocks = select( 'core/block-editor' ).getBlocks();
 
-		if ( typeof store.__unstableIsEditorReady !== 'function' ) {
-			// This is probably a very old veresion of the plugin, bail out.
-			unsubscribe();
-			return;
-		}
-
-		const isReady = store.__unstableIsEditorReady();
-		if ( isReady ) {
-			requestAnimationFrame( () => {
-				calypsoPort.postMessage( {
-					action: 'trackPerformance',
-					payload: {
-						mark: 'editor.ready',
-					},
-				} );
-			} );
-			unsubscribe();
-		}
+	requestAnimationFrame( () => {
+		calypsoPort.postMessage( {
+			action: 'trackPerformance',
+			payload: {
+				mark: 'editor.ready',
+				isNew,
+				blockCount: blocks.length,
+			},
+		} );
 	} );
 }
 

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -380,7 +380,10 @@ class CalypsoifyIframe extends Component<
 
 		if ( EditorActions.TrackPerformance === action ) {
 			if ( payload.mark === 'editor.ready' ) {
-				this.props.stopPerformanceTracking();
+				this.props.stopPerformanceTracking( {
+					isNew: payload.isNew,
+					blockCount: payload.blockCount,
+				} );
 			}
 		}
 	};

--- a/client/lib/performance-tracking/index.ts
+++ b/client/lib/performance-tracking/index.ts
@@ -6,5 +6,7 @@ export { withStopPerformanceTrackingProp } from './with-stop-performance-trackin
 export { default as PerformanceTrackerStop } from './performance-tracker-stop';
 
 export type PerformanceTrackProps = {
-	stopPerformanceTracking: ( metadata: { [ key: string ]: string | boolean | number } ) => void;
+	stopPerformanceTracking: (
+		metadata: { [ key: string ]: string | boolean | number } = {}
+	) => void;
 };

--- a/client/lib/performance-tracking/index.ts
+++ b/client/lib/performance-tracking/index.ts
@@ -6,5 +6,5 @@ export { withStopPerformanceTrackingProp } from './with-stop-performance-trackin
 export { default as PerformanceTrackerStop } from './performance-tracker-stop';
 
 export type PerformanceTrackProps = {
-	stopPerformanceTracking: () => void;
+	stopPerformanceTracking: ( metadata: { [ key: string ]: string | boolean | number } ) => void;
 };

--- a/client/lib/performance-tracking/index.ts
+++ b/client/lib/performance-tracking/index.ts
@@ -6,7 +6,5 @@ export { withStopPerformanceTrackingProp } from './with-stop-performance-trackin
 export { default as PerformanceTrackerStop } from './performance-tracker-stop';
 
 export type PerformanceTrackProps = {
-	stopPerformanceTracking: (
-		metadata: { [ key: string ]: string | boolean | number } = {}
-	) => void;
+	stopPerformanceTracking: ( metadata?: { [ key: string ]: string | boolean | number } ) => void;
 };

--- a/client/lib/performance-tracking/lib.js
+++ b/client/lib/performance-tracking/lib.js
@@ -18,12 +18,12 @@ import {
 } from 'state/current-user/selectors';
 
 /**
- * These reporters are added to _all_ performance tracking metrics.
- * Be sure to add only reporters that make sense for all metrics and are always present.
+ * This reporter is added to _all_ performance tracking metrics.
+ * Be sure to add only metrics that make sense for tarcked pages and are always present.
  *
  * @param state redux state
  */
-const getDefaultCollector = ( state ) => {
+const buildDefaultCollector = ( state ) => {
 	const siteId = getSelectedSiteId( state );
 	const siteIsJetpack = isJetpackSite( state, siteId );
 	const siteIsSingleUser = isSingleUserSite( state, siteId );
@@ -40,23 +40,28 @@ const getDefaultCollector = ( state ) => {
 	};
 };
 
+const buildMetadataCollector = ( metadata = {} ) => {
+	return ( reporter ) => {
+		Object.entries( metadata ).forEach( ( [ key, value ] ) => reporter.data.set( key, value ) );
+	};
+};
+
 const isPerformanceTrackingEnabled = () => {
 	const isEnabledForEnvironment = config.isEnabled( CONFIG_NAME );
 	const isEnabledForCurrentInteraction = abtest( AB_NAME ) === AB_VARIATION_ON;
 	return isEnabledForEnvironment && isEnabledForCurrentInteraction;
 };
 
-export const startPerformanceTracking = (
-	name,
-	{ fullPageLoad = false, collectors = [] } = {}
-) => {
+export const startPerformanceTracking = ( name, { fullPageLoad = false } = {} ) => {
 	if ( isPerformanceTrackingEnabled() ) {
-		start( name, { fullPageLoad, collectors } );
+		start( name, { fullPageLoad } );
 	}
 };
 
-export const stopPerformanceTracking = ( name, state, { collectors = [] } = {} ) => {
+export const stopPerformanceTracking = ( name, { state = {}, metadata = {} } = {} ) => {
 	if ( isPerformanceTrackingEnabled() ) {
-		stop( name, { collectors: [ getDefaultCollector( state ), ...collectors ] } );
+		stop( name, {
+			collectors: [ buildDefaultCollector( state ), buildMetadataCollector( metadata ) ],
+		} );
 	}
 };

--- a/client/lib/performance-tracking/lib.js
+++ b/client/lib/performance-tracking/lib.js
@@ -19,7 +19,7 @@ import {
 
 /**
  * This reporter is added to _all_ performance tracking metrics.
- * Be sure to add only metrics that make sense for tarcked pages and are always present.
+ * Be sure to add only metrics that make sense for tracked pages and are always present.
  *
  * @param state redux state
  */

--- a/client/lib/performance-tracking/test/lib.js
+++ b/client/lib/performance-tracking/test/lib.js
@@ -106,16 +106,6 @@ describe( 'startPerformanceTracking', () => {
 			expect.objectContaining( { fullPageLoad: false } )
 		);
 	} );
-
-	it( 'passes the list of collectors', () => {
-		const collectors = [];
-		startPerformanceTracking( 'pageName', { collectors } );
-
-		expect( start ).toHaveBeenCalledWith(
-			expect.anything(),
-			expect.objectContaining( { collectors } )
-		);
-	} );
 } );
 
 describe( 'stopPerformanceTracking', () => {
@@ -156,16 +146,6 @@ describe( 'stopPerformanceTracking', () => {
 		expect( stop ).toHaveBeenCalledWith( 'pageName', expect.anything() );
 	} );
 
-	it( 'passes the list of collectors', () => {
-		const collector = () => {};
-		stopPerformanceTracking( 'pageName', {}, { collectors: [ collector ] } );
-
-		expect( stop ).toHaveBeenCalledWith(
-			expect.anything(),
-			expect.objectContaining( { collectors: expect.arrayContaining( [ collector ] ) } )
-		);
-	} );
-
 	it( 'uses the state to generate the default collector', () => {
 		const state = {};
 		const report = {
@@ -177,7 +157,7 @@ describe( 'stopPerformanceTracking', () => {
 		getSelectedSiteId.mockImplementation( () => 42 );
 
 		// Run the default collector
-		stopPerformanceTracking( 'pageName', state );
+		stopPerformanceTracking( 'pageName', { state } );
 		const defaultCollector = stop.mock.calls[ 0 ][ 1 ].collectors[ 0 ];
 		defaultCollector( report );
 
@@ -187,5 +167,23 @@ describe( 'stopPerformanceTracking', () => {
 		expect( report.data.get( 'siteIsJetpack' ) ).toBe( false );
 		expect( report.data.get( 'siteIsSingleUser' ) ).toBe( false );
 		expect( report.data.get( 'siteIsAtomic' ) ).toBe( false );
+	} );
+
+	it( 'uses metdata to generate a collector', () => {
+		const report = {
+			data: new Map(),
+		};
+
+		// Run the default collector
+		stopPerformanceTracking( 'pageName', {
+			state: {},
+			metadata: {
+				foo: 42,
+			},
+		} );
+		const metadataCollector = stop.mock.calls[ 0 ][ 1 ].collectors[ 1 ];
+		metadataCollector( report );
+
+		expect( report.data.get( 'foo' ) ).toBe( 42 );
 	} );
 } );

--- a/client/lib/performance-tracking/use-performance-tracker-stop.js
+++ b/client/lib/performance-tracking/use-performance-tracker-stop.js
@@ -18,7 +18,7 @@ export function usePerformanceTrackerStop() {
 	// Use `useLayoutEffect` + rAF to be as close as possible to the actual rendering
 	useLayoutEffect( () => {
 		requestAnimationFrame( () => {
-			stopPerformanceTracking( sectionName, store.getState() );
+			stopPerformanceTracking( sectionName, { state: store.getState() } );
 		} );
 	}, [ sectionName, store ] );
 }

--- a/client/lib/performance-tracking/with-stop-performance-tracking-prop.jsx
+++ b/client/lib/performance-tracking/with-stop-performance-tracking-prop.jsx
@@ -11,7 +11,7 @@ import { getSectionName } from 'state/ui/selectors';
 
 export const withStopPerformanceTrackingProp = ( () => {
 	return connect( null, {
-		stopPerformanceTracking: ( metadata ) => ( dispatch, getState ) => {
+		stopPerformanceTracking: ( metadata = {} ) => ( dispatch, getState ) => {
 			const state = getState();
 			const sectionName = getSectionName( state );
 			stopPerformanceTracking( sectionName, { state, metadata } );

--- a/client/lib/performance-tracking/with-stop-performance-tracking-prop.jsx
+++ b/client/lib/performance-tracking/with-stop-performance-tracking-prop.jsx
@@ -11,10 +11,10 @@ import { getSectionName } from 'state/ui/selectors';
 
 export const withStopPerformanceTrackingProp = ( () => {
 	return connect( null, {
-		stopPerformanceTracking: () => ( dispatch, getState ) => {
+		stopPerformanceTracking: ( metadata ) => ( dispatch, getState ) => {
 			const state = getState();
 			const sectionName = getSectionName( state );
-			stopPerformanceTracking( sectionName, state );
+			stopPerformanceTracking( sectionName, { state, metadata } );
 		},
 	} );
 } )();

--- a/package.json
+++ b/package.json
@@ -286,6 +286,7 @@
 		"eslint-plugin-react": "^7.20.0",
 		"eslint-plugin-wpcalypso": "^4.1.0",
 		"exports-loader": "^0.7.0",
+		"fake-indexeddb": "^3.0.0",
 		"fork-ts-checker-webpack-plugin": "^3.1.1",
 		"gettext-parser": "^4.0.3",
 		"glob": "^7.1.6",

--- a/package.json
+++ b/package.json
@@ -286,7 +286,6 @@
 		"eslint-plugin-react": "^7.20.0",
 		"eslint-plugin-wpcalypso": "^4.1.0",
 		"exports-loader": "^0.7.0",
-		"fake-indexeddb": "^3.0.0",
 		"fork-ts-checker-webpack-plugin": "^3.1.1",
 		"gettext-parser": "^4.0.3",
 		"glob": "^7.1.6",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change the API in the wrapper `client/lib/performance-tracking/` and exported components to be able to accept an arbitrary object with metadata instead of collectors: consumers shouldn't need to know what a collector is just to send a key/value in the report.

* Instrument gutenframe to capture whether the user is creating a new post and the number of blocks.

#### Testing instructions

First, deploy changes in `wpcom-block-editor` (requires sandbox aliased to `wpcom-sandbox`):

* `cd apps/wpcom-block-editor`
* Run `yarn wpcom-sync` and leave it running.
* In a separate terminal, run `yarn build:prod`. This should update the changes in `wpcom-block-editor` to your sandbox.
* Redirect `widgets.wp.com` to your sandbox IP address.

Then, test the changes in Calypso:

* Start calypso with `yarn start`
* Go to your posts/pages and edit one of them.
* Check the network tab in Dev Tools for requests to `/logstash`. Inspect the payload, it should say `isNew:false` and `blockCount` (with the number of blocks in your post/page)
* Create a new post/page and verify they payload now includes `isNew:true` and `blockCount:0`
