### PR TITLE
Move and modularise theme setup state

### DIFF
--- a/client/my-sites/site-settings/theme-setup-dialog/index.jsx
+++ b/client/my-sites/site-settings/theme-setup-dialog/index.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
@@ -13,7 +12,12 @@ import page from 'page';
 import { Dialog } from '@automattic/components';
 import PulsingDot from 'components/pulsing-dot';
 import { getSelectedSite } from 'state/ui/selectors';
-import { toggleDialog, runThemeSetup } from 'state/ui/theme-setup/actions';
+import { toggleDialog, runThemeSetup as runThemeSetupAction } from 'state/theme-setup/actions';
+import {
+	isThemeSetupDialogVisible,
+	isThemeSetupActive,
+	getThemeSetupResult,
+} from 'state/theme-setup/selectors';
 
 /**
  * Style dependencies
@@ -112,12 +116,10 @@ class ThemeSetupDialog extends React.Component {
 	}
 }
 
-ThemeSetupDialog = localize( ThemeSetupDialog );
-
 const mapStateToProps = ( state ) => {
-	const isDialogVisible = state.ui.themeSetup.isDialogVisible;
-	const isActive = state.ui.themeSetup.active;
-	const result = state.ui.themeSetup.result;
+	const isDialogVisible = isThemeSetupDialogVisible( state );
+	const isActive = isThemeSetupActive( state );
+	const result = getThemeSetupResult( state );
 	const site = getSelectedSite( state );
 	return {
 		isDialogVisible,
@@ -127,4 +129,6 @@ const mapStateToProps = ( state ) => {
 	};
 };
 
-export default connect( mapStateToProps, { toggleDialog, runThemeSetup } )( ThemeSetupDialog );
+export default connect( mapStateToProps, { toggleDialog, runThemeSetup: runThemeSetupAction } )(
+	localize( ThemeSetupDialog )
+);

--- a/client/my-sites/site-settings/theme-setup/index.jsx
+++ b/client/my-sites/site-settings/theme-setup/index.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
@@ -19,7 +18,7 @@ import ThemeSetupPlaceholder from './theme-setup-placeholder';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { getActiveTheme, getTheme } from 'state/themes/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
-import { toggleDialog } from 'state/ui/theme-setup/actions';
+import { toggleDialog } from 'state/theme-setup/actions';
 
 /**
  * Style dependencies

--- a/client/state/theme-setup/actions.js
+++ b/client/state/theme-setup/actions.js
@@ -1,13 +1,14 @@
 /**
  * Internal dependencies
  */
-
 import wpcom from 'lib/wp';
 import {
 	THEME_SETUP_TOGGLE_DIALOG,
 	THEME_SETUP_REQUEST,
 	THEME_SETUP_RESULT,
 } from 'state/themes/action-types';
+
+import 'state/theme-setup/init';
 
 export function toggleDialog() {
 	return {

--- a/client/state/theme-setup/init.js
+++ b/client/state/theme-setup/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'state/redux-store';
+import reducer from './reducer';
+
+registerReducer( [ 'themeSetup' ], reducer );

--- a/client/state/theme-setup/package.json
+++ b/client/state/theme-setup/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/theme-setup/reducer.js
+++ b/client/state/theme-setup/reducer.js
@@ -1,8 +1,4 @@
 /**
- * External dependencies
- */
-
-/**
  * Internal dependencies
  */
 import {
@@ -10,6 +6,7 @@ import {
 	THEME_SETUP_RESULT,
 	THEME_SETUP_TOGGLE_DIALOG,
 } from 'state/themes/action-types';
+import { withStorageKey } from 'state/utils';
 
 const initialState = {
 	active: false,
@@ -30,4 +27,4 @@ export const themeSetup = ( state = initialState, action ) => {
 	return state;
 };
 
-export default themeSetup;
+export default withStorageKey( 'themeSetup', themeSetup );

--- a/client/state/theme-setup/selectors.js
+++ b/client/state/theme-setup/selectors.js
@@ -1,0 +1,16 @@
+/**
+ * Internal dependencies
+ */
+import 'state/theme-setup/init';
+
+export function isThemeSetupDialogVisible( state ) {
+	return state.themeSetup.isDialogVisible;
+}
+
+export function isThemeSetupActive( state ) {
+	return state.themeSetup.active;
+}
+
+export function getThemeSetupResult( state ) {
+	return state.themeSetup.result;
+}

--- a/client/state/ui/reducer.js
+++ b/client/state/ui/reducer.js
@@ -26,7 +26,6 @@ import payment from './payment/reducer';
 import postTypeList from './post-type-list/reducer';
 import preview from './preview/reducer';
 import section from './section/reducer';
-import themeSetup from './theme-setup/reducers';
 
 /**
  * Tracks the currently selected site ID.
@@ -119,7 +118,6 @@ const reducer = combineReducers( {
 	section,
 	selectedSiteId,
 	siteSelectionInitialized,
-	themeSetup,
 } );
 
 export default reducer;


### PR DESCRIPTION
This PR is one of many working on modularising state in Calypso. This one handles theme setup.

For more details on state modularisation, see the [modularised state documentation](https://github.com/Automattic/wp-calypso/blob/master/docs/modularized-state.md) and p4TIVU-9lM-p2.

Note: I added all the reviewers that GitHub suggested. Please feel free to ignore the review request or pull in someone else if you're not comfortable reviewing this PR. Thank you!

#### Changes proposed in this Pull Request

* Move `themeSetup` state out of `ui` and into a new top level entry
* Modularise it
* Extract a few inline selectors to a proper selector module.

#### Testing instructions

* Install [Redux DevTools](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en).
* Open DevTools and switch to the Redux tab.
* Open `/read` on the live branch or your local copy of this branch.
* Click `State` on the top right to ensure you see all state, and not just the diff for the last action: 
![image](https://user-images.githubusercontent.com/409615/73774406-d3e87d80-477b-11ea-9f59-3e42cc00101f.png)
* Analyse the tree and note that there's no `themeSetup` key, even if you expand the list of keys. This indicates that the theme setup state hasn't been loaded yet.
* Click `My Sites` on the masterbar, followed by `Manage` and `Settings` on the sidebar.
* Verify that a `themeSetup` key is added with the theme setup state. This indicates that the theme setup state has now been loaded.
* Verify that theme setup-related functionality works normally, by using the feature (tested myself, and everything seems to work correctly). You may need to test things locally, as the feature might not be available on the live branch.