### PR TITLE
Fix the Jetpack activation issue when automated transfers ends

### DIFF
--- a/client/components/jetpack/upsell-switch/index.tsx
+++ b/client/components/jetpack/upsell-switch/index.tsx
@@ -99,7 +99,7 @@ function UpsellSwitch( props: Props ): React.ReactElement {
 export default connect( ( state, ownProps: Props ) => {
 	const siteId = getSelectedSiteId( state );
 	const siteState = ownProps.getStateForSite( state, siteId );
-	const atomicSite = siteId ? isAtomicSite( state, siteId ) : false;
+	const atomicSite = siteId && isAtomicSite( state, siteId );
 
 	return {
 		siteId,

--- a/client/components/jetpack/upsell-switch/index.tsx
+++ b/client/components/jetpack/upsell-switch/index.tsx
@@ -10,6 +10,7 @@ import classNames from 'classnames';
  */
 import isJetpackCloud from 'lib/jetpack/is-jetpack-cloud';
 import { getSelectedSiteId } from 'state/ui/selectors';
+import isAtomicSite from 'state/selectors/is-site-wpcom-atomic';
 import Main from 'components/main';
 
 type QueryComponentProps = {
@@ -35,32 +36,47 @@ type Props = {
 	getStateForSite: QueryFunction;
 	siteId: number | null;
 	siteState: SiteState | null;
+	atomicSite: boolean;
 };
 
 function UpsellSwitch( props: Props ): React.ReactElement {
-	const { UpsellComponent, display, children, QueryComponent, siteId, siteState } = props;
+	const {
+		UpsellComponent,
+		display,
+		children,
+		QueryComponent,
+		siteId,
+		siteState,
+		atomicSite,
+	} = props;
 
 	const [ { showUpsell, isLoading }, setState ] = useState( {
 		showUpsell: true,
 		isLoading: true,
 	} );
+
 	useEffect( () => {
+		// Show loading placeholder, the site's state isn't initialized
 		if ( ! siteState || siteState?.state === 'uninitialized' ) {
 			return setState( {
 				isLoading: true,
 				showUpsell: true,
 			} );
 		}
-		const { state } = siteState;
-		if ( state === 'unavailable' ) {
+
+		// Show the expected content. It's distinct to unavailable (active, inactive, provisioning)
+		// or if it's an Atomic site
+		if ( siteState.state !== 'unavailable' || atomicSite ) {
 			return setState( {
 				isLoading: false,
-				showUpsell: true,
+				showUpsell: false,
 			} );
 		}
+
+		// Show the upsell page
 		return setState( {
 			isLoading: false,
-			showUpsell: false,
+			showUpsell: true,
 		} );
 	}, [ siteState ] );
 
@@ -83,9 +99,11 @@ function UpsellSwitch( props: Props ): React.ReactElement {
 export default connect( ( state, ownProps: Props ) => {
 	const siteId = getSelectedSiteId( state );
 	const siteState = ownProps.getStateForSite( state, siteId );
+	const atomicSite = siteId ? isAtomicSite( state, siteId ) : false;
 
 	return {
 		siteId,
 		siteState,
+		atomicSite,
 	};
 } )( UpsellSwitch );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes the issue when the process of transferring a Simple site to an Atomic site ends. The server responds with a `no_connected_jetpack` state, but it's already connected. So, this change checks if it's an Atomic site in the `UpsellSwitch`. Address this fix on the server is a little bit more complicated because the states are cached and we'd need a temporary notice page.

#### Testing instructions

- Select a Simple site with a Business plan. Or revert an Atomic site and reload the page.
- Go to Backup section and click on "Activate Jetpack Backup now"
- When the process ends, the Backup section will show up.
