### PR TITLE
media-storage: use data layer

### DIFF
--- a/client/components/data/query-media-storage/index.jsx
+++ b/client/components/data/query-media-storage/index.jsx
@@ -5,7 +5,6 @@
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 
 /**
  * Internal dependencies
@@ -63,17 +62,8 @@ QueryMediaStorage.defaultProps = {
 };
 
 export default connect(
-	( state, ownProps ) => {
-		return {
-			requestingMediaStorage: isRequestingMediaStorage( state, ownProps.siteId ),
-		};
-	},
-	( dispatch ) => {
-		return bindActionCreators(
-			{
-				requestMediaStorage,
-			},
-			dispatch
-		);
-	}
+	( state, ownProps ) => ( {
+		requestingMediaStorage: isRequestingMediaStorage( state, ownProps.siteId ),
+	} ),
+	{ requestMediaStorage }
 )( QueryMediaStorage );

--- a/client/state/data-layer/wpcom/sites/media-storage/index.js
+++ b/client/state/data-layer/wpcom/sites/media-storage/index.js
@@ -1,0 +1,46 @@
+/**
+ * Internal dependencies
+ */
+
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { http } from 'state/data-layer/wpcom-http/actions';
+import {
+	SITE_MEDIA_STORAGE_REQUEST,
+	SITE_MEDIA_STORAGE_REQUEST_SUCCESS,
+	SITE_MEDIA_STORAGE_REQUEST_FAILURE,
+} from 'state/action-types';
+import { receiveMediaStorage } from 'state/sites/media-storage/actions';
+
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
+export function requestMediaStorage( action ) {
+	return [
+		http(
+			{
+				method: 'GET',
+				path: `/sites/${ action.siteId }/media-storage`,
+				apiVersion: '1.1',
+			},
+			action
+		),
+	];
+}
+
+export const requestMediaStorageSuccess = ( { siteId }, mediaStorage ) => [
+	receiveMediaStorage( mediaStorage, siteId ),
+	{ type: SITE_MEDIA_STORAGE_REQUEST_SUCCESS, siteId },
+];
+
+export const requestMediaStorageError = ( { siteId }, error ) => [
+	{ type: SITE_MEDIA_STORAGE_REQUEST_FAILURE, siteId, error },
+];
+
+registerHandlers( 'state/data-layer/wpcom/sites/media-storage/index.js', {
+	[ SITE_MEDIA_STORAGE_REQUEST ]: [
+		dispatchRequest( {
+			fetch: requestMediaStorage,
+			onSuccess: requestMediaStorageSuccess,
+			onError: requestMediaStorageError,
+		} ),
+	],
+} );

--- a/client/state/data-layer/wpcom/sites/media-storage/test/__snapshots__/index.js.snap
+++ b/client/state/data-layer/wpcom/sites/media-storage/test/__snapshots__/index.js.snap
@@ -1,0 +1,28 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`wpcom-api #requestMediaStorageError() should dispatch receive media storage actions 1`] = `
+Array [
+  Object {
+    "error": [Error: arbitrary error],
+    "siteId": 12378129379,
+    "type": "SITE_MEDIA_STORAGE_REQUEST_FAILURE",
+  },
+]
+`;
+
+exports[`wpcom-api #requestMediaStorageSuccess() should dispatch receive media storage actions 1`] = `
+Array [
+  Object {
+    "mediaStorage": Object {
+      "max_storage_bytes": 214748364800,
+      "storage_used_bytes": 349630702,
+    },
+    "siteId": 12378129379,
+    "type": "SITE_MEDIA_STORAGE_RECEIVE",
+  },
+  Object {
+    "siteId": 12378129379,
+    "type": "SITE_MEDIA_STORAGE_REQUEST_SUCCESS",
+  },
+]
+`;

--- a/client/state/data-layer/wpcom/sites/media-storage/test/index.js
+++ b/client/state/data-layer/wpcom/sites/media-storage/test/index.js
@@ -1,0 +1,52 @@
+/**
+ * Internal dependencies
+ */
+import { requestMediaStorage, requestMediaStorageSuccess, requestMediaStorageError } from '../';
+import { receiveMediaStorage } from 'state/sites/media-storage/actions';
+import { http } from 'state/data-layer/wpcom-http/actions';
+
+const ARBITRARY_SITE_ID = 12378129379;
+
+describe( 'wpcom-api', () => {
+	describe( '#requestMediaStorage()', () => {
+		test( 'should return HTTP request action to media storage endpoint', () => {
+			const action = { siteId: ARBITRARY_SITE_ID };
+
+			expect( requestMediaStorage( action ) ).toEqual( [
+				http(
+					{ apiVersion: '1.1', method: 'GET', path: `/sites/${ ARBITRARY_SITE_ID }/media-storage` },
+					action
+				),
+			] );
+		} );
+	} );
+
+	describe( '#requestMediaStorageSuccess()', () => {
+		test( 'should dispatch receive media storage actions', () => {
+			const mediaStorageResponse = {
+				max_storage_bytes: 214748364800,
+				storage_used_bytes: 349630702,
+			};
+			const result = requestMediaStorageSuccess(
+				{ siteId: ARBITRARY_SITE_ID },
+				mediaStorageResponse
+			);
+
+			expect( result[ 0 ] ).toEqual(
+				receiveMediaStorage( mediaStorageResponse, ARBITRARY_SITE_ID )
+			);
+			expect( result ).toMatchSnapshot();
+		} );
+	} );
+
+	describe( '#requestMediaStorageError()', () => {
+		test( 'should dispatch receive media storage actions', () => {
+			const result = requestMediaStorageError(
+				{ siteId: ARBITRARY_SITE_ID },
+				new Error( 'arbitrary error' )
+			);
+
+			expect( result ).toMatchSnapshot();
+		} );
+	} );
+} );

--- a/client/state/sites/media-storage/actions.js
+++ b/client/state/sites/media-storage/actions.js
@@ -2,13 +2,21 @@
  * Internal dependencies
  */
 
-import wpcom from 'lib/wp';
-import {
-	SITE_MEDIA_STORAGE_RECEIVE,
-	SITE_MEDIA_STORAGE_REQUEST,
-	SITE_MEDIA_STORAGE_REQUEST_SUCCESS,
-	SITE_MEDIA_STORAGE_REQUEST_FAILURE,
-} from 'state/action-types';
+import { SITE_MEDIA_STORAGE_RECEIVE, SITE_MEDIA_STORAGE_REQUEST } from 'state/action-types';
+
+import 'state/data-layer/wpcom/sites/media-storage';
+
+/**
+ * Triggers a network reqeust to find media storage limits for a given site
+ *
+ * @param {number} siteId Site ID
+ */
+export function requestMediaStorage( siteId ) {
+	return {
+		type: SITE_MEDIA_STORAGE_REQUEST,
+		siteId,
+	};
+}
 
 /**
  * Returns an action object to be used in signalling that a mediaStorage object
@@ -23,38 +31,5 @@ export function receiveMediaStorage( mediaStorage, siteId ) {
 		type: SITE_MEDIA_STORAGE_RECEIVE,
 		mediaStorage,
 		siteId,
-	};
-}
-
-/**
- * Triggers a network request to find media storage limits for a given site
- *
- * @param   {number}   siteId Site ID
- * @returns {Function}        Action thunk
- */
-export function requestMediaStorage( siteId ) {
-	return ( dispatch ) => {
-		dispatch( {
-			type: SITE_MEDIA_STORAGE_REQUEST,
-			siteId,
-		} );
-		return wpcom
-			.undocumented()
-			.site( siteId )
-			.mediaStorage()
-			.then( ( mediaStorage ) => {
-				dispatch( receiveMediaStorage( mediaStorage, siteId ) );
-				dispatch( {
-					type: SITE_MEDIA_STORAGE_REQUEST_SUCCESS,
-					siteId,
-				} );
-			} )
-			.catch( ( error ) => {
-				dispatch( {
-					type: SITE_MEDIA_STORAGE_REQUEST_FAILURE,
-					siteId,
-					error,
-				} );
-			} );
 	};
 }

--- a/client/state/sites/media-storage/test/actions.js
+++ b/client/state/sites/media-storage/test/actions.js
@@ -1,29 +1,10 @@
 /**
- * External dependencies
- */
-import { expect } from 'chai';
-
-/**
  * Internal dependencies
  */
 import { receiveMediaStorage, requestMediaStorage } from '../actions';
-import {
-	SITE_MEDIA_STORAGE_RECEIVE,
-	SITE_MEDIA_STORAGE_REQUEST,
-	SITE_MEDIA_STORAGE_REQUEST_SUCCESS,
-	SITE_MEDIA_STORAGE_REQUEST_FAILURE,
-} from 'state/action-types';
-import useNock from 'test/helpers/use-nock';
-import { useSandbox } from 'test/helpers/use-sinon';
+import { SITE_MEDIA_STORAGE_RECEIVE, SITE_MEDIA_STORAGE_REQUEST } from 'state/action-types';
 
 describe( 'actions', () => {
-	let sandbox, spy;
-
-	useSandbox( ( newSandbox ) => {
-		sandbox = newSandbox;
-		spy = sandbox.spy();
-	} );
-
 	describe( '#receiveMediaStorage()', () => {
 		test( 'should return an action object', () => {
 			const siteId = 2916284;
@@ -32,7 +13,7 @@ describe( 'actions', () => {
 				storage_used_bytes: -1,
 			};
 			const action = receiveMediaStorage( mediaStorage, 2916284 );
-			expect( action ).to.eql( {
+			expect( action ).toEqual( {
 				type: SITE_MEDIA_STORAGE_RECEIVE,
 				siteId,
 				mediaStorage,
@@ -40,61 +21,12 @@ describe( 'actions', () => {
 		} );
 	} );
 
-	describe( '#receiveMediaStorage()', () => {
-		useNock( ( nock ) => {
-			nock( 'https://public-api.wordpress.com:443' )
-				.persist()
-				.get( '/rest/v1.1/sites/2916284/media-storage' )
-				.reply( 200, {
-					max_storage_bytes: 3221225472,
-					storage_used_bytes: 323506,
-				} )
-				.get( '/rest/v1.1/sites/77203074/media-storage' )
-				.reply( 403, {
-					error: 'authorization_required',
-					message: 'An active access token must be used to access media-storage.',
-				} );
-		} );
-
-		test( 'should dispatch fetch action when thunk triggered', () => {
-			requestMediaStorage( 2916284 )( spy );
-			expect( spy ).to.have.been.calledWith( {
+	describe( '#requestMediaStorage()', () => {
+		test( 'should return an action object', () => {
+			const action = requestMediaStorage( 2916284 );
+			expect( action ).toEqual( {
 				type: SITE_MEDIA_STORAGE_REQUEST,
 				siteId: 2916284,
-			} );
-		} );
-
-		test( 'should dispatch receive action when request completes', () => {
-			return requestMediaStorage( 2916284 )( spy ).then( () => {
-				expect( spy ).to.have.been.calledWith( {
-					type: SITE_MEDIA_STORAGE_RECEIVE,
-					mediaStorage: {
-						max_storage_bytes: 3221225472,
-						storage_used_bytes: 323506,
-					},
-					siteId: 2916284,
-				} );
-			} );
-		} );
-
-		test( 'should dispatch success action when request completes', () => {
-			return requestMediaStorage( 2916284 )( spy ).then( () => {
-				expect( spy ).to.have.been.calledWith( {
-					type: SITE_MEDIA_STORAGE_REQUEST_SUCCESS,
-					siteId: 2916284,
-				} );
-			} );
-		} );
-
-		test( 'should dispatch fail action when request fails', () => {
-			return requestMediaStorage( 77203074 )( spy ).then( () => {
-				expect( spy ).to.have.been.calledWith( {
-					type: SITE_MEDIA_STORAGE_REQUEST_FAILURE,
-					siteId: 77203074,
-					error: sandbox.match( {
-						message: 'An active access token must be used to access media-storage.',
-					} ),
-				} );
 			} );
 		} );
 	} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Refactor `requestMediaStorage` to use data layer

#### Testing instructions

1. Go to `/media` and make sure the storage block is shown

<img width="248" alt="Screenshot 2020-06-24 at 18 25 10" src="https://user-images.githubusercontent.com/9202899/85594248-0bcb6100-b648-11ea-9d93-fa709bf35211.png">

2. On a site with a paid plan go to _Settings_ > _Performance_ and make sure it's shown there as well

<img width="344" alt="Screenshot 2020-06-24 at 18 26 20" src="https://user-images.githubusercontent.com/9202899/85594416-34535b00-b648-11ea-93a4-e79f871f0391.png">

Found this while working on media reduxification and took the opportunity. 
