### PR TITLE
e2e: Add delay to twitter check

### DIFF
--- a/test/e2e/lib/pages/twitter-feed-page.js
+++ b/test/e2e/lib/pages/twitter-feed-page.js
@@ -26,6 +26,7 @@ export default class TwitterFeedPage extends AsyncBaseContainer {
 		const driver = this.driver;
 		return await driver
 			.wait( async function () {
+				await driver.sleep( 4000 );
 				await driver.navigate().refresh();
 				return await isEventuallyPresentAndDisplayed(
 					driver,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This change just adds a 4 second delay before we reload the Twitter page to check it for our tweet. We were reloading it so quickly that with multiple tests running, it was hitting a limit and blocking us.

#### Testing instructions

* Make sure the test `Public Posts: Preview and Publish a Public Post` passes in CI.
