### PR TITLE
DO NOT MERGE: Global Notices: Swap box-shadow for filter

### DIFF
--- a/client/components/global-notices/style.scss
+++ b/client/components/global-notices/style.scss
@@ -35,8 +35,7 @@
 	text-align: left;
 	pointer-events: auto;
 	border-radius: 0;
-	box-shadow: 0 2px 5px rgba( 0, 0, 0, 0.2 ),
-		0 0 56px rgba( 0, 0, 0, 0.15 );
+	box-shadow: 0 2px 5px rgba( 0, 0, 0, 0.2 );
 
 	.notice__icon-wrapper {
 		border-radius: 0;

--- a/client/components/global-notices/style.scss
+++ b/client/components/global-notices/style.scss
@@ -35,7 +35,7 @@
 	text-align: left;
 	pointer-events: auto;
 	border-radius: 0;
-	box-shadow: 0 2px 5px rgba( 0, 0, 0, 0.2 );
+	filter: drop-shadow( 0 2px 5px rgba( 0, 0, 0, 0.2 ) ) drop-shadow( 0 0 56px rgba( 0, 0, 0, 0.15 ) );
 
 	.notice__icon-wrapper {
 		border-radius: 0;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This is an experimental PR to test how changing the global notice drop-shadow affects a particularly sneaky rendering bug in Chrome, don't merge it, please. 

See #42003 