### PR TITLE
Domains: Remove problematic "blacklist"/"whitelist" language #43395

### DIFF
--- a/client/components/domains/register-domain-step/utility.js
+++ b/client/components/domains/register-domain-step/utility.js
@@ -57,10 +57,10 @@ export function markFeaturedSuggestions(
 	return output;
 }
 
-export function filterOutDomainsWithTlds( suggestions, blacklistTlds ) {
+export function filterOutDomainsWithTlds( suggestions, disallowedTlds ) {
 	return suggestions.filter( ( suggestion ) => {
 		const tld = suggestion.domain_name.split( '.' ).pop();
-		return blacklistTlds.indexOf( tld ) === -1;
+		return disallowedTlds.indexOf( tld ) === -1;
 	} );
 }
 

--- a/client/lib/domains/constants.js
+++ b/client/lib/domains/constants.js
@@ -25,7 +25,7 @@ export const domainAvailability = {
 	AVAILABLE: 'available',
 	AVAILABLE_PREMIUM: 'available_premium',
 	AVAILABILITY_CHECK_ERROR: 'availability_check_error',
-	BLACKLISTED: 'blacklisted_domain',
+	DISALLOWED: 'blacklisted_domain',
 	DOMAIN_SUGGESTIONS_THROTTLED: 'domain_suggestions_throttled',
 	DOTBLOG_SUBDOMAIN: 'dotblog_subdomain',
 	EMPTY_QUERY: 'empty_query',

--- a/client/lib/domains/get-tld.js
+++ b/client/lib/domains/get-tld.js
@@ -8,7 +8,7 @@ import wpcomMultiLevelTlds from './tlds/wpcom-multi-level-tlds.json';
  * Parse the tld from a given domain name, semi-naively. The function
  * first parses against a list of tlds that have been sold on WP.com
  * and falls back to a simplistic "everything after the last dot" approach
- * if the whitelist failed. This is ultimately not comprehensive as that
+ * if the list of explicitly allowed tlds failed. This is ultimately not comprehensive as that
  * is a poor base assumption (lots of second level tlds, etc). However,
  * for our purposes, the approach should be "good enough" for a long time.
  *

--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -233,7 +233,7 @@ function getAvailabilityNotice( domain, error, errorData ) {
 			);
 			break;
 
-		case domainAvailability.BLACKLISTED:
+		case domainAvailability.DISALLOWED:
 			if ( domain && domain.toLowerCase().indexOf( 'wordpress' ) > -1 ) {
 				message = translate(
 					'Due to {{a1}}trademark policy{{/a1}}, ' +
@@ -254,7 +254,7 @@ function getAvailabilityNotice( domain, error, errorData ) {
 				);
 			} else {
 				message = translate(
-					'Domain cannot be mapped to a WordPress.com blog because of blacklisted term.'
+					'Domain cannot be mapped to a WordPress.com blog because of disallowed term.'
 				);
 			}
 			break;

--- a/client/lib/domains/registration/test/availability-messages.js
+++ b/client/lib/domains/registration/test/availability-messages.js
@@ -25,7 +25,7 @@ describe( 'getAvailabilityNotice()', () => {
 
 	test( 'Should return default message when domain is not a string', () => {
 		expect(
-			getAvailabilityNotice( null, domainAvailability.BLACKLISTED, {
+			getAvailabilityNotice( null, domainAvailability.DISALLOWED, {
 				site: 1,
 				maintenanceEndTime: 2,
 			} )

--- a/client/my-sites/current-site/domain-warnings.jsx
+++ b/client/my-sites/current-site/domain-warnings.jsx
@@ -18,7 +18,7 @@ import QuerySiteDomains from 'components/data/query-site-domains';
 import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
 import isSiteEligibleForFullSiteEditing from 'state/selectors/is-site-eligible-for-full-site-editing';
 
-const ruleWhiteList = [
+const allowedRules = [
 	'unverifiedDomainsCanManage',
 	'unverifiedDomainsCannotManage',
 	'expiredDomainsCanManage',
@@ -53,7 +53,7 @@ const CurrentSiteDomainWarnings = ( {
 				isCompact
 				selectedSite={ selectedSite }
 				domains={ domains }
-				ruleWhiteList={ ruleWhiteList }
+				allowedRules={ allowedRules }
 				isSiteEligibleForFSE={ isSiteEligibleForFSE }
 				siteIsUnlaunched={ siteIsUnlaunched }
 			/>

--- a/client/my-sites/domains/components/domain-warnings/index.jsx
+++ b/client/my-sites/domains/components/domain-warnings/index.jsx
@@ -60,7 +60,7 @@ const newTransfersWrongNSWarning = 'new-transfer-wrong-ns';
 export class DomainWarnings extends React.PureComponent {
 	static propTypes = {
 		domains: PropTypes.array,
-		ruleWhiteList: PropTypes.array,
+		allowedRules: PropTypes.array,
 		domain: PropTypes.object,
 		isCompact: PropTypes.bool,
 		siteIsUnlaunched: PropTypes.bool,
@@ -69,7 +69,7 @@ export class DomainWarnings extends React.PureComponent {
 
 	static defaultProps = {
 		isCompact: false,
-		ruleWhiteList: [
+		allowedRules: [
 			'expiredDomainsCanManage',
 			'expiringDomainsCanManage',
 			'unverifiedDomainsCanManage',
@@ -125,7 +125,7 @@ export class DomainWarnings extends React.PureComponent {
 			this.newTransfersWrongNS,
 			this.pendingConsent,
 		];
-		const validRules = this.props.ruleWhiteList.map( ( ruleName ) => this[ ruleName ] );
+		const validRules = this.props.allowedRules.map( ( ruleName ) => this[ ruleName ] );
 		return intersection( allRules, validRules );
 	}
 

--- a/client/my-sites/domains/components/domain-warnings/test/index.js
+++ b/client/my-sites/domains/components/domain-warnings/test/index.js
@@ -417,11 +417,11 @@ describe( 'index', () => {
 	} );
 
 	describe( 'Ruleset filtering', () => {
-		test( 'should only process whitelisted renderers', () => {
+		test( 'should only process allowed renderers', () => {
 			const props = {
 				translate: identity,
 				domain: { name: 'example.com' },
-				ruleWhiteList: [],
+				allowedRules: [],
 				selectedSite: {},
 				moment,
 			};
@@ -435,7 +435,7 @@ describe( 'index', () => {
 			const props = {
 				translate: identity,
 				domain: { name: 'example.com' },
-				ruleWhiteList: [ 'getDomains' ],
+				allowedRules: [ 'getDomains' ],
 				selectedSite: {},
 				moment,
 			};

--- a/client/my-sites/domains/domain-management/edit/domain-types/registered-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/registered-domain-type.jsx
@@ -356,7 +356,7 @@ class RegisteredDomainType extends React.Component {
 				domain={ this.props.domain }
 				position="registered-domain"
 				selectedSite={ this.props.selectedSite }
-				ruleWhiteList={ [ 'newTransfersWrongNS', 'pendingConsent' ] }
+				allowedRules={ [ 'newTransfersWrongNS', 'pendingConsent' ] }
 			/>
 		);
 	}

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -86,7 +86,7 @@ export class List extends React.Component {
 					domains={ this.props.domains }
 					position="domain-list"
 					selectedSite={ this.props.selectedSite }
-					ruleWhiteList={ [
+					allowedRules={ [
 						'newDomainsWithPrimary',
 						'newDomains',
 						'unverifiedDomainsCanManage',

--- a/client/my-sites/domains/domain-management/name-servers/index.jsx
+++ b/client/my-sites/domains/domain-management/name-servers/index.jsx
@@ -134,7 +134,7 @@ class NameServers extends React.Component {
 					domain={ domain }
 					position="domain-name-servers"
 					selectedSite={ this.props.selectedSite }
-					ruleWhiteList={ [ 'pendingTransfer' ] }
+					allowedRules={ [ 'pendingTransfer' ] }
 				/>
 				{ this.warning() }
 				{ this.planUpsellForNonPrimaryDomain( domain ) }

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -153,7 +153,7 @@ class CurrentPlan extends Component {
 						domains={ domains }
 						position="current-plan"
 						selectedSite={ selectedSite }
-						ruleWhiteList={ [
+						allowedRules={ [
 							'newDomainsWithPrimary',
 							'newDomains',
 							'unverifiedDomainsCanManage',

--- a/packages/domain-picker/src/domain-picker/index.tsx
+++ b/packages/domain-picker/src/domain-picker/index.tsx
@@ -154,6 +154,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 					<Icon icon={ search } />
 				</div>
 				<TextControl
+					// Unable to remove this instance due to it being a HotJar term: https://github.com/Automattic/wp-calypso/pull/43348#discussion_r442015229
 					data-hj-whitelist
 					hideLabelFromVision
 					label={ label }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change various variable names to remove blacklist/whitelist
* Change `ruleWhiteList` prop to `allowedRules`

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure all instances of `ruleWhiteList` are renamed to `allowedRules`
* Ensure unit tests pass

Addresses part of https://github.com/Automattic/wp-calypso/issues/43395
