### PR TITLE
Always show post type tabs for Scheduled and Trashed

### DIFF
--- a/client/my-sites/post-type-filter/index.jsx
+++ b/client/my-sites/post-type-filter/index.jsx
@@ -5,7 +5,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { localize, getLocaleSlug } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { compact, find, flow, includes, reduce } from 'lodash';
+import { compact, find, flow, reduce } from 'lodash';
 
 /**
  * Internal dependencies
@@ -56,19 +56,6 @@ export class PostTypeFilter extends Component {
 		return reduce(
 			counts,
 			( memo, count, status ) => {
-				// * Always add 'publish' and 'draft' tabs
-				// * Add all tabs in all-sites mode
-				// * Add all tabs in JP mode, for CPTs
-				// * In all other cases, add status tabs only if there's at least one post/CPT with that status
-				if (
-					siteId &&
-					! ( jetpack && query.type !== 'post' ) &&
-					! count &&
-					! includes( [ 'publish', 'draft' ], status )
-				) {
-					return memo;
-				}
-
 				let label, pathStatus;
 				switch ( status ) {
 					case 'publish':


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates `/posts` so that the "Scheduled" and "Trashed" tabs are visible regardless of whether any scheduled/trashed posts exist for the blog.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Verify unit tests pass.
* Navigate to the `/posts` view for a blog on your account. Remove all scheduled and trashed posts. Verify that the tabs still appear with a "0" post count instead of disappearing.

![image](https://user-images.githubusercontent.com/13437011/85615184-774e0800-b621-11ea-8a63-2253192a8449.png)


Fixes #41413
