### PR TITLE
Global Notices: Remove secondary drop shadow

### DIFF
--- a/client/components/global-notices/style.scss
+++ b/client/components/global-notices/style.scss
@@ -35,8 +35,7 @@
 	text-align: left;
 	pointer-events: auto;
 	border-radius: 0;
-	box-shadow: 0 2px 5px rgba( 0, 0, 0, 0.2 ),
-		0 0 56px rgba( 0, 0, 0, 0.15 );
+	box-shadow: 0 2px 5px rgba( 0, 0, 0, 0.2 );
 
 	.notice__icon-wrapper {
 		border-radius: 0;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* We'd added a second drop shadow with a 56px spread behind global notices, to very slightly darken the screen around the notice.
* Removing the second drop shadow fixes the graphics rendering issue for certain graphics cards in Chrome. This is a less drastic and more backwards-compatible solution than `filter`, but it means we lose the extra visual depth.
* Example of the rendering bug: 

<img src="https://user-images.githubusercontent.com/448298/81436459-8ba07900-9137-11ea-82f3-e28751043393.png">

* Here's what the notice looks like with the extra drop shadow and without. 

**Before**

<img width="1680" alt="with double box shadow" src="https://user-images.githubusercontent.com/2124984/85747693-7f677f80-b6d5-11ea-84bc-bf029997e91c.png">


**After**

<img width="1680" alt="without double box shadow" src="https://user-images.githubusercontent.com/2124984/85747854-a3c35c00-b6d5-11ea-8a75-0b9d53323eaf.png">

Fixes #42003 
