### PR TITLE
e2e: Some changes to make tests run better in sauce

### DIFF
--- a/test/e2e/config/default.json
+++ b/test/e2e/config/default.json
@@ -20,9 +20,9 @@
 	"sauceConfigurations": {
 		"osx-chrome": {
 			"browserName": "chrome",
-			"platform": "OS X 10.14",
+			"platform": "OS X 10.15",
 			"screenResolution": "2048x1536",
-			"version": "latest-1"
+			"version": "latest"
 		},
 		"osx-firefox": {
 			"browserName": "firefox",

--- a/test/e2e/lib/components/secure-payment-component.js
+++ b/test/e2e/lib/components/secure-payment-component.js
@@ -104,7 +104,7 @@ export default class SecurePaymentComponent extends AsyncBaseContainer {
 					pauseBetweenKeysMS: pauseBetweenKeysMS,
 				}
 			);
-			driverHelper.clickWhenClickable(
+			await driverHelper.clickWhenClickable(
 				this.driver,
 				By.css( `#country-selector option[value="${ cardCountryCode }"]` )
 			);

--- a/test/e2e/lib/driver-manager.js
+++ b/test/e2e/lib/driver-manager.js
@@ -80,6 +80,8 @@ export async function startBrowser( { useCustomUA = true, resizeBrowserWindow = 
 	let driver;
 	let options;
 	let builder;
+	const chromeVersion = await readFileSync( './.chromedriver_version', 'utf8' ).trim();
+	const userAgent = `user-agent=Mozilla/5.0 (wp-e2e-tests) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/${ chromeVersion } Safari/537.36`;
 	const pref = new webdriver.logging.Preferences();
 	pref.setLevel( 'browser', webdriver.logging.Level.SEVERE );
 	pref.setLevel( 'performance', webdriver.logging.Level.ALL );
@@ -111,6 +113,7 @@ export async function startBrowser( { useCustomUA = true, resizeBrowserWindow = 
 		if ( caps.browserName === 'chrome' ) {
 			options = new chrome.Options();
 			options.addArguments( '--app=https://www.wordpress.com' );
+			options.addArguments( userAgent );
 			builder.setChromeOptions( options );
 		}
 
@@ -141,8 +144,6 @@ export async function startBrowser( { useCustomUA = true, resizeBrowserWindow = 
 				options.addArguments( '--no-first-run' );
 
 				if ( useCustomUA ) {
-					const chromeVersion = await readFileSync( './.chromedriver_version', 'utf8' ).trim();
-					const userAgent = `user-agent=Mozilla/5.0 (wp-e2e-tests) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/${ chromeVersion } Safari/537.36`;
 					options.addArguments( userAgent );
 				}
 				if (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Since we keep hitting the limit to sign-ups, which breaks test, especially canary tests, we want to be able to run them on Sauce Labs. This stabilizes the tests so that they will pass there.

#### Testing instructions

* Make sure the tests pass locally using `./run.sh -R -C -l osx-chrome`

