### PR TITLE
Plan Price: show plan price in the current user's currency

### DIFF
--- a/client/my-sites/plan-price/README.md
+++ b/client/my-sites/plan-price/README.md
@@ -2,7 +2,7 @@ PlanPrice Component
 =============
 
 PlanPrice component is a React component used to display plan's price with a currency and a discount, if any.
-It can be used anywhere where a plan's price is required.
+It can be used anywhere where a plan's price is required. The price will be displayed in the current user's currency.
 
 If you want to emphasize that a plan's price is discounted, use two `<PlanPrice>` components as below and wrap them in a
 flexbox container.

--- a/client/my-sites/plan-price/index.jsx
+++ b/client/my-sites/plan-price/index.jsx
@@ -2,122 +2,119 @@
  * External dependencies
  */
 
+import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React from 'react';
 import classNames from 'classnames';
-import { localize } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { getCurrencyObject } from '@automattic/format-currency';
 
 /**
  * Internal dependencies
  */
 import Badge from 'components/badge';
+import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
 
 /**
  * Style dependencies
  */
 import './style.scss';
 
-export class PlanPrice extends Component {
-	render() {
-		const {
-			currencyCode,
-			rawPrice,
-			original,
-			discounted,
-			className,
-			isInSignup,
-			isOnSale,
-			taxText,
-			translate,
-		} = this.props;
+function PlanPrice( {
+	currencyCode,
+	rawPrice,
+	original,
+	discounted,
+	className,
+	isInSignup,
+	isOnSale,
+	taxText,
+} ) {
+	const translate = useTranslate();
 
-		if ( ! currencyCode || ! rawPrice ) {
-			return null;
-		}
+	if ( ! currencyCode || ! rawPrice ) {
+		return null;
+	}
 
-		// "Normalize" the input price or price range.
-		const rawPriceRange = Array.isArray( rawPrice ) ? rawPrice.slice( 0, 2 ) : [ rawPrice ];
-		if ( rawPriceRange.includes( 0 ) ) {
-			return null;
-		}
+	// "Normalize" the input price or price range.
+	const rawPriceRange = Array.isArray( rawPrice ) ? rawPrice.slice( 0, 2 ) : [ rawPrice ];
+	if ( rawPriceRange.includes( 0 ) ) {
+		return null;
+	}
 
-		const priceRange = rawPriceRange.map( ( item ) => {
-			return {
-				price: getCurrencyObject( item, currencyCode ),
-				raw: item,
-			};
-		} );
-
-		const classes = classNames( 'plan-price', className, {
-			'is-original': original,
-			'is-discounted': discounted,
-		} );
-
-		const renderPrice = ( priceObj ) => {
-			const fraction = priceObj.raw - priceObj.price.integer > 0 && priceObj.price.fraction;
-			if ( fraction ) {
-				return `${ priceObj.price.integer }${ fraction }`;
-			}
-			return priceObj.price.integer;
+	const priceRange = rawPriceRange.map( ( item ) => {
+		return {
+			price: getCurrencyObject( item, currencyCode ),
+			raw: item,
 		};
+	} );
 
-		if ( isInSignup ) {
-			const smallerPrice = renderPrice( priceRange[ 0 ] );
-			const higherPrice = priceRange[ 1 ] && renderPrice( priceRange[ 1 ] );
+	const classes = classNames( 'plan-price', className, {
+		'is-original': original,
+		'is-discounted': discounted,
+	} );
 
-			return (
-				<span className={ classes }>
-					{ priceRange[ 0 ].price.symbol }
-					{ ! higherPrice && renderPrice( priceRange[ 0 ] ) }
-					{ higherPrice &&
-						translate( '%(smallerPrice)s-%(higherPrice)s', {
-							args: { smallerPrice, higherPrice },
-							comment: 'The price range for a particular product',
-						} ) }
-				</span>
-			);
+	const renderPrice = ( priceObj ) => {
+		const fraction = priceObj.raw - priceObj.price.integer > 0 && priceObj.price.fraction;
+		if ( fraction ) {
+			return `${ priceObj.price.integer }${ fraction }`;
 		}
+		return priceObj.price.integer;
+	};
 
-		const renderPriceHtml = ( priceObj ) => {
-			return (
-				<>
-					<span className="plan-price__integer">{ priceObj.price.integer }</span>
-					<sup className="plan-price__fraction">
-						{ priceObj.raw - priceObj.price.integer > 0 && priceObj.price.fraction }
-					</sup>
-				</>
-			);
-		};
-
-		const saleBadgeText = translate( 'Sale', {
-			comment: 'Shown next to a domain that has a special discounted sale price',
-		} );
-
-		const smallerPriceHtml = renderPriceHtml( priceRange[ 0 ] );
-		const higherPriceHtml = priceRange[ 1 ] && renderPriceHtml( priceRange[ 1 ] );
+	if ( isInSignup ) {
+		const smallerPrice = renderPrice( priceRange[ 0 ] );
+		const higherPrice = priceRange[ 1 ] && renderPrice( priceRange[ 1 ] );
 
 		return (
-			<h4 className={ classes }>
-				<sup className="plan-price__currency-symbol">{ priceRange[ 0 ].price.symbol }</sup>
-				{ ! higherPriceHtml && renderPriceHtml( priceRange[ 0 ] ) }
-				{ higherPriceHtml &&
-					translate( '{{smallerPrice/}}-{{higherPrice/}}', {
-						components: { smallerPrice: smallerPriceHtml, higherPrice: higherPriceHtml },
+			<span className={ classes }>
+				{ priceRange[ 0 ].price.symbol }
+				{ ! higherPrice && renderPrice( priceRange[ 0 ] ) }
+				{ higherPrice &&
+					translate( '%(smallerPrice)s-%(higherPrice)s', {
+						args: { smallerPrice, higherPrice },
 						comment: 'The price range for a particular product',
 					} ) }
-				{ taxText && (
-					<sup className="plan-price__tax-amount">
-						{ translate( '(+%(taxText)s tax)', { args: { taxText } } ) }
-					</sup>
-				) }
-				{ isOnSale && <Badge>{ saleBadgeText }</Badge> }
-			</h4>
+			</span>
 		);
 	}
-}
 
-export default localize( PlanPrice );
+	const renderPriceHtml = ( priceObj ) => {
+		return (
+			<>
+				<span className="plan-price__integer">{ priceObj.price.integer }</span>
+				<sup className="plan-price__fraction">
+					{ priceObj.raw - priceObj.price.integer > 0 && priceObj.price.fraction }
+				</sup>
+			</>
+		);
+	};
+
+	const saleBadgeText = translate( 'Sale', {
+		comment: 'Shown next to a domain that has a special discounted sale price',
+	} );
+
+	const smallerPriceHtml = renderPriceHtml( priceRange[ 0 ] );
+	const higherPriceHtml = priceRange[ 1 ] && renderPriceHtml( priceRange[ 1 ] );
+
+	return (
+		<h4 className={ classes }>
+			<sup className="plan-price__currency-symbol">{ priceRange[ 0 ].price.symbol }</sup>
+			{ ! higherPriceHtml && renderPriceHtml( priceRange[ 0 ] ) }
+			{ higherPriceHtml &&
+				translate( '{{smallerPrice/}}-{{higherPrice/}}', {
+					components: { smallerPrice: smallerPriceHtml, higherPrice: higherPriceHtml },
+					comment: 'The price range for a particular product',
+				} ) }
+			{ taxText && (
+				<sup className="plan-price__tax-amount">
+					{ translate( '(+%(taxText)s tax)', { args: { taxText } } ) }
+				</sup>
+			) }
+			{ isOnSale && <Badge>{ saleBadgeText }</Badge> }
+		</h4>
+	);
+}
 
 PlanPrice.propTypes = {
 	rawPrice: PropTypes.oneOfType( [ PropTypes.number, PropTypes.arrayOf( PropTypes.number ) ] ),
@@ -127,7 +124,6 @@ PlanPrice.propTypes = {
 	className: PropTypes.string,
 	isOnSale: PropTypes.bool,
 	taxText: PropTypes.string,
-	translate: PropTypes.func.isRequired,
 };
 
 PlanPrice.defaultProps = {
@@ -137,3 +133,7 @@ PlanPrice.defaultProps = {
 	className: '',
 	isOnSale: false,
 };
+
+export default connect( ( state ) => ( {
+	currencyCode: getCurrentUserCurrencyCode( state ),
+} ) )( PlanPrice );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As outlined in issue https://github.com/Automattic/wp-calypso/issues/28145 we're currently showing plan prices in USD in quite a few places in Calypso. The advised solution in said issue is to connect the `PlanPrice` component so we can ensure we're always showing the plan price in the current user's currency across the board.

This PR
* converts the class component to a functional component
* connects the component to get the current user's currency via getCurrentUserCurrencyCode

Fixes https://github.com/Automattic/wp-calypso/issues/28145

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In order to test this, the user you're testing with needs to have a currency other than USD
* You can change the user currency in your user's Store Admin
* Either run Calypso locally or use [this calypso.live link ](https://calypso.live/?branch=update/price-plan-connect-currency-code)
* Go to `/devdocs/blocks/`
* Search for `PlanPrice` and `UpsellNudge`
* Verify that currencies are displayed in your user's currency (not USD)
* Click through other parts of Calypso and verify that plan price currencies are displayed in your user's currency (not USD)

#### Screenshots

| Before  | After |
| ------------- | ------------- |
| <img width="756" alt="Screenshot 2020-06-24 at 23 06 05" src="https://user-images.githubusercontent.com/1562646/85629891-f1f34380-b672-11ea-9ba4-720ed23e9172.png">  | <img width="755" alt="Screenshot 2020-06-24 at 23 07 38" src="https://user-images.githubusercontent.com/1562646/85629910-fae41500-b672-11ea-98b0-a947057edb67.png"> |

| Before  | After |
| ------------- | ------------- |
| <img width="753" alt="Screenshot 2020-06-24 at 23 06 20" src="https://user-images.githubusercontent.com/1562646/85629962-19e2a700-b673-11ea-8e58-bbb6dd62edde.png"> | <img width="757" alt="Screenshot 2020-06-24 at 23 07 19" src="https://user-images.githubusercontent.com/1562646/85629949-118a6c00-b673-11ea-8027-16aa8edcf381.png"> |

