### PR TITLE
Jetpack Cloud: Add OAuth client ID as query parameter

### DIFF
--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -248,12 +248,18 @@ export class LoginLinks extends React.Component {
 		}
 
 		const queryArgs = { action: 'lostpassword' };
+
 		// If we got here coming from Jetpack Cloud login page, we want to go back
 		// to it after we finish the process
 		if ( isJetpackCloudOAuth2Client( this.props.oauth2Client ) ) {
 			const currentUrl = new URL( window.location.href );
 			currentUrl.searchParams.append( 'lostpassword_flow', true );
 			queryArgs.redirect_to = currentUrl.toString();
+
+			// This parameter tells WPCOM that we are coming from Jetpack.com,
+			// so it can present the user a Lost password page that works in
+			// the context of Jetpack.com.
+			queryArgs.client_id = this.props.oauth2Client.id;
 		}
 
 		return (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add the OAuth client ID as query parameter when going to the `Lost password` page from Jetpack Cloud login flow. With this, the `Lost password` page, which lives in WPCOM codebase, can offer a better experience for users coming from Jetpack Cloud (links will point to Jetpack Cloud instead of to WordPress.com). Without this, the login flow is broken for users that need to reset their password.

#### Testing instructions

* Run this PR locally, Calypso build (`yarn start`).
* Visit `cloud.jetpack.com` in an incognito window. You will be redirected to WordPress.com login page.
* In the browser URL, replace the first part of the URL that says `https://wordpress.com/` with `http://calypso.localhost:3000` (keep the rest of the URL). This will load the Login page from your local environment.
* Verify that the `Lost Password` link includes a query parameter called `client_id` and its value is one of 69040 (stage), 69041 (prod), or 68663 (dev).

Fixes 1169345694087188-as-1181835040893659

#### Demo
![Kapture 2020-06-24 at 18 57 51](https://user-images.githubusercontent.com/3418513/85632141-218f5500-b64d-11ea-857b-9380f8ce6c70.gif)
