### PR TITLE
Misc: Remove problematic "blacklist"/"whitelist" language #43395

### DIFF
--- a/client/lib/cart-values/index.js
+++ b/client/lib/cart-values/index.js
@@ -17,7 +17,7 @@ import {
 	hasDomainRegistration,
 	hasPlan,
 } from './cart-items';
-import { isCredits, isDomainRedemption, whitelistAttributes } from 'lib/products-values';
+import { isCredits, isDomainRedemption, allowedProductAttributes } from 'lib/products-values';
 import { detectWebPaymentMethod } from 'lib/web-payment';
 
 // Auto-vivification from https://github.com/kolodny/immutability-helper#autovivification
@@ -268,7 +268,7 @@ export function fillInAllCartItemAttributes( cart, products ) {
 
 export function fillInSingleCartItemAttributes( cartItem, products ) {
 	const product = products[ cartItem.product_slug ];
-	const attributes = whitelistAttributes( product );
+	const attributes = allowedProductAttributes( product );
 
 	return extend( {}, cartItem, attributes );
 }

--- a/client/lib/cart/actions.js
+++ b/client/lib/cart/actions.js
@@ -126,7 +126,7 @@ export function getRememberedCoupon() {
 		debug( 'No coupons found in localStorage: ', coupons );
 		return null;
 	}
-	const COUPON_CODE_WHITELIST = [
+	const ALLOWED_COUPON_CODE_LIST = [
 		'ALT',
 		'FBSAVE15',
 		'FIVERR',
@@ -160,7 +160,7 @@ export function getRememberedCoupon() {
 	debug( 'Storing coupons in localStorage: ', coupons );
 	window.localStorage.setItem( MARKETING_COUPONS_KEY, JSON.stringify( coupons ) );
 	if (
-		COUPON_CODE_WHITELIST.includes(
+		ALLOWED_COUPON_CODE_LIST.includes(
 			-1 !== mostRecentCouponCode.indexOf( '_' )
 				? mostRecentCouponCode.substring( 0, mostRecentCouponCode.indexOf( '_' ) )
 				: mostRecentCouponCode

--- a/client/lib/plugins/test/sanitize-section-content.js
+++ b/client/lib/plugins/test/sanitize-section-content.js
@@ -11,7 +11,7 @@ import { sanitizeSectionContent as clean } from '../sanitize-section-content';
  * Attempts to create a DOM node from given HTML
  *
  * @param {string} html expected HTML to create node
- * @returns {Node | null} possible node described by HTML
+ * @returns {object | null} possible node described by HTML
  */
 const cleanNode = ( html ) => {
 	const div = document.createElement( 'div' );
@@ -21,30 +21,30 @@ const cleanNode = ( html ) => {
 	return div.firstChild;
 };
 
-test( 'should allow whitelisted tags', () =>
+test( 'should not strip allowed tags', () =>
 	expect( clean( '<div>👍</div>' ) ).toBe( '<div>👍</div>' ) );
 
-test( 'should strip out non-whitelisted tags', () =>
+test( 'should strip out disallowed tags', () =>
 	expect( clean( '<marquee></marquee>' ) ).toBe( '' ) );
 
 test( 'should preserve children of stripped tags', () =>
 	expect( clean( '<unsupported><b>👍</b></unsupported>' ) ).toBe( '<b>👍</b>' ) );
 
-test( 'should strip out content with non-whitelisted tags', () =>
+test( 'should strip out content with disallowed tags', () =>
 	expect( clean( '<p><script>alert("do bad things")</script>👍</p>' ) ).toBe(
 		'<p>alert("do bad things")👍</p>'
 	) );
 
-test( 'should strip out non-whitelisted children', () =>
+test( 'should strip out disallowed children', () =>
 	expect( clean( '<marquee><marquee>👍</marquee></marquee>' ) ).toBe( '👍' ) );
 
 test( 'should not break when no attributes present', () =>
 	expect( clean( '<p></p>' ) ).toBe( '<p></p>' ) );
 
-test( 'should allow whitelisted attributes', () =>
+test( 'should not strip allowed attributes', () =>
 	expect( clean( '<img alt="graphic">' ) ).toBe( '<img alt="graphic">' ) );
 
-test( 'should strip out non-whitelisted attributes', () =>
+test( 'should strip out disallowed attributes', () =>
 	expect( clean( '<span style="font-size: 128px;">👍</span>' ) ).toBe( '<span>👍</span>' ) );
 
 test( 'should allow http(s) links', () => {
@@ -105,7 +105,7 @@ test( 'should strip out <script> tags', () => expect( clean( '<script></script>'
  * which leads to unexpected `<script>` tags. However, we are using
  * the browser's parser and not our own and thus don't need to test for
  * some of those situations. We are already verifying that we strip
- * <script> tags as well as non-whitelisted attributes, so in order for
+ * <script> tags as well as disallowed attributes, so in order for
  * those security-related tests to fail our earlier tests would have
  * also failed, and again we don't need to double-test them.
  *

--- a/client/lib/plugins/test/utils.js
+++ b/client/lib/plugins/test/utils.js
@@ -43,14 +43,14 @@ describe( 'Plugins Utils', () => {
 		} );
 	} );
 
-	describe( 'whiteListPluginData', () => {
-		test( 'should have a method whiteListPluginData', () => {
-			assert.isFunction( PluginUtils.whiteListPluginData );
+	describe( 'getAllowedPluginData', () => {
+		test( 'should have a method getAllowedPluginData', () => {
+			assert.isFunction( PluginUtils.getAllowedPluginData );
 		} );
 
 		test( 'should stip out unknown keys', () => {
 			const plugin = { unknownKey: true };
-			assert.deepEqual( PluginUtils.whiteListPluginData( plugin ), {} );
+			assert.deepEqual( PluginUtils.getAllowedPluginData( plugin ), {} );
 		} );
 
 		test( 'should keep known keys', () => {
@@ -69,7 +69,7 @@ describe( 'Plugins Utils', () => {
 				update: {},
 				updating: false,
 			};
-			assert.deepEqual( PluginUtils.whiteListPluginData( plugin ), plugin );
+			assert.deepEqual( PluginUtils.getAllowedPluginData( plugin ), plugin );
 		} );
 	} );
 

--- a/client/lib/plugins/utils.js
+++ b/client/lib/plugins/utils.js
@@ -13,7 +13,7 @@ import { sanitizeSectionContent } from './sanitize-section-content';
 /**
  * @param  {object} site       Site Object
  * @param  {object} log        Notice log Object
- * @returns {Bool} True if notice matches criteria
+ * @returns {boolean} True if notice matches criteria
  */
 function isSameSiteNotice( site, log ) {
 	return site && log.site && log.site.ID === site.ID;
@@ -22,7 +22,7 @@ function isSameSiteNotice( site, log ) {
 /**
  * @param  {string} pluginSlug Plugin Slug
  * @param  {object} log        Notice log Object
- * @returns {Bool} True if notice matches criteria
+ * @returns {boolean} True if notice matches criteria
  */
 function isSamePluginNotice( pluginSlug, log ) {
 	return pluginSlug && log.plugin && log.plugin.slug === pluginSlug;
@@ -34,7 +34,7 @@ function isSamePluginNotice( pluginSlug, log ) {
  * @param  {object} site       Site Object
  * @param  {string} pluginSlug Plugin Slug
  * @param  {object} log        Notice log Object
- * @returns {Bool} True if notice matches criteria
+ * @returns {boolean} True if notice matches criteria
  */
 function filterNoticesBy( site, pluginSlug, log ) {
 	if ( ! site && ! pluginSlug ) {
@@ -50,7 +50,7 @@ function filterNoticesBy( site, pluginSlug, log ) {
 	return false;
 }
 
-export function whiteListPluginData( plugin ) {
+export function getAllowedPluginData( plugin ) {
 	return pick(
 		plugin,
 		'action_links',
@@ -144,7 +144,7 @@ export function normalizeCompatibilityList( compatibilityList ) {
 }
 
 export function normalizePluginData( plugin, pluginData ) {
-	plugin = whiteListPluginData( assign( plugin, pluginData ) );
+	plugin = getAllowedPluginData( assign( plugin, pluginData ) );
 
 	return transform( plugin, function ( returnData, item, key ) {
 		switch ( key ) {

--- a/client/lib/products-values/index.js
+++ b/client/lib/products-values/index.js
@@ -528,7 +528,7 @@ export function isUnlimitedThemes( product ) {
 	return 'unlimited_themes' === product.product_slug;
 }
 
-export function whitelistAttributes( product ) {
+export function allowedProductAttributes( product ) {
 	return pick( product, Object.keys( schema.properties ) );
 }
 

--- a/client/lib/safe-image-url/index.js
+++ b/client/lib/safe-image-url/index.js
@@ -33,7 +33,7 @@ const REGEXP_A8C_HOST = /^([-a-zA-Z0-9_]+\.)*(gravatar\.com|wordpress\.com|wp\.c
  * Generate a safe version of the provided URL
  *
  * Images that Calypso uses have to be provided by a trusted TLS host. To do
- * this, we check the host of the URL against a whitelist, and run the image
+ * this, we check the host of the URL against a list of allowed hosts, and run the image
  * through photon if the host name does not match.
  *
  * NOTE: This function will return `null` for external URLs with query strings,

--- a/client/lib/safe-image-url/test/index.js
+++ b/client/lib/safe-image-url/test/index.js
@@ -12,7 +12,7 @@ describe( 'safeImageUrl()', () => {
 			expect( safeImageUrl( dataImageUrl ) ).toEqual( dataImageUrl );
 		} );
 
-		test( 'should make a non-whitelisted protocol safe', () => {
+		test( 'should make a disallowed protocol safe', () => {
 			[ 'javascript:alert("foo")', 'data:application/json;base64,', 'about:config' ].forEach(
 				( url ) => {
 					expect( safeImageUrl( url ) ).toMatch( /^https:\/\/i[0-2]\.wp.com\// );

--- a/client/login/ssr.js
+++ b/client/login/ssr.js
@@ -7,19 +7,18 @@ import { intersection } from 'lodash';
  * A middleware that enables (or disables) server side rendering for the /log-in page.
  *
  * Unlike the rest of the SSRed pages, the log-in page enables SSRing also when a set of parameters is set (see below
- * whitelistedQueryKeys). Some of these parameters may need to fulfill additional formats (example: when redirect_to is
+ * validQueryKeys). Some of these parameters may need to fulfill additional formats (example: when redirect_to is
  * present, then it also needs to start with a certain prefix).
  *
  * @param {object}   context  The entire request context
  * @param {Function} next     Next middleware in the running sequence
  */
 export function setShouldServerSideRenderLogin( context, next ) {
-	const whitelistedQueryKeys = [ 'client_id', 'signup_flow', 'redirect_to' ];
+	const validQueryKeys = [ 'client_id', 'signup_flow', 'redirect_to' ];
 	const queryKeys = Object.keys( context.query );
 
-	// if there are any parameters, they must be ONLY the ones in the whitelist
-	const hasOnlyValidKeys =
-		queryKeys.length === intersection( queryKeys, whitelistedQueryKeys ).length;
+	// if there are any parameters, they must be ONLY the ones in the list of valid query keys
+	const hasOnlyValidKeys = queryKeys.length === intersection( queryKeys, validQueryKeys ).length;
 
 	context.serverSideRender =
 		hasOnlyValidKeys && isRedirectToValidForSsr( context.query.redirect_to );

--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -118,7 +118,7 @@ function renderProvisionPlugins( context ) {
 	context.store.dispatch( hideSidebar() );
 
 	context.primary = React.createElement( PlanSetup, {
-		whitelist: context.query.only || false,
+		forSpecificPlugin: context.query.only || false,
 	} );
 }
 

--- a/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
+++ b/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
@@ -240,7 +240,7 @@ class PlansSetup extends React.Component {
 	};
 
 	renderPluginsPlaceholders = () => {
-		const placeholderCount = this.props.whitelist ? 1 : 2;
+		const placeholderCount = this.props.forSpecificPlugin ? 1 : 2;
 		return range( placeholderCount ).map( ( i ) => <PluginItem key={ 'placeholder-' + i } /> );
 	};
 
@@ -558,17 +558,17 @@ export default connect(
 	( state, ownProps ) => {
 		const siteId = getSelectedSiteId( state );
 		const selectedSite = getSelectedSite( state );
-		const whitelist = ownProps.whitelist || false;
+		const forSpecificPlugin = ownProps.forSpecificPlugin || false;
 
 		return {
 			wporg: state.plugins.wporg.items,
 			isRequesting: isRequesting( state, siteId ),
 			hasRequested: hasRequested( state, siteId ),
-			isInstalling: isInstalling( state, siteId, whitelist ),
-			isFinished: isFinished( state, siteId, whitelist ),
-			plugins: getPluginsForSite( state, siteId, whitelist ),
-			activePlugin: getActivePlugin( state, siteId, whitelist ),
-			nextPlugin: getNextPlugin( state, siteId, whitelist ),
+			isInstalling: isInstalling( state, siteId, forSpecificPlugin ),
+			isFinished: isFinished( state, siteId, forSpecificPlugin ),
+			plugins: getPluginsForSite( state, siteId, forSpecificPlugin ),
+			activePlugin: getActivePlugin( state, siteId, forSpecificPlugin ),
+			nextPlugin: getNextPlugin( state, siteId, forSpecificPlugin ),
 			selectedSite: selectedSite,
 			isRequestingSites: isRequestingSites( state ),
 			sitesInitialized: hasInitializedSites( state ),

--- a/client/reader/stats.js
+++ b/client/reader/stats.js
@@ -127,8 +127,8 @@ export function recordTrack( eventName, eventProperties, { pathnameOverride } = 
 	recordTracksEvent( eventName, eventProperties );
 }
 
-const tracksRailcarEventWhitelist = new Set();
-tracksRailcarEventWhitelist
+const allowedTracksRailcarEventNames = new Set();
+allowedTracksRailcarEventNames
 	.add( 'calypso_reader_related_post_from_same_site_clicked' )
 	.add( 'calypso_reader_related_post_from_other_site_clicked' )
 	.add( 'calypso_reader_related_post_site_clicked' )
@@ -165,7 +165,7 @@ export const recordTracksRailcarInteract = partial(
 
 export function recordTrackForPost( eventName, post = {}, additionalProps = {}, options ) {
 	recordTrack( eventName, assign( getTracksPropertiesForPost( post ), additionalProps ), options );
-	if ( post.railcar && tracksRailcarEventWhitelist.has( eventName ) ) {
+	if ( post.railcar && allowedTracksRailcarEventNames.has( eventName ) ) {
 		// check for overrides for the railcar
 		recordTracksRailcarInteract(
 			eventName,
@@ -173,7 +173,7 @@ export function recordTrackForPost( eventName, post = {}, additionalProps = {}, 
 			pick( additionalProps, [ 'ui_position', 'ui_algo' ] )
 		);
 	} else if ( process.env.NODE_ENV !== 'production' && post.railcar ) {
-		console.warn( 'Consider whitelisting reader track', eventName ); //eslint-disable-line no-console
+		console.warn( 'Consider allowing reader track', eventName ); //eslint-disable-line no-console
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change some function-local variable names and update JSDoc comments to remove problematic language
* Rename `whitelist` prop on `PlanSetup` to `forSpecificPlugin`

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure unit tests pass
* Ensure installing a plugin under Jetpack with and without the `only=plugin-name` query parameter behaves as expected

Addresses part of #43395 
