### PR TITLE
Donations: Fall back to default products if no products are already defined.

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/donations/donations.js
+++ b/apps/full-site-editing/full-site-editing-plugin/donations/donations.js
@@ -15,7 +15,7 @@ import { Button } from '@wordpress/components';
  */
 import StripeNudge from './stripe-nudge';
 
-const Donations = ( { stripeConnectUrl } ) => {
+const Donations = ( { products, stripeConnectUrl } ) => {
 	const [ activeTab, setActiveTab ] = useState( 'one-time' );
 
 	const isActive = ( button ) => ( activeTab === button ? 'active' : null );

--- a/apps/full-site-editing/full-site-editing-plugin/donations/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/donations/edit.js
@@ -27,6 +27,25 @@ const Edit = () => {
 		setIsLoading( false );
 	};
 
+	const hasRequiredProducts = ( resultProducts ) => {
+		const USDDonations = resultProducts.filter(
+			( product ) => product.currency === 'USD' && product.type === 'donation'
+		);
+
+		if ( ! USDDonations.length ) {
+			return;
+		}
+
+		const intervals = [];
+		USDDonations.forEach( ( donation ) => intervals.push( donation.interval ) );
+
+		return (
+			intervals.includes( 'one-time' ) &&
+			intervals.includes( '1 month' ) &&
+			intervals.includes( '1 year' )
+		);
+	};
+
 	const mapStatusToState = ( result ) => {
 		if ( ( ! result && typeof result !== 'object' ) || result.errors ) {
 			setLoadingError( __( 'Could not load data from WordPress.com.', 'full-site-editing' ) );
@@ -35,7 +54,7 @@ const Edit = () => {
 			setUpgradeUrl( result.upgrade_url );
 			setStripeConnectUrl( result.connect_url );
 
-			if ( result.products.length ) {
+			if ( result.products.length && hasRequiredProducts( result.products ) ) {
 				setProducts( result.products );
 			} else {
 				fetchDefaultProducts( 'USD' ).then(

--- a/apps/full-site-editing/full-site-editing-plugin/donations/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/donations/edit.js
@@ -11,6 +11,7 @@ import Donations from './donations';
 import LoadingError from './loading-error';
 import LoadingStatus from './loading-status';
 import UpgradePlan from './upgrade-plan';
+import fetchDefaultProducts from './fetch-default-products';
 import fetchStatus from './fetch-status';
 
 const Edit = () => {
@@ -18,7 +19,13 @@ const Edit = () => {
 	const [ loadingError, setLoadingError ] = useState( '' );
 	const [ shouldUpgrade, setShouldUpgrade ] = useState( false );
 	const [ stripeConnectUrl, setStripeConnectUrl ] = useState( false );
+	const [ products, setProducts ] = useState( [] );
 	const [ upgradeUrl, setUpgradeUrl ] = useState( '' );
+
+	const apiError = ( message ) => {
+		setLoadingError( message );
+		setIsLoading( false );
+	};
 
 	const mapStatusToState = ( result ) => {
 		if ( ( ! result && typeof result !== 'object' ) || result.errors ) {
@@ -27,13 +34,17 @@ const Edit = () => {
 			setShouldUpgrade( result.should_upgrade_to_access_memberships );
 			setUpgradeUrl( result.upgrade_url );
 			setStripeConnectUrl( result.connect_url );
+
+			if ( result.products.length ) {
+				setProducts( result.products );
+			} else {
+				fetchDefaultProducts( 'USD' ).then(
+					( defaultProducts ) => setProducts( defaultProducts ),
+					apiError
+				);
+			}
 		}
 
-		setIsLoading( false );
-	};
-
-	const apiError = ( message ) => {
-		setLoadingError( message );
 		setIsLoading( false );
 	};
 
@@ -54,7 +65,7 @@ const Edit = () => {
 		return <UpgradePlan upgradeUrl={ upgradeUrl } />;
 	}
 
-	return <Donations stripeConnectUrl={ stripeConnectUrl } />;
+	return <Donations stripeConnectUrl={ stripeConnectUrl } products={ products } />;
 };
 
 export default Edit;

--- a/apps/full-site-editing/full-site-editing-plugin/donations/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/donations/edit.js
@@ -27,22 +27,18 @@ const Edit = () => {
 		setIsLoading( false );
 	};
 
-	const hasRequiredProducts = ( resultProducts ) => {
-		const USDDonations = resultProducts.filter(
-			( product ) => product.currency === 'USD' && product.type === 'donation'
-		);
-
-		if ( ! USDDonations.length ) {
-			return;
-		}
-
-		const intervals = [];
-		USDDonations.forEach( ( donation ) => intervals.push( donation.interval ) );
+	const hasRequiredProducts = ( productList, productCurrency ) => {
+		const productIntervals = productList.reduce( ( intervals, { currency, type, interval } ) => {
+			if ( currency === productCurrency && type === 'donation' ) {
+				intervals.push( interval );
+			}
+			return intervals;
+		}, [] );
 
 		return (
-			intervals.includes( 'one-time' ) &&
-			intervals.includes( '1 month' ) &&
-			intervals.includes( '1 year' )
+			productIntervals.includes( 'one-time' ) &&
+			productIntervals.includes( '1 month' ) &&
+			productIntervals.includes( '1 year' )
 		);
 	};
 
@@ -54,7 +50,7 @@ const Edit = () => {
 			setUpgradeUrl( result.upgrade_url );
 			setStripeConnectUrl( result.connect_url );
 
-			if ( result.products.length && hasRequiredProducts( result.products ) ) {
+			if ( result.products.length && hasRequiredProducts( result.products, 'USD' ) ) {
 				setProducts( result.products );
 			} else {
 				fetchDefaultProducts( 'USD' ).then(

--- a/apps/full-site-editing/full-site-editing-plugin/donations/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/donations/edit.js
@@ -38,7 +38,7 @@ const Edit = () => {
 	};
 
 	useEffect( () => {
-		const updateData = () => fetchStatus().then( mapStatusToState, apiError );
+		const updateData = () => fetchStatus( 'donation' ).then( mapStatusToState, apiError );
 		updateData();
 	}, [] );
 

--- a/apps/full-site-editing/full-site-editing-plugin/donations/fetch-default-products.js
+++ b/apps/full-site-editing/full-site-editing-plugin/donations/fetch-default-products.js
@@ -1,0 +1,19 @@
+/* eslint-disable wpcalypso/import-docblock */
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+const fetchDefaultProducts = async ( currency ) => {
+	try {
+		const result = await apiFetch( {
+			path: `/wpcom/v2/memberships/products?type=donation&currency=${ currency }`,
+			method: 'POST',
+		} );
+		return result;
+	} catch ( error ) {
+		return Promise.reject( error.message );
+	}
+};
+
+export default fetchDefaultProducts;

--- a/apps/full-site-editing/full-site-editing-plugin/donations/fetch-default-products.js
+++ b/apps/full-site-editing/full-site-editing-plugin/donations/fetch-default-products.js
@@ -7,8 +7,12 @@ import apiFetch from '@wordpress/api-fetch';
 const fetchDefaultProducts = async ( currency ) => {
 	try {
 		const result = await apiFetch( {
-			path: `/wpcom/v2/memberships/products?type=donation&currency=${ currency }`,
+			path: '/wpcom/v2/memberships/products',
 			method: 'POST',
+			data: {
+				type: 'donation',
+				currency,
+			},
 		} );
 		return result;
 	} catch ( error ) {

--- a/apps/full-site-editing/full-site-editing-plugin/donations/fetch-status.js
+++ b/apps/full-site-editing/full-site-editing-plugin/donations/fetch-status.js
@@ -4,10 +4,14 @@
  */
 import apiFetch from '@wordpress/api-fetch';
 
-const fetchStatus = async () => {
+const fetchStatus = async ( type = null ) => {
+	let path = '/wpcom/v2/memberships/status';
+	if ( type ) {
+		path += `?type=${ type }`;
+	}
 	try {
 		const result = await apiFetch( {
-			path: '/wpcom/v2/memberships/status',
+			path,
 			method: 'GET',
 		} );
 		return result;


### PR DESCRIPTION
The Donations block will rely on membership products existing to give the site visitor options for donating. If the user inserts a Donations block but does not already have some USD subscription products set up, the block will call the new `POST /memberships/products` endpoint (https://github.com/Automattic/jetpack/pull/16242) to generate some default products.

Part of #42856 .

<img width="1198" alt="Screen Shot 2020-06-24 at 4 28 35 PM" src="https://user-images.githubusercontent.com/349751/85637386-e9c9e280-b637-11ea-8a9b-9cabd3a2fd1f.png">

**Testing Instructions**

* `cd apps/full-site-editing; yarn dev --sync;`
* Sandbox the API and the store. More info in PCYsg-lW4-p2 #sandbox-method
* Sandbox a test site with a paid plan, and ensure the site has the `fse-donations-block` blog sticker applied (if not, it can be done from the site's Blog RC).
* At `/earn/payments-plans/:site`, delete any existing test products.
* With devtools open, add a Donations block in a new post with the block editor.
* Connect to Stripe in development mode if necessary.
* Verify a successful call was made to `/memberships/products?type=donation&currency=USD`.