### PR TITLE
Jetpack Connect: fix wrong URL in LocaleSuggestions

### DIFF
--- a/client/jetpack-connect/jetpack-connection.jsx
+++ b/client/jetpack-connect/jetpack-connection.jsx
@@ -268,6 +268,7 @@ const jetpackConnection = ( WrappedComponent ) => {
 				<WrappedComponent
 					processJpSite={ this.processJpSite }
 					status={ this.state.status }
+					path={ this.props.path }
 					renderFooter={ this.renderFooter }
 					renderNotices={ this.renderNotices }
 					isCurrentUrlFetching={ this.isCurrentUrlFetching() }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes a wrong URL in the Jetpack Connect language suggestion box.

#### Testing instructions

1. Open an incognito browser window with a browser preferred language set to non-English.
2. Visit https://wordpress.com/jetpack/connect/scan
3. Look at the language suggestion box and confirm that they are https://wordpress.com/jetpack/connect/scan/{locale} instead of https://wordpress.com/{locale}

Fixes #43668
