### PR TITLE
Editor: Hide switch editor links if in editor deprecation group

### DIFF
--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -41,6 +41,8 @@ import { getEditedPostValue } from 'state/posts/selectors';
 import QueryActiveTheme from 'components/data/query-active-theme';
 import isGutenbergOptInEnabled from 'state/selectors/is-gutenberg-opt-in-enabled';
 import isGutenbergOptOutEnabled from 'state/selectors/is-gutenberg-opt-out-enabled';
+import inEditorDeprecationGroup from 'state/editor-deprecation-group/selectors/in-editor-deprecation-group';
+import { isEnabled } from 'config';
 
 class InlineHelpPopover extends Component {
 	static propTypes = {
@@ -179,7 +181,7 @@ class InlineHelpPopover extends Component {
 	};
 
 	renderPrimaryView = () => {
-		const { translate, siteId, showOptIn, showOptOut, isCheckout } = this.props;
+		const { translate, siteId, showOptIn, showOptOut, isCheckout, editorDeprecated } = this.props;
 
 		// Don't show additional items inside Checkout.
 		if ( isCheckout ) {
@@ -189,7 +191,7 @@ class InlineHelpPopover extends Component {
 		return (
 			<>
 				<QueryActiveTheme siteId={ siteId } />
-				{ showOptOut && (
+				{ showOptOut && ! editorDeprecated && (
 					<Button
 						onClick={ this.switchToClassicEditor }
 						className="inline-help__classic-editor-toggle"
@@ -198,7 +200,7 @@ class InlineHelpPopover extends Component {
 					</Button>
 				) }
 
-				{ showOptIn && (
+				{ showOptIn && ! editorDeprecated && (
 					<Button
 						onClick={ this.switchToBlockEditor }
 						className="inline-help__gutenberg-editor-toggle"
@@ -310,6 +312,7 @@ function mapStateToProps( state ) {
 		showOptIn: showSwitchEditorButton && optInEnabled && isCalypsoClassic,
 		gutenbergUrl,
 		isCheckout: section.name && section.name === 'checkout',
+		editorDeprecated: isEnabled( 'editor/after-deprecation' ) && inEditorDeprecationGroup( state ),
 	};
 }
 

--- a/config/development.json
+++ b/config/development.json
@@ -59,7 +59,7 @@
 		"domains/new-status-design/new-options": true,
 		"domains/new-status-design/security-option": true,
 		"earn/rename-payment-blocks": true,
-		"editor/after-deprecation": false,
+		"editor/after-deprecation": true,
 		"editor/before-deprecation": true,
 		"email-accounts/enabled": true,
 		"external-media": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Hide the Switch to Classic/Block Editor links in the inline help popover if the user is in the editor deprecation group. See D44256-code for details on this group.

#### Testing instructions

1. Checkout this PR branch
2. Login with user matching editor deprecation group requirements in D44256-code 
  **OR** 
  Sanbox API and update `/wp-content/rest-api-endpoints/sites-gutenberg-v3.php` to return true for `in_editor_deprecation_group`
3. Ensure you see no switch editor buttons within the inline help popover when in either classic or block editor.
4. Logout then in with new user not matching the deprecation group requirements
  **OR**
  Undo changes to sandboxed API endpoint.
5. Ensure that you see the Switch to Classic Editor button in the popover while in the block editor and the Switch to Block Editor button while in the classic editor.
