### PR TITLE
Editor: Pass user's editor deprecation group status to iframed editor

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -49,6 +49,7 @@ import EditorDocumentHead from 'post-editor/editor-document-head';
 import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
 import { withStopPerformanceTrackingProp, PerformanceTrackProps } from 'lib/performance-tracking';
 import { REASON_BLOCK_EDITOR_UNKOWN_IFRAME_LOAD_FAILURE } from 'state/desktop/window-events';
+import inEditorDeprecationGroup from 'state/editor-deprecation-group/selectors/in-editor-deprecation-group';
 
 /**
  * Types
@@ -750,6 +751,11 @@ const mapStateToProps = (
 	// needed for loading the editor in SU sessions
 	if ( wpcom.addSupportParams ) {
 		queryArgs = wpcom.addSupportParams( queryArgs );
+	}
+
+	// Pass through to iframed editor if user is in editor deprecation group.
+	if ( config.isEnabled( 'editor/after-deprecation' ) && inEditorDeprecationGroup( state ) ) {
+		queryArgs[ 'in-editor-deprecation-group' ] = 1;
 	}
 
 	const siteAdminUrl =


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* If `editor/after-deprecation` feature flag is enabled and user belongs to the current editor deprecation group, pass on a query string param to the iframed block editor so it can adjust behaviour accordingly.

#### Testing instructions

1. Checkout this PR branch
2. Turn on `config/development.json` feature flag for `editor/after-deprecation` if not already on.
3. Fire up Calypso locally and login with user matching editor deprecation group requirements from D44256-code
  **OR**
  Sandbox API, fudging `sites-gutenberg-v3.php` endpoint to return true for `in_editor_deprecation_group`
4. Edit post using block editor and ensure iframe url contains `in-editor-deprecation-group` query string param.
5. Logout and back in with user not matching the editor deprecation group requirements from D44256
  **OR**
  Undo changes to sandboxed API
6. Edit post again using block editor and ensure iframe url does no contain the `in-editor-deprecation-group` query string param.
