### PR TITLE
Site Editor: increase the wait time for loading the iframe

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -152,7 +152,7 @@ class CalypsoifyIframe extends Component<
 								this.props.iframeUrl
 						  )
 						: window.location.replace( this.props.iframeUrl );
-				}, 6000 ); // One second longer than we give the iframe to load
+				}, 10000 ); // Five seconds longer than we give the iframe to load
 			}
 		}, 1000 );
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Currently the Site Editor is taking a long time to load, which was causing this code to redirect to wp-admin.

#### Testing instructions

1. Create a new FSE site through https://horizon.wordpress.com/new?flags=gutenboarding/site-editor
2. Open that site in local instance of Calypso.
3. Open the site editor and verify that you are not redirected to wp-admin after a couple of seconds.