### PR TITLE
Premium Content: Handle plans in the container block

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/buttons/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/buttons/edit.js
@@ -11,6 +11,7 @@ import { compose } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { addFilter } from '@wordpress/hooks';
 
 const ALLOWED_BLOCKS = [
 	'core/button',
@@ -23,7 +24,7 @@ const alignmentHooksSetting = {
 	isEmbedButton: true,
 };
 
-function ButtonsEdit( { context, innerBlocks, setRecurringPaymentsPlan } ) {
+function ButtonsEdit( { context, subscribeButton, setSubscribeButtonPlan } ) {
 	const planId = context[ 'premium-content/planId' ];
 
 	const template = [
@@ -37,12 +38,32 @@ function ButtonsEdit( { context, innerBlocks, setRecurringPaymentsPlan } ) {
 		[ 'premium-content/login-button' ],
 	];
 
+	// Keep in sync the plan selected on the Premium Content block with the plan selected on the Recurring Payments
+	// inner block acting as a subscribe button.
 	useEffect( () => {
-		if ( planId ) {
-			// Updates the plan on any Recurring Payment inner block.
-			setRecurringPaymentsPlan( planId );
+		if ( ! planId || ! subscribeButton ) {
+			return;
 		}
-	}, [ planId, innerBlocks ] );
+
+		if ( subscribeButton.attributes.planId !== planId ) {
+			setSubscribeButtonPlan( planId );
+		}
+	}, [ planId, subscribeButton ] );
+
+	// Hides the inspector controls of the Recurring Payments inner block acting as a subscribe button so users can only
+	// switch plans using the plan selector of the Premium Content block.
+	useEffect( () => {
+		addFilter(
+			'jetpack.RecurringPayments.showControls',
+			'full-site-editing/premium-content-hide-recurring-payments-controls',
+			( showControls, clientId ) => {
+				if ( clientId === subscribeButton.clientId ) {
+					return false;
+				}
+				return showControls;
+			}
+		);
+	}, [ subscribeButton ] );
 
 	return (
 		// eslint-disable-next-line wpcalypso/jsx-classname-namespace
@@ -60,28 +81,22 @@ function ButtonsEdit( { context, innerBlocks, setRecurringPaymentsPlan } ) {
 
 export default compose( [
 	withSelect( ( select, props ) => ( {
-		innerBlocks: select( 'core/block-editor' ).getBlock( props.clientId ).innerBlocks,
+		// Only first block is assumed to be a subscribe button (users can add additional Recurring Payments blocks for
+		// other plans).
+		subscribeButton: select( 'core/block-editor' )
+			.getBlock( props.clientId )
+			.innerBlocks.find( ( block ) => block.name === 'jetpack/recurring-payments' ),
 	} ) ),
-	withDispatch( ( dispatch, props, registry ) => ( {
+	withDispatch( ( dispatch, props ) => ( {
 		/**
-		 * Updates the selected plan on the Recurring Payments inner block.
+		 * Updates the plan on the Recurring Payments block acting as a subscribe button.
 		 *
-		 * @param planId {int} Recurring Payments plan.
+		 * @param planId {int} Plan ID.
 		 */
-		setRecurringPaymentsPlan( planId ) {
-			const { updateBlockAttributes } = dispatch( 'core/block-editor' );
-			const { getBlock } = registry.select( 'core/block-editor' );
-
-			const updatePlanAttribute = ( block ) => {
-				if ( block.name === 'jetpack/recurring-payments' ) {
-					updateBlockAttributes( block.clientId, { planId } );
-				}
-
-				block.innerBlocks.forEach( updatePlanAttribute );
-			};
-
-			const block = getBlock( props.clientId );
-			updatePlanAttribute( block );
+		setSubscribeButtonPlan( planId ) {
+			dispatch( 'core/block-editor' ).updateBlockAttributes( props.subscribeButton.clientId, {
+				planId,
+			} );
 		},
 	} ) ),
 ] )( ButtonsEdit );

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/buttons/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/buttons/edit.js
@@ -53,6 +53,9 @@ function ButtonsEdit( { context, subscribeButton, setSubscribeButtonPlan } ) {
 	// Hides the inspector controls of the Recurring Payments inner block acting as a subscribe button so users can only
 	// switch plans using the plan selector of the Premium Content block.
 	useEffect( () => {
+		if ( ! subscribeButton ) {
+			return;
+		}
 		addFilter(
 			'jetpack.RecurringPayments.showControls',
 			'full-site-editing/premium-content-hide-recurring-payments-controls',

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/logged-out-view/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/logged-out-view/edit.js
@@ -23,13 +23,17 @@ import Context from '../container/context';
  * @property { string } containerClientId
  * @property { Attributes } attributes
  * @property { Function } setAttributes
- * @property { Function } selectBlock
+ * @property { Function } selectContainerBlock
  *
  * @param { Props } props Properties
  */
-function Edit( { selectBlock } ) {
+function Edit( { selectContainerBlock } ) {
 	useEffect( () => {
-		selectBlock();
+		// Selects the container block on mount.
+		//
+		// Execution delayed with setTimeout to ensure it runs after any block auto-selection performed by inner blocks
+		// (such as the Recurring Payments block). @see https://github.com/Automattic/wp-calypso/issues/43450
+		setTimeout( selectContainerBlock, 0 );
 	}, [] );
 
 	return (
@@ -75,7 +79,7 @@ export default compose( [
 	withDispatch( ( dispatch, props ) => {
 		const { selectBlock } = dispatch( 'core/block-editor' );
 		return {
-			selectBlock() {
+			selectContainerBlock() {
 				// @ts-ignore difficult to type with JSDoc
 				selectBlock( props.containerClientId );
 			},

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/editor.css
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/editor.css
@@ -120,4 +120,9 @@
 
 .wp-block-buttons .wp-block[data-type='jetpack/recurring-payments'] {
 	display: inline-block;
+	margin: 0 8px 0 0;
+}
+
+.editor-styles-wrapper .wp-block-buttons .wp-block[data-type='jetpack/recurring-payments'] .wp-block-button:not( .alignleft ):not( .alignright ) {
+	margin: 0;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

For some reason I couldn't find, the Recurring Payments block acting as a subscribe button for the Premium Content block is auto-selected when the Premium Content block component is mounted.

This was causing some confusion since the Recurring Payments block displays a plan selector in the sidebar making users to assume that selector can change the plan of the Premium Content block. But that plan selector is actually useless since the Premium Content block [forces its selected plan to any nested Recurring Payments block](https://github.com/Automattic/wp-calypso/blob/ea4003723293ba41b1d367891cf9de7102c1beb9/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/buttons/edit.js#L40-L45). 

To help solving that problem this PR ensures the Premium Content block is auto-selected when mounted, so users can use the right plan selector .

It also hides the plan selector of the Recurring Payments block if the block is nested in a Premium Content block (requires https://github.com/Automattic/jetpack/pull/16313).

This PR also fixes a couple of CSS styles so the subscribe/login buttons are separated by the same margin used in the core buttons.

Before | After
--- | ---
![Jun-25-2020 16-05-22](https://user-images.githubusercontent.com/1233880/85735494-fc0e5400-b6fd-11ea-9dc5-3003391d6aae.gif) | ![Jun-29-2020 14-37-20](https://user-images.githubusercontent.com/1233880/86006350-1efa7a00-ba16-11ea-800c-bb73067aa4be.gif)


#### Testing instructions
* `cd apps/full-site-editing; yarn dev --sync`.
* Apply D45624-code.
* Sandbox the API and the store. More info in PCYsg-lW4-p2 #sandbox-method.
* Switch to a site with a paid plan.
* Go to Earn > Collect recurring payments > Recurring payments plans.
* Create a few plans.
* Go into the block editor and insert a Premium Content block.
* Make sure the Premium Content block is auto-selected.
* Make sure you can switch plans from the plan selector that is displayed in the block toolbar.
* Select the subscribe button.
* Make sure the sidebar does not display any selector for changing the plan.

Fixes https://github.com/Automattic/wp-calypso/issues/43450.
