### PR TITLE
Jetpack: update type scale on Backup / Scan

### DIFF
--- a/client/components/jetpack/backup-date-picker/style.scss
+++ b/client/components/jetpack/backup-date-picker/style.scss
@@ -3,7 +3,7 @@
 	align-items: center;
 	background: #fff;
 	padding-top: 0.5rem;
-	font-size: 0.875rem;
+	font-size: $font-body-small;
 
 	@include breakpoint-deprecated( '>660px' ) {
 		background: transparent;

--- a/client/components/jetpack/daily-backup-status/style.scss
+++ b/client/components/jetpack/daily-backup-status/style.scss
@@ -35,13 +35,13 @@
 
 .daily-backup-status__date,
 .daily-backup-status__static-title {
-	font-size: 1.4rem;
+	font-size: $font-title-medium;
 	font-weight: 400;
 	margin-bottom: 1rem;
 }
 
 .daily-backup-status__failed-message {
-	font-size: 1.4rem;
+	font-size: $font-title-medium;
 	font-weight: 400;
 	color: var( --color-scary-50 );
 	margin-bottom: 0.5rem;
@@ -84,12 +84,12 @@
 }
 
 .daily-backup-status__title {
-	font-size: 22px;
+	font-size: $font-title-medium;
 	font-weight: 600;
 	margin-bottom: 18px;
 
 	@include breakpoint-deprecated( '>660px' ) {
-		font-size: 36px;
+		font-size: $font-headline-small;
 		margin: 8px 0 12px;
 	}
 }
@@ -166,7 +166,7 @@
 	margin-top: -0.3rem;
 	color: var( --studio-gray-40 );
 	font-weight: 400;
-	font-size: 0.9rem;
+	font-size: $font-body-small;
 }
 
 .daily-backup-status__credentials-warning {
@@ -179,7 +179,7 @@
 	align-items: center;
 	margin-bottom: 1rem;
 	font-weight: 600;
-	font-size: 0.9rem;
+	font-size: $font-body-small;
 	line-height: 1rem;
 }
 
@@ -221,7 +221,7 @@
 	}
 
 	div {
-		font-size: 18px;
+		font-size: $font-title-small;
 		font-weight: 600;
 	}
 }
@@ -267,7 +267,7 @@
 	top: -1.9rem;
 	background-color: rgba( 0, 0, 0, 0.5 );
 	color: #fff;
-	font-size: 0.8rem;
+	font-size: $font-body-small;
 	padding-top: 0.3rem;
 }
 
@@ -399,7 +399,7 @@
 		margin-top: 0;
 		color: var( --studio-gray-40 );
 		font-weight: 400;
-		font-size: 0.9rem;
+		font-size: $font-body;
 	}
 
 	.form-button.daily-backup-status__download-button,
@@ -413,7 +413,7 @@
 	}
 
 	.daily-backup-status__failed-message {
-		font-size: 36px;
+		font-size: $font-headline-small;
 		font-weight: 600;
 		margin-bottom: 2rem;
 	}

--- a/client/components/jetpack/scan-threats/style.scss
+++ b/client/components/jetpack/scan-threats/style.scss
@@ -5,8 +5,8 @@
 
 	&__error, &__rerun {
 		text-align: center;
-		font-size: $font-body;
-		line-height: 24px;
+		font-size: $font-body-small;
+		line-height: 20px;
 		color: var( --studio-gray-40 );
 		margin-top: 24px;
 	}
@@ -16,7 +16,6 @@
 		border: initial;
 		font-weight: normal;
 		vertical-align: initial;
-		font-size: initial;
 		color: var( --color-link );
 		background: inherit;
 

--- a/client/components/jetpack/server-credentials-wizard-dialog/style.scss
+++ b/client/components/jetpack/server-credentials-wizard-dialog/style.scss
@@ -7,7 +7,7 @@
 
 	.server-credentials-wizard-dialog {
 		&__header {
-			font-size: 18px;
+			font-size: $font-title-small;
 			border-bottom: 1px solid #dcdcde;
 			margin: -8px -24px 16px;
 			padding: 0 24px 16px;

--- a/client/components/jetpack/stats-footer/style.scss
+++ b/client/components/jetpack/stats-footer/style.scss
@@ -23,7 +23,7 @@
 }
 
 .stats-footer__stat {
-	font-size: 20px;
+	font-size: $font-title-small;
 	margin: 0 24px 20px 0;
 	flex: 1;
 	max-width: 110px;
@@ -34,7 +34,7 @@
 }
 
 .stats-footer__stat-number {
-	font-size: 28px;
+	font-size: $font-title-large;
 	display: block;
 }
 

--- a/client/components/jetpack/threat-description/style.scss
+++ b/client/components/jetpack/threat-description/style.scss
@@ -6,7 +6,7 @@
 	&__section-title {
 		margin-bottom: 20px;
 
-		font-size: rem( 18px );
+		font-size: $font-title-small;
 		line-height: 1.3; /* 24/18 */
 	}
 

--- a/client/components/jetpack/threat-dialog/style.scss
+++ b/client/components/jetpack/threat-dialog/style.scss
@@ -1,7 +1,7 @@
 .dialog.threat-dialog {
 	.threat-dialog {
 		&__header {
-			font-size: 18px;
+			font-size: $font-title-small;
 			border-bottom: 1px solid #dcdcde;
 			margin: -8px -24px 16px;
 			padding: 0 24px 16px;

--- a/client/components/jetpack/threat-item/style.scss
+++ b/client/components/jetpack/threat-item/style.scss
@@ -8,9 +8,14 @@
 		@include placeholder( --color-neutral-10 );
 	}
 
-	.card-heading {
-		font-size: $font-title-small;
+	.card-heading,
+	.threat-item-header__alert-filename {
+		font-size: $font-body;
 		line-height: 24px;
+
+		@include breakpoint-deprecated( '>800px' ) {
+			font-size: $font-title-small;
+		}
 	}
 
 	.log-item__subheader {

--- a/client/components/jetpack/threat-item/style.scss
+++ b/client/components/jetpack/threat-item/style.scss
@@ -9,7 +9,7 @@
 	}
 
 	.card-heading {
-		font-size: 18px;
+		font-size: $font-title-small;
 		line-height: 24px;
 	}
 

--- a/client/my-sites/backup/style.scss
+++ b/client/my-sites/backup/style.scss
@@ -67,7 +67,7 @@
 .backup__subheader {
 	margin: 20px 16px 8px;
 
-	font-family: $brand-serif;
+	@extend .wp-brand-font;
 	font-size: $font-title-small;
 
 	@include breakpoint-deprecated( '>660px' ) {

--- a/client/my-sites/backup/style.scss
+++ b/client/my-sites/backup/style.scss
@@ -67,7 +67,7 @@
 .backup__subheader {
 	margin: 20px 16px 8px;
 
-	font-family: 'Recoleta', Georgia, 'Times New Roman', Times, serif;
+	font-family: $brand-serif;
 	font-size: $font-title-small;
 
 	@include breakpoint-deprecated( '>660px' ) {

--- a/client/my-sites/backup/style.scss
+++ b/client/my-sites/backup/style.scss
@@ -54,7 +54,7 @@
 }
 
 .backup__search-header {
-	font-size: 1.3rem;
+	font-size: $font-title-small;
 	font-weight: 400;
 	margin-top: 2rem;
 	margin-bottom: 0.5rem;
@@ -68,7 +68,7 @@
 	margin: 20px 16px 8px;
 
 	font-family: 'Recoleta', Georgia, 'Times New Roman', Times, serif;
-	font-size: rem( 21px );
+	font-size: $font-title-small;
 
 	@include breakpoint-deprecated( '>660px' ) {
 		margin: 36px 0 4px;

--- a/client/my-sites/scan/style.scss
+++ b/client/my-sites/scan/style.scss
@@ -72,7 +72,7 @@
 .scan__subheader {
 	margin: 20px 16px 8px;
 
-	font-family: $brand-serif;
+	@extend .wp-brand-font;
 	font-size: $font-title-small;
 
 	@include breakpoint-deprecated( '>660px' ) {

--- a/client/my-sites/scan/style.scss
+++ b/client/my-sites/scan/style.scss
@@ -72,7 +72,7 @@
 .scan__subheader {
 	margin: 20px 16px 8px;
 
-	font-family: 'Recoleta', Georgia, 'Times New Roman', Times, serif;
+	font-family: $brand-serif;
 	font-size: $font-title-small;
 
 	@include breakpoint-deprecated( '>660px' ) {

--- a/client/my-sites/scan/style.scss
+++ b/client/my-sites/scan/style.scss
@@ -16,7 +16,7 @@
 }
 
 .scan__content p {
-	font-size: 18px;
+	font-size: $font-body;
 	margin-bottom: 16px;
 	line-height: 24px;
 
@@ -53,13 +53,13 @@
 
 .scan__header {
 	color: var( --studio-black );
-	font-size: rem( 28px );
+	font-size: $font-title-medium;
+	font-weight: 600;
 	line-height: 1;
 	margin: 32px 0 16px;
 
 	@include breakpoint-deprecated( '>660px' ) {
-		font-size: rem( 36px );
-		font-weight: 600;
+		font-size: $font-headline-small;
 		margin: 32px 0 24px;
 	}
 	&.is-placeholder {
@@ -73,7 +73,7 @@
 	margin: 20px 16px 8px;
 
 	font-family: 'Recoleta', Georgia, 'Times New Roman', Times, serif;
-	font-size: rem( 21px );
+	font-size: $font-title-small;
 
 	@include breakpoint-deprecated( '>660px' ) {
 		margin: 36px 0 4px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update type scale on Jetpack Backup/Scan.
* Use typeface variable on Jetpack Backup/Scan upsell pages.

cc @sixhours so that you're aware of this change.

#### Screenshots

Before | After
--|--
![image](https://user-images.githubusercontent.com/390760/85737290-2872a200-b6f7-11ea-8a71-18999f8a12a6.png) | ![image](https://user-images.githubusercontent.com/390760/85737274-2577b180-b6f7-11ea-9313-2908c48e263d.png)
![image](https://user-images.githubusercontent.com/390760/85737401-43ddad00-b6f7-11ea-8961-96c715984509.png) | ![image](https://user-images.githubusercontent.com/390760/85737412-46400700-b6f7-11ea-8a49-08bdde7766f7.png)
![image](https://user-images.githubusercontent.com/390760/85740096-3fb28f00-b6f9-11ea-9ddb-0cbf4313cb0a.png) | ![image](https://user-images.githubusercontent.com/390760/85740132-47723380-b6f9-11ea-98bc-353c8c1bd6a0.png)
![image](https://user-images.githubusercontent.com/390760/85738456-f57cde00-b6f7-11ea-89c2-9e20070dbbd5.png) | ![image](https://user-images.githubusercontent.com/390760/85738404-eb5adf80-b6f7-11ea-80ce-7b1718a63f9c.png)
![image](https://user-images.githubusercontent.com/390760/85741257-2c53f380-b6fa-11ea-83a2-0ce9dd63f12d.png) | ![image](https://user-images.githubusercontent.com/390760/85741292-34139800-b6fa-11ea-903f-a51e8f3f2041.png)


#### Testing instructions

**For Jetpack.com**

* Spin up this PR by running `yarn run start-jetpack-cloud`.
* Open `http://jetpack.cloud.localhost:3000/` and select any Jetpack site with Scan and Backup.
* Confirm you see the changes and that everything looks good.

**For WordPress.com, Jetpack sites**

* Spin up this PR by running `yarn start`.
* Open `http://calypso.localhost:3000/` and select any Jetpack site with Scan and Backup.
* Confirm you see the changes and that everything looks good.

**For WordPress.com, Simple sites**

* Spin up this PR by running `yarn start`.
* Open `http://calypso.localhost:3000/` and select any Simple site with a Free, Personal or Premium plan.
* Go to `Jetpack > Backup`.
* Confirm you see the changes and that everything looks good.