### PR TITLE
Jetpack: prevent widows on upsell cards

### DIFF
--- a/client/components/promo-section/promo-card/style.scss
+++ b/client/components/promo-section/promo-card/style.scss
@@ -38,7 +38,7 @@
 			@extend .wp-brand-font;
 			font-size: 20px;
 			line-height: 28px;
-			margin-bottom: 0;
+			margin-bottom: 8px;
 		}
 
 		@include breakpoint-deprecated( '>480px' ) {

--- a/client/my-sites/backup/wpcom-backup-upsell.tsx
+++ b/client/my-sites/backup/wpcom-backup-upsell.tsx
@@ -17,6 +17,7 @@ import FormattedHeader from 'components/formatted-header';
 import PromoCard from 'components/promo-section/promo-card';
 import useTrackCallback from 'lib/jetpack/use-track-callback';
 import { getSelectedSiteSlug } from 'state/ui/selectors';
+import { preventWidows } from 'lib/formatting';
 
 /**
  * Asset dependencies
@@ -44,7 +45,7 @@ export default function WPCOMUpsellPage(): ReactElement {
 			/>
 
 			<PromoCard
-				title={ translate( 'Get time travel for your site with Jetpack Backup' ) }
+				title={ preventWidows( translate( 'Get time travel for your site with Jetpack Backup' ) ) }
 				image={ { path: JetpackBackupSVG } }
 				isPrimary
 			>

--- a/client/my-sites/backup/wpcom-backup-upsell.tsx
+++ b/client/my-sites/backup/wpcom-backup-upsell.tsx
@@ -50,8 +50,10 @@ export default function WPCOMUpsellPage(): ReactElement {
 				isPrimary
 			>
 				<p>
-					{ translate(
-						'Backup gives you granular control over your site, with the ability to restore it to any previous state, and export it at any time.'
+					{ preventWidows(
+						translate(
+							'Backup gives you granular control over your site, with the ability to restore it to any previous state, and export it at any time.'
+						)
 					) }
 				</p>
 

--- a/client/my-sites/backup/wpcom-upsell.tsx
+++ b/client/my-sites/backup/wpcom-upsell.tsx
@@ -69,8 +69,10 @@ export default function WPCOMUpsellPage(): ReactElement {
 				isPrimary
 			>
 				<p>
-					{ translate(
-						'Backup gives you granular control over your site, with the ability to restore it to any previous state, and export it at any time.'
+					{ preventWidows(
+						translate(
+							'Backup gives you granular control over your site, with the ability to restore it to any previous state, and export it at any time.'
+						)
 					) }
 				</p>
 				<PromoCardCTA

--- a/client/my-sites/backup/wpcom-upsell.tsx
+++ b/client/my-sites/backup/wpcom-upsell.tsx
@@ -22,6 +22,7 @@ import Gridicon from 'components/gridicon';
 import { getSitePlan } from 'state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import WhatIsJetpack from 'components/jetpack/what-is-jetpack';
+import { preventWidows } from 'lib/formatting';
 
 /**
  * Asset dependencies
@@ -63,7 +64,7 @@ export default function WPCOMUpsellPage(): ReactElement {
 			/>
 
 			<PromoCard
-				title={ translate( 'Get time travel for your site with Jetpack Backup' ) }
+				title={ preventWidows( translate( 'Get time travel for your site with Jetpack Backup' ) ) }
 				image={ { path: JetpackBackupSVG } }
 				isPrimary
 			>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Prevents widows on Jetpack Backup upsells.
* Add minimal margin to the title in `PromoSection` to create a bit of separation.

cc @Automattic/dotcom-manage-design for the last item of the list above.

#### Screenshots

Before | After
--|--
![image](https://user-images.githubusercontent.com/390760/85747150-efd6c680-b6fe-11ea-94b8-84e8defbc403.png) | ![image](https://user-images.githubusercontent.com/390760/85747952-9e7b0700-b6ff-11ea-8ebf-1af2487a5573.png)
![image](https://user-images.githubusercontent.com/390760/85747097-e3526e00-b6fe-11ea-98b9-c96c26cd0fe4.png) | ![image](https://user-images.githubusercontent.com/390760/85747075-df265080-b6fe-11ea-980d-6bf11160c009.png)

#### Testing instructions

* Spin up this PR.
* Select a simple site on a free plan and go to:
  * `Jetpack > Backup`
  * `Tools > Earn`
* Make sure the promo cards look good in both instances.
