### PR TITLE
ESLint: Add inclusive language rule #43600

### DIFF
--- a/package.json
+++ b/package.json
@@ -279,6 +279,7 @@
 		"eslint-config-prettier": "^6.11.0",
 		"eslint-config-wpcalypso": "^5.0.0",
 		"eslint-plugin-import": "^2.20.0",
+		"eslint-plugin-inclusive-language": "^1.0.0",
 		"eslint-plugin-jest": "^23.6.0",
 		"eslint-plugin-jsdoc": "^18.11.0",
 		"eslint-plugin-jsx-a11y": "^6.2.3",

--- a/package.json
+++ b/package.json
@@ -277,7 +277,7 @@
 		"enzyme-to-json": "^3.4.3",
 		"eslint": "^7.1.0",
 		"eslint-config-prettier": "^6.11.0",
-		"eslint-config-wpcalypso": "^5.0.0",
+		"eslint-config-wpcalypso": "^6.0.0",
 		"eslint-plugin-import": "^2.20.0",
 		"eslint-plugin-inclusive-language": "^1.0.0",
 		"eslint-plugin-jest": "^23.6.0",

--- a/packages/eslint-config-wpcalypso/CHANGELOG.md
+++ b/packages/eslint-config-wpcalypso/CHANGELOG.md
@@ -1,3 +1,7 @@
+### v6.0.0 (2020-07-01)
+
+- Add [`inclusive-language`](https://github.com/muenzpraeger/eslint-plugin-inclusive-language) rule (01f9b02524)
+
 ### v5.0.0 (2019-11-19)
 
 - Require eslint v6

--- a/packages/eslint-config-wpcalypso/index.js
+++ b/packages/eslint-config-wpcalypso/index.js
@@ -11,7 +11,7 @@ module.exports = {
 		},
 	},
 	extends: [ 'eslint:recommended', 'plugin:jsdoc/recommended' ],
-	plugins: [ 'jsdoc', 'wpcalypso' ],
+	plugins: [ 'jsdoc', 'wpcalypso', 'inclusive-language' ],
 	rules: {
 		'array-bracket-spacing': [ 2, 'always' ],
 		'brace-style': [ 2, '1tbs' ],
@@ -144,5 +144,8 @@ module.exports = {
 		'wpcalypso/jsx-classname-namespace': 2,
 		'wpcalypso/redux-no-bound-selectors': 2,
 		yoda: 0,
+
+		// Ensure our codebases use inclusive language
+		'inclusive-language/use-inclusive-words': 'error',
 	},
 };

--- a/packages/eslint-config-wpcalypso/package.json
+++ b/packages/eslint-config-wpcalypso/package.json
@@ -26,7 +26,8 @@
 	"peerDependencies": {
 		"eslint": "^7.0.0",
 		"eslint-plugin-jsdoc": "^18.0.0",
-		"eslint-plugin-wpcalypso": "^3.4.1 || ^4.0.0"
+		"eslint-plugin-wpcalypso": "^3.4.1 || ^4.0.0",
+		"eslint-plugin-inclusive-language": "^1.0.0"
 	},
 	"dependencies": {
 		"eslint-plugin-react-hooks": "^3.0.0"

--- a/packages/eslint-config-wpcalypso/package.json
+++ b/packages/eslint-config-wpcalypso/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "eslint-config-wpcalypso",
-	"version": "5.0.0",
+	"version": "6.0.0",
 	"description": "ESLint configuration following WordPress.com's Calypso JavaScript Coding Guidelines",
 	"keywords": [
 		"eslint"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10748,6 +10748,11 @@ eslint-plugin-import@^2.20.0:
     read-pkg-up "^2.0.0"
     resolve "^1.12.0"
 
+eslint-plugin-inclusive-language@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-inclusive-language/-/eslint-plugin-inclusive-language-1.0.0.tgz#bf2222355065b344770be052a0fc3420a5bba7e5"
+  integrity sha512-O+dHXecD09zB4yaiFXy36KMm2Wt7bHskXF4LMJJLt3j+1956wZ68mH16h50PWwjiLZXcMtrAyBB9N9Vk9Gt84A==
+
 eslint-plugin-jest@^23.6.0:
   version "23.6.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-23.6.0.tgz#508b32f80d44058c8c01257c0ee718cfbd521e9d"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add [`eslint-plugin-inclusive-language`](https://github.com/muenzpraeger/eslint-plugin-inclusive-language) to our global `.eslintrc`. This will prevent non-inclusive language from being reintroduced into our repository.

This is a major version bump and will require a package re-release after merging.

#### Testing instructions

* `yarn install` and then attempt to add one of the non-inclusive terms from the plugin: https://github.com/muenzpraeger/eslint-plugin-inclusive-language/blob/primary/lib/config/inclusive-words.json

#### In action

<img width="684" alt="Captura de Tela 2020-06-25 às 08 48 56" src="https://user-images.githubusercontent.com/24264157/85753389-10802b80-b6c1-11ea-97b1-b8da9726f5b4.png">

Fixes #43600
