### PR TITLE
Fix new Jetpack Settings Link

### DIFF
--- a/client/lib/jetpack/paths.ts
+++ b/client/lib/jetpack/paths.ts
@@ -16,7 +16,7 @@ export const scanPath = ( siteSlug?: string ) =>
 	siteSlug ? `${ scanBasePath() }/${ siteSlug }` : scanBasePath();
 
 const calypsoBasePath = () =>
-	abtest( 'jetpackSidebarSection' ) !== 'showJetpackSidebarSection'
+	abtest( 'jetpackSidebarSection' ) === 'showJetpackSidebarSection'
 		? '/settings/jetpack'
 		: '/settings/security';
 

--- a/client/my-sites/site-settings/settings-jetpack/index.js
+++ b/client/my-sites/site-settings/settings-jetpack/index.js
@@ -9,9 +9,7 @@ import page from 'page';
 import { makeLayout, render as clientRender, notFound } from 'controller';
 import { navigation, siteSelection } from 'my-sites/controller';
 import { setScroll, siteSettings } from 'my-sites/site-settings/settings-controller';
-import { siteHasScanProductPurchase } from 'state/purchases/selectors';
 import isJetpackSectionEnabledForSite from 'state/selectors/is-jetpack-section-enabled-for-site';
-import isRewindActive from 'state/selectors/is-rewind-active';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { jetpack } from './controller';
 
@@ -19,10 +17,8 @@ const notFoundIfNotEnabled = ( context, next ) => {
 	const state = context.store.getState();
 	const siteId = getSelectedSiteId( state );
 	const showJetpackSection = isJetpackSectionEnabledForSite( state, siteId );
-	const hasScanProduct = siteHasScanProductPurchase( state, siteId );
-	const hasActiveRewind = isRewindActive( state, siteId );
 
-	if ( ! showJetpackSection || ( ! hasScanProduct && ! hasActiveRewind ) ) {
+	if ( ! showJetpackSection ) {
 		return notFound( context, next );
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix the settings path when new jetpack sidebar enabled
* Remove the requirement that jetpack products be purchases to navigate to route

#### Testing instructions

1. Navigate to `/settings/security` for a jetpack site with the `jepackSidebarSection` abtest set to `showJetpackSidebarSection`
2. Verify you can see the "Looking for Jetpack backups and security scans settings?" notice at the top of the page ( if not follow the steps below to unhide it ) <img width="930" alt="Screen Shot 2020-06-25 at 8 55 33 AM" src="https://user-images.githubusercontent.com/2810519/85754358-d82d1d00-b6c1-11ea-9e18-2217df14ad88.png">
3. Click "Take me there!"
4. Verify you are taken to `/settings/jetpack`
5. Reload the page, verify that it still works the same
6. Manually enter the route for a non-jetpack site to `settings/jetpack`
7. Verify you see the following:
<img width="1136" alt="Screen Shot 2020-06-25 at 9 35 06 AM" src="https://user-images.githubusercontent.com/2810519/85761879-0ada1400-b6c8-11ea-98e6-e3a0ee08221e.png">



