### PR TITLE
Jetpack Connect HoC: provide passed props to the wrapped component.

### DIFF
--- a/client/jetpack-connect/jetpack-connection.jsx
+++ b/client/jetpack-connect/jetpack-connection.jsx
@@ -20,9 +20,7 @@ import versionCompare from 'lib/version-compare';
 import { redirect } from './utils';
 import { addQueryArgs, externalRedirect } from 'lib/route';
 import { checkUrl, dismissUrl } from 'state/jetpack-connect/actions';
-import { FLOW_TYPES } from 'state/jetpack-connect/constants';
 import { getConnectingSite, getJetpackSiteByUrl } from 'state/jetpack-connect/selectors';
-import { getCurrentUserId } from 'state/current-user/selectors';
 import { isRequestingSites } from 'state/sites/selectors';
 import { retrieveMobileRedirect } from './persistence-utils';
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -259,10 +257,6 @@ const jetpackConnection = ( WrappedComponent ) => {
 
 		handleOnClickTos = () => this.props.recordTracksEvent( 'calypso_jpc_tos_link_click' );
 
-		isInstall() {
-			return includes( FLOW_TYPES, this.props.type );
-		}
-
 		render() {
 			return (
 				<WrappedComponent
@@ -272,6 +266,7 @@ const jetpackConnection = ( WrappedComponent ) => {
 					renderFooter={ this.renderFooter }
 					renderNotices={ this.renderNotices }
 					isCurrentUrlFetching={ this.isCurrentUrlFetching() }
+					connectProps={ this.props }
 				/>
 			);
 		}
@@ -290,7 +285,6 @@ const jetpackConnection = ( WrappedComponent ) => {
 			return {
 				// eslint-disable-next-line wpcalypso/redux-no-bound-selectors
 				getJetpackSiteByUrl: ( url ) => getJetpackSiteByUrl( state, url ),
-				isLoggedIn: !! getCurrentUserId( state ),
 				isMobileAppFlow,
 				isRequestingSites: isRequestingSites( state ),
 				jetpackConnectSite,

--- a/client/jetpack-connect/jetpack-connection.jsx
+++ b/client/jetpack-connect/jetpack-connection.jsx
@@ -262,11 +262,10 @@ const jetpackConnection = ( WrappedComponent ) => {
 				<WrappedComponent
 					processJpSite={ this.processJpSite }
 					status={ this.state.status }
-					path={ this.props.path }
 					renderFooter={ this.renderFooter }
 					renderNotices={ this.renderNotices }
 					isCurrentUrlFetching={ this.isCurrentUrlFetching() }
-					connectProps={ this.props }
+					{ ...this.props }
 				/>
 			);
 		}

--- a/client/jetpack-connect/main.jsx
+++ b/client/jetpack-connect/main.jsx
@@ -34,10 +34,10 @@ export class JetpackConnectMain extends Component {
 		processJpSite: PropTypes.func,
 	};
 
-	state = this.props.connectProps.url
+	state = this.props.url
 		? {
-				currentUrl: cleanUrl( this.props.connectProps.url ),
-				shownUrl: this.props.connectProps.url,
+				currentUrl: cleanUrl( this.props.url ),
+				shownUrl: this.props.url,
 				waitingForSites: false,
 		  }
 		: {
@@ -47,30 +47,30 @@ export class JetpackConnectMain extends Component {
 		  };
 
 	UNSAFE_componentWillMount() {
-		if ( this.props.connectProps.url ) {
-			this.checkUrl( cleanUrl( this.props.connectProps.url ) );
+		if ( this.props.url ) {
+			this.checkUrl( cleanUrl( this.props.url ) );
 		}
 	}
 
 	componentDidMount() {
 		let from = 'direct';
-		if ( this.props.connectProps.type === 'install' ) {
+		if ( this.props.type === 'install' ) {
 			from = 'jpdotcom';
 		}
-		if ( this.props.connectProps.type === 'pro' ) {
+		if ( this.props.type === 'pro' ) {
 			from = 'ad';
 		}
-		if ( this.props.connectProps.type === 'premium' ) {
+		if ( this.props.type === 'premium' ) {
 			from = 'ad';
 		}
-		if ( this.props.connectProps.type === 'personal' ) {
+		if ( this.props.type === 'personal' ) {
 			from = 'ad';
 		}
 
 		this.props.recordTracksEvent( 'calypso_jpc_url_view', {
 			jpc_from: from,
-			cta_id: this.props.connectProps.ctaId,
-			cta_from: this.props.connectProps.ctaFrom,
+			cta_id: this.props.ctaId,
+			cta_from: this.props.ctaFrom,
 		} );
 	}
 
@@ -110,7 +110,7 @@ export class JetpackConnectMain extends Component {
 	handleOnClickTos = () => this.props.recordTracksEvent( 'calypso_jpc_tos_link_click' );
 
 	isInstall() {
-		return includes( FLOW_TYPES, this.props.connectProps.type );
+		return includes( FLOW_TYPES, this.props.type );
 	}
 
 	renderSiteInput( status ) {
@@ -134,21 +134,15 @@ export class JetpackConnectMain extends Component {
 	}
 
 	renderLocaleSuggestions() {
-		if ( this.props.isLoggedIn || ! this.props.connectProps.locale ) {
+		if ( this.props.isLoggedIn || ! this.props.locale ) {
 			return;
 		}
 
-		return (
-			<LocaleSuggestions
-				path={ this.props.connectProps.path }
-				locale={ this.props.connectProps.locale }
-			/>
-		);
+		return <LocaleSuggestions path={ this.props.path } locale={ this.props.locale } />;
 	}
 
 	render() {
-		const { renderFooter, status } = this.props;
-		const { type } = this.props.connectProps;
+		const { renderFooter, status, type } = this.props;
 		return (
 			<MainWrapper>
 				{ this.renderLocaleSuggestions() }

--- a/client/jetpack-connect/main.jsx
+++ b/client/jetpack-connect/main.jsx
@@ -34,10 +34,10 @@ export class JetpackConnectMain extends Component {
 		processJpSite: PropTypes.func,
 	};
 
-	state = this.props.url
+	state = this.props.connectProps.url
 		? {
-				currentUrl: cleanUrl( this.props.url ),
-				shownUrl: this.props.url,
+				currentUrl: cleanUrl( this.props.connectProps.url ),
+				shownUrl: this.props.connectProps.url,
 				waitingForSites: false,
 		  }
 		: {
@@ -47,30 +47,30 @@ export class JetpackConnectMain extends Component {
 		  };
 
 	UNSAFE_componentWillMount() {
-		if ( this.props.url ) {
-			this.checkUrl( cleanUrl( this.props.url ) );
+		if ( this.props.connectProps.url ) {
+			this.checkUrl( cleanUrl( this.props.connectProps.url ) );
 		}
 	}
 
 	componentDidMount() {
 		let from = 'direct';
-		if ( this.props.type === 'install' ) {
+		if ( this.props.connectProps.type === 'install' ) {
 			from = 'jpdotcom';
 		}
-		if ( this.props.type === 'pro' ) {
+		if ( this.props.connectProps.type === 'pro' ) {
 			from = 'ad';
 		}
-		if ( this.props.type === 'premium' ) {
+		if ( this.props.connectProps.type === 'premium' ) {
 			from = 'ad';
 		}
-		if ( this.props.type === 'personal' ) {
+		if ( this.props.connectProps.type === 'personal' ) {
 			from = 'ad';
 		}
 
 		this.props.recordTracksEvent( 'calypso_jpc_url_view', {
 			jpc_from: from,
-			cta_id: this.props.ctaId,
-			cta_from: this.props.ctaFrom,
+			cta_id: this.props.connectProps.ctaId,
+			cta_from: this.props.connectProps.ctaFrom,
 		} );
 	}
 
@@ -110,7 +110,7 @@ export class JetpackConnectMain extends Component {
 	handleOnClickTos = () => this.props.recordTracksEvent( 'calypso_jpc_tos_link_click' );
 
 	isInstall() {
-		return includes( FLOW_TYPES, this.props.type );
+		return includes( FLOW_TYPES, this.props.connectProps.type );
 	}
 
 	renderSiteInput( status ) {
@@ -134,16 +134,21 @@ export class JetpackConnectMain extends Component {
 	}
 
 	renderLocaleSuggestions() {
-		if ( this.props.isLoggedIn || ! this.props.locale ) {
+		if ( this.props.isLoggedIn || ! this.props.connectProps.locale ) {
 			return;
 		}
 
-		return <LocaleSuggestions path={ this.props.path } locale={ this.props.locale } />;
+		return (
+			<LocaleSuggestions
+				path={ this.props.connectProps.path }
+				locale={ this.props.connectProps.locale }
+			/>
+		);
 	}
 
 	render() {
-		const { renderFooter, status, type } = this.props;
-
+		const { renderFooter, status } = this.props;
+		const { type } = this.props.connectProps;
 		return (
 			<MainWrapper>
 				{ this.renderLocaleSuggestions() }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

By moving the connection logic to an HoC we overrode the props passed to the wrapped component ( here, from the controller ). The props should be accessed via HoC.

* Also, we remove a redundant function definition and an own prop.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* go to  http://calypso.localhost:3000/jetpack/connect?url=:site
* verify that the input field is pre-filled and the connection processing gets initiated without any action after the page loads ( checking the URL, site status, initiating connection whenever applicable) 

