### PR TITLE
Jetpack Backup: include new backup only events

### DIFF
--- a/client/components/jetpack/daily-backup-status/index.jsx
+++ b/client/components/jetpack/daily-backup-status/index.jsx
@@ -96,7 +96,9 @@ class DailyBackupStatus extends Component {
 
 		// We should only showing the summarized ActivityCard for Real-time sites when the latest backup is not a full backup
 		const showBackupDetails =
-			hasRealtimeBackups && 'rewind__backup_complete_full' !== backup.activityName;
+			hasRealtimeBackups &&
+			( 'rewind__backup_complete_full' !== backup.activityName ||
+				'rewind__backup_only_complete_full' !== backup.activityName );
 
 		return (
 			<>

--- a/client/lib/jetpack/backup-utils.js
+++ b/client/lib/jetpack/backup-utils.js
@@ -25,7 +25,8 @@ export const isActivityItemDateEqual = ( activityDateString, targetDateString ) 
 export const getBackupAttemptsForDate = ( logs, targetDateString ) => ( {
 	complete: logs.filter(
 		( item ) =>
-			'rewind__backup_complete_full' === item.activityName &&
+			( 'rewind__backup_complete_full' === item.activityName ||
+				'rewind__backup_only_complete_full' === item.activityName ) &&
 			isActivityItemDateEqual( item.activityDate, targetDateString )
 	),
 	error: logs.filter(
@@ -137,7 +138,9 @@ export const isActivityBackup = ( activity ) => {
 	return (
 		'rewind__backup_complete_full' === activity.activityName ||
 		'rewind__backup_complete_initial' === activity.activityName ||
-		'rewind__backup_error' === activity.activityName
+		'rewind__backup_error' === activity.activityName ||
+		'rewind__backup_only_complete_full' === activity.activityName ||
+		'rewind__backup_only_complete_initial' === activity.activityName
 	);
 };
 
@@ -173,7 +176,9 @@ export const getRealtimeBackups = ( logs, date ) => {
 export const isSuccessfulDailyBackup = ( backup ) => {
 	return (
 		'rewind__backup_complete_full' === backup.activityName ||
-		'rewind__backup_complete_initial' === backup.activityName
+		'rewind__backup_complete_initial' === backup.activityName ||
+		'rewind__backup_only_complete_full' === backup.activityName ||
+		'rewind__backup_only_complete_initial' === backup.activityName
 	);
 };
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Recently, two new Backup related events were added: `rewind__backup_only_complete_full` and `rewind__backup_only_complete_initial`. This PRs includes them so we can make use of them in Backup's UI.

#### Testing instructions

* Prerequisite: self-hosted Jetpack site with Backup product and a Free plan. 
* Visit `http://jetpack.cloud.localhost:3000/backup/[site]`.
* Verify that you see a backup for the day.
* Visit `https://cloud.jetpack.com/backup/[site]`.
* Verify that you don't see a backup for the day.

Fixes 1179060693083348-as-1182030255774641

#### Demo
##### Before
![image](https://user-images.githubusercontent.com/3418513/85759938-bfcff900-b6e7-11ea-9895-d679853aa9ad.png)

##### After
![image](https://user-images.githubusercontent.com/3418513/85759893-b5adfa80-b6e7-11ea-8996-c2a46708aa27.png)

