### PR TITLE
Fix blank screen for clone tool

### DIFF
--- a/client/my-sites/site-settings/navigation.jsx
+++ b/client/my-sites/site-settings/navigation.jsx
@@ -115,7 +115,8 @@ export default connect( ( state ) => {
 	return {
 		site,
 		shouldShowJetpackSettings:
-			isJetpackSectionEnabledForSite( state, site.ID ) &&
+			siteId &&
+			isJetpackSectionEnabledForSite( state, siteId ) &&
 			( siteHasScanProductPurchase( state, siteId ) || isRewindActive( state, siteId ) ),
 	};
 } )( localize( SiteSettingsNavigation ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* don't relay on site object in site-settings, it has lead to a critical error when using the clone tool

#### Testing instructions

1. navigate to `/settings/general` for a jetpack site on production
2. click the Clone under site tools
3. verify you see a blank screen
4. repeat for this branch, verify you see the "Let's clone :siteTitle" on the blue screen
