### PR TITLE
Scan: Jetpack site with no Scan purchase is shown a loading placeholder indefinitely

### DIFF
--- a/client/components/jetpack/upsell-switch/README.md
+++ b/client/components/jetpack/upsell-switch/README.md
@@ -5,19 +5,23 @@
 It functions by being passed a query component and function, which is used to query the site state. If the state is `unavailable`, it shows the upsell component with a `reason` passed as a prop.
 
 It is designed to be wrapped around a page like so:
+
 ```jsx
 const Page = (
 	<UpsellSwitch
 		UpsellComponent={ UpsellPage }
 		QueryComponent={ QuerySite }
 		getStateForSite={ getStateBySiteId }
+		isRequestingForSite={ isRequestingForSite }
 		display={ <ContentPage /> }
 	>
 		<div>Loading...</div>
 	</UpsellSwitch>
 );
 ```
+
 Alternatively, it can be inserted into a controller callback stack like so:
+
 ```jsx
 export function showUpsellTest( context, next ) {
 	context.primary = (
@@ -25,6 +29,7 @@ export function showUpsellTest( context, next ) {
 			UpsellComponent={ UpsellPage }
 			QueryComponent={ QuerySite }
 			getStateForSite={ getStateBySiteId }
+			isRequestingForSite={ isRequestingForSite }
 			display={ context.primary }
 		>
 			<div>Loading...</div>
@@ -33,27 +38,37 @@ export function showUpsellTest( context, next ) {
 	next();
 }
 ```
+
 and used in the page callbacks _after_ the page is declared:
+
 ```js
-page(
-	'/test/:site',
-	siteSelection,
-	navigation,
-	test,
-	showUpsellTest,
-	makeLayout,
-	clientRender
-);
+page( '/test/:site', siteSelection, navigation, test, showUpsellTest, makeLayout, clientRender );
 ```
+
 ## Props
+
 The following props can be passed to the `<UpsellSwitch />` component:
+
 ### `UpsellComponent`
+
 Required. A component to display when an upsell is required. Will be passed `reason` as a prop, if any.
+
 ### `QueryComponent`
+
 Required. A data component to query the site state.
+
 ### `getStateForSite`
+
 Required. Function to pull the state of the system from the store. Should take the Redux state as the first arg, and the site ID as the second.
+
+### `isRequestingForSite`
+
+Required. Function to pull the status of the request from the store. Should take the Redux state as the first arg, and the site ID as the second. Should return true while the request is being made, false otherwise.
+
 ### `display`
+
 Required. A component to display with the site has a valid status.
+
 ### `children`
+
 Optional. Components to display while loading site state.

--- a/client/components/jetpack/upsell-switch/index.tsx
+++ b/client/components/jetpack/upsell-switch/index.tsx
@@ -63,6 +63,12 @@ function UpsellSwitch( props: Props ): React.ReactElement {
 	const [ uiState, setUiState ] = useState< UiState >( null );
 	const [ showUpsell, setUpsell ] = useState( false );
 
+	// Reset states when site or section changes
+	useEffect( () => {
+		setUiState( null );
+		setUpsell( false );
+	}, [ siteId, QueryComponent ] );
+
 	// The data queried by QueryComponent can be fetched at any time by other
 	// parts of the app and therefore trigger a rendering of the loading state.
 	// We want to prevent that by making sure the component renders its loading

--- a/client/components/jetpack/upsell-switch/index.tsx
+++ b/client/components/jetpack/upsell-switch/index.tsx
@@ -42,8 +42,8 @@ type Props = {
 	isRequesting: boolean;
 };
 
-const UI_STATE_LOADING = Symbol( 'loading' );
-const UI_STATE_LOADED = Symbol( 'loaded' );
+const UI_STATE_LOADING = Symbol();
+const UI_STATE_LOADED = Symbol();
 
 type UiState = typeof UI_STATE_LOADED | typeof UI_STATE_LOADING | null;
 
@@ -68,13 +68,17 @@ function UpsellSwitch( props: Props ): React.ReactElement {
 	// We want to prevent that by making sure the component renders its loading
 	// state only once while mounted.
 	useEffect( () => {
-		if ( ! uiState && isRequesting ) {
-			setUiState( UI_STATE_LOADING );
+		if ( ! uiState ) {
+			if ( isRequesting ) {
+				setUiState( UI_STATE_LOADING );
+			} else if ( state ) {
+				setUiState( UI_STATE_LOADED );
+			}
 		}
 		if ( UI_STATE_LOADING === uiState && ! isRequesting ) {
 			setUiState( UI_STATE_LOADED );
 		}
-	}, [ uiState, isRequesting ] );
+	}, [ uiState, isRequesting, state ] );
 
 	useEffect( () => {
 		// Show the expected content only if the state is distinct to unavailable

--- a/client/my-sites/backup/controller.js
+++ b/client/my-sites/backup/controller.js
@@ -24,9 +24,12 @@ export function showUpsellIfNoBackup( context, next ) {
 		<>
 			<UpsellSwitch
 				UpsellComponent={ UpsellComponent }
-				display={ context.primary }
-				getStateForSite={ getRewindState }
 				QueryComponent={ QueryRewindState }
+				getStateForSite={ getRewindState }
+				isRequestingForSite={ ( state, siteId ) =>
+					'uninitialized' === getRewindState( state, siteId )?.state
+				}
+				display={ context.primary }
 			>
 				<SidebarNavigation />
 				{ ! isJetpackCloud() && (

--- a/client/my-sites/scan/controller.js
+++ b/client/my-sites/scan/controller.js
@@ -11,6 +11,7 @@ import ScanPage from './main';
 import ScanHistoryPage from './history';
 import ScanUpsellPage from './upsell';
 import WPCOMScanUpsellPage from './wpcom-scan-upsell';
+import getSiteScanRequestStatus from 'state/selectors/get-site-scan-request-status';
 import getSiteScanState from 'state/selectors/get-site-scan-state';
 import QueryJetpackScan from 'components/data/query-jetpack-scan';
 import ScanPlaceholder from 'components/jetpack/scan-placeholder';
@@ -46,6 +47,7 @@ function scanUpsellSwitcher( placeholder, primary ) {
 			UpsellComponent={ UpsellComponent }
 			display={ primary }
 			getStateForSite={ getSiteScanState }
+			getRequestStatusForSite={ getSiteScanRequestStatus }
 			QueryComponent={ QueryJetpackScan }
 		>
 			{ placeholder }

--- a/client/my-sites/scan/controller.js
+++ b/client/my-sites/scan/controller.js
@@ -45,10 +45,12 @@ function scanUpsellSwitcher( placeholder, primary ) {
 	return (
 		<UpsellSwitch
 			UpsellComponent={ UpsellComponent }
-			display={ primary }
-			getStateForSite={ getSiteScanState }
-			getRequestStatusForSite={ getSiteScanRequestStatus }
 			QueryComponent={ QueryJetpackScan }
+			getStateForSite={ getSiteScanState }
+			isRequestingForSite={ ( state, siteId ) =>
+				'pending' === getSiteScanRequestStatus( state, siteId )
+			}
+			display={ primary }
 		>
 			{ placeholder }
 		</UpsellSwitch>

--- a/client/my-sites/scan/main.tsx
+++ b/client/my-sites/scan/main.tsx
@@ -13,7 +13,6 @@ import classNames from 'classnames';
  * Internal dependencies
  */
 import DocumentHead from 'components/data/document-head';
-import QueryJetpackScan from 'components/data/query-jetpack-scan';
 import FormattedHeader from 'components/formatted-header';
 import SecurityIcon from 'components/jetpack/security-icon';
 import ScanPlaceholder from 'components/jetpack/scan-placeholder';
@@ -250,7 +249,6 @@ class ScanPage extends Component< Props > {
 			>
 				<DocumentHead title="Scan" />
 				<SidebarNavigation />
-				<QueryJetpackScan siteId={ siteId } />
 				<PageViewTracker path="/scan/:site" title="Scanner" />
 				{ ! isJetpackPlatform && (
 					<FormattedHeader headerText={ 'Jetpack Scan' } align="left" brandFont />

--- a/client/my-sites/scan/main.tsx
+++ b/client/my-sites/scan/main.tsx
@@ -13,6 +13,7 @@ import classNames from 'classnames';
  * Internal dependencies
  */
 import DocumentHead from 'components/data/document-head';
+import QueryJetpackScan from 'components/data/query-jetpack-scan';
 import FormattedHeader from 'components/formatted-header';
 import SecurityIcon from 'components/jetpack/security-icon';
 import ScanPlaceholder from 'components/jetpack/scan-placeholder';
@@ -249,6 +250,7 @@ class ScanPage extends Component< Props > {
 			>
 				<DocumentHead title="Scan" />
 				<SidebarNavigation />
+				<QueryJetpackScan siteId={ siteId } />
 				<PageViewTracker path="/scan/:site" title="Scanner" />
 				{ ! isJetpackPlatform && (
 					<FormattedHeader headerText={ 'Jetpack Scan' } align="left" brandFont />

--- a/client/state/data-layer/wpcom/sites/scan/index.js
+++ b/client/state/data-layer/wpcom/sites/scan/index.js
@@ -125,13 +125,11 @@ const onFetchStatusSuccess = ( action, scan ) => ( dispatch ) => {
 	}
 };
 
-const onFetchStatusFailure = ( ...response ) => {
-	return [
-		{
-			type: JETPACK_SCAN_REQUEST_FAILURE,
-			siteId: response.siteId,
-		},
-	];
+const onFetchStatusFailure = ( { siteId } ) => ( dispatch ) => {
+	dispatch( {
+		type: JETPACK_SCAN_REQUEST_FAILURE,
+		siteId,
+	} );
 };
 
 registerHandlers( 'state/data-layer/wpcom/sites/scan', {

--- a/client/state/selectors/get-site-scan-request-status.ts
+++ b/client/state/selectors/get-site-scan-request-status.ts
@@ -1,0 +1,16 @@
+/**
+ * Internal dependencies
+ */
+import 'state/data-layer/wpcom/sites/scan';
+
+/**
+ * Returns the current Jetpack Scan request status for a given site.
+ * Returns undefined if the site is unknown, or if no information is available.
+ *
+ * @param {object} state	Global state tree
+ * @param {number} siteId	The ID of the site we're querying
+ * @returns {?object}		An object describing the current scan request status
+ */
+export default function getSiteScanRequestStatus( state, siteId ) {
+	return state.jetpackScan.requestStatus?.[ siteId ];
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request

Visiting the _Scan_ section of a Jetpack site without Scan enabled shows the loading placeholder indefinitely instead of showing the upsell section (see screenshot below). This PR fixes this.

### Implementation notes

There are several things to not here:
- The `JETPACK_SCAN_REQUEST_FAILURE` action needed to be explicitly dispatched from the error handler.
- For the Scan use case, the component `UpsellSwitch` used `state.jetpackScan.scan` for the loading logic, while it should have used `state.jetpackScan.requestStatus` (`state.jetpackScan.scan` stays an empty object if the request fails and the loading state cannot be identified).
- `UpsellSwitch` is shared between Scan and Backup sections.
- The loading logic in `UpsellSwitch` had code specific to the Backup section. With the new update, it made sense to extract that logic in a function passed as a prop, to make the component section agnostic.
- The scan information is fetched in several parts of the app. This could make the Scan section reload completely (showing the loading state) while the customer was interacting with it. The `UpsellSwitch` now makes sure to render the loading state only once while mounted.

### Testing instructions

Before testing, make sure you've got 2 Jetpack sites available. One should have Backup but no Scan, and the other one the opposite. The goal here is to make sure the appropriate sections load for Backup and Scan.

### Switching sections

For each site:

1. Go to a page that's neither _Backup_ nor _Scan_, let's say _Plan_
2. Go to _Backup_. Verify that you see the Backup feature or upsell
3. Refresh the page and check again
4. Go to _Scan_. Verify that you see the Scan feature or upsell
5. Refresh the page and check again

### Switching site

1. Go to _Scan_ with one of your site and check that you see what's expected
2. Switch to the other site and check you see what's expected with this site
3. Repeat for backup

### Screenshots

<img width="676" alt="Screen Shot 2020-06-22 at 3 59 17 PM" src="https://user-images.githubusercontent.com/1620183/85776749-ffe6aa00-b6ee-11ea-9993-b60165d45a19.png">
