### PR TITLE
Move SidebarNavigation component to the all sites controller

### DIFF
--- a/client/my-sites/domains/domain-management/controller.jsx
+++ b/client/my-sites/domains/domain-management/controller.jsx
@@ -35,6 +35,7 @@ import {
 } from 'my-sites/email/paths';
 import { getSelectedSiteSlug } from 'state/ui/selectors';
 import { decodeURIComponentIfValid } from 'lib/url';
+import SidebarNavigation from 'my-sites/sidebar-navigation';
 
 export default {
 	domainManagementList( pageContext, next ) {
@@ -55,7 +56,12 @@ export default {
 	},
 
 	domainManagementListAllSites( pageContext, next ) {
-		pageContext.primary = <DomainManagement.ListAll />;
+		pageContext.primary = (
+			<>
+				<SidebarNavigation />
+				<DomainManagement.ListAll />
+			</>
+		);
 		next();
 	},
 

--- a/client/my-sites/domains/domain-management/controller.jsx
+++ b/client/my-sites/domains/domain-management/controller.jsx
@@ -35,7 +35,6 @@ import {
 } from 'my-sites/email/paths';
 import { getSelectedSiteSlug } from 'state/ui/selectors';
 import { decodeURIComponentIfValid } from 'lib/url';
-import SidebarNavigation from 'my-sites/sidebar-navigation';
 
 export default {
 	domainManagementList( pageContext, next ) {
@@ -56,12 +55,7 @@ export default {
 	},
 
 	domainManagementListAllSites( pageContext, next ) {
-		pageContext.primary = (
-			<>
-				<SidebarNavigation />
-				<DomainManagement.ListAll />
-			</>
-		);
+		pageContext.primary = <DomainManagement.ListAll />;
 		next();
 	},
 

--- a/client/my-sites/domains/domain-management/list/list-all.jsx
+++ b/client/my-sites/domains/domain-management/list/list-all.jsx
@@ -28,7 +28,7 @@ import ListItemPlaceholder from './item-placeholder';
 import Main from 'components/main';
 import PropTypes from 'prop-types';
 import QueryAllDomains from 'components/data/query-all-domains';
-import SidebarNavigation from 'my-sites/sidebar-navigation';
+
 /**
  * Style dependencies
  */
@@ -103,7 +103,6 @@ class ListAll extends Component {
 					<QueryAllDomains />
 					<Main wideLayout>
 						<DocumentHead title={ translate( 'Domains', { context: 'A navigation label.' } ) } />
-						<SidebarNavigation />
 						<div className="list-all__items">{ this.renderDomainsList() }</div>
 					</Main>
 				</div>

--- a/client/my-sites/domains/domain-management/list/list-all.jsx
+++ b/client/my-sites/domains/domain-management/list/list-all.jsx
@@ -28,7 +28,7 @@ import ListItemPlaceholder from './item-placeholder';
 import Main from 'components/main';
 import PropTypes from 'prop-types';
 import QueryAllDomains from 'components/data/query-all-domains';
-
+import SidebarNavigation from 'my-sites/sidebar-navigation';
 /**
  * Style dependencies
  */
@@ -102,6 +102,7 @@ class ListAll extends Component {
 				<div className="list-all__container">
 					<QueryAllDomains />
 					<Main wideLayout>
+						<SidebarNavigation />
 						<DocumentHead title={ translate( 'Domains', { context: 'A navigation label.' } ) } />
 						<div className="list-all__items">{ this.renderDomainsList() }</div>
 					</Main>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR moves the `SidebarNavigation` component from within the `ListAll` component to the all sites controller.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit the [all domains view ](http://calypso.localhost:3000/domains/manage)
* Use the "toggle device" toolbar in the browser developer console to view the `all domains view` in a mobile resolution.
* Confirm that the `SidebarNavigation` (which is actually just a toggle) is visible at the top of the screen below the `All Domains` title.

<img width="386" alt="Screenshot 2020-06-29 at 2 28 10 PM" src="https://user-images.githubusercontent.com/277661/86011812-135a8380-ba15-11ea-8b83-1ee4c7416844.png">


