### PR TITLE
Change sslStatusHuman ON to ACTIVE

### DIFF
--- a/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
+++ b/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
@@ -481,8 +481,8 @@ class DomainManagementNavigationEnhanced extends React.Component {
 				} );
 				break;
 			case sslStatuses.SSL_ACTIVE:
-				sslStatusHuman = translate( 'on', {
-					comment: 'Shows as "HTTPS encryption: on" in the nav menu',
+				sslStatusHuman = translate( 'active', {
+					comment: 'Shows as "HTTPS encryption: active" in the nav menu',
 				} );
 				break;
 			case sslStatuses.SSL_DISABLED:


### PR DESCRIPTION
When navigating Calypso in pt_BR, I found an error on the message displayed for `HTTPS encryption: on`.

After some research, I noticed it is being caused by [an existing string on translate.WordPress.com](https://translate.wordpress.com/projects/wpcom/pt-br/default/?filters%5Bstatus%5D=either&filters%5Boriginal_id%5D=360&filters%5Btranslation_id%5D=133376):

> Comment:
> - translators: the word 'on' appears between the product name and the date of next renewal
> - Shows as "HTTPS encryption: on" in the nav menu 

I checked only pt-BR but I believe we will have the same issue with more languages too.

As we can't translate the same word twice, it would be better to use `active` instead of `on` here.

![Translation Error](https://cldup.com/ot2_wSZZU7.png)

cc @carinapilar 