### PR TITLE
Checkout: Add stack and component trace to error boundary logging

### DIFF
--- a/client/my-sites/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout-system-decider.js
@@ -99,7 +99,7 @@ export default function CheckoutSystemDecider( {
 					extra: {
 						env: config( 'env_id' ),
 						type: 'checkout_system_decider',
-						message: String( error.message ),
+						message: String( error ),
 					},
 				} )
 			);

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -200,6 +200,18 @@ export default function WPCheckout( {
 
 	useUpdateCartLocationWhenPaymentMethodChanges( activePaymentMethod, updateCartContactDetails );
 
+	const onReviewError = useCallback(
+		( error ) =>
+			onEvent( {
+				type: 'STEP_LOAD_ERROR',
+				payload: {
+					message: error,
+					stepId: 'review',
+				},
+			} ),
+		[ onEvent ]
+	);
+
 	return (
 		<Checkout>
 			<CheckoutSummaryArea className={ isSummaryVisible ? 'is-visible' : '' }>
@@ -220,6 +232,7 @@ export default function WPCheckout( {
 			</CheckoutSummaryArea>
 			<CheckoutStepArea>
 				<CheckoutStepBody
+					onError={ onReviewError }
 					className="wp-checkout__review-order-step"
 					stepId="review-order-step"
 					isStepActive={ isOrderReviewActive }

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -148,7 +148,7 @@ A [React error boundary](https://reactjs.org/docs/error-boundaries.html) that ca
 
 
 - `errorMessage: React.ReactNode`. The error message to display to the user if there is a problem; typically a string but can also be a component.
-- `onError?: (Error) => void`. A function to be called when there is an error. Can be used for logging.
+- `onError?: (string) => void`. A function to be called when there is an error. Can be used for logging.
 
 ### CheckoutProvider
 
@@ -209,7 +209,7 @@ A component that looks like a checkout step. Normally you don't need to use this
 - `stepNumber: number`. The step number to display for the step.
 - `totalSteps: number`. The total number of steps in the current connected group of steps.
 - `errorMessage?: string`. The error message to display in the React error boundary if there is an error thrown by any component in this step.
-- `onError?: (error: Error) => void`. A callback to be called from the React error boundary if there is an error thrown by any component in this step.
+- `onError?: (string) => void`. A callback to be called from the React error boundary if there is an error thrown by any component in this step.
 - `editButtonText?: string`. The text to display instead of "Edit" for the edit step button.
 - `editButtonAriaLabel?: string`. The text to display for `aria-label` instead of "Edit" for the edit step button.
 - `nextStepButtonText?: string`. Like `editButtonText` but for the "Continue" button.

--- a/packages/composite-checkout/src/components/checkout-error-boundary.js
+++ b/packages/composite-checkout/src/components/checkout-error-boundary.js
@@ -18,10 +18,11 @@ export default class CheckoutErrorBoundary extends React.Component {
 		return { currentError: error, hasError: true };
 	}
 
-	componentDidCatch( error ) {
+	componentDidCatch( error, errorInfo ) {
 		if ( this.props.onError ) {
-			debug( 'reporting error', error );
-			this.props.onError( error );
+			const errorMessage = `${ error.message }; Stack: ${ error.stack }; Component Stack: ${ errorInfo.componentStack }`;
+			debug( 'reporting the error', errorMessage );
+			this.props.onError( errorMessage );
 		}
 	}
 

--- a/packages/composite-checkout/src/components/checkout-payment-methods.js
+++ b/packages/composite-checkout/src/components/checkout-payment-methods.js
@@ -30,7 +30,7 @@ export default function CheckoutPaymentMethods( { summary, isComplete, className
 	const { __ } = useI18n();
 	const onEvent = useEvents();
 	const onError = useCallback(
-		( error ) => onEvent( { type: 'PAYMENT_METHOD_LOAD_ERROR', payload: error.message } ),
+		( error ) => onEvent( { type: 'PAYMENT_METHOD_LOAD_ERROR', payload: error } ),
 		[ onEvent ]
 	);
 

--- a/packages/composite-checkout/src/components/checkout-provider.js
+++ b/packages/composite-checkout/src/components/checkout-provider.js
@@ -103,7 +103,7 @@ export const CheckoutProvider = ( props ) => {
 	const { __ } = useI18n();
 	const errorMessage = __( 'Sorry, there was an error loading this page.' );
 	const onError = useCallback(
-		( error ) => onEvent?.( { type: 'PAGE_LOAD_ERROR', payload: error.message } ),
+		( error ) => onEvent?.( { type: 'PAGE_LOAD_ERROR', payload: error } ),
 		[ onEvent ]
 	);
 	return (

--- a/packages/composite-checkout/src/components/checkout-steps.js
+++ b/packages/composite-checkout/src/components/checkout-steps.js
@@ -153,7 +153,7 @@ export function CheckoutStepArea( { children, className } ) {
 		activeStepNumber > totalSteps && totalSteps > 0 ? totalSteps : activeStepNumber;
 	const isThereAnotherNumberedStep = actualActiveStepNumber < totalSteps;
 	const onSubmitButtonLoadError = useCallback(
-		( error ) => onEvent( { type: 'SUBMIT_BUTTON_LOAD_ERROR', payload: error.message } ),
+		( error ) => onEvent( { type: 'SUBMIT_BUTTON_LOAD_ERROR', payload: error } ),
 		[ onEvent ]
 	);
 
@@ -288,7 +288,7 @@ export function CheckoutStep( {
 			onEvent( {
 				type: 'STEP_LOAD_ERROR',
 				payload: {
-					message: error.message,
+					message: error,
 					stepId,
 				},
 			} ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When a fatal error is thrown in composite checkout's rendering process, we catch and log that error using a React error boundary called `CheckoutErrorBoundary`. Previously, that component accepted an `onError` function prop that would be called with the `Error` object that was thrown by React. However, I wanted to also include the "component trace" that error boundaries provide. Furthermore, I wanted to include both the component trace and the stack trace itself to the message logged to Logstash.

There's various ways I could have done this but I decided that the simplest was probably to change the `onError` function provided to accept an error string instead of an `Error` object, and to create that string by concatenating the error message, stack trace, and component trace.

Another option would have been to create and pass a new error object with the updated message, but that seems misleading since _that_ object's stack trace would have been incorrect.

A third option would have been to add a new property for the component trace to the passed error object, but then we'd be changing an undocumented property of a very standardized object and that could have unintended side effects.

#### Testing instructions

- Cause a fatal error somewhere in composite checkout's render tree.
- Verify that you see the error boundary error message appear on the screen.
- Check Logstash for the string "composite checkout load error" and verify that you see the message, the stack trace, and the component trace.