### PR TITLE
composite-checkout: Add missing google_apps_registration_data property to G Suite transactions

### DIFF
--- a/client/lib/cart-values/types.ts
+++ b/client/lib/cart-values/types.ts
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import type { GSuiteProductUser } from 'lib/gsuite/new-users';
+import type { WPCOMTransactionEndpointDomainDetails } from 'my-sites/checkout/composite-checkout/types/transaction-endpoint';
 
 export type CartItemValue = {
 	product_id?: number;
@@ -22,6 +23,7 @@ export type CartItemExtra = {
 	source?: string;
 	domain_to_bundle?: string;
 	google_apps_users?: GSuiteProductUser[];
+	google_apps_registration_data?: WPCOMTransactionEndpointDomainDetails;
 	purchaseId?: string;
 	purchaseDomain?: string;
 	purchaseType?: string;

--- a/client/my-sites/checkout/composite-checkout/contact-validation.js
+++ b/client/my-sites/checkout/composite-checkout/contact-validation.js
@@ -15,6 +15,7 @@ import wp from 'lib/wp';
  * Internal dependencies
  */
 import { isLineItemADomain } from 'my-sites/checkout/composite-checkout/wpcom/hooks/has-domains';
+import { isGSuiteProductSlug } from 'lib/gsuite';
 
 const wpcom = wp.undocumented();
 
@@ -95,7 +96,7 @@ export async function getDomainValidationResult( items, contactInfo ) {
 
 export async function getGSuiteValidationResult( items, contactInfo ) {
 	const domainNames = items
-		.filter( ( item ) => !! item.wpcom_meta?.extra?.google_apps_users?.length )
+		.filter( ( item ) => isGSuiteProductSlug( item.wpcom_meta?.product_slug ) )
 		.map( ( item ) => item.wpcom_meta?.meta ?? '' );
 	const formattedContactDetails = prepareContactDetailsForValidation( 'gsuite', contactInfo );
 	return wpcomValidateGSuiteContactInformation( formattedContactDetails, domainNames );

--- a/client/my-sites/checkout/composite-checkout/types/paypal-express.ts
+++ b/client/my-sites/checkout/composite-checkout/types/paypal-express.ts
@@ -61,6 +61,7 @@ export function createPayPalExpressEndpointRequestPayloadFromLineItems( {
 			postalCode,
 			subdivisionCode,
 			items: items.filter( ( item ) => ! getNonProductWPCOMCartItemTypes().includes( item.type ) ),
+			contactDetails: domainDetails,
 		} ),
 		country,
 		postalCode,

--- a/client/my-sites/checkout/composite-checkout/types/paypal-express.ts
+++ b/client/my-sites/checkout/composite-checkout/types/paypal-express.ts
@@ -2,14 +2,16 @@
  * External dependencies
  */
 import { getNonProductWPCOMCartItemTypes } from 'my-sites/checkout/composite-checkout/wpcom';
-import { WPCOMCartItem } from 'my-sites/checkout/composite-checkout/wpcom/types';
+import type {
+	WPCOMCartItem,
+	DomainContactDetails,
+} from 'my-sites/checkout/composite-checkout/wpcom/types';
 
 /**
  * Internal dependencies
  */
 import {
 	WPCOMTransactionEndpointCart,
-	WPCOMTransactionEndpointDomainDetails,
 	createTransactionEndpointCartFromLineItems,
 } from './transaction-endpoint';
 
@@ -21,7 +23,7 @@ export type PayPalExpressEndpointRequestPayload = {
 	successUrl: string;
 	cancelUrl: string;
 	cart: WPCOMTransactionEndpointCart;
-	domainDetails: WPCOMTransactionEndpointDomainDetails;
+	domainDetails: DomainContactDetails;
 	country: string;
 	postalCode: string;
 	isWhiteGloveOffer: boolean;
@@ -45,7 +47,7 @@ export function createPayPalExpressEndpointRequestPayloadFromLineItems( {
 	country: string;
 	postalCode: string;
 	subdivisionCode: string;
-	domainDetails: WPCOMTransactionEndpointDomainDetails;
+	domainDetails: DomainContactDetails;
 	items: WPCOMCartItem[];
 } ): PayPalExpressEndpointRequestPayload {
 	const urlParams = new URLSearchParams( window.location.search );

--- a/client/my-sites/checkout/composite-checkout/types/transaction-endpoint.ts
+++ b/client/my-sites/checkout/composite-checkout/types/transaction-endpoint.ts
@@ -47,13 +47,7 @@ export type WPCOMTransactionEndpointCart = {
 	currency: string;
 	temporary: false;
 	extra: string[];
-	products: {
-		product_id: number;
-		meta?: string;
-		currency: string;
-		volume: number;
-		extra?: CartItemExtra;
-	}[];
+	products: WPCOMTransactionEndpointCartItem[];
 	tax: {
 		location: {
 			country_code: string;
@@ -61,6 +55,14 @@ export type WPCOMTransactionEndpointCart = {
 			subdivision_code?: string;
 		};
 	};
+};
+
+type WPCOMTransactionEndpointCartItem = {
+	product_id: number;
+	meta?: string;
+	currency: string;
+	volume: number;
+	extra?: CartItemExtra;
 };
 
 export type WPCOMTransactionEndpointDomainDetails = {

--- a/client/my-sites/checkout/composite-checkout/types/transaction-endpoint.ts
+++ b/client/my-sites/checkout/composite-checkout/types/transaction-endpoint.ts
@@ -7,7 +7,10 @@ import debugFactory from 'debug';
  * Internal dependencies
  */
 import { getNonProductWPCOMCartItemTypes } from 'my-sites/checkout/composite-checkout/wpcom';
-import { WPCOMCartItem } from 'my-sites/checkout/composite-checkout/wpcom/types';
+import type {
+	WPCOMCartItem,
+	DomainContactDetails,
+} from 'my-sites/checkout/composite-checkout/wpcom/types';
 import type { CartItemExtra } from 'lib/cart-values/types';
 import { isGSuiteProductSlug } from 'lib/gsuite';
 
@@ -22,7 +25,7 @@ export type WPCOMTransactionEndpoint = (
 export type WPCOMTransactionEndpointRequestPayload = {
 	cart: WPCOMTransactionEndpointCart;
 	payment: WPCOMTransactionEndpointPaymentDetails;
-	domainDetails?: WPCOMTransactionEndpointDomainDetails;
+	domainDetails?: DomainContactDetails;
 	isWhiteGloveOffer: boolean;
 };
 
@@ -66,30 +69,6 @@ type WPCOMTransactionEndpointCartItem = {
 	extra?: CartItemExtra;
 };
 
-export type WPCOMTransactionEndpointDomainDetails = {
-	firstName: string;
-	lastName: string;
-	email: string;
-	phone: string;
-	address_1: string;
-	city: string;
-	state: string;
-	countryCode: string;
-	postalCode: string;
-};
-
-const emptyDomainDetails: WPCOMTransactionEndpointDomainDetails = {
-	firstName: '',
-	lastName: '',
-	email: '',
-	phone: '',
-	address_1: '',
-	city: '',
-	state: '',
-	countryCode: '',
-	postalCode: '',
-};
-
 // Create cart object as required by the WPCOM transactions endpoint
 // '/me/transactions/': WPCOM_JSON_API_Transactions_Endpoint
 export function createTransactionEndpointCartFromLineItems( {
@@ -107,7 +86,7 @@ export function createTransactionEndpointCartFromLineItems( {
 	postalCode: string;
 	subdivisionCode?: string;
 	items: WPCOMCartItem[];
-	contactDetails: WPCOMTransactionEndpointDomainDetails;
+	contactDetails: DomainContactDetails;
 } ): WPCOMTransactionEndpointCart {
 	debug( 'creating cart from items', items );
 
@@ -152,7 +131,7 @@ function createTransactionEndpointCartItemFromLineItem(
 
 function addRegistrationDataToGSuiteItem(
 	item: WPCOMCartItem,
-	contactDetails: WPCOMTransactionEndpointDomainDetails
+	contactDetails: DomainContactDetails
 ): WPCOMCartItem {
 	if ( ! isGSuiteProductSlug( item.wpcom_meta?.product_slug ) ) {
 		return item;
@@ -188,7 +167,7 @@ export function createTransactionEndpointRequestPayloadFromLineItems( {
 	country: string;
 	postalCode: string;
 	subdivisionCode?: string;
-	domainDetails?: WPCOMTransactionEndpointDomainDetails;
+	domainDetails?: DomainContactDetails;
 	items: WPCOMCartItem[];
 	paymentMethodType: string;
 	paymentMethodToken?: string;
@@ -210,7 +189,7 @@ export function createTransactionEndpointRequestPayloadFromLineItems( {
 			postalCode,
 			subdivisionCode,
 			items: items.filter( ( item ) => item.type !== 'tax' ),
-			contactDetails: domainDetails || emptyDomainDetails,
+			contactDetails: domainDetails || {},
 		} ),
 		domainDetails,
 		payment: {

--- a/client/my-sites/checkout/composite-checkout/types/transaction-endpoint.ts
+++ b/client/my-sites/checkout/composite-checkout/types/transaction-endpoint.ts
@@ -9,6 +9,7 @@ import debugFactory from 'debug';
 import { getNonProductWPCOMCartItemTypes } from 'my-sites/checkout/composite-checkout/wpcom';
 import { WPCOMCartItem } from 'my-sites/checkout/composite-checkout/wpcom/types';
 import type { CartItemExtra } from 'lib/cart-values/types';
+import { isGSuiteProductSlug } from 'lib/gsuite';
 
 const debug = debugFactory( 'calypso:transaction-endpoint' );
 
@@ -153,7 +154,7 @@ function addRegistrationDataToGSuiteItem(
 	item: WPCOMCartItem,
 	contactDetails: WPCOMTransactionEndpointDomainDetails
 ): WPCOMCartItem {
-	if ( ! item.wpcom_meta?.extra.google_apps_users ) {
+	if ( ! isGSuiteProductSlug( item.wpcom_meta?.product_slug ) ) {
 		return item;
 	}
 	return {

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -44,6 +44,7 @@ import {
 	getDomainValidationResult,
 	getGSuiteValidationResult,
 } from 'my-sites/checkout/composite-checkout/contact-validation';
+import { isGSuiteProductSlug } from 'lib/gsuite';
 
 const debug = debugFactory( 'calypso:wp-checkout' );
 
@@ -52,8 +53,8 @@ const ContactFormTitle = () => {
 	const isActive = useIsStepActive();
 	const isComplete = useIsStepComplete();
 	const [ items ] = useLineItems();
-	const isGSuiteInCart = items.some(
-		( item ) => !! item.wpcom_meta?.extra?.google_apps_users?.length
+	const isGSuiteInCart = items.some( ( item ) =>
+		isGSuiteProductSlug( item.wpcom_meta?.product_slug )
 	);
 
 	if ( areDomainsInLineItems( items ) ) {
@@ -110,8 +111,8 @@ export default function WPCheckout( {
 	const [ items ] = useLineItems();
 	const firstDomainItem = items.find( isLineItemADomain );
 	const isDomainFieldsVisible = !! firstDomainItem;
-	const isGSuiteInCart = items.some(
-		( item ) => !! item.wpcom_meta?.extra?.google_apps_users?.length
+	const isGSuiteInCart = items.some( ( item ) =>
+		isGSuiteProductSlug( item.wpcom_meta?.product_slug )
 	);
 	const shouldShowContactStep = isDomainFieldsVisible || total.amount.value > 0;
 

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-contact-form.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-contact-form.js
@@ -25,6 +25,7 @@ import { SummaryLine, SummaryDetails } from './summary-details';
 import { LeftColumn, RightColumn } from './ie-fallback';
 import { prepareDomainContactDetails, prepareDomainContactDetailsErrors, isValid } from '../types';
 import getContactDetailsCache from 'state/selectors/get-contact-details-cache';
+import { isGSuiteProductSlug } from 'lib/gsuite';
 
 const debug = debugFactory( 'calypso:composite-checkout:wp-contact-form' );
 
@@ -41,8 +42,8 @@ export default function WPContactForm( {
 	const translate = useTranslate();
 	const [ items ] = useLineItems();
 	const isDomainFieldsVisible = useHasDomainsInCart();
-	const isGSuiteInCart = items.some(
-		( item ) => !! item.wpcom_meta?.extra?.google_apps_users?.length
+	const isGSuiteInCart = items.some( ( item ) =>
+		isGSuiteProductSlug( item.wpcom_meta?.product_slug )
 	);
 	const contactInfo = useSelect( ( select ) => select( 'wpcom' ).getContactInfo() );
 	const { formStatus } = useFormStatus();

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
@@ -351,14 +351,13 @@ const WPOrderReviewListItem = styled.li`
 
 function GSuiteUsersList( { item } ) {
 	const users = item.wpcom_meta?.extra?.google_apps_users ?? [];
-	const gsuiteDiscountCallout = <GSuiteDiscountCallout item={ item } />;
 	return (
 		<>
 			{ users.map( ( user, index ) => {
 				return (
 					<LineItemMeta key={ user.email }>
 						<div key={ user.email }>{ user.email }</div>
-						{ index === 0 && gsuiteDiscountCallout }
+						{ index === 0 && <GSuiteDiscountCallout item={ item } /> }
 					</LineItemMeta>
 				);
 			} ) }

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
@@ -20,6 +20,7 @@ import joinClasses from './join-classes';
 import { useHasDomainsInCart } from '../hooks/has-domains';
 import { ItemVariationPicker } from './item-variation-picker';
 import { isBusinessPlan } from 'lib/plans';
+import { isGSuiteProductSlug } from 'lib/gsuite';
 
 export function WPOrderReviewSection( { children, className } ) {
 	return <div className={ joinClasses( [ className, 'order-review-section' ] ) }>{ children }</div>;
@@ -53,18 +54,7 @@ function WPLineItem( {
 	const isRenewal = item.wpcom_meta?.extra?.purchaseId;
 	// Show the variation picker when this is not a renewal
 	const shouldShowVariantSelector = getItemVariants && item.wpcom_meta && ! isRenewal;
-	const isGSuite = !! item.wpcom_meta?.extra?.google_apps_users?.length;
-
-	let gsuiteDiscountCallout = null;
-	if (
-		isGSuite &&
-		item.amount.value < item.wpcom_meta?.item_original_subtotal_integer &&
-		item.wpcom_meta?.is_sale_coupon_applied
-	) {
-		gsuiteDiscountCallout = (
-			<DiscountCalloutUI>{ translate( 'Discount for first year' ) }</DiscountCalloutUI>
-		);
-	}
+	const isGSuite = isGSuiteProductSlug( item.wpcom_meta?.product_slug );
 
 	const productSlug = item.wpcom_meta?.product_slug;
 	const isBusinessPlanProduct = productSlug && isBusinessPlan( productSlug );
@@ -92,12 +82,7 @@ function WPLineItem( {
 					<DomainDiscountCallout item={ item } />
 				</LineItemMeta>
 			) }
-			{ isGSuite && (
-				<GSuiteUsersList
-					users={ item.wpcom_meta.extra.google_apps_users }
-					gsuiteDiscountCallout={ gsuiteDiscountCallout }
-				/>
-			) }
+			{ isGSuite && <GSuiteUsersList item={ item } /> }
 			{ hasDeleteButton && formStatus === 'ready' && (
 				<>
 					<DeleteButton
@@ -364,7 +349,9 @@ const WPOrderReviewListItem = styled.li`
 	list-style: none;
 `;
 
-function GSuiteUsersList( { users, gsuiteDiscountCallout } ) {
+function GSuiteUsersList( { item } ) {
+	const users = item.wpcom_meta?.extra?.google_apps_users ?? [];
+	const gsuiteDiscountCallout = <GSuiteDiscountCallout item={ item } />;
 	return (
 		<>
 			{ users.map( ( user, index ) => {
@@ -432,7 +419,7 @@ function LineItemSublabelAndPrice( { item } ) {
 	const translate = useTranslate();
 	const isDomainRegistration = item.wpcom_meta?.is_domain_registration;
 	const isDomainMap = item.type === 'domain_map';
-	const isGSuite = !! item.wpcom_meta?.extra?.google_apps_users?.length;
+	const isGSuite = isGSuiteProductSlug( item.wpcom_meta?.product_slug );
 
 	if ( item.type === 'plan' && item.wpcom_meta?.months_per_bill_period ) {
 		return translate( '%(sublabel)s: %(monthlyPrice)s per month × %(monthsPerBillPeriod)s', {
@@ -473,5 +460,18 @@ function DomainDiscountCallout( { item } ) {
 		return <DiscountCalloutUI>{ translate( 'Free with your plan' ) }</DiscountCalloutUI>;
 	}
 
+	return null;
+}
+
+function GSuiteDiscountCallout( { item } ) {
+	const translate = useTranslate();
+	const isGSuite = isGSuiteProductSlug( item.wpcom_meta?.product_slug );
+	if (
+		isGSuite &&
+		item.amount.value < item.wpcom_meta?.item_original_subtotal_integer &&
+		item.wpcom_meta?.is_sale_coupon_applied
+	) {
+		return <DiscountCalloutUI>{ translate( 'Discount for first year' ) }</DiscountCalloutUI>;
+	}
 	return null;
 }

--- a/client/my-sites/checkout/composite-checkout/wpcom/test/shopping-cart-endpoint.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/test/shopping-cart-endpoint.js
@@ -80,6 +80,7 @@ describe( 'addItemToResponseCart', function () {
 			included_domain_purchase_amount: null,
 			is_bundled: null,
 			is_domain_registration: null,
+			is_sale_coupon_applied: false,
 			is_renewal: undefined,
 			item_subtotal_display: null,
 			item_subtotal_integer: null,

--- a/client/my-sites/checkout/composite-checkout/wpcom/types/backend/shopping-cart-endpoint.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/types/backend/shopping-cart-endpoint.ts
@@ -365,6 +365,7 @@ function convertRequestCartProductToResponseCartProduct(
 		product_type: null,
 		included_domain_purchase_amount: null,
 		is_renewal: undefined,
+		is_sale_coupon_applied: false,
 		subscription_id: undefined,
 	};
 }

--- a/client/my-sites/checkout/composite-checkout/wpcom/types/checkout-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/types/checkout-cart.ts
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import { CheckoutPaymentMethodSlug } from './checkout-payment-method-slug';
+import type { CartItemExtra } from 'lib/cart-values/types';
 
 /**
  * Amount object as used by composite-checkout. If that
@@ -35,7 +36,7 @@ export type WPCOMCartItem = CheckoutCartItem & {
 		plan_length?: string;
 		product_id: number;
 		product_slug: string;
-		extra: object;
+		extra: CartItemExtra;
 		volume?: number;
 		item_original_cost_display: string;
 		item_original_cost_integer: number;

--- a/client/my-sites/checkout/composite-checkout/wpcom/types/wpcom-store-state.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/types/wpcom-store-state.ts
@@ -38,7 +38,7 @@ export type ManagedContactDetailsShape< T > = {
 	tldExtraFields?: ManagedContactDetailsTldExtraFieldsShape< T >;
 };
 
-type ManagedContactDetailsTldExtraFieldsShape< T > = {
+export type ManagedContactDetailsTldExtraFieldsShape< T > = {
 	ca?: {
 		lang?: T;
 		legalType?: T;
@@ -336,9 +336,9 @@ function touchIfDifferent(
 
 function setValueUnlessTouched(
 	newValue: undefined | null | string,
-	oldData: ManagedValue
-): ManagedValue {
-	if ( newValue === undefined || newValue === null ) {
+	oldData: ManagedValue | undefined
+): ManagedValue | undefined {
+	if ( newValue === undefined || newValue === null || oldData === undefined ) {
 		return oldData;
 	}
 	return oldData.isTouched ? oldData : { ...oldData, value: newValue, errors: [] };
@@ -500,7 +500,7 @@ function prepareUkDomainContactExtraDetailsErrors(
 ): UkDomainContactExtraDetailsErrors | null {
 	if ( details.tldExtraFields?.uk ) {
 		// Needed for compatibility with existing component props
-		const toErrorPayload = ( errorMessage, index ) => {
+		const toErrorPayload = ( errorMessage: string, index: number ) => {
 			return { errorCode: index.toString(), errorMessage };
 		};
 
@@ -598,11 +598,11 @@ export function prepareGSuiteContactValidationRequest(
 ): GSuiteContactValidationRequest {
 	return {
 		contact_information: {
-			firstName: details.firstName.value,
-			lastName: details.lastName.value,
-			alternateEmail: details.alternateEmail.value,
-			postalCode: details.postalCode.value,
-			countryCode: details.countryCode.value,
+			firstName: details.firstName?.value ?? '',
+			lastName: details.lastName?.value ?? '',
+			alternateEmail: details.alternateEmail?.value ?? '',
+			postalCode: details.postalCode?.value ?? '',
+			countryCode: details.countryCode?.value ?? '',
 		},
 	};
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When G Suite support was added to new checkout, I failed to add the `google_apps_registration_data` property to the `extra` object on each cart item submitted to the transactions endpoint. That property is supposed to include a duplicate of the domain details record. This PR corrects that oversight.

#### Testing instructions

- Attempt to purchase a G Suite subscription using composite checkout.
- Submit the transaction and examine the endpoint request that is sent; verify that it includes `extra.google_apps_registration_data` for each product under `cart`.