### PR TITLE
Launch Jetpack Sidebar Section for all Users

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -167,13 +167,4 @@ export default {
 		defaultVariation: 'control',
 		allowExistingUsers: true,
 	},
-	jetpackSidebarSection: {
-		datestamp: '20200622',
-		variations: {
-			showJetpackSidebarSection: 0,
-			control: 100,
-		},
-		defaultVariation: 'control',
-		allowExistingUsers: true,
-	},
 };

--- a/client/lib/jetpack/paths.ts
+++ b/client/lib/jetpack/paths.ts
@@ -1,7 +1,6 @@
 /**
  * Internal dependencies
  */
-import { abtest } from 'lib/abtest';
 import { addQueryArgs } from 'lib/url';
 import isJetpackCloud from 'lib/jetpack/is-jetpack-cloud';
 
@@ -15,11 +14,6 @@ const scanBasePath = () => '/scan';
 export const scanPath = ( siteSlug?: string ) =>
 	siteSlug ? `${ scanBasePath() }/${ siteSlug }` : scanBasePath();
 
-const calypsoBasePath = () =>
-	abtest( 'jetpackSidebarSection' ) === 'showJetpackSidebarSection'
-		? '/settings/jetpack'
-		: '/settings/security';
-
-const settingsBasePath = () => ( isJetpackCloud() ? '/settings' : calypsoBasePath() );
+const settingsBasePath = () => ( isJetpackCloud() ? '/settings' : '/settings/jetpack' );
 export const settingsPath = ( siteSlug?: string ) =>
 	siteSlug ? `${ settingsBasePath() }/${ siteSlug }` : settingsBasePath();

--- a/client/state/selectors/is-jetpack-section-enabled-for-site.ts
+++ b/client/state/selectors/is-jetpack-section-enabled-for-site.ts
@@ -1,7 +1,6 @@
 /**
  * Internal dependencies
  */
-import { abtest } from 'lib/abtest';
 import { isEnabled } from 'config';
 import isAtomicSite from 'state/selectors/is-site-automated-transfer';
 import isJetpackSite from 'state/sites/selectors/is-jetpack-site';
@@ -11,11 +10,6 @@ const FLAG_ATOMIC_SITES = 'jetpack/features-section/atomic';
 const FLAG_SIMPLE_SITES = 'jetpack/features-section/simple';
 
 export default function isJetpackSectionEnabledForSite( state: object, siteId?: number | null ) {
-	// If the ab test is disabled there's no need to look any further.
-	if ( abtest( 'jetpackSidebarSection' ) !== 'showJetpackSidebarSection' ) {
-		return false;
-	}
-
 	// From here, we can only determine whether the Jetpack section is enabled
 	// if we have a site ID -- no site ID, no access.
 	if ( ! siteId ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Launch Backup Section for all users
* Launch Scan Section for all Jetpack users
* Move Activity Log into Jetpack Section
* Launch Separate Jetpack Settings for all users

#### Testing instructions

1. Launch the branch, verify the `showJetpackSidebar` is not present in the abtest menu 
2. Verify the Backup Section is visible under the Jetpack Section, verify that it works as expected for simple sites, atomic sites, and Jetpack Sites
3. Verify the scan section is visible for Jetpack Sites
4. Verify the "Jetpack" Settings section is visible for Jetpack Sites
