### PR TITLE
composite-checkout: Implement Sofort payment method in composite checkout package and use it in calypso

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -478,7 +478,9 @@ export default function CompositeCheckout( {
 			giropay: ( transactionData ) =>
 				genericRedirectProcessor( 'giropay', transactionData, getThankYouUrl, isWhiteGloveOffer ),
 			ideal: ( transactionData ) =>
-				genericRedirectProcessor( 'ideal', transactionData, getThankYouUrl, isWhiteGloveOffer ),
+                genericRedirectProcessor( 'ideal', transactionData, getThankYouUrl, isWhiteGloveOffer ),
+            sofort: ( transactionData ) =>
+                genericRedirectProcessor( 'sofort', transactionData, getThankYouUrl, isWhiteGloveOffer ),
 			'full-credits': fullCreditsProcessor,
 			'existing-card': existingCardProcessor,
 			paypal: ( transactionData ) =>

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -478,9 +478,9 @@ export default function CompositeCheckout( {
 			giropay: ( transactionData ) =>
 				genericRedirectProcessor( 'giropay', transactionData, getThankYouUrl, isWhiteGloveOffer ),
 			ideal: ( transactionData ) =>
-                genericRedirectProcessor( 'ideal', transactionData, getThankYouUrl, isWhiteGloveOffer ),
-            sofort: ( transactionData ) =>
-                genericRedirectProcessor( 'sofort', transactionData, getThankYouUrl, isWhiteGloveOffer ),
+				genericRedirectProcessor( 'ideal', transactionData, getThankYouUrl, isWhiteGloveOffer ),
+			sofort: ( transactionData ) =>
+				genericRedirectProcessor( 'sofort', transactionData, getThankYouUrl, isWhiteGloveOffer ),
 			'full-credits': fullCreditsProcessor,
 			'existing-card': existingCardProcessor,
 			paypal: ( transactionData ) =>

--- a/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
@@ -125,6 +125,16 @@ export async function submitStripeRedirectTransaction( paymentMethodId, transact
 	return submit( formattedTransactionData );
 }
 
+export async function submitStripeSofortTransaction( transactionData, submit ) {
+	const formattedTransactionData = createTransactionEndpointRequestPayloadFromLineItems( {
+		...transactionData,
+		paymentMethodType: 'WPCOM_Billing_Stripe_Source_Sofort',
+		paymentPartnerProcessorId: transactionData.stripeConfiguration.processor_id,
+	} );
+	debug( 'sending stripe sofort transaction', formattedTransactionData );
+	return submit( formattedTransactionData );
+}
+
 export function submitCreditsTransaction( transactionData, submit ) {
 	debug( 'formatting full credits transaction', transactionData );
 	const formattedTransactionData = createTransactionEndpointRequestPayloadFromLineItems( {

--- a/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
@@ -125,16 +125,6 @@ export async function submitStripeRedirectTransaction( paymentMethodId, transact
 	return submit( formattedTransactionData );
 }
 
-export async function submitStripeSofortTransaction( transactionData, submit ) {
-	const formattedTransactionData = createTransactionEndpointRequestPayloadFromLineItems( {
-		...transactionData,
-		paymentMethodType: 'WPCOM_Billing_Stripe_Source_Sofort',
-		paymentPartnerProcessorId: transactionData.stripeConfiguration.processor_id,
-	} );
-	debug( 'sending stripe sofort transaction', formattedTransactionData );
-	return submit( formattedTransactionData );
-}
-
 export function submitCreditsTransaction( transactionData, submit ) {
 	debug( 'formatting full credits transaction', transactionData );
 	const formattedTransactionData = createTransactionEndpointRequestPayloadFromLineItems( {

--- a/client/my-sites/checkout/composite-checkout/use-create-payment-methods.js
+++ b/client/my-sites/checkout/composite-checkout/use-create-payment-methods.js
@@ -267,12 +267,12 @@ export default function useCreatePaymentMethods( {
 	} );
 
 	const giropayMethod = useCreateGiropay( {
-    onlyLoadPaymentMethods,
-    isStripeLoading,
-    stripeLoadingError,
-    stripeConfiguration,
-    stripe,
-} );
+		onlyLoadPaymentMethods,
+		isStripeLoading,
+		stripeLoadingError,
+		stripeConfiguration,
+		stripe,
+	} );
 	const sofortMethod = useCreateSofort( {
 		onlyLoadPaymentMethods,
 		isStripeLoading,
@@ -319,7 +319,7 @@ export default function useCreatePaymentMethods( {
 		...existingCardMethods,
 		idealMethod,
 		giropayMethod,
-        sofortMethod,
+		sofortMethod,
 		stripeMethod,
 		paypalMethod,
 	].filter( Boolean );

--- a/client/my-sites/checkout/composite-checkout/use-create-payment-methods.js
+++ b/client/my-sites/checkout/composite-checkout/use-create-payment-methods.js
@@ -10,6 +10,8 @@ import {
 	createGiropayPaymentMethodStore,
 	createIdealMethod,
 	createIdealPaymentMethodStore,
+	createSofortMethod,
+	createSofortPaymentMethodStore,
 	createFullCreditsMethod,
 	createFreePaymentMethod,
 	createApplePayMethod,
@@ -109,6 +111,32 @@ function useCreateIdeal( {
 		() =>
 			shouldLoad
 				? createIdealMethod( {
+						store: paymentMethodStore,
+						stripe,
+						stripeConfiguration,
+				  } )
+				: null,
+		[ shouldLoad, paymentMethodStore, stripe, stripeConfiguration ]
+	);
+}
+
+function useCreateSofort( {
+	onlyLoadPaymentMethods,
+	isStripeLoading,
+	stripeLoadingError,
+	stripeConfiguration,
+	stripe,
+} ) {
+	// If this PM is allowed by props, allowed by the cart, stripe is not loading, and there is no stripe error, then create the PM.
+	const isMethodAllowed = onlyLoadPaymentMethods
+		? onlyLoadPaymentMethods.includes( 'sofort' )
+		: true;
+	const shouldLoad = isMethodAllowed && ! isStripeLoading && ! stripeLoadingError;
+	const paymentMethodStore = useMemo( () => createSofortPaymentMethodStore(), [] );
+	return useMemo(
+		() =>
+			shouldLoad
+				? createSofortMethod( {
 						store: paymentMethodStore,
 						stripe,
 						stripeConfiguration,
@@ -239,6 +267,13 @@ export default function useCreatePaymentMethods( {
 	} );
 
 	const giropayMethod = useCreateGiropay( {
+    onlyLoadPaymentMethods,
+    isStripeLoading,
+    stripeLoadingError,
+    stripeConfiguration,
+    stripe,
+} );
+	const sofortMethod = useCreateSofort( {
 		onlyLoadPaymentMethods,
 		isStripeLoading,
 		stripeLoadingError,
@@ -284,6 +319,7 @@ export default function useCreatePaymentMethods( {
 		...existingCardMethods,
 		idealMethod,
 		giropayMethod,
+        sofortMethod,
 		stripeMethod,
 		paypalMethod,
 	].filter( Boolean );

--- a/packages/composite-checkout/src/lib/payment-methods/sofort.js
+++ b/packages/composite-checkout/src/lib/payment-methods/sofort.js
@@ -1,0 +1,238 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import styled from '@emotion/styled';
+import debugFactory from 'debug';
+import { sprintf } from '@wordpress/i18n';
+import { useI18n } from '@automattic/react-i18n';
+
+/**
+ * Internal dependencies
+ */
+import Field from '../../components/field';
+import Button from '../../components/button';
+import {
+	usePaymentProcessor,
+	useTransactionStatus,
+	useLineItems,
+	renderDisplayValueMarkdown,
+	useEvents,
+} from '../../public-api';
+import { SummaryLine, SummaryDetails } from '../styled-components/summary-details';
+import { useFormStatus } from '../form-status';
+import { registerStore, useSelect, useDispatch } from '../../lib/registry';
+import { PaymentMethodLogos } from '../styled-components/payment-method-logos';
+
+const debug = debugFactory( 'composite-checkout:sofort-payment-method' );
+
+export function createSofortPaymentMethodStore() {
+	debug( 'creating a new sofort payment method store' );
+	const actions = {
+		changeCustomerName( payload ) {
+			return { type: 'CUSTOMER_NAME_SET', payload };
+		},
+	};
+
+	const selectors = {
+		getCustomerName( state ) {
+			return state.customerName || '';
+		},
+	};
+
+	const store = registerStore( 'sofort', {
+		reducer(
+			state = {
+				customerName: { value: '', isTouched: false },
+			},
+			action
+		) {
+			switch ( action.type ) {
+				case 'CUSTOMER_NAME_SET':
+					return { ...state, customerName: { value: action.payload, isTouched: true } };
+			}
+			return state;
+		},
+		actions,
+		selectors,
+	} );
+
+	return { ...store, actions, selectors };
+}
+
+export function createSofortMethod( { store, stripe, stripeConfiguration } ) {
+	return {
+		id: 'sofort',
+		label: <SofortLabel />,
+		activeContent: <SofortFields stripe={ stripe } stripeConfiguration={ stripeConfiguration } />,
+		submitButton: (
+			<SofortPayButton
+				store={ store }
+				stripe={ stripe }
+				stripeConfiguration={ stripeConfiguration }
+			/>
+		),
+		inactiveContent: <SofortSummary />,
+		getAriaLabel: ( __ ) => __( 'Sofort' ),
+	};
+}
+
+function SofortFields() {
+	const { __ } = useI18n();
+
+	const customerName = useSelect( ( select ) => select( 'sofort' ).getCustomerName() );
+	const { changeCustomerName } = useDispatch( 'sofort' );
+	const { formStatus } = useFormStatus();
+	const isDisabled = formStatus !== 'ready';
+
+	return (
+		<SofortFormWrapper>
+			<SofortField
+				id="cardholderName"
+				type="Text"
+				autoComplete="cc-name"
+				label={ __( 'Your name' ) }
+				value={ customerName?.value ?? '' }
+				onChange={ changeCustomerName }
+				isError={ customerName?.isTouched && customerName?.value.length === 0 }
+				errorMessage={ __( 'This field is required' ) }
+				disabled={ isDisabled }
+			/>
+		</SofortFormWrapper>
+	);
+}
+
+const SofortFormWrapper = styled.div`
+	padding: 16px;
+	position: relative;
+
+	:after {
+		display: block;
+		width: calc( 100% - 6px );
+		height: 1px;
+		content: '';
+		background: ${ ( props ) => props.theme.colors.borderColorLight };
+		position: absolute;
+		top: 0;
+		left: 3px;
+		
+		.rtl & {
+		    left: auto;
+		    right: 3px;
+		}
+	}
+`;
+
+const SofortField = styled( Field )`
+	margin-top: 16px;
+
+	:first-of-type {
+		margin-top: 0;
+	}
+`;
+
+function SofortPayButton( { disabled, store, stripe, stripeConfiguration } ) {
+	const { __ } = useI18n();
+	const [ items, total ] = useLineItems();
+	const { formStatus } = useFormStatus();
+	const {
+		setTransactionRedirecting,
+		setTransactionError,
+		setTransactionPending,
+	} = useTransactionStatus();
+	const submitTransaction = usePaymentProcessor( 'sofort' );
+	const onEvent = useEvents();
+	const customerName = useSelect( ( select ) => select( 'sofort' ).getCustomerName() );
+
+	return (
+		<Button
+			disabled={ disabled }
+			onClick={ () => {
+				if ( isFormValid( store ) ) {
+					debug( 'submitting sofort payment' );
+					setTransactionPending();
+					onEvent( { type: 'REDIRECT_TRANSACTION_BEGIN', payload: { paymentMethodId: 'sofort' } } );
+					submitTransaction( {
+						stripe,
+						name: customerName?.value,
+						items,
+						total,
+						stripeConfiguration,
+					} )
+						.then( ( stripeResponse ) => {
+							if ( ! stripeResponse?.redirect_url ) {
+								setTransactionError(
+									__(
+										'There was an error processing your payment. Please try again or contact support.'
+									)
+								);
+								return;
+							}
+							debug( 'sofort transaction requires redirect', stripeResponse.redirect_url );
+							setTransactionRedirecting( stripeResponse.redirect_url );
+						} )
+						.catch( ( error ) => {
+							setTransactionError( error.message );
+						} );
+				}
+			} }
+			buttonType="primary"
+			isBusy={ 'submitting' === formStatus }
+			fullWidth
+		>
+			<ButtonContents formStatus={ formStatus } total={ total } />
+		</Button>
+	);
+}
+
+function ButtonContents( { formStatus, total } ) {
+	const { __ } = useI18n();
+	if ( formStatus === 'submitting' ) {
+		return __( 'Processing…' );
+	}
+	if ( formStatus === 'ready' ) {
+		return sprintf( __( 'Pay %s' ), renderDisplayValueMarkdown( total.amount.displayValue ) );
+	}
+	return __( 'Please wait…' );
+}
+
+function SofortSummary() {
+	const customerName = useSelect( ( select ) => select( 'sofort' ).getCustomerName() );
+
+	return (
+		<SummaryDetails>
+			<SummaryLine>{ customerName?.value }</SummaryLine>
+		</SummaryDetails>
+	);
+}
+
+function isFormValid( store ) {
+	const customerName = store.selectors.getCustomerName( store.getState() );
+
+	if ( ! customerName?.value.length ) {
+		// Touch the field so it displays a validation error
+		store.dispatch( store.actions.changeCustomerName( '' ) );
+		return false;
+	}
+	return true;
+}
+
+function SofortLabel() {
+	const { __ } = useI18n();
+	return (
+		<React.Fragment>
+			<span>{ __( 'Sofort' ) }</span>
+			<PaymentMethodLogos className="sofort__logo payment-logos">
+				<SofortLogoUI />
+			</PaymentMethodLogos>
+		</React.Fragment>
+	);
+}
+
+const SofortLogoUI = styled( SofortLogo )`
+	width: 64px;
+`;
+
+function SofortLogo( { className } ) {
+	return <img src="/calypso/images/upgrades/sofort.svg" alt="Sofort" className={ className } />;
+}

--- a/packages/composite-checkout/src/public-api.js
+++ b/packages/composite-checkout/src/public-api.js
@@ -38,6 +38,7 @@ import {
 import { createFullCreditsMethod } from './lib/payment-methods/full-credits';
 import { createFreePaymentMethod } from './lib/payment-methods/free-purchase';
 import { createIdealPaymentMethodStore, createIdealMethod } from './lib/payment-methods/ideal';
+import { createSofortPaymentMethodStore, createSofortMethod } from './lib/payment-methods/sofort';
 import {
 	createGiropayPaymentMethodStore,
 	createGiropayMethod,
@@ -93,6 +94,8 @@ export {
 	createGiropayPaymentMethodStore,
 	createIdealMethod,
 	createIdealPaymentMethodStore,
+	createSofortMethod,
+	createSofortPaymentMethodStore,
 	createPayPalMethod,
 	createRegistry,
 	createStripeMethod,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Implement Sofort payment method in composite checkout.

![Screen Shot 2020-06-25 at 5 17 16 PM](https://user-images.githubusercontent.com/9310939/85801451-81970180-b708-11ea-89a7-ad55025b81db.png)

#### Testing instructions

* Apply D45520-code to force this payment method to be available (or use a vpn to spoof a German IP address), and enter checkout with Euros as your currency.
