### PR TITLE
Hide editor sidebar first time users sees the editor

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/wpcom-nux.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/wpcom-nux.js
@@ -30,6 +30,7 @@ function WpcomNux() {
 			select( 'automattic/starter-page-layouts' ).isOpen(),
 	} ) );
 
+	const { closeGeneralSidebar } = useDispatch( 'core/edit-post' );
 	const { setWpcomNuxStatus } = useDispatch( 'automattic/nux' );
 
 	// On mount check if the WPCOM NUX status exists in state, otherwise fetch it from the API.
@@ -43,6 +44,11 @@ function WpcomNux() {
 		};
 		fetchWpcomNuxStatus();
 	}, [ isWpcomNuxEnabled, setWpcomNuxStatus ] );
+
+	// Hide editor sidebar first time users sees the editor
+	useEffect( () => {
+		isWpcomNuxEnabled && closeGeneralSidebar();
+	}, [ closeGeneralSidebar, isWpcomNuxEnabled ] );
 
 	if ( ! isWpcomNuxEnabled || isSPTOpen ) {
 		return null;


### PR DESCRIPTION
Resolves https://github.com/Automattic/wp-calypso/issues/37279

From the issue:

> Please watch the "Making First Home Page Edits" testing video on this post: p58i-8d4-p2
>
> On first entry into the block editor, the sidebar is very distracting and doesn’t contain anything immediately relevant or useful to the user. We’ve seen this as an issue in almost all user tests. He goes through the sidebar and quickly realizes there is nothing there for him. “Move to trash?! I don’t want to do that!”
>
> As a secondary note, this hurts sidebar interactions later on when there are useful items in the sidebar for blocks. We’ve immediately set the expectation that the sidebar is something to avoid.


#### Changes proposed in this Pull Request

* When customer first time opens the editor, hide the editor sidebar.
* It's tied to showing the welcome modal, so if you create a new site and welcome modal doesn't show, also sidebar won't hide.
* Sidebar must be opened manually from gear icon
* On next visits to editor, if sidebar was opened, it'll remain open and won't auto-hide

### Before
<img width="1116" alt="Screenshot 2020-06-26 at 09 40 10" src="https://user-images.githubusercontent.com/87168/85828427-15acab80-b791-11ea-8ac1-3688b2707468.png">

### After
<img width="1115" alt="Screenshot 2020-06-26 at 09 40 17" src="https://user-images.githubusercontent.com/87168/85828422-12b1bb00-b791-11ea-9ee4-88bca75c65be.png">



#### Testing instructions
- In `apps/full-site-editing` build this to your sandbox; `yarn dev --sync`
- With your existing account that you used to in past dismiss the welcome modal, create new site from `/new` and land at editor; observe sidebar open
- With new user account, create a site from `/new` and land in the editor. Note welcome modal, and no sidebar.
- Open the sidebar from gear icon
- With same account, visit the editor again; note sidebar is open
