### PR TITLE
Typography: package font variables

### DIFF
--- a/client/assets/stylesheets/shared/_typography.scss
+++ b/client/assets/stylesheets/shared/_typography.scss
@@ -1,18 +1,11 @@
 // Brand font
 
-@import '~@automattic/typography/sass/fonts';
+@import '~@automattic/typography/sass/font-brand';
+@import '~@automattic/typography/sass/font-family';
+@import '~@automattic/typography/sass/font-size';
 
 // Typeface Variables
 
-$monospace: 'Courier 10 Pitch', Courier, monospace;
-$code: Monaco, Consolas, 'Andale Mono', 'DejaVu Sans Mono', $monospace;
-
-$serif-fallback: Georgia, 'Times New Roman', Times, serif;
-$serif: 'Noto Serif', $serif-fallback;
-
-$sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen-Sans', 'Ubuntu', 'Cantarell',
-	'Helvetica Neue', sans-serif;
-$sans-rtl: Tahoma, $sans;
 
 $signup-sans: 'Noto Sans', $sans;
 
@@ -23,35 +16,3 @@ $signup-sans: 'Noto Sans', $sans;
 	-moz-osx-font-smoothing: grayscale;
 	color: var( --color-text );
 }
-
-// ======================================================================
-// Rem function
-//
-// Convert px to rem in a readable fashion.
-//
-// Example: font-size: rem( 21px );
-// ======================================================================
-
-$root-font-size: 16px;
-
-@function rem( $pixels, $context: $root-font-size ) {
-	@return $pixels / $context * 1rem;
-}
-
-// NOTE:
-// If there are exceptions to these stacks,
-// please mark them with a //typography-exception comment
-// so we can easily search for them later.
-
-// Typography size variables
-
-$font-headline-large: rem( 54px );
-$font-headline-medium: rem( 48px );
-$font-headline-small: rem( 36px );
-$font-title-large: rem( 32px );
-$font-title-medium: rem( 24px );
-$font-title-small: rem( 20px );
-$font-body: rem( 16px );
-$font-body-small: rem( 14px );
-$font-body-extra-small: rem( 12px );
-$font-code: rem( 15px );

--- a/client/assets/stylesheets/shared/_typography.scss
+++ b/client/assets/stylesheets/shared/_typography.scss
@@ -1,5 +1,3 @@
-// Brand font
-
 @import '~@automattic/typography/sass/font-brand';
 @import '~@automattic/typography/sass/font-family';
 @import '~@automattic/typography/sass/font-size';

--- a/packages/typography/README.md
+++ b/packages/typography/README.md
@@ -1,6 +1,6 @@
 # Typography
 
-@automattic/typography is a Sass file for shared typographic elements across WordPress.com products. Right now, this package contains the `@font-face` declaration for the WordPress.com brand font.
+`@automattic/typography` are collection of Sass files for shared typographic elements across WordPress.com products.
 
 ## Installation
 
@@ -10,10 +10,22 @@ yarn add @automattic/typography
 
 ## Usage
 
-Import the Sass file:
+Import the Sass files you need:
 
-`@import '~@automattic/typography/sass/fonts';`
+```scss
+@import '~@automattic/typography/sass/font-brand';
+@import '~@automattic/typography/sass/font-family';
+@import '~@automattic/typography/sass/font-size';
+```
 
-Then apply the class name `wp-brand-font` to any elements that should display with Recoleta:
+### Using brand font
 
-`<h1 className="wp-brand-font">Brand font heading</h1>`
+Imported `font-brand.scss` file contains the `@font-face` declaration for the WordPress.com brand font Recoleta.
+
+Apply the class name `wp-brand-font` to any elements that should display with Recoleta:
+
+```jsx
+<h1 className="wp-brand-font">Brand font heading</h1>
+```
+
+The package does not ship with the font files itself.

--- a/packages/typography/sass/font-brand.scss
+++ b/packages/typography/sass/font-brand.scss
@@ -1,3 +1,5 @@
+@import './font-family';
+
 @font-face {
 	font-display: swap;
 	font-family: 'Recoleta';
@@ -6,7 +8,6 @@
 	url( 'https://s1.wp.com/i/fonts/recoleta/400.woff' ) format( 'woff' );
 }
 
-$serif: 'Noto Serif', Georgia, 'Times New Roman', Times, serif;
 $brand-serif: 'Recoleta', $serif;
 
 .wp-brand-font {

--- a/packages/typography/sass/font-family.scss
+++ b/packages/typography/sass/font-family.scss
@@ -1,0 +1,7 @@
+$monospace: 'Courier 10 Pitch', Courier, monospace;
+$code: Monaco, Consolas, 'Andale Mono', 'DejaVu Sans Mono', $monospace;
+$serif-fallback: Georgia, 'Times New Roman', Times, serif;
+$serif: 'Noto Serif', $serif-fallback;
+$sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen-Sans', 'Ubuntu', 'Cantarell',
+	'Helvetica Neue', sans-serif;
+$sans-rtl: Tahoma, $sans;

--- a/packages/typography/sass/font-size.scss
+++ b/packages/typography/sass/font-size.scss
@@ -1,0 +1,31 @@
+// ======================================================================
+// Rem function
+//
+// Convert px to rem in a readable fashion.
+//
+// Example: font-size: rem( 21px );
+// ======================================================================
+
+$root-font-size: 16px;
+
+@function rem( $pixels, $context: $root-font-size ) {
+	@return $pixels / $context * 1rem;
+}
+
+// NOTE:
+// If there are exceptions to these stacks,
+// please mark them with a //typography-exception comment
+// so we can easily search for them later.
+
+// Typography size variables
+
+$font-headline-large: rem( 54px );
+$font-headline-medium: rem( 48px );
+$font-headline-small: rem( 36px );
+$font-title-large: rem( 32px );
+$font-title-medium: rem( 24px );
+$font-title-small: rem( 20px );
+$font-body: rem( 16px );
+$font-body-small: rem( 14px );
+$font-body-extra-small: rem( 12px );
+$font-code: rem( 15px );


### PR DESCRIPTION
I'm specifically interested in re-using these soon in another package that gets shipped to FSE plugin.

See https://github.com/Automattic/wp-calypso/pull/43593/files#diff-ca13dadde8c75ff85a7b846a48f3b7d9R8

#### Changes proposed in this Pull Request

* Package typography variables into a package for re-use

#### Testing instructions

- Re-build Calypso `yarn`
- Boot Calypso and ensure everything works as usual