### PR TITLE
Domains: Display transfer and contact info menu items even if the user has no permissions

### DIFF
--- a/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
+++ b/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
@@ -207,10 +207,6 @@ class DomainManagementNavigationEnhanced extends React.Component {
 		const { selectedSite, translate, currentRoute, domain } = this.props;
 		const { privateDomain, privacyAvailable } = domain;
 
-		if ( ! domain.currentUserCanManage ) {
-			return null;
-		}
-
 		if ( ! this.isDomainInNormalState() && ! this.isDomainInGracePeriod() ) {
 			return null;
 		}
@@ -237,10 +233,6 @@ class DomainManagementNavigationEnhanced extends React.Component {
 	getTransferDomain() {
 		const { moment, selectedSite, translate, domain, currentRoute } = this.props;
 		const { expired, isLocked, transferAwayEligibleAt } = domain;
-
-		if ( ! domain.currentUserCanManage ) {
-			return null;
-		}
 
 		if ( expired && ! this.isDomainInGracePeriod() ) {
 			return null;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This undoes a change in #43579 which hides the contact info and the transfer navigation items for domains if the user cannot access those. 

#### Testing instructions

For a domain on one of your sites which you do not own:

 - Verify the contact info and the transfer items both show in the navigation menu
 - Verify clicking on any of them gives you a permission related notice
