### PR TITLE
Jetpack: don't use wideLayout in Jetpack Scan sections

### DIFF
--- a/client/my-sites/scan/history/index.tsx
+++ b/client/my-sites/scan/history/index.tsx
@@ -39,7 +39,6 @@ export default function ScanHistoryPage( { filter }: Props ) {
 			className={ classNames( 'history', {
 				is_jetpackcom: isJetpackPlatform,
 			} ) }
-			wideLayout={ ! isJetpackPlatform }
 		>
 			<DocumentHead title={ translate( 'Scan' ) } />
 			<SidebarNavigation />

--- a/client/my-sites/scan/main.tsx
+++ b/client/my-sites/scan/main.tsx
@@ -246,7 +246,6 @@ class ScanPage extends Component< Props > {
 				className={ classNames( 'scan', {
 					is_jetpackcom: isJetpackPlatform,
 				} ) }
-				wideLayout={ ! isJetpackPlatform }
 			>
 				<DocumentHead title="Scan" />
 				<SidebarNavigation />


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove `wideLayout` in Jetpack Scan sections:
  * Scanner
  * History

#### Screenshots

Before | After
--|--
![image](https://user-images.githubusercontent.com/390760/85851897-7e068780-b7a7-11ea-9671-4b5f02b29369.png) | ![image](https://user-images.githubusercontent.com/390760/85851927-8fe82a80-b7a7-11ea-829c-0f4bd4b9f0d8.png)


#### Testing instructions

* Spin up this PR.
* Select a Jetpack site with the Scan product.
* Head to `Jetpack > Scan`.
* Ensure the layout is narrow and that it matches the Jetpack Backup section.
