### PR TITLE
i18n: Add Jetpack Connect route with locale param

### DIFF
--- a/client/jetpack-connect/index.js
+++ b/client/jetpack-connect/index.js
@@ -133,7 +133,7 @@ export default function () {
 	);
 
 	page(
-		`/jetpack/connect/${ locale }`,
+		`/jetpack/connect/:type(personal|premium|pro|backup|scan|realtimebackup)?/${ locale }`,
 		controller.redirectWithoutLocaleIfLoggedIn,
 		controller.persistMobileAppFlow,
 		controller.setMasterbar,

--- a/client/jetpack-connect/jetpack-connection.jsx
+++ b/client/jetpack-connect/jetpack-connection.jsx
@@ -5,7 +5,7 @@ import debugModule from 'debug';
 import config from 'config';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { flowRight, get, includes, startsWith } from 'lodash';
+import { flowRight, get, includes, startsWith, omit } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -258,6 +258,8 @@ const jetpackConnection = ( WrappedComponent ) => {
 		handleOnClickTos = () => this.props.recordTracksEvent( 'calypso_jpc_tos_link_click' );
 
 		render() {
+			const props = this.props.locale ? this.props : omit( this.props, 'locale' );
+
 			return (
 				<WrappedComponent
 					processJpSite={ this.processJpSite }
@@ -265,7 +267,7 @@ const jetpackConnection = ( WrappedComponent ) => {
 					renderFooter={ this.renderFooter }
 					renderNotices={ this.renderNotices }
 					isCurrentUrlFetching={ this.isCurrentUrlFetching() }
-					{ ...this.props }
+					{ ...props }
 				/>
 			);
 		}

--- a/client/jetpack-connect/main-header.jsx
+++ b/client/jetpack-connect/main-header.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { PureComponent } from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { concat } from 'lodash';
 import { localize } from 'i18n-calypso';
@@ -13,7 +13,7 @@ import FormattedHeader from 'components/formatted-header';
 import { FLOW_TYPES } from 'state/jetpack-connect/constants';
 import { retrievePlan } from './persistence-utils';
 
-class JetpackConnectMainHeader extends PureComponent {
+class JetpackConnectMainHeader extends Component {
 	static propTypes = {
 		type: PropTypes.oneOf( concat( FLOW_TYPES, false ) ),
 	};

--- a/client/jetpack-connect/site-url-input.jsx
+++ b/client/jetpack-connect/site-url-input.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { PureComponent } from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Gridicon from 'components/gridicon';
 import { localize } from 'i18n-calypso';
@@ -17,7 +17,7 @@ import Spinner from 'components/spinner';
 import SuggestionSearch from 'components/suggestion-search';
 import { localizeUrl } from 'lib/i18n-utils';
 
-class JetpackConnectSiteUrlInput extends PureComponent {
+class JetpackConnectSiteUrlInput extends Component {
 	static propTypes = {
 		handleOnClickTos: PropTypes.func,
 		isError: PropTypes.oneOfType( [ PropTypes.string, PropTypes.bool ] ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add route handling for Jetpack Connect routes with type and locale parameters.

![image](https://user-images.githubusercontent.com/2722412/85855085-52db6280-b7be-11ea-8cb1-9d8f69bba8bc.png)

#### Testing instructions

* Open http://calypso.localhost:3000/jetpack/connect/scan/{locale} in non-logged window (e.g. Incognito Tab)
* Confirm it renders requested locale.
* Open http://calypso.localhost:3000/jetpack/connect/scan/{locale} in logged window
* Confirm you get redirected to route without locale and page renders with the locale from your user's settings.