### PR TITLE
Jetpack Cloud: Add loading placeholder for ActivityCardList

### DIFF
--- a/client/components/activity-card-list/index.jsx
+++ b/client/components/activity-card-list/index.jsx
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -29,7 +30,7 @@ import './style.scss';
 
 class ActivityCardList extends Component {
 	static propTypes = {
-		logs: PropTypes.array.isRequired,
+		logs: PropTypes.array,
 		pageSize: PropTypes.number.isRequired,
 		showDateSeparators: PropTypes.bool,
 		showFilter: PropTypes.bool,
@@ -134,7 +135,7 @@ class ActivityCardList extends Component {
 		);
 
 		return (
-			<>
+			<div className="activity-card-list">
 				{ showFilter && (
 					<Filterbar
 						{ ...{
@@ -172,19 +173,72 @@ class ActivityCardList extends Component {
 						total={ logs.length }
 					/>
 				) }
-			</>
+			</div>
 		);
 	}
 
+	renderLoading() {
+		const { showPagination, showDateSeparators, isBreakpointActive } = this.props;
+
+		/* eslint-disable wpcalypso/jsx-classname-namespace */
+		return (
+			<div className="activity-card-list__loading-placeholder">
+				<div className="filterbar" />
+				{ showPagination && (
+					<div
+						className={ classNames( 'activity-card-list__pagination-top', {
+							'is-compact': isBreakpointActive,
+						} ) }
+					/>
+				) }
+				<div key="activity-card-list__date-group-loading">
+					{ showDateSeparators && (
+						<div className="activity-card-list__date-group-date">
+							<span>MMM Do</span>
+						</div>
+					) }
+					<div className="activity-card-list__date-group-content">
+						{ [ 1, 2, 3 ].map( ( i ) => (
+							<div
+								className="activity-card-list__secondary-card activity-card"
+								key={ `loading-secondary-${ i }` }
+							>
+								<div className="activity-card__time">
+									<div className="activity-card__time-text">Sometime</div>
+								</div>
+								<div className="card" />
+							</div>
+						) ) }
+						<div className="activity-card-list__primary-card activity-card">
+							<div className="activity-card__time">
+								<div className="activity-card__time-text">Sometime</div>
+							</div>
+							<div className="card" />
+						</div>
+					</div>
+				</div>
+				{ showPagination && (
+					<div
+						className={ classNames( 'activity-card-list__pagination-bottom', {
+							'is-compact': isBreakpointActive,
+						} ) }
+					/>
+				) }
+			</div>
+		);
+		/* eslint-disable wpcalypso/jsx-classname-namespace */
+	}
+
 	render() {
-		const { applySiteOffset, siteId } = this.props;
+		const { applySiteOffset, siteId, logs } = this.props;
 
 		return (
-			<div className="activity-card-list">
+			<>
 				<QueryRewindCapabilities siteId={ siteId } />
 				<QueryRewindState siteId={ siteId } />
-				{ applySiteOffset && this.renderData() }
-			</div>
+				{ ! logs && this.renderLoading() }
+				{ logs && applySiteOffset && this.renderData() }
+			</>
 		);
 	}
 }

--- a/client/components/activity-card-list/style.scss
+++ b/client/components/activity-card-list/style.scss
@@ -187,3 +187,54 @@
 		}
 	}
 }
+
+.activity-card-list__loading-placeholder {
+	.filterbar {
+		@include placeholder( --color-neutral-10 );
+		height: 51px;
+		margin-bottom: 2rem;
+	}
+
+	.activity-card-list__pagination-top,
+	.activity-card-list__pagination-bottom {
+		@include placeholder( --color-neutral-10 );
+		height: 34px;
+		width: 50%;
+		margin: 0 auto;
+
+		&.is-compact {
+			height: 28px;
+		}
+	}
+
+	.activity-card-list__date-group-date {
+		span {
+			@include placeholder( --color-neutral-10 );
+			font-weight: 600;
+			font-size: 1rem;
+			line-height: 23px;
+		}
+	}
+
+	.activity-card-list__date-group-content::before {
+		background: transparent;
+	}
+
+	.activity-card__time-text {
+		@include placeholder( --color-neutral-10 );
+	}
+
+	.activity-card {
+		margin-bottom: 32px;
+	}
+
+	.card {
+		@include placeholder( --color-neutral-10 );
+		height: 102px;
+		border-left: initial;
+
+		&::before {
+			background: transparent;
+		}
+	}
+}

--- a/client/my-sites/activity/activity-log-v2/index.tsx
+++ b/client/my-sites/activity/activity-log-v2/index.tsx
@@ -67,7 +67,7 @@ const ActivityLogV2: FunctionComponent = () => {
 				/>
 			) }
 			<div className="activity-log-v2__content">
-				{ logs && <ActivityCardList logs={ logs } pageSize={ 10 } /> }
+				<ActivityCardList logs={ logs } pageSize={ 10 } />
 			</div>
 		</Main>
 	);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add a placeholder to be shown while the ActivityCardList is loading on Jetpack.com (or on WordPress.com, if the `activity-log/v2` flag is enabled).

Fixes `1179060693083348-as-1181062906895905`.

#### Testing instructions

* For both Jetpack.com and WordPress.com, load the Activity Log (v2). To do this with WordPress.com, enable the `activity-log/v2` feature flag.
* Verify that you see a pulsing placeholder while activity log items are loaded, and that the placeholder looks like a silhouette of a real Activity Log.

#### Screenshots

##### Jetpack.com

![Screen Shot 2020-06-26 at 09 20 10](https://user-images.githubusercontent.com/670067/85868166-894db900-b78f-11ea-8d9e-b929854bd660.png)
![Screen Shot 2020-06-26 at 09 19 41](https://user-images.githubusercontent.com/670067/85868173-8c48a980-b78f-11ea-982d-022f96c283bc.png)

##### WordPress.com

![Screen Shot 2020-06-26 at 09 17 39](https://user-images.githubusercontent.com/670067/85868205-95d21180-b78f-11ea-9ba1-b7b47157a12a.png)
![Screen Shot 2020-06-26 at 09 18 28](https://user-images.githubusercontent.com/670067/85868215-98cd0200-b78f-11ea-84c2-6fca08b1203b.png)