### PR TITLE
Jetpack Cloud: handle different 'post__published' activity objects

### DIFF
--- a/client/components/jetpack/daily-backup-status/backup-changes.jsx
+++ b/client/components/jetpack/daily-backup-status/backup-changes.jsx
@@ -81,7 +81,7 @@ const BackupChanges = ( { deltas } ) => {
 				<div key={ item.activityId } className="daily-backup-status__post-block">
 					<Gridicon className="daily-backup-status__post-icon" icon="pencil" />
 					<a className="daily-backup-status__post-link" href={ item.activityDescription[ 0 ].url }>
-						{ item.activityDescription[ 0 ].children[ 0 ] }
+						{ item.activityDescription[ 0 ].children[ 0 ].text }
 					</a>
 				</div>
 			);

--- a/client/components/jetpack/daily-backup-status/backup-changes.jsx
+++ b/client/components/jetpack/daily-backup-status/backup-changes.jsx
@@ -81,7 +81,9 @@ const BackupChanges = ( { deltas } ) => {
 				<div key={ item.activityId } className="daily-backup-status__post-block">
 					<Gridicon className="daily-backup-status__post-icon" icon="pencil" />
 					<a className="daily-backup-status__post-link" href={ item.activityDescription[ 0 ].url }>
-						{ item.activityDescription[ 0 ].children[ 0 ].text }
+						{ typeof item.activityDescription[ 0 ].children[ 0 ] === 'string'
+							? item.activityDescription[ 0 ].children[ 0 ]
+							: item.activityDescription[ 0 ].children[ 0 ].text }
 					</a>
 				</div>
 			);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* In the case of a `post__published` activity, the `activityDescription` content can be either a string or an object, thus, we need to handle both cases. Before, we assumed that they always were strings, but now we now that for some activities this is not true, they can be objects as well.

#### Testing instructions

* Check that post published events still look fine in the Backup section.
* Check that the user with the problem now sees the Backup section.

Fixes 1179060693083348-as-1182184869996409

#### Demo

##### This page was a blank screen before this change (this is the affected user site)
![image](https://user-images.githubusercontent.com/3418513/85868456-b0f94d00-b7a0-11ea-8220-c7f826890379.png)

