### PR TITLE
Modularise push notifications state

### DIFF
--- a/client/state/push-notifications/actions.js
+++ b/client/state/push-notifications/actions.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import debugFactory from 'debug';
 import wpcom from 'lib/wp';
 
@@ -33,6 +32,8 @@ import {
 } from './utils';
 import { registerServerWorker } from 'lib/service-worker';
 import { recordTracksEvent, bumpStat } from 'state/analytics/actions';
+
+import 'state/push-notifications/init';
 
 const debug = debugFactory( 'calypso:push-notifications' );
 const serviceWorkerOptions = {
@@ -143,7 +144,7 @@ export function fetchAndLoadServiceWorker() {
 
 export function deactivateSubscription() {
 	return ( dispatch ) => {
-		navigator.serviceWorker
+		window.navigator.serviceWorker
 			.getRegistration( serviceWorkerOptions )
 			.then( ( serviceWorkerRegistration ) => {
 				serviceWorkerRegistration.pushManager

--- a/client/state/push-notifications/init.js
+++ b/client/state/push-notifications/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'state/redux-store';
+import reducer from './reducer';
+
+registerReducer( [ 'pushNotifications' ], reducer );

--- a/client/state/push-notifications/reducer.js
+++ b/client/state/push-notifications/reducer.js
@@ -7,7 +7,7 @@ import { omit } from 'lodash';
 /**
  * Internal dependencies
  */
-import { combineReducers, withSchemaValidation } from 'state/utils';
+import { combineReducers, withSchemaValidation, withStorageKey } from 'state/utils';
 import { settingsSchema, systemSchema } from './schema';
 
 import {
@@ -134,7 +134,9 @@ const settings = withSchemaValidation( settingsSchema, ( state = { enabled: fals
 	return state;
 } );
 
-export default combineReducers( {
+const combinedReducer = combineReducers( {
 	settings,
 	system,
 } );
+
+export default withStorageKey( 'pushNotifications', combinedReducer );

--- a/client/state/push-notifications/selectors.js
+++ b/client/state/push-notifications/selectors.js
@@ -1,3 +1,8 @@
+/**
+ * Internal dependencies
+ */
+import 'state/push-notifications/init';
+
 // `getState().pushNotifications.system`
 export const isApiReady = ( state ) => !! state.pushNotifications.system.apiReady;
 export const isAuthorized = ( state ) => !! state.pushNotifications.system.authorized;

--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -55,7 +55,6 @@ import plugins from './plugins/reducer';
 import postFormats from './post-formats/reducer';
 import postTypes from './post-types/reducer';
 import productsList from './products-list/reducer';
-import pushNotifications from './push-notifications/reducer';
 import receipts from './receipts/reducer';
 import rewind from './rewind/reducer';
 import selectedEditor from './selected-editor/reducer';
@@ -122,7 +121,6 @@ const reducers = {
 	postFormats,
 	postTypes,
 	productsList,
-	pushNotifications,
 	receipts,
 	rewind,
 	selectedEditor,


### PR DESCRIPTION
This PR is one of many working on modularising state in Calypso. This one handles push notifications.

For more details on state modularisation, see the [modularised state documentation](https://github.com/Automattic/wp-calypso/blob/master/docs/modularized-state.md) and p4TIVU-9lM-p2.

Fixes #42471.

#### Changes proposed in this Pull Request

* Modularise push notifications state

#### Testing instructions

Push notifications are always loaded on boot, so it's difficult to test the automatic loading portion of this PR.

With that in mind, in order to verify that this change works correctly, please smoke test push notification functionality and ensure that it continues to work as before.