### PR TITLE
G Suite: Refine copy on Thank You page

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/blogger-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/blogger-plan-details.jsx
@@ -20,7 +20,7 @@ const BloggerPlanDetails = ( { selectedSite, sitePlans, purchases } ) => {
 
 	return (
 		<div>
-			{ googleAppsWasPurchased && <GoogleAppsDetails isRequired /> }
+			{ googleAppsWasPurchased && <GoogleAppsDetails purchases={ purchases } /> }
 
 			<CustomDomainPurchaseDetail
 				onlyBlogDomain={ true }

--- a/client/my-sites/checkout/checkout-thank-you/business-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/business-plan-details.jsx
@@ -54,7 +54,7 @@ const BusinessPlanDetails = ( {
 
 	return (
 		<div>
-			{ googleAppsWasPurchased && <GoogleAppsDetails isRequired /> }
+			{ googleAppsWasPurchased && <GoogleAppsDetails purchases={ purchases } /> }
 
 			{ shouldPromoteJetpack && (
 				<PurchaseDetail

--- a/client/my-sites/checkout/checkout-thank-you/domain-registration-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/domain-registration-details.jsx
@@ -63,7 +63,7 @@ const DomainRegistrationDetails = ( {
 					/>
 				) }
 
-				{ googleAppsWasPurchased && <GoogleAppsDetails isRequired /> }
+				{ googleAppsWasPurchased && <GoogleAppsDetails purchases={ purchases } /> }
 			</div>
 
 			<PurchaseDetail

--- a/client/my-sites/checkout/checkout-thank-you/ecommerce-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/ecommerce-plan-details.jsx
@@ -34,7 +34,7 @@ const EcommercePlanDetails = ( { selectedSite, sitePlans, selectedFeature, purch
 
 	return (
 		<div>
-			{ googleAppsWasPurchased && <GoogleAppsDetails isRequired /> }
+			{ googleAppsWasPurchased && <GoogleAppsDetails purchases={ purchases } /> }
 
 			<CustomDomainPurchaseDetail
 				selectedSite={ selectedSite }

--- a/client/my-sites/checkout/checkout-thank-you/google-apps-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/google-apps-details.jsx
@@ -7,39 +7,98 @@ import i18n from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { GOOGLE_APPS_LEARNING_CENTER } from 'lib/url/support';
+import { CONTACT, GOOGLE_APPS_LEARNING_CENTER } from 'lib/url/support';
 import PurchaseDetail from 'components/purchase-detail';
 import { useSelector } from 'react-redux';
 import { getCurrentUserEmail } from 'state/current-user/selectors';
+import { isGoogleApps } from 'lib/products-values';
+import { isGSuiteExtraLicenseProductSlug } from 'lib/gsuite';
 
-const GoogleAppsDetails = () => {
+const GoogleAppsDetails = ( { purchases } ) => {
 	const email = useSelector( getCurrentUserEmail );
+
+	const purchase = purchases.find( isGoogleApps );
+
+	if ( isGSuiteExtraLicenseProductSlug( purchase.productSlug ) ) {
+		return (
+			<PurchaseDetail
+				icon="mail"
+				title={ i18n.translate(
+					'Keep an eye on your email to finish setting up your new email addresses'
+				) }
+				description={ i18n.translate(
+					'We are setting up your new G Suite users but {{strong}}this process can take several minutes' +
+						'{{/strong}}. We will email you at %(email)s with login information once they are ready but if ' +
+						"you still haven't received anything after a few hours, do not hesitate to {{link}}contact support{{/link}}.",
+					{
+						components: {
+							strong: <strong />,
+							link: (
+								<a
+									className="checkout-thank-you__gsuite-support-link"
+									href={ CONTACT }
+									rel="noopener noreferrer"
+									target="_blank"
+								/>
+							),
+						},
+						args: {
+							email,
+						},
+					}
+				) }
+				isRequired
+			/>
+		);
+	}
 
 	return (
 		<PurchaseDetail
 			icon="mail"
-			title={ i18n.translate( 'Check your email to finish setting up your G Suite account' ) }
-			description={ i18n.translate(
-				'We emailed you at {{strong}}%(email)s{{/strong}} with login information ' +
-					'so you can start using new professional email addresses and other G Suite apps. ' +
-					'If you can’t find it, try searching “G Suite” in your email inbox. {{link}}Learn more about G Suite{{/link}}',
-				{
-					components: {
-						strong: <strong />,
-						link: (
-							<a
-								className="checkout-thank-you__gsuite-support-link"
-								href={ GOOGLE_APPS_LEARNING_CENTER }
-								rel="noopener noreferrer"
-								target="_blank"
-							/>
-						),
-					},
-					args: {
-						email,
-					},
-				}
+			title={ i18n.translate(
+				'Keep an eye on your email to finish setting up your G Suite account'
 			) }
+			description={
+				<div>
+					<p>
+						{ i18n.translate(
+							'We are setting up your new G Suite account but {{strong}}this process can take several ' +
+								'minutes{{/strong}}. We will email you at %(email)s with login information once it is ' +
+								'ready, so you can start using your new professional email addresses and other G Suite apps.',
+							{
+								components: {
+									strong: <strong />,
+								},
+								args: {
+									email,
+								},
+							}
+						) }
+					</p>
+
+					<p>
+						{ i18n.translate(
+							"If you still haven't received anything after a few hours, do not hesitate to {{link}}contact support{{/link}}.",
+							{
+								components: {
+									link: (
+										<a
+											className="checkout-thank-you__gsuite-support-link"
+											href={ CONTACT }
+											rel="noopener noreferrer"
+											target="_blank"
+										/>
+									),
+								},
+							}
+						) }
+					</p>
+				</div>
+			}
+			buttonText={ i18n.translate( 'Learn more about G Suite' ) }
+			href={ GOOGLE_APPS_LEARNING_CENTER }
+			target="_blank"
+			rel="noopener noreferrer"
 			requiredText={ i18n.translate( 'Almost done! One step remaining…' ) }
 			isRequired
 		/>

--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -21,6 +21,7 @@ import {
 	isPlan,
 	isSiteRedirect,
 } from 'lib/products-values';
+import { isGSuiteExtraLicenseProductSlug, isGSuiteProductSlug } from 'lib/gsuite';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { localize } from 'i18n-calypso';
 import { preventWidows } from 'lib/formatting';
@@ -174,16 +175,21 @@ export class CheckoutThankYouHeader extends PureComponent {
 			);
 		}
 
-		if ( isGoogleApps( primaryPurchase ) ) {
+		if ( isGSuiteProductSlug( primaryPurchase.productSlug ) ) {
 			return preventWidows(
 				translate(
-					'Your domain {{strong}}%(domainName)s{{/strong}} is now set up to use G Suite. ' +
-						"It's doing somersaults in excitement!",
+					'Your domain {{strong}}%(domainName)s{{/strong}} will be using G Suite very soon.',
 					{
 						args: { domainName: primaryPurchase.meta },
 						components: { strong: <strong /> },
 					}
 				)
+			);
+		}
+
+		if ( isGSuiteExtraLicenseProductSlug( primaryPurchase.productSlug ) ) {
+			return preventWidows(
+				translate( 'You will receive an email confirmation shortly for your purchase.' )
 			);
 		}
 

--- a/client/my-sites/checkout/checkout-thank-you/personal-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/personal-plan-details.jsx
@@ -26,7 +26,7 @@ const PersonalPlanDetails = ( { translate, selectedSite, sitePlans, purchases } 
 
 	return (
 		<div>
-			{ googleAppsWasPurchased && <GoogleAppsDetails isRequired /> }
+			{ googleAppsWasPurchased && <GoogleAppsDetails purchases={ purchases } /> }
 
 			<CustomDomainPurchaseDetail
 				selectedSite={ selectedSite }

--- a/client/my-sites/checkout/checkout-thank-you/premium-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/premium-plan-details.jsx
@@ -42,7 +42,7 @@ const PremiumPlanDetails = ( {
 
 	return (
 		<div>
-			{ googleAppsWasPurchased && <GoogleAppsDetails isRequired /> }
+			{ googleAppsWasPurchased && <GoogleAppsDetails purchases={ purchases } /> }
 
 			<CustomDomainPurchaseDetail
 				selectedSite={ selectedSite }


### PR DESCRIPTION
This pull request updates the copy of the `Thank You` page which currently doesn’t convey the asynchronous nature of the G Suite provisioning process - something that leads users to cancel their G Suite subscription if they haven’t received the email with their credentials soon after seeing this page. It also refines the headings which were misleading in some cases:

##### New G Suite account purchased

Before | After
------ | -----
![screenshot](https://user-images.githubusercontent.com/594356/86247933-797a0e80-bbad-11ea-8733-a5c07b916812.png) | ![screenshot](https://user-images.githubusercontent.com/594356/86247983-8a2a8480-bbad-11ea-9ef2-caa0d108c156.png)


##### New G Suite account purchased at the same time than a domain

Before | After
------ | -----
![screenshot](https://user-images.githubusercontent.com/594356/86248195-d70e5b00-bbad-11ea-9bbd-499508a4853f.png)| ![screenshot](https://user-images.githubusercontent.com/594356/86248231-e7bed100-bbad-11ea-9e07-c2c65752333e.png)


##### New G Suite license purchased

Before | After
------ | -----
![screenshot](https://user-images.githubusercontent.com/594356/86248388-1f2d7d80-bbae-11ea-8f9c-7d3b414bf336.png)| ![screenshot](https://user-images.githubusercontent.com/594356/86248409-2785b880-bbae-11ea-9461-4050f94971b6.png)

I've disabled the brown heading in this case as the G Suite account would have already been activated successfully, so it's probably less important to catch the user's attention here. I'm happy to revert that if someone has strong opinion about it though.

#### Testing instructions

1. Run `git checkout update/gsuite-thank-you-copy` and start your server, or open a [live branch](https://calypso.live/?branch=update/gsuite-thank-you-copy)
2. Open the [`Email` page](http://calypso.localhost:3000/email)
3. Purchase a G Suite account
4. Assert that the copy on the `Thank You` page matches what is mentioned above
5. Purchase an additional license for that account
6. Assert that the copy on the `Thank You` page matches what is mentioned above

> Note it is possible to avoid purchasing a new account and additional licenses if you already have a G Suite account. In that case, you can simply locate the receipt id in our Payment Admin, and loads the following url:
> ```
> http://calypso.localhost:3000/checkout/thank-you/:site/:receipt_id
> ```

/cc @fditrapani 