### PR TITLE
Modularise WordAds state

### DIFF
--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -73,7 +73,6 @@ import userDevices from './user-devices/reducer';
 import userProfileLinks from './profile-links/reducer';
 import userSettings from './user-settings/reducer';
 import users from './users/reducer';
-import wordads from './wordads/reducer';
 
 // Legacy reducers
 // The reducers in this list are not modularized, and are always loaded on boot.
@@ -139,7 +138,6 @@ const reducers = {
 	userProfileLinks,
 	userSettings,
 	users,
-	wordads,
 };
 
 export default combineReducers( reducers );

--- a/client/state/selectors/get-wordads-settings.js
+++ b/client/state/selectors/get-wordads-settings.js
@@ -4,6 +4,8 @@
 import createSelector from 'lib/create-selector';
 import { isJetpackSite } from 'state/sites/selectors';
 
+import 'state/wordads/init';
+
 /**
  * Returns the WordAds settings on a certain site.
  * Returns null if the site is unknown, or settings have not been fetched yet.

--- a/client/state/selectors/is-saving-wordads-settings.js
+++ b/client/state/selectors/is-saving-wordads-settings.js
@@ -1,4 +1,9 @@
 /**
+ * Internal dependencies
+ */
+import 'state/wordads/init';
+
+/**
  * Returns true if we are saving the Wordads settings for the specified site ID, false otherwise.
  *
  * @param  {object}  state  Global state tree

--- a/client/state/wordads/approve/actions.js
+++ b/client/state/wordads/approve/actions.js
@@ -1,7 +1,6 @@
 /**
  * Internal dependencies
  */
-
 import wpcom from 'lib/wp';
 import {
 	WORDADS_SITE_APPROVE_REQUEST,
@@ -10,6 +9,8 @@ import {
 	WORDADS_SITE_APPROVE_REQUEST_DISMISS_ERROR,
 	WORDADS_SITE_APPROVE_REQUEST_DISMISS_SUCCESS,
 } from 'state/action-types';
+
+import 'state/wordads/init';
 
 export const requestWordAdsApproval = ( siteId ) => ( dispatch ) => {
 	dispatch( {

--- a/client/state/wordads/approve/selectors.js
+++ b/client/state/wordads/approve/selectors.js
@@ -1,10 +1,15 @@
 /**
+ * Internal dependencies
+ */
+import 'state/wordads/init';
+
+/**
  * Returns true if we're currently requesting WordAds approval
  *
+ * @param   {object} state  Global State
  * @param {number} siteId Site Id
  * @returns {boolean}       requesting state
  */
-
 export function isRequestingWordAdsApproval( state, siteId ) {
 	return !! state.wordads.approve.requesting[ siteId ];
 }

--- a/client/state/wordads/earnings/actions.js
+++ b/client/state/wordads/earnings/actions.js
@@ -1,10 +1,10 @@
 /**
  * Internal dependencies
  */
-
 import { WORDADS_EARNINGS_REQUEST, WORDADS_EARNINGS_RECEIVE } from 'state/action-types';
 
 import 'state/data-layer/wpcom/wordads/earnings';
+import 'state/wordads/init';
 
 export const requestWordadsEarnings = ( siteId ) => ( {
 	type: WORDADS_EARNINGS_REQUEST,

--- a/client/state/wordads/earnings/selectors.js
+++ b/client/state/wordads/earnings/selectors.js
@@ -4,6 +4,11 @@
 import { get } from 'lodash';
 
 /**
+ * Internal dependencies
+ */
+import 'state/wordads/init';
+
+/**
  * Returns earnings object for a siteId
  *
  * @param   {object} state  Global State

--- a/client/state/wordads/init.js
+++ b/client/state/wordads/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'state/redux-store';
+import reducer from './reducer';
+
+registerReducer( [ 'wordads' ], reducer );

--- a/client/state/wordads/package.json
+++ b/client/state/wordads/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/wordads/reducer.js
+++ b/client/state/wordads/reducer.js
@@ -1,16 +1,17 @@
 /**
  * Internal dependencies
  */
-
-import { combineReducers } from 'state/utils';
+import { combineReducers, withStorageKey } from 'state/utils';
 import approve from './approve/reducer';
 import earnings from './earnings/reducer';
 import settings from './settings/reducer';
 import status from './status/reducer';
 
-export default combineReducers( {
+const combinedReducer = combineReducers( {
 	approve,
 	earnings,
 	settings,
 	status,
 } );
+
+export default withStorageKey( 'wordads', combinedReducer );

--- a/client/state/wordads/settings/actions.js
+++ b/client/state/wordads/settings/actions.js
@@ -11,6 +11,7 @@ import {
 } from 'state/action-types';
 
 import 'state/data-layer/wpcom/wordads/settings';
+import 'state/wordads/init';
 
 /**
  * Returns an action object, signalling that WordAds settings for a site have been requested.

--- a/client/state/wordads/status/actions.js
+++ b/client/state/wordads/status/actions.js
@@ -1,11 +1,11 @@
 /**
  * Internal dependencies
  */
-
 import { WORDADS_STATUS_REQUEST, WORDADS_STATUS_RECEIVE } from 'state/action-types';
 import { pick } from 'lodash';
 
 import 'state/data-layer/wpcom/wordads/status';
+import 'state/wordads/init';
 
 export const requestWordadsStatus = ( siteId ) => ( {
 	type: WORDADS_STATUS_REQUEST,

--- a/client/state/wordads/status/selectors.js
+++ b/client/state/wordads/status/selectors.js
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import 'state/wordads/init';
 
 export function isSiteWordadsUnsafe( state, siteId ) {
 	return get( state, [ 'wordads', 'status', siteId, 'unsafe' ], false );


### PR DESCRIPTION
This PR is one of many working on modularising state in Calypso. This one handles WordAds.

For more details on state modularisation, see the [modularised state documentation](https://github.com/Automattic/wp-calypso/blob/master/docs/modularized-state.md) and p4TIVU-9lM-p2.

Note: I added reviewers that GitHub suggested. Please feel free to ignore the review request or pull in someone else if you're not comfortable reviewing this PR. Thank you!

Fixes #42492.

#### Changes proposed in this Pull Request

* Modularise WordAds state

#### Testing instructions

* Install [Redux DevTools](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en).
* Open DevTools and switch to the Redux tab.
* Open `/read` on the live branch or your local copy of this branch.
* Click `State` on the top right to ensure you see all state, and not just the diff for the last action: 
![image](https://user-images.githubusercontent.com/409615/73774406-d3e87d80-477b-11ea-9f59-3e42cc00101f.png)
* Analyse the tree and note that there's no `wordads` key, even if you expand the list of keys. This indicates that the WordAds state hasn't been loaded yet.
* Click `My Sites` on the masterbar, followed by `Tools` and `Earn` on the sidebar.
* Verify that a `wordads` key is added with the WordAds state. This indicates that the WordAds state has now been loaded.
* Verify that WordAds-related functionality works normally. This indicates that I didn't mess up.