### PR TITLE
composite checkout: Add EPS support

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -485,6 +485,8 @@ export default function CompositeCheckout( {
 				genericRedirectProcessor( 'ideal', transactionData, getThankYouUrl, isWhiteGloveOffer ),
 			sofort: ( transactionData ) =>
 				genericRedirectProcessor( 'sofort', transactionData, getThankYouUrl, isWhiteGloveOffer ),
+			eps: ( transactionData ) =>
+				genericRedirectProcessor( 'eps', transactionData, getThankYouUrl, isWhiteGloveOffer ),
 			'full-credits': fullCreditsProcessor,
 			'existing-card': existingCardProcessor,
 			paypal: ( transactionData ) =>

--- a/client/my-sites/checkout/composite-checkout/use-create-payment-methods.js
+++ b/client/my-sites/checkout/composite-checkout/use-create-payment-methods.js
@@ -16,6 +16,8 @@ import {
 	createIdealPaymentMethodStore,
 	createSofortMethod,
 	createSofortPaymentMethodStore,
+	createEpsMethod,
+	createEpsPaymentMethodStore,
 	createFullCreditsMethod,
 	createFreePaymentMethod,
 	createApplePayMethod,
@@ -200,6 +202,30 @@ function useCreateSofort( {
 	);
 }
 
+function useCreateEps( {
+	onlyLoadPaymentMethods,
+	isStripeLoading,
+	stripeLoadingError,
+	stripeConfiguration,
+	stripe,
+} ) {
+	// If this PM is allowed by props, allowed by the cart, stripe is not loading, and there is no stripe error, then create the PM.
+	const isMethodAllowed = onlyLoadPaymentMethods ? onlyLoadPaymentMethods.includes( 'eps' ) : true;
+	const shouldLoad = isMethodAllowed && ! isStripeLoading && ! stripeLoadingError;
+	const paymentMethodStore = useMemo( () => createEpsPaymentMethodStore(), [] );
+	return useMemo(
+		() =>
+			shouldLoad
+				? createEpsMethod( {
+						store: paymentMethodStore,
+						stripe,
+						stripeConfiguration,
+				  } )
+				: null,
+		[ shouldLoad, paymentMethodStore, stripe, stripeConfiguration ]
+	);
+}
+
 function useCreateFullCredits( { onlyLoadPaymentMethods, credits } ) {
 	const shouldLoadFullCreditsMethod = onlyLoadPaymentMethods
 		? onlyLoadPaymentMethods.includes( 'full-credits' )
@@ -343,6 +369,15 @@ export default function useCreatePaymentMethods( {
 		stripeConfiguration,
 		stripe,
 	} );
+
+	const epsMethod = useCreateEps( {
+		onlyLoadPaymentMethods,
+		isStripeLoading,
+		stripeLoadingError,
+		stripeConfiguration,
+		stripe,
+	} );
+
 	const sofortMethod = useCreateSofort( {
 		onlyLoadPaymentMethods,
 		isStripeLoading,
@@ -392,6 +427,7 @@ export default function useCreatePaymentMethods( {
 		sofortMethod,
 		alipayMethod,
 		p24Method,
+		epsMethod,
 		stripeMethod,
 		paypalMethod,
 	].filter( Boolean );

--- a/packages/composite-checkout/src/lib/payment-methods/eps.js
+++ b/packages/composite-checkout/src/lib/payment-methods/eps.js
@@ -1,0 +1,235 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import styled from '@emotion/styled';
+import debugFactory from 'debug';
+import { sprintf } from '@wordpress/i18n';
+import { useI18n } from '@automattic/react-i18n';
+
+/**
+ * Internal dependencies
+ */
+import Field from '../../components/field';
+import Button from '../../components/button';
+import {
+	usePaymentProcessor,
+	useTransactionStatus,
+	useLineItems,
+	renderDisplayValueMarkdown,
+	useEvents,
+} from '../../public-api';
+import { SummaryLine, SummaryDetails } from '../styled-components/summary-details';
+import { useFormStatus } from '../form-status';
+import { registerStore, useSelect, useDispatch } from '../../lib/registry';
+import { PaymentMethodLogos } from '../styled-components/payment-method-logos';
+
+const debug = debugFactory( 'composite-checkout:eps-payment-method' );
+
+export function createEpsPaymentMethodStore() {
+	debug( 'creating a new eps payment method store' );
+	const actions = {
+		changeCustomerName( payload ) {
+			return { type: 'CUSTOMER_NAME_SET', payload };
+		},
+	};
+
+	const selectors = {
+		getCustomerName( state ) {
+			return state.customerName || '';
+		},
+	};
+
+	const store = registerStore( 'eps', {
+		reducer(
+			state = {
+				customerName: { value: '', isTouched: false },
+			},
+			action
+		) {
+			switch ( action.type ) {
+				case 'CUSTOMER_NAME_SET':
+					return { ...state, customerName: { value: action.payload, isTouched: true } };
+			}
+			return state;
+		},
+		actions,
+		selectors,
+	} );
+
+	return { ...store, actions, selectors };
+}
+
+export function createEpsMethod( { store, stripe, stripeConfiguration } ) {
+	return {
+		id: 'eps',
+		label: <EpsLabel />,
+		activeContent: <EpsFields stripe={ stripe } stripeConfiguration={ stripeConfiguration } />,
+		submitButton: (
+			<EpsPayButton store={ store } stripe={ stripe } stripeConfiguration={ stripeConfiguration } />
+		),
+		inactiveContent: <EpsSummary />,
+		getAriaLabel: ( __ ) => __( 'EPS e-Pay' ),
+	};
+}
+
+function EpsFields() {
+	const { __ } = useI18n();
+
+	const customerName = useSelect( ( select ) => select( 'eps' ).getCustomerName() );
+	const { changeCustomerName } = useDispatch( 'eps' );
+	const { formStatus } = useFormStatus();
+	const isDisabled = formStatus !== 'ready';
+
+	return (
+		<EpsFormWrapper>
+			<EpsField
+				id="cardholderName"
+				type="Text"
+				autoComplete="cc-name"
+				label={ __( 'Your name' ) }
+				value={ customerName?.value ?? '' }
+				onChange={ changeCustomerName }
+				isError={ customerName?.isTouched && customerName?.value.length === 0 }
+				errorMessage={ __( 'This field is required' ) }
+				disabled={ isDisabled }
+			/>
+		</EpsFormWrapper>
+	);
+}
+
+const EpsFormWrapper = styled.div`
+	padding: 16px;
+	position: relative;
+
+	:after {
+		display: block;
+		width: calc( 100% - 6px );
+		height: 1px;
+		content: '';
+		background: ${ ( props ) => props.theme.colors.borderColorLight };
+		position: absolute;
+		top: 0;
+		left: 3px;
+
+		.rtl & {
+			left: auto;
+			right: 3px;
+		}
+	}
+`;
+
+const EpsField = styled( Field )`
+	margin-top: 16px;
+
+	:first-of-type {
+		margin-top: 0;
+	}
+`;
+
+function EpsPayButton( { disabled, store, stripe, stripeConfiguration } ) {
+	const { __ } = useI18n();
+	const [ items, total ] = useLineItems();
+	const { formStatus } = useFormStatus();
+	const {
+		setTransactionRedirecting,
+		setTransactionError,
+		setTransactionPending,
+	} = useTransactionStatus();
+	const submitTransaction = usePaymentProcessor( 'eps' );
+	const onEvent = useEvents();
+	const customerName = useSelect( ( select ) => select( 'eps' ).getCustomerName() );
+
+	return (
+		<Button
+			disabled={ disabled }
+			onClick={ () => {
+				if ( isFormValid( store ) ) {
+					debug( 'submitting eps payment' );
+					setTransactionPending();
+					onEvent( { type: 'REDIRECT_TRANSACTION_BEGIN', payload: { paymentMethodId: 'eps' } } );
+					submitTransaction( {
+						stripe,
+						name: customerName?.value,
+						items,
+						total,
+						stripeConfiguration,
+					} )
+						.then( ( stripeResponse ) => {
+							if ( ! stripeResponse?.redirect_url ) {
+								setTransactionError(
+									__(
+										'There was an error processing your payment. Please try again or contact support.'
+									)
+								);
+								return;
+							}
+							debug( 'eps transaction requires redirect', stripeResponse.redirect_url );
+							setTransactionRedirecting( stripeResponse.redirect_url );
+						} )
+						.catch( ( error ) => {
+							setTransactionError( error.message );
+						} );
+				}
+			} }
+			buttonType="primary"
+			isBusy={ 'submitting' === formStatus }
+			fullWidth
+		>
+			<ButtonContents formStatus={ formStatus } total={ total } />
+		</Button>
+	);
+}
+
+function ButtonContents( { formStatus, total } ) {
+	const { __ } = useI18n();
+	if ( formStatus === 'submitting' ) {
+		return __( 'Processing…' );
+	}
+	if ( formStatus === 'ready' ) {
+		return sprintf( __( 'Pay %s' ), renderDisplayValueMarkdown( total.amount.displayValue ) );
+	}
+	return __( 'Please wait…' );
+}
+
+function EpsSummary() {
+	const customerName = useSelect( ( select ) => select( 'eps' ).getCustomerName() );
+
+	return (
+		<SummaryDetails>
+			<SummaryLine>{ customerName?.value }</SummaryLine>
+		</SummaryDetails>
+	);
+}
+
+function isFormValid( store ) {
+	const customerName = store.selectors.getCustomerName( store.getState() );
+
+	if ( ! customerName?.value.length ) {
+		// Touch the field so it displays a validation error
+		store.dispatch( store.actions.changeCustomerName( '' ) );
+		return false;
+	}
+
+	return true;
+}
+
+function EpsLabel() {
+	const { __ } = useI18n();
+	return (
+		<React.Fragment>
+			<span>{ __( 'EPS e-Pay' ) }</span>
+			<PaymentMethodLogos className="eps__logo payment-logos">
+				<EpsLogoUI />
+			</PaymentMethodLogos>
+		</React.Fragment>
+	);
+}
+
+const EpsLogoUI = styled( EpsLogo )`
+	width: 28px;
+`;
+
+function EpsLogo( { className } ) {
+	return <img src="/calypso/images/upgrades/eps.svg" alt="EPS e-Pay" className={ className } />;
+}

--- a/packages/composite-checkout/src/public-api.js
+++ b/packages/composite-checkout/src/public-api.js
@@ -41,6 +41,7 @@ import { createIdealPaymentMethodStore, createIdealMethod } from './lib/payment-
 import { createSofortPaymentMethodStore, createSofortMethod } from './lib/payment-methods/sofort';
 import { createAlipayPaymentMethodStore, createAlipayMethod } from './lib/payment-methods/alipay';
 import { createP24PaymentMethodStore, createP24Method } from './lib/payment-methods/p24';
+import { createEpsPaymentMethodStore, createEpsMethod } from './lib/payment-methods/eps';
 import {
 	createGiropayPaymentMethodStore,
 	createGiropayMethod,
@@ -91,6 +92,8 @@ export {
 	createAlipayMethod,
 	createAlipayPaymentMethodStore,
 	createApplePayMethod,
+	createEpsMethod,
+	createEpsPaymentMethodStore,
 	createExistingCardMethod,
 	createFreePaymentMethod,
 	createFullCreditsMethod,
@@ -98,12 +101,12 @@ export {
 	createGiropayPaymentMethodStore,
 	createIdealMethod,
 	createIdealPaymentMethodStore,
-	createSofortMethod,
-	createSofortPaymentMethodStore,
 	createP24Method,
 	createP24PaymentMethodStore,
 	createPayPalMethod,
 	createRegistry,
+	createSofortMethod,
+	createSofortPaymentMethodStore,
 	createStripeMethod,
 	createStripePaymentMethodStore,
 	defaultRegistry,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add EPS payments support to composite checkout.

![image](https://user-images.githubusercontent.com/9310939/85911058-17558e00-b7e8-11ea-9db5-c0c2b66c3981.png)

#### Testing instructions

- Use D45560-code to force this payment method to be available from the API
- Sandbox the store.
- Add a plan to your cart and visit checkout. 
- Add `?flags=composite-checkout-force` to the query string in the URL and reload the page because currently it is disabled for international currencies.
- Verify that "EPS e-Pay" is an option displayed in the final payment step.
- Verify that you cannot pay if the "Name" field is empty.
- Fill out the "Name" field and submit the payment.
- Verify that you are redirected to a Stripe test page.
- Click to accept the payment and verify that the payment completes successfully and that the plan is purchased.
