### PR TITLE
Queries products associated with a site to hide upsell

### DIFF
--- a/client/components/jetpack/upsell-switch/README.md
+++ b/client/components/jetpack/upsell-switch/README.md
@@ -72,3 +72,5 @@ Required. A component to display with the site has a valid status.
 ### `children`
 
 Optional. Components to display while loading site state.
+### `productSlugTest`
+Optional. Provide a function that takes a string and outputs a boolean to test for the presence of a given product.

--- a/client/components/jetpack/upsell-switch/index.tsx
+++ b/client/components/jetpack/upsell-switch/index.tsx
@@ -77,6 +77,7 @@ function UpsellSwitch( props: Props ): React.ReactElement {
 	const [ uiState, setUiState ] = useState< UiState >( null );
 	const [ showUpsell, setUpsell ] = useState( false );
 
+	// Returns true if this product is present, either as a product or in the plan.
 	const hasProduct = useMemo( () => {
 		if ( ! productSlugTest || ( ! siteProducts && ! sitePlan ) ) {
 			return false;

--- a/client/my-sites/backup/controller.js
+++ b/client/my-sites/backup/controller.js
@@ -17,6 +17,7 @@ import SidebarNavigation from 'my-sites/sidebar-navigation';
 import getRewindState from 'state/selectors/get-rewind-state';
 import QueryRewindState from 'components/data/query-rewind-state';
 import isJetpackCloud from 'lib/jetpack/is-jetpack-cloud';
+import { isJetpackBackupSlug } from 'lib/products-values';
 
 export function showUpsellIfNoBackup( context, next ) {
 	const UpsellComponent = isJetpackCloud() ? BackupUpsell : WPCOMBackupUpsell;
@@ -30,6 +31,7 @@ export function showUpsellIfNoBackup( context, next ) {
 					'uninitialized' === getRewindState( state, siteId )?.state
 				}
 				display={ context.primary }
+				productSlugTest={ isJetpackBackupSlug }
 			>
 				<SidebarNavigation />
 				{ ! isJetpackCloud() && (

--- a/client/my-sites/scan/controller.js
+++ b/client/my-sites/scan/controller.js
@@ -17,6 +17,7 @@ import QueryJetpackScan from 'components/data/query-jetpack-scan';
 import ScanPlaceholder from 'components/jetpack/scan-placeholder';
 import ScanHistoryPlaceholder from 'components/jetpack/scan-history-placeholder';
 import isJetpackCloud from 'lib/jetpack/is-jetpack-cloud';
+import { isJetpackScanSlug } from 'lib/products-values';
 
 export function showUpsellIfNoScan( context, next ) {
 	context.primary = scanUpsellSwitcher( <ScanPlaceholder />, context.primary );
@@ -51,6 +52,7 @@ function scanUpsellSwitcher( placeholder, primary ) {
 				'pending' === getSiteScanRequestStatus( state, siteId )
 			}
 			display={ primary }
+			productSlugTest={ isJetpackScanSlug }
 		>
 			{ placeholder }
 		</UpsellSwitch>

--- a/client/state/sites/selectors/get-site-plan.ts
+++ b/client/state/sites/selectors/get-site-plan.ts
@@ -29,7 +29,10 @@ export interface SitePlan {
  * @param siteId Site ID
  * @returns Site's plan object
  */
-export default function getSitePlan( state, siteId: number ): SitePlan | null {
+export default function getSitePlan( state, siteId: number | null ): SitePlan | null {
+	if ( ! siteId ) {
+		return null;
+	}
 	const site = getRawSite( state, siteId );
 
 	if ( ! site ) {

--- a/client/state/sites/selectors/get-site-products.ts
+++ b/client/state/sites/selectors/get-site-products.ts
@@ -1,0 +1,64 @@
+/**
+ * External dependencies
+ */
+import { DefaultRootState } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import getRawSite from 'state/selectors/get-raw-site';
+
+export interface SiteProduct {
+	productId: number;
+	productSlug: string;
+	productName: string;
+	productNameShort: string | null;
+	expired: boolean;
+	userIsOwner: boolean;
+}
+
+interface RawSiteProduct {
+	product_id: string;
+	product_slug: string;
+	product_name: string;
+	product_name_short: string | null;
+	expired: boolean;
+	user_is_owner: boolean;
+}
+
+interface SiteWithProducts {
+	products: RawSiteProduct[];
+}
+
+function isSiteWithProducts( site: null | object ): site is SiteWithProducts {
+	return ( site as SiteWithProducts ).products !== undefined;
+}
+
+/**
+ * Gets a site's products from the state.
+ *
+ * @param state Redux state.
+ * @param siteId The site ID.
+ */
+export default function getSiteProducts(
+	state: DefaultRootState,
+	siteId: number | null
+): null | SiteProduct[] {
+	if ( ! siteId ) {
+		return null;
+	}
+	const site = getRawSite( state, siteId );
+
+	if ( ! site || ! isSiteWithProducts( site ) ) {
+		return null;
+	}
+
+	return site.products.map( ( product ) => ( {
+		productId: parseInt( product.product_id, 10 ),
+		productSlug: product.product_slug,
+		productName: product.product_name,
+		productNameShort: product.product_name_short || null,
+		expired: !! product.expired,
+		userIsOwner: !! product.user_is_owner,
+	} ) );
+}

--- a/client/state/sites/selectors/index.js
+++ b/client/state/sites/selectors/index.js
@@ -28,6 +28,7 @@ export { default as getSiteOption } from './get-site-option';
 export { default as getSitePlan } from './get-site-plan';
 export { default as getSitePlanSlug } from './get-site-plan-slug';
 export { default as getSitePostsPage } from './get-site-posts-page';
+export { default as getSiteProducts } from './get-site-products';
 export { default as getSiteSlug } from './get-site-slug';
 export { default as getSiteThemeShowcasePath } from './get-site-theme-showcase-path';
 export { default as getSiteTitle } from './get-site-title';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a `productSlugTest`, which allows testing if a given product is purchased for displaying the product upsell.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a connected Jetpack site without Backup.
* Purchase Backup and go through the flow to arrive at Cloud.
* Verify the product upsell does not appear and check the state to see if it is `unavailable`.
* Verify the same for the WordPress.com Jetpack section.
* Break the Jetpack connection.
* Verify the above again.
* Run the same tests, this time with a plan that includes a Backup product.

Fixes 1179060693083348-as-1182126242633417.
