### PR TITLE
Jetpack Scan: standardize main components class names

### DIFF
--- a/client/components/jetpack/scan-history-placeholder/index.tsx
+++ b/client/components/jetpack/scan-history-placeholder/index.tsx
@@ -11,7 +11,7 @@ import './style.scss';
 const ScanHistoryPlaceholder: FunctionComponent = () => {
 	return (
 		<div className="scan-history-placeholder history">
-			<h1 className="scan-history-placeholder__header history__header">History</h1>
+			<h1 className="scan-history-placeholder__header">History</h1>
 			<p className="scan-history-placeholder__content">
 				The scanning history contains a record of all previously active threats on your site.
 			</p>

--- a/client/components/jetpack/scan-history-placeholder/style.scss
+++ b/client/components/jetpack/scan-history-placeholder/style.scss
@@ -3,3 +3,17 @@
 	display: inline-flex;
 	@include placeholder( --color-neutral-10 );
 }
+
+.scan-history-placeholder__header {
+	margin: 32px 0 16px;
+
+	font-size: 28px;
+	line-height: 1;
+
+	@include breakpoint-deprecated( '>660px' ) {
+		margin: 32px 0 24px;
+
+		font-size: 36px;
+		font-weight: 600;
+	}
+}

--- a/client/my-sites/scan/history/index.tsx
+++ b/client/my-sites/scan/history/index.tsx
@@ -36,7 +36,7 @@ export default function ScanHistoryPage( { filter }: Props ) {
 
 	return (
 		<Main
-			className={ classNames( 'history', {
+			className={ classNames( 'scan history', {
 				is_jetpackcom: isJetpackPlatform,
 			} ) }
 		>

--- a/client/my-sites/scan/history/style.scss
+++ b/client/my-sites/scan/history/style.scss
@@ -13,14 +13,6 @@
 	}
 }
 
-.history.is_jetpackcom .section-nav {
-	margin-top: 16px;
-
-	@include breakpoint-deprecated( '>660px' ) {
-		margin-top: 0;
-	}
-}
-
 .history__body {
 	@include breakpoint-deprecated( '<660px' ) {
 		padding: 0 16px;

--- a/client/my-sites/scan/history/style.scss
+++ b/client/my-sites/scan/history/style.scss
@@ -1,18 +1,3 @@
-.history {
-	&__header {
-		color: var( --studio-black );
-		font-size: 28px;
-		line-height: 1;
-		margin: 32px 0 16px;
-
-		@include breakpoint-deprecated( '>660px' ) {
-			font-size: 36px;
-			font-weight: 600;
-			margin: 32px 0 24px;
-		}
-	}
-}
-
 .history__body {
 	@include breakpoint-deprecated( '<660px' ) {
 		padding: 0 16px;

--- a/client/my-sites/scan/style.scss
+++ b/client/my-sites/scan/style.scss
@@ -1,12 +1,4 @@
-.scan.is_jetpackcom .section-nav {
-	margin-top: 16px;
-
-	@include breakpoint-deprecated( '>660px' ) {
-		margin-top: 0;
-	}
-}
-
-.scan__main .formatted-header.is-left-align {
+.scan .formatted-header {
 	margin-top: 20px;
 
 	@include breakpoint-deprecated( '>660px' ) {
@@ -116,5 +108,17 @@
 		@include breakpoint-deprecated( '>660px' ) {
 			margin-top: 64px;
 		}
+	}
+}
+
+/**
+ * Jetpack.com specific styles
+ */
+
+.scan.is_jetpackcom .section-nav {
+	margin-top: 16px;
+
+	@include breakpoint-deprecated( '>660px' ) {
+		margin-top: 0;
 	}
 }

--- a/client/my-sites/scan/upsell.jsx
+++ b/client/my-sites/scan/upsell.jsx
@@ -77,7 +77,7 @@ function renderUpsell( reason ) {
 
 export default function ScanUpsellPage( { reason } ) {
 	return (
-		<Main className="scan__main">
+		<Main className="scan">
 			<DocumentHead title="Scan" />
 			<SidebarNavigation />
 			<PageViewTracker path="/scan/:site" title="Scanner Upsell" />

--- a/client/my-sites/scan/wpcom-scan-upsell.tsx
+++ b/client/my-sites/scan/wpcom-scan-upsell.tsx
@@ -30,7 +30,7 @@ export default function WPCOMScanUpsellPage(): ReactElement {
 	const siteSlug = useSelector( getSelectedSiteSlug );
 
 	return (
-		<Main className="scan__main scan__wpcom-upsell">
+		<Main className="scan scan__wpcom-upsell">
 			<DocumentHead title="Scanner" />
 			<SidebarNavigation />
 			<PageViewTracker path="/scan/:site" title="Scanner" />

--- a/client/my-sites/scan/wpcom-upsell.tsx
+++ b/client/my-sites/scan/wpcom-upsell.tsx
@@ -62,7 +62,7 @@ export default function WPCOMScanUpsellPage(): ReactElement {
 	}, [ planSlug ] );
 
 	return (
-		<Main className="scan__main scan__wpcom-upsell">
+		<Main className="scan scan__wpcom-upsell">
 			<DocumentHead title="Scanner" />
 			<SidebarNavigation />
 			<PageViewTracker path="/scan/:site" title="Scanner" />


### PR DESCRIPTION
#### Changes proposed in this Pull Request

There's some discrepancy in the class names of the high-level pages of the Scan feature. This can cause layout glitches when switching from page to page. This PR fixes it.

It moves the styles of the history placeholder header closer to its component as well.

#### Testing instructions

1. Download the PR and run Calyspo
2. With a Jetpack site that has Scan, go to _Scan > Scanner_ and check that everything looks good (loading and normal state)
3. Switch between Scanner and History and check there's no layout glitch
4. With a Jetpack site that doesn't have Scan, go to _Scan_ and check the upsell page (loading and normal state). An issue tackled in #43698 prevents the display of the upsell for now.
5. Run Jetpack cloud
6. Check that _Scan > Scanner_ and _Scan > History_ still look good