### PR TITLE
Match casing for 'My Plan' to other blocks in the 'Plans' section

### DIFF
--- a/client/my-sites/plans/current-plan/purchases-listing.jsx
+++ b/client/my-sites/plans/current-plan/purchases-listing.jsx
@@ -298,7 +298,7 @@ class PurchasesListing extends Component {
 		return (
 			<Fragment>
 				<Card compact>
-					<strong>{ translate( 'My plan' ) }</strong>
+					<strong>{ translate( 'My Plan' ) }</strong>
 				</Card>
 				{ this.isLoading() ? (
 					<MyPlanCard isPlaceholder />


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* In the Plan section on WordPress.com, change casing from **My plan** to **My Plan** so that it's consistent with other headings on the page.

#### Testing instructions

* Open WordPress.com.
* Go to **Plan** in the **My Sites** sidebar menu.
* Verify that the top header on the **My Plan** subsection is spelled with an uppercase P instead of a lowercase one.

#### Screenshots

##### After

<img width="243" alt="Screen Shot 2020-06-26 at 14 37 02" src="https://user-images.githubusercontent.com/670067/85894924-41dd2200-b7bb-11ea-8656-8df13addee04.png">

##### Before

<img width="221" alt="Screen Shot 2020-06-26 at 14 34 29" src="https://user-images.githubusercontent.com/670067/85894939-49043000-b7bb-11ea-919e-25cc02021b37.png">