### PR TITLE
composite-checkout: display existing cards before any other method

### DIFF
--- a/client/my-sites/checkout/composite-checkout/use-create-payment-methods.js
+++ b/client/my-sites/checkout/composite-checkout/use-create-payment-methods.js
@@ -280,8 +280,8 @@ export default function useCreatePaymentMethods( {
 	return [
 		freePaymentMethod,
 		fullCreditsPaymentMethod,
-		applePayMethod,
 		...existingCardMethods,
+		applePayMethod,
 		idealMethod,
 		giropayMethod,
 		stripeMethod,


### PR DESCRIPTION
This moves a user's existing cards to the top of the payment method options, after free and full credits. The order should be:

- free
- full credits
- existing cards
- apple pay
- any available local methods
- new card
- paypal

ref: p1593269871323900-slack-payments-shilling