### PR TITLE
Hide full-site-editing filter when selected site is not legacy-FSE

### DIFF
--- a/client/state/data-layer/wpcom/theme-filters/index.js
+++ b/client/state/data-layer/wpcom/theme-filters/index.js
@@ -3,6 +3,7 @@
  */
 
 import i18n from 'i18n-calypso';
+import { omit } from 'lodash';
 
 /**
  * Internal dependencies
@@ -11,6 +12,8 @@ import { THEME_FILTERS_REQUEST, THEME_FILTERS_ADD } from 'state/themes/action-ty
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { errorNotice } from 'state/notices/actions';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import isSiteUsingFullSiteEditing from 'state/selectors/is-site-using-full-site-editing';
 
 import { registerHandlers } from 'state/data-layer/handler-registry';
 
@@ -24,16 +27,30 @@ const fetchFilters = ( action ) =>
 		action
 	);
 
-const storeFilters = ( action, data ) => ( { type: THEME_FILTERS_ADD, filters: data } );
+const storeFilters = ( action, data ) => {
+	const filters = action.isFse ? data : omit( data, 'feature.full-site-editing' );
+	return { type: THEME_FILTERS_ADD, filters };
+};
 
 const reportError = () => errorNotice( i18n.translate( 'Problem fetching theme filters.' ) );
 
+const themeFiltersHandlers = dispatchRequest( {
+	fetch: fetchFilters,
+	onSuccess: storeFilters,
+	onError: reportError,
+} );
+
 registerHandlers( 'state/data-layer/wpcom/theme-filters/index.js', {
 	[ THEME_FILTERS_REQUEST ]: [
-		dispatchRequest( {
-			fetch: fetchFilters,
-			onSuccess: storeFilters,
-			onError: reportError,
-		} ),
+		( store, action ) => {
+			const state = store.getState();
+			const selectedSiteId = getSelectedSiteId( state );
+			const isFse = isSiteUsingFullSiteEditing( state, selectedSiteId );
+
+			return themeFiltersHandlers( store, {
+				...action,
+				isFse,
+			} );
+		},
 	],
 } );

--- a/client/state/data-layer/wpcom/theme-filters/index.js
+++ b/client/state/data-layer/wpcom/theme-filters/index.js
@@ -13,7 +13,7 @@ import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { errorNotice } from 'state/notices/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import isSiteUsingFullSiteEditing from 'state/selectors/is-site-using-full-site-editing';
+import isSiteEligibleForFullSiteEditing from 'state/selectors/is-site-eligible-for-full-site-editing';
 
 import { registerHandlers } from 'state/data-layer/handler-registry';
 
@@ -45,7 +45,7 @@ registerHandlers( 'state/data-layer/wpcom/theme-filters/index.js', {
 		( store, action ) => {
 			const state = store.getState();
 			const selectedSiteId = getSelectedSiteId( state );
-			const isFse = isSiteUsingFullSiteEditing( state, selectedSiteId );
+			const isFse = isSiteEligibleForFullSiteEditing( state, selectedSiteId );
 
 			return themeFiltersHandlers( store, {
 				...action,


### PR DESCRIPTION
This PR hides the legacy full site editing filter from the `/themes` magic search card (the advanced search where you can select to search by feature, layout, etc), but reveals it for users with a selected site that is eligible for full site editing.

#### Changes proposed in this Pull Request

* Only show the `feature:full-site-editing` filter on legacy FSE sites, otherwise omit it from being stored in state.

#### Screenshot

![image](https://user-images.githubusercontent.com/14988353/86562261-c131d900-bfa5-11ea-9d8b-71f818397537.png)

In the above screenshot note that if you start typing `full` as the feature, `full-site-editing` does not appear in the list.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* While logged out, go to `/themes`, and from the search card, click "feature", and start typing in `fullsiteediting` — you should not see the option in the list
* While logged in, and with a site that doesn't have the FSE sticker, go to `/themes` and you still shouldn't see the full-site-editing filter in the search card
* While logged in, and with a site selected that _does_ have the FSE sticker, go to `/themes` and you should be able to see the `full-site-editing` filter in the search card, and it should work as expected.

Fixes #39604
