### PR TITLE
Split rest of analytics actions

### DIFF
--- a/client/state/analytics/actions/bump-stat.js
+++ b/client/state/analytics/actions/bump-stat.js
@@ -1,0 +1,18 @@
+/**
+ * Internal dependencies
+ */
+import { ANALYTICS_STAT_BUMP } from 'state/action-types';
+
+export function bumpStat( group, name ) {
+	return {
+		type: ANALYTICS_STAT_BUMP,
+		meta: {
+			analytics: [
+				{
+					type: ANALYTICS_STAT_BUMP,
+					payload: { group, name },
+				},
+			],
+		},
+	};
+}

--- a/client/state/analytics/actions/compose-analytics.js
+++ b/client/state/analytics/actions/compose-analytics.js
@@ -8,7 +8,7 @@ import { ANALYTICS_MULTI_TRACK } from 'state/action-types';
  */
 import { flatMap, property } from 'lodash';
 
-export default function composeAnalytics( ...analytics ) {
+export function composeAnalytics( ...analytics ) {
 	return {
 		type: ANALYTICS_MULTI_TRACK,
 		meta: {

--- a/client/state/analytics/actions/enhance-with-site-type.js
+++ b/client/state/analytics/actions/enhance-with-site-type.js
@@ -18,7 +18,7 @@ import { getSelectedSite } from 'state/ui/selectors';
  * @returns {object} the new Redux action
  * @see client/state/utils/withEnhancers
  */
-export default function enhanceWithSiteType( action, getState ) {
+export function enhanceWithSiteType( action, getState ) {
 	const site = getSelectedSite( getState() );
 
 	if ( site !== null ) {

--- a/client/state/analytics/actions/index.js
+++ b/client/state/analytics/actions/index.js
@@ -1,11 +1,7 @@
 /**
  * Internal dependencies
  */
-import {
-	ANALYTICS_STAT_BUMP,
-	ANALYTICS_TRACKING_ON,
-	ANALYTICS_TRACKS_OPT_OUT,
-} from 'state/action-types';
+import { ANALYTICS_TRACKING_ON, ANALYTICS_TRACKS_OPT_OUT } from 'state/action-types';
 
 /**
  * Re-exports
@@ -23,20 +19,7 @@ export { recordTracksEventWithClientId, recordPageViewWithClientId } from './rec
 export { default as withAnalytics } from './with-analytics';
 export { default as enhanceWithSiteType } from './enhance-with-site-type';
 export { default as composeAnalytics } from './compose-analytics';
-
-export function bumpStat( group, name ) {
-	return {
-		type: ANALYTICS_STAT_BUMP,
-		meta: {
-			analytics: [
-				{
-					type: ANALYTICS_STAT_BUMP,
-					payload: { group, name },
-				},
-			],
-		},
-	};
-}
+export { bumpStat } from './bump-stat';
 
 export function loadTrackingTool( trackingTool ) {
 	return {

--- a/client/state/analytics/actions/index.js
+++ b/client/state/analytics/actions/index.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { ANALYTICS_TRACKING_ON, ANALYTICS_TRACKS_OPT_OUT } from 'state/action-types';
+import { ANALYTICS_TRACKS_OPT_OUT } from 'state/action-types';
 
 /**
  * Re-exports
@@ -20,13 +20,7 @@ export { default as withAnalytics } from './with-analytics';
 export { default as enhanceWithSiteType } from './enhance-with-site-type';
 export { default as composeAnalytics } from './compose-analytics';
 export { bumpStat } from './bump-stat';
-
-export function loadTrackingTool( trackingTool ) {
-	return {
-		type: ANALYTICS_TRACKING_ON,
-		trackingTool,
-	};
-}
+export { loadTrackingTool } from './load-tracking-tool';
 
 export function setTracksOptOut( isOptingOut ) {
 	return {

--- a/client/state/analytics/actions/index.js
+++ b/client/state/analytics/actions/index.js
@@ -1,9 +1,4 @@
 /**
- * Internal dependencies
- */
-import { ANALYTICS_TRACKS_OPT_OUT } from 'state/action-types';
-
-/**
  * Re-exports
  */
 export {
@@ -21,10 +16,4 @@ export { default as enhanceWithSiteType } from './enhance-with-site-type';
 export { default as composeAnalytics } from './compose-analytics';
 export { bumpStat } from './bump-stat';
 export { loadTrackingTool } from './load-tracking-tool';
-
-export function setTracksOptOut( isOptingOut ) {
-	return {
-		type: ANALYTICS_TRACKS_OPT_OUT,
-		isOptingOut,
-	};
-}
+export { setTracksOptOut } from './set-tracks-opt-out';

--- a/client/state/analytics/actions/index.js
+++ b/client/state/analytics/actions/index.js
@@ -11,9 +11,9 @@ export {
 	recordGooglePageView,
 } from './record';
 export { recordTracksEventWithClientId, recordPageViewWithClientId } from './record-with-client-id';
-export { default as withAnalytics } from './with-analytics';
-export { default as enhanceWithSiteType } from './enhance-with-site-type';
-export { default as composeAnalytics } from './compose-analytics';
+export { withAnalytics } from './with-analytics';
+export { enhanceWithSiteType } from './enhance-with-site-type';
+export { composeAnalytics } from './compose-analytics';
 export { bumpStat } from './bump-stat';
 export { loadTrackingTool } from './load-tracking-tool';
 export { setTracksOptOut } from './set-tracks-opt-out';

--- a/client/state/analytics/actions/load-tracking-tool.js
+++ b/client/state/analytics/actions/load-tracking-tool.js
@@ -1,0 +1,11 @@
+/**
+ * Internal dependencies
+ */
+import { ANALYTICS_TRACKING_ON } from 'state/action-types';
+
+export function loadTrackingTool( trackingTool ) {
+	return {
+		type: ANALYTICS_TRACKING_ON,
+		trackingTool,
+	};
+}

--- a/client/state/analytics/actions/set-tracks-opt-out.js
+++ b/client/state/analytics/actions/set-tracks-opt-out.js
@@ -1,0 +1,11 @@
+/**
+ * Internal dependencies
+ */
+import { ANALYTICS_TRACKS_OPT_OUT } from 'state/action-types';
+
+export function setTracksOptOut( isOptingOut ) {
+	return {
+		type: ANALYTICS_TRACKS_OPT_OUT,
+		isOptingOut,
+	};
+}

--- a/client/state/analytics/actions/with-analytics.js
+++ b/client/state/analytics/actions/with-analytics.js
@@ -16,6 +16,4 @@ const joinAnalytics = ( analytics, action ) =>
 		  }
 		: merge( {}, action, { meta: { analytics: mergedMetaData( analytics, action ) } } );
 
-const withAnalytics = curry( joinAnalytics );
-
-export default withAnalytics;
+export const withAnalytics = curry( joinAnalytics );


### PR DESCRIPTION
This is a small PR that splits a few remaining actions away from the index file. This allows us to reference them directly, when we don't want to import from the index (which can end up pulling unwanted code through some tree-shaking quirks).

#### Changes proposed in this Pull Request

* Split out the rest of `state/analytics/actions`, since a few methods were still in the index file
* Use named exports everywhere, for consistency

#### Testing instructions

There are no real code changes here, only a bit of code moving around. The unit tests and a clean build should be enough to ensure that there are no issues.
