### PR TITLE
Split `ui` actions

### DIFF
--- a/client/state/ui/actions/history.js
+++ b/client/state/ui/actions/history.js
@@ -1,0 +1,17 @@
+/**
+ * Internal dependencies
+ */
+import { HISTORY_REPLACE } from 'state/action-types';
+
+/**
+ * Replaces the current url and modifies the browser history entry. Equivalent to window.replaceHistory
+ *
+ * @param {string} path Navigation path
+ * @param {boolean} saveContext true if we should save the current page.js context
+ * @returns {object} Action object
+ */
+export const replaceHistory = ( path, saveContext ) => ( {
+	type: HISTORY_REPLACE,
+	path,
+	saveContext,
+} );

--- a/client/state/ui/actions/index.js
+++ b/client/state/ui/actions/index.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { NAVIGATE, HISTORY_REPLACE } from 'state/action-types';
+import { HISTORY_REPLACE } from 'state/action-types';
 
 /**
  * Re-exports
@@ -11,14 +11,7 @@ export { showMasterbar, hideMasterbar } from '../masterbar-visibility/actions';
 export { setSelectedSiteId, setAllSitesSelected } from './set-sites';
 export { toggleNotificationsPanel } from './notifications';
 export { setPreviewShowing } from './preview';
-
-/**
- * Returns an action object signalling navigation to the given path.
- *
- * @param  {string} path Navigation path
- * @returns {object}      Action object
- */
-export const navigate = ( path ) => ( { type: NAVIGATE, path } );
+export { navigate } from './navigate';
 
 /**
  * Replaces the current url and modifies the browser history entry. Equivalent to window.replaceHistory

--- a/client/state/ui/actions/index.js
+++ b/client/state/ui/actions/index.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { PREVIEW_IS_SHOWING, NAVIGATE, HISTORY_REPLACE } from 'state/action-types';
+import { NAVIGATE, HISTORY_REPLACE } from 'state/action-types';
 
 /**
  * Re-exports
@@ -10,13 +10,7 @@ export { setSection, hideSidebar } from '../section/actions';
 export { showMasterbar, hideMasterbar } from '../masterbar-visibility/actions';
 export { setSelectedSiteId, setAllSitesSelected } from './set-sites';
 export { toggleNotificationsPanel } from './notifications';
-
-export function setPreviewShowing( isShowing ) {
-	return {
-		type: PREVIEW_IS_SHOWING,
-		isShowing,
-	};
-}
+export { setPreviewShowing } from './preview';
 
 /**
  * Returns an action object signalling navigation to the given path.

--- a/client/state/ui/actions/index.js
+++ b/client/state/ui/actions/index.js
@@ -1,10 +1,10 @@
 /**
  * Re-exports
  */
-export { setSection, hideSidebar } from '../section/actions';
-export { showMasterbar, hideMasterbar } from '../masterbar-visibility/actions';
-export { setSelectedSiteId, setAllSitesSelected } from './set-sites';
-export { toggleNotificationsPanel } from './notifications';
-export { setPreviewShowing } from './preview';
 export { navigate } from './navigate';
 export { replaceHistory } from './history';
+export { setPreviewShowing } from './preview';
+export { setSection, hideSidebar } from '../section/actions';
+export { setSelectedSiteId, setAllSitesSelected } from './set-sites';
+export { showMasterbar, hideMasterbar } from '../masterbar-visibility/actions';
+export { toggleNotificationsPanel } from './notifications';

--- a/client/state/ui/actions/index.js
+++ b/client/state/ui/actions/index.js
@@ -1,12 +1,7 @@
 /**
  * Internal dependencies
  */
-import {
-	PREVIEW_IS_SHOWING,
-	NOTIFICATIONS_PANEL_TOGGLE,
-	NAVIGATE,
-	HISTORY_REPLACE,
-} from 'state/action-types';
+import { PREVIEW_IS_SHOWING, NAVIGATE, HISTORY_REPLACE } from 'state/action-types';
 
 /**
  * Re-exports
@@ -14,6 +9,7 @@ import {
 export { setSection, hideSidebar } from '../section/actions';
 export { showMasterbar, hideMasterbar } from '../masterbar-visibility/actions';
 export { setSelectedSiteId, setAllSitesSelected } from './set-sites';
+export { toggleNotificationsPanel } from './notifications';
 
 export function setPreviewShowing( isShowing ) {
 	return {
@@ -21,17 +17,6 @@ export function setPreviewShowing( isShowing ) {
 		isShowing,
 	};
 }
-
-/**
- * Sets ui state to toggle the notifications panel
- *
- * @returns {object} An action object
- */
-export const toggleNotificationsPanel = () => {
-	return {
-		type: NOTIFICATIONS_PANEL_TOGGLE,
-	};
-};
 
 /**
  * Returns an action object signalling navigation to the given path.

--- a/client/state/ui/actions/index.js
+++ b/client/state/ui/actions/index.js
@@ -2,47 +2,18 @@
  * Internal dependencies
  */
 import {
-	SELECTED_SITE_SET,
 	PREVIEW_IS_SHOWING,
 	NOTIFICATIONS_PANEL_TOGGLE,
 	NAVIGATE,
 	HISTORY_REPLACE,
 } from 'state/action-types';
 
-import 'state/data-layer/wpcom/sites/jitm';
-
 /**
  * Re-exports
  */
 export { setSection, hideSidebar } from '../section/actions';
 export { showMasterbar, hideMasterbar } from '../masterbar-visibility/actions';
-
-/**
- * Returns an action object to be used in signalling that a site has been set
- * as selected.
- *
- * @param {number} siteId Site ID
- * @returns {object} Action object
- */
-export function setSelectedSiteId( siteId ) {
-	return {
-		type: SELECTED_SITE_SET,
-		siteId,
-	};
-}
-
-/**
- * Returns an action object to be used in signalling that all sites have been
- * set as selected.
- *
- * @returns {object} Action object
- */
-export function setAllSitesSelected() {
-	return {
-		type: SELECTED_SITE_SET,
-		siteId: null,
-	};
-}
+export { setSelectedSiteId, setAllSitesSelected } from './set-sites';
 
 export function setPreviewShowing( isShowing ) {
 	return {

--- a/client/state/ui/actions/index.js
+++ b/client/state/ui/actions/index.js
@@ -1,9 +1,4 @@
 /**
- * Internal dependencies
- */
-import { HISTORY_REPLACE } from 'state/action-types';
-
-/**
  * Re-exports
  */
 export { setSection, hideSidebar } from '../section/actions';
@@ -12,16 +7,4 @@ export { setSelectedSiteId, setAllSitesSelected } from './set-sites';
 export { toggleNotificationsPanel } from './notifications';
 export { setPreviewShowing } from './preview';
 export { navigate } from './navigate';
-
-/**
- * Replaces the current url and modifies the browser history entry. Equivalent to window.replaceHistory
- *
- * @param {string} path Navigation path
- * @param {boolean} saveContext true if we should save the current page.js context
- * @returns {object} Action object
- */
-export const replaceHistory = ( path, saveContext ) => ( {
-	type: HISTORY_REPLACE,
-	path,
-	saveContext,
-} );
+export { replaceHistory } from './history';

--- a/client/state/ui/actions/navigate.js
+++ b/client/state/ui/actions/navigate.js
@@ -1,0 +1,12 @@
+/**
+ * Internal dependencies
+ */
+import { NAVIGATE } from 'state/action-types';
+
+/**
+ * Returns an action object signalling navigation to the given path.
+ *
+ * @param  {string} path Navigation path
+ * @returns {object}      Action object
+ */
+export const navigate = ( path ) => ( { type: NAVIGATE, path } );

--- a/client/state/ui/actions/notifications.js
+++ b/client/state/ui/actions/notifications.js
@@ -1,0 +1,15 @@
+/**
+ * Internal dependencies
+ */
+import { NOTIFICATIONS_PANEL_TOGGLE } from 'state/action-types';
+
+/**
+ * Sets ui state to toggle the notifications panel
+ *
+ * @returns {object} An action object
+ */
+export const toggleNotificationsPanel = () => {
+	return {
+		type: NOTIFICATIONS_PANEL_TOGGLE,
+	};
+};

--- a/client/state/ui/actions/package.json
+++ b/client/state/ui/actions/package.json
@@ -1,0 +1,3 @@
+{
+	"sideEffects": false
+}

--- a/client/state/ui/actions/preview.js
+++ b/client/state/ui/actions/preview.js
@@ -1,0 +1,11 @@
+/**
+ * Internal dependencies
+ */
+import { PREVIEW_IS_SHOWING } from 'state/action-types';
+
+export function setPreviewShowing( isShowing ) {
+	return {
+		type: PREVIEW_IS_SHOWING,
+		isShowing,
+	};
+}

--- a/client/state/ui/actions/set-sites.js
+++ b/client/state/ui/actions/set-sites.js
@@ -1,0 +1,33 @@
+/**
+ * Internal dependencies
+ */
+import { SELECTED_SITE_SET } from 'state/action-types';
+
+import 'state/data-layer/wpcom/sites/jitm';
+
+/**
+ * Returns an action object to be used in signalling that a site has been set
+ * as selected.
+ *
+ * @param {number} siteId Site ID
+ * @returns {object} Action object
+ */
+export function setSelectedSiteId( siteId ) {
+	return {
+		type: SELECTED_SITE_SET,
+		siteId,
+	};
+}
+
+/**
+ * Returns an action object to be used in signalling that all sites have been
+ * set as selected.
+ *
+ * @returns {object} Action object
+ */
+export function setAllSitesSelected() {
+	return {
+		type: SELECTED_SITE_SET,
+		siteId: null,
+	};
+}


### PR DESCRIPTION
Some `ui` actions live in separate modules, while others are in the index file. This PR splits them all out into smaller, feature-related modules, in preparation for some modularisation work.

#### Changes proposed in this Pull Request

* Split `ui` actions into modules

#### Testing instructions

There are no real code changes in this PR, only a few bits of code moving around. The unit tests and a clean build should be enough to ensure that there are no issues.