### PR TITLE
Fallback to gridicon for missing site icon

### DIFF
--- a/client/reader/components/favicon/index.js
+++ b/client/reader/components/favicon/index.js
@@ -10,7 +10,7 @@ function Favicon( props ) {
 
 	// if loading error or missing icon show W Gridicon
 	if ( hasError || site.site_icon === null ) {
-		return <Gridicon icon="my-sites" size={ 18 } className={ props.className } />;
+		return <Gridicon icon="globe" size={ 18 } className={ props.className } />;
 	}
 
 	return (

--- a/client/reader/components/favicon/index.js
+++ b/client/reader/components/favicon/index.js
@@ -8,8 +8,8 @@ function Favicon( props ) {
 	const { site, className, size } = props;
 	const [ hasError, setError ] = useState( false );
 
-	// if loading error show W Gridicon
-	if ( hasError ) {
+	// if loading error or missing icon show W Gridicon
+	if ( hasError || site.site_icon === null ) {
 		return <Gridicon icon="my-sites" size={ 18 } className={ props.className } />;
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As of D45259-code we are not sending a possible favicon url if we have no blavatar, this adds a fallback to use `W` gridicon if we have no site icon.

#### Testing instructions
Go to Reader -> expand Following Sites -> Sites should either have their site icon or a `W` logo.
