### PR TITLE
InlineHelp: fix visual minor issues

### DIFF
--- a/client/my-sites/customer-home/cards/features/help-search/style.scss
+++ b/client/my-sites/customer-home/cards/features/help-search/style.scss
@@ -169,11 +169,11 @@ $min_results_height: 180px;
 		background-color: var( --color-neutral-5 );
 
 		&:first-child {
-			margin-top: 8px;
+			margin-top: 12px;
 		}
 
 		&:last-child {
-			margin-bottom: 8px;
+			margin-bottom: 12px;
 		}
 
 		&:nth-child( 4 ) {

--- a/client/my-sites/customer-home/cards/features/help-search/style.scss
+++ b/client/my-sites/customer-home/cards/features/help-search/style.scss
@@ -3,7 +3,7 @@
 $search_results_top_spacing: 24px;
 $card_padding_small: 16px;
 $card_padding_large: 24px;
-$min_results_height: 175px;
+$min_results_height: 180px;
 
 .customer-home__layout .help-search {
 
@@ -157,14 +157,14 @@ $min_results_height: 175px;
 	// PlaceholderLines component
 	.inline-help__results-placeholder {
 		min-height: $min_results_height;
-		margin: $search_results_top_spacing 0 0;
+		margin: #{$search_results_top_spacing + 1} #{-$search_results_top_spacing} 0;
 		padding: #{$search_results_top_spacing / 2 - 1px } 0 0 0;
 		border-top: 1px solid var( --color-border-subtle );
 	}
 
 	.inline-help__results-placeholder-item {
 		height: 15px;
-		margin: 20px 0;
+		margin: 20px $card_padding_large 0;
 		border-radius: 16px;
 		background-color: var( --color-neutral-5 );
 

--- a/client/my-sites/customer-home/cards/features/help-search/style.scss
+++ b/client/my-sites/customer-home/cards/features/help-search/style.scss
@@ -157,7 +157,7 @@ $min_results_height: 180px;
 	// PlaceholderLines component
 	.inline-help__results-placeholder {
 		min-height: $min_results_height;
-		margin: #{$search_results_top_spacing + 1} #{-$search_results_top_spacing} 0;
+		margin: #{$search_results_top_spacing + 1} 0 0 #{-$search_results_top_spacing};
 		padding: #{$search_results_top_spacing / 2 - 1px } 0 0 0;
 		border-top: 1px solid var( --color-border-subtle );
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR tweak the `<HelpSearch />` component which renders the support card, rightly rendered in the customer home page.

#### Testing instructions

* Detect these visual issues paying attention to the help search section:

![help-search-visual-issues](https://user-images.githubusercontent.com/77539/86000508-05403f00-b9e4-11ea-84e3-51dd48a91b9c.gif)

* Apply these changes

Confirm it fixes:

* The horizontal line
* placeholder items margin/padding

<img width="671" alt="Screen Shot 2020-06-29 at 10 33 22 AM" src="https://user-images.githubusercontent.com/77539/86012192-0ed1a300-b9f4-11ea-8fd8-4bade1b6ba1d.png">


Fixes https://github.com/Automattic/wp-calypso/issues/43753
