### PR TITLE
Configure apiFetch properly in plans store so it works in wp-admin

### DIFF
--- a/packages/data-stores/package.json
+++ b/packages/data-stores/package.json
@@ -32,6 +32,7 @@
 		"watch": "check-npm-client && tsc --project ./tsconfig.json --watch"
 	},
 	"dependencies": {
+		"@wordpress/api-fetch": "^3.18.0",
 		"@wordpress/data-controls": "^1.4.0",
 		"@wordpress/url": "^2.8.2",
 		"fast-json-stable-stringify": "^2.1.0",

--- a/packages/data-stores/src/plans/resolvers.ts
+++ b/packages/data-stores/src/plans/resolvers.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { apiFetch } from '@wordpress/data-controls';
+import type { APIFetchOptions } from '@wordpress/api-fetch';
 
 /**
  * Internal dependencies
@@ -34,11 +35,17 @@ function getMonthlyPrice( plan: APIPlan ) {
 }
 
 export function* getPrices() {
+	/* the type below (APIFetchOptions) as a blatant lie to TypeScript :D
+	   the data-controls package is mistyped to demand APIFetchOptions
+	   as a parameter, while APIFetchOptions is meant for `@wordpress/api-fetch`,
+	   NOT for { apiFetch } from '@wordpress/data-controls'.
+	*/
 	const plans = yield apiFetch( {
-		path: 'https://public-api.wordpress.com/rest/v1.5/plans',
+		global: true, // needed when used in wp-admin, otherwise wp-admin will add site-prefix (search for wpcomFetchAddSitePrefix)
+		url: 'https://public-api.wordpress.com/rest/v1.5/plans',
 		mode: 'cors',
 		credentials: 'omit',
-	} );
+	} as APIFetchOptions );
 
 	// filter for supported plans
 	const WPCOMPlans: APIPlan[] = plans.filter(

--- a/yarn.lock
+++ b/yarn.lock
@@ -4356,6 +4356,15 @@
     "@wordpress/i18n" "^3.12.0"
     "@wordpress/url" "^2.15.0"
 
+"@wordpress/api-fetch@^3.18.0":
+  version "3.18.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/api-fetch/-/api-fetch-3.18.0.tgz#db34a2e814a2bb295cb2b538ba66925875ae5e3d"
+  integrity sha512-sNT/9yOC9G/G/6QOd4b1d4tckwWS1IrLVulxRFcyhBSorB0XCu07j40nQxhrPKANgi8dLawke4hlfJdlQ9CSZQ==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
+    "@wordpress/i18n" "^3.14.0"
+    "@wordpress/url" "^2.17.0"
+
 "@wordpress/autop@^2.7.0":
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/@wordpress/autop/-/autop-2.7.0.tgz#8cfedffcd3b6f41a6afd59ca4abbab67ea890ae9"
@@ -4888,6 +4897,18 @@
     sprintf-js "^1.1.1"
     tannin "^1.2.0"
 
+"@wordpress/i18n@^3.14.0":
+  version "3.14.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/i18n/-/i18n-3.14.0.tgz#682822d7674ae0ccfd8502737f0094047d196b4e"
+  integrity sha512-FQbSggdvkdS+IWMNhTl3n1nThqfzAPxORvoFpjDma7DOwuRKOA8iPyomwacfeG/krAeaurj1DIDzDvZh9Ex79w==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
+    gettext-parser "^1.3.1"
+    lodash "^4.17.15"
+    memize "^1.1.0"
+    sprintf-js "^1.1.1"
+    tannin "^1.2.0"
+
 "@wordpress/icons@*", "@wordpress/icons@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@wordpress/icons/-/icons-2.0.0.tgz#9a27deb0a629fbe51b5d108de63b21fdd731f205"
@@ -5148,6 +5169,16 @@
   version "2.15.0"
   resolved "https://registry.yarnpkg.com/@wordpress/url/-/url-2.15.0.tgz#76801f246faa289d84538ab9a786daabfd981a9b"
   integrity sha512-nDGZslWZ6TMve3/09O9b2vGaCP2JXoe95uIrkChkw1DVH3tq/tCg1gwQsPXvhBIw5OmopzwlSEuwwp348hyaCA==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
+    lodash "^4.17.15"
+    qs "^6.5.2"
+    react-native-url-polyfill "^1.1.2"
+
+"@wordpress/url@^2.17.0":
+  version "2.17.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/url/-/url-2.17.0.tgz#ef656bc9b576fe7d2146253ee459c9937648b11c"
+  integrity sha512-4OBUy8IKZlobXe41GASw+p5xP/Nvh+HSzfhTN+BU0OggnIsXvZpf0iBYRYGp6M60ne8MkeEoQg9rMM22Osh9Cg==
   dependencies:
     "@babel/runtime" "^7.9.2"
     lodash "^4.17.15"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Unless the request is flagged with `global: true`, WordPress'es `wpcomFetchAddSitePrefix` middleware adds the site prefix (e.g: `site/235423523/`) to every WPCOM API request. This PR marks plans requests as global to prevent that. 

This middleware isn't used in Gutenboarding, that's why we got away with not adding `global` flag up to this point. 

#### Testing instructions

1. In Gutenboarding, make sure the plans grid shows prices.
2. Follow the steps in https://github.com/Automattic/wp-calypso/pull/43593 and make sure the prices show up in the plans grid in wp-admin. This is not very necessary since it's too much work and I already tested.


