### PR TITLE
Gutenboarding: Ensure no line break on every size (at least for English).

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
@@ -12,18 +12,18 @@
 	display: flex;
 	flex-direction: column;
 	margin: 0 -20px;
-	padding: 25px 20px 20px;
+	padding: 24px;
 
 	@include break-small {
 		@include onboarding-heading-text;
 		margin: 0 -44px; // override block margins
-		padding: 0 120px;
+		padding: 48px;
 		justify-content: center;
 	}
 
 	@include break-medium {
 		margin: 0 -88px; // override block margins
-		padding: 12px 170px 0;
+		padding: 64px;
 		font-size: 64px;
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR just ensures there's no line-break on intent gathering label (at least on English language) in all sizes starting from > 320px.

See p1593098213010700-slack-CNMU1UHHB.

#### Testing instructions

* Go to `/new` and resize browser width.

#### Screenshot
![2020-06-29_16-19-44 (1)](https://user-images.githubusercontent.com/1287077/86017717-a5b65380-ba24-11ea-8b07-ea5907c7ce4d.gif)

