### PR TITLE
Modularise invites state

### DIFF
--- a/client/state/invites/actions.js
+++ b/client/state/invites/actions.js
@@ -20,6 +20,8 @@ import {
 	INVITE_RESEND_REQUEST_SUCCESS,
 } from 'state/action-types';
 
+import 'state/invites/init';
+
 /**
  * Triggers a network request to fetch invites for the specified site.
  *

--- a/client/state/invites/init.js
+++ b/client/state/invites/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'state/redux-store';
+import reducer from './reducer';
+
+registerReducer( [ 'invites' ], reducer );

--- a/client/state/invites/package.json
+++ b/client/state/invites/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/invites/reducer.js
+++ b/client/state/invites/reducer.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-case-declarations */
 /**
  * External dependencies
  */
@@ -7,7 +6,12 @@ import { includes, map, pick, zipObject } from 'lodash';
 /**
  * Internal dependencies
  */
-import { combineReducers, withSchemaValidation, withoutPersistence } from 'state/utils';
+import {
+	combineReducers,
+	withSchemaValidation,
+	withoutPersistence,
+	withStorageKey,
+} from 'state/utils';
 import {
 	INVITES_DELETE_REQUEST,
 	INVITES_DELETE_REQUEST_FAILURE,
@@ -176,16 +180,18 @@ export const counts = withoutPersistence( ( state = {}, action ) => {
  */
 export function requestingResend( state = {}, action ) {
 	switch ( action.type ) {
-		case INVITE_RESEND_REQUEST:
+		case INVITE_RESEND_REQUEST: {
 			const inviteResendRequests = Object.assign( {}, state[ action.siteId ], {
 				[ action.inviteId ]: 'requesting',
 			} );
 			return Object.assign( {}, state, { [ action.siteId ]: inviteResendRequests } );
-		case INVITE_RESEND_REQUEST_SUCCESS:
+		}
+		case INVITE_RESEND_REQUEST_SUCCESS: {
 			const inviteResendSuccesses = Object.assign( {}, state[ action.siteId ], {
 				[ action.inviteId ]: 'success',
 			} );
 			return Object.assign( {}, state, { [ action.siteId ]: inviteResendSuccesses } );
+		}
 		case INVITE_RESEND_REQUEST_FAILURE: {
 			const inviteResendFailures = Object.assign( {}, state[ action.siteId ], {
 				[ action.inviteId ]: 'failure',
@@ -208,7 +214,7 @@ export function requestingResend( state = {}, action ) {
  */
 export function deleting( state = {}, action ) {
 	switch ( action.type ) {
-		case INVITES_DELETE_REQUEST:
+		case INVITES_DELETE_REQUEST: {
 			const inviteDeletionRequests = Object.assign(
 				{},
 				state[ action.siteId ],
@@ -218,7 +224,8 @@ export function deleting( state = {}, action ) {
 				)
 			);
 			return Object.assign( {}, state, { [ action.siteId ]: inviteDeletionRequests } );
-		case INVITES_DELETE_REQUEST_FAILURE:
+		}
+		case INVITES_DELETE_REQUEST_FAILURE: {
 			const inviteDeletionFailures = Object.assign(
 				{},
 				state[ action.siteId ],
@@ -228,7 +235,8 @@ export function deleting( state = {}, action ) {
 				)
 			);
 			return Object.assign( {}, state, { [ action.siteId ]: inviteDeletionFailures } );
-		case INVITES_DELETE_REQUEST_SUCCESS:
+		}
+		case INVITES_DELETE_REQUEST_SUCCESS: {
 			const inviteDeletionSuccesses = Object.assign(
 				{},
 				state[ action.siteId ],
@@ -238,12 +246,13 @@ export function deleting( state = {}, action ) {
 				)
 			);
 			return Object.assign( {}, state, { [ action.siteId ]: inviteDeletionSuccesses } );
+		}
 	}
 
 	return state;
 }
 
-export default combineReducers( {
+const combinedReducer = combineReducers( {
 	requesting,
 	items,
 	counts,
@@ -251,3 +260,5 @@ export default combineReducers( {
 	deleting,
 	links,
 } );
+
+export default withStorageKey( 'invites', combinedReducer );

--- a/client/state/invites/selectors.js
+++ b/client/state/invites/selectors.js
@@ -8,6 +8,8 @@ import { get, find, indexOf, values } from 'lodash';
  */
 import treeSelect from '@automattic/tree-select';
 
+import 'state/invites/init';
+
 /**
  * Returns true if currently requesting invites for the given site, or false
  * otherwise.

--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -36,7 +36,6 @@ import immediateLogin from './immediate-login/reducer';
 import importerNux from './importer-nux/reducer';
 import imports from './imports/reducer';
 import inlineSupportArticle from './inline-support-article/reducer';
-import invites from './invites/reducer';
 import jetpackProductInstall from './jetpack-product-install/reducer';
 import jetpackRemoteInstall from './jetpack-remote-install/reducer';
 import jetpackSync from './jetpack-sync/reducer';
@@ -103,7 +102,6 @@ const reducers = {
 	importerNux,
 	imports,
 	inlineSupportArticle,
-	invites,
 	jetpackProductInstall,
 	jetpackRemoteInstall,
 	jetpackSync,


### PR DESCRIPTION
This PR is one of many working on modularising state in Calypso. This one handles invites.

For more details on state modularisation, see the [modularised state documentation](https://github.com/Automattic/wp-calypso/blob/master/docs/modularized-state.md) and p4TIVU-9lM-p2.

Note: I added all the reviewers that GitHub suggested. Please feel free to ignore the review request or pull in someone else if you're not comfortable reviewing this PR. Thank you!

Fixes #42450.

#### Changes proposed in this Pull Request

* Modularise `invites` state
* Minor lint fixes

#### Testing instructions

Invites state gets automatically loaded on boot due to the notifications middleware, so it's difficult to test the automatic loading portion of this PR. It should be enough to smoke-test invite functionality to ensure that this PR doesn't introduce any issues.