### PR TITLE
Misc.: Remove Team Calypso from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,31 +9,11 @@
 #
 # See https://help.github.com/en/articles/about-code-owners for details on the format of this file
 
-# Root level files and configuration
-/*.* @Automattic/team-calypso
-
-# Scripts
-/bin @Automattic/team-calypso
-
-# Client initialization
-/client/boot @Automattic/team-calypso
-
-# Client framework parts
-/client/config @Automattic/team-calypso
-/client/controller @Automattic/team-calypso
-/client/document @Automattic/team-calypso
-/client/layout @Automattic/team-calypso
-
 # Comments management
 /client/my-sites/comment* @Automattic/serenity
 
 # Customer Home
 /client/my-sites/customer-home @Automattic/manage
-
-# Developer guides
-/docs/coding-guidelines @Automattic/team-calypso
-/docs/guide @Automattic/team-calypso
-/docs/testing @Automattic/team-calypso
 
 # G Suite
 /client/components/data/query-gsuite-users @Automattic/cobalt
@@ -91,12 +71,6 @@
 /client/reader @Automattic/reader
 /client/blocks/reader-* @Automattic/reader
 /client/state/reader @Automattic/reader
-
-# Server infrastructure
-/server @Automattic/team-calypso
-
-# Test infrastructure
-/test @Automattic/team-calypso
 
 # Types, TypeScript, and type annotations
 /client/types.ts @Automattic/type-review


### PR DESCRIPTION
This came up during a team discussion.
To start off this work I'm just removing us completely from
CODEOWNERS. We can discuss the actual appropriate scope for
our team in the PR and update it as we make decisions about
what is actually important for us to get notifications for.

#### Changes proposed in this Pull Request

* Update Team Calypso's CODEOWNERS lines to reduce the number of notifications we get.