### PR TITLE
Stats: adding a promotional card to the bottom of the Stats page

### DIFF
--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -11,7 +11,6 @@ import { find } from 'lodash';
 /**
  * Internal dependencies
  */
-import { Card, Button } from '@automattic/components';
 import DocumentHead from 'components/data/document-head';
 import StatsPeriodNavigation from './stats-period-navigation';
 import Main from 'components/main';
@@ -267,36 +266,42 @@ class StatsSite extends Component {
 						</div>
 					</div>
 				</div>
-				<div>
-					{ isFreePlan && (
-						<Card>
-							<h3 className="stats__promo-title">free plan start earning money now</h3>
-							<p>
-								Accept credit and debit card payments today for just about anything – physical and
-								digital goods, services, donations and tips, or access to your exclusive content.
-								Turn your website into a reliable source of income with payments and ads.
-							</p>
-							<Button className="stats__action" href="http://www.url.com">
-								Get started
-							</Button>
-							<div className="stats__illustration">
-								<img src={ earnIllustration } alt="" />
-							</div>
-						</Card>
-					) }
-					{ ! isFreePlan && (
-						<Card>
-							<h3 className="stats__promo-title">paid plan start earning money now</h3>
-							<p>
-								Accept credit and debit card payments today for just about anything – physical and
-								digital goods, services, donations and tips, or access to your exclusive content.
-								Turn your website into a reliable source of income with payments and ads.
-							</p>
-							<div className="stats__illustration">
-								<img src={ earnIllustration } alt="" />
-							</div>
-						</Card>
-					) }
+				<div className="stats__promo">
+					<div className="stats__promo-text">
+						{ isFreePlan && (
+							<>
+								<h2 className="stats__promo-title">{ translate( 'Start earning money now.' ) }</h2>
+								<p>
+									{ translate(
+										'Upgrade to any paid plan and start accepting payments for just about anything – physical and digital goods, services, donations, or access to exclusive content. {{link}}Learn how to get started{{/link}}.',
+										{
+											components: {
+												link: <a href={ `/earn/${ slug }` } />,
+											},
+										}
+									) }
+								</p>
+							</>
+						) }
+						{ ! isFreePlan && (
+							<>
+								<h2 className="stats__promo-title">{ translate( 'Start earning money now.' ) }</h2>
+								<p>
+									{ translate(
+										'Accept credit and debit card payments today for just about anything – physical and digital goods, services, donations and tips, or access to your exclusive content. {{link}}Learn how to get started{{/link}}.',
+										{
+											components: {
+												link: <a href={ `/earn/${ slug }` } />,
+											},
+										}
+									) }
+								</p>
+							</>
+						) }
+					</div>
+					<div className="stats__promo-illustration">
+						<img src={ earnIllustration } alt="" />
+					</div>
 				</div>
 				<JetpackColophon />
 			</>

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -11,6 +11,7 @@ import { find } from 'lodash';
 /**
  * Internal dependencies
  */
+import { Card, Button } from '@automattic/components';
 import DocumentHead from 'components/data/document-head';
 import StatsPeriodNavigation from './stats-period-navigation';
 import Main from 'components/main';
@@ -28,7 +29,7 @@ import StickyPanel from 'components/sticky-panel';
 import JetpackBackupCredsBanner from 'blocks/jetpack-backup-creds-banner';
 import JetpackColophon from 'components/jetpack-colophon';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
-import { isJetpackSite, getSitePlanSlug } from 'state/sites/selectors';
+import { isJetpackSite, getSitePlanSlug, isCurrentPlanPaid } from 'state/sites/selectors';
 import { recordGoogleEvent, recordTracksEvent, withAnalytics } from 'state/analytics/actions';
 import PrivacyPolicyBanner from 'blocks/privacy-policy-banner';
 import QuerySiteKeyrings from 'components/data/query-site-keyrings';
@@ -39,6 +40,12 @@ import QueryJetpackModules from 'components/data/query-jetpack-modules';
 import EmptyContent from 'components/empty-content';
 import { activateModule } from 'state/jetpack/modules/actions';
 import getCurrentRouteParameterized from 'state/selectors/get-current-route-parameterized';
+
+/**
+ * Image dependencies
+ */
+
+import earnIllustration from 'assets/images/customer-home/illustration--task-earn.svg';
 
 function updateQueryString( query = {} ) {
 	return {
@@ -126,7 +133,7 @@ class StatsSite extends Component {
 	};
 
 	renderStats() {
-		const { date, siteId, slug, isJetpack } = this.props;
+		const { date, siteId, slug, isJetpack, isFreePlan } = this.props;
 
 		const queryDate = date.format( 'YYYY-MM-DD' );
 		const { period, endOf } = this.props.period;
@@ -260,6 +267,37 @@ class StatsSite extends Component {
 						</div>
 					</div>
 				</div>
+				<div>
+					{ isFreePlan && (
+						<Card>
+							<h3 className="stats__promo-title">free plan start earning money now</h3>
+							<p>
+								Accept credit and debit card payments today for just about anything – physical and
+								digital goods, services, donations and tips, or access to your exclusive content.
+								Turn your website into a reliable source of income with payments and ads.
+							</p>
+							<Button className="stats__action" href="http://www.url.com">
+								Get started
+							</Button>
+							<div className="stats__illustration">
+								<img src={ earnIllustration } alt="" />
+							</div>
+						</Card>
+					) }
+					{ ! isFreePlan && (
+						<Card>
+							<h3 className="stats__promo-title">paid plan start earning money now</h3>
+							<p>
+								Accept credit and debit card payments today for just about anything – physical and
+								digital goods, services, donations and tips, or access to your exclusive content.
+								Turn your website into a reliable source of income with payments and ads.
+							</p>
+							<div className="stats__illustration">
+								<img src={ earnIllustration } alt="" />
+							</div>
+						</Card>
+					) }
+				</div>
 				<JetpackColophon />
 			</>
 		);
@@ -324,6 +362,7 @@ export default connect(
 			siteId,
 			slug: getSelectedSiteSlug( state ),
 			planSlug: getSitePlanSlug( state, siteId ),
+			isFreePlan: ! isCurrentPlanPaid( state, siteId ),
 			showEnableStatsModule,
 			path: getCurrentRouteParameterized( state, siteId ),
 		};

--- a/client/my-sites/stats/style.scss
+++ b/client/my-sites/stats/style.scss
@@ -59,3 +59,22 @@
 		display: none;
 	}
 }
+
+.stats__promo-title {
+	@extend .wp-brand-font;
+	font-size: 28px;
+	line-height: 36px;
+	margin-bottom: 4px;
+
+	@include breakpoint-deprecated( '>800px' ) {
+		font-size: 32px;
+		line-height: 40px;
+	}
+}
+
+.stats__action {
+	display: flex;
+	padding-top: 0;
+	margin-top: auto;
+	font-size: $font-body-small;
+}

--- a/client/my-sites/stats/style.scss
+++ b/client/my-sites/stats/style.scss
@@ -60,21 +60,49 @@
 	}
 }
 
-.stats__promo-title {
-	@extend .wp-brand-font;
-	font-size: 28px;
-	line-height: 36px;
-	margin-bottom: 4px;
 
-	@include breakpoint-deprecated( '>800px' ) {
-		font-size: 32px;
-		line-height: 40px;
-	}
-}
-
-.stats__action {
+.stats__promo {
 	display: flex;
-	padding-top: 0;
-	margin-top: auto;
-	font-size: $font-body-small;
+	background: var( --color-surface );
+	box-shadow: 0 0 0 1px var( --color-border-subtle );
+	position: relative;
+
+	.stats__promo-text, .stats__promo-illustration {
+		box-sizing: border-box;
+		padding: 24px;
+
+		@include breakpoint-deprecated( '>1040px' ) {
+			padding: 32px;
+		}
+	}
+
+	.stats__promo-text {
+		display: flex;
+		flex-direction: column;
+		align-items: flex-start;
+	}
+
+	.stats__promo-illustration {
+		display: none;
+		@include breakpoint-deprecated( '>800px' ) {
+			width: 33.33%;
+			display: block;
+			align-self: center;
+			flex-shrink: 0;
+			margin-left: auto;
+			text-align: center;
+		}
+	}
+
+	.stats__promo-title {
+		@extend .wp-brand-font;
+		font-size: 28px;
+		line-height: 36px;
+		margin-bottom: 4px;
+
+		@include breakpoint-deprecated( '>800px' ) {
+			font-size: 32px;
+			line-height: 40px;
+		}
+	}
 }


### PR DESCRIPTION
This PR adds a promotional card to the bottom of the Stats page, featuring the Earn features.  Additional context is at pbMlHh-mP-p2.

The copy varies based on whether the custom is on a paid plan. Both CTAs point the customer to the Earn page where they can learn more about the features.

Before:
<img width="1007" alt="Screen Shot 2020-06-29 at 12 36 03 PM" src="https://user-images.githubusercontent.com/35781181/86032318-25342a80-ba05-11ea-8558-e1f8da13232b.png">


After (Free plan):
<img width="1027" alt="Screen Shot 2020-06-29 at 12 35 16 PM" src="https://user-images.githubusercontent.com/35781181/86032268-0b92e300-ba05-11ea-9024-5e1333fa7a6f.png">

After (Paid plan):
<img width="1007" alt="Screen Shot 2020-06-29 at 12 37 33 PM" src="https://user-images.githubusercontent.com/35781181/86032427-56145f80-ba05-11ea-88fb-feb393db1fd7.png">


#### Testing instructions

* Checkout branch (git checkout update/stats-add-earn-card
* Run Calypso (yarn start)
* Click the Stats link in the Calypso left nav once with a Free plan user and once with a Paid plan user.
* Scroll to the bottom and confirm that the correct version of the Earn promo card is displayed.
* Click the links and confirm that they navigate to the Earn page.
