### PR TITLE
Get top level TLD before deciding which cctld forms to display

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -48,7 +48,7 @@ import { fetchPaymentCountries } from 'state/countries/actions';
 import { StateSelect } from 'my-sites/domains/components/form';
 import ManagedContactDetailsFormFields from 'components/domains/contact-details-form-fields/managed-contact-details-form-fields';
 import { getPlan } from 'lib/plans';
-import { getTld } from 'lib/domains';
+import { getTopLevelOfTld } from 'lib/domains';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import { useStripe } from 'lib/stripe';
 import CheckoutTerms from '../checkout/checkout-terms.jsx';
@@ -389,7 +389,7 @@ export default function CompositeCheckout( {
 			! hasDomainRegistration( responseCart ) &&
 			! hasTransferProduct( responseCart );
 		const getIsFieldDisabled = () => isDisabled;
-		const tlds = getAllTlds( domainNames );
+		const tlds = getAllTopLevelTlds( domainNames );
 
 		return (
 			<React.Fragment>
@@ -756,8 +756,8 @@ function getAnalyticsPath( purchaseId, product, selectedSiteSlug, selectedFeatur
 	return { analyticsPath, analyticsProps };
 }
 
-function getAllTlds( domainNames ) {
-	return Array.from( new Set( domainNames.map( getTld ) ) ).sort();
+function getAllTopLevelTlds( domainNames ) {
+	return Array.from( new Set( domainNames.map( getTopLevelOfTld ) ) ).sort();
 }
 
 function displayRenewalSuccessNotice( responseCart, purchases, translate, moment ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* #43391 fixed a theretofore unnoticed bug that caused problems with multi level TLDs, like `me.uk`. This PR ports that fix to composite checkout. Note that composite checkout is not yet live in the countries and currencies most likely to have been affected by this.

#### Testing instructions

Enter checkout with a domain having a multi-level TLD; there's a list of the [ones we support](https://github.com/Automattic/wp-calypso/blob/master/client/lib/domains/tlds/wpcom-multi-level-tlds.json). Choose one where the top level TLD has extra data requirements - `uk`, `ca`, and `fr`. Make sure that you are prompted to enter extra country specific information during checkout.