### PR TITLE
Jetpack Scan: set initial filter option from URL

### DIFF
--- a/client/components/jetpack/threat-history-list/index.jsx
+++ b/client/components/jetpack/threat-history-list/index.jsx
@@ -31,7 +31,7 @@ const filterOptions = [
 	{ value: 'ignored', label: 'Ignored' },
 ];
 
-const ThreatStatusFilter = ( { isPlaceholder, onSelect } ) => {
+const ThreatStatusFilter = ( { isPlaceholder, onSelect, initialSelected } ) => {
 	return isPlaceholder ? (
 		<div className="threat-history-list__filters is-placeholder"></div>
 	) : (
@@ -39,6 +39,7 @@ const ThreatStatusFilter = ( { isPlaceholder, onSelect } ) => {
 			className="threat-history-list__filters"
 			options={ filterOptions }
 			onSelect={ onSelect }
+			initialSelected={ initialSelected }
 			primary
 		/>
 	);
@@ -117,6 +118,7 @@ const ThreatHistoryList = ( {
 				<div className="threat-history-list__filters-wrapper">
 					<ThreatStatusFilter
 						isPlaceholder={ isRequestingHistory }
+						initialSelected={ currentFilter.value }
 						onSelect={ handleOnFilterChange }
 					/>
 				</div>

--- a/client/components/jetpack/threat-history-list/index.tsx
+++ b/client/components/jetpack/threat-history-list/index.tsx
@@ -19,19 +19,45 @@ import getSiteScanHistory from 'state/selectors/get-site-scan-history';
 import contactSupportUrl from 'lib/jetpack/contact-support-url';
 import { withLocalizedMoment } from 'components/localized-moment';
 import { useThreats } from 'lib/jetpack/use-threats';
+import { Threat } from 'components/jetpack/threat-item/types';
 
 /**
  * Style dependencies
  */
 import './style.scss';
 
-const filterOptions = [
+type FilterValue = 'all' | 'fixed' | 'ignored';
+type FilterOption =
+	| {
+			value: 'all';
+			label: 'All';
+	  }
+	| {
+			value: 'fixed';
+			label: 'Fixed';
+	  }
+	| {
+			value: 'ignored';
+			label: 'Ignored';
+	  };
+
+const filterOptions: FilterOption[] = [
 	{ value: 'all', label: 'All' },
 	{ value: 'fixed', label: 'Fixed' },
 	{ value: 'ignored', label: 'Ignored' },
 ];
 
-const ThreatStatusFilter = ( { isPlaceholder, onSelect, initialSelected } ) => {
+interface ThreatStatusFilterProps {
+	isPlaceholder: boolean;
+	onSelect: ( ...args: any[] ) => void;
+	initialSelected: FilterValue;
+}
+
+const ThreatStatusFilter: React.FC< ThreatStatusFilterProps > = ( {
+	isPlaceholder,
+	onSelect,
+	initialSelected,
+} ) => {
 	return isPlaceholder ? (
 		<div className="threat-history-list__filters is-placeholder"></div>
 	) : (
@@ -45,7 +71,17 @@ const ThreatStatusFilter = ( { isPlaceholder, onSelect, initialSelected } ) => {
 	);
 };
 
-const ThreatHistoryList = ( {
+interface ThreatHistoryListProps {
+	siteId: number;
+	siteName: string;
+	siteSlug: string;
+	isRequestingHistory: boolean;
+	threats: Threat[];
+	filter: FilterValue;
+	dispatchRecordTracksEvent: Function;
+}
+
+const ThreatHistoryList: React.FC< ThreatHistoryListProps > = ( {
 	siteId,
 	siteName,
 	siteSlug,
@@ -139,7 +175,6 @@ const ThreatHistoryList = ( {
 						showDialog={ showThreatDialog }
 						onCloseDialog={ closeDialog }
 						onConfirmation={ fixThreat }
-						siteId={ siteId }
 						siteName={ siteName }
 						threat={ selectedThreat }
 						action={ 'fix' }

--- a/client/components/jetpack/threat-history-list/index.tsx
+++ b/client/components/jetpack/threat-history-list/index.tsx
@@ -98,13 +98,14 @@ const mapStateToProps = ( state: DefaultRootState ) => {
 		siteName,
 		siteSlug,
 		isRequestingHistory: showPlaceholders,
-		threats: logEntries,
+		threats: logEntries as Threat[],
 	};
 };
 
 const mapDispatchToProps = { dispatchRecordTracksEvent: recordTracksEvent };
 
-type Props = ExternalProps & typeof mapDispatchToProps & ReturnType< typeof mapStateToProps >;
+type ConnectedProps = typeof mapDispatchToProps & ReturnType< typeof mapStateToProps >;
+type Props = ExternalProps & ConnectedProps;
 
 const ThreatHistoryList: React.FC< Props > = ( {
 	siteId,

--- a/client/components/jetpack/threat-history-list/index.tsx
+++ b/client/components/jetpack/threat-history-list/index.tsx
@@ -94,8 +94,8 @@ const ThreatHistoryList: React.FC< ThreatHistoryListProps > = ( {
 	const [ showThreatDialog, setShowThreatDialog ] = React.useState( false );
 	const dispatch = useDispatch();
 	const handleOnFilterChange = React.useCallback(
-		( filterEntry ) => {
-			let filterValue = filterEntry.value;
+		( filterEntry: FilterOption ) => {
+			let filterValue: FilterValue | '' = filterEntry.value;
 			if ( 'all' === filterValue ) {
 				filterValue = '';
 			}

--- a/client/components/jetpack/threat-history-list/index.tsx
+++ b/client/components/jetpack/threat-history-list/index.tsx
@@ -72,10 +72,6 @@ const ThreatStatusFilter: React.FC< ThreatStatusFilterProps > = ( {
 	);
 };
 
-interface ExternalProps {
-	filter: FilterValue;
-}
-
 const mapStateToProps = ( state: DefaultRootState ) => {
 	const site = getSelectedSite( state ) as Site;
 	const siteId = site.ID;
@@ -103,6 +99,10 @@ const mapStateToProps = ( state: DefaultRootState ) => {
 };
 
 const mapDispatchToProps = { dispatchRecordTracksEvent: recordTracksEvent };
+
+interface ExternalProps {
+	filter: FilterValue;
+}
 
 type ConnectedProps = typeof mapDispatchToProps & ReturnType< typeof mapStateToProps >;
 type Props = ExternalProps & ConnectedProps;

--- a/client/components/jetpack/threat-history-list/index.tsx
+++ b/client/components/jetpack/threat-history-list/index.tsx
@@ -189,7 +189,7 @@ const ThreatHistoryList: React.FC< Props > = ( {
 				{ filteredEntries.map( ( threat ) => (
 					<ThreatItem
 						key={ threat.id }
-						threat={ threat as Threat }
+						threat={ threat }
 						onFixThreat={ () => openDialog( threat ) }
 						isFixing={ !! updatingThreats.find( ( threatId ) => threatId === threat.id ) }
 						contactSupportUrl={ contactSupportUrl( siteSlug ) }

--- a/client/state/selectors/get-site-scan-history.js
+++ b/client/state/selectors/get-site-scan-history.js
@@ -6,6 +6,7 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
+import { Threat } from 'components/jetpack/threat-item/types';
 import 'state/data-layer/wpcom/sites/scan';
 
 /**
@@ -14,7 +15,7 @@ import 'state/data-layer/wpcom/sites/scan';
  *
  * @param  {object}   state    Global state tree
  * @param  {number}   siteId   The ID of the site we're querying
- * @returns {object[]}         Array of threats found
+ * @returns {Threat[]}         Array of threats found
  */
 export default function getSiteScanHistory( state, siteId ) {
 	return get( state, [ 'jetpackScan', 'history', 'data', siteId, 'threats' ], [] );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Currently, the initial state of the filter is not in sync with the URL. A user going to `/scan/history/[site]/fixed` won't see the `Fixed` option as the selected one because the filter always starts with `All` as the default option. This doesn't impact what threats users see, since the data is in sync with the URL, thus, in the previous example user will only see fixed threats.

#### Implementation notes

I took the opportunity to transform the `jsx` into a `tsx` and to configure some basic types. Please feel free to suggests improvements in this regard.

#### Testing instructions

* Prerequisite: self-hosted Jetpack site with Scan and threats in the History section.
* Run this PR (Calypso Blue or Calypso Green).
* Visit `/scan/history/content-cat.jurassic.ninja/fixed`
* Verify the filter highlights the `fixed` option.
* Verify the History section only shows fixed threats.
* Repeat with the `ignored` option.

Fixes 1179060693083348-as-1182457675971209

#### Demo

##### Before
![Kapture 2020-06-29 at 13 42 11](https://user-images.githubusercontent.com/3418513/86042143-1a858f80-ba1d-11ea-88a9-89178954e326.gif)

##### After
![Kapture 2020-06-29 at 15 29 38](https://user-images.githubusercontent.com/3418513/86042351-69cbc000-ba1d-11ea-8662-bdbbd2ad6cf0.gif)
