### PR TITLE
Fix the all-domains redux state to use `withStorageKey` so the state is persistent

### DIFF
--- a/client/state/all-domains/reducer.js
+++ b/client/state/all-domains/reducer.js
@@ -1,6 +1,7 @@
 /**
  * Internal dependencies
  */
+import { combineReducers, withSchemaValidation, withStorageKey } from 'state/utils';
 import {
 	ALL_DOMAINS_REQUEST,
 	ALL_DOMAINS_REQUEST_FAILURE,
@@ -43,8 +44,11 @@ export const requesting = ( state = false, action ) => {
 	return state;
 };
 
-export default combineReducers( {
-	domains: allDomains,
-	requesting,
-	errors,
-} );
+export default withStorageKey(
+	'all-domains',
+	combineReducers( {
+		domains: allDomains,
+		requesting,
+		errors,
+	} )
+);

--- a/client/state/all-domains/reducer.js
+++ b/client/state/all-domains/reducer.js
@@ -1,14 +1,13 @@
 /**
  * Internal dependencies
  */
-import { combineReducers, withSchemaValidation, withStorageKey } from 'state/utils';
 import {
 	ALL_DOMAINS_REQUEST,
 	ALL_DOMAINS_REQUEST_FAILURE,
 	ALL_DOMAINS_REQUEST_SUCCESS,
 } from 'state/action-types';
 import { allDomainsSchema } from './schema';
-import { combineReducers, withSchemaValidation } from 'state/utils';
+import { combineReducers, withSchemaValidation, withStorageKey } from 'state/utils';
 import { createLightSiteDomainObject } from 'state/all-domains/helpers';
 
 export const allDomains = withSchemaValidation( allDomainsSchema, ( state = [], action ) => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* add `withStorageKey` to the all-domains reducer so the state is persistent. I followed the instructions here - https://github.com/Automattic/wp-calypso/blob/master/docs/modularized-state.md

#### Testing instructions

* Load the all domains management screen. Then refresh and verify that it'll first show you the domains before refreshing the data or comment out the `QueryAllDomains` component and check that the domain list will still render
