### PR TITLE
Revert "Move SidebarNavigation component to the all sites controller"

### DIFF
--- a/client/my-sites/domains/domain-management/list/list-all.jsx
+++ b/client/my-sites/domains/domain-management/list/list-all.jsx
@@ -109,8 +109,8 @@ class ListAll extends Component {
 				<div className="list-all__container">
 					<QueryAllDomains />
 					<Main wideLayout>
-						<SidebarNavigation />
 						<DocumentHead title={ translate( 'Domains', { context: 'A navigation label.' } ) } />
+						<SidebarNavigation />
 						<div className="list-all__items">{ this.renderDomainsList() }</div>
 					</Main>
 				</div>


### PR DESCRIPTION
Reverts Automattic/wp-calypso#43699