### PR TITLE
Reader: ensure button block matches main site styles

### DIFF
--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -251,18 +251,12 @@
 		margin: 0;
 		outline: 0;
 		overflow: hidden;
-		text-overflow: ellipsis;
-		text-decoration: none;
 		vertical-align: top;
-		box-sizing: border-box;
 		font-size: 14px;
 		font-weight: 600;
 		line-height: 22px;
 		border-radius: 2px;
 		padding: 8px 14px;
-		-webkit-appearance: none;
-		-moz-appearance: none;
-		appearance: none;
 		border-color: var( --color-neutral-10 );
 	}
 

--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -241,6 +241,31 @@
 		margin: auto;
 	}
 
+	.wp-block-button {
+		font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen-Sans', 'Ubuntu',
+			'Cantarell', 'Helvetica Neue', sans-serif;
+		border-style: solid;
+		border-width: 1px;
+		cursor: pointer;
+		display: inline-block;
+		margin: 0;
+		outline: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		text-decoration: none;
+		vertical-align: top;
+		box-sizing: border-box;
+		font-size: 14px;
+		font-weight: 600;
+		line-height: 22px;
+		border-radius: 2px;
+		padding: 8px 14px;
+		-webkit-appearance: none;
+		-moz-appearance: none;
+		appearance: none;
+		border-color: var( --color-neutral-10 );
+	}
+
 	// Import Gutenberg gallery styles
 	@import 'gutenberg-gallery.scss';
 

--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -242,8 +242,6 @@
 	}
 
 	.wp-block-button {
-		font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen-Sans', 'Ubuntu',
-			'Cantarell', 'Helvetica Neue', sans-serif;
 		border-style: solid;
 		border-width: 1px;
 		cursor: pointer;

--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -241,6 +241,10 @@
 		margin: auto;
 	}
 
+	.wp-block-buttons {
+		margin: 0px;
+	}
+
 	.wp-block-button {
 		border-style: solid;
 		font-family: $sans;
@@ -248,6 +252,8 @@
 		cursor: pointer;
 		display: inline-block;
 		margin: 0;
+		margin-right: 0.25em;
+		margin-bottom: 0.6em;
 		outline: 0;
 		overflow: hidden;
 		vertical-align: top;

--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -242,7 +242,7 @@
 	}
 
 	.wp-block-buttons {
-		margin: 0px;
+		margin: 0;
 	}
 
 	.wp-block-button {

--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -243,6 +243,7 @@
 
 	.wp-block-button {
 		border-style: solid;
+		font-family: $sans;
 		border-width: 1px;
 		cursor: pointer;
 		display: inline-block;
@@ -256,6 +257,11 @@
 		border-radius: 2px;
 		padding: 8px 14px;
 		border-color: var( --color-neutral-10 );
+	}
+
+	.wp-block-button__link,
+	.wp-block-button__link:hover {
+		color: inherit;
 	}
 
 	// Import Gutenberg gallery styles


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This change handles styling the button block in reader to match the website It is only part 1 of 8 of this issue:

https://github.com/Automattic/wp-calypso/issues/43595

#### Testing instructions

Before:

<img width="1291" alt="Screenshot 2020-07-01 13 50 54" src="https://user-images.githubusercontent.com/570876/86194169-eedfe200-bba1-11ea-9cd1-0cf2738225bf.png">

Taken from: http://calypso.localhost:3000/read/blogs/159889361/posts/1363


Firefox After:

<img width="1226" alt="Screenshot 2020-07-01 15 17 40" src="https://user-images.githubusercontent.com/570876/86199369-0cb34400-bbae-11ea-9f0d-651b17f12ed4.png">


