### PR TITLE
Fix - 'Manage all Reusable Blocks' link in the block inserter.

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -617,7 +617,7 @@ function openLinksInParentFrame( calypsoPort ) {
 
 	if ( calypsoifyGutenberg.manageReusableBlocksUrl ) {
 		const manageReusableBlocksLinkSelectors = [
-			'.editor-inserter__manage-reusable-blocks', // Link in the Blocks Inserter
+			'.block-editor-inserter__manage-reusable-blocks', // Link in the Blocks Inserter
 			'a.components-menu-item__button[href*="post_type=wp_block"]', // Link in the More Menu
 		].join( ',' );
 		$( '#editor' ).on( 'click', manageReusableBlocksLinkSelectors, ( e ) => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Attempt to fix #38928 - upon investigation this seems to be due to an outdated selector.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sync wpcom-block-editor build from this PR.
* Test a site with a reusable block (must create a reusable block to see the noted section of the inserter)
* Search for "Reusable" in the block inserter and click the 'Manage all reusable blocks' link.
* Verify this leads you to the blocks management page in calypso.

Fixes #38928
