### PR TITLE
Fix the e2e tests for Calypso and the Activity Log menu move

### DIFF
--- a/client/components/jetpack/sidebar/menu-items/index.jsx
+++ b/client/components/jetpack/sidebar/menu-items/index.jsx
@@ -43,6 +43,7 @@ export default ( { path, showIcons, tracksEventNames, expandSection } ) => {
 		<>
 			<QueryScanState siteId={ siteId } />
 			<SidebarItem
+				tipTarget="activity"
 				icon={ showIcons ? 'clipboard' : undefined }
 				label={ translate( 'Activity Log', {
 					comment: 'Jetpack sidebar menu item',

--- a/test/e2e/lib/components/sidebar-component.js
+++ b/test/e2e/lib/components/sidebar-component.js
@@ -15,7 +15,7 @@ export default class SidebarComponent extends AsyncBaseContainer {
 		super( driver, By.css( '.sidebar' ) );
 		this.storeSelector = By.css( '.menu-link-text[data-e2e-sidebar="Store"]' );
 	}
-	async _postInit(){
+	async _postInit() {
 		return await this.ensureSidebarMenuVisible();
 	}
 
@@ -72,7 +72,7 @@ export default class SidebarComponent extends AsyncBaseContainer {
 	}
 
 	async selectActivity() {
-		await this.expandDrawerItem( 'Tools' );
+		await this.expandDrawerItem( 'Jetpack' );
 		return await this._scrollToAndClickMenuItem( 'activity' );
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix the e2e tests for Calypso because the Activity Log is now under Jetpack. Related to https://github.com/Automattic/wp-calypso/pull/43708

#### Testing instructions

* Verify that the e2e tests finish correctly
