### PR TITLE
Site Settings: Specify Jetpack Connection Owner

### DIFF
--- a/client/my-sites/site-settings/manage-connection/site-ownership.jsx
+++ b/client/my-sites/site-settings/manage-connection/site-ownership.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';

--- a/client/my-sites/site-settings/manage-connection/site-ownership.jsx
+++ b/client/my-sites/site-settings/manage-connection/site-ownership.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
@@ -19,7 +20,8 @@ import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import Gravatar from 'components/gravatar';
 import isJetpackSiteConnected from 'state/selectors/is-jetpack-site-connected';
 import isJetpackSiteInDevelopmentMode from 'state/selectors/is-jetpack-site-in-development-mode';
-import isJetpackUserMaster from 'state/selectors/is-jetpack-user-master';
+import isJetpackUserConnectionOwner from 'state/selectors/is-jetpack-user-connection-owner';
+import getJetpackConnectionOwner from 'state/selectors/get-jetpack-connection-owner';
 import OwnershipInformation from './ownership-information';
 import QueryJetpackConnection from 'components/data/query-jetpack-connection';
 import QueryJetpackUserConnection from 'components/data/query-jetpack-user-connection';
@@ -155,7 +157,13 @@ class SiteOwnership extends Component {
 	}
 
 	renderConnectionDetails() {
-		const { siteIsConnected, siteIsInDevMode, translate, userIsMaster } = this.props;
+		const {
+			connectionOwner,
+			siteIsConnected,
+			siteIsInDevMode,
+			userIsConnectionOwner,
+			translate,
+		} = this.props;
 
 		if ( siteIsConnected === false ) {
 			return translate( 'The site is not connected.' );
@@ -173,14 +181,22 @@ class SiteOwnership extends Component {
 
 		return (
 			<Fragment>
-				{ userIsMaster !== null && (
+				{ userIsConnectionOwner !== null && (
 					<FormSettingExplanation>
-						{ userIsMaster
+						{ userIsConnectionOwner
 							? translate( "You are the owner of this site's connection to WordPress.com." )
-							: translate( "Somebody else owns this site's connection to WordPress.com." ) }
+							: translate(
+									"{{strong}}%(connectionOwner)s{{/strong}} owns this site's connection to WordPress.com.",
+									{
+										args: { connectionOwner },
+										components: {
+											strong: <strong />,
+										},
+									}
+							  ) }
 					</FormSettingExplanation>
 				) }
-				{ userIsMaster && this.renderCurrentUserDropdown() }
+				{ userIsConnectionOwner && this.renderCurrentUserDropdown() }
 			</Fragment>
 		);
 	}
@@ -273,6 +289,7 @@ export default connect(
 
 		return {
 			canManageOptions: canCurrentUser( state, siteId, 'manage_options' ),
+			connectionOwner: getJetpackConnectionOwner( state, siteId ),
 			currentUser: getCurrentUser( state ),
 			isCurrentPlanOwner,
 			isPaidPlan,
@@ -280,7 +297,7 @@ export default connect(
 			siteIsConnected: isJetpackSiteConnected( state, siteId ),
 			siteIsJetpack: isJetpackSite( state, siteId ),
 			siteIsInDevMode: isJetpackSiteInDevelopmentMode( state, siteId ),
-			userIsMaster: isJetpackUserMaster( state, siteId ),
+			userIsConnectionOwner: isJetpackUserConnectionOwner( state, siteId ),
 		};
 	},
 	{ changeOwner, recordTracksEvent, transferPlanOwnership }

--- a/client/state/jetpack/connection/actions.js
+++ b/client/state/jetpack/connection/actions.js
@@ -66,7 +66,7 @@ export const requestJetpackUserConnectionData = ( siteId ) => {
 				dispatch( {
 					type: JETPACK_USER_CONNECTION_DATA_RECEIVE,
 					siteId,
-					data: response.data.currentUser,
+					data: response.data,
 				} );
 				dispatch( {
 					type: JETPACK_USER_CONNECTION_DATA_REQUEST_SUCCESS,

--- a/client/state/jetpack/connection/test/actions.js
+++ b/client/state/jetpack/connection/test/actions.js
@@ -143,18 +143,20 @@ describe( 'actions', () => {
 				} );
 			} );
 
-			test( 'should dispatch success and receive actions when request successfully completes', () => {
-				return requestJetpackUserConnectionData( siteId )( spy ).then( () => {
-					expect( spy ).to.have.been.calledWith( {
-						type: JETPACK_USER_CONNECTION_DATA_RECEIVE,
-						siteId,
-						data,
-					} );
+			test( 'should dispatch success and receive actions when request successfully completes', async () => {
+				await requestJetpackUserConnectionData( siteId )( spy );
 
-					expect( spy ).to.have.been.calledWith( {
-						type: JETPACK_USER_CONNECTION_DATA_REQUEST_SUCCESS,
-						siteId,
-					} );
+				expect( spy ).to.have.been.calledWith( {
+					type: JETPACK_USER_CONNECTION_DATA_RECEIVE,
+					siteId,
+					data: {
+						currentUser: data,
+					},
+				} );
+
+				expect( spy ).to.have.been.calledWith( {
+					type: JETPACK_USER_CONNECTION_DATA_REQUEST_SUCCESS,
+					siteId,
 				} );
 			} );
 		} );

--- a/client/state/selectors/get-jetpack-connection-owner.js
+++ b/client/state/selectors/get-jetpack-connection-owner.js
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import getJetpackUserConnection from 'state/selectors/get-jetpack-user-connection';
+
+/**
+ * Returns the display name of the Jetpack connection's owner.
+ *
+ * @param  {object}   state    Global state tree
+ * @param  {number}   siteId   The ID of the site we're querying
+ * @returns {?string}          The name of the Jetpack connection's owner
+ */
+export default function getJetpackConnectionOwner( state, siteId ) {
+	return get( getJetpackUserConnection( state, siteId ), [ 'connectionOwner' ], null );
+}

--- a/client/state/selectors/is-jetpack-user-connection-owner.js
+++ b/client/state/selectors/is-jetpack-user-connection-owner.js
@@ -10,13 +10,13 @@ import { get } from 'lodash';
 import getJetpackUserConnection from 'state/selectors/get-jetpack-user-connection';
 
 /**
- * Returns true if the Jetpack site current user is the master user who owns the connection. False otherwise.
+ * Returns true if the Jetpack site current user is the user who owns the connection. False otherwise.
  * Returns null if the site is unknown, or there is no information yet.
  *
  * @param  {object}   state    Global state tree
  * @param  {number}   siteId   The ID of the site we're querying
  * @returns {?boolean}          Whether the current site user is the master user.
  */
-export default function isJetpackUserMaster( state, siteId ) {
-	return get( getJetpackUserConnection( state, siteId ), [ 'isMaster' ], null );
+export default function isJetpackUserConnectionOwner( state, siteId ) {
+	return get( getJetpackUserConnection( state, siteId ), 'currentUser.isMaster', null );
 }

--- a/client/state/selectors/is-jetpack-user-connection-owner.js
+++ b/client/state/selectors/is-jetpack-user-connection-owner.js
@@ -15,7 +15,7 @@ import getJetpackUserConnection from 'state/selectors/get-jetpack-user-connectio
  *
  * @param  {object}   state    Global state tree
  * @param  {number}   siteId   The ID of the site we're querying
- * @returns {?boolean}          Whether the current site user is the master user.
+ * @returns {?boolean}          Whether the current site user owns the connection.
  */
 export default function isJetpackUserConnectionOwner( state, siteId ) {
 	return get( getJetpackUserConnection( state, siteId ), 'currentUser.isMaster', null );

--- a/client/state/selectors/test/fixtures/jetpack-connection.js
+++ b/client/state/selectors/test/fixtures/jetpack-connection.js
@@ -38,29 +38,35 @@ export const requests = {
 
 export const dataItems = {
 	12345678: {
-		gravatar: '<img />',
-		isConnected: true,
-		isMaster: true,
-		permissions: {
-			edit_posts: true,
+		currentUser: {
+			gravatar: '<img />',
+			isConnected: true,
+			isMaster: true,
+			permissions: {
+				edit_posts: true,
+			},
+			username: 'automattic',
+			wpcomUser: {
+				ID: 12345678,
+				login: 'automattic',
+			},
 		},
-		username: 'automattic',
-		wpcomUser: {
-			ID: 12345678,
-			login: 'automattic',
-		},
+		connectionOwner: 'exampleuser',
 	},
 	87654321: {
-		gravatar: '<img />',
-		isConnected: true,
-		isMaster: false,
-		permissions: {
-			edit_posts: true,
+		currentUser: {
+			gravatar: '<img />',
+			isConnected: true,
+			isMaster: false,
+			permissions: {
+				edit_posts: true,
+			},
+			username: 'automattic',
+			wpcomUser: {
+				ID: 12345678,
+				login: 'automattic',
+			},
 		},
-		username: 'automattic',
-		wpcomUser: {
-			ID: 12345678,
-			login: 'automattic',
-		},
+		connectionOwner: 'exampleuser',
 	},
 };

--- a/client/state/selectors/test/get-jetpack-connection-owner.js
+++ b/client/state/selectors/test/get-jetpack-connection-owner.js
@@ -1,0 +1,20 @@
+/**
+ * Internal dependencies
+ */
+import getJetpackConnectionOwner from 'state/selectors/get-jetpack-connection-owner';
+import { dataItems } from './fixtures/jetpack-connection';
+
+describe( 'isJetpackUserConnectionOwner()', () => {
+	test( "should return the owner of the Jetpack site's connection", () => {
+		const state = {
+				jetpack: {
+					connection: {
+						dataItems,
+					},
+				},
+			},
+			siteId = 87654321;
+		const output = getJetpackConnectionOwner( state, siteId );
+		expect( output ).toEqual( 'exampleuser' );
+	} );
+} );

--- a/client/state/selectors/test/is-jetpack-user-connection-owner.js
+++ b/client/state/selectors/test/is-jetpack-user-connection-owner.js
@@ -6,11 +6,11 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
-import isJetpackUserMaster from 'state/selectors/is-jetpack-user-master';
+import isJetpackUserConnectionOwner from 'state/selectors/is-jetpack-user-connection-owner';
 import { dataItems } from './fixtures/jetpack-connection';
 
-describe( 'isJetpackUserMaster()', () => {
-	test( "should return true if the user is the master user of the site's connection", () => {
+describe( 'isJetpackUserConnectionOwner()', () => {
+	test( "should return true if the user is the owner of the site's connection", () => {
 		const stateIn = {
 				jetpack: {
 					connection: {
@@ -19,11 +19,11 @@ describe( 'isJetpackUserMaster()', () => {
 				},
 			},
 			siteId = 12345678;
-		const output = isJetpackUserMaster( stateIn, siteId );
+		const output = isJetpackUserConnectionOwner( stateIn, siteId );
 		expect( output ).to.be.true;
 	} );
 
-	test( "should return false if the user is not the master user of the site's connection", () => {
+	test( "should return false if the user is not the owner of the site's connection", () => {
 		const stateIn = {
 				jetpack: {
 					connection: {
@@ -32,7 +32,7 @@ describe( 'isJetpackUserMaster()', () => {
 				},
 			},
 			siteId = 87654321;
-		const output = isJetpackUserMaster( stateIn, siteId );
+		const output = isJetpackUserConnectionOwner( stateIn, siteId );
 		expect( output ).to.be.false;
 	} );
 
@@ -45,7 +45,7 @@ describe( 'isJetpackUserMaster()', () => {
 				},
 			},
 			siteId = 88888888;
-		const output = isJetpackUserMaster( stateIn, siteId );
+		const output = isJetpackUserConnectionOwner( stateIn, siteId );
 		expect( output ).to.be.null;
 	} );
 } );


### PR DESCRIPTION
Requires Automattic/jetpack#16327

#### Changes proposed in this Pull Request

This changes the wording of "Someone else" to a specific username in Site Settings. Although I have no strong views on the language of `master` either, as this PR involves touching those selectors, I've updated them as part of #43303 too.  

#### Testing instructions

Apply the changes on the Jetpack side and visit `/settings/manage-connection/site` from an account which doesn't own the connection.

**Before:**

<img width="829" alt="Screenshot 2020-06-30 at 10 49 51" src="https://user-images.githubusercontent.com/43215253/86112075-71dc3c00-babf-11ea-919f-522c388b2d6f.png">

**After:**

_When not as owner:_

<img width="1005" alt="Screenshot 2020-06-30 at 10 36 55" src="https://user-images.githubusercontent.com/43215253/86111764-114cff00-babf-11ea-871f-9ba6138857fd.png">

_When as owner (no changes):_
<img width="859" alt="Screenshot 2020-06-30 at 10 37 00" src="https://user-images.githubusercontent.com/43215253/86111769-127e2c00-babf-11ea-8b65-4cb4650583ae.png">

cc @joanrho, @ockham 

Fixes #25812
