### PR TITLE
FSE: Run phpcbf on the synced files to fix text domain

### DIFF
--- a/apps/full-site-editing/bin/sync-newspack-blocks.sh
+++ b/apps/full-site-editing/bin/sync-newspack-blocks.sh
@@ -124,9 +124,12 @@ cp -R $CODE/src/blocks/carousel $TARGET/blocks/
 cp -R $CODE/src/shared $TARGET/
 cp -R $CODE/src/components $TARGET/
 
-# Fix the text domain
+echo "Fixing the text domains…"
+echo -n "eslint --fix: "
 npx eslint . --fix > /dev/null 2>&1
-phpcbf $TARGET
+echo "done"
+echo -n "phpcbf: "
+../../vendor/bin/phpcbf -q $TARGET | grep "A TOTAL OF" || exit 1
 
 if [ "$MODE" = "npm" ] ; then
 	# Finds and prints the version of newspack from package.json

--- a/apps/full-site-editing/bin/sync-newspack-blocks.sh
+++ b/apps/full-site-editing/bin/sync-newspack-blocks.sh
@@ -129,7 +129,7 @@ echo -n "eslint --fix: "
 npx eslint . --fix > /dev/null 2>&1
 echo "done"
 echo -n "phpcbf: "
-../../vendor/bin/phpcbf -q $TARGET | grep "A TOTAL OF" || exit 1
+../../vendor/bin/phpcbf -q $TARGET | grep "A TOTAL OF" || echo '!! There was an error executing phpcbf'
 
 if [ "$MODE" = "npm" ] ; then
 	# Finds and prints the version of newspack from package.json

--- a/apps/full-site-editing/bin/sync-newspack-blocks.sh
+++ b/apps/full-site-editing/bin/sync-newspack-blocks.sh
@@ -126,6 +126,7 @@ cp -R $CODE/src/components $TARGET/
 
 # Fix the text domain
 npx eslint . --fix > /dev/null 2>&1
+phpcbf $TARGET
 
 if [ "$MODE" = "npm" ] ; then
 	# Finds and prints the version of newspack from package.json


### PR DESCRIPTION
In the current FSE release we have gettext calls with the wrong text domain: https://plugins.trac.wordpress.org/browser/full-site-editing/trunk/newspack-blocks/synced-newspack-blocks/blocks/homepage-articles/view.php#L218

#### Changes proposed in this Pull Request

* Fix the text domain of the synced newspack blocks

#### Testing instructions

```
cd apps/full-site-editing
yarn run sync:newspack-blocks --branch=master
grep "post author" full-site-editing-plugin/blog-posts-block/newspack-homepage-articles/blocks/homepage-articles/view.php
```

If you receive an error message like `ERROR: Referenced sniff "PHPCompatibility" does not exist` either put your `vendor/bin` directory into the path or make sure that you have installed the sniff (for example with `composer global require phpcompatibility/php-compatibility`).

This should show gettext calls with a parameter `full-site-editing`, not `newspack-blocks`.