### PR TITLE
Modularise post types state

### DIFF
--- a/client/state/post-types/actions.js
+++ b/client/state/post-types/actions.js
@@ -1,10 +1,10 @@
 /**
  * Internal dependencies
  */
-
 import { POST_TYPES_RECEIVE, POST_TYPES_REQUEST } from 'state/action-types';
 
 import 'state/data-layer/wpcom/sites/post-types';
+import 'state/post-types/init';
 
 /**
  * Returns an action object to be used in signalling that post types for a site

--- a/client/state/post-types/init.js
+++ b/client/state/post-types/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'state/redux-store';
+import reducer from './reducer';
+
+registerReducer( [ 'postTypes' ], reducer );

--- a/client/state/post-types/package.json
+++ b/client/state/post-types/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/post-types/reducer.js
+++ b/client/state/post-types/reducer.js
@@ -6,7 +6,7 @@ import { keyBy } from 'lodash';
 /**
  * Internal dependencies
  */
-import { combineReducers, keyedReducer, withSchemaValidation } from 'state/utils';
+import { combineReducers, keyedReducer, withSchemaValidation, withStorageKey } from 'state/utils';
 import { items as itemsSchema } from './schema';
 import taxonomies from './taxonomies/reducer';
 import { POST_TYPES_RECEIVE } from 'state/action-types';
@@ -32,7 +32,9 @@ export const items = withSchemaValidation(
 	} )
 );
 
-export default combineReducers( {
+const combinedReducer = combineReducers( {
 	items,
 	taxonomies,
 } );
+
+export default withStorageKey( 'postTypes', combinedReducer );

--- a/client/state/post-types/selectors.js
+++ b/client/state/post-types/selectors.js
@@ -1,4 +1,9 @@
 /**
+ * Internal dependencies
+ */
+import 'state/post-types/init';
+
+/**
  * Returns the known post types for a site.
  *
  * @param  {object}  state  Global state tree

--- a/client/state/post-types/taxonomies/actions.js
+++ b/client/state/post-types/taxonomies/actions.js
@@ -1,7 +1,6 @@
 /**
  * Internal dependencies
  */
-
 import wpcom from 'lib/wp';
 import {
 	POST_TYPES_TAXONOMIES_RECEIVE,
@@ -9,6 +8,8 @@ import {
 	POST_TYPES_TAXONOMIES_REQUEST_FAILURE,
 	POST_TYPES_TAXONOMIES_REQUEST_SUCCESS,
 } from 'state/action-types';
+
+import 'state/post-types/init';
 
 /**
  * Returns an action object to be used in signalling that post type taxonomies

--- a/client/state/post-types/taxonomies/selectors.js
+++ b/client/state/post-types/taxonomies/selectors.js
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
-
 import { find, get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import 'state/post-types/init';
 
 /**
  * Returns true if a network request is in-progress for the specified site ID,

--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -53,7 +53,6 @@ import pageTemplates from './page-templates/reducer';
 import plans from './plans/reducer';
 import plugins from './plugins/reducer';
 import postFormats from './post-formats/reducer';
-import postTypes from './post-types/reducer';
 import productsList from './products-list/reducer';
 import pushNotifications from './push-notifications/reducer';
 import receipts from './receipts/reducer';
@@ -120,7 +119,6 @@ const reducers = {
 	plans,
 	plugins,
 	postFormats,
-	postTypes,
 	productsList,
 	pushNotifications,
 	receipts,


### PR DESCRIPTION
This PR is one of many working on modularising state in Calypso. This one handles post types.

For more details on state modularisation, see the [modularised state documentation](https://github.com/Automattic/wp-calypso/blob/master/docs/modularized-state.md) and p4TIVU-9lM-p2.

Note: I added reviewers that GitHub suggested. Please feel free to ignore the review request or pull in someone else if you're not comfortable reviewing this PR. Thank you!

Fixes #42469.

#### Changes proposed in this Pull Request

* Modularise post types state

#### Testing instructions

* Install [Redux DevTools](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en).
* Open DevTools and switch to the Redux tab.
* Open `/read` on the live branch or your local copy of this branch.
* Click `State` on the top right to ensure you see all state, and not just the diff for the last action: 
![image](https://user-images.githubusercontent.com/409615/73774406-d3e87d80-477b-11ea-9f59-3e42cc00101f.png)
* Analyse the tree and note that there's no `postTypes` key, even if you expand the list of keys. This indicates that the post types state hasn't been loaded yet.
* Click `My Sites` on the masterbar.
* Verify that a `postTypes` key is added with the post types state. This indicates that the post types state has now been loaded.
* Verify that post types-related functionality works normally. This indicates that I didn't mess up.