### PR TITLE
Donation block: Add block settings

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/donations/donations.js
+++ b/apps/full-site-editing/full-site-editing-plugin/donations/donations.js
@@ -6,53 +6,106 @@ import classNames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { useState } from '@wordpress/element';
+import { InspectorControls, __experimentalBlock as Block } from '@wordpress/block-editor';
+import { Button, ExternalLink, PanelBody, ToggleControl } from '@wordpress/components';
+import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Button } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import StripeNudge from './stripe-nudge';
 
-const Donations = ( { products, stripeConnectUrl } ) => {
+const Donations = ( { attributes, products, setAttributes, siteSlug, stripeConnectUrl } ) => {
+	const { oneTimePlanId, monthlyPlanId, annuallyPlanId, showCustomAmount } = attributes;
 	const [ activeTab, setActiveTab ] = useState( 'one-time' );
 
-	const isActive = ( button ) => ( activeTab === button ? 'active' : null );
+	const isTabActive = ( tab ) => activeTab === tab;
+
+	useEffect( () => {
+		if ( ! oneTimePlanId ) {
+			setAttributes( { oneTimePlanId: products[ 'one-time' ] } );
+		}
+	}, [ oneTimePlanId ] );
 
 	return (
-		<div className="donations__container">
-			{ stripeConnectUrl && <StripeNudge stripeConnectUrl={ stripeConnectUrl } /> }
-			<div className="donations__tabs">
-				<Button className={ isActive( 'one-time' ) } onClick={ () => setActiveTab( 'one-time' ) }>
-					{ __( 'One-Time', 'full-site-editing' ) }
-				</Button>
-				<Button className={ isActive( 'monthly' ) } onClick={ () => setActiveTab( 'monthly' ) }>
-					{ __( 'Monthly', 'full-site-editing' ) }
-				</Button>
-				<Button className={ isActive( 'annually' ) } onClick={ () => setActiveTab( 'annually' ) }>
-					{ __( 'Annually', 'full-site-editing' ) }
-				</Button>
-				<div
-					id="donations__tab-one-time"
-					className={ classNames( 'donations__tab', { active: isActive( 'one-time' ) } ) }
-				>
-					{ __( 'One time', 'full-site-editing' ) }
+		<>
+			<Block.div>
+				{ stripeConnectUrl && <StripeNudge stripeConnectUrl={ stripeConnectUrl } /> }
+				<div className="donations__container">
+					{ ( monthlyPlanId || annuallyPlanId ) && (
+						<div className="donations__tabs">
+							<Button
+								className={ classNames( { 'is-active': isTabActive( 'one-time' ) } ) }
+								onClick={ () => setActiveTab( 'one-time' ) }
+							>
+								{ __( 'One-Time', 'full-site-editing' ) }
+							</Button>
+							{ monthlyPlanId && (
+								<Button
+									className={ classNames( { 'is-active': isTabActive( 'monthly' ) } ) }
+									onClick={ () => setActiveTab( 'monthly' ) }
+								>
+									{ __( 'Monthly', 'full-site-editing' ) }
+								</Button>
+							) }
+							{ annuallyPlanId && (
+								<Button
+									className={ classNames( { 'is-active': isTabActive( 'annually' ) } ) }
+									onClick={ () => setActiveTab( 'annually' ) }
+								>
+									{ __( 'Annually', 'full-site-editing' ) }
+								</Button>
+							) }
+						</div>
+					) }
+					<div className="donations__content">
+						<div>
+							{ isTabActive( 'one-time' ) && __( 'Make a one-time donation', 'full-site-editing' ) }
+							{ isTabActive( 'monthly' ) && __( 'Make a monthly donation', 'full-site-editing' ) }
+							{ isTabActive( 'annually' ) && __( 'Make a yearly donation', 'full-site-editing' ) }
+						</div>
+						{ showCustomAmount && (
+							<div>{ __( 'Or enter a custom amount', 'full-site-editing' ) } </div>
+						) }
+					</div>
 				</div>
-				<div
-					id="donations__tab-monthly"
-					className={ classNames( 'donations__tab', { active: isActive( 'monthly' ) } ) }
-				>
-					{ __( 'Monthly', 'full-site-editing' ) }
-				</div>
-				<div
-					id="donations__tab-annually"
-					className={ classNames( 'donations__tab', { active: isActive( 'annually' ) } ) }
-				>
-					{ __( 'Annually', 'full-site-editing' ) }
-				</div>
-			</div>
-		</div>
+				<InspectorControls>
+					<PanelBody title={ __( 'Settings', 'full-site-editing' ) }>
+						<ToggleControl
+							checked={ !! monthlyPlanId }
+							onChange={ ( showMonthlyDonations ) => {
+								setAttributes( {
+									monthlyPlanId: showMonthlyDonations ? products[ '1 month' ] : null,
+								} );
+							} }
+							label={ __( 'Show monthly donations', 'full-site-editing' ) }
+						/>
+						<ToggleControl
+							checked={ !! annuallyPlanId }
+							onChange={ ( showAnnuallyDonations ) => {
+								setAttributes( {
+									annuallyPlanId: showAnnuallyDonations ? products[ '1 year' ] : null,
+								} );
+							} }
+							label={ __( 'Show annual donations', 'full-site-editing' ) }
+						/>
+						<ToggleControl
+							checked={ showCustomAmount }
+							onChange={ ( newShowCustomAmountValue ) => {
+								setAttributes( {
+									showCustomAmount: newShowCustomAmountValue,
+								} );
+							} }
+							label={ __( 'Show custom amount option', 'full-site-editing' ) }
+						/>
+						<ExternalLink href={ `https://wordpress.com/earn/payments/${ siteSlug }` }>
+							{ __( 'View donation earnings', 'full-site-editing' ) }
+						</ExternalLink>
+					</PanelBody>
+				</InspectorControls>
+			</Block.div>
+		</>
 	);
 };
 

--- a/apps/full-site-editing/full-site-editing-plugin/donations/donations.js
+++ b/apps/full-site-editing/full-site-editing-plugin/donations/donations.js
@@ -29,83 +29,81 @@ const Donations = ( { attributes, products, setAttributes, siteSlug, stripeConne
 	}, [ oneTimePlanId ] );
 
 	return (
-		<>
-			<Block.div>
-				{ stripeConnectUrl && <StripeNudge stripeConnectUrl={ stripeConnectUrl } /> }
-				<div className="donations__container">
-					{ ( monthlyPlanId || annuallyPlanId ) && (
-						<div className="donations__tabs">
+		<Block.div>
+			{ stripeConnectUrl && <StripeNudge stripeConnectUrl={ stripeConnectUrl } /> }
+			<div className="donations__container">
+				{ ( monthlyPlanId || annuallyPlanId ) && (
+					<div className="donations__tabs">
+						<Button
+							className={ classNames( { 'is-active': isTabActive( 'one-time' ) } ) }
+							onClick={ () => setActiveTab( 'one-time' ) }
+						>
+							{ __( 'One-Time', 'full-site-editing' ) }
+						</Button>
+						{ monthlyPlanId && (
 							<Button
-								className={ classNames( { 'is-active': isTabActive( 'one-time' ) } ) }
-								onClick={ () => setActiveTab( 'one-time' ) }
+								className={ classNames( { 'is-active': isTabActive( 'monthly' ) } ) }
+								onClick={ () => setActiveTab( 'monthly' ) }
 							>
-								{ __( 'One-Time', 'full-site-editing' ) }
+								{ __( 'Monthly', 'full-site-editing' ) }
 							</Button>
-							{ monthlyPlanId && (
-								<Button
-									className={ classNames( { 'is-active': isTabActive( 'monthly' ) } ) }
-									onClick={ () => setActiveTab( 'monthly' ) }
-								>
-									{ __( 'Monthly', 'full-site-editing' ) }
-								</Button>
-							) }
-							{ annuallyPlanId && (
-								<Button
-									className={ classNames( { 'is-active': isTabActive( 'annually' ) } ) }
-									onClick={ () => setActiveTab( 'annually' ) }
-								>
-									{ __( 'Annually', 'full-site-editing' ) }
-								</Button>
-							) }
-						</div>
-					) }
-					<div className="donations__content">
-						<div>
-							{ isTabActive( 'one-time' ) && __( 'Make a one-time donation', 'full-site-editing' ) }
-							{ isTabActive( 'monthly' ) && __( 'Make a monthly donation', 'full-site-editing' ) }
-							{ isTabActive( 'annually' ) && __( 'Make a yearly donation', 'full-site-editing' ) }
-						</div>
-						{ showCustomAmount && (
-							<div>{ __( 'Or enter a custom amount', 'full-site-editing' ) } </div>
+						) }
+						{ annuallyPlanId && (
+							<Button
+								className={ classNames( { 'is-active': isTabActive( 'annually' ) } ) }
+								onClick={ () => setActiveTab( 'annually' ) }
+							>
+								{ __( 'Annually', 'full-site-editing' ) }
+							</Button>
 						) }
 					</div>
+				) }
+				<div className="donations__content">
+					<div>
+						{ isTabActive( 'one-time' ) && __( 'Make a one-time donation', 'full-site-editing' ) }
+						{ isTabActive( 'monthly' ) && __( 'Make a monthly donation', 'full-site-editing' ) }
+						{ isTabActive( 'annually' ) && __( 'Make a yearly donation', 'full-site-editing' ) }
+					</div>
+					{ showCustomAmount && (
+						<div>{ __( 'Or enter a custom amount', 'full-site-editing' ) } </div>
+					) }
 				</div>
-				<InspectorControls>
-					<PanelBody title={ __( 'Settings', 'full-site-editing' ) }>
-						<ToggleControl
-							checked={ !! monthlyPlanId }
-							onChange={ ( showMonthlyDonations ) => {
-								setAttributes( {
-									monthlyPlanId: showMonthlyDonations ? products[ '1 month' ] : null,
-								} );
-							} }
-							label={ __( 'Show monthly donations', 'full-site-editing' ) }
-						/>
-						<ToggleControl
-							checked={ !! annuallyPlanId }
-							onChange={ ( showAnnuallyDonations ) => {
-								setAttributes( {
-									annuallyPlanId: showAnnuallyDonations ? products[ '1 year' ] : null,
-								} );
-							} }
-							label={ __( 'Show annual donations', 'full-site-editing' ) }
-						/>
-						<ToggleControl
-							checked={ showCustomAmount }
-							onChange={ ( newShowCustomAmountValue ) => {
-								setAttributes( {
-									showCustomAmount: newShowCustomAmountValue,
-								} );
-							} }
-							label={ __( 'Show custom amount option', 'full-site-editing' ) }
-						/>
-						<ExternalLink href={ `https://wordpress.com/earn/payments/${ siteSlug }` }>
-							{ __( 'View donation earnings', 'full-site-editing' ) }
-						</ExternalLink>
-					</PanelBody>
-				</InspectorControls>
-			</Block.div>
-		</>
+			</div>
+			<InspectorControls>
+				<PanelBody title={ __( 'Settings', 'full-site-editing' ) }>
+					<ToggleControl
+						checked={ !! monthlyPlanId }
+						onChange={ ( showMonthlyDonations ) => {
+							setAttributes( {
+								monthlyPlanId: showMonthlyDonations ? products[ '1 month' ] : null,
+							} );
+						} }
+						label={ __( 'Show monthly donations', 'full-site-editing' ) }
+					/>
+					<ToggleControl
+						checked={ !! annuallyPlanId }
+						onChange={ ( showAnnuallyDonations ) => {
+							setAttributes( {
+								annuallyPlanId: showAnnuallyDonations ? products[ '1 year' ] : null,
+							} );
+						} }
+						label={ __( 'Show annual donations', 'full-site-editing' ) }
+					/>
+					<ToggleControl
+						checked={ showCustomAmount }
+						onChange={ ( newShowCustomAmountValue ) => {
+							setAttributes( {
+								showCustomAmount: newShowCustomAmountValue,
+							} );
+						} }
+						label={ __( 'Show custom amount option', 'full-site-editing' ) }
+					/>
+					<ExternalLink href={ `https://wordpress.com/earn/payments/${ siteSlug }` }>
+						{ __( 'View donation earnings', 'full-site-editing' ) }
+					</ExternalLink>
+				</PanelBody>
+			</InspectorControls>
+		</Block.div>
 	);
 };
 

--- a/apps/full-site-editing/full-site-editing-plugin/donations/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/donations/index.js
@@ -47,7 +47,28 @@ const addPaidBlockFlags = async () => {
 function registerDonationsBlock() {
 	registerBlockType( 'a8c/donations', {
 		title: __( 'Donations (a8c-only)', 'full-site-editing' ),
-		description: __( 'Accept donations on your site.', 'full-site-editing' ),
+		description: __(
+			'Collect one-time, monthly, or annually recurring donations.',
+			'full-site-editing'
+		),
+		attributes: {
+			oneTimePlanId: {
+				type: 'number',
+				default: null,
+			},
+			monthlyPlanId: {
+				type: 'number',
+				default: null,
+			},
+			annuallyPlanId: {
+				type: 'number',
+				default: null,
+			},
+			showCustomAmount: {
+				type: 'boolean',
+				default: false,
+			},
+		},
 		category: 'common',
 		icon: (
 			<svg
@@ -80,13 +101,6 @@ function registerDonationsBlock() {
 		supports: {
 			html: false,
 		},
-		keywords: [
-			'donations',
-			/* translators: block keyword */
-			__( 'premium', 'full-site-editing' ),
-			/* translators: block keyword */
-			__( 'paywall', 'full-site-editing' ),
-		],
 		edit,
 		save() {
 			return <div>Donations block</div>;

--- a/apps/full-site-editing/full-site-editing-plugin/donations/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/donations/style.scss
@@ -1,39 +1,38 @@
-.donations__tabs {
-  border: 1px solid #ddd;
-  display: grid;
-  grid-template-columns: repeat( 3, 1fr );
-}
+.donations__container {
+	border: 1px solid #a7aaad;
 
-.donations__tabs .components-button {
-  border-bottom: 1px solid #ddd;
-}
+	.donations__tabs {
+		display: flex;
+		border-bottom: 1px solid #a7aaad;
 
-.donations__tabs .components-button:first-child.active {
-  border-right: 1px solid #ddd;
-}
+		.components-button {
+			font-weight: bold;
+			display: inline-block;
+			flex-grow: 1;
+			text-align: center;
+			font-size: 16px;
+			padding: 16px;
+			height: auto;
+			border-radius: 0;
+			border-left: 1px solid #a7aaad;
 
-.donations__tabs .components-button:nth-child( 2 ).active {
-  border-left: 1px solid #ddd;
-  border-right: 1px solid #ddd;
-}
+			&:first-child {
+				border-left: none;
+			}
 
-.donations__tabs .components-button:nth-child( 3 ).active {
-  border-left: 1px solid #ddd;
-}
+			&:hover {
+				color: inherit;
+			}
 
-.donations__tabs .components-button.active {
-  border-bottom: none;
-}
+			&.is-active {
+				background-color: #2271b1;
+				box-shadow: none;
+				color: #fff;
+			}
+		}
+	}
 
-.donations__tab {
-  grid-area: 2/1/2/4;
-  visibility: hidden;
-}
-
-.donations__tab.active {
-  visibility: visible;
-}
-
-.donations__nudge {
-  margin-bottom: 32px;
+	.donations__content {
+		padding: 24px;
+	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add a settings panel to the Donation block so user can toggle monthly, annual, and “Other” amount options on or off.

![Jun-30-2020 16-00-51](https://user-images.githubusercontent.com/1233880/86135568-4e2eeb00-baeb-11ea-9cc1-0b822f9efe2c.gif)

#### Testing instructions

* Generate a new FSE build and sync it to your sandbox: `cd apps/full-site-editing; yarn dev --sync`.
* Sandbox the API and the store. More info in PCYsg-lW4-p2 #sandbox-method.
* Sandbox a test site with a paid plan, and ensure the site has the `fse-donations-block` blog sticker applied (if not, it can be done from the site's Blog RC).
* Insert a Donations block in a new post with the block editor.
* Verify you can toggle all the settings in the right sidebar and the UI updates accordingly.
* Save the post and reload the editor.
* Make sure the block loads with the previous state.
* Switch to the code editor and confirm the attributes are correctly serialized. You should get something like this if all settings are enabled:
```
<!-- wp:a8c/donations {"oneTimePlanId":573,"monthlyPlanId":569,"annuallyPlanId":570,"showCustomAmount":true} -->
<div class="wp-block-a8c-donations">Donations block</div>
<!-- /wp:a8c/donations -->
```

Part of #42856
