### PR TITLE
Accept currentDomain as a string in domain picker

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/editor-domain-picker/src/domain-picker-modal/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-domain-picker/src/domain-picker-modal/index.tsx
@@ -28,7 +28,7 @@ const DomainPickerModal: React.FunctionComponent< Props > = ( { isOpen, onClose,
 			onRequestClose={ onClose }
 			title=""
 		>
-			<DomainPicker showDomainCategories { ...props } />
+			<DomainPicker { ...props } />
 		</Modal>
 	);
 };

--- a/client/landing/gutenboarding/onboarding-block/domains/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/domains/index.tsx
@@ -87,7 +87,7 @@ const DomainsStep: React.FunctionComponent< Props > = ( { isModal } ) => {
 				analyticsFlowId={ FLOW_ID }
 				initialDomainSearch={ domainSearch }
 				onSetDomainSearch={ setDomainSearch }
-				currentDomain={ domain }
+				currentDomain={ domain?.domain_name }
 				onDomainSelect={ onDomainSelect }
 				analyticsUiAlgo={ isModal ? 'domain_modal' : 'domain_page' }
 			/>

--- a/packages/domain-picker/src/domain-picker/index.tsx
+++ b/packages/domain-picker/src/domain-picker/index.tsx
@@ -48,7 +48,7 @@ export interface Props {
 	/** Domain suggestions to show when the picker is expanded */
 	quantityExpanded?: number;
 
-	currentDomain?: DomainSuggestion;
+	currentDomain?: string;
 
 	/** The flow where the Domain Picker is used. Eg: Gutenboarding */
 	analyticsFlowId: string;
@@ -73,12 +73,11 @@ const DomainPicker: FunctionComponent< Props > = ( {
 	analyticsUiAlgo,
 	initialDomainSearch = '',
 	onSetDomainSearch,
+	currentDomain,
 } ) => {
 	const { __ } = useI18n();
 	const label = __( 'Search for a domain' );
 
-	// We're not keeping the current selection in local state at the moment
-	//const [ currentSelection, setCurrentSelection ] = useState( currentDomain );
 	const [ isExpanded, setIsExpanded ] = useState( false );
 
 	// keep domain query in local state to allow free editing of the input value while the modal is open
@@ -180,6 +179,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 					<div className="domain-picker__suggestion-item-group">
 						{ domainSuggestions?.map( ( suggestion, i ) => (
 							<SuggestionItem
+								selected={ currentDomain === suggestion.domain_name }
 								key={ suggestion.domain_name }
 								suggestion={ suggestion }
 								railcarId={ baseRailcarId ? `${ baseRailcarId }${ i }` : undefined }

--- a/packages/domain-picker/src/domain-picker/style.scss
+++ b/packages/domain-picker/src/domain-picker/style.scss
@@ -69,6 +69,12 @@
 		cursor: default;
 	}
 
+	&.is-selected {
+		background: var( --studio-blue-0 );
+		border-color: var( --studio-blue-40 );
+		z-index: 2;
+	}
+
 	&:hover,
 	&:focus {
 		&:not( .placeholder ) {

--- a/packages/domain-picker/src/domain-picker/suggestion-item.tsx
+++ b/packages/domain-picker/src/domain-picker/suggestion-item.tsx
@@ -18,6 +18,7 @@ interface Props {
 	isRecommended?: boolean;
 	onRender: () => void;
 	onSelect: ( domainSuggestion: DomainSuggestion ) => void;
+	selected?: boolean;
 }
 
 const DomainPickerSuggestionItem: FunctionComponent< Props > = ( {
@@ -26,6 +27,7 @@ const DomainPickerSuggestionItem: FunctionComponent< Props > = ( {
 	isRecommended = false,
 	onSelect,
 	onRender,
+	selected,
 } ) => {
 	const { __ } = useI18n();
 
@@ -65,6 +67,7 @@ const DomainPickerSuggestionItem: FunctionComponent< Props > = ( {
 			type="button"
 			className={ classnames( 'domain-picker__suggestion-item', {
 				'is-free': suggestion.is_free,
+				'is-selected': selected,
 			} ) }
 			onClick={ onDomainSelect }
 			id={ labelId }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This changes two things:

1. Makes DomainPicker accept `currentDomain` as a string, being the domain name itself.
2. Changes FSE domain picker just to show that this works. 
3. Adds selected state for DomainSuggestionItem. UI-wise it looks like the hover state, I got the inspo from 0:20 [in this video](https://d.pr/v/4JXMgX). 
4. A by product is that Gutenboarding now highlights the selected domain when you go back to the domain picker by pressing back. I love this.


#### Testing instructions

##### Gutenboarding

1. Go to Gutenboarding and name your site.
2. Pick a domain. No domain should be highlighted at this step.
3. Press back to see it highlighted. 

##### FSE
1. In root, run `yarn start` to run Calypso
2. In `apps/full-site-editing`, run `yarn dev --sync` to run the app and sync it with your sandbox.
3. Create and sandbox a simple site.
4. Define a `A8C_FSE_DOMAIN_PICKER_ENABLE` flag and set it to true in PHP.
5. Pick a domain
6. Open domain picker again, selected domain should be highhlited.


Related to https://github.com/Automattic/wp-calypso/issues/43750
