### PR TITLE
Load detailed domain data when rendering the all domains list

### DIFF
--- a/client/my-sites/domains/domain-management/list/domain-item.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-item.jsx
@@ -14,10 +14,14 @@ import FormCheckbox from 'components/forms/form-checkbox';
 import DomainNotice from 'my-sites/domains/domain-management/components/domain-notice';
 import EllipsisMenu from 'components/ellipsis-menu';
 import PopoverMenuItem from 'components/popover/menu-item';
+import { hasGSuiteWithUs, getGSuiteMailboxCount } from 'lib/gsuite';
+import { withoutHttp } from 'lib/url';
 
 class DomainItem extends PureComponent {
 	static propTypes = {
 		domain: PropTypes.object.isRequired,
+		domainDetails: PropTypes.object,
+		site: PropTypes.object,
 		isManagingAllSites: PropTypes.bool,
 		showSite: PropTypes.bool,
 		showCheckbox: PropTypes.bool,
@@ -70,8 +74,49 @@ class DomainItem extends PureComponent {
 		);
 	}
 
+	renderEmail( domainDetails ) {
+		const { translate } = this.props;
+
+		if ( hasGSuiteWithUs( domainDetails ) ) {
+			const gSuiteMailboxCount = getGSuiteMailboxCount( domainDetails );
+			return translate( '%(gSuiteMailboxCount)d mailbox', '%(gSuiteMailboxCount)d mailboxes', {
+				count: gSuiteMailboxCount,
+				args: {
+					gSuiteMailboxCount,
+				},
+				comment: 'The number of GSuite mailboxes active for the current domain',
+			} );
+		}
+
+		if ( domainDetails?.emailForwardsCount > 0 ) {
+			return translate( '%(emailForwardsCount)d forward', '%(emailForwardsCount)d forwards', {
+				count: domainDetails.emailForwardsCount,
+				args: {
+					emailForwardsCount: domainDetails.emailForwardsCount,
+				},
+				comment: 'The number of email forwards active for the current domain',
+			} );
+		}
+
+		return (
+			<Button compact onClick={ this.addEmailClick }>
+				{ translate( 'Add', {
+					context: 'Button label',
+					comment: '"Add" as in "Add an email"',
+				} ) }
+			</Button>
+		);
+	}
+
+	getSiteName( site ) {
+		if ( site.name ) {
+			return `${ site.name } (${ withoutHttp( site.URL ) })`;
+		}
+		return withoutHttp( site.URL );
+	}
+
 	render() {
-		const { domain, showSite, showCheckbox, translate } = this.props;
+		const { domain, showSite, site, showCheckbox, domainDetails, translate } = this.props;
 
 		return (
 			<CompactCard className="domain-item" onClick={ this.handleClick }>
@@ -89,32 +134,30 @@ class DomainItem extends PureComponent {
 					</div>
 					{ showSite && (
 						<div className="domain-item__meta">
-							{ translate( 'Site: %(siteURL)s', {
+							{ translate( 'Site: %(siteName)s', {
 								args: {
-									siteURL: 'todo',
+									siteName: this.getSiteName( site ),
 								},
-								comment: '%(siteURL)s is the URL of the site',
+								comment:
+									'%(siteName)s is the site name and URL or just the URL used to identify a site',
 							} ) }
 						</div>
 					) }
 				</div>
 				<div className="domain-item__transfer-lock">
-					<Gridicon className="domain-item__icon" size={ 18 } icon="checkmark" />
+					{ domainDetails?.isLocked && (
+						<Gridicon className="domain-item__icon" size={ 18 } icon="checkmark" />
+					) }
 				</div>
 				<div className="domain-item__privacy">
-					<Gridicon className="domain-item__icon" size={ 18 } icon="checkmark" />
+					{ domainDetails?.privateDomain && (
+						<Gridicon className="domain-item__icon" size={ 18 } icon="checkmark" />
+					) }
 				</div>
 				<div className="domain-item__auto-renew">
 					<Gridicon className="domain-item__icon" size={ 18 } icon="minus" />
 				</div>
-				<div className="domain-item__email">
-					<Button compact onClick={ this.addEmailClick }>
-						{ translate( 'Add', {
-							context: 'Button label',
-							comment: '"Add" as in "Add an email"',
-						} ) }
-					</Button>
-				</div>
+				<div className="domain-item__email">{ this.renderEmail( domainDetails ) }</div>
 				{ this.renderOptionsButton() }
 			</CompactCard>
 		);

--- a/client/my-sites/domains/domain-management/list/list-all.jsx
+++ b/client/my-sites/domains/domain-management/list/list-all.jsx
@@ -6,6 +6,7 @@ import { keyBy, keys, times } from 'lodash';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
@@ -18,7 +19,7 @@ import { domainAddNew } from 'my-sites/domains/paths';
 import DocumentHead from 'components/data/document-head';
 import DomainItem from './domain-item';
 import FormattedHeader from 'components/formatted-header';
-import { getFlatDomainsList } from 'state/sites/domains/selectors';
+import { getAllDomains, getFlatDomainsList } from 'state/sites/domains/selectors';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { getCurrentRoute } from 'state/selectors/get-current-route';
 import { getDomainManagementPath } from './utils';
@@ -26,10 +27,12 @@ import getVisibleSites from 'state/selectors/get-visible-sites';
 import isRequestingAllDomains from 'state/selectors/is-requesting-all-domains';
 import ListItemPlaceholder from './item-placeholder';
 import Main from 'components/main';
-import PropTypes from 'prop-types';
 import { type as domainTypes } from 'lib/domains/constants';
 import QueryAllDomains from 'components/data/query-all-domains';
+import QuerySiteDomains from 'components/data/query-site-domains';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
+import { emailManagement } from 'my-sites/email/paths';
+
 /**
  * Style dependencies
  */
@@ -56,8 +59,10 @@ class ListAll extends Component {
 		page( getDomainManagementPath( domain.domain, domain.type, site.slug, currentRoute ) );
 	};
 
-	handleAddEmailClick = () => {
-		// TODO
+	handleAddEmailClick = ( domain ) => {
+		const { sites, currentRoute } = this.props;
+		const site = sites[ domain.blogId ];
+		page( emailManagement( site.slug, domain.domain, currentRoute ) );
 	};
 
 	headerButtons() {
@@ -73,8 +78,14 @@ class ListAll extends Component {
 	}
 
 	isLoading() {
-		const { domainsList, requestingDomains } = this.props;
-		return requestingDomains && domainsList.length === 0;
+		const { domainsList, requestingDomains, sites } = this.props;
+		return ! sites || ( requestingDomains && domainsList.length === 0 );
+	}
+
+	findDomainDetails( domainsDetails = [], domain = {} ) {
+		return domainsDetails[ domain?.blogId ]?.find(
+			( element ) => element.type === domain.type && element.domain === domain.domain
+		);
 	}
 
 	renderDomainsList() {
@@ -82,21 +93,25 @@ class ListAll extends Component {
 			return times( 3, ( n ) => <ListItemPlaceholder key={ `item-${ n }` } /> );
 		}
 
-		const { domainsList, canManageSitesMap } = this.props;
+		const { domainsList, sites, domainsDetails, canManageSitesMap } = this.props;
 
 		return domainsList
 			.filter(
 				( domain ) => domain.type !== domainTypes.WPCOM && canManageSitesMap[ domain.blogId ]
 			) // filter on sites we can manage, that aren't `wpcom` type
 			.map( ( domain, index ) => (
-				<DomainItem
-					key={ `${ index }-${ domain.name }` }
-					domain={ domain }
-					isManagingAllSites={ true }
-					showSite={ true }
-					onClick={ this.handleDomainItemClick }
-					onAddEmailClick={ this.handleAddEmailClick }
-				/>
+				<React.Fragment key={ `${ index }-${ domain.name }` }>
+					{ domain?.blogId && <QuerySiteDomains siteId={ domain.blogId } /> }
+					<DomainItem
+						domain={ domain }
+						domainDetails={ this.findDomainDetails( domainsDetails, domain ) }
+						site={ sites[ domain?.blogId ] }
+						isManagingAllSites={ true }
+						showSite={ true }
+						onClick={ this.handleDomainItemClick }
+						onAddEmailClick={ this.handleAddEmailClick }
+					/>
+				</React.Fragment>
 			) );
 	}
 
@@ -135,6 +150,7 @@ export default connect(
 			canManageSitesMap: canCurrentUserForSites( state, keys( sites ), 'manage_options' ),
 			currentRoute: getCurrentRoute( state ),
 			domainsList: getFlatDomainsList( state ),
+			domainsDetails: getAllDomains( state ),
 			requestingDomains: isRequestingAllDomains( state ),
 			sites,
 			user: getCurrentUser( state ),

--- a/client/my-sites/email/paths.js
+++ b/client/my-sites/email/paths.js
@@ -2,13 +2,13 @@
  * External dependencies
  */
 import { startsWith } from 'lodash';
-import { isUnderDomainManagementAll } from 'my-sites/domains/paths';
+import { isUnderDomainManagementAll, domainManagementRoot } from 'my-sites/domains/paths';
 
 export const emailManagementPrefix = '/email';
 export const emailManagementAllSitesPrefix = '/email/all';
 
 function resolveRootPath( relativeTo ) {
-	if ( relativeTo === emailManagementAllSitesPrefix ) {
+	if ( relativeTo === emailManagementAllSitesPrefix || relativeTo === domainManagementRoot() ) {
 		return emailManagementAllSitesPrefix;
 	}
 	if ( isUnderEmailManagementAll( relativeTo ) || isUnderDomainManagementAll( relativeTo ) ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Load detailed domain data when rendering the all domains list
* Show the site title/URL in the domain item
* Fix the Add email URL
* Render the privacy/transfer lock checkmarks

#### Testing instructions

* Open /domains/manage and verify that the detailed domain data is queried and loaded

