### PR TITLE
E2E: Apply suite-tag override only on default magellan config

### DIFF
--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -242,7 +242,13 @@ elif [ $CIRCLE_NODE_TOTAL > 1 ]; then
       for locale in ${LOCALE_ARRAY[@]}; do
         for config in "${MAGELLAN_CONFIGS[@]}"; do
           if [ "$config" != "" ]; then
-            CMD="env BROWSERSIZE=$size BROWSERLOCALE=$locale $MAGELLAN --mocha_args='$MOCHA_ARGS' --config='$config' --max_workers=$WORKERS --local_browser=$LOCAL_BROWSER --test=$FILE_LIST $SUITE_TAG_OVERRIDE"
+            if [[ "$config" == *"magellan.json"* ]]; then
+            	S_T_OVERRIDE=$SUITE_TAG_OVERRIDE;
+            else
+            	S_T_OVERRIDE=""
+            fi
+
+            CMD="env BROWSERSIZE=$size BROWSERLOCALE=$locale $MAGELLAN --mocha_args='$MOCHA_ARGS' --config='$config' --max_workers=$WORKERS --local_browser=$LOCAL_BROWSER --test=$FILE_LIST $S_T_OVERRIDE"
 
             eval $CMD
             RETURN+=$?


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR fixes an issue we were having when running Jetpack e2e tests. The issue is that because we were overriding the suite for the signup tests, we were overriding it for other configs as well.  This PR makes sure we only apply the override if we're using the default `magellan.json` config file.

#### Testing instructions
To Test, you'll want to try and run some of the configs locally. 
Run All Default tests - `CIRCLE_NODE_TOTAL=2 ./run.sh -g`
Run All Default tests minus some signup tests - `CIRCLE_NODE_TOTAL=2 SUITE_TAG=parallel ./run.sh -g`
Run Jetpack tests with suite tag - `CIRCLE_NODE_TOTAL=2 SUITE_TAG=parallel ./run.sh -j`
Run Jetpack tests w/o suite tag - `CIRCLE_NODE_TOTAL=2 ./run.sh -j`

All three runs should start different numbers of tests (89, 77, 43, 43 )
