### PR TITLE
P2: add additional props to calypso invite accepted event

### DIFF
--- a/client/lib/invites/actions.js
+++ b/client/lib/invites/actions.js
@@ -134,7 +134,10 @@ export function acceptInvite( invite, callback ) {
 					dispatch( successNotice( ...acceptedNotice( invite ) ) );
 				}
 
-				recordTracksEvent( 'calypso_invite_accepted' );
+				recordTracksEvent( 'calypso_invite_accepted', {
+					is_p2_site: get( invite, 'site.is_wpforteams_site', false ),
+					inviter_blog_id: get( invite, 'site.ID', false ),
+				} );
 			}
 			dispatch( requestSites() );
 			if ( typeof callback === 'function' ) {


### PR DESCRIPTION
In this PR, we add additional props to the `calypso_invite_accepted` Tracks event:
- `is_p2_site`
- `inviter_blog_id`

That should help us identify how many people are invited to P2 sites and to which sites if needed.

## Testing instructions

Using a P2 site, go to `http://calypso.localhost:3000/people/new` and invite some other email address which doesn't have a WP.com account yet (you can use any 10 minute email provider, for example). After accepting the invite link, head to the Tracks dashboard to "Live View" and input the `calypso_invite_accepted` event. You need to wait 5-10 minutes for your event to be shown. Now, expand the event (the chevron on the left to its name). It should contain the above properties.

Note: everybody will get these two new props, not just P2 sites. I guess that's okay or should we add conditions?