### PR TITLE
Gutenboarding: remove meta from plan product when adding to cart

### DIFF
--- a/client/landing/gutenboarding/hooks/use-on-site-creation.ts
+++ b/client/landing/gutenboarding/hooks/use-on-site-creation.ts
@@ -81,7 +81,6 @@ export default function useOnSiteCreation() {
 
 			if ( selectedPlan && ! selectedPlan?.isFree ) {
 				const planProduct = {
-					meta: selectedPlan.title,
 					product_id: selectedPlan.productId,
 					product_slug: selectedPlan.storeSlug,
 					extra: {


### PR DESCRIPTION
### Existing problem
After choosing a paid plan in Gutenboarding, if the cart has been abandoned, when choosing the same plan in Calypso, the same plan will be duplicated in cart. This is the visible result on the `/checkout` page: https://cloudup.com/cZ2FvOMUJVa.

There are 2 ways of reproducing this and the only difference would be the `extra.context` property on the plan product:
**1. through `/plans` page**
`extra.context: "calypstore"`
Demo: https://cloudup.com/czLS4SU_si5
*There is also a possible unwanted redirect to `/plans` reported in https://github.com/Automattic/wp-calypso/issues/43433 but the user can also manually abandon cart and then go to Plans in Calypso to upgrade as seen in demo.

**2. through the Launch flow**
`extra.context: "signup"`
Demo: https://cloudup.com/cELnJgu193E

From the screen recordings above we can see the issue can be reproduced regardless of the following:
- new user or existing user already logged in;
- free or paid or domain added to cart;

### Changes proposed in this Pull Request
* Remove `meta` from plan product when adding to cart (based on p1593533324472500-slack-dotcom-create)

### Testing instructions
* Go to [/new](https://wordpress.com/new) in production and reproduce the scenarios describe above.
* Go to [/new](https://calypso.live/new?branch=fix/gutenboarding-remove-meta-from-plan-product) and both should be fixed (only one plan should be displayed in cart).

Fixes: pNPgK-57c-p2
