### PR TITLE
Fix title for Social Logins when viewed using new security navigation

### DIFF
--- a/client/me/social-login/index.jsx
+++ b/client/me/social-login/index.jsx
@@ -91,7 +91,7 @@ class SocialLogin extends Component {
 				{ ! useCheckupMenu && <SecuritySectionNav path={ path } /> }
 				{ useCheckupMenu && (
 					<HeaderCake backText={ translate( 'Back' ) } backHref="/me/security">
-						{ translate( 'Two-Step Authentication' ) }
+						{ translate( 'Social Logins' ) }
 					</HeaderCake>
 				) }
 

--- a/client/me/social-login/index.jsx
+++ b/client/me/social-login/index.jsx
@@ -79,8 +79,8 @@ class SocialLogin extends Component {
 
 	render() {
 		const { path, translate } = this.props;
-		const title = translate( 'Social Login' );
 		const useCheckupMenu = config.isEnabled( 'security/security-checkup' );
+		const title = useCheckupMenu ? translate( 'Social Logins' ) : translate( 'Social Login' );
 
 		return (
 			<Main className="security social-login">
@@ -91,7 +91,7 @@ class SocialLogin extends Component {
 				{ ! useCheckupMenu && <SecuritySectionNav path={ path } /> }
 				{ useCheckupMenu && (
 					<HeaderCake backText={ translate( 'Back' ) } backHref="/me/security">
-						{ translate( 'Social Logins' ) }
+						{ title }
 					</HeaderCake>
 				) }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This fixes the title for the Social Logins header and page title when using the new navigation in `/me/security`.

#### Testing instructions

* Go to `/me/security/social-login` either on staging or on calypso.live.
* Verify that the top navigation bar and the overall tab/window both have "Social Logins" as the title.