### PR TITLE
State: Replace media selection flux action with redux

### DIFF
--- a/client/blocks/image-selector/index.jsx
+++ b/client/blocks/image-selector/index.jsx
@@ -41,6 +41,7 @@ export class ImageSelector extends Component {
 		showEditIcon: PropTypes.bool,
 		siteId: PropTypes.number,
 		translate: PropTypes.func,
+		setMediaLibrarySelectedItems: PropTypes.func,
 	};
 
 	static defaultProps = {

--- a/client/blocks/image-selector/index.jsx
+++ b/client/blocks/image-selector/index.jsx
@@ -14,11 +14,11 @@ import { noop } from 'lodash';
 import ImageSelectorPreview from './preview';
 import ImageSelectorDropZone from './dropzone';
 import isDropZoneVisible from 'state/selectors/is-drop-zone-visible';
-import MediaActions from 'lib/media/actions';
 import MediaModal from 'post-editor/media-modal';
 import MediaStore from 'lib/media/store';
 import { localize } from 'i18n-calypso';
 import { getSelectedSiteId } from 'state/ui/selectors';
+import { setMediaLibrarySelectedItems } from 'state/media/actions';
 
 /**
  * Style dependencies
@@ -59,7 +59,7 @@ export class ImageSelector extends Component {
 
 		if ( imageIds ) {
 			const images = imageIds.map( ( imageId ) => MediaStore.get( siteId, imageId ) );
-			MediaActions.setLibrarySelectedItems( siteId, images );
+			this.props.setMediaLibrarySelectedItems( siteId, images );
 		}
 
 		this.setState( {
@@ -159,15 +159,18 @@ export class ImageSelector extends Component {
 	}
 }
 
-export default connect( ( state, ownProps ) => {
-	const { siteId } = ownProps;
-	const props = {
-		siteId: getSelectedSiteId( state ),
-		isImageSelectorDropZoneVisible: isDropZoneVisible( state, 'imageSelector' ),
-	};
+export default connect(
+	( state, ownProps ) => {
+		const { siteId } = ownProps;
+		const props = {
+			siteId: getSelectedSiteId( state ),
+			isImageSelectorDropZoneVisible: isDropZoneVisible( state, 'imageSelector' ),
+		};
 
-	if ( siteId ) {
-		props.siteId = siteId;
-	}
-	return props;
-} )( localize( ImageSelector ) );
+		if ( siteId ) {
+			props.siteId = siteId;
+		}
+		return props;
+	},
+	{ setMediaLibrarySelectedItems }
+)( localize( ImageSelector ) );

--- a/client/blocks/image-selector/test/index.jsx
+++ b/client/blocks/image-selector/test/index.jsx
@@ -47,6 +47,7 @@ describe( 'ImageSelector', () => {
 		onImageSelected: noop,
 		onRemoveImage: noop,
 		imageIds: [],
+		setMediaLibrarySelectedItems: noop,
 	};
 	const store = {
 		getState: () => ( {

--- a/client/components/tinymce/plugins/media/drop-zone.jsx
+++ b/client/components/tinymce/plugins/media/drop-zone.jsx
@@ -13,11 +13,11 @@ import { bumpStat } from 'lib/analytics/mc';
 import getMediaErrors from 'state/selectors/get-media-errors';
 import getMediaLibrarySelectedItems from 'state/selectors/get-media-library-selected-items';
 import MediaDropZone from 'my-sites/media-library/drop-zone';
-import MediaActions from 'lib/media/actions';
 import { getMimePrefix } from 'lib/media/utils';
 import markup from 'post-editor/media-modal/markup';
 import { getSelectedSite } from 'state/ui/selectors';
 import { blockSave } from 'state/editor/save-blockers/actions';
+import { setMediaLibrarySelectedItems } from 'state/media/actions';
 
 class TinyMCEDropZone extends React.Component {
 	static propTypes = {
@@ -107,7 +107,7 @@ class TinyMCEDropZone extends React.Component {
 			}
 
 			onInsertMedia( markup.get( site, selectedItems[ 0 ] ) );
-			MediaActions.setLibrarySelectedItems( site.ID, [] );
+			this.props.setMediaLibrarySelectedItems( site.ID, [] );
 		} else {
 			// In all other cases, show the media modal list view
 			onRenderModal( { visible: true } );
@@ -144,5 +144,5 @@ export default connect(
 			selectedItems: getMediaLibrarySelectedItems( state, site?.ID ),
 		};
 	},
-	{ blockSave }
+	{ blockSave, setMediaLibrarySelectedItems }
 )( TinyMCEDropZone );

--- a/client/components/tinymce/plugins/media/plugin.jsx
+++ b/client/components/tinymce/plugins/media/plugin.jsx
@@ -13,7 +13,6 @@ import closest from 'component-closest';
 /**
  * Internal dependencies
  */
-import { reduxDispatch } from 'lib/redux-bridge';
 import * as MediaConstants from 'lib/media/constants';
 import MediaActions from 'lib/media/actions';
 import { getThumbnailSizeDimensions } from 'lib/media/utils';
@@ -494,7 +493,7 @@ function mediaButton( editor ) {
 					view: ModalViews.DETAIL,
 				}
 			);
-			reduxDispatch( setMediaLibrarySelectedItems( siteId, [ image ] ) );
+			dispatch( setMediaLibrarySelectedItems( siteId, [ image ] ) );
 		},
 	} );
 
@@ -736,7 +735,7 @@ function mediaButton( editor ) {
 			delete gallery.orderby;
 		}
 
-		reduxDispatch( setMediaLibrarySelectedItems( selectedSite.ID, gallery.items ) );
+		dispatch( setMediaLibrarySelectedItems( selectedSite.ID, gallery.items ) );
 
 		renderModal(
 			{

--- a/client/components/tinymce/plugins/media/plugin.jsx
+++ b/client/components/tinymce/plugins/media/plugin.jsx
@@ -13,6 +13,7 @@ import closest from 'component-closest';
 /**
  * Internal dependencies
  */
+import { reduxDispatch } from 'lib/redux-bridge';
 import * as MediaConstants from 'lib/media/constants';
 import MediaActions from 'lib/media/actions';
 import { getThumbnailSizeDimensions } from 'lib/media/utils';
@@ -31,6 +32,7 @@ import { getEditorRawContent, isEditorSaveBlocked } from 'state/editor/selectors
 import { ModalViews } from 'state/ui/media-modal/constants';
 import { renderWithReduxStore } from 'lib/react-helpers';
 import Gridicon from 'components/gridicon';
+import { setMediaLibrarySelectedItems } from 'state/media/actions';
 
 /**
  * Module variables
@@ -307,7 +309,7 @@ function mediaButton( editor ) {
 			// hasn't yet been loaded, we preload the image before rendering.
 			const imageUrl = event.resizedImageUrl || media.URL;
 			if ( ! loadedImages.isLoaded( imageUrl ) ) {
-				const preloadImage = new Image();
+				const preloadImage = new window.Image();
 				preloadImage.src = imageUrl;
 				preloadImage.onload = loadedImages.onLoad.bind( null, imageUrl );
 				preloadImage.onerror = preloadImage.onload;
@@ -492,7 +494,7 @@ function mediaButton( editor ) {
 					view: ModalViews.DETAIL,
 				}
 			);
-			MediaActions.setLibrarySelectedItems( siteId, [ image ] );
+			reduxDispatch( setMediaLibrarySelectedItems( siteId, [ image ] ) );
 		},
 	} );
 
@@ -734,7 +736,7 @@ function mediaButton( editor ) {
 			delete gallery.orderby;
 		}
 
-		MediaActions.setLibrarySelectedItems( selectedSite.ID, gallery.items );
+		reduxDispatch( setMediaLibrarySelectedItems( selectedSite.ID, gallery.items ) );
 
 		renderModal(
 			{

--- a/client/components/tinymce/plugins/simple-payments/dialog/product-image-picker.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/product-image-picker.jsx
@@ -16,8 +16,7 @@ import AsyncLoad from 'components/async-load';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import EditorFeaturedImagePreviewContainer from 'post-editor/editor-featured-image/preview-container';
 import RemoveButton from 'components/remove-button';
-import { requestMediaItem } from 'state/media/actions';
-import MediaActions from 'lib/media/actions';
+import { requestMediaItem, setMediaLibrarySelectedItems } from 'state/media/actions';
 
 class ProductImagePicker extends Component {
 	static propTypes = {
@@ -62,7 +61,7 @@ class ProductImagePicker extends Component {
 	onImageChange = ( imageId ) => {
 		this.props.input.onChange( imageId );
 		// the action cares only about the ID -- that allows us to construct a 'valid' item
-		MediaActions.setLibrarySelectedItems( this.props.siteId, [ { ID: imageId } ] );
+		this.props.setMediaLibrarySelectedItems( this.props.siteId, [ { ID: imageId } ] );
 	};
 
 	getImagePlaceholder() {
@@ -139,4 +138,5 @@ class ProductImagePicker extends Component {
 
 export default connect( ( state ) => ( { siteId: getSelectedSiteId( state ) } ), {
 	requestMediaItem,
+	setMediaLibrarySelectedItems,
 } )( localize( ProductImagePicker ) );

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -50,6 +50,7 @@ import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
 import { withStopPerformanceTrackingProp, PerformanceTrackProps } from 'lib/performance-tracking';
 import { REASON_BLOCK_EDITOR_UNKOWN_IFRAME_LOAD_FAILURE } from 'state/desktop/window-events';
 import inEditorDeprecationGroup from 'state/editor-deprecation-group/selectors/in-editor-deprecation-group';
+import { setMediaLibrarySelectedItems } from 'state/media/actions';
 
 /**
  * Types
@@ -207,7 +208,7 @@ class CalypsoifyIframe extends Component<
 			if ( data.imageId ) {
 				const { siteId } = this.props;
 				const image = MediaStore.get( siteId, data.imageId );
-				MediaActions.setLibrarySelectedItems( siteId, [ image ] );
+				this.props.setMediaLibrarySelectedItems( siteId, [ image ] );
 			}
 
 			this.setState( {
@@ -249,9 +250,9 @@ class CalypsoifyIframe extends Component<
 					};
 				} );
 
-				MediaActions.setLibrarySelectedItems( siteId, selectedItems );
+				this.props.setMediaLibrarySelectedItems( siteId, selectedItems );
 			} else {
-				MediaActions.setLibrarySelectedItems( siteId, [] );
+				this.props.setMediaLibrarySelectedItems( siteId, [] );
 			}
 
 			this.setState( { isMediaModalVisible: true, allowedTypes, gallery, multiple } );
@@ -818,6 +819,7 @@ const mapDispatchToProps = {
 	trashPost,
 	updateSiteFrontPage,
 	notifyDesktopCannotOpenEditor,
+	setMediaLibrarySelectedItems,
 };
 
 type ConnectedProps = ReturnType< typeof mapStateToProps > & typeof mapDispatchToProps;

--- a/client/lib/media/actions.js
+++ b/client/lib/media/actions.js
@@ -24,7 +24,6 @@ import {
 	failMediaItemRequest,
 	failMediaRequest,
 	receiveMedia,
-	setMediaLibrarySelectedItems,
 	successMediaItemRequest,
 	successMediaRequest,
 } from 'state/media/actions';
@@ -35,7 +34,6 @@ import {
  * TODO: Better method types
  *
  * @property {Function} fetch
- * @property {Function} setLibrarySelectedItems
  */
 
 /**
@@ -314,16 +312,6 @@ MediaActions.delete = function ( siteId, item ) {
 				siteId: siteId,
 			} );
 		} );
-};
-
-MediaActions.setLibrarySelectedItems = function ( siteId, items ) {
-	debug( 'Setting selected items for %d as %o', siteId, items );
-	Dispatcher.handleViewAction( {
-		type: 'SET_MEDIA_LIBRARY_SELECTED_ITEMS',
-		siteId: siteId,
-		data: items,
-	} );
-	reduxDispatch( setMediaLibrarySelectedItems( siteId, items ) );
 };
 
 MediaActions.clearValidationErrors = function ( siteId, itemId ) {

--- a/client/my-sites/media-library/index.jsx
+++ b/client/my-sites/media-library/index.jsx
@@ -14,7 +14,6 @@ import { connect } from 'react-redux';
 import Content from './content';
 import getMediaErrors from 'state/selectors/get-media-errors';
 import getMediaLibrarySelectedItems from 'state/selectors/get-media-library-selected-items';
-import MediaActions from 'lib/media/actions';
 import MediaLibraryDropZone from './drop-zone';
 import { filterItemsByMimePrefix } from 'lib/media/utils';
 import filterToMimePrefix from './filter-to-mime-prefix';
@@ -26,6 +25,7 @@ import {
 	getKeyringConnections,
 } from 'state/sharing/keyring/selectors';
 import { requestKeyringConnections } from 'state/sharing/keyring/actions';
+import { setMediaLibrarySelectedItems } from 'state/media/actions';
 
 /**
  * Style dependencies
@@ -121,7 +121,7 @@ class MediaLibrary extends Component {
 		}
 
 		if ( ! isEqual( selectedItems, filteredItems ) ) {
-			MediaActions.setLibrarySelectedItems( this.props.site.ID, filteredItems );
+			this.props.setMediaLibrarySelectedItems( this.props.site.ID, filteredItems );
 		}
 
 		this.props.onAddMedia();
@@ -219,5 +219,6 @@ export default connect(
 	} ),
 	{
 		requestKeyringConnections,
+		setMediaLibrarySelectedItems,
 	}
 )( MediaLibrary );

--- a/client/my-sites/media-library/list.jsx
+++ b/client/my-sites/media-library/list.jsx
@@ -12,7 +12,6 @@ import React from 'react';
  * Internal dependencies
  */
 import getMediaLibrarySelectedItems from 'state/selectors/get-media-library-selected-items';
-import MediaActions from 'lib/media/actions';
 import { getMimePrefix } from 'lib/media/utils';
 import ListItem from './list-item';
 import ListNoResults from './list-no-results';
@@ -21,6 +20,7 @@ import ListPlanUpgradeNudge from './list-plan-upgrade-nudge';
 import SortedGrid from 'components/sorted-grid';
 import { withLocalizedMoment } from 'components/localized-moment';
 import { getPreference } from 'state/preferences/selectors';
+import { setMediaLibrarySelectedItems } from 'state/media/actions';
 
 export class MediaLibraryList extends React.Component {
 	static displayName = 'MediaLibraryList';
@@ -138,7 +138,7 @@ export class MediaLibraryList extends React.Component {
 		} );
 
 		if ( this.props.site ) {
-			MediaActions.setLibrarySelectedItems( this.props.site.ID, selectedItems );
+			this.props.setMediaLibrarySelectedItems( this.props.site.ID, selectedItems );
 		}
 	};
 
@@ -254,7 +254,10 @@ export class MediaLibraryList extends React.Component {
 	}
 }
 
-export default connect( ( state, { site } ) => ( {
-	mediaScale: getPreference( state, 'mediaScale' ),
-	selectedItems: getMediaLibrarySelectedItems( state, site?.ID ),
-} ) )( withRtl( withLocalizedMoment( MediaLibraryList ) ) );
+export default connect(
+	( state, { site } ) => ( {
+		mediaScale: getPreference( state, 'mediaScale' ),
+		selectedItems: getMediaLibrarySelectedItems( state, site?.ID ),
+	} ),
+	{ setMediaLibrarySelectedItems }
+)( withRtl( withLocalizedMoment( MediaLibraryList ) ) );

--- a/client/my-sites/media-library/test/list.jsx
+++ b/client/my-sites/media-library/test/list.jsx
@@ -30,18 +30,11 @@ jest.mock( 'my-sites/media-library/list-item', () => require( 'components/empty-
 jest.mock( 'my-sites/media-library/list-plan-upgrade-nudge', () =>
 	require( 'components/empty-component' )
 );
-jest.mock( 'lib/media/actions', () => ( {
-	__esModule: true,
-	default: {
-		setLibrarySelectedItems: ( siteId, mediaIds ) => {
-			mockSelectedItems.length = 0;
-			mockSelectedItems.push( ...mediaIds );
-		},
-	},
-} ) );
 
 describe( 'MediaLibraryList item selection', () => {
 	let wrapper, mediaList;
+
+	const setMediaLibrarySelectedItems = jest.fn();
 
 	function toggleItem( itemIndex, shiftClick ) {
 		mediaList.toggleItem( fixtures.media[ itemIndex ], shiftClick );
@@ -79,6 +72,7 @@ describe( 'MediaLibraryList item selection', () => {
 					mediaScale={ 0.24 }
 					moment={ moment }
 					selectedItems={ [] }
+					setMediaLibrarySelectedItems={ setMediaLibrarySelectedItems }
 				/>
 			);
 			mediaList = wrapper.find( MediaList ).instance();
@@ -167,6 +161,7 @@ describe( 'MediaLibraryList item selection', () => {
 					moment={ moment }
 					single
 					selectedItems={ [] }
+					setMediaLibrarySelectedItems={ setMediaLibrarySelectedItems }
 				/>
 			);
 			mediaList = wrapper.find( MediaList ).instance();
@@ -209,6 +204,7 @@ describe( 'MediaLibraryList item selection', () => {
 					source={ source }
 					single
 					selectedItems={ [] }
+					setMediaLibrarySelectedItems={ setMediaLibrarySelectedItems }
 				/>
 			)
 				.find( MediaList )

--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -446,4 +446,6 @@ const mapStateToProps = ( state, { mediaId, site } ) => {
 	};
 };
 
-export default connect( mapStateToProps, { editMedia, deleteMedia, setMediaLibrarySelectedItems } )( localize( Media ) );
+export default connect( mapStateToProps, { editMedia, deleteMedia, setMediaLibrarySelectedItems } )(
+	localize( Media )
+);

--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -30,6 +30,7 @@ import accept from 'lib/accept';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import searchUrl from 'lib/search-url';
 import { editMedia, deleteMedia } from 'state/media/thunks';
+import { setMediaLibrarySelectedItems } from 'state/media/actions';
 
 /**
  * Style dependencies
@@ -76,7 +77,7 @@ class Media extends Component {
 		}
 
 		if ( this.props.selectedSite ) {
-			MediaActions.setLibrarySelectedItems( this.props.selectedSite.ID, [] );
+			this.props.setMediaLibrarySelectedItems( this.props.selectedSite.ID, [] );
 		}
 
 		page( redirect );
@@ -445,4 +446,4 @@ const mapStateToProps = ( state, { mediaId, site } ) => {
 	};
 };
 
-export default connect( mapStateToProps, { editMedia, deleteMedia } )( localize( Media ) );
+export default connect( mapStateToProps, { editMedia, deleteMedia, setMediaLibrarySelectedItems } )( localize( Media ) );

--- a/client/post-editor/editor-featured-image/index.jsx
+++ b/client/post-editor/editor-featured-image/index.jsx
@@ -12,7 +12,6 @@ import { noop } from 'lodash';
  * Internal dependencies
  */
 import MediaModal from 'post-editor/media-modal';
-import MediaActions from 'lib/media/actions';
 import { recordEditorStat, recordEditorEvent } from 'state/posts/stats';
 import EditorFeaturedImagePreviewContainer from './preview-container';
 import FeaturedImageDropZone from './dropzone';
@@ -28,6 +27,7 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { getEditorPostId } from 'state/editor/selectors';
 import { getEditedPost } from 'state/posts/selectors';
 import { editPost } from 'state/posts/actions';
+import { setMediaLibrarySelectedItems } from 'state/media/actions';
 
 /**
  * Style dependencies
@@ -61,7 +61,7 @@ class EditorFeaturedImage extends Component {
 		const { siteId, featuredImage } = this.props;
 
 		if ( featuredImage ) {
-			MediaActions.setLibrarySelectedItems( siteId, [ featuredImage ] );
+			this.props.setMediaLibrarySelectedItems( siteId, [ featuredImage ] );
 		}
 
 		this.setState( {
@@ -198,5 +198,6 @@ export default connect(
 		recordEditorStat,
 		recordEditorEvent,
 		recordTracksEvent,
+		setMediaLibrarySelectedItems,
 	}
 )( localize( EditorFeaturedImage ) );

--- a/client/post-editor/editor-html-toolbar/index.jsx
+++ b/client/post-editor/editor-html-toolbar/index.jsx
@@ -16,7 +16,6 @@ import { Env } from 'tinymce/tinymce';
  */
 import { serialize as serializeContactForm } from 'components/tinymce/plugins/contact-form/shortcode-utils';
 import { serialize as serializeSimplePayment } from 'components/tinymce/plugins/simple-payments/shortcode-utils';
-import MediaActions from 'lib/media/actions';
 import { getMimePrefix } from 'lib/media/utils';
 import markup from 'post-editor/media-modal/markup';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
@@ -41,6 +40,7 @@ import getMediaErrors from 'state/selectors/get-media-errors';
 import getMediaLibrarySelectedItems from 'state/selectors/get-media-library-selected-items';
 import SimplePaymentsDialog from 'components/tinymce/plugins/simple-payments/dialog';
 import { withLocalizedMoment } from 'components/localized-moment';
+import { setMediaLibrarySelectedItems } from 'state/media/actions';
 
 /**
  * Style dependencies
@@ -495,7 +495,7 @@ export class EditorHtmlToolbar extends Component {
 			}
 
 			this.onInsertMedia( markup.get( site, selectedItems[ 0 ] ) );
-			MediaActions.setLibrarySelectedItems( site.ID, [] );
+			this.props.setMediaLibrarySelectedItems( site.ID, [] );
 		} else {
 			// In all other cases, show the media modal list view
 			this.openMediaModal();
@@ -724,6 +724,7 @@ const mapDispatchToProps = {
 	fieldRemove,
 	fieldUpdate,
 	settingsUpdate,
+	setMediaLibrarySelectedItems,
 };
 
 export default connect(

--- a/client/post-editor/media-modal/gallery/drop-zone.jsx
+++ b/client/post-editor/media-modal/gallery/drop-zone.jsx
@@ -12,8 +12,8 @@ import { isEqual } from 'lodash';
  */
 import getMediaLibrarySelectedItems from 'state/selectors/get-media-library-selected-items';
 import MediaLibraryDropZone from 'my-sites/media-library/drop-zone';
-import MediaActions from 'lib/media/actions';
 import { filterItemsByMimePrefix } from 'lib/media/utils';
+import { setMediaLibrarySelectedItems } from 'state/media/actions';
 
 class EditorMediaModalGalleryDropZone extends React.Component {
 	static propTypes = {
@@ -34,7 +34,7 @@ class EditorMediaModalGalleryDropZone extends React.Component {
 		const filteredItems = filterItemsByMimePrefix( selectedItems, 'image' );
 
 		if ( ! isEqual( selectedItems, filteredItems ) ) {
-			MediaActions.setLibrarySelectedItems( site.ID, filteredItems );
+			this.props.setMediaLibrarySelectedItems( site.ID, filteredItems );
 			this.props.onInvalidItemAdded();
 		}
 	};
@@ -50,6 +50,9 @@ class EditorMediaModalGalleryDropZone extends React.Component {
 	}
 }
 
-export default connect( ( state, { site } ) => ( {
-	selectedItems: getMediaLibrarySelectedItems( state, site?.ID ),
-} ) )( EditorMediaModalGalleryDropZone );
+export default connect(
+	( state, { site } ) => ( {
+		selectedItems: getMediaLibrarySelectedItems( state, site?.ID ),
+	} ),
+	{ setMediaLibrarySelectedItems }
+)( EditorMediaModalGalleryDropZone );

--- a/client/post-editor/media-modal/gallery/remove-button.jsx
+++ b/client/post-editor/media-modal/gallery/remove-button.jsx
@@ -13,7 +13,7 @@ import PropTypes from 'prop-types';
  */
 import { ScreenReaderText } from '@automattic/components';
 import getMediaLibrarySelectedItems from 'state/selectors/get-media-library-selected-items';
-import MediaActions from 'lib/media/actions';
+import { setMediaLibrarySelectedItems } from 'state/media/actions';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
@@ -31,7 +31,7 @@ class RemoveButton extends PureComponent {
 
 		const items = reject( selectedItems, ( item ) => item.ID === itemId );
 
-		MediaActions.setLibrarySelectedItems( siteId, items );
+		this.props.setMediaLibrarySelectedItems( siteId, items );
 	};
 
 	render() {
@@ -52,6 +52,9 @@ class RemoveButton extends PureComponent {
 
 RemoveButton.displayName = 'RemoveButton';
 
-export default connect( ( state, { siteId } ) => ( {
-	selectedItems: getMediaLibrarySelectedItems( state, siteId ),
-} ) )( localize( RemoveButton ) );
+export default connect(
+	( state, { siteId } ) => ( {
+		selectedItems: getMediaLibrarySelectedItems( state, siteId ),
+	} ),
+	{ setMediaLibrarySelectedItems }
+)( localize( RemoveButton ) );

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -40,6 +40,7 @@ import { resetMediaModalView } from 'state/ui/media-modal/actions';
 import { setEditorMediaModalView } from 'state/editor/actions';
 import { ModalViews } from 'state/ui/media-modal/constants';
 import { editMedia, deleteMedia } from 'state/media/thunks';
+import { setMediaLibrarySelectedItems } from 'state/media/actions';
 import ImageEditor from 'blocks/image-editor';
 import VideoEditor from 'blocks/video-editor';
 import MediaModalDialog from './dialog';
@@ -117,7 +118,7 @@ export class EditorMediaModal extends Component {
 
 	UNSAFE_componentWillReceiveProps( nextProps ) {
 		if ( nextProps.site && this.props.visible && ! nextProps.visible ) {
-			MediaActions.setLibrarySelectedItems( nextProps.site.ID, [] );
+			this.props.setMediaLibrarySelectedItems( nextProps.site.ID, [] );
 		}
 
 		if ( this.props.visible === nextProps.visible ) {
@@ -143,13 +144,13 @@ export class EditorMediaModal extends Component {
 	UNSAFE_componentWillMount() {
 		const { view, selectedItems, site, single } = this.props;
 		if ( ! isEmpty( selectedItems ) && ( view === ModalViews.LIST || single ) ) {
-			MediaActions.setLibrarySelectedItems( site.ID, [] );
+			this.props.setMediaLibrarySelectedItems( site.ID, [] );
 		}
 	}
 
 	componentWillUnmount() {
 		this.props.resetView();
-		MediaActions.setLibrarySelectedItems( this.props.site.ID, [] );
+		this.props.setMediaLibrarySelectedItems( this.props.site.ID, [] );
 	}
 
 	getDefaultState( props ) {
@@ -297,7 +298,7 @@ export class EditorMediaModal extends Component {
 	};
 
 	onAddAndEditImage = () => {
-		MediaActions.setLibrarySelectedItems( this.props.site.ID, [] );
+		this.props.setMediaLibrarySelectedItems( this.props.site.ID, [] );
 
 		this.props.setView( ModalViews.IMAGE_EDITOR );
 	};
@@ -446,7 +447,7 @@ export class EditorMediaModal extends Component {
 			} else {
 				items = items.concat( item );
 			}
-			MediaActions.setLibrarySelectedItems( site.ID, items );
+			this.props.setMediaLibrarySelectedItems( site.ID, items );
 		}
 
 		// Find and set detail selected index for the edited item
@@ -655,5 +656,6 @@ export default connect(
 		recordEditorEvent,
 		recordEditorStat,
 		editMedia,
+		setMediaLibrarySelectedItems,
 	}
 )( localize( EditorMediaModal ) );

--- a/client/post-editor/media-modal/test/index.jsx
+++ b/client/post-editor/media-modal/test/index.jsx
@@ -15,7 +15,6 @@ import React from 'react';
  */
 import { EditorMediaModal } from '../';
 import accept from 'lib/accept';
-import mediaActions from 'lib/media/actions';
 import { ModalViews } from 'state/ui/media-modal/constants';
 import { useSandbox } from 'test/helpers/use-sinon';
 

--- a/client/post-editor/media-modal/test/index.jsx
+++ b/client/post-editor/media-modal/test/index.jsx
@@ -39,9 +39,6 @@ jest.mock( 'post-editor/media-modal/secondary-actions', () =>
 	require( 'components/empty-component' )
 );
 jest.mock( 'lib/accept', () => require( 'sinon' ).stub().callsArgWithAsync( 1, true ) );
-jest.mock( 'lib/media/actions', () => ( {
-	setLibrarySelectedItems: () => {},
-} ) );
 jest.mock( 'my-sites/media-library', () => require( 'components/empty-component' ) );
 
 /**
@@ -57,13 +54,21 @@ const DUMMY_VIDEO_MEDIA = [
 ];
 
 describe( 'EditorMediaModal', () => {
-	let spy, deleteMedia, setLibrarySelectedItems, onClose;
+	let spy, deleteMedia, onClose, setMediaLibrarySelectedItems, baseProps;
 
 	useSandbox( ( sandbox ) => {
 		spy = sandbox.spy();
-		setLibrarySelectedItems = sandbox.stub( mediaActions, 'setLibrarySelectedItems' );
 		deleteMedia = sandbox.stub();
 		onClose = sandbox.stub();
+		setMediaLibrarySelectedItems = sandbox.stub();
+		baseProps = {
+			setMediaLibrarySelectedItems,
+			site: DUMMY_SITE,
+			selectedItems: DUMMY_MEDIA,
+			translate,
+			onClose,
+			deleteMedia,
+		};
 	} );
 
 	afterEach( () => {
@@ -71,27 +76,15 @@ describe( 'EditorMediaModal', () => {
 	} );
 
 	test( 'When `single` selection screen chosen should initialise with no items selected', () => {
-		shallow(
-			<EditorMediaModal
-				single={ true }
-				site={ DUMMY_SITE }
-				view={ null }
-				selectedItems={ DUMMY_MEDIA }
-			/>
-		).instance();
-		expect( setLibrarySelectedItems ).to.have.been.calledWith( DUMMY_SITE.ID, [] );
+		shallow( <EditorMediaModal { ...baseProps } single={ true } view={ null } /> ).instance();
+		expect( setMediaLibrarySelectedItems ).to.have.been.calledWith( DUMMY_SITE.ID, [] );
 	} );
 
 	test( 'should prompt to delete a single item from the list view', () => {
 		const media = DUMMY_MEDIA.slice( 0, 1 );
 
 		const tree = shallow(
-			<EditorMediaModal
-				site={ DUMMY_SITE }
-				selectedItems={ media }
-				translate={ translate }
-				deleteMedia={ deleteMedia }
-			/>
+			<EditorMediaModal { ...baseProps } selectedItems={ media } />
 		).instance();
 		tree.deleteMedia();
 
@@ -109,14 +102,7 @@ describe( 'EditorMediaModal', () => {
 	} );
 
 	test( 'should prompt to delete multiple items from the list view', () => {
-		const tree = shallow(
-			<EditorMediaModal
-				site={ DUMMY_SITE }
-				selectedItems={ DUMMY_MEDIA }
-				translate={ translate }
-				deleteMedia={ deleteMedia }
-			/>
-		).instance();
+		const tree = shallow( <EditorMediaModal { ...baseProps } /> ).instance();
 		tree.deleteMedia();
 
 		expect( accept ).to.have.been.calledWith(
@@ -136,12 +122,7 @@ describe( 'EditorMediaModal', () => {
 	test( 'should prompt to delete a single item from the detail view', () => {
 		const media = DUMMY_MEDIA[ 0 ];
 		const tree = shallow(
-			<EditorMediaModal
-				site={ DUMMY_SITE }
-				selectedItems={ [ media ] }
-				view={ ModalViews.DETAIL }
-				deleteMedia={ deleteMedia }
-			/>
+			<EditorMediaModal { ...baseProps } selectedItems={ [ media ] } view={ ModalViews.DETAIL } />
 		).instance();
 		tree.deleteMedia();
 
@@ -160,12 +141,7 @@ describe( 'EditorMediaModal', () => {
 
 	test( 'should prompt to delete a single item from the detail view, even when multiple selected', () => {
 		const tree = shallow(
-			<EditorMediaModal
-				site={ DUMMY_SITE }
-				selectedItems={ DUMMY_MEDIA }
-				view={ ModalViews.DETAIL }
-				deleteMedia={ deleteMedia }
-			/>
+			<EditorMediaModal { ...baseProps } view={ ModalViews.DETAIL } />
 		).instance();
 		tree.deleteMedia();
 
@@ -186,7 +162,7 @@ describe( 'EditorMediaModal', () => {
 	test( 'should return to the list view after deleting the only item in detail view', () => {
 		const tree = shallow(
 			<EditorMediaModal
-				site={ DUMMY_SITE }
+				{ ...baseProps }
 				selectedItems={ DUMMY_MEDIA.slice( 0, 1 ) }
 				view={ ModalViews.DETAIL }
 				setView={ spy }
@@ -205,12 +181,7 @@ describe( 'EditorMediaModal', () => {
 
 	test( 'should revert to an earlier media item when the last item is deleted from detail view', () => {
 		const tree = shallow(
-			<EditorMediaModal
-				site={ DUMMY_SITE }
-				selectedItems={ DUMMY_MEDIA }
-				view={ ModalViews.DETAIL }
-				setView={ spy }
-			/>
+			<EditorMediaModal { ...baseProps } view={ ModalViews.DETAIL } setView={ spy } />
 		).instance();
 		tree.setDetailSelectedIndex( 1 );
 		tree.deleteMedia();
@@ -227,7 +198,7 @@ describe( 'EditorMediaModal', () => {
 	test( 'should show no buttons if editing an image', () => {
 		const tree = shallow(
 			<EditorMediaModal
-				site={ DUMMY_SITE }
+				{ ...baseProps }
 				selectedItems={ [] }
 				view={ ModalViews.IMAGE_EDITOR }
 				setView={ spy }
@@ -242,7 +213,7 @@ describe( 'EditorMediaModal', () => {
 	test( 'should show a Copy to media library button when viewing external media (no selection)', () => {
 		const tree = shallow(
 			<EditorMediaModal
-				site={ DUMMY_SITE }
+				{ ...baseProps }
 				view={ ModalViews.DETAIL }
 				setView={ spy }
 				selectedItems={ [] }
@@ -259,7 +230,7 @@ describe( 'EditorMediaModal', () => {
 	test( 'should show a Copy to media library button when 1 external image is selected', () => {
 		const tree = shallow(
 			<EditorMediaModal
-				site={ DUMMY_SITE }
+				{ ...baseProps }
 				view={ ModalViews.DETAIL }
 				selectedItems={ DUMMY_MEDIA.slice( 0, 1 ) }
 				setView={ spy }
@@ -276,7 +247,7 @@ describe( 'EditorMediaModal', () => {
 	test( 'should show a copy button when 1 external video is selected', () => {
 		const tree = shallow(
 			<EditorMediaModal
-				site={ DUMMY_SITE }
+				{ ...baseProps }
 				view={ ModalViews.DETAIL }
 				selectedItems={ DUMMY_VIDEO_MEDIA }
 				setView={ spy }
@@ -292,12 +263,7 @@ describe( 'EditorMediaModal', () => {
 
 	test( 'should show a copy button when 2 or more external media are selected', () => {
 		const tree = shallow(
-			<EditorMediaModal
-				site={ DUMMY_SITE }
-				view={ ModalViews.DETAIL }
-				selectedItems={ DUMMY_MEDIA }
-				setView={ spy }
-			/>
+			<EditorMediaModal { ...baseProps } view={ ModalViews.DETAIL } setView={ spy } />
 		).instance();
 
 		tree.setState( { source: 'external' } );
@@ -309,12 +275,7 @@ describe( 'EditorMediaModal', () => {
 
 	test( 'should show a continue button when multiple images are selected', () => {
 		const tree = shallow(
-			<EditorMediaModal
-				site={ DUMMY_SITE }
-				selectedItems={ DUMMY_MEDIA }
-				view={ ModalViews.DETAIL }
-				setView={ spy }
-			/>
+			<EditorMediaModal { ...baseProps } view={ ModalViews.DETAIL } setView={ spy } />
 		).instance();
 
 		const buttons = tree.getModalButtons();
@@ -325,7 +286,7 @@ describe( 'EditorMediaModal', () => {
 	test( 'should show an insert button if none or one local items are selected', () => {
 		const tree = shallow(
 			<EditorMediaModal
-				site={ DUMMY_SITE }
+				{ ...baseProps }
 				view={ ModalViews.DETAIL }
 				setView={ spy }
 				selectedItems={ [] }
@@ -340,8 +301,7 @@ describe( 'EditorMediaModal', () => {
 	test( 'should show an insert button if multiple images are selected when gallery view is disabled', () => {
 		const tree = shallow(
 			<EditorMediaModal
-				site={ DUMMY_SITE }
-				selectedItems={ DUMMY_MEDIA }
+				{ ...baseProps }
 				view={ ModalViews.DETAIL }
 				setView={ spy }
 				galleryViewEnabled={ false }
@@ -356,13 +316,7 @@ describe( 'EditorMediaModal', () => {
 	describe( '#confirmSelection()', () => {
 		test( 'should close modal if viewing local media and button is pressed', () => {
 			const tree = shallow(
-				<EditorMediaModal
-					site={ DUMMY_SITE }
-					selectedItems={ DUMMY_MEDIA }
-					onClose={ onClose }
-					view={ ModalViews.DETAIL }
-					setView={ spy }
-				/>
+				<EditorMediaModal { ...baseProps } view={ ModalViews.DETAIL } setView={ spy } />
 			).instance();
 
 			tree.confirmSelection();
@@ -382,12 +336,7 @@ describe( 'EditorMediaModal', () => {
 
 		test( 'should copy external media after loading WordPress library if 1 or more media are selected and button is pressed', () => {
 			const tree = shallow(
-				<EditorMediaModal
-					site={ DUMMY_SITE }
-					selectedItems={ DUMMY_MEDIA }
-					view={ ModalViews.DETAIL }
-					setView={ spy }
-				/>
+				<EditorMediaModal { ...baseProps } view={ ModalViews.DETAIL } setView={ spy } />
 			).instance();
 
 			tree.setState( { source: 'external' } );
@@ -412,7 +361,7 @@ describe( 'EditorMediaModal', () => {
 		test( 'should copy external after loading WordPress library if 1 video is selected and button is pressed', () => {
 			const tree = shallow(
 				<EditorMediaModal
-					site={ DUMMY_SITE }
+					{ ...baseProps }
 					selectedItems={ DUMMY_VIDEO_MEDIA }
 					view={ ModalViews.DETAIL }
 					setView={ spy }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove `MediaActions.setLibrarySelectedItems` and replace all usages of it with the redux action `setMediaLibrarySelectedItems`

#### Testing instructions

* For the following areas, manually check that selecting, deselecting, auto-selection of uploaded items all continue to work:
    * Block editor media modal
    * Classic editor media modal for add media
    * Classic editor media modal for featured image
    * Classic editor gallery dropzone, selection, removal, editing
    * Site icon settings
    * Podcast cover image
    * General site media
    * Classic block media
    * Classic block simple payments

Addresses part of #43664 
