### PR TITLE
Ensure security nav always triggers two factor queries

### DIFF
--- a/client/me/security-checkup/two-factor-authentication.jsx
+++ b/client/me/security-checkup/two-factor-authentication.jsx
@@ -75,12 +75,15 @@ class SecurityCheckupTwoFactorAuthentication extends React.Component {
 		}
 
 		return (
-			<SecurityCheckupNavigationItem
-				path={ '/me/security/two-step' }
-				materialIcon={ icon }
-				text={ translate( 'Two-Step Authentication' ) }
-				description={ description }
-			/>
+			<React.Fragment>
+				<QueryUserSettings />
+				<SecurityCheckupNavigationItem
+					path={ '/me/security/two-step' }
+					materialIcon={ icon }
+					text={ translate( 'Two-Step Authentication' ) }
+					description={ description }
+				/>
+			</React.Fragment>
 		);
 	}
 }

--- a/client/me/security-checkup/two-factor-backup-codes.jsx
+++ b/client/me/security-checkup/two-factor-backup-codes.jsx
@@ -64,12 +64,15 @@ class SecurityCheckupTwoFactorBackupCodes extends React.Component {
 		}
 
 		return (
-			<SecurityCheckupNavigationItem
-				path={ '/me/security/two-step' }
-				materialIcon={ icon }
-				text={ translate( 'Two-Step Backup Codes' ) }
-				description={ description }
-			/>
+			<React.Fragment>
+				<QueryUserSettings />
+				<SecurityCheckupNavigationItem
+					path={ '/me/security/two-step' }
+					materialIcon={ icon }
+					text={ translate( 'Two-Step Backup Codes' ) }
+					description={ description }
+				/>
+			</React.Fragment>
 		);
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This change restructures the two 2FA-related security nav items to include a `QueryUserSettings` element in all cases, instead of just when we're showing a placeholder.

#### Testing instructions

* Visit `/me/security` and check the status of the "Two-Step Authentication" entry, and (if it's visible) the "Two-Step Backup Codes" entry.
* Click on the "Two-Step Authentication" item/row.
* If you had 2FA enabled already:
  - Disable 2FA, and then hit the "Back" button.
  - Verify that the main security nav reflects the change after navigating back. (We'll do this later if you didn't have 2FA enabled 😄.)
  - Click on the "Two-Step Authentication" item/row to get back to the 2FA screen.
* Work through the process to enable 2FA using either your phone number or an app, _but don't verify the backup codes yet_. (You should still save them somewhere! We'll need them a bit later.)
* Click the "Back" button in the top left corner, and verify that the "Two-Step Authentication" item shows 2FA as enabled (possibly after a small delay while fetching updated data), and verify that the "Two-Step Backup Codes" item is visible and shows that you still need to verify the codes.
* Click on the "Two-Step Authentication" item/row again.
* Enter one of the backup codes to verify the codes.
* Click the "Back" button, and verify that the "Two-Step Backup Codes" item updates to reflect the verification.
* If you didn't have 2FA enabled to start with:
  - Click on one of the 2FA items/rows.
  - Disable 2FA.
  - Click on the "Back" button and verify that the "Two-Step Authentication" item updates.