### PR TITLE
Jetpack Scan Section: Expand long text in button dialogs horizontally

### DIFF
--- a/client/components/jetpack/threat-dialog/style.scss
+++ b/client/components/jetpack/threat-dialog/style.scss
@@ -53,7 +53,8 @@
 			width: 100%;
 
 			@include breakpoint-deprecated( '>480px' ) {
-				width: 140px;
+				min-width: 140px;
+				width: auto;
 			}
 		}
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* maintain the design ( 140px width buttons ) for short phrases, but otherwise let scan dialogs expand horizontally

![Untitled 4](https://user-images.githubusercontent.com/2810519/86172252-ed93b400-bad2-11ea-9848-971bdd98add3.png)


#### Testing instructions

1. Have a test site with threat
2. Navigate to `/scan/` on Jetpack Cloud UI w/ branch
3. Open the "fix threat" or "ignore threat" dialog by clicking either button 
![Screen Shot 2020-06-30 at 13 11 58](https://user-images.githubusercontent.com/2810519/86172543-609d2a80-bad3-11ea-8b5e-bf06d1e7e503.png)
4. Verify english leaves the buttons at 140px54. Use dev tools to drop long text into the buttons
6. Verify mobile screen sizes still expand buttons correctly 

fixes 1164141197617539-as-1178616538435396