### PR TITLE
eCommPlan: Update store link target.

### DIFF
--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -634,7 +634,7 @@ export class MySitesSidebar extends Component {
 
 		let storeLink = '/store' + siteSuffix;
 		if ( isEcommerce( site.plan ) ) {
-			storeLink = site.options.admin_url + 'admin.php?page=wc-setup-checklist&calypsoify=1';
+			storeLink = site.options.admin_url + 'admin.php?page=wc-setup&calypsoify=1';
 		}
 
 		return (

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -634,7 +634,7 @@ export class MySitesSidebar extends Component {
 
 		let storeLink = '/store' + siteSuffix;
 		if ( isEcommerce( site.plan ) ) {
-			storeLink = site.options.admin_url + 'admin.php?page=wc-setup&calypsoify=1';
+			storeLink = site.options.admin_url + 'admin.php?page=wc-admin&calypsoify=1';
 		}
 
 		return (

--- a/client/my-sites/sidebar/test/sidebar.js
+++ b/client/my-sites/sidebar/test/sidebar.js
@@ -94,7 +94,7 @@ describe( 'MySitesSidebar', () => {
 
 			const wrapper = shallow( <Store /> );
 			expect( wrapper.props().link ).toEqual(
-				'http://test.com/wp-admin/admin.php?page=wc-setup-checklist&calypsoify=1'
+				'http://test.com/wp-admin/admin.php?page=wc-setup&calypsoify=1'
 			);
 		} );
 

--- a/client/my-sites/sidebar/test/sidebar.js
+++ b/client/my-sites/sidebar/test/sidebar.js
@@ -94,7 +94,7 @@ describe( 'MySitesSidebar', () => {
 
 			const wrapper = shallow( <Store /> );
 			expect( wrapper.props().link ).toEqual(
-				'http://test.com/wp-admin/admin.php?page=wc-setup&calypsoify=1'
+				'http://test.com/wp-admin/admin.php?page=wc-admin&calypsoify=1'
 			);
 		} );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

With some recent changes to the onboarding flow in WooCommerce for eCommerce plan sites, we need to update the target of the "Store" link in the Calypso sidebar. This branch updates that link.

#### Testing instructions
To test you need to have a site that is on an active eCommerce Plan

* Open up My Sites, and select your site that is an eCommerce Plan.
* Verify the link target is updated to  `admin.php?page=wc-setup&calypsoify=1`
* Verify the tests are passing
