### PR TITLE
Add redirects back to WordPress.com from Jetpack Product Upsell Pages

### DIFF
--- a/client/my-sites/backup/wpcom-backup-upsell.tsx
+++ b/client/my-sites/backup/wpcom-backup-upsell.tsx
@@ -8,16 +8,17 @@ import { useSelector } from 'react-redux';
 /**
  * Internal dependencies
  */
+import { addQueryArgs } from '@wordpress/url';
 import { Button } from '@automattic/components';
-import DocumentHead from 'components/data/document-head';
-import Main from 'components/main';
-import SidebarNavigation from 'my-sites/sidebar-navigation';
-import PageViewTracker from 'lib/analytics/page-view-tracker';
-import FormattedHeader from 'components/formatted-header';
-import PromoCard from 'components/promo-section/promo-card';
-import useTrackCallback from 'lib/jetpack/use-track-callback';
 import { getSelectedSiteSlug } from 'state/ui/selectors';
 import { preventWidows } from 'lib/formatting';
+import DocumentHead from 'components/data/document-head';
+import FormattedHeader from 'components/formatted-header';
+import Main from 'components/main';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
+import PromoCard from 'components/promo-section/promo-card';
+import SidebarNavigation from 'my-sites/sidebar-navigation';
+import useTrackCallback from 'lib/jetpack/use-track-callback';
 
 /**
  * Asset dependencies
@@ -60,7 +61,9 @@ export default function WPCOMUpsellPage(): ReactElement {
 				<div className="backup__wpcom-ctas">
 					<Button
 						className="backup__wpcom-cta backup__wpcom-realtime-cta"
-						href={ `/checkout/${ siteSlug }/jetpack_backup_realtime` }
+						href={ addQueryArgs( `/checkout/${ siteSlug }/jetpack_backup_realtime`, {
+							redirect_to: window.location.href,
+						} ) }
 						onClick={ onUpgradeClick }
 						selfTarget={ true }
 						primary
@@ -69,7 +72,9 @@ export default function WPCOMUpsellPage(): ReactElement {
 					</Button>
 					<Button
 						className="backup__wpcom-cta backup__wpcom-daily-cta"
-						href={ `/checkout/${ siteSlug }/jetpack_backup_daily` }
+						href={ addQueryArgs( `/checkout/${ siteSlug }/jetpack_backup_daily`, {
+							redirect_to: window.location.href,
+						} ) }
 						onClick={ onUpgradeClick }
 						selfTarget={ true }
 					>

--- a/client/my-sites/scan/wpcom-scan-upsell.tsx
+++ b/client/my-sites/scan/wpcom-scan-upsell.tsx
@@ -8,15 +8,16 @@ import { useSelector } from 'react-redux';
 /**
  * Internal dependencies
  */
+import { addQueryArgs } from '@wordpress/url';
+import { getSelectedSiteSlug } from 'state/ui/selectors';
 import DocumentHead from 'components/data/document-head';
-import Main from 'components/main';
-import SidebarNavigation from 'my-sites/sidebar-navigation';
-import PageViewTracker from 'lib/analytics/page-view-tracker';
 import FormattedHeader from 'components/formatted-header';
+import Main from 'components/main';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
 import PromoCard from 'components/promo-section/promo-card';
 import PromoCardCTA from 'components/promo-section/promo-card/cta';
+import SidebarNavigation from 'my-sites/sidebar-navigation';
 import useTrackCallback from 'lib/jetpack/use-track-callback';
-import { getSelectedSiteSlug } from 'state/ui/selectors';
 
 /**
  * Asset dependencies
@@ -56,7 +57,9 @@ export default function WPCOMScanUpsellPage(): ReactElement {
 					cta={ {
 						text: translate( 'Get daily scanning' ),
 						action: {
-							url: `/checkout/${ siteSlug }/jetpack_scan`,
+							url: addQueryArgs( `/checkout/${ siteSlug }/jetpack_scan`, {
+								redirect_to: window.location.href,
+							} ),
 							onClick: onUpgradeClick,
 							selfTarget: true,
 						},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* add `redirect_to` args to the backup and scan upsells on WordPress.com

#### Testing instructions

1. spin up a new Jetpack site and connect
2. navigate to `/scan/:siteSlug` on a WordPress.com instance of the branch
3. purchase scan via the "Get daily scan" upset
4. verify you are redirected back to the same WordPress.com scan page
5. Repeat steps 2-4 for `/backup/:siteSlug`

Fixes 1164141197617539-as-1182651032185545
