### PR TITLE
Fix/43595 headings styling on reader matches site

### DIFF
--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -12,28 +12,37 @@
 		font-size: 28px;
 		font-weight: 700;
 		margin: 0 0 16px;
+		font-family: 'Inter var', -apple-system, BlinkMacSystemFont, 'Helvetica Neue', Helvetica,
+			sans-serif;
 	}
 
 	h2 {
 		font-size: 24px;
 		font-weight: 700;
 		margin: 0 0 8px;
+		font-family: 'Inter var', -apple-system, BlinkMacSystemFont, 'Helvetica Neue', Helvetica,
+			sans-serif;
 	}
-
 	h3 {
 		font-size: 20px;
 		font-weight: 700;
 		margin: 0 0 8px;
+		font-family: 'Inter var', -apple-system, BlinkMacSystemFont, 'Helvetica Neue', Helvetica,
+			sans-serif;
 	}
 
 	h4 {
 		font-size: 18px;
 		font-weight: 700;
 		margin: 0 0 8px;
+		font-family: 'Inter var', -apple-system, BlinkMacSystemFont, 'Helvetica Neue', Helvetica,
+			sans-serif;
 	}
 
 	h5 {
 		font-weight: 700;
+		font-family: 'Inter var', -apple-system, BlinkMacSystemFont, 'Helvetica Neue', Helvetica,
+			sans-serif;
 	}
 
 	p,

--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -241,6 +241,69 @@
 		margin: auto;
 	}
 
+	.wp-block-button {
+		display: inline-block;
+		margin-right: 8px;
+		margin-bottom: 8px;
+		border: 1px solid var( --color-neutral-10 );
+		padding: 1.1em 1.44em;
+	}
+
+	.wp-block-button__link {
+		-webkit-appearance: none;
+		-moz-appearance: none;
+		border: none;
+		border-radius: 0;
+		cursor: pointer;
+		display: inline-block;
+		font-size: 1.5rem;
+		font-weight: 600;
+		letter-spacing: 0.0333em;
+		line-height: 1.25;
+		margin: 0;
+		opacity: 1;
+		text-align: center;
+		text-decoration: none;
+		text-transform: uppercase;
+		transition: opacity 0.15s linear;
+	}
+
+	/* .has-vivid-red-background-color {
+		background-color: #cf2e2e;
+	}
+
+	.has-vivid-purple-background-color {
+		background-color: #9b51e0;
+	}
+
+	.has-luminous-vivid-orange-background-color {
+		background-color: #ff6900;
+	}
+
+	.has-luminous-vivid-amber-background-color {
+		background-color: #fcb900;
+	}
+
+	.has-vivid-green-cyan-background-color {
+		background-color: #00d084;
+	}
+
+	.has-vivid-cyan-blue-background-color {
+		background-color: #0693e3;
+	} */
+
+	/* .has-cool-to-warm-spectrum-gradient-background {
+		background: linear-gradient(
+			135deg,
+			#4aeadc,
+			#9778d1 20%,
+			#cf2aba 40%,
+			#ee2c82 60%,
+			#fb6962 80%,
+			#fef84c
+		);
+	} */
+
 	// Import Gutenberg gallery styles
 	@import 'gutenberg-gallery.scss';
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This change handles styling the button block in reader to match the website It is one part of this issue:

#43595

#### Testing instructions

Visit: http://calypso.localhost:3000/read/blogs/159889361/posts/984

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Before: 

![Screenshot 2020-07-03 11 16 37](https://user-images.githubusercontent.com/570876/86416660-abf74900-bd1e-11ea-8070-a86b06f72855.png)

After:

