### PR TITLE
Fix broken rich text blocks in layout picker preview in Firefox

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/block-iframe-preview.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/block-iframe-preview.js
@@ -9,6 +9,7 @@ import classnames from 'classnames';
  */
 /* eslint-disable import/no-extraneous-dependencies */
 import {
+	createPortal,
 	useRef,
 	useEffect,
 	useState,
@@ -87,7 +88,6 @@ const BlockFramePreview = ( {
 	title,
 } ) => {
 	const frameContainerRef = useRef();
-	const renderedBlocksRef = useRef();
 	const iframeRef = useRef();
 
 	// Set the initial scale factor.
@@ -176,15 +176,6 @@ const BlockFramePreview = ( {
 		body.scrollTop = 0;
 	}, [ recomputeBlockListKey ] );
 
-	// Append rendered Blocks to iFrame when changed
-	useEffect( () => {
-		const renderedBlocksDOM = renderedBlocksRef && renderedBlocksRef.current;
-
-		if ( renderedBlocksDOM ) {
-			iframeRef.current.contentDocument.body.appendChild( renderedBlocksDOM );
-		}
-	}, [ recomputeBlockListKey ] );
-
 	// Handling windows resize event.
 	useEffect( () => {
 		const refreshPreview = debounce( rescale, DEBOUNCE_TIMEOUT );
@@ -215,22 +206,26 @@ const BlockFramePreview = ( {
 				title={ __( 'Preview', 'full-site-editing' ) }
 				className={ classnames( 'editor-styles-wrapper', className ) }
 				style={ style }
-			/>
-
-			<div ref={ renderedBlocksRef } className="block-editor">
-				<div className="edit-post-visual-editor">
-					<div className="editor-styles-wrapper">
-						<div className="editor-writing-flow">
-							<CustomBlockPreview
-								blocks={ renderedBlocks }
-								settings={ settings }
-								hidePageTitle={ ! title }
-								recomputeBlockListKey={ recomputeBlockListKey }
-							/>
-						</div>
-					</div>
-				</div>
-			</div>
+			>
+				{ iframeRef.current?.contentDocument?.body &&
+					createPortal(
+						<div className="block-editor">
+							<div className="edit-post-visual-editor">
+								<div className="editor-styles-wrapper">
+									<div className="editor-writing-flow">
+										<CustomBlockPreview
+											blocks={ renderedBlocks }
+											settings={ settings }
+											hidePageTitle={ ! title }
+											recomputeBlockListKey={ recomputeBlockListKey }
+										/>
+									</div>
+								</div>
+							</div>
+						</div>,
+						iframeRef.current.contentDocument.body
+					) }
+			</iframe>
 		</div>
 	);
 	/* eslint-enable wpcalypso/jsx-classname-namespace */


### PR DESCRIPTION
Fix for #43611 where the preview for layouts containing RichText components would fail on the first render, but if you then clicked on other layouts, it would render correctly. This appeared to only affect Firefox, as Chrome looked OK.

In Firefox, when first previewing a layout that contains RichText elements, the blocks would fail rendering when calling [`createElement` in Gutenberg](https://github.com/wordpress/gutenberg/blob/c6df2f4207959a517884cabce26134e78f8bec6c/packages/rich-text/src/to-dom.js#L126). I'm not 100% sure of the cause, but the issue only occurred when we append the `renderedBlocksDOM` to the iframe. My suspicion is that because `createElement` [re-uses a single document](https://github.com/wordpress/gutenberg/blob/4178f2da468fe85505acd659bbd8fd3c95dcd7c9/packages/rich-text/src/create-element.js#L19), creating that document outside of the iFrame context fails when it's added to the iFrame context. Then the subsequent time it's called, perhaps because it's in a fresh context, the subsequent calls work fine.

Whatever the actual cause, swapping out the use of two refs, where we render in the parent context and then `appendChild` to the iframe, and instead using `createPortal` to render directly to the iFrame, appears to fix the issue.

#### Changes proposed in this Pull Request

* In the start page templates layout picker, remove the `renderedBlocksRef` and use `createPortal` to render the `<CustomBlockPreview>` directly in the iFrame.

#### Screenshot (before)

![image](https://user-images.githubusercontent.com/14988353/86218036-9e797c00-bbc3-11ea-8395-05c508e2bf8f.png)

#### Screenshot (after)

![image](https://user-images.githubusercontent.com/14988353/86218202-cff24780-bbc3-11ea-98ee-19dd4435e6d1.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Verify that you can replicate the issue in #43611 
* Sandbox the FSE plugin changes (D45752-code), and your test site
* In Firefox, go to add a new page in your test site. From the initial "Blank" layout, select a layout that contains `RichText` components (e.g. paragraphs and headings) — any of the About pages should do it.
* On first render, the blocks should render correctly and not throw errors (note: many of the layouts _do_ throw unexpected block errors, e.g. Jetpack contact forms / latest posts blocks — these are pre-existing issues and not related to this change)

* Test across Chrome, Edge, IE, etc to make sure there are no regressions.

Fixes #43611 
