### PR TITLE
state: add `fetch` thunk and replace usages of `MediaActions.fetch`

### DIFF
--- a/client/blocks/image-selector/preview.jsx
+++ b/client/blocks/image-selector/preview.jsx
@@ -14,10 +14,10 @@ import { localize } from 'i18n-calypso';
  */
 import { Button } from '@automattic/components';
 import ImagePreloader from 'components/image-preloader';
-import MediaActions from 'lib/media/actions';
 import MediaStore from 'lib/media/store';
 import Spinner from 'components/spinner';
 import { url } from 'lib/media/utils';
+import { fetch } from 'state/media/thunks';
 
 export class ImageSelectorPreview extends Component {
 	static propTypes = {
@@ -80,7 +80,7 @@ export class ImageSelectorPreview extends Component {
 				id = parseInt( id, 10 );
 				const media = MediaStore.get( siteId, id );
 				if ( ! media ) {
-					MediaActions.fetch( siteId, id );
+					fetch( siteId, id );
 				}
 			} );
 		} );

--- a/client/blocks/image-selector/preview.jsx
+++ b/client/blocks/image-selector/preview.jsx
@@ -8,6 +8,7 @@ import { isEqual, uniq } from 'lodash';
 import classNames from 'classnames';
 import Gridicon from 'components/gridicon';
 import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -80,7 +81,7 @@ export class ImageSelectorPreview extends Component {
 				id = parseInt( id, 10 );
 				const media = MediaStore.get( siteId, id );
 				if ( ! media ) {
-					fetchMediaItem( siteId, id );
+					this.props.fetchMediaItem( siteId, id );
 				}
 			} );
 		} );
@@ -237,4 +238,4 @@ export class ImageSelectorPreview extends Component {
 	}
 }
 
-export default localize( ImageSelectorPreview );
+export default connect( null, { fetchMediaItem } )( localize( ImageSelectorPreview ) );

--- a/client/blocks/image-selector/preview.jsx
+++ b/client/blocks/image-selector/preview.jsx
@@ -17,7 +17,7 @@ import ImagePreloader from 'components/image-preloader';
 import MediaStore from 'lib/media/store';
 import Spinner from 'components/spinner';
 import { url } from 'lib/media/utils';
-import { fetch } from 'state/media/thunks';
+import { fetchMediaItem } from 'state/media/thunks';
 
 export class ImageSelectorPreview extends Component {
 	static propTypes = {
@@ -80,7 +80,7 @@ export class ImageSelectorPreview extends Component {
 				id = parseInt( id, 10 );
 				const media = MediaStore.get( siteId, id );
 				if ( ! media ) {
-					fetch( siteId, id );
+					fetchMediaItem( siteId, id );
 				}
 			} );
 		} );

--- a/client/components/tinymce/plugins/media/plugin.jsx
+++ b/client/components/tinymce/plugins/media/plugin.jsx
@@ -32,6 +32,7 @@ import { ModalViews } from 'state/ui/media-modal/constants';
 import { renderWithReduxStore } from 'lib/react-helpers';
 import Gridicon from 'components/gridicon';
 import { setMediaLibrarySelectedItems } from 'state/media/actions';
+import { fetch } from 'state/media/thunks';
 
 /**
  * Module variables
@@ -718,7 +719,7 @@ function mediaButton( editor ) {
 
 			const media = MediaStore.get( selectedSite.ID, id );
 			if ( ! media ) {
-				MediaActions.fetch( selectedSite.ID, id );
+				store.dispatch( fetch( selectedSite.ID, id ) );
 			}
 
 			return assign( { ID: id }, media );
@@ -781,7 +782,7 @@ function mediaButton( editor ) {
 			}
 
 			setTimeout( function () {
-				MediaActions.fetch( selectedSite.ID, parsed.media.ID );
+				store.dispatch( fetch( selectedSite.ID, parsed.media.ID ) );
 			}, 0 );
 		} );
 	}

--- a/client/components/tinymce/plugins/media/plugin.jsx
+++ b/client/components/tinymce/plugins/media/plugin.jsx
@@ -32,7 +32,7 @@ import { ModalViews } from 'state/ui/media-modal/constants';
 import { renderWithReduxStore } from 'lib/react-helpers';
 import Gridicon from 'components/gridicon';
 import { setMediaLibrarySelectedItems } from 'state/media/actions';
-import { fetch } from 'state/media/thunks';
+import { fetchMediaItem } from 'state/media/thunks';
 
 /**
  * Module variables
@@ -719,7 +719,7 @@ function mediaButton( editor ) {
 
 			const media = MediaStore.get( selectedSite.ID, id );
 			if ( ! media ) {
-				store.dispatch( fetch( selectedSite.ID, id ) );
+				store.dispatch( fetchMediaItem( selectedSite.ID, id ) );
 			}
 
 			return assign( { ID: id }, media );
@@ -782,7 +782,7 @@ function mediaButton( editor ) {
 			}
 
 			setTimeout( function () {
-				store.dispatch( fetch( selectedSite.ID, parsed.media.ID ) );
+				store.dispatch( fetchMediaItem( selectedSite.ID, parsed.media.ID ) );
 			}, 0 );
 		} );
 	}

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -50,7 +50,7 @@ import { withStopPerformanceTrackingProp, PerformanceTrackProps } from 'lib/perf
 import { REASON_BLOCK_EDITOR_UNKOWN_IFRAME_LOAD_FAILURE } from 'state/desktop/window-events';
 import inEditorDeprecationGroup from 'state/editor-deprecation-group/selectors/in-editor-deprecation-group';
 import { setMediaLibrarySelectedItems } from 'state/media/actions';
-import { fetch as fetchMediaItem } from 'state/media/thunks';
+import { fetchMediaItem } from 'state/media/thunks';
 
 /**
  * Types

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -10,7 +10,6 @@ import { localize, LocalizeProps } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import MediaActions from 'lib/media/actions';
 import MediaStore from 'lib/media/store';
 import EditorMediaModal from 'post-editor/editor-media-modal';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
@@ -51,6 +50,7 @@ import { withStopPerformanceTrackingProp, PerformanceTrackProps } from 'lib/perf
 import { REASON_BLOCK_EDITOR_UNKOWN_IFRAME_LOAD_FAILURE } from 'state/desktop/window-events';
 import inEditorDeprecationGroup from 'state/editor-deprecation-group/selectors/in-editor-deprecation-group';
 import { setMediaLibrarySelectedItems } from 'state/media/actions';
+import { fetch as fetchMediaItem } from 'state/media/thunks';
 
 /**
  * Types
@@ -242,7 +242,7 @@ class CalypsoifyIframe extends Component<
 				const selectedItems = ids.map( ( id ) => {
 					const media = MediaStore.get( siteId, id );
 					if ( ! media ) {
-						MediaActions.fetch( siteId, id );
+						this.props.fetchMediaItem( siteId, id );
 					}
 					return {
 						ID: id,
@@ -820,6 +820,7 @@ const mapDispatchToProps = {
 	updateSiteFrontPage,
 	notifyDesktopCannotOpenEditor,
 	setMediaLibrarySelectedItems,
+	fetchMediaItem,
 };
 
 type ConnectedProps = ReturnType< typeof mapStateToProps > & typeof mapDispatchToProps;

--- a/client/lib/media/actions.js
+++ b/client/lib/media/actions.js
@@ -56,35 +56,6 @@ MediaActions.setQuery = function ( siteId, query ) {
 	} );
 };
 
-MediaActions.fetch = function ( siteId, itemId ) {
-	const fetchKey = [ siteId, itemId ].join();
-	if ( MediaActions._fetching[ fetchKey ] ) {
-		return;
-	}
-
-	MediaActions._fetching[ fetchKey ] = true;
-	Dispatcher.handleViewAction( {
-		type: 'FETCH_MEDIA_ITEM',
-		siteId: siteId,
-		id: itemId,
-	} );
-
-	debug( 'Fetching media for %d using ID %d', siteId, itemId );
-	wpcom
-		.site( siteId )
-		.media( itemId )
-		.get( function ( error, data ) {
-			Dispatcher.handleServerAction( {
-				type: 'RECEIVE_MEDIA_ITEM',
-				error: error,
-				siteId: siteId,
-				data: data,
-			} );
-
-			delete MediaActions._fetching[ fetchKey ];
-		} );
-};
-
 MediaActions.fetchNextPage = function ( siteId ) {
 	if ( MediaListStore.isFetchingNextPage( siteId ) ) {
 		return;

--- a/client/lib/media/test/actions.js
+++ b/client/lib/media/test/actions.js
@@ -99,48 +99,6 @@ describe( 'MediaActions', () => {
 		} );
 	} );
 
-	describe( '#fetch()', () => {
-		test( 'should call to the WordPress.com REST API', () => {
-			return new Promise( ( done ) => {
-				Dispatcher.handleViewAction.restore();
-				sandbox.stub( Dispatcher, 'handleViewAction' ).callsFake( function () {
-					expect( MediaActions._fetching ).to.have.all.keys( [
-						[ DUMMY_SITE_ID, DUMMY_ITEM.ID ].join(),
-					] );
-				} );
-
-				MediaActions.fetch( DUMMY_SITE_ID, DUMMY_ITEM.ID );
-
-				expect( Dispatcher.handleViewAction ).to.have.been.calledOnce;
-				expect( stubs.mediaGet ).to.have.been.calledOn( [ DUMMY_SITE_ID, DUMMY_ITEM.ID ].join() );
-				process.nextTick( function () {
-					expect( Dispatcher.handleServerAction ).to.have.been.calledWithMatch( {
-						type: 'RECEIVE_MEDIA_ITEM',
-						error: null,
-						siteId: DUMMY_SITE_ID,
-						data: DUMMY_API_RESPONSE,
-					} );
-
-					done();
-				} );
-			} );
-		} );
-
-		test( 'should not allow simultaneous request for the same item', () => {
-			MediaActions.fetch( DUMMY_SITE_ID, DUMMY_ITEM.ID );
-			MediaActions.fetch( DUMMY_SITE_ID, DUMMY_ITEM.ID );
-
-			expect( stubs.mediaGet ).to.have.been.calledOnce;
-		} );
-
-		test( 'should allow simultaneous request for different items', () => {
-			MediaActions.fetch( DUMMY_SITE_ID, DUMMY_ITEM.ID );
-			MediaActions.fetch( DUMMY_SITE_ID, DUMMY_ITEM.ID + 1 );
-
-			expect( stubs.mediaGet ).to.have.been.calledTwice;
-		} );
-	} );
-
 	describe( '#fetchNextPage()', () => {
 		test( 'should call to the internal WordPress.com REST API', () => {
 			return new Promise( ( done ) => {

--- a/client/post-editor/editor-featured-image/preview-container.jsx
+++ b/client/post-editor/editor-featured-image/preview-container.jsx
@@ -5,17 +5,16 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { defer } from 'lodash';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
-import MediaActions from 'lib/media/actions';
 import MediaStore from 'lib/media/store';
 import EditorFeaturedImagePreview from './preview';
+import { fetch } from 'state/media/thunks';
 
-export default class extends React.Component {
-	static displayName = 'EditorFeaturedImagePreviewContainer';
-
+class EditorFeaturedImagePreviewContainer extends React.Component {
 	static propTypes = {
 		siteId: PropTypes.number.isRequired,
 		itemId: PropTypes.oneOfType( [ PropTypes.number, PropTypes.string ] ).isRequired,
@@ -53,7 +52,7 @@ export default class extends React.Component {
 			}
 
 			defer( () => {
-				MediaActions.fetch( this.props.siteId, this.props.itemId );
+				this.props.fetch( this.props.siteId, this.props.itemId );
 			} );
 		} );
 	};
@@ -83,3 +82,5 @@ export default class extends React.Component {
 		);
 	}
 }
+
+export default connect( null, { fetch } )( EditorFeaturedImagePreviewContainer );

--- a/client/post-editor/editor-featured-image/preview-container.jsx
+++ b/client/post-editor/editor-featured-image/preview-container.jsx
@@ -12,7 +12,7 @@ import { connect } from 'react-redux';
  */
 import MediaStore from 'lib/media/store';
 import EditorFeaturedImagePreview from './preview';
-import { fetch } from 'state/media/thunks';
+import { fetchMediaItem } from 'state/media/thunks';
 
 class EditorFeaturedImagePreviewContainer extends React.Component {
 	static propTypes = {
@@ -83,4 +83,4 @@ class EditorFeaturedImagePreviewContainer extends React.Component {
 	}
 }
 
-export default connect( null, { fetch } )( EditorFeaturedImagePreviewContainer );
+export default connect( null, { fetchMediaItem } )( EditorFeaturedImagePreviewContainer );

--- a/client/state/data-layer/wpcom/sites/media/index.js
+++ b/client/state/data-layer/wpcom/sites/media/index.js
@@ -31,6 +31,8 @@ import {
 	dispatchFluxUpdateMediaItemError,
 	dispatchFluxRemoveMediaItemSuccess,
 	dispatchFluxRemoveMediaItemError,
+	dispatchFluxRequestMediaItemSuccess,
+	dispatchFluxRequestMediaItemError,
 } from 'state/media/utils/flux-adapter';
 
 import { registerHandlers } from 'state/data-layer/handler-registry';
@@ -122,13 +124,17 @@ export function requestMediaItem( action ) {
 	];
 }
 
-export const receiveMediaItem = ( { mediaId, siteId }, media ) => [
-	receiveMedia( siteId, media ),
-	successMediaItemRequest( siteId, mediaId ),
-];
+export const receiveMediaItem = ( { mediaId, siteId }, media ) => ( dispatch ) => {
+	dispatch( receiveMedia( siteId, media ) );
+	dispatch( successMediaItemRequest( siteId, mediaId ) );
 
-export const receiveMediaItemError = ( { mediaId, siteId } ) =>
-	failMediaItemRequest( siteId, mediaId );
+	dispatchFluxRequestMediaItemSuccess( siteId, media );
+};
+
+export const receiveMediaItemError = ( { mediaId, siteId }, error ) => ( dispatch ) => {
+	dispatch( failMediaItemRequest( siteId, mediaId ) );
+	dispatchFluxRequestMediaItemError( siteId, error );
+};
 
 export const requestDeleteMedia = ( action ) => {
 	return [

--- a/client/state/data-layer/wpcom/sites/media/index.js
+++ b/client/state/data-layer/wpcom/sites/media/index.js
@@ -104,7 +104,7 @@ export const requestMediaSuccess = ( { siteId, query }, { media, found } ) => [
 
 export const requestMediaError = ( { siteId, query } ) => failMediaRequest( siteId, query );
 
-export function handleMediaItemRequest( action ) {
+export function requestMediaItem( action ) {
 	const { mediaId, query, siteId } = action;
 
 	log( 'Request media item %d for site %d', mediaId, siteId );
@@ -165,7 +165,7 @@ registerHandlers( 'state/data-layer/wpcom/sites/media/index.js', {
 
 	[ MEDIA_ITEM_REQUEST ]: [
 		dispatchRequest( {
-			fetch: handleMediaItemRequest,
+			fetch: requestMediaItem,
 			onSuccess: receiveMediaItem,
 			onError: receiveMediaItemError,
 		} ),

--- a/client/state/data-layer/wpcom/sites/media/test/index.js
+++ b/client/state/data-layer/wpcom/sites/media/test/index.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import {
-	handleMediaItemRequest,
+	requestMediaItem,
 	receiveMediaItem,
 	receiveMediaItemError,
 	requestMedia,
@@ -56,7 +56,7 @@ describe( 'media request', () => {
 	} );
 } );
 
-describe( 'handleMediaItemRequest', () => {
+describe( 'requestMediaItem', () => {
 	test( 'should dispatch an http action', () => {
 		const siteId = 12345;
 		const mediaId = 67890;
@@ -65,7 +65,7 @@ describe( 'handleMediaItemRequest', () => {
 			mediaId,
 			siteId,
 		};
-		expect( handleMediaItemRequest( action ) ).toEqual(
+		expect( requestMediaItem( action ) ).toEqual(
 			expect.arrayContaining( [
 				http(
 					{
@@ -90,12 +90,13 @@ describe( 'receiveMediaItem', () => {
 			siteId,
 		};
 		const media = { ID: 91827364 };
-		expect( receiveMediaItem( action, media ) ).toEqual(
-			expect.arrayContaining( [
-				receiveMedia( siteId, media ),
-				successMediaItemRequest( siteId, mediaId ),
-			] )
-		);
+
+		const dispatch = jest.fn();
+
+		receiveMediaItem( action, media )( dispatch );
+
+		expect( dispatch ).toHaveBeenNthCalledWith( 1, receiveMedia( siteId, media ) );
+		expect( dispatch ).toHaveBeenNthCalledWith( 2, successMediaItemRequest( siteId, mediaId ) );
 	} );
 } );
 
@@ -108,6 +109,11 @@ describe( 'receiveMediaItemError', () => {
 			mediaId,
 			siteId,
 		};
-		expect( receiveMediaItemError( action ) ).toEqual( failMediaItemRequest( siteId, mediaId ) );
+
+		const dispatch = jest.fn();
+
+		receiveMediaItemError( action )( dispatch );
+
+		expect( dispatch ).toHaveBeenCalledWith( failMediaItemRequest( siteId, mediaId ) );
 	} );
 } );

--- a/client/state/media/thunks/fetch-media-item.js
+++ b/client/state/media/thunks/fetch-media-item.js
@@ -11,7 +11,7 @@ import { dispatchFluxFetchMediaItem } from 'state/media/utils/flux-adapter';
 
 const debug = debugFactory( 'calypso:media' );
 
-export const fetch = ( siteId, mediaId ) => ( dispatch ) => {
+export const fetchMediaItem = ( siteId, mediaId ) => ( dispatch ) => {
 	debug( 'Fetching media for %d using ID %d', siteId, mediaId );
 
 	dispatch( requestMediaItem( siteId, mediaId ) );

--- a/client/state/media/thunks/fetch.js
+++ b/client/state/media/thunks/fetch.js
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+import debugFactory from 'debug';
+
+/**
+ * Internal dependencies
+ */
+import { requestMediaItem } from 'state/media/actions';
+import { dispatchFluxFetchMediaItem } from 'state/media/utils/flux-adapter';
+
+const debug = debugFactory( 'calypso:media' );
+
+export const fetch = ( siteId, mediaId ) => ( dispatch ) => {
+	debug( 'Fetching media for %d using ID %d', siteId, mediaId );
+
+	dispatch( requestMediaItem( siteId, mediaId ) );
+
+	dispatchFluxFetchMediaItem( siteId, mediaId );
+};

--- a/client/state/media/thunks/index.js
+++ b/client/state/media/thunks/index.js
@@ -4,3 +4,4 @@ export { addExternalMedia } from './add-external-media';
 export { editMedia } from './edit-media';
 export { updateMedia } from './update-media';
 export { deleteMedia } from './delete-media';
+export { fetch } from './fetch';

--- a/client/state/media/thunks/index.js
+++ b/client/state/media/thunks/index.js
@@ -4,4 +4,4 @@ export { addExternalMedia } from './add-external-media';
 export { editMedia } from './edit-media';
 export { updateMedia } from './update-media';
 export { deleteMedia } from './delete-media';
-export { fetch } from './fetch';
+export { fetchMediaItem } from './fetch-media-item';

--- a/client/state/media/utils/flux-adapter.js
+++ b/client/state/media/utils/flux-adapter.js
@@ -27,6 +27,22 @@ export const dispatchFluxReceiveMediaItemError = ( transientMediaId, siteId, err
 		error,
 	} );
 
+export const dispatchFluxRequestMediaItemSuccess = ( siteId, mediaItem ) => {
+	Dispatcher.handleServerAction( {
+		type: 'RECEIVE_MEDIA_ITEM',
+		siteId,
+		data: mediaItem,
+	} );
+};
+
+export const dispatchFluxRequestMediaItemError = ( siteId, error ) => {
+	Dispatcher.handleServerAction( {
+		type: 'RECEIVE_MEDIA_ITEM',
+		siteId,
+		error,
+	} );
+};
+
 export const dispatchFluxUpdateMediaItem = ( siteId, updatedMediaItem ) => {
 	Dispatcher.handleViewAction( {
 		type: 'RECEIVE_MEDIA_ITEM',
@@ -72,6 +88,14 @@ export const dispatchFluxRemoveMediaItemError = ( siteId, error ) => {
 		type: 'REMOVE_MEDIA_ITEM',
 		siteId,
 		error,
+	} );
+};
+
+export const dispatchFluxFetchMediaItem = ( siteId, mediaId ) => {
+	Dispatcher.handleViewAction( {
+		type: 'FETCH_MEDIA_ITEM',
+		siteId: siteId,
+		id: mediaId,
 	} );
 };
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* create a `fetch` thunk which requests a media item by id
* replace usages of `MediaActions.fetch` with `fetch` thunk

#### Testing instructions

##### Gutenberg Editor

1. Open the Gutenberg Editor and place an image somewhere in your post / site
2. Hit reload and click on the image, then hit _Replace_

The second step should trigger a network request to fetch media data. I'm not exactly sure why this call is there because there's already a fetch triggered by only clicking on the item (step 1) and there's another request to `/media` as soon as the media library popup is shown. Here's what this cascade of requests looks for me (same on this branch and master):

<img width="756" alt="Screenshot 2020-07-06 at 10 40 09" src="https://user-images.githubusercontent.com/9202899/86573726-14d7fe80-bf75-11ea-8034-5dc831bcdbca.png">

##### TinyMCE media plugin

1. Open a post in the classic editor which contains an image
2. Open the browser devtools and switch to the _Network_ tab
3. Reload the window
4. Make sure there's an XHR request to `/media/<mediaId>`
5. Right-click on the image and click the edit icon
6. Make sure in the modal the image loads and meta data is there

##### `<EditorFeaturedImagePreviewContainer />`

I think this component is subject to be refactored. As far as I understand what's happening, the `fetch()` call is basically dead code because there's a `<QueryMedia />` component used in the parent component which already takes care of fetching relevant media information.

To test, however, if this code would work correctly you can comment out the `<QueryMedia />` component in `client/post-editor/editor-featured-image/index.jsx` and follow these steps:

1. Open a post which has a featured image
2. Make sure the preview image above the post loads

##### `<ImageSelectorPreview />`

This one is a bit tricky to test, but I didn't found another way to trigger the `fetch()` action.

You'll need at least two images in your media library and you need to know their IDs.

1. Go to `/devdocs/blocks/image-selector`
2. Open your browser devtools (assuming you also have the React.js devtools plugin installed)
3. Click on the "plus" and add an image from your media library
4. Go to React devtools _Components_ tab and search for `<ImageSelectorPreview />`
5. Edit the `itemIds` array in the _props_ section and replace the existing ID with another one.
6. Make sure the new image loads!

If you want to dig even deeper to make sure the correct function is triggered go to the _Sources_ tab, open the `blocks/image-selector/preview.jsx` file and add a breakpoint to the line where we call the `fetch()` action.

related to #43660
