### PR TITLE
PlansGrid: Use plans store key from constant instead of registering.

### DIFF
--- a/packages/plans-grid/src/constants.ts
+++ b/packages/plans-grid/src/constants.ts
@@ -1,0 +1,1 @@
+export const PLANS_STORE = 'automattic/onboard/plans';

--- a/packages/plans-grid/src/plans-details/index.tsx
+++ b/packages/plans-grid/src/plans-details/index.tsx
@@ -4,19 +4,20 @@
 import React from 'react';
 import { useI18n } from '@automattic/react-i18n';
 import { useSelect } from '@wordpress/data';
-import { Plans } from '@automattic/data-stores';
 import { Button } from '@wordpress/components';
-
 import { Icon, check } from '@wordpress/icons';
 
-const TickIcon = <Icon icon={ check } size={ 25 } />;
+/**
+ * Internal dependencies
+ */
+import { PLANS_STORE } from '../constants';
 
 /**
  * Style dependencies
  */
 import './style.scss';
 
-const PLANS_STORE = Plans.register();
+const TickIcon = <Icon icon={ check } size={ 25 } />;
 
 type Props = {
 	onSelect: Function;

--- a/packages/plans-grid/src/plans-grid/index.tsx
+++ b/packages/plans-grid/src/plans-grid/index.tsx
@@ -4,7 +4,7 @@
 import * as React from 'react';
 import { useDispatch } from '@wordpress/data';
 import { useI18n } from '@automattic/react-i18n';
-import { Plans, DomainSuggestions } from '@automattic/data-stores';
+import type { Plans, DomainSuggestions } from '@automattic/data-stores';
 
 /**
  * Internal dependencies
@@ -12,13 +12,12 @@ import { Plans, DomainSuggestions } from '@automattic/data-stores';
 import { Title } from '../titles';
 import PlansTable from '../plans-table';
 import PlansDetails from '../plans-details';
+import { PLANS_STORE } from '../constants';
 
 /**
  * Style dependencies
  */
 import './style.scss';
-
-const PLANS_STORE = Plans.register();
 type PlansSlug = Plans.PlanSlug;
 
 export interface Props {

--- a/packages/plans-grid/src/plans-table/index.tsx
+++ b/packages/plans-grid/src/plans-table/index.tsx
@@ -3,19 +3,18 @@
  */
 import React, { useState } from 'react';
 import { useSelect } from '@wordpress/data';
-import { Plans, DomainSuggestions } from '@automattic/data-stores';
+import type { DomainSuggestions } from '@automattic/data-stores';
 
 /**
  * Internal dependencies
  */
 import PlanItem from './plan-item';
+import { PLANS_STORE } from '../constants';
 
 /**
  * Style dependencies
  */
 import './style.scss';
-
-const PLANS_STORE = Plans.register();
 
 export interface Props {
 	selectedPlanSlug: string;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use plans store key from constant instead of registering.

#### Testing instructions

* Rebuild plans grid package (simply run `yarn` on local folder just to be sure everything is rebuilt).
* Test on `/new` and ensure plans grid still works.
