### PR TITLE
Separate free and paid domains in domain picker and fix empty state on mobile

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -118,7 +118,7 @@ export default {
 		allowExistingUsers: true,
 	},
 	newSiteGutenbergOnboarding: {
-		datestamp: '20200617',
+		datestamp: '20200702',
 		variations: {
 			gutenberg: 10,
 			control: 90,

--- a/packages/domain-picker/src/domain-picker/index.tsx
+++ b/packages/domain-picker/src/domain-picker/index.tsx
@@ -185,6 +185,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 							) }
 						</div>
 
+<<<<<<< HEAD
 						<div className="domain-picker__suggestion-item-group">
 							{ ! domainSuggestions ||
 							( domainSuggestions?.length && domainSuggestions?.length > 1 ) ? (
@@ -205,6 +206,50 @@ const DomainPicker: FunctionComponent< Props > = ( {
 										onSelect={ onDomainSelect }
 									/>
 								) ) ?? times( quantity - 1, ( i ) => <SuggestionItemPlaceholder key={ i } /> ) }
+=======
+							{ domainSuggestions.length > 1 && (
+								<div className="domain-picker__suggestion-item-group">
+									<p className="domain-picker__suggestion-group-label">
+										{ __( 'Custom domains' ) }
+									</p>
+									{ domainSuggestions.slice( 1 ).map( ( suggestion, i ) => (
+										<SuggestionItem
+											key={ suggestion.domain_name }
+											suggestion={ suggestion }
+											railcarId={ baseRailcarId ? `${ baseRailcarId }${ i }` : undefined }
+											isRecommended={ i === 0 }
+											onRender={ () =>
+												handleItemRender( suggestion, `${ baseRailcarId }${ i }`, i, i === 0 )
+											}
+											onSelect={ onDomainSelect }
+										/>
+									) ) }
+								</div>
+							) }
+
+							{ ! isExpanded &&
+								allDomainSuggestions?.length &&
+								allDomainSuggestions?.length > quantity && (
+									<div className="domain-picker__show-more">
+										<Button onClick={ () => setIsExpanded( true ) }>
+											{ __( 'View more results' ) }
+										</Button>
+									</div>
+								) }
+						</div>
+					) : (
+						<div className="domain-picker__suggestion-sections">
+							<div className="domain-picker__suggestion-item-group">
+								<p className="domain-picker__suggestion-group-label">{ __( 'Sub-domain' ) }</p>
+								<SuggestionItemPlaceholder key={ -1 } />
+							</div>
+							<div className="domain-picker__suggestion-item-group">
+								<p className="domain-picker__suggestion-group-label">{ __( 'Custom domains' ) }</p>
+								{ times( quantity - 1, ( i ) => (
+									<SuggestionItemPlaceholder key={ i } />
+								) ) }
+							</div>
+>>>>>>> Handle lack of paid domains response from the API
 						</div>
 
 						{ ! isExpanded &&

--- a/packages/domain-picker/src/domain-picker/index.tsx
+++ b/packages/domain-picker/src/domain-picker/index.tsx
@@ -184,8 +184,6 @@ const DomainPicker: FunctionComponent< Props > = ( {
 								<SuggestionItemPlaceholder />
 							) }
 						</div>
-
-<<<<<<< HEAD
 						<div className="domain-picker__suggestion-item-group">
 							{ ! domainSuggestions ||
 							( domainSuggestions?.length && domainSuggestions?.length > 1 ) ? (
@@ -206,50 +204,6 @@ const DomainPicker: FunctionComponent< Props > = ( {
 										onSelect={ onDomainSelect }
 									/>
 								) ) ?? times( quantity - 1, ( i ) => <SuggestionItemPlaceholder key={ i } /> ) }
-=======
-							{ domainSuggestions.length > 1 && (
-								<div className="domain-picker__suggestion-item-group">
-									<p className="domain-picker__suggestion-group-label">
-										{ __( 'Custom domains' ) }
-									</p>
-									{ domainSuggestions.slice( 1 ).map( ( suggestion, i ) => (
-										<SuggestionItem
-											key={ suggestion.domain_name }
-											suggestion={ suggestion }
-											railcarId={ baseRailcarId ? `${ baseRailcarId }${ i }` : undefined }
-											isRecommended={ i === 0 }
-											onRender={ () =>
-												handleItemRender( suggestion, `${ baseRailcarId }${ i }`, i, i === 0 )
-											}
-											onSelect={ onDomainSelect }
-										/>
-									) ) }
-								</div>
-							) }
-
-							{ ! isExpanded &&
-								allDomainSuggestions?.length &&
-								allDomainSuggestions?.length > quantity && (
-									<div className="domain-picker__show-more">
-										<Button onClick={ () => setIsExpanded( true ) }>
-											{ __( 'View more results' ) }
-										</Button>
-									</div>
-								) }
-						</div>
-					) : (
-						<div className="domain-picker__suggestion-sections">
-							<div className="domain-picker__suggestion-item-group">
-								<p className="domain-picker__suggestion-group-label">{ __( 'Sub-domain' ) }</p>
-								<SuggestionItemPlaceholder key={ -1 } />
-							</div>
-							<div className="domain-picker__suggestion-item-group">
-								<p className="domain-picker__suggestion-group-label">{ __( 'Custom domains' ) }</p>
-								{ times( quantity - 1, ( i ) => (
-									<SuggestionItemPlaceholder key={ i } />
-								) ) }
-							</div>
->>>>>>> Handle lack of paid domains response from the API
 						</div>
 
 						{ ! isExpanded &&

--- a/packages/domain-picker/src/domain-picker/index.tsx
+++ b/packages/domain-picker/src/domain-picker/index.tsx
@@ -100,16 +100,6 @@ const DomainPicker: FunctionComponent< Props > = ( {
 		isExpanded ? quantityExpanded : quantity
 	);
 
-	// Put the free domain at the second place and things will be sorted properly
-	if ( domainSuggestions && domainSuggestions.length > 1 ) {
-		const freeDomainIndex = domainSuggestions.findIndex( ( domain ) => domain.is_free );
-		if ( freeDomainIndex > -1 ) {
-			const swap = domainSuggestions[ 1 ];
-			domainSuggestions[ 1 ] = domainSuggestions[ freeDomainIndex ];
-			domainSuggestions[ freeDomainIndex ] = swap;
-		}
-	}
-
 	// Reset expansion state after every search
 	useEffect( () => {
 		setIsExpanded( false );
@@ -176,20 +166,47 @@ const DomainPicker: FunctionComponent< Props > = ( {
 							<DomainCategories selected={ domainCategory } onSelect={ setDomainCategory } />
 						</div>
 					) }
-					<div className="domain-picker__suggestion-item-group">
-						{ domainSuggestions?.map( ( suggestion, i ) => (
-							<SuggestionItem
-								selected={ currentDomain === suggestion.domain_name }
-								key={ suggestion.domain_name }
-								suggestion={ suggestion }
-								railcarId={ baseRailcarId ? `${ baseRailcarId }${ i }` : undefined }
-								isRecommended={ i === 0 }
-								onRender={ () =>
-									handleItemRender( suggestion, `${ baseRailcarId }${ i }`, i, i === 0 )
-								}
-								onSelect={ onDomainSelect }
-							/>
-						) ) ?? times( quantity, ( i ) => <SuggestionItemPlaceholder key={ i } /> ) }
+					<div className="domain-picker__suggestion-sections">
+						<div className="domain-picker__suggestion-item-group">
+							<p className="domain-picker__suggestion-group-label">{ __( 'Sub-domain' ) }</p>
+							{ domainSuggestions?.[ 0 ] ? (
+								<SuggestionItem
+									key={ domainSuggestions[ 0 ].domain_name }
+									suggestion={ domainSuggestions[ 0 ] }
+									railcarId={ baseRailcarId ? `${ baseRailcarId }1` : undefined }
+									onRender={ () =>
+										handleItemRender( domainSuggestions[ 0 ], `${ baseRailcarId }1`, 0, false )
+									}
+									selected={ currentDomain === domainSuggestions[ 0 ].domain_name }
+									onSelect={ onDomainSelect }
+								/>
+							) : (
+								<SuggestionItemPlaceholder />
+							) }
+						</div>
+
+						<div className="domain-picker__suggestion-item-group">
+							{ ! domainSuggestions ||
+							( domainSuggestions?.length && domainSuggestions?.length > 1 ) ? (
+								<p className="domain-picker__suggestion-group-label">{ __( 'Custom domains' ) }</p>
+							) : null }
+							{ domainSuggestions
+								?.slice( 1 )
+								.map( ( suggestion, i ) => (
+									<SuggestionItem
+										key={ suggestion.domain_name }
+										suggestion={ suggestion }
+										railcarId={ baseRailcarId ? `${ baseRailcarId }${ i }` : undefined }
+										isRecommended={ i === 0 }
+										onRender={ () =>
+											handleItemRender( suggestion, `${ baseRailcarId }${ i }`, i, i === 0 )
+										}
+										selected={ currentDomain === suggestion.domain_name }
+										onSelect={ onDomainSelect }
+									/>
+								) ) ?? times( quantity - 1, ( i ) => <SuggestionItemPlaceholder key={ i } /> ) }
+						</div>
+
 						{ ! isExpanded &&
 							allDomainSuggestions?.length &&
 							allDomainSuggestions?.length > quantity && (

--- a/packages/domain-picker/src/domain-picker/style.scss
+++ b/packages/domain-picker/src/domain-picker/style.scss
@@ -50,6 +50,21 @@
 	flex-grow: 1;
 }
 
+.domain-picker__suggestion-sections {
+	flex: 1;
+}
+
+.domain-picker__suggestion-group-label {
+	margin: 0;
+	margin-top: 1.5em;
+	margin-bottom: 1em;
+	text-transform: uppercase;
+	color: var( --studio-gray-20 );
+	font-size: 12px;
+	font-weight: 400;
+	letter-spacing: 1px;
+}
+
 .domain-picker__suggestion-item {
 	@include domain-picker-package-medium-text;
 	display: flex;
@@ -92,6 +107,16 @@
 				opacity: 0;
 			}
 		}
+	}
+
+	&:first-of-type {
+		border-top-left-radius: 5px;
+		border-top-right-radius: 5px;
+	}
+
+	&:last-of-type {
+		border-bottom-left-radius: 5px;
+		border-bottom-right-radius: 5px;
 	}
 
 	+ .domain-picker__suggestion-item {

--- a/packages/domain-picker/src/domain-picker/style.scss
+++ b/packages/domain-picker/src/domain-picker/style.scss
@@ -4,13 +4,22 @@
 .domain-picker__empty-state {
 	display: flex;
 	justify-content: center;
-	align-items: center;
+	flex-direction: column;
 
 	&--text {
 		max-width: 320px;
 		font-size: 0.9em;
-		margin: 0 10px;
+		margin: 10px 0;
 		color: $dark-gray-500;
+	}
+
+	@include break-mobile {
+		flex-direction: row;
+		align-items: center;
+
+		&--text {
+			margin: 15px 0;
+		}
 	}
 }
 

--- a/packages/domain-picker/src/domain-picker/suggestion-item.tsx
+++ b/packages/domain-picker/src/domain-picker/suggestion-item.tsx
@@ -85,7 +85,7 @@ const DomainPickerSuggestionItem: FunctionComponent< Props > = ( {
 				} ) }
 			>
 				{ suggestion.is_free ? (
-					__( 'Free' )
+					__( 'Included in free plan' )
 				) : (
 					<>
 						<span className="domain-picker__price-long">


### PR DESCRIPTION
#### Changes proposed in this Pull Request

1. It separates domains into two subgroups, free and paid.
2. It fixes the empty state on mobile. Currently, it looks like this:
<kbd><img src="https://user-images.githubusercontent.com/17054134/86241695-b4774480-bba3-11ea-9bc1-6c9ac5fed441.png" width="300" /></kbd>
After the change, it looks like this:
<kbd><img src="https://user-images.githubusercontent.com/17054134/86242118-762e5500-bba4-11ea-94f7-b9e817c39e25.png" width="300" /></kbd>


#### Testing instructions

1. Search for a domain, placeholders should have the same structure as results.
2. Search for a very long domain (50+ chars), the API will give only free option, results should look sane (the Custom domains subgroup shouldn't show up at all).
3. Test on mobile. It should look as you'd expect.
4. Test empty state by emptying the search field. On Desktop and mobile (Chrome DevTools is more than enough).

Fixes https://github.com/Automattic/wp-calypso/issues/43823


#### For translators:
Screenshot for translators:
![image](https://user-images.githubusercontent.com/17054134/86245916-7fbabb80-bbaa-11ea-87c2-3f182be07a2f.png)
