### PR TITLE
Coming soon simplified (WIP prototype)

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/coming-soon/coming-soon.php
+++ b/apps/full-site-editing/full-site-editing-plugin/coming-soon/coming-soon.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Coming Soon
+ *
+ * @package A8C\FSE
+ */
+
+namespace A8C\FSE\Coming_soon;
+
+function show_coming_soon_page() {
+	global $post;
+
+	if ( is_user_logged_in() ) {
+		return false;
+	}
+
+	// Handle the case where we are not rendering a post.
+	if ( ! isset( $post ) ) {
+		return false;
+	}
+
+	// Allow anonymous previews
+	if ( isset( $_GET['preview'] ) ) {
+		return false;
+	}
+
+	return ( (int) get_option( 'page_on_front' ) === $post->ID );
+}
+
+function coming_soon_page() {
+	global $post;
+	if ( ! show_coming_soon_page() ) {
+		return;
+	}
+
+	$id = (int) get_option( 'page_for_coming_soon', 0 );
+
+	if ( empty( $id ) ) {
+		return;
+	}
+
+	$page = get_post( $id );
+
+	if ( ! $page ) {
+		return;
+	}
+
+	// Disable a few floating UI things
+	add_filter( 'wpcom_disable_logged_out_follow', '__return_true', 1, 999 );
+	add_filter( 'wpl_is_enabled_sitewide', '__return_false', 1, 999 );
+	// add_filter( 'jetpack_disable_eu_cookie_law_widget', '__return_true', 1, 999 );
+
+	?><!doctype html>
+	<html <?php language_attributes(); ?>>
+		<head>
+			<meta charset="<?php bloginfo( 'charset' ); ?>" />
+			<meta name="viewport" content="width=device-width, initial-scale=1" />
+			<?php wp_head(); ?>
+		</head>
+		<body>
+			<?php echo apply_filters( 'the_content', $page->post_content ); ?>
+			<?php wp_footer(); ?>
+		</body>
+	</html>
+	<?php
+	die();
+}
+add_action( 'wp', __NAMESPACE__ . '\coming_soon_page' );

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -327,3 +327,11 @@ function load_donations() {
 	require_once __DIR__ . '/donations/donations.php';
 }
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_donations' );
+
+/**
+ * Coming soon
+ */
+function load_coming_soon() {
+	require_once __DIR__ . '/coming-soon/coming-soon.php';
+}
+add_action( 'plugins_loaded', __NAMESPACE__ . '\load_coming_soon' );

--- a/client/my-sites/pages/page-card-info/index.jsx
+++ b/client/my-sites/pages/page-card-info/index.jsx
@@ -9,7 +9,7 @@ import Gridicon from 'components/gridicon';
 /**
  * Internal dependencies
  */
-import { isFrontPage, isPostsPage } from 'state/pages/selectors';
+import { isComingSoonPage, isFrontPage, isPostsPage } from 'state/pages/selectors';
 import PostRelativeTimeStatus from 'my-sites/post-relative-time-status';
 import canCurrentUser from 'state/selectors/can-current-user';
 import getEditorUrl from 'state/selectors/get-editor-url';
@@ -42,6 +42,7 @@ function PageCardInfo( {
 	page,
 	showTimestamp,
 	showPublishedStatus,
+	isComingSoon,
 	isFront,
 	isPosts,
 	siteUrl,
@@ -65,6 +66,12 @@ function PageCardInfo( {
 						gridiconSize={ ICON_SIZE }
 						includeBasicStatus={ true }
 					/>
+				) }
+				{ isComingSoon && (
+					<span className="page-card-info__badge">
+						<Gridicon icon="house" size={ ICON_SIZE } className="page-card-info__badge-icon" />
+						<span className="page-card-info__badge-text">{ translate( 'Coming soon page' ) }</span>
+					</span>
 				) }
 				{ isFront && (
 					<span className="page-card-info__badge">
@@ -95,6 +102,7 @@ export default connect( ( state, props ) => {
 	const themeId = PostMetadata.homepageTemplate( props.page );
 
 	return {
+		isComingSoon: isComingSoonPage( state, props.page.site_ID, props.page.ID ),
 		isFront: isFrontPage( state, props.page.site_ID, props.page.ID ),
 		isPosts: isPostsPage( state, props.page.site_ID, props.page.ID ),
 		theme: themeId && getTheme( state, 'wpcom', themeId ),

--- a/client/state/data-layer/wpcom/sites/homepage/index.js
+++ b/client/state/data-layer/wpcom/sites/homepage/index.js
@@ -22,6 +22,7 @@ const updateSiteFrontPageRequest = ( action ) =>
 			body: {
 				is_page_on_front: 'page' === get( action.frontPageOptions, 'show_on_front' ),
 				page_on_front_id: get( action.frontPageOptions, 'page_on_front' ),
+				page_for_coming_soon_id: get( action.frontPageOptions, 'page_for_coming_soon' ),
 				page_for_posts_id: get( action.frontPageOptions, 'page_for_posts' ),
 			},
 		},
@@ -30,13 +31,14 @@ const updateSiteFrontPageRequest = ( action ) =>
 
 const setSiteFrontPage = (
 	{ siteId },
-	{ is_page_on_front, page_on_front_id, page_for_posts_id }
+	{ is_page_on_front, page_on_front_id, page_for_coming_soon_id, page_for_posts_id }
 ) => ( dispatch ) => {
 	dispatch(
 		bypassDataLayer(
 			updateSiteFrontPage( siteId, {
 				show_on_front: is_page_on_front ? 'page' : 'posts',
 				page_on_front: parseInt( page_on_front_id, 10 ),
+				page_for_coming_soon: parseInt( page_for_coming_soon_id, 10 ),
 				page_for_posts: parseInt( page_for_posts_id, 10 ),
 			} )
 		)

--- a/client/state/pages/selectors.js
+++ b/client/state/pages/selectors.js
@@ -5,7 +5,11 @@
 /**
  * Internal dependencies
  */
-import { getSiteFrontPage, getSitePostsPage } from 'state/sites/selectors';
+import { getComingSoonPage, getSiteFrontPage, getSitePostsPage } from 'state/sites/selectors';
+
+export function isComingSoonPage( state, siteId, pageId ) {
+	return pageId === getComingSoonPage( state, siteId );
+}
 
 export function isFrontPage( state, siteId, pageId ) {
 	return pageId === getSiteFrontPage( state, siteId );

--- a/client/state/sites/actions.js
+++ b/client/state/sites/actions.js
@@ -202,6 +202,7 @@ export const sitePluginUpdated = ( siteId ) => ( {
  * @param  {string} [frontPageOptions.show_on_front] What to show in homepage. Can be 'page' or 'posts'.
  * @param  {number} [frontPageOptions.page_on_front] If `show_on_front = 'page'`, the front page ID.
  * @param  {number} [frontPageOptions.page_for_posts] If `show_on_front = 'page'`, the posts page ID.
+ * @param  {number} [frontPageOptions.page_for_coming_soon] Coming soon page ID.
  * @returns {object} Action object
  */
 export const updateSiteFrontPage = ( siteId, frontPageOptions ) => ( {

--- a/client/state/sites/selectors/get-coming-soon-page.js
+++ b/client/state/sites/selectors/get-coming-soon-page.js
@@ -1,0 +1,15 @@
+/**
+ * Internal dependencies
+ */
+import { getSiteOption } from 'state/sites/selectors';
+
+/**
+ * Returns the ID of the coming soon page, or 0 if not set.
+ *
+ * @param {object} state Global state tree
+ * @param {object} siteId Site ID
+ * @returns {number} ID of the static page set as the coming soon page, or 0 if not set
+ */
+export default function getComingSoonPage( state, siteId ) {
+	return getSiteOption( state, siteId, 'page_for_coming_soon' );
+}

--- a/client/state/sites/selectors/index.js
+++ b/client/state/sites/selectors/index.js
@@ -8,6 +8,7 @@ export { default as canCurrentUserUseStore } from './can-current-user-use-store'
 export { default as canJetpackSiteAutoUpdateCore } from './can-jetpack-site-auto-update-core';
 export { default as canJetpackSiteAutoUpdateFiles } from './can-jetpack-site-auto-update-files';
 export { default as canJetpackSiteUpdateFiles } from './can-jetpack-site-update-files';
+export { default as getComingSoonPage } from './get-coming-soon-page';
 export { default as getCustomizerUrl } from './get-customizer-url';
 export { default as getJetpackComputedAttributes } from './get-jetpack-computed-attributes';
 export { default as getJetpackSiteUpdateFilesDisabledReasons } from './get-jetpack-site-update-files-disabled-reasons';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add simple coming soon to FSE plugin:


#### Testing instructions

1. Apply D45700-code in your sandbox and make sure you're sandboxing the API.
1. Build Calypso or use live-link
1. Create new page with "coming soon" texts
1. Go to "pages" in Calypso, and click three dots menu for that page
1. Set the page as "coming soon"
1. Build FSE plugin and sync it to your sandbox: `cd apps/full-site-editing && yarn dev --sync`
1. Go to your site's frontpage as non-authenticated user, confirm you now see your coming soon page
1. Go to same page as authenticated user, you should see the page normally
1. In editor you can edit everything regularly
1. Customizer loads homepage regurlarly
