### PR TITLE
Stats: Adding promotional banner to the stats page, featuring Earn

### DIFF
--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -39,6 +39,8 @@ import QueryJetpackModules from 'components/data/query-jetpack-modules';
 import EmptyContent from 'components/empty-content';
 import { activateModule } from 'state/jetpack/modules/actions';
 import getCurrentRouteParameterized from 'state/selectors/get-current-route-parameterized';
+import Banner from 'components/banner';
+import isVipSite from 'state/selectors/is-vip-site';
 
 function updateQueryString( query = {} ) {
 	return {
@@ -126,7 +128,7 @@ class StatsSite extends Component {
 	};
 
 	renderStats() {
-		const { date, siteId, slug, isJetpack } = this.props;
+		const { date, siteId, slug, isJetpack, isVip } = this.props;
 
 		const queryDate = date.format( 'YYYY-MM-DD' );
 		const { period, endOf } = this.props.period;
@@ -180,6 +182,21 @@ class StatsSite extends Component {
 						period={ this.props.period }
 						chartTab={ this.props.chartTab }
 					/>
+					{ ! isVip && (
+						<Banner
+							className="stats__upsell-nudge"
+							icon="star"
+							title={ translate( 'Start earning money now' ) }
+							description={ translate(
+								'Accept payments for just about anything and turn your website into a reliable source of income with payments and ads.'
+							) }
+							href={ `/earn/${ slug }` }
+							tracksImpressionName="calypso_earn_banner_on_stats_impression"
+							tracksClickName="calypso__earn_banner_on_stats_cta_click"
+							showIcon={ true }
+							jetpack={ false }
+						/>
+					) }
 					<StickyPanel className="stats__sticky-navigation">
 						<StatsPeriodNavigation
 							date={ date }
@@ -317,11 +334,13 @@ export default connect(
 	( state ) => {
 		const siteId = getSelectedSiteId( state );
 		const isJetpack = isJetpackSite( state, siteId );
+		const isVip = isVipSite( state, siteId );
 		const showEnableStatsModule =
 			siteId && isJetpack && isJetpackModuleActive( state, siteId, 'stats' ) === false;
 		return {
 			isJetpack,
 			siteId,
+			isVip,
 			slug: getSelectedSiteSlug( state ),
 			planSlug: getSitePlanSlug( state, siteId ),
 			showEnableStatsModule,


### PR DESCRIPTION
This PR adds a promotional banner below the chart on the Stats page, featuring the Earn features. Additional context is at pbMlHh-mP-p2.

Clicking the banner takes the customer to the Earn page where they can learn more about the features. From there, the customer can either upgrade or activate the feature, depending on whether they have a paid plan.

Before:
<img width="1007" alt="Screen Shot 2020-07-01 at 10 14 35 AM" src="https://user-images.githubusercontent.com/35781181/86254350-b03b2f00-bb83-11ea-9d8a-af2e4d665157.png">

After:
<img width="1007" alt="Screen Shot 2020-07-01 at 8 05 11 AM" src="https://user-images.githubusercontent.com/35781181/86254386-b9c49700-bb83-11ea-9547-332d2b764c0c.png">


#### Testing instructions

* Checkout branch (git checkout update/stats-add-earn-card-v2
* Run Calypso (yarn start)
* Click the Stats link in the Calypso left nav.
* Confirm that the Earn promo banner is displayed.
* Click the link and confirm that it navigates to the Earn page.
