### PR TITLE
Render the auto-renew checkmark using the detailed domain data

### DIFF
--- a/client/my-sites/domains/domain-management/list/domain-item.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-item.jsx
@@ -155,7 +155,12 @@ class DomainItem extends PureComponent {
 					) }
 				</div>
 				<div className="list__domain-auto-renew">
-					<Gridicon className="domain-item__icon" size={ 18 } icon="minus" />
+					{ domainDetails?.bundledPlanSubscriptionId && (
+						<Gridicon className="domain-item__icon" size={ 18 } icon="minus" />
+					) }
+					{ ! domainDetails?.bundledPlanSubscriptionId && domainDetails?.isAutoRenewing && (
+						<Gridicon className="domain-item__icon" size={ 18 } icon="checkmark" />
+					) }
 				</div>
 				<div className="list__domain-email">{ this.renderEmail( domainDetails ) }</div>
 				{ this.renderOptionsButton() }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Render the auto-renew checkmark using the detailed domain data

#### Testing instructions

* Open /domains/manage and verify that the auto-renew checkmark is rendered properly. For mapped domains bundled with plan I decided to render the minus since the auto-renew is not changeable.
