### PR TITLE
Sidebar: fix showing Tools&Manage based on capabilities

### DIFF
--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -861,6 +861,15 @@ export class MySitesSidebar extends Component {
 		this.onNavigate();
 	};
 
+	canViewAdminSections = () => {
+		const { isAllSitesView, canUserManageOptions, canUserManagePlugins } = this.props;
+
+		return (
+			( ! isAllSitesView && canUserManageOptions ) ||
+			( isAllSitesView && ( canUserManageOptions || canUserManagePlugins ) )
+		);
+	};
+
 	renderSidebarMenus() {
 		if ( this.props.isDomainOnly ) {
 			return (
@@ -930,7 +939,7 @@ export class MySitesSidebar extends Component {
 				<QueryRewindState siteId={ this.props.siteId } />
 				<QueryScanState siteId={ this.props.siteId } />
 
-				{ tools && (
+				{ tools && this.canViewAdminSections() && (
 					<ExpandableSidebarMenu
 						onClick={ this.toggleSection( SIDEBAR_SECTION_TOOLS ) }
 						expanded={ this.props.isToolsSectionOpen }
@@ -945,19 +954,21 @@ export class MySitesSidebar extends Component {
 					</ExpandableSidebarMenu>
 				) }
 
-				<ExpandableSidebarMenu
-					onClick={ this.toggleSection( SIDEBAR_SECTION_MANAGE ) }
-					expanded={ this.props.isManageSectionOpen }
-					title={ this.props.translate( 'Manage' ) }
-					materialIcon="settings"
-				>
-					<ul>
-						{ this.hosting() }
-						{ this.upgrades() }
-						{ this.users() }
-						{ this.siteSettings() }
-					</ul>
-				</ExpandableSidebarMenu>
+				{ this.canViewAdminSections() && (
+					<ExpandableSidebarMenu
+						onClick={ this.toggleSection( SIDEBAR_SECTION_MANAGE ) }
+						expanded={ this.props.isManageSectionOpen }
+						title={ this.props.translate( 'Manage' ) }
+						materialIcon="settings"
+					>
+						<ul>
+							{ this.hosting() }
+							{ this.upgrades() }
+							{ this.users() }
+							{ this.siteSettings() }
+						</ul>
+					</ExpandableSidebarMenu>
+				) }
 
 				{ this.wpAdmin() }
 			</div>
@@ -1050,6 +1061,7 @@ function mapStateToProps( state ) {
 		scanState: getScanState( state, siteId ),
 		rewindState: getRewindState( state, siteId ),
 		isCloudEligible: isJetpackCloudEligible( state, siteId ),
+		isAllSitesView: getSelectedSiteId( state ) === null,
 	};
 }
 


### PR DESCRIPTION
Fixes #42619

In this PR, we fix when we show or hide "Tools" and "Manage" sections in the sidebar based on user's capabilities in regards to the selected site or if it's an All Sites view based on whether the user has capabilities on at least a single site.

I think it's partly a regression introduced in #34676 but I might be wrong.

## Testing instructions

Create a new WP.com account. Invite that wpcom account to another wpcom site as a contributor.

When you select the site on which you are contributor, you shouldn't see Manage and Tools in the sidebar. When you select your primary site, you should see both. When you select All Sites view, you should also see both items since you have the capabilities on the primary site.