### PR TITLE
Posts: Do not show "Upsell Nudge" on Jetpack sites.

### DIFF
--- a/client/my-sites/post-type-list/index.jsx
+++ b/client/my-sites/post-type-list/index.jsx
@@ -18,6 +18,7 @@ import QueryRecentPostViews from 'components/data/query-stats-recent-post-views'
 import { DEFAULT_POST_QUERY } from 'lib/query-manager/post/constants';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import isVipSite from 'state/selectors/is-vip-site';
+import isJetpackSite from 'state/sites/selectors/is-jetpack-site';
 import {
 	isRequestingPostsForQueryIgnoringPage,
 	getPostsForQueryIgnoringPage,
@@ -251,7 +252,7 @@ class PostTypeList extends Component {
 	}
 
 	render() {
-		const { query, siteId, isRequestingPosts, translate, isVip } = this.props;
+		const { query, siteId, isRequestingPosts, translate, isVip, isJetpack } = this.props;
 		const { maxRequestedPage, recentViewIds } = this.state;
 		const posts = this.props.posts || [];
 		const postStatuses = query.status.split( ',' );
@@ -266,6 +267,7 @@ class PostTypeList extends Component {
 			siteId &&
 			posts.length > 10 &&
 			! isVip &&
+			! isJetpack &&
 			query &&
 			( query.type === 'post' || ! query.type ) &&
 			( postStatuses.includes( 'publish' ) || postStatuses.includes( 'private' ) );
@@ -316,6 +318,7 @@ export default connect( ( state, ownProps ) => {
 		siteId,
 		posts: getPostsForQueryIgnoringPage( state, siteId, ownProps.query ),
 		isVip: isVipSite( state, siteId ),
+		isJetpack: isJetpackSite( state, siteId ),
 		isRequestingPosts: isRequestingPostsForQueryIgnoringPage( state, siteId, ownProps.query ),
 		totalPostCount: getPostsFoundForQuery( state, siteId, ownProps.query ),
 		totalPageCount,


### PR DESCRIPTION
The `UpsellNudge` component suggests an upgrade for WordPress.com sites.
Showing it on Jetpack sites is unnecessary, as we don't show ads on Jetpack sites.
It may even be harmful as somebody might get an impression that we are going to show ads on their Jetpack site, which isn't true.

The problem was reported by @csonnek directly to Jetpack Crew, no issue was created.

#### Changes proposed in this Pull Request

The PR adjusts the condition for the `UpsellNudge` so it would not be rendered on Jetpack sites.

#### Testing instructions

1. Open Calypso and choose a Jetpack site with 11 or more posts.
2. Go to the "Site -> Posts" section and make sure that the "Upsell Nudge" **doesn't** show up among the posts.
3. Switch the site to a WordPress.com one with a free plan. It should also have at least 11 posts.
4. Go to the "Site -> Posts" section and make sure that Upsell Nudge **does** show up there after 10th post.

##### Before:
<img width="347" alt="Screen Shot 2020-07-01 at 10 29 40 AM" src="https://user-images.githubusercontent.com/1341249/86262714-dbbf1900-bb85-11ea-9596-4bc795c2579a.png">

###### After:
<img width="347" alt="Screen Shot 2020-07-01 at 10 32 53 AM" src="https://user-images.githubusercontent.com/1341249/86263053-496b4500-bb86-11ea-8934-0db9396f2c5e.png">
