### PR TITLE
ci: add wp-desktop Slack + Github notifications

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -224,7 +224,7 @@ references:
       when: on_success
       command: cd desktop && yarn ci:github:dismiss-review
   desktop-notify-github-failure: &desktop-notify-github-failure
-      name: Notify Github Success
+      name: Notify Github Failure
       when: on_fail
       command: cd desktop && yarn ci:github:add-review
   desktop-notify-slack-failure: &desktop-notify-slack-failure

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -227,6 +227,11 @@ references:
       name: Notify Github Success
       when: on_fail
       command: cd desktop && yarn ci:github:add-review
+  desktop-notify-slack-failure: &desktop-notify-slack-failure
+      webhook: '$SLACK_WP_DESKTOP_E2E'
+      fail_only: true
+      mentions: '$CIRCLE_USERNAME'
+      failure_message: ':red_circle: wp-desktop tests for $CIRCLE_BRANCH have failed.\n\nCalypso PR: $CIRCLE_PULL_REQUEST'
 
 commands:
   prepare:
@@ -641,6 +646,7 @@ jobs:
           root: /home/circleci/wp-calypso
           paths: *desktop-cache-paths
       - run: *desktop-notify-github-failure
+      - slack/status: *desktop-notify-slack-failure
 
   wp-desktop-mac:
     macos:
@@ -693,6 +699,7 @@ jobs:
             - desktop/release
       - run: *desktop-notify-github-success
       - run: *desktop-notify-github-failure
+      - slack/status: *desktop-notify-slack-failure
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -219,6 +219,14 @@ references:
       name: Save desktop cache
       key: v6-desktop-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_SHA1 }}
       paths: *desktop-cache-paths
+  desktop-notify-github-success: &desktop-notify-github-success
+      name: Notify Github Success
+      when: on_success
+      command: cd desktop && yarn ci:github:dismiss-review
+  desktop-notify-github-failure: &desktop-notify-github-failure
+      name: Notify Github Success
+      when: on_fail
+      command: cd desktop && yarn ci:github:add-review
 
 commands:
   prepare:
@@ -632,6 +640,7 @@ jobs:
       - persist_to_workspace:
           root: /home/circleci/wp-calypso
           paths: *desktop-cache-paths
+      - run: *desktop-notify-github-failure
 
   wp-desktop-mac:
     macos:
@@ -682,6 +691,8 @@ jobs:
           root: ~/wp-calypso
           paths:
             - desktop/release
+      - run: *desktop-notify-github-success
+      - run: *desktop-notify-github-failure
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -632,9 +632,6 @@ jobs:
     <<: *desktop_defaults
     steps:
       - checkout
-      - run:
-          name: Test CI Failure
-          command: exit 1
       - run: *update-node
       - run: *yarn-install
       - restore_cache: *desktop-restore-source-cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -632,6 +632,9 @@ jobs:
     <<: *desktop_defaults
     steps:
       - checkout
+      - run:
+          name: Test CI Failure
+          command: exit 1
       - run: *update-node
       - run: *yarn-install
       - restore_cache: *desktop-restore-source-cache

--- a/desktop/bin/github/add-review.js
+++ b/desktop/bin/github/add-review.js
@@ -1,0 +1,7 @@
+const { addReview } = require( './review-actions' );
+
+try {
+	addReview();
+} catch ( error ) {
+	console.log( 'ERROR: failed to add review: ', error ); // eslint-disable-line no-console
+}

--- a/desktop/bin/github/dismiss-review.js
+++ b/desktop/bin/github/dismiss-review.js
@@ -1,0 +1,8 @@
+const { getReviews } = require( './review-actions' );
+
+try {
+	// dismiss existing reviews for user 'wp-desktop'
+	getReviews( true );
+} catch ( error ) {
+	console.log( 'ERROR: failed to dismiss review(s): ', error ); // eslint-disable-line no-console
+}

--- a/desktop/bin/github/review-actions.js
+++ b/desktop/bin/github/review-actions.js
@@ -1,0 +1,113 @@
+/* eslint-disable import/no-nodejs-modules */
+
+// External Dependencies
+const https = require( 'https' );
+
+// Module Constants
+const buildName = process.env.CIRCLE_JOB;
+const buildUrl = process.env.CIRCLE_BUILD_URL;
+const pullRequestUserName = `@${ process.env.CIRCLE_USERNAME }` || '';
+const pullRequestNum = getPullNumber( process.env.CIRCLE_PULL_REQUEST );
+
+const gitHubReviewUsername = 'wp-desktop';
+const calypsoProject = 'Automattic/wp-calypso';
+const pullRequestSha = process.env.CIRCLE_SHA1;
+const githubReviewsBaseUrl = `/repos/${ calypsoProject }/pulls/${ pullRequestNum }/reviews`;
+
+async function request( method = 'GET', postData, path ) {
+	const params = {
+		method,
+		port: 443,
+		host: 'api.github.com',
+		path: path ? path : githubReviewsBaseUrl,
+		headers: {
+			'User-Agent': 'wp-desktop',
+			Authorization: 'token ' + process.env.WP_DESKTOP_SECRET,
+		},
+	};
+
+	return new Promise( ( resolve, reject ) => {
+		const req = https.request( params, ( res ) => {
+			if ( res.statusCode < 200 || res.statusCode >= 300 ) {
+				return reject( new Error( `Status Code: ${ res.statusCode }` ) );
+			}
+
+			const data = [];
+
+			res.on( 'data', ( chunk ) => {
+				data.push( chunk );
+			} );
+
+			res.on( 'end', () => resolve( Buffer.concat( data ).toString() ) );
+		} );
+
+		req.on( 'error', reject );
+
+		if ( postData ) {
+			req.write( postData );
+		}
+
+		req.end();
+	} );
+}
+
+function dismissReview( reviewId ) {
+	const dismissReviewURL = githubReviewsBaseUrl + `/${ reviewId }/dismissals`;
+	const body = JSON.stringify( { message: 'wp-desktop ci passing, closing review' } );
+	return request( 'PUT', body, dismissReviewURL );
+}
+
+async function getReviews( dismiss ) {
+	let reviewed = false;
+	const response = await request( 'GET' );
+	const reviews = JSON.parse( response );
+	if ( reviews.length > 0 ) {
+		for ( let i = 0; i < reviews.length; i++ ) {
+			const review = reviews[ i ];
+			if ( review.user.login === gitHubReviewUsername && review.state !== 'DISMISSED' ) {
+				reviewed = true;
+				if ( dismiss ) {
+					const id = review.id;
+					dismissReview( id );
+				}
+			}
+		}
+	}
+	return reviewed;
+}
+
+async function addReview() {
+	const alreadyReviewed = await getReviews( false );
+
+	// if there are no existing reviews then create one
+	if ( ! alreadyReviewed ) {
+		const msg =
+			`WordPress Desktop CI Failure in job \`${ buildName }\`:` +
+			`\n\n${ pullRequestUserName } please inspect this job's build steps for breaking changes at [this link](${ buildUrl }).` +
+			` For temporal failures, you may try to "Rerun Workflow from Failed".` +
+			`\n\nPlease also ensure this branch is rebased off latest Calypso master.`;
+		const createReviewParameters = {
+			commit_id: pullRequestSha,
+			body: msg,
+			event: 'REQUEST_CHANGES',
+		};
+
+		const body = JSON.stringify( createReviewParameters );
+
+		await request( 'POST', body );
+	}
+}
+
+// get PR number from URL formatted like https://github.com/Automattic/wp-calypso/pull/12345
+function getPullNumber( url ) {
+	const components = url.split( '/' );
+	if ( components.length > 0 ) {
+		return components.pop();
+	}
+	return null;
+}
+
+module.exports = {
+	addReview,
+	getReviews,
+};

--- a/desktop/bin/github/review-actions.js
+++ b/desktop/bin/github/review-actions.js
@@ -82,7 +82,7 @@ async function addReview() {
 	// if there are no existing reviews then create one
 	if ( ! alreadyReviewed ) {
 		const msg =
-			`WordPress Desktop CI Failure in job \`${ buildName }\`:` +
+			`WordPress Desktop CI Failure for job "${ buildName }".` +
 			`\n\n${ pullRequestUserName } please inspect this job's build steps for breaking changes at [this link](${ buildUrl }).` +
 			` For temporal failures, you may try to "Rerun Workflow from Failed".` +
 			`\n\nPlease also ensure this branch is rebased off latest Calypso master.`;

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -20,7 +20,9 @@
 		"wordpress.com"
 	],
 	"scripts": {
-		"build": "npx electron-builder ${ELECTRON_BUILDER_ARGS} build --publish never"
+		"build": "npx electron-builder ${ELECTRON_BUILDER_ARGS} build --publish never",
+		"ci:github:add-review": "node bin/github/add-review.js",
+		"ci:github:dismiss-review": "node bin/github/dismiss-review.js"
 	},
 	"devDependencies": {
 		"asana-phrase": "0.0.8",


### PR DESCRIPTION
### Description

This PR adds Slack and Github notifications for wp-desktop CI. Existing notification logic has been ported from the [canary bridge](https://github.com/Automattic/wp-desktop-gh-bridge/) and [wp-desktop Circle config](https://github.com/Automattic/wp-desktop/blob/ea4649bad1710cae42cefe8596a3ea5779762c6f/.circleci/config.yml#L267).

Github reviews have now been augmented to include a direct link to the failing job:

<p align="center">
<img width="500" alt="Screen Shot 2020-07-01 at 12 26 32 PM" src="https://user-images.githubusercontent.com/8979548/86268441-32345380-bb96-11ea-98cb-c76140705dd8.png">
<p>

### How Was This Tested

A failing commit was created in this branch in f1728fff582a32838c510a2774a89cb959ff69d4. Confirmed that a Slack notification was posted, and a Github review added by the `wp-desktop` account.