### PR TITLE
Fix: Cursor in FormTextInput moves to the end when editing

### DIFF
--- a/client/components/forms/form-text-input/index.jsx
+++ b/client/components/forms/form-text-input/index.jsx
@@ -15,14 +15,10 @@ export default class FormTextInput extends PureComponent {
 	};
 
 	state = {
-		value: '',
+		value: this.props.value || '',
 	};
 
 	currentTextField = undefined;
-
-	componentDidMount() {
-		this.state = { value: this.props.value || '' };
-	}
 
 	componentDidUpdate( oldProps ) {
 		this.updateValueIfNeeded( oldProps.value );

--- a/client/components/forms/form-text-input/index.jsx
+++ b/client/components/forms/form-text-input/index.jsx
@@ -14,7 +14,26 @@ export default class FormTextInput extends PureComponent {
 		className: PropTypes.string,
 	};
 
+	state = {
+		value: '',
+	};
+
 	currentTextField = undefined;
+
+	componentDidMount() {
+		this.state = { value: this.props.value || '' };
+	}
+
+	componentDidUpdate( oldProps ) {
+		this.updateValueIfNeeded( oldProps.value );
+	}
+
+	updateValueIfNeeded( oldValue ) {
+		const { value } = this.props;
+		if ( oldValue !== value && value !== this.state.value ) {
+			this.setState( { value } );
+		}
+	}
 
 	textFieldRef = ( element ) => {
 		this.currentTextField = element;
@@ -44,8 +63,21 @@ export default class FormTextInput extends PureComponent {
 		}
 	};
 
+	onChange = ( event ) => {
+		this.setState( { value: event.target.value } );
+		this.props.onChange?.( event );
+	};
+
 	render() {
-		const props = omit( this.props, 'isError', 'isValid', 'selectOnFocus', 'inputRef' );
+		const props = omit(
+			this.props,
+			'isError',
+			'isValid',
+			'selectOnFocus',
+			'inputRef',
+			'onChange',
+			'value'
+		);
 
 		const classes = classNames( 'form-text-input', this.props.className, {
 			'is-error': this.props.isError,
@@ -56,9 +88,11 @@ export default class FormTextInput extends PureComponent {
 			<input
 				type="text"
 				{ ...props }
+				value={ this.state.value }
 				ref={ this.textFieldRef }
 				className={ classes }
 				onClick={ this.selectOnFocus }
+				onChange={ this.onChange }
 			/>
 		);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR fixes the bug that the text cursor moves to the end when editing. See the below video.

![textcursor-bug](https://user-images.githubusercontent.com/212034/86265887-5c6e2b80-bbff-11ea-9ffa-c2ecf78beeed.gif)

The text field triggers `onChange` event then an ancestor component passes updated `value` prop to the field component. This bug occurs because the `value` prop change takes longer than React tolerates. Eventually React resets the selection, sets the value to the field, and moves the cursor to the end of the new text.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Purchase any plan to see the checkout form.
* Enter the card holder name and delete a letter in the middle.
* The text cursor should not move to the end.
