### PR TITLE
ESLint: Demote inclusive language rule to a warning

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -176,5 +176,8 @@ module.exports = {
 		// - events because we use it for some event emitters
 		// - path because we use it quite a bit
 		'import/no-nodejs-modules': [ 'error', { allow: [ 'url', 'events', 'path', 'config' ] } ],
+
+		// temporarily demote inclusive language rule to a warning until we clear the repository
+		'inclusive-language/use-inclusive-words': 'warn',
 	},
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Demote inclusive language rule to a warning

There are currently too many places to fix that cause errors for people for whom fixing them is out of scope. Likewise, there is no way to exclude specific terms (like `masterbar`) which will probably take a lot longer time to fix.

We can upgrade this rule back to an error (the default) once the rule supports exclusion lists in its configuration. I'm planning on opening a PR for this in the rule.

