### PR TITLE
Show DomainNotice in the all domains list

### DIFF
--- a/client/lib/domains/index.js
+++ b/client/lib/domains/index.js
@@ -28,4 +28,5 @@ export { getRegisteredDomains, isRegisteredDomain } from './registered-domains';
 export { requestGdprConsentManagementLink } from './request-gdpr-consent-management-link';
 export { resendIcannVerification } from './resend-icann-verification';
 export { resendInboundTransferEmail } from './resend-inbound-transfer-email';
+export { resolveDomainStatus } from './resolve-domain-status';
 export { startInboundTransfer } from './start-inbound-transfer';

--- a/client/lib/domains/resolve-domain-status.js
+++ b/client/lib/domains/resolve-domain-status.js
@@ -1,0 +1,209 @@
+/**
+ * External dependencies
+ */
+import { translate } from 'i18n-calypso';
+import moment from 'moment';
+
+/**
+ * Internal dependencies
+ */
+import { transferStatus, type as domainTypes } from './constants';
+import { isExpiringSoon } from 'lib/domains/utils/is-expiring-soon';
+import { isRecentlyRegistered } from 'lib/domains/utils/is-recently-registered';
+import { hasPendingGSuiteUsers } from 'lib/gsuite';
+import { shouldRenderExpiringCreditCard } from 'lib/purchases';
+
+export function resolveDomainStatus(
+	domain,
+	purchase = null,
+	isJetpackSite = null,
+	isSiteAutomatedTransfer = null
+) {
+	switch ( domain.type ) {
+		case domainTypes.MAPPED:
+			if ( isExpiringSoon( domain, 30 ) ) {
+				const expiresMessage = translate( 'Expires in %(days)s', {
+					args: { days: moment.utc( domain.expiry ).fromNow( true ) },
+				} );
+
+				if ( isExpiringSoon( domain, 5 ) ) {
+					return {
+						statusText: expiresMessage,
+						statusClass: 'status-error',
+						icon: 'info',
+						listStatusText: expiresMessage,
+						listStatusClass: 'alert',
+					};
+				}
+
+				return {
+					statusText: expiresMessage,
+					statusClass: 'status-warning',
+					icon: 'info',
+					listStatusText: expiresMessage,
+					listStatusClass: 'warning',
+				};
+			}
+
+			if ( ( ! isJetpackSite || isSiteAutomatedTransfer ) && ! domain.pointsToWpcom ) {
+				return {
+					statusText: translate( 'Action required' ),
+					statusClass: 'status-error',
+					icon: 'info',
+				};
+			}
+
+			if ( hasPendingGSuiteUsers( domain ) ) {
+				return {
+					statusText: translate( 'Action required' ),
+					statusClass: 'status-warning',
+					icon: 'info',
+				};
+			}
+
+			return {
+				statusText: translate( 'Active' ),
+				statusClass: 'status-success',
+				icon: 'check_circle',
+			};
+
+		case domainTypes.REGISTERED:
+			if ( domain.pendingTransfer ) {
+				return {
+					statusText: translate( 'Outbound transfer initiated' ),
+					statusClass: 'status-error',
+					icon: 'cached',
+				};
+			}
+
+			if ( purchase && shouldRenderExpiringCreditCard( purchase ) ) {
+				return {
+					statusText: translate( 'Action required' ),
+					statusClass: 'status-error',
+					icon: 'info',
+				};
+			}
+
+			if ( domain.isPendingIcannVerification && domain.currentUserCanManage ) {
+				return {
+					statusText: translate( 'Action required' ),
+					statusClass: 'status-error',
+					icon: 'info',
+				};
+			}
+
+			if ( domain.expired ) {
+				return {
+					statusText: translate( 'Action required' ),
+					statusClass: 'status-error',
+					icon: 'info',
+					listStatusText: translate( 'Expired %(timeSinceExpiry)s', {
+						args: {
+							timeSinceExpiry: moment( domain.expiry ).fromNow(),
+						},
+						comment:
+							'timeSinceExpiry is of the form "[number] [time-period] ago" e.g. "3 days ago"',
+					} ),
+					listStatusClass: 'alert',
+				};
+			}
+
+			if ( isExpiringSoon( domain, 30 ) ) {
+				const expiresMessage = translate( 'Expires in %(days)s', {
+					args: { days: moment.utc( domain.expiry ).fromNow( true ) },
+				} );
+
+				if ( isExpiringSoon( domain, 5 ) ) {
+					return {
+						statusText: expiresMessage,
+						statusClass: 'status-error',
+						icon: 'info',
+						listStatusText: expiresMessage,
+						listStatusClass: 'alert',
+					};
+				}
+
+				return {
+					statusText: expiresMessage,
+					statusClass: 'status-warning',
+					icon: 'info',
+					listStatusText: expiresMessage,
+					listStatusClass: 'warning',
+				};
+			}
+
+			if ( isRecentlyRegistered( domain.registrationDate ) ) {
+				return {
+					statusText: translate( 'Activating' ),
+					statusClass: 'status-pending',
+					icon: 'cloud_upload',
+					listStatusText: translate( 'Activating' ),
+					listStatusClass: 'info',
+				};
+			}
+
+			if ( hasPendingGSuiteUsers( domain ) ) {
+				return {
+					statusText: translate( 'Action required' ),
+					statusClass: 'status-warning',
+					icon: 'info',
+				};
+			}
+
+			return {
+				statusText: translate( 'Active' ),
+				statusClass: 'status-success',
+				icon: 'check_circle',
+			};
+
+		case domainTypes.SITE_REDIRECT:
+			if ( purchase && shouldRenderExpiringCreditCard( purchase ) ) {
+				return {
+					statusText: translate( 'Action required' ),
+					statusClass: 'status-error',
+					icon: 'info',
+				};
+			}
+
+			return {
+				statusText: translate( 'Active' ),
+				statusClass: 'status-success',
+				icon: 'check_circle',
+			};
+
+		case domainTypes.WPCOM:
+			return {
+				statusText: translate( 'Active' ),
+				statusClass: 'status-success',
+				icon: 'check_circle',
+			};
+
+		case domainTypes.TRANSFER:
+			if ( domain.transferStatus === transferStatus.PENDING_START ) {
+				return {
+					statusText: translate( 'Action required' ),
+					statusClass: 'status-error',
+					icon: 'info',
+					listStatusText: translate( 'Action required' ),
+					listStatusClass: 'alert',
+				};
+			} else if ( domain.transferStatus === transferStatus.CANCELLED ) {
+				return {
+					statusText: translate( 'Transfer failed' ),
+					statusClass: 'status-error',
+					icon: 'info',
+					listStatusText: translate( 'Transfer failed' ),
+					listStatusClass: 'alert',
+				};
+			}
+
+			return {
+				statusText: translate( 'Transfer in progress' ),
+				statusClass: 'status-success',
+				icon: 'cached',
+			};
+
+		default:
+			return {};
+	}
+}

--- a/client/my-sites/domains/domain-management/edit/domain-types/registered-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/registered-domain-type.jsx
@@ -43,89 +43,9 @@ import { DomainExpiryOrRenewal, WrapDomainStatusButtons } from './helpers';
 import OutboundTransferConfirmation from '../../components/outbound-transfer-confirmation';
 import { hasPendingGSuiteUsers } from 'lib/gsuite';
 import PendingGSuiteTosNotice from 'my-sites/domains/components/domain-warnings/pending-gsuite-tos-notice';
+import { resolveDomainStatus } from 'lib/domains';
 
 class RegisteredDomainType extends React.Component {
-	resolveStatus() {
-		const { domain, translate, purchase, moment } = this.props;
-		const { registrationDate, expiry } = domain;
-
-		if ( domain.pendingTransfer ) {
-			return {
-				statusText: translate( 'Outbound transfer initiated' ),
-				statusClass: 'status-error',
-				icon: 'cached',
-			};
-		}
-
-		if ( purchase && shouldRenderExpiringCreditCard( purchase ) ) {
-			return {
-				statusText: translate( 'Action required' ),
-				statusClass: 'status-error',
-				icon: 'info',
-			};
-		}
-
-		if ( domain.isPendingIcannVerification && domain.currentUserCanManage ) {
-			return {
-				statusText: translate( 'Action required' ),
-				statusClass: 'status-error',
-				icon: 'info',
-			};
-		}
-
-		if ( isExpiringSoon( domain, 30 ) ) {
-			const expiresMessage = translate( 'Expires in %(days)s', {
-				args: { days: moment.utc( expiry ).fromNow( true ) },
-			} );
-
-			if ( isExpiringSoon( domain, 5 ) ) {
-				return {
-					statusText: expiresMessage,
-					statusClass: 'status-error',
-					icon: 'info',
-				};
-			}
-
-			return {
-				statusText: expiresMessage,
-				statusClass: 'status-warning',
-				icon: 'info',
-			};
-		}
-
-		if ( domain.expired ) {
-			return {
-				statusText: translate( 'Action required' ),
-				statusClass: 'status-error',
-				icon: 'info',
-			};
-		}
-
-		const recentlyRegistered = isRecentlyRegistered( registrationDate );
-
-		if ( recentlyRegistered ) {
-			return {
-				statusText: translate( 'Activating' ),
-				statusClass: 'status-pending',
-				icon: 'cloud_upload',
-			};
-		}
-
-		if ( hasPendingGSuiteUsers( domain ) ) {
-			return {
-				statusText: translate( 'Action required' ),
-				statusClass: 'status-warning',
-				icon: 'info',
-			};
-		}
-
-		return {
-			statusText: translate( 'Active' ),
-			statusClass: 'status-success',
-			icon: 'check_circle',
-		};
-	}
-
 	renderExpired() {
 		const { domain, purchase, isLoadingPurchase, translate, moment } = this.props;
 		const domainsLink = ( link ) => <a href={ link } target="_blank" rel="noopener noreferrer" />;
@@ -369,7 +289,7 @@ class RegisteredDomainType extends React.Component {
 		const { domain, selectedSite, purchase, isLoadingPurchase } = this.props;
 		const { name: domain_name } = domain;
 
-		const { statusText, statusClass, icon } = this.resolveStatus();
+		const { statusText, statusClass, icon } = resolveDomainStatus( domain, purchase );
 
 		const newStatusDesignAutoRenew = config.isEnabled( 'domains/new-status-design/auto-renew' );
 		const newDomainManagementNavigation = config.isEnabled(

--- a/client/my-sites/domains/domain-management/edit/domain-types/site-redirect-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/site-redirect-type.jsx
@@ -22,30 +22,12 @@ import { getCurrentUserId } from 'state/current-user/selectors';
 import RenewButton from 'my-sites/domains/domain-management/edit/card/renew-button';
 import AutoRenewToggle from 'me/purchases/manage-purchase/auto-renew-toggle';
 import QuerySitePurchases from 'components/data/query-site-purchases';
-import { shouldRenderExpiringCreditCard } from 'lib/purchases';
 import ExpiringCreditCard from '../card/notices/expiring-credit-card';
 import DomainManagementNavigationEnhanced from '../navigation/enhanced';
 import { DomainExpiryOrRenewal, WrapDomainStatusButtons } from './helpers';
+import { resolveDomainStatus } from 'lib/domains';
 
 class SiteRedirectType extends React.Component {
-	resolveStatus() {
-		const { translate, purchase } = this.props;
-
-		if ( purchase && shouldRenderExpiringCreditCard( purchase ) ) {
-			return {
-				statusText: translate( 'Action required' ),
-				statusClass: 'status-error',
-				icon: 'info',
-			};
-		}
-
-		return {
-			statusText: translate( 'Active' ),
-			statusClass: 'status-success',
-			icon: 'check_circle',
-		};
-	}
-
 	renderDefaultRenewButton() {
 		const { domain, purchase, isLoadingPurchase } = this.props;
 
@@ -111,7 +93,7 @@ class SiteRedirectType extends React.Component {
 		const { domain, selectedSite, purchase, isLoadingPurchase } = this.props;
 		const { name: domain_name } = domain;
 
-		const { statusText, statusClass, icon } = this.resolveStatus();
+		const { statusText, statusClass, icon } = resolveDomainStatus( domain, purchase );
 
 		const newStatusDesignAutoRenew = config.isEnabled( 'domains/new-status-design/auto-renew' );
 

--- a/client/my-sites/domains/domain-management/edit/domain-types/transfer-in-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/transfer-in-domain-type.jsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import page from 'page';
 
 /**
  * Internal dependencies
@@ -18,37 +19,12 @@ import {
 	hasLoadedSitePurchasesFromServer,
 } from 'state/purchases/selectors';
 import { transferStatus } from 'lib/domains/constants';
-import page from 'page';
 import { domainManagementTransferInPrecheck } from 'my-sites/domains/paths';
 import { INCOMING_DOMAIN_TRANSFER_STATUSES } from 'lib/url/support';
 import DomainManagementNavigation from '../navigation';
+import { resolveDomainStatus } from 'lib/domains';
 
 class TransferInDomainType extends React.Component {
-	resolveStatus() {
-		const { domain, translate } = this.props;
-		const { transferStatus: status } = domain;
-
-		if ( status === transferStatus.PENDING_START ) {
-			return {
-				statusText: translate( 'Action required' ),
-				statusClass: 'status-error',
-				icon: 'info',
-			};
-		} else if ( status === transferStatus.CANCELLED ) {
-			return {
-				statusText: translate( 'Transfer failed' ),
-				statusClass: 'status-error',
-				icon: 'info',
-			};
-		}
-
-		return {
-			statusText: translate( 'Transfer in progress' ),
-			statusClass: 'status-success',
-			icon: 'cached',
-		};
-	}
-
 	startTransfer = () => {
 		const { domain, selectedSite } = this.props;
 		page( domainManagementTransferInPrecheck( selectedSite.slug, domain.name ) );
@@ -140,7 +116,7 @@ class TransferInDomainType extends React.Component {
 		const { domain, selectedSite, purchase, isLoadingPurchase } = this.props;
 		const { name: domain_name } = domain;
 
-		const { statusText, statusClass, icon } = this.resolveStatus();
+		const { statusText, statusClass, icon } = resolveDomainStatus( domain, purchase );
 
 		return (
 			<div className="domain-types__container">

--- a/client/my-sites/domains/domain-management/list/domain-item.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-item.jsx
@@ -5,6 +5,7 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import Gridicon from 'components/gridicon';
 import { localize } from 'i18n-calypso';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -16,6 +17,7 @@ import EllipsisMenu from 'components/ellipsis-menu';
 import PopoverMenuItem from 'components/popover/menu-item';
 import { hasGSuiteWithUs, getGSuiteMailboxCount } from 'lib/gsuite';
 import { withoutHttp } from 'lib/url';
+import { resolveDomainStatus } from 'lib/domains';
 
 class DomainItem extends PureComponent {
 	static propTypes = {
@@ -117,9 +119,12 @@ class DomainItem extends PureComponent {
 
 	render() {
 		const { domain, showSite, site, showCheckbox, domainDetails, translate } = this.props;
+		const { listStatusText, listStatusClass } = resolveDomainStatus( domainDetails || domain );
+
+		const rowClasses = classNames( 'domain-item', `domain-item__status-${ listStatusClass }` );
 
 		return (
-			<CompactCard className="domain-item" onClick={ this.handleClick }>
+			<CompactCard className={ rowClasses } onClick={ this.handleClick }>
 				{ showCheckbox && (
 					<FormCheckbox
 						className="domain-item__checkbox"
@@ -130,7 +135,9 @@ class DomainItem extends PureComponent {
 				<div className="list__domain-link">
 					<div className="domain-item__status">
 						<div className="domain-item__title">{ domain.domain }</div>
-						<DomainNotice status="info" text="Activating domain" />
+						{ listStatusText && (
+							<DomainNotice status={ listStatusClass || 'info' } text={ listStatusText } />
+						) }
 					</div>
 					{ showSite && (
 						<div className="domain-item__meta">

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -184,6 +184,19 @@ input[type='radio'].domain-management-list-item__radio {
 	color: var( --color-text-subtle );
 }
 
+
+.domain-item__status-info {
+	border-left: 3px solid var( --color-success-50 );
+}
+
+.domain-item__status-warning {
+	border-left: 3px solid var( --color-warning-40 );
+}
+
+.domain-item__status-alert {
+	border-left: 3px solid var( --color-error );
+}
+
 .domain-item__status {
 	display: flex;
 	flex-wrap: wrap;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Show a DomainNotice in the all domains list
* Highlight rows with expiring/expired domains

I decided to move the status resolving in a separate helper function so that we have consistency across different domain presentations (list vs status page).

Here's how it looks:
<img width="1057" alt="Screenshot 2020-07-02 at 1 45 47" src="https://user-images.githubusercontent.com/1355045/86298262-ff29a880-bc05-11ea-91c5-ecf061583ee4.png">
<img width="470" alt="Screenshot 2020-07-02 at 1 46 04" src="https://user-images.githubusercontent.com/1355045/86298267-00f36c00-bc06-11ea-8678-3aec7b02f1bb.png">

#### Testing instructions

* Open /domains/manage and verify that the notices for expiring/expired/activating domains are rendered. Also verify that the rows are highlighted with 3px left border.

Fixes #
