### PR TITLE
Editor: increase iframe timeout

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -152,7 +152,7 @@ class CalypsoifyIframe extends Component<
 								this.props.iframeUrl
 						  )
 						: window.location.replace( this.props.iframeUrl );
-				}, 6000 ); // One second longer than we give the iframe to load
+				}, 8000 ); // One second longer than we give the iframe to load
 			}
 		}, 1000 );
 	}

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -152,7 +152,7 @@ class CalypsoifyIframe extends Component<
 								this.props.iframeUrl
 						  )
 						: window.location.replace( this.props.iframeUrl );
-				}, 8000 ); // One second longer than we give the iframe to load
+				}, 8000 ); // Three seconds longer than we give the iframe to load
 			}
 		}, 1000 );
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Increases the iframe timeout value by 2 seconds to see if this fixes random redirects of the editor in Simple sites

#### Testing instructions

* Checkout this PR to local calypso dev env and check that editor is iframed correctly in Simple and Atomic sites.
