### PR TITLE
Reader: make tags displayed consistent between post card and full post

### DIFF
--- a/client/blocks/reader-full-post/header-tags.jsx
+++ b/client/blocks/reader-full-post/header-tags.jsx
@@ -3,12 +3,16 @@
  */
 import PropTypes from 'prop-types';
 import React from 'react';
-import { take, map, values } from 'lodash';
+import { take, values } from 'lodash';
+
+const TAGS_TO_SHOW = 5;
 
 const ReaderFullPostHeaderTags = ( { tags } ) => {
-	const numberOfTagsToDisplay = 5;
-	const tagsToDisplay = take( values( tags ), numberOfTagsToDisplay );
-	const listItems = map( tagsToDisplay, ( tag ) => {
+	let tagsInOccurrenceOrder = values( tags );
+	tagsInOccurrenceOrder.sort( ( a, b ) => b.post_count - a.post_count );
+	tagsInOccurrenceOrder = take( tagsInOccurrenceOrder, TAGS_TO_SHOW );
+
+	const listItems = tagsInOccurrenceOrder.map( ( tag ) => {
 		return (
 			<li key={ `post-tag-${ tag.slug }` } className="reader-full-post__header-tag-list-item">
 				<a href={ `/tag/${ tag.slug }` } className="reader-full-post__header-tag-list-item-link">


### PR DESCRIPTION
#### Changes proposed in this Pull Request

While writing a support doc, I noticed that the display of tags is not consistent between Reader post cards and full post:
* post cards display 3 tags, sorted by tag popularity
* full post displays 5 tags, not sorted

I thought it'd be best to make the sort order consistent between the two.

Before:

Post card
<img width="759" alt="Screen Shot 2020-07-02 at 15 50 37" src="https://user-images.githubusercontent.com/17325/86314511-0390a880-bc7c-11ea-99a7-8d294af7e98f.png">

Full post
<img width="826" alt="Screen Shot 2020-07-02 at 15 50 31" src="https://user-images.githubusercontent.com/17325/86314521-08555c80-bc7c-11ea-8ec3-3b16f665f64e.png">

After:

Full post
<img width="1019" alt="Screen Shot 2020-07-02 at 15 51 36" src="https://user-images.githubusercontent.com/17325/86314539-186d3c00-bc7c-11ea-82c3-cec92d38d56b.png">


#### Testing instructions

Verify that full post shows the same first 3 tags as the post card. A good example is:

Post cards
http://calypso.localhost:3000/read/feeds/36149739

Full post
http://calypso.localhost:3000/read/feeds/36149739/posts/2786929875

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

