### PR TITLE
Update FSE plugin to version 1.11.0

### DIFF
--- a/.github/workflows/full-site-editing-plugin.yml
+++ b/.github/workflows/full-site-editing-plugin.yml
@@ -28,6 +28,11 @@ jobs:
       if: steps.cache.outputs.cache-hit != 'true'
       run: yarn install --frozen-lockfile # Not needed when restoring from cache.
 
+    - name: Run composer
+      uses: nick-zh/composer-php@master
+      with:
+        action: 'install'
+
     - name: Build packages
       if: steps.cache.outputs.cache-hit == 'true'
       run: yarn run postinstall # Needed only when not running yarn install.

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Full Site Editing
  * Description: Enhances your page creation workflow within the Block Editor.
- * Version: 1.10
+ * Version: 1.11
  * Author: Automattic
  * Author URI: https://automattic.com/wordpress-plugins/
  * License: GPLv2 or later

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -35,7 +35,7 @@ namespace A8C\FSE;
  *
  * @var string
  */
-define( 'PLUGIN_VERSION', '1.10' );
+define( 'PLUGIN_VERSION', '1.11' );
 
 // Always include these helper files for dotcom FSE.
 require_once __DIR__ . '/dotcom-fse/helpers.php';

--- a/apps/full-site-editing/full-site-editing-plugin/readme.txt
+++ b/apps/full-site-editing/full-site-editing-plugin/readme.txt
@@ -3,7 +3,7 @@ Contributors: alexislloyd, allancole, automattic, bartkalisz, codebykat, copons,
 Tags: block, blocks, editor, gutenberg, page
 Requires at least: 5.0
 Tested up to: 5.4
-Stable tag: 1.10
+Stable tag: 1.11
 Requires PHP: 5.6.20
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -39,6 +39,17 @@ This plugin is experimental, so we don't provide any support for it outside of w
 
 
 == Changelog ==
+
+= 1.11 =
+* Fix broken blocks in page layout picker preview in Firefox.
+* Add settings to the donation block.
+* Fix premium content block to ensure it is auto-selected when mounted.
+* Add fallback to donations block to set default products if none are already defined.
+* Fix block pattern preview viewport scaling.
+* Fix broken site editor page.
+* Add one time payment option to payment plans.
+* Add a general transform to premium content.
+* Fix custom font size in block patterns previews.
 
 = 1.10 =
 * Improvements to the premium blocks.

--- a/apps/full-site-editing/package.json
+++ b/apps/full-site-editing/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/full-site-editing",
-	"version": "1.10.0",
+	"version": "1.11.0",
 	"description": "Plugin for full site editing with the block editor.",
 	"sideEffects": true,
 	"repository": {


### PR DESCRIPTION
This PR bumps the FSE plugin version to v1.11.0 for rolling out another release. It includes a fair few changes based on looking at https://github.com/Automattic/wp-calypso/commits/master/apps/full-site-editing. I've cross-referenced these below:

Included changes:

* Run phpcbf on the synced files to fix text domain #43792
* Fix page layout picker preview in Firefox (broken RichText blocks) #43822
* Domain picker: cleanup and analytics fix #43796
* Donation block: Add block settings #43798
* Premium Content: Handle plans in the container block #43684
* Donations: Fall back to default products if no products are already defined #43665
* FSE: Add plans grid modal #43593
* Add domain picker to FSE #42951
* Blog Posts Block: allow newspack-blocks installation from github #43526
* Nav sidebar: sidebar can be enabled by a filter #43509
* FSE Plugin: Block Pattern Preview Viewport Scaling #43362
* FSE plugin: fix broken site editor page #43581
* Earn: add one time payment option to payment plans #43417
* Premium Content: add a general transform to premium content #42548
* Block Patterns: Fix custom font size in previews #43546
* Nav Sidebar: clicking nav items opens that item in the block editor #43471

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox the diff associated with this version bump (D45821-code)
* Test on a simple site
* Test on an Atomic site with the Gutenberg plugin enabled
* Test on an Atomic site without the Gutenberg plugin
* Test in Calypso and via wp-admin

If approving this PR, please approve D45821-code, too :)

@Automattic/serenity can you please double-check that the commits included in this release are working correctly? I'm not so familiar with the Donations or Premium Content blocks, so just want to make sure it's all good to go!

