### PR TITLE
FSE: Domain Picker Smart Component

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/editor-domain-picker/src/domain-picker-button/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-domain-picker/src/domain-picker-button/index.tsx
@@ -2,45 +2,20 @@
  * External dependencies
  */
 import * as React from 'react';
-import { useSelect } from '@wordpress/data';
 import 'a8c-fse-common-data-stores';
-import { Site } from '@automattic/data-stores';
-// eslint-disable-next-line no-duplicate-imports
-import type { DomainSuggestions } from '@automattic/data-stores';
 
+/**
+ * Internal dependencies
+ */
 import DomainPickerModal from '../domain-picker-modal';
 import { Button } from '@wordpress/components';
 import { Icon, chevronDown } from '@wordpress/icons';
-const FLOW_ID = 'gutenboarding';
-
-const SITES_STORE = Site.register( { client_id: '', client_secret: '' } );
-
-declare global {
-	interface Window {
-		_currentSiteId: number;
-	}
-}
+import { useCurrentDomain } from '../hooks/use-current-domain';
 
 export default function DomainPickerButton() {
 	const [ isDomainModalVisible, setDomainModalVisibility ] = React.useState( false );
-	const [ domainSearch, setDomainSearch ] = React.useState( '' );
-	const site = useSelect( ( select ) => select( SITES_STORE ).getSite( window._currentSiteId ) );
-	const [ domainName, setDomainName ] = React.useState(
-		site?.URL && new URL( site?.URL ).hostname
-	);
 
-	React.useEffect( () => {
-		setDomainName( ( site?.URL && new URL( site?.URL ).hostname ) || '' );
-	}, [ site ] );
-
-	const search = ( domainSearch.trim() || site?.name ) ?? '';
-
-	const handleDomainSelect = ( domain?: DomainSuggestions.DomainSuggestion ) => {
-		// TODO: store whole domain suggestion object here because it has product_id and other useful info
-		// that we need for the cart
-		setDomainName( domain?.domain_name );
-		setDomainModalVisibility( false );
-	};
+	const currentDomain = useCurrentDomain();
 
 	return (
 		<>
@@ -50,21 +25,12 @@ export default function DomainPickerButton() {
 				aria-pressed={ isDomainModalVisible }
 				onClick={ () => setDomainModalVisibility( ( s ) => ! s ) }
 			>
-				<span className="domain-picker-button__label">{ `Domain: ${ domainName ?? '' }` }</span>
+				<span className="domain-picker-button__label">{ `Domain: ${ currentDomain.domain_name }` }</span>
 				<Icon icon={ chevronDown } size={ 22 } />
 			</Button>
-			<DomainPickerModal
-				analyticsFlowId={ FLOW_ID }
-				analyticsUiAlgo="editor_domain_modal"
-				initialDomainSearch={ search }
-				onSetDomainSearch={ setDomainSearch }
-				isOpen={ isDomainModalVisible }
-				// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-				// @ts-ignore
-				currentDomain={ domainName }
-				onDomainSelect={ handleDomainSelect }
-				onClose={ () => setDomainModalVisibility( false ) }
-			/>
+			{ isDomainModalVisible && (
+				<DomainPickerModal onClose={ () => setDomainModalVisibility( false ) } />
+			) }
 		</>
 	);
 }

--- a/apps/full-site-editing/full-site-editing-plugin/editor-domain-picker/src/domain-picker-fse/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-domain-picker/src/domain-picker-fse/index.tsx
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+import * as React from 'react';
+import DomainPicker, { Props as DomainPickerProps } from '@automattic/domain-picker';
+import type { DomainSuggestions } from '@automattic/data-stores';
+
+/**
+ * Internal dependencies
+ */
+import 'a8c-fse-common-data-stores';
+import { useSite, useCurrentDomain } from '../hooks/use-current-domain';
+
+const FLOW_ID = 'gutenboarding';
+
+export type Props = Partial< DomainPickerProps >;
+
+const DomainPickerFSE: React.FunctionComponent< Props > = ( props ) => {
+	const [ domainSearch, setDomainSearch ] = React.useState( '' );
+
+	const site = useSite();
+	const currentDomain = useCurrentDomain();
+
+	const search = ( domainSearch.trim() || site?.name ) ?? '';
+
+	// TODO: This should go to the domain or launch store.
+	const [ domainName, setDomainName ] = React.useState( currentDomain );
+
+	const handleDomainSelect = ( domain?: DomainSuggestions.DomainSuggestion ) => {
+		// TODO: store whole domain suggestion object here because it has product_id and other useful info
+		// that we need for the cart
+		setDomainName( domain?.domain_name );
+	};
+
+	return (
+		<DomainPicker
+			analyticsFlowId={ FLOW_ID }
+			analyticsUiAlgo="editor_domain_modal"
+			initialDomainSearch={ search }
+			onSetDomainSearch={ setDomainSearch }
+			showDomainCategories
+			currentDomain={ domainName }
+			onDomainSelect={ handleDomainSelect }
+			{ ...props }
+		/>
+	);
+};
+
+export default DomainPickerFSE;

--- a/apps/full-site-editing/full-site-editing-plugin/editor-domain-picker/src/domain-picker-modal/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-domain-picker/src/domain-picker-modal/index.tsx
@@ -7,19 +7,14 @@ import { Modal } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import DomainPicker, { Props as DomainPickerProps } from '@automattic/domain-picker';
+import DomainPickerFSE, { Props as DomainPickerFSEProps } from '../domain-picker-fse';
 import './styles.scss';
 
-interface Props extends DomainPickerProps {
-	isOpen: boolean;
+interface Props extends DomainPickerFSEProps {
 	onClose: () => void;
 }
 
-const DomainPickerModal: React.FunctionComponent< Props > = ( { isOpen, onClose, ...props } ) => {
-	if ( ! isOpen ) {
-		return null;
-	}
-
+const DomainPickerModal: React.FunctionComponent< Props > = ( { onClose, ...props } ) => {
 	return (
 		<Modal
 			className="domain-picker-modal"
@@ -28,7 +23,7 @@ const DomainPickerModal: React.FunctionComponent< Props > = ( { isOpen, onClose,
 			onRequestClose={ onClose }
 			title=""
 		>
-			<DomainPicker { ...props } />
+			<DomainPickerFSE { ...props } />
 		</Modal>
 	);
 };

--- a/apps/full-site-editing/full-site-editing-plugin/editor-domain-picker/src/hooks/use-current-domain.ts
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-domain-picker/src/hooks/use-current-domain.ts
@@ -1,0 +1,22 @@
+/**
+ * External dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { Site } from '@automattic/data-stores';
+
+const SITES_STORE = Site.register( { client_id: '', client_secret: '' } );
+
+declare global {
+	interface Window {
+		_currentSiteId: number;
+	}
+}
+
+export function useSite() {
+	return useSelect( ( select ) => select( SITES_STORE ).getSite( window._currentSiteId ) );
+}
+
+export function useCurrentDomain() {
+	const site = useSite();
+	return ( site?.URL && new URL( site?.URL ).hostname ) || '';
+}

--- a/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-steps/domain-step/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-steps/domain-step/index.tsx
@@ -9,6 +9,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import LaunchStep, { Props as LaunchStepProps } from '../../launch-step';
+import DomainPickerFSE from '../../../../editor-domain-picker/src/domain-picker-fse';
 import './styles.scss';
 
 const DomainStep: React.FunctionComponent< LaunchStepProps > = ( { onPrevStep, onNextStep } ) => {
@@ -40,7 +41,10 @@ const DomainStep: React.FunctionComponent< LaunchStepProps > = ( { onPrevStep, o
 					</Button>
 				</div>
 			</div>
-			<div className="nux-launch-step__body"></div>
+			<div className="nux-launch-step__body">
+				{ /* TODO: When a domain is selected, it should advance to the next step */ }
+				<DomainPickerFSE />
+			</div>
 		</LaunchStep>
 	);
 };

--- a/packages/domain-picker/src/domain-picker/index.tsx
+++ b/packages/domain-picker/src/domain-picker/index.tsx
@@ -31,7 +31,7 @@ import './style.scss';
 type DomainSuggestion = DomainSuggestions.DomainSuggestion;
 
 export interface Props {
-	header: React.ReactElement;
+	header?: React.ReactElement;
 
 	showDomainCategories?: boolean;
 
@@ -144,7 +144,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 
 	return (
 		<div className="domain-picker">
-			{ header }
+			{ header && header }
 			<div className="domain-picker__search">
 				<div className="domain-picker__search-icon">
 					<Icon icon={ search } />


### PR DESCRIPTION
Note: This PR is based off `add/fse-editor-site-launch` from https://github.com/Automattic/wp-calypso/pull/43825. When `add/fse-editor-site-launch` is merged, we'll change the base branch of this PR to `master`.

## Changes proposed in this Pull Request

- Created `DomainPickerFSE` smart component.
- Refactored `DomainPickerButton` & `DomainPickerModal` (in FSE) to reuse `DomainPickerFSE`.
- Use `DomainPickerFSE` in launch plugin's `DomainStep` component.

**Other changes:**
- Refactored some logic to `useCurrentDomain` and `useSite` hook.
- The `header` param is made optional in `@automattic/domain-picker` package.

## Testing instructions

**Setup**
* Add `define( 'A8C_FSE_SITE_LAUNCH_ENABLE', true );` and `define( 'A8C_FSE_DOMAIN_PICKER_ENABLE', true );` to `./config/sandbox.php`.
* Run `yarn` on root calypso folder make sure `@automattic/domain-picker` package is rebuilt.
* Run `yarn dev --sync` on `apps\full-site-editing` folder.

**Test**
* Go to `/wp-admin/post-new.php?post_type=page` on your sandbox site.
* Test domain picker through the **domain picker button** on the block editor header.
* Test domain picker through the **launch button** on the block editor header. 

**Things To Know**
- This PR doesn't deal with what happens after use picks a domain, so the following behaviour is expected.
  - Selecting a domain in domains modal doesn't close the modal, it also doesn't change the selected domain on the domains button (need the shared launch store for this to happen).
  - Selecting a domain in launch modal doesn't advance to the next step.

## Screenshot

DomainPickerFSE on DomainStep
![image](https://user-images.githubusercontent.com/1287077/86325658-b2af8e80-bc40-11ea-940a-84bacd3ce830.png)

DomainPickerFSE on DomainPickerModal
![image](https://user-images.githubusercontent.com/1287077/86325654-b04d3480-bc40-11ea-95d1-64288b32a6d5.png)

Fixes part of #43750
