### PR TITLE
FSE: Plans Grid Smart Component

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/editor-plans-grid/src/hooks/use-selected-plan.ts
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-plans-grid/src/hooks/use-selected-plan.ts
@@ -1,1 +1,19 @@
-// TODO: Remove this. This is added to fix wonky PHPCS error.
+/**
+ * External dependencies
+ */
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { PLANS_STORE } from '../stores';
+
+export function useSelectedPlan() {
+	// TODO: Switch to paid plan when use switch to paid domain.
+	const currentPlan = useSelect( ( select ) => {
+		return select( PLANS_STORE ).getSelectedPlan();
+	} );
+
+	// FIX: PlansGrid currentPlan params expecting undefined while `getSelectedPlan()` is returning null.
+	return currentPlan || undefined;
+}

--- a/apps/full-site-editing/full-site-editing-plugin/editor-plans-grid/src/plans-grid-button/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-plans-grid/src/plans-grid-button/index.tsx
@@ -2,8 +2,6 @@
  * External dependencies
  */
 import * as React from 'react';
-import { useSelect, useDispatch } from '@wordpress/data';
-import { Plans } from '@automattic/data-stores';
 import { Button } from '@wordpress/components';
 import { Icon, chevronDown } from '@wordpress/icons';
 import 'a8c-fse-common-data-stores';
@@ -12,28 +10,11 @@ import 'a8c-fse-common-data-stores';
  * Internal dependencies
  */
 import PlansModal from '../plans-modal';
-import { PLANS_STORE } from '../stores';
-
-type PlansSlug = Plans.PlanSlug;
+import { useSelectedPlan } from '../hooks/use-selected-plan';
 
 const PlansGridButton = () => {
 	const [ isPlansModalVisible, setPlansModalVisibility ] = React.useState( false );
-
-	// TODO: Get current domain from store.
-	const currentDomain = undefined;
-
-	// TODO: Proper plan selection as seen in gutenboarding version. Needs currentDomain to work on this.
-	const currentPlan = useSelect( ( select ) => {
-		const selectedPlan = select( PLANS_STORE ).getSelectedPlan();
-		return selectedPlan || undefined;
-	} );
-
-	const { setPlan } = useDispatch( PLANS_STORE );
-
-	const handlePlanSelect = ( plan: PlansSlug ) => {
-		setPlan( plan );
-		setPlansModalVisibility( false );
-	};
+	const currentPlan = useSelectedPlan();
 
 	return (
 		<>
@@ -43,17 +24,10 @@ const PlansGridButton = () => {
 				aria-pressed={ isPlansModalVisible }
 				onClick={ () => setPlansModalVisibility( ( s ) => ! s ) }
 			>
-				{ /* TODO: Refine this  */ }
-				<span>Plans: { currentPlan && currentPlan.title }</span>
+				<span>Plans: { currentPlan?.title }</span>
 				<Icon icon={ chevronDown } size={ 22 } />
 			</Button>
-			<PlansModal
-				isOpen={ isPlansModalVisible }
-				currentDomain={ currentDomain }
-				currentPlan={ currentPlan }
-				onPlanSelect={ handlePlanSelect }
-				onClose={ () => setPlansModalVisibility( false ) }
-			/>
+			{ isPlansModalVisible && <PlansModal onClose={ () => setPlansModalVisibility( false ) } /> }
 		</>
 	);
 };

--- a/apps/full-site-editing/full-site-editing-plugin/editor-plans-grid/src/plans-grid-fse/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-plans-grid/src/plans-grid-fse/index.tsx
@@ -1,0 +1,36 @@
+/**
+ * External dependencies
+ */
+import * as React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import PlansGrid, { Props as PlansGridProps } from '@automattic/plans-grid';
+import { useSelectedPlan } from '../hooks/use-selected-plan';
+
+export type Props = Partial< PlansGridProps >;
+
+const PlansGridFSE: React.FunctionComponent< Props > = ( { ...props } ) => {
+	// TODO: Get current domain from launch store.
+	const currentDomain = undefined;
+
+	const currentPlan = useSelectedPlan();
+
+	// const { setPlan } = useDispatch( PLANS_STORE );
+
+	// const handlePlanSelect = ( plan: Plans.PlanSlug ) => {
+	// 	setPlan( plan );
+	// };
+
+	return (
+		<PlansGrid
+			currentDomain={ currentDomain }
+			currentPlan={ currentPlan }
+			// onPlanSelect={ handlePlanSelect }
+			{ ...props }
+		/>
+	);
+};
+
+export default PlansGridFSE;

--- a/apps/full-site-editing/full-site-editing-plugin/editor-plans-grid/src/plans-grid-fse/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-plans-grid/src/plans-grid-fse/index.tsx
@@ -17,20 +17,7 @@ const PlansGridFSE: React.FunctionComponent< Props > = ( { ...props } ) => {
 
 	const currentPlan = useSelectedPlan();
 
-	// const { setPlan } = useDispatch( PLANS_STORE );
-
-	// const handlePlanSelect = ( plan: Plans.PlanSlug ) => {
-	// 	setPlan( plan );
-	// };
-
-	return (
-		<PlansGrid
-			currentDomain={ currentDomain }
-			currentPlan={ currentPlan }
-			// onPlanSelect={ handlePlanSelect }
-			{ ...props }
-		/>
-	);
+	return <PlansGrid currentDomain={ currentDomain } currentPlan={ currentPlan } { ...props } />;
 };
 
 export default PlansGridFSE;

--- a/apps/full-site-editing/full-site-editing-plugin/editor-plans-grid/src/plans-modal/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-plans-grid/src/plans-modal/index.tsx
@@ -8,19 +8,14 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import PlansGrid, { Props as PlansGridProps } from '@automattic/plans-grid';
+import PlansGridFSE, { Props as PlansGridFSEProps } from '../plans-grid-fse';
 import './styles.scss';
 
-interface Props extends Omit< PlansGridProps, 'header' > {
-	isOpen: boolean;
+interface Props extends PlansGridFSEProps {
 	onClose: () => void;
 }
 
-const PlansModal: React.FunctionComponent< Props > = ( { isOpen, onClose, ...props } ) => {
-	if ( ! isOpen ) {
-		return null;
-	}
-
+const PlansModal: React.FunctionComponent< Props > = ( { onClose, ...props } ) => {
 	const header = (
 		<div>
 			{ /* eslint-disable @wordpress/i18n-text-domain */ }
@@ -41,8 +36,9 @@ const PlansModal: React.FunctionComponent< Props > = ( { isOpen, onClose, ...pro
 			onRequestClose={ onClose }
 			title=""
 		>
+			{ header }
 			<div className="plans-grid-container">
-				<PlansGrid header={ header } { ...props } />
+				<PlansGridFSE { ...props } />
 			</div>
 		</Modal>
 	);

--- a/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-steps/plan-step/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-steps/plan-step/index.tsx
@@ -9,6 +9,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import LaunchStep, { Props as LaunchStepProps } from '../../launch-step';
+import PlansGridFSE from '../../../../editor-plans-grid/src/plans-grid-fse';
 import './styles.scss';
 
 const PlanStep: React.FunctionComponent< LaunchStepProps > = ( { onPrevStep } ) => {
@@ -34,7 +35,9 @@ const PlanStep: React.FunctionComponent< LaunchStepProps > = ( { onPrevStep } ) 
 					</Button>
 				</div>
 			</div>
-			<div className="nux-launch-step__body"></div>
+			<div className="nux-launch-step__body">
+				<PlansGridFSE />
+			</div>
 		</LaunchStep>
 	);
 };

--- a/packages/plans-grid/src/plans-grid/index.tsx
+++ b/packages/plans-grid/src/plans-grid/index.tsx
@@ -21,7 +21,7 @@ import './style.scss';
 type PlansSlug = Plans.PlanSlug;
 
 export interface Props {
-	header: React.ReactElement;
+	header?: React.ReactElement;
 	currentPlan?: Plans.Plan;
 	onPlanSelect?: ( plan: PlansSlug ) => void;
 	onPickDomainClick?: () => void;
@@ -46,7 +46,8 @@ const PlansGrid: React.FunctionComponent< Props > = ( {
 
 	return (
 		<div className="plans-grid">
-			<div className="plans-grid__header">{ header }</div>
+			{ header && <div className="plans-grid__header">{ header }</div> }
+
 			<div className="plans-grid__table">
 				<div className="plans-grid__table-container">
 					<PlansTable


### PR DESCRIPTION
Note: This PR is based off `add/fse-editor-site-launch` from https://github.com/Automattic/wp-calypso/pull/43825. When `add/fse-editor-site-launch` is merged, we'll change the base branch of this PR to `master`.

## Changes proposed in this Pull Request

- Created `PlansGridFSE` smart component.
- Refactored `PlansGridButton` & `PlansGridModal` (in FSE) to reuse `PlansGridFSE`.
- Use `PlansGridFSE` in launch plugin's `PlanStep` component.

**Other changes:**
- Refactored some logic to `useSelectedPlan` hook.
- The `header` param is made optional in `@automattic/plans-grid` package.

## Testing instructions

**Setup**
* Add `define( 'A8C_FSE_SITE_LAUNCH_ENABLE', true );` and `define( 'A8C_FSE_PLANS_GRID_ENABLE', true );` to `./config/sandbox.php`.
* Run `yarn` on root calypso folder make sure `@automattic/plans-grid` package is rebuilt.
* Run `yarn dev --sync` on `apps\full-site-editing` folder.

**Test**
* Go to `/wp-admin/post-new.php?post_type=page` on your sandbox site.
* Test plans grid through the **plans button** on the block editor header.
* Test plans grid through the **launch button** on the block editor header. 

**Things To Know**
- This PR doesn't deal with what happens after user selects a plan, so the following behaviour is expected.
  - Selecting a plan in plans modal doesn't close the modal, but you should see the selected plan change in the plans button.
  - Selecting a plan in launch modal doesn't advance to the next step.

## Screenshot

PlansGridFSE on PlanStep
![image](https://user-images.githubusercontent.com/1287077/86325193-f3f36e80-bc3f-11ea-974d-443a55f683b2.png)

PlansGridFSE on PlansGridModal
![image](https://user-images.githubusercontent.com/1287077/86325205-f950b900-bc3f-11ea-9375-59d7578b8c7e.png)

Fixes part of #43750
