### PR TITLE
My Home - remove "site created" banner and add to checklist.

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
@@ -84,6 +84,22 @@ export const getTask = (
 ) => {
 	let taskData = {};
 	switch ( task.id ) {
+		case 'start_site_setup':
+			taskData = {
+				timing: 1,
+				title: translate( 'Site created' ),
+				description: translate(
+					"Next, we'll guide you through setting up and launching your site."
+				),
+				actionText: 'Get started',
+				...( ! task.isCompleted && {
+					actionDispatch: requestSiteChecklistTaskUpdate,
+					actionDispatchArgs: [ siteId, task.id ],
+				} ),
+				actionAdvanceToNext: true,
+				completeOnView: true,
+			};
+			break;
 		case SITE_CHECKLIST_KNOWN_TASKS.DOMAIN_VERIFIED:
 			taskData = {
 				timing: 2,

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
@@ -17,6 +17,7 @@ import { verifyEmail } from 'state/current-user/email-verification/actions';
 // A list of known tasks for the calypso client/state/data-layer/wpcom/checklist/index.js
 // You need to alter this object in case of adding / removing tasks
 export const SITE_CHECKLIST_KNOWN_TASKS = {
+	START_SITE_SETUP: 'start_site_setup',
 	DOMAIN_VERIFIED: 'domain_verified',
 	EMAIL_VERIFIED: 'email_verified',
 	BLOGNAME_SET: 'blogname_set',
@@ -84,7 +85,7 @@ export const getTask = (
 ) => {
 	let taskData = {};
 	switch ( task.id ) {
-		case 'start_site_setup':
+		case SITE_CHECKLIST_KNOWN_TASKS.START_SITE_SETUP:
 			taskData = {
 				timing: 1,
 				title: translate( 'Site created' ),


### PR DESCRIPTION
This PR works in conjunction with `code-D45830` to seek to address https://github.com/Automattic/wp-calypso/issues/42846 by:

* Removing the "Your site has been created" banner from the My Home page.
* Add the "Site Created" celebration as a checklist step which is automatically marked as completed.

Note this PR is responsible for the text of the new checklist task for "Site Created" only. All persistence is handled in `D45830-code`.

This PR also updates the  `<SiteSetupList>` component to only show "Action" buttons for the task if the text for these is provided in the task definition. This avoids having to show an action button for "Create your site" when this is not possible as the site is already created and it would make absolutely no sense whatsoever. 

## Screenshots

![Annotation on 2020-07-02 at 11-18-50](https://user-images.githubusercontent.com/444434/86347206-e0eb9900-bc55-11ea-937c-08c2da6199bb.png)


## Testing instructions

* Apply D45830-code to your sandbox. 
* On sandbox change `if ( $site_created_date > strtotime( '2020-07-09' ) ) ` so that the date is _before_ today's date (for testing only!). Ensure these changes have been synced to your sandbox. See also `Testing with the PR` from instructions on D45830-code.
* Checkout this PR.
* Boot Calypso - `yarn start`. Wait for ages...
* Create a new site on WordPress.com via `http://calypso.localhost:3000/`.
* Once complete you should land on the "My Home" page.
* You should:
  - Not see the "Your site has been created banner" (see Issue).
  - See the `Site setup` checklist as the primary item at the top of the page.
  - See the first task `Site Created` selected and visible.
  - See the first task `Site Created` also marked as ✅ complete.
* You should also be able to click on the `Site Created` task step and view details about that task including a description.
* You should be able to click on the CTA "Get started" and advanced to the next incomplete task in the checklist.
* You should be able to reload the page and see the `Site Created` tasks remain ✅ and the first incomplete task selected.
* Add `?debug=true&view=VIEW_SITE_SETUP` to your URL to view the site setup view and verify the above still holds.
* Repeat the above, but this time instead of hitting the "Get started" CTA on the "Site Created" task, simply reload the page. You should see the "Site Created" task is complete, but not selected. Instead the next incomplete task should be selected. This confirms that user interaction is not required in order to mark the "Site Created" task as complete.
* Also verify that the "Site step" progress bar in the Calypso sidebar increments without a hard refresh as checklist tasks are updated. See https://github.com/Automattic/wp-calypso/pull/43861#issuecomment-655156660.
* Also verify that for a site registered _before_ 2020-07-09 that you do not see the "Site Created" step.

Addresses https://github.com/Automattic/wp-calypso/issues/42846
