### PR TITLE
Jetpack Search: enable purchases via "...search/yearly" routes.

### DIFF
--- a/client/jetpack-connect/jetpack-connection.jsx
+++ b/client/jetpack-connect/jetpack-connection.jsx
@@ -5,7 +5,7 @@ import debugModule from 'debug';
 import config from 'config';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { flowRight, get, includes, startsWith, omit } from 'lodash';
+import { flowRight, get, includes, omit } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -197,9 +197,12 @@ const jetpackConnection = ( WrappedComponent ) => {
 			}
 
 			if ( this.checkProperty( 'isWordPressDotCom' ) ) {
-				const product = window.location.href.split( '/' )[ 5 ];
+				const product_path = window.location.pathname;
 
-				if ( startsWith( product, 'jetpack_search' ) || startsWith( product, 'wpcom_search' ) ) {
+				if (
+					product_path.includes( 'jetpack_search' ) ||
+					product_path.includes( 'wpcom_search' )
+				) {
 					return IS_DOT_COM_GET_SEARCH;
 				}
 				return IS_DOT_COM;
@@ -207,15 +210,6 @@ const jetpackConnection = ( WrappedComponent ) => {
 
 			if ( this.isError( 'site_blacklisted' ) ) {
 				return SITE_BLOCKED;
-			}
-
-			if ( this.checkProperty( 'isWordPressDotCom' ) ) {
-				const product = window.location.href.split( '/' )[ 5 ];
-
-				if ( startsWith( product, 'jetpack_search' ) ) {
-					return IS_DOT_COM_GET_SEARCH;
-				}
-				return IS_DOT_COM;
 			}
 
 			if ( this.props.jetpackConnectSite.installConfirmedByUser === false ) {

--- a/client/jetpack-connect/search.jsx
+++ b/client/jetpack-connect/search.jsx
@@ -148,10 +148,18 @@ export class SearchPurchase extends Component {
 	}
 
 	getProduct() {
-		const product = window.location.pathname.split( '/' )[ 3 ];
-		const type = window.location.pathname.split( '/' )[ 4 ];
+		const type = window.location.pathname.includes( 'monthly' ) && 'monthly';
+		let product = '';
 
-		return [ 'monthly' ].includes( type ) ? product + '_' + type : product;
+		if ( window.location.pathname.includes( 'jetpack_search' ) ) {
+			product = type ? 'jetpack_search_monthly' : 'jetpack_search';
+		}
+
+		if ( window.location.pathname.includes( 'wpcom_search' ) ) {
+			product = type ? 'wpcom_search_monthly' : 'wpcom_search';
+		}
+
+		return product;
 	}
 
 	renderSiteInput( status ) {

--- a/client/jetpack-connect/search.jsx
+++ b/client/jetpack-connect/search.jsx
@@ -151,7 +151,7 @@ export class SearchPurchase extends Component {
 		const product = window.location.pathname.split( '/' )[ 3 ];
 		const type = window.location.pathname.split( '/' )[ 4 ];
 
-		return [ 'monthly', 'yearly' ].includes( type ) ? product + '_' + type : product;
+		return [ 'monthly' ].includes( type ) ? product + '_' + type : product;
 	}
 
 	renderSiteInput( status ) {

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -330,7 +330,7 @@ export class Checkout extends React.Component {
 					? jetpackProductItem( 'wpcom_search_monthly' )
 					: jetpackProductItem( 'wpcom_search' );
 			} else {
-				cartItem = null;
+				cartItem = ! isJetpackNotAtomic ? null : cartItem;
 			}
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Process purchases via `/jetpack/connect/jetpack_search/yearly` and `/jetpack/connect/wpcom_search/yearly` routes. 
At the moment inputting urls is disabled at those screens. We use `/jetpack/connect/jetpack_search` for yearly product type, but since /yearly had been defined as a route, we should keep it functional.
Also, here we adapt product type definition such that it is independent of the actual route.

Second fix is processing purchases for Jetpack sites- we correct the condition that moderated WP.com vs. JP site type of product at checkout. It was adding an empty product and as such, redirecting to /plans.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to ` /jetpack/connect/(jetpack|wpcom)_search/yearly` and verify the purchase process. 
* Verify the purchase for a Jetpack site.


