### PR TITLE
Scan history: prevent a filter layout glitch when hovering the environment badge

### DIFF
--- a/client/components/jetpack/threat-history-list/style.scss
+++ b/client/components/jetpack/threat-history-list/style.scss
@@ -12,7 +12,7 @@
 		border-radius: 4px;
 	}
 
-	&__filters {
+	.segmented-control {
 		max-width: 230px;
 		margin: 0 auto;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Hovering the environment badge (the floating button at the bottom right corner) with the mouse triggers the loading of CSS that overwrites some of the page specific styles, moving the filters to the left of the screen (see screenshots). This commit increases the specificity of the styles in question.

#### Testing instructions

1. Download the PR and run Calypso
2. Select a site that has a security threat
3. Go to _Scan > History_
4. Hover the environment badge
5. Check that the filters are still centered in the page

#### Screenshots

<img width="701" alt="Screen Shot 2020-07-02 at 11 39 31 AM" src="https://user-images.githubusercontent.com/1620183/86379480-e5fe1780-bc58-11ea-9231-bdb11ea5bd72.png">
<img width="754" alt="Screen Shot 2020-07-02 at 11 40 34 AM" src="https://user-images.githubusercontent.com/1620183/86379512-ed252580-bc58-11ea-862e-a535795a77e8.png">
