### PR TITLE
Jetpack Backup: Ensure that backups in backupsOnSelectedDate are correct

### DIFF
--- a/client/my-sites/backup/main.jsx
+++ b/client/my-sites/backup/main.jsx
@@ -104,10 +104,11 @@ class BackupsPage extends Component {
 	 *  Return an object with the last backup and the rest of the activities from the selected date
 	 */
 	backupsFromSelectedDate = () => {
-		const { moment } = this.props;
+		const { moment, siteCapabilities } = this.props;
 
 		const date = this.getSelectedDate();
 		const index = moment( date ).format( INDEX_FORMAT );
+		const hasRealtimeBackups = includes( siteCapabilities, 'backup-realtime' );
 
 		const backupsOnSelectedDate = {
 			lastBackup: null,
@@ -117,7 +118,10 @@ class BackupsPage extends Component {
 		if ( index in this.props.indexedLog && this.props.indexedLog[ index ].length > 0 ) {
 			this.props.indexedLog[ index ].forEach( ( log ) => {
 				// Discard log if it's not activity rewindable, failed backup or with streams
-				if ( ! isActivityBackup( log ) && ! isSuccessfulRealtimeBackup( log ) ) {
+				if (
+					( ! hasRealtimeBackups && ! isActivityBackup( log ) ) ||
+					( ! isActivityBackup( log ) && ! isSuccessfulRealtimeBackup( log ) )
+				) {
 					return;
 				}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When non-daily-backup activities in the API are reported to be rewindable when the site does not have realtime backups, there is a slight disconnect in the UI because we make some UI assumptions, and the API does not agree. This PR updates the `backupsFromSelectedDate` method and strictly checks if the site has realtime backups, instead of assuming that the API will be correct.

#### Testing instructions

The original bug is not easily reproducible, so I suggest using whatever mechanism is comfortable for you to reproduce the issue below. Apply this patch locally and the issue should be fixed.

It's also strongly advisable to check a number of other sites and ensure that no unexpected unrelated breakages have occurred.

Fixes # 5525
