### PR TITLE
Create selector to check for product conflicts

### DIFF
--- a/client/lib/products-values/constants.js
+++ b/client/lib/products-values/constants.js
@@ -21,6 +21,8 @@ export const PRODUCT_WPCOM_SEARCH = 'wpcom_search';
 export const PRODUCT_WPCOM_SEARCH_MONTHLY = 'wpcom_search_monthly';
 export const PRODUCT_JETPACK_SCAN = 'jetpack_scan';
 export const PRODUCT_JETPACK_SCAN_MONTHLY = 'jetpack_scan_monthly';
+export const PRODUCT_JETPACK_ANTISPAM = 'jetpack_antispam';
+export const PRODUCT_JETPACK_ANTISPAM_MONTHLY = 'jetpack_antispam_monthly';
 
 export const JETPACK_BACKUP_PRODUCTS_YEARLY = [
 	PRODUCT_JETPACK_BACKUP_DAILY,
@@ -44,6 +46,11 @@ export const JETPACK_SEARCH_PRODUCTS = [
 export const isJetpackSearch = ( slug ) => JETPACK_SEARCH_PRODUCTS.includes( slug );
 
 export const JETPACK_SCAN_PRODUCTS = [ PRODUCT_JETPACK_SCAN, PRODUCT_JETPACK_SCAN_MONTHLY ];
+
+export const JETPACK_ANTISPAM_PRODUCTS = [
+	PRODUCT_JETPACK_ANTISPAM,
+	PRODUCT_JETPACK_ANTISPAM_MONTHLY,
+];
 
 export const JETPACK_PRODUCTS_LIST = [
 	...JETPACK_BACKUP_PRODUCTS,

--- a/client/lib/products-values/constants.js
+++ b/client/lib/products-values/constants.js
@@ -21,8 +21,8 @@ export const PRODUCT_WPCOM_SEARCH = 'wpcom_search';
 export const PRODUCT_WPCOM_SEARCH_MONTHLY = 'wpcom_search_monthly';
 export const PRODUCT_JETPACK_SCAN = 'jetpack_scan';
 export const PRODUCT_JETPACK_SCAN_MONTHLY = 'jetpack_scan_monthly';
-export const PRODUCT_JETPACK_ANTISPAM = 'jetpack_antispam';
-export const PRODUCT_JETPACK_ANTISPAM_MONTHLY = 'jetpack_antispam_monthly';
+export const PRODUCT_JETPACK_ANTI_SPAM = 'jetpack_anti_spam';
+export const PRODUCT_JETPACK_ANTI_SPAM_MONTHLY = 'jetpack_anti_spam_monthly';
 
 export const JETPACK_BACKUP_PRODUCTS_YEARLY = [
 	PRODUCT_JETPACK_BACKUP_DAILY,
@@ -47,9 +47,9 @@ export const isJetpackSearch = ( slug ) => JETPACK_SEARCH_PRODUCTS.includes( slu
 
 export const JETPACK_SCAN_PRODUCTS = [ PRODUCT_JETPACK_SCAN, PRODUCT_JETPACK_SCAN_MONTHLY ];
 
-export const JETPACK_ANTISPAM_PRODUCTS = [
-	PRODUCT_JETPACK_ANTISPAM,
-	PRODUCT_JETPACK_ANTISPAM_MONTHLY,
+export const JETPACK_ANTI_SPAM_PRODUCTS = [
+	PRODUCT_JETPACK_ANTI_SPAM,
+	PRODUCT_JETPACK_ANTI_SPAM_MONTHLY,
 ];
 
 export const JETPACK_PRODUCTS_LIST = [

--- a/client/state/sites/products/conflicts.ts
+++ b/client/state/sites/products/conflicts.ts
@@ -1,0 +1,66 @@
+/**
+ * Internal dependencies
+ */
+import createSelector from 'lib/create-selector';
+import { FEATURE_SPAM_AKISMET_PLUS } from 'lib/plans/constants';
+import {
+	PRODUCT_JETPACK_ANTISPAM,
+	PRODUCT_JETPACK_ANTISPAM_MONTHLY,
+	JETPACK_ANTISPAM_PRODUCTS,
+} from 'lib/products-values/constants';
+import { hasFeature } from 'state/sites/plans/selectors';
+import isSiteWPCOM from 'state/selectors/is-site-wpcom';
+import { hasSiteProduct } from 'state/sites/selectors';
+
+/**
+ * Type dependencies
+ */
+import type { AppState } from 'types';
+
+/**
+ * Checks if Jetpack Anti-Spam is conflicting with a site's current products.
+ *
+ * @param {AppState} state The redux state.
+ * @param {number} siteId The site ID.
+ * @returns {boolean|null} True for conflict, or null when it's unable to be determined.
+ */
+export const isAntiSpamConflicting = createSelector(
+	( state: AppState, siteId: number ): boolean | null => {
+		const planHasFeature = hasFeature( state, siteId, FEATURE_SPAM_AKISMET_PLUS );
+		const isWPCOM = isSiteWPCOM( state, siteId );
+		const hasAntiSpam = hasSiteProduct( state, siteId, JETPACK_ANTISPAM_PRODUCTS );
+		return planHasFeature || isWPCOM || hasAntiSpam;
+	},
+	[
+		( state: AppState, siteId: number ) => [
+			hasFeature( state, siteId, FEATURE_SPAM_AKISMET_PLUS ),
+			isSiteWPCOM( state, siteId ),
+			hasSiteProduct( state, siteId, JETPACK_ANTISPAM_PRODUCTS ),
+		],
+	]
+);
+
+/**
+ * Check if a given product conflicts with an existing site purchase.
+ *
+ * @param {AppState} state The redux state.
+ * @param {number|null} siteId Either the site ID, or null.
+ * @param {string} productSlug The product slug.
+ * @returns {boolean|null} True or false, or null when it's unable to be determined.
+ */
+export default function isProductConflictingWithSite(
+	state: AppState,
+	siteId: number | null,
+	productSlug: string
+): boolean | null {
+	if ( ! siteId ) {
+		return null;
+	}
+
+	switch ( productSlug ) {
+		case PRODUCT_JETPACK_ANTISPAM:
+		case PRODUCT_JETPACK_ANTISPAM_MONTHLY:
+			return isAntiSpamConflicting( state, siteId );
+	}
+	return null;
+}

--- a/client/state/sites/products/conflicts.ts
+++ b/client/state/sites/products/conflicts.ts
@@ -4,9 +4,9 @@
 import createSelector from 'lib/create-selector';
 import { FEATURE_SPAM_AKISMET_PLUS } from 'lib/plans/constants';
 import {
-	PRODUCT_JETPACK_ANTISPAM,
-	PRODUCT_JETPACK_ANTISPAM_MONTHLY,
-	JETPACK_ANTISPAM_PRODUCTS,
+	PRODUCT_JETPACK_ANTI_SPAM,
+	PRODUCT_JETPACK_ANTI_SPAM_MONTHLY,
+	JETPACK_ANTI_SPAM_PRODUCTS,
 } from 'lib/products-values/constants';
 import { hasFeature } from 'state/sites/plans/selectors';
 import isSiteWPCOM from 'state/selectors/is-site-wpcom';
@@ -28,14 +28,14 @@ export const isAntiSpamConflicting = createSelector(
 	( state: AppState, siteId: number ): boolean | null => {
 		const planHasFeature = hasFeature( state, siteId, FEATURE_SPAM_AKISMET_PLUS );
 		const isWPCOM = isSiteWPCOM( state, siteId );
-		const hasAntiSpam = hasSiteProduct( state, siteId, JETPACK_ANTISPAM_PRODUCTS );
+		const hasAntiSpam = hasSiteProduct( state, siteId, JETPACK_ANTI_SPAM_PRODUCTS );
 		return planHasFeature || isWPCOM || hasAntiSpam;
 	},
 	[
 		( state: AppState, siteId: number ) => [
 			hasFeature( state, siteId, FEATURE_SPAM_AKISMET_PLUS ),
 			isSiteWPCOM( state, siteId ),
-			hasSiteProduct( state, siteId, JETPACK_ANTISPAM_PRODUCTS ),
+			hasSiteProduct( state, siteId, JETPACK_ANTI_SPAM_PRODUCTS ),
 		],
 	]
 );
@@ -58,8 +58,8 @@ export default function isProductConflictingWithSite(
 	}
 
 	switch ( productSlug ) {
-		case PRODUCT_JETPACK_ANTISPAM:
-		case PRODUCT_JETPACK_ANTISPAM_MONTHLY:
+		case PRODUCT_JETPACK_ANTI_SPAM:
+		case PRODUCT_JETPACK_ANTI_SPAM_MONTHLY:
 			return isAntiSpamConflicting( state, siteId );
 	}
 	return null;

--- a/client/state/sites/products/test/conflicts.ts
+++ b/client/state/sites/products/test/conflicts.ts
@@ -1,0 +1,117 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { default as isProductConflictingWithSite, isAntiSpamConflicting } from '../conflicts';
+import {
+	PRODUCT_JETPACK_ANTISPAM,
+	PRODUCT_JETPACK_ANTISPAM_MONTHLY,
+} from 'lib/products-values/constants';
+import { PLAN_JETPACK_FREE, PLAN_JETPACK_PERSONAL } from 'lib/plans/constants';
+
+/**
+ * Type dependencies
+ */
+import type { AppState } from 'types';
+
+describe( 'conflicts', () => {
+	const getStateForSite = ( {
+		productSlug = '',
+		plan = PLAN_JETPACK_FREE,
+		jetpack = true,
+		atomic = false,
+	} = {} ): AppState => ( {
+		sites: {
+			plans: {
+				1234: {
+					data: [
+						{
+							currentPlan: true,
+							productSlug: plan,
+						},
+					],
+				},
+			},
+			items: {
+				1234: {
+					jetpack,
+					options: {
+						is_automated_transfer: atomic,
+					},
+					products: [ { product_slug: productSlug } ],
+				},
+			},
+		},
+		ui: {
+			selectedSiteId: null,
+		},
+	} );
+	describe( '#isProductConflictingWithSite()', () => {
+		test( 'should return null for a null siteId', () => {
+			const isProductConflicting = isProductConflictingWithSite(
+				{},
+				null,
+				PRODUCT_JETPACK_ANTISPAM
+			);
+			expect( isProductConflicting ).to.be.null;
+		} );
+
+		test( 'should return null for a test product', () => {
+			const isProductConflicting = isProductConflictingWithSite( {}, 1234, 'test' );
+			expect( isProductConflicting ).to.be.null;
+		} );
+
+		test( 'should return true when testing for Anti-Spam annual', () => {
+			const isProductConflicting = isProductConflictingWithSite(
+				getStateForSite( { productSlug: PRODUCT_JETPACK_ANTISPAM } ),
+				1234,
+				PRODUCT_JETPACK_ANTISPAM
+			);
+			expect( isProductConflicting ).to.be.true;
+		} );
+
+		test( 'should return true when testing for Anti-Spam monthly', () => {
+			const isProductConflicting = isProductConflictingWithSite(
+				getStateForSite( { productSlug: PRODUCT_JETPACK_ANTISPAM_MONTHLY } ),
+				1234,
+				PRODUCT_JETPACK_ANTISPAM_MONTHLY
+			);
+			expect( isProductConflicting ).to.be.true;
+		} );
+	} );
+
+	describe( '#isAntiSpamConflicting', () => {
+		test( 'should return true when the site has a plan with anti-spam', () => {
+			const state = getStateForSite( { plan: PLAN_JETPACK_PERSONAL } );
+			const isConflicting = isAntiSpamConflicting( state, 1234 );
+			expect( isConflicting ).to.be.true;
+		} );
+
+		test( 'should return true when the site is not Jetpack', () => {
+			const isConflicting = isAntiSpamConflicting( getStateForSite( { jetpack: false } ), 1234 );
+			expect( isConflicting ).to.be.true;
+		} );
+
+		test( 'should return true when the site is Atomic', () => {
+			const isConflicting = isAntiSpamConflicting( getStateForSite( { atomic: true } ), 1234 );
+			expect( isConflicting ).to.be.true;
+		} );
+
+		test( 'should return true when the site already has Anti-Spam', () => {
+			const isConflicting = isAntiSpamConflicting(
+				getStateForSite( { productSlug: PRODUCT_JETPACK_ANTISPAM_MONTHLY } ),
+				1234
+			);
+			expect( isConflicting ).to.be.true;
+		} );
+
+		test( 'should return false when the site satisfies the other conditions', () => {
+			const isConflicting = isAntiSpamConflicting( getStateForSite(), 1234 );
+			expect( isConflicting ).to.be.false;
+		} );
+	} );
+} );

--- a/client/state/sites/products/test/conflicts.ts
+++ b/client/state/sites/products/test/conflicts.ts
@@ -8,8 +8,8 @@ import { expect } from 'chai';
  */
 import { default as isProductConflictingWithSite, isAntiSpamConflicting } from '../conflicts';
 import {
-	PRODUCT_JETPACK_ANTISPAM,
-	PRODUCT_JETPACK_ANTISPAM_MONTHLY,
+	PRODUCT_JETPACK_ANTI_SPAM,
+	PRODUCT_JETPACK_ANTI_SPAM_MONTHLY,
 } from 'lib/products-values/constants';
 import { PLAN_JETPACK_FREE, PLAN_JETPACK_PERSONAL } from 'lib/plans/constants';
 
@@ -55,7 +55,7 @@ describe( 'conflicts', () => {
 			const isProductConflicting = isProductConflictingWithSite(
 				{},
 				null,
-				PRODUCT_JETPACK_ANTISPAM
+				PRODUCT_JETPACK_ANTI_SPAM
 			);
 			expect( isProductConflicting ).to.be.null;
 		} );
@@ -67,18 +67,18 @@ describe( 'conflicts', () => {
 
 		test( 'should return true when testing for Anti-Spam annual', () => {
 			const isProductConflicting = isProductConflictingWithSite(
-				getStateForSite( { productSlug: PRODUCT_JETPACK_ANTISPAM } ),
+				getStateForSite( { productSlug: PRODUCT_JETPACK_ANTI_SPAM } ),
 				1234,
-				PRODUCT_JETPACK_ANTISPAM
+				PRODUCT_JETPACK_ANTI_SPAM
 			);
 			expect( isProductConflicting ).to.be.true;
 		} );
 
 		test( 'should return true when testing for Anti-Spam monthly', () => {
 			const isProductConflicting = isProductConflictingWithSite(
-				getStateForSite( { productSlug: PRODUCT_JETPACK_ANTISPAM_MONTHLY } ),
+				getStateForSite( { productSlug: PRODUCT_JETPACK_ANTI_SPAM_MONTHLY } ),
 				1234,
-				PRODUCT_JETPACK_ANTISPAM_MONTHLY
+				PRODUCT_JETPACK_ANTI_SPAM_MONTHLY
 			);
 			expect( isProductConflicting ).to.be.true;
 		} );
@@ -103,7 +103,7 @@ describe( 'conflicts', () => {
 
 		test( 'should return true when the site already has Anti-Spam', () => {
 			const isConflicting = isAntiSpamConflicting(
-				getStateForSite( { productSlug: PRODUCT_JETPACK_ANTISPAM_MONTHLY } ),
+				getStateForSite( { productSlug: PRODUCT_JETPACK_ANTI_SPAM_MONTHLY } ),
 				1234
 			);
 			expect( isConflicting ).to.be.true;

--- a/client/state/sites/selectors/has-site-product.ts
+++ b/client/state/sites/selectors/has-site-product.ts
@@ -30,5 +30,12 @@ export default createSelector(
 			).length > 0
 		);
 	},
-	( state: AppState, siteId: number | null ) => getSiteProducts( state, siteId )
+	( state: AppState, siteId: number | null ) => getSiteProducts( state, siteId ),
+	( state: AppState, siteId: number | null, productSlug: string | string[] ): string => {
+		siteId = siteId || 0;
+		if ( ! Array.isArray( productSlug ) ) {
+			productSlug = [ productSlug ];
+		}
+		return `{ siteId || 0 }-${ productSlug.join( '-' ) }`;
+	}
 );

--- a/client/state/sites/selectors/has-site-product.ts
+++ b/client/state/sites/selectors/has-site-product.ts
@@ -1,0 +1,34 @@
+/**
+ * External dependencies
+ */
+import { intersection } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import createSelector from 'lib/create-selector';
+import { getSiteProducts } from 'state/sites/selectors';
+
+/**
+ * Type dependencies
+ */
+import type { AppState } from 'types';
+
+export default createSelector(
+	( state: AppState, siteId: number | null, productSlug: string | string[] ): boolean | null => {
+		const siteProducts = getSiteProducts( state, siteId );
+		if ( null === siteProducts ) {
+			return null;
+		}
+		if ( ! Array.isArray( productSlug ) ) {
+			productSlug = [ productSlug ];
+		}
+		return (
+			intersection(
+				siteProducts.map( ( { productSlug: slug } ) => slug ),
+				productSlug
+			).length > 0
+		);
+	},
+	( state: AppState, siteId: number | null ) => getSiteProducts( state, siteId )
+);

--- a/client/state/sites/selectors/index.js
+++ b/client/state/sites/selectors/index.js
@@ -38,6 +38,7 @@ export { default as hasAllSitesList } from './has-all-sites-list';
 export { default as hasDefaultSiteTitle } from './has-default-site-title';
 export { default as hasJetpackSiteCustomDomain } from './has-jetpack-site-custom-domain';
 export { default as hasJetpackSiteJetpackThemes } from './has-jetpack-site-jetpack-themes';
+export { default as hasSiteProduct } from './has-site-product';
 export { default as hasJetpackSiteJetpackThemesExtendedFeatures } from './has-jetpack-site-jetpack-themes-extended-features';
 export { default as hasStaticFrontPage } from './has-static-front-page';
 export { default as isCurrentPlanPaid } from './is-current-plan-paid';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This adds a new file to detect product purchase conflicts, with the only implementation so far for Anti-Spam.
* Also adds a selector `hasSiteProduct` to check if a given site has a product or products.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Unit tests pass.

Fixes 1181531115069428-as-1182817583001067.
