### PR TITLE
Jetpack Cloud: Add upgrade path and hide filter in Activity Log v2

### DIFF
--- a/client/components/jetpack/upsell/index.tsx
+++ b/client/components/jetpack/upsell/index.tsx
@@ -19,7 +19,7 @@ interface Props {
 	buttonLink: TranslateResult;
 	buttonText?: TranslateResult;
 	headerText: TranslateResult;
-	iconComponent: ReactChild;
+	iconComponent?: ReactChild;
 	onClick?: () => void;
 }
 

--- a/client/my-sites/activity/activity-log-v2/index.tsx
+++ b/client/my-sites/activity/activity-log-v2/index.tsx
@@ -20,6 +20,7 @@ import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import ActivityCardList from 'components/activity-card-list';
 import DocumentHead from 'components/data/document-head';
 import QuerySitePlans from 'components/data/query-site-plans';
+import QuerySitePurchases from 'components/data/query-site-purchases';
 import FormattedHeader from 'components/formatted-header';
 import Upsell from 'components/jetpack/upsell';
 import getActivityLogFilter from 'state/selectors/get-activity-log-filter';
@@ -90,6 +91,7 @@ const ActivityLogV2: FunctionComponent = () => {
 			wideLayout={ ! isJetpackCloud() }
 		>
 			{ siteId && <QuerySitePlans siteId={ siteId } /> }
+			{ siteId && <QuerySitePurchases siteId={ siteId } /> }
 			<DocumentHead title={ translate( 'Activity log' ) } />
 			<SidebarNavigation />
 			<PageViewTracker path="/activity-log/:site" title="Activity log" />

--- a/client/my-sites/activity/activity-log-v2/index.tsx
+++ b/client/my-sites/activity/activity-log-v2/index.tsx
@@ -5,17 +5,22 @@ import { useSelector } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
 import classNames from 'classnames';
 import React, { FunctionComponent, useEffect } from 'react';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
  */
+import QuerySitePlans from 'components/data/query-site-plans';
+import { isFreePlan } from 'lib/plans';
 import { getHttpData } from 'state/data-layer/http-data';
-import { getSelectedSiteId } from 'state/ui/selectors';
 import { requestActivityLogs, getRequestActivityLogsId } from 'state/data-getters';
+import { getCurrentPlan } from 'state/sites/plans/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
 import ActivityCardList from 'components/activity-card-list';
 import DocumentHead from 'components/data/document-head';
 import FormattedHeader from 'components/formatted-header';
 import getActivityLogFilter from 'state/selectors/get-activity-log-filter';
+import isVipSite from 'state/selectors/is-vip-site';
 import isJetpackCloud from 'lib/jetpack/is-jetpack-cloud';
 import Main from 'components/main';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
@@ -32,6 +37,13 @@ const ActivityLogV2: FunctionComponent = () => {
 	const siteId = useSelector( getSelectedSiteId );
 	const filter = useSelector( ( state ) => getActivityLogFilter( state, siteId ) );
 	const logs = useSelector( () => getHttpData( getRequestActivityLogsId( siteId, filter ) ).data );
+	const siteIsOnFreePlan = useSelector(
+		( state ) =>
+			isFreePlan( get( getCurrentPlan( state, siteId ), 'productSlug' ) ) &&
+			! isVipSite( state, siteId )
+	);
+
+	const showFilter = ! siteIsOnFreePlan;
 
 	// when the filter changes, re-request the logs
 	useEffect( () => {
@@ -45,6 +57,7 @@ const ActivityLogV2: FunctionComponent = () => {
 			} ) }
 			wideLayout={ ! isJetpackCloud() }
 		>
+			{ siteId && <QuerySitePlans siteId={ siteId } /> }
 			<DocumentHead title={ translate( 'Activity log' ) } />
 			<SidebarNavigation />
 			<PageViewTracker path="/activity-log/:site" title="Activity log" />
@@ -67,7 +80,7 @@ const ActivityLogV2: FunctionComponent = () => {
 				/>
 			) }
 			<div className="activity-log-v2__content">
-				<ActivityCardList logs={ logs } pageSize={ 10 } />
+				<ActivityCardList logs={ logs } pageSize={ 10 } showFilter={ showFilter } />
 			</div>
 		</Main>
 	);

--- a/client/my-sites/activity/activity-log-v2/index.tsx
+++ b/client/my-sites/activity/activity-log-v2/index.tsx
@@ -58,7 +58,7 @@ const ActivityLogV2: FunctionComponent = () => {
 		<Upsell
 			headerText={ translate( 'Welcome to your site’s activity' ) }
 			bodyText={ translate(
-				'With your free plan, you can monitor the 20 most recent events. A paid plan unlocks more powerful features. You can access all site activity for the last 30 days and filter events by type and date range to quickly find the information you need.'
+				'With your free plan, you can monitor the 20 most recent events. A paid plan unlocks more powerful features. You can access all site activity for the last 30 days and filter events by type and date range to quickly find the information you need. '
 			) }
 			buttonLink={ `https://jetpack.com/upgrade/backup/?site=${ selectedSiteSlug }` }
 			buttonText={ translate( 'Upgrade Now' ) }

--- a/client/my-sites/activity/activity-log-v2/index.tsx
+++ b/client/my-sites/activity/activity-log-v2/index.tsx
@@ -61,7 +61,7 @@ const ActivityLogV2: FunctionComponent = () => {
 			bodyText={ translate(
 				'With your free plan, you can monitor the 20 most recent events. A paid plan unlocks more powerful features. You can access all site activity for the last 30 days and filter events by type and date range to quickly find the information you need. '
 			) }
-			buttonLink={ `https://jetpack.com/upgrade/backup/?site=${ selectedSiteSlug }` }
+			buttonLink={ `https://wordpress.com/plans/${ selectedSiteSlug }?feature=offsite-backup-vaultpress-daily&plan=jetpack_personal_monthly` }
 			buttonText={ translate( 'Upgrade Now' ) }
 			onClick={ () =>
 				dispatch( recordTracksEvent( 'calypso_jetpack_activity_log_upgrade_click' ) )

--- a/client/my-sites/activity/activity-log-v2/style.scss
+++ b/client/my-sites/activity/activity-log-v2/style.scss
@@ -4,6 +4,7 @@ main.activity-log-v2 {
 			margin-top: 32px;
 		}
 		.activity-log-v2__content {
+			margin-top: 32px;
 			margin-bottom: 32px;
 		}
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

On free plans the Activity Log limits the display to show 20 items, hides the filter options, and provides an upgrade path to  unlock the full functionality. Activity Log v2 is currently limited to 20 items for free plans, but there is no upgrade path or explanation of why only 20 items show, and filtering still works.

This PR updates the Activity Log v2 so that it hides the filter and provides an explanation along with an upgrade path. The copy comes from the upgrade prompt in WordPress.com, and the layout is the same as the Upsell pages but with the icon removed.

When eligible for upgrade:
<img width="779" alt="image" src="https://user-images.githubusercontent.com/42627630/86409721-0e007180-bc7f-11ea-922a-d38e3af8f8e0.png">

When Activity Log is fully activated:
<img width="798" alt="image" src="https://user-images.githubusercontent.com/42627630/86409671-f628ed80-bc7e-11ea-8632-208541b29305.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Visit `/activity-log/<SITE_SLUG>` for the following types of sites and verify that the behavior is correct:
1. Free plan: upgrade shows
2. Any backup product: upgrade does not show
3. Any scan product without backup: upgrade shows
4. Any other paid plan: upgrade does not show
