### PR TITLE
Jetpack Anti Spam: add Anti Spam

### DIFF
--- a/client/lib/products-values/constants.js
+++ b/client/lib/products-values/constants.js
@@ -21,6 +21,8 @@ export const PRODUCT_WPCOM_SEARCH = 'wpcom_search';
 export const PRODUCT_WPCOM_SEARCH_MONTHLY = 'wpcom_search_monthly';
 export const PRODUCT_JETPACK_SCAN = 'jetpack_scan';
 export const PRODUCT_JETPACK_SCAN_MONTHLY = 'jetpack_scan_monthly';
+export const PRODUCT_JETPACK_ANTI_SPAM = 'jetpack_anti_spam';
+export const PRODUCT_JETPACK_ANTI_SPAM_MONTHLY = 'jetpack_anti_spam_monthly';
 
 export const JETPACK_BACKUP_PRODUCTS_YEARLY = [
 	PRODUCT_JETPACK_BACKUP_DAILY,
@@ -44,10 +46,15 @@ export const JETPACK_SEARCH_PRODUCTS = [
 export const isJetpackSearch = ( slug ) => JETPACK_SEARCH_PRODUCTS.includes( slug );
 
 export const JETPACK_SCAN_PRODUCTS = [ PRODUCT_JETPACK_SCAN, PRODUCT_JETPACK_SCAN_MONTHLY ];
+export const JETPACK_ANTI_SPAM_PRODUCTS = [
+	PRODUCT_JETPACK_ANTI_SPAM,
+	PRODUCT_JETPACK_ANTI_SPAM_MONTHLY,
+];
 
 export const JETPACK_PRODUCTS_LIST = [
 	...JETPACK_BACKUP_PRODUCTS,
 	...( isEnabled( 'jetpack/scan-product' ) ? JETPACK_SCAN_PRODUCTS : [] ),
+	...( isEnabled( 'jetpack/anti-spam-product' ) ? JETPACK_ANTI_SPAM_PRODUCTS : [] ),
 	...( isEnabled( 'jetpack/search-product' ) ? JETPACK_SEARCH_PRODUCTS : [] ),
 ];
 
@@ -62,6 +69,7 @@ export const JETPACK_SEARCH_TIER_MORE_THAN_1M_RECORDS = 'more_than_1m_records';
 export const JETPACK_BACKUP_PRODUCT_LANDING_PAGE_URL = 'https://jetpack.com/upgrade/backup/';
 export const JETPACK_SEARCH_PRODUCT_LANDING_PAGE_URL = 'https://jetpack.com/upgrade/search/';
 export const JETPACK_SCAN_PRODUCT_LANDING_PAGE_URL = 'https://jetpack.com/upgrade/scan/';
+export const JETPACK_ANTI_SPAM_PRODUCT_LANDING_PAGE_URL = 'https://jetpack.com/upgrade/anti-spam/';
 
 export const JETPACK_PRODUCT_PRICE_MATRIX = {
 	[ PRODUCT_JETPACK_BACKUP_DAILY ]: {
@@ -80,6 +88,10 @@ export const JETPACK_PRODUCT_PRICE_MATRIX = {
 		relatedProduct: PRODUCT_JETPACK_SCAN_MONTHLY,
 		ratio: 12,
 	},
+	[ PRODUCT_JETPACK_ANTI_SPAM ]: {
+		relatedProduct: PRODUCT_JETPACK_ANTI_SPAM_MONTHLY,
+		ratio: 12,
+	},
 };
 
 // Translatable strings
@@ -93,6 +105,8 @@ export const getJetpackProductsShortNames = () => {
 		[ PRODUCT_JETPACK_SEARCH_MONTHLY ]: translate( 'Search' ),
 		[ PRODUCT_JETPACK_SCAN ]: translate( 'Daily Scan' ),
 		[ PRODUCT_JETPACK_SCAN_MONTHLY ]: translate( 'Daily Scan' ),
+		[ PRODUCT_JETPACK_ANTI_SPAM ]: translate( 'Anti Spam' ),
+		[ PRODUCT_JETPACK_ANTI_SPAM_MONTHLY ]: translate( 'Anti Spam' ),
 	};
 };
 
@@ -126,6 +140,8 @@ export const getJetpackProductsDisplayNames = () => {
 			} ) }{ ' ' }
 		</>
 	);
+
+	const antiSpam = <>{ translate( 'Jetpack Anti Spam' ) }</>;
 	return {
 		[ PRODUCT_JETPACK_BACKUP_DAILY ]: backupDaily,
 		[ PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY ]: backupDaily,
@@ -137,11 +153,14 @@ export const getJetpackProductsDisplayNames = () => {
 		[ PRODUCT_WPCOM_SEARCH_MONTHLY ]: search,
 		[ PRODUCT_JETPACK_SCAN ]: scanDaily,
 		[ PRODUCT_JETPACK_SCAN_MONTHLY ]: scanDaily,
+		[ PRODUCT_JETPACK_ANTI_SPAM ]: antiSpam,
+		[ PRODUCT_JETPACK_ANTI_SPAM_MONTHLY ]: antiSpam,
 	};
 };
 export const getJetpackProductsTaglines = () => {
 	const searchTagline = translate( 'Search your site.' );
-	const scanTagline = 'Scan your site.';
+	const scanTagline = translate( 'Scan your site.' );
+	const antiSpamTagline = translate( 'Automatically clear spam from comments and forms.' );
 	return {
 		[ PRODUCT_JETPACK_BACKUP_DAILY ]: translate(
 			'Your data is being securely backed up every day with a 30-day archive.'
@@ -161,6 +180,8 @@ export const getJetpackProductsTaglines = () => {
 		[ PRODUCT_WPCOM_SEARCH_MONTHLY ]: searchTagline,
 		[ PRODUCT_JETPACK_SCAN ]: scanTagline,
 		[ PRODUCT_JETPACK_SCAN_MONTHLY ]: scanTagline,
+		[ PRODUCT_JETPACK_ANTI_SPAM ]: antiSpamTagline,
+		[ PRODUCT_JETPACK_ANTI_SPAM_MONTHLY ]: antiSpamTagline,
 	};
 };
 
@@ -170,6 +191,9 @@ export const getJetpackProductsDescriptions = () => {
 	);
 	const scanDescription = translate(
 		'Automatic scanning and one-click fixes keep your site one step ahead of security threats.'
+	);
+	const antiSpamDescription = translate(
+		'Automatically clear spam from comments and forms. Save time, get more responses, give your visitors a better experience – all without lifting a finger.'
 	);
 	return {
 		[ PRODUCT_JETPACK_BACKUP_DAILY ]: translate(
@@ -188,6 +212,8 @@ export const getJetpackProductsDescriptions = () => {
 		[ PRODUCT_JETPACK_SEARCH_MONTHLY ]: searchDescription,
 		[ PRODUCT_JETPACK_SCAN ]: scanDescription,
 		[ PRODUCT_JETPACK_SCAN_MONTHLY ]: scanDescription,
+		[ PRODUCT_JETPACK_ANTI_SPAM ]: antiSpamDescription,
+		[ PRODUCT_JETPACK_ANTI_SPAM_MONTHLY ]: antiSpamDescription,
 	};
 };
 
@@ -245,6 +271,33 @@ export const getJetpackProducts = () => {
 			optionDescriptions: getJetpackProductsDescriptions(),
 			optionsLabel: translate( 'Select a product option:' ),
 			slugs: JETPACK_SCAN_PRODUCTS,
+		} );
+	isEnabled( 'jetpack/anti-spam-product' ) &&
+		output.push( {
+			title: translate( 'Jetpack Anti Spam' ),
+			description: getJetpackProductsDescriptions()[ PRODUCT_JETPACK_ANTI_SPAM ],
+			// There is only one option per billing interval, but this
+			// component still needs the full display with radio buttons.
+			forceRadios: true,
+			hasPromo: false,
+			id: PRODUCT_JETPACK_ANTI_SPAM,
+			link: {
+				label: translate( 'Learn more' ),
+				props: {
+					location: 'product_jetpack_anti_spam_description',
+					slug: 'learn-more-anti-spam',
+				},
+				url: JETPACK_ANTI_SPAM_PRODUCT_LANDING_PAGE_URL,
+			},
+			options: {
+				yearly: [ PRODUCT_JETPACK_ANTI_SPAM ],
+				monthly: [ PRODUCT_JETPACK_ANTI_SPAM_MONTHLY ],
+			},
+			optionShortNames: getJetpackProductsShortNames(),
+			optionDisplayNames: getJetpackProductsDisplayNames(),
+			optionDescriptions: getJetpackProductsDescriptions(),
+			optionsLabel: translate( 'Select a product option:' ),
+			slugs: JETPACK_ANTI_SPAM_PRODUCTS,
 		} );
 	isEnabled( 'jetpack/search-product' ) &&
 		output.push( {

--- a/client/lib/products-values/constants.js
+++ b/client/lib/products-values/constants.js
@@ -105,8 +105,8 @@ export const getJetpackProductsShortNames = () => {
 		[ PRODUCT_JETPACK_SEARCH_MONTHLY ]: translate( 'Search' ),
 		[ PRODUCT_JETPACK_SCAN ]: translate( 'Daily Scan' ),
 		[ PRODUCT_JETPACK_SCAN_MONTHLY ]: translate( 'Daily Scan' ),
-		[ PRODUCT_JETPACK_ANTI_SPAM ]: translate( 'Anti Spam' ),
-		[ PRODUCT_JETPACK_ANTI_SPAM_MONTHLY ]: translate( 'Anti Spam' ),
+		[ PRODUCT_JETPACK_ANTI_SPAM ]: translate( 'Anti-Spam' ),
+		[ PRODUCT_JETPACK_ANTI_SPAM_MONTHLY ]: translate( 'Anti-Spam' ),
 	};
 };
 
@@ -141,7 +141,7 @@ export const getJetpackProductsDisplayNames = () => {
 		</>
 	);
 
-	const antiSpam = <>{ translate( 'Jetpack Anti Spam' ) }</>;
+	const antiSpam = <>{ translate( 'Jetpack Anti-Spam' ) }</>;
 	return {
 		[ PRODUCT_JETPACK_BACKUP_DAILY ]: backupDaily,
 		[ PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY ]: backupDaily,
@@ -274,7 +274,7 @@ export const getJetpackProducts = () => {
 		} );
 	isEnabled( 'jetpack/anti-spam-product' ) &&
 		output.push( {
-			title: translate( 'Jetpack Anti Spam' ),
+			title: translate( 'Jetpack Anti-Spam' ),
 			description: getJetpackProductsDescriptions()[ PRODUCT_JETPACK_ANTI_SPAM ],
 			// There is only one option per billing interval, but this
 			// component still needs the full display with radio buttons.

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -305,9 +305,7 @@ export class Checkout extends React.Component {
 		}
 
 		if (
-			( startsWith( product, 'jetpack_backup' ) ||
-				startsWith( product, 'jetpack_scan' ) ||
-				startsWith( product, 'jetpack_anti_spam' ) ) &&
+			( startsWith( product, 'jetpack_backup' ) || startsWith( product, 'jetpack_scan' ) ) &&
 			isJetpackNotAtomic
 		) {
 			cartItem = jetpackProductItem( product );

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -305,7 +305,9 @@ export class Checkout extends React.Component {
 		}
 
 		if (
-			( startsWith( product, 'jetpack_backup' ) || startsWith( product, 'jetpack_scan' ) ) &&
+			( startsWith( product, 'jetpack_backup' ) ||
+				startsWith( product, 'jetpack_scan' ) ||
+				startsWith( product, 'jetpack_anti_spam' ) ) &&
 			isJetpackNotAtomic
 		) {
 			cartItem = jetpackProductItem( product );

--- a/config/development.json
+++ b/config/development.json
@@ -89,6 +89,7 @@
 		"jetpack/features-section/atomic": true,
 		"jetpack/features-section/jetpack": true,
 		"jetpack/scan-product": true,
+		"jetpack/anti-spam-product": true,
 		"jetpack/backups-restore": true,
 		"jetpack/on-demand-scan": true,
 		"jitms": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds Jetpack Anti Spam to the Plans page.

Revision D45785-code is required for this to work (Anti Spam is include in `/products` response).

#### Testing instructions

Prerequisites:
* D45785-code running in your sandbox (public-api.wordpress.com sandboxed).
* Jetpack site.

Instructions:
* Run this PR (you have to run `yarn start` since this adds a new config variable).
* Select your Jetpack site.
* Visit `http://calypso.localhost:3000/plans/my-plan/[site]`.
* Confirm that you see the Jetpack Anti Spam product card.
* Does the copy looks right?
* Does the design looks right?

Fixes 1181531115069428-as-1182646983386223

#### Demo
![image](https://user-images.githubusercontent.com/3418513/86406778-22963700-bc8a-11ea-9570-a803a10bb046.png)

![image](https://user-images.githubusercontent.com/3418513/86406731-0c887680-bc8a-11ea-9600-9c271c273e71.png)

![Kapture 2020-07-02 at 17 33 41](https://user-images.githubusercontent.com/3418513/86406894-52ddd580-bc8a-11ea-99d8-8041213fc9d5.gif)
