### PR TITLE
composite-checkout: Prevent returning invalid concierge upsell url with pending receipt

### DIFF
--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
@@ -68,6 +68,25 @@ describe( 'getThankYouPageUrl', () => {
 		expect( url ).toBe( '/checkout/thank-you/foo.bar/pending/1234abcd' );
 	} );
 
+	it( 'redirects to the quickstart offer thank-you page with a placeholder receipt id when a site but no orderId is set and the cart contains the personal plan', () => {
+		isEnabled.mockImplementation( ( flag ) => flag === 'upsell/concierge-session' );
+		const cart = {
+			products: [
+				{
+					product_slug: 'personal-bundle',
+				},
+			],
+		};
+		const url = getThankYouPageUrl( {
+			...defaultArgs,
+			siteSlug: 'foo.bar',
+			cart,
+		} );
+		expect( url ).toBe(
+			'/checkout/thank-you/foo.bar/pending?redirectTo=https://example.com/checkout/offer-quickstart-session/:receiptId/foo.bar'
+		);
+	} );
+
 	it( 'redirects to the thank-you page with a placeholder receiptId with a site when the cart is not empty but there is no receipt id', () => {
 		const cart = { products: [ { id: 'something' } ] };
 		const url = getThankYouPageUrl( { ...defaultArgs, siteSlug: 'foo.bar', cart } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The Stripe redirect payment methods (iDEAL, Sofort, Giropay, Bancontact, etc.) all have to submit a `success_url` to the `/me/transactions` endpoint which is then passed along to Stripe. Then the page gets redirected to confirm the payment, and when it comes back, it uses that `success_url` (slightly modified by the `/rest/v1/me/transactions/source-payment` endpoint to replace receipt placeholder text and append the order ID) to tell calypso what page to show next.

For some of these payment methods (notably Bancontact - see #43651 ), the receipt placeholder text is replaced with `pending`. In a "regular" thank-you page url like `/checkout/thank-you/example.com/pending/12345`, that causes calypso to display a "please wait" page which polls the server until the order is complete or fails. However, some conditions can cause the thank-you url to be an upsell page instead, creating a url like `/checkout/offer-quickstart-session/pending/example.com/12345` which is an invalid calypso route, causing the user to see a blank page.

In old checkout, Stripe redirect payment methods customize the `success_url` by taking what the url would be and then placing it in a `redirectTo` query string after a regular thank-you `pending` page url. New checkout does not have this behavior, causing the user to be redirected to a blank page after payment is complete.

In this PR, we first make sure that an invalid redirect url cannot be generated. 

#### Testing instructions

TBD