### PR TITLE
Gutenboarding: Track when launch button is clicked.

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/editor-gutenboarding-launch/index.ts
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-gutenboarding-launch/index.ts
@@ -5,6 +5,8 @@ import { __ } from '@wordpress/i18n';
 import domReady from '@wordpress/dom-ready';
 import { addAction } from '@wordpress/hooks';
 import { dispatch } from '@wordpress/data';
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+
 // Depend on `core/editor` store.
 import '@wordpress/editor';
 
@@ -71,6 +73,9 @@ function updateEditor() {
 			// Disable href navigation
 			e.preventDefault();
 			await dispatch( 'core/editor' ).savePost();
+
+			recordTracksEvent( 'calypso_editor_launch_click', {} );
+
 			// Using window.top to escape from the editor iframe on WordPress.com
 			window.top.location.href = launchHref;
 		};

--- a/apps/full-site-editing/full-site-editing-plugin/editor-gutenboarding-launch/index.ts
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-gutenboarding-launch/index.ts
@@ -74,7 +74,7 @@ function updateEditor() {
 			e.preventDefault();
 			await dispatch( 'core/editor' ).savePost();
 
-			recordTracksEvent( 'calypso_editor_launch_click', {} );
+			recordTracksEvent( 'calypso_newsite_editor_launch_click' );
 
 			// Using window.top to escape from the editor iframe on WordPress.com
 			window.top.location.href = launchHref;

--- a/apps/full-site-editing/package.json
+++ b/apps/full-site-editing/package.json
@@ -92,6 +92,7 @@
 		"prepare": "check-npm-client && yarn run sync:newspack-blocks --nodemodules"
 	},
 	"dependencies": {
+		"@automattic/calypso-analytics": "^1.0.0-alpha.1",
 		"@automattic/calypso-build": "*",
 		"@automattic/data-stores": "^1.0.0-alpha.1",
 		"@automattic/domain-picker": "^1.0.0-alpha.0",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Track when launch button is clicked.

#### Testing instructions

* `yarn dev --sync` the `app/full-site-editing` folder to your sandbox.
* Create a new site until reach the editor stage, copy the url (so your can reopen later), point to that site on your sandbox, close & reopen your browser if you have to, then reopen the url you copied.
* On your network panel on developer tools, ensure Preserve Log is checked.
* Click Launch.
* Check for `t.gif` request.

#### Screenshot

![image](https://user-images.githubusercontent.com/1287077/86432855-6411fb00-bcf9-11ea-9a5f-87ba1edf1534.png)


Fixes #43828
