### PR TITLE
New P2: skip preview 

### DIFF
--- a/client/state/sites/selectors/is-site-previewable.js
+++ b/client/state/sites/selectors/is-site-previewable.js
@@ -29,6 +29,10 @@ export default function isSitePreviewable( state, siteId ) {
 		return false;
 	}
 
+	if ( site.options.is_wpforteams_site ) {
+		return false;
+	}
+
 	const unmappedUrl = getSiteOption( state, siteId, 'unmapped_url' );
 	return !! unmappedUrl && isHttps( unmappedUrl );
 }

--- a/client/state/sites/selectors/is-site-previewable.js
+++ b/client/state/sites/selectors/is-site-previewable.js
@@ -29,7 +29,8 @@ export default function isSitePreviewable( state, siteId ) {
 		return false;
 	}
 
-	if ( site.options.is_wpforteams_site ) {
+	const isWPForTeamsSite = getSiteOption( state, siteId, 'is_wpforteams_site' );
+	if ( isWPForTeamsSite ) {
 		return false;
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Skip preview for P2 (wpforteams) sites

#### Testing instructions
* Click the _View \<site>_ link, under the _Switch Site_ button on the sidebar. 
    - P2 sites: It should redirect to your site instead of displaying a preview.
    - Normal WPCOM sites: It should display a preview.

Fixes 588-gh-p2
