### PR TITLE
composite-checkout: Pass onEvent handler to useStoredCards

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -547,7 +547,7 @@ export default function CompositeCheckout( {
 			paypal: ( transactionData ) =>
 				payPalProcessor( transactionData, getThankYouUrl, couponItem, isWhiteGloveOffer ),
 		} ),
-		[ couponItem, getThankYouUrl, isWhiteGloveOffer ]
+		[ couponItem, getThankYouUrl, isWhiteGloveOffer, siteSlug ]
 	);
 
 	useRecordCheckoutLoaded(

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -336,7 +336,8 @@ export default function CompositeCheckout( {
 	useRedirectIfCartEmpty( items, `/plans/${ siteSlug || '' }`, isLoadingCart );
 
 	const { storedCards, isLoading: isLoadingStoredCards } = useStoredCards(
-		getStoredCards || wpcomGetStoredCards
+		getStoredCards || wpcomGetStoredCards,
+		recordEvent
 	);
 	const {
 		canMakePayment: isApplePayAvailable,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Somehow, the required second argument to `useStoredCards` was never passed. This argument is only used if there is an error while loading stored cards, but it would cause a fatal error in that case since `undefined` is not a function.

This PR adds that argument.

#### Testing instructions

- Modify the stored cards endpoint to return an error. This can be done on the server or more easily by modifying the definition of `wpcomGetStoredCards` in `client/my-sites/checkout/composite-checkout/composite-checkout.js` as follows:

```
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -101,7 +101,9 @@ const wpcom = wp.undocumented();
 // otherwise we get `this is not defined` errors.
 const wpcomGetCart = ( ...args ) => wpcom.getCart( ...args );
 const wpcomSetCart = ( ...args ) => wpcom.setCart( ...args );
-const wpcomGetStoredCards = ( ...args ) => wpcom.getStoredCards( ...args );
+const wpcomGetStoredCards = () => {
+       throw new Error( 'test error' );
+};

 export default function CompositeCheckout( {
        siteSlug,
```

- Load composite checkout and verify that there is no fatal error and that the payment methods load correctly.

#### Screenshots:

Before (page freezes in loading state):

![Screen Shot 2020-07-03 at 5 12 16 PM](https://user-images.githubusercontent.com/2036909/86497622-63588380-bd50-11ea-906c-0669a5c5f1ba.png)


After (no fatal error):

![Screen Shot 2020-07-03 at 5 09 31 PM](https://user-images.githubusercontent.com/2036909/86497574-2c826d80-bd50-11ea-8abe-bdb5719f0fb3.png)
