### PR TITLE
Earn: Improve Wrapping of "New" Pill

### DIFF
--- a/client/components/promo-section/promo-card/style.scss
+++ b/client/components/promo-section/promo-card/style.scss
@@ -21,6 +21,11 @@
 		}
 	}
 
+	.action-panel__title {
+		display: flex;
+		justify-content: space-between;
+	}
+
 	.action-panel__body {
 		display: flex;
 		flex-direction: column;
@@ -93,8 +98,8 @@
 		}
 	}
 	.promo-card__title-badge {
-		margin-left: 48px;
 		background-color: var( --color-accent-60 );
 		color: var( --color-text-inverted );
+		margin: auto 0 auto 8px;
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Ensures the "New" pill isn't super distant from the text upon breaking to a new line

#### Testing instructions

Check the "New" pill on the Earn page and verify that it looks better in both English and other languages where the text is lengthier. (Screenshots below are in French) 

**Before:**

<img width="1113" alt="Screenshot 2020-07-04 at 10 54 41" src="https://user-images.githubusercontent.com/43215253/86510150-24284200-bde5-11ea-8f50-f6a6cb89128f.png">

**After:**

<img width="1102" alt="Screenshot 2020-07-04 at 10 54 50" src="https://user-images.githubusercontent.com/43215253/86510151-268a9c00-bde5-11ea-99c5-2987d174e304.png">

cc @sixhours 

Fixes #43158
