### PR TITLE
Reader Conversations: fix pointer state

### DIFF
--- a/client/blocks/conversations/list.scss
+++ b/client/blocks/conversations/list.scss
@@ -1,4 +1,6 @@
-
+.conversations__comment-list {
+	cursor: initial; // override style from .card.is-clickable
+}
 
 .conversations__comment-list-ul {
 	list-style-type: none;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In Reader Conversations, the entire comment is using the 'pointer' cursor, even for areas that are not clickable.

![2020-07-06 11-59-05 2020-07-06 11_59_32](https://user-images.githubusercontent.com/17325/86545082-3094d200-bf80-11ea-862c-dafea9cad2b6.gif)

This PR resets the cursor so only clickable areas of the comment should use 'pointer'.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Visit Reader Conversations at http://calypso.localhost:3000/read/conversations. If you can't see any posts there, try liking this post: https://jetpack.com/2019/04/02/jetpack-7-2/ and refresh Conversations after a few moments.

When hovering over the comment, you should have a normal cursor.

When hovering over linked areas, like the author name (where they have a website) or the comment date, you should see the pointer cursor.
