### PR TITLE
Add a convert to blocks button

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/editor.js
+++ b/apps/wpcom-block-editor/src/wpcom/editor.js
@@ -15,6 +15,7 @@ import './features/deprecate-coblocks-buttons';
 import './features/fix-block-invalidation-errors';
 import './features/reorder-block-categories';
 import './features/tracking';
+import './features/convert-to-blocks-button';
 
 import InserterMenuTrackingEvent from './features/tracking/wpcom-inserter-menu-search-term';
 

--- a/apps/wpcom-block-editor/src/wpcom/features/convert-to-blocks-button.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/convert-to-blocks-button.js
@@ -1,0 +1,83 @@
+/* eslint-disable import/no-extraneous-dependencies */
+
+/**
+ * External dependencies
+ */
+
+/**
+ * WordPress dependencies
+ */
+
+import { addFilter } from '@wordpress/hooks';
+import { Component } from '@wordpress/element';
+import { BlockControls } from '@wordpress/block-editor';
+import { Toolbar, ToolbarButton } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { compose } from '@wordpress/compose';
+import { withSelect, withDispatch } from '@wordpress/data';
+import { rawHandler, serialize } from '@wordpress/blocks';
+/* eslint-enable import/no-extraneous-dependencies */
+
+/**
+ * Internal dependencies
+ */
+
+export function withConvertToBlocksButton( ClassicEdit ) {
+	return class extends Component {
+		render() {
+			return (
+				<>
+					<BlockControls>
+						<Toolbar>
+							<ToolbarButton
+								title={ __( 'Convert to Blocks' ) }
+								onClick={ this.props.convertToBlocks }
+							>
+								{ __( 'Convert to Blocks' ) }
+							</ToolbarButton>
+						</Toolbar>
+					</BlockControls>
+					<ClassicEdit { ...this.props } />
+				</>
+			);
+		}
+	};
+}
+
+/**
+ * Intercepts the registration of the Core Classic block, and adds a 'Convert to Blocks' button
+ * to the toolbar.
+ *
+ * @param {object} blockSettings - The settings of the block being registered.
+ *
+ * @returns {object} The blockSettings, with our extra functionality inserted.
+ */
+const convertToBlocksButton = ( blockSettings ) => {
+	// Bail if this is not the core classic block, or if the hook has been triggered by a deprecation.
+	if ( 'core/freeform' !== blockSettings.name || blockSettings.isDeprecation ) {
+		return blockSettings;
+	}
+
+	const { edit } = blockSettings;
+
+	return {
+		...blockSettings,
+		edit: compose(
+			withSelect( ( select, { clientId } ) => {
+				const block = select( 'core/block-editor' ).getBlock( clientId );
+				return {
+					block,
+				};
+			} ),
+			withDispatch( ( dispatch, { block } ) => ( {
+				convertToBlocks: () =>
+					dispatch( 'core/block-editor' ).replaceBlocks(
+						block.clientId,
+						rawHandler( { HTML: serialize( block ) } )
+					),
+			} ) )
+		)( withConvertToBlocksButton( edit ) ),
+	};
+};
+
+addFilter( 'blocks.registerBlockType', 'a8c/add-convert-to-classic', convertToBlocksButton );

--- a/apps/wpcom-block-editor/src/wpcom/features/convert-to-blocks-button.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/convert-to-blocks-button.js
@@ -9,7 +9,6 @@
  */
 
 import { addFilter } from '@wordpress/hooks';
-import { Component } from '@wordpress/element';
 import { BlockControls } from '@wordpress/block-editor';
 import { Toolbar, ToolbarButton } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -23,17 +22,23 @@ import { rawHandler, serialize } from '@wordpress/blocks';
  */
 
 export function withConvertToBlocksButton( ClassicEdit ) {
-	return class extends Component {
+	return class extends ClassicEdit {
 		render() {
+			const defaultBlock = super.render();
+
+			if ( ! Array.isArray( defaultBlock ) ) {
+				return <ClassicEdit { ...this.props } />;
+			}
+
 			return (
 				<>
 					<BlockControls>
 						<Toolbar>
 							<ToolbarButton
-								title={ __( 'Convert to Blocks' ) }
+								title={ __( 'Convert to blocks' ) }
 								onClick={ this.props.convertToBlocks }
 							>
-								{ __( 'Convert to Blocks' ) }
+								{ __( 'Convert to blocks' ) }
 							</ToolbarButton>
 						</Toolbar>
 					</BlockControls>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a convert to blocks button to block toolbar in iframed editor as alternative to convert to blocks dialog

#### Testing instructions

- Check out this PR and build the wpcom block editor files with yarn build:prod in the apps/wpcom-block-editor/package.json folder.
- Sync the files created by the build in the '/dist' folder with your sandbox widgets/wpcom-block-editor folder
- Make sure that a 'Convert to blocks' button appears when adding/editing a Classic Block
- Sync a build of https://github.com/WordPress/gutenberg/pull/23704 to current gutenberg build folder on sandbox, then reload the editor and make sure only one 'Convert to blocks' button shows

Before:

<img width="562" alt="Screen Shot 2020-07-06 at 4 52 16 PM" src="https://user-images.githubusercontent.com/3629020/86557022-13282e00-bfa9-11ea-97dc-644a72ee3fa9.png">

After:

<img width="559" alt="Screen Shot 2020-07-06 at 4 47 34 PM" src="https://user-images.githubusercontent.com/3629020/86557031-16231e80-bfa9-11ea-93d5-240544571531.png">

Part of #43626
