### PR TITLE
Update FSE plugin to version 1.12.0

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Full Site Editing
  * Description: Enhances your page creation workflow within the Block Editor.
- * Version: 1.11
+ * Version: 1.12
  * Author: Automattic
  * Author URI: https://automattic.com/wordpress-plugins/
  * License: GPLv2 or later
@@ -35,7 +35,7 @@ namespace A8C\FSE;
  *
  * @var string
  */
-define( 'PLUGIN_VERSION', '1.11' );
+define( 'PLUGIN_VERSION', '1.12' );
 
 // Always include these helper files for dotcom FSE.
 require_once __DIR__ . '/dotcom-fse/helpers.php';

--- a/apps/full-site-editing/full-site-editing-plugin/readme.txt
+++ b/apps/full-site-editing/full-site-editing-plugin/readme.txt
@@ -3,7 +3,7 @@ Contributors: alexislloyd, allancole, automattic, bartkalisz, codebykat, copons,
 Tags: block, blocks, editor, gutenberg, page
 Requires at least: 5.0
 Tested up to: 5.4
-Stable tag: 1.11
+Stable tag: 1.12
 Requires PHP: 5.6.20
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -39,6 +39,11 @@ This plugin is experimental, so we don't provide any support for it outside of w
 
 
 == Changelog ==
+
+= 1.12 =
+* Experimental navigation sidebar in block editor, can be enabled in config or with a hook.
+* Default content included in the donation block can be edited.
+* Track when the launch button is clicked.
 
 = 1.11 =
 * Fix broken blocks in page layout picker preview in Firefox.

--- a/apps/full-site-editing/package.json
+++ b/apps/full-site-editing/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/full-site-editing",
-	"version": "1.11.0",
+	"version": "1.12.0",
 	"description": "Plugin for full site editing with the block editor.",
 	"sideEffects": true,
 	"repository": {


### PR DESCRIPTION
### Changes proposed in this Pull Request
* Version bump
* Changelog

I didn't mention the changes to plans grid or domain picker (which are under development) in the changelog.

### Testing instructions
* Apply D45968-code to your sandbox
* Check the donation block content is editable (#43834)
* Check the launch button records a track event (#43885)
* Add the `nav-sidebar-enabled` sticker to your test site (or define `WPCOM_BLOCK_EDITOR_SIDEBAR`) and check that clicking the (W) opens the nav sidebar

If approving this could you please also approve D45968-code :)