### PR TITLE
Inline Help: disable tabbing on search results and allow selected item to change style when hovered

### DIFF
--- a/client/blocks/inline-help/inline-help-compact-result.jsx
+++ b/client/blocks/inline-help/inline-help-compact-result.jsx
@@ -32,6 +32,7 @@ class InlineHelpCompactResult extends Component {
 					href={ helpLink.link }
 					title={ decodeEntities( helpLink.description ) }
 					onClick={ this.onClick }
+					tabIndex={ -1 }
 				>
 					{ preventWidows( decodeEntities( helpLink.title ) ) }
 				</a>

--- a/client/blocks/inline-help/inline-help-search-results.jsx
+++ b/client/blocks/inline-help/inline-help-search-results.jsx
@@ -50,6 +50,7 @@ function HelpSearchResults( {
 					href={ localizeUrl( link ) }
 					onClick={ selectResultHandler( index ) }
 					title={ decodeEntities( description ) }
+					tabIndex={ -1 }
 				>
 					{ preventWidows( decodeEntities( title ) ) }
 				</a>

--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -377,12 +377,18 @@
 		cursor: pointer;
 		color: var( --color-text-inverted );
 
+		&:hover,
+		&:focus {
+			background: none;
+
+			a {
+				color: var( --color-link-dark );
+			}
+
+		}
+
 		a {
 			color: var( --color-text-inverted );
-			&:hover,
-			&:focus {
-				background: none;
-			}
 		}
 	}
 

--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -384,7 +384,6 @@
 			a {
 				color: var( --color-link-dark );
 			}
-
 		}
 
 		a {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR aims to fix Inline Help issue https://github.com/Automattic/wp-calypso/issues/43616 by

* disabling tabbing on search results (arrow navigation instead)
* allowing the selected item to change style when hovered

Fixes https://github.com/Automattic/wp-calypso/issues/43616

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

For before state:
* Go to wordpress.com/home/{your-site}
* Locate `Get help` section
* Enter search input
* See how tabbing selects search results
* Enter search input again
* Use arrow down to select a search result
* Notice how hovering the selected result doesn't change the visual state

For after state:
* Repeat the steps above locally or on this PR's [calypso.live link](https://calypso.live/?branch=update/inline-help-disable-results-tabbing)
* Tabbing should skip search results
* Hovering a selected item, the visual state of said item should change

#### Screenshots

| Before  | After |
| ------------- | ------------- |
| ![ezgif com-video-to-gif (2)](https://user-images.githubusercontent.com/1562646/86589135-596f9400-bf8d-11ea-93af-4383890c65ad.gif) | ![ezgif com-video-to-gif (3)](https://user-images.githubusercontent.com/1562646/86589179-7906bc80-bf8d-11ea-936c-902b602a50f3.gif) |