### PR TITLE
Jetpack Search: add WP.com Search purchase Thank you note

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -96,11 +96,11 @@ export class CheckoutThankYouHeader extends PureComponent {
 				<div>
 					<p>{ translate( 'We are currently indexing your site.' ) }</p>
 					<p>
-						{ translate( 'In the meantime we have configured Jetpack Search on your site.' ) +
-							' ' +
-							translate(
-								'You should try customizing it in your traditional WordPress Dashboard.'
-							) }
+						{ translate(
+							'In the meantime, we have configured Jetpack Search on your site' +
+								' ' +
+								'— you should try customizing it in your traditional WordPress dashboard.'
+						) }
 					</p>
 				</div>
 			);

--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -93,12 +93,16 @@ export class CheckoutThankYouHeader extends PureComponent {
 
 		if ( purchases && purchases[ 0 ].productType === 'search' ) {
 			return (
-				translate( 'We are currently indexing your site.' ) +
-				'\n' +
-				translate(
-					'In the meantime we have configured Jetpack Search on your site.' +
-						'You should try customizing it i your traditional WordPress Dashboard.'
-				)
+				<div>
+					<p>{ translate( 'We are currently indexing your site.' ) }</p>
+					<p>
+						{ translate( 'In the meantime we have configured Jetpack Search on your site.' ) +
+							' ' +
+							translate(
+								'You should try customizing it in your traditional WordPress Dashboard.'
+							) }
+					</p>
+				</div>
 			);
 		}
 
@@ -425,7 +429,7 @@ export class CheckoutThankYouHeader extends PureComponent {
 			return (
 				<div className="checkout-thank-you__header-button">
 					<button className={ headerButtonClassName } onClick={ this.goToCustomizer }>
-						{ translate( 'Try Search and customize it now.' ) }
+						{ translate( 'Try Search and customize it now' ) }
 					</button>
 				</div>
 			);

--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -324,7 +324,12 @@ export class CheckoutThankYouHeader extends PureComponent {
 		event.preventDefault();
 		const { siteAdminUrl } = this.props;
 
-		//Maybe record tracks event
+		this.props.recordTracksEvent( 'calypso_jetpack_product_thankyou', {
+			product_name: 'search',
+			value: 'Customizer',
+			site: 'wpcom',
+		} );
+
 		window.location.href = siteAdminUrl + 'customize.php?autofocus[section]=jetpack_search';
 	};
 

--- a/client/my-sites/checkout/checkout-thank-you/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/style.scss
@@ -178,6 +178,7 @@
 .checkout-thank-you__success-message-item {
 	font-size: 18px;
 	font-weight: 400;
+	margin-top: 15px;
 }
 
 .checkout-thank-you__header.is-placeholder {

--- a/client/my-sites/plans/current-plan/current-plan-thank-you/thank-you.js
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you/thank-you.js
@@ -63,6 +63,7 @@ export class ThankYouCard extends Component {
 			this.props.recordTracksEvent( 'calypso_jetpack_product_thankyou', {
 				product_name: 'search',
 				value,
+				site: 'jetpack',
 			} );
 		};
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adding Search specific Thank you message and redirect the Customizer to setup/try the product
* Add tracking to[ match the Jetpack purchase](https://github.com/Automattic/wp-calypso/blob/2f841681ef171e14181efd14d4858be29d715564/client/my-sites/plans/current-plan/current-plan-thank-you/thank-you.js#L63), extending the latter with the site info.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Purchase Jetpack Search for a WP.com at `http://calypso.localhost:3000/checkout/:wpcomsite/jetpack_search_monthly`
- verify that the Thank you note is displayed with a relevant text
- verify the redirect to the Customizer

![ty](https://user-images.githubusercontent.com/13561163/86611544-17574a00-bfaf-11ea-91ca-2e3dae3e5c73.png)

Fixes https://github.com/Automattic/wp-calypso/issues/42285
