### PR TITLE
Simplify local state management in `<SiteSetupList>` component via useReducer

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
@@ -4,7 +4,7 @@
 import { Card, Button } from '@automattic/components';
 import { isDesktop, isWithinBreakpoint, subscribeIsWithinBreakpoint } from '@automattic/viewport';
 import { translate } from 'i18n-calypso';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useReducer } from 'react';
 import { connect, useDispatch } from 'react-redux';
 import page from 'page';
 import classnames from 'classnames';
@@ -94,6 +94,43 @@ const trackTaskDisplay = ( dispatch, task, siteId ) => {
 	);
 };
 
+const siteSetupListReducer = ( state, action ) => {
+	switch ( action.type ) {
+		case 'SET_CURRENT_TASK_ID':
+			return {
+				...state,
+				currentTaskId: action.currentTaskId,
+			};
+		case 'SET_CURRENT_TASK':
+			return {
+				...state,
+				currentTask: action.currentTask,
+			};
+		case 'SET_USER_SELECTED_TASK':
+			return {
+				...state,
+				userSelectedTask: action.userSelectedTask,
+			};
+		case 'SET_USE_DRILL_LAYOUT':
+			return {
+				...state,
+				useDrillLayout: action.useDrillLayout,
+			};
+		case 'SET_CURRENT_DRILL_LAYOUT_VIEW':
+			return {
+				...state,
+				currentDrillLayoutView: action.currentDrillLayoutView,
+			};
+		case 'SET_IS_LOADING':
+			return {
+				...state,
+				isLoading: action.isLoading,
+			};
+		default:
+			return state;
+	}
+};
+
 const SiteSetupList = ( {
 	emailVerificationStatus,
 	isEmailUnverified,
@@ -104,13 +141,65 @@ const SiteSetupList = ( {
 	taskUrls,
 	userEmail,
 } ) => {
-	const [ currentTaskId, setCurrentTaskId ] = useState( null );
-	const [ currentTask, setCurrentTask ] = useState( null );
-	const [ userSelectedTask, setUserSelectedTask ] = useState( false );
-	const [ useDrillLayout, setUseDrillLayout ] = useState( false );
-	const [ currentDrillLayoutView, setCurrentDrillLayoutView ] = useState( 'nav' );
-	const [ isLoading, setIsLoading ] = useState( false );
+	// Data layer dispatch
 	const dispatch = useDispatch();
+
+	// Local state reducer
+	const [ state, localDispatch ] = useReducer( siteSetupListReducer, {
+		currentTaskId: null, // id of the current task
+		currentTask: null, // full object for current task
+		userSelectedTask: false, // was the currently selected task selected by the user
+		useDrillLayout: false, // is using small-screen layout view
+		currentDrillLayoutView: 'nav', // viewing a card on the list of checklist steps?
+	} );
+
+	// Set currentTaskId
+	const currentTaskId = state.currentTaskId;
+	const setCurrentTaskId = ( id ) =>
+		localDispatch( {
+			type: 'SET_CURRENT_TASK_ID',
+			currentTaskId: id,
+		} );
+
+	// Set currentTask
+	const currentTask = state.currentTask;
+	const setCurrentTask = ( task ) =>
+		localDispatch( {
+			type: 'SET_CURRENT_TASK',
+			currentTask: task,
+		} );
+
+	// Set userSelectedTask
+	const userSelectedTask = state.currentTask;
+	const setUserSelectedTask = ( isUserSelectedTask ) =>
+		localDispatch( {
+			type: 'SET_USER_SELECTED_TASK',
+			userSelectedTask: isUserSelectedTask,
+		} );
+
+	// Set useDrillLayout
+	const useDrillLayout = state.useDrillLayout;
+	const setUseDrillLayout = ( shouldUseDrillLayout ) =>
+		localDispatch( {
+			type: 'SET_USE_DRILL_LAYOUT',
+			useDrillLayout: shouldUseDrillLayout,
+		} );
+
+	// Set currentDrillLayoutView
+	const currentDrillLayoutView = state.currentDrillLayoutView;
+	const setCurrentDrillLayoutView = ( drillLayoutView ) =>
+		localDispatch( {
+			type: 'SET_CURRENT_DRILL_LAYOUT_VIEW',
+			currentDrillLayoutView: drillLayoutView,
+		} );
+
+	// Set isLoading
+	const isLoading = state.isLoading;
+	const setIsLoading = ( currentlyLoading ) =>
+		localDispatch( {
+			type: 'SET_IS_LOADING',
+			isLoading: currentlyLoading,
+		} );
 
 	const isDomainUnverified =
 		tasks.filter( ( task ) => task.id === 'domain_verified' && ! task.isCompleted ).length > 0;

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
@@ -4,7 +4,7 @@
 import { Card, Button } from '@automattic/components';
 import { isDesktop, isWithinBreakpoint, subscribeIsWithinBreakpoint } from '@automattic/viewport';
 import { translate } from 'i18n-calypso';
-import React, { useEffect, useState, useReducer } from 'react';
+import React, { useEffect, useReducer } from 'react';
 import { connect, useDispatch } from 'react-redux';
 import page from 'page';
 import classnames from 'classnames';

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
@@ -299,21 +299,25 @@ const SiteSetupList = ( {
 			{ ( ! useDrillLayout || currentDrillLayoutView === 'nav' ) && (
 				<div className="site-setup-list__nav">
 					{ ! useDrillLayout && <CardHeading>{ translate( 'Site setup' ) }</CardHeading> }
-					{ tasks.map( ( task ) => (
-						<NavItem
-							key={ task.id }
-							taskId={ task.id }
-							text={ getTask( task ).title }
-							isCompleted={ task.isCompleted }
-							isCurrent={ task.id === currentTask.id }
-							onClick={ () => {
-								setUserSelectedTask( true );
-								setCurrentTaskId( task.id );
-								setCurrentDrillLayoutView( 'task' );
-							} }
-							showChevron={ useDrillLayout }
-						/>
-					) ) }
+					{ tasks.map( ( task ) => {
+						const taskTitle = getTask( task ).title;
+
+						return taskTitle ? (
+							<NavItem
+								key={ task.id }
+								taskId={ task.id }
+								text={ getTask( task ).title }
+								isCompleted={ task.isCompleted }
+								isCurrent={ task.id === currentTask.id }
+								onClick={ () => {
+									setUserSelectedTask( true );
+									setCurrentTaskId( task.id );
+									setCurrentDrillLayoutView( 'task' );
+								} }
+								showChevron={ useDrillLayout }
+							/>
+						) : null;
+					} ) }
 				</div>
 			) }
 			{ ( ! useDrillLayout || currentDrillLayoutView === 'task' ) && (


### PR DESCRIPTION
The `<SiteSetupList />` had 5 separate `useState` definitions. This was becoming difficult to reason about.

This PR refactors the local state to use a reducer pattern to make state updates simpler. This is done via the React `useReducer` hook.

#### Testing instructions

* Checkout this PR.
* Boot Calypso - yarn start. Wait for ages...
* Create a new site on WordPress.com via http://calypso.localhost:3000/.
* Once complete you should land on the "My Home" page.
* You should see the checklist.
* You should be able to manually navigate between checklist items by clicking on them.
* You should be able to complete the tasks associated with the checklist items and see that reflected in the UI state as ✅ .
* You should see an alternative layout on "small screens" which allows you to "drill" in and out of sections of the checklist rather.

This PR is a subset of changes required by https://github.com/Automattic/wp-calypso/pull/43861
