### PR TITLE
Update: Add google maps static URLs with the signature query parameter

### DIFF
--- a/client/lib/post-metadata/index.js
+++ b/client/lib/post-metadata/index.js
@@ -4,6 +4,12 @@
 
 import { find } from 'lodash';
 import { getThemeIdFromStylesheet } from 'state/themes/utils';
+import { stringify } from 'qs';
+
+/**
+ * Internal dependencies
+ */
+import config from 'config';
 
 /**
  * Module variables
@@ -145,6 +151,43 @@ const PostMetadata = {
 
 		if ( latitude && longitude ) {
 			return [ latitude, longitude ];
+		}
+	},
+
+	geoStaticMapUrl: function ( post ) {
+		if ( ! post ) {
+			return;
+		}
+
+		const coordinates = this.geoCoordinates( post );
+		if ( ! coordinates ) {
+			return;
+		}
+		const latitude = coordinates[ 0 ].toFixed( 6 );
+		const longitude = coordinates[ 1 ].toFixed( 6 );
+
+		if (
+			latitude === post?.geo?.latitude.toFixed( 6 ) &&
+			longitude === post?.geo?.longitude.toFixed( 6 )
+		) {
+			const staticImage = post?.geo?.map_url;
+			if ( staticImage ) {
+				return staticImage;
+			}
+		}
+
+		if ( latitude && longitude ) {
+			const GOOGLE_MAPS_BASE_URL = 'https://maps.google.com/maps/api/staticmap?';
+
+			return (
+				GOOGLE_MAPS_BASE_URL +
+				stringify( {
+					markers: coordinates.join( ',' ),
+					zoom: 8,
+					size: '400x300',
+					key: config( 'google_maps_and_places_api_key' ),
+				} )
+			);
 		}
 	},
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Google maps static image urls should be generated with the signature url part. 

Currently we generate the image using just the coordinates and the api key. By including the signature we are making it images not have a limit.

<img width="256" alt="Screen Shot 2020-07-06 at 4 29 38 PM" src="https://user-images.githubusercontent.com/115071/86604712-05bd7480-bfa6-11ea-8287-80d966c38ee9.png">


#### Testing instructions
1. Apply the following PR. D45918-code and sandbox the api. So that api request come from your sandbox.

* Go to the Classic Calypso editor add a location. Save the post
* Does location have a URL that has a signature in it? 
* Edit the location. Does it still work as expected. 

Note that in this PR we are not always make the URL have the signature since when the user sets the address we don't make a request to the api to be able to generate the proper URL. 


