### PR TITLE
Editor: Force Gutenberg For Users in the Deprecation Group

### DIFF
--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -27,6 +27,7 @@ import { requestSelectedEditor, setSelectedEditor } from 'state/selected-editor/
 import { getGutenbergEditorUrl } from 'state/selectors/get-gutenberg-editor-url';
 import { shouldLoadGutenberg } from 'state/selectors/should-load-gutenberg';
 import { shouldRedirectGutenberg } from 'state/selectors/should-redirect-gutenberg';
+import inEditorDeprecationGroup from 'state/editor-deprecation-group/selectors/in-editor-deprecation-group';
 
 function getPostID( context ) {
 	if ( ! context.params.post || 'new' === context.params.post ) {
@@ -195,7 +196,7 @@ async function redirectIfBlockEditor( context, next ) {
 	}
 
 	// If the new editor is classic, we bypass the selected editor check.
-	if ( 'classic' === newEditorChoice ) {
+	if ( ! inEditorDeprecationGroup( state ) && 'classic' === newEditorChoice ) {
 		return next();
 	}
 

--- a/client/state/selectors/should-load-gutenberg.js
+++ b/client/state/selectors/should-load-gutenberg.js
@@ -2,11 +2,12 @@
  * Internal dependencies
  */
 import { getSelectedEditor } from 'state/selectors/get-selected-editor';
+import inEditorDeprecationGroup from 'state/editor-deprecation-group/selectors/in-editor-deprecation-group';
 
 export const shouldLoadGutenberg = ( state, siteId ) => {
 	const validEditors = [ 'gutenberg-iframe', 'gutenberg-redirect', 'gutenberg-redirect-and-style' ];
 	const selectedEditor = getSelectedEditor( state, siteId );
-	return validEditors.indexOf( selectedEditor ) > -1;
+	return inEditorDeprecationGroup( state ) || validEditors.indexOf( selectedEditor ) > -1;
 };
 
 export default shouldLoadGutenberg;


### PR DESCRIPTION

#### Changes proposed in this Pull Request

This relates to #43803 part of the project to deprecate the Calypso editor.

If the `editor_deprecation_group` user attribute has been set for the
current user, then we should load Gutenberg as the editor regardless of
their editor preferences. This updates the `should-load-gutenberg`
selector to handle that.

#### Testing instructions

From Calypso, with a site that has the editor preference set to classic, set the `editor_deprecation_group` user attribute to `true` and then pick a post to edit and/or create a new post/page.

No matter how you try to get to the Calypso editor, you should always be redirected to Gutenberg.
