### PR TITLE
Revert "Jetpack Anti Spam: add Anti Spam"

### DIFF
--- a/client/lib/products-values/constants.js
+++ b/client/lib/products-values/constants.js
@@ -46,10 +46,6 @@ export const JETPACK_SEARCH_PRODUCTS = [
 export const isJetpackSearch = ( slug ) => JETPACK_SEARCH_PRODUCTS.includes( slug );
 
 export const JETPACK_SCAN_PRODUCTS = [ PRODUCT_JETPACK_SCAN, PRODUCT_JETPACK_SCAN_MONTHLY ];
-export const JETPACK_ANTI_SPAM_PRODUCTS = [
-	PRODUCT_JETPACK_ANTI_SPAM,
-	PRODUCT_JETPACK_ANTI_SPAM_MONTHLY,
-];
 
 export const JETPACK_ANTI_SPAM_PRODUCTS = [
 	PRODUCT_JETPACK_ANTI_SPAM,
@@ -59,7 +55,6 @@ export const JETPACK_ANTI_SPAM_PRODUCTS = [
 export const JETPACK_PRODUCTS_LIST = [
 	...JETPACK_BACKUP_PRODUCTS,
 	...( isEnabled( 'jetpack/scan-product' ) ? JETPACK_SCAN_PRODUCTS : [] ),
-	...( isEnabled( 'jetpack/anti-spam-product' ) ? JETPACK_ANTI_SPAM_PRODUCTS : [] ),
 	...( isEnabled( 'jetpack/search-product' ) ? JETPACK_SEARCH_PRODUCTS : [] ),
 ];
 
@@ -74,7 +69,6 @@ export const JETPACK_SEARCH_TIER_MORE_THAN_1M_RECORDS = 'more_than_1m_records';
 export const JETPACK_BACKUP_PRODUCT_LANDING_PAGE_URL = 'https://jetpack.com/upgrade/backup/';
 export const JETPACK_SEARCH_PRODUCT_LANDING_PAGE_URL = 'https://jetpack.com/upgrade/search/';
 export const JETPACK_SCAN_PRODUCT_LANDING_PAGE_URL = 'https://jetpack.com/upgrade/scan/';
-export const JETPACK_ANTI_SPAM_PRODUCT_LANDING_PAGE_URL = 'https://jetpack.com/upgrade/anti-spam/';
 
 export const JETPACK_PRODUCT_PRICE_MATRIX = {
 	[ PRODUCT_JETPACK_BACKUP_DAILY ]: {
@@ -93,10 +87,6 @@ export const JETPACK_PRODUCT_PRICE_MATRIX = {
 		relatedProduct: PRODUCT_JETPACK_SCAN_MONTHLY,
 		ratio: 12,
 	},
-	[ PRODUCT_JETPACK_ANTI_SPAM ]: {
-		relatedProduct: PRODUCT_JETPACK_ANTI_SPAM_MONTHLY,
-		ratio: 12,
-	},
 };
 
 // Translatable strings
@@ -110,8 +100,6 @@ export const getJetpackProductsShortNames = () => {
 		[ PRODUCT_JETPACK_SEARCH_MONTHLY ]: translate( 'Search' ),
 		[ PRODUCT_JETPACK_SCAN ]: translate( 'Daily Scan' ),
 		[ PRODUCT_JETPACK_SCAN_MONTHLY ]: translate( 'Daily Scan' ),
-		[ PRODUCT_JETPACK_ANTI_SPAM ]: translate( 'Anti-Spam' ),
-		[ PRODUCT_JETPACK_ANTI_SPAM_MONTHLY ]: translate( 'Anti-Spam' ),
 	};
 };
 
@@ -145,8 +133,6 @@ export const getJetpackProductsDisplayNames = () => {
 			} ) }{ ' ' }
 		</>
 	);
-
-	const antiSpam = <>{ translate( 'Jetpack Anti-Spam' ) }</>;
 	return {
 		[ PRODUCT_JETPACK_BACKUP_DAILY ]: backupDaily,
 		[ PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY ]: backupDaily,
@@ -158,14 +144,11 @@ export const getJetpackProductsDisplayNames = () => {
 		[ PRODUCT_WPCOM_SEARCH_MONTHLY ]: search,
 		[ PRODUCT_JETPACK_SCAN ]: scanDaily,
 		[ PRODUCT_JETPACK_SCAN_MONTHLY ]: scanDaily,
-		[ PRODUCT_JETPACK_ANTI_SPAM ]: antiSpam,
-		[ PRODUCT_JETPACK_ANTI_SPAM_MONTHLY ]: antiSpam,
 	};
 };
 export const getJetpackProductsTaglines = () => {
 	const searchTagline = translate( 'Search your site.' );
-	const scanTagline = translate( 'Scan your site.' );
-	const antiSpamTagline = translate( 'Automatically clear spam from comments and forms.' );
+	const scanTagline = 'Scan your site.';
 	return {
 		[ PRODUCT_JETPACK_BACKUP_DAILY ]: translate(
 			'Your data is being securely backed up every day with a 30-day archive.'
@@ -185,8 +168,6 @@ export const getJetpackProductsTaglines = () => {
 		[ PRODUCT_WPCOM_SEARCH_MONTHLY ]: searchTagline,
 		[ PRODUCT_JETPACK_SCAN ]: scanTagline,
 		[ PRODUCT_JETPACK_SCAN_MONTHLY ]: scanTagline,
-		[ PRODUCT_JETPACK_ANTI_SPAM ]: antiSpamTagline,
-		[ PRODUCT_JETPACK_ANTI_SPAM_MONTHLY ]: antiSpamTagline,
 	};
 };
 
@@ -196,9 +177,6 @@ export const getJetpackProductsDescriptions = () => {
 	);
 	const scanDescription = translate(
 		'Automatic scanning and one-click fixes keep your site one step ahead of security threats.'
-	);
-	const antiSpamDescription = translate(
-		'Automatically clear spam from comments and forms. Save time, get more responses, give your visitors a better experience – all without lifting a finger.'
 	);
 	return {
 		[ PRODUCT_JETPACK_BACKUP_DAILY ]: translate(
@@ -217,8 +195,6 @@ export const getJetpackProductsDescriptions = () => {
 		[ PRODUCT_JETPACK_SEARCH_MONTHLY ]: searchDescription,
 		[ PRODUCT_JETPACK_SCAN ]: scanDescription,
 		[ PRODUCT_JETPACK_SCAN_MONTHLY ]: scanDescription,
-		[ PRODUCT_JETPACK_ANTI_SPAM ]: antiSpamDescription,
-		[ PRODUCT_JETPACK_ANTI_SPAM_MONTHLY ]: antiSpamDescription,
 	};
 };
 
@@ -276,33 +252,6 @@ export const getJetpackProducts = () => {
 			optionDescriptions: getJetpackProductsDescriptions(),
 			optionsLabel: translate( 'Select a product option:' ),
 			slugs: JETPACK_SCAN_PRODUCTS,
-		} );
-	isEnabled( 'jetpack/anti-spam-product' ) &&
-		output.push( {
-			title: translate( 'Jetpack Anti-Spam' ),
-			description: getJetpackProductsDescriptions()[ PRODUCT_JETPACK_ANTI_SPAM ],
-			// There is only one option per billing interval, but this
-			// component still needs the full display with radio buttons.
-			forceRadios: true,
-			hasPromo: false,
-			id: PRODUCT_JETPACK_ANTI_SPAM,
-			link: {
-				label: translate( 'Learn more' ),
-				props: {
-					location: 'product_jetpack_anti_spam_description',
-					slug: 'learn-more-anti-spam',
-				},
-				url: JETPACK_ANTI_SPAM_PRODUCT_LANDING_PAGE_URL,
-			},
-			options: {
-				yearly: [ PRODUCT_JETPACK_ANTI_SPAM ],
-				monthly: [ PRODUCT_JETPACK_ANTI_SPAM_MONTHLY ],
-			},
-			optionShortNames: getJetpackProductsShortNames(),
-			optionDisplayNames: getJetpackProductsDisplayNames(),
-			optionDescriptions: getJetpackProductsDescriptions(),
-			optionsLabel: translate( 'Select a product option:' ),
-			slugs: JETPACK_ANTI_SPAM_PRODUCTS,
 		} );
 	isEnabled( 'jetpack/search-product' ) &&
 		output.push( {

--- a/config/development.json
+++ b/config/development.json
@@ -89,7 +89,6 @@
 		"jetpack/features-section/atomic": true,
 		"jetpack/features-section/jetpack": true,
 		"jetpack/scan-product": true,
-		"jetpack/anti-spam-product": true,
 		"jetpack/backups-restore": true,
 		"jetpack/on-demand-scan": true,
 		"jitms": true,


### PR DESCRIPTION
Reverts Automattic/wp-calypso#43880

^ This PR introduced by mistake a constant that was already present in a file:

```
ERROR in ./client/lib/products-values/constants.js
/Users/nathan/code/local-a8c/wp-calypso/client/lib/products-values/constants.js: Identifier 'JETPACK_ANTI_SPAM_PRODUCTS' has already been declared (54:13)
> 54 | export const JETPACK_ANTI_SPAM_PRODUCTS = [
```