### PR TITLE
Checkout: update mobile submit button

### DIFF
--- a/client/my-sites/checkout/checkout/checkout-terms.jsx
+++ b/client/my-sites/checkout/checkout/checkout-terms.jsx
@@ -20,7 +20,7 @@ class CheckoutTerms extends React.Component {
 		const { cart } = this.props;
 		return (
 			<Fragment>
-				<div className="checkout__terms">
+				<div className="checkout__terms" id="checkout-terms">
 					<strong>
 						{ this.props.translate( 'By checking out:', {
 							comment:

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -531,8 +531,17 @@ function SubmitButtonHeader() {
 }
 
 const SubmitButtonHeaderUI = styled.div`
+	display: none;
 	font-size: 13px;
 	margin-top: -5px;
 	margin-bottom: 10px;
 	text-align: center;
+
+	.is-last-step-active & {
+		display: block;
+
+		@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
+			display: none;
+		}
+	}
 `;

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -537,7 +537,7 @@ const SubmitButtonHeaderUI = styled.div`
 	margin-bottom: 10px;
 	text-align: center;
 
-	.is-last-step-active & {
+	.checkout__step-wrapper--last-step & {
 		display: block;
 
 		@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -231,7 +231,7 @@ export default function WPCheckout( {
 					<SecondaryCartPromotions responseCart={ responseCart } addItemToCart={ addItemToCart } />
 				</CheckoutSummaryBody>
 			</CheckoutSummaryArea>
-			<CheckoutStepArea>
+			<CheckoutStepArea submitButtonHeader={ <SubmitButtonHeader /> }>
 				<CheckoutStepBody
 					onError={ onReviewError }
 					className="wp-checkout__review-order-step"
@@ -516,3 +516,23 @@ function useUpdateCartLocationWhenPaymentMethodChanges(
 		}
 	}, [ activePaymentMethod, updateCartContactDetails ] );
 }
+
+function SubmitButtonHeader() {
+	const translate = useTranslate();
+	return (
+		<SubmitButtonHeaderUI>
+			{ translate( 'By checking out you agree to our {{a}}Terms of Service{{/a}}', {
+				components: {
+					a: <a href="#checkout-terms" />,
+				},
+			} ) }
+		</SubmitButtonHeaderUI>
+	);
+}
+
+const SubmitButtonHeaderUI = styled.div`
+	font-size: 13px;
+	margin-top: -5px;
+	margin-bottom: 10px;
+	text-align: center;
+`;

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -521,7 +521,7 @@ function SubmitButtonHeader() {
 	const translate = useTranslate();
 	return (
 		<SubmitButtonHeaderUI>
-			{ translate( 'By checking out you agree to our {{a}}Terms of Service{{/a}}', {
+			{ translate( 'By continuing, you agree to our {{a}}Terms of Service{{/a}}.', {
 				components: {
 					a: <a href="#checkout-terms" />,
 				},

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -519,11 +519,14 @@ function useUpdateCartLocationWhenPaymentMethodChanges(
 
 function SubmitButtonHeader() {
 	const translate = useTranslate();
+
+	const scrollToTOS = () => document.getElementById( 'checkout-terms' ).scrollIntoView();
+
 	return (
 		<SubmitButtonHeaderUI>
-			{ translate( 'By continuing, you agree to our {{a}}Terms of Service{{/a}}.', {
+			{ translate( 'By continuing, you agree to our {{button}}Terms of Service{{/button}}.', {
 				components: {
-					a: <a href="#checkout-terms" />,
+					button: <button onClick={ scrollToTOS } />,
 				},
 			} ) }
 		</SubmitButtonHeaderUI>
@@ -542,6 +545,18 @@ const SubmitButtonHeaderUI = styled.div`
 
 		@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
 			display: none;
+		}
+	}
+
+	button {
+		color: ${ ( props ) => props.theme.colors.highlight };
+		display: inline;
+		font-size: 13px;
+		text-decoration: underline;
+		width: auto;
+
+		&:hover {
+			color: ${ ( props ) => props.theme.colors.highlightOver };
 		}
 	}
 `;

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
@@ -349,6 +349,7 @@ const WPOrderReviewList = styled.ul`
 	border-top: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
 	box-sizing: border-box;
 	margin: 20px 30px 20px 0;
+	padding: 0;
 
 	.rtl & {
 		margin: 20px 0 20px 30px;

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -203,13 +203,19 @@ This component's props are:
 - `validatingButtonText?: string`. Used in place of "Please wait…" on the next step button when `isCompleteCallback` returns an unresolved Promise.
 - `validatingButtonAriaLabel:? string`. Used for the `aria-label` attribute on the next step button when `isCompleteCallback` returns an unresolved Promise.
 
-## CheckoutArea
+## CheckoutStepArea
 
 Creates the Checkout form and provides a wrapper for [CheckoutStep](#CheckoutStep) and [CheckoutStepBody](#CheckoutStepBody) objects. Should be a direct child of [Checkout](#Checkout).
+
+This component's props are:
+
+- `submitButtonHeader: React.ReactNode`. Displays with the Checkout submit button.
 
 ## CheckoutStepBody
 
 A component that looks like a checkout step. Normally you don't need to use this directly, since [CheckoutStep](#CheckoutStep) creates this for you, but you can use it manually if you wish.
+
+This component's props are:
 
 - `stepId: string`. A unique ID for this step.
 - `isStepActive: boolean`. True if the step should be rendered as active. Renders `activeStepContent`.

--- a/packages/composite-checkout/src/components/checkout-steps.js
+++ b/packages/composite-checkout/src/components/checkout-steps.js
@@ -150,7 +150,7 @@ export const CheckoutSummaryCard = styled.div`
 	}
 `;
 
-export function CheckoutStepArea( { children, className } ) {
+export function CheckoutStepArea( { children, className, submitButtonHeader } ) {
 	const { __ } = useI18n();
 	const onEvent = useEvents();
 	const { formStatus } = useFormStatus();
@@ -165,10 +165,14 @@ export function CheckoutStepArea( { children, className } ) {
 	);
 
 	return (
-		<CheckoutStepAreaUI className={ joinClasses( [ className, 'checkout__step-wrapper' ] ) }>
+		<CheckoutStepAreaUI
+			className={ joinClasses( [ className, 'checkout__step-wrapper' ] ) }
+			isLastStepActive={ ! isThereAnotherNumberedStep }
+		>
 			{ children }
 
 			<SubmitButtonWrapperUI isLastStepActive={ ! isThereAnotherNumberedStep }>
+				{ submitButtonHeader ? submitButtonHeader : null }
 				<CheckoutErrorBoundary
 					errorMessage={ __( 'There was a problem with the submit button.' ) }
 					onError={ onSubmitButtonLoadError }
@@ -179,6 +183,10 @@ export function CheckoutStepArea( { children, className } ) {
 		</CheckoutStepAreaUI>
 	);
 }
+
+CheckoutStep.propTypes = {
+	submitButtonHeader: PropTypes.node,
+};
 
 export function CheckoutSteps( { children, areStepsActive = true } ) {
 	let stepNumber = 0;
@@ -799,7 +807,7 @@ function getStepNumberFromUrl() {
 		const stepNumber = parts.length > 1 ? parts[ 1 ] : 1;
 		return parseInt( stepNumber, 10 );
 	}
-	return 1;
+	return null;
 }
 
 function useChangeStepNumberForUrl( setActiveStepNumber ) {
@@ -816,7 +824,7 @@ function useChangeStepNumberForUrl( setActiveStepNumber ) {
 		window.addEventListener?.( 'hashchange', () => {
 			const newStepNumber = getStepNumberFromUrl();
 			debug( 'step number in url changed to', newStepNumber );
-			isSubscribed && setActiveStepNumber( newStepNumber );
+			newStepNumber && isSubscribed && setActiveStepNumber( newStepNumber );
 		} );
 		return () => ( isSubscribed = false );
 	}, [ setActiveStepNumber ] );

--- a/packages/composite-checkout/src/components/checkout-steps.js
+++ b/packages/composite-checkout/src/components/checkout-steps.js
@@ -543,7 +543,7 @@ const SubmitButtonWrapperUI = styled.div`
 			position: relative;
 			border: 0;
 
-			button {
+			.checkout-button {
 				width: 100%;
 			}
 		}

--- a/packages/composite-checkout/src/components/checkout-steps.js
+++ b/packages/composite-checkout/src/components/checkout-steps.js
@@ -164,7 +164,7 @@ export function CheckoutStepArea( { children, className, submitButtonHeader } ) 
 	const classNames = joinClasses( [
 		'checkout__step-wrapper',
 		...( className ? [ className ] : [] ),
-		...( ! isThereAnotherNumberedStep ? [ 'is-last-step-active' ] : [] ),
+		...( ! isThereAnotherNumberedStep ? [ 'checkout__step-wrapper--last-step' ] : [] ),
 	] );
 
 	return (
@@ -489,7 +489,7 @@ const CheckoutStepAreaUI = styled.div`
 	margin: 0 auto;
 	width: 100%;
 
-	&.is-last-step-active {
+	&.checkout__step-wrapper--last-step {
 		margin-bottom: 100px;
 	}
 
@@ -520,7 +520,7 @@ const SubmitButtonWrapperUI = styled.div`
 	border-top-style: solid;
 	border-top-color: ${ ( props ) => props.theme.colors.borderColorLight };
 
-	.is-last-step-active & {
+	.checkout__step-wrapper--last-step & {
 		border-top-width: 1px;
 		position: fixed;
 	}
@@ -533,13 +533,13 @@ const SubmitButtonWrapperUI = styled.div`
 	button {
 		width: 100%;
 
-		.is-last-step-active & {
+		.checkout__step-wrapper--last-step & {
 			width: calc( 100% - 60px );
 		}
 	}
 
 	@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
-		.is-last-step-active & {
+		.checkout__step-wrapper--last-step & {
 			position: relative;
 			border: 0;
 

--- a/packages/composite-checkout/src/components/checkout-steps.js
+++ b/packages/composite-checkout/src/components/checkout-steps.js
@@ -530,7 +530,7 @@ const SubmitButtonWrapperUI = styled.div`
 		left: auto;
 	}
 
-	button {
+	.checkout-button {
 		width: 100%;
 
 		.checkout__step-wrapper--last-step & {
@@ -821,7 +821,7 @@ function getStepNumberFromUrl() {
 		const stepNumber = parts.length > 1 ? parts[ 1 ] : 1;
 		return parseInt( stepNumber, 10 );
 	}
-	return null;
+	return 1;
 }
 
 function useChangeStepNumberForUrl( setActiveStepNumber ) {
@@ -838,7 +838,7 @@ function useChangeStepNumberForUrl( setActiveStepNumber ) {
 		window.addEventListener?.( 'hashchange', () => {
 			const newStepNumber = getStepNumberFromUrl();
 			debug( 'step number in url changed to', newStepNumber );
-			newStepNumber && isSubscribed && setActiveStepNumber( newStepNumber );
+			isSubscribed && setActiveStepNumber( newStepNumber );
 		} );
 		return () => ( isSubscribed = false );
 	}, [ setActiveStepNumber ] );

--- a/packages/composite-checkout/src/components/checkout-steps.js
+++ b/packages/composite-checkout/src/components/checkout-steps.js
@@ -55,10 +55,7 @@ export function Checkout( { children, className } ) {
 	if ( formStatus === 'loading' ) {
 		return (
 			<ContainerUI className={ classNames }>
-				<MainContentUI
-					className={ joinClasses( [ className, 'checkout__content' ] ) }
-					isLastStepActive={ false }
-				>
+				<MainContentUI className={ joinClasses( [ className, 'checkout__content' ] ) }>
 					<LoadingContent />
 				</MainContentUI>
 			</ContainerUI>
@@ -164,14 +161,17 @@ export function CheckoutStepArea( { children, className, submitButtonHeader } ) 
 		[ onEvent ]
 	);
 
+	const classNames = joinClasses( [
+		'checkout__step-wrapper',
+		...( className ? [ className ] : [] ),
+		...( ! isThereAnotherNumberedStep ? [ 'is-last-step-active' ] : [] ),
+	] );
+
 	return (
-		<CheckoutStepAreaUI
-			className={ joinClasses( [ className, 'checkout__step-wrapper' ] ) }
-			isLastStepActive={ ! isThereAnotherNumberedStep }
-		>
+		<CheckoutStepAreaUI className={ classNames }>
 			{ children }
 
-			<SubmitButtonWrapperUI isLastStepActive={ ! isThereAnotherNumberedStep }>
+			<SubmitButtonWrapperUI>
 				{ submitButtonHeader ? submitButtonHeader : null }
 				<CheckoutErrorBoundary
 					errorMessage={ __( 'There was a problem with the submit button.' ) }
@@ -486,8 +486,12 @@ const CheckoutSummaryUI = styled.div`
 const CheckoutStepAreaUI = styled.div`
 	background: ${ ( props ) => props.theme.colors.surface };
 	box-sizing: border-box;
-	margin: 0 auto ${ ( props ) => ( props.isLastStepActive ? '100px' : 0 ) };
+	margin: 0 auto;
 	width: 100%;
+
+	&.is-last-step-active {
+		margin-bottom: 100px;
+	}
 
 	@media ( ${ ( props ) => props.theme.breakpoints.smallPhoneUp } ) {
 		border: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
@@ -507,18 +511,18 @@ const CheckoutStepAreaUI = styled.div`
 const SubmitButtonWrapperUI = styled.div`
 	background: ${ ( props ) => props.theme.colors.background };
 	padding: 24px;
-	position: ${ ( props ) => ( props.isLastStepActive ? 'fixed' : 'relative' ) };
 	bottom: 0;
 	left: 0;
 	box-sizing: border-box;
 	width: 100%;
 	z-index: 10;
-	border-top-width: ${ ( props ) => ( props.isLastStepActive ? '1px' : '0' ) };
+	border-top-width: 0;
 	border-top-style: solid;
 	border-top-color: ${ ( props ) => props.theme.colors.borderColorLight };
 
-	button {
-		width: ${ ( props ) => ( props.isLastStepActive ? 'calc( 100% - 60px )' : '100%' ) };
+	.is-last-step-active & {
+		border-top-width: 1px;
+		position: fixed;
 	}
 
 	.rtl & {
@@ -526,12 +530,22 @@ const SubmitButtonWrapperUI = styled.div`
 		left: auto;
 	}
 
-	@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
-		position: relative;
-		border: 0;
+	button {
+		width: 100%;
 
-		button {
-			width: 100%;
+		.is-last-step-active & {
+			width: calc( 100% - 60px );
+		}
+	}
+
+	@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
+		.is-last-step-active & {
+			position: relative;
+			border: 0;
+
+			button {
+				width: 100%;
+			}
 		}
 	}
 `;

--- a/packages/composite-checkout/src/components/loading-content.js
+++ b/packages/composite-checkout/src/components/loading-content.js
@@ -36,7 +36,7 @@ const LoadingContentWrapperUI = styled.div`
 	background: ${ ( props ) => props.theme.colors.surface };
 	width: 100%;
 	box-sizing: border-box;
-	margin-bottom: ${ ( props ) => ( props.isLastStepActive ? '100px' : 0 ) };
+	margin-bottom: 0;
 
 	@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
 		border: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };

--- a/packages/composite-checkout/src/components/payment-request-button.js
+++ b/packages/composite-checkout/src/components/payment-request-button.js
@@ -70,6 +70,7 @@ const ApplePayButton = styled.button`
 	-webkit-appearance: -apple-pay-button;
 	-apple-pay-button-style: black;
 	-apple-pay-button-type: plain;
+	height: 38px;
 	width: 100%;
 	position: relative;
 


### PR DESCRIPTION
This adds a relative link to the Terms of Service when the submit button is active and `position: fixed`. It also cleans up two small visual bugs where the fixed submit button overlaps the "total" in the final step, and the ApplePay button wasn't the correct height.

Fixes #43954 

Before | After
------------ | -------------
<img width="338" alt="before" src="https://user-images.githubusercontent.com/942359/86919071-a2425c80-c0f5-11ea-90fe-2b3a5b7e9290.png"> | <img width="336" alt="after" src="https://user-images.githubusercontent.com/942359/86919087-a8383d80-c0f5-11ea-9d0b-5cb918d8b74a.png">

**To Test:**
- visit Checkout (`?flags=composite-checkout-force`) on a mobile device (or using the web inspector)
- complete the billing/contact information step if it's not already complete
- when the payment method step is active, the submit button should become `position: fixed`
- verify that the fixed submit button has a link to the Terms of Service
- click the link and verify that the Terms of Service are visible