### PR TITLE
Earn: flip rename-payment-blocks feature flag to true for all envs

### DIFF
--- a/config/desktop.json
+++ b/config/desktop.json
@@ -29,7 +29,7 @@
 		"domains/gdpr-consent-page": true,
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/pagination": true,
-		"earn/rename-payment-blocks": false,
+		"earn/rename-payment-blocks": true,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -36,7 +36,7 @@
 		"domains/new-status-design/auto-renew": true,
 		"domains/new-status-design/new-options": true,
 		"domains/new-status-design/security-option": true,
-		"earn/rename-payment-blocks": false,
+		"earn/rename-payment-blocks": true,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,

--- a/config/production.json
+++ b/config/production.json
@@ -35,7 +35,7 @@
 		"domains/new-status-design/auto-renew": true,
 		"domains/new-status-design/new-options": true,
 		"domains/new-status-design/security-option": true,
-		"earn/rename-payment-blocks": false,
+		"earn/rename-payment-blocks": true,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -38,7 +38,7 @@
 		"domains/new-status-design/auto-renew": true,
 		"domains/new-status-design/new-options": true,
 		"domains/new-status-design/security-option": true,
-		"earn/rename-payment-blocks": false,
+		"earn/rename-payment-blocks": true,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,

--- a/config/test.json
+++ b/config/test.json
@@ -36,7 +36,7 @@
 		"desktop-promo": true,
 		"devdocs": true,
 		"devdocs/redirect-loggedout-homepage": true,
-		"earn/rename-payment-blocks": false,
+		"earn/rename-payment-blocks": true,
 		"gdpr-banner": false,
 		"google-my-business": false,
 		"help": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -43,7 +43,7 @@
 		"domains/new-status-design/auto-renew": true,
 		"domains/new-status-design/new-options": true,
 		"domains/new-status-design/security-option": true,
-		"earn/rename-payment-blocks": false,
+		"earn/rename-payment-blocks": true,
 		"email-accounts/enabled": true,
 		"external-media": true,
 		"external-media/google-photos": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR flips the `rename-payment-blocks` feature flag to true so that the feature will be enabled across all environments, not just dev.
* See the following issues for context:
    * https://github.com/Automattic/wp-calypso/issues/42862
    * https://github.com/Automattic/wp-calypso/issues/42861

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Verify code changes to enable flag in all environments.
