### PR TITLE
Remove jetpack menu for p2 sites

### DIFF
--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -401,6 +401,10 @@ export class MySitesSidebar extends Component {
 	jetpack() {
 		const { isJetpackSectionOpen, path } = this.props;
 
+		if ( isEnabled( 'signup/wpforteams' ) && this.props.isSiteWPForTeams ) {
+			return null;
+		}
+
 		return (
 			<ExpandableSidebarMenu
 				expanded={ isJetpackSectionOpen }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Remove Jetpack menu section for new P2 sites.

#### Testing instructions
- Make sure you have a p2 site selected in My Sites
- Jetpack menu item should not be visible
