### PR TITLE
Allow checklist to have different text for Nav Items and the task "card" 

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
@@ -88,7 +88,8 @@ export const getTask = (
 		case SITE_CHECKLIST_KNOWN_TASKS.START_SITE_SETUP:
 			taskData = {
 				timing: 1,
-				title: translate( 'Site created' ),
+				label: translate( 'Site created' ),
+				title: translate( 'Your site has been created!' ),
 				description: translate(
 					"Next, we'll guide you through setting up and launching your site."
 				),

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
@@ -231,11 +231,14 @@ const SiteSetupList = ( {
 			{ ( ! useDrillLayout || currentDrillLayoutView === 'nav' ) && (
 				<div className="site-setup-list__nav">
 					{ ! useDrillLayout && <CardHeading>{ translate( 'Site setup' ) }</CardHeading> }
-					{ tasks.map( ( task ) => (
+					{ tasks.map( ( task ) => {
+						const enhancedTask = getTask( task );
+
+						return (
 						<NavItem
 							key={ task.id }
 							taskId={ task.id }
-							text={ getTask( task ).title }
+							text={ enhancedTask.label || enhancedTask.title }
 							isCompleted={ task.isCompleted }
 							isCurrent={ task.id === currentTask.id }
 							onClick={ () => {
@@ -246,6 +249,7 @@ const SiteSetupList = ( {
 							showChevron={ useDrillLayout }
 						/>
 					) ) }
+					} ) }
 				</div>
 			) }
 			{ ( ! useDrillLayout || currentDrillLayoutView === 'task' ) && (

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
@@ -235,20 +235,20 @@ const SiteSetupList = ( {
 						const enhancedTask = getTask( task );
 
 						return (
-						<NavItem
-							key={ task.id }
-							taskId={ task.id }
-							text={ enhancedTask.label || enhancedTask.title }
-							isCompleted={ task.isCompleted }
-							isCurrent={ task.id === currentTask.id }
-							onClick={ () => {
-								setTaskIsManuallySelected( true );
-								setCurrentTaskId( task.id );
-								setCurrentDrillLayoutView( 'task' );
-							} }
-							showChevron={ useDrillLayout }
-						/>
-					) ) }
+							<NavItem
+								key={ task.id }
+								taskId={ task.id }
+								text={ enhancedTask.label || enhancedTask.title }
+								isCompleted={ task.isCompleted }
+								isCurrent={ task.id === currentTask.id }
+								onClick={ () => {
+									setTaskIsManuallySelected( true );
+									setCurrentTaskId( task.id );
+									setCurrentDrillLayoutView( 'task' );
+								} }
+								showChevron={ useDrillLayout }
+							/>
+						);
 					} ) }
 				</div>
 			) }


### PR DESCRIPTION
Affords ability to have custom text for checklist Nav items that differs from the `title` shown in the checklist card content.

This is part of a solution to realise the design shown in https://github.com/Automattic/wp-calypso/pull/43861#issuecomment-653317424 whereby the checklist "Nav" item for "Site Creation" has _different_ text to the title text "Your site has been created!" shown in the main task card body.

#### Changes proposed in this Pull Request

* Adds an optional `label` prop to all enhanced `task` objects.
* Updates `<SiteSetupList />` to prefer using the `label` text for Nav items if it is provided. 
* Continue to fallback to original `title` prop to ensure backwards compability.

#### Testing instructions

* Checkout this PR.
* Build Calypso `yarn && yarn start` - wait...
* Apply the following patch to your local environment by saving it as a file (eg: `get-text.patch`) and then [applying it using git](https://stackoverflow.com/questions/28192623/create-patch-or-diff-file-from-git-repository-and-apply-it-to-another-different) (ie: `git apply get-text.patch` - note this assumes your patch is in the same directory as your git repo)

```diff
diff --git a/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js b/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
index e3f4b1c635..6337a2997b 100644
--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
@@ -116,7 +116,8 @@ export const getTask = (
 		case 'blogname_set':
 			taskData = {
 				timing: 1,
-				title: translate( 'Name your site' ),
+				title: translate( 'A slightly longer version of Name your site' ),
+				label: translate( 'Name your site' ),
 				description: translate(
 					'Give your new site a title to let people know what your site is about. A good title introduces your brand and the primary topics of your site.'
 				),

```
* Create a new site on WordPress.com via `http://calypso.localhost:3000/`.
* Once complete you should land on the "My Home" page and see the checklist.
* The checklist item for `Name your site` should look like the screenshot below, with the Nav item title being different from the title shown in the task card body.

![Screen Shot 2020-07-07 at 09 18 23](https://user-images.githubusercontent.com/444434/86746243-d43eba80-c032-11ea-8988-eb7291e1b7fe.png)

