### PR TITLE
FSE: When switching to an auto loading homepage theme, ensure Edit Homepage link opens up the page layout picker in Atomic / Jetpack sites

### DIFF
--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -32,6 +32,7 @@ import { requestSite } from 'state/sites/actions';
 import getCustomizeOrEditFrontPageUrl from 'state/selectors/get-customize-or-edit-front-page-url';
 import shouldCustomizeHomepageWithGutenberg from 'state/selectors/should-customize-homepage-with-gutenberg';
 import getSiteUrl from 'state/selectors/get-site-url';
+import { addQueryArgs } from 'lib/route';
 
 /**
  * Style dependencies
@@ -299,7 +300,10 @@ export default connect(
 			currentTheme,
 			shouldEditHomepageWithGutenberg,
 			detailsUrl: getThemeDetailsUrl( state, currentThemeId, siteId ),
-			customizeUrl: getCustomizeOrEditFrontPageUrl( state, currentThemeId, siteId ),
+			customizeUrl: addQueryArgs(
+				{ 'new-homepage': true },
+				getCustomizeOrEditFrontPageUrl( state, currentThemeId, siteId )
+			),
 			forumUrl: getThemeForumUrl( state, currentThemeId, siteId ),
 			isActivating: !! isActivatingTheme( state, siteId ),
 			hasActivated: !! hasActivatedTheme( state, siteId ),

--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -33,7 +33,8 @@ import getCustomizeOrEditFrontPageUrl from 'state/selectors/get-customize-or-edi
 import shouldCustomizeHomepageWithGutenberg from 'state/selectors/should-customize-homepage-with-gutenberg';
 import getSiteUrl from 'state/selectors/get-site-url';
 import { addQueryArgs } from 'lib/route';
-
+import isSiteAtomic from 'state/selectors/is-site-wpcom-atomic';
+import { themeHasAutoLoadingHomepage } from 'state/themes/selectors/theme-has-auto-loading-homepage';
 /**
  * Style dependencies
  */
@@ -294,16 +295,24 @@ export default connect(
 		// Note: Gutenberg buttons will only show if the homepage is a page.
 		const shouldEditHomepageWithGutenberg = shouldCustomizeHomepageWithGutenberg( state, siteId );
 
+		const isAtomic = isSiteAtomic( state, siteId );
+		const hasAutoLoadingHomepage = themeHasAutoLoadingHomepage( state, currentThemeId );
+
+		const customizeUrl =
+			isAtomic && hasAutoLoadingHomepage
+				? addQueryArgs(
+						{ 'new-homepage': true },
+						getCustomizeOrEditFrontPageUrl( state, currentThemeId, siteId )
+				  )
+				: getCustomizeOrEditFrontPageUrl( state, currentThemeId, siteId );
+
 		return {
 			siteId,
 			siteUrl,
 			currentTheme,
 			shouldEditHomepageWithGutenberg,
 			detailsUrl: getThemeDetailsUrl( state, currentThemeId, siteId ),
-			customizeUrl: addQueryArgs(
-				{ 'new-homepage': true },
-				getCustomizeOrEditFrontPageUrl( state, currentThemeId, siteId )
-			),
+			customizeUrl,
 			forumUrl: getThemeForumUrl( state, currentThemeId, siteId ),
 			isActivating: !! isActivatingTheme( state, siteId ),
 			hasActivated: !! hasActivatedTheme( state, siteId ),

--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -34,6 +34,7 @@ import shouldCustomizeHomepageWithGutenberg from 'state/selectors/should-customi
 import getSiteUrl from 'state/selectors/get-site-url';
 import { addQueryArgs } from 'lib/route';
 import isSiteAtomic from 'state/selectors/is-site-wpcom-atomic';
+import { isJetpackSite } from 'state/sites/selectors';
 import { themeHasAutoLoadingHomepage } from 'state/themes/selectors/theme-has-auto-loading-homepage';
 /**
  * Style dependencies
@@ -296,10 +297,12 @@ export default connect(
 		const shouldEditHomepageWithGutenberg = shouldCustomizeHomepageWithGutenberg( state, siteId );
 
 		const isAtomic = isSiteAtomic( state, siteId );
+		const isJetpack = isJetpackSite( state, siteId );
 		const hasAutoLoadingHomepage = themeHasAutoLoadingHomepage( state, currentThemeId );
 
+		// Atomic & Jetpack do not have auto-loading-homepage behavior, so we trigger the layout picker for them.
 		const customizeUrl =
-			isAtomic && hasAutoLoadingHomepage
+			( isAtomic || isJetpack ) && hasAutoLoadingHomepage
 				? addQueryArgs(
 						{ 'new-homepage': true },
 						getCustomizeOrEditFrontPageUrl( state, currentThemeId, siteId )

--- a/client/state/themes/actions/activate.js
+++ b/client/state/themes/actions/activate.js
@@ -11,6 +11,7 @@ import {
 	hasAutoLoadingHomepageModalAccepted,
 	themeHasAutoLoadingHomepage,
 } from 'state/themes/selectors';
+import isSiteAtomic from 'state/selectors/is-site-wpcom-atomic';
 
 import 'state/themes/init';
 
@@ -33,6 +34,8 @@ export function activate( themeId, siteId, source = 'unknown', purchased = false
 		 */
 		if (
 			themeHasAutoLoadingHomepage( getState(), themeId ) &&
+			! isJetpackSite( getState(), siteId ) &&
+			! isSiteAtomic( getState(), siteId ) &&
 			! hasAutoLoadingHomepageModalAccepted( getState(), themeId )
 		) {
 			return dispatch( showAutoLoadingHomepageWarning( themeId ) );


### PR DESCRIPTION
This change updates the logic when switching to a template first theme, so that the page layout picker is opened when clicking the Edit Homepage link.

#### Changes proposed in this Pull Request

* Open page layout picker when clicking Edit homepage after activating an auto loading homepage theme
* Gate this feature behind Atomic & Jetpack sites, as this is designed to compensate for those environments not supporting auto loading homepages.

#### Screenshot

![switch-themes-small](https://user-images.githubusercontent.com/14988353/86751296-e98f0580-c081-11ea-82d3-b51d2170855a.gif)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/themes` while logged in and switch themes in an Atomic or Jetpack site
* You shouldn't see a warning about the homepage automatically changing
* Click "Edit Homepage" and you should be redirected to the editor, with the page layout picker opened

Your Jetpack test site needs to have the Editing Toolkit installed if you want to see the layout picker open. Even without it installed you'll still see the `?new-homepage=true` param in the url.