### PR TITLE
i18n: Force LTR direction for domain extension buttons

### DIFF
--- a/client/components/domains/search-filters/style.scss
+++ b/client/components/domains/search-filters/style.scss
@@ -89,8 +89,6 @@
 	}
 }
 
-
-
 .search-filters__buttons {
 	display: flex;
 	flex-flow: row;
@@ -114,6 +112,10 @@
 
 	// Increase specificity to override button styles in signup
 	body.is-section-signup .layout & {
+		.search-filters__tld-button {
+			direction: ltr;
+		}
+
 		button.search-filters__tld-button,
 		button.search-filters__popover-button {
 			font-size: $font-body-small;

--- a/client/components/domains/search-filters/style.scss
+++ b/client/components/domains/search-filters/style.scss
@@ -113,6 +113,7 @@
 	// Increase specificity to override button styles in signup
 	body.is-section-signup .layout & {
 		.search-filters__tld-button {
+			/*rtl:ignore*/
 			direction: ltr;
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Force LTR text direction for domain extension (TLD) buttons.

**Before:**
![image](https://user-images.githubusercontent.com/2722412/86764541-c9931e00-c050-11ea-91ae-5ed87401b0f9.png)

**After:**
![image](https://user-images.githubusercontent.com/2722412/86764617-d879d080-c050-11ea-8c1d-dd0052695bad.png)

#### Testing instructions

* Boot Calypso with RTL language (e.g. Hebrew)
* Go to `/start/domains` and confirm domain extensions are using `ltr` direction 
