### PR TITLE
Gutenboarding: persist free domain when selecting free plan

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/editor-domain-picker/src/domain-picker-button/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-domain-picker/src/domain-picker-button/index.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import * as React from 'react';
-import 'a8c-fse-common-data-stores';
 
 /**
  * Internal dependencies

--- a/apps/full-site-editing/full-site-editing-plugin/editor-domain-picker/src/domain-picker-fse/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-domain-picker/src/domain-picker-fse/index.tsx
@@ -8,7 +8,6 @@ import type { DomainSuggestions } from '@automattic/data-stores';
 /**
  * Internal dependencies
  */
-import 'a8c-fse-common-data-stores';
 import { useSite, useCurrentDomain } from '../hooks/use-current-domain';
 
 const FLOW_ID = 'gutenboarding';

--- a/apps/full-site-editing/full-site-editing-plugin/editor-plans-grid/src/hooks/use-selected-plan.ts
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-plans-grid/src/hooks/use-selected-plan.ts
@@ -10,10 +10,11 @@ import { PLANS_STORE } from '../stores';
 
 export function useSelectedPlan() {
 	// TODO: Switch to paid plan when use switch to paid domain.
+	// TODO_2: Get selected plan from launch store
 	const currentPlan = useSelect( ( select ) => {
-		return select( PLANS_STORE ).getSelectedPlan();
+		return select( PLANS_STORE ).getDefaultPaidPlan();
 	} );
 
 	// FIX: PlansGrid currentPlan params expecting undefined while `getSelectedPlan()` is returning null.
-	return currentPlan || undefined;
+	return currentPlan;
 }

--- a/apps/full-site-editing/full-site-editing-plugin/editor-plans-grid/src/plans-grid-button/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-plans-grid/src/plans-grid-button/index.tsx
@@ -4,7 +4,6 @@
 import * as React from 'react';
 import { Button } from '@wordpress/components';
 import { Icon, chevronDown } from '@wordpress/icons';
-import 'a8c-fse-common-data-stores';
 
 /**
  * Internal dependencies

--- a/apps/full-site-editing/full-site-editing-plugin/editor-plans-grid/src/plans-grid-fse/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-plans-grid/src/plans-grid-fse/index.tsx
@@ -17,7 +17,16 @@ const PlansGridFSE: React.FunctionComponent< Props > = ( { ...props } ) => {
 
 	const currentPlan = useSelectedPlan();
 
-	return <PlansGrid currentDomain={ currentDomain } currentPlan={ currentPlan } { ...props } />;
+	const handleSelect = ( plan ) => console.log( plan ); // eslint-disable-line no-console
+
+	return (
+		<PlansGrid
+			currentDomain={ currentDomain }
+			currentPlan={ currentPlan }
+			onPlanSelect={ handleSelect }
+			{ ...props }
+		/>
+	);
 };
 
 export default PlansGridFSE;

--- a/client/landing/gutenboarding/constants.ts
+++ b/client/landing/gutenboarding/constants.ts
@@ -9,16 +9,6 @@ import type { ValuesType } from 'utility-types';
  */
 export const FLOW_ID = 'gutenboarding';
 
-/**
- * Debounce our input + HTTP dependent select changes
- *
- * Rapidly changing input generates excessive HTTP requests.
- * It also leads to jarring UI changes.
- *
- * @see https://stackoverflow.com/a/44755058/1432801
- */
-export const selectorDebounce = 300;
-
 const fontTitles: Partial< Record< Font, string > > = {
 	'Playfair Display': 'Playfair',
 };

--- a/client/landing/gutenboarding/hooks/use-free-domain-suggestion.ts
+++ b/client/landing/gutenboarding/hooks/use-free-domain-suggestion.ts
@@ -2,19 +2,15 @@
  * External dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { useDebounce } from 'use-debounce';
 
 /**
  * Internal dependencies
  */
 import { DOMAIN_SUGGESTIONS_STORE } from '../stores/domain-suggestions';
 import { STORE_KEY as ONBOARD_STORE } from '../stores/onboard';
-import { selectorDebounce } from '../constants';
 
 export function useFreeDomainSuggestion() {
-	const { siteTitle, siteVertical } = useSelect( ( select ) => select( ONBOARD_STORE ).getState() );
-
-	const [ domainSearch ] = useDebounce( siteTitle, selectorDebounce );
+	const domainSearch = useSelect( ( select ) => select( ONBOARD_STORE ).getDomainSearch() );
 
 	return useSelect(
 		( select ) => {
@@ -27,6 +23,6 @@ export function useFreeDomainSuggestion() {
 				quantity: 1,
 			} )?.[ 0 ];
 		},
-		[ domainSearch, siteVertical ]
+		[ domainSearch ]
 	);
 }

--- a/client/landing/gutenboarding/hooks/use-on-login.ts
+++ b/client/landing/gutenboarding/hooks/use-on-login.ts
@@ -10,7 +10,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { STORE_KEY as ONBOARD_STORE } from '../stores/onboard';
 import { USER_STORE } from '../stores/user';
 import { SITE_STORE } from '../stores/site';
-import { useShouldSiteBePublicOnSelectedPlan } from './use-selected-plan';
+import { useShouldSiteBePublic } from './use-selected-plan';
 import { useNewQueryParam } from '../path';
 
 /**
@@ -23,7 +23,7 @@ export default function useOnSignup() {
 	const isCreatingSite = useSelect( ( select ) => select( SITE_STORE ).isFetchingSite() );
 	const newSite = useSelect( ( select ) => select( SITE_STORE ).getNewSite() );
 	const shouldTriggerCreate = useNewQueryParam();
-	const shouldSiteBePublic = useShouldSiteBePublicOnSelectedPlan();
+	const shouldSiteBePublic = useShouldSiteBePublic();
 
 	React.useEffect( () => {
 		if ( ! isCreatingSite && ! newSite && currentUser && shouldTriggerCreate ) {

--- a/client/landing/gutenboarding/hooks/use-on-signup.ts
+++ b/client/landing/gutenboarding/hooks/use-on-signup.ts
@@ -10,7 +10,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { STORE_KEY as ONBOARD_STORE } from '../stores/onboard';
 import { USER_STORE } from '../stores/user';
 import { SITE_STORE } from '../stores/site';
-import { useShouldSiteBePublicOnSelectedPlan } from './use-selected-plan';
+import { useShouldSiteBePublic } from './use-selected-plan';
 
 /**
  * After signup a site is automatically created using the username and bearerToken
@@ -21,7 +21,7 @@ export default function useOnSignup() {
 
 	const newUser = useSelect( ( select ) => select( USER_STORE ).getNewUser() );
 	const newSite = useSelect( ( select ) => select( SITE_STORE ).getNewSite() );
-	const shouldSiteBePublic = useShouldSiteBePublicOnSelectedPlan();
+	const shouldSiteBePublic = useShouldSiteBePublic();
 
 	const handleCreateSite = React.useCallback(
 		( username: string, bearerToken?: string, isPublicSite?: boolean ) => {

--- a/client/landing/gutenboarding/hooks/use-on-site-creation.ts
+++ b/client/landing/gutenboarding/hooks/use-on-site-creation.ts
@@ -13,7 +13,7 @@ import { PLANS_STORE } from '../stores/plans';
 import { USER_STORE } from '../stores/user';
 import { SITE_STORE } from '../stores/site';
 import { recordOnboardingComplete } from '../lib/analytics';
-import { useSelectedPlan, useIsSelectedPlanEcommerce } from './use-selected-plan';
+import { useSelectedPlan, useShouldSiteBePublic } from './use-selected-plan';
 
 const wpcom = wp.undocumented();
 
@@ -62,7 +62,7 @@ export default function useOnSiteCreation() {
 	const newSite = useSelect( ( select ) => select( SITE_STORE ).getNewSite() );
 	const newUser = useSelect( ( select ) => select( USER_STORE ).getNewUser() );
 	const selectedPlan = useSelectedPlan();
-	const isEcommercePlan = useIsSelectedPlanEcommerce();
+	const shouldSiteBePublic = useShouldSiteBePublic();
 	const design = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedDesign() );
 
 	const { resetOnboardStore, setIsRedirecting, setSelectedSite } = useDispatch( ONBOARD_STORE );
@@ -110,7 +110,7 @@ export default function useOnSiteCreation() {
 						? `site-editor%2F${ newSite.site_slug }`
 						: `block-editor%2Fpage%2F${ newSite.site_slug }%2Fhome`;
 
-					const redirectionUrl = isEcommercePlan
+					const redirectionUrl = shouldSiteBePublic
 						? `/checkout/${ newSite.site_slug }?preLaunch=1&isGutenboardingCreate=1`
 						: `/checkout/${ newSite.site_slug }?preLaunch=1&isGutenboardingCreate=1&redirect_to=%2F${ editorUrl }`;
 					window.location.href = redirectionUrl;
@@ -144,7 +144,7 @@ export default function useOnSiteCreation() {
 		setIsRedirecting,
 		setSelectedSite,
 		flowCompleteTrackingParams,
-		isEcommercePlan,
+		shouldSiteBePublic,
 		design,
 	] );
 }

--- a/client/landing/gutenboarding/hooks/use-selected-plan.ts
+++ b/client/landing/gutenboarding/hooks/use-selected-plan.ts
@@ -39,11 +39,7 @@ export function useSelectedPlan() {
 	return selectedPlan || planFromPath || defaultPlan;
 }
 
-export function useIsSelectedPlanEcommerce() {
+export function useShouldSiteBePublic() {
 	const currentSlug = useSelectedPlan()?.storeSlug;
 	return useSelect( ( select ) => select( PLANS_STORE ).isPlanEcommerce( currentSlug ) );
-}
-
-export function useShouldSiteBePublicOnSelectedPlan() {
-	return useIsSelectedPlanEcommerce();
 }

--- a/client/landing/gutenboarding/hooks/use-selected-plan.ts
+++ b/client/landing/gutenboarding/hooks/use-selected-plan.ts
@@ -11,7 +11,7 @@ import { PLANS_STORE } from '../stores/plans';
 import { usePlanRouteParam } from '../path';
 
 export function useSelectedPlan() {
-	const selectedPlan = useSelect( ( select ) => select( PLANS_STORE ).getSelectedPlan() );
+	const selectedPlan = useSelect( ( select ) => select( ONBOARD_STORE ).getPlan() );
 
 	const planPath = usePlanRouteParam();
 	const planFromPath = useSelect( ( select ) => select( PLANS_STORE ).getPlanByPath( planPath ) );
@@ -19,16 +19,16 @@ export function useSelectedPlan() {
 
 	const hasPaidDomain = useSelect( ( select ) => select( ONBOARD_STORE ).hasPaidDomain() );
 	const hasPaidDesign = useSelect( ( select ) => select( ONBOARD_STORE ).hasPaidDesign() );
-	const defaultPlan = useSelect( ( select ) =>
-		select( PLANS_STORE ).getDefaultPlan( hasPaidDomain, hasPaidDesign )
-	);
 
-	// If the selected plan is not a paid plan
-	// and the user selects a premium domain
+	const defaultPaidPlan = useSelect( ( select ) => select( PLANS_STORE ).getDefaultPaidPlan() );
+
+	// If the selected plan is not a paid plan and the user selects a premium domain
 	// return the default paid plan.
-	if ( hasPaidDomain && isPlanFree( selectedPlan?.storeSlug ) ) {
-		return defaultPlan;
+	if ( isPlanFree( selectedPlan?.storeSlug ) && hasPaidDomain ) {
+		return defaultPaidPlan;
 	}
+
+	const defaultPlan = hasPaidDomain || hasPaidDesign ? defaultPaidPlan : undefined;
 
 	/**
 	 * Plan is decided in this order

--- a/client/landing/gutenboarding/hooks/use-step-navigation.ts
+++ b/client/landing/gutenboarding/hooks/use-step-navigation.ts
@@ -10,7 +10,7 @@ import { useHistory } from 'react-router-dom';
 import { Step, usePath, useCurrentStep } from '../path';
 import { STORE_KEY as ONBOARD_STORE } from '../stores/onboard';
 import { USER_STORE } from '../stores/user';
-import { useShouldSiteBePublicOnSelectedPlan } from './use-selected-plan';
+import { useShouldSiteBePublic } from './use-selected-plan';
 import useSignup from './use-signup';
 
 /**
@@ -37,7 +37,7 @@ export default function useStepNavigation(): { goBack: () => void; goNext: () =>
 	// @TODO: move site creation to a separate hook or an action on the ONBOARD store
 	const currentUser = useSelect( ( select ) => select( USER_STORE ).getCurrentUser() );
 	const { createSite } = useDispatch( ONBOARD_STORE );
-	const shouldSiteBePublic = useShouldSiteBePublicOnSelectedPlan();
+	const shouldSiteBePublic = useShouldSiteBePublic();
 	const { onSignupDialogOpen } = useSignup();
 	const handleSiteCreation = () =>
 		currentUser

--- a/client/landing/gutenboarding/hooks/use-step-navigation.ts
+++ b/client/landing/gutenboarding/hooks/use-step-navigation.ts
@@ -9,11 +9,9 @@ import { useHistory } from 'react-router-dom';
  */
 import { Step, usePath, useCurrentStep } from '../path';
 import { STORE_KEY as ONBOARD_STORE } from '../stores/onboard';
-
-import { useShouldSiteBePublicOnSelectedPlan } from './use-selected-plan';
 import { USER_STORE } from '../stores/user';
+import { useShouldSiteBePublicOnSelectedPlan } from './use-selected-plan';
 import useSignup from './use-signup';
-import { PLANS_STORE } from '../stores/plans';
 
 /**
  * A React hook that returns callback to navigate to previous and next steps in Gutenboarding flow
@@ -50,7 +48,7 @@ export default function useStepNavigation(): { goBack: () => void; goNext: () =>
 	const { domain, hasUsedPlansStep } = useSelect( ( select ) =>
 		select( ONBOARD_STORE ).getState()
 	);
-	const plan = useSelect( ( select ) => select( PLANS_STORE ).getSelectedPlan() );
+	const plan = useSelect( ( select ) => select( ONBOARD_STORE ).getPlan() );
 
 	// remove Domains step only if it's at the end
 	if ( ! siteTitle && domain ) {

--- a/client/landing/gutenboarding/onboarding-block/domains/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/domains/index.tsx
@@ -54,7 +54,7 @@ const DomainsStep: React.FunctionComponent< Props > = ( { isModal } ) => {
 	const handleBack = () => ( isModal ? history.goBack() : goBack() );
 	const handleNext = () => {
 		trackEventWithFlow( 'calypso_newsite_domain_select', {
-			domain_name: domain?.domain_name,
+			domain_name: selectedDomainRef.current,
 		} );
 		if ( isModal ) {
 			history.goBack();

--- a/client/landing/gutenboarding/onboarding-block/plans/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/plans/index.tsx
@@ -37,8 +37,7 @@ const PlansStep: React.FunctionComponent< Props > = ( { isModal } ) => {
 	const domain = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedDomain() );
 	const isPlanFree = useSelect( ( select ) => select( PLANS_STORE ).isPlanFree );
 
-	//@TODO: do the same for domains step
-	const { setDomain, setHasUsedPlansStep } = useDispatch( ONBOARD_STORE );
+	const { setDomain, updatePlan, setHasUsedPlansStep } = useDispatch( ONBOARD_STORE );
 	React.useEffect( () => {
 		! isModal && setHasUsedPlansStep( true );
 	}, [] );
@@ -57,9 +56,12 @@ const PlansStep: React.FunctionComponent< Props > = ( { isModal } ) => {
 
 	const handleBack = () => ( isModal ? history.goBack() : goBack() );
 	const handlePlanSelect = ( planSlug: PlanSlug ) => {
-		if ( isPlanFree( planSlug ) ) {
+		// When picking a free plan, if there is a paid domain selected, it's changed automatically to a free domain
+		if ( isPlanFree( planSlug ) && ! domain?.is_free ) {
 			setDomain( freeDomainSuggestion );
 		}
+
+		updatePlan( planSlug );
 
 		if ( isModal ) {
 			history.goBack();

--- a/client/landing/gutenboarding/stores/onboard/actions.ts
+++ b/client/landing/gutenboarding/stores/onboard/actions.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import type { DomainSuggestions, Site, VerticalsTemplates } from '@automattic/data-stores';
+import type { DomainSuggestions, Site, VerticalsTemplates, Plans } from '@automattic/data-stores';
 import { dispatch, select } from '@wordpress/data-controls';
 import guessTimezone from '../../../../lib/i18n-utils/guess-timezone';
 
@@ -11,6 +11,7 @@ import guessTimezone from '../../../../lib/i18n-utils/guess-timezone';
 import type { Design, SiteVertical } from './types';
 import { STORE_KEY as ONBOARD_STORE } from './constants';
 import { SITE_STORE } from '../site';
+import { PLANS_STORE } from '../plans';
 import type { State } from '.';
 import type { FontPair } from '../../constants';
 
@@ -92,6 +93,16 @@ export const setShowSignupDialog = ( showSignup: boolean ) => ( {
 	showSignup,
 } );
 
+export const setPlan = ( plan: Plans.Plan ) => ( {
+	type: 'SET_PLAN' as const,
+	plan,
+} );
+
+export function* updatePlan( planSlug: Plans.PlanSlug ) {
+	const plan: Plans.Plan = yield select( PLANS_STORE, 'getPlanBySlug', planSlug );
+	yield setPlan( plan );
+}
+
 export function* createSite( username: string, bearerToken?: string, isPublicSite = false ) {
 	const { domain, selectedDesign, selectedFonts, siteTitle, siteVertical }: State = yield select(
 		ONBOARD_STORE,
@@ -153,4 +164,5 @@ export type OnboardAction = ReturnType<
 	| typeof setSiteVertical
 	| typeof togglePageLayout
 	| typeof setShowSignupDialog
+	| typeof setPlan
 >;

--- a/client/landing/gutenboarding/stores/onboard/index.ts
+++ b/client/landing/gutenboarding/stores/onboard/index.ts
@@ -34,6 +34,7 @@ registerStore< State >( STORE_KEY, {
 		'selectedDesign',
 		'selectedFonts',
 		'selectedSite',
+		'plan',
 	],
 } );
 

--- a/client/landing/gutenboarding/stores/onboard/reducer.ts
+++ b/client/landing/gutenboarding/stores/onboard/reducer.ts
@@ -3,7 +3,7 @@
  */
 import type { Reducer } from 'redux';
 import { combineReducers } from '@wordpress/data';
-import type { DomainSuggestions } from '@automattic/data-stores';
+import type { DomainSuggestions, Plans } from '@automattic/data-stores';
 
 /**
  * Internal dependencies
@@ -144,6 +144,16 @@ const showSignupDialog: Reducer< boolean, OnboardAction > = ( state = false, act
 	return state;
 };
 
+const plan: Reducer< Plans.Plan | undefined, OnboardAction > = ( state, action ) => {
+	if ( action.type === 'SET_PLAN' ) {
+		return action.plan;
+	}
+	if ( action.type === 'RESET_ONBOARD_STORE' ) {
+		return undefined;
+	}
+	return state;
+};
+
 const reducer = combineReducers( {
 	domain,
 	domainSearch,
@@ -157,6 +167,7 @@ const reducer = combineReducers( {
 	siteTitle,
 	siteVertical,
 	showSignupDialog,
+	plan,
 } );
 
 export type State = ReturnType< typeof reducer >;

--- a/client/landing/gutenboarding/stores/onboard/selectors.ts
+++ b/client/landing/gutenboarding/stores/onboard/selectors.ts
@@ -25,3 +25,4 @@ export const getSelectedDomain = ( state: State ) => state.domain;
 export const getSelectedSiteTitle = ( state: State ) => state.siteTitle;
 export const getDomainSearch = ( state: State ) =>
 	state.domainSearch || getSelectedSiteTitle( state );
+export const getPlan = ( state: State ) => state.plan;

--- a/client/package.json
+++ b/client/package.json
@@ -170,7 +170,6 @@
 		"tracekit": "^0.4.5",
 		"twemoji": "^12.1.4",
 		"url": "^0.11.0",
-		"use-debounce": "^3.1.0",
 		"use-subscription": "^1.3.0",
 		"utility-types": "^3.10.0",
 		"uuid": "^7.0.3",

--- a/packages/data-stores/src/plans/actions.ts
+++ b/packages/data-stores/src/plans/actions.ts
@@ -1,19 +1,7 @@
-/**
- * Internal dependencies
- */
-import type { PlanSlug } from './types';
-
 export const setPrices = ( prices: Record< string, string > ) => {
 	return {
 		type: 'SET_PRICES' as const,
 		prices,
-	};
-};
-
-export const setPlan = ( slug?: PlanSlug ) => {
-	return {
-		type: 'SET_PLAN' as const,
-		slug: slug,
 	};
 };
 
@@ -23,4 +11,4 @@ export const resetPlan = () => {
 	};
 };
 
-export type PlanAction = ReturnType< typeof setPlan | typeof resetPlan | typeof setPrices >;
+export type PlanAction = ReturnType< typeof resetPlan | typeof setPrices >;

--- a/packages/data-stores/src/plans/index.ts
+++ b/packages/data-stores/src/plans/index.ts
@@ -31,7 +31,6 @@ export function register(): typeof STORE_KEY {
 			controls,
 			reducer: reducer as any,
 			selectors,
-			persist: [ 'selectedPlanSlug' ],
 		} );
 	}
 	return STORE_KEY;

--- a/packages/data-stores/src/plans/reducer.ts
+++ b/packages/data-stores/src/plans/reducer.ts
@@ -14,11 +14,9 @@ export const supportedPlanSlugs = Object.keys( PLANS_LIST );
 
 const DEFAUlT_STATE: {
 	supportedPlanSlugs: PlanSlug[];
-	selectedPlanSlug?: PlanSlug;
 	prices: PricesMap;
 } = {
 	supportedPlanSlugs,
-	selectedPlanSlug: undefined,
 	prices: {
 		[ PLAN_FREE ]: '',
 		[ PLAN_PERSONAL ]: '',
@@ -30,11 +28,6 @@ const DEFAUlT_STATE: {
 
 const reducer = function ( state = DEFAUlT_STATE, action: PlanAction ) {
 	switch ( action.type ) {
-		case 'SET_PLAN':
-			return {
-				...state,
-				selectedPlanSlug: action.slug,
-			};
 		case 'SET_PRICES':
 			return {
 				...state,

--- a/packages/data-stores/src/plans/selectors.ts
+++ b/packages/data-stores/src/plans/selectors.ts
@@ -10,11 +10,9 @@ function getPlan( slug: PlanSlug ) {
 	return PLANS_LIST[ slug ];
 }
 
-export const getSelectedPlan = ( state: State ) =>
-	state.selectedPlanSlug ? getPlan( state.selectedPlanSlug ) : null;
+export const getPlanBySlug = ( _: State, slug: PlanSlug ) => getPlan( slug );
 
-export const getDefaultPlan = ( _: State, hasPaidDomain: boolean, hasPaidDesign: boolean ) =>
-	hasPaidDomain || hasPaidDesign ? getPlan( DEFAULT_PAID_PLAN ) : undefined;
+export const getDefaultPaidPlan = () => getPlan( DEFAULT_PAID_PLAN );
 
 export const getSupportedPlans = ( state: State ) => state.supportedPlanSlugs.map( getPlan );
 

--- a/packages/domain-picker/src/constants.ts
+++ b/packages/domain-picker/src/constants.ts
@@ -1,4 +1,14 @@
 export const PAID_DOMAINS_TO_SHOW = 5;
 export const PAID_DOMAINS_TO_SHOW_EXPANDED = 10;
+
+/**
+ * Debounce our input + HTTP dependent select changes
+ *
+ * Rapidly changing input generates excessive HTTP requests.
+ * It also leads to jarring UI changes.
+ *
+ * @see https://stackoverflow.com/a/44755058/1432801
+ */
 export const DOMAIN_SEARCH_DEBOUNCE_INTERVAL = 300;
+
 export const DOMAIN_SUGGESTIONS_STORE = 'automattic/domains/suggestions';

--- a/packages/plans-grid/package.json
+++ b/packages/plans-grid/package.json
@@ -39,7 +39,6 @@
 		"classnames": "^2.2.6",
 		"lodash": "^4.17.15",
 		"tslib": "^1.10.0",
-		"use-debounce": "^3.1.0",
 		"uuid": "^7.0.2"
 	},
 	"devDependencies": {

--- a/packages/plans-grid/src/plans-grid/index.tsx
+++ b/packages/plans-grid/src/plans-grid/index.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import * as React from 'react';
-import { useDispatch } from '@wordpress/data';
 import { useI18n } from '@automattic/react-i18n';
 import type { Plans, DomainSuggestions } from '@automattic/data-stores';
 
@@ -12,8 +11,6 @@ import type { Plans, DomainSuggestions } from '@automattic/data-stores';
 import { Title } from '../titles';
 import PlansTable from '../plans-table';
 import PlansDetails from '../plans-details';
-import { PLANS_STORE } from '../constants';
-
 /**
  * Style dependencies
  */
@@ -23,7 +20,7 @@ type PlansSlug = Plans.PlanSlug;
 export interface Props {
 	header?: React.ReactElement;
 	currentPlan?: Plans.Plan;
-	onPlanSelect?: ( plan: PlansSlug ) => void;
+	onPlanSelect: ( plan: PlansSlug ) => void;
 	onPickDomainClick?: () => void;
 	currentDomain?: DomainSuggestions.DomainSuggestion;
 }
@@ -37,13 +34,6 @@ const PlansGrid: React.FunctionComponent< Props > = ( {
 } ) => {
 	const { __ } = useI18n();
 
-	const { setPlan } = useDispatch( PLANS_STORE );
-
-	const handlePlanSelect = ( plan: PlansSlug ) => {
-		setPlan( plan );
-		onPlanSelect?.( plan );
-	};
-
 	return (
 		<div className="plans-grid">
 			{ header && <div className="plans-grid__header">{ header }</div> }
@@ -52,7 +42,7 @@ const PlansGrid: React.FunctionComponent< Props > = ( {
 				<div className="plans-grid__table-container">
 					<PlansTable
 						selectedPlanSlug={ currentPlan?.storeSlug ?? '' }
-						onPlanSelect={ handlePlanSelect }
+						onPlanSelect={ onPlanSelect }
 						currentDomain={ currentDomain }
 						onPickDomainClick={ onPickDomainClick }
 					></PlansTable>
@@ -64,7 +54,7 @@ const PlansGrid: React.FunctionComponent< Props > = ( {
 					<Title>{ __( 'Detailed comparison' ) }</Title>
 				</div>
 				<div className="plans-grid__details-container">
-					<PlansDetails onSelect={ handlePlanSelect } />
+					<PlansDetails onSelect={ onPlanSelect } />
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Update condition to trigger automatic domain update when selecting Free plan.
* Add `plan` to `ONBOARD` store and remove `selectedPlanSlug` from `@data-stores/plans`.

#### Testing instructions
* go to [/new](https://wordpress.com/new?fresh) in production and try to reproduce #43927
* go to [/new](https://calypso.live/new?branch=fix/gutenboarding-persist-free-domain) and the free domain should be persisted
* the rest of domain and plan selection functionality and analytics events should remain the same.

Fixes #43927
