### PR TITLE
GitHub Actions: Replace master references with origin/HEAD

### DIFF
--- a/.github/workflows/full-site-editing-plugin.yml
+++ b/.github/workflows/full-site-editing-plugin.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@master
+      uses: actions/checkout@HEAD
 
-    # https://github.com/actions/cache/blob/master/examples.md#node---lerna
+    # https://github.com/actions/cache/blob/HEAD/examples.md#node---lerna
     - name: Restore node_modules cache
       id: cache
-      uses: actions/cache@master
+      uses: actions/cache@HEAD
       with:
         path: |
           node_modules
@@ -29,7 +29,7 @@ jobs:
       run: yarn install --frozen-lockfile # Not needed when restoring from cache.
 
     - name: Run composer
-      uses: nick-zh/composer-php@master
+      uses: nick-zh/composer-php@HEAD
       with:
         action: 'install'
 
@@ -56,11 +56,11 @@ jobs:
       TRIGGER_CALYPSO_APP_BUILD_ENDPOINT: ${{ secrets.TRIGGER_CALYPSO_APP_BUILD_ENDPOINT }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@master
+      uses: actions/checkout@HEAD
 
     # It saves a bit of time to download the artifact rather than doing a build.
     - name: Get Build
-      uses: actions/download-artifact@master
+      uses: actions/download-artifact@HEAD
       with:
         name: fse-build-archive
         path: apps/full-site-editing/full-site-editing-plugin
@@ -74,24 +74,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@master
+      uses: actions/checkout@HEAD
 
     # It saves a bit of time to download the artifact rather than doing a build.
     - name: Get build
-      uses: actions/download-artifact@master
+      uses: actions/download-artifact@HEAD
       with:
         name: fse-build-archive
         path: apps/full-site-editing/full-site-editing-plugin
 
     - name: Run composer
-      uses: nick-zh/composer-php@master
+      uses: nick-zh/composer-php@HEAD
       with:
         action: 'install'
 
     # We still need to access some local node modules to run things.
     - name: Restore node_modules cache
       id: cache
-      uses: actions/cache@master
+      uses: actions/cache@HEAD
       with:
         path: |
           node_modules
@@ -120,10 +120,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@master
+      uses: actions/checkout@HEAD
 
     - name: Run composer
-      uses: nick-zh/composer-php@master
+      uses: nick-zh/composer-php@HEAD
       with:
         action: 'install'
 


### PR DESCRIPTION
In many cases, `origin` just by itself is an alias for origin/HEAD.
When a specific branch name is needed, such as in the case of the
CI caches changed in this commit, we can use HEAD as a direct
alias for the primary branch, regardless of to what it is currently
set.

See `set-head` entry in `git remote` man page: https://mirrors.edge.kernel.org/pub/software/scm/git/docs/git-remote.html

Our repository is configured with `HEAD -> master`:

```
$ git branch -l -a | grep remotes/origin/HEAD
remotes/origin/HEAD -> origin/master
```

#### Changes proposed in this Pull Request

* Update GitHub Action references to `master` branch with references to `origin/HEAD` or just `origin` or `HEAD` when appropriate

#### Testing instructions

* Check that GitHub actions on this PR continue to work

Part of https://github.com/Automattic/wp-calypso/issues/43939
