### PR TITLE
Calypso Editor: Check it geo coordinates are not invalid

### DIFF
--- a/client/lib/post-metadata/index.js
+++ b/client/lib/post-metadata/index.js
@@ -167,8 +167,8 @@ const PostMetadata = {
 		const longitude = coordinates[ 1 ].toFixed( 6 );
 
 		if (
-			latitude === post?.geo?.latitude.toFixed( 6 ) &&
-			longitude === post?.geo?.longitude.toFixed( 6 )
+			latitude === post?.geo?.latitude?.toFixed( 6 ) &&
+			longitude === post?.geo?.longitude?.toFixed( 6 )
 		) {
 			const staticImage = post?.geo?.map_url;
 			if ( staticImage ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes an error introduced in https://github.com/Automattic/wp-calypso/pull/43912

That causes a JS error when a user tried to add a new geo coordinate. 

#### Testing instructions
* Set a site to use the previous Editor.  
* Create a new post using the older calypso editor, set a title, set the location, in the sidebar. 
* Notice that it works as expected. 





