### PR TITLE
composite-checkout: Move stripe redirect payment methods to end of list

### DIFF
--- a/client/my-sites/checkout/composite-checkout/use-create-payment-methods.js
+++ b/client/my-sites/checkout/composite-checkout/use-create-payment-methods.js
@@ -497,6 +497,8 @@ export default function useCreatePaymentMethods( {
 		fullCreditsPaymentMethod,
 		...existingCardMethods,
 		applePayMethod,
+		stripeMethod,
+		paypalMethod,
 		idealMethod,
 		giropayMethod,
 		sofortMethod,
@@ -505,7 +507,5 @@ export default function useCreatePaymentMethods( {
 		epsMethod,
 		wechatMethod,
 		bancontactMethod,
-		stripeMethod,
-		paypalMethod,
 	].filter( Boolean );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Per our discussion in pbOQVh-kI-p2, this PR moves the Stripe redirect payment methods (iDEAL, Bancontact, etc.) to the bottom of the list of available payment methods to better mirror their order in old checkout.

#### Testing instructions

- Visit composite checkout after forcing one of the Stripe redirect methods to be enabled (you can do this using a VPN for a country like `NL` or applying a diff on the server like D45029-code).
- Verify that the redirect payment method is shown after the other payment methods (existing cards, then new cards, then paypal).