### PR TITLE
composite-checkout: Use detected country code

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -771,7 +771,16 @@ function CountrySelectMenu( {
 
 function useDetectedCountryCode() {
 	const detectedCountryCode = useSelector( getCurrentUserCountryCode );
-	dispatch( 'wpcom' ).updateCountryCode( detectedCountryCode );
+	const [ haveUsedDetectedCountryCode, setHaveUsedDetectedCountryCode ] = useState( false );
+
+	useEffect( () => {
+		// Dispatch exactly once
+		if ( ! haveUsedDetectedCountryCode ) {
+			debug( 'using detected country code "' + detectedCountryCode + '"' );
+			dispatch( 'wpcom' ).loadCountryCodeFromGeoIP( detectedCountryCode );
+			setHaveUsedDetectedCountryCode( true );
+		}
+	} );
 }
 
 function useCachedDomainContactDetails() {

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -771,16 +771,16 @@ function CountrySelectMenu( {
 
 function useDetectedCountryCode() {
 	const detectedCountryCode = useSelector( getCurrentUserCountryCode );
-	const [ haveUsedDetectedCountryCode, setHaveUsedDetectedCountryCode ] = useState( false );
+	const refHaveUsedDetectedCountryCode = useRef( false );
 
 	useEffect( () => {
 		// Dispatch exactly once
-		if ( ! haveUsedDetectedCountryCode ) {
+		if ( detectedCountryCode && ! refHaveUsedDetectedCountryCode.current ) {
 			debug( 'using detected country code "' + detectedCountryCode + '"' );
 			dispatch( 'wpcom' ).loadCountryCodeFromGeoIP( detectedCountryCode );
-			setHaveUsedDetectedCountryCode( true );
+			refHaveUsedDetectedCountryCode.current = true;
 		}
-	}, [ haveUsedDetectedCountryCode, detectedCountryCode ] );
+	}, [ detectedCountryCode ] );
 }
 
 function useCachedDomainContactDetails() {

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -44,6 +44,7 @@ import {
 import { FormCountrySelect } from 'components/forms/form-country-select';
 import RegistrantExtraInfoForm from 'components/domains/registrant-extra-info';
 import getCountries from 'state/selectors/get-countries';
+import { getCurrentUserCountryCode } from 'state/current-user/selectors';
 import { fetchPaymentCountries } from 'state/countries/actions';
 import { StateSelect } from 'my-sites/domains/components/form';
 import ManagedContactDetailsFormFields from 'components/domains/contact-details-form-fields/managed-contact-details-form-fields';
@@ -322,6 +323,7 @@ export default function CompositeCheckout( {
 		updateContactDetailsCache
 	);
 
+	useDetectedCountryCode();
 	useCachedDomainContactDetails();
 
 	useDisplayErrors( errors, showErrorMessage );
@@ -765,6 +767,11 @@ function CountrySelectMenu( {
 			/>
 		</FormFieldAnnotation>
 	);
+}
+
+function useDetectedCountryCode() {
+	const detectedCountryCode = useSelector( getCurrentUserCountryCode );
+	dispatch( 'wpcom' ).updateCountryCode( detectedCountryCode );
 }
 
 function useCachedDomainContactDetails() {

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -780,7 +780,7 @@ function useDetectedCountryCode() {
 			dispatch( 'wpcom' ).loadCountryCodeFromGeoIP( detectedCountryCode );
 			setHaveUsedDetectedCountryCode( true );
 		}
-	} );
+	}, [ haveUsedDetectedCountryCode, detectedCountryCode ] );
 }
 
 function useCachedDomainContactDetails() {

--- a/client/my-sites/checkout/composite-checkout/wpcom/hooks/wpcom-store.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/hooks/wpcom-store.ts
@@ -30,6 +30,7 @@ type WpcomStoreAction =
 	| { type: 'UPDATE_POSTAL_CODE'; payload: string }
 	| { type: 'TOUCH_CONTACT_DETAILS' }
 	| { type: 'UPDATE_COUNTRY_CODE'; payload: string }
+	| { type: 'LOAD_COUNTRY_CODE_FROM_GEOIP'; payload: string }
 	| {
 			type: 'LOAD_DOMAIN_CONTACT_DETAILS_FROM_CACHE';
 			payload: PossiblyCompleteDomainContactDetails;
@@ -78,6 +79,8 @@ export function useWpcomStore(
 				return updaters.setErrorMessages( state, action.payload );
 			case 'TOUCH_CONTACT_DETAILS':
 				return updaters.touchContactFields( state );
+			case 'LOAD_COUNTRY_CODE_FROM_GEOIP':
+				return updaters.populateCountryCodeFromGeoIP( state, action.payload );
 			case 'LOAD_DOMAIN_CONTACT_DETAILS_FROM_CACHE':
 				return updaters.populateDomainFieldsFromCache( state, action.payload );
 			default:
@@ -155,6 +158,10 @@ export function useWpcomStore(
 
 			updateVatId( payload: string ): WpcomStoreAction {
 				return { type: 'UPDATE_VAT_ID', payload: payload };
+			},
+
+			loadCountryCodeFromGeoIP( payload: string ): WpcomStoreAction {
+				return { type: 'LOAD_COUNTRY_CODE_FROM_GEOIP', payload };
 			},
 
 			loadDomainContactDetailsFromCache(

--- a/client/my-sites/checkout/composite-checkout/wpcom/types/wpcom-store-state.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/types/wpcom-store-state.ts
@@ -719,6 +719,10 @@ export type ManagedContactDetailsUpdaters = {
 		arg0: ManagedContactDetails,
 		arg1: ManagedContactDetailsErrors
 	) => ManagedContactDetails;
+	populateCountryCodeFromGeoIP: (
+		arg0: ManagedContactDetails,
+		arg1: string
+	) => ManagedContactDetails;
 	populateDomainFieldsFromCache: (
 		arg0: ManagedContactDetails,
 		arg1: PossiblyCompleteDomainContactDetails
@@ -789,6 +793,16 @@ export const managedContactDetailsUpdaters: ManagedContactDetailsUpdaters = {
 		errors: ManagedContactDetailsErrors
 	): ManagedContactDetails => {
 		return setManagedContactDetailsErrors( errors, oldDetails );
+	},
+
+	populateCountryCodeFromGeoIP: (
+		oldDetails: ManagedContactDetails,
+		newCountryCode: string
+	): ManagedContactDetails => {
+		return {
+			...oldDetails,
+			countryCode: setValueUnlessTouched( newCountryCode, oldDetails.countryCode ),
+		};
 	},
 
 	populateDomainFieldsFromCache: (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* When a user enters checkout, prepopulate the country code field with the data detected by `getCurrentUserCountryCode`. Uses the same mechanism as loading domain contact details from cache, so will not overwrite manually entered data.

Unforgeable screenshots to definitely prove it works:

![Screen Shot 2020-07-07 at 2 03 46 PM](https://user-images.githubusercontent.com/9310939/86837502-a07c8880-c064-11ea-8005-2c01be07a8f2.png)
![Screen Shot 2020-07-07 at 2 11 32 PM](https://user-images.githubusercontent.com/9310939/86837514-a2464c00-c064-11ea-9abe-be7d8965e093.png)
![Screen Shot 2020-07-07 at 2 21 26 PM](https://user-images.githubusercontent.com/9310939/86837543-aa05f080-c064-11ea-9c8b-f3e25f1bcf27.png)


#### Testing instructions

You'll need to trick calypso into thinking you are in some other countries, for instance by using a VPN, or by manually setting `detectedCountryCode` as defined in this PR to any ISO 3166-1 alpha-2 (that means two-letter) country code, like 'ca' or 'jp' or 'br'.

You'll also need to force composite checkout to load, for example using the `?flags=composite-checkout-force` query parameter.

1. Enter checkout as a brand new user and verify that the country field is prepopulated and that the data is close to correct. ("Close", because VPNs and proxies may conspire to make this a little bit wrong, like UK instead of Ireland.)
2. Change your country using one of the above methods, reload checkout, and verify that the prepopulated country data changes as expected.
3. Manually select a different country. Click around checkout to cause the contact details step to rerender. Verify that your manually entered country value "sticks" - is not overwritten by the detected value.
4. Un-spoof your country, enter checkout as an established user with cached domain details, and verify that your country code is the correct (cached) value.
5. Change your country again, reload checkout, and verify that the prepopulated country data _does not change_ (e.g. is still the cached value).