### PR TITLE
Redirects the checkout for Jetpack already connected state

### DIFF
--- a/client/jetpack-connect/constants.js
+++ b/client/jetpack-connect/constants.js
@@ -9,3 +9,4 @@ export const REMOTE_PATH_AUTH =
 export const REMOTE_PATH_INSTALL =
 	'/wp-admin/plugin-install.php?tab=plugin-information&plugin=jetpack';
 export const ALLOWED_MOBILE_APP_REDIRECT_URL_LIST = [ /^wordpress:\/\// ];
+export const JPC_PATH_CHECKOUT = '/checkout';

--- a/client/jetpack-connect/jetpack-connection.jsx
+++ b/client/jetpack-connect/jetpack-connection.jsx
@@ -22,7 +22,7 @@ import { addQueryArgs, externalRedirect } from 'lib/route';
 import { checkUrl, dismissUrl } from 'state/jetpack-connect/actions';
 import { getConnectingSite, getJetpackSiteByUrl } from 'state/jetpack-connect/selectors';
 import { isRequestingSites } from 'state/sites/selectors';
-import { retrieveMobileRedirect } from './persistence-utils';
+import { retrieveMobileRedirect, retrievePlan } from './persistence-utils';
 import { recordTracksEvent } from 'state/analytics/actions';
 
 import { IS_DOT_COM_GET_SEARCH, MINIMUM_JETPACK_VERSION } from './constants';
@@ -90,6 +90,15 @@ const jetpackConnection = ( WrappedComponent ) => {
 				this.redirect( 'plans_selection', url );
 			}
 
+			if ( status === ALREADY_CONNECTED && ! this.state.redirecting ) {
+				const currentPlan = retrievePlan();
+				if ( currentPlan ) {
+					this.redirect( 'checkout', url, currentPlan );
+				} else {
+					this.redirect( 'plans_selection', url );
+				}
+			}
+
 			if ( this.state.waitingForSites && ! this.props.isRequestingSites ) {
 				// eslint-disable-next-line react/no-did-update-set-state
 				this.setState( { waitingForSites: false } );
@@ -119,11 +128,11 @@ const jetpackConnection = ( WrappedComponent ) => {
 			} );
 		};
 
-		redirect = ( type, url ) => {
+		redirect = ( type, url, product ) => {
 			if ( ! this.state.redirecting ) {
 				this.setState( { redirecting: true } );
 
-				redirect( type, url );
+				redirect( type, url, product );
 			}
 		};
 

--- a/client/jetpack-connect/utils.js
+++ b/client/jetpack-connect/utils.js
@@ -13,7 +13,12 @@ import { urlToSlug } from 'lib/url';
  * Internal dependencies
  */
 import { addQueryArgs, externalRedirect, untrailingslashit } from 'lib/route';
-import { JPC_PATH_PLANS, JPC_PATH_REMOTE_INSTALL, REMOTE_PATH_AUTH } from './constants';
+import {
+	JPC_PATH_PLANS,
+	JPC_PATH_REMOTE_INSTALL,
+	REMOTE_PATH_AUTH,
+	JPC_PATH_CHECKOUT,
+} from './constants';
 
 export function authQueryTransformer( queryObject ) {
 	return {
@@ -135,9 +140,10 @@ export function parseAuthorizationQuery( query ) {
  *
  * @param  {string}     type Redirect type
  * @param  {string}     url Site url
- * @returns {?object}          Redirect url
+ * @param  {?string}    product Product slug
+ * @returns {string}        Redirect url
  */
-export function redirect( type, url ) {
+export function redirect( type, url, product = null ) {
 	let urlRedirect = '';
 	const instr = '/jetpack/connect/instructions';
 
@@ -157,7 +163,12 @@ export function redirect( type, url ) {
 	}
 
 	if ( type === 'install_instructions' ) {
-		urlRedirect = addQueryArgs( { url: url }, instr );
+		urlRedirect = addQueryArgs( { url }, instr );
+		page.redirect( urlRedirect );
+	}
+
+	if ( type === 'checkout' ) {
+		urlRedirect = `${ JPC_PATH_CHECKOUT }/${ urlToSlug( url ) }/${ product }`;
 		page.redirect( urlRedirect );
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes an issue where the `ALREADY_CONNECTED` state isn't handled.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `/jetpack/connect/pro` (or other product) and input the URL of a Jetpack site that is connected and you own.
* End up on the checkout page.
