### PR TITLE
Adds Jetpack Anti-Spam to checkout flow

### DIFF
--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -51,6 +51,8 @@ import {
 	PRODUCT_JETPACK_SEARCH_MONTHLY,
 	PRODUCT_JETPACK_SCAN,
 	PRODUCT_JETPACK_SCAN_MONTHLY,
+	PRODUCT_JETPACK_ANTI_SPAM,
+	PRODUCT_JETPACK_ANTI_SPAM_MONTHLY,
 } from 'lib/products-values/constants';
 
 /**
@@ -66,6 +68,7 @@ const analyticsPageTitleByType = {
 	backup: 'Jetpack Daily Backup',
 	jetpack_search: 'Jetpack Search',
 	scan: 'Jetpack Scan Daily',
+	antispam: 'Jetpack Anti-Spam',
 };
 
 const removeSidebar = ( context ) => context.store.dispatch( hideSidebar() );
@@ -80,6 +83,7 @@ const getPlanSlugFromFlowType = ( type, interval = 'yearly' ) => {
 			backup: PRODUCT_JETPACK_BACKUP_DAILY,
 			jetpack_search: PRODUCT_JETPACK_SEARCH,
 			scan: PRODUCT_JETPACK_SCAN,
+			antispam: PRODUCT_JETPACK_ANTI_SPAM,
 		},
 		monthly: {
 			personal: PLAN_JETPACK_PERSONAL_MONTHLY,
@@ -89,6 +93,7 @@ const getPlanSlugFromFlowType = ( type, interval = 'yearly' ) => {
 			backup: PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY,
 			jetpack_search: PRODUCT_JETPACK_SEARCH_MONTHLY,
 			scan: PRODUCT_JETPACK_SCAN_MONTHLY,
+			antispam: PRODUCT_JETPACK_ANTI_SPAM_MONTHLY,
 		},
 	};
 

--- a/client/jetpack-connect/index.js
+++ b/client/jetpack-connect/index.js
@@ -24,8 +24,18 @@ export default function () {
 	const isLoggedOut = ! user.get();
 	const locale = getLanguageRouteParam( 'locale' );
 
+	const planTypeString = [
+		'personal',
+		'premium',
+		'pro',
+		'backup',
+		'scan',
+		'realtimebackup',
+		'antispam',
+	].join( '|' );
+
 	page(
-		'/jetpack/connect/:type(personal|premium|pro|backup|scan|realtimebackup)/:interval(yearly|monthly)?',
+		`/jetpack/connect/:type(${ planTypeString })/:interval(yearly|monthly)?`,
 		controller.persistMobileAppFlow,
 		controller.setMasterbar,
 		controller.connect,
@@ -134,7 +144,7 @@ export default function () {
 	);
 
 	page(
-		`/jetpack/connect/:type(personal|premium|pro|backup|scan|realtimebackup)?/${ locale }`,
+		`/jetpack/connect/:type(${ planTypeString })?/${ locale }`,
 		controller.redirectWithoutLocaleIfLoggedIn,
 		controller.persistMobileAppFlow,
 		controller.setMasterbar,

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -305,7 +305,9 @@ export class Checkout extends React.Component {
 		}
 
 		if (
-			( startsWith( product, 'jetpack_backup' ) || startsWith( product, 'jetpack_scan' ) ) &&
+			( startsWith( product, 'jetpack_backup' ) ||
+				startsWith( product, 'jetpack_scan' ) ||
+				startsWith( product, 'jetpack_anti_spam' ) ) &&
 			isJetpackNotAtomic
 		) {
 			cartItem = jetpackProductItem( product );

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -44,6 +44,14 @@ import {
 	isJetpackBackupSlug,
 	isJetpackCloudProductSlug,
 } from 'lib/products-values';
+import {
+	JETPACK_PRODUCTS_LIST,
+	JETPACK_SEARCH_PRODUCTS,
+	PRODUCT_JETPACK_SEARCH,
+	PRODUCT_JETPACK_SEARCH_MONTHLY,
+	PRODUCT_WPCOM_SEARCH,
+	PRODUCT_WPCOM_SEARCH_MONTHLY,
+} from 'lib/products-values/constants';
 import PendingPaymentBlocker from './pending-payment-blocker';
 import { clearSitePlans } from 'state/sites/plans/actions';
 import { clearPurchases } from 'state/purchases/actions';
@@ -290,50 +298,36 @@ export class Checkout extends React.Component {
 			cartItem = getCartItemForPlan( planSlug );
 		}
 
-		if ( startsWith( this.props.product, 'theme' ) ) {
-			cartMeta = this.props.product.split( ':' )[ 1 ];
+		if ( startsWith( product, 'theme' ) ) {
+			cartMeta = product.split( ':' )[ 1 ];
 			cartItem = themeItem( cartMeta );
 		}
 
-		if ( startsWith( this.props.product, 'domain-mapping' ) ) {
-			cartMeta = this.props.product.split( ':' )[ 1 ];
+		if ( startsWith( product, 'domain-mapping' ) ) {
+			cartMeta = product.split( ':' )[ 1 ];
 			cartItem = domainMapping( { domain: cartMeta } );
 		}
 
-		if ( startsWith( this.props.product, 'concierge-session' ) ) {
+		if ( startsWith( product, 'concierge-session' ) ) {
 			cartItem = ! hasConciergeSession( cart ) && conciergeSessionItem();
 		}
 
-		if (
-			( startsWith( product, 'jetpack_backup' ) ||
-				startsWith( product, 'jetpack_scan' ) ||
-				startsWith( product, 'jetpack_anti_spam' ) ) &&
-			isJetpackNotAtomic
-		) {
-			cartItem = jetpackProductItem( product );
-		}
-
-		if (
-			[
-				'jetpack_search',
-				'wpcom_search',
-				'jetpack_search_monthly',
-				'wpcom_search_monthly',
-			].includes( product )
-		) {
+		if ( JETPACK_SEARCH_PRODUCTS.includes( product ) ) {
 			if ( isJetpackNotAtomic ) {
 				cartItem = product.includes( 'monthly' )
-					? jetpackProductItem( 'jetpack_search_monthly' )
-					: jetpackProductItem( 'jetpack_search' );
+					? jetpackProductItem( PRODUCT_JETPACK_SEARCH_MONTHLY )
+					: jetpackProductItem( PRODUCT_JETPACK_SEARCH );
 			}
 
 			if ( config.isEnabled( 'jetpack/wpcom-search-product' ) && ! isJetpackNotAtomic ) {
 				cartItem = product.includes( 'monthly' )
-					? jetpackProductItem( 'wpcom_search_monthly' )
-					: jetpackProductItem( 'wpcom_search' );
+					? jetpackProductItem( PRODUCT_WPCOM_SEARCH_MONTHLY )
+					: jetpackProductItem( PRODUCT_WPCOM_SEARCH );
 			} else {
 				cartItem = ! isJetpackNotAtomic ? null : cartItem;
 			}
+		} else if ( JETPACK_PRODUCTS_LIST.includes( product ) && isJetpackNotAtomic ) {
+			cartItem = jetpackProductItem( product );
 		}
 
 		if ( cartItem ) {

--- a/client/state/jetpack-connect/constants.js
+++ b/client/state/jetpack-connect/constants.js
@@ -3,4 +3,14 @@ export const JETPACK_CONNECT_TTL_SECONDS = JETPACK_CONNECT_TTL / 60;
 export const JETPACK_CONNECT_AUTHORIZE_TTL = 60 * 60 * 1000; // 1 hour
 export const AUTH_ATTEMPS_TTL = 60 * 1000; // 1 minute
 
-export const FLOW_TYPES = [ 'install', 'jetpack_search', 'backup', 'personal', 'premium', 'pro' ];
+export const FLOW_TYPES = [
+	'install',
+	'personal',
+	'premium',
+	'pro',
+	'jetpack_search',
+	'backup',
+	'realtimebackup',
+	'scan',
+	'antispam',
+];


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds Jetpack Anti-Spam as an option for checkout.
* Refactors checkout to use product constants instead of strings.

**Notes**
* ~Relies on D45785-code.~
* ~There is a bug in #43956 that would interfere with this.~

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `/jetpack/connect/antispam`.
* Input a connected Jetpack site URL.
* Verify that Anti-Spam appears in the cart.
* Check out and verify the product is added.

Fixes 1181531115069428-as-1182685648881645.
