### PR TITLE
Jetpack Search: enable product removal for Atomic sites

### DIFF
--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -29,6 +29,7 @@ import {
 	isJetpackProduct,
 	isPlan,
 } from 'lib/products-values';
+import { isJetpackSearch } from 'lib/products-values/constants';
 import notices from 'notices';
 import { purchasesRoot } from '../paths';
 import { getPurchasesError } from 'state/purchases/selectors';
@@ -340,8 +341,7 @@ class RemovePurchase extends Component {
 				/>
 			);
 		}
-
-		if ( this.props.isAtomicSite && ! purchase.productName.includes( 'Search' ) ) {
+		if ( this.props.isAtomicSite && ! isJetpackSearch( purchase.productSlug ) ) {
 			return this.renderAtomicDialog( purchase );
 		}
 

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -341,7 +341,7 @@ class RemovePurchase extends Component {
 			);
 		}
 
-		if ( this.props.isAtomicSite ) {
+		if ( this.props.isAtomicSite && ! purchase.productName.includes( 'Search' ) ) {
 			return this.renderAtomicDialog( purchase );
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Enable removal of Search product for Atomic sites without the need to contact support.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Buy Search for an Atomic site using e.g.  `wordpress.com/jetpack/connect/jetpack_search` when proxied
* remove the product at `/me/purchases` tab
* verify that what follows is the cancellation survey, not a nudge to contact HEs.
 


Fixes https://github.com/Automattic/wp-calypso/issues/43768
