### PR TITLE
Update theme thanks modal buttons to use sentence case

### DIFF
--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -190,7 +190,7 @@ class ThanksModal extends Component {
 			return translate( 'Activating theme…' );
 		}
 
-		const gutenbergContent = translate( 'Edit Homepage' );
+		const gutenbergContent = translate( 'Edit homepage' );
 		const customizerContent = (
 			<>
 				<Gridicon icon="external" />
@@ -208,7 +208,7 @@ class ThanksModal extends Component {
 	getViewSiteLabel = () => (
 		<span className="thanks-modal__button-customize">
 			<Gridicon icon="external" />
-			{ translate( 'View Site' ) }
+			{ translate( 'View site' ) }
 		</span>
 	);
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update the `/themes` `ThanksModal` to use sentence case for the buttons instead of title case

Part of p9Jlb4-1ly-p2, and raised in https://github.com/Automattic/wp-calypso/pull/43933#issuecomment-655043127

#### Screenshot

![image](https://user-images.githubusercontent.com/14988353/86864281-3de0c680-c110-11ea-80fb-0612e194270f.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* While logged in, go to `/themes` on your test site and switch themes. After activating the theme, the buttons for "View site" and "Edit homepage" should be in sentence case instead of title case

Fixes #
