### PR TITLE
Update activate button in AutoLoadingHomepageModal to use sentence case

### DIFF
--- a/client/my-sites/themes/auto-loading-homepage-modal.jsx
+++ b/client/my-sites/themes/auto-loading-homepage-modal.jsx
@@ -102,7 +102,7 @@ class AutoLoadingHomepageModal extends Component {
 					},
 					{
 						action: 'activeTheme',
-						label: translate( 'Yes, Activate %(themeName)s', {
+						label: translate( 'Yes, activate %(themeName)s', {
 							args: { themeName },
 						} ),
 						isPrimary: true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update "Yes, Activate" button in AutoLoadingHomepageModal to use sentence case ("Yes, activate")

#### Screenshot

![image](https://user-images.githubusercontent.com/14988353/86876440-139b0300-c128-11ea-8536-132b79a0f572.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* While logged in, go to `/themes` and switch your test site to use one of the main template first themes that support AutoLoadingHomepageModal (e.g. Rivington or Dalston) or any Varia child theme
* The button should say `Yes, activate` followed by the theme name, instead of `Yes, Activate`

Fixes #
