### PR TITLE
Sites Checklist: transform api data 

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
@@ -14,9 +14,21 @@ import { launchSiteOrRedirectToLaunchSignupFlow } from 'state/sites/launch/actio
 import { localizeUrl } from 'lib/i18n-utils';
 import { verifyEmail } from 'state/current-user/email-verification/actions';
 
+// A list of known tasks for the calypso client/state/data-layer/wpcom/checklist/index.js
+// You need to alter this object in case of adding / removing tasks
+export const SITE_CHECKLIST_KNOWN_TASKS = {
+	DOMAIN_VERIFIED: 'domain_verified',
+	EMAIL_VERIFIED: 'email_verified',
+	BLOGNAME_SET: 'blogname_set',
+	MOBILE_APP_INSTALLED: 'mobile_app_installed',
+	SITE_LAUNCHED: 'site_launched',
+	FRONT_PAGE_UPDATED: 'front_page_updated',
+	SITE_MENU_UPDATED: 'site_menu_updated',
+};
+
 const getTaskDescription = ( task, { isDomainUnverified, isEmailUnverified } ) => {
 	switch ( task.id ) {
-		case 'site_launched':
+		case SITE_CHECKLIST_KNOWN_TASKS.SITE_LAUNCHED:
 			if ( isDomainUnverified ) {
 				return (
 					<>
@@ -48,9 +60,9 @@ const isTaskDisabled = (
 	{ emailVerificationStatus, isDomainUnverified, isEmailUnverified }
 ) => {
 	switch ( task.id ) {
-		case 'email_verified':
+		case SITE_CHECKLIST_KNOWN_TASKS.EMAIL_VERIFIED:
 			return 'requesting' === emailVerificationStatus || ! isEmailUnverified;
-		case 'site_launched':
+		case SITE_CHECKLIST_KNOWN_TASKS.SITE_LAUNCHED:
 			return isDomainUnverified || isEmailUnverified;
 		default:
 			return false;
@@ -72,7 +84,7 @@ export const getTask = (
 ) => {
 	let taskData = {};
 	switch ( task.id ) {
-		case 'domain_verified':
+		case SITE_CHECKLIST_KNOWN_TASKS.DOMAIN_VERIFIED:
 			taskData = {
 				timing: 2,
 				title:
@@ -91,7 +103,7 @@ export const getTask = (
 				actionText: translate( 'Verify' ),
 			};
 			break;
-		case 'email_verified':
+		case SITE_CHECKLIST_KNOWN_TASKS.EMAIL_VERIFIED:
 			taskData = {
 				timing: 1,
 				title: translate( 'Confirm your email address' ),
@@ -113,7 +125,7 @@ export const getTask = (
 				actionDispatchArgs: [ { showGlobalNotices: true } ],
 			};
 			break;
-		case 'blogname_set':
+		case SITE_CHECKLIST_KNOWN_TASKS.BLOGNAME_SET:
 			taskData = {
 				timing: 1,
 				title: translate( 'Name your site' ),
@@ -125,7 +137,7 @@ export const getTask = (
 				tour: 'checklistSiteTitle',
 			};
 			break;
-		case 'mobile_app_installed':
+		case SITE_CHECKLIST_KNOWN_TASKS.MOBILE_APP_INSTALLED:
 			taskData = {
 				timing: 3,
 				title: translate( 'Get the WordPress app' ),
@@ -141,7 +153,7 @@ export const getTask = (
 				isSkippable: true,
 			};
 			break;
-		case 'site_launched':
+		case SITE_CHECKLIST_KNOWN_TASKS.SITE_LAUNCHED:
 			taskData = {
 				timing: 1,
 				title: translate( 'Launch your site' ),
@@ -154,7 +166,7 @@ export const getTask = (
 				actionDisableOnComplete: true,
 			};
 			break;
-		case 'front_page_updated':
+		case SITE_CHECKLIST_KNOWN_TASKS.FRONT_PAGE_UPDATED:
 			taskData = {
 				timing: 20,
 				title: translate( 'Update your Home page' ),
@@ -165,7 +177,7 @@ export const getTask = (
 				actionUrl: taskUrls?.front_page_updated,
 			};
 			break;
-		case 'site_menu_updated':
+		case SITE_CHECKLIST_KNOWN_TASKS.SITE_MENU_UPDATED:
 			taskData = {
 				timing: 10,
 				title: translate( 'Create a site menu' ),

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
@@ -30,6 +30,7 @@ import { requestGuidedTour } from 'state/ui/guided-tours/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { skipCurrentViewHomeLayout } from 'state/home/actions';
 import NavItem from './nav-item';
+import { SITE_CHECKLIST_KNOWN_TASKS } from 'my-sites/customer-home/cards/tasks/site-setup-list/get-task';
 import { getTask } from './get-task';
 
 /**
@@ -113,7 +114,9 @@ const SiteSetupList = ( {
 	const dispatch = useDispatch();
 
 	const isDomainUnverified =
-		tasks.filter( ( task ) => task.id === 'domain_verified' && ! task.isCompleted ).length > 0;
+		tasks.filter(
+			( task ) => task.id === SITE_CHECKLIST_KNOWN_TASKS.DOMAIN_VERIFIED && ! task.isCompleted
+		).length > 0;
 
 	// Move to first incomplete task on first load.
 	useEffect( () => {

--- a/client/state/data-layer/wpcom/checklist/index.js
+++ b/client/state/data-layer/wpcom/checklist/index.js
@@ -13,10 +13,39 @@ import { receiveSiteChecklist } from 'state/checklist/actions';
 
 import { registerHandlers } from 'state/data-layer/handler-registry';
 
-// The checklist API requests use the http_envelope query param, however on
-// desktop the envelope is not being unpacked for some reason. This conversion
-// ensures the payload has been unpacked.
-const fromApi = ( payload ) => get( payload, 'body', payload );
+// A list of known tasks for the calypso client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
+const knownTaskIds = [
+	'site_created',
+	'domain_verified',
+	'email_verified',
+	'blogname_set',
+	'mobile_app_installed',
+	'site_launched',
+	'front_page_updated',
+	'site_menu_updated',
+];
+
+// Transform the response to a data / schema calypso understands, eg filter out unknown tasks
+const fromApi = ( payload ) => {
+	// The checklist API requests use the http_envelope query param, however on
+	// desktop the envelope is not being unpacked for some reason. This conversion
+	// ensures the payload has been unpacked.
+	const data = get( payload, 'body', payload );
+
+	if ( ! data ) {
+		throw new TypeError( `Missing 'body' property on API response` );
+	}
+	if ( ! Array.isArray( data.tasks ) ) {
+		throw new TypeError( `API response needs array of tasks: found ${ typeof data.tasks }` );
+	}
+	return {
+		designType: data.designType,
+		phase2: data.phase2,
+		segment: data.segment,
+		verticals: data.verticals,
+		tasks: data.tasks.filter( ( task ) => knownTaskIds.includes( task.id ) ),
+	};
+};
 
 export const fetchChecklist = ( action ) =>
 	http(
@@ -33,24 +62,7 @@ export const fetchChecklist = ( action ) =>
 	);
 
 export const receiveChecklistSuccess = ( action, receivedChecklist ) => {
-	let checklist = receivedChecklist;
-
-	// Legacy object-based data format, let's convert it to the new array-based format and ultimately remove it.
-	if ( ! Array.isArray( receivedChecklist.tasks ) ) {
-		checklist = {
-			...receivedChecklist,
-			tasks: Object.keys( receivedChecklist.tasks ).map( ( taskId ) => {
-				const { completed, ...rest } = receivedChecklist.tasks[ taskId ];
-				return {
-					id: taskId,
-					isCompleted: completed,
-					...rest,
-				};
-			} ),
-		};
-	}
-
-	return receiveSiteChecklist( action.siteId, checklist );
+	return receiveSiteChecklist( action.siteId, receivedChecklist );
 };
 
 const dispatchChecklistRequest = dispatchRequest( {

--- a/client/state/data-layer/wpcom/checklist/index.js
+++ b/client/state/data-layer/wpcom/checklist/index.js
@@ -7,23 +7,12 @@ import { get, noop } from 'lodash';
  * Internal dependencies
  */
 import { SITE_CHECKLIST_REQUEST, SITE_CHECKLIST_TASK_UPDATE } from 'state/action-types';
+import { SITE_CHECKLIST_KNOWN_TASKS } from 'my-sites/customer-home/cards/tasks/site-setup-list/get-task';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { receiveSiteChecklist } from 'state/checklist/actions';
 
 import { registerHandlers } from 'state/data-layer/handler-registry';
-
-// A list of known tasks for the calypso client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
-const knownTaskIds = [
-	'site_created',
-	'domain_verified',
-	'email_verified',
-	'blogname_set',
-	'mobile_app_installed',
-	'site_launched',
-	'front_page_updated',
-	'site_menu_updated',
-];
 
 // Transform the response to a data / schema calypso understands, eg filter out unknown tasks
 const fromApi = ( payload ) => {
@@ -43,7 +32,9 @@ const fromApi = ( payload ) => {
 		phase2: data.phase2,
 		segment: data.segment,
 		verticals: data.verticals,
-		tasks: data.tasks.filter( ( task ) => knownTaskIds.includes( task.id ) ),
+		tasks: data.tasks.filter( ( task ) =>
+			Object.values( SITE_CHECKLIST_KNOWN_TASKS ).includes( task.id )
+		),
 	};
 };
 

--- a/client/state/selectors/is-site-checklist-complete.js
+++ b/client/state/selectors/is-site-checklist-complete.js
@@ -5,6 +5,7 @@ import getSiteTaskList from 'state/selectors/get-site-task-list';
 import getSiteChecklist from 'state/selectors/get-site-checklist';
 import isSiteChecklistLoading from 'state/selectors/is-site-checklist-loading';
 import { getSiteFrontPage } from 'state/sites/selectors';
+import { SITE_CHECKLIST_KNOWN_TASKS } from 'my-sites/customer-home/cards/tasks/site-setup-list/get-task';
 
 /**
  * Checks whether the tasklist has been completed.
@@ -28,21 +29,21 @@ export default function isSiteChecklistComplete( state, siteId ) {
 	const hasFrontPageSet = !! getSiteFrontPage( state, siteId );
 
 	/**
-		If a task is completed, it's because:
-		A) the task is marked as complete, its isCompleted prop is true.
-		B) the task front_page_updated is pending but the site doesn't have a page set as front page.
-		This is because updating the front page doesn't apply when the site doesn't have a page set as the front page. 
-		Any other case leads to a pending task.
-
-		@param   {object}  task The task that we'll check to see if it's completed.
-		@returns {boolean}      Whether the task is considered to be completed or not.
-	*/
+	 *	If a task is completed, it's because:
+	 *	A) the task is marked as complete, its isCompleted prop is true.
+	 *	B) the task front_page_updated is pending but the site doesn't have a page set as front page.
+	 *	This is because updating the front page doesn't apply when the site doesn't have a page set as the front page.
+	 *	Any other case leads to a pending task.
+	 *
+	 *		@param   {object}  task The task that we'll check to see if it's completed.
+	 *		@returns {boolean}      Whether the task is considered to be completed or not.
+	 */
 	const isTaskComplete = ( task ) => {
 		if ( task.isCompleted ) {
 			return true;
 		}
 
-		if ( 'front_page_updated' === task.id && ! hasFrontPageSet ) {
+		if ( SITE_CHECKLIST_KNOWN_TASKS.FRONT_PAGE_UPDATED === task.id && ! hasFrontPageSet ) {
 			return true;
 		}
 


### PR DESCRIPTION
While trying to test https://github.com/Automattic/wp-calypso/pull/43861 we saw that the PR is heavily dependent on the date that will be deployed D45830-code. That condition not only makes testing more difficult (we have to manually override it after patching) but also leaves legacy code behind `if ( $site_created_date > strtotime( '2020-07-09' ) ) {` 

**UPDATE**
As @getdave suggested,
> current PR will not preclude the need to conditionally serve the new "site created" task based on the date the site was registered. If we serve these tasks to sites that were created in the past before this task existed then Users who have previously completed the checklist will have the checklist re-shown to them.

> However, this PR does **make it easier to deploy new tasks to new sites on the server without fear that the UI will break if it doesn't have matching task definitions.**


#### Changes proposed in this Pull Request

* make sure calypso handles only known tasks, regardless what wpcom serves
* remove legacy data conversion, task are an Array already

#### Testing instructions
- Checkout this PR.
- Boot Calypso - yarn start. Wait for ages...
- Open devtools' Network tab and filter/search for `checklist`.
- Create a new site on WordPress.com via http://calypso.localhost:3000/.
- Once complete you should land on the "My Home" page.
* You should see the following (in my case that my email is confirmed)
![](https://cln.sh/mBUgCX+)
* Back in devtools Network tab inspect the request to the checklist endpoint. Open the `tasks` array in the response and match up against what you see on the frontend.
* Now **repeat the same steps** but this time apply D45830-code to your sandbox. This will serve a task `site_created` which has no equivalent task definition on the frontend. You should still see the same result on the checklist as the frontend shouldn't "respond" to task from the server which have no frontend definition.

