### PR TITLE
 FSE: Add Current layout to starter page templates page layout picker when editing a homepage

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/class-starter-page-templates.php
@@ -158,6 +158,10 @@ class Starter_Page_Templates {
 				'title' => 'Blank',
 				'slug'  => 'blank',
 			),
+			array(
+				'title' => 'Current',
+				'slug'  => 'current',
+			),
 		);
 		/**
 		 * Filters the config before it's passed to the frontend.

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/components/block-iframe-preview.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/components/block-iframe-preview.js
@@ -206,6 +206,7 @@ const BlockFramePreview = ( {
 				title={ __( 'Preview', 'full-site-editing' ) }
 				className={ classnames( 'editor-styles-wrapper', className ) }
 				style={ style }
+				tabIndex={ -1 }
 			>
 				{ iframeRef.current?.contentDocument?.body &&
 					createPortal(

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/components/block-iframe-preview.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/components/block-iframe-preview.js
@@ -161,6 +161,16 @@ const BlockFramePreview = ( {
 				'editor-styles-wrapper',
 				'block-editor__container'
 			);
+			/*
+			 * Temporarly override height of the Post Title.
+			 * Post Title component doesn't resize correctly,
+			 * this quick CSS fix overrides the height to be auto
+			 * A Core PR will rectify this (see below).
+			 *
+			 * See: https://github.com/WordPress/gutenberg/pull/20609/
+			 */
+			iframeRef.current.contentDocument.head.innerHTML +=
+				'<style>.editor-post-title .editor-post-title__input { height: auto !important; }</style>';
 			rescale();
 		}, 0 );
 	}, [ setTimeout, bodyClassName, rescale ] );

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
@@ -7,13 +7,6 @@ import { isNil, isEmpty } from 'lodash';
 import classnames from 'classnames';
 
 /**
- * WordPress dependencies
- */
-/* eslint-disable import/no-extraneous-dependencies */
-import { Disabled } from '@wordpress/components';
-/* eslint-enable import/no-extraneous-dependencies */
-
-/**
  * Internal dependencies
  */
 import BlockIframePreview from './block-iframe-preview';
@@ -41,9 +34,7 @@ const TemplateSelectorItem = ( props ) => {
 
 	// Define static or dynamic preview.
 	const innerPreview = useDynamicPreview ? (
-		<Disabled>
-			<BlockIframePreview blocks={ blocks } viewportWidth={ 960 } />
-		</Disabled>
+		<BlockIframePreview blocks={ blocks } viewportWidth={ 960 } />
 	) : (
 		<img
 			className="template-selector-item__media"

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/components/test/__snapshots__/template-selector-preview.test.js.snap
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/components/test/__snapshots__/template-selector-preview.test.js.snap
@@ -9,6 +9,7 @@ exports[`TemplateSelectorPreview Basic rendering renders the preview and no plac
       <iframe
         class="editor-styles-wrapper block-iframe-preview"
         style="transform: scale( 1 );"
+        tabindex="-1"
         title="Preview"
       />
     </div>

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/index.js
@@ -355,6 +355,10 @@ class PageTemplateModal extends Component {
 		}
 
 		const isCurrentPreview = templatesList[ 0 ]?.slug === 'current';
+		// Skip rendering current preview if there is no page content.
+		if ( isCurrentPreview && ! blocksByTemplateSlug.current?.length ) {
+			return null;
+		}
 
 		return (
 			<fieldset className="page-template-modal__list">

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/index.js
@@ -438,11 +438,10 @@ class PageTemplateModal extends Component {
 					) : (
 						<>
 							<form className="page-template-modal__form">
-								{ this.props.isFrontPage &&
-									this.renderTemplatesList(
-										currentTemplate,
-										__( 'Current', 'full-site-editing' )
-									) }
+								{ this.renderTemplatesList(
+									currentTemplate,
+									__( 'Current', 'full-site-editing' )
+								) }
 
 								{ this.props.isFrontPage &&
 									this.renderTemplatesList(

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/index.js
@@ -58,9 +58,13 @@ class PageTemplateModal extends Component {
 		const blocksByTemplateSlugs = reduce(
 			templates,
 			( prev, { slug, content } ) => {
-				prev[ slug ] = content
-					? parseBlocks( replacePlaceholders( content, this.props.siteInformation ) )
-					: [];
+				if ( slug === 'current' ) {
+					prev[ slug ] = this.props.currentBlocks;
+				} else {
+					prev[ slug ] = content
+						? parseBlocks( replacePlaceholders( content, this.props.siteInformation ) )
+						: [];
+				}
 				return prev;
 			},
 			{}
@@ -350,6 +354,8 @@ class PageTemplateModal extends Component {
 			return null;
 		}
 
+		const isCurrentPreview = templatesList[ 0 ]?.slug === 'current';
+
 		return (
 			<fieldset className="page-template-modal__list">
 				<legend className="page-template-modal__form-title">{ legendLabel }</legend>
@@ -358,7 +364,7 @@ class PageTemplateModal extends Component {
 					templates={ filteredTemplatesList }
 					blocksByTemplates={ blocksByTemplateSlug }
 					onTemplateSelect={ this.previewTemplate }
-					useDynamicPreview={ false }
+					useDynamicPreview={ isCurrentPreview }
 					siteInformation={ this.props.siteInformation }
 					selectedTemplate={ this.state.previewedTemplate }
 				/>

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/index.js
@@ -37,7 +37,6 @@ import mapBlocksRecursively from './utils/map-blocks-recursively';
 import containsMissingBlock from './utils/contains-missing-block';
 /* eslint-enable import/no-extraneous-dependencies */
 
-const DEFAULT_HOMEPAGE_TEMPLATE = 'maywood';
 const INSERTING_HOOK_NAME = 'isInsertingPageTemplate';
 const INSERTING_HOOK_NAMESPACE = 'automattic/full-site-editing/inserting-template';
 
@@ -167,26 +166,15 @@ class PageTemplateModal extends Component {
 
 	static getDefaultSelectedTemplate = ( props ) => {
 		const blankTemplate = get( props.templates, [ 0, 'slug' ] );
-		let previouslyChosenTemplate = props._starter_page_template;
+		const previouslyChosenTemplate = props._starter_page_template;
 
-		// Usally the "new page" case
+		// Usually the "new page" case
 		if ( ! props.isFrontPage && ! previouslyChosenTemplate ) {
 			return blankTemplate;
 		}
 
-		// Normalize "home" slug into the current theme.
-		if ( previouslyChosenTemplate === 'home' ) {
-			previouslyChosenTemplate = props.theme;
-		}
-
-		const slug = previouslyChosenTemplate || props.theme;
-
-		if ( find( props.templates, { slug } ) ) {
-			return slug;
-		} else if ( find( props.templates, { slug: DEFAULT_HOMEPAGE_TEMPLATE } ) ) {
-			return DEFAULT_HOMEPAGE_TEMPLATE;
-		}
-		return blankTemplate;
+		// if the page isn't new, select "Current" as the default template
+		return 'current';
 	};
 
 	setTemplate = ( slug ) => {
@@ -442,60 +430,48 @@ class PageTemplateModal extends Component {
 									currentTemplate,
 									__( 'Current', 'full-site-editing' )
 								) }
-
 								{ this.props.isFrontPage &&
 									this.renderTemplatesList(
 										homepageTemplates,
 										__( 'Home Pages', 'full-site-editing' )
 									) }
-
 								{ this.renderTemplatesList( blankTemplate, __( 'Blank', 'full-site-editing' ) ) }
-
 								{ this.renderTemplatesList(
 									aboutTemplates,
 									__( 'About Pages', 'full-site-editing' )
 								) }
-
 								{ this.renderTemplatesList(
 									blogTemplates,
 									__( 'Blog Pages', 'full-site-editing' )
 								) }
-
 								{ this.renderTemplatesList(
 									contactTemplates,
 									__( 'Contact Pages', 'full-site-editing' )
 								) }
-
 								{ this.renderTemplatesList(
 									eventTemplates,
 									__( 'Event Pages', 'full-site-editing' )
 								) }
-
 								{ this.renderTemplatesList(
 									menuTemplates,
 									__( 'Menu Pages', 'full-site-editing' )
 								) }
-
 								{ this.renderTemplatesList(
 									portfolioTemplates,
 									__( 'Portfolio Pages', 'full-site-editing' )
 								) }
-
 								{ this.renderTemplatesList(
 									productTemplates,
 									__( 'Product Pages', 'full-site-editing' )
 								) }
-
 								{ this.renderTemplatesList(
 									servicesTemplates,
 									__( 'Services Pages', 'full-site-editing' )
 								) }
-
 								{ this.renderTemplatesList(
 									teamTemplates,
 									__( 'Team Pages', 'full-site-editing' )
 								) }
-
 								{ ! this.props.isFrontPage &&
 									this.renderTemplatesList(
 										homepageTemplates,

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/index.js
@@ -58,13 +58,9 @@ class PageTemplateModal extends Component {
 		const blocksByTemplateSlugs = reduce(
 			templates,
 			( prev, { slug, content } ) => {
-				if ( slug === 'current' ) {
-					prev[ slug ] = this.props.currentBlocks;
-				} else {
-					prev[ slug ] = content
-						? parseBlocks( replacePlaceholders( content, this.props.siteInformation ) )
-						: [];
-				}
+				prev[ slug ] = content
+					? parseBlocks( replacePlaceholders( content, this.props.siteInformation ) )
+					: [];
 				return prev;
 			},
 			{}
@@ -333,12 +329,21 @@ class PageTemplateModal extends Component {
 			return null;
 		}
 
-		// The raw `templates` prop is not filtered to remove Templates that
-		// contain missing Blocks. Therefore we compare with the keys of the
-		// filtered templates from `getBlocksByTemplateSlugs()` and filter this
-		// list to match. This ensures that the list of Template thumbnails is
-		// filtered so that it does not include Templates that have missing Blocks.
-		const blocksByTemplateSlug = this.getBlocksByTemplateSlugs( this.props.templates );
+		let blocksByTemplateSlug;
+		const isCurrentPreview = templatesList[ 0 ]?.slug === 'current';
+
+		if ( isCurrentPreview ) {
+			blocksByTemplateSlug = {
+				current: this.props.currentBlocks,
+			};
+		} else {
+			// The raw `templates` prop is not filtered to remove Templates that
+			// contain missing Blocks. Therefore we compare with the keys of the
+			// filtered templates from `getBlocksByTemplateSlugs()` and filter this
+			// list to match. This ensures that the list of Template thumbnails is
+			// filtered so that it does not include Templates that have missing Blocks.
+			blocksByTemplateSlug = this.getBlocksByTemplateSlugs( this.props.templates );
+		}
 		const templatesWithoutMissingBlocks = Object.keys( blocksByTemplateSlug );
 
 		const filterOutTemplatesWithMissingBlocks = ( templatesToFilter, filterIn ) => {
@@ -354,7 +359,6 @@ class PageTemplateModal extends Component {
 			return null;
 		}
 
-		const isCurrentPreview = templatesList[ 0 ]?.slug === 'current';
 		// Skip rendering current preview if there is no page content.
 		if ( isCurrentPreview && ! blocksByTemplateSlug.current?.length ) {
 			return null;

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/index.js
@@ -366,10 +366,23 @@ class PageTemplateModal extends Component {
 
 	render() {
 		const { previewedTemplate, isLoading } = this.state;
-		const { isPromptedFromSidebar, hidePageTitle, isOpen } = this.props;
+		const { isPromptedFromSidebar, hidePageTitle, isOpen, currentBlocks } = this.props;
 
 		if ( ! isOpen ) {
 			return null;
+		}
+
+		// Sometimes currentBlocks is not loaded before getBlocksForPreview is called
+		// getBlocksForPreview memoizes the function call which causes it to always
+		// call it with an empty array. We delete the the cache for the function
+		// to allow it to memoize the loaded currentBlocks.
+		const currentBlocksPreviewCache = this.getBlocksForPreview.cache.get( 'current' );
+		if (
+			currentBlocksPreviewCache &&
+			currentBlocks &&
+			currentBlocksPreviewCache.length !== currentBlocks.length
+		) {
+			this.getBlocksForPreview.cache.delete( 'current' );
 		}
 
 		const {

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/index.js
@@ -317,21 +317,17 @@ class PageTemplateModal extends Component {
 			return null;
 		}
 
-		let blocksByTemplateSlug;
 		const isCurrentPreview = templatesList[ 0 ]?.slug === 'current';
 
-		if ( isCurrentPreview ) {
-			blocksByTemplateSlug = {
-				current: this.props.currentBlocks,
-			};
-		} else {
-			// The raw `templates` prop is not filtered to remove Templates that
-			// contain missing Blocks. Therefore we compare with the keys of the
-			// filtered templates from `getBlocksByTemplateSlugs()` and filter this
-			// list to match. This ensures that the list of Template thumbnails is
-			// filtered so that it does not include Templates that have missing Blocks.
-			blocksByTemplateSlug = this.getBlocksByTemplateSlugs( this.props.templates );
-		}
+		const blocksByTemplateSlug = isCurrentPreview
+			? { current: this.props.currentBlocks }
+			: // The raw `templates` prop is not filtered to remove Templates that
+			  // contain missing Blocks. Therefore we compare with the keys of the
+			  // filtered templates from `getBlocksByTemplateSlugs()` and filter this
+			  // list to match. This ensures that the list of Template thumbnails is
+			  // filtered so that it does not include Templates that have missing Blocks.
+			  this.getBlocksByTemplateSlugs( this.props.templates );
+
 		const templatesWithoutMissingBlocks = Object.keys( blocksByTemplateSlug );
 
 		const filterOutTemplatesWithMissingBlocks = ( templatesToFilter, filterIn ) => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add Current layout option to page layout picker when a user is editing / updating a homepage

#### Still to do

* [ ] Switch on dynamic previews for _just_ the Current button, and see if that works instead of having a screenshot or empty square for this button
* [x] The current option shouldn't display if this is a brand new page

#### Screenshot

![image](https://user-images.githubusercontent.com/14988353/86896999-31795f80-c14a-11ea-936c-77724a141d99.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up a local development environment (e.g. go to the `apps/full-site-editing` directory and run `yarn wp-env start`
* Run the local dev environment for FSE (e.g. fo to the `apps/full-site-editing` directory and run `yarn dev` or if you want to sync to your sandbox, run `yarn dev --sync`)
* In your WP install, set a page to be the front page in the customizer
* Go to edit that page, and then add the `?new-homepage` query param so that you open up the page layout selector for a homepage, where you should then see the Current layout option. E.g. for my own local test site, the URL is `http://localhost:4013/wp-admin/post.php?post=2&action=edit&new-homepage`
* With Current layout selected, you should see a preview of the current blocks in your page, and the page title should be correct in the preview
* Try selecting different page layouts — these should all replace the page's content, however if you select Current layout, it should _not_ replace the page content.

Related to: #43933
