### PR TITLE
Gutenboarding: FSE launch store and flow

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/common/data-stores/index.ts
+++ b/apps/full-site-editing/full-site-editing-plugin/common/data-stores/index.ts
@@ -3,3 +3,5 @@
  */
 import './domain-suggestions';
 import './plans';
+import './site';
+import './launch';

--- a/apps/full-site-editing/full-site-editing-plugin/common/data-stores/launch/actions.ts
+++ b/apps/full-site-editing/full-site-editing-plugin/common/data-stores/launch/actions.ts
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import type { DomainSuggestions, Plans } from '@automattic/data-stores';
+import { dispatch, select } from '@wordpress/data-controls';
+
+/**
+ * Internal dependencies
+ */
+import { SITE_ID, SITE_STORE, PLANS_STORE } from './constants';
+
+export const setDomain = ( domain: DomainSuggestions.DomainSuggestion ) => ( {
+	type: 'SET_DOMAIN' as const,
+	domain,
+} );
+
+export const setDomainSearch = ( domainSearch: string ) => ( {
+	type: 'SET_DOMAIN_SEARCH' as const,
+	domainSearch,
+} );
+
+export const setPlan = ( plan: Plans.Plan ) => ( {
+	type: 'SET_PLAN' as const,
+	plan,
+} );
+
+export function* updatePlan( planSlug: Plans.PlanSlug ) {
+	const plan: Plans.Plan = yield select( PLANS_STORE, 'getPlanBySlug', planSlug );
+	yield setPlan( plan );
+}
+
+export function* launchSite() {
+	try {
+		const success = yield dispatch( SITE_STORE, 'launchSite', SITE_ID );
+		return success;
+	} catch ( error ) {
+		// console.log( 'launch error', error );
+	}
+}
+
+export type LaunchAction = ReturnType< typeof setDomain | typeof setDomainSearch | typeof setPlan >;

--- a/apps/full-site-editing/full-site-editing-plugin/common/data-stores/launch/constants.ts
+++ b/apps/full-site-editing/full-site-editing-plugin/common/data-stores/launch/constants.ts
@@ -1,0 +1,10 @@
+export const STORE_KEY = 'automattic/launch';
+export const SITE_STORE = 'automattic/site';
+export const PLANS_STORE = 'automattic/onboard/plans';
+
+declare global {
+	interface Window {
+		_currentSiteId: number;
+	}
+}
+export const SITE_ID = window._currentSiteId;

--- a/apps/full-site-editing/full-site-editing-plugin/common/data-stores/launch/index.ts
+++ b/apps/full-site-editing/full-site-editing-plugin/common/data-stores/launch/index.ts
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+import { controls } from '@wordpress/data-controls';
+import { plugins, registerStore, use } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { STORE_KEY } from './constants';
+import reducer, { State } from './reducer';
+import * as actions from './actions';
+import * as selectors from './selectors';
+import persistOptions from './persist';
+import type { SelectFromMap, DispatchFromMap } from '@automattic/data-stores';
+
+export type { State };
+export { STORE_KEY };
+
+use( plugins.persistence, persistOptions );
+
+registerStore< State >( STORE_KEY, {
+	actions,
+	controls,
+	reducer: reducer as any,
+	selectors,
+	persist: [ 'domain', 'plan' ],
+} );
+
+declare module '@wordpress/data' {
+	function dispatch( key: typeof STORE_KEY ): DispatchFromMap< typeof actions >;
+	function select( key: typeof STORE_KEY ): SelectFromMap< typeof selectors >;
+}

--- a/apps/full-site-editing/full-site-editing-plugin/common/data-stores/launch/persist.ts
+++ b/apps/full-site-editing/full-site-editing-plugin/common/data-stores/launch/persist.ts
@@ -1,0 +1,6 @@
+/**
+ * External dependencies
+ */
+import { persistenceConfigFactory } from '@automattic/data-stores';
+
+export default persistenceConfigFactory( 'WP_LAUNCH' );

--- a/apps/full-site-editing/full-site-editing-plugin/common/data-stores/launch/reducer.ts
+++ b/apps/full-site-editing/full-site-editing-plugin/common/data-stores/launch/reducer.ts
@@ -1,0 +1,45 @@
+/**
+ * External dependencies
+ */
+import type { Reducer } from 'redux';
+import { combineReducers } from '@wordpress/data';
+import type { DomainSuggestions, Plans } from '@automattic/data-stores';
+
+/**
+ * Internal dependencies
+ */
+import type { LaunchAction } from './actions';
+
+const domain: Reducer< DomainSuggestions.DomainSuggestion | undefined, LaunchAction > = (
+	state,
+	action
+) => {
+	if ( action.type === 'SET_DOMAIN' ) {
+		return action.domain;
+	}
+	return state;
+};
+
+const domainSearch: Reducer< string, LaunchAction > = ( state = '', action ) => {
+	if ( action.type === 'SET_DOMAIN_SEARCH' ) {
+		return action.domainSearch;
+	}
+	return state;
+};
+
+const plan: Reducer< Plans.Plan | undefined, LaunchAction > = ( state, action ) => {
+	if ( action.type === 'SET_PLAN' ) {
+		return action.plan;
+	}
+	return state;
+};
+
+const reducer = combineReducers( {
+	domain,
+	domainSearch,
+	plan,
+} );
+
+export type State = ReturnType< typeof reducer >;
+
+export default reducer;

--- a/apps/full-site-editing/full-site-editing-plugin/common/data-stores/launch/selectors.ts
+++ b/apps/full-site-editing/full-site-editing-plugin/common/data-stores/launch/selectors.ts
@@ -1,0 +1,15 @@
+/**
+ * Internal dependencies
+ */
+import type { State } from './reducer';
+
+export const getState = ( state: State ) => state;
+
+export const hasPaidDomain = ( state: State ): boolean => {
+	if ( ! state.domain ) {
+		return false;
+	}
+	return ! state.domain.is_free;
+};
+export const getSelectedDomain = ( state: State ) => state.domain;
+export const getSelectedPlan = ( state: State ) => state.plan;

--- a/apps/full-site-editing/full-site-editing-plugin/common/data-stores/site.ts
+++ b/apps/full-site-editing/full-site-editing-plugin/common/data-stores/site.ts
@@ -1,0 +1,6 @@
+/**
+ * External dependencies
+ */
+import { Site } from '@automattic/data-stores';
+
+Site.register( { client_id: '', client_secret: '' } );

--- a/apps/full-site-editing/full-site-editing-plugin/editor-domain-picker/src/domain-picker-button/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-domain-picker/src/domain-picker-button/index.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import * as React from 'react';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -9,12 +10,13 @@ import * as React from 'react';
 import DomainPickerModal from '../domain-picker-modal';
 import { Button } from '@wordpress/components';
 import { Icon, chevronDown } from '@wordpress/icons';
-import { useCurrentDomain } from '../hooks/use-current-domain';
+import { useCurrentDomainName } from '../hooks/use-current-domain';
+import { LAUNCH_STORE } from '../stores';
 
 export default function DomainPickerButton() {
 	const [ isDomainModalVisible, setDomainModalVisibility ] = React.useState( false );
-
-	const currentDomain = useCurrentDomain();
+	const freeDomain = useCurrentDomainName();
+	const { domain } = useSelect( ( select ) => select( LAUNCH_STORE ).getState() );
 
 	return (
 		<>
@@ -24,7 +26,9 @@ export default function DomainPickerButton() {
 				aria-pressed={ isDomainModalVisible }
 				onClick={ () => setDomainModalVisibility( ( s ) => ! s ) }
 			>
-				<span className="domain-picker-button__label">{ `Domain: ${ currentDomain.domain_name }` }</span>
+				<span className="domain-picker-button__label">{ `Domain: ${
+					domain?.domain_name || freeDomain
+				}` }</span>
 				<Icon icon={ chevronDown } size={ 22 } />
 			</Button>
 			{ isDomainModalVisible && (

--- a/apps/full-site-editing/full-site-editing-plugin/editor-domain-picker/src/domain-picker-modal/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-domain-picker/src/domain-picker-modal/index.tsx
@@ -7,14 +7,14 @@ import { Modal } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import DomainPickerFSE, { Props as DomainPickerFSEProps } from '../domain-picker-fse';
+import DomainPickerFSE from '../domain-picker-fse';
 import './styles.scss';
 
-interface Props extends DomainPickerFSEProps {
+interface Props {
 	onClose: () => void;
 }
 
-const DomainPickerModal: React.FunctionComponent< Props > = ( { onClose, ...props } ) => {
+const DomainPickerModal: React.FunctionComponent< Props > = ( { onClose } ) => {
 	return (
 		<Modal
 			className="domain-picker-modal"
@@ -23,7 +23,7 @@ const DomainPickerModal: React.FunctionComponent< Props > = ( { onClose, ...prop
 			onRequestClose={ onClose }
 			title=""
 		>
-			<DomainPickerFSE { ...props } />
+			<DomainPickerFSE onSelect={ onClose } />
 		</Modal>
 	);
 };

--- a/apps/full-site-editing/full-site-editing-plugin/editor-domain-picker/src/hooks/use-current-domain.ts
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-domain-picker/src/hooks/use-current-domain.ts
@@ -2,9 +2,11 @@
  * External dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { Site } from '@automattic/data-stores';
 
-const SITES_STORE = Site.register( { client_id: '', client_secret: '' } );
+/**
+ * Internal dependencies
+ */
+import { SITE_STORE } from '../stores';
 
 declare global {
 	interface Window {
@@ -13,10 +15,10 @@ declare global {
 }
 
 export function useSite() {
-	return useSelect( ( select ) => select( SITES_STORE ).getSite( window._currentSiteId ) );
+	return useSelect( ( select ) => select( SITE_STORE ).getSite( window._currentSiteId ) );
 }
 
-export function useCurrentDomain() {
+export function useCurrentDomainName() {
 	const site = useSite();
 	return ( site?.URL && new URL( site?.URL ).hostname ) || '';
 }

--- a/apps/full-site-editing/full-site-editing-plugin/editor-domain-picker/src/stores/index.ts
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-domain-picker/src/stores/index.ts
@@ -4,3 +4,5 @@
 import 'a8c-fse-common-data-stores';
 
 export const DOMAIN_SUGGESTIONS_STORE = 'automattic/domains/suggestions';
+export const LAUNCH_STORE = 'automattic/launch';
+export const SITE_STORE = 'automattic/site';

--- a/apps/full-site-editing/full-site-editing-plugin/editor-plans-grid/src/hooks/use-selected-plan.ts
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-plans-grid/src/hooks/use-selected-plan.ts
@@ -6,15 +6,20 @@ import { useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { PLANS_STORE } from '../stores';
+import { LAUNCH_STORE, PLANS_STORE } from '../stores';
 
 export function useSelectedPlan() {
-	// TODO: Switch to paid plan when use switch to paid domain.
-	// TODO_2: Get selected plan from launch store
-	const currentPlan = useSelect( ( select ) => {
+	const { domain, plan } = useSelect( ( select ) => select( LAUNCH_STORE ).getState() );
+
+	const defaultPaidPlan = useSelect( ( select ) => {
 		return select( PLANS_STORE ).getDefaultPaidPlan();
 	} );
 
-	// FIX: PlansGrid currentPlan params expecting undefined while `getSelectedPlan()` is returning null.
-	return currentPlan;
+	if ( domain && ! domain?.is_free && ! plan ) {
+		return defaultPaidPlan;
+	}
+
+	// TODO: Switch to paid plan when use switch to paid domain.
+
+	return plan;
 }

--- a/apps/full-site-editing/full-site-editing-plugin/editor-plans-grid/src/plans-grid-fse/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-plans-grid/src/plans-grid-fse/index.tsx
@@ -2,31 +2,30 @@
  * External dependencies
  */
 import * as React from 'react';
+import { useSelect, useDispatch } from '@wordpress/data';
+import PlansGrid from '@automattic/plans-grid';
+
+import type { Plans } from '@automattic/data-stores';
 
 /**
  * Internal dependencies
  */
-import PlansGrid, { Props as PlansGridProps } from '@automattic/plans-grid';
-import { useSelectedPlan } from '../hooks/use-selected-plan';
+import { LAUNCH_STORE } from '../stores';
 
-export type Props = Partial< PlansGridProps >;
+interface Props {
+	onSelect?: () => void;
+}
 
-const PlansGridFSE: React.FunctionComponent< Props > = ( { ...props } ) => {
-	// TODO: Get current domain from launch store.
-	const currentDomain = undefined;
+const PlansGridFSE: React.FunctionComponent< Props > = ( { onSelect } ) => {
+	const { domain } = useSelect( ( select ) => select( LAUNCH_STORE ).getState() );
+	const { updatePlan } = useDispatch( LAUNCH_STORE );
 
-	const currentPlan = useSelectedPlan();
+	const handleSelect = ( planSlug: Plans.PlanSlug ) => {
+		updatePlan( planSlug );
+		onSelect?.();
+	};
 
-	const handleSelect = ( plan ) => console.log( plan ); // eslint-disable-line no-console
-
-	return (
-		<PlansGrid
-			currentDomain={ currentDomain }
-			currentPlan={ currentPlan }
-			onPlanSelect={ handleSelect }
-			{ ...props }
-		/>
-	);
+	return <PlansGrid currentDomain={ domain } onPlanSelect={ handleSelect } />;
 };
 
 export default PlansGridFSE;

--- a/apps/full-site-editing/full-site-editing-plugin/editor-plans-grid/src/plans-modal/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-plans-grid/src/plans-modal/index.tsx
@@ -8,14 +8,14 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import PlansGridFSE, { Props as PlansGridFSEProps } from '../plans-grid-fse';
+import PlansGridFSE from '../plans-grid-fse';
 import './styles.scss';
 
-interface Props extends PlansGridFSEProps {
+interface Props {
 	onClose: () => void;
 }
 
-const PlansModal: React.FunctionComponent< Props > = ( { onClose, ...props } ) => {
+const PlansModal: React.FunctionComponent< Props > = ( { onClose } ) => {
 	const header = (
 		<div>
 			{ /* eslint-disable @wordpress/i18n-text-domain */ }
@@ -38,7 +38,7 @@ const PlansModal: React.FunctionComponent< Props > = ( { onClose, ...props } ) =
 		>
 			{ header }
 			<div className="plans-grid-container">
-				<PlansGridFSE { ...props } />
+				<PlansGridFSE onSelect={ onClose } />
 			</div>
 		</Modal>
 	);

--- a/apps/full-site-editing/full-site-editing-plugin/editor-plans-grid/src/stores/index.ts
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-plans-grid/src/stores/index.ts
@@ -4,3 +4,4 @@
 import 'a8c-fse-common-data-stores';
 
 export const PLANS_STORE = 'automattic/onboard/plans';
+export const LAUNCH_STORE = 'automattic/launch';

--- a/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/hooks/index.ts
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/hooks/index.ts
@@ -1,0 +1,2 @@
+export * from './use-site';
+export * from './use-on-launch';

--- a/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/hooks/use-on-launch.ts
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/hooks/use-on-launch.ts
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+import * as React from 'react';
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { useSite } from './';
+import { LAUNCH_STORE } from '../stores';
+
+declare global {
+	interface Window {
+		_currentSiteId: number;
+	}
+}
+
+export const useOnLaunch = () => {
+	const { launchStatus } = useSite();
+	const { plan } = useSelect( ( select ) => select( LAUNCH_STORE ).getState() );
+
+	React.useEffect( () => {
+		if ( launchStatus ) {
+			if ( plan && ! plan?.isFree ) {
+				console.log( 'set cart and then redirect to /checkout to purchase plan' ); //eslint-disable-line no-console
+				//window.location.href = `https://wordpress.com/checkout/${ window._currentSiteId }?preLaunch=1&isGutenboardingCreate=1`;
+				return;
+			}
+			window.location.href = `https://wordpress.com/home/${ window._currentSiteId }`;
+		}
+	}, [ launchStatus ] );
+};

--- a/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/hooks/use-on-launch.ts
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/hooks/use-on-launch.ts
@@ -57,7 +57,7 @@ export const useOnLaunch = () => {
 					// 	: `block-editor%2Fpage%2F${ newSite.site_slug }%2Fhome`;
 					// window.location.href = `https://wordpress.com/checkout/${ window._currentSiteId }?preLaunch=1&isGutenboardingCreate=1&redirect_to=%2F${ editorUrl }`;
 
-					window.location.href = `https://wordpress.com/checkout/${ window._currentSiteId }?preLaunch=1`;
+					window.top.location.href = `https://wordpress.com/checkout/${ window._currentSiteId }?preLaunch=1`;
 				};
 
 				// TODO: record tracks event

--- a/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/hooks/use-on-launch.ts
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/hooks/use-on-launch.ts
@@ -57,7 +57,7 @@ export const useOnLaunch = () => {
 					// 	: `block-editor%2Fpage%2F${ newSite.site_slug }%2Fhome`;
 					// window.location.href = `https://wordpress.com/checkout/${ window._currentSiteId }?preLaunch=1&isGutenboardingCreate=1&redirect_to=%2F${ editorUrl }`;
 
-					window.location.href = `https://wordpress.com/checkout/${ window._currentSiteId }?preLaunch=1&isGutenboardingCreate=1`;
+					window.location.href = `https://wordpress.com/checkout/${ window._currentSiteId }?preLaunch=1`;
 				};
 
 				// TODO: record tracks event

--- a/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/hooks/use-site.ts
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/hooks/use-site.ts
@@ -1,0 +1,28 @@
+/**
+ * External dependencies
+ */
+import { useSelect } from '@wordpress/data';
+
+/**
+ * External dependencies
+ */
+import { SITE_STORE } from '../stores';
+
+declare global {
+	interface Window {
+		_currentSiteId: number;
+	}
+}
+
+export function useSite() {
+	const site = useSelect( ( select ) => select( SITE_STORE ).getSite( window._currentSiteId ) );
+	const launchStatus = useSelect( ( select ) =>
+		select( SITE_STORE ).isLaunched( window._currentSiteId )
+	);
+
+	return {
+		isSiteUnlaunched: site?.launch_status === 'unlaunched' && ! launchStatus,
+		isFreePlan: site?.plan.is_free,
+		launchStatus,
+	};
+}

--- a/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-button/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-button/index.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import * as React from 'react';
+import { useDispatch } from '@wordpress/data';
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
@@ -9,30 +10,53 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import LaunchModal from '../launch-modal';
+import { LAUNCH_STORE } from '../stores';
+import { useSite, useOnLaunch } from '../hooks';
+
 import './styles.scss';
 
 const LaunchButton: React.FunctionComponent = () => {
+	const { launchSite } = useDispatch( LAUNCH_STORE );
+	const { isSiteUnlaunched, isFreePlan } = useSite();
 	const [ isLaunchModalVisible, setLaunchModalVisibility ] = React.useState( false );
+	const [ isLaunching, setIsLaunching ] = React.useState( false );
 
-	const handleClick = () => {
-		setLaunchModalVisibility( ! isLaunchModalVisible );
+	const handleLaunch = () => {
+		setIsLaunching( true );
+		launchSite();
 	};
 
 	const handleModalClose = () => {
 		setLaunchModalVisibility( false );
 	};
 
+	const handleClick = () => {
+		isFreePlan ? setLaunchModalVisibility( ! isLaunchModalVisible ) : handleLaunch();
+	};
+
+	// adding the hook to handle redirects after launch to the root component which is always mounted until we launch
+	useOnLaunch();
+
 	return (
 		<>
-			<Button
-				aria-expanded={ isLaunchModalVisible }
-				aria-pressed={ isLaunchModalVisible }
-				aria-haspopup="menu"
-				onClick={ handleClick }
-			>
-				{ __( 'Launch site', 'full-site-editing' ) }
-			</Button>
-			{ isLaunchModalVisible && <LaunchModal onClose={ handleModalClose } /> }
+			{ isSiteUnlaunched && (
+				<Button
+					aria-expanded={ isLaunchModalVisible }
+					aria-pressed={ isLaunchModalVisible }
+					aria-haspopup="menu"
+					onClick={ handleClick }
+				>
+					{ __( 'Launch site', 'full-site-editing' ) }
+				</Button>
+			) }
+			{ isLaunchModalVisible && (
+				<LaunchModal
+					onClose={ handleModalClose }
+					onSubmit={ handleLaunch }
+					isLaunching={ isLaunching }
+				/>
+			) }
+			{ isLaunching && <LaunchModal isLaunching /> }
 		</>
 	);
 };

--- a/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-modal/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-modal/index.tsx
@@ -17,10 +17,17 @@ import Launch, { LaunchStepType } from '../launch';
 
 interface Props {
 	onClose?: () => void;
+	onSubmit?: () => void;
 	step?: LaunchStepType;
+	isLaunching?: boolean;
 }
 
-const LaunchModal: React.FunctionComponent< Props > = ( { onClose, step } ) => {
+const LaunchModal: React.FunctionComponent< Props > = ( {
+	onClose,
+	onSubmit,
+	step,
+	isLaunching,
+} ) => {
 	const handleClose = () => {
 		onClose?.();
 	};
@@ -31,12 +38,16 @@ const LaunchModal: React.FunctionComponent< Props > = ( { onClose, step } ) => {
 			overlayClassName="nux-launch-modal-overlay"
 			bodyOpenClassName="has-nux-launch-modal"
 			onRequestClose={ handleClose }
-			title={ __(
-				"You're almost there! Review a few things before launching your site!",
-				'full-site-editing'
-			) }
+			title={
+				isLaunching
+					? __( 'Hooray! Your site will be ready shortly.', 'full-site-editing' )
+					: __(
+							"You're almost there! Review a few things before launching your site!",
+							'full-site-editing'
+					  )
+			}
 		>
-			<Launch step={ step }></Launch>
+			{ isLaunching ? 'launch animation' : <Launch step={ step } onSubmit={ onSubmit }></Launch> }
 		</Modal>
 	);
 };

--- a/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-steps/domain-step/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-steps/domain-step/index.tsx
@@ -17,10 +17,6 @@ const DomainStep: React.FunctionComponent< LaunchStepProps > = ( { onPrevStep, o
 		onPrevStep?.();
 	};
 
-	const handleContinue = () => {
-		onNextStep?.();
-	};
-
 	return (
 		<LaunchStep className="nux-launch-domain-step">
 			<div className="nux-launch-step__header">
@@ -36,14 +32,10 @@ const DomainStep: React.FunctionComponent< LaunchStepProps > = ( { onPrevStep, o
 					<Button isTertiary onClick={ handleBack }>
 						{ __( 'Go back', 'full-site-editing' ) }
 					</Button>
-					<Button isPrimary onClick={ handleContinue }>
-						{ __( 'Continue', 'full-site-editing' ) }
-					</Button>
 				</div>
 			</div>
 			<div className="nux-launch-step__body">
-				{ /* TODO: When a domain is selected, it should advance to the next step */ }
-				<DomainPickerFSE />
+				<DomainPickerFSE onSelect={ onNextStep } />
 			</div>
 		</LaunchStep>
 	);

--- a/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-steps/plan-step/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-steps/plan-step/index.tsx
@@ -12,9 +12,9 @@ import LaunchStep, { Props as LaunchStepProps } from '../../launch-step';
 import PlansGridFSE from '../../../../editor-plans-grid/src/plans-grid-fse';
 import './styles.scss';
 
-const PlanStep: React.FunctionComponent< LaunchStepProps > = ( { onPrevStep } ) => {
+const PlanStep: React.FunctionComponent< LaunchStepProps > = ( { onPrevStep, onNextStep } ) => {
 	const handleBack = () => {
-		onPrevStep && onPrevStep();
+		onPrevStep?.();
 	};
 
 	return (
@@ -36,7 +36,7 @@ const PlanStep: React.FunctionComponent< LaunchStepProps > = ( { onPrevStep } ) 
 				</div>
 			</div>
 			<div className="nux-launch-step__body">
-				<PlansGridFSE />
+				<PlansGridFSE onSelect={ onNextStep } />
 			</div>
 		</LaunchStep>
 	);

--- a/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch/index.tsx
@@ -7,13 +7,11 @@ import type { ValuesType } from 'utility-types';
 /**
  * Internal dependencies
  */
-import PrivacyStep from '../launch-steps/privacy-step';
 import DomainStep from '../launch-steps/domain-step';
 import PlanStep from '../launch-steps/plan-step';
 import './styles.scss';
 
 export const LaunchStep = {
-	Privacy: 'privacy',
 	Domain: 'domain',
 	Plan: 'plan',
 };
@@ -21,19 +19,18 @@ export const LaunchStep = {
 export type LaunchStepType = ValuesType< typeof LaunchStep >;
 
 const LaunchStepComponents = {
-	[ LaunchStep.Privacy ]: PrivacyStep,
 	[ LaunchStep.Domain ]: DomainStep,
 	[ LaunchStep.Plan ]: PlanStep,
 };
 
-const LaunchSequence = [ LaunchStep.Privacy, LaunchStep.Domain, LaunchStep.Plan ];
+const LaunchSequence = [ LaunchStep.Domain, LaunchStep.Plan ];
 
 interface Props {
 	step?: LaunchStepType;
 	onSubmit?: () => void;
 }
 
-const Launch: React.FunctionComponent< Props > = ( { step = LaunchStep.Privacy, onSubmit } ) => {
+const Launch: React.FunctionComponent< Props > = ( { step = LaunchStep.Domain, onSubmit } ) => {
 	const initialSequence = LaunchSequence.indexOf( step );
 
 	const [ currentSequence, setCurrentSequence ] = React.useState( initialSequence );

--- a/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch/index.tsx
@@ -30,9 +30,10 @@ const LaunchSequence = [ LaunchStep.Privacy, LaunchStep.Domain, LaunchStep.Plan 
 
 interface Props {
 	step?: LaunchStepType;
+	onSubmit?: () => void;
 }
 
-const Launch: React.FunctionComponent< Props > = ( { step = LaunchStep.Privacy } ) => {
+const Launch: React.FunctionComponent< Props > = ( { step = LaunchStep.Privacy, onSubmit } ) => {
 	const initialSequence = LaunchSequence.indexOf( step );
 
 	const [ currentSequence, setCurrentSequence ] = React.useState( initialSequence );
@@ -50,20 +51,17 @@ const Launch: React.FunctionComponent< Props > = ( { step = LaunchStep.Privacy }
 	};
 
 	const handleNextStep = () => {
-		let nextSequence = currentSequence + 1;
+		const nextSequence = currentSequence + 1;
 		const maxSequence = LaunchSequence.length - 1;
 		if ( nextSequence > maxSequence ) {
-			nextSequence = maxSequence;
+			onSubmit?.();
 		}
 		setCurrentSequence( nextSequence );
 	};
 
 	return (
 		<div className="nux-launch">
-			<CurrentLaunchStep
-				onPrevStep={ handlePrevStep }
-				onNextStep={ handleNextStep }
-			></CurrentLaunchStep>
+			<CurrentLaunchStep onPrevStep={ handlePrevStep } onNextStep={ handleNextStep } />
 		</div>
 	);
 };

--- a/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/stores/index.ts
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/stores/index.ts
@@ -1,0 +1,7 @@
+/**
+ * External dependencies
+ */
+import 'a8c-fse-common-data-stores';
+
+export const SITE_STORE = 'automattic/site';
+export const LAUNCH_STORE = 'automattic/launch';

--- a/apps/full-site-editing/package.json
+++ b/apps/full-site-editing/package.json
@@ -105,6 +105,7 @@
 		"@wordpress/components": "*",
 		"@wordpress/compose": "*",
 		"@wordpress/data": "*",
+		"@wordpress/data-controls": "*",
 		"@wordpress/date": "*",
 		"@wordpress/dependency-extraction-webpack-plugin": "^2.6.0",
 		"@wordpress/dom-ready": "*",

--- a/apps/full-site-editing/package.json
+++ b/apps/full-site-editing/package.json
@@ -127,6 +127,7 @@
 		"moment": "*",
 		"newspack-blocks": "github:Automattic/newspack-blocks#v1.7.0",
 		"react": "^16.12.0",
+		"redux": "^4.0.5",
 		"react-dom": "^16.12.0",
 		"utility-types": "^3.10.0"
 	},

--- a/client/landing/gutenboarding/hooks/use-on-site-creation.ts
+++ b/client/landing/gutenboarding/hooks/use-on-site-creation.ts
@@ -9,7 +9,6 @@ import wp from '../../../lib/wp';
  * Internal dependencies
  */
 import { STORE_KEY as ONBOARD_STORE } from '../stores/onboard';
-import { PLANS_STORE } from '../stores/plans';
 import { USER_STORE } from '../stores/user';
 import { SITE_STORE } from '../stores/site';
 import { recordOnboardingComplete } from '../lib/analytics';
@@ -66,7 +65,6 @@ export default function useOnSiteCreation() {
 	const design = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedDesign() );
 
 	const { resetOnboardStore, setIsRedirecting, setSelectedSite } = useDispatch( ONBOARD_STORE );
-	const { resetPlan } = useDispatch( PLANS_STORE );
 	const flowCompleteTrackingParams = {
 		isNewSite: !! newSite,
 		isNewUser: !! newUser,
@@ -102,7 +100,6 @@ export default function useOnSiteCreation() {
 						...cart,
 						products: [ ...cart.products, planProduct, domainProduct ],
 					} );
-					resetPlan();
 					resetOnboardStore();
 					setSelectedSite( newSite.blogid );
 
@@ -124,7 +121,6 @@ export default function useOnSiteCreation() {
 			}
 
 			recordOnboardingComplete( flowCompleteTrackingParams );
-			resetPlan();
 			resetOnboardStore();
 			setSelectedSite( newSite.blogid );
 
@@ -140,7 +136,6 @@ export default function useOnSiteCreation() {
 		newSite,
 		newUser,
 		resetOnboardStore,
-		resetPlan,
 		setIsRedirecting,
 		setSelectedSite,
 		flowCompleteTrackingParams,

--- a/client/lib/checkout/index.js
+++ b/client/lib/checkout/index.js
@@ -76,12 +76,17 @@ export function getExitCheckoutUrl(
 	upgradeIntent,
 	redirectTo,
 	returnToBlockEditor,
+	returnToHome,
 	previousPath
 ) {
 	let url = '/plans/';
 
 	if ( returnToBlockEditor ) {
 		return `/block-editor/page/${ siteSlug }/home`;
+	}
+
+	if ( returnToHome ) {
+		return `/home/${ siteSlug }`;
 	}
 
 	if ( hasRenewalItem( cart ) ) {

--- a/client/my-sites/checkout/checkout/checkout-container.jsx
+++ b/client/my-sites/checkout/checkout/checkout-container.jsx
@@ -122,7 +122,8 @@ class CheckoutContainer extends React.Component {
 							redirectTo={ redirectTo }
 							upgradeIntent={ upgradeIntent }
 							hideNudge={ isComingFromGutenboarding || isComingFromUpsell }
-							returnToBlockEditor={ isComingFromGutenboarding || isGutenboardingCreate }
+							returnToBlockEditor={ isGutenboardingCreate }
+							returnToHome={ isComingFromGutenboarding }
 							isWhiteGloveOffer={ isWhiteGloveOffer }
 						>
 							{ this.props.children }

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -111,6 +111,7 @@ export class Checkout extends React.Component {
 		couponCode: PropTypes.string,
 		isJetpackNotAtomic: PropTypes.bool,
 		returnToBlockEditor: PropTypes.bool,
+		returnToHome: PropTypes.bool,
 		selectedFeature: PropTypes.string,
 		loadTrackingTool: PropTypes.func.isRequired,
 	};
@@ -344,7 +345,7 @@ export class Checkout extends React.Component {
 			return true;
 		}
 
-		const { selectedSiteSlug, transaction, returnToBlockEditor } = this.props;
+		const { selectedSiteSlug, transaction, returnToBlockEditor, returnToHome } = this.props;
 
 		if ( ! transaction ) {
 			return true;
@@ -382,6 +383,7 @@ export class Checkout extends React.Component {
 				this.props.upgradeIntent,
 				this.props.redirectTo,
 				returnToBlockEditor,
+				returnToHome,
 				this.props.previousRoute
 			);
 		}

--- a/packages/calypso-analytics/src/tracks.ts
+++ b/packages/calypso-analytics/src/tracks.ts
@@ -164,7 +164,7 @@ export function identifyUser( userData: any ): any {
 	pushEventToTracksQueue( [ 'identifyUser', currentUser.ID, currentUser.username ] );
 }
 
-export function recordTracksEvent( eventName: string, eventProperties: any ) {
+export function recordTracksEvent( eventName: string, eventProperties?: any ) {
 	eventProperties = eventProperties || {};
 
 	if ( process.env.NODE_ENV !== 'production' && typeof console !== 'undefined' ) {

--- a/packages/data-stores/src/plans/actions.ts
+++ b/packages/data-stores/src/plans/actions.ts
@@ -11,4 +11,4 @@ export const resetPlan = () => {
 	};
 };
 
-export type PlanAction = ReturnType< typeof resetPlan | typeof setPrices >;
+export type PlanAction = ReturnType< typeof setPrices >;

--- a/packages/data-stores/src/plans/reducer.ts
+++ b/packages/data-stores/src/plans/reducer.ts
@@ -33,8 +33,6 @@ const reducer = function ( state = DEFAUlT_STATE, action: PlanAction ) {
 				...state,
 				prices: action.prices,
 			};
-		case 'RESET_PLAN':
-			return DEFAUlT_STATE;
 		default:
 			return state;
 	}

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -7,6 +7,7 @@ import type {
 	NewSiteSuccessResponse,
 	SiteDetails,
 	SiteError,
+	Cart,
 } from './types';
 import type { WpcomClientCredentials } from '../shared-types';
 import { wpcomRequest } from '../wpcom-request-controls';
@@ -88,11 +89,6 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		siteId,
 	} );
 
-	/**
-	 * Launches a private site
-	 *
-	 * @param {string} siteId - ID of the site to be launched
-	 */
 	function* launchSite( siteId: number ) {
 		yield wpcomRequest( {
 			path: `/sites/${ siteId }/launch`,
@@ -101,6 +97,26 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		} );
 		yield launchedSite( siteId );
 		return true;
+	}
+
+	// TODO: move getCart and setCart to a 'cart' data-store
+	function* getCart( siteId: number ) {
+		const success = yield wpcomRequest( {
+			path: '/me/shopping-cart/' + siteId,
+			apiVersion: '1.1',
+			method: 'GET',
+		} );
+		return success;
+	}
+
+	function* setCart( siteId: number, cartData: Cart ) {
+		const success = yield wpcomRequest( {
+			path: '/me/shopping-cart/' + siteId,
+			apiVersion: '1.1',
+			method: 'POST',
+			body: cartData,
+		} );
+		return success;
 	}
 
 	return {
@@ -114,6 +130,8 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		reset,
 		launchSite,
 		launchedSite,
+		getCart,
+		setCart,
 	};
 }
 

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -83,6 +83,26 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		type: 'RESET_RECEIVE_NEW_SITE_FAILED' as const,
 	} );
 
+	const launchedSite = ( siteId: number ) => ( {
+		type: 'LAUNCHED_SITE' as const,
+		siteId,
+	} );
+
+	/**
+	 * Launches a private site
+	 *
+	 * @param {string} siteId - ID of the site to be launched
+	 */
+	function* launchSite( siteId: number ) {
+		yield wpcomRequest( {
+			path: `/sites/${ siteId }/launch`,
+			apiVersion: '1.1',
+			method: 'post',
+		} );
+		yield launchedSite( siteId );
+		return true;
+	}
+
 	return {
 		fetchNewSite,
 		receiveNewSite,
@@ -92,6 +112,8 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		receiveSite,
 		receiveSiteFailed,
 		reset,
+		launchSite,
+		launchedSite,
 	};
 }
 
@@ -106,6 +128,7 @@ export type Action =
 			| ActionCreators[ 'receiveSiteFailed' ]
 			| ActionCreators[ 'reset' ]
 			| ActionCreators[ 'resetNewSiteFailed' ]
+			| ActionCreators[ 'launchedSite' ]
 	  >
 	// Type added so we can dispatch actions in tests, but has no runtime cost
 	| { type: 'TEST_ACTION' };

--- a/packages/data-stores/src/site/reducer.ts
+++ b/packages/data-stores/src/site/reducer.ts
@@ -72,13 +72,23 @@ export const sites: Reducer< { [ key: number ]: SiteDetails | undefined }, Actio
 	return state;
 };
 
+export const launchStatus: Reducer< { [ key: number ]: boolean }, Action > = (
+	state = {},
+	action
+) => {
+	if ( action.type === 'LAUNCHED_SITE' ) {
+		return { ...state, [ action.siteId ]: true };
+	}
+	return state;
+};
+
 const newSite = combineReducers( {
 	data: newSiteData,
 	error: newSiteError,
 	isFetching: isFetchingSite,
 } );
 
-const reducer = combineReducers( { newSite, sites } );
+const reducer = combineReducers( { newSite, sites, launchStatus } );
 
 export type State = ReturnType< typeof reducer >;
 

--- a/packages/data-stores/src/site/selectors.ts
+++ b/packages/data-stores/src/site/selectors.ts
@@ -21,3 +21,7 @@ export const isNewSite = ( state: State ) => !! state.newSite.data;
 export const getSite = ( state: State, siteId: number ) => {
 	return state.sites[ siteId ];
 };
+
+export const isLaunched = ( state: State, siteId: number ) => {
+	return state.launchStatus[ siteId ];
+};

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -71,3 +71,34 @@ export interface SiteError {
 }
 
 export type SiteResponse = SiteDetails | SiteError;
+
+export interface Cart {
+	blog_id: number;
+	cart_key: number;
+	coupon: string;
+	coupon_discounts: unknown[];
+	coupon_discounts_integer: unknown[];
+	is_coupon_applied: boolean;
+	has_bundle_credit: boolean;
+	next_domain_is_free: boolean;
+	next_domain_condition: string;
+	products: unknown[];
+	total_cost: number;
+	currency: string;
+	total_cost_display: string;
+	total_cost_integer: number;
+	temporary: boolean;
+	tax: unknown;
+	sub_total: number;
+	sub_total_display: string;
+	sub_total_integer: number;
+	total_tax: number;
+	total_tax_display: string;
+	total_tax_integer: number;
+	credits: number;
+	credits_display: string;
+	credits_integer: number;
+	allowed_payment_methods: unknown[];
+	create_new_blog: boolean;
+	messages: Record< 'errors' | 'success', unknown >;
+}

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -56,8 +56,12 @@ export interface SiteDetails {
 	name: string;
 	description: string;
 	URL: string;
+	launch_status: string;
 	options: {
 		created_at: string;
+	};
+	plan: {
+		is_free: boolean;
 	};
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4697,6 +4697,20 @@
     mousetrap "^1.6.5"
     react-resize-aware "^3.0.1"
 
+"@wordpress/compose@^3.19.0":
+  version "3.19.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/compose/-/compose-3.19.0.tgz#243fad68577991c7ac4e4cc9d4ff2b64f5a69769"
+  integrity sha512-MB/VPJJhyU/GeAeN3dRvUbkaWEKGlrbZvz/cTzF+qf27rtK7PmMyOQIGlTiQtw7wE5nhcWIifTzhyofodTlQiA==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
+    "@wordpress/element" "^2.16.0"
+    "@wordpress/is-shallow-equal" "^2.1.0"
+    "@wordpress/priority-queue" "^1.7.0"
+    clipboard "^2.0.1"
+    lodash "^4.17.15"
+    mousetrap "^1.6.5"
+    react-resize-aware "^3.0.1"
+
 "@wordpress/core-data@^2.16.0":
   version "2.16.0"
   resolved "https://registry.yarnpkg.com/@wordpress/core-data/-/core-data-2.16.0.tgz#5a1577de46f9312e3cb8e227f0ea74be4afb6232"
@@ -4715,6 +4729,14 @@
     equivalent-key-map "^0.2.2"
     lodash "^4.17.15"
     rememo "^3.0.0"
+
+"@wordpress/data-controls@*":
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/data-controls/-/data-controls-1.16.0.tgz#ce54e1faf454f8850ae7198093c7717ce24eedab"
+  integrity sha512-NnUlVEOnxGeCl3zCR4nml/CVm2JIgFqJ0xNoBCXqf6xrErN3f7DIDGu2JgRwyB6yzLs5OMN3TIWRheTc2TnvWA==
+  dependencies:
+    "@wordpress/api-fetch" "^3.18.0"
+    "@wordpress/data" "^4.22.0"
 
 "@wordpress/data-controls@^1.12.0", "@wordpress/data-controls@^1.4.0":
   version "1.12.0"
@@ -4753,6 +4775,26 @@
     "@wordpress/compose" "^3.18.0"
     "@wordpress/deprecated" "^2.9.0"
     "@wordpress/element" "^2.15.0"
+    "@wordpress/is-shallow-equal" "^2.1.0"
+    "@wordpress/priority-queue" "^1.7.0"
+    "@wordpress/redux-routine" "^3.10.0"
+    equivalent-key-map "^0.2.2"
+    is-promise "^4.0.0"
+    lodash "^4.17.15"
+    memize "^1.1.0"
+    redux "^4.0.0"
+    turbo-combine-reducers "^1.0.2"
+    use-memo-one "^1.1.1"
+
+"@wordpress/data@^4.22.0":
+  version "4.22.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/data/-/data-4.22.0.tgz#788fd0b0e87f4b978deb0f1f7ba0e937b3f47f0c"
+  integrity sha512-dflzpbNnor/C2EUoidk8+qePTd6SyoiMFjcOijVD9el6248hlYOKxCNHBadcgJ+XO3BYTzImQgkPE87iCCIuNQ==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
+    "@wordpress/compose" "^3.19.0"
+    "@wordpress/deprecated" "^2.9.0"
+    "@wordpress/element" "^2.16.0"
     "@wordpress/is-shallow-equal" "^2.1.0"
     "@wordpress/priority-queue" "^1.7.0"
     "@wordpress/redux-routine" "^3.10.0"
@@ -4932,6 +4974,17 @@
   version "2.15.0"
   resolved "https://registry.yarnpkg.com/@wordpress/element/-/element-2.15.0.tgz#53489c52c0cfb5a18364a75529e26a08493f3bf5"
   integrity sha512-XXJxvjlQo0+1L+QFUXSWc8HCPR3I9aG0yxs+kJ8k8SHQxkUOZkqLQLYtwoNJpAlvgyKeFQNigpoddjoVbDDm7Q==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
+    "@wordpress/escape-html" "^1.9.0"
+    lodash "^4.17.15"
+    react "^16.9.0"
+    react-dom "^16.9.0"
+
+"@wordpress/element@^2.16.0":
+  version "2.16.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/element/-/element-2.16.0.tgz#8196a74a6a9049eed2a5b7a51eb696fd553bbf4c"
+  integrity sha512-1ijo/GR/uBfL4teCQ3oFdUTqkeV2EZ32SCvXl30iPbqYmaNSzT1ZI1dlW8GO5o5UBja9BG11hnaOwm93pE2y2A==
   dependencies:
     "@babel/runtime" "^7.9.2"
     "@wordpress/escape-html" "^1.9.0"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add launch store and use it FSE launch flow.
* When pressing Launch site button:
  * if a paid plan is active => launch the site and redirect to `/home`.
  * if a free plan is active => the launch modal with launch steps opens.
* When completing the launch flow (selecting a domain and a plan):
  * if a free plan has been selected => launch the site => redirect to `/home`.
  * if a paid plan has been selected => launch the site => redirect to `/checkout` => redirect to `/home`.

#### Testing instructions

**Setup**
* Add `define( 'A8C_FSE_SITE_LAUNCH_ENABLE', true );` to `./config/sandbox.php`.
* Run `yarn dev --sync` on your local `apps\full-site-editing folder`.

**Scenario 1**
* Go to [wordpress.com/new](https://wordpress.com/new) and complete the flow by choosing and purchasing a paid plan (not eCommerce).
* Sandbox the new site and press **_Launch site_** button in wp-admin => Launch screen => redirect to `/home`.

**Scenario 2**
* Go to [wordpress.com/new](https://wordpress.com/new) and complete the flow by choosing Free plan.
* Sandbox the new site and press **_Launch site_** button in wp-admin.
* Complete the flow by choosing a domain and the Free plan => Launch screen => redirect to `/home`.

**Scenario 3**
* Same as scenario 2 but this time choose a paid plan during launch flow => Launch screen => redirect to `/checkout` => redirect to `/home` when completing purchase or abandoning cart.

#### Follow up

* Add error handling for site creation
* Update / add unit tests for `@data-stores/site`
* Extract cart services from `@data-stores/site` into a dedicated `cart` data-store
* Add site launch animation
* Check if there are cart items and decide how to use those (eg: paid domain)

Fixes part of #43750 