### PR TITLE
Implement wp-admin cart management hook

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/editor-domain-picker/src/domain-picker-button/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-domain-picker/src/domain-picker-button/index.tsx
@@ -3,6 +3,8 @@
  */
 import * as React from 'react';
 import 'a8c-fse-common-data-stores';
+import { useSite } from '../../../editor-domain-picker/src/hooks/use-current-domain';
+import { Cart } from '@automattic/wpcom-hooks';
 
 /**
  * Internal dependencies
@@ -17,6 +19,10 @@ export default function DomainPickerButton() {
 
 	const currentDomain = useCurrentDomain();
 
+	const site = useSite();
+
+	const [ cart ] = Cart.useSiteCart?.( site?.ID );
+
 	return (
 		<>
 			<Button
@@ -28,6 +34,7 @@ export default function DomainPickerButton() {
 				<span className="domain-picker-button__label">{ `Domain: ${ currentDomain.domain_name }` }</span>
 				<Icon icon={ chevronDown } size={ 22 } />
 			</Button>
+			Cart products count: { cart?.products.length }
 			{ isDomainModalVisible && (
 				<DomainPickerModal onClose={ () => setDomainModalVisibility( false ) } />
 			) }

--- a/apps/full-site-editing/full-site-editing-plugin/editor-domain-picker/src/domain-picker-fse/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-domain-picker/src/domain-picker-fse/index.tsx
@@ -4,6 +4,7 @@
 import * as React from 'react';
 import DomainPicker, { Props as DomainPickerProps } from '@automattic/domain-picker';
 import type { DomainSuggestions } from '@automattic/data-stores';
+//import { Cart } from '@automattic/wpcom-hooks';
 
 /**
  * Internal dependencies
@@ -19,6 +20,9 @@ const DomainPickerFSE: React.FunctionComponent< Props > = ( props ) => {
 	const [ domainSearch, setDomainSearch ] = React.useState( '' );
 
 	const site = useSite();
+
+	//const [ cart, setCart ] = Cart.useSiteCart?.( site?.ID );
+
 	const currentDomain = useCurrentDomain();
 
 	const search = ( domainSearch.trim() || site?.name ) ?? '';

--- a/apps/full-site-editing/full-site-editing-plugin/editor-domain-picker/src/domain-picker-fse/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-domain-picker/src/domain-picker-fse/index.tsx
@@ -4,7 +4,7 @@
 import * as React from 'react';
 import DomainPicker, { Props as DomainPickerProps } from '@automattic/domain-picker';
 import type { DomainSuggestions } from '@automattic/data-stores';
-//import { Cart } from '@automattic/wpcom-hooks';
+import { Cart } from '@automattic/wpcom-hooks';
 
 /**
  * Internal dependencies
@@ -16,12 +16,19 @@ const FLOW_ID = 'gutenboarding';
 
 export type Props = Partial< DomainPickerProps >;
 
+let a = 1;
+
 const DomainPickerFSE: React.FunctionComponent< Props > = ( props ) => {
 	const [ domainSearch, setDomainSearch ] = React.useState( '' );
 
 	const site = useSite();
 
-	//const [ cart, setCart ] = Cart.useSiteCart?.( site?.ID );
+	const [ cart, setCart ] = Cart.useSiteCart?.( site?.ID );
+
+	// this hacky logic is just to test both reading and writing functionalities of the hook in the PR
+	if ( cart && a-- ) {
+		setCart( cart );
+	}
 
 	const currentDomain = useCurrentDomain();
 

--- a/apps/full-site-editing/full-site-editing-plugin/editor-domain-picker/src/domain-picker-fse/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-domain-picker/src/domain-picker-fse/index.tsx
@@ -16,19 +16,12 @@ const FLOW_ID = 'gutenboarding';
 
 export type Props = Partial< DomainPickerProps >;
 
-let a = 1;
-
 const DomainPickerFSE: React.FunctionComponent< Props > = ( props ) => {
 	const [ domainSearch, setDomainSearch ] = React.useState( '' );
 
 	const site = useSite();
 
 	const [ cart, setCart ] = Cart.useSiteCart?.( site?.ID );
-
-	// this hacky logic is just to test both reading and writing functionalities of the hook in the PR
-	if ( cart && a-- ) {
-		setCart( cart );
-	}
 
 	const currentDomain = useCurrentDomain();
 
@@ -41,6 +34,21 @@ const DomainPickerFSE: React.FunctionComponent< Props > = ( props ) => {
 		// TODO: store whole domain suggestion object here because it has product_id and other useful info
 		// that we need for the cart
 		setDomainName( domain?.domain_name );
+
+		const domainProduct = {
+			meta: domain?.domain_name,
+			product_id: domain?.product_id,
+			extra: {
+				privacy_available: domain?.supports_privacy,
+				privacy: domain?.supports_privacy,
+				source: 'gutenboarding',
+			},
+		};
+
+		setCart( {
+			...cart,
+			products: [ domainProduct ],
+		} as Cart.Cart );
 	};
 
 	return (

--- a/apps/full-site-editing/full-site-editing-plugin/editor-plans-grid/src/plans-grid-button/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-plans-grid/src/plans-grid-button/index.tsx
@@ -5,6 +5,9 @@ import * as React from 'react';
 import { Button } from '@wordpress/components';
 import { Icon, chevronDown } from '@wordpress/icons';
 import 'a8c-fse-common-data-stores';
+import { useSite } from '../../../editor-domain-picker/src/hooks/use-current-domain';
+
+import { Cart } from '@automattic/wpcom-hooks';
 
 /**
  * Internal dependencies
@@ -15,6 +18,9 @@ import { useSelectedPlan } from '../hooks/use-selected-plan';
 const PlansGridButton = () => {
 	const [ isPlansModalVisible, setPlansModalVisibility ] = React.useState( false );
 	const currentPlan = useSelectedPlan();
+	const site = useSite();
+
+	const [ cart, setCart ] = Cart.useSiteCart?.( site?.ID );
 
 	return (
 		<>
@@ -26,6 +32,17 @@ const PlansGridButton = () => {
 			>
 				<span>Plans: { currentPlan?.title }</span>
 				<Icon icon={ chevronDown } size={ 22 } />
+			</Button>
+			Cart products count (different React tree): { cart?.products.length }
+			<Button
+				onClick={ () => {
+					setCart( {
+						...cart,
+						products: [],
+					} as Cart.Cart );
+				} }
+			>
+				Clear cart
 			</Button>
 			{ isPlansModalVisible && <PlansModal onClose={ () => setPlansModalVisibility( false ) } /> }
 		</>

--- a/apps/full-site-editing/package.json
+++ b/apps/full-site-editing/package.json
@@ -98,6 +98,7 @@
 		"@automattic/domain-picker": "^1.0.0-alpha.0",
 		"@automattic/format-currency": "^1.0.0-alpha.0",
 		"@automattic/plans-grid": "^1.0.0-alpha.0",
+		"@automattic/wpcom-hooks": "^1.0.0-alpha.0",
 		"@wordpress/api-fetch": "*",
 		"@wordpress/base-styles": "1.9.0",
 		"@wordpress/block-editor": "*",

--- a/client/package.json
+++ b/client/package.json
@@ -32,6 +32,7 @@
 		"@automattic/tree-select": "^1.0.3",
 		"@automattic/viewport": "^1.0.0",
 		"@automattic/viewport-react": "^1.0.0",
+		"@automattic/wpcom-hooks": "^1.0.0-alpha.0",
 		"@babel/runtime": "^7.9.2",
 		"@emotion/core": "^10.0.27",
 		"@emotion/styled": "^10.0.27",

--- a/packages/wpcom-hooks/.eslintrc.js
+++ b/packages/wpcom-hooks/.eslintrc.js
@@ -1,0 +1,21 @@
+const path = require( 'path' );
+
+module.exports = {
+	env: {
+		browser: true,
+	},
+	rules: {
+		'import/no-extraneous-dependencies': [ 'error', { packageDir: __dirname } ],
+	},
+	overrides: [
+		{
+			files: [ '**/test/**/*' ],
+			rules: {
+				'import/no-extraneous-dependencies': [
+					'error',
+					{ packageDir: [ __dirname, path.join( __dirname, '..', '..' ) ] },
+				],
+			},
+		},
+	],
+};

--- a/packages/wpcom-hooks/CHANGELOG.md
+++ b/packages/wpcom-hooks/CHANGELOG.md
@@ -1,0 +1,3 @@
+# 1.0.0-alpha.0
+
+- Initial prerelease

--- a/packages/wpcom-hooks/README.md
+++ b/packages/wpcom-hooks/README.md
@@ -1,0 +1,3 @@
+# WPCOM React hooks
+
+A useful collection of React hooks than can be useful when dealing with WPCOM APIs.

--- a/packages/wpcom-hooks/README.md
+++ b/packages/wpcom-hooks/README.md
@@ -1,3 +1,29 @@
 # WPCOM React hooks
 
 A useful collection of React hooks than can be useful when dealing with WPCOM APIs.
+
+## Hooks list
+
+### `useSiteCart`
+
+React hook that asynchronously syncs the cart with the server. You can use it similar to the way you use `useState`. e.g
+
+```js
+const [ cart, setCart ] = Cart.useSiteCart( siteID );
+```
+
+`setCart` returns a promise that resolves to the server version of the cart (the up-to-date one).
+
+**Caveat**: it can only be used in a signed in site (eg. in wp-admin).
+
+#### Usage
+
+```jsx
+import { Cart } from '@automattic/wpcom-hooks';
+
+function RenderCartProduct({ siteID }) {
+    const [cart] = Cart.useSiteCart(siteID);
+
+    return cart?.products.map(p => <li>{p.name}</li>);
+}
+```

--- a/packages/wpcom-hooks/jest.config.js
+++ b/packages/wpcom-hooks/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	preset: '@automattic/calypso-build',
+	rootDir: __dirname,
+	setupFiles: [ 'regenerator-runtime/runtime' ],
+};

--- a/packages/wpcom-hooks/package.json
+++ b/packages/wpcom-hooks/package.json
@@ -1,0 +1,49 @@
+{
+	"name": "@automattic/wpcom-hooks",
+	"version": "1.0.0-alpha.0",
+	"description": "React hooks than can be useful when dealing with WPCOM APIs",
+	"homepage": "https://github.com/Automattic/wp-calypso",
+	"license": "GPL-2.0-or-later",
+	"author": "Automattic Inc.",
+	"main": "dist/cjs/index.js",
+	"module": "dist/esm/index.js",
+	"sideEffects": false,
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/Automattic/wp-calypso.git",
+		"directory": "packages/wpcom-hooks"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"bugs": {
+		"url": "https://github.com/Automattic/wp-calypso/issues"
+	},
+	"files": [
+		"dist",
+		"src"
+	],
+	"types": "dist/types",
+	"scripts": {
+		"clean": "check-npm-client && npx rimraf dist \"../../.tsc-cache/packages__wpcom-hooks*\"",
+		"prepare": "check-npm-client && tsc --project ./tsconfig.json && tsc --project ./tsconfig-cjs.json",
+		"prepublish": "check-npm-client && yarn run clean",
+		"watch": "check-npm-client && tsc --project ./tsconfig.json --watch"
+	},
+	"dependencies": {
+		"@wordpress/api-fetch": "^3.18.0",
+		"@wordpress/url": "^2.8.2",
+		"fast-json-stable-stringify": "^2.1.0",
+		"i18n-calypso": "^5.0.0",
+		"qs": "^6.9.1",
+		"react": "^16.12.0",
+		"redux": "^4.0.5",
+		"tslib": "^1.10.0",
+		"utility-types": "^3.10.0",
+		"wpcom": "^6.0.0",
+		"wpcom-proxy-request": "^6.0.0"
+	},
+	"peerDependencies": {
+		"@wordpress/data": "^4"
+	}
+}

--- a/packages/wpcom-hooks/src/cart/index.ts
+++ b/packages/wpcom-hooks/src/cart/index.ts
@@ -5,30 +5,106 @@ import React from 'react';
 import WPCOM from 'wpcom';
 import apiFetch from '@wordpress/api-fetch';
 
-export function useSiteCart( siteId: string ) {
-	const [ cart, setCart ] = React.useState( 0 );
+const wpcom = new WPCOM( undefined, apiFetch );
+
+export interface Cart {
+	blog_id: number;
+	cart_key: number;
+	coupon: string;
+	coupon_discounts: unknown[];
+	coupon_discounts_integer: number[];
+	coupon_discounts_display: unknown[];
+	is_coupon_applied: boolean;
+	has_bundle_credit: boolean;
+	next_domain_is_free: boolean;
+	next_domain_condition: string;
+	products: unknown[];
+	total_cost: number;
+	currency: string;
+	total_cost_display: string;
+	total_cost_integer: number;
+	temporary: boolean;
+	tax: Tax;
+	savings_total: number;
+	savings_total_display: string;
+	savings_total_integer: number;
+	coupon_savings_total: number;
+	coupon_savings_total_display: string;
+	coupon_savings_total_integer: number;
+	sub_total: number;
+	sub_total_display: string;
+	sub_total_integer: number;
+	total_tax: number;
+	total_tax_display: string;
+	total_tax_integer: number;
+	credits: number;
+	credits_display: string;
+	credits_integer: number;
+	allowed_payment_methods: string[];
+	create_new_blog: boolean;
+	messages: Messages;
+}
+
+export interface Messages {
+	errors: unknown[];
+	success: unknown[];
+}
+
+export interface Tax {
+	location: unknown[];
+	display_taxes: boolean;
+}
+
+/**
+ * React hook that asynchronously syncs the cart with the server
+ * You can use it similar to the way you use useState. e.g [cart, setCart] = useSiteCart(ID).
+ * setCart returns a promise that resolves to the server's cart
+ *
+ * Caveat: it can only be used in a signed in site (eg. in wp-admin).
+ *
+ * @param siteId the site id
+ */
+export function useSiteCart(
+	siteId: string
+): [ Cart | undefined, ( newCart: Cart ) => Promise< Cart > ] {
+	const [ cart, setLocalCart ] = React.useState< Cart >();
 	const [ updateTick, setUpdateTick ] = React.useState( 1 );
 
 	React.useEffect( () => {
-		const wpcom = new WPCOM( undefined, apiFetch );
-		( async function () {
-			const serverCart = await wpcom.sendRequest(
+		wpcom
+			.sendRequest(
 				{
 					global: true, // needed when used in wp-admin, otherwise wp-admin will add site-prefix (search for wpcomFetchAddSitePrefix)
 					url: `https://public-api.wordpress.com/rest/v1/sites/${ siteId }/shopping-cart`,
 					mode: 'cors',
-					credentials: 'omit',
 				},
-				() => 0
-			);
-			setCart( serverCart );
-		} )();
+				() => 0 // sendRequest requires a callback even though it returns a promise
+			)
+			.then( setLocalCart );
 	}, [ siteId, updateTick ] );
 
-	async function publicSetCart( newCart: number ) {
-		setCart( newCart );
-		setUpdateTick( ( tick ) => tick++ );
+	function setCart( newCart: Cart ) {
+		// optimistically set the cart
+		setLocalCart( newCart );
+
+		// sync with server
+		return wpcom
+			.sendRequest(
+				{
+					method: 'POST',
+					global: true, // needed when used in wp-admin, otherwise wp-admin will add site-prefix (search for wpcomFetchAddSitePrefix)
+					url: `https://public-api.wordpress.com/rest/v1/sites/${ siteId }/shopping-cart`,
+					mode: 'cors',
+					data: newCart,
+				},
+				() => 0 // sendRequest requires a callback even though it returns a promise
+			)
+			.then( ( serverCart: Cart ) => {
+				setLocalCart( serverCart );
+				setUpdateTick( ( tick ) => tick++ );
+				return serverCart;
+			} );
 	}
 
-	return [ cart, publicSetCart ];
+	return [ cart, setCart ];
 }

--- a/packages/wpcom-hooks/src/cart/index.ts
+++ b/packages/wpcom-hooks/src/cart/index.ts
@@ -1,0 +1,34 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import WPCOM from 'wpcom';
+import apiFetch from '@wordpress/api-fetch';
+
+export function useSiteCart( siteId: string ) {
+	const [ cart, setCart ] = React.useState( 0 );
+	const [ updateTick, setUpdateTick ] = React.useState( 1 );
+
+	React.useEffect( () => {
+		const wpcom = new WPCOM( undefined, apiFetch );
+		( async function () {
+			const serverCart = await wpcom.sendRequest(
+				{
+					global: true, // needed when used in wp-admin, otherwise wp-admin will add site-prefix (search for wpcomFetchAddSitePrefix)
+					url: `https://public-api.wordpress.com/rest/v1/sites/${ siteId }/shopping-cart`,
+					mode: 'cors',
+					credentials: 'omit',
+				},
+				() => 0
+			);
+			setCart( serverCart );
+		} )();
+	}, [ siteId, updateTick ] );
+
+	async function publicSetCart( newCart: number ) {
+		setCart( newCart );
+		setUpdateTick( ( tick ) => tick++ );
+	}
+
+	return [ cart, publicSetCart ];
+}

--- a/packages/wpcom-hooks/src/index.ts
+++ b/packages/wpcom-hooks/src/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Internal dependencies
+ */
+import * as Cart from './cart';
+
+export { Cart };

--- a/packages/wpcom-hooks/tsconfig-cjs.json
+++ b/packages/wpcom-hooks/tsconfig-cjs.json
@@ -1,0 +1,14 @@
+{
+	"extends": "./tsconfig",
+	"compilerOptions": {
+		"module": "commonjs",
+		"declaration": false,
+		"declarationMap": false,
+		"declarationDir": null,
+		"outDir": "dist/cjs",
+		"composite": false,
+		"incremental": true,
+
+		"tsBuildInfoFile": "../../.tsc-cache/packages__data-stores--cjs"
+	}
+}

--- a/packages/wpcom-hooks/tsconfig.json
+++ b/packages/wpcom-hooks/tsconfig.json
@@ -1,0 +1,39 @@
+{
+	"compilerOptions": {
+		"target": "ES5",
+		"lib": [ "DOM", "ES2015", "ScriptHost" ],
+		"module": "ESNEXT",
+		"allowJs": false,
+		"jsx": "react",
+		"declaration": true,
+		"declarationMap": true,
+		"declarationDir": "dist/types",
+		"rootDir": "src",
+		"outDir": "dist/esm",
+
+		"strict": true,
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"noImplicitReturns": true,
+		"noFallthroughCasesInSwitch": true,
+
+		"moduleResolution": "node",
+		"esModuleInterop": true,
+		"downlevelIteration": true,
+
+		"forceConsistentCasingInFileNames": true,
+
+		"importsNotUsedAsValues": "error",
+
+		"typeRoots": [ "../../node_modules/@types" ],
+		"types": [],
+
+		"noEmitHelpers": true,
+		"importHelpers": true,
+
+		"composite": true,
+		"tsBuildInfoFile": "../../.tsc-cache/packages__data-stores"
+	},
+	"include": [ "src" ],
+	"exclude": [ "**/docs/*", "**/test/*" ]
+}

--- a/packages/wpcom.js/index.d.ts
+++ b/packages/wpcom.js/index.d.ts
@@ -1,0 +1,1 @@
+declare module 'wpcom';

--- a/packages/wpcom.js/package.json
+++ b/packages/wpcom.js/package.json
@@ -6,6 +6,7 @@
 	"module": "dist/esm/index.js",
 	"author": "Automattic, Inc.",
 	"private": true,
+	"types": "./index.d.ts",
 	"scripts": {
 		"clean": "check-npm-client && npx rimraf dist",
 		"prepublish": "check-npm-client && yarn run clean",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

1. This PR creates a new package called `wpcom-hooks`. This package is meant to have a collection of useful React hooks that deal with wpcom API.

2. It starts with adding a React hook that fetches and syncs local and remote cart versions with the server (`useSiteCart`). I think it's a pretty elegant solution to deal with the cart in wp-admin. 

#### Note 💡 
All the code in FSE is throwaway code. It's just meant to test the functionality. Most of the reviewing scrutiny should be for this `packages/wpcom-hooks/src/cart/index.ts` file.

This also means you shouldn't worry about the conflicts listed below (they're all in FSE).

#### Testing functionality
1. Spin up an FSE env.
2. Go to wp-admin/post-new.php.
3. On the top banner, you should see three new things:

`Cart products count (different React tree): 0`
`Cart products count: 0`
`Clear cart`

All these points are using the hook. They belong to different React apps (trees), yet when any one of them calls `setCart` all three should re-render with the new information. 
4. To test this, open the domain picker and pick a domain. The products count should change to 1 everywhere (assuming you start with 0). 
5. Click "Clear cart" and the count should be 0 everywhere too. 
6. If you refresh the page at any point, the state should be preserved.

#### Testing network requests

1. Open DevTools > Network and filter for "shoppping-cart".
2. Go to wp-admin/post-new.php. You should see a GET request for the cart.
3. Pick a domain, you should see a POST request that contains the domain you picked. 


Once approved, I'll remove all the FSE code I added. 
