### PR TITLE
Jetpack Connection: clear the plan selection cookie after redirect to checkout during JPC

### DIFF
--- a/client/jetpack-connect/jetpack-connection.jsx
+++ b/client/jetpack-connect/jetpack-connection.jsx
@@ -22,7 +22,7 @@ import { addQueryArgs, externalRedirect } from 'lib/route';
 import { checkUrl, dismissUrl } from 'state/jetpack-connect/actions';
 import { getConnectingSite, getJetpackSiteByUrl } from 'state/jetpack-connect/selectors';
 import { isRequestingSites } from 'state/sites/selectors';
-import { retrieveMobileRedirect, retrievePlan } from './persistence-utils';
+import { clearPlan, retrieveMobileRedirect, retrievePlan } from './persistence-utils';
 import { recordTracksEvent } from 'state/analytics/actions';
 
 import { IS_DOT_COM_GET_SEARCH, MINIMUM_JETPACK_VERSION } from './constants';
@@ -92,6 +92,7 @@ const jetpackConnection = ( WrappedComponent ) => {
 
 			if ( status === ALREADY_CONNECTED && ! this.state.redirecting ) {
 				const currentPlan = retrievePlan();
+				clearPlan();
 				if ( currentPlan ) {
 					this.redirect( 'checkout', url, currentPlan );
 				} else {


### PR DESCRIPTION

It is an Appendix to https://github.com/Automattic/wp-calypso/pull/43956, addressing[ the comment](https://github.com/Automattic/wp-calypso/pull/43956#issuecomment-655148024) regarding plan retrieval info.


#### Changes proposed in this Pull Request

* Clear the plan info to avoid reusing this information at the subsequent connection attempt.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

For a connected JP site, within a single browser session:

* initiate plan purchase at `/jetpack/connect/pro`
* verify the presence of the plan in cart at `/checkout` 
* initiate connection without plan selection at `/jetpack/connect`
* verify redirect to the canonical JP plans grid 

