### PR TITLE
Rollback Signup test: Use Passwordless signup after Plans step #43061

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -23,6 +23,7 @@ import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
+import { abtest } from 'lib/abtest';
 
 /**
  * Internal dependencies
@@ -769,14 +770,6 @@ class SignupForm extends Component {
 		return <p className="signup-form__terms-of-service-link">{ tosText }</p>;
 	};
 
-	getExplanation = () => {
-		return (
-			<p className="signup-form__terms-of-service-link signup-form__terms-of-service-link-is-explanation-text">
-				{ this.props.explanationText }
-			</p>
-		);
-	};
-
 	getNotice() {
 		if ( this.props.step && 'invalid' === this.props.step.status ) {
 			return this.globalNotice( this.props.step.errors[ 0 ] );
@@ -859,16 +852,14 @@ class SignupForm extends Component {
 			? this.getLoginLink()
 			: localizeUrl( config( 'login_url' ), this.props.locale );
 
-		const loginTextByFlowName =
-			flowName === 'onboarding'
-				? translate( 'Log in to create a site for your existing account.' )
-				: translate( 'Already have a WordPress.com account?' );
-
-		const footerLoginText = this.props.footerLoginText || loginTextByFlowName;
 		return (
 			<>
 				<LoggedOutFormLinks>
-					<LoggedOutFormLinkItem href={ logInUrl }>{ footerLoginText }</LoggedOutFormLinkItem>
+					<LoggedOutFormLinkItem href={ logInUrl }>
+						{ flowName === 'onboarding'
+							? translate( 'Log in to create a site for your existing account.' )
+							: translate( 'Already have a WordPress.com account?' ) }
+					</LoggedOutFormLinkItem>
 					{ this.props.oauth2Client && (
 						<LoggedOutFormBackLink
 							oauth2Client={ this.props.oauth2Client }
@@ -972,51 +963,27 @@ class SignupForm extends Component {
 				</div>
 			);
 		}
+
 		/*
-			AB Test: passwordlessAfterPlans
 
-			`<PasswordlessSignupForm />` is for the `onboarding-passwordless` flow.
+			AB Test: passwordlessSignup
 
-			We are testing whether a having a passwordless account creation after domain and plans, improves signup rate in the `onboarding` flow
+			`<PasswordlessSignupForm />` is for the `onboarding` flow.
+
+			We are testing whether a passwordless account creation and login improves signup rate in the `onboarding` flow
 		*/
-		const isPasswordlessAfterPlans = 'onboarding-passwordless' === this.props.flowName;
-
-		if ( isPasswordlessAfterPlans ) {
+		if (
+			( this.props.flowName === 'onboarding' || this.props.flowName === 'test-fse' ) &&
+			'passwordless' === abtest( 'passwordlessSignup' )
+		) {
 			const logInUrl = config.isEnabled( 'login/native-login-links' )
 				? this.getLoginLink()
 				: localizeUrl( config( 'login_url' ), this.props.locale );
-			const textProps = pick( this.props, [
-				'submittingButtonText',
-				'defaultButtonText',
-				'headerText',
-				'subHeaderText',
-				'emailInputLabel',
-			] );
-
-			const isFreePlan = this.props.signupDependencies && ! this.props.signupDependencies.cartItem;
-			if ( isFreePlan ) {
-				textProps.submittingButtonText =
-					this.props.freeSubmittingButtonText || textProps.submittingButtonText;
-				textProps.defaultButtonText =
-					this.props.freeDefaultButtonText || textProps.defaultButtonText;
-			}
-
-			const socialTextProps = pick( this.props, [
-				'socialAlternativeText',
-				'socialTosText',
-				'socialGoogleLabel',
-				'socialAppleLabel',
-			] );
-
-			const renderTerms = this.props.explanationText
-				? this.getExplanation
-				: this.termsOfServiceLink;
 
 			return (
 				<div
 					className={ classNames( 'signup-form', this.props.className, {
 						'is-showing-recaptcha-tos': this.props.showRecaptchaToS,
-						'is-passwordless-after-plans': isPasswordlessAfterPlans,
 					} ) }
 				>
 					{ this.getNotice() }
@@ -1025,19 +992,17 @@ class SignupForm extends Component {
 						stepName={ this.props.stepName }
 						flowName={ this.props.flowName }
 						goToNextStep={ this.props.goToNextStep }
-						renderTerms={ renderTerms }
+						renderTerms={ this.termsOfServiceLink }
 						logInUrl={ logInUrl }
 						disabled={ this.props.disabled }
 						disableSubmitButton={ this.props.disableSubmitButton }
 						recaptchaClientId={ this.props.recaptchaClientId }
-						{ ...textProps }
 					/>
 					{ this.props.isSocialSignupEnabled && ! this.userCreationComplete() && (
 						<SocialSignupForm
 							handleResponse={ this.props.handleSocialResponse }
 							socialService={ this.props.socialService }
 							socialServiceResponse={ this.props.socialServiceResponse }
-							{ ...socialTextProps }
 						/>
 					) }
 

--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -155,7 +155,6 @@ class PasswordlessSignupForm extends Component {
 		this.submitStep( {
 			username,
 			bearer_token: response.bearer_token,
-			marketing_price_group: response?.marketing_price_group ?? '',
 		} );
 	};
 
@@ -239,13 +238,9 @@ class PasswordlessSignupForm extends Component {
 				</LoggedOutFormFooter>
 			);
 		}
-
-		const defaultButtonText =
-			this.props.defaultButtonText || this.props.translate( 'Create your account' );
-		const submittingButtonText =
-			this.props.submittingButtonText || this.props.translate( 'Creating Your Account…' );
-
-		const submitButtonText = isSubmitting ? submittingButtonText : defaultButtonText;
+		const submitButtonText = isSubmitting
+			? this.props.translate( 'Creating Your Account…' )
+			: this.props.translate( 'Create your account' );
 		return (
 			<LoggedOutFormFooter>
 				<Button
@@ -269,12 +264,11 @@ class PasswordlessSignupForm extends Component {
 		const { translate } = this.props;
 		const { errorMessages, isSubmitting } = this.state;
 
-		const emailInputLabel = this.props.emailInputLabel || translate( 'Enter your email address' );
 		return (
 			<div className="signup-form__passwordless-form-wrapper">
 				<LoggedOutForm onSubmit={ this.onFormSubmit } noValidate>
 					<ValidationFieldset errorMessages={ errorMessages }>
-						<FormLabel htmlFor="email">{ emailInputLabel }</FormLabel>
+						<FormLabel htmlFor="email">{ translate( 'Enter your email address' ) }</FormLabel>
 						<FormTextInput
 							autoCapitalize={ 'off' }
 							className="signup-form__passwordless-email"

--- a/client/blocks/signup-form/social.jsx
+++ b/client/blocks/signup-form/social.jsx
@@ -88,11 +88,12 @@ class SocialSignupForm extends Component {
 		const host = typeof window !== 'undefined' && window.location.host;
 		const redirectUri = `https://${ host }/start/user`;
 		const uxModeApple = config.isEnabled( 'sign-in-with-apple/redirect' ) ? 'redirect' : uxMode;
-		const alternativeText =
-			this.props.socialAlternativeText || this.props.translate( 'Or create an account using:' );
+
 		return (
 			<div className="signup-form__social">
-				{ ! this.props.compact && <p>{ preventWidows( alternativeText ) }</p> }
+				{ ! this.props.compact && (
+					<p>{ preventWidows( this.props.translate( 'Or create an account using:' ) ) }</p>
+				) }
 
 				<div className="signup-form__social-buttons">
 					<GoogleLoginButton
@@ -101,7 +102,6 @@ class SocialSignupForm extends Component {
 						uxMode={ uxMode }
 						redirectUri={ redirectUri }
 						onClick={ () => this.trackSocialLogin( 'google' ) }
-						label={ this.props.socialGoogleLabel }
 						socialServiceResponse={
 							this.props.socialService === 'google' ? this.props.socialServiceResponse : null
 						}
@@ -113,30 +113,28 @@ class SocialSignupForm extends Component {
 						uxMode={ uxModeApple }
 						redirectUri={ redirectUri }
 						onClick={ () => this.trackSocialLogin( 'apple' ) }
-						label={ this.props.socialAppleLabel }
 						socialServiceResponse={
 							this.props.socialService === 'apple' ? this.props.socialServiceResponse : null
 						}
 					/>
 
 					<p className="signup-form__social-buttons-tos">
-						{ this.props.socialTosText ||
-							this.props.translate(
-								"If you continue with Google or Apple and don't already have a WordPress.com account, you" +
-									' are creating an account and you agree to our' +
-									' {{a}}Terms of Service{{/a}}.',
-								{
-									components: {
-										a: (
-											<a
-												href={ localizeUrl( 'https://wordpress.com/tos/' ) }
-												target="_blank"
-												rel="noopener noreferrer"
-											/>
-										),
-									},
-								}
-							) }
+						{ this.props.translate(
+							"If you continue with Google or Apple and don't already have a WordPress.com account, you" +
+								' are creating an account and you agree to our' +
+								' {{a}}Terms of Service{{/a}}.',
+							{
+								components: {
+									a: (
+										<a
+											href={ localizeUrl( 'https://wordpress.com/tos/' ) }
+											target="_blank"
+											rel="noopener noreferrer"
+										/>
+									),
+								},
+							}
+						) }
 					</p>
 				</div>
 			</div>

--- a/client/blocks/signup-form/style.scss
+++ b/client/blocks/signup-form/style.scss
@@ -91,30 +91,6 @@
 	}
 }
 
-.signup-form.is-showing-recaptcha-tos {
-	.signup-form__terms-of-service-link {
-		margin: 25px 0 0;
-	}
-}
-
-.signup-form.is-passwordless-after-plans {
-	.social-buttons__button {
-		background: none;
-		border: none;
-		width: 50%;
-		box-shadow: none;
-		float: left;
-		color: var( --color-text-inverted );
-		text-decoration: underline;
-		margin-bottom: 30px;
-	}
-	.signup-form__social-buttons-tos {
-		font-size: 12px;
-		margin: 5px 0;
-		clear: both;
-	}
-}
-
 // Replace recaptcha badge with ToS text and space
 // everything out a little more.
 @media ( max-width: 660px ) {

--- a/client/components/social-buttons/apple.js
+++ b/client/components/social-buttons/apple.js
@@ -36,14 +36,12 @@ class AppleLoginButton extends Component {
 		scope: PropTypes.string,
 		uxMode: PropTypes.oneOf( [ 'redirect', 'popup' ] ),
 		socialServiceResponse: PropTypes.object,
-		label: PropTypes.string,
 	};
 
 	static defaultProps = {
 		onClick: noop,
 		scope: 'name email',
 		uxMode: 'popup',
-		label: '',
 	};
 
 	appleClient = null;
@@ -153,12 +151,11 @@ class AppleLoginButton extends Component {
 						<AppleIcon isDisabled={ isDisabled } />
 
 						<span className="social-buttons__service-name">
-							{ this.props.label ||
-								this.props.translate( 'Continue with %(service)s', {
-									args: { service: 'Apple' },
-									comment:
-										'%(service)s is the name of a third-party authentication provider, e.g. "Google", "Facebook", "Apple" ...',
-								} ) }
+							{ this.props.translate( 'Continue with %(service)s', {
+								args: { service: 'Apple' },
+								comment:
+									'%(service)s is the name of a third-party authentication provider, e.g. "Google", "Facebook", "Apple" ...',
+							} ) }
 						</span>
 					</button>
 				) }

--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -37,14 +37,12 @@ class GoogleLoginButton extends Component {
 		scope: PropTypes.string,
 		translate: PropTypes.func.isRequired,
 		uxMode: PropTypes.string,
-		label: PropTypes.string,
 	};
 
 	static defaultProps = {
 		scope: 'https://www.googleapis.com/auth/userinfo.profile',
 		fetchBasicProfile: true,
 		onClick: noop,
-		label: '',
 	};
 
 	state = {
@@ -222,12 +220,11 @@ class GoogleLoginButton extends Component {
 						<GoogleIcon isDisabled={ isDisabled } />
 
 						<span className="social-buttons__service-name">
-							{ this.props.label ||
-								this.props.translate( 'Continue with %(service)s', {
-									args: { service: 'Google' },
-									comment:
-										'%(service)s is the name of a third-party authentication provider, e.g. "Google", "Facebook", "Apple" ...',
-								} ) }
+							{ this.props.translate( 'Continue with %(service)s', {
+								args: { service: 'Google' },
+								comment:
+									'%(service)s is the name of a third-party authentication provider, e.g. "Google", "Facebook", "Apple" ...',
+							} ) }
 						</span>
 					</button>
 				) }

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -148,16 +148,6 @@ export default {
 		allowExistingUsers: false,
 		countryCodeTargets: [ 'US' ],
 	},
-	passwordlessAfterPlans: {
-		datestamp: '20200618',
-		variations: {
-			variantPasswordless: 0,
-			control: 100,
-		},
-		defaultVariation: 'control',
-		allowExistingUsers: true,
-		countryCodeTargets: [ 'US' ],
-	},
 	showBusinessPlanBump: {
 		datestamp: '20200619',
 		variations: {

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -125,15 +125,6 @@ export function generateFlows( {
 			showRecaptcha: true,
 		},
 
-		'onboarding-passwordless': {
-			steps: [ 'domains', 'plans', 'user-passwordless' ],
-			destination: getSignupDestination,
-			description:
-				'Simplify the User step (account creation step) and move it right before the Checkout, after Plans/Domains steps. Read more in https://wp.me/pbxNRc-m0',
-			lastModified: '2020-06-17',
-			showRecaptcha: true,
-		},
-
 		desktop: {
 			steps: [ 'about', 'themes', 'domains', 'plans', 'user' ],
 			destination: getSignupDestination,

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -52,7 +52,6 @@ const stepNameToModuleName = {
 	'template-first-themes': 'theme-selection',
 	'fse-themes': 'theme-selection',
 	user: 'user',
-	'user-passwordless': 'user',
 	'oauth2-user': 'user',
 	'oauth2-name': 'user',
 	displayname: 'user',

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import React from 'react';
 import { noop } from 'lodash';
 import i18n from 'i18n-calypso';
 
@@ -150,42 +149,6 @@ export function generateSteps( {
 			providesDependencies: [ 'bearer_token', 'username', 'marketing_price_group' ],
 			props: {
 				isSocialSignupEnabled: config.isEnabled( 'signup/social' ),
-			},
-		},
-
-		'user-passwordless': {
-			stepName: 'user-passwordless',
-			apiRequestFunction: createAccount,
-			providesToken: true,
-			providesDependencies: [ 'bearer_token', 'username', 'marketing_price_group' ],
-			props: {
-				isSocialSignupEnabled: config.isEnabled( 'signup/social' ),
-				// Flow is to be use on English locale only, no need to translate labels
-				fallbackHeaderText: "Let's do this",
-				fallbackSubHeaderText: "You're one step away to get going with your site",
-				submittingButtonText: 'Go to Checkout »',
-				defaultButtonText: 'Go to Checkout »',
-				freeSubmittingButtonText: 'Continue »',
-				freeDefaultButtonText: 'Continue »',
-				emailInputLabel: 'Your email address',
-
-				// Used translations to insert html
-				explanationText:
-					"You'll be able to log in to your account using this address. You can also set a password later.",
-				socialAlternativeText: 'Or continue using:',
-
-				// Used translations to insert html
-				socialTosText: i18n.translate(
-					'By proceeding, you agree to our {{a}}Terms of Service{{/a}}.',
-					{
-						components: {
-							a: <a href="https://wordpress.com/tos/" target="_blank" rel="noopener noreferrer" />,
-						},
-					}
-				),
-				footerLoginText: 'Already have an account? Log in',
-				socialGoogleLabel: 'Google',
-				socialAppleLabel: 'Apple',
 			},
 		},
 

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -84,7 +84,6 @@ export default {
 		} else if (
 			context.pathname.indexOf( 'domain' ) >= 0 ||
 			context.pathname.indexOf( 'plan' ) >= 0 ||
-			context.pathname.indexOf( 'onboarding-passwordless' ) >= 0 ||
 			context.pathname.indexOf( 'wpcc' ) >= 0 ||
 			context.pathname.indexOf( 'launch-site' ) >= 0 ||
 			context.params.flowName === 'user' ||
@@ -113,22 +112,6 @@ export default {
 					const countryCode = geo.data.body.country_short;
 					if ( 'gutenberg' === abtest( 'newSiteGutenbergOnboarding', countryCode ) ) {
 						window.location.replace( window.location.origin + '/new' + window.location.search );
-					} else if (
-						-1 === context.pathname.indexOf( 'free' ) &&
-						-1 === context.pathname.indexOf( 'personal' ) &&
-						-1 === context.pathname.indexOf( 'premium' ) &&
-						-1 === context.pathname.indexOf( 'business' ) &&
-						-1 === context.pathname.indexOf( 'ecommerce' ) &&
-						'variantPasswordless' === abtest( 'passwordlessAfterPlans', countryCode )
-					) {
-						const stepName = getStepName( context.params );
-						const stepSectionName = getStepSectionName( context.params );
-						const urlWithoutLocale = getStepUrl(
-							'onboarding-passwordless',
-							stepName,
-							stepSectionName
-						);
-						window.location = urlWithoutLocale;
 					} else {
 						removeWhiteBackground();
 						next();

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -659,10 +659,6 @@ class DomainsStep extends React.Component {
 		const fallbackSubHeaderText = this.getSubHeaderText();
 		const showSkip = isDomainStepSkippable( flowName );
 
-		let hideBack;
-		if ( 'onboarding-passwordless' === flowName && ! this.props.stepSectionName ) {
-			hideBack = true;
-		}
 		return (
 			<StepWrapper
 				flowName={ this.props.flowName }
@@ -683,7 +679,6 @@ class DomainsStep extends React.Component {
 				allowBackFirstStep={ !! backUrl }
 				backLabelText={ backLabelText }
 				hideSkip={ ! showSkip }
-				hideBack={ hideBack }
 				isTopButtons={ showSkip }
 				goToNextStep={ this.handleSkip }
 				skipHeadingText={ translate( 'Not sure yet?' ) }

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -439,12 +439,9 @@ export class UserStep extends Component {
 				flowName={ this.props.flowName }
 				stepName={ this.props.stepName }
 				headerText={ this.getHeaderText() }
-				fallbackHeaderText={
-					this.props.fallbackHeaderText || this.props.translate( 'Create your account.' )
-				}
 				subHeaderText={ this.state.subHeaderText }
-				fallbackSubHeaderText={ this.props.fallbackSubHeaderText }
 				positionInFlow={ this.props.positionInFlow }
+				fallbackHeaderText={ this.props.translate( 'Create your account.' ) }
 				stepContent={ this.renderSignupForm() }
 			/>
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Rolls back changes for 'Passwordless signup after Plans step' experiment pbxNRc-m0-p2

#### Testing instructions

1. Go to /start
2. There **shouldn't** be any 'variantPasswordless' AB test variant and flow **shouldn't** redirect to `/start/onboarding-plans-passwordless/domains`
<img src="https://user-images.githubusercontent.com/2749938/86924363-06861000-c138-11ea-960e-2cd096ce5905.png" width="400">
3. You should be able to complete the flow without errors.
