### PR TITLE
InlineHelp: renders results from cache

### DIFF
--- a/client/blocks/inline-help/inline-help-search-results.jsx
+++ b/client/blocks/inline-help/inline-help-search-results.jsx
@@ -137,7 +137,7 @@ function HelpSearchResults( {
 	};
 
 	const renderSearchResults = () => {
-		if ( isSearching ) {
+		if ( isSearching && ! searchResults.length ) {
 			// reset current section reference.
 			supportTypeRef.current = null;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR checks if there are results in the cache for the current search query. If so, it picks and shows them up immediately. Finally, it performs a request in the second step in order to keep the data synced.

#### Testing instructions

Type different terms in the search box in order to populate the cache. Then, type the same terms and confirm that it renders faster.

![inline-help-cache-results](https://user-images.githubusercontent.com/77539/86930761-bd20cb00-c10d-11ea-91cc-c42f71bf643d.gif)

Confirm that the app performs the requests even if the component renders the results before.

![image](https://user-images.githubusercontent.com/77539/86931798-ebeb7100-c10e-11ea-89b4-329e3dab425c.png)


Switch between the customer home page and the other pages and confirm that the data is persistent between these two components.


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Fixes InlineHelp: pick up results from cache #43990
