### PR TITLE
babel-plugin-i18n-calypso: Fix translate calls comment extraction

### DIFF
--- a/packages/babel-plugin-i18n-calypso/package.json
+++ b/packages/babel-plugin-i18n-calypso/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/babel-plugin-i18n-calypso",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"description": "A Babel plugin to generate a POT file for translate calls",
 	"main": "src/index.js",
 	"dependencies": {

--- a/packages/babel-plugin-i18n-calypso/src/index.js
+++ b/packages/babel-plugin-i18n-calypso/src/index.js
@@ -97,6 +97,10 @@ function getExtractedComment( path, _originalNodeLine ) {
 
 	let comment;
 	forEach( node.leadingComments, ( commentNode ) => {
+		if ( ! commentNode.loc ) {
+			return;
+		}
+
 		const { line } = commentNode.loc.end;
 		if ( line < _originalNodeLine - 1 || line > _originalNodeLine ) {
 			return;


### PR DESCRIPTION
`babel-plugin-i18n-calypso` has started crashing since Babel 7.10.x, as it started adding `#__PURE__` annotations (comment blocks) for `__`. These comments are missing `loc` property and because of that `getExtractedComment` is throwing an error as it's trying to access deep nested properties of it.

#### Changes proposed in this Pull Request

* Exit `getExtractedComment` earlier if comment node is missing `loc` property

#### Testing instructions

* Run `NODE_ENV=build_pot yarn build`. POT files should be compiled in `build/i18n-calypso` without getting errors of `Cannot read property 'end' of undefined` type.