### PR TITLE
Modularise `gutenbergOptInOut` state

### DIFF
--- a/client/state/data-layer/wpcom/sites/gutenberg/index.js
+++ b/client/state/data-layer/wpcom/sites/gutenberg/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import { has, noop } from 'lodash';
 
 /**
@@ -18,7 +17,9 @@ import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { registerHandlers } from 'state/data-layer/handler-registry';
 import { replaceHistory } from 'state/ui/actions';
+
 import 'state/editor-deprecation-group/init';
+import 'state/gutenberg-opt-in-out/init';
 
 const fetchGutenbergOptInData = ( action ) =>
 	http(

--- a/client/state/gutenberg-opt-in-out/init.js
+++ b/client/state/gutenberg-opt-in-out/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'state/redux-store';
+import reducer from './reducer';
+
+registerReducer( [ 'gutenbergOptInOut' ], reducer );

--- a/client/state/gutenberg-opt-in-out/package.json
+++ b/client/state/gutenberg-opt-in-out/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/gutenberg-opt-in-out/reducer.js
+++ b/client/state/gutenberg-opt-in-out/reducer.js
@@ -2,9 +2,11 @@
  * Internal dependencies
  */
 import { GUTENBERG_OPT_IN_OUT_SET } from 'state/action-types';
-import { keyedReducer } from 'state/utils';
+import { keyedReducer, withStorageKey } from 'state/utils';
 
 export const gutenbergOptInOut = ( state, { type, optIn, optOut } ) =>
 	type === GUTENBERG_OPT_IN_OUT_SET ? { optIn, optOut } : state;
 
-export default keyedReducer( 'siteId', gutenbergOptInOut );
+const reducer = keyedReducer( 'siteId', gutenbergOptInOut );
+
+export default withStorageKey( 'gutenbergOptInOut', reducer );

--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -22,7 +22,6 @@ import documentHead from './document-head/reducer';
 import embeds from './embeds/reducer';
 import experiments from './experiments/reducer';
 import gsuiteUsers from './gsuite-users/reducer';
-import gutenbergOptInOut from './gutenberg-opt-in-out/reducer';
 import happychat from './happychat/reducer';
 import help from './help/reducer';
 import home from './home/reducer';
@@ -68,7 +67,6 @@ const reducers = {
 	embeds,
 	experiments,
 	gsuiteUsers,
-	gutenbergOptInOut,
 	happychat,
 	help,
 	home,

--- a/client/state/selectors/is-gutenberg-opt-in-enabled.js
+++ b/client/state/selectors/is-gutenberg-opt-in-enabled.js
@@ -9,6 +9,8 @@ import { get } from 'lodash';
 import getSelectedEditor from 'state/selectors/get-selected-editor';
 import isClassicEditorForced from 'state/selectors/is-classic-editor-forced';
 
+import 'state/gutenberg-opt-in-out/init';
+
 export const isGutenbergOptInEnabled = ( state, siteId ) => {
 	return (
 		get( state, [ 'gutenbergOptInOut', siteId, 'optIn' ], false ) &&

--- a/client/state/selectors/is-gutenberg-opt-out-enabled.js
+++ b/client/state/selectors/is-gutenberg-opt-out-enabled.js
@@ -9,6 +9,8 @@ import { get } from 'lodash';
 import getSelectedEditor from 'state/selectors/get-selected-editor';
 import isClassicEditorForced from 'state/selectors/is-classic-editor-forced';
 
+import 'state/gutenberg-opt-in-out/init';
+
 export const isGutenbergOptOutEnabled = ( state, siteId ) => {
 	return (
 		get( state, [ 'gutenbergOptInOut', siteId, 'optOut' ], false ) &&


### PR DESCRIPTION
This PR is one of many working on modularising state in Calypso. This one handles `gutenbergOptInOut` state.

For more details on state modularisation, see the [modularised state documentation](https://github.com/Automattic/wp-calypso/blob/master/docs/modularized-state.md) and p4TIVU-9lM-p2.

Note: I added all the reviewers that GitHub suggested. Please feel free to ignore the review request or pull in someone else if you're not comfortable reviewing this PR. Thank you!

Fixes #42438.

#### Changes proposed in this Pull Request

* Modularise `gutenbergOptInOut` state.

#### Testing instructions

The lazy loading aspects of this PR aren't easy to test here, since this state seems to be loaded early on by Calypso, as part of other editor-related state.

As for the rest of the functionality, please smoke test Gutenberg opt-in/opt-out state and verify that it continues to work correctly. I couldn't find any issues, but my testing was very limited.