### PR TITLE
Marketing tools: Adding an Earn card to the Marketing Tools page.

### DIFF
--- a/client/my-sites/marketing/tools/index.tsx
+++ b/client/my-sites/marketing/tools/index.tsx
@@ -96,9 +96,7 @@ export const MarketingTools: FunctionComponent< Props > = ( {
 					) }
 					imagePath={ earnIllustration }
 				>
-					<Button onClick={ handleEarnClick } href="https://wp.me/logo-maker">
-						{ translate( 'Start earning' ) }
-					</Button>
+					<Button onClick={ handleEarnClick }>{ translate( 'Start earning' ) }</Button>
 				</MarketingToolsFeature>
 
 				<MarketingToolsFeature

--- a/client/my-sites/marketing/tools/index.tsx
+++ b/client/my-sites/marketing/tools/index.tsx
@@ -17,6 +17,7 @@ import MarketingToolsHeader from './header';
 import { marketingConnections, marketingTraffic } from 'my-sites/marketing/paths';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import { recordTracksEvent as recordTracksEventAction } from 'state/analytics/actions';
+import earnIllustration from 'assets/images/customer-home/illustration--task-earn.svg';
 
 /**
  * Types
@@ -43,6 +44,12 @@ export const MarketingTools: FunctionComponent< Props > = ( {
 		recordTracksEvent( 'calypso_marketing_tools_boost_my_traffic_button_click' );
 
 		page( marketingTraffic( selectedSiteSlug ) );
+	};
+
+	const handleEarnClick = () => {
+		recordTracksEvent( 'calypso_marketing_tools_earn_button_click' );
+
+		page( `/earn/${ selectedSiteSlug }` );
 	};
 
 	const handleCreateALogoClick = () => {
@@ -79,6 +86,18 @@ export const MarketingTools: FunctionComponent< Props > = ( {
 						target="_blank"
 					>
 						{ translate( 'Create a logo' ) }
+					</Button>
+				</MarketingToolsFeature>
+
+				<MarketingToolsFeature
+					title={ translate( 'Build your community, following, and income with Earn tools' ) }
+					description={ translate(
+						'Increase engagement and income on your site by accepting payments for just about anything – physical and digital goods, services, donations, or access to exclusive content.'
+					) }
+					imagePath={ earnIllustration }
+				>
+					<Button onClick={ handleEarnClick } href="https://wp.me/logo-maker">
+						{ translate( 'Start earning' ) }
 					</Button>
 				</MarketingToolsFeature>
 


### PR DESCRIPTION
This PR adds a new card that highlights the Earn features to the Marketing Tools page. Context behind the update is provided on pbMlHh-n1-p2.

Below are screenshots showing the before and after...

Before:
<img width="1008" alt="Screen Shot 2020-07-08 at 12 53 22 PM" src="https://user-images.githubusercontent.com/35781181/86948631-67531f80-c11b-11ea-8bec-a7d6c9b95bad.png">

After:
<img width="1030" alt="Screen Shot 2020-07-08 at 1 58 18 PM" src="https://user-images.githubusercontent.com/35781181/86953898-1cd5a100-c123-11ea-82ca-824cd7528c9e.png">


#### Testing instructions
* Checkout branch (git checkout update/marketing-add-earn-banner)
* Run calypso
* Navigate to the Marketing Tools page (/marketing/tools/:siteSlug)
* Confirm that the Earn banner displays properly
* Click the link and confirm that it takes you to the Earn page.
