### PR TITLE
Media: Replace MediaActions.sourceChanged with redux action

### DIFF
--- a/client/lib/media/actions.js
+++ b/client/lib/media/actions.js
@@ -2,16 +2,12 @@
  * External dependencies
  */
 import { assign } from 'lodash';
-import debugFactory from 'debug';
-const debug = debugFactory( 'calypso:media' );
 
 /**
  * Internal dependencies
  */
 import Dispatcher from 'dispatcher';
-import { reduxDispatch } from 'lib/redux-bridge';
 import MediaStore from './store';
-import { changeMediaSource } from 'state/media/actions';
 
 /**
  * @typedef IMediaActions
@@ -44,15 +40,6 @@ MediaActions.edit = function ( siteId, item ) {
 		siteId: siteId,
 		data: newItem,
 	} );
-};
-
-MediaActions.sourceChanged = function ( siteId ) {
-	debug( 'Media data source changed' );
-	Dispatcher.handleViewAction( {
-		type: 'CHANGE_MEDIA_SOURCE',
-		siteId,
-	} );
-	reduxDispatch( changeMediaSource( siteId ) );
 };
 
 export default MediaActions;

--- a/client/lib/media/test/actions.js
+++ b/client/lib/media/test/actions.js
@@ -102,15 +102,4 @@ describe( 'MediaActions', () => {
 			} );
 		} );
 	} );
-
-	describe( '#sourceChanged()', () => {
-		test( 'should dispatch the `CHANGE_MEDIA_SOURCE` action with the specified siteId', () => {
-			MediaActions.sourceChanged( DUMMY_SITE_ID );
-
-			expect( Dispatcher.handleViewAction ).to.have.been.calledWithMatch( {
-				type: 'CHANGE_MEDIA_SOURCE',
-				siteId: DUMMY_SITE_ID,
-			} );
-		} );
-	} );
 } );

--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -19,7 +19,6 @@ import TrackComponentView from 'lib/analytics/track-component-view';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 import MediaListData from 'components/data/media-list-data';
-import MediaActions from 'lib/media/actions';
 import {
 	ValidationErrors as MediaValidationErrors,
 	MEDIA_IMAGE_RESIZER,
@@ -39,7 +38,7 @@ import { pauseGuidedTour, resumeGuidedTour } from 'state/ui/guided-tours/actions
 import { deleteKeyringConnection } from 'state/sharing/keyring/actions';
 import { getGuidedTourState } from 'state/ui/guided-tours/selectors';
 import { withoutNotice } from 'state/notices/actions';
-import { clearMediaErrors } from 'state/media/actions';
+import { clearMediaErrors, changeMediaSource } from 'state/media/actions';
 
 /**
  * Style dependencies
@@ -92,7 +91,7 @@ export class MediaLibraryContent extends React.Component {
 		) {
 			// We have transitioned from an invalid Google status to a valid one - migration is complete
 			// Force a refresh of the list - this won't happen automatically as we've cached our previous failed query.
-			MediaActions.sourceChanged( this.props.site.ID );
+			this.props.changeMediaSource( this.props.site.ID );
 		}
 	}
 
@@ -255,7 +254,7 @@ export class MediaLibraryContent extends React.Component {
 	}
 
 	retryList = () => {
-		MediaActions.sourceChanged( this.props.site.ID );
+		this.props.changeMediaSource( this.props.site.ID );
 	};
 
 	renderNoticeAction( upgradeNudgeName, upgradeNudgeFeature ) {
@@ -468,6 +467,7 @@ export default connect(
 			dispatch( deleteKeyring() );
 		},
 		clearMediaErrors,
+		changeMediaSource,
 	},
 	null,
 	{ pure: false }

--- a/client/my-sites/media-library/external-media-header.jsx
+++ b/client/my-sites/media-library/external-media-header.jsx
@@ -15,7 +15,8 @@ import MediaLibraryScale from './scale';
 import { Card, Button } from '@automattic/components';
 import MediaListStore from 'lib/media/list-store';
 import StickyPanel from 'components/sticky-panel';
-import { addExternalMedia, fetchNextMediaPage, changeMediaSource } from 'state/media/thunks';
+import { addExternalMedia, fetchNextMediaPage } from 'state/media/thunks';
+import { changeMediaSource } from 'state/media/actions';
 
 const DEBOUNCE_TIME = 250;
 

--- a/client/my-sites/media-library/external-media-header.jsx
+++ b/client/my-sites/media-library/external-media-header.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
 import { connect } from 'react-redux';
 import Gridicon from 'components/gridicon';
@@ -14,10 +13,9 @@ import PropTypes from 'prop-types';
  */
 import MediaLibraryScale from './scale';
 import { Card, Button } from '@automattic/components';
-import MediaActions from 'lib/media/actions';
 import MediaListStore from 'lib/media/list-store';
 import StickyPanel from 'components/sticky-panel';
-import { addExternalMedia, fetchNextMediaPage } from 'state/media/thunks';
+import { addExternalMedia, fetchNextMediaPage, changeMediaSource } from 'state/media/thunks';
 
 const DEBOUNCE_TIME = 250;
 
@@ -90,8 +88,8 @@ class MediaLibraryExternalHeader extends React.Component {
 	onClick() {
 		const { ID } = this.props.site;
 
-		MediaActions.sourceChanged( ID );
 		this.props.fetchNextMediaPage( ID );
+		this.props.changeMediaSource( ID );
 	}
 
 	onCopy = () => {
@@ -159,6 +157,6 @@ class MediaLibraryExternalHeader extends React.Component {
 	}
 }
 
-export default connect( null, { addExternalMedia, fetchNextMediaPage } )(
+export default connect( null, { addExternalMedia, changeMediaSource, fetchNextMediaPage } )(
 	localize( MediaLibraryExternalHeader )
 );

--- a/client/my-sites/media-library/test/content.jsx
+++ b/client/my-sites/media-library/test/content.jsx
@@ -14,9 +14,6 @@ import { noop } from 'lodash';
  */
 import { MediaLibraryContent } from 'my-sites/media-library/content';
 import { ValidationErrors } from 'lib/media/constants';
-import MediaActions from 'lib/media/actions';
-
-jest.mock( 'lib/media/actions' );
 
 const googleConnection = {
 	service: 'google_photos',
@@ -205,37 +202,43 @@ describe( 'MediaLibraryContent', () => {
 		} );
 
 		test( 'sourceChanged issued when expired google service goes from invalid to ok', () => {
+			const changeMediaSource = jest.fn();
 			const propsBefore = {
 				source: 'google_photos',
 				isConnected: false,
 				googleConnection: null,
 				mediaValidationErrorTypes,
+				changeMediaSource,
 			};
 			const propsAfter = {
 				source: 'google_photos',
 				isConnected: false,
 				googleConnection,
+				changeMediaSource,
 			};
 			const wrapper = getMediaContent( propsBefore );
 
-			MediaActions.sourceChanged.mockReset();
+			changeMediaSource.mockReset();
 			wrapper.setProps( propsAfter );
 
-			expect( MediaActions.sourceChanged.mock.calls.length ).toEqual( 1 );
+			expect( changeMediaSource ).toHaveBeenCalledTimes( 1 );
 		} );
 
 		test( 'sourceChanged not issued when google service remains constant', () => {
+			const changeMediaSource = jest.fn();
+
 			const propsBefore = {
 				source: 'google_photos',
 				isConnected: false,
 				googleConnection: googleConnectionInvalid,
+				changeMediaSource,
 			};
 			const wrapper = getMediaContent( propsBefore );
 
-			MediaActions.sourceChanged.mockReset();
+			changeMediaSource.mockReset();
 			wrapper.setProps( propsBefore );
 
-			expect( MediaActions.sourceChanged.mock.calls.length ).toEqual( 0 );
+			expect( changeMediaSource ).toHaveBeenCalledTimes( 0 );
 		} );
 	} );
 } );

--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -30,7 +30,7 @@ import accept from 'lib/accept';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import searchUrl from 'lib/search-url';
 import { editMedia, deleteMedia } from 'state/media/thunks';
-import { setMediaLibrarySelectedItems } from 'state/media/actions';
+import { setMediaLibrarySelectedItems, changeMediaSource } from 'state/media/actions';
 
 /**
  * Style dependencies
@@ -282,7 +282,7 @@ class Media extends Component {
 			this.onFilterChange( '' );
 		}
 
-		MediaActions.sourceChanged( this.props.selectedSite.ID );
+		this.props.changeMediaSource( this.props.selectedSite.ID );
 		this.setState( { source }, cb );
 	};
 
@@ -446,6 +446,9 @@ const mapStateToProps = ( state, { mediaId, site } ) => {
 	};
 };
 
-export default connect( mapStateToProps, { editMedia, deleteMedia, setMediaLibrarySelectedItems } )(
-	localize( Media )
-);
+export default connect( mapStateToProps, {
+	editMedia,
+	deleteMedia,
+	setMediaLibrarySelectedItems,
+	changeMediaSource,
+} )( localize( Media ) );

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -40,7 +40,7 @@ import { resetMediaModalView } from 'state/ui/media-modal/actions';
 import { setEditorMediaModalView } from 'state/editor/actions';
 import { ModalViews } from 'state/ui/media-modal/constants';
 import { editMedia, deleteMedia, addExternalMedia } from 'state/media/thunks';
-import { setMediaLibrarySelectedItems } from 'state/media/actions';
+import { setMediaLibrarySelectedItems, changeMediaSource } from 'state/media/actions';
 import ImageEditor from 'blocks/image-editor';
 import VideoEditor from 'blocks/video-editor';
 import MediaModalDialog from './dialog';
@@ -130,7 +130,7 @@ export class EditorMediaModal extends Component {
 
 			if ( nextProps.source && this.state.source !== nextProps.source && nextProps.site ) {
 				// Signal that we're coming from another data source
-				MediaActions.sourceChanged( nextProps.site.ID );
+				this.props.changeMediaSource( nextProps.site.ID );
 			}
 		} else {
 			this.props.resetView();
@@ -166,7 +166,7 @@ export class EditorMediaModal extends Component {
 		const { site } = this.props;
 
 		// Trigger the action to clear pointers/selected items
-		MediaActions.sourceChanged( site.ID );
+		this.props.changeMediaSource( site.ID );
 
 		// Change our state back to WordPress
 		this.setState(
@@ -421,7 +421,7 @@ export class EditorMediaModal extends Component {
 	};
 
 	onSourceChange = ( source ) => {
-		MediaActions.sourceChanged( this.props.site.ID );
+		this.props.changeMediaSource( this.props.site.ID );
 		this.setState( {
 			source,
 			search: undefined,
@@ -658,5 +658,6 @@ export default connect(
 		editMedia,
 		setMediaLibrarySelectedItems,
 		addExternalMedia,
+		changeMediaSource,
 	}
 )( localize( EditorMediaModal ) );

--- a/client/post-editor/media-modal/test/index.jsx
+++ b/client/post-editor/media-modal/test/index.jsx
@@ -53,13 +53,14 @@ const DUMMY_VIDEO_MEDIA = [
 ];
 
 describe( 'EditorMediaModal', () => {
-	let spy, deleteMedia, onClose, setMediaLibrarySelectedItems, baseProps;
+	let spy, deleteMedia, onClose, setMediaLibrarySelectedItems, changeMediaSource, baseProps;
 
 	useSandbox( ( sandbox ) => {
 		spy = sandbox.spy();
 		deleteMedia = sandbox.stub();
 		onClose = sandbox.stub();
 		setMediaLibrarySelectedItems = sandbox.stub();
+		changeMediaSource = sandbox.stub();
 		baseProps = {
 			setMediaLibrarySelectedItems,
 			site: DUMMY_SITE,
@@ -67,6 +68,7 @@ describe( 'EditorMediaModal', () => {
 			translate,
 			onClose,
 			deleteMedia,
+			changeMediaSource,
 		};
 	} );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Replace calls to `MediaActions.sourceChanged` with the redux action

#### Testing instructions

* Test that changing the "source" of the media library works (move to pexel, google photos, etc) in the main media page.

Part of https://github.com/Automattic/wp-calypso/issues/43664
