### PR TITLE
InlineHelp: Update icon colors in admin results

### DIFF
--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -385,9 +385,12 @@
 		}
 
 		.gridicon {
-			align-self: center;
-			margin-right: 8px;
+			align-self: baseline;
 			color: var( --color-neutral-light );
+			flex-shrink: 0;
+			margin-right: 8px;
+			position: relative;
+				top: 2px;
 		}
 
 		&:hover {
@@ -396,8 +399,6 @@
 			background: var( --color-neutral-0 );
 
 			.gridicon {
-				align-self: center;
-				margin-right: 8px;
 				color: var( --color-neutral );
 			}
 		}

--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -350,6 +350,7 @@
 
 .inline-help__results-title {
 	margin-top: 10px;
+
 	h2 {
 		font-weight: bold;
 		line-height: 1.4;

--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -356,6 +356,7 @@
 		line-height: 1.4;
 		display: block;
 		padding: 8px 16px;
+		font-size: $font-body-small;
 
 		&:after {
 			content: ':';

--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -349,12 +349,13 @@
 }
 
 .inline-help__results-title {
+	margin-top: 10px;
 	h2 {
 		font-weight: bold;
 		line-height: 1.4;
 		display: block;
 		padding: 8px 16px;
-		font-size: $font-body-small;
+
 		&:after {
 			content: ':';
 		}
@@ -383,14 +384,21 @@
 		}
 
 		.gridicon {
-			align-self: baseline;
+			align-self: center;
 			margin-right: 8px;
+			color: var( --color-neutral-light );
 		}
 
 		&:hover {
 			cursor: pointer;
 			//color: var( --color-primary );
 			background: var( --color-neutral-0 );
+
+			.gridicon {
+				align-self: center;
+				margin-right: 8px;
+				color: var( --color-neutral );
+			}
 		}
 	}
 
@@ -409,6 +417,10 @@
 		}
 
 		a {
+			color: var( --color-text-inverted );
+		}
+
+		.gridicon {
 			color: var( --color-text-inverted );
 		}
 	}

--- a/client/my-sites/customer-home/cards/features/help-search/style.scss
+++ b/client/my-sites/customer-home/cards/features/help-search/style.scss
@@ -94,7 +94,7 @@ $min_results_height: 180px;
 			margin-right: 8px;
 
 			.gridicon {
-				margin: 0 3px -3px 0;
+				margin: 0 5px -3px 0;
 			}
 
 			&:hover,

--- a/client/my-sites/customer-home/cards/features/help-search/style.scss
+++ b/client/my-sites/customer-home/cards/features/help-search/style.scss
@@ -95,6 +95,8 @@ $min_results_height: 180px;
 
 			.gridicon {
 				margin: 0 5px -3px 0;
+					position: relative;
+					top: 0;
 			}
 
 			&:hover,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR updates the icon colors in admin search results.

#### Testing instructions

1. Open the Help FAB and/or Customer Home
2. Type in a query. Example: `domain`
3. Make sure the icon colors look like the following:

## Help FAB:

**Normal state:**
![Screen Shot 2020-07-08 at 11 39 49 AM](https://user-images.githubusercontent.com/4924246/86957779-10941880-c110-11ea-98da-f8ebf283b641.png)

**Hover state:**
![Screen Shot 2020-07-08 at 11 39 53 AM](https://user-images.githubusercontent.com/4924246/86957801-1689f980-c110-11ea-9498-14b744a3a70f.png)

**Active state:**
![Screen Shot 2020-07-08 at 11 40 00 AM](https://user-images.githubusercontent.com/4924246/86957828-1ee23480-c110-11ea-9fa8-09564b720b1e.png)

## Customer Home

**Normal state:**
![Screen Shot 2020-07-08 at 11 50 08 AM](https://user-images.githubusercontent.com/4924246/86958585-3f5ebe80-c111-11ea-818e-4b83882ec4e3.png)

**Hover state:**
![Screen Shot 2020-07-08 at 11 50 11 AM](https://user-images.githubusercontent.com/4924246/86958594-42f24580-c111-11ea-87d7-c39c2ee72a2e.png)

**Active state:**
![Screen Shot 2020-07-08 at 11 50 17 AM](https://user-images.githubusercontent.com/4924246/86958617-4be31700-c111-11ea-982c-0b2b3410ac12.png)

cc @retrofox 
