### PR TITLE
Update destination for newly registered/activating domains

### DIFF
--- a/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
+++ b/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
@@ -39,6 +39,7 @@ import { withoutHttp } from 'lib/url';
 import RemovePurchase from 'me/purchases/remove-purchase';
 import { hasGSuiteWithUs, getGSuiteMailboxCount } from 'lib/gsuite';
 import getCurrentRoute from 'state/selectors/get-current-route';
+import { isRecentlyRegistered } from 'lib/domains/utils';
 
 import './style.scss';
 
@@ -148,22 +149,29 @@ class DomainManagementNavigationEnhanced extends React.Component {
 		const { selectedSite, translate, domain } = this.props;
 
 		const wpcomUrl = withoutHttp( getUnmappedUrl( selectedSite ) );
-		const { pointsToWpcom, isPrimary } = domain;
+		const {
+			isPrimary,
+			isPendingIcannVerification,
+			pendingTransfer,
+			pointsToWpcom,
+			registrationDate,
+		} = domain;
 
-		if ( pointsToWpcom && isPrimary ) {
-			return translate( 'Destination: primary domain for %(wpcomUrl)s', {
-				args: {
-					wpcomUrl,
-				},
-			} );
-		}
+		const activating =
+			isRecentlyRegistered( registrationDate ) && ! pendingTransfer && ! isPendingIcannVerification;
 
-		if ( pointsToWpcom && ! isPrimary ) {
-			return translate( 'Destination: %(wpcomUrl)s', {
-				args: {
-					wpcomUrl,
-				},
-			} );
+		if ( pointsToWpcom || activating ) {
+			return isPrimary
+				? translate( 'Destination: primary domain for %(wpcomUrl)s', {
+						args: {
+							wpcomUrl,
+						},
+				  } )
+				: translate( 'Destination: %(wpcomUrl)s', {
+						args: {
+							wpcomUrl,
+						},
+				  } );
 		}
 
 		return translate( 'Destination: external service' );

--- a/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
+++ b/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
@@ -149,16 +149,9 @@ class DomainManagementNavigationEnhanced extends React.Component {
 		const { selectedSite, translate, domain } = this.props;
 
 		const wpcomUrl = withoutHttp( getUnmappedUrl( selectedSite ) );
-		const {
-			isPrimary,
-			isPendingIcannVerification,
-			pendingTransfer,
-			pointsToWpcom,
-			registrationDate,
-		} = domain;
+		const { isPrimary, pendingTransfer, pointsToWpcom, registrationDate } = domain;
 
-		const activating =
-			isRecentlyRegistered( registrationDate ) && ! pendingTransfer;
+		const activating = isRecentlyRegistered( registrationDate ) && ! pendingTransfer;
 
 		if ( pointsToWpcom || activating ) {
 			return isPrimary

--- a/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
+++ b/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
@@ -158,7 +158,7 @@ class DomainManagementNavigationEnhanced extends React.Component {
 		} = domain;
 
 		const activating =
-			isRecentlyRegistered( registrationDate ) && ! pendingTransfer && ! isPendingIcannVerification;
+			isRecentlyRegistered( registrationDate ) && ! pendingTransfer;
 
 		if ( pointsToWpcom || activating ) {
 			return isPrimary


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* We are now just displaying the site name for recently registered domains that haven't resolved yet.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Purchase a domain
* Navigate to the domain management edit interface i.e. `domains/manage/<domain>/edit/<site>`
* Confirm that the site name is used when domain is `activating` ...

<img width="725" alt="Screenshot 2020-07-08 at 7 47 55 PM" src="https://user-images.githubusercontent.com/277661/86958815-a6519700-c154-11ea-8e01-3693cab5439f.png">


