### PR TITLE
P2 signup: Change learn more link

### DIFF
--- a/client/signup/steps/p2-site/index.jsx
+++ b/client/signup/steps/p2-site/index.jsx
@@ -329,8 +329,8 @@ class P2Site extends React.Component {
 				</form>
 
 				<div className="p2-site__learn-more">
-					<a href="https://wordpress.com/support" className="p2-site__learn-more-link">
-						Learn more about P2
+					<a href="https://wordpress.com/p2" className="p2-site__learn-more-link">
+						{ this.props.translate( 'Learn more about P2' ) }
 					</a>
 				</div>
 			</P2StepWrapper>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Point "Learn more about P2" to https://wordpress.com/p2

#### Testing instructions

* spin up this branch
* navigate to /start/p2
* check that "Learn more about P2" now links to https://wordpress.com/p2
