### PR TITLE
Fix the race condition for experiment assignment

### DIFF
--- a/client/components/data/query-experiments/index.tsx
+++ b/client/components/data/query-experiments/index.tsx
@@ -18,13 +18,59 @@ type QueryProps = {
 	anonId: string;
 };
 
+/**
+ * Stolen from w.js.
+ * In the case of a fresh page load, we absolutely need to get the user's anonid as quickly as possible.
+ */
+const getCookie = () => {
+	const name_eq = encodeURIComponent( 'tk_ai' ) + '=';
+	const name_eq_len = name_eq.length;
+	let cookies = document.cookie.split( '; ' );
+	let cookies_len = cookies.length;
+
+	// In testing all browsers use `; ` as seperator but just in case for RFC also try `;`
+	if ( cookies_len === 1 ) {
+		cookies = document.cookie.split( ';' );
+		cookies_len = cookies.length;
+	}
+
+	for ( cookies_len--; cookies_len >= 0; cookies_len-- ) {
+		if ( cookies[ cookies_len ].substring( 0, name_eq_len ) === name_eq ) {
+			return decodeURIComponent( cookies[ cookies_len ].substring( name_eq_len ) );
+		}
+	}
+
+	return null;
+};
+
+const forceGetAnonId = () => {
+	return new Promise( ( resolve ) => {
+		const value = getCookie();
+		if ( value !== null ) {
+			resolve( value );
+			return;
+		}
+
+		setTimeout( () => {
+			// if we still don't have a anonid ... then, we can't wait forever.
+			resolve( getCookie() );
+		}, 10 );
+	} );
+};
+
 const QueryExperiments: FunctionComponent< QueryProps > = ( {
 	updateAfter,
 	doFetchExperiments,
 	anonId,
 } ) => {
 	useEffect( () => {
-		if ( updateAfter < Date.now() ) doFetchExperiments( anonId );
+		if ( updateAfter < Date.now() ) {
+			if ( anonId === null ) {
+				forceGetAnonId().then( ( newId ) => doFetchExperiments( newId ) );
+			} else {
+				doFetchExperiments( anonId );
+			}
+		}
 	}, [ updateAfter, doFetchExperiments, anonId ] );
 
 	return null;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This attempts to query the raw cookie, and then waiting 10 milliseconds if it's unavailable. This appears to work perfectly fine on several of my devices, 3G speed, LTE speed, throttled down CPU, etc.
* I'm using the same code as w.js uses instead of a library we already have. I'll experiment with using the library or using this code and see which one affects the bundle less. I'm leaning towards using this code for now because this is about to wrap the login component in #43675 and this code appears to be very lean, though I'm not a fan.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Merge this branch with #43675, go to http://calypso.localhost:3000/start/user with a fresh browser (incognito) and validate `wpcom_experiment_variation_requested` fires with your anonid.

#### Further Improvements

This doesn't actually resolve the issue, but just makes it far less likely. A better fix would be to NOT get an assignment until we have an anonid, however, that introduces some interesting issues:

1. Maybe the browser is blocking the tracks library, in that case the user will never get an anonid and we create a bad experience by waiting.

A better approach, is that the assignment framework detects this anomaly (no user or anon id) and then returns a key with the anon id we generate in the assignment framework. In this case, the client detects when we have a user id and then performs the aliasing from there. In the case where tracks is blocked, this will basically be a noop and the data will be lost, but it was lost any way...

This approach will take time, so I'm opening this hotfix style PR to solve the problem in the meantime. Please merge it before/with #43675 
