### PR TITLE
Deps: Update webpack-node-externals to 2.1.0

### DIFF
--- a/client/webpack.config.node.js
+++ b/client/webpack.config.node.js
@@ -45,9 +45,8 @@ function getExternals() {
 	return [
 		// Don't bundle any node_modules, both to avoid a massive bundle, and problems
 		// with modules that are incompatible with webpack bundling.
-		//
 		nodeExternals( {
-			whitelist: [
+			allowlist: [
 				// `@automattic/components` is forced to be webpack-ed because it has SCSS and other
 				// non-JS asset imports that couldn't be processed by Node.js at runtime.
 				'@automattic/components',

--- a/package.json
+++ b/package.json
@@ -369,7 +369,7 @@
 		"webpack-dev-middleware": "^3.7.2",
 		"webpack-dev-server": "^3.10.3",
 		"webpack-hot-middleware": "^2.25.0",
-		"webpack-node-externals": "^1.7.2",
+		"webpack-node-externals": "^2.1.0",
 		"whybundled": "^1.4.2",
 		"wp-calypso": "^0.17.0",
 		"wp-e2e-tests": "^0.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -26724,10 +26724,10 @@ webpack-log@^2.0.0:
     ansi-colors "^3.0.0"
     uuid "^3.3.2"
 
-webpack-node-externals@^1.7.2:
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/webpack-node-externals/-/webpack-node-externals-1.7.2.tgz#6e1ee79ac67c070402ba700ef033a9b8d52ac4e3"
-  integrity sha512-ajerHZ+BJKeCLviLUUmnyd5B4RavLF76uv3cs6KNuO8W+HuQaEs0y0L7o40NQxdPy5w0pcv8Ew7yPUAQG0UdCg==
+webpack-node-externals@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/webpack-node-externals/-/webpack-node-externals-2.1.0.tgz#b2a397fbfc8f87c6b40a2a127083e915da500b37"
+  integrity sha512-infWsm1GDlfak2sGcmiS4Upd3AK7JXhBeeHyf/CtAoUoF3ExlbYv4aTpk/wekXc5sE0uPEW/Eh3kYz8eC19VNA==
 
 webpack-rtl-plugin@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update webpack-node-externals and remove one instance of problematic language 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Verify the build still includes the `@automattic/components` package by verifying that places that use the components still work. For example the ImageSelector's button usage.

Part of https://github.com/Automattic/wp-calypso/issues/43395

Related: https://github.com/liady/webpack-node-externals/pull/75
