### PR TITLE
Plans: Tweak Payments feature language in the Plans feature list.

### DIFF
--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -990,8 +990,9 @@ export const FEATURES_LIST = {
 
 	[ constants.FEATURE_MEMBERSHIPS ]: {
 		getSlug: () => constants.FEATURE_MEMBERSHIPS,
-		getTitle: () => i18n.translate( 'Sell Subscriptions' ),
-		getDescription: () => i18n.translate( 'Accept monthly or annual payments on your website.' ),
+		getTitle: () => i18n.translate( 'Payments' ),
+		getDescription: () =>
+			i18n.translate( 'Accept one-time, monthly, or annual payments on your website.' ),
 	},
 
 	[ constants.FEATURE_PREMIUM_CONTENT_BLOCK ]: {


### PR DESCRIPTION
This PR tweaks the language that describes the Payments features in the Plans comparison section of Calypso. These changes match the current verbiage on the /pricing page of WPcom.

Before:
<img width="1030" alt="Screen Shot 2020-07-08 at 4 12 50 PM" src="https://user-images.githubusercontent.com/35781181/86967095-2ae1ec80-c138-11ea-86f4-9a3804d0382f.png">

After:
<img width="1030" alt="Screen Shot 2020-07-08 at 4 29 59 PM" src="https://user-images.githubusercontent.com/35781181/86967301-75636900-c138-11ea-947c-ede805e8db0c.png">

And here's a picture of the new tooltip copy:
![86920153-4d9fe100-c0f7-11ea-828e-5ba95a74d183](https://user-images.githubusercontent.com/35781181/86967911-47325900-c139-11ea-82e5-cab3864fc0a4.png)


#### Testing instructions

* Checkout the branch (git checkout update/plates-tweak-payments-wording)
* Start Calypso (yarn start)
* Navigate to /plans/:siteSlug
* Confirm that the Payments row contains the updated copy.
