### PR TITLE
InlineHelp: Make focus on the search input element once open

### DIFF
--- a/client/blocks/inline-help/inline-help-search-card.jsx
+++ b/client/blocks/inline-help/inline-help-search-card.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useRef, useEffect } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { identity, includes } from 'lodash';
@@ -44,6 +44,23 @@ const InlineHelpSearchCard = ( {
 	placeholder,
 	translate = identity,
 } ) => {
+	const cardRef = useRef();
+
+	// Make focus in the input element.
+	useEffect( () => {
+	    if ( ! cardRef?.current ) {
+	    	return;
+	    }
+
+	    const inputElement = cardRef.current.searchInput;
+	    if ( ! inputElement ) {
+	    	return;
+	    }
+	    const timerId = setTimeout( () => ( inputElement.focus() ), 0 );
+
+	    return () => window.clearTimeout( timerId );
+	}, [ cardRef ] );
+
 	const onKeyDown = ( event ) => {
 		// ignore keyboard access when manipulating a text selection in input etc.
 		if ( event.getModifierState( 'Shift' ) ) {
@@ -107,6 +124,7 @@ const InlineHelpSearchCard = ( {
 
 	return (
 		<SearchCard
+			ref={ cardRef }
 			searching={ isSearching }
 			initialValue={ query }
 			onSearch={ searchHelperHandler }

--- a/client/blocks/inline-help/inline-help-search-card.jsx
+++ b/client/blocks/inline-help/inline-help-search-card.jsx
@@ -31,15 +31,15 @@ import { SUPPORT_TYPE_ADMIN_SECTION } from './constants';
 const debug = debugFactory( 'calypso:inline-help' );
 
 const InlineHelpSearchCard = ( {
-	selectPreviousResult,
-	selectNextResult,
+	setPreviousResult,
+	setNextResult,
 	selectedResultIndex,
 	selectedResult = {},
 	query = '',
 	onSelect,
 	track,
 	location = 'inline-help-popover',
-	setInlineHelpSearchQuery,
+	setSearchQuery,
 	isSearching,
 	placeholder,
 	translate = identity,
@@ -64,7 +64,7 @@ const InlineHelpSearchCard = ( {
 		const timerId = setTimeout( () => inputElement.focus(), 0 );
 
 		return () => window.clearTimeout( timerId );
-	}, [ cardRef ] );
+	}, [ cardRef, location ] );
 
 	const onKeyDown = ( event ) => {
 		// ignore keyboard access when manipulating a text selection in input etc.
@@ -80,10 +80,10 @@ const InlineHelpSearchCard = ( {
 
 		switch ( event.key ) {
 			case 'ArrowUp':
-				selectPreviousResult();
+				setPreviousResult();
 				break;
 			case 'ArrowDown':
-				selectNextResult();
+				setNextResult();
 				break;
 			case 'Enter': {
 				// check and catch admin section links.
@@ -113,9 +113,9 @@ const InlineHelpSearchCard = ( {
 	};
 
 	const searchHelperHandler = ( searchQuery ) => {
-		const query = searchQuery.trim();
+		const inputQuery = searchQuery.trim();
 
-		if ( query?.length ) {
+		if ( inputQuery?.length ) {
 			debug( 'search query received: ', searchQuery );
 			track( 'calypso_inlinehelp_search', {
 				search_query: searchQuery,
@@ -124,7 +124,7 @@ const InlineHelpSearchCard = ( {
 		}
 
 		// Set the query search
-		setInlineHelpSearchQuery( searchQuery );
+		setSearchQuery( searchQuery );
 	};
 
 	return (
@@ -158,9 +158,9 @@ const mapStateToProps = ( state, ownProps ) => ( {
 } );
 const mapDispatchToProps = {
 	track: recordTracksEvent,
-	setInlineHelpSearchQuery,
-	selectNextResult,
-	selectPreviousResult,
+	seSearchQuery: setInlineHelpSearchQuery,
+	setNextResult: selectNextResult,
+	setPreviousResult: selectPreviousResult,
 };
 
 export default connect( mapStateToProps, mapDispatchToProps )( localize( InlineHelpSearchCard ) );

--- a/client/blocks/inline-help/inline-help-search-card.jsx
+++ b/client/blocks/inline-help/inline-help-search-card.jsx
@@ -48,17 +48,17 @@ const InlineHelpSearchCard = ( {
 
 	// Make focus in the input element.
 	useEffect( () => {
-	    if ( ! cardRef?.current ) {
-	    	return;
-	    }
+		if ( ! cardRef?.current ) {
+			return;
+		}
 
-	    const inputElement = cardRef.current.searchInput;
-	    if ( ! inputElement ) {
-	    	return;
-	    }
-	    const timerId = setTimeout( () => ( inputElement.focus() ), 0 );
+		const inputElement = cardRef.current.searchInput;
+		if ( ! inputElement ) {
+			return;
+		}
+		const timerId = setTimeout( () => inputElement.focus(), 0 );
 
-	    return () => window.clearTimeout( timerId );
+		return () => window.clearTimeout( timerId );
 	}, [ cardRef ] );
 
 	const onKeyDown = ( event ) => {

--- a/client/blocks/inline-help/inline-help-search-card.jsx
+++ b/client/blocks/inline-help/inline-help-search-card.jsx
@@ -46,8 +46,13 @@ const InlineHelpSearchCard = ( {
 } ) => {
 	const cardRef = useRef();
 
-	// Make focus in the input element.
+	// Focus in the input element.
 	useEffect( () => {
+		// Focuses only in the popover.
+		if ( location !== 'inline-help-popover' ) {
+			return;
+		}
+
 		if ( ! cardRef?.current ) {
 			return;
 		}

--- a/client/blocks/inline-help/inline-help-search-card.jsx
+++ b/client/blocks/inline-help/inline-help-search-card.jsx
@@ -158,7 +158,7 @@ const mapStateToProps = ( state, ownProps ) => ( {
 } );
 const mapDispatchToProps = {
 	track: recordTracksEvent,
-	seSearchQuery: setInlineHelpSearchQuery,
+	setSearchQuery: setInlineHelpSearchQuery,
 	setNextResult: selectNextResult,
 	setPreviousResult: selectPreviousResult,
 };

--- a/client/blocks/inline-help/inline-help-search-card.jsx
+++ b/client/blocks/inline-help/inline-help-search-card.jsx
@@ -48,19 +48,12 @@ const InlineHelpSearchCard = ( {
 
 	// Focus in the input element.
 	useEffect( () => {
+		const inputElement = cardRef.current?.searchInput;
 		// Focuses only in the popover.
-		if ( location !== 'inline-help-popover' ) {
+		if ( location !== 'inline-help-popover' || ! inputElement ) {
 			return;
 		}
 
-		if ( ! cardRef?.current ) {
-			return;
-		}
-
-		const inputElement = cardRef.current.searchInput;
-		if ( ! inputElement ) {
-			return;
-		}
 		const timerId = setTimeout( () => inputElement.focus(), 0 );
 
 		return () => window.clearTimeout( timerId );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR focuses on the input element of the search card. I've had to add a timeout since there is a race condition that makes the flow lose the focus.
Also, it rewrites the component using a function instead of a class inherited from the react Component one.

<img src="https://user-images.githubusercontent.com/77539/86842963-50a9bb80-c07c-11ea-8a68-9fca0e5ee1cb.png" width="400px" />

#### Testing instructions

* Apply these changes
* Click on the FAB icon on order to open the popover
* Confirm that it focuses on the input search element.

![inline-help-focuses](https://user-images.githubusercontent.com/77539/86981580-53c8a880-c15d-11ea-87ff-ee4e2ba71782.gif)


Fixes https://github.com/Automattic/wp-calypso/issues/43958
