### PR TITLE
Remove isLarge prop from Button block in FSE starter-page-templates

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -487,11 +487,11 @@ class PageTemplateModal extends Component {
 				>
 					<Button
 						isPrimary
-						isLarge
 						disabled={ isEmpty( previewedTemplate ) || isLoading }
 						onClick={ this.handleConfirmation }
 					>
 						{ sprintf(
+							/* translators: %s is name of a page layout. Eg: Dalston or Blank. */
 							__( 'Use %s layout', 'full-site-editing' ),
 							this.getTitleByTemplateSlug( previewedTemplate )
 						) }


### PR DESCRIPTION
In Gutenberg the `isLarge` prop was removed from the Button component in https://github.com/WordPress/gutenberg/pull/23239 — this PR removes the prop from our instance of the Button block in starter page templates, so that it doesn't error in the console

This it the button in question — it should look the same after applying this change.

![image](https://user-images.githubusercontent.com/14988353/87016638-50dbbf80-c212-11ea-9d5c-83f4acb1fd13.png)

#### Changes proposed in this Pull Request

* Remove isLarge prop from Button component
* Add translators line to keep linting happy!

#### Testing instructions

You should not see the following error in the console:

![image](https://user-images.githubusercontent.com/14988353/87016472-170ab900-c212-11ea-85eb-3ef5c09ce514.png)


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up a local development environment (e.g. go to the apps/full-site-editing directory and run wp-env start
* Run the local dev environment for FSE (e.g. fo to the apps/full-site-editing directory and run yarn dev or if you want to sync to your sandbox, run yarn dev --sync)
* In your WP install, go to create a new page, and it should open up the starter page templates page layout picker
* The button in the top right should look and function the same as normal
* You shouldn't see the console error about `isLarge`

Fixes #
