### PR TITLE
Revert "Create white glove AB test" - Resolving the revert conflicts

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -138,17 +138,6 @@ export default {
 		localeTargets: 'any',
 		allowExistingUsers: true,
 	},
-<<<<<<< HEAD
-	whiteGloveUpsell: {
-		datestamp: '20200623',
-		variations: {
-			variantShowOffer: 50,
-			control: 50,
-		},
-		defaultVariation: 'control',
-		allowExistingUsers: false,
-		countryCodeTargets: [ 'US' ],
-	},
 	passwordlessAfterPlans: {
 		datestamp: '20200618',
 		variations: {
@@ -168,6 +157,4 @@ export default {
 		defaultVariation: 'control',
 		allowExistingUsers: true,
 	},
-=======
->>>>>>> parent of f9bd012961... Create white glove AB test (#42783)
 };

--- a/client/me/concierge/shared/no-available-times.js
+++ b/client/me/concierge/shared/no-available-times.js
@@ -11,11 +11,7 @@ import { localize } from 'i18n-calypso';
 import { Card } from '@automattic/components';
 import PrimaryHeader from './primary-header';
 import { recordTracksEvent } from 'state/analytics/actions';
-<<<<<<< HEAD
-import isSiteWhiteGlove from 'state/selectors/is-site-white-glove';
 import ExternalLinkWithTracking from 'components/external-link/with-tracking';
-=======
->>>>>>> parent of f9bd012961... Create white glove AB test (#42783)
 
 class NoAvailableTimes extends Component {
 	componentDidMount() {
@@ -32,7 +28,6 @@ class NoAvailableTimes extends Component {
 						{ translate( 'Sorry, all upcoming sessions are full.' ) }
 					</h2>
 					{ translate(
-<<<<<<< HEAD
 						'We add new sessions daily, so please check back soon for more options. In the meantime, consider attending one of our expert webinars on a wide variety of topics designed to help you build and grow your site. {{externalLink1}}View webinars{{/externalLink1}} or {{externalLink2}}contact us in Live Chat{{/externalLink2}}.',
 						{
 							components: {
@@ -50,12 +45,6 @@ class NoAvailableTimes extends Component {
 										tracksEventName="calypso_concierge_book_contact_us"
 									/>
 								),
-=======
-						'We schedule Quick Start Sessions up to 24 hours in advance and all upcoming sessions are full. Please check back later or {{link}}contact us in Live Chat{{/link}}.',
-						{
-							components: {
-								link: <a href="https://wordpress.com/help/contact" />,
->>>>>>> parent of f9bd012961... Create white glove AB test (#42783)
 							},
 						}
 					) }

--- a/client/my-sites/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout-system-decider.js
@@ -113,7 +113,6 @@ export default function CheckoutSystemDecider( {
 
 	if ( 'composite-checkout' === checkoutVariant ) {
 		return (
-<<<<<<< HEAD
 			<CheckoutErrorBoundary
 				errorMessage={ translate( 'Sorry, there was an error loading this page.' ) }
 				onError={ logCheckoutError }
@@ -129,26 +128,10 @@ export default function CheckoutSystemDecider( {
 						feature={ selectedFeature }
 						plan={ plan }
 						cart={ cart }
-						isWhiteGloveOffer={ isWhiteGloveOffer }
 						isComingFromUpsell={ isComingFromUpsell }
 					/>
 				</StripeHookProvider>
 			</CheckoutErrorBoundary>
-=======
-			<StripeHookProvider fetchStripeConfiguration={ fetchStripeConfigurationWpcom }>
-				<CompositeCheckout
-					siteSlug={ selectedSite?.slug }
-					siteId={ selectedSite?.ID }
-					product={ product }
-					purchaseId={ purchaseId }
-					couponCode={ couponCode }
-					redirectTo={ redirectTo }
-					feature={ selectedFeature }
-					plan={ plan }
-					cart={ cart }
-				/>
-			</StripeHookProvider>
->>>>>>> parent of f9bd012961... Create white glove AB test (#42783)
 		);
 	}
 

--- a/client/my-sites/checkout/checkout-thank-you/business-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/business-plan-details.jsx
@@ -32,7 +32,6 @@ function trackOnboardingButtonClick() {
 	recordTracksEvent( 'calypso_checkout_thank_you_onboarding_click' );
 }
 
-<<<<<<< HEAD
 const BusinessPlanDetails = ( {
 	selectedSite,
 	sitePlans,
@@ -44,9 +43,6 @@ const BusinessPlanDetails = ( {
 		isJetpackSectionEnabledForSite( state, selectedSite?.ID )
 	);
 
-=======
-const BusinessPlanDetails = ( { selectedSite, sitePlans, selectedFeature, purchases } ) => {
->>>>>>> parent of f9bd012961... Create white glove AB test (#42783)
 	const plan = find( sitePlans.data, isBusiness );
 	const googleAppsWasPurchased = purchases.some( isGoogleApps );
 

--- a/client/my-sites/checkout/checkout/checkout-container.jsx
+++ b/client/my-sites/checkout/checkout/checkout-container.jsx
@@ -85,11 +85,7 @@ class CheckoutContainer extends React.Component {
 			clearTransaction,
 			isComingFromGutenboarding,
 			isGutenboardingCreate,
-<<<<<<< HEAD
-			isWhiteGloveOffer,
 			isComingFromUpsell,
-=======
->>>>>>> parent of f9bd012961... Create white glove AB test (#42783)
 		} = this.props;
 
 		const TransactionData = clearTransaction ? CartData : CheckoutData;

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -120,11 +120,7 @@ export default function CompositeCheckout( {
 	purchaseId,
 	cart,
 	couponCode: couponCodeFromUrl,
-<<<<<<< HEAD
-	isWhiteGloveOffer,
 	isComingFromUpsell,
-=======
->>>>>>> parent of f9bd012961... Create white glove AB test (#42783)
 } ) {
 	const translate = useTranslate();
 	const isJetpackNotAtomic = useSelector(
@@ -229,11 +225,7 @@ export default function CompositeCheckout( {
 		isJetpackNotAtomic,
 		product,
 		siteId,
-<<<<<<< HEAD
-		isWhiteGloveOffer,
 		hideNudge,
-=======
->>>>>>> parent of f9bd012961... Create white glove AB test (#42783)
 	} );
 
 	const moment = useLocalizedMoment();
@@ -487,74 +479,26 @@ export default function CompositeCheckout( {
 			'free-purchase': freePurchaseProcessor,
 			card: stripeCardProcessor,
 			alipay: ( transactionData ) =>
-				genericRedirectProcessor(
-					'alipay',
-					transactionData,
-					getThankYouUrl,
-					isWhiteGloveOffer,
-					siteSlug
-				),
+				genericRedirectProcessor( 'alipay', transactionData, getThankYouUrl, siteSlug ),
 			p24: ( transactionData ) =>
-				genericRedirectProcessor(
-					'p24',
-					transactionData,
-					getThankYouUrl,
-					isWhiteGloveOffer,
-					siteSlug
-				),
+				genericRedirectProcessor( 'p24', transactionData, getThankYouUrl, siteSlug ),
 			bancontact: ( transactionData ) =>
-				genericRedirectProcessor(
-					'bancontact',
-					transactionData,
-					getThankYouUrl,
-					isWhiteGloveOffer,
-					siteSlug
-				),
+				genericRedirectProcessor( 'bancontact', transactionData, getThankYouUrl, siteSlug ),
 			giropay: ( transactionData ) =>
-				genericRedirectProcessor(
-					'giropay',
-					transactionData,
-					getThankYouUrl,
-					isWhiteGloveOffer,
-					siteSlug
-				),
+				genericRedirectProcessor( 'giropay', transactionData, getThankYouUrl, siteSlug ),
 			wechat: ( transactionData ) =>
-				genericRedirectProcessor(
-					'wechat',
-					transactionData,
-					getThankYouUrl,
-					isWhiteGloveOffer,
-					siteSlug
-				),
+				genericRedirectProcessor( 'wechat', transactionData, getThankYouUrl, siteSlug ),
 			ideal: ( transactionData ) =>
-				genericRedirectProcessor(
-					'ideal',
-					transactionData,
-					getThankYouUrl,
-					isWhiteGloveOffer,
-					siteSlug
-				),
+				genericRedirectProcessor( 'ideal', transactionData, getThankYouUrl, siteSlug ),
 			sofort: ( transactionData ) =>
-				genericRedirectProcessor(
-					'sofort',
-					transactionData,
-					getThankYouUrl,
-					isWhiteGloveOffer,
-					siteSlug
-				),
+				genericRedirectProcessor( 'sofort', transactionData, getThankYouUrl, siteSlug ),
 			eps: ( transactionData ) =>
-				genericRedirectProcessor(
-					'eps',
-					transactionData,
-					getThankYouUrl,
-					isWhiteGloveOffer,
-					siteSlug
-				),
+				genericRedirectProcessor( 'eps', transactionData, getThankYouUrl, siteSlug ),
 			'full-credits': fullCreditsProcessor,
 			'existing-card': existingCardProcessor,
 			paypal: ( transactionData ) => payPalProcessor( transactionData, getThankYouUrl, couponItem ),
 		} ),
-		[ couponItem, getThankYouUrl, isWhiteGloveOffer, siteSlug ]
+		[ couponItem, getThankYouUrl, siteSlug ]
 	);
 
 	useRecordCheckoutLoaded(
@@ -577,7 +521,6 @@ export default function CompositeCheckout( {
 			<QueryStoredCards />
 
 			<PageViewTracker path={ analyticsPath } title="Checkout" properties={ analyticsProps } />
-<<<<<<< HEAD
 			<CartProvider cart={ responseCart }>
 				<CheckoutProvider
 					items={ itemsForCheckout }
@@ -616,52 +559,9 @@ export default function CompositeCheckout( {
 						isCartPendingUpdate={ isCartPendingUpdate }
 						CheckoutTerms={ CheckoutTerms }
 						showErrorMessageBriefly={ showErrorMessageBriefly }
-						isWhiteGloveOffer={ isWhiteGloveOffer }
 					/>
 				</CheckoutProvider>
 			</CartProvider>
-=======
-			<CheckoutProvider
-				locale={ 'en-us' }
-				items={ itemsForCheckout }
-				total={ total }
-				onPaymentComplete={ onPaymentComplete }
-				showErrorMessage={ showErrorMessage }
-				showInfoMessage={ showInfoMessage }
-				showSuccessMessage={ showSuccessMessage }
-				onEvent={ recordEvent }
-				paymentMethods={ paymentMethods }
-				paymentProcessors={ paymentProcessors }
-				registry={ defaultRegistry }
-				isLoading={
-					isLoadingCart || isLoadingStoredCards || paymentMethods.length < 1 || items.length < 1
-				}
-				isValidating={ isCartPendingUpdate }
-			>
-				<WPCheckout
-					removeItem={ removeItem }
-					updateLocation={ updateLocation }
-					submitCoupon={ submitCoupon }
-					removeCoupon={ removeCoupon }
-					couponStatus={ couponStatus }
-					changePlanLength={ changeItemVariant }
-					siteId={ siteId }
-					siteUrl={ siteSlug }
-					CountrySelectMenu={ CountrySelectMenu }
-					countriesList={ countriesList }
-					StateSelect={ StateSelect }
-					renderDomainContactFields={ renderDomainContactFields }
-					variantSelectOverride={ variantSelectOverride }
-					getItemVariants={ getItemVariants }
-					responseCart={ responseCart }
-					addItemToCart={ addItemWithEssentialProperties }
-					subtotal={ subtotal }
-					isCartPendingUpdate={ isCartPendingUpdate }
-					CheckoutTerms={ CheckoutTerms }
-					showErrorMessageBriefly={ showErrorMessageBriefly }
-				/>
-			</CheckoutProvider>
->>>>>>> parent of f9bd012961... Create white glove AB test (#42783)
 		</React.Fragment>
 	);
 }

--- a/client/my-sites/checkout/composite-checkout/payment-method-processors.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-processors.js
@@ -23,18 +23,12 @@ import { createStripePaymentMethod } from 'lib/stripe';
 
 const { select, dispatch } = defaultRegistry;
 
-export function genericRedirectProcessor(
-	paymentMethodId,
-	submitData,
-	getThankYouUrl,
-	isWhiteGloveOffer,
-	siteSlug
-) {
+export function genericRedirectProcessor( paymentMethodId, submitData, getThankYouUrl, siteSlug ) {
 	const { protocol, hostname, port, pathname } = parseUrl(
 		typeof window !== 'undefined' ? window.location.href : 'https://wordpress.com',
 		true
 	);
-	const cancelUrlQuery = isWhiteGloveOffer ? { type: 'white-glove' } : {};
+	const cancelUrlQuery = {};
 	const redirectToSuccessUrl = formatUrl( {
 		protocol,
 		hostname,

--- a/client/my-sites/checkout/composite-checkout/types/transaction-endpoint.ts
+++ b/client/my-sites/checkout/composite-checkout/types/transaction-endpoint.ts
@@ -25,12 +25,7 @@ export type WPCOMTransactionEndpoint = (
 export type WPCOMTransactionEndpointRequestPayload = {
 	cart: WPCOMTransactionEndpointCart;
 	payment: WPCOMTransactionEndpointPaymentDetails;
-<<<<<<< HEAD
 	domainDetails?: DomainContactDetails;
-	isWhiteGloveOffer: boolean;
-=======
-	domainDetails?: WPCOMTransactionEndpointDomainDetails;
->>>>>>> parent of f9bd012961... Create white glove AB test (#42783)
 };
 
 export type WPCOMTransactionEndpointPaymentDetails = {

--- a/client/my-sites/checkout/composite-checkout/use-get-thank-you-url.js
+++ b/client/my-sites/checkout/composite-checkout/use-get-thank-you-url.js
@@ -49,13 +49,9 @@ export function getThankYouPageUrl( {
 	getUrlFromCookie = retrieveSignupDestination,
 	saveUrlToCookie = persistSignupDestination,
 	isEligibleForSignupDestinationResult,
-<<<<<<< HEAD
-	isWhiteGloveOffer,
 	hideNudge,
 	didPurchaseFail,
 	isTransactionResultEmpty,
-=======
->>>>>>> parent of f9bd012961... Create white glove AB test (#42783)
 } ) {
 	debug( 'starting getThankYouPageUrl' );
 	// If we're given an explicit `redirectTo` query arg, make sure it's either internal
@@ -345,11 +341,7 @@ export function useGetThankYouUrl( {
 	isJetpackNotAtomic,
 	product,
 	siteId,
-<<<<<<< HEAD
-	isWhiteGloveOffer,
 	hideNudge,
-=======
->>>>>>> parent of f9bd012961... Create white glove AB test (#42783)
 } ) {
 	const selectedSiteData = useSelector( ( state ) => getSelectedSite( state ) );
 	const adminUrl = selectedSiteData?.options?.admin_url;
@@ -393,13 +385,9 @@ export function useGetThankYouUrl( {
 			isJetpackNotAtomic,
 			product,
 			isEligibleForSignupDestinationResult,
-<<<<<<< HEAD
-			isWhiteGloveOffer,
 			hideNudge,
 			didPurchaseFail,
 			isTransactionResultEmpty,
-=======
->>>>>>> parent of f9bd012961... Create white glove AB test (#42783)
 		} );
 		debug( 'getThankYouUrl returned', url );
 		return url;
@@ -413,7 +401,6 @@ export function useGetThankYouUrl( {
 		feature,
 		purchaseId,
 		cart,
-		isWhiteGloveOffer,
 		hideNudge,
 	] );
 	return getThankYouUrl;

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
@@ -19,11 +19,8 @@ import { useTranslate } from 'i18n-calypso';
 import joinClasses from './join-classes';
 import { useHasDomainsInCart } from '../hooks/has-domains';
 import { ItemVariationPicker } from './item-variation-picker';
-<<<<<<< HEAD
 import { isBusinessPlan } from 'lib/plans';
 import { isGSuiteProductSlug } from 'lib/gsuite';
-=======
->>>>>>> parent of f9bd012961... Create white glove AB test (#42783)
 
 export function WPOrderReviewSection( { children, className } ) {
 	return <div className={ joinClasses( [ className, 'order-review-section' ] ) }>{ children }</div>;
@@ -58,17 +55,11 @@ function WPLineItem( {
 	const shouldShowVariantSelector = getItemVariants && item.wpcom_meta && ! isRenewal;
 	const isGSuite = isGSuiteProductSlug( item.wpcom_meta?.product_slug );
 
-<<<<<<< HEAD
 	const productSlug = item.wpcom_meta?.product_slug;
 	const isBusinessPlanProduct = productSlug && isBusinessPlan( productSlug );
-	const productName =
-		isBusinessPlanProduct && isWhiteGloveOffer
-			? `${ item.label } (with Expert guidance)`
-			: item.label;
+	const productName = isBusinessPlanProduct ? `${ item.label } (with Expert guidance)` : item.label;
 
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
-=======
->>>>>>> parent of f9bd012961... Create white glove AB test (#42783)
 	return (
 		<div
 			className={ joinClasses( [ className, 'checkout-line-item' ] ) }
@@ -302,11 +293,7 @@ export function WPOrderReviewLineItems( {
 	variantSelectOverride,
 	getItemVariants,
 	onChangePlanLength,
-<<<<<<< HEAD
-	isWhiteGloveOffer,
-=======
 	couponStatus,
->>>>>>> parent of f9bd012961... Create white glove AB test (#42783)
 } ) {
 	return (
 		<WPOrderReviewList className={ joinClasses( [ className, 'order-review-line-items' ] ) }>

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
@@ -19,7 +19,6 @@ import { useTranslate } from 'i18n-calypso';
 import joinClasses from './join-classes';
 import { useHasDomainsInCart } from '../hooks/has-domains';
 import { ItemVariationPicker } from './item-variation-picker';
-import { isBusinessPlan } from 'lib/plans';
 import { isGSuiteProductSlug } from 'lib/gsuite';
 
 export function WPOrderReviewSection( { children, className } ) {
@@ -56,8 +55,6 @@ function WPLineItem( {
 	const isGSuite = isGSuiteProductSlug( item.wpcom_meta?.product_slug );
 
 	const productSlug = item.wpcom_meta?.product_slug;
-	const isBusinessPlanProduct = productSlug && isBusinessPlan( productSlug );
-	const productName = isBusinessPlanProduct ? `${ item.label } (with Expert guidance)` : item.label;
 
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
@@ -293,7 +290,6 @@ export function WPOrderReviewLineItems( {
 	variantSelectOverride,
 	getItemVariants,
 	onChangePlanLength,
-	couponStatus,
 } ) {
 	return (
 		<WPOrderReviewList className={ joinClasses( [ className, 'order-review-line-items' ] ) }>

--- a/client/my-sites/checkout/upsell-nudge/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/index.jsx
@@ -166,20 +166,7 @@ export class UpsellNudge extends React.Component {
 		}
 	}
 
-<<<<<<< HEAD
-	getUrl( url, args ) {
-		return addQueryArgs(
-			{
-				...args,
-			},
-			url
-		);
-	}
-
 	handleClickDecline = ( shouldHideUpsellNudges = true ) => {
-=======
-	handleClickDecline = () => {
->>>>>>> parent of f9bd012961... Create white glove AB test (#42783)
 		const { trackUpsellButtonClick, upsellType, handleCheckoutCompleteRedirect } = this.props;
 
 		trackUpsellButtonClick( `calypso_${ upsellType.replace( /-/g, '_' ) }_decline_button_click` );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR is part of the effort of reverting all the changes introduced by #42783. 
For the reverting strategy applied here, please refer to the base branch: https://github.com/Automattic/wp-calypso/pull/44022

#### Testing instructions

* Code review. Make sure the conflict resolution makes sense.
* Make sure you won't see the Expert Guidance offer even if you explicitly assign yourself to the variation group. There is an accompanied Playwright script below that can automate this.
* Run through a few purchasing flow and make sure they work.

#### Run the test script

1. Copy the script below into a file and put it in a folder. e.g. `sandbox/expert-guidance.js`
1. In `sandbox`, run `npm i -D playwright`
1. Run the script by `node expert-guidance.js`

On the master branch, running this script should lead you to the checkout page with the Expert Guidance product in the cart; on this branch, it shouldn't.

```
const { chromium } = require( 'playwright' );
const assert = require( 'assert' );

( async () => {
	const browser = await chromium.launch( {
		headless: false,
	} );
	const context = await browser.newContext( {
		locale: 'en',
	} );
	const page = await context.newPage();

	await page.goto( 'http://calypso.localhost:3000/start' );
	await page.evaluate( () => {
		window.localStorage.setItem( 'ABTests', '{"whiteGloveUpsell_20200623":"variantShowOffer"}' );
	} );

	const randSerial = Math.floor( 100000 * Math.random() ) + 65535;
	const email = 'southptest2+' + randSerial + '@gmail.com';
	const userName = 'southptest' + randSerial;
	const password = <fill in whatever you want>

	// user step
	await page.fill( 'css=input#email', email );
	await page.fill( 'css=input#username', userName );
	await page.fill( 'css=input#password', password );
	await page.click( 'css=button[type="submit"]' );

	await page.waitForNavigation();

	// domain step
	const freeDomain = userName + '.wordpress.com';
	await page.fill( 'css=input[type="search"]', freeDomain );
	await page.click( 'css=div[data-e2e-domain="' + freeDomain + '" >> css=button[type="button"]' );

	await page.waitForNavigation();

	// plan step
	await page.click( 'css=.plans-features-main__banner-content >> css=button[type="button"]' );
	await page.waitForNavigation( { url: /offer-white-glove/ } );

	// expert guidance page
	const buyButtonSelector = 'css=button.white-glove__accept-offer-button';
	await page.waitForSelector( buyButtonSelector );
 	await page.click( buyButtonSelector );
} )();

```
