### PR TITLE
Jetpack Scan & Backup: Hide for Non-Admins

### DIFF
--- a/client/my-sites/backup/main.jsx
+++ b/client/my-sites/backup/main.jsx
@@ -26,6 +26,7 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { requestActivityLogs } from 'state/data-getters';
 import { withLocalizedMoment } from 'components/localized-moment';
 import BackupPlaceholder from 'components/jetpack/backup-placeholder';
+import EmptyContent from 'components/empty-content';
 import FormattedHeader from 'components/formatted-header';
 import BackupDelta from 'components/jetpack/backup-delta';
 import DailyBackupStatus from 'components/jetpack/daily-backup-status';
@@ -40,6 +41,7 @@ import Main from 'components/main';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import getActivityLogFilter from 'state/selectors/get-activity-log-filter';
 import ActivityCardList from 'components/activity-card-list';
+import canCurrentUser from 'state/selectors/can-current-user';
 import getSiteUrl from 'state/sites/selectors/get-site-url';
 import getDoesRewindNeedCredentials from 'state/selectors/get-does-rewind-need-credentials.js';
 import getSiteGmtOffset from 'state/selectors/get-site-gmt-offset';
@@ -256,8 +258,22 @@ class BackupsPage extends Component {
 		);
 	}
 
+	renderContent() {
+		const { isAdmin, isEmptyFilter, translate } = this.props;
+
+		if ( ! isAdmin ) {
+			return (
+				<EmptyContent
+					illustration="/calypso/images/illustrations/illustration-404.svg"
+					title={ translate( 'You are not authorized to view this page' ) }
+				/>
+			);
+		}
+
+		return isEmptyFilter ? this.renderMain() : this.renderBackupSearch();
+	}
+
 	render() {
-		const { isEmptyFilter } = this.props;
 		return (
 			<div
 				className={ classNames( 'backup__page', {
@@ -273,8 +289,7 @@ class BackupsPage extends Component {
 					{ ! isJetpackCloud() && (
 						<FormattedHeader headerText="Jetpack Backup" align="left" brandFont />
 					) }
-
-					{ isEmptyFilter ? this.renderMain() : this.renderBackupSearch() }
+					{ this.renderContent() }
 				</Main>
 			</div>
 		);
@@ -372,6 +387,7 @@ const mapStateToProps = ( state ) => {
 		allowRestore,
 		doesRewindNeedCredentials,
 		filter,
+		isAdmin: canCurrentUser( state, siteId, 'manage_options' ),
 		isEmptyFilter: getIsEmptyFilter( filter ),
 		siteCapabilities,
 		logs: logs?.data ?? [],

--- a/client/my-sites/backup/wpcom-backup-upsell.tsx
+++ b/client/my-sites/backup/wpcom-backup-upsell.tsx
@@ -10,11 +10,13 @@ import { useSelector } from 'react-redux';
  */
 import { addQueryArgs } from '@wordpress/url';
 import { Button } from '@automattic/components';
-import { getSelectedSiteSlug } from 'state/ui/selectors';
+import { getSelectedSiteSlug, getSelectedSiteId } from 'state/ui/selectors';
+import canCurrentUser from 'state/selectors/can-current-user';
 import { preventWidows } from 'lib/formatting';
 import DocumentHead from 'components/data/document-head';
 import FormattedHeader from 'components/formatted-header';
 import Main from 'components/main';
+import Notice from 'components/notice';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import PromoCard from 'components/promo-section/promo-card';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
@@ -31,6 +33,8 @@ const trackEventName = 'calypso_jetpack_backup_upsell';
 export default function WPCOMUpsellPage(): ReactElement {
 	const onUpgradeClick = useTrackCallback( undefined, trackEventName );
 	const siteSlug = useSelector( getSelectedSiteSlug );
+	const siteId = useSelector( getSelectedSiteId );
+	const isAdmin = useSelector( ( state ) => canCurrentUser( state, siteId, 'manage_options' ) );
 
 	return (
 		<Main className="backup__main backup__wpcom-upsell">
@@ -58,29 +62,39 @@ export default function WPCOMUpsellPage(): ReactElement {
 					) }
 				</p>
 
-				<div className="backup__wpcom-ctas">
-					<Button
-						className="backup__wpcom-cta backup__wpcom-realtime-cta"
-						href={ addQueryArgs( `/checkout/${ siteSlug }/jetpack_backup_realtime`, {
-							redirect_to: window.location.href,
-						} ) }
-						onClick={ onUpgradeClick }
-						selfTarget={ true }
-						primary
-					>
-						{ translate( 'Get real-time backups' ) }
-					</Button>
-					<Button
-						className="backup__wpcom-cta backup__wpcom-daily-cta"
-						href={ addQueryArgs( `/checkout/${ siteSlug }/jetpack_backup_daily`, {
-							redirect_to: window.location.href,
-						} ) }
-						onClick={ onUpgradeClick }
-						selfTarget={ true }
-					>
-						{ translate( 'Get daily backups' ) }
-					</Button>
-				</div>
+				{ ! isAdmin && (
+					<Notice
+						status="is-warning"
+						text={ translate( 'Only site administrators can upgrade to access Backup.' ) }
+						showDismiss={ false }
+					/>
+				) }
+
+				{ isAdmin && (
+					<div className="backup__wpcom-ctas">
+						<Button
+							className="backup__wpcom-cta backup__wpcom-realtime-cta"
+							href={ addQueryArgs( `/checkout/${ siteSlug }/jetpack_backup_realtime`, {
+								redirect_to: window.location.href,
+							} ) }
+							onClick={ onUpgradeClick }
+							selfTarget={ true }
+							primary
+						>
+							{ translate( 'Get real-time backups' ) }
+						</Button>
+						<Button
+							className="backup__wpcom-cta backup__wpcom-daily-cta"
+							href={ addQueryArgs( `/checkout/${ siteSlug }/jetpack_backup_daily`, {
+								redirect_to: window.location.href,
+							} ) }
+							onClick={ onUpgradeClick }
+							selfTarget={ true }
+						>
+							{ translate( 'Get daily backups' ) }
+						</Button>
+					</div>
+				) }
 			</PromoCard>
 		</Main>
 	);

--- a/client/my-sites/backup/wpcom-upsell.tsx
+++ b/client/my-sites/backup/wpcom-upsell.tsx
@@ -14,12 +14,14 @@ import SidebarNavigation from 'my-sites/sidebar-navigation';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import { isFreePlan } from 'lib/plans';
 import FormattedHeader from 'components/formatted-header';
+import Notice from 'components/notice';
 import PromoSection, { Props as PromoSectionProps } from 'components/promo-section';
 import PromoCard from 'components/promo-section/promo-card';
 import PromoCardCTA from 'components/promo-section/promo-card/cta';
 import useTrackCallback from 'lib/jetpack/use-track-callback';
 import Gridicon from 'components/gridicon';
 import { getSitePlan } from 'state/sites/selectors';
+import canCurrentUser from 'state/selectors/can-current-user';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import WhatIsJetpack from 'components/jetpack/what-is-jetpack';
 import { preventWidows } from 'lib/formatting';
@@ -48,6 +50,7 @@ export default function WPCOMUpsellPage(): ReactElement {
 	const onUpgradeClick = useTrackCallback( undefined, trackEventName );
 	const siteSlug = useSelector( getSelectedSiteSlug );
 	const siteId = useSelector( getSelectedSiteId );
+	const isAdmin = useSelector( ( state ) => canCurrentUser( state, siteId, 'manage_options' ) );
 	const { product_slug: planSlug } = useSelector( ( state ) => getSitePlan( state, siteId ) );
 
 	return (
@@ -75,16 +78,25 @@ export default function WPCOMUpsellPage(): ReactElement {
 						)
 					) }
 				</p>
-				<PromoCardCTA
-					cta={ {
-						text: translate( 'Upgrade to Business Plan' ),
-						action: {
-							url: `/checkout/${ siteSlug }/business`,
-							onClick: onUpgradeClick,
-							selfTarget: true,
-						},
-					} }
-				/>
+				{ ! isAdmin && (
+					<Notice
+						status="is-warning"
+						text={ translate( 'Only site administrators can upgrade to the Business plan.' ) }
+						showDismiss={ false }
+					/>
+				) }
+				{ isAdmin && (
+					<PromoCardCTA
+						cta={ {
+							text: translate( 'Upgrade to Business Plan' ),
+							action: {
+								url: `/checkout/${ siteSlug }/business`,
+								onClick: onUpgradeClick,
+								selfTarget: true,
+							},
+						} }
+					/>
+				) }
 			</PromoCard>
 
 			{ isFreePlan( planSlug ) && (

--- a/client/my-sites/scan/history/index.tsx
+++ b/client/my-sites/scan/history/index.tsx
@@ -11,6 +11,7 @@ import { useSelector } from 'react-redux';
  */
 import DocumentHead from 'components/data/document-head';
 import QueryJetpackScanHistory from 'components/data/query-jetpack-scan-history';
+import EmptyContent from 'components/empty-content';
 import FormattedHeader from 'components/formatted-header';
 import ThreatHistoryList from 'components/jetpack/threat-history-list';
 import Main from 'components/main';
@@ -18,6 +19,7 @@ import PageViewTracker from 'lib/analytics/page-view-tracker';
 import isJetpackCloud from 'lib/jetpack/is-jetpack-cloud';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import { getSelectedSiteId } from 'state/ui/selectors';
+import canCurrentUser from 'state/selectors/can-current-user';
 import ScanNavigation from '../navigation';
 
 /**
@@ -32,6 +34,7 @@ interface Props {
 export default function ScanHistoryPage( { filter }: Props ) {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId );
+	const isAdmin = useSelector( ( state ) => canCurrentUser( state, siteId, 'manage_options' ) );
 	const isJetpackPlatform = isJetpackCloud();
 
 	return (
@@ -42,20 +45,30 @@ export default function ScanHistoryPage( { filter }: Props ) {
 		>
 			<DocumentHead title={ translate( 'Scan' ) } />
 			<SidebarNavigation />
-			<QueryJetpackScanHistory siteId={ siteId } />
 			<PageViewTracker path="/scan/history/:site" title="Scan History" />
 			{ ! isJetpackPlatform && (
 				<FormattedHeader headerText={ 'Jetpack Scan' } align="left" brandFont />
 			) }
-			<ScanNavigation section={ 'history' } />
-			<section className="history__body">
-				<p className="history__description">
-					{ translate(
-						'The scanning history contains a record of all previously active threats on your site.'
-					) }
-				</p>
-				<ThreatHistoryList filter={ filter } />
-			</section>
+			{ ! isAdmin && (
+				<EmptyContent
+					illustration="/calypso/images/illustrations/illustration-404.svg"
+					title={ translate( 'You are not authorized to view this page' ) }
+				/>
+			) }
+			{ isAdmin && (
+				<>
+					<QueryJetpackScanHistory siteId={ siteId } />
+					<ScanNavigation section={ 'history' } />
+					<section className="history__body">
+						<p className="history__description">
+							{ translate(
+								'The scanning history contains a record of all previously active threats on your site.'
+							) }
+						</p>
+						<ThreatHistoryList filter={ filter } />
+					</section>
+				</>
+			) }
 		</Main>
 	);
 }

--- a/client/my-sites/scan/main.tsx
+++ b/client/my-sites/scan/main.tsx
@@ -19,11 +19,13 @@ import SecurityIcon from 'components/jetpack/security-icon';
 import ScanPlaceholder from 'components/jetpack/scan-placeholder';
 import ScanThreats from 'components/jetpack/scan-threats';
 import { Scan, Site } from 'my-sites/scan/types';
+import EmptyContent from 'components/empty-content';
 import Gridicon from 'components/gridicon';
 import Main from 'components/main';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
+import canCurrentUser from 'state/selectors/can-current-user';
 import getSiteUrl from 'state/sites/selectors/get-site-url';
 import getSiteScanProgress from 'state/selectors/get-site-scan-progress';
 import getSiteScanIsInitial from 'state/selectors/get-site-scan-is-initial';
@@ -234,7 +236,7 @@ class ScanPage extends Component< Props > {
 	}
 
 	render() {
-		const { siteId } = this.props;
+		const { isAdmin, siteId } = this.props;
 		const isJetpackPlatform = isJetpackCloud();
 
 		if ( ! siteId ) {
@@ -249,15 +251,25 @@ class ScanPage extends Component< Props > {
 			>
 				<DocumentHead title="Scan" />
 				<SidebarNavigation />
-				<QueryJetpackScan siteId={ siteId } />
 				<PageViewTracker path="/scan/:site" title="Scanner" />
 				{ ! isJetpackPlatform && (
 					<FormattedHeader headerText={ 'Jetpack Scan' } align="left" brandFont />
 				) }
-				<ScanNavigation section={ 'scanner' } />
-				<Card>
-					<div className="scan__content">{ this.renderScanState() }</div>
-				</Card>
+				{ isAdmin && (
+					<>
+						<QueryJetpackScan siteId={ siteId } />
+						<ScanNavigation section={ 'scanner' } />
+						<Card>
+							<div className="scan__content">{ this.renderScanState() }</div>
+						</Card>
+					</>
+				) }
+				{ ! isAdmin && (
+					<EmptyContent
+						illustration="/calypso/images/illustrations/illustration-404.svg"
+						title={ translate( 'You are not authorized to view this page' ) }
+					/>
+				) }
 			</Main>
 		);
 	}
@@ -277,6 +289,7 @@ export default connect(
 		const scanState = ( getSiteScanState( state, siteId ) as Scan ) ?? undefined;
 		const scanProgress = getSiteScanProgress( state, siteId ) ?? undefined;
 		const isInitialScan = getSiteScanIsInitial( state, siteId );
+		const isAdmin = canCurrentUser( state, siteId, 'manage_options' );
 
 		return {
 			site,
@@ -285,6 +298,7 @@ export default connect(
 			scanState,
 			scanProgress,
 			isInitialScan,
+			isAdmin,
 		};
 	},
 	{

--- a/client/my-sites/scan/wpcom-scan-upsell.tsx
+++ b/client/my-sites/scan/wpcom-scan-upsell.tsx
@@ -9,10 +9,12 @@ import { useSelector } from 'react-redux';
  * Internal dependencies
  */
 import { addQueryArgs } from '@wordpress/url';
-import { getSelectedSiteSlug } from 'state/ui/selectors';
+import { getSelectedSiteSlug, getSelectedSiteId } from 'state/ui/selectors';
+import canCurrentUser from 'state/selectors/can-current-user';
 import DocumentHead from 'components/data/document-head';
 import FormattedHeader from 'components/formatted-header';
 import Main from 'components/main';
+import Notice from 'components/notice';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import PromoCard from 'components/promo-section/promo-card';
 import PromoCardCTA from 'components/promo-section/promo-card/cta';
@@ -28,6 +30,8 @@ import './style.scss';
 export default function WPCOMScanUpsellPage(): ReactElement {
 	const onUpgradeClick = useTrackCallback( undefined, 'calypso_jetpack_scan_upsell' );
 	const siteSlug = useSelector( getSelectedSiteSlug );
+	const siteId = useSelector( getSelectedSiteId );
+	const isAdmin = useSelector( ( state ) => canCurrentUser( state, siteId, 'manage_options' ) );
 
 	return (
 		<Main className="scan scan__wpcom-upsell">
@@ -53,18 +57,29 @@ export default function WPCOMScanUpsellPage(): ReactElement {
 							'to keep your site ahead of security threats.'
 					) }
 				</p>
-				<PromoCardCTA
-					cta={ {
-						text: translate( 'Get daily scanning' ),
-						action: {
-							url: addQueryArgs( `/checkout/${ siteSlug }/jetpack_scan`, {
-								redirect_to: window.location.href,
-							} ),
-							onClick: onUpgradeClick,
-							selfTarget: true,
-						},
-					} }
-				/>
+
+				{ ! isAdmin && (
+					<Notice
+						status="is-warning"
+						text={ translate( 'Only site administrators can upgrade to access daily scanning.' ) }
+						showDismiss={ false }
+					/>
+				) }
+
+				{ isAdmin && (
+					<PromoCardCTA
+						cta={ {
+							text: translate( 'Get daily scanning' ),
+							action: {
+								url: addQueryArgs( `/checkout/${ siteSlug }/jetpack_scan`, {
+									redirect_to: window.location.href,
+								} ),
+								onClick: onUpgradeClick,
+								selfTarget: true,
+							},
+						} }
+					/>
+				) }
 			</PromoCard>
 		</Main>
 	);

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -399,9 +399,13 @@ export class MySitesSidebar extends Component {
 	}
 
 	jetpack() {
-		const { isJetpackSectionOpen, path } = this.props;
+		const { canUserManageOptions, isJetpackSectionOpen, path } = this.props;
 
 		if ( isEnabled( 'signup/wpforteams' ) && this.props.isSiteWPForTeams ) {
+			return null;
+		}
+
+		if ( ! canUserManageOptions ) {
 			return null;
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Currently, Jetpack Scan & Backup pretty easily allows non-admins to access places which they shouldn't be able to access, notably the Checkout, which causes Calypso to start breaking. This PR fixes this, taking precedence from the Earn section. 

#### Testing instructions

This is only applicable to non-admins; everything should be the same for administrators.

Firstly, the Jetpack section should disappear in the sidebar.

<img width="261" alt="Screenshot 2020-07-09 at 13 24 31" src="https://user-images.githubusercontent.com/43215253/87039751-8b7c3280-c1e7-11ea-809d-29f3c0a43a3a.png">

Individual sections tend to also receive these changes in Calypso, such as to prevent people accessing them by switching sites. For nudges, a notice should appear informing the user that only administrators can upgrade, just as is the case in the Earn section. 

<img width="902" alt="Screenshot 2020-07-09 at 12 52 23" src="https://user-images.githubusercontent.com/43215253/87039921-cc744700-c1e7-11ea-9a4a-0951b9e25b99.png">
<img width="1038" alt="Screenshot 2020-07-09 at 12 46 04" src="https://user-images.githubusercontent.com/43215253/87039969-e01fad80-c1e7-11ea-848b-43216d3925a0.png">

If, however, the nudge does not appear as the site already has access to the product, the usual authorisation error should occur.

<img width="878" alt="Screenshot 2020-07-09 at 12 46 37" src="https://user-images.githubusercontent.com/43215253/87040024-f62d6e00-c1e7-11ea-863f-abfe3d4b6761.png">
<img width="770" alt="Screenshot 2020-07-09 at 13 59 16" src="https://user-images.githubusercontent.com/43215253/87043056-6c33d400-c1ec-11ea-8426-e73ea90f622f.png">

