### PR TITLE
Modularise connected applications state

### DIFF
--- a/client/state/connected-applications/actions.js
+++ b/client/state/connected-applications/actions.js
@@ -10,6 +10,7 @@ import {
 
 import 'state/data-layer/wpcom/me/connected-applications';
 import 'state/data-layer/wpcom/me/connected-applications/delete';
+import 'state/connected-applications/init';
 
 /**
  * Returns an action object to signal the request of the user's connected applications.

--- a/client/state/connected-applications/init.js
+++ b/client/state/connected-applications/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'state/redux-store';
+import reducer from './reducer';
+
+registerReducer( [ 'connectedApplications' ], reducer );

--- a/client/state/connected-applications/package.json
+++ b/client/state/connected-applications/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/connected-applications/reducer.js
+++ b/client/state/connected-applications/reducer.js
@@ -10,7 +10,7 @@ import {
 	CONNECTED_APPLICATION_DELETE_SUCCESS,
 	CONNECTED_APPLICATIONS_RECEIVE,
 } from 'state/action-types';
-import { withSchemaValidation } from 'state/utils';
+import { withSchemaValidation, withStorageKey } from 'state/utils';
 import schema from './schema';
 
 const reducer = ( state = null, action ) => {
@@ -24,4 +24,6 @@ const reducer = ( state = null, action ) => {
 	}
 };
 
-export default withSchemaValidation( schema, reducer );
+const validatedReducer = withSchemaValidation( schema, reducer );
+
+export default withStorageKey( 'connectedApplications', validatedReducer );

--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -17,7 +17,6 @@ import { reducer as httpData } from 'state/data-layer/http-data';
 import accountRecovery from './account-recovery/reducer';
 import activityLog from './activity-log/reducer';
 import atomicTransfer from './atomic-transfer/reducer';
-import connectedApplications from './connected-applications/reducer';
 import currentUser from './current-user/reducer';
 import { reducer as dataRequests } from './data-layer/wpcom-http/utils';
 import documentHead from './document-head/reducer';
@@ -77,7 +76,6 @@ const reducers = {
 	accountRecovery,
 	activityLog,
 	atomicTransfer,
-	connectedApplications,
 	currentUser,
 	dataRequests,
 	documentHead,

--- a/client/state/selectors/get-connected-applications.js
+++ b/client/state/selectors/get-connected-applications.js
@@ -3,6 +3,8 @@
  */
 import { get } from 'lodash';
 
+import 'state/connected-applications/init';
+
 /**
  * Returns the connected applications of the current user.
  *


### PR DESCRIPTION
This PR is one of many working on modularising state in Calypso. This one handles connected applications.

For more details on state modularisation, see the [modularised state documentation](https://github.com/Automattic/wp-calypso/blob/master/docs/modularized-state.md) and p4TIVU-9lM-p2.

Note: I added reviewers that GitHub suggested. Please feel free to ignore the review request or pull in someone else if you're not comfortable reviewing this PR. Thank you!

Fixes #42427.

#### Changes proposed in this Pull Request

* Modularise connected applications state

#### Testing instructions

* Install [Redux DevTools](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en).
* Open DevTools and switch to the Redux tab.
* Open `/read` on the live branch or your local copy of this branch.
* Click `State` on the top right to ensure you see all state, and not just the diff for the last action: 
![image](https://user-images.githubusercontent.com/409615/73774406-d3e87d80-477b-11ea-9f59-3e42cc00101f.png)
* Analyse the tree and note that there's no `connectedApplications` key, even if you expand the list of keys. This indicates that the connected applications state hasn't been loaded yet.
* Click your avatar on the masterbar, followed by `Security` on the sidebar.
* Open the `Connected Applications` section.
* Verify that a `connectedApplications` key is added with the connected applications state. This indicates that the connected applications state has now been loaded.
* Verify that connected applications-related functionality works normally. This indicates that I didn't mess up.