### PR TITLE
media state: remove `MediaActions.delete`

### DIFF
--- a/client/lib/media/actions.js
+++ b/client/lib/media/actions.js
@@ -18,7 +18,6 @@ import MediaListStore from './list-store';
 import {
 	changeMediaSource,
 	createMediaItem,
-	deleteMedia,
 	failMediaItemRequest,
 	failMediaRequest,
 	receiveMedia,
@@ -246,39 +245,6 @@ MediaActions.update = function ( siteId, item, editMediaFile = false ) {
 				error: error,
 				siteId: siteId,
 				data: editMediaFile ? { ...data, isDirty: true } : data,
-			} );
-		} );
-};
-
-MediaActions.delete = function ( siteId, item ) {
-	if ( Array.isArray( item ) ) {
-		item.forEach( MediaActions.delete.bind( null, siteId ) );
-		return;
-	}
-
-	Dispatcher.handleViewAction( {
-		type: 'REMOVE_MEDIA_ITEM',
-		siteId: siteId,
-		data: item,
-	} );
-
-	reduxDispatch( deleteMedia( siteId, item.ID ) );
-
-	debug( 'Deleting media from %d by ID %d', siteId, item.ID );
-	wpcom
-		.site( siteId )
-		.media( item.ID )
-		.delete( function ( error, data ) {
-			Dispatcher.handleServerAction( {
-				type: 'REMOVE_MEDIA_ITEM',
-				error: error,
-				siteId: siteId,
-				data: data,
-			} );
-			// also refetch storage limits
-			Dispatcher.handleServerAction( {
-				type: 'FETCH_MEDIA_LIMITS',
-				siteId: siteId,
 			} );
 		} );
 };

--- a/client/lib/media/test/actions.js
+++ b/client/lib/media/test/actions.js
@@ -338,48 +338,6 @@ describe( 'MediaActions', () => {
 		} );
 	} );
 
-	describe( '#delete()', () => {
-		const item = { ID: 100 };
-
-		test( 'should accept a single item', () => {
-			MediaActions.delete( DUMMY_SITE_ID, item );
-			expect( stubs.mediaDelete ).to.have.been.calledOnce;
-		} );
-
-		test( 'should accept an array of items', () => {
-			MediaActions.delete( DUMMY_SITE_ID, [ item, item ] );
-			expect( stubs.mediaDelete ).to.have.been.calledTwice;
-		} );
-
-		test( 'should call to the WordPress.com REST API', () => {
-			return new Promise( ( done ) => {
-				MediaActions.delete( DUMMY_SITE_ID, item );
-
-				expect( stubs.mediaDelete ).to.have.been.calledOn( [ DUMMY_SITE_ID, item.ID ].join() );
-				process.nextTick( function () {
-					expect( Dispatcher.handleServerAction ).to.have.been.calledWithMatch( {
-						type: 'REMOVE_MEDIA_ITEM',
-						error: null,
-						siteId: DUMMY_SITE_ID,
-						data: DUMMY_API_RESPONSE,
-					} );
-
-					done();
-				} );
-			} );
-		} );
-
-		test( 'should immediately remove the item', () => {
-			MediaActions.delete( DUMMY_SITE_ID, item );
-
-			expect( Dispatcher.handleViewAction ).to.have.been.calledWithMatch( {
-				type: 'REMOVE_MEDIA_ITEM',
-				siteId: DUMMY_SITE_ID,
-				data: item,
-			} );
-		} );
-	} );
-
 	describe( '#sourceChanged()', () => {
 		test( 'should dispatch the `CHANGE_MEDIA_SOURCE` action with the specified siteId', () => {
 			MediaActions.sourceChanged( DUMMY_SITE_ID );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove `MediaActions.delete`

#### Testing instructions

* Ensure all unit tests pass
* Ensure `MediaActions.delete` isn't used anywhere throughout Calypso

related to #43662

