### PR TITLE
Modularise timezones state

### DIFF
--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -67,7 +67,6 @@ import siteSettings from './site-settings/reducer';
 import sites from './sites/reducer';
 import storedCards from './stored-cards/reducer';
 import support from './support/reducer';
-import timezones from './timezones/reducer';
 import ui from './ui/reducer';
 import userDevices from './user-devices/reducer';
 import userProfileLinks from './profile-links/reducer';
@@ -133,7 +132,6 @@ const reducers = {
 	sites,
 	storedCards,
 	support,
-	timezones,
 	ui,
 	userDevices,
 	userProfileLinks,

--- a/client/state/selectors/get-raw-offsets.js
+++ b/client/state/selectors/get-raw-offsets.js
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import 'state/timezones/init';
 
 /**
  * Return manual utc offsets data

--- a/client/state/selectors/get-timezones-by-continent.js
+++ b/client/state/selectors/get-timezones-by-continent.js
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import 'state/timezones/init';
 
 /**
  * Return the timezones by continent data

--- a/client/state/selectors/get-timezones-label.js
+++ b/client/state/selectors/get-timezones-label.js
@@ -1,8 +1,9 @@
 /**
  * Internal dependencies
  */
-
 import getTimezonesLabels from 'state/selectors/get-timezones-labels';
+
+import 'state/timezones/init';
 
 /**
  * Return timezone `label` according to the given timezone key (value)

--- a/client/state/selectors/get-timezones-labels-by-continent.js
+++ b/client/state/selectors/get-timezones-labels-by-continent.js
@@ -1,15 +1,15 @@
 /**
  * External dependencies
  */
-
 import { fromPairs, map } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import getTimezonesByContinent from 'state/selectors/get-timezones-by-continent';
-
 import getTimezonesLabel from 'state/selectors/get-timezones-label';
+
+import 'state/timezones/init';
 
 /**
  * Return the timezones by continent data

--- a/client/state/selectors/get-timezones-labels.js
+++ b/client/state/selectors/get-timezones-labels.js
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import 'state/timezones/init';
 
 /**
  * Return an object of timezones.

--- a/client/state/selectors/get-timezones.js
+++ b/client/state/selectors/get-timezones.js
@@ -1,13 +1,14 @@
 /**
  * External dependencies
  */
-
 import { get, map, toPairs } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import getTimezonesLabel from 'state/selectors/get-timezones-label';
+
+import 'state/timezones/init';
 
 /**
  * Return all timezones ordered by arrays with

--- a/client/state/timezones/actions.js
+++ b/client/state/timezones/actions.js
@@ -1,10 +1,10 @@
 /**
  * Internal dependencies
  */
-
 import { TIMEZONES_RECEIVE, TIMEZONES_REQUEST } from 'state/action-types';
 
 import 'state/data-layer/wpcom/timezones';
+import 'state/timezones/init';
 
 export const requestTimezones = () => ( {
 	type: TIMEZONES_REQUEST,

--- a/client/state/timezones/init.js
+++ b/client/state/timezones/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'state/redux-store';
+import reducer from './reducer';
+
+registerReducer( [ 'timezones' ], reducer );

--- a/client/state/timezones/package.json
+++ b/client/state/timezones/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/timezones/reducer.js
+++ b/client/state/timezones/reducer.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { combineReducers, withSchemaValidation } from 'state/utils';
+import { combineReducers, withSchemaValidation, withStorageKey } from 'state/utils';
 import { TIMEZONES_RECEIVE } from 'state/action-types';
 
 import { rawOffsetsSchema, labelsSchema, continentsSchema } from './schema';
@@ -33,8 +33,10 @@ export const byContinents = withSchemaValidation( continentsSchema, ( state = {}
 	return state;
 } );
 
-export default combineReducers( {
+const combinedReducer = combineReducers( {
 	rawOffsets,
 	labels,
 	byContinents,
 } );
+
+export default withStorageKey( 'timezones', combinedReducer );


### PR DESCRIPTION
This PR is one of many working on modularising state in Calypso. This one handles timezones.

For more details on state modularisation, see the [modularised state documentation](https://github.com/Automattic/wp-calypso/blob/master/docs/modularized-state.md) and p4TIVU-9lM-p2.

Note: I added reviewers that GitHub suggested. Please feel free to ignore the review request or pull in someone else if you're not comfortable reviewing this PR. Thank you!

Fixes #42485.

#### Changes proposed in this Pull Request

* Modularise timezones state

#### Testing instructions

* Install [Redux DevTools](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en).
* Open DevTools and switch to the Redux tab.
* Open `/read` on the live branch or your local copy of this branch.
* Click `State` on the top right to ensure you see all state, and not just the diff for the last action: 
![image](https://user-images.githubusercontent.com/409615/73774406-d3e87d80-477b-11ea-9f59-3e42cc00101f.png)
* Analyse the tree and note that there's no `timezones` key, even if you expand the list of keys. This indicates that the timezones state hasn't been loaded yet.
* Click `My Sites` on the top bar, followed by `Manage` and `Settings` on the sidebar.
* Verify that a `timezones` key is added with the timezones state. This indicates that the timezones state has now been loaded.
* Verify that timezone-related functionality works normally. This indicates that I didn't mess up.