### PR TITLE
Fix call to action message for downloading backup

### DIFF
--- a/client/my-sites/backup/rewind-flow/download.tsx
+++ b/client/my-sites/backup/rewind-flow/download.tsx
@@ -79,7 +79,9 @@ const BackupDownloadFlow: FunctionComponent< Props > = ( {
 					}
 				) }
 			</p>
-			<h4 className="rewind-flow__cta">{ translate( 'Choose the items you wish to include in the download:' ) }</h4>
+			<h4 className="rewind-flow__cta">
+				{ translate( 'Choose the items you wish to include in the download:' ) }
+			</h4>
 			<RewindConfigEditor currentConfig={ rewindConfig } onConfigChange={ setRewindConfig } />
 			<RewindFlowNotice
 				gridicon="notice-outline"

--- a/client/my-sites/backup/rewind-flow/download.tsx
+++ b/client/my-sites/backup/rewind-flow/download.tsx
@@ -79,7 +79,7 @@ const BackupDownloadFlow: FunctionComponent< Props > = ( {
 					}
 				) }
 			</p>
-			<h4 className="rewind-flow__cta">{ translate( 'Choose the items you wish to restore:' ) }</h4>
+			<h4 className="rewind-flow__cta">{ translate( 'Choose the items you wish to include in the download:' ) }</h4>
 			<RewindConfigEditor currentConfig={ rewindConfig } onConfigChange={ setRewindConfig } />
 			<RewindFlowNotice
 				gridicon="notice-outline"


### PR DESCRIPTION
Remove reference to backup restoration.

#### Changes proposed in this Pull Request

* Updates top message:
  * From: "Choose the items you wish to restore:"
  * To: "Choose the items you wish to include in the download:"

Before:
<img width="717" alt="Screen Shot 2020-07-09 at 2 31 22 pm" src="https://user-images.githubusercontent.com/68693/87046452-23324e80-c1f1-11ea-9c45-cc7304242d27.png">

After:
<img width="733" alt="Screen Shot 2020-07-09 at 2 35 39 pm" src="https://user-images.githubusercontent.com/68693/87046786-80c69b00-c1f1-11ea-94e3-41785bee5e41.png">

#### Testing instructions

* Observe the message is correct.

