### PR TITLE
Media Library: Wrap plan storage bar in a link if an upgrade is available

### DIFF
--- a/client/blocks/plan-storage/bar.jsx
+++ b/client/blocks/plan-storage/bar.jsx
@@ -22,23 +22,11 @@ export class PlanStorageBar extends Component {
 		className: PropTypes.string,
 		mediaStorage: PropTypes.object,
 		displayUpgradeLink: PropTypes.bool,
-		siteSlug: PropTypes.string.isRequired,
 		sitePlanSlug: PropTypes.string.isRequired,
 	};
 
-	static defaultProps = {
-		siteSlug: '',
-	};
-
 	render() {
-		const {
-			className,
-			displayUpgradeLink,
-			mediaStorage,
-			sitePlanSlug,
-			siteSlug,
-			translate,
-		} = this.props;
+		const { className, displayUpgradeLink, mediaStorage, sitePlanSlug, translate } = this.props;
 
 		if ( planHasFeature( sitePlanSlug, FEATURE_UNLIMITED_STORAGE ) ) {
 			return null;
@@ -75,9 +63,7 @@ export class PlanStorageBar extends Component {
 				</span>
 
 				{ displayUpgradeLink && (
-					<a className="plan-storage__storage-link" href={ `/plans/${ siteSlug }` }>
-						{ translate( 'Upgrade' ) }
-					</a>
+					<span className="plan-storage__storage-link">{ translate( 'Upgrade' ) }</span>
 				) }
 
 				{ this.props.children }

--- a/client/blocks/plan-storage/index.jsx
+++ b/client/blocks/plan-storage/index.jsx
@@ -55,18 +55,30 @@ export class PlanStorage extends Component {
 		const planHasTopStorageSpace =
 			isBusinessPlan( sitePlanSlug ) || isEcommercePlan( sitePlanSlug );
 
-		return (
-			<div className={ classNames( className, 'plan-storage' ) }>
+		const displayUpgradeLink = canUserUpgrade && ! planHasTopStorageSpace;
+
+		const planStorageComponents = (
+			<>
 				<QueryMediaStorage siteId={ siteId } />
 				<PlanStorageBar
-					siteSlug={ siteSlug }
 					sitePlanSlug={ sitePlanSlug }
 					mediaStorage={ this.props.mediaStorage }
-					displayUpgradeLink={ canUserUpgrade && ! planHasTopStorageSpace }
+					displayUpgradeLink={ displayUpgradeLink }
 				>
 					{ this.props.children }
 				</PlanStorageBar>
-			</div>
+			</>
+		);
+
+		if ( displayUpgradeLink ) {
+			return (
+				<a className={ classNames( className, 'plan-storage' ) } href={ `/plans/${ siteSlug }` }>
+					{ planStorageComponents }
+				</a>
+			);
+		}
+		return (
+			<div className={ classNames( className, 'plan-storage' ) }>{ planStorageComponents }</div>
 		);
 	}
 }

--- a/client/blocks/plan-storage/test/plan-storage.jsx
+++ b/client/blocks/plan-storage/test/plan-storage.jsx
@@ -45,7 +45,6 @@ describe( 'PlanStorage basic tests', () => {
 		const storage = shallow( <PlanStorage { ...props } /> );
 		const bar = storage.find( 'Localized(PlanStorageBar)' );
 		assert.lengthOf( bar, 1 );
-		assert.equal( bar.props().siteSlug, props.siteSlug );
 		assert.equal( bar.props().sitePlanSlug, props.sitePlanSlug );
 		assert.equal( bar.props().mediaStorage, props.mediaStorage );
 	} );


### PR DESCRIPTION
## Changes proposed in this Pull Request

* This partially addresses #40986 by updating the hit state on the media library PlanStorage component to encompass the whole block rather than just upgrade link.

**Before**

<img width="300" alt="Screen Shot 2020-07-09 at 9 58 01 AM" src="https://user-images.githubusercontent.com/2124984/87049231-b73cef80-c1ca-11ea-8ff2-4c1a23393b91.png">

**After**

<img width="306" alt="Screen Shot 2020-07-09 at 9 57 39 AM" src="https://user-images.githubusercontent.com/2124984/87049240-ba37e000-c1ca-11ea-8fda-fa7d68cb7893.png">

#### Testing instructions

* Switch to this PR
* Navigate to `/media` on a site that is free or has a plan less than Business; there should be an upgrade link as shown above
* You should be able to click anywhere within the plan storage block to get to the Plans page to upgrade. Setting focus on the link should outline the whole block.
* Check the Media Library on a Jetpack site; you should not see the plan storage block at all
* Check the Media Library on a Business site; you should not see the upgrade link at all, and you should not be able to click on the plan storage box