### PR TITLE
Checkout Redesign: add Jetpack support

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -27,7 +27,7 @@ import isSiteMigrationInProgress from 'state/selectors/is-site-migration-in-prog
 import isSiteMigrationActiveRoute from 'state/selectors/is-site-migration-active-route';
 import { setNextLayoutFocus } from 'state/ui/layout-focus/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { getSiteSlug } from 'state/sites/selectors';
+import { getSiteSlug, isJetpackSite } from 'state/sites/selectors';
 import canCurrentUserUseCustomerHome from 'state/sites/selectors/can-current-user-use-customer-home';
 import { getStatsPathForTab } from 'lib/route';
 import { domainManagementList } from 'my-sites/domains/paths';
@@ -38,6 +38,8 @@ import { requestHttpData } from 'state/data-layer/http-data';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { hasUnseen } from 'state/reader-ui/seen-posts/selectors';
 import getPreviousPath from 'state/selectors/get-previous-path.js';
+import isAtomicSite from 'state/selectors/is-site-automated-transfer';
+import JetpackLogo from 'components/jetpack-logo';
 
 class MasterbarLoggedIn extends React.Component {
 	static propTypes = {
@@ -167,6 +169,7 @@ class MasterbarLoggedIn extends React.Component {
 			isMigrationInProgress,
 			previousPath,
 			siteSlug,
+			isJetpackNotAtomic,
 		} = this.props;
 
 		if ( isCheckout === true ) {
@@ -186,7 +189,8 @@ class MasterbarLoggedIn extends React.Component {
 							tooltip={ translate( 'Close Checkout' ) }
 							tipTarget="close"
 						/>
-						<WordPressWordmark className="masterbar__wpcom-wordmark" />
+						{ ! isJetpackNotAtomic && <WordPressWordmark className="masterbar__wpcom-wordmark" /> }
+						{ isJetpackNotAtomic && <JetpackLogo className="masterbar__jetpack-wordmark" full /> }
 						<span className="masterbar__secure-checkout-text">
 							{ translate( 'Secure checkout' ) }
 						</span>
@@ -278,6 +282,7 @@ export default connect(
 			migrationStatus: getSiteMigrationStatus( state, currentSelectedSiteId ),
 			currentSelectedSiteId,
 			previousPath: getPreviousPath( state ),
+			isJetpackNotAtomic: isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId ),
 		};
 	},
 	{ setNextLayoutFocus, recordTracksEvent, updateSiteMigrationMeta }

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -23,6 +23,12 @@ $autobar-height: 20px;
 		background: var( --studio-orange );
 		border-bottom: 1px solid var( --studio-orange-60 );
 	}
+
+	.is-section-checkout.is-jetpack-site & {
+		background-color: var( --color-jetpack-masterbar-background );
+		border-bottom: 1px solid var( --color-jetpack-masterbar-border );
+		color: var( --color-jetpack-masterbar-text );
+	}
 }
 
 .pride .masterbar {
@@ -112,6 +118,10 @@ $autobar-height: 20px;
 
 	.gridicon {
 		fill: var( --color-masterbar-text ); // only because safari gets currentColor wrong
+
+		.is-section-checkout.is-jetpack-site & {
+			fill: var( --color-jetpack-masterbar-text );
+		}
 	}
 
 	.gridicon + .masterbar__item-content {
@@ -121,6 +131,11 @@ $autobar-height: 20px;
 	&:hover {
 		background: var( --color-masterbar-item-hover-background );
 		color: var( --color-masterbar-text );
+
+		.is-section-checkout.is-jetpack-site & {
+			background: var( --color-jetpack-masterbar-item-hover-background );
+			color: var( --color-jetpack-masterbar-text );
+		}
 	}
 
 	&:focus {
@@ -129,6 +144,11 @@ $autobar-height: 20px;
 		.accessible-focus & {
 			box-shadow: inset 0 0 0 2px var( --color-primary-light );
 			color: var( --color-masterbar-text );
+		}
+
+		.is-section-checkout.is-jetpack-site & {
+			box-shadow: inset 0 0 0 2px var( --color-jetpack-masterbar-item-hover-background );
+			color: var( --color-jetpack-masterbar-text );
 		}
 	}
 
@@ -154,8 +174,12 @@ $autobar-height: 20px;
 	}
 
 	&.masterbar__close-button {
-		border-right: 1px solid var( --color-primary-light );
+		border-right: 1px solid var( --color-masterbar-border );
 		margin-right: 15px;
+
+		.is-section-checkout.is-jetpack-site & {
+			border-right: 1px solid var( --color-jetpack-masterbar-border );
+		}
 
 		.masterbar__item-content {
 			display: none;
@@ -575,8 +599,18 @@ a.masterbar__quick-language-switcher {
 		margin-right: 5px;
 	}
 
+	.masterbar__jetpack-wordmark {
+		height: 25px;
+		margin-right: 5px;
+	}
+
 	.masterbar__secure-checkout-text {
 		color: var( --color-primary-5 );
 		transform: translateY( 1px );
+
+		.is-jetpack-site & {
+			color: var( --color-jetpack-masterbar-text );
+			transform: translateY( -1px );
+		}
 	}
 }

--- a/client/my-sites/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout-system-decider.js
@@ -229,7 +229,7 @@ function getCheckoutVariant(
 	// products via URL, so we list those slugs here. Renewals use actual slugs,
 	// so they do not need to go through this check.
 	const isRenewal = !! purchaseId;
-	const pseudoSlugsToAllow = [
+	let pseudoSlugsToAllow = [
 		'blogger',
 		'blogger-2-years',
 		'business',
@@ -237,6 +237,12 @@ function getCheckoutVariant(
 		'concierge-session',
 		'ecommerce',
 		'ecommerce-2-years',
+		'personal',
+		'personal-2-years',
+		'premium', // WordPress.com or Jetpack Premium Yearly
+		'premium-2-years',
+	];
+	const jetpackPseudoSlugsToAllow = [
 		'jetpack_backup_daily',
 		'jetpack_backup_realtime',
 		'jetpack_personal',
@@ -244,14 +250,13 @@ function getCheckoutVariant(
 		'jetpack-personal-monthly',
 		'jetpack_scan',
 		'jetpack_search',
-		'personal',
-		'personal-2-years',
-		'premium', // WordPress.com or Jetpack Premium Yearly
-		'premium-monthly', // Jetpack Premium Monthly
-		'premium-2-years',
+		'premium-monthly',
 		'professional',
 		'professional-monthly',
 	];
+	if ( config( 'env_id' ) !== 'production' ) {
+		pseudoSlugsToAllow = [ ...pseudoSlugsToAllow, ...jetpackPseudoSlugsToAllow ];
+	}
 	const slugPrefixesToAllow = [ 'domain-mapping:', 'theme:' ];
 	if (
 		! isRenewal &&

--- a/client/my-sites/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout-system-decider.js
@@ -237,10 +237,20 @@ function getCheckoutVariant(
 		'concierge-session',
 		'ecommerce',
 		'ecommerce-2-years',
+		'jetpack_backup_daily',
+		'jetpack_backup_realtime',
+		'jetpack_personal',
+		'jetpack-personal',
+		'jetpack-personal-monthly',
+		'jetpack_scan',
+		'jetpack_search',
 		'personal',
 		'personal-2-years',
-		'premium',
+		'premium', // WordPress.com or Jetpack Premium Yearly
+		'premium-monthly', // Jetpack Premium Monthly
 		'premium-2-years',
+		'professional',
+		'professional-monthly',
 	];
 	const slugPrefixesToAllow = [ 'domain-mapping:', 'theme:' ];
 	if (

--- a/client/my-sites/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout-system-decider.js
@@ -210,13 +210,16 @@ function getCheckoutVariant(
 		return 'disallowed-geo';
 	}
 
-	// Disable if this is a jetpack site
-	if ( isJetpack && ! isAtomic ) {
+	// Disable for Jetpack sites in production
+	if ( config( 'env_id' ) === 'production' && isJetpack && ! isAtomic ) {
 		debug( 'shouldShowCompositeCheckout false because jetpack site' );
 		return 'jetpack-site';
 	}
-	// Disable for jetpack plans
-	if ( cart.products?.find( ( product ) => product.product_slug.includes( 'jetpack' ) ) ) {
+	// Disable for Jetpack plans in production
+	if (
+		config( 'env_id' ) === 'production' &&
+		cart.products?.find( ( product ) => product.product_slug.includes( 'jetpack' ) )
+	) {
 		debug( 'shouldShowCompositeCheckout false because cart contains jetpack' );
 		return 'jetpack-product';
 	}

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -1,5 +1,3 @@
-@import 'jetpack-connect/colors.scss';
-
 @mixin section-border( $position ) {
 	&::before {
 		display: block;
@@ -1146,77 +1144,6 @@
 	display: block;
 	font-size: $font-body-extra-small;
 	font-style: italic;
-}
-
-.is-section-checkout.is-jetpack-site {
-	.layout__content {
-		position: static;
-		// Adjust the padding as we no longer
-		// show the masterbar.
-		padding-top: 48px;
-
-		@include breakpoint-deprecated( '<660px' ) {
-			padding-top: 0;
-		}
-	}
-
-	// Move the sidebar up top
-	.layout__secondary {
-		top: 0;
-	}
-
-	// Hide the masterbar for real
-	.masterbar {
-		display: none;
-	}
-}
-
-.is-section-checkout.is-jetpack-site,
-.is-section-checkout-thank-you.is-jetpack-site {
-	@include jetpack-connect-colors();
-
-	.payment-box-section {
-		--color-primary: var( --color-primary-50 );
-	}
-}
-
-.is-section-checkout.is-jetpack-site {
-	min-height: 100%;
-	background-color: var( --color-jetpack-onboarding-background );
-
-	.formatted-header {
-		color: var( --color-jetpack-onboarding-text );
-	}
-
-	.formatted-header__subtitle {
-		color: var( --color-primary-10 );
-	}
-
-	.card {
-		box-shadow: none;
-		border-radius: 3px;
-
-		&.section-header {
-			border-bottom-left-radius: 0;
-			border-bottom-right-radius: 0;
-		}
-
-		&.payment-box {
-			border-top-left-radius: 0;
-			border-top-right-radius: 0;
-		}
-	}
-}
-
-.is-section-checkout-thank-you.is-jetpack-site {
-	min-height: 100%;
-	background-color: var( --color-jetpack-onboarding-background );
-
-	.checkout-thank-you__jetpack .plan-thank-you-card .thank-you-card,
-	.checkout-thank-you__jetpack .plan-thank-you-card .thank-you-card,
-	.checkout-thank-you__jetpack .plan-thank-you-card .thank-you-card {
-		box-shadow: none;
-	}
 }
 
 .checkout__site-created-notice-wrapper {

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -1,3 +1,5 @@
+@import 'jetpack-connect/colors.scss';
+
 @mixin section-border( $position ) {
 	&::before {
 		display: block;
@@ -1144,6 +1146,15 @@
 	display: block;
 	font-size: $font-body-extra-small;
 	font-style: italic;
+}
+
+.is-section-checkout.is-jetpack-site,
+.is-section-checkout-thank-you.is-jetpack-site {
+	@include jetpack-connect-colors();
+
+	.payment-box-section {
+		--color-primary: var( --color-primary-50 );
+	}
 }
 
 .checkout__site-created-notice-wrapper {

--- a/client/my-sites/checkout/composite-checkout/add-items.ts
+++ b/client/my-sites/checkout/composite-checkout/add-items.ts
@@ -13,6 +13,7 @@ import {
 	themeItem,
 	jetpackProductItem,
 } from 'lib/cart-values/cart-items';
+import { JETPACK_PRODUCTS_LIST } from 'lib/products-values/constants';
 import type { RequestCartProduct } from './wpcom/types';
 
 const debug = debugFactory( 'calypso:composite-checkout:add-items' );
@@ -65,9 +66,8 @@ export function createItemToAddToCart( {
 	}
 
 	if (
-		( productAlias?.startsWith( 'jetpack_backup' ) ||
-			productAlias?.startsWith( 'jetpack_search' ) ||
-			productAlias?.startsWith( 'jetpack_scan' ) ) &&
+		productAlias &&
+		JETPACK_PRODUCTS_LIST.includes( productAlias ) &&
 		isJetpackNotAtomic &&
 		product_id
 	) {

--- a/client/my-sites/checkout/composite-checkout/add-items.ts
+++ b/client/my-sites/checkout/composite-checkout/add-items.ts
@@ -66,7 +66,8 @@ export function createItemToAddToCart( {
 
 	if (
 		( productAlias?.startsWith( 'jetpack_backup' ) ||
-			productAlias?.startsWith( 'jetpack_search' ) ) &&
+			productAlias?.startsWith( 'jetpack_search' ) ||
+			productAlias?.startsWith( 'jetpack_scan' ) ) &&
 		isJetpackNotAtomic &&
 		product_id
 	) {

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -17,7 +17,7 @@ import {
 	domainRequiredContactDetails,
 	taxRequiredContactDetails,
 } from 'my-sites/checkout/composite-checkout/wpcom';
-import { CheckoutProvider, defaultRegistry } from '@automattic/composite-checkout';
+import { CheckoutProvider, checkoutTheme, defaultRegistry } from '@automattic/composite-checkout';
 
 /**
  * Internal dependencies
@@ -528,6 +528,15 @@ export default function CompositeCheckout( {
 		product
 	);
 
+	const jetpackColors = isJetpackNotAtomic
+		? {
+				primary: '#008710',
+				primaryBorder: '#004515',
+				primaryOver: '#007117',
+		  }
+		: {};
+	const theme = { ...checkoutTheme, colors: { ...checkoutTheme.colors, ...jetpackColors } };
+
 	return (
 		<React.Fragment>
 			<QuerySitePlans siteId={ siteId } />
@@ -553,6 +562,7 @@ export default function CompositeCheckout( {
 						isLoadingCart || isLoadingStoredCards || paymentMethods.length < 1 || items.length < 1
 					}
 					isValidating={ isCartPendingUpdate }
+					theme={ theme }
 				>
 					<WPCheckout
 						removeItem={ removeItem }

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -84,7 +84,7 @@ import { AUTO_RENEWAL } from 'lib/url/support';
 import { useLocalizedMoment } from 'components/localized-moment';
 import isDomainOnlySite from 'state/selectors/is-domain-only-site';
 import { retrieveSignupDestination, clearSignupDestinationCookie } from 'signup/utils';
-import { useWpcomProductVariants } from './wpcom/hooks/product-variants';
+import { useProductVariants } from './wpcom/hooks/product-variants';
 import { CartProvider } from './cart-provider';
 import { translateResponseCartToWPCOMCart } from './wpcom/lib/translate-cart';
 import useShoppingCartManager from './wpcom/hooks/use-shopping-cart-manager';
@@ -468,7 +468,7 @@ export default function CompositeCheckout( {
 		);
 	};
 
-	const getItemVariants = useWpcomProductVariants( {
+	const getItemVariants = useProductVariants( {
 		siteId,
 		productSlug: getPlanProductSlugs( items )[ 0 ],
 	} );

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -90,6 +90,7 @@ import { translateResponseCartToWPCOMCart } from './wpcom/lib/translate-cart';
 import useShoppingCartManager from './wpcom/hooks/use-shopping-cart-manager';
 import useShowAddCouponSuccessMessage from './wpcom/hooks/use-show-add-coupon-success-message';
 import useCountryList from './wpcom/hooks/use-country-list';
+import { colors } from '@automattic/color-studio';
 
 const debug = debugFactory( 'calypso:composite-checkout:composite-checkout' );
 
@@ -530,9 +531,14 @@ export default function CompositeCheckout( {
 
 	const jetpackColors = isJetpackNotAtomic
 		? {
-				primary: '#008710',
-				primaryBorder: '#004515',
-				primaryOver: '#007117',
+				primary: colors[ 'Jetpack Green' ],
+				primaryBorder: colors[ 'Jetpack Green 80' ],
+				primaryOver: colors[ 'Jetpack Green 60' ],
+				success: colors[ 'Jetpack Green' ],
+				discount: colors[ 'Jetpack Green' ],
+				highlight: colors[ 'Blue 50' ],
+				highlightBorder: colors[ 'Blue 80' ],
+				highlightOver: colors[ 'Blue 60' ],
 		  }
 		: {};
 	const theme = { ...checkoutTheme, colors: { ...checkoutTheme.colors, ...jetpackColors } };

--- a/client/my-sites/checkout/composite-checkout/use-prepare-product-for-cart.js
+++ b/client/my-sites/checkout/composite-checkout/use-prepare-product-for-cart.js
@@ -251,7 +251,7 @@ function getProductSlugFromAlias( productAlias ) {
 	if ( productAlias === 'concierge-session' ) {
 		return 'concierge-session';
 	}
-	return null;
+	return productAlias;
 }
 
 function createRenewalItemToAddToCart( productAlias, productId, purchaseId, selectedSiteSlug ) {

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
@@ -428,7 +428,7 @@ function LineItemSublabelAndPrice( { item } ) {
 	const isDomainMap = item.type === 'domain_map';
 	const isGSuite = isGSuiteProductSlug( item.wpcom_meta?.product_slug );
 
-	if ( item.type === 'plan' && item.wpcom_meta?.months_per_bill_period ) {
+	if ( item.type === 'plan' && item.wpcom_meta?.months_per_bill_period > 1 ) {
 		return translate( '%(sublabel)s: %(monthlyPrice)s per month × %(monthsPerBillPeriod)s', {
 			args: {
 				sublabel: item.sublabel,
@@ -438,6 +438,17 @@ function LineItemSublabelAndPrice( { item } ) {
 			comment: 'product type and monthly breakdown of total cost, separated by a colon',
 		} );
 	}
+
+	if ( item.type === 'plan' && item.wpcom_meta?.months_per_bill_period === 1 ) {
+		return translate( '%(sublabel)s: %(monthlyPrice)s per month', {
+			args: {
+				sublabel: item.sublabel,
+				monthlyPrice: item.wpcom_meta.item_subtotal_monthly_cost_display,
+			},
+			comment: 'product type and monthly breakdown of total cost, separated by a colon',
+		} );
+	}
+
 	if (
 		( isDomainRegistration || isDomainMap || isGSuite ) &&
 		item.wpcom_meta?.months_per_bill_period === 12

--- a/client/my-sites/checkout/composite-checkout/wpcom/hooks/product-variants.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/hooks/product-variants.js
@@ -13,17 +13,23 @@ import debugFactory from 'debug';
 import { requestPlans } from 'state/plans/actions';
 import { computeProductsWithPrices } from 'state/products-list/selectors';
 import { getPlan, findPlansKeys } from 'lib/plans';
-import { GROUP_WPCOM, TERM_ANNUALLY, TERM_BIENNIALLY, TERM_MONTHLY } from 'lib/plans/constants';
+import {
+	GROUP_WPCOM,
+	GROUP_JETPACK,
+	TERM_ANNUALLY,
+	TERM_BIENNIALLY,
+	TERM_MONTHLY,
+} from 'lib/plans/constants';
 import { requestProductsList } from 'state/products-list/actions';
 import { myFormatCurrency } from 'blocks/subscription-length-picker';
 
 const debug = debugFactory( 'calypso:composite-checkout:product-variants' );
 
-export function useWpcomProductVariants( { siteId, productSlug, credits, couponDiscounts } ) {
+export function useProductVariants( { siteId, productSlug, credits, couponDiscounts } ) {
 	const translate = useTranslate();
 	const reduxDispatch = useDispatch();
 
-	const variantProductSlugs = useVariantWpcomPlanProductSlugs( productSlug );
+	const variantProductSlugs = useVariantPlanProductSlugs( productSlug );
 
 	const productsWithPrices = useSelector( ( state ) => {
 		return computeProductsWithPrices(
@@ -94,7 +100,7 @@ function VariantPriceDiscount( { variant } ) {
 	);
 }
 
-function useVariantWpcomPlanProductSlugs( productSlug ) {
+function useVariantPlanProductSlugs( productSlug ) {
 	const reduxDispatch = useDispatch();
 
 	const chosenPlan = getPlan( productSlug );
@@ -117,8 +123,8 @@ function useVariantWpcomPlanProductSlugs( productSlug ) {
 		return [];
 	}
 
-	// Only construct variants for WP.com plans
-	if ( chosenPlan.group !== GROUP_WPCOM ) {
+	// Only construct variants for WP.com and Jetpack plans
+	if ( chosenPlan.group !== GROUP_WPCOM && chosenPlan.group !== GROUP_JETPACK ) {
 		return [];
 	}
 

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_default.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_default.scss
@@ -263,6 +263,12 @@
 	--color-masterbar-toggle-drafts-editor-hover-background: var( --studio-gray-40 );
 	--color-masterbar-toggle-drafts-editor-border: var( --studio-gray-10 );
 
+	--color-jetpack-masterbar-background: var( --studio-white );
+	--color-jetpack-masterbar-border: var( --studio-gray-5 );
+	--color-jetpack-masterbar-text: var( --studio-gray-50 );
+	--color-jetpack-masterbar-item-hover-background: var( --studio-gray-5 );
+	--color-jetpack-masterbar-item-active-background: var( --studio-gray-20 );
+
 	--color-sidebar-background: var( --color-surface );
 	--color-sidebar-background-rgb: var( --studio-white-rgb );
 	--color-sidebar-border: var( --studio-gray-5 );

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -75,7 +75,7 @@ See the [demo](demo/index.js) for an example of using this package.
 
 ## Styles and Themes
 
-Each component will be styled using [@emotion/styled](https://emotion.sh/docs/styled) and many of the styles will be editable by passing a `theme` object to the `CheckoutProvider`.
+Each component will be styled using [@emotion/styled](https://emotion.sh/docs/styled) and many of the styles will be editable by passing a `theme` object to the `CheckoutProvider`. The [`checkoutTheme`](#checkoutTheme) object is available from the package API, and can be merged with new values to customize the design.
 
 For style customization beyond what is available in the theme, each component will also include a unique static className using BEM syntax.
 
@@ -270,6 +270,10 @@ A wrapper for a section of a list of related line items. Renders its `children` 
 Renders the `total` prop like a line item, but with different styling.
 
 An optional boolean prop, `collapsed`, can be used to simplify the output for when the review section is collapsed.
+
+### checkoutTheme
+
+An [@emotion/styled](https://emotion.sh/docs/styled) theme object that can be merged with custom theme variables and passed to [CheckoutProvider](#checkout-provider) in order to customize the default Checkout design.
 
 ### createApplePayMethod
 

--- a/packages/composite-checkout/src/public-api.js
+++ b/packages/composite-checkout/src/public-api.js
@@ -72,6 +72,7 @@ import { useFormStatus } from './lib/form-status';
 import { CheckIcon as CheckoutCheckIcon } from './components/shared-icons';
 import { useTransactionStatus } from './lib/transaction-status';
 import { usePaymentProcessor } from './lib/payment-processors';
+import checkoutTheme from './theme';
 
 // Re-export the public API
 export {
@@ -140,4 +141,5 @@ export {
 	useSetStepComplete,
 	useTotal,
 	useTransactionStatus,
+	checkoutTheme,
 };


### PR DESCRIPTION
This adds Jetpack product and plan support to the new Checkout flow for all environments except production - allowing us to test purchase flows outside of Calypso.

ref: pbOQVh-l8-p2

In order to avoid adding additional complexity, this _does_ modify the current production Jetpack Checkout in the following ways:

- removes the dark background (and related box-shadow/border adjustments)
- shows the primary header (master) bar, with Jetpack branding and close button (with same behavior as removing items from cart)

**Production Before** | **Production After** | **Testing**
------------ | ------------- | -------------
![production-before](https://user-images.githubusercontent.com/942359/88803184-15317700-d17a-11ea-98be-efff9946c03c.png) | ![production-after](https://user-images.githubusercontent.com/942359/88803248-2f6b5500-d17a-11ea-8e44-f6363bd5aee3.png) | ![testing](https://user-images.githubusercontent.com/942359/88803330-4a3dc980-d17a-11ea-999f-714e6b638eac.png)


**To Test Composite Checkout ("Testing" from screenshots):**
- with a Jetpack site (you can create a new one at jurassic.ninja), visit `/plans/`
- choose a plan or product (scroll beneath the plans) to visit checkout
- verify that composite checkout loads, with the current product added to the cart
- verify that you can complete checkout
- verify that you're redirected to the correct page (`/plans/`) with the Jetpack success modal

**To test changes to existing Checkout ("Production After" from screenshots):**
- with a Jetpack site (you can create a new one at jurassic.ninja), visit `/plans/`
- choose a plan or product (scroll beneath the plans) to visit checkout
- force existing checkout by reloading the page with the query string: `?flags=old-checkout-force` (you might need to remove the `#step2` hash)
- verify that legacy checkout loads, with the current product added to the cart
- verify that the design changes look okay
- verify that you can complete checkout
- verify that you're redirected to the correct page (`/plans/`) with the Jetpack success modal