### PR TITLE
Remove usage of Node's 'url' from `lib/post-normalizer`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -135,6 +135,11 @@ module.exports = {
 						importNames: [ 'Dashicon', 'Icon' ],
 						message: 'Please use `@wordpress/icons` instead.',
 					},
+					// Use `lib/url` instead of Node's 'url'.
+					{
+						name: 'url',
+						message: "Please use 'lib/url' instead.",
+					},
 				],
 			},
 		],

--- a/client/blocks/reader-post-card/gallery.jsx
+++ b/client/blocks/reader-post-card/gallery.jsx
@@ -36,12 +36,15 @@ const PostGallery = ( { post, children, isDiscover } ) => {
 			w: READER_CONTENT_WIDTH / imagesToDisplay.length,
 		} );
 		const safeCssUrl = cssSafeUrl( imageUrl );
-		const imageStyle = {
-			backgroundImage: 'url(' + safeCssUrl + ')',
-			backgroundSize: 'cover',
-			backgroundPosition: '50% 50%',
-			backgroundRepeat: 'no-repeat',
-		};
+		let imageStyle = { background: 'none' };
+		if ( safeCssUrl ) {
+			imageStyle = {
+				backgroundImage: 'url(' + safeCssUrl + ')',
+				backgroundSize: 'cover',
+				backgroundPosition: '50% 50%',
+				backgroundRepeat: 'no-repeat',
+			};
+		}
 		return (
 			<li key={ `post-${ post.ID }-image-${ index }` } className="reader-post-card__gallery-item">
 				<div className="reader-post-card__gallery-image" style={ imageStyle } />

--- a/client/lib/post-normalizer/rule-content-disable-autoplay.js
+++ b/client/lib/post-normalizer/rule-content-disable-autoplay.js
@@ -1,34 +1,33 @@
 /**
- * External dependencies
+ * Internal dependencies
  */
-import { forEach } from 'lodash';
-import url from 'url';
+import { getUrlParts, getUrlFromParts } from 'lib/url';
 
-function stripAutoPlays( query ) {
-	const keys = Object.keys( query ).filter( function ( k ) {
-		return /^auto_?play$/i.test( k );
-	} );
-	forEach( keys, ( key ) => {
-		// In the rare case that we're handed an array of values, use the first one
-		const firstValue = Array.isArray( query[ key ] ) ? query[ key ][ 0 ] : query[ key ];
-		const val = firstValue.toLowerCase();
+function stripAutoPlays( searchParams ) {
+	const returnVal = new URLSearchParams( searchParams );
+
+	const keys = Array.from( searchParams.keys() ).filter( ( k ) => /^auto_?play$/i.test( k ) ) || [];
+
+	keys.forEach( ( key ) => {
+		// In the rare case that we're handed an array of values, we use the first one
+		const val = searchParams.get( key ).toLowerCase();
 		if ( val === '1' ) {
-			query[ key ] = '0';
+			returnVal.set( key, '0' );
 		} else if ( val === 'true' ) {
-			query[ key ] = 'false';
+			returnVal.set( key, 'false' );
 		} else {
 			// force a singular value
-			query[ key ] = val;
+			returnVal.set( key, val );
 		}
 	} );
-	return query;
+	return returnVal;
 }
 
 export function disableAutoPlayOnMedia( post, dom ) {
 	if ( ! dom ) {
 		throw new Error( 'this transform must be used as part of withContentDOM' );
 	}
-	forEach( dom.querySelectorAll( 'audio, video' ), ( el ) => ( el.autoplay = false ) );
+	dom.querySelectorAll( 'audio, video' ).forEach( ( el ) => ( el.autoplay = false ) );
 	return post;
 }
 
@@ -37,12 +36,12 @@ export function disableAutoPlayOnEmbeds( post, dom ) {
 		throw new Error( 'this transform must be used as part of withContentDOM' );
 	}
 
-	forEach( dom.querySelectorAll( 'iframe' ), ( embed ) => {
-		const srcUrl = url.parse( embed.src, true, true );
-		if ( srcUrl.query ) {
-			srcUrl.query = stripAutoPlays( srcUrl.query );
-			srcUrl.search = null;
-			embed.src = url.format( srcUrl );
+	dom.querySelectorAll( 'iframe' ).forEach( ( embed ) => {
+		const urlParts = getUrlParts( embed.src );
+		if ( urlParts.search ) {
+			urlParts.searchParams = stripAutoPlays( urlParts.searchParams );
+			delete urlParts.search;
+			embed.src = getUrlFromParts( urlParts ).href;
 		}
 	} );
 

--- a/client/lib/post-normalizer/rule-content-make-embeds-safe.js
+++ b/client/lib/post-normalizer/rule-content-make-embeds-safe.js
@@ -1,13 +1,12 @@
 /**
  * External dependencies
  */
-
 import { some, forEach, startsWith, endsWith } from 'lodash';
 import { iframeIsAllowed } from './utils';
-import url from 'url';
+import { getUrlParts } from 'lib/url';
 
 /**
- * Internal Dependencies
+ * Internal dependencies
  */
 
 /** Given an iframe, is it okay to have it run without a sandbox?
@@ -24,7 +23,7 @@ function doesNotNeedSandbox( iframe ) {
 		'player.twitch.tv',
 	];
 
-	const hostName = iframe.src && url.parse( iframe.src ).hostname;
+	const hostName = iframe.src && getUrlParts( iframe.src ).hostname;
 	const iframeHost = hostName && hostName.toLowerCase();
 
 	return some( trustedHosts, ( trustedHost ) => endsWith( '.' + iframeHost, '.' + trustedHost ) );

--- a/client/lib/post-normalizer/rule-content-make-images-safe.js
+++ b/client/lib/post-normalizer/rule-content-make-images-safe.js
@@ -4,7 +4,7 @@
 import { forEach, startsWith, some, includes, filter } from 'lodash';
 
 /**
- * Internal Dependencies
+ * Internal dependencies
  */
 import safeImageURL from 'lib/safe-image-url';
 import { maxWidthPhotonishURL } from './utils';

--- a/client/lib/post-normalizer/rule-content-make-images-safe.js
+++ b/client/lib/post-normalizer/rule-content-make-images-safe.js
@@ -1,8 +1,6 @@
 /**
  * External dependencies
  */
-
-import url from 'url';
 import { forEach, startsWith, some, includes, filter } from 'lodash';
 
 /**
@@ -10,12 +8,13 @@ import { forEach, startsWith, some, includes, filter } from 'lodash';
  */
 import safeImageURL from 'lib/safe-image-url';
 import { maxWidthPhotonishURL } from './utils';
+import { getUrlParts, getUrlFromParts, resolveRelativePath } from 'lib/url';
 
 const TRANSPARENT_GIF =
 	'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
 
 /**
- * @param {Node} node - Takes in a DOM Node and mutates it so that it no longer has an 'on*' event handlers e.g. onClick
+ * @param {window.Node} node - Takes in a DOM Node and mutates it so that it no longer has an 'on*' event handlers e.g. onClick
  */
 const removeUnwantedAttributes = ( node ) => {
 	if ( ! node || ! node.hasAttributes() ) {
@@ -57,12 +56,17 @@ const imageShouldBeRemovedFromContent = ( imageUrl ) => {
 
 function makeImageSafe( post, image, maxWidth ) {
 	let imgSource = image.getAttribute( 'src' );
-	const parsedImgSrc = url.parse( imgSource, false, true );
-	const hostName = parsedImgSrc.hostname;
+	const imgSourceParts = getUrlParts( imgSource );
+	const hostName = imgSourceParts.hostname;
 
 	// if imgSource is relative, prepend post domain so it isn't relative to calypso
 	if ( ! hostName ) {
-		imgSource = url.resolve( post.URL, imgSource );
+		const postUrlParts = getUrlParts( post.URL );
+		imgSource = getUrlFromParts( {
+			protocol: postUrlParts.protocol,
+			host: postUrlParts.host,
+			pathname: resolveRelativePath( postUrlParts.pathname, imgSourceParts.pathname ),
+		} ).href;
 	}
 
 	let safeSource = maxWidth

--- a/client/lib/post-normalizer/utils/iframe-is-allowed.js
+++ b/client/lib/post-normalizer/utils/iframe-is-allowed.js
@@ -1,12 +1,16 @@
 /**
- * External Dependencies
+ * External dependencies
  */
 import { some, endsWith } from 'lodash';
-import url from 'url';
 
 /**
- * Determines if an iframe is from a source we trust.  We allow these to be the featured media and also give
- * them a free-er sandbox
+ * Internal dependencies
+ */
+import { getUrlParts } from 'lib/url';
+
+/**
+ * Determines if an iframe is from a source we trust. We allow these to be the featured media and also give
+ * them a freer sandbox
  *
  * @param  {object} iframe the iframe to check
  * @returns {boolean} true if allowed
@@ -45,7 +49,7 @@ export function iframeIsAllowed( iframe ) {
 		'icloud.com',
 		'read.amazon.com',
 	];
-	const hostName = iframe.src && url.parse( iframe.src ).hostname;
+	const hostName = iframe.src && getUrlParts( iframe.src ).hostname;
 	const iframeSrc = hostName && hostName.toLowerCase();
 	return some( allowedIframeHosts, function ( allowedHost ) {
 		return endsWith( '.' + iframeSrc, '.' + allowedHost );

--- a/client/lib/post-normalizer/utils/is-featured-image-in-content.js
+++ b/client/lib/post-normalizer/utils/is-featured-image-in-content.js
@@ -1,22 +1,21 @@
 /**
- * External Dependencies
+ * External dependencies
  */
 import { findIndex } from 'lodash';
-import url from 'url';
 
 /**
- * Internal Dependencies
+ * Internal dependencies
  */
 import { isPhotonHost } from 'lib/post-normalizer/utils/is-photon-host';
 import { thumbIsLikelyImage } from 'lib/post-normalizer/utils/thumb-is-likely-image';
+import { getUrlParts } from 'lib/url';
 
 function getPathname( uri ) {
-	const parsedUrl = url.parse( uri );
-	const path = parsedUrl.pathname;
-	if ( isPhotonHost( parsedUrl.hostname ) ) {
-		return path.substring( path.indexOf( '/', 1 ) );
+	const { pathname, hostname } = getUrlParts( uri );
+	if ( isPhotonHost( hostname ) ) {
+		return pathname.substring( pathname.indexOf( '/', 1 ) );
 	}
-	return path;
+	return pathname;
 }
 
 /** returns whether or not a posts featuredImages is contained within the contents

--- a/client/lib/post-normalizer/utils/is-url-likely-an-image.js
+++ b/client/lib/post-normalizer/utils/is-url-likely-an-image.js
@@ -1,8 +1,12 @@
 /**
- * External Dependencies
+ * External dependencies
  */
 import { some, endsWith } from 'lodash';
-import url from 'url';
+
+/**
+ * Internal dependencies
+ */
+import { getUrlParts } from 'lib/url';
 
 /** Determine if url is likely pointed to an image
  *
@@ -14,6 +18,6 @@ export function isUrlLikelyAnImage( uri ) {
 		return false;
 	}
 
-	const withoutQuery = url.parse( uri ).pathname;
+	const withoutQuery = getUrlParts( uri ).pathname;
 	return some( [ '.jpg', '.jpeg', '.png', '.gif' ], ( ext ) => endsWith( withoutQuery, ext ) );
 }

--- a/client/lib/post-normalizer/utils/make-image-url-safe.js
+++ b/client/lib/post-normalizer/utils/make-image-url-safe.js
@@ -1,18 +1,22 @@
 /**
- * External Dependencies
- */
-import url from 'url';
-
-/**
- * Internal Dependencies
+ * Internal dependencies
  */
 import { maxWidthPhotonishURL } from 'lib/post-normalizer/utils/max-width-photonish-url';
 import safeImageURL from 'lib/safe-image-url';
+import { getUrlParts, resolveRelativePath, getUrlFromParts } from 'lib/url';
 
 export function makeImageURLSafe( object, propName, maxWidth, baseURL ) {
 	if ( object && object[ propName ] ) {
-		if ( baseURL && ! url.parse( object[ propName ], true, true ).hostname ) {
-			object[ propName ] = url.resolve( baseURL, object[ propName ] );
+		const urlParts = getUrlParts( object[ propName ] );
+		if ( baseURL && ! urlParts.hostname ) {
+			const { pathname: basePath } = getUrlParts( baseURL );
+			const resolvedPath = resolveRelativePath( basePath, object[ propName ] );
+			object[ propName ] = getUrlFromParts( {
+				...urlParts,
+				protocol: baseURL.protocol,
+				hostname: baseURL.hostname,
+				pathname: resolvedPath,
+			} ).href;
 		}
 		object[ propName ] = safeImageURL( object[ propName ] );
 

--- a/client/lib/post-normalizer/utils/max-width-photonish-url.js
+++ b/client/lib/post-normalizer/utils/max-width-photonish-url.js
@@ -15,7 +15,7 @@ export function maxWidthPhotonishURL( imageURL, width ) {
 
 	let urlParts = {};
 	try {
-		urlParts = getUrlParts( imageURL ); // true, true means allow protocol-less hosts and parse the querystring
+		urlParts = getUrlParts( imageURL );
 	} catch ( e ) {
 		/**
 		 * `url.parse` throws in a few places where it calls decodeURIComponent

--- a/client/lib/post-normalizer/utils/max-width-photonish-url.js
+++ b/client/lib/post-normalizer/utils/max-width-photonish-url.js
@@ -1,7 +1,7 @@
 /**
- * External Dependencies
+ * Internal dependencies
  */
-import url from 'url';
+import { getUrlParts, getUrlFromParts } from 'lib/url';
 
 const IMAGE_SCALE_FACTOR =
 	typeof window !== 'undefined' && window.devicePixelRatio && window.devicePixelRatio > 1 ? 2 : 1;
@@ -13,9 +13,9 @@ export function maxWidthPhotonishURL( imageURL, width ) {
 		return imageURL;
 	}
 
-	let parsedURL = {};
+	let urlParts = {};
 	try {
-		parsedURL = url.parse( imageURL, true, true ); // true, true means allow protocol-less hosts and parse the querystring
+		urlParts = getUrlParts( imageURL ); // true, true means allow protocol-less hosts and parse the querystring
 	} catch ( e ) {
 		/**
 		 * `url.parse` throws in a few places where it calls decodeURIComponent
@@ -24,34 +24,31 @@ export function maxWidthPhotonishURL( imageURL, width ) {
 		 */
 	}
 
-	if ( ! parsedURL.host ) {
+	if ( ! urlParts.host ) {
 		return imageURL;
 	}
 
-	const isGravatar = parsedURL.host.indexOf( 'gravatar.com' ) !== -1;
+	const isGravatar = urlParts.host.indexOf( 'gravatar.com' ) !== -1;
 
-	delete parsedURL.search;
+	delete urlParts.search;
 	// strip other sizing params
 	for ( const param of [ 'h', 'crop', 'resize', 'fit' ] ) {
-		delete parsedURL.query[ param ];
+		urlParts.searchParams.delete( param );
 	}
 
 	const sizeParam = isGravatar ? 's' : 'w';
-	parsedURL.query[ sizeParam ] = width * IMAGE_SCALE_FACTOR;
+	urlParts.searchParams.set( sizeParam, width * IMAGE_SCALE_FACTOR );
 
 	if ( ! isGravatar ) {
 		// gravatar doesn't support these, only photon / files.wordpress
-		parsedURL.query.quality = DEFAULT_PHOTON_QUALITY;
-		parsedURL.query.strip = 'info'; // strip all exif data, leave ICC intact
+		urlParts.searchParams.set( 'quality', DEFAULT_PHOTON_QUALITY );
+		urlParts.searchParams.set( 'strip', 'info' ); // strip all exif data, leave ICC intact
 	}
 
 	// make a new query object with keys in a known order
-	parsedURL.query = Object.keys( parsedURL.query )
-		.sort()
-		.reduce( ( memo, key ) => {
-			memo[ key ] = parsedURL.query[ key ];
-			return memo;
-		}, {} );
+	const sortedKeys = Array.from( urlParts.searchParams.keys() ).sort();
+	const sortedParams = new URLSearchParams();
+	sortedKeys.forEach( ( key ) => sortedParams.set( key, urlParts.searchParams.get( key ) ) );
 
-	return url.format( parsedURL );
+	return getUrlFromParts( { ...urlParts, searchParams: sortedParams } ).href;
 }

--- a/client/lib/url/index.ts
+++ b/client/lib/url/index.ts
@@ -13,3 +13,4 @@ export { addSchemeIfMissing, setUrlScheme } from './scheme-utils';
 export { decodeURIIfValid, decodeURIComponentIfValid } from './decode-utils';
 export { default as format } from './format';
 export { getUrlParts, getUrlFromParts } from './url-parts';
+export { default as resolveRelativePath } from './resolve-relative-path';

--- a/client/lib/url/resolve-relative-path.ts
+++ b/client/lib/url/resolve-relative-path.ts
@@ -1,0 +1,29 @@
+/**
+ * Internal dependencies
+ */
+import { determineUrlType, URL_TYPE } from './url-type';
+
+const DUMMY_URL = 'http://__domain__.invalid/';
+
+export default function resolveRelativePath( basePath: string, relativePath: string ): string {
+	basePath = basePath || '/';
+	const baseType = determineUrlType( basePath );
+
+	if ( baseType !== URL_TYPE.PATH_ABSOLUTE ) {
+		throw new Error( '`basePath` should be an absolute path' );
+	}
+
+	const url = new URL( DUMMY_URL );
+	url.pathname = basePath;
+
+	if ( ! relativePath ) {
+		return url.pathname;
+	}
+
+	url.pathname =
+		( url.pathname.endsWith( '/' ) ? url.pathname.slice( 0, -1 ) : url.pathname ) +
+		( relativePath.startsWith( '/' ) ? '' : '/' ) +
+		relativePath;
+
+	return url.pathname;
+}

--- a/client/lib/url/test/resolve-relative-path.js
+++ b/client/lib/url/test/resolve-relative-path.js
@@ -8,7 +8,7 @@
 import resolveRelativePath from '../resolve-relative-path';
 
 describe( 'resolveRelativePath()', () => {
-	test( 'should return `/` when both parameters are ommitted', () => {
+	test( 'should return `/` when both parameters are omitted', () => {
 		expect( resolveRelativePath( undefined, undefined ) ).toBe( '/' );
 	} );
 

--- a/client/lib/url/test/resolve-relative-path.js
+++ b/client/lib/url/test/resolve-relative-path.js
@@ -1,0 +1,34 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * Internal dependencies
+ */
+import resolveRelativePath from '../resolve-relative-path';
+
+describe( 'resolveRelativePath()', () => {
+	test( 'should return `/` when both parameters are ommitted', () => {
+		expect( resolveRelativePath( undefined, undefined ) ).toBe( '/' );
+	} );
+
+	test( 'should return the base path when the relative path is ommitted', () => {
+		expect( resolveRelativePath( '/foo', undefined ) ).toBe( '/foo' );
+	} );
+
+	test( 'should handle relative paths with `.`', () => {
+		expect( resolveRelativePath( '/foo', '.' ) ).toBe( '/foo/' );
+		expect( resolveRelativePath( '/foo/bar', '.' ) ).toBe( '/foo/bar/' );
+	} );
+
+	test( 'should handle relative paths with `..`', () => {
+		expect( resolveRelativePath( '/foo/bar/baz', '..' ) ).toBe( '/foo/bar/' );
+		expect( resolveRelativePath( '/foo/bar/baz', '../..' ) ).toBe( '/foo/' );
+		expect( resolveRelativePath( '/foo/bar/baz', '../biz' ) ).toBe( '/foo/bar/biz' );
+	} );
+
+	test( 'should handle relative paths with `..` when they go past the root', () => {
+		expect( resolveRelativePath( '/foo/bar/baz', '../../../../..' ) ).toBe( '/' );
+		expect( resolveRelativePath( '/foo/bar/baz', '../../../../../biz' ) ).toBe( '/biz' );
+	} );
+} );

--- a/client/lib/url/test/resolve-relative-path.js
+++ b/client/lib/url/test/resolve-relative-path.js
@@ -12,7 +12,7 @@ describe( 'resolveRelativePath()', () => {
 		expect( resolveRelativePath( undefined, undefined ) ).toBe( '/' );
 	} );
 
-	test( 'should return the base path when the relative path is ommitted', () => {
+	test( 'should return the base path when the relative path is omitted', () => {
 		expect( resolveRelativePath( '/foo', undefined ) ).toBe( '/foo' );
 	} );
 


### PR DESCRIPTION
Node's `url` module is deprecated, and we're moving away from it in Calypso, towards Calypso's `lib/url`. The post normalizer is one of the areas still making use of the deprecated module, and this PR addresses that.

#### Changes proposed in this Pull Request

* Add new `resolveRelativePath` utility to `lib/url`
* Remove usage of Node's `url` from `lib/post-normalizer`
* Mark usage of Node's `url` module as a lint error

#### Testing instructions

* Ensure that all post normalizer unit tests continue to work correctly
* Ensure that Reader continues to work normally, with posts still being correctly normalized and displayed
