### PR TITLE
Checkout: add AB test for non-US/non-USD users

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -175,5 +175,6 @@ export default {
 		},
 		defaultVariation: 'regular',
 		allowExistingUsers: true,
+		localeTargets: 'any',
 	},
 };

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -167,4 +167,13 @@ export default {
 		defaultVariation: 'control',
 		allowExistingUsers: true,
 	},
+	showCompositeCheckoutI18N: {
+		datestamp: '20200710',
+		variations: {
+			composite: 90,
+			regular: 10,
+		},
+		defaultVariation: 'regular',
+		allowExistingUsers: true,
+	},
 };

--- a/client/my-sites/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout-system-decider.js
@@ -240,9 +240,9 @@ function getCheckoutVariant(
 		return 'composite-checkout';
 	}
 	// Add remaining users to new AB test with 10% holdout
-	if ( abtest( 'showCompositeCheckoutI18N' ) === 'composite' ) {
-		debug( 'shouldShowCompositeCheckout true because user is in abtest' );
-		return 'composite-checkout';
+	if ( abtest( 'showCompositeCheckoutI18N' ) !== 'composite' ) {
+		debug( 'shouldShowCompositeCheckout false because user is in abtest control variant' );
+		return 'control-variant';
 	}
 
 	debug( 'shouldShowCompositeCheckout true' );

--- a/client/my-sites/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout-system-decider.js
@@ -20,6 +20,7 @@ import { getCurrentUserLocale, getCurrentUserCountryCode } from 'state/current-u
 import { isJetpackSite } from 'state/sites/selectors';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import { logToLogstash } from 'state/logstash/actions';
+import { abtest } from 'lib/abtest';
 
 const debug = debugFactory( 'calypso:checkout-system-decider' );
 const wpcom = wp.undocumented();
@@ -177,30 +178,24 @@ function getCheckoutVariant(
 		return 'composite-checkout';
 	}
 
+	// Disable for Brazil and India
+	if ( countryCode?.toLowerCase() === 'br' || countryCode?.toLowerCase() === 'in' ) {
+		debug(
+			'shouldShowCompositeCheckout false because country is not allowed',
+			countryCode?.toLowerCase()
+		);
+		return 'disallowed-geo';
+	}
+
 	// Disable if this is a jetpack site
 	if ( isJetpack && ! isAtomic ) {
 		debug( 'shouldShowCompositeCheckout false because jetpack site' );
 		return 'jetpack-site';
 	}
-	// Disable for non-USD
-	if ( cart.currency !== 'USD' ) {
-		debug( 'shouldShowCompositeCheckout false because currency is not USD' );
-		return 'disallowed-currency';
-	}
 	// Disable for jetpack plans
 	if ( cart.products?.find( ( product ) => product.product_slug.includes( 'jetpack' ) ) ) {
 		debug( 'shouldShowCompositeCheckout false because cart contains jetpack' );
 		return 'jetpack-product';
-	}
-	// Disable for non-EN
-	if ( ! locale?.toLowerCase().startsWith( 'en' ) ) {
-		debug( 'shouldShowCompositeCheckout false because locale is not EN' );
-		return 'disallowed-locale';
-	}
-	// Disable for non-US
-	if ( countryCode?.toLowerCase() !== 'us' ) {
-		debug( 'shouldShowCompositeCheckout false because country is not US' );
-		return 'disallowed-geo';
 	}
 
 	// If the URL is adding a product, only allow things already supported.
@@ -233,6 +228,21 @@ function getCheckoutVariant(
 			productSlug
 		);
 		return 'disallowed-product';
+	}
+
+	// Removes users from initial AB test
+	if (
+		cart.currency === 'USD' &&
+		countryCode?.toLowerCase() === 'us' &&
+		locale?.toLowerCase().startsWith( 'en' )
+	) {
+		debug( 'shouldShowCompositeCheckout true' );
+		return 'composite-checkout';
+	}
+	// Add remaining users to new AB test with 10% holdout
+	if ( abtest( 'showCompositeCheckoutI18N' ) === 'composite' ) {
+		debug( 'shouldShowCompositeCheckout true because user is in abtest' );
+		return 'composite-checkout';
 	}
 
 	debug( 'shouldShowCompositeCheckout true' );


### PR DESCRIPTION
Currently, the new Checkout flow is only shown to EN-locale/US-geo/USD-currency users. Now that RTL support, translations, and most of our local payment methods have been added to the flow, we can open it up to more users. 

This PR implements a 90/10 (new/old) AB test for users previously excluded from the new flow. The test and gating excludes the following:

- users from the EN/US/USD cohort (100% of these users should see the new flow)
- Brazilian and Indian geo (until Ebanx and Dlocal support is added)

**To test:**
- verify that a EN/US/USD user is shown composite checkout and that the `showCompositeCheckoutI18N` AB test is not assigned (debug: `calypso:abtests showCompositeCheckoutI18N: new variation:` )
- verify that a user in Brazil or India is shown legacy checkout
- verify that all other users are assigned a variant from the `showCompositeCheckoutI18N` AB test
- verify that users in the AB `composite` variant are shown the appropriate translations, currency, and local payment methods
- verify that users in the AB `composite` variant are able to successfully complete a purchase
- verify that users in the AB `regular` variant are shown legacy checkout and are able to successfully complete a purchase