### PR TITLE
Notifications: Set 0 margins on buttons in the notification header area on mobile

### DIFF
--- a/apps/notifications/src/panel/boot/stylesheets/main.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/main.scss
@@ -47,6 +47,7 @@
 		cursor: pointer;
 		font-size: inherit;
 		outline: none;
+		margin: 0;
 		padding: 0;
 
 		&[disabled] {
@@ -308,7 +309,7 @@
 		transform: translateY( -50% );
 
 		h2 {
-			font: 300 21px/24px $sans;
+			font: 400 21px/24px $sans;
 			margin-bottom: 4px;
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Explicitly set top and bottom margins to 0px on buttons in the notifications header. This helps to better vertically center the content.

| Before | After |
| ------------- | ------------- |
| ![IMG_4230](https://user-images.githubusercontent.com/2124984/87071542-5d4b2280-c1e8-11ea-94d5-5e79eb767c39.PNG) | ![IMG_4229](https://user-images.githubusercontent.com/2124984/87071261-f75e9b00-c1e7-11ea-9803-fdf857a1aa5d.PNG)| 

#### Testing instructions

* Switch to this PR and load it on a mobile device
* Open the notifications panel and click a specific notification
* Note the heading (Back, title, up/down arrows); they should be vertically centered and aligned
* Double-check the notifications panel on a desktop screen.

Fixes #43490 
