### PR TITLE
Retry site request to WPCOM on JSON API Module-related Failure

### DIFF
--- a/client/landing/jetpack-cloud/index.js
+++ b/client/landing/jetpack-cloud/index.js
@@ -37,7 +37,7 @@ const landingController = ( context, next ) => {
 };
 
 export default function () {
-	page( '/', siteSelection, redirectToPrimarySiteLanding );
-	page( '/landing', siteSelection, selectionPrompt, sites, makeLayout, clientRender );
 	page( '/landing/:site', siteSelection, landingController, makeLayout, clientRender );
+	page( '/landing', siteSelection, selectionPrompt, sites, makeLayout, clientRender );
+	page( '/', siteSelection, redirectToPrimarySiteLanding );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* try to re-request site info from wpcom in the case that the site in question does not have it's JSON API module active.
#### Testing instructions

1. Set primary site to a Jetpack site, deactivate JSON API Module for that site
2. Navigate to `/` on Jetpack Cloud
3. Verify you eventually are taken to `/backup` or `/scan` for that site
