### PR TITLE
ci: add wp-desktop windows and linux

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -789,6 +789,7 @@ jobs:
       - run:
           name: Build Desktop Windows
           command: |
+                  # Use make for bash-like environment variable substitution
                   make -f desktop/Makefile package ELECTRON_BUILDER_ARGS='-c.win.certificateSubjectName="Automattic, Inc."'
       - run:
           name: Archive Unpacked Directories

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -790,6 +790,7 @@ jobs:
           name: Build Desktop Windows
           command: |
                   # Use make for bash-like environment variable substitution
+                  # Note: cd into desktop as ELECTRON_BUILDER_ARGS will not resolve correctly if we use make -f syntax from repo root.
                   cd desktop
                   make package ELECTRON_BUILDER_ARGS='-c.win.certificateSubjectName="Automattic, Inc."'
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -886,9 +886,9 @@ workflows:
       # - wp-desktop-mac:
       #     requires:
       #       - wp-desktop-source
-      - wp-desktop-linux:
-          requires:
-            - wp-desktop-source
+      # - wp-desktop-linux:
+      #     requires:
+      #       - wp-desktop-source
       - wp-desktop-windows:
           requires:
             - wp-desktop-source

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -736,6 +736,7 @@ jobs:
             set +e
             rm -rf desktop/release/github
             rm -rf desktop/release/linux-unpacked
+            rm -rf desktop/release/.icon-set
       - store_artifacts:
           when: always
           path: desktop/release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -790,7 +790,8 @@ jobs:
           name: Build Desktop Windows
           command: |
                   # Use make for bash-like environment variable substitution
-                  make -f desktop/Makefile package ELECTRON_BUILDER_ARGS='-c.win.certificateSubjectName="Automattic, Inc."'
+                  cd desktop
+                  make Makefile package ELECTRON_BUILDER_ARGS='-c.win.certificateSubjectName="Automattic, Inc."'
       - run:
           name: Archive Unpacked Directories
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -775,13 +775,13 @@ jobs:
           name: Install Desktop Dependencies
           command: yarn run build-desktop:install-app-deps
       - run: Import Codesigning Certificate
-          command: |
-                  # Workaround for Sign Tool "private key filter" bug in Circle's Windows image.
-                  # Ref: https://travis-ci.community/t/codesigning-on-windows/
-                  #
-                  # Fix: Import .p12 into the local certificate store. Sign Tool will use
-                  # package.json's `certificateSubjectName` to find the imported cert.
-                  Import-PfxCertificate -FilePath $env:CSC_LINK -CertStoreLocation Cert:\LocalMachine\Root -Password (ConvertTo-SecureString -String $env:WIN_CSC_KEY_PASSWORD -AsPlainText -Force)
+        command: |
+                # Workaround for Sign Tool "private key filter" bug in Circle's Windows image.
+                # Ref: https://travis-ci.community/t/codesigning-on-windows/
+                #
+                # Fix: Import .p12 into the local certificate store. Sign Tool will use
+                # package.json's `certificateSubjectName` to find the imported cert.
+                Import-PfxCertificate -FilePath $env:CSC_LINK -CertStoreLocation Cert:\LocalMachine\Root -Password (ConvertTo-SecureString -String $env:WIN_CSC_KEY_PASSWORD -AsPlainText -Force)
       - run:
           name: Build Desktop Windows
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -802,7 +802,7 @@ jobs:
           shell: bash.exe
       - store_artifacts:
           when: always
-          path: desktop/release
+          path: desktop\release
       - persist_to_workspace:
           root: C:\Users\circleci\wp-calypso
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -881,9 +881,9 @@ workflows:
   wp-desktop:
     jobs:
       - wp-desktop-source
-      - wp-desktop-mac:
-          requires:
-            - wp-desktop-source
+      # - wp-desktop-mac:
+      #     requires:
+      #       - wp-desktop-source
       - wp-desktop-linux:
           requires:
             - wp-desktop-source

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -788,6 +788,7 @@ jobs:
 
                   $env:ELECTRON_BUILDER_ARGS='-c.win.certificateSubjectName="Automattic, Inc."'
                   yarn run build-desktop:app
+          shell: bash.exe
       - run:
           name: Archive Unpacked Directories
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -701,6 +701,54 @@ jobs:
       - run: *desktop-notify-github-failure
       - slack/status: *desktop-notify-slack-failure
 
+  wp-desktop-linux:
+    <<: *desktop_defaults
+    shell: /bin/bash --login
+    steps:
+      - checkout
+      - attach_workspace:
+          at: ~/wp-calypso
+      - run: *update-node
+      - run: *desktop-install-app-deps
+      - run:
+          name: Build Desktop Linux
+          environment:
+            CSC_LINK: resource/certificates/win.p12
+          command: |
+                  set +e
+                  source $HOME/.nvm/nvm.sh
+                  nvm use
+
+                  yarn run build-desktop:app
+      - run:
+          name: e2e Tests
+          command: |
+            source $HOME/.nvm/nvm.sh
+            nvm use
+            npm install -g yarn
+
+            yarn run test-desktop:e2e
+      - run:
+          when: always
+          name: Clean Up
+          command: |
+            set +e
+            rm -rf desktop/release/github
+            rm -rf desktop/release/linux-unpacked
+      - store_artifacts:
+          when: always
+          path: desktop/release
+      - store_artifacts:
+          when: always
+          path: desktop/e2e/logs
+      - store_artifacts:
+          when: always
+          path: desktop/e2e/screenshots
+      - persist_to_workspace:
+          root: ~/wp-calypso
+          paths:
+            - desktop/release
+
 workflows:
   version: 2
   calypso:
@@ -775,6 +823,9 @@ workflows:
     jobs:
       - wp-desktop-source
       - wp-desktop-mac:
+          requires:
+            - wp-desktop-source
+      - wp-desktop-linux:
           requires:
             - wp-desktop-source
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -785,9 +785,8 @@ jobs:
       - run:
           name: Build Desktop Windows
           command: |
-                  $env:ELECTRON_BUILDER_ARGS='-c.win.certificateSubjectName="Automattic, Inc."'
+                  $env:ELECTRON_BUILDER_ARGS='--c.win.certificateSubjectName="Automattic, Inc."'
                   yarn run build-desktop:app
-          shell: bash.exe
       - run:
           name: Archive Unpacked Directories
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -778,19 +778,10 @@ jobs:
           name: Install Desktop Dependencies
           command: yarn run build-desktop:install-app-deps
       - run:
-          name: Import Codesigning Certificate
-          command: |
-                  # Workaround for Sign Tool "private key filter" bug in Circle's Windows image.
-                  # Ref: https://travis-ci.community/t/codesigning-on-windows/
-                  #
-                  # Fix: Import .p12 into the local certificate store. Sign Tool will use
-                  # package.json's `certificateSubjectName` to find the imported cert.
-                  Import-PfxCertificate -FilePath $env:CSC_LINK -CertStoreLocation Cert:\LocalMachine\Root -Password (ConvertTo-SecureString -String $env:WIN_CSC_KEY_PASSWORD -AsPlainText -Force)
-      - run:
           name: Build Desktop Windows
           command: |
-                  # Use make for bash-like environment variable substitution
-                  make -f desktop/Makefile package ELECTRON_BUILDER_ARGS='-c.win.certificateSubjectName=""Automattic, Inc.""'
+                  $env:CSC_KEY_PASSWORD=$env:WIN_CSC_KEY_PASSWORD
+                  make -f desktop/Makefile package
       - run:
           name: Archive Unpacked Directories
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -790,7 +790,8 @@ jobs:
           name: Build Desktop Windows
           command: |
                   # Use make for bash-like environment variable substitution
-                  make -f desktop/Makefile package ELECTRON_BUILDER_ARGS='-c.win.certificateSubjectName=""Automattic, Inc.""'
+                  cd desktop
+                  make package ELECTRON_BUILDER_ARGS='-c.win.certificateSubjectName="Automattic, Inc."'
       - run:
           name: Archive Unpacked Directories
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -790,7 +790,7 @@ jobs:
           name: Build Desktop Windows
           command: |
                   # Use make for bash-like environment variable substitution
-                  $env:MSYS2_ARG_CONV_EXCL="*"
+                  $env:MSYS_NO_PATHCONV=1
                   make -f desktop/Makefile package ELECTRON_BUILDER_ARGS='-c.win.certificateSubjectName="Automattic, Inc."'
       - run:
           name: Archive Unpacked Directories

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -790,7 +790,7 @@ jobs:
           name: Build Desktop Windows
           command: |
                   # Use make for bash-like environment variable substitution
-                  make -f desktop/Makefile package ELECTRON_BUILDER_ARGS='-c.win.certificateSubjectName=`"Automattic, Inc.`"'
+                  make -f desktop/Makefile package ELECTRON_BUILDER_ARGS='-c.win.certificateSubjectName=""Automattic, Inc.""'
       - run:
           name: Archive Unpacked Directories
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -888,9 +888,9 @@ workflows:
   wp-desktop:
     jobs:
       - wp-desktop-source
-      # - wp-desktop-mac:
-      #     requires:
-      #       - wp-desktop-source
+      - wp-desktop-mac:
+          requires:
+            - wp-desktop-source
       - wp-desktop-linux:
           requires:
             - wp-desktop-source

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -634,7 +634,7 @@ jobs:
     steps:
       - checkout
       - run: *update-node
-      # - run: *yarn-install
+      - run: *yarn-install
       - restore_cache: *desktop-restore-source-cache
       # - run: *desktop-decrypt-assets
       # - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -817,74 +817,74 @@ jobs:
 
 workflows:
   version: 2
-#   calypso:
-#     jobs:
-#       - setup
-#       - prime-calypso-live:
-#           filters:
-#             branches:
-#               ignore: master
-#       - test-full-site-editing:
-#           requires:
-#             - setup
-#       - build-notifications:
-#           requires:
-#             - setup
-#       - build-o2-blocks:
-#           requires:
-#             - setup
-#       - build-wpcom-block-editor:
-#           requires:
-#             - setup
-#       - lint-and-translate:
-#           requires:
-#             - setup
-#       - test-client:
-#           requires:
-#             - setup
-#       - test-packages:
-#           requires:
-#             - setup
-#       - test-server:
-#           requires:
-#             - setup
-#       - typecheck-strict:
-#           requires:
-#             - setup
-#       - wait-calypso-live:
-#           requires:
-#             - test-client
-#             - test-server
-#           filters:
-#             branches:
-#               ignore:
-#                 # Do not spin up calypso.live for `master`
-#                 - master
-#                 # Do not spin up calypso.live for fork pull requests. Calypso.live will not build them.
-#                 - /pull\/[0-9]+/
-# #      - test-e2e-canary:
-# #          requires:
-# #            - wait-calypso-live
-# #          test-flags: '-C -S $CIRCLE_SHA1'
-#       - test-e2e-canary:
-#           name: test-e2e-canary-ie
-#           requires:
-#             - wait-calypso-live
-#           test-flags: '-z -S $CIRCLE_SHA1'
-#           test-target: 'IE11'
-#           slack-webhook: '$SLACK_IE'
-#       - test-e2e-canary:
-#           name: test-e2e-canary-safari
-#           requires:
-#             - wait-calypso-live
-#           test-flags: '-y -S $CIRCLE_SHA1'
-#       - test-e2e-canary:
-#           name: test-e2e-canary-woo
-#           requires:
-#             - wait-calypso-live
-#           test-flags: '-W -S $CIRCLE_SHA1'
-#           test-target: 'WOO'
-#           slack-webhook: '$SLACK_WOO'
+  calypso:
+    jobs:
+      - setup
+      - prime-calypso-live:
+          filters:
+            branches:
+              ignore: master
+      - test-full-site-editing:
+          requires:
+            - setup
+      - build-notifications:
+          requires:
+            - setup
+      - build-o2-blocks:
+          requires:
+            - setup
+      - build-wpcom-block-editor:
+          requires:
+            - setup
+      - lint-and-translate:
+          requires:
+            - setup
+      - test-client:
+          requires:
+            - setup
+      - test-packages:
+          requires:
+            - setup
+      - test-server:
+          requires:
+            - setup
+      - typecheck-strict:
+          requires:
+            - setup
+      - wait-calypso-live:
+          requires:
+            - test-client
+            - test-server
+          filters:
+            branches:
+              ignore:
+                # Do not spin up calypso.live for `master`
+                - master
+                # Do not spin up calypso.live for fork pull requests. Calypso.live will not build them.
+                - /pull\/[0-9]+/
+#      - test-e2e-canary:
+#          requires:
+#            - wait-calypso-live
+#          test-flags: '-C -S $CIRCLE_SHA1'
+      - test-e2e-canary:
+          name: test-e2e-canary-ie
+          requires:
+            - wait-calypso-live
+          test-flags: '-z -S $CIRCLE_SHA1'
+          test-target: 'IE11'
+          slack-webhook: '$SLACK_IE'
+      - test-e2e-canary:
+          name: test-e2e-canary-safari
+          requires:
+            - wait-calypso-live
+          test-flags: '-y -S $CIRCLE_SHA1'
+      - test-e2e-canary:
+          name: test-e2e-canary-woo
+          requires:
+            - wait-calypso-live
+          test-flags: '-W -S $CIRCLE_SHA1'
+          test-target: 'WOO'
+          slack-webhook: '$SLACK_WOO'
   wp-desktop:
     jobs:
       - wp-desktop-source

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -636,12 +636,12 @@ jobs:
       - run: *update-node
       - run: *yarn-install
       - restore_cache: *desktop-restore-source-cache
-      # - run: *desktop-decrypt-assets
-      # - run:
-      #     name: Build Desktop Source
-      #     no_output_timeout: 15m
-      #     command: |
-      #       yarn run build-desktop:source
+      - run: *desktop-decrypt-assets
+      - run:
+          name: Build Desktop Source
+          no_output_timeout: 15m
+          command: |
+            yarn run build-desktop:source
       - save_cache: *desktop-save-source-cache
       - persist_to_workspace:
           root: /home/circleci/wp-calypso

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -215,10 +215,10 @@ references:
   desktop-restore-source-cache: &desktop-restore-source-cache
       name: Restore desktop cache
       keys:
-        - v6-desktop-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_SHA1 }}
+        - v6-desktop-{{ .Environment.CIRCLE_JOB }}-32D47EBD-EDFD-4475-B8FC-B600AF81755C
   desktop-save-source-cache: &desktop-save-source-cache
       name: Save desktop cache
-      key: v6-desktop-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_SHA1 }}
+      key: v6-desktop-{{ .Environment.CIRCLE_JOB }}-32D47EBD-EDFD-4475-B8FC-B600AF81755C
       paths: *desktop-cache-paths
   desktop-notify-github-success: &desktop-notify-github-success
       name: Notify Github Success

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -636,12 +636,12 @@ jobs:
       - run: *update-node
       - run: *yarn-install
       - restore_cache: *desktop-restore-source-cache
-      - run: *desktop-decrypt-assets
-      - run:
-          name: Build Desktop Source
-          no_output_timeout: 15m
-          command: |
-            yarn run build-desktop:source
+      # - run: *desktop-decrypt-assets
+      # - run:
+      #     name: Build Desktop Source
+      #     no_output_timeout: 15m
+      #     command: |
+      #       yarn run build-desktop:source
       - save_cache: *desktop-save-source-cache
       - persist_to_workspace:
           root: /home/circleci/wp-calypso

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -785,6 +785,7 @@ jobs:
 
                   # $env:CSC_KEY_PASSWORD=$env:WIN_CSC_KEY_PASSWORD
 
+                  $env:ELECTRON_BUILDER_ARGS='-c.win.certificateSubjectName="Automattic, Inc."'
                   yarn run build-desktop:app
       - run:
           name: Archive Unpacked Directories

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -790,7 +790,6 @@ jobs:
           name: Build Desktop Windows
           command: |
                   # Use make for bash-like environment variable substitution
-                  $env:MSYS_NO_PATHCONV=1
                   make -f desktop/Makefile package ELECTRON_BUILDER_ARGS='-c.win.certificateSubjectName="Automattic, Inc."'
       - run:
           name: Archive Unpacked Directories

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -634,7 +634,7 @@ jobs:
     steps:
       - checkout
       - run: *update-node
-      - run: *yarn-install
+      # - run: *yarn-install
       - restore_cache: *desktop-restore-source-cache
       # - run: *desktop-decrypt-assets
       # - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -810,74 +810,74 @@ jobs:
 
 workflows:
   version: 2
-  calypso:
-    jobs:
-      - setup
-      - prime-calypso-live:
-          filters:
-            branches:
-              ignore: master
-      - test-full-site-editing:
-          requires:
-            - setup
-      - build-notifications:
-          requires:
-            - setup
-      - build-o2-blocks:
-          requires:
-            - setup
-      - build-wpcom-block-editor:
-          requires:
-            - setup
-      - lint-and-translate:
-          requires:
-            - setup
-      - test-client:
-          requires:
-            - setup
-      - test-packages:
-          requires:
-            - setup
-      - test-server:
-          requires:
-            - setup
-      - typecheck-strict:
-          requires:
-            - setup
-      - wait-calypso-live:
-          requires:
-            - test-client
-            - test-server
-          filters:
-            branches:
-              ignore:
-                # Do not spin up calypso.live for `master`
-                - master
-                # Do not spin up calypso.live for fork pull requests. Calypso.live will not build them.
-                - /pull\/[0-9]+/
-#      - test-e2e-canary:
-#          requires:
-#            - wait-calypso-live
-#          test-flags: '-C -S $CIRCLE_SHA1'
-      - test-e2e-canary:
-          name: test-e2e-canary-ie
-          requires:
-            - wait-calypso-live
-          test-flags: '-z -S $CIRCLE_SHA1'
-          test-target: 'IE11'
-          slack-webhook: '$SLACK_IE'
-      - test-e2e-canary:
-          name: test-e2e-canary-safari
-          requires:
-            - wait-calypso-live
-          test-flags: '-y -S $CIRCLE_SHA1'
-      - test-e2e-canary:
-          name: test-e2e-canary-woo
-          requires:
-            - wait-calypso-live
-          test-flags: '-W -S $CIRCLE_SHA1'
-          test-target: 'WOO'
-          slack-webhook: '$SLACK_WOO'
+#   calypso:
+#     jobs:
+#       - setup
+#       - prime-calypso-live:
+#           filters:
+#             branches:
+#               ignore: master
+#       - test-full-site-editing:
+#           requires:
+#             - setup
+#       - build-notifications:
+#           requires:
+#             - setup
+#       - build-o2-blocks:
+#           requires:
+#             - setup
+#       - build-wpcom-block-editor:
+#           requires:
+#             - setup
+#       - lint-and-translate:
+#           requires:
+#             - setup
+#       - test-client:
+#           requires:
+#             - setup
+#       - test-packages:
+#           requires:
+#             - setup
+#       - test-server:
+#           requires:
+#             - setup
+#       - typecheck-strict:
+#           requires:
+#             - setup
+#       - wait-calypso-live:
+#           requires:
+#             - test-client
+#             - test-server
+#           filters:
+#             branches:
+#               ignore:
+#                 # Do not spin up calypso.live for `master`
+#                 - master
+#                 # Do not spin up calypso.live for fork pull requests. Calypso.live will not build them.
+#                 - /pull\/[0-9]+/
+# #      - test-e2e-canary:
+# #          requires:
+# #            - wait-calypso-live
+# #          test-flags: '-C -S $CIRCLE_SHA1'
+#       - test-e2e-canary:
+#           name: test-e2e-canary-ie
+#           requires:
+#             - wait-calypso-live
+#           test-flags: '-z -S $CIRCLE_SHA1'
+#           test-target: 'IE11'
+#           slack-webhook: '$SLACK_IE'
+#       - test-e2e-canary:
+#           name: test-e2e-canary-safari
+#           requires:
+#             - wait-calypso-live
+#           test-flags: '-y -S $CIRCLE_SHA1'
+#       - test-e2e-canary:
+#           name: test-e2e-canary-woo
+#           requires:
+#             - wait-calypso-live
+#           test-flags: '-W -S $CIRCLE_SHA1'
+#           test-target: 'WOO'
+#           slack-webhook: '$SLACK_WOO'
   wp-desktop:
     jobs:
       - wp-desktop-source

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -772,6 +772,9 @@ jobs:
           name: Install Yarn
           command: npm install -g yarn
       - run:
+          name: Install Make
+          command: cinst make
+      - run:
           name: Install Desktop Dependencies
           command: yarn run build-desktop:install-app-deps
       - run:
@@ -786,8 +789,7 @@ jobs:
       - run:
           name: Build Desktop Windows
           command: |
-                  npx electron-builder --c.win.certificateSubjectName="Automattic, Inc." build --publish never
-                  yarn run build-desktop:app
+                  make -f desktop/Makefile package ELECTRON_BUILDER_ARGS='-c.win.certificateSubjectName="Automattic, Inc."'
       - run:
           name: Archive Unpacked Directories
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -790,8 +790,8 @@ jobs:
           name: Build Desktop Windows
           command: |
                   # Use make for bash-like environment variable substitution
-                  cd desktop
-                  make Makefile package ELECTRON_BUILDER_ARGS='-c.win.certificateSubjectName="Automattic, Inc."'
+                  $env:MSYS2_ARG_CONV_EXCL="*"
+                  make -f desktop/Makefile package ELECTRON_BUILDER_ARGS='-c.win.certificateSubjectName="Automattic, Inc."'
       - run:
           name: Archive Unpacked Directories
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -215,10 +215,10 @@ references:
   desktop-restore-source-cache: &desktop-restore-source-cache
       name: Restore desktop cache
       keys:
-        - v6-desktop-{{ .Environment.CIRCLE_JOB }}-32D47EBD-EDFD-4475-B8FC-B600AF81755C
+        - v6-desktop-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_SHA1 }}
   desktop-save-source-cache: &desktop-save-source-cache
       name: Save desktop cache
-      key: v6-desktop-{{ .Environment.CIRCLE_JOB }}-32D47EBD-EDFD-4475-B8FC-B600AF81755C
+      key: v6-desktop-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_SHA1 }}
       paths: *desktop-cache-paths
   desktop-notify-github-success: &desktop-notify-github-success
       name: Notify Github Success

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -774,14 +774,15 @@ jobs:
       - run:
           name: Install Desktop Dependencies
           command: yarn run build-desktop:install-app-deps
-      - run: Import Codesigning Certificate
-        command: |
-                # Workaround for Sign Tool "private key filter" bug in Circle's Windows image.
-                # Ref: https://travis-ci.community/t/codesigning-on-windows/
-                #
-                # Fix: Import .p12 into the local certificate store. Sign Tool will use
-                # package.json's `certificateSubjectName` to find the imported cert.
-                Import-PfxCertificate -FilePath $env:CSC_LINK -CertStoreLocation Cert:\LocalMachine\Root -Password (ConvertTo-SecureString -String $env:WIN_CSC_KEY_PASSWORD -AsPlainText -Force)
+      - run:
+          name: Import Codesigning Certificate
+          command: |
+                  # Workaround for Sign Tool "private key filter" bug in Circle's Windows image.
+                  # Ref: https://travis-ci.community/t/codesigning-on-windows/
+                  #
+                  # Fix: Import .p12 into the local certificate store. Sign Tool will use
+                  # package.json's `certificateSubjectName` to find the imported cert.
+                  Import-PfxCertificate -FilePath $env:CSC_LINK -CertStoreLocation Cert:\LocalMachine\Root -Password (ConvertTo-SecureString -String $env:WIN_CSC_KEY_PASSWORD -AsPlainText -Force)
       - run:
           name: Build Desktop Windows
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -790,7 +790,7 @@ jobs:
           name: Build Desktop Windows
           command: |
                   # Use make for bash-like environment variable substitution
-                  make -f desktop/Makefile package ELECTRON_BUILDER_ARGS='-c.win.certificateSubjectName="Automattic, Inc."'
+                  make -f desktop/Makefile package ELECTRON_BUILDER_ARGS='-c.win.certificateSubjectName=`"Automattic, Inc.`"'
       - run:
           name: Archive Unpacked Directories
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   slack: circleci/slack@3.4.2
+  win: circleci/windows@2.2.0
 
 references:
   defaults: &defaults
@@ -749,6 +750,64 @@ jobs:
           paths:
             - desktop/release
 
+  wp-desktop-windows:
+    executor:
+      name: win/default
+    working_directory: C:\Users\circleci\wp-calypso
+    environment:
+      CSC_LINK: C:\Users\circleci\wp-calypso\desktop\resource\certificates\win.p12
+      CSC_FOR_PULL_REQUEST: true
+    steps:
+      - checkout
+      - attach_workspace:
+          at: C:\Users\circleci\wp-calypso
+      - run:
+          name: Install Node Version
+          command: |
+                  $NODE_VERSION = Get-Content .nvmrc
+                  nvm install $NODE_VERSION
+                  nvm use $NODE_VERSION
+      - run:
+          name: Install Yarn
+          command: npm install -g yarn
+      - run:
+          name: Install Desktop Dependencies
+          command: yarn run build-desktop:install-app-deps
+      - run:
+          name: Build Desktop Windows
+          command: |
+                  # Workaround for Sign Tool "private key filter" bug in Circle's Windows image.
+                  # Ref: https://travis-ci.community/t/codesigning-on-windows/
+                  #
+                  # Fix: Import .p12 into the local certificate store. Sign Tool will use
+                  # package.json's `certificateSubjectName` to find the imported cert.
+                  Import-PfxCertificate -FilePath $env:CSC_LINK -CertStoreLocation Cert:\LocalMachine\Root -Password (ConvertTo-SecureString -String $env:WIN_CSC_KEY_PASSWORD -AsPlainText -Force)
+
+                  # $env:CSC_KEY_PASSWORD=$env:WIN_CSC_KEY_PASSWORD
+
+                  yarn run build-desktop:app
+      - run:
+          name: Archive Unpacked Directories
+          command: |
+            tar -zcf desktop/release/win-unpacked-x64.tar.gz desktop/release/win-unpacked
+            tar -zcf desktop/release/win-unpacked-ia32.tar.gz desktop/release/win-ia32-unpacked
+      - run:
+          when: always
+          name: Clean Up
+          command: |
+            set +e
+            rm -rf desktop/release/github
+            rm -rf desktop/release/win-unpacked
+            rm -rf desktop/release/win-ia32-unpacked
+          shell: bash.exe
+      - store_artifacts:
+          when: always
+          path: desktop/release
+      - persist_to_workspace:
+          root: C:\Users\circleci\wp-calypso
+          paths:
+            - desktop\release
+
 workflows:
   version: 2
   calypso:
@@ -826,6 +885,9 @@ workflows:
           requires:
             - wp-desktop-source
       - wp-desktop-linux:
+          requires:
+            - wp-desktop-source
+      - wp-desktop-windows:
           requires:
             - wp-desktop-source
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -786,7 +786,7 @@ jobs:
       - run:
           name: Build Desktop Windows
           command: |
-                  $env:ELECTRON_BUILDER_ARGS='--c.win.certificateSubjectName="Automattic, Inc."'
+                  npx electron-builder --c.win.certificateSubjectName="Automattic, Inc." build --publish never
                   yarn run build-desktop:app
       - run:
           name: Archive Unpacked Directories

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -774,8 +774,7 @@ jobs:
       - run:
           name: Install Desktop Dependencies
           command: yarn run build-desktop:install-app-deps
-      - run:
-          name: Build Desktop Windows
+      - run: Import Codesigning Certificate
           command: |
                   # Workaround for Sign Tool "private key filter" bug in Circle's Windows image.
                   # Ref: https://travis-ci.community/t/codesigning-on-windows/
@@ -783,9 +782,9 @@ jobs:
                   # Fix: Import .p12 into the local certificate store. Sign Tool will use
                   # package.json's `certificateSubjectName` to find the imported cert.
                   Import-PfxCertificate -FilePath $env:CSC_LINK -CertStoreLocation Cert:\LocalMachine\Root -Password (ConvertTo-SecureString -String $env:WIN_CSC_KEY_PASSWORD -AsPlainText -Force)
-
-                  # $env:CSC_KEY_PASSWORD=$env:WIN_CSC_KEY_PASSWORD
-
+      - run:
+          name: Build Desktop Windows
+          command: |
                   $env:ELECTRON_BUILDER_ARGS='-c.win.certificateSubjectName="Automattic, Inc."'
                   yarn run build-desktop:app
           shell: bash.exe

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -778,10 +778,19 @@ jobs:
           name: Install Desktop Dependencies
           command: yarn run build-desktop:install-app-deps
       - run:
+          name: Import Codesigning Certificate
+          command: |
+                  # Workaround for Sign Tool "private key filter" bug in Circle's Windows image.
+                  # Ref: https://travis-ci.community/t/codesigning-on-windows/
+                  #
+                  # Fix: Import .p12 into the local certificate store. Sign Tool will use
+                  # package.json's `certificateSubjectName` to find the imported cert.
+                  Import-PfxCertificate -FilePath $env:CSC_LINK -CertStoreLocation Cert:\LocalMachine\Root -Password (ConvertTo-SecureString -String $env:WIN_CSC_KEY_PASSWORD -AsPlainText -Force)
+      - run:
           name: Build Desktop Windows
           command: |
-                  $env:CSC_KEY_PASSWORD=$env:WIN_CSC_KEY_PASSWORD
-                  make -f desktop/Makefile package
+                  # Use make for bash-like environment variable substitution
+                  make -f desktop/Makefile package ELECTRON_BUILDER_ARGS='-c.win.certificateSubjectName=""Automattic, Inc.""'
       - run:
           name: Archive Unpacked Directories
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -891,9 +891,9 @@ workflows:
       # - wp-desktop-mac:
       #     requires:
       #       - wp-desktop-source
-      # - wp-desktop-linux:
-      #     requires:
-      #       - wp-desktop-source
+      - wp-desktop-linux:
+          requires:
+            - wp-desktop-source
       - wp-desktop-windows:
           requires:
             - wp-desktop-source

--- a/desktop/Makefile
+++ b/desktop/Makefile
@@ -46,6 +46,8 @@ source:
 
 	@cd $(CALYPSO_DIR) && yarn run build-desktop:source
 
+# Note: cannot prepend prepend desktop/pacakge.json with full path: cannot be resolved on Windows.
+# Instead, cd to desktop directory within the subprocess.
 PACKAGE_ELECTRON_VERSION = $(shell cd $(DESKTOP_DIR) && node -e "console.log(require('./package.json').devDependencies.electron)")
 
 package:

--- a/desktop/Makefile
+++ b/desktop/Makefile
@@ -46,7 +46,7 @@ source:
 
 	@cd $(CALYPSO_DIR) && yarn run build-desktop:source
 
-PACKAGE_ELECTRON_VERSION := $(shell node -e "console.log(require('$(DESKTOP_DIR)/package.json').devDependencies.electron)")
+PACKAGE_ELECTRON_VERSION := $(shell node -e "console.log(require('./package.json').devDependencies.electron)")
 
 package:
 	$(info Packaging app...)

--- a/desktop/Makefile
+++ b/desktop/Makefile
@@ -46,10 +46,8 @@ source:
 
 	@cd $(CALYPSO_DIR) && yarn run build-desktop:source
 
-# Note: cannot prepend prepend desktop/pacakge.json with full path: cannot be resolved on Windows.
-# Instead, cd to desktop directory within the subprocess.
-PACKAGE_ELECTRON_VERSION = $(shell cd $(DESKTOP_DIR) && node -e "console.log(require('./package.json').devDependencies.electron)")
-
+# Note: cannot prepend prepend desktop/package.json with full path: cannot be resolved on Windows.
+package: PACKAGE_ELECTRON_VERSION = $(shell cd $(DESKTOP_DIR) node -e "console.log(require('./package.json').devDependencies.electron)")
 package:
 	$(info Packaging app...)
 

--- a/desktop/Makefile
+++ b/desktop/Makefile
@@ -47,7 +47,7 @@ source:
 	@cd $(CALYPSO_DIR) && yarn run build-desktop:source
 
 # Note: cannot prepend prepend desktop/package.json with full path: cannot be resolved on Windows.
-package: PACKAGE_ELECTRON_VERSION = $(shell cd $(DESKTOP_DIR) node -e "console.log(require('./package.json').devDependencies.electron)")
+package: PACKAGE_ELECTRON_VERSION = $(shell cd $(DESKTOP_DIR) && node -e "console.log(require('./package.json').devDependencies.electron)")
 package:
 	$(info Packaging app...)
 

--- a/desktop/Makefile
+++ b/desktop/Makefile
@@ -46,10 +46,14 @@ source:
 
 	@cd $(CALYPSO_DIR) && yarn run build-desktop:source
 
+# Note: cannot prepend prepend desktop/pacakge.json with full path: cannot be resolved on Windows.
+# Instead, cd to desktop directory within the subprocess.
+PACKAGE_ELECTRON_VERSION = $(shell cd $(DESKTOP_DIR) && node -e "console.log(require('./package.json').devDependencies.electron)")
+
 package:
 	$(info Packaging app...)
 
-	@cd $(CALYPSO_DIR) && yarn run build-desktop:app
+	@npx electron-builder ${ELECTRON_BUILDER_ARGS} -c.electronVersion=$(PACKAGE_ELECTRON_VERSION) build --publish never
 
 e2e:
 	$(info Running end-to-end tests...)

--- a/desktop/Makefile
+++ b/desktop/Makefile
@@ -46,14 +46,10 @@ source:
 
 	@cd $(CALYPSO_DIR) && yarn run build-desktop:source
 
-# Note: cannot prepend prepend desktop/pacakge.json with full path: cannot be resolved on Windows.
-# Instead, cd to desktop directory within the subprocess.
-PACKAGE_ELECTRON_VERSION = $(shell cd $(DESKTOP_DIR) && node -e "console.log(require('./package.json').devDependencies.electron)")
-
 package:
 	$(info Packaging app...)
 
-	@npx electron-builder ${ELECTRON_BUILDER_ARGS} -c.electronVersion=$(PACKAGE_ELECTRON_VERSION) build --publish never
+	@cd $(CALYPSO_DIR) && yarn run build-desktop:app
 
 e2e:
 	$(info Running end-to-end tests...)

--- a/desktop/Makefile
+++ b/desktop/Makefile
@@ -46,7 +46,7 @@ source:
 
 	@cd $(CALYPSO_DIR) && yarn run build-desktop:source
 
-PACKAGE_ELECTRON_VERSION := $(shell node -e "console.log(require('./package.json').devDependencies.electron)")
+PACKAGE_ELECTRON_VERSION := $(shell node -e "console.log(require('$(DESKTOP_DIR)/package.json').devDependencies.electron)")
 
 package:
 	$(info Packaging app...)

--- a/desktop/Makefile
+++ b/desktop/Makefile
@@ -46,7 +46,7 @@ source:
 
 	@cd $(CALYPSO_DIR) && yarn run build-desktop:source
 
-PACKAGE_ELECTRON_VERSION = $(shell node -e "console.log(require('$(DESKTOP_DIR)/package.json').devDependencies.electron)")
+PACKAGE_ELECTRON_VERSION = $(shell cd $(DESKTOP_DIR) && node -e "console.log(require('./package.json').devDependencies.electron)")
 
 package:
 	$(info Packaging app...)

--- a/desktop/Makefile
+++ b/desktop/Makefile
@@ -46,10 +46,12 @@ source:
 
 	@cd $(CALYPSO_DIR) && yarn run build-desktop:source
 
+PACKAGE_ELECTRON_VERSION := $(shell node -e "console.log(require('./package.json').devDependencies.electron)")
+
 package:
 	$(info Packaging app...)
 
-	@cd $(CALYPSO_DIR) && yarn run build-desktop:app
+	@npx electron-builder ${ELECTRON_BUILDER_ARGS} -c.electronVersion=$(PACKAGE_ELECTRON_VERSION) build --publish never
 
 e2e:
 	$(info Running end-to-end tests...)

--- a/desktop/Makefile
+++ b/desktop/Makefile
@@ -46,7 +46,7 @@ source:
 
 	@cd $(CALYPSO_DIR) && yarn run build-desktop:source
 
-PACKAGE_ELECTRON_VERSION := $(shell node -e "console.log(require('./package.json').devDependencies.electron)")
+PACKAGE_ELECTRON_VERSION = $(shell node -e "console.log(require('$(DESKTOP_DIR)/package.json').devDependencies.electron)")
 
 package:
 	$(info Packaging app...)


### PR DESCRIPTION
### Description

Porting linux and windows build jobs to Calypso Circle config as part of the migration of wp-desktop to the Calypso monorepo.

This PR includes:

- [x] Build Linux
- [x] Linux e2e
- [x] Build Windows