### PR TITLE
Typography: Update devdocs guidelines to be more specific about Recoleta usage

### DIFF
--- a/client/devdocs/design/typography.jsx
+++ b/client/devdocs/design/typography.jsx
@@ -103,9 +103,16 @@ export default class Typography extends React.PureComponent {
 					<h2>Brand Typography</h2>
 
 					<p>
-						We use Recoleta sparingly to add our brand's flavor to select headings. Since this font
-						is not compatible with some languages, we use a special class that targets specific
-						locales, and falls back to the <code>$serif</code> stack when necessary.
+						We use Recoleta sparingly to add our brand's flavor to select headings. In general,
+						Recoleta should be used for main page titles (linked from the main sidebar navigation)
+						and no more than one main heading per page. It looks best at sizes 24px or greater, or{ ' ' }
+						<code>$font-title-medium</code> in our type scale.
+					</p>
+
+					<p>
+						Since Recoleta is not compatible with some languages, we use a special class that
+						targets specific locales, and falls back to the <code>$serif</code> stack when
+						necessary.
 					</p>
 
 					<h3>How to use:</h3>

--- a/client/devdocs/design/typography.jsx
+++ b/client/devdocs/design/typography.jsx
@@ -109,11 +109,18 @@ export default class Typography extends React.PureComponent {
 						<code>$font-title-medium</code> in our type scale.
 					</p>
 
+					<p>Recoleta should not be used for UI elements, such as buttons or navigation.</p>
+
 					<p>
 						Since Recoleta is not compatible with some languages, we use a special class that
 						targets specific locales, and falls back to the <code>$serif</code> stack when
 						necessary.
 					</p>
+
+					<Card className="design__typography-brand-example">
+						<h2>Quick foxes jump nightly above wizards.</h2>
+						<h3>Pack my box with five dozen liquor jugs</h3>
+					</Card>
 
 					<h3>How to use:</h3>
 

--- a/client/devdocs/style.scss
+++ b/client/devdocs/style.scss
@@ -466,10 +466,20 @@ $devdocs-max-width: 720px;
 	}
 }
 
+.design__typography-brand-example {
+	@extend .wp-brand-font;
+
+	h2 {
+		margin-top: 16px;
+	}
+}
+
 .design__typography-code-example {
 	font-family: $code;
 	font-size: $font-body;
 }
+
+
 
 .design__typography-modular-scale {
 	max-width: 400px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

*  Add some general guidelines for using Recoleta; only for page titles and one major heading per page, not for UI elements.
* Adds a visual example of Recoleta to match the content and UI examples shown

**Before**
<img width="770" alt="Screen Shot 2020-07-13 at 2 16 47 PM" src="https://user-images.githubusercontent.com/2124984/87338851-c5b14100-c513-11ea-9ad7-e18cfdd83981.png">

**After**

<img width="772" alt="Screen Shot 2020-07-13 at 2 26 01 PM" src="https://user-images.githubusercontent.com/2124984/87339578-d1513780-c514-11ea-8ee6-35d553144827.png">


#### Testing instructions

* Switch to this PR
* Go to `/devdocs/typography` and check out the Recoleta section for changes.
