### PR TITLE
Jetpack: add new Jetpack product card

### DIFF
--- a/client/components/jetpack-bundle-card/README.md
+++ b/client/components/jetpack-bundle-card/README.md
@@ -1,0 +1,1 @@
+# Jetpack Bundle Card

--- a/client/components/jetpack-bundle-card/docs/example.tsx
+++ b/client/components/jetpack-bundle-card/docs/example.tsx
@@ -1,0 +1,34 @@
+/**
+ * External dependencies
+ */
+import { noop } from 'lodash';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import JetpackBundleCard from 'components/jetpack-bundle-card';
+
+export default function JetpackBundleCardExample() {
+	return (
+		<div>
+			<h3>Jetpack Bundle Card</h3>
+			<JetpackBundleCard
+				iconSlug="jetpack_anti_spam"
+				productName="Security Bundle"
+				subheadline="Get all of the essential security tools"
+				description="Enjoy the peace of mind of complete site protection. This bundle includes everything you need to keep your site backed up, free of spam and one-step ahead of threats. Options available: Real-Time or Daily"
+				originalPrice={ 30 }
+				discountedPrice={ 25 }
+				withStartingPrice
+				billingTimeFrame="per month, billed yearly"
+				badgeLabel="Best value"
+				buttonLabel="Get the Security Bundle"
+				onButtonClick={ noop }
+				features="Lorem ipsum dolor sit amet consectetur adipisicing elit. Aliquid quia, eum culpa maxime tempore soluta! Expedita, praesentium eaque nulla id placeat illo quibusdam rem nam ipsum. Labore nulla praesentium rerum?"
+			/>
+		</div>
+	);
+}
+
+JetpackBundleCardExample.displayName = 'JetpackBundleCardExample';

--- a/client/components/jetpack-bundle-card/docs/example.tsx
+++ b/client/components/jetpack-bundle-card/docs/example.tsx
@@ -1,32 +1,25 @@
 /**
  * External dependencies
  */
-import { noop } from 'lodash';
 import React from 'react';
 
 /**
  * Internal dependencies
  */
 import JetpackBundleCard from 'components/jetpack-bundle-card';
+import {
+	productCardWithProductTypeAndBadge,
+	productCardWithDiscount,
+} from 'components/jetpack-product-card/fixture';
 
 export default function JetpackBundleCardExample() {
 	return (
 		<div>
-			<h3>Jetpack Bundle Card</h3>
-			<JetpackBundleCard
-				iconSlug="jetpack_anti_spam"
-				productName="Security Bundle"
-				subheadline="Get all of the essential security tools"
-				description="Enjoy the peace of mind of complete site protection. This bundle includes everything you need to keep your site backed up, free of spam and one-step ahead of threats. Options available: Real-Time or Daily"
-				originalPrice={ 30 }
-				discountedPrice={ 25 }
-				withStartingPrice
-				billingTimeFrame="per month, billed yearly"
-				badgeLabel="Best value"
-				buttonLabel="Get the Security Bundle"
-				onButtonClick={ noop }
-				features="Lorem ipsum dolor sit amet consectetur adipisicing elit. Aliquid quia, eum culpa maxime tempore soluta! Expedita, praesentium eaque nulla id placeat illo quibusdam rem nam ipsum. Labore nulla praesentium rerum?"
-			/>
+			<h3>Jetpack Product Card with Product Type and Badge</h3>
+			<JetpackBundleCard { ...productCardWithProductTypeAndBadge } />
+			<br />
+			<h3>Jetpack Bundle Card with Discount</h3>
+			<JetpackBundleCard { ...productCardWithDiscount } />
 		</div>
 	);
 }

--- a/client/components/jetpack-bundle-card/index.tsx
+++ b/client/components/jetpack-bundle-card/index.tsx
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import classNames from 'classnames';
+import React, { FunctionComponent } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import JetpackProductCard, {
+	Props as JetpackProductCardProps,
+} from 'components/jetpack-product-card';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+type Props = JetpackProductCardProps;
+
+const JetpackBundleCard: FunctionComponent< Props > = ( props ) => {
+	return (
+		<JetpackProductCard
+			{ ...props }
+			className={ classNames( props.className, 'jetpack-bundle-card' ) }
+		/>
+	);
+};
+
+export default JetpackBundleCard;

--- a/client/components/jetpack-bundle-card/style.scss
+++ b/client/components/jetpack-bundle-card/style.scss
@@ -1,0 +1,15 @@
+.jetpack-bundle-card {
+	$jetpack-bundle-card-color: var( --studio-jetpack-green-40 );
+
+	.jetpack-product-card__header {
+		border-color: $jetpack-bundle-card-color;
+	}
+
+	.plan-price {
+		border-color: $jetpack-bundle-card-color;
+	}
+
+	.jetpack-product-card__badge {
+		color: $jetpack-bundle-card-color;
+	}
+}

--- a/client/components/jetpack-product-card/README.md
+++ b/client/components/jetpack-product-card/README.md
@@ -1,0 +1,1 @@
+# Jetpack Product Card

--- a/client/components/jetpack-product-card/docs/example.tsx
+++ b/client/components/jetpack-product-card/docs/example.tsx
@@ -10,6 +10,7 @@ import JetpackProductCard from 'components/jetpack-product-card';
 import {
 	productCard,
 	highlightedProductCard,
+	ownedProductCard,
 	productCardWithProductTypeAndBadgeAndStartingPriceAndDiscount,
 	productCardWithLongTexts,
 	expandedProductCardWithCategoriesAndMore,
@@ -23,6 +24,9 @@ export default function JetpackProductCardExample() {
 			<br />
 			<h3>Highlighted Jetpack Product Card</h3>
 			<JetpackProductCard { ...highlightedProductCard } />
+			<br />
+			<h3>Owned Jetpack Product Card</h3>
+			<JetpackProductCard { ...ownedProductCard } />
 			<br />
 			<h3>Jetpack Product Card with Product Type, Badge, Starting Price and Discount</h3>
 			<JetpackProductCard { ...productCardWithProductTypeAndBadgeAndStartingPriceAndDiscount } />

--- a/client/components/jetpack-product-card/docs/example.tsx
+++ b/client/components/jetpack-product-card/docs/example.tsx
@@ -11,7 +11,8 @@ import {
 	productCard,
 	highlightedProductCard,
 	ownedProductCard,
-	productCardWithProductTypeAndBadgeAndStartingPriceAndDiscount,
+	productCardWithProductTypeAndBadge,
+	productCardWithDiscount,
 	productCardWithLongTexts,
 	expandedProductCardWithCategoriesAndMore,
 } from '../fixture';
@@ -28,13 +29,16 @@ export default function JetpackProductCardExample() {
 			<h3>Owned Jetpack Product Card</h3>
 			<JetpackProductCard { ...ownedProductCard } />
 			<br />
-			<h3>Jetpack Product Card with Product Type, Badge, Starting Price and Discount</h3>
-			<JetpackProductCard { ...productCardWithProductTypeAndBadgeAndStartingPriceAndDiscount } />
+			<h3>Jetpack Product Card with Product Type and Badge</h3>
+			<JetpackProductCard { ...productCardWithProductTypeAndBadge } />
+			<br />
+			<h3>Jetpack Product Card with Discount</h3>
+			<JetpackProductCard { ...productCardWithDiscount } />
 			<br />
 			<h3>Jetpack Product Card with Long Texts</h3>
 			<JetpackProductCard { ...productCardWithLongTexts } />
 			<br />
-			<h3>Expanded Jetpack Product Card with Categories and More Link</h3>
+			<h3>Expanded Jetpack Product Card with Features Categories and More Link</h3>
 			<JetpackProductCard { ...expandedProductCardWithCategoriesAndMore } />
 		</div>
 	);

--- a/client/components/jetpack-product-card/docs/example.tsx
+++ b/client/components/jetpack-product-card/docs/example.tsx
@@ -55,6 +55,19 @@ export default function JetpackProductCardExample() {
 				features="Lorem ipsum dolor sit amet consectetur adipisicing elit. Aliquid quia, eum culpa maxime tempore soluta! Expedita, praesentium eaque nulla id placeat illo quibusdam rem nam ipsum. Labore nulla praesentium rerum?"
 			/>
 			<br />
+			<h3>HIghlighted Jetpack Product Card</h3>
+			<JetpackProductCard
+				iconSlug="jetpack_anti_spam"
+				productName="Security Bundle"
+				subheadline="Get all of the essential security tools"
+				description="Enjoy the peace of mind of complete site protection. This bundle includes everything you need to keep your site backed up, free of spam and one-step ahead of threats. Options available: Real-Time or Daily"
+				originalPrice={ 30 }
+				billingTimeFrame="per month, billed yearly"
+				buttonLabel="Get the Security Bundle"
+				onButtonClick={ noop }
+				features="Lorem ipsum dolor sit amet consectetur adipisicing elit. Aliquid quia, eum culpa maxime tempore soluta! Expedita, praesentium eaque nulla id placeat illo quibusdam rem nam ipsum. Labore nulla praesentium rerum?"
+				isHighlighted
+			/>
 		</div>
 	);
 }

--- a/client/components/jetpack-product-card/docs/example.tsx
+++ b/client/components/jetpack-product-card/docs/example.tsx
@@ -1,74 +1,37 @@
 /**
  * External dependencies
  */
-import { noop } from 'lodash';
 import React from 'react';
 
 /**
  * Internal dependencies
  */
 import JetpackProductCard from 'components/jetpack-product-card';
+import {
+	productCard,
+	highlightedProductCard,
+	productCardWithProductTypeAndBadgeAndStartingPriceAndDiscount,
+	productCardWithLongTexts,
+	expandedProductCardWithCategoriesAndMore,
+} from '../fixture';
 
 export default function JetpackProductCardExample() {
 	return (
 		<div>
 			<h3>Jetpack Product Card</h3>
-			<JetpackProductCard
-				iconSlug="jetpack_anti_spam"
-				productName="Security Bundle"
-				subheadline="Get all of the essential security tools"
-				description="Enjoy the peace of mind of complete site protection. This bundle includes everything you need to keep your site backed up, free of spam and one-step ahead of threats. Options available: Real-Time or Daily"
-				originalPrice={ 30 }
-				billingTimeFrame="per month, billed yearly"
-				buttonLabel="Get the Security Bundle"
-				onButtonClick={ noop }
-				features="Lorem ipsum dolor sit amet consectetur adipisicing elit. Aliquid quia, eum culpa maxime tempore soluta! Expedita, praesentium eaque nulla id placeat illo quibusdam rem nam ipsum. Labore nulla praesentium rerum?"
-			/>
+			<JetpackProductCard { ...productCard } />
 			<br />
-			<h3>Jetpack Product Card with Long Name and Subheadline</h3>
-			<JetpackProductCard
-				iconSlug="jetpack_anti_spam"
-				productName="Security Bundle Security Bundle Security Bundle"
-				subheadline="Get all of the essential security tools. Get all of the essential security tools. Get all of the essential security tools."
-				description="Enjoy the peace of mind of complete site protection. This bundle includes everything you need to keep your site backed up, free of spam and one-step ahead of threats. Options available: Real-Time or Daily"
-				originalPrice={ 30 }
-				billingTimeFrame="per month, billed yearly"
-				buttonLabel="Get the Security Bundle"
-				onButtonClick={ noop }
-				features="Lorem ipsum dolor sit amet consectetur adipisicing elit. Aliquid quia, eum culpa maxime tempore soluta! Expedita, praesentium eaque nulla id placeat illo quibusdam rem nam ipsum. Labore nulla praesentium rerum?"
-			/>
+			<h3>Highlighted Jetpack Product Card</h3>
+			<JetpackProductCard { ...highlightedProductCard } />
 			<br />
 			<h3>Jetpack Product Card with Product Type, Badge, Starting Price and Discount</h3>
-			<JetpackProductCard
-				iconSlug="jetpack_anti_spam"
-				productName="Security Bundle"
-				productType="Real-Time"
-				subheadline="Get all of the essential security tools"
-				description="Enjoy the peace of mind of complete site protection. This bundle includes everything you need to keep your site backed up, free of spam and one-step ahead of threats. Options available: Real-Time or Daily"
-				originalPrice={ 30 }
-				discountedPrice={ 25 }
-				withStartingPrice
-				billingTimeFrame="per month, billed yearly"
-				badgeLabel="Best value"
-				buttonLabel="Get the Security Bundle"
-				onButtonClick={ noop }
-				features="Lorem ipsum dolor sit amet consectetur adipisicing elit. Aliquid quia, eum culpa maxime tempore soluta! Expedita, praesentium eaque nulla id placeat illo quibusdam rem nam ipsum. Labore nulla praesentium rerum?"
-			/>
+			<JetpackProductCard { ...productCardWithProductTypeAndBadgeAndStartingPriceAndDiscount } />
 			<br />
-			<h3>Highlighted and Expanded Jetpack Product Card</h3>
-			<JetpackProductCard
-				iconSlug="jetpack_anti_spam"
-				productName="Security Bundle"
-				subheadline="Get all of the essential security tools"
-				description="Enjoy the peace of mind of complete site protection. This bundle includes everything you need to keep your site backed up, free of spam and one-step ahead of threats. Options available: Real-Time or Daily"
-				originalPrice={ 30 }
-				billingTimeFrame="per month, billed yearly"
-				buttonLabel="Get the Security Bundle"
-				onButtonClick={ noop }
-				features="Lorem ipsum dolor sit amet consectetur adipisicing elit. Aliquid quia, eum culpa maxime tempore soluta! Expedita, praesentium eaque nulla id placeat illo quibusdam rem nam ipsum. Labore nulla praesentium rerum?"
-				isHighlighted
-				isExpanded
-			/>
+			<h3>Jetpack Product Card with Long Texts</h3>
+			<JetpackProductCard { ...productCardWithLongTexts } />
+			<br />
+			<h3>Expanded Jetpack Product Card with Categories and More Link</h3>
+			<JetpackProductCard { ...expandedProductCardWithCategoriesAndMore } />
 		</div>
 	);
 }

--- a/client/components/jetpack-product-card/docs/example.tsx
+++ b/client/components/jetpack-product-card/docs/example.tsx
@@ -1,0 +1,62 @@
+/**
+ * External dependencies
+ */
+import { noop } from 'lodash';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import JetpackProductCard from 'components/jetpack-product-card';
+
+export default function JetpackProductCardExample() {
+	return (
+		<div>
+			<h3>Jetpack Product Card</h3>
+			<JetpackProductCard
+				iconSlug="jetpack_anti_spam"
+				productName="Security Bundle"
+				subheadline="Get all of the essential security tools"
+				description="Enjoy the peace of mind of complete site protection. This bundle includes everything you need to keep your site backed up, free of spam and one-step ahead of threats. Options available: Real-Time or Daily"
+				originalPrice={ 30 }
+				billingTimeFrame="per month, billed yearly"
+				buttonLabel="Get the Security Bundle"
+				onButtonClick={ noop }
+				features="Lorem ipsum dolor sit amet consectetur adipisicing elit. Aliquid quia, eum culpa maxime tempore soluta! Expedita, praesentium eaque nulla id placeat illo quibusdam rem nam ipsum. Labore nulla praesentium rerum?"
+			/>
+			<br />
+			<h3>Jetpack Product Card with Long Name and Subheadline</h3>
+			<JetpackProductCard
+				iconSlug="jetpack_anti_spam"
+				productName="Security Bundle Security Bundle Security Bundle"
+				subheadline="Get all of the essential security tools. Get all of the essential security tools. Get all of the essential security tools."
+				description="Enjoy the peace of mind of complete site protection. This bundle includes everything you need to keep your site backed up, free of spam and one-step ahead of threats. Options available: Real-Time or Daily"
+				originalPrice={ 30 }
+				billingTimeFrame="per month, billed yearly"
+				buttonLabel="Get the Security Bundle"
+				onButtonClick={ noop }
+				features="Lorem ipsum dolor sit amet consectetur adipisicing elit. Aliquid quia, eum culpa maxime tempore soluta! Expedita, praesentium eaque nulla id placeat illo quibusdam rem nam ipsum. Labore nulla praesentium rerum?"
+			/>
+			<br />
+			<h3>Jetpack Product Card with Product Type, Badge, Starting Price and Discount</h3>
+			<JetpackProductCard
+				iconSlug="jetpack_anti_spam"
+				productName="Security Bundle"
+				productType="Real-Time"
+				subheadline="Get all of the essential security tools"
+				description="Enjoy the peace of mind of complete site protection. This bundle includes everything you need to keep your site backed up, free of spam and one-step ahead of threats. Options available: Real-Time or Daily"
+				originalPrice={ 30 }
+				discountedPrice={ 25 }
+				withStartingPrice
+				billingTimeFrame="per month, billed yearly"
+				badgeLabel="Best value"
+				buttonLabel="Get the Security Bundle"
+				onButtonClick={ noop }
+				features="Lorem ipsum dolor sit amet consectetur adipisicing elit. Aliquid quia, eum culpa maxime tempore soluta! Expedita, praesentium eaque nulla id placeat illo quibusdam rem nam ipsum. Labore nulla praesentium rerum?"
+			/>
+			<br />
+		</div>
+	);
+}
+
+JetpackProductCardExample.displayName = 'JetpackProductCardExample';

--- a/client/components/jetpack-product-card/docs/example.tsx
+++ b/client/components/jetpack-product-card/docs/example.tsx
@@ -15,6 +15,7 @@ import {
 	productCardWithDiscount,
 	productCardWithLongTexts,
 	expandedProductCardWithCategoriesAndMore,
+	productCardWithCancelButton,
 } from '../fixture';
 
 export default function JetpackProductCardExample() {
@@ -40,6 +41,9 @@ export default function JetpackProductCardExample() {
 			<br />
 			<h3>Expanded Jetpack Product Card with Features Categories and More Link</h3>
 			<JetpackProductCard { ...expandedProductCardWithCategoriesAndMore } />
+			<br />
+			<h3>Jetpack Product Card with Cancel Button</h3>
+			<JetpackProductCard { ...productCardWithCancelButton } />
 		</div>
 	);
 }

--- a/client/components/jetpack-product-card/docs/example.tsx
+++ b/client/components/jetpack-product-card/docs/example.tsx
@@ -55,7 +55,7 @@ export default function JetpackProductCardExample() {
 				features="Lorem ipsum dolor sit amet consectetur adipisicing elit. Aliquid quia, eum culpa maxime tempore soluta! Expedita, praesentium eaque nulla id placeat illo quibusdam rem nam ipsum. Labore nulla praesentium rerum?"
 			/>
 			<br />
-			<h3>HIghlighted Jetpack Product Card</h3>
+			<h3>Highlighted and Expanded Jetpack Product Card</h3>
 			<JetpackProductCard
 				iconSlug="jetpack_anti_spam"
 				productName="Security Bundle"
@@ -67,6 +67,7 @@ export default function JetpackProductCardExample() {
 				onButtonClick={ noop }
 				features="Lorem ipsum dolor sit amet consectetur adipisicing elit. Aliquid quia, eum culpa maxime tempore soluta! Expedita, praesentium eaque nulla id placeat illo quibusdam rem nam ipsum. Labore nulla praesentium rerum?"
 				isHighlighted
+				isExpanded
 			/>
 		</div>
 	);

--- a/client/components/jetpack-product-card/features-item.tsx
+++ b/client/components/jetpack-product-card/features-item.tsx
@@ -8,6 +8,7 @@ import React, { FunctionComponent } from 'react';
  */
 import Gridicon from 'components/gridicon';
 import InfoPopover from 'components/info-popover';
+import { preventWidows } from 'lib/formatting';
 import { FeaturesItem } from './types';
 
 export type Props = {
@@ -23,9 +24,9 @@ const JetpackProductCardFeaturesItem: FunctionComponent< Props > = ( { item } ) 
 		<li className="jetpack-product-card__features-item">
 			<div className="jetpack-product-card__features-summary">
 				<Gridicon className="jetpack-product-card__features-icon" icon={ icon || DEFAULT_ICON } />
-				<p className="jetpack-product-card__features-text">{ text }</p>
+				<p className="jetpack-product-card__features-text">{ preventWidows( text ) }</p>
 			</div>
-			{ description && <InfoPopover>{ description }</InfoPopover> }
+			{ description && <InfoPopover>{ preventWidows( description ) }</InfoPopover> }
 		</li>
 	);
 };

--- a/client/components/jetpack-product-card/features-item.tsx
+++ b/client/components/jetpack-product-card/features-item.tsx
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+import React, { FunctionComponent } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Gridicon from 'components/gridicon';
+import InfoPopover from 'components/info-popover';
+import { FeaturesItem } from './types';
+
+export type Props = {
+	item: FeaturesItem;
+};
+
+const DEFAULT_ICON = 'checkmark';
+
+const JetpackProductCardFeaturesItem: FunctionComponent< Props > = ( { item } ) => {
+	const { icon, text, description } = item;
+
+	return (
+		<li className="jetpack-product-card__features-item">
+			<div className="jetpack-product-card__features-summary">
+				<Gridicon className="jetpack-product-card__features-icon" icon={ icon || DEFAULT_ICON } />
+				<p className="jetpack-product-card__features-text">{ text }</p>
+			</div>
+			{ description && <InfoPopover>{ description }</InfoPopover> }
+		</li>
+	);
+};
+
+export default JetpackProductCardFeaturesItem;

--- a/client/components/jetpack-product-card/features-item.tsx
+++ b/client/components/jetpack-product-card/features-item.tsx
@@ -9,7 +9,7 @@ import React, { FunctionComponent } from 'react';
 import Gridicon from 'components/gridicon';
 import InfoPopover from 'components/info-popover';
 import { preventWidows } from 'lib/formatting';
-import { FeaturesItem } from './types';
+import type { FeaturesItem } from './types';
 
 export type Props = {
 	item: FeaturesItem;

--- a/client/components/jetpack-product-card/features.tsx
+++ b/client/components/jetpack-product-card/features.tsx
@@ -2,15 +2,19 @@
  * External dependencies
  */
 import { useTranslate } from 'i18n-calypso';
-import React, { useState, useCallback, FunctionComponent, ReactNode } from 'react';
+import { isArray, isObject } from 'lodash';
+import React, { useState, useCallback, FunctionComponent } from 'react';
 
 /**
  * Internal dependencies
  */
+import ExternalLink from 'components/external-link';
 import FoldableCard from 'components/foldable-card';
+import FeaturesItem from './features-item';
+import { Features } from './types';
 
 export type Props = {
-	features: ReactNode;
+	features: Features;
 	isExpanded?: boolean;
 };
 
@@ -23,6 +27,25 @@ const JetpackProductCardFeatures: FunctionComponent< Props > = ( {
 	const onClose = useCallback( () => setExpanded( false ), [ setExpanded ] );
 	const translate = useTranslate();
 
+	const { items, more } = features;
+
+	let itemsEl;
+
+	if ( isArray( items ) ) {
+		itemsEl = items.map( ( item ) => <FeaturesItem item={ item } key={ item.text } /> );
+	} else if ( isObject( items ) ) {
+		itemsEl = Object.keys( items ).map( ( category ) => (
+			<li key={ category }>
+				<p className="jetpack-product-card__features-category">{ category }</p>
+				<ul className="jetpack-product-card__features-list">
+					{ items[ category ].map( ( item ) => (
+						<FeaturesItem item={ item } key={ item.text } />
+					) ) }
+				</ul>
+			</li>
+		) );
+	}
+
 	return (
 		<FoldableCard
 			header={ isExpanded ? translate( 'Hide features' ) : translate( 'Show features' ) }
@@ -31,7 +54,14 @@ const JetpackProductCardFeatures: FunctionComponent< Props > = ( {
 			onOpen={ onOpen }
 			onClose={ onClose }
 		>
-			{ features }
+			<ul className="jetpack-product-card__features-list">{ itemsEl }</ul>
+			{ more && (
+				<div className="jetpack-product-card__feature-more">
+					<ExternalLink icon={ true } href={ more.url }>
+						{ more.label }
+					</ExternalLink>
+				</div>
+			) }
 		</FoldableCard>
 	);
 };

--- a/client/components/jetpack-product-card/features.tsx
+++ b/client/components/jetpack-product-card/features.tsx
@@ -10,6 +10,7 @@ import React, { useState, useCallback, FunctionComponent } from 'react';
  */
 import ExternalLink from 'components/external-link';
 import FoldableCard from 'components/foldable-card';
+import useTrackCallback from 'lib/jetpack/use-track-callback';
 import FeaturesItem from './features-item';
 import type { Features } from './types';
 
@@ -22,9 +23,23 @@ const JetpackProductCardFeatures: FunctionComponent< Props > = ( {
 	features,
 	isExpanded: isExpandedByDefault,
 } ) => {
+	const trackShowFeatures = useTrackCallback(
+		undefined,
+		'calypso_jetpack_show_product_card_features'
+	);
+	const trackHideFeatures = useTrackCallback(
+		undefined,
+		'calypso_jetpack_hide_product_card_features'
+	);
 	const [ isExpanded, setExpanded ] = useState( !! isExpandedByDefault );
-	const onOpen = useCallback( () => setExpanded( true ), [ setExpanded ] );
-	const onClose = useCallback( () => setExpanded( false ), [ setExpanded ] );
+	const onOpen = useCallback( () => {
+		setExpanded( true );
+		trackShowFeatures();
+	}, [ setExpanded, trackShowFeatures ] );
+	const onClose = useCallback( () => {
+		setExpanded( false );
+		trackHideFeatures();
+	}, [ setExpanded, trackHideFeatures ] );
 	const translate = useTranslate();
 
 	const { items, more } = features;

--- a/client/components/jetpack-product-card/features.tsx
+++ b/client/components/jetpack-product-card/features.tsx
@@ -11,7 +11,7 @@ import React, { useState, useCallback, FunctionComponent } from 'react';
 import ExternalLink from 'components/external-link';
 import FoldableCard from 'components/foldable-card';
 import FeaturesItem from './features-item';
-import { Features } from './types';
+import type { Features } from './types';
 
 export type Props = {
 	features: Features;

--- a/client/components/jetpack-product-card/features.tsx
+++ b/client/components/jetpack-product-card/features.tsx
@@ -9,12 +9,16 @@ import React, { useState, useCallback, FunctionComponent, ReactNode } from 'reac
  */
 import FoldableCard from 'components/foldable-card';
 
-interface Props {
+export type Props = {
 	features: ReactNode;
-}
+	isExpanded?: boolean;
+};
 
-const JetpackProductCardFeatures: FunctionComponent< Props > = ( { features } ) => {
-	const [ isExpanded, setExpanded ] = useState( false );
+const JetpackProductCardFeatures: FunctionComponent< Props > = ( {
+	features,
+	isExpanded: isExpandedByDefault,
+} ) => {
+	const [ isExpanded, setExpanded ] = useState( !! isExpandedByDefault );
 	const onOpen = useCallback( () => setExpanded( true ), [ setExpanded ] );
 	const onClose = useCallback( () => setExpanded( false ), [ setExpanded ] );
 	const translate = useTranslate();
@@ -23,6 +27,7 @@ const JetpackProductCardFeatures: FunctionComponent< Props > = ( { features } ) 
 		<FoldableCard
 			header={ isExpanded ? translate( 'Hide features' ) : translate( 'Show features' ) }
 			clickableHeader
+			expanded={ isExpanded }
 			onOpen={ onOpen }
 			onClose={ onClose }
 		>

--- a/client/components/jetpack-product-card/features.tsx
+++ b/client/components/jetpack-product-card/features.tsx
@@ -1,0 +1,34 @@
+/**
+ * External dependencies
+ */
+import { useTranslate } from 'i18n-calypso';
+import React, { useState, useCallback, FunctionComponent, ReactNode } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import FoldableCard from 'components/foldable-card';
+
+interface Props {
+	features: ReactNode;
+}
+
+const JetpackProductCardFeatures: FunctionComponent< Props > = ( { features } ) => {
+	const [ isExpanded, setExpanded ] = useState( false );
+	const onOpen = useCallback( () => setExpanded( true ), [ setExpanded ] );
+	const onClose = useCallback( () => setExpanded( false ), [ setExpanded ] );
+	const translate = useTranslate();
+
+	return (
+		<FoldableCard
+			header={ isExpanded ? translate( 'Hide features' ) : translate( 'Show features' ) }
+			clickableHeader
+			onOpen={ onOpen }
+			onClose={ onClose }
+		>
+			{ features }
+		</FoldableCard>
+	);
+};
+
+export default JetpackProductCardFeatures;

--- a/client/components/jetpack-product-card/fixture/index.ts
+++ b/client/components/jetpack-product-card/fixture/index.ts
@@ -89,3 +89,10 @@ export const expandedProductCardWithCategoriesAndMore = {
 		},
 	},
 };
+
+export const productCardWithCancelButton = {
+	...productCard,
+	buttonLabel: 'Yes, add Real-Time Scan',
+	cancelLabel: 'No, I do not want Scan',
+	onCancelClick: noop,
+};

--- a/client/components/jetpack-product-card/fixture/index.ts
+++ b/client/components/jetpack-product-card/fixture/index.ts
@@ -42,6 +42,12 @@ export const highlightedProductCard = {
 	isHighlighted: true,
 };
 
+export const ownedProductCard = {
+	...productCard,
+	badgeLabel: 'You own this',
+	isOwned: true,
+};
+
 export const productCardWithProductTypeAndBadgeAndStartingPriceAndDiscount = {
 	...productCard,
 	productType: 'Real-Time',

--- a/client/components/jetpack-product-card/fixture/index.ts
+++ b/client/components/jetpack-product-card/fixture/index.ts
@@ -48,12 +48,17 @@ export const ownedProductCard = {
 	isOwned: true,
 };
 
-export const productCardWithProductTypeAndBadgeAndStartingPriceAndDiscount = {
+export const productCardWithProductTypeAndBadge = {
 	...productCard,
 	productType: 'Real-Time',
+	badgeLabel: 'Best value',
+};
+
+export const productCardWithDiscount = {
+	...productCard,
 	discountedPrice: 25,
 	withStartingPrice: true,
-	badgeLabel: 'Best value',
+	discountMessage: 'Save $100 a year on Scan because you own backup',
 };
 
 export const productCardWithLongTexts = {

--- a/client/components/jetpack-product-card/fixture/index.ts
+++ b/client/components/jetpack-product-card/fixture/index.ts
@@ -30,6 +30,7 @@ export const productCard = {
 	subheadline: 'Get all of the essential security tools',
 	description:
 		'Enjoy the peace of mind of complete site protection. This bundle includes everything you need to keep your site backed up, free of spam and one-step ahead of threats. Options available: Real-Time or Daily',
+	currencyCode: 'USD',
 	originalPrice: 30,
 	billingTimeFrame: 'per month, billed yearly',
 	buttonLabel: 'Get the Security Bundle',

--- a/client/components/jetpack-product-card/fixture/index.ts
+++ b/client/components/jetpack-product-card/fixture/index.ts
@@ -1,0 +1,80 @@
+/**
+ * External dependencies
+ */
+import { noop } from 'lodash';
+
+export const featuresItems = [
+	{
+		text: 'Static file hosting',
+	},
+	{
+		icon: 'lock',
+		text: 'Real-Time Security Bundle',
+		description: 'Lorem ipsum dolor sit amet consectetur adipisicing elit.',
+	},
+];
+
+export const features = {
+	items: featuresItems,
+};
+
+export const categorizedFeatures = {
+	items: {
+		Security: featuresItems,
+	},
+};
+
+export const productCard = {
+	iconSlug: 'jetpack_anti_spam',
+	productName: 'Security Bundle',
+	subheadline: 'Get all of the essential security tools',
+	description:
+		'Enjoy the peace of mind of complete site protection. This bundle includes everything you need to keep your site backed up, free of spam and one-step ahead of threats. Options available: Real-Time or Daily',
+	originalPrice: 30,
+	billingTimeFrame: 'per month, billed yearly',
+	buttonLabel: 'Get the Security Bundle',
+	onButtonClick: noop,
+	features,
+};
+
+export const highlightedProductCard = {
+	...productCard,
+	isHighlighted: true,
+};
+
+export const productCardWithProductTypeAndBadgeAndStartingPriceAndDiscount = {
+	...productCard,
+	productType: 'Real-Time',
+	discountedPrice: 25,
+	withStartingPrice: true,
+	badgeLabel: 'Best value',
+};
+
+export const productCardWithLongTexts = {
+	...productCard,
+	productName: 'Security Bundle Security Bundle Security Bundle',
+	subheadline:
+		'Get all of the essential security tools. Get all of the essential security tools. Get all of the essential security tools.',
+	features: {
+		items: [
+			...featuresItems,
+			{
+				icon: 'lock',
+				text: 'Real-Time Security Bundle Real-Time Security Bundle Real-Time Security Bundle',
+				description: 'Lorem ipsum dolor sit amet consectetur adipisicing elit.',
+			},
+		],
+	},
+};
+
+export const expandedProductCardWithCategoriesAndMore = {
+	...productCard,
+	isExpanded: true,
+	features: {
+		...categorizedFeatures,
+		more: {
+			url: 'https://jetpack.com',
+			label: 'And 25 more',
+		},
+	},
+};

--- a/client/components/jetpack-product-card/index.tsx
+++ b/client/components/jetpack-product-card/index.tsx
@@ -34,6 +34,7 @@ type OwnProps = {
 	buttonLabel: string;
 	onButtonClick: () => void;
 	isHighlighted?: boolean;
+	isOwned?: boolean;
 };
 
 export type Props = OwnProps & FeaturesProps;
@@ -53,6 +54,7 @@ const JetpackProductCard: FunctionComponent< Props > = ( {
 	buttonLabel,
 	onButtonClick,
 	isHighlighted,
+	isOwned,
 	features,
 	isExpanded,
 } ) => {
@@ -63,7 +65,7 @@ const JetpackProductCard: FunctionComponent< Props > = ( {
 	const isDiscounted = isFinite( discountedPrice );
 
 	return (
-		<div className={ classNames( className, 'jetpack-product-card' ) }>
+		<div className={ classNames( className, 'jetpack-product-card', { 'is-owned': isOwned } ) }>
 			<header className="jetpack-product-card__header">
 				<ProductIcon className="jetpack-product-card__icon" slug={ iconSlug } />
 				<div className="jetpack-product-card__summary">

--- a/client/components/jetpack-product-card/index.tsx
+++ b/client/components/jetpack-product-card/index.tsx
@@ -10,6 +10,7 @@ import React, { useRef, FunctionComponent, ReactNode } from 'react';
  * Internal dependencies
  */
 import { Button, ProductIcon } from '@automattic/components';
+import { preventWidows } from 'lib/formatting';
 import PlanPrice from 'my-sites/plan-price';
 import JetpackProductCardFeatures, { Props as FeaturesProps } from './features';
 import useFlexboxWrapDetection from './lib/use-flexbox-wrap-detection';
@@ -79,12 +80,15 @@ const JetpackProductCard: FunctionComponent< Props > = ( {
 				<div className="jetpack-product-card__summary">
 					<div className="jetpack-product-card__headings">
 						<h1 className="jetpack-product-card__product-name">
-							{ productName }
+							{ preventWidows( productName ) }
 							{ productType && (
-								<span className="jetpack-product-card__product-type"> { productType }</span>
+								<span className="jetpack-product-card__product-type">
+									{ ' ' }
+									{ preventWidows( productType ) }
+								</span>
 							) }
 						</h1>
-						<p className="jetpack-product-card__subheadline">{ subheadline }</p>
+						<p className="jetpack-product-card__subheadline">{ preventWidows( subheadline ) }</p>
 					</div>
 					<div
 						className={ classNames( 'jetpack-product-card__price', {
@@ -112,7 +116,9 @@ const JetpackProductCard: FunctionComponent< Props > = ( {
 			</header>
 			<div className="jetpack-product-card__body">
 				{ discountMessage && (
-					<p className="jetpack-product-card__discount-message">{ discountMessage }</p>
+					<p className="jetpack-product-card__discount-message">
+						{ preventWidows( discountMessage ) }
+					</p>
 				) }
 				<Button
 					className="jetpack-product-card__button"

--- a/client/components/jetpack-product-card/index.tsx
+++ b/client/components/jetpack-product-card/index.tsx
@@ -11,7 +11,7 @@ import React, { useRef, FunctionComponent, ReactNode } from 'react';
  */
 import { Button, ProductIcon } from '@automattic/components';
 import PlanPrice from 'my-sites/plan-price';
-import JetpackProductCardFeatures from './features';
+import JetpackProductCardFeatures, { Props as FeaturesProps } from './features';
 import useFlexboxWrapDetection from './lib/use-flexbox-wrap-detection';
 
 /**
@@ -19,7 +19,7 @@ import useFlexboxWrapDetection from './lib/use-flexbox-wrap-detection';
  */
 import './style.scss';
 
-export interface Props {
+type OwnProps = {
 	className?: string;
 	iconSlug: string;
 	productName: string;
@@ -33,9 +33,10 @@ export interface Props {
 	badgeLabel?: string;
 	buttonLabel: string;
 	onButtonClick: () => void;
-	features: ReactNode;
 	isHighlighted?: boolean;
-}
+};
+
+export type Props = OwnProps & FeaturesProps;
 
 const JetpackProductCard: FunctionComponent< Props > = ( {
 	className,
@@ -53,6 +54,7 @@ const JetpackProductCard: FunctionComponent< Props > = ( {
 	onButtonClick,
 	features,
 	isHighlighted,
+	isExpanded,
 } ) => {
 	const translate = useTranslate();
 	const priceEl = useRef( null );
@@ -102,7 +104,7 @@ const JetpackProductCard: FunctionComponent< Props > = ( {
 				</Button>
 				<p className="jetpack-product-card__description">{ description }</p>
 			</div>
-			<JetpackProductCardFeatures features={ features } />
+			<JetpackProductCardFeatures features={ features } isExpanded={ isExpanded } />
 		</div>
 	);
 };

--- a/client/components/jetpack-product-card/index.tsx
+++ b/client/components/jetpack-product-card/index.tsx
@@ -1,0 +1,104 @@
+/**
+ * External dependencies
+ */
+import classNames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
+import { isFinite } from 'lodash';
+import React, { useRef, FunctionComponent, ReactNode } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { Button, ProductIcon } from '@automattic/components';
+import PlanPrice from 'my-sites/plan-price';
+import JetpackProductCardFeatures from './features';
+import useFlexboxWrapDetection from './lib/use-flexbox-wrap-detection';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+export interface Props {
+	className?: string;
+	iconSlug: string;
+	productName: string;
+	productType?: string;
+	subheadline: string;
+	description: ReactNode;
+	originalPrice: number;
+	discountedPrice?: number;
+	withStartingPrice?: boolean;
+	billingTimeFrame: string;
+	badgeLabel?: string;
+	buttonLabel: string;
+	onButtonClick: () => void;
+	features: ReactNode;
+}
+
+const JetpackProductCard: FunctionComponent< Props > = ( {
+	className,
+	iconSlug,
+	productName,
+	productType,
+	subheadline,
+	description,
+	originalPrice,
+	discountedPrice,
+	withStartingPrice,
+	billingTimeFrame,
+	badgeLabel,
+	buttonLabel,
+	onButtonClick,
+	features,
+} ) => {
+	const translate = useTranslate();
+	const priceEl = useRef( null );
+	const isHeaderWrapped = useFlexboxWrapDetection( priceEl );
+
+	const isDiscounted = isFinite( discountedPrice );
+
+	return (
+		<div className={ classNames( className, 'jetpack-product-card' ) }>
+			<header className="jetpack-product-card__header">
+				<ProductIcon className="jetpack-product-card__icon" slug={ iconSlug } />
+				<div className="jetpack-product-card__summary">
+					<div className="jetpack-product-card__headings">
+						<h1 className="jetpack-product-card__product-name">
+							{ productName }
+							{ productType && (
+								<span className="jetpack-product-card__product-type"> { productType }</span>
+							) }
+						</h1>
+						<p className="jetpack-product-card__subheadline">{ subheadline }</p>
+					</div>
+					<div
+						className={ classNames( 'jetpack-product-card__price', {
+							'is-left-aligned': isHeaderWrapped,
+						} ) }
+						ref={ priceEl }
+					>
+						<span className="jetpack-product-card__raw-price">
+							{ withStartingPrice && (
+								<span className="jetpack-product-card__from">{ translate( 'from' ) }</span>
+							) }
+							<PlanPrice rawPrice={ originalPrice } original={ isDiscounted } />
+							{ isDiscounted && <PlanPrice rawPrice={ discountedPrice } discounted /> }
+						</span>
+						<span className="jetpack-product-card__billing-time-frame">{ billingTimeFrame }</span>
+					</div>
+				</div>
+				{ badgeLabel && <div className="jetpack-product-card__badge">{ badgeLabel }</div> }
+			</header>
+			<div className="jetpack-product-card__body">
+				<Button className="jetpack-product-card__button" onClick={ onButtonClick }>
+					{ buttonLabel }
+				</Button>
+				<p className="jetpack-product-card__description">{ description }</p>
+			</div>
+			<JetpackProductCardFeatures features={ features } />
+		</div>
+	);
+};
+
+export default JetpackProductCard;

--- a/client/components/jetpack-product-card/index.tsx
+++ b/client/components/jetpack-product-card/index.tsx
@@ -26,6 +26,7 @@ type OwnProps = {
 	productType?: string;
 	subheadline: string;
 	description: ReactNode;
+	currencyCode: string;
 	originalPrice: number;
 	discountedPrice?: number;
 	withStartingPrice?: boolean;
@@ -49,6 +50,7 @@ const JetpackProductCard: FunctionComponent< Props > = ( {
 	productType,
 	subheadline,
 	description,
+	currencyCode,
 	originalPrice,
 	discountedPrice,
 	withStartingPrice,
@@ -94,8 +96,14 @@ const JetpackProductCard: FunctionComponent< Props > = ( {
 							{ withStartingPrice && (
 								<span className="jetpack-product-card__from">{ translate( 'from' ) }</span>
 							) }
-							<PlanPrice rawPrice={ originalPrice } original={ isDiscounted } />
-							{ isDiscounted && <PlanPrice rawPrice={ discountedPrice } discounted /> }
+							<PlanPrice
+								rawPrice={ originalPrice }
+								original={ isDiscounted }
+								currencyCode={ currencyCode }
+							/>
+							{ isDiscounted && (
+								<PlanPrice rawPrice={ discountedPrice } discounted currencyCode={ currencyCode } />
+							) }
 						</span>
 						<span className="jetpack-product-card__billing-time-frame">{ billingTimeFrame }</span>
 					</div>

--- a/client/components/jetpack-product-card/index.tsx
+++ b/client/components/jetpack-product-card/index.tsx
@@ -31,6 +31,7 @@ type OwnProps = {
 	withStartingPrice?: boolean;
 	billingTimeFrame: string;
 	badgeLabel?: string;
+	discountMessage?: string;
 	buttonLabel: string;
 	onButtonClick: () => void;
 	isHighlighted?: boolean;
@@ -51,6 +52,7 @@ const JetpackProductCard: FunctionComponent< Props > = ( {
 	withStartingPrice,
 	billingTimeFrame,
 	badgeLabel,
+	discountMessage,
 	buttonLabel,
 	onButtonClick,
 	isHighlighted,
@@ -97,6 +99,9 @@ const JetpackProductCard: FunctionComponent< Props > = ( {
 				{ badgeLabel && <div className="jetpack-product-card__badge">{ badgeLabel }</div> }
 			</header>
 			<div className="jetpack-product-card__body">
+				{ discountMessage && (
+					<p className="jetpack-product-card__discount-message">{ discountMessage }</p>
+				) }
 				<Button
 					className="jetpack-product-card__button"
 					primary={ isHighlighted }

--- a/client/components/jetpack-product-card/index.tsx
+++ b/client/components/jetpack-product-card/index.tsx
@@ -3,8 +3,8 @@
  */
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { isFinite } from 'lodash';
-import React, { useRef, FunctionComponent, ReactNode } from 'react';
+import { isFinite, isNumber } from 'lodash';
+import React, { createElement, useRef, FunctionComponent, ReactNode } from 'react';
 
 /**
  * Internal dependencies
@@ -25,6 +25,7 @@ type OwnProps = {
 	iconSlug: string;
 	productName: string;
 	productType?: string;
+	headingLevel?: number;
 	subheadline: string;
 	description: ReactNode;
 	currencyCode: string;
@@ -49,6 +50,7 @@ const JetpackProductCard: FunctionComponent< Props > = ( {
 	iconSlug,
 	productName,
 	productType,
+	headingLevel,
 	subheadline,
 	description,
 	currencyCode,
@@ -72,6 +74,9 @@ const JetpackProductCard: FunctionComponent< Props > = ( {
 	const isHeaderWrapped = useFlexboxWrapDetection( priceEl );
 
 	const isDiscounted = isFinite( discountedPrice );
+	const parsedHeadingLevel = isNumber( headingLevel )
+		? Math.min( Math.max( Math.floor( headingLevel ), 1 ), 6 )
+		: 2;
 
 	return (
 		<div className={ classNames( className, 'jetpack-product-card', { 'is-owned': isOwned } ) }>
@@ -79,15 +84,19 @@ const JetpackProductCard: FunctionComponent< Props > = ( {
 				<ProductIcon className="jetpack-product-card__icon" slug={ iconSlug } />
 				<div className="jetpack-product-card__summary">
 					<div className="jetpack-product-card__headings">
-						<h1 className="jetpack-product-card__product-name">
-							{ preventWidows( productName ) }
-							{ productType && (
-								<span className="jetpack-product-card__product-type">
-									{ ' ' }
-									{ preventWidows( productType ) }
-								</span>
-							) }
-						</h1>
+						{ createElement(
+							`h${ parsedHeadingLevel }`,
+							{ className: 'jetpack-product-card__product-name' },
+							<>
+								{ preventWidows( productName ) }
+								{ productType && (
+									<span className="jetpack-product-card__product-type">
+										{ ' ' }
+										{ preventWidows( productType ) }
+									</span>
+								) }
+							</>
+						) }
 						<p className="jetpack-product-card__subheadline">{ preventWidows( subheadline ) }</p>
 					</div>
 					<div

--- a/client/components/jetpack-product-card/index.tsx
+++ b/client/components/jetpack-product-card/index.tsx
@@ -52,8 +52,8 @@ const JetpackProductCard: FunctionComponent< Props > = ( {
 	badgeLabel,
 	buttonLabel,
 	onButtonClick,
-	features,
 	isHighlighted,
+	features,
 	isExpanded,
 } ) => {
 	const translate = useTranslate();

--- a/client/components/jetpack-product-card/index.tsx
+++ b/client/components/jetpack-product-card/index.tsx
@@ -34,6 +34,7 @@ export interface Props {
 	buttonLabel: string;
 	onButtonClick: () => void;
 	features: ReactNode;
+	isHighlighted?: boolean;
 }
 
 const JetpackProductCard: FunctionComponent< Props > = ( {
@@ -51,6 +52,7 @@ const JetpackProductCard: FunctionComponent< Props > = ( {
 	buttonLabel,
 	onButtonClick,
 	features,
+	isHighlighted,
 } ) => {
 	const translate = useTranslate();
 	const priceEl = useRef( null );
@@ -91,7 +93,11 @@ const JetpackProductCard: FunctionComponent< Props > = ( {
 				{ badgeLabel && <div className="jetpack-product-card__badge">{ badgeLabel }</div> }
 			</header>
 			<div className="jetpack-product-card__body">
-				<Button className="jetpack-product-card__button" onClick={ onButtonClick }>
+				<Button
+					className="jetpack-product-card__button"
+					primary={ isHighlighted }
+					onClick={ onButtonClick }
+				>
 					{ buttonLabel }
 				</Button>
 				<p className="jetpack-product-card__description">{ description }</p>

--- a/client/components/jetpack-product-card/index.tsx
+++ b/client/components/jetpack-product-card/index.tsx
@@ -34,6 +34,8 @@ type OwnProps = {
 	discountMessage?: string;
 	buttonLabel: string;
 	onButtonClick: () => void;
+	cancelLabel?: string;
+	onCancelClick?: () => void;
 	isHighlighted?: boolean;
 	isOwned?: boolean;
 };
@@ -55,6 +57,8 @@ const JetpackProductCard: FunctionComponent< Props > = ( {
 	discountMessage,
 	buttonLabel,
 	onButtonClick,
+	cancelLabel,
+	onCancelClick,
 	isHighlighted,
 	isOwned,
 	features,
@@ -104,11 +108,16 @@ const JetpackProductCard: FunctionComponent< Props > = ( {
 				) }
 				<Button
 					className="jetpack-product-card__button"
-					primary={ isHighlighted }
+					primary={ isHighlighted || !! cancelLabel }
 					onClick={ onButtonClick }
 				>
 					{ buttonLabel }
 				</Button>
+				{ cancelLabel && (
+					<Button className="jetpack-product-card__cancel" onClick={ onCancelClick }>
+						{ cancelLabel }
+					</Button>
+				) }
 				<p className="jetpack-product-card__description">{ description }</p>
 			</div>
 			<JetpackProductCardFeatures features={ features } isExpanded={ isExpanded } />

--- a/client/components/jetpack-product-card/lib/use-flexbox-wrap-detection.ts
+++ b/client/components/jetpack-product-card/lib/use-flexbox-wrap-detection.ts
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ */
+import { useState, useCallback, useEffect, RefObject } from 'react';
+
+export default function useFlexboxWrapDetection( el: RefObject< HTMLElement > ): boolean {
+	const [ isWrapped, setWrapped ] = useState( false );
+	const detectWrap = useCallback( () => {
+		if ( el?.current ) {
+			setWrapped( el.current.offsetTop > 0 );
+		}
+	}, [ el, setWrapped ] );
+
+	useEffect( () => {
+		detectWrap();
+
+		window.addEventListener( 'resize', detectWrap );
+
+		return () => window.removeEventListener( 'resize', detectWrap );
+	}, [ detectWrap ] );
+
+	return isWrapped;
+}

--- a/client/components/jetpack-product-card/style.scss
+++ b/client/components/jetpack-product-card/style.scss
@@ -186,3 +186,51 @@ $jetpack-product-card-icon-size: 55px;
 	margin-bottom: 42px;
 	padding: 0 4px;
 }
+
+.jetpack-product-card__features-category {
+	margin: 8px 0 12px;
+	padding-bottom: 6px;
+
+	border-bottom: solid 1px var( --color-border-subtle );
+	color: var( --color-text-subtle );
+
+	font-weight: 600;
+}
+
+.jetpack-product-card__features-list {
+	margin: 0;
+
+	list-style-type: none;
+}
+
+.jetpack-product-card__features-item {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	padding: 12px 0;
+}
+
+.jetpack-product-card__features-summary {
+	display: flex;
+	align-items: flex-start;
+}
+
+.jetpack-product-card__features-text {
+	flex: 1;
+	margin: 0 16px 0 0;
+}
+
+.jetpack-product-card__features-icon {
+	margin-right: 14px;
+
+	&.gridicons-checkmark {
+		fill: var( --color-primary-50 );
+	}
+}
+
+.jetpack-product-card__feature-more {
+	margin-top: 24px;
+	padding-top: 16px;
+
+	border-top: solid 1px var( --color-border-subtle );
+}

--- a/client/components/jetpack-product-card/style.scss
+++ b/client/components/jetpack-product-card/style.scss
@@ -81,6 +81,7 @@ $jetpack-product-card-icon-size: 55px;
 
 .jetpack-product-card__product-type {
 	font-style: italic;
+	font-weight: 400;
 }
 
 .jetpack-product-card__subheadline {
@@ -190,8 +191,7 @@ $jetpack-product-card-icon-size: 55px;
 	font-style: italic;
 }
 
-.jetpack-product-card__button,
-.jetpack-product-card__cancel {
+.jetpack-product-card .button {
 	width: 100%;
 	margin-bottom: 20px;
 }

--- a/client/components/jetpack-product-card/style.scss
+++ b/client/components/jetpack-product-card/style.scss
@@ -190,7 +190,8 @@ $jetpack-product-card-icon-size: 55px;
 	font-style: italic;
 }
 
-.jetpack-product-card__button {
+.jetpack-product-card__button,
+.jetpack-product-card__cancel {
 	width: 100%;
 	margin-bottom: 20px;
 }

--- a/client/components/jetpack-product-card/style.scss
+++ b/client/components/jetpack-product-card/style.scss
@@ -71,6 +71,10 @@ $jetpack-product-card-icon-size: 55px;
 	justify-content: space-between;
 }
 
+.jetpack-product-card__headings {
+	margin-right: 16px;
+}
+
 .jetpack-product-card__product-name {
 	margin-bottom: 6px;
 
@@ -94,14 +98,10 @@ $jetpack-product-card-icon-size: 55px;
 }
 
 .jetpack-product-card__price {
-	margin: -4px 0 20px 16px;
+	margin: -4px 0 20px;
 
-	&.is-left-aligned {
-		margin-left: 0;
-
-		& .jetpack-product-card__raw-price {
-			justify-content: flex-start;
-		}
+	&.is-left-aligned .jetpack-product-card__raw-price {
+		justify-content: flex-start;
 	}
 }
 

--- a/client/components/jetpack-product-card/style.scss
+++ b/client/components/jetpack-product-card/style.scss
@@ -1,0 +1,188 @@
+$jetpack-product-card-circle-size: 65px;
+$jetpack-product-card-icon-size: 55px;
+
+.jetpack-product-card {
+	position: relative;
+
+	box-sizing: border-box;
+	margin: calc( 24px + #{$jetpack-product-card-circle-size/2} ) 0 24px;
+
+	background: var( --color-surface );
+	border: 1px solid var( --color-border-subtle );
+	border-left: none;
+	border-right: none;
+
+	// Top circle
+	&::before {
+		content: '';
+
+		position: absolute;
+		top: -$jetpack-product-card-circle-size/2;
+		left: calc( 50% - #{$jetpack-product-card-circle-size/2} );
+
+		display: block;
+		box-sizing: border-box;
+		width: $jetpack-product-card-circle-size;
+		height: $jetpack-product-card-circle-size;
+
+		background: inherit;
+		border: 1px solid var( --color-border-subtle );
+		border-radius: 50%;
+	}
+
+	// Mask for the bottom half of the circle
+	&::after {
+		content: '';
+
+		position: absolute;
+		top: 0;
+		left: calc( 50% - #{$jetpack-product-card-circle-size/2} );
+
+		display: block;
+		width: $jetpack-product-card-circle-size;
+		height: $jetpack-product-card-circle-size/2;
+
+		background: inherit;
+	}
+}
+
+.jetpack-product-card__header {
+	position: relative;
+
+	padding: 42px 16px 12px;
+
+	border-bottom: solid 2px var( --color-border-subtle );
+}
+
+.jetpack-product-card .product-icon {
+	position: absolute;
+	top: -$jetpack-product-card-icon-size/2;
+	left: calc( 50% - #{$jetpack-product-card-icon-size/2} );
+	z-index: 1;
+
+	width: $jetpack-product-card-icon-size;
+}
+
+.jetpack-product-card__summary {
+	position: relative;
+
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: space-between;
+}
+
+.jetpack-product-card__product-name {
+	margin-bottom: 2px;
+
+	font-size: $font-title-medium;
+	font-weight: 600;
+	line-height: rem( 30px ) / $font-title-medium;
+}
+
+.jetpack-product-card__product-type {
+	font-style: italic;
+}
+
+.jetpack-product-card__subheadline {
+	margin-bottom: 24px;
+
+	color: var( --color-text-subtle );
+
+	font-size: $font-body-extra-small;
+	line-height: rem( 16px ) / $font-body-extra-small;
+}
+
+.jetpack-product-card__price {
+	margin: -4px 0 20px 16px;
+
+	&.is-left-aligned {
+		margin-left: 0;
+
+		& .jetpack-product-card__raw-price {
+			justify-content: flex-start;
+		}
+	}
+}
+
+.jetpack-product-card__from,
+.jetpack-product-card__billing-time-frame {
+	display: block;
+
+	color: var( --color-text-subtle );
+
+	font-size: $font-body-extra-small;
+	font-style: italic;
+	line-height: 1;
+}
+
+.jetpack-product-card__from {
+	margin: 0 8px 8px 0;
+}
+
+.jetpack-product-card__raw-price {
+	display: flex;
+	justify-content: flex-end;
+	align-items: flex-end;
+	margin-bottom: 4px;
+
+	:last-child {
+		margin-right: 0;
+	}
+}
+
+.jetpack-product-card .plan-price {
+	&.is-original::before {
+		// Enable the overwrite of the border color by setting it to .plan-price
+		border-color: inherit;
+	}
+
+	&.is-discounted {
+		color: var( --color-text );
+
+		.plan-price__currency-symbol {
+			color: inherit;
+		}
+	}
+}
+
+.jetpack-product-card .plan-price__integer {
+	font-weight: 600;
+}
+
+.jetpack-product-card .jetpack-product-card__badge {
+	$jetpack-product-card-badge-height: 24px;
+
+	position: absolute;
+	left: 16px;
+	bottom: -$jetpack-product-card-badge-height/2;
+
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	box-sizing: border-box;
+	height: $jetpack-product-card-badge-height;
+	padding: 0 16px;
+
+	background: var( --color-surface );
+	border: 1px solid currentColor;
+	border-radius: 4px;
+	color: var( --color-border );
+
+	font-size: rem( 13px );
+	line-height: $jetpack-product-card-badge-height;
+	text-transform: uppercase;
+}
+
+.jetpack-product-card__body {
+	padding: 36px 16px 0;
+}
+
+.jetpack-product-card__button {
+	width: 100%;
+	margin-bottom: 20px;
+}
+
+.jetpack-product-card__description {
+	margin-bottom: 42px;
+	padding: 0 4px;
+}

--- a/client/components/jetpack-product-card/style.scss
+++ b/client/components/jetpack-product-card/style.scss
@@ -72,7 +72,7 @@ $jetpack-product-card-icon-size: 55px;
 }
 
 .jetpack-product-card__product-name {
-	margin-bottom: 2px;
+	margin-bottom: 6px;
 
 	font-size: $font-title-medium;
 	font-weight: 600;

--- a/client/components/jetpack-product-card/style.scss
+++ b/client/components/jetpack-product-card/style.scss
@@ -182,6 +182,14 @@ $jetpack-product-card-icon-size: 55px;
 	padding: 36px 16px 0;
 }
 
+.jetpack-product-card__discount-message {
+	margin: -20px 0 16px;
+
+	color: var( --color-success-40 );
+
+	font-style: italic;
+}
+
 .jetpack-product-card__button {
 	width: 100%;
 	margin-bottom: 20px;

--- a/client/components/jetpack-product-card/style.scss
+++ b/client/components/jetpack-product-card/style.scss
@@ -149,7 +149,7 @@ $jetpack-product-card-icon-size: 55px;
 	font-weight: 600;
 }
 
-.jetpack-product-card .jetpack-product-card__badge {
+.jetpack-product-card__badge {
 	$jetpack-product-card-badge-height: 24px;
 
 	position: absolute;
@@ -171,6 +171,11 @@ $jetpack-product-card-icon-size: 55px;
 	font-size: rem( 13px );
 	line-height: $jetpack-product-card-badge-height;
 	text-transform: uppercase;
+}
+
+.jetpack-product-card.is-owned .jetpack-product-card__badge {
+	background-color: var( --color-neutral-40 );
+	color: var( --color-text-inverted );
 }
 
 .jetpack-product-card__body {

--- a/client/components/jetpack-product-card/types.ts
+++ b/client/components/jetpack-product-card/types.ts
@@ -1,0 +1,15 @@
+export type FeaturesItem = {
+	icon?: string;
+	text: string;
+	description?: string;
+};
+
+export type FeaturesMoreLink = {
+	url: string;
+	label: string;
+};
+
+export type Features = {
+	items: FeaturesItem[] | { [ category: string ]: FeaturesItem[] };
+	more?: FeaturesMoreLink;
+};

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -73,8 +73,10 @@ import InfoPopover from 'components/info-popover/docs/example';
 import InlineSupportLink from 'components/inline-support-link/docs/example';
 import InputChrono from 'components/input-chrono/docs/example';
 import JetpackColophonExample from 'components/jetpack-colophon/docs/example';
+import JetpackBundleCard from 'components/jetpack-bundle-card/docs/example';
 import JetpackHeaderExample from 'components/jetpack-header/docs/example';
 import JetpackLogoExample from 'components/jetpack-logo/docs/example';
+import JetpackProductCard from 'components/jetpack-product-card/docs/example';
 import LanguagePicker from 'components/language-picker/docs/example';
 import LineChart from 'components/line-chart/docs/example';
 import ListEnd from 'components/list-end/docs/example';
@@ -229,9 +231,11 @@ export default class DesignAssets extends React.Component {
 					<InfoPopover readmeFilePath="info-popover" />
 					<InlineSupportLink readmeFilePath="inline-support-link" />
 					<InputChrono readmeFilePath="input-chrono" />
+					<JetpackBundleCard readmeFilePath="jetpack-bundle-card" />
 					<JetpackColophonExample readmeFilePath="jetpack-colophon" />
 					<JetpackHeaderExample readmeFilePath="jetpack-header" />
 					<JetpackLogoExample readmeFilePath="jetpack-logo" />
+					<JetpackProductCard readmeFilePath="jetpack-product-card" />
 					<LanguagePicker readmeFilePath="language-picker" />
 					<LineChart readmeFilePath="line-chart" />
 					<ListEnd readmeFilePath="list-end" />


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR adds a new product card for Jetpack items. It's currently available from the _UI Components_ section of the live docs. 

A product can be a bundle (e.g. Security), a plan (e.g. All-in), or an individual product (e.g. Backup). The card can be used for all three of them.

### Implementation notes

#### Spacing

The spacing values annotated in the mockups cannot always be directly transposed to padding/margin in CSS. I've followed the mockups closely but let me know if something looks off.

#### Colors

Product cards have a different color depending on the product (bundle, plan, and individual product). The `JetpackBundleCard` is a proof of concept of how that's handled.

#### Wrapped price

The headings and the price are on the same row, the former being left aligned and the latter right aligned. However if the card is too small to display both side by side, the price is pushed down, in which case it must be left aligned too. This is not doable purely in CSS as far as I can tell since there's no way to know if a flex container wrapped its children or not. It's however possible with a little JS, hence the `useFlexboxWrapDetection` hook.

#### Todos

[ ] Desktop version
[ ] Implement the top "half circle" shape properly
[ ] Add a README
[ ] Move and document the wrap hook

### Testing instructions

- Download the PR

#### Generic product card

- Go to `/devdocs/design/jetpack-product-card`

This is a bit tricky to test. First, adding screenshots of all possible variations would make this PR quite heavy to review. Then, the implementation uses some components that already exist, which might differ slightly from what's in the mockups (see captures below). So, in particular:

- Check that the layout and spacing look similar to the mockups
- Check that the price is pushed down when the product name takes more space
- Check that you can expand/collapse the features

#### Bundle card

- Go to `/devdocs/design/jetpack-bundle-card`
- Check that the badge "Best value" and the border behind are green
- Check that the bar of the struck through price is green

### Screenshots

#### Mockups

<img width="400" alt="Screen Shot 2020-07-13 at 2 38 49 PM" src="https://user-images.githubusercontent.com/1620183/87341586-e380a500-c517-11ea-84fd-60cd17c16748.png">
<img width="389" alt="Screen Shot 2020-07-13 at 2 38 19 PM" src="https://user-images.githubusercontent.com/1620183/87341606-eda2a380-c517-11ea-87f9-a174e4eb1551.png">
<img width="519" alt="Screen Shot 2020-07-13 at 2 38 32 PM" src="https://user-images.githubusercontent.com/1620183/87341619-f09d9400-c517-11ea-8dfd-fb7fee0275ad.png">

 
