### PR TITLE
My Home: Add Tracks events and bump stats for each card impression.

### DIFF
--- a/client/my-sites/customer-home/locations/primary/index.jsx
+++ b/client/my-sites/customer-home/locations/primary/index.jsx
@@ -64,7 +64,7 @@ const Primary = ( { cards, renderCard } ) => {
 };
 
 export default connect( null, ( dispatch ) => ( {
-	renderCard: ( card, index ) =>
+	renderCard: ( card ) =>
 		cardComponents[ card ] &&
 		dispatch(
 			withAnalytics(
@@ -75,7 +75,7 @@ export default connect( null, ( dispatch ) => ( {
 					bumpStat( 'calypso_customer_home_card_impression', card )
 				),
 				React.createElement( cardComponents[ card ], {
-					key: index,
+					key: card,
 					isIos: card === 'home-task-go-mobile-ios' ? true : null,
 				} )
 			)

--- a/client/my-sites/customer-home/locations/secondary/index.jsx
+++ b/client/my-sites/customer-home/locations/secondary/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -9,28 +10,40 @@ import React from 'react';
 import Stats from 'my-sites/customer-home/cards/features/stats';
 import LearnGrow from './learn-grow';
 import { FEATURE_STATS, SECTION_LEARN_GROW } from 'my-sites/customer-home/cards/constants';
+import {
+	bumpStat,
+	composeAnalytics,
+	recordTracksEvent,
+	withAnalytics,
+} from 'state/analytics/actions';
 
 const cardComponents = {
 	[ FEATURE_STATS ]: Stats,
 	[ SECTION_LEARN_GROW ]: LearnGrow,
 };
 
-const Secondary = ( { cards } ) => {
+const Secondary = ( { cards, renderCard } ) => {
 	if ( ! cards || ! cards.length ) {
 		return null;
 	}
 
-	return (
-		<>
-			{ cards.map(
-				( card ) =>
-					cardComponents[ card ] &&
-					React.createElement( cardComponents[ card ], {
-						key: card,
-					} )
-			) }
-		</>
-	);
+	return <>{ cards.map( renderCard ) }</>;
 };
 
-export default Secondary;
+export default connect( null, ( dispatch ) => ( {
+	renderCard: ( card ) =>
+		cardComponents[ card ] &&
+		dispatch(
+			withAnalytics(
+				composeAnalytics(
+					recordTracksEvent( 'calypso_customer_home_card_impression', {
+						card,
+					} ),
+					bumpStat( 'calypso_customer_home_card_impression', card )
+				),
+				React.createElement( cardComponents[ card ], {
+					key: card,
+				} )
+			)
+		),
+} ) )( Secondary );

--- a/client/my-sites/customer-home/locations/secondary/index.jsx
+++ b/client/my-sites/customer-home/locations/secondary/index.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -10,40 +9,28 @@ import { connect } from 'react-redux';
 import Stats from 'my-sites/customer-home/cards/features/stats';
 import LearnGrow from './learn-grow';
 import { FEATURE_STATS, SECTION_LEARN_GROW } from 'my-sites/customer-home/cards/constants';
-import {
-	bumpStat,
-	composeAnalytics,
-	recordTracksEvent,
-	withAnalytics,
-} from 'state/analytics/actions';
 
 const cardComponents = {
 	[ FEATURE_STATS ]: Stats,
 	[ SECTION_LEARN_GROW ]: LearnGrow,
 };
 
-const Secondary = ( { cards, renderCard } ) => {
+const Secondary = ( { cards } ) => {
 	if ( ! cards || ! cards.length ) {
 		return null;
 	}
 
-	return <>{ cards.map( renderCard ) }</>;
+	return (
+		<>
+			{ cards.map(
+				( card ) =>
+					cardComponents[ card ] &&
+					React.createElement( cardComponents[ card ], {
+						key: card,
+					} )
+			) }
+		</>
+	);
 };
 
-export default connect( null, ( dispatch ) => ( {
-	renderCard: ( card ) =>
-		cardComponents[ card ] &&
-		dispatch(
-			withAnalytics(
-				composeAnalytics(
-					recordTracksEvent( 'calypso_customer_home_card_impression', {
-						card,
-					} ),
-					bumpStat( 'calypso_customer_home_card_impression', card )
-				),
-				React.createElement( cardComponents[ card ], {
-					key: card,
-				} )
-			)
-		),
-} ) )( Secondary );
+export default Secondary;

--- a/client/my-sites/customer-home/locations/secondary/learn-grow/index.jsx
+++ b/client/my-sites/customer-home/locations/secondary/learn-grow/index.jsx
@@ -19,6 +19,12 @@ import {
 	EDUCATION_GUTENBERG,
 	EDUCATION_EARN,
 } from 'my-sites/customer-home/cards/constants';
+import {
+	bumpStat,
+	composeAnalytics,
+	recordTracksEvent,
+	withAnalytics,
+} from 'state/analytics/actions';
 
 /**
  * Style dependencies
@@ -31,7 +37,7 @@ const cardComponents = {
 	[ EDUCATION_EARN ]: EducationEarn,
 };
 
-const LearnGrow = ( { cards } ) => {
+const LearnGrow = ( { cards, renderCard } ) => {
 	const translate = useTranslate();
 
 	if ( ! cards || ! cards.length ) {
@@ -43,15 +49,7 @@ const LearnGrow = ( { cards } ) => {
 			<h2 className="learn-grow__heading customer-home__section-heading">
 				{ translate( 'Learn and grow' ) }
 			</h2>
-			<Card className="learn-grow__content">
-				{ cards.map(
-					( card, index ) =>
-						cardComponents[ card ] &&
-						React.createElement( cardComponents[ card ], {
-							key: index,
-						} )
-				) }
-			</Card>
+			<Card className="learn-grow__content">{ cards.map( renderCard ) }</Card>
 		</>
 	);
 };
@@ -65,4 +63,22 @@ const mapStateToProps = ( state ) => {
 	};
 };
 
-export default connect( mapStateToProps )( LearnGrow );
+const mapDispatchToProps = ( dispatch ) => ( {
+	renderCard: ( card, index ) =>
+		cardComponents[ card ] &&
+		dispatch(
+			withAnalytics(
+				composeAnalytics(
+					recordTracksEvent( 'calypso_customer_home_card_impression', {
+						card,
+					} ),
+					bumpStat( 'calypso_customer_home_card_impression', card )
+				),
+				React.createElement( cardComponents[ card ], {
+					key: index,
+				} )
+			)
+		),
+} );
+
+export default connect( mapStateToProps, mapDispatchToProps )( LearnGrow );

--- a/client/my-sites/customer-home/locations/secondary/learn-grow/index.jsx
+++ b/client/my-sites/customer-home/locations/secondary/learn-grow/index.jsx
@@ -64,7 +64,7 @@ const mapStateToProps = ( state ) => {
 };
 
 const mapDispatchToProps = ( dispatch ) => ( {
-	renderCard: ( card, index ) =>
+	renderCard: ( card ) =>
 		cardComponents[ card ] &&
 		dispatch(
 			withAnalytics(
@@ -75,7 +75,7 @@ const mapDispatchToProps = ( dispatch ) => ( {
 					bumpStat( 'calypso_customer_home_card_impression', card )
 				),
 				React.createElement( cardComponents[ card ], {
-					key: index,
+					key: card,
 				} )
 			)
 		),

--- a/client/my-sites/customer-home/locations/tertiary/manage-site/index.jsx
+++ b/client/my-sites/customer-home/locations/tertiary/manage-site/index.jsx
@@ -22,6 +22,12 @@ import {
 	FEATURE_QUICK_START,
 	FEATURE_SUPPORT,
 } from 'my-sites/customer-home/cards/constants';
+import {
+	bumpStat,
+	composeAnalytics,
+	recordTracksEvent,
+	withAnalytics,
+} from 'state/analytics/actions';
 
 const cardComponents = {
 	[ FEATURE_GO_MOBILE ]: GoMobile,
@@ -31,7 +37,7 @@ const cardComponents = {
 	[ ACTION_WP_FOR_TEAMS_QUICK_LINKS ]: WpForTeamsQuickLinks,
 };
 
-const ManageSite = ( { cards } ) => {
+const ManageSite = ( { cards, renderCard } ) => {
 	const translate = useTranslate();
 
 	if ( ! cards || ! cards.length ) {
@@ -43,13 +49,7 @@ const ManageSite = ( { cards } ) => {
 			<h2 className="manage-site__heading customer-home__section-heading">
 				{ translate( 'Manage your site' ) }
 			</h2>
-			{ cards.map(
-				( card, index ) =>
-					cardComponents[ card ] &&
-					React.createElement( cardComponents[ card ], {
-						key: index,
-					} )
-			) }
+			{ cards.map( renderCard ) }
 		</>
 	);
 };
@@ -63,4 +63,22 @@ const mapStateToProps = ( state ) => {
 	};
 };
 
-export default connect( mapStateToProps )( ManageSite );
+const mapDispatchToProps = ( dispatch ) => ( {
+	renderCard: ( card ) =>
+		cardComponents[ card ] &&
+		dispatch(
+			withAnalytics(
+				composeAnalytics(
+					recordTracksEvent( 'calypso_customer_home_card_impression', {
+						card,
+					} ),
+					bumpStat( 'calypso_customer_home_card_impression', card )
+				),
+				React.createElement( cardComponents[ card ], {
+					key: card,
+				} )
+			)
+		),
+} );
+
+export default connect( mapStateToProps, mapDispatchToProps )( ManageSite );


### PR DESCRIPTION
This PR adds a Tracks event and MC stats bump for each card impression. Only actual cards are tracked, no our pseudo-sub-location cards (eg. `home-section-learn-grow`) that serve only to contain proper cards.

<img width="1525" alt="Screen Shot 2020-07-09 at 1 03 57 PM" src="https://user-images.githubusercontent.com/349751/87085630-0abc3700-c1e5-11ea-9fb0-3764f201499d.png">

Since card IDs are unique, I've also standardized on using the card ID as the `map` key (previously, it was a mix of `index` and `card`).

There should be no visible changes to the UI, only events and stats firing.

Fixes https://github.com/Automattic/wp-calypso/issues/43767

**Testing instructions**
* Apply this branch to a local install, and monitor events in the DevTools console with `localStorage.debug='calypso:analytics*'`
* Load My Home (`/home/:site`) for a variety of sites, and verify that each card displayed is represented with Tracks and bump stats events.