### PR TITLE
Earn: make proof of concept for donation dynamic block render

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/donations/donations.php
+++ b/apps/full-site-editing/full-site-editing-plugin/donations/donations.php
@@ -32,6 +32,17 @@ function fse_donations_block() {
 		array(),
 		filemtime( plugin_dir_path( __FILE__ ) . 'dist/donations.css' )
 	);
+
+	register_block_type(
+		'a8c/donations',
+		array(
+			'editor_script'   => 'jetpack-event-countdown',
+			'editor_style'    => 'jetpack-event-countdown-style',
+			'render_callback' => function( $attribs, $content ) {
+				return '<div class="wp-block-a8c-donations">Donations Placeholder</div>';
+			},
+		)
+	);
 }
 
 add_action( 'init', 'A8C\FSE\Earn\Donations\fse_donations_block' );

--- a/apps/full-site-editing/full-site-editing-plugin/donations/donations.php
+++ b/apps/full-site-editing/full-site-editing-plugin/donations/donations.php
@@ -58,7 +58,7 @@ function fse_donations_block() {
 			'script'    => 'a8c-donations',
 			'render_callback' => function( $attributes, $content ) {
 				global $wp;
-				$button_url = add_query_arg(
+				$button_url_once = add_query_arg(
 					array(
 						'blog'     => esc_attr( get_blog_id() ),
 						'plan'     => esc_attr( $attributes[ 'oneTimePlanId' ] ), //TODO: also render other plans
@@ -70,9 +70,35 @@ function fse_donations_block() {
 					),
 					'https://subscribe.wordpress.com/memberships/'
 				);
+				$button_url_monthly = add_query_arg(
+					array(
+						'blog'     => esc_attr( get_blog_id() ),
+						'plan'     => esc_attr( $attributes[ 'monthlyPlanId' ] ), //TODO: also render other plans
+						'lang'     => esc_attr( get_locale() ),
+						'pid'      => esc_attr( get_the_ID() ), // Needed for analytics purposes.
+						'redirect' => esc_attr( rawurlencode( home_url( $wp->request ) ) ), // Needed for redirect back in case of redirect-based flow.
+						'amount'   => esc_attr( 11.11 ),
+						//'customAmount' => esc_attr( true ),
+					),
+					'https://subscribe.wordpress.com/memberships/'
+				);
+				$button_url_yearly = add_query_arg(
+					array(
+						'blog'     => esc_attr( get_blog_id() ),
+						'plan'     => esc_attr( $attributes[ 'annuallyPlanId' ] ), //TODO: also render other plans
+						'lang'     => esc_attr( get_locale() ),
+						'pid'      => esc_attr( get_the_ID() ), // Needed for analytics purposes.
+						'redirect' => esc_attr( rawurlencode( home_url( $wp->request ) ) ), // Needed for redirect back in case of redirect-based flow.
+						'amount'   => esc_attr( 22.22 ),
+						'customAmount' => esc_attr( true ),
+					),
+					'https://subscribe.wordpress.com/memberships/'
+				);
 				return sprintf(
-					'<div class="wp-block-a8c-donations"><a role="button" href="%1$s">Donation Placeholder</a></div>',
-					$button_url
+					'<div class="wp-block-a8c-donations"><a role="button" href="%1$s">Donation Once Placeholder</a><a role="button" href="%2$s">Donation Monthly Placeholder</a><a role="button" href="%3$s">Donation Yearly Placeholder</a></div>',
+					$button_url_once,
+					$button_url_monthly,
+					$button_url_yearly
 				);
 			},
 		)

--- a/apps/full-site-editing/full-site-editing-plugin/donations/donations.php
+++ b/apps/full-site-editing/full-site-editing-plugin/donations/donations.php
@@ -7,10 +7,20 @@
 
 namespace A8C\FSE\Earn\Donations;
 
+function get_blog_id() {
+	if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+		return get_current_blog_id();
+	}
+
+	return \Jetpack_Options::get_option( 'id' );
+}
+
 /**
  * Initialize the Donations block.
  */
 function fse_donations_block() {
+	$dir      = __DIR__;
+
 	$gate = apply_filters( 'wpcom_donations_block_init', false );
 	if ( ! $gate ) {
 		return;
@@ -18,8 +28,9 @@ function fse_donations_block() {
 
 	$asset_file = include plugin_dir_path( __FILE__ ) . 'dist/donations.asset.php';
 
+	//TODO: looks like this is also loading on published view
 	wp_enqueue_script(
-		'a8c-donations',
+		'a8c-donations-editor',
 		plugins_url( 'dist/donations.js', __FILE__ ),
 		$asset_file['dependencies'],
 		$asset_file['version'],
@@ -27,19 +38,42 @@ function fse_donations_block() {
 	);
 
 	wp_enqueue_style(
-		'a8c-donations',
+		'a8c-donations-editor',
 		plugins_url( 'dist/donations.css', __FILE__ ),
 		array(),
 		filemtime( plugin_dir_path( __FILE__ ) . 'dist/donations.css' )
 	);
 
+	//TODO: add handling for multiple dist targets (editor vs view bundle)
+	wp_enqueue_script(
+		'a8c-donations',
+		plugins_url( 'view.js', __FILE__ ),
+		array(),
+		filemtime( plugin_dir_path( __FILE__ ) . 'view.js' )
+	);
+
 	register_block_type(
 		'a8c/donations',
 		array(
-			'editor_script'   => 'jetpack-event-countdown',
-			'editor_style'    => 'jetpack-event-countdown-style',
-			'render_callback' => function( $attribs, $content ) {
-				return '<div class="wp-block-a8c-donations">Donations Placeholder</div>';
+			'script'    => 'a8c-donations',
+			'render_callback' => function( $attributes, $content ) {
+				global $wp;
+				$button_url = add_query_arg(
+					array(
+						'blog'     => esc_attr( get_blog_id() ),
+						'plan'     => esc_attr( $attributes[ 'oneTimePlanId' ] ), //TODO: also render other plans
+						'lang'     => esc_attr( get_locale() ),
+						'pid'      => esc_attr( get_the_ID() ), // Needed for analytics purposes.
+						'redirect' => esc_attr( rawurlencode( home_url( $wp->request ) ) ), // Needed for redirect back in case of redirect-based flow.
+						'amount'   => esc_attr( 12.34 ),
+						'customAmount' => esc_attr( true ),
+					),
+					'https://subscribe.wordpress.com/memberships/'
+				);
+				return sprintf(
+					'<div class="wp-block-a8c-donations"><a role="button" href="%1$s">Donation Placeholder</a></div>',
+					$button_url
+				);
 			},
 		)
 	);

--- a/apps/full-site-editing/full-site-editing-plugin/donations/view.js
+++ b/apps/full-site-editing/full-site-editing-plugin/donations/view.js
@@ -1,0 +1,67 @@
+/* global tb_show, tb_remove */
+
+/**
+ * External dependencies
+ */
+//import domReady from '@wordpress/dom-ready';
+
+/**
+ * Internal dependencies
+ */
+//import './view.scss';
+const blockClassName = 'wp-block-a8c-donations';
+
+/**
+ * Since "close" button is inside our checkout iframe, in order to close it, it has to pass a message to higher scope to close the modal.
+ *
+ * @param {object} eventFromIframe - message event that gets emmited in the checkout iframe.
+ * @listens message
+ */
+function handleIframeResult( eventFromIframe ) {
+	if ( eventFromIframe.origin === 'https://subscribe.wordpress.com' && eventFromIframe.data ) {
+		const data = JSON.parse( eventFromIframe.data );
+		if ( data && data.action === 'close' ) {
+			window.removeEventListener( 'message', handleIframeResult );
+			tb_remove();
+		}
+	}
+}
+
+function donate( block, checkoutURL ) {
+	block.addEventListener( 'click', ( event ) => {
+		event.preventDefault();
+		window.scrollTo( 0, 0 );
+		tb_show( null, checkoutURL + '&display=alternate&TB_iframe=true', null );
+		window.addEventListener( 'message', handleIframeResult, false );
+		const tbWindow = document.querySelector( '#TB_window' );
+		tbWindow.classList.add( 'jetpack-memberships-modal' );
+
+		// This line has to come after the Thickbox has opened otherwise Firefox doesn't scroll to the top.
+		window.scrollTo( 0, 0 );
+	} );
+}
+
+const initializeDonationBlocks = () => {
+	const donationButtons = Array.prototype.slice.call(
+		document.querySelectorAll( '.' + blockClassName + ' a' )
+	);
+	donationButtons.forEach( ( block ) => {
+		if ( block.getAttribute( 'data-jetpack-block-initialized' ) === 'true' ) {
+			return;
+		}
+
+		const checkoutURL = block.getAttribute( 'href' );
+		try {
+			donate( block, checkoutURL );
+		} catch ( err ) {
+			// eslint-disable-next-line no-console
+			console.error( 'Problem donating ' + checkoutURL, err );
+		}
+
+		block.setAttribute( 'data-jetpack-block-initialized', 'true' );
+	} );
+};
+
+if ( typeof window !== 'undefined' ) {
+	document.addEventListener( 'DOMContentLoaded', initializeDonationBlocks );
+}


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/44108 Complete WIP (nothing interesting yet)

| edit | published view |
| ------------- | ------------- |
| <img width="1132" alt="Screen Shot 2020-07-09 at 4 27 13 PM" src="https://user-images.githubusercontent.com/1270189/87100400-246b7780-c201-11ea-8c2c-59bdb2ad2c3c.png"> | <img width="761" alt="Screen Shot 2020-07-09 at 4 27 30 PM" src="https://user-images.githubusercontent.com/1270189/87100405-28979500-c201-11ea-9e32-c579c7e84b58.png"> |


Some things to do next:
- [ ] Add in a dummy render and wire in the iframe boilerplate needed to checkout in the published view (subscribe.wordpress.com/memberships)
- [ ] Go back to the donations edit view and serialize suggested plan values
- [ ] Render published view to match edit view + the needed (minimal) JS to power the donation tabs.