### PR TITLE
InlineHelp: improvements

### DIFF
--- a/client/blocks/inline-help/inline-help-search-results.jsx
+++ b/client/blocks/inline-help/inline-help-search-results.jsx
@@ -3,7 +3,7 @@
  */
 import React, { useRef, Fragment } from 'react';
 import PropTypes from 'prop-types';
-import { identity, isEmpty } from 'lodash';
+import { identity, isEmpty, noop } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
@@ -34,7 +34,7 @@ function HelpSearchResults( {
 	hasAPIResults = false,
 	isSearching = false,
 	onSelect,
-	onAdminSectionSelect,
+	onAdminSectionSelect = noop,
 	searchQuery = '',
 	searchResults = [],
 	selectedResult = {},
@@ -174,7 +174,7 @@ HelpSearchResults.propTypes = {
 	translate: PropTypes.func,
 	searchQuery: PropTypes.string,
 	onSelect: PropTypes.func.isRequired,
-	onAdminSectionSelect: PropTypes.func.isRequired,
+	onAdminSectionSelect: PropTypes.func,
 	hasAPIResults: PropTypes.bool,
 	searchResults: PropTypes.array,
 	selectedResultIndex: PropTypes.number,

--- a/client/blocks/inline-help/inline-help-search-results.jsx
+++ b/client/blocks/inline-help/inline-help-search-results.jsx
@@ -34,6 +34,7 @@ function HelpSearchResults( {
 	hasAPIResults = false,
 	isSearching = false,
 	onSelect,
+	onAdminSectionSelect,
 	searchQuery = '',
 	searchResults = [],
 	selectedResult = {},
@@ -91,6 +92,7 @@ function HelpSearchResults( {
 			if ( ! /^http/.test( link ) ) {
 				event.preventDefault();
 				page( link );
+				onAdminSectionSelect( event )
 			}
 
 			return;
@@ -172,6 +174,7 @@ HelpSearchResults.propTypes = {
 	translate: PropTypes.func,
 	searchQuery: PropTypes.string,
 	onSelect: PropTypes.func.isRequired,
+	onAdminSectionSelect: PropTypes.func.isRequired,
 	hasAPIResults: PropTypes.bool,
 	searchResults: PropTypes.array,
 	selectedResultIndex: PropTypes.number,

--- a/client/blocks/inline-help/inline-help-search-results.jsx
+++ b/client/blocks/inline-help/inline-help-search-results.jsx
@@ -103,7 +103,7 @@ function HelpSearchResults( {
 	const selectCurrentResultIndex = ( index ) => () => selectSearchResult( index );
 
 	const renderHelpLink = (
-		{ link, key, description, title, support_type = SUPPORT_TYPE_API_HELP },
+		{ link, key, description, title, support_type = SUPPORT_TYPE_API_HELP, icon = 'domains' },
 		index
 	) => {
 		const addResultsSection = supportTypeRef?.current !== support_type || ! index;
@@ -127,7 +127,7 @@ function HelpSearchResults( {
 						tabIndex={ -1 }
 					>
 						{ support_type === SUPPORT_TYPE_ADMIN_SECTION && (
-							<Gridicon icon="domains" size={ 18 } />
+							<Gridicon icon={ icon } size={ 18 } />
 						) }
 						<span>{ preventWidows( decodeEntities( title ) ) }</span>
 					</a>

--- a/client/blocks/inline-help/inline-help-search-results.jsx
+++ b/client/blocks/inline-help/inline-help-search-results.jsx
@@ -92,7 +92,7 @@ function HelpSearchResults( {
 			if ( ! /^http/.test( link ) ) {
 				event.preventDefault();
 				page( link );
-				onAdminSectionSelect( event )
+				onAdminSectionSelect( event );
 			}
 
 			return;

--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -332,5 +332,5 @@ const mapDispatchToProps = {
 
 export default compose(
 	localize,
-	connect( mapStateToProps,  mapDispatchToProps )
+	connect( mapStateToProps, mapDispatchToProps )
 )( withMobileBreakpoint( InlineHelpPopover ) );

--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -8,6 +8,7 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
 import Gridicon from 'components/gridicon';
+import { withMobileBreakpoint } from '@automattic/viewport-react';
 
 /**
  * Internal Dependencies
@@ -68,6 +69,14 @@ class InlineHelpPopover extends Component {
 	openResultView = ( event ) => {
 		event.preventDefault();
 		this.openSecondaryView( VIEW_RICH_RESULT );
+	};
+
+	setAdminSection = () => {
+		const { isBreakpointActive: isMobile, onClose } = this.props;
+		if ( ! isMobile ) {
+			return;
+		}
+		onClose();
 	};
 
 	moreHelpClicked = () => {
@@ -143,6 +152,7 @@ class InlineHelpPopover extends Component {
 					<InlineHelpSearchCard onSelect={ this.openResultView } query={ this.props.searchQuery } />
 					<InlineHelpSearchResults
 						onSelect={ this.openResultView }
+						onAdminSectionSelect={ this.setAdminSection }
 						searchQuery={ this.props.searchQuery }
 					/>
 				</div>
@@ -322,5 +332,5 @@ const mapDispatchToProps = {
 
 export default compose(
 	localize,
-	connect( mapStateToProps, mapDispatchToProps )
-)( InlineHelpPopover );
+	connect( mapStateToProps,  mapDispatchToProps )
+)( withMobileBreakpoint( InlineHelpPopover ) );

--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -358,7 +358,7 @@
 		padding: 8px 16px;
 		font-size: $font-body-small;
 
-		&:after {
+		&::after {
 			content: ':';
 		}
 	}


### PR DESCRIPTION
This PR collects a handful of issues about the InlineHelp / HelpSearch components. Let's discuss in each issue and just use this PR for testing and handle the code.

#### Issues list

- [x] InlineHelp: Update admin results to use correct icons #44060
- [x] InlineHelp: Collapse FAB after click on mobile #44061
~- [ ] InlineHelp: Anchor to appropriate sections from admin results #44059~

#### Changes proposed in this Pull Request

* All changes to achieve the issues list.

## Testing instructions

🖥️ [Live test](https://calypso.live/?branch=update/support-improvements)

Test that all issues listed above are properly handled by these changes:

### 🎨 InlineHelp: Update admin results to use correct icons #44060


Before | After
-------| -----
<img src="https://user-images.githubusercontent.com/4924246/87096688-372d7e80-c1f8-11ea-9167-bc366c51e9ac.png" widh="348" /> | <img width="348" alt="Screen Shot 2020-07-10 at 8 49 10 AM" src="https://user-images.githubusercontent.com/77539/87151458-452bdf80-c28a-11ea-8a07-947ebbf65f11.png">


### InlineHelp: Collapse FAB after click on mobile #44061

Confirm the Popover auto-collapses once the user clicks in an admin section link and the viewport is in the mobile width.

<img src="https://user-images.githubusercontent.com/77539/87292620-74835c00-c4d7-11ea-8c03-1f9a0fc96f7c.gif" width="350px" />


~### InlineHelp: Anchor to appropriate sections from admin results #44059~



Fixes #44060
