### PR TITLE
Gutenboarding: Only show the new launch flow in gutenboarding created sites.

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/editor-gutenboarding-launch/index.ts
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-gutenboarding-launch/index.ts
@@ -18,7 +18,7 @@ import './index.scss';
 interface CalypsoifyWindow extends Window {
 	calypsoifyGutenberg?: {
 		frankenflowUrl?: string;
-		isFseGutenboarding?: boolean;
+		isGutenboarding?: boolean;
 		[ key: string ]: unknown;
 	};
 }
@@ -34,7 +34,7 @@ let handled = false;
 function updateEditor() {
 	if (
 		handled ||
-		! window?.calypsoifyGutenberg?.isFseGutenboarding ||
+		! window?.calypsoifyGutenberg?.isGutenboarding ||
 		! window?.calypsoifyGutenberg?.frankenflowUrl
 	) {
 		return;

--- a/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/index.ts
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/index.ts
@@ -3,20 +3,46 @@
  */
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-
+import domReady from '@wordpress/dom-ready';
+import { addAction } from '@wordpress/hooks';
 import 'a8c-fse-common-data-stores';
-
+/**
+ * Internal dependencies
+ */
 import LaunchButton from './src/launch-button';
 
-const awaitSettingsBar = setInterval( () => {
-	const settingsBar = document.querySelector( '.edit-post-header__settings' );
-	if ( ! settingsBar ) {
+interface CalypsoifyWindow extends Window {
+	calypsoifyGutenberg?: {
+		isGutenboarding?: boolean;
+		[ key: string ]: unknown;
+	};
+}
+declare const window: CalypsoifyWindow;
+
+domReady( () => {
+	updateEditor();
+	// Hook fallback incase setGutenboardingStatus runs after initial dom render.
+	addAction( 'setGutenboardingStatus', 'a8c-gutenboarding', updateEditor );
+} );
+
+let handled = false;
+function updateEditor() {
+	if ( handled || ! window?.calypsoifyGutenberg?.isGutenboarding ) {
 		return;
 	}
-	clearInterval( awaitSettingsBar );
 
-	const launchButtonContainer = document.createElement( 'div' );
-	settingsBar.prepend( launchButtonContainer );
+	handled = true;
 
-	ReactDOM.render( React.createElement( LaunchButton ), launchButtonContainer );
-} );
+	const awaitSettingsBar = setInterval( () => {
+		const settingsBar = document.querySelector( '.edit-post-header__settings' );
+		if ( ! settingsBar ) {
+			return;
+		}
+		clearInterval( awaitSettingsBar );
+
+		const launchButtonContainer = document.createElement( 'div' );
+		settingsBar.prepend( launchButtonContainer );
+
+		ReactDOM.render( React.createElement( LaunchButton ), launchButtonContainer );
+	} );
+}

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -736,7 +736,6 @@ function getGutenboardingStatus( calypsoPort ) {
 	port1.onmessage = ( { data } ) => {
 		const { isGutenboarding, frankenflowUrl } = data;
 		calypsoifyGutenberg.isGutenboarding = isGutenboarding;
-		calypsoifyGutenberg.isFseGutenboarding = isGutenboarding;
 		calypsoifyGutenberg.frankenflowUrl = frankenflowUrl;
 		// Hook necessary if message recieved after editor has loaded.
 		window.wp.hooks.doAction( 'setGutenboardingStatus', isGutenboarding );


### PR DESCRIPTION
#### Note to anyone reading this while preparing a release of the FSE plugin
This change doesn't require any release notes. We're developing a new feature which is currently hidden behind a flag.

## Changes proposed in this request

Only show the launch button on gutenboarding created sites.

## Test Instructions

**Site created through `/start`**
- Create a site using `/start`.
- Once you have a hostname, point it to the sandbox.
- Go back to `https://wordp*ess.com/block-editor/page/your_unlaunched_start_site.wordpress.com`.
- You should NOT see the Launch button.

**Site created through `/new`**
- Create a site using `/new`.
- Once you have a hostname, point it to the sandbox.
- Go back to `https://wordp*ess.com/block-editor/page/your_unlaunched_gutenboarding_site.wordpress.com`.
- You should see the Launch button.

Fixes part of #43750