### PR TITLE
Modularise site settings state

### DIFF
--- a/client/my-sites/marketing/connections/services/google-my-business.js
+++ b/client/my-sites/marketing/connections/services/google-my-business.js
@@ -26,7 +26,6 @@ export class GoogleMyBusiness extends SharingService {
 		// This foreign propTypes access should be safe because we expect all of them to be removed
 		// eslint-disable-next-line react/forbid-foreign-prop-types
 		...SharingService.propTypes,
-		saveRequests: PropTypes.object,
 		siteSettings: PropTypes.object,
 		connectGoogleMyBusinessAccount: PropTypes.func,
 		disconnectGoogleMyBusinessAccount: PropTypes.func,
@@ -123,6 +122,7 @@ export class GoogleMyBusiness extends SharingService {
 		// Render a custom logo here because Google My Business is not part of SocialLogos
 		return (
 			<GoogleMyBusinessLogo
+				// eslint-disable-next-line wpcalypso/jsx-classname-namespace
 				className="sharing-service__logo"
 				height="36"
 				style={ { padding: 6 + 'px' } }
@@ -138,7 +138,6 @@ export default connectFor(
 		...props,
 		availableExternalAccounts: getGoogleMyBusinessLocations( state, props.siteId ),
 		requestingSiteKeyrings: isRequestingSiteKeyrings( state, props.siteId ),
-		saveRequests: state.siteSettings.saveRequests,
 		removableConnections: props.keyringConnections,
 		fetchConnection: props.requestKeyringConnections,
 		siteUserConnections: getSiteUserConnectionsForGoogleMyBusiness( state, props.siteId ),

--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -63,7 +63,6 @@ import simplePayments from './simple-payments/reducer';
 import siteAddressChange from './site-address-change/reducer';
 import siteKeyrings from './site-keyrings/reducer';
 import siteRoles from './site-roles/reducer';
-import siteSettings from './site-settings/reducer';
 import sites from './sites/reducer';
 import storedCards from './stored-cards/reducer';
 import support from './support/reducer';
@@ -129,7 +128,6 @@ const reducers = {
 	siteAddressChange,
 	siteKeyrings,
 	siteRoles,
-	siteSettings,
 	sites,
 	storedCards,
 	support,

--- a/client/state/selectors/get-podcasting-category-id.js
+++ b/client/state/selectors/get-podcasting-category-id.js
@@ -4,6 +4,8 @@
 import { get } from 'lodash';
 import isPrivateSite from 'state/selectors/is-private-site';
 
+import 'state/site-settings/init';
+
 /**
  * Returns the Podcasting category ID for a given site ID.
  *

--- a/client/state/selectors/get-site-gmt-offset.js
+++ b/client/state/selectors/get-site-gmt-offset.js
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import 'state/site-settings/init';
 
 /**
  * Returns the site's UTC offset as a number.

--- a/client/state/selectors/get-site-timezone-value.js
+++ b/client/state/selectors/get-site-timezone-value.js
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import 'state/site-settings/init';
 
 /**
  * Returns the site's timezone value, in the format of 'America/Araguaina.'

--- a/client/state/site-settings/actions.js
+++ b/client/state/site-settings/actions.js
@@ -1,7 +1,6 @@
 /**
  * Internal dependencies
  */
-
 import wpcom from 'lib/wp';
 import {
 	SITE_SETTINGS_RECEIVE,
@@ -16,6 +15,7 @@ import {
 import { normalizeSettings } from './utils';
 
 import 'state/data-layer/wpcom/sites/homepage';
+import 'state/site-settings/init';
 
 /**
  * Returns an action object to be used in signalling that site settings have been received.

--- a/client/state/site-settings/init.js
+++ b/client/state/site-settings/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'state/redux-store';
+import reducer from './reducer';
+
+registerReducer( [ 'siteSettings' ], reducer );

--- a/client/state/site-settings/jetpack-credentials-banner/selectors.ts
+++ b/client/state/site-settings/jetpack-credentials-banner/selectors.ts
@@ -9,6 +9,8 @@ import { DefaultRootState } from 'react-redux';
 import { getPreference } from 'state/preferences/selectors';
 import { Preference } from 'my-sites/site-settings/jetpack-credentials-banner/types';
 
+import 'state/site-settings/init';
+
 const MAX_BANNER_VIEWS = 10;
 const NINETY_DAYS_IN_MILLISECONDS = 90 * 24 * 60 * 60 * 1000;
 export const JETPACK_CREDENTIALS_BANNER_PREFERENCE = 'backup-scan-security-settings-moved';

--- a/client/state/site-settings/package.json
+++ b/client/state/site-settings/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/site-settings/reducer.js
+++ b/client/state/site-settings/reducer.js
@@ -6,7 +6,12 @@ import { includes } from 'lodash';
 /**
  * Internal dependencies
  */
-import { combineReducers, withSchemaValidation, withoutPersistence } from 'state/utils';
+import {
+	combineReducers,
+	withoutPersistence,
+	withSchemaValidation,
+	withStorageKey,
+} from 'state/utils';
 import { items as itemSchemas } from './schema';
 import {
 	MEDIA_DELETE,
@@ -135,8 +140,10 @@ export const items = withSchemaValidation( itemSchemas, ( state = {}, action ) =
 	return state;
 } );
 
-export default combineReducers( {
+const combinedReducer = combineReducers( {
 	items,
 	requesting,
 	saveRequests,
 } );
+
+export default withStorageKey( 'siteSettings', combinedReducer );

--- a/client/state/site-settings/selectors.js
+++ b/client/state/site-settings/selectors.js
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import 'state/site-settings/init';
 
 /**
  * Returns true if we are requesting settings for the specified site ID, false otherwise.


### PR DESCRIPTION
This PR is one of many working on modularising state in Calypso. This one handles site settings.

For more details on state modularisation, see the [modularised state documentation](https://github.com/Automattic/wp-calypso/blob/master/docs/modularized-state.md) and p4TIVU-9lM-p2.

Note: I added all the reviewers that GitHub suggested. Please feel free to ignore the review request or pull in someone else if you're not comfortable reviewing this PR. Thank you!

Fixes #42481.

#### Changes proposed in this Pull Request

* Modularise site settings state
* Remove direct access (no selector) to site settings state in `GoogleMyBusiness`, which appears to be unused

#### Testing instructions

Site settings state gets automatically loaded on boot due to the notifications middleware, so it's difficult to test the automatic loading portion of this PR.

Since site settings are so widely used across Calypso, though, it should be enough to smoke-test basic site functionality to ensure that this PR doesn't introduce any issues.
