### PR TITLE
Adds a section header to make primary domains more prominent

### DIFF
--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -50,6 +50,8 @@ import DomainItem from './domain-item';
 import ListHeader from './list-header';
 import QuerySitePurchases from 'components/data/query-site-purchases';
 import PopoverCart from 'my-sites/checkout/cart/popover-cart';
+import InfoPopover from 'components/info-popover';
+
 /**
  * Style dependencies
  */
@@ -205,6 +207,7 @@ export class List extends React.Component {
 				{ this.domainWarnings() }
 				{ this.domainCreditsInfoNotice() }
 
+				<div className="domain-management-list__primary-domain">{ this.renderPrimaryDomain() }</div>
 				<div className="domain-management-list__items">{ this.listNewItems() }</div>
 				<DomainToPlanNudge />
 			</>
@@ -452,6 +455,39 @@ export class List extends React.Component {
 			! domain.isWPCOMDomain &&
 			! domain.isWpcomStagingDomain
 		);
+	}
+
+	renderPrimaryDomain() {
+		const { domains, translate } = this.props;
+		const primaryDomain = find( domains, 'isPrimary' );
+
+		if ( this.isLoading() || ! primaryDomain ) {
+			return <ListItemPlaceholder />;
+		}
+
+		return [
+			<CompactCard className="list__header-primary-domain" key="primary-domain-header">
+				<div className="list__header-primary-domain-info">
+					{ translate( 'Primary domain' ) }
+					<InfoPopover iconSize={ 18 }>
+						{ translate(
+							'Your primary domain is the address ' +
+								'visitors will see in their browser ' +
+								'when visiting your site. ' +
+								'All other custom domains redirect to the primary domain.'
+						) }
+					</InfoPopover>
+				</div>
+				<div className="list__header-primary-domain-buttons">
+					<Button compact className="list__change-primary-domain">
+						{ translate( 'Change primary domain' ) }
+					</Button>
+				</div>
+			</CompactCard>,
+			<CompactCard className="list__item-primary-domain" key="primary-domain-content">
+				<div className="list__header-primary-domain-content">{ primaryDomain.name }</div>
+			</CompactCard>,
+		];
 	}
 
 	listNewItems() {

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -472,10 +472,7 @@ export class List extends React.Component {
 					{ translate( 'Primary domain' ) }
 					<InfoPopover iconSize={ 18 }>
 						{ translate(
-							'Your primary domain is the address ' +
-								'visitors will see in their browser ' +
-								'when visiting your site. ' +
-								'All other custom domains redirect to the primary domain.'
+							'Your primary domain is the address visitors will see in their address bar when visiting your blog. All other domains will redirect to the primary domain.'
 						) }
 					</InfoPopover>
 				</div>

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -51,6 +51,7 @@ import ListHeader from './list-header';
 import QuerySitePurchases from 'components/data/query-site-purchases';
 import PopoverCart from 'my-sites/checkout/cart/popover-cart';
 import InfoPopover from 'components/info-popover';
+import ExternalLink from 'components/external-link';
 
 /**
  * Style dependencies
@@ -458,7 +459,7 @@ export class List extends React.Component {
 	}
 
 	renderPrimaryDomain() {
-		const { domains, translate } = this.props;
+		const { domains, selectedSite, translate } = this.props;
 		const primaryDomain = find( domains, 'isPrimary' );
 
 		if ( this.isLoading() || ! primaryDomain ) {
@@ -485,7 +486,17 @@ export class List extends React.Component {
 				</div>
 			</CompactCard>,
 			<CompactCard className="list__item-primary-domain" key="primary-domain-content">
-				<div className="list__header-primary-domain-content">{ primaryDomain.name }</div>
+				<div className="list__header-primary-domain-content">
+					<ExternalLink
+						className="list__header-primary-domain-url"
+						href={ selectedSite.URL }
+						title={ translate( 'Launch your site' ) }
+						target="_blank"
+						icon={ true }
+					>
+						{ primaryDomain.name }
+					</ExternalLink>
+				</div>
 			</CompactCard>,
 		];
 	}

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -7,6 +7,27 @@
 	margin-bottom: 2px;
 }
 
+.list__header-primary-domain {
+	display: flex;
+
+	.list__header-primary-domain-info {
+		text-align: left;
+		flex: 1;
+	}
+
+	.list__header-primary-domain-buttons {
+		display: flex;
+	}
+}
+
+.domain-management-list__primary-domain {
+	margin-bottom: 24px;
+
+	.list__item-primary-domain {
+		font-size: 1.6rem;
+	}
+}
+
 .domain-management-list-item {
 	&.busy {
 		background-color: var( --color-neutral-0 );

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -9,6 +9,7 @@
 
 .list__header-primary-domain {
 	display: flex;
+	align-items: center;
 
 	.list__header-primary-domain-info {
 		text-align: left;

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -13,6 +13,12 @@
 	.list__header-primary-domain-info {
 		text-align: left;
 		flex: 1;
+		font-size: $font-body-small;
+
+		button {
+			margin-left: 5px;
+			vertical-align: middle;
+		}
 	}
 
 	.list__header-primary-domain-buttons {
@@ -32,7 +38,7 @@
 	margin-bottom: 24px;
 
 	.list__item-primary-domain {
-		font-size: 1.6rem;
+		font-size: $font-title-large;
 	}
 }
 

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -20,6 +20,14 @@
 	}
 }
 
+.list__item-primary-domain {
+
+	.list__header-primary-domain-url {
+		color:inherit;
+		text-decoration: none;
+	}
+}
+
 .domain-management-list__primary-domain {
 	margin-bottom: 24px;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR adds a section for the primary domain to the sites domain manager. The click handler to change the primary domain is not hooked up yet.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Should look like this when viewed:

<img width="1085" alt="Screenshot 2020-07-10 at 4 27 46 PM" src="https://user-images.githubusercontent.com/277661/87171289-62809e00-c2ca-11ea-825f-86000096baad.png">

