### PR TITLE
editor: update timeout for desktop app

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -137,18 +137,22 @@ class CalypsoifyIframe extends Component<
 	componentDidMount() {
 		MediaStore.on( 'change', this.updateImageBlocks );
 		window.addEventListener( 'message', this.onMessage, false );
+
+		const isDesktop = config.isEnabled( 'desktop' ); // Three seconds longer than we give the iframe to load
+		const timeoutMs = isDesktop ? 25000 : 8000;
+
 		this.waitForIframeToInit = setInterval( () => {
 			if ( this.props.shouldLoadIframe ) {
 				clearInterval( this.waitForIframeToInit );
 				this.waitForIframeToLoad = setTimeout( () => {
-					config.isEnabled( 'desktop' )
+					isDesktop
 						? this.props.notifyDesktopCannotOpenEditor(
 								this.props.site,
 								REASON_BLOCK_EDITOR_UNKOWN_IFRAME_LOAD_FAILURE,
 								this.props.iframeUrl
 						  )
 						: window.location.replace( this.props.iframeUrl );
-				}, 8000 ); // Three seconds longer than we give the iframe to load
+				}, timeoutMs );
 			}
 		}, 1000 );
 	}


### PR DESCRIPTION
### Description

We've been getting an increased number of reports of users running into an "unhandled error" resulting from a timeout when trying to load the block editor:

```
[2020-07-06 16:59:08.701] [desktop:external-links] [info] Cannot 
open editor for site: 
{"siteId":175060405,"reason":"REASON_BLOCK_EDITOR_UNKOWN_IFRAME_LOAD_FAILURE","editorUrl":"https://xxxxx.com/wp-admin/post.php?post=470&action=edit&calypsoify=1&block-editor=1&frame-nonce=nnnnnnnnn%3A2%3xxxxxxxxxxxxxxxxxxxxxxxxxxxx&origin=http%3A%2F%2F127.0.0.1%3A41050&environment-id=desktop","wpAdminLoginUrl":null,"origin":"https://xxxxxxxxxx.com","canUserManageOptions":true}
```

This timeout was introduced in #43248 and makes it so loading the editor times out after 6 (now 8) seconds. However, this timeout is likely too strict for the desktop app (and to be fair, even browsers) as it has been observed that Gutenberg can take as long as 22 seconds when loading an Atomic site from a cold cache (see p58i-95P-p2).

Bumping the timeout for desktop to 25 seconds which is by no means an acceptable threshold for an ideal user experience, but at least mitigates this issue while performance optimization of Gutenberg is pending (p4TIVU-p2).

Ref: #3110882-zen