### PR TITLE
Checkout Thank-You: Remove assumption that site and purchases exist

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -342,6 +342,10 @@ export class CheckoutThankYouHeader extends PureComponent {
 		event.preventDefault();
 		const { siteAdminUrl } = this.props;
 
+		if ( ! siteAdminUrl ) {
+			return;
+		}
+
 		this.props.recordTracksEvent( 'calypso_jetpack_product_thankyou', {
 			product_name: 'search',
 			value: 'Customizer',

--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -35,6 +35,11 @@ import isAtomicSite from 'state/selectors/is-site-automated-transfer';
 
 export class CheckoutThankYouHeader extends PureComponent {
 	static propTypes = {
+		isAtomic: PropTypes.bool,
+		siteAdminUrl: PropTypes.string,
+		displayMode: PropTypes.string,
+		upgradeIntent: PropTypes.string,
+		selectedSite: PropTypes.object,
 		isDataLoaded: PropTypes.bool.isRequired,
 		primaryPurchase: PropTypes.object,
 		hasFailedPurchases: PropTypes.bool,
@@ -42,6 +47,9 @@ export class CheckoutThankYouHeader extends PureComponent {
 		siteUnlaunchedBeforeUpgrade: PropTypes.bool,
 		primaryCta: PropTypes.func,
 		purchases: PropTypes.array,
+		translate: PropTypes.func.isRequired,
+		recordTracksEvent: PropTypes.func.isRequired,
+		recordStartTransferClickInThankYou: PropTypes.func.isRequired,
 	};
 
 	getHeading() {

--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -55,7 +55,7 @@ export class CheckoutThankYouHeader extends PureComponent {
 			return translate( 'Some items failed.' );
 		}
 
-		if ( purchases && purchases[ 0 ].productType === 'search' ) {
+		if ( purchases?.length > 0 && purchases[ 0 ].productType === 'search' ) {
 			return translate( 'Welcome to Jetpack Search!' );
 		}
 
@@ -92,7 +92,7 @@ export class CheckoutThankYouHeader extends PureComponent {
 			return translate( 'Some of the items in your cart could not be added.' );
 		}
 
-		if ( purchases && purchases[ 0 ].productType === 'search' ) {
+		if ( purchases?.length > 0 && purchases[ 0 ].productType === 'search' ) {
 			return (
 				<div>
 					<p>{ translate( 'We are currently indexing your site.' ) }</p>
@@ -413,7 +413,7 @@ export class CheckoutThankYouHeader extends PureComponent {
 		return (
 			primaryPurchase &&
 			isDomainRegistration( primaryPurchase ) &&
-			purchases.filter( isDomainRegistration ).length === 1
+			purchases?.filter( isDomainRegistration ).length === 1
 		);
 	}
 
@@ -429,7 +429,7 @@ export class CheckoutThankYouHeader extends PureComponent {
 		} = this.props;
 		const headerButtonClassName = 'button is-primary';
 		const isConciergePurchase = 'concierge' === displayMode;
-		const isSearch = purchases && purchases[ 0 ].productType === 'search';
+		const isSearch = purchases?.length > 0 && purchases[ 0 ].productType === 'search';
 
 		if ( isSearch ) {
 			return (
@@ -561,8 +561,8 @@ export class CheckoutThankYouHeader extends PureComponent {
 export default connect(
 	( state, ownProps ) => ( {
 		upgradeIntent: ownProps.upgradeIntent || getCheckoutUpgradeIntent( state ),
-		isAtomic: isAtomicSite( state, ownProps.selectedSite.ID ),
-		siteAdminUrl: getSiteAdminUrl( state, ownProps.selectedSite.ID ),
+		isAtomic: isAtomicSite( state, ownProps.selectedSite?.ID ),
+		siteAdminUrl: getSiteAdminUrl( state, ownProps.selectedSite?.ID ),
 	} ),
 	{
 		recordStartTransferClickInThankYou,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The `CheckoutThankYouHeader` component makes two faulty assumptions: 

- That the optional `selectedSite` prop is set and contains an object.
- That the optional `purchases` prop is an array with at least a single element if it is set.

This PR corrects those assumptions.

#### Testing instructions

- Without this PR, visit https://wordpress.com/checkout/thank-you/no-site and verify that you see an error boundary message and that there is a fatal error in the console. (You can do this in production.)
- With this PR, visit http://calypso.localhost:3000/checkout/thank-you/no-site and verify that you see a "Congratulations" page.