### PR TITLE
Add logging for getThankYouUrl arguments and result

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -228,6 +228,7 @@ export default function CompositeCheckout( {
 		siteId,
 		isWhiteGloveOffer,
 		hideNudge,
+		recordEvent,
 	} );
 
 	const moment = useLocalizedMoment();

--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -123,13 +123,7 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 				);
 
 			case 'PAYMENT_METHOD_SELECT': {
-				reduxDispatch(
-					logStashEventAction(
-						'payment_method_select',
-						String( action.payload ),
-						'payment_method_select'
-					)
-				);
+				reduxDispatch( logStashEventAction( 'payment_method_select', String( action.payload ) ) );
 
 				// Need to convert to the slug format used in old checkout so events are comparable
 				const rawPaymentMethodSlug = String( action.payload );
@@ -398,11 +392,10 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 
 			case 'THANK_YOU_URL_GENERATED':
 				return reduxDispatch(
-					logStashEventAction(
-						'thank_you_url_generated',
-						String( action.payload ),
-						'thank you url generated'
-					)
+					logStashEventAction( 'thank_you_url_generated', 'thank you url generated', {
+						url: action.payload.url,
+						arguments: action.payload.arguments,
+					} )
 				);
 
 			default:
@@ -416,20 +409,22 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 	};
 }
 
-function logStashLoadErrorEventAction( type, payload, additionalData = {} ) {
-	return logStashEventAction( type, payload, 'composite checkout load error', additionalData );
+function logStashLoadErrorEventAction( type, errorMessage, additionalData = {} ) {
+	return logStashEventAction( type, 'composite checkout load error', {
+		...additionalData,
+		message: errorMessage,
+	} );
 }
 
-function logStashEventAction( type, payload, message, additionalData = {} ) {
+function logStashEventAction( type, message, dataForLog = {} ) {
 	return logToLogstash( {
 		feature: 'calypso_client',
-		message: message,
+		message,
 		severity: config( 'env_id' ) === 'production' ? 'error' : 'debug',
 		extra: {
 			env: config( 'env_id' ),
 			type,
-			message: payload,
-			...additionalData,
+			...dataForLog,
 		},
 	} );
 }

--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -396,6 +396,15 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 				return recordAddEvent( action.payload );
 			}
 
+			case 'THANK_YOU_URL_GENERATED':
+				return reduxDispatch(
+					logStashEventAction(
+						'thank_you_url_generated',
+						String( action.payload ),
+						'thank you url generated'
+					)
+				);
+
 			default:
 				debug( 'unknown checkout event', action );
 				return reduxDispatch(

--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -123,7 +123,9 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 				);
 
 			case 'PAYMENT_METHOD_SELECT': {
-				reduxDispatch( logStashEventAction( 'payment_method_select', String( action.payload ) ) );
+				reduxDispatch(
+					logStashEventAction( 'payment_method_select', { newMethodId: String( action.payload ) } )
+				);
 
 				// Need to convert to the slug format used in old checkout so events are comparable
 				const rawPaymentMethodSlug = String( action.payload );
@@ -392,7 +394,7 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 
 			case 'THANK_YOU_URL_GENERATED':
 				return reduxDispatch(
-					logStashEventAction( 'thank_you_url_generated', 'thank you url generated', {
+					logStashEventAction( 'thank you url generated', {
 						url: action.payload.url,
 						arguments: action.payload.arguments,
 					} )
@@ -409,21 +411,21 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 	};
 }
 
-function logStashLoadErrorEventAction( type, errorMessage, additionalData = {} ) {
-	return logStashEventAction( type, 'composite checkout load error', {
+function logStashLoadErrorEventAction( errorType, errorMessage, additionalData = {} ) {
+	return logStashEventAction( 'composite checkout load error', {
 		...additionalData,
+		type: errorType,
 		message: errorMessage,
 	} );
 }
 
-function logStashEventAction( type, message, dataForLog = {} ) {
+function logStashEventAction( message, dataForLog = {} ) {
 	return logToLogstash( {
 		feature: 'calypso_client',
 		message,
 		severity: config( 'env_id' ) === 'production' ? 'error' : 'debug',
 		extra: {
 			env: config( 'env_id' ),
-			type,
 			...dataForLog,
 		},
 	} );

--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -88,7 +88,7 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 
 			case 'STEP_LOAD_ERROR':
 				reduxDispatch(
-					logStashEventAction( 'step_load', String( action.payload.message ), {
+					logStashLoadErrorEventAction( 'step_load', String( action.payload.message ), {
 						stepId: action.payload.stepId,
 					} )
 				);
@@ -101,7 +101,9 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 				);
 
 			case 'SUBMIT_BUTTON_LOAD_ERROR':
-				reduxDispatch( logStashEventAction( 'submit_button_load', String( action.payload ) ) );
+				reduxDispatch(
+					logStashLoadErrorEventAction( 'submit_button_load', String( action.payload ) )
+				);
 
 				return reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_composite_submit_button_load_error', {
@@ -110,7 +112,9 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 				);
 
 			case 'PAYMENT_METHOD_LOAD_ERROR':
-				reduxDispatch( logStashEventAction( 'payment_method_load', String( action.payload ) ) );
+				reduxDispatch(
+					logStashLoadErrorEventAction( 'payment_method_load', String( action.payload ) )
+				);
 
 				return reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_composite_payment_method_load_error', {
@@ -123,7 +127,6 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 					logStashEventAction(
 						'payment_method_select',
 						String( action.payload ),
-						{},
 						'payment_method_select'
 					)
 				);
@@ -140,7 +143,7 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 			}
 
 			case 'PAGE_LOAD_ERROR':
-				reduxDispatch( logStashEventAction( 'page_load', String( action.payload ) ) );
+				reduxDispatch( logStashLoadErrorEventAction( 'page_load', String( action.payload ) ) );
 
 				return reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_composite_page_load_error', {
@@ -404,10 +407,14 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 	};
 }
 
-function logStashEventAction( type, payload, additionalData = {}, message ) {
+function logStashLoadErrorEventAction( type, payload, additionalData = {} ) {
+	return logStashEventAction( type, payload, 'composite checkout load error', additionalData );
+}
+
+function logStashEventAction( type, payload, message, additionalData = {} ) {
 	return logToLogstash( {
 		feature: 'calypso_client',
-		message: message ?? 'composite checkout load error',
+		message: message,
 		severity: config( 'env_id' ) === 'production' ? 'error' : 'debug',
 		extra: {
 			env: config( 'env_id' ),

--- a/client/my-sites/checkout/composite-checkout/use-get-thank-you-url.js
+++ b/client/my-sites/checkout/composite-checkout/use-get-thank-you-url.js
@@ -346,6 +346,7 @@ export function useGetThankYouUrl( {
 	siteId,
 	isWhiteGloveOffer,
 	hideNudge,
+	recordEvent,
 } ) {
 	const selectedSiteData = useSelector( ( state ) => getSelectedSite( state ) );
 	const adminUrl = selectedSiteData?.options?.admin_url;
@@ -361,23 +362,7 @@ export function useGetThankYouUrl( {
 		const orderId = transactionResult.order_id;
 		const isTransactionResultEmpty = isEmpty( transactionResult );
 
-		debug( 'getThankYouUrl called with', {
-			siteSlug,
-			adminUrl,
-			receiptId,
-			orderId,
-			redirectTo,
-			purchaseId,
-			feature,
-			cart,
-			isJetpackNotAtomic,
-			product,
-			isEligibleForSignupDestinationResult,
-			hideNudge,
-			didPurchaseFail,
-			isTransactionResultEmpty,
-		} );
-		const url = getThankYouPageUrl( {
+		const getThankYouPageUrlArguments = {
 			siteSlug,
 			adminUrl,
 			receiptId,
@@ -393,10 +378,17 @@ export function useGetThankYouUrl( {
 			hideNudge,
 			didPurchaseFail,
 			isTransactionResultEmpty,
-		} );
+		};
+		debug( 'getThankYouUrl called with', getThankYouPageUrlArguments );
+		const url = getThankYouPageUrl( getThankYouPageUrlArguments );
 		debug( 'getThankYouUrl returned', url );
+		recordEvent( {
+			type: 'THANK_YOU_URL_GENERATED',
+			payload: { arguments: getThankYouPageUrlArguments, url },
+		} );
 		return url;
 	}, [
+		recordEvent,
 		isEligibleForSignupDestinationResult,
 		siteSlug,
 		adminUrl,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This adds logstash logging for every call to `getThankYouUrl` in composite checkout.

#### Testing instructions

- Visit composite checkout.
- Choose PayPal.
- Press the submit button (no need to confirm the actual payment).
- Visit logstash and look for the string `"thank you url generated"` and verify that you see the event you caused and that the `message` key contains the `url` and `arguments` for the call to `getThankYouUrl`.