### PR TITLE
Stats: Fix Conditions for Displaying the Earn Banner

### DIFF
--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -28,7 +28,7 @@ import StickyPanel from 'components/sticky-panel';
 import JetpackBackupCredsBanner from 'blocks/jetpack-backup-creds-banner';
 import JetpackColophon from 'components/jetpack-colophon';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
-import { isJetpackSite, getSitePlanSlug } from 'state/sites/selectors';
+import { isJetpackSite, getSitePlanSlug, getSiteOption } from 'state/sites/selectors';
 import { recordGoogleEvent, recordTracksEvent, withAnalytics } from 'state/analytics/actions';
 import PrivacyPolicyBanner from 'blocks/privacy-policy-banner';
 import QuerySiteKeyrings from 'components/data/query-site-keyrings';
@@ -38,6 +38,7 @@ import isJetpackModuleActive from 'state/selectors/is-jetpack-module-active';
 import QueryJetpackModules from 'components/data/query-jetpack-modules';
 import EmptyContent from 'components/empty-content';
 import { activateModule } from 'state/jetpack/modules/actions';
+import canCurrentUser from 'state/selectors/can-current-user';
 import getCurrentRouteParameterized from 'state/selectors/get-current-route-parameterized';
 import Banner from 'components/banner';
 import isVipSite from 'state/selectors/is-vip-site';
@@ -128,7 +129,7 @@ class StatsSite extends Component {
 	};
 
 	renderStats() {
-		const { date, siteId, slug, isJetpack, isVip } = this.props;
+		const { date, hasWordAds, siteId, slug, isAdmin, isJetpack, isVip } = this.props;
 
 		const queryDate = date.format( 'YYYY-MM-DD' );
 		const { period, endOf } = this.props.period;
@@ -182,7 +183,7 @@ class StatsSite extends Component {
 						period={ this.props.period }
 						chartTab={ this.props.chartTab }
 					/>
-					{ ! isVip && (
+					{ ! isVip && isAdmin && ! hasWordAds && (
 						<Banner
 							className="stats__upsell-nudge"
 							icon="star"
@@ -338,7 +339,9 @@ export default connect(
 		const showEnableStatsModule =
 			siteId && isJetpack && isJetpackModuleActive( state, siteId, 'stats' ) === false;
 		return {
+			isAdmin: canCurrentUser( state, siteId, 'manage_options' ),
 			isJetpack,
+			hasWordAds: getSiteOption( state, siteId, 'wordads' ),
 			siteId,
 			isVip,
 			slug: getSelectedSiteSlug( state ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

My understanding is that it's desired to use the Banner component over the UpsellNudge for this, but the Banner component lacks a lot of the logic on when this should be displayed. In this case, it means non-admins are being shown the nudge, which leads them to a page that crashes Calypso.

<img width="1671" alt="Screenshot 2020-07-11 at 14 53 57" src="https://user-images.githubusercontent.com/43215253/87225626-696ce680-c386-11ea-95e2-9a26c55f72c8.png">

This adds it to separately to Stats here. It also hides the banner for people who already are earning money - I'm assuming that this should be the behaviour based on the language of `Start earning money now` but let me know if not!

#### Testing instructions

Verify the Earn banner doesn't appear for users who aren't admins or already are earning money! :) 

<img width="1160" alt="Screenshot 2020-07-11 at 15 00 33" src="https://user-images.githubusercontent.com/43215253/87225794-4858c580-c387-11ea-8bf0-9e10d588e6e5.png">

cc @donlair, @danhauk 