### PR TITLE
Earn: Prevent Crash by Disabling for Non-Admins

### DIFF
--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -16,8 +16,10 @@ import { getSelectedSiteSlug, getSelectedSiteId } from 'state/ui/selectors';
 import getSiteBySlug from 'state/sites/selectors/get-site-by-slug';
 import { hasFeature, getSitePlanSlug } from 'state/sites/plans/selectors';
 import { isCurrentPlanPaid, isJetpackSite } from 'state/sites/selectors';
+import canCurrentUser from 'state/selectors/can-current-user';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import { isRequestingWordAdsApprovalForSite } from 'state/wordads/approve/selectors';
+import EmptyContent from 'components/empty-content';
 import PromoSection, { Props as PromoSectionProps } from 'components/promo-section';
 import QueryMembershipsSettings from 'components/data/query-memberships-settings';
 import QueryWordadsStatus from 'components/data/query-wordads-status';
@@ -72,6 +74,7 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 	isFreePlan,
 	isJetpack,
 	isAtomicSite,
+	isUserAdmin,
 	isLoading,
 	hasSimplePayments,
 	hasWordAds,
@@ -504,6 +507,15 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 		] ),
 	};
 
+	if ( ! isUserAdmin ) {
+		return (
+			<EmptyContent
+				illustration="/calypso/images/illustrations/illustration-404.svg"
+				title={ translate( 'You are not authorized to view this page' ) }
+			/>
+		);
+	}
+
 	return (
 		<Fragment>
 			{ ! hasWordAds && <QueryWordadsStatus siteId={ siteId } /> }
@@ -538,6 +550,7 @@ export default connect< ConnectedProps, {}, {} >(
 			isFreePlan,
 			isJetpack: isJetpackSite( state, siteId ),
 			isAtomicSite: isSiteAutomatedTransfer( state, siteId ),
+			isUserAdmin: canCurrentUser( state, siteId, 'manage_options' ),
 			hasWordAds: hasFeature( state, siteId, FEATURE_WORDADS_INSTANT ),
 			hasSimplePayments: hasFeature( state, siteId, FEATURE_SIMPLE_PAYMENTS ),
 			hasConnectedAccount,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Earn currently crashes for non-admins, who shouldn't be able to access this section anyway

<img width="1671" alt="Screenshot 2020-07-11 at 14 53 57" src="https://user-images.githubusercontent.com/43215253/87225626-696ce680-c386-11ea-95e2-9a26c55f72c8.png">

#### Testing instructions

Check Earn as a non-admin and verify that instead of crashing, an error message is displayed!

<img width="1143" alt="Screenshot 2020-07-12 at 08 46 49" src="https://user-images.githubusercontent.com/43215253/87241547-3c6b1300-c41c-11ea-82bd-155e30104f6e.png">

cc @mmtr, @blackjackkent, @artpi 