### PR TITLE
Add local docker development environment

### DIFF
--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -1,0 +1,14 @@
+FROM node:12.18.0
+LABEL maintainer="Automattic"
+
+WORKDIR    /calypso
+
+ENV        CONTAINER 'docker'
+ENV        PROGRESS=true
+
+# Build a "source" layer
+#
+# This layer is populated with up-to-date files from
+# Calypso development.
+COPY . /calypso/
+RUN yarn install

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -1,0 +1,12 @@
+version: '3'
+services:
+    calypso:
+        build: 
+            context: .
+            dockerfile: ./Dockerfile.development
+        command: yarn start
+        ports:
+            - 3000:3000
+        working_dir: /calypso
+        volumes:
+            - .:/calypso:cached

--- a/docs/experimental-docker-development-environment.md
+++ b/docs/experimental-docker-development-environment.md
@@ -1,0 +1,21 @@
+# Experimental Docker based development environment
+
+An experimental Docker based development environment was recently added to the `wp-calypso` environment. It employs the [`Dockerfile.development`](../../Dockerfile.development) file alongside the [`docker-compose.development.yml`](../docker-compose.development.yml) file to spin up a Calypso build in a docker container with the files mapped to your repositories file system. This means that Calypso itself is running in the Docker container while you can still edit files on your normal file-system without having to connect your editor to the Docker environment.
+
+## Usage
+
+Ensure you have the latest version of Docker and `docker-compose` installed. You may then run `yarn dc:up` which will build the base image by copying the repository and then running `yarn install`. That will then be used to create a `calypso` service, which has its volumes mapped and has Calypso running via `yarn start`. Once that has finished, you may use `yarn dc:logs` to observe the logs for the container running Calypso.
+
+## Troubleshooting
+
+This section has mostly not been filled out yet. We're still working on identifying the issues and limitations of the docker environment.
+
+### Calypso is stuck rebuilding after I checked out a branch
+
+To fix this, you'll need to kill the docker-compose service by running `yarn dc:down` and then `yarn dc:up` again. This effectively mirrors using `ctrl + c` to stop Webpack and then running `yarn start` to start it back up again.
+
+## Known limitations
+
+It is slow to install. One improvement we could make in the future is to publish base images for every checkout of master that could be pulled, preferrably heavily optimized so devs are only pulling the smallest differences and not ending up with hundreds of gigs of docker images clogging their hard drives.
+
+If we do the above then we will inevitably run into disk space issues, so we could do well to add a helper `dc:` command to clean out docker images over a certain age.

--- a/package.json
+++ b/package.json
@@ -95,6 +95,8 @@
 		"distclean": "check-npm-client && yarn run clean && npx rimraf node_modules client/node_modules desktop/node_modules apps/*/node_modules packages/*/node_modules test/e2e/node_modules .tsc-cache vendor",
 		"docker": "check-npm-client && docker run -it --name wp-calypso --rm -p 80:3000 wp-calypso",
 		"docker-jetpack-cloud": "check-npm-client && docker run -it --env CALYPSO_ENV=jetpack-cloud-production --name wp-calypso --rm -p 80:3000 wp-calypso",
+		"dc:up": "docker-compose --file=docker-compose.development.yml up -d",
+		"dc:logs": "docker-compose --file=docker-compose.development.yml logs -f calypso",
 		"eslint-branch": "check-npm-client && node bin/eslint-branch.js",
 		"install-if-deps-outdated": "check-npm-client && node bin/install-if-deps-outdated.js",
 		"install-if-no-packages": "check-npm-client && node bin/install-if-no-packages.js",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add `Dockerfile.development` to build baseline environment
* Add `docker-compose.development.yml` to use docker-compose to run the local environment

TODO:
* Add preliminary documentation for how to use this and what problems currently exist with it

Outstanding questions:
1. What are the limitations? I haven't used this for actual development yet so I'm not sure if it will actually work but small changes and checking out other commits on master worked great.
1. It's a little slower building. Why? Is there a way to adress this?

Next steps:
1. Use a smarter base container than `node` (i.e., one based on Calypso specifically, probably with dependencies installed)

#### Testing instructions

Increase docker's alotted memory to at least like 4 or 8 GB (not sure what the min actually is). Ensure you do not already have Calypso running locally.

Checkout the branch and run `yarn dc:up` from the root directory of your local `wp-calypso` repository. This will start the local Calypso environment on port `3000` as usual. Use `yarn dc:logs` to observe the logs for the `calypso` container.

Make observable changes to the code and ensure the changes are reflected in the running instance. 
