### PR TITLE
Nav sidebar: Remove the page slug which was displayed below the page title

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-item/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-item/index.tsx
@@ -44,14 +44,9 @@ export default function NavItem( { item, postType, selected, statusLabel }: NavI
 				href={ editUrl }
 				target={ applyFilters( 'a8c.WpcomBlockEditorNavSidebar.linkTarget', undefined ) }
 			>
-				<div className="wpcom-block-editor-nav-item__title-container">
-					<div className={ titleClasses }>
-						{ item.title?.raw ||
-							_x( 'Untitled', 'post title for posts with no title', 'full-site-editing' ) }
-					</div>
-					{ item.slug && (
-						<div className="wpcom-block-editor-nav-item__slug">{ `/${ item.slug }/` }</div>
-					) }
+				<div className={ titleClasses }>
+					{ item.title?.raw ||
+						_x( 'Untitled', 'post title for posts with no title', 'full-site-editing' ) }
 				</div>
 				{ statusLabel && <div className="wpcom-block-editor-nav-item__label">{ statusLabel }</div> }
 			</Button>

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-item/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-item/style.scss
@@ -30,20 +30,13 @@
 	}
 }
 
-.wpcom-block-editor-nav-item__title-container {
-	flex: 1;
-}
-
 .wpcom-block-editor-nav-item__title {
+	flex: 1;
+
 	&.is-untitled {
 		font-style: italic;
 		color: $medium-gray-text;
 	}
-}
-
-.wpcom-block-editor-nav-item__slug {
-	font-size: $default-font-size - 2;
-	padding-top: 4px;
 }
 
 .wpcom-block-editor-nav-item__label {

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
@@ -199,7 +199,7 @@ function useNavItems(): Post[] {
 
 		const items =
 			select( 'core' ).getEntityRecords( 'postType', currentPostType, {
-				_fields: 'id,slug,status,title',
+				_fields: 'id,status,title',
 				exclude: [ currentPostId ],
 				orderby: 'modified',
 				per_page: 10,

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/types.ts
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/types.ts
@@ -1,6 +1,5 @@
 export interface Post {
 	id: number;
-	slug: string;
 	status: string;
 	title: { raw: string; rendered: string };
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove slug from items in the nav sidebar
* Remove `slug` from the network response when loading page info

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out branch
* Define `WPCOM_BLOCK_EDITOR_SIDEBAR` in `.wp-env.override.json`
* `cd apps/full-site-editing && npx wp-env start && yarn dev`
* Open the block editor at `localhost:4013` and open the nav sidebar
* The page/post slug shouldn't appear in the sidebar

Fixes #43974
