### PR TITLE
EditorFeaturedImagePreviewContainer: replace `MediaStore.get` with `getMediaItem` redux selector

### DIFF
--- a/client/components/tinymce/plugins/media/plugin.jsx
+++ b/client/components/tinymce/plugins/media/plugin.jsx
@@ -33,6 +33,7 @@ import { renderWithReduxStore } from 'lib/react-helpers';
 import Gridicon from 'components/gridicon';
 import { clearMediaItemErrors, setMediaLibrarySelectedItems } from 'state/media/actions';
 import { fetchMediaItem } from 'state/media/thunks';
+import getMediaItem from 'state/selectors/get-media-item';
 
 /**
  * Module variables
@@ -180,7 +181,7 @@ function mediaButton( editor ) {
 
 			// Let's get the media object counterpart of an image in post/page editor.
 			// This media object contains the latest changes to the media file.
-			const media = MediaStore.get( selectedSite.ID, current.media.ID );
+			const media = getMediaItem( getState(), selectedSite.ID, current.media.ID );
 
 			let mediaHasCaption = false;
 			let captionNode = null;
@@ -480,7 +481,7 @@ function mediaButton( editor ) {
 			if ( ! imageId ) {
 				return;
 			}
-			const image = MediaStore.get( siteId, imageId );
+			const image = getMediaItem( getState(), siteId, imageId );
 
 			dispatch( clearMediaItemErrors( siteId ) );
 			renderModal(
@@ -530,7 +531,7 @@ function mediaButton( editor ) {
 			}
 
 			// Attempt to find media in Flux store
-			const media = MediaStore.get( selectedSite.ID, parsed.media.ID );
+			const media = getMediaItem( getState(), selectedSite.ID, parsed.media.ID );
 			if ( media && media.caption ) {
 				content = media.caption;
 			} else {
@@ -598,7 +599,7 @@ function mediaButton( editor ) {
 		}
 
 		// Attempt to find media in Flux store
-		let media = assign( {}, MediaStore.get( selectedSite.ID, parsed.media.ID ) );
+		let media = assign( {}, getMediaItem( getState(), selectedSite.ID, parsed.media.ID ) );
 		delete media.caption;
 		media = assign( {}, parsed.media, media );
 
@@ -649,7 +650,7 @@ function mediaButton( editor ) {
 		const parsed = deserialize( event.element );
 		const media = assign(
 			{ width: Infinity, height: Infinity },
-			MediaStore.get( selectedSite.ID, parsed.media.ID )
+			getMediaItem( getState(), selectedSite.ID, parsed.media.ID )
 		);
 		const currentRatio = computeRatio( parsed.media, media );
 
@@ -717,7 +718,7 @@ function mediaButton( editor ) {
 		gallery.items = gallery.ids.split( ',' ).map( ( id ) => {
 			id = parseInt( id, 10 );
 
-			const media = MediaStore.get( selectedSite.ID, id );
+			const media = getMediaItem( getState(), selectedSite.ID, id );
 			if ( ! media ) {
 				store.dispatch( fetchMediaItem( selectedSite.ID, id ) );
 			}
@@ -777,7 +778,7 @@ function mediaButton( editor ) {
 		( event.content.match( REGEXP_IMG ) || [] ).forEach( function ( img ) {
 			const parsed = deserialize( img );
 
-			if ( ! parsed.media.ID || MediaStore.get( selectedSite.ID, parsed.media.ID ) ) {
+			if ( ! parsed.media.ID || getMediaItem( getState(), selectedSite.ID, parsed.media.ID ) ) {
 				return;
 			}
 

--- a/client/post-editor/editor-featured-image/preview-container.jsx
+++ b/client/post-editor/editor-featured-image/preview-container.jsx
@@ -4,14 +4,13 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import { defer } from 'lodash';
 import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
-import MediaStore from 'lib/media/store';
 import EditorFeaturedImagePreview from './preview';
+import getMediaItem from 'state/selectors/get-media-item';
 import { fetchMediaItem } from 'state/media/thunks';
 
 class EditorFeaturedImagePreviewContainer extends React.Component {
@@ -23,59 +22,22 @@ class EditorFeaturedImagePreviewContainer extends React.Component {
 		showEditIcon: PropTypes.bool,
 	};
 
-	state = {
-		image: null,
-	};
-
 	componentDidMount() {
-		this.fetchImage();
-		MediaStore.on( 'change', this.updateImageState );
+		this.props.fetchMediaItem( this.props.siteId, this.props.itemId );
 	}
 
 	componentDidUpdate( prevProps ) {
 		const { siteId, itemId } = this.props;
 		if ( siteId !== prevProps.siteId || itemId !== prevProps.itemId ) {
-			this.fetchImage();
+			this.props.fetchMediaItem( siteId, itemId );
+			this.props.onImageChange( itemId );
 		}
 	}
-
-	componentWillUnmount() {
-		MediaStore.off( 'change', this.updateImageState );
-	}
-
-	fetchImage = () => {
-		// We may not necessarily need to trigger a network request if we
-		// already have the data for the media item, so first update the state
-		this.updateImageState( () => {
-			if ( this.state.image ) {
-				return;
-			}
-
-			defer( () => {
-				this.props.fetchMediaItem( this.props.siteId, this.props.itemId );
-			} );
-		} );
-	};
-
-	updateImageState = ( callback ) => {
-		const image = MediaStore.get( this.props.siteId, this.props.itemId );
-		this.setState( { image }, () => {
-			if ( 'function' === typeof callback ) {
-				callback();
-			}
-		} );
-
-		defer( () => {
-			if ( this.props.onImageChange && image && image.ID ) {
-				this.props.onImageChange( image.ID );
-			}
-		} );
-	};
 
 	render() {
 		return (
 			<EditorFeaturedImagePreview
-				image={ this.state.image }
+				image={ this.props.image }
 				maxWidth={ this.props.maxWidth }
 				showEditIcon
 			/>
@@ -83,4 +45,10 @@ class EditorFeaturedImagePreviewContainer extends React.Component {
 	}
 }
 
-export default connect( null, { fetchMediaItem } )( EditorFeaturedImagePreviewContainer );
+const mapStateToProps = ( state, { siteId, itemId } ) => ( {
+	image: getMediaItem( state, siteId, itemId ),
+} );
+
+export default connect( mapStateToProps, { fetchMediaItem } )(
+	EditorFeaturedImagePreviewContainer
+);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* EditorFeaturedImagePreviewContainer: Replace `MediaStore.get` with `getMediaItem` redux selector

#### Testing instructions

* Use the classic post editor to create a new post
* Set a featured image (from the right sidebar) and make sure it loads in the preview container (above the post)
* Click on that preview container and change the image, make sure that loads as well

related to #43663
