### PR TITLE
Jetpack Checklist: fixes jetpack checklist not loading:

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
@@ -13,23 +13,11 @@ import { requestSiteChecklistTaskUpdate } from 'state/checklist/actions';
 import { launchSiteOrRedirectToLaunchSignupFlow } from 'state/sites/launch/actions';
 import { localizeUrl } from 'lib/i18n-utils';
 import { verifyEmail } from 'state/current-user/email-verification/actions';
-
-// A list of known tasks for the calypso client/state/data-layer/wpcom/checklist/index.js
-// You need to alter this object in case of adding / removing tasks
-export const SITE_CHECKLIST_KNOWN_TASKS = {
-	START_SITE_SETUP: 'start_site_setup',
-	DOMAIN_VERIFIED: 'domain_verified',
-	EMAIL_VERIFIED: 'email_verified',
-	BLOGNAME_SET: 'blogname_set',
-	MOBILE_APP_INSTALLED: 'mobile_app_installed',
-	SITE_LAUNCHED: 'site_launched',
-	FRONT_PAGE_UPDATED: 'front_page_updated',
-	SITE_MENU_UPDATED: 'site_menu_updated',
-};
+import { CHECKLIST_KNOWN_TASKS } from 'state/data-layer/wpcom/checklist/index.js';
 
 const getTaskDescription = ( task, { isDomainUnverified, isEmailUnverified } ) => {
 	switch ( task.id ) {
-		case SITE_CHECKLIST_KNOWN_TASKS.SITE_LAUNCHED:
+		case CHECKLIST_KNOWN_TASKS.SITE_LAUNCHED:
 			if ( isDomainUnverified ) {
 				return (
 					<>
@@ -61,9 +49,9 @@ const isTaskDisabled = (
 	{ emailVerificationStatus, isDomainUnverified, isEmailUnverified }
 ) => {
 	switch ( task.id ) {
-		case SITE_CHECKLIST_KNOWN_TASKS.EMAIL_VERIFIED:
+		case CHECKLIST_KNOWN_TASKS.EMAIL_VERIFIED:
 			return 'requesting' === emailVerificationStatus || ! isEmailUnverified;
-		case SITE_CHECKLIST_KNOWN_TASKS.SITE_LAUNCHED:
+		case CHECKLIST_KNOWN_TASKS.SITE_LAUNCHED:
 			return isDomainUnverified || isEmailUnverified;
 		default:
 			return false;
@@ -85,7 +73,7 @@ export const getTask = (
 ) => {
 	let taskData = {};
 	switch ( task.id ) {
-		case SITE_CHECKLIST_KNOWN_TASKS.START_SITE_SETUP:
+		case CHECKLIST_KNOWN_TASKS.START_SITE_SETUP:
 			taskData = {
 				timing: 1,
 				label: translate( 'Site created' ),
@@ -102,7 +90,7 @@ export const getTask = (
 				completeOnView: true,
 			};
 			break;
-		case SITE_CHECKLIST_KNOWN_TASKS.DOMAIN_VERIFIED:
+		case CHECKLIST_KNOWN_TASKS.DOMAIN_VERIFIED:
 			taskData = {
 				timing: 2,
 				title:
@@ -121,7 +109,7 @@ export const getTask = (
 				actionText: translate( 'Verify' ),
 			};
 			break;
-		case SITE_CHECKLIST_KNOWN_TASKS.EMAIL_VERIFIED:
+		case CHECKLIST_KNOWN_TASKS.EMAIL_VERIFIED:
 			taskData = {
 				timing: 1,
 				title: translate( 'Confirm your email address' ),
@@ -143,7 +131,7 @@ export const getTask = (
 				actionDispatchArgs: [ { showGlobalNotices: true } ],
 			};
 			break;
-		case SITE_CHECKLIST_KNOWN_TASKS.BLOGNAME_SET:
+		case CHECKLIST_KNOWN_TASKS.BLOGNAME_SET:
 			taskData = {
 				timing: 1,
 				title: translate( 'Name your site' ),
@@ -155,7 +143,7 @@ export const getTask = (
 				tour: 'checklistSiteTitle',
 			};
 			break;
-		case SITE_CHECKLIST_KNOWN_TASKS.MOBILE_APP_INSTALLED:
+		case CHECKLIST_KNOWN_TASKS.MOBILE_APP_INSTALLED:
 			taskData = {
 				timing: 3,
 				title: translate( 'Get the WordPress app' ),
@@ -171,7 +159,7 @@ export const getTask = (
 				isSkippable: true,
 			};
 			break;
-		case SITE_CHECKLIST_KNOWN_TASKS.SITE_LAUNCHED:
+		case CHECKLIST_KNOWN_TASKS.SITE_LAUNCHED:
 			taskData = {
 				timing: 1,
 				title: translate( 'Launch your site' ),
@@ -184,7 +172,7 @@ export const getTask = (
 				actionDisableOnComplete: true,
 			};
 			break;
-		case SITE_CHECKLIST_KNOWN_TASKS.FRONT_PAGE_UPDATED:
+		case CHECKLIST_KNOWN_TASKS.FRONT_PAGE_UPDATED:
 			taskData = {
 				timing: 20,
 				title: translate( 'Update your Home page' ),
@@ -195,7 +183,7 @@ export const getTask = (
 				actionUrl: taskUrls?.front_page_updated,
 			};
 			break;
-		case SITE_CHECKLIST_KNOWN_TASKS.SITE_MENU_UPDATED:
+		case CHECKLIST_KNOWN_TASKS.SITE_MENU_UPDATED:
 			taskData = {
 				timing: 10,
 				title: translate( 'Create a site menu' ),

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
@@ -30,7 +30,7 @@ import { requestGuidedTour } from 'state/ui/guided-tours/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { skipCurrentViewHomeLayout } from 'state/home/actions';
 import NavItem from './nav-item';
-import { SITE_CHECKLIST_KNOWN_TASKS } from 'my-sites/customer-home/cards/tasks/site-setup-list/get-task';
+import { CHECKLIST_KNOWN_TASKS } from 'state/data-layer/wpcom/checklist/index.js';
 import { getTask } from './get-task';
 
 /**
@@ -120,7 +120,7 @@ const SiteSetupList = ( {
 
 	const isDomainUnverified =
 		tasks.filter(
-			( task ) => task.id === SITE_CHECKLIST_KNOWN_TASKS.DOMAIN_VERIFIED && ! task.isCompleted
+			( task ) => task.id === CHECKLIST_KNOWN_TASKS.DOMAIN_VERIFIED && ! task.isCompleted
 		).length > 0;
 
 	// Move to first incomplete task on first load.

--- a/client/my-sites/plans/current-plan/jetpack-checklist/index.tsx
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/index.tsx
@@ -32,6 +32,7 @@ import { Button, Card } from '@automattic/components';
 import JetpackProductInstall from 'my-sites/plans/current-plan/jetpack-product-install';
 import { getTaskList } from 'lib/checklist';
 import { settingsPath } from 'lib/jetpack/paths';
+import { CHECKLIST_KNOWN_TASKS } from 'state/data-layer/wpcom/checklist/index.js';
 
 /**
  * Style dependencies
@@ -178,7 +179,7 @@ class JetpackChecklist extends PureComponent< Props & LocalizeProps > {
 							completed={ isRewindActive }
 							href={ settingsPath( siteSlug ) }
 							onClick={ this.handleTaskStart( {
-								taskId: 'jetpack_backups',
+								taskId: CHECKLIST_KNOWN_TASKS.JETPACK_BACKUPS,
 								tourId: isRewindActive ? undefined : 'jetpackBackupsRewind',
 							} ) }
 						/>
@@ -193,7 +194,7 @@ class JetpackChecklist extends PureComponent< Props & LocalizeProps > {
 							completed={ vaultpressFinished }
 							href="https://dashboard.vaultpress.com"
 							inProgress={ ! vaultpressFinished }
-							onClick={ this.handleTaskStart( { taskId: 'jetpack_backups' } ) }
+							onClick={ this.handleTaskStart( { taskId: CHECKLIST_KNOWN_TASKS.JETPACK_BACKUPS } ) }
 						/>
 					) }
 
@@ -215,8 +216,8 @@ class JetpackChecklist extends PureComponent< Props & LocalizeProps > {
 					) }
 
 					<Task
-						id="jetpack_monitor"
-						completed={ this.isComplete( 'jetpack_monitor' ) }
+						id={ CHECKLIST_KNOWN_TASKS.JETPACK_MONITOR }
+						completed={ this.isComplete( CHECKLIST_KNOWN_TASKS.JETPACK_MONITOR ) }
 						completedButtonText={ translate( 'Change', { context: 'verb' } ) }
 						completedTitle={ translate( 'You turned on Downtime Monitoring.' ) }
 						description={ translate(
@@ -225,15 +226,15 @@ class JetpackChecklist extends PureComponent< Props & LocalizeProps > {
 						duration={ this.getDuration( 3 ) }
 						href={ `/settings/security/${ siteSlug }` }
 						onClick={ this.handleTaskStart( {
-							taskId: 'jetpack_monitor',
+							taskId: CHECKLIST_KNOWN_TASKS.JETPACK_MONITOR,
 							tourId: 'jetpackMonitoring',
 						} ) }
 						title={ translate( 'Downtime Monitoring' ) }
 					/>
 
 					<Task
-						id="jetpack_plugin_updates"
-						completed={ this.isComplete( 'jetpack_plugin_updates' ) }
+						id={ CHECKLIST_KNOWN_TASKS.JETPACK_PLUGIN_UPDATES }
+						completed={ this.isComplete( CHECKLIST_KNOWN_TASKS.JETPACK_PLUGIN_UPDATES ) }
 						completedButtonText={ translate( 'Change', { context: 'verb' } ) }
 						completedTitle={ translate( 'You turned on automatic plugin updates.' ) }
 						description={ translate(
@@ -242,15 +243,15 @@ class JetpackChecklist extends PureComponent< Props & LocalizeProps > {
 						duration={ this.getDuration( 3 ) }
 						href={ `/plugins/manage/${ siteSlug }` }
 						onClick={ this.handleTaskStart( {
-							taskId: 'jetpack_plugin_updates',
+							taskId: CHECKLIST_KNOWN_TASKS.JETPACK_PLUGIN_UPDATES,
 							tourId: 'jetpackPluginUpdates',
 						} ) }
 						title={ translate( 'Automatic Plugin Updates' ) }
 					/>
 
 					<Task
-						id="jetpack_sign_in"
-						completed={ this.isComplete( 'jetpack_sign_in' ) }
+						id={ CHECKLIST_KNOWN_TASKS.JETPACK_SIGN_IN }
+						completed={ this.isComplete( CHECKLIST_KNOWN_TASKS.JETPACK_SIGN_IN ) }
 						completedButtonText={ translate( 'Change', { context: 'verb' } ) }
 						completedTitle={ translate( 'You completed your sign in preferences.' ) }
 						description={ translate(
@@ -259,15 +260,15 @@ class JetpackChecklist extends PureComponent< Props & LocalizeProps > {
 						duration={ this.getDuration( 3 ) }
 						href={ `/settings/security/${ siteSlug }` }
 						onClick={ this.handleTaskStart( {
-							taskId: 'jetpack_sign_in',
+							taskId: CHECKLIST_KNOWN_TASKS.JETPACK_SIGN_IN,
 							tourId: 'jetpackSignIn',
 						} ) }
 						title={ translate( 'WordPress.com sign in' ) }
 					/>
 
 					<Task
-						id="jetpack_site_accelerator"
-						completed={ this.isComplete( 'jetpack_site_accelerator' ) }
+						id={ CHECKLIST_KNOWN_TASKS.JETPACK_SITE_ACCELERATOR }
+						completed={ this.isComplete( CHECKLIST_KNOWN_TASKS.JETPACK_SITE_ACCELERATOR ) }
 						completedButtonText={ translate( 'Configure' ) }
 						completedTitle={ translate(
 							'Site accelerator is serving your images and static files through our global CDN.'
@@ -278,15 +279,15 @@ class JetpackChecklist extends PureComponent< Props & LocalizeProps > {
 						duration={ this.getDuration( 1 ) }
 						href={ `/settings/performance/${ siteSlug }` }
 						onClick={ this.handleTaskStart( {
-							taskId: 'jetpack_site_accelerator',
+							taskId: CHECKLIST_KNOWN_TASKS.JETPACK_SITE_ACCELERATOR,
 							tourId: 'jetpackSiteAccelerator',
 						} ) }
 						title={ translate( 'Site Accelerator' ) }
 					/>
 
 					<Task
-						id="jetpack_lazy_images"
-						completed={ this.isComplete( 'jetpack_lazy_images' ) }
+						id={ CHECKLIST_KNOWN_TASKS.JETPACK_LAZY_IMAGES }
+						completed={ this.isComplete( CHECKLIST_KNOWN_TASKS.JETPACK_LAZY_IMAGES ) }
 						completedButtonText={ translate( 'Upload images' ) }
 						completedTitle={ translate( 'Lazy load images is improving your site speed.' ) }
 						description={ translate(
@@ -294,12 +295,12 @@ class JetpackChecklist extends PureComponent< Props & LocalizeProps > {
 						) }
 						duration={ this.getDuration( 1 ) }
 						href={
-							this.isComplete( 'jetpack_lazy_images' )
+							this.isComplete( CHECKLIST_KNOWN_TASKS.JETPACK_LAZY_IMAGES )
 								? `/media/${ siteSlug }`
 								: `/settings/performance/${ siteSlug }`
 						}
 						onClick={ this.handleTaskStart( {
-							taskId: 'jetpack_lazy_images',
+							taskId: CHECKLIST_KNOWN_TASKS.JETPACK_LAZY_IMAGES,
 							tourId: 'jetpackLazyImages',
 						} ) }
 						title={ translate( 'Lazy Load Images' ) }
@@ -307,24 +308,24 @@ class JetpackChecklist extends PureComponent< Props & LocalizeProps > {
 
 					{ ( isPremium || isProfessional ) && (
 						<Task
-							id="jetpack_video_hosting"
+							id={ CHECKLIST_KNOWN_TASKS.JETPACK_VIDEO_HOSTING }
 							title={ translate( 'Video Hosting' ) }
 							description={ translate(
 								'Enable fast, high-definition, ad-free video hosting through our global CDN network.'
 							) }
-							completed={ this.isComplete( 'jetpack_video_hosting' ) }
+							completed={ this.isComplete( CHECKLIST_KNOWN_TASKS.JETPACK_VIDEO_HOSTING ) }
 							completedButtonText={ translate( 'Upload videos' ) }
 							completedTitle={ translate(
 								'High-speed, high-definition, and ad-free video hosting is enabled.'
 							) }
 							duration={ this.getDuration( 3 ) }
 							href={
-								this.isComplete( 'jetpack_video_hosting' )
+								this.isComplete( CHECKLIST_KNOWN_TASKS.JETPACK_VIDEO_HOSTING )
 									? `/media/videos/${ siteSlug }`
 									: `/settings/performance/${ siteSlug }`
 							}
 							onClick={ this.handleTaskStart( {
-								taskId: 'jetpack_video_hosting',
+								taskId: CHECKLIST_KNOWN_TASKS.JETPACK_VIDEO_HOSTING,
 								tourId: 'jetpackVideoHosting',
 							} ) }
 						/>
@@ -332,7 +333,7 @@ class JetpackChecklist extends PureComponent< Props & LocalizeProps > {
 
 					{ isProfessional && (
 						<Task
-							id="jetpack_search"
+							id={ CHECKLIST_KNOWN_TASKS.JETPACK_SEARCH }
 							title={ translate( 'Enhanced Search' ) }
 							description={ translate(
 								'Activate an enhanced, customizable search to replace the default WordPress search feature.'
@@ -342,14 +343,14 @@ class JetpackChecklist extends PureComponent< Props & LocalizeProps > {
 								'The default WordPress search has been replaced by Enhanced Search.'
 							) }
 							duration={ this.getDuration( 1 ) }
-							completed={ this.isComplete( 'jetpack_search' ) }
+							completed={ this.isComplete( CHECKLIST_KNOWN_TASKS.JETPACK_SEARCH ) }
 							href={
-								this.isComplete( 'jetpack_search' )
+								this.isComplete( CHECKLIST_KNOWN_TASKS.JETPACK_SEARCH )
 									? this.props.widgetCustomizerPaneUrl
 									: `/settings/performance/${ siteSlug }`
 							}
 							onClick={ this.handleTaskStart( {
-								taskId: 'jetpack_search',
+								taskId: CHECKLIST_KNOWN_TASKS.JETPACK_SEARCH,
 								tourId: 'jetpackSearch',
 							} ) }
 						/>

--- a/client/state/checklist/reducer.js
+++ b/client/state/checklist/reducer.js
@@ -9,6 +9,7 @@ import {
 	SITE_CHECKLIST_TASK_UPDATE,
 } from 'state/action-types';
 import { items as itemSchemas } from './schema';
+import { CHECKLIST_KNOWN_TASKS } from 'state/data-layer/wpcom/checklist/index.js';
 
 const setChecklistTaskCompletion = ( state, taskId, completed ) => ( {
 	...state,
@@ -18,13 +19,13 @@ const setChecklistTaskCompletion = ( state, taskId, completed ) => ( {
 } );
 
 const moduleTaskMap = {
-	'lazy-images': 'jetpack_lazy_images',
-	monitor: 'jetpack_monitor',
+	'lazy-images': CHECKLIST_KNOWN_TASKS.JETPACK_LAZY_IMAGES,
+	monitor: CHECKLIST_KNOWN_TASKS.JETPACK_MONITOR,
 	// Both photon and photon-cdn mark the Site Accelerator Task as completed
-	photon: 'jetpack_site_accelerator',
-	'photon-cdn': 'jetpack_site_accelerator',
-	search: 'jetpack_search',
-	videopress: 'jetpack_video_hosting',
+	photon: CHECKLIST_KNOWN_TASKS.JETPACK_SITE_ACCELERATOR,
+	'photon-cdn': CHECKLIST_KNOWN_TASKS.JETPACK_SITE_ACCELERATOR,
+	search: CHECKLIST_KNOWN_TASKS.JETPACK_SEARCH,
+	videopress: CHECKLIST_KNOWN_TASKS.JETPACK_VIDEO_HOSTING,
 };
 
 const items = withSchemaValidation( itemSchemas, ( state = {}, action ) => {

--- a/client/state/selectors/is-site-checklist-complete.js
+++ b/client/state/selectors/is-site-checklist-complete.js
@@ -5,7 +5,7 @@ import getSiteTaskList from 'state/selectors/get-site-task-list';
 import getSiteChecklist from 'state/selectors/get-site-checklist';
 import isSiteChecklistLoading from 'state/selectors/is-site-checklist-loading';
 import { getSiteFrontPage } from 'state/sites/selectors';
-import { SITE_CHECKLIST_KNOWN_TASKS } from 'my-sites/customer-home/cards/tasks/site-setup-list/get-task';
+import { CHECKLIST_KNOWN_TASKS } from 'state/data-layer/wpcom/checklist/index.js';
 
 /**
  * Checks whether the tasklist has been completed.
@@ -43,7 +43,7 @@ export default function isSiteChecklistComplete( state, siteId ) {
 			return true;
 		}
 
-		if ( SITE_CHECKLIST_KNOWN_TASKS.FRONT_PAGE_UPDATED === task.id && ! hasFrontPageSet ) {
+		if ( CHECKLIST_KNOWN_TASKS.FRONT_PAGE_UPDATED === task.id && ! hasFrontPageSet ) {
 			return true;
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* reinstate transforming jetpack tasks object to array
* whitelist jetpack tasks
* declare tasks centrally in `client/state/data-layer/wpcom/checklist/index.js` 

#### Testing instructions
**Jetpack Checklist**
1. Open a jetpack enabled site (not atomic) in http://calypso.localhost:3000/
2. Go to Plans -> My Plan
3. Check that `My Checklist` is loading

![](https://cln.sh/ujzVED+)

**Site Checklist**
1. Create a new free site
2. Go to My Home
3. Check that the Site Checklist loads

![](https://cln.sh/ayx5ad+)

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


Fixes #44099
