### PR TITLE
WooDNA: Use the correct Woo-branded messaging in the Jetpack Connection flow even if the connection comes from a partner host like Pressable

### DIFF
--- a/client/jetpack-connect/auth-form-header.jsx
+++ b/client/jetpack-connect/auth-form-header.jsx
@@ -57,6 +57,10 @@ export class AuthFormHeader extends Component {
 	getHeaderText() {
 		const { translate, partnerSlug, isWoo, wooDnaConfig } = this.props;
 
+		if ( wooDnaConfig && wooDnaConfig.isWooDnaFlow() ) {
+			return wooDnaConfig.getServiceName();
+		}
+
 		let host = '';
 		switch ( partnerSlug ) {
 			case 'dreamhost':
@@ -92,10 +96,6 @@ export class AuthFormHeader extends Component {
 				default:
 					return translate( 'Connecting your store' );
 			}
-		}
-
-		if ( wooDnaConfig && wooDnaConfig.isWooDnaFlow() ) {
-			return wooDnaConfig.getServiceName();
 		}
 
 		switch ( currentState ) {


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/761

#### Changes proposed in this Pull Request

On the Jetpack Connection screens, made the "Woo-branded" title/header/subtitle messages have a higher priority than partner-related messages. So, if a site is on Pressable **and** is connecting WooCommerce Payments, the messages used will be the WooCommerce Payments ones, not the Pressable-related ones.

#### Testing instructions

- Create a Pressable site. Alternatively, if you have setup the whole flow including a `wpcom` sandbox, DM me and I'll give you an easier way to test this without having to create a Pressable site.
- Install WooCommerce Payments and go through the Jetpack connection flow. If you're testing this on a local Calypso environment, you'll need to add `define( 'WOOCOMMERCE_CALYPSO_ENVIRONMENT', 'development' );` to your WordPress site.

On `master`, you'd see something like the screenshot on https://github.com/Automattic/woocommerce-payments/issues/761.
On this branch, you'll see the expected `WooCommerce Payments / Authorize your connection`.