### PR TITLE
Fix signup flows with a login step

### DIFF
--- a/client/state/test/initial-state.js
+++ b/client/state/test/initial-state.js
@@ -409,135 +409,6 @@ describe( 'initial-state', () => {
 					expect( state._timestamp ).toBeUndefined();
 				} );
 			} );
-
-			describe( 'with empty persisted signup state for logged in user, and persisted state for logged out user', () => {
-				let state, consoleErrorSpy, getStoredItemSpy;
-
-				const _timestamp = Date.now();
-				const storedState = {
-					'redux-state-logged-out:signup': {
-						dependencyStore: {
-							siteType: 'blog',
-							siteTitle: 'Logged out test title',
-						},
-						progress: {
-							'logged-out-step': {
-								stepName: 'logged-out-step',
-								status: 'completed',
-							},
-						},
-						_timestamp,
-					},
-				};
-				const serverState = {};
-
-				beforeAll( async () => {
-					isEnabled.enablePersistRedux();
-					window.initialReduxState = serverState;
-					consoleErrorSpy = jest.spyOn( global.console, 'error' );
-					getStoredItemSpy = jest
-						.spyOn( browserStorage, 'getAllStoredItems' )
-						.mockResolvedValue( storedState );
-
-					await loadAllState();
-					state = getInitialState( combineReducers( { signup: signupReducer } ) );
-				} );
-
-				afterAll( () => {
-					window.initialReduxState = null;
-					isEnabled.disablePersistRedux();
-					consoleErrorSpy.mockRestore();
-					getStoredItemSpy.mockRestore();
-				} );
-
-				test( 'builds initial state without errors', () => {
-					expect( consoleErrorSpy ).not.toHaveBeenCalled();
-				} );
-
-				test( 'builds initial signup state from logged out state', () => {
-					expect( state.signup.dependencyStore ).toEqual(
-						storedState[ 'redux-state-logged-out:signup' ].dependencyStore
-					);
-					expect( state.signup.progress ).toEqual(
-						storedState[ 'redux-state-logged-out:signup' ].progress
-					);
-				} );
-
-				test( 'does not add timestamp to initial state', () => {
-					expect( state._timestamp ).toBeUndefined();
-				} );
-			} );
-
-			describe( 'with existing persisted signup state for logged in user, and persisted state for logged out user', () => {
-				let state, consoleErrorSpy, getStoredItemSpy;
-
-				const _timestamp = Date.now();
-				const storedState = {
-					'redux-state-123456789:signup': {
-						dependencyStore: {
-							siteType: 'blog',
-							siteTitle: 'Logged in test title',
-						},
-						progress: {
-							'logged-in-step': {
-								stepName: 'logged-in-step',
-								status: 'completed',
-							},
-						},
-						_timestamp,
-					},
-					'redux-state-logged-out:signup': {
-						dependencyStore: {
-							siteType: 'blog',
-							siteTitle: 'Logged out test title',
-						},
-						progress: {
-							'logged-out-step': {
-								stepName: 'logged-out-step',
-								status: 'completed',
-							},
-						},
-						_timestamp,
-					},
-				};
-				const serverState = {};
-
-				beforeAll( async () => {
-					isEnabled.enablePersistRedux();
-					window.initialReduxState = serverState;
-					consoleErrorSpy = jest.spyOn( global.console, 'error' );
-					getStoredItemSpy = jest
-						.spyOn( browserStorage, 'getAllStoredItems' )
-						.mockResolvedValue( storedState );
-
-					await loadAllState();
-					state = getInitialState( combineReducers( { signup: signupReducer } ) );
-				} );
-
-				afterAll( () => {
-					window.initialReduxState = null;
-					isEnabled.disablePersistRedux();
-					consoleErrorSpy.mockRestore();
-					getStoredItemSpy.mockRestore();
-				} );
-
-				test( 'builds initial state without errors', () => {
-					expect( consoleErrorSpy ).not.toHaveBeenCalled();
-				} );
-
-				test( 'builds initial signup state from logged in state', () => {
-					expect( state.signup.dependencyStore ).toEqual(
-						storedState[ 'redux-state-123456789:signup' ].dependencyStore
-					);
-					expect( state.signup.progress ).toEqual(
-						storedState[ 'redux-state-123456789:signup' ].progress
-					);
-				} );
-
-				test( 'does not add timestamp to initial state', () => {
-					expect( state._timestamp ).toBeUndefined();
-				} );
-			} );
 		} );
 	} );
 
@@ -716,6 +587,131 @@ describe( 'initial-state', () => {
 
 			test( 'builds initial state using saved state', () => {
 				expect( state.organizations.items ).toEqual( [ { id: 1, slug: 'saved' } ] );
+			} );
+		} );
+
+		describe( 'with empty persisted signup state for logged in user, and persisted state for logged out user', () => {
+			let state, consoleErrorSpy, getStoredItemSpy;
+
+			const _timestamp = Date.now();
+			const storedState = {
+				'redux-state-logged-out:signup': {
+					dependencyStore: {
+						siteType: 'blog',
+						siteTitle: 'Logged out test title',
+					},
+					progress: {
+						'logged-out-step': {
+							stepName: 'logged-out-step',
+							status: 'completed',
+						},
+					},
+					_timestamp,
+				},
+			};
+			const serverState = {};
+
+			beforeAll( async () => {
+				isEnabled.enablePersistRedux();
+				window.initialReduxState = serverState;
+				consoleErrorSpy = jest.spyOn( global.console, 'error' );
+				getStoredItemSpy = jest
+					.spyOn( browserStorage, 'getAllStoredItems' )
+					.mockResolvedValue( storedState );
+
+				await loadAllState();
+				state = getStateFromCache( signupReducer, 'signup' );
+			} );
+
+			afterAll( () => {
+				window.initialReduxState = null;
+				isEnabled.disablePersistRedux();
+				consoleErrorSpy.mockRestore();
+				getStoredItemSpy.mockRestore();
+			} );
+
+			test( 'builds initial state without errors', () => {
+				expect( consoleErrorSpy ).not.toHaveBeenCalled();
+			} );
+
+			test( 'builds initial signup state from logged out state', () => {
+				expect( state.dependencyStore ).toEqual(
+					storedState[ 'redux-state-logged-out:signup' ].dependencyStore
+				);
+				expect( state.progress ).toEqual( storedState[ 'redux-state-logged-out:signup' ].progress );
+			} );
+
+			test( 'does not add timestamp to initial state', () => {
+				expect( state._timestamp ).toBeUndefined();
+			} );
+		} );
+
+		describe( 'with existing persisted signup state for logged in user, and persisted state for logged out user', () => {
+			let state, consoleErrorSpy, getStoredItemSpy;
+
+			const _timestamp = Date.now();
+			const storedState = {
+				'redux-state-123456789:signup': {
+					dependencyStore: {
+						siteType: 'blog',
+						siteTitle: 'Logged in test title',
+					},
+					progress: {
+						'logged-in-step': {
+							stepName: 'logged-in-step',
+							status: 'completed',
+						},
+					},
+					_timestamp,
+				},
+				'redux-state-logged-out:signup': {
+					dependencyStore: {
+						siteType: 'blog',
+						siteTitle: 'Logged out test title',
+					},
+					progress: {
+						'logged-out-step': {
+							stepName: 'logged-out-step',
+							status: 'completed',
+						},
+					},
+					_timestamp,
+				},
+			};
+			const serverState = {};
+
+			beforeAll( async () => {
+				isEnabled.enablePersistRedux();
+				window.initialReduxState = serverState;
+				consoleErrorSpy = jest.spyOn( global.console, 'error' );
+				getStoredItemSpy = jest
+					.spyOn( browserStorage, 'getAllStoredItems' )
+					.mockResolvedValue( storedState );
+
+				await loadAllState();
+				state = getStateFromCache( signupReducer, 'signup' );
+			} );
+
+			afterAll( () => {
+				window.initialReduxState = null;
+				isEnabled.disablePersistRedux();
+				consoleErrorSpy.mockRestore();
+				getStoredItemSpy.mockRestore();
+			} );
+
+			test( 'builds initial state without errors', () => {
+				expect( consoleErrorSpy ).not.toHaveBeenCalled();
+			} );
+
+			test( 'builds initial signup state from logged in state', () => {
+				expect( state.dependencyStore ).toEqual(
+					storedState[ 'redux-state-123456789:signup' ].dependencyStore
+				);
+				expect( state.progress ).toEqual( storedState[ 'redux-state-123456789:signup' ].progress );
+			} );
+
+			test( 'does not add timestamp to initial state', () => {
+				expect( state._timestamp ).toBeUndefined();
 			} );
 		} );
 	} );


### PR DESCRIPTION
Signup state requires a special case, where state gets loaded from the logged-out persisted state when the logged-in one is empty. This is done to enable signup flows where the user starts out logged out, but logs in as part of the process.

When signup state was modularised, this special handling remained in the portion of code that handles legacy state, rather than being moved to the portion that handles modularised state. This caused the previously mentioned flows to break.

This PR fixes that.

#### Changes proposed in this Pull Request

* Move signup special case from legacy state handling to modularised state handling

#### Testing instructions

IMPORTANT NOTE: Do not test this in development. Development has a 25% chance of clearing persisted state as a way of detecting some classes of bugs, a feature which interferes with the normal behaviour of this flow. Please use the live branch instead.

* Start as a logged-out user
* Go to `/start/p2/p2-site`
* Fill in the form
* Click "Continue"
* Click "Already have a WordPress.com account?"
* Log in
* Verify that you are redirected to a congratulation page, rather than the initial form.
