### PR TITLE
i18n: Rewrite paths for modules from packages when matching chunk with POT refs

### DIFF
--- a/bin/build-languages.js
+++ b/bin/build-languages.js
@@ -147,6 +147,19 @@ function createLanguagesDir() {
 	return languagesPaths.forEach( ( { publicPath } ) => mkdirp.sync( publicPath ) );
 }
 
+// Get module reference
+function getModuleRefenrece( module ) {
+	// Rewrite module from `packages/` to match references in POT
+	if ( module.indexOf( 'packages/' ) === 0 ) {
+		return module
+			.replace( /^packages\//, '' )
+			.replace( '/dist/esm/', '/src/' )
+			.replace( /\.\w+/, '' );
+	}
+
+	return module;
+}
+
 // Download languages revisions
 function downloadLanguagesRevions() {
 	return new Promise( ( resolve ) => {
@@ -264,7 +277,9 @@ function buildLanguageChunks( downloadedLanguages, languageRevisions ) {
 			const chunks = _.mapValues( chunksMap, ( modules ) => {
 				return _.chain( translationsFlatten )
 					.pickBy( ( { comments } ) =>
-						modules.some( ( module ) => ( comments.reference || '' ).includes( module ) )
+						modules.some( ( module ) => {
+							return ( comments.reference || '' ).includes( getModuleRefenrece( module ) );
+						} )
 					)
 					.keys()
 					.value();

--- a/bin/build-languages.js
+++ b/bin/build-languages.js
@@ -148,7 +148,7 @@ function createLanguagesDir() {
 }
 
 // Get module reference
-function getModuleRefenrece( module ) {
+function getModuleReference( module ) {
 	// Rewrite module from `packages/` to match references in POT
 	if ( module.indexOf( 'packages/' ) === 0 ) {
 		return module
@@ -297,7 +297,7 @@ function buildLanguageChunks( downloadedLanguages, languageRevisions ) {
 				const strings = new Set();
 
 				modules.forEach( ( modulePath ) => {
-					modulePath = getModuleRefenrece( modulePath );
+					modulePath = getModuleReference( modulePath );
 					const key = /\.\w+/.test( modulePath )
 						? modulePath
 						: Object.keys( translationsByRef ).find( ( ref ) => ref.indexOf( modulePath ) === 0 );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Rewrite paths for modules from packages when matching chunk with POT refs

#### Testing instructions

Run `CALYPSO_ENV=production BUILD_TRANSLATION_CHUNKS=true yarn run build` and confirm translation chunks in `public/evergreen/languages` contain strings from `packages/**`, e.g. look for strings from `packages/composite-checkout`.