### PR TITLE
Activity Log: Hide alt-text overflow for broken images

### DIFF
--- a/client/my-sites/activity/activity-log-item/style.scss
+++ b/client/my-sites/activity/activity-log-item/style.scss
@@ -395,6 +395,8 @@
 	height: auto;
 	max-width: 48px;
 	max-height: 48px;
+	overflow: hidden;
+	font-size: $font-body-small;
 }
 
 .activity-log-item__activity-media .is-full-width {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Hide text overflow for Activity Log thumbnails, so that their alt text doesn't create large chunks of confusing whitespace.
* Make the font size for Activity Log thumbnails small, so their alt text is sized consistently with the rest of the UI when highlighted/visible.

#### Testing instructions

* On a Jetpack site with Activity Log (preferably one with a custom 404 page), attach at least two pieces of media to a post and make their alternative text very long.
* Make the URL for that media unreachable by our CDN, by deleting or moving it **outside the WordPress interface.**
* Visit the site's Activity Log and find the media attachment event for the media you added.
* Verify that broken image thumbnails do not take up any extra space.
* Verify that working image thumbnails still display as before.

#### Screenshots

##### Before

<img width="1058" alt="Screen Shot 2020-07-13 at 12 54 07" src="https://user-images.githubusercontent.com/670067/87337362-ecb64580-c508-11ea-880f-2682442b886e.png">

##### After

<img width="1045" alt="Screen Shot 2020-07-13 at 12 54 43" src="https://user-images.githubusercontent.com/670067/87337337-e58f3780-c508-11ea-8973-730710d30ac2.png">