### PR TITLE
Support dedicated /me/security UI to change email address 

### DIFF
--- a/client/components/data/query-user-settings/index.jsx
+++ b/client/components/data/query-user-settings/index.jsx
@@ -4,6 +4,7 @@
 
 import { Component } from 'react';
 import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
@@ -11,8 +12,12 @@ import { connect } from 'react-redux';
 import { fetchUserSettings } from 'state/user-settings/actions';
 
 class QueryUserSettings extends Component {
+	static propTypes = {
+		onError: PropTypes.func,
+	};
+
 	UNSAFE_componentWillMount() {
-		this.props.fetchUserSettings();
+		this.props.fetchUserSettings( this.props.onError );
 	}
 
 	render() {

--- a/client/me/account/email-address.jsx
+++ b/client/me/account/email-address.jsx
@@ -68,6 +68,13 @@ class AccountSettingsEmailAddress extends React.Component {
 		return props.originalEmailAddress;
 	}
 
+	getOriginalEmailAddress( props ) {
+		if ( props.userSettings ) {
+			return props.userSettings.getOriginalSetting( 'user_email' );
+		}
+		return props.originalEmailAddress;
+	}
+
 	getPendingEmailAddress( props ) {
 		if ( props.userSettings ) {
 			if ( props.userSettings.isPendingEmailChange() ) {
@@ -239,7 +246,11 @@ class AccountSettingsEmailAddress extends React.Component {
 			<FormFieldset>
 				<FormLabel htmlFor="user_email">{ translate( 'Email address' ) }</FormLabel>
 				<FormTextInput
-					disabled={ this.hasPendingEmailChange( this.props ) || isSubmitting() }
+					disabled={
+						this.hasPendingEmailChange( this.props ) ||
+						isSubmitting() ||
+						null === this.getOriginalEmailAddress( this.props )
+					}
 					id="user_email"
 					name="user_email"
 					isError={ !! this.state.emailValidationError }

--- a/client/me/account/email-address.jsx
+++ b/client/me/account/email-address.jsx
@@ -1,0 +1,248 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import emailValidator from 'email-validator';
+import { localize } from 'i18n-calypso';
+import { noop } from 'lodash-es';
+
+/**
+ * Internal dependencies
+ */
+import { cancelPendingEmailChange, setUserSetting } from 'state/user-settings/actions';
+import FormTextInput from 'components/forms/form-text-input';
+import FormTextValidation from 'components/forms/form-input-validation';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormLabel from 'components/forms/form-label';
+import FormSettingExplanation from 'components/forms/form-setting-explanation';
+import getUnsavedUserSettings from 'state/selectors/get-unsaved-user-settings';
+import getUserSetting from 'state/selectors/get-user-setting';
+import isPendingEmailChange from 'state/selectors/is-pending-email-change';
+import Notice from 'components/notice';
+import NoticeAction from 'components/notice/notice-action';
+
+class AccountSettingsEmailAddress extends React.Component {
+	static propTypes = {
+		debug: PropTypes.func,
+		emailValidationListener: PropTypes.func,
+		errorNotice: PropTypes.func.isRequired,
+		focusHandler: PropTypes.func,
+		isSubmitting: PropTypes.func.isRequired,
+		successNotice: PropTypes.func.isRequired,
+		translate: PropTypes.func.isRequired,
+		userSettings: PropTypes.object,
+	};
+
+	static defaultProps = {
+		debug: noop,
+		focusHandler: noop,
+	};
+
+	constructor( props ) {
+		super( props );
+		this.state = {
+			emailValidationError: false,
+			initialHasPendingEmailChange: this.hasPendingEmailChange( props ),
+			isCancellingPendingEmailChange: false,
+		};
+		this.cancelEmailChange = this.cancelEmailChange.bind( this );
+		this.updateEmailAddress = this.updateEmailAddress.bind( this );
+		props.emailValidationListener && props.emailValidationListener( true );
+	}
+
+	getEmailAddress( props ) {
+		if ( this.hasPendingEmailChange( props ) ) {
+			return this.getPendingEmailAddress( props );
+		}
+		if ( props.userSettings ) {
+			return props.userSettings.getSetting( 'user_email' );
+		}
+		if ( props.unsavedUserSettings && props.unsavedUserSettings.user_email ) {
+			return props.unsavedUserSettings.user_email;
+		}
+		return props.userEmailAddress;
+	}
+
+	getPendingEmailAddress( props ) {
+		if ( props.userSettings ) {
+			if ( props.userSettings.isPendingEmailChange() ) {
+				return props.userSettings.getSetting( 'new_user_email' );
+			}
+			return null;
+		}
+		if ( props.hasPendingEmailChange ) {
+			return props.pendingEmailAddress;
+		}
+		return null;
+	}
+
+	hasPendingEmailChange( props ) {
+		// Rely on userSettings when we have them; fall back on state if not.
+		return props.userSettings
+			? props.userSettings.isPendingEmailChange()
+			: props.hasPendingEmailChange;
+	}
+
+	cancelEmailChange() {
+		const { debug, errorNotice, successNotice, translate, userSettings } = this.props;
+		this.setState( { isCancellingPendingEmailChange: true } );
+		const errorMessage = translate(
+			'There was a problem canceling the email change. Please, try again.'
+		);
+		if ( userSettings ) {
+			const thisComponent = this;
+			userSettings.cancelPendingEmailChange( ( error, response ) => {
+				const newState = {
+					isCancellingPendingEmailChange: false,
+				};
+				if ( error ) {
+					debug( 'Error canceling email change: ' + JSON.stringify( error ) );
+					errorNotice( errorMessage );
+				} else {
+					newState.initialHasPendingEmailChange = false;
+					debug( JSON.stringify( 'Email change canceled successfully' + response ) );
+					successNotice( thisComponent.getCancelEmailChangeSuccessMessage() );
+				}
+				thisComponent.setState( newState );
+			} );
+			return;
+		}
+
+		this.props.cancelPendingEmailChange( () => {
+			this.setState( { isCancellingPendingEmailChange: false } );
+			errorNotice( errorMessage );
+		} );
+	}
+
+	getCancelEmailChangeSuccessMessage() {
+		return this.props.translate( 'The email change has been successfully canceled.' );
+	}
+
+	updateEmailAddress( event ) {
+		const { value } = event.target;
+		const { emailValidationListener, userSettings } = this.props;
+		const emailValidationError =
+			( '' === value && 'empty' ) || ( ! emailValidator.validate( value ) && 'invalid' ) || false;
+		this.setState( { emailValidationError } );
+		emailValidationListener && emailValidationListener( ! emailValidationError );
+
+		if ( userSettings ) {
+			userSettings.updateSetting( 'user_email', value );
+		} else {
+			this.props.setUserSetting( 'user_email', value );
+		}
+	}
+
+	checkCancelEmailChangeSuccess() {
+		// Add a sanity check for cases where we cancelled a pending email change,
+		// but only discover that as a result of an update to our props connected
+		// to the relevant state.
+		const { successNotice } = this.props;
+		if (
+			! this.state.isCancellingPendingEmailChange ||
+			this.hasPendingEmailChange( this.props ) ||
+			! this.state.initialHasPendingEmailChange
+		) {
+			return;
+		}
+		this.setState( { isCancellingPendingEmailChange: false, initialHasPendingEmailChange: false } );
+		successNotice( this.getCancelEmailChangeSuccessMessage() );
+	}
+
+	renderEmailValidation() {
+		const { translate, unsavedUserSettings, userSettings } = this.props;
+
+		let unsaved_email;
+		if ( userSettings ) {
+			if ( ! userSettings.isSettingUnsaved( 'user_email' ) ) {
+				return null;
+			}
+			unsaved_email = userSettings.getSetting( 'user_email' );
+		} else {
+			if ( ! unsavedUserSettings || ! unsavedUserSettings.user_email ) {
+				return null;
+			}
+			unsaved_email = unsavedUserSettings.user_email;
+		}
+
+		if ( ! this.state.emailValidationError ) {
+			return null;
+		}
+
+		let notice;
+		switch ( this.state.emailValidationError ) {
+			case 'invalid':
+				notice = translate( '%(email)s is not a valid email address.', {
+					args: { email: unsaved_email },
+				} );
+				break;
+			case 'empty':
+				notice = translate( 'Email address can not be empty.' );
+				break;
+		}
+
+		return <FormTextValidation isError={ true } text={ notice } />;
+	}
+
+	renderPendingEmailChange() {
+		const { translate } = this.props;
+
+		if ( ! this.hasPendingEmailChange( this.props ) ) {
+			return null;
+		}
+
+		return (
+			<Notice
+				showDismiss={ false }
+				status="is-info"
+				text={ translate(
+					'There is a pending change of your email to %(email)s. Please check your inbox for a confirmation link.',
+					{
+						args: {
+							email: this.getPendingEmailAddress( this.props ),
+						},
+					}
+				) }
+			>
+				<NoticeAction onClick={ this.cancelEmailChange }>{ translate( 'Cancel' ) }</NoticeAction>
+			</Notice>
+		);
+	}
+
+	render() {
+		this.checkCancelEmailChangeSuccess();
+		const { focusHandler, isSubmitting, translate } = this.props;
+		const emailAddress = this.getEmailAddress( this.props ) || '';
+		return (
+			<FormFieldset>
+				<FormLabel htmlFor="user_email">{ translate( 'Email address' ) }</FormLabel>
+				<FormTextInput
+					disabled={ this.hasPendingEmailChange( this.props ) || isSubmitting() }
+					id="user_email"
+					name="user_email"
+					isError={ !! this.state.emailValidationError }
+					onFocus={ focusHandler || noop }
+					value={ emailAddress }
+					onChange={ this.updateEmailAddress }
+				/>
+				{ this.renderEmailValidation() }
+				{ this.renderPendingEmailChange() }
+				<FormSettingExplanation>
+					{ translate( 'Will not be publicly displayed' ) }
+				</FormSettingExplanation>
+			</FormFieldset>
+		);
+	}
+}
+
+export default connect(
+	( state ) => ( {
+		hasPendingEmailChange: isPendingEmailChange( state ),
+		pendingEmailAddress: getUserSetting( state, 'new_user_email' ),
+		unsavedUserSettings: getUnsavedUserSettings( state ),
+		userEmailAddress: getUserSetting( state, 'user_email' ),
+	} ),
+	{ cancelPendingEmailChange, setUserSetting }
+)( localize( AccountSettingsEmailAddress ) );

--- a/client/me/account/email-address.jsx
+++ b/client/me/account/email-address.jsx
@@ -62,7 +62,7 @@ class AccountSettingsEmailAddress extends React.Component {
 		if ( props.userSettings ) {
 			return props.userSettings.getSetting( 'user_email' );
 		}
-		if ( props.unsavedUserSettings && props.unsavedUserSettings.user_email ) {
+		if ( props.unsavedUserSettings && typeof props.unsavedUserSettings.user_email === 'string' ) {
 			return props.unsavedUserSettings.user_email;
 		}
 		return props.originalEmailAddress;

--- a/client/me/account/email-address.jsx
+++ b/client/me/account/email-address.jsx
@@ -49,7 +49,7 @@ class AccountSettingsEmailAddress extends React.Component {
 		};
 		this.cancelEmailChange = this.cancelEmailChange.bind( this );
 		this.updateEmailAddress = this.updateEmailAddress.bind( this );
-		props.emailValidationListener && props.emailValidationListener( true );
+		props.emailValidationListener && props.emailValidationListener( false );
 	}
 
 	getEmailAddress( props ) {
@@ -126,7 +126,7 @@ class AccountSettingsEmailAddress extends React.Component {
 		const emailValidationError =
 			( '' === value && 'empty' ) || ( ! emailValidator.validate( value ) && 'invalid' ) || false;
 		this.setState( { emailValidationError } );
-		emailValidationListener && emailValidationListener( ! emailValidationError );
+		emailValidationListener && emailValidationListener( false !== emailValidationError );
 
 		if ( userSettings ) {
 			userSettings.updateSetting( 'user_email', value );

--- a/client/me/account/email-address.jsx
+++ b/client/me/account/email-address.jsx
@@ -180,17 +180,17 @@ class AccountSettingsEmailAddress extends React.Component {
 	renderEmailValidation() {
 		const { translate, unsavedUserSettings, userSettings } = this.props;
 
-		let unsaved_email;
+		let unsavedEmail;
 		if ( userSettings ) {
 			if ( ! userSettings.isSettingUnsaved( 'user_email' ) ) {
 				return null;
 			}
-			unsaved_email = userSettings.getSetting( 'user_email' );
+			unsavedEmail = userSettings.getSetting( 'user_email' );
 		} else {
 			if ( ! unsavedUserSettings || typeof unsavedUserSettings.user_email !== 'string' ) {
 				return null;
 			}
-			unsaved_email = unsavedUserSettings.user_email;
+			unsavedEmail = unsavedUserSettings.user_email;
 		}
 
 		if ( ! this.state.emailValidationError ) {
@@ -205,7 +205,7 @@ class AccountSettingsEmailAddress extends React.Component {
 			case 'invalid':
 			default:
 				notice = translate( '%(email)s is not a valid email address.', {
-					args: { email: unsaved_email },
+					args: { email: unsavedEmail },
 				} );
 				break;
 		}

--- a/client/me/account/email-address.jsx
+++ b/client/me/account/email-address.jsx
@@ -180,7 +180,7 @@ class AccountSettingsEmailAddress extends React.Component {
 			}
 			unsaved_email = userSettings.getSetting( 'user_email' );
 		} else {
-			if ( ! unsavedUserSettings || ! unsavedUserSettings.user_email ) {
+			if ( ! unsavedUserSettings || typeof unsavedUserSettings.user_email !== 'string' ) {
 				return null;
 			}
 			unsaved_email = unsavedUserSettings.user_email;
@@ -192,13 +192,14 @@ class AccountSettingsEmailAddress extends React.Component {
 
 		let notice;
 		switch ( this.state.emailValidationError ) {
+			case 'empty':
+				notice = translate( 'Email address can not be empty.' );
+				break;
 			case 'invalid':
+			default:
 				notice = translate( '%(email)s is not a valid email address.', {
 					args: { email: unsaved_email },
 				} );
-				break;
-			case 'empty':
-				notice = translate( 'Email address can not be empty.' );
 				break;
 		}
 

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -8,13 +8,13 @@ import TransitionGroup from 'react-transition-group/TransitionGroup';
 import CSSTransition from 'react-transition-group/CSSTransition';
 import { localize } from 'i18n-calypso';
 import debugFactory from 'debug';
-import emailValidator from 'email-validator';
 import { debounce, flowRight as compose, get, has, map, size, update } from 'lodash';
 import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
+import AccountSettingsEmailAddress from './email-address';
 import LanguagePicker from 'components/language-picker';
 import MeSidebarNavigation from 'me/sidebar-navigation';
 import { protectForm } from 'lib/protect-form';
@@ -24,7 +24,6 @@ import { languages } from 'languages';
 import { supportsCssCustomProperties } from 'lib/feature-detection';
 import { Card, Button } from '@automattic/components';
 import FormTextInput from 'components/forms/form-text-input';
-import FormTextValidation from 'components/forms/form-input-validation';
 import FormCheckbox from 'components/forms/form-checkbox';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
@@ -38,7 +37,6 @@ import { recordGoogleEvent, recordTracksEvent, bumpStat } from 'state/analytics/
 import ReauthRequired from 'me/reauth-required';
 import twoStepAuthorization from 'lib/two-step-authorization';
 import Notice from 'components/notice';
-import NoticeAction from 'components/notice/notice-action';
 import observe from 'lib/mixins/data-observe'; // eslint-disable-line no-restricted-imports
 import Main from 'components/main';
 import SitesDropdown from 'components/sites-dropdown';
@@ -158,20 +156,6 @@ const Account = createReactClass( {
 		this.updateUserSetting( colorSchemeKey, colorScheme );
 	},
 
-	getEmailAddress() {
-		return this.hasPendingEmailChange()
-			? this.getUserSetting( 'new_user_email' )
-			: this.getUserSetting( 'user_email' );
-	},
-
-	updateEmailAddress( event ) {
-		const { value } = event.target;
-		const emailValidationError =
-			( '' === value && 'empty' ) || ( ! emailValidator.validate( value ) && 'invalid' ) || false;
-		this.setState( { emailValidationError } );
-		this.updateUserSetting( 'user_email', value );
-	},
-
 	updateUserLoginConfirm( event ) {
 		this.setState( { userLoginConfirm: event.target.value } );
 	},
@@ -182,8 +166,12 @@ const Account = createReactClass( {
 		this.props.username.validate( username );
 	},
 
-	hasEmailValidationError() {
-		return !! this.state.emailValidationError;
+	isEmailInvalid() {
+		return !! this.state.emailIsInvalid;
+	},
+
+	setEmailValidationState( emailIsInvalid ) {
+		this.setState( { emailIsInvalid } );
 	},
 
 	shouldDisplayCommunityTranslator() {
@@ -276,21 +264,6 @@ const Account = createReactClass( {
 				) }
 			</FormSettingExplanation>
 		);
-	},
-
-	cancelEmailChange() {
-		const { translate, userSettings } = this.props;
-		userSettings.cancelPendingEmailChange( ( error, response ) => {
-			if ( error ) {
-				debug( 'Error canceling email change: ' + JSON.stringify( error ) );
-				this.props.errorNotice(
-					translate( 'There was a problem canceling the email change. Please, try again.' )
-				);
-			} else {
-				debug( JSON.stringify( 'Email change canceled successfully' + response ) );
-				this.props.successNotice( translate( 'The email change has been successfully canceled.' ) );
-			}
-		} );
 	},
 
 	handleRadioChange( event ) {
@@ -424,35 +397,6 @@ const Account = createReactClass( {
 		);
 	},
 
-	hasPendingEmailChange() {
-		return this.props.userSettings.isPendingEmailChange();
-	},
-
-	renderPendingEmailChange() {
-		const { translate } = this.props;
-
-		if ( ! this.hasPendingEmailChange() ) {
-			return null;
-		}
-
-		return (
-			<Notice
-				showDismiss={ false }
-				status="is-info"
-				text={ translate(
-					'There is a pending change of your email to %(email)s. Please check your inbox for a confirmation link.',
-					{
-						args: {
-							email: this.getUserSetting( 'new_user_email' ),
-						},
-					}
-				) }
-			>
-				<NoticeAction onClick={ this.cancelEmailChange }>{ translate( 'Cancel' ) }</NoticeAction>
-			</Notice>
-		);
-	},
-
 	renderUsernameValidation() {
 		const { translate, username, userSettings } = this.props;
 
@@ -524,31 +468,6 @@ const Account = createReactClass( {
 		);
 	},
 
-	renderEmailValidation() {
-		const { translate, userSettings } = this.props;
-
-		if ( ! userSettings.isSettingUnsaved( 'user_email' ) ) {
-			return null;
-		}
-
-		if ( ! this.state.emailValidationError ) {
-			return null;
-		}
-		let notice;
-		switch ( this.state.emailValidationError ) {
-			case 'invalid':
-				notice = translate( '%(email)s is not a valid email address.', {
-					args: { email: this.getUserSetting( 'user_email' ) },
-				} );
-				break;
-			case 'empty':
-				notice = translate( 'Email address can not be empty.' );
-				break;
-		}
-
-		return <FormTextValidation isError={ true } text={ notice } />;
-	},
-
 	/*
 	 * These form fields are displayed when there is not a username change in progress.
 	 */
@@ -556,29 +475,19 @@ const Account = createReactClass( {
 		const { translate, userSettings } = this.props;
 
 		const isSubmitButtonDisabled =
-			! userSettings.hasUnsavedSettings() ||
-			this.getDisabledState() ||
-			this.hasEmailValidationError();
+			! userSettings.hasUnsavedSettings() || this.getDisabledState() || this.isEmailInvalid();
 
 		return (
 			<div className="account__settings-form" key="settingsForm">
-				<FormFieldset>
-					<FormLabel htmlFor="user_email">{ translate( 'Email address' ) }</FormLabel>
-					<FormTextInput
-						disabled={ this.getDisabledState() || this.hasPendingEmailChange() }
-						id="user_email"
-						name="user_email"
-						isError={ !! this.state.emailValidationError }
-						onFocus={ this.getFocusHandler( 'Email Address Field' ) }
-						value={ this.getEmailAddress() || '' }
-						onChange={ this.updateEmailAddress }
-					/>
-					{ this.renderEmailValidation() }
-					{ this.renderPendingEmailChange() }
-					<FormSettingExplanation>
-						{ translate( 'Will not be publicly displayed' ) }
-					</FormSettingExplanation>
-				</FormFieldset>
+				<AccountSettingsEmailAddress
+					debug={ debug }
+					emailValidationListener={ this.setEmailValidationState }
+					errorNotice={ this.props.errorNotice }
+					focusHandler={ this.getFocusHandler( 'Email Address Field' ) }
+					isSubmitting={ this.getDisabledState }
+					successNotice={ this.props.successNotice }
+					userSettings={ userSettings }
+				/>
 
 				<FormFieldset>
 					<FormLabel htmlFor="primary_site_ID">{ translate( 'Primary site' ) }</FormLabel>

--- a/client/me/security-account-email/index.jsx
+++ b/client/me/security-account-email/index.jsx
@@ -87,7 +87,6 @@ class SecurityAccountEmail extends React.Component {
 						<AccountSettingsEmailAddress
 							emailValidationListener={ this.setEmailValidationState }
 							errorNotice={ this.props.errorNotice }
-							//focusHandler={ this.getFocusHandler( 'Email Address Field' ) }
 							isSubmitting={ this.isSubmitting }
 							successNotice={ this.props.successNotice }
 						/>

--- a/client/me/security-account-email/index.jsx
+++ b/client/me/security-account-email/index.jsx
@@ -93,7 +93,7 @@ class SecurityAccountEmail extends React.Component {
 						/>
 						<FormButton
 							isSubmitting={ this.isSubmitting() }
-							disabled={ ! this.canSubmit() && ! this.isSubmitting() }
+							disabled={ ! this.canSubmit() || this.isSubmitting() }
 						>
 							{ this.isSubmitting()
 								? translate( 'Updating…' )

--- a/client/me/security-account-email/index.jsx
+++ b/client/me/security-account-email/index.jsx
@@ -37,6 +37,7 @@ class SecurityAccountEmail extends React.Component {
 		this.state = {
 			emailIsInvalid: true,
 		};
+		this.showFetchError = this.showFetchError.bind( this );
 		this.isSubmitting = this.isSubmitting.bind( this );
 		this.setEmailValidationState = this.setEmailValidationState.bind( this );
 		this.submitEmailForm = this.submitEmailForm.bind( this );
@@ -58,16 +59,20 @@ class SecurityAccountEmail extends React.Component {
 		);
 	}
 
+	showFetchError() {
+		this.props.errorNotice(
+			this.props.translate( 'There was a problem getting your email address.' )
+		);
+	}
+
 	submitEmailForm( event ) {
 		event.preventDefault();
+		const { errorNotice: displayErrorNotice, translate } = this.props;
 
 		this.setState( { isSubmitting: true } );
 
-		this.props.saveUserSettings( null, function ( error ) {
-			const errorMessage = error.message
-				? error.message
-				: this.props.translate( 'There was a problem updating your email address.' );
-			this.props.errorNotice( errorMessage );
+		this.props.saveUserSettings( null, () => {
+			displayErrorNotice( translate( 'There was a problem updating your email address.' ) );
 		} );
 	}
 
@@ -86,11 +91,7 @@ class SecurityAccountEmail extends React.Component {
 					{ translate( 'Account Email' ) }
 				</HeaderCake>
 
-				<QueryUserSettings
-					onError={ this.props.errorNotice(
-						translate( 'There was a problem getting your email address' )
-					) }
-				/>
+				<QueryUserSettings onError={ this.showFetchError } />
 				<Card className="security-account-email__settings">
 					<form onSubmit={ this.submitEmailForm }>
 						<AccountSettingsEmailAddress

--- a/client/me/security-account-email/index.jsx
+++ b/client/me/security-account-email/index.jsx
@@ -1,0 +1,112 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import AccountSettingsEmailAddress from 'me/account/email-address';
+import { Card } from '@automattic/components';
+import DocumentHead from 'components/data/document-head';
+import { errorNotice, successNotice } from 'state/notices/actions';
+import FormButton from 'components/forms/form-button';
+import HeaderCake from 'components/header-cake';
+import isFetchingUserSettings from 'state/selectors/is-fetching-user-settings';
+import isPendingEmailChange from 'state/selectors/is-pending-email-change';
+import Main from 'components/main';
+import MeSidebarNavigation from 'me/sidebar-navigation';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
+import QueryUserSettings from 'components/data/query-user-settings';
+import ReauthRequired from 'me/reauth-required';
+import { saveUserSettings } from 'state/user-settings/actions';
+import twoStepAuthorization from 'lib/two-step-authorization';
+
+class SecurityAccountEmail extends React.Component {
+	static propTypes = {
+		path: PropTypes.string,
+		translate: PropTypes.func.isRequired,
+	};
+
+	constructor( props ) {
+		super( props );
+		this.state = {
+			emailIsValid: true,
+		};
+		this.isSubmitting = this.isSubmitting.bind( this );
+		this.setEmailValidationState = this.setEmailValidationState.bind( this );
+		this.submitEmailForm = this.submitEmailForm.bind( this );
+	}
+
+	setEmailValidationState( emailIsValid ) {
+		this.setState( { emailIsValid } );
+	}
+
+	isSubmitting() {
+		return this.props.isFetchingUserSettings;
+	}
+
+	canSubmit() {
+		return this.state.emailIsValid && ! this.props.isPendingEmailChange;
+	}
+
+	submitEmailForm( event ) {
+		event.preventDefault();
+
+		this.setState( { isSubmitting: true } );
+
+		this.props.saveUserSettings( null, function ( error ) {
+			const errorMessage = error.message
+				? error.message
+				: this.props.translate( 'There was a problem updating your email address.' );
+			this.props.errorNotice( errorMessage );
+		} );
+	}
+
+	render() {
+		const { path, translate } = this.props;
+
+		return (
+			<Main className="security security-account-email">
+				<PageViewTracker path={ path } title="Me > Security Account Email" />
+				<ReauthRequired twoStepAuthorization={ twoStepAuthorization } />
+				<MeSidebarNavigation />
+
+				<DocumentHead title={ translate( 'Account Email' ) } />
+
+				<HeaderCake backText={ translate( 'Back' ) } backHref="/me/security">
+					{ translate( 'Account Email' ) }
+				</HeaderCake>
+
+				<QueryUserSettings />
+				<Card className="security-account-email__settings">
+					<form onSubmit={ this.submitEmailForm }>
+						<AccountSettingsEmailAddress
+							emailValidationListener={ this.setEmailValidationState }
+							errorNotice={ this.props.errorNotice }
+							//focusHandler={ this.getFocusHandler( 'Email Address Field' ) }
+							isSubmitting={ this.isSubmitting }
+							successNotice={ this.props.successNotice }
+						/>
+						<FormButton isSubmitting={ this.isSubmitting() } disabled={ ! this.canSubmit() }>
+							{ this.isSubmitting()
+								? translate( 'Updating…' )
+								: translate( 'Update account email' ) }
+						</FormButton>
+					</form>
+				</Card>
+			</Main>
+		);
+	}
+}
+
+export default connect(
+	( state ) => ( {
+		isFetchingUserSettings: isFetchingUserSettings( state ),
+		isPendingEmailChange: isPendingEmailChange( state ),
+	} ),
+	{ errorNotice, saveUserSettings, successNotice }
+)( localize( SecurityAccountEmail ) );

--- a/client/me/security-account-email/index.jsx
+++ b/client/me/security-account-email/index.jsx
@@ -17,6 +17,7 @@ import FormButton from 'components/forms/form-button';
 import HeaderCake from 'components/header-cake';
 import isFetchingUserSettings from 'state/selectors/is-fetching-user-settings';
 import isPendingEmailChange from 'state/selectors/is-pending-email-change';
+import isSavingUserSettings from 'state/selectors/is-saving-user-settings';
 import Main from 'components/main';
 import MeSidebarNavigation from 'me/sidebar-navigation';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
@@ -46,11 +47,15 @@ class SecurityAccountEmail extends React.Component {
 	}
 
 	isSubmitting() {
-		return this.props.isFetchingUserSettings;
+		return this.props.isSavingUserSettings;
 	}
 
 	canSubmit() {
-		return ! this.state.emailIsInvalid && ! this.props.isPendingEmailChange;
+		return (
+			! this.props.isFetchingUserSettings &&
+			! this.state.emailIsInvalid &&
+			! this.props.isPendingEmailChange
+		);
 	}
 
 	submitEmailForm( event ) {
@@ -81,7 +86,11 @@ class SecurityAccountEmail extends React.Component {
 					{ translate( 'Account Email' ) }
 				</HeaderCake>
 
-				<QueryUserSettings />
+				<QueryUserSettings
+					onError={ this.props.errorNotice(
+						translate( 'There was a problem getting your email address' )
+					) }
+				/>
 				<Card className="security-account-email__settings">
 					<form onSubmit={ this.submitEmailForm }>
 						<AccountSettingsEmailAddress
@@ -109,6 +118,7 @@ export default connect(
 	( state ) => ( {
 		isFetchingUserSettings: isFetchingUserSettings( state ),
 		isPendingEmailChange: isPendingEmailChange( state ),
+		isSavingUserSettings: isSavingUserSettings( state ),
 	} ),
 	{ errorNotice, saveUserSettings, successNotice }
 )( localize( SecurityAccountEmail ) );

--- a/client/me/security-account-email/index.jsx
+++ b/client/me/security-account-email/index.jsx
@@ -91,7 +91,10 @@ class SecurityAccountEmail extends React.Component {
 							isSubmitting={ this.isSubmitting }
 							successNotice={ this.props.successNotice }
 						/>
-						<FormButton isSubmitting={ this.isSubmitting() } disabled={ ! this.canSubmit() }>
+						<FormButton
+							isSubmitting={ this.isSubmitting() }
+							disabled={ ! this.canSubmit() && ! this.isSubmitting() }
+						>
 							{ this.isSubmitting()
 								? translate( 'Updating…' )
 								: translate( 'Update account email' ) }

--- a/client/me/security-account-email/index.jsx
+++ b/client/me/security-account-email/index.jsx
@@ -34,15 +34,15 @@ class SecurityAccountEmail extends React.Component {
 	constructor( props ) {
 		super( props );
 		this.state = {
-			emailIsValid: true,
+			emailIsInvalid: true,
 		};
 		this.isSubmitting = this.isSubmitting.bind( this );
 		this.setEmailValidationState = this.setEmailValidationState.bind( this );
 		this.submitEmailForm = this.submitEmailForm.bind( this );
 	}
 
-	setEmailValidationState( emailIsValid ) {
-		this.setState( { emailIsValid } );
+	setEmailValidationState( emailIsInvalid ) {
+		this.setState( { emailIsInvalid } );
 	}
 
 	isSubmitting() {
@@ -50,7 +50,7 @@ class SecurityAccountEmail extends React.Component {
 	}
 
 	canSubmit() {
-		return this.state.emailIsValid && ! this.props.isPendingEmailChange;
+		return ! this.state.emailIsInvalid && ! this.props.isPendingEmailChange;
 	}
 
 	submitEmailForm( event ) {

--- a/client/me/security-checkup/account-email.jsx
+++ b/client/me/security-checkup/account-email.jsx
@@ -11,6 +11,8 @@ import { localize } from 'i18n-calypso';
  */
 import { getCurrentUserEmail, isCurrentUserEmailVerified } from 'state/current-user/selectors';
 import { getOKIcon, getWarningIcon } from './icons.js';
+import getUserSetting from 'state/selectors/get-user-setting';
+import isPendingEmailChange from 'state/selectors/is-pending-email-change';
 import SecurityCheckupNavigationItem from './navigation-item';
 
 class SecurityCheckupAccountEmail extends React.Component {
@@ -21,11 +23,30 @@ class SecurityCheckupAccountEmail extends React.Component {
 	};
 
 	render() {
-		const { primaryEmail, primaryEmailVerified, translate } = this.props;
+		const {
+			isPendingEmailChange: hasPendingEmailChange,
+			pendingEmailAddress,
+			primaryEmail,
+			primaryEmailVerified,
+			translate,
+		} = this.props;
 
 		let icon, description;
 
-		if ( ! primaryEmailVerified ) {
+		if ( hasPendingEmailChange ) {
+			icon = getWarningIcon();
+			description = translate(
+				'There is an unconfirmed change of your email address to {{strong}}%(emailAddress)s{{/strong}}.',
+				{
+					args: {
+						emailAddress: pendingEmailAddress,
+					},
+					components: {
+						strong: <strong />,
+					},
+				}
+			);
+		} else if ( ! primaryEmailVerified ) {
 			icon = getWarningIcon();
 			description = translate(
 				'Your account email address is {{strong}}%(emailAddress)s{{/strong}}, but is not verified yet.',
@@ -65,6 +86,8 @@ class SecurityCheckupAccountEmail extends React.Component {
 }
 
 export default connect( ( state ) => ( {
+	isPendingEmailChange: isPendingEmailChange( state ),
+	pendingEmailAddress: getUserSetting( state, 'new_user_email' ),
 	primaryEmail: getCurrentUserEmail( state ),
 	primaryEmailVerified: isCurrentUserEmailVerified( state ),
 } ) )( localize( SecurityCheckupAccountEmail ) );

--- a/client/me/security-checkup/account-email.jsx
+++ b/client/me/security-checkup/account-email.jsx
@@ -55,7 +55,7 @@ class SecurityCheckupAccountEmail extends React.Component {
 
 		return (
 			<SecurityCheckupNavigationItem
-				path={ '/me/account' }
+				path={ '/me/security/account-email' }
 				materialIcon={ icon }
 				text={ translate( 'Account Email' ) }
 				description={ description }

--- a/client/me/security/controller.js
+++ b/client/me/security/controller.js
@@ -15,6 +15,7 @@ import accountPasswordData from 'lib/account-password-data';
 import SocialLoginComponent from 'me/social-login';
 import ConnectedAppsComponent from 'me/connected-applications';
 import AccountRecoveryComponent from 'me/security-account-recovery';
+import SecurityAccountEmail from 'me/security-account-email';
 import SecurityCheckupComponent from 'me/security-checkup';
 import { getSocialServiceFromClientId } from 'lib/login';
 
@@ -50,6 +51,11 @@ export function connectedApplications( context, next ) {
 		userSettings: userSettings,
 		path: context.path,
 	} );
+	next();
+}
+
+export function accountEmail( context, next ) {
+	context.primary = React.createElement( SecurityAccountEmail, { path: context.path } );
 	next();
 }
 

--- a/client/me/security/index.js
+++ b/client/me/security/index.js
@@ -10,6 +10,7 @@ import config from 'config';
 import { makeLayout, render as clientRender } from 'controller';
 import { sidebar } from 'me/controller';
 import {
+	accountEmail,
 	accountRecovery,
 	connectedApplications,
 	password,
@@ -26,6 +27,7 @@ export default function () {
 
 	if ( useCheckupMenu ) {
 		page( '/me/security/password', sidebar, password, makeLayout, clientRender );
+		page( '/me/security/account-email', sidebar, accountEmail, makeLayout, clientRender );
 	}
 
 	if ( config.isEnabled( 'signup/social-management' ) ) {

--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -77,6 +77,7 @@ class MeSidebar extends React.Component {
 		const { context, translate } = this.props;
 		const filterMap = {
 			'/me': 'profile',
+			'/me/security/account-email': 'security',
 			'/me/security/account-recovery': 'security',
 			'/me/security/connected-applications': 'security',
 			'/me/security/password': 'security',

--- a/client/state/data-layer/wpcom/me/settings/index.js
+++ b/client/state/data-layer/wpcom/me/settings/index.js
@@ -49,8 +49,7 @@ export const storeFetchedUserSettings = ( action, data ) => updateUserSettings( 
  */
 export function saveUserSettings( action ) {
 	return ( dispatch, getState ) => {
-		const { settingsOverride } = action;
-		const settings = settingsOverride || getUnsavedUserSettings( getState() );
+		const settings = action.settingsOverride || getUnsavedUserSettings( getState() );
 		if ( ! isEmpty( settings ) ) {
 			dispatch(
 				http(
@@ -81,6 +80,13 @@ export const finishUserSettingsSave = ( { settingsOverride }, data ) => ( dispat
 	userLib().fetch();
 };
 
+export const handleUserSettingsSaveError = ( action, error ) => {
+	if ( ! action.onError ) {
+		return;
+	}
+	action.onError( error );
+};
+
 registerHandlers( 'state/data-layer/wpcom/me/settings/index.js', {
 	[ USER_SETTINGS_REQUEST ]: [
 		dispatchRequest( {
@@ -94,7 +100,7 @@ registerHandlers( 'state/data-layer/wpcom/me/settings/index.js', {
 		dispatchRequest( {
 			fetch: saveUserSettings,
 			onSuccess: finishUserSettingsSave,
-			onError: noop,
+			onError: handleUserSettingsSaveError,
 			fromApi,
 		} ),
 	],

--- a/client/state/data-layer/wpcom/me/settings/index.js
+++ b/client/state/data-layer/wpcom/me/settings/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 
-import { isEmpty, keys, mapValues, noop } from 'lodash';
+import { isEmpty, isFunction, keys, mapValues } from 'lodash';
 
 /**
  * Internal dependencies
@@ -80,8 +80,8 @@ export const finishUserSettingsSave = ( { settingsOverride }, data ) => ( dispat
 	userLib().fetch();
 };
 
-export const handleUserSettingsSaveError = ( action, error ) => {
-	if ( ! action.onError ) {
+export const handleUserSettingsError = ( action, error ) => {
+	if ( ! isFunction( action.onError ) ) {
 		return;
 	}
 	action.onError( error );
@@ -92,7 +92,7 @@ registerHandlers( 'state/data-layer/wpcom/me/settings/index.js', {
 		dispatchRequest( {
 			fetch: requestUserSettings,
 			onSuccess: storeFetchedUserSettings,
-			onError: noop,
+			onError: handleUserSettingsError,
 			fromApi,
 		} ),
 	],
@@ -100,7 +100,7 @@ registerHandlers( 'state/data-layer/wpcom/me/settings/index.js', {
 		dispatchRequest( {
 			fetch: saveUserSettings,
 			onSuccess: finishUserSettingsSave,
-			onError: handleUserSettingsSaveError,
+			onError: handleUserSettingsError,
 			fromApi,
 		} ),
 	],

--- a/client/state/selectors/is-fetching-user-settings.js
+++ b/client/state/selectors/is-fetching-user-settings.js
@@ -4,10 +4,10 @@
 import { get } from 'lodash';
 
 /**
- * Returns whether we are currently fetching or saving user settings for the current user.
+ * Returns whether we are currently fetching user settings for the current user.
  *
  * @param {object} state global app state
- * @returns {?boolean} whether we are fetching or saving user settings.
+ * @returns {?boolean} whether we are fetching user settings.
  */
 export default function isFetchingUserSettings( state ) {
 	return get( state, [ 'userSettings', 'fetchingSettings' ], false );

--- a/client/state/selectors/is-fetching-user-settings.js
+++ b/client/state/selectors/is-fetching-user-settings.js
@@ -1,0 +1,14 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Returns whether we are currently fetching or saving user settings for the current user.
+ *
+ * @param {object} state global app state
+ * @returns {?boolean} whether we are fetching or saving user settings.
+ */
+export default function isFetchingUserSettings( state ) {
+	return get( state, [ 'userSettings', 'fetchingSettings' ], false );
+}

--- a/client/state/selectors/is-pending-email-change.js
+++ b/client/state/selectors/is-pending-email-change.js
@@ -11,5 +11,5 @@ import { get } from 'lodash';
  * @returns {boolean} pending email state
  */
 export default function isPendingEmailChange( state ) {
-	return get( state, 'userSettings.settings.new_user_email', null );
+	return !! get( state, 'userSettings.settings.new_user_email', null );
 }

--- a/client/state/selectors/is-saving-user-settings.js
+++ b/client/state/selectors/is-saving-user-settings.js
@@ -1,0 +1,14 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Returns whether we are currently saving user settings for the current user.
+ *
+ * @param {object} state global app state
+ * @returns {?boolean} whether we are saving user settings.
+ */
+export default function isSavingUserSettings( state ) {
+	return get( state, [ 'userSettings', 'savingSettings' ], false );
+}

--- a/client/state/user-settings/actions.js
+++ b/client/state/user-settings/actions.js
@@ -32,14 +32,23 @@ export const fetchUserSettings = () => ( {
 } );
 
 /**
+ * Documentation for onError callback that can be supplied to some of the actions below.
+ *
+ * @callback userSettingsOnErrorCallback
+ * @param {object} error
+ */
+
+/**
  * Post settings to WordPress.com API at /me/settings endpoint
  *
  * @param {object} settingsOverride - default settings object
+ * @param {userSettingsOnErrorCallback} onError - callback to invoke if an error occurs
  * @returns {object} Action object
  */
-export const saveUserSettings = ( settingsOverride ) => ( {
+export const saveUserSettings = ( settingsOverride, onError ) => ( {
 	type: USER_SETTINGS_SAVE,
-	settingsOverride,
+	onError,
+	settingsOverride: settingsOverride || false,
 } );
 
 /**
@@ -53,9 +62,16 @@ export const updateUserSettings = ( settingValues ) => ( {
 	settingValues,
 } );
 
-export const cancelPendingEmailChange = () => ( {
+/**
+ * Returns an action object signalling a pending email change should be cancelled.
+ *
+ * @param {userSettingsOnErrorCallback} onError - callback to invoke if an error occurs.
+ * @returns {object} Action object
+ */
+export const cancelPendingEmailChange = ( onError ) => ( {
 	type: USER_SETTINGS_SAVE,
 	settingsOverride: { user_email_change_pending: false },
+	onError,
 } );
 
 export const clearUnsavedUserSettings = ( settingNames = null ) => ( {

--- a/client/state/user-settings/actions.js
+++ b/client/state/user-settings/actions.js
@@ -23,20 +23,22 @@ import 'state/data-layer/wpcom/me/settings';
 const debug = debugFactory( 'calypso:user:settings' );
 
 /**
- * Fetch user settings from WordPress.com API and store them in UserSettings instance
- *
- * @returns {object} Action object
- */
-export const fetchUserSettings = () => ( {
-	type: USER_SETTINGS_REQUEST,
-} );
-
-/**
  * Documentation for onError callback that can be supplied to some of the actions below.
  *
  * @callback userSettingsOnErrorCallback
  * @param {object} error
  */
+
+/**
+ * Fetch user settings from WordPress.com API and store them in UserSettings instance
+ *
+ * @param {userSettingsOnErrorCallback} onError - callback to invoke if an error occurs
+ * @returns {object} Action object
+ */
+export const fetchUserSettings = ( onError ) => ( {
+	type: USER_SETTINGS_REQUEST,
+	onError,
+} );
 
 /**
  * Post settings to WordPress.com API at /me/settings endpoint

--- a/client/state/user-settings/reducer.js
+++ b/client/state/user-settings/reducer.js
@@ -8,12 +8,25 @@ import { omit } from 'lodash';
  * Internal dependencies
  */
 import {
+	USER_SETTINGS_REQUEST,
+	USER_SETTINGS_SAVE,
 	USER_SETTINGS_UPDATE,
 	USER_SETTINGS_UNSAVED_CLEAR,
 	USER_SETTINGS_UNSAVED_SET,
 	USER_SETTINGS_UNSAVED_REMOVE,
 } from 'state/action-types';
-import { combineReducers } from 'state/utils';
+import { combineReducers, withoutPersistence } from 'state/utils';
+
+export const fetchingSettings = withoutPersistence( ( state = false, action ) => {
+	switch ( action.type ) {
+		case USER_SETTINGS_REQUEST:
+		case USER_SETTINGS_SAVE:
+			return true;
+		case USER_SETTINGS_UPDATE:
+			return false;
+	}
+	return state;
+} );
 
 export const settings = ( state = null, { type, settingValues } ) =>
 	USER_SETTINGS_UPDATE === type ? { ...state, ...settingValues } : state;
@@ -43,6 +56,7 @@ export const unsavedSettings = ( state = {}, action ) => {
 };
 
 export default combineReducers( {
+	fetchingSettings,
 	settings,
 	unsavedSettings,
 } );

--- a/client/state/user-settings/reducer.js
+++ b/client/state/user-settings/reducer.js
@@ -20,8 +20,19 @@ import { combineReducers, withoutPersistence } from 'state/utils';
 export const fetchingSettings = withoutPersistence( ( state = false, action ) => {
 	switch ( action.type ) {
 		case USER_SETTINGS_REQUEST:
+			return true;
+		case USER_SETTINGS_SAVE:
+		case USER_SETTINGS_UPDATE:
+			return false;
+	}
+	return state;
+} );
+
+export const savingSettings = withoutPersistence( ( state = false, action ) => {
+	switch ( action.type ) {
 		case USER_SETTINGS_SAVE:
 			return true;
+		case USER_SETTINGS_REQUEST:
 		case USER_SETTINGS_UPDATE:
 			return false;
 	}
@@ -57,6 +68,7 @@ export const unsavedSettings = ( state = {}, action ) => {
 
 export default combineReducers( {
 	fetchingSettings,
+	savingSettings,
 	settings,
 	unsavedSettings,
 } );

--- a/client/state/user-settings/test/reducer.js
+++ b/client/state/user-settings/test/reducer.js
@@ -7,8 +7,10 @@ import deepFreeze from 'deep-freeze';
 /**
  * Internal dependencies
  */
-import reducer, { settings, unsavedSettings } from '../reducer';
+import reducer, { fetchingSettings, settings, unsavedSettings } from '../reducer';
 import {
+	USER_SETTINGS_REQUEST,
+	USER_SETTINGS_SAVE,
 	USER_SETTINGS_UPDATE,
 	USER_SETTINGS_UNSAVED_SET,
 	USER_SETTINGS_UNSAVED_REMOVE,
@@ -17,7 +19,37 @@ import {
 
 describe( 'reducer', () => {
 	test( 'should export expected reducer keys', () => {
-		expect( reducer( undefined, {} ) ).to.have.keys( [ 'settings', 'unsavedSettings' ] );
+		expect( reducer( undefined, {} ) ).to.have.keys( [
+			'fetchingSettings',
+			'settings',
+			'unsavedSettings',
+		] );
+	} );
+
+	describe( 'fetchingSettings', () => {
+		test( 'should default to false', () => {
+			const state = fetchingSettings( undefined, {} );
+
+			expect( state ).to.eql( false );
+		} );
+
+		test( 'should be set to false when receiving update', () => {
+			const state = fetchingSettings( true, { type: USER_SETTINGS_UPDATE } );
+
+			expect( state ).to.eql( false );
+		} );
+
+		test( 'should be set to true when requesting data', () => {
+			const state = fetchingSettings( false, { type: USER_SETTINGS_REQUEST } );
+
+			expect( state ).to.eql( true );
+		} );
+
+		test( 'should be set to true when saving data', () => {
+			const state = fetchingSettings( false, { type: USER_SETTINGS_SAVE } );
+
+			expect( state ).to.eql( true );
+		} );
 	} );
 
 	describe( 'settings', () => {

--- a/client/state/user-settings/test/reducer.js
+++ b/client/state/user-settings/test/reducer.js
@@ -7,7 +7,7 @@ import deepFreeze from 'deep-freeze';
 /**
  * Internal dependencies
  */
-import reducer, { fetchingSettings, settings, unsavedSettings } from '../reducer';
+import reducer, { fetchingSettings, savingSettings, settings, unsavedSettings } from '../reducer';
 import {
 	USER_SETTINGS_REQUEST,
 	USER_SETTINGS_SAVE,
@@ -21,6 +21,7 @@ describe( 'reducer', () => {
 	test( 'should export expected reducer keys', () => {
 		expect( reducer( undefined, {} ) ).to.have.keys( [
 			'fetchingSettings',
+			'savingSettings',
 			'settings',
 			'unsavedSettings',
 		] );
@@ -45,8 +46,34 @@ describe( 'reducer', () => {
 			expect( state ).to.eql( true );
 		} );
 
-		test( 'should be set to true when saving data', () => {
+		test( 'should be set to false when saving data', () => {
 			const state = fetchingSettings( false, { type: USER_SETTINGS_SAVE } );
+
+			expect( state ).to.eql( false );
+		} );
+	} );
+
+	describe( 'savingSettings', () => {
+		test( 'should default to false', () => {
+			const state = savingSettings( undefined, {} );
+
+			expect( state ).to.eql( false );
+		} );
+
+		test( 'should be set to false when receiving update', () => {
+			const state = savingSettings( true, { type: USER_SETTINGS_UPDATE } );
+
+			expect( state ).to.eql( false );
+		} );
+
+		test( 'should be set to false when requesting data', () => {
+			const state = savingSettings( false, { type: USER_SETTINGS_REQUEST } );
+
+			expect( state ).to.eql( false );
+		} );
+
+		test( 'should be set to true when saving data', () => {
+			const state = savingSettings( false, { type: USER_SETTINGS_SAVE } );
 
 			expect( state ).to.eql( true );
 		} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR may well be too big, but it takes on a number of closely related tasks to expand the work in #43527:
* It updates the state and data layers for user settings as follows:
  - Settings updates now support an error handler callback
  - There is a new `isFetchingUserSettings()` selector (and the related wiring) so fetches and updates can be reflected in the UI
  - The `isPendingEmailChange()` selector has been updated to force a boolean return value.
* It refactors the email logic currently used in `/me/account` into a dedicated component
  - At the same time, it does _not_refactor the existing code to use Redux, so it has plenty of bifurcation depending on whether the container is supplying a `UserSettings` object or expecting the component to rely on the Redux state.
* It adds a new component to `/me/security/account-email` that is only responsible for updating the account email address, and fits the UX for the other menu items listed under `/me/security`.

#### Testing instructions

There is a LOT to test here.

##### Regression Tests for `/me/account`

Our main goal here is to make sure that the existing email modification UI continues to work. Make sure the following work:
* Navigate to `/me/account` and update the email address field.
  - Make sure that invalid addresses result in an error being shown, and the submit button being disabled.
  - Make sure that if the email address is the same as your starting email address, the submit button is disabled.
  - Enter a valid email address and submit the updated email address.
* Ensure that after you've submitted the change, a pending change warning appears and you can't modify the field directly.
* Click on the "Cancel" option for the pending change, and verify that the form updates and reverts to the original email address, and you can update and submit the email address again.
It may also be worth verifying an email to check that the UI updates appropriately -- this is existing behaviour, but I don't believe I touched it in this case.

##### Testing the email option in `/me/security`

Using a local Calypso version, or by using the [calypso.live](https://calypso.live/?branch=try/security-account-email-ui) UI for this branch, try the following:
* Navigate to `/me/security`.
* Verify that clicking on the "Account Email" entry takes you to `/me/security/account-email`, and that clicking the "Back" button gets you back to the menu. Click on the "Account Email" entry again.
* In the dedicated email UI, verify that the following occur:
  - When the email address in the text box matches your initial email address, the "Update" button is disabled.
  - When the email address in the text box is invalid, an appropriate error should be displayed, and the "Update" button should be disabled.
  - When you type in a valid email address, the "Update" button should be enabled.
* Type in a valid email address for yourself, and click on the "Update" button.
* The button text should change to "Updating..." and should be disabled while that text displays. Once the update completes, the button should remain disabled with the original "Update" text. In addition, the email field should be disabled and should show a prominent notice indicating that the email change is still pending.
* Click on the "Back" button.
* Verify that the "Account Email" entry shows a warning icon and the text: "There is an unconfirmed change of your email address to **email@example.com**."
* Click on the "Account Email" entry, and verify that the pending email change is displayed.
* Click on the "Cancel" text/link in the email warning, and verify that the email field reverts to your original email address.
* Click on the "Back" button, and verify that the main security menu shows a check-mark and your original email address.