### PR TITLE
Customer Home: Use transform rather than margin to center SVG

### DIFF
--- a/client/my-sites/customer-home/cards/features/help-search/style.scss
+++ b/client/my-sites/customer-home/cards/features/help-search/style.scss
@@ -59,9 +59,9 @@ $min_results_height: 180px;
 
 		.gridicon {
 			fill: var( --color-text-inverted );
-			margin: 1px 0 0 1px;
 			height: 24px;
 			width: 24px;
+			transform: translate( 1px, 1px );
 		}
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Safari has some rendering weirdness with the help SVG icon; it appears off-center at certain browser widths, and "wiggles" side to side when the browser is resized. This happens regardless of the size of the container, border, margins, padding, display type, etc. and is unique to Safari.
* Using `transform` rather than `margin` to center the icon seems to fix the problem. I'm not sure why, but suspect it has to do with browser rendering/painting and the benefits of using transforms over positioning for rendering performance.

**Before**

<img width="361" alt="Screen Shot 2020-07-13 at 4 06 18 PM" src="https://user-images.githubusercontent.com/2124984/87349072-c356e300-c523-11ea-92d3-75dd21ab2adf.png">

**After**

<img width="358" alt="Screen Shot 2020-07-13 at 4 06 09 PM" src="https://user-images.githubusercontent.com/2124984/87349084-c8b42d80-c523-11ea-9a02-a3941c968feb.png">

#### Testing instructions

* Switch to this PR
* Navigate to Customer Home and check out the "More help" section; the help icon should be centered in the blue circle. It shouldn't "wiggle" when you resize the browser window.

Fixes #43169
