### PR TITLE
Fix console error due to bad propTypes declaration

### DIFF
--- a/client/me/security-checkup/social-logins.jsx
+++ b/client/me/security-checkup/social-logins.jsx
@@ -14,7 +14,7 @@ import SecurityCheckupNavigationItem from './navigation-item';
 
 class SecurityCheckupSocialLogins extends React.Component {
 	static propTypes = {
-		socialConnections: PropTypes.number.isRequired,
+		socialConnectionCount: PropTypes.number.isRequired,
 		translate: PropTypes.func.isRequired,
 	};
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This change fixes the `propTypes` for the new Social Logins component added as part of the work to restructure `/me/security`. The prop was declared as required, but with the wrong name... 😬 This change brings the declaration into line with the rest of the code. 🤦

#### Testing instructions

* Navigate to `/me/security` in the calypso.live branch, and verify that there aren't any console errors.