### PR TITLE
Customer Home: Move checklist items from left to right

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/current-task-item.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/current-task-item.jsx
@@ -4,20 +4,13 @@
 import React from 'react';
 import { translate } from 'i18n-calypso';
 import { Button } from '@automattic/components';
-import Badge from 'components/badge';
-
 /**
  * Internal dependencies
  */
+import Badge from 'components/badge';
 import Gridicon from 'components/gridicon';
 
-const CurrentTaskItem = ( {
-	currentTask,
-	skipTask,
-	startTask,
-	setTaskIsManuallySelected,
-	useDrillLayout,
-} ) => {
+const CurrentTaskItem = ( { currentTask, skipTask, startTask, useAccordionLayout } ) => {
 	return (
 		<div className="site-setup-list__task task">
 			<div className="site-setup-list__task-text task__text">
@@ -34,7 +27,7 @@ const CurrentTaskItem = ( {
 						} ) }
 					</div>
 				) }
-				{ useDrillLayout ? null : (
+				{ ! useAccordionLayout && (
 					<h2 className="site-setup-list__task-title task__title">{ currentTask.title }</h2>
 				) }
 				<p className="site-setup-list__task-description task__description">
@@ -57,10 +50,7 @@ const CurrentTaskItem = ( {
 					{ currentTask.isSkippable && ! currentTask.isCompleted && (
 						<Button
 							className="site-setup-list__task-skip task__skip is-link"
-							onClick={ () => {
-								setTaskIsManuallySelected( false );
-								skipTask();
-							} }
+							onClick={ () => skipTask() }
 						>
 							{ translate( 'Skip for now' ) }
 						</Button>

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/current-task-item.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/current-task-item.jsx
@@ -1,0 +1,66 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { translate } from 'i18n-calypso';
+import { Button } from '@automattic/components';
+import Badge from 'components/badge';
+
+/**
+ * Internal dependencies
+ */
+import Gridicon from 'components/gridicon';
+
+const CurrentTaskItem = ( { currentTask, skipTask, startTask, setTaskIsManuallySelected } ) => {
+	return (
+		<div className="site-setup-list__task task">
+			<div className="site-setup-list__task-text task__text">
+				{ currentTask.isCompleted ? (
+					<Badge type="info" className="site-setup-list__task-badge task__badge">
+						{ translate( 'Complete' ) }
+					</Badge>
+				) : (
+					<div className="site-setup-list__task-timing task__timing">
+						<Gridicon icon="time" size={ 18 } />
+						{ translate( '%d minute', '%d minutes', {
+							count: currentTask.timing,
+							args: [ currentTask.timing ],
+						} ) }
+					</div>
+				) }
+				<h2 className="site-setup-list__task-title task__title">{ currentTask.title }</h2>
+				<p className="site-setup-list__task-description task__description">
+					{ currentTask.description }
+				</p>
+				<div className="site-setup-list__task-actions task__actions">
+					{ currentTask.actionText && (
+						<Button
+							className="site-setup-list__task-action task__action"
+							primary
+							onClick={ () => startTask() }
+							disabled={
+								currentTask.isDisabled ||
+								( currentTask.isCompleted && currentTask.actionDisableOnComplete )
+							}
+						>
+							{ currentTask.actionText }
+						</Button>
+					) }
+					{ currentTask.isSkippable && ! currentTask.isCompleted && (
+						<Button
+							className="site-setup-list__task-skip task__skip is-link"
+							onClick={ () => {
+								setTaskIsManuallySelected( false );
+								skipTask();
+							} }
+						>
+							{ translate( 'Skip for now' ) }
+						</Button>
+					) }
+				</div>
+			</div>
+		</div>
+	);
+};
+
+export default CurrentTaskItem;

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/current-task-item.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/current-task-item.jsx
@@ -11,7 +11,13 @@ import Badge from 'components/badge';
  */
 import Gridicon from 'components/gridicon';
 
-const CurrentTaskItem = ( { currentTask, skipTask, startTask, setTaskIsManuallySelected } ) => {
+const CurrentTaskItem = ( {
+	currentTask,
+	skipTask,
+	startTask,
+	setTaskIsManuallySelected,
+	useDrillLayout,
+} ) => {
 	return (
 		<div className="site-setup-list__task task">
 			<div className="site-setup-list__task-text task__text">
@@ -28,7 +34,9 @@ const CurrentTaskItem = ( { currentTask, skipTask, startTask, setTaskIsManuallyS
 						} ) }
 					</div>
 				) }
-				<h2 className="site-setup-list__task-title task__title">{ currentTask.title }</h2>
+				{ useDrillLayout ? null : (
+					<h2 className="site-setup-list__task-title task__title">{ currentTask.title }</h2>
+				) }
 				<p className="site-setup-list__task-description task__description">
 					{ currentTask.description }
 				</p>

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
@@ -15,7 +15,6 @@ import classnames from 'classnames';
 import CardHeading from 'components/card-heading';
 import Spinner from 'components/spinner';
 import { getTaskList } from 'lib/checklist';
-import Gridicon from 'components/gridicon';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { requestSiteChecklistTaskUpdate } from 'state/checklist/actions';
 import { resetVerifyEmailState } from 'state/current-user/email-verification/actions';
@@ -231,47 +230,32 @@ const SiteSetupList = ( {
 					const isCurrent = task.id === currentTask.id;
 					const isCompleted = task.isCompleted;
 
-					return useDrillLayout && isCurrent ? (
-						<div
-							className={ classnames( 'nav-item', {
-								'is-current': isCurrent,
-							} ) }
-						>
-							<div className="nav-item__status">
-								{ isCompleted ? (
-									<Gridicon className="nav-item__complete" icon="checkmark" size={ 18 } />
-								) : (
-									<div className="nav-item__pending" />
-								) }
-							</div>
-							<CurrentTaskItem
-								currentTask={ currentTask }
-								skipTask={ () => skipTask( dispatch, currentTask, tasks, siteId, setIsLoading ) }
-								startTask={ () =>
-									startTask( dispatch, currentTask, siteId, advanceToNextIncompleteTask )
-								}
-								setTaskIsManuallySelected={ setTaskIsManuallySelected }
+					return (
+						<>
+							<NavItem
+								key={ task.id }
+								taskId={ task.id }
+								text={ enhancedTask.label || enhancedTask.title }
+								isCompleted={ isCompleted }
+								isCurrent={ isCurrent }
+								onClick={ () => {
+									setTaskIsManuallySelected( true );
+									setCurrentTaskId( task.id );
+								} }
+								useDrillLayout={ useDrillLayout }
 							/>
-							{ useDrillLayout &&
-								( isCurrent ? (
-									<Gridicon className="nav-item__chevron" icon="chevron-up" size={ 18 } />
-								) : (
-									<Gridicon className="nav-item__chevron" icon="chevron-down" size={ 18 } />
-								) ) }
-						</div>
-					) : (
-						<NavItem
-							key={ task.id }
-							taskId={ task.id }
-							text={ enhancedTask.label || enhancedTask.title }
-							isCompleted={ isCompleted }
-							isCurrent={ isCurrent }
-							onClick={ () => {
-								setTaskIsManuallySelected( true );
-								setCurrentTaskId( task.id );
-							} }
-							useDrillLayout={ useDrillLayout }
-						/>
+							{ useDrillLayout && isCurrent ? (
+								<CurrentTaskItem
+									currentTask={ currentTask }
+									skipTask={ () => skipTask( dispatch, currentTask, tasks, siteId, setIsLoading ) }
+									startTask={ () =>
+										startTask( dispatch, currentTask, siteId, advanceToNextIncompleteTask )
+									}
+									useDrillLayout={ useDrillLayout }
+									setTaskIsManuallySelected={ setTaskIsManuallySelected }
+								/>
+							) : null }
+						</>
 					);
 				} ) }
 			</div>

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
@@ -228,30 +228,6 @@ const SiteSetupList = ( {
 					</>
 				</CardHeading>
 			) }
-			{ ( ! useDrillLayout || currentDrillLayoutView === 'nav' ) && (
-				<div className="site-setup-list__nav">
-					{ ! useDrillLayout && <CardHeading>{ translate( 'Site setup' ) }</CardHeading> }
-					{ tasks.map( ( task ) => {
-						const enhancedTask = getTask( task );
-
-						return (
-							<NavItem
-								key={ task.id }
-								taskId={ task.id }
-								text={ enhancedTask.label || enhancedTask.title }
-								isCompleted={ task.isCompleted }
-								isCurrent={ task.id === currentTask.id }
-								onClick={ () => {
-									setTaskIsManuallySelected( true );
-									setCurrentTaskId( task.id );
-									setCurrentDrillLayoutView( 'task' );
-								} }
-								showChevron={ useDrillLayout }
-							/>
-						);
-					} ) }
-				</div>
-			) }
 			{ ( ! useDrillLayout || currentDrillLayoutView === 'task' ) && (
 				<div className="site-setup-list__task task">
 					<div className="site-setup-list__task-text task__text">
@@ -301,6 +277,30 @@ const SiteSetupList = ( {
 							) }
 						</div>
 					</div>
+				</div>
+			) }
+			{ ( ! useDrillLayout || currentDrillLayoutView === 'nav' ) && (
+				<div className="site-setup-list__nav">
+					{ ! useDrillLayout && <CardHeading>{ translate( 'Site setup' ) }</CardHeading> }
+					{ tasks.map( ( task ) => {
+						const enhancedTask = getTask( task );
+
+						return (
+							<NavItem
+								key={ task.id }
+								taskId={ task.id }
+								text={ enhancedTask.label || enhancedTask.title }
+								isCompleted={ task.isCompleted }
+								isCurrent={ task.id === currentTask.id }
+								onClick={ () => {
+									setTaskIsManuallySelected( true );
+									setCurrentTaskId( task.id );
+									setCurrentDrillLayoutView( 'task' );
+								} }
+								showChevron={ useDrillLayout }
+							/>
+						);
+					} ) }
 				</div>
 			) }
 		</Card>

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
@@ -112,7 +112,7 @@ const SiteSetupList = ( {
 	const [ currentTaskId, setCurrentTaskId ] = useState( null );
 	const [ currentTask, setCurrentTask ] = useState( null );
 	const [ taskIsManuallySelected, setTaskIsManuallySelected ] = useState( false );
-	const [ useDrillLayout, setUseDrillLayout ] = useState( false );
+	const [ useAccordionLayout, setUseAccordionLayout ] = useState( false );
 	const [ isLoading, setIsLoading ] = useState( false );
 	const dispatch = useDispatch();
 
@@ -195,9 +195,9 @@ const SiteSetupList = ( {
 
 	useEffect( () => {
 		if ( isWithinBreakpoint( '<960px' ) ) {
-			setUseDrillLayout( true );
+			setUseAccordionLayout( true );
 		}
-		subscribeIsWithinBreakpoint( '<960px', ( isActive ) => setUseDrillLayout( isActive ) );
+		subscribeIsWithinBreakpoint( '<960px', ( isActive ) => setUseAccordionLayout( isActive ) );
 	}, [] );
 
 	if ( ! currentTask ) {
@@ -211,8 +211,7 @@ const SiteSetupList = ( {
 	return (
 		<Card className={ classnames( 'site-setup-list', { 'is-loading': isLoading } ) }>
 			{ isLoading && <Spinner /> }
-			{ useDrillLayout && <CardHeading>{ translate( 'Site setup' ) }</CardHeading> }
-			{ ! useDrillLayout && (
+			{ ! useAccordionLayout && (
 				<CurrentTaskItem
 					currentTask={ currentTask }
 					skipTask={ () => skipTask( dispatch, currentTask, tasks, siteId, setIsLoading ) }
@@ -224,7 +223,7 @@ const SiteSetupList = ( {
 			) }
 
 			<div className="site-setup-list__nav">
-				{ ! useDrillLayout && <CardHeading>{ translate( 'Site setup' ) }</CardHeading> }
+				<CardHeading>{ translate( 'Site setup' ) }</CardHeading>
 				{ tasks.map( ( task ) => {
 					const enhancedTask = getTask( task );
 					const isCurrent = task.id === currentTask.id;
@@ -242,17 +241,19 @@ const SiteSetupList = ( {
 									setTaskIsManuallySelected( true );
 									setCurrentTaskId( task.id );
 								} }
-								useDrillLayout={ useDrillLayout }
+								useAccordionLayout={ useAccordionLayout }
 							/>
-							{ useDrillLayout && isCurrent ? (
+							{ useAccordionLayout && isCurrent ? (
 								<CurrentTaskItem
 									currentTask={ currentTask }
-									skipTask={ () => skipTask( dispatch, currentTask, tasks, siteId, setIsLoading ) }
+									skipTask={ () => {
+										setTaskIsManuallySelected( false );
+										skipTask( dispatch, currentTask, tasks, siteId, setIsLoading );
+									} }
 									startTask={ () =>
 										startTask( dispatch, currentTask, siteId, advanceToNextIncompleteTask )
 									}
-									useDrillLayout={ useDrillLayout }
-									setTaskIsManuallySelected={ setTaskIsManuallySelected }
+									useAccordionLayout={ useAccordionLayout }
 								/>
 							) : null }
 						</>

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
@@ -113,6 +113,7 @@ const SiteSetupList = ( {
 	const [ currentTask, setCurrentTask ] = useState( null );
 	const [ taskIsManuallySelected, setTaskIsManuallySelected ] = useState( false );
 	const [ useAccordionLayout, setUseAccordionLayout ] = useState( false );
+	const [ showAccordionSelectedTask, setShowAccordionSelectedTask ] = useState( false );
 	const [ isLoading, setIsLoading ] = useState( false );
 	const dispatch = useDispatch();
 
@@ -238,14 +239,23 @@ const SiteSetupList = ( {
 								taskId={ task.id }
 								text={ enhancedTask.label || enhancedTask.title }
 								isCompleted={ isCompleted }
-								isCurrent={ isCurrent }
-								onClick={ () => {
-									setTaskIsManuallySelected( true );
-									setCurrentTaskId( task.id );
-								} }
+								isCurrent={
+									useAccordionLayout ? isCurrent && showAccordionSelectedTask : isCurrent
+								}
+								onClick={
+									useAccordionLayout && isCurrent && showAccordionSelectedTask
+										? () => {
+												setShowAccordionSelectedTask( false );
+										  }
+										: () => {
+												setShowAccordionSelectedTask( true );
+												setTaskIsManuallySelected( true );
+												setCurrentTaskId( task.id );
+										  }
+								}
 								useAccordionLayout={ useAccordionLayout }
 							/>
-							{ useAccordionLayout && isCurrent ? (
+							{ useAccordionLayout && isCurrent && showAccordionSelectedTask ? (
 								<CurrentTaskItem
 									currentTask={ currentTask }
 									skipTask={ () => {

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
@@ -212,11 +212,7 @@ const SiteSetupList = ( {
 	return (
 		<Card className={ classnames( 'site-setup-list', { 'is-loading': isLoading } ) }>
 			{ isLoading && <Spinner /> }
-			{ useDrillLayout && (
-				<CardHeading>
-					<>{ translate( 'Site setup' ) }</>
-				</CardHeading>
-			) }
+			{ useDrillLayout && <CardHeading>{ translate( 'Site setup' ) }</CardHeading> }
 			{ ! useDrillLayout && (
 				<CurrentTaskItem
 					currentTask={ currentTask }

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
@@ -214,11 +214,13 @@ const SiteSetupList = ( {
 			{ ! useAccordionLayout && (
 				<CurrentTaskItem
 					currentTask={ currentTask }
-					skipTask={ () => skipTask( dispatch, currentTask, tasks, siteId, setIsLoading ) }
+					skipTask={ () => {
+						setTaskIsManuallySelected( false );
+						skipTask( dispatch, currentTask, tasks, siteId, setIsLoading );
+					} }
 					startTask={ () =>
 						startTask( dispatch, currentTask, siteId, advanceToNextIncompleteTask )
 					}
-					setTaskIsManuallySelected={ setTaskIsManuallySelected }
 				/>
 			) }
 

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/nav-item.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/nav-item.jsx
@@ -11,7 +11,7 @@ import classnames from 'classnames';
 import Gridicon from 'components/gridicon';
 import { recordTracksEvent } from 'state/analytics/actions';
 
-const NavItem = ( { text, taskId, isCompleted, isCurrent, onClick, useDrillLayout } ) => {
+const NavItem = ( { text, taskId, isCompleted, isCurrent, onClick, useAccordionLayout } ) => {
 	const dispatch = useDispatch();
 
 	const trackExpand = () =>
@@ -43,7 +43,7 @@ const NavItem = ( { text, taskId, isCompleted, isCurrent, onClick, useDrillLayou
 			<div className="nav-item__text">
 				<h6>{ text }</h6>
 			</div>
-			{ useDrillLayout && (
+			{ useAccordionLayout && (
 				<Gridicon
 					className="nav-item__chevron"
 					icon={ isCurrent ? 'chevron-up' : 'chevron-down' }

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/nav-item.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/nav-item.jsx
@@ -11,7 +11,7 @@ import classnames from 'classnames';
 import Gridicon from 'components/gridicon';
 import { recordTracksEvent } from 'state/analytics/actions';
 
-const NavItem = ( { text, taskId, isCompleted, isCurrent, onClick, showChevron } ) => {
+const NavItem = ( { text, taskId, isCompleted, isCurrent, onClick, useDrillLayout } ) => {
 	const dispatch = useDispatch();
 
 	const trackExpand = () =>
@@ -43,7 +43,12 @@ const NavItem = ( { text, taskId, isCompleted, isCurrent, onClick, showChevron }
 			<div className="nav-item__text">
 				<h6>{ text }</h6>
 			</div>
-			{ showChevron && <Gridicon className="nav-item__chevron" icon="chevron-right" size={ 18 } /> }
+			{ useDrillLayout &&
+				( isCurrent ? (
+					<Gridicon className="nav-item__chevron" icon="chevron-up" size={ 18 } />
+				) : (
+					<Gridicon className="nav-item__chevron" icon="chevron-down" size={ 18 } />
+				) ) }
 		</button>
 	);
 };

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/nav-item.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/nav-item.jsx
@@ -43,12 +43,13 @@ const NavItem = ( { text, taskId, isCompleted, isCurrent, onClick, useDrillLayou
 			<div className="nav-item__text">
 				<h6>{ text }</h6>
 			</div>
-			{ useDrillLayout &&
-				( isCurrent ? (
-					<Gridicon className="nav-item__chevron" icon="chevron-up" size={ 18 } />
-				) : (
-					<Gridicon className="nav-item__chevron" icon="chevron-down" size={ 18 } />
-				) ) }
+			{ useDrillLayout && (
+				<Gridicon
+					className="nav-item__chevron"
+					icon={ isCurrent ? 'chevron-up' : 'chevron-down' }
+					size={ 18 }
+				/>
+			) }
 		</button>
 	);
 };

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
@@ -97,6 +97,7 @@
 
 	.site-setup-list__task {
 		box-shadow: none;
+		flex: 1;
 	}
 
 	.site-setup-list__task-actions {

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
@@ -27,7 +27,7 @@
 		align-items: center;
 	}
 
-	.nav-item {
+	button.nav-item {
 		display: flex;
 		align-items: center;
 		padding: 16px 24px;
@@ -55,6 +55,20 @@
 			@include breakpoint-deprecated( '<960px' ) {
 				background-color: transparent;
 			}
+		}
+	}
+
+	div.nav-item {
+		display: flex;
+		align-items: flex-start;
+		padding: 16px 24px;
+		border-bottom: 1px solid var( --color-border-subtle );
+		transition: all 0.1s;
+		&:last-child {
+			border-bottom: none;
+		}
+		.task .task__text {
+			padding: 0;
 		}
 	}
 

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
@@ -17,6 +17,19 @@
 
 		@include breakpoint-deprecated( '<960px' ) {
 			width: 100%;
+			border-left: none;
+		}
+
+		.site-setup-list__task {
+			padding: 0 24px 16px;
+			border-bottom: 1px solid var( --color-border-subtle );
+			transition: all 0.1s;
+			&:last-child {
+				border-bottom: none;
+			}
+			.task__text {
+				padding: 0;
+			}
 		}
 	}
 
@@ -53,22 +66,9 @@
 			font-weight: 600;
 
 			@include breakpoint-deprecated( '<960px' ) {
+				border-bottom: none;
 				background-color: transparent;
 			}
-		}
-	}
-
-	div.nav-item {
-		display: flex;
-		align-items: flex-start;
-		padding: 16px 24px;
-		border-bottom: 1px solid var( --color-border-subtle );
-		transition: all 0.1s;
-		&:last-child {
-			border-bottom: none;
-		}
-		.task .task__text {
-			padding: 0;
 		}
 	}
 

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
@@ -9,7 +9,7 @@
 	.site-setup-list__nav {
 		width: 328px;
 		flex-shrink: 0;
-		border-right: 1px solid var( --color-border-subtle );
+		border-left: 1px solid var( --color-border-subtle );
 
 		@include breakpoint-deprecated( '<1280px' ) {
 			width: 260px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Checklist for a new site is on the right side which gives user more focus on the main cards and tasks vs list of items in the checklist.

#### Testing instructions
- It can be tested by creating a new site and going to homepage of site where checklist can be seen.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
Before:
![image](https://user-images.githubusercontent.com/41870839/87356489-c97aad00-c57f-11ea-9ac6-b8571b40b852.png)
After:
![image](https://user-images.githubusercontent.com/41870839/87356537-dac3b980-c57f-11ea-9d59-b3104e645241.png)

*

Fixes #44112 
