### PR TITLE
Update FSE plugin to version to 1.13

### DIFF
--- a/.github/workflows/full-site-editing-plugin.yml
+++ b/.github/workflows/full-site-editing-plugin.yml
@@ -14,6 +14,11 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@HEAD
 
+    - name: Run composer
+      uses: nick-zh/composer-php@HEAD
+      with:
+        action: 'install'
+
     # https://github.com/actions/cache/blob/HEAD/examples.md#node---lerna
     - name: Restore node_modules cache
       id: cache
@@ -27,11 +32,6 @@ jobs:
     - name: Install dependencies
       if: steps.cache.outputs.cache-hit != 'true'
       run: yarn install --frozen-lockfile # Not needed when restoring from cache.
-
-    - name: Run composer
-      uses: nick-zh/composer-php@HEAD
-      with:
-        action: 'install'
 
     - name: Build packages
       if: steps.cache.outputs.cache-hit == 'true'

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Full Site Editing
  * Description: Enhances your page creation workflow within the Block Editor.
- * Version: 1.12
+ * Version: 1.13
  * Author: Automattic
  * Author URI: https://automattic.com/wordpress-plugins/
  * License: GPLv2 or later
@@ -35,7 +35,7 @@ namespace A8C\FSE;
  *
  * @var string
  */
-define( 'PLUGIN_VERSION', '1.12' );
+define( 'PLUGIN_VERSION', '1.13' );
 
 // Always include these helper files for dotcom FSE.
 require_once __DIR__ . '/dotcom-fse/helpers.php';

--- a/apps/full-site-editing/full-site-editing-plugin/readme.txt
+++ b/apps/full-site-editing/full-site-editing-plugin/readme.txt
@@ -40,6 +40,11 @@ This plugin is experimental, so we don't provide any support for it outside of w
 
 == Changelog ==
 
+= 1.13 =
+* Change the category of FSE blocks from legacy to the updated ones (https://github.com/Automattic/wp-calypso/issues/43198).
+* Add a helper function that can be used to assign categories with older fallbacks.
+* Add support for TypeScript tests.
+
 = 1.12 =
 * Experimental navigation sidebar in block editor, can be enabled in config or with a hook.
 * Default content included in the donation block can be edited.

--- a/apps/full-site-editing/full-site-editing-plugin/readme.txt
+++ b/apps/full-site-editing/full-site-editing-plugin/readme.txt
@@ -3,7 +3,7 @@ Contributors: alexislloyd, allancole, automattic, bartkalisz, codebykat, copons,
 Tags: block, blocks, editor, gutenberg, page
 Requires at least: 5.0
 Tested up to: 5.4
-Stable tag: 1.12
+Stable tag: 1.13
 Requires PHP: 5.6.20
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/apps/full-site-editing/full-site-editing-plugin/readme.txt
+++ b/apps/full-site-editing/full-site-editing-plugin/readme.txt
@@ -44,6 +44,8 @@ This plugin is experimental, so we don't provide any support for it outside of w
 * Change the category of FSE blocks from legacy to the updated ones (https://github.com/Automattic/wp-calypso/issues/43198).
 * Add a helper function that can be used to assign categories with older fallbacks.
 * Add support for TypeScript tests.
+* Update visual style of navigation sidebar.
+* Fix navigation sidebar dismiss button in IE.
 
 = 1.12 =
 * Experimental navigation sidebar in block editor, can be enabled in config or with a hook.

--- a/apps/full-site-editing/package.json
+++ b/apps/full-site-editing/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/full-site-editing",
-	"version": "1.12.0",
+	"version": "1.13.0",
 	"description": "Plugin for full site editing with the block editor.",
 	"sideEffects": true,
 	"repository": {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Version bump and changelog.

#### Testing instructions

This deploy includes quite a number of PRs, so I'm going to ask as many authors as possible to quickly re-test their changes against the release candidate to make sure there are no surprising interactions.

The detailed instructions are in the field-guide here: 
- (wpcom) https://wp.me/PCYsg-ly5/#viewing-the-fse-features
- (atomic) https://wp.me/PCYsg-ly5/#atomic-testing

But if you just need the short version:
* Apply code-D46328
* Test on a sandboxed simple-site with appropriate FSE-plugin flags
* Test on an atomic site with and without Gutenberg enabled

Here's the rc plugin link for your convenience [fse-build-archive](https://github.com/Automattic/wp-calypso/suites/939857407/artifacts/11616059) (2.23 MB) (updated to include fix by @akirk)

Please also add any comment you'd like included in changelog here, and I'll add them in before I merge

#### Changelog entries

* Change the category of FSE blocks from legacy to the updated ones (https://github.com/Automattic/wp-calypso/issues/43198).
* Add a helper function that can be used to assign categories with older fallbacks.
* Add support for TypeScript tests.
* Update visual style of navigation sidebar.
* Fix navigation sidebar dismiss button in IE.

#### PRs to test

- https://github.com/Automattic/wp-calypso/pull/43935 @razvanpapadopol
  - [x] wpcom
  - [x] AT
- https://github.com/Automattic/wp-calypso/pull/43983 @razvanpapadopol
  - [x] wpcom
  - [x] AT
- https://github.com/Automattic/wp-calypso/pull/44087 @yansern / @razvanpapadopol
  - [x] wpcom
  - [x] AT
- https://github.com/Automattic/wp-calypso/pull/43993 @saramarcondes
  - [x] wpcom
  - [x] AT
- https://github.com/Automattic/wp-calypso/pull/41474 @jasmussen / @georgeh
  - [x] wpcom
  - [x] AT
- https://github.com/Automattic/wp-calypso/pull/44021 @andrewserong
  - [x] wpcom
  - [x] AT
- https://github.com/Automattic/wp-calypso/pull/43906 @p-jackson
  - [x] wpcom
  - [x] AT
- https://github.com/Automattic/wp-calypso/pull/44092 @p-jackson
  - [x] wpcom
  - [x] AT
- https://github.com/Automattic/wp-calypso/pull/44199 @ramon / @p-jackson
  - [x] wpcom
  - [x] AT
- https://github.com/Automattic/wp-calypso/pull/44196 @ramonjd 
  - [x] wpcom
  - [x] AT
- https://github.com/Automattic/wp-calypso/pull/44077 @yansern 
  - [x] wpcom
  - [x] AT
- https://github.com/Automattic/wp-calypso/pull/43670 @fullofcaffeine 
  - [x] wpcom
  - [x] AT
- https://github.com/Automattic/wp-calypso/pull/44127 @p-jackson 
  - [x] wpcom
  - [x] AT
- https://github.com/Automattic/wp-calypso/pull/44243 @kwight
  - [x] wpcom
  - [x] AT
- https://github.com/Automattic/wp-calypso/pull/44191 @gwwar
  - [x] wpcom
  - [x] AT

#### Final pre-release checks

- [x] Confirm `phpcbf` fixes occur in the Github action build log (Should be in Build FSE plugin/Build packages
![Update_FSE_plugin_to_version_to_1_13_by_deBhal_·_Pull_Request__44125_·_Automattic_wp-calypso](https://user-images.githubusercontent.com/5952255/88257383-eb52fd00-cd00-11ea-9854-29453cf60ad1.jpg)


