### PR TITLE
CircleCI Artifacts: Change branch name back

### DIFF
--- a/bin/get-circle-artifact-url.js
+++ b/bin/get-circle-artifact-url.js
@@ -12,7 +12,7 @@ const basePath = '/api/v1.1/project/github/Automattic/wp-calypso';
 const maxBuilds = 100;
 
 async function getCircleArtifactUrl( pathMatchRegex ) {
-	if ( ! pathMatchRegex instanceof RegExp ) {
+	if ( ! ( pathMatchRegex instanceof RegExp ) ) {
 		console.error( 'Expected a valid RegExp. Received: %o', pathMatchRegex );
 		process.exit( 1 );
 	}
@@ -20,7 +20,7 @@ async function getCircleArtifactUrl( pathMatchRegex ) {
 		// Fetch recent successful master builds
 		const builds = await httpsGetJsonPromise( {
 			...baseOptions,
-			path: `${ basePath }/tree/HEAD?filter=successful&limit=${ maxBuilds }`,
+			path: `${ basePath }/tree/master?filter=successful&limit=${ maxBuilds }`,
 		} );
 
 		const buildNumbersWithArtifacts = builds


### PR DESCRIPTION
#43993 broke downloading our calypso-strings.pot, this fixes it by bringing back the branch name to the CircleCI URL.

## Testing Instructions
Ensure that `bin/get-circle-string-artifact-url` outputs a CircleCI Artifact URL to a calypso-strings.pot.