### PR TITLE
Update email setup messaging and colours in the domain status notices

### DIFF
--- a/client/lib/domains/resolve-domain-status.js
+++ b/client/lib/domains/resolve-domain-status.js
@@ -56,7 +56,7 @@ export function resolveDomainStatus(
 			if ( hasPendingGSuiteUsers( domain ) ) {
 				return {
 					statusText: translate( 'Action required' ),
-					statusClass: 'status-warning',
+					statusClass: 'status-error',
 					icon: 'info',
 				};
 			}
@@ -145,7 +145,7 @@ export function resolveDomainStatus(
 			if ( hasPendingGSuiteUsers( domain ) ) {
 				return {
 					statusText: translate( 'Action required' ),
-					statusClass: 'status-warning',
+					statusClass: 'status-error',
 					icon: 'info',
 				};
 			}

--- a/client/my-sites/domains/components/domain-warnings/pending-gsuite-tos-notice.jsx
+++ b/client/my-sites/domains/components/domain-warnings/pending-gsuite-tos-notice.jsx
@@ -126,7 +126,7 @@ class PendingGSuiteTosNotice extends React.PureComponent {
 				siteSlug={ this.props.siteSlug }
 				user={ users[ 0 ] }
 				isCompact={ false }
-				cta={ translate( 'Get started' ) }
+				cta={ translate( 'Finish setup' ) }
 			/>
 		);
 
@@ -135,11 +135,14 @@ class PendingGSuiteTosNotice extends React.PureComponent {
 				<>
 					<p>
 						{ translate(
-							'%(email)s is almost ready! Complete the setup to activate your new email address.',
+							'Your email {{strong}}%(email)s{{/strong}} is almost ready! Complete the setup to activate your new email address.',
 							{
 								args: {
 									email: emails,
 									comment: '%(email)s will be an email address',
+								},
+								components: {
+									strong: <strong />,
 								},
 							}
 						) }
@@ -153,7 +156,7 @@ class PendingGSuiteTosNotice extends React.PureComponent {
 			<>
 				<p>
 					{ translate(
-						'%(emails)s are almost ready! Complete the setup to activate your new email addresses.',
+						'Your emails {{strong}}%(emails)s{{/strong}} are almost ready! Complete the setup to activate your new email addresses.',
 						{
 							args: {
 								emails: emails,
@@ -161,6 +164,9 @@ class PendingGSuiteTosNotice extends React.PureComponent {
 							comment:
 								'%(emails)s will be a list of email addresses separated by a comma, ' +
 								'e.g. test@example.com, test2@example.com',
+							components: {
+								strong: <strong />,
+							},
 						}
 					) }
 				</p>

--- a/client/my-sites/domains/components/domain-warnings/pending-gsuite-tos-notice.jsx
+++ b/client/my-sites/domains/components/domain-warnings/pending-gsuite-tos-notice.jsx
@@ -130,43 +130,19 @@ class PendingGSuiteTosNotice extends React.PureComponent {
 			/>
 		);
 
-		if ( users.length === 1 ) {
-			return (
-				<>
-					<p>
-						{ translate(
-							'Your email {{strong}}%(email)s{{/strong}} is almost ready! Complete the setup to activate your new email address.',
-							{
-								args: {
-									email: emails,
-									comment: '%(email)s will be an email address',
-								},
-								components: {
-									strong: <strong />,
-								},
-							}
-						) }
-					</p>
-					{ button }
-				</>
-			);
-		}
-
 		return (
 			<>
 				<p>
 					{ translate(
-						'Your emails {{strong}}%(emails)s{{/strong}} are almost ready! Complete the setup to activate your new email addresses.',
+						'Your mailbox {{strong}}%(emails)s{{/strong}} is almost ready! Complete the setup to activate your new email address.',
+						'Your mailboxes {{strong}}%(emails)s{{/strong}} are almost ready! Complete the setup to activate your new email addresses.',
 						{
-							args: {
-								emails: emails,
-							},
+							count: users.length,
+							args: { emails },
 							comment:
 								'%(emails)s will be a list of email addresses separated by a comma, ' +
 								'e.g. test@example.com, test2@example.com',
-							components: {
-								strong: <strong />,
-							},
+							components: { strong },
 						}
 					) }
 				</p>

--- a/client/my-sites/domains/components/domain-warnings/pending-gsuite-tos-notice.jsx
+++ b/client/my-sites/domains/components/domain-warnings/pending-gsuite-tos-notice.jsx
@@ -126,7 +126,7 @@ class PendingGSuiteTosNotice extends React.PureComponent {
 				siteSlug={ this.props.siteSlug }
 				user={ users[ 0 ] }
 				isCompact={ false }
-				cta={ translate( 'Finish setup' ) }
+				cta={ translate( 'Finish Setup' ) }
 			/>
 		);
 


### PR DESCRIPTION
#### Summary

* This PR updates email setup messaging and colours to make it more consistent with other notifications.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Purchase a G Suite subscription. Do not login into the subsequent account, nor accept the TOS.
* Confirm that the domain status notice has a notification about completing the G Suite setup.
* Confirm that the following are true:

    - The status message starts with: "Your email "
    - The email address is **bold** in the message
    - The CTA button says "Finish setup"
    - The status icon and message are wrapped with the `status-error` class which makes the colour red.

<img width="734" alt="Screenshot 2020-07-14 at 8 21 29 AM" src="https://user-images.githubusercontent.com/277661/87396669-13c55380-c5ab-11ea-8bd3-83b2b003680b.png">


