### PR TITLE
Use styles folder instead.

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/use-classic-block-guide.scss
+++ b/apps/wpcom-block-editor/src/wpcom/features/use-classic-block-guide.scss
@@ -1,4 +1,4 @@
-@import '~@automattic/typography/sass/fonts';
+@import '~@automattic/typography/styles/fonts';
 
 .use-classic-block-guide__heading {
 	font-family: $brand-serif;


### PR DESCRIPTION
Rename to `styles` from `sass` in this file. `apps/wpcom-block-editor/src/wpcom/features/use-classic-block-guide.scss`.

I should've rebased this PR https://github.com/Automattic/wp-calypso/pull/44077 before merging because seems like there is a new file that is using typography package in the last 24 hours.