### PR TITLE
Gutenboarding: Use V5 domain picker.

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/domains/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/domains/index.tsx
@@ -81,7 +81,12 @@ const DomainsStep: React.FunctionComponent< Props > = ( { isModal } ) => {
 			</div>
 			<ActionButtons>
 				<BackButton onClick={ handleBack } />
-				{ domain ? <NextButton onClick={ handleNext } /> : <SkipButton onClick={ handleNext } /> }
+				{ ! isModal &&
+					( domain ? (
+						<NextButton onClick={ handleNext } />
+					) : (
+						<SkipButton onClick={ handleNext } />
+					) ) }
 			</ActionButtons>
 		</div>
 	);

--- a/client/landing/gutenboarding/onboarding-block/domains/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/domains/index.tsx
@@ -7,7 +7,14 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { useI18n } from '@automattic/react-i18n';
 import DomainPicker from '@automattic/domain-picker';
 import type { DomainSuggestions } from '@automattic/data-stores';
-import { Title, SubTitle, ActionButtons, BackButton } from '@automattic/onboarding';
+import {
+	Title,
+	SubTitle,
+	ActionButtons,
+	BackButton,
+	NextButton,
+	SkipButton,
+} from '@automattic/onboarding';
 
 /**
  * Internal dependencies
@@ -64,7 +71,6 @@ const DomainsStep: React.FunctionComponent< Props > = ( { isModal } ) => {
 
 	const onDomainSelect = ( suggestion: DomainSuggestion | undefined ) => {
 		setDomain( suggestion );
-		handleNext();
 	};
 
 	const header = (
@@ -75,6 +81,7 @@ const DomainsStep: React.FunctionComponent< Props > = ( { isModal } ) => {
 			</div>
 			<ActionButtons>
 				<BackButton onClick={ handleBack } />
+				{ domain ? <NextButton onClick={ handleNext } /> : <SkipButton onClick={ handleNext } /> }
 			</ActionButtons>
 		</div>
 	);

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -118,7 +118,7 @@ export default {
 		allowExistingUsers: true,
 	},
 	newSiteGutenbergOnboarding: {
-		datestamp: '20200702',
+		datestamp: '20200714',
 		variations: {
 			gutenberg: 10,
 			control: 90,

--- a/packages/domain-picker/src/domain-name-explanation/index.tsx
+++ b/packages/domain-picker/src/domain-name-explanation/index.tsx
@@ -19,10 +19,10 @@ export const DomainNameExplanationImage: FunctionComponent = () => {
 			<rect x="8" y="8" width="25" height="25" rx="5" fill="#fff" />
 			<rect x="40" y="8" width="25" height="25" rx="5" fill="#fff" />
 			<rect x="72" y="8" width="300" height="25" rx="5" fill="#fff" />
-			<text x="80" y="26" fontFamily="roboto" fill="#999">
+			<text x="80" y="26" fill="#999">
 				https://
 			</text>
-			<text x="133" y="26" fontFamily="roboto" fill="#515151">
+			<text x="133" y="26" fill="#515151">
 				example.com
 			</text>
 		</svg>

--- a/packages/domain-picker/src/domain-picker/index.tsx
+++ b/packages/domain-picker/src/domain-picker/index.tsx
@@ -179,42 +179,19 @@ const DomainPicker: FunctionComponent< Props > = ( {
 					) }
 					<div className="domain-picker__suggestion-sections">
 						<div className="domain-picker__suggestion-item-group">
-							<p className="domain-picker__suggestion-group-label">{ __( 'Sub-domain' ) }</p>
-							{ domainSuggestions?.[ 0 ] ? (
+							{ domainSuggestions?.map( ( suggestion, i ) => (
 								<SuggestionItem
-									key={ domainSuggestions[ 0 ].domain_name }
-									suggestion={ domainSuggestions[ 0 ] }
-									railcarId={ baseRailcarId ? `${ baseRailcarId }1` : undefined }
+									key={ suggestion.domain_name }
+									suggestion={ suggestion }
+									railcarId={ baseRailcarId ? `${ baseRailcarId }${ i }` : undefined }
+									isRecommended={ i === 1 }
 									onRender={ () =>
-										handleItemRender( domainSuggestions[ 0 ], `${ baseRailcarId }1`, 0, false )
+										handleItemRender( suggestion, `${ baseRailcarId }${ i }`, i, i === 1 )
 									}
-									selected={ currentDomain === domainSuggestions[ 0 ].domain_name }
+									selected={ currentDomain === suggestion.domain_name }
 									onSelect={ onDomainSelect }
 								/>
-							) : (
-								<SuggestionItemPlaceholder />
-							) }
-						</div>
-						<div className="domain-picker__suggestion-item-group">
-							{ ! domainSuggestions ||
-							( domainSuggestions?.length && domainSuggestions?.length > 1 ) ? (
-								<p className="domain-picker__suggestion-group-label">{ __( 'Custom domains' ) }</p>
-							) : null }
-							{ domainSuggestions
-								?.slice( 1 )
-								.map( ( suggestion, i ) => (
-									<SuggestionItem
-										key={ suggestion.domain_name }
-										suggestion={ suggestion }
-										railcarId={ baseRailcarId ? `${ baseRailcarId }${ i }` : undefined }
-										isRecommended={ i === 0 }
-										onRender={ () =>
-											handleItemRender( suggestion, `${ baseRailcarId }${ i }`, i, i === 0 )
-										}
-										selected={ currentDomain === suggestion.domain_name }
-										onSelect={ onDomainSelect }
-									/>
-								) ) ?? times( quantity - 1, ( i ) => <SuggestionItemPlaceholder key={ i } /> ) }
+							) ) ?? times( quantity, ( i ) => <SuggestionItemPlaceholder key={ i } /> ) }
 						</div>
 
 						{ ! isExpanded &&

--- a/packages/domain-picker/src/domain-picker/style.scss
+++ b/packages/domain-picker/src/domain-picker/style.scss
@@ -137,7 +137,7 @@
 			border-color: var( --studio-blue-30 );
 			background-color: var( --studio-blue-30 );
 
-			&::before {
+			&::after {
 				content: '';
 				width: 12px;
 				height: 12px;

--- a/packages/domain-picker/src/domain-picker/style.scss
+++ b/packages/domain-picker/src/domain-picker/style.scss
@@ -93,31 +93,6 @@
 		cursor: default;
 	}
 
-	&.is-selected {
-		background: var( --studio-blue-0 );
-		border-color: var( --studio-blue-40 );
-		z-index: 2;
-	}
-
-	&:hover,
-	&:focus {
-		&:not( .placeholder ) {
-			background: var( --studio-blue-0 );
-			border-color: var( --studio-blue-40 );
-			z-index: 2;
-		}
-
-		// Fade between price and select button only happens on desktop view.
-		@include break-small {
-			.domain-picker__suggestion-item-select-button {
-				opacity: 1;
-			}
-			.domain-picker__price {
-				opacity: 0;
-			}
-		}
-	}
-
 	&:first-of-type {
 		border-top-left-radius: 5px;
 		border-top-right-radius: 5px;
@@ -146,6 +121,43 @@
 		100% {
 			transform: translateY( 0 );
 			opacity: 1;
+		}
+	}
+
+	input[type='radio'].domain-picker__suggestion-radio-button {
+		width: 16px;
+		height: 16px;
+		min-width: 16px; // prevents long domain from squishing the radio button
+		padding: 0;
+		margin: 1px 12px 0 0;
+		vertical-align: middle;
+		position: relative;
+
+		&:checked {
+			border-color: var( --studio-blue-30 );
+			background-color: var( --studio-blue-30 );
+
+			&::before {
+				content: '';
+				width: 12px;
+				height: 12px;
+				border: 2px solid white;
+				border-radius: 50%;
+				position: absolute;
+				margin: 0;
+				background: transparent;
+			}
+
+			&:focus {
+				border-color: var( --studio-blue-30 );
+				box-shadow: 0 0 0 1px var( --studio-blue-30 );
+			}
+		}
+
+		&:not( :disabled ):focus,
+		&:not( :disabled ):hover {
+			border-color: var( --studio-blue-30 );
+			box-shadow: 0 0 0 1px var( --studio-blue-30 );
 		}
 	}
 }
@@ -212,65 +224,17 @@
 	}
 }
 
-.domain-picker__price-long {
+.domain-picker__price-inclusive {
+	color: var( --studio-green-40 );
 	display: none;
+
 	@include break-small {
 		display: inline;
 	}
 }
 
-.domain-picker__price-short {
-	display: inline;
-	@include break-small {
-		display: none;
-	}
-}
-
 .domain-picker__price-cost {
 	text-decoration: line-through;
-}
-
-.domain-picker__suggestion-item-select-button {
-	display: flex;
-	align-items: center;
-	height: 36px;
-
-	span {
-		display: none;
-	}
-
-	svg {
-		fill: var( --studio-blue-50 );
-		margin-left: 10px;
-		margin-right: -2px;
-	}
-
-	@include break-small {
-		// We're mocking the look of a button,
-		// this is not an actual button.
-		background: $blue-medium-focus;
-		color: var( --studio-white );
-		border-radius: 2px;
-		padding: 0 12px;
-		opacity: 0;
-		transition: opacity 200ms ease-in-out;
-
-		// Overlaps price for transition purpose
-		position: absolute;
-		right: 14px;
-
-		&:hover {
-			background: mix( black, $blue-medium-focus, 10% );
-		}
-
-		span {
-			display: inline-block;
-		}
-
-		svg {
-			display: none;
-		}
-	}
 }
 
 .domain-picker__body {

--- a/packages/domain-picker/src/domain-picker/style.scss
+++ b/packages/domain-picker/src/domain-picker/style.scss
@@ -1,5 +1,6 @@
 @import '~@automattic/calypso-color-schemes';
 @import '~@automattic/onboarding/styles/mixins';
+@import '~@automattic/typography/styles/fonts';
 
 .domain-picker__empty-state {
 	display: flex;
@@ -164,8 +165,15 @@
 
 .domain-picker__suggestion-item-name {
 	flex-grow: 1;
-	margin-right: 24px;
 	letter-spacing: 0.4px;
+
+	.domain-picker__suggestion-item:not( .is-free ) & {
+		margin-right: 0;
+
+		@include break-mobile {
+			margin-right: 24px;
+		}
+	}
 
 	.domain-picker__domain-name {
 		word-break: break-word; // use hyphens if any to break domain name

--- a/packages/domain-picker/src/domain-picker/suggestion-item.tsx
+++ b/packages/domain-picker/src/domain-picker/suggestion-item.tsx
@@ -7,8 +7,6 @@ import classnames from 'classnames';
 import { sprintf } from '@wordpress/i18n';
 import { v4 as uuid } from 'uuid';
 import { recordTrainTracksInteract } from '@automattic/calypso-analytics';
-import { Icon, arrowRight } from '@wordpress/icons';
-import { createInterpolateElement } from '@wordpress/element';
 
 type DomainSuggestion = import('@automattic/data-stores').DomainSuggestions.DomainSuggestion;
 
@@ -63,15 +61,20 @@ const DomainPickerSuggestionItem: FunctionComponent< Props > = ( {
 	};
 
 	return (
-		<button
-			type="button"
+		<label
 			className={ classnames( 'domain-picker__suggestion-item', {
 				'is-free': suggestion.is_free,
 				'is-selected': selected,
 			} ) }
-			onClick={ onDomainSelect }
-			id={ labelId }
 		>
+			<input
+				aria-labelledby={ labelId }
+				className="domain-picker__suggestion-radio-button"
+				type="radio"
+				name="domain-picker-suggestion-option"
+				onChange={ onDomainSelect }
+				checked={ selected }
+			/>
 			<div className="domain-picker__suggestion-item-name">
 				<span className="domain-picker__domain-name">{ domainName }</span>
 				<span className="domain-picker__domain-tld">{ domainTld }</span>
@@ -85,22 +88,11 @@ const DomainPickerSuggestionItem: FunctionComponent< Props > = ( {
 				} ) }
 			>
 				{ suggestion.is_free ? (
-					__( 'Included in free plan' )
+					__( 'Free' )
 				) : (
 					<>
-						<span className="domain-picker__price-long">
-							{ createInterpolateElement(
-								sprintf(
-									/* translators: %s is the price with currency. Eg: $15/year. */
-									__( 'Included in paid plan, <strikethrough>%s/year</strikethrough>' ),
-									suggestion.cost
-								),
-								{
-									strikethrough: <span className="domain-picker__price-cost"></span>,
-								}
-							) }
-						</span>
-						<span className="domain-picker__price-short domain-picker__price-cost">
+						<span className="domain-picker__price-inclusive"> { __( 'Included in plans' ) } </span>
+						<span className="domain-picker__price-cost">
 							{
 								/* translators: %s is the price with currency. Eg: $15/year. */
 								sprintf( __( '%s/year' ), suggestion.cost )
@@ -109,11 +101,7 @@ const DomainPickerSuggestionItem: FunctionComponent< Props > = ( {
 					</>
 				) }
 			</div>
-			<div className="domain-picker__suggestion-item-select-button">
-				<span>{ __( 'Select' ) }</span>
-				<Icon icon={ arrowRight } size={ 18 } />
-			</div>
-		</button>
+		</label>
 	);
 };
 

--- a/test/e2e/lib/pages/gutenboarding/domains-page.js
+++ b/test/e2e/lib/pages/gutenboarding/domains-page.js
@@ -14,8 +14,8 @@ export default class DomainsPage extends AsyncBaseContainer {
 		super( driver, By.css( '.domains' ) );
 	}
 
-	async clickFreeSuggestionItem() {
-		const freeSuggestionItemSelector = By.css( '.domain-picker__suggestion-item.is-free' );
-		return await driverHelper.clickWhenClickable( this.driver, freeSuggestionItemSelector );
+	async skipStep() {
+		const skipButtonSelector = By.css( '.action-buttons__skip' );
+		return await driverHelper.clickWhenClickable( this.driver, skipButtonSelector );
 	}
 }

--- a/test/e2e/specs/wp-gutenboarding-spec.js
+++ b/test/e2e/specs/wp-gutenboarding-spec.js
@@ -50,9 +50,9 @@ describe( 'Gutenboarding: (' + screenSize + ')', function () {
 			await acquireIntentPage.goToNextStep();
 		} );
 
-		step( 'Can see Domains Page and select free suggestion item', async function () {
+		step( 'Can see Domains Page and skip selecting a domain', async function () {
 			const domainsPage = await DomainsPage.Expect( driver );
-			await domainsPage.clickFreeSuggestionItem();
+			await domainsPage.skipStep();
 		} );
 
 		step( 'Can see Design Selector and select a random free design', async function () {


### PR DESCRIPTION
(More context in pbAok1-1eE-p2)

#### Changes proposed in this Pull Request

* Radio buttons.
* Skip/continue button to move onwards.
* Green “included in plans” text.
* Change label next to the free domain back to “Free”
* Remove free/paid grouping and have the free domain on top
* Fix weird font on domain name explanation image.

#### Testing instructions

* Go to `/new` and test the domain picker.
* Also test it on mobile view with long domain names.

#### Screenshots

![2020-07-14_13-48-00](https://user-images.githubusercontent.com/1287077/87422960-d75d1c00-c5d9-11ea-8145-194cb6da7933.png)
![2020-07-14_13-48-29](https://user-images.githubusercontent.com/1287077/87422963-d9bf7600-c5d9-11ea-872f-5d66a3fa060a.png)
![2020-07-14_13-52-45](https://user-images.githubusercontent.com/1287077/87422971-dcba6680-c5d9-11ea-8b6a-0c22a675d6f4.png)
![2020-07-14_13-48-53](https://user-images.githubusercontent.com/1287077/87422972-ddeb9380-c5d9-11ea-963a-f9a23bff6fd4.png)

Fixes pbAok1-1eE-p2
