### PR TITLE
Plans: Remove the Google Voucher cards from My Plans and a checkout thank …

### DIFF
--- a/client/blocks/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features-list/index.jsx
@@ -23,7 +23,6 @@ import { PLANS_LIST } from 'lib/plans/plans-list';
 import FindNewTheme from './find-new-theme';
 import UploadPlugins from './upload-plugins';
 import AdvertisingRemoved from './advertising-removed';
-import GoogleVouchers from './google-vouchers';
 import CustomizeTheme from './customize-theme';
 import CustomCSS from './custom-css';
 import VideoAudioPosts from './video-audio-posts';
@@ -78,7 +77,6 @@ export class ProductPurchaseFeaturesList extends Component {
 					liveChatButtonEventName={ 'calypso_livechat_my_plan_ecommerce' }
 				/>
 				<CustomDomain selectedSite={ selectedSite } hasDomainCredit={ planHasDomainCredit } />
-				<GoogleVouchers selectedSite={ selectedSite } />
 				<GoogleAnalyticsStats selectedSite={ selectedSite } />
 				<GoogleMyBusiness selectedSite={ selectedSite } />
 				<AdvertisingRemoved isBusinessPlan selectedSite={ selectedSite } />
@@ -118,7 +116,6 @@ export class ProductPurchaseFeaturesList extends Component {
 				{ isWordadsInstantActivationEligible( selectedSite ) && (
 					<MonetizeSite selectedSite={ selectedSite } />
 				) }
-				<GoogleVouchers selectedSite={ selectedSite } />
 				<GoogleAnalyticsStats selectedSite={ selectedSite } />
 				<GoogleMyBusiness selectedSite={ selectedSite } />
 				<AdvertisingRemoved isBusinessPlan selectedSite={ selectedSite } />
@@ -150,7 +147,6 @@ export class ProductPurchaseFeaturesList extends Component {
 				<CustomDomain selectedSite={ selectedSite } hasDomainCredit={ planHasDomainCredit } />
 				<GoogleAnalyticsStats selectedSite={ selectedSite } />
 				<AdvertisingRemoved isBusinessPlan={ false } selectedSite={ selectedSite } />
-				<GoogleVouchers selectedSite={ selectedSite } />
 				{ showCustomizerFeature && <CustomizeTheme selectedSite={ selectedSite } /> }
 				{ ! showCustomizerFeature && <CustomCSS selectedSite={ selectedSite } /> }
 				<VideoAudioPosts selectedSite={ selectedSite } plan={ plan } />

--- a/client/my-sites/checkout/checkout-thank-you/premium-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/premium-plan-details.jsx
@@ -11,18 +11,15 @@ import { useTranslate } from 'i18n-calypso';
  */
 import CustomDomainPurchaseDetail from './custom-domain-purchase-detail';
 import GoogleAppsDetails from './google-apps-details';
-import GoogleVoucherDetails from './google-voucher';
 import { isWordadsInstantActivationEligible } from 'lib/ads/utils';
 import { isPremium, isGoogleApps } from 'lib/products-values';
 import { newPost } from 'lib/paths';
 import PurchaseDetail from 'components/purchase-detail';
-import QuerySiteVouchers from 'components/data/query-site-vouchers';
 
 /**
  * Image dependencies
  */
 import analyticsImage from 'assets/images/illustrations/google-analytics.svg';
-import googleAdwordsImage from 'assets/images/illustrations/adwords-google.svg';
 import advertisingRemovedImage from 'assets/images/upgrades/removed-advertising.svg';
 import customizeThemeImage from 'assets/images/upgrades/customize-theme.svg';
 import mediaPostImage from 'assets/images/upgrades/media-post.svg';
@@ -77,24 +74,6 @@ const PremiumPlanDetails = ( {
 				) }
 				buttonText={ translate( 'Connect Google Analytics' ) }
 				href={ '/settings/analytics/' + selectedSite.slug }
-			/>
-
-			<QuerySiteVouchers siteId={ selectedSite.ID } />
-			<PurchaseDetail
-				id="google-credits"
-				icon={
-					<img alt={ translate( 'Google AdWords Illustration' ) } src={ googleAdwordsImage } />
-				}
-				title={ translate( 'Google Ads credit' ) }
-				description={ translate(
-					'Use a %(cost)s credit with Google to bring traffic to your most important Posts and Pages.',
-					{
-						args: {
-							cost: '$100',
-						},
-					}
-				) }
-				body={ <GoogleVoucherDetails selectedSite={ selectedSite } /> }
 			/>
 
 			{ ! selectedFeature && (


### PR DESCRIPTION
This PR removes the Google Voucher card from My Plans, because the Google vouchers aren't working now that our contract with them has expired. Additional context on p7DVsv-8Wc-p2. 

Here's a screenshot of the card on My Plans:
<img width="1079" alt="Screen Shot 2020-07-14 at 7 01 36 AM" src="https://user-images.githubusercontent.com/35781181/87424961-e5e00f00-c5aa-11ea-9d5e-74f2912bd275.png">


#### Testing instructions

* Checkout this branch (git checkout update/plans-remove-google-credit-card).
* Start calypso.
* Navigate to My Plans (/plans/my-plans/:siteSlug) with a Business plan site.
* Confirm that the Google Voucher card does not display.