### PR TITLE
Checkout: add phone number to field OVO wallet

### DIFF
--- a/client/lib/checkout/constants.js
+++ b/client/lib/checkout/constants.js
@@ -37,7 +37,7 @@ export const PAYMENT_PROCESSOR_COUNTRIES_FIELDS = {
 		],
 	},
 	ID: {
-		fields: [ 'name', 'nik' ],
+		fields: [ 'name', 'nik', 'phone-number' ],
 	},
 };
 


### PR DESCRIPTION
In order to improve the refund flow for OVO, we need to a pass a phone number associate with the account through to dLocal.

<img width="733" alt="Screen Shot 2020-07-14 at 9 56 16 AM" src="https://user-images.githubusercontent.com/942359/87440402-ee8f1000-c5bf-11ea-96b3-801cd5c79749.png">

ref: pbOQVh-h-p2

**To Test:**
- apply D46370-code, sandbox store, and sandbox `public-api`
- set your currency to `IDR` (Indonesia)
- visit legacy Checkout
- verify that OVO is shown as a payment method
- verify that the phone input is shown (with Indonesia pre-selected)
- verify that all 3 fields are required
- submit a payment with any name, 16-digit NIK, and 10-digit phone number
- verify that you're redirected to dLocal's sandbox payment gateway