### PR TITLE
Domains: Add make primary domain functionality to new site domains view

### DIFF
--- a/client/my-sites/domains/domain-management/list/domain-item.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-item.jsx
@@ -13,6 +13,7 @@ import classNames from 'classnames';
  */
 import { Button, CompactCard } from '@automattic/components';
 import FormCheckbox from 'components/forms/form-checkbox';
+import FormRadio from 'components/forms/form-radio';
 import DomainNotice from 'my-sites/domains/domain-management/components/domain-notice';
 import EllipsisMenu from 'components/ellipsis-menu';
 import PopoverMenuItem from 'components/popover/menu-item';
@@ -38,10 +39,12 @@ class DomainItem extends PureComponent {
 		showCheckbox: PropTypes.bool,
 		onClick: PropTypes.func.isRequired,
 		onMakePrimaryClick: PropTypes.func,
+		onSelect: PropTypes.func,
 		onToggle: PropTypes.func,
 		purchase: PropTypes.object,
 		isLoadingDomainDetails: PropTypes.bool,
 		selectionIndex: PropTypes.number,
+		enableSelection: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -53,8 +56,12 @@ class DomainItem extends PureComponent {
 		isBusy: false,
 	};
 
-	handleClick = () => {
-		this.props.onClick( this.props.domainDetails );
+	handleClick = ( e ) => {
+		if ( this.props.enableSelection ) {
+			this.onSelect( e );
+		} else {
+			this.props.onClick( this.props.domainDetails );
+		}
 	};
 
 	stopPropagation = ( event ) => {
@@ -91,6 +98,12 @@ class DomainItem extends PureComponent {
 		if ( onMakePrimaryClick ) {
 			onMakePrimaryClick( selectionIndex, domainDetails );
 		}
+	};
+
+	onSelect = ( event ) => {
+		const { domainDetails, selectionIndex, onSelect } = this.props;
+		event.stopPropagation();
+		onSelect( selectionIndex, domainDetails );
 	};
 
 	canRenewDomain() {
@@ -296,7 +309,7 @@ class DomainItem extends PureComponent {
 	}
 
 	render() {
-		const { domain, domainDetails, isManagingAllSites, showCheckbox } = this.props;
+		const { domain, domainDetails, isManagingAllSites, showCheckbox, enableSelection } = this.props;
 		const { listStatusText, listStatusClass } = resolveDomainStatus( domainDetails || domain );
 
 		const rowClasses = classNames( 'domain-item', `domain-item__status-${ listStatusClass }` );
@@ -312,6 +325,9 @@ class DomainItem extends PureComponent {
 						onChange={ this.onToggle }
 						onClick={ this.stopPropagation }
 					/>
+				) }
+				{ enableSelection && (
+					<FormRadio className="domain-item__checkbox" onClick={ this.onSelect } />
 				) }
 				<div className="list__domain-link">
 					<div className="domain-item__status">

--- a/client/my-sites/domains/domain-management/list/domain-item.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-item.jsx
@@ -120,6 +120,17 @@ class DomainItem extends PureComponent {
 		);
 	}
 
+	canSetAsPrimary() {
+		const { domainDetails, isManagingAllSites, shouldUpgradeToMakePrimary } = this.props;
+		return (
+			! isManagingAllSites &&
+			domainDetails &&
+			domainDetails.canSetAsPrimary &&
+			! domainDetails.isPrimary &&
+			! shouldUpgradeToMakePrimary
+		);
+	}
+
 	upgradeToMakePrimary() {
 		const { translate } = this.props;
 
@@ -174,7 +185,7 @@ class DomainItem extends PureComponent {
 	}
 
 	renderOptionsButton() {
-		const { disabled, domainDetails, isBusy, isManagingAllSites, translate } = this.props;
+		const { disabled, isBusy, translate } = this.props;
 
 		return (
 			<div className="list__domain-options">
@@ -183,7 +194,7 @@ class DomainItem extends PureComponent {
 					onClick={ this.stopPropagation }
 					toggleTitle={ translate( 'Options' ) }
 				>
-					{ ! isManagingAllSites && ! domainDetails.isPrimary && (
+					{ this.canSetAsPrimary() && (
 						<PopoverMenuItem icon="domains" onClick={ this.makePrimary }>
 							{ translate( 'Make primary domain' ) }
 						</PopoverMenuItem>

--- a/client/my-sites/domains/domain-management/list/domain-item.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-item.jsx
@@ -25,6 +25,7 @@ import { resolveDomainStatus } from 'lib/domains';
 import InfoPopover from 'components/info-popover';
 import { emailManagement } from 'my-sites/email/paths';
 import Spinner from 'components/spinner';
+import TrackComponentView from 'lib/analytics/track-component-view';
 
 class DomainItem extends PureComponent {
 	static propTypes = {
@@ -41,6 +42,8 @@ class DomainItem extends PureComponent {
 		onMakePrimaryClick: PropTypes.func,
 		onSelect: PropTypes.func,
 		onToggle: PropTypes.func,
+		onUpgradeClick: PropTypes.func,
+		shouldUpgradeToMakePrimary: PropTypes.boolean,
 		purchase: PropTypes.object,
 		isLoadingDomainDetails: PropTypes.bool,
 		selectionIndex: PropTypes.number,
@@ -114,6 +117,20 @@ class DomainItem extends PureComponent {
 			domainDetails.currentUserCanManage &&
 			[ domainTypes.WPCOM, domainTypes.TRANSFER ].indexOf( domainDetails.type ) === -1 &&
 			! domainDetails.bundledPlanSubscriptionId
+		);
+	}
+
+	upgradeToMakePrimary() {
+		const { translate } = this.props;
+
+		return (
+			<div className="domain-item__upsell">
+				<span>{ translate( 'Upgrade to a paid plan to make this your primary domain' ) }</span>
+				<Button primary onClick={ this.props.onUpgradeClick }>
+					{ translate( 'Upgrade' ) }
+				</Button>
+				<TrackComponentView eventName="calypso_domain_management_list_change_primary_upgrade_impression" />
+			</div>
 		);
 	}
 
@@ -296,11 +313,21 @@ class DomainItem extends PureComponent {
 	}
 
 	renderOverlay() {
-		if ( this.props.isBusy ) {
+		const { enableSelection, isBusy, shouldUpgradeToMakePrimary } = this.props;
+		if ( isBusy ) {
 			return (
 				<div className="domain-item__overlay">
 					{ this.busyMessage() }
 					<Spinner className="domain-item__spinner" size={ 20 } />
+				</div>
+			);
+		}
+
+		if ( enableSelection && shouldUpgradeToMakePrimary ) {
+			return (
+				// eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions
+				<div className="domain-item__overlay" onClick={ this.stopPropagation }>
+					{ this.upgradeToMakePrimary() }
 				</div>
 			);
 		}

--- a/client/my-sites/domains/domain-management/list/domain-item.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-item.jsx
@@ -27,6 +27,7 @@ import Spinner from 'components/spinner';
 
 class DomainItem extends PureComponent {
 	static propTypes = {
+		busyMessage: PropTypes.string,
 		currentRoute: PropTypes.string,
 		disabled: PropTypes.bool,
 		domain: PropTypes.object.isRequired,
@@ -275,10 +276,17 @@ class DomainItem extends PureComponent {
 		return null;
 	}
 
+	busyMessage() {
+		if ( this.props.isBusy && this.props.busyMessage ) {
+			return <div className="domain-item__busy-message">{ this.props.busyMessage }</div>;
+		}
+	}
+
 	renderOverlay() {
 		if ( this.props.isBusy ) {
 			return (
 				<div className="domain-item__overlay">
+					{ this.busyMessage() }
 					<Spinner className="domain-item__spinner" size={ 20 } />
 				</div>
 			);

--- a/client/my-sites/domains/domain-management/list/domain-item.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-item.jsx
@@ -123,12 +123,12 @@ class DomainItem extends PureComponent {
 	}
 
 	renderOptionsButton() {
-		const { isManagingAllSites, translate } = this.props;
+		const { domainDetails, isManagingAllSites, translate } = this.props;
 
 		return (
 			<div className="list__domain-options">
 				<EllipsisMenu onClick={ this.stopPropagation } toggleTitle={ translate( 'Options' ) }>
-					{ ! isManagingAllSites && (
+					{ ! isManagingAllSites && ! domainDetails.isPrimary && (
 						<PopoverMenuItem icon="domains">{ translate( 'Make primary domain' ) }</PopoverMenuItem>
 					) }
 					{ this.canRenewDomain() && (

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -526,6 +526,10 @@ export class List extends React.Component {
 				site={ selectedSite }
 				isManagingAllSites={ false }
 				onClick={ this.goToEditDomainRoot }
+				isBusy={ this.state.settingPrimaryDomain && index === this.state.primaryDomainIndex }
+				disabled={ this.state.settingPrimaryDomain }
+				selectionIndex={ index }
+				onMakePrimaryClick={ this.handleUpdatePrimaryDomain }
 			/>
 		) );
 

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -530,9 +530,11 @@ export class List extends React.Component {
 				busyMessage={ this.props.translate( 'Setting Primary Domain…', {
 					context: 'Shows up when the primary domain is changing and the user is waiting',
 				} ) }
-				disabled={ this.state.settingPrimaryDomain }
+				disabled={ this.state.settingPrimaryDomain || this.state.changePrimaryDomainModeEnabled }
+				enableSelection={ this.state.changePrimaryDomainModeEnabled && domain.canSetAsPrimary }
 				selectionIndex={ index }
 				onMakePrimaryClick={ this.handleUpdatePrimaryDomain }
+				onSelect={ this.handleUpdatePrimaryDomain }
 			/>
 		) );
 

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -527,6 +527,9 @@ export class List extends React.Component {
 				isManagingAllSites={ false }
 				onClick={ this.goToEditDomainRoot }
 				isBusy={ this.state.settingPrimaryDomain && index === this.state.primaryDomainIndex }
+				busyMessage={ this.props.translate( 'Setting Primary Domain…', {
+					context: 'Shows up when the primary domain is changing and the user is waiting',
+				} ) }
 				disabled={ this.state.settingPrimaryDomain }
 				selectionIndex={ index }
 				onMakePrimaryClick={ this.handleUpdatePrimaryDomain }

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -525,7 +525,7 @@ export class List extends React.Component {
 				domainDetails={ domain }
 				site={ selectedSite }
 				isManagingAllSites={ false }
-				onClick={ this.goToEditDomainRoot }
+				onClick={ this.state.settingPrimaryDomain ? noop : this.goToEditDomainRoot }
 				isBusy={ this.state.settingPrimaryDomain && index === this.state.primaryDomainIndex }
 				busyMessage={ this.props.translate( 'Setting Primary Domain…', {
 					context: 'Shows up when the primary domain is changing and the user is waiting',

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -477,8 +477,18 @@ export class List extends React.Component {
 					</InfoPopover>
 				</div>
 				<div className="list__header-primary-domain-buttons">
-					<Button compact className="list__change-primary-domain">
-						{ translate( 'Change primary domain' ) }
+					<Button
+						compact
+						className="list__change-primary-domain"
+						onClick={
+							this.state.changePrimaryDomainModeEnabled
+								? this.disableChangePrimaryDomainMode
+								: this.enableChangePrimaryDomainMode
+						}
+					>
+						{ this.state.changePrimaryDomainModeEnabled
+							? translate( 'Abort primary domain change' )
+							: translate( 'Change primary domain' ) }
 					</Button>
 				</div>
 			</CompactCard>,

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -535,6 +535,8 @@ export class List extends React.Component {
 				selectionIndex={ index }
 				onMakePrimaryClick={ this.handleUpdatePrimaryDomain }
 				onSelect={ this.handleUpdatePrimaryDomain }
+				onUpgradeClick={ this.goToPlans }
+				shouldUpgradeToMakePrimary={ this.shouldUpgradeToMakeDomainPrimary( domain ) }
 			/>
 		) );
 

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -122,7 +122,7 @@
 	}
 }
 
-.domain-management-list-item__upsell {
+.domain-management-list-item__upsell, .domain-item__upsell {
 	display: flex;
 	align-items: center;
 	justify-content: center;
@@ -357,6 +357,10 @@ input[type='radio'].domain-management-list-item__radio {
 
 	.domain-item__busy-message {
 		font-size: $font-body-small;
+		margin-left: auto;
+	}
+
+	.domain-item__upsell {
 		margin-left: auto;
 	}
 }

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -355,7 +355,8 @@ input[type='radio'].domain-management-list-item__radio {
 	display: flex;
 	align-items: center;
 
-	.domain-item__spinner {
+	.domain-item__busy-message {
+		font-size: $font-body-small;
 		margin-left: auto;
 	}
 }

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -341,3 +341,22 @@ input[type='radio'].domain-management-list-item__radio {
 		right: -3px;
 	}
 }
+
+.domain-item__overlay {
+	z-index: 2;
+	background-color: rgba( 255, 255, 255, 0.8 );
+	box-sizing: border-box;
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+	padding: 16px 24px;
+	display: flex;
+	align-items: center;
+
+	.domain-item__spinner {
+		margin-left: auto;
+	}
+}
+


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This adds the ability to set domains as primary in the new site domains view.

<img width="1062" alt="Screenshot 2020-07-14 at 3 15 18 PM" src="https://user-images.githubusercontent.com/13062352/87430060-f0b79580-c5e4-11ea-9fcc-1af58e8d12f7.png">
<img width="207" alt="Screenshot 2020-07-14 at 3 15 36 PM" src="https://user-images.githubusercontent.com/13062352/87430065-f1e8c280-c5e4-11ea-964e-de9dc5c83de2.png">


#### Testing instructions

- Go to /domains/manage/<site>
- Test 'Make primary domain' button works as expected


Also, set `state.changePrimaryDomainModeEnabled` to `true`, and:

- Verify the radio button shows correctly
- Verify on free sites, the plan upsell appears
- Make sure choosing any domain makes that domain primary (when eligible)

