### PR TITLE
Modularise sharing state.

### DIFF
--- a/client/my-sites/marketing/connections/services-group.jsx
+++ b/client/my-sites/marketing/connections/services-group.jsx
@@ -14,6 +14,7 @@ import {
 	getEligibleKeyringServices,
 	isKeyringServicesFetching,
 } from 'state/sharing/services/selectors';
+import { getExpandedService } from 'state/sharing/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import Notice from 'components/notice';
 import SectionHeader from 'components/section-header';
@@ -113,5 +114,5 @@ SharingServicesGroup.defaultProps = {
 export default connect( ( state, { type } ) => ( {
 	isFetching: isKeyringServicesFetching( state ),
 	services: getEligibleKeyringServices( state, getSelectedSiteId( state ), type ),
-	expandedService: state.sharing.expandedService,
+	expandedService: getExpandedService( state ),
 } ) )( SharingServicesGroup );

--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -50,7 +50,6 @@ import postFormats from './post-formats/reducer';
 import receipts from './receipts/reducer';
 import rewind from './rewind/reducer';
 import selectedEditor from './selected-editor/reducer';
-import sharing from './sharing/reducer';
 import simplePayments from './simple-payments/reducer';
 import siteAddressChange from './site-address-change/reducer';
 import siteKeyrings from './site-keyrings/reducer';
@@ -105,7 +104,6 @@ const reducers = {
 	receipts,
 	rewind,
 	selectedEditor,
-	sharing,
 	simplePayments,
 	siteAddressChange,
 	siteKeyrings,

--- a/client/state/selectors/get-post-share-published-actions.js
+++ b/client/state/selectors/get-post-share-published-actions.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import { get, orderBy } from 'lodash';
 
 /**
@@ -9,6 +8,8 @@ import { get, orderBy } from 'lodash';
  */
 import { enrichPublicizeActionsWithConnections } from 'state/selectors/utils/';
 import createSelector from 'lib/create-selector';
+
+import 'state/sharing/init';
 
 const getPublishedActions = ( state, siteId, postId ) =>
 	orderBy(

--- a/client/state/selectors/get-post-share-scheduled-actions.js
+++ b/client/state/selectors/get-post-share-scheduled-actions.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import { get, orderBy } from 'lodash';
 
 /**
@@ -9,6 +8,8 @@ import { get, orderBy } from 'lodash';
  */
 import { enrichPublicizeActionsWithConnections } from 'state/selectors/utils/';
 import createSelector from 'lib/create-selector';
+
+import 'state/sharing/init';
 
 const getScheduledActions = ( state, siteId, postId ) =>
 	orderBy(

--- a/client/state/selectors/get-publicize-connection.js
+++ b/client/state/selectors/get-publicize-connection.js
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import 'state/sharing/init';
 
 /**
  * Return the connection object accoring to the given connectionId.

--- a/client/state/selectors/is-deleting-publicize-share-action.js
+++ b/client/state/selectors/is-deleting-publicize-share-action.js
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import 'state/sharing/init';
 
 /**
  * @param  {object}   state    Global state tree

--- a/client/state/selectors/is-editing-publicize-share-post-action.js
+++ b/client/state/selectors/is-editing-publicize-share-post-action.js
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import 'state/sharing/init';
 
 /**
  * @param  {object}   state    Global state tree

--- a/client/state/selectors/is-fetching-publicize-share-actions-published.js
+++ b/client/state/selectors/is-fetching-publicize-share-actions-published.js
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import 'state/sharing/init';
 
 /**
  * @param {object} state Global state tree

--- a/client/state/selectors/is-fetching-publicize-share-actions-scheduled.js
+++ b/client/state/selectors/is-fetching-publicize-share-actions-scheduled.js
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import 'state/sharing/init';
 
 /**
  * @param {object} state Global state tree

--- a/client/state/selectors/is-requesting-sharing-buttons.js
+++ b/client/state/selectors/is-requesting-sharing-buttons.js
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import 'state/sharing/init';
 
 /**
  * Returns true if we are requesting the sharing buttons for the specified site ID, false otherwise.

--- a/client/state/selectors/is-saving-sharing-buttons.js
+++ b/client/state/selectors/is-saving-sharing-buttons.js
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import 'state/sharing/init';
 
 /**
  * Returns true if we are saving the sharing buttons for the specified site ID, false otherwise.

--- a/client/state/selectors/is-sharing-buttons-save-successful.js
+++ b/client/state/selectors/is-sharing-buttons-save-successful.js
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import 'state/sharing/init';
 
 /**
  * Returns true if the save sharing buttons requests is successful

--- a/client/state/sharing/actions.js
+++ b/client/state/sharing/actions.js
@@ -1,8 +1,9 @@
 /**
  * Internal dependencies
  */
-
 import { CONNECTIONS_SET_EXPANDED_SERVICE } from 'state/action-types';
+
+import 'state/sharing/init';
 
 /**
  * Triggers a network request for a user's connected services.

--- a/client/state/sharing/init.js
+++ b/client/state/sharing/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'state/redux-store';
+import reducer from './reducer';
+
+registerReducer( [ 'sharing' ], reducer );

--- a/client/state/sharing/keyring/actions.js
+++ b/client/state/sharing/keyring/actions.js
@@ -1,7 +1,6 @@
 /**
  * Internal dependencies
  */
-
 import wpcom from 'lib/wp';
 import {
 	KEYRING_CONNECTION_DELETE,
@@ -12,8 +11,12 @@ import {
 	KEYRING_CONNECTIONS_REQUEST_SUCCESS,
 } from 'state/action-types';
 
+import 'state/sharing/init';
+
 /**
  * Triggers a network request for a user's connected services.
+ *
+ * @param {boolean} forceExternalUsersRefetch Whether to force refetching of external users
  *
  * @returns {Function} Action thunk
  */

--- a/client/state/sharing/keyring/selectors.js
+++ b/client/state/sharing/keyring/selectors.js
@@ -1,13 +1,14 @@
 /**
  * External dependencies
  */
-
 import { filter, values } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import createSelector from 'lib/create-selector';
+
+import 'state/sharing/init';
 
 /**
  * Returns an array of keyring connection objects.

--- a/client/state/sharing/package.json
+++ b/client/state/sharing/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/sharing/publicize/actions.js
+++ b/client/state/sharing/publicize/actions.js
@@ -1,7 +1,6 @@
 /**
  * Internal dependencies
  */
-
 import wpcom from 'lib/wp';
 import {
 	PUBLICIZE_CONNECTION_CREATE,
@@ -23,6 +22,8 @@ import {
 	PUBLICIZE_SHARE_FAILURE,
 	PUBLICIZE_SHARE_DISMISS,
 } from 'state/action-types';
+
+import 'state/sharing/init';
 
 export function dismissShareConfirmation( siteId, postId ) {
 	return {

--- a/client/state/sharing/publicize/publicize-actions/actions.js
+++ b/client/state/sharing/publicize/publicize-actions/actions.js
@@ -1,7 +1,6 @@
 /**
  * Internal dependencies
  */
-
 import wpcom from 'lib/wp';
 import {
 	PUBLICIZE_SHARE_ACTIONS_SCHEDULED_REQUEST,
@@ -20,6 +19,8 @@ import {
 	PUBLICIZE_SHARE_ACTION_SCHEDULE_SUCCESS,
 	PUBLICIZE_SHARE_ACTION_SCHEDULE_FAILURE,
 } from 'state/action-types';
+
+import 'state/sharing/init';
 
 export function fetchPostShareActionsScheduled( siteId, postId ) {
 	return ( dispatch ) => {

--- a/client/state/sharing/publicize/selectors.js
+++ b/client/state/sharing/publicize/selectors.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import { filter, get } from 'lodash';
 
 /**
@@ -11,6 +10,8 @@ import createSelector from 'lib/create-selector';
 import canCurrentUser from 'state/selectors/can-current-user';
 import { getCurrentUserId } from 'state/current-user/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
+
+import 'state/sharing/init';
 
 /**
  * Returns an array of known connections for the given site ID.

--- a/client/state/sharing/reducer.js
+++ b/client/state/sharing/reducer.js
@@ -1,10 +1,9 @@
 /**
  * Internal dependencies
  */
-
 import { CONNECTIONS_SET_EXPANDED_SERVICE } from 'state/action-types';
 import keyring from './keyring/reducer';
-import { combineReducers, withoutPersistence } from 'state/utils';
+import { combineReducers, withoutPersistence, withStorageKey } from 'state/utils';
 import publicize from './publicize/reducer';
 import services from './services/reducer';
 
@@ -17,9 +16,11 @@ export const expandedService = withoutPersistence( ( state = '', action ) => {
 	return state;
 } );
 
-export default combineReducers( {
+const combinedReducer = combineReducers( {
 	keyring,
 	publicize,
 	services,
 	expandedService,
 } );
+
+export default withStorageKey( 'sharing', combinedReducer );

--- a/client/state/sharing/selectors.js
+++ b/client/state/sharing/selectors.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import { some } from 'lodash';
 
 /**
@@ -12,6 +11,8 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { getKeyringConnectionsByName } from './keyring/selectors';
 import { getSiteUserConnectionsForService } from './publicize/selectors';
 import { getKeyringServiceByName } from './services/selectors';
+
+import 'state/sharing/init';
 
 /**
  * Given a service, returns a flattened array of all possible accounts for the
@@ -78,4 +79,13 @@ export function getAvailableExternalAccounts( state, serviceName ) {
  */
 export function isServiceExpanded( state, service ) {
 	return service.ID === state.sharing.expandedService;
+}
+
+/**
+ * Returns the ID for the currently expanded service on /marketing/connections
+ *
+ * @param {object} state Global state tree
+ */
+export function getExpandedService( state ) {
+	return state.sharing.expandedService;
 }

--- a/client/state/sharing/services/actions.js
+++ b/client/state/sharing/services/actions.js
@@ -1,7 +1,6 @@
 /**
  * Internal dependencies
  */
-
 import wpcom from 'lib/wp';
 import {
 	KEYRING_SERVICES_RECEIVE,
@@ -10,6 +9,8 @@ import {
 	KEYRING_SERVICES_REQUEST_SUCCESS,
 } from 'state/action-types';
 import { getSelectedSiteId } from 'state/ui/selectors';
+
+import 'state/sharing/init';
 
 /**
  * Triggers a network request for Keyring services.

--- a/client/state/sharing/services/selectors.js
+++ b/client/state/sharing/services/selectors.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import { filter } from 'lodash';
 
 /**
@@ -11,6 +10,8 @@ import config from 'config';
 import canCurrentUser from 'state/selectors/can-current-user';
 import { isJetpackSite, isJetpackModuleActive } from 'state/sites/selectors';
 import isSiteGoogleMyBusinessEligible from 'state/selectors/is-site-google-my-business-eligible';
+
+import 'state/sharing/init';
 
 /**
  * Returns an object of service objects.


### PR DESCRIPTION
This PR is one of many working on modularising state in Calypso. This one handles sharing.

For more details on state modularisation, see the [modularised state documentation](https://github.com/Automattic/wp-calypso/blob/master/docs/modularized-state.md) and p4TIVU-9lM-p2.

Note: I added reviewers that GitHub suggested. Please feel free to ignore the review request or pull in someone else if you're not comfortable reviewing this PR. Thank you!

Fixes #42475.

#### Changes proposed in this Pull Request

* Modularise sharing state

#### Testing instructions

* Install [Redux DevTools](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en).
* Open DevTools and switch to the Redux tab.
* Open `/read` on the live branch or your local copy of this branch.
* Click `State` on the top right to ensure you see all state, and not just the diff for the last action: 
![image](https://user-images.githubusercontent.com/409615/73774406-d3e87d80-477b-11ea-9f59-3e42cc00101f.png)
* Analyse the tree and note that there's no `sharing` key, even if you expand the list of keys. This indicates that the sharing state hasn't been loaded yet.
* Click `My Sites` on the top bar.
* Verify that a `sharing` key is added with the sharing state. This indicates that the sharing state has now been loaded.
* Verify that sharing-related functionality works normally. This indicates that I didn't mess up.