### PR TITLE
Modularise plans state

### DIFF
--- a/client/state/plans/actions.js
+++ b/client/state/plans/actions.js
@@ -7,7 +7,9 @@ import {
 	PLANS_REQUEST_SUCCESS,
 	PLANS_REQUEST_FAILURE,
 } from 'state/action-types';
+
 import 'state/data-layer/wpcom/plans';
+import 'state/plans/init';
 
 /**
  * Action creator function: RECEIVE

--- a/client/state/plans/init.js
+++ b/client/state/plans/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'state/redux-store';
+import reducer from './reducer';
+
+registerReducer( [ 'plans' ], reducer );

--- a/client/state/plans/package.json
+++ b/client/state/plans/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/plans/reducer.js
+++ b/client/state/plans/reducer.js
@@ -7,7 +7,7 @@ import {
 	PLANS_REQUEST_SUCCESS,
 	PLANS_REQUEST_FAILURE,
 } from 'state/action-types';
-import { combineReducers, withSchemaValidation } from 'state/utils';
+import { combineReducers, withSchemaValidation, withStorageKey } from 'state/utils';
 import { itemsSchema } from './schema';
 
 /**
@@ -67,8 +67,10 @@ export const error = ( state = false, action ) => {
 	return state;
 };
 
-export default combineReducers( {
+const combinedReducer = combineReducers( {
 	items,
 	requesting,
 	error,
 } );
+
+export default withStorageKey( 'plans', combinedReducer );

--- a/client/state/plans/selectors.js
+++ b/client/state/plans/selectors.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import { get, find } from 'lodash';
 
 /**
@@ -9,6 +8,8 @@ import { get, find } from 'lodash';
  */
 import createSelector from 'lib/create-selector';
 import { calculateMonthlyPriceForPlan } from 'lib/plans';
+
+import 'state/plans/init';
 
 /**
  * Return WordPress plans getting from state object

--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -49,7 +49,6 @@ import { unseenCount as notificationsUnseenCount } from './notifications';
 import npsSurvey from './nps-survey/reducer';
 import orderTransactions from './order-transactions/reducer';
 import pageTemplates from './page-templates/reducer';
-import plans from './plans/reducer';
 import plugins from './plugins/reducer';
 import postFormats from './post-formats/reducer';
 import postTypes from './post-types/reducer';
@@ -115,7 +114,6 @@ const reducers = {
 	npsSurvey,
 	orderTransactions,
 	pageTemplates,
-	plans,
 	plugins,
 	postFormats,
 	postTypes,


### PR DESCRIPTION
This PR is one of many working on modularising state in Calypso. This one handles plans.

For more details on state modularisation, see the [modularised state documentation](https://github.com/Automattic/wp-calypso/blob/master/docs/modularized-state.md) and p4TIVU-9lM-p2.

Note: I added reviewers that GitHub suggested. Please feel free to ignore the review request or pull in someone else if you're not comfortable reviewing this PR. Thank you!

#### Changes proposed in this Pull Request

* Modularise plans state

#### Testing instructions

* Install [Redux DevTools](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en).
* Open DevTools and switch to the Redux tab.
* Open `/read` on the live branch or your local copy of this branch.
* Click `State` on the top right to ensure you see all state, and not just the diff for the last action: 
![image](https://user-images.githubusercontent.com/409615/73774406-d3e87d80-477b-11ea-9f59-3e42cc00101f.png)
* Analyse the tree and note that there's no `plans` key, even if you expand the list of keys. This indicates that the plans state hasn't been loaded yet.
* Click `My Sites` on the top bar.
* Verify that a `plans` key is added with the plans state. This indicates that the plans state has now been loaded.
* Verify that plans-related functionality works normally. This indicates that I didn't mess up.