### PR TITLE
Jetpack Search:  enable Jetpack Search in production

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -60,6 +60,7 @@
 		"jetpack/happychat": true,
 		"jetpack/scan-product": true,
 		"jetpack/search-product": true,
+		"jetpack/wpcom-search-product": true,
 		"jetpack/on-demand-scan": true,
 		"jetpack/backups-restore": true,
 		"jitms": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* add and enable the Jetpack Search feature flag in production env.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* purchase a plan at `wordpress.com/purchase-product/jetpack_search` when not proxied


