### PR TITLE
Domain-only flow: Set back button/action based on qurey parameter

### DIFF
--- a/client/signup/navigation-link/index.jsx
+++ b/client/signup/navigation-link/index.jsx
@@ -38,6 +38,7 @@ export class NavigationLink extends Component {
 		stepName: PropTypes.string.isRequired,
 		// Allows to force a back button in the first step for example.
 		allowBackFirstStep: PropTypes.bool,
+		rel: PropTypes.string
 	};
 
 	static defaultProps = {
@@ -159,6 +160,7 @@ export class NavigationLink extends Component {
 				className={ buttonClasses }
 				href={ this.getBackUrl() }
 				onClick={ this.handleClick }
+				rel={ this.props.rel }
 			>
 				{ backGridicon }
 				{ text }

--- a/client/signup/navigation-link/index.jsx
+++ b/client/signup/navigation-link/index.jsx
@@ -38,7 +38,7 @@ export class NavigationLink extends Component {
 		stepName: PropTypes.string.isRequired,
 		// Allows to force a back button in the first step for example.
 		allowBackFirstStep: PropTypes.bool,
-		rel: PropTypes.string
+		rel: PropTypes.string,
 	};
 
 	static defaultProps = {

--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -52,7 +52,7 @@ class StepWrapper extends Component {
 				stepName={ this.props.stepName }
 				stepSectionName={ this.props.stepSectionName }
 				backUrl={ this.props.backUrl }
-				rel={ this.props.externalBackUrl ? 'external' : '' }
+				rel={ this.props.isExternalBackUrl ? 'external' : '' }
 				labelText={ this.props.backLabelText }
 				allowBackFirstStep={ this.props.allowBackFirstStep }
 			/>

--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -32,7 +32,7 @@ class StepWrapper extends Component {
 		// Displays an <hr> above the skip button and adds more white space
 		isLargeSkipLayout: PropTypes.bool,
 		isTopButtons: PropTypes.bool,
-		isExternalBackUrl: PropTypes.bool
+		isExternalBackUrl: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -52,7 +52,7 @@ class StepWrapper extends Component {
 				stepName={ this.props.stepName }
 				stepSectionName={ this.props.stepSectionName }
 				backUrl={ this.props.backUrl }
-				rel={ this.props.externalBackUrl ? 'external': '' }
+				rel={ this.props.externalBackUrl ? 'external' : '' }
 				labelText={ this.props.backLabelText }
 				allowBackFirstStep={ this.props.allowBackFirstStep }
 			/>

--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -32,6 +32,7 @@ class StepWrapper extends Component {
 		// Displays an <hr> above the skip button and adds more white space
 		isLargeSkipLayout: PropTypes.bool,
 		isTopButtons: PropTypes.bool,
+		isExternalBackUrl: PropTypes.bool
 	};
 
 	static defaultProps = {
@@ -51,6 +52,7 @@ class StepWrapper extends Component {
 				stepName={ this.props.stepName }
 				stepSectionName={ this.props.stepSectionName }
 				backUrl={ this.props.backUrl }
+				rel={ this.props.externalBackUrl ? 'external': '' }
 				labelText={ this.props.backLabelText }
 				allowBackFirstStep={ this.props.allowBackFirstStep }
 			/>

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -686,6 +686,12 @@ class DomainsStep extends React.Component {
 			}
 		}
 
+		// Use a generic back action when landing directly on domain.
+		if ( 'domain' === flowName ) {
+			backUrl = 'javascript:history.back()';
+			backLabelText = translate( 'Back' );
+		}
+
 		const headerText = this.getHeaderText();
 		const fallbackSubHeaderText = this.getSubHeaderText();
 		const showSkip = isDomainStepSkippable( flowName );

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -665,7 +665,7 @@ class DomainsStep extends React.Component {
 
 		const { flowName, isAllDomains, translate, sites } = this.props;
 		const hasSite = Object.keys( sites ).length > 0;
-		let backUrl, backLabelText;
+		let backUrl, backLabelText, isExternalBackUrl;
 
 		if ( 'transfer' === this.props.stepSectionName || 'mapping' === this.props.stepSectionName ) {
 			backUrl = getStepUrl(
@@ -693,9 +693,7 @@ class DomainsStep extends React.Component {
 		};
 		const source = get( this.props, 'queryObject.source' );
 
-		let isExternalBackUrl;
-
-		if ( backUrlSourceOverrides[ source ] ) {
+		if ( source && backUrlSourceOverrides[ source ] ) {
 			backUrl = backUrlSourceOverrides[ source ];
 			backLabelText = translate( 'Back' );
 
@@ -712,10 +710,10 @@ class DomainsStep extends React.Component {
 				flowName={ this.props.flowName }
 				stepName={ this.props.stepName }
 				backUrl={ backUrl }
-				externalBackUrl={ isExternalBackUrl }
 				positionInFlow={ this.props.positionInFlow }
 				headerText={ headerText }
 				subHeaderText={ fallbackSubHeaderText }
+				isExternalBackUrl={ isExternalBackUrl }
 				fallbackHeaderText={ headerText }
 				fallbackSubHeaderText={ fallbackSubHeaderText }
 				stepContent={

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -686,10 +686,21 @@ class DomainsStep extends React.Component {
 			}
 		}
 
-		// Use a generic back action when landing directly on domain.
-		if ( 'domain' === flowName ) {
-			backUrl = 'javascript:history.back()';
+		// Override Back link if source parameter is found below
+		const backUrlSourceOverrides = {
+			'business-name-generator': '/business-name-generator',
+			'domains': '/domains'
+		};
+		const source = get( this.props, 'queryObject.source' );
+
+		let isExternalBackUrl;
+
+		if ( backUrlSourceOverrides[ source ] ) {
+			backUrl = backUrlSourceOverrides[ source ];
 			backLabelText = translate( 'Back' );
+
+			// Solves route conflicts between LP and calypso (ex. /domains).
+			isExternalBackUrl = true;
 		}
 
 		const headerText = this.getHeaderText();
@@ -701,6 +712,7 @@ class DomainsStep extends React.Component {
 				flowName={ this.props.flowName }
 				stepName={ this.props.stepName }
 				backUrl={ backUrl }
+				externalBackUrl={ isExternalBackUrl }
 				positionInFlow={ this.props.positionInFlow }
 				headerText={ headerText }
 				subHeaderText={ fallbackSubHeaderText }

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -689,7 +689,7 @@ class DomainsStep extends React.Component {
 		// Override Back link if source parameter is found below
 		const backUrlSourceOverrides = {
 			'business-name-generator': '/business-name-generator',
-			'domains': '/domains',
+			domains: '/domains',
 		};
 		const source = get( this.props, 'queryObject.source' );
 

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -689,7 +689,7 @@ class DomainsStep extends React.Component {
 		// Override Back link if source parameter is found below
 		const backUrlSourceOverrides = {
 			'business-name-generator': '/business-name-generator',
-			'domains': '/domains'
+			'domains': '/domains',
 		};
 		const source = get( this.props, 'queryObject.source' );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Landing on the [domain-only](https://wordpress.com/start/domain/domain-only?search=yes&new=Rightbrain%20Coffee) flow, (from [Domains](https://wordpress.com/domains/) or [Business Name Generator](https://wordpress.com/business-name-generator/) LP) shows as 'Back to sites' back button. Clicking on the button tries to take you to the [Sites page](https://wordpress.com/sites) instead of going to the previous page.

This PR fixes this by using a `source` parameter set to either 'domains' or 'business-name-generator' in order to override the default back link URL and label.

The `source` params have been added to the pages here:
- /domains:  D48184-code
- /business-name-generator: D48185-code

![Screenshot on 2020-07-14 at 18-08-33](https://user-images.githubusercontent.com/2749938/87442600-2799a580-c5fd-11ea-9679-e999ed05a6b7.png)




#### Testing instructions

##### With source param
* Navigate to the domain-only step with `source` URL param set to [domains](https://wordpress.com/start/domain/domain-only?new=coffee&search=yes&source=domains) or [business-name-generator](https://wordpress.com/start/domain/domain-only?new=coffee&search=yes&source=business-name-generator)
* Domain search should still work
* Top top left link should say 'Back' 
* Clicking the link while having the `&source=domains` should take you to [/domains Landing Page](https://wordpress.com/domains/) (and not the calypso /domains page)
* Clicking the link while having the `&source=business-name-generator` should take you to [/business-name-generator Landing Page](https://wordpress.com/business-name-generator/)


##### Without source param
* Navigate to the domain-only step without a `source` URL param
* Domain search should still work
* Top top left link should say 'Back to My Sites' and point to [/sites page](https://wordpress.com/sites/)
 
![Screenshot on 2020-07-22 at 19-07-06](https://user-images.githubusercontent.com/2749938/88200316-ac646f00-cc4e-11ea-991c-4d221db2d459.png)
![Screenshot on 2020-07-22 at 19-06-13](https://user-images.githubusercontent.com/2749938/88200321-ae2e3280-cc4e-11ea-8247-d31cfa282b92.png)
