### PR TITLE
Editor: Set the deprecation parameter only if the editor is classic

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -30,6 +30,7 @@ import { updateSiteFrontPage } from 'state/sites/actions';
 import getCurrentRoute from 'state/selectors/get-current-route';
 import getPostTypeTrashUrl from 'state/selectors/get-post-type-trash-url';
 import getGutenbergEditorUrl from 'state/selectors/get-gutenberg-editor-url';
+import { getSelectedEditor } from 'state/selectors/get-selected-editor';
 import getEditorCloseConfig from 'state/selectors/get-editor-close-config';
 import wpcom from 'lib/wp';
 import EditorRevisionsDialog from 'post-editor/editor-revisions/dialog';
@@ -734,7 +735,7 @@ const mapStateToProps = (
 	}
 
 	// Pass through to iframed editor if user is in editor deprecation group.
-	if ( inEditorDeprecationGroup( state ) ) {
+	if ( inEditorDeprecationGroup( state ) && 'classic' === getSelectedEditor( state, siteId ) ) {
 		queryArgs[ 'in-editor-deprecation-group' ] = 1;
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The classic block welcome guide is set to display for any site when the
user is in the deprecation group. This change adds a check to make sure
that the user has their editor set to classic for the site that they are
loading the editor for.

If that's not the case, then we don't set the query parameter on the
iframe because it's not for this site that they have been flagged to
receive the deprecation email.

#### Testing instructions

* Set a user attribute for your user using wpsh on a sandbox $ update_user_attribute( USER_ID, 'editor_deprecation_group', true )
* Open the block editor on a site and in the browser dev tools select `post-new.php` or `post.php` as the javascript context and in console run `wp.data.dispatch( 'core/edit-post' ).toggleFeature( 'welcomeGuide' );` - The classic block Welcome guide will display.
* Don't dismiss the guide, and checkout this branch.
* Load the block editor on the same site and you will either get no welcome guide, or the WordPress.com one.
* Check also on a site with the editor set to classic that the classic block guide still displays.

