### PR TITLE
Media: Use redux selector for next page fetching

### DIFF
--- a/client/components/data/media-list-data/README.md
+++ b/client/components/data/media-list-data/README.md
@@ -29,5 +29,4 @@ The child component should expect to receive any props defined during the render
 
 - `media`: An ordered array of known media items for the site, or `undefined` if currently fetching data
 - `mediaHasNextPage`: A boolean indicating whether more media items exist for the site
-- `mediaFetchingNextPage`: A boolean indicating whether the next page of media items is being fetched
 - `mediaOnFetchNextPage`: A function to invoke when more media items are desired

--- a/client/components/data/media-list-data/index.jsx
+++ b/client/components/data/media-list-data/index.jsx
@@ -20,7 +20,6 @@ function getStateData( siteId ) {
 	return {
 		media: MediaListStore.getAll( siteId ),
 		mediaHasNextPage: MediaListStore.hasNextPage( siteId ),
-		mediaFetchingNextPage: MediaListStore.isFetchingNextPage( siteId ),
 	};
 }
 

--- a/client/lib/media/list-store.js
+++ b/client/lib/media/list-store.js
@@ -59,13 +59,11 @@ function receiveSingle( siteId, item, itemId ) {
 }
 
 function removeSingle( siteId, item ) {
-	let index;
-
 	if ( ! ( siteId in MediaListStore._media ) ) {
 		return;
 	}
 
-	index = MediaListStore._media[ siteId ].indexOf( item.ID );
+	const index = MediaListStore._media[ siteId ].indexOf( item.ID );
 	if ( -1 !== index ) {
 		MediaListStore._media[ siteId ].splice( index, 1 );
 	}
@@ -132,13 +130,13 @@ function sourceHasDate( source ) {
 }
 
 MediaListStore.isItemMatchingQuery = function ( siteId, item ) {
-	let query, matches;
+	let matches;
 
 	if ( ! ( siteId in MediaListStore._activeQueries ) ) {
 		return true;
 	}
 
-	query = omit( MediaListStore._activeQueries[ siteId ].query, SAME_QUERY_IGNORE_PARAMS );
+	const query = omit( MediaListStore._activeQueries[ siteId ].query, SAME_QUERY_IGNORE_PARAMS );
 
 	if ( ! Object.keys( query ).length ) {
 		return true;
@@ -216,13 +214,6 @@ MediaListStore.hasNextPage = function ( siteId ) {
 	return (
 		! ( siteId in MediaListStore._activeQueries ) ||
 		null !== MediaListStore._activeQueries[ siteId ].nextPageHandle
-	);
-};
-
-MediaListStore.isFetchingNextPage = function ( siteId ) {
-	return (
-		siteId in MediaListStore._activeQueries &&
-		MediaListStore._activeQueries[ siteId ].isFetchingNextPage
 	);
 };
 

--- a/client/lib/media/test/list-store.js
+++ b/client/lib/media/test/list-store.js
@@ -267,32 +267,6 @@ describe( 'MediaListStore', () => {
 		} );
 	} );
 
-	describe( '#isFetchingNextPage()', () => {
-		test( 'should return false no request has been made', () => {
-			expect( MediaListStore.isFetchingNextPage( DUMMY_SITE_ID ) ).to.not.be.ok;
-		} );
-
-		test( 'should return true if site media is being fetched', () => {
-			dispatchFetchMedia();
-
-			expect( MediaListStore.isFetchingNextPage( DUMMY_SITE_ID ) ).to.be.ok;
-		} );
-
-		test( 'should return false if site media was received', () => {
-			dispatchFetchMedia();
-			dispatchReceiveMediaItems();
-
-			expect( MediaListStore.isFetchingNextPage( DUMMY_SITE_ID ) ).to.not.be.ok;
-		} );
-
-		test( 'should return false when the query was changed', () => {
-			dispatchFetchMedia();
-			dispatchSetQuery( { query: { mime_type: 'audio/' } } );
-
-			expect( MediaListStore.isFetchingNextPage( DUMMY_SITE_ID ) ).to.not.be.ok;
-		} );
-	} );
-
 	describe( '#isItemMatchingQuery', () => {
 		let isItemMatchingQuery;
 
@@ -382,10 +356,12 @@ describe( 'MediaListStore', () => {
 			expect( MediaListStore.getAll( DUMMY_SITE_ID ) ).to.not.be.undefined;
 		} );
 
-		test( 'should emit a change event when receiving updates', ( done ) => {
-			MediaListStore.once( 'change', done );
+		test( 'should emit a change event when receiving updates', () => {
+			return new Promise( ( done ) => {
+				MediaListStore.once( 'change', done );
 
-			dispatchReceiveMediaItems();
+				dispatchReceiveMediaItems();
+			} );
 		} );
 
 		test( 'should ignore received items where the query does not match', () => {

--- a/client/my-sites/media-library/external-media-header.jsx
+++ b/client/my-sites/media-library/external-media-header.jsx
@@ -13,10 +13,10 @@ import PropTypes from 'prop-types';
  */
 import MediaLibraryScale from './scale';
 import { Card, Button } from '@automattic/components';
-import MediaListStore from 'lib/media/list-store';
 import StickyPanel from 'components/sticky-panel';
 import { addExternalMedia, fetchNextMediaPage } from 'state/media/thunks';
 import { changeMediaSource } from 'state/media/actions';
+import isFetchingNextPage from 'state/selectors/is-fetching-next-page';
 
 const DEBOUNCE_TIME = 250;
 
@@ -31,59 +31,53 @@ class MediaLibraryExternalHeader extends React.Component {
 		sticky: PropTypes.bool,
 		hasAttribution: PropTypes.bool,
 		hasRefreshButton: PropTypes.bool,
+		isFetchingNextPage: PropTypes.bool,
 	};
 
 	constructor( props ) {
 		super( props );
 
 		this.handleClick = this.onClick.bind( this );
-		this.handleMedia = this.onUpdateState.bind( this );
 
-		// The MediaListStore fetching state can bounce between true and false quickly.
+		// The redux `isFetchingNextPage` state can bounce between true and false quickly.
 		// We disable the refresh button if fetching and rather than have the button flicker
-		// we debounce when fetching=false, but don't debounce when fetching=true - this means
+		// we debounce when debouncedFetching=false, but don't debounce when debouncedFetching=true - this means
 		// our refresh button is disabled instantly but only enabled after the debounce time
 		this.handleFetchOn = this.onSetFetch.bind( this );
 		this.handleFetchOff = debounce( this.onDisableFetch.bind( this ), DEBOUNCE_TIME );
 
-		this.state = this.getState();
+		this.state = {
+			debouncedFetching: props.isFetchingNextPage,
+		};
 	}
 
 	onSetFetch() {
-		// We're now fetching - cancel any fetch=off debounce as we want the button to be disabled instantly
+		// We're now debouncedFetching - cancel any fetch=off debounce as we want the button to be disabled instantly
 		this.handleFetchOff.cancel();
-		this.setState( { fetching: true } );
+		this.setState( { debouncedFetching: true } );
 	}
 
 	onDisableFetch() {
-		// This is debounced so we only enable the button DEBOUNCE_TIME after fetching is false
-		this.setState( { fetching: false } );
-	}
-
-	componentDidMount() {
-		MediaListStore.on( 'change', this.handleMedia );
+		// This is debounced so we only enable the button DEBOUNCE_TIME after debouncedFetching is false
+		this.setState( { debouncedFetching: false } );
 	}
 
 	componentWillUnmount() {
 		// Cancel the debounce, just in case it fires after we've unmounted
 		this.handleFetchOff.cancel();
-		MediaListStore.off( 'change', this.handleMedia );
 	}
 
-	onUpdateState() {
-		const { fetching } = this.getState();
+	componentDidUpdate() {
+		if ( this.props.isFetchingNextPage === this.state.debouncedFetching ) {
+			// don't force a re-update if already synced
+			return;
+		}
 
-		if ( fetching ) {
+		if ( this.props.isFetchingNextPage ) {
 			this.handleFetchOn();
 		} else {
 			this.handleFetchOff();
 		}
-	}
-
-	getState() {
-		return {
-			fetching: MediaListStore.isFetchingNextPage( this.props.site.ID ),
-		};
 	}
 
 	onClick() {
@@ -129,7 +123,7 @@ class MediaLibraryExternalHeader extends React.Component {
 				{ hasAttribution && this.renderPexelsAttribution() }
 
 				{ hasRefreshButton && (
-					<Button compact disabled={ this.state.fetching } onClick={ this.handleClick }>
+					<Button compact disabled={ this.state.debouncedFetching } onClick={ this.handleClick }>
 						<Gridicon icon="refresh" size={ 24 } />
 
 						{ translate( 'Refresh' ) }
@@ -158,6 +152,10 @@ class MediaLibraryExternalHeader extends React.Component {
 	}
 }
 
-export default connect( null, { addExternalMedia, changeMediaSource, fetchNextMediaPage } )(
+const mapStateToProps = ( state, { site } ) => ( {
+	isFetchingNextPage: isFetchingNextPage( state, site?.ID ),
+} );
+
+export default connect( mapStateToProps, { addExternalMedia, changeMediaSource, fetchNextMediaPage } )(
 	localize( MediaLibraryExternalHeader )
 );

--- a/client/my-sites/media-library/list.jsx
+++ b/client/my-sites/media-library/list.jsx
@@ -21,6 +21,7 @@ import SortedGrid from 'components/sorted-grid';
 import { withLocalizedMoment } from 'components/localized-moment';
 import { getPreference } from 'state/preferences/selectors';
 import { setMediaLibrarySelectedItems } from 'state/media/actions';
+import isFetchingNextPage from 'state/selectors/is-fetching-next-page';
 
 export class MediaLibraryList extends React.Component {
 	static displayName = 'MediaLibraryList';
@@ -37,7 +38,7 @@ export class MediaLibraryList extends React.Component {
 		mediaScale: PropTypes.number.isRequired,
 		thumbnailType: PropTypes.string,
 		mediaHasNextPage: PropTypes.bool,
-		mediaFetchingNextPage: PropTypes.bool,
+		isFetchingNextPage: PropTypes.bool,
 		mediaOnFetchNextPage: PropTypes.func,
 		single: PropTypes.bool,
 		scrollable: PropTypes.bool,
@@ -48,7 +49,7 @@ export class MediaLibraryList extends React.Component {
 		containerWidth: 0,
 		rowPadding: 10,
 		mediaHasNextPage: false,
-		mediaFetchingNextPage: false,
+		isFetchingNextPage: false,
 		mediaOnFetchNextPage: noop,
 		single: false,
 		scrollable: false,
@@ -242,7 +243,7 @@ export class MediaLibraryList extends React.Component {
 				items={ this.props.media || [] }
 				itemsPerRow={ this.getItemsPerRow() }
 				lastPage={ ! this.props.mediaHasNextPage }
-				fetchingNextPage={ this.props.mediaFetchingNextPage }
+				fetchingNextPage={ this.props.isFetchingNextPage }
 				guessedItemHeight={ this.getMediaItemHeight() }
 				fetchNextPage={ onFetchNextPage }
 				getItemRef={ this.getItemRef }
@@ -258,6 +259,7 @@ export default connect(
 	( state, { site } ) => ( {
 		mediaScale: getPreference( state, 'mediaScale' ),
 		selectedItems: getMediaLibrarySelectedItems( state, site?.ID ),
+		isFetchingNextPage: isFetchingNextPage( state, site?.ID ),
 	} ),
 	{ setMediaLibrarySelectedItems }
 )( withRtl( withLocalizedMoment( MediaLibraryList ) ) );

--- a/client/state/selectors/is-fetching-next-page.js
+++ b/client/state/selectors/is-fetching-next-page.js
@@ -1,15 +1,17 @@
 /**
- * Internal dependencies
+ * External dependencies
  */
 import { get } from 'lodash';
+import createSelector from 'lib/create-selector';
 
-/**
- * Returns true if media is being requested for a specified site ID and query.
- *
- * @param  {object}  state  Global state tree
- * @param  {number}  siteId Site ID
- * @returns {boolean}           True if media is being requested
- */
-export default function isFetchingNextPage( state, siteId ) {
-	return get( state.media.fetching, [ siteId, 'nextPage' ], false );
-}
+export default createSelector(
+	/**
+	 * Returns true if media is being requested for a specified site ID and query.
+	 *
+	 * @param {object} state The state object
+	 * @param {number} siteId Site ID
+	 * @returns {boolean}           True if media is being requested
+	 */
+	( state, siteId ) => get( state.media.fetching, [ siteId, 'nextPage' ], false ),
+	[ ( state, siteId ) => state.media.fetching?.[ siteId ] ]
+);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Replace `MediaListStore.isFetchingNextPage` with calls to redux selector for `isFetchingNextPage`
* Remove `MediaListStore.isFetchingNextPage` and related state
* Memoize `isFetchingNextPage`

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Using all three sources (uploaded, pexels, and google photos) ensure that when loading the next page of items, that placeholders are rendered in the same way as production
* Using the google photos source, ensure that the refresh button is disabled when:
    * You have just pressed the refresh button
    * A new page of media items is loading (you'll need a photos account with at least 50 or more photos for this to work)

Part of https://github.com/Automattic/wp-calypso/issues/43663
