### PR TITLE
Composite Checkout: Filter out unknown payment methods in translateResponseCartToWPCOMCart

### DIFF
--- a/client/my-sites/checkout/composite-checkout/wpcom/lib/translate-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/lib/translate-cart.ts
@@ -136,10 +136,8 @@ export function translateResponseCartToWPCOMCart( serverCart: ResponseCart ): WP
 		subtotal: subtotalItem,
 		credits: credits_integer > 0 ? creditsLineItem : null,
 		allowedPaymentMethods: allowed_payment_methods
-			.filter( ( slug ) => {
-				return slug !== 'WPCOM_Billing_MoneyPress_Paygate';
-			} ) // TODO: stop returning this from the server
 			.map( readWPCOMPaymentMethodClass )
+			.filter( Boolean )
 			.map( translateWpcomPaymentMethodToCheckoutPaymentMethod )
 			.filter( Boolean ),
 		couponCode: coupon,

--- a/client/my-sites/checkout/composite-checkout/wpcom/lib/translate-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/lib/translate-cart.ts
@@ -17,6 +17,7 @@ import {
 	CheckoutCartItem,
 	readWPCOMPaymentMethodClass,
 	translateWpcomPaymentMethodToCheckoutPaymentMethod,
+	WPCOMPaymentMethodClass,
 } from '../types';
 import { isPlan, isDomainTransferProduct, isDomainProduct } from 'lib/products-values';
 
@@ -137,12 +138,13 @@ export function translateResponseCartToWPCOMCart( serverCart: ResponseCart ): WP
 		credits: credits_integer > 0 ? creditsLineItem : null,
 		allowedPaymentMethods: allowed_payment_methods
 			.map( readWPCOMPaymentMethodClass )
-			.filter( Boolean )
-			.map( translateWpcomPaymentMethodToCheckoutPaymentMethod )
-			.filter( Boolean ),
+			.filter( ( Boolean as WPCOMPaymentMethodClass ) as ExcludesNull )
+			.map( translateWpcomPaymentMethodToCheckoutPaymentMethod ),
 		couponCode: coupon,
 	};
 }
+
+type ExcludesNull = < T >( x: T | null ) => x is T;
 
 function isRealProduct( serverCartItem: ResponseCartProduct | TempResponseCartProduct ): boolean {
 	// Credits are displayed separately, so we do not need to include the pseudo-product in the line items.

--- a/client/my-sites/checkout/composite-checkout/wpcom/types/backend/payment-method.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/types/backend/payment-method.ts
@@ -105,9 +105,9 @@ export interface WPCOMBillingWebPayment {
  *
  * @param slug Name of one of the payment method classes on WPCOM
  *
- * @returns Typed payment method slug
+ * @returns Typed payment method slug or null
  */
-export function readWPCOMPaymentMethodClass( slug: string ): WPCOMPaymentMethodClass {
+export function readWPCOMPaymentMethodClass( slug: string ): WPCOMPaymentMethodClass | null {
 	switch ( slug ) {
 		case 'WPCOM_Billing_WPCOM':
 		case 'WPCOM_Billing_Ebanx':
@@ -127,8 +127,7 @@ export function readWPCOMPaymentMethodClass( slug: string ): WPCOMPaymentMethodC
 		case 'WPCOM_Billing_Web_Payment':
 			return { name: slug };
 	}
-
-	throw new Error( `Unrecognized payment method class name: "${ slug }"` );
+	return null;
 }
 
 /**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

`translateResponseCartToWPCOMCart()` is used to transform the `ResponseCart` object (the data from the shopping cart endpoint) into the data we use in new checkout. Part of this is the "available payment methods" array. That array is passed through `readWPCOMPaymentMethodClass` which transforms it to an object with a `name` property. However, if the latter function is passed an unknown payment method, it will throw an error. This doesn't leave much room for the server to add new experimental payment methods, and it also is a poor experience for the user.

In this PR we instead ignore unknown payment methods.

#### Testing instructions

- Modify the shopping cart endpoint to return an unknown allowed payment method string _or_ remove some of the allowed payment method strings from `readWPCOMPaymentMethodClass`.
- Load composite checkout and be sure that the page loads correctly without throwing an error.