### PR TITLE
DomainPicker: Support for non-changeable existing subdomain.

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/common/data-stores/launch/actions.ts
+++ b/apps/full-site-editing/full-site-editing-plugin/common/data-stores/launch/actions.ts
@@ -14,6 +14,10 @@ export const setDomain = ( domain: DomainSuggestions.DomainSuggestion ) => ( {
 	domain,
 } );
 
+export const unsetDomain = () => ( {
+	type: 'UNSET_DOMAIN' as const,
+} );
+
 export const setDomainSearch = ( domainSearch: string ) => ( {
 	type: 'SET_DOMAIN_SEARCH' as const,
 	domainSearch,
@@ -38,4 +42,6 @@ export function* launchSite() {
 	}
 }
 
-export type LaunchAction = ReturnType< typeof setDomain | typeof setDomainSearch | typeof setPlan >;
+export type LaunchAction = ReturnType<
+	typeof setDomain | typeof unsetDomain | typeof setDomainSearch | typeof setPlan
+>;

--- a/apps/full-site-editing/full-site-editing-plugin/common/data-stores/launch/reducer.ts
+++ b/apps/full-site-editing/full-site-editing-plugin/common/data-stores/launch/reducer.ts
@@ -17,6 +17,9 @@ const domain: Reducer< DomainSuggestions.DomainSuggestion | undefined, LaunchAct
 	if ( action.type === 'SET_DOMAIN' ) {
 		return action.domain;
 	}
+	if ( action.type === 'UNSET_DOMAIN' ) {
+		return undefined;
+	}
 	return state;
 };
 

--- a/apps/full-site-editing/full-site-editing-plugin/editor-domain-picker/src/domain-picker-fse/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-domain-picker/src/domain-picker-fse/index.tsx
@@ -58,6 +58,7 @@ const DomainPickerFSE: React.FunctionComponent< Props > = ( { onSelect } ) => {
 			onDomainSelect={ handleDomainSelect }
 			onExistingSubdomainSelect={ handleExistingSubdomainSelect }
 			analyticsUiAlgo="editor_domain_modal"
+			segregateFreeAndPaid
 		/>
 	);
 };

--- a/apps/full-site-editing/full-site-editing-plugin/editor-domain-picker/src/domain-picker-fse/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-domain-picker/src/domain-picker-fse/index.tsx
@@ -26,13 +26,17 @@ const DomainPickerFSE: React.FunctionComponent< Props > = ( { onSelect } ) => {
 	const freeDomain = useCurrentDomainName();
 
 	const { domain, domainSearch } = useSelect( ( select ) => select( LAUNCH_STORE ).getState() );
-	const { setDomain, setDomainSearch } = useDispatch( LAUNCH_STORE );
+	const { setDomain, unsetDomain, setDomainSearch } = useDispatch( LAUNCH_STORE );
 
 	const search = ( domainSearch.trim() || site?.name ) ?? '';
 
 	const handleDomainSelect = ( suggestion: DomainSuggestions.DomainSuggestion ) => {
 		setDomain( suggestion );
 		onSelect?.();
+	};
+
+	const handleExistingSubdomainSelect = () => {
+		unsetDomain();
 	};
 
 	const trackDomainSearchInteraction = ( query: string ) => {
@@ -50,7 +54,9 @@ const DomainPickerFSE: React.FunctionComponent< Props > = ( { onSelect } ) => {
 			onSetDomainSearch={ setDomainSearch }
 			onDomainSearchBlur={ trackDomainSearchInteraction }
 			currentDomain={ domain?.domain_name || freeDomain }
+			existingSubdomain={ freeDomain }
 			onDomainSelect={ handleDomainSelect }
+			onExistingSubdomainSelect={ handleExistingSubdomainSelect }
 			analyticsUiAlgo="editor_domain_modal"
 		/>
 	);

--- a/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-steps/domain-step/styles.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-steps/domain-step/styles.scss
@@ -3,3 +3,13 @@
 .nux-launch-domain-step {
 	padding-bottom: $onboarding-footer-height + 28px;
 }
+
+.domain-picker__suggestion-item {
+	input[type='radio'].domain-picker__suggestion-radio-button {
+		// Specific for WP-Admin environment.
+		&:checked::after {
+			top: 1px;
+			left: 1px;
+		}
+	}
+}

--- a/packages/domain-picker/src/domain-picker/index.tsx
+++ b/packages/domain-picker/src/domain-picker/index.tsx
@@ -30,6 +30,15 @@ import './style.scss';
 
 type DomainSuggestion = DomainSuggestions.DomainSuggestion;
 
+export const ItemGrouper: FunctionComponent< {
+	groupItems: boolean;
+} > = function ItemGrouper( { groupItems, children } ) {
+	if ( groupItems ) {
+		return <div className="domain-picker__suggestion-item-group">{ children }</div>;
+	}
+	return <>{ children }</>;
+};
+
 export interface Props {
 	header?: React.ReactElement;
 
@@ -68,6 +77,9 @@ export interface Props {
 
 	/** Called when the domain search query is changed */
 	onSetDomainSearch: ( value: string ) => void;
+
+	/** Weather to segregate free and paid domains from each other */
+	segregateFreeAndPaid: boolean;
 }
 
 const DomainPicker: FunctionComponent< Props > = ( {
@@ -84,6 +96,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 	onSetDomainSearch,
 	currentDomain,
 	existingSubdomain,
+	segregateFreeAndPaid = false,
 } ) => {
 	const { __ } = useI18n();
 	const label = __( 'Search for a domain' );
@@ -182,51 +195,63 @@ const DomainPicker: FunctionComponent< Props > = ( {
 						</div>
 					) }
 					<div className="domain-picker__suggestion-sections">
-						<div className="domain-picker__suggestion-item-group">
-							{ existingSubdomain && (
-								<SuggestionItem
-									key={ existingSubdomain }
-									domain={ existingSubdomain }
-									cost="Free"
-									isFree
-									isExistingSubdomain
-									railcarId={ baseRailcarId ? `${ baseRailcarId }${ 0 }` : undefined }
-									onRender={ () =>
-										handleItemRender( existingSubdomain, `${ baseRailcarId }${ 0 }`, 0, false )
-									}
-									selected={ currentDomain === existingSubdomain }
-									onSelect={ () => {
-										onExistingSubdomainSelect?.( existingSubdomain );
-									} }
-								/>
+						<>
+							{ segregateFreeAndPaid && (
+								<p className="domain-picker__suggestion-group-label">{ __( 'Keep sub-domain' ) }</p>
 							) }
-							{ domainSuggestions?.map( ( suggestion, i ) => {
-								const index = existingSubdomain ? i + 1 : i;
-								const isRecommended = index === 1;
-								return (
+							<ItemGrouper groupItems={ segregateFreeAndPaid }>
+								{ existingSubdomain && (
 									<SuggestionItem
-										key={ suggestion.domain_name }
-										domain={ suggestion.domain_name }
-										cost={ suggestion.cost }
-										isFree={ suggestion.is_free }
-										isRecommended={ isRecommended }
-										railcarId={ baseRailcarId ? `${ baseRailcarId }${ index }` : undefined }
+										key={ existingSubdomain }
+										domain={ existingSubdomain }
+										cost="Free"
+										isFree
+										isExistingSubdomain
+										railcarId={ baseRailcarId ? `${ baseRailcarId }${ 0 }` : undefined }
 										onRender={ () =>
-											handleItemRender(
-												suggestion.domain_name,
-												`${ baseRailcarId }${ index }`,
-												index,
-												isRecommended
-											)
+											handleItemRender( existingSubdomain, `${ baseRailcarId }${ 0 }`, 0, false )
 										}
+										selected={ currentDomain === existingSubdomain }
 										onSelect={ () => {
-											onDomainSelect( suggestion );
+											onExistingSubdomainSelect?.( existingSubdomain );
 										} }
-										selected={ currentDomain === suggestion.domain_name }
 									/>
-								);
-							} ) ?? times( quantity, ( i ) => <SuggestionItemPlaceholder key={ i } /> ) }
-						</div>
+								) }
+							</ItemGrouper>
+							{ segregateFreeAndPaid && (
+								<p className="domain-picker__suggestion-group-label">
+									{ __( 'Professional domains' ) }
+								</p>
+							) }
+							<ItemGrouper groupItems={ segregateFreeAndPaid }>
+								{ domainSuggestions?.map( ( suggestion, i ) => {
+									const index = existingSubdomain ? i + 1 : i;
+									const isRecommended = index === 1;
+									return (
+										<SuggestionItem
+											key={ suggestion.domain_name }
+											domain={ suggestion.domain_name }
+											cost={ suggestion.cost }
+											isFree={ suggestion.is_free }
+											isRecommended={ isRecommended }
+											railcarId={ baseRailcarId ? `${ baseRailcarId }${ index }` : undefined }
+											onRender={ () =>
+												handleItemRender(
+													suggestion.domain_name,
+													`${ baseRailcarId }${ index }`,
+													index,
+													isRecommended
+												)
+											}
+											onSelect={ () => {
+												onDomainSelect( suggestion );
+											} }
+											selected={ currentDomain === suggestion.domain_name }
+										/>
+									);
+								} ) ?? times( quantity, ( i ) => <SuggestionItemPlaceholder key={ i } /> ) }
+							</ItemGrouper>
+						</>
 
 						{ ! isExpanded &&
 							allDomainSuggestions?.length &&

--- a/packages/domain-picker/src/domain-picker/index.tsx
+++ b/packages/domain-picker/src/domain-picker/index.tsx
@@ -44,7 +44,7 @@ export interface Props {
 
 	onExistingSubdomainSelect?: ( existingSubdomain: string ) => void;
 
-	/** Paid omain suggestions to show when the picker isn't expanded */
+	/** Paid domain suggestions to show when the picker isn't expanded */
 	quantity?: number;
 
 	/** Domain suggestions to show when the picker is expanded */
@@ -183,7 +183,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 					) }
 					<div className="domain-picker__suggestion-sections">
 						<div className="domain-picker__suggestion-item-group">
-							{ domainSuggestions && existingSubdomain && (
+							{ existingSubdomain && (
 								<SuggestionItem
 									key={ existingSubdomain }
 									domain={ existingSubdomain }

--- a/packages/domain-picker/src/domain-picker/index.tsx
+++ b/packages/domain-picker/src/domain-picker/index.tsx
@@ -79,7 +79,7 @@ export interface Props {
 	onSetDomainSearch: ( value: string ) => void;
 
 	/** Weather to segregate free and paid domains from each other */
-	segregateFreeAndPaid: boolean;
+	segregateFreeAndPaid?: boolean;
 }
 
 const DomainPicker: FunctionComponent< Props > = ( {

--- a/packages/domain-picker/src/domain-picker/style.scss
+++ b/packages/domain-picker/src/domain-picker/style.scss
@@ -67,12 +67,12 @@
 .domain-picker__suggestion-group-label {
 	margin: 0;
 	margin-top: 1.5em;
-	margin-bottom: 1em;
+	margin-bottom: 0.5em;
 	text-transform: uppercase;
-	color: var( --studio-gray-20 );
+	color: var( --studio-gray-40 );
 	font-size: 12px;
-	font-weight: 400;
 	letter-spacing: 1px;
+	font-weight: bold;
 }
 
 .domain-picker__suggestion-item {

--- a/packages/domain-picker/src/domain-picker/style.scss
+++ b/packages/domain-picker/src/domain-picker/style.scss
@@ -265,3 +265,8 @@
 	width: 220px;
 	padding-right: 30px;
 }
+
+.domain-picker__change-subdomain-tip {
+	font-size: $font-body-extra-small;
+	color: var( --studio-gray-40 );
+}

--- a/packages/domain-picker/src/domain-picker/style.scss
+++ b/packages/domain-picker/src/domain-picker/style.scss
@@ -139,6 +139,11 @@
 			border-color: var( --studio-blue-30 );
 			background-color: var( --studio-blue-30 );
 
+			// wp-admin's forms.css uses ::before on radio button
+			&::before {
+				display: none;
+			}
+
 			&::after {
 				content: '';
 				width: 12px;

--- a/packages/domain-picker/src/domain-picker/suggestion-item.tsx
+++ b/packages/domain-picker/src/domain-picker/suggestion-item.tsx
@@ -8,20 +8,24 @@ import { sprintf } from '@wordpress/i18n';
 import { v4 as uuid } from 'uuid';
 import { recordTrainTracksInteract } from '@automattic/calypso-analytics';
 
-type DomainSuggestion = import('@automattic/data-stores').DomainSuggestions.DomainSuggestion;
-
 interface Props {
-	suggestion: DomainSuggestion;
-	railcarId: string | undefined;
+	domain: string;
+	cost: string;
+	isFree?: boolean;
+	isExistingSubdomain?: boolean;
 	isRecommended?: boolean;
+	railcarId: string | undefined;
 	onRender: () => void;
-	onSelect: ( domainSuggestion: DomainSuggestion ) => void;
+	onSelect: ( domain: string ) => void;
 	selected?: boolean;
 }
 
 const DomainPickerSuggestionItem: FunctionComponent< Props > = ( {
-	suggestion,
+	domain,
+	cost,
 	railcarId,
+	isFree = false,
+	isExistingSubdomain = false,
 	isRecommended = false,
 	onSelect,
 	onRender,
@@ -29,7 +33,6 @@ const DomainPickerSuggestionItem: FunctionComponent< Props > = ( {
 } ) => {
 	const { __ } = useI18n();
 
-	const domain = suggestion.domain_name;
 	const dotPos = domain.indexOf( '.' );
 	const domainName = domain.slice( 0, dotPos );
 	const domainTld = domain.slice( dotPos );
@@ -57,13 +60,13 @@ const DomainPickerSuggestionItem: FunctionComponent< Props > = ( {
 				railcarId: previousRailcarId,
 			} );
 		}
-		onSelect( suggestion );
+		onSelect( domain );
 	};
 
 	return (
 		<label
 			className={ classnames( 'domain-picker__suggestion-item', {
-				'is-free': suggestion.is_free,
+				'is-free': isFree,
 				'is-selected': selected,
 			} ) }
 		>
@@ -76,18 +79,25 @@ const DomainPickerSuggestionItem: FunctionComponent< Props > = ( {
 				checked={ selected }
 			/>
 			<div className="domain-picker__suggestion-item-name">
-				<span className="domain-picker__domain-name">{ domainName }</span>
-				<span className="domain-picker__domain-tld">{ domainTld }</span>
-				{ isRecommended && (
-					<div className="domain-picker__badge is-recommended">{ __( 'Recommended' ) }</div>
+				<div>
+					<span className="domain-picker__domain-name">{ domainName }</span>
+					<span className="domain-picker__domain-tld">{ domainTld }</span>
+					{ isRecommended && (
+						<div className="domain-picker__badge is-recommended">{ __( 'Recommended' ) }</div>
+					) }
+				</div>
+				{ isExistingSubdomain && (
+					<div className="domain-picker__change-subdomain-tip">
+						{ __( 'You can change your free subdomain later under Domain Settings.' ) }
+					</div>
 				) }
 			</div>
 			<div
 				className={ classnames( 'domain-picker__price', {
-					'is-paid': ! suggestion.is_free,
+					'is-paid': ! isFree,
 				} ) }
 			>
-				{ suggestion.is_free ? (
+				{ isFree ? (
 					__( 'Free' )
 				) : (
 					<>
@@ -95,7 +105,7 @@ const DomainPickerSuggestionItem: FunctionComponent< Props > = ( {
 						<span className="domain-picker__price-cost">
 							{
 								/* translators: %s is the price with currency. Eg: $15/year. */
-								sprintf( __( '%s/year' ), suggestion.cost )
+								sprintf( __( '%s/year' ), cost )
 							}
 						</span>
 					</>


### PR DESCRIPTION
#### Note to anyone reading this while preparing a release of the FSE plugin
This change doesn't require any release notes. We're developing a new feature which is currently hidden behind a flag.

## Changes proposed in this Pull Request

When domain picker is used under FSE, the user already has an existing free subdomain. The domain picker should show the user's existing free subdomain.

* A new action `UNSET_DOMAIN` is added to launch store.
* DomainSuggestionItem component accepts `domain`, `cost` and `isFree` param instead of the whole `suggestion` object. This makes `<SuggestionItem>` component reusable to display existing free subdomain which doesn't have a `suggestion` object.

When the existing free subdomain is picked, the `UNSET_DOMAIN` action is called. The `domain` prop in the launch store is set to `undefined`.

**Note:**
1. Ignore the flow weirdness (radio button with missing continue button) on launch flow. This PR is just to review and discuss technical implementation of this feature.
2. I decided not to implement tooltip design, but rather display the change subdomain hint on the next line. This is because using tooltip introduces challenges like how to properly center it next to the domain name and how it should be presented in mobile view. 


## Testing instructions

* Run `yarn` to build and `yarn dev --sync` on `apps/full-site-editing`.
* Test on an unlaunched site on sandbox through the "Launch Site" button. **In FSE, you should see the domains are segregated into free and paid groups.**
* Test on gutenboarding `/new` to ensure there is no regression on the domain picker. **In gutenboarding, you should _NOT_ see the domains are segregated into free and paid groups.**

## Screenshot

![image](https://user-images.githubusercontent.com/1287077/87449410-78a99980-c5fd-11ea-8a26-dd21beb5ef9c.png)

Fixes part of #43750
