### PR TITLE
Remove Node's `url` from reader

### DIFF
--- a/client/reader/discover/helper.js
+++ b/client/reader/discover/helper.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { find, get } from 'lodash';
-import url from 'url';
 import config from 'config';
 import Debug from 'debug';
 
@@ -12,6 +11,7 @@ const debug = Debug( 'calypso:reader:discover' ); // eslint-disable-line
  */
 import userUtils from 'lib/user/utils';
 import { getSiteUrl as readerRouteGetSiteUrl } from 'reader/route';
+import { getUrlParts } from 'lib/url';
 
 function hasDiscoverSlug( post, searchSlug ) {
 	const metaData = get( post, 'discover_metadata.discover_fp_post_formats' );
@@ -72,9 +72,8 @@ export function getSourceData( post ) {
 }
 
 export function getLinkProps( linkUrl ) {
-	const parsedUrl = url.parse( linkUrl ),
-		hostname = get( parsedUrl, 'hostname' ),
-		isExternal = hostname && hostname !== window.location.hostname;
+	const { hostname } = getUrlParts( linkUrl );
+	const isExternal = hostname && hostname !== window.location.hostname;
 
 	return {
 		rel: isExternal ? 'external' : '',

--- a/client/reader/get-helpers.js
+++ b/client/reader/get-helpers.js
@@ -1,7 +1,6 @@
 /**
  * External Dependencies
  */
-import url from 'url';
 import { translate } from 'i18n-calypso';
 import { trim } from 'lodash';
 
@@ -10,6 +9,7 @@ import { trim } from 'lodash';
  */
 import { decodeEntities } from 'lib/formatting';
 import { isSiteDescriptionBlocked } from 'reader/lib/site-description-blocklist';
+import { getUrlParts } from 'lib/url';
 
 /**
  * Given a feed, site, or post: return the site url. return false if one could not be found.
@@ -69,7 +69,7 @@ export const getSiteName = ( { feed, site, post } = {} ) => {
 		siteName = site.domain;
 	} else {
 		const siteUrl = getSiteUrl( { feed, site, post } );
-		siteName = siteUrl ? url.parse( siteUrl ).hostname : null;
+		siteName = siteUrl ? getUrlParts( siteUrl ).hostname : null;
 	}
 
 	return decodeEntities( siteName );

--- a/client/reader/stream/x-post.jsx
+++ b/client/reader/stream/x-post.jsx
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import ReactDom from 'react-dom';
 import classnames from 'classnames';
-import url from 'url';
 import { localize } from 'i18n-calypso';
 import closest from 'component-closest';
 import { get, forEach, uniqBy } from 'lodash';
@@ -21,6 +20,7 @@ import { getFeed } from 'state/reader/feeds/selectors';
 import QueryReaderSite from 'components/data/query-reader-site';
 import QueryReaderFeed from 'components/data/query-reader-feed';
 import Emojify from 'components/emojify';
+import { getUrlParts } from 'lib/url';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 class CrossPost extends PureComponent {
@@ -80,7 +80,7 @@ class CrossPost extends PureComponent {
 	};
 
 	getSiteNameFromURL = ( siteURL ) => {
-		return siteURL && `+${ url.parse( siteURL ).hostname.split( '.' )[ 0 ] }`;
+		return siteURL && `+${ getUrlParts( siteURL ).hostname.split( '.' )[ 0 ] }`;
 	};
 
 	getDescription = ( authorFirstName ) => {

--- a/client/reader/xpost-helper.js
+++ b/client/reader/xpost-helper.js
@@ -1,13 +1,13 @@
 /**
  * External dependencies
  */
-import url from 'url';
 import { has } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import displayTypes from 'state/reader/posts/display-types';
+import { getUrlParts } from 'lib/url';
 
 const { X_POST } = displayTypes;
 
@@ -42,11 +42,11 @@ const exported = {
 					meta.key === '_xpost_original_permalink' ||
 					meta.key === 'xcomment_original_permalink'
 				) {
-					const parsedURL = url.parse( meta.value, false, false );
-					xPostMetadata.siteURL = `${ parsedURL.protocol }//${ parsedURL.host }`;
-					xPostMetadata.postURL = `${ xPostMetadata.siteURL }${ parsedURL.path }`;
-					if ( parsedURL.hash && parsedURL.hash.indexOf( '#comment-' ) === 0 ) {
-						xPostMetadata.commentURL = parsedURL.href;
+					const urlParts = getUrlParts( meta.value );
+					xPostMetadata.siteURL = `${ urlParts.protocol }//${ urlParts.host }`;
+					xPostMetadata.postURL = `${ xPostMetadata.siteURL }${ urlParts.pathname }`;
+					if ( urlParts.hash && urlParts.hash.indexOf( '#comment-' ) === 0 ) {
+						xPostMetadata.commentURL = meta.value;
 					}
 				} else if ( meta.key === 'xpost_origin' ) {
 					const ids = meta.value.split( ':' );


### PR DESCRIPTION
Node's `url` module is deprecated, and we're moving away from it in Calypso, towards Calypso's `lib/url`. Reader is one of the areas still making use of the deprecated module, and this PR addresses that.

#### Changes proposed in this Pull Request

* Remove usage of Node's `url` from reader

#### Testing instructions

Please smoke-test Reader and ensure that it continues to work correctly.
