### PR TITLE
Fixing event tracking for Earn banner clicks on the Stats page

### DIFF
--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -192,8 +192,9 @@ class StatsSite extends Component {
 								'Accept payments for just about anything and turn your website into a reliable source of income with payments and ads.'
 							) }
 							href={ `/earn/${ slug }` }
-							tracksImpressionName="calypso_earn_banner_on_stats_impression"
-							tracksClickName="calypso__earn_banner_on_stats_cta_click"
+							event="stats_earn_nudge"
+							tracksImpressionName="calypso_upgrade_nudge_impression"
+							tracksClickName="calypso_upgrade_nudge_cta_click"
 							showIcon={ true }
 							jetpack={ false }
 						/>


### PR DESCRIPTION
This PR fixes the event tracking for clicks on the Earn banner on the Stats page.

Here's a console output showing the Tracks event firing when the banner is clicked:

<img width="850" alt="Screen Shot 2020-07-14 at 2 23 23 PM" src="https://user-images.githubusercontent.com/35781181/87462280-af6fb780-c5dd-11ea-9069-c49da8becd30.png">

#### Testing instructions

* Checkout the branch (git checkout update/stats-earn-banner-tracking)
* Start Calypso
* Navigate to the stats page (/stats/day/:siteSlug)
* Click the banner with the dev console open.
* Confirm that you are directed to the Earn page
* Confirm that the Tracks event fires

Fixes #43832 
