### PR TITLE
fix(featured image preview): call `fetchMediaItem` instead of `fetch`

### DIFF
--- a/client/components/tinymce/plugins/wpcom-view/views/simple-payments/index.jsx
+++ b/client/components/tinymce/plugins/wpcom-view/views/simple-payments/index.jsx
@@ -32,7 +32,12 @@ class SimplePaymentsView extends Component {
 			<div className="wpview-content wpview-type-simple-payments">
 				<QuerySimplePayments siteId={ siteId } productId={ productId } />
 				<QuerySitePlans siteId={ siteId } />
-				{ product && <QueryMedia siteId={ siteId } mediaId={ product.featuredImageId } /> }
+				{ product && (
+					<QueryMedia
+						siteId={ siteId }
+						mediaId={ product.featuredImageId === '' ? 0 : parseInt( product.featuredImageId ) }
+					/>
+				) }
 				{ this.renderContent() }
 			</div>
 		);

--- a/client/post-editor/editor-featured-image/preview-container.jsx
+++ b/client/post-editor/editor-featured-image/preview-container.jsx
@@ -52,7 +52,7 @@ class EditorFeaturedImagePreviewContainer extends React.Component {
 			}
 
 			defer( () => {
-				this.props.fetch( this.props.siteId, this.props.itemId );
+				this.props.fetchMediaItem( this.props.siteId, this.props.itemId );
 			} );
 		} );
 	};

--- a/client/state/data-layer/wpcom/sites/media/index.js
+++ b/client/state/data-layer/wpcom/sites/media/index.js
@@ -90,7 +90,8 @@ export function requestMedia( action ) {
 
 	const { siteId, query } = action;
 
-	const path = query.source ? `/meta/external-media/${ query.source }` : `/sites/${ siteId }/media`;
+	const path =
+		query && query.source ? `/meta/external-media/${ query.source }` : `/sites/${ siteId }/media`;
 
 	return [
 		http(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* EditorFeaturedImagePreviewContainer: call `this.props.fetchMediaItem` instead of `this.props.fetch` (the latter doesn't exist on that component)
* Fix property access in data layer handler `requestMedia`
* Ensures Pay with Paypal block uses `QueryMedia` with valid `mediaId`s.

#### Testing instructions

* Open a post which has a featured image in the classic post editor and verify no `Uncaught TypeError: this.props.fetch is not a function` error appears in the console.
* Using the classic post editor try adding a Pay with Paypal block, this shouldn't cause any errors in the console.

Fixes #
