### PR TITLE
Jetpack Connect: Adds &hpi=1 to URL to signify that the user is in a purchase flow

### DIFF
--- a/client/jetpack-connect/help-button.jsx
+++ b/client/jetpack-connect/help-button.jsx
@@ -24,7 +24,7 @@ export default function JetpackConnectHelpButton( { label, url } ) {
 	return (
 		<LoggedOutFormLinkItem
 			className="jetpack-connect__help-button"
-			href={ url || 'https://jetpack.com/contact-support' }
+			href={ url || 'https://jetpack.com/contact-support?hpi=1' }
 			target="_blank"
 			rel="noopener noreferrer"
 			onClick={ recordClick }


### PR DESCRIPTION
See p1HpG7-9xU-p2 for context

#### Changes proposed in this Pull Request

* Add hpi=1 to support link that is displayed in the Jetpack connect flow

#### Testing instructions

- Checkout patch
- Go to http://calypso.localhost:3000/jetpack/connect and ensure that support link includes `hpi=1` 
- Enter URL to connect a site
- Ensure support link here also has `hpi=1`

Fixes #
