### PR TITLE
Jetpack Professional: Remove mentions of "enhanced search"

### DIFF
--- a/client/lib/plans/plans-list.js
+++ b/client/lib/plans/plans-list.js
@@ -923,8 +923,8 @@ export const PLANS_LIST = {
 		getDescription: () =>
 			i18n.translate(
 				'{{strong}}Best for organizations:{{/strong}}' +
-					'The most powerful WordPress sites: real-time backups, ' +
-					'enhanced search, and unlimited premium themes.',
+					'The most powerful WordPress sites: real-time backups ' +
+					'and unlimited premium themes.',
 				plansDescriptionHeadingComponent
 			),
 		getTagline: () =>
@@ -994,8 +994,8 @@ export const PLANS_LIST = {
 		getDescription: () =>
 			i18n.translate(
 				'{{strong}}Best for organizations:{{/strong}}' +
-					'The most powerful WordPress sites: real-time backups, ' +
-					'enhanced search, and unlimited premium themes.',
+					'The most powerful WordPress sites: real-time backups ' +
+					'and unlimited premium themes.',
 				plansDescriptionHeadingComponent
 			),
 		getTagline: () =>

--- a/client/my-sites/plans/current-plan/jetpack-checklist/index.tsx
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/index.tsx
@@ -330,31 +330,6 @@ class JetpackChecklist extends PureComponent< Props & LocalizeProps > {
 							} ) }
 						/>
 					) }
-
-					{ isProfessional && (
-						<Task
-							id={ CHECKLIST_KNOWN_TASKS.JETPACK_SEARCH }
-							title={ translate( 'Enhanced Search' ) }
-							description={ translate(
-								'Activate an enhanced, customizable search to replace the default WordPress search feature.'
-							) }
-							completedButtonText={ translate( 'Add search widget' ) }
-							completedTitle={ translate(
-								'The default WordPress search has been replaced by Enhanced Search.'
-							) }
-							duration={ this.getDuration( 1 ) }
-							completed={ this.isComplete( CHECKLIST_KNOWN_TASKS.JETPACK_SEARCH ) }
-							href={
-								this.isComplete( CHECKLIST_KNOWN_TASKS.JETPACK_SEARCH )
-									? this.props.widgetCustomizerPaneUrl
-									: `/settings/performance/${ siteSlug }`
-							}
-							onClick={ this.handleTaskStart( {
-								taskId: CHECKLIST_KNOWN_TASKS.JETPACK_SEARCH,
-								tourId: 'jetpackSearch',
-							} ) }
-						/>
-					) }
 				</Checklist>
 			</Fragment>
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes "enhanced search" from Jetpack Professional plan descriptions.
* Removes "enhanced search" step from the post-purchase checklist.

#### Testing instructions

1. Navigate to `/plans/:jetpackSiteSlug`
2. Ensure that Jetpack Professional plan description contains no mention of "search".
3. Purchase Jetpack Professional for your Jetpack site.
4. Ensure you are directed to `/plans/my-plan/:jetpackSiteSlug`.
5. Ensure that there's no checklist item for "enhanced search" or adding a search widget.