### PR TITLE
Reader: modify heading sizes and alignment

### DIFF
--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -21,34 +21,37 @@
 		text-align: left;
 	}
 
+	/*
+	Not sure this code is needed presumably we don't have h1 in content?
 	h1 {
 		font-size: 54px;
 		margin: 0 0 16px;
 	}
+	*/
 
 	h2 {
-		font-size: $font-title-medium;
+		font-size: $font-title-large;
 		font-weight: 700;
 		margin: 0 0 8px;
 	}
 
 	h3 {
-		font-size: $font-title-small;
+		font-size: $font-title-medium;
 		font-weight: 700;
 		margin: 0 0 8px;
 	}
 
 	h4 {
-		font-size: 32px;
+		font-size: $font-title-small;
 		margin: 0 0 8px;
 	}
 
 	h5 {
-		font-size: 24px;
+		font-size: $font-body;
 	}
 
 	h6 {
-		font-size: 21px;
+		font-size: $font-body-small;
 	}
 
 	p,

--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -8,9 +8,21 @@
 	overflow-wrap: break-word;
 	word-wrap: break-word;
 
-	h1 {
-		font-size: 28px;
+	h1,
+	h2,
+	h3,
+	h4,
+	h5,
+	h6 {
 		font-weight: 700;
+		margin-bottom: 15px;
+		margin-top: 30px;
+		line-height: 1.1;
+		text-align: left;
+	}
+
+	h1 {
+		font-size: 54px;
 		margin: 0 0 16px;
 	}
 
@@ -27,13 +39,16 @@
 	}
 
 	h4 {
-		font-size: 18px;
-		font-weight: 700;
+		font-size: 32px;
 		margin: 0 0 8px;
 	}
 
 	h5 {
-		font-weight: 700;
+		font-size: 24px;
+	}
+
+	h6 {
+		font-size: 21px;
 	}
 
 	p,

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -1,5 +1,3 @@
-
-
 // Styles targeted at story content
 @import './_content.scss';
 
@@ -151,6 +149,71 @@
 
 	@include breakpoint-deprecated( '<660px' ) {
 		margin-top: -35px;
+	}
+
+	h1,
+	h2,
+	h3,
+	h4,
+	h5,
+	h6 {
+		font-weight: 700; /* Taken from http://calypso.localhost:3000/read/blogs/159889361/posts/984 */
+		/* margin-bottom: 5px;
+		margin-top: 5px;  Taken from http://calypso.localhost:3000/read/blogs/159889361/posts/984 */
+
+		margin-bottom: 15px; /* visually more appealing margin? */
+		margin-top: 30px; /* visually more appealing margin? */
+		line-height: 1.1; /* added to deal with overlapping text issues (https://css-tricks.com/almanac/properties/l/line-height/) */
+	}
+
+	h1 {
+		/* font-size: 8.4rem; original rem from http://calypso.localhost:3000/read/blogs/159889361/posts/984 */
+		/* font-size: 4.2rem; estimated best rem without changing root size */
+		font-size: 54px; /* Taken from: wp-calypso/client/components/card-heading/style.scss */
+		font-weight: 800; /* Taken from http://calypso.localhost:3000/read/blogs/159889361/posts/984 */
+	}
+
+	h2 {
+		/* font-size: 4.8rem; */
+		/* font-size: 2.4rem; */
+		font-size: 47px;
+	}
+
+	h3 {
+		/* font-size: 4rem; */
+		/* font-size: 2rem; */
+		font-size: 36px;
+	}
+
+	h4 {
+		/* font-size: 3.2rem; */
+		/* font-size: 1.6rem; */
+		font-size: 32px;
+	}
+
+	h5 {
+		/* font-size: 2.4rem; */
+		/* font-size: 1.2rem; */
+		font-size: 24px;
+	}
+
+	h6 {
+		/* font-size: 1.8rem; */
+		/* font-size: 0.9rem; */
+		font-size: 21px;
+	}
+
+	.has-text-align-center {
+		/* justify-content: center; */
+		text-align: center;
+	}
+	.has-text-align-left {
+		/* justify-content: flex-start; */
+		text-align: left;
+	}
+	.has-text-align-right {
+		/* justify-content: flex-end; */
+		text-align: right;
 	}
 }
 
@@ -461,6 +524,7 @@
 
 	.reader-full-post__header-title-link {
 		display: block;
+		font-family: $sans;
 	}
 
 	.reader-full-post__header-title-link,

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -150,44 +150,6 @@
 	@include breakpoint-deprecated( '<660px' ) {
 		margin-top: -35px;
 	}
-
-	h1,
-	h2,
-	h3,
-	h4,
-	h5,
-	h6 {
-		font-weight: 700;
-		margin-bottom: 15px;
-		margin-top: 30px;
-		line-height: 1.1;
-		text-align: left;
-	}
-
-	h1 {
-		font-size: 54px;
-		font-weight: 800;
-	}
-
-	h2 {
-		font-size: 47px;
-	}
-
-	h3 {
-		font-size: 36px;
-	}
-
-	h4 {
-		font-size: 32px;
-	}
-
-	h5 {
-		font-size: 24px;
-	}
-
-	h6 {
-		font-size: 21px;
-	}
 }
 
 .reader-full-post__story-content {

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -157,63 +157,36 @@
 	h4,
 	h5,
 	h6 {
-		font-weight: 700; /* Taken from http://calypso.localhost:3000/read/blogs/159889361/posts/984 */
-		/* margin-bottom: 5px;
-		margin-top: 5px;  Taken from http://calypso.localhost:3000/read/blogs/159889361/posts/984 */
-
-		margin-bottom: 15px; /* visually more appealing margin? */
-		margin-top: 30px; /* visually more appealing margin? */
-		line-height: 1.1; /* added to deal with overlapping text issues (https://css-tricks.com/almanac/properties/l/line-height/) */
+		font-weight: 700;
+		margin-bottom: 15px;
+		margin-top: 30px;
+		line-height: 1.1;
+		text-align: left;
 	}
 
 	h1 {
-		/* font-size: 8.4rem; original rem from http://calypso.localhost:3000/read/blogs/159889361/posts/984 */
-		/* font-size: 4.2rem; estimated best rem without changing root size */
-		font-size: 54px; /* Taken from: wp-calypso/client/components/card-heading/style.scss */
-		font-weight: 800; /* Taken from http://calypso.localhost:3000/read/blogs/159889361/posts/984 */
+		font-size: 54px;
+		font-weight: 800;
 	}
 
 	h2 {
-		/* font-size: 4.8rem; */
-		/* font-size: 2.4rem; */
 		font-size: 47px;
 	}
 
 	h3 {
-		/* font-size: 4rem; */
-		/* font-size: 2rem; */
 		font-size: 36px;
 	}
 
 	h4 {
-		/* font-size: 3.2rem; */
-		/* font-size: 1.6rem; */
 		font-size: 32px;
 	}
 
 	h5 {
-		/* font-size: 2.4rem; */
-		/* font-size: 1.2rem; */
 		font-size: 24px;
 	}
 
 	h6 {
-		/* font-size: 1.8rem; */
-		/* font-size: 0.9rem; */
 		font-size: 21px;
-	}
-
-	.has-text-align-center {
-		/* justify-content: center; */
-		text-align: center;
-	}
-	.has-text-align-left {
-		/* justify-content: flex-start; */
-		text-align: left;
-	}
-	.has-text-align-right {
-		/* justify-content: flex-end; */
-		text-align: right;
 	}
 }
 
@@ -524,7 +497,6 @@
 
 	.reader-full-post__header-title-link {
 		display: block;
-		font-family: $sans;
 	}
 
 	.reader-full-post__header-title-link,


### PR DESCRIPTION
…les (https://github.com/Automattic/wp-calypso/issues/43595#issuecomment-654828809)

#### Changes proposed in this Pull Request

This PR deals with just the headings section of: https://github.com/Automattic/wp-calypso/issues/43595

#### Testing instructions

Taken from: http://calypso.localhost:3000/read/blogs/159889361/posts/984

Before:

<img width="1232" alt="Screenshot 2020-07-15 15 58 42" src="https://user-images.githubusercontent.com/570876/87501820-28414300-c6b4-11ea-941b-ba2fbc772f11.png">

After:

<img width="1260" alt="Screenshot 2020-07-15 15 57 43" src="https://user-images.githubusercontent.com/570876/87501747-fc25c200-c6b3-11ea-8b25-cc2aa73c7a15.png">



Fixes #
