### PR TITLE
EditorFeaturedImagePreviewContainer: replace `MediaStore.get` with `getMediaItem` redux selector

### DIFF
--- a/client/post-editor/editor-featured-image/preview-container.jsx
+++ b/client/post-editor/editor-featured-image/preview-container.jsx
@@ -4,14 +4,13 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import { defer } from 'lodash';
 import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
-import MediaStore from 'lib/media/store';
 import EditorFeaturedImagePreview from './preview';
+import getMediaItem from 'state/selectors/get-media-item';
 import { fetchMediaItem } from 'state/media/thunks';
 
 class EditorFeaturedImagePreviewContainer extends React.Component {
@@ -23,59 +22,22 @@ class EditorFeaturedImagePreviewContainer extends React.Component {
 		showEditIcon: PropTypes.bool,
 	};
 
-	state = {
-		image: null,
-	};
-
 	componentDidMount() {
-		this.fetchImage();
-		MediaStore.on( 'change', this.updateImageState );
+		this.props.fetchMediaItem( this.props.siteId, this.props.itemId );
 	}
 
 	componentDidUpdate( prevProps ) {
 		const { siteId, itemId } = this.props;
 		if ( siteId !== prevProps.siteId || itemId !== prevProps.itemId ) {
-			this.fetchImage();
+			this.props.fetchMediaItem( siteId, itemId );
+			this.props.onImageChange( itemId );
 		}
 	}
-
-	componentWillUnmount() {
-		MediaStore.off( 'change', this.updateImageState );
-	}
-
-	fetchImage = () => {
-		// We may not necessarily need to trigger a network request if we
-		// already have the data for the media item, so first update the state
-		this.updateImageState( () => {
-			if ( this.state.image ) {
-				return;
-			}
-
-			defer( () => {
-				this.props.fetchMediaItem( this.props.siteId, this.props.itemId );
-			} );
-		} );
-	};
-
-	updateImageState = ( callback ) => {
-		const image = MediaStore.get( this.props.siteId, this.props.itemId );
-		this.setState( { image }, () => {
-			if ( 'function' === typeof callback ) {
-				callback();
-			}
-		} );
-
-		defer( () => {
-			if ( this.props.onImageChange && image && image.ID ) {
-				this.props.onImageChange( image.ID );
-			}
-		} );
-	};
 
 	render() {
 		return (
 			<EditorFeaturedImagePreview
-				image={ this.state.image }
+				image={ this.props.image }
 				maxWidth={ this.props.maxWidth }
 				showEditIcon
 			/>
@@ -83,4 +45,10 @@ class EditorFeaturedImagePreviewContainer extends React.Component {
 	}
 }
 
-export default connect( null, { fetchMediaItem } )( EditorFeaturedImagePreviewContainer );
+const mapStateToProps = ( state, { siteId, itemId } ) => ( {
+	image: getMediaItem( state, siteId, itemId ),
+} );
+
+export default connect( mapStateToProps, { fetchMediaItem } )(
+	EditorFeaturedImagePreviewContainer
+);

--- a/client/post-editor/editor-featured-image/preview-container.jsx
+++ b/client/post-editor/editor-featured-image/preview-container.jsx
@@ -29,7 +29,9 @@ class EditorFeaturedImagePreviewContainer extends React.Component {
 	componentDidUpdate( prevProps ) {
 		const { siteId, itemId } = this.props;
 		if ( siteId !== prevProps.siteId || itemId !== prevProps.itemId ) {
-			this.props.fetchMediaItem( siteId, itemId );
+			if ( ! this.props.image ) {
+				this.props.fetchMediaItem( siteId, itemId );
+			}
 			this.props.onImageChange( itemId );
 		}
 	}

--- a/client/post-editor/editor-featured-image/preview-container.jsx
+++ b/client/post-editor/editor-featured-image/preview-container.jsx
@@ -27,12 +27,15 @@ class EditorFeaturedImagePreviewContainer extends React.Component {
 	}
 
 	componentDidUpdate( prevProps ) {
-		const { siteId, itemId } = this.props;
+		const { siteId, itemId, image } = this.props;
 		if ( siteId !== prevProps.siteId || itemId !== prevProps.itemId ) {
-			if ( ! this.props.image ) {
+			if ( ! image ) {
 				this.props.fetchMediaItem( siteId, itemId );
 			}
-			this.props.onImageChange( itemId );
+
+			if ( this.props.onImageChange && image && image.ID ) {
+				this.props.onImageChange( itemId );
+			}
 		}
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* EditorFeaturedImagePreviewContainer: Replace `MediaStore.get` with `getMediaItem` redux selector

#### Testing instructions

* Use the classic post editor to create a new post
* Set a featured image (from the right sidebar) and make sure it loads in the preview container (above the post)
* Click on that preview container and change the image, make sure that loads as well

related to #43663