### PR TITLE
Check if the sites has loaded before rendering the all domains list

### DIFF
--- a/client/my-sites/domains/domain-management/list/list-all.jsx
+++ b/client/my-sites/domains/domain-management/list/list-all.jsx
@@ -39,6 +39,7 @@ import QuerySiteDomains from 'components/data/query-site-domains';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import { getUserPurchases } from 'state/purchases/selectors';
 import QueryUserPurchases from 'components/data/query-user-purchases';
+import { hasAllSitesList } from 'state/sites/selectors';
 
 /**
  * Style dependencies
@@ -80,8 +81,8 @@ class ListAll extends Component {
 	}
 
 	isLoading() {
-		const { domainsList, requestingFlatDomains, sites } = this.props;
-		return ! sites || ( requestingFlatDomains && domainsList.length === 0 );
+		const { domainsList, requestingFlatDomains, hasAllSitesLoaded } = this.props;
+		return ! hasAllSitesLoaded || ( requestingFlatDomains && domainsList.length === 0 );
 	}
 
 	findDomainDetails( domainsDetails = [], domain = {} ) {
@@ -92,6 +93,7 @@ class ListAll extends Component {
 
 	renderDomainItem( domain ) {
 		const { currentRoute, domainsDetails, sites, requestingSiteDomains } = this.props;
+		const domainDetails = this.findDomainDetails( domainsDetails, domain );
 
 		return (
 			<>
@@ -99,10 +101,12 @@ class ListAll extends Component {
 				<DomainItem
 					currentRoute={ currentRoute }
 					domain={ domain }
-					domainDetails={ this.findDomainDetails( domainsDetails, domain ) }
+					domainDetails={ domainDetails }
 					site={ sites[ domain?.blogId ] }
 					isManagingAllSites={ true }
-					isLoadingDomainDetails={ requestingSiteDomains[ domain?.blogId ] ?? false }
+					isLoadingDomainDetails={
+						! domainDetails && ( requestingSiteDomains[ domain?.blogId ] ?? false )
+					}
 					onClick={ this.handleDomainItemClick }
 				/>
 			</>
@@ -173,6 +177,7 @@ export default connect(
 			requestingFlatDomains: isRequestingAllDomains( state ),
 			requestingSiteDomains: getAllRequestingSiteDomains( state ),
 			sites,
+			hasAllSitesLoaded: hasAllSitesList( state ),
 			user,
 		};
 	},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Loading the all domains list sometimes rerenders the list and it looks like it's reordering the domains list. Turns out that's because the `currentUser` capabilities are not loaded in one pass so the list is rerendered multiple times on initial load. To fix this I've added a check if we've loaded the sites first so there is no rerendering/reordering of the domains list.

#### Testing instructions

* Disable caching in the devtools and reload `/domains/manage` multuple times. The list should load in one pass without reordering (try without this PR to see how it looks).
