### PR TITLE
Modularise notification settings state

### DIFF
--- a/client/state/notification-settings/actions.js
+++ b/client/state/notification-settings/actions.js
@@ -19,7 +19,9 @@ import {
 	NOTIFICATION_SETTINGS_TOGGLE_SETTING,
 } from 'state/action-types';
 import { successNotice, errorNotice } from 'state/notices/actions';
+
 import 'state/data-layer/wpcom/me/notification/settings';
+import 'state/notification-settings/init';
 
 /**
  * Returns an action object to signal the request of the current user notification settings.

--- a/client/state/notification-settings/init.js
+++ b/client/state/notification-settings/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'state/redux-store';
+import reducer from './reducer';
+
+registerReducer( [ 'notificationSettings' ], reducer );

--- a/client/state/notification-settings/package.json
+++ b/client/state/notification-settings/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/notification-settings/reducer.js
+++ b/client/state/notification-settings/reducer.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { combineReducers } from 'state/utils';
+import { combineReducers, withStorageKey } from 'state/utils';
 import toggleState from 'state/notification-settings/toggle-state';
 import {
 	NOTIFICATION_SETTINGS_FETCH,
@@ -63,7 +63,9 @@ export const settings = ( state = { clean: null, dirty: null }, action ) => {
 	return state;
 };
 
-export default combineReducers( {
+const combinedReducer = combineReducers( {
 	isFetching,
 	settings,
 } );
+
+export default withStorageKey( 'notificationSettings', combinedReducer );

--- a/client/state/notification-settings/selectors.js
+++ b/client/state/notification-settings/selectors.js
@@ -3,6 +3,11 @@
  */
 import { get, isEqual } from 'lodash';
 
+/**
+ * Internal dependencies
+ */
+import 'state/notification-settings/init';
+
 export const getNotificationSettings = ( state, source ) =>
 	get( state, [ 'notificationSettings', 'settings', 'dirty', source ] );
 

--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -44,7 +44,6 @@ import jitm from './jitm/reducer';
 import media from './media/reducer';
 import mySites from './my-sites/reducer';
 import notices from './notices/reducer';
-import notificationSettings from './notification-settings/reducer';
 import { unseenCount as notificationsUnseenCount } from './notifications';
 import npsSurvey from './nps-survey/reducer';
 import orderTransactions from './order-transactions/reducer';
@@ -110,7 +109,6 @@ const reducers = {
 	media,
 	mySites,
 	notices,
-	notificationSettings,
 	notificationsUnseenCount,
 	npsSurvey,
 	orderTransactions,


### PR DESCRIPTION
This PR is one of many working on modularising state in Calypso. This one handles notification settings state.

For more details on state modularisation, see the [modularised state documentation](https://github.com/Automattic/wp-calypso/blob/master/docs/modularized-state.md) and p4TIVU-9lM-p2.

Fixes #42461.

#### Changes proposed in this Pull Request

* Modularise notification settings state

#### Testing instructions

* Install [Redux DevTools](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en).
* Open DevTools and switch to the Redux tab.
* Open `/read` on the live branch or your local copy of this branch.
* Click `State` on the top right to ensure you see all state, and not just the diff for the last action: 
![image](https://user-images.githubusercontent.com/409615/73774406-d3e87d80-477b-11ea-9f59-3e42cc00101f.png)
* Analyse the tree and note that there's no `notificationSettings` key, even if you expand the list of keys. This indicates that the notification settings state hasn't been loaded yet.
* Click your avatar on the top bar, followed by `Notification Settings` on the sidebar.
* Verify that a `notificationSettings` key is added with the notification settings state. This indicates that the notification settings state has now been loaded.
* Verify that notification settings-related functionality works normally. This indicates that I didn't mess up.