### PR TITLE
Modularise exporter state

### DIFF
--- a/client/my-sites/exporter/notices.jsx
+++ b/client/my-sites/exporter/notices.jsx
@@ -13,7 +13,7 @@ import CompletePurchaseNotice from './guided-transfer-card/complete-purchase-not
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 import { CALYPSO_CONTACT } from 'lib/url/support';
-import { getExportingState } from 'state/exporter/selectors';
+import { getExportingState, getDownloadUrl } from 'state/exporter/selectors';
 import { isGuidedTransferAwaitingPurchase } from 'state/sites/guided-transfer/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { States } from 'state/exporter/constants';
@@ -70,7 +70,7 @@ class Notices extends Component {
 const mapStateToProps = ( state ) => ( {
 	exportDidComplete: getExportingState( state, getSelectedSiteId( state ) ) === States.COMPLETE,
 	exportDidFail: getExportingState( state, getSelectedSiteId( state ) ) === States.FAILED,
-	exportDownloadURL: state.exporter.downloadURL,
+	exportDownloadURL: getDownloadUrl( state ),
 	isGuidedTransferAwaitingPurchase: isGuidedTransferAwaitingPurchase(
 		state,
 		getSelectedSiteId( state )

--- a/client/state/exporter/actions.js
+++ b/client/state/exporter/actions.js
@@ -1,7 +1,6 @@
 /**
  * Internal dependencies
  */
-
 import wpcom from 'lib/wp';
 import {
 	EXPORT_ADVANCED_SETTINGS_FETCH,
@@ -22,6 +21,7 @@ import {
 import { prepareExportRequest } from './selectors';
 
 import 'state/data-layer/wpcom/sites/exports/media';
+import 'state/exporter/init';
 
 /**
  * Sets the post type to export.
@@ -50,7 +50,7 @@ export function setPostTypeFieldValue( siteId, postType, fieldName, value ) {
  * Fetches the available advanced settings for customizing export content
  *
  * @param {number} siteId The ID of the site to fetch
- * @returns {thunk}        An action thunk for fetching the advanced settings
+ * @returns {Function}        An action thunk for fetching the advanced settings
  */
 export function advancedSettingsFetch( siteId ) {
 	return ( dispatch, getState ) => {

--- a/client/state/exporter/init.js
+++ b/client/state/exporter/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'state/redux-store';
+import reducer from './reducer';
+
+registerReducer( [ 'exporter' ], reducer );

--- a/client/state/exporter/package.json
+++ b/client/state/exporter/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/exporter/reducer.js
+++ b/client/state/exporter/reducer.js
@@ -1,7 +1,6 @@
 /**
  * Internal dependencies
  */
-
 import {
 	EXPORT_ADVANCED_SETTINGS_FETCH_FAIL,
 	EXPORT_ADVANCED_SETTINGS_FETCH,
@@ -15,7 +14,7 @@ import {
 	EXPORT_FAILURE,
 	SET_MEDIA_EXPORT_DATA,
 } from 'state/action-types';
-import { combineReducers } from 'state/utils';
+import { combineReducers, withStorageKey } from 'state/utils';
 import { States } from './constants';
 
 export function selectedPostType( state = null, action ) {
@@ -147,7 +146,7 @@ export function mediaExportUrl( state = null, action ) {
 	return state;
 }
 
-export default combineReducers( {
+const combinedReducer = combineReducers( {
 	selectedPostType,
 	selectedAdvancedSettings,
 	exportingState,
@@ -156,3 +155,5 @@ export default combineReducers( {
 	downloadURL,
 	mediaExportUrl,
 } );
+
+export default withStorageKey( 'exporter', combinedReducer );

--- a/client/state/exporter/selectors.js
+++ b/client/state/exporter/selectors.js
@@ -1,9 +1,10 @@
 /**
  * Internal dependencies
  */
-
 import { States } from './constants.js';
 import { get } from 'lodash';
+
+import 'state/exporter/init';
 
 export const getExportingState = ( state, siteId ) => {
 	const exportingState = state.exporter.exportingState;
@@ -116,4 +117,8 @@ export function prepareExportRequest( state, siteId, { exportAll = true } = {} )
 	const postType = getSelectedPostType( state );
 	const selectedFieldValues = getPostTypeFieldValues( state, siteId, postType );
 	return Object.assign( { post_type: postType }, selectedFieldValues );
+}
+
+export function getDownloadUrl( state ) {
+	return state.exporter.downloadURL;
 }

--- a/client/state/exporter/test/reducer.js
+++ b/client/state/exporter/test/reducer.js
@@ -6,7 +6,7 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
-import { selectedAdvancedSettings, advancedSettings, fetchingAdvancedSettings } from '../reducers';
+import { selectedAdvancedSettings, advancedSettings, fetchingAdvancedSettings } from '../reducer';
 import { SAMPLE_ADVANCED_SETTINGS, SAMPLE_ADVANCED_SETTINGS_EMPTY } from './data';
 import {
 	EXPORT_ADVANCED_SETTINGS_FETCH_FAIL,

--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -24,7 +24,6 @@ import documentHead from './document-head/reducer';
 import emailForwarding from './email-forwarding/reducer';
 import embeds from './embeds/reducer';
 import experiments from './experiments/reducer';
-import exporter from './exporter/reducers';
 import gsuiteUsers from './gsuite-users/reducer';
 import gutenbergOptInOut from './gutenberg-opt-in-out/reducer';
 import happinessEngineers from './happiness-engineers/reducer';
@@ -89,7 +88,6 @@ const reducers = {
 	emailForwarding,
 	embeds,
 	experiments,
-	exporter,
 	gsuiteUsers,
 	gutenbergOptInOut,
 	happinessEngineers,

--- a/client/state/selectors/get-media-export-url.js
+++ b/client/state/selectors/get-media-export-url.js
@@ -3,4 +3,9 @@
  */
 import { get } from 'lodash';
 
+/**
+ * Internal dependencies
+ */
+import 'state/exporter/init';
+
 export default ( state ) => get( state, 'exporter.mediaExportUrl', null );


### PR DESCRIPTION
This PR is one of many working on modularising state in Calypso. This one handles exporter state.

For more details on state modularisation, see the [modularised state documentation](https://github.com/Automattic/wp-calypso/blob/master/docs/modularized-state.md) and p4TIVU-9lM-p2.

Note: I added reviewers that GitHub suggested. Please feel free to ignore the review request or pull in someone else if you're not comfortable reviewing this PR. Thank you!

Fixes #42435.

#### Changes proposed in this Pull Request

* Modularise exporter state
* Rename `reducers.js` to `reducer.js`, for consistency with other parts of state
* Add a new selector, to replace inline state access in component
* Minor lint fixes

#### Testing instructions

* Install [Redux DevTools](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en).
* Open DevTools and switch to the Redux tab.
* Open `/read` on the live branch or your local copy of this branch.
* Click `State` on the top right to ensure you see all state, and not just the diff for the last action: 
![image](https://user-images.githubusercontent.com/409615/73774406-d3e87d80-477b-11ea-9f59-3e42cc00101f.png)
* Analyse the tree and note that there's no `exporter` key, even if you expand the list of keys. This indicates that the exporter state hasn't been loaded yet.
* Click `My Sites` on the top bar, followed by `Tools` and `Export`.
* Verify that a `exporter` key is added with the exporter state. This indicates that the exporter state has now been loaded.
* Verify that exporter-related functionality works normally. This indicates that I didn't mess up.