### PR TITLE
Fix some lazy loading weirdnesses with the all domains list

### DIFF
--- a/client/my-sites/domains/domain-management/list/list-all.jsx
+++ b/client/my-sites/domains/domain-management/list/list-all.jsx
@@ -103,7 +103,7 @@ class ListAll extends Component {
 	renderDomainItem( domain, index ) {
 		const { currentRoute, domainsDetails, sites, requestingSiteDomains } = this.props;
 
-		const content = (
+		return (
 			<React.Fragment key={ `domain-item-${ index }-${ domain.name }` }>
 				{ domain?.blogId && (
 					<LazyRender>
@@ -121,8 +121,6 @@ class ListAll extends Component {
 				/>
 			</React.Fragment>
 		);
-
-		return content;
 	}
 
 	renderDomainsList() {

--- a/client/my-sites/domains/domain-management/list/list-all.jsx
+++ b/client/my-sites/domains/domain-management/list/list-all.jsx
@@ -56,6 +56,8 @@ class ListAll extends Component {
 		requestingSiteDomains: PropTypes.object,
 	};
 
+	renderedQuerySiteDomains = {};
+
 	clickAddDomain = () => {
 		this.props.addDomainClick();
 		page( domainAddNew( '' ) );
@@ -90,12 +92,24 @@ class ListAll extends Component {
 		);
 	}
 
-	renderDomainItem( domain ) {
+	renderQuerySiteDomainsOnce( blogId ) {
+		if ( this.renderedQuerySiteDomains[ blogId ] ) {
+			return null;
+		}
+		this.renderedQuerySiteDomains[ blogId ] = true;
+		return <QuerySiteDomains siteId={ blogId } />;
+	}
+
+	renderDomainItem( domain, index ) {
 		const { currentRoute, domainsDetails, sites, requestingSiteDomains } = this.props;
 
-		return (
-			<>
-				{ domain?.blogId && <QuerySiteDomains siteId={ domain.blogId } /> }
+		const content = (
+			<React.Fragment key={ `domain-item-${ index }-${ domain.name }` }>
+				{ domain?.blogId && (
+					<LazyRender>
+						{ ( render ) => ( render ? this.renderQuerySiteDomainsOnce( domain.blogId ) : null ) }
+					</LazyRender>
+				) }
 				<DomainItem
 					currentRoute={ currentRoute }
 					domain={ domain }
@@ -105,8 +119,10 @@ class ListAll extends Component {
 					isLoadingDomainDetails={ requestingSiteDomains[ domain?.blogId ] ?? false }
 					onClick={ this.handleDomainItemClick }
 				/>
-			</>
+			</React.Fragment>
 		);
+
+		return content;
 	}
 
 	renderDomainsList() {
@@ -120,11 +136,9 @@ class ListAll extends Component {
 			.filter(
 				( domain ) => domain.type !== domainTypes.WPCOM && canManageSitesMap[ domain.blogId ]
 			) // filter on sites we can manage, that aren't `wpcom` type
-			.map( ( domain, index ) => (
-				<LazyRender key={ `lazy-${ index }-${ domain.name }` }>
-					{ ( render ) => ( render ? this.renderDomainItem( domain ) : <ListItemPlaceholder /> ) }
-				</LazyRender>
-			) );
+			.map( ( domain, index ) => {
+				return this.renderDomainItem( domain, index );
+			} );
 
 		return [ <ListHeader key="list-header" />, ...domainListItems ];
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Only load the `QuerySiteDomains` component once per `DomainItem` in the all domains list
* Don't render a placeholder for the `DomainItem` component within the `LazyRenderer` - once the all domain data is available we don't need to do that

#### Testing instructions

* Open the network tab in your devtools and verify that the detailed domain data is only loaded once per site
* When you scroll down the list you shouldn't see the general domain item placeholder component loaded at all
