### PR TITLE
Extra target and files related methods to middleware

### DIFF
--- a/client/server/middleware/assets.js
+++ b/client/server/middleware/assets.js
@@ -1,0 +1,80 @@
+/**
+ * External dependencies
+ */
+import fs from 'fs';
+import path from 'path';
+import { defaults, groupBy, flatten } from 'lodash';
+
+const ASSETS_PATH = path.join( __dirname, '../', 'bundler' );
+const EMPTY_ASSETS = { js: [], 'css.ltr': [], 'css.rtl': [] };
+
+const getAssetsPath = ( target ) => {
+	const result = path.join(
+		ASSETS_PATH,
+		target ? `assets-${ target }.json` : 'assets-fallback.json'
+	);
+	return result;
+};
+
+const getAssetType = ( asset ) => {
+	if ( asset.endsWith( '.rtl.css' ) ) {
+		return 'css.rtl';
+	}
+	if ( asset.endsWith( '.css' ) ) {
+		return 'css.ltr';
+	}
+
+	return 'js';
+};
+
+const getChunkByName = ( assets, chunkName ) =>
+	assets.chunks.find( ( chunk ) => chunk.names.some( ( name ) => name === chunkName ) );
+
+const getChunkById = ( assets, chunkId ) => assets.chunks.find( ( chunk ) => chunk.id === chunkId );
+
+const groupAssetsByType = ( assets ) => defaults( groupBy( assets, getAssetType ), EMPTY_ASSETS );
+
+export default () => {
+	const cachedAssets = {};
+
+	return ( req, res, next ) => {
+		req.getAssets = () => {
+			const target = req.getTarget();
+			if ( ! cachedAssets[ target ] ) {
+				cachedAssets[ target ] = JSON.parse( fs.readFileSync( getAssetsPath( target ), 'utf8' ) );
+			}
+			return cachedAssets[ target ];
+		};
+
+		req.getFilesForEntrypoint = ( name ) => {
+			const entrypointAssets = req
+				.getAssets()
+				.entrypoints[ name ].assets.filter( ( asset ) => ! asset.startsWith( 'manifest' ) );
+			return groupAssetsByType( entrypointAssets );
+		};
+
+		req.getFilesForChunk = ( chunkName ) => {
+			const assets = req.getAssets();
+			const chunk = getChunkByName( assets, chunkName );
+
+			if ( ! chunk ) {
+				console.warn( 'cannot find the chunk ' + chunkName );
+				console.warn( 'available chunks:' );
+				assets.chunks.forEach( ( c ) => {
+					console.log( '    ' + c.id + ': ' + c.names.join( ',' ) );
+				} );
+				return EMPTY_ASSETS;
+			}
+
+			const allTheFiles = chunk.files.concat(
+				flatten( chunk.siblings.map( ( sibling ) => getChunkById( assets, sibling ).files ) )
+			);
+
+			return groupAssetsByType( allTheFiles );
+		};
+
+		req.getEmptyAssets = () => EMPTY_ASSETS;
+
+		next();
+	};
+};

--- a/client/server/middleware/build-target.js
+++ b/client/server/middleware/build-target.js
@@ -1,0 +1,46 @@
+/**
+ * External dependencies
+ */
+import { matchesUA } from 'browserslist-useragent';
+
+/**
+ * Checks whether a user agent is included in the browser list for an environment.
+ *
+ * @param {string} userAgentString The user agent string.
+ * @param {string} environment The `browserslist` environment.
+ *
+ * @returns {boolean} Whether the user agent is included in the browser list.
+ */
+function isUAInBrowserslist( userAgentString, environment = 'defaults' ) {
+	return matchesUA( userAgentString, {
+		env: environment,
+		ignorePatch: true,
+		ignoreMinor: true,
+		allowHigherVersions: true,
+	} );
+}
+
+export default ( calypsoEnv ) => ( req, res, next ) => {
+	const isDevelopment = process.env.NODE_ENV === 'development';
+	const isDesktop = calypsoEnv === 'desktop' || calypsoEnv === 'desktop-development';
+
+	const devTarget = process.env.DEV_TARGET || 'evergreen';
+	const uaTarget = isUAInBrowserslist( req.useragent.source, 'evergreen' )
+		? 'evergreen'
+		: 'fallback';
+
+	// Did the user force fallback, via query parameter?
+	const prodTarget = req.query.forceFallback ? 'fallback' : uaTarget;
+
+	let target = isDevelopment ? devTarget : prodTarget;
+
+	if ( isDesktop ) {
+		target = 'fallback';
+	}
+
+	req.getTarget = () => {
+		return target === 'fallback' ? null : target;
+	};
+
+	next();
+};


### PR DESCRIPTION
### Background

I'm trying to extract webpack-dev-server form `client/server` logic. The idea is that for production it will read the assets from the filesystem (as it does today), but for dev mode it will redirect it to a separate web server. This will allow quick reload of the node service without having to bundle everything all the time. It will also pave the path for potential improvements like deploy the client assets to a shared place (eg: an S3 bucket) without having to deploy the node service every time.

The first step was to introduce tests for the server to make sure I don't break anything (#43177). The next step is to use that safety net to refactor this mega-module and split into smaller modules. This PR is the first of those refactors. Note that no tests has been changed but everything still passes. 

### Future

The next step would be to refactor the tests without changing the code to accommodate them to the new modules (i.e. split the meta-test). Then rinse and repeat with further refactors, until we are happy with the structure of this part of the code.

### Changes in this PR

Refactor methods to compute the request target and assets to middleware. The core of the change is extract existing methods to separate files without changing their logic.

### Testing instructions

Test the following for regular sections (eg: `/read`), 404 pages, `/log-in` and `/gutenboarding`:

* Checkout the branch and start it with `yarn start`. Verify you can navigate around and you get assets from `/calypso/evergreen`. 
* Start the branch with `DEV_TARGET=fallback yarn start` and verify you get assets from `fallback`.
* Load calypso.live with a modern browser, verify assets come from `/calypso/evergreen`.
* Load calypso.live and pass `?forceFallback=true`. Verify assets come from `/calypso/fallback`.
