### PR TITLE
Reader: Increase indentation on sidebar submenu items

### DIFF
--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -241,10 +241,6 @@
 		padding-left: 55px;
 	}
 
-	.sidebar__menu-link-reader {
-		padding-left: 23px;
-	}
-
 	&.is-toggle-open {
 		.sidebar__expandable-arrow {
 			transform: rotate( 180deg );

--- a/client/reader/sidebar/style.scss
+++ b/client/reader/sidebar/style.scss
@@ -49,7 +49,7 @@
 	}
 
 	.sidebar__separator {
-		height: 30px;
+		height: 0;
 	}
 
 	.sidebar__menu-item-sitename {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* See #43396 
* Trying another design for the Reader sidebar; the space between menu groups looked off compared to other areas of the Calypso sidebar. This removes the extra space and indents submenu items for an alternative approach to the hierarchy.

**Before**

<img width="1680" alt="Screen Shot 2020-07-15 at 2 34 00 PM" src="https://user-images.githubusercontent.com/2124984/87582391-54ef5d80-c6a8-11ea-9dfb-eae0819147a0.png">

**After**

<img width="1680" alt="Screen Shot 2020-07-15 at 2 33 43 PM" src="https://user-images.githubusercontent.com/2124984/87582353-4b65f580-c6a8-11ea-9326-f0ad2da74eed.png">

#### Testing instructions

* Switch to this PR and navigate to `/read`
* Note the changes in the sidebar layout; does anything break? Is the hierarchy clearer?
