### PR TITLE
WordAds: Add CCPA configuration settings for Jetpack sites

### DIFF
--- a/client/my-sites/marketing/traffic/index.js
+++ b/client/my-sites/marketing/traffic/index.js
@@ -42,6 +42,7 @@ const SiteSettingsTraffic = ( {
 	isJetpackAdmin,
 	isRequestingSettings,
 	isSavingSettings,
+	onChangeField,
 	setFieldValue,
 	translate,
 } ) => (
@@ -62,6 +63,8 @@ const SiteSettingsTraffic = ( {
 				isSavingSettings={ isSavingSettings }
 				isRequestingSettings={ isRequestingSettings }
 				fields={ fields }
+				onSubmitForm={ handleSubmitForm }
+				onChangeField={ onChangeField }
 			/>
 		) }
 		{ isAdmin && <SeoSettingsHelpCard disabled={ isRequestingSettings || isSavingSettings } /> }
@@ -126,6 +129,8 @@ const getFormSettings = partialRight( pick, [
 	'count_roles',
 	'roles',
 	'enable_header_ad',
+	'wordads_ccpa_enabled',
+	'wordads_ccpa_privacy_policy_url',
 	'jetpack_relatedposts_allowed',
 	'jetpack_relatedposts_enabled',
 	'jetpack_relatedposts_show_headline',

--- a/client/my-sites/site-settings/jetpack-ads.jsx
+++ b/client/my-sites/site-settings/jetpack-ads.jsx
@@ -15,6 +15,9 @@ import { Card, CompactCard } from '@automattic/components';
 import CompactFormToggle from 'components/forms/form-toggle/compact';
 import ExternalLink from 'components/external-link';
 import FormFieldset from 'components/forms/form-fieldset';
+import FormLabel from 'components/forms/form-label';
+import FormTextInput from 'components/forms/form-text-input';
+import FormSectionHeading from 'components/forms/form-section-heading';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import SupportInfo from 'components/support-info';
 import JetpackModuleToggle from 'my-sites/site-settings/jetpack-module-toggle';
@@ -23,6 +26,8 @@ import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { hasFeature } from 'state/sites/plans/selectors';
 import isJetpackModuleActive from 'state/selectors/is-jetpack-module-active';
 import { FEATURE_WORDADS_INSTANT, PLAN_JETPACK_PREMIUM } from 'lib/plans/constants';
+import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
+import { getCustomizerUrl } from 'state/sites/selectors';
 
 class JetpackAds extends Component {
 	static defaultProps = {
@@ -112,7 +117,16 @@ class JetpackAds extends Component {
 	}
 
 	renderSettings() {
-		const { selectedSiteId, selectedSiteSlug, wordadsModuleActive, translate } = this.props;
+		const {
+			fields,
+			onChangeField,
+			selectedSiteId,
+			selectedSiteSlug,
+			wordadsModuleActive,
+			translate,
+			siteIsAtomic,
+			widgetsUrl,
+		} = this.props;
 		const formPending = this.isFormPending();
 
 		return (
@@ -138,6 +152,91 @@ class JetpackAds extends Component {
 							) }
 						</div>
 					</FormFieldset>
+
+					<hr />
+					<FormSectionHeading>{ translate( 'Privacy and Consent' ) }</FormSectionHeading>
+					<FormFieldset>
+						<SupportInfo
+							text={ translate(
+								'Enables a targeted advertising opt-out link for California consumers, as required by the California Consumer Privacy Act (CCPA).'
+							) }
+							link={
+								siteIsAtomic
+									? 'https://wordpress.com/support/your-wordpress-com-site-and-the-ccpa/'
+									: 'https://jetpack.com/support/ads/'
+							}
+						/>
+						{ this.renderToggle(
+							'wordads_ccpa_enabled',
+							! wordadsModuleActive,
+							translate( 'Enable targeted advertising to California site visitors (CCPA)' )
+						) }
+
+						<div className="site-settings__child-settings">
+							<FormSettingExplanation>
+								{ translate(
+									'For more information about the California Consumer Privacy Act (CCPA) and how it pertains to your site, please consult our {{a}}CCPA guide for site owners{{/a}}.',
+									{
+										components: {
+											a: (
+												<a
+													href={
+														siteIsAtomic
+															? 'https://wordpress.com/support/your-wordpress-com-site-and-the-ccpa/'
+															: 'https://jetpack.com/support/ads/'
+													}
+													target="_blank"
+													rel="noopener noreferrer"
+												/>
+											),
+										},
+									}
+								) }
+							</FormSettingExplanation>
+						</div>
+					</FormFieldset>
+
+					{ fields.wordads_ccpa_enabled && (
+						<div className="site-settings__child-settings">
+							<FormFieldset>
+								<FormLabel>{ translate( 'Do Not Sell Link' ) }</FormLabel>
+								<span>
+									{ translate(
+										'CCPA requires that you place a "Do Not Sell My Personal Information" link on every page of your site where targeted advertising will appear. You can use the {{a}}Do Not Sell Link (CCPA) Widget{{/a}}, or the {{code}}[ccpa-do-not-sell-link]{{/code}} shortcode to automatically place this link on your site. Note: the link will always display to logged in administrators regardless of geolocation.',
+										{
+											components: {
+												a: <a href={ widgetsUrl } target="_blank" rel="noopener noreferrer" />,
+												code: <code />,
+											},
+										}
+									) }
+								</span>
+								<FormSettingExplanation>
+									{ translate(
+										'Failure to add this link will result in non-compliance with CCPA.'
+									) }
+								</FormSettingExplanation>
+							</FormFieldset>
+							<FormFieldset>
+								<FormLabel htmlFor="ccpa-privacy-policy-url">
+									{ translate( 'Privacy Policy URL' ) }
+								</FormLabel>
+								<FormTextInput
+									name="ccpa_privacy_policy_url"
+									id="ccpa-privacy-policy-url"
+									value={ fields.wordads_ccpa_privacy_policy_url || '' }
+									onChange={ onChangeField( 'wordads_ccpa_privacy_policy_url' ) }
+									disabled={ formPending }
+									placeholder="https://"
+								/>
+								<FormSettingExplanation>
+									{ translate(
+										'Adds a link to your privacy policy to the bottom of the CCPA notice popup (optional).'
+									) }
+								</FormSettingExplanation>
+							</FormFieldset>
+						</div>
+					) }
 				</Card>
 
 				{ wordadsModuleActive && (
@@ -150,11 +249,17 @@ class JetpackAds extends Component {
 	}
 
 	render() {
-		const { hasWordadsFeature, translate } = this.props;
+		const { hasWordadsFeature, isSavingSettings, onSubmitForm, translate } = this.props;
 
 		return (
 			<div>
-				<SettingsSectionHeader title={ translate( 'Ads' ) } />
+				<SettingsSectionHeader
+					disabled={ this.isFormPending() }
+					isSaving={ isSavingSettings }
+					onButtonClick={ onSubmitForm }
+					showButton={ hasWordadsFeature }
+					title={ translate( 'Ads' ) }
+				/>
 
 				{ hasWordadsFeature ? this.renderSettings() : this.renderUpgradeBanner() }
 			</div>
@@ -172,5 +277,7 @@ export default connect( ( state ) => {
 		selectedSiteId,
 		selectedSiteSlug,
 		wordadsModuleActive: !! isJetpackModuleActive( state, selectedSiteId, 'wordads' ),
+		siteIsAtomic: isSiteAutomatedTransfer( state, selectedSiteId ),
+		widgetsUrl: getCustomizerUrl( state, selectedSiteId, 'widgets' ),
 	};
 } )( localize( JetpackAds ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds WordAds CCPA configuration settings to Marketing -> Traffic for Jetpack sites

#### Testing instructions

* Enable WordAds on a Jetpack site
* Navigate to Marketing -> Traffic
* Verify you can enable/disable CCPA as well as set a Privacy Policy link
* Verify changes apply to your Jetpack site
* Verify settings sync with Jetpack -> Settings -> Traffic in `wp-admin`
