### PR TITLE
Preview: Fix Search & Social breaks other previews

### DIFF
--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -182,6 +182,9 @@ export class WebPreviewContent extends Component {
 
 	setIframeUrl = ( iframeUrl ) => {
 		if ( ! this.iframe || ( ! this.props.showPreview && this.props.isModalWindow ) ) {
+			if ( this.state.iframeUrl !== 'about:blank' ) {
+				this.setState( { iframeUrl: 'about:blank' } );
+			}
 			return;
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix blank iframe issue after switching from SEO mode to other views like Desktop, Mobile, etc. 

#### Testing instructions
1. Try to preview any post or page
2. Switch from Desktop to other devices
3. Now Switch to SEO mode
4. Switch back to Desktop or other devices than SEO

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
Before: 
https://cloudup.com/c9gyEV_TOq7
After:
https://www.loom.com/share/adf28ee1ec7f4d9b8059c1b35506b0a5


Fixes #44184 
@sixhours 