### PR TITLE
Earn: do not register premium content blocks when gutenberg features are not available

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/buttons/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/buttons/edit.js
@@ -25,7 +25,7 @@ const alignmentHooksSetting = {
 };
 
 function ButtonsEdit( { context, subscribeButton, setSubscribeButtonPlan } ) {
-	const planId = context[ 'premium-content/planId' ];
+	const planId = context ? context[ 'premium-content/planId' ] : null;
 
 	const template = [
 		[

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/buttons/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/buttons/index.js
@@ -9,9 +9,10 @@ import { button as icon } from '@wordpress/icons';
  */
 import edit from './edit';
 import save from './save';
+import { getCategoryWithFallbacks } from '../../../block-helpers';
 
 const name = 'premium-content/buttons';
-const category = 'design';
+const category = getCategoryWithFallbacks( 'design', 'common' );
 
 const settings = {
 	name,

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/login-button/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/login-button/index.js
@@ -9,9 +9,10 @@ import { __ } from '@wordpress/i18n';
  */
 import edit from './edit';
 import save from './save';
+import { getCategoryWithFallbacks } from '../../../block-helpers';
 
 const name = 'premium-content/login-button';
-const category = 'design';
+const category = getCategoryWithFallbacks( 'design', 'common' );
 
 /**
  * @typedef {object} Attributes

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/index.js
@@ -9,6 +9,10 @@ import { mergeWith } from 'lodash';
 import apiFetch from '@wordpress/api-fetch';
 import { getBlockType, registerBlockType, unregisterBlockType } from '@wordpress/blocks';
 import { _x } from '@wordpress/i18n';
+import {
+	__experimentalAlignmentHookSettingsProvider,
+	__experimentalBlock,
+} from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -18,6 +22,10 @@ import * as subscriberView from './blocks/subscriber-view';
 import * as loggedOutView from './blocks/logged-out-view';
 import * as buttons from './blocks/buttons';
 import * as loginButton from './blocks/login-button';
+
+const supportsDecoupledBlocks = !! (
+	__experimentalAlignmentHookSettingsProvider && __experimentalBlock
+);
 
 /**
  * Function to register an individual block.
@@ -129,5 +137,7 @@ export const registerPremiumContentBlocks = () => {
 	[ container, loggedOutView, subscriberView, buttons, loginButton ].forEach( registerBlock );
 };
 
-registerPremiumContentBlocks();
-configurePremiumContentBlocks();
+if ( supportsDecoupledBlocks ) {
+	registerPremiumContentBlocks();
+	configurePremiumContentBlocks();
+}

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/premium-content.php
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/premium-content.php
@@ -156,7 +156,7 @@ function premium_content_current_visitor_can_access( $attributes, $block ) {
 		$selected_plan_id = (int) $attributes['selectedPlanId'];
 	}
 
-	if ( isset( $block->context['premium-content/planId'] ) ) {
+	if ( isset( $block ) && isset( $block->context['premium-content/planId'] ) ) {
 		$selected_plan_id = (int) $block->context['premium-content/planId'];
 	}
 
@@ -217,7 +217,7 @@ function premium_content_container_render( $attributes, $content ) {
  *
  * @return string Content to render.
  */
-function premium_content_block_logged_out_view_render( $attributes, $content, $block ) {
+function premium_content_block_logged_out_view_render( $attributes, $content, $block = null ) {
 	if ( ! premium_content_pre_render_checks() ) {
 		return '';
 	}
@@ -246,7 +246,7 @@ function premium_content_block_logged_out_view_render( $attributes, $content, $b
  *
  * @return string Final content to render.
  */
-function premium_content_block_subscriber_view_render( $attributes, $content, $block ) {
+function premium_content_block_subscriber_view_render( $attributes, $content, $block = null ) {
 	if ( ! premium_content_pre_render_checks() ) {
 		return '';
 	}


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/44160 this PR simply opts to not register the premium content block when our desired gutenberg features are not available.

Previously in https://github.com/Automattic/wp-calypso/pull/42715 we added the ability to decouple the premium content buttons from the container block. This depended on the provides context block feature that landed in Gutenberg plugin ~8.0. Latest WP 5.4.2 has a mix of Gutenberg plugin versions of 6.6-7.5  https://developer.wordpress.org/block-editor/principles/versions-in-wordpress meaning that a fallback approach isn't viable in this case (we'd have to guess the passed planId).

| FSE + WP 5.4.2 (no plugin) | FSE + Gutenberg 8.3+ |
| ------------- | ------------- |
| <img width="835" alt="Screen Shot 2020-07-16 at 5 36 21 PM" src="https://user-images.githubusercontent.com/1270189/87736149-41b5be00-c78c-11ea-9d84-719a7187d143.png"> | <img width="908" alt="Screen Shot 2020-07-16 at 5 38 52 PM" src="https://user-images.githubusercontent.com/1270189/87736176-55612480-c78c-11ea-9228-59e1fd6c5f04.png"> |

### Testing Instructions
* Setup a WP instance of your choosing
* Install Jetpack and connect, paying for a personal plan or above
* Download and activate the FSE plugin from `FSE plugin / Build FSE plugin (pull_request)` In this PR's GH workflow
* Try to insert the premium content block with Gutenberg disabled (should not be available in picker)
* Activate Gutenberg
* Try to insert the premium content block (verify that it works as expected)
* Deactivate Gutenberg
* Reload the edited page, and see that we have a block not registered warning.

| FSE build | Download Artifact |
| ------------- | ------------- |
| <img width="832" alt="screen-shot-2020-07-14-at-4 41 45-pm" src="https://user-images.githubusercontent.com/1270189/87736522-31521300-c78d-11ea-9397-1ea5fa49a4cf.png"> | <img width="832" alt="screen-shot-2020-07-14-at-4 41 08-pm" src="https://user-images.githubusercontent.com/1270189/87736526-32834000-c78d-11ea-9330-fa13b6ec6dce.png"> |


