### PR TITLE
Premium Content: Tidy up deprecation errors.

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/premium-content.php
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/premium-content.php
@@ -82,6 +82,12 @@ function premium_content_block_init() {
 		array(),
 		filemtime( "$dir/$style_css" )
 	);
+
+	// Determine required `context` key based on Gutenberg version.
+	$deprecated = function_exists( 'gutenberg_get_post_from_context' );
+	$provides   = $deprecated ? 'providesContext' : 'provides_context';
+	$uses       = $deprecated ? 'context' : 'uses_context';
+
 	register_block_type(
 		'premium-content/container',
 		array(
@@ -89,7 +95,7 @@ function premium_content_block_init() {
 			'editor_style'    => 'premium-content-editor',
 			'style'           => 'premium-content-frontend',
 			'render_callback' => '\A8C\FSE\Earn\PremiumContent\premium_content_container_render',
-			'providesContext' => array(
+			$provides         => array(
 				'premium-content/planId' => 'selectedPlanId',
 			),
 		)
@@ -98,7 +104,7 @@ function premium_content_block_init() {
 		'premium-content/subscriber-view',
 		array(
 			'render_callback' => '\A8C\FSE\Earn\PremiumContent\premium_content_block_subscriber_view_render',
-			'context'         => array( 'premium-content/planId' ),
+			$uses             => array( 'premium-content/planId' ),
 		)
 	);
 	register_block_type(
@@ -107,7 +113,7 @@ function premium_content_block_init() {
 			'render_callback' => '\A8C\FSE\Earn\PremiumContent\premium_content_block_logged_out_view_render',
 			'script'          => 'premium-content-frontend',
 			'style'           => 'premium-content-frontend',
-			'context'         => array( 'premium-content/planId' ),
+			$uses             => array( 'premium-content/planId' ),
 		)
 	);
 	register_block_type(


### PR DESCRIPTION
Starting with https://github.com/WordPress/gutenberg/pull/22686/, the PHP `register_block_type` block arguments for `context` and `providesContext` were deprecated (replaced by `uses_context` and `provides_context` respectively). This PR updates the usage to quiet the `doing_it_wrong()` errors.

<img width="1543" alt="Screen Shot 2020-07-15 at 4 27 36 PM" src="https://user-images.githubusercontent.com/349751/87609716-26797e80-c6b8-11ea-8227-c80e4bcc7c12.png">

**Testing Instructions**
* Set up a JN test site that is connected to WP.com and has a JP Premium plan attached.
* Install the latest Gutenberg plugin.
* Use the build artifact from the `FSE plugin / Build FSE plugin (pull_request)` task below as a ZIP plugin that you can upload to the test site.
* Create a post, and add a Premium Content block for testing.
* Save the post, and check the front-end of the post: the above errors should not display.