### PR TITLE
Earn: premium content fallback to saving button attributes when gutenberg is disabled

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/logged-out-view/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/logged-out-view/edit.js
@@ -6,11 +6,18 @@ import { __ } from '@wordpress/i18n';
 import { useEffect } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
+import {
+	__experimentalAlignmentHookSettingsProvider,
+	__experimentalBlock,
+} from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
  */
 import Context from '../container/context';
+import SubmitButtons from './submit-buttons';
+
+const supportsDecoupledBlocks = __experimentalAlignmentHookSettingsProvider && __experimentalBlock;
 
 /**
  * Block edit function
@@ -27,7 +34,18 @@ import Context from '../container/context';
  *
  * @param { Props } props Properties
  */
-function Edit( { selectContainerBlock } ) {
+function Edit( props ) {
+	const {
+		selectContainerBlock,
+		subscribeButtonText,
+		loginButtonText,
+		backgroundButtonColor,
+		textButtonColor,
+		customBackgroundButtonColor,
+		customTextButtonColor,
+		setAttributes,
+	} = props;
+
 	useEffect( () => {
 		// Selects the container block on mount.
 		//
@@ -36,6 +54,34 @@ function Edit( { selectContainerBlock } ) {
 		setTimeout( selectContainerBlock, 0 );
 	}, [] );
 
+	const buttons = (
+		<SubmitButtons
+			{ ...{
+				attributes: {
+					subscribeButtonText,
+					loginButtonText,
+					backgroundButtonColor,
+					textButtonColor,
+					customBackgroundButtonColor,
+					customTextButtonColor,
+				},
+				setAttributes,
+			} }
+		/>
+	);
+	const template = [
+		[ 'core/heading', { content: __( 'Subscribe to get access', 'full-site-editing' ), level: 3 } ],
+		[
+			'core/paragraph',
+			{
+				content: __( 'Read more of this content when you subscribe today.', 'full-site-editing' ),
+			},
+		],
+	];
+
+	if ( supportsDecoupledBlocks ) {
+		template.push( [ 'premium-content/buttons' ] );
+	}
 	return (
 		<Context.Consumer>
 			{ ( { selectedTab, stripeNudge } ) => (
@@ -43,25 +89,8 @@ function Edit( { selectContainerBlock } ) {
 				// eslint-disable-next-line
 				<div hidden={ selectedTab.id === 'premium' } className={ selectedTab.className }>
 					{ stripeNudge }
-					<InnerBlocks
-						templateLock={ false }
-						template={ [
-							[
-								'core/heading',
-								{ content: __( 'Subscribe to get access', 'full-site-editing' ), level: 3 },
-							],
-							[
-								'core/paragraph',
-								{
-									content: __(
-										'Read more of this content when you subscribe today.',
-										'full-site-editing'
-									),
-								},
-							],
-							[ 'premium-content/buttons' ],
-						] }
-					/>
+					<InnerBlocks templateLock={ false } template={ template } />
+					{ ! supportsDecoupledBlocks && buttons }
 				</div>
 			) }
 		</Context.Consumer>

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/logged-out-view/submit-buttons.js
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/logged-out-view/submit-buttons.js
@@ -1,0 +1,188 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import classnames from 'classnames';
+import { useEffect } from '@wordpress/element';
+import { compose } from '@wordpress/compose';
+import { withFallbackStyles } from '@wordpress/components';
+import {
+	InspectorControls,
+	PanelColorSettings,
+	ContrastChecker,
+	RichText,
+	withColors,
+} from '@wordpress/block-editor';
+import { get } from 'lodash';
+
+const { getComputedStyle } = window;
+
+const applyFallbackStyles = withFallbackStyles( ( node, ownProps ) => {
+	const { textButtonColor, backgroundButtonColor } = ownProps;
+	const backgroundColorValue = backgroundButtonColor && backgroundButtonColor.color;
+	const textColorValue = textButtonColor && textButtonColor.color;
+	//avoid the use of querySelector if textColor color is known and verify if node is available.
+
+	let textNode;
+	let button;
+
+	if ( ! textColorValue && node ) {
+		textNode = node.querySelector( '[contenteditable="true"]' );
+	}
+
+	if ( node.querySelector( '.wp-block-button__link' ) ) {
+		button = node.querySelector( '.wp-block-button__link' );
+	} else {
+		button = node;
+	}
+
+	let fallbackBackgroundColor;
+	let fallbackTextColor;
+
+	if ( node && button ) {
+		fallbackBackgroundColor = getComputedStyle( button ).backgroundColor;
+	}
+
+	if ( textNode ) {
+		fallbackTextColor = getComputedStyle( textNode ).color;
+	}
+
+	return {
+		fallbackBackgroundColor: backgroundColorValue || fallbackBackgroundColor,
+		fallbackTextColor: textColorValue || fallbackTextColor,
+	};
+} );
+
+/**
+ * Block edit function
+ *
+ * @typedef { import('@wordpress/block-editor').ColorPalette.Color } Color
+ * @property { string } class
+ * @property { string } color
+ * @property { string } name
+ * @property { string } slug
+ *
+ * @typedef { import('./').Attributes } Attributes
+ * @typedef {object} Props
+ * @property { Color } backgroundButtonColor
+ * @property { Color } textButtonColor
+ * @property { string } fallbackBackgroundColor
+ * @property { string } fallbackTextColor
+ * @property { Attributes } attributes
+ * @property { () => void } setBackgroundButtonColor
+ * @property { () => void } setTextButtonColor
+ * @property { (attributes: Partial<Attributes>) => void } setAttributes
+ *
+ * @param { Props } props
+ */
+function SubmitButtons( props ) {
+	useEffect( () => {
+		setButtonClasses();
+		setCustomButtonColors();
+	}, [ props.backgroundButtonColor, props.textButtonColor ] );
+
+	function setButtonClasses() {
+		const buttonClasses = getButtonClasses();
+		props.setAttributes( { buttonClasses } );
+	}
+
+	function setCustomButtonColors() {
+		const customTextButtonColor = getTextButtonColor();
+		const customBackgroundButtonColor = getBackgroundButtonColor();
+
+		if ( customTextButtonColor !== undefined ) {
+			props.setAttributes( { customTextButtonColor } );
+		}
+
+		if ( customBackgroundButtonColor !== undefined ) {
+			props.setAttributes( { customBackgroundButtonColor } );
+		}
+	}
+
+	function getTextButtonColor() {
+		return get( props.textButtonColor, 'color' );
+	}
+
+	function getBackgroundButtonColor() {
+		return get( props.backgroundButtonColor, 'color' );
+	}
+
+	function getButtonClasses() {
+		const { textButtonColor, backgroundButtonColor } = props;
+		const textClass = get( textButtonColor, 'class' );
+		const backgroundClass = get( backgroundButtonColor, 'class' );
+		return classnames( 'wp-block-button__link', {
+			'has-text-color': textButtonColor.color,
+			[ textClass ]: textClass,
+			'has-background': backgroundButtonColor.color,
+			[ backgroundClass ]: backgroundClass,
+		} );
+	}
+
+	const {
+		attributes,
+		setAttributes,
+		backgroundButtonColor,
+		textButtonColor,
+		setBackgroundButtonColor,
+		setTextButtonColor,
+		fallbackBackgroundColor,
+		fallbackTextColor,
+	} = props;
+
+	const backgroundColor = backgroundButtonColor.color || fallbackBackgroundColor;
+	const color = textButtonColor.color || fallbackTextColor;
+	const buttonStyle = { border: 'none', backgroundColor, color };
+	const buttonClasses = getButtonClasses();
+
+	return (
+		<div>
+			<div className="wp-block-button premium-content-logged-out-view-button">
+				<RichText
+					placeholder={ __( 'Add text…', 'full-site-editing' ) }
+					value={ attributes.subscribeButtonText }
+					onChange={ ( nextValue ) => setAttributes( { subscribeButtonText: nextValue } ) }
+					className={ buttonClasses }
+					style={ buttonStyle }
+					keepPlaceholderOnFocus
+				/>
+				<RichText
+					placeholder={ __( 'Add text…', 'full-site-editing' ) }
+					value={ attributes.loginButtonText }
+					onChange={ ( nextValue ) => setAttributes( { loginButtonText: nextValue } ) }
+					className={ buttonClasses }
+					style={ buttonStyle }
+					keepPlaceholderOnFocus
+				/>
+			</div>
+			<InspectorControls>
+				<PanelColorSettings
+					title={ __( 'Button Color Settings', 'full-site-editing' ) }
+					colorSettings={ [
+						{
+							value: backgroundButtonColor || undefined,
+							onChange: setBackgroundButtonColor,
+							label: __( 'Background Color', 'full-site-editing' ),
+						},
+						{
+							value: textButtonColor || undefined,
+							onChange: setTextButtonColor,
+							label: __( 'Text Color', 'full-site-editing' ),
+						},
+					] }
+				/>
+				<ContrastChecker
+					textColor={ color }
+					backgroundColor={ backgroundColor }
+					fallbackBackgroundColor={ fallbackBackgroundColor }
+					fallbackTextColor={ fallbackTextColor }
+				/>
+			</InspectorControls>
+		</div>
+	);
+}
+
+export default compose( [
+	withColors( { backgroundButtonColor: 'background-color' }, { textButtonColor: 'color' } ),
+	applyFallbackStyles,
+] )( SubmitButtons );

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/index.js
@@ -9,6 +9,10 @@ import { mergeWith } from 'lodash';
 import apiFetch from '@wordpress/api-fetch';
 import { getBlockType, registerBlockType, unregisterBlockType } from '@wordpress/blocks';
 import { _x } from '@wordpress/i18n';
+import {
+	__experimentalAlignmentHookSettingsProvider,
+	__experimentalBlock,
+} from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -18,6 +22,8 @@ import * as subscriberView from './blocks/subscriber-view';
 import * as loggedOutView from './blocks/logged-out-view';
 import * as buttons from './blocks/buttons';
 import * as loginButton from './blocks/login-button';
+
+const supportsDecoupledBlocks = __experimentalAlignmentHookSettingsProvider && __experimentalBlock;
 
 /**
  * Function to register an individual block.
@@ -119,14 +125,20 @@ const hideButtonsIfMembershipsNotSetUp = ( membershipsStatus ) => {
 const configurePremiumContentBlocks = async () => {
 	const membershipsStatus = await getMembershipsStatus();
 	addPaidBlockFlags( membershipsStatus );
-	hideButtonsIfMembershipsNotSetUp( membershipsStatus );
+	if ( supportsDecoupledBlocks ) {
+		hideButtonsIfMembershipsNotSetUp( membershipsStatus );
+	}
 };
 
 /**
  * Function to register Premium Content blocks.
  */
 export const registerPremiumContentBlocks = () => {
-	[ container, loggedOutView, subscriberView, buttons, loginButton ].forEach( registerBlock );
+	if ( supportsDecoupledBlocks ) {
+		[ container, loggedOutView, subscriberView, buttons, loginButton ].forEach( registerBlock );
+	} else {
+		[ container, loggedOutView, subscriberView ].forEach( registerBlock );
+	}
 };
 
 registerPremiumContentBlocks();


### PR DESCRIPTION
Part of #44160 this adds fallback handling to the Premium Content block when Gutenberg is not enabled. Alternate to https://github.com/Automattic/wp-calypso/pull/44191, this PR tries to fallback to saved button block attributes. WIP

Thinking through this, it might make more sense to snapshot an older version of the block in another folder and load it when we feature sniff during registration. 🤔 