### PR TITLE
WPCOM Block Editor: show dismiss button in IE 11

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/style.scss
@@ -14,7 +14,7 @@ $transition-period: 200ms;
 	right: 0;
 	bottom: 0;
 	// Use the same z-index as the <Modal> component
-	z-index: z-index( '.components-modal__header' );
+	z-index: z-index( '.interface-interface-skeleton__header' );
 	animation: wpcom-block-editor-nav-sidebar-nav-sidebar__fade $transition-period ease-out forwards;
 	@include reduce-motion( 'animation' );
 

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/style.scss
@@ -13,7 +13,7 @@ $transition-period: 200ms;
 	left: 0;
 	right: 0;
 	bottom: 0;
-	// Use the same z-index as the <Modal> component
+	// Use the same z-index as the edit-post-layout header
 	z-index: z-index( '.interface-interface-skeleton__header' );
 	animation: wpcom-block-editor-nav-sidebar-nav-sidebar__fade $transition-period ease-out forwards;
 	@include reduce-motion( 'animation' );


### PR DESCRIPTION
## Changes proposed in this Pull Request

In IE 11, the WP logo we use to dismiss the sidebar seemed to... _disappear_...

To fix this, the click guards needs a z-index higher or equal to the `.interface-interface-skeleton__header` otherwise the edit post header will appear on top.

#### Before

<img width="706" alt="Screen Shot 2020-07-16 at 2 01 39 pm" src="https://user-images.githubusercontent.com/6458278/87625410-6ea6a880-c76d-11ea-9982-4add895126b2.png">

#### After

<img width="696" alt="Screen Shot 2020-07-16 at 2 05 17 pm" src="https://user-images.githubusercontent.com/6458278/87625405-6babb800-c76d-11ea-93ca-d12f07e7562a.png">

## Testing instructions

Enable the sidebar by defining `WPCOM_BLOCK_EDITOR_SIDEBAR` as `true` in your sandbox.

Apply D46468-code to sandbox

Find your favourite IE11 testing method (Browserstack?)

The WP logo button should be there. 

Ensure it still works in other browsers :)

Fixes #44067
