### PR TITLE
Reader: fix background color of tag stream when an error occurs

### DIFF
--- a/client/reader/style.scss
+++ b/client/reader/style.scss
@@ -9,8 +9,8 @@
 }
 
 .is-reader-page .recommended-for-you.main,
-.is-reader-page .following.main {
-
+.is-reader-page .following.main,
+.is-reader-page .tag-stream__main.main {
 	@include breakpoint-deprecated( '>660px' ) {
 		margin: 30px auto;
 	}

--- a/client/reader/tag-stream/header.jsx
+++ b/client/reader/tag-stream/header.jsx
@@ -95,8 +95,8 @@ class TagStreamHeader extends React.Component {
 		return (
 			<div className={ classes }>
 				<QueryReaderTagImages tag={ imageSearchString } />
-				{ showFollow && (
-					<div className="tag-stream__header-follow">
+				<div className="tag-stream__header-follow">
+					{ showFollow && (
 						<FollowButton
 							followLabel={ translate( 'Follow Tag' ) }
 							followingLabel={ translate( 'Following tag' ) }
@@ -104,9 +104,8 @@ class TagStreamHeader extends React.Component {
 							following={ following }
 							onFollowToggle={ onFollowToggle }
 						/>
-					</div>
-				) }
-
+					) }
+				</div>
 				<div className="tag-stream__header-image" style={ imageStyle }>
 					<h1 className="tag-stream__header-image-title">
 						<Gridicon icon="tag" size={ 24 } />

--- a/client/reader/tag-stream/main.jsx
+++ b/client/reader/tag-stream/main.jsx
@@ -113,7 +113,7 @@ class TagStream extends React.Component {
 
 		if ( tag && tag.error ) {
 			return (
-				<ReaderMain>
+				<ReaderMain className="tag-stream__main">
 					<QueryReaderFollowedTags />
 					<QueryReaderTag tag={ this.props.decodedTagSlug } />
 					{ this.props.showBack && <HeaderBack /> }
@@ -123,7 +123,7 @@ class TagStream extends React.Component {
 						showFollow={ false }
 						showBack={ this.props.showBack }
 					/>
-					<EmptyContent />
+					{ emptyContent }
 				</ReaderMain>
 			);
 		}

--- a/client/reader/tag-stream/main.jsx
+++ b/client/reader/tag-stream/main.jsx
@@ -1,5 +1,5 @@
 /**
- * External Dependencies
+ * External dependencies
  */
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -8,7 +8,7 @@ import { connect } from 'react-redux';
 import { find } from 'lodash';
 
 /**
- * Internal Dependencies
+ * Internal dependencies
  */
 import Stream from 'reader/stream';
 import DocumentHead from 'components/data/document-head';
@@ -20,6 +20,7 @@ import { getReaderTags, getReaderFollowedTags } from 'state/reader/tags/selector
 import { requestFollowTag, requestUnfollowTag } from 'state/reader/tags/items/actions';
 import QueryReaderFollowedTags from 'components/data/query-reader-followed-tags';
 import QueryReaderTag from 'components/data/query-reader-tag';
+import ReaderMain from 'reader/components/reader-main';
 
 /**
  * Style dependencies
@@ -112,7 +113,7 @@ class TagStream extends React.Component {
 
 		if ( tag && tag.error ) {
 			return (
-				<React.Fragment>
+				<ReaderMain>
 					<QueryReaderFollowedTags />
 					<QueryReaderTag tag={ this.props.decodedTagSlug } />
 					{ this.props.showBack && <HeaderBack /> }
@@ -123,7 +124,7 @@ class TagStream extends React.Component {
 						showBack={ this.props.showBack }
 					/>
 					<EmptyContent />
-				</React.Fragment>
+				</ReaderMain>
 			);
 		}
 

--- a/client/reader/tag-stream/style.scss
+++ b/client/reader/tag-stream/style.scss
@@ -123,3 +123,8 @@
 .is-reader-page .main .tag-stream__empty-content {
 	margin-top: 15px;
 }
+
+// Overrides default 720px width
+.is-reader-page .tag-stream__main.main {
+	max-width: 800px;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When attempting to load a non-existent tag in Reader, the error page that eventually appears has a grey background. This PR fixes the error state to display the standard white background.

Before:

<img width="1213" alt="Screen Shot 2020-07-16 at 17 00 48" src="https://user-images.githubusercontent.com/17325/87629063-58591680-c786-11ea-8fe3-592ff9086049.png">

After:

<img width="1213" alt="Screen Shot 2020-07-16 at 16 59 52" src="https://user-images.githubusercontent.com/17325/87629107-6f980400-c786-11ea-9676-d4bf4e72b57b.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Visit a non-existent tag like http://calypso.localhost:3000/tag/dsgdsgdsgdsgsdsggsdg. 
2. Wait for the API requests to complete. 
3. Ensure that the displayed page has a white background.

