### PR TITLE
Force Gutenboarding designs to use jpg instead of webp while we investigate webp 404s

### DIFF
--- a/client/landing/gutenboarding/available-designs.ts
+++ b/client/landing/gutenboarding/available-designs.ts
@@ -35,9 +35,7 @@ export const getDesignImageUrl = ( design: Design ) => {
 	// https://github.com/Automattic/wp-calypso/issues/40564
 	if ( ! isEnabled( 'gutenboarding/mshot-preview' ) ) {
 		// When we update the static images, bump the version for cache busting
-		return `/calypso/page-templates/design-screenshots/${ design.slug }_${ design.template }_${
-			design.theme
-		}.${ canUseWebP ? 'webp' : 'jpg' }?v=2`;
+		return `/calypso/page-templates/design-screenshots/${ design.slug }_${ design.template }_${ design.theme }.jpg?v=2`;
 	}
 
 	const mshotsUrl = 'https://s.wordpress.com/mshots/v1/';

--- a/client/landing/gutenboarding/available-designs.ts
+++ b/client/landing/gutenboarding/available-designs.ts
@@ -16,17 +16,19 @@ interface AvailableDesigns {
 
 const availableDesigns: Readonly< AvailableDesigns > = availableDesignsConfig;
 
-function getCanUseWebP() {
-	if ( typeof window !== 'undefined' ) {
-		const elem = document.createElement( 'canvas' );
-		if ( elem.getContext?.( '2d' ) ) {
-			return elem.toDataURL( 'image/webp' ).indexOf( 'data:image/webp' ) === 0;
-		}
-	}
-	return false;
-}
+// TODO: work out why webp images were 404ing in production
+//
+// function getCanUseWebP() {
+// 	if ( typeof window !== 'undefined' ) {
+// 		const elem = document.createElement( 'canvas' );
+// 		if ( elem.getContext?.( '2d' ) ) {
+// 			return elem.toDataURL( 'image/webp' ).indexOf( 'data:image/webp' ) === 0;
+// 		}
+// 	}
+// 	return false;
+// }
 
-const canUseWebP = getCanUseWebP();
+// const canUseWebP = getCanUseWebP();
 
 export const getDesignImageUrl = ( design: Design ) => {
 	// We temporarily show pre-generated screenshots until we can generate tall versions dynamically using mshots.


### PR DESCRIPTION
Fixes issue with https://github.com/Automattic/wp-calypso/pull/44165 throwing a 404 for webp images in Google Chrome

#### Changes proposed in this Pull Request

* Force Gutenboarding designs to use .jpg images instead of webP


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/new/design` in Chrome and make sure the design images load
* Confirm they still load in FF / Safari, etc.

Fixes #
