### PR TITLE
Nav sidebar: Add site title and link to the sidebar

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/class-wpcom-block-editor-nav-sidebar.php
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/class-wpcom-block-editor-nav-sidebar.php
@@ -63,7 +63,7 @@ class WPCOM_Block_Editor_Nav_Sidebar {
 			'wpcom-block-editor-nav-sidebar-script',
 			'wpcomBlockEditorNavSidebar',
 			array(
-				'homeUrl' => home_url()
+				'homeUrl' => home_url(),
 			)
 		);
 

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/class-wpcom-block-editor-nav-sidebar.php
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/class-wpcom-block-editor-nav-sidebar.php
@@ -59,6 +59,17 @@ class WPCOM_Block_Editor_Nav_Sidebar {
 			plugins_url( 'dist/', __FILE__ )
 		);
 
+		wp_localize_script(
+			'wpcom-block-editor-nav-sidebar-script',
+			'wpcomBlockEditorNavSidebar',
+			array(
+				'assetsUrl' => plugins_url( 'dist/', __FILE__ ),
+				'homeHost'  => parse_url( home_url() ),
+				'homeUrl'   => home_url(),
+				'siteTitle' => esc_html( get_bloginfo( 'name' ) ),
+			)
+		);
+
 		$style_path = 'dist/wpcom-block-editor-nav-sidebar' . ( is_rtl() ? '.rtl' : '' ) . '.css';
 		wp_enqueue_style(
 			'wpcom-block-editor-nav-sidebar-style',

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/class-wpcom-block-editor-nav-sidebar.php
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/class-wpcom-block-editor-nav-sidebar.php
@@ -63,10 +63,7 @@ class WPCOM_Block_Editor_Nav_Sidebar {
 			'wpcom-block-editor-nav-sidebar-script',
 			'wpcomBlockEditorNavSidebar',
 			array(
-				'assetsUrl' => plugins_url( 'dist/', __FILE__ ),
-				'homeHost'  => parse_url( home_url() ),
-				'homeUrl'   => home_url(),
-				'siteTitle' => esc_html( get_bloginfo( 'name' ) ),
+				'homeUrl' => home_url()
 			)
 		);
 

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
@@ -202,12 +202,12 @@ function WpcomBlockEditorNavSidebar() {
 						iconSize={ 36 }
 						onClick={ dismissSidebar }
 					/>
-					<p className="wpcom-block-editor-nav-sidebar-nav-sidebar__site-title">
-						<span>{ siteTitle }</span>
-						<ExternalLink href={ SITE_HOME_URL }>
-							{ __( 'Visit site', 'full-site-editing' ) }
-						</ExternalLink>
-					</p>
+				</div>
+				<div className="wpcom-block-editor-nav-sidebar-nav-sidebar__site-title">
+					<h2>{ siteTitle }</h2>
+					<ExternalLink href={ SITE_HOME_URL }>
+						{ __( 'Visit site', 'full-site-editing' ) }
+					</ExternalLink>
 				</div>
 				<Button
 					href={ closeUrl }

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
@@ -20,7 +20,7 @@ import { compose } from '@wordpress/compose';
 /**
  * Internal dependencies
  */
-import { STORE_KEY } from '../../constants';
+import { STORE_KEY, SITE_HOME_HOST_NAME, SITE_HOME_URL, SITE_TITLE } from '../../constants';
 import CreatePage from '../create-page';
 import NavItem from '../nav-item';
 import { Post } from '../../types';
@@ -200,6 +200,10 @@ function WpcomBlockEditorNavSidebar() {
 						iconSize={ 36 }
 						onClick={ dismissSidebar }
 					/>
+					<p className="wpcom-block-editor-nav-sidebar-nav-sidebar__site-title">
+						<span>{ SITE_TITLE }</span>
+						<a href={ SITE_HOME_URL }>{ SITE_HOME_HOST_NAME }</a>
+					</p>
 				</div>
 				<Button
 					href={ closeUrl }

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
@@ -7,6 +7,7 @@ import {
 	Button as OriginalButton,
 	IsolatedEventContainer,
 	withConstrainedTabbing,
+	ExternalLink,
 } from '@wordpress/components';
 import { arrowLeft, wordpress } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
@@ -20,7 +21,7 @@ import { compose } from '@wordpress/compose';
 /**
  * Internal dependencies
  */
-import { STORE_KEY, SITE_HOME_HOST_NAME, SITE_HOME_URL, SITE_TITLE } from '../../constants';
+import { STORE_KEY, SITE_HOME_URL } from '../../constants';
 import CreatePage from '../create-page';
 import NavItem from '../nav-item';
 import { Post } from '../../types';
@@ -35,14 +36,15 @@ const Button = ( {
 
 function WpcomBlockEditorNavSidebar() {
 	const { toggleSidebar, setSidebarClosing } = useDispatch( STORE_KEY );
-	const [ isOpen, isClosing, postType, selectedItemId ] = useSelect( ( select ) => {
-		const { getPostType } = select( 'core' ) as any;
+	const [ isOpen, isClosing, postType, selectedItemId, siteTitle ] = useSelect( ( select ) => {
+		const { getPostType, getSite } = select( 'core' ) as any;
 
 		return [
 			select( STORE_KEY ).isSidebarOpened(),
 			select( STORE_KEY ).isSidebarClosing(),
 			getPostType( select( 'core/editor' ).getCurrentPostType() ),
 			select( 'core/editor' ).getCurrentPostId(),
+			getSite()?.title,
 		];
 	} );
 
@@ -201,8 +203,10 @@ function WpcomBlockEditorNavSidebar() {
 						onClick={ dismissSidebar }
 					/>
 					<p className="wpcom-block-editor-nav-sidebar-nav-sidebar__site-title">
-						<span>{ SITE_TITLE }</span>
-						<a href={ SITE_HOME_URL }>{ SITE_HOME_HOST_NAME }</a>
+						<span>{ siteTitle }</span>
+						<ExternalLink href={ SITE_HOME_URL }>
+							{ __( 'Visit site', 'full-site-editing' ) }
+						</ExternalLink>
 					</p>
 				</div>
 				<Button

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
@@ -205,9 +205,11 @@ function WpcomBlockEditorNavSidebar() {
 				</div>
 				<div className="wpcom-block-editor-nav-sidebar-nav-sidebar__site-title">
 					<h2>{ siteTitle }</h2>
-					<ExternalLink href={ SITE_HOME_URL }>
-						{ __( 'Visit site', 'full-site-editing' ) }
-					</ExternalLink>
+					{ SITE_HOME_URL && (
+						<ExternalLink href={ SITE_HOME_URL }>
+							{ __( 'Visit site', 'full-site-editing' ) }
+						</ExternalLink>
+					) }
 				</div>
 				<Button
 					href={ closeUrl }

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/style.scss
@@ -67,6 +67,22 @@ $transition-period: 100ms;
 	flex: $header-height 0 0;
 }
 
+.wpcom-block-editor-nav-sidebar-nav-sidebar__site-title {
+    padding: 8px 16px;
+	margin-top: 14px;
+
+	h2 {
+		color: $white;
+		margin: 0;
+		font-size: $big-font-size;
+		line-height: $default-line-height;
+	}
+
+	a {
+		color: $light-gray-800;
+	}
+}
+
 .wpcom-block-editor-nav-sidebar-nav-sidebar__dismiss-sidebar-button {
 	position: fixed;
 	top: 0;

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/constants.ts
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/constants.ts
@@ -2,9 +2,10 @@ export const STORE_KEY = 'automattic/block-editor-nav-sidebar';
 
 declare global {
 	interface Window {
-		_currentSiteId: number;
+		wpcomBlockEditorNavSidebar: {
+			homeUrl: string;
+		};
 	}
 }
-export const SITE_HOME_HOST_NAME = window.wpcomBlockEditorNavSidebar.homeHost;
+
 export const SITE_HOME_URL = window.wpcomBlockEditorNavSidebar.homeUrl;
-export const SITE_TITLE = window.wpcomBlockEditorNavSidebar.siteTitle;

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/constants.ts
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/constants.ts
@@ -1,1 +1,10 @@
 export const STORE_KEY = 'automattic/block-editor-nav-sidebar';
+
+declare global {
+	interface Window {
+		_currentSiteId: number;
+	}
+}
+export const SITE_HOME_HOST_NAME = window.wpcomBlockEditorNavSidebar.homeHost;
+export const SITE_HOME_URL = window.wpcomBlockEditorNavSidebar.homeUrl;
+export const SITE_TITLE = window.wpcomBlockEditorNavSidebar.siteTitle;

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/constants.ts
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/constants.ts
@@ -2,10 +2,10 @@ export const STORE_KEY = 'automattic/block-editor-nav-sidebar';
 
 declare global {
 	interface Window {
-		wpcomBlockEditorNavSidebar: {
+		wpcomBlockEditorNavSidebar?: {
 			homeUrl: string;
 		};
 	}
 }
 
-export const SITE_HOME_URL = window.wpcomBlockEditorNavSidebar.homeUrl;
+export const SITE_HOME_URL = window.wpcomBlockEditorNavSidebar?.homeUrl;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adds the site title and a link to the site homepage to the top of the nav sidebar.

<img width="868" alt="Screenshot 2020-07-16 at 10 57 59 PM" src="https://user-images.githubusercontent.com/1500769/87663431-e699c080-c7b7-11ea-94d5-d25105180cda.png">

* Server renders a `wpcomBlockEditorNavSidebar` constant on the page that contains the site's home url (it wasn't readily available anywhere in the data store that I could see)
* Displays the site title at the top of the sidebar
* Displays a link to the site's homepage that will open in a new tab

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox your favourite test site
* Apply D46470-code to your sandbox
* Define `WPCOM_BLOCK_EDITOR_SIDEBAR` in your sandbox
* Go to the block editor and click the (W) to open the sidebar

Fixes #43973
