### PR TITLE
Extract context middleware

### DIFF
--- a/client/server/middleware/context/app.js
+++ b/client/server/middleware/context/app.js
@@ -1,0 +1,28 @@
+/**
+ * Internal dependencies
+ */
+import utils from 'server/bundler/utils';
+
+const SERVER_BASE_PATH = '/public';
+const staticFiles = [ { path: 'editor.css' }, { path: 'tinymce/skins/wordpress/wp-content.css' } ];
+const staticFilesUrls = staticFiles.reduce( ( result, file ) => {
+	if ( ! file.hash ) {
+		file.hash = utils.hashFile( process.cwd() + SERVER_BASE_PATH + '/' + file.path );
+	}
+	result[ file.path ] = utils.getUrl( file.path, file.hash );
+	return result;
+}, {} );
+
+export default ( req, calypsoEnv ) => {
+	const devEnvironments = [ 'development', 'jetpack-cloud-development' ];
+	const isDebug = devEnvironments.includes( calypsoEnv ) || req.query.debug !== undefined;
+
+	return {
+		app: {
+			// use ipv4 address when is ipv4 mapped address
+			clientIp: req.ip ? req.ip.replace( '::ffff:', '' ) : req.ip,
+			isDebug,
+			staticUrls: staticFilesUrls,
+		},
+	};
+};

--- a/client/server/middleware/context/badge.js
+++ b/client/server/middleware/context/badge.js
@@ -1,0 +1,48 @@
+/**
+ * Internal dependencies
+ */
+import config from 'config';
+
+export default ( calypsoEnv ) => {
+	const context = {
+		abTestHelper: !! config.isEnabled( 'dev/test-helper' ),
+		preferencesHelper: !! config.isEnabled( 'dev/preferences-helper' ),
+	};
+
+	switch ( calypsoEnv ) {
+		case 'wpcalypso':
+			context.badge = calypsoEnv;
+			context.feedbackURL = 'https://github.com/Automattic/wp-calypso/issues/';
+			break;
+
+		case 'horizon':
+			context.badge = 'feedback';
+			context.feedbackURL = 'https://horizonfeedback.wordpress.com/';
+			break;
+
+		case 'stage':
+			context.badge = 'staging';
+			context.feedbackURL = 'https://github.com/Automattic/wp-calypso/issues/';
+			break;
+
+		case 'development':
+			context.badge = 'dev';
+			context.feedbackURL = 'https://github.com/Automattic/wp-calypso/issues/';
+			break;
+
+		case 'jetpack-cloud-stage':
+			context.badge = 'jetpack-cloud-staging';
+			context.feedbackURL = 'https://github.com/Automattic/wp-calypso/issues/';
+			break;
+
+		case 'jetpack-cloud-development':
+			context.badge = 'jetpack-cloud-dev';
+			context.feedbackURL = 'https://github.com/Automattic/wp-calypso/issues/';
+			break;
+
+		default:
+			context.badge = false;
+	}
+
+	return context;
+};

--- a/client/server/middleware/context/dev-info.js
+++ b/client/server/middleware/context/dev-info.js
@@ -1,0 +1,42 @@
+/**
+ * External dependencies
+ */
+import { execSync } from 'child_process';
+
+function getCurrentBranchName() {
+	try {
+		return execSync( 'git rev-parse --abbrev-ref HEAD' ).toString().replace( /\s/gm, '' );
+	} catch ( err ) {
+		return undefined;
+	}
+}
+
+function getCurrentCommitShortChecksum() {
+	try {
+		return execSync( 'git rev-parse --short HEAD' ).toString().replace( /\s/gm, '' );
+	} catch ( err ) {
+		return undefined;
+	}
+}
+
+export default ( req, calypsoEnv ) => {
+	const context = {
+		commitSha: process.env.hasOwnProperty( 'COMMIT_SHA' ) ? process.env.COMMIT_SHA : '(unknown)',
+	};
+
+	switch ( calypsoEnv ) {
+		case 'wpcalypso':
+			// this is for calypso.live, so that branchName can be available while rendering the page
+			if ( req.query.branch ) {
+				context.branchName = req.query.branch;
+			}
+			break;
+		case 'development':
+		case 'jetpack-cloud-development':
+			context.branchName = getCurrentBranchName();
+			context.commitChecksum = getCurrentCommitShortChecksum();
+			break;
+	}
+
+	return context;
+};

--- a/client/server/middleware/context/index.js
+++ b/client/server/middleware/context/index.js
@@ -1,0 +1,46 @@
+/**
+ * Internal dependencies
+ */
+import config from 'config';
+import sanitize from 'server/sanitize';
+import wooDnaConfig from 'jetpack-connect/woo-dna-config';
+import isWCComConnect from './is-wccom-connect';
+import reduxStore from './redux-store';
+import devInfo from './dev-info';
+import lang from './lang';
+import badge from './badge';
+import app from './app';
+
+export default ( calypsoEnv ) => ( req, res, next ) => {
+	req.setDefaultContext = ( entrypoint = 'entry-main' ) => {
+		const target = req.getTarget();
+
+		req.context = {
+			...req.context,
+
+			compileDebug: process.env.NODE_ENV === 'development',
+			user: false,
+			env: calypsoEnv,
+			sanitize,
+			requestFrom: req.query.from,
+			isWooDna: wooDnaConfig( req.query ).isWooDnaFlow(),
+			entrypoint: req.getFilesForEntrypoint( entrypoint ),
+			manifest: req.getAssets().manifests.manifest,
+			faviconURL: config( 'favicon_url' ),
+			devDocsURL: '/devdocs',
+			bodyClasses: [],
+			addEvergreenCheck: target === 'evergreen' && calypsoEnv !== 'development',
+			target: target || 'fallback',
+			devDocs: Boolean( calypsoEnv === 'wpcalypso' || calypsoEnv === 'development' ),
+
+			...app( req, calypsoEnv ),
+			...badge( calypsoEnv ),
+			...lang( req ),
+			...reduxStore( req ),
+			...isWCComConnect( req ),
+			...devInfo( req, calypsoEnv ),
+		};
+	};
+
+	next();
+};

--- a/client/server/middleware/context/is-wccom-connect.js
+++ b/client/server/middleware/context/is-wccom-connect.js
@@ -1,0 +1,18 @@
+/**
+ * Internal dependencies
+ */
+import config from 'config';
+import { isWooOAuth2Client } from 'lib/oauth2-clients';
+
+export default ( req ) => {
+	const oauthClientId = req.query.oauth2_client_id || req.query.client_id;
+	const isWCComConnect =
+		config.isEnabled( 'woocommerce/onboarding-oauth' ) &&
+		( 'login' === req.context.sectionName || 'signup' === req.context.sectionName ) &&
+		req.query[ 'wccom-from' ] &&
+		isWooOAuth2Client( { id: parseInt( oauthClientId ) } );
+
+	return {
+		isWCComConnect,
+	};
+};

--- a/client/server/middleware/context/lang.js
+++ b/client/server/middleware/context/lang.js
@@ -1,0 +1,25 @@
+/**
+ * Internal dependencies
+ */
+import config from 'config';
+
+export default ( req ) => {
+	let lang = config( 'i18n_default_locale_slug' );
+
+	// We assign request.context.lang in the handleLocaleSubdomains()
+	// middleware function if we detect a language slug in subdomain
+	if ( req.context && req.context.lang ) {
+		lang = req.context.lang;
+	}
+
+	const flags = ( req.query.flags || '' ).split( ',' );
+
+	return {
+		lang,
+		isRTL: config( 'rtl' ),
+		useTranslationChunks:
+			config.isEnabled( 'use-translation-chunks' ) ||
+			flags.includes( 'use-translation-chunks' ) ||
+			req.query.hasOwnProperty( 'useTranslationChunks' ),
+	};
+};

--- a/client/server/middleware/context/redux-store.js
+++ b/client/server/middleware/context/redux-store.js
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import { pick } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { createReduxStore } from 'state';
+import { setStore } from 'state/redux-store';
+import stateCache from 'server/state-cache';
+import { getNormalizedPath } from 'server/isomorphic-routing';
+import initialReducer from 'state/reducer';
+import { DESERIALIZE } from 'state/action-types';
+
+// TODO: Re-use (a modified version of) client/state/initial-state#getInitialServerState here
+function getInitialServerState( serializedServerState ) {
+	// Bootstrapped state from a server-render
+	const serverState = initialReducer( serializedServerState, { type: DESERIALIZE } );
+	return pick( serverState, Object.keys( serializedServerState ) );
+}
+
+export default ( req ) => {
+	let initialServerState = {};
+	// We don't compare context.query against an allowed list here. Explicit allowance lists are route-specific,
+	// i.e. they can be created by route-specific middleware. `getDefaultContext` is always
+	// called before route-specific middleware, so it's up to the cache *writes* in server
+	// render to make sure that Redux state and markup are only cached for specified query args.
+	const cacheKey = getNormalizedPath( req.path, req.query );
+	if ( cacheKey ) {
+		const serializeCachedServerState = stateCache.get( cacheKey ) || {};
+		initialServerState = getInitialServerState( serializeCachedServerState );
+	}
+
+	const reduxStore = createReduxStore( initialServerState );
+	setStore( reduxStore );
+
+	return {
+		store: reduxStore,
+	};
+};

--- a/client/server/middleware/locale-subdomain.js
+++ b/client/server/middleware/locale-subdomain.js
@@ -1,0 +1,43 @@
+/**
+ * External dependencies
+ */
+import { endsWith, includes, split } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import config from 'config';
+import { getLanguage } from 'lib/i18n-utils';
+
+/**
+ * Sets language properties to context if
+ * a WordPress.com language slug is detected in the hostname
+ */
+export default () => ( req, res, next ) => {
+	const langSlug = endsWith( req.hostname, config( 'hostname' ) )
+		? split( req.hostname, '.' )[ 0 ]
+		: null;
+
+	if ( langSlug && includes( config( 'magnificent_non_en_locales' ), langSlug ) ) {
+		// Retrieve the language object for the RTL information.
+		const language = getLanguage( langSlug );
+
+		// Switch locales only in a logged-out state.
+		if ( language && ! req.context.isLoggedIn ) {
+			req.context = {
+				...req.context,
+				lang: language.langSlug,
+				isRTL: !! language.rtl,
+			};
+		} else {
+			// Strip the langSlug and redirect using hostname
+			// so that the user's locale preferences take priority.
+			const protocol = req.get( 'X-Forwarded-Proto' ) === 'https' ? 'https' : 'http';
+			const port = process.env.PORT || config( 'port' ) || '';
+			const hostname = req.hostname.substr( langSlug.length + 1 );
+			const redirectUrl = `${ protocol }://${ hostname }:${ port }${ req.path }`;
+			return res.redirect( redirectUrl );
+		}
+	}
+	next();
+};

--- a/client/server/middleware/logged-in.js
+++ b/client/server/middleware/logged-in.js
@@ -1,0 +1,18 @@
+/*
+ * Look at the request headers and determine if the request is logged in or logged out or if
+ * it's a support session. Set `req.context.isLoggedIn` and `req.context.isSupportSession` flags
+ * accordingly. The handler is called very early (immediately after parsing the cookies) and
+ * all following handlers (including the locale and redirect ones) can rely on the context values.
+ */
+export default () => ( req, res, next ) => {
+	const isSupportSession = !! req.get( 'x-support-session' ) || !! req.cookies.support_session_id;
+	const isLoggedIn = !! req.cookies.wordpress_logged_in;
+
+	req.context = {
+		...req.context,
+		isSupportSession,
+		isLoggedIn,
+	};
+
+	next();
+};


### PR DESCRIPTION
### Background

I'm trying to extract webpack-dev-server form `client/server` logic. The idea is that for production it will read the assets from the filesystem (as it does today), but for dev mode it will redirect it to a separate web server. This will allow quick reload of the node service without having to bundle everything all the time. It will also pave the path for potential improvements like deploy the client assets to a shared place (eg: an S3 bucket) without having to deploy the node service every time. The next step is to use that safety net to refactor this mega-module and split into smaller modules. Note that no tests has been changed but everything still passes. 

The progress so far has been:
* Introduce tests for the server to make sure I don't break anything (#43177). 
* Extract middleware related to files and assets (#44178)

### Future

The next step would be to refactor the tests without changing the code to accommodate them to the new modules (i.e. split the meta-test). Then rinse and repeat with further refactors, until we are happy with the structure of this part of the code.

### Changes in this PR

* Extract `defaultContext` logic and split it into cohesive modules.
* Extract middleware to detect subdomain and locale
* Extract middleware to detect if the user is logged in or is a support session.

### Testing instructions

* Check that you can load the page in different locales, including RTL language.
* Check that you can load the page as an authenticated user and as an anonymous user.
* Check that the badge still works, including abtest and preferences helper.
* Check that the branch name is displayed in the badge (you need to start Calypso locally to verify this)
* Check that SSR pages (login form, `/start`, and `/themes`) works
