### PR TITLE
Pausing Premium to Business bump test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -149,10 +149,10 @@ export default {
 		countryCodeTargets: [ 'US' ],
 	},
 	showBusinessPlanBump: {
-		datestamp: '20200619',
+		datestamp: '20300619',
 		variations: {
-			variantShowPlanBump: 50,
-			control: 50,
+			variantShowPlanBump: 0,
+			control: 100,
 		},
 		defaultVariation: 'control',
 		allowExistingUsers: true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR pauses the Premium to Business bump test by shifting all traffic to the control and setting a date in the future to prevent further assignment. More pbxNRc-lW-p2

#### Testing instructions

* Signup for a new account using the calypso.live link below.
* Add a Premium plan to cart and complete the purchase
* Verify the following:
 * That you are not shown the Business upsell and are assigned to control for `showBusinessPlanBump` test.
 * This should be the same for new account, new site or upgrading an existing site.