### PR TITLE
Modularise imports state

### DIFF
--- a/client/lib/importer/actions.js
+++ b/client/lib/importer/actions.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import Dispatcher from 'dispatcher';
 import { includes, partial } from 'lodash';
 import wpLib from 'lib/wp';
@@ -31,6 +30,10 @@ import {
 import { appStates } from 'state/imports/constants';
 import { fromApi, toApi } from './common';
 import { reduxDispatch } from 'lib/redux-bridge';
+
+// This library unfortunately relies on global Redux state directly, by e.g. creating actions.
+// Because of this, we need to ensure that the relevant portion of state is initialized.
+import 'state/imports/init';
 
 const ID_GENERATOR_PREFIX = 'local-generated-id-';
 

--- a/client/lib/importer/store.js
+++ b/client/lib/importer/store.js
@@ -28,6 +28,10 @@ import {
 import { appStates } from 'state/imports/constants';
 import { createReducerStore } from 'lib/store';
 
+// This library unfortunately relies on global Redux state directly.
+// Because of this, we need to ensure that the relevant portion of state is initialized.
+import 'state/imports/init';
+
 /**
  * Module variables
  */

--- a/client/my-sites/importer/importer-header/index.jsx
+++ b/client/my-sites/importer/importer-header/index.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
-import { get, includes } from 'lodash';
+import { includes } from 'lodash';
 import { connect } from 'react-redux';
 import classnames from 'classnames';
 
@@ -12,6 +12,7 @@ import classnames from 'classnames';
  * Internal dependencies
  */
 import { appStates } from 'state/imports/constants';
+import { isUploading } from 'state/imports/uploads/selectors';
 import ImporterLogo from 'my-sites/importer/importer-logo';
 
 /**
@@ -58,5 +59,5 @@ class ImporterHeader extends React.PureComponent {
 }
 
 export default connect( ( state ) => ( {
-	isUploading: get( state, 'imports.uploads.inProgress' ),
+	isUploading: isUploading( state ),
 } ) )( localize( ImporterHeader ) );

--- a/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
+++ b/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
@@ -5,7 +5,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
-import { includes, isEmpty, noop, flowRight, has, get, trim, sortBy, reverse } from 'lodash';
+import { includes, isEmpty, noop, flowRight, has, trim, sortBy, reverse } from 'lodash';
 import url from 'url';
 import moment from 'moment';
 
@@ -34,6 +34,13 @@ import ErrorPane from '../error-pane';
 import SiteImporterSitePreview from './site-importer-site-preview';
 import { appStates } from 'state/imports/constants';
 import { cancelImport, setUploadStartState } from 'lib/importer/actions';
+import {
+	getError,
+	getImportData,
+	getImportStage,
+	getValidatedSiteUrl,
+	isLoading as isLoadingSelector,
+} from 'state/imports/site-importer/selectors';
 
 /**
  * Style dependencies
@@ -285,21 +292,13 @@ class SiteImporterInputPane extends React.Component {
 
 export default flowRight(
 	connect(
-		( state ) => {
-			const { isLoading, error, importData, importStage, validatedSiteUrl } = get(
-				state,
-				'imports.siteImporter',
-				{}
-			);
-
-			return {
-				isLoading,
-				error,
-				importData,
-				importStage,
-				validatedSiteUrl,
-			};
-		},
+		( state ) => ( {
+			error: getError( state ),
+			importData: getImportData( state ),
+			importStage: getImportStage( state ),
+			isLoading: isLoadingSelector( state ),
+			validatedSiteUrl: getValidatedSiteUrl( state ),
+		} ),
 		{
 			recordTracksEvent,
 			setSelectedEditor,

--- a/client/my-sites/importer/uploading-pane.jsx
+++ b/client/my-sites/importer/uploading-pane.jsx
@@ -1,13 +1,12 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
-import { defer, flow, get, includes, noop, truncate } from 'lodash';
+import { defer, flow, includes, noop, truncate } from 'lodash';
 import Gridicon from 'components/gridicon';
 
 /**
@@ -15,6 +14,7 @@ import Gridicon from 'components/gridicon';
  */
 import { startMappingAuthors, startUpload } from 'lib/importer/actions';
 import { appStates } from 'state/imports/constants';
+import { getUploadFilename, getUploadPercentComplete } from 'state/imports/uploads/selectors';
 import DropZone from 'components/drop-zone';
 import { ProgressBar } from '@automattic/components';
 import ImporterActionButtonContainer from 'my-sites/importer/importer-action-buttons/container';
@@ -175,8 +175,8 @@ class UploadingPane extends React.PureComponent {
 
 export default flow(
 	connect( ( state ) => ( {
-		filename: get( state, 'imports.uploads.filename' ),
-		percentComplete: get( state, 'imports.uploads.percentComplete' ),
+		filename: getUploadFilename( state ),
+		percentComplete: getUploadPercentComplete( state ),
 	} ) ),
 	localize
 )( UploadingPane );

--- a/client/state/imports/init.js
+++ b/client/state/imports/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'state/redux-store';
+import reducer from './reducer';
+
+registerReducer( [ 'imports' ], reducer );

--- a/client/state/imports/package.json
+++ b/client/state/imports/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/imports/reducer.js
+++ b/client/state/imports/reducer.js
@@ -1,11 +1,13 @@
 /**
  * Internal dependencies
  */
-import { combineReducers } from 'state/utils';
+import { combineReducers, withStorageKey } from 'state/utils';
 import uploadsReducer from 'state/imports/uploads/reducer';
 import siteImporterReducer from 'state/imports/site-importer/reducer';
 
-export default combineReducers( {
+const combinedReducer = combineReducers( {
 	uploads: uploadsReducer,
 	siteImporter: siteImporterReducer,
 } );
+
+export default withStorageKey( 'imports', combinedReducer );

--- a/client/state/imports/site-importer/actions.js
+++ b/client/state/imports/site-importer/actions.js
@@ -32,6 +32,8 @@ import {
 import { getState as getImporterState } from 'lib/importer/store';
 import { prefetchmShotsPreview } from 'lib/mshots';
 
+import 'state/imports/init';
+
 const sortAndStringify = ( items ) => items.slice( 0 ).sort().join( ', ' );
 
 export const startSiteImporterImport = () => ( {

--- a/client/state/imports/site-importer/selectors.js
+++ b/client/state/imports/site-importer/selectors.js
@@ -1,0 +1,24 @@
+/**
+ * Internal dependencies
+ */
+import 'state/imports/init';
+
+export function isLoading( state ) {
+	return state.imports.siteImporter?.isLoading;
+}
+
+export function getError( state ) {
+	return state.imports.siteImporter?.error;
+}
+
+export function getImportData( state ) {
+	return state.imports.siteImporter?.importData;
+}
+
+export function getImportStage( state ) {
+	return state.imports.siteImporter?.importStage;
+}
+
+export function getValidatedSiteUrl( state ) {
+	state.imports.siteImporter?.validatedSiteUrl;
+}

--- a/client/state/imports/uploads/selectors.js
+++ b/client/state/imports/uploads/selectors.js
@@ -1,0 +1,16 @@
+/**
+ * Internal dependencies
+ */
+import 'state/imports/init';
+
+export function getUploadFilename( state ) {
+	return state.imports.uploads?.filename;
+}
+
+export function getUploadPercentComplete( state ) {
+	return state.imports.uploads?.percentComplete;
+}
+
+export function isUploading( state ) {
+	return state.imports.uploads?.inProgress;
+}

--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -34,7 +34,6 @@ import home from './home/reducer';
 import i18n from './i18n/reducer';
 import immediateLogin from './immediate-login/reducer';
 import importerNux from './importer-nux/reducer';
-import imports from './imports/reducer';
 import inlineSupportArticle from './inline-support-article/reducer';
 import invites from './invites/reducer';
 import jetpackProductInstall from './jetpack-product-install/reducer';
@@ -100,7 +99,6 @@ const reducers = {
 	i18n,
 	immediateLogin,
 	importerNux,
-	imports,
 	inlineSupportArticle,
 	invites,
 	jetpackProductInstall,


### PR DESCRIPTION
This PR is one of many working on modularising state in Calypso. This one handles imports state.

For more details on state modularisation, see the [modularised state documentation](https://github.com/Automattic/wp-calypso/blob/master/docs/modularized-state.md) and p4TIVU-9lM-p2.

Note: I added reviewers that GitHub suggested. Please feel free to ignore the review request or pull in someone else if you're not comfortable reviewing this PR. Thank you!

Fixes #42447.

#### Changes proposed in this Pull Request

* Modularise imports state
* Create selectors and use them in components that were accessing state directly

#### Testing instructions

* Install [Redux DevTools](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en).
* Open DevTools and switch to the Redux tab.
* Open `/read` on the live branch or your local copy of this branch.
* Click `State` on the top right to ensure you see all state, and not just the diff for the last action: 
![image](https://user-images.githubusercontent.com/409615/73774406-d3e87d80-477b-11ea-9f59-3e42cc00101f.png)
* Analyse the tree and note that there's no `imports` key, even if you expand the list of keys. This indicates that the imports state hasn't been loaded yet.
* Click `My Sites` on the top bar, followed by `Tools` and `Import`.
* Verify that a `imports` key is added with the imports state. This indicates that the imports state has now been loaded.
* Verify that import-related functionality works normally. This indicates that I didn't mess up.