### PR TITLE
i18n: Preserve rtl:ignore directive comment for domain extensions direction

### DIFF
--- a/client/components/domains/search-filters/style.scss
+++ b/client/components/domains/search-filters/style.scss
@@ -113,7 +113,7 @@
 	// Increase specificity to override button styles in signup
 	body.is-section-signup .layout & {
 		.search-filters__tld-button {
-			/*rtl:ignore*/
+			/*!rtl:ignore*/
 			direction: ltr;
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add `!` at the beginning of the `rtl:ignore` comment to prevent it from being stripped in compressed mode (production build)

![image](https://user-images.githubusercontent.com/2722412/87678003-167aa100-c783-11ea-8f20-825d98e1e261.png)

#### Testing instructions

* Set your WordPress.com UI to any RTL language
* Open calypso.live with the branch from this PR and go to `/start/domains`.
* Confirm TLD buttons are using `ltr` direction.

Related https://github.com/Automattic/wp-calypso/pull/43934
