### PR TITLE
e2e:Fix coupon test

### DIFF
--- a/test/e2e/lib/components/secure-payment-component.js
+++ b/test/e2e/lib/components/secure-payment-component.js
@@ -356,7 +356,7 @@ export default class SecurePaymentComponent extends AsyncBaseContainer {
 	async removeFromCart() {
 		return await driverHelper.clickWhenClickable(
 			this.driver,
-			By.css( 'button.cart__remove-item' )
+			By.css( 'button svg[aria-labelledby*="checkout-delete-button-0"]' )
 		);
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Something changed in the secure payment component and the e2e tests couldn't find the remove item from cart button. I suspect it was related to https://github.com/Automattic/wp-calypso/pull/44043 because of the timing that the test started failing, the fact that it deals with checkout, and that the full suite of e2e tests weren't run against it prior to merging.

#### Testing instructions
* ensure e2e tests pass
