### PR TITLE
P2 signup: validate fields only on Continue

### DIFF
--- a/client/signup/steps/p2-site/index.jsx
+++ b/client/signup/steps/p2-site/index.jsx
@@ -73,6 +73,7 @@ class P2Site extends React.Component {
 			debounceWait: VALIDATION_DELAY_AFTER_FIELD_CHANGES,
 			hideFieldErrorsOnChange: true,
 			initialState: initialState,
+			skipSanitizeAndValidateOnFieldChange: true,
 		} );
 
 		this.state = {
@@ -116,34 +117,38 @@ class P2Site extends React.Component {
 			};
 		}
 
-		wpcom.undocumented().sitesNew(
-			{
-				blog_name: `${ fields.site }.p2.blog`,
-				blog_title: fields.siteTitle,
-				validate: true,
-			},
-			function ( error, response ) {
-				debug( error, response );
+		if ( ! isEmpty( fields.site ) ) {
+			wpcom.undocumented().sitesNew(
+				{
+					blog_name: `${ fields.site }.p2.blog`,
+					blog_title: fields.siteTitle,
+					validate: true,
+				},
+				function ( error, response ) {
+					debug( error, response );
 
-				if ( error && error.message ) {
-					if ( fields.site && ! includes( siteUrlsSearched, fields.site ) ) {
-						siteUrlsSearched.push( fields.site );
+					if ( error && error.message ) {
+						if ( fields.site && ! includes( siteUrlsSearched, fields.site ) ) {
+							siteUrlsSearched.push( fields.site );
 
-						recordTracksEvent( 'calypso_signup_wp_for_teams_site_url_validation_failed', {
-							error: error.error,
-							site_url: fields.site,
-						} );
+							recordTracksEvent( 'calypso_signup_wp_for_teams_site_url_validation_failed', {
+								error: error.error,
+								site_url: fields.site,
+							} );
+						}
+
+						timesValidationFailed++;
+
+						messages.site = {
+							[ error.error ]: error.message,
+						};
 					}
-
-					timesValidationFailed++;
-
-					messages.site = {
-						[ error.error ]: error.message,
-					};
+					onComplete( null, messages );
 				}
-				onComplete( null, messages );
-			}
-		);
+			);
+		} else if ( ! isEmpty( messages ) ) {
+			onComplete( null, messages );
+		}
 	};
 
 	setFormState = ( state ) => {
@@ -190,7 +195,6 @@ class P2Site extends React.Component {
 
 	handleBlur = () => {
 		this.formStateController.sanitize();
-		this.formStateController.validate();
 		this.save();
 	};
 


### PR DESCRIPTION
Fixes various smaller validation issues.

In this PR, we validate the fields of the `p2-site` P2 signup flow only on hitting the "Continue" button instead of trying to validate on blur as well. This way it's simpler due to the site validation async nature.

## Testing instructions

Navigate to `http://calypso.localhost:3000/start/p2` and play with the form to see if you like the validation logic. Try empty sites, sites which are taken, malformed site names, etc.