### PR TITLE
Email Forwarding Count: Improve Colour Contrast

### DIFF
--- a/client/my-sites/email/email-forwarding/style.scss
+++ b/client/my-sites/email/email-forwarding/style.scss
@@ -85,7 +85,7 @@ ul.email-forwarding__list {
 }
 
 .email-forwarding__limit {
-	color: var( --color-neutral-light );
+	color: var( --color-text-subtle );
 	line-height: 3em;
 	margin-bottom: 15px;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Should be a super quick and easy review to an issue which I just spotted on Calypso: the count for Emailing Forward doesn't pass the colour contrast requirements. Most of these were updates ages ago, but I suspect this one was just missed.

#### Testing instructions

Check the screenshots below (the page is `/email/**siteSlug**/forwarding/**domain**`).

**Before:**
<img width="359" alt="Screenshot 2020-07-16 at 14 59 22" src="https://user-images.githubusercontent.com/43215253/87680362-3e630800-c775-11ea-90d4-d42008fa489b.png">

**After:**
<img width="372" alt="Screenshot 2020-07-16 at 14 59 33" src="https://user-images.githubusercontent.com/43215253/87680388-44f17f80-c775-11ea-8391-0d1f3ef036c4.png">

cc @sixhours, @cbauerman 
