### PR TITLE
Modularise email forwarding state

### DIFF
--- a/client/state/email-forwarding/actions.js
+++ b/client/state/email-forwarding/actions.js
@@ -20,6 +20,7 @@ import 'state/data-layer/wpcom/email-forwarding/add';
 import 'state/data-layer/wpcom/email-forwarding/get';
 import 'state/data-layer/wpcom/email-forwarding/remove';
 import 'state/data-layer/wpcom/email-forwarding/resend-email-verification';
+import 'state/email-forwarding/init';
 
 export const getEmailForwards = ( domainName ) => {
 	return {

--- a/client/state/email-forwarding/init.js
+++ b/client/state/email-forwarding/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'state/redux-store';
+import reducer from './reducer';
+
+registerReducer( [ 'emailForwarding' ], reducer );

--- a/client/state/email-forwarding/package.json
+++ b/client/state/email-forwarding/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/email-forwarding/reducer.js
+++ b/client/state/email-forwarding/reducer.js
@@ -9,8 +9,9 @@ import { orderBy } from 'lodash';
 import {
 	combineReducers,
 	keyedReducer,
-	withSchemaValidation,
 	withoutPersistence,
+	withSchemaValidation,
+	withStorageKey,
 } from 'state/utils';
 import {
 	EMAIL_FORWARDING_REQUEST,
@@ -180,7 +181,7 @@ export const requestErrorReducer = withoutPersistence( ( state = false, action )
 	return state;
 } );
 
-export default keyedReducer(
+const combinedReducer = keyedReducer(
 	'domainName',
 	combineReducers( {
 		forwards: forwardsReducer,
@@ -190,3 +191,5 @@ export default keyedReducer(
 		type: typeReducer,
 	} )
 );
+
+export default withStorageKey( 'emailForwarding', combinedReducer );

--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -21,7 +21,6 @@ import connectedApplications from './connected-applications/reducer';
 import currentUser from './current-user/reducer';
 import { reducer as dataRequests } from './data-layer/wpcom-http/utils';
 import documentHead from './document-head/reducer';
-import emailForwarding from './email-forwarding/reducer';
 import embeds from './embeds/reducer';
 import experiments from './experiments/reducer';
 import exporter from './exporter/reducers';
@@ -86,7 +85,6 @@ const reducers = {
 	currentUser,
 	dataRequests,
 	documentHead,
-	emailForwarding,
 	embeds,
 	experiments,
 	exporter,

--- a/client/state/selectors/get-email-forwarding-mx-servers.js
+++ b/client/state/selectors/get-email-forwarding-mx-servers.js
@@ -4,6 +4,11 @@
 import { get } from 'lodash';
 
 /**
+ * Internal dependencies
+ */
+import 'state/email-forwarding/init';
+
+/**
  * Retrieve a list of custom mx servers for a particular domainn
  *
  * @param  {object} state    Global state tree

--- a/client/state/selectors/get-email-forwarding-type.js
+++ b/client/state/selectors/get-email-forwarding-type.js
@@ -4,6 +4,11 @@
 import { get } from 'lodash';
 
 /**
+ * Internal dependencies
+ */
+import 'state/email-forwarding/init';
+
+/**
  * Retrieve the type of the email forwards
  *
  * @param  {object} state    Global state tree

--- a/client/state/selectors/get-email-forwards.js
+++ b/client/state/selectors/get-email-forwards.js
@@ -4,6 +4,11 @@
 import { get } from 'lodash';
 
 /**
+ * Internal dependencies
+ */
+import 'state/email-forwarding/init';
+
+/**
  * Retrieve a list of email forwards for a particular domain
  *
  * @param  {object} state    Global state tree

--- a/client/state/selectors/is-requesting-email-forwards.js
+++ b/client/state/selectors/is-requesting-email-forwards.js
@@ -4,6 +4,11 @@
 import { get } from 'lodash';
 
 /**
+ * Internal dependencies
+ */
+import 'state/email-forwarding/init';
+
+/**
  *
  * @param  {object} state  Global state tree
  * @param  {string} domainName the domain name of the forwards


### PR DESCRIPTION
This PR is one of many working on modularising state in Calypso. This one handles email forwarding state.

For more details on state modularisation, see the [modularised state documentation](https://github.com/Automattic/wp-calypso/blob/master/docs/modularized-state.md) and p4TIVU-9lM-p2.

Note: I added reviewers that GitHub suggested. Please feel free to ignore the review request or pull in someone else if you're not comfortable reviewing this PR. Thank you!

Fixes #42432.

#### Changes proposed in this Pull Request

* Modularise email forwarding state

#### Testing instructions

* Install [Redux DevTools](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en).
* Open DevTools and switch to the Redux tab.
* Open `/home` on the live branch or your local copy of this branch.
* Click `State` on the top right to ensure you see all state, and not just the diff for the last action: 
![image](https://user-images.githubusercontent.com/409615/73774406-d3e87d80-477b-11ea-9f59-3e42cc00101f.png)
* Analyse the tree and note that there's no `emailForwarding` key, even if you expand the list of keys. This indicates that the email forwarding state hasn't been loaded yet.
* Switch to a site with a custom domain.
* Click `Manage` on the sidebar, followed by `Domains`.
* Click `Add` in the email column on the table.
* Verify that a `emailForwarding` key is added with the email forwarding state. This indicates that the email forwarding state has now been loaded.
* Verify that email forwarding-related functionality works normally. This indicates that I didn't mess up.