### PR TITLE
Checkout: Improve "Secure Payment" Contrast

### DIFF
--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -794,7 +794,7 @@
 }
 
 .checkout__secure-payment {
-	color: var( --color-neutral-20 );
+	color: var( --color-text-subtle );
 	flex-grow: 1;
 	margin-top: 10px;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The current "Secure payment" text doesn't pass colour contrast requirements - it was probably accidentally missed when all the others were updated last year.

#### Testing instructions

If you add a plan to the Checkout and go to it, you'll see it next to the Pay button!

**Before:**
<img width="311" alt="Screenshot 2020-07-16 at 15 31 08" src="https://user-images.githubusercontent.com/43215253/87683809-681e2e00-c779-11ea-8e01-1438c9e4f81e.png">

**After:**
<img width="296" alt="Screenshot 2020-07-16 at 15 29 36" src="https://user-images.githubusercontent.com/43215253/87683740-576db800-c779-11ea-8723-2e020397564b.png">

cc @sixhours 
