### PR TITLE
Domain Refund Policy: use array index instead of translate object for map key

### DIFF
--- a/client/my-sites/checkout/checkout/domain-refund-policy.jsx
+++ b/client/my-sites/checkout/checkout/domain-refund-policy.jsx
@@ -111,8 +111,8 @@ class DomainRefundPolicy extends React.Component {
 
 		return (
 			<>
-				{ policies.map( ( policy ) => (
-					<div className="checkout__domain-refund-policy" key={ policy }>
+				{ policies.map( ( policy, index ) => (
+					<div className="checkout__domain-refund-policy" key={ index }>
 						<Gridicon icon="info-outline" size={ 18 } />
 						<p>{ policy }</p>
 					</div>


### PR DESCRIPTION
In our composite checkout logging, we're getting the following error for the `map` function in the `DomainRefundPolicy` component: `TypeError: Cannot convert object to primitive value`

Unfortunately, it's hard to reproduce and infrequent, but I think this happens because we use a translation object for the map `key`. This PR switches the `key` to the array item's index. Worst case, it shouldn't hurt.

ref: p1594878303422400-slack-payments-dev

**To test:**
- Add a domain or domain renewal to the cart and visit composite checkout with `?flags=composite-checkout-force`
- Verify that the correct domain refund policy is shown without any console errors