### PR TITLE
Media: Remove unnecessary MediaStore.get from ImageSelector and Calypsoify

### DIFF
--- a/client/blocks/image-selector/index.jsx
+++ b/client/blocks/image-selector/index.jsx
@@ -60,7 +60,6 @@ export class ImageSelector extends Component {
 		if ( imageIds ) {
 			this.props.setMediaLibrarySelectedItems(
 				siteId,
-				// this action only cares about the ID so there's no reason to retrieve the full image object from the store
 				imageIds.map( ( ID ) => ( { ID } ) )
 			);
 		}

--- a/client/blocks/image-selector/index.jsx
+++ b/client/blocks/image-selector/index.jsx
@@ -15,7 +15,6 @@ import ImageSelectorPreview from './preview';
 import ImageSelectorDropZone from './dropzone';
 import isDropZoneVisible from 'state/selectors/is-drop-zone-visible';
 import MediaModal from 'post-editor/media-modal';
-import MediaStore from 'lib/media/store';
 import { localize } from 'i18n-calypso';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { setMediaLibrarySelectedItems } from 'state/media/actions';
@@ -59,8 +58,11 @@ export class ImageSelector extends Component {
 		const { siteId, imageIds } = this.props;
 
 		if ( imageIds ) {
-			const images = imageIds.map( ( imageId ) => MediaStore.get( siteId, imageId ) );
-			this.props.setMediaLibrarySelectedItems( siteId, images );
+			this.props.setMediaLibrarySelectedItems(
+				siteId,
+				// this action only cares about the ID so there's no reason to retrieve the full image object from the store
+				imageIds.map( ( ID ) => ( { ID } ) )
+			);
 		}
 
 		this.setState( {

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -208,8 +208,7 @@ class CalypsoifyIframe extends Component<
 		if ( WindowActions.ClassicBlockOpenMediaModel === action ) {
 			if ( data.imageId ) {
 				const { siteId } = this.props;
-				const image = MediaStore.get( siteId, data.imageId );
-				this.props.setMediaLibrarySelectedItems( siteId, [ image ] );
+				this.props.setMediaLibrarySelectedItems( siteId, [ { ID: data.imageId } ] );
 			}
 
 			this.setState( {


### PR DESCRIPTION
Precendence for this approach:

https://github.com/Automattic/wp-calypso/blob/da4fd95d445bb77810888caafb721842006b0e6d/client/components/tinymce/plugins/simple-payments/dialog/product-image-picker.jsx#L64

We can do this because indeed the reducer for this action only
cares about the ID on the objects passed in.

#### Changes proposed in this Pull Request

* Remove `MediaStore.get` from `ImageSelector` block

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the `ImageSelector` block in devdocs/blocks and ensure that selecting items in the media modal and when uploading still works

Related to https://github.com/Automattic/wp-calypso/issues/43663
