### PR TITLE
Signup: Add reskinSignupFlow a/b test

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -107,6 +107,7 @@ class SignupForm extends Component {
 		suggestedUsername: PropTypes.string.isRequired,
 		translate: PropTypes.func.isRequired,
 		showRecaptchaToS: PropTypes.bool,
+		horizontal: PropTypes.bool,
 
 		// Connected props
 		oauth2Client: PropTypes.object,
@@ -119,6 +120,7 @@ class SignupForm extends Component {
 		flowName: '',
 		isSocialSignupEnabled: false,
 		showRecaptchaToS: false,
+		horizontal: false,
 	};
 
 	state = {
@@ -1015,6 +1017,7 @@ class SignupForm extends Component {
 			<div
 				className={ classNames( 'signup-form', this.props.className, {
 					'is-showing-recaptcha-tos': this.props.showRecaptchaToS,
+					'is-horizontal': this.props.horizontal,
 				} ) }
 			>
 				{ this.getNotice() }
@@ -1028,6 +1031,12 @@ class SignupForm extends Component {
 
 					{ this.props.formFooter || this.formFooter() }
 				</LoggedOutForm>
+
+				{ this.props.horizontal && (
+					<div className="signup-form__separator">
+						<span className="signup-form__separator-text">{ this.props.translate( 'or' ) }</span>
+					</div>
+				) }
 
 				{ this.props.isSocialSignupEnabled && ! this.userCreationComplete() && (
 					<SocialSignupForm

--- a/client/blocks/signup-form/style.scss
+++ b/client/blocks/signup-form/style.scss
@@ -112,3 +112,145 @@
 		}
 	}
 }
+
+.signup-form.is-horizontal {
+	$breakpoint-mobile: 660px;
+	$separator-style: 1px solid #eaeaeb;
+
+	display: flex;
+	flex-wrap: wrap;
+	margin-top: 50px;
+
+	.logged-out-form,
+	.signup-form__social {
+		width: calc( 50% - 30px );
+		max-width: 408px;
+		padding: 0 16px;
+		box-shadow: none;
+
+		@media screen and ( max-width: $breakpoint-mobile ) {
+			width: unset;
+		}
+	}
+
+	.signup-form__social p {
+		text-align: left;
+	}
+
+	.signup-form__social > p {
+		display: none;
+	}
+
+	.signup-form__separator {
+		position: relative;
+		display: flex;
+		width: 60px;
+		align-items: center;
+		justify-content: center;
+
+		@media screen and ( max-width: $breakpoint-mobile ) {
+			width: calc( 100% - 32px );
+			margin: 20px auto;
+		}
+
+		&::before {
+			position: absolute;
+			content: '';
+			border-left: $separator-style;
+			top: 0;
+			left: 50%;
+			height: 100%;
+
+			@media screen and ( max-width: $breakpoint-mobile ) {
+				border-left: 0;
+				border-top: $separator-style;
+				top: 50%;
+				left: 0;
+				height: 0;
+				width: 100%;
+			}
+		}
+	}
+
+	.signup-form__separator-text {
+		background: var( --studio-white );
+		text-transform: uppercase;
+		text-align: center;
+		padding: 24px 0;
+		font-size: 12px;
+		z-index: 1;
+
+		@media screen and ( max-width: $breakpoint-mobile ) {
+			padding: 0 24px;
+		}
+	}
+
+	.signup-form__social-buttons {
+		display: flex;
+		flex-direction: column;
+		height: 100%;
+		justify-content: center;
+	}
+
+	.social-buttons__button {
+		border: 0;
+		box-shadow: none;
+		text-align: left;
+		padding-left: 0;
+
+		@media screen and ( max-width: $breakpoint-mobile ) {
+			text-align: center;
+			margin-bottom: 5px;
+		}
+
+		> svg {
+			border: 1px solid #e2e4e7;
+			padding: 12px;
+			border-radius: 24px;
+		}
+	}
+
+	.social-buttons__service-name {
+		margin-left: 12px;
+	}
+
+	p.signup-form__social-buttons-tos {
+		font-size: 0.75rem;
+
+		@media screen and ( max-width: $breakpoint-mobile ) {
+			max-width: 408px;
+			text-align: center;
+			padding: 0 16px;
+		}
+	}
+
+	> .logged-out-form__links {
+		max-width: 100%;
+		margin-top: 30px;
+
+		@media screen and ( max-width: $breakpoint-mobile ) {
+			margin-top: 0;
+
+			&::before, &::after {
+				content: '';
+				display: block;
+				margin: 40px auto 24px;
+				border: 0;
+				padding: 0;
+				border-top: $separator-style;
+				width: 90px;
+			}
+		}
+	}
+
+	.signup-form__recaptcha-tos {
+		padding: 0 16px;
+		margin: 0 auto;
+
+		.logged-out-form__links {
+			&::before {
+				content: none;
+			}
+		}
+	}
+}

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -32,7 +32,6 @@ import { getProductsList } from 'state/products-list/selectors';
 import Badge from 'components/badge';
 import InfoPopover from 'components/info-popover';
 import { HTTPS_SSL } from 'lib/url/support';
-import { getABTestVariation } from 'lib/abtest';
 
 const NOTICE_GREEN = '#4ab866';
 
@@ -421,7 +420,6 @@ const mapStateToProps = ( state, props ) => {
 			currentUserCurrencyCode,
 			stripZeros
 		),
-		isReskinned: props.isSignupStep && 'reskinned' === getABTestVariation( 'reskinSignupFlow' ),
 	};
 };
 

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -421,7 +421,7 @@ const mapStateToProps = ( state, props ) => {
 			currentUserCurrencyCode,
 			stripZeros
 		),
-		isReskinned: 'reskinned' === getABTestVariation( 'reskinSignupFlow' ),
+		isReskinned: props.isSignupStep && 'reskinned' === getABTestVariation( 'reskinSignupFlow' ),
 	};
 };
 

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -32,6 +32,7 @@ import { getProductsList } from 'state/products-list/selectors';
 import Badge from 'components/badge';
 import InfoPopover from 'components/info-popover';
 import { HTTPS_SSL } from 'lib/url/support';
+import { getABTestVariation } from 'lib/abtest';
 
 const NOTICE_GREEN = '#4ab866';
 
@@ -60,6 +61,7 @@ class DomainRegistrationSuggestion extends React.Component {
 		unavailableDomains: PropTypes.array,
 		productCost: PropTypes.string,
 		productSaleCost: PropTypes.string,
+		isReskinned: PropTypes.bool,
 	};
 
 	componentDidMount() {
@@ -185,6 +187,34 @@ class DomainRegistrationSuggestion extends React.Component {
 		);
 	}
 
+	/**
+	 * Splits a domain into name and tld. Everything after the "first dot"
+	 * becomes the tld. This is not very comprehensive since there can be
+	 * subdomains which would fail this test. However, for our purpose of
+	 * highlighting the TLD in domain suggestions, this is good enough.
+	 *
+	 * @param {string} domain The domain to be parsed
+	 */
+	getDomainParts( domain ) {
+		const parts = domain.split( '.' );
+		const name = parts[ 0 ];
+		const tld = `.${ parts.slice( 1 ).join( '.' ) }`;
+		return {
+			name,
+			tld,
+		};
+	}
+
+	renderDomainParts( domain ) {
+		const { name, tld } = this.getDomainParts( domain );
+		return (
+			<div className="domain-registration-suggestion__domain-title">
+				<span className="domain-registration-suggestion__domain-title-name">{ name }</span>
+				<span className="domain-registration-suggestion__domain-title-tld">{ tld }</span>
+			</div>
+		);
+	}
+
 	renderDomain() {
 		const {
 			isFeatured,
@@ -192,6 +222,7 @@ class DomainRegistrationSuggestion extends React.Component {
 			productSaleCost,
 			suggestion: { domain_name: domain },
 			translate,
+			isReskinned,
 		} = this.props;
 
 		let isAvailable = false;
@@ -201,7 +232,11 @@ class DomainRegistrationSuggestion extends React.Component {
 			isAvailable = true;
 		}
 
-		const title = isAvailable ? translate( '%s is available!', { args: domain } ) : domain;
+		let title = isAvailable ? translate( '%s is available!', { args: domain } ) : domain;
+		if ( isReskinned ) {
+			title = this.renderDomainParts( domain );
+		}
+
 		const paidDomain = isPaidDomain( this.getPriceRule() );
 		const saleBadgeText = translate( 'Sale', {
 			comment: 'Shown next to a domain that has a special discounted sale price',
@@ -386,6 +421,7 @@ const mapStateToProps = ( state, props ) => {
 			currentUserCurrencyCode,
 			stripZeros
 		),
+		isReskinned: 'reskinned' === getABTestVariation( 'reskinSignupFlow' ),
 	};
 };
 

--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -339,7 +339,7 @@ const mapStateToProps = ( state, ownProps ) => {
 		// Set site design type only if we're in signup
 		siteDesignType: ownProps.isSignupStep && getDesignType( state ),
 		isSitePreviewVisible: ownProps.isSignupStep && isSitePreviewVisible( state ),
-		isReskinned: 'reskinned' === getABTestVariation( 'reskinSignupFlow' ),
+		isReskinned: ownProps.isSignupStep && 'reskinned' === getABTestVariation( 'reskinSignupFlow' ),
 	};
 };
 

--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -25,7 +25,6 @@ import { getDesignType } from 'state/signup/steps/design-type/selectors';
 import { DESIGN_TYPE_STORE } from 'signup/constants';
 import { hideSitePreview } from 'state/signup/preview/actions';
 import { isSitePreviewVisible } from 'state/signup/preview/selectors';
-import { getABTestVariation } from 'lib/abtest';
 
 /**
  * Style dependencies
@@ -60,6 +59,7 @@ class DomainSearchResults extends React.Component {
 		fetchAlgo: PropTypes.string,
 		pendingCheckSuggestion: PropTypes.object,
 		unavailableDomains: PropTypes.array,
+		isReskinned: PropTypes.bool,
 	};
 
 	componentDidUpdate() {
@@ -339,7 +339,6 @@ const mapStateToProps = ( state, ownProps ) => {
 		// Set site design type only if we're in signup
 		siteDesignType: ownProps.isSignupStep && getDesignType( state ),
 		isSitePreviewVisible: ownProps.isSignupStep && isSitePreviewVisible( state ),
-		isReskinned: ownProps.isSignupStep && 'reskinned' === getABTestVariation( 'reskinSignupFlow' ),
 	};
 };
 

--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -7,6 +7,7 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
 import { get, includes, times, first } from 'lodash';
+import { isMobile } from '@automattic/viewport';
 
 /**
  * Internal dependencies
@@ -24,6 +25,7 @@ import { getDesignType } from 'state/signup/steps/design-type/selectors';
 import { DESIGN_TYPE_STORE } from 'signup/constants';
 import { hideSitePreview } from 'state/signup/preview/actions';
 import { isSitePreviewVisible } from 'state/signup/preview/selectors';
+import { getABTestVariation } from 'lib/abtest';
 
 /**
  * Style dependencies
@@ -224,7 +226,8 @@ class DomainSearchResults extends React.Component {
 	}
 
 	renderDomainSuggestions() {
-		const { isDomainOnly, suggestions } = this.props;
+		const { isDomainOnly, suggestions, isReskinned } = this.props;
+		const isReskinnedAndNotOnMobile = isReskinned && ! isMobile();
 		let suggestionCount;
 		let featuredSuggestionElement;
 		let suggestionElements;
@@ -292,6 +295,7 @@ class DomainSearchResults extends React.Component {
 						isEligibleVariantForDomainTest={ this.props.isEligibleVariantForDomainTest }
 						selectedFreePlanInSwapFlow={ this.props.selectedFreePlanInSwapFlow }
 						selectedPaidPlanInSwapFlow={ this.props.selectedPaidPlanInSwapFlow }
+						buttonStyles={ { primary: isReskinnedAndNotOnMobile } }
 					/>
 				);
 			} );
@@ -335,6 +339,7 @@ const mapStateToProps = ( state, ownProps ) => {
 		// Set site design type only if we're in signup
 		siteDesignType: ownProps.isSignupStep && getDesignType( state ),
 		isSitePreviewVisible: ownProps.isSignupStep && isSitePreviewVisible( state ),
+		isReskinned: 'reskinned' === getABTestVariation( 'reskinSignupFlow' ),
 	};
 };
 

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -259,9 +259,6 @@
 body.is-section-signup.is-white-signup {
 	.featured-domain-suggestions {
 		.domain-registration-suggestion__title {
-			@import '~@automattic/typography/styles/fonts';
-			@import '~@automattic/onboarding/styles/mixins';
-			@include onboarding-font-recoleta;
 			font-size: 1.625rem;
 		}
 	}

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -1,3 +1,6 @@
+@import '~@wordpress/base-styles/breakpoints';
+@import '~@wordpress/base-styles/mixins';
+
 .domain-suggestion:not( .featured-domain-suggestion ) {
 	display: flex;
 	flex-direction: column;
@@ -249,6 +252,121 @@
 	.is-section-domains & {
 		@include breakpoint-deprecated( '>800px' ) {
 			display: block;
+		}
+	}
+}
+
+body.is-section-signup.is-white-signup {
+	.featured-domain-suggestions {
+		.domain-registration-suggestion__title {
+			@import '~@automattic/typography/styles/fonts';
+			@import '~@automattic/onboarding/styles/mixins';
+			@include onboarding-font-recoleta;
+			font-size: 1.625rem;
+		}
+	}
+
+	.domain-registration-suggestion__progress-bar {
+		.badge {
+			background-color: var( --color-neutral-100 );
+			border-radius: 2px;
+		}
+	}
+
+	.domain-suggestion {
+
+		.domain-product-price__free-text {
+			color: var( --color-neutral-60 );
+			font-size: $font-body;
+		}
+
+		.domain-product-price__price {
+			font-size: $font-body-small;
+
+			&:not( .domain-product-price__free-price ) {
+				color: var( --color-neutral-40 );
+			}
+		}
+
+		&:not( .featured-domain-suggestion ) {
+
+			.domain-suggestion__content {
+				@include breakpoint-deprecated( '>660px' ) {
+					&.domain-suggestion__content-domain-copy-test {
+						justify-content: space-between;
+					}
+				}
+			}
+
+			.domain-registration-suggestion__domain-title {
+				line-height: 3rem;
+				.domain-registration-suggestion__domain-title-tld {
+					color: var( --color-accent );
+				}
+			}
+
+			.domain-product-price__free-price {
+				font-size: $font-body;
+				
+				@include break-mobile {
+					font-size: $font-body-small;
+				}
+			}
+
+			.domain-product-price__free-text {
+				font-size: $font-body;
+				
+				@include break-mobile {
+					font-size: $font-body-small;
+				}
+			}
+
+			.domain-product-price__price:not( .domain-product-price__free-price ) {
+				font-size: $font-body-small;
+
+				@include break-mobile {
+					font-size: $font-body-extra-small;
+				}
+			}
+
+			&.is-clickable:hover {
+				@include break-mobile {
+					background: var( --color-primary-0 );
+					box-shadow: 0 0 0 1px var( --color-primary-40 );
+
+					.domain-suggestion__action:not( .is-borderless ) {
+						border-radius: 4px;
+						display: block;
+						line-height: 17px;
+						padding: 11px 24px 10px;
+					}
+
+					.domain-product-price {
+						display: none;
+					}
+				}
+			}
+
+			&:not( .domain-transfer-suggestion ) {
+				.domain-suggestion__action {
+					@include break-mobile {
+						display: none;
+					}
+				}
+			}
+	
+			&.domain-transfer-suggestion {
+				$cod-grey: #2b2d2f;
+
+				.domain-suggestion__action {
+					color: $cod-grey;
+					text-decoration-line: underline;
+				}
+				.domain-suggestion__chevron {
+					fill: $cod-grey;
+					margin-left: 0;
+				}
+			}
 		}
 	}
 }

--- a/client/components/domains/example-domain-suggestions/style.scss
+++ b/client/components/domains/example-domain-suggestions/style.scss
@@ -39,3 +39,21 @@
 		margin: 0 auto;
 	}
 }
+
+body.is-section-signup.is-white-signup {
+	.example-domain-suggestions {
+		max-width: 678px;
+
+		p {
+			text-align: left;
+		}
+		.example-domain-suggestions__explanation {
+			color: var( --color-neutral-40 );
+		}
+		.example-domain-suggestions__mapping-information {
+			a {
+				color: var( --color-neutral-60 );
+			}
+		}
+	}
+}

--- a/client/components/domains/free-domain-explainer/index.jsx
+++ b/client/components/domains/free-domain-explainer/index.jsx
@@ -3,11 +3,13 @@
  */
 import React from 'react';
 import { localize } from 'i18n-calypso';
+import { omit } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { Button } from '@automattic/components';
+import { getABTestVariation } from 'lib/abtest';
 
 /**
  * Style dependencies
@@ -21,8 +23,27 @@ class FreeDomainExplainer extends React.Component {
 		this.props.onSkip( undefined, hideFreePlan );
 	};
 
+	/**
+	 * Wraps content in a <span> if the user is assigned the
+	 * `reskinned` group of the `reskinSignupFlow` a/b test.
+	 * If not, renders the content in a <p> as the default.
+	 *
+	 * @param {*} props Props passed to the <p> or <span>
+	 */
+	TextWrapper( props ) {
+		const { isReskinned } = props;
+		props = omit( props, 'isReskinned' );
+		return isReskinned ? (
+			<span { ...props }>{ props.children }</span>
+		) : (
+			<p { ...props }>{ props.children }</p>
+		);
+	}
+
 	render() {
 		const { translate } = this.props;
+		const { TextWrapper } = this;
+		const isReskinned = 'reskinned' === getABTestVariation( 'reskinSignupFlow' );
 
 		return (
 			<div className="free-domain-explainer card is-compact">
@@ -30,21 +51,21 @@ class FreeDomainExplainer extends React.Component {
 					<h1 className="free-domain-explainer__title">
 						{ translate( 'Get a free one-year domain registration with any paid plan.' ) }
 					</h1>
-					<p className="free-domain-explainer__subtitle">
+					<TextWrapper isReskinned={ isReskinned } className="free-domain-explainer__subtitle">
 						{ translate(
 							"We'll pay the registration fees for your new domain when you choose a paid plan during the next step."
 						) }
-					</p>
-					<p className="free-domain-explainer__subtitle">
+					</TextWrapper>
+					<TextWrapper isReskinned={ isReskinned } className="free-domain-explainer__subtitle">
 						{ translate( "You can claim your free custom domain later if you aren't ready yet." ) }
 						<Button
 							borderless
 							className="free-domain-explainer__subtitle-link"
 							onClick={ this.handleClick }
 						>
-							{ translate( 'Review our plans to get started' ) } &raquo;
+							{ translate( 'Review our plans to get started' ) } { ! isReskinned && <>&raquo;</> }
 						</Button>
-					</p>
+					</TextWrapper>
 				</header>
 			</div>
 		);

--- a/client/components/domains/free-domain-explainer/index.jsx
+++ b/client/components/domains/free-domain-explainer/index.jsx
@@ -9,7 +9,6 @@ import { omit } from 'lodash';
  * Internal dependencies
  */
 import { Button } from '@automattic/components';
-import { getABTestVariation } from 'lib/abtest';
 
 /**
  * Style dependencies
@@ -17,6 +16,11 @@ import { getABTestVariation } from 'lib/abtest';
 import './style.scss';
 
 class FreeDomainExplainer extends React.Component {
+	constructor( props ) {
+		super( props );
+		this.TextWrapper = this.TextWrapper.bind( this );
+	}
+
 	handleClick = () => {
 		const hideFreePlan = true;
 
@@ -41,9 +45,8 @@ class FreeDomainExplainer extends React.Component {
 	}
 
 	render() {
-		const { translate } = this.props;
+		const { translate, isReskinned } = this.props;
 		const { TextWrapper } = this;
-		const isReskinned = 'reskinned' === getABTestVariation( 'reskinSignupFlow' );
 
 		return (
 			<div className="free-domain-explainer card is-compact">
@@ -51,12 +54,12 @@ class FreeDomainExplainer extends React.Component {
 					<h1 className="free-domain-explainer__title">
 						{ translate( 'Get a free one-year domain registration with any paid plan.' ) }
 					</h1>
-					<TextWrapper isReskinned={ isReskinned } className="free-domain-explainer__subtitle">
+					<TextWrapper className="free-domain-explainer__subtitle">
 						{ translate(
 							"We'll pay the registration fees for your new domain when you choose a paid plan during the next step."
 						) }
 					</TextWrapper>
-					<TextWrapper isReskinned={ isReskinned } className="free-domain-explainer__subtitle">
+					<TextWrapper className="free-domain-explainer__subtitle">
 						{ translate( "You can claim your free custom domain later if you aren't ready yet." ) }
 						<Button
 							borderless

--- a/client/components/domains/free-domain-explainer/style.scss
+++ b/client/components/domains/free-domain-explainer/style.scss
@@ -1,3 +1,6 @@
+@import '~@wordpress/base-styles/breakpoints';
+@import '~@wordpress/base-styles/mixins';
+
 .free-domain-explainer__title {
 
     color: var( --color-text );
@@ -24,5 +27,35 @@
         margin-left: 0.3em;
         text-decoration: underline;
         vertical-align: baseline;
+    }
+}
+
+body.is-section-signup.is-white-signup {
+    .free-domain-explainer {
+        @include break-mobile {
+            margin-bottom: 1em;
+        }
+
+        .free-domain-explainer__subtitle {
+            color: var( --color-neutral-60 );
+            font-size: 1rem;
+            margin-bottom: 0;
+
+            &::after {
+                content: ' ';
+                
+                @include break-mobile {
+                    content: '\a';
+                    white-space: pre;
+                }
+            }
+
+            .free-domain-explainer__subtitle-link {
+                display: block;
+                color: var( --color-neutral-60 );
+                font-weight: 400;
+                margin: 0;
+            }
+        }
     }
 }

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -151,6 +151,7 @@ class RegisterDomainStep extends React.Component {
 		recordFiltersSubmit: PropTypes.func.isRequired,
 		recordFiltersReset: PropTypes.func.isRequired,
 		vertical: PropTypes.string,
+		isReskinned: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -1100,6 +1101,7 @@ class RegisterDomainStep extends React.Component {
 						isEligibleVariantForDomainTest={ this.props.isEligibleVariantForDomainTest }
 						selectedFreePlanInSwapFlow={ this.props.selectedFreePlanInSwapFlow }
 						selectedPaidPlanInSwapFlow={ this.props.selectedPaidPlanInSwapFlow }
+						isReskinned={ this.props.isReskinned }
 					/>
 				);
 			}, this );
@@ -1145,7 +1147,12 @@ class RegisterDomainStep extends React.Component {
 	}
 
 	renderFreeDomainExplainer() {
-		return <FreeDomainExplainer onSkip={ this.props.hideFreePlan } />;
+		return (
+			<FreeDomainExplainer
+				onSkip={ this.props.hideFreePlan }
+				isReskinned={ this.props.isReskinned }
+			/>
+		);
 	}
 
 	onAddDomain = ( suggestion ) => {
@@ -1267,6 +1274,7 @@ class RegisterDomainStep extends React.Component {
 					isEligibleVariantForDomainTest={ this.props.isEligibleVariantForDomainTest }
 					selectedFreePlanInSwapFlow={ this.props.selectedFreePlanInSwapFlow }
 					selectedPaidPlanInSwapFlow={ this.props.selectedPaidPlanInSwapFlow }
+					isReskinned={ this.props.isReskinned }
 				>
 					{ this.props.isEligibleVariantForDomainTest &&
 						hasResults &&

--- a/client/components/domains/search-filters/style.scss
+++ b/client/components/domains/search-filters/style.scss
@@ -1,3 +1,6 @@
+@import '~@wordpress/base-styles/breakpoints';
+@import '~@wordpress/base-styles/mixins';
+
 .search-filters__dropdown-filters {
 	align-items: center;
 	border-left: 1px solid var( --color-neutral-10 );
@@ -213,6 +216,28 @@
 		color: var( --color-neutral-70 );
 		&.is-selected span {
 			color: var( --color-text-inverted );
+		}
+	}
+}
+
+body.is-section-signup.is-white-signup {
+	$accent-blue: #117ac9;
+	.search-filters-extensions__popover {
+		@include break-medium {
+			transform: translateX( 65px );
+		}
+
+		.token-field__suggestion {
+			&.is-selected {
+				background: $accent-blue;
+			}
+		}
+	}
+	.search-filters__popover-button {
+		&.is-active {
+			background: initial;
+			color: $accent-blue;
+			border-color: $accent-blue;
 		}
 	}
 }

--- a/client/components/domains/search-filters/tld-filter-bar.jsx
+++ b/client/components/domains/search-filters/tld-filter-bar.jsx
@@ -163,11 +163,11 @@ export class TldFilterBar extends Component {
 		return (
 			<Popover
 				autoPosition={ false }
-				className="search-filters__popover"
+				className="search-filters__popover search-filters-extensions__popover"
 				context={ this.button }
 				isVisible={ this.state.showPopover }
 				onClose={ this.handleFiltersSubmit }
-				position="bottom left"
+				position="bottom"
 			>
 				<FormFieldset className="search-filters__token-field-fieldset">
 					<TokenField

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -52,6 +52,7 @@ import { getCurrentOAuth2Client } from 'state/oauth2-clients/ui/selectors';
 import LayoutLoader from './loader';
 import wooDnaConfig from 'jetpack-connect/woo-dna-config';
 import { getABTestVariation } from 'lib/abtest';
+import { getCurrentFlowName } from 'state/signup/flow/selectors';
 
 /**
  * Style dependencies
@@ -154,17 +155,22 @@ class Layout extends Component {
 					config.isEnabled( 'woocommerce/onboarding-oauth' ) &&
 					isWooOAuth2Client( this.props.oauth2Client ) &&
 					this.props.wccomFrom,
-				'is-white-signup':
-					'signup' === this.props.sectionName &&
-					'reskinned' === getABTestVariation( 'reskinSignupFlow' ),
 			}
 		);
 
 		const optionalBodyProps = () => {
 			const optionalProps = {};
 
-			if ( this.props.isNewLaunchFlow || this.props.isCheckoutFromGutenboarding ) {
-				optionalProps.bodyClass = 'is-new-launch-flow';
+			const bodyClass = classnames( {
+				'is-new-launch-flow': this.props.isNewLaunchFlow || this.props.isCheckoutFromGutenboarding,
+				'is-white-signup':
+					'signup' === this.props.sectionName &&
+					this.props.isOnboardingFlow &&
+					'reskinned' === getABTestVariation( 'reskinSignupFlow' ),
+			} );
+
+			if ( bodyClass ) {
+				optionalProps.bodyClass = bodyClass;
 			}
 
 			return optionalProps;
@@ -279,6 +285,7 @@ export default connect( ( state ) => {
 	const isEligibleForJITM =
 		[ 'stats', 'plans', 'themes', 'plugins', 'comments' ].indexOf( sectionName ) >= 0;
 	const isNewLaunchFlow = startsWith( currentRoute, '/start/new-launch' );
+	const isOnboardingFlow = 'onboarding' === getCurrentFlowName( state );
 
 	return {
 		masterbarIsHidden:
@@ -311,5 +318,6 @@ export default connect( ( state ) => {
 		shouldQueryAllSites: currentRoute && currentRoute !== '/jetpack/connect/authorize',
 		isNewLaunchFlow,
 		isCheckoutFromGutenboarding,
+		isOnboardingFlow,
 	};
 } )( Layout );

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -51,6 +51,7 @@ import { isWooOAuth2Client } from 'lib/oauth2-clients';
 import { getCurrentOAuth2Client } from 'state/oauth2-clients/ui/selectors';
 import LayoutLoader from './loader';
 import wooDnaConfig from 'jetpack-connect/woo-dna-config';
+import { getABTestVariation } from 'lib/abtest';
 
 /**
  * Style dependencies
@@ -161,6 +162,10 @@ class Layout extends Component {
 
 			if ( this.props.isNewLaunchFlow || this.props.isCheckoutFromGutenboarding ) {
 				optionalProps.bodyClass = 'is-new-launch-flow';
+			}
+
+			if ( 'reskinned' === getABTestVariation( 'reskinSignupFlow' ) ) {
+				optionalProps.bodyClass = classnames( optionalProps.bodyClass, 'is-white-signup' );
 			}
 
 			return optionalProps;

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -154,6 +154,9 @@ class Layout extends Component {
 					config.isEnabled( 'woocommerce/onboarding-oauth' ) &&
 					isWooOAuth2Client( this.props.oauth2Client ) &&
 					this.props.wccomFrom,
+				'is-white-signup':
+					'signup' === this.props.sectionName &&
+					'reskinned' === getABTestVariation( 'reskinSignupFlow' ),
 			}
 		);
 
@@ -162,10 +165,6 @@ class Layout extends Component {
 
 			if ( this.props.isNewLaunchFlow || this.props.isCheckoutFromGutenboarding ) {
 				optionalProps.bodyClass = 'is-new-launch-flow';
-			}
-
-			if ( 'reskinned' === getABTestVariation( 'reskinSignupFlow' ) ) {
-				optionalProps.bodyClass = classnames( optionalProps.bodyClass, 'is-white-signup' );
 			}
 
 			return optionalProps;

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -250,6 +250,6 @@ export default {
 		},
 		defaultVariation: 'control',
 		allowExistingUsers: true,
-		localeExceptions: [ 'en' ],
+		localeExceptions: [ 'en', 'es' ],
 	},
 };

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -250,6 +250,7 @@ export default {
 		},
 		defaultVariation: 'control',
 		allowExistingUsers: true,
+		localeTargets: 'any',
 		localeExceptions: [ 'en', 'es' ],
 	},
 };

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -249,7 +249,7 @@ export default {
 			control: 50,
 		},
 		defaultVariation: 'control',
-		allowExistingUsers: true,
+		allowExistingUsers: false,
 		localeTargets: 'any',
 		localeExceptions: [ 'en', 'es' ],
 	},

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -243,7 +243,7 @@ export default {
 		defaultVariation: 'noverticals',
 	},
 	reskinSignupFlow: {
-		datestamp: '20200720',
+		datestamp: '20200812',
 		variations: {
 			reskinned: 50,
 			control: 50,

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -250,5 +250,6 @@ export default {
 		},
 		defaultVariation: 'control',
 		allowExistingUsers: true,
+		localeTargets: 'any',
 	},
 };

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -241,6 +241,14 @@ export default {
 			noverticals: 50,
 		},
 		defaultVariation: 'noverticals',
+	},
+	reskinSignupFlow: {
+		datestamp: '20200720',
+		variations: {
+			reskinned: 50,
+			control: 50,
+		},
+		defaultVariation: 'control',
 		allowExistingUsers: true,
 	},
 };

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -250,6 +250,6 @@ export default {
 		},
 		defaultVariation: 'control',
 		allowExistingUsers: true,
-		localeTargets: 'any',
+		localeExceptions: [ 'en' ],
 	},
 };

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -613,7 +613,7 @@ export class PlanFeatures extends Component {
 				key={ index }
 				description={ description }
 				hideInfoPopover={ feature.hideInfoPopover }
-				hideGridicon={ this.props.withScroll }
+				hideGridicon={ this.props.isReskinned ? false : this.props.withScroll }
 			>
 				<span className="plan-features__item-info">
 					<span className="plan-features__item-title">{ feature.getTitle() }</span>

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -75,6 +75,7 @@ import getPreviousRoute from 'state/selectors/get-previous-route';
 import { getTld } from 'lib/domains';
 import { isDiscountActive } from 'state/selectors/get-active-discount.js';
 import { selectSiteId as selectHappychatSiteId } from 'state/help/actions';
+import { getABTestVariation } from 'lib/abtest';
 
 /**
  * Style dependencies
@@ -146,6 +147,7 @@ export class PlansFeaturesMain extends Component {
 			siteId,
 			plansWithScroll,
 			customHeader,
+			isReskinned,
 		} = this.props;
 
 		const plans = this.getPlansForPlanFeatures();
@@ -202,6 +204,7 @@ export class PlansFeaturesMain extends Component {
 						availablePlans,
 					} ) }
 					siteId={ siteId }
+					isReskinned={ isReskinned }
 				/>
 			</div>
 		);
@@ -428,7 +431,7 @@ export class PlansFeaturesMain extends Component {
 	};
 
 	renderFreePlanBanner() {
-		const { hideFreePlan, translate, flowName, isInSignup, customHeader } = this.props;
+		const { hideFreePlan, translate, flowName, isInSignup, customHeader, isReskinned } = this.props;
 		const className = 'is-free-plan';
 		const callToAction =
 			isInSignup && flowName === 'launch-site'
@@ -442,8 +445,12 @@ export class PlansFeaturesMain extends Component {
 		return (
 			<div className="plans-features-main__banner">
 				<div className="plans-features-main__banner-content">
-					{ translate( 'Not sure yet?' ) }
-					<Button className={ className } onClick={ this.handleFreePlanButtonClick } borderless>
+					<span>{ translate( 'Not sure yet?' ) }</span>
+					<Button
+						className={ className }
+						onClick={ this.handleFreePlanButtonClick }
+						borderless={ ! isReskinned }
+					>
 						{ callToAction }
 					</Button>
 				</div>
@@ -592,6 +599,7 @@ PlansFeaturesMain.propTypes = {
 	plansWithScroll: PropTypes.bool,
 	planTypes: PropTypes.array,
 	customHeader: PropTypes.node,
+	isReskinned: PropTypes.bool,
 };
 
 PlansFeaturesMain.defaultProps = {
@@ -606,6 +614,7 @@ PlansFeaturesMain.defaultProps = {
 	siteSlug: '',
 	withWPPlanTabs: false,
 	plansWithScroll: false,
+	isReskinned: false,
 };
 
 export default connect(
@@ -618,6 +627,8 @@ export default connect(
 			selectedPlan: props.selectedPlan,
 			currentPlan,
 		} );
+
+		const isReskinned = 'reskinned' === getABTestVariation( 'reskinSignupFlow' );
 
 		return {
 			// This is essentially a hack - discounts are the only endpoint that we can rely on both on /plans and
@@ -635,6 +646,7 @@ export default connect(
 			siteId,
 			siteSlug: getSiteSlug( state, get( props.site, [ 'ID' ] ) ),
 			sitePlanSlug: currentPlan && currentPlan.product_slug,
+			isReskinned,
 		};
 	},
 	{

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -628,7 +628,8 @@ export default connect(
 			currentPlan,
 		} );
 
-		const isReskinned = 'reskinned' === getABTestVariation( 'reskinSignupFlow' );
+		const isReskinned =
+			props.isInSignup && 'reskinned' === getABTestVariation( 'reskinSignupFlow' );
 
 		return {
 			// This is essentially a hack - discounts are the only endpoint that we can rely on both on /plans and

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -629,7 +629,9 @@ export default connect(
 		} );
 
 		const isReskinned =
-			props.isInSignup && 'reskinned' === getABTestVariation( 'reskinSignupFlow' );
+			props.isInSignup &&
+			'onboarding' === props.flowName &&
+			'reskinned' === getABTestVariation( 'reskinSignupFlow' );
 
 		return {
 			// This is essentially a hack - discounts are the only endpoint that we can rely on both on /plans and

--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -1,3 +1,6 @@
+@import '~@wordpress/base-styles/breakpoints';
+@import '~@wordpress/base-styles/mixins';
+
 // Content group
 .plans-features-main__group {
 	& + & {
@@ -99,4 +102,138 @@
 	font-size: $font-body-small;
 	line-height: 1.35;
 	color: var( --color-text-subtle );
+}
+
+/**
+ * Styles for design reskin
+ * The `is-white-signup` class is attached to the body when the user is assigned the `reskinned` group of the `reskinSignupFlow` a/b test
+ */
+body.is-section-signup.is-white-signup {
+	.signup__step.is-plans .formatted-header {
+		margin-bottom: 30px;
+	}
+
+	.plans-features-main {
+		.plans-features-main__group.is-wpcom {
+			padding-top: 0;
+		}
+	
+		.plans-features-main__banner-content {
+			box-shadow: none;
+			display: flex;
+			align-items: center;
+			justify-content: center;
+	
+			.is-free-plan {
+				padding: 12px 32px;
+				margin-left: 12px;
+				border-radius: 4px;
+				font-weight: 400;
+			}
+		}
+	
+		.plan-features__header {
+			border-top: 1px solid #e2e4e7;
+			border-bottom: none;
+			border-radius: 0;
+			padding: 20px;
+	
+			.plan-features__header-title {
+				font-size: 18px;
+			}
+	
+			.plan-features__audience {
+				color: #646970;
+				font-weight: normal;
+			}
+	
+			.plan-pill {
+				text-transform: none;
+				background: var( --color-text );
+				color: var( --color-text-inverted );
+				font-size: 13px;
+				left: 20px;
+				padding: 2px 8px 3px;
+			}
+		}
+	
+		.plan-features__scroller-container {
+			.plan-features__scroll-button {
+				background: var( --color-text );
+				color: var( --color-text-inverted );
+				&[disabled] {
+					display: none;
+				}
+			}
+			.plan-features__scroll-indicator-dot {
+				background: var( --color-neutral-5 );
+				&.is-highlighted {
+					background: var( --color-neutral-100 );
+				}
+			}
+	
+			.plan-features__table {
+				@include break-mobile {
+					border-spacing: 0;
+					border-collapse: collapse;
+				}
+		
+				tbody:first-child tr {
+					border-top-left-radius: 5px;
+					border-top-right-radius: 5px;
+				}
+		
+				.plan-features__table-item {
+					border-left: 1px solid #e2e4e7;
+					border-right: 1px solid #e2e4e7;
+					background-clip: padding-box;
+					
+					.plan-features__description {
+						color: var( --color-neutral-60-rgb );
+						padding-bottom: 42px;
+					}
+				}
+			
+				.plan-features__pricing {
+					border-color: #e2e4e7;
+		
+					.plan-price {
+						text-align: left;
+						font-size: 32px;
+						color: var( --color-neutral-100 );
+						margin-top: 15px;
+						
+						.plan-price__currency-symbol {
+							vertical-align: initial;
+							font-size: 32px;
+							color: var( --color-neutral-100 );
+						}
+					}
+		
+					.plan-features__header-billing-info {
+						text-align: left;
+						font-size: 10px;
+						color: var( --color-neutral-50 );
+						font-weight: 400;
+					}
+				}
+			
+				.plan-features__row {
+					border-top: none;
+					border-bottom: none;
+				}
+			
+				.plan-features__item-checkmark {
+					fill: #00a32a;
+				}
+		
+				.plan-features__item-tip-info {
+					.gridicon {
+						fill: #ccced0;
+					}
+				}
+			}
+		}
+	}
+
 }

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -189,10 +189,14 @@ class Signup extends React.Component {
 			this.setState( { resumingStep: destinationStep } );
 			return page.redirect( getStepUrl( this.props.flowName, destinationStep, this.props.locale ) );
 		}
+
+		if ( this.props.isReskinned ) {
+			this.addCssClassToBodyForReskinnedFlow();
+		}
 	}
 
 	UNSAFE_componentWillReceiveProps( nextProps ) {
-		const { stepName, flowName, progress } = nextProps;
+		const { stepName, flowName, progress, isReskinned } = nextProps;
 
 		if ( this.props.stepName !== stepName ) {
 			this.removeFulfilledSteps( nextProps );
@@ -208,6 +212,10 @@ class Signup extends React.Component {
 
 		if ( ! this.state.controllerHasReset && ! isEqual( this.props.progress, progress ) ) {
 			this.updateShouldShowLoadingScreen( progress );
+		}
+
+		if ( isReskinned && ! this.props.isReskinned ) {
+			this.addCssClassToBodyForReskinnedFlow();
 		}
 	}
 
@@ -624,6 +632,14 @@ class Signup extends React.Component {
 		}
 	}
 
+	/**
+	 * Temporary hack for adding a css class to the body
+	 * for a user who is assigned to the reskinned group of reskinSignupFlow a/b test.
+	 */
+	addCssClassToBodyForReskinnedFlow() {
+		document.body.classList.add( 'is-white-signup' );
+	}
+
 	render() {
 		// Prevent rendering a step if in the middle of performing a redirect or resuming progress.
 		if (
@@ -641,10 +657,9 @@ class Signup extends React.Component {
 		}
 
 		const showProgressIndicator = 'pressable-nux' === this.props.flowName ? false : true;
-		const reskinnedClass = this.props.isReskinned ? 'is-reskinned' : '';
 
 		return (
-			<div className={ `signup is-${ kebabCase( this.props.flowName ) } ${ reskinnedClass }` }>
+			<div className={ `signup is-${ kebabCase( this.props.flowName ) }` }>
 				<DocumentHead title={ this.props.pageTitle } />
 				{ ! isWPForTeamsFlow( this.props.flowName ) && (
 					<SignupHeader

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -78,6 +78,7 @@ import {
 import WpcomLoginForm from './wpcom-login-form';
 import SiteMockups from './site-mockup';
 import P2SignupProcessingScreen from 'signup/p2-processing-screen';
+import ReskinnedProcessingScreen from 'signup/reskinned-processing-screen';
 import user from 'lib/user';
 import getCurrentLocaleSlug from 'state/selectors/get-current-locale-slug';
 import { abtest } from 'lib/abtest';
@@ -553,6 +554,21 @@ class Signup extends React.Component {
 		return flows.getFlow( this.props.flowName ).steps.length;
 	}
 
+	renderProcessingScreen() {
+		if ( isWPForTeamsFlow( this.props.flowName ) ) {
+			return <P2SignupProcessingScreen />;
+		}
+
+		if ( this.props.isReskinned ) {
+			const domainItem = get( this.props, 'signupDependencies.domainItem', false );
+			const hasPaidDomain = isDomainRegistration( domainItem );
+
+			return <ReskinnedProcessingScreen hasPaidDomain={ hasPaidDomain } />;
+		}
+
+		return <SignupProcessingScreen />;
+	}
+
 	renderCurrentStep() {
 		const domainItem = get( this.props, 'signupDependencies.domainItem', false );
 		const currentStepProgress = find( this.props.progress, { stepName: this.props.stepName } );
@@ -575,10 +591,6 @@ class Signup extends React.Component {
 		const hideFreePlan = planWithDomain || this.props.isDomainOnlySite || selectedHideFreePlan;
 		const shouldRenderLocaleSuggestions = 0 === this.getPositionInFlow() && ! this.props.isLoggedIn;
 
-		const ProcessingScreen = isWPForTeamsFlow( this.props.flowName )
-			? P2SignupProcessingScreen
-			: SignupProcessingScreen;
-
 		return (
 			<div className="signup__step" key={ stepKey }>
 				<div className={ `signup__step is-${ kebabCase( this.props.stepName ) }` }>
@@ -586,7 +598,7 @@ class Signup extends React.Component {
 						<LocaleSuggestions path={ this.props.path } locale={ this.props.locale } />
 					) }
 					{ this.state.shouldShowLoadingScreen ? (
-						<ProcessingScreen />
+						this.renderProcessingScreen()
 					) : (
 						<CurrentComponent
 							path={ this.props.path }
@@ -667,6 +679,7 @@ class Signup extends React.Component {
 						flowName={ this.props.flowName }
 						showProgressIndicator={ showProgressIndicator }
 						shouldShowLoadingScreen={ this.state.shouldShowLoadingScreen }
+						isReskinned={ this.props.isReskinned }
 					/>
 				) }
 				<div className="signup__steps">{ this.renderCurrentStep() }</div>

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -80,6 +80,7 @@ import SiteMockups from './site-mockup';
 import P2SignupProcessingScreen from 'signup/p2-processing-screen';
 import user from 'lib/user';
 import getCurrentLocaleSlug from 'state/selectors/get-current-locale-slug';
+import { abtest } from 'lib/abtest';
 
 /**
  * Style dependencies
@@ -640,9 +641,10 @@ class Signup extends React.Component {
 		}
 
 		const showProgressIndicator = 'pressable-nux' === this.props.flowName ? false : true;
+		const reskinnedClass = this.props.isReskinned ? 'is-reskinned' : '';
 
 		return (
-			<div className={ `signup is-${ kebabCase( this.props.flowName ) }` }>
+			<div className={ `signup is-${ kebabCase( this.props.flowName ) } ${ reskinnedClass }` }>
 				<DocumentHead title={ this.props.pageTitle } />
 				{ ! isWPForTeamsFlow( this.props.flowName ) && (
 					<SignupHeader
@@ -679,6 +681,9 @@ export default connect(
 			'props.showSiteMockups',
 			false
 		);
+		const isReskinned =
+			'onboarding' === ownProps.flowName && 'reskinned' === abtest( 'reskinSignupFlow' );
+
 		return {
 			domainsWithPlansOnly: getCurrentUser( state )
 				? currentUserHasFlag( state, NON_PRIMARY_DOMAINS_TO_FREE_USERS ) // this is intentional, not a mistake
@@ -697,6 +702,7 @@ export default connect(
 			shouldStepShowSitePreview,
 			isSitePreviewVisible: shouldStepShowSitePreview && isSitePreviewVisible( state ),
 			localeSlug: getCurrentLocaleSlug( state ),
+			isReskinned,
 		};
 	},
 	{

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -22,6 +22,7 @@ import {
 	startsWith,
 } from 'lodash';
 import { connect } from 'react-redux';
+import { getLocaleSlug } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -709,7 +710,9 @@ export default connect(
 			false
 		);
 		const isReskinned =
-			'onboarding' === ownProps.flowName && 'reskinned' === abtest( 'reskinSignupFlow' );
+			'onboarding' === ownProps.flowName &&
+			! /^en\b/.test( getLocaleSlug() ) &&
+			'reskinned' === abtest( 'reskinSignupFlow' );
 
 		return {
 			domainsWithPlansOnly: getCurrentUser( state )

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -22,7 +22,6 @@ import {
 	startsWith,
 } from 'lodash';
 import { connect } from 'react-redux';
-import { getLocaleSlug } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -710,9 +709,7 @@ export default connect(
 			false
 		);
 		const isReskinned =
-			'onboarding' === ownProps.flowName &&
-			! /^en\b/.test( getLocaleSlug() ) &&
-			'reskinned' === abtest( 'reskinSignupFlow' );
+			'onboarding' === ownProps.flowName && 'reskinned' === abtest( 'reskinSignupFlow' );
 
 		return {
 			domainsWithPlansOnly: getCurrentUser( state )

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -196,7 +196,7 @@ class Signup extends React.Component {
 	}
 
 	UNSAFE_componentWillReceiveProps( nextProps ) {
-		const { stepName, flowName, progress, isReskinned } = nextProps;
+		const { stepName, flowName, progress, isReskinned, path } = nextProps;
 
 		if ( this.props.stepName !== stepName ) {
 			this.removeFulfilledSteps( nextProps );
@@ -213,8 +213,7 @@ class Signup extends React.Component {
 		if ( ! this.state.controllerHasReset && ! isEqual( this.props.progress, progress ) ) {
 			this.updateShouldShowLoadingScreen( progress );
 		}
-
-		if ( isReskinned && ! this.props.isReskinned ) {
+		if ( isReskinned && ( ! this.props.isReskinned || path !== this.props.path ) ) {
 			this.addCssClassToBodyForReskinnedFlow();
 		}
 	}

--- a/client/signup/navigation-link/index.jsx
+++ b/client/signup/navigation-link/index.jsx
@@ -18,6 +18,7 @@ import { recordTracksEvent } from 'state/analytics/actions';
 import { submitSignupStep } from 'state/signup/progress/actions';
 import { getSignupProgress } from 'state/signup/progress/selectors';
 import { getFilteredSteps } from '../utils';
+import { getABTestVariation } from 'lib/abtest';
 
 /**
  * Style dependencies
@@ -132,7 +133,13 @@ export class NavigationLink extends Component {
 
 		if ( this.props.direction === 'back' ) {
 			backGridicon = <Gridicon icon="arrow-left" size={ 18 } />;
-			text = labelText ? labelText : translate( 'Back' );
+			if ( labelText ) {
+				text = labelText;
+			} else if ( 'reskinned' === getABTestVariation( 'reskinSignupFlow' ) ) {
+				text = translate( 'Go Back' );
+			} else {
+				text = translate( 'Back' );
+			}
 		}
 
 		if ( this.props.direction === 'forward' ) {

--- a/client/signup/reskinned-processing-screen/index.jsx
+++ b/client/signup/reskinned-processing-screen/index.jsx
@@ -1,0 +1,76 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { sprintf } from '@wordpress/i18n';
+import { useI18n } from '@automattic/react-i18n';
+import { useInterval } from 'lib/interval/use-interval';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+// Total time to perform "loading"
+const DURATION_IN_MS = 6000;
+
+/**
+ * This component is cloned from the CreateSite component of Gutenboarding flow
+ * to work with the onboarding signup flow.
+ */
+export default function ReskinnedProcessingScreen( { hasPaidDomain } ) {
+	const { __ } = useI18n();
+
+	const steps = React.useRef(
+		[
+			__( 'Building your site' ),
+			hasPaidDomain && __( 'Getting your domain' ),
+			__( 'Applying design' ),
+		].filter( Boolean )
+	);
+	const totalSteps = steps.current.length;
+
+	const [ currentStep, setCurrentStep ] = React.useState( 0 );
+
+	/**
+	 * Completion progress: 0 <= progress <= 1
+	 */
+	const progress = ( currentStep + 1 ) / totalSteps;
+	const isComplete = progress >= 1;
+
+	useInterval(
+		() => setCurrentStep( ( s ) => s + 1 ),
+		// Enable the interval when progress is incomplete
+		isComplete ? null : DURATION_IN_MS / totalSteps
+	);
+
+	// Force animated progress bar to start at 0
+	const [ hasStarted, setHasStarted ] = React.useState( false );
+	React.useEffect( () => {
+		const id = setTimeout( () => setHasStarted( true ), 750 );
+		return () => clearTimeout( id );
+	}, [] );
+
+	return (
+		<div className="reskinned-processing-screen">
+			<h1 className="reskinned-processing-screen__progress-step">
+				{ steps.current[ currentStep ] }
+			</h1>
+			<div
+				className="reskinned-processing-screen__progress-bar"
+				style={ {
+					'--progress': ! hasStarted ? /* initial 10% progress */ 0.1 : progress,
+				} }
+			/>
+			<p className="reskinned-processing-screen__progress-numbered-steps">
+				{
+					// translators: these are progress steps. Eg: step 1 of 4.
+					sprintf( __( 'Step %(currentStep)d of %(totalSteps)d' ), {
+						currentStep: currentStep + 1,
+						totalSteps,
+					} )
+				}
+			</p>
+		</div>
+	);
+}

--- a/client/signup/reskinned-processing-screen/style.scss
+++ b/client/signup/reskinned-processing-screen/style.scss
@@ -1,6 +1,4 @@
 @import '~@automattic/onboarding/styles/mixins';
-@import 'assets/stylesheets/gutenberg-base-styles';
-@import 'landing/gutenboarding/onboarding-block/colors';
 
 $progress-duration: 800ms;
 
@@ -32,8 +30,9 @@ $progress-duration: 800ms;
 	}
 
 	&__progress-step {
-		@include onboarding-heading-text-mobile;
-
+		@include onboarding-font-recoleta;
+		font-size: 26px;
+		line-height: 40px;
 		text-align: center;
 		vertical-align: middle;
 		margin: 0;

--- a/client/signup/reskinned-processing-screen/style.scss
+++ b/client/signup/reskinned-processing-screen/style.scss
@@ -1,0 +1,48 @@
+@import '~@automattic/onboarding/styles/mixins';
+@import 'assets/stylesheets/gutenberg-base-styles';
+@import 'landing/gutenboarding/onboarding-block/colors';
+
+$progress-duration: 800ms;
+
+.reskinned-processing-screen {
+	padding: 1em;
+	max-width: 540px;
+
+	margin: 32vh auto;
+
+	&__progress-bar {
+		position: relative;
+		overflow: hidden;
+		height: 6px;
+		margin-top: 1em;
+		background: var( --studio-gray-10 );
+		--progress: 0;
+
+		&::before {
+			background: var( --studio-blue-40 );
+			transform: translateX( calc( -100% * min( 1 - var( --progress, 0 ), 1 ) ) );
+			position: absolute;
+			content: '';
+			top: 0;
+			left: 0;
+			right: 0;
+			bottom: 0;
+			transition: transform $progress-duration ease-out;
+		}
+	}
+
+	&__progress-step {
+		@include onboarding-heading-text-mobile;
+
+		text-align: center;
+		vertical-align: middle;
+		margin: 0;
+	}
+
+	&__progress-numbered-steps {
+		margin-top: 0.7em;
+		padding: 1em;
+		text-align: center;
+		color: var( --studio-gray-40 );
+	}
+}

--- a/client/signup/signup-header/index.jsx
+++ b/client/signup/signup-header/index.jsx
@@ -26,16 +26,13 @@ export default class SignupHeader extends Component {
 		flowName: PropTypes.string,
 		showProgressIndicator: PropTypes.bool,
 		shouldShowLoadingScreen: PropTypes.bool,
+		isReskinned: PropTypes.bool,
 	};
-
-	constructor( props ) {
-		super( props );
-	}
 
 	render() {
 		const logoClasses = classnames( {
 			'wordpress-logo': true,
-			'is-large': this.props.shouldShowLoadingScreen,
+			'is-large': this.props.shouldShowLoadingScreen && ! this.props.isReskinned,
 		} );
 
 		return (

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -49,7 +49,7 @@ import { isDomainStepSkippable } from 'signup/config/steps';
 import { fetchUsernameSuggestion } from 'state/signup/optional-dependencies/actions';
 import { isSitePreviewVisible } from 'state/signup/preview/selectors';
 import { hideSitePreview, showSitePreview } from 'state/signup/preview/actions';
-import { abtest } from 'lib/abtest';
+import { abtest, getABTestVariation } from 'lib/abtest';
 import getSitesItems from 'state/selectors/get-sites-items';
 
 /**
@@ -73,6 +73,7 @@ class DomainsStep extends React.Component {
 		stepSectionName: PropTypes.string,
 		selectedSite: PropTypes.object,
 		vertical: PropTypes.string,
+		isReskinned: PropTypes.bool,
 	};
 
 	getDefaultState = () => ( {
@@ -497,6 +498,7 @@ class DomainsStep extends React.Component {
 				hideFreePlan={ this.handleSkip }
 				selectedFreePlanInSwapFlow={ selectedFreePlanInSwapFlow }
 				selectedPaidPlanInSwapFlow={ selectedPaidPlanInSwapFlow }
+				isReskinned={ this.props.isReskinned }
 			/>
 		);
 
@@ -753,6 +755,9 @@ export default connect(
 	( state, ownProps ) => {
 		const productsList = getAvailableProductsList( state );
 		const productsLoaded = ! isEmpty( productsList );
+		const isReskinned =
+			'onboarding' === ownProps.flowName &&
+			'reskinned' === getABTestVariation( 'reskinSignupFlow' );
 
 		return {
 			designType: getDesignType( state ),
@@ -764,6 +769,7 @@ export default connect(
 			selectedSite: getSite( state, ownProps.signupDependencies.siteSlug ),
 			isSitePreviewVisible: isSitePreviewVisible( state ),
 			sites: getSitesItems( state ),
+			isReskinned,
 		};
 	},
 	{

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -1,3 +1,6 @@
+@import '~@wordpress/base-styles/breakpoints';
+@import '~@wordpress/base-styles/mixins';
+
 .domains__step-section-wrapper {
 	margin: 0 auto;
 	max-width: 720px;
@@ -37,6 +40,81 @@
 		.register-domain-step__search-card,
 		.search.is-open.has-focus {
 			border-radius: 0;
+		}
+	}
+}
+
+/**
+ * Styles for design reskin
+ * The `is-white-signup` class is attached to the body when the user is assigned the `reskinned` group of the `reskinSignupFlow` a/b test
+ */
+body.is-section-signup.is-white-signup {
+
+	$light-white: #f3f4f5;
+
+	.signup__step.is-domains .formatted-header {
+		margin-bottom: 30px;
+	}
+
+	.domains__step-content {
+		.search.is-open.has-focus {
+			box-shadow: 0 0 0 2px  var( --color-accent );
+			background: var( --color-surface );
+			.search__input {
+				background: var( --color-surface );
+			}
+		}
+		.register-domain-step__search-card {
+			background: $light-white;
+			box-shadow: none;
+			margin: 20px;
+
+			@include break-mobile {
+				margin: initial;
+			}
+		}
+		.search__input {
+			background:  $light-white;
+		}
+		.search.is-open .search__input-fade.ltr::before {
+			display: none;
+		}
+		.search__open-icon {
+			transform: scaleX( -1 );
+		}
+		.search__close-icon {
+			display: none;
+		}
+	}
+
+	.search-filters__dropdown-filters {
+		border: none;
+
+		&.search-filters__dropdown-filters--is-open {
+			box-shadow: none;
+		}
+
+		.button {
+			flex-direction: row;
+
+			&:hover, &:focus {
+				box-shadow: none;
+			}
+
+			.search-filters__dropdown-filters-button-text {
+				padding-left: 6px;
+			}
+		}
+	}
+
+	.search-filters__popover {
+		$accent-blue: #117ac9;
+		.button.is-primary {
+			background: $accent-blue;
+			border-color: $accent-blue;
+		}
+		.popover__arrow {
+			display: none;
 		}
 	}
 }

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -66,7 +66,8 @@ body.is-section-signup.is-white-signup {
 		}
 		.register-domain-step__search-card {
 			background: $light-white;
-			box-shadow: none;
+			box-shadow: 0 0 0 1.5px  var( --color-neutral-10 );
+			border-radius: 4px;
 			margin: 20px;
 
 			@include break-mobile {
@@ -75,6 +76,9 @@ body.is-section-signup.is-white-signup {
 		}
 		.search__input {
 			background:  $light-white;
+			&::placeholder {
+				color: var( --color-neutral-100 );
+			}
 		}
 		.search.is-open .search__input-fade.ltr::before {
 			display: none;
@@ -102,6 +106,7 @@ body.is-section-signup.is-white-signup {
 			}
 
 			.search-filters__dropdown-filters-button-text {
+				color: var( --color-neutral-60 );
 				padding-left: 6px;
 			}
 		}

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -33,8 +33,13 @@ import config from 'config';
 import AsyncLoad from 'components/async-load';
 import WooCommerceConnectCartHeader from 'extensions/woocommerce/components/woocommerce-connect-cart-header';
 import { getSocialServiceFromClientId } from 'lib/login';
-import { abtest } from 'lib/abtest';
+import { abtest, getABTestVariation } from 'lib/abtest';
 import JetpackLogo from 'components/jetpack-logo';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
 
 export class UserStep extends Component {
 	static propTypes = {
@@ -427,6 +432,7 @@ export class UserStep extends Component {
 					socialServiceResponse={ socialServiceResponse }
 					recaptchaClientId={ this.state.recaptchaClientId }
 					showRecaptchaToS={ flows.getFlow( this.props.flowName )?.showRecaptcha }
+					horizontal={ 'reskinned' === getABTestVariation( 'reskinSignupFlow' ) }
 				/>
 				<div id="g-recaptcha"></div>
 			</>

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -394,7 +394,7 @@ export class UserStep extends Component {
 	}
 
 	renderSignupForm() {
-		const { oauth2Client, wccomFrom } = this.props;
+		const { oauth2Client, wccomFrom, flowName } = this.props;
 		let socialService, socialServiceResponse;
 		let isSocialSignupEnabled = this.props.isSocialSignupEnabled;
 		const hashObject = this.props.initialContext && this.props.initialContext.hash;
@@ -415,6 +415,9 @@ export class UserStep extends Component {
 			isSocialSignupEnabled = true;
 		}
 
+		const isReskinned =
+			'onboarding' === flowName && 'reskinned' === getABTestVariation( 'reskinSignupFlow' );
+
 		return (
 			<>
 				<SignupForm
@@ -432,7 +435,7 @@ export class UserStep extends Component {
 					socialServiceResponse={ socialServiceResponse }
 					recaptchaClientId={ this.state.recaptchaClientId }
 					showRecaptchaToS={ flows.getFlow( this.props.flowName )?.showRecaptcha }
-					horizontal={ 'reskinned' === getABTestVariation( 'reskinSignupFlow' ) }
+					horizontal={ isReskinned }
 				/>
 				<div id="g-recaptcha"></div>
 			</>

--- a/client/signup/steps/user/style.scss
+++ b/client/signup/steps/user/style.scss
@@ -1,0 +1,22 @@
+body.is-section-signup.is-white-signup .signup.is-onboarding {
+	.signup-form.is-horizontal {
+		.form-label,
+		.signup-form__terms-of-service-link,
+		.signup-form__terms-of-service-link a,
+		.signup-form__social-buttons-tos,
+		.signup-form__social-buttons-tos a,
+		.signup-form__social p,
+		.signup-form__recaptcha-tos,
+		.logged-out-form__links .logged-out-form__link-item {
+			color: var( --studio-gray-40 );
+			font-weight: normal;
+		}
+
+		.signup-form__terms-of-service-link a,
+		.signup-form__social-buttons-tos a,
+		.signup-form__recaptcha-tos a {
+			color: inherit;
+			text-decoration: underline;
+		}
+	}
+}

--- a/client/signup/steps/user/test/index.js
+++ b/client/signup/steps/user/test/index.js
@@ -20,6 +20,7 @@ import { UserStep as User } from '../';
 jest.mock( 'blocks/signup-form', () => require( 'components/empty-component' ) );
 jest.mock( 'lib/abtest', () => ( {
 	abtest: () => '',
+	getABTestVariation: () => null,
 } ) );
 jest.mock( 'signup/step-wrapper', () => require( 'components/empty-component' ) );
 jest.mock( 'signup/utils', () => ( {

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -456,17 +456,23 @@ body.is-section-signup.is-white-signup .signup.is-onboarding {
 	--color-accent: #117ac9;
 	--color-accent-60: #0e64a5;
 
-	.signup-header .wordpress-logo {
-		position: absolute;
-		left: 16px;
-		top: 12px;
-		fill: var( --color-text );
-		transform-origin: 0 0;
-	}
-
-	.flow-progress-indicator {
-		color: var( --color-text );
-		font-weight: normal;
+	.signup-header {
+		.wordpress-logo {
+			position: absolute;
+			left: 24px;
+			top: 20px;
+			fill: var( --color-text );
+			transform-origin: 0 0;
+		}
+		.signup-header__right {
+			top: 22px;
+			right: 24px;
+			
+			.flow-progress-indicator {
+				color: var( --color-text );
+				font-weight: normal;
+			}
+		}
 	}
 
 	.navigation-link.button.back {
@@ -475,8 +481,8 @@ body.is-section-signup.is-white-signup .signup.is-onboarding {
 		}
 
 		color: $gray-50;
-		top: 12px;
-		left: 50px;
+		top: 23px;
+		left: 72px;
 		text-decoration: underline;
 		font-weight: normal;
 	}

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -483,21 +483,33 @@ body.is-section-signup.is-white-signup .signup.is-onboarding {
 			@include onboarding-font-recoleta;
 			color: $gray-100;
 			letter-spacing: 0.2px;
-			font-size: 42px;
+			font-size: 2.6rem;
 
 			@media screen and ( max-width: $breakpoint-mobile ) {
-				font-size: 26px;
+				max-width: 328px;
+				font-size: 1.6rem;
+				text-align: left;
+				padding: 0 16px;
+				margin: 0 auto;
 			}
 		}
 
 		.formatted-header__subtitle {
 			color: $gray-60;
+
+			@media screen and ( max-width: $breakpoint-mobile ) {
+				max-width: 328px;
+				font-size: 0.875rem;
+				text-align: left;
+				padding: 0 16px;
+				margin: 0 auto;
+			}
 		}
 	}
 
 	button.is-primary {
 		background: #117ac9;
-		// box-shadow: unset;
+		box-shadow: none;
 		border: 0;
 	}
 }

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -443,3 +443,61 @@ body.is-section-signup.is-new-launch-flow .layout:not( .dops ):not( .is-wccom-oa
 		color: var( --color-text );
 	}
 }
+
+/**
+ * Common styles for reskinSignupFlow a/b test
+ */
+body.is-section-signup.is-white-signup .signup.is-onboarding {
+	$gray-100: #101517;
+	$gray-60: #50575e;
+	$gray-50: #646970;
+	$breakpoint-mobile: 660px;
+
+	.signup-header .wordpress-logo {
+		position: absolute;
+		left: 16px;
+		top: 12px;
+		fill: var( --color-text );
+		transform-origin: 0 0;
+	}
+
+	.flow-progress-indicator {
+		color: var( --color-text );
+		font-weight: normal;
+	}
+
+	.navigation-link.button.back {
+		svg {
+			display: none;
+		}
+
+		color: $gray-50;
+		top: 12px;
+		left: 50px;
+		text-decoration: underline;
+		font-weight: normal;
+	}
+
+	.formatted-header {
+		.formatted-header__title {
+			@include onboarding-font-recoleta;
+			color: $gray-100;
+			letter-spacing: 0.2px;
+			font-size: 42px;
+
+			@media screen and ( max-width: $breakpoint-mobile ) {
+				font-size: 26px;
+			}
+		}
+
+		.formatted-header__subtitle {
+			color: $gray-60;
+		}
+	}
+
+	button.is-primary {
+		background: #117ac9;
+		// box-shadow: unset;
+		border: 0;
+	}
+}

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -454,6 +454,7 @@ body.is-section-signup.is-white-signup .signup.is-onboarding {
 	$breakpoint-mobile: 660px;
 
 	--color-accent: #117ac9;
+	--color-accent-60: #0e64a5;
 
 	.signup-header .wordpress-logo {
 		position: absolute;
@@ -511,7 +512,6 @@ body.is-section-signup.is-white-signup .signup.is-onboarding {
 	}
 
 	button.is-primary {
-		background: #117ac9;
 		box-shadow: none;
 		border: 0;
 	}

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -482,7 +482,6 @@ body.is-section-signup.is-white-signup .signup.is-onboarding {
 
 	.formatted-header {
 		margin-top: 48px;
-
 		.formatted-header__title {
 			@include onboarding-font-recoleta;
 			color: $gray-100;

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -453,6 +453,8 @@ body.is-section-signup.is-white-signup .signup.is-onboarding {
 	$gray-50: #646970;
 	$breakpoint-mobile: 660px;
 
+	--color-accent: #117ac9;
+
 	.signup-header .wordpress-logo {
 		position: absolute;
 		left: 16px;
@@ -479,6 +481,8 @@ body.is-section-signup.is-white-signup .signup.is-onboarding {
 	}
 
 	.formatted-header {
+		margin-top: 48px;
+
 		.formatted-header__title {
 			@include onboarding-font-recoleta;
 			color: $gray-100;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR impldements an A/B test to show a different look of the `onboarding` signup flow to the variation group. See pau2Xa-1x4-p2 for more details.

cc @aneeshd16 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/new`.
* Make sure you're assigned to `reskinned` group of `reskinSignupFlow` a/b test.
  * Note: this test is intended to work only for non-EN and non-ES users. (p1596055144383000-slack-marketing-health).
* The signup flow should look as below.

<img width="866" alt="new-signup" src="https://user-images.githubusercontent.com/212034/87685294-2e234b00-c7be-11ea-9893-2779d65a45ed.png">
<img width="866" alt="new-domains" src="https://user-images.githubusercontent.com/212034/87685302-324f6880-c7be-11ea-9e4a-d3179f673544.png">
<img width="866" alt="new-domain-selection" src="https://user-images.githubusercontent.com/212034/87685310-34b1c280-c7be-11ea-9767-13d1c9261e7d.png">
<img width="866" alt="new-plans" src="https://user-images.githubusercontent.com/212034/87685317-37acb300-c7be-11ea-86bf-dc1d6116029f.png">
<img width="866" alt="new-processing" src="https://user-images.githubusercontent.com/212034/87685325-39767680-c7be-11ea-9f00-7178855b2a80.png">


