### PR TITLE
Domains: Add helper text in site redirect settings update dialog

### DIFF
--- a/client/lib/url/support.js
+++ b/client/lib/url/support.js
@@ -87,6 +87,7 @@ export const SETTING_PRIMARY_DOMAIN = `${ root }/domains/#set-a-primary-address`
 export const SETTING_UP_PREMIUM_SERVICES = `${ root }/setting-up-premium-services`;
 export const STRONG_PASSWORD = `${ root }/selecting-a-strong-password/`;
 export const SHARING = `${ root }/sharing`;
+export const SITE_REDIRECT = `${ root }/site-redirect`;
 export const START = `${ root }/start`;
 export const STATS_CLICKS = `${ root }/stats/#clicks`;
 export const STATS_REFERRERS = `${ root }/stats/#referrers`;

--- a/client/my-sites/domains/domain-management/site-redirect/index.jsx
+++ b/client/my-sites/domains/domain-management/site-redirect/index.jsx
@@ -37,6 +37,7 @@ import { getSelectedSite } from 'state/ui/selectors';
 import { getSiteRedirectLocation } from 'state/domains/site-redirect/selectors';
 import { withoutHttp } from 'lib/url';
 import getCurrentRoute from 'state/selectors/get-current-route';
+import { localizeUrl } from 'lib/i18n-utils';
 
 /**
  * Style dependencies
@@ -148,7 +149,19 @@ class SiteRedirect extends React.Component {
 								/>
 
 								<p className="site-redirect__explanation">
-									{ translate( 'All domains on this site will redirect here.' ) }
+									{ translate(
+										'All domains on this site will redirect here as long as this domain is set as your primary domain. ' +
+											'{{learnMoreLink}}Learn more{{/learnMoreLink}}',
+										{
+											components: {
+												learnMoreLink: (
+													<a
+														href={ localizeUrl( 'https://wordpress.com/support/site-redirect/' ) }
+													/>
+												),
+											},
+										}
+									) }
 								</p>
 							</FormFieldset>
 

--- a/client/my-sites/domains/domain-management/site-redirect/index.jsx
+++ b/client/my-sites/domains/domain-management/site-redirect/index.jsx
@@ -37,7 +37,7 @@ import { getSelectedSite } from 'state/ui/selectors';
 import { getSiteRedirectLocation } from 'state/domains/site-redirect/selectors';
 import { withoutHttp } from 'lib/url';
 import getCurrentRoute from 'state/selectors/get-current-route';
-import { localizeUrl } from 'lib/i18n-utils';
+import { SITE_REDIRECT } from 'lib/url/support';
 
 /**
  * Style dependencies
@@ -155,9 +155,7 @@ class SiteRedirect extends React.Component {
 										{
 											components: {
 												learnMoreLink: (
-													<a
-														href={ localizeUrl( 'https://wordpress.com/support/site-redirect/' ) }
-													/>
+													<a href={ SITE_REDIRECT } target="_blank" rel="noopener noreferrer" />
 												),
 											},
 										}

--- a/client/my-sites/domains/domain-management/site-redirect/style.scss
+++ b/client/my-sites/domains/domain-management/site-redirect/style.scss
@@ -16,4 +16,8 @@
 	font-size: $font-body-small;
 	font-style: italic;
 	color: var( --color-text-subtle );
+
+	a {
+		white-space: nowrap;
+	}
 }


### PR DESCRIPTION
To disable a site redirect users have to make it the *non* primary domain for the site.
Users trying to disable a site redirect, who might not know about this, may end up in the site redirect settings update dialog, trying to disable it. 

Users would benefit from more explicits ways to accomplish this task. As mentioned by @klimeryk in #42317, this could be addressed by the work @fditrapani and @hambai are doing around domain management. In the meantime, it would be helpful to put an explicit helper text in the site redirect settings update dialog with a link to the support docs, where there's a section that explains how to disable a site redirect.

#### Changes proposed in this Pull Request

* Added a helper text in the site redirect settings dialog with a localized link to the site redirect support docs.

##### Before

<img width="754" alt="imagen" src="https://user-images.githubusercontent.com/5444806/87683949-0c8f7880-c758-11ea-8b73-0773ec6839a2.png">

##### After

<img width="717" alt="imagen" src="https://user-images.githubusercontent.com/5444806/87684110-3ba5ea00-c758-11ea-9693-e40398006673.png">

#### Testing instructions

* Create a site redirect (omit this step if there's one already defined)
* Go to Manage > Domains and click the domain of the site redirect
* Update the site redirect by clicking "Redirect settings"
* Verify that under the form input field there's a message that says: "All domains on this site will redirect here as long as this domain is set as your primary domain. Learn more".
* Verify that, if the interface language is English, clicking the "Learn more" link takes you to https://wordpress.com/support/site-redirect/.
* Verify that, if the interface language is other than English, clicking the "Learn more" link takes you to the localized version of https://wordpress.com/support/site-redirect/ that matches the selected interface language.

Fixes #42317 
