### PR TITLE
Jetpack Connect: allow retry when rendering notices when site info is not present.

### DIFF
--- a/client/jetpack-connect/jetpack-connect-notices.jsx
+++ b/client/jetpack-connect/jetpack-connect-notices.jsx
@@ -88,6 +88,7 @@ export class JetpackConnectNotices extends Component {
 
 		switch ( noticeType ) {
 			case NOT_EXISTS:
+				noticeValues.userCanRetry = true;
 				return noticeValues;
 
 			case SITE_BLOCKED:


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* http://calypso.localhost:3000/jetpack/connect?url=:SITE&mobile_redirect=wordpress://jetpack-connection?source=stats


