### PR TITLE
Prevents upsell for Jetpack Backup & Scan for WP.com

### DIFF
--- a/client/components/formatted-header/index.jsx
+++ b/client/components/formatted-header/index.jsx
@@ -47,13 +47,24 @@ function FormattedHeader( {
 }
 
 FormattedHeader.propTypes = {
+	id: PropTypes.string,
+	className: PropTypes.string,
 	brandFont: PropTypes.bool,
-	headerText: PropTypes.node,
-	subHeaderText: PropTypes.node,
+	headerText: PropTypes.oneOfType( [ PropTypes.node, PropTypes.string ] ).isRequired,
+	subHeaderText: PropTypes.oneOfType( [ PropTypes.node, PropTypes.string ] ),
 	compactOnMobile: PropTypes.bool,
 	isSecondary: PropTypes.bool,
-	align: PropTypes.string,
-	brandFont: PropTypes.bool,
+	align: PropTypes.oneOf( [ 'center', 'left', 'right' ] ),
+};
+
+FormattedHeader.defaultProps = {
+	id: '',
+	className: '',
+	brandFont: false,
+	subHeaderText: '',
+	compactOnMobile: false,
+	isSecondary: false,
+	align: 'center',
 };
 
 export default FormattedHeader;

--- a/client/jetpack-connect/test/__snapshots__/auth-form-header.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/auth-form-header.js.snap
@@ -3,7 +3,13 @@
 exports[`AuthFormHeader renders as expected 1`] = `
 <div>
   <FormattedHeader
+    align="center"
+    brandFont={false}
+    className=""
+    compactOnMobile={false}
     headerText="Create an account to set up Jetpack"
+    id=""
+    isSecondary={false}
     subHeaderText="You are moments away from a better WordPress."
   />
   <CompactCard

--- a/client/lib/formatting/prevent-widows.js
+++ b/client/lib/formatting/prevent-widows.js
@@ -1,7 +1,7 @@
 /**
  * Prevent widows by replacing spaces between the last `wordsToKeep` words in the text with non-breaking spaces
  *
- * @param  {string} text        the text to work on
+ * @param  {string|@i18n-calypso/TranslateResult} text the text to work on
  * @param  {number} wordsToKeep the number of words to keep together
  * @returns {string}             the widow-prevented string
  */

--- a/client/my-sites/backup/wpcom-backup-upsell.tsx
+++ b/client/my-sites/backup/wpcom-backup-upsell.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { ReactElement } from 'react';
+import React, { ReactElement, FunctionComponent } from 'react';
 import { translate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 
@@ -28,14 +28,124 @@ import useTrackCallback from 'lib/jetpack/use-track-callback';
 import JetpackBackupSVG from 'assets/images/illustrations/jetpack-backup.svg';
 import './style.scss';
 
-const trackEventName = 'calypso_jetpack_backup_upsell';
+const JetpackBackupErrorSVG = '/calypso/images/illustrations/jetpack-cloud-backup-error.svg';
 
-export default function WPCOMUpsellPage(): ReactElement {
-	const onUpgradeClick = useTrackCallback( undefined, trackEventName );
+const BackupMultisiteBody: FunctionComponent = () => (
+	<PromoCard
+		title={ preventWidows( translate( 'WordPress multi-sites are not supported' ) ) }
+		image={ { path: JetpackBackupErrorSVG } }
+		isPrimary
+	>
+		<p>
+			{ preventWidows(
+				translate(
+					"We're sorry, Jetpack Backup is not compatible with multisite WordPress installations at this time."
+				)
+			) }
+		</p>
+	</PromoCard>
+);
+
+const BackupVPActiveBody: FunctionComponent = () => {
+	const onUpgradeClick = useTrackCallback( undefined, 'calypso_jetpack_backup_vaultpress_click' );
+	return (
+		<PromoCard
+			title={ preventWidows( translate( 'Your site has VaultPress' ) ) }
+			image={ { path: JetpackBackupErrorSVG } }
+			isPrimary
+		>
+			<p>
+				{ preventWidows(
+					translate(
+						'Your site is already backed up by VaultPress. You can find a link to your VaultPress dashboard below.'
+					)
+				) }
+			</p>
+			<div className="backup__wpcom-ctas">
+				<Button
+					className="backup__wpcom-cta backup__wpcom-realtime-cta"
+					href="https://dashboard.vaultpress.com"
+					onClick={ onUpgradeClick }
+					selfTarget={ true }
+					primary
+				>
+					{ translate( 'Visit Dashboard' ) }
+				</Button>
+			</div>
+		</PromoCard>
+	);
+};
+
+const BackupUpsellBody: FunctionComponent = () => {
+	const onUpgradeClick = useTrackCallback( undefined, 'calypso_jetpack_backup_upsell' );
 	const siteSlug = useSelector( getSelectedSiteSlug );
 	const siteId = useSelector( getSelectedSiteId );
-	const isAdmin = useSelector( ( state ) => canCurrentUser( state, siteId, 'manage_options' ) );
+	const isAdmin = useSelector(
+		( state ) => siteId && canCurrentUser( state, siteId, 'manage_options' )
+	);
+	return (
+		<PromoCard
+			title={ preventWidows( translate( 'Get time travel for your site with Jetpack Backup' ) ) }
+			image={ { path: JetpackBackupSVG } }
+			isPrimary
+		>
+			<p>
+				{ preventWidows(
+					translate(
+						'Backup gives you granular control over your site, with the ability to restore it to any previous state, and export it at any time.'
+					)
+				) }
+			</p>
 
+			{ ! isAdmin && (
+				<Notice
+					status="is-warning"
+					text={ translate( 'Only site administrators can upgrade to access Backup.' ) }
+					showDismiss={ false }
+				/>
+			) }
+
+			{ isAdmin && (
+				<div className="backup__wpcom-ctas">
+					<Button
+						className="backup__wpcom-cta backup__wpcom-realtime-cta"
+						href={ addQueryArgs( `/checkout/${ siteSlug }/jetpack_backup_realtime`, {
+							redirect_to: window.location.href,
+						} ) }
+						onClick={ onUpgradeClick }
+						selfTarget={ true }
+						primary
+					>
+						{ translate( 'Get real-time backups' ) }
+					</Button>
+					<Button
+						className="backup__wpcom-cta backup__wpcom-daily-cta"
+						href={ addQueryArgs( `/checkout/${ siteSlug }/jetpack_backup_daily`, {
+							redirect_to: window.location.href,
+						} ) }
+						onClick={ onUpgradeClick }
+						selfTarget={ true }
+					>
+						{ translate( 'Get daily backups' ) }
+					</Button>
+				</div>
+			) }
+		</PromoCard>
+	);
+};
+
+export default function WPCOMUpsellPage( { reason }: { reason: string } ): ReactElement {
+	let body;
+	switch ( reason ) {
+		case 'multisite_not_supported':
+			body = <BackupMultisiteBody />;
+			break;
+		case 'vp_active_on_site':
+			body = <BackupVPActiveBody />;
+			break;
+		default:
+			body = <BackupUpsellBody />;
+	}
 	return (
 		<Main className="backup__main backup__wpcom-upsell">
 			<DocumentHead title="Jetpack Backup" />
@@ -49,53 +159,7 @@ export default function WPCOMUpsellPage(): ReactElement {
 				brandFont
 			/>
 
-			<PromoCard
-				title={ preventWidows( translate( 'Get time travel for your site with Jetpack Backup' ) ) }
-				image={ { path: JetpackBackupSVG } }
-				isPrimary
-			>
-				<p>
-					{ preventWidows(
-						translate(
-							'Backup gives you granular control over your site, with the ability to restore it to any previous state, and export it at any time.'
-						)
-					) }
-				</p>
-
-				{ ! isAdmin && (
-					<Notice
-						status="is-warning"
-						text={ translate( 'Only site administrators can upgrade to access Backup.' ) }
-						showDismiss={ false }
-					/>
-				) }
-
-				{ isAdmin && (
-					<div className="backup__wpcom-ctas">
-						<Button
-							className="backup__wpcom-cta backup__wpcom-realtime-cta"
-							href={ addQueryArgs( `/checkout/${ siteSlug }/jetpack_backup_realtime`, {
-								redirect_to: window.location.href,
-							} ) }
-							onClick={ onUpgradeClick }
-							selfTarget={ true }
-							primary
-						>
-							{ translate( 'Get real-time backups' ) }
-						</Button>
-						<Button
-							className="backup__wpcom-cta backup__wpcom-daily-cta"
-							href={ addQueryArgs( `/checkout/${ siteSlug }/jetpack_backup_daily`, {
-								redirect_to: window.location.href,
-							} ) }
-							onClick={ onUpgradeClick }
-							selfTarget={ true }
-						>
-							{ translate( 'Get daily backups' ) }
-						</Button>
-					</div>
-				) }
-			</PromoCard>
+			{ body }
 		</Main>
 	);
 }

--- a/client/my-sites/backup/wpcom-backup-upsell.tsx
+++ b/client/my-sites/backup/wpcom-backup-upsell.tsx
@@ -4,12 +4,12 @@
 import React, { ReactElement, FunctionComponent } from 'react';
 import { translate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
+import { addQueryArgs } from '@wordpress/url';
+import { Button } from '@automattic/components';
 
 /**
  * Internal dependencies
  */
-import { addQueryArgs } from '@wordpress/url';
-import { Button } from '@automattic/components';
 import { getSelectedSiteSlug, getSelectedSiteId } from 'state/ui/selectors';
 import canCurrentUser from 'state/selectors/can-current-user';
 import { preventWidows } from 'lib/formatting';

--- a/client/my-sites/scan/style.scss
+++ b/client/my-sites/scan/style.scss
@@ -109,6 +109,10 @@
 			margin-top: 64px;
 		}
 	}
+
+	.security-icon {
+		width: 80px;
+	}
 }
 
 /**

--- a/client/my-sites/scan/wpcom-scan-upsell.tsx
+++ b/client/my-sites/scan/wpcom-scan-upsell.tsx
@@ -1,9 +1,10 @@
 /**
  * External dependencies
  */
-import React, { ReactElement } from 'react';
+import React, { ReactElement, FunctionComponent } from 'react';
 import { translate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
+import { Button } from '@automattic/components';
 
 /**
  * Internal dependencies
@@ -20,6 +21,8 @@ import PromoCard from 'components/promo-section/promo-card';
 import PromoCardCTA from 'components/promo-section/promo-card/cta';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import useTrackCallback from 'lib/jetpack/use-track-callback';
+import { preventWidows } from 'lib/formatting';
+import SecurityIcon from 'components/jetpack/security-icon';
 
 /**
  * Asset dependencies
@@ -27,12 +30,111 @@ import useTrackCallback from 'lib/jetpack/use-track-callback';
 import JetpackScanSVG from 'assets/images/illustrations/jetpack-scan.svg';
 import './style.scss';
 
-export default function WPCOMScanUpsellPage(): ReactElement {
+const ScanMultisiteBody: FunctionComponent = () => (
+	<PromoCard
+		title={ preventWidows( translate( 'WordPress multi-sites are not supported' ) ) }
+		image={ <SecurityIcon icon="info" /> }
+		isPrimary
+	>
+		<p>
+			{ preventWidows(
+				translate(
+					"We're sorry, Jetpack Scan is not compatible with multisite WordPress installations at this time."
+				)
+			) }
+		</p>
+	</PromoCard>
+);
+
+const ScanVPActiveBody: FunctionComponent = () => {
+	const onUpgradeClick = useTrackCallback( undefined, 'calypso_jetpack_scan_vaultpress_click' );
+	return (
+		<PromoCard
+			title={ preventWidows( translate( 'Your site has VaultPress' ) ) }
+			image={ <SecurityIcon icon="info" /> }
+			isPrimary
+		>
+			<p>
+				{ preventWidows(
+					translate(
+						'Your site is already backed up by VaultPress. You can find a link to your VaultPress dashboard below.'
+					)
+				) }
+			</p>
+			<div className="scan__wpcom-ctas">
+				<Button
+					className="scan__wpcom-cta backup__wpcom-realtime-cta"
+					href="https://dashboard.vaultpress.com"
+					onClick={ onUpgradeClick }
+					selfTarget={ true }
+					primary
+				>
+					{ translate( 'Visit Dashboard' ) }
+				</Button>
+			</div>
+		</PromoCard>
+	);
+};
+
+const ScanUpsellBody: FunctionComponent = () => {
 	const onUpgradeClick = useTrackCallback( undefined, 'calypso_jetpack_scan_upsell' );
 	const siteSlug = useSelector( getSelectedSiteSlug );
 	const siteId = useSelector( getSelectedSiteId );
-	const isAdmin = useSelector( ( state ) => canCurrentUser( state, siteId, 'manage_options' ) );
+	const isAdmin = useSelector(
+		( state ) => siteId && canCurrentUser( state, siteId, 'manage_options' )
+	);
 
+	return (
+		<PromoCard
+			title={ translate( 'We guard your site. You run your business.' ) }
+			image={ { path: JetpackScanSVG } }
+			isPrimary
+		>
+			<p>
+				{ translate(
+					'Scan gives you automated scanning and one-click fixes ' +
+						'to keep your site ahead of security threats.'
+				) }
+			</p>
+
+			{ ! isAdmin && (
+				<Notice
+					status="is-warning"
+					text={ translate( 'Only site administrators can upgrade to access daily scanning.' ) }
+					showDismiss={ false }
+				/>
+			) }
+
+			{ isAdmin && (
+				<PromoCardCTA
+					cta={ {
+						text: translate( 'Get daily scanning' ),
+						action: {
+							url: addQueryArgs( `/checkout/${ siteSlug }/jetpack_scan`, {
+								redirect_to: window.location.href,
+							} ),
+							onClick: onUpgradeClick,
+							selfTarget: true,
+						},
+					} }
+				/>
+			) }
+		</PromoCard>
+	);
+};
+
+export default function WPCOMScanUpsellPage( { reason }: { reason?: string } ): ReactElement {
+	let body;
+	switch ( reason ) {
+		case 'multisite_not_supported':
+			body = <ScanMultisiteBody />;
+			break;
+		case 'vp_active_on_site':
+			body = <ScanVPActiveBody />;
+			break;
+		default:
+			body = <ScanUpsellBody />;
+	}
 	return (
 		<Main className="scan scan__wpcom-upsell">
 			<DocumentHead title="Scanner" />
@@ -46,41 +148,7 @@ export default function WPCOMScanUpsellPage(): ReactElement {
 				brandFont
 			/>
 
-			<PromoCard
-				title={ translate( 'We guard your site. You run your business.' ) }
-				image={ { path: JetpackScanSVG } }
-				isPrimary
-			>
-				<p>
-					{ translate(
-						'Scan gives you automated scanning and one-click fixes ' +
-							'to keep your site ahead of security threats.'
-					) }
-				</p>
-
-				{ ! isAdmin && (
-					<Notice
-						status="is-warning"
-						text={ translate( 'Only site administrators can upgrade to access daily scanning.' ) }
-						showDismiss={ false }
-					/>
-				) }
-
-				{ isAdmin && (
-					<PromoCardCTA
-						cta={ {
-							text: translate( 'Get daily scanning' ),
-							action: {
-								url: addQueryArgs( `/checkout/${ siteSlug }/jetpack_scan`, {
-									redirect_to: window.location.href,
-								} ),
-								onClick: onUpgradeClick,
-								selfTarget: true,
-							},
-						} }
-					/>
-				) }
-			</PromoCard>
+			{ body }
 		</Main>
 	);
 }

--- a/client/my-sites/scan/wpcom-scan-upsell.tsx
+++ b/client/my-sites/scan/wpcom-scan-upsell.tsx
@@ -57,7 +57,7 @@ const ScanVPActiveBody: FunctionComponent = () => {
 			<p>
 				{ preventWidows(
 					translate(
-						'Your site is already backed up by VaultPress. You can find a link to your VaultPress dashboard below.'
+						'Your site is already protected by VaultPress. You can find a link to your VaultPress dashboard below.'
 					)
 				) }
 			</p>

--- a/client/my-sites/scan/wpcom-scan-upsell.tsx
+++ b/client/my-sites/scan/wpcom-scan-upsell.tsx
@@ -57,7 +57,7 @@ const ScanVPActiveBody: FunctionComponent = () => {
 			<p>
 				{ preventWidows(
 					translate(
-						'Your site is already protected by VaultPress. You can find a link to your VaultPress dashboard below.'
+						'Your site already is protected by VaultPress. You can find a link to your VaultPress dashboard below.'
 					)
 				) }
 			</p>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds two new upsell designs mirroring the work done for cloud.jetpack.com and in #44187.

#### Screenshots
**Backup - VaultPress**

<img width="750" alt="Screen Shot 2020-07-16 at 12 57 45 PM" src="https://user-images.githubusercontent.com/1760168/87700661-ad843080-c764-11ea-9a96-b5dc90e56a26.png">

**Backup - Multi-sites**

<img width="777" alt="Screen Shot 2020-07-16 at 12 59 40 PM" src="https://user-images.githubusercontent.com/1760168/87700672-b117b780-c764-11ea-9da3-cc1688435660.png">

**Scan - VaultPress**

<img width="772" alt="Screen Shot 2020-07-16 at 3 48 50 PM" src="https://user-images.githubusercontent.com/1760168/87715801-e085ee80-c77b-11ea-9068-a993f1d07b1b.png">

**Scan - Multi-Sites**

<img width="775" alt="Screen Shot 2020-07-16 at 3 42 48 PM" src="https://user-images.githubusercontent.com/1760168/87715420-5178d680-c77b-11ea-97d5-614e30124c22.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Create a Jetpack multisite and connect it.
- With this code, visit wordpress.com and navigate to the Backup nav for the site.
- Verify Backup matches the screenshot for multi-sites above.
- Do the same, but with Scan.
- Do the same but with a single site with VaultPress installed.
- Verify Backup & Scan matches the screenshot for VaultPress above.

**Note:** Jetpack Scan may not show the correct state for multisites. This is a known API issue. An alternative way to test would be to set the `reason` prop on the `WPCOMScanUpsellPage` component.

Fixes 1184358343400545-as-1184719508034178.
