### PR TITLE
Revert "WPCOM Block Editor: show dismiss button in IE 11"

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/style.scss
@@ -12,8 +12,8 @@ $transition-period: 100ms;
 	left: 0;
 	right: 0;
 	bottom: 0;
-	// Use the same z-index as the edit-post-layout header
-	z-index: z-index( '.interface-interface-skeleton__header' );
+	// Use the same z-index as the <Modal> component
+	z-index: z-index( '.components-modal__header' );
 	animation: wpcom-block-editor-nav-sidebar-nav-sidebar__fade $transition-period ease-out forwards;
 	@include reduce-motion( 'animation' );
 


### PR DESCRIPTION
Reverts Automattic/wp-calypso#44196