### PR TITLE
Premium Content: Correct "non-static method call" errors.

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/subscription-service/class-jetpack-token-subscription-service.php
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/subscription-service/class-jetpack-token-subscription-service.php
@@ -32,7 +32,8 @@ class Jetpack_Token_Subscription_Service extends Token_Subscription_Service {
 	 * @inheritDoc
 	 */
 	function get_key() {
-		$token = Manager::get_access_token();
+		$connection = new Manager();
+		$token      = $connection->get_access_token();
 		if ( ! isset( $token->secret ) ) {
 			return false;
 		}


### PR DESCRIPTION
The Premium Content block causes log errors by calling a non-static method statically to get tokens. This PR corrects the code usage to avoid the errors.

Discovered by @blackjackkent while testing #44192 .

<img width="1729" alt="87706667-84b06b00-c765-11ea-86e6-bedd9764b079" src="https://user-images.githubusercontent.com/349751/87727859-bd0c7500-c776-11ea-8c11-852b5396e4cc.png">


**Testing Instructions**
* Set up a JN test site that is connected to WP.com and has a JP Premium plan attached.
* Sandbox the store and API. Set the JN site to use the sandboxed API (WP Admin > Settings > Jetpack Constants).
* Install the latest Gutenberg plugin.
* Use the build artifact from the `FSE plugin / Build FSE plugin (pull_request)` task below as a ZIP plugin that you can upload to the test site.
* Create a post, and add a Premium Content block for testing.
* Save the post, and open the front-end of the post in an incognito window.
* Subscribe to the content, using the test store card credentials to purchase.
* The page will reload to show the now-accessible content; Verify it loads without the above errors.