### PR TITLE
Gutenboarding: show webp design screenshots

### DIFF
--- a/client/landing/gutenboarding/available-designs.ts
+++ b/client/landing/gutenboarding/available-designs.ts
@@ -16,19 +16,17 @@ interface AvailableDesigns {
 
 const availableDesigns: Readonly< AvailableDesigns > = availableDesignsConfig;
 
-// TODO: work out why webp images were 404ing in production
-//
-// function getCanUseWebP() {
-// 	if ( typeof window !== 'undefined' ) {
-// 		const elem = document.createElement( 'canvas' );
-// 		if ( elem.getContext?.( '2d' ) ) {
-// 			return elem.toDataURL( 'image/webp' ).indexOf( 'data:image/webp' ) === 0;
-// 		}
-// 	}
-// 	return false;
-// }
+function getCanUseWebP() {
+	if ( typeof window !== 'undefined' ) {
+		const elem = document.createElement( 'canvas' );
+		if ( elem.getContext?.( '2d' ) ) {
+			return elem.toDataURL( 'image/webp' ).indexOf( 'data:image/webp' ) === 0;
+		}
+	}
+	return false;
+}
 
-// const canUseWebP = getCanUseWebP();
+const canUseWebP = getCanUseWebP();
 
 export const getDesignImageUrl = ( design: Design ) => {
 	// We temporarily show pre-generated screenshots until we can generate tall versions dynamically using mshots.
@@ -37,7 +35,9 @@ export const getDesignImageUrl = ( design: Design ) => {
 	// https://github.com/Automattic/wp-calypso/issues/40564
 	if ( ! isEnabled( 'gutenboarding/mshot-preview' ) ) {
 		// When we update the static images, bump the version for cache busting
-		return `/calypso/page-templates/design-screenshots/${ design.slug }_${ design.template }_${ design.theme }.jpg?v=2`;
+		return `/calypso/page-templates/design-screenshots/${ design.slug }_${ design.template }_${
+			design.theme
+		}.${ canUseWebP ? 'webp' : 'jpg' }?v=2`;
 	}
 
 	const mshotsUrl = 'https://s.wordpress.com/mshots/v1/';


### PR DESCRIPTION
## Changes proposed in this Pull Request

**The news is in**: we can officially server [webp image files from production and stage environments](https://wordpress.com/calypso/page-templates/design-screenshots/rockfield_rockfield_rockfield.webp).

pMz3w-bHt-p2#comment-80676

This PR reverts the temporary fix in #44198, which reverted the original, failed attempt to dish up webp images in #44165. 

#### Testing instructions

Take a look at the screenshots at the `/new/design` step in Chrome or Firefox.

How do they look?

Now check in Safari or IE11 (they don't support webp). Do the JPEGs load instead?

**Also, to the person that is merging**: how does stage look before you :shipit: ? After you've deployed, does prod look okay to you?


