### PR TITLE
P2: Signup: fix invalid blog title validation

### DIFF
--- a/client/signup/steps/p2-site/index.jsx
+++ b/client/signup/steps/p2-site/index.jsx
@@ -124,7 +124,7 @@ class P2Site extends React.Component {
 					blog_title: fields.siteTitle,
 					validate: true,
 				},
-				function ( error, response ) {
+				( error, response ) => {
 					debug( error, response );
 
 					if ( error && error.message ) {
@@ -141,7 +141,9 @@ class P2Site extends React.Component {
 
 						if ( error.error === 'blog_title_invalid' ) {
 							messages.siteTitle = {
-								[ error.error ]: error.message,
+								[ error.error ]: this.props.translate(
+									'Please enter a valid team or project name.'
+								),
 							};
 						} else {
 							messages.site = {

--- a/client/signup/steps/p2-site/index.jsx
+++ b/client/signup/steps/p2-site/index.jsx
@@ -139,10 +139,17 @@ class P2Site extends React.Component {
 
 						timesValidationFailed++;
 
-						messages.site = {
-							[ error.error ]: error.message,
-						};
+						if ( error.error === 'blog_title_invalid' ) {
+							messages.siteTitle = {
+								[ error.error ]: error.message,
+							};
+						} else {
+							messages.site = {
+								[ error.error ]: error.message,
+							};
+						}
 					}
+
 					onComplete( null, messages );
 				}
 			);


### PR DESCRIPTION
In this PR, we fix invalid blog title validation in the P2 signup flow.

![](https://user-images.githubusercontent.com/3392497/85328016-7e5d0500-b4bf-11ea-99a6-bc3bb7a8b394.png)

> If you put a HTML-like input in the site title field, like <img src, you'll get a validation error... but on the wrong field - the site URL 😅 Even if the site URL is actually valid:

## Testing instructions

Navigate to `/start/p2` and fill in the name of the P2. Try invalid names like `<img`. Fill in site address and hit "Continue". It should show correct validation. Verify you can create a P2 site by filling in valid inputs.