### PR TITLE
Modularise account recovery state.

### DIFF
--- a/client/state/account-recovery/init.js
+++ b/client/state/account-recovery/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'state/redux-store';
+import reducer from './reducer';
+
+registerReducer( [ 'accountRecovery' ], reducer );

--- a/client/state/account-recovery/package.json
+++ b/client/state/account-recovery/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/account-recovery/reducer.js
+++ b/client/state/account-recovery/reducer.js
@@ -1,8 +1,7 @@
 /**
  * Internal dependencies
  */
-
-import { combineReducers, withoutPersistence } from 'state/utils';
+import { combineReducers, withoutPersistence, withStorageKey } from 'state/utils';
 import settings from './settings/reducer';
 import {
 	ACCOUNT_RECOVERY_SETTINGS_FETCH,
@@ -23,7 +22,9 @@ const isFetchingSettings = withoutPersistence( ( state = false, action ) => {
 	return state;
 } );
 
-export default combineReducers( {
+const combinedReducer = combineReducers( {
 	settings,
 	isFetchingSettings,
 } );
+
+export default withStorageKey( 'accountRecovery', combinedReducer );

--- a/client/state/account-recovery/selectors.js
+++ b/client/state/account-recovery/selectors.js
@@ -1,2 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import 'state/account-recovery/init';
+
 export const isFetchingAccountRecoverySettings = ( state ) =>
 	state.accountRecovery.isFetchingSettings;

--- a/client/state/account-recovery/settings/actions.js
+++ b/client/state/account-recovery/settings/actions.js
@@ -25,6 +25,8 @@ import {
 	ACCOUNT_RECOVERY_SETTINGS_VALIDATE_PHONE_FAILED,
 } from 'state/action-types';
 
+import 'state/account-recovery/init';
+
 const TARGET_PHONE = 'phone';
 const TARGET_EMAIL = 'email';
 

--- a/client/state/account-recovery/settings/selectors.js
+++ b/client/state/account-recovery/settings/selectors.js
@@ -1,3 +1,8 @@
+/**
+ * Internal dependencies
+ */
+import 'state/account-recovery/init';
+
 export const isAccountRecoverySettingsReady = ( state ) => {
 	return state.accountRecovery.settings.isReady;
 };

--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -14,7 +14,6 @@ import { reducer as httpData } from 'state/data-layer/http-data';
 /**
  * Reducers
  */
-import accountRecovery from './account-recovery/reducer';
 import activityLog from './activity-log/reducer';
 import atomicTransfer from './atomic-transfer/reducer';
 import connectedApplications from './connected-applications/reducer';
@@ -79,7 +78,6 @@ import wordads from './wordads/reducer';
 // The reducers in this list are not modularized, and are always loaded on boot.
 // Please do not add to this list. See #39261 and p4TIVU-9lM-p2 for more details.
 const reducers = {
-	accountRecovery,
 	activityLog,
 	atomicTransfer,
 	connectedApplications,

--- a/client/state/selectors/is-requesting-reset-password.js
+++ b/client/state/selectors/is-requesting-reset-password.js
@@ -1,7 +1,11 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import 'state/account-recovery/init';
 
 export default ( state ) => get( state, 'accountRecovery.reset.resetPassword.isRequesting', false );


### PR DESCRIPTION
This PR is one of many working on modularising state in Calypso. This one handles account recovery state.

For more details on state modularisation, see the [modularised state documentation](https://github.com/Automattic/wp-calypso/blob/master/docs/modularized-state.md) and p4TIVU-9lM-p2.

Note: I added all the reviewers that GitHub suggested. Please feel free to ignore the review request or pull in someone else if you're not comfortable reviewing this PR. Thank you!

Fixes #42418.

#### Changes proposed in this Pull Request

* Modularise account recovery state

#### Testing instructions

Account recovery state gets automatically loaded on boot due to the notifications middleware, so it's difficult to test the automatic loading portion of this PR.

Smoke-testing account recovery functionality should be enough to validate this PR, since no actual functional code changes to account recovery code have taken place.
