### PR TITLE
Modularise happiness engineers state

### DIFF
--- a/client/state/happiness-engineers/actions.js
+++ b/client/state/happiness-engineers/actions.js
@@ -1,7 +1,6 @@
 /**
  * Internal dependencies
  */
-
 import wpcom from 'lib/wp';
 import {
 	HAPPINESS_ENGINEERS_FETCH,
@@ -9,6 +8,8 @@ import {
 	HAPPINESS_ENGINEERS_FETCH_FAILURE,
 	HAPPINESS_ENGINEERS_FETCH_SUCCESS,
 } from 'state/action-types';
+
+import 'state/happiness-engineers/init';
 
 /**
  * Returns an action object used in signalling that a list of HEs

--- a/client/state/happiness-engineers/init.js
+++ b/client/state/happiness-engineers/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'state/redux-store';
+import reducer from './reducer';
+
+registerReducer( [ 'happinessEngineers' ], reducer );

--- a/client/state/happiness-engineers/package.json
+++ b/client/state/happiness-engineers/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/happiness-engineers/reducer.js
+++ b/client/state/happiness-engineers/reducer.js
@@ -6,7 +6,12 @@ import { map } from 'lodash';
 /**
  * Internal dependencies
  */
-import { combineReducers, withSchemaValidation, withoutPersistence } from 'state/utils';
+import {
+	combineReducers,
+	withoutPersistence,
+	withSchemaValidation,
+	withStorageKey,
+} from 'state/utils';
 import { itemsSchema } from './schema';
 import {
 	HAPPINESS_ENGINEERS_FETCH,
@@ -56,7 +61,9 @@ export const items = withSchemaValidation( itemsSchema, ( state = null, action )
 	return state;
 } );
 
-export default combineReducers( {
+const combinedReducer = combineReducers( {
 	requesting,
 	items,
 } );
+
+export default withStorageKey( 'happinessEngineers', combinedReducer );

--- a/client/state/happiness-engineers/selectors.js
+++ b/client/state/happiness-engineers/selectors.js
@@ -1,11 +1,15 @@
 /**
+ * Internal dependencies
+ */
+import 'state/happiness-engineers/init';
+
+/**
  * Returns happiness engineers
  *
  *
  * @param {{}} state currents state
  * @returns {Array} happiness engineers
  */
-
 export function getHappinessEngineers( state ) {
 	return state.happinessEngineers.items;
 }

--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -27,7 +27,6 @@ import experiments from './experiments/reducer';
 import exporter from './exporter/reducers';
 import gsuiteUsers from './gsuite-users/reducer';
 import gutenbergOptInOut from './gutenberg-opt-in-out/reducer';
-import happinessEngineers from './happiness-engineers/reducer';
 import happychat from './happychat/reducer';
 import help from './help/reducer';
 import home from './home/reducer';
@@ -92,7 +91,6 @@ const reducers = {
 	exporter,
 	gsuiteUsers,
 	gutenbergOptInOut,
-	happinessEngineers,
 	happychat,
 	help,
 	home,


### PR DESCRIPTION
This PR is one of many working on modularising state in Calypso. This one handles happiness engineers state.

For more details on state modularisation, see the [modularised state documentation](https://github.com/Automattic/wp-calypso/blob/master/docs/modularized-state.md) and p4TIVU-9lM-p2.

Note: I added reviewers that GitHub suggested. Please feel free to ignore the review request or pull in someone else if you're not comfortable reviewing this PR. Thank you!

Fixes #42439.

#### Changes proposed in this Pull Request

* Modularise happiness engineers state

#### Testing instructions

* Install [Redux DevTools](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en).
* Open DevTools and switch to the Redux tab.
* Open `/read` on the live branch or your local copy of this branch.
* Click `State` on the top right to ensure you see all state, and not just the diff for the last action: 
![image](https://user-images.githubusercontent.com/409615/73774406-d3e87d80-477b-11ea-9f59-3e42cc00101f.png)
* Analyse the tree and note that there's no `happinessEngineers` key, even if you expand the list of keys. This indicates that the happiness engineers state hasn't been loaded yet.
* Click the hovering help icon on the bottom right corner of the page, and choose `More help` in the callout dialog.
* Verify that a `happinessEngineers` key is added with the happiness engineers state. This indicates that the happiness engineers state has now been loaded.
* Verify that happiness engineer avatars display correctly. This indicates that I didn't mess up.