### PR TITLE
Modularise Jetpack remote and product install state

### DIFF
--- a/client/state/jetpack-product-install/actions.js
+++ b/client/state/jetpack-product-install/actions.js
@@ -9,6 +9,7 @@ import {
 
 import 'state/data-layer/wpcom/jetpack-blogs/product-install';
 import 'state/data-layer/wpcom/jetpack-blogs/product-install-status';
+import 'state/jetpack-product-install/init';
 
 /**
  * Start the Jetpack product install process for that site.

--- a/client/state/jetpack-product-install/init.js
+++ b/client/state/jetpack-product-install/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'state/redux-store';
+import reducer from './reducer';
+
+registerReducer( [ 'jetpackProductInstall' ], reducer );

--- a/client/state/jetpack-product-install/package.json
+++ b/client/state/jetpack-product-install/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/jetpack-product-install/reducer.js
+++ b/client/state/jetpack-product-install/reducer.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import { JETPACK_PRODUCT_INSTALL_STATUS_RECEIVE } from 'state/action-types';
-import { keyedReducer } from 'state/utils';
+import { keyedReducer, withStorageKey } from 'state/utils';
 
 const reducer = keyedReducer( 'siteId', ( state = {}, { type, status } ) => {
 	switch ( type ) {
@@ -13,4 +13,4 @@ const reducer = keyedReducer( 'siteId', ( state = {}, { type, status } ) => {
 	}
 } );
 
-export default reducer;
+export default withStorageKey( 'jetpackProductInstall', reducer );

--- a/client/state/jetpack-remote-install/actions.js
+++ b/client/state/jetpack-remote-install/actions.js
@@ -8,6 +8,7 @@ import {
 } from 'state/action-types';
 
 import 'state/data-layer/wpcom/jetpack-install';
+import 'state/jetpack-remote-install/init';
 
 /**
  * Install the jetpack plugin on a remote .org site.

--- a/client/state/jetpack-remote-install/init.js
+++ b/client/state/jetpack-remote-install/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'state/redux-store';
+import reducer from './reducer';
+
+registerReducer( [ 'jetpackRemoteInstall' ], reducer );

--- a/client/state/jetpack-remote-install/package.json
+++ b/client/state/jetpack-remote-install/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/jetpack-remote-install/reducer.js
+++ b/client/state/jetpack-remote-install/reducer.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { combineReducers, keyedReducer } from 'state/utils';
+import { combineReducers, keyedReducer, withStorageKey } from 'state/utils';
 import {
 	JETPACK_REMOTE_INSTALL,
 	JETPACK_REMOTE_INSTALL_FAILURE,
@@ -46,8 +46,10 @@ export const errorMessageReducer = keyedReducer(
 	}
 );
 
-export default combineReducers( {
+const combinedReducer = combineReducers( {
 	errorCode: errorCodeReducer,
 	errorMessage: errorMessageReducer,
 	isComplete,
 } );
+
+export default withStorageKey( 'jetpackRemoteInstall', combinedReducer );

--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -35,8 +35,6 @@ import immediateLogin from './immediate-login/reducer';
 import importerNux from './importer-nux/reducer';
 import imports from './imports/reducer';
 import inlineSupportArticle from './inline-support-article/reducer';
-import jetpackProductInstall from './jetpack-product-install/reducer';
-import jetpackRemoteInstall from './jetpack-remote-install/reducer';
 import jetpackSync from './jetpack-sync/reducer';
 import jitm from './jitm/reducer';
 import media from './media/reducer';
@@ -90,8 +88,6 @@ const reducers = {
 	importerNux,
 	imports,
 	inlineSupportArticle,
-	jetpackProductInstall,
-	jetpackRemoteInstall,
 	jetpackSync,
 	jitm,
 	media,

--- a/client/state/selectors/get-jetpack-product-install-progress.js
+++ b/client/state/selectors/get-jetpack-product-install-progress.js
@@ -4,6 +4,11 @@
 import { get } from 'lodash';
 
 /**
+ * Internal dependencies
+ */
+import 'state/jetpack-product-install/init';
+
+/**
  * @param {object} state  Global app state.
  * @param {number} siteId ID of the site to get Jetpack product install status of.
  * @returns {?number} Jetpack product installation progress (0 to 100), `null` if not started or no info yet.

--- a/client/state/selectors/get-jetpack-product-install-status.js
+++ b/client/state/selectors/get-jetpack-product-install-status.js
@@ -4,6 +4,11 @@
 import { get } from 'lodash';
 
 /**
+ * Internal dependencies
+ */
+import 'state/jetpack-product-install/init';
+
+/**
  * @param {object} state  Global app state.
  * @param {number} siteId ID of the site to get Jetpack product install status of.
  * @returns {?object} An object containing the current Jetpack product install status.

--- a/client/state/selectors/get-jetpack-remote-install-error-code.js
+++ b/client/state/selectors/get-jetpack-remote-install-error-code.js
@@ -4,6 +4,11 @@
 import { get } from 'lodash';
 
 /**
+ * Internal dependencies
+ */
+import 'state/jetpack-remote-install/init';
+
+/**
  * Returns any error code that has resulted from requesting
  * a remote install of the jetpack plugin on the .org
  * site at the given url.

--- a/client/state/selectors/get-jetpack-remote-install-error-message.js
+++ b/client/state/selectors/get-jetpack-remote-install-error-message.js
@@ -4,6 +4,11 @@
 import { get } from 'lodash';
 
 /**
+ * Internal dependencies
+ */
+import 'state/jetpack-remote-install/init';
+
+/**
  * Returns any error message that has resulted from requesting
  * a remote install of the jetpack plugin on the .org
  * site at the given url.

--- a/client/state/selectors/is-jetpack-remote-install-complete.js
+++ b/client/state/selectors/is-jetpack-remote-install-complete.js
@@ -4,12 +4,17 @@
 import { get } from 'lodash';
 
 /**
+ * Internal dependencies
+ */
+import 'state/jetpack-remote-install/init';
+
+/**
  * Returns success status of an attempted remote install
  * of the jetpack plugin to the .org site at the given url.
  *
  * @param {object} state Global state tree
  * @param {string} url .org site URL
- * @returns {bool} True if installation and activation was successful
+ * @returns {boolean} True if installation and activation was successful
  */
 export default function isJetpackRemoteInstallComplete( state, url ) {
 	return !! get( state.jetpackRemoteInstall.isComplete, url, false );


### PR DESCRIPTION
This PR is one of many working on modularising state in Calypso. This one handles Jetpack remote install and Jetpack product install state.

For more details on state modularisation, see the [modularised state documentation](https://github.com/Automattic/wp-calypso/blob/master/docs/modularized-state.md) and p4TIVU-9lM-p2.

Note: I added reviewers that GitHub suggested. Please feel free to ignore the review request or pull in someone else if you're not comfortable reviewing this PR. Thank you!

Fixes #42451. Fixes #42452.

#### Changes proposed in this Pull Request

* Jetpack remote install and Jetpack product install state

#### Testing instructions

* Install [Redux DevTools](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en).
* Open DevTools and switch to the Redux tab.
* Open `/home` on the live branch or your local copy of this branch.
* Click `State` on the top right to ensure you see all state, and not just the diff for the last action: 
![image](https://user-images.githubusercontent.com/409615/73774406-d3e87d80-477b-11ea-9f59-3e42cc00101f.png)
* Analyse the tree and note that there's no `jetpackProductInstall` key, even if you expand the list of keys. This indicates that the Jetpack product install state hasn't been loaded yet.
* Click `Plan` on the sidebar.
* Verify that a `jetpackProductInstall` key is added with the Jetpack product install state (most likely empty). This indicates that the Jetpack product install state has now been loaded.
* Verify that Jetpack product install and Jetpack remote install work correctly in the Calypso Jetpack connection flows. This indicates that I didn't mess up.