### PR TITLE
Adds the Anti-Spam product on staging and horizon

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -58,6 +58,7 @@
 		"jetpack/features-section/atomic": true,
 		"jetpack/features-section/jetpack": true,
 		"jetpack/search-product": true,
+		"jetpack/anti-spam-product": true,
 		"jetpack/backups-restore": true,
 		"jetpack/on-demand-scan": true,
 		"jitms": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -58,7 +58,6 @@
 		"jetpack/features-section/atomic": true,
 		"jetpack/features-section/jetpack": true,
 		"jetpack/search-product": true,
-		"jetpack/anti-spam-product": true,
 		"jetpack/backups-restore": true,
 		"jetpack/on-demand-scan": true,
 		"jitms": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -66,6 +66,7 @@
 		"jetpack/scan-product": true,
 		"jetpack/search-product": true,
 		"jetpack/wpcom-search-product": true,
+		"jetpack/anti-spam-product": true,
 		"jetpack/on-demand-scan": true,
 		"jetpack/backups-restore": true,
 		"jitms": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -71,6 +71,7 @@
 		"jetpack/features-section/jetpack": true,
 		"jetpack/scan-product": true,
 		"jetpack/search-product": true,
+		"jetpack/anti-spam-product": true,
 		"jetpack/on-demand-scan": true,
 		"jetpack/backups-restore": true,
 		"jitms": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This enables the Jetpack Anti-Spam product on staging and horizon environments.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Either start stage/horizon or wait till the build of calypso.live finishes.
* Verify Jetpack Anti-Spam appears.

Fixes 1181531115069428-as-1184719508033177.
