### PR TITLE
ci(wp-desktop): trigger deployment with tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -849,74 +849,74 @@ jobs:
 
 workflows:
   version: 2
-#   calypso:
-#     jobs:
-#       - setup
-#       - prime-calypso-live:
-#           filters:
-#             branches:
-#               ignore: master
-#       - test-full-site-editing:
-#           requires:
-#             - setup
-#       - build-notifications:
-#           requires:
-#             - setup
-#       - build-o2-blocks:
-#           requires:
-#             - setup
-#       - build-wpcom-block-editor:
-#           requires:
-#             - setup
-#       - lint-and-translate:
-#           requires:
-#             - setup
-#       - test-client:
-#           requires:
-#             - setup
-#       - test-packages:
-#           requires:
-#             - setup
-#       - test-server:
-#           requires:
-#             - setup
-#       - typecheck-strict:
-#           requires:
-#             - setup
-#       - wait-calypso-live:
-#           requires:
-#             - test-client
-#             - test-server
-#           filters:
-#             branches:
-#               ignore:
-#                 # Do not spin up calypso.live for `master`
-#                 - master
-#                 # Do not spin up calypso.live for fork pull requests. Calypso.live will not build them.
-#                 - /pull\/[0-9]+/
-# #      - test-e2e-canary:
-# #          requires:
-# #            - wait-calypso-live
-# #          test-flags: '-C -S $CIRCLE_SHA1'
-#       - test-e2e-canary:
-#           name: test-e2e-canary-ie
-#           requires:
-#             - wait-calypso-live
-#           test-flags: '-z -S $CIRCLE_SHA1'
-#           test-target: 'IE11'
-#           slack-webhook: '$SLACK_IE'
-#       - test-e2e-canary:
-#           name: test-e2e-canary-safari
-#           requires:
-#             - wait-calypso-live
-#           test-flags: '-y -S $CIRCLE_SHA1'
-#       - test-e2e-canary:
-#           name: test-e2e-canary-woo
-#           requires:
-#             - wait-calypso-live
-#           test-flags: '-W -S $CIRCLE_SHA1'
-#           test-target: 'WOO'
-#           slack-webhook: '$SLACK_WOO'
+  calypso:
+    jobs:
+      - setup
+      - prime-calypso-live:
+          filters:
+            branches:
+              ignore: master
+      - test-full-site-editing:
+          requires:
+            - setup
+      - build-notifications:
+          requires:
+            - setup
+      - build-o2-blocks:
+          requires:
+            - setup
+      - build-wpcom-block-editor:
+          requires:
+            - setup
+      - lint-and-translate:
+          requires:
+            - setup
+      - test-client:
+          requires:
+            - setup
+      - test-packages:
+          requires:
+            - setup
+      - test-server:
+          requires:
+            - setup
+      - typecheck-strict:
+          requires:
+            - setup
+      - wait-calypso-live:
+          requires:
+            - test-client
+            - test-server
+          filters:
+            branches:
+              ignore:
+                # Do not spin up calypso.live for `master`
+                - master
+                # Do not spin up calypso.live for fork pull requests. Calypso.live will not build them.
+                - /pull\/[0-9]+/
+#      - test-e2e-canary:
+#          requires:
+#            - wait-calypso-live
+#          test-flags: '-C -S $CIRCLE_SHA1'
+      - test-e2e-canary:
+          name: test-e2e-canary-ie
+          requires:
+            - wait-calypso-live
+          test-flags: '-z -S $CIRCLE_SHA1'
+          test-target: 'IE11'
+          slack-webhook: '$SLACK_IE'
+      - test-e2e-canary:
+          name: test-e2e-canary-safari
+          requires:
+            - wait-calypso-live
+          test-flags: '-y -S $CIRCLE_SHA1'
+      - test-e2e-canary:
+          name: test-e2e-canary-woo
+          requires:
+            - wait-calypso-live
+          test-flags: '-W -S $CIRCLE_SHA1'
+          test-target: 'WOO'
+          slack-webhook: '$SLACK_WOO'
   wp-desktop:
     jobs:
       - wp-desktop-source
@@ -929,7 +929,6 @@ workflows:
       - wp-desktop-windows:
           requires:
             - wp-desktop-source
-
   wp-desktop-release:
     when: << pipeline.git.tag >>
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -756,8 +756,6 @@ jobs:
       name: win/default
     working_directory: C:\Users\circleci\wp-calypso
     environment:
-      CSC_LINK: C:\Users\circleci\wp-calypso\desktop\resource\certificates\win.p12
-      CSC_FOR_PULL_REQUEST: true
     steps:
       - checkout
       - attach_workspace:
@@ -777,22 +775,26 @@ jobs:
       - run:
           name: Install Desktop Dependencies
           command: yarn run build-desktop:install-app-deps
-      - run:
-          name: Import Codesigning Certificate
-          command: |
-                  # Workaround for Sign Tool "private key filter" bug in Circle's Windows image.
-                  # Ref: https://travis-ci.community/t/codesigning-on-windows/
-                  #
-                  # Fix: Import .p12 into the local certificate store. Sign Tool will use
-                  # package.json's `certificateSubjectName` to find the imported cert.
-                  Import-PfxCertificate -FilePath $env:CSC_LINK -CertStoreLocation Cert:\LocalMachine\Root -Password (ConvertTo-SecureString -String $env:WIN_CSC_KEY_PASSWORD -AsPlainText -Force)
+      - when:
+          condition: << pipeline.git.tag >>
+          steps:
+            - run:
+                name: Import Codesigning Certificate
+                command: |
+                        # Workaround for Sign Tool "private key filter" bug in Circle's Windows image.
+                        # Ref: https://travis-ci.community/t/codesigning-on-windows/
+                        #
+                        # Fix: Import .p12 into the local certificate store. Sign Tool will use
+                        # package.json's `certificateSubjectName` to find the imported cert.
+                        $env:CSC_LINK='C:\Users\circleci\wp-calypso\desktop\resource\certificates\win.p12'
+                        Import-PfxCertificate -FilePath $env:CSC_LINK -CertStoreLocation Cert:\LocalMachine\Root -Password (ConvertTo-SecureString -String $env:WIN_CSC_KEY_PASSWORD -AsPlainText -Force)
       - run:
           name: Build Desktop Windows
           command: |
                   # Use make for bash-like environment variable substitution
-                  # Note: cd into desktop as ELECTRON_BUILDER_ARGS will not resolve correctly if we use make -f syntax from repo root.
-                  cd desktop
-                  make package ELECTRON_BUILDER_ARGS='-c.win.certificateSubjectName="Automattic, Inc."'
+
+                  If ( $env:CIRCLE_TAG ) { $env:ELECTRON_BUILDER_ARGS='-c.win.certificateSubjectName=""Automattic, Inc.""' }
+                  make -f desktop/Makefile package ELECTRON_BUILDER_ARGS=$env:ELECTRON_BUILDER_ARGS
       - run:
           name: Archive Unpacked Directories
           command: |
@@ -815,76 +817,106 @@ jobs:
           paths:
             - desktop\release
 
+  wp-desktop-publish:
+    docker:
+      - image: circleci/golang:1.12
+    working_directory: /home/circleci/wp-calypso
+    environment:
+      VERSION: << pipeline.git.tag >>
+    steps:
+      - attach_workspace:
+          at: /home/circleci/wp-calypso
+      - run:
+          name: Install Dependencies
+          command: go get github.com/tcnksm/ghr
+      - run:
+          name: Publish Github Release
+          command: |
+            echo "Publishing draft release for wp-desktop $VERSION..."
+            NAME="WP-Desktop ${VERSION#?}"
+
+            ghr \
+              --token "${GH_TOKEN}" \
+              --username "${CIRCLE_PROJECT_USERNAME}" \
+              --repository "${CIRCLE_PROJECT_REPONAME}" \
+              --commitish "${CIRCLE_SHA1}" \
+              --name "${NAME}" \
+              --delete \
+              --draft \
+              "${VERSION}" desktop/release/
+
+            echo "Publish complete"
+
 workflows:
   version: 2
-  calypso:
-    jobs:
-      - setup
-      - prime-calypso-live:
-          filters:
-            branches:
-              ignore: master
-      - test-full-site-editing:
-          requires:
-            - setup
-      - build-notifications:
-          requires:
-            - setup
-      - build-o2-blocks:
-          requires:
-            - setup
-      - build-wpcom-block-editor:
-          requires:
-            - setup
-      - lint-and-translate:
-          requires:
-            - setup
-      - test-client:
-          requires:
-            - setup
-      - test-packages:
-          requires:
-            - setup
-      - test-server:
-          requires:
-            - setup
-      - typecheck-strict:
-          requires:
-            - setup
-      - wait-calypso-live:
-          requires:
-            - test-client
-            - test-server
-          filters:
-            branches:
-              ignore:
-                # Do not spin up calypso.live for `master`
-                - master
-                # Do not spin up calypso.live for fork pull requests. Calypso.live will not build them.
-                - /pull\/[0-9]+/
-#      - test-e2e-canary:
-#          requires:
-#            - wait-calypso-live
-#          test-flags: '-C -S $CIRCLE_SHA1'
-      - test-e2e-canary:
-          name: test-e2e-canary-ie
-          requires:
-            - wait-calypso-live
-          test-flags: '-z -S $CIRCLE_SHA1'
-          test-target: 'IE11'
-          slack-webhook: '$SLACK_IE'
-      - test-e2e-canary:
-          name: test-e2e-canary-safari
-          requires:
-            - wait-calypso-live
-          test-flags: '-y -S $CIRCLE_SHA1'
-      - test-e2e-canary:
-          name: test-e2e-canary-woo
-          requires:
-            - wait-calypso-live
-          test-flags: '-W -S $CIRCLE_SHA1'
-          test-target: 'WOO'
-          slack-webhook: '$SLACK_WOO'
+#   calypso:
+#     jobs:
+#       - setup
+#       - prime-calypso-live:
+#           filters:
+#             branches:
+#               ignore: master
+#       - test-full-site-editing:
+#           requires:
+#             - setup
+#       - build-notifications:
+#           requires:
+#             - setup
+#       - build-o2-blocks:
+#           requires:
+#             - setup
+#       - build-wpcom-block-editor:
+#           requires:
+#             - setup
+#       - lint-and-translate:
+#           requires:
+#             - setup
+#       - test-client:
+#           requires:
+#             - setup
+#       - test-packages:
+#           requires:
+#             - setup
+#       - test-server:
+#           requires:
+#             - setup
+#       - typecheck-strict:
+#           requires:
+#             - setup
+#       - wait-calypso-live:
+#           requires:
+#             - test-client
+#             - test-server
+#           filters:
+#             branches:
+#               ignore:
+#                 # Do not spin up calypso.live for `master`
+#                 - master
+#                 # Do not spin up calypso.live for fork pull requests. Calypso.live will not build them.
+#                 - /pull\/[0-9]+/
+# #      - test-e2e-canary:
+# #          requires:
+# #            - wait-calypso-live
+# #          test-flags: '-C -S $CIRCLE_SHA1'
+#       - test-e2e-canary:
+#           name: test-e2e-canary-ie
+#           requires:
+#             - wait-calypso-live
+#           test-flags: '-z -S $CIRCLE_SHA1'
+#           test-target: 'IE11'
+#           slack-webhook: '$SLACK_IE'
+#       - test-e2e-canary:
+#           name: test-e2e-canary-safari
+#           requires:
+#             - wait-calypso-live
+#           test-flags: '-y -S $CIRCLE_SHA1'
+#       - test-e2e-canary:
+#           name: test-e2e-canary-woo
+#           requires:
+#             - wait-calypso-live
+#           test-flags: '-W -S $CIRCLE_SHA1'
+#           test-target: 'WOO'
+#           slack-webhook: '$SLACK_WOO'
   wp-desktop:
     jobs:
       - wp-desktop-source
@@ -897,6 +929,40 @@ workflows:
       - wp-desktop-windows:
           requires:
             - wp-desktop-source
+
+  wp-desktop-release:
+    when: << pipeline.git.tag >>
+    jobs:
+      - wp-desktop-source:
+          filters:
+            tags:
+              only: /.*/
+      - wp-desktop-mac:
+          requires:
+            - wp-desktop-source
+          filters:
+            tags:
+              only: /.*/
+      - wp-desktop-linux:
+          requires:
+            - wp-desktop-source
+          filters:
+            tags:
+              only: /.*/
+      - wp-desktop-windows:
+          requires:
+            - wp-desktop-source
+          filters:
+            tags:
+              only: /.*/
+      - wp-desktop-publish:
+          requires:
+            - wp-desktop-mac
+            - wp-desktop-linux
+            - wp-desktop-windows
+          filters:
+            tags:
+              only: /.*/
 
   calypso-nightly:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -935,25 +935,25 @@ workflows:
       - wp-desktop-source:
           filters:
             tags:
-              only: /.*/
+              only: /v.*/
       - wp-desktop-mac:
           requires:
             - wp-desktop-source
           filters:
             tags:
-              only: /.*/
+              only: /v.*/
       - wp-desktop-linux:
           requires:
             - wp-desktop-source
           filters:
             tags:
-              only: /.*/
+              only: /v.*/
       - wp-desktop-windows:
           requires:
             - wp-desktop-source
           filters:
             tags:
-              only: /.*/
+              only: /v.*/
       - wp-desktop-publish:
           requires:
             - wp-desktop-mac
@@ -961,7 +961,7 @@ workflows:
             - wp-desktop-windows
           filters:
             tags:
-              only: /.*/
+              only: /v.*/
 
   calypso-nightly:
     jobs:

--- a/client/desktop/lib/config/index.js
+++ b/client/desktop/lib/config/index.js
@@ -1,4 +1,4 @@
-const pkg = require( '../../../package.json' );
+const pkg = require( '../../../../desktop/package.json' );
 const config = require( '../../config.json' );
 
 // Merge in some details from package.json

--- a/desktop/Makefile
+++ b/desktop/Makefile
@@ -51,7 +51,7 @@ package: PACKAGE_ELECTRON_VERSION = $(shell cd $(DESKTOP_DIR) && node -e "consol
 package:
 	$(info Packaging app...)
 
-	@npx electron-builder ${ELECTRON_BUILDER_ARGS} -c.electronVersion=$(PACKAGE_ELECTRON_VERSION) build --publish never
+	@cd $(DESKTOP_DIR) && npx electron-builder ${ELECTRON_BUILDER_ARGS} -c.electronVersion=$(PACKAGE_ELECTRON_VERSION) build --publish never
 
 e2e:
 	$(info Running end-to-end tests...)

--- a/desktop/bin/after_sign_hook.js
+++ b/desktop/bin/after_sign_hook.js
@@ -4,11 +4,13 @@ const path = require( 'path' );
 const { notarize } = require( 'electron-notarize' );
 
 const APP_ID = 'com.automattic.wordpress';
-const NOTARIZATION_ASC_PROVIDER = 'AutomatticInc';
-const NOTARIZATION_ID = process.env.NOTARIZATION_ID;
-const NOTARIZATION_PWD = process.env.NOTARIZATION_PWD;
+const NOTARIZATION_ID = process.env.WPDESKTOP_NOTARIZATION_ID;
+const NOTARIZATION_PWD = process.env.WPDESKTOP_NOTARIZATION_PWD;
+const NOTARIZATION_ASC_PROVIDER = process.env.APPLE_DEVELOPER_SHORT_NAME;
 
-const shouldNotarize = process.platform === 'darwin' && !! process.env.CIRCLE_TAG;
+const circleTag = process.env.CIRCLE_TAG;
+const shouldNotarize =
+	process.platform === 'darwin' && !! circleTag && circleTag.startsWith( 'desktop' );
 
 function elapsed( start ) {
 	const now = new Date();

--- a/desktop/bin/after_sign_hook.js
+++ b/desktop/bin/after_sign_hook.js
@@ -9,7 +9,7 @@ const NOTARIZATION_PWD = process.env.WPDESKTOP_NOTARIZATION_PWD;
 const NOTARIZATION_ASC_PROVIDER = process.env.APPLE_DEVELOPER_SHORT_NAME;
 
 const circleTag = process.env.CIRCLE_TAG;
-const shouldNotarize = process.platform === 'darwin' && !! circleTag;
+const shouldNotarize = process.platform === 'darwin' && !! circleTag && circleTag.startsWith( 'v' );
 
 function elapsed( start ) {
 	const now = new Date();

--- a/desktop/bin/after_sign_hook.js
+++ b/desktop/bin/after_sign_hook.js
@@ -9,8 +9,7 @@ const NOTARIZATION_PWD = process.env.WPDESKTOP_NOTARIZATION_PWD;
 const NOTARIZATION_ASC_PROVIDER = process.env.APPLE_DEVELOPER_SHORT_NAME;
 
 const circleTag = process.env.CIRCLE_TAG;
-const shouldNotarize =
-	process.platform === 'darwin' && !! circleTag && circleTag.startsWith( 'desktop' );
+const shouldNotarize = process.platform === 'darwin' && !! circleTag;
 
 function elapsed( start ) {
 	const now = new Date();
@@ -30,7 +29,7 @@ module.exports = async function ( context ) {
 	const appName = path.basename( app );
 
 	const start = new Date();
-	console.log( `  • notarizing ${ appName }...` );
+	console.log( `  • notarizing ${ appName }...` ); // eslint-disable-line no-console
 	await notarize( {
 		appBundleId: APP_ID,
 		appPath: app,
@@ -38,5 +37,5 @@ module.exports = async function ( context ) {
 		appleIdPassword: NOTARIZATION_PWD,
 		ascProvider: NOTARIZATION_ASC_PROVIDER,
 	} );
-	console.log( `  • done notarizing ${ appName }, took ${ elapsed( start ) }` );
+	console.log( `  • done notarizing ${ appName }, took ${ elapsed( start ) }` ); // eslint-disable-line no-console
 };

--- a/desktop/desktop-config/config-development.json
+++ b/desktop/desktop-config/config-development.json
@@ -6,7 +6,7 @@
 	"server_host": "calypso.localhost",
 	"updater": {
 		"downloadUrl": "https://apps.wordpress.com/desktop/",
-		"apiUrl": "https://api.github.com/repos/Automattic/wp-desktop/releases",
+		"apiUrl": "https://api.github.com/repos/Automattic/wp-calypso/releases",
 		"delay": 2000,
 		"interval": 600000
 	},

--- a/desktop/desktop-config/config-release.json
+++ b/desktop/desktop-config/config-release.json
@@ -2,7 +2,7 @@
 	"build": "release",
 	"updater": {
 		"downloadUrl": "https://apps.wordpress.com/desktop/",
-		"apiUrl": "https://api.github.com/repos/Automattic/wp-desktop/releases",
+		"apiUrl": "https://api.github.com/repos/Automattic/wp-calypso/releases",
 		"delay": 2000,
 		"interval": 43200000
 	}

--- a/desktop/desktop-config/config-updater.json
+++ b/desktop/desktop-config/config-updater.json
@@ -7,8 +7,8 @@
 		"colors": true
 	},
 	"updater": {
-		"downloadUrl": "https://github.com/Automattic/wp-desktop/releases",
-		"apiUrl": "https://api.github.com/repos/Automattic/wp-desktop/releases",
+		"downloadUrl": "https://github.com/Automattic/wp-calypso/releases",
+		"apiUrl": "https://api.github.com/repos/Automattic/wp-calypso/releases",
 		"delay": 2000,
 		"interval": 600000
 	}

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,9 +1,9 @@
 {
 	"name": "WordPressDesktop",
-	"version": "5.2.0",
+	"version": "9.9.9",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/Automattic/wp-desktop/"
+		"url": "https://github.com/Automattic/wp-calypso/"
 	},
 	"license": "GPLv2",
 	"private": true,

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "WordPressDesktop",
-	"version": "9.9.9",
+	"version": "5.2.0",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/Automattic/wp-calypso/"


### PR DESCRIPTION
### Description

This PR adds tag-triggered deployment for wp-desktop. Similar to the wp-desktop repo today, deployment is triggered by tagging a commit and pushing the tag to origin. The logic is largely copied over from existing wp-desktop Circle config which you can compare [here](https://github.com/Automattic/wp-desktop/blob/03f69ace2c945cd1c20afbc6e3a2fb477f94412a/.circleci/config.yml#L570-L607).

- Tagged builds will trigger MacOS notarization (now using a centralized `WP Desktop` Apple Developer account instead of personal credentials).
- Builds on all platforms build and run successfully, and I was able to confirm that the app will auto-update to a published release in the Calypso repository.

A separate PR in the wp-desktop repo will point the auto-updater of a final wp-desktop build to this repo in order to switch users overs, at which point we will sunset the wp-desktop repository.

### Notes on Tagging

For the time being, we will continue to use tags formatted like `v1.2.3` at the repository level. Initial attempts were made to get tags like `desktop/1.2.3` to work, but unfortunately electron-updater is **very** strict about the format of tags used to manage the project, as it has some deep internal logic that resolves updates based off this strict assumption.

Repository-level tags have not been utilized for a while and I've gotten the OK from @griffbrad to use semver tags at the repo-level in the meanwhile. Longer-term, we'll want to explore other options such as setting up a mirror repository or a custom release server (such as those mentioned [here](https://www.electronjs.org/docs/tutorial/updates#deploying-an-update-server)) that we can point the client to instead.

### Additional Refinements

Circle's Windows implementation has a few bugs that lead to intermittent code signing failures. To minimize this, we code sign Windows builds only when the release is tagged.

 - With Windows code signing (on tag): [link](https://app.circleci.com/pipelines/github/Automattic/wp-calypso/67613/workflows/d95ec3ea-dadb-4eff-aebc-d9127e43d6a8)
- Without Windows code signing (BAU without tag): [link](https://app.circleci.com/pipelines/github/Automattic/wp-calypso/67618/workflows/885d1ffb-8052-46e1-bb8f-4dba3332d356)

Also some minor refinements to the `make package` instruction of the Makefile (necessary for Windows jobs).