### PR TITLE
Jetpack Anti-Spam: fix broken Thank You modal in Safari

### DIFF
--- a/client/my-sites/plans/current-plan/current-plan-thank-you/style.scss
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you/style.scss
@@ -1,6 +1,7 @@
 .current-plan-thank-you {
 	display: flex;
 	flex-direction: row;
+	align-items: center;
 	max-width: 720px;
 
 	@include breakpoint-deprecated( '>800px' ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* In Safari, the Thank You modal is broken because the image takes the whole height of the screen. This PR fixes this by setting, in the parent component, the `align-items` CSS prop to `center`. This bug is affecting the Jetpack Search Thank You modal as well.

#### Testing instructions

* Run this PR and open **Safari**.
* Visit `http://calypso.localhost:3000/plans/my-plan/[site]?thank-you=&product=jetpack_anti_spam`.
* Verify that the modal looks fine.
* Visit `http://calypso.localhost:3000/plans/my-plan/[site]?thank-you=&product=jetpack_search`.
* Verify that the modal looks fine.

Fixes #

#### Demo
##### Before
![image](https://user-images.githubusercontent.com/3418513/87829074-a2a8c900-c854-11ea-8a2b-774719f71534.png)

##### After
![image](https://user-images.githubusercontent.com/3418513/87829059-991f6100-c854-11ea-8eee-1e06ed30bcda.png)
