### PR TITLE
Home: track card impressions and relax dismissable-card schema validation

### DIFF
--- a/client/state/preferences/schema.js
+++ b/client/state/preferences/schema.js
@@ -2,7 +2,7 @@ export const remoteValuesSchema = {
 	type: [ 'null', 'object' ],
 	patternProperties: {
 		'^dismissible-card-.+$': {
-			type: 'boolean',
+			type: [ 'boolean', 'object' ],
 		},
 	},
 	properties: {


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/43767 and https://github.com/Automattic/wp-calypso/issues/43984

This PR adds handling to automatically track home card impressions in primary, secondary and tertiary locations

<img width="1750" alt="Screen Shot 2020-07-17 at 3 58 17 PM" src="https://user-images.githubusercontent.com/1270189/87837289-d6c9bd00-c847-11ea-9fb6-8f8a5e55924c.png">

I also relaxed schema validation for preferences. Previously we were throwing out persisted state in indexedDB, because home task cards were storing objects instead of the expected boolean value.

<img width="1274" alt="Screen Shot 2020-07-17 at 4 07 03 PM" src="https://user-images.githubusercontent.com/1270189/87837342-0b3d7900-c848-11ea-91dd-cb7391256aab.png">

### Testing Instructions
- Spin up this branch
- Visit calypso.localhost:3000/home
- In devtools set `localStorage.debug = 'calypso:analytics*';` in console
- Refresh home
- We should see the following card tracking events.
- Try completing or dismissing task cards. We should see additional impression events.
- We should see no warnings about schema validation errors for preferences persistence
- Navigating between My Sites/Reader does not cause a WSOD
