### PR TITLE
Checkout: update credit card label based on existing cards

### DIFF
--- a/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
@@ -21,6 +21,7 @@ import Button from '../../components/button';
 import PaymentLogo from './payment-logo';
 import { showStripeModalAuth } from '../stripe';
 import {
+	useAllPaymentMethods,
 	usePaymentProcessor,
 	useTransactionStatus,
 	useMessages,
@@ -527,9 +528,16 @@ function isCreditCardFormValid( store, __ ) {
 
 function CreditCardLabel() {
 	const { __ } = useI18n();
+	const allPaymentMethods = useAllPaymentMethods();
+	const hasExistingCard = allPaymentMethods.filter( ( paymentMethod ) =>
+		paymentMethod.id.startsWith( 'existingCard-' )
+	);
+	const labelText = hasExistingCard
+		? __( 'Use a New Credit/Debit Card' )
+		: __( 'Credit or debit card' );
 	return (
 		<React.Fragment>
-			<span>{ __( 'Credit or debit card' ) }</span>
+			<span>{ labelText }</span>
 			<CreditCardLogos />
 		</React.Fragment>
 	);


### PR DESCRIPTION
This updates the label for the new credit card payment method, based on whether or not the user has an existing stored card. Without a stored card, the payment method is labeled "Credit or debit card" and with a stored card, it is labeled "Use a New Credit/Debit Card" (re-using the string from legacy checkout).