### PR TITLE
Checkout: fix contact field and validation styles

### DIFF
--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-contact-form.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-contact-form.js
@@ -82,6 +82,18 @@ export default function WPContactForm( {
 
 const BillingFormFields = styled.div`
 	margin-bottom: 16px;
+
+	.form-input-validation {
+		padding: 6px 6px 11px;
+	}
+
+	.form-input-validation .gridicon {
+		float: none;
+		margin-left: 0;
+		width: 18px;
+		vertical-align: text-top;
+		height: 18px;
+	}
 `;
 
 const FormField = styled( Field )`

--- a/client/my-sites/domains/components/form/state-select.jsx
+++ b/client/my-sites/domains/components/form/state-select.jsx
@@ -77,7 +77,7 @@ class StateSelect extends PureComponent {
 		const validationId = `validation-field-${ this.props.name }`;
 
 		return (
-			<div>
+			<>
 				{ countryCode && <QueryCountryStates countryCode={ countryCode } /> }
 				{ isEmpty( countryStates ) ? (
 					<Input inputRef={ this.inputRef } { ...this.props } />
@@ -113,7 +113,7 @@ class StateSelect extends PureComponent {
 						) }
 					</div>
 				) }
-			</div>
+			</>
 		);
 	}
 }


### PR DESCRIPTION
This fixes the styles for the city, state, and zip code fields when they're all on the same row on non-mobile devices.

**Currently:**
<img width="507" alt="Screen Shot 2020-07-19 at 7 17 09 PM" src="https://user-images.githubusercontent.com/942359/87887597-a5422480-c9f4-11ea-81b1-f64a414fb3c5.png">

This is partly due to an extra wrapper div in the return of the state field component, which prevents the flex styles from being applied properly. Additionally, the validation errors for those fields can be pretty illegible due to their widths, so this adjusts them to bring the icon inline and reduce the left/right padding:

**Before:** | **After:**
------------ | -------------
<img width="568" alt="Screen Shot 2020-07-19 at 7 13 30 PM" src="https://user-images.githubusercontent.com/942359/87887660-14b81400-c9f5-11ea-8da7-d79015767dbe.png"> | <img width="565" alt="Screen Shot 2020-07-19 at 7 12 18 PM" src="https://user-images.githubusercontent.com/942359/87887670-1da8e580-c9f5-11ea-9b22-918c0604ba43.png">

**To test:**
- visit checkout on a non-mobile device with a domain in your cart
- in the contact details, make sure that your country is set to "United States"
- verify that the field widths are equal
- try to submit invalid data
- verify that the validation errors are more legible
