### PR TITLE
Ensure spacers are visually similar in read to the main site 

### DIFF
--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -54,6 +54,11 @@
 		background: transparent;
 	}
 
+	.wp-block-spacer {
+		height: 20px;
+		clear: both;
+	}
+
 	aside {
 		margin: 0;
 		border: none;


### PR DESCRIPTION
https://github.com/Automattic/wp-calypso/issues/43595#issue-644080561

#### Changes proposed in this Pull Request

This resolves the visual differences with the "spacers" in reader as requested in https://github.com/Automattic/wp-calypso/issues/43595

#### Testing instructions

Visit: http://calypso.localhost:3000/read/blogs/159889361/posts/1028

**Before:**
<img width="1366" alt="Screenshot 2020-07-20 16 15 28" src="https://user-images.githubusercontent.com/570876/87899105-3e7c4400-caa4-11ea-9d8d-0de5009209f4.png">

**After:**
<img width="1325" alt="Screenshot 2020-07-20 16 16 16" src="https://user-images.githubusercontent.com/570876/87899143-5d7ad600-caa4-11ea-82be-e56e3c50f4da.png">


Fixes #
