### PR TITLE
Reader: ensure Gutenberg tables are visually similar to the original site

### DIFF
--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -276,6 +276,11 @@
 		line-height: 1.8;
 	}
 
+	.wp-block-table th {
+		font-weight: bold;
+		background: var( --color-neutral-0 );
+	}
+
 	.wp-block-button__link,
 	.wp-block-button__link:hover {
 		color: inherit;

--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -265,6 +265,17 @@
 		border-color: var( --color-neutral-10 );
 	}
 
+	.wp-block-table table {
+		border-collapse: collapse;
+	}
+
+	.wp-block-table td,
+	.wp-block-table th {
+		border: 1px solid #767676;
+		font-size: 1em;
+		line-height: 1.8;
+	}
+
 	.wp-block-button__link,
 	.wp-block-button__link:hover {
 		color: inherit;

--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -271,7 +271,7 @@
 
 	.wp-block-table td,
 	.wp-block-table th {
-		border: 1px solid #767676;
+		border: 1px solid var( --color-neutral-10 );
 		font-size: 1em;
 		line-height: 1.8;
 	}


### PR DESCRIPTION
Part of #43595.

#### Changes proposed in this Pull Request

This resolves the visual differences with the tables in reader as requested in #43595

#### Testing instructions

http://calypso.localhost:3000/read/blogs/165243437/posts/1717

**Before**
![Screenshot 2020-07-20 17 02 48](https://user-images.githubusercontent.com/570876/87902853-be0f1080-caae-11ea-999c-9c776347423d.png)

**After**

<img width="1410" alt="Screenshot 2020-07-22 14 49 29" src="https://user-images.githubusercontent.com/570876/88128694-9b096b80-cc2a-11ea-840e-855870ad5c70.png">


