### PR TITLE
Gutenboarding: Add launch sidebar

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/common/data-stores/launch/actions.ts
+++ b/apps/full-site-editing/full-site-editing-plugin/common/data-stores/launch/actions.ts
@@ -8,6 +8,22 @@ import { dispatch, select } from '@wordpress/data-controls';
  * Internal dependencies
  */
 import { SITE_ID, SITE_STORE, PLANS_STORE } from './constants';
+import type { LaunchStepType } from './types';
+
+export const setStep = ( step: LaunchStepType ) => ( {
+	type: 'SET_STEP' as const,
+	step,
+} );
+
+export const setStepComplete = ( step: LaunchStepType ) => ( {
+	type: 'SET_STEP_COMPLETE' as const,
+	step,
+} );
+
+export const setStepIncomplete = ( step: LaunchStepType ) => ( {
+	type: 'SET_STEP_INCOMPLETE' as const,
+	step,
+} );
 
 export const setDomain = ( domain: DomainSuggestions.DomainSuggestion ) => ( {
 	type: 'SET_DOMAIN' as const,
@@ -43,5 +59,11 @@ export function* launchSite() {
 }
 
 export type LaunchAction = ReturnType<
-	typeof setDomain | typeof unsetDomain | typeof setDomainSearch | typeof setPlan
+	| typeof unsetDomain
+	| typeof setStep
+	| typeof setStepComplete
+	| typeof setStepIncomplete
+	| typeof setDomain
+	| typeof setDomainSearch
+	| typeof setPlan
 >;

--- a/apps/full-site-editing/full-site-editing-plugin/common/data-stores/launch/data.ts
+++ b/apps/full-site-editing/full-site-editing-plugin/common/data-stores/launch/data.ts
@@ -1,0 +1,13 @@
+export const LaunchStep = {
+	Name: 'name',
+	Domain: 'domain',
+	Plan: 'plan',
+	Final: 'final',
+};
+
+export const LaunchSequence = [
+	LaunchStep.Name,
+	LaunchStep.Domain,
+	LaunchStep.Plan,
+	LaunchStep.Final,
+];

--- a/apps/full-site-editing/full-site-editing-plugin/common/data-stores/launch/reducer.ts
+++ b/apps/full-site-editing/full-site-editing-plugin/common/data-stores/launch/reducer.ts
@@ -8,7 +8,26 @@ import type { DomainSuggestions, Plans } from '@automattic/data-stores';
 /**
  * Internal dependencies
  */
+import { LaunchStep } from './data';
+import type { LaunchStepType } from './types';
 import type { LaunchAction } from './actions';
+
+const step: Reducer< LaunchStepType, LaunchAction > = ( state = LaunchStep.Name, action ) => {
+	if ( action.type === 'SET_STEP' ) {
+		return action.step;
+	}
+	return state;
+};
+
+const completedSteps: Reducer< LaunchStepType[], LaunchAction > = ( state = [], action ) => {
+	if ( action.type === 'SET_STEP_COMPLETE' ) {
+		return [ ...state, action.step ];
+	}
+	if ( action.type === 'SET_STEP_INCOMPLETE' ) {
+		return state.filter( ( completedStep ) => completedStep !== action.step );
+	}
+	return state;
+};
 
 const domain: Reducer< DomainSuggestions.DomainSuggestion | undefined, LaunchAction > = (
 	state,
@@ -38,6 +57,8 @@ const plan: Reducer< Plans.Plan | undefined, LaunchAction > = ( state, action ) 
 };
 
 const reducer = combineReducers( {
+	step,
+	completedSteps,
 	domain,
 	domainSearch,
 	plan,

--- a/apps/full-site-editing/full-site-editing-plugin/common/data-stores/launch/types.ts
+++ b/apps/full-site-editing/full-site-editing-plugin/common/data-stores/launch/types.ts
@@ -1,0 +1,11 @@
+/**
+ * External dependencies
+ */
+import type { ValuesType } from 'utility-types';
+
+/**
+ * Internal dependencies
+ */
+import { LaunchStep } from './data';
+
+export type LaunchStepType = ValuesType< typeof LaunchStep >;

--- a/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-menu/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-menu/index.tsx
@@ -1,0 +1,48 @@
+/**
+ * External dependencies
+ */
+import * as React from 'react';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+
+import { LAUNCH_STORE } from '../stores';
+import { LaunchStep, LaunchSequence } from '../../../common/data-stores/launch/data';
+import LaunchMenuItem from './item';
+import './styles.scss';
+
+const LaunchStepMenuItemTitles = {
+	[ LaunchStep.Name ]: __( 'Name your site', 'full-site-editing' ),
+	[ LaunchStep.Domain ]: __( 'Select a domain', 'full-site-editing' ),
+	[ LaunchStep.Plan ]: __( 'Select a plan', 'full-site-editing' ),
+	[ LaunchStep.Final ]: __( 'Launch your site', 'full-site-editing' ),
+};
+
+const LaunchMenu = () => {
+	const { step: currentStep, completedSteps } = useSelect( ( select ) =>
+		select( LAUNCH_STORE ).getState()
+	);
+
+	const { setStep } = useDispatch( LAUNCH_STORE );
+
+	return (
+		<div className="nux-launch-menu">
+			<h4>{ __( 'Site Launch Steps', 'full-site-editing' ) }</h4>
+			<div className="nux-launch-menu__item-group">
+				{ LaunchSequence.map( ( step ) => (
+					<LaunchMenuItem
+						title={ LaunchStepMenuItemTitles[ step ] }
+						isCompleted={ completedSteps.includes( step ) }
+						isCurrent={ step === currentStep }
+						onClick={ () => setStep( step ) }
+					/>
+				) ) }
+			</div>
+		</div>
+	);
+};
+
+export default LaunchMenu;

--- a/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-menu/item.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-menu/item.tsx
@@ -1,0 +1,48 @@
+/**
+ * External dependencies
+ */
+import * as React from 'react';
+import { __ } from '@wordpress/i18n';
+import { Button, SVG, Circle } from '@wordpress/components';
+import { Icon, check } from '@wordpress/icons';
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+
+const circle = (
+	<SVG viewBox="0 0 24 24">
+		<Circle cx="12" cy="12" r="5" />
+	</SVG>
+);
+
+interface Props {
+	title: string;
+	isCompleted?: boolean;
+	isCurrent: boolean;
+	onClick: () => void;
+}
+
+const LaunchMenuItem: React.FunctionComponent< Props > = ( {
+	title,
+	isCompleted,
+	isCurrent,
+	onClick,
+} ) => {
+	return (
+		<Button
+			className={ classnames( 'nux-launch-menu__item', {
+				'is-current': isCurrent,
+				'is-completed': isCompleted,
+			} ) }
+			onClick={ onClick }
+			isLink
+		>
+			<Icon icon={ isCompleted ? check : circle } size={ 16 } />
+			<span>{ title }</span>
+		</Button>
+	);
+};
+
+export default LaunchMenuItem;

--- a/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-menu/styles.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-menu/styles.scss
@@ -1,0 +1,56 @@
+@import '~@automattic/onboarding/styles/mixins';
+
+.nux-launch-menu {
+	h4 {
+		text-transform: uppercase;
+		margin: 50px 0 20px;
+	}
+}
+
+.nux-launch-menu__item-group {
+	margin: 0 -12px;
+}
+
+.nux-launch-menu__item.components-button.is-link {
+	@include onboarding-medium-text;
+	display: flex;
+	color: var( --studio-gray-30 );
+	width: 100%;
+	text-align: left;
+	text-decoration: none;
+	padding: 20px 14px;
+
+	&:hover {
+		color: initial;
+	}
+
+	&:focus {
+		box-shadow: none;
+	}
+
+	svg {
+		margin-right: 10px;
+		color: var( --studio-gray-10 );
+		// cosmetic alignment
+		position: relative;
+		top: 1px;
+		left: -1px;
+	}
+
+	&.is-current {
+		background: var( --studio-blue-0 );
+		color: initial;
+
+		svg {
+			color: initial;
+		}
+	}
+
+	&.is-completed {
+		svg {
+			color: var( --studio-green-40 );
+			top: 0;
+			left: 0;
+		}
+	}
+}

--- a/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-modal/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-modal/index.tsx
@@ -2,9 +2,11 @@
  * External dependencies
  */
 import * as React from 'react';
+import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { Modal, Button } from '@wordpress/components';
 import { Icon, wordpress, close } from '@wordpress/icons';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -14,45 +16,49 @@ import './styles.scss';
 /**
  * Internal dependencies
  */
-import Launch, { LaunchStepType } from '../launch';
+import { LAUNCH_STORE } from '../stores';
+import Launch from '../launch';
+import LaunchSidebar from '../launch-sidebar';
 
 interface Props {
 	onClose?: () => void;
 	onSubmit?: () => void;
-	step?: LaunchStepType;
 	isLaunching?: boolean;
 }
 
-const LaunchModal: React.FunctionComponent< Props > = ( {
-	onClose,
-	onSubmit,
-	step,
-	isLaunching,
-} ) => (
-	<Modal
-		className="nux-launch-modal"
-		overlayClassName="nux-launch-modal-overlay"
-		bodyOpenClassName="has-nux-launch-modal"
-		onRequestClose={ () => onClose?.() }
-		title=""
-	>
-		<div className="nux-launch-modal-header">
-			<div className="nux-launch-modal-header__wp-logo">
-				<Icon icon={ wordpress } size={ 36 } />
-			</div>
+const LaunchModal: React.FunctionComponent< Props > = ( { onClose, onSubmit, isLaunching } ) => {
+	const { step: currentStep } = useSelect( ( select ) => select( LAUNCH_STORE ).getState() );
 
+	return (
+		<Modal
+			className={ classnames( 'nux-launch-modal', `step-${ currentStep }` ) }
+			overlayClassName="nux-launch-modal-overlay"
+			bodyOpenClassName="has-nux-launch-modal"
+			onRequestClose={ () => onClose?.() }
+			title=""
+		>
+			<div className="nux-launch-modal-header">
+				<div className="nux-launch-modal-header__wp-logo">
+					<Icon icon={ wordpress } size={ 36 } />
+				</div>
+			</div>
+			<div className="nux-launch-modal-body">
+				{ isLaunching ? 'launch animation' : <Launch onSubmit={ onSubmit }></Launch> }
+			</div>
+			<div className="nux-launch-modal-aside">
+				<LaunchSidebar></LaunchSidebar>
+			</div>
 			<Button
 				isLink
-				className="nux-launch-modal-header__close-button"
+				className="nux-launch-modal__close-button"
 				onClick={ onClose }
 				aria-label={ __( 'Close dialog', 'full-site-editing' ) }
 				disabled={ ! onClose }
 			>
 				<Icon icon={ close } size={ 24 } />
 			</Button>
-		</div>
-		{ isLaunching ? 'launch animation' : <Launch step={ step } onSubmit={ onSubmit }></Launch> }
-	</Modal>
-);
+		</Modal>
+	);
+};
 
 export default LaunchModal;

--- a/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-modal/styles.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-modal/styles.scss
@@ -2,6 +2,12 @@
 @import '~@wordpress/base-styles/variables';
 @import '~@wordpress/base-styles/z-index';
 
+body.has-nux-launch-modal {
+	// Prevent jumpyness when switching between
+	// long & short launch step content.
+	overflow-y: scroll;
+}
+
 .nux-launch-modal-overlay {
 	&.components-modal__screen-overlay {
 		background: none;
@@ -23,6 +29,8 @@
 		border: none;
 		box-shadow: none;
 		position: absolute;
+		overflow: hidden;
+		background: transparent;
 	}
 
 	.components-modal__header {
@@ -30,19 +38,18 @@
 	}
 
 	.components-modal__content {
+		display: flex;
 		padding: 0;
+		overflow: auto;
 	}
 }
 
-// This mimics WP's modal header.
 .nux-launch-modal-header {
-	position: sticky;
+	position: fixed;
 	top: 0;
 	z-index: z-index( '.components-modal__header' );
+	width: 100%;
 	height: $header-height;
-	border-bottom: 1px solid var( --studio-gray-5 );
-	padding: 24px;
-	margin: 0 -24px 24px;
 	display: flex;
 	flex-direction: row;
 	align-items: center;
@@ -58,7 +65,30 @@
 	height: 60px;
 }
 
-.nux-launch-modal-header__close-button.components-button.is-link {
+.nux-launch-modal-body {
+	flex-grow: 1;
+	padding-top: $header-height;
+	background: var( --studio-white );
+}
+
+.nux-launch-modal-aside {
+	position: sticky;
+	width: $sidebar-width;
+	height: 100%;
+	min-width: $sidebar-width;
+	max-width: $sidebar-width;
+	top: 0;
+	border-left: 1px solid var( --studio-gray-5 );
+	padding-top: $header-height;
+	background: var( --studio-white );
+	z-index: z-index( '.components-modal__header' ) + 1;
+}
+
+.nux-launch-modal__close-button.components-button.is-link {
+	position: fixed;
+	top: 0;
+	right: 0;
+	z-index: z-index( '.components-modal__header' ) + 2;
 	width: 60px;
 	height: 60px;
 	justify-content: center;

--- a/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-sidebar/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-sidebar/index.tsx
@@ -1,0 +1,29 @@
+/**
+ * External dependencies
+ */
+import * as React from 'react';
+import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import LaunchMenu from '../launch-menu';
+import './styles.scss';
+
+const LaunchSidebar = () => {
+	return (
+		<div className="nux-launch-sidebar">
+			<h2>{ __( "You're almost there!", 'full-site-editing' ) }</h2>
+			<h3>
+				{ __(
+					'Complete the following steps to launch your site. Your site will remain private until you Launch.',
+					'full-site-editing'
+				) }
+			</h3>
+			<LaunchMenu />
+		</div>
+	);
+};
+
+export default LaunchSidebar;

--- a/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-sidebar/styles.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-sidebar/styles.scss
@@ -1,0 +1,18 @@
+@import '~@automattic/onboarding/styles/mixins';
+
+.nux-launch-sidebar {
+	padding: 0 24px;
+
+	h2 {
+		@include onboarding-font-recoleta;
+		font-size: $font-title-medium;
+	}
+
+	h3 {
+		font-family: $default-font;
+		font-weight: normal;
+		font-size: $font-body-small;
+		line-height: 1.5;
+		color: var( --studio-gray-60 );
+	}
+}

--- a/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-step/styles.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-step/styles.scss
@@ -3,6 +3,7 @@
 
 .nux-launch-step {
 	@include onboarding-block-margin;
+	background: var( --studio-white );
 }
 
 .nux-launch-step__header {

--- a/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-steps/domain-step/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-steps/domain-step/index.tsx
@@ -2,19 +2,29 @@
  * External dependencies
  */
 import * as React from 'react';
+import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { Title, SubTitle } from '@automattic/onboarding';
 
 /**
  * Internal dependencies
  */
-import LaunchStep, { Props as LaunchStepProps } from '../../launch-step';
+import { LAUNCH_STORE } from '../../stores';
+import { LaunchStep } from '../../../../common/data-stores/launch/data';
+import LaunchStepContainer, { Props as LaunchStepProps } from '../../launch-step';
 import DomainPickerFSE from '../../../../editor-domain-picker/src/domain-picker-fse';
 import './styles.scss';
 
 const DomainStep: React.FunctionComponent< LaunchStepProps > = ( { onNextStep } ) => {
+	const { setStepComplete } = useDispatch( LAUNCH_STORE );
+
+	const handleSelect = () => {
+		setStepComplete( LaunchStep.Domain );
+		onNextStep?.();
+	};
+
 	return (
-		<LaunchStep className="nux-launch-domain-step">
+		<LaunchStepContainer className="nux-launch-domain-step">
 			<div className="nux-launch-step__header">
 				<div>
 					<Title>{ __( 'Choose a domain', 'full-site-editing' ) }</Title>
@@ -24,9 +34,9 @@ const DomainStep: React.FunctionComponent< LaunchStepProps > = ( { onNextStep } 
 				</div>
 			</div>
 			<div className="nux-launch-step__body">
-				<DomainPickerFSE onSelect={ onNextStep } />
+				<DomainPickerFSE onSelect={ handleSelect } />
 			</div>
-		</LaunchStep>
+		</LaunchStepContainer>
 	);
 };
 

--- a/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-steps/final-step/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-steps/final-step/index.tsx
@@ -1,0 +1,32 @@
+/**
+ * External dependencies
+ */
+import * as React from 'react';
+import { Button } from '@wordpress/components';
+/**
+ * Internal dependencies
+ */
+import LaunchStepContainer, { Props as LaunchStepProps } from '../../launch-step';
+import './styles.scss';
+
+const FinalStep: React.FunctionComponent< LaunchStepProps > = ( { onNextStep } ) => {
+	const handleClick = () => {
+		onNextStep?.();
+	};
+
+	return (
+		<LaunchStepContainer className="nux-launch-final-step">
+			<div className="nux-final-preview-hint">
+				<div>
+					This is just a demo of how to reveal the site content behind to let user preview one more
+					time before submitting.
+				</div>
+				<Button isPrimary onClick={ handleClick }>
+					Confirm &amp; Launch
+				</Button>
+			</div>
+		</LaunchStepContainer>
+	);
+};
+
+export default FinalStep;

--- a/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-steps/final-step/styles.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-steps/final-step/styles.scss
@@ -1,0 +1,14 @@
+.nux-launch-modal.step-final {
+	// Try: Reveal site content behind
+	.nux-launch-modal-body {
+		background: transparent;
+	}
+}
+
+.nux-final-preview-hint {
+	background: var( --studio-blue-0 );
+	width: 100%;
+	position: absolute;
+	left: 0;
+	padding: 20px;
+}

--- a/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-steps/name-step/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-steps/name-step/index.tsx
@@ -1,0 +1,47 @@
+/**
+ * External dependencies
+ */
+import * as React from 'react';
+import { useDispatch } from '@wordpress/data';
+import { __ as X__ } from '@wordpress/i18n';
+import { Title, SubTitle } from '@automattic/onboarding';
+import { Button } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { LAUNCH_STORE } from '../../stores';
+import { LaunchStep } from '../../../../common/data-stores/launch/data';
+import LaunchStepContainer, { Props as LaunchStepProps } from '../../launch-step';
+import './styles.scss';
+
+const NameStep: React.FunctionComponent< LaunchStepProps > = ( { onNextStep } ) => {
+	const { setStepComplete } = useDispatch( LAUNCH_STORE );
+
+	const handleClick = () => {
+		setStepComplete( LaunchStep.Name );
+		onNextStep?.();
+	};
+
+	return (
+		<LaunchStepContainer className="nux-launch-name-step">
+			<div className="nux-launch-step__header">
+				<div>
+					<Title>{ X__( 'Name your site', 'full-site-editing' ) }</Title>
+					<SubTitle>{ X__( 'Pick a name for your site.', 'full-site-editing' ) }</SubTitle>
+				</div>
+			</div>
+			<div className="nux-launch-step__body">
+				<p>
+					For now, this page serves as a demo of how to mark a step as complete and go to the next
+					step.
+				</p>
+				<Button onClick={ handleClick } isPrimary>
+					Mark Complete &amp; Go To Next Step
+				</Button>
+			</div>
+		</LaunchStepContainer>
+	);
+};
+
+export default NameStep;

--- a/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-steps/plan-step/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-steps/plan-step/index.tsx
@@ -2,23 +2,33 @@
  * External dependencies
  */
 import * as React from 'react';
+import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { Title, SubTitle, ActionButtons, BackButton } from '@automattic/onboarding';
 
 /**
  * Internal dependencies
  */
-import LaunchStep, { Props as LaunchStepProps } from '../../launch-step';
+import { LAUNCH_STORE } from '../../stores';
+import { LaunchStep } from '../../../../common/data-stores/launch/data';
+import LaunchStepContainer, { Props as LaunchStepProps } from '../../launch-step';
 import PlansGridFSE from '../../../../editor-plans-grid/src/plans-grid-fse';
 import './styles.scss';
 
 const PlanStep: React.FunctionComponent< LaunchStepProps > = ( { onPrevStep, onNextStep } ) => {
+	const { setStepComplete } = useDispatch( LAUNCH_STORE );
+
 	const handleBack = () => {
 		onPrevStep?.();
 	};
 
+	const handleSelect = () => {
+		setStepComplete( LaunchStep.Plan );
+		onNextStep?.();
+	};
+
 	return (
-		<LaunchStep className="nux-launch-plan-step">
+		<LaunchStepContainer className="nux-launch-plan-step">
 			<div className="nux-launch-step__header">
 				<div>
 					<Title>{ __( 'Select a plan', 'full-site-editing' ) }</Title>
@@ -34,9 +44,9 @@ const PlanStep: React.FunctionComponent< LaunchStepProps > = ( { onPrevStep, onN
 				</ActionButtons>
 			</div>
 			<div className="nux-launch-step__body">
-				<PlansGridFSE onSelect={ onNextStep } />
+				<PlansGridFSE onSelect={ handleSelect } />
 			</div>
-		</LaunchStep>
+		</LaunchStepContainer>
 	);
 };
 

--- a/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch/index.tsx
@@ -2,49 +2,45 @@
  * External dependencies
  */
 import * as React from 'react';
-import type { ValuesType } from 'utility-types';
+import { useSelect, useDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
+import { LAUNCH_STORE } from '../stores';
+import { LaunchStep, LaunchSequence } from '../../../common/data-stores/launch/data';
+import type { LaunchStepType } from '../../../common/data-stores/launch/types';
+import NameStep from '../launch-steps/name-step';
 import DomainStep from '../launch-steps/domain-step';
 import PlanStep from '../launch-steps/plan-step';
+import FinalStep from '../launch-steps/final-step';
 import './styles.scss';
 
-export const LaunchStep = {
-	Domain: 'domain',
-	Plan: 'plan',
-};
-
-export type LaunchStepType = ValuesType< typeof LaunchStep >;
-
 const LaunchStepComponents = {
+	[ LaunchStep.Name ]: NameStep,
 	[ LaunchStep.Domain ]: DomainStep,
 	[ LaunchStep.Plan ]: PlanStep,
+	[ LaunchStep.Final ]: FinalStep,
 };
-
-const LaunchSequence = [ LaunchStep.Domain, LaunchStep.Plan ];
 
 interface Props {
 	step?: LaunchStepType;
 	onSubmit?: () => void;
 }
 
-const Launch: React.FunctionComponent< Props > = ( { step = LaunchStep.Domain, onSubmit } ) => {
-	const initialSequence = LaunchSequence.indexOf( step );
+const Launch: React.FunctionComponent< Props > = ( { onSubmit } ) => {
+	const { step: currentStep } = useSelect( ( select ) => select( LAUNCH_STORE ).getState() );
+	const { setStep } = useDispatch( LAUNCH_STORE );
 
-	const [ currentSequence, setCurrentSequence ] = React.useState( initialSequence );
-
-	const currentStepName = LaunchSequence[ currentSequence ];
-
-	const CurrentLaunchStep = LaunchStepComponents[ currentStepName ];
+	const currentSequence = LaunchSequence.indexOf( currentStep );
 
 	const handlePrevStep = () => {
 		let prevSequence = currentSequence - 1;
 		if ( prevSequence < 0 ) {
 			prevSequence = 0;
 		}
-		setCurrentSequence( prevSequence );
+
+		setStep( LaunchSequence[ prevSequence ] );
 	};
 
 	const handleNextStep = () => {
@@ -53,8 +49,10 @@ const Launch: React.FunctionComponent< Props > = ( { step = LaunchStep.Domain, o
 		if ( nextSequence > maxSequence ) {
 			onSubmit?.();
 		}
-		setCurrentSequence( nextSequence );
+		setStep( LaunchSequence[ nextSequence ] );
 	};
+
+	const CurrentLaunchStep = LaunchStepComponents[ currentStep ];
 
 	return (
 		<div className="nux-launch">


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Added launch sidebar.

**Note:**
* The "Name Step" is used as a demo to show how to mark a step as completed and move to the next step.
* The "Final Step" is used as a demo to show how to reveal the site content behind (This is not so usable. It should render a page preview in an iframe instead like that preview modal). 

#### Testing instructions

* Run `yarn dev --sync` on `apps/full-site-editing`.
* Create an unlaunched site and point that hostname of the unlaunched site to your sandbox.
* Click "Launch site" button.
* Clicking on any step on the sidebar should jump to that particular step.

## Screenshot

![2020-07-20_11-04-55 (1)](https://user-images.githubusercontent.com/1287077/87921080-622a9480-ca7a-11ea-8012-da51180b8d88.gif)

![image](https://user-images.githubusercontent.com/1287077/87920578-b5501780-ca79-11ea-954f-be11037d8cd9.png)

![image](https://user-images.githubusercontent.com/1287077/87920586-b719db00-ca79-11ea-88c0-3aac8ab11bbf.png)

![image](https://user-images.githubusercontent.com/1287077/87920594-b97c3500-ca79-11ea-83c5-2bb8baa24cac.png)

![image](https://user-images.githubusercontent.com/1287077/87920648-c9941480-ca79-11ea-8c8d-d2fa2345a463.png)


Fixes part of #43750
