### PR TITLE
Add security src

### DIFF
--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -505,7 +505,7 @@ function setUpCSP( req, res, next ) {
 			"'self'",
 			'https://public-api.wordpress.com',
 			'https://accounts.google.com/',
-			'jetpack.com',
+			'https://jetpack.com',
 		],
 		'font-src': [
 			"'self'",

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -499,8 +499,14 @@ function setUpCSP( req, res, next ) {
 			'https://www.google-analytics.com',
 			'https://amplifypixel.outbrain.com',
 			'https://img.youtube.com',
+			'localhost:8888',
 		],
-		'frame-src': [ "'self'", 'https://public-api.wordpress.com', 'https://accounts.google.com/' ],
+		'frame-src': [
+			"'self'",
+			'https://public-api.wordpress.com',
+			'https://accounts.google.com/',
+			'jetpack.com',
+		],
 		'font-src': [
 			"'self'",
 			'*.wp.com',
@@ -508,7 +514,12 @@ function setUpCSP( req, res, next ) {
 			'data:', // should remove 'data:' ASAP
 		],
 		'media-src': [ "'self'" ],
-		'connect-src': [ "'self'", 'https://*.wordpress.com/', 'https://*.wp.com' ],
+		'connect-src': [
+			"'self'",
+			'https://*.wordpress.com/',
+			'https://*.wp.com',
+			'https://wordpress.com',
+		],
 		'report-uri': [ '/cspreport' ],
 	};
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

I saw a few errors reported in the console. This fixes them.

* Adds `localhost:8888` for use with `event-monitor`
* Adds `jetpack.com` as a frame src
* Adds `https://wordpress.com` for connect-src 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Errors

* Go to http://calypso.localhost:3000/start/onboarding
* Create a new user
* See no errors about frame-src and connect-src

2. Event Monitor

* Configure `event-monitor` (private repo)
* See no errors about `img-src` security when navigating.

