### PR TITLE
Fix tracks aliasing

### DIFF
--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -438,7 +438,7 @@ export function createAccount(
 			( response && response.user_id ) ||
 			userData.ID;
 
-		const email = ( response && response.email ) || ( userData && userData.user_email );
+		const email = ( response && response.email ) || ( userData && userData.email );
 
 		const registrationUserData = {
 			ID: userId,

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -438,7 +438,8 @@ export function createAccount(
 			( response && response.user_id ) ||
 			userData.ID;
 
-		const email = ( response && response.email ) || ( userData && userData.email );
+		const email =
+			( response && response.email ) || ( userData && ( userData.email || userData.user_email ) );
 
 		const registrationUserData = {
 			ID: userId,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Apparently we don't always have the email address when trying to identify the user (tested with http://calypso.localhost/start/onboarding). It looks like we're just trying to access the incorrect property from `userData` however, I decided to keep `.user_email` and `.email` because I'm not certain we'll always have `.email` or `.user_email` in every possible flow and I'd like to believe it's there for a reason and correct some of the time.

#### Testing instructions

* Configure `event-monitor` or set tracks debug to `true`
* Go to http://calypso.locahost:3000/start/onboarding
* See alias event while viewing the domain search interface