### PR TITLE
Adds 'now' to the renew button to make it more specific

### DIFF
--- a/client/my-sites/domains/domain-management/edit/card/renew-button/index.jsx
+++ b/client/my-sites/domains/domain-management/edit/card/renew-button/index.jsx
@@ -70,7 +70,7 @@ class RenewButton extends React.Component {
 		}
 
 		const buttonClasses = classNames( 'renew-button', { 'is-loading': loading } );
-		let buttonLabel = translate( 'Renew for {{strong}}%(price)s{{/strong}}', {
+		let buttonLabel = translate( 'Renew now for {{strong}}%(price)s{{/strong}}', {
 			components: { strong: <strong /> },
 			args: { price: formattedPrice },
 		} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds `now` to the CTA text of the domain renew button.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* The renew button should have 'Renew now for ..' cta, to reduce confusion when auto-renew is set to true.

<img width="738" alt="Screenshot 2020-07-20 at 2 53 16 PM" src="https://user-images.githubusercontent.com/277661/87945622-e7bd3d00-ca98-11ea-8b37-87c9480bfe88.png">

