### PR TITLE
Domain Refund Policy: use a unique key for return

### DIFF
--- a/client/my-sites/checkout/checkout/domain-refund-policy.jsx
+++ b/client/my-sites/checkout/checkout/domain-refund-policy.jsx
@@ -27,17 +27,17 @@ class DomainRefundPolicy extends React.Component {
 	};
 
 	/**
-	 * @returns {[]} Returns an array of renderable policies.
+	 * @returns {{}} Returns an object of renderable policies with unique keys.
 	 */
 	getApplicablePolicies = () => {
-		const policies = [];
+		let policies = {};
 
 		if ( hasNewDomainRegistration( this.props.cart ) ) {
-			policies.push( this.renderNewPolicy() );
+			policies = { ...policies, ...this.renderNewPolicy() };
 		}
 
 		if ( hasDomainRenewal( this.props.cart ) ) {
-			policies.push( this.renderRenewalPolicy() );
+			policies = { ...policies, ...this.renderRenewalPolicy() };
 		}
 
 		return policies;
@@ -73,11 +73,11 @@ class DomainRefundPolicy extends React.Component {
 			);
 		}
 
-		return message;
+		return { newDomainPolicy: message };
 	};
 
 	renderRenewalPolicy = () => {
-		return this.props.translate(
+		const message = this.props.translate(
 			'Please note: to receive a {{refundsSupportPage}}refund for a domain renewal{{/refundsSupportPage}}, you must {{cancelDomainSupportPage}}cancel your domain{{/cancelDomainSupportPage}} within 96 hours of the renewal transaction. Canceling the domain means it will be deleted and you may not be able to recover it.',
 			{
 				components: {
@@ -100,6 +100,8 @@ class DomainRefundPolicy extends React.Component {
 				},
 			}
 		);
+
+		return { renewalPolicy: message };
 	};
 
 	render() {
@@ -109,16 +111,12 @@ class DomainRefundPolicy extends React.Component {
 
 		const policies = this.getApplicablePolicies();
 
-		return (
-			<>
-				{ policies.map( ( policy, index ) => (
-					<div className="checkout__domain-refund-policy" key={ index }>
-						<Gridicon icon="info-outline" size={ 18 } />
-						<p>{ policy }</p>
-					</div>
-				) ) }
-			</>
-		);
+		return Object.entries( policies ).map( ( [ name, message ] ) => (
+			<div className="checkout__domain-refund-policy" key={ 'refund-policy-' + name }>
+				<Gridicon icon="info-outline" size={ 18 } />
+				<p>{ message }</p>
+			</div>
+		) );
 	}
 }
 

--- a/client/my-sites/checkout/checkout/domain-refund-policy.jsx
+++ b/client/my-sites/checkout/checkout/domain-refund-policy.jsx
@@ -33,11 +33,11 @@ class DomainRefundPolicy extends React.Component {
 		let policies = {};
 
 		if ( hasNewDomainRegistration( this.props.cart ) ) {
-			policies = { ...policies, ...this.renderNewPolicy() };
+			policies = { ...policies, newDomain: this.renderNewPolicy() };
 		}
 
 		if ( hasDomainRenewal( this.props.cart ) ) {
-			policies = { ...policies, ...this.renderRenewalPolicy() };
+			policies = { ...policies, renewal: this.renderRenewalPolicy() };
 		}
 
 		return policies;
@@ -73,11 +73,11 @@ class DomainRefundPolicy extends React.Component {
 			);
 		}
 
-		return { newDomainPolicy: message };
+		return message;
 	};
 
 	renderRenewalPolicy = () => {
-		const message = this.props.translate(
+		return this.props.translate(
 			'Please note: to receive a {{refundsSupportPage}}refund for a domain renewal{{/refundsSupportPage}}, you must {{cancelDomainSupportPage}}cancel your domain{{/cancelDomainSupportPage}} within 96 hours of the renewal transaction. Canceling the domain means it will be deleted and you may not be able to recover it.',
 			{
 				components: {
@@ -100,8 +100,6 @@ class DomainRefundPolicy extends React.Component {
 				},
 			}
 		);
-
-		return { renewalPolicy: message };
 	};
 
 	render() {
@@ -112,7 +110,7 @@ class DomainRefundPolicy extends React.Component {
 		const policies = this.getApplicablePolicies();
 
 		return Object.entries( policies ).map( ( [ name, message ] ) => (
-			<div className="checkout__domain-refund-policy" key={ 'refund-policy-' + name }>
+			<div className="checkout__domain-refund-policy" key={ 'domain-refund-policy-' + name }>
 				<Gridicon icon="info-outline" size={ 18 } />
 				<p>{ message }</p>
 			</div>


### PR DESCRIPTION
I introduced a code smell in #44272 by using the array index as the element key in a mapped return. This switches it to a keyed object literal.

Fixes #44272

props @nbloomf @sirbrillig 

**To test:**

- Add a domain or domain renewal to the cart and visit composite checkout with `?flags=composite-checkout-force`
- Verify that the correct domain refund policy is shown without any console errors
- Check legacy Checkout with `?flags=old-checkout-force`