### PR TITLE
Don't show Welcome message for Free plan

### DIFF
--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -116,11 +116,19 @@ class CurrentPlan extends Component {
 			shouldShowDomainWarnings,
 			showJetpackChecklist,
 			showThankYou,
+			currentPlan,
 			translate,
 		} = this.props;
 
 		const currentPlanSlug = selectedSite.plan.product_slug,
 			isLoading = this.isLoading();
+
+		let ensureShowThankYou = showThankYou;
+
+		if ( ! currentPlan || isFreePlan( currentPlan ) || isFreeJetpackPlan( currentPlan ) ) {
+			// Ensure that we don't have to show the card for Free plan
+			ensureShowThankYou = false;
+		}
 
 		const planConstObj = getPlan( currentPlanSlug ),
 			planFeaturesHeader = translate( '%(planName)s plan features', {
@@ -144,12 +152,14 @@ class CurrentPlan extends Component {
 				<QuerySitePurchases siteId={ selectedSiteId } />
 				{ shouldQuerySiteDomains && <QuerySiteDomains siteId={ selectedSiteId } /> }
 
-				<Dialog
-					baseClassName="current-plan__dialog dialog__content dialog__backdrop"
-					isVisible={ showThankYou }
-				>
-					{ this.renderThankYou() }
-				</Dialog>
+				{ ensureShowThankYou && (
+					<Dialog
+						baseClassName="current-plan__dialog dialog__content dialog__backdrop"
+						isVisible={ ensureShowThankYou }
+					>
+						{ this.renderThankYou() }
+					</Dialog>
+				) }
 
 				<PlansNavigation path={ path } />
 

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -116,19 +116,11 @@ class CurrentPlan extends Component {
 			shouldShowDomainWarnings,
 			showJetpackChecklist,
 			showThankYou,
-			currentPlan,
 			translate,
 		} = this.props;
 
 		const currentPlanSlug = selectedSite.plan.product_slug,
 			isLoading = this.isLoading();
-
-		let ensureShowThankYou = showThankYou;
-
-		if ( ! currentPlan || isFreePlan( currentPlan ) || isFreeJetpackPlan( currentPlan ) ) {
-			// Ensure that we don't have to show the card for Free plan
-			ensureShowThankYou = false;
-		}
 
 		const planConstObj = getPlan( currentPlanSlug ),
 			planFeaturesHeader = translate( '%(planName)s plan features', {
@@ -152,10 +144,10 @@ class CurrentPlan extends Component {
 				<QuerySitePurchases siteId={ selectedSiteId } />
 				{ shouldQuerySiteDomains && <QuerySiteDomains siteId={ selectedSiteId } /> }
 
-				{ ensureShowThankYou && (
+				{ showThankYou && (
 					<Dialog
 						baseClassName="current-plan__dialog dialog__content dialog__backdrop"
-						isVisible={ ensureShowThankYou }
+						isVisible={ showThankYou }
 					>
 						{ this.renderThankYou() }
 					</Dialog>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When a user buys the new Jetpack Anti-Spam product, they see the Anti-Spam Thank You message and when you click on the button they see for a second the Jetpack Free Welcome. The same happens with the Scan and Backup products. After a discussion, we decided to remove the Jetpack Free Welcome since it's a rare case and with the new Offer Reset project it'll change.

More info: 1181531115069428-as-1185305720915537

Before you saw:

![image](https://user-images.githubusercontent.com/9832440/87963496-b2244e00-cab0-11ea-9a78-cf7d75be2fff.png)
and then, for a second:
![image](https://user-images.githubusercontent.com/9832440/87965366-8b1b4b80-cab3-11ea-9f3e-66a4ab989b67.png)

Then with this PR, you see only the "Say goodby spam!"

#### Testing instructions

- Go to a Jetpack free site
- Now go to this URL: `plans/my-plan/[your-site]?thank-you=&product=jetpack_anti_spam_monthly`
- Click on "Go back to your site". Now you don't see the Welcome message.
- Check the rest of the Thank you messages:
  - `?thank-you=&product=jetpack_scan`
  - `?thank-you=&product=jetpack_backup`
