### PR TITLE
Make all composite-checkout debug lines in calypso start the same

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -92,7 +92,7 @@ import { retrieveSignupDestination, clearSignupDestinationCookie } from 'signup/
 import { useWpcomProductVariants } from './wpcom/hooks/product-variants';
 import { CartProvider } from './cart-provider';
 
-const debug = debugFactory( 'calypso:composite-checkout' );
+const debug = debugFactory( 'calypso:composite-checkout:composite-checkout' );
 
 const { select, dispatch, registerStore } = defaultRegistry;
 

--- a/client/my-sites/checkout/composite-checkout/types/transaction-endpoint.ts
+++ b/client/my-sites/checkout/composite-checkout/types/transaction-endpoint.ts
@@ -14,7 +14,7 @@ import type {
 import type { CartItemExtra } from 'lib/cart-values/types';
 import { isGSuiteProductSlug } from 'lib/gsuite';
 
-const debug = debugFactory( 'calypso:transaction-endpoint' );
+const debug = debugFactory( 'calypso:composite-checkout:transaction-endpoint' );
 
 export type WPCOMTransactionEndpoint = (
 	_: WPCOMTransactionEndpointRequestPayload

--- a/client/my-sites/checkout/composite-checkout/use-get-thank-you-url.js
+++ b/client/my-sites/checkout/composite-checkout/use-get-thank-you-url.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { format as formatUrl, parse as parseUrl } from 'url';
+import { format as formatUrl, parse as parseUrl } from 'url'; // eslint-disable-line no-restricted-imports
 import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import { defaultRegistry } from '@automattic/composite-checkout';

--- a/client/my-sites/checkout/composite-checkout/use-get-thank-you-url.js
+++ b/client/my-sites/checkout/composite-checkout/use-get-thank-you-url.js
@@ -9,7 +9,7 @@ import debugFactory from 'debug';
 import { isEmpty } from 'lodash';
 
 const { select } = defaultRegistry;
-const debug = debugFactory( 'calypso:composite-checkout-thank-you' );
+const debug = debugFactory( 'calypso:composite-checkout:use-get-thank-you-url' );
 
 /**
  * Internal dependencies

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -46,7 +46,7 @@ import {
 } from 'my-sites/checkout/composite-checkout/contact-validation';
 import { isGSuiteProductSlug } from 'lib/gsuite';
 
-const debug = debugFactory( 'calypso:wp-checkout' );
+const debug = debugFactory( 'calypso:composite-checkout:wp-checkout' );
 
 const ContactFormTitle = () => {
 	const translate = useTranslate();

--- a/client/my-sites/checkout/composite-checkout/wpcom/hooks/use-shopping-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/hooks/use-shopping-cart.ts
@@ -29,7 +29,7 @@ import {
 } from '../types';
 import { translateResponseCartToWPCOMCart } from '../lib/translate-cart';
 
-const debug = debugFactory( 'composite-checkout-wpcom:shopping-cart-manager' );
+const debug = debugFactory( 'calypso:composite-checkout:shopping-cart-manager' );
 
 /**
  *     * responseCart


### PR DESCRIPTION
This normalizes all the debug function keys used throughout the
composite-checkout section of calypso (not the package by the same name,
which has its own key) so that they all start with
`calypso:composite-checkout`.

#### Testing instructions

- Visit composite checkout, set `localStorage.setItem('debug', 'calypso:composite-checkout:*')` and reload the page.
- Verify that you see a bunch of logs, notably that you see lines from `calypso:composite-checkout:shopping-cart-manager`.