### PR TITLE
e2e tests: Make SecurePaymentComponent.removeFromCart work for both checkouts

### DIFF
--- a/test/e2e/lib/components/secure-payment-component.js
+++ b/test/e2e/lib/components/secure-payment-component.js
@@ -356,7 +356,7 @@ export default class SecurePaymentComponent extends AsyncBaseContainer {
 	async removeFromCart() {
 		return await driverHelper.clickWhenClickable(
 			this.driver,
-			By.css( 'button svg[aria-labelledby*="checkout-delete-button-0"]' )
+			By.css( 'button.cart__remove-item,button svg[aria-labelledby*="checkout-delete-button-0"]' )
 		);
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is a follow-up to https://github.com/Automattic/wp-calypso/pull/44213 just to make sure that the `SecurePaymentComponent.removeFromCart` function will work for both old and new checkout, following the pattern of the rest of the class.

#### Testing instructions

Make sure e2e tests continue to pass.