### PR TITLE
Jetpack Search: remove WP.com purchase announcement notice when adding a WP.com site

### DIFF
--- a/client/jetpack-connect/connection-notice-types.js
+++ b/client/jetpack-connect/connection-notice-types.js
@@ -11,7 +11,6 @@ export const ALREADY_OWNED = 'alreadyOwned';
 export const DEFAULT_AUTHORIZE_ERROR = 'defaultAuthorizeError';
 export const INSTALL_RESPONSE_ERROR = 'unableToInstall';
 export const IS_DOT_COM = 'isDotCom';
-export const IS_DOT_COM_GET_SEARCH = 'isDotComGetSearch';
 export const JETPACK_IS_DISCONNECTED = 'jetpackIsDisconnected';
 export const JETPACK_IS_VALID = 'jetpackIsValid';
 export const LOGIN_FAILURE = 'loginFailure';

--- a/client/jetpack-connect/jetpack-connect-notices.jsx
+++ b/client/jetpack-connect/jetpack-connect-notices.jsx
@@ -16,7 +16,6 @@ import {
 	INSTALL_RESPONSE_ERROR,
 	INVALID_CREDENTIALS,
 	IS_DOT_COM,
-	IS_DOT_COM_GET_SEARCH,
 	JETPACK_IS_DISCONNECTED,
 	JETPACK_IS_VALID,
 	NOT_ACTIVE_JETPACK,
@@ -50,7 +49,6 @@ export class JetpackConnectNotices extends Component {
 			INSTALL_RESPONSE_ERROR,
 			INVALID_CREDENTIALS,
 			IS_DOT_COM,
-			IS_DOT_COM_GET_SEARCH,
 			JETPACK_IS_DISCONNECTED,
 			JETPACK_IS_VALID,
 			NOT_ACTIVE_JETPACK,
@@ -106,14 +104,6 @@ export class JetpackConnectNotices extends Component {
 				noticeValues.status = 'is-success';
 				noticeValues.icon = 'plugins';
 				noticeValues.text = translate( 'Good news! WordPress.com sites already have Jetpack.' );
-				return noticeValues;
-
-			case IS_DOT_COM_GET_SEARCH:
-				noticeValues.status = 'is-success';
-				noticeValues.icon = 'status';
-				noticeValues.text = translate(
-					'Good news! Jetpack Search is coming soon to WordPress.com sites.'
-				);
 				return noticeValues;
 
 			case NOT_WORDPRESS:


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Search is soft launched for WP.com sites. Here, we remove the "Good news! Jetpack Search is coming soon to WordPress.com sites." notice.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* start at `/purchase-product/jetpack_search` 
* select/type a WP.com site url
* verify redirect to Checkout without a notice being displayed


