### PR TITLE
Replace url module with lib/url to fix lint errors.

### DIFF
--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -15,7 +15,6 @@ import {
 	pick,
 	startsWith,
 } from 'lodash';
-import { parse as parseURL } from 'url';
 
 /**
  * Internal dependencies
@@ -33,6 +32,7 @@ import {
 	supportsPrivacyProtectionPurchase,
 	planItem as getCartItemForPlan,
 } from 'lib/cart-values/cart-items';
+import { getUrlParts } from 'lib/url';
 
 // State actions and selectors
 import { getDesignType } from 'state/signup/steps/design-type/selectors';
@@ -237,7 +237,7 @@ export function createSiteWithCart( callback, dependencies, stepData, reduxStore
 			return;
 		}
 
-		const parsedBlogURL = parseURL( response.blog_details.url );
+		const parsedBlogURL = getUrlParts( response.blog_details.url );
 
 		const siteSlug = parsedBlogURL.hostname;
 		const siteId = response.blog_details.blogid;
@@ -531,7 +531,7 @@ export function createSite( callback, dependencies, stepData, reduxStore ) {
 		let providedDependencies, siteSlug;
 
 		if ( response && response.blog_details ) {
-			const parsedBlogURL = parseURL( response.blog_details.url );
+			const parsedBlogURL = getUrlParts( response.blog_details.url );
 			siteSlug = parsedBlogURL.hostname;
 
 			providedDependencies = { siteSlug };
@@ -568,7 +568,7 @@ export function createWpForTeamsSite( callback, dependencies, stepData, reduxSto
 		let providedDependencies, siteSlug;
 
 		if ( response && response.blog_details ) {
-			const parsedBlogURL = parseURL( response.blog_details.url );
+			const parsedBlogURL = getUrlParts( response.blog_details.url );
 			siteSlug = parsedBlogURL.hostname;
 
 			providedDependencies = { siteSlug };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The `url` module was recently added as a restricted import in #44041 with the recommendation to replace it with `lib/url`. This causes a lint error when files are touched that use the 'url' module. I ran into this lint error in the PR https://github.com/Automattic/wp-calypso/pull/44206, where `client/lib/signup/step-actions/index.js` uses this module. 

This PR replaces `parse` from url with `getUrlParts` from `lib/url`. I'm separating this change out to its own PR given that this affects the signup flow.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Begin at /start logged out, go through the signup flow and verify that you are able to create a site. Try both free and paid plan sites.
* This also touches the WPForTeams workflow. I think the way to test it is to begin at /start/wp-for-teams logged out, go through the signup flow, and confirm that you are able to create a new site.
