### PR TITLE
Editor: add parent post query arg

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -876,7 +876,6 @@ function handleUncaughtErrors( calypsoPort ) {
 
 async function handleEditorLoaded( calypsoPort ) {
 	await isEditorReadyWithBlocks();
-
 	const isNew = select( 'core/editor' ).isCleanNewPost();
 	const blocks = select( 'core/block-editor' ).getBlocks();
 
@@ -895,14 +894,20 @@ async function handleEditorLoaded( calypsoPort ) {
 }
 
 async function preselectParentPage() {
-	const postType = select( 'core/editor' ).getCurrentPostType();
 	const parentPostId = parseInt( getQueryArg( window.location.href, 'parent_post' ) );
-	if ( 'page' === postType && parentPostId && parentPostId > 0 ) {
-		const pages = await getPages();
-		const isValidParentId = pages.some( ( page ) => page.id === parentPostId );
-		if ( isValidParentId ) {
-			dispatch( 'core/editor' ).editPost( { parent: parentPostId } );
-		}
+	if ( ! parentPostId || isNaN( parseInt( parentPostId ) ) ) {
+		return;
+	}
+
+	const postType = select( 'core/editor' ).getCurrentPostType();
+	if ( 'page' !== postType ) {
+		return;
+	}
+
+	const pages = await getPages();
+	const isValidParentId = pages.some( ( page ) => page.id === parentPostId );
+	if ( isValidParentId ) {
+		dispatch( 'core/editor' ).editPost( { parent: parentPostId } );
 	}
 }
 

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -877,8 +877,9 @@ function handleUncaughtErrors( calypsoPort ) {
 async function handleEditorLoaded( calypsoPort ) {
 	await isEditorReadyWithBlocks();
 
+	const postType = select( 'core/editor' ).getCurrentPostType();
 	const parentPostId = getQueryArg( window.location.href, 'parent_post' );
-	if ( parentPostId && parentPostId > 0 ) {
+	if ( 'page' === postType && parentPostId && parentPostId > 0 ) {
 		dispatch( 'core/editor' ).editPost( { parent: parentPostId } );
 	}
 

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -877,9 +877,9 @@ function handleUncaughtErrors( calypsoPort ) {
 async function handleEditorLoaded( calypsoPort ) {
 	await isEditorReadyWithBlocks();
 
-	const parentPageId = getQueryArg( window.location.href, 'parent_post' );
-	if ( parentPageId && parentPageId > 0 ) {
-		dispatch( 'core/editor' ).editPost( { parent: parentPageId } );
+	const parentPostId = getQueryArg( window.location.href, 'parent_post' );
+	if ( parentPostId && parentPostId > 0 ) {
+		dispatch( 'core/editor' ).editPost( { parent: parentPostId } );
 	}
 
 	const isNew = select( 'core/editor' ).isCleanNewPost();

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -876,6 +876,12 @@ function handleUncaughtErrors( calypsoPort ) {
 
 async function handleEditorLoaded( calypsoPort ) {
 	await isEditorReadyWithBlocks();
+
+	const parentPageId = getQueryArg( window.location.href, 'parent_post' );
+	if ( parentPageId && parentPageId > 0 ) {
+		dispatch( 'core/editor' ).editPost( { parent: parentPageId } );
+	}
+
 	const isNew = select( 'core/editor' ).isCleanNewPost();
 	const blocks = select( 'core/block-editor' ).getBlocks();
 

--- a/apps/wpcom-block-editor/src/utils.js
+++ b/apps/wpcom-block-editor/src/utils.js
@@ -55,3 +55,15 @@ export const isEditorReadyWithBlocks = async () =>
 			}
 		} );
 	} );
+
+export const getPages = async () =>
+	new Promise( ( resolve ) => {
+		const unsubscribe = subscribe( () => {
+			const pages = select( 'core' ).getEntityRecords( 'postType', 'page' );
+
+			if ( pages !== null ) {
+				unsubscribe();
+				resolve( pages );
+			}
+		} );
+	} );

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -5,6 +5,7 @@
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import { endsWith, get, map, partial, pickBy, startsWith, isArray, flowRight } from 'lodash';
+/* eslint-disable no-restricted-imports */
 import url from 'url';
 import { localize, LocalizeProps } from 'i18n-calypso';
 /**

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -72,7 +72,7 @@ interface Props {
 	pressThis: any;
 	siteAdminUrl: T.URL | null;
 	fseParentPageId: T.PostId;
-	parentPageId: T.PostId;
+	parentPostId: T.PostId;
 }
 
 interface State {
@@ -711,7 +711,7 @@ const mapStateToProps = (
 		postType,
 		duplicatePostId,
 		fseParentPageId,
-		parentPageId,
+		parentPostId,
 		creatingNewHomepage,
 		editorType = 'post',
 	}: Props
@@ -728,7 +728,7 @@ const mapStateToProps = (
 		post_type: postType !== 'post' && postType, // Use postType if it's different than post.
 		calypsoify: 1,
 		fse_parent_post: fseParentPageId != null && fseParentPageId,
-		parent_post: parentPageId != null && parentPageId,
+		parent_post: parentPostId != null && parentPostId,
 		'block-editor': 1,
 		'frame-nonce': getSiteOption( state, siteId, siteOption ) || '',
 		'jetpack-copy': duplicatePostId,
@@ -789,7 +789,7 @@ const mapStateToProps = (
 		siteCreationFlow: getSiteOption( state, siteId, 'site_creation_flow' ),
 		isSiteUnlaunched: isUnlaunchedSite( state, siteId ),
 		site: getSite( state, siteId ),
-		parentPageId,
+		parentPostId,
 	};
 };
 

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -71,6 +71,7 @@ interface Props {
 	pressThis: any;
 	siteAdminUrl: T.URL | null;
 	fseParentPageId: T.PostId;
+	parentPageId: T.PostId;
 }
 
 interface State {
@@ -709,6 +710,7 @@ const mapStateToProps = (
 		postType,
 		duplicatePostId,
 		fseParentPageId,
+		parentPageId,
 		creatingNewHomepage,
 		editorType = 'post',
 	}: Props
@@ -725,6 +727,7 @@ const mapStateToProps = (
 		post_type: postType !== 'post' && postType, // Use postType if it's different than post.
 		calypsoify: 1,
 		fse_parent_post: fseParentPageId != null && fseParentPageId,
+		parent_post: parentPageId != null && parentPageId,
 		'block-editor': 1,
 		'frame-nonce': getSiteOption( state, siteId, siteOption ) || '',
 		'jetpack-copy': duplicatePostId,
@@ -785,6 +788,7 @@ const mapStateToProps = (
 		siteCreationFlow: getSiteOption( state, siteId, 'site_creation_flow' ),
 		isSiteUnlaunched: isUnlaunchedSite( state, siteId ),
 		site: getSite( state, siteId ),
+		parentPageId,
 	};
 };
 

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -205,7 +205,7 @@ export const post = ( context, next ) => {
 	const siteId = getSelectedSiteId( state );
 	const pressThis = getPressThisData( context.query );
 	const fseParentPageId = parseInt( context.query.fse_parent_post, 10 ) || null;
-	const parentPageId = parseInt( context.query.parent_post, 10 ) || null;
+	const parentPostId = parseInt( context.query.parent_post, 10 ) || null;
 
 	// Set postId on state.editor.postId, so components like editor revisions can read from it.
 	context.store.dispatch( { type: EDITOR_START, siteId, postId } );
@@ -221,7 +221,7 @@ export const post = ( context, next ) => {
 			duplicatePostId={ duplicatePostId }
 			pressThis={ pressThis }
 			fseParentPageId={ fseParentPageId }
-			parentPageId={ parentPageId }
+			parentPostId={ parentPostId }
 			creatingNewHomepage={ postType === 'page' && has( context, 'query.new-homepage' ) }
 		/>
 	);

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -205,6 +205,7 @@ export const post = ( context, next ) => {
 	const siteId = getSelectedSiteId( state );
 	const pressThis = getPressThisData( context.query );
 	const fseParentPageId = parseInt( context.query.fse_parent_post, 10 ) || null;
+	const parentPageId = parseInt( context.query.parent_post, 10 ) || null;
 
 	// Set postId on state.editor.postId, so components like editor revisions can read from it.
 	context.store.dispatch( { type: EDITOR_START, siteId, postId } );
@@ -220,6 +221,7 @@ export const post = ( context, next ) => {
 			duplicatePostId={ duplicatePostId }
 			pressThis={ pressThis }
 			fseParentPageId={ fseParentPageId }
+			parentPageId={ parentPageId }
 			creatingNewHomepage={ postType === 'page' && has( context, 'query.new-homepage' ) }
 		/>
 	);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds an optional `parent_post` query arg to the block editor URL, so we can preselect the value in the Parent Page dropdown. If this argument is provided, the Parent Page attribute will be pre-set to its value.

### Test Setup instructions
* Sandbox `widgets.wp.com` and keep a sandbox connection open.
* Apply this PR's build diff D46720-code

#### Testing instructions
1. Visit `http://calypso.localhost:3000/block-editor/page/<YOUR-TEST-BLOG>?parent_post=<THE-PARENT-PAGE-ID>`
2. Check **Page Attributes** on the side panel. It should be preselected to the parent page specified in the URL.
3. Check that saving the page persists the parent page attribute. Also check that the user can freely change the parent page attribute (i.e. we only preselect).
4. Check that `parent_post` is purely optional -- not setting it doesn't break the editor.
5. Check that passing an invalid parent page ID does not break the editor.

Partly fixes 719-gh-p2
