### PR TITLE
Plans Grid: fix double horizontal scrollbar

### DIFF
--- a/packages/plans-grid/src/plans-grid/style.scss
+++ b/packages/plans-grid/src/plans-grid/style.scss
@@ -42,7 +42,7 @@
 .plans-grid__details-container {
 	@media ( max-width: $plans-grid-max-page-width ) {
 		overflow-x: auto;
-		width: 100vw;
+		width: 100%;
 		position: absolute;
 		left: 0;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Change width to percentage for plans details comparison container to take into consideration the vertical scroll of the browser and prevent displaying an extra scrollbar at the bottom.


**Before**
<img width="600" alt="Screenshot 2020-07-21 at 13 02 21" src="https://user-images.githubusercontent.com/14192054/88041705-71c9dc00-cb53-11ea-8172-5add3ac608a3.png">


**After**
<img width="600" alt="Screenshot 2020-07-21 at 13 09 12" src="https://user-images.githubusercontent.com/14192054/88041694-6f678200-cb53-11ea-9548-7eb4a57aabd5.png">


#### Testing instructions
* Go to[ /new](https://calypso.live/new?branch=fix/plans-grid-horizontal-scroll) on a screen below 1440px width.
* Open Plans grid.
* Scroll to bottom on the page and check the following:
  * between ~850px and 1440px there shouldn't be any horizontal scrollbar at the bottom.
  * between 600px and ~850px there should be only one scrollbar at the bottom.

Fixes https://github.com/Automattic/wp-calypso/pull/44087#pullrequestreview-450057630