### PR TITLE
Checkout: use fixed positioning for sidebar summary

### DIFF
--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -215,7 +215,7 @@ export default function WPCheckout( {
 
 	return (
 		<Checkout>
-			<CheckoutSummaryArea className={ isSummaryVisible ? 'is-visible' : '' }>
+			<CheckoutSummaryAreaUI className={ isSummaryVisible ? 'is-visible' : '' }>
 				<CheckoutSummaryTitleLink onClick={ () => setIsSummaryVisible( ! isSummaryVisible ) }>
 					<CheckoutSummaryTitle>
 						<CheckoutSummaryTitleIcon icon="info-outline" size={ 20 } />
@@ -230,7 +230,7 @@ export default function WPCheckout( {
 					<WPCheckoutOrderSummary />
 					<SecondaryCartPromotions responseCart={ responseCart } addItemToCart={ addItemToCart } />
 				</CheckoutSummaryBody>
-			</CheckoutSummaryArea>
+			</CheckoutSummaryAreaUI>
 			<CheckoutStepArea submitButtonHeader={ <SubmitButtonHeader /> }>
 				<CheckoutStepBody
 					onError={ onReviewError }
@@ -346,6 +346,12 @@ export default function WPCheckout( {
 	);
 }
 
+const CheckoutSummaryAreaUI = styled( CheckoutSummaryArea )`
+	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
+		position: relative;
+	}
+`;
+
 const CheckoutSummaryTitleLink = styled.button`
 	background: ${ ( props ) => props.theme.colors.background };
 	border-bottom: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
@@ -426,6 +432,7 @@ const CheckoutSummaryBody = styled.div`
 
 	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
 		display: block;
+		position: fixed;
 	}
 `;
 

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -432,6 +432,7 @@ const CheckoutSummaryBody = styled.div`
 
 	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
 		display: block;
+		max-width: 328px;
 		position: fixed;
 	}
 `;


### PR DESCRIPTION
On non-mobile devices, the Checkout summary is displayed in the sidebar with features, total, and savings. This PR keeps the summary on the page as the user scrolls.

![fixed-sidebar](https://user-images.githubusercontent.com/942359/88058033-eb040780-cb30-11ea-8773-33ebac15c88f.gif)

**To test:**
- add an item to your cart and visit the new Checkout flow (with `?flags=composite-checkout-force`)
- verify that when the sidebar is shown (landscape tablet and desktop devices), the summary scrolls with the page
- verify that when the sidebar is collapse (mobile devices), the summary behaves as normal