### PR TITLE
Domains: Add auto renew toggle button in domain options

### DIFF
--- a/client/my-sites/domains/domain-management/list/domain-item.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-item.jsx
@@ -404,18 +404,27 @@ class DomainItem extends PureComponent {
 		return null;
 	}
 
-	busyMessage() {
-		if ( this.props.isBusy && this.props.busyMessage ) {
-			return <div className="domain-item__busy-message">{ this.props.busyMessage }</div>;
+	busyMessage( message ) {
+		if ( message ) {
+			return <div className="domain-item__busy-message">{ message }</div>;
 		}
 	}
 
 	renderOverlay() {
-		const { enableSelection, isBusy, shouldUpgradeToMakePrimary } = this.props;
-		if ( isBusy ) {
+		const {
+			enableSelection,
+			isBusy,
+			busyMessage,
+			shouldUpgradeToMakePrimary,
+			translate,
+		} = this.props;
+
+		if ( isBusy || this.state.isTogglingAutoRenew ) {
 			return (
 				<div className="domain-item__overlay">
-					{ this.busyMessage() }
+					{ this.busyMessage(
+						this.state.isTogglingAutoRenew ? translate( 'Toggling auto-renew' ) : busyMessage
+					) }
 					<Spinner className="domain-item__spinner" size={ 20 } />
 				</div>
 			);
@@ -442,13 +451,13 @@ class DomainItem extends PureComponent {
 					planName={ site.plan.product_name_short }
 					purchase={ purchase }
 					siteDomain={ site.slug }
-					onClose={ () => {} }
+					onClose={ this.closeDialogs }
 					onConfirm={ this.toggleAutoRenew }
 				/>
 				<AutoRenewPaymentMethodDialog
 					isVisible={ this.state.showPaymentMethodDialog }
 					purchase={ purchase }
-					onClose={ () => {} }
+					onClose={ this.closeDialogs }
 					onAddClick={ this.goToUpdatePaymentMethod }
 				/>
 			</>
@@ -465,29 +474,32 @@ class DomainItem extends PureComponent {
 		} );
 
 		return (
-			<CompactCard className={ rowClasses } onClick={ this.handleClick }>
-				{ showCheckbox && (
-					<FormCheckbox
-						className="domain-item__checkbox"
-						onChange={ this.onToggle }
-						onClick={ this.stopPropagation }
-					/>
-				) }
-				{ enableSelection && (
-					<FormRadio className="domain-item__checkbox" onClick={ this.onSelect } />
-				) }
-				<div className="list__domain-link">
-					<div className="domain-item__status">
-						<div className={ domainTitleClass }>{ domain.domain }</div>
-						{ listStatusText && (
-							<DomainNotice status={ listStatusClass || 'info' } text={ listStatusText } />
-						) }
+			<>
+				<CompactCard className={ rowClasses } onClick={ this.handleClick }>
+					{ showCheckbox && (
+						<FormCheckbox
+							className="domain-item__checkbox"
+							onChange={ this.onToggle }
+							onClick={ this.stopPropagation }
+						/>
+					) }
+					{ enableSelection && (
+						<FormRadio className="domain-item__checkbox" onClick={ this.onSelect } />
+					) }
+					<div className="list__domain-link">
+						<div className="domain-item__status">
+							<div className={ domainTitleClass }>{ domain.domain }</div>
+							{ listStatusText && (
+								<DomainNotice status={ listStatusClass || 'info' } text={ listStatusText } />
+							) }
+						</div>
+						{ this.renderSiteMeta() }
 					</div>
-					{ this.renderSiteMeta() }
-				</div>
-				{ this.renderActionItems() }
-				{ this.renderOverlay() }
-			</CompactCard>
+					{ this.renderActionItems() }
+					{ this.renderOverlay() }
+				</CompactCard>
+				{ this.canRenewDomain() && this.renderDialogs() }
+			</>
 		);
 	}
 }

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import { find, findIndex, get, identity, noop, times, isEmpty } from 'lodash';
+import { find, findIndex, get, identity, isEmpty, keyBy, noop, times } from 'lodash';
 import Gridicon from 'components/gridicon';
 import page from 'page';
 import React from 'react';
@@ -52,6 +52,7 @@ import QuerySitePurchases from 'components/data/query-site-purchases';
 import PopoverCart from 'my-sites/checkout/cart/popover-cart';
 import InfoPopover from 'components/info-popover';
 import ExternalLink from 'components/external-link';
+import { getSitePurchases } from 'state/purchases/selectors';
 
 /**
  * Style dependencies
@@ -520,6 +521,7 @@ export class List extends React.Component {
 			renderAllSites,
 			isDomainOnly,
 			hasSingleSite,
+			purchases,
 		} = this.props;
 
 		const domains =
@@ -547,6 +549,7 @@ export class List extends React.Component {
 				onSelect={ this.handleUpdatePrimaryDomain }
 				onUpgradeClick={ this.goToPlans }
 				shouldUpgradeToMakePrimary={ this.shouldUpgradeToMakeDomainPrimary( domain ) }
+				purchase={ purchases[ domain.subscriptionId ] }
 			/>
 		) );
 
@@ -667,6 +670,7 @@ export default connect(
 		const selectedSite = get( ownProps, 'selectedSite', null );
 		const isOnFreePlan = get( selectedSite, 'plan.is_free', false );
 		const siteCount = get( getSites( state ), 'length', 0 );
+		const purchases = keyBy( getSitePurchases( state, siteId ) || [], 'id' );
 
 		return {
 			currentRoute: getCurrentRoute( state ),
@@ -679,6 +683,7 @@ export default connect(
 			hasSingleSite: siteCount === 1,
 			isOnFreePlan,
 			userCanManageOptions,
+			purchases,
 		};
 	},
 	( dispatch ) => {

--- a/client/my-sites/domains/domain-management/list/list-all.jsx
+++ b/client/my-sites/domains/domain-management/list/list-all.jsx
@@ -102,7 +102,7 @@ class ListAll extends Component {
 	}
 
 	renderDomainItem( domain, index ) {
-		const { currentRoute, domainsDetails, sites, requestingSiteDomains } = this.props;
+		const { currentRoute, domainsDetails, purchases, sites, requestingSiteDomains } = this.props;
 		const domainDetails = this.findDomainDetails( domainsDetails, domain );
 
 		return (
@@ -122,6 +122,7 @@ class ListAll extends Component {
 						! domainDetails && ( requestingSiteDomains[ domain?.blogId ] ?? false )
 					}
 					onClick={ this.handleDomainItemClick }
+					purchase={ purchases[ domainDetails?.subscriptionId ] }
 				/>
 			</React.Fragment>
 		);

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -358,6 +358,7 @@ input[type='radio'].domain-management-list-item__radio {
 	.domain-item__busy-message {
 		font-size: $font-body-small;
 		margin-left: auto;
+		margin-right: 8px;
 	}
 
 	.domain-item__upsell {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds the auto renew toggle button to the domain options.

#### Testing instructions

Verify the following for both the all domains view, and the site domains view

* For domains you have purchased, verify the toggle button appears in the options menu
* Verify the appropriate dialog is shown when disabling auto renew, and that it's functionality is intact
* Check that the payment method dialog appears when no card is linked to the domain purchase, and that the buttons work as expected
