### PR TITLE
P2 signup: use lodash deburr to strip non-ascii chars

### DIFF
--- a/client/signup/steps/p2-site/index.jsx
+++ b/client/signup/steps/p2-site/index.jsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { includes, isEmpty, map } from 'lodash';
+import { includes, isEmpty, map, deburr } from 'lodash';
 import debugFactory from 'debug';
 
 /**
@@ -90,7 +90,9 @@ class P2Site extends React.Component {
 		if ( ! domain ) {
 			return domain;
 		}
-		return domain.replace( /[^a-zA-Z0-9]/g, '' ).toLowerCase();
+		return deburr( domain )
+			.replace( /[^a-zA-Z0-9]/g, '' )
+			.toLowerCase();
 	};
 
 	sanitize = ( fields, onComplete ) => {


### PR DESCRIPTION
@klimeryk originally reported:

> OK, this one is a "nice to have", but something we've done for Domain Search in WPCOM is to try to "recover" as much of the original string/query submitted by the user as possible - not just kill everything that is not a good, ol' ASCII character. So, zażółć would become zazolc instead of za (as it does in this flow).

> Thankfully, it's a very simple change if you have lodash available (which I assume you do if you're in Calypso... or working on JavaScript ;)). They have a super handy deburr method exactly to handle this case: https://lodash.com/docs/4.17.15#deburr

We implement that in this PR.

## Testing instructions

Navigate to `/start/p2` and input various non-ascii characters into the site address field (like čučoriedka, ďateľ, zażółć). Special characters should be stripped but the base one kept.