### PR TITLE
Domain Picker: return empty state for single character query

### DIFF
--- a/packages/domain-picker/src/domain-picker/index.tsx
+++ b/packages/domain-picker/src/domain-picker/index.tsx
@@ -170,7 +170,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 					value={ domainSearch }
 				/>
 			</div>
-			{ domainSearch.trim() ? (
+			{ domainSearch.trim()?.length > 1 ? (
 				<div className="domain-picker__body">
 					{ showDomainCategories && (
 						<div className="domain-picker__aside">

--- a/packages/domain-picker/src/hooks/use-domain-suggestions.ts
+++ b/packages/domain-picker/src/hooks/use-domain-suggestions.ts
@@ -19,7 +19,7 @@ export function useDomainSuggestions(
 
 	return useSelect(
 		( select ) => {
-			if ( ! domainSearch ) {
+			if ( ! domainSearch || domainSearch.length < 2 ) {
 				return;
 			}
 			return select( DOMAIN_SUGGESTIONS_STORE ).getDomainSuggestions( domainSearch, {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Single character search query doesn't return valid TLDs. With this change we'll display empty state for domain search when the search query has less than 2 characters.

#### Testing instructions

* Go to [/new](https://calypso.live/new?branch=update/domain-picker-minimum-search-query-length).
* Reach the domain selection step or use the button from top bar.
* Enter a single character to search for a domain and empty state should be still visible.
* Enter two characters and valid domain suggestions should appear.

Fixes #43855 
