### PR TITLE
Search Preview: rename references to use description instead of snippet variable

### DIFF
--- a/client/components/seo-preview-pane/index.jsx
+++ b/client/components/seo-preview-pane/index.jsx
@@ -113,7 +113,7 @@ const GoogleSite = ( site, frontPageMetaDescription ) => (
 	<SearchPreview
 		title={ site.name }
 		url={ site.URL }
-		snippet={ frontPageMetaDescription || getSeoExcerptForSite( site ) }
+		description={ frontPageMetaDescription || getSeoExcerptForSite( site ) }
 	/>
 );
 
@@ -121,7 +121,7 @@ const GooglePost = ( site, post, frontPageMetaDescription ) => (
 	<SearchPreview
 		title={ get( post, 'seoTitle', '' ) }
 		url={ get( post, 'URL', '' ) }
-		snippet={ frontPageMetaDescription || getSeoExcerptForPost( post ) }
+		description={ frontPageMetaDescription || getSeoExcerptForPost( post ) }
 	/>
 );
 

--- a/client/components/seo/search-preview/index.jsx
+++ b/client/components/seo/search-preview/index.jsx
@@ -13,7 +13,7 @@ import { firstValid, hardTruncation, shortEnough, truncatedAtSpace } from '../he
 import './style.scss';
 
 const TITLE_LENGTH = 63;
-const SNIPPET_LENGTH = 160;
+const DESCRIPTION_LENGTH = 160;
 
 const googleTitle = firstValid(
 	shortEnough( TITLE_LENGTH ),
@@ -21,15 +21,15 @@ const googleTitle = firstValid(
 	hardTruncation( TITLE_LENGTH )
 );
 
-const googleSnippet = firstValid(
-	shortEnough( SNIPPET_LENGTH ),
-	truncatedAtSpace( SNIPPET_LENGTH - 80, SNIPPET_LENGTH + 10 ),
-	hardTruncation( SNIPPET_LENGTH )
+const googleDescription = firstValid(
+	shortEnough( DESCRIPTION_LENGTH ),
+	truncatedAtSpace( DESCRIPTION_LENGTH - 80, DESCRIPTION_LENGTH + 10 ),
+	hardTruncation( DESCRIPTION_LENGTH )
 );
 
 const googleUrl = hardTruncation( 79 );
 
-export default function SearchPreview( { snippet, title, url } ) {
+export default function SearchPreview( { description, title, url } ) {
 	const translate = useTranslate();
 
 	return (
@@ -38,7 +38,9 @@ export default function SearchPreview( { snippet, title, url } ) {
 			<div className="search-preview__display">
 				<div className="search-preview__title">{ googleTitle( title ) }</div>
 				<div className="search-preview__url">{ googleUrl( url ) } ▾</div>
-				<div className="search-preview__snippet">{ googleSnippet( snippet || '' ) }</div>
+				<div className="search-preview__description">
+					{ googleDescription( description || '' ) }
+				</div>
 			</div>
 		</div>
 	);
@@ -47,11 +49,11 @@ export default function SearchPreview( { snippet, title, url } ) {
 SearchPreview.propTypes = {
 	title: PropTypes.string,
 	url: PropTypes.string,
-	snippet: PropTypes.string,
+	description: PropTypes.string,
 };
 
 SearchPreview.defaultProps = {
 	title: '',
 	url: '',
-	snippet: '',
+	description: '',
 };

--- a/client/components/seo/search-preview/style.scss
+++ b/client/components/seo/search-preview/style.scss
@@ -50,7 +50,7 @@
 	max-width: 616px;
 }
 
-.search-preview__snippet {
+.search-preview__description {
 	color: #545454; // matching Google results
 	font-size: $font-body-small;
 	line-height: 1.4;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Rename `SearchPreview` component references to use description instead of snippet variable

#### Testing instructions

**On Master**
- Run yarn && yarn start to build all the things. Wait for Calypso to boot. Goto http://calypso.localhost:3000/.
- On a Business site, create a new Post with some content and a title and click "Preview".
- Toggle the Preview to "Search and Social" using the dropdown.
- You should see the post preview for Google Search

**On this PR branch**
- Checkout this branch.
- Run yarn && yarn start to build all the things. Wait for Calypso to boot. Goto http://calypso.localhost:3000/.
- On a Business site, create a new Post with some content and a title and click "Preview".
- Toggle the Preview to "Search and Social" using the dropdown.
- You should see the post preview for Google Search with no errors.
- Nothing should brake in the console or be visually different


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

![](https://cln.sh/1d9CAO+)

Fixes #44308
