### PR TITLE
Show the provisioning progress bar when a user buys Anti-Spam

### DIFF
--- a/client/lib/products-values/index.js
+++ b/client/lib/products-values/index.js
@@ -13,6 +13,7 @@ import {
 	JETPACK_BACKUP_PRODUCTS,
 	JETPACK_PRODUCTS_LIST,
 	JETPACK_SCAN_PRODUCTS,
+	JETPACK_ANTI_SPAM_PRODUCTS,
 } from './constants';
 import { PRODUCTS_LIST } from './products-list';
 import {
@@ -227,11 +228,22 @@ export function isJetpackScanSlug( productSlug ) {
 	return JETPACK_SCAN_PRODUCTS.includes( productSlug );
 }
 
+export function isJetpackAntiSpamSlug( productSlug ) {
+	return JETPACK_ANTI_SPAM_PRODUCTS.includes( productSlug );
+}
+
 export function isJetpackScan( product ) {
 	product = formatProduct( product );
 	assertValidProduct( product );
 
 	return isJetpackScanSlug( product.product_slug );
+}
+
+export function isJetpackAntiSpam( product ) {
+	product = formatProduct( product );
+	assertValidProduct( product );
+
+	return isJetpackAntiSpamSlug( product.product_slug );
 }
 
 export function isJetpackCloudProductSlug( productSlug ) {

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -7,7 +7,6 @@ import { localize } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { format as formatUrl, parse as parseUrl } from 'url';
 
 /**
  * Internal dependencies
@@ -43,6 +42,7 @@ import {
 	isJetpackScanSlug,
 	isJetpackBackupSlug,
 	isJetpackCloudProductSlug,
+	isJetpackAntiSpamSlug,
 } from 'lib/products-values';
 import {
 	JETPACK_PRODUCTS_LIST,
@@ -104,7 +104,7 @@ import {
 	retrieveSignupDestination,
 	clearSignupDestinationCookie,
 } from 'signup/utils';
-import { isExternal, addQueryArgs } from 'lib/url';
+import { isExternal, addQueryArgs, format as formatUrl, getUrlParts as parseUrl } from 'lib/url';
 import { withLocalizedMoment } from 'components/localized-moment';
 import { abtest } from 'lib/abtest';
 import isPrivateSite from 'state/selectors/is-private-site';
@@ -422,13 +422,21 @@ export class Checkout extends React.Component {
 		// - does not have a receipt number but has an item in cart(as in the case of paying with a redirect payment type)
 		if ( selectedSiteSlug && ( ! isReceiptEmpty || ! isCartEmpty ) ) {
 			const isJetpackProduct = product && isJetpackProductSlug( product );
+			const isJetpackAntiSpam = product && isJetpackAntiSpamSlug( product );
+
+			let installQuery = '&install=all';
+
+			if ( isJetpackAntiSpam ) {
+				installQuery = '&install=akismet';
+			}
+
 			// If we just purchased a Jetpack product, redirect to the my plans page.
 			if ( isJetpackNotAtomic && isJetpackProduct ) {
-				return `/plans/my-plan/${ selectedSiteSlug }?thank-you&product=${ product }`;
+				return `/plans/my-plan/${ selectedSiteSlug }?thank-you&product=${ product }${ installQuery }`;
 			}
 			// If we just purchased a Jetpack plan (not a Jetpack product), redirect to the Jetpack onboarding plugin install flow.
 			if ( isJetpackNotAtomic ) {
-				return `/plans/my-plan/${ selectedSiteSlug }?thank-you&install=all`;
+				return `/plans/my-plan/${ selectedSiteSlug }?thank-you${ installQuery }`;
 			}
 
 			return selectedFeature && isValidFeatureKey( selectedFeature )

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -7,6 +7,8 @@ import { localize } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
+import { format as formatUrl, parse as parseUrl } from 'url';
 
 /**
  * Internal dependencies
@@ -104,7 +106,7 @@ import {
 	retrieveSignupDestination,
 	clearSignupDestinationCookie,
 } from 'signup/utils';
-import { isExternal, addQueryArgs, format as formatUrl, getUrlParts as parseUrl } from 'lib/url';
+import { isExternal, addQueryArgs } from 'lib/url';
 import { withLocalizedMoment } from 'components/localized-moment';
 import { abtest } from 'lib/abtest';
 import isPrivateSite from 'state/selectors/is-private-site';

--- a/client/my-sites/plans/current-plan/current-plan-thank-you/anti-spam-thank-you.tsx
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you/anti-spam-thank-you.tsx
@@ -13,10 +13,12 @@ import ThankYou, { ThankYouCtaType } from './thank-you';
 import getJetpackProductInstallProgress from 'state/selectors/get-jetpack-product-install-progress';
 import { getSelectedSiteId } from 'state/ui/selectors';
 
-const ThankYouCta: ThankYouCtaType = ( { dismissUrl, recordThankYouClick } ) => {
+const ThankYouCta: ThankYouCtaType = ( { siteAdminUrl, recordThankYouClick } ) => {
 	const translate = useTranslate();
+	const jetpackDashboard = siteAdminUrl + 'admin.php?page=jetpack#/dashboard';
+
 	return (
-		<Button primary href={ dismissUrl } onClick={ () => recordThankYouClick( 'anti-spam' ) }>
+		<Button primary href={ jetpackDashboard } onClick={ () => recordThankYouClick( 'anti-spam' ) }>
 			{ translate( 'Go back to your site' ) }
 		</Button>
 	);
@@ -41,11 +43,7 @@ const AntiSpamProductThankYou = ( { installProgress } ): ReactElement => {
 					) }
 				</p>
 				{ ! isInstalled && (
-					<ProgressBar
-						isPulsing={ ! isInstalled }
-						total={ 100 }
-						value={ Math.max( installProgress, 10 ) }
-					/>
+					<ProgressBar isPulsing={ true } total={ 100 } value={ Math.max( installProgress, 10 ) } />
 				) }
 			</>
 		</ThankYou>

--- a/client/my-sites/plans/current-plan/current-plan-thank-you/anti-spam-thank-you.tsx
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you/anti-spam-thank-you.tsx
@@ -3,12 +3,15 @@
  */
 import React, { ReactElement } from 'react';
 import { useTranslate } from 'i18n-calypso';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
-import { Button } from '@automattic/components';
+import { Button, ProgressBar } from '@automattic/components';
 import ThankYou, { ThankYouCtaType } from './thank-you';
+import getJetpackProductInstallProgress from 'state/selectors/get-jetpack-product-install-progress';
+import { getSelectedSiteId } from 'state/ui/selectors';
 
 const ThankYouCta: ThankYouCtaType = ( { dismissUrl, recordThankYouClick } ) => {
 	const translate = useTranslate();
@@ -19,22 +22,41 @@ const ThankYouCta: ThankYouCtaType = ( { dismissUrl, recordThankYouClick } ) => 
 	);
 };
 
-const AntiSpamProductThankYou = (): ReactElement => {
+const AntiSpamProductThankYou = ( { installProgress } ): ReactElement => {
 	const translate = useTranslate();
+	const isInstalled = installProgress === 100;
+
 	return (
 		<ThankYou
 			illustration="/calypso/images/illustrations/thankYou.svg"
 			title={ translate( 'Say goodbye to spam!' ) }
-			ThankYouCtaComponent={ ThankYouCta }
+			showHideMessage={ ! isInstalled }
+			ThankYouCtaComponent={ isInstalled && ThankYouCta }
 		>
-			<p>{ translate( "We're setting up Jetpack Anti-Spam for you right now." ) }</p>
-			<p>
-				{ translate(
-					"In no time you'll be able to enjoy more peace of mind and provide a better experience to your visitors."
+			<>
+				<p>{ translate( "We're setting up Jetpack Anti-Spam for you right now." ) }</p>
+				<p>
+					{ translate(
+						"In no time you'll be able to enjoy more peace of mind and provide a better experience to your visitors."
+					) }
+				</p>
+				{ ! isInstalled && (
+					<ProgressBar
+						isPulsing={ ! isInstalled }
+						total={ 100 }
+						value={ Math.max( installProgress, 10 ) }
+					/>
 				) }
-			</p>
+			</>
 		</ThankYou>
 	);
 };
 
-export default AntiSpamProductThankYou;
+export default connect( ( state ) => {
+	const siteId = getSelectedSiteId( state );
+	const installProgress = siteId && getJetpackProductInstallProgress( state, siteId );
+
+	return {
+		installProgress,
+	};
+} )( AntiSpamProductThankYou );

--- a/client/my-sites/plans/current-plan/jetpack-checklist/index.tsx
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/index.tsx
@@ -19,7 +19,8 @@ import JetpackChecklistHeader from './header';
 import QueryJetpackProductInstallStatus from 'components/data/query-jetpack-product-install-status';
 import QueryRewindState from 'components/data/query-rewind-state';
 import QuerySiteChecklist from 'components/data/query-site-checklist';
-import { format as formatUrl, getUrlParts as parseUrl } from 'lib/url';
+// eslint-disable-next-line no-restricted-imports
+import { format as formatUrl, parse as parseUrl } from 'url';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSlug, getCustomizerUrl, getSiteProducts } from 'state/sites/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';

--- a/client/my-sites/plans/current-plan/jetpack-checklist/index.tsx
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/index.tsx
@@ -19,14 +19,15 @@ import JetpackChecklistHeader from './header';
 import QueryJetpackProductInstallStatus from 'components/data/query-jetpack-product-install-status';
 import QueryRewindState from 'components/data/query-rewind-state';
 import QuerySiteChecklist from 'components/data/query-site-checklist';
-import { format as formatUrl, parse as parseUrl } from 'url';
+import { format as formatUrl, getUrlParts as parseUrl } from 'lib/url';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
-import { getSiteSlug, getCustomizerUrl } from 'state/sites/selectors';
+import { getSiteSlug, getCustomizerUrl, getSiteProducts } from 'state/sites/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { requestGuidedTour } from 'state/ui/guided-tours/actions';
 import { URL } from 'types';
 import { getSitePlanSlug } from 'state/sites/plans/selectors';
 import { isBusinessPlan, isPremiumPlan } from 'lib/plans';
+import { isJetpackAntiSpam } from 'lib/products-values';
 import withTrackingTool from 'lib/analytics/with-tracking-tool';
 import { Button, Card } from '@automattic/components';
 import JetpackProductInstall from 'my-sites/plans/current-plan/jetpack-product-install';
@@ -124,6 +125,7 @@ class JetpackChecklist extends PureComponent< Props & LocalizeProps > {
 			isPaidPlan,
 			isPremium,
 			isProfessional,
+			hasAntiSpam,
 			productInstallStatus,
 			rewindState,
 			siteId,
@@ -137,10 +139,12 @@ class JetpackChecklist extends PureComponent< Props & LocalizeProps > {
 		const isRewindAvailable = rewindState !== 'uninitialized' && rewindState !== 'unavailable';
 		const isRewindUnavailable = rewindState === 'unavailable';
 
+		const hasJetpackProductInstallation = isPaidPlan || hasAntiSpam;
+
 		return (
 			<Fragment>
 				{ siteId && <QuerySiteChecklist siteId={ siteId } /> }
-				{ isPaidPlan && <QueryJetpackProductInstallStatus siteId={ siteId } /> }
+				{ hasJetpackProductInstallation && <QueryJetpackProductInstallStatus siteId={ siteId } /> }
 				{ isPaidPlan && <QueryRewindState siteId={ siteId } /> }
 				<JetpackProductInstall />
 
@@ -198,7 +202,7 @@ class JetpackChecklist extends PureComponent< Props & LocalizeProps > {
 						/>
 					) }
 
-					{ isPaidPlan && productInstallStatus && (
+					{ hasJetpackProductInstallation && productInstallStatus && (
 						<Task
 							id="jetpack_akismet"
 							title={ translate( "We're automatically turning on Anti-spam." ) }
@@ -336,49 +340,56 @@ class JetpackChecklist extends PureComponent< Props & LocalizeProps > {
 	}
 }
 
-const connectComponent = connect(
-	( state ) => {
-		const site = getSelectedSite( state );
-		const siteId = getSelectedSiteId( state );
-		const productInstallStatus = getJetpackProductInstallStatus( state, siteId );
-		const rewindState = get( getRewindState( state, siteId ), 'state', 'uninitialized' );
+function mapStateToProps( state ) {
+	const site = getSelectedSite( state );
+	const siteId = getSelectedSiteId( state );
+	const productInstallStatus = getJetpackProductInstallStatus( state, siteId );
+	const rewindState = get( getRewindState( state, siteId ), 'state', 'uninitialized' );
 
-		// Link to "My Plan" page in Jetpack
-		let wpAdminUrl = get( site, 'options.admin_url' );
-		wpAdminUrl = wpAdminUrl
-			? formatUrl( {
-					...parseUrl( wpAdminUrl + 'admin.php' ),
-					query: { page: 'jetpack' },
-					hash: '/my-plan',
-			  } )
-			: undefined;
+	// Link to "My Plan" page in Jetpack
+	let wpAdminUrl = get( site, 'options.admin_url' );
+	wpAdminUrl = wpAdminUrl
+		? formatUrl( {
+				...parseUrl( wpAdminUrl + 'admin.php' ),
+				query: { page: 'jetpack' },
+				hash: '/my-plan',
+		  } )
+		: undefined;
 
-		const planSlug = getSitePlanSlug( state, siteId );
-		const isPremium = !! planSlug && isPremiumPlan( planSlug );
-		const isProfessional = ! isPremium && !! planSlug && isBusinessPlan( planSlug );
-		const isPaidPlan = isPremium || isProfessional || isSiteOnPaidPlan( state, siteId );
+	const planSlug = getSitePlanSlug( state, siteId );
+	const isPremium = !! planSlug && isPremiumPlan( planSlug );
+	const isProfessional = ! isPremium && !! planSlug && isBusinessPlan( planSlug );
+	const isPaidPlan = isPremium || isProfessional || isSiteOnPaidPlan( state, siteId );
 
-		return {
-			akismetFinished: productInstallStatus && productInstallStatus.akismet_status === 'installed',
-			vaultpressFinished:
-				productInstallStatus &&
-				includes( [ 'installed', 'skipped' ], productInstallStatus.vaultpress_status ),
-			widgetCustomizerPaneUrl: siteId ? getCustomizerUrl( state, siteId, 'widgets' ) : null,
-			isPremium,
-			isProfessional,
-			isPaidPlan,
-			rewindState,
-			productInstallStatus,
-			siteId,
-			siteSlug: getSiteSlug( state, siteId ),
-			taskStatuses: get( getSiteChecklist( state, siteId ), 'tasks' ),
-			wpAdminUrl,
-		};
-	},
-	{
-		recordTracksEvent,
-		requestGuidedTour,
-	}
-);
+	const siteProducts = getSiteProducts( state, siteId );
+	const hasAntiSpam =
+		siteProducts && siteProducts.filter( ( product ) => isJetpackAntiSpam( product ) ).length > 0;
 
-export default connectComponent( localize( withTrackingTool( 'HotJar' )( JetpackChecklist ) ) );
+	return {
+		akismetFinished: productInstallStatus && productInstallStatus.akismet_status === 'installed',
+		vaultpressFinished:
+			productInstallStatus &&
+			includes( [ 'installed', 'skipped' ], productInstallStatus.vaultpress_status ),
+		widgetCustomizerPaneUrl: siteId ? getCustomizerUrl( state, siteId, 'widgets' ) : null,
+		isPremium,
+		isProfessional,
+		isPaidPlan,
+		hasAntiSpam,
+		rewindState,
+		productInstallStatus,
+		siteId,
+		siteSlug: getSiteSlug( state, siteId ),
+		taskStatuses: get( getSiteChecklist( state, siteId ), 'tasks' ),
+		wpAdminUrl,
+	};
+}
+
+const mapDispatchToProps = {
+	recordTracksEvent,
+	requestGuidedTour,
+};
+
+export default connect(
+	mapStateToProps,
+	mapDispatchToProps
+)( localize( withTrackingTool( 'HotJar' )( JetpackChecklist ) ) );

--- a/client/my-sites/plans/current-plan/jetpack-product-install/index.tsx
+++ b/client/my-sites/plans/current-plan/jetpack-product-install/index.tsx
@@ -317,7 +317,9 @@ export class JetpackProductInstall extends Component< Props, State > {
 
 		return (
 			<Fragment>
-				<Interval period={ PLUGIN_KEY_REFETCH_INTERVAL } onTick={ this.fetchPluginKeys } />
+				{ progressComplete !== 100 && (
+					<Interval period={ PLUGIN_KEY_REFETCH_INTERVAL } onTick={ this.fetchPluginKeys } />
+				) }
 				{ hasErrorInstalling && (
 					<Notice
 						status="is-error"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This change adds a progress bar to the Anti-Spam Welcome message. This checks the status of the installation triggered in the backend after the purchase.

While the process is running:
![image](https://user-images.githubusercontent.com/9832440/88070705-e65c4500-cb6a-11ea-9593-e1e9f3bd6bac.png)

When the process ends, you will see:
![image](https://user-images.githubusercontent.com/9832440/88070524-af862f00-cb6a-11ea-9ca2-14fe3434e696.png)

And when you click on the button, you can check that the Anti-Spam installation is completed:
![image](https://user-images.githubusercontent.com/9832440/88070982-33d8b200-cb6b-11ea-98ab-0d62c6595e82.png)

#### Testing instructions

- Get a JN site and connect to your account
- Buy Anti-Spam product
- See the provisioning progress working, and at the end of the process, the button "Go back to your site" will appear
- Click on the button and see that the Anti-Spam installation is completed like you see in the screenshot.
