### PR TITLE
wp-link/dialog: get media item from redux store

### DIFF
--- a/client/components/tinymce/plugins/wplink/dialog.jsx
+++ b/client/components/tinymce/plugins/wplink/dialog.jsx
@@ -12,7 +12,6 @@ import { find } from 'lodash';
  * Internal dependencies
  */
 import { deserialize } from 'lib/media-serialization';
-import MediaStore from 'lib/media/store';
 import { url as mediaUrl } from 'lib/media/utils';
 import { Dialog } from '@automattic/components';
 import FormTextInput from 'components/forms/form-text-input';
@@ -26,6 +25,7 @@ import { getSitePosts } from 'state/posts/selectors';
 import { decodeEntities } from 'lib/formatting';
 import { recordEditorEvent, recordEditorStat } from 'state/posts/stats';
 import Gridicon from 'components/gridicon';
+import { getMediaItem } from 'state/media/thunks';
 
 /**
  * Module variables
@@ -162,7 +162,7 @@ class LinkDialog extends React.Component {
 			parsedImage = deserialize( selectedNode );
 			if ( this.props.site && parsedImage.media.ID ) {
 				knownImage =
-					MediaStore.get( this.props.site.ID, parsedImage.media.ID ) || parsedImage.media;
+					this.props.getMediaItem( this.props.site.ID, parsedImage.media.ID ) || parsedImage.media;
 				return mediaUrl( knownImage, {
 					size: 'full',
 				} );
@@ -371,5 +371,5 @@ export default connect(
 			sitePosts: selectedSite ? getSitePosts( state, selectedSite.ID ) : null,
 		};
 	},
-	{ recordEditorEvent, recordEditorStat }
+	{ recordEditorEvent, recordEditorStat, getMediaItem }
 )( localize( LinkDialog ) );

--- a/client/state/media/thunks/get-media-item.js
+++ b/client/state/media/thunks/get-media-item.js
@@ -1,0 +1,20 @@
+/**
+ * Internal dependencies
+ */
+import getMediaItem from 'state/selectors/get-media-item';
+
+/**
+ * Returns a media item from the redux store
+ *
+ * @param {number} siteId site identifier
+ * @param {number} mediaId media item identifier
+ */
+export default function ( siteId, mediaId ) {
+	/* @TODO: this function was introduced as a workaround to be able to
+	 * access a media item from the redux store programatically in
+	 * components/tinymce/plugins/wplink/dialog.jsx:165 – ideally it
+	 * shouldn't be used anywhere else where we can get data from the
+	 * redux store via connect() method */
+
+	return ( dispatch, getState ) => getMediaItem( getState(), siteId, mediaId );
+}

--- a/client/state/media/thunks/index.js
+++ b/client/state/media/thunks/index.js
@@ -7,3 +7,4 @@ export { deleteMedia } from './delete-media';
 export { fetchMediaItem } from './fetch-media-item';
 export { addWoocommerceProductImage } from './add-woocommerce-product-image';
 export { fetchNextMediaPage } from './fetch-next-media-page';
+export { default as getMediaItem } from './get-media-item';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* wp-link/dialog: use thunk to select media item from redux store (due to its programmatic usage, otherwise we'd use the `connect()` method)

#### Testing instructions

* Open a post in the classic post editor which contains an image or create a new post and hit _Save_
* Reload your browser tab
* Now select the image and hit the link button
* Make sure the image URL is shown in the URL field

related to #43663 
