### PR TITLE
Jetpack Connect: do not fire track events related to using wpcom site during the Search purchase flow.

### DIFF
--- a/client/jetpack-connect/jetpack-connection.jsx
+++ b/client/jetpack-connect/jetpack-connection.jsx
@@ -103,7 +103,7 @@ const jetpackConnection = ( WrappedComponent ) => {
 			if ( this.state.waitingForSites && ! this.props.isRequestingSites ) {
 				// eslint-disable-next-line react/no-did-update-set-state
 				this.setState( { waitingForSites: false } );
-				this.checkUrl( url );
+				this.checkUrl( url, status === IS_DOT_COM_GET_SEARCH );
 			}
 
 			if (
@@ -164,8 +164,8 @@ const jetpackConnection = ( WrappedComponent ) => {
 			);
 		}
 
-		checkUrl( url ) {
-			return this.props.checkUrl( url, !! this.props.getJetpackSiteByUrl( url ) );
+		checkUrl( url, isSearch ) {
+			return this.props.checkUrl( url, !! this.props.getJetpackSiteByUrl( url ), isSearch );
 		}
 
 		checkProperty( propName ) {

--- a/client/my-sites/purchase-product/search.jsx
+++ b/client/my-sites/purchase-product/search.jsx
@@ -75,7 +75,7 @@ export class SearchPurchase extends Component {
 
 	UNSAFE_componentWillMount() {
 		if ( this.props.url ) {
-			this.checkUrl( cleanUrl( this.props.url ) );
+			this.checkUrl( cleanUrl( this.props.url ), true );
 		}
 		if ( ! this.props.isLoggedIn ) {
 			this.goToRemoteInstall( JPC_PATH_REMOTE_INSTALL );
@@ -115,8 +115,8 @@ export class SearchPurchase extends Component {
 		this.getCandidateSites( url );
 	};
 
-	checkUrl( url ) {
-		return this.props.checkUrl( url, !! this.props.getJetpackSiteByUrl( url ) );
+	checkUrl( url, isSearch ) {
+		return this.props.checkUrl( url, !! this.props.getJetpackSiteByUrl( url ), isSearch );
 	}
 
 	handleUrlSubmit = () => {
@@ -129,7 +129,7 @@ export class SearchPurchase extends Component {
 		if ( this.props.isRequestingSites ) {
 			this.setState( { waitingForSites: true } );
 		} else {
-			this.checkUrl( this.state.currentUrl );
+			this.checkUrl( this.state.currentUrl, true );
 		}
 	};
 

--- a/client/state/jetpack-connect/actions/check-url.js
+++ b/client/state/jetpack-connect/actions/check-url.js
@@ -23,7 +23,7 @@ import 'state/jetpack-connect/init';
 const _fetching = {};
 const debug = debugFactory( 'calypso:jetpack-connect:actions' );
 
-export function checkUrl( url, isUrlOnSites ) {
+export function checkUrl( url, isUrlOnSites, isPurchasingSearch ) {
 	return ( dispatch ) => {
 		if ( _fetching[ url ] ) {
 			return;
@@ -73,7 +73,11 @@ export function checkUrl( url, isUrlOnSites ) {
 
 				let errorCode = null;
 				let instructionsType = null;
-				if ( data && data.isWordPressDotCom ) {
+				let isSearch = true;
+				if ( isPurchasingSearch ) {
+					isSearch = false;
+				}
+				if ( data && data.isWordPressDotCom && isSearch ) {
 					errorCode = 'calypso_jpc_error_wpdotcomsite';
 				} else if ( data && ! data.exists ) {
 					errorCode = 'calypso_jpc_error_notexists';

--- a/client/state/jetpack-connect/actions/check-url.js
+++ b/client/state/jetpack-connect/actions/check-url.js
@@ -23,7 +23,7 @@ import 'state/jetpack-connect/init';
 const _fetching = {};
 const debug = debugFactory( 'calypso:jetpack-connect:actions' );
 
-export function checkUrl( url, isUrlOnSites, isPurchasingSearch ) {
+export function checkUrl( url, isUrlOnSites, allowWPCOMSite ) {
 	return ( dispatch ) => {
 		if ( _fetching[ url ] ) {
 			return;
@@ -74,7 +74,7 @@ export function checkUrl( url, isUrlOnSites, isPurchasingSearch ) {
 				let errorCode = null;
 				let instructionsType = null;
 				let isSearch = true;
-				if ( isPurchasingSearch ) {
+				if ( allowWPCOMSite ) {
 					isSearch = false;
 				}
 				if ( data && data.isWordPressDotCom && isSearch ) {


### PR DESCRIPTION


#### Changes proposed in this Pull Request

* remove the `calypso_jpc_error_wpdotcomsite` event when purchasing Search for WPCOM sites

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* purchase Search for WP.com site  via `/purchase-product/jetpack_search`
* verify no `calypso_jpc_error_wpdotcomsite` event fired
* connect via `jetpack/connect` for a WP.com site 
* verify that the event fires as the notice around Jetpack being part of WP.com sites appears. 

