### PR TITLE
My Sites: prevent double slash in URL when performing redirects on single-site account

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -351,7 +351,8 @@ export function siteSelection( context, next ) {
 		const primarySiteId = getPrimarySiteId( getState() );
 
 		const redirectToPrimary = ( primarySiteSlug ) => {
-			let redirectPath = `${ context.pathname }/${ primarySiteSlug }`;
+			const pathname = context.pathname.replace( /\/?$/, '/' ); // append trailing slash if not present
+			let redirectPath = `${ pathname }${ primarySiteSlug }`;
 			if ( context.querystring ) {
 				redirectPath += `?${ context.querystring }`;
 			}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This pull request resolves an issue where a user with only one site on their account would see issues when navigating through certain redirects that caused an unintentional doubling of forward slashes in the redirecting URL. This occasionally broke functionality on the redirected page.
    * For example, `/plans` would redirect correctly to `/plans/{siteDomain}`, but `/plans/` would redirect incorrectly to `/plans//{siteDomain}`, which would then break.


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Log into an account with only one site associated with it.
* While logged into Calypso, navigate to `wordpress.com/plans/`.
* Verify that you are navigated as expected to `wordpress.com/plans/{siteDomain}` for the site on the account.

Fixes #42628
