### PR TITLE
Adds reskinned design for the plans step

### DIFF
--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -611,7 +611,7 @@ export class PlanFeatures extends Component {
 				key={ index }
 				description={ description }
 				hideInfoPopover={ feature.hideInfoPopover }
-				hideGridicon={ this.props.withScroll }
+				hideGridicon={ this.props.isReskinned ? false : this.props.withScroll }
 			>
 				<span className="plan-features__item-info">
 					<span className="plan-features__item-title">{ feature.getTitle() }</span>

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -76,6 +76,7 @@ import getPreviousRoute from 'state/selectors/get-previous-route';
 import { getTld } from 'lib/domains';
 import { isDiscountActive } from 'state/selectors/get-active-discount.js';
 import { selectSiteId as selectHappychatSiteId } from 'state/help/actions';
+import { abtest } from 'lib/abtest';
 
 /**
  * Style dependencies
@@ -147,6 +148,7 @@ export class PlansFeaturesMain extends Component {
 			siteId,
 			plansWithScroll,
 			customHeader,
+			isReskinned,
 		} = this.props;
 
 		const plans = this.getPlansForPlanFeatures();
@@ -203,6 +205,7 @@ export class PlansFeaturesMain extends Component {
 						availablePlans,
 					} ) }
 					siteId={ siteId }
+					isReskinned={ isReskinned }
 				/>
 			</div>
 		);
@@ -428,7 +431,7 @@ export class PlansFeaturesMain extends Component {
 	};
 
 	renderFreePlanBanner() {
-		const { hideFreePlan, translate, flowName, isInSignup, customHeader } = this.props;
+		const { hideFreePlan, translate, flowName, isInSignup, customHeader, isReskinned } = this.props;
 		const className = 'is-free-plan';
 		const callToAction =
 			isInSignup && flowName === 'launch-site'
@@ -442,8 +445,12 @@ export class PlansFeaturesMain extends Component {
 		return (
 			<div className="plans-features-main__banner">
 				<div className="plans-features-main__banner-content">
-					{ translate( 'Not sure yet?' ) }
-					<Button className={ className } onClick={ this.handleFreePlanButtonClick } borderless>
+					<span>{ translate( 'Not sure yet?' ) }</span>
+					<Button
+						className={ className }
+						onClick={ this.handleFreePlanButtonClick }
+						borderless={ ! isReskinned }
+					>
 						{ callToAction }
 					</Button>
 				</div>
@@ -592,6 +599,7 @@ PlansFeaturesMain.propTypes = {
 	plansWithScroll: PropTypes.bool,
 	planTypes: PropTypes.array,
 	customHeader: PropTypes.node,
+	isReskinned: PropTypes.bool,
 };
 
 PlansFeaturesMain.defaultProps = {
@@ -606,6 +614,7 @@ PlansFeaturesMain.defaultProps = {
 	siteSlug: '',
 	withWPPlanTabs: false,
 	plansWithScroll: false,
+	isReskinned: false,
 };
 
 export default connect(
@@ -618,6 +627,11 @@ export default connect(
 			selectedPlan: props.selectedPlan,
 			currentPlan,
 		} );
+
+		const isReskinned =
+			props.isInSignup &&
+			'onboarding' === props.flowName &&
+			'reskinned' === abtest( 'reskinSignupFlow' );
 
 		return {
 			// This is essentially a hack - discounts are the only endpoint that we can rely on both on /plans and
@@ -635,6 +649,7 @@ export default connect(
 			siteId,
 			siteSlug: getSiteSlug( state, get( props.site, [ 'ID' ] ) ),
 			sitePlanSlug: currentPlan && currentPlan.product_slug,
+			isReskinned,
 		};
 	},
 	{

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -76,7 +76,7 @@ import getPreviousRoute from 'state/selectors/get-previous-route';
 import { getTld } from 'lib/domains';
 import { isDiscountActive } from 'state/selectors/get-active-discount.js';
 import { selectSiteId as selectHappychatSiteId } from 'state/help/actions';
-import { abtest } from 'lib/abtest';
+import { getABTestVariation } from 'lib/abtest';
 
 /**
  * Style dependencies
@@ -628,10 +628,7 @@ export default connect(
 			currentPlan,
 		} );
 
-		const isReskinned =
-			props.isInSignup &&
-			'onboarding' === props.flowName &&
-			'reskinned' === abtest( 'reskinSignupFlow' );
+		const isReskinned = 'reskinned' === getABTestVariation( 'reskinSignupFlow' );
 
 		return {
 			// This is essentially a hack - discounts are the only endpoint that we can rely on both on /plans and

--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -101,43 +101,133 @@
 	color: var( --color-text-subtle );
 }
 
-body.is-section-signup.is-white-signup .plans-features-main {
-	.plans-features-main__banner-content {
-		box-shadow: none;
-		display: flex;
-		align-items: center;
-		justify-content: center;
+/**
+ * Styles for design reskin
+ * The `is-white-signup` class is attached to the body when the user is assigned the `reskinned` group of the `reskinSignupFlow` a/b test
+ */
+body.is-section-signup.is-white-signup {
+	.signup__step.is-plans .formatted-header {
+		margin-bottom: 30px;
+	}
 
-		.is-free-plan {
-			padding: 12px 32px;
-			margin-left: 12px;
-			border-radius: 4px;
-			font-weight: 400;
+	.plans-features-main {
+		.plans-features-main__group.is-wpcom {
+			padding-top: 0;
+		}
+	
+		.plans-features-main__banner-content {
+			box-shadow: none;
+			display: flex;
+			align-items: center;
+			justify-content: center;
+	
+			.is-free-plan {
+				padding: 12px 32px;
+				margin-left: 12px;
+				border-radius: 4px;
+				font-weight: 400;
+			}
+		}
+	
+		.plan-features__header {
+			border-top: 1px solid #e2e4e7;
+			border-bottom: none;
+			border-radius: 0;
+			padding: 20px;
+	
+			.plan-features__header-title {
+				font-size: 18px;
+			}
+	
+			.plan-features__audience {
+				color: #646970;
+				font-weight: normal;
+			}
+	
+			.plan-pill {
+				text-transform: none;
+				background: var( --color-text );
+				color: var( --color-text-inverted );
+				font-size: 13px;
+				left: 20px;
+				padding: 2px 8px 3px;
+			}
+		}
+	
+		.plan-features__scroller-container {
+			.plan-features__scroll-button {
+				background: var( --color-text );
+				color: var( --color-text-inverted );
+				&[disabled] {
+					display: none;
+				}
+			}
+			.plan-features__scroll-indicator-dot {
+				background: var( --color-neutral-5 );
+				&.is-highlighted {
+					background: var( --color-neutral-100 );
+				}
+			}
+	
+			.plan-features__table {
+				border-spacing: 0;
+				border-collapse: collapse;
+		
+				tbody:first-child tr {
+					border-top-left-radius: 5px;
+					border-top-right-radius: 5px;
+				}
+		
+				.plan-features__table-item {
+					border-left: 1px solid #e2e4e7;
+					border-right: 1px solid #e2e4e7;
+					
+					.plan-features__description {
+						color: var( --color-neutral-60-rgb );
+						padding-bottom: 42px;
+					}
+				}
+			
+				.plan-features__pricing {
+					border-color: #e2e4e7;
+		
+					.plan-price {
+						text-align: left;
+						font-size: 32px;
+						color: var( --color-neutral-100 );
+						margin-top: 15px;
+						
+						.plan-price__currency-symbol {
+							vertical-align: initial;
+							font-size: 32px;
+							color: var( --color-neutral-100 );
+						}
+					}
+		
+					.plan-features__header-billing-info {
+						text-align: left;
+						font-size: 10px;
+						color: var( --color-neutral-50 );
+						font-weight: 400;
+					}
+				}
+			
+				.plan-features__row {
+					border-top: none;
+					border-bottom: none;
+				}
+			
+				.plan-features__item-checkmark {
+					fill: #00a32a;
+				}
+		
+				.plan-features__item-tip-info {
+					.gridicon {
+						fill: #ccced0;
+					}
+				}
+			}
 		}
 	}
 
-	.plan-features__header {
-		border-top: 1px solid #e2e4e7;
-		border-left: 1px solid #e2e4e7;
-		border-right: 1px solid #e2e4e7;
-		border-bottom: none;
-	}
-
-	.plan-features__table-item {
-		border-left: 1px solid #e2e4e7;
-		border-right: 1px solid #e2e4e7;
-	}
-
-	.plan-features__pricing {
-		border-top: none;
-	}
-
-	.plan-features__row {
-		border-top: none;
-		border-bottom: none;
-	}
-
-	.plan-features__item-checkmark {
-		fill: #00a32a;
-	}
 }

--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -100,3 +100,44 @@
 	line-height: 1.35;
 	color: var( --color-text-subtle );
 }
+
+body.is-section-signup.is-white-signup .plans-features-main {
+	.plans-features-main__banner-content {
+		box-shadow: none;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+
+		.is-free-plan {
+			padding: 12px 32px;
+			margin-left: 12px;
+			border-radius: 4px;
+			font-weight: 400;
+		}
+	}
+
+	.plan-features__header {
+		border-top: 1px solid #e2e4e7;
+		border-left: 1px solid #e2e4e7;
+		border-right: 1px solid #e2e4e7;
+		border-bottom: none;
+	}
+
+	.plan-features__table-item {
+		border-left: 1px solid #e2e4e7;
+		border-right: 1px solid #e2e4e7;
+	}
+
+	.plan-features__pricing {
+		border-top: none;
+	}
+
+	.plan-features__row {
+		border-top: none;
+		border-bottom: none;
+	}
+
+	.plan-features__item-checkmark {
+		fill: #00a32a;
+	}
+}

--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -1,3 +1,6 @@
+@import '~@wordpress/base-styles/breakpoints';
+@import '~@wordpress/base-styles/mixins';
+
 // Content group
 .plans-features-main__group {
 	& + & {
@@ -170,8 +173,10 @@ body.is-section-signup.is-white-signup {
 			}
 	
 			.plan-features__table {
-				border-spacing: 0;
-				border-collapse: collapse;
+				@include break-mobile {
+					border-spacing: 0;
+					border-collapse: collapse;
+				}
 		
 				tbody:first-child tr {
 					border-top-left-radius: 5px;

--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -181,6 +181,7 @@ body.is-section-signup.is-white-signup {
 				.plan-features__table-item {
 					border-left: 1px solid #e2e4e7;
 					border-right: 1px solid #e2e4e7;
+					background-clip: padding-box;
 					
 					.plan-features__description {
 						color: var( --color-neutral-60-rgb );

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -464,7 +464,6 @@ body.is-section-signup.is-white-signup .signup.is-onboarding {
 
 	.formatted-header {
 		margin-top: 48px;
-
 		.formatted-header__title {
 			@include onboarding-font-recoleta;
 			color: $gray-100;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates the plans step design to according to the new reskin
* More details in https://github.com/Automattic/wp-calypso/pull/44223

Changes:
- [x] Free Plan banner spacing and borders
- [x] Borders of plan features
- [x] Green checkmark for plan features
- [x] "Popular" pill design update
- [x] Spacing and typography for plan titles
- [x] Spacing and typography for plan prices


Current Screenshot:
![image](https://user-images.githubusercontent.com/5436027/88169468-a1531400-cc39-11ea-820a-a57be54109d9.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* Go to /start/new.
* Make sure you're assigned to `reskinned` group of `reskinSignupFlow` a/b test.
* Proceed to the plans step, the screen should look like this:
![image](https://user-images.githubusercontent.com/212034/87685317-37acb300-c7be-11ea-86bf-dc1d6116029f.png)

cc: @taggon 
