### PR TITLE
Bug Fix: Scroll to top of page when link is clicked

### DIFF
--- a/client/devdocs/design/search-collection.jsx
+++ b/client/devdocs/design/search-collection.jsx
@@ -110,7 +110,7 @@ const Collection = ( {
 					name={ exampleName }
 					unique={ !! component }
 					url={ exampleLink }
-					pageScroll={ scroll }
+					onTitleClick={ scroll }
 				>
 					{ example }
 				</DocsExampleWrapper>

--- a/client/devdocs/design/search-collection.jsx
+++ b/client/devdocs/design/search-collection.jsx
@@ -106,12 +106,15 @@ const Collection = ( {
 
 		return (
 			<div>
-				<button onClick={ scroll } onKeyPress={ scroll }>
-					<DocsExampleWrapper name={ exampleName } unique={ !! component } url={ exampleLink }>
-						{ example }
-					</DocsExampleWrapper>
-					{ component && <ReadmeViewer readmeFilePath={ readmeFilePath } /> }
-				</button>
+				<DocsExampleWrapper
+					name={ exampleName }
+					unique={ !! component }
+					url={ exampleLink }
+					pageScroll={ scroll }
+				>
+					{ example }
+				</DocsExampleWrapper>
+				{ component && <ReadmeViewer readmeFilePath={ readmeFilePath } /> }
 			</div>
 		);
 	} );

--- a/client/devdocs/design/search-collection.jsx
+++ b/client/devdocs/design/search-collection.jsx
@@ -106,24 +106,24 @@ const Collection = ( {
 
 		return (
 			<div>
-				<DocsExampleWrapper name={ exampleName } unique={ !! component } url={ exampleLink }>
-					{ example }
-				</DocsExampleWrapper>
-				{ component && <ReadmeViewer readmeFilePath={ readmeFilePath } /> }
+				<button onClick={ scroll } onKeyPress={ scroll }>
+					<DocsExampleWrapper name={ exampleName } unique={ !! component } url={ exampleLink }>
+						{ example }
+					</DocsExampleWrapper>
+					{ component && <ReadmeViewer readmeFilePath={ readmeFilePath } /> }
+				</button>
 			</div>
 		);
 	} );
 
 	return (
 		<div className="design__collection">
-			<button onClick={ scroll() } onKeyPress={ scroll() }>
-				{ showCounter > 1 && filter && (
-					<div className="design__instance-links">
-						<span className="design__instance-links-label">Results:</span>
-						{ summary }
-					</div>
-				) }
-			</button>
+			{ showCounter > 1 && filter && (
+				<div className="design__instance-links">
+					<span className="design__instance-links-label">Results:</span>
+					{ summary }
+				</div>
+			) }
 
 			{ /* Load first chunk, lazy load all others as needed. */ }
 

--- a/client/devdocs/design/search-collection.jsx
+++ b/client/devdocs/design/search-collection.jsx
@@ -62,6 +62,10 @@ const Collection = ( {
 	let showCounter = 0;
 	const summary = [];
 
+	const scroll = () => {
+		window.scrollTo( 0, 0 );
+	};
+
 	const examples = React.Children.map( children, ( example ) => {
 		if ( ! example || ! shouldShowInstance( example, filter, component ) ) {
 			return null;
@@ -112,12 +116,14 @@ const Collection = ( {
 
 	return (
 		<div className="design__collection">
-			{ showCounter > 1 && filter && (
-				<div className="design__instance-links">
-					<span className="design__instance-links-label">Results:</span>
-					{ summary }
-				</div>
-			) }
+			<button onClick={ scroll() } onKeyPress={ scroll() }>
+				{ showCounter > 1 && filter && (
+					<div className="design__instance-links">
+						<span className="design__instance-links-label">Results:</span>
+						{ summary }
+					</div>
+				) }
+			</button>
 
 			{ /* Load first chunk, lazy load all others as needed. */ }
 

--- a/client/devdocs/docs-example/wrapper.jsx
+++ b/client/devdocs/docs-example/wrapper.jsx
@@ -10,12 +10,12 @@ import classNames from 'classnames';
  */
 import DocsExampleError from 'devdocs/docs-example/error';
 
-const renderTitle = ( unique, name, url, pageScroll ) =>
+const renderTitle = ( unique, name, url, onTitleClick ) =>
 	unique ? (
 		<h2 className="docs-example__wrapper-header-title">{ name }</h2>
 	) : (
 		<h2 className="docs-example__wrapper-header-title">
-			<a href={ url } onClick={ pageScroll } onKeyPress={ pageScroll }>
+			<a href={ url } onClick={ onTitleClick } onKeyPress={ onTitleClick }>
 				{ name }
 			</a>
 		</h2>
@@ -26,7 +26,6 @@ class DocsExampleWrapper extends Component {
 		name: PropTypes.string.isRequired,
 		unique: PropTypes.bool,
 		url: PropTypes.string.isRequired,
-		pageScroll: PropTypes.func.isRequired,
 	};
 
 	state = {
@@ -38,7 +37,7 @@ class DocsExampleWrapper extends Component {
 	}
 
 	render() {
-		const { children, name, unique, url, pageScroll } = this.props;
+		const { children, name, unique, url, onTitleClick } = this.props;
 
 		return (
 			<div
@@ -47,7 +46,7 @@ class DocsExampleWrapper extends Component {
 				} ) }
 			>
 				<div className="docs-example__wrapper-header">
-					{ renderTitle( unique, name, url, pageScroll ) }
+					{ renderTitle( unique, name, url, onTitleClick ) }
 				</div>
 				<div className="docs-example__wrapper-content">
 					<span className="docs-example__wrapper-content-centering">

--- a/client/devdocs/docs-example/wrapper.jsx
+++ b/client/devdocs/docs-example/wrapper.jsx
@@ -26,6 +26,7 @@ class DocsExampleWrapper extends Component {
 		name: PropTypes.string.isRequired,
 		unique: PropTypes.bool,
 		url: PropTypes.string.isRequired,
+		onTitleClick: PropTypes.func,
 	};
 
 	state = {

--- a/client/devdocs/docs-example/wrapper.jsx
+++ b/client/devdocs/docs-example/wrapper.jsx
@@ -10,12 +10,14 @@ import classNames from 'classnames';
  */
 import DocsExampleError from 'devdocs/docs-example/error';
 
-const renderTitle = ( unique, name, url ) =>
+const renderTitle = ( unique, name, url, pageScroll ) =>
 	unique ? (
 		<h2 className="docs-example__wrapper-header-title">{ name }</h2>
 	) : (
 		<h2 className="docs-example__wrapper-header-title">
-			<a href={ url }>{ name }</a>
+			<a href={ url } onClick={ pageScroll } onKeyPress={ pageScroll }>
+				{ name }
+			</a>
 		</h2>
 	);
 
@@ -24,6 +26,7 @@ class DocsExampleWrapper extends Component {
 		name: PropTypes.string.isRequired,
 		unique: PropTypes.bool,
 		url: PropTypes.string.isRequired,
+		pageScroll: PropTypes.func.isRequired,
 	};
 
 	state = {
@@ -35,7 +38,7 @@ class DocsExampleWrapper extends Component {
 	}
 
 	render() {
-		const { children, name, unique, url } = this.props;
+		const { children, name, unique, url, pageScroll } = this.props;
 
 		return (
 			<div
@@ -43,7 +46,9 @@ class DocsExampleWrapper extends Component {
 					'docs-example__wrapper-unique': unique,
 				} ) }
 			>
-				<div className="docs-example__wrapper-header">{ renderTitle( unique, name, url ) }</div>
+				<div className="docs-example__wrapper-header">
+					{ renderTitle( unique, name, url, pageScroll ) }
+				</div>
 				<div className="docs-example__wrapper-content">
 					<span className="docs-example__wrapper-content-centering">
 						{ this.state.hasError ? <DocsExampleError /> : children }


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Added autoscroll function to onClick and onKeyPress events.  Specifically, the issue pointed out that the component link would render at the bottom of the documentation page. I noticed that the same thing happened with other components within the parent, so I added a function that would cause the links to render at the top of the documentation page.
*

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
Go to : https://wpcalypso.wordpress.com/devdocs/design , scroll down to to view Popover docs (or any other link on the bottom half of the page). The documentation for Popover should be scrolled to the top of the page after following the link.


*

Fixes #24337