### PR TITLE
Reinstate click override of the editor close button

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -548,6 +548,8 @@ function handleCloseEditor( calypsoPort ) {
 		doAction( 'a8c.wpcom-block-editor.closeEditor' );
 	};
 
+	handleCloseInLegacyEditors( dispatchAction );
+
 	if ( isNavSidebarPresent() ) {
 		return;
 	}
@@ -588,6 +590,19 @@ function handleCloseEditor( calypsoPort ) {
 			);
 		},
 	} );
+}
+
+// The close button is generally overridden using the <MainDashboardButton> slot API
+// which was introduced in Gutenberg 8.2. In older editors we still need to override
+// the click handler so that the link will open in the parent frame instead of the
+// iframe. If this happens to be a newer version of the editor the <MainDashboardButton>
+// in `handleCloseEditor()` will end up overriding these chanages.
+function handleCloseInLegacyEditors( handleClose ) {
+	const legacySelector = '.edit-post-fullscreen-mode-close__toolbar a'; // support for Gutenberg plugin < v7.7
+	const selector = '.edit-post-header .edit-post-fullscreen-mode-close';
+	const siteEditorSelector = '.edit-site-header .edit-site-fullscreen-mode-close';
+	$( '#editor' ).on( 'click', `${ legacySelector }, ${ selector }`, handleClose );
+	$( '#edit-site-editor' ).on( 'click', `${ siteEditorSelector }`, handleClose );
 }
 
 /**


### PR DESCRIPTION
Fixes an issue introduced in #43313 and reported in Automattic/wp-desktop#941

#43313 removed the old code that overrode the click handler of the (W) in the blocked editor, and replaced it with a new method that used a slot API introduced in Gutenberg 8.2. I thought editors with GB versions < 8.2 would continue to work as we have other code that replaces the `href` attribute of the (W) button with a url back to Calypso. However changing the `href` isn't enough as that causes the navigation to happen within the editor iframe, not in the parent frame. 

I think ideally we would override the `href` _and_ `target` attributes of the (W) button here: https://github.com/Automattic/jetpack/blob/15294dbfe8ee61ca649fe5891b9e4d0cc8702091/modules/calypsoify/mods-gutenberg.js#L33
However that won't address the issue for sites that haven't updated there Jetpack version.

This code reinstates the click handler override that existed before #43313. My slight worry is that it might interfere with the (W) button in editors that have the latest version of Gutenberg, but I don't think it will because the new slot API should completely remove the old (W) that is being overridden using jQuery.
Testing should confirm this.

#### Changes proposed in this Pull Request

* Reinstate the click handler for the (W) that was removed #43313 here: https://github.com/Automattic/wp-calypso/pull/43313/files#diff-9a28151776793191d27d22c072f05340L594

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply these changes to your sandbox by either:
  * Checking out this branch, `cd apps/wpcom-block-editor && yarn build --output-path=dist`, and copy the contents of `apps/wpcom-block-editor/dist` to your sandbox, or
  * Run the steps under the "Automatic" head of this page PCYsg-l4k-p2, using the build number `819097`
* Sandbox `widgets.wp.com`
* Test exiting the block editor in these environments:
  * Simple site
  * Atomic site
  * Atomic site with various versions of GB activated
  * jurassic.ninja site
  * jurassic.ninja with various versions of GB activated
  * WordPress.com desktop app

Fixes Automattic/wp-desktop#941
