### PR TITLE
Use the Calypso theme standard colors for the domain statuses

### DIFF
--- a/client/lib/domains/resolve-domain-status.js
+++ b/client/lib/domains/resolve-domain-status.js
@@ -134,7 +134,7 @@ export function resolveDomainStatus(
 			if ( isRecentlyRegistered( domain.registrationDate ) ) {
 				return {
 					statusText: translate( 'Activating' ),
-					statusClass: 'status-pending',
+					statusClass: 'status-success',
 					icon: 'cloud_upload',
 					listStatusText: translate( 'Activating' ),
 					listStatusClass: 'info',
@@ -152,7 +152,7 @@ export function resolveDomainStatus(
 			if ( isDomainOnlySite ) {
 				return {
 					statusText: translate( 'Parked' ),
-					statusClass: 'status-parked',
+					statusClass: 'status-neutral',
 					icon: 'download_done',
 				};
 			}

--- a/client/my-sites/domains/domain-management/edit/style.scss
+++ b/client/my-sites/domains/domain-management/edit/style.scss
@@ -66,10 +66,7 @@
 	.status-success {
 		@include domain_status_color( var( --color-success ) );
 	}
-	.status-parked {
-		@include domain_status_color( #787C82 );
-	}
-	.status-pending {
+	.status-neutral {
 		@include domain_status_color( var( --color-neutral ) );
 	}
 	.status-warning {

--- a/client/my-sites/domains/domain-management/edit/style.scss
+++ b/client/my-sites/domains/domain-management/edit/style.scss
@@ -64,19 +64,19 @@
 
 .domain-types__container {
 	.status-success {
-		@include domain_status_color( #008a20 );
+		@include domain_status_color( var( --color-success ) );
 	}
 	.status-parked {
 		@include domain_status_color( #787C82 );
 	}
 	.status-pending {
-		@include domain_status_color( #3582C4 );
+		@include domain_status_color( var( --color-neutral ) );
 	}
 	.status-warning {
-		@include domain_status_color( #B69000 );
+		@include domain_status_color( var( --color-warning ) );
 	}
 	.status-error {
-		@include domain_status_color( #C9356E );
+		@include domain_status_color( var( --color-error ) );
 	}
 
 	.domain-status__card {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Instead of hardcoding the status colors we can use the standard theme colors for warning/error/success

Here's how it looks:

<img width="746" alt="Screenshot 2020-07-22 at 10 10 15" src="https://user-images.githubusercontent.com/1355045/88145894-d0e72980-cc03-11ea-9286-3dd7e2fb4c38.png">
<img width="743" alt="Screenshot 2020-07-22 at 10 10 32" src="https://user-images.githubusercontent.com/1355045/88145897-d2b0ed00-cc03-11ea-9a78-7dc8dfbba44b.png">
<img width="744" alt="Screenshot 2020-07-22 at 10 11 23" src="https://user-images.githubusercontent.com/1355045/88145902-d3498380-cc03-11ea-9290-85cf0ff9de4a.png">
<img width="747" alt="Screenshot 2020-07-22 at 10 11 45" src="https://user-images.githubusercontent.com/1355045/88145905-d3e21a00-cc03-11ea-8652-2f79b4720251.png">


#### Testing instructions

* Check domains in different statuses - expired, expiring soon and activating and verify that the colors look okay
