### PR TITLE
Adds missing dependencies to o2-blocks

### DIFF
--- a/apps/o2-blocks/package.json
+++ b/apps/o2-blocks/package.json
@@ -22,12 +22,17 @@
 		"build": "check-npm-client && calypso-build editor='./src/editor.js' --env.WP"
 	},
 	"dependencies": {
+		"@wordpress/api-fetch": "^3.15.0",
 		"@wordpress/block-editor": "^3.11.0",
 		"@wordpress/blocks": "^6.16.0",
 		"@wordpress/components": "^9.6.0",
+		"@wordpress/data": "^4.18.0",
 		"@wordpress/editor": "^9.16.0",
 		"@wordpress/element": "^2.14.0",
+		"@wordpress/hooks": "^2.8.0",
 		"@wordpress/i18n": "^3.12.0",
-		"classnames": "^2.2.6"
+		"classnames": "^2.2.6",
+		"lodash": "^4.17.15",
+		"moment": "^2.26.0"
 	}
 }


### PR DESCRIPTION
### Problem

`@yarnpkg/doctor` found a bunch of undeclared dependencies and missing peer dependencies:

```
➤ YN0000: ┌ /Users/sergio/src/automattic/wp-calypso2/apps/o2-blocks/package.json
➤ YN0000: │ User scripts prefixed with "pre" or "post" (like "prebuild") will not be called in sequence anymore; prefer calling prologues and epilogues explicitly
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/apps/o2-blocks/src/p2-autocomplete/editor.js:4:1: Undeclared dependency on @wordpress/api-fetch
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/apps/o2-blocks/src/p2-autocomplete/editor.js:5:1: Undeclared dependency on @wordpress/hooks
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/apps/o2-blocks/src/p2-autocomplete/editor.js:6:1: Undeclared dependency on lodash
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/apps/o2-blocks/src/project-status/editor.js:11:1: Undeclared dependency on @wordpress/data
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/apps/o2-blocks/src/task/editor.js:5:1: Undeclared dependency on moment
➤ YN0000: └ Completed in 0.86s
```

### Changes

This PR adds those dependencies to `./apps/o2-blocks/package.json`. The version ranges have been copied from `./package.json` to make sure nothing changes.

### Testing instructions

Verify files have not actually changed:
* Checkout master, run `yarn; cd apps/o2-blocks; yarn build` and copy the folder `apps/o2-blocks/dist` somewhere (eg: to `$HOME/dist-master`)
* Checkout this branch and repeat the same steps. The folder can be copied to `$HOME/dist-branch`
* Compare the generated files in both `dist` folders. You can use this command (assuming the folders are named `dist-master` and `dist-branch` and they live in the same directory): `for file in dist-master/*; do diff $file ${file/dist-master/dist-branch}; done`. The only changes should be those related with the commit hash.

Verify there are no more missing packages:
* Run `npx @yarnpkg/doctor` inside `./apps/o2-blocks`. All warnings about missing dependencies should be gone now.
