### PR TITLE
Adds missing dependencies to wpcom-block-editor

### DIFF
--- a/apps/wpcom-block-editor/package.json
+++ b/apps/wpcom-block-editor/package.json
@@ -26,7 +26,31 @@
 		"wpcom-sync": "check-npm-client && ./bin/wpcom-watch-and-sync.sh"
 	},
 	"dependencies": {
+		"@wordpress/block-editor": "^3.11.0",
+		"@wordpress/blocks": "^6.16.0",
+		"@wordpress/components": "^9.6.0",
+		"@wordpress/compose": "^3.15.0",
+		"@wordpress/data": "^4.18.0",
+		"@wordpress/dom-ready": "^2.9.0",
+		"@wordpress/editor": "^9.16.0",
+		"@wordpress/element": "^2.14.0",
+		"@wordpress/hooks": "^2.8.0",
+		"@wordpress/i18n": "^3.12.0",
+		"@wordpress/icons": "^2.0.0",
 		"@wordpress/interface": "^0.6.0",
-		"debug": "^4.1.1"
+		"@wordpress/plugins": "^2.16.0",
+		"@wordpress/rich-text": "^3.16.0",
+		"@wordpress/url": "^2.15.0",
+		"debug": "^4.1.1",
+		"jquery": "^1.12.3",
+		"lodash": "^4.17.15",
+		"react": "^16.12.0",
+		"tinymce": "^4.9.6"
+	},
+	"devDependencies": {
+		"@automattic/calypso-build": "^6.1.0",
+		"@wordpress/dependency-extraction-webpack-plugin": "^2.6.0",
+		"enzyme": "^3.11.0",
+		"npm-run-all": "^4.1.5"
 	}
 }


### PR DESCRIPTION
### Problem

`@yarnpkg/doctor` found a bunch of undeclared dependencies and missing peer dependencies:

```
➤ YN0000: ┌ /Users/sergio/src/automattic/wp-calypso2/apps/wpcom-block-editor/package.json
➤ YN0000: │ User scripts prefixed with "pre" or "post" (like "prebuild") will not be called in sequence anymore; prefer calling prologues and epilogues explicitly
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/apps/wpcom-block-editor/webpack.config.js:10:43: Undeclared dependency on @wordpress/dependency-extraction-webpack-plugin
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/apps/wpcom-block-editor/webpack.config.js:11:30: Undeclared dependency on @automattic/calypso-build
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/apps/wpcom-block-editor/bin/npm-run-build.js:10:16: Undeclared dependency on npm-run-all
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/apps/wpcom-block-editor/src/utils.js:5:1: Undeclared dependency on @wordpress/data
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/apps/wpcom-block-editor/src/wpcom/editor.js:7:1: Undeclared dependency on @wordpress/plugins
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/apps/wpcom-block-editor/src/default/features/rich-text.js:7:1: Undeclared dependency on @wordpress/compose
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/apps/wpcom-block-editor/src/default/features/rich-text.js:8:1: Undeclared dependency on @wordpress/data
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/apps/wpcom-block-editor/src/default/features/rich-text.js:9:1: Undeclared dependency on @wordpress/editor
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/apps/wpcom-block-editor/src/default/features/rich-text.js:10:1: Undeclared dependency on @wordpress/rich-text
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/apps/wpcom-block-editor/src/default/features/rich-text.js:11:1: Undeclared dependency on lodash
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/apps/wpcom-block-editor/src/default/features/switch-to-classic.js:7:1: Undeclared dependency on jquery
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js:7:1: Undeclared dependency on jquery
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js:8:1: Undeclared dependency on lodash
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js:9:1: Undeclared dependency on @wordpress/data
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js:10:1: Undeclared dependency on @wordpress/blocks
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js:11:1: Undeclared dependency on @wordpress/hooks
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js:12:1: Undeclared dependency on @wordpress/url
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js:13:1: Undeclared dependency on @wordpress/plugins
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js:15:1: Undeclared dependency on @wordpress/components
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js:16:1: Undeclared dependency on @wordpress/icons
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js:17:1: Undeclared dependency on react
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js:18:1: Undeclared dependency on tinymce
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/apps/wpcom-block-editor/src/calypso/features/tinymce.js:6:1: Undeclared dependency on tinymce
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/apps/wpcom-block-editor/src/wpcom/features/convert-to-blocks-button.js:11:1: Undeclared dependency on @wordpress/hooks
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/apps/wpcom-block-editor/src/wpcom/features/convert-to-blocks-button.js:12:1: Undeclared dependency on @wordpress/block-editor
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/apps/wpcom-block-editor/src/wpcom/features/convert-to-blocks-button.js:13:1: Undeclared dependency on @wordpress/components
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/apps/wpcom-block-editor/src/wpcom/features/convert-to-blocks-button.js:14:1: Undeclared dependency on @wordpress/i18n
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/apps/wpcom-block-editor/src/wpcom/features/convert-to-blocks-button.js:15:1: Undeclared dependency on @wordpress/compose
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/apps/wpcom-block-editor/src/wpcom/features/convert-to-blocks-button.js:16:1: Undeclared dependency on @wordpress/data
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/apps/wpcom-block-editor/src/wpcom/features/convert-to-blocks-button.js:17:1: Undeclared dependency on @wordpress/blocks
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/apps/wpcom-block-editor/src/wpcom/features/deprecate-coblocks-buttons.js:6:1: Undeclared dependency on @wordpress/blocks
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/apps/wpcom-block-editor/src/wpcom/features/deprecate-coblocks-buttons.js:7:1: Undeclared dependency on @wordpress/dom-ready
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/apps/wpcom-block-editor/src/wpcom/features/fix-block-invalidation-errors.js:6:1: Undeclared dependency on @wordpress/data
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/apps/wpcom-block-editor/src/wpcom/features/fix-block-invalidation-errors.js:7:1: Undeclared dependency on @wordpress/blocks
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/apps/wpcom-block-editor/src/wpcom/features/images.js:5:1: Undeclared dependency on @wordpress/i18n
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/apps/wpcom-block-editor/src/wpcom/features/reorder-block-categories.js:5:1: Undeclared dependency on @wordpress/blocks
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/apps/wpcom-block-editor/src/wpcom/features/reorder-block-categories.js:6:1: Undeclared dependency on @wordpress/dom-ready
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/apps/wpcom-block-editor/src/wpcom/features/tracking.js:5:1: Undeclared dependency on @wordpress/data
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/apps/wpcom-block-editor/src/wpcom/features/tracking.js:6:1: Undeclared dependency on @wordpress/plugins
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/apps/wpcom-block-editor/src/wpcom/features/tracking.js:7:1: Undeclared dependency on @wordpress/hooks
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/apps/wpcom-block-editor/src/wpcom/features/tracking.js:8:1: Undeclared dependency on lodash
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/apps/wpcom-block-editor/src/wpcom/features/use-classic-block-guide.js:5:1: Undeclared dependency on @wordpress/element
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/apps/wpcom-block-editor/src/wpcom/features/use-classic-block-guide.js:6:1: Undeclared dependency on @wordpress/components
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/apps/wpcom-block-editor/src/wpcom/features/use-classic-block-guide.js:7:1: Undeclared dependency on @wordpress/data
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/apps/wpcom-block-editor/src/wpcom/features/use-classic-block-guide.js:9:1: Undeclared dependency on @wordpress/i18n
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/apps/wpcom-block-editor/src/wpcom/features/use-classic-block-guide.js:10:1: Undeclared dependency on @wordpress/plugins
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/apps/wpcom-block-editor/src/wpcom/features/tracking/track-record-event.js:5:1: Undeclared dependency on lodash
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-inserter-inline-search-term.js:6:1: Undeclared dependency on lodash
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-inserter-inline-search-term.js:11:1: Undeclared dependency on @wordpress/data
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-inserter-menu-search-term.js:5:1: Undeclared dependency on lodash
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-inserter-menu-search-term.js:10:1: Undeclared dependency on @wordpress/element
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-inserter-menu-search-term.js:11:1: Undeclared dependency on @wordpress/data
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-inserter-menu-search-term.js:12:1: Undeclared dependency on @wordpress/block-editor
➤ YN0000: └ Completed in 1.18s
```

### Changes

This PR adds those dependencies to `./apps/wpcom-block-editor/package.json`. The version ranges have been copied from `./package.json` to make sure nothing changes.

### Testing instructions

Verify files have not actually changed:
* Checkout master, run `yarn; cd apps/wpcom-block-editor; yarn build:prod` and copy the folder `apps/wpcom-block-editor/dist` somewhere (eg: to `$HOME/dist-master`)
* Checkout this branch and repeat the same steps. The folder can be copied to `$HOME/dist-branch`
* Compare the generated files in both `dist` folders. You can use this command (assuming the folders are named `dist-master` and `dist-branch` and they live in the same directory): `for file in dist-master/*; do diff $file ${file/dist-master/dist-branch}; done`. The should be no differences.

Verify there are no more missing packages:
* Run `npx @yarnpkg/doctor` inside `./apps/wpcom-block-editor`. All warnings about missing dependencies should be gone now.
