### PR TITLE
Add missing dependencies to @automattic/calypso-build

### DIFF
--- a/packages/calypso-build/package.json
+++ b/packages/calypso-build/package.json
@@ -43,6 +43,7 @@
 		"@babel/preset-env": "^7.8.4",
 		"@babel/preset-react": "^7.8.3",
 		"@babel/preset-typescript": "^7.8.3",
+		"@babel/helpers": "^7.9.0",
 		"@types/webpack-env": "^1.15.2",
 		"@wordpress/babel-plugin-import-jsx-pragma": "^2.5.0",
 		"@wordpress/browserslist-config": "^2.6.0",
@@ -73,6 +74,9 @@
 		"webpack-rtl-plugin": "^2.0.0"
 	},
 	"peerDependencies": {
-		"enzyme": "^3.11.0"
+		"enzyme": "^3.11.0",
+		"react": "^16.0.0",
+		"react-dom": "^16.0.0",
+		"jest": ">=22.0.0"
 	}
 }


### PR DESCRIPTION
### Problem

`@yarnpkg/doctor` found a bunch of undeclared dependencies and missing peer dependencies:

```
➤ YN0000: ┌ /Users/sergio/src/automattic/wp-calypso2/packages/calypso-build/package.json
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/packages/calypso-build/webpack.config.js:129:15: Strings should avoid referencing the node_modules directory (prefer require.resolve)
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/packages/calypso-build/babel/default.js:41:14: Undeclared dependency on @babel/helpers
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/packages/calypso-build/webpack/file-loader.js:9:7: Webpack configs from non-private packages should avoid referencing loaders without require.resolve
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/packages/calypso-build/webpack/sass.js:19:7: Webpack configs from non-private packages should avoid referencing loaders without require.resolve
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/packages/calypso-build/webpack/transpile.js:26:7: Webpack configs from non-private packages should avoid referencing loaders without require.resolve
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/packages/calypso-build/webpack/util.js:110:17: Strings should avoid referencing the node_modules directory (prefer require.resolve)
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/packages/calypso-build/package.json:57:30: Unmet transitive peer dependency on react@^16.0.0-0, via enzyme-adapter-react-16@^1.15.1
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/packages/calypso-build/package.json:57:30: Unmet transitive peer dependency on react-dom@^16.0.0-0, via enzyme-adapter-react-16@^1.15.1
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/packages/calypso-build/package.json:62:18: Unmet transitive peer dependency on jest@>=22.0.0, via jest-enzyme@^7.1.2
➤ YN0000: └ Completed in 8.89s
```

### Changes

This PR adds the missing dependency to `./packages/calypso-build/package.json`. The version ranges has been copied from `./package.json` to make sure nothing changes.

### Testing instructions

Verify there are no more missing packages:
* Run `npx @yarnpkg/doctor` inside `./packages/calypso-build`. All warnings about missing dependencies should be gone now.
