### PR TITLE
Split lib/gsuite

### DIFF
--- a/client/lib/gsuite/can-domain-add-gsuite.js
+++ b/client/lib/gsuite/can-domain-add-gsuite.js
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ */
+import { endsWith } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { canUserPurchaseGSuite } from './can-user-purchase-gsuite';
+
+/**
+ * Determines whether G Suite is allowed for the specified domain.
+ *
+ * @param {string} domainName - domain name
+ * @returns {boolean} - true if G Suite is allowed, false otherwise
+ */
+export function canDomainAddGSuite( domainName ) {
+	if ( endsWith( domainName, '.wpcomstaging.com' ) ) {
+		return false;
+	}
+
+	return canUserPurchaseGSuite();
+}

--- a/client/lib/gsuite/can-user-purchase-gsuite.js
+++ b/client/lib/gsuite/can-user-purchase-gsuite.js
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import userFactory from 'lib/user';
+
+/**
+ * Determines whether G Suite can be purchased by the user based on their country.
+ *
+ * @returns {boolean} true if the user is allowed to purchase G Suite, false otherwise
+ */
+export function canUserPurchaseGSuite() {
+	const user = userFactory();
+
+	return get( user.get(), 'is_valid_google_apps_country', false );
+}

--- a/client/lib/gsuite/get-annual-price.js
+++ b/client/lib/gsuite/get-annual-price.js
@@ -1,0 +1,25 @@
+/**
+ * External dependencies
+ */
+import { isNumber, isString } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { formatPrice } from 'lib/gsuite/utils/format-price';
+
+/**
+ * Formats the specified yearly price.
+ *
+ * @param {number} cost - yearly cost (e.g. '99.99')
+ * @param {string} currencyCode - code of the currency (e.g. 'USD')
+ * @param {string} defaultValue - value to return when the price can't be determined
+ * @returns {string} - the yearly price formatted (e.g. '$99.99'), otherwise the default value
+ */
+export function getAnnualPrice( cost, currencyCode, defaultValue = '-' ) {
+	if ( ! isNumber( cost ) && ! isString( currencyCode ) ) {
+		return defaultValue;
+	}
+
+	return formatPrice( cost, currencyCode );
+}

--- a/client/lib/gsuite/get-eligible-gsuite-domain.js
+++ b/client/lib/gsuite/get-eligible-gsuite-domain.js
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ */
+import { get, sortBy } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { canDomainAddGSuite } from './can-domain-add-gsuite';
+import { getGSuiteSupportedDomains } from './gsuite-supported-domain';
+
+/**
+ * Retrieves the first domain that is eligible to G Suite in this order:
+ *
+ *   - The domain from the site currently selected, if eligible
+ *   - The primary domain of the site, if eligible
+ *   - The first non-primary domain eligible found
+ *
+ * @param {string} selectedDomainName - domain name for the site currently selected by the user
+ * @param {Array} domains - list of domain objects
+ * @returns {string} - the name of the first eligible domain found
+ */
+export function getEligibleGSuiteDomain( selectedDomainName, domains ) {
+	if ( selectedDomainName && canDomainAddGSuite( selectedDomainName ) ) {
+		return selectedDomainName;
+	}
+
+	// Orders domains with the primary domain in first position, if any
+	const supportedDomains = sortBy(
+		getGSuiteSupportedDomains( domains ),
+		( domain ) => ! domain.isPrimary
+	);
+
+	return get( supportedDomains, '[0].name', '' );
+}

--- a/client/lib/gsuite/get-gsuite-mailbox-count.js
+++ b/client/lib/gsuite/get-gsuite-mailbox-count.js
@@ -1,0 +1,8 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+export function getGSuiteMailboxCount( domain ) {
+	return get( domain, 'googleAppsSubscription.totalUserCount', 0 );
+}

--- a/client/lib/gsuite/get-login-url-with-tos-redirect.js
+++ b/client/lib/gsuite/get-login-url-with-tos-redirect.js
@@ -1,0 +1,17 @@
+/**
+ * Creates the Google ToS redirect url given email and domain
+ *
+ * @param {string} email - email
+ * @param {string} domain - domain name
+ * @returns {string} - ToS url redirect
+ */
+export function getLoginUrlWithTOSRedirect( email, domain ) {
+	return (
+		'https://accounts.google.com/AccountChooser?' +
+		`Email=${ encodeURIComponent( email ) }` +
+		`&service=CPanel` +
+		`&continue=${ encodeURIComponent(
+			`https://admin.google.com/${ domain }/AcceptTermsOfService?continue=https://mail.google.com/mail/u/${ email }`
+		) }`
+	);
+}

--- a/client/lib/gsuite/get-monthly-price.js
+++ b/client/lib/gsuite/get-monthly-price.js
@@ -1,0 +1,25 @@
+/**
+ * External dependencies
+ */
+import { isNumber, isString } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { formatPrice } from 'lib/gsuite/utils/format-price';
+
+/**
+ * Computes and formats the monthly price from the specified yearly price.
+ *
+ * @param {number} cost - yearly cost (e.g. '99.99')
+ * @param {string} currencyCode - code of the currency (e.g. 'USD')
+ * @param {string} defaultValue - value to return when the price can't be determined
+ * @returns {string} - the monthly price rounded to the nearest tenth (e.g. '$8.40'), otherwise the default value
+ */
+export function getMonthlyPrice( cost, currencyCode, defaultValue = '-' ) {
+	if ( ! isNumber( cost ) && ! isString( currencyCode ) ) {
+		return defaultValue;
+	}
+
+	return formatPrice( cost / 12, currencyCode, { precision: 1 } );
+}

--- a/client/lib/gsuite/gsuite-product-slug.js
+++ b/client/lib/gsuite/gsuite-product-slug.js
@@ -1,0 +1,38 @@
+/**
+ * Internal dependencies
+ */
+import {
+	GSUITE_BASIC_SLUG,
+	GSUITE_BUSINESS_SLUG,
+	GSUITE_EXTRA_LICENSE_SLUG,
+} from 'lib/gsuite/constants';
+
+/**
+ * Determines whether the specified product slug is for G Suite Basic or Business.
+ *
+ * @param {string} productSlug - slug of the product
+ * @returns {boolean} true if the slug refers to G Suite Basic or Business, false otherwise
+ */
+export function isGSuiteProductSlug( productSlug ) {
+	return [ GSUITE_BASIC_SLUG, GSUITE_BUSINESS_SLUG ].includes( productSlug );
+}
+
+/**
+ * Determines whether the specified product slug is for a G Suite extra license.
+ *
+ * @param {string} productSlug - slug of the product
+ * @returns {boolean} true if the slug refers to an extra license, false otherwise
+ */
+export function isGSuiteExtraLicenseProductSlug( productSlug ) {
+	return productSlug === GSUITE_EXTRA_LICENSE_SLUG;
+}
+
+/**
+ * Determines whether the specified product slug refers to any type of G Suite product.
+ *
+ * @param {string} productSlug - slug of the product
+ * @returns {boolean} true if the slug refers to any G Suite product, false otherwise
+ */
+export function isGSuiteOrExtraLicenseProductSlug( productSlug ) {
+	return isGSuiteProductSlug( productSlug ) || isGSuiteExtraLicenseProductSlug( productSlug );
+}

--- a/client/lib/gsuite/gsuite-supported-domain.js
+++ b/client/lib/gsuite/gsuite-supported-domain.js
@@ -1,0 +1,40 @@
+/**
+ * Internal dependencies
+ */
+import { isMappedDomainWithWpcomNameservers, isRegisteredDomain } from 'lib/domains';
+import { canDomainAddGSuite } from './can-domain-add-gsuite';
+import { hasGSuiteWithUs } from './has-gsuite-with-us';
+import { hasGSuiteWithAnotherProvider } from './has-gsuite-with-another-provider';
+
+/**
+ * Filters a list of domains by the domains that eligible for G Suite.
+ *
+ * @param {Array} domains - list of domain objects
+ * @returns {Array} - the list of domains that are eligible for G Suite
+ */
+export function getGSuiteSupportedDomains( domains ) {
+	return domains.filter( function ( domain ) {
+		if ( hasGSuiteWithAnotherProvider( domain ) ) {
+			return false;
+		}
+
+		const isHostedOnWpcom =
+			isRegisteredDomain( domain ) && ( domain.hasWpcomNameservers || hasGSuiteWithUs( domain ) );
+
+		if ( ! isHostedOnWpcom && ! isMappedDomainWithWpcomNameservers( domain ) ) {
+			return false;
+		}
+
+		return canDomainAddGSuite( domain.name );
+	} );
+}
+
+/**
+ * Given a list of domains does one of them support G Suite
+ *
+ * @param {Array} domains - list of domain objects
+ * @returns {boolean} - Does list of domains contain a G Suited supported domain
+ */
+export function hasGSuiteSupportedDomain( domains ) {
+	return getGSuiteSupportedDomains( domains ).length > 0;
+}

--- a/client/lib/gsuite/has-gsuite-with-another-provider.js
+++ b/client/lib/gsuite/has-gsuite-with-another-provider.js
@@ -1,0 +1,16 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Given a domain object, does that domain have G Suite with another provider.
+ *
+ * @param {object} domain - domain object
+ * @returns {boolean} - true if the domain is with another provider, false otherwise
+ */
+export function hasGSuiteWithAnotherProvider( domain ) {
+	const domainStatus = get( domain, 'googleAppsSubscription.status', '' );
+
+	return 'other_provider' === domainStatus;
+}

--- a/client/lib/gsuite/has-gsuite-with-us.js
+++ b/client/lib/gsuite/has-gsuite-with-us.js
@@ -1,0 +1,16 @@
+/**
+ * External dependencies
+ */
+import { get, includes } from 'lodash';
+
+/**
+ * Given a domain object, does that domain have G Suite with us.
+ *
+ * @param {object} domain - domain object
+ * @returns {boolean} - true if the domain is under our management, false otherwise
+ */
+export function hasGSuiteWithUs( domain ) {
+	const defaultValue = '';
+	const domainStatus = get( domain, 'googleAppsSubscription.status', defaultValue );
+	return ! includes( [ defaultValue, 'no_subscription', 'other_provider' ], domainStatus );
+}

--- a/client/lib/gsuite/has-pending-gsuite-users.js
+++ b/client/lib/gsuite/has-pending-gsuite-users.js
@@ -1,0 +1,14 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Does a domain have pending G Suite Users
+ *
+ * @param {object} domain - domain object
+ * @returns {boolean} - Does domain have pending G Suite users
+ */
+export function hasPendingGSuiteUsers( domain ) {
+	return get( domain, 'googleAppsSubscription.pendingUsers.length', 0 ) !== 0;
+}

--- a/client/lib/gsuite/index.js
+++ b/client/lib/gsuite/index.js
@@ -16,6 +16,7 @@ export {
 	isGSuiteOrExtraLicenseProductSlug,
 	isGSuiteProductSlug,
 } from './gsuite-product-slug';
+export { getLoginUrlWithTOSRedirect } from './get-login-url-with-tos-redirect';
 
 /**
  * Determines whether G Suite is allowed for the specified domain.
@@ -81,24 +82,6 @@ export function getGSuiteSupportedDomains( domains ) {
 
 export function getGSuiteMailboxCount( domain ) {
 	return get( domain, 'googleAppsSubscription.totalUserCount', 0 );
-}
-
-/**
- * Creates the Google ToS redirect url given email and domain
- *
- * @param {string} email - email
- * @param {string} domain - domain name
- * @returns {string} - ToS url redirect
- */
-export function getLoginUrlWithTOSRedirect( email, domain ) {
-	return (
-		'https://accounts.google.com/AccountChooser?' +
-		`Email=${ encodeURIComponent( email ) }` +
-		`&service=CPanel` +
-		`&continue=${ encodeURIComponent(
-			`https://admin.google.com/${ domain }/AcceptTermsOfService?continue=https://mail.google.com/mail/u/${ email }`
-		) }`
-	);
 }
 
 /**

--- a/client/lib/gsuite/index.js
+++ b/client/lib/gsuite/index.js
@@ -9,6 +9,7 @@ import { get, sortBy } from 'lodash';
 import { isMappedDomainWithWpcomNameservers, isRegisteredDomain } from 'lib/domains';
 import { canDomainAddGSuite } from './can-domain-add-gsuite';
 import { hasGSuiteWithUs } from './has-gsuite-with-us';
+import { hasGSuiteWithAnotherProvider } from './has-gsuite-with-another-provider';
 
 export { getAnnualPrice } from './get-annual-price';
 export { getMonthlyPrice } from './get-monthly-price';
@@ -22,6 +23,7 @@ export { canUserPurchaseGSuite } from './can-user-purchase-gsuite';
 export { canDomainAddGSuite } from './can-domain-add-gsuite';
 export { getGSuiteMailboxCount } from './get-gsuite-mailbox-count';
 export { hasGSuiteWithUs } from './has-gsuite-with-us';
+export { hasGSuiteWithAnotherProvider } from './has-gsuite-with-another-provider';
 
 /**
  * Retrieves the first domain that is eligible to G Suite in this order:
@@ -69,18 +71,6 @@ export function getGSuiteSupportedDomains( domains ) {
 
 		return canDomainAddGSuite( domain.name );
 	} );
-}
-
-/**
- * Given a domain object, does that domain have G Suite with another provider.
- *
- * @param {object} domain - domain object
- * @returns {boolean} - true if the domain is with another provider, false otherwise
- */
-export function hasGSuiteWithAnotherProvider( domain ) {
-	const domainStatus = get( domain, 'googleAppsSubscription.status', '' );
-
-	return 'other_provider' === domainStatus;
 }
 
 /**

--- a/client/lib/gsuite/index.js
+++ b/client/lib/gsuite/index.js
@@ -24,6 +24,7 @@ export { canDomainAddGSuite } from './can-domain-add-gsuite';
 export { getGSuiteMailboxCount } from './get-gsuite-mailbox-count';
 export { hasGSuiteWithUs } from './has-gsuite-with-us';
 export { hasGSuiteWithAnotherProvider } from './has-gsuite-with-another-provider';
+export { hasPendingGSuiteUsers } from './has-pending-gsuite-users';
 
 /**
  * Retrieves the first domain that is eligible to G Suite in this order:
@@ -81,14 +82,4 @@ export function getGSuiteSupportedDomains( domains ) {
  */
 export function hasGSuiteSupportedDomain( domains ) {
 	return getGSuiteSupportedDomains( domains ).length > 0;
-}
-
-/**
- * Does a domain have pending G Suite Users
- *
- * @param {object} domain - domain object
- * @returns {boolean} - Does domain have pending G Suite users
- */
-export function hasPendingGSuiteUsers( domain ) {
-	return get( domain, 'googleAppsSubscription.pendingUsers.length', 0 ) !== 0;
 }

--- a/client/lib/gsuite/index.js
+++ b/client/lib/gsuite/index.js
@@ -7,7 +7,7 @@ import { endsWith, get, sortBy, includes } from 'lodash';
  * Internal dependencies
  */
 import { isMappedDomainWithWpcomNameservers, isRegisteredDomain } from 'lib/domains';
-import userFactory from 'lib/user';
+import { canUserPurchaseGSuite } from './can-user-purchase-gsuite';
 
 export { getAnnualPrice } from './get-annual-price';
 export { getMonthlyPrice } from './get-monthly-price';
@@ -17,6 +17,7 @@ export {
 	isGSuiteProductSlug,
 } from './gsuite-product-slug';
 export { getLoginUrlWithTOSRedirect } from './get-login-url-with-tos-redirect';
+export { canUserPurchaseGSuite } from './can-user-purchase-gsuite';
 
 /**
  * Determines whether G Suite is allowed for the specified domain.
@@ -126,15 +127,4 @@ export function hasGSuiteSupportedDomain( domains ) {
  */
 export function hasPendingGSuiteUsers( domain ) {
 	return get( domain, 'googleAppsSubscription.pendingUsers.length', 0 ) !== 0;
-}
-
-/**
- * Determines whether G Suite can be purchased by the user based on their country.
- *
- * @returns {boolean} true if the user is allowed to purchase G Suite, false otherwise
- */
-export function canUserPurchaseGSuite() {
-	const user = userFactory();
-
-	return get( user.get(), 'is_valid_google_apps_country', false );
 }

--- a/client/lib/gsuite/index.js
+++ b/client/lib/gsuite/index.js
@@ -33,7 +33,7 @@ function applyPrecision( cost, precision ) {
  * @param {string} domainName - domain name
  * @returns {boolean} - true if G Suite is allowed, false otherwise
  */
-function canDomainAddGSuite( domainName ) {
+export function canDomainAddGSuite( domainName ) {
 	if ( endsWith( domainName, '.wpcomstaging.com' ) ) {
 		return false;
 	}
@@ -65,7 +65,7 @@ function formatPrice( cost, currencyCode, options = {} ) {
  * @param {string} defaultValue - value to return when the price can't be determined
  * @returns {string} - the yearly price formatted (e.g. '$99.99'), otherwise the default value
  */
-function getAnnualPrice( cost, currencyCode, defaultValue = '-' ) {
+export function getAnnualPrice( cost, currencyCode, defaultValue = '-' ) {
 	if ( ! isNumber( cost ) && ! isString( currencyCode ) ) {
 		return defaultValue;
 	}
@@ -84,7 +84,7 @@ function getAnnualPrice( cost, currencyCode, defaultValue = '-' ) {
  * @param {Array} domains - list of domain objects
  * @returns {string} - the name of the first eligible domain found
  */
-function getEligibleGSuiteDomain( selectedDomainName, domains ) {
+export function getEligibleGSuiteDomain( selectedDomainName, domains ) {
 	if ( selectedDomainName && canDomainAddGSuite( selectedDomainName ) ) {
 		return selectedDomainName;
 	}
@@ -104,7 +104,7 @@ function getEligibleGSuiteDomain( selectedDomainName, domains ) {
  * @param {Array} domains - list of domain objects
  * @returns {Array} - the list of domains that are eligible for G Suite
  */
-function getGSuiteSupportedDomains( domains ) {
+export function getGSuiteSupportedDomains( domains ) {
 	return domains.filter( function ( domain ) {
 		if ( hasGSuiteWithAnotherProvider( domain ) ) {
 			return false;
@@ -121,7 +121,7 @@ function getGSuiteSupportedDomains( domains ) {
 	} );
 }
 
-function getGSuiteMailboxCount( domain ) {
+export function getGSuiteMailboxCount( domain ) {
 	return get( domain, 'googleAppsSubscription.totalUserCount', 0 );
 }
 
@@ -132,7 +132,7 @@ function getGSuiteMailboxCount( domain ) {
  * @param {string} domain - domain name
  * @returns {string} - ToS url redirect
  */
-function getLoginUrlWithTOSRedirect( email, domain ) {
+export function getLoginUrlWithTOSRedirect( email, domain ) {
 	return (
 		'https://accounts.google.com/AccountChooser?' +
 		`Email=${ encodeURIComponent( email ) }` +
@@ -151,7 +151,7 @@ function getLoginUrlWithTOSRedirect( email, domain ) {
  * @param {string} defaultValue - value to return when the price can't be determined
  * @returns {string} - the monthly price rounded to the nearest tenth (e.g. '$8.40'), otherwise the default value
  */
-function getMonthlyPrice( cost, currencyCode, defaultValue = '-' ) {
+export function getMonthlyPrice( cost, currencyCode, defaultValue = '-' ) {
 	if ( ! isNumber( cost ) && ! isString( currencyCode ) ) {
 		return defaultValue;
 	}
@@ -165,7 +165,7 @@ function getMonthlyPrice( cost, currencyCode, defaultValue = '-' ) {
  * @param {object} domain - domain object
  * @returns {boolean} - true if the domain is under our management, false otherwise
  */
-function hasGSuiteWithUs( domain ) {
+export function hasGSuiteWithUs( domain ) {
 	const defaultValue = '';
 	const domainStatus = get( domain, 'googleAppsSubscription.status', defaultValue );
 	return ! includes( [ defaultValue, 'no_subscription', 'other_provider' ], domainStatus );
@@ -177,7 +177,7 @@ function hasGSuiteWithUs( domain ) {
  * @param {object} domain - domain object
  * @returns {boolean} - true if the domain is with another provider, false otherwise
  */
-function hasGSuiteWithAnotherProvider( domain ) {
+export function hasGSuiteWithAnotherProvider( domain ) {
 	const domainStatus = get( domain, 'googleAppsSubscription.status', '' );
 
 	return 'other_provider' === domainStatus;
@@ -189,7 +189,7 @@ function hasGSuiteWithAnotherProvider( domain ) {
  * @param {Array} domains - list of domain objects
  * @returns {boolean} - Does list of domains contain a G Suited supported domain
  */
-function hasGSuiteSupportedDomain( domains ) {
+export function hasGSuiteSupportedDomain( domains ) {
 	return getGSuiteSupportedDomains( domains ).length > 0;
 }
 
@@ -199,7 +199,7 @@ function hasGSuiteSupportedDomain( domains ) {
  * @param {object} domain - domain object
  * @returns {boolean} - Does domain have pending G Suite users
  */
-function hasPendingGSuiteUsers( domain ) {
+export function hasPendingGSuiteUsers( domain ) {
 	return get( domain, 'googleAppsSubscription.pendingUsers.length', 0 ) !== 0;
 }
 
@@ -209,7 +209,7 @@ function hasPendingGSuiteUsers( domain ) {
  * @param {string} productSlug - slug of the product
  * @returns {boolean} true if the slug refers to G Suite Basic or Business, false otherwise
  */
-function isGSuiteProductSlug( productSlug ) {
+export function isGSuiteProductSlug( productSlug ) {
 	return [ GSUITE_BASIC_SLUG, GSUITE_BUSINESS_SLUG ].includes( productSlug );
 }
 
@@ -219,7 +219,7 @@ function isGSuiteProductSlug( productSlug ) {
  * @param {string} productSlug - slug of the product
  * @returns {boolean} true if the slug refers to an extra license, false otherwise
  */
-function isGSuiteExtraLicenseProductSlug( productSlug ) {
+export function isGSuiteExtraLicenseProductSlug( productSlug ) {
 	return productSlug === GSUITE_EXTRA_LICENSE_SLUG;
 }
 
@@ -229,7 +229,7 @@ function isGSuiteExtraLicenseProductSlug( productSlug ) {
  * @param {string} productSlug - slug of the product
  * @returns {boolean} true if the slug refers to any G Suite product, false otherwise
  */
-function isGSuiteOrExtraLicenseProductSlug( productSlug ) {
+export function isGSuiteOrExtraLicenseProductSlug( productSlug ) {
 	return isGSuiteProductSlug( productSlug ) || isGSuiteExtraLicenseProductSlug( productSlug );
 }
 
@@ -238,26 +238,8 @@ function isGSuiteOrExtraLicenseProductSlug( productSlug ) {
  *
  * @returns {boolean} true if the user is allowed to purchase G Suite, false otherwise
  */
-function canUserPurchaseGSuite() {
+export function canUserPurchaseGSuite() {
 	const user = userFactory();
 
 	return get( user.get(), 'is_valid_google_apps_country', false );
 }
-
-export {
-	canDomainAddGSuite,
-	canUserPurchaseGSuite,
-	getAnnualPrice,
-	getEligibleGSuiteDomain,
-	getGSuiteMailboxCount,
-	getGSuiteSupportedDomains,
-	getLoginUrlWithTOSRedirect,
-	getMonthlyPrice,
-	hasGSuiteSupportedDomain,
-	hasGSuiteWithAnotherProvider,
-	hasGSuiteWithUs,
-	hasPendingGSuiteUsers,
-	isGSuiteExtraLicenseProductSlug,
-	isGSuiteOrExtraLicenseProductSlug,
-	isGSuiteProductSlug,
-};

--- a/client/lib/gsuite/index.js
+++ b/client/lib/gsuite/index.js
@@ -15,6 +15,8 @@ import { formatPrice } from 'lib/gsuite/utils/format-price';
 import { isMappedDomainWithWpcomNameservers, isRegisteredDomain } from 'lib/domains';
 import userFactory from 'lib/user';
 
+export { getAnnualPrice } from './get-annual-price';
+
 /**
  * Determines whether G Suite is allowed for the specified domain.
  *
@@ -27,22 +29,6 @@ export function canDomainAddGSuite( domainName ) {
 	}
 
 	return canUserPurchaseGSuite();
-}
-
-/**
- * Formats the specified yearly price.
- *
- * @param {number} cost - yearly cost (e.g. '99.99')
- * @param {string} currencyCode - code of the currency (e.g. 'USD')
- * @param {string} defaultValue - value to return when the price can't be determined
- * @returns {string} - the yearly price formatted (e.g. '$99.99'), otherwise the default value
- */
-export function getAnnualPrice( cost, currencyCode, defaultValue = '-' ) {
-	if ( ! isNumber( cost ) && ! isString( currencyCode ) ) {
-		return defaultValue;
-	}
-
-	return formatPrice( cost, currencyCode );
 }
 
 /**

--- a/client/lib/gsuite/index.js
+++ b/client/lib/gsuite/index.js
@@ -19,6 +19,7 @@ export {
 export { getLoginUrlWithTOSRedirect } from './get-login-url-with-tos-redirect';
 export { canUserPurchaseGSuite } from './can-user-purchase-gsuite';
 export { canDomainAddGSuite } from './can-domain-add-gsuite';
+export { getGSuiteMailboxCount } from './get-gsuite-mailbox-count';
 
 /**
  * Retrieves the first domain that is eligible to G Suite in this order:
@@ -66,10 +67,6 @@ export function getGSuiteSupportedDomains( domains ) {
 
 		return canDomainAddGSuite( domain.name );
 	} );
-}
-
-export function getGSuiteMailboxCount( domain ) {
-	return get( domain, 'googleAppsSubscription.totalUserCount', 0 );
 }
 
 /**

--- a/client/lib/gsuite/index.js
+++ b/client/lib/gsuite/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { endsWith, get, isNumber, isString, sortBy, includes } from 'lodash';
+import { endsWith, get, sortBy, includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -11,11 +11,11 @@ import {
 	GSUITE_BUSINESS_SLUG,
 	GSUITE_EXTRA_LICENSE_SLUG,
 } from 'lib/gsuite/constants';
-import { formatPrice } from 'lib/gsuite/utils/format-price';
 import { isMappedDomainWithWpcomNameservers, isRegisteredDomain } from 'lib/domains';
 import userFactory from 'lib/user';
 
 export { getAnnualPrice } from './get-annual-price';
+export { getMonthlyPrice } from './get-monthly-price';
 
 /**
  * Determines whether G Suite is allowed for the specified domain.
@@ -99,22 +99,6 @@ export function getLoginUrlWithTOSRedirect( email, domain ) {
 			`https://admin.google.com/${ domain }/AcceptTermsOfService?continue=https://mail.google.com/mail/u/${ email }`
 		) }`
 	);
-}
-
-/**
- * Computes and formats the monthly price from the specified yearly price.
- *
- * @param {number} cost - yearly cost (e.g. '99.99')
- * @param {string} currencyCode - code of the currency (e.g. 'USD')
- * @param {string} defaultValue - value to return when the price can't be determined
- * @returns {string} - the monthly price rounded to the nearest tenth (e.g. '$8.40'), otherwise the default value
- */
-export function getMonthlyPrice( cost, currencyCode, defaultValue = '-' ) {
-	if ( ! isNumber( cost ) && ! isString( currencyCode ) ) {
-		return defaultValue;
-	}
-
-	return formatPrice( cost / 12, currencyCode, { precision: 1 } );
 }
 
 /**

--- a/client/lib/gsuite/index.js
+++ b/client/lib/gsuite/index.js
@@ -1,14 +1,3 @@
-/**
- * External dependencies
- */
-import { get, sortBy } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import { canDomainAddGSuite } from './can-domain-add-gsuite';
-import { getGSuiteSupportedDomains } from './gsuite-supported-domain';
-
 export { getAnnualPrice } from './get-annual-price';
 export { getMonthlyPrice } from './get-monthly-price';
 export {
@@ -24,28 +13,4 @@ export { hasGSuiteWithUs } from './has-gsuite-with-us';
 export { hasGSuiteWithAnotherProvider } from './has-gsuite-with-another-provider';
 export { hasPendingGSuiteUsers } from './has-pending-gsuite-users';
 export { getGSuiteSupportedDomains, hasGSuiteSupportedDomain } from './gsuite-supported-domain';
-
-/**
- * Retrieves the first domain that is eligible to G Suite in this order:
- *
- *   - The domain from the site currently selected, if eligible
- *   - The primary domain of the site, if eligible
- *   - The first non-primary domain eligible found
- *
- * @param {string} selectedDomainName - domain name for the site currently selected by the user
- * @param {Array} domains - list of domain objects
- * @returns {string} - the name of the first eligible domain found
- */
-export function getEligibleGSuiteDomain( selectedDomainName, domains ) {
-	if ( selectedDomainName && canDomainAddGSuite( selectedDomainName ) ) {
-		return selectedDomainName;
-	}
-
-	// Orders domains with the primary domain in first position, if any
-	const supportedDomains = sortBy(
-		getGSuiteSupportedDomains( domains ),
-		( domain ) => ! domain.isPrimary
-	);
-
-	return get( supportedDomains, '[0].name', '' );
-}
+export { getEligibleGSuiteDomain } from './get-eligible-gsuite-domain';

--- a/client/lib/gsuite/index.js
+++ b/client/lib/gsuite/index.js
@@ -1,16 +1,16 @@
+export { canDomainAddGSuite } from './can-domain-add-gsuite';
+export { canUserPurchaseGSuite } from './can-user-purchase-gsuite';
 export { getAnnualPrice } from './get-annual-price';
+export { getEligibleGSuiteDomain } from './get-eligible-gsuite-domain';
+export { getGSuiteMailboxCount } from './get-gsuite-mailbox-count';
+export { getLoginUrlWithTOSRedirect } from './get-login-url-with-tos-redirect';
 export { getMonthlyPrice } from './get-monthly-price';
 export {
 	isGSuiteExtraLicenseProductSlug,
 	isGSuiteOrExtraLicenseProductSlug,
 	isGSuiteProductSlug,
 } from './gsuite-product-slug';
-export { getLoginUrlWithTOSRedirect } from './get-login-url-with-tos-redirect';
-export { canUserPurchaseGSuite } from './can-user-purchase-gsuite';
-export { canDomainAddGSuite } from './can-domain-add-gsuite';
-export { getGSuiteMailboxCount } from './get-gsuite-mailbox-count';
-export { hasGSuiteWithUs } from './has-gsuite-with-us';
-export { hasGSuiteWithAnotherProvider } from './has-gsuite-with-another-provider';
-export { hasPendingGSuiteUsers } from './has-pending-gsuite-users';
 export { getGSuiteSupportedDomains, hasGSuiteSupportedDomain } from './gsuite-supported-domain';
-export { getEligibleGSuiteDomain } from './get-eligible-gsuite-domain';
+export { hasGSuiteWithAnotherProvider } from './has-gsuite-with-another-provider';
+export { hasGSuiteWithUs } from './has-gsuite-with-us';
+export { hasPendingGSuiteUsers } from './has-pending-gsuite-users';

--- a/client/lib/gsuite/index.js
+++ b/client/lib/gsuite/index.js
@@ -1,13 +1,13 @@
 /**
  * External dependencies
  */
-import { endsWith, get, sortBy, includes } from 'lodash';
+import { get, sortBy, includes } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { isMappedDomainWithWpcomNameservers, isRegisteredDomain } from 'lib/domains';
-import { canUserPurchaseGSuite } from './can-user-purchase-gsuite';
+import { canDomainAddGSuite } from './can-domain-add-gsuite';
 
 export { getAnnualPrice } from './get-annual-price';
 export { getMonthlyPrice } from './get-monthly-price';
@@ -18,20 +18,7 @@ export {
 } from './gsuite-product-slug';
 export { getLoginUrlWithTOSRedirect } from './get-login-url-with-tos-redirect';
 export { canUserPurchaseGSuite } from './can-user-purchase-gsuite';
-
-/**
- * Determines whether G Suite is allowed for the specified domain.
- *
- * @param {string} domainName - domain name
- * @returns {boolean} - true if G Suite is allowed, false otherwise
- */
-export function canDomainAddGSuite( domainName ) {
-	if ( endsWith( domainName, '.wpcomstaging.com' ) ) {
-		return false;
-	}
-
-	return canUserPurchaseGSuite();
-}
+export { canDomainAddGSuite } from './can-domain-add-gsuite';
 
 /**
  * Retrieves the first domain that is eligible to G Suite in this order:

--- a/client/lib/gsuite/index.js
+++ b/client/lib/gsuite/index.js
@@ -6,16 +6,16 @@ import { endsWith, get, sortBy, includes } from 'lodash';
 /**
  * Internal dependencies
  */
-import {
-	GSUITE_BASIC_SLUG,
-	GSUITE_BUSINESS_SLUG,
-	GSUITE_EXTRA_LICENSE_SLUG,
-} from 'lib/gsuite/constants';
 import { isMappedDomainWithWpcomNameservers, isRegisteredDomain } from 'lib/domains';
 import userFactory from 'lib/user';
 
 export { getAnnualPrice } from './get-annual-price';
 export { getMonthlyPrice } from './get-monthly-price';
+export {
+	isGSuiteExtraLicenseProductSlug,
+	isGSuiteOrExtraLicenseProductSlug,
+	isGSuiteProductSlug,
+} from './gsuite-product-slug';
 
 /**
  * Determines whether G Suite is allowed for the specified domain.
@@ -143,36 +143,6 @@ export function hasGSuiteSupportedDomain( domains ) {
  */
 export function hasPendingGSuiteUsers( domain ) {
 	return get( domain, 'googleAppsSubscription.pendingUsers.length', 0 ) !== 0;
-}
-
-/**
- * Determines whether the specified product slug is for G Suite Basic or Business.
- *
- * @param {string} productSlug - slug of the product
- * @returns {boolean} true if the slug refers to G Suite Basic or Business, false otherwise
- */
-export function isGSuiteProductSlug( productSlug ) {
-	return [ GSUITE_BASIC_SLUG, GSUITE_BUSINESS_SLUG ].includes( productSlug );
-}
-
-/**
- * Determines whether the specified product slug is for a G Suite extra license.
- *
- * @param {string} productSlug - slug of the product
- * @returns {boolean} true if the slug refers to an extra license, false otherwise
- */
-export function isGSuiteExtraLicenseProductSlug( productSlug ) {
-	return productSlug === GSUITE_EXTRA_LICENSE_SLUG;
-}
-
-/**
- * Determines whether the specified product slug refers to any type of G Suite product.
- *
- * @param {string} productSlug - slug of the product
- * @returns {boolean} true if the slug refers to any G Suite product, false otherwise
- */
-export function isGSuiteOrExtraLicenseProductSlug( productSlug ) {
-	return isGSuiteProductSlug( productSlug ) || isGSuiteExtraLicenseProductSlug( productSlug );
 }
 
 /**

--- a/client/lib/gsuite/index.js
+++ b/client/lib/gsuite/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import formatCurrency from '@automattic/format-currency';
 import { endsWith, get, isNumber, isString, sortBy, includes } from 'lodash';
 
 /**
@@ -12,20 +11,9 @@ import {
 	GSUITE_BUSINESS_SLUG,
 	GSUITE_EXTRA_LICENSE_SLUG,
 } from 'lib/gsuite/constants';
+import { formatPrice } from 'lib/gsuite/utils/format-price';
 import { isMappedDomainWithWpcomNameservers, isRegisteredDomain } from 'lib/domains';
 import userFactory from 'lib/user';
-
-/**
- * Applies a precision to the cost
- *
- * @param {number} cost - cost
- * @param {number} precision - precision to apply to cost
- * @returns {string} - Returns price with applied precision
- */
-function applyPrecision( cost, precision ) {
-	const exponent = Math.pow( 10, precision );
-	return Math.ceil( cost * exponent ) / exponent;
-}
 
 /**
  * Determines whether G Suite is allowed for the specified domain.
@@ -39,22 +27,6 @@ export function canDomainAddGSuite( domainName ) {
 	}
 
 	return canUserPurchaseGSuite();
-}
-
-/**
- * Formats price given cost and currency
- *
- * @param {number} cost - cost
- * @param {string} currencyCode - currency code to format with
- * @param {object} options - options containing precision
- * @returns {string} - Returns a formatted price
- */
-function formatPrice( cost, currencyCode, options = {} ) {
-	if ( undefined !== options.precision ) {
-		cost = applyPrecision( cost, options.precision );
-	}
-
-	return formatCurrency( cost, currencyCode, cost % 1 > 0 ? {} : { precision: 0 } );
 }
 
 /**

--- a/client/lib/gsuite/index.js
+++ b/client/lib/gsuite/index.js
@@ -6,10 +6,8 @@ import { get, sortBy } from 'lodash';
 /**
  * Internal dependencies
  */
-import { isMappedDomainWithWpcomNameservers, isRegisteredDomain } from 'lib/domains';
 import { canDomainAddGSuite } from './can-domain-add-gsuite';
-import { hasGSuiteWithUs } from './has-gsuite-with-us';
-import { hasGSuiteWithAnotherProvider } from './has-gsuite-with-another-provider';
+import { getGSuiteSupportedDomains } from './gsuite-supported-domain';
 
 export { getAnnualPrice } from './get-annual-price';
 export { getMonthlyPrice } from './get-monthly-price';
@@ -25,6 +23,7 @@ export { getGSuiteMailboxCount } from './get-gsuite-mailbox-count';
 export { hasGSuiteWithUs } from './has-gsuite-with-us';
 export { hasGSuiteWithAnotherProvider } from './has-gsuite-with-another-provider';
 export { hasPendingGSuiteUsers } from './has-pending-gsuite-users';
+export { getGSuiteSupportedDomains, hasGSuiteSupportedDomain } from './gsuite-supported-domain';
 
 /**
  * Retrieves the first domain that is eligible to G Suite in this order:
@@ -49,37 +48,4 @@ export function getEligibleGSuiteDomain( selectedDomainName, domains ) {
 	);
 
 	return get( supportedDomains, '[0].name', '' );
-}
-
-/**
- * Filters a list of domains by the domains that eligible for G Suite.
- *
- * @param {Array} domains - list of domain objects
- * @returns {Array} - the list of domains that are eligible for G Suite
- */
-export function getGSuiteSupportedDomains( domains ) {
-	return domains.filter( function ( domain ) {
-		if ( hasGSuiteWithAnotherProvider( domain ) ) {
-			return false;
-		}
-
-		const isHostedOnWpcom =
-			isRegisteredDomain( domain ) && ( domain.hasWpcomNameservers || hasGSuiteWithUs( domain ) );
-
-		if ( ! isHostedOnWpcom && ! isMappedDomainWithWpcomNameservers( domain ) ) {
-			return false;
-		}
-
-		return canDomainAddGSuite( domain.name );
-	} );
-}
-
-/**
- * Given a list of domains does one of them support G Suite
- *
- * @param {Array} domains - list of domain objects
- * @returns {boolean} - Does list of domains contain a G Suited supported domain
- */
-export function hasGSuiteSupportedDomain( domains ) {
-	return getGSuiteSupportedDomains( domains ).length > 0;
 }

--- a/client/lib/gsuite/index.js
+++ b/client/lib/gsuite/index.js
@@ -1,13 +1,14 @@
 /**
  * External dependencies
  */
-import { get, sortBy, includes } from 'lodash';
+import { get, sortBy } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { isMappedDomainWithWpcomNameservers, isRegisteredDomain } from 'lib/domains';
 import { canDomainAddGSuite } from './can-domain-add-gsuite';
+import { hasGSuiteWithUs } from './has-gsuite-with-us';
 
 export { getAnnualPrice } from './get-annual-price';
 export { getMonthlyPrice } from './get-monthly-price';
@@ -20,6 +21,7 @@ export { getLoginUrlWithTOSRedirect } from './get-login-url-with-tos-redirect';
 export { canUserPurchaseGSuite } from './can-user-purchase-gsuite';
 export { canDomainAddGSuite } from './can-domain-add-gsuite';
 export { getGSuiteMailboxCount } from './get-gsuite-mailbox-count';
+export { hasGSuiteWithUs } from './has-gsuite-with-us';
 
 /**
  * Retrieves the first domain that is eligible to G Suite in this order:
@@ -67,18 +69,6 @@ export function getGSuiteSupportedDomains( domains ) {
 
 		return canDomainAddGSuite( domain.name );
 	} );
-}
-
-/**
- * Given a domain object, does that domain have G Suite with us.
- *
- * @param {object} domain - domain object
- * @returns {boolean} - true if the domain is under our management, false otherwise
- */
-export function hasGSuiteWithUs( domain ) {
-	const defaultValue = '';
-	const domainStatus = get( domain, 'googleAppsSubscription.status', defaultValue );
-	return ! includes( [ defaultValue, 'no_subscription', 'other_provider' ], domainStatus );
 }
 
 /**

--- a/client/lib/gsuite/new-users.ts
+++ b/client/lib/gsuite/new-users.ts
@@ -10,7 +10,7 @@ import { v4 as uuidv4 } from 'uuid';
  * Internal dependencies
  */
 import { googleApps, googleAppsExtraLicenses } from 'lib/cart-values/cart-items';
-import { hasGSuiteWithUs } from '.';
+import { hasGSuiteWithUs } from './has-gsuite-with-us';
 
 // exporting these in the big export below causes trouble
 export interface GSuiteNewUserField {
@@ -126,7 +126,7 @@ const validateOverallEmail = (
 const validateOverallEmailAgainstExistingEmails = (
 	{ value: mailBox, error: mailBoxError }: GSuiteNewUserField,
 	{ value: domain }: GSuiteNewUserField,
-	existingGSuiteUsers: []
+	existingGSuiteUsers: [  ]
 ): GSuiteNewUserField => ( {
 	value: mailBox,
 	error:
@@ -216,7 +216,7 @@ const validateUsers = (
 
 const validateAgainstExistingUsers = (
 	{ uuid, domain, mailBox, firstName, lastName }: GSuiteNewUser,
-	existingGSuiteUsers: []
+	existingGSuiteUsers: [  ]
 ) => ( {
 	uuid,
 	firstName,

--- a/client/lib/gsuite/package.json
+++ b/client/lib/gsuite/package.json
@@ -1,0 +1,3 @@
+{
+	"sideEffects": false
+}

--- a/client/lib/gsuite/utils/format-price.js
+++ b/client/lib/gsuite/utils/format-price.js
@@ -1,0 +1,32 @@
+/**
+ * External dependencies
+ */
+import formatCurrency from '@automattic/format-currency';
+
+/**
+ * Applies a precision to the cost
+ *
+ * @param {number} cost - cost
+ * @param {number} precision - precision to apply to cost
+ * @returns {string} - Returns price with applied precision
+ */
+function applyPrecision( cost, precision ) {
+	const exponent = Math.pow( 10, precision );
+	return Math.ceil( cost * exponent ) / exponent;
+}
+
+/**
+ * Formats price given cost and currency
+ *
+ * @param {number} cost - cost
+ * @param {string} currencyCode - currency code to format with
+ * @param {object} options - options containing precision
+ * @returns {string} - Returns a formatted price
+ */
+export function formatPrice( cost, currencyCode, options = {} ) {
+	if ( undefined !== options.precision ) {
+		cost = applyPrecision( cost, options.precision );
+	}
+
+	return formatCurrency( cost, currencyCode, cost % 1 > 0 ? {} : { precision: 0 } );
+}


### PR DESCRIPTION
`lib/gsuite` is currently made up of a monolithic `index.js`, with many different imports and exports, and a few other files.

This PR splits the various methods out of `index.js` into their own modules, re-exporting them from `index.js`. It also adds a `package.json` file with `sideEffects` configuration so that the bundler can take advantage of the newly-added modularisation.

These changes should remove a reasonable amount of JS from the critical path (13.4KB / 2.6KB compressed), by ensuring `lib/gsuite` functionality is spread out across multiple chunks, according to where it's needed.

#### Changes proposed in this Pull Request

* Split the various exports out of `lib/gsuite/index.js`
* Move `formatPrice` to a `utils` directory
* Add `package.json` file with `sideEffects` configuration

#### Testing instructions

There are no functionality-related code changes in this PR, only moving code around and updating paths. No testing should be needed other than ensuring unit tests continue to work, and that the build completes successfully.
