### PR TITLE
Add missing dependencies to babel-plugin-transform-wpcalypso-async

### DIFF
--- a/packages/babel-plugin-transform-wpcalypso-async/package.json
+++ b/packages/babel-plugin-transform-wpcalypso-async/package.json
@@ -12,5 +12,8 @@
 	},
 	"dependencies": {
 		"lodash": "^4.17.15"
+	},
+	"devDependencies": {
+		"@babel/core": "^7.9.0"
 	}
 }


### PR DESCRIPTION
### Problem

`@yarnpkg/doctor` found an undeclared dependency:
```
➤ YN0000: ┌ /Users/sergio/src/automattic/wp-calypso2/packages/babel-plugin-transform-wpcalypso-async/package.json
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/packages/babel-plugin-transform-wpcalypso-async/test/index.js:4:15: Undeclared dependency on @babel/core
➤ YN0000: └ Completed in 0.56s
```

### Changes

This PR adds that dependency to `./packages/babel-plugin-transform-wpcalypso-async/package.json`. The version range has been copied from `./package.json` to make sure nothing changes.

### Testing instructions

Verify there are no more missing packages:
* Run `npx @yarnpkg/doctor` inside `./packages/babel-plugin-transform-wpcalypso-async`. All warnings about missing dependencies should be gone now.
