### PR TITLE
Fix experiment component to always have an anonId if there is one.

### DIFF
--- a/client/components/data/query-experiments/index.tsx
+++ b/client/components/data/query-experiments/index.tsx
@@ -9,30 +9,27 @@ import { connect } from 'react-redux';
  * Internal Dependencies
  */
 import { fetchExperiments } from 'state/data-layer/wpcom/experiments';
-import { getAnonId, nextRefresh } from 'state/experiments/selectors';
+import { nextRefresh } from 'state/experiments/selectors';
 import { AppState } from 'types';
 
 type QueryProps = {
 	doFetchExperiments: typeof fetchExperiments;
 	updateAfter: number;
-	anonId: string;
 };
 
 const QueryExperiments: FunctionComponent< QueryProps > = ( {
 	updateAfter,
 	doFetchExperiments,
-	anonId,
 } ) => {
 	useEffect( () => {
-		if ( updateAfter < Date.now() ) doFetchExperiments( anonId );
-	}, [ updateAfter, doFetchExperiments, anonId ] );
+		if ( updateAfter < Date.now() ) doFetchExperiments();
+	}, [ updateAfter, doFetchExperiments ] );
 
 	return null;
 };
 
 const mapStateToProps = ( state: AppState ) => ( {
 	updateAfter: nextRefresh( state ),
-	anonId: getAnonId( state ),
 } );
 
 export default connect( mapStateToProps, { doFetchExperiments: fetchExperiments } )(

--- a/client/components/experiment/index.tsx
+++ b/client/components/experiment/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-import React, { FunctionComponent } from 'react';
+import React, { FunctionComponent, useEffect, useState } from 'react';
 import { connect } from 'react-redux';
 import { AppState } from 'types';
 
@@ -23,11 +23,20 @@ export { default as LoadingVariations } from './loading-variations';
  * @param props The properties that describe the experiment
  */
 export const Experiment: FunctionComponent< ExperimentProps > = ( props ) => {
-	const { isLoading: loading, variation, children } = props;
+	const { isLoading: loading, variation, children, name: experimentName } = props;
+	const [ eventFired, setEventFired ] = useState< boolean >( false );
+	useEffect( () => {
+		setEventFired( true );
+	}, [] );
 
-	// we deliberately don't include any props/information about the experiment. This event is not intended to be used
-	// in an experiment as an exposure event.
-	recordTracksEvent( 'calypso_experiment_rendered', {} );
+	if ( ! eventFired ) {
+		// Do to how tracks works, we need to always fire an event immediately to generate an anonid. This event is here
+		// to guarantee that we have an anonid if the browser needs one.
+
+		recordTracksEvent( 'calypso_experiment_rendered', {
+			experimentName,
+		} );
+	}
 
 	return (
 		<>

--- a/client/components/experiment/index.tsx
+++ b/client/components/experiment/index.tsx
@@ -25,10 +25,9 @@ export { default as LoadingVariations } from './loading-variations';
 export const Experiment: FunctionComponent< ExperimentProps > = ( props ) => {
 	const { isLoading: loading, variation, children } = props;
 
-	recordTracksEvent( 'calypso_experiment_rendered', {
-		variation: props.variation,
-		experiment_name: props.variation,
-	} );
+	// we deliberately don't include any props/information about the experiment. This event is not intended to be used
+	// in an experiment as an exposure event.
+	recordTracksEvent( 'calypso_experiment_rendered', {} );
 
 	return (
 		<>

--- a/client/components/experiment/index.tsx
+++ b/client/components/experiment/index.tsx
@@ -11,6 +11,7 @@ import { AppState } from 'types';
 import { getVariationForUser, isLoading } from 'state/experiments/selectors';
 import QueryExperiments from 'components/data/query-experiments';
 import { ExperimentProps } from './experiment-props';
+import { recordTracksEvent } from 'lib/analytics/tracks';
 
 export { default as Variation } from './variation';
 export { default as DefaultVariation } from './default-variation';
@@ -23,6 +24,12 @@ export { default as LoadingVariations } from './loading-variations';
  */
 export const Experiment: FunctionComponent< ExperimentProps > = ( props ) => {
 	const { isLoading: loading, variation, children } = props;
+
+	recordTracksEvent( 'calypso_experiment_rendered', {
+		variation: props.variation,
+		experiment_name: props.variation,
+	} );
+
 	return (
 		<>
 			<QueryExperiments />

--- a/client/components/experiment/index.tsx
+++ b/client/components/experiment/index.tsx
@@ -26,15 +26,16 @@ export const Experiment: FunctionComponent< ExperimentProps > = ( props ) => {
 	const { isLoading: loading, variation, children, name: experimentName } = props;
 	const [ eventFired, setEventFired ] = useState< boolean >( false );
 	useEffect( () => {
+		// set the event fired so we only fire the event after rendering once.
 		setEventFired( true );
 	}, [] );
 
 	if ( ! eventFired ) {
-		// Do to how tracks works, we need to always fire an event immediately to generate an anonid. This event is here
+		// Due to how tracks works, we need to always fire an event immediately to generate an anonid. This event is here
 		// to guarantee that we have an anonid if the browser needs one.
 
 		recordTracksEvent( 'calypso_experiment_rendered', {
-			experimentName,
+			experiment_name: experimentName,
 		} );
 	}
 

--- a/client/state/data-layer/wpcom/experiments/index.js
+++ b/client/state/data-layer/wpcom/experiments/index.js
@@ -43,12 +43,10 @@ export const handleFetchExperiments = ( action ) =>
 
 /**
  * Inform the data-layer to request new experiments from the API
- *
- * @param anonId The anonymous identifier to send to the API
  */
-export const fetchExperiments = ( anonId ) => ( {
+export const fetchExperiments = () => ( {
 	type: EXPERIMENT_FETCH,
-	anonId: anonId == null ? getAnonIdFromCookie() : anonId,
+	anonId: getAnonIdFromCookie(),
 } );
 
 /**

--- a/client/state/experiments/reducer.ts
+++ b/client/state/experiments/reducer.ts
@@ -56,6 +56,7 @@ const reducer: Reducer< ExperimentState, HandledActions > = (
 		case EXPERIMENT_FETCH:
 			return {
 				...state,
+				anonId: getAnonIdFromCookie(),
 				isLoading: true,
 			};
 		default:


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Ensures that we call the API after we have an anonid.

#### Testing instructions

* Visit http://calypso.localhost:3000/start/onboarding with no cookies
* Check the network pane and ensure the call to the API includes an anonID.
