### PR TITLE
Reader: Update the styling of the counters

### DIFF
--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -146,7 +146,7 @@
 		line-height: 0;
 		padding: 8px 6px;
 		position: absolute;
-			top: 9px;
+		top: 9px;
 	}
 
 	.badge {

--- a/client/reader/sidebar/reader-sidebar-followed-sites/item.jsx
+++ b/client/reader/sidebar/reader-sidebar-followed-sites/item.jsx
@@ -49,7 +49,7 @@ export class ReaderSidebarFollowingItem extends Component {
 				>
 					<Favicon site={ site } className="sidebar__menu-item-siteicon" size={ 18 } />
 
-					<div className="sidebar__menu-item-sitename">{ site.name }</div>
+					<span className="sidebar__menu-item-sitename">{ site.name }</span>
 					{ site.unseen_count > 0 && <Count count={ site.unseen_count } compact /> }
 				</a>
 			</li>

--- a/client/reader/sidebar/reader-sidebar-organizations/list-item.jsx
+++ b/client/reader/sidebar/reader-sidebar-organizations/list-item.jsx
@@ -49,7 +49,7 @@ export class ReaderSidebarOrganizationsListItem extends Component {
 				>
 					<Favicon site={ site } className="sidebar__menu-item-siteicon" size={ 18 } />
 
-					<div className="sidebar__menu-item-sitename">{ site.name }</div>
+					<span className="sidebar__menu-item-sitename">{ site.name }</span>
 					{ site.unseen_count > 0 && <Count count={ site.unseen_count } compact /> }
 				</a>
 			</li>

--- a/client/reader/sidebar/style.scss
+++ b/client/reader/sidebar/style.scss
@@ -16,11 +16,13 @@
 
 	.sidebar__menu .count {
 		position: relative;
+		flex-shrink: 0;
 		top: 0;
 		margin-left: auto;
 		box-sizing: border-box;
 		padding: 4px 6px;
 		line-height: 1;
+		min-width: 22px;
 		background-color: var( --color-sidebar-menu-hover-background );
 		border-color: var( --color-sidebar-menu-hover-background );
 		outline-color: var( --color-sidebar-menu-hover-background );

--- a/client/reader/sidebar/style.scss
+++ b/client/reader/sidebar/style.scss
@@ -20,7 +20,6 @@
 		margin-left: auto;
 		box-sizing: border-box;
 		padding: 4px 6px;
-		min-width: 22px;
 		line-height: 1;
 		background-color: var( --color-sidebar-menu-hover-background );
 		border-color: var( --color-sidebar-menu-hover-background );
@@ -44,6 +43,7 @@
 	.sidebar__menu-item-siteicon {
 		margin-right: 15px;
 		position: relative;
+		flex-shrink: 0;
 	}
 
 	.sidebar__separator {

--- a/client/reader/sidebar/style.scss
+++ b/client/reader/sidebar/style.scss
@@ -14,21 +14,31 @@
 		padding-bottom: 5px;
 	}
 
-	.sidebar__menu-link:hover .count {
-		background-color: var( --color-sidebar-text-alternative );
-		border-color: var( --color-sidebar-text-alternative );
-		outline-color: var( --color-sidebar-text-alternative );
-		color: var( --color-text );
-	}
-
 	.sidebar__menu .count {
+		position: relative;
+		top: 0;
+		margin-left: auto;
+		box-sizing: border-box;
+		padding: 4px 6px;
+		min-width: 22px;
+		line-height: 1;
 		background-color: var( --color-sidebar-menu-hover-background );
 		border-color: var( --color-sidebar-menu-hover-background );
 		outline-color: var( --color-sidebar-menu-hover-background );
 		color: var( --color-sidebar-text-alternative );
 
-		position: absolute;
-		right: 15px;
+	}
+
+	.sidebar__menu-link:hover .count {
+		border-color: var( --color-sidebar-menu-hover-text );
+		outline-color: red;
+		color: var( --color-sidebar-menu-hover-text );
+	}
+
+	.selected .sidebar__menu-link .count {
+		background: transparent;
+		color: var( --color-sidebar-menu-selected-text );
+		border-color: var( --color-sidebar-menu-selected-text );
 	}
 
 	.sidebar__menu-item-siteicon {
@@ -45,5 +55,6 @@
 		text-overflow: ellipsis;
 		white-space: nowrap;
 		overflow: hidden;
+		margin-right: 4px;
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request
 
* Small tweaks to the counters recently introduced in the Reader: if the site's name is very long, they could overlap. These changes keep them separated; they also make the counters a bit taller and adjust the colors so they work better with the different themes.

**Before**
![image](https://user-images.githubusercontent.com/820374/88195668-33f2b380-cc38-11ea-9689-37b9d26833cb.png)

**After**
![image](https://user-images.githubusercontent.com/820374/88195711-3c4aee80-cc38-11ea-8179-ac294023c44b.png)


#### Testing instructions

* Switch to this PR and go to /read
* Does everything look fine in the sidebar? Is the layout breaking in any way?
