### PR TITLE
social-previews package: Make usable for outside consumers

### DIFF
--- a/packages/social-previews/README.md
+++ b/packages/social-previews/README.md
@@ -8,6 +8,19 @@ At the current time there are components to display previews for a:
 - Twitter post.
 - Google Search result.
 
+## Prerequisites
+
+Your application must be able to load Sass/SCSS files. You may implement this
+however you like.
+
+- In a wp-calypso or jetpack environment, Sass loading is already provided.
+- If you're using create-react-app, you may install `node-sass` or [read the
+  CRA documentation on
+  sass](https://create-react-app.dev/docs/adding-a-sass-stylesheet/) for more
+  info.
+- If you're using your own webpack config, [read the webpack documentation on
+  adding a sass-loader](https://webpack.js.org/loaders/sass-loader/).
+
 ## Usage
 
 Here's a simple usage example using the preview component for Facebook:

--- a/packages/social-previews/README.md
+++ b/packages/social-previews/README.md
@@ -28,7 +28,7 @@ Here's a simple usage example using the preview component for Facebook:
 ```js
 import { FacebookPreview } from '@automattic/social-previews';
 
-<Facebook
+<FacebookPreview
 	title="Five for the Future"
 	description="Launched in 2014, Five for the Future encourages organizations to contribute five percent of their resources to WordPress development. WordPress co-founder Matt Mullenweg proposed this benchmark to maintain a “golden ratio” of contributors to users."
 	url="https://wordpress.org/five-for-the-future/"

--- a/packages/social-previews/README.md
+++ b/packages/social-previews/README.md
@@ -1,26 +1,26 @@
-Social Previews
-========
+# Social Previews
 
 This package contains low level components that can be used to display an _approximation_ of how a given post might like look when viewed on various social media / search platforms.
 
 At the current time there are components to display previews for a:
 
-* Facebook post.
-* Twitter post.
-* Google Search result.
+- Facebook post.
+- Twitter post.
+- Google Search result.
 
 ## Usage
+
 Here's a simple usage example using the preview component for Facebook:
 
 ```js
 import { FacebookPreview } from '@automattic/social-previews';
 
 <Facebook
-    title="Five for the Future"
-    description="Launched in 2014, Five for the Future encourages organizations to contribute five percent of their resources to WordPress development. WordPress co-founder Matt Mullenweg proposed this benchmark to maintain a “golden ratio” of contributors to users."
-    url="https://wordpress.org/five-for-the-future/"
-    author="Matt Mullenweg"
-/>
+	title="Five for the Future"
+	description="Launched in 2014, Five for the Future encourages organizations to contribute five percent of their resources to WordPress development. WordPress co-founder Matt Mullenweg proposed this benchmark to maintain a “golden ratio” of contributors to users."
+	url="https://wordpress.org/five-for-the-future/"
+	author="Matt Mullenweg"
+/>;
 ```
 
 Here is another example using the Search result component:
@@ -29,20 +29,20 @@ Here is another example using the Search result component:
 import { SearchPreview } from '@automattic/social-previews';
 
 <SearchPreview
-    title="Five for the Future"
-    description="Launched in 2014, Five for the Future encourages organizations to contribute five percent of their resources to WordPress development. WordPress co-founder Matt Mullenweg proposed this benchmark to maintain a “golden ratio” of contributors to users."
-    url="https://wordpress.org/five-for-the-future/"
-    author="Matt Mullenweg"
-/>
+	title="Five for the Future"
+	description="Launched in 2014, Five for the Future encourages organizations to contribute five percent of their resources to WordPress development. WordPress co-founder Matt Mullenweg proposed this benchmark to maintain a “golden ratio” of contributors to users."
+	url="https://wordpress.org/five-for-the-future/"
+	author="Matt Mullenweg"
+/>;
 ```
 
 ## Properties
 
 There are a number of common properties used across all components:
 
-* `title` - the title of the post being previewed.
-* `description` - a longer description of the post being previewed.
-* `url` - the full URL of the post being previewed.
+- `title` - the title of the post being previewed.
+- `description` - a longer description of the post being previewed.
+- `url` - the full URL of the post being previewed.
 
 In addition each individual component accepts optional additional properties that may be specific to their given platform (eg: `image`, `author`...etc).
 

--- a/packages/social-previews/package.json
+++ b/packages/social-previews/package.json
@@ -45,7 +45,6 @@
 		"enzyme": "^3.11.0"
 	},
 	"peerDependencies": {
-		"react": "^16.12.0",
-		"node-sass": ">= 4.x"
+		"react": "^16.12.0"
 	}
 }

--- a/packages/social-previews/package.json
+++ b/packages/social-previews/package.json
@@ -45,6 +45,7 @@
 		"enzyme": "^3.11.0"
 	},
 	"peerDependencies": {
-		"react": "^16.12.0"
+		"react": "^16.12.0",
+		"node-sass": ">= 4.x"
 	}
 }

--- a/packages/social-previews/src/facebook-preview/style.scss
+++ b/packages/social-previews/src/facebook-preview/style.scss
@@ -9,6 +9,8 @@
  * @blame: dmsnell
 */
 
+@import '../variables.scss';
+
 .facebook-preview {
 	border: none;
 	box-shadow: 0 0 0 1px rgba( 0, 0, 0, 0.15 ) inset, 0 1px 4px rgba( 0, 0, 0, 0.1 );

--- a/packages/social-previews/src/search-preview/style.scss
+++ b/packages/social-previews/src/search-preview/style.scss
@@ -9,6 +9,8 @@
  * @blame: dmsnell
 */
 
+@import '../variables.scss';
+
 .search-preview__header {
 	margin: 0;
 	padding: 8px 0;

--- a/packages/social-previews/src/twitter-preview/style.scss
+++ b/packages/social-previews/src/twitter-preview/style.scss
@@ -9,6 +9,8 @@
  * @blame: dmsnell
 */
 
+@import '../variables.scss';
+
 .twitter-preview {
 	width: inherit;
 	overflow-x: auto;

--- a/packages/social-previews/src/variables.scss
+++ b/packages/social-previews/src/variables.scss
@@ -1,0 +1,12 @@
+// Define variables, but only if they already don't exist.
+//                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+// This is for any outside consumers of the package that
+// don't have the entire calypso environment, which provides
+// these variables from a private package.
+// (See: https://sass-lang.com/documentation/variables#default-values )
+
+// In a regular calypso environment with @automattic/typography pulled in,
+// these won't have any effect.
+
+$font-body-extra-small: 12px !default;
+$font-body-small: 14px !default;


### PR DESCRIPTION
#### Existing problem

If you create a new react app with `create-react-app`, add the package [`@automattic/social-previews`](https://www.npmjs.com/package/@automattic/social-previews) (added in #44170), and add an example social preview, the app crashes.  Ideally, the app should be usable outside the calypso ecosystem.

There are 2 main problems: 

* A sass file is imported, but the app doesn't know what to do with it.
* Two sass variables are referenced, but they're from @automattic/typography, a package inside calypso that's set to be private, and isn't published on npm.

#### Changes proposed in this Pull Request

* List node-sass as a peerDependency so users of this package know that they need to install it as well.
* Add sass code that defines the variables `$font-body-extra-small` and `$font-body-small`, but only if they're not already defined.  The goal is to not change the behavior of calypso but to allow outside users of the package to use it without crashing.

#### Testing instructions (Initial Problem)

* Check out the master branch in calypso.
* `cd packages/social-previews`
* `yarn link`
* `cd` outside of calypso.
* Create a new react app with `create-react-app`.  Outside of calypso:
```
npx create-react-app my-app
cd my-app
npm start
```
* `yarn link @automattic/social-previews`
* `yarn add @automattic/social-previews`
* Copy and paste some example code from https://www.npmjs.com/package/@automattic/social-previews into your `src/App.js.`
* `yarn start` and view the website.

You should see the new component - but you probably won't have gotten this far since the PR is not published on NPM. 

**To test the fixes in the external app**:

First, install node-sass into your external app.  You'll have to trust that the peerDependencies change gives you a warning about this; I couldn't find a way to test it.

* `yarn add node-sass`

The next goal is to get the updated package code into your outside app.

* Stop your react app.
* Go to calypso and check out this branch. `git checkout update/social-previews`.
* The `yarn link` you set up earlier should take care of the next steps.
* ~~`cd packages/social-previews`~~
* ~~`yarn clean && yarn prepublish && yarn prepare`~~
* ~~`cp -R dist ~/dev/my-app/node-modules/@automattic/social-previews/        # Change to where your my-app dir is.`~~

* Now if you go to the external app, you should be able to `yarn start` and see the component.

**To test the fixes in calypso:**

* Stop your react app.
* Go to calypso and check out this branch. `git checkout update/social-previews`.
* Run `yarn && yarn start` to build all the things. Wait for Calypso to boot. Goto `http://calypso.localhost:3000/`.
* On a `Business` site, create a new Post with some content and a title and click "Preview".
* Toggle the Preview to "Search and Social" using the dropdown.
* You should see the same post previews [as on `master`] and be able to toggle between each type with no errors.
* The font sizes should look the same as before.  For example, you should be able to look at the CSS rules for `.search-preview__url` and see that the font-size is a rem value coming from `@automattic/typography`, not a px value coming from this pull request.

#### Conclusion

Tagging @getdave @marekhrabe @cpapazoglou for review.  Also, maybe this should wait until we do the jetpack integration? Or review this along side it?

