### PR TITLE
Gutenboarding: update domains step within site creation flow

### DIFF
--- a/client/landing/gutenboarding/hooks/use-step-navigation.ts
+++ b/client/landing/gutenboarding/hooks/use-step-navigation.ts
@@ -46,13 +46,12 @@ export default function useStepNavigation(): { goBack: () => void; goNext: () =>
 			: onSignupDialogOpen();
 
 	// Logic necessary to skip Domains or Plans steps
-	const { domain, hasUsedPlansStep } = useSelect( ( select ) =>
+	const { domain, hasUsedDomainsStep, hasUsedPlansStep } = useSelect( ( select ) =>
 		select( ONBOARD_STORE ).getState()
 	);
 	const plan = useSelect( ( select ) => select( ONBOARD_STORE ).getPlan() );
 
-	// remove Domains step only if it's at the end
-	if ( ! siteTitle && domain ) {
+	if ( domain && ! hasUsedDomainsStep ) {
 		steps = steps.filter( ( step ) => step !== Step.Domains );
 	}
 	if ( plan && ! hasUsedPlansStep ) {
@@ -64,8 +63,7 @@ export default function useStepNavigation(): { goBack: () => void; goNext: () =>
 	const nextStepPath =
 		currentStepIndex < steps.length - 1 ? makePath( steps[ currentStepIndex + 1 ] ) : '';
 
-	// Plans and Domains step are skipped if plan/domain is already selected.
-	const isLastStep = currentStepIndex === steps.length - 1 || currentStepIndex === -1; // final step could have been removed because of selection
+	const isLastStep = currentStepIndex === steps.length - 1;
 
 	const handleBack = () => history.push( previousStepPath );
 	const handleNext = () => ( isLastStep ? handleSiteCreation() : history.push( nextStepPath ) );

--- a/client/landing/gutenboarding/hooks/use-step-navigation.ts
+++ b/client/landing/gutenboarding/hooks/use-step-navigation.ts
@@ -31,9 +31,10 @@ export default function useStepNavigation(): { goBack: () => void; goNext: () =>
 	const { i18nLocale } = useI18n();
 	// If the user enters a site title on Intent Capture step we are showing Domains step next.
 	// Else, we're showing Domains step before Plans step.
-	let steps = siteTitle
-		? [ Step.IntentGathering, Step.Domains, Step.DesignSelection, Step.Style, Step.Plans ]
-		: [ Step.IntentGathering, Step.DesignSelection, Step.Style, Step.Domains, Step.Plans ];
+	let steps =
+		siteTitle?.length > 1
+			? [ Step.IntentGathering, Step.Domains, Step.DesignSelection, Step.Style, Step.Plans ]
+			: [ Step.IntentGathering, Step.DesignSelection, Step.Style, Step.Domains, Step.Plans ];
 
 	// @TODO: move site creation to a separate hook or an action on the ONBOARD store
 	const currentUser = useSelect( ( select ) => select( USER_STORE ).getCurrentUser() );

--- a/client/landing/gutenboarding/onboarding-block/domains/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/domains/index.tsx
@@ -45,7 +45,11 @@ const DomainsStep: React.FunctionComponent< Props > = ( { isModal } ) => {
 	const domain = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedDomain() );
 	const domainSearch = useSelect( ( select ) => select( ONBOARD_STORE ).getDomainSearch() );
 
-	const { setDomain, setDomainSearch } = useDispatch( ONBOARD_STORE );
+	const { setDomain, setDomainSearch, setHasUsedDomainsStep } = useDispatch( ONBOARD_STORE );
+
+	React.useEffect( () => {
+		! isModal && setHasUsedDomainsStep( true );
+	}, [] );
 
 	// Keep a copy of the selected domain locally so it's available when the component is unmounting
 	const selectedDomainRef = React.useRef< string | undefined >();

--- a/client/landing/gutenboarding/stores/onboard/actions.ts
+++ b/client/landing/gutenboarding/stores/onboard/actions.ts
@@ -87,6 +87,11 @@ export const setIsRedirecting = ( isRedirecting: boolean ) => ( {
 	isRedirecting,
 } );
 
+export const setHasUsedDomainsStep = ( hasUsedDomainsStep: boolean ) => ( {
+	type: 'SET_HAS_USED_DOMAINS_STEP' as const,
+	hasUsedDomainsStep,
+} );
+
 export const setHasUsedPlansStep = ( hasUsedPlansStep: boolean ) => ( {
 	type: 'SET_HAS_USED_PLANS_STEP' as const,
 	hasUsedPlansStep,
@@ -168,6 +173,7 @@ export type OnboardAction = ReturnType<
 	| typeof setDomainCategory
 	| typeof setFonts
 	| typeof setIsRedirecting
+	| typeof setHasUsedDomainsStep
 	| typeof setHasUsedPlansStep
 	| typeof setSelectedDesign
 	| typeof setSelectedSite

--- a/client/landing/gutenboarding/stores/onboard/index.ts
+++ b/client/landing/gutenboarding/stores/onboard/index.ts
@@ -29,6 +29,7 @@ registerStore< State >( STORE_KEY, {
 		'domainSearch',
 		'siteTitle',
 		'siteVertical',
+		'hasUsedDomainsStep',
 		'hasUsedPlansStep',
 		'pageLayouts',
 		'selectedDesign',

--- a/client/landing/gutenboarding/stores/onboard/reducer.ts
+++ b/client/landing/gutenboarding/stores/onboard/reducer.ts
@@ -124,6 +124,16 @@ const isRedirecting: Reducer< boolean, OnboardAction > = ( state = false, action
 	return state;
 };
 
+const hasUsedDomainsStep: Reducer< boolean, OnboardAction > = ( state = false, action ) => {
+	if ( action.type === 'SET_HAS_USED_DOMAINS_STEP' ) {
+		return action.hasUsedDomainsStep;
+	}
+	if ( action.type === 'RESET_ONBOARD_STORE' ) {
+		return false;
+	}
+	return state;
+};
+
 const hasUsedPlansStep: Reducer< boolean, OnboardAction > = ( state = false, action ) => {
 	if ( action.type === 'SET_HAS_USED_PLANS_STEP' ) {
 		return action.hasUsedPlansStep;
@@ -159,6 +169,7 @@ const reducer = combineReducers( {
 	domainSearch,
 	domainCategory,
 	isRedirecting,
+	hasUsedDomainsStep,
 	hasUsedPlansStep,
 	pageLayouts,
 	selectedFonts,


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Hide Domains step from the flow similar to how Plans step is hidden (prevent [early flow completion](https://cloudup.com/cuAsVwnz0yr)):
  - if the step has been loaded once within the flow, always show it when navigating back/forward
  - if the step hasn't been loaded yet but there is a value set through the modal, then hide it
* Show Domains step as the second step only if the site title entered is longer than 2 characters. This will make the navigation more stable preventing unwanted [position switch](https://cloudup.com/cK5FDWdR_KC) or [redirect](https://cloudup.com/cdBKS3II3n6).

### Testing instructions
**Scenario 1**
* go to [/new](https://calypso.live/new?branch=fix/gutenboarding-domains-step).
* type 1 character and press _Enter_ key to save site title and advance => Design step should appear.
* go back and type at least 2 characters and then click _Continue_ => Domains step should appear.

**Scenario 2**
* go to [/new](https://calypso.live/new?branch=fix/gutenboarding-domains-step) with `?fresh` query param.
* skip first step.
* open Domains modal and select a domain. Press _Go back_ to return to main flow.
* advance through the flow without landing on Domains step anymore.