### PR TITLE
FSE: Fix missing inserter

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/editor/block-inserter/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/editor/block-inserter/index.js
@@ -11,6 +11,9 @@ import { render } from '@wordpress/element';
  */
 import PostContentBlockAppender from './post-content-block-appender';
 
+const CONTAINER_CLASS_NAME = 'fse-post-content-block-inserter';
+const CONTAINER_ID = 'fse-post-content-block-inserter';
+
 /**
  * Renders a custom block inserter that will append new blocks inside the post content block.
  */
@@ -26,14 +29,34 @@ function renderPostContentBlockInserter() {
 			return;
 		}
 		clearInterval( editPostHeaderToolbarInception );
+		injectBlockInserter();
 
-		const blockInserterContainer = document.createElement( 'div' );
-		blockInserterContainer.classList.add( 'fse-post-content-block-inserter' );
-
-		headerToolbar.insertBefore( blockInserterContainer, headerToolbar.firstChild );
-
-		render( <PostContentBlockAppender />, blockInserterContainer );
+		// Re-inject the FSE inserter as needed in case React re-renders the header
+		const wpbody = document.getElementById( 'wpbody' );
+		if ( wpbody && typeof window.MutationObserver !== 'undefined' ) {
+			const observer = new window.MutationObserver( injectBlockInserter );
+			observer.observe( document.getElementById( 'wpbody' ), { subtree: true, childList: true } );
+		}
 	} );
 }
 
-domReady( () => renderPostContentBlockInserter() );
+function injectBlockInserter() {
+	if ( document.getElementById( CONTAINER_ID ) ) {
+		return;
+	}
+
+	const headerToolbar = document.querySelector( '.edit-post-header-toolbar' );
+	if ( ! headerToolbar ) {
+		return;
+	}
+
+	const blockInserterContainer = document.createElement( 'div' );
+	blockInserterContainer.className = CONTAINER_CLASS_NAME;
+	blockInserterContainer.id = CONTAINER_ID;
+
+	headerToolbar.insertBefore( blockInserterContainer, headerToolbar.firstChild );
+
+	render( <PostContentBlockAppender />, blockInserterContainer );
+}
+
+domReady( renderPostContentBlockInserter );

--- a/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/editor/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/editor/style.scss
@@ -1,4 +1,4 @@
-.edit-post-header-toolbar > .edit-post-header-toolbar__inserter-toggle {
+.post-type-page .edit-post-header-toolbar > .edit-post-header-toolbar__inserter-toggle {
 	display: none;
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add a MutationObserver to re-inject a React component on DOM changes if the component is not already present.

This is a workaround for https://github.com/Automattic/wp-calypso/issues/43784, which observed that the component is missing. The component is injected into a React tree, which is volatile. Injected components like this will disappear if a parent is re-rendered.

This also adds a class to fix the block inserter from being removed from the post editor. It should only be removed from the page editor.

#### Testing instructions

Use a [dotcom-fse](https://horizon.wordpress.com/start/test-fse) enabled site for testing.

* Try to reproduce https://github.com/Automattic/wp-calypso/issues/43784 on a Simple site without Gutenberg edge.
* Try to reproduce https://github.com/Automattic/wp-calypso/issues/43784 on a Simple site with Gutenberg edge.
* Visit the post editor and ensure you can see the standard block inserter (https://github.com/Automattic/wp-calypso/issues/43784#issuecomment-662551458).

Fixes https://github.com/Automattic/wp-calypso/issues/43784