### PR TITLE
Activity Log: Hide alt-text overflow for broken images in Firefox

### DIFF
--- a/client/my-sites/activity/activity-log-item/style.scss
+++ b/client/my-sites/activity/activity-log-item/style.scss
@@ -391,6 +391,7 @@
 	background-color: var( --color-neutral-10 );
 }
 .activity-log-item__activity-media .is-thumbnail {
+	display: inline-block;
 	width: auto;
 	height: auto;
 	max-width: 48px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Make preview thumbnails in the Activity Log explicitly `inline-block` so that their alt-text doesn't affect the rest of their corresponding card.

Follows up on #44116.

#### Testing instructions

* **Prerequisite:** Open wp-calypso in Firefox.
* For any site with Activity Log, find or create an Activity Log entry where multiple images are attached to a post.
* Observe/verify that for such entries, a broken preview image with long alt text does not cause the rest of the layout to shift to the right. (**Tip:** To easily simulate this condition, open DevTools and inspect the preview image thumbnail. Change its `src` attribute to a non-existent URL and its `alt` attribute to a very long string.)

* To test for regression issues, verify behavior and appearance are unchanged for other browsers and for all other media thumbnails in the Activity Log.

#### Screenshots

##### Before

<img width="1061" alt="Screen Shot 2020-07-22 at 12 31 23" src="https://user-images.githubusercontent.com/670067/88208983-a3a47680-cc17-11ea-9f36-97f872eecf28.png">

##### After

<img width="1063" alt="Screen Shot 2020-07-22 at 12 31 09" src="https://user-images.githubusercontent.com/670067/88208967-9dae9580-cc17-11ea-999d-22e0aaaa9e26.png">
