### PR TITLE
Support: Identify tickets created from chat overflow

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -2043,13 +2043,20 @@ Undocumented.prototype.getDirectlyConfiguration = function ( fn ) {
 	);
 };
 
-Undocumented.prototype.submitKayakoTicket = function ( subject, message, locale, client, fn ) {
+Undocumented.prototype.submitKayakoTicket = function (
+	subject,
+	message,
+	locale,
+	client,
+	isChatOverflow,
+	fn
+) {
 	debug( 'submitKayakoTicket' );
 
 	return this.wpcom.req.post(
 		{
 			path: '/help/tickets/kayako/new',
-			body: { subject, message, locale, client },
+			body: { subject, message, locale, client, is_chat_overflow: isChatOverflow },
 		},
 		fn
 	);

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -464,9 +464,12 @@ class HelpContact extends React.Component {
 		// 2. The support request isn't sent to the forums. Because forum support
 		//    requests are sent to the language specific forums (for popular languages)
 		//    we don't tell the user that support is only offered in English.
+		// 3. The support request isn't sent to Upwork. This is support given in
+		//    the user's language.
 		const showHelpLanguagePrompt =
 			config( 'livechat_support_locales' ).indexOf( currentUserLocale ) === -1 &&
-			SUPPORT_FORUM !== variationSlug;
+			SUPPORT_FORUM !== variationSlug &&
+			SUPPORT_UPWORK_TICKET !== variationSlug;
 
 		return {
 			compact: this.props.compact,

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -62,10 +62,12 @@ import { recordTracksEvent as recordTracksEventAction } from 'state/analytics/ac
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import QueryLanguageNames from 'components/data/query-language-names';
 import getInlineHelpSupportVariation, {
+	SUPPORT_CHAT_OVERFLOW,
 	SUPPORT_DIRECTLY,
+	SUPPORT_FORUM,
 	SUPPORT_HAPPYCHAT,
 	SUPPORT_TICKET,
-	SUPPORT_FORUM,
+	SUPPORT_UPWORK_TICKET,
 } from 'state/selectors/get-inline-help-support-variation';
 
 /**
@@ -185,7 +187,7 @@ class HelpContact extends React.Component {
 
 	submitKayakoTicket = ( contactForm ) => {
 		const { subject, message, howCanWeHelp, howYouFeel, site } = contactForm;
-		const { currentUserLocale } = this.props;
+		const { currentUserLocale, supportVariation } = this.props;
 
 		const ticketMeta = [
 			'How can you help: ' + howCanWeHelp,
@@ -203,6 +205,7 @@ class HelpContact extends React.Component {
 			kayakoMessage,
 			currentUserLocale,
 			this.props.clientSlug,
+			supportVariation === SUPPORT_CHAT_OVERFLOW,
 			( error ) => {
 				if ( error ) {
 					// TODO: bump a stat here
@@ -369,7 +372,9 @@ class HelpContact extends React.Component {
 					showQASuggestions: true,
 				};
 			}
+			case SUPPORT_CHAT_OVERFLOW:
 			case SUPPORT_TICKET:
+			case SUPPORT_UPWORK_TICKET:
 				return {
 					onSubmit: this.submitKayakoTicket,
 					buttonLabel: isSubmitting ? translate( 'Sending email' ) : translate( 'Email us' ),

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -228,6 +228,7 @@ class HelpContact extends React.Component {
 
 				recordTracksEvent( 'calypso_help_contact_submit', {
 					ticket_type: 'kayako',
+					support_variation: supportVariation,
 					site_plan_product_id: site ? site.plan.product_id : null,
 					is_automated_transfer: site ? site.options.is_automated_transfer : null,
 				} );

--- a/client/state/selectors/get-inline-help-support-variation.js
+++ b/client/state/selectors/get-inline-help-support-variation.js
@@ -9,24 +9,25 @@ import isHappychatAvailable from 'state/happychat/selectors/is-happychat-availab
 import isHappychatUserEligible from 'state/happychat/selectors/is-happychat-user-eligible';
 import { isTicketSupportEligible } from 'state/help/ticket/selectors';
 
+export const SUPPORT_CHAT_OVERFLOW = 'SUPPORT_CHAT_OVERFLOW';
 export const SUPPORT_DIRECTLY = 'SUPPORT_DIRECTLY';
+export const SUPPORT_FORUM = 'SUPPORT_FORUM';
 export const SUPPORT_HAPPYCHAT = 'SUPPORT_HAPPYCHAT';
 export const SUPPORT_TICKET = 'SUPPORT_TICKET';
-export const SUPPORT_FORUM = 'SUPPORT_FORUM';
+export const SUPPORT_UPWORK_TICKET = 'SUPPORT_UPWORK_TICKET';
 
 /**
  * @param {object} state Global state tree
  * @returns {string} One of the exported support variation constants listed above
  */
 export default function getSupportVariation( state ) {
-	if (
-		config.isEnabled( 'happychat' ) &&
-		isHappychatAvailable( state ) &&
-		isHappychatUserEligible( state ) &&
-		// Upwork-eligible customers should skip Happychat and get sent to Tickets
-		! isEligibleForUpworkSupport( state )
-	) {
-		return SUPPORT_HAPPYCHAT;
+	if ( isEligibleForUpworkSupport( state ) && isTicketSupportEligible( state ) ) {
+		// Upwork-eligible customers are sent to tickets, even if chat is available
+		return SUPPORT_UPWORK_TICKET;
+	}
+
+	if ( config.isEnabled( 'happychat' ) && isHappychatUserEligible( state ) ) {
+		return isHappychatAvailable( state ) ? SUPPORT_HAPPYCHAT : SUPPORT_CHAT_OVERFLOW;
 	}
 
 	if ( isTicketSupportEligible( state ) ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When Chat is full or unavailable, customers are sent to Tickets instead. We want to track how often this happens, so we can calculate the actual demand for live chat support.

This PR does a couple things to accomplish that:
- Adjusts `getInlineHelpSupportVariation` to add two new support types: `SUPPORT_CHAT_OVERFLOW` and `SUPPORT_UPWORK_TICKET` (which was created to make the logic clearer)
- Both of these new variations still end up creating tickets, but when it's `SUPPORT_CHAT_OVERFLOW` we pass that along to the API that creates the ticket (so it can be flagged in Zendesk)
- Also adds a new param to the Tracks event, so we can double-check overflow tickets in Tracks as well

And as an added bonus, now that we can clearly differentiate Upwork Tickets from normal Tickets, this remove the "English-only" warning on the contact form for Upwork support (because this _is_ native language support).

#### Testing instructions

Essentially, we need to trigger the changed support variations to ensure they still work as expected.

- Sign in as an English user without chat access
  - You should create a normal ticket (example: 3165085-zen)
- Sign in as an English user with chat access and chat staffed
  - You should get the option to start a chat
- Sign in as an English user with chat access but chat is not staffed
  - You should create a ticket with "Chat overflow" flagged (example: 3165094-zen)
- Sign in with an Upwork-supported language with high-value plans
  - You should get the option to chat
  - You should see the "english-only" notice
- Sign in with an Upwork-supported language without high-value plans
  - You should create a ticket tagged with that language (example: 3165091-zen)
  - You should _not_ see the "english-only" notice