### PR TITLE
e2e: Change timeout so that tests don't fail on sauce

### DIFF
--- a/test/e2e/magellan-canary.json
+++ b/test/e2e/magellan-canary.json
@@ -9,5 +9,5 @@
 	"framework": "testarmada-magellan-mocha-plugin",
 	"reporters": [ "./lib/reporter/magellan-reporter.js" ],
 	"executors": [ "testarmada-magellan-local-executor" ],
-	"bail_time": 300000
+	"bail_time": 450000
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This change extends the timeout for individual canaries. They were timing out when running on SauceLabs.

#### Testing instructions

* Locally, run `./run.sh -C -l osx-chrome` and make sure tests pass

