### PR TITLE
Fix the domain only management pages not working from the all domains view

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -47,6 +47,7 @@ import {
 	domainManagementTransfer,
 	domainManagementTransferOut,
 	domainManagementTransferToOtherSite,
+	domainManagementRoot,
 } from 'my-sites/domains/paths';
 import {
 	emailManagement,
@@ -180,6 +181,12 @@ function isPathAllowedForDomainOnlySite( path, slug, primaryDomain, contextParam
 		}
 		return pathFactory( slug, slug );
 	} );
+
+	domainManagementPaths = domainManagementPaths.concat(
+		allPaths.map( ( pathFactory ) => {
+			return pathFactory( slug, slug, domainManagementRoot() );
+		} )
+	);
 
 	if ( primaryDomain && slug !== primaryDomain.name ) {
 		domainManagementPaths = domainManagementPaths.concat(

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -7,6 +7,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import Gridicon from 'components/gridicon';
+// eslint-disable-next-line no-restricted-imports
 import { format as formatUrl, parse as parseUrl } from 'url';
 import { memoize } from 'lodash';
 import { ProgressBar } from '@automattic/components';
@@ -1061,7 +1062,7 @@ function mapStateToProps( state ) {
 		scanState: getScanState( state, siteId ),
 		rewindState: getRewindState( state, siteId ),
 		isCloudEligible: isJetpackCloudEligible( state, siteId ),
-		isAllSitesView: getSelectedSiteId( state ) === null,
+		isAllSitesView: isAllDomainsView || getSelectedSiteId( state ) === null,
 	};
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Turns out that if you open the all domains view and click on a domain purchased from the domain only flow it shows you the Loch Ness monster and 3 buttons instead of the domain management page. That's because of the special way we handle domain only purchases so here's a fix for that.

#### Testing instructions

* Open /domains/manage and click on a domain purchased via the domain only flow. You should see the domain management page
