### PR TITLE
Jetpack Connect: Fix inconsistent URL in `/jetpack/connect` page state

### DIFF
--- a/client/jetpack-connect/jetpack-connection.jsx
+++ b/client/jetpack-connect/jetpack-connection.jsx
@@ -66,12 +66,20 @@ const jetpackConnection = ( WrappedComponent ) => {
 
 		goBack = () => page.back();
 
+		// HACK: We wrap _processJpSite here so that this.state.url
+		// is consistent/up-to-date for all downstream calls.
+		// Calling _processJpSite in setState's callback guarantees
+		// it will only be executed after the state has been changed.
+		//
+		// TODO: Come back and simplify state management for this component.
 		processJpSite = ( url ) => {
+			this.setState( { url }, () => this._processJpSite( url ) );
+		};
+
+		_processJpSite = ( url ) => {
 			const { isMobileAppFlow, skipRemoteInstall, forceRemoteInstall } = this.props;
 
 			const status = this.getStatus( url );
-
-			this.setState( { url } );
 
 			if (
 				status === NOT_CONNECTED_JETPACK &&

--- a/client/jetpack-connect/jetpack-connection.jsx
+++ b/client/jetpack-connect/jetpack-connection.jsx
@@ -45,7 +45,6 @@ const debug = debugModule( 'calypso:jetpack-connect:main' );
 const jetpackConnection = ( WrappedComponent ) => {
 	class JetpackConnection extends Component {
 		state = {
-			status: '',
 			url: '',
 			redirecting: false,
 			waitingForSites: true,
@@ -72,7 +71,7 @@ const jetpackConnection = ( WrappedComponent ) => {
 
 			const status = this.getStatus( url );
 
-			this.setState( { url, status } );
+			this.setState( { url } );
 
 			if (
 				status === NOT_CONNECTED_JETPACK &&
@@ -187,13 +186,15 @@ const jetpackConnection = ( WrappedComponent ) => {
 		}
 
 		renderNotices = () => {
+			const status = this.getStatus( this.state.url );
+
 			return ! this.isCurrentUrlFetching() &&
 				this.isCurrentUrlFetched() &&
 				! this.props.jetpackConnectSite.isDismissed &&
-				this.state.status ? (
+				status ? (
 				<JetpackConnectNotices
-					noticeType={ this.state.status }
-					onDismissClick={ IS_DOT_COM === this.state.status ? this.goBack : this.dismissUrl }
+					noticeType={ status }
+					onDismissClick={ IS_DOT_COM === status ? this.goBack : this.dismissUrl }
 					url={ this.state.url }
 					onTerminalError={ this.props.isMobileAppFlow ? this.redirectToMobileApp : null }
 				/>
@@ -273,11 +274,12 @@ const jetpackConnection = ( WrappedComponent ) => {
 
 		render() {
 			const props = this.props.locale ? this.props : omit( this.props, 'locale' );
+			const status = this.getStatus( this.state.url );
 
 			return (
 				<WrappedComponent
 					processJpSite={ this.processJpSite }
-					status={ this.state.status }
+					status={ status }
 					renderFooter={ this.renderFooter }
 					renderNotices={ this.renderNotices }
 					isCurrentUrlFetching={ this.isCurrentUrlFetching() }


### PR DESCRIPTION
Found while researching/troubleshooting for #44228.

#### Changes proposed in this Pull Request

* Remove `status` from the component state in `JetpackConnection`, since it can be derived completely from `getStatus()`.
* Wrap `processJpSite` so that it only executes once `this.state.url` is updated from the supplied input, since `this.state.url` is used in several downstream calls but is not guaranteed to be updated until the component re-renders.

#### Testing instructions

* If you're so inclined, add debugger statements or `console.log` statements while typing a site URL on the `/jetpack/connect` page and verify that the state URL matches what you've typed.
* Alternatively: set the URL by adding a `?url=<site url>` query parameter and verify the state URL reflects the same value.
* No known effects for end users.
* Check for regression issues, especially in the mobile app flow (see #44228).
