### PR TITLE
Settings: simplify language picker component

### DIFF
--- a/client/components/language-picker/index.jsx
+++ b/client/components/language-picker/index.jsx
@@ -8,7 +8,6 @@ import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { find, isString, noop } from 'lodash';
-import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies
@@ -178,7 +177,6 @@ export class LanguagePicker extends PureComponent {
 							<div className="language-picker__name-label">{ langName }</div>
 						</div>
 					</div>
-					<Gridicon icon="chevron-down" size="20" />
 				</button>
 				{ this.renderModal( language.langSlug ) }
 			</Fragment>

--- a/client/components/language-picker/index.jsx
+++ b/client/components/language-picker/index.jsx
@@ -8,6 +8,7 @@ import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { find, isString, noop } from 'lodash';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies
@@ -155,7 +156,7 @@ export class LanguagePicker extends PureComponent {
 			return this.renderPlaceholder();
 		}
 
-		const { disabled, translate } = this.props;
+		const { disabled } = this.props;
 		const langName = language.name;
 		const { langCode, langSubcode } = getLanguageCodeLabels( language.langSlug );
 
@@ -177,9 +178,9 @@ export class LanguagePicker extends PureComponent {
 					<div className="language-picker__name">
 						<div className="language-picker__name-inner">
 							<div className="language-picker__name-label">{ langName }</div>
-							<div className="language-picker__name-change">{ translate( 'Change' ) }</div>
 						</div>
 					</div>
+					<Gridicon icon="chevron-down" />
 				</button>
 				{ this.renderModal( language.langSlug ) }
 			</Fragment>

--- a/client/components/language-picker/index.jsx
+++ b/client/components/language-picker/index.jsx
@@ -170,9 +170,7 @@ export class LanguagePicker extends PureComponent {
 				>
 					<div className="language-picker__icon">
 						<div className="language-picker__icon-inner">
-							{ langCode }
-							{ langSubcode && <br /> }
-							{ langSubcode }
+							{ langSubcode ? `${ langCode } ${ langSubcode }` : langCode }
 						</div>
 					</div>
 					<div className="language-picker__name">
@@ -180,7 +178,7 @@ export class LanguagePicker extends PureComponent {
 							<div className="language-picker__name-label">{ langName }</div>
 						</div>
 					</div>
-					<Gridicon icon="chevron-down" />
+					<Gridicon icon="chevron-down" size="20" />
 				</button>
 				{ this.renderModal( language.langSlug ) }
 			</Fragment>

--- a/client/components/language-picker/style.scss
+++ b/client/components/language-picker/style.scss
@@ -21,19 +21,9 @@
 	&[disabled] {
 		cursor: default;
 		color: var( --color-neutral-40 );
-
-		.gridicons-chevron-down {
-			color: var( --color-neutral-0 );
-		}
 	}
 
 	&:not( [disabled] ) {
-		&:hover {
-			.gridicons-chevron-down {
-				color: var( --color-neutral-30 );
-			}
-		}
-
 		&:focus {
 			&,
 			.language-picker__icon {
@@ -44,10 +34,6 @@
 
 			&:hover {
 				box-shadow: 0 0 0 2px var( --color-primary-20 );
-			}
-
-			.gridicons-chevron-down {
-				color: var( --color-neutral-70 );
 			}
 		}
 	}
@@ -65,19 +51,10 @@
 			background-color: var( --color-neutral-0 );
 		}
 	}
-
-	.gridicons-chevron-down {
-		align-self: center;
-		color: var( --color-neutral-10 );
-		flex-grow: 0;
-		flex-shrink: 0;
-		margin-right: 10px;
-	}
 }
 
 .language-picker__icon {
 	width: 64px;
-	margin: 4px 0;
 	display: flex;
 	align-items: center;
 	justify-content: center;

--- a/client/components/language-picker/style.scss
+++ b/client/components/language-picker/style.scss
@@ -5,13 +5,14 @@
 	width: 300px;
 	display: flex;
 	flex: 1 0 auto;
-	font-size: $font-body-small;
-	height: 48px;
+	font-size: $font-body;
+	height: 40px;
 	align-items: stretch;
 	cursor: pointer;
 	transition: border-color 150ms ease-in-out;
 	text-align: left;
 	line-height: inherit;
+	color: var( --color-neutral-70 );
 
 	@include breakpoint-deprecated( '<660px' ) {
 		width: 100%;
@@ -19,19 +20,17 @@
 
 	&[disabled] {
 		cursor: default;
-		color: var( --color-neutral-0 );
+		color: var( --color-neutral-40 );
 
-		&,
-		.language-picker__icon {
-			border-color: var( --color-neutral-0 );
+		.gridicons-chevron-down {
+			color: var( --color-neutral-0 );
 		}
 	}
 
 	&:not( [disabled] ) {
 		&:hover {
-			&,
-			.language-picker__icon {
-				border-color: var( --color-neutral-20 );
+			.gridicons-chevron-down {
+				color: var( --color-neutral-30 );
 			}
 		}
 
@@ -45,6 +44,10 @@
 
 			&:hover {
 				box-shadow: 0 0 0 2px var( --color-primary-20 );
+			}
+
+			.gridicons-chevron-down {
+				color: var( --color-neutral-70 );
 			}
 		}
 	}
@@ -62,13 +65,13 @@
 			background-color: var( --color-neutral-0 );
 		}
 	}
+
 	.gridicons-chevron-down {
 		align-self: center;
-		color: var( --color-neutral-20 );
+		color: var( --color-neutral-10 );
 		flex-grow: 0;
 		flex-shrink: 0;
 		margin-right: 10px;
-		transition: transform 0.15s cubic-bezier( 0.175, 0.885, 0.32, 1.275 ), color 0.2s ease-in;
 	}
 }
 
@@ -85,8 +88,8 @@
 
 .language-picker__icon-inner {
 	text-transform: uppercase;
-	font-weight: 600;
 	line-height: 1;
+	white-space: nowrap;
 }
 
 .language-picker__name {
@@ -99,7 +102,6 @@
 }
 
 .language-picker__name-inner {
-	font-weight: 600;
 	overflow: hidden;
 }
 

--- a/client/components/language-picker/style.scss
+++ b/client/components/language-picker/style.scss
@@ -6,7 +6,7 @@
 	display: flex;
 	flex: 1 0 auto;
 	font-size: $font-body-small;
-	height: 64px;
+	height: 48px;
 	align-items: stretch;
 	cursor: pointer;
 	transition: border-color 150ms ease-in-out;
@@ -19,15 +19,11 @@
 
 	&[disabled] {
 		cursor: default;
+		color: var( --color-neutral-0 );
 
 		&,
 		.language-picker__icon {
 			border-color: var( --color-neutral-0 );
-		}
-
-		&,
-		.language-picker__name-change {
-			color: var( --color-neutral-0 );
 		}
 	}
 
@@ -66,6 +62,14 @@
 			background-color: var( --color-neutral-0 );
 		}
 	}
+	.gridicons-chevron-down {
+		align-self: center;
+		color: var( --color-neutral-20 );
+		flex-grow: 0;
+		flex-shrink: 0;
+		margin-right: 10px;
+		transition: transform 0.15s cubic-bezier( 0.175, 0.885, 0.32, 1.275 ), color 0.2s ease-in;
+	}
 }
 
 .language-picker__icon {
@@ -86,10 +90,12 @@
 }
 
 .language-picker__name {
-	flex: auto;
+	flex: 1 0 auto;
 	margin: 4px 16px;
 	display: flex;
 	align-items: center;
+	position: relative;
+	width: 0;
 }
 
 .language-picker__name-inner {
@@ -98,10 +104,10 @@
 }
 
 .language-picker__name-label {
+	overflow: hidden;
 	white-space: nowrap;
-}
 
-.language-picker__name-change {
-	text-transform: uppercase;
-	color: var( --color-text-subtle );
+	&::after {
+		@include long-content-fade( $color: var( --color-surface-rgb ) );
+	}
 }

--- a/client/components/language-picker/test/index.jsx
+++ b/client/components/language-picker/test/index.jsx
@@ -70,7 +70,7 @@ describe( 'LanguagePicker', () => {
 		const newProps = { ...defaultProps, value: 'es-mx_gringos' };
 		const wrapper = shallow( <LanguagePicker { ...newProps } /> );
 		expect( wrapper.find( '.language-picker__icon-inner' ).html() ).toBe(
-			'<div class="language-picker__icon-inner">es<br/>mx</div>'
+			'<div class="language-picker__icon-inner">es mx</div>'
 		);
 		expect( wrapper.find( '.language-picker__name-label' ).text() ).toBe(
 			'Español de México de los Gringos'


### PR DESCRIPTION
The language picker used in the general settings and account settings screens is a custom dropdown. It has the word 'CHANGE' inside the box indicating it can be clicked, but as discussed in #41938 this doesn't seem necessary.
As proposed by @rickybanister we can make it look exactly like a standard dropdown, like the timezone picker just below in the general settings screen, for visual consistency.

#### Changes proposed in this Pull Request

* Matched the style of the language picker custom drop down to the style of standard drop downs (select elements), including focused and hovered states.
* The language code and subcode are now shown in one single line, instead of two lines, to allow the custom drop down to match the height of standard drop downs.
* Added a fade for long content

##### Before (general settings)
<img width="741" alt="imagen" src="https://user-images.githubusercontent.com/5444806/88236543-a2913a80-cc53-11ea-840d-66bbae5d7c35.png">

##### After (general settings)
<img width="744" alt="imagen" src="https://user-images.githubusercontent.com/5444806/88236820-4aa70380-cc54-11ea-82cb-cc82f32ca01c.png">

##### Before (account settings)
<img width="564" alt="imagen" src="https://user-images.githubusercontent.com/5444806/88237128-ef294580-cc54-11ea-89d7-74f0452d9493.png">

##### After (account settings)
<img width="561" alt="imagen" src="https://user-images.githubusercontent.com/5444806/88237162-06683300-cc55-11ea-8513-936ece0d7493.png">

##### Before (language code and subcode - two lines)
<img width="381" alt="imagen" src="https://user-images.githubusercontent.com/5444806/88239014-9d36ee80-cc59-11ea-9721-2782f8ae7981.png">

##### After (language code and subcode - one line)
<img width="385" alt="imagen" src="https://user-images.githubusercontent.com/5444806/88239125-d7a08b80-cc59-11ea-9b4c-138fcaf61a11.png">

#### Testing instructions

* In the sidebar, go to Manage > Settings
* Verify that the language picker visually matches the timezone dropdown bellow (size, colors and fonts).
* Pass the mouse over the language picker
* Verify that the chevron's color gets darkened as the one inside the timezone dropdown does when hovered
* Using the keyboard, set the focus on the language picker
* Verify that the language picker gets highlighted as the timezone dropdown does when focused
* Click on the language picker and select "Español de México" from the popup
* Verify that the text inside the language picker is now "ES MX | Español de México"

Fixes #41938 

cc: @jsnajdr 
