### PR TITLE
Support label fix

### DIFF
--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -338,17 +338,17 @@ export class HelpContactForm extends React.PureComponent {
 		const howCanWeHelpOptions = [
 			{
 				value: 'gettingStarted',
-				label: translate( 'Help getting started' ),
+				label: translate( 'Get started' ),
 				subtext: translate( 'Can you show me how to…' ),
 			},
 			{
 				value: 'somethingBroken',
-				label: translate( 'Something is broken' ),
+				label: translate( "Report something isn't working" ),
 				subtext: translate( 'Can you check this out…' ),
 			},
 			{
 				value: 'suggestion',
-				label: translate( 'I have a suggestion' ),
+				label: translate( 'Make a suggestion' ),
 				subtext: translate( 'I think it would be cool if…' ),
 			},
 		];
@@ -385,7 +385,7 @@ export class HelpContactForm extends React.PureComponent {
 
 				{ showHowCanWeHelpField && (
 					<div>
-						<FormLabel>{ translate( 'How can we help?' ) }</FormLabel>
+						<FormLabel>{ translate( "You're reaching out to…" ) }</FormLabel>
 						{ this.renderFormSelection( 'howCanWeHelp', howCanWeHelpOptions ) }
 					</div>
 				) }
@@ -419,7 +419,7 @@ export class HelpContactForm extends React.PureComponent {
 					</div>
 				) }
 
-				<FormLabel htmlFor="message">{ translate( 'Tell us more about the problem' ) }</FormLabel>
+				<FormLabel htmlFor="message">{ translate( 'How can we help?' ) }</FormLabel>
 				<FormTextarea
 					placeholder={ translate( 'Ask away! Help will be with you soon.' ) }
 					id="message"

--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -419,7 +419,7 @@ export class HelpContactForm extends React.PureComponent {
 					</div>
 				) }
 
-				<FormLabel htmlFor="message">{ translate( 'How can we help?' ) }</FormLabel>
+				<FormLabel htmlFor="message">{ translate( 'Tell us more about the problem' ) }</FormLabel>
 				<FormTextarea
 					placeholder={ translate( 'Ask away! Help will be with you soon.' ) }
 					id="message"


### PR DESCRIPTION
cc: @sixhours

Changes proposed in this Pull Request

Change wording on support contact form to avoid duplicate wording. "How can we help?" was used twice.
*
Testing instructions

    Starting at URL: /help/contact
    Final field now says "Tell us more about the problem" instead of "How can we help?"

Before:
![image](https://user-images.githubusercontent.com/53018748/88240603-4ca49e80-cc23-11ea-916b-113dfb40b8d2.png)


After:
![image](https://user-images.githubusercontent.com/53018748/88729402-81a36c00-d0cf-11ea-8ab0-ba091a32665e.png)


Fixes #44287