### PR TITLE
composite-checkout: Do not redirect to plans page if there are errors to display

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -335,7 +335,7 @@ export default function CompositeCheckout( {
 	).filter( Boolean );
 	debug( 'items for checkout', itemsForCheckout );
 
-	useRedirectIfCartEmpty( items, `/plans/${ siteSlug || '' }`, isLoadingCart );
+	useRedirectIfCartEmpty( items, `/plans/${ siteSlug || '' }`, isLoadingCart, errors );
 
 	const { storedCards, isLoading: isLoadingStoredCards } = useStoredCards(
 		getStoredCards || wpcomGetStoredCards,
@@ -601,25 +601,14 @@ function isNotCouponError( error ) {
 	return ! couponErrorCodes.includes( error.code );
 }
 
-function useRedirectIfCartEmpty( items, redirectUrl, isLoading ) {
-	const [ prevItemsLength, setPrevItemsLength ] = useState( 0 );
-
+function useRedirectIfCartEmpty( items, redirectUrl, isLoading, errors ) {
 	useEffect( () => {
-		setPrevItemsLength( items.length );
-	}, [ items ] );
-
-	useEffect( () => {
-		if ( prevItemsLength > 0 && items.length === 0 ) {
-			debug( 'cart has become empty; redirecting...' );
-			page.redirect( redirectUrl );
-			return;
-		}
-		if ( ! isLoading && items.length === 0 ) {
+		if ( ! isLoading && items.length === 0 && errors.length === 0 ) {
 			debug( 'cart is empty and not still loading; redirecting...' );
 			page.redirect( redirectUrl );
 			return;
 		}
-	}, [ redirectUrl, items, prevItemsLength, isLoading ] );
+	}, [ redirectUrl, items, isLoading, errors ] );
 }
 
 function useCountryList( overrideCountryList ) {

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -205,6 +205,7 @@ export default function CompositeCheckout( {
 		allowedPaymentMethods: serverAllowedPaymentMethods,
 		variantSelectOverride,
 		responseCart,
+		loadingError,
 		addItem,
 	} = useShoppingCart(
 		siteSlug,
@@ -326,7 +327,7 @@ export default function CompositeCheckout( {
 	useDetectedCountryCode();
 	useCachedDomainContactDetails();
 
-	useDisplayErrors( errors, showErrorMessage );
+	useDisplayErrors( [ ...errors, loadingError ].filter( Boolean ), showErrorMessage );
 
 	const isFullCredits = credits?.amount.value > 0 && credits?.amount.value >= subtotal.amount.value;
 	const itemsForCheckout = ( items.length
@@ -335,7 +336,12 @@ export default function CompositeCheckout( {
 	).filter( Boolean );
 	debug( 'items for checkout', itemsForCheckout );
 
-	useRedirectIfCartEmpty( items, `/plans/${ siteSlug || '' }`, isLoadingCart, errors );
+	useRedirectIfCartEmpty(
+		items,
+		`/plans/${ siteSlug || '' }`,
+		isLoadingCart,
+		[ ...errors, loadingError ].filter( Boolean )
+	);
 
 	const { storedCards, isLoading: isLoadingStoredCards } = useStoredCards(
 		getStoredCards || wpcomGetStoredCards,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR has two effects:

1. If there is an error while fetching or updating the cart, save and display that error message.
2. If there are any errors from fetching or updating the cart, or if there are any errors returned in the `errors` part of the cart response, do not redirect to the plans page (which we would normally do because the cart may be "empty" if it did not load).

#### Screenshot

![Screen Shot 2020-07-22 at 8 26 00 PM](https://user-images.githubusercontent.com/2036909/88242279-b9875b00-cc5a-11ea-80e4-023f93e73699.png)


#### Testing instructions

- Sandbox the API.
- Visit the `/plans` page in local calypso.
- Apply D46792-code on your sandbox. You must do this AFTER loading the plans page for this test to work.
- On the plans page (without reloading), click an "Upgrade" button to add a plan to your cart. This will redirect you to checkout.
- Verify that you see an error message that reads "User or Token does not have access to specified site."
- Remove D46792-code and repeat the test. Verify that checkout loads correctly.
- Remove all the products from your cart. Verify that you are redirected to the `/plans` page.