### PR TITLE
Adds missing dependencies for wpcom-proxy-request

### DIFF
--- a/packages/wpcom-proxy-request/package.json
+++ b/packages/wpcom-proxy-request/package.json
@@ -46,5 +46,8 @@
 		"progress-event": "^1.0.0",
 		"uuid": "^7.0.1",
 		"wp-error": "^1.3.0"
+	},
+	"devDependencies": {
+		"chai": "^4.2.0"
 	}
 }


### PR DESCRIPTION
### Problem

`@yarnpkg/doctor` found an undeclared dependency:
```
➤ YN0000: ┌ /Users/sergio/src/automattic/wp-calypso/packages/wpcom-proxy-request/package.json
➤ YN0000: │ User scripts prefixed with "pre" or "post" (like "prepublish") will not be called in sequence anymore; prefer calling prologues and epilogues explicitly
➤ YN0000: │ User scripts prefixed with "pre" or "post" (like "prepare") will not be called in sequence anymore; prefer calling prologues and epilogues explicitly
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso/packages/wpcom-proxy-request/test/index.js:6:1: Undeclared dependency on chai
➤ YN0000: └ Completed in 1.85s
```

### Changes

This PR adds that dependency to `./packages/wpcom-proxy-request/package.json`. The version range has been copied from `./package.json` to make sure nothing changes.

### Testing instructions

Verify there are no more missing packages:
* Run `npx @yarnpkg/doctor` inside `./packages/wpcom-proxy-request`. All warnings about missing dependencies should be gone now.
