### PR TITLE
Add missing dependencies to package webpack-inline-constant-exports-plugin

### DIFF
--- a/packages/webpack-inline-constant-exports-plugin/package.json
+++ b/packages/webpack-inline-constant-exports-plugin/package.json
@@ -22,5 +22,8 @@
 	"scripts": {},
 	"peerDependencies": {
 		"webpack": "^4.29.6"
+	},
+	"devDependencies": {
+		"rimraf": "^3.0.0"
 	}
 }


### PR DESCRIPTION
### Problem

`@yarnpkg/doctor` found an undeclared dependency:
```
➤ YN0000: ┌ /Users/sergio/src/automattic/wp-calypso2/packages/webpack-inline-constant-exports-plugin/package.json
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso2/packages/webpack-inline-constant-exports-plugin/test/index.js:6:16: Undeclared dependency on rimraf
➤ YN0000: └ Completed in 0.44s
```

### Changes

This PR adds that dependency to `./packages/webpack-inline-constant-exports-plugin/package.json`. The version range has been copied from `./package.json` to make sure nothing changes.

### Testing instructions

Verify there are no more missing packages:
* Run `npx @yarnpkg/doctor` inside `./packages/webpack-inline-constant-exports-plugin`. All warnings about missing dependencies should be gone now.
