### PR TITLE
Add missing dependencies to package webpack-config-flag-plugin

### DIFF
--- a/packages/webpack-config-flag-plugin/package.json
+++ b/packages/webpack-config-flag-plugin/package.json
@@ -17,5 +17,8 @@
 	"license": "GPL-2.0-or-later",
 	"publishConfig": {
 		"access": "public"
+	},
+	"devDependencies": {
+		"rimraf": "^3.0.0"
 	}
 }


### PR DESCRIPTION
### Problem

`@yarnpkg/doctor` found an undeclared dependency:
```
➤ YN0000: ┌ /Users/sergio/src/automattic/wp-calypso/packages/webpack-config-flag-plugin/package.json
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso/packages/webpack-config-flag-plugin/test/index.js:6:16: Undeclared dependency on rimraf
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso/packages/webpack-config-flag-plugin/test/fixtures/default-import/function.js:1:1: Undeclared dependency on config
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso/packages/webpack-config-flag-plugin/test/fixtures/default-import/module.js:1:1: Undeclared dependency on config
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso/packages/webpack-config-flag-plugin/test/fixtures/default-import/rename.js:1:1: Undeclared dependency on config
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso/packages/webpack-config-flag-plugin/test/fixtures/default-import/shadowed-by-param.js:1:1: Undeclared dependency on config
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso/packages/webpack-config-flag-plugin/test/fixtures/default-import/shadowed-by-var.js:1:1: Undeclared dependency on config
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso/packages/webpack-config-flag-plugin/test/fixtures/default-import/wrong-flag.js:1:1: Undeclared dependency on config
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso/packages/webpack-config-flag-plugin/test/fixtures/named-import/function.js:1:1: Undeclared dependency on config
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso/packages/webpack-config-flag-plugin/test/fixtures/named-import/module.js:1:1: Undeclared dependency on config
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso/packages/webpack-config-flag-plugin/test/fixtures/named-import/rename.js:1:1: Undeclared dependency on config
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso/packages/webpack-config-flag-plugin/test/fixtures/named-import/shadowed-by-param.js:1:1: Undeclared dependency on config
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso/packages/webpack-config-flag-plugin/test/fixtures/named-import/shadowed-by-var.js:1:1: Undeclared dependency on config
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso/packages/webpack-config-flag-plugin/test/fixtures/named-import/wrong-flag.js:1:1: Undeclared dependency on config
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso/packages/webpack-config-flag-plugin/test/fixtures/namespace-import/function.js:1:1: Undeclared dependency on config
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso/packages/webpack-config-flag-plugin/test/fixtures/namespace-import/module.js:1:1: Undeclared dependency on config
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso/packages/webpack-config-flag-plugin/test/fixtures/namespace-import/rename.js:1:1: Undeclared dependency on config
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso/packages/webpack-config-flag-plugin/test/fixtures/namespace-import/shadowed-by-param.js:1:1: Undeclared dependency on config
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso/packages/webpack-config-flag-plugin/test/fixtures/namespace-import/shadowed-by-var.js:1:1: Undeclared dependency on config
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso/packages/webpack-config-flag-plugin/test/fixtures/namespace-import/wrong-flag.js:1:1: Undeclared dependency on config
➤ YN0000: └ Completed in 0.33s
```

### Changes

This PR adds that dependency to `./packages/webpack-config-flag-plugin/package.json`. The version range has been copied from `./package.json` to make sure nothing changes.

### Testing instructions

Verify there are no more missing packages:
* Run `npx @yarnpkg/doctor` inside `./packages/webpack-config-flag-plugin`. All warnings about missing dependencies should be gone now (other than dependencies in fixtures)
