### PR TITLE
Add missing dependency to viewport-react

### DIFF
--- a/packages/viewport-react/package.json
+++ b/packages/viewport-react/package.json
@@ -22,7 +22,11 @@
 		"@wordpress/compose": "^3.7.0"
 	},
 	"peerDependencies": {
-		"react": "^16.0.0"
+		"react": "^16.13.1",
+		"react-dom": "^16.12.0"
+	},
+	"devDependencies": {
+		"regenerator-runtime": "^0.13.4"
 	},
 	"scripts": {
 		"clean": "check-npm-client && npx rimraf dist",


### PR DESCRIPTION
### Problem

`@yarnpkg/doctor` found an undeclared dependency:
```
➤ YN0000: ┌ /Users/sergio/src/automattic/wp-calypso/packages/viewport-react/package.json
➤ YN0000: │ User scripts prefixed with "pre" or "post" (like "prepublish") will not be called in sequence anymore; prefer calling prologues and epilogues explicitly
➤ YN0000: │ User scripts prefixed with "pre" or "post" (like "prepare") will not be called in sequence anymore; prefer calling prologues and epilogues explicitly
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso/packages/viewport-react/test/index.js:8:1: Undeclared dependency on regenerator-runtime
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso/packages/viewport-react/test/index.js:10:1: Undeclared dependency on react-dom
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso/packages/viewport-react/test/index.js:11:1: Undeclared dependency on react-dom
➤ YN0000: └ Completed in 0.33s
```

### Changes

This PR adds that dependency to `./packages/viewport-react/package.json`. The version range has been copied from `./package.json` to make sure nothing changes.

### Testing instructions

Verify there are no more missing packages:
* Run `npx @yarnpkg/doctor` inside `./packages/viewport-react`. All warnings about missing dependencies should be gone now (other than dependencies in fixtures)
