### PR TITLE
Add missing dependencies to package viewport

### DIFF
--- a/packages/viewport/package.json
+++ b/packages/viewport/package.json
@@ -23,5 +23,8 @@
 	},
 	"publishConfig": {
 		"access": "public"
+	},
+	"devDependencies": {
+		"regenerator-runtime": "^0.13.4"
 	}
 }


### PR DESCRIPTION
### Problem

`@yarnpkg/doctor` found an undeclared dependency:
```
➤ YN0000: ┌ /Users/sergio/src/automattic/wp-calypso/packages/viewport/package.json
➤ YN0000: │ User scripts prefixed with "pre" or "post" (like "prepublish") will not be called in sequence anymore; prefer calling prologues and epilogues explicitly
➤ YN0000: │ User scripts prefixed with "pre" or "post" (like "prepare") will not be called in sequence anymore; prefer calling prologues and epilogues explicitly
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso/packages/viewport/test/index.js:7:1: Undeclared dependency on regenerator-runtime
➤ YN0000: └ Completed in 0.32s
```

### Changes

This PR adds that dependency to `./packages/viewport/package.json`. The version range has been copied from `./package.json` to make sure nothing changes.

### Testing instructions

Verify there are no more missing packages:
* Run `npx @yarnpkg/doctor` inside `./packages/viewport`. All warnings about missing dependencies should be gone now (other than dependencies in fixtures)
