### PR TITLE
Add missing dependencies to package popup-monitor

### DIFF
--- a/packages/popup-monitor/package.json
+++ b/packages/popup-monitor/package.json
@@ -34,5 +34,8 @@
 	},
 	"dependencies": {
 		"lodash": "^4.17.15"
+	},
+	"devDependencies": {
+		"chai": "^4.2.0"
 	}
 }


### PR DESCRIPTION
### Problem

`@yarnpkg/doctor` found an undeclared dependency:
```
➤ YN0000: ┌ /Users/sergio/src/automattic/wp-calypso/packages/popup-monitor/package.json
➤ YN0000: │ User scripts prefixed with "pre" or "post" (like "prepublish") will not be called in sequence anymore; prefer calling prologues and epilogues explicitly
➤ YN0000: │ User scripts prefixed with "pre" or "post" (like "prepare") will not be called in sequence anymore; prefer calling prologues and epilogues explicitly
➤ YN0000: │ /Users/sergio/src/automattic/wp-calypso/packages/popup-monitor/test/index.js:8:1: Undeclared dependency on chai
➤ YN0000: └ Completed in 0.33s
```

### Changes

This PR adds that dependency to `./packages/popup-monitor/package.json`. The version range has been copied from `./package.json` to make sure nothing changes.

### Testing instructions

Verify there are no more missing packages:
* Run `npx @yarnpkg/doctor` inside `./packages/popup-monitor`. All warnings about missing dependencies should be gone now (other than dependencies in fixtures)
