### PR TITLE
Add tracking for new domain list features and events

### DIFF
--- a/client/my-sites/domains/domain-management/controller.jsx
+++ b/client/my-sites/domains/domain-management/controller.jsx
@@ -27,6 +27,7 @@ import {
 	domainManagementTransferToOtherSite,
 	domainManagementManageConsent,
 	domainManagementDomainConnectMapping,
+	domainManagementRoot,
 } from 'my-sites/domains/paths';
 import {
 	emailManagement,
@@ -55,14 +56,21 @@ export default {
 	},
 
 	domainManagementListAllSites( pageContext, next ) {
-		pageContext.primary = <DomainManagement.ListAll />;
+		pageContext.primary = (
+			<DomainManagementData
+				analyticsPath={ domainManagementRoot() }
+				analyticsTitle="Domain Management > All Domains"
+				component={ DomainManagement.ListAll }
+				context={ pageContext }
+			/>
+		);
 		next();
 	},
 
 	domainManagementEdit( pageContext, next ) {
 		pageContext.primary = (
 			<DomainManagementData
-				analyticsPath={ domainManagementEdit( ':site', ':domain' ) }
+				analyticsPath={ domainManagementEdit( ':site', ':domain', pageContext.canonicalPath ) }
 				analyticsTitle="Domain Management > Edit"
 				component={ DomainManagement.Edit }
 				context={ pageContext }

--- a/client/my-sites/domains/domain-management/list/domain-item.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-item.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { connect } from 'react-redux';
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import page from 'page';
@@ -33,6 +34,7 @@ import {
 } from 'my-sites/domains/paths';
 import Spinner from 'components/spinner';
 import TrackComponentView from 'lib/analytics/track-component-view';
+import { composeAnalytics, recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
 
 class DomainItem extends PureComponent {
 	static propTypes = {
@@ -85,11 +87,12 @@ class DomainItem extends PureComponent {
 	};
 
 	addEmailClick = ( event ) => {
-		const { currentRoute, disabled, domain, site } = this.props;
+		const { addEmailClick, currentRoute, disabled, domain, site } = this.props;
 		event.stopPropagation();
 		if ( disabled ) {
 			return;
 		}
+		addEmailClick(); // analytics/tracks
 		page( emailManagement( site.slug, domain.domain, currentRoute ) );
 	};
 
@@ -435,4 +438,14 @@ class DomainItem extends PureComponent {
 	}
 }
 
-export default localize( DomainItem );
+const addEmailClick = () =>
+	composeAnalytics(
+		recordGoogleEvent( 'Domain Management', 'Clicked "Add Email" Button in List/ListAll' ),
+		recordTracksEvent( 'calypso_domain_management_list_add_email_click' )
+	);
+
+export default connect( null, ( dispatch ) => {
+	return {
+		addEmailClick: () => dispatch( addEmailClick() ),
+	};
+} )( localize( DomainItem ) );

--- a/client/my-sites/domains/domain-management/list/domain-item.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-item.jsx
@@ -89,10 +89,12 @@ class DomainItem extends PureComponent {
 	addEmailClick = ( event ) => {
 		const { addEmailClick, currentRoute, disabled, domain, site } = this.props;
 		event.stopPropagation();
+
+		addEmailClick( domain ); // analytics/tracks
+
 		if ( disabled ) {
 			return;
 		}
-		addEmailClick(); // analytics/tracks
 		page( emailManagement( site.slug, domain.domain, currentRoute ) );
 	};
 
@@ -438,14 +440,21 @@ class DomainItem extends PureComponent {
 	}
 }
 
-const addEmailClick = () =>
+const addEmailClick = ( domain ) =>
 	composeAnalytics(
-		recordGoogleEvent( 'Domain Management', 'Clicked "Add Email" Button in List/ListAll' ),
-		recordTracksEvent( 'calypso_domain_management_list_add_email_click' )
+		recordGoogleEvent(
+			'Domain Management',
+			'Clicked "Add Email" Button in DomainItem',
+			'Domain Name',
+			domain.name
+		),
+		recordTracksEvent( 'calypso_domain_management_domain_item_add_email_click', {
+			section: domain.type,
+		} )
 	);
 
 export default connect( null, ( dispatch ) => {
 	return {
-		addEmailClick: () => dispatch( addEmailClick() ),
+		addEmailClick: ( domain ) => dispatch( addEmailClick( domain ) ),
 	};
 } )( localize( DomainItem ) );

--- a/client/my-sites/domains/domain-management/list/domain-item.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-item.jsx
@@ -87,10 +87,10 @@ class DomainItem extends PureComponent {
 	};
 
 	addEmailClick = ( event ) => {
-		const { addEmailClick, currentRoute, disabled, domain, site } = this.props;
+		const { trackAddEmailClick, currentRoute, disabled, domain, site } = this.props;
 		event.stopPropagation();
 
-		addEmailClick( domain ); // analytics/tracks
+		trackAddEmailClick( domain ); // analytics/tracks
 
 		if ( disabled ) {
 			return;
@@ -440,11 +440,11 @@ class DomainItem extends PureComponent {
 	}
 }
 
-const addEmailClick = ( domain ) =>
+const trackAddEmailClick = ( domain ) =>
 	recordTracksEvent( 'calypso_domain_management_domain_item_add_email_click', {
 		section: domain.type,
 	} );
 
 export default connect( null, {
-	addEmailClick,
+	trackAddEmailClick,
 } )( localize( DomainItem ) );

--- a/client/my-sites/domains/domain-management/list/domain-item.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-item.jsx
@@ -34,7 +34,7 @@ import {
 } from 'my-sites/domains/paths';
 import Spinner from 'components/spinner';
 import TrackComponentView from 'lib/analytics/track-component-view';
-import { composeAnalytics, recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
+import { recordTracksEvent } from 'state/analytics/actions';
 
 class DomainItem extends PureComponent {
 	static propTypes = {
@@ -441,20 +441,10 @@ class DomainItem extends PureComponent {
 }
 
 const addEmailClick = ( domain ) =>
-	composeAnalytics(
-		recordGoogleEvent(
-			'Domain Management',
-			'Clicked "Add Email" Button in DomainItem',
-			'Domain Name',
-			domain.name
-		),
-		recordTracksEvent( 'calypso_domain_management_domain_item_add_email_click', {
-			section: domain.type,
-		} )
-	);
+	recordTracksEvent( 'calypso_domain_management_domain_item_add_email_click', {
+		section: domain.type,
+	} );
 
-export default connect( null, ( dispatch ) => {
-	return {
-		addEmailClick: ( domain ) => dispatch( addEmailClick( domain ) ),
-	};
+export default connect( null, {
+	addEmailClick,
 } )( localize( DomainItem ) );

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -84,6 +84,10 @@ export class List extends React.Component {
 		isPopoverCartVisible: false,
 	};
 
+	componentDidMount() {
+		this.props.listView();
+	}
+
 	isLoading() {
 		return this.props.isRequestingSiteDomains && this.props.domains.length === 0;
 	}
@@ -402,14 +406,18 @@ export class List extends React.Component {
 		} );
 	}
 
-	handleUpdatePrimaryDomain = ( index, domain ) => {
+	handleUpdatePrimaryDomainOptionClick = ( index, domain ) => {
+		return this.handleUpdatePrimaryDomain( index, domain, 'item_option_click' );
+	};
+
+	handleUpdatePrimaryDomain = ( index, domain, mode = 'item_select_legacy' ) => {
 		const { translate } = this.props;
 
 		if ( this.state.settingPrimaryDomain ) {
 			return;
 		}
 
-		this.props.changePrimary( domain );
+		this.props.changePrimary( domain, mode );
 		const currentPrimaryIndex = findIndex( this.props.domains, { isPrimary: true } ),
 			currentPrimaryName = this.props.domains[ currentPrimaryIndex ].name;
 
@@ -554,7 +562,7 @@ export class List extends React.Component {
 				disabled={ this.state.settingPrimaryDomain || this.state.changePrimaryDomainModeEnabled }
 				enableSelection={ this.state.changePrimaryDomainModeEnabled && domain.canSetAsPrimary }
 				selectionIndex={ index }
-				onMakePrimaryClick={ this.handleUpdatePrimaryDomain }
+				onMakePrimaryClick={ this.handleUpdatePrimaryDomainOptionClick }
 				onSelect={ this.handleUpdatePrimaryDomain }
 				onUpgradeClick={ this.goToPlans }
 				shouldUpgradeToMakePrimary={ this.shouldUpgradeToMakeDomainPrimary( domain ) }
@@ -634,6 +642,8 @@ export class List extends React.Component {
 	};
 }
 
+const listView = () => recordTracksEvent( 'calypso_domain_management_list_site_view' );
+
 const addDomainClick = () =>
 	composeAnalytics(
 		recordGoogleEvent( 'Domain Management', 'Clicked "Add Domain" Button in List' ),
@@ -658,7 +668,7 @@ const disablePrimaryDomainMode = () =>
 const upsellUpgradeClick = () =>
 	recordTracksEvent( 'calypso_domain_management_make_primary_plan_upgrade_click' );
 
-const changePrimary = ( domain ) =>
+const changePrimary = ( domain, mode ) =>
 	composeAnalytics(
 		recordGoogleEvent(
 			'Domain Management',
@@ -668,6 +678,7 @@ const changePrimary = ( domain ) =>
 		),
 		recordTracksEvent( 'calypso_domain_management_list_change_primary_domain_click', {
 			section: domain.type,
+			mode,
 		} )
 	);
 
@@ -700,11 +711,12 @@ export default connect(
 						cta_name: 'domain_info_notice',
 					} )
 				),
+			listView: () => dispatch( listView() ),
 			setPrimaryDomain: ( ...props ) => setPrimaryDomain( ...props )( dispatch ),
 			addDomainClick: () => dispatch( addDomainClick() ),
 			enablePrimaryDomainMode: () => dispatch( enablePrimaryDomainMode() ),
 			disablePrimaryDomainMode: () => dispatch( disablePrimaryDomainMode() ),
-			changePrimary: ( domain ) => dispatch( changePrimary( domain ) ),
+			changePrimary: ( domain, mode ) => dispatch( changePrimary( domain, mode ) ),
 			successNotice: ( text, options ) => dispatch( successNotice( text, options ) ),
 			errorNotice: ( text, options ) => dispatch( errorNotice( text, options ) ),
 			upsellUpgradeClick: () => dispatch( upsellUpgradeClick() ),

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -84,10 +84,6 @@ export class List extends React.Component {
 		isPopoverCartVisible: false,
 	};
 
-	componentDidMount() {
-		this.props.listView();
-	}
-
 	isLoading() {
 		return this.props.isRequestingSiteDomains && this.props.domains.length === 0;
 	}
@@ -642,8 +638,6 @@ export class List extends React.Component {
 	};
 }
 
-const listView = () => recordTracksEvent( 'calypso_domain_management_list_site_view' );
-
 const addDomainClick = () =>
 	composeAnalytics(
 		recordGoogleEvent( 'Domain Management', 'Clicked "Add Domain" Button in List' ),
@@ -711,7 +705,6 @@ export default connect(
 						cta_name: 'domain_info_notice',
 					} )
 				),
-			listView: () => dispatch( listView() ),
 			setPrimaryDomain: ( ...props ) => setPrimaryDomain( ...props )( dispatch ),
 			addDomainClick: () => dispatch( addDomainClick() ),
 			enablePrimaryDomainMode: () => dispatch( enablePrimaryDomainMode() ),

--- a/client/my-sites/domains/domain-management/list/list-all.jsx
+++ b/client/my-sites/domains/domain-management/list/list-all.jsx
@@ -59,6 +59,10 @@ class ListAll extends Component {
 
 	renderedQuerySiteDomains = {};
 
+	componentDidMount() {
+		this.props.listAllView();
+	}
+
 	clickAddDomain = () => {
 		this.props.addDomainClick();
 		page( domainAddNew( '' ) );
@@ -168,6 +172,8 @@ class ListAll extends Component {
 	}
 }
 
+const listAllView = () => recordTracksEvent( 'calypso_domain_management_list_all_view' );
+
 const addDomainClick = () =>
 	composeAnalytics(
 		recordGoogleEvent( 'Domain Management', 'Clicked "Add Domain" Button in ListAll' ),
@@ -194,6 +200,9 @@ export default connect(
 		};
 	},
 	( dispatch ) => {
-		return { addDomainClick: () => dispatch( addDomainClick() ) };
+		return {
+			addDomainClick: () => dispatch( addDomainClick() ),
+			listAllView: () => dispatch( listAllView() ),
+		};
 	}
 )( localize( ListAll ) );

--- a/client/my-sites/domains/domain-management/list/list-all.jsx
+++ b/client/my-sites/domains/domain-management/list/list-all.jsx
@@ -59,10 +59,6 @@ class ListAll extends Component {
 
 	renderedQuerySiteDomains = {};
 
-	componentDidMount() {
-		this.props.listAllView();
-	}
-
 	clickAddDomain = () => {
 		this.props.addDomainClick();
 		page( domainAddNew( '' ) );
@@ -172,8 +168,6 @@ class ListAll extends Component {
 	}
 }
 
-const listAllView = () => recordTracksEvent( 'calypso_domain_management_list_all_view' );
-
 const addDomainClick = () =>
 	composeAnalytics(
 		recordGoogleEvent( 'Domain Management', 'Clicked "Add Domain" Button in ListAll' ),
@@ -199,10 +193,7 @@ export default connect(
 			user,
 		};
 	},
-	( dispatch ) => {
-		return {
-			addDomainClick: () => dispatch( addDomainClick() ),
-			listAllView: () => dispatch( listAllView() ),
-		};
+	{
+		addDomainClick,
 	}
 )( localize( ListAll ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds tracking mostly for events initially omitted:

    - Add domain
    - Add email
    - Change primary domain
    - Make Domain Primary option


* Adds page view analytics to `ListAll` to make it consistent with `List`

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/domains/manage` to bring up the all domains list.
    * The `Redux` state profiler is the best way to see when event actions dispatched. 
    * One can also enable analytics logging by doing: ```localStorage.setItem('debug', 'calypso:analytics:*');```
* Confirm that there is a corresponding event triggered by each of the actions listed above.


