### PR TITLE
Nav sidebar: exclude the latest posts page

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/class-wpcom-block-editor-nav-sidebar.php
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/class-wpcom-block-editor-nav-sidebar.php
@@ -59,11 +59,20 @@ class WPCOM_Block_Editor_Nav_Sidebar {
 			plugins_url( 'dist/', __FILE__ )
 		);
 
+		$post_ids_to_exclude = array();
+
+		// Only exclude page_for_posts when a static page is being used as the front page, because
+		// page_for_posts can be a valid id even when showing a traditional blog page on front.
+		if ( 'page' === get_option( 'show_on_front' ) ) {
+			$post_ids_to_exclude[] = get_option( 'page_for_posts' );
+		}
+
 		wp_localize_script(
 			'wpcom-block-editor-nav-sidebar-script',
 			'wpcomBlockEditorNavSidebar',
 			array(
-				'homeUrl' => home_url(),
+				'homeUrl'          => home_url(),
+				'postIdsToExclude' => $post_ids_to_exclude,
 			)
 		);
 

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
@@ -21,7 +21,7 @@ import { compose } from '@wordpress/compose';
 /**
  * Internal dependencies
  */
-import { STORE_KEY, SITE_HOME_URL } from '../../constants';
+import { STORE_KEY, SITE_HOME_URL, POST_IDS_TO_EXCLUDE } from '../../constants';
 import CreatePage from '../create-page';
 import NavItem from '../nav-item';
 import { Post } from '../../types';
@@ -273,7 +273,7 @@ function useNavItems(): Post[] {
 		const items =
 			select( 'core' ).getEntityRecords( 'postType', currentPostType, {
 				_fields: 'id,status,title',
-				exclude: [ currentPostId ],
+				exclude: [ currentPostId, ...POST_IDS_TO_EXCLUDE ],
 				orderby: 'modified',
 				per_page: 10,
 				status: statusFilter,

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/constants.ts
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/constants.ts
@@ -4,8 +4,12 @@ declare global {
 	interface Window {
 		wpcomBlockEditorNavSidebar?: {
 			homeUrl: string;
+			postIdsToExclude: string[];
 		};
 	}
 }
 
 export const SITE_HOME_URL = window.wpcomBlockEditorNavSidebar?.homeUrl;
+export const POST_IDS_TO_EXCLUDE = ( window.wpcomBlockEditorNavSidebar?.postIdsToExclude || [] )
+	.map( ( id ) => parseInt( id, 10 ) )
+	.filter( ( id ) => ! isNaN( id ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Displaying the "Latest posts" page in the nav sidebar can be a bit misleading: pbAok1-1fU-p2#comment-2510

* Add a `postIdsToExclude` global the server can use to exclude pages/posts from the nav sidebar
* Exclude the "Latest posts" page from the nav sidebar

Notice in this change we're careful to check the state of the `show_on_front` setting before excluding the "Latest posts" page because the interpretation of the `page_for_posts` setting depends on the `show_on_front` setting (described in [the `is_home()` docs](https://developer.wordpress.org/reference/functions/is_home/#usage))

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch
* `cd apps/full-site-editing && yarn build && npx wp-env start`
* `localhost:4013/wp-admin`
* In the customizer change the Homepage Settings to "A static page", and choose one of your pages to be the "Posts page"
* Open a page in the editor
* Open the nav sidebar and see that the "posts page" isn't displayed
