### PR TITLE
Revert "Update post "Search and Social" preview components to use @automattic/social-previews"

### DIFF
--- a/client/components/seo-preview-pane/index.jsx
+++ b/client/components/seo-preview-pane/index.jsx
@@ -11,7 +11,9 @@ import { compact, find, get, identity, overSome } from 'lodash';
  */
 import SeoPreviewUpgradeNudge from 'components/seo/preview-upgrade-nudge';
 import ReaderPreview from 'components/seo/reader-preview';
-import { FacebookPreview, TwitterPreview, SearchPreview } from '@automattic/social-previews';
+import FacebookPreview from 'components/seo/facebook-preview';
+import TwitterPreview from 'components/seo/twitter-preview';
+import SearchPreview from 'components/seo/search-preview';
 import VerticalMenu from 'components/vertical-menu';
 import PostMetadata from 'lib/post-metadata';
 import { formatExcerpt } from 'lib/post-normalizer/rule-create-better-excerpt';

--- a/client/components/seo/facebook-preview/index.jsx
+++ b/client/components/seo/facebook-preview/index.jsx
@@ -1,0 +1,65 @@
+/**
+ * External dependencies
+ */
+
+import PropTypes from 'prop-types';
+import React, { PureComponent } from 'react';
+import { compact } from 'lodash';
+import { firstValid, hardTruncation, shortEnough } from '../helpers';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+const TITLE_LENGTH = 80;
+const DESCRIPTION_LENGTH = 200;
+
+const baseDomain = ( url ) =>
+	url &&
+	url
+		.replace( /^[^/]+[/]*/, '' ) // strip leading protocol
+		.replace( /\/.*$/, '' ); // strip everything after the domain
+
+const facebookTitle = firstValid( shortEnough( TITLE_LENGTH ), hardTruncation( TITLE_LENGTH ) );
+
+const facebookDescription = firstValid(
+	shortEnough( DESCRIPTION_LENGTH ),
+	hardTruncation( DESCRIPTION_LENGTH )
+);
+
+export class FacebookPreview extends PureComponent {
+	render() {
+		const { url, type, title, description, image, author } = this.props;
+
+		return (
+			<div className={ `facebook-preview facebook-preview__${ type }` }>
+				<div className="facebook-preview__content">
+					<div className="facebook-preview__image">
+						{ image && <img alt="Facebook Preview Thumbnail" src={ image } /> }
+					</div>
+					<div className="facebook-preview__body">
+						<div className="facebook-preview__title">{ facebookTitle( title || '' ) }</div>
+						<div className="facebook-preview__description">
+							{ facebookDescription( description || '' ) }
+						</div>
+						<div className="facebook-preview__url">
+							{ compact( [ baseDomain( url ), author ] ).join( ' | ' ) }
+						</div>
+					</div>
+				</div>
+			</div>
+		);
+	}
+}
+
+FacebookPreview.propTypes = {
+	url: PropTypes.string,
+	type: PropTypes.string,
+	title: PropTypes.string,
+	description: PropTypes.string,
+	image: PropTypes.string,
+	author: PropTypes.string,
+};
+
+export default FacebookPreview;

--- a/client/components/seo/facebook-preview/style.scss
+++ b/client/components/seo/facebook-preview/style.scss
@@ -1,0 +1,135 @@
+/*
+ * CSS values in this file are specific and
+ * designed to match the CSS on external sites,
+ * such as Google and Facebook. Therefore there
+ * will be exceptions to our CSS guidelines here
+ * but please do not "update" this file to
+ * conform.
+ *
+ * @blame: dmsnell
+*/
+
+.facebook-preview {
+	border: none;
+	box-shadow: 0 0 0 1px rgba( 0, 0, 0, 0.15 ) inset, 0 1px 4px rgba( 0, 0, 0, 0.1 );
+	display: flex;
+	overflow-x: auto;
+	max-width: 527px;
+	margin: 0 auto;
+	-webkit-overflow-scrolling: touch;
+}
+
+.facebook-preview__content {
+	display: flex;
+}
+
+.facebook-preview__body {
+	display: flex;
+	flex-direction: column;
+	margin: 10px 12px;
+}
+
+.facebook-preview__title {
+	color: #1d2129;
+	font-family: Georgia, serif;
+	font-size: 18px;
+	/* stylelint-disable-next-line scales/font-weight */
+	font-weight: 600;
+	line-height: 22px;
+	max-height: 100px;
+	transition: color 0.1s ease-in-out;
+}
+
+.facebook-preview__description {
+	color: #1d2129;
+	flex-grow: 1;
+	font-family: helvetica, arial, sans-serif;
+	font-size: $font-body-extra-small;
+	line-height: 16px;
+	overflow-y: hidden;
+}
+
+.facebook-preview__url {
+	color: #606770;
+	font-family: helvetica, arial, sans-serif;
+	font-size: $font-body-extra-small;
+	line-height: 12px;
+	text-transform: uppercase;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.facebook-preview__article {
+	.facebook-preview__content {
+		flex-direction: column;
+		min-width: 100%;
+	}
+
+	.facebook-preview__image {
+		max-height: 250px;
+		display: flex;
+		justify-content: center;
+		align-items: center;
+		overflow-y: hidden;
+
+		& img {
+			height: auto;
+			width: 100%;
+			max-width: 527px;
+		}
+	}
+
+	.facebook-preview__body {
+		height: auto;
+		max-height: 100px;
+	}
+
+	.facebook-preview__title {
+		margin-bottom: 5px;
+	}
+
+	.facebook-preview__url {
+		margin-top: 9px;
+	}
+}
+
+.facebook-preview__website {
+	max-height: 158px;
+	overflow: hidden;
+
+	.facebook-preview__image {
+		flex-shrink: 0;
+		height: 158px;
+		width: 158px;
+
+		& img {
+			display: block;
+			font-size: $font-body-small;
+			height: auto;
+			width: 100%;
+		}
+
+		&::after {
+			border: 1px solid;
+			border-color: rgba( 0, 0, 0, 0.098 ) rgba( 0, 0, 0, 0.149 ) rgba( 0, 0, 0, 0.231 );
+			content: '';
+			display: block;
+			height: 100%;
+			width: 100%;
+		}
+	}
+
+	.facebook-preview__body {
+		width: 100%;
+	}
+
+	.facebook-preview__title {
+		margin-bottom: 5px;
+		max-height: 110px;
+	}
+
+	.facebook-preview__url {
+		margin-top: auto;
+		margin-bottom: 5px;
+	}
+}

--- a/client/components/seo/search-preview/index.jsx
+++ b/client/components/seo/search-preview/index.jsx
@@ -1,0 +1,59 @@
+/**
+ * External dependencies
+ */
+
+import PropTypes from 'prop-types';
+import { useTranslate } from 'i18n-calypso';
+import React from 'react';
+import { firstValid, hardTruncation, shortEnough, truncatedAtSpace } from '../helpers';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+const TITLE_LENGTH = 63;
+const DESCRIPTION_LENGTH = 160;
+
+const googleTitle = firstValid(
+	shortEnough( TITLE_LENGTH ),
+	truncatedAtSpace( TITLE_LENGTH - 40, TITLE_LENGTH + 10 ),
+	hardTruncation( TITLE_LENGTH )
+);
+
+const googleDescription = firstValid(
+	shortEnough( DESCRIPTION_LENGTH ),
+	truncatedAtSpace( DESCRIPTION_LENGTH - 80, DESCRIPTION_LENGTH + 10 ),
+	hardTruncation( DESCRIPTION_LENGTH )
+);
+
+const googleUrl = hardTruncation( 79 );
+
+export default function SearchPreview( { description, title, url } ) {
+	const translate = useTranslate();
+
+	return (
+		<div className="search-preview">
+			<h2 className="search-preview__header">{ translate( 'Search Preview' ) }</h2>
+			<div className="search-preview__display">
+				<div className="search-preview__title">{ googleTitle( title ) }</div>
+				<div className="search-preview__url">{ googleUrl( url ) } ▾</div>
+				<div className="search-preview__description">
+					{ googleDescription( description || '' ) }
+				</div>
+			</div>
+		</div>
+	);
+}
+
+SearchPreview.propTypes = {
+	title: PropTypes.string,
+	url: PropTypes.string,
+	description: PropTypes.string,
+};
+
+SearchPreview.defaultProps = {
+	title: '',
+	url: '',
+	description: '',
+};

--- a/client/components/seo/search-preview/style.scss
+++ b/client/components/seo/search-preview/style.scss
@@ -1,0 +1,58 @@
+/*
+ * CSS values in this file are specific and
+ * designed to match the CSS on external sites,
+ * such as Google and Facebook. Therefore there
+ * will be exceptions to our CSS guidelines here
+ * but please do not "update" this file to
+ * conform.
+ *
+ * @blame: dmsnell
+*/
+
+.search-preview__header {
+	margin: 0;
+	padding: 8px 0;
+	background-color: var( --color-neutral-0 );
+	border: 1px solid var( --color-neutral-0 );
+	border-bottom: 0;
+	font-size: $font-body-extra-small;
+	line-height: 1;
+	font-weight: bold;
+	text-transform: uppercase;
+	text-align: center;
+	color: var( --color-neutral-40 );
+}
+
+.search-preview__display {
+	border: 1px solid var( --color-neutral-0 );
+	font-family: arial, sans-serif;
+	padding: 10px 20px;
+	word-wrap: break-word;
+}
+
+.search-preview__title {
+	color: #1a0dab; // matching Google results
+	font-size: 18px;
+	line-height: 1.2;
+	max-width: 616px;
+
+	&:hover {
+		cursor: pointer;
+		text-decoration: underline;
+	}
+}
+
+.search-preview__url {
+	color: #006621; // matching Google results
+	font-size: $font-body-small;
+	height: 17px;
+	line-height: 16px;
+	max-width: 616px;
+}
+
+.search-preview__description {
+	color: #545454; // matching Google results
+	font-size: $font-body-small;
+	line-height: 1.4;
+	max-width: 616px;
+}

--- a/client/components/seo/twitter-preview/index.jsx
+++ b/client/components/seo/twitter-preview/index.jsx
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+
+import PropTypes from 'prop-types';
+import React, { PureComponent } from 'react';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+const baseDomain = ( url ) =>
+	url
+		.replace( /^[^/]+[/]*/, '' ) // strip leading protocol
+		.replace( /\/.*$/, '' ); // strip everything after the domain
+
+export class TwitterPreview extends PureComponent {
+	render() {
+		const { url, title, type, description, image } = this.props;
+
+		const previewImageStyle = {
+			backgroundImage: 'url(' + image + ')',
+		};
+
+		return (
+			<div className="twitter-preview">
+				<div className={ `twitter-preview__${ type }` }>
+					{ image && <div className="twitter-preview__image" style={ previewImageStyle } /> }
+					<div className="twitter-preview__body">
+						<div className="twitter-preview__title">{ title }</div>
+						<div className="twitter-preview__description">{ description }</div>
+						<div className="twitter-preview__url">{ baseDomain( url || '' ) }</div>
+					</div>
+				</div>
+			</div>
+		);
+	}
+}
+
+TwitterPreview.propTypes = {
+	url: PropTypes.string,
+	title: PropTypes.string,
+	type: PropTypes.string,
+	description: PropTypes.string,
+	image: PropTypes.string,
+};
+
+export default TwitterPreview;

--- a/client/components/seo/twitter-preview/style.scss
+++ b/client/components/seo/twitter-preview/style.scss
@@ -1,0 +1,105 @@
+/*
+ * CSS values in this file are specific and
+ * designed to match the CSS on external sites,
+ * such as Google and Facebook. Therefore there
+ * will be exceptions to our CSS guidelines here
+ * but please do not "update" this file to
+ * conform.
+ *
+ * @blame: dmsnell
+*/
+
+.twitter-preview {
+	width: inherit;
+	overflow-x: auto;
+	-webkit-overflow-scrolling: touch;
+	margin: 20px;
+}
+
+.twitter-preview__summary {
+	width: 506px;
+	height: 125px;
+	margin: 0 auto;
+	overflow: hidden;
+	border: 1px solid #e1e8ed;
+	border-radius: 0.42857em;
+}
+
+.twitter-preview__large_image_summary {
+	width: 506px;
+	height: auto;
+	margin: 0 auto;
+	overflow: hidden;
+	border: 1px solid #e1e8ed;
+	border-radius: 0.42857em;
+}
+
+.twitter-preview__image {
+	background-size: cover;
+	background-position: center;
+}
+
+.twitter-preview__summary
+.twitter-preview__image {
+	float: left;
+	width: 125px;
+	height: 125px;
+}
+
+.twitter-preview__large_image_summary
+.twitter-preview__image {
+	width: 506px;
+	height: 254px;
+	border-bottom: 1px solid #e1e8ed;
+}
+
+.twitter-preview__body {
+	padding: 0.75em;
+	text-decoration: none;
+	font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+	font-size: $font-body-small;
+	color: black;
+	text-align: left;
+	line-height: 1.3em;
+	overflow: hidden;
+}
+
+.twitter-preview__summary
+.twitter-preview__body {
+	margin-left: 125px;
+	border-left: 1px solid #e1e8ed;
+	height: 100%;
+}
+
+.twitter-preview__large_image_summary
+.twitter-preview__body {
+	padding-left: 1em;
+	padding-right: 1em;
+}
+
+.twitter-preview__title {
+	max-height: 1.3em;
+	white-space: nowrap;
+	font-weight: bold;
+	font-size: 1em;
+	margin: 0 0 0.15em;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.twitter-preview__description {
+	margin-top: 0.32333em;
+	max-height: 3.9em;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.twitter-preview__url {
+	text-transform: lowercase;
+	color: #8899a6;
+	max-height: 1.3em;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	margin-top: 0.32333em;
+}

--- a/client/components/share/facebook-share-preview/index.jsx
+++ b/client/components/share/facebook-share-preview/index.jsx
@@ -10,7 +10,7 @@ import { isNull } from 'lodash';
 /**
  * Internal dependencies
  */
-import { FacebookPreview } from '@automattic/social-previews';
+import FacebookPreview from 'components/seo/facebook-preview';
 
 /**
  * Style dependencies

--- a/client/package.json
+++ b/client/package.json
@@ -30,7 +30,6 @@
 		"@automattic/react-i18n": "^1.0.0-alpha.0",
 		"@automattic/react-virtualized": "^9.21.2",
 		"@automattic/request-external-access": "^1.0.0",
-		"@automattic/social-previews": "^1.0.0",
 		"@automattic/tree-select": "^1.0.3",
 		"@automattic/viewport": "^1.0.0",
 		"@automattic/viewport-react": "^1.0.0",


### PR DESCRIPTION
Reverts Automattic/wp-calypso#44351

During testing it was noticed that the CSS styling was missing from the Previews for `Search and Social` in Calypso. This was not in evidence during development.

<img width="1269" alt="Screenshot 2020-07-23 at 08 42 23" src="https://user-images.githubusercontent.com/444434/88262912-fc7c1980-ccc0-11ea-8701-64a5b843f523.png">

To confirm this revert fixes the issue check out this PR and...

- On a **Business** site, create a new Post with some content and a title and click "Preview".
- Toggle the Preview to "Search and Social" using the dropdown.
- You should see the post social and search previews and be able to toggle between each type with no errors.
- All styling should be in place (ie: it shoudln't look like the "broken" screenshot above).