### PR TITLE
Use the proper selector to get all site items for the all domains list

### DIFF
--- a/client/my-sites/domains/domain-management/list/list-all.jsx
+++ b/client/my-sites/domains/domain-management/list/list-all.jsx
@@ -29,7 +29,7 @@ import {
 import { getCurrentUser } from 'state/current-user/selectors';
 import { getCurrentRoute } from 'state/selectors/get-current-route';
 import { getDomainManagementPath } from './utils';
-import getVisibleSites from 'state/selectors/get-visible-sites';
+import getSitesItems from 'state/selectors/get-sites-items';
 import isRequestingAllDomains from 'state/selectors/is-requesting-all-domains';
 import ListItemPlaceholder from './item-placeholder';
 import Main from 'components/main';
@@ -176,7 +176,7 @@ const addDomainClick = () =>
 
 export default connect(
 	( state ) => {
-		const sites = keyBy( getVisibleSites( state ), 'ID' );
+		const sites = keyBy( getSitesItems( state ), 'ID' );
 		const user = getCurrentUser( state );
 		const purchases = keyBy( getUserPurchases( state, user?.ID ) || [], 'id' );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* We're using the wrong selector when rendering the all domains list which may hide some domains in case the site visibility is set to false.

Props to @ajaykj for reporting and helping me debug this

#### Testing instructions

* Hide a site with a domain from the site selector. Then refresh /domains/manage - the domain should still be visible (without this PR it's not rendered)

