### PR TITLE
Mark CSS and SCSS as a `sideEffect`s in `@automattic/social-previews`

### DIFF
--- a/packages/social-previews/CHANGELOG.md
+++ b/packages/social-previews/CHANGELOG.md
@@ -1,3 +1,9 @@
-1.0.0
------
+Changelog
+========
+
+#### v1.0.1 (2019-07-23)
+- Mark CSS and SCSS files as `sideEffects` to ensure they are not discarded during build processes tree-shaking.
+
+
+#### v1.0.0 (2019-07-22)
 - Initial release after extracting from Calypso.

--- a/packages/social-previews/package.json
+++ b/packages/social-previews/package.json
@@ -4,7 +4,10 @@
 	"description": "A suite of components to generate previews for a post for both social and search engines",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",
-	"sideEffects": false,
+	"sideEffects": [
+		"*.css",
+		"*.scss"
+	],
 	"keywords": [
         "wordpress",
         "social",

--- a/packages/social-previews/package.json
+++ b/packages/social-previews/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/social-previews",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "A suite of components to generate previews for a post for both social and search engines",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",


### PR DESCRIPTION
This PR adds `css` and `scss` files as `sideEffects` in the `package.json` for the `@automattic/social-previews` package.

Without this webpack tree shaking will remove the CSS from the build and leave the package without styles.

See p1595490568480700-slack-ajax for some context on why this is important. Basically when we attempted to use this in Calypso build the CSS was stripped out in production build leaving us with unstyled components.


#### Changes proposed in this Pull Request

* Adds 

```js
"sideEffects": [
        "*.css",
        "*.scss"
    ],
```

to `package.json`

* Bumps package version to `1.0.1` in `package.json` and `CHANGELOG.md`.

#### Testing instructions

* Open https://calypso.live/?branch=try/fix-social-previews-package-to-include-css-sideeffects.
* On a Business site, create a new Post with some content and a title and click "Preview".
* Toggle the Preview to "Search and Social" using the dropdown.
* You should see the post previews and be able to toggle between each type with no errors.
* You should see CSS styles applied correctly.

