### PR TITLE
Calypso linting: allow WP dependencies as import docblocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -295,7 +295,7 @@
 		"eslint-plugin-jsx-a11y": "^6.2.3",
 		"eslint-plugin-prettier": "^3.1.2",
 		"eslint-plugin-react": "^7.20.0",
-		"eslint-plugin-wpcalypso": "^4.1.0",
+		"eslint-plugin-wpcalypso": "^5.0.0",
 		"exports-loader": "^0.7.0",
 		"fake-indexeddb": "^3.1.0",
 		"fork-ts-checker-webpack-plugin": "^3.1.1",

--- a/packages/eslint-config-wpcalypso/package.json
+++ b/packages/eslint-config-wpcalypso/package.json
@@ -27,7 +27,7 @@
 		"eslint": "^7.0.0",
 		"eslint-plugin-inclusive-language": "^1.2.0",
 		"eslint-plugin-jsdoc": "^18.0.0",
-		"eslint-plugin-wpcalypso": "^3.4.1 || ^4.0.0"
+		"eslint-plugin-wpcalypso": "^3.4.1 || ^4.0.0 || ^5.0.0"
 	},
 	"dependencies": {
 		"eslint-plugin-react-hooks": "^4.0.5"

--- a/packages/eslint-plugin-wpcalypso/CHANGELOG.md
+++ b/packages/eslint-plugin-wpcalypso/CHANGELOG.md
@@ -1,6 +1,10 @@
 #### Unreleased
+
+#### v5.0.0 (2020-07-23)
+
 - Breaking: Removed rule [`import-no-redux-combine-reducers`](docs/rules/import-no-redux-combine-reducers.md)
 - Enhancement: `jsx-classname-namespace` understands Storybook `index.stories.js` files and treats them as root files
+- Enhancement: `import-docblock` now supports WordPress dependencies.
 
 #### v4.1.0 (2019-05-07)
 

--- a/packages/eslint-plugin-wpcalypso/README.md
+++ b/packages/eslint-plugin-wpcalypso/README.md
@@ -43,7 +43,7 @@ Then configure the rules you want to use under the rules section.
 - [`i18n-no-variables`](docs/rules/i18n-no-variables.md): Disallow variables as translate strings
 - [`jsx-classname-namespace`](docs/rules/jsx-classname-namespace.md): Ensure JSX className adheres to CSS namespace guidelines
 - [`jsx-gridicon-size`](docs/rules/jsx-gridicon-size.md): Enforce recommended Gridicon size attributes
-- [`import-docblock`](docs/rules/import-docblock.md): Enforce external, internal dependencies docblocks
+- [`import-docblock`](docs/rules/import-docblock.md): Enforce external, internal, WordPress dependencies docblocks
 - [`post-message-no-wildcard-targets`](docs/rules/post-message-no-wildcard-targets.md): Disallow using the wildcard '*' in `postMessage`
 - [`redux-no-bound-selectors`](docs/rules/redux-no-bound-selectors.md): Disallow creation of selectors bound to Redux state
 

--- a/packages/eslint-plugin-wpcalypso/docs/rules/import-docblock.md
+++ b/packages/eslint-plugin-wpcalypso/docs/rules/import-docblock.md
@@ -1,6 +1,6 @@
-# Enforce external, internal dependencies docblocks
+# Enforce external, internal, WordPress dependencies docblocks
 
-When importing modules, you should distinguish external dependencies from internal dependencies using DocBlock multi-line comments. Because Calypso modifies the `NODE_PATH` to allow importing modules directly from the root `client/` directory, it can be otherwise unclear whether an imported module is an internal or an external dependency.
+When importing modules, you should distinguish external dependencies from internal or WordPress dependencies using DocBlock multi-line comments. Because Calypso modifies the `NODE_PATH` to allow importing modules directly from the root `client/` directory, it can be otherwise unclear whether an imported module is an internal, external, or WordPress dependency.
 
 ## Rule Details
 

--- a/packages/eslint-plugin-wpcalypso/lib/rules/import-docblock.js
+++ b/packages/eslint-plugin-wpcalypso/lib/rules/import-docblock.js
@@ -1,5 +1,5 @@
 /**
- * @file Enforce external, internal dependencies docblocks
+ * @file Enforce external, internal, WordPress dependencies docblocks
  * @author Automattic
  * @copyright 2016 Automattic. All rights reserved.
  * See LICENSE.md file in root directory for full license.
@@ -9,13 +9,13 @@
 // Rule Definition
 //------------------------------------------------------------------------------
 
-const ERROR_MESSAGE = 'Missing external, internal dependencies docblocks';
-const RX_DOCBLOCK = /\/\*\*\n \* (Ex|In)ternal dependencies\s*\n \*\//i;
+const ERROR_MESSAGE = 'Missing external, internal, WordPress dependencies docblocks';
+const RX_DOCBLOCK = /\/\*\*\n \* ((Ex|In)ternal|WordPress) dependencies\s*\n \*\//i;
 
 module.exports = {
 	meta: {
 		docs: {
-			description: 'Enforce external, internal dependencies docblocks',
+			description: 'Enforce external, internal, WordPress dependencies docblocks',
 			category: 'Stylistic Issues',
 		},
 	},

--- a/packages/eslint-plugin-wpcalypso/lib/rules/test/import-docblock.js
+++ b/packages/eslint-plugin-wpcalypso/lib/rules/test/import-docblock.js
@@ -1,5 +1,5 @@
 /**
- * @file Enforce external, internal dependencies docblocks
+ * @file Enforce external, internal, WordPress dependencies docblocks
  * @author Automattic
  * @copyright 2016 Automattic. All rights reserved.
  * See LICENSE.md file in root directory for full license.
@@ -27,19 +27,19 @@ new RuleTester( {
 			code: `/**
  * External dependencies
  */
-import eslint from \'eslint\';`,
+import eslint from 'eslint';`,
 		},
 		{
 			code: `/**
  * External dependencies
  */
-import eslint from \'eslint\';`,
+import eslint from 'eslint';`,
 		},
 		{
 			code: `/**
  * External dependencies${ ' ' }
  */
-import eslint from \'eslint\';`,
+import eslint from 'eslint';`,
 		},
 	],
 
@@ -48,7 +48,7 @@ import eslint from \'eslint\';`,
 			code: "import eslint from 'eslint';",
 			errors: [
 				{
-					message: 'Missing external, internal dependencies docblocks',
+					message: 'Missing external, internal, WordPress dependencies docblocks',
 				},
 			],
 		},

--- a/packages/eslint-plugin-wpcalypso/package.json
+++ b/packages/eslint-plugin-wpcalypso/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "eslint-plugin-wpcalypso",
-	"version": "4.1.0",
+	"version": "5.0.0",
 	"description": "Custom ESLint rules for the WordPress.com Calypso project",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
Fixes #44387

#### Changes proposed in this Pull Request

* Update the `wpcalypso/import-docblock` rule so it allows for WordPress dependencies in addition to the existing External and Internal dependencies.
* Release a new version of the package including this change (and the other un-released changes).

#### Testing instructions

* Do the tests pass?
* This should now be a valid import:
```js
/**
 * WordPress dependencies
 */
import { __ } from '@wordpress/i18n';
```
