### PR TITLE
Block editor: Only add legacy handling for closing the editor when it's needed

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -595,12 +595,18 @@ function handleCloseEditor( calypsoPort ) {
 // The close button is generally overridden using the <MainDashboardButton> slot API
 // which was introduced in Gutenberg 8.2. In older editors we still need to override
 // the click handler so that the link will open in the parent frame instead of the
-// iframe. If this happens to be a newer version of the editor the <MainDashboardButton>
-// in `handleCloseEditor()` will end up overriding these chanages.
+// iframe. We try not to add the click handler if <MainDashboardButton> has been used.
 function handleCloseInLegacyEditors( handleClose ) {
-	const legacySelector = '.edit-post-fullscreen-mode-close__toolbar a'; // support for Gutenberg plugin < v7.7
-	const selector = '.edit-post-header .edit-post-fullscreen-mode-close';
+	// Selects close buttons in Gutenberg plugin < v7.7
+	const legacySelector = '.edit-post-fullscreen-mode-close__toolbar a';
+
+	// Selects the close button in modern Gutenberg versions, unless it itself is a close button override
+	const wpcomCloseSelector = '.wpcom-block-editor__close-button';
+	const navSidebarCloseSelector = '.wpcom-block-editor-nav-sidebar-toggle-sidebar-button__button';
+	const selector = `.edit-post-header .edit-post-fullscreen-mode-close:not(${ wpcomCloseSelector }):not(${ navSidebarCloseSelector })`;
+
 	const siteEditorSelector = '.edit-site-header .edit-site-fullscreen-mode-close';
+
 	$( '#editor' ).on( 'click', `${ legacySelector }, ${ selector }`, handleClose );
 	$( '#edit-site-editor' ).on( 'click', `${ siteEditorSelector }`, handleClose );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Since #43313 the editor close button (the (W) button in the top-left) has been overridden in the calypso iframe using the official slot API added in GB 8.2. This is done in `wpcom-block-editor`. However `wpcom-block-editor` is included in many places, including places where GB is < 8.2. That's why in #44331 I re-introduced the legacy overrides, because it had introduced Automattic/wp-desktop#941. That way if GB < 8.2 the legacy override would be used, and in GB >= 8.2 the new override would be used.

The issue: if the nav sidebar is enabled then the legacy override interferes with the behaviour. That's because the legacy override uses a CSS selector that matches the overridden (W) too.

* Change the selector used by the close button override so that it:
  * Doesn't match the button that opens the nav sidebar
  * Doesn't match the link used to navigate back to calypso

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply changes to sandbox using the steps under the **Automatic** heading here: PCYsg-l4k-p2
* Sandbox `widgets.wp.com`
* Check the block editor close button works
  * On a simple site
  * On a jurassic.ninja site
    * With the latest gutenberg
    * Without the latest gutenberg
  * On an atomic site
    * With the latest gutenberg
    * Without the latest gutenberg