### PR TITLE
Fix intermitent e2e tests by using reliable CSS selector for activity page 

### DIFF
--- a/test/e2e/lib/pages/stats/activity-page.js
+++ b/test/e2e/lib/pages/stats/activity-page.js
@@ -11,7 +11,7 @@ import * as driverHelper from '../../driver-helper';
 
 export default class ActivityPage extends AsyncBaseContainer {
 	constructor( driver ) {
-		super( driver, By.css( '.activity-log__wrapper' ) );
+		super( driver, By.css( '.is-section-activity' ) );
 	}
 
 	async postTitleDisplayed( postTitle ) {


### PR DESCRIPTION
Currently, a lot of e2e tests (eg: https://github.com/Automattic/wp-calypso/pull/44385) are failing on CI with

<img width="996" alt="Screenshot 2020-07-23 at 12 02 32" src="https://user-images.githubusercontent.com/444434/88279726-75d53580-ccdc-11ea-852b-6fff4bd14f02.png">

This warns of selector `.activity-log__wrapper` being missing.

If we dive into the code the presence of this selector is dependent on:

1. Activity items being present
2. Network conditions

To avoid potential timeout issues this PR updates the selector which determines whether we are on the Activirty _Page_  to use a selector which is independent of data/loading conditions. 

This is now `.is-section-activity`.

![Screen Shot 2020-07-23 at 12 10 29](https://user-images.githubusercontent.com/444434/88280338-85a14980-ccdd-11ea-90ff-f9a4da71b379.png)

IMHO it would be better not to rely on the presence of the Activity _Log_ to determine whether we’re on the right _page_ as this is merely one component of the wider Activity page.

#### Changes proposed in this Pull Request

* Update CSS selector which determines whether we are on the Activity Page to target element which is likely to be present even in adverse data/network conditions.

#### Testing instructions

* Check CI doesn't fail with


<img width="996" alt="Screenshot 2020-07-23 at 12 02 32" src="https://user-images.githubusercontent.com/444434/88279726-75d53580-ccdc-11ea-852b-6fff4bd14f02.png">

* Also check other tests don't start failing!


