### PR TITLE
Signup: Add reskinned user step

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -107,6 +107,7 @@ class SignupForm extends Component {
 		suggestedUsername: PropTypes.string.isRequired,
 		translate: PropTypes.func.isRequired,
 		showRecaptchaToS: PropTypes.bool,
+		horizontal: PropTypes.bool,
 
 		// Connected props
 		oauth2Client: PropTypes.object,
@@ -119,6 +120,7 @@ class SignupForm extends Component {
 		flowName: '',
 		isSocialSignupEnabled: false,
 		showRecaptchaToS: false,
+		horizontal: false,
 	};
 
 	state = {
@@ -1015,6 +1017,7 @@ class SignupForm extends Component {
 			<div
 				className={ classNames( 'signup-form', this.props.className, {
 					'is-showing-recaptcha-tos': this.props.showRecaptchaToS,
+					'is-horizontal': this.props.horizontal,
 				} ) }
 			>
 				{ this.getNotice() }
@@ -1028,6 +1031,12 @@ class SignupForm extends Component {
 
 					{ this.props.formFooter || this.formFooter() }
 				</LoggedOutForm>
+
+				{ this.props.horizontal && (
+					<div className="signup-form__separator">
+						<span className="signup-form__separator-text">{ this.props.translate( 'or' ) }</span>
+					</div>
+				) }
 
 				{ this.props.isSocialSignupEnabled && ! this.userCreationComplete() && (
 					<SocialSignupForm

--- a/client/blocks/signup-form/style.scss
+++ b/client/blocks/signup-form/style.scss
@@ -112,3 +112,145 @@
 		}
 	}
 }
+
+.signup-form.is-horizontal {
+	$breakpoint-mobile: 660px;
+	$separator-style: 1px solid #eaeaeb;
+
+	display: flex;
+	flex-wrap: wrap;
+	margin-top: 50px;
+
+	.logged-out-form,
+	.signup-form__social {
+		width: calc( 50% - 30px );
+		max-width: 408px;
+		padding: 0 16px;
+		box-shadow: none;
+
+		@media screen and ( max-width: $breakpoint-mobile ) {
+			width: unset;
+		}
+	}
+
+	.signup-form__social p {
+		text-align: left;
+	}
+
+	.signup-form__social > p {
+		display: none;
+	}
+
+	.signup-form__separator {
+		position: relative;
+		display: flex;
+		width: 60px;
+		align-items: center;
+		justify-content: center;
+
+		@media screen and ( max-width: $breakpoint-mobile ) {
+			width: calc( 100% - 32px );
+			margin: 20px auto;
+		}
+
+		&::before {
+			position: absolute;
+			content: '';
+			border-left: $separator-style;
+			top: 0;
+			left: 50%;
+			height: 100%;
+
+			@media screen and ( max-width: $breakpoint-mobile ) {
+				border-left: 0;
+				border-top: $separator-style;
+				top: 50%;
+				left: 0;
+				height: 0;
+				width: 100%;
+			}
+		}
+	}
+
+	.signup-form__separator-text {
+		background: var( --studio-white );
+		text-transform: uppercase;
+		text-align: center;
+		padding: 24px 0;
+		font-size: 12px;
+		z-index: 1;
+
+		@media screen and ( max-width: $breakpoint-mobile ) {
+			padding: 0 24px;
+		}
+	}
+
+	.signup-form__social-buttons {
+		display: flex;
+		flex-direction: column;
+		height: 100%;
+		justify-content: center;
+	}
+
+	.social-buttons__button {
+		border: 0;
+		box-shadow: none;
+		text-align: left;
+		padding-left: 0;
+
+		@media screen and ( max-width: $breakpoint-mobile ) {
+			text-align: center;
+			margin-bottom: 5px;
+		}
+
+		> svg {
+			border: 1px solid #e2e4e7;
+			padding: 12px;
+			border-radius: 24px;
+		}
+	}
+
+	.social-buttons__service-name {
+		margin-left: 12px;
+	}
+
+	p.signup-form__social-buttons-tos {
+		font-size: 0.75rem;
+
+		@media screen and ( max-width: $breakpoint-mobile ) {
+			max-width: 408px;
+			text-align: center;
+			padding: 0 16px;
+		}
+	}
+
+	> .logged-out-form__links {
+		max-width: 100%;
+		margin-top: 30px;
+
+		@media screen and ( max-width: $breakpoint-mobile ) {
+			margin-top: 0;
+
+			&::before, &::after {
+				content: '';
+				display: block;
+				margin: 40px auto 24px;
+				border: 0;
+				padding: 0;
+				border-top: $separator-style;
+				width: 90px;
+			}
+		}
+	}
+
+	.signup-form__recaptcha-tos {
+		padding: 0 16px;
+		margin: 0 auto;
+
+		.logged-out-form__links {
+			&::before {
+				content: none;
+			}
+		}
+	}
+}

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -33,8 +33,13 @@ import config from 'config';
 import AsyncLoad from 'components/async-load';
 import WooCommerceConnectCartHeader from 'extensions/woocommerce/components/woocommerce-connect-cart-header';
 import { getSocialServiceFromClientId } from 'lib/login';
-import { abtest } from 'lib/abtest';
+import { abtest, getABTestVariation } from 'lib/abtest';
 import JetpackLogo from 'components/jetpack-logo';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
 
 export class UserStep extends Component {
 	static propTypes = {
@@ -427,6 +432,7 @@ export class UserStep extends Component {
 					socialServiceResponse={ socialServiceResponse }
 					recaptchaClientId={ this.state.recaptchaClientId }
 					showRecaptchaToS={ flows.getFlow( this.props.flowName )?.showRecaptcha }
+					horizontal={ 'reskinned' === getABTestVariation( 'reskinSignupFlow' ) }
 				/>
 				<div id="g-recaptcha"></div>
 			</>

--- a/client/signup/steps/user/style.scss
+++ b/client/signup/steps/user/style.scss
@@ -1,0 +1,24 @@
+body.is-section-signup.is-white-signup .signup.is-onboarding {
+	$gray-40: #787c82;
+
+	.signup-form.is-horizontal {
+		.form-label,
+		.signup-form__terms-of-service-link,
+		.signup-form__terms-of-service-link a,
+		.signup-form__social-buttons-tos,
+		.signup-form__social-buttons-tos a,
+		.signup-form__social p,
+		.signup-form__recaptcha-tos,
+		.logged-out-form__links .logged-out-form__link-item {
+			color: $gray-40;
+			font-weight: normal;
+		}
+
+		.signup-form__terms-of-service-link a,
+		.signup-form__social-buttons-tos a,
+		.signup-form__recaptcha-tos a {
+			color: inherit;
+			text-decoration: underline;
+		}
+	}
+}

--- a/client/signup/steps/user/style.scss
+++ b/client/signup/steps/user/style.scss
@@ -1,6 +1,4 @@
 body.is-section-signup.is-white-signup .signup.is-onboarding {
-	$gray-40: #787c82;
-
 	.signup-form.is-horizontal {
 		.form-label,
 		.signup-form__terms-of-service-link,
@@ -10,7 +8,7 @@ body.is-section-signup.is-white-signup .signup.is-onboarding {
 		.signup-form__social p,
 		.signup-form__recaptcha-tos,
 		.logged-out-form__links .logged-out-form__link-item {
-			color: $gray-40;
+			color: var( --studio-gray-40 );
 			font-weight: normal;
 		}
 

--- a/client/signup/steps/user/test/index.js
+++ b/client/signup/steps/user/test/index.js
@@ -20,6 +20,7 @@ import { UserStep as User } from '../';
 jest.mock( 'blocks/signup-form', () => require( 'components/empty-component' ) );
 jest.mock( 'lib/abtest', () => ( {
 	abtest: () => '',
+	getABTestVariation: () => null,
 } ) );
 jest.mock( 'signup/step-wrapper', () => require( 'components/empty-component' ) );
 jest.mock( 'signup/utils', () => ( {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds reskinned user step to the reskinning signup flow project. More details can be found in #44223.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/new` as a logged out user.
* Make sure you're assigned to the `reskinned` group of `reskinSignupFlow` a/b test.
* The user step should look like as follows and you should be able to complete the step:
  _Desktop_ 
  <img width="765" alt="사이트_만들기_—_WordPress_com" src="https://user-images.githubusercontent.com/212034/88280070-26185d80-cd20-11ea-950a-606107573917.png">
  _Desktop with locale selector_ 
  <img width="886" alt="Create_a_site_—_WordPress_com" src="https://user-images.githubusercontent.com/212034/88280282-798aab80-cd20-11ea-878d-7a08234b8cf4.png">
  _Desktop with invalid fields_. 
  <img width="886" alt="Create_a_site_—_WordPress_com" src="https://user-images.githubusercontent.com/212034/88280502-e2722380-cd20-11ea-816b-e039e2f92616.png">
  _Mobile_ 
  <img width="395" alt="사이트_만들기_—_WordPress_com" src="https://user-images.githubusercontent.com/212034/88280135-42b49580-cd20-11ea-95e3-f49055625ec3.png">
