### PR TITLE
Fix intermitent e2e coupon tests by using by force wait until cart has fully loaded before asserting on total update

### DIFF
--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
@@ -45,7 +45,10 @@ export default function WPCheckoutOrderSummary() {
 	const isCartUpdating = 'validating' === formStatus;
 
 	return (
-		<CheckoutSummaryCardUI className={ isCartUpdating ? 'is-loading' : '' }>
+		<CheckoutSummaryCardUI
+			className={ isCartUpdating ? 'is-loading' : '' }
+			data-e2e-cart-is-loading={ isCartUpdating }
+		>
 			<CheckoutSummaryFeatures>
 				<CheckoutSummaryFeaturesTitle>
 					{ translate( 'Included with your purchase' ) }

--- a/test/e2e/lib/components/secure-payment-component.js
+++ b/test/e2e/lib/components/secure-payment-component.js
@@ -304,6 +304,11 @@ export default class SecurePaymentComponent extends AsyncBaseContainer {
 	async waitForCouponToBeRemoved() {
 		const isCompositeCheckout = await this.isCompositeCheckout();
 		if ( isCompositeCheckout ) {
+			await driverHelper.waitTillNotPresent(
+				this.driver,
+				By.css( '[data-e2e-cart-is-loading="true"]' )
+			);
+
 			return await driverHelper.waitTillNotPresent(
 				this.driver,
 				By.css( '#checkout-line-item-coupon-line-item' )


### PR DESCRIPTION
Tests are failing on CI for 

<img width="994" alt="Screenshot 2020-07-23 at 13 42 45" src="https://user-images.githubusercontent.com/444434/88287596-6b219d00-ccea-11ea-93f8-70e7c122f387.png">

From the CI videos it looks like we might be assertion on the new total after the coupon has been removed too early (ie: before the cart has finished updating).

This PR tries to fix this by waiting until the loading state is no longer present before asserting on the new cost.

#### Changes proposed in this Pull Request

* Add `data-e2e` helper to determine whether cart total is still updating.
* Wait on this selector before proceeding to assertion on new total.

#### Testing instructions

* Test on CI should not fail on Coupon step shown in screenshot above.
* Running test locally with `./node_modules/.bin/mocha specs/wp-plan-purchase-spec.js` should pass.

Fixes #
