### PR TITLE
Don't use signup suggestions vendor for domain-only purchases

### DIFF
--- a/client/landing/gutenboarding/stores/domain-suggestions/index.ts
+++ b/client/landing/gutenboarding/stores/domain-suggestions/index.ts
@@ -6,5 +6,5 @@ import { getSuggestionsVendor } from 'lib/domains/suggestions';
 
 export const DOMAIN_SUGGESTIONS_STORE = DomainSuggestions.register( {
 	/* Returns an ID for the domain suggestions vendor. Passing `true` to getSuggestionsVendor returns the signup variant.*/
-	vendor: getSuggestionsVendor( true ),
+	vendor: getSuggestionsVendor( { isSignup: true } ),
 } );

--- a/client/lib/domains/suggestions/index.js
+++ b/client/lib/domains/suggestions/index.js
@@ -1,12 +1,13 @@
 /**
  * Get the suggestions vendor
  *
- * @param {boolean} [isSignup=false] Whether the query is part of a signup flow.
+ * @param {object} [options={}] Options to control the behaviour.
+ * @param {boolean} [options.isSignup=false] Whether the query is part of a signup flow.
  *
  * @returns {string} Vendor string to pass as part of the domain suggestions query.
  */
-export const getSuggestionsVendor = ( isSignup = false ) => {
-	if ( isSignup ) {
+export const getSuggestionsVendor = ( options = {} ) => {
+	if ( options && options.isSignup ) {
 		return 'variation4_front';
 	}
 	return 'variation2_front';

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -487,7 +487,7 @@ class DomainsStep extends React.Component {
 				isEligibleVariantForDomainTest={ this.isEligibleVariantForDomainTest() }
 				suggestion={ initialQuery }
 				designType={ this.getDesignType() }
-				vendor={ getSuggestionsVendor( ! this.props.isDomainOnly ) }
+				vendor={ getSuggestionsVendor( { isSignup: ! this.props.isDomainOnly } ) }
 				deemphasiseTlds={ this.props.flowName === 'ecommerce' ? [ 'blog' ] : [] }
 				selectedSite={ this.props.selectedSite }
 				showSkipButton={ this.props.showSkipButton }

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -487,7 +487,7 @@ class DomainsStep extends React.Component {
 				isEligibleVariantForDomainTest={ this.isEligibleVariantForDomainTest() }
 				suggestion={ initialQuery }
 				designType={ this.getDesignType() }
-				vendor={ getSuggestionsVendor( true ) }
+				vendor={ getSuggestionsVendor( ! this.props.isDomainOnly ) }
 				deemphasiseTlds={ this.props.flowName === 'ecommerce' ? [ 'blog' ] : [] }
 				selectedSite={ this.props.selectedSite }
 				showSkipButton={ this.props.showSkipButton }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR changes the logic used in the shared `DomainsStep` component so that it fetches the non-signup suggestions vendor when we're in the domain-only purchase flow available via `wordpress.com/domains`.

#### Testing instructions

* Enable your browser developer tools and switch to the network tab.
* Visit `/domains` on your local instance or on [calypso.live](https://calypso.live/?branch=fix/domain-suggestions-vendor-for-domain-only-flow), and enter a search term.
* Verify that you see suggestions, and the network call to `https://public-api.wordpress.com/rest/v1.1/domains/suggestions` includes the URL parameter and value of `vendor=variation2_front` (this is our non-signup search vendor).
* Visit `/start/domains` on your local instance or on calypso.live, and enter a search term.
* Verify that you see suggestions, and the network call to `https://public-api.wordpress.com/rest/v1.1/domains/suggestions` includes the URL parameter and value of `vendor=variation4_front` (this is our signup search vendor).