### PR TITLE
Add more domains list options

### DIFF
--- a/client/lib/domains/index.js
+++ b/client/lib/domains/index.js
@@ -16,6 +16,8 @@ export { getTld } from './get-tld';
 export { getTopLevelOfTld } from './get-top-level-of-tld';
 export { getUnformattedDomainPrice } from './get-unformatted-domain-price';
 export { getUnformattedDomainSalePrice } from './get-unformatted-domain-sale-price';
+export { isDomainUpdateable } from './is-domain-updateable';
+export { isDomainInGracePeriod } from './is-domain-in-grace-period';
 export { isHstsRequired } from './is-hsts-required';
 export { isSubdomain } from './is-subdomain';
 export {

--- a/client/lib/domains/is-domain-in-grace-period.js
+++ b/client/lib/domains/is-domain-in-grace-period.js
@@ -1,0 +1,8 @@
+/**
+ * External dependencies
+ */
+import moment from 'moment';
+
+export function isDomainInGracePeriod( domain ) {
+	return moment().subtract( 18, 'days' ) <= moment( domain?.expiry );
+}

--- a/client/lib/domains/is-domain-updateable.js
+++ b/client/lib/domains/is-domain-updateable.js
@@ -1,0 +1,3 @@
+export function isDomainUpdateable( domain ) {
+	return ! domain?.pendingTransfer && ! domain?.expired;
+}

--- a/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
+++ b/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
@@ -12,7 +12,12 @@ import Gridicon from 'components/gridicon';
 import config from 'config';
 import { addQueryArgs } from '@wordpress/url';
 import { withLocalizedMoment } from 'components/localized-moment';
-import { getDomainTypeText, isSubdomain } from 'lib/domains';
+import {
+	getDomainTypeText,
+	isSubdomain,
+	isDomainUpdateable,
+	isDomainInGracePeriod,
+} from 'lib/domains';
 import VerticalNav from 'components/vertical-nav';
 import VerticalNavItem from 'components/vertical-nav/item';
 import MaterialIcon from 'components/material-icon';
@@ -78,23 +83,11 @@ const DomainManagementNavigationItem = function ( props ) {
 };
 
 class DomainManagementNavigationEnhanced extends React.Component {
-	isDomainInNormalState() {
-		const { domain } = this.props;
-		const { expired, pendingTransfer } = domain;
-		return ! pendingTransfer && ! expired;
-	}
-
-	isDomainInGracePeriod() {
-		const { domain, moment } = this.props;
-		const { expiry } = domain;
-		return moment().subtract( 18, 'days' ) <= moment( expiry );
-	}
-
 	getEmail() {
 		const { selectedSite, translate, currentRoute, domain } = this.props;
 		const { emailForwardsCount } = domain;
 
-		if ( ! this.isDomainInNormalState() ) {
+		if ( ! isDomainUpdateable( domain ) ) {
 			return null;
 		}
 
@@ -173,7 +166,7 @@ class DomainManagementNavigationEnhanced extends React.Component {
 	getNameServers() {
 		const { translate, domain, currentRoute, selectedSite } = this.props;
 
-		if ( ! this.isDomainInNormalState() && ! this.isDomainInGracePeriod() ) {
+		if ( ! isDomainUpdateable( domain ) && ! isDomainInGracePeriod( domain ) ) {
 			return null;
 		}
 
@@ -208,7 +201,7 @@ class DomainManagementNavigationEnhanced extends React.Component {
 		const { selectedSite, translate, currentRoute, domain } = this.props;
 		const { privateDomain, privacyAvailable } = domain;
 
-		if ( ! this.isDomainInNormalState() && ! this.isDomainInGracePeriod() ) {
+		if ( ! isDomainUpdateable( domain ) && ! isDomainInGracePeriod( domain ) ) {
 			return null;
 		}
 
@@ -235,7 +228,7 @@ class DomainManagementNavigationEnhanced extends React.Component {
 		const { moment, selectedSite, translate, domain, currentRoute } = this.props;
 		const { expired, isLocked, transferAwayEligibleAt } = domain;
 
-		if ( expired && ! this.isDomainInGracePeriod() ) {
+		if ( expired && ! isDomainInGracePeriod( domain ) ) {
 			return null;
 		}
 

--- a/client/my-sites/domains/domain-management/list/domain-item.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-item.jsx
@@ -21,9 +21,16 @@ import { hasGSuiteWithUs, getGSuiteMailboxCount } from 'lib/gsuite';
 import { withoutHttp } from 'lib/url';
 import { type as domainTypes } from 'lib/domains/constants';
 import { handleRenewNowClick } from 'lib/purchases';
-import { resolveDomainStatus } from 'lib/domains';
+import { resolveDomainStatus, isDomainInGracePeriod, isDomainUpdateable } from 'lib/domains';
 import InfoPopover from 'components/info-popover';
 import { emailManagement } from 'my-sites/email/paths';
+import {
+	domainManagementContactsPrivacy,
+	domainManagementNameServers,
+	domainManagementTransfer,
+	domainManagementDns,
+	domainManagementSecurity,
+} from 'my-sites/domains/paths';
 import Spinner from 'components/spinner';
 import TrackComponentView from 'lib/analytics/track-component-view';
 
@@ -185,7 +192,7 @@ class DomainItem extends PureComponent {
 	}
 
 	renderOptionsButton() {
-		const { disabled, isBusy, translate } = this.props;
+		const { disabled, isBusy, site, domain, domainDetails, currentRoute, translate } = this.props;
 
 		return (
 			<div className="list__domain-options">
@@ -205,6 +212,51 @@ class DomainItem extends PureComponent {
 						</PopoverMenuItem>
 					) }
 					<PopoverMenuItem icon="pencil">{ translate( 'Edit settings' ) }</PopoverMenuItem>
+					{ domain.type === domainTypes.MAPPED && (
+						<PopoverMenuItem
+							icon="list-unordered"
+							href={ domainManagementDns( site.slug, domain.domain, currentRoute ) }
+						>
+							{ translate( 'DNS Records' ) }
+						</PopoverMenuItem>
+					) }
+					{ domain.type === domainTypes.REGISTERED &&
+						( isDomainUpdateable( domainDetails ) || isDomainInGracePeriod( domainDetails ) ) && (
+							<PopoverMenuItem
+								icon="domains"
+								href={ domainManagementNameServers( site.slug, domain.domain, currentRoute ) }
+							>
+								{ translate( 'Name servers' ) }
+							</PopoverMenuItem>
+						) }
+					{ domain.type === domainTypes.REGISTERED &&
+						( isDomainUpdateable( domainDetails ) || isDomainInGracePeriod( domainDetails ) ) && (
+							<PopoverMenuItem
+								icon="reader"
+								href={ domainManagementContactsPrivacy( site.slug, domain.domain, currentRoute ) }
+							>
+								{ translate( 'Contact information' ) }
+							</PopoverMenuItem>
+						) }
+					{ domain.type === domainTypes.REGISTERED &&
+						! ( domainDetails?.expired && ! isDomainInGracePeriod( domainDetails ) ) && (
+							<PopoverMenuItem
+								icon="reply"
+								href={ domainManagementTransfer( site.slug, domain.domain, currentRoute ) }
+							>
+								{ translate( 'Transfer domain' ) }
+							</PopoverMenuItem>
+						) }
+					{ [ domainTypes.REGISTERED, domainTypes.MAPPED ].includes( domain.type ) &&
+						domainDetails?.pointsToWpcom &&
+						domainDetails?.sslStatus && (
+							<PopoverMenuItem
+								icon="lock"
+								href={ domainManagementSecurity( site.slug, domain.domain, currentRoute ) }
+							>
+								{ translate( 'Security' ) }
+							</PopoverMenuItem>
+						) }
 				</EllipsisMenu>
 			</div>
 		);

--- a/client/my-sites/domains/domain-management/list/domain-item.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-item.jsx
@@ -50,7 +50,7 @@ class DomainItem extends PureComponent {
 		onSelect: PropTypes.func,
 		onToggle: PropTypes.func,
 		onUpgradeClick: PropTypes.func,
-		shouldUpgradeToMakePrimary: PropTypes.boolean,
+		shouldUpgradeToMakePrimary: PropTypes.bool,
 		purchase: PropTypes.object,
 		isLoadingDomainDetails: PropTypes.bool,
 		selectionIndex: PropTypes.number,

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -295,6 +295,9 @@ input[type='radio'].domain-management-list-item__radio {
 	width: 65px;
 	font-size: $font-body-small;
 	text-align: center;
+	button {
+		width: 100%;
+	}
 }
 
 .domain-item__icon {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* We're adding more shortcuts from the domain management list to domain management pages. To be more specific - we'll add shortcuts in the options menu to manage:
  * Name servers
  * DNS records
  * Contact information
  * Transfer
  * Security

Here's how it looks (the menu items are different depending the the domain type and status):

<img width="218" alt="Screenshot 2020-07-23 at 17 46 50" src="https://user-images.githubusercontent.com/1355045/88327400-b316e300-cd2f-11ea-841f-c89f056786ab.png">
<img width="217" alt="Screenshot 2020-07-23 at 17 46 28" src="https://user-images.githubusercontent.com/1355045/88327393-b14d1f80-cd2f-11ea-9cf6-528422139b4a.png">
<img width="219" alt="Screenshot 2020-07-23 at 17 46 35" src="https://user-images.githubusercontent.com/1355045/88327399-b316e300-cd2f-11ea-920e-909f83fce441.png">


#### Testing instructions

* Open the all domains management list and click on the ellipsis menu on the right and try clicking on the different options
