### PR TITLE
Signup: remove persisted 'user' step after logging in

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -260,13 +260,7 @@ class Signup extends React.Component {
 
 		const p2SiteStep = this.props.progress[ 'p2-site' ];
 
-		if (
-			this.props.progress.user &&
-			p2SiteStep &&
-			p2SiteStep.status === 'pending' &&
-			user() &&
-			user().get()
-		) {
+		if ( p2SiteStep && p2SiteStep.status === 'pending' && user() && user().get() ) {
 			// By removing and adding the p2-site step, we trigger the `SignupFlowController` store listener
 			// to process the signup flow.
 			this.props.removeStep( p2SiteStep );

--- a/client/state/initial-state.js
+++ b/client/state/initial-state.js
@@ -303,6 +303,11 @@ export function getStateFromCache( reducer, subkey ) {
 		reduxStateKey = getPersistenceKey( subkey, true );
 		persistedState = stateCache[ reduxStateKey ] ?? null;
 
+		// If we are logged in, we no longer need the 'user' step in signup progress tree.
+		if ( persistedState && persistedState.progress && persistedState.progress.user ) {
+			delete persistedState.progress.user;
+		}
+
 		debug( 'fetched signup state from logged out state', persistedState );
 	}
 


### PR DESCRIPTION
In https://github.com/Automattic/wp-calypso/pull/44106, we restored persisted `signup` state tree after a user logged into Calypso so they can continue a signup process. However, part of the signup state tree is `progress`. It contains the various steps of the signup process, like `domains` or `user`. The `user` step only makes sense to be inside `progress` if we are creating a new user (like filling out the user form) or when the form is processing (being saved to the server).

When we log in to an unfinished signup flow which had the `user` step, I don't think it makes sense to preserve it and load it to the logged-in session. Let's remove it from the cached state before loading it. We also need to remove the `user` step because otherwise the `SignupFlowController` will reset the whole progress during its initialization if it detects a user is logged in and we have `user` step in progress: https://github.com/Automattic/wp-calypso/blob/9f68446d01aa59838a4cfb3299dd1b64c441691e/client/lib/signup/flow-controller.ts#L145. If we reset the signup progress like that, we can't continue the signup after logging in. /cc @scruffian I know it has been more than 5 years but you've introduced that `_resetStoresIfUserHasLoggedIn` change in 10746-gh-calypso-pre-oss. Perhaps you could have a look at this PR to see if I'm introducing some regressions by doing this, please.

## Testing instructions

Test a few signup flows (not just P2) to make sure they work as before.