### PR TITLE
Jetpack Cloud: Fix Backup/Scan upsell for sites that aren't eligible

### DIFF
--- a/client/components/jetpack/upsell-switch/index.tsx
+++ b/client/components/jetpack/upsell-switch/index.tsx
@@ -126,8 +126,7 @@ function UpsellSwitch( props: Props ): React.ReactElement {
 		if (
 			UI_STATE_LOADED === uiState &&
 			! atomicSite &&
-			! hasProduct &&
-			( ! state || state === 'unavailable' )
+			( ! state || state === 'unavailable' || ! hasProduct )
 		) {
 			setUpsell( true );
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Changes the logic in UpsellSwitch to account for sites that may have a product purchased but are not eligible to use it (e.g., sites with Jetpack Professional but which are using VaultPress).

Fixes `1164141197617539-as-1185661726673658`.

#### Testing instructions

(Note: for examples, see screenshots below.)

* Check that VaultPress sites see a VaultPress notice/call-to-action when visiting the Backup or Scan page on Calypso.
* Check that multisite sites see a multisite notice when visiting the Backup page on Calypso.
* Verify that sites eligible for Backup and Scan see the correct upsell (if not purchased) or the actual Backup/Scan page (if purchased).

#### Screenshots

##### VaultPress site on Backup page

<img width="387" alt="Screen Shot 2020-07-23 at 11 09 48" src="https://user-images.githubusercontent.com/670067/88310974-ef1d5a00-ccd5-11ea-8661-26e941bfc28b.png">

##### VaultPress site on Scan page

<img width="388" alt="Screen Shot 2020-07-23 at 11 17 46" src="https://user-images.githubusercontent.com/670067/88311179-30ae0500-ccd6-11ea-80b1-76b2bff8e699.png">

##### Multisite site on Backup page

<img width="386" alt="Screen Shot 2020-07-23 at 11 03 35" src="https://user-images.githubusercontent.com/670067/88310988-f6446800-ccd5-11ea-9e1a-d2ab6264a921.png">

##### "Normal" site on Backup page (not purchased)

<img width="388" alt="Screen Shot 2020-07-23 at 11 21 53" src="https://user-images.githubusercontent.com/670067/88312024-41ab4600-ccd7-11ea-8930-8748ab7bffeb.png">

##### "Normal" site on Scan page (not purchased)

<img width="388" alt="Screen Shot 2020-07-23 at 11 21 05" src="https://user-images.githubusercontent.com/670067/88311544-a0bc8b00-ccd6-11ea-80e4-5fce5969a119.png">