### PR TITLE
composite-checkout: Add logstash to cart load/save errors

### DIFF
--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -156,6 +156,10 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 				);
 
 			case 'CART_ERROR':
+				reduxDispatch(
+					logStashLoadErrorEventAction( action.payload.type, String( action.payload.message ) )
+				);
+
 				return reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_composite_cart_error', {
 						error_type: action.payload.type,

--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -157,7 +157,10 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 
 			case 'CART_ERROR':
 				reduxDispatch(
-					logStashLoadErrorEventAction( action.payload.type, String( action.payload.message ) )
+					logStashEventAction( 'calypso_checkout_composite_cart_error', {
+						type: action.payload.type,
+						message: action.payload.message,
+					} )
 				);
 
 				return reduxDispatch(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This adds logstash logging to cart load and save errors in addition to the existing Tracks logging for those issues.

#### Testing instructions

- Sandbox the API.
- Visit the `/plans` page in local calypso.
- Apply D46792-code on your sandbox. You must do this AFTER loading the plans page for this test to work.
- On the plans page (without reloading), click an "Upgrade" button to add a plan to your cart. This will redirect you to checkout.
- Verify that you see an error message that reads "User or Token does not have access to specified site."
- Search logstash for "calypso_checkout_composite_cart_error" and verify that you see your error logged there.