### PR TITLE
Remove the options label from the domain list header

### DIFF
--- a/client/my-sites/domains/domain-management/list/list-header.jsx
+++ b/client/my-sites/domains/domain-management/list/list-header.jsx
@@ -61,7 +61,7 @@ class ListHeader extends React.PureComponent {
 						) }
 					</InfoPopover>
 				</div>
-				<div className="list__domain-options">{ translate( 'Options' ) }</div>
+				<div className="list__domain-options"></div>
 			</CompactCard>
 		);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* As requested by @fditrapani - we don't what to show the "Options" label in the domains list header. Here's how it looks now:

<img width="779" alt="Screenshot 2020-07-23 at 22 19 38" src="https://user-images.githubusercontent.com/1355045/88329448-a3e56480-cd32-11ea-8317-0c8c2548000b.png">


#### Testing instructions

* Open the domains list view `/domains/manage` and verify that the "Options" label is missing
