### PR TITLE
composite-checkout: Use the siteId rather than the siteSlug for the cart key

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -208,7 +208,7 @@ export default function CompositeCheckout( {
 		loadingError,
 		addItem,
 	} = useShoppingCart(
-		siteSlug,
+		siteId,
 		canInitializeCart && ! isLoadingCartSynchronizer && ! isFetchingProducts,
 		productsForCart,
 		couponCodeFromUrl,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Composite Checkout's `useShoppingCart` hook calls the `/me/shopping-cart` endpoint for the user's site using a "cart key" to identify the cart for that site. This cart key can be either the site's ID or the site's domain name. Currently we are using the site's domain name, but this may sometimes cause issues when the server tries to convert that domain name back into an ID.

In this PR, I modified the hook to use the site's ID as the cart key instead. For most sites, this should have no effect.

#### Testing instructions

Add a product to your cart and visit composite checkout. Verify that you can add products and remove products as normal.