### PR TITLE
InlineHelp: Keep FAB Open When Interacting with Article Modal

### DIFF
--- a/client/blocks/inline-help/inline-help-rich-result.jsx
+++ b/client/blocks/inline-help/inline-help-rich-result.jsx
@@ -75,10 +75,10 @@ class InlineHelpRichResult extends Component {
 		);
 
 		this.props.recordTracksEvent( `calypso_inlinehelp_${ type }_open`, tracksData );
-		this.props.closePopover();
 
 		if ( type === RESULT_TOUR ) {
 			event.preventDefault();
+			this.props.closePopover();
 			this.props.requestGuidedTour( tour );
 		} else if ( type === RESULT_VIDEO ) {
 			event.preventDefault();

--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -43,6 +43,7 @@ import QueryActiveTheme from 'components/data/query-active-theme';
 import isGutenbergOptInEnabled from 'state/selectors/is-gutenberg-opt-in-enabled';
 import isGutenbergOptOutEnabled from 'state/selectors/is-gutenberg-opt-out-enabled';
 import inEditorDeprecationGroup from 'state/editor-deprecation-group/selectors/in-editor-deprecation-group';
+import SupportArticleDialog from 'blocks/support-article-dialog/docs/example';
 
 class InlineHelpPopover extends Component {
 	static propTypes = {
@@ -249,6 +250,7 @@ class InlineHelpPopover extends Component {
 				position="top left"
 				context={ this.props.context }
 				className={ classNames( 'inline-help__popover', popoverClasses ) }
+				ignoreContext={ SupportArticleDialog }
 			>
 				{ this.renderPopoverContent() }
 				{ this.renderPopoverFooter() }


### PR DESCRIPTION
Fixes #43637

#### Changes proposed in this Pull Request

1. Change the `InlineHelpRichResult` component so that it only closes the FAB Popover when a tour is opened ("Start tour" button), not when a video or article is opened ("Read more" button).
2. Add the `SupportArticleDialog` component as an `ignoreContext` prop on the `InlineHelpPopover` component so that clicks to the article modal don't close the FAB.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the FAB (click the question mark button in the lower right)
* Type in a query (e.g. "Finding Free Images and Other Media") and click on one of the article results (this opens up a modal)
* Close the modal
* [ ] The FAB should still be open
* Click on a tour result (e.g. "Learn Media Library Basics" -- need to be on media/{blog})
* [ ] The FAB should close.
* Click on a video result (e.g. "Add a Photo Gallery" -- need to be on media/{blog}) and click to open the video
* Close the video modal
* [ ] The FAB should still be open