### PR TITLE
Earn: remove earn/rename-payment-blocks feature flag

### DIFF
--- a/client/blocks/inline-help/contextual-help.js
+++ b/client/blocks/inline-help/contextual-help.js
@@ -9,7 +9,6 @@ import i18n, { translate } from 'i18n-calypso';
  */
 import { RESULT_TOUR, RESULT_VIDEO } from './constants';
 import { localizeUrl } from 'lib/i18n-utils';
-import { isEnabled } from 'config';
 
 /**
  * Module variables
@@ -1208,9 +1207,7 @@ const getVideosForSection = () => ( {
 		{
 			type: RESULT_VIDEO,
 			link: 'https://www.youtube.com/embed/V8UToJoSf4Q',
-			title: isEnabled( 'earn/rename-payment-blocks' )
-				? translate( 'Add a Pay with PayPal button' )
-				: translate( 'Add a Simple Payment Button' ),
+			title: translate( 'Add a Pay with PayPal button' ),
 			description: translate(
 				'Find out how to add a payment button to your WordPress.com website.'
 			),

--- a/client/blocks/product-purchase-features-list/sell-online-paypal.jsx
+++ b/client/blocks/product-purchase-features-list/sell-online-paypal.jsx
@@ -10,7 +10,6 @@ import { localize } from 'i18n-calypso';
  */
 import PurchaseDetail from 'components/purchase-detail';
 import { localizeUrl } from 'lib/i18n-utils';
-import { isEnabled } from 'config';
 
 /**
  * Image dependencies
@@ -18,37 +17,18 @@ import { isEnabled } from 'config';
 import paymentsImage from 'assets/images/illustrations/payments.svg';
 
 export default localize( ( { isJetpack, translate } ) => {
-	let supportDocLink;
-	if ( isEnabled( 'earn/rename-payment-blocks' ) ) {
-		supportDocLink = localizeUrl(
-			isJetpack
-				? 'https://jetpack.com/support/pay-with-paypal/'
-				: 'https://wordpress.com/support/pay-with-paypal/'
-		);
-	} else {
-		supportDocLink = localizeUrl(
-			isJetpack
-				? 'https://jetpack.com/support/simple-payment-button/'
-				: 'https://wordpress.com/support/simple-payments/'
-		);
-	}
+	const supportDocLink = localizeUrl(
+		isJetpack
+			? 'https://jetpack.com/support/pay-with-paypal/'
+			: 'https://wordpress.com/support/pay-with-paypal/'
+	);
 	return (
 		<div className="product-purchase-features-list__item">
 			<PurchaseDetail
-				buttonText={
-					isEnabled( 'earn/rename-payment-blocks' )
-						? translate( 'Collect PayPal payments' )
-						: translate( 'Collect payments' )
-				}
-				description={
-					isEnabled( 'earn/rename-payment-blocks' )
-						? translate(
-								'Add a button to any post or page to collect PayPal payments for physical products, digital goods, services, or donations.'
-						  )
-						: translate(
-								'Add a payment button to any post or page to collect PayPal payments for physical products, digital goods, services, or donations.'
-						  )
-				}
+				buttonText={ translate( 'Collect PayPal payments' ) }
+				description={ translate(
+					'Add a button to any post or page to collect PayPal payments for physical products, digital goods, services, or donations.'
+				) }
 				href={ supportDocLink }
 				icon={ <img alt="" src={ paymentsImage } /> }
 				target="_blank"

--- a/client/components/tinymce/plugins/insert-menu/menu-items.jsx
+++ b/client/components/tinymce/plugins/insert-menu/menu-items.jsx
@@ -93,11 +93,7 @@ menuItems.push( {
 	item: (
 		<GridiconButton
 			icon={ <Gridicon icon="money" /> }
-			label={
-				config.isEnabled( 'earn/rename-payment-blocks' )
-					? i18n.translate( 'Pay with PayPal' )
-					: i18n.translate( 'Payment button' )
-			}
+			label={ i18n.translate( 'Pay with PayPal' ) }
 			e2e="payment-button"
 		/>
 	),

--- a/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
@@ -13,7 +13,6 @@ import { find, isNumber, pick, noop, get, isEmpty } from 'lodash';
 /**
  * Internal dependencies
  */
-import { isEnabled } from 'config';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import getSimplePayments from 'state/selectors/get-simple-payments';
 import QuerySimplePayments from 'components/data/query-simple-payments';
@@ -480,15 +479,9 @@ class SimplePaymentsDialog extends Component {
 						<UpsellNudge
 							className="editor-simple-payments-modal__nudge-nudge"
 							title={ translate( 'Upgrade your plan to our Premium or Business plan!' ) }
-							description={
-								isEnabled( 'earn/rename-payment-blocks' )
-									? translate(
-											'Get Pay with PayPal buttons, advanced social media tools, your own domain, and more.'
-									  )
-									: translate(
-											'Get simple payments, advanced social media tools, your own domain, and more.'
-									  )
-							}
+							description={ translate(
+								'Get Pay with PayPal buttons, advanced social media tools, your own domain, and more.'
+							) }
 							feature={ FEATURE_SIMPLE_PAYMENTS }
 							event="editor_simple_payments_modal_nudge"
 							tracksImpressionName="calypso_upgrade_nudge_impression"
@@ -499,15 +492,9 @@ class SimplePaymentsDialog extends Component {
 					secondaryAction={
 						<a
 							className="empty-content__action button"
-							href={
-								isEnabled( 'earn/rename-payment-blocks' )
-									? localizeUrl( 'https://wordpress.com/support/pay-with-paypal/' )
-									: localizeUrl( 'https://wordpress.com/support/simple-payments/' )
-							}
+							href={ localizeUrl( 'https://wordpress.com/support/pay-with-paypal/' ) }
 						>
-							{ isEnabled( 'earn/rename-payment-blocks' )
-								? translate( 'Learn more about Pay with PayPal' )
-								: translate( 'Learn more about Simple Payments' ) }
+							{ translate( 'Learn more about Pay with PayPal' ) }
 						</a>
 					}
 				/>,
@@ -538,15 +525,9 @@ class SimplePaymentsDialog extends Component {
 					secondaryAction={
 						<a
 							className="empty-content__action button"
-							href={
-								isEnabled( 'earn/rename-payment-blocks' )
-									? localizeUrl( 'https://wordpress.com/support/pay-with-paypal/' )
-									: localizeUrl( 'https://wordpress.com/support/simple-payments/' )
-							}
+							href={ localizeUrl( 'https://wordpress.com/support/pay-with-paypal/' ) }
 						>
-							{ isEnabled( 'earn/rename-payment-blocks' )
-								? translate( 'Learn more about Pay with PayPal' )
-								: translate( 'Learn more about Simple Payments' ) }
+							{ translate( 'Learn more about Pay with PayPal' ) }
 						</a>
 					}
 				/>,

--- a/client/components/tinymce/plugins/wpcom-view/views/simple-payments/index.jsx
+++ b/client/components/tinymce/plugins/wpcom-view/views/simple-payments/index.jsx
@@ -22,7 +22,6 @@ import QuerySitePlans from 'components/data/query-site-plans';
 import QueryMedia from 'components/data/query-media';
 import { getCurrentPlan, hasFeature } from 'state/sites/plans/selectors';
 import { FEATURE_SIMPLE_PAYMENTS } from 'lib/plans/constants';
-import { isEnabled } from 'config';
 
 class SimplePaymentsView extends Component {
 	render() {
@@ -57,9 +56,7 @@ class SimplePaymentsView extends Component {
 						<Gridicon icon="cross" />
 					</div>
 					<p className="wpview-type-simple-payments__unsupported-message">
-						{ isEnabled( 'earn/rename-payment-blocks' )
-							? translate( "Your plan doesn't include Pay with PayPal" )
-							: translate( "Your plan doesn't include Simple Payments" ) }
+						{ translate( "Your plan doesn't include Pay with PayPal" ) }
 					</p>
 				</div>
 			);

--- a/client/layout/guided-tours/docs/examples/tours/simple-payments-end-of-year-guide.js
+++ b/client/layout/guided-tours/docs/examples/tours/simple-payments-end-of-year-guide.js
@@ -21,7 +21,6 @@ import {
 	Link,
 } from 'layout/guided-tours/config-elements';
 import { hasSelectedSitePremiumOrBusinessPlan } from '../selectors/has-selected-site-premium-or-business-plan';
-import { isEnabled } from 'config';
 import { localizeUrl } from 'lib/i18n-utils';
 
 export const SimplePaymentsEndOfYearGuide = makeTour(
@@ -69,16 +68,8 @@ export const SimplePaymentsEndOfYearGuide = makeTour(
 						<Next step="add-new-page">{ translate( 'Get started!' ) }</Next>
 						<Quit>{ translate( 'No thanks.' ) }</Quit>
 					</ButtonRow>
-					<Link
-						href={
-							isEnabled( 'earn/rename-payment-blocks' )
-								? localizeUrl( 'https://wordpress.com/support/pay-with-paypal/' )
-								: localizeUrl( 'https://wordpress.com/support/simple-payments/' )
-						}
-					>
-						{ isEnabled( 'earn/rename-payment-blocks' )
-							? translate( 'Learn more about Pay with PayPal.' )
-							: translate( 'Learn more about Simple Payments.' ) }
+					<Link href={ localizeUrl( 'https://wordpress.com/support/pay-with-paypal/' ) }>
+						{ translate( 'Learn more about Pay with PayPal.' ) }
 					</Link>
 				</Fragment>
 			) }

--- a/client/layout/guided-tours/tours/simple-payments-email-tour/index.js
+++ b/client/layout/guided-tours/tours/simple-payments-email-tour/index.js
@@ -21,7 +21,6 @@ import {
 import { AddContentButton } from 'layout/guided-tours/button-labels';
 import { getSectionName, hasSidebar } from 'state/ui/selectors';
 import { targetForSlug } from 'layout/guided-tours/positioning';
-import { isEnabled } from 'config';
 import { localizeUrl } from 'lib/i18n-utils';
 
 const sectionHasSidebar = ( state ) =>
@@ -143,16 +142,8 @@ export const SimplePaymentsEmailTour = makeTour(
 							{ translate( 'Got it, thanks!' ) }
 						</DelegatingQuit>
 					</ButtonRow>
-					<Link
-						href={
-							isEnabled( 'earn/rename-payment-blocks' )
-								? localizeUrl( 'https://wordpress.com/support/pay-with-paypal/' )
-								: localizeUrl( 'https://wordpress.com/support/simple-payments/' )
-						}
-					>
-						{ isEnabled( 'earn/rename-payment-blocks' )
-							? translate( 'Learn more about Pay with PayPal.' )
-							: translate( 'Learn more about Simple Payments.' ) }
+					<Link href={ localizeUrl( 'https://wordpress.com/support/pay-with-paypal/' ) }>
+						{ translate( 'Learn more about Pay with PayPal.' ) }
 					</Link>
 				</Fragment>
 			) }

--- a/client/layout/guided-tours/tours/simple-payments-tour/index.js
+++ b/client/layout/guided-tours/tours/simple-payments-tour/index.js
@@ -17,7 +17,6 @@ import {
 	Link,
 	Quit,
 } from 'layout/guided-tours/config-elements';
-import { isEnabled } from 'config';
 import { localizeUrl } from 'lib/i18n-utils';
 
 export const SimplePaymentsTour = makeTour(
@@ -55,16 +54,8 @@ export const SimplePaymentsTour = makeTour(
 							<span>{ translate( 'Upgrade' ) }</span>
 						</SiteLink>
 					</ButtonRow>
-					<Link
-						href={
-							isEnabled( 'earn/rename-payment-blocks' )
-								? localizeUrl( 'https://wordpress.com/support/pay-with-paypal-button/' )
-								: localizeUrl( 'https://wordpress.com/support/simple-payments/' )
-						}
-					>
-						{ isEnabled( 'earn/rename-payment-blocks' )
-							? translate( 'Learn more about Pay with PayPal.' )
-							: translate( 'Learn more about Simple Payments.' ) }
+					<Link href={ localizeUrl( 'https://wordpress.com/support/pay-with-paypal-button/' ) }>
+						{ translate( 'Learn more about Pay with PayPal.' ) }
 					</Link>
 				</Fragment>
 			) }

--- a/client/lib/discounts/active-discounts.js
+++ b/client/lib/discounts/active-discounts.js
@@ -9,15 +9,12 @@ import {
 	TYPE_PERSONAL,
 	TYPE_PREMIUM,
 } from 'lib/plans/constants';
-import { isEnabled } from 'config';
 
-const simplePaymentsNoticeTextWPCOM = isEnabled( 'earn/rename-payment-blocks' )
-	? 'Upgrade to a Premium or Business plan today and start collecting payments with the Pay with PayPal button!'
-	: 'Upgrade to a Premium or Business plan today and start collecting payments with the Simple Payments button!';
+const simplePaymentsNoticeTextWPCOM =
+	'Upgrade to a Premium or Business plan today and start collecting payments with the Pay with PayPal button!';
 
-const simplePaymentsNoticeTextJetpack = isEnabled( 'earn/rename-payment-blocks' )
-	? 'Upgrade to a Premium or Professional plan today and start collecting payments with the Pay with PayPal button!'
-	: 'Upgrade to a Premium or Professional plan today and start collecting payments with the Simple Payments button!';
+const simplePaymentsNoticeTextJetpack =
+	'Upgrade to a Premium or Professional plan today and start collecting payments with the Pay with PayPal button!';
 
 /**
  * No translate() used on some of these since we're launching those promotions just for the EN audience

--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -11,7 +11,6 @@ import { invoke } from 'lodash';
 import * as constants from './constants';
 import { DOMAIN_PRICING_AND_AVAILABLE_TLDS } from 'lib/url/support';
 import ExternalLinkWithTracking from 'components/external-link/with-tracking';
-import { isEnabled } from 'config';
 
 export const FEATURES_LIST = {
 	[ constants.FEATURE_BLANK ]: {
@@ -104,13 +103,9 @@ export const FEATURES_LIST = {
 		getSlug: () => constants.FEATURE_ALL_PREMIUM_FEATURES,
 		getTitle: () => i18n.translate( 'All Premium features' ),
 		getDescription: () => {
-			isEnabled( 'earn/rename-payment-blocks' )
-				? i18n.translate(
-						'Including unlimited premium themes, advanced design and monetization options, Pay with PayPal buttons, and a custom domain name for one year.'
-				  )
-				: i18n.translate(
-						'Including unlimited premium themes, advanced design and monetization options, simple payment buttons, and a custom domain name for one year.'
-				  );
+			return i18n.translate(
+				'Including unlimited premium themes, advanced design and monetization options, Pay with PayPal buttons, and a custom domain name for one year.'
+			);
 		},
 	},
 
@@ -483,10 +478,7 @@ export const FEATURES_LIST = {
 	},
 	[ constants.FEATURE_SIMPLE_PAYMENTS ]: {
 		getSlug: () => constants.FEATURE_SIMPLE_PAYMENTS,
-		getTitle: () =>
-			isEnabled( 'earn/rename-payment-blocks' )
-				? i18n.translate( 'Pay with PayPal' )
-				: i18n.translate( 'Simple Payments' ),
+		getTitle: () => i18n.translate( 'Pay with PayPal' ),
 		getDescription: () => i18n.translate( 'Sell anything with a simple PayPal button.' ),
 	},
 	[ constants.FEATURE_NO_BRANDING ]: {
@@ -541,13 +533,9 @@ export const FEATURES_LIST = {
 		getSlug: () => constants.FEATURE_WORDADS_INSTANT,
 		getTitle: () => i18n.translate( 'Site monetization' ),
 		getDescription: () =>
-			isEnabled( 'earn/rename-payment-blocks' )
-				? i18n.translate(
-						'Earn money on your site by displaying ads and collecting payments or donations.'
-				  )
-				: i18n.translate(
-						'Earn money on your site by displaying ads and collecting recurring payments or donations.'
-				  ),
+			i18n.translate(
+				'Earn money on your site by displaying ads and collecting payments or donations.'
+			),
 	},
 
 	[ constants.FEATURE_WP_SUBDOMAIN ]: {

--- a/client/me/memberships/main.jsx
+++ b/client/me/memberships/main.jsx
@@ -20,7 +20,7 @@ import { CompactCard } from '@automattic/components';
 import EmptyContent from 'components/empty-content';
 import { withLocalizedMoment } from 'components/localized-moment';
 import { getAllSubscriptions } from 'state/memberships/subscriptions/selectors';
-import { isEnabled } from 'config';
+
 /**
  * Style dependencies
  */
@@ -84,13 +84,7 @@ const MembershipsHistory = ( { translate, subscriptions, moment } ) => {
 	if ( subscriptions && subscriptions.length ) {
 		content = (
 			<>
-				<SectionHeader
-					label={
-						isEnabled( 'earn/rename-payment-blocks' )
-							? translate( 'Active payments plans' )
-							: translate( 'Active Recurring Payments plans' )
-					}
-				/>
+				<SectionHeader label={ translate( 'Active payments plans' ) } />
 				{ subscriptions.map(
 					( subscription ) => (
 						<MembershipItem
@@ -108,11 +102,7 @@ const MembershipsHistory = ( { translate, subscriptions, moment } ) => {
 		content = (
 			<CompactCard className="memberships__no-content">
 				<EmptyContent
-					title={
-						isEnabled( 'earn/rename-payment-blocks' )
-							? translate( 'No payments found.' )
-							: translate( 'No Recurring Payments found.' )
-					}
+					title={ translate( 'No payments found.' ) }
 					illustration={ noMembershipsImage }
 				/>
 			</CompactCard>

--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -30,7 +30,6 @@ import { bumpStat, composeAnalytics, recordTracksEvent } from 'state/analytics/a
 import ClipboardButtonInput from 'components/clipboard-button-input';
 import { CtaButton } from 'components/promo-section/promo-card/cta';
 import { localizeUrl } from 'lib/i18n-utils';
-import { isEnabled } from 'config';
 
 /**
  * Image dependencies
@@ -104,16 +103,12 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 	 * @returns {object} Object with props to render a PromoCard.
 	 */
 	const getSimplePaymentsCard = () => {
-		const supportLink = isEnabled( 'earn/rename-payment-blocks' )
-			? localizeUrl( 'https://wordpress.com/support/wordpress-editor/blocks/pay-with-paypal/' )
-			: localizeUrl(
-					'https://wordpress.com/support/wordpress-editor/blocks/simple-payments-block/'
-			  );
+		const supportLink = localizeUrl(
+			'https://wordpress.com/support/wordpress-editor/blocks/pay-with-paypal/'
+		);
 		const cta = hasSimplePayments
 			? {
-					text: isEnabled( 'earn/rename-payment-blocks' )
-						? translate( 'Learn how to get started' )
-						: translate( 'Add one-time payments' ),
+					text: translate( 'Learn how to get started' ),
 					action: { url: supportLink, onClick: () => trackCtaButton( 'simple-payments' ) },
 			  }
 			: {
@@ -128,36 +123,19 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 		const learnMoreLink = hasSimplePayments
 			? null
 			: { url: supportLink, onClick: () => trackLearnLink( 'simple-payments' ) };
-		let title, body;
-		if ( isEnabled( 'earn/rename-payment-blocks' ) ) {
-			title = translate( 'Collect PayPal payments' );
-			body = hasSimplePayments
-				? translate(
-						'Accept credit card payments via PayPal for physical products, digital goods, services, donations, or support of your creative work.'
-				  )
-				: translate(
-						'Accept credit card payments via PayPal for physical products, digital goods, services, donations, or support of your creative work. {{em}}Available with a Premium, Business, or eCommerce plan{{/em}}.',
-						{
-							components: {
-								em: <em />,
-							},
-						}
-				  );
-		} else {
-			title = translate( 'Collect one-time payments' );
-			body = hasSimplePayments
-				? translate(
-						'Accept credit card payments for physical products, digital goods, services, donations, or support of your creative work.'
-				  )
-				: translate(
-						'Accept credit card payments for physical products, digital goods, services, donations, or support of your creative work. {{em}}Available with a Premium, Business, or eCommerce plan{{/em}}.',
-						{
-							components: {
-								em: <em />,
-							},
-						}
-				  );
-		}
+		const title = translate( 'Collect PayPal payments' );
+		const body = hasSimplePayments
+			? translate(
+					'Accept credit card payments via PayPal for physical products, digital goods, services, donations, or support of your creative work.'
+			  )
+			: translate(
+					'Accept credit card payments via PayPal for physical products, digital goods, services, donations, or support of your creative work. {{em}}Available with a Premium, Business, or eCommerce plan{{/em}}.',
+					{
+						components: {
+							em: <em />,
+						},
+					}
+			  );
 		return {
 			title,
 			body,
@@ -177,7 +155,6 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 	 * @returns {object} Object with props to render a PromoCard.
 	 */
 	const getRecurringPaymentsCard = () => {
-		const isPayments = isEnabled( 'earn/rename-payment-blocks' );
 		const cta = isFreePlan
 			? {
 					text: translate( 'Unlock this feature' ),
@@ -187,46 +164,27 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 					},
 			  }
 			: {
-					text: isPayments
-						? translate( 'Collect payments' )
-						: translate( 'Collect recurring payments' ),
+					text: translate( 'Collect payments' ),
 					action: () => {
 						trackCtaButton( 'recurring-payments' );
 						page( `/earn/payments/${ selectedSiteSlug }` );
 					},
 			  };
-		const hasConnectionTitle = isPayments
-			? translate( 'Manage payments' )
-			: translate( 'Manage recurring payments' );
-		const noConnectionTitle = isPayments
-			? translate( 'Collect payments' )
-			: translate( 'Collect recurring payments' );
+		const hasConnectionTitle = translate( 'Manage payments' );
+		const noConnectionTitle = translate( 'Collect payments' );
 		const title = hasConnectedAccount ? hasConnectionTitle : noConnectionTitle;
 
-		const hasConnectionBody = isPayments
-			? translate(
-					"Manage your customers and subscribers, or your current subscription options and review the total revenue that you've made from payments."
-			  )
-			: translate(
-					"Manage your subscribers, or your current subscription options and review the total revenue that you've made from recurring payments."
-			  );
-		const noConnectionBody = isPayments
-			? translate(
-					'Accept one-time and recurring credit card payments for digital goods, physical products, services, memberships, subscriptions, and donations. {{em}}Available with any paid plan{{/em}}.',
-					{
-						components: {
-							em: <em />,
-						},
-					}
-			  )
-			: translate(
-					'Accept ongoing and automated credit card payments for subscriptions, memberships, services, and donations. {{em}}Available with any paid plan{{/em}}.',
-					{
-						components: {
-							em: <em />,
-						},
-					}
-			  );
+		const hasConnectionBody = translate(
+			"Manage your customers and subscribers, or your current subscription options and review the total revenue that you've made from payments."
+		);
+		const noConnectionBody = translate(
+			'Accept one-time and recurring credit card payments for digital goods, physical products, services, memberships, subscriptions, and donations. {{em}}Available with any paid plan{{/em}}.',
+			{
+				components: {
+					em: <em />,
+				},
+			}
+		);
 
 		const body = hasConnectedAccount ? hasConnectionBody : noConnectionBody;
 

--- a/client/my-sites/earn/main.jsx
+++ b/client/my-sites/earn/main.jsx
@@ -29,7 +29,6 @@ import MembershipsSection from './memberships';
 import MembershipsProductsSection from './memberships/products';
 import ReferAFriendSection from './refer-a-friend';
 import { canAccessAds } from 'lib/ads/utils';
-import { isEnabled } from 'config';
 
 class EarningsMain extends Component {
 	static propTypes = {
@@ -125,10 +124,7 @@ class EarningsMain extends Component {
 
 		switch ( this.props.section ) {
 			case 'payments':
-				return isEnabled( 'earn/rename-payment-blocks' )
-					? translate( 'Payments' )
-					: translate( 'Recurring Payments' );
-
+				return translate( 'Payments' );
 			case 'ads-earnings':
 			case 'ads-settings':
 				return translate( 'Ads' );

--- a/client/my-sites/earn/memberships/add-edit-plan-modal.jsx
+++ b/client/my-sites/earn/memberships/add-edit-plan-modal.jsx
@@ -28,7 +28,6 @@ import { requestAddProduct, requestUpdateProduct } from 'state/memberships/produ
 import SectionNav from 'components/section-nav';
 import SectionNavTabs from 'components/section-nav/tabs';
 import SectionNavTabItem from 'components/section-nav/item';
-import { isEnabled } from 'config';
 
 /**
  * @typedef {[string, number] CurrencyMinimum
@@ -190,9 +189,7 @@ const RecurringPaymentsPlanAddEditModal = ( {
 					welcome_email_content: editedCustomConfirmationMessage,
 					subscribe_as_site_subscriber: editedPostsEmail,
 				},
-				isEnabled( 'earn/rename-payment-blocks' )
-					? translate( 'Added "%s" payment plan.', { args: editedProductName } )
-					: translate( 'Added "%s" product.', { args: editedProductName } )
+				translate( 'Added "%s" payment plan.', { args: editedProductName } )
 			);
 		} else if ( reason === 'submit' && product ) {
 			updateProduct(
@@ -208,26 +205,17 @@ const RecurringPaymentsPlanAddEditModal = ( {
 					welcome_email_content: editedCustomConfirmationMessage,
 					subscribe_as_site_subscriber: editedPostsEmail,
 				},
-				isEnabled( 'earn/rename-payment-blocks' )
-					? translate( 'Updated "%s" payment plan.', { args: editedProductName } )
-					: translate( 'Updated "%s" product.', { args: editedProductName } )
+				translate( 'Updated "%s" payment plan.', { args: editedProductName } )
 			);
 		}
 		closeDialog();
 	};
 
 	const renderGeneralTab = () => {
-		const isPayments = isEnabled( 'earn/rename-payment-blocks' );
-		const editProduct = isPayments
-			? translate( 'Edit your existing payment plan.' )
-			: translate( 'Edit your existing Recurring Payments plan.' );
-		const noProduct = isPayments
-			? translate(
-					'Each amount you add will create a separate payment plan. You can create many of them.'
-			  )
-			: translate(
-					'Each amount you add will create a separate Recurring Payments plan. You can create multiple plans.'
-			  );
+		const editProduct = translate( 'Edit your existing payment plan.' );
+		const noProduct = translate(
+			'Each amount you add will create a separate payment plan. You can create many of them.'
+		);
 		return (
 			<>
 				<p>{ product ? editProduct : noProduct }</p>
@@ -235,15 +223,9 @@ const RecurringPaymentsPlanAddEditModal = ( {
 					<FormLabel htmlFor="currency">{ translate( 'Select price' ) }</FormLabel>
 					{ product && (
 						<Notice
-							text={
-								isPayments
-									? translate(
-											'Updating the price will not affect existing subscribers, who will pay what they were originally charged on renewal.'
-									  )
-									: translate(
-											'Updating the price will not affect existing subscribers, who will pay what they were originally charged.'
-									  )
-							}
+							text={ translate(
+								'Updating the price will not affect existing subscribers, who will pay what they were originally charged on renewal.'
+							) }
 							showDismiss={ false }
 						/>
 					) }
@@ -273,27 +255,17 @@ const RecurringPaymentsPlanAddEditModal = ( {
 				</FormFieldset>
 				<FormFieldset>
 					<FormLabel htmlFor="renewal_schedule">
-						{ isPayments
-							? translate( 'Select renewal frequency' )
-							: translate( 'Select renewal schedule' ) }
+						{ translate( 'Select renewal frequency' ) }
 					</FormLabel>
 					<FormSelect id="renewal_schedule" value={ editedSchedule } onChange={ onSelectSchedule }>
-						<option value="1 month">
-							{ isPayments ? translate( 'Renew monthly' ) : translate( 'Monthly' ) }
-						</option>
-						<option value="1 year">
-							{ isPayments ? translate( 'Renew yearly' ) : translate( 'Yearly' ) }
-						</option>
-						{ isEnabled( 'earn/rename-payment-blocks' ) && (
-							<option value="one-time">{ translate( 'One time sale' ) }</option>
-						) }
+						<option value="1 month">{ translate( 'Renew monthly' ) }</option>
+						<option value="1 year">{ translate( 'Renew yearly' ) }</option>
+						<option value="one-time">{ translate( 'One time sale' ) }</option>
 					</FormSelect>
 				</FormFieldset>
 				<FormFieldset>
 					<FormLabel htmlFor="title">
-						{ isPayments
-							? translate( 'Please describe your payment plan' )
-							: translate( 'Please describe your subscription' ) }
+						{ translate( 'Please describe your payment plan' ) }
 					</FormLabel>
 					<FormTextInput
 						id="title"
@@ -312,11 +284,9 @@ const RecurringPaymentsPlanAddEditModal = ( {
 				</FormFieldset>
 				<FormFieldset>
 					<FormToggle onChange={ handleMultiplePerUser } checked={ editedMultiplePerUser }>
-						{ isPayments
-							? translate(
-									'Allow the same customer to purchase or sign up to this plan multiple times.'
-							  )
-							: translate( 'Allow the same customer to sign up multiple times to the same plan.' ) }
+						{ translate(
+							'Allow the same customer to purchase or sign up to this plan multiple times.'
+						) }
 					</FormToggle>
 				</FormFieldset>
 			</>
@@ -324,19 +294,14 @@ const RecurringPaymentsPlanAddEditModal = ( {
 	};
 
 	const renderEmailTab = () => {
-		const isPayments = isEnabled( 'earn/rename-payment-blocks' );
 		return (
 			<>
 				<FormFieldset>
 					<h6 className="memberships__dialog-form-header">{ translate( 'Posts via email' ) }</h6>
 					<p>
-						{ isPayments
-							? translate(
-									'Allow members of this payment plan to opt into receiving new posts via email.'
-							  )
-							: translate(
-									'Allow members of this recurring payment plan to opt into receiving new posts via email.'
-							  ) }{ ' ' }
+						{ translate(
+							'Allow members of this payment plan to opt into receiving new posts via email.'
+						) }{ ' ' }
 						<InlineSupportLink
 							supportPostId={ 154624 }
 							supportLink="https://wordpress.com/support/wordpress-editor/blocks/recurring-payments-button/" // TODO: Link to specific section once article is update
@@ -348,11 +313,7 @@ const RecurringPaymentsPlanAddEditModal = ( {
 						onChange={ ( newValue ) => setEditedPostsEmail( newValue ) }
 						checked={ editedPostsEmail }
 					>
-						{ isPayments
-							? translate( 'Email newly published posts to your customers.' )
-							: translate(
-									'Email newly published posts to members of this recurring payment plan who have opted in.'
-							  ) }
+						{ translate( 'Email newly published posts to your customers.' ) }
 					</FormToggle>
 				</FormFieldset>
 				<FormFieldset>
@@ -360,13 +321,9 @@ const RecurringPaymentsPlanAddEditModal = ( {
 						{ translate( 'Custom confirmation message' ) }
 					</h6>
 					<p>
-						{ isPayments
-							? translate(
-									'Add a custom message to the confirmation email that is sent after purchase. For example, you can thank your customers.'
-							  )
-							: translate(
-									'Add a custom message to the confirmation email that is sent out for this recurring payment plan.'
-							  ) }
+						{ translate(
+							'Add a custom message to the confirmation email that is sent after purchase. For example, you can thank your customers.'
+						) }
 					</p>
 					<CountedTextArea
 						value={ editedCustomConfirmationMessage }
@@ -380,13 +337,8 @@ const RecurringPaymentsPlanAddEditModal = ( {
 		);
 	};
 
-	const isPayments = isEnabled( 'earn/rename-payment-blocks' );
-	const editPlan = isPayments
-		? translate( 'Edit a payment plan' )
-		: translate( 'Edit Recurring Payment plan' );
-	const addPlan = isPayments
-		? translate( 'Add a new payment plan' )
-		: translate( 'Add new Recurring Payment plan' );
+	const editPlan = translate( 'Edit a payment plan' );
+	const addPlan = translate( 'Add a new payment plan' );
 	return (
 		<Dialog
 			isVisible={ true }

--- a/client/my-sites/earn/memberships/index.jsx
+++ b/client/my-sites/earn/memberships/index.jsx
@@ -45,7 +45,6 @@ import {
 	getConnectUrlForSiteId,
 } from 'state/memberships/settings/selectors';
 import { getProductsForSiteId } from 'state/memberships/product-list/selectors';
-import { isEnabled } from 'config';
 
 /**
  * Image dependencies
@@ -222,51 +221,27 @@ class MembershipsSection extends Component {
 	}
 
 	renderSubscriberList() {
-		const isPayments = isEnabled( 'earn/rename-payment-blocks' );
 		return (
 			<div>
-				<SectionHeader
-					label={
-						isPayments
-							? this.props.translate( 'Customers and Subscribers' )
-							: this.props.translate( 'Subscribers' )
-					}
-				/>
+				<SectionHeader label={ this.props.translate( 'Customers and Subscribers' ) } />
 				{ Object.values( this.props.subscribers ).length === 0 && (
 					<Card>
-						{ isPayments
-							? this.props.translate(
-									"You haven't added any customers. {{a}}Learn more{{/a}} about payments.",
-									{
-										components: {
-											a: (
-												<a
-													href={ localizeUrl(
-														'https://wordpress.com/support/recurring-payments-button/'
-													) }
-													target="_blank"
-													rel="noreferrer noopener"
-												/>
-											),
-										},
-									}
-							  )
-							: this.props.translate(
-									"You haven't added any subscribers. {{a}}Learn more{{/a}} about recurring payments.",
-									{
-										components: {
-											a: (
-												<a
-													href={ localizeUrl(
-														'https://wordpress.com/support/recurring-payments-button/'
-													) }
-													target="_blank"
-													rel="noreferrer noopener"
-												/>
-											),
-										},
-									}
-							  ) }
+						{ this.props.translate(
+							"You haven't added any customers. {{a}}Learn more{{/a}} about payments.",
+							{
+								components: {
+									a: (
+										<a
+											href={ localizeUrl(
+												'https://wordpress.com/support/wordpress-editor/blocks/payments/'
+											) }
+											target="_blank"
+											rel="noreferrer noopener"
+										/>
+									),
+								},
+							}
+						) }
 					</Card>
 				) }
 				{ Object.values( this.props.subscribers ).length > 0 && (
@@ -328,16 +303,13 @@ class MembershipsSection extends Component {
 	}
 
 	renderSettings() {
-		const isPayments = isEnabled( 'earn/rename-payment-blocks' );
 		return (
 			<div>
 				<SectionHeader label={ this.props.translate( 'Settings' ) } />
 				<CompactCard href={ '/earn/payments-plans/' + this.props.siteSlug }>
 					<QueryMembershipProducts siteId={ this.props.siteId } />
 					<div className="memberships__module-products-title">
-						{ isPayments
-							? this.props.translate( 'Payment plans' )
-							: this.props.translate( 'Recurring Payments plans' ) }
+						{ this.props.translate( 'Payment plans' ) }
 					</div>
 					<div className="memberships__module-products-list">
 						<Gridicon icon="tag" size={ 12 } className="memberships__module-products-list-icon" />
@@ -357,9 +329,7 @@ class MembershipsSection extends Component {
 							{ this.props.translate( 'Disconnect Stripe Account' ) }
 						</p>
 						<p className="memberships__settings-section-desc">
-							{ isPayments
-								? this.props.translate( 'Disconnect Payments from your Stripe account' )
-								: this.props.translate( 'Disconnect Recurring Payments from your Stripe account' ) }
+							{ this.props.translate( 'Disconnect Payments from your Stripe account' ) }
 						</p>
 					</div>
 				</CompactCard>
@@ -371,9 +341,7 @@ class MembershipsSection extends Component {
 							action: 'cancel',
 						},
 						{
-							label: isPayments
-								? this.props.translate( 'Disconnect Payments from Stripe' )
-								: this.props.translate( 'Disconnect Recurring Payments from Stripe' ),
+							label: this.props.translate( 'Disconnect Payments from Stripe' ),
 							isPrimary: true,
 							action: 'disconnect',
 						},
@@ -382,36 +350,20 @@ class MembershipsSection extends Component {
 				>
 					<h1>{ this.props.translate( 'Confirmation' ) }</h1>
 					<p>
-						{ isPayments
-							? this.props.translate(
-									'Do you want to disconnect Payments from your Stripe account?'
-							  )
-							: this.props.translate(
-									'Do you want to disconnect Recurring Payments from your Stripe account?'
-							  ) }
+						{ this.props.translate(
+							'Do you want to disconnect Payments from your Stripe account?'
+						) }
 					</p>
 					<Notice
-						text={
-							isPayments
-								? this.props.translate(
-										'Once you disconnect Payments from Stripe, new subscribers won’t be able to sign up and existing subscriptions will stop working.{{br/}}{{strong}}Disconnecting your Stripe account here will remove it from all your WordPress.com and Jetpack sites.{{/strong}}',
-										{
-											components: {
-												br: <br />,
-												strong: <strong />,
-											},
-										}
-								  )
-								: this.props.translate(
-										'Once you disconnect Recurring Payments from Stripe, new subscribers won’t be able to sign up and existing subscriptions will stop working.{{br/}}{{strong}}Disconnecting your Stripe account here will remove it from all your WordPress.com and Jetpack sites.{{/strong}}',
-										{
-											components: {
-												br: <br />,
-												strong: <strong />,
-											},
-										}
-								  )
-						}
+						text={ this.props.translate(
+							'Once you disconnect Payments from Stripe, new subscribers won’t be able to sign up and existing subscriptions will stop working.{{br/}}{{strong}}Disconnecting your Stripe account here will remove it from all your WordPress.com and Jetpack sites.{{/strong}}',
+							{
+								components: {
+									br: <br />,
+									strong: <strong />,
+								},
+							}
+						) }
 						showDismiss={ false }
 					/>
 				</Dialog>
@@ -641,11 +593,7 @@ class MembershipsSection extends Component {
 					shouldDisplay={ () => true }
 					feature={ FEATURE_MEMBERSHIPS }
 					title={ this.props.translate( 'Upgrade to the Personal plan' ) }
-					description={
-						isEnabled( 'earn/rename-payment-blocks' )
-							? this.props.translate( 'Upgrade to start selling.' )
-							: this.props.translate( 'Upgrade to start earning recurring revenue.' )
-					}
+					description={ this.props.translate( 'Upgrade to start selling.' ) }
 					showIcon={ true }
 					event="calypso_memberships_upsell_nudge"
 					tracksImpressionName="calypso_upgrade_nudge_impression"
@@ -658,13 +606,7 @@ class MembershipsSection extends Component {
 			return this.renderOnboarding(
 				<Notice
 					status="is-warning"
-					text={
-						isEnabled( 'earn/rename-payment-blocks' )
-							? this.props.translate( 'Only site administrators can edit Payments settings.' )
-							: this.props.translate(
-									'Only site administrators can edit Recurring Payments settings.'
-							  )
-					}
+					text={ this.props.translate( 'Only site administrators can edit Payments settings.' ) }
 					showDismiss={ false }
 				/>
 			);

--- a/client/my-sites/earn/memberships/products.jsx
+++ b/client/my-sites/earn/memberships/products.jsx
@@ -21,7 +21,6 @@ import PopoverMenuItem from 'components/popover/menu-item';
 import Gridicon from 'components/gridicon';
 import RecurringPaymentsPlanAddEditModal from './add-edit-plan-modal';
 import RecurringPaymentsPlanDeleteModal from './delete-plan-modal';
-import { isEnabled } from 'config';
 
 class MembershipsProductsSection extends Component {
 	state = {
@@ -68,16 +67,12 @@ class MembershipsProductsSection extends Component {
 			<div>
 				<QueryMembershipProducts siteId={ this.props.siteId } />
 				<HeaderCake backHref={ '/earn/payments/' + this.props.siteSlug }>
-					{ isEnabled( 'earn/rename-payment-blocks' )
-						? this.props.translate( 'Payment plans' )
-						: this.props.translate( 'Recurring Payments plans' ) }
+					{ this.props.translate( 'Payment plans' ) }
 				</HeaderCake>
 
 				<SectionHeader>
 					<Button primary compact onClick={ () => this.openAddEditDialog( null ) }>
-						{ isEnabled( 'earn/rename-payment-blocks' )
-							? this.props.translate( 'Add a new payment plan' )
-							: this.props.translate( 'Add new plan' ) }
+						{ this.props.translate( 'Add a new payment plan' ) }
 					</Button>
 				</SectionHeader>
 				{ this.props.products.map( ( product ) => (

--- a/client/my-sites/feature-upsell/ads-upsell.jsx
+++ b/client/my-sites/feature-upsell/ads-upsell.jsx
@@ -31,7 +31,6 @@ import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
 import { isRequestingActivePromotions } from 'state/active-promotions/selectors';
 import { getUpsellPlanPrice, redirectUnlessCanUpgradeSite } from './utils';
 import redirectIf from './redirect-if';
-import { isEnabled } from 'config';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
@@ -195,9 +194,7 @@ class WordAdsUpsellComponent extends Component {
 					<div className="feature-upsell__features-list-item">
 						<Feature
 							icon={ <Gridicon icon="money" size={ 48 } /> }
-							title={
-								isEnabled( 'earn/rename-payment-blocks' ) ? 'Pay with PayPal' : 'Simple Payments'
-							}
+							title={ 'Pay with PayPal' }
 							description={
 								'Accept credit card payments on your site with the click of a button! Sell products, take donations, ' +
 								'sell tickets - add payment buttons to any page right from the WordPress editor'

--- a/client/my-sites/feature-upsell/features.jsx
+++ b/client/my-sites/feature-upsell/features.jsx
@@ -18,7 +18,6 @@ import { getSiteSlug } from 'state/sites/selectors';
 import { getCurrentPlan } from 'state/sites/plans/selectors';
 import DocumentHead from 'components/data/document-head';
 import TipInfo from '../../components/purchase-detail/tip-info';
-import { isEnabled } from 'config';
 
 /**
  * Image dependencies
@@ -151,9 +150,7 @@ class FeaturesComponent extends Component {
 				<div className="product-purchase-features-list__item">
 					<PurchaseDetail
 						icon={ <img alt="" src={ wordAdsImage } /> }
-						title={
-							isEnabled( 'earn/rename-payment-blocks' ) ? 'Pay with PayPal' : 'Simple Payments'
-						}
+						title={ 'Pay with PayPal' }
 						description={
 							'Accept credit card payments on your site with the click of a button! Sell products, take donations, ' +
 							'sell tickets - add payment buttons to any page right from the WordPress editor'

--- a/client/my-sites/feature-upsell/plugins-upsell.jsx
+++ b/client/my-sites/feature-upsell/plugins-upsell.jsx
@@ -29,7 +29,6 @@ import RefundAsterisk from 'my-sites/feature-upsell/refund-asterisk';
 import { getUpsellPlanPrice, redirectUnlessCanUpgradeSite } from './utils';
 import { hasFeature } from 'state/sites/plans/selectors';
 import redirectIf from './redirect-if';
-import { isEnabled } from 'config';
 
 /*
  * This is just for english audience and is not translated on purpose, remember to add
@@ -73,9 +72,7 @@ class PluginsUpsellComponent extends Component {
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	render() {
 		const { price } = this.props;
-		const simplePaymentsName = isEnabled( 'earn/rename-payment-blocks' )
-			? 'Pay with PayPal'
-			: 'Simple Payments';
+		const simplePaymentsName = 'Pay with PayPal';
 		return (
 			<div role="main" className="main is-wide-layout feature-upsell__main is-plugins">
 				{ ! price && (

--- a/client/my-sites/feature-upsell/themes-upsell.jsx
+++ b/client/my-sites/feature-upsell/themes-upsell.jsx
@@ -29,7 +29,6 @@ import RefundAsterisk from 'my-sites/feature-upsell/refund-asterisk';
 import { getUpsellPlanPrice, redirectUnlessCanUpgradeSite } from './utils';
 import { hasFeature } from 'state/sites/plans/selectors';
 import redirectIf from './redirect-if';
-import { isEnabled } from 'config';
 
 /*
  * This is just for english audience and is not translated on purpose, remember to add
@@ -73,9 +72,7 @@ class ThemesUpsellComponent extends Component {
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	render() {
 		const { price } = this.props;
-		const simplePaymentsName = isEnabled( 'earn/rename-payment-blocks' )
-			? 'Pay with PayPal'
-			: 'Simple Payments';
+		const simplePaymentsName = 'Pay with PayPal';
 		return (
 			<div role="main" className="main is-wide-layout feature-upsell__main is-themes">
 				{ ! price && (

--- a/client/state/data-layer/wpcom/sites/simple-payments/index.js
+++ b/client/state/data-layer/wpcom/sites/simple-payments/index.js
@@ -32,7 +32,6 @@ import {
 } from 'state/simple-payments/product-list/actions';
 
 import { registerHandlers } from 'state/data-layer/handler-registry';
-import { isEnabled } from 'config';
 
 /**
  * Convert custom post metadata array to product attributes
@@ -70,9 +69,7 @@ function customPostMetadataToProductAttributes( metadata ) {
  */
 export function customPostToProduct( customPost ) {
 	if ( ! isValidSimplePaymentsProduct( customPost ) ) {
-		const simplePaymentsName = isEnabled( 'earn/rename-payment-blocks' )
-			? 'Pay with PayPal'
-			: 'Simple Payments';
+		const simplePaymentsName = 'Pay with PayPal';
 		throw new TransformerError(
 			'Custom post is not a valid ' + simplePaymentsName + ' product',
 			customPost

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -29,7 +29,6 @@
 		"domains/gdpr-consent-page": true,
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/pagination": true,
-		"earn/rename-payment-blocks": true,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,

--- a/config/development.json
+++ b/config/development.json
@@ -58,7 +58,6 @@
 		"domains/new-status-design/auto-renew": true,
 		"domains/new-status-design/new-options": true,
 		"domains/new-status-design/security-option": true,
-		"earn/rename-payment-blocks": true,
 		"email-accounts/enabled": true,
 		"external-media": true,
 		"external-media/google-photos": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -36,7 +36,6 @@
 		"domains/new-status-design/auto-renew": true,
 		"domains/new-status-design/new-options": true,
 		"domains/new-status-design/security-option": true,
-		"earn/rename-payment-blocks": true,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,

--- a/config/production.json
+++ b/config/production.json
@@ -35,7 +35,6 @@
 		"domains/new-status-design/auto-renew": true,
 		"domains/new-status-design/new-options": true,
 		"domains/new-status-design/security-option": true,
-		"earn/rename-payment-blocks": true,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -38,7 +38,6 @@
 		"domains/new-status-design/auto-renew": true,
 		"domains/new-status-design/new-options": true,
 		"domains/new-status-design/security-option": true,
-		"earn/rename-payment-blocks": true,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,

--- a/config/test.json
+++ b/config/test.json
@@ -36,7 +36,6 @@
 		"desktop-promo": true,
 		"devdocs": true,
 		"devdocs/redirect-loggedout-homepage": true,
-		"earn/rename-payment-blocks": true,
 		"gdpr-banner": false,
 		"google-my-business": false,
 		"help": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -43,7 +43,6 @@
 		"domains/new-status-design/auto-renew": true,
 		"domains/new-status-design/new-options": true,
 		"domains/new-status-design/security-option": true,
-		"earn/rename-payment-blocks": true,
 		"email-accounts/enabled": true,
 		"external-media": true,
 		"external-media/google-photos": true,


### PR DESCRIPTION
Follow up to https://github.com/Automattic/wp-calypso/pull/42848 this removes a feature flag that gated a block rename of (Simple Payments -> Pay with PayPal) and (Recurring Payments -> Payments) to align with a Jetpack release. We no longer need this.

Some visuals (not exhaustive)

| copy examples |  |  |  |  |
| --- | --- | --- | --- | --- |
| <img width="1122" alt="Screen Shot 2020-07-23 at 4 30 13 PM" src="https://user-images.githubusercontent.com/1270189/88348521-83051b00-cd02-11ea-90ac-a774d3965bd0.png"> | <img width="1103" alt="Screen Shot 2020-07-23 at 4 30 59 PM" src="https://user-images.githubusercontent.com/1270189/88348576-aa5be800-cd02-11ea-9d35-1c0766c65658.png"> | <img width="1115" alt="Screen Shot 2020-07-23 at 4 31 14 PM" src="https://user-images.githubusercontent.com/1270189/88348591-b21b8c80-cd02-11ea-888a-bf554bc7799b.png"> | <img width="1078" alt="Screen Shot 2020-07-23 at 4 31 21 PM" src="https://user-images.githubusercontent.com/1270189/88348607-ba73c780-cd02-11ea-9670-f76d9b6d48ec.png"> | <img width="1171" alt="Screen Shot 2020-07-23 at 4 32 14 PM" src="https://user-images.githubusercontent.com/1270189/88348695-f9098200-cd02-11ea-9670-9950d3c488f6.png"> |

<img width="1103" alt="Screen Shot 2020-07-23 at 4 31 34 PM" src="https://user-images.githubusercontent.com/1270189/88348673-f018b080-cd02-11ea-8fac-2df12a539b72.png">

### Testing Instructions
- Visit /earn and /plans and verify that copy makes sense (No visible text changes)
- Purchase a personal plan or above and link a stripe account. (see also PCYsg-lW4-p2 for a dev stripe connection under "store sandbox method" )
- When adding a new payment plan, a one time payment is still an option