### PR TITLE
Nav sidebar: Add active style to sidebar nav items and home button to ensure text is white while clicked

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-item/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-item/style.scss
@@ -12,7 +12,8 @@
 	text-align: initial;
 	color: $white;
 
-	&:hover {
+	&:hover,
+	&:not( [aria-disabled='true'] ):active {
 		color: $white;
 	}
 

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/style.scss
@@ -100,7 +100,8 @@ $transition-period: 100ms;
 	padding: 8px 11px !important;
 	margin: 14px 0;
 
-	&:hover {
+	&:hover,
+	&:not( [aria-disabled='true'] ):active {
 		color: $white;
 	}
 


### PR DESCRIPTION
A tiny PR to ensure that the text in the buttons in the nav sidebar are white while clicked.

#### Changes proposed in this Pull Request

* Add `&:not( [aria-disabled='true'] ):active` selector to the `.wpcom-block-editor-nav-item` and `.wpcom-block-editor-nav-sidebar-nav-sidebar__home-button` classes. The `aria-disabled` specificity is required so that we override the `components-button:not([aria-disabled="true"]):active` selector in Gutenberg.

#### Screenshot (before)

Screenshot while clicking an item in the nav sidebar list:

![image](https://user-images.githubusercontent.com/14988353/88355615-98cd1b80-cda8-11ea-8961-0d4e55d667a2.png)

#### Screenshot (after)

Screenshot while clicking an item in the nav sidebar list:

![image](https://user-images.githubusercontent.com/14988353/88355688-d3cf4f00-cda8-11ea-9a4a-9b6ac974496b.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch
* `cd apps/full-site-editing && yarn build && npx wp-env start`
* `localhost:4013/wp-admin`
* Go to edit a post or a page
* Click the `W` button to open the nav sidebar
* Click and hold on any of the listed pages or the back button and the text should be white
