### PR TITLE
Reader: Fix clicking search field in the share popup menu of a post closes the popup

### DIFF
--- a/client/blocks/reader-share/index.jsx
+++ b/client/blocks/reader-share/index.jsx
@@ -125,6 +125,12 @@ class ReaderShare extends React.Component {
 
 	toggle = ( event ) => {
 		event.preventDefault();
+		if ( this.state.showingMenu ) {
+			if ( ! this.shareButton.current.contains( event.target ) ) {
+				return;
+			}
+		}
+
 		if ( ! this.state.showingMenu ) {
 			stats.recordAction( 'open_share' );
 			stats.recordGaEvent( 'Opened Share' );


### PR DESCRIPTION
The share button shown in the bottom right corner of posts displayed in the Reader opens a popover menu with sharing options when clicked. If the user clicks on the search field (displayed when the user has more than 6 sites), the popover closes unexpectedly.

#### Changes proposed in this Pull Request

* Avoid closing the share popup menu when clicks are performed inside of it

#### Testing instructions

Pre-condition: The user must have 7 sites or more for the search field to be displayed in the share menu.

* Go to Reader in the Masterbar and then select Discover in the sidebar
* Click the share icon in the bottom right corner of a post
* Verify that the share menu is displayed, with a search field
* Click on the search field
* Verify that the share menu is still visible
* Type a text in the search field
* Verify that the share menu is still visible
* Click outside the share menu
* Verify that the share menu is closed and not visible anymore
* Click the share icon again
* Verify that the share menu is displayed, with a search field
* Click outside the share menu
* Verify that the share menu is closed and not visible anymore

Fixes #44080

cc: @bluefuton 