### PR TITLE
Hide the cart in the site domains list when empty

### DIFF
--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -52,6 +52,7 @@ import QuerySitePurchases from 'components/data/query-site-purchases';
 import PopoverCart from 'my-sites/checkout/cart/popover-cart';
 import InfoPopover from 'components/info-popover';
 import ExternalLink from 'components/external-link';
+import { getAllCartItems } from 'lib/cart-values/cart-items';
 
 /**
  * Style dependencies
@@ -180,6 +181,25 @@ export class List extends React.Component {
 		} );
 	};
 
+	renderCart() {
+		if ( isEmpty( getAllCartItems( this.props.cart ) ) ) {
+			return null;
+		}
+
+		return (
+			<PopoverCart
+				cart={ this.props.cart }
+				selectedSite={ this.props.selectedSite }
+				visible={ this.state.isPopoverCartVisible }
+				pinned={ false }
+				path={ this.props.currentRoute }
+				onToggle={ this.togglePopoverCart }
+				closeSectionNavMobilePanel={ noop }
+				compact
+			/>
+		);
+	}
+
 	renderNewDesign() {
 		return (
 			<>
@@ -191,16 +211,7 @@ export class List extends React.Component {
 						align="left"
 					/>
 					<div className="list__domains-header-buttons">
-						<PopoverCart
-							cart={ this.props.cart }
-							selectedSite={ this.props.selectedSite }
-							visible={ this.state.isPopoverCartVisible }
-							pinned={ false }
-							path={ this.props.currentRoute }
-							onToggle={ this.togglePopoverCart }
-							closeSectionNavMobilePanel={ noop }
-							compact
-						/>
+						{ this.renderCart() }
 						{ this.addDomainButton() }
 					</div>
 				</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Conditionally renders the popover cart if there are items

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to the domains list for a site i.e. `/domains/manage/<site>`
* Open another tab/window whilst logged and add items to the cart
* Confirm that the cart disappears from the site list when all items are removed, or when it's empty

