### PR TITLE
Block editor: fix checker for parent page preselect feature

### DIFF
--- a/apps/wpcom-block-editor/src/utils.js
+++ b/apps/wpcom-block-editor/src/utils.js
@@ -59,7 +59,7 @@ export const isEditorReadyWithBlocks = async () =>
 export const getPages = async () =>
 	new Promise( ( resolve ) => {
 		const unsubscribe = subscribe( () => {
-			const pages = select( 'core' ).getEntityRecords( 'postType', 'page' );
+			const pages = select( 'core' ).getEntityRecords( 'postType', 'page', { per_page: -1 } );
 
 			if ( pages !== null ) {
 				unsubscribe();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Specify `per_page: -1` in the call to `getEntityRecords()` inside `getPages()`, as the result set is used to validate the value passed in the `parent_post` param. Currently, only a subset of pages is returned, which causes the checker to incorrectly reject some of the values passed. This is a patch for [a recently committed feature](https://github.com/Automattic/wp-calypso/pull/44300).

#### Testing instructions

* Sandbox `widgets.wp.com`
* Apply D46858-code (this is the diff containing this PR's build) to your sandbox.
* Navigate to `calypso.localhost:3000/block-editor/page/<your-test-site>?parent_post=<a-valid-page-id>`. Make sure your test site has more than 5 pages to effectively test this patch, e.g. LighthouseP2
* You should see under **Page Attributes > Parent Page** sidebar dropdown that the page is pre-selected.
