### PR TITLE
Gutenboaridng: re-add primary button to DomainsModal

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/domains/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/domains/index.tsx
@@ -85,12 +85,7 @@ const DomainsStep: React.FunctionComponent< Props > = ( { isModal } ) => {
 			</div>
 			<ActionButtons>
 				<BackButton onClick={ handleBack } />
-				{ ! isModal &&
-					( domain ? (
-						<NextButton onClick={ handleNext } />
-					) : (
-						<SkipButton onClick={ handleNext } />
-					) ) }
+				{ domain ? <NextButton onClick={ handleNext } /> : <SkipButton onClick={ handleNext } /> }
 			</ActionButtons>
 		</div>
 	);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Reverting this commit: https://github.com/Automattic/wp-calypso/pull/44132/commits/528aadad86eced95b49855eb625852602d5ba236
* When writing [this comment](https://github.com/Automattic/wp-calypso/pull/44132#discussion_r454344115), I haven't realised we are removing all the primary buttons from this screen.

#### Testing instructions

* Go to [/new](https://calypso.live/new?branch=update/gutenboarding-domains-modal-primary-button)
* Skip first step and then open domains modal.
* Go back and Continue buttons should be visible, both with the same action to close the modal.

Mentioned in pbAok1-1hJ-p2