### PR TITLE
Fix CCJK text wrapping in 'Filters' button in domains search and cart popover

### DIFF
--- a/client/components/domains/search-filters/style.scss
+++ b/client/components/domains/search-filters/style.scss
@@ -43,6 +43,7 @@
 
 		.search-filters__dropdown-filters-button-text {
 			line-height: 1.2;
+			white-space: nowrap;
 
 			@include breakpoint-deprecated( '<660px' ) {
 				display: none;

--- a/client/my-sites/checkout/cart/style.scss
+++ b/client/my-sites/checkout/cart/style.scss
@@ -141,13 +141,15 @@
 
 		.cart__total-label {
 			display: table-cell;
-			width: auto;
+			width: 100%;
+			word-break: keep-all;
 		}
 
 		.cart__total-amount {
 			display: table-cell;
 			text-align: right;
-			width: 100%;
+			width: auto;
+			white-space: nowrap;
 		}
 
 		.cart__total-amount.last-cell {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This change makes sure that the words for 'Filters' in domains search and 'Total:' in cart popover on the same page are not broken into multiple lines for CCJK characters (Chinese Traditional/Simplified, Japanese, Korean) and that longer texts would be broken on word boundary

#### Testing instructions

Switch to Traditional/Simplified Chinese, Japanese and Korean, navigate to /domains/add and check the 'Filters' button next to the search field, then add a domain and click on the cart popover to test the 'Total' text. Test for regression issues with a Latin-based language, long amounts (using HUF / IDR currencies or by editing the html in the browser), RTL language.

***Before for Japanese/Simplified and Traditional Chinese/Korean:***
<img src="https://user-images.githubusercontent.com/7847633/88392713-c8861e80-cdbc-11ea-83a3-65f1fb3c6bd6.png" width="350"><img src="https://user-images.githubusercontent.com/7847633/88392794-e81d4700-cdbc-11ea-8394-7521904637e6.png" width="350"><img src="https://user-images.githubusercontent.com/7847633/88393109-6e398d80-cdbd-11ea-9ff7-a120158f91be.png" width="350"><img src="https://user-images.githubusercontent.com/7847633/88393113-71cd1480-cdbd-11ea-95b2-df732eb13eb0.png" width="350">

***After for Japanese/Simplified and Traditional Chinese/Korean:***
<img src="https://user-images.githubusercontent.com/7847633/88393302-b48eec80-cdbd-11ea-9beb-79e7b78cd978.png" width="350"><img src="https://user-images.githubusercontent.com/7847633/88393315-b8227380-cdbd-11ea-90f6-64ca4f0cf743.png" width="350"><img src="https://user-images.githubusercontent.com/7847633/88393320-bb1d6400-cdbd-11ea-8521-8fa56a8bea06.png" width="350"><img src="https://user-images.githubusercontent.com/7847633/88393325-beb0eb00-cdbd-11ea-81ff-6f5e7c0929d3.png" width="350">
