### PR TITLE
Jetpack Search: include monthly period in the Search product details.

### DIFF
--- a/client/lib/products-values/constants.js
+++ b/client/lib/products-values/constants.js
@@ -104,6 +104,8 @@ export const getJetpackProductsShortNames = () => {
 		[ PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY ]: translate( 'Real-Time Backups' ),
 		[ PRODUCT_JETPACK_SEARCH ]: translate( 'Search' ),
 		[ PRODUCT_JETPACK_SEARCH_MONTHLY ]: translate( 'Search' ),
+		[ PRODUCT_WPCOM_SEARCH ]: translate( 'Search' ),
+		[ PRODUCT_WPCOM_SEARCH_MONTHLY ]: translate( 'Search' ),
 		[ PRODUCT_JETPACK_SCAN ]: translate( 'Daily Scan' ),
 		[ PRODUCT_JETPACK_SCAN_MONTHLY ]: translate( 'Daily Scan' ),
 		[ PRODUCT_JETPACK_ANTI_SPAM ]: translate( 'Anti-Spam' ),

--- a/client/lib/products-values/products-list.ts
+++ b/client/lib/products-values/products-list.ts
@@ -48,4 +48,16 @@ export const PRODUCTS_LIST = {
 		term: TERM_MONTHLY,
 		bill_period: PLAN_MONTHLY_PERIOD,
 	},
+	[ constants.PRODUCT_WPCOM_SEARCH ]: {
+		product_name: PRODUCT_SHORT_NAMES[ constants.PRODUCT_WPCOM_SEARCH ],
+		product_slug: constants.PRODUCT_WPCOM_SEARCH,
+		term: TERM_ANNUALLY,
+		bill_period: PLAN_ANNUAL_PERIOD,
+	},
+	[ constants.PRODUCT_WPCOM_SEARCH_MONTHLY ]: {
+		product_name: PRODUCT_SHORT_NAMES[ constants.PRODUCT_WPCOM_SEARCH_MONTHLY ],
+		product_slug: constants.PRODUCT_WPCOM_SEARCH_MONTHLY,
+		term: TERM_MONTHLY,
+		bill_period: PLAN_MONTHLY_PERIOD,
+	},
 };

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -48,6 +48,7 @@ import UserItem from 'components/user';
 import { withLocalizedMoment } from 'components/localized-moment';
 import { canEditPaymentDetails, getEditCardDetailsPath, isDataLoading } from '../utils';
 import { TERM_BIENNIALLY, TERM_MONTHLY } from 'lib/plans/constants';
+import { PRODUCT_WPCOM_SEARCH_MONTHLY } from 'lib/products-values/constants';
 
 class PurchaseMeta extends Component {
 	static propTypes = {
@@ -82,6 +83,11 @@ class PurchaseMeta extends Component {
 
 		if ( isIncludedWithPlan( purchase ) ) {
 			return translate( 'Free with Plan' );
+		}
+
+		// define term for Jetpack Search products for which plan.term is undefined
+		if ( purchase.productSlug === PRODUCT_WPCOM_SEARCH_MONTHLY ) {
+			period = translate( 'month' );
 		}
 
 		if ( plan && plan.term ) {

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -48,7 +48,6 @@ import UserItem from 'components/user';
 import { withLocalizedMoment } from 'components/localized-moment';
 import { canEditPaymentDetails, getEditCardDetailsPath, isDataLoading } from '../utils';
 import { TERM_BIENNIALLY, TERM_MONTHLY } from 'lib/plans/constants';
-import { PRODUCT_WPCOM_SEARCH_MONTHLY } from 'lib/products-values/constants';
 
 class PurchaseMeta extends Component {
 	static propTypes = {
@@ -83,11 +82,6 @@ class PurchaseMeta extends Component {
 
 		if ( isIncludedWithPlan( purchase ) ) {
 			return translate( 'Free with Plan' );
-		}
-
-		// define term for Jetpack Search products for which plan.term is undefined
-		if ( purchase.productSlug === PRODUCT_WPCOM_SEARCH_MONTHLY ) {
-			period = translate( 'month' );
 		}
 
 		if ( plan && plan.term ) {


### PR DESCRIPTION
Currently all Search WPCOM plans are marked yearly because plan's term has not been included in the `plans-list.js`.
Here I propose a variation, but we might prefer modifying the latter  /cc @DavidRothstein for thoughts.

* adapt period to product plan type for Search

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* purchase a monthly Jetpack product for a WPCOM site at `purchase-product/jetpack_search_monthly`
* go `/me/purchases` and open your site's card
* verify that the price subscription corresponds to the correct period (e.g. 5.5usd/month) 

Fixes https://github.com/Automattic/wp-calypso/issues/44402

