### PR TITLE
composite-checkout: Log the requestCart that was sent for SET_SERVER_CART_ERROR

### DIFF
--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -160,6 +160,7 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 					logStashEventAction( 'calypso_checkout_composite_cart_error', {
 						type: action.payload.type,
 						message: action.payload.message,
+						cart: action.payload.cart,
 					} )
 				);
 

--- a/client/my-sites/checkout/composite-checkout/wpcom/hooks/use-shopping-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/hooks/use-shopping-cart.ts
@@ -637,10 +637,9 @@ function useCartUpdateAndRevalidate(
 			.catch( ( error ) => {
 				debug( 'error while fetching cart', error );
 				hookDispatch( { type: 'RAISE_ERROR', error: 'SET_SERVER_CART_ERROR', message: error } );
-				// TODO: log the request (at least the products) so we can see why it failed
 				onEvent?.( {
 					type: 'CART_ERROR',
-					payload: { type: 'SET_SERVER_CART_ERROR', message: error },
+					payload: { type: 'SET_SERVER_CART_ERROR', message: error, cart: requestCart },
 				} );
 			} );
 	}, [ setServerCart, cacheStatus, responseCart, onEvent, hookDispatch ] );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This changes the logstash logging for shopping-cart errors so that it includes the cart object that was sent to the server in the case of errors that occur when the cart is being saved.

#### Testing instructions

- Sandbox the API.
- Visit calypso and add a product to your cart. You should be directed to checkout.
- Apply D46792-code on your sandbox. You must do this AFTER loading checkout for this test to work.
- Modify the cart, for example by removing a product from your cart.
- Verify that you see an error message that reads "User or Token does not have access to specified site."
- Search logstash for "calypso_checkout_composite_cart_error" and verify that you see your error logged there and that it includes the cart.
