### PR TITLE
Checkout: Remove index-as-key in DomainRegistrationAgreement

### DIFF
--- a/client/my-sites/checkout/checkout/domain-registration-agreement.jsx
+++ b/client/my-sites/checkout/checkout/domain-registration-agreement.jsx
@@ -47,12 +47,11 @@ class DomainRegistrationAgreement extends React.Component {
 		const preamble = this.props.translate(
 			'You agree to the following domain name registration agreements:'
 		);
-		let key = 0;
 		return (
 			<Fragment>
 				<p>{ preamble }</p>
 				{ map( agreementsList, ( { url, domains } ) => (
-					<p key={ key++ }>{ this.renderAgreementLinkForList( url, domains ) }</p>
+					<p key={ url + domains.length }>{ this.renderAgreementLinkForList( url, domains ) }</p>
 				) ) }
 			</Fragment>
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This fixes a potential bug introduced in https://github.com/Automattic/wp-calypso/pull/31810 where an array index was used as a React key ([a classic but often poorly understood anti-pattern](https://stackoverflow.com/questions/59517962/react-using-index-as-key-for-items-in-the-list)). I believe that this is causing fatal rendering errors when removing a product from the cart causes the list of agreements to change in such a way that the elements are identified by the wrong key. Since the keys are not tied to the agreements, React attempts to modify the DOM with incorrect data and throws the error `Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.`.

In this PR I use the agreement url as the key instead, combined with the number of domains for that key. I hope that these will be unique enough to prevent rendering errors.

#### Testing instructions

Visit checkout with various sets of domain registration agreements and try to set it up so that removing an item from the cart changes the list of agreements displayed. Verify that there are no fatal errors and that the agreements are displayed as expected in such a case.