### PR TITLE
Checkout: Use feature string as key for CheckoutSummaryFeaturesListItem

### DIFF
--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
@@ -161,15 +161,14 @@ function CheckoutSummaryPlanFeatures() {
 
 	return (
 		<>
-			{ planFeatures &&
-				planFeatures.map( ( feature, index ) => {
-					return (
-						<CheckoutSummaryFeaturesListItem key={ index }>
-							<WPCheckoutCheckIcon />
-							{ feature }
-						</CheckoutSummaryFeaturesListItem>
-					);
-				} ) }
+			{ planFeatures.filter( Boolean ).map( ( feature ) => {
+				return (
+					<CheckoutSummaryFeaturesListItem key={ String( feature ) }>
+						<WPCheckoutCheckIcon />
+						{ feature }
+					</CheckoutSummaryFeaturesListItem>
+				);
+			} ) }
 		</>
 	);
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This fixes a potential bug introduced in https://github.com/Automattic/wp-calypso/pull/42854 where an array index was used as a React key ([a classic but often poorly understood anti-pattern](https://stackoverflow.com/questions/59517962/react-using-index-as-key-for-items-in-the-list)). I believe that this is causing fatal rendering errors when removing a product from the cart causes the list of features to change in such a way that the elements are identified by the wrong key. Since the keys are not tied to the features, React attempts to modify the DOM with incorrect data and throws the error `Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.`.

In this PR I use the feature string as the key instead. I hope that these will be unique enough to prevent rendering errors. This only works if `getPlanFeatures()` always returns an array of strings, but currently it does so (note that it does also return arrays containing `false` values due to the array building technique in `getPlanFeatures()` so this PR also filters those out).

#### Testing instructions

Visit checkout with various sets of feature lists and try to set it up so that removing an item from the cart changes the list of features displayed. Verify that there are no fatal errors and that the features are displayed as expected in such a case.