### PR TITLE
Checkout: Make sure product uuid is never the same

### DIFF
--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
@@ -73,6 +73,7 @@ function WPLineItem( {
 			{ hasDeleteButton && formStatus === 'ready' && (
 				<>
 					<DeleteButton
+						className="checkout-line-item__remove-product"
 						buttonType="borderless"
 						disabled={ isDisabled }
 						onClick={ () => {

--- a/client/my-sites/checkout/composite-checkout/wpcom/types/backend/shopping-cart-endpoint.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/types/backend/shopping-cart-endpoint.ts
@@ -297,10 +297,10 @@ export function convertRawResponseCartToResponseCart(
 			display_taxes: rawResponseCart.tax.display_taxes,
 		},
 		// Add uuid to products returned by the server
-		products: rawResponseCart.products.map( ( product, index ) => {
+		products: rawResponseCart.products.map( ( product ) => {
 			return {
 				...product,
-				uuid: index.toString(),
+				uuid: product.product_slug + lastUUID++,
 			};
 		} ),
 	} as ResponseCart;

--- a/test/e2e/lib/components/secure-payment-component.js
+++ b/test/e2e/lib/components/secure-payment-component.js
@@ -358,10 +358,13 @@ export default class SecurePaymentComponent extends AsyncBaseContainer {
 		return this.waitForCouponToBeRemoved();
 	}
 
-	async removeFromCart() {
+	async removeBusinessPlan() {
+		const productSlug = this.businessPlanSlug;
 		return await driverHelper.clickWhenClickable(
 			this.driver,
-			By.css( 'button.cart__remove-item,button svg[aria-labelledby*="checkout-delete-button-0"]' )
+			By.css(
+				`button.cart__remove-item,.checkout-line-item[data-e2e-product-slug="${ productSlug }"] button.checkout-line-item__remove-product`
+			)
 		);
 	}
 

--- a/test/e2e/specs/wp-plan-purchase-spec.js
+++ b/test/e2e/specs/wp-plan-purchase-spec.js
@@ -141,7 +141,7 @@ describe( `[${ host }] Plans: (${ screenSize })`, function () {
 		step( 'Remove from cart', async function () {
 			const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
 
-			return await securePaymentComponent.removeFromCart();
+			return await securePaymentComponent.removeBusinessPlan();
 		} );
 	} );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Every product in the `items` prop of `@automattic/composite-checkout`'s `CheckoutProvider` needs to have a unique `id`. Since the products returned from the shopping cart endpoint do not have unique IDs, we create them (as `uuid`) when the cart is fetched in `convertRawResponseCartToResponseCart()`.

Previously, we were using the item's array index as the `uuid`, but this is risky, since that id is used throughout the codebase for a React key. Indirectly, this creates [a classic but often poorly understood anti-pattern](https://stackoverflow.com/questions/59517962/react-using-index-as-key-for-items-in-the-list). I believe that this might be causing fatal rendering errors when removing a product from the cart causes the list of products to change in such a way that the elements are identified by the wrong key. Since the keys are not tied to the items, React attempts to modify the DOM with incorrect data and throws the error `Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.`.

In this PR I use the product slug and a unique, increasing integer as the key instead (globally increasing during the JS session, not per function call). This should make every item returned by the function totally unique, which should prevent any rendering errors and at worst might cause extra unnecessary renders.

#### Testing instructions

Visit checkout with more than one product. Remove one of the products and be sure that there are no fatal errors and that after the cart updates the remaining products are displayed correctly.
