### PR TITLE
Docs: update loading of style files for components

### DIFF
--- a/client/components/README.md
+++ b/client/components/README.md
@@ -3,7 +3,7 @@ Components
 
 Components are React components used for composing the UI of Calypso.
 
-They come with their own styles defined [according to our guidelines](../../docs/coding-guidelines/css.md), and manually loaded from the [styles assets folder](../../assets/stylesheets/_components.scss). Structuring the user interface with these building blocks has several benefits — like allowing to quickly construct a view that is visually consistent with the rest of Calypso, and easier to iterate on.
+They come with their own styles defined [according to our guidelines](../../docs/coding-guidelines/css.md), and manually loaded from the styles file in a component's folder: `component/style.scss` (as an example, [here is the styles file of the Accordion component](./accordion/style.scss)). Structuring the user interface with these building blocks has several benefits — like allowing to quickly construct a view that is visually consistent with the rest of Calypso, and easier to iterate on.
 
 Many of these components can be seen in action in our [DevDocs: UI Components](https://wpcalypso.wordpress.com/devdocs/design) section.
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The existing description refers and links to an older structure/file that no longer exists (`assets/stylesheets/_components.scss`). This PR updates the text to reflect that each component has its own `styles.scss` inside the component's folder, and adds a link to the styles file of the Accordion component as an example.
