### PR TITLE
Editor: Add link to block editor help pages

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/use-classic-block-guide.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/use-classic-block-guide.js
@@ -48,8 +48,13 @@ const ClassicGuide = () => {
 										{ __( 'Meet the Classic block' ) }
 									</h1>
 									<p className="edit-post-welcome-guide__text">
-										{ __(
-											'The block editor is now the default editor for all your sites, but you can still use the Classic block, if you prefer.'
+										{ createInterpolateElement(
+											__(
+												'The <a>block editor</a> is now the default editor for all your sites, but you can still use the Classic block, if you prefer.'
+											),
+											{
+												a: <a href={ 'https://wordpress.com/support/wordpress-editor/' } />,
+											}
 										) }
 									</p>
 								</>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add a link to the block editor help pages in the classic block welcome guide

#### Testing instructions

- Set a user attribute for your user using wpsh on a sandbox $ update_user_attribute( USER_ID, 'editor_deprecation_group', true )
- Check out this PR and build the wpcom block editor files with yarn build:prod in the apps/wpcom-block-editor/package.json folder.
- Sync the files created by the build in the '/dist' folder with your sandbox widgets/wpcom-block-editor folder
- Make sure site used above is sandboxed Load editor editor again and make sure the Classic block guide loads and that the 'block editor' text on first page of guide is hyperlinked to the help pages.

<img width="326" alt="Screen Shot 2020-07-27 at 1 48 02 PM" src="https://user-images.githubusercontent.com/3629020/88496244-a7b60700-d010-11ea-8b5b-e1790f1bb4ec.png">

Part of #44328
