### PR TITLE
Change editor close button label from "Home" to "My Home"

### DIFF
--- a/client/state/selectors/get-editor-close-config.js
+++ b/client/state/selectors/get-editor-close-config.js
@@ -52,7 +52,7 @@ export default function getEditorCloseConfig( state, siteId, postType, fseParent
 	if ( ! lastNonEditorRoute || ! postType || doesRouteMatch( /^\/home\/?/ ) ) {
 		return {
 			url: `/home/${ getSiteSlug( state, siteId ) }`,
-			label: translate( 'Home' ),
+			label: translate( 'My Home' ),
 		};
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When the (W) button in the block editor is going to take the user back to the customer home page, the button's tooltip says "Home". This could be easily confused with taking the user to their site's homepage.

Everywhere else in Calypso the customer home page is called "My Home". The tooltip should be consistent with that.

**Before**
<img width="284" alt="Screenshot 2020-07-27 at 8 45 41 AM" src="https://user-images.githubusercontent.com/1500769/88502558-e9e84400-d022-11ea-8f8d-e16af07bba62.png">

**After**
<img width="282" alt="Screenshot 2020-07-27 at 4 09 48 PM" src="https://user-images.githubusercontent.com/1500769/88502777-a4784680-d023-11ea-9675-9e8d9f7efa67.png">

p58i-9f7-p2#comment-47138

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the block editor from the My Home page in Calypso, the (W) tooltip should say "My Home"
* Open the block editor from the pages or posts page in Calypso, the tooltip should say "View Pages/Posts", or whatever it used to say
* Open the block editor on a site with the nav sidebar enabled (e.g. bAok1-p2) and check that the back button in the sidebar has the correct label

