### PR TITLE
Jetpack Search: Add product icon for the monthly version of the product.

### DIFF
--- a/packages/components/src/product-icon/config.js
+++ b/packages/components/src/product-icon/config.js
@@ -33,6 +33,7 @@ export const paths = {
 	'wpcom-personal': wpcomPersonal,
 	'wpcom-premium': wpcomPremium,
 	'wpcom-search': jetpackSearch,
+	'wpcom-search_monthly': jetpackSearch,
 };
 
 export const iconToProductSlugMap = {
@@ -49,7 +50,12 @@ export const iconToProductSlugMap = {
 	'jetpack-backup-daily': [ 'jetpack_backup_daily', 'jetpack_backup_daily_monthly' ],
 	'jetpack-backup-realtime': [ 'jetpack_backup_realtime', 'jetpack_backup_realtime_monthly' ],
 	'jetpack-scan': [ 'jetpack_scan', 'jetpack_scan_monthly' ],
-	'jetpack-search': [ 'jetpack_search', 'jetpack_search_monthly', 'wpcom_search' ],
+	'jetpack-search': [
+		'jetpack_search',
+		'jetpack_search_monthly',
+		'wpcom_search',
+		'wpcom_search_monthly',
+	],
 	'jetpack-anti-spam': [ 'jetpack_anti_spam', 'jetpack_anti_spam_monthly' ],
 };
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* add the icons in the /manage-purchase section

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* purchase a monthly version of the product for a WPCOM site
* verify that the icon is present in the /me/purchases section, as well as the subsequent manage purchase one

Fixes https://github.com/Automattic/wp-calypso/issues/44407
