### PR TITLE
Remove Quick Start from Bussiness feature on plans page

### DIFF
--- a/client/lib/plans/plans-list.js
+++ b/client/lib/plans/plans-list.js
@@ -318,7 +318,6 @@ const getPlanBusinessDetails = () => ( {
 			isEnabled( 'republicize' ) && constants.FEATURE_REPUBLICIZE,
 			constants.FEATURE_WORDADS_INSTANT,
 			constants.FEATURE_VIDEO_UPLOADS,
-			constants.FEATURE_BUSINESS_ONBOARDING,
 			constants.FEATURE_ADVANCED_SEO,
 			isEnabled( 'automated-transfer' ) && constants.FEATURE_UPLOAD_PLUGINS,
 			isEnabled( 'automated-transfer' ) && constants.FEATURE_UPLOAD_THEMES,

--- a/client/lib/plans/plans-list.js
+++ b/client/lib/plans/plans-list.js
@@ -330,6 +330,7 @@ const getPlanBusinessDetails = () => ( {
 		constants.FEATURE_NO_ADS,
 		constants.FEATURE_ADVANCED_DESIGN,
 		constants.FEATURE_VIDEO_UPLOADS,
+		constants.FEATURE_BUSINESS_ONBOARDING,
 	],
 	getSignupFeatures: () => [
 		constants.FEATURE_UPLOAD_THEMES_PLUGINS,

--- a/client/lib/plans/plans-list.js
+++ b/client/lib/plans/plans-list.js
@@ -318,6 +318,7 @@ const getPlanBusinessDetails = () => ( {
 			isEnabled( 'republicize' ) && constants.FEATURE_REPUBLICIZE,
 			constants.FEATURE_WORDADS_INSTANT,
 			constants.FEATURE_VIDEO_UPLOADS,
+			constants.FEATURE_BUSINESS_ONBOARDING,
 			constants.FEATURE_ADVANCED_SEO,
 			isEnabled( 'automated-transfer' ) && constants.FEATURE_UPLOAD_PLUGINS,
 			isEnabled( 'automated-transfer' ) && constants.FEATURE_UPLOAD_THEMES,

--- a/client/lib/plans/plans-list.js
+++ b/client/lib/plans/plans-list.js
@@ -330,7 +330,6 @@ const getPlanBusinessDetails = () => ( {
 		constants.FEATURE_NO_ADS,
 		constants.FEATURE_ADVANCED_DESIGN,
 		constants.FEATURE_VIDEO_UPLOADS,
-		constants.FEATURE_BUSINESS_ONBOARDING,
 	],
 	getSignupFeatures: () => [
 		constants.FEATURE_UPLOAD_THEMES_PLUGINS,

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -64,6 +64,8 @@ import {
 	TYPE_PREMIUM,
 	TYPE_BUSINESS,
 	GROUP_WPCOM,
+	FEATURE_BUSINESS_ONBOARDING,
+	PLAN_BUSINESS,
 } from 'lib/plans/constants';
 import { getPlanFeaturesObject } from 'lib/plans/features-list';
 import PlanFeaturesScroller from './scroller';
@@ -832,11 +834,14 @@ export default connect(
 
 				// Show price divided by 12? Only for non JP plans, or if plan is only available yearly.
 				const showMonthlyPrice = ! isJetpack || isSiteAT || ( ! relatedMonthlyPlan && showMonthly );
+				let features = planConstantObj.getPlanCompareFeatures( abtest );
 
-				let planFeatures = getPlanFeaturesObject(
-					planConstantObj.getPlanCompareFeatures( abtest )
-				);
+				// TODO: remove this once Quick Start sessions have been removed from Business Plan
+				if ( PLAN_BUSINESS === plan ) {
+					features = features.filter( ( feature ) => feature !== FEATURE_BUSINESS_ONBOARDING );
+				}
 
+				let planFeatures = getPlanFeaturesObject( features );
 				if ( placeholder || ! planObject || isLoadingSitePlans ) {
 					isPlaceholder = true;
 				}

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -38,6 +38,7 @@ import {
 	getPlanPath,
 	isFreePlan,
 	isWpComEcommercePlan,
+	isWpComBusinessPlan,
 	getPlanClass,
 } from 'lib/plans';
 import {
@@ -65,7 +66,6 @@ import {
 	TYPE_BUSINESS,
 	GROUP_WPCOM,
 	FEATURE_BUSINESS_ONBOARDING,
-	PLAN_BUSINESS,
 } from 'lib/plans/constants';
 import { getPlanFeaturesObject } from 'lib/plans/features-list';
 import PlanFeaturesScroller from './scroller';
@@ -837,7 +837,7 @@ export default connect(
 				let features = planConstantObj.getPlanCompareFeatures( abtest );
 
 				// TODO: remove this once Quick Start sessions have been removed from Business Plan
-				if ( PLAN_BUSINESS === plan ) {
+				if ( isWpComBusinessPlan( plan ) ) {
 					features = features.filter( ( feature ) => feature !== FEATURE_BUSINESS_ONBOARDING );
 				}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR removes the **Get personalized help** feature from the Business Plan on the /plans page. See pbBQWj-eI-p2 for more details.

<img width="320" src="https://user-images.githubusercontent.com/2749938/88536023-b356fd00-d013-11ea-901b-04c2f3fb04e0.png"/>


#### Testing instructions

* Go to [/plans](https://wordpress.com/plans)
* Under the Business Plans column (under 'Business sites and online stores' tab)
* There shouldn't be any **Get personalized help** feature
