### PR TITLE
Add Reskinned Signup Processing Screen

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -77,6 +77,7 @@ import {
 import WpcomLoginForm from './wpcom-login-form';
 import SiteMockups from './site-mockup';
 import P2SignupProcessingScreen from 'signup/p2-processing-screen';
+import ReskinnedProcessingScreen from 'signup/reskinned-processing-screen';
 import user from 'lib/user';
 import { abtest } from 'lib/abtest';
 
@@ -537,6 +538,21 @@ class Signup extends React.Component {
 		return flows.getFlow( this.props.flowName ).steps.length;
 	}
 
+	renderProcessingScreen() {
+		if ( isWPForTeamsFlow( this.props.flowName ) ) {
+			return <P2SignupProcessingScreen />;
+		}
+
+		if ( this.props.isReskinned ) {
+			const domainItem = get( this.props, 'signupDependencies.domainItem', false );
+			const hasPaidDomain = isDomainRegistration( domainItem );
+
+			return <ReskinnedProcessingScreen hasPaidDomain={ hasPaidDomain } />;
+		}
+
+		return <SignupProcessingScreen />;
+	}
+
 	renderCurrentStep() {
 		const domainItem = get( this.props, 'signupDependencies.domainItem', false );
 		const currentStepProgress = find( this.props.progress, { stepName: this.props.stepName } );
@@ -559,10 +575,6 @@ class Signup extends React.Component {
 		const hideFreePlan = planWithDomain || this.props.isDomainOnlySite || selectedHideFreePlan;
 		const shouldRenderLocaleSuggestions = 0 === this.getPositionInFlow() && ! this.props.isLoggedIn;
 
-		const ProcessingScreen = isWPForTeamsFlow( this.props.flowName )
-			? P2SignupProcessingScreen
-			: SignupProcessingScreen;
-
 		return (
 			<div className="signup__step" key={ stepKey }>
 				<div className={ `signup__step is-${ kebabCase( this.props.stepName ) }` }>
@@ -570,7 +582,7 @@ class Signup extends React.Component {
 						<LocaleSuggestions path={ this.props.path } locale={ this.props.locale } />
 					) }
 					{ this.state.shouldShowLoadingScreen ? (
-						<ProcessingScreen />
+						this.renderProcessingScreen()
 					) : (
 						<CurrentComponent
 							path={ this.props.path }
@@ -651,6 +663,7 @@ class Signup extends React.Component {
 						flowName={ this.props.flowName }
 						showProgressIndicator={ showProgressIndicator }
 						shouldShowLoadingScreen={ this.state.shouldShowLoadingScreen }
+						isReskinned={ this.props.isReskinned }
 					/>
 				) }
 				<div className="signup__steps">{ this.renderCurrentStep() }</div>

--- a/client/signup/reskinned-processing-screen/index.jsx
+++ b/client/signup/reskinned-processing-screen/index.jsx
@@ -1,0 +1,76 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { sprintf } from '@wordpress/i18n';
+import { useI18n } from '@automattic/react-i18n';
+import { useInterval } from 'lib/interval/use-interval';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+// Total time to perform "loading"
+const DURATION_IN_MS = 6000;
+
+/**
+ * This component is cloned from the CreateSite component of Gutenboarding flow
+ * to work with the onboarding signup flow.
+ */
+export default function ReskinnedProcessingScreen( { hasPaidDomain } ) {
+	const { __ } = useI18n();
+
+	const steps = React.useRef(
+		[
+			__( 'Building your site' ),
+			hasPaidDomain && __( 'Getting your domain' ),
+			__( 'Applying design' ),
+		].filter( Boolean )
+	);
+	const totalSteps = steps.current.length;
+
+	const [ currentStep, setCurrentStep ] = React.useState( 0 );
+
+	/**
+	 * Completion progress: 0 <= progress <= 1
+	 */
+	const progress = ( currentStep + 1 ) / totalSteps;
+	const isComplete = progress >= 1;
+
+	useInterval(
+		() => setCurrentStep( ( s ) => s + 1 ),
+		// Enable the interval when progress is incomplete
+		isComplete ? null : DURATION_IN_MS / totalSteps
+	);
+
+	// Force animated progress bar to start at 0
+	const [ hasStarted, setHasStarted ] = React.useState( false );
+	React.useEffect( () => {
+		const id = setTimeout( () => setHasStarted( true ), 750 );
+		return () => clearTimeout( id );
+	}, [] );
+
+	return (
+		<div className="reskinned-processing-screen">
+			<h1 className="reskinned-processing-screen__progress-step">
+				{ steps.current[ currentStep ] }
+			</h1>
+			<div
+				className="reskinned-processing-screen__progress-bar"
+				style={ {
+					'--progress': ! hasStarted ? /* initial 10% progress */ 0.1 : progress,
+				} }
+			/>
+			<p className="reskinned-processing-screen__progress-numbered-steps">
+				{
+					// translators: these are progress steps. Eg: step 1 of 4.
+					sprintf( __( 'Step %(currentStep)d of %(totalSteps)d' ), {
+						currentStep: currentStep + 1,
+						totalSteps,
+					} )
+				}
+			</p>
+		</div>
+	);
+}

--- a/client/signup/reskinned-processing-screen/style.scss
+++ b/client/signup/reskinned-processing-screen/style.scss
@@ -1,0 +1,48 @@
+@import '~@automattic/onboarding/styles/mixins';
+@import 'assets/stylesheets/gutenberg-base-styles';
+@import 'landing/gutenboarding/onboarding-block/colors';
+
+$progress-duration: 800ms;
+
+.reskinned-processing-screen {
+	padding: 1em;
+	max-width: 540px;
+
+	margin: 32vh auto;
+
+	&__progress-bar {
+		position: relative;
+		overflow: hidden;
+		height: 6px;
+		margin-top: 1em;
+		background: var( --studio-gray-10 );
+		--progress: 0;
+
+		&::before {
+			background: var( --studio-blue-40 );
+			transform: translateX( calc( -100% * min( 1 - var( --progress, 0 ), 1 ) ) );
+			position: absolute;
+			content: '';
+			top: 0;
+			left: 0;
+			right: 0;
+			bottom: 0;
+			transition: transform $progress-duration ease-out;
+		}
+	}
+
+	&__progress-step {
+		@include onboarding-heading-text-mobile;
+
+		text-align: center;
+		vertical-align: middle;
+		margin: 0;
+	}
+
+	&__progress-numbered-steps {
+		margin-top: 0.7em;
+		padding: 1em;
+		text-align: center;
+		color: var( --studio-gray-40 );
+	}
+}

--- a/client/signup/signup-header/index.jsx
+++ b/client/signup/signup-header/index.jsx
@@ -26,16 +26,13 @@ export default class SignupHeader extends Component {
 		flowName: PropTypes.string,
 		showProgressIndicator: PropTypes.bool,
 		shouldShowLoadingScreen: PropTypes.bool,
+		isReskinned: PropTypes.bool,
 	};
-
-	constructor( props ) {
-		super( props );
-	}
 
 	render() {
 		const logoClasses = classnames( {
 			'wordpress-logo': true,
-			'is-large': this.props.shouldShowLoadingScreen,
+			'is-large': this.props.shouldShowLoadingScreen && ! this.props.isReskinned,
 		} );
 
 		return (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds redesigned signup processing screen to the reskinning signup flow project. More details can be found in #44223.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/new`
* Make sure you're assigned to the `reskinned` group of `reskinSignupFlow` a/b test.
* Follow the signup flow.
* You should be able to see the redesigned signup processing screen as follows at the end of the signup flow. Note that the second step can be omitted when you pick a free domain.
<img width="895" alt="Create_a_site_—_WordPress_com" src="https://user-images.githubusercontent.com/212034/88538416-4d399c80-d04a-11ea-9ede-77d40b5c64aa.png">
<img width="895" alt="Create_a_site_—_WordPress_com" src="https://user-images.githubusercontent.com/212034/88538588-938efb80-d04a-11ea-8f04-900e7afe6b91.png">
<img width="828" alt="Create_a_site_—_WordPress_com" src="https://user-images.githubusercontent.com/212034/88538499-735f3c80-d04a-11ea-8fd1-98aa9e076f61.png">

