### PR TITLE
Remove coming soon

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -282,6 +282,7 @@ export class SiteSettingsFormGeneral extends Component {
 		const {
 			fields,
 			isRequestingSettings,
+			isWPForTeamsSite,
 			eventTracker,
 			siteIsJetpack,
 			siteIsAtomic,
@@ -294,7 +295,7 @@ export class SiteSettingsFormGeneral extends Component {
 
 		return (
 			<FormFieldset>
-				{ ! isNonAtomicJetpackSite && (
+				{ ! isNonAtomicJetpackSite && ! isWPForTeamsSite && (
 					<>
 						<FormLabel className="site-settings__visibility-label is-coming-soon">
 							<FormRadio


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Hide `Coming Soon` site setting for P2 sites.

#### Testing instructions
- Open Settings -> General for a regular site, there should be the option of Coming Soon under `Privacy`
- Open Settings -> General for a P2 site, there should be no option of Coming Soon under `Privacy`
