### PR TITLE
Block themes section for p2

### DIFF
--- a/client/my-sites/themes/controller.jsx
+++ b/client/my-sites/themes/controller.jsx
@@ -4,6 +4,7 @@
 import { compact, includes, isEmpty, startsWith } from 'lodash';
 import debugFactory from 'debug';
 import React from 'react';
+import page from 'page';
 
 /**
  * Internal Dependencies
@@ -17,6 +18,8 @@ import { DEFAULT_THEME_QUERY } from 'state/themes/constants';
 import { requestThemes, requestThemeFilters, setBackPath } from 'state/themes/actions';
 import { getThemeFilters, getThemesForQuery } from 'state/themes/selectors';
 import { getAnalyticsData } from './helpers';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import isSiteWPForTeams from 'state/selectors/is-site-wpforteams';
 
 const debug = debugFactory( 'calypso:themes' );
 
@@ -55,6 +58,13 @@ export function upload( context, next ) {
 }
 
 export function loggedIn( context, next ) {
+	// Block direct access for P2 sites
+	const state = context.store.getState();
+	const siteId = getSelectedSiteId( state );
+	if ( isSiteWPForTeams( state, siteId ) ) {
+		return page.redirect( `/home/${ context.params.site_id }` );
+	}
+
 	// Scroll to the top
 	if ( typeof window !== 'undefined' ) {
 		window.scrollTo( 0, 0 );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Block direct access to themes route for P2 sites.

#### Testing instructions
- Select a regular site -> Accessing Themes should work
- Select a P2 site -> go to Home, change `/home/` to `/themes/` in the URL -> should be redirected back to Home.