### PR TITLE
Use the proper selector for site items

### DIFF
--- a/client/my-sites/domains/domain-management/list/list-all.jsx
+++ b/client/my-sites/domains/domain-management/list/list-all.jsx
@@ -29,7 +29,7 @@ import {
 import { getCurrentUser } from 'state/current-user/selectors';
 import { getCurrentRoute } from 'state/selectors/get-current-route';
 import { getDomainManagementPath } from './utils';
-import getSitesItems from 'state/selectors/get-sites-items';
+import getSites from 'state/selectors/get-sites';
 import isRequestingAllDomains from 'state/selectors/is-requesting-all-domains';
 import ListItemPlaceholder from './item-placeholder';
 import Main from 'components/main';
@@ -176,7 +176,7 @@ const addDomainClick = () =>
 
 export default connect(
 	( state ) => {
-		const sites = keyBy( getSitesItems( state ), 'ID' );
+		const sites = keyBy( getSites( state ), 'ID' );
 		const user = getCurrentUser( state );
 		const purchases = keyBy( getUserPurchases( state, user?.ID ) || [], 'id' );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Turns out we're not using the proper selector in #44362 which resulted in items not being clickable. Here's a fix for that

#### Testing instructions

* Verify that the domain items and the option menu items are clickable and open the proper pages
