### PR TITLE
Remove Quick Start from Bussiness feature on My Plan page

### DIFF
--- a/client/blocks/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features-list/index.jsx
@@ -108,9 +108,7 @@ export class ProductPurchaseFeaturesList extends Component {
 		// TODO: remove this and just have isBusinessOnboardingAvailable = hasAvailableConciergeSessions once free QS sessions are actually removed from Business Plan
 		if ( currentPlan && hasAvailableConciergeSessions ) {
 			const expiryDateMoment = this.props.moment( currentPlan.expiryDate );
-			const businessOnboardingExpiration = this.props
-				.moment( PLAN_BUSINESS_ONBOARDING_EXPIRE )
-				.add( '1', 'year' );
+			const businessOnboardingExpiration = this.props.moment( PLAN_BUSINESS_ONBOARDING_EXPIRE );
 
 			isBusinessOnboardingAvailable = businessOnboardingExpiration.diff( expiryDateMoment ) > 0;
 		}

--- a/client/blocks/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features-list/index.jsx
@@ -45,7 +45,7 @@ import { hasDomainCredit, getCurrentPlan } from 'state/sites/plans/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
 import isSiteUsingFullSiteEditing from 'state/selectors/is-site-using-full-site-editing';
-
+import getHasAvailableConciergeSessions from 'state/selectors/get-concierge-has-available-sessions';
 /**
  * Style dependencies
  */
@@ -100,11 +100,13 @@ export class ProductPurchaseFeaturesList extends Component {
 			planHasDomainCredit,
 			selectedSite,
 			showCustomizerFeature,
+			hasAvailableConciergeSessions,
 		} = this.props;
 
 		let isBusinessOnboardingAvailable = false;
 
-		if ( currentPlan ) {
+		// TODO: remove this and just have isBusinessOnboardingAvailable = hasAvailableConciergeSessions once free QS sessions are actually removed from Business Plan
+		if ( currentPlan && hasAvailableConciergeSessions ) {
 			const expiryDateMoment = this.props.moment( currentPlan.expiryDate );
 			const businessOnboardingExpiration = this.props
 				.moment( PLAN_BUSINESS_ONBOARDING_EXPIRE )
@@ -343,6 +345,7 @@ export default connect(
 			planHasDomainCredit: hasDomainCredit( state, selectedSiteId ),
 			showCustomizerFeature: ! isSiteUsingFullSiteEditing( state, selectedSiteId ),
 			currentPlan: getCurrentPlan( state, selectedSiteId ),
+			hasAvailableConciergeSessions: getHasAvailableConciergeSessions( state ),
 		};
 	},
 	{

--- a/client/blocks/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features-list/index.jsx
@@ -102,10 +102,16 @@ export class ProductPurchaseFeaturesList extends Component {
 			showCustomizerFeature,
 		} = this.props;
 
-		const expiryDateMoment = this.props.moment( currentPlan.expiryDate );
-		const businessOnboardingExpiration = this.props.moment( PLAN_BUSINESS_ONBOARDING_EXPIRE ).add( '1', 'year' );
+		let isBusinessOnboardingAvailable = false;
 
-		const isBusinessOnboardingAvailable = businessOnboardingExpiration.diff( expiryDateMoment ) > 0;
+		if ( currentPlan ) {
+			const expiryDateMoment = this.props.moment( currentPlan.expiryDate );
+			const businessOnboardingExpiration = this.props
+				.moment( PLAN_BUSINESS_ONBOARDING_EXPIRE )
+				.add( '1', 'year' );
+
+			isBusinessOnboardingAvailable = businessOnboardingExpiration.diff( expiryDateMoment ) > 0;
+		}
 
 		return (
 			<Fragment>

--- a/client/blocks/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features-list/index.jsx
@@ -102,15 +102,10 @@ export class ProductPurchaseFeaturesList extends Component {
 			showCustomizerFeature,
 		} = this.props;
 
-		const subscribedDateMoment = this.props.moment( currentPlan.subscribedDate );
-		const firstRenewalDateMoment = this.props.moment( currentPlan.subscribedDate ).add( '1', 'year' );
-		const businessOnboardingExpiration = new Date( PLAN_BUSINESS_ONBOARDING_EXPIRE );
-		const now = new Date();
+		const expiryDateMoment = this.props.moment( currentPlan.expiryDate );
+		const businessOnboardingExpiration = this.props.moment( PLAN_BUSINESS_ONBOARDING_EXPIRE ).add( '1', 'year' );
 
-		const isSubscribedBeforeExpiration = subscribedDateMoment.diff( businessOnboardingExpiration ) < 0;
-		const isNotRenewed = firstRenewalDateMoment.diff( now ) > 0;
-
-		const isBusinessOnboardingAvailable = isSubscribedBeforeExpiration && isNotRenewed;
+		const isBusinessOnboardingAvailable = businessOnboardingExpiration.diff( expiryDateMoment ) > 0;
 
 		return (
 			<Fragment>

--- a/client/blocks/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features-list/index.jsx
@@ -103,10 +103,13 @@ export class ProductPurchaseFeaturesList extends Component {
 			scheduleId,
 		} = this.props;
 
-		const expiryDateMoment = this.props.moment( currentPlan.expiryDate );
-		const businessOnboardingExpiration = this.props.moment( PLAN_BUSINESS_ONBOARDING_EXPIRE );
+		let hasBusinessOnboardingExpired;
+		if ( currentPlan ) {
+			const expiryDateMoment = this.props.moment( currentPlan.expiryDate );
+			const businessOnboardingExpiration = this.props.moment( PLAN_BUSINESS_ONBOARDING_EXPIRE );
 
-		const hasBusinessOnboardingExpired = businessOnboardingExpiration.diff( expiryDateMoment ) < 0;
+			hasBusinessOnboardingExpired = businessOnboardingExpiration.diff( expiryDateMoment ) < 0;
+		}
 
 		const hasIncludedSessions = scheduleId === 1;
 		const hasPurchsedSessions = scheduleId > 1;

--- a/client/blocks/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features-list/index.jsx
@@ -45,7 +45,7 @@ import { hasDomainCredit, getCurrentPlan } from 'state/sites/plans/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
 import isSiteUsingFullSiteEditing from 'state/selectors/is-site-using-full-site-editing';
-import getHasAvailableConciergeSessions from 'state/selectors/get-concierge-has-available-sessions';
+import getConciergeScheduleId from 'state/selectors/get-concierge-schedule-id';
 /**
  * Style dependencies
  */
@@ -100,18 +100,19 @@ export class ProductPurchaseFeaturesList extends Component {
 			planHasDomainCredit,
 			selectedSite,
 			showCustomizerFeature,
-			hasAvailableConciergeSessions,
+			scheduleId,
 		} = this.props;
 
-		let isBusinessOnboardingAvailable = false;
+		const expiryDateMoment = this.props.moment( currentPlan.expiryDate );
+		const businessOnboardingExpiration = this.props.moment( PLAN_BUSINESS_ONBOARDING_EXPIRE );
 
-		// TODO: remove this and just have isBusinessOnboardingAvailable = hasAvailableConciergeSessions once free QS sessions are actually removed from Business Plan
-		if ( currentPlan && hasAvailableConciergeSessions ) {
-			const expiryDateMoment = this.props.moment( currentPlan.expiryDate );
-			const businessOnboardingExpiration = this.props.moment( PLAN_BUSINESS_ONBOARDING_EXPIRE );
+		const hasBusinessOnboardingExpired = businessOnboardingExpiration.diff( expiryDateMoment ) < 0;
 
-			isBusinessOnboardingAvailable = businessOnboardingExpiration.diff( expiryDateMoment ) > 0;
-		}
+		const hasIncludedSessions = scheduleId === 1;
+		const hasPurchsedSessions = scheduleId > 1;
+
+		const isBusinessOnboardingAvailable =
+			hasPurchsedSessions || ( hasIncludedSessions && ! hasBusinessOnboardingExpired );
 
 		return (
 			<Fragment>
@@ -343,7 +344,7 @@ export default connect(
 			planHasDomainCredit: hasDomainCredit( state, selectedSiteId ),
 			showCustomizerFeature: ! isSiteUsingFullSiteEditing( state, selectedSiteId ),
 			currentPlan: getCurrentPlan( state, selectedSiteId ),
-			hasAvailableConciergeSessions: getHasAvailableConciergeSessions( state ),
+			scheduleId: getConciergeScheduleId( state ),
 		};
 	},
 	{

--- a/client/blocks/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features-list/index.jsx
@@ -19,6 +19,7 @@ import {
 	TYPE_BLOGGER,
 	TYPE_FREE,
 	PLAN_BUSINESS_ONBOARDING_EXPIRE,
+	PLAN_BUSINESS_2Y_ONBOARDING_EXPIRE,
 } from 'lib/plans/constants';
 import { PLANS_LIST } from 'lib/plans/plans-list';
 import FindNewTheme from './find-new-theme';
@@ -106,7 +107,10 @@ export class ProductPurchaseFeaturesList extends Component {
 		let hasBusinessOnboardingExpired;
 		if ( currentPlan ) {
 			const expiryDateMoment = this.props.moment( currentPlan.expiryDate );
-			const businessOnboardingExpiration = this.props.moment( PLAN_BUSINESS_ONBOARDING_EXPIRE );
+			const is2YearPlan = selectedSite.plan.product_id === 1028;
+			const businessOnboardingExpiration = this.props.moment(
+				is2YearPlan ? PLAN_BUSINESS_2Y_ONBOARDING_EXPIRE : PLAN_BUSINESS_ONBOARDING_EXPIRE
+			);
 
 			hasBusinessOnboardingExpired = businessOnboardingExpiration.diff( expiryDateMoment ) < 0;
 		}

--- a/client/blocks/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features-list/index.jsx
@@ -18,6 +18,7 @@ import {
 	TYPE_PERSONAL,
 	TYPE_BLOGGER,
 	TYPE_FREE,
+	PLAN_BUSINESS_2_YEARS,
 	PLAN_BUSINESS_ONBOARDING_EXPIRE,
 	PLAN_BUSINESS_2Y_ONBOARDING_EXPIRE,
 } from 'lib/plans/constants';
@@ -107,7 +108,8 @@ export class ProductPurchaseFeaturesList extends Component {
 		let hasBusinessOnboardingExpired;
 		if ( currentPlan ) {
 			const expiryDateMoment = this.props.moment( currentPlan.expiryDate );
-			const is2YearPlan = selectedSite.plan.product_id === 1028;
+
+			const is2YearPlan = plan === PLAN_BUSINESS_2_YEARS;
 			const businessOnboardingExpiration = this.props.moment(
 				is2YearPlan ? PLAN_BUSINESS_2Y_ONBOARDING_EXPIRE : PLAN_BUSINESS_ONBOARDING_EXPIRE
 			);
@@ -116,10 +118,10 @@ export class ProductPurchaseFeaturesList extends Component {
 		}
 
 		const hasIncludedSessions = scheduleId === 1;
-		const hasPurchsedSessions = scheduleId > 1;
+		const hasPurchasedSessions = scheduleId > 1;
 
 		const isBusinessOnboardingAvailable =
-			hasPurchsedSessions || ( hasIncludedSessions && ! hasBusinessOnboardingExpired );
+			hasPurchasedSessions || ( hasIncludedSessions && ! hasBusinessOnboardingExpired );
 
 		return (
 			<Fragment>

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -44,7 +44,7 @@ export const PLAN_HOST_BUNDLE = 'host-bundle';
 export const PLAN_WPCOM_ENTERPRISE = 'wpcom-enterprise';
 export const PLAN_CHARGEBACK = 'chargeback';
 
-export const PLAN_BUSINESS_ONBOARDING_EXPIRE = '2020-07-27T00:00:00+00:00';
+export const PLAN_BUSINESS_ONBOARDING_EXPIRE = '2021-07-30T00:00:00+00:00';
 
 export const NEW_PLANS = [];
 export const BEST_VALUE_PLANS = [ PLAN_JETPACK_PREMIUM, PLAN_JETPACK_PREMIUM_MONTHLY ];

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -44,6 +44,8 @@ export const PLAN_HOST_BUNDLE = 'host-bundle';
 export const PLAN_WPCOM_ENTERPRISE = 'wpcom-enterprise';
 export const PLAN_CHARGEBACK = 'chargeback';
 
+export const PLAN_BUSINESS_ONBOARDING_EXPIRE = '2020-07-27T00:00:00+00:00';
+
 export const NEW_PLANS = [];
 export const BEST_VALUE_PLANS = [ PLAN_JETPACK_PREMIUM, PLAN_JETPACK_PREMIUM_MONTHLY ];
 export const JETPACK_PLANS = [

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -44,7 +44,7 @@ export const PLAN_HOST_BUNDLE = 'host-bundle';
 export const PLAN_WPCOM_ENTERPRISE = 'wpcom-enterprise';
 export const PLAN_CHARGEBACK = 'chargeback';
 
-export const PLAN_BUSINESS_ONBOARDING_EXPIRE = '2021-07-30T00:00:00+00:00';
+export const PLAN_BUSINESS_ONBOARDING_EXPIRE = '2021-07-31T00:00:00+00:00';
 
 export const NEW_PLANS = [];
 export const BEST_VALUE_PLANS = [ PLAN_JETPACK_PREMIUM, PLAN_JETPACK_PREMIUM_MONTHLY ];

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -45,6 +45,7 @@ export const PLAN_WPCOM_ENTERPRISE = 'wpcom-enterprise';
 export const PLAN_CHARGEBACK = 'chargeback';
 
 export const PLAN_BUSINESS_ONBOARDING_EXPIRE = '2021-07-31T00:00:00+00:00';
+export const PLAN_BUSINESS_2Y_ONBOARDING_EXPIRE = '2022-07-31T00:00:00+00:00';
 
 export const NEW_PLANS = [];
 export const BEST_VALUE_PLANS = [ PLAN_JETPACK_PREMIUM, PLAN_JETPACK_PREMIUM_MONTHLY ];

--- a/client/me/concierge/main.js
+++ b/client/me/concierge/main.js
@@ -27,7 +27,6 @@ import QuerySitePlans from 'components/data/query-site-plans';
 import getConciergeAvailableTimes from 'state/selectors/get-concierge-available-times';
 import getConciergeScheduleId from 'state/selectors/get-concierge-schedule-id';
 import getConciergeNextAppointment from 'state/selectors/get-concierge-next-appointment';
-import getHasAvailableConciergeSessions from 'state/selectors/get-concierge-has-available-sessions';
 import getUserSettings from 'state/selectors/get-user-settings';
 import { getSite } from 'state/sites/selectors';
 import NoAvailableTimes from './shared/no-available-times';
@@ -81,8 +80,7 @@ export class ConciergeMain extends Component {
 			userSettings,
 			nextAppointment,
 			rescheduling,
-			hasAvailableConciergeSessions,
-	} = this.props;
+		} = this.props;
 
 		const CurrentStep = steps[ this.state.currentStep ];
 		const Skeleton = this.props.skeleton;
@@ -144,5 +142,4 @@ export default connect( ( state, props ) => ( {
 	site: getSite( state, props.siteSlug ),
 	scheduleId: getConciergeScheduleId( state ),
 	userSettings: getUserSettings( state ),
-	hasAvailableConciergeSessions: getHasAvailableConciergeSessions( state ),
 } ) )( ConciergeMain );

--- a/client/me/concierge/main.js
+++ b/client/me/concierge/main.js
@@ -27,6 +27,7 @@ import QuerySitePlans from 'components/data/query-site-plans';
 import getConciergeAvailableTimes from 'state/selectors/get-concierge-available-times';
 import getConciergeScheduleId from 'state/selectors/get-concierge-schedule-id';
 import getConciergeNextAppointment from 'state/selectors/get-concierge-next-appointment';
+import getHasAvailableConciergeSessions from 'state/selectors/get-concierge-has-available-sessions';
 import getUserSettings from 'state/selectors/get-user-settings';
 import { getSite } from 'state/sites/selectors';
 import NoAvailableTimes from './shared/no-available-times';
@@ -80,7 +81,8 @@ export class ConciergeMain extends Component {
 			userSettings,
 			nextAppointment,
 			rescheduling,
-		} = this.props;
+			hasAvailableConciergeSessions,
+	} = this.props;
 
 		const CurrentStep = steps[ this.state.currentStep ];
 		const Skeleton = this.props.skeleton;
@@ -142,4 +144,5 @@ export default connect( ( state, props ) => ( {
 	site: getSite( state, props.siteSlug ),
 	scheduleId: getConciergeScheduleId( state ),
 	userSettings: getUserSettings( state ),
+	hasAvailableConciergeSessions: getHasAvailableConciergeSessions( state ),
 } ) )( ConciergeMain );

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -86,7 +86,7 @@ class CurrentPlan extends Component {
 
 	isLoading() {
 		const { selectedSite, isRequestingSitePlans: isRequestingPlans, hasAvailableConciergeSessions } = this.props;
-		console.log('hasAvailableConciergeSessions', hasAvailableConciergeSessions);
+
 		return ! selectedSite || isRequestingPlans || hasAvailableConciergeSessions === null;
 	}
 

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -85,9 +85,13 @@ class CurrentPlan extends Component {
 	}
 
 	isLoading() {
-		const { selectedSite, isRequestingSitePlans: isRequestingPlans, hasAvailableConciergeSessions } = this.props;
+		const {
+			selectedSite,
+			isRequestingSitePlans: isRequestingPlans,
+			hasAvailableConciergeSessions,
+		} = this.props;
 
-		return ! selectedSite || isRequestingPlans || hasAvailableConciergeSessions === null;
+		return ! selectedSite || isRequestingPlans || null === hasAvailableConciergeSessions;
 	}
 
 	renderThankYou() {

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -49,8 +49,8 @@ import AntiSpamProductThankYou from './current-plan-thank-you/anti-spam-thank-yo
 import SearchProductThankYou from './current-plan-thank-you/search-thank-you';
 import { isFreeJetpackPlan, isFreePlan } from 'lib/products-values';
 import { getSitePurchases } from 'state/purchases/selectors';
-import getHasAvailableConciergeSessions from 'state/selectors/get-concierge-has-available-sessions';
 import QueryConciergeInitial from 'components/data/query-concierge-initial';
+import getConciergeScheduleId from 'state/selectors/get-concierge-schedule-id';
 
 /**
  * Style dependencies
@@ -85,9 +85,9 @@ class CurrentPlan extends Component {
 	}
 
 	isLoading() {
-		const { selectedSite, isRequestingSitePlans: isRequestingPlans, hasAvailableConciergeSessions } = this.props;
-		console.log('hasAvailableConciergeSessions', hasAvailableConciergeSessions);
-		return ! selectedSite || isRequestingPlans || hasAvailableConciergeSessions === null;
+		const { selectedSite, isRequestingSitePlans: isRequestingPlans, scheduleId } = this.props;
+
+		return ! selectedSite || isRequestingPlans || null === scheduleId;
 	}
 
 	renderThankYou() {
@@ -161,7 +161,10 @@ class CurrentPlan extends Component {
 					headerText={ translate( 'Plans' ) }
 					align="left"
 				/>
-				{ selectedSiteId && <QueryConciergeInitial siteId={ selectedSiteId } /> }
+				{ selectedSiteId && (
+					// key={ selectedSiteId } ensures data is refetched for changing selectedSiteId
+					<QueryConciergeInitial key={ selectedSiteId } siteId={ selectedSiteId } />
+				) }
 				<QuerySites siteId={ selectedSiteId } />
 				<QuerySitePlans siteId={ selectedSiteId } />
 				<QuerySitePurchases siteId={ selectedSiteId } />
@@ -261,6 +264,6 @@ export default connect( ( state, { requestThankYou } ) => {
 		shouldShowDomainWarnings: ! isJetpack || isAutomatedTransfer,
 		showJetpackChecklist: isJetpackNotAtomic,
 		showThankYou: requestThankYou && isJetpackNotAtomic,
-		hasAvailableConciergeSessions: getHasAvailableConciergeSessions( state ),
+		scheduleId: getConciergeScheduleId( state ),
 	};
 } )( localize( CurrentPlan ) );

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -49,6 +49,8 @@ import AntiSpamProductThankYou from './current-plan-thank-you/anti-spam-thank-yo
 import SearchProductThankYou from './current-plan-thank-you/search-thank-you';
 import { isFreeJetpackPlan, isFreePlan } from 'lib/products-values';
 import { getSitePurchases } from 'state/purchases/selectors';
+import getHasAvailableConciergeSessions from 'state/selectors/get-concierge-has-available-sessions';
+import QueryConciergeInitial from 'components/data/query-concierge-initial';
 
 /**
  * Style dependencies
@@ -83,9 +85,9 @@ class CurrentPlan extends Component {
 	}
 
 	isLoading() {
-		const { selectedSite, isRequestingSitePlans: isRequestingPlans } = this.props;
-
-		return ! selectedSite || isRequestingPlans;
+		const { selectedSite, isRequestingSitePlans: isRequestingPlans, hasAvailableConciergeSessions } = this.props;
+		console.log('hasAvailableConciergeSessions', hasAvailableConciergeSessions);
+		return ! selectedSite || isRequestingPlans || hasAvailableConciergeSessions === null;
 	}
 
 	renderThankYou() {
@@ -159,6 +161,7 @@ class CurrentPlan extends Component {
 					headerText={ translate( 'Plans' ) }
 					align="left"
 				/>
+				{ selectedSiteId && <QueryConciergeInitial siteId={ selectedSiteId } /> }
 				<QuerySites siteId={ selectedSiteId } />
 				<QuerySitePlans siteId={ selectedSiteId } />
 				<QuerySitePurchases siteId={ selectedSiteId } />
@@ -258,5 +261,6 @@ export default connect( ( state, { requestThankYou } ) => {
 		shouldShowDomainWarnings: ! isJetpack || isAutomatedTransfer,
 		showJetpackChecklist: isJetpackNotAtomic,
 		showThankYou: requestThankYou && isJetpackNotAtomic,
+		hasAvailableConciergeSessions: getHasAvailableConciergeSessions( state ),
 	};
 } )( localize( CurrentPlan ) );

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -85,13 +85,9 @@ class CurrentPlan extends Component {
 	}
 
 	isLoading() {
-		const {
-			selectedSite,
-			isRequestingSitePlans: isRequestingPlans,
-			hasAvailableConciergeSessions,
-		} = this.props;
-
-		return ! selectedSite || isRequestingPlans || null === hasAvailableConciergeSessions;
+		const { selectedSite, isRequestingSitePlans: isRequestingPlans, hasAvailableConciergeSessions } = this.props;
+		console.log('hasAvailableConciergeSessions', hasAvailableConciergeSessions);
+		return ! selectedSite || isRequestingPlans || hasAvailableConciergeSessions === null;
 	}
 
 	renderThankYou() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR removes the **Quick Start session** feature from Business  My Plan page. See pbBQWj-eI-p2 for more details.
This doesn't apply to current plans (before 07-31-2020) until their next renewal.

<img width="460" alt="88524080-931e4280-d001-11ea-82f4-c24eb45bf867" src="https://user-images.githubusercontent.com/2749938/88548969-6fbabe00-d028-11ea-8436-dfe6b43d863f.png">


#### Testing instructions

##### New plan
* Subscribe to a new business plan.
* Go to [/plans/my-plan](https://wordpress.com/plans/my-plan)
* There shouldn't be any **Quick Start session** section

<img width="460" src="https://user-images.githubusercontent.com/2749938/88549854-7a298780-d029-11ea-9cd7-83b4309de81e.png">

##### New plan with purchased QS session
* Use a site with a new plan (created after 07-31-2020) with a pre-purchased QS (or purchase one [here](https://wordpress.com/checkout/offer-support-session))
* Go to [/plans/my-plan](https://wordpress.com/plans/my-plan)
* The **Quick Start session** section should now be visible

##### Old plan 
* Select a previously created business plan
* Go to [/plans/my-plan](https://wordpress.com/plans/my-plan)
* The **Quick Start session** section should be visible