### PR TITLE
i18n: add context to copy in duplicate product notice

### DIFF
--- a/client/my-sites/checkout/checkout/duplicate-product-notice-content.tsx
+++ b/client/my-sites/checkout/checkout/duplicate-product-notice-content.tsx
@@ -46,6 +46,7 @@ const DuplicateProductNoticeContent: FunctionComponent< Props > = ( { product, s
 						args: {
 							product: product.productName,
 						},
+						comment: 'The `product` variable refers to the product the customer owns already',
 						components: {
 							link: <a href={ subscriptionUrl } />,
 						},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds some context to the copy of `DuplicateProductNoticeContent` for translation purpose.

#### Testing instructions

The update is really straightforward. If you want to check that the notice still appears correctly, refer to the instructions in #44181.