### PR TITLE
Adds reskinning signup flow for domains step

### DIFF
--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -61,6 +61,7 @@ class DomainRegistrationSuggestion extends React.Component {
 		unavailableDomains: PropTypes.array,
 		productCost: PropTypes.string,
 		productSaleCost: PropTypes.string,
+		isReskinned: PropTypes.bool,
 	};
 
 	componentDidMount() {

--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -59,6 +59,7 @@ class DomainSearchResults extends React.Component {
 		fetchAlgo: PropTypes.string,
 		pendingCheckSuggestion: PropTypes.object,
 		unavailableDomains: PropTypes.array,
+		isReskinned: PropTypes.bool,
 	};
 
 	componentDidUpdate() {

--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -24,6 +24,7 @@ import { getDesignType } from 'state/signup/steps/design-type/selectors';
 import { DESIGN_TYPE_STORE } from 'signup/constants';
 import { hideSitePreview } from 'state/signup/preview/actions';
 import { isSitePreviewVisible } from 'state/signup/preview/selectors';
+import { getABTestVariation } from 'lib/abtest';
 
 /**
  * Style dependencies
@@ -224,7 +225,7 @@ class DomainSearchResults extends React.Component {
 	}
 
 	renderDomainSuggestions() {
-		const { isDomainOnly, suggestions } = this.props;
+		const { isDomainOnly, suggestions, isReskinned } = this.props;
 		let suggestionCount;
 		let featuredSuggestionElement;
 		let suggestionElements;
@@ -290,6 +291,7 @@ class DomainSearchResults extends React.Component {
 						unavailableDomains={ this.props.unavailableDomains }
 						isEligibleVariantForDomainTest={ this.props.isEligibleVariantForDomainTest }
 						shouldHideFreeDomainExplainer={ this.props.shouldHideFreeDomainExplainer }
+						buttonStyles={ { primary: isReskinned } }
 					/>
 				);
 			} );
@@ -333,6 +335,7 @@ const mapStateToProps = ( state, ownProps ) => {
 		// Set site design type only if we're in signup
 		siteDesignType: ownProps.isSignupStep && getDesignType( state ),
 		isSitePreviewVisible: ownProps.isSignupStep && isSitePreviewVisible( state ),
+		isReskinned: 'reskinned' === getABTestVariation( 'reskinSignupFlow' ),
 	};
 };
 

--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -24,7 +24,6 @@ import { getDesignType } from 'state/signup/steps/design-type/selectors';
 import { DESIGN_TYPE_STORE } from 'signup/constants';
 import { hideSitePreview } from 'state/signup/preview/actions';
 import { isSitePreviewVisible } from 'state/signup/preview/selectors';
-import { getABTestVariation } from 'lib/abtest';
 
 /**
  * Style dependencies
@@ -59,7 +58,6 @@ class DomainSearchResults extends React.Component {
 		fetchAlgo: PropTypes.string,
 		pendingCheckSuggestion: PropTypes.object,
 		unavailableDomains: PropTypes.array,
-		isReskinned: PropTypes.bool,
 	};
 
 	componentDidUpdate() {
@@ -226,7 +224,7 @@ class DomainSearchResults extends React.Component {
 	}
 
 	renderDomainSuggestions() {
-		const { isDomainOnly, suggestions, isReskinned } = this.props;
+		const { isDomainOnly, suggestions } = this.props;
 		let suggestionCount;
 		let featuredSuggestionElement;
 		let suggestionElements;
@@ -292,7 +290,6 @@ class DomainSearchResults extends React.Component {
 						unavailableDomains={ this.props.unavailableDomains }
 						isEligibleVariantForDomainTest={ this.props.isEligibleVariantForDomainTest }
 						shouldHideFreeDomainExplainer={ this.props.shouldHideFreeDomainExplainer }
-						buttonStyles={ { primary: isReskinned } }
 					/>
 				);
 			} );
@@ -336,7 +333,6 @@ const mapStateToProps = ( state, ownProps ) => {
 		// Set site design type only if we're in signup
 		siteDesignType: ownProps.isSignupStep && getDesignType( state ),
 		isSitePreviewVisible: ownProps.isSignupStep && isSitePreviewVisible( state ),
-		isReskinned: 'reskinned' === getABTestVariation( 'reskinSignupFlow' ),
 	};
 };
 

--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -7,6 +7,7 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
 import { get, includes, times, first } from 'lodash';
+import { isMobile } from '@automattic/viewport';
 
 /**
  * Internal dependencies
@@ -24,6 +25,7 @@ import { getDesignType } from 'state/signup/steps/design-type/selectors';
 import { DESIGN_TYPE_STORE } from 'signup/constants';
 import { hideSitePreview } from 'state/signup/preview/actions';
 import { isSitePreviewVisible } from 'state/signup/preview/selectors';
+import { getABTestVariation } from 'lib/abtest';
 
 /**
  * Style dependencies
@@ -224,7 +226,8 @@ class DomainSearchResults extends React.Component {
 	}
 
 	renderDomainSuggestions() {
-		const { isDomainOnly, suggestions } = this.props;
+		const { isDomainOnly, suggestions, isReskinned } = this.props;
+		const isReskinnedAndNotOnMobile = isReskinned && ! isMobile();
 		let suggestionCount;
 		let featuredSuggestionElement;
 		let suggestionElements;
@@ -290,6 +293,7 @@ class DomainSearchResults extends React.Component {
 						unavailableDomains={ this.props.unavailableDomains }
 						isEligibleVariantForDomainTest={ this.props.isEligibleVariantForDomainTest }
 						shouldHideFreeDomainExplainer={ this.props.shouldHideFreeDomainExplainer }
+						buttonStyles={ { primary: isReskinnedAndNotOnMobile } }
 					/>
 				);
 			} );
@@ -333,6 +337,7 @@ const mapStateToProps = ( state, ownProps ) => {
 		// Set site design type only if we're in signup
 		siteDesignType: ownProps.isSignupStep && getDesignType( state ),
 		isSitePreviewVisible: ownProps.isSignupStep && isSitePreviewVisible( state ),
+		isReskinned: 'reskinned' === getABTestVariation( 'reskinSignupFlow' ),
 	};
 };
 

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -271,6 +271,8 @@ body.is-section-signup.is-white-signup {
 	}
 
 	.domain-suggestion {
+		$accent-blue: #117ac9;
+
 		&:not( .featured-domain-suggestion ) {
 			transition: none;
 
@@ -279,6 +281,12 @@ body.is-section-signup.is-white-signup {
 					&.domain-suggestion__content-domain-copy-test {
 						justify-content: space-between;
 					}
+				}
+			}
+
+			.domain-registration-suggestion__domain-title {
+				.domain-registration-suggestion__domain-title-tld {
+					color: $accent-blue;
 				}
 			}
 

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -296,7 +296,9 @@ body.is-section-signup.is-white-signup {
 				box-shadow: 0 0 0 1px var( --color-primary-40 );
 
 				.domain-suggestion__action {
+					border-radius: 4px;
 					display: block;
+					padding: 0.85em 1.7em;
 				}
 
 				.domain-product-price {

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -252,3 +252,76 @@
 		}
 	}
 }
+
+body.is-section-signup.is-white-signup {
+	.featured-domain-suggestions {
+		.domain-registration-suggestion__title {
+			@import '~@automattic/typography/styles/fonts';
+			@import '~@automattic/onboarding/styles/mixins';
+			@include onboarding-font-recoleta;
+			font-size: 1.625rem;
+		}
+	}
+
+	.domain-registration-suggestion__progress-bar {
+		.badge {
+			background-color: var( --color-neutral-100 );
+			border-radius: 2px;
+		}
+	}
+
+	.domain-suggestion {
+		&:not( .featured-domain-suggestion ) {
+			transition: none;
+
+			.domain-suggestion__content {
+				@include breakpoint-deprecated( '>660px' ) {
+					&.domain-suggestion__content-domain-copy-test {
+						justify-content: space-between;
+					}
+				}
+			}
+
+			.domain-product-price__free-text {
+				color: var( --color-neutral-60 );
+				font-size: $font-body-small;
+			}
+
+			.domain-product-price__price {
+				color: var( --color-neutral-40 );
+			}
+
+			&.is-clickable:hover {
+				background: var( --color-primary-0 );
+				box-shadow: 0 0 0 1px var( --color-primary-40 );
+
+				.domain-suggestion__action {
+					display: block;
+				}
+
+				.domain-product-price {
+					display: none;
+				}
+			}
+
+			&:not( .domain-transfer-suggestion ) {
+				.domain-suggestion__action {
+					display: none;
+				}
+			}
+	
+			&.domain-transfer-suggestion {
+				$cod-grey: #2b2d2f;
+
+				.domain-suggestion__action {
+					color: $cod-grey;
+					text-decoration-line: underline;
+				}
+				.domain-suggestion__chevron {
+					fill: $cod-grey;
+					margin-left: 0;
+				}
+			}
+		}
+	}
+}

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -274,7 +274,6 @@ body.is-section-signup.is-white-signup {
 	}
 
 	.domain-suggestion {
-		$accent-blue: #117ac9;
 
 		.domain-product-price__free-text {
 			color: var( --color-neutral-60 );
@@ -302,7 +301,7 @@ body.is-section-signup.is-white-signup {
 			.domain-registration-suggestion__domain-title {
 				line-height: 3rem;
 				.domain-registration-suggestion__domain-title-tld {
-					color: $accent-blue;
+					color: var( --color-accent );
 				}
 			}
 

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -276,6 +276,19 @@ body.is-section-signup.is-white-signup {
 	.domain-suggestion {
 		$accent-blue: #117ac9;
 
+		.domain-product-price__free-text {
+			color: var( --color-neutral-60 );
+			font-size: $font-body;
+		}
+
+		.domain-product-price__price {
+			font-size: $font-body-small;
+
+			&:not( .domain-product-price__free-price ) {
+				color: var( --color-neutral-40 );
+			}
+		}
+
 		&:not( .featured-domain-suggestion ) {
 
 			.domain-suggestion__content {
@@ -287,21 +300,25 @@ body.is-section-signup.is-white-signup {
 			}
 
 			.domain-registration-suggestion__domain-title {
-				line-height: 40px;
+				line-height: 3rem;
 				.domain-registration-suggestion__domain-title-tld {
 					color: $accent-blue;
 				}
 			}
 
 			.domain-product-price__free-text {
-				color: var( --color-neutral-60 );
-				font-size: $font-body-small;
+				font-size: $font-body;
+				
+				@include break-mobile {
+					font-size: $font-body-small;
+				}
 			}
 
 			.domain-product-price__price {
 				font-size: $font-body-small;
-				&:not( .domain-product-price__free-price ) {
-					color: var( --color-neutral-40 );
+
+				@include break-mobile {
+					font-size: $font-body-extra-small;
 				}
 			}
 

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -352,8 +352,6 @@ body.is-section-signup.is-white-signup {
 				.domain-suggestion__action {
 					@include break-mobile {
 						display: none;
-						background: $accent-blue;
-						color: var( --color-surface );
 					}
 				}
 			}

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -1,3 +1,6 @@
+@import '~@wordpress/base-styles/breakpoints';
+@import '~@wordpress/base-styles/mixins';
+
 .domain-suggestion:not( .featured-domain-suggestion ) {
 	display: flex;
 	flex-direction: column;
@@ -316,7 +319,11 @@ body.is-section-signup.is-white-signup {
 
 			&:not( .domain-transfer-suggestion ) {
 				.domain-suggestion__action {
-					display: none;
+					@include break-mobile {
+						display: none;
+						background: $accent-blue;
+						color: var( --color-surface );
+					}
 				}
 			}
 	

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -331,18 +331,20 @@ body.is-section-signup.is-white-signup {
 			}
 
 			&.is-clickable:hover {
-				background: var( --color-primary-0 );
-				box-shadow: 0 0 0 1px var( --color-primary-40 );
+				@include break-mobile {
+					background: var( --color-primary-0 );
+					box-shadow: 0 0 0 1px var( --color-primary-40 );
 
-				.domain-suggestion__action:not( .is-borderless ) {
-					border-radius: 4px;
-					display: block;
-					line-height: 17px;
-					padding: 11px 24px 10px;
-				}
+					.domain-suggestion__action:not( .is-borderless ) {
+						border-radius: 4px;
+						display: block;
+						line-height: 17px;
+						padding: 11px 24px 10px;
+					}
 
-				.domain-product-price {
-					display: none;
+					.domain-product-price {
+						display: none;
+					}
 				}
 			}
 

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -306,6 +306,14 @@ body.is-section-signup.is-white-signup {
 				}
 			}
 
+			.domain-product-price__free-price {
+				font-size: $font-body;
+				
+				@include break-mobile {
+					font-size: $font-body-small;
+				}
+			}
+
 			.domain-product-price__free-text {
 				font-size: $font-body;
 				
@@ -314,7 +322,7 @@ body.is-section-signup.is-white-signup {
 				}
 			}
 
-			.domain-product-price__price {
+			.domain-product-price__price:not( .domain-product-price__free-price ) {
 				font-size: $font-body-small;
 
 				@include break-mobile {

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -277,7 +277,6 @@ body.is-section-signup.is-white-signup {
 		$accent-blue: #117ac9;
 
 		&:not( .featured-domain-suggestion ) {
-			transition: none;
 
 			.domain-suggestion__content {
 				@include breakpoint-deprecated( '>660px' ) {
@@ -288,6 +287,7 @@ body.is-section-signup.is-white-signup {
 			}
 
 			.domain-registration-suggestion__domain-title {
+				line-height: 40px;
 				.domain-registration-suggestion__domain-title-tld {
 					color: $accent-blue;
 				}
@@ -299,17 +299,21 @@ body.is-section-signup.is-white-signup {
 			}
 
 			.domain-product-price__price {
-				color: var( --color-neutral-40 );
+				font-size: $font-body-small;
+				&:not( .domain-product-price__free-price ) {
+					color: var( --color-neutral-40 );
+				}
 			}
 
 			&.is-clickable:hover {
 				background: var( --color-primary-0 );
 				box-shadow: 0 0 0 1px var( --color-primary-40 );
 
-				.domain-suggestion__action {
+				.domain-suggestion__action:not( .is-borderless ) {
 					border-radius: 4px;
 					display: block;
-					padding: 0.85em 1.7em;
+					line-height: 17px;
+					padding: 11px 24px 10px;
 				}
 
 				.domain-product-price {

--- a/client/components/domains/example-domain-suggestions/style.scss
+++ b/client/components/domains/example-domain-suggestions/style.scss
@@ -39,3 +39,21 @@
 		margin: 0 auto;
 	}
 }
+
+body.is-section-signup.is-white-signup {
+	.example-domain-suggestions {
+		max-width: 678px;
+
+		p {
+			text-align: left;
+		}
+		.example-domain-suggestions__explanation {
+			color: var( --color-neutral-40 );
+		}
+		.example-domain-suggestions__mapping-information {
+			a {
+				color: var( --color-neutral-60 );
+			}
+		}
+	}
+}

--- a/client/components/domains/free-domain-explainer/index.jsx
+++ b/client/components/domains/free-domain-explainer/index.jsx
@@ -8,6 +8,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import { Button } from '@automattic/components';
+import { getABTestVariation } from 'lib/abtest';
 
 /**
  * Style dependencies
@@ -23,6 +24,7 @@ class FreeDomainExplainer extends React.Component {
 
 	render() {
 		const { translate } = this.props;
+		const isReskinned = 'reskinned' === getABTestVariation( 'reskinSignupFlow' );
 
 		return (
 			<div className="free-domain-explainer card is-compact">
@@ -42,7 +44,7 @@ class FreeDomainExplainer extends React.Component {
 							className="free-domain-explainer__subtitle-link"
 							onClick={ this.handleClick }
 						>
-							{ translate( 'Review our plans to get started' ) } &raquo;
+							{ translate( 'Review our plans to get started' ) } { ! isReskinned && <>&raquo;</> }
 						</Button>
 					</p>
 				</header>

--- a/client/components/domains/free-domain-explainer/index.jsx
+++ b/client/components/domains/free-domain-explainer/index.jsx
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import { localize } from 'i18n-calypso';
+import { omit } from 'lodash';
 
 /**
  * Internal dependencies
@@ -22,8 +23,26 @@ class FreeDomainExplainer extends React.Component {
 		this.props.onSkip( undefined, hideFreePlan );
 	};
 
+	/**
+	 * Wraps content in a <span> if the user is assigned the
+	 * `reskinned` group of the `reskinSignupFlow` a/b test.
+	 * If not, renders the content in a <p> as the default.
+	 *
+	 * @param {*} props Props passed to the <p> or <span>
+	 */
+	TextWrapper( props ) {
+		const { isReskinned } = props;
+		props = omit( props, 'isReskinned' );
+		return isReskinned ? (
+			<span { ...props }>{ props.children }</span>
+		) : (
+			<p { ...props }>{ props.children }</p>
+		);
+	}
+
 	render() {
 		const { translate } = this.props;
+		const { TextWrapper } = this;
 		const isReskinned = 'reskinned' === getABTestVariation( 'reskinSignupFlow' );
 
 		return (
@@ -32,12 +51,12 @@ class FreeDomainExplainer extends React.Component {
 					<h1 className="free-domain-explainer__title">
 						{ translate( 'Get a free one-year domain registration with any paid plan.' ) }
 					</h1>
-					<p className="free-domain-explainer__subtitle">
+					<TextWrapper isReskinned={ isReskinned } className="free-domain-explainer__subtitle">
 						{ translate(
 							"We'll pay the registration fees for your new domain when you choose a paid plan during the next step."
 						) }
-					</p>
-					<p className="free-domain-explainer__subtitle">
+					</TextWrapper>
+					<TextWrapper isReskinned={ isReskinned } className="free-domain-explainer__subtitle">
 						{ translate( "You can claim your free custom domain later if you aren't ready yet." ) }
 						<Button
 							borderless
@@ -46,7 +65,7 @@ class FreeDomainExplainer extends React.Component {
 						>
 							{ translate( 'Review our plans to get started' ) } { ! isReskinned && <>&raquo;</> }
 						</Button>
-					</p>
+					</TextWrapper>
 				</header>
 			</div>
 		);

--- a/client/components/domains/free-domain-explainer/style.scss
+++ b/client/components/domains/free-domain-explainer/style.scss
@@ -1,3 +1,6 @@
+@import '~@wordpress/base-styles/breakpoints';
+@import '~@wordpress/base-styles/mixins';
+
 .free-domain-explainer__title {
 
     color: var( --color-text );
@@ -24,5 +27,26 @@
         margin-left: 0.3em;
         text-decoration: underline;
         vertical-align: baseline;
+    }
+}
+
+body.is-section-signup.is-white-signup {
+    .free-domain-explainer {
+        @include break-mobile {
+            margin-bottom: 1em;
+        }
+
+        .free-domain-explainer__subtitle {
+            color: var( --color-neutral-60 );
+            font-size: 1rem;
+            margin-bottom: 0;
+
+            .free-domain-explainer__subtitle-link {
+                display: block;
+                color: var( --color-neutral-60 );
+                font-weight: 400;
+                margin: 0;
+            }
+        }
     }
 }

--- a/client/components/domains/free-domain-explainer/style.scss
+++ b/client/components/domains/free-domain-explainer/style.scss
@@ -41,6 +41,15 @@ body.is-section-signup.is-white-signup {
             font-size: 1rem;
             margin-bottom: 0;
 
+            &::after {
+                content: ' ';
+                
+                @include break-mobile {
+                    content: '\a';
+                    white-space: pre;
+                }
+            }
+
             .free-domain-explainer__subtitle-link {
                 display: block;
                 color: var( --color-neutral-60 );

--- a/client/components/domains/search-filters/style.scss
+++ b/client/components/domains/search-filters/style.scss
@@ -1,3 +1,6 @@
+@import '~@wordpress/base-styles/breakpoints';
+@import '~@wordpress/base-styles/mixins';
+
 .search-filters__dropdown-filters {
 	align-items: center;
 	border-left: 1px solid var( --color-neutral-10 );
@@ -212,6 +215,14 @@
 		color: var( --color-neutral-70 );
 		&.is-selected span {
 			color: var( --color-text-inverted );
+		}
+	}
+}
+
+body.is-section-signup.is-white-signup {
+	.search-filters-extensions__popover {
+		@include break-medium {
+			transform: translateX( 65px );
 		}
 	}
 }

--- a/client/components/domains/search-filters/style.scss
+++ b/client/components/domains/search-filters/style.scss
@@ -220,9 +220,23 @@
 }
 
 body.is-section-signup.is-white-signup {
+	$accent-blue: #117ac9;
 	.search-filters-extensions__popover {
 		@include break-medium {
 			transform: translateX( 65px );
+		}
+
+		.token-field__suggestion {
+			&.is-selected {
+				background: $accent-blue;
+			}
+		}
+	}
+	.search-filters__popover-button {
+		&.is-active {
+			background: initial;
+			color: $accent-blue;
+			border-color: $accent-blue;
 		}
 	}
 }

--- a/client/components/domains/search-filters/tld-filter-bar.jsx
+++ b/client/components/domains/search-filters/tld-filter-bar.jsx
@@ -163,11 +163,11 @@ export class TldFilterBar extends Component {
 		return (
 			<Popover
 				autoPosition={ false }
-				className="search-filters__popover"
+				className="search-filters__popover search-filters-extensions__popover"
 				context={ this.button }
 				isVisible={ this.state.showPopover }
 				onClose={ this.handleFiltersSubmit }
-				position="bottom left"
+				position="bottom"
 			>
 				<FormFieldset className="search-filters__token-field-fieldset">
 					<TokenField

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -105,12 +105,6 @@ body.is-section-signup.is-white-signup {
 	}
 
 	.search-filters__popover {
-		width: calc( 100vw - 40px );
-
-		@include break-mobile {
-			width: 28em;
-		}
-
 		.button.is-primary {
 			background: $accent-blue;
 			border-color: $accent-blue;

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -1,3 +1,6 @@
+@import '~@wordpress/base-styles/breakpoints';
+@import '~@wordpress/base-styles/mixins';
+
 .domains__step-section-wrapper {
 	margin: 0 auto;
 	max-width: 720px;
@@ -37,6 +40,83 @@
 		.register-domain-step__search-card,
 		.search.is-open.has-focus {
 			border-radius: 0;
+		}
+	}
+}
+
+/**
+ * Styles for design reskin
+ * The `is-white-signup` class is attached to the body when the user is assigned the `reskinned` group of the `reskinSignupFlow` a/b test
+ */
+body.is-section-signup.is-white-signup {
+
+	$accent-blue: #117ac9;
+	$light-white: #f3f4f5;
+
+	.signup__step.is-domains .formatted-header {
+		margin-bottom: 30px;
+	}
+
+	.domains__step-content {
+		.search.is-open.has-focus {
+			box-shadow: 0 0 0 2px  $accent-blue;
+		}
+		.register-domain-step__search-card {
+			background: $light-white;
+			box-shadow: none;
+			margin: 20px;
+
+			@include break-mobile {
+				margin: initial;
+			}
+		}
+		.search__input {
+			background:  $light-white;
+		}
+		.search.is-open .search__input-fade.ltr::before {
+			display: none;
+		}
+		.search__open-icon {
+			transform: scaleX( -1 );
+		}
+		.search__close-icon {
+			display: none;
+		}
+	}
+
+	.search-filters__dropdown-filters {
+		border: none;
+
+		&.search-filters__dropdown-filters--is-open {
+			box-shadow: none;
+		}
+
+		.button {
+			flex-direction: row;
+
+			&:hover, &:focus {
+				box-shadow: none;
+			}
+
+			.search-filters__dropdown-filters-button-text {
+				padding-left: 6px;
+			}
+		}
+	}
+
+	.search-filters__popover {
+		width: calc( 100vw - 40px );
+
+		@include break-mobile {
+			width: 28em;
+		}
+
+		.button.is-primary {
+			background: $accent-blue;
+			border-color: $accent-blue;
+		}
+		.popover__arrow {
+			display: none;
 		}
 	}
 }

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -60,6 +60,10 @@ body.is-section-signup.is-white-signup {
 	.domains__step-content {
 		.search.is-open.has-focus {
 			box-shadow: 0 0 0 2px  $accent-blue;
+			background: var( --color-surface );
+			.search__input {
+				background: var( --color-surface );
+			}
 		}
 		.register-domain-step__search-card {
 			background: $light-white;

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -95,6 +95,12 @@ body.is-section-signup.is-white-signup {
 			box-shadow: none;
 		}
 
+		&.search-filters__dropdown-filters--has-filter-values {
+			.button.is-borderless {
+				color: $accent-blue;
+			}
+		}
+
 		.button {
 			flex-direction: row;
 

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -50,7 +50,6 @@
  */
 body.is-section-signup.is-white-signup {
 
-	$accent-blue: #117ac9;
 	$light-white: #f3f4f5;
 
 	.signup__step.is-domains .formatted-header {
@@ -59,7 +58,7 @@ body.is-section-signup.is-white-signup {
 
 	.domains__step-content {
 		.search.is-open.has-focus {
-			box-shadow: 0 0 0 2px  $accent-blue;
+			box-shadow: 0 0 0 2px  var( --color-accent );
 			background: var( --color-surface );
 			.search__input {
 				background: var( --color-surface );
@@ -95,12 +94,6 @@ body.is-section-signup.is-white-signup {
 			box-shadow: none;
 		}
 
-		&.search-filters__dropdown-filters--has-filter-values {
-			.button.is-borderless {
-				color: $accent-blue;
-			}
-		}
-
 		.button {
 			flex-direction: row;
 
@@ -115,6 +108,7 @@ body.is-section-signup.is-white-signup {
 	}
 
 	.search-filters__popover {
+		$accent-blue: #117ac9;
 		.button.is-primary {
 			background: $accent-blue;
 			border-color: $accent-blue;

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -493,7 +493,7 @@ body.is-section-signup.is-white-signup .signup.is-onboarding {
 		}
 	}
 
-	button.is-primary {
+	button.is-primary:not( .is-busy ) {
 		background: #117ac9;
 		box-shadow: none;
 		border: 0;

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -433,11 +433,10 @@ body.is-section-signup.is-white-signup .signup.is-onboarding {
 	$gray-100: #101517;
 	$gray-60: #50575e;
 	$gray-50: #646970;
-	$accent-blue: #117ac9;
-	$accent-blue-60: #0e64a5;
 	$breakpoint-mobile: 660px;
 
 	--color-accent: #117ac9;
+	--color-accent-60: #0e64a5;
 
 	.signup-header .wordpress-logo {
 		position: absolute;
@@ -495,23 +494,9 @@ body.is-section-signup.is-white-signup .signup.is-onboarding {
 		}
 	}
 
-	button.is-primary:not( .is-busy ) {
-		background: $accent-blue;
+	button.is-primary {
 		box-shadow: none;
 		border: 0;
 	}
 
-	button.is-primary {
-		&.is-busy {
-			background-size: 120px 100%;
-			background-image: linear-gradient(
-				-45deg,
-				$accent-blue 28%,
-				$accent-blue-60 28%,
-				$accent-blue-60 72%,
-				$accent-blue 72%
-				);
-			}
-			border-color: $accent-blue;
-	}
 }

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -498,5 +498,4 @@ body.is-section-signup.is-white-signup .signup.is-onboarding {
 		box-shadow: none;
 		border: 0;
 	}
-
 }

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -433,6 +433,8 @@ body.is-section-signup.is-white-signup .signup.is-onboarding {
 	$gray-100: #101517;
 	$gray-60: #50575e;
 	$gray-50: #646970;
+	$accent-blue: #117ac9;
+	$accent-blue-60: #0e64a5;
 	$breakpoint-mobile: 660px;
 
 	--color-accent: #117ac9;
@@ -494,8 +496,22 @@ body.is-section-signup.is-white-signup .signup.is-onboarding {
 	}
 
 	button.is-primary:not( .is-busy ) {
-		background: #117ac9;
+		background: $accent-blue;
 		box-shadow: none;
 		border: 0;
+	}
+
+	button.is-primary {
+		&.is-busy {
+			background-size: 120px 100%;
+			background-image: linear-gradient(
+				-45deg,
+				$accent-blue 28%,
+				$accent-blue-60 28%,
+				$accent-blue-60 72%,
+				$accent-blue 72%
+				);
+			}
+			border-color: $accent-blue;
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds redesigned domains step screen to the reskinning signup flow project. More details can be found in #44223

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /start/new
* Make sure you're assigned to the reskinned group of reskinSignupFlow a/b test.
* Follow the signup flow till you are on the domains step.
* The screens should look like these:

Domain (unfocused)
![Domain (unfocused)](https://user-images.githubusercontent.com/5436027/88649147-414ee880-d0e5-11ea-8f96-314642a5f500.jpg)
Domain (focused)
![Domain (focused)](https://user-images.githubusercontent.com/5436027/88649132-3dbb6180-d0e5-11ea-9586-f6ed93693ee6.jpg)
Filters
![unfocused)](https://user-images.githubusercontent.com/5436027/88649304-62afd480-d0e5-11ea-990d-4f00102bb270.jpg)
Domain (extensions)
![Domain (extensions)](https://user-images.githubusercontent.com/5436027/88649428-79562b80-d0e5-11ea-8540-4a0e18926a44.jpg)
Domain (options)
![Domain (options)](https://user-images.githubusercontent.com/5436027/88649452-7eb37600-d0e5-11ea-8ba8-c8d6ff0a01b2.jpg)
Domain (search)
![Domain (search)](https://user-images.githubusercontent.com/5436027/88649461-81ae6680-d0e5-11ea-87ed-46872cb2e40b.jpg)
Domain (selection hover)
![Domain (selection hover)](https://user-images.githubusercontent.com/5436027/88649462-8246fd00-d0e5-11ea-9dbc-697d556c0c53.jpg)


