### PR TITLE
Composite checkout: Hide alternate email when G Suite is not in cart

### DIFF
--- a/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.jsx
+++ b/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.jsx
@@ -58,6 +58,7 @@ export class ManagedContactDetailsFormFields extends Component {
 		getIsFieldDisabled: PropTypes.func,
 		userCountryCode: PropTypes.string,
 		needsOnlyGoogleAppsDetails: PropTypes.bool,
+		needsAlternateEmailForGSuite: PropTypes.bool,
 		hasCountryStates: PropTypes.bool,
 		translate: PropTypes.func,
 	};
@@ -71,6 +72,7 @@ export class ManagedContactDetailsFormFields extends Component {
 		getIsFieldDisabled: () => {},
 		onContactDetailsChange: () => {},
 		needsOnlyGoogleAppsDetails: false,
+		needsAlternateEmailForGSuite: false,
 		hasCountryStates: false,
 		translate: ( x ) => x,
 		userCountryCode: 'US',
@@ -366,7 +368,7 @@ export class ManagedContactDetailsFormFields extends Component {
 						}
 					) }
 				</div>
-				{ this.props.needsOnlyGoogleAppsDetails && this.renderAlternateEmailFieldForGSuite() }
+				{ this.props.needsAlternateEmailForGSuite && this.renderAlternateEmailFieldForGSuite() }
 
 				{ this.props.needsOnlyGoogleAppsDetails ? (
 					<GSuiteFields

--- a/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.jsx
+++ b/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.jsx
@@ -323,12 +323,24 @@ export class ManagedContactDetailsFormFields extends Component {
 	}
 
 	renderAlternateEmailFieldForGSuite() {
+		let customErrorMessage = this.props.contactDetailsErrors?.alternateEmail;
+		// We also show 'email' field errors because this field will only be shown
+		// if email is invalid (and email will not be shown) so we should show
+		// those errors somewhere. However, only show them if the `alternateEmail`
+		// has not been entered.
+		if (
+			! customErrorMessage &&
+			this.props.contactDetailsErrors?.email &&
+			! this.props.contactDetails?.alternateEmail?.length > 0
+		) {
+			customErrorMessage = this.props.contactDetailsErrors.email;
+		}
 		return (
 			<div className="contact-details-form-fields__row">
 				<Input
 					label={ this.props.translate( 'Alternate email address' ) }
 					{ ...this.getFieldProps( 'alternate-email', {
-						customErrorMessage: this.props.contactDetailsErrors?.alternateEmail,
+						customErrorMessage,
 					} ) }
 				/>
 			</div>

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -372,7 +372,8 @@ export default function WPCheckout( {
 							}
 							completeStepContent={
 								<WPContactFormSummary
-									showDomainContactSummary={ shouldShowDomainContactFields }
+									areThereDomainProductsInCart={ areThereDomainProductsInCart }
+									isGSuiteInCart={ isGSuiteInCart }
 									isLoggedOutCart={ isLoggedOutCart }
 								/>
 							}

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-contact-form-summary.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-contact-form-summary.js
@@ -34,7 +34,12 @@ export default function WPContactFormSummary( { showDomainContactSummary, isLogg
 		contactInfo.postalCode.value,
 		contactInfo.countryCode.value
 	);
-	const showEmailSummary = isLoggedOutCart || showDomainContactSummary;
+
+	const shouldShowEmailSummary =
+		contactInfo.email.value?.length > 0 &&
+		( showDomainContactSummary || isGSuiteInCart ) &&
+		( ! contactInfo.alternateEmail.value?.length > 0 ||
+			contactInfo.alternateEmail.value === contactInfo.email.value );
 
 	return (
 		<GridRow>
@@ -48,9 +53,7 @@ export default function WPContactFormSummary( { showDomainContactSummary, isLogg
 						<SummaryLine>{ contactInfo.organization.value } </SummaryLine>
 					) }
 
-					{ showEmailSummary && contactInfo.email.value?.length > 0 && (
-						<SummaryLine>{ contactInfo.email.value }</SummaryLine>
-					) }
+					{ isLoggedOutCart || shouldShowEmailSummary && <SummaryLine>{ contactInfo.email.value }</SummaryLine> }
 
 					{ isGSuiteInCart && (
 						<AlternateEmailSummary

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-contact-form-summary.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-contact-form-summary.js
@@ -35,12 +35,6 @@ export default function WPContactFormSummary( { showDomainContactSummary, isLogg
 		contactInfo.countryCode.value
 	);
 
-	const shouldShowEmailSummary =
-		contactInfo.email.value?.length > 0 &&
-		( showDomainContactSummary || isGSuiteInCart ) &&
-		( ! contactInfo.alternateEmail.value?.length > 0 ||
-			contactInfo.alternateEmail.value === contactInfo.email.value );
-
 	return (
 		<GridRow>
 			<div>
@@ -53,14 +47,12 @@ export default function WPContactFormSummary( { showDomainContactSummary, isLogg
 						<SummaryLine>{ contactInfo.organization.value } </SummaryLine>
 					) }
 
-					{ isLoggedOutCart || shouldShowEmailSummary && <SummaryLine>{ contactInfo.email.value }</SummaryLine> }
-
-					{ isGSuiteInCart && (
-						<AlternateEmailSummary
-							contactInfo={ contactInfo }
-							showDomainContactSummary={ showDomainContactSummary }
-						/>
-					) }
+					<EmailSummary
+						isLoggedOutCart={ isLoggedOutCart }
+						contactInfo={ contactInfo }
+						showDomainContactSummary={ showDomainContactSummary }
+						isGSuiteInCart={ isGSuiteInCart }
+					/>
 
 					{ showDomainContactSummary && contactInfo.phone.value?.length > 0 && (
 						<SummaryLine>{ contactInfo.phone.value }</SummaryLine>
@@ -101,12 +93,27 @@ function joinNonEmptyValues( joinString, ...values ) {
 	return values.filter( ( value ) => value?.length > 0 ).join( joinString );
 }
 
-function AlternateEmailSummary( { contactInfo, showDomainContactSummary } ) {
-	if ( ! contactInfo.alternateEmail.value?.length ) {
+function EmailSummary( {
+	contactInfo,
+	showDomainContactSummary,
+	isGSuiteInCart,
+	isLoggedOutCart,
+} ) {
+	if ( ! showDomainContactSummary && ! isGSuiteInCart && ! isLoggedOutCart ) {
 		return null;
 	}
-	if ( contactInfo.alternateEmail.value === contactInfo.email.value && showDomainContactSummary ) {
+
+	if ( ! contactInfo.alternateEmail.value && ! contactInfo.email.value ) {
 		return null;
 	}
-	return <SummaryLine>{ contactInfo.alternateEmail.value }</SummaryLine>;
+
+	if ( isGSuiteInCart && contactInfo.alternateEmail.value ) {
+		return <SummaryLine>{ contactInfo.alternateEmail.value }</SummaryLine>;
+	}
+
+	if ( ! contactInfo.email.value ) {
+		return null;
+	}
+
+	return <SummaryLine>{ contactInfo.email.value }</SummaryLine>;
 }

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-contact-form-summary.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-contact-form-summary.js
@@ -52,10 +52,12 @@ export default function WPContactFormSummary( { showDomainContactSummary, isLogg
 						<SummaryLine>{ contactInfo.email.value }</SummaryLine>
 					) }
 
-					{ isGSuiteInCart && <AlternateEmailSummary
-						contactInfo={ contactInfo }
-						showDomainContactSummary={ showDomainContactSummary }
-					/>
+					{ isGSuiteInCart && (
+						<AlternateEmailSummary
+							contactInfo={ contactInfo }
+							showDomainContactSummary={ showDomainContactSummary }
+						/>
+					) }
 
 					{ showDomainContactSummary && contactInfo.phone.value?.length > 0 && (
 						<SummaryLine>{ contactInfo.phone.value }</SummaryLine>

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-contact-form-summary.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-contact-form-summary.js
@@ -52,10 +52,9 @@ export default function WPContactFormSummary( { showDomainContactSummary, isLogg
 						<SummaryLine>{ contactInfo.email.value }</SummaryLine>
 					) }
 
-					<AlternateEmailSummary
+					{ isGSuiteInCart && <AlternateEmailSummary
 						contactInfo={ contactInfo }
 						showDomainContactSummary={ showDomainContactSummary }
-						isGSuiteInCart={ isGSuiteInCart }
 					/>
 
 					{ showDomainContactSummary && contactInfo.phone.value?.length > 0 && (
@@ -97,10 +96,7 @@ function joinNonEmptyValues( joinString, ...values ) {
 	return values.filter( ( value ) => value?.length > 0 ).join( joinString );
 }
 
-function AlternateEmailSummary( { contactInfo, showDomainContactSummary, isGSuiteInCart } ) {
-	if ( ! isGSuiteInCart && ! showDomainContactSummary ) {
-		return null;
-	}
+function AlternateEmailSummary( { contactInfo, showDomainContactSummary } ) {
 	if ( ! contactInfo.alternateEmail.value?.length ) {
 		return null;
 	}

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-contact-form-summary.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-contact-form-summary.js
@@ -55,7 +55,6 @@ export default function WPContactFormSummary( {
 				<AddressSummary
 					contactInfo={ contactInfo }
 					areThereDomainProductsInCart={ areThereDomainProductsInCart }
-					isGSuiteInCart={ isGSuiteInCart }
 				/>
 			</div>
 		</GridRow>
@@ -101,17 +100,14 @@ function EmailSummary( {
 	return <SummaryLine>{ contactInfo.email.value }</SummaryLine>;
 }
 
-function AddressSummary( { contactInfo, areThereDomainProductsInCart, isGSuiteInCart } ) {
-	if ( ! areThereDomainProductsInCart && ! isGSuiteInCart ) {
-		return null;
-	}
+function AddressSummary( { contactInfo, areThereDomainProductsInCart } ) {
 	const postalAndCountry = joinNonEmptyValues(
 		', ',
 		contactInfo.postalCode.value,
 		contactInfo.countryCode.value
 	);
 
-	if ( ! areThereDomainProductsInCart && isGSuiteInCart ) {
+	if ( ! areThereDomainProductsInCart ) {
 		return (
 			<SummaryDetails>
 				{ postalAndCountry && <SummaryLine>{ postalAndCountry }</SummaryLine> }

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-contact-form.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-contact-form.js
@@ -28,6 +28,7 @@ import {
 	hasGoogleApps,
 	hasDomainRegistration,
 	hasTransferProduct,
+	needsExplicitAlternateEmailForGSuite,
 } from 'lib/cart-values/cart-items';
 import { useCart } from 'my-sites/checkout/composite-checkout/cart-provider';
 import { getTopLevelOfTld } from 'lib/domains';
@@ -263,12 +264,16 @@ function DomainContactDetails( {
 		! hasDomainRegistration( responseCart ) &&
 		! hasTransferProduct( responseCart );
 	const getIsFieldDisabled = () => isDisabled;
+	const needsAlternateEmailForGSuite =
+		needsOnlyGoogleAppsDetails &&
+		needsExplicitAlternateEmailForGSuite( responseCart, contactDetails );
 	const tlds = getAllTopLevelTlds( domainNames );
 
 	return (
 		<React.Fragment>
 			<ManagedContactDetailsFormFields
 				needsOnlyGoogleAppsDetails={ needsOnlyGoogleAppsDetails }
+				needsAlternateEmailForGSuite={ needsAlternateEmailForGSuite }
 				contactDetails={ contactDetails }
 				contactDetailsErrors={
 					shouldShowContactDetailsValidationErrors ? contactDetailsErrors : {}

--- a/client/my-sites/checkout/composite-checkout/wpcom/types/backend/domain-contact-validation-endpoint.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/types/backend/domain-contact-validation-endpoint.ts
@@ -28,7 +28,8 @@ export type GSuiteContactValidationRequest = {
 	contact_information: {
 		firstName: string;
 		lastName: string;
-		alternateEmail: string;
+		email?: string;
+		alternateEmail?: string;
 		postalCode: string;
 		countryCode: string;
 	};

--- a/client/my-sites/checkout/composite-checkout/wpcom/types/wpcom-store-state.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/types/wpcom-store-state.ts
@@ -634,8 +634,9 @@ export function prepareGSuiteContactValidationRequest(
 		contact_information: {
 			firstName: details.firstName?.value ?? '',
 			lastName: details.lastName?.value ?? '',
-			...( details.email?.value && { email: details.email?.value } ),
-			...( details.alternateEmail?.value && { email: details.alternateEmail?.value } ),
+			...( details.alternateEmail?.value && { alternateEmail: details.alternateEmail?.value } ),
+			...( ! details.alternateEmail?.value &&
+				details.email?.value && { email: details.email?.value } ),
 			postalCode: tryToGuessPostalCodeFormat(
 				details.postalCode?.value ?? '',
 				details.countryCode?.value

--- a/client/my-sites/checkout/composite-checkout/wpcom/types/wpcom-store-state.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/types/wpcom-store-state.ts
@@ -881,10 +881,7 @@ export const managedContactDetailsUpdaters: ManagedContactDetailsUpdaters = {
 			lastName: setValueUnlessTouched( newDetails.lastName, oldDetails.lastName ),
 			organization: setValueUnlessTouched( newDetails.organization, oldDetails.organization ),
 			email: setValueUnlessTouched( newDetails.email, oldDetails.email ),
-			alternateEmail: setValueUnlessTouched(
-				newDetails.alternateEmail || newDetails.email,
-				oldDetails.alternateEmail
-			),
+			alternateEmail: setValueUnlessTouched( newDetails.alternateEmail, oldDetails.alternateEmail ),
 			phone: setValueUnlessTouched( newDetails.phone, oldDetails.phone ),
 			address1: setValueUnlessTouched( newDetails.address1, oldDetails.address1 ),
 			address2: setValueUnlessTouched( newDetails.address2, oldDetails.address2 ),

--- a/client/my-sites/checkout/composite-checkout/wpcom/types/wpcom-store-state.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/types/wpcom-store-state.ts
@@ -634,7 +634,8 @@ export function prepareGSuiteContactValidationRequest(
 		contact_information: {
 			firstName: details.firstName?.value ?? '',
 			lastName: details.lastName?.value ?? '',
-			alternateEmail: details.alternateEmail?.value ?? '',
+			...( details.email?.value && { email: details.email?.value } ),
+			...( details.alternateEmail?.value && { email: details.alternateEmail?.value } ),
 			postalCode: tryToGuessPostalCodeFormat(
 				details.postalCode?.value ?? '',
 				details.countryCode?.value


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Since the `alternateEmail` field is only used by G Suite (see https://github.com/Automattic/wp-calypso/pull/35920), there's no need to display it when a G Suite product is not currently in the cart. (See also https://github.com/Automattic/wp-calypso/pull/43403 which fixed a tangential issue.)

This PR does the following:

1. Hides the `alternateEmail` field from the contact form inactive step summary when a G Suite product is not in the cart. (Previously it would also be shown if a domain product was in the cart. This new behavior matches old checkout.)
2. Stops pre-populating the `alternateEmail` field. In order to pre-populate the `alternateEmail` field when G Suite is in the cart, we were setting its initial value to match the `email` field's value, if the latter was set and the former was not. 
3. Sends either `email` or `alternateEmail` to the validation endpoint. Previously, we were only sending `alternateEmail`.
4. Displays validation errors for `email` in addition to those from `alternateEmail` on the alternate email field if the validation fails (but only if `alternateEmail` is not edited, in which case it would instead only display `alternateEmail` errors).
5. Hides address and telephone contact info in the summary if a domain product is not in the cart.

Fixes #44426

#### Testing instructions

Testing a plan without a domain or G Suite:

- Add a plan to your cart.
- Visit checkout.
- In the checkout page, click on the "Edit" button next to Contact Information.
- Fill out the postal code and country and click "Continue".
- Verify that the contact step summary shows the postal code and country.

Testing a domain without G Suite:

- For a site you already own, go to Manage -> Domains and click on "Add a domain to this site".
- Search for and select a domain.
- Proceed to checkout.
- In the checkout page, click on the "Edit" button next to Contact Information.
- Update your email address and click on "Continue".
- Verify that only the new email address is shown in the inactive contact information step.

Testing G Suite with a domain:

- Add a G Suite product to your cart with a domain (you can do this by just removing and re-adding the domain which will bring up the G Suite product screen before checkout).
- Verify that the contact information step displays the "Email" field but not the "Alternate email" field.
- Try setting the email field to an address that matches the domain you're registering (eg: for the domain `example.com`, set the address to `me@example.com`).
- Click "Continue" and verify that you receive an error that the email address domain cannot match the domain.
- Change the email address to not match the domain.
- Click "Continue" and verify that you move on to the next step.

Testing G Suite alternate email: 

- Clear your cart.
- For a domain you already own, add a G Suite product to your cart (so that there is no domain in your cart) and visit checkout.
- Verify that the contact information step display no email field (unless your saved email field is invalid).
- Click "Continue" and verify that you move on to the next step.
- Somehow force the saved email field to be invalid. You can do this by applying D47627-code and then customizing the email address to match the domain in your cart.
- Visit checkout again.
- Verify that the contact information step displays the empty "Alternate email" field.
- Click "Continue" and verify that you receive an error that the email address domain cannot match the domain.
- Enter an email address that still matches the domain.
- Click "Continue" and verify that you receive an error that the email address domain cannot match the domain.
- Change the email address to not match the domain.
- Click "Continue" and verify that you move on to the next step.
