### PR TITLE
e2e: Set timeout on some long running optional waits.

### DIFF
--- a/test/e2e/lib/components/secure-payment-component.js
+++ b/test/e2e/lib/components/secure-payment-component.js
@@ -181,7 +181,7 @@ export default class SecurePaymentComponent extends AsyncBaseContainer {
 
 	async payWithStoredCardIfPossible( cardCredentials ) {
 		const storedCardSelector = By.css( '.credit-card__stored-card' );
-		if ( await driverHelper.isEventuallyPresentAndDisplayed( this.driver, storedCardSelector ) ) {
+		if ( await driverHelper.isEventuallyPresentAndDisplayed( this.driver, storedCardSelector, this.explicitWaitMS / 5 ) ) {
 			await driverHelper.clickWhenClickable( this.driver, storedCardSelector );
 		} else {
 			await this.enterTestCreditCardDetails( cardCredentials );

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -467,7 +467,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 
 	async dismissEditorWelcomeModal() {
 		const welcomeModal = By.css( '.components-guide__container' );
-		if ( await driverHelper.isEventuallyPresentAndDisplayed( this.driver, welcomeModal ) ) {
+		if ( await driverHelper.isEventuallyPresentAndDisplayed( this.driver, welcomeModal, this.explicitWaitMS / 5 ) ) {
 			try {
 				// Easiest way to dismiss it, but it might not work in IE.
 				await this.driver.findElement( By.css( '.components-guide' ) ).sendKeys( Key.ESCAPE );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR modifies the timeout times on 2 instances where we're waiting for something that may or may not appear. Rather than waiting the full 20 seconds, we now only wait 4 seconds. That should be plenty of time and will save quite a bit of time in the tests.

#### Testing instructions

* Make sure the tests pass in CI.
