### PR TITLE
Add new availability message

### DIFF
--- a/client/lib/domains/constants.js
+++ b/client/lib/domains/constants.js
@@ -25,6 +25,7 @@ export const domainAvailability = {
 	AVAILABLE: 'available',
 	AVAILABLE_PREMIUM: 'available_premium',
 	AVAILABILITY_CHECK_ERROR: 'availability_check_error',
+	CONFLICTING_CNAME_EXISTS: 'conflicting_cname_exists',
 	DISALLOWED: 'blacklisted_domain',
 	DOMAIN_SUGGESTIONS_THROTTLED: 'domain_suggestions_throttled',
 	DOTBLOG_SUBDOMAIN: 'dotblog_subdomain',

--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -97,6 +97,18 @@ function getAvailabilityNotice( domain, error, errorData ) {
 				}
 			);
 			break;
+		case domainAvailability.CONFLICTING_CNAME_EXISTS:
+			message = translate(
+				'There is an existing CNAME for {{strong}}%(domain)s{{/strong}}. If you want to map this subdomain, you should remove the conflicting CNAME DNS record first.',
+				{
+					args: { domain },
+					components: {
+						strong: <strong />,
+						a: <a rel="noopener noreferrer" href={ domainTransferIn( site, domain ) } />,
+					},
+				}
+			);
+			break;
 		case domainAvailability.MAPPED_SAME_SITE_TRANSFERRABLE:
 			message = translate(
 				'{{strong}}%(domain)s{{/strong}} is already connected to this site, but registered somewhere else. Do you want to move ' +

--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -104,7 +104,6 @@ function getAvailabilityNotice( domain, error, errorData ) {
 					args: { domain },
 					components: {
 						strong: <strong />,
-						a: <a rel="noopener noreferrer" href={ domainTransferIn( site, domain ) } />,
 					},
 				}
 			);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update the error message shown when attempting purchase a mapping for a subdomain that has a pre-existing conflicting CNAME record.

#### Testing instructions

* Apply D46527-code
* Create a CNAME record for a domain that you own (ex. foo.example.com)
* Attempt to purchase a mapping for the subdomain
* Make sure that the correct error message is shown:
<img width="1069" alt="Screen_Shot_2020-07-17_at_1_34_09_PM" src="https://user-images.githubusercontent.com/1379730/87821637-260af000-c83e-11ea-8b0c-3c8c5fb51139.png">

