### PR TITLE
Checkout: Do not display contact details form if the cart is only renewals

### DIFF
--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-contact-form.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-contact-form.js
@@ -19,13 +19,20 @@ import debugFactory from 'debug';
 /**
  * Internal dependencies
  */
-import { useHasDomainsInCart, useDomainNamesInCart } from '../hooks/has-domains';
+import { useDomainNamesInCart } from '../hooks/has-domains';
 import Field from './field';
 import { SummaryLine, SummaryDetails } from './summary-details';
 import { LeftColumn, RightColumn } from './ie-fallback';
 import { prepareDomainContactDetails, prepareDomainContactDetailsErrors, isValid } from '../types';
 import getContactDetailsCache from 'state/selectors/get-contact-details-cache';
 import { isGSuiteProductSlug } from 'lib/gsuite';
+import {
+	hasGoogleApps,
+	hasDomainRegistration,
+	hasOnlyRenewalItems,
+	hasTransferProduct,
+} from 'lib/cart-values/cart-items';
+import { useCart } from 'my-sites/checkout/composite-checkout/cart-provider';
 
 const debug = debugFactory( 'calypso:composite-checkout:wp-contact-form' );
 
@@ -41,7 +48,6 @@ export default function WPContactForm( {
 } ) {
 	const translate = useTranslate();
 	const [ items ] = useLineItems();
-	const isDomainFieldsVisible = useHasDomainsInCart();
 	const isGSuiteInCart = items.some( ( item ) =>
 		isGSuiteProductSlug( item.wpcom_meta?.product_slug )
 	);
@@ -49,12 +55,14 @@ export default function WPContactForm( {
 	const { formStatus } = useFormStatus();
 	const isStepActive = useIsStepActive();
 	const isDisabled = ! isStepActive || formStatus !== 'ready';
+	const cart = useCart();
+
 	useSkipToLastStepIfFormComplete( contactValidationCallback );
 
 	if ( summary && isComplete ) {
 		return (
 			<ContactFormSummary
-				isDomainFieldsVisible={ isDomainFieldsVisible }
+				isDomainFieldsVisible={ needsDomainDetails( cart ) }
 				isGSuiteInCart={ isGSuiteInCart }
 			/>
 		);
@@ -67,7 +75,7 @@ export default function WPContactForm( {
 		<BillingFormFields>
 			<RenderContactDetails
 				translate={ translate }
-				isDomainFieldsVisible={ isDomainFieldsVisible }
+				isDomainFieldsVisible={ needsDomainDetails( cart ) }
 				isGSuiteInCart={ isGSuiteInCart }
 				contactInfo={ contactInfo }
 				renderDomainContactFields={ renderDomainContactFields }
@@ -442,4 +450,14 @@ function saveStepNumberToUrl( stepNumber ) {
 	// eslint reports this as undefined.)
 	const event = new HashChangeEvent( 'hashchange' ); // eslint-disable-line no-undef
 	window.dispatchEvent( event );
+}
+
+function needsDomainDetails( cart ) {
+	if ( cart && hasOnlyRenewalItems( cart ) ) {
+		return false;
+	}
+
+	return (
+		cart && ( hasDomainRegistration( cart ) || hasGoogleApps( cart ) || hasTransferProduct( cart ) )
+	);
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR changes the behavior of the new checkout form's contact details so that it will not display if the cart contains only renewal items. This behavior should match [old checkout](https://github.com/Automattic/wp-calypso/blob/096d4759a964ebb19bcf0a068e51d438e9fab080/client/my-sites/checkout/checkout/index.jsx#L917) (with the small exception that it no longer checks `hasDomainDetails( transaction )` since we don't have a transaction but I don't think that's going to be an issue). Previously, we had been displaying the contact details form fields any time that there were domain products in the cart.

#### Screenshots

Before:

![Screen Shot 2020-07-27 at 2 21 16 PM](https://user-images.githubusercontent.com/2036909/88577259-bb636c80-d014-11ea-965e-c9ee82fbc4da.png)

After:

![Screen Shot 2020-07-27 at 2 17 32 PM](https://user-images.githubusercontent.com/2036909/88577272-be5e5d00-d014-11ea-92dc-fe44dd927652.png)


#### Testing instructions

- Add a domain product to your cart (we may want to test this with different domain products for completeness) and visit checkout.
- Verify that you see the full "Contact information" step including name, address, and phone number.
- Complete the purchase.
- Visit http://calypso.localhost:3000/me/purchases and click the domain, then click "Renew now". You'll be redirected to checkout.
- Verify that the "Contact information" step only includes the "tax" information which is just postal code and country.