### PR TITLE
Typography: Update 36px font sizes to use Sass variable

### DIFF
--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -446,7 +446,7 @@
 	max-width: 750px;
 
 	@include breakpoint-deprecated( '>960px' ) {
-		font-size: 36px;
+		font-size: $font-headline-small;
 		line-height: 46px;
 	}
 

--- a/client/blocks/support-article-dialog/style.scss
+++ b/client/blocks/support-article-dialog/style.scss
@@ -76,7 +76,7 @@
 	max-width: 750px;
 
 	@include breakpoint-deprecated( '>960px' ) {
-		font-size: 36px;
+		font-size: $font-headline-small;
 		line-height: 46px;
 	}
 

--- a/client/components/card-heading/style.scss
+++ b/client/components/card-heading/style.scss
@@ -20,7 +20,7 @@
 }
 
 .card-heading-36 {
-	font-size: 36px;
+	font-size: $font-headline-small;
 }
 
 .card-heading-32 {

--- a/client/components/jetpack/scan-history-placeholder/style.scss
+++ b/client/components/jetpack/scan-history-placeholder/style.scss
@@ -13,7 +13,7 @@
 	@include breakpoint-deprecated( '>660px' ) {
 		margin: 32px 0 24px;
 
-		font-size: 36px;
+		font-size: $font-headline-small;
 		font-weight: 600;
 	}
 }

--- a/client/components/share/tumblr-share-preview/style.scss
+++ b/client/components/share/tumblr-share-preview/style.scss
@@ -51,7 +51,7 @@
 .tumblr-share-preview__post-title {
     font-family: Gibson, Helvetica Neue, HelveticaNeue, Helvetica, Arial, sans-serif;
     font-weight: 400;
-    font-size: 36px;
+    font-size: $font-headline-small;
     line-height: 47px;
     margin-bottom: 10px;
 }

--- a/client/landing/jetpack-cloud/sections/settings/style.scss
+++ b/client/landing/jetpack-cloud/sections/settings/style.scss
@@ -54,7 +54,7 @@
 	margin: 16px 0 24px;
 
 	@include breakpoint-deprecated('>660px') {
-		font-size: 36px;
+		font-size: $font-headline-small;
 		margin: 32px 0;
 	}
 }

--- a/client/landing/jetpack-cloud/style.scss
+++ b/client/landing/jetpack-cloud/style.scss
@@ -197,7 +197,7 @@ html {
 		line-height: 32px;
 
 		@include breakpoint-deprecated('>660px') {
-			font-size: 36px;
+			font-size: $font-headline-small;
 			line-height: 40px;
 		}
 	}

--- a/client/my-sites/checkout/upsell-nudge/white-glove/style.scss
+++ b/client/my-sites/checkout/upsell-nudge/white-glove/style.scss
@@ -123,7 +123,7 @@ main.white-glove.main {
 	}
 
 	&__header {
-		font-size: 36px;
+		font-size: $font-headline-small;
 		font-weight: normal;
 		text-align: center;
 		line-height: 1.4;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates all instances of 36px to the equivalent variable `$font-headline-small`
* I found no other instances of font sizes 37px - 46px (yay!) so there should be no visual changes.

**Visuals (not exhaustive)**

<img width="942" alt="Screen Shot 2020-07-29 at 12 03 49 PM" src="https://user-images.githubusercontent.com/2124984/88823868-95b0a180-d193-11ea-9f97-1e9c327e4bde.png">

<img width="1406" alt="Screen Shot 2020-07-29 at 12 04 57 PM" src="https://user-images.githubusercontent.com/2124984/88823997-bed13200-d193-11ea-9b45-ee7aeacd00e1.png">

<img width="916" alt="Screen Shot 2020-07-29 at 12 05 46 PM" src="https://user-images.githubusercontent.com/2124984/88824051-d90b1000-d193-11ea-8181-eb45207cc02f.png">

<img width="817" alt="Screen Shot 2020-07-29 at 12 06 30 PM" src="https://user-images.githubusercontent.com/2124984/88824152-f8a23880-d193-11ea-82bd-26cc0a6a5a16.png">

#### Testing instructions

*  Switch to this PR
* Look for instances of large font size 36px across Calypso; note any visual regressions or bugs
