### PR TITLE
Typography: Update font sizes 47-48px to use Sass var

### DIFF
--- a/client/components/card-heading/style.scss
+++ b/client/components/card-heading/style.scss
@@ -16,7 +16,7 @@
 /* 47px is deprecated, use .card-heading-48 */
 .card-heading-47,
 .card-heading-48 {
-	font-size: 47px;
+	font-size: $font-headline-medium;
 }
 
 .card-heading-36 {

--- a/client/my-sites/migrate/section-migrate.scss
+++ b/client/my-sites/migrate/section-migrate.scss
@@ -138,7 +138,7 @@
 	}
 
 	.plan-price__integer {
-		font-size: 48px;
+		font-size: $font-headline-medium;
 		font-weight: 600;
 	}
 }

--- a/client/signup/p2-processing-screen/style.scss
+++ b/client/signup/p2-processing-screen/style.scss
@@ -14,7 +14,7 @@
 
 .p2-processing-screen__text {
 	font-weight: bold;
-	font-size: 48px;
+	font-size: $font-headline-medium;
 	line-height: 58px;
 	margin-top: 111px;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update font sizes 47px and 48px to `$font-headline-medium`
* Only one value gets changed here; the `CardHeading` component was using 47px instead of 48px. The others are just conversions from `48px` to the equivalent variable.

**Before**

<img width="1363" alt="Screen Shot 2020-07-28 at 4 07 41 PM" src="https://user-images.githubusercontent.com/2124984/88716180-afe37480-d0ec-11ea-991e-ac43fc7c125f.png">

**After**

<img width="1357" alt="Screen Shot 2020-07-28 at 4 07 26 PM" src="https://user-images.githubusercontent.com/2124984/88716192-b40f9200-d0ec-11ea-90e6-26fdf30a8110.png">

#### Testing instructions

* Switch to this PR
* Check on extra large font sizes 48px across Calypso