### PR TITLE
Typography: Update instances of 52px and 54px to use Sass variable

### DIFF
--- a/client/components/card-heading/style.scss
+++ b/client/components/card-heading/style.scss
@@ -10,7 +10,7 @@
 }
 
 .card-heading-54 {
-	font-size: 54px;
+	font-size: $font-headline-large;
 }
 
 /* 47px is deprecated, use .card-heading-48 */

--- a/client/devdocs/style.scss
+++ b/client/devdocs/style.scss
@@ -367,7 +367,7 @@ $devdocs-max-width: 720px;
 
 	h1 {
 		color: var( --color-neutral-70 );
-		font-size: 54px;
+		font-size: $font-headline-large;
 		line-height: 1.4;
 		margin-top: 0;
 	}

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -874,7 +874,7 @@ body.is-section-signup #primary .segmented-control.is-customer-type-toggle {
 		.plan-price {
 			font-weight: 600;
 			margin-right: 10px;
-			font-size: 52px;
+			font-size: $font-headline-large;
 			font-family: 'Helvetica Neue', helvetica, arial, sans-serif;
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update once instance of 52px and two instances of 54px to use `$font-headline-large`

**Before**

<img width="340" alt="Screen Shot 2020-07-28 at 4 45 05 PM" src="https://user-images.githubusercontent.com/2124984/88719758-c809c280-d0f1-11ea-9c4c-e68bf58d39e2.png">

**After**

<img width="335" alt="Screen Shot 2020-07-28 at 4 45 15 PM" src="https://user-images.githubusercontent.com/2124984/88719776-cdffa380-d0f1-11ea-8dc0-3ef9364606b8.png">


#### Testing instructions

* Switch to this PR
* Check the plans part of onboarding from `/start` on a mobile device; the plan price will have gotten a teensy big larger as a result of this change
* Otherwise there should be no visual changes or breakage