### PR TITLE
Site Settings - fix support links to open in modal dialog

### DIFF
--- a/client/components/inline-support-link/index.jsx
+++ b/client/components/inline-support-link/index.jsx
@@ -73,9 +73,9 @@ class InlineSupportLink extends Component {
 		};
 
 		// props.children overrides text prop if both are provided
-		const shouldDisplayChildren = children != null;
-		const shouldDisplayTextPropValue = ! children && showText;
-		const shouldDisplayIcon = ! children && supportPostId && showIcon;
+		const displayChildren = children != null;
+		const displayText = ! children && showText;
+		const displayIcon = ! children && supportPostId && showIcon;
 
 		return (
 			<LinkComponent
@@ -86,9 +86,9 @@ class InlineSupportLink extends Component {
 				rel="noopener noreferrer"
 				{ ...externalLinkProps }
 			>
-				{ shouldDisplayChildren && children }
-				{ shouldDisplayTextPropValue && ( text || translate( 'Learn more' ) ) }
-				{ shouldDisplayIcon && <Gridicon icon="help-outline" size={ iconSize } /> }
+				{ displayChildren && children }
+				{ displayText && ( text || translate( 'Learn more' ) ) }
+				{ displayIcon && <Gridicon icon="help-outline" size={ iconSize } /> }
 			</LinkComponent>
 		);
 	}

--- a/client/components/inline-support-link/index.jsx
+++ b/client/components/inline-support-link/index.jsx
@@ -58,6 +58,7 @@ class InlineSupportLink extends Component {
 			iconSize,
 			translate,
 			openDialog,
+			children,
 		} = this.props;
 
 		if ( ! supportPostId && ! supportLink ) {
@@ -71,6 +72,11 @@ class InlineSupportLink extends Component {
 			iconSize,
 		};
 
+		// props.children overrides text prop if both are provided
+		const shouldDisplayChildren = children != null;
+		const shouldDisplayTextPropValue = ! children && showText;
+		const shouldDisplayIcon = ! children && supportPostId && showIcon;
+
 		return (
 			<LinkComponent
 				className="inline-support-link"
@@ -80,8 +86,9 @@ class InlineSupportLink extends Component {
 				rel="noopener noreferrer"
 				{ ...externalLinkProps }
 			>
-				{ showText && ( text || translate( 'Learn more' ) ) }
-				{ supportPostId && showIcon && <Gridicon icon="help-outline" size={ iconSize } /> }
+				{ shouldDisplayChildren && children }
+				{ shouldDisplayTextPropValue && ( text || translate( 'Learn more' ) ) }
+				{ shouldDisplayIcon && <Gridicon icon="help-outline" size={ iconSize } /> }
 			</LinkComponent>
 		);
 	}

--- a/client/my-sites/site-settings/custom-content-types/index.jsx
+++ b/client/my-sites/site-settings/custom-content-types/index.jsx
@@ -22,6 +22,7 @@ import { isJetpackSite } from 'state/sites/selectors';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import SupportInfo from 'components/support-info';
 import { localizeUrl } from 'lib/i18n-utils';
+import InlineSupportLink from 'components/inline-support-link';
 
 /**
  * Style dependencies
@@ -140,11 +141,17 @@ class CustomContentTypes extends Component {
 		const { translate } = this.props;
 		const fieldLabel = translate( 'Testimonials' );
 		const fieldDescription = translate(
-			'Add, organize, and display {{link}}testimonials{{/link}}. If your theme doesn’t support testimonials yet, ' +
+			'Add, organize, and display {{link /}}. If your theme doesn’t support testimonials yet, ' +
 				'you can display them using the shortcode [testimonials].',
 			{
 				components: {
-					link: <a href={ localizeUrl( 'https://wordpress.com/support/testimonials/' ) } />,
+					link: (
+						<InlineSupportLink
+							supportLink={ localizeUrl( 'https://wordpress.com/support/testimonials/' ) }
+							supportPostId={ 97757 }
+							text={ translate( 'testimonials' ) }
+						/>
+					),
 				},
 			}
 		);
@@ -156,11 +163,17 @@ class CustomContentTypes extends Component {
 		const { translate } = this.props;
 		const fieldLabel = translate( 'Portfolio projects' );
 		const fieldDescription = translate(
-			'Add, organize, and display {{link}}portfolio projects{{/link}}. If your theme doesn’t support portfolio projects yet, ' +
+			'Add, organize, and display {{link /}}. If your theme doesn’t support portfolio projects yet, ' +
 				'you can display them using the shortcode [portfolio].',
 			{
 				components: {
-					link: <a href={ localizeUrl( 'https://wordpress.com/support/portfolios/' ) } />,
+					link: (
+						<InlineSupportLink
+							supportLink={ localizeUrl( 'https://wordpress.com/support/portfolios/' ) }
+							supportPostId={ 84808 }
+							text={ translate( 'portfolio projects' ) }
+						/>
+					),
 				},
 			}
 		);

--- a/client/my-sites/site-settings/custom-content-types/index.jsx
+++ b/client/my-sites/site-settings/custom-content-types/index.jsx
@@ -141,7 +141,7 @@ class CustomContentTypes extends Component {
 		const { translate } = this.props;
 		const fieldLabel = translate( 'Testimonials' );
 		const fieldDescription = translate(
-			'Add, organize, and display {{link /}}. If your theme doesn’t support testimonials yet, ' +
+			'Add, organize, and display {{link}}testimonials{{/link}}. If your theme doesn’t support testimonials yet, ' +
 				'you can display them using the shortcode [testimonials].',
 			{
 				components: {
@@ -149,7 +149,6 @@ class CustomContentTypes extends Component {
 						<InlineSupportLink
 							supportLink={ localizeUrl( 'https://wordpress.com/support/testimonials/' ) }
 							supportPostId={ 97757 }
-							text={ translate( 'testimonials' ) }
 						/>
 					),
 				},
@@ -163,7 +162,7 @@ class CustomContentTypes extends Component {
 		const { translate } = this.props;
 		const fieldLabel = translate( 'Portfolio projects' );
 		const fieldDescription = translate(
-			'Add, organize, and display {{link /}}. If your theme doesn’t support portfolio projects yet, ' +
+			'Add, organize, and display {{link}}portfolio projects{{/link}}. If your theme doesn’t support portfolio projects yet, ' +
 				'you can display them using the shortcode [portfolio].',
 			{
 				components: {
@@ -171,7 +170,6 @@ class CustomContentTypes extends Component {
 						<InlineSupportLink
 							supportLink={ localizeUrl( 'https://wordpress.com/support/portfolios/' ) }
 							supportPostId={ 84808 }
-							text={ translate( 'portfolio projects' ) }
 						/>
 					),
 				},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR updates WPCOM support links on `/settings/writing/{siteUrl}` to open in a dialog modal rather than navigating completely to the support site.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In the Calypso sidebar for a site you own, click `Manage` -> `Settings`.
* Click the "Writing" tab.
* Click the "testimonials" and "portfolio projects" links under "Content Types" and verify that both of them open up a support site modal dialog.



Fixes #43789
