### PR TITLE
Add checks for invalid keyboard submissions in transfer domain UI

### DIFF
--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -124,6 +124,14 @@ class TransferDomainStep extends React.Component {
 		}
 	}
 
+	canInitiateTransfer = () => {
+		const { cart, selectedSite } = this.props;
+		const { searchQuery } = this.state;
+		return (
+			getTld( searchQuery ) && ! hasToUpgradeToPayForADomain( selectedSite, cart, searchQuery )
+		);
+	};
+
 	getMapDomainUrl() {
 		const { basePath, mapDomainUrl, selectedSite } = this.props;
 		if ( mapDomainUrl ) {
@@ -226,7 +234,7 @@ class TransferDomainStep extends React.Component {
 	};
 
 	addTransfer() {
-		const { cart, selectedSite, translate } = this.props;
+		const { translate } = this.props;
 		const { searchQuery, submittingAvailability, submittingWhois } = this.state;
 		const submitting = submittingAvailability || submittingWhois;
 
@@ -255,11 +263,7 @@ class TransferDomainStep extends React.Component {
 							onFocus={ this.recordInputFocus }
 						/>
 						<Button
-							disabled={
-								! getTld( searchQuery ) ||
-								hasToUpgradeToPayForADomain( selectedSite, cart, searchQuery ) ||
-								submitting
-							}
+							disabled={ submitting || ! this.canInitiateTransfer() }
 							busy={ submitting }
 							className="transfer-domain-step__go button is-primary"
 							onClick={ this.handleFormSubmit }
@@ -474,6 +478,11 @@ class TransferDomainStep extends React.Component {
 
 	handleFormSubmit = ( event ) => {
 		event.preventDefault();
+
+		// Check for a keyboard-driven submission of invalid data.
+		if ( ! this.canInitiateTransfer() ) {
+			return;
+		}
 
 		const { analyticsSection, searchQuery } = this.state;
 		const domain = getFixedDomainSearch( searchQuery );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR adds a check for invalid content any time the transfer form is submitted, instead of preventing actions via the button we display. That prevents keyboard-driven submissions from triggering searches we can already tell are invalid.

#### Testing instructions

* Navigate to `/domains/add/transfer/<your-site>`.
* Open the network tab in your tools.
* Type a string that is not a valid FQDN into the box and hit Enter/Return. (You can use a single word like "test" or "something".)
* Verify that we don't make any requests to the server for `inbound-transfer-status` or `is-available`.
* Add a valid TLD to the end of your query, e.g. `something.it`, `test.xyz`
* Verify that the "Transfer" button is enabled and hitting Enter and/or clicking the "Transfer" button triggers the two requests above.