### PR TITLE
Adds new eslint rule to detect package-relative imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,5 @@
 const { merge } = require( 'lodash' );
+const path = require( 'path' );
 const reactVersion = require( './client/package.json' ).dependencies.react;
 
 module.exports = {
@@ -221,6 +222,19 @@ module.exports = {
 					'site_blacklisted',
 					'blacklisted_domain',
 				],
+			},
+		],
+		// Disabled for now until we finish the migration
+		'wpcalypso/no-pacakge-relative-imports': [
+			'off',
+			{
+				mapping: [
+					{
+						dir: path.join( __dirname, 'client' ),
+						module: 'wp-calypso',
+					},
+				],
+				warnOnDynamicImport: true,
 			},
 		],
 	},

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -225,7 +225,7 @@ module.exports = {
 			},
 		],
 		// Disabled for now until we finish the migration
-		'wpcalypso/no-pacakge-relative-imports': [
+		'wpcalypso/no-package-relative-imports': [
 			'off',
 			{
 				mapping: [

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -226,15 +226,16 @@ module.exports = {
 		],
 		// Disabled for now until we finish the migration
 		'wpcalypso/no-package-relative-imports': [
-			'off',
+			'error',
 			{
-				mapping: [
+				mappings: [
 					{
 						dir: path.join( __dirname, 'client' ),
 						module: 'wp-calypso',
 					},
 				],
-				warnOnDynamicImport: true,
+				warnOnNonLiteralImport: true,
+				automaticExtensions: [ '.js', '.ts', '.json', '.jsx', '.tsx' ],
 			},
 		],
 	},

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -226,7 +226,7 @@ module.exports = {
 		],
 		// Disabled for now until we finish the migration
 		'wpcalypso/no-package-relative-imports': [
-			'error',
+			'off',
 			{
 				mappings: [
 					{

--- a/package.json
+++ b/package.json
@@ -389,5 +389,8 @@
 			"pre-commit": "yarn run -s install-if-no-packages && node bin/pre-commit-hook.js",
 			"pre-push": "yarn run -s install-if-no-packages && node bin/pre-push-hook.js"
 		}
+	},
+	"devDependencies": {
+		"eslint-nibble": "^5.1.0"
 	}
 }

--- a/packages/eslint-plugin-wpcalypso/docs/rules/no-package-relative-imports.md
+++ b/packages/eslint-plugin-wpcalypso/docs/rules/no-package-relative-imports.md
@@ -47,3 +47,12 @@ import config from './config';
 import config from '../../../config';
 import config from 'dirA'; //when `dirA` is not a directory or file in ./client/
 ```
+
+## Configuration
+
+The rule accept a configuration object with:
+
+* `mapping`. An array of objects like `{dir: string, module: string}`. This defines which imports get replaced. It means: for every import of X, X being a subdirectory of `<dir>`, replace it with an import of `<module>/X`.
+
+* `warnOnDynamicImport`. There are some cases where this rule can't figure out if an import should be replaced or not, namely dynamic imports (e.g.: `require(path+'/thing')`. If this property is `true`, it will print out a warning when those imports are found.
+				

--- a/packages/eslint-plugin-wpcalypso/docs/rules/no-package-relative-imports.md
+++ b/packages/eslint-plugin-wpcalypso/docs/rules/no-package-relative-imports.md
@@ -1,0 +1,49 @@
+# Forbid package-relative imports
+
+When importing modules, we support importing them relative to `./client` but using a absolute syntax:
+
+```js
+import config from 'config';
+import userFactory from 'lib/user';
+```
+
+Those work because Webpack will search for those modules in ./client first, and then in node_modules (so the example above gets resolved as ./client/config and ./client/lib/user). The current approach has some problems, namely having to configure every module resolution (webpack, node.js, typescript, IDEs...) to understand and follow that pattern.
+
+As an alternative, we can rewrite the above as
+
+```js
+import config from 'wp-calypso/config';
+import userFactory from 'wp-calypso/lib/user';
+```
+
+Which works because `wp-calypso` is a valid package in our repository, points to `./client` and is declared as a dependency in the root `package.json`. This will work out of the box in all module resolution systems.
+
+This rule forbid the former approach and can auto-fix it to the latter.
+
+## Rule Details
+
+The following patterns are considered an error:
+
+```js
+import config from 'config';
+import * as stats from 'reader/stats';
+import { localizeUrl } from 'lib/i18n-utils';
+export { default as ActionCard } from 'components/action-card/docs/example';
+export * from 'components/AppBar';
+const config = require('config');
+```
+
+The following patterns are not warnings:
+
+```js
+import config from 'wp-calypso/config';
+import * as stats from 'wp-calypso/reader/stats';
+import { localizeUrl } from 'wp-calypso/lib/i18n-utils';
+export { default as ActionCard } from 'wp-calypso/components/action-card/docs/example';
+export * from 'wp-calypso/components/AppBar';
+const config = require('wp-calypso/config');
+
+import config from './config';
+import config from '../../../config';
+import config from 'dirA'; //when `dirA` is not a directory or file in ./client/
+```

--- a/packages/eslint-plugin-wpcalypso/docs/rules/no-package-relative-imports.md
+++ b/packages/eslint-plugin-wpcalypso/docs/rules/no-package-relative-imports.md
@@ -18,11 +18,11 @@ import userFactory from 'wp-calypso/lib/user';
 
 Which works because `wp-calypso` is a valid package in our repository, points to `./client` and is declared as a dependency in the root `package.json`. This will work out of the box in all module resolution systems.
 
-This rule forbid the former approach and can auto-fix it to the latter.
+This rule forbids the former approach and can auto-fix it to the latter.
 
 ## Rule Details
 
-The following patterns are considered an error:
+The following patterns are considered incorrect:
 
 ```js
 import config from 'config';
@@ -33,7 +33,7 @@ export * from 'components/AppBar';
 const config = require('config');
 ```
 
-The following patterns are not warnings:
+The following patterns are correct
 
 ```js
 import config from 'wp-calypso/config';
@@ -52,7 +52,8 @@ import config from 'dirA'; //when `dirA` is not a directory or file in ./client/
 
 The rule accept a configuration object with:
 
-* `mapping`. An array of objects like `{dir: string, module: string}`. This defines which imports get replaced. It means: for every import of X, X being a subdirectory of `<dir>`, replace it with an import of `<module>/X`.
+* `mappings`. An array of objects like `{dir: string, module: string}`. This defines which imports get replaced. It means: for every import of X, X being a subdirectory or file of `<dir>`, replace it with an import of `<module>/X`.
 
-* `warnOnDynamicImport`. There are some cases where this rule can't figure out if an import should be replaced or not, namely dynamic imports (e.g.: `require(path+'/thing')`. If this property is `true`, it will print out a warning when those imports are found.
-				
+* `automaticExtensions`. An array with the list of extensions to try to import automatically. For example, `['.js', '.json', '.ts']`. This means that when the rule finds something like `import 'file'`, it will apply the mappings if `file.js`, `file.json`, or `file.ts` are files in `<dir>`
+
+* `warnOnNonLiteralImport`. There are some cases where this rule can't figure out if an import should be replaced or not, namely non-literal imports (e.g.: `require(path+'/thing')`. If this property is `true`, it will print out a warning when those imports are found.

--- a/packages/eslint-plugin-wpcalypso/lib/rules/index.js
+++ b/packages/eslint-plugin-wpcalypso/lib/rules/index.js
@@ -11,5 +11,5 @@ module.exports = {
 	'jsx-gridicon-size': require( './jsx-gridicon-size' ),
 	'post-message-no-wildcard-targets': require( './post-message-no-wildcard-targets' ),
 	'redux-no-bound-selectors': require( './redux-no-bound-selectors' ),
-	'no-pacakge-relative-imports': require( './no-package-relative-imports' ),
+	'no-package-relative-imports': require( './no-package-relative-imports' ),
 };

--- a/packages/eslint-plugin-wpcalypso/lib/rules/index.js
+++ b/packages/eslint-plugin-wpcalypso/lib/rules/index.js
@@ -11,4 +11,5 @@ module.exports = {
 	'jsx-gridicon-size': require( './jsx-gridicon-size' ),
 	'post-message-no-wildcard-targets': require( './post-message-no-wildcard-targets' ),
 	'redux-no-bound-selectors': require( './redux-no-bound-selectors' ),
+	'no-pacakge-relative-imports': require( './no-package-relative-imports' ),
 };

--- a/packages/eslint-plugin-wpcalypso/lib/rules/no-package-relative-imports.js
+++ b/packages/eslint-plugin-wpcalypso/lib/rules/no-package-relative-imports.js
@@ -1,0 +1,111 @@
+const fs = require( 'fs' );
+const path = require( 'path' );
+
+const getRelativeImports = ( relativeDir ) => {
+	return fs.readdirSync( relativeDir, { withFileTypes: true } ).map( ( file ) => {
+		const fileName = file.name;
+		if ( file.isDirectory() ) return fileName;
+		const extension = path.extname( fileName );
+		if ( extension !== '.js' ) return fileName;
+		return path.basename( fileName, extension );
+	} );
+};
+
+const reportIfPackageRelative = ( { context, node, dependency } ) => {
+	const { mapping, warnOnDynamicImport } = context.options[ 0 ];
+
+	if ( ! dependency ) return;
+	const { value: dependencyName, type: dependencyType } = dependency;
+
+	if ( dependencyType !== 'Literal' ) {
+		if ( warnOnDynamicImport ) {
+			// eslint-disable-next-line no-console
+			console.warn(
+				`Invalid import, only literal imports are supported. File ${ context.getFilename() }:${
+					node.loc.start.line
+				}`
+			);
+		}
+		return;
+	}
+
+	if ( typeof dependencyName !== 'string' ) return;
+
+	mapping.forEach( ( { dir, module } ) => {
+		const deps = getRelativeImports( dir );
+
+		if ( deps.includes( dependencyName.split( '/' )[ 0 ] ) ) {
+			context.report( {
+				node,
+				messageId: 'noPackageRelativeImport',
+				data: {
+					relativeDir: dir,
+					import: dependencyName,
+				},
+				fix: ( fixer ) => {
+					return fixer.replaceText( dependency, `'${ module }/${ dependencyName }'` );
+				},
+			} );
+		}
+	} );
+};
+
+module.exports = {
+	type: 'problem',
+	meta: {
+		messages: {
+			noPackageRelativeImport: 'Import {{import}} relative to `{{relativeDir}}` is not allowed',
+			invalidImport: 'Invalid import, only literal imports are supported',
+		},
+		docs: {
+			description: 'Forbid package-relative imports',
+		},
+		fixable: 'code',
+		schema: [
+			{
+				type: 'object',
+				additionalProperties: false,
+				properties: {
+					mapping: {
+						type: 'array',
+						items: {
+							type: 'object',
+							additionalProperties: false,
+							properties: {
+								dir: { type: 'string' },
+								module: { type: 'string' },
+							},
+						},
+					},
+					warnOnDynamicImport: {
+						type: 'boolean',
+					},
+				},
+			},
+		],
+	},
+	create( context ) {
+		const reportESMImport = ( node ) =>
+			reportIfPackageRelative( { context, node, dependency: node.source } );
+
+		const reportCJSRequire = ( node ) =>
+			reportIfPackageRelative( { context, node, dependency: node.arguments[ 0 ] } );
+
+		return {
+			ImportDeclaration: reportESMImport,
+			ExportNamedDeclaration: reportESMImport,
+			ExportAllDeclaration: reportESMImport,
+			ImportExpression: reportESMImport,
+			CallExpression: ( node ) => {
+				if (
+					node.callee &&
+					node.callee.type === 'Identifier' &&
+					node.callee.name === 'require' &&
+					node.arguments.length === 1
+				) {
+					reportCJSRequire( node );
+				}
+			},
+		};
+	},
+};

--- a/packages/eslint-plugin-wpcalypso/lib/rules/no-package-relative-imports.js
+++ b/packages/eslint-plugin-wpcalypso/lib/rules/no-package-relative-imports.js
@@ -4,67 +4,91 @@ const path = require( 'path' );
 /**
  * Returns the imports relative to a directory.
  * For example, if the FS is:
- *   - dir/
- *      └ subdir/
- *      └ file.js
- *      └ data.json
+ * - dir/
+ *   ├ subdir/
+ *   ├ file.js
+ *   ├ data.json
+ *   └ test.txt
  *
- * It will return the array ['subdir', 'file', 'data.json']
+ * It will return the array ['subdir', 'file', 'data', 'test.txt]
+ *
+ * @param relativeDir The directory to find relative imports to
+ * @param automaticExtensions {array} List of extensions that are automatically tried when importing a file. Defaults to [".js",".json",".node"] (default Node.js extensions)
  */
-const getRelativeImports = ( relativeDir ) => {
+const getRelativeImports = ( relativeDir, automaticExtensions = [ '.js', '.json', '.node' ] ) => {
 	return fs.readdirSync( relativeDir, { withFileTypes: true } ).map( ( file ) => {
 		const fileName = file.name;
-		if ( file.isDirectory() ) return fileName;
+
+		// Directories can be import directly
+		if ( file.isDirectory() ) {
+			return fileName;
+		}
+
+		// If the file extension is in the automatic extensions, they can be imported
+		// directly (eg: index.js can be improted as 'index')
 		const extension = path.extname( fileName );
-		if ( extension !== '.js' ) return fileName;
-		return path.basename( fileName, extension );
+		if ( automaticExtensions.includes( extension ) ) {
+			return path.basename( fileName, extension );
+		}
+
+		// Else, it needs the full name to be imported (eg: import 'file.txt'). This is
+		// valid because webpack may know how to impor that extension.
+		return fileName;
 	} );
 };
 
 /**
- * For each import (CJS and ESM), check if the import could be relative to one of the
- * configured `mapping` (eg: if you are importing 'X' and 'X' is a subdirectory of ./client)
- * If it is, prepend the import with the module (eg: `import 'X'` becomes `import 'wp-client/X'`)
+ * For each import (CJS or ESM), check if the import could be relative to one of the
+ * configured `mappings`. If it is, prepend the import with the module.
+ *
+ * Example:
+ *
+ * With mappings `[ {dir: '/app/client', module: 'wp-calypso'} ]`
+ * If the code is importing `foo` and `foo` is a subdirectory of `/app/client/`, this rule
+ * will warn the user and optionally replace it with `wp-calypso/foo`
+ *
+ * @param {object} arg Function arguments
+ * @param {object} arg.context The context as provided by ESLint (https://eslint.org/docs/developer-guide/working-with-rules#the-context-object)
+ * @param {object} arg.node A node representing the ESM/CJS import that violates the rule
+ * @param {object} arg.mappings The mappings dir->package used to replace package-relative imports
+ * @param {object} arg.automaticExtensions Array with the extensions to try to import automatically
+ * @param {object} arg.importedModule A node representing the dependency being imported
  */
-const reportIfPackageRelative = ( { context, node, dependency } ) => {
-	const { mapping, warnOnDynamicImport } = context.options[ 0 ];
+const report = ( { context, node, mappings, automaticExtensions, importedModule } ) =>
+	mappings.forEach( ( { dir, module } ) => {
+		const deps = getRelativeImports( dir, automaticExtensions );
 
-	// Because ExportNamedDeclaration and ExportAllDeclaration may not have an imported source (aka node.source)
-	if ( ! dependency ) return;
-	const { value: dependencyName, type: dependencyType } = dependency;
-
-	// This part is only relevant for CJS imports
-	if ( dependencyType !== 'Literal' ) {
-		if ( warnOnDynamicImport ) {
-			// eslint-disable-next-line no-console
-			console.warn(
-				`Invalid import, only literal imports are supported. File ${ context.getFilename() }:${
-					node.loc.start.line
-				}`
-			);
-		}
-		return;
-	}
-
-	if ( typeof dependencyName !== 'string' ) return;
-
-	mapping.forEach( ( { dir, module } ) => {
-		const deps = getRelativeImports( dir );
-
-		if ( deps.includes( dependencyName.split( '/' )[ 0 ] ) ) {
+		if ( deps.includes( importedModule.value.split( '/' )[ 0 ] ) ) {
 			context.report( {
 				node,
 				messageId: 'noPackageRelativeImport',
 				data: {
 					relativeDir: dir,
-					import: dependencyName,
+					import: importedModule.value,
 				},
 				fix: ( fixer ) => {
-					return fixer.replaceText( dependency, `'${ module }/${ dependencyName }'` );
+					return fixer.replaceText( importedModule, `'${ module }/${ importedModule.value }'` );
 				},
 			} );
 		}
 	} );
+
+/**
+ * Checks if an import is a Literal string or somethign else (eg: an expression)
+ *
+ * @param {object} importedModule A node representing the dependency being imported
+ */
+const isLiteralImport = ( importedModule ) =>
+	importedModule.type === 'Literal' && typeof importedModule.value === 'string';
+
+/**
+ * Checks if an import is a bare import (it doesn't start with with . or /)
+ *
+ * @param {object} importedModule A node representing the dependency being imported
+ * @param {string} importedModule.value Name of the imported module
+ */
+const isBareImport = ( { value } ) => {
+	return ! value.startsWith( '.' ) && ! value.startsWith( '/' );
 };
 
 module.exports = {
@@ -83,7 +107,7 @@ module.exports = {
 				type: 'object',
 				additionalProperties: false,
 				properties: {
-					mapping: {
+					mappings: {
 						type: 'array',
 						items: {
 							type: 'object',
@@ -94,25 +118,56 @@ module.exports = {
 							},
 						},
 					},
-					warnOnDynamicImport: {
+					warnOnNonLiteralImport: {
 						type: 'boolean',
+					},
+					automaticExtensions: {
+						type: 'array',
+						items: {
+							type: 'string',
+						},
 					},
 				},
 			},
 		],
 	},
 	create( context ) {
-		const reportESMImport = ( node ) =>
-			reportIfPackageRelative( { context, node, dependency: node.source } );
+		const reportImport = ( node, importedModule ) => {
+			const warnOnNonLiteralImport = context.options[ 0 ].warnOnNonLiteralImport;
 
-		const reportCJSRequire = ( node ) =>
-			reportIfPackageRelative( { context, node, dependency: node.arguments[ 0 ] } );
+			// ExportNamedDeclaration and ExportAllDeclaration may not import a module
+			if ( ! importedModule ) return;
+
+			if ( ! isLiteralImport( importedModule ) ) {
+				if ( warnOnNonLiteralImport ) {
+					// eslint-disable-next-line no-console
+					console.warn(
+						`Invalid import, only literal imports are supported. File ${ context.getFilename() }:${
+							node.loc.start.line
+						}`
+					);
+				}
+				return;
+			}
+
+			if ( ! isBareImport( importedModule ) ) {
+				return;
+			}
+
+			report( {
+				context,
+				node,
+				mappings: context.options[ 0 ].mappings,
+				automaticExtensions: context.options[ 0 ].automaticExtensions,
+				importedModule,
+			} );
+		};
 
 		return {
-			ImportDeclaration: reportESMImport,
-			ExportNamedDeclaration: reportESMImport,
-			ExportAllDeclaration: reportESMImport,
-			ImportExpression: reportESMImport,
+			ImportDeclaration: ( node ) => reportImport( node, node.source ),
+			ExportNamedDeclaration: ( node ) => reportImport( node, node.source ),
+			ExportAllDeclaration: ( node ) => reportImport( node, node.source ),
+			ImportExpression: ( node ) => reportImport( node, node.source ),
 			CallExpression: ( node ) => {
 				if (
 					node.callee &&
@@ -120,7 +175,7 @@ module.exports = {
 					node.callee.name === 'require' &&
 					node.arguments.length === 1
 				) {
-					reportCJSRequire( node );
+					reportImport( node, node.arguments[ 0 ] );
 				}
 			},
 		};

--- a/packages/eslint-plugin-wpcalypso/lib/rules/test/no-package-relative-imports.js
+++ b/packages/eslint-plugin-wpcalypso/lib/rules/test/no-package-relative-imports.js
@@ -1,0 +1,146 @@
+/**
+ * @file Forbid package-relative imports
+ * @author Automattic
+ * @copyright 2020 Automattic. All rights reserved.
+ * See LICENSE.md file in root directory for full license.
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require( '../no-package-relative-imports' );
+const RuleTester = require( 'eslint' ).RuleTester;
+const path = require( 'path' );
+const fs = require( 'fs' );
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const calypsoDir = path.join( __dirname, '../../../../../client' );
+const options = [
+	{
+		mapping: [
+			{
+				dir: calypsoDir,
+				module: 'wp-calypso',
+			},
+		],
+		warnOnDynamicImport: true,
+	},
+];
+
+new RuleTester( {
+	parserOptions: {
+		ecmaVersion: 6,
+		sourceType: 'module',
+	},
+} ).run( 'no-package-relative-imports', rule, {
+	valid: [
+		{ code: `import config from 'wp-calypso/config';`, options },
+		{ code: "import * as stats from 'wp-calypso/reader/stats';", options },
+		{ code: "import { localizeUrl } from 'wp-calypso/lib/i18n-utils';", options },
+		{
+			code:
+				"export { default as ActionCard } from 'wp-calypso/components/action-card/docs/example';",
+			options,
+		},
+		{ code: "export * from 'wp-calypso/components/AppBar';", options },
+		{ code: "const config = require('wp-calypso/config');", options },
+		{ code: "import config from './config';", options },
+		{ code: "import config from '../../../config';", options },
+		{ code: "import config from 'random-directory';", options },
+	],
+
+	invalid: [
+		{
+			code: `import config from 'config';`,
+			options,
+			errors: [
+				{
+					message: `Import config relative to \`${ calypsoDir }\` is not allowed`,
+					type: 'ImportDeclaration',
+				},
+			],
+			output: `import config from 'wp-calypso/config';`,
+		},
+		{
+			code: `import * as stats from 'reader/stats';`,
+			options,
+			errors: [
+				{
+					message: `Import reader/stats relative to \`${ calypsoDir }\` is not allowed`,
+					type: 'ImportDeclaration',
+				},
+			],
+			output: `import * as stats from 'wp-calypso/reader/stats';`,
+		},
+		{
+			code: `import { localizeUrl } from 'lib/i18n-utils';`,
+			options,
+			errors: [
+				{
+					message: `Import lib/i18n-utils relative to \`${ calypsoDir }\` is not allowed`,
+					type: 'ImportDeclaration',
+				},
+			],
+			output: `import { localizeUrl } from 'wp-calypso/lib/i18n-utils';`,
+		},
+		{
+			code: `export { default as ActionCard } from 'components/action-card/docs/example';`,
+			options,
+			errors: [
+				{
+					message: `Import components/action-card/docs/example relative to \`${ calypsoDir }\` is not allowed`,
+					type: 'ExportNamedDeclaration',
+				},
+			],
+			output: `export { default as ActionCard } from 'wp-calypso/components/action-card/docs/example';`,
+		},
+		{
+			code: `export * from 'components/AppBar';`,
+			options,
+			errors: [
+				{
+					message: `Import components/AppBar relative to \`${ calypsoDir }\` is not allowed`,
+					type: 'ExportAllDeclaration',
+				},
+			],
+			output: `export * from 'wp-calypso/components/AppBar';`,
+		},
+		{
+			code: `const config = require('config');`,
+			options,
+			errors: [
+				{
+					message: `Import config relative to \`${ calypsoDir }\` is not allowed`,
+					type: 'CallExpression',
+				},
+			],
+			output: `const config = require('wp-calypso/config');`,
+		},
+
+		// Dynamic test: test the rule with each subdirectory and file inside `./client`
+		...fs
+			.readdirSync( calypsoDir, { withFileTypes: true } )
+			.map( ( file ) => {
+				const fileName = file.name;
+				if ( file.isDirectory() ) return fileName;
+				const extension = path.extname( fileName );
+				if ( extension !== '.js' ) return fileName;
+				return path.basename( fileName, extension );
+			} )
+			.map( ( dir ) => ( {
+				code: `import * as foo from '${ dir }';`,
+				options,
+				errors: [
+					{
+						message: `Import ${ dir } relative to \`${ calypsoDir }\` is not allowed`,
+						type: 'ImportDeclaration',
+					},
+				],
+				output: `import * as foo from 'wp-calypso/${ dir }';`,
+			} ) ),
+	],
+} );

--- a/packages/webpack-config-flag-plugin/.eslintrc.js
+++ b/packages/webpack-config-flag-plugin/.eslintrc.js
@@ -3,4 +3,12 @@ module.exports = {
 		'import/no-extraneous-dependencies': [ 'error', { packageDir: __dirname } ],
 		'import/no-nodejs-modules': 0,
 	},
+	overrides: [
+		{
+			files: [ '**/fixtures/**/*' ],
+			rules: {
+				'wpcalypso/no-relative-imports': 'off',
+			},
+		},
+	],
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -7069,7 +7069,7 @@ axobject-query@^2.0.2:
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.1.2.tgz#2bdffc0371e643e5f03ba99065d5179b9ca79799"
   integrity sha512-ICt34ZmrVt8UQnvPl6TVyDTkmhXmAyAT4Jh5ugfGUX4MOrZ+U/ZY6/sdylRw3qGNr9Ub5AJsaHeDMzNLehRdOQ==
 
-babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
+babel-code-frame@6.26.0, babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
   integrity sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=
@@ -11936,6 +11936,24 @@ eslint-config-prettier@^6.10.1, eslint-config-prettier@^6.11.0:
   dependencies:
     get-stdin "^6.0.0"
 
+eslint-filtered-fix@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-filtered-fix/-/eslint-filtered-fix-0.1.1.tgz#07e08a8c7cde059c6db00c3b2b001fa4756cb74e"
+  integrity sha1-B+CKjHzeBZxtsAw7KwAfpHVst04=
+  dependencies:
+    optionator "^0.8.2"
+
+eslint-formatter-friendly@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-formatter-friendly/-/eslint-formatter-friendly-6.0.0.tgz#8363888f7b50f992dfaed72a849a604fc97d598f"
+  integrity sha512-fOBwGn2r8BPQ1KSKyVzjXP8VFxJ2tWKxxn2lIF+k1ezN/pFB44HDlrn5kBm1vxbyyRa/LC+1vHJwc7WETUAZ2Q==
+  dependencies:
+    babel-code-frame "6.26.0"
+    chalk "^2.0.1"
+    extend "^3.0.0"
+    strip-ansi "^4.0.0"
+    text-table "^0.2.0"
+
 eslint-import-resolver-node@^0.3.2:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.3.tgz#dbaa52b6b2816b50bc6711af75422de808e98404"
@@ -11951,6 +11969,19 @@ eslint-module-utils@^2.4.1:
   dependencies:
     debug "^2.6.9"
     pkg-dir "^2.0.0"
+
+eslint-nibble@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-nibble/-/eslint-nibble-5.1.0.tgz#f279b6ae0d60a61636c7f95142bdd43f913f68e2"
+  integrity sha512-wgmhwlMaNBbaDHrxg8/Os0LCOOatfzy6IaU07HFk6/UirfsTCqD9XoH0+9UNk2V16uPZXgLSiUIwGBtxliXnHw==
+  dependencies:
+    chalk "^2.4.1"
+    eslint-filtered-fix "^0.1.1"
+    eslint-formatter-friendly "^6.0.0"
+    eslint-stats ianvs/eslint-stats#cb1ff8251b50c7f0cb431a2b395431ebfdeb10c8
+    eslint-summary "^1.0.0"
+    inquirer "^6.2.0"
+    optionator "^0.8.2"
 
 eslint-plugin-import@^2.20.0:
   version "2.20.0"
@@ -12090,6 +12121,21 @@ eslint-scope@^5.0.0:
   dependencies:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
+
+eslint-stats@ianvs/eslint-stats#cb1ff8251b50c7f0cb431a2b395431ebfdeb10c8:
+  version "1.0.0"
+  resolved "https://codeload.github.com/ianvs/eslint-stats/tar.gz/cb1ff8251b50c7f0cb431a2b395431ebfdeb10c8"
+  dependencies:
+    chalk "^2.4.1"
+    lodash "^4.17.4"
+
+eslint-summary@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-summary/-/eslint-summary-1.0.0.tgz#b811f00437016b20c0f6f5234479bd6395b57886"
+  integrity sha1-uBHwBDcBayDA9vUjRHm9Y5W1eIY=
+  dependencies:
+    chalk "^1.0.0"
+    text-table "^0.2.0"
 
 eslint-utils@^1.4.3:
   version "1.4.3"
@@ -20080,7 +20126,7 @@ optimist@^0.6.1:
     minimist "~0.0.1"
     wordwrap "~0.0.2"
 
-optionator@^0.8.1, optionator@^0.8.3:
+optionator@^0.8.1, optionator@^0.8.2, optionator@^0.8.3:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.3.tgz#84fa1d036fe9d3c7e21d99884b601167ec8fb495"
   integrity sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==


### PR DESCRIPTION
### Change

This PR introduces a new eslint rule to forbid package-relative imports. The rule is disabled for now (see Plan).
This PR also introduces a new dependency on `eslint-nibble`, that we'll use to selectively fix eslint rules.


### Background

Calypso allows package-relative imports, like

```js
import config from 'config';
import userFactory from 'lib/user';
```

While this saves us from having to type an endless stream of `../../../../../` for relative imports, it has some drawbacks: it makes the code harder to statically analyze, and such relative import has to be configured in all our tools that do module resolution (node.js, webpack, typescript, IDEs...).

An alternative would be to use regular NPM imports using `wp-calypso`:
```js
import config from 'wp-calypso/config';
import userFactory from 'wp-calypso/lib/user';
```

This works because `./client` is actually an NPM package called `wp-calypso`, and it is referenced as a dependency in the root's `package.json`. 

#### Migration plan

After playing with some other ideas (see section 'Alternatives'), I think the best way to do this migration is an eslint rule. We can turn it on to prevent new files to use the package-relative import, and we can use https://www.npmjs.com/package/eslint-nibble to gradually fix parts of our codebase.

#### Alternatives

Ideas I consider and didn't work:

* Use a bunch of `bash`+`sed`+`grep` magic: it works for simple cases, but super hard to do when the import is split into several lines. Plus it will require extra work to forbid new files to use package-relative imports.
* Use `calypso-codemods`: the wrapper around `jscodeshift` doesn't allow configuration of the rule or change the parser to support TypeScript. Plus it will require extra work to forbid new files to use package-relative imports.

So the idea is:

1. Introduce a new eslint rule (this PR) and blog about it.
2. Convert small pieces of our codebase to use relative imports, ensure everything works:
   * [x] Compiling evergreen/fallback
   * [x] Starting Node server
   * [x] Running tests
   * [x] Compiling TS projects
   * [ ] ...
3. Enable the rule to prevent new files to use the wrong syntax.
4. Keep migrating the whole codebase.

### Testing instructions

You can run the rule for a subset of files by:
1. Open `.eslintrc` and configure the rule `wpcalypso/no-package-relative-imports` from `off` to `error`.
2. Run `./node_modules/.bin/eslint-nibble --ext .js,.jsx,.ts,.tsx --rule wpcalypso/no-package-relative-imports <path>` (warning: applying it in all `./client` takes several minutes)
3. Apply the fixes and validate that the results make sense.

