### PR TITLE
Activity Log: Only show "Backup underway" banner during a site's first backup

### DIFF
--- a/client/components/data/query-rewind-backups/README.md
+++ b/client/components/data/query-rewind-backups/README.md
@@ -1,0 +1,37 @@
+Query Rewind Backups
+====================
+
+`QueryRewindBackups` is a React component which dispatches actions for querying the details of a site's most recent Rewind backups.
+
+## Usage
+
+Render the component, passing `siteId`. It does not accept any children, nor does it render any elements to the page. You can use it adjacent to other sibling components which make use of the fetched data made available through the global application state.
+
+```jsx
+import React from 'react';
+import { useSelector } from 'react-redux';
+import getRewindBackups from 'state/selectors/get-rewind-backups';
+import QueryRewindBackups from 'components/data/query-rewind-backups';
+
+export default function MyComponent( { siteId } ) {
+	const rewindBackups = useSelector( getRewindBackups( siteId ) );
+
+	return (
+		<>
+			<QueryRewindBackups siteId={ siteId } />
+			<MyOtherComponent backups={ rewindBackups } />
+		</>
+	);
+}
+```
+
+## Props
+
+### `siteId`
+
+<table>
+	<tr><th>Type</th><td>Number</td></tr>
+	<tr><th>Required</th><td>Yes</td></tr>
+</table>
+
+The site ID for which a list of the most recent backups should be requested.

--- a/client/components/data/query-rewind-backups/index.js
+++ b/client/components/data/query-rewind-backups/index.js
@@ -11,7 +11,13 @@ import { requestRewindBackups } from 'state/rewind/backups/actions';
 
 const QueryRewindBackups = ( { siteId } ) => {
 	const dispatch = useDispatch();
-	useEffect( () => dispatch( requestRewindBackups( siteId ) ), [ dispatch, siteId ] );
+	useEffect( () => {
+		if ( ! siteId ) {
+			return;
+		}
+
+		dispatch( requestRewindBackups( siteId ) );
+	}, [ dispatch, siteId ] );
 
 	return null;
 };

--- a/client/components/data/query-rewind-backups/index.js
+++ b/client/components/data/query-rewind-backups/index.js
@@ -1,0 +1,19 @@
+/**
+ * External dependencies
+ */
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { requestRewindBackups } from 'state/rewind/backups/actions';
+
+const QueryRewindBackups = ( { siteId } ) => {
+	const dispatch = useDispatch();
+	useEffect( () => dispatch( requestRewindBackups( siteId ) ), [ dispatch, siteId ] );
+
+	return null;
+};
+
+export default QueryRewindBackups;

--- a/client/my-sites/activity/activity-log/index.jsx
+++ b/client/my-sites/activity/activity-log/index.jsx
@@ -360,6 +360,35 @@ class ActivityLog extends Component {
 		);
 	}
 
+	renderBackupStatus() {
+		if ( this.props.rewindState?.state !== 'provisioning' ) {
+			return;
+		}
+
+		const { supportsRealtimeBackup, translate } = this.props;
+
+		const provisioningText = supportsRealtimeBackup
+			? translate(
+					"We're currently backing up your site for the first time, " +
+						"and we'll let you know when we're finished. " +
+						"After this initial backup, we'll save future changes in real time."
+			  )
+			: translate(
+					"We're currently backing up your site for the first time, " +
+						"and we'll let you know when we're finished. " +
+						"After this initial backup, we'll save future changes every day."
+			  );
+
+		return (
+			<Banner
+				icon="history"
+				disableHref
+				title={ translate( 'Your backup is underway' ) }
+				description={ provisioningText }
+			/>
+		);
+	}
+
 	getActivityLog() {
 		const {
 			enableRewind,
@@ -373,7 +402,6 @@ class ActivityLog extends Component {
 			isAtomic,
 			isJetpack,
 			isIntroDismissed,
-			supportsRealtimeBackup,
 		} = this.props;
 
 		const disableRestore =
@@ -410,16 +438,6 @@ class ActivityLog extends Component {
 			};
 		} )();
 
-		const provisioningText = supportsRealtimeBackup
-			? translate(
-					"We're currently backing up your site for the first time, and we'll let you know when we're finished. " +
-						"After this initial backup, we'll save future changes in real time."
-			  )
-			: translate(
-					"We're currently backing up your site for the first time, and we'll let you know when we're finished. " +
-						"After this initial backup, we'll save future changes every day."
-			  );
-
 		return (
 			<>
 				{ siteId && 'active' === rewindState.state && (
@@ -447,14 +465,7 @@ class ActivityLog extends Component {
 				{ siteId && 'unavailable' === rewindState.state && (
 					<RewindUnavailabilityNotice siteId={ siteId } />
 				) }
-				{ 'provisioning' === rewindState.state && (
-					<Banner
-						icon="history"
-						disableHref
-						title={ translate( 'Your backup is underway' ) }
-						description={ provisioningText }
-					/>
-				) }
+				{ this.renderBackupStatus() }
 				<IntroBanner siteId={ siteId } />
 				{ siteHasNoLog && isIntroDismissed && <UpgradeBanner siteId={ siteId } /> }
 				{ siteId && isJetpack && <ActivityLogTasklist siteId={ siteId } /> }

--- a/client/my-sites/activity/activity-log/index.jsx
+++ b/client/my-sites/activity/activity-log/index.jsx
@@ -362,7 +362,7 @@ class ActivityLog extends Component {
 		);
 	}
 
-	renderBackupStatus() {
+	renderFirstBackupStatus() {
 		const mostRecentBackup = this.props.rewindBackups && this.props.rewindBackups[ 0 ];
 		const isFirstBackup = this.props.rewindBackups?.length === 1;
 		if ( ! isFirstBackup || mostRecentBackup?.status !== 'started' ) {
@@ -470,7 +470,7 @@ class ActivityLog extends Component {
 				{ siteId && 'unavailable' === rewindState.state && (
 					<RewindUnavailabilityNotice siteId={ siteId } />
 				) }
-				{ this.renderBackupStatus() }
+				{ this.renderFirstBackupStatus() }
 				<IntroBanner siteId={ siteId } />
 				{ siteHasNoLog && isIntroDismissed && <UpgradeBanner siteId={ siteId } /> }
 				{ siteId && isJetpack && <ActivityLogTasklist siteId={ siteId } /> }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change logic so that the "first backup underway" banner only shows during the first attempted backup of a site.
* Move the logic for the "first backup underway" banner into its own function. (We could later modify this code to show live backup status banners, if we want to.)
* Add a query component, `QueryRewindBackups`, to fetch data about the most recent backups for a site.

Fixes `1164141197617539-as-1181871794129033`.

##### Implementation notes

* I wonder if it might be more accurate here to show "first backup underway" for *every* backup attempt until a successful backup is complete, but this approach looks like it would take significantly more work and put a lot more demand on the client, network traffic-wise. If this is something we're interested in, I encourage someone to create a new issue as an enhancement request.

#### Testing instructions

##### Case 1: a site's first backup

* Create a new site with Jetpack, or find a Jetpack site that has never been backed up before.
* Purchase Jetpack Backup to initiate the site's first backup.
* Go to Activity Log and observe the "Your backup is underway" banner is visible. (This may take a few seconds, because Backups are queued and may be slightly delayed. Refresh the page multiple times if needed, but it should appear no longer than one minute after purchase.)
* Once the backup completes (times may vary), refresh the page and observe that the "Your backup is underway" banner has disappeared.

##### Case 2: subsequent site backups

* For a Jetpack site with at least one existing backup attempt -- failed, successful, doesn't matter -- trigger another backup.
* Go to Activity Log and observe that the "Your backup is underway" banner does not appear at any time during the backup process.

#### Screenshot (for reference)

<img width="389" alt="image" src="https://user-images.githubusercontent.com/670067/88674900-fbc3f880-d0af-11ea-958e-2f8579d63b6d.png">
