### PR TITLE
Social Previews: strip html tags

### DIFF
--- a/client/components/seo/facebook-preview/index.jsx
+++ b/client/components/seo/facebook-preview/index.jsx
@@ -32,6 +32,8 @@ export class FacebookPreview extends PureComponent {
 	render() {
 		const { url, type, title, description, image, author } = this.props;
 
+		const strippedDescription = description ? description.replace( /<[^>]+>/g, '' ) : '';
+
 		return (
 			<div className={ `facebook-preview facebook-preview__${ type }` }>
 				<div className="facebook-preview__content">
@@ -41,7 +43,7 @@ export class FacebookPreview extends PureComponent {
 					<div className="facebook-preview__body">
 						<div className="facebook-preview__title">{ facebookTitle( title || '' ) }</div>
 						<div className="facebook-preview__description">
-							{ facebookDescription( description || '' ) }
+							{ facebookDescription( strippedDescription ) }
 						</div>
 						<div className="facebook-preview__url">
 							{ compact( [ baseDomain( url ), author ] ).join( ' | ' ) }

--- a/client/components/seo/search-preview/index.jsx
+++ b/client/components/seo/search-preview/index.jsx
@@ -32,6 +32,8 @@ const googleUrl = hardTruncation( 79 );
 export default function SearchPreview( { description, title, url } ) {
 	const translate = useTranslate();
 
+	const strippedDescription = description ? description.replace( /<[^>]+>/g, '' ) : '';
+
 	return (
 		<div className="search-preview">
 			<h2 className="search-preview__header">{ translate( 'Search Preview' ) }</h2>
@@ -39,7 +41,7 @@ export default function SearchPreview( { description, title, url } ) {
 				<div className="search-preview__title">{ googleTitle( title ) }</div>
 				<div className="search-preview__url">{ googleUrl( url ) } ▾</div>
 				<div className="search-preview__description">
-					{ googleDescription( description || '' ) }
+					{ googleDescription( strippedDescription ) }
 				</div>
 			</div>
 		</div>

--- a/client/components/seo/twitter-preview/index.jsx
+++ b/client/components/seo/twitter-preview/index.jsx
@@ -23,13 +23,15 @@ export class TwitterPreview extends PureComponent {
 			backgroundImage: 'url(' + image + ')',
 		};
 
+		const strippedDescription = description ? description.replace( /<[^>]+>/g, '' ) : '';
+
 		return (
 			<div className="twitter-preview">
 				<div className={ `twitter-preview__${ type }` }>
 					{ image && <div className="twitter-preview__image" style={ previewImageStyle } /> }
 					<div className="twitter-preview__body">
 						<div className="twitter-preview__title">{ title }</div>
-						<div className="twitter-preview__description">{ description }</div>
+						<div className="twitter-preview__description">{ strippedDescription }</div>
 						<div className="twitter-preview__url">{ baseDomain( url || '' ) }</div>
 					</div>
 				</div>

--- a/packages/social-previews/src/facebook-preview/index.jsx
+++ b/packages/social-previews/src/facebook-preview/index.jsx
@@ -32,6 +32,8 @@ export class FacebookPreview extends PureComponent {
 	render() {
 		const { url, type, title, description, image, author } = this.props;
 
+		const strippedDescription = description ? description.replace( /<[^>]+>/g, '' ) : '';
+
 		return (
 			<div className={ `facebook-preview facebook-preview__${ type }` }>
 				<div className="facebook-preview__content">
@@ -41,7 +43,7 @@ export class FacebookPreview extends PureComponent {
 					<div className="facebook-preview__body">
 						<div className="facebook-preview__title">{ facebookTitle( title || '' ) }</div>
 						<div className="facebook-preview__description">
-							{ facebookDescription( description || '' ) }
+							{ facebookDescription( strippedDescription ) }
 						</div>
 						<div className="facebook-preview__url">
 							{ compact( [ baseDomain( url ), author ] ).join( ' | ' ) }

--- a/packages/social-previews/src/search-preview/index.jsx
+++ b/packages/social-previews/src/search-preview/index.jsx
@@ -32,6 +32,8 @@ const googleUrl = hardTruncation( 79 );
 export default function SearchPreview( { description, title, url } ) {
 	const translate = useTranslate();
 
+	const strippedDescription = description ? description.replace( /<[^>]+>/g, '' ) : '';
+
 	return (
 		<div className="search-preview">
 			<h2 className="search-preview__header">{ translate( 'Search Preview' ) }</h2>
@@ -39,7 +41,7 @@ export default function SearchPreview( { description, title, url } ) {
 				<div className="search-preview__title">{ googleTitle( title ) }</div>
 				<div className="search-preview__url">{ googleUrl( url ) } ▾</div>
 				<div className="search-preview__description">
-					{ googleDescription( description || '' ) }
+					{ googleDescription( strippedDescription ) }
 				</div>
 			</div>
 		</div>

--- a/packages/social-previews/src/twitter-preview/index.jsx
+++ b/packages/social-previews/src/twitter-preview/index.jsx
@@ -23,13 +23,15 @@ export class TwitterPreview extends PureComponent {
 			backgroundImage: 'url(' + image + ')',
 		};
 
+		const strippedDescription = description ? description.replace( /<[^>]+>/g, '' ) : '';
+
 		return (
 			<div className="twitter-preview">
 				<div className={ `twitter-preview__${ type }` }>
 					{ image && <div className="twitter-preview__image" style={ previewImageStyle } /> }
 					<div className="twitter-preview__body">
 						<div className="twitter-preview__title">{ title }</div>
-						<div className="twitter-preview__description">{ description }</div>
+						<div className="twitter-preview__description">{ strippedDescription }</div>
 						<div className="twitter-preview__url">{ baseDomain( url || '' ) }</div>
 					</div>
 				</div>

--- a/packages/social-previews/test/index.js
+++ b/packages/social-previews/test/index.js
@@ -45,6 +45,21 @@ describe( 'Facebook previews', () => {
 		expect( descTextNoEllipsis ).toHaveLength( 200 );
 	} );
 
+	it( 'should strip html tags from the description', () => {
+		const wrapper = shallow(
+			<Facebook description="<p style='color:red'>I know the kings of <span>England, and I quote the fights historical, From Marathon to Waterloo, in order categorical; I'm very well acquainted, too, with matters mathematical, I understand equations, <span>both</span> the simple and quadratical; About binomial theorem I'm teeming with a lot o' news, With many cheerful facts about the square of the hypotenuse." />
+		);
+
+		const descEl = wrapper.find( '.facebook-preview__description' );
+		expect( descEl.exists() ).toBeTruthy();
+		expect( descEl.text() ).toEqual(
+			"I know the kings of England, and I quote the fights historical, From Marathon to Waterloo, in order categorical; I'm very well acquainted, too, with matters mathematical, I understand equations, both …"
+		);
+
+		const descTextNoEllipsis = descEl.text().replace( '…', '' );
+		expect( descTextNoEllipsis ).toHaveLength( 200 );
+	} );
+
 	it( 'should display image only when provided', () => {
 		const wrapperNoImage = shallow( <Facebook /> );
 		const wrapperWithImage = shallow( <Facebook image={ IMAGE_SRC_FIXTURE } /> );
@@ -117,6 +132,18 @@ describe( 'Twitter previews', () => {
 	it( 'should display a untruncated description', () => {
 		const wrapper = shallow(
 			<Twitter description="I know the kings of England, and I quote the fights historical, From Marathon to Waterloo, in order categorical; I'm very well acquainted, too, with matters mathematical, I understand equations, both the simple and quadratical; About binomial theorem I'm teeming with a lot o' news, With many cheerful facts about the square of the hypotenuse." />
+		);
+
+		const descEl = wrapper.find( '.twitter-preview__description' );
+		expect( descEl.exists() ).toBeTruthy();
+		expect( descEl.text() ).toEqual(
+			"I know the kings of England, and I quote the fights historical, From Marathon to Waterloo, in order categorical; I'm very well acquainted, too, with matters mathematical, I understand equations, both the simple and quadratical; About binomial theorem I'm teeming with a lot o' news, With many cheerful facts about the square of the hypotenuse."
+		);
+	} );
+
+	it( 'should strip html tasgs from the description', () => {
+		const wrapper = shallow(
+			<Twitter description="<p style='color:red'>I know the kings of <span>England, and I quote the fights historical, From Marathon to Waterloo, in order categorical; I'm very well acquainted, too, with matters mathematical, I understand equations, <span>both</span> the simple and quadratical; About binomial theorem I'm teeming with a lot o' news, With many cheerful facts about the square of the hypotenuse." />
 		);
 
 		const descEl = wrapper.find( '.twitter-preview__description' );
@@ -252,6 +279,21 @@ describe( 'Search previews', () => {
 			);
 			const descriptionElNoEllipsis = descriptionEl.text().replace( '…', '' );
 			expect( descriptionElNoEllipsis ).toHaveLength( 160 );
+		} );
+
+		it( 'should strip html tags from the description', () => {
+			const descriptionUpperBound = 160 + 10;
+			const wrapper = shallow(
+				<Search description="<p style='color:red'>I am the very model</p> of a modern Major-General, I've information vegetable, animal, and mineral. I know the kings of England, and I quote the fights historical, <span>From</span> Marathon to Waterloo, in order categorical; I'm very well acquainted, too, with matters mathematical, I understand equations, both the simple and quadratical; About binomial theorem I'm teeming with a lot o' news, With many cheerful facts about the square of the hypotenuse." />
+			);
+
+			const descriptionEl = wrapper.find( '.search-preview__description' );
+			expect( descriptionEl.exists() ).toBeTruthy();
+			expect( descriptionEl.text() ).toEqual(
+				"I am the very model of a modern Major-General, I've information vegetable, animal, and mineral. I know the kings of England, and I quote the fights historical, From…"
+			);
+			const rawDescriptionText = descriptionEl.text().replace( '…', '' );
+			expect( rawDescriptionText.length ).toBeLessThanOrEqual( descriptionUpperBound );
 		} );
 	} );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* strip html tags from descriptions for social previews

#### Testing instructions
**Manual for legacy components** 
- Run yarn && yarn start to build all the things. Wait for Calypso to boot. Goto http://calypso.localhost:3000/.
- On a Business site, create a new Post with some content and a title and click "Preview".
- Toggle the Preview to "Search and Social" using the dropdown.
- You should see the post previews and be able to toggle between each type with no errors.
- Edit your page to only include an html block with the following
```
<p>paragraph Test</p>
<p class="test">Class Test</p>
<p style="color:red;">Style Test</p><p>
</p><div>Div Test</div>
```
- Facebook, Google, Twitter previews should display their description without any html tags

**Automatic for social-previews npm package**
`>yarn run jest -c=test/packages/jest.config.js packages/social-previews/test/index.js`

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
Before | After
-------|------
![](https://cln.sh/itXAez+) | ![](https://cln.sh/2A2PHh+)


Fixes #43948
