### PR TITLE
P2 signup: use .wordpress.com subdomain for p2 creation

### DIFF
--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -553,7 +553,7 @@ export function createWpForTeamsSite( callback, dependencies, stepData, reduxSto
 	const themeSlugWithRepo = 'pub/p2020';
 
 	const data = {
-		blog_name: `${ site }.p2.blog`,
+		blog_name: site,
 		blog_title: siteTitle,
 		public: -1, // wp for teams sites are not supposed to be public
 		options: {

--- a/client/signup/steps/p2-site/index.jsx
+++ b/client/signup/steps/p2-site/index.jsx
@@ -122,7 +122,7 @@ class P2Site extends React.Component {
 		if ( ! isEmpty( fields.site ) ) {
 			wpcom.undocumented().sitesNew(
 				{
-					blog_name: `${ fields.site }.p2.blog`,
+					blog_name: fields.site,
 					blog_title: fields.siteTitle,
 					validate: true,
 				},
@@ -310,7 +310,7 @@ class P2Site extends React.Component {
 						onBlur={ this.handleBlur }
 						onChange={ this.handleChangeEvent }
 					/>
-					<span className="p2-site__wordpress-domain-suffix">.p2.blog</span>
+					<span className="p2-site__wordpress-domain-suffix">.wordpress.com</span>
 				</ValidationFieldset>
 			</>
 		);


### PR DESCRIPTION
We need to switch back to using the `.wordpress.com` subdomain for P2 sites until we solve the 3rd party cookies issue.

## Testing

Navigate to `/start/p2` and create a new P2 site. It should be in the `<site>.wordpress.com` format now.