### PR TITLE
babel-plugin-i18n-calypso: Fix merging matching strings properties

### DIFF
--- a/packages/babel-plugin-i18n-calypso/package.json
+++ b/packages/babel-plugin-i18n-calypso/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/babel-plugin-i18n-calypso",
-	"version": "1.1.1",
+	"version": "1.2.0",
 	"description": "A Babel plugin to generate a POT file for translate calls",
 	"main": "src/index.js",
 	"dependencies": {

--- a/packages/babel-plugin-i18n-calypso/src/index.js
+++ b/packages/babel-plugin-i18n-calypso/src/index.js
@@ -211,6 +211,7 @@ function mergeStrings( source, target ) {
 		source.comments.extracted += '\n' + target.comments.extracted;
 	}
 
+	// A previous singular string matches a plural string. In PO files those are merged.
 	if ( ! source.hasOwnProperty( 'msgid_plural' ) && target.hasOwnProperty( 'msgid_plural' ) ) {
 		source.msgid_plural = target.msgid_plural;
 		source.msgstr = target.msgstr;

--- a/packages/babel-plugin-i18n-calypso/src/index.js
+++ b/packages/babel-plugin-i18n-calypso/src/index.js
@@ -189,6 +189,34 @@ function isValidTranslationKey( key ) {
 	);
 }
 
+/**
+ * Merge the properties of extracted string objects.
+ *
+ * @param   {object} source left-hand string object
+ * @param   {object} target right-hand string object
+ *
+ * @returns {void}
+ */
+function mergeStrings( source, target ) {
+	if ( ! source.comments.reference.includes( target.comments.reference ) ) {
+		source.comments.reference += '\n' + target.comments.reference;
+	}
+
+	if ( ! source.comments.extracted ) {
+		source.comments.extracted = target.comments.extracted;
+	} else if (
+		target.comments.extracted &&
+		! source.comments.extracted.includes( target.comments.extracted )
+	) {
+		source.comments.extracted += '\n' + target.comments.extracted;
+	}
+
+	if ( ! source.hasOwnProperty( 'msgid_plural' ) && target.hasOwnProperty( 'msgid_plural' ) ) {
+		source.msgid_plural = target.msgid_plural;
+		source.msgstr = target.msgstr;
+	}
+}
+
 module.exports = function () {
 	let strings = {},
 		nplurals = 2,
@@ -317,12 +345,8 @@ module.exports = function () {
 
 				if ( ! strings[ msgctxt ].hasOwnProperty( msgid ) ) {
 					strings[ msgctxt ][ msgid ] = translation;
-				} else if (
-					! strings[ msgctxt ][ msgid ].comments.reference.includes(
-						translation.comments.reference
-					)
-				) {
-					strings[ msgctxt ][ msgid ].comments.reference += '\n' + translation.comments.reference;
+				} else {
+					mergeStrings( strings[ msgctxt ][ msgid ], translation );
 				}
 			},
 			Program: {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Merge plurals and extracted comments for strings with the same singular (`msgid`) within the same JS file.

#### Testing instructions

Add the following code snippet to some JS component, e.g. `client/me/constants.js`:
```
i18n.translate( 'Test string extraction', { comment: 'comment1' } );
i18n.translate( 'Test string extraction', 'plural', {
	comment: 'comment2',
} );
```

Run `NODE_ENV=build_pot yarn build` and confirm `build/i18n-calypso/client-me-constants.js.pot` (or the respective POT file if you've added the snippet to other module) contains the extracted string with both comments and plural.
