### PR TITLE
Desktop: Fix the "try the block editor" dialog

### DIFF
--- a/client/post-editor/editor-gutenberg-dialogs/index.tsx
+++ b/client/post-editor/editor-gutenberg-dialogs/index.tsx
@@ -17,6 +17,7 @@ import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer'
 import isPrivateSite from 'state/selectors/is-private-site';
 import getWpAdminClassicEditorRedirectionUrl from '../../state/selectors/get-wp-admin-classic-editor-redirection-url';
 import isEditorDeprecationDialogShowing from 'state/selectors/is-editor-deprecation-dialog-showing';
+import { isEnabled } from 'config';
 
 /**
  * We don't support classic editor in Calypso for private atomic sites. This components makes sure
@@ -81,7 +82,8 @@ const EditorGutenbergDialogs: React.FC< {} > = () => {
 		]
 	);
 
-	if ( editorDeprecationDialogShowing ) {
+	if ( editorDeprecationDialogShowing && ! isEnabled( 'desktop' ) ) {
+		// This condition needs to be kept in sync with https://github.com/Automattic/wp-calypso/blob/dbfef92960de2c1a8f4b061cdd9b5d1914c12648/client/post-editor/post-editor.jsx#L305
 		return null;
 	}
 

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -57,7 +57,7 @@ import {
 	isEditedPostDirty,
 } from 'state/posts/selectors';
 import { getCurrentUserId } from 'state/current-user/selectors';
-import editedPostHasContent from 'state/selectors/edited-post-has-content';
+import { editedPostHasContent } from 'state/posts/selectors/edited-post-has-content';
 import hasBrokenSiteUserConnection from 'state/selectors/has-broken-site-user-connection';
 import isVipSite from 'state/selectors/is-vip-site';
 import EditorConfirmationSidebar from 'post-editor/editor-confirmation-sidebar';

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -57,7 +57,7 @@ import {
 	isEditedPostDirty,
 } from 'state/posts/selectors';
 import { getCurrentUserId } from 'state/current-user/selectors';
-import { editedPostHasContent } from 'state/posts/selectors/edited-post-has-content';
+import editedPostHasContent from 'state/selectors/edited-post-has-content';
 import hasBrokenSiteUserConnection from 'state/selectors/has-broken-site-user-connection';
 import isVipSite from 'state/selectors/is-vip-site';
 import EditorConfirmationSidebar from 'post-editor/editor-confirmation-sidebar';
@@ -302,6 +302,7 @@ export class PostEditor extends React.Component {
 				<EditorPostTypeUnsupported />
 				<EditorForbidden />
 				<EditorRevisionsDialog loadRevision={ this.loadRevision } />
+				{ /* This condition needs to be kept in sync with https://github.com/Automattic/wp-calypso/blob/680cc77f39400aab3e090c373630c8dd0f1887cd/client/post-editor/editor-gutenberg-dialogs/index.tsx#L84*/ }
 				{ ! this.props.isEditorDeprecated && ! isEnabled( 'desktop' ) && (
 					<EditorDeprecationDialog />
 				) }


### PR DESCRIPTION
Allows users to try the Block editor by using the button in the sidebar. The editor deprecation dialog message was preventing this dialog from showing.

#### Changes proposed in this Pull Request
Make sure the conditions under which the editor deprecation dialog shows is reflected in the Gutenberg Opt In dialog, so that the Opt In dialog can show when the button is clicked.

#### Testing instructions
- Clear local storage
- Set a site to use the classic editor: http://calypso.localhost:3000/post/[site]?set-editor=classic
- You should see the deprecation notice:

<img width="1193" alt="Screenshot 2020-07-28 at 16 38 44" src="https://user-images.githubusercontent.com/275961/88688166-f4710f00-d0f0-11ea-98b9-c02b32697adf.png">

- Now visit http://calypso.localhost:3000/post/[site]?flags=desktop
- You should not see the deprecation notice
- Click on "Try the block editor" in the sidebar.
- You should see the opt in notice:

<img width="1196" alt="Screenshot 2020-07-28 at 16 24 06" src="https://user-images.githubusercontent.com/275961/88686485-0baefd00-d0ef-11ea-9e24-e787d94f387b.png">


Fixes #
