### PR TITLE
Typography: Fix incorrect REM values in typography standards in devdocs

### DIFF
--- a/client/devdocs/design/typography.jsx
+++ b/client/devdocs/design/typography.jsx
@@ -237,7 +237,7 @@ export default class Typography extends React.PureComponent {
 									<code>$font-title-small</code>
 								</td>
 								<td>20</td>
-								<td>1.313</td>
+								<td>1.25</td>
 							</tr>
 							<tr>
 								<td>
@@ -258,7 +258,7 @@ export default class Typography extends React.PureComponent {
 									<code>$font-body-extra-small</code>
 								</td>
 								<td>12</td>
-								<td>0.667</td>
+								<td>0.75</td>
 							</tr>
 						</tbody>
 					</table>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Found this while I was working on linting for font sizes. I didn't update the rem units for 20px and 12px correctly in /devdocs; they still corresponded to the old type scale. 

**Before**

<img width="450" alt="Screen Shot 2020-07-28 at 1 38 55 PM" src="https://user-images.githubusercontent.com/2124984/88701476-0b573780-d0d8-11ea-97bf-a7632e9979c0.png">

**After**

<img width="439" alt="Screen Shot 2020-07-28 at 1 51 31 PM" src="https://user-images.githubusercontent.com/2124984/88702534-73f2e400-d0d9-11ea-897e-52a77f10f702.png">

#### Testing instructions

* Switch to this PR and navigate to `/devdocs/design/typography`
* Scroll to the bottom of the page
* Double-check my math 😅 
