### PR TITLE
desktop: disable backup

### DIFF
--- a/client/components/jetpack/sidebar/menu-items/index.jsx
+++ b/client/components/jetpack/sidebar/menu-items/index.jsx
@@ -20,6 +20,7 @@ import getIsSiteWPCOM from 'state/selectors/is-site-wpcom';
 import QueryScanState from 'components/data/query-jetpack-scan';
 import ScanBadge from 'components/jetpack/scan-badge';
 import SidebarItem from 'layout/sidebar/item';
+import { isEnabled } from 'config';
 
 export default ( { path, showIcons, tracksEventNames, expandSection } ) => {
 	const translate = useTranslate();
@@ -30,6 +31,8 @@ export default ( { path, showIcons, tracksEventNames, expandSection } ) => {
 	const isWPCOM = useSelector( ( state ) => getIsSiteWPCOM( state, siteId ) );
 	const scanProgress = useSelector( ( state ) => getSiteScanProgress( state, siteId ) );
 	const scanThreats = useSelector( ( state ) => getSiteScanThreats( state, siteId ) );
+
+	const isDesktop = isEnabled( 'desktop' );
 
 	const onNavigate = ( event ) => () => {
 		dispatch( recordTracksEvent( event ) );
@@ -53,15 +56,21 @@ export default ( { path, showIcons, tracksEventNames, expandSection } ) => {
 				selected={ currentPathMatches( `/activity-log/${ siteSlug }` ) }
 				expandSection={ expandSection }
 			/>
-			<SidebarItem
-				materialIcon={ showIcons ? 'backup' : undefined }
-				materialIconStyle="filled"
-				label="Backup"
-				link={ backupPath( siteSlug ) }
-				onNavigate={ onNavigate( tracksEventNames.backupClicked ) }
-				selected={ currentPathMatches( backupPath( siteSlug ) ) }
-				expandSection={ expandSection }
-			/>
+			{
+				// Backup does not work in wp-desktop. Disable in the desktop app until
+				// it can be revisited: https://github.com/Automattic/wp-desktop/issues/943
+				! isDesktop && (
+					<SidebarItem
+						materialIcon={ showIcons ? 'backup' : undefined }
+						materialIconStyle="filled"
+						label="Backup"
+						link={ backupPath( siteSlug ) }
+						onNavigate={ onNavigate( tracksEventNames.backupClicked ) }
+						selected={ currentPathMatches( backupPath( siteSlug ) ) }
+						expandSection={ expandSection }
+					/>
+				)
+			}
 			{ ! isWPCOM && (
 				<SidebarItem
 					materialIcon={ showIcons ? 'security' : undefined }


### PR DESCRIPTION
### Description

This PR disables backup in the wp-desktop app as a number of backup features do not work (see Automattic/wp-desktop#943). Until we can revisit how this feature is implemented in the desktop app in its entirety, let's disable it for now.

### To Test

Requires a site with a purchased plan in order for the backup feature to be available.

1. Select Plan in the sidebar.
1. Select the Plans tab to view available plans.
1. Purchase a plan to get Jetpack backups.

- Desktop: verify that the backup menu item is hidden (for a site with a purchased plan)

<p align="center">
<img width="250" alt="jetpack-no-backup" src="https://user-images.githubusercontent.com/8979548/88705808-05645500-d0de-11ea-9039-b0e951294201.png">
</p>

- Web: verify the backup menu items continues to be shown as expected

<p align="center">
<img width="250" alt="jetpack-backup" src="https://user-images.githubusercontent.com/8979548/88705813-085f4580-d0de-11ea-9323-421928c713d2.png">
</p>