### PR TITLE
Typography: Update stylelintrc to include correct font size rem values

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -2,6 +2,7 @@
 	"plugins": ["@signal-noise/stylelint-scales"],
 	"rules": {
 		"scales/font-weight": [[ 400, 600, 700, "normal", "bold", "inherit" ]],
+		"scales/font-size": [[ 0.75, 0.875, 1, 1.25, 1.5, 2, 2.25, 3, 3.375 ], { unit: "rem" } ],
 
 		"color-hex-case": "lower",
 		"color-no-invalid-hex": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update stylelintrc with rem units and values corresponding to the new variables.
* Stylelint scales does not lint for Sass variable names, but this will still be useful to catch the use of ems or px or values outside the given scale. It's a step in the right direction.
* Also noted stylelint scales does not output the desired units in the error message if both values (scale and unit) are incorrect; only if the value is correct but the unit is not. I may open a ticket with them to suggest including that information since it could be useful (the difference between `.75px` and `.75rem` is pretty big. :D) 

**Visual output example**

<img width="523" alt="Screen Shot 2020-07-28 at 2 30 16 PM" src="https://user-images.githubusercontent.com/2124984/88706464-e619f780-d0de-11ea-9cd5-7633c9393b33.png">

#### Testing instructions

* Switch to this PR and run `yarn build`
* Update a SCSS file with a `font-size` value you know to be outside the above scale (ie. `font-size: 18px`)
* Try to commit the file; you should get an error similar to the one above.
