### PR TITLE
My Sites: Put 'Add your credentials' banner below site nav on mobile

### DIFF
--- a/client/my-sites/site-settings/main.jsx
+++ b/client/my-sites/site-settings/main.jsx
@@ -29,12 +29,12 @@ import './style.scss';
 const SiteSettingsComponent = ( { siteId, translate } ) => {
 	return (
 		<Main className="site-settings">
-			<JetpackBackupCredsBanner event={ 'settings-backup-credentials' } />
 			<DocumentHead title={ translate( 'Site Settings' ) } />
 			<QueryProductsList />
 			<QuerySitePurchases siteId={ siteId } />
 			<JetpackDevModeNotice />
 			<SidebarNavigation />
+			<JetpackBackupCredsBanner event={ 'settings-backup-credentials' } />
 			<FormattedHeader
 				brandFont
 				className="site-settings__page-heading"

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -156,8 +156,8 @@ class StatsSite extends Component {
 		return (
 			<>
 				<PrivacyPolicyBanner />
-				<JetpackBackupCredsBanner event={ 'stats-backup-credentials' } />
 				<SidebarNavigation />
+				<JetpackBackupCredsBanner event={ 'stats-backup-credentials' } />
 				<FormattedHeader
 					brandFont
 					className="stats__section-header"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Move the "Add your server credentials" banner below site navigation on the **Settings** and **Stats** pages, as it is on the **Activity** page.

#### Testing instructions

* Select a Jetpack site with no stored server credentials, or invalid stored server credentials.
* On the **Activity**, **Stats**, and **Settings** pages, for mobile layouts, verify that the "Add your server credentials" banner appears directly *below* the site selection/navigation bar, instead of above it.

#### Screenshots

<img width="393" alt="Screen Shot 2020-07-28 at 13 44 44" src="https://user-images.githubusercontent.com/670067/88708018-a7813e80-d0d8-11ea-9c5a-26e3fc49dab4.png">

<img width="387" alt="Screen Shot 2020-07-28 at 13 44 58" src="https://user-images.githubusercontent.com/670067/88708030-ab14c580-d0d8-11ea-9c99-0f87023478cb.png">

<img width="386" alt="Screen Shot 2020-07-28 at 13 45 18" src="https://user-images.githubusercontent.com/670067/88708047-aea84c80-d0d8-11ea-88c4-b1464ae75a7b.png">