### PR TITLE
Rename FSE plugin to WordPress.com Editing Toolkit plugin

### DIFF
--- a/apps/full-site-editing/README.md
+++ b/apps/full-site-editing/README.md
@@ -2,6 +2,23 @@
 
 This plugin includes many sub-features which add blocks and new functionality to the Gutenberg editor. The plugin provides a single codebase which can be installed on any platform which requires these features, such as the WordPress.com multisite or other standalone WordPress instances.
 
+**Note: This plugin is currently being renamed from Full Site Editing Plugin to WordPress.com Editing Toolkit Plugin.**
+In the near future, the following will be changed:
+
+- Directories and filenames referencing "full site editing"
+- Code referencing those filenames
+- Documentation
+- CI job names
+
+Those will be updated to use "editing-toolkit" in place of "full-site-editing"
+
+The following items will likely not change:
+
+- The plugin slug, which will remain `full-site-editing` due to rename limitations in WordPress.
+- The root full-site-editing-plugin.php file (to preserve the plugin slug).
+- The `full-site-editing` textdomain, also to reference the slug.
+- The \A8C\FSE php namespace may not ever be fully converted, since it is referenced in many places outside of the plugin.
+
 ## File Architecture
 
 - `package.json`: The package file for the editing toolkit monorepo app.

--- a/apps/full-site-editing/README.md
+++ b/apps/full-site-editing/README.md
@@ -1,12 +1,13 @@
-# Full Site Editing (FSE) Plugin
+# WordPress.com Editing Toolkit Plugin
 
-This plugin should not be confused with the site editor work in core Gutenberg. This plugin includes many sub-features which add blocks and ophew functionality to the Gutenberg editor. The plugin provides a single codebase which can be installed on any platform which requires these features, such as the WordPress.com multisite or other standalone WordPress instances. 
+This plugin includes many sub-features which add blocks and new functionality to the Gutenberg editor. The plugin provides a single codebase which can be installed on any platform which requires these features, such as the WordPress.com multisite or other standalone WordPress instances.
 
 ## File Architecture
-* `package.json`: The package file for the FSE monorepo app.
-* `.wp-env.json`: Local environment configuration for the FSE plugin.
-* `bin/`: Scripts to assis with your local developmenet environment and testing.
-* `full-site-editing-plugin/`: The root of the FSE plugin.
+
+- `package.json`: The package file for the editing toolkit monorepo app.
+- `.wp-env.json`: Local environment configuration for the editing toolkit plugin.
+- `bin/`: Scripts to assis with your local developmenet environment and testing.
+- `full-site-editing-plugin/`: The root of the editing toolkit plugin.
   - `full-site-editing-plugin.php`: All initialization code should go here.
   - `block-patterns/`: Additional block patterns for Gutenberg.
   - `common/`: General functionality which doesn't fit a specific feature and is always executed.
@@ -15,7 +16,7 @@ This plugin should not be confused with the site editor work in core Gutenberg. 
   - `event-countdown-block/`: A block which counts down to a specified date.
   - `global-styles/`: (_deprecated_) A plugin which adds a global font picker to the editor. (Superceeded by global style work in Gutenberg.)
   - `jetpack-timeline/`: A block which lets you create a timeline of events.
-  - `newspack-blocks/`: Container for newspack blocks such as the carousel block and the blog post block. 
+  - `newspack-blocks/`: Container for newspack blocks such as the carousel block and the blog post block.
   - `posts-list-block/`: (_deprecated_) A simple block to show a list of posts on a page. (Superceeded by the blog-posts-block.)
   - `site-editor/`: Gutenberg site-editor integration code for WordPress.com.
   - `starter-page-templates/`: Allows you to select different page layouts made of blocks.
@@ -41,20 +42,20 @@ import 'a8c-fse-common-data-stores';
 _Note: `cd` to `apps/full-site-editing` before running these commands_
 
 - `yarn dev`<br>
-Compiles the plugins and watches for changes.
+  Compiles the plugins and watches for changes.
 
 - `yarn build`<br>
-Compiles and minifies the plugins for production.
+  Compiles and minifies the plugins for production.
 
 Both these scripts will also move all source and PHP files into `/dist` in their respective folders.
 
 The entry point is:
 
-- __Plugin__: `/full-site-editing-plugin/{{plugin-directory}}/index.js`
+- **Plugin**: `/full-site-editing-plugin/{{plugin-directory}}/index.js`
 
 The output is:
 
-- __Plugin__: `/full-site-editing-plugin/{{plugin-directory}}/dist`
+- **Plugin**: `/full-site-editing-plugin/{{plugin-directory}}/dist`
 
 ### Building Individual _Plugins_
 
@@ -68,7 +69,9 @@ yarn build:posts-list-block`
 ## Local Development
 
 ### Docker:
+
 For a simple Docker experience, use wp-env.
+
 ```sh
 # From wp-calypso root:
 ./apps/full-site-editing/bin/setup-env.sh
@@ -85,9 +88,10 @@ wp-env stop
 wp-env run cli wp ... # Runs a wp-cli command.
 ```
 
-Once the environment running, you can use the dev script (shown above), and the environment will automatically see the updated build. It works by mounting the FSE plugin as a Docker volume.
+Once the environment running, you can use the dev script (shown above), and the environment will automatically see the updated build. It works by mounting the editing toolkit plugin as a Docker volume.
 
 ### Other:
+
 Build (or `dev`) and symlink the plugin into a local WordPress install.
 
 E.g.

--- a/apps/full-site-editing/dev-plugin/dev.php
+++ b/apps/full-site-editing/dev-plugin/dev.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * Plugin Name: WordPress.com Editor Toolkit Development
- * Description: Overrides for Editor Toolkit development.
+ * Plugin Name: WordPress.com Editing Toolkit Development
+ * Description: Overrides for Editing Toolkit development.
  * Version: dev
  * Author: Automattic
  * Author URI: https://automattic.com/wordpress-plugins/

--- a/apps/full-site-editing/dev-plugin/dev.php
+++ b/apps/full-site-editing/dev-plugin/dev.php
@@ -1,12 +1,8 @@
 <?php
 /**
- * Plugin Name: Full Site Editing Development
- * Description: Overrides for Full Site Editing development.
+ * Plugin Name: WordPress.com Editor Toolkit Development
+ * Description: Overrides for Editor Toolkit development.
  * Version: dev
- * Author: Automattic
- * Author URI: https://automattic.com/wordpress-plugins/
- * License: GPLv2 or later
- * Text Domain: full-site-editing
  * Author: Automattic
  * Author URI: https://automattic.com/wordpress-plugins/
  * License: GPLv2 or later

--- a/apps/full-site-editing/dev-plugin/dev.php
+++ b/apps/full-site-editing/dev-plugin/dev.php
@@ -15,6 +15,9 @@ namespace A8C\FSE;
 
 use A8C\FSE\EarnDev\SubscriptionService\Mock_SubscriptionService;
 
+/**
+ * Load mock paywall for development.
+ */
 function premium_content_dev_paywall() {
 	include_once __DIR__ . '/premium-content/class-mock-subscription-service.php';
 	return new Mock_SubscriptionService();

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Plugin Name: Full Site Editing
+ * Plugin Name: WordPress.com Editing Toolkit
  * Description: Enhances your page creation workflow within the Block Editor.
  * Version: 1.14
  * Author: Automattic
@@ -22,8 +22,8 @@ namespace A8C\FSE;
  * includes your feature's files via the 'plugins_loaded' action.
  *
  * Please take care to _not_ load your feature's files if there are situations
- * which could cause bugs. For example, FSE files are only loaded if FSE is
- * active on the site.
+ * which could cause bugs. For example, dotcom FSE files are only loaded if dotcom
+ * FSE isactive on the site.
  *
  * Finally, don't forget to use the A8C\FSE namespace for your code. :)
  */
@@ -50,7 +50,7 @@ function load_core_site_editor() {
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_core_site_editor' );
 
 /**
- * Load Full Site Editing.
+ * Load dotcom-FSE.
  */
 function load_full_site_editing() {
 	// Bail if FSE should not be active on the site. We do not
@@ -185,9 +185,9 @@ add_action( 'plugins_loaded', __NAMESPACE__ . '\load_editor_gutenboarding_launch
  * Add front-end CoBlocks gallery block scripts.
  *
  * This function performs the same enqueueing duties as `CoBlocks_Block_Assets::frontend_scripts`,
- * but for our FSE header and footer content. `frontend_scripts` uses `has_block` to determine
- * if gallery blocks are present, and `has_block` is not aware of content sections outside of
- * post_content yet.
+ * but for dotcom FSE header and footer content. `frontend_scripts` uses
+ * `has_block` to determine if gallery blocks are present, and `has_block` is
+ * not aware of content sections outside of post_content yet.
  */
 function enqueue_coblocks_gallery_scripts() {
 	if ( ! function_exists( 'CoBlocks' ) || ! is_full_site_editing_active() ) {
@@ -272,7 +272,7 @@ function load_wpcom_block_editor_nux() {
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_wpcom_block_editor_nux' );
 
 /**
- * Load FSE block patterns
+ * Load editing toolkit block patterns
  */
 function load_block_patterns() {
 	if ( ! function_exists( '\gutenberg_load_block_pattern' ) ) {

--- a/apps/full-site-editing/full-site-editing-plugin/readme.txt
+++ b/apps/full-site-editing/full-site-editing-plugin/readme.txt
@@ -1,4 +1,4 @@
-=== Full Site Editing ===
+=== WordPress.com Editing Toolkit ===
 Contributors: alexislloyd, allancole, automattic, bartkalisz, codebykat, copons, dmsnell, get_dave, glendaviesnz, gwwar, iamtakashi, iandstewart, jeryj, Joen, jonsurrell, kwight, marekhrabe, mattwiebe, mkaz, mmtr86, mppfeiffer, noahtallen, nosolosw, nrqsnchz, obenland, okenobi, owolski, philipmjackson, vindl
 Tags: block, blocks, editor, gutenberg, page
 Requires at least: 5.0
@@ -8,7 +8,7 @@ Requires PHP: 5.6.20
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
-Enhances your page creation workflow within the Block Editor.
+Enhances the editing experience in the Block Editor.
 
 == Description ==
 

--- a/apps/full-site-editing/package.json
+++ b/apps/full-site-editing/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@automattic/full-site-editing",
 	"version": "1.14.0",
-	"description": "Plugin for editing related features.",
+	"description": "Plugin for editing-related features.",
 	"sideEffects": true,
 	"repository": {
 		"type": "git",

--- a/apps/full-site-editing/package.json
+++ b/apps/full-site-editing/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@automattic/full-site-editing",
 	"version": "1.14.0",
-	"description": "Plugin for full site editing with the block editor.",
+	"description": "Plugin for editing related features.",
 	"sideEffects": true,
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
### Changes proposed in this Pull Request
1. Change the display name of the plugin.
2. Update documentation and comments to use new name.

This does not change code or directories yet. (Separate PRs)

### Testing instructions
1. Install in a WordPress instance.
2. Verify that the plugin display name is "WordPress.com Editing Toolkit"

### Screenshots
<img width="1517" alt="Screen Shot 2020-07-28 at 12 07 53 PM" src="https://user-images.githubusercontent.com/6265975/88710102-fcb65380-d0ca-11ea-89df-afc099d8b7de.png">


