### PR TITLE
Importers: Fix Preview image generation issue

### DIFF
--- a/client/state/imports/site-importer/selectors.js
+++ b/client/state/imports/site-importer/selectors.js
@@ -20,5 +20,5 @@ export function getImportStage( state ) {
 }
 
 export function getValidatedSiteUrl( state ) {
-	state.imports.siteImporter?.validatedSiteUrl;
+	return state.imports.siteImporter?.validatedSiteUrl;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fix the issue with importers failing to load their preview image (and consquently failing to import content from any site). See pbkcP4-ee-p2 for context.

The reason is a missing `return` statement, apparently an oversight in https://github.com/Automattic/wp-calypso/pull/44205/files#diff-d1e744ac3ffa8e0248ab3a0b29c3065eR23.

#### Testing instructions

- Go to `http://calypso.localhost:3000/import/<yoursite>.wordpress.com`
- Click on [Import from] Wix
- Select an example Wix site to import from. (See e.g. pbkcP4-ee-p2#comment-568).

Fixes #44503.