### PR TITLE
Launch Jetpack Anti-Spam

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -58,6 +58,7 @@
 		"jetpack/features-section/jetpack": true,
 		"jetpack/search-product": true,
 		"jetpack/backups-restore": true,
+		"jetpack/anti-spam-product": true,
 		"jetpack/on-demand-scan": true,
 		"jitms": true,
 		"keyboard-shortcuts": true,

--- a/config/production.json
+++ b/config/production.json
@@ -60,6 +60,7 @@
 		"jetpack/scan-product": true,
 		"jetpack/search-product": true,
 		"jetpack/wpcom-search-product": true,
+		"jetpack/anti-spam-product": true,
 		"jetpack/on-demand-scan": true,
 		"jetpack/backups-restore": true,
 		"jitms": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds Jetpack Anti-Spam produce to production and horizon config files.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run a local copy of Calypso prod.
* Verify Jetpack Anti-Spam is visible and able to be purchased.

Fixes 1181531115069428-as-1185356281661171.
