### PR TITLE
Analytics: Fix bug preventing wp-affiliate-tracker cookie from being set

### DIFF
--- a/client/lib/analytics/track-affiliate-referral.js
+++ b/client/lib/analytics/track-affiliate-referral.js
@@ -43,7 +43,7 @@ export async function trackAffiliateReferral( { affiliateId, campaignId, subId, 
 
 	try {
 		const response = await window.fetch( 'https://refer.wordpress.com/clicks/67402', {
-			withCredentials: true, // Needed to check and set the 'wp-affiliate-tracker' cookie.
+			credentials: 'include', // Needed to check and set the 'wp-affiliate-tracker' cookie.
 			method: 'POST',
 			headers,
 			body,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This fix replaces the incorrect `withCredentials: true` option being passed to `fetch()` with the correct `credentials: 'include'` option, which fixes a bug where the `wp-affiliate-tracker` cookie was not being properly set.

With the incorrect option, the `wp-affiliate-tracker` cookie was being received in the headers but not being sent to the browser. This is because [`fetch()` won't send cookies unless the `credentials` init option is set.](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Parameters) 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

To observe the bug:

- Visit https://wordpress.com/start/user?ref=alp-lp&tk_amp=1*s4a2cn*amp_client_id*YW1wLWQzY3J6b2JOMmpXazhSZ3NkRnhJelE.*aff*MzAxMDI.*sid*RU4tMTU0NTkwMzg.&_gl=1*1ptehrf*_ga*YW1wLVRvYXBDT2R0WHZKVnV3WG0tQTlEc2c
- In the Chrome Inspector, Filter Network requests by `refer.wordpress.com` and observe that the `set-cookie: wp-affiliate-tracker` header was passed in the Response Headers
- In the Chrome Inspector, visit Application → Cookies → https://wordpress.com and observe that the `wp-affiliate-tracker` cookie is **not** set as would be expected

To test the fix:
- Run Calypso locally with this patch applied and visit this URL: http://calypso.localhost:3000/start/user?ref=alp-lp&tk_amp=1*s4a2cn*amp_client_id*YW1wLWQzY3J6b2JOMmpXazhSZ3NkRnhJelE.*aff*MzAxMDI.*sid*RU4tMTU0NTkwMzg.&_gl=1*1ptehrf*_ga*YW1wLVRvYXBDT2R0WHZKVnV3WG0tQTlEc2c
- In the Chrome Inspector, visit Application → Cookies → http://calypso.localhost:3000 and confirm the `wp-affiliate-tracker` cookie was set.
