### PR TITLE
Nav sidebar: Increase contrast for "Visit site" links active/hover/focus states

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/style.scss
@@ -80,6 +80,12 @@ $transition-period: 100ms;
 
 	a {
 		color: $light-gray-800;
+
+		&:active,
+		&:focus,
+		&:hover {
+			color: $white;
+		}
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Ensures that the text in the "Visit site" link in the nav sidebar is always readable.

* Make the "Visit site" link white when in the `:active`, `:focus` and `:hover` states.

![Jul-29-2020 14-48-14](https://user-images.githubusercontent.com/1500769/88750880-9274e000-d1aa-11ea-869b-7dd1593488a6.gif)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch
* `cd apps/full-site-editing && yarn build && npx wp-env start`
* `localhost:4013/wp-admin`
* Go to edit a post or a page
* Click the `W` button to open the nav sidebar
* Hover over the link
* Tab to the link
* Click and hold on any of the link
* It should be readable

Fixes #44446 