### PR TITLE
Nav sidebar: correctly format site titles correctly when they are long or have punctuation

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { useLayoutEffect, useRef, useEffect, useState } from '@wordpress/element';
+import { decodeEntities } from '@wordpress/html-entities';
 import { useDispatch, useSelect } from '@wordpress/data';
 import {
 	Button as OriginalButton,
@@ -204,7 +205,7 @@ function WpcomBlockEditorNavSidebar() {
 					/>
 				</div>
 				<div className="wpcom-block-editor-nav-sidebar-nav-sidebar__site-title">
-					<h2>{ siteTitle }</h2>
+					<h2>{ decodeEntities( siteTitle ) }</h2>
 					{ SITE_HOME_URL && (
 						<ExternalLink href={ SITE_HOME_URL }>
 							{ __( 'Visit site', 'full-site-editing' ) }

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/style.scss
@@ -76,6 +76,7 @@ $transition-period: 100ms;
 		margin: 0;
 		font-size: $big-font-size;
 		line-height: $default-line-height;
+		word-wrap: break-word;
 	}
 
 	a {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Wrap site title using `word-wrap: break-word`. This will wrap very long words, but will also ensure that it will still prefer to wrap on spaces where possible.
* Decode html entities in the site title before rendering 

**Before**
<img width="771" alt="before wrap" src="https://user-images.githubusercontent.com/1500769/88760887-1f776380-d1c2-11ea-94f8-4906262dd454.png">

**After**
<img width="771" alt="after wrap" src="https://user-images.githubusercontent.com/1500769/88760893-21d9bd80-d1c2-11ea-9911-164c2379f34a.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply the D47155-code to your sandbox
* Sandbox your favourite test site
* Give your test site a snazzy name that either has very long words or some totally reasonable symbols e.g. `&` or `'`
* You should also test it with a site title with shorter words, and the wrapping should still behave as you'd expect (wrapping on spaces)
* See how your title looks in the nav sidebar

