### PR TITLE
Bump WordPress.com Editing Toolkit version to 1.15

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WordPress.com Editing Toolkit
  * Description: Enhances your page creation workflow within the Block Editor.
- * Version: 1.14
+ * Version: 1.15
  * Author: Automattic
  * Author URI: https://automattic.com/wordpress-plugins/
  * License: GPLv2 or later
@@ -35,7 +35,7 @@ namespace A8C\FSE;
  *
  * @var string
  */
-define( 'PLUGIN_VERSION', '1.14' );
+define( 'PLUGIN_VERSION', '1.15' );
 
 // Always include these helper files for dotcom FSE.
 require_once __DIR__ . '/dotcom-fse/helpers.php';

--- a/apps/full-site-editing/full-site-editing-plugin/readme.txt
+++ b/apps/full-site-editing/full-site-editing-plugin/readme.txt
@@ -3,7 +3,7 @@ Contributors: alexislloyd, allancole, automattic, bartkalisz, codebykat, copons,
 Tags: block, blocks, editor, gutenberg, page
 Requires at least: 5.0
 Tested up to: 5.4
-Stable tag: 1.14
+Stable tag: 1.15
 Requires PHP: 5.6.20
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -39,6 +39,14 @@ This plugin is experimental, so we don't provide any support for it outside of w
 
 
 == Changelog ==
+
+= 1.15
+* Plugin display name changed to WordPress.com Editing Toolkit.
+* The donation block has been removed from the plugin.
+* Add a launch sidebar to the editor to walk the user through the launch flows.
+* Improved contrast of links in the navigation sidebar.
+* Fix formatting of the site title in the navigation sidebar.
+* Fix broken site editor close button when navigation sidebar is active.
 
 = 1.14 =
 * Add missing dependencies to package declaration.

--- a/apps/full-site-editing/package.json
+++ b/apps/full-site-editing/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/full-site-editing",
-	"version": "1.14.0",
+	"version": "1.15.0",
 	"description": "Plugin for editing-related features.",
 	"sideEffects": true,
 	"repository": {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Bumps version of the editing toolkit

New Relase notes:
* Plugin display name changed to WordPress.com Editing Toolkit.
* The donation block has been removed from the plugin.
* Improved contrast of links in the navigation sidebar.
* Add a launch sidebar to the editor to walk the user through the launch flows.
* Fix formatting of the site title in the navigation sidebar.

Changes included in this release:
* #44299 
* #44418 
* #44412 
* #44499 
* #44507 
* #42835 
* #44146 
* #44278 
* #44508 
* #44546 
* #44549
* #44574
* #44582
* #44601

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D47156-code to your sandbox
* Check the features included in this release appear in the editor as expected
* Smoke test the editor on Atomic with and without the Gutenberg plugin enabled
