### PR TITLE
Jetpack: Remove partner logic to allow some plan management again for partner-provisioned products

### DIFF
--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -208,10 +208,6 @@ class ManagePurchase extends Component {
 			return null;
 		}
 
-		if ( isPartnerPurchase( purchase ) ) {
-			return null;
-		}
-
 		if ( canEditPaymentDetails( purchase ) ) {
 			const path = getEditCardDetailsPath( this.props.siteSlug, purchase );
 			const renewing = isRenewing( purchase );
@@ -237,10 +233,6 @@ class ManagePurchase extends Component {
 	}
 
 	renderRemovePurchaseNavItem() {
-		if ( isPartnerPurchase( this.props.purchase ) ) {
-			return null;
-		}
-
 		return (
 			<RemovePurchase
 				hasLoadedSites={ this.props.hasLoadedSites }
@@ -294,7 +286,7 @@ class ManagePurchase extends Component {
 		const { isAtomicSite, purchase, translate } = this.props;
 		const { id } = purchase;
 
-		if ( ! isCancelable( purchase ) || isPartnerPurchase( purchase ) ) {
+		if ( ! isCancelable( purchase ) ) {
 			return null;
 		}
 
@@ -413,9 +405,7 @@ class ManagePurchase extends Component {
 			<div className="manage-purchase__content">
 				<span className="manage-purchase__description">{ description }</span>
 				<span className="manage-purchase__settings-link">
-					{ ! isPartnerPurchase( purchase ) && site && (
-						<ProductLink purchase={ purchase } selectedSite={ site } />
-					) }
+					{ site && <ProductLink purchase={ purchase } selectedSite={ site } /> }
 				</span>
 				{ registrationAgreementUrl && (
 					<a href={ registrationAgreementUrl } target="_blank" rel="noopener noreferrer">

--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -926,7 +926,7 @@ class PurchaseNotice extends Component {
 			return null;
 		}
 
-		if ( isDomainTransfer( this.props.purchase ) || isPartnerPurchase( this.props.purchase ) ) {
+		if ( isDomainTransfer( this.props.purchase ) ) {
 			return null;
 		}
 
@@ -943,6 +943,10 @@ class PurchaseNotice extends Component {
 		const expiredNotice = this.renderExpiredRenewNotice();
 		if ( expiredNotice ) {
 			return expiredNotice;
+		}
+
+		if ( isPartnerPurchase( this.props.purchase ) ) {
+			return null;
 		}
 
 		const expiringNotice = this.renderPurchaseExpiringNotice();

--- a/client/my-sites/plans/current-plan/purchases-listing.jsx
+++ b/client/my-sites/plans/current-plan/purchases-listing.jsx
@@ -182,8 +182,8 @@ class PurchasesListing extends Component {
 	getActionButton( purchase ) {
 		const { selectedSiteSlug, translate } = this.props;
 
-		// No action button if there's no site selected or we're dealing with a partner site.
-		if ( ! selectedSiteSlug || ! purchase || isPartnerPurchase( purchase ) ) {
+		// No action button if there's no site selected.
+		if ( ! selectedSiteSlug || ! purchase ) {
 			return null;
 		}
 

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -29,7 +29,6 @@ import withTrackingTool from 'lib/analytics/with-tracking-tool';
 import { getByPurchaseId } from 'state/purchases/selectors';
 import QuerySitePurchases from 'components/data/query-site-purchases';
 import { getCurrentPlan } from 'state/sites/plans/selectors';
-import { isPartnerPurchase, getPartnerName } from 'lib/purchases';
 import CartData from 'components/data/cart';
 import { PerformanceTrackerStop } from 'lib/performance-tracking';
 
@@ -78,33 +77,6 @@ class Plans extends React.Component {
 		}
 	}
 
-	renderPlanWithPartner = () => {
-		const { context, purchase, translate } = this.props;
-
-		const partnerName = getPartnerName( purchase );
-
-		return (
-			<div>
-				<DocumentHead title={ translate( 'Plans', { textOnly: true } ) } />
-				<Main wideLayout={ true }>
-					<SidebarNavigation />
-					<div id="plans" className="plans plans__has-sidebar">
-						<PlansNavigation path={ context.path } />
-						<EmptyContent
-							illustration="/calypso/images/illustrations/illustration-jetpack.svg"
-							title={ translate( 'Your plan is managed by %(partnerName)s', {
-								args: { partnerName },
-							} ) }
-							line={ translate(
-								'You purchased this plan as part of an all inclusive package with your website host.'
-							) }
-						/>
-					</div>
-				</Main>
-			</div>
-		);
-	};
-
 	renderPlaceholder = () => {
 		return (
 			<div>
@@ -124,16 +96,11 @@ class Plans extends React.Component {
 			translate,
 			displayJetpackPlans,
 			canAccessPlans,
-			purchase,
 			customerType,
 		} = this.props;
 
 		if ( ! selectedSite || this.isInvalidPlanInterval() ) {
 			return this.renderPlaceholder();
-		}
-
-		if ( purchase && isPartnerPurchase( purchase ) ) {
-			return this.renderPlanWithPartner();
 		}
 
 		return (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Undo several changes from #36463 as we are re-allowing user cancellations and upgrades from partner-provisioned products. These purchases should still not be renewable or show price/billing period info.

#### Screenshots
`/me/purchases`:
#### BEFORE
<img width="765" alt="Before-me-purchases" src="https://user-images.githubusercontent.com/19717814/88779731-f2ce3800-d13e-11ea-85c2-120835313a0b.png">

#### AFTER (no change)
<img width="748" alt="After-me-purchases" src="https://user-images.githubusercontent.com/19717814/88990786-c2e47900-d293-11ea-965a-ac8155a7d27f.png">

***
`/me/purchases/:siteSlug/:purchaseId`:
#### BEFORE
<img width="781" alt="Before-purchaseID" src="https://user-images.githubusercontent.com/19717814/88781273-08446180-d141-11ea-8bd0-131759e87335.png">

#### AFTER
<img width="761" alt="After-purchaseID" src="https://user-images.githubusercontent.com/19717814/88990807-ced03b00-d293-11ea-956f-1fa11ce50a11.png">

***
`/plans/:siteSlug`:
#### BEFORE
<img width="1787" alt="Before-plans" src="https://user-images.githubusercontent.com/19717814/88781438-3fb30e00-d141-11ea-859b-df2294bb74f4.png">

#### AFTER
<img width="1595" alt="After-plans" src="https://user-images.githubusercontent.com/19717814/88991558-d7c20c00-d295-11ea-8a65-7b197151bb3a.png">

***
`/plans/my-plan/:siteSlug`:
#### BEFORE
<img width="1128" alt="Before-MyPlan" src="https://user-images.githubusercontent.com/19717814/88781533-5ce7dc80-d141-11ea-93d7-d42cda05b103.png">

#### AFTER (no change)
<img width="1131" alt="After-MyPlan" src="https://user-images.githubusercontent.com/19717814/88991054-7483aa00-d294-11ea-9b3d-afe300c93608.png">

***
#### Testing instructions

1. Provision a Jurassic Ninja site with a partner Jetpack plan. You can use the Jetpack Start tool in MC.
2. Visit each of this pages
   * `/me/purchases`
   * `/me/purchases/:siteSlug/:purchaseId`
   * `/plans/:siteSlug`
   * `/plans/my-plan/:siteSlug`
3. For each of these pages
   * Your Partner Plan Site on Production - these should match the "Before" Screenshots
   * Your Partner Plan Site on the branch - these should match the "After" Screenshots