### PR TITLE
Update Quick Start CTA link from the Business purchase Thank you page

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/business-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/business-plan-details.jsx
@@ -37,7 +37,6 @@ const BusinessPlanDetails = ( {
 	sitePlans,
 	selectedFeature,
 	purchases,
-	displayMode,
 } ) => {
 	const shouldPromoteJetpack = useSelector( ( state ) =>
 		isJetpackSectionEnabledForSite( state, selectedSite?.ID )
@@ -72,7 +71,8 @@ const BusinessPlanDetails = ( {
 				icon={ <img alt="" src={ conciergeImage } /> }
 				title={ i18n.translate( 'Get personalized help' ) }
 				description={ i18n.translate(
-					'Schedule a $49 Quick Start session with a Happiness Engineer to set up your site and learn more about WordPress.com.'
+					'Schedule a Quick Start session with a Happiness Engineer to set up ' +
+						'your site and learn more about WordPress.com.'
 				) }
 				buttonText={ i18n.translate( 'Purchase a session' ) }
 				href={ `/checkout/offer-quickstart-session` }

--- a/client/my-sites/checkout/checkout-thank-you/business-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/business-plan-details.jsx
@@ -40,6 +40,7 @@ const BusinessPlanDetails = ( { selectedSite, sitePlans, selectedFeature, purcha
 	const plan = find( sitePlans.data, isBusiness );
 	const googleAppsWasPurchased = purchases.some( isGoogleApps );
 
+	const locale = i18n.getLocaleSlug();
 	return (
 		<div>
 			{ googleAppsWasPurchased && <GoogleAppsDetails purchases={ purchases } /> }
@@ -62,17 +63,19 @@ const BusinessPlanDetails = ( { selectedSite, sitePlans, selectedFeature, purcha
 				hasDomainCredit={ plan && plan.hasDomainCredit }
 			/>
 
-			<PurchaseDetail
-				icon={ <img alt="" src={ conciergeImage } /> }
-				title={ i18n.translate( 'Get personalized help' ) }
-				description={ i18n.translate(
-					'Schedule a Quick Start session with a Happiness Engineer to set up ' +
+			{ ( 'en' === locale || i18n.hasTranslation( 'Purchase a session' ) ) && (
+				<PurchaseDetail
+					icon={ <img alt="" src={ conciergeImage } /> }
+					title={ i18n.translate( 'Get personalized help' ) }
+					description={ i18n.translate(
+						'Schedule a Quick Start session with a Happiness Engineer to set up ' +
 						'your site and learn more about WordPress.com.'
-				) }
-				buttonText={ i18n.translate( 'Purchase a session' ) }
-				href={ `/checkout/offer-quickstart-session` }
-				onClick={ trackOnboardingButtonClick }
-			/>
+					) }
+					buttonText={ i18n.translate( 'Purchase a session' ) }
+					href={ `/checkout/offer-quickstart-session` }
+					onClick={ trackOnboardingButtonClick }
+				/>
+			) }
 
 			{ ! selectedFeature && (
 				<PurchaseDetail

--- a/client/my-sites/checkout/checkout-thank-you/business-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/business-plan-details.jsx
@@ -69,7 +69,7 @@ const BusinessPlanDetails = ( { selectedSite, sitePlans, selectedFeature, purcha
 					title={ i18n.translate( 'Get personalized help' ) }
 					description={ i18n.translate(
 						'Schedule a Quick Start session with a Happiness Engineer to set up ' +
-						'your site and learn more about WordPress.com.'
+							'your site and learn more about WordPress.com.'
 					) }
 					buttonText={ i18n.translate( 'Purchase a session' ) }
 					href={ `/checkout/offer-quickstart-session` }

--- a/client/my-sites/checkout/checkout-thank-you/business-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/business-plan-details.jsx
@@ -72,11 +72,10 @@ const BusinessPlanDetails = ( {
 				icon={ <img alt="" src={ conciergeImage } /> }
 				title={ i18n.translate( 'Get personalized help' ) }
 				description={ i18n.translate(
-					'Schedule a Quick Start session with a Happiness Engineer to set up ' +
-						'your site and learn more about WordPress.com.'
+					'Schedule a $49 Quick Start session with a Happiness Engineer to set up your site and learn more about WordPress.com.'
 				) }
-				buttonText={ i18n.translate( 'Schedule a session' ) }
-				href={ `/me/concierge/${ selectedSite.slug }/book` }
+				buttonText={ i18n.translate( 'Purchase a session' ) }
+				href={ `/checkout/offer-quickstart-session` }
 				onClick={ trackOnboardingButtonClick }
 			/>
 

--- a/client/my-sites/checkout/checkout-thank-you/business-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/business-plan-details.jsx
@@ -32,12 +32,7 @@ function trackOnboardingButtonClick() {
 	recordTracksEvent( 'calypso_checkout_thank_you_onboarding_click' );
 }
 
-const BusinessPlanDetails = ( {
-	selectedSite,
-	sitePlans,
-	selectedFeature,
-	purchases,
-} ) => {
+const BusinessPlanDetails = ( { selectedSite, sitePlans, selectedFeature, purchases } ) => {
 	const shouldPromoteJetpack = useSelector( ( state ) =>
 		isJetpackSectionEnabledForSite( state, selectedSite?.ID )
 	);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR changes **Get personalized help** section's CTA link on the Business Plan purchase. New link should now showcases a Quick Start session upsell.
See pbBQWj-eI-p2 for more details.

<img width="460" src="https://user-images.githubusercontent.com/2749938/88781610-45d2da00-d195-11ea-8b46-23f2a25e0d1b.png"/>


#### Testing instructions

* Purchase a new Business plan or upgrade.
* The CTA button for the **Get personalised help** should be **Purchase a session** and should point to [https://wordpress.com/checkout/offer-quickstart-session](https://wordpress.com/checkout/offer-quickstart-session)
<img width="660" src="https://user-images.githubusercontent.com/2749938/88805172-817e9b80-d1b7-11ea-997d-4124365ad25b.png"/>


