### PR TITLE
Enable all domains list on production

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -71,6 +71,7 @@
 		"login/native-login-links": true,
 		"login/wp-login": true,
 		"mailchimp": false,
+		"manage/all-domains": true,
 		"manage/comments": true,
 		"manage/custom-post-types": true,
 		"manage/customize": true,

--- a/config/production.json
+++ b/config/production.json
@@ -74,6 +74,7 @@
 		"login/native-login-links": true,
 		"login/wp-login": true,
 		"mailchimp": true,
+		"manage/all-domains": true,
 		"manage/comments": true,
 		"manage/custom-post-types": true,
 		"manage/customize": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -81,6 +81,7 @@
 		"login/native-login-links": true,
 		"login/wp-login": true,
 		"mailchimp": true,
+		"manage/all-domains": true,
 		"manage/comments": true,
 		"manage/custom-post-types": true,
 		"manage/customize": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Enable the feature flag for all domains view ( aka `/domains/manage` ) on production.

This feature flag introduces a central place to manage all domains across different sites that you manage. That includes a redesign of the site specific domain list and how the primary domain is displayed and changed in there.

The view was created in the following PRs: #42741, #42930, #42954, #43181, #43347, #43356, #43375, #43456, #43696, #43717, #43772, #43794, #43801, #43833, #43864, #43913, #43952, #43999, #44072, #44135, #44171, #44176, #44362, #44378, #44384, #44399

#### Testing instructions

* Verify that `/domains/manage` is visible on staging/production.
