### PR TITLE
calypsoify-iframe: replace `MediaStore.get` with `getMediaItem` thunk

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -51,7 +51,7 @@ import { withStopPerformanceTrackingProp, PerformanceTrackProps } from 'lib/perf
 import { REASON_BLOCK_EDITOR_UNKOWN_IFRAME_LOAD_FAILURE } from 'state/desktop/window-events';
 import inEditorDeprecationGroup from 'state/editor-deprecation-group/selectors/in-editor-deprecation-group';
 import { setMediaLibrarySelectedItems } from 'state/media/actions';
-import { fetchMediaItem } from 'state/media/thunks';
+import { fetchMediaItem, getMediaItem } from 'state/media/thunks';
 
 /**
  * Types
@@ -242,7 +242,7 @@ class CalypsoifyIframe extends Component<
 					? value.map( ( item ) => parseInt( item, 10 ) )
 					: [ parseInt( value, 10 ) ];
 				const selectedItems = ids.map( ( id ) => {
-					const media = MediaStore.get( siteId, id );
+					const media = this.props.getMediaItem( siteId, id );
 					if ( ! media ) {
 						this.props.fetchMediaItem( siteId, id );
 					}
@@ -806,6 +806,7 @@ const mapDispatchToProps = {
 	notifyDesktopCannotOpenEditor,
 	setMediaLibrarySelectedItems,
 	fetchMediaItem,
+	getMediaItem,
 };
 
 type ConnectedProps = ReturnType< typeof mapStateToProps > & typeof mapDispatchToProps;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* calypsoify-iframe: replace `MediaStore.get` with `getMediaItem` thunk

#### Testing instructions

1. Open a post in Gutenberg which contains an image on a simple site
2. Hit reload
3. Open the browser devtools and change to the _Network_ tab, filter for `/media` XHRs
4. Click on that image and hit _Replace_ > _Open Media Library_
5. Make sure there's a request fetching that image `/media/<mediaId>`
6. Close the modal by clicking on _Cancel_ and do 4. again but make sure there's no such request like in 5.

related to #43663
