### PR TITLE
CircleCI: Store Lint test results

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -359,6 +359,8 @@ jobs:
                 --output-file "$CIRCLE_TEST_REPORTS/eslint/results.xml" \
                 $FILES_TO_LINT
             fi
+      - store_test_results:
+          path: /tmp/test_results
 
   build-notifications:
     <<: *defaults

--- a/client/components/button-group/index.jsx
+++ b/client/components/button-group/index.jsx
@@ -12,7 +12,7 @@ import './style.scss';
 
 class ButtonGroup extends PureComponent {
 	static propTypes = {
-		children(props) {
+		children( props ) {
 			let error = null;
 			React.Children.forEach( props.children, ( child ) => {
 				if ( child && ( ! child.props || child.props.type !== 'button' ) ) {

--- a/client/components/button-group/index.jsx
+++ b/client/components/button-group/index.jsx
@@ -12,7 +12,7 @@ import './style.scss';
 
 class ButtonGroup extends PureComponent {
 	static propTypes = {
-		children( props ) {
+		children(props) {
 			let error = null;
 			React.Children.forEach( props.children, ( child ) => {
 				if ( child && ( ! child.props || child.props.type !== 'button' ) ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Previously, test results from ESLint weren't stored by the corresponding CircleCI job, as @sirbrillig reported (p1595979536234600-slack-calypso). 

![Screen Shot 2020-07-28 at 7 48 16 PM](https://user-images.githubusercontent.com/96308/88795967-348fca80-d1a1-11ea-822b-7d9b50c292f5.png)

This PR adds them. See [CircleCI docs](https://circleci.com/docs/2.0/collect-test-data/#eslint).

#### Testing instructions

I pushed a [commit](https://github.com/Automattic/wp-calypso/pull/44519/commits/82d143f56770634e37c424e5865092c34531ee90) that introduced a lint error. CircleCI is now reporting the error :tada: 

![image](https://user-images.githubusercontent.com/96308/88797721-124b7c00-d1a4-11ea-8839-965dd509a003.png)
