### PR TITLE
Social Previews: moved code to a helper function

### DIFF
--- a/packages/social-previews/src/facebook-preview/index.jsx
+++ b/packages/social-previews/src/facebook-preview/index.jsx
@@ -5,7 +5,7 @@
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import { compact } from 'lodash';
-import { firstValid, hardTruncation, shortEnough } from '../helpers';
+import { firstValid, hardTruncation, shortEnough, stripHtmlTags } from '../helpers';
 
 /**
  * Style dependencies
@@ -32,8 +32,6 @@ export class FacebookPreview extends PureComponent {
 	render() {
 		const { url, type, title, description, image, author } = this.props;
 
-		const strippedDescription = description ? description.replace( /<[^>]+>/g, '' ) : '';
-
 		return (
 			<div className={ `facebook-preview facebook-preview__${ type }` }>
 				<div className="facebook-preview__content">
@@ -43,7 +41,7 @@ export class FacebookPreview extends PureComponent {
 					<div className="facebook-preview__body">
 						<div className="facebook-preview__title">{ facebookTitle( title || '' ) }</div>
 						<div className="facebook-preview__description">
-							{ facebookDescription( strippedDescription ) }
+							{ facebookDescription( stripHtmlTags( description ) ) }
 						</div>
 						<div className="facebook-preview__url">
 							{ compact( [ baseDomain( url ), author ] ).join( ' | ' ) }

--- a/packages/social-previews/src/helpers.js
+++ b/packages/social-previews/src/helpers.js
@@ -17,3 +17,6 @@ export const hardTruncation = ( limit ) => ( title ) => title.slice( 0, limit ).
 
 export const firstValid = ( ...predicates ) => ( a ) =>
 	find( predicates, ( p ) => false !== p( a ) )( a );
+
+export const stripHtmlTags = ( description ) =>
+	description ? description.replace( /(<([^>]+)>)/gi, '' ) : '';

--- a/packages/social-previews/src/search-preview/index.jsx
+++ b/packages/social-previews/src/search-preview/index.jsx
@@ -5,7 +5,13 @@
 import PropTypes from 'prop-types';
 import { useTranslate } from 'i18n-calypso';
 import React from 'react';
-import { firstValid, hardTruncation, shortEnough, truncatedAtSpace } from '../helpers';
+import {
+	firstValid,
+	hardTruncation,
+	shortEnough,
+	truncatedAtSpace,
+	stripHtmlTags,
+} from '../helpers';
 
 /**
  * Style dependencies
@@ -32,8 +38,6 @@ const googleUrl = hardTruncation( 79 );
 export default function SearchPreview( { description, title, url } ) {
 	const translate = useTranslate();
 
-	const strippedDescription = description ? description.replace( /<[^>]+>/g, '' ) : '';
-
 	return (
 		<div className="search-preview">
 			<h2 className="search-preview__header">{ translate( 'Search Preview' ) }</h2>
@@ -41,7 +45,7 @@ export default function SearchPreview( { description, title, url } ) {
 				<div className="search-preview__title">{ googleTitle( title ) }</div>
 				<div className="search-preview__url">{ googleUrl( url ) } ▾</div>
 				<div className="search-preview__description">
-					{ googleDescription( strippedDescription ) }
+					{ googleDescription( stripHtmlTags( description ) ) }
 				</div>
 			</div>
 		</div>

--- a/packages/social-previews/src/twitter-preview/index.jsx
+++ b/packages/social-previews/src/twitter-preview/index.jsx
@@ -6,6 +6,12 @@ import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 
 /**
+ * Internal dependencies
+ */
+
+import { stripHtmlTags } from '../helpers';
+
+/**
  * Style dependencies
  */
 import './style.scss';
@@ -23,15 +29,13 @@ export class TwitterPreview extends PureComponent {
 			backgroundImage: 'url(' + image + ')',
 		};
 
-		const strippedDescription = description ? description.replace( /<[^>]+>/g, '' ) : '';
-
 		return (
 			<div className="twitter-preview">
 				<div className={ `twitter-preview__${ type }` }>
 					{ image && <div className="twitter-preview__image" style={ previewImageStyle } /> }
 					<div className="twitter-preview__body">
 						<div className="twitter-preview__title">{ title }</div>
-						<div className="twitter-preview__description">{ strippedDescription }</div>
+						<div className="twitter-preview__description">{ stripHtmlTags( description ) }</div>
 						<div className="twitter-preview__url">{ baseDomain( url || '' ) }</div>
 					</div>
 				</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

For the social previews npm package only:

* move strip code to a helper function
* use enhanced regex as proposed in issue

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* run 
`>yarn run jest -c=test/packages/jest.config.js packages/social-previews/test/index.js`

Fixes #44521
