### PR TITLE
Remove problematic language from Jetpack selector and documentation

### DIFF
--- a/client/extensions/woocommerce/app/promotions/promotion-models.js
+++ b/client/extensions/woocommerce/app/promotions/promotion-models.js
@@ -361,7 +361,7 @@ const freeShippingModel = {
 };
 
 /**
- * Master list of models by promotion type.
+ * Primary list of models by promotion type.
  *
  * Note: The keys of this object correspond with promotion.type
  */
@@ -379,7 +379,7 @@ export default allModels;
  *
  * @param {object} promotion The promotion to validate.
  * @param {string} currency The currency to use for validations.
- * @param { bool } showEmptyValidationErrors True if empty required fields should be errors.
+ * @param {boolean} showEmptyValidationErrors True if empty required fields should be errors.
  * @returns {object} Validation error strings keyed by their field names.
  */
 export function validateAll( promotion, currency, showEmptyValidationErrors ) {

--- a/client/my-sites/site-settings/manage-connection/site-ownership.jsx
+++ b/client/my-sites/site-settings/manage-connection/site-ownership.jsx
@@ -20,7 +20,7 @@ import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import Gravatar from 'components/gravatar';
 import isJetpackSiteConnected from 'state/selectors/is-jetpack-site-connected';
 import isJetpackSiteInDevelopmentMode from 'state/selectors/is-jetpack-site-in-development-mode';
-import isJetpackUserMaster from 'state/selectors/is-jetpack-user-master';
+import isJetpackUserConnectionOwner from 'state/selectors/is-jetpack-user-connection-owner';
 import OwnershipInformation from './ownership-information';
 import QueryJetpackConnection from 'components/data/query-jetpack-connection';
 import QueryJetpackUserConnection from 'components/data/query-jetpack-user-connection';
@@ -156,7 +156,7 @@ class SiteOwnership extends Component {
 	}
 
 	renderConnectionDetails() {
-		const { siteIsConnected, siteIsInDevMode, translate, userIsMaster } = this.props;
+		const { siteIsConnected, siteIsInDevMode, translate, userIsConnectionOwner } = this.props;
 
 		if ( siteIsConnected === false ) {
 			return translate( 'The site is not connected.' );
@@ -174,14 +174,14 @@ class SiteOwnership extends Component {
 
 		return (
 			<Fragment>
-				{ userIsMaster !== null && (
+				{ userIsConnectionOwner !== null && (
 					<FormSettingExplanation>
-						{ userIsMaster
+						{ userIsConnectionOwner
 							? translate( "You are the owner of this site's connection to WordPress.com." )
 							: translate( "Somebody else owns this site's connection to WordPress.com." ) }
 					</FormSettingExplanation>
 				) }
-				{ userIsMaster && this.renderCurrentUserDropdown() }
+				{ userIsConnectionOwner && this.renderCurrentUserDropdown() }
 			</Fragment>
 		);
 	}
@@ -281,7 +281,7 @@ export default connect(
 			siteIsConnected: isJetpackSiteConnected( state, siteId ),
 			siteIsJetpack: isJetpackSite( state, siteId ),
 			siteIsInDevMode: isJetpackSiteInDevelopmentMode( state, siteId ),
-			userIsMaster: isJetpackUserMaster( state, siteId ),
+			userIsConnectionOwner: isJetpackUserConnectionOwner( state, siteId ),
 		};
 	},
 	{ changeOwner, recordTracksEvent, transferPlanOwnership }

--- a/client/state/selectors/is-jetpack-user-connection-owner.js
+++ b/client/state/selectors/is-jetpack-user-connection-owner.js
@@ -10,13 +10,14 @@ import { get } from 'lodash';
 import getJetpackUserConnection from 'state/selectors/get-jetpack-user-connection';
 
 /**
- * Returns true if the Jetpack site current user is the master user who owns the connection. False otherwise.
+ * Returns true if the Jetpack site current user is the user who owns the connection. False otherwise.
  * Returns null if the site is unknown, or there is no information yet.
  *
  * @param  {object}   state    Global state tree
  * @param  {number}   siteId   The ID of the site we're querying
- * @returns {?boolean}          Whether the current site user is the master user.
+ * @returns {?boolean}          Whether the current site user is the connection owner.
  */
-export default function isJetpackUserMaster( state, siteId ) {
+export default function isJetpackUserConnectionOwner( state, siteId ) {
+	// eslint-disable-next-line inclusive-language/use-inclusive-words
 	return get( getJetpackUserConnection( state, siteId ), [ 'isMaster' ], null );
 }

--- a/client/state/selectors/test/is-jetpack-user-connection-owner.js
+++ b/client/state/selectors/test/is-jetpack-user-connection-owner.js
@@ -6,11 +6,11 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
-import isJetpackUserMaster from 'state/selectors/is-jetpack-user-master';
+import isJetpackUserConnectionOwner from 'state/selectors/is-jetpack-user-connection-owner';
 import { dataItems } from './fixtures/jetpack-connection';
 
-describe( 'isJetpackUserMaster()', () => {
-	test( "should return true if the user is the master user of the site's connection", () => {
+describe( 'isJetpackUserConnectionOwner()', () => {
+	test( "should return true if the user is owner of the site's connection", () => {
 		const stateIn = {
 				jetpack: {
 					connection: {
@@ -19,11 +19,11 @@ describe( 'isJetpackUserMaster()', () => {
 				},
 			},
 			siteId = 12345678;
-		const output = isJetpackUserMaster( stateIn, siteId );
+		const output = isJetpackUserConnectionOwner( stateIn, siteId );
 		expect( output ).to.be.true;
 	} );
 
-	test( "should return false if the user is not the master user of the site's connection", () => {
+	test( "should return false if the user is not the owner of the site's connection", () => {
 		const stateIn = {
 				jetpack: {
 					connection: {
@@ -32,7 +32,7 @@ describe( 'isJetpackUserMaster()', () => {
 				},
 			},
 			siteId = 87654321;
-		const output = isJetpackUserMaster( stateIn, siteId );
+		const output = isJetpackUserConnectionOwner( stateIn, siteId );
 		expect( output ).to.be.false;
 	} );
 
@@ -45,7 +45,7 @@ describe( 'isJetpackUserMaster()', () => {
 				},
 			},
 			siteId = 88888888;
-		const output = isJetpackUserMaster( stateIn, siteId );
+		const output = isJetpackUserConnectionOwner( stateIn, siteId );
 		expect( output ).to.be.null;
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Rename `isJetpackUserMaster` to `isJetpackUserConnectionOwner`
* Update a comment to remove problematic language
* Fix a linting error

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

I'm still unclear on these, trying to get verification of exactly how this is.
* Using an external site that is connected to Calypso via Jetpack, navigate to the "connection settings" and verify that with the correct user you see that you are either an owner or not the owner of the connection.
* Ensure unit tests still pass

Part of #43395 
