### PR TITLE
Update how primary domain change affects the domain item row

### DIFF
--- a/client/my-sites/domains/domain-management/list/domain-item.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-item.jsx
@@ -407,7 +407,9 @@ class DomainItem extends PureComponent {
 		const { domain, domainDetails, isManagingAllSites, showCheckbox, enableSelection } = this.props;
 		const { listStatusText, listStatusClass } = resolveDomainStatus( domainDetails || domain );
 
-		const rowClasses = classNames( 'domain-item', `domain-item__status-${ listStatusClass }` );
+		const rowClasses = classNames( 'domain-item', `domain-item__status-${ listStatusClass }`, {
+			'domain-item__enable-selection': enableSelection,
+		} );
 		const domainTitleClass = classNames( 'domain-item__title', {
 			'domain-item__primary': ! isManagingAllSites && domainDetails?.isPrimary,
 		} );

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -502,7 +502,7 @@ export class List extends React.Component {
 						}
 					>
 						{ this.state.changePrimaryDomainModeEnabled
-							? translate( 'Abort primary domain change' )
+							? translate( 'Cancel primary domain change' )
 							: translate( 'Change primary domain' ) }
 					</Button>
 				</div>
@@ -577,7 +577,12 @@ export class List extends React.Component {
 
 		return [
 			<QuerySitePurchases key="query-purchases" siteId={ selectedSite.ID } />,
-			<ListHeader key="domains-header" />,
+			<ListHeader
+				key="domains-header"
+				headerClasses={ {
+					'domain-item__enable-selection': this.state.changePrimaryDomainModeEnabled,
+				} }
+			/>,
 			...domainListItems,
 			manageAllDomainsLink,
 		];

--- a/client/my-sites/domains/domain-management/list/list-header.jsx
+++ b/client/my-sites/domains/domain-management/list/list-header.jsx
@@ -3,6 +3,8 @@
  */
 import { localize } from 'i18n-calypso';
 import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -16,11 +18,17 @@ import InfoPopover from 'components/info-popover';
 import './style.scss';
 
 class ListHeader extends React.PureComponent {
+	static propTypes = {
+		headerClasses: PropTypes.object,
+	};
+
 	render() {
-		const { translate } = this.props;
+		const { headerClasses, translate } = this.props;
+
+		const listHeaderClasses = classNames( 'list-header', headerClasses );
 
 		return (
-			<CompactCard className="list-header">
+			<CompactCard className={ listHeaderClasses }>
 				<div className="list__domain-link" />
 				<div className="list__domain-transfer-lock">
 					{ translate( 'Transfer lock' ) }

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -345,6 +345,12 @@ input[type='radio'].domain-management-list-item__radio {
 	}
 }
 
+.domain-item__enable-selection {
+	> .list__domain-transfer-lock, > .list__domain-privacy, > .list__domain-auto-renew, > .list__domain-email, > .list__domain-options {
+		visibility: hidden;
+	}
+}
+
 .domain-item__overlay {
 	z-index: 2;
 	background-color: rgba( 255, 255, 255, 0.8 );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Hide the detailed domain information when the "Change primary domain" button is clicked 
* Change the "Abort primary domain change" button text to "Cancel primary domain change"

Here's how it looks (before clicking on the button):
<img width="1059" alt="Screenshot 2020-07-29 at 19 14 45" src="https://user-images.githubusercontent.com/1355045/88825237-037abe80-d1d0-11ea-997a-348af68a18b0.png">
After clicking on the button:
<img width="1058" alt="Screenshot 2020-07-29 at 19 14 51" src="https://user-images.githubusercontent.com/1355045/88825244-05dd1880-d1d0-11ea-9e4f-c7160579407a.png">


#### Testing instructions

* Open the site domains view and click on "Change primary domain" button in the header section
* Verify that the detailed domain data is hidden
