### PR TITLE
Checkout: Do not display contact details form if the cart is only renewals, take 2

### DIFF
--- a/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
@@ -17,6 +17,12 @@ import {
 	translateCheckoutPaymentMethodToWpcomPaymentMethod,
 	prepareDomainContactDetails,
 } from 'my-sites/checkout/composite-checkout/wpcom';
+import {
+	hasGoogleApps,
+	hasDomainRegistration,
+	hasOnlyRenewalItems,
+	hasTransferProduct,
+} from 'lib/cart-values/cart-items';
 
 const debug = debugFactory( 'calypso:composite-checkout:payment-method-helpers' );
 
@@ -354,4 +360,17 @@ export function filterAppropriatePaymentMethods( {
 				allowedPaymentMethods || serverAllowedPaymentMethods
 			);
 		} );
+}
+
+export function needsDomainDetails( cart ) {
+	if ( cart && hasOnlyRenewalItems( cart ) ) {
+		return false;
+	}
+	if (
+		cart &&
+		( hasDomainRegistration( cart ) || hasGoogleApps( cart ) || hasTransferProduct( cart ) )
+	) {
+		return true;
+	}
+	return false;
 }

--- a/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
@@ -24,6 +24,7 @@ import {
 	hasOnlyRenewalItems,
 	hasTransferProduct,
 } from 'lib/cart-values/cart-items';
+import { createStripePaymentMethod } from 'lib/stripe';
 
 const debug = debugFactory( 'calypso:composite-checkout:payment-method-helpers' );
 const { select } = defaultRegistry;
@@ -369,4 +370,14 @@ export function needsDomainDetails( cart ) {
 		return true;
 	}
 	return false;
+}
+
+export function createStripePaymentMethodToken( { stripe, name, country, postalCode } ) {
+	return createStripePaymentMethod( stripe, {
+		name,
+		address: {
+			country,
+			postal_code: postalCode,
+		},
+	} );
 }

--- a/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
@@ -4,6 +4,7 @@
 import React, { useReducer, useEffect, useState } from 'react';
 import debugFactory from 'debug';
 import { useTranslate } from 'i18n-calypso';
+import { defaultRegistry } from '@automattic/composite-checkout';
 
 /**
  * Internal dependencies
@@ -25,6 +26,7 @@ import {
 } from 'lib/cart-values/cart-items';
 
 const debug = debugFactory( 'calypso:composite-checkout:payment-method-helpers' );
+const { select } = defaultRegistry;
 
 export function useStoredCards( getStoredCards, onEvent ) {
 	const [ state, dispatch ] = useReducer( storedCardsReducer, {
@@ -93,19 +95,18 @@ export async function submitPayPalExpressRequest( transactionData, submit ) {
 	return submit( formattedTransactionData );
 }
 
-export function getDomainDetails( select ) {
+function getDomainDetails() {
 	const managedContactDetails = select( 'wpcom' )?.getContactInfo?.() ?? {};
 	return prepareDomainContactDetails( managedContactDetails );
 }
 
 export function addDomainDetailsToSubmitData(
 	submitData,
-	select,
 	{ includeDomainDetails, includeGSuiteDetails }
 ) {
 	return {
 		...submitData,
-		domainDetails: includeDomainDetails || includeGSuiteDetails ? getDomainDetails( select ) : null,
+		domainDetails: includeDomainDetails || includeGSuiteDetails ? getDomainDetails() : null,
 	};
 }
 

--- a/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
@@ -92,6 +92,13 @@ export function getDomainDetails( select ) {
 	return prepareDomainContactDetails( managedContactDetails );
 }
 
+export function addDomainDetailsToSubmitData( submitData, select ) {
+	return {
+		...submitData,
+		domainDetails: getDomainDetails( select ),
+	};
+}
+
 export async function fetchStripeConfiguration( requestArgs, wpcom ) {
 	return wpcom.stripeConfiguration( requestArgs );
 }

--- a/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
@@ -95,19 +95,10 @@ export async function submitPayPalExpressRequest( transactionData, submit ) {
 	return submit( formattedTransactionData );
 }
 
-function getDomainDetails() {
+export function getDomainDetails( { includeDomainDetails, includeGSuiteDetails } ) {
 	const managedContactDetails = select( 'wpcom' )?.getContactInfo?.() ?? {};
-	return prepareDomainContactDetails( managedContactDetails );
-}
-
-export function addDomainDetailsToSubmitData(
-	submitData,
-	{ includeDomainDetails, includeGSuiteDetails }
-) {
-	return {
-		...submitData,
-		domainDetails: includeDomainDetails || includeGSuiteDetails ? getDomainDetails() : null,
-	};
+	const domainDetails = prepareDomainContactDetails( managedContactDetails );
+	return includeDomainDetails || includeGSuiteDetails ? domainDetails : null;
 }
 
 export async function fetchStripeConfiguration( requestArgs, wpcom ) {

--- a/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
@@ -98,10 +98,14 @@ export function getDomainDetails( select ) {
 	return prepareDomainContactDetails( managedContactDetails );
 }
 
-export function addDomainDetailsToSubmitData( submitData, select ) {
+export function addDomainDetailsToSubmitData(
+	submitData,
+	select,
+	{ includeDomainDetails, includeGSuiteDetails }
+) {
 	return {
 		...submitData,
-		domainDetails: getDomainDetails( select ),
+		domainDetails: includeDomainDetails || includeGSuiteDetails ? getDomainDetails( select ) : null,
 	};
 }
 

--- a/client/my-sites/checkout/composite-checkout/payment-method-processors.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-processors.js
@@ -8,7 +8,7 @@ import { format as formatUrl, parse as parseUrl } from 'url'; // eslint-disable-
  * Internal dependencies
  */
 import {
-	addDomainDetailsToSubmitData,
+	getDomainDetails,
 	wpcomTransaction,
 	wpcomPayPalExpress,
 	submitApplePayPayment,
@@ -55,21 +55,16 @@ export function genericRedirectProcessor(
 	} );
 	const pending = submitStripeRedirectTransaction(
 		paymentMethodId,
-		addDomainDetailsToSubmitData(
-			{
-				...submitData,
-				successUrl,
-				cancelUrl,
-				country: select( 'wpcom' )?.getContactInfo?.()?.countryCode?.value,
-				postalCode: select( 'wpcom' )?.getContactInfo?.()?.postalCode?.value,
-				subdivisionCode: select( 'wpcom' )?.getContactInfo?.()?.state?.value,
-				siteId: select( 'wpcom' )?.getSiteId?.(),
-			},
-			{
-				includeDomainDetails,
-				includeGSuiteDetails,
-			}
-		),
+		{
+			...submitData,
+			successUrl,
+			cancelUrl,
+			country: select( 'wpcom' )?.getContactInfo?.()?.countryCode?.value,
+			postalCode: select( 'wpcom' )?.getContactInfo?.()?.postalCode?.value,
+			subdivisionCode: select( 'wpcom' )?.getContactInfo?.()?.state?.value,
+			siteId: select( 'wpcom' )?.getSiteId?.(),
+			domainDetails: getDomainDetails( { includeDomainDetails, includeGSuiteDetails } ),
+		},
 		wpcomTransaction
 	);
 	// save result so we can get receipt_id and failed_purchases in getThankYouPageUrl
@@ -82,18 +77,13 @@ export function genericRedirectProcessor(
 
 export function applePayProcessor( submitData, { includeDomainDetails, includeGSuiteDetails } ) {
 	const pending = submitApplePayPayment(
-		addDomainDetailsToSubmitData(
-			{
-				...submitData,
-				siteId: select( 'wpcom' )?.getSiteId?.(),
-				country: select( 'wpcom' )?.getContactInfo?.()?.countryCode?.value,
-				postalCode: select( 'wpcom' )?.getContactInfo?.()?.postalCode?.value,
-			},
-			{
-				includeDomainDetails,
-				includeGSuiteDetails,
-			}
-		),
+		{
+			...submitData,
+			siteId: select( 'wpcom' )?.getSiteId?.(),
+			country: select( 'wpcom' )?.getContactInfo?.()?.countryCode?.value,
+			postalCode: select( 'wpcom' )?.getContactInfo?.()?.postalCode?.value,
+			domainDetails: getDomainDetails( { includeDomainDetails, includeGSuiteDetails } ),
+		},
 		wpcomTransaction
 	);
 	// save result so we can get receipt_id and failed_purchases in getThankYouPageUrl
@@ -114,20 +104,15 @@ export async function stripeCardProcessor(
 		postalCode: select( 'wpcom' )?.getContactInfo?.()?.postalCode?.value,
 	} );
 	const pending = submitStripeCardTransaction(
-		addDomainDetailsToSubmitData(
-			{
-				...submitData,
-				country: select( 'wpcom' )?.getContactInfo?.()?.countryCode?.value,
-				postalCode: select( 'wpcom' )?.getContactInfo?.()?.postalCode?.value,
-				subdivisionCode: select( 'wpcom' )?.getContactInfo?.()?.state?.value,
-				siteId: select( 'wpcom' )?.getSiteId?.(),
-				paymentMethodToken,
-			},
-			{
-				includeDomainDetails,
-				includeGSuiteDetails,
-			}
-		),
+		{
+			...submitData,
+			country: select( 'wpcom' )?.getContactInfo?.()?.countryCode?.value,
+			postalCode: select( 'wpcom' )?.getContactInfo?.()?.postalCode?.value,
+			subdivisionCode: select( 'wpcom' )?.getContactInfo?.()?.state?.value,
+			siteId: select( 'wpcom' )?.getSiteId?.(),
+			domainDetails: getDomainDetails( { includeDomainDetails, includeGSuiteDetails } ),
+			paymentMethodToken,
+		},
 		wpcomTransaction
 	);
 	// save result so we can get receipt_id and failed_purchases in getThankYouPageUrl
@@ -143,19 +128,14 @@ export async function existingCardProcessor(
 	{ includeDomainDetails, includeGSuiteDetails }
 ) {
 	const pending = submitExistingCardPayment(
-		addDomainDetailsToSubmitData(
-			{
-				...submitData,
-				country: select( 'wpcom' )?.getContactInfo?.()?.countryCode?.value,
-				postalCode: select( 'wpcom' )?.getContactInfo?.()?.postalCode?.value,
-				subdivisionCode: select( 'wpcom' )?.getContactInfo?.()?.state?.value,
-				siteId: select( 'wpcom' )?.getSiteId?.(),
-			},
-			{
-				includeDomainDetails,
-				includeGSuiteDetails,
-			}
-		),
+		{
+			...submitData,
+			country: select( 'wpcom' )?.getContactInfo?.()?.countryCode?.value,
+			postalCode: select( 'wpcom' )?.getContactInfo?.()?.postalCode?.value,
+			subdivisionCode: select( 'wpcom' )?.getContactInfo?.()?.state?.value,
+			siteId: select( 'wpcom' )?.getSiteId?.(),
+			domainDetails: getDomainDetails( { includeDomainDetails, includeGSuiteDetails } ),
+		},
 		wpcomTransaction
 	);
 	// save result so we can get receipt_id and failed_purchases in getThankYouPageUrl
@@ -181,19 +161,14 @@ export async function freePurchaseProcessor(
 	{ includeDomainDetails, includeGSuiteDetails }
 ) {
 	const pending = submitFreePurchaseTransaction(
-		addDomainDetailsToSubmitData(
-			{
-				...submitData,
-				siteId: select( 'wpcom' )?.getSiteId?.(),
-				// this data is intentionally empty so we do not charge taxes
-				country: null,
-				postalCode: null,
-			},
-			{
-				includeDomainDetails,
-				includeGSuiteDetails,
-			}
-		),
+		{
+			...submitData,
+			siteId: select( 'wpcom' )?.getSiteId?.(),
+			domainDetails: getDomainDetails( { includeDomainDetails, includeGSuiteDetails } ),
+			// this data is intentionally empty so we do not charge taxes
+			country: null,
+			postalCode: null,
+		},
 		wpcomTransaction
 	);
 	// save result so we can get receipt_id and failed_purchases in getThankYouPageUrl
@@ -208,19 +183,14 @@ export async function fullCreditsProcessor(
 	{ includeDomainDetails, includeGSuiteDetails }
 ) {
 	const pending = submitCreditsTransaction(
-		addDomainDetailsToSubmitData(
-			{
-				...submitData,
-				siteId: select( 'wpcom' )?.getSiteId?.(),
-				// this data is intentionally empty so we do not charge taxes
-				country: null,
-				postalCode: null,
-			},
-			{
-				includeDomainDetails,
-				includeGSuiteDetails,
-			}
-		),
+		{
+			...submitData,
+			siteId: select( 'wpcom' )?.getSiteId?.(),
+			domainDetails: getDomainDetails( { includeDomainDetails, includeGSuiteDetails } ),
+			// this data is intentionally empty so we do not charge taxes
+			country: null,
+			postalCode: null,
+		},
 		wpcomTransaction
 	);
 	// save result so we can get receipt_id and failed_purchases in getThankYouPageUrl
@@ -250,22 +220,17 @@ export async function payPalProcessor(
 	} );
 
 	const pending = submitPayPalExpressRequest(
-		addDomainDetailsToSubmitData(
-			{
-				...submitData,
-				successUrl,
-				cancelUrl,
-				siteId: select( 'wpcom' )?.getSiteId?.() ?? '',
-				couponId: couponItem?.wpcom_meta?.couponCode,
-				country: select( 'wpcom' )?.getContactInfo?.()?.countryCode?.value ?? '',
-				postalCode: select( 'wpcom' )?.getContactInfo?.()?.postalCode?.value ?? '',
-				subdivisionCode: select( 'wpcom' )?.getContactInfo?.()?.state?.value ?? '',
-			},
-			{
-				includeDomainDetails,
-				includeGSuiteDetails,
-			}
-		),
+		{
+			...submitData,
+			successUrl,
+			cancelUrl,
+			siteId: select( 'wpcom' )?.getSiteId?.() ?? '',
+			couponId: couponItem?.wpcom_meta?.couponCode,
+			country: select( 'wpcom' )?.getContactInfo?.()?.countryCode?.value ?? '',
+			postalCode: select( 'wpcom' )?.getContactInfo?.()?.postalCode?.value ?? '',
+			subdivisionCode: select( 'wpcom' )?.getContactInfo?.()?.state?.value ?? '',
+			domainDetails: getDomainDetails( { includeDomainDetails, includeGSuiteDetails } ),
+		},
 		wpcomPayPalExpress
 	);
 	// save result so we can get receipt_id and failed_purchases in getThankYouPageUrl

--- a/client/my-sites/checkout/composite-checkout/payment-method-processors.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-processors.js
@@ -65,7 +65,6 @@ export function genericRedirectProcessor(
 				subdivisionCode: select( 'wpcom' )?.getContactInfo?.()?.state?.value,
 				siteId: select( 'wpcom' )?.getSiteId?.(),
 			},
-			select,
 			{
 				includeDomainDetails,
 				includeGSuiteDetails,
@@ -90,7 +89,6 @@ export function applePayProcessor( submitData, { includeDomainDetails, includeGS
 				country: select( 'wpcom' )?.getContactInfo?.()?.countryCode?.value,
 				postalCode: select( 'wpcom' )?.getContactInfo?.()?.postalCode?.value,
 			},
-			select,
 			{
 				includeDomainDetails,
 				includeGSuiteDetails,
@@ -125,7 +123,6 @@ export async function stripeCardProcessor(
 				siteId: select( 'wpcom' )?.getSiteId?.(),
 				paymentMethodToken,
 			},
-			select,
 			{
 				includeDomainDetails,
 				includeGSuiteDetails,
@@ -154,7 +151,6 @@ export async function existingCardProcessor(
 				subdivisionCode: select( 'wpcom' )?.getContactInfo?.()?.state?.value,
 				siteId: select( 'wpcom' )?.getSiteId?.(),
 			},
-			select,
 			{
 				includeDomainDetails,
 				includeGSuiteDetails,
@@ -193,7 +189,6 @@ export async function freePurchaseProcessor(
 				country: null,
 				postalCode: null,
 			},
-			select,
 			{
 				includeDomainDetails,
 				includeGSuiteDetails,
@@ -221,7 +216,6 @@ export async function fullCreditsProcessor(
 				country: null,
 				postalCode: null,
 			},
-			select,
 			{
 				includeDomainDetails,
 				includeGSuiteDetails,
@@ -267,7 +261,6 @@ export async function payPalProcessor(
 				postalCode: select( 'wpcom' )?.getContactInfo?.()?.postalCode?.value ?? '',
 				subdivisionCode: select( 'wpcom' )?.getContactInfo?.()?.state?.value ?? '',
 			},
-			select,
 			{
 				includeDomainDetails,
 				includeGSuiteDetails,

--- a/client/my-sites/checkout/composite-checkout/payment-method-processors.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-processors.js
@@ -9,6 +9,7 @@ import { format as formatUrl, parse as parseUrl } from 'url'; // eslint-disable-
  */
 import {
 	getDomainDetails,
+	createStripePaymentMethodToken,
 	wpcomTransaction,
 	wpcomPayPalExpress,
 	submitApplePayPayment,
@@ -19,7 +20,6 @@ import {
 	submitExistingCardPayment,
 	submitPayPalExpressRequest,
 } from './payment-method-helpers';
-import { createStripePaymentMethod } from 'lib/stripe';
 
 const { select, dispatch } = defaultRegistry;
 
@@ -144,16 +144,6 @@ export async function existingCardProcessor(
 		dispatch( 'wpcom' ).setTransactionResponse( result );
 	} );
 	return pending;
-}
-
-function createStripePaymentMethodToken( { stripe, name, country, postalCode } ) {
-	return createStripePaymentMethod( stripe, {
-		name,
-		address: {
-			country,
-			postal_code: postalCode,
-		},
-	} );
 }
 
 export async function freePurchaseProcessor(

--- a/client/my-sites/checkout/composite-checkout/payment-method-processors.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-processors.js
@@ -2,13 +2,13 @@
  * External dependencies
  */
 import { defaultRegistry } from '@automattic/composite-checkout';
-import { format as formatUrl, parse as parseUrl } from 'url';
+import { format as formatUrl, parse as parseUrl } from 'url'; // eslint-disable-line no-restricted-imports
 
 /**
  * Internal dependencies
  */
 import {
-	getDomainDetails,
+	addDomainDetailsToSubmitData,
 	wpcomTransaction,
 	wpcomPayPalExpress,
 	submitApplePayPayment,
@@ -51,16 +51,18 @@ export function genericRedirectProcessor( paymentMethodId, submitData, getThankY
 	} );
 	const pending = submitStripeRedirectTransaction(
 		paymentMethodId,
-		{
-			...submitData,
-			successUrl,
-			cancelUrl,
-			country: select( 'wpcom' )?.getContactInfo?.()?.countryCode?.value,
-			postalCode: select( 'wpcom' )?.getContactInfo?.()?.postalCode?.value,
-			subdivisionCode: select( 'wpcom' )?.getContactInfo?.()?.state?.value,
-			siteId: select( 'wpcom' )?.getSiteId?.(),
-			domainDetails: getDomainDetails( select ),
-		},
+		addDomainDetailsToSubmitData(
+			{
+				...submitData,
+				successUrl,
+				cancelUrl,
+				country: select( 'wpcom' )?.getContactInfo?.()?.countryCode?.value,
+				postalCode: select( 'wpcom' )?.getContactInfo?.()?.postalCode?.value,
+				subdivisionCode: select( 'wpcom' )?.getContactInfo?.()?.state?.value,
+				siteId: select( 'wpcom' )?.getSiteId?.(),
+			},
+			select
+		),
 		wpcomTransaction
 	);
 	// save result so we can get receipt_id and failed_purchases in getThankYouPageUrl
@@ -73,13 +75,15 @@ export function genericRedirectProcessor( paymentMethodId, submitData, getThankY
 
 export function applePayProcessor( submitData ) {
 	const pending = submitApplePayPayment(
-		{
-			...submitData,
-			siteId: select( 'wpcom' )?.getSiteId?.(),
-			domainDetails: getDomainDetails( select ),
-			country: select( 'wpcom' )?.getContactInfo?.()?.countryCode?.value,
-			postalCode: select( 'wpcom' )?.getContactInfo?.()?.postalCode?.value,
-		},
+		addDomainDetailsToSubmitData(
+			{
+				...submitData,
+				siteId: select( 'wpcom' )?.getSiteId?.(),
+				country: select( 'wpcom' )?.getContactInfo?.()?.countryCode?.value,
+				postalCode: select( 'wpcom' )?.getContactInfo?.()?.postalCode?.value,
+			},
+			select
+		),
 		wpcomTransaction
 	);
 	// save result so we can get receipt_id and failed_purchases in getThankYouPageUrl
@@ -97,15 +101,17 @@ export async function stripeCardProcessor( submitData ) {
 		postalCode: select( 'wpcom' )?.getContactInfo?.()?.postalCode?.value,
 	} );
 	const pending = submitStripeCardTransaction(
-		{
-			...submitData,
-			country: select( 'wpcom' )?.getContactInfo?.()?.countryCode?.value,
-			postalCode: select( 'wpcom' )?.getContactInfo?.()?.postalCode?.value,
-			subdivisionCode: select( 'wpcom' )?.getContactInfo?.()?.state?.value,
-			siteId: select( 'wpcom' )?.getSiteId?.(),
-			domainDetails: getDomainDetails( select ),
-			paymentMethodToken,
-		},
+		addDomainDetailsToSubmitData(
+			{
+				...submitData,
+				country: select( 'wpcom' )?.getContactInfo?.()?.countryCode?.value,
+				postalCode: select( 'wpcom' )?.getContactInfo?.()?.postalCode?.value,
+				subdivisionCode: select( 'wpcom' )?.getContactInfo?.()?.state?.value,
+				siteId: select( 'wpcom' )?.getSiteId?.(),
+				paymentMethodToken,
+			},
+			select
+		),
 		wpcomTransaction
 	);
 	// save result so we can get receipt_id and failed_purchases in getThankYouPageUrl
@@ -118,14 +124,16 @@ export async function stripeCardProcessor( submitData ) {
 
 export async function existingCardProcessor( submitData ) {
 	const pending = submitExistingCardPayment(
-		{
-			...submitData,
-			country: select( 'wpcom' )?.getContactInfo?.()?.countryCode?.value,
-			postalCode: select( 'wpcom' )?.getContactInfo?.()?.postalCode?.value,
-			subdivisionCode: select( 'wpcom' )?.getContactInfo?.()?.state?.value,
-			siteId: select( 'wpcom' )?.getSiteId?.(),
-			domainDetails: getDomainDetails( select ),
-		},
+		addDomainDetailsToSubmitData(
+			{
+				...submitData,
+				country: select( 'wpcom' )?.getContactInfo?.()?.countryCode?.value,
+				postalCode: select( 'wpcom' )?.getContactInfo?.()?.postalCode?.value,
+				subdivisionCode: select( 'wpcom' )?.getContactInfo?.()?.state?.value,
+				siteId: select( 'wpcom' )?.getSiteId?.(),
+			},
+			select
+		),
 		wpcomTransaction
 	);
 	// save result so we can get receipt_id and failed_purchases in getThankYouPageUrl
@@ -148,14 +156,16 @@ function createStripePaymentMethodToken( { stripe, name, country, postalCode } )
 
 export async function freePurchaseProcessor( submitData ) {
 	const pending = submitFreePurchaseTransaction(
-		{
-			...submitData,
-			siteId: select( 'wpcom' )?.getSiteId?.(),
-			domainDetails: getDomainDetails( select ),
-			// this data is intentionally empty so we do not charge taxes
-			country: null,
-			postalCode: null,
-		},
+		addDomainDetailsToSubmitData(
+			{
+				...submitData,
+				siteId: select( 'wpcom' )?.getSiteId?.(),
+				// this data is intentionally empty so we do not charge taxes
+				country: null,
+				postalCode: null,
+			},
+			select
+		),
 		wpcomTransaction
 	);
 	// save result so we can get receipt_id and failed_purchases in getThankYouPageUrl
@@ -167,14 +177,16 @@ export async function freePurchaseProcessor( submitData ) {
 
 export async function fullCreditsProcessor( submitData ) {
 	const pending = submitCreditsTransaction(
-		{
-			...submitData,
-			siteId: select( 'wpcom' )?.getSiteId?.(),
-			domainDetails: getDomainDetails( select ),
-			// this data is intentionally empty so we do not charge taxes
-			country: null,
-			postalCode: null,
-		},
+		addDomainDetailsToSubmitData(
+			{
+				...submitData,
+				siteId: select( 'wpcom' )?.getSiteId?.(),
+				// this data is intentionally empty so we do not charge taxes
+				country: null,
+				postalCode: null,
+			},
+			select
+		),
 		wpcomTransaction
 	);
 	// save result so we can get receipt_id and failed_purchases in getThankYouPageUrl
@@ -201,17 +213,19 @@ export async function payPalProcessor( submitData, getThankYouUrl, couponItem ) 
 	} );
 
 	const pending = submitPayPalExpressRequest(
-		{
-			...submitData,
-			successUrl,
-			cancelUrl,
-			siteId: select( 'wpcom' )?.getSiteId?.() ?? '',
-			domainDetails: getDomainDetails( select ),
-			couponId: couponItem?.wpcom_meta?.couponCode,
-			country: select( 'wpcom' )?.getContactInfo?.()?.countryCode?.value ?? '',
-			postalCode: select( 'wpcom' )?.getContactInfo?.()?.postalCode?.value ?? '',
-			subdivisionCode: select( 'wpcom' )?.getContactInfo?.()?.state?.value ?? '',
-		},
+		addDomainDetailsToSubmitData(
+			{
+				...submitData,
+				successUrl,
+				cancelUrl,
+				siteId: select( 'wpcom' )?.getSiteId?.() ?? '',
+				couponId: couponItem?.wpcom_meta?.couponCode,
+				country: select( 'wpcom' )?.getContactInfo?.()?.countryCode?.value ?? '',
+				postalCode: select( 'wpcom' )?.getContactInfo?.()?.postalCode?.value ?? '',
+				subdivisionCode: select( 'wpcom' )?.getContactInfo?.()?.state?.value ?? '',
+			},
+			select
+		),
 		wpcomPayPalExpress
 	);
 	// save result so we can get receipt_id and failed_purchases in getThankYouPageUrl

--- a/client/my-sites/checkout/composite-checkout/payment-method-processors.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-processors.js
@@ -23,7 +23,11 @@ import { createStripePaymentMethod } from 'lib/stripe';
 
 const { select, dispatch } = defaultRegistry;
 
-export function genericRedirectProcessor( paymentMethodId, submitData, getThankYouUrl, siteSlug ) {
+export function genericRedirectProcessor(
+	paymentMethodId,
+	submitData,
+	{ getThankYouUrl, siteSlug, includeDomainDetails, includeGSuiteDetails }
+) {
 	const { protocol, hostname, port, pathname } = parseUrl(
 		typeof window !== 'undefined' ? window.location.href : 'https://wordpress.com',
 		true
@@ -61,7 +65,11 @@ export function genericRedirectProcessor( paymentMethodId, submitData, getThankY
 				subdivisionCode: select( 'wpcom' )?.getContactInfo?.()?.state?.value,
 				siteId: select( 'wpcom' )?.getSiteId?.(),
 			},
-			select
+			select,
+			{
+				includeDomainDetails,
+				includeGSuiteDetails,
+			}
 		),
 		wpcomTransaction
 	);
@@ -73,7 +81,7 @@ export function genericRedirectProcessor( paymentMethodId, submitData, getThankY
 	return pending;
 }
 
-export function applePayProcessor( submitData ) {
+export function applePayProcessor( submitData, { includeDomainDetails, includeGSuiteDetails } ) {
 	const pending = submitApplePayPayment(
 		addDomainDetailsToSubmitData(
 			{
@@ -82,7 +90,11 @@ export function applePayProcessor( submitData ) {
 				country: select( 'wpcom' )?.getContactInfo?.()?.countryCode?.value,
 				postalCode: select( 'wpcom' )?.getContactInfo?.()?.postalCode?.value,
 			},
-			select
+			select,
+			{
+				includeDomainDetails,
+				includeGSuiteDetails,
+			}
 		),
 		wpcomTransaction
 	);
@@ -94,7 +106,10 @@ export function applePayProcessor( submitData ) {
 	return pending;
 }
 
-export async function stripeCardProcessor( submitData ) {
+export async function stripeCardProcessor(
+	submitData,
+	{ includeDomainDetails, includeGSuiteDetails }
+) {
 	const paymentMethodToken = await createStripePaymentMethodToken( {
 		...submitData,
 		country: select( 'wpcom' )?.getContactInfo?.()?.countryCode?.value,
@@ -110,7 +125,11 @@ export async function stripeCardProcessor( submitData ) {
 				siteId: select( 'wpcom' )?.getSiteId?.(),
 				paymentMethodToken,
 			},
-			select
+			select,
+			{
+				includeDomainDetails,
+				includeGSuiteDetails,
+			}
 		),
 		wpcomTransaction
 	);
@@ -122,7 +141,10 @@ export async function stripeCardProcessor( submitData ) {
 	return pending;
 }
 
-export async function existingCardProcessor( submitData ) {
+export async function existingCardProcessor(
+	submitData,
+	{ includeDomainDetails, includeGSuiteDetails }
+) {
 	const pending = submitExistingCardPayment(
 		addDomainDetailsToSubmitData(
 			{
@@ -132,7 +154,11 @@ export async function existingCardProcessor( submitData ) {
 				subdivisionCode: select( 'wpcom' )?.getContactInfo?.()?.state?.value,
 				siteId: select( 'wpcom' )?.getSiteId?.(),
 			},
-			select
+			select,
+			{
+				includeDomainDetails,
+				includeGSuiteDetails,
+			}
 		),
 		wpcomTransaction
 	);
@@ -154,7 +180,10 @@ function createStripePaymentMethodToken( { stripe, name, country, postalCode } )
 	} );
 }
 
-export async function freePurchaseProcessor( submitData ) {
+export async function freePurchaseProcessor(
+	submitData,
+	{ includeDomainDetails, includeGSuiteDetails }
+) {
 	const pending = submitFreePurchaseTransaction(
 		addDomainDetailsToSubmitData(
 			{
@@ -164,7 +193,11 @@ export async function freePurchaseProcessor( submitData ) {
 				country: null,
 				postalCode: null,
 			},
-			select
+			select,
+			{
+				includeDomainDetails,
+				includeGSuiteDetails,
+			}
 		),
 		wpcomTransaction
 	);
@@ -175,7 +208,10 @@ export async function freePurchaseProcessor( submitData ) {
 	return pending;
 }
 
-export async function fullCreditsProcessor( submitData ) {
+export async function fullCreditsProcessor(
+	submitData,
+	{ includeDomainDetails, includeGSuiteDetails }
+) {
 	const pending = submitCreditsTransaction(
 		addDomainDetailsToSubmitData(
 			{
@@ -185,7 +221,11 @@ export async function fullCreditsProcessor( submitData ) {
 				country: null,
 				postalCode: null,
 			},
-			select
+			select,
+			{
+				includeDomainDetails,
+				includeGSuiteDetails,
+			}
 		),
 		wpcomTransaction
 	);
@@ -197,7 +237,10 @@ export async function fullCreditsProcessor( submitData ) {
 	return pending;
 }
 
-export async function payPalProcessor( submitData, getThankYouUrl, couponItem ) {
+export async function payPalProcessor(
+	submitData,
+	{ getThankYouUrl, couponItem, includeDomainDetails, includeGSuiteDetails }
+) {
 	const { protocol, hostname, port, pathname } = parseUrl( window.location.href, true );
 	const successUrl = formatUrl( {
 		protocol,
@@ -224,7 +267,11 @@ export async function payPalProcessor( submitData, getThankYouUrl, couponItem ) 
 				postalCode: select( 'wpcom' )?.getContactInfo?.()?.postalCode?.value ?? '',
 				subdivisionCode: select( 'wpcom' )?.getContactInfo?.()?.state?.value ?? '',
 			},
-			select
+			select,
+			{
+				includeDomainDetails,
+				includeGSuiteDetails,
+			}
 		),
 		wpcomPayPalExpress
 	);

--- a/client/my-sites/checkout/composite-checkout/types/paypal-express.ts
+++ b/client/my-sites/checkout/composite-checkout/types/paypal-express.ts
@@ -23,7 +23,7 @@ export type PayPalExpressEndpointRequestPayload = {
 	successUrl: string;
 	cancelUrl: string;
 	cart: WPCOMTransactionEndpointCart;
-	domainDetails: DomainContactDetails;
+	domainDetails: DomainContactDetails | null;
 	country: string;
 	postalCode: string;
 };
@@ -46,7 +46,7 @@ export function createPayPalExpressEndpointRequestPayloadFromLineItems( {
 	country: string;
 	postalCode: string;
 	subdivisionCode: string;
-	domainDetails: DomainContactDetails;
+	domainDetails: DomainContactDetails | null;
 	items: WPCOMCartItem[];
 } ): PayPalExpressEndpointRequestPayload {
 	return {

--- a/client/my-sites/checkout/composite-checkout/types/transaction-endpoint.ts
+++ b/client/my-sites/checkout/composite-checkout/types/transaction-endpoint.ts
@@ -86,7 +86,7 @@ export function createTransactionEndpointCartFromLineItems( {
 	postalCode: string;
 	subdivisionCode?: string;
 	items: WPCOMCartItem[];
-	contactDetails: DomainContactDetails;
+	contactDetails: DomainContactDetails | null;
 } ): WPCOMTransactionEndpointCart {
 	debug( 'creating cart from items', items );
 
@@ -131,7 +131,7 @@ function createTransactionEndpointCartItemFromLineItem(
 
 function addRegistrationDataToGSuiteItem(
 	item: WPCOMCartItem,
-	contactDetails: DomainContactDetails
+	contactDetails: DomainContactDetails | null
 ): WPCOMCartItem {
 	if ( ! isGSuiteProductSlug( item.wpcom_meta?.product_slug ) ) {
 		return item;

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -46,12 +46,7 @@ import {
 	getGSuiteValidationResult,
 } from 'my-sites/checkout/composite-checkout/contact-validation';
 import { isGSuiteProductSlug } from 'lib/gsuite';
-import {
-	hasGoogleApps,
-	hasDomainRegistration,
-	hasOnlyRenewalItems,
-	hasTransferProduct,
-} from 'lib/cart-values/cart-items';
+import { needsDomainDetails } from 'my-sites/checkout/composite-checkout/payment-method-helpers';
 
 const debug = debugFactory( 'calypso:composite-checkout:wp-checkout' );
 
@@ -604,16 +599,3 @@ const CheckoutNoticeWrapper = styled.div`
 		}
 	}
 `;
-
-function needsDomainDetails( cart ) {
-	if ( cart && hasOnlyRenewalItems( cart ) ) {
-		return false;
-	}
-	if (
-		cart &&
-		( hasDomainRegistration( cart ) || hasGoogleApps( cart ) || hasTransferProduct( cart ) )
-	) {
-		return true;
-	}
-	return false;
-}

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -33,6 +33,7 @@ import useCouponFieldState from '../hooks/use-coupon-field-state';
 import WPCheckoutOrderReview from './wp-checkout-order-review';
 import WPCheckoutOrderSummary from './wp-checkout-order-summary';
 import WPContactForm from './wp-contact-form';
+import WPContactFormSummary from './wp-contact-form-summary';
 import { isCompleteAndValid } from '../types';
 import { WPOrderReviewTotal, WPOrderReviewSection, LineItemUI } from './wp-order-review-line-items';
 import MaterialIcon from 'components/material-icon';
@@ -45,6 +46,12 @@ import {
 	getGSuiteValidationResult,
 } from 'my-sites/checkout/composite-checkout/contact-validation';
 import { isGSuiteProductSlug } from 'lib/gsuite';
+import {
+	hasGoogleApps,
+	hasDomainRegistration,
+	hasOnlyRenewalItems,
+	hasTransferProduct,
+} from 'lib/cart-values/cart-items';
 
 const debug = debugFactory( 'calypso:composite-checkout:wp-checkout' );
 
@@ -108,12 +115,12 @@ export default function WPCheckout( {
 	const onEvent = useEvents();
 
 	const [ items ] = useLineItems();
-	const firstDomainItem = items.find( isLineItemADomain );
-	const isDomainFieldsVisible = !! firstDomainItem;
+	const areThereDomainProductsInCart = items.some( isLineItemADomain );
 	const isGSuiteInCart = items.some( ( item ) =>
 		isGSuiteProductSlug( item.wpcom_meta?.product_slug )
 	);
-	const shouldShowContactStep = isDomainFieldsVisible || total.amount.value > 0;
+	const shouldShowContactStep = areThereDomainProductsInCart || total.amount.value > 0;
+	const shouldShowDomainContactFields = shouldShowContactStep && needsDomainDetails( responseCart );
 
 	const contactInfo = useSelect( ( sel ) => sel( 'wpcom' ).getContactInfo() ) || {};
 	const { setSiteId, touchContactFields, applyDomainContactValidationResults } = useDispatch(
@@ -127,7 +134,7 @@ export default function WPCheckout( {
 
 	const validateContactDetailsAndDisplayErrors = async () => {
 		debug( 'validating contact details with side effects' );
-		if ( isDomainFieldsVisible ) {
+		if ( shouldShowDomainContactFields ) {
 			const validationResult = await getDomainValidationResult( items, contactInfo );
 			debug( 'validating contact details result', validationResult );
 			handleContactValidationResult( {
@@ -154,7 +161,7 @@ export default function WPCheckout( {
 	};
 	const validateContactDetails = async () => {
 		debug( 'validating contact details' );
-		if ( isDomainFieldsVisible ) {
+		if ( shouldShowDomainContactFields ) {
 			const validationResult = await getDomainValidationResult( items, contactInfo );
 			debug( 'validating contact details result', validationResult );
 			return isContactValidationResponseValid( validationResult, contactInfo );
@@ -294,8 +301,6 @@ export default function WPCheckout( {
 							activeStepContent={
 								<WPContactForm
 									siteUrl={ siteUrl }
-									isComplete={ false }
-									isActive={ true }
 									countriesList={ countriesList }
 									StateSelect={ StateSelect }
 									renderDomainContactFields={ renderDomainContactFields }
@@ -303,10 +308,11 @@ export default function WPCheckout( {
 										shouldShowContactDetailsValidationErrors
 									}
 									contactValidationCallback={ validateContactDetails }
+									shouldShowDomainContactFields={ shouldShowDomainContactFields }
 								/>
 							}
 							completeStepContent={
-								<WPContactForm summary isComplete={ true } isActive={ false } />
+								<WPContactFormSummary showDomainContactSummary={ shouldShowDomainContactFields } />
 							}
 							titleContent={ <ContactFormTitle /> }
 							editButtonText={ translate( 'Edit' ) }
@@ -597,3 +603,16 @@ const CheckoutNoticeWrapper = styled.div`
 		}
 	}
 `;
+
+function needsDomainDetails( cart ) {
+	if ( cart && hasOnlyRenewalItems( cart ) ) {
+		return false;
+	}
+	if (
+		cart &&
+		( hasDomainRegistration( cart ) || hasGoogleApps( cart ) || hasTransferProduct( cart ) )
+	) {
+		return true;
+	}
+	return false;
+}

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -119,7 +119,8 @@ export default function WPCheckout( {
 	const isGSuiteInCart = items.some( ( item ) =>
 		isGSuiteProductSlug( item.wpcom_meta?.product_slug )
 	);
-	const shouldShowContactStep = areThereDomainProductsInCart || total.amount.value > 0;
+	const shouldShowContactStep =
+		areThereDomainProductsInCart || isGSuiteInCart || total.amount.value > 0;
 	const shouldShowDomainContactFields = shouldShowContactStep && needsDomainDetails( responseCart );
 
 	const contactInfo = useSelect( ( sel ) => sel( 'wpcom' ).getContactInfo() ) || {};

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-contact-form-summary.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-contact-form-summary.js
@@ -1,0 +1,123 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import styled from '@emotion/styled';
+import { useSelect, useLineItems } from '@automattic/composite-checkout';
+import { useTranslate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { SummaryLine, SummaryDetails } from './summary-details';
+import { isGSuiteProductSlug } from 'lib/gsuite';
+
+export default function WPContactFormSummary( { showDomainContactSummary } ) {
+	const [ items ] = useLineItems();
+	const isGSuiteInCart = items.some( ( item ) =>
+		isGSuiteProductSlug( item.wpcom_meta?.product_slug )
+	);
+	const translate = useTranslate();
+	const contactInfo = useSelect( ( select ) => select( 'wpcom' ).getContactInfo() );
+
+	// Check if paymentData is empty
+	if ( Object.entries( contactInfo ).length === 0 ) {
+		return null;
+	}
+
+	const fullName = joinNonEmptyValues(
+		' ',
+		contactInfo.firstName.value,
+		contactInfo.lastName.value
+	);
+	const cityAndState = joinNonEmptyValues( ', ', contactInfo.city.value, contactInfo.state.value );
+	const postalAndCountry = joinNonEmptyValues(
+		', ',
+		contactInfo.postalCode.value,
+		contactInfo.countryCode.value
+	);
+
+	return (
+		<GridRow>
+			<div>
+				<SummaryDetails>
+					{ ( isGSuiteInCart || showDomainContactSummary ) && fullName && (
+						<SummaryLine>{ fullName }</SummaryLine>
+					) }
+
+					{ showDomainContactSummary && contactInfo.organization.value?.length > 0 && (
+						<SummaryLine>{ contactInfo.organization.value } </SummaryLine>
+					) }
+
+					{ showDomainContactSummary && contactInfo.email.value?.length > 0 && (
+						<SummaryLine>{ contactInfo.email.value }</SummaryLine>
+					) }
+
+					<AlternateEmailSummary
+						contactInfo={ contactInfo }
+						showDomainContactSummary={ showDomainContactSummary }
+						isGSuiteInCart={ isGSuiteInCart }
+					/>
+
+					{ showDomainContactSummary && contactInfo.phone.value?.length > 0 && (
+						<SummaryLine>{ contactInfo.phone.value }</SummaryLine>
+					) }
+				</SummaryDetails>
+
+				<SummaryDetails>
+					{ showDomainContactSummary && contactInfo.address1.value?.length > 0 && (
+						<SummaryLine>{ contactInfo.address1.value } </SummaryLine>
+					) }
+
+					{ showDomainContactSummary && contactInfo.address2.value?.length > 0 && (
+						<SummaryLine>{ contactInfo.address2.value } </SummaryLine>
+					) }
+
+					{ showDomainContactSummary && cityAndState && (
+						<SummaryLine>{ cityAndState }</SummaryLine>
+					) }
+
+					{ postalAndCountry && <SummaryLine>{ postalAndCountry }</SummaryLine> }
+				</SummaryDetails>
+
+				{ contactInfo.vatId.value?.length > 0 && (
+					<SummaryDetails>
+						{ contactInfo.vatId.value?.length > 0 && (
+							<SummaryLine>
+								{ translate( 'VAT indentification number:' ) }
+								{ contactInfo.vatId.value }
+							</SummaryLine>
+						) }
+					</SummaryDetails>
+				) }
+			</div>
+		</GridRow>
+	);
+}
+
+const GridRow = styled.div`
+	display: -ms-grid;
+	display: grid;
+	width: 100%;
+	-ms-grid-columns: 48% 4% 48%;
+	grid-template-columns: 48% 48%;
+	grid-column-gap: 4%;
+	justify-items: stretch;
+`;
+
+function joinNonEmptyValues( joinString, ...values ) {
+	return values.filter( ( value ) => value?.length > 0 ).join( joinString );
+}
+
+function AlternateEmailSummary( { contactInfo, showDomainContactSummary, isGSuiteInCart } ) {
+	if ( ! isGSuiteInCart && ! showDomainContactSummary ) {
+		return null;
+	}
+	if ( ! contactInfo.alternateEmail.value?.length ) {
+		return null;
+	}
+	if ( contactInfo.alternateEmail.value === contactInfo.email.value && showDomainContactSummary ) {
+		return null;
+	}
+	return <SummaryLine>{ contactInfo.alternateEmail.value }</SummaryLine>;
+}

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-contact-form.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-contact-form.js
@@ -23,6 +23,7 @@ import { prepareDomainContactDetails, prepareDomainContactDetailsErrors, isValid
 import { isGSuiteProductSlug } from 'lib/gsuite';
 import useSkipToLastStepIfFormComplete from '../hooks/use-skip-to-last-step-if-form-complete';
 import useIsCachedContactFormValid from '../hooks/use-is-cached-contact-form-valid';
+import CountrySelectMenu from './country-select-menu';
 
 export default function WPContactForm( {
 	countriesList,

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-contact-form.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-contact-form.js
@@ -53,13 +53,14 @@ export default function WPContactForm( {
 	const isDisabled = ! isStepActive || formStatus !== 'ready';
 	const cart = useCart();
 	const isCachedContactFormValid = useIsCachedContactFormValid( contactValidationCallback );
+	const isDomainFieldsVisible = needsDomainDetails( cart, isCachedContactFormValid );
 
 	useSkipToLastStepIfFormComplete( isCachedContactFormValid );
 
 	if ( summary && isComplete ) {
 		return (
 			<ContactFormSummary
-				isDomainFieldsVisible={ needsDomainDetails( cart ) }
+				isDomainFieldsVisible={ isDomainFieldsVisible }
 				isGSuiteInCart={ isGSuiteInCart }
 			/>
 		);
@@ -72,7 +73,7 @@ export default function WPContactForm( {
 		<BillingFormFields>
 			<RenderContactDetails
 				translate={ translate }
-				isDomainFieldsVisible={ needsDomainDetails( cart ) }
+				isDomainFieldsVisible={ isDomainFieldsVisible }
 				isGSuiteInCart={ isGSuiteInCart }
 				contactInfo={ contactInfo }
 				renderDomainContactFields={ renderDomainContactFields }
@@ -376,12 +377,15 @@ const ContactDetailsFormDescription = styled.p`
 	margin: 0 0 16px;
 `;
 
-function needsDomainDetails( cart ) {
-	if ( cart && hasOnlyRenewalItems( cart ) ) {
+function needsDomainDetails( cart, isCachedContactFormValid ) {
+	if ( cart && hasOnlyRenewalItems( cart ) && isCachedContactFormValid ) {
 		return false;
 	}
-
-	return (
-		cart && ( hasDomainRegistration( cart ) || hasGoogleApps( cart ) || hasTransferProduct( cart ) )
-	);
+	if (
+		cart &&
+		( hasDomainRegistration( cart ) || hasGoogleApps( cart ) || hasTransferProduct( cart ) )
+	) {
+		return true;
+	}
+	return false;
 }

--- a/client/my-sites/checkout/composite-checkout/wpcom/hooks/use-is-cached-contact-form-valid.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/hooks/use-is-cached-contact-form-valid.js
@@ -1,0 +1,62 @@
+/**
+ * External dependencies
+ */
+import { useEffect, useRef, useState } from 'react';
+import { useFormStatus } from '@automattic/composite-checkout';
+import { useSelector } from 'react-redux';
+import debugFactory from 'debug';
+
+/**
+ * Internal dependencies
+ */
+import getContactDetailsCache from 'state/selectors/get-contact-details-cache';
+
+const debug = debugFactory( 'calypso:composite-checkout:use-is-cached-contact-form-valid' );
+
+export default function useIsCachedContactFormValid( contactValidationCallback ) {
+	const cachedContactDetails = useSelector( getContactDetailsCache );
+	const hasValidated = useRef( false );
+	const shouldResetFormStatus = useRef( false );
+	const { formStatus, setFormValidating, setFormReady } = useFormStatus();
+	const [ isFormValid, setFormValid ] = useState( false );
+
+	useEffect( () => {
+		if ( ! contactValidationCallback ) {
+			debug( 'Cannot validate contact details; no validation callback' );
+			return;
+		}
+		if ( ! hasValidated.current && cachedContactDetails ) {
+			hasValidated.current = true;
+			if ( formStatus === 'ready' ) {
+				setFormValidating();
+				shouldResetFormStatus.current = true;
+			}
+			contactValidationCallback()
+				.then( ( areDetailsCompleteAndValid ) => {
+					// If the details are already populated and valid, jump to payment method step
+					if ( areDetailsCompleteAndValid ) {
+						setFormValid( true );
+						debug( 'Contact details are already populated and valid' );
+					} else {
+						debug( 'Contact details are already populated but not valid' );
+					}
+					if ( shouldResetFormStatus.current ) {
+						setFormReady();
+					}
+				} )
+				.catch( () => {
+					if ( shouldResetFormStatus.current ) {
+						setFormReady();
+					}
+				} );
+		}
+	}, [
+		formStatus,
+		setFormReady,
+		setFormValidating,
+		cachedContactDetails,
+		contactValidationCallback,
+	] );
+
+	return isFormValid;
+}

--- a/client/my-sites/checkout/composite-checkout/wpcom/hooks/use-skip-to-last-step-if-form-complete.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/hooks/use-skip-to-last-step-if-form-complete.js
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+import { useEffect, useRef } from 'react';
+import { useSetStepComplete } from '@automattic/composite-checkout';
+import debugFactory from 'debug';
+
+const debug = debugFactory( 'calypso:composite-checkout:use-skip-to-last-step-if-form-complete' );
+
+export default function useSkipToLastStepIfFormComplete( isCachedContactFormValid ) {
+	const hasDecided = useRef( false );
+	const setStepCompleteStatus = useSetStepComplete();
+
+	useEffect( () => {
+		if ( ! isCachedContactFormValid ) {
+			return;
+		}
+		if ( ! hasDecided.current ) {
+			hasDecided.current = true;
+			// If the details are already populated and valid, jump to payment method step
+			if ( isCachedContactFormValid ) {
+				debug( 'Contact details are already populated; skipping to payment method step' );
+				saveStepNumberToUrl( 2 ); // TODO: can we do this dynamically somehow in case the step numbers change?
+				setStepCompleteStatus( 1, true ); // TODO: can we do this dynamically somehow in case the step numbers change?
+			}
+		}
+	}, [ isCachedContactFormValid, setStepCompleteStatus ] );
+}
+
+function saveStepNumberToUrl( stepNumber ) {
+	if ( ! window?.history || ! window?.location ) {
+		return;
+	}
+	const newHash = stepNumber > 1 ? `#step${ stepNumber }` : '';
+	if ( window.location.hash === newHash ) {
+		return;
+	}
+	const newUrl = window.location.hash
+		? window.location.href.replace( window.location.hash, newHash )
+		: window.location.href + newHash;
+	debug( 'updating url to', newUrl );
+	window.history.replaceState( null, '', newUrl );
+	// Modifying history does not trigger a hashchange event which is what
+	// composite-checkout uses to change its current step, so we must fire one
+	// manually. (HashChangeEvent is part of the web API so I'm not sure why
+	// eslint reports this as undefined.)
+	const event = new HashChangeEvent( 'hashchange' ); // eslint-disable-line no-undef
+	window.dispatchEvent( event );
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is another attempt at https://github.com/Automattic/wp-calypso/pull/44468, which was reverted in https://github.com/Automattic/wp-calypso/pull/44506

This PR changes the behavior of the new checkout form's contact details so that it will not display if the cart contains only renewal items and the existing cached contact details are valid. This behavior should mostly match [old checkout](https://github.com/Automattic/wp-calypso/blob/096d4759a964ebb19bcf0a068e51d438e9fab080/client/my-sites/checkout/checkout/index.jsx#L917). Previously, we had been displaying the contact details form fields any time that there were domain products in the cart.

In addition, it prevents sending the `domain_details` property to the transactions endpoint (and to paypal, etc.) when the cart contains only renewals.

#### Screenshots

Before:

![Screen Shot 2020-07-27 at 2 21 16 PM](https://user-images.githubusercontent.com/2036909/88577259-bb636c80-d014-11ea-965e-c9ee82fbc4da.png)

After:

![Screen Shot 2020-07-27 at 2 17 32 PM](https://user-images.githubusercontent.com/2036909/88577272-be5e5d00-d014-11ea-92dc-fe44dd927652.png)


#### Testing instructions

- Add a domain product to your cart (we may want to test this with different domain products for completeness) and visit checkout.
- Verify that you see the full "Contact information" step including name, address, and phone number.
- Complete the purchase. Verify that the purchase is successful. (Bonus: monitor the `/me/transactions` API call and make sure that `domain_details` is sent with the full contact data.)
- Visit http://calypso.localhost:3000/me/purchases and click the domain, then click "Renew now". You'll be redirected to checkout.
- Verify that the "Contact information" step only includes the "tax" information which is just postal code and country.
- Complete the purchase. Verify that the purchase is successful. (Bonus: monitor the `/me/transactions` API call and make sure that `domain_details` is sent with `null`.)
