### PR TITLE
Update the domain list header styling

### DIFF
--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -188,7 +188,7 @@ input[type='radio'].domain-management-list-item__radio {
 .list-header {
 	.info-popover {
 		vertical-align: middle;
-		margin-left: 1px;
+		margin-left: 2px;
 	}
 
 	@include breakpoint-deprecated( '<960px' ) {
@@ -280,7 +280,7 @@ input[type='radio'].domain-management-list-item__radio {
 }
 
 .list__domain-auto-renew {
-	width: 95px;
+	width: 96px;
 }
 
 .list__domain-privacy {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* We're adding one more pixel between the info icon in the domains list header
* The options title was removed in another PR

<img width="434" alt="Screenshot 2020-07-29 at 23 21 50" src="https://user-images.githubusercontent.com/1355045/88849258-4f3e5f80-d1f2-11ea-8cbe-1feafa66cd77.png">

#### Testing instructions

* Just verify that the left margin of the `info-popover` button is 2px and it still looks good and no lines are broken
