### PR TITLE
Fix/export suggestions calypso doctor

### DIFF
--- a/packages/calypso-doctor/cli.js
+++ b/packages/calypso-doctor/cli.js
@@ -11,13 +11,6 @@ const main = async () => {
 			"If you don't want to run this tool automatically, set the env var CALYPSO_DOCTOR_SKIP=true"
 		)
 	);
-
-	console.log();
-	console.log( chalk.redBright( 'Calypso Doctor is in beta.' ) );
-	console.log(
-		chalk.redBright( 'If you see any error please ignore it, but let Team Calypso know.' )
-	);
-
 	const results = await runEvaluations();
 
 	console.log( '' );

--- a/packages/calypso-doctor/evaluations/node-chromedriver.js
+++ b/packages/calypso-doctor/evaluations/node-chromedriver.js
@@ -19,7 +19,7 @@ module.exports = {
 	},
 	fix: () => {
 		const shell = getShellRc();
-		if ( shell ) return `Add \`CHROMEDRIVER_SKIP_DOWNLOAD=true\` to ${ shell }`;
+		if ( shell ) return `Add \`export CHROMEDRIVER_SKIP_DOWNLOAD=true\` to ${ shell }`;
 		return 'Set env variable `CHROMEDRIVER_SKIP_DOWNLOAD` with value `true`';
 	},
 };

--- a/packages/calypso-doctor/evaluations/node-memory.js
+++ b/packages/calypso-doctor/evaluations/node-memory.js
@@ -34,7 +34,8 @@ module.exports = {
 	fix: () => {
 		const desiredValue = getMemInMb() * 0.75;
 		const shell = getShellRc();
-		if ( shell ) return `Add \`NODE_OPTIONS=--max-old-space-size=${ desiredValue }\` to ${ shell }`;
+		if ( shell )
+			return `Add \`export NODE_OPTIONS=--max-old-space-size=${ desiredValue }\` to ${ shell }`;
 		return `Set env variable \`NODE_OPTIONS\` with value \`--max-old-space-size=${ desiredValue }\``;
 	},
 };

--- a/packages/calypso-doctor/evaluations/node-puppeteer.js
+++ b/packages/calypso-doctor/evaluations/node-puppeteer.js
@@ -19,7 +19,7 @@ module.exports = {
 	},
 	fix: () => {
 		const shell = getShellRc();
-		if ( shell ) return `Add \`PUPPETEER_SKIP_DOWNLOAD=true\` to ${ shell }`;
+		if ( shell ) return `Add \`export PUPPETEER_SKIP_DOWNLOAD=true\` to ${ shell }`;
 		return 'Set env variable `PUPPETEER_SKIP_DOWNLOAD` with value `true`';
 	},
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* [Calypso Doctor] Remove beta message. It was causing confusion.
* [Calypso Doctor] Add `export` keyword when suggesting to add an env variable to .bashrc/.zshrc

#### Testing instructions

* Run `yarn calypso-doctor` and notice the "this is in beta" message is gone
* Run `unset NODE_OPTS && yarn calypso-doctor`. Now the suggestion should say "Add `exports NODE_OPTS...`". Same for `PUPPETEER_SKIP_DOWNLOAD` and `CHROMEDRIVER_SKIP_DOWNLOAD`
