### PR TITLE
Move Editing Toolkit JS tests to GitHub & rename

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -403,15 +403,7 @@ jobs:
           command: |
             cd apps/wpcom-block-editor/ && yarn build --output-path=$CIRCLE_ARTIFACTS/wpcom-block-editor
       - store-artifacts-and-test-results
-  test-full-site-editing:
-    <<: *defaults
-    parallelism: 1
-    steps:
-      - prepare
-      - run:
-          name: Run Full Site Editing client tests
-          command: |
-            cd apps/full-site-editing && yarn run test:js
+
   test-client:
     <<: *defaults
     parallelism: 6
@@ -904,9 +896,6 @@ workflows:
           filters:
             branches:
               ignore: master
-      - test-full-site-editing:
-          requires:
-            - setup
       - build-notifications:
           requires:
             - setup

--- a/.github/workflows/editing-toolkit-plugin.yml
+++ b/.github/workflows/editing-toolkit-plugin.yml
@@ -33,11 +33,6 @@ jobs:
       if: steps.cache.outputs.cache-hit != 'true'
       run: yarn install --frozen-lockfile # Not needed when restoring from cache.
 
-    - name: Composer install
-      uses: nick-zh/composer-php@HEAD
-      with:
-        action: 'install'
-
     - name: Build packages
       if: steps.cache.outputs.cache-hit == 'true'
       run: yarn run postinstall # Needed only when not running yarn install.
@@ -52,6 +47,39 @@ jobs:
         name: editing-toolkit-build-archive
         path: apps/full-site-editing/full-site-editing-plugin
 
+  jest:
+    name: Run JS tests
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@HEAD
+
+    # https://github.com/actions/cache/blob/HEAD/examples.md#node---lerna
+    - name: Restore node_modules cache
+      id: cache
+      uses: actions/cache@HEAD
+      with:
+        path: |
+          node_modules
+          */*/node_modules
+        key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+
+    - name: Install dependencies
+      if: steps.cache.outputs.cache-hit != 'true'
+      run: yarn install --frozen-lockfile # Not needed when restoring from cache.
+
+    # It saves a bit of time to download the artifact rather than doing a build.
+    - name: Get build
+      uses: actions/download-artifact@HEAD
+      with:
+        name: editing-toolkit-build-archive
+        path: apps/full-site-editing/full-site-editing-plugin
+
+    - name: Test JavaScript
+      run: yarn run test:js
+      working-directory: apps/full-site-editing
+
   mc_upload:
     name: Create wpcom sync diff
     needs: build
@@ -64,7 +92,7 @@ jobs:
       uses: actions/checkout@HEAD
 
     # It saves a bit of time to download the artifact rather than doing a build.
-    - name: Get Build
+    - name: Get build
       uses: actions/download-artifact@HEAD
       with:
         name: editing-toolkit-build-archive

--- a/apps/full-site-editing/README.md
+++ b/apps/full-site-editing/README.md
@@ -10,7 +10,7 @@ In the near future, the following will be changed:
 - Documentation
 - CI job names
 
-Those will be updated to use "editing-toolkit" in place of "full-site-editing"
+Those will be updated to use "editing-toolkit" in place of "full-site-editing."
 
 The following items will likely not change:
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request
1. Remove editing toolkit tests from circleCI
2. Rename from fse to editing toolkit
3. Add to GH actions.

#### Testing instructions
test-unit JS tests should look good in CI