### PR TITLE
Rename editing toolkit package name

### DIFF
--- a/apps/full-site-editing/dev-plugin/dev.php
+++ b/apps/full-site-editing/dev-plugin/dev.php
@@ -8,7 +8,7 @@
  * License: GPLv2 or later
  * Text Domain: full-site-editing
  *
- * @package A8C\FSE
+ * @package A8C\EditingToolkit
  */
 
 namespace A8C\FSE;

--- a/apps/full-site-editing/full-site-editing-plugin/block-inserter-modifications/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-inserter-modifications/index.php
@@ -2,7 +2,7 @@
 /**
  * Block Inserter Modifications
  *
- * @package A8C\FSE
+ * @package A8C\EditingToolkit
  */
 
 namespace A8C\FSE\Block_Inserter_Modifications;

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/class-block-patterns.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/class-block-patterns.php
@@ -2,7 +2,7 @@
 /**
  * Block Patterns file.
  *
- * @package A8C\FSE
+ * @package A8C\EditingToolkit
  */
 
 namespace A8C\FSE;

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/call-to-action-02.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/call-to-action-02.php
@@ -2,7 +2,7 @@
 /**
  * Call to Action pattern.
  *
- * @package A8C\FSE
+ * @package A8C\EditingToolkit
  */
 
 $markup = '

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/call-to-action-03.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/call-to-action-03.php
@@ -2,7 +2,7 @@
 /**
  * Call to Action pattern.
  *
- * @package A8C\FSE
+ * @package A8C\EditingToolkit
  */
 
 $markup = '

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/collage-gallery.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/collage-gallery.php
@@ -2,7 +2,7 @@
 /**
  * Collage gallery pattern.
  *
- * @package A8C\FSE
+ * @package A8C\EditingToolkit
  */
 
 $markup = '

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/coming-soon.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/coming-soon.php
@@ -2,7 +2,7 @@
 /**
  * Coming Soon pattern.
  *
- * @package A8C\FSE
+ * @package A8C\EditingToolkit
  */
 
 $markup = '

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/contact-02.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/contact-02.php
@@ -2,7 +2,7 @@
 /**
  * Contact pattern.
  *
- * @package A8C\FSE
+ * @package A8C\EditingToolkit
  */
 
 $markup = '

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/contact-03.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/contact-03.php
@@ -2,7 +2,7 @@
 /**
  * Contact pattern.
  *
- * @package A8C\FSE
+ * @package A8C\EditingToolkit
  */
 
 // phpcs:disable WordPress.WP.CapitalPDangit.Misspelled

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/contact-04.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/contact-04.php
@@ -2,7 +2,7 @@
 /**
  * Contact pattern.
  *
- * @package A8C\FSE
+ * @package A8C\EditingToolkit
  */
 
 // phpcs:disable WordPress.WP.CapitalPDangit.Misspelled

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/contact.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/contact.php
@@ -2,7 +2,7 @@
 /**
  * Contact pattern.
  *
- * @package A8C\FSE
+ * @package A8C\EditingToolkit
  */
 
 $markup = '

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/description-and-image.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/description-and-image.php
@@ -2,7 +2,7 @@
 /**
  * Description and Image pattern.
  *
- * @package A8C\FSE
+ * @package A8C\EditingToolkit
  */
 
 $markup = '

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/food-menu.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/food-menu.php
@@ -2,7 +2,7 @@
 /**
  * Food menu pattern.
  *
- * @package A8C\FSE
+ * @package A8C\EditingToolkit
  */
 
 $markup = '

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/headline-02.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/headline-02.php
@@ -2,7 +2,7 @@
 /**
  * Headline pattern.
  *
- * @package A8C\FSE
+ * @package A8C\EditingToolkit
  */
 
 $markup = '

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/headline.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/headline.php
@@ -2,7 +2,7 @@
 /**
  * Headline pattern.
  *
- * @package A8C\FSE
+ * @package A8C\EditingToolkit
  */
 
 $markup = '

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/image-and-description.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/image-and-description.php
@@ -2,7 +2,7 @@
 /**
  * Image and Description pattern.
  *
- * @package A8C\FSE
+ * @package A8C\EditingToolkit
  */
 
 $markup = '

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/image-and-text.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/image-and-text.php
@@ -2,7 +2,7 @@
 /**
  * Image and Text pattern.
  *
- * @package A8C\FSE
+ * @package A8C\EditingToolkit
  */
 
 $markup = '

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/images-with-titles.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/images-with-titles.php
@@ -2,7 +2,7 @@
 /**
  * Image with Titles pattern.
  *
- * @package A8C\FSE
+ * @package A8C\EditingToolkit
  */
 
 $markup = '

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/list.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/list.php
@@ -2,7 +2,7 @@
 /**
  * List pattern.
  *
- * @package A8C\FSE
+ * @package A8C\EditingToolkit
  */
 
 $markup = '

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/masonry-gallery.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/masonry-gallery.php
@@ -2,7 +2,7 @@
 /**
  * Masonry gallery pattern.
  *
- * @package A8C\FSE
+ * @package A8C\EditingToolkit
  */
 
 $markup = '

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/numbered-list.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/numbered-list.php
@@ -2,7 +2,7 @@
 /**
  * Numbered List pattern.
  *
- * @package A8C\FSE
+ * @package A8C\EditingToolkit
  */
 
 $markup = '

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/numbers.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/numbers.php
@@ -2,7 +2,7 @@
 /**
  * Numbers pattern.
  *
- * @package A8C\FSE
+ * @package A8C\EditingToolkit
  */
 
 $markup = '

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/portraits-and-text.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/portraits-and-text.php
@@ -2,7 +2,7 @@
 /**
  * Portraits and Text pattern.
  *
- * @package A8C\FSE
+ * @package A8C\EditingToolkit
  */
 
 $markup = '

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/recent-posts-02.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/recent-posts-02.php
@@ -2,7 +2,7 @@
 /**
  * Recent Posts pattern.
  *
- * @package A8C\FSE
+ * @package A8C\EditingToolkit
  */
 
 $markup = '

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/recent-posts.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/recent-posts.php
@@ -2,7 +2,7 @@
 /**
  * Recent Posts pattern.
  *
- * @package A8C\FSE
+ * @package A8C\EditingToolkit
  */
 
 $markup = '

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/three-columns-and-image.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/three-columns-and-image.php
@@ -2,7 +2,7 @@
 /**
  * Call to action pattern.
  *
- * @package A8C\FSE
+ * @package A8C\EditingToolkit
  */
 
 $markup = '

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/three-images-side-by-side.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/three-images-side-by-side.php
@@ -2,7 +2,7 @@
 /**
  * Three images side-by-side pattern.
  *
- * @package A8C\FSE
+ * @package A8C\EditingToolkit
  */
 
 $markup = '

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/tiled-mosaic-gallery.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/tiled-mosaic-gallery.php
@@ -2,7 +2,7 @@
 /**
  * Tiled Mosaic Gallery pattern.
  *
- * @package A8C\FSE
+ * @package A8C\EditingToolkit
  */
 
 $markup = '

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/two-column-text-and-image.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/two-column-text-and-image.php
@@ -2,7 +2,7 @@
 /**
  * Two Column Text and Image pattern.
  *
- * @package A8C\FSE
+ * @package A8C\EditingToolkit
  */
 
 $markup = '

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/two-images-and-quote.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/two-images-and-quote.php
@@ -2,7 +2,7 @@
 /**
  * Two images and quote pattern.
  *
- * @package A8C\FSE
+ * @package A8C\EditingToolkit
  */
 
 $markup = '

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/two-images-side-by-side.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/two-images-side-by-side.php
@@ -2,7 +2,7 @@
 /**
  * Two images side-by-side pattern.
  *
- * @package A8C\FSE
+ * @package A8C\EditingToolkit
  */
 
 $markup = '

--- a/apps/full-site-editing/full-site-editing-plugin/common/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/common/index.php
@@ -6,7 +6,7 @@
  * Currently, this module may not be the best place if you need to load
  * front-end assets, but you could always add a separate action for that.
  *
- * @package A8C\FSE
+ * @package A8C\EditingToolkit
  */
 
 namespace A8C\FSE\Common;

--- a/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/blocks/navigation-menu/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/blocks/navigation-menu/index.php
@@ -2,7 +2,7 @@
 /**
  * Render navigation menu block file.
  *
- * @package A8C\FSE
+ * @package A8C\EditingToolkit
  */
 
 namespace A8C\FSE;

--- a/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/blocks/post-content/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/blocks/post-content/index.php
@@ -2,7 +2,7 @@
 /**
  * Render post content block file.
  *
- * @package A8C\FSE
+ * @package A8C\EditingToolkit
  */
 
 namespace A8C\FSE;

--- a/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/blocks/site-credit/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/blocks/site-credit/index.php
@@ -2,7 +2,7 @@
 /**
  * Site credit backend functions.
  *
- * @package A8C\FSE
+ * @package A8C\EditingToolkit
  */
 
 namespace A8C\FSE;

--- a/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/blocks/site-description/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/blocks/site-description/index.php
@@ -2,7 +2,7 @@
 /**
  * Render site description file.
  *
- * @package A8C\FSE
+ * @package A8C\EditingToolkit
  */
 
 namespace A8C\FSE;

--- a/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/blocks/site-title/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/blocks/site-title/index.php
@@ -2,7 +2,7 @@
 /**
  * Render site title block.
  *
- * @package A8C\FSE
+ * @package A8C\EditingToolkit
  */
 
 namespace A8C\FSE;

--- a/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/blocks/template/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/blocks/template/index.php
@@ -2,7 +2,7 @@
 /**
  * Render template block file.
  *
- * @package A8C\FSE
+ * @package A8C\EditingToolkit
  */
 
 namespace A8C\FSE;

--- a/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/class-full-site-editing.php
@@ -2,7 +2,7 @@
 /**
  * Full site editing file.
  *
- * @package A8C\FSE
+ * @package A8C\EditingToolkit
  */
 
 namespace A8C\FSE;

--- a/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/helpers.php
+++ b/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/helpers.php
@@ -6,7 +6,7 @@
  * plugin is activated on the site. (Not to be confused with whether FSE is
  * active on the site!)
  *
- * @package A8C\FSE
+ * @package A8C\EditingToolkit
  */
 
 namespace A8C\FSE;

--- a/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/serialize-block-fallback.php
+++ b/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/serialize-block-fallback.php
@@ -2,7 +2,7 @@
 /**
  * Fallback to provide serialize_block support being added to WP 5.3.0
  *
- * @package A8C\FSE
+ * @package A8C\EditingToolkit
  */
 
 if ( ! function_exists( 'serialize_block' ) ) {

--- a/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/templates/class-rest-templates-controller.php
+++ b/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/templates/class-rest-templates-controller.php
@@ -2,7 +2,7 @@
 /**
  * REST Templates Controller file.
  *
- * @package A8C\FSE
+ * @package A8C\EditingToolkit
  */
 
 namespace A8C\FSE;

--- a/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/templates/class-template-image-inserter.php
+++ b/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/templates/class-template-image-inserter.php
@@ -2,7 +2,7 @@
 /**
  * Full site editing file.
  *
- * @package A8C\FSE
+ * @package A8C\EditingToolkit
  */
 
 namespace A8C\FSE;

--- a/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/templates/class-wp-template-inserter.php
+++ b/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/templates/class-wp-template-inserter.php
@@ -2,7 +2,7 @@
 /**
  * Full site editing file.
  *
- * @package A8C\FSE
+ * @package A8C\EditingToolkit
  */
 
 namespace A8C\FSE;

--- a/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/templates/class-wp-template.php
+++ b/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/templates/class-wp-template.php
@@ -2,7 +2,7 @@
 /**
  * WP Template file.
  *
- * @package A8C\FSE
+ * @package A8C\EditingToolkit
  */
 
 namespace A8C\FSE;

--- a/apps/full-site-editing/full-site-editing-plugin/editor-domain-picker/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-domain-picker/index.php
@@ -6,7 +6,7 @@
  * Currently, this module may not be the best place if you need to load
  * front-end assets, but you could always add a separate action for that.
  *
- * @package A8C\FSE
+ * @package A8C\EditingToolkit
  */
 
 namespace A8C\FSE\EditorDomainPicker;

--- a/apps/full-site-editing/full-site-editing-plugin/editor-gutenboarding-launch/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-gutenboarding-launch/index.php
@@ -6,7 +6,7 @@
  * Currently, this module may not be the best place if you need to load
  * front-end assets, but you could always add a separate action for that.
  *
- * @package A8C\FSE
+ * @package A8C\EditingToolkit
  */
 
 namespace A8C\FSE\EditorGutenboardingLaunchButton;

--- a/apps/full-site-editing/full-site-editing-plugin/editor-plans-grid/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-plans-grid/index.php
@@ -2,7 +2,7 @@
 /**
  * Plans grid for block editor.
  *
- * @package A8C\FSE
+ * @package A8C\EditingToolkit
  */
 
 namespace A8C\FSE\EditorPlansGrid;

--- a/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/index.php
@@ -6,7 +6,7 @@
  * Currently, this module may not be the best place if you need to load
  * front-end assets, but you could always add a separate action for that.
  *
- * @package A8C\FSE
+ * @package A8C\EditingToolkit
  */
 
 namespace A8C\FSE\EditorSiteLaunch;

--- a/apps/full-site-editing/full-site-editing-plugin/event-countdown-block/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/event-countdown-block/index.php
@@ -2,7 +2,7 @@
 /**
  * Event Countdown Block
  *
- * @package A8C\FSE
+ * @package A8C\EditingToolkit
  */
 
 add_action(

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -8,7 +8,7 @@
  * License: GPLv2 or later
  * Text Domain: full-site-editing
  *
- * @package A8C\FSE
+ * @package A8C\EditingToolkit
  */
 
 namespace A8C\FSE;

--- a/apps/full-site-editing/full-site-editing-plugin/jetpack-timeline/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/jetpack-timeline/index.php
@@ -2,7 +2,7 @@
 /**
  * Timeline Block
  *
- * @package A8C\FSE
+ * @package A8C\EditingToolkit
  */
 
 // Register Block Scripts.

--- a/apps/full-site-editing/full-site-editing-plugin/newspack-blocks/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/newspack-blocks/index.php
@@ -2,7 +2,7 @@
 /**
  * Blog posts file.
  *
- * @package A8C\FSE
+ * @package A8C\EditingToolkit
  */
 
 namespace A8C\FSE;

--- a/apps/full-site-editing/full-site-editing-plugin/phpunit/bootstrap.php
+++ b/apps/full-site-editing/full-site-editing-plugin/phpunit/bootstrap.php
@@ -4,7 +4,7 @@
  *
  * @see https://github.com/WordPress/gutenberg/blob/HEAD/phpunit/bootstrap.php
  *
- * @package FullSiteEditing
+ * @package A8C\EditingToolkit
  */
 
 // Require composer dependencies.

--- a/apps/full-site-editing/full-site-editing-plugin/phpunit/class-is-fse-active-test.php
+++ b/apps/full-site-editing/full-site-editing-plugin/phpunit/class-is-fse-active-test.php
@@ -2,7 +2,7 @@
 /**
  * Is FSE Active Tests File
  *
- * @package full-site-editing-plugin
+ * @package A8C\EditingToolkit
  */
 
 namespace A8C\FSE;

--- a/apps/full-site-editing/full-site-editing-plugin/posts-list-block/class-posts-list-block.php
+++ b/apps/full-site-editing/full-site-editing-plugin/posts-list-block/class-posts-list-block.php
@@ -2,7 +2,7 @@
 /**
  * Posts list block file.
  *
- * @package A8C\FSE
+ * @package A8C\EditingToolkit
  */
 
 namespace A8C\FSE;

--- a/apps/full-site-editing/full-site-editing-plugin/posts-list-block/templates/no-posts.php
+++ b/apps/full-site-editing/full-site-editing-plugin/posts-list-block/templates/no-posts.php
@@ -2,7 +2,7 @@
 /**
  * Template for displaying a message that posts cannot be found.
  *
- * @package full-site-editing
+ * @package A8C\EditingToolkit
  * @link https://developer.wordpress.org/themes/basics/template-hierarchy/
  */
 

--- a/apps/full-site-editing/full-site-editing-plugin/posts-list-block/templates/post-item.php
+++ b/apps/full-site-editing/full-site-editing-plugin/posts-list-block/templates/post-item.php
@@ -2,7 +2,7 @@
 /**
  * Post Item.
  *
- * @package full-site-editing
+ * @package A8C\EditingToolkit
  *
  * phpcs:disable WordPress.XSS.EscapeOutput.OutputNotEscaped
  */

--- a/apps/full-site-editing/full-site-editing-plugin/posts-list-block/templates/posts-list.php
+++ b/apps/full-site-editing/full-site-editing-plugin/posts-list-block/templates/posts-list.php
@@ -2,7 +2,7 @@
 /**
  * Posts List
  *
- * @package full-site-editing
+ * @package A8C\EditingToolkit
  */
 
 /**

--- a/apps/full-site-editing/full-site-editing-plugin/posts-list-block/utils.php
+++ b/apps/full-site-editing/full-site-editing-plugin/posts-list-block/utils.php
@@ -2,7 +2,7 @@
 /**
  * Template functions.
  *
- * @package A8C\FSE
+ * @package A8C\EditingToolkit
  */
 
 namespace A8C\FSE;

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/premium-content.php
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/premium-content.php
@@ -2,7 +2,7 @@
 /**
  * Registers premium block types only available on paid plans.
  *
- * @package A8C\FSE\Earn\PremiumContent;
+ * @package A8C\EditingToolkit\Earn\PremiumContent;
  */
 
 declare( strict_types = 1 );

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/subscription-service/class-jetpack-token-subscription-service.php
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/subscription-service/class-jetpack-token-subscription-service.php
@@ -1,7 +1,7 @@
 <?php declare( strict_types = 1 );
 
 /**
- * @package A8C\FSE\Earn
+ * @package A8C\EditingToolkit\Earn
  *
  * A paywall that exchanges JWT tokens from WordPress.com to allow
  * a current visitor to view content that has been deemed "Premium content".

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/subscription-service/class-subscription-service.php
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/subscription-service/class-subscription-service.php
@@ -1,6 +1,6 @@
 <?php declare( strict_types = 1 );
 /**
- * @package A8C\FSE\Earn\PremiumContent;
+ * @package A8C\EditingToolkit\Earn\PremiumContent;
  *
  * The Subscription Service represents the entity responsible for making sure a visitor
  * can see blocks that are considered premium content.

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/subscription-service/class-token-subscription-service.php
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/subscription-service/class-token-subscription-service.php
@@ -1,6 +1,6 @@
 <?php declare( strict_types = 1 );
 /**
- * @package A8C\FSE\Earn
+ * @package A8C\EditingToolkit\Earn
  *
  * A paywall that exchanges JWT tokens from WordPress.com to allow
  * a current visitor to view content that has been deemed "Premium content".

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/subscription-service/class-unconfigured-subscription-service.php
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/subscription-service/class-unconfigured-subscription-service.php
@@ -1,6 +1,6 @@
 <?php declare( strict_types = 1 );
 /**
- * @package A8C\FSE\Earn
+ * @package A8C\EditingToolkit\Earn
  *
  * The environment does not have a subscription service available.
  *

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/subscription-service/class-wpcom-offline-subscription-service.php
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/subscription-service/class-wpcom-offline-subscription-service.php
@@ -1,6 +1,6 @@
 <?php declare( strict_types = 1 );
 /**
- * @package A8C\FSE\Earn
+ * @package A8C\EditingToolkit\Earn
  *
  * This subscription service is used when a subscriber is offline and a token is not available.
  * This subscription service will be used when rendering content in email and reader on WPCOM only.

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/subscription-service/class-wpcom-token-subscription-service.php
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/subscription-service/class-wpcom-token-subscription-service.php
@@ -1,6 +1,6 @@
 <?php declare( strict_types = 1 );
 /**
- * @package A8C\FSE\Earn
+ * @package A8C\EditingToolkit\Earn
  *
  * A paywall that exchanges JWT tokens from WordPress.com to allow
  * a current visitor to view content that has been deemed "Premium content".

--- a/apps/full-site-editing/full-site-editing-plugin/site-editor/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/site-editor/index.php
@@ -13,7 +13,7 @@
  * The difference being that that was a custom Dotcom solution and this one is being built on
  * top of core FSE. When ready, it should completely replace the existing dotcom-fse functionality.
  *
- * @package A8C\FSE
+ * @package A8C\EditingToolkit
  */
 
 namespace A8C\FSE;

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
@@ -2,7 +2,7 @@
 /**
  * Starter page templates file.
  *
- * @package A8C\FSE
+ * @package A8C\EditingToolkit
  */
 
 namespace A8C\FSE;

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-wp-rest-sideload-image-controller.php
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-wp-rest-sideload-image-controller.php
@@ -2,7 +2,7 @@
 /**
  * WP_REST_Sideload_Image_Controller file.
  *
- * @package A8C\FSE
+ * @package A8C\EditingToolkit
  */
 
 namespace A8C\FSE;

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/class-wpcom-block-editor-nav-sidebar.php
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/class-wpcom-block-editor-nav-sidebar.php
@@ -2,7 +2,7 @@
 /**
  * WPCOM block editor nav sidebar file.
  *
- * @package A8C\FSE
+ * @package A8C\EditingToolkit
  */
 
 namespace A8C\FSE;

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nux/class-wp-rest-wpcom-block-editor-nux-status-controller.php
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nux/class-wp-rest-wpcom-block-editor-nux-status-controller.php
@@ -2,7 +2,7 @@
 /**
  * WP_REST_WPCOM_Block_Editor_NUX_Status_Controller file.
  *
- * @package A8C\FSE
+ * @package A8C\EditingToolkit
  */
 
 namespace A8C\FSE;

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nux/class-wpcom-block-editor-nux.php
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nux/class-wpcom-block-editor-nux.php
@@ -2,7 +2,7 @@
 /**
  * WPCOM Block Editor NUX file.
  *
- * @package A8C\FSE
+ * @package A8C\EditingToolkit
  */
 
 namespace A8C\FSE;

--- a/bin/pre-commit-hook.js
+++ b/bin/pre-commit-hook.js
@@ -10,7 +10,7 @@ const path = require( 'path' );
 
 const phpcsPath = getPathForCommand( 'phpcs' );
 const phpcbfPath = getPathForCommand( 'phpcbf' );
-
+console.log( phpcbfPath );
 function quotedPath( pathToQuote ) {
 	if ( pathToQuote.includes( ' ' ) ) {
 		return `"${ pathToQuote }"`;

--- a/bin/pre-commit-hook.js
+++ b/bin/pre-commit-hook.js
@@ -10,7 +10,7 @@ const path = require( 'path' );
 
 const phpcsPath = getPathForCommand( 'phpcs' );
 const phpcbfPath = getPathForCommand( 'phpcbf' );
-console.log( phpcbfPath );
+
 function quotedPath( pathToQuote ) {
 	if ( pathToQuote.includes( ' ' ) ) {
 		return `"${ pathToQuote }"`;


### PR DESCRIPTION
There were several `@package` declarations in the plugin, including:
- A8C\FSE
- FullSiteEditing
- full-site-editing
- full-site-editing-plugin

This have all been renamed to `A8C\EditingToolkit`.

#### Testing instructions
1. look at the changes and see if they make sense
2. test locally (phpunit should pass)
3. Expect phpcs to fail because of other issues in the modified files. verify they are unrelated to package name.
