### PR TITLE
Move `DomainWarning` message in the `DomainItem` component

### DIFF
--- a/client/lib/domains/resolve-domain-status.js
+++ b/client/lib/domains/resolve-domain-status.js
@@ -49,6 +49,8 @@ export function resolveDomainStatus(
 					statusText: translate( 'Action required' ),
 					statusClass: 'status-error',
 					icon: 'info',
+					listStatusText: translate( 'Complete setup' ),
+					listStatusClass: 'warning',
 				};
 			}
 

--- a/client/lib/domains/resolve-domain-status.js
+++ b/client/lib/domains/resolve-domain-status.js
@@ -46,8 +46,8 @@ export function resolveDomainStatus(
 
 			if ( ( ! isJetpackSite || isSiteAutomatedTransfer ) && ! domain.pointsToWpcom ) {
 				return {
-					statusText: translate( 'Action required' ),
-					statusClass: 'status-error',
+					statusText: translate( 'Complete setup' ),
+					statusClass: 'status-warning',
 					icon: 'info',
 					listStatusText: translate( 'Complete setup' ),
 					listStatusClass: 'warning',

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -96,12 +96,9 @@ export class List extends React.Component {
 					position="domain-list"
 					selectedSite={ this.props.selectedSite }
 					allowedRules={ [
-						'newDomainsWithPrimary',
-						'newDomains',
 						'unverifiedDomainsCanManage',
 						'pendingGSuiteTosAcceptanceDomains',
 						'unverifiedDomainsCannotManage',
-						'wrongNSMappedDomains',
 						'transferStatus',
 						'newTransfersWrongNS',
 						'pendingConsent',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Instead of showing one big warning for mapped domains not pointing at us at the top of the domains list we'll show a "Complete setup" status notice in the DomainItem component with warning color.

It looks like this:

<img width="1074" alt="Screenshot 2020-07-30 at 11 55 24" src="https://user-images.githubusercontent.com/1355045/88903745-d1636e00-d25c-11ea-854c-484eb56d33b9.png">

And we're removing this warning from the top of the list:

<img width="1074" alt="Screenshot 2020-07-30 at 12 03 42" src="https://user-images.githubusercontent.com/1355045/88903784-e213e400-d25c-11ea-9843-790da74ef669.png">

#### Testing instructions

* Add domain mapping for a domain that doesn't point to WordPress.com site and verify that you see the "Complete setup" info notice and that the item is marked with a warning color (orange)
