### PR TITLE
Fixes invalid JSX

### DIFF
--- a/client/reader/list-manage/feed-item.tsx
+++ b/client/reader/list-manage/feed-item.tsx
@@ -42,7 +42,7 @@ function renderFeedError( err: FeedError ) {
 		<div className="feed-item list-item is-error">
 			<div className="list-item__content">
 				<div className="list-item__icon">
-					<Gridicon icon="notice" size={ 24 } /> }
+					<Gridicon icon="notice" size={ 24 } />
 				</div>
 
 				<div className="list-item__info">

--- a/client/reader/list-manage/site-item.tsx
+++ b/client/reader/list-manage/site-item.tsx
@@ -41,7 +41,7 @@ function renderSiteError( err: SiteError ) {
 		<div className="site-item list-item is-error">
 			<div className="list-item__content">
 				<div className="list-item__icon">
-					<Gridicon icon="notice" size={ 24 } /> }
+					<Gridicon icon="notice" size={ 24 } />
 				</div>
 
 				<div className="list-item__info">


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes invalid JSX.
I'm pretty sure these files are not used, that's the reason compilation doesn't break today.

They need to be fixed because otherwise eslint will break when linting those files.

Happy to remove them instead if we are sure this feature is not coming back any time soon.