### PR TITLE
Adds support for <AsyncLoad> and asyncRequire() to eslint rule

### DIFF
--- a/packages/eslint-plugin-wpcalypso/docs/rules/no-package-relative-imports.md
+++ b/packages/eslint-plugin-wpcalypso/docs/rules/no-package-relative-imports.md
@@ -24,24 +24,30 @@ This rule forbids the former approach and can auto-fix it to the latter.
 
 The following patterns are considered incorrect:
 
-```js
+```jsx
 import config from 'config';
 import * as stats from 'reader/stats';
 import { localizeUrl } from 'lib/i18n-utils';
 export { default as ActionCard } from 'components/action-card/docs/example';
 export * from 'components/AppBar';
-const config = require('config');
+const config1 = require('config');
+const config2 = asyncRequire('config');
+
+const component = <AsyncLoad require="config"/>
 ```
 
 The following patterns are correct
 
-```js
+```jsx
 import config from 'wp-calypso/config';
 import * as stats from 'wp-calypso/reader/stats';
 import { localizeUrl } from 'wp-calypso/lib/i18n-utils';
 export { default as ActionCard } from 'wp-calypso/components/action-card/docs/example';
 export * from 'wp-calypso/components/AppBar';
-const config = require('wp-calypso/config');
+const config1 = require('wp-calypso/config');
+const config2 = asyncRequire('wp-calypso/config');
+
+const component = <AsyncLoad require="wp-calypso/config"/>
 
 import config from './config';
 import config from '../../../config';

--- a/packages/eslint-plugin-wpcalypso/lib/rules/test/no-package-relative-imports.js
+++ b/packages/eslint-plugin-wpcalypso/lib/rules/test/no-package-relative-imports.js
@@ -37,6 +37,9 @@ new RuleTester( {
 	parserOptions: {
 		ecmaVersion: 6,
 		sourceType: 'module',
+		ecmaFeatures: {
+			jsx: true,
+		},
 	},
 } ).run( 'no-package-relative-imports', rule, {
 	valid: [
@@ -50,6 +53,8 @@ new RuleTester( {
 		},
 		{ code: "export * from 'wp-calypso/components/AppBar';", options },
 		{ code: "const config = require('wp-calypso/config');", options },
+		{ code: "const config = asyncRequire('wp-calypso/config');", options },
+		{ code: "const component = <AsyncLoad require='wp-calypso/config'/>", options },
 		{ code: "import config from './config';", options },
 		{ code: "import config from '../../../config';", options },
 		{ code: "import config from 'random-directory';", options },
@@ -121,6 +126,28 @@ new RuleTester( {
 				},
 			],
 			output: `const config = require('wp-calypso/config');`,
+		},
+		{
+			code: `const config = asyncRequire('config');`,
+			options,
+			errors: [
+				{
+					message: `Import config relative to \`${ calypsoDir }\` is not allowed`,
+					type: 'CallExpression',
+				},
+			],
+			output: `const config = asyncRequire('wp-calypso/config');`,
+		},
+		{
+			code: `const component = <AsyncLoad require="config"/>`,
+			options,
+			errors: [
+				{
+					message: `Import config relative to \`${ calypsoDir }\` is not allowed`,
+					type: 'JSXElement',
+				},
+			],
+			output: `const component = <AsyncLoad require="wp-calypso/config"/>`,
 		},
 
 		// Dynamic test: test the rule with each subdirectory and file inside `./client`

--- a/packages/eslint-plugin-wpcalypso/lib/rules/test/no-package-relative-imports.js
+++ b/packages/eslint-plugin-wpcalypso/lib/rules/test/no-package-relative-imports.js
@@ -34,6 +34,7 @@ const options = [
 ];
 
 new RuleTester( {
+	parser: require.resolve( 'babel-eslint' ),
 	parserOptions: {
 		ecmaVersion: 6,
 		sourceType: 'module',
@@ -54,6 +55,7 @@ new RuleTester( {
 		{ code: "export * from 'wp-calypso/components/AppBar';", options },
 		{ code: "const config = require('wp-calypso/config');", options },
 		{ code: "const config = asyncRequire('wp-calypso/config');", options },
+		{ code: "const getConfig = async () => await import('wp-calypso/config');", options },
 		{ code: "const component = <AsyncLoad require='wp-calypso/config'/>", options },
 		{ code: "import config from './config';", options },
 		{ code: "import config from '../../../config';", options },
@@ -137,6 +139,17 @@ new RuleTester( {
 				},
 			],
 			output: `const config = asyncRequire('wp-calypso/config');`,
+		},
+		{
+			code: `const config = async () => await import('config');`,
+			options,
+			errors: [
+				{
+					message: `Import config relative to \`${ calypsoDir }\` is not allowed`,
+					type: 'ImportExpression',
+				},
+			],
+			output: `const config = async () => await import('wp-calypso/config');`,
 		},
 		{
 			code: `const component = <AsyncLoad require="config"/>`,


### PR DESCRIPTION
### Changes

Adds support to detect and fix package-relative modules when using the component `<AsyncLoad>` or the function `asyncRequire()`

### Background

See https://github.com/Automattic/wp-calypso/pull/44479 for the rationale of this rule.

### Testing instructions

1. Open `.eslintrc` and configure the rule `wpcalypso/no-package-relative-imports` from `off` to `error`.
2. Run `./node_modules/.bin/eslint-nibble --ext .js,.jsx,.ts,.tsx --rule wpcalypso/no-package-relative-imports client/blocks/inline-help/index.jsx`
3. Open the file `client/blocks/inline-help/index.jsx` and check the changes make sense