### PR TITLE
Updates the back navigation link for the signup reskinned flow

### DIFF
--- a/client/signup/navigation-link/index.jsx
+++ b/client/signup/navigation-link/index.jsx
@@ -18,6 +18,7 @@ import { recordTracksEvent } from 'state/analytics/actions';
 import { submitSignupStep } from 'state/signup/progress/actions';
 import { getSignupProgress } from 'state/signup/progress/selectors';
 import { getFilteredSteps } from '../utils';
+import { getABTestVariation } from 'lib/abtest';
 
 /**
  * Style dependencies
@@ -132,7 +133,13 @@ export class NavigationLink extends Component {
 
 		if ( this.props.direction === 'back' ) {
 			backGridicon = <Gridicon icon="arrow-left" size={ 18 } />;
-			text = labelText ? labelText : translate( 'Back' );
+			if ( labelText ) {
+				text = labelText;
+			} else if ( 'reskinned' === getABTestVariation( 'reskinSignupFlow' ) ) {
+				text = translate( 'Go Back' );
+			} else {
+				text = translate( 'Back' );
+			}
 		}
 
 		if ( this.props.direction === 'forward' ) {

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -456,17 +456,23 @@ body.is-section-signup.is-white-signup .signup.is-onboarding {
 	--color-accent: #117ac9;
 	--color-accent-60: #0e64a5;
 
-	.signup-header .wordpress-logo {
-		position: absolute;
-		left: 16px;
-		top: 12px;
-		fill: var( --color-text );
-		transform-origin: 0 0;
-	}
-
-	.flow-progress-indicator {
-		color: var( --color-text );
-		font-weight: normal;
+	.signup-header {
+		.wordpress-logo {
+			position: absolute;
+			left: 24px;
+			top: 20px;
+			fill: var( --color-text );
+			transform-origin: 0 0;
+		}
+		.signup-header__right {
+			top: 22px;
+			right: 24px;
+			
+			.flow-progress-indicator {
+				color: var( --color-text );
+				font-weight: normal;
+			}
+		}
 	}
 
 	.navigation-link.button.back {
@@ -475,8 +481,8 @@ body.is-section-signup.is-white-signup .signup.is-onboarding {
 		}
 
 		color: $gray-50;
-		top: 12px;
-		left: 50px;
+		top: 23px;
+		left: 72px;
 		text-decoration: underline;
 		font-weight: normal;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates the "back" navigation text to "Go Back"
* Updates the position of the link according to the Figma design.

#### Testing instructions

* Go to /start/new
* Make sure you're assigned to the reskinned group of reskinSignupFlow a/b test.
* Follow the signup flow steps
The top area should look like this:

Signup
![image](https://user-images.githubusercontent.com/5436027/88934639-81a59680-d29e-11ea-9289-1dffaabb493c.png)

Domains
![image](https://user-images.githubusercontent.com/5436027/88934724-997d1a80-d29e-11ea-96d2-e73eb0e4dd88.png)

Plans
![image](https://user-images.githubusercontent.com/5436027/88934785-a8fc6380-d29e-11ea-94b7-89b4335fc044.png)
