### PR TITLE
Enable Feature Picker in production and bump AB datestamp

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -118,7 +118,7 @@ export default {
 		allowExistingUsers: true,
 	},
 	newSiteGutenbergOnboarding: {
-		datestamp: '20200714',
+		datestamp: '20200730',
 		variations: {
 			gutenberg: 10,
 			control: 90,

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -118,7 +118,7 @@ export default {
 		allowExistingUsers: true,
 	},
 	newSiteGutenbergOnboarding: {
-		datestamp: '20200730',
+		datestamp: '20200731',
 		variations: {
 			gutenberg: 10,
 			control: 90,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -53,6 +53,7 @@
 		"gutenboarding/style-preview-verticals": false,
 		"gutenboarding/alpha-templates": true,
 		"gutenboarding/language-picker": false,
+		"gutenboarding/feature-picker": true,
 		"happychat": true,
 		"help": true,
 		"help/courses": true,


### PR DESCRIPTION
**On hold** until [redesigned launch flow](https://github.com/Automattic/wp-calypso/issues/43750) and [v2 rollback](https://github.com/Automattic/wp-calypso/issues/44454) are released and tested.

#### Changes proposed in this Pull Request

* This releases the feature picker to production and bumps the AB datestamp. 

#### Testing instructions

Create a site using [`calypso.live`](https://calypso.live/new?branch=bump-ab-test-gutenboarding) and you should see the feature picker after you select a font pairing.

Fixes https://github.com/Automattic/wp-calypso/issues/44428
