### PR TITLE
Removes site offset time from Backup page

### DIFF
--- a/client/components/jetpack/daily-backup-status/index.jsx
+++ b/client/components/jetpack/daily-backup-status/index.jsx
@@ -42,11 +42,10 @@ class DailyBackupStatus extends Component {
 	};
 
 	getDisplayDate = ( date, withLatest = true ) => {
-		const { translate, moment, timezone, gmtOffset } = this.props;
+		const { translate, moment } = this.props;
 
-		//Apply the time offset
-		const backupDate = applySiteOffset( moment( date ), { timezone, gmtOffset } );
-		const today = applySiteOffset( moment(), { timezone, gmtOffset } );
+		const backupDate = moment( date );
+		const today = moment();
 
 		const isToday = today.isSame( backupDate, 'day' );
 		const yearToday = today.format( 'YYYY' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This removes the site offset from being applied to Backup dates to fix incorrect time display.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Set up a new JP site.
* Set the site offset to a timezone ahead of yours.
* Connect a site to Jetpack Backup.
* Observe Jetpack Backup dash on prod. (you may need to trigger a backup first!)
* Observe the same on this branch.
* Verify that the time is correct on the latter.

Fixes 1143508703416848-as-1185886809463829.