### PR TITLE
Checkout: show notice when customer adds to cart a Backup product already included in the plan

### DIFF
--- a/client/my-sites/checkout/checkout/included-product-notice-content.tsx
+++ b/client/my-sites/checkout/checkout/included-product-notice-content.tsx
@@ -11,11 +11,8 @@ import { useSelector } from 'react-redux';
  */
 import { getProductBySlug } from 'state/products-list/selectors';
 import { getSitePurchases } from 'state/purchases/selectors';
-
-type Plan = {
-	product_slug: string;
-	product_name_short: string;
-};
+import type { Plan } from 'state/plans/types';
+import type { RawSiteProduct } from 'state/sites/selectors/get-site-products';
 
 type Site = {
 	ID: number;
@@ -33,7 +30,9 @@ const IncludedProductNoticeContent: FunctionComponent< Props > = ( {
 	productSlug,
 	selectedSite,
 } ) => {
-	const product = useSelector( ( state ) => getProductBySlug( state, productSlug ) );
+	const product = useSelector( ( state ) =>
+		getProductBySlug( state, productSlug )
+	) as RawSiteProduct;
 	const translate = useTranslate();
 	const purchases = useSelector( ( state ) => getSitePurchases( state, selectedSite?.ID ) );
 	const purchase = isArray( purchases )
@@ -52,7 +51,7 @@ const IncludedProductNoticeContent: FunctionComponent< Props > = ( {
 					{
 						args: {
 							plan: plan.product_name_short,
-							product: ( product as any )?.product_name,
+							product: product?.product_name,
 						},
 						comment:
 							'The `plan` variable refers to the short name of the plan the customer owns already. `product` refers to the product in the cart that is already included in the plan.',

--- a/client/my-sites/checkout/checkout/included-product-notice-content.tsx
+++ b/client/my-sites/checkout/checkout/included-product-notice-content.tsx
@@ -1,0 +1,69 @@
+/**
+ * External dependencies
+ */
+import { useTranslate } from 'i18n-calypso';
+import { isArray } from 'lodash';
+import React, { FunctionComponent } from 'react';
+import { useSelector } from 'react-redux';
+
+/**
+ * Internal Dependencies
+ */
+import { getProductBySlug } from 'state/products-list/selectors';
+import { getSitePurchases } from 'state/purchases/selectors';
+
+type Plan = {
+	product_slug: string;
+	product_name_short: string;
+};
+
+type Site = {
+	ID: number;
+	slug: string;
+};
+
+type Props = {
+	plan: Plan;
+	productSlug: string;
+	selectedSite: Site;
+};
+
+const IncludedProductNoticeContent: FunctionComponent< Props > = ( {
+	plan,
+	productSlug,
+	selectedSite,
+} ) => {
+	const product = useSelector( ( state ) => getProductBySlug( state, productSlug ) );
+	const translate = useTranslate();
+	const purchases = useSelector( ( state ) => getSitePurchases( state, selectedSite?.ID ) );
+	const purchase = isArray( purchases )
+		? purchases.find( ( p ) => p.productSlug === plan.product_slug )
+		: null;
+	const purchaseId = purchase?.id;
+	const subscriptionUrl = purchaseId
+		? `/me/purchases/${ selectedSite.slug }/${ purchaseId }`
+		: '/me/purchases/';
+
+	return (
+		<div className="checkout__duplicate-notice">
+			<p className="checkout__duplicate-notice-message">
+				{ translate(
+					'You currently own Jetpack %(plan)s. The product you are about to purchase, %(product)s, is already included in this plan.',
+					{
+						args: {
+							plan: plan.product_name_short,
+							product: ( product as any )?.product_name,
+						},
+						comment:
+							'The `plan` variable refers to the short name of the plan the customer owns already. `product` refers to the product in the cart that is already included in the plan.',
+					}
+				) }
+			</p>
+			<a className="checkout__duplicate-notice-link" href={ subscriptionUrl }>
+				{ translate( 'Manage subscription' ) }
+			</a>
+		</div>
+	);
+};
+
+export default IncludedProductNoticeContent;

--- a/client/my-sites/checkout/checkout/owned-product-notice-content.tsx
+++ b/client/my-sites/checkout/checkout/owned-product-notice-content.tsx
@@ -26,7 +26,7 @@ type Props = {
 	selectedSite: Site;
 };
 
-const DuplicateProductNoticeContent: FunctionComponent< Props > = ( { product, selectedSite } ) => {
+const OwnedProductNoticeContent: FunctionComponent< Props > = ( { product, selectedSite } ) => {
 	const translate = useTranslate();
 	const purchases = useSelector( ( state ) => getSitePurchases( state, selectedSite?.ID ) );
 	const purchase = isArray( purchases )
@@ -60,4 +60,4 @@ const DuplicateProductNoticeContent: FunctionComponent< Props > = ( { product, s
 	);
 };
 
-export default DuplicateProductNoticeContent;
+export default OwnedProductNoticeContent;

--- a/client/my-sites/checkout/checkout/owned-product-notice-content.tsx
+++ b/client/my-sites/checkout/checkout/owned-product-notice-content.tsx
@@ -10,11 +10,7 @@ import { useSelector } from 'react-redux';
  * Internal Dependencies
  */
 import { getSitePurchases } from 'state/purchases/selectors';
-
-type Product = {
-	productSlug: string;
-	productName: string;
-};
+import type { SiteProduct } from 'state/sites/selectors/get-site-products';
 
 type Site = {
 	ID: number;
@@ -22,7 +18,7 @@ type Site = {
 };
 
 type Props = {
-	product: Product;
+	product: SiteProduct;
 	selectedSite: Site;
 };
 

--- a/client/state/plans/types.ts
+++ b/client/state/plans/types.ts
@@ -1,0 +1,9 @@
+export type Plan = {
+	expired: boolean;
+	is_free: boolean;
+	product_id: number;
+	product_name_short: string;
+	product_slug: string;
+	user_is_owner: boolean;
+	// TODO: complete
+};

--- a/client/state/sites/products/conflicts.ts
+++ b/client/state/sites/products/conflicts.ts
@@ -4,6 +4,8 @@
 import createSelector from 'lib/create-selector';
 import {
 	FEATURE_SPAM_AKISMET_PLUS,
+	FEATURE_JETPACK_BACKUP_REALTIME,
+	FEATURE_JETPACK_BACKUP_DAILY,
 	JETPACK_PLANS,
 	PLAN_JETPACK_FREE,
 	PLAN_JETPACK_BUSINESS,
@@ -140,6 +142,41 @@ export const isPlanIncludingSiteBackup = createSelector(
 			] ),
 		],
 	]
+);
+
+/**
+ * Check if a Backup product is already included in a site plan.
+ *
+ * @param {AppState} state The redux state.
+ * @param {number} siteId The site ID.
+ * @param {string} productSlug The product slug.
+ * @returns {boolean|null} True if the product is already included in a plan, or null when it's unable to be determined.
+ */
+export const isBackupProductIncludedInSitePlan = createSelector(
+	( state: AppState, siteId: number | null, productSlug: string ): boolean | null => {
+		if ( ! siteId ) {
+			return null;
+		}
+
+		let feature;
+
+		if (
+			[ PRODUCT_JETPACK_BACKUP_DAILY, PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY ].includes( productSlug )
+		) {
+			feature = FEATURE_JETPACK_BACKUP_DAILY;
+		} else if (
+			[ PRODUCT_JETPACK_BACKUP_REALTIME, PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY ].includes(
+				productSlug
+			)
+		) {
+			feature = FEATURE_JETPACK_BACKUP_REALTIME;
+		} else {
+			return null;
+		}
+
+		return hasFeature( state, siteId, feature );
+	},
+	[ ( state: AppState, siteId: number | null, productSlug: string ) => [ siteId, productSlug ] ]
 );
 
 export type IncompatibleProducts = {

--- a/client/state/sites/selectors/get-site-products.ts
+++ b/client/state/sites/selectors/get-site-products.ts
@@ -17,7 +17,7 @@ export interface SiteProduct {
 	userIsOwner: boolean;
 }
 
-interface RawSiteProduct {
+export interface RawSiteProduct {
 	product_id: string;
 	product_slug: string;
 	product_name: string;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Using jetpack.com, a customer could end up on the checkout page with a Backup product in their cart that is already included in their Jetpack plan. This PR adds a warning at the top of the checkout page in such cases.

This is the next step of https://github.com/Automattic/wp-calypso/pull/44181.

#### Implementation notes

Only Backup is part of the scope of this PR. It was difficult to make the code more generic (i.e. handling more than the Backup product), since it seems that there's no code that links the products directly to the plan features (which is what `isBackupProductIncludedInSitePlan` essentially does). 

I renamed `DuplicateProductNoticeContent` to better distinguish between this notice and the one introduced in https://github.com/Automattic/wp-calypso/pull/44181.

#### Testing instructions

- Download the PR
- Select a self-hosted Jetpack site with a Personal, or Premium plan
- Visit the URL `/checkout/:site/jetpack_backup_daily`
- Check that the notice is present (see screenshot below), that the copy makes sense and that the link brings you to the purchase page
- Visit the URL `/checkout/:site/jetpack_backup_realtime`
- Check that you **don't** see the notice
- Select a JP site with a Professional plan
- Visit the URL `/checkout/:site/jetpack_backup_daily`
- Check that you see the notice
- Visit the URL `/checkout/:site/jetpack_backup_realtime`
- Check that you see the notice

You may want to then follow the testing instructions in https://github.com/Automattic/wp-calypso/pull/44181.

#### Screenshots

New notice shown in the checkout page
<img width="695" alt="Screen Shot 2020-07-30 at 3 55 45 PM" src="https://user-images.githubusercontent.com/1620183/88968321-2adb9500-d27d-11ea-88cd-f77c89ce9c07.png">
