### PR TITLE
Nav sidebar: hide the sidebar in the experimental site editor

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/attach-sidebar.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nav-sidebar/src/attach-sidebar.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect, createPortal, useState } from '@wordpress/element';
 import { __experimentalMainDashboardButton as MainDashboardButton } from '@wordpress/interface';
 import { registerPlugin as originalRegisterPlugin, PluginSettings } from '@wordpress/plugins';
@@ -42,6 +42,12 @@ registerPlugin( 'a8c-full-site-editing-nav-sidebar', {
 				document.body.removeChild( clickGuardRoot );
 			};
 		} );
+
+		// Uses presence of data store to detect whether this is the experimental site editor.
+		const isSiteEditor = useSelect( ( select ) => !! select( 'core/edit-site' ) );
+		if ( isSiteEditor ) {
+			return null;
+		}
 
 		return (
 			<MainDashboardButton>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* hides the sidebar in the experimental site editor

Ideally we wouldn't enqueue the nav sidebar JS if it's not going to be used, but this is a quick fix for the broken close button in the site editor.

The `'core/edit-site'` store is being registered after this module loads, which means we can't check for the data store until much later. Unfortunately that means the nav sidebar plugin is still registered and starts rendering before we can bail out.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D47337-code to sandbox
* Sandbox a site that has the experimental site editor (you can create one at https://horizon.wordpress.com/new?flags=gutenboarding/site-editor)
* Navigate to https://horizon.wordpress.com/site-editor/YOUR_SITES_DOMAIN
* The (W) button should work as expected
* Open the post/page editor
* The (W) button should open the nav sidebar
