### PR TITLE
Classic editor: hotfix for editor toolbar

### DIFF
--- a/client/post-editor/editor-ground-control/style.scss
+++ b/client/post-editor/editor-ground-control/style.scss
@@ -1,10 +1,10 @@
 .editor-ground-control {
-	display: flex;
+	display: flex ! important;
 	align-items: center;
-	padding: 0;
+	padding: 0 ! important;
 	margin-bottom: 0;
 	transition: 0.3s box-shadow;
-	position: fixed;
+	position: fixed ! important;
 	top: 0;
 	left: 0;
 	right: 0;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is an attempt at a 🔥 HOTFIX 🔥  for a recent bug in the classic editor toolbar header. 

For some yet unknown reason the `.card` styles are overriding the `.editor-ground-control` styles.

**Before**

<img width="816" alt="Screen Shot 2020-07-31 at 3 52 22 pm" src="https://user-images.githubusercontent.com/6458278/89004761-41015800-d346-11ea-9712-2e95c61c8968.png">

**After**

<img width="1085" alt="Screen Shot 2020-07-31 at 3 54 32 pm" src="https://user-images.githubusercontent.com/6458278/89004758-3e9efe00-d346-11ea-8dde-dad010637876.png">


#### Testing instructions

Test using a site that has the classic editor enabled

To enable classic editor on one of your simple sites, head to your User RC and enable it

The toolbar should look normal
