### PR TITLE
fix(media): make sure we reset 'nextPageHandle' in case query changes

### DIFF
--- a/client/state/data-layer/wpcom/sites/media/index.js
+++ b/client/state/data-layer/wpcom/sites/media/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { toPairs } from 'lodash';
+import { toPairs, isEqual, omit } from 'lodash';
 
 /**
  * Internal dependencies
@@ -38,6 +38,7 @@ import {
 } from 'state/media/utils/flux-adapter';
 
 import { registerHandlers } from 'state/data-layer/handler-registry';
+import getNextPageQuery from 'state/selectors/get-next-page-query';
 
 /**
  * Module variables
@@ -107,7 +108,16 @@ export function requestMedia( action ) {
 	];
 }
 
-export const requestMediaSuccess = ( { siteId, query }, data ) => ( dispatch ) => {
+export const requestMediaSuccess = ( { siteId, query }, data ) => ( dispatch, getState ) => {
+	if (
+		! isEqual(
+			omit( query, 'page_handle' ),
+			omit( getNextPageQuery( getState(), siteId ), 'page_handle' )
+		)
+	) {
+		dispatch( successMediaRequest( siteId, query ) );
+		return;
+	}
 	dispatch( receiveMedia( siteId, data.media, data.found, query ) );
 	dispatch( successMediaRequest( siteId, query ) );
 	dispatch( setNextPageHandle( siteId, data.meta ) );

--- a/client/state/data-layer/wpcom/sites/media/test/index.js
+++ b/client/state/data-layer/wpcom/sites/media/test/index.js
@@ -23,17 +23,30 @@ import {
 describe( 'media request', () => {
 	test( 'should dispatch SUCCESS action when request completes', () => {
 		const dispatch = jest.fn();
+		const getState = jest.fn( () => ( {
+			media: {
+				fetching: {
+					2916284: {
+						query: {
+							mime_type: 'image/',
+						},
+					},
+				},
+			},
+		} ) );
 
 		const meta = Symbol( 'media request meta' );
 
-		requestMediaSuccess(
-			{ siteId: 2916284, query: 'a=b' },
-			{ media: { ID: 10, title: 'media title' }, found: true, meta }
-		)( dispatch );
+		const query = { number: 20, mime_type: 'image/' };
 
-		expect( dispatch ).toHaveBeenCalledWith( successMediaRequest( 2916284, 'a=b' ) );
+		requestMediaSuccess(
+			{ siteId: 2916284, query },
+			{ media: { ID: 10, title: 'media title' }, found: true, meta }
+		)( dispatch, getState );
+
+		expect( dispatch ).toHaveBeenCalledWith( successMediaRequest( 2916284, query ) );
 		expect( dispatch ).toHaveBeenCalledWith(
-			receiveMedia( 2916284, { ID: 10, title: 'media title' }, true, 'a=b' )
+			receiveMedia( 2916284, { ID: 10, title: 'media title' }, true, query )
 		);
 		expect( dispatch ).toHaveBeenCalledWith( setNextPageHandle( 2916284, meta ) );
 	} );

--- a/client/state/media/reducer.js
+++ b/client/state/media/reducer.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 
-import { isEmpty, mapValues, omit, pickBy, without, isNil, merge } from 'lodash';
+import { isEmpty, mapValues, omit, pickBy, without, isNil, merge, isEqual } from 'lodash';
 /**
  * Internal dependencies
  */
@@ -496,9 +496,15 @@ export const fetching = withoutPersistence( ( state = {}, action ) => {
 		case MEDIA_SET_QUERY: {
 			const { siteId, query } = action;
 
+			const newState = { ...state[ siteId ], query };
+
+			if ( ! isEqual( query, state[ siteId ]?.query ) ) {
+				delete newState.nextPageHandle;
+			}
+
 			return {
 				...state,
-				[ siteId ]: { ...state[ siteId ], query },
+				[ siteId ]: newState,
 			};
 		}
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Reported via p1596152527276500-slack-C02DQP0FP

* media state: make sure `nextPageHandle` is reset in case query changes
* media data layer: don't refill the store with data in case the query changed during the request

There seemed to be timing issues where switching back and forth between filters in the media library (Images, Documents, etc) would mix up request. That caused a new request, for example on _Images_, to use query data from the previously chosen filter (especially `nextPageHandle`) and wouldn't fetch most recent data but where the previous request finished.

#### Testing instructions

1. Go to a site with a lot of images (> 200) and open the media library /1
2. Now switch back and forth between _"All"_ and _"Images"_
3. Make sure you always get the most recent image first after switching
4. It's also a good idea to smoke test media library on `/media`, classic editor and Gutenberg

/1 to reproduce this bug (on the main branch) it's necessary to change filters while images are still being loaded