### PR TITLE
Classic editor: hotfix for classic editor toolbar

### DIFF
--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -21,6 +21,7 @@ import { getCurrentRoute } from 'state/selectors/get-current-route';
 import getCurrentQueryArguments from 'state/selectors/get-current-query-arguments';
 import { getSection, masterbarIsVisible } from 'state/ui/selectors';
 import BodySectionCssClass from './body-section-css-class';
+import GdprBanner from 'blocks/gdpr-banner';
 import wooDnaConfig from 'jetpack-connect/woo-dna-config';
 
 /**
@@ -127,9 +128,7 @@ const LayoutLoggedOut = ( {
 					{ secondary }
 				</div>
 			</div>
-			{ config.isEnabled( 'gdpr-banner' ) && (
-				<AsyncLoad require="blocks/gdpr-banner" placeholder={ null } />
-			) }
+			{ config.isEnabled( 'gdpr-banner' ) && <GdprBanner /> }
 		</div>
 	);
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Testing reverting #39979 to see if it fixes the layout bug in classic editor whereby the entire top toolbar styles are overwritten by `.card`. 

The current theory is that the deferred import causes the `.card` styles to be loaded later rather than early (in the split second before the app realizes the user is logged in), which is what we need in order for the editor styles to override them.

That's the theory anyway.

If this doesn't work, the fallback attempt is here: https://github.com/Automattic/wp-calypso/pull/44578

**Before**

<img width="816" alt="Screen Shot 2020-07-31 at 3 52 22 pm" src="https://user-images.githubusercontent.com/6458278/89004761-41015800-d346-11ea-9712-2e95c61c8968.png">

**After**

<img width="1085" alt="Screen Shot 2020-07-31 at 3 54 32 pm" src="https://user-images.githubusercontent.com/6458278/89004758-3e9efe00-d346-11ea-8dde-dad010637876.png">


#### Testing instructions

Use https://calypso.live/?branch=try/revert-gdpr-async-to-fix-classic-editor-card-override

This currently can't be tested locally due to the config setting for `gdpr-banner`, which is false for development

Test using a site that has the classic editor enabled

To enable classic editor on one of your simple sites, head to your User RC and enable it

The toolbar should look as one would expect a respectable toolbar to look like: distinguished, graceful, lithe...


