### PR TITLE
Reader: add css for Gutenberg social link block

### DIFF
--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -474,3 +474,322 @@
 .reader-full-post .embed-vimeo {
 	margin-bottom: 0;
 }
+.wp-block-social-links .wp-social-link a,
+.wp-block-social-links .wp-social-link a:hover {
+    text-decoration: none;
+    border-bottom: 0;
+    box-shadow: none;
+}
+.wp-social-link {
+    display: block;
+    width: 36px;
+    height: 36px;
+    border-radius: 36px;
+    margin-right: 8px;
+    transition: transform 0.1s ease;
+}
+@media ( prefers-reduced-motion: reduce ) {
+    .wp-social-link {
+        transition-duration: 0s;
+    }
+}
+.wp-social-link a {
+    padding: 6px;
+    display: block;
+    line-height: 0;
+    transition: transform 0.1s ease;
+}
+.wp-social-link a,
+.wp-social-link a:active,
+.wp-social-link a:hover,
+.wp-social-link a:visited,
+.wp-social-link svg {
+    color: currentColor;
+    fill: currentColor;
+}
+.wp-social-link:hover {
+    transform: scale( 1.1 );
+}
+.wp-block-social-links {
+    display: block;
+    margin-left: 0;
+    margin-right: 0;
+		padding: 0;
+}
+.wp-block-social-links li {
+    display: inline-block;
+}
+.wp-block-social-links:not( .is-style-logos-only ) .wp-social-link {
+    background-color: #f0f0f0;
+    color: #444;
+}
+.wp-block-social-links:not( .is-style-logos-only ) .wp-social-link-amazon {
+    background-color: #f90;
+    color: #fff;
+}
+.wp-block-social-links:not( .is-style-logos-only ) .wp-social-link-bandcamp {
+    background-color: #1ea0c3;
+    color: #fff;
+}
+.wp-block-social-links:not( .is-style-logos-only ) .wp-social-link-behance {
+    background-color: #0757fe;
+    color: #fff;
+}
+.wp-block-social-links:not( .is-style-logos-only ) .wp-social-link-codepen {
+    background-color: #1e1f26;
+    color: #fff;
+}
+.wp-block-social-links:not( .is-style-logos-only ) .wp-social-link-deviantart {
+    background-color: #02e49b;
+    color: #fff;
+}
+.wp-block-social-links:not( .is-style-logos-only ) .wp-social-link-dribbble {
+    background-color: #e94c89;
+    color: #fff;
+}
+.wp-block-social-links:not( .is-style-logos-only ) .wp-social-link-dropbox {
+    background-color: #4280ff;
+    color: #fff;
+}
+.wp-block-social-links:not( .is-style-logos-only ) .wp-social-link-etsy {
+    background-color: #f45800;
+    color: #fff;
+}
+.wp-block-social-links:not( .is-style-logos-only ) .wp-social-link-facebook {
+    background-color: #1778f2;
+    color: #fff;
+}
+.wp-block-social-links:not( .is-style-logos-only ) .wp-social-link-fivehundredpx {
+    background-color: #000;
+    color: #fff;
+}
+.wp-block-social-links:not( .is-style-logos-only ) .wp-social-link-flickr {
+    background-color: #0461dd;
+    color: #fff;
+}
+.wp-block-social-links:not( .is-style-logos-only ) .wp-social-link-foursquare {
+    background-color: #e65678;
+    color: #fff;
+}
+.wp-block-social-links:not( .is-style-logos-only ) .wp-social-link-github {
+    background-color: #24292d;
+    color: #fff;
+}
+.wp-block-social-links:not( .is-style-logos-only ) .wp-social-link-goodreads {
+    background-color: #eceadd;
+    color: #382110;
+}
+.wp-block-social-links:not( .is-style-logos-only ) .wp-social-link-google {
+    background-color: #ea4434;
+    color: #fff;
+}
+.wp-block-social-links:not( .is-style-logos-only ) .wp-social-link-instagram {
+    background-color: #f00075;
+    color: #fff;
+}
+.wp-block-social-links:not( .is-style-logos-only ) .wp-social-link-lastfm {
+    background-color: #e21b24;
+    color: #fff;
+}
+.wp-block-social-links:not( .is-style-logos-only ) .wp-social-link-linkedin {
+    background-color: #0d66c2;
+    color: #fff;
+}
+.wp-block-social-links:not( .is-style-logos-only ) .wp-social-link-mastodon {
+    background-color: #3288d4;
+    color: #fff;
+}
+.wp-block-social-links:not( .is-style-logos-only ) .wp-social-link-medium {
+    background-color: #02ab6c;
+    color: #fff;
+}
+.wp-block-social-links:not( .is-style-logos-only ) .wp-social-link-meetup {
+    background-color: #f6405f;
+    color: #fff;
+}
+.wp-block-social-links:not( .is-style-logos-only ) .wp-social-link-pinterest {
+    background-color: #e60122;
+    color: #fff;
+}
+.wp-block-social-links:not( .is-style-logos-only ) .wp-social-link-pocket {
+    background-color: #ef4155;
+    color: #fff;
+}
+.wp-block-social-links:not( .is-style-logos-only ) .wp-social-link-reddit {
+    background-color: #fe4500;
+    color: #fff;
+}
+.wp-block-social-links:not( .is-style-logos-only ) .wp-social-link-skype {
+    background-color: #0478d7;
+    color: #fff;
+}
+.wp-block-social-links:not( .is-style-logos-only ) .wp-social-link-snapchat {
+    background-color: #fefc00;
+    color: #fff;
+    stroke: #000;
+}
+.wp-block-social-links:not( .is-style-logos-only ) .wp-social-link-soundcloud {
+    background-color: #ff5600;
+    color: #fff;
+}
+.wp-block-social-links:not( .is-style-logos-only ) .wp-social-link-spotify {
+    background-color: #1bd760;
+    color: #fff;
+}
+.wp-block-social-links:not( .is-style-logos-only ) .wp-social-link-tumblr {
+    background-color: #011835;
+    color: #fff;
+}
+.wp-block-social-links:not( .is-style-logos-only ) .wp-social-link-twitch {
+    background-color: #6440a4;
+    color: #fff;
+}
+.wp-block-social-links:not( .is-style-logos-only ) .wp-social-link-twitter {
+    background-color: #1da1f2;
+    color: #fff;
+}
+.wp-block-social-links:not( .is-style-logos-only ) .wp-social-link-vimeo {
+    background-color: #1eb7ea;
+    color: #fff;
+}
+.wp-block-social-links:not( .is-style-logos-only ) .wp-social-link-vk {
+    background-color: #4680c2;
+    color: #fff;
+}
+.wp-block-social-links:not( .is-style-logos-only ) .wp-social-link-wordpress {
+    background-color: #3499cd;
+    color: #fff;
+}
+.wp-block-social-links:not( .is-style-logos-only ) .wp-social-link-yelp {
+    background-color: #d32422;
+    color: #fff;
+}
+.wp-block-social-links:not( .is-style-logos-only ) .wp-social-link-youtube {
+    background-color: red;
+    color: #fff;
+}
+.wp-block-social-links.is-style-logos-only .wp-social-link {
+    background: none;
+    padding: 4px;
+}
+.wp-block-social-links.is-style-logos-only .wp-social-link svg {
+    width: 28px;
+    height: 28px;
+}
+.wp-block-social-links.is-style-logos-only .wp-social-link-amazon {
+    color: #f90;
+}
+.wp-block-social-links.is-style-logos-only .wp-social-link-bandcamp {
+    color: #1ea0c3;
+}
+.wp-block-social-links.is-style-logos-only .wp-social-link-behance {
+    color: #0757fe;
+}
+.wp-block-social-links.is-style-logos-only .wp-social-link-codepen {
+    color: #1e1f26;
+}
+.wp-block-social-links.is-style-logos-only .wp-social-link-deviantart {
+    color: #02e49b;
+}
+.wp-block-social-links.is-style-logos-only .wp-social-link-dribbble {
+    color: #e94c89;
+}
+.wp-block-social-links.is-style-logos-only .wp-social-link-dropbox {
+    color: #4280ff;
+}
+.wp-block-social-links.is-style-logos-only .wp-social-link-etsy {
+    color: #f45800;
+}
+.wp-block-social-links.is-style-logos-only .wp-social-link-facebook {
+    color: #1778f2;
+}
+.wp-block-social-links.is-style-logos-only .wp-social-link-fivehundredpx {
+    color: #000;
+}
+.wp-block-social-links.is-style-logos-only .wp-social-link-flickr {
+    color: #0461dd;
+}
+.wp-block-social-links.is-style-logos-only .wp-social-link-foursquare {
+    color: #e65678;
+}
+.wp-block-social-links.is-style-logos-only .wp-social-link-github {
+    color: #24292d;
+}
+.wp-block-social-links.is-style-logos-only .wp-social-link-goodreads {
+    color: #382110;
+}
+.wp-block-social-links.is-style-logos-only .wp-social-link-google {
+    color: #ea4434;
+}
+.wp-block-social-links.is-style-logos-only .wp-social-link-instagram {
+    color: #f00075;
+}
+.wp-block-social-links.is-style-logos-only .wp-social-link-lastfm {
+    color: #e21b24;
+}
+.wp-block-social-links.is-style-logos-only .wp-social-link-linkedin {
+    color: #0d66c2;
+}
+.wp-block-social-links.is-style-logos-only .wp-social-link-mastodon {
+    color: #3288d4;
+}
+.wp-block-social-links.is-style-logos-only .wp-social-link-medium {
+    color: #02ab6c;
+}
+.wp-block-social-links.is-style-logos-only .wp-social-link-meetup {
+    color: #f6405f;
+}
+.wp-block-social-links.is-style-logos-only .wp-social-link-pinterest {
+    color: #e60122;
+}
+.wp-block-social-links.is-style-logos-only .wp-social-link-pocket {
+    color: #ef4155;
+}
+.wp-block-social-links.is-style-logos-only .wp-social-link-reddit {
+    color: #fe4500;
+}
+.wp-block-social-links.is-style-logos-only .wp-social-link-skype {
+    color: #0478d7;
+}
+.wp-block-social-links.is-style-logos-only .wp-social-link-snapchat {
+    color: #fff;
+    stroke: #000;
+}
+.wp-block-social-links.is-style-logos-only .wp-social-link-soundcloud {
+    color: #ff5600;
+}
+.wp-block-social-links.is-style-logos-only .wp-social-link-spotify {
+    color: #1bd760;
+}
+.wp-block-social-links.is-style-logos-only .wp-social-link-tumblr {
+    color: #011835;
+}
+.wp-block-social-links.is-style-logos-only .wp-social-link-twitch {
+    color: #6440a4;
+}
+.wp-block-social-links.is-style-logos-only .wp-social-link-twitter {
+    color: #1da1f2;
+}
+.wp-block-social-links.is-style-logos-only .wp-social-link-vimeo {
+    color: #1eb7ea;
+}
+.wp-block-social-links.is-style-logos-only .wp-social-link-vk {
+    color: #4680c2;
+}
+.wp-block-social-links.is-style-logos-only .wp-social-link-wordpress {
+    color: #3499cd;
+}
+.wp-block-social-links.is-style-logos-only .wp-social-link-yelp {
+    background-color: #d32422;
+    color: #fff;
+}
+.wp-block-social-links.is-style-logos-only .wp-social-link-youtube {
+    color: red;
+}
+.wp-block-social-links.is-style-pill-shape .wp-social-link {
+    width: auto;
+}
+.wp-block-social-links.is-style-pill-shape .wp-social-link a {
+    padding-left: 16px;
+    padding-right: 16px;
+}

--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -474,6 +474,8 @@
 .reader-full-post .embed-vimeo {
 	margin-bottom: 0;
 }
+
+// Social Icons Styles
 .wp-block-social-links .wp-social-link a,
 .wp-block-social-links .wp-social-link a:hover {
     text-decoration: none;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR adds support for the social icon links to the `_content.scss`, so that Android, iOS, and the web will properly format the block while viewing the post in the Reader. 

The following github issues will provide more detail
[Android](https://github.com/wordpress-mobile/WordPress-Android/issues/12545)
[iOS](https://github.com/wordpress-mobile/WordPress-iOS/issues/14541)

Of note:
On the web, the social icons link adheres to all alignments - center, left, right and cases in which no alignment has been chosen. For the native clients, there is a prior rule that dictates whether or not left and right alignments will be respected based upon the screen size of the device. Devices smaller than 660px will not respect those settings.

#### Testing instructions
* Open the following reader post in Production
 https://wordpress.com/read/feeds/96421692/posts/2831851458
 Notice that the social icons are showing vertically, not colored, not centered and have the list indicator 
- Start Calypso
- Navigate to http://calypso.localhost:3000/read/feeds/96421692/posts/2831851458
The social icons should be showing horizontally, centered, colored and the list indicator will be gone

| Before  | After  |
|---|---|
| <kbd><img src="https://user-images.githubusercontent.com/506707/89044056-73e02780-d317-11ea-9015-a99b0a1e27be.png" width=320></kbd> | <kbd> <img src="https://user-images.githubusercontent.com/506707/89044083-79d60880-d317-11ea-8640-19c265d63a4d.png" width=320></kbd>  |



