### PR TITLE
Modularise help state.

### DIFF
--- a/client/state/help/actions.js
+++ b/client/state/help/actions.js
@@ -11,6 +11,7 @@ import {
 
 import 'state/data-layer/wpcom/help/search';
 import 'state/data-layer/wpcom/help/support-history';
+import 'state/help/init';
 
 export const selectSiteId = ( siteId ) => ( {
 	type: HELP_CONTACT_FORM_SITE_SELECT,

--- a/client/state/help/courses/actions.js
+++ b/client/state/help/courses/actions.js
@@ -1,8 +1,9 @@
 /**
  * Internal dependencies
  */
-
 import { HELP_COURSES_RECEIVE } from 'state/action-types';
+
+import 'state/help/init';
 
 /**
  * Returns an action object used in signalling that a set of help courses has been

--- a/client/state/help/courses/selectors.js
+++ b/client/state/help/courses/selectors.js
@@ -1,11 +1,15 @@
 /**
+ * Internal dependencies
+ */
+import 'state/help/init';
+
+/**
  * Returns an array of course objects.
  *
  *
  * @param {object} state  Global state tree
  * @returns {Array}         Course objects
  */
-
 export function getHelpCourses( state ) {
 	return state.help.courses.items;
 }

--- a/client/state/help/directly/actions.js
+++ b/client/state/help/directly/actions.js
@@ -1,7 +1,6 @@
 /**
  * Internal dependencies
  */
-
 import {
 	DIRECTLY_ASK_QUESTION,
 	DIRECTLY_INITIALIZATION_START,
@@ -9,6 +8,8 @@ import {
 	DIRECTLY_INITIALIZATION_ERROR,
 } from 'state/action-types';
 import 'state/data-layer/third-party/directly';
+
+import 'state/help/init';
 
 export function askQuestion( questionText, name, email ) {
 	return { type: DIRECTLY_ASK_QUESTION, questionText, name, email };

--- a/client/state/help/init.js
+++ b/client/state/help/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'state/redux-store';
+import reducer from './reducer';
+
+registerReducer( [ 'help' ], reducer );

--- a/client/state/help/package.json
+++ b/client/state/help/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/help/reducer.js
+++ b/client/state/help/reducer.js
@@ -7,7 +7,7 @@ import {
 	SUPPORT_HISTORY_SET,
 } from 'state/action-types';
 import courses from './courses/reducer';
-import { combineReducers } from 'state/utils';
+import { combineReducers, withStorageKey } from 'state/utils';
 import directly from './directly/reducer';
 import ticket from './ticket/reducer';
 
@@ -59,7 +59,7 @@ export const supportHistory = ( state = [], { type, items } ) => {
 	}
 };
 
-export default combineReducers( {
+const combinedReducer = combineReducers( {
 	courses,
 	directly,
 	links,
@@ -67,3 +67,5 @@ export default combineReducers( {
 	selectedSiteId,
 	supportHistory,
 } );
+
+export default withStorageKey( 'help', combinedReducer );

--- a/client/state/help/selectors.js
+++ b/client/state/help/selectors.js
@@ -9,6 +9,8 @@ import { get } from 'lodash';
 import getSelectedOrPrimarySiteId from 'state/selectors/get-selected-or-primary-site-id';
 import { getSite } from 'state/sites/selectors';
 
+import 'state/help/init';
+
 export const getHelpSiteId = ( state ) => state.help?.selectedSiteId;
 
 /*

--- a/client/state/help/ticket/actions.js
+++ b/client/state/help/ticket/actions.js
@@ -1,7 +1,6 @@
 /**
  * Internal dependencies
  */
-
 import wpcom from 'lib/wp';
 import {
 	HELP_TICKET_CONFIGURATION_REQUEST,
@@ -9,6 +8,8 @@ import {
 	HELP_TICKET_CONFIGURATION_REQUEST_FAILURE,
 	HELP_TICKET_CONFIGURATION_DISMISS_ERROR,
 } from 'state/action-types';
+
+import 'state/help/init';
 
 export const ticketSupportConfigurationRequestSuccess = ( configuration ) => {
 	return {

--- a/client/state/help/ticket/selectors.js
+++ b/client/state/help/ticket/selectors.js
@@ -1,3 +1,8 @@
+/**
+ * Internal dependencies
+ */
+import 'state/help/init';
+
 export const isTicketSupportEligible = ( state ) => {
 	return state.help?.ticket?.isUserEligible;
 };

--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -24,7 +24,6 @@ import experiments from './experiments/reducer';
 import gsuiteUsers from './gsuite-users/reducer';
 import gutenbergOptInOut from './gutenberg-opt-in-out/reducer';
 import happychat from './happychat/reducer';
-import help from './help/reducer';
 import home from './home/reducer';
 import i18n from './i18n/reducer';
 import immediateLogin from './immediate-login/reducer';
@@ -70,7 +69,6 @@ const reducers = {
 	gsuiteUsers,
 	gutenbergOptInOut,
 	happychat,
-	help,
 	home,
 	httpData,
 	i18n,

--- a/client/state/selectors/get-active-support-tickets.js
+++ b/client/state/selectors/get-active-support-tickets.js
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import 'state/help/init';
 
 const ACTIVE_STATUSES = [ 'New', 'Open', 'Hold' ];
 

--- a/client/state/selectors/get-help-links.js
+++ b/client/state/selectors/get-help-links.js
@@ -1,4 +1,9 @@
 /**
+ * Internal dependencies
+ */
+import 'state/help/init';
+
+/**
  * Returns the help links that user received as a result of their last search query
  *
  * @param  {object} state Global state tree

--- a/client/state/selectors/has-user-asked-a-directly-question.js
+++ b/client/state/selectors/has-user-asked-a-directly-question.js
@@ -1,4 +1,9 @@
 /**
+ * Internal dependencies
+ */
+import 'state/help/init';
+
+/**
  * Tells whether the user has asked a question through the Directly RTM widget.
  *
  *
@@ -7,7 +12,6 @@
  * @param {object}  state  Global state tree
  * @returns {boolean}        Whether a question has been asked
  */
-
 export default function hasUserAskedADirectlyQuestion( state ) {
 	return state.help.directly.questionAsked !== null;
 }

--- a/client/state/selectors/is-directly-failed.js
+++ b/client/state/selectors/is-directly-failed.js
@@ -13,6 +13,8 @@
  */
 import { STATUS_ERROR } from 'state/help/directly/constants';
 
+import 'state/help/init';
+
 export default function isDirectlyFailed( state ) {
 	return state.help?.directly.status === STATUS_ERROR;
 }

--- a/client/state/selectors/is-directly-ready.js
+++ b/client/state/selectors/is-directly-ready.js
@@ -13,6 +13,8 @@
  */
 import { STATUS_READY } from 'state/help/directly/constants';
 
+import 'state/help/init';
+
 export default function getDirectlyStatus( state ) {
 	return state.help?.directly.status === STATUS_READY;
 }

--- a/client/state/selectors/is-directly-uninitialized.js
+++ b/client/state/selectors/is-directly-uninitialized.js
@@ -13,6 +13,8 @@
  */
 import { STATUS_UNINITIALIZED } from 'state/help/directly/constants';
 
+import 'state/help/init';
+
 export default function isDirectlyUninitialized( state ) {
 	return state.help?.directly.status === STATUS_UNINITIALIZED;
 }


### PR DESCRIPTION
This PR is one of many working on modularising state in Calypso. This one handles account help state.

For more details on state modularisation, see the [modularised state documentation](https://github.com/Automattic/wp-calypso/blob/master/docs/modularized-state.md) and p4TIVU-9lM-p2.

Note: I added all the reviewers that GitHub suggested. Please feel free to ignore the review request or pull in someone else if you're not comfortable reviewing this PR. Thank you!

Fixes #42441.

#### Changes proposed in this Pull Request

* Modularise help state

#### Testing instructions

Help state gets automatically loaded on boot due to the happychat middleware, so it's difficult to test the automatic loading portion of this PR.

Smoke-testing help functionality should be enough to validate this PR, since no actual functional code changes to help code have taken place.
