### PR TITLE
Composite checkout: fix purchase link in duplicate notice

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -39,6 +39,7 @@ import {
 	requestContactDetailsCache,
 	updateContactDetailsCache,
 } from 'state/domains/management/actions';
+import QuerySitePurchases from 'components/data/query-site-purchases';
 import RegistrantExtraInfoForm from 'components/domains/registrant-extra-info';
 import { getCurrentUserCountryCode } from 'state/current-user/selectors';
 import { StateSelect } from 'my-sites/domains/components/form';
@@ -531,6 +532,7 @@ export default function CompositeCheckout( {
 	return (
 		<React.Fragment>
 			<QuerySitePlans siteId={ siteId } />
+			<QuerySitePurchases siteId={ siteId } />
 			<QueryPlans />
 			<QueryProducts />
 			<QueryContactDetailsCache />

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
@@ -207,6 +207,7 @@ describe( 'CompositeCheckout', () => {
 						},
 					},
 				},
+				purchases: {},
 				countries: { payments: countryList, domains: countryList },
 			};
 		} );


### PR DESCRIPTION
Reverts Automattic/wp-calypso#44572

This PR reapplies the changes of https://github.com/Automattic/wp-calypso/pull/44564 but updates a test in addition.