### PR TITLE
Implementing Business plan bump offer

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -181,15 +181,6 @@ export default {
 			'ZA',
 		],
 	},
-	showBusinessPlanBump: {
-		datestamp: '20300619',
-		variations: {
-			variantShowPlanBump: 0,
-			control: 100,
-		},
-		defaultVariation: 'control',
-		allowExistingUsers: true,
-	},
 	offerResetFlow: {
 		datestamp: '20200804',
 		variations: {

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -481,15 +481,11 @@ export class Checkout extends React.Component {
 		}
 	}
 
-	maybeShowPlanBumpOfferConcierge( receiptId, stepResult ) {
+	maybeShowPlanBumpOffer( receiptId, stepResult ) {
 		const { cart, selectedSiteSlug } = this.props;
 
 		if ( hasPremiumPlan( cart ) && stepResult && isEmpty( stepResult.failed_purchases ) ) {
-			if ( 'variantShowPlanBump' === abtest( 'showBusinessPlanBump' ) ) {
-				return `/checkout/${ selectedSiteSlug }/offer-plan-upgrade/business/${ receiptId }`;
-			}
-
-			return `/checkout/offer-quickstart-session/${ receiptId }/${ selectedSiteSlug }`;
+			return `/checkout/${ selectedSiteSlug }/offer-plan-upgrade/business/${ receiptId }`;
 		}
 
 		return;
@@ -515,7 +511,7 @@ export class Checkout extends React.Component {
 			// A user just purchased one of the qualifying plans
 			// Show them the concierge session upsell page
 
-			const upgradePath = this.maybeShowPlanBumpOfferConcierge( pendingOrReceiptId, stepResult );
+			const upgradePath = this.maybeShowPlanBumpOffer( pendingOrReceiptId, stepResult );
 			if ( upgradePath ) {
 				return upgradePath;
 			}

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
@@ -28,8 +28,6 @@ jest.mock( 'lib/abtest', () => ( {
 	abtest: jest.fn( ( name ) => {
 		if ( 'conciergeUpsellDial' === name ) {
 			return 'offer';
-		} else if ( 'showBusinessPlanBump' === name ) {
-			return 'variantShowPlanBump';
 		}
 	} ),
 } ) );

--- a/client/my-sites/checkout/composite-checkout/use-get-thank-you-url.js
+++ b/client/my-sites/checkout/composite-checkout/use-get-thank-you-url.js
@@ -230,7 +230,7 @@ function getFallbackDestination( {
 	return '/';
 }
 
-function maybeShowPlanBumpOfferConcierge( {
+function maybeShowPlanBumpOffer( {
 	pendingOrReceiptId,
 	orderId,
 	cart,
@@ -239,10 +239,7 @@ function maybeShowPlanBumpOfferConcierge( {
 	isTransactionResultEmpty,
 } ) {
 	if ( hasPremiumPlan( cart ) && ! isTransactionResultEmpty && ! didPurchaseFail ) {
-		if ( 'variantShowPlanBump' === abtest( 'showBusinessPlanBump' ) ) {
-			return `/checkout/${ siteSlug }/offer-plan-upgrade/business/${ pendingOrReceiptId }`;
-		}
-		return getQuickstartUrl( { pendingOrReceiptId, siteSlug, orderId } );
+		return `/checkout/${ siteSlug }/offer-plan-upgrade/business/${ pendingOrReceiptId }`;
 	}
 
 	return;
@@ -272,7 +269,7 @@ function getRedirectUrlForConciergeNudge( {
 		// A user just purchased one of the qualifying plans
 		// Show them the concierge session upsell page
 
-		const upgradePath = maybeShowPlanBumpOfferConcierge( {
+		const upgradePath = maybeShowPlanBumpOffer( {
 			pendingOrReceiptId,
 			orderId,
 			cart,

--- a/client/my-sites/checkout/composite-checkout/use-get-thank-you-url.js
+++ b/client/my-sites/checkout/composite-checkout/use-get-thank-you-url.js
@@ -232,7 +232,6 @@ function getFallbackDestination( {
 
 function maybeShowPlanBumpOffer( {
 	pendingOrReceiptId,
-	orderId,
 	cart,
 	siteSlug,
 	didPurchaseFail,
@@ -271,7 +270,6 @@ function getRedirectUrlForConciergeNudge( {
 
 		const upgradePath = maybeShowPlanBumpOffer( {
 			pendingOrReceiptId,
-			orderId,
 			cart,
 			siteSlug,
 			didPurchaseFail,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR implements the Plan offer tested here pbxNRc-lW-p2

#### Testing instructions

- Signup for a new account.
- Add a Premium plan to cart and complete the purchase
- Verify the following:
 - That you are shown the Business upgrade upsell
 - That there's no `showBusinessPlanBump` test.

With other plans you should not see this offer, but either no offer or the QS offer.

