### PR TITLE
Adds a new block TimeMismatchWarning

### DIFF
--- a/client/blocks/time-mismatch-warning/README.md
+++ b/client/blocks/time-mismatch-warning/README.md
@@ -1,0 +1,22 @@
+Time Mismatch Warning
+=====================
+
+`TimeMismatchWarning` is a block that notifies users if there's a difference between their configured site timezone and their browser time. This is helpful to make users aware that events may appear to be the "incorrect" time and nudge them to fix the issue (if any).
+
+Nothing will appear if we don't detect a discrepancy.
+
+## How to use
+
+```jsx
+import TimeMismatchWarning from 'blocks/time-mismatch-warning';
+
+const Test = () => (
+	<>
+		<TimeMismatchWarning />
+		<ListWithTimes />
+	</>
+);
+```
+
+## Props
+There is only one prop: `status`. This is optional, and allows overriding the notice status. See the `Notice` component for allowed values.

--- a/client/blocks/time-mismatch-warning/docs/example.tsx
+++ b/client/blocks/time-mismatch-warning/docs/example.tsx
@@ -1,0 +1,19 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { TimeMismatchWarning } from 'blocks/time-mismatch-warning';
+import { useLocalizedMoment } from 'components/localized-moment';
+
+const TimeMismatchWarningExample = () => {
+	const moment = useLocalizedMoment();
+	const offsetTime = moment().add( 1, 'hour' );
+	return <TimeMismatchWarning applySiteOffset={ () => offsetTime } />;
+};
+TimeMismatchWarningExample.displayName = 'TimeMismatchWarning';
+
+export default TimeMismatchWarningExample;

--- a/client/blocks/time-mismatch-warning/index.tsx
+++ b/client/blocks/time-mismatch-warning/index.tsx
@@ -4,7 +4,6 @@
 import React, { FC } from 'react';
 import { useSelector } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
-import { flowRight } from 'lodash';
 
 /**
  * Internal dependencies
@@ -57,4 +56,4 @@ export const TimeMismatchWarning: FC< ExternalProps & ConnectedProps > = ( {
 	);
 };
 
-export default flowRight( withApplySiteOffset )( TimeMismatchWarning );
+export default withApplySiteOffset( TimeMismatchWarning );

--- a/client/blocks/time-mismatch-warning/index.tsx
+++ b/client/blocks/time-mismatch-warning/index.tsx
@@ -1,0 +1,60 @@
+/**
+ * External dependencies
+ */
+import React, { FC } from 'react';
+import { useSelector } from 'react-redux';
+import { useTranslate } from 'i18n-calypso';
+import { flowRight } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import Notice from 'components/notice';
+import { withApplySiteOffset, applySiteOffsetType } from 'components/site-offset';
+import { useLocalizedMoment } from 'components/localized-moment';
+
+/**
+ * Type dependencies
+ */
+import { getSelectedSiteSlug } from 'state/ui/selectors';
+
+interface ConnectedProps {
+	applySiteOffset: applySiteOffsetType;
+}
+
+interface ExternalProps {
+	status?: string;
+}
+
+export const TimeMismatchWarning: FC< ExternalProps & ConnectedProps > = ( {
+	applySiteOffset,
+	status = 'is-warning',
+}: ExternalProps & ConnectedProps ) => {
+	const translate = useTranslate();
+	const moment = useLocalizedMoment();
+	const siteSlug = useSelector( getSelectedSiteSlug );
+	const settingsUrl = siteSlug ? `/settings/general/${ siteSlug }` : '#';
+	const now = moment();
+	const siteOffset = applySiteOffset( now );
+
+	if ( ! siteOffset || now.isSame( siteOffset ) ) {
+		return null;
+	}
+
+	return (
+		<Notice status={ status }>
+			{ translate(
+				'Looks like your computer time and site time don’t match! ' +
+					'We’re going to show you times based on your site. ' +
+					'If that doesn’t look right, you can {{SiteSettings}}go here to update it{{/SiteSettings}}.',
+				{
+					components: {
+						SiteSettings: <a href={ settingsUrl } />,
+					},
+				}
+			) }
+		</Notice>
+	);
+};
+
+export default flowRight( withApplySiteOffset )( TimeMismatchWarning );

--- a/client/blocks/time-mismatch-warning/test/index.jsx
+++ b/client/blocks/time-mismatch-warning/test/index.jsx
@@ -1,0 +1,40 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { shallow } from 'enzyme';
+import { noop } from 'lodash';
+import moment from 'moment';
+
+/**
+ * Internal dependencies
+ */
+import { TimeMismatchWarning } from '../index';
+
+jest.mock( 'react-redux', () => ( {
+	...jest.requireActual( 'react-redux' ),
+	useSelector: jest.fn(),
+} ) );
+jest.mock( 'i18n-calypso', () => ( {
+	...jest.requireActual( 'i18n-calypso' ),
+	useTranslate: jest.fn( () => ( text ) => text ),
+} ) );
+
+describe( 'TimeMismatchWarning', () => {
+	test( 'to render nothing if times match', () => {
+		const wrapper = shallow( <TimeMismatchWarning applySiteOffset={ noop } /> );
+		expect( wrapper.isEmptyRender() ).toBeTruthy();
+	} );
+
+	test( 'to render if time does not match', () => {
+		const applySiteOffset = () => moment().add( 1, 'hour' );
+		const wrapper = shallow( <TimeMismatchWarning applySiteOffset={ applySiteOffset } /> );
+		expect( wrapper ).toMatchInlineSnapshot( `
+		<Localized(Notice)
+		  status="is-warning"
+		>
+		  Looks like your computer time and site time don’t match! We’re going to show you times based on your site. If that doesn’t look right, you can {{SiteSettings}}go here to update it{{/SiteSettings}}.
+		</Localized(Notice)>
+	` );
+	} );
+} );

--- a/client/devdocs/design/blocks.jsx
+++ b/client/devdocs/design/blocks.jsx
@@ -83,6 +83,7 @@ import ConversationFollowButton from 'blocks/conversation-follow-button/docs/exa
 import ColorSchemePicker from 'blocks/color-scheme-picker/docs/example';
 import UserMentions from 'blocks/user-mentions/docs/example';
 import SupportArticleDialog from 'blocks/support-article-dialog/docs/example';
+import TimeMismatchWarning from 'blocks/time-mismatch-warning/docs/example';
 import UpsellNudge from 'blocks/upsell-nudge/docs/example';
 
 export default class AppComponents extends React.Component {
@@ -198,6 +199,7 @@ export default class AppComponents extends React.Component {
 					) }
 					<SupportArticleDialog />
 					<ImageSelector readmeFilePath="image-selector" />
+					<TimeMismatchWarning readmeFilePath="time-mismatch-warning" />
 					<UpsellNudge />
 				</Collection>
 			</Main>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a new block, `TimeMismatchWarning`. This block displays a warning when the site time and user time do not match.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Review devdocs to ensure block renders as expected.

<img width="728" alt="Screen Shot 2020-07-31 at 6 53 56 PM" src="https://user-images.githubusercontent.com/1760168/89085428-356e5b00-d35f-11ea-8574-047668a6d5b6.png">

Fixes 1143508703416848-as-1185886809463829. Ref p1596221587136600-slack-CQXNTE9K9.