### PR TITLE
Reader: Allow opening the share popup menu with the keyboard

### DIFF
--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -515,8 +515,9 @@
 
 	.reader-share__button .gridicon {
 		position: relative;
-		top: 1px;
+		top: 0;
 		margin-right: 0;
+		margin-top: 0;
 	}
 
 	.like-button .gridicon {

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -515,7 +515,7 @@
 
 	.reader-share__button .gridicon {
 		position: relative;
-		top: 1px;
+		top: 3px;
 	}
 
 	.like-button .gridicon {

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -515,7 +515,7 @@
 
 	.reader-share__button .gridicon {
 		position: relative;
-		top: 3px;
+		top: 1px;
 		margin-right: 0;
 	}
 

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -516,6 +516,7 @@
 	.reader-share__button .gridicon {
 		position: relative;
 		top: 3px;
+		margin-right: 0;
 	}
 
 	.like-button .gridicon {

--- a/client/blocks/reader-post-options-menu/style.scss
+++ b/client/blocks/reader-post-options-menu/style.scss
@@ -9,7 +9,6 @@
 		}
 
 		&:focus {
-			box-shadow: none;
 			outline: thin dotted;
 		}
 	}

--- a/client/blocks/reader-share/index.jsx
+++ b/client/blocks/reader-share/index.jsx
@@ -21,6 +21,7 @@ import * as stats from 'reader/stats';
 import { preload } from 'sections-helper';
 import SiteSelector from 'components/site-selector';
 import getPrimarySiteId from 'state/selectors/get-primary-site-id';
+import { Button } from '@automattic/components';
 
 /**
  * Style dependencies
@@ -123,14 +124,7 @@ class ReaderShare extends React.Component {
 		} );
 	};
 
-	toggle = ( event ) => {
-		event.preventDefault();
-		if ( this.state.showingMenu ) {
-			if ( ! this.shareButton.current.contains( event.target ) ) {
-				return;
-			}
-		}
-
+	toggle = () => {
 		if ( ! this.state.showingMenu ) {
 			stats.recordAction( 'open_share' );
 			stats.recordGaEvent( 'Opened Share' );
@@ -183,17 +177,23 @@ class ReaderShare extends React.Component {
 			this.props.tagName,
 			{
 				className: 'reader-share',
-				onClick: this.toggle,
+				onClick: ( event ) => event.preventDefault(),
 				onTouchStart: preloadEditor,
 				onMouseEnter: preloadEditor,
 			},
 			[
-				<span key="button" ref={ this.shareButton } className={ buttonClasses }>
+				<Button
+					key="button"
+					ref={ this.shareButton }
+					className={ buttonClasses }
+					onClick={ this.toggle }
+					borderless
+				>
 					<Gridicon icon="share" size={ this.props.iconSize } />
 					<span className="reader-share__button-label">
 						{ translate( 'Share', { comment: 'Share the post' } ) }
 					</span>
-				</span>,
+				</Button>,
 				this.state.showingMenu && (
 					<ReaderPopoverMenu
 						key="menu"

--- a/client/blocks/reader-share/index.jsx
+++ b/client/blocks/reader-share/index.jsx
@@ -188,8 +188,9 @@ class ReaderShare extends React.Component {
 					className={ buttonClasses }
 					onClick={ this.toggle }
 					borderless
+					compact={ this.props.iconSize === 18 }
 				>
-					<Gridicon icon="share" size={ this.props.iconSize } />
+					<Gridicon icon="share" />
 					<span className="reader-share__button-label">
 						{ translate( 'Share', { comment: 'Share the post' } ) }
 					</span>

--- a/client/blocks/reader-share/style.scss
+++ b/client/blocks/reader-share/style.scss
@@ -4,6 +4,8 @@
 	position: relative;
 	display: inline-flex;
 	align-items: center;
+	font-size: 100%;
+	line-height: 22px;
 
 	&:hover,
 	&:active {
@@ -16,8 +18,6 @@
 
 	&.is-borderless {
 		.gridicon {
-			width: unset;
-			height: unset;
 			margin-right: 0;
 			margin-top: 0;
 			top: 0;

--- a/client/blocks/reader-share/style.scss
+++ b/client/blocks/reader-share/style.scss
@@ -34,6 +34,7 @@
 
 .reader-share__button-label {
 	margin-left: 6px;
+	font-weight: normal;
 
 	@include breakpoint-deprecated( '<480px' ) {
 		display: none;

--- a/client/blocks/reader-share/style.scss
+++ b/client/blocks/reader-share/style.scss
@@ -1,16 +1,22 @@
-.reader-share__button {
-	align-items: center;
-	box-sizing: border-box;
+.reader-share__button.button {
 	color: var( --color-text-subtle );
-	display: inline-flex;
 	padding: 4px;
 	position: relative;
 
 	&:hover,
-	&:focus,
 	&:active {
-		cursor: pointer;
 		color: var( --color-primary );
+	}
+
+	&:focus {
+		outline: thin dotted;
+	}
+
+	&.is-borderless {
+		.gridicon {
+			width: 18px;
+			height: 18px;
+		}
 	}
 
 	.gridicon {

--- a/client/blocks/reader-share/style.scss
+++ b/client/blocks/reader-share/style.scss
@@ -2,6 +2,8 @@
 	color: var( --color-text-subtle );
 	padding: 4px;
 	position: relative;
+	display: inline-flex;
+	align-items: center;
 
 	&:hover,
 	&:active {
@@ -14,8 +16,11 @@
 
 	&.is-borderless {
 		.gridicon {
-			width: 18px;
-			height: 18px;
+			width: unset;
+			height: unset;
+			margin-right: 0;
+			margin-top: 0;
+			top: 0;
 		}
 	}
 


### PR DESCRIPTION
As reported in #44417, users couldn't set the focus on the share button of Reader's posts using the Tab key, and couldn't open the share popup menu when pressing the Enter key.

The ellipsis button that opens the post options was working as expected (it could be focused and opened the options menu when pressing the Enter key), so I took `ReaderPostOptionsMenu` component as an example to follow, for fixing this issue.

#### Changes proposed in this Pull Request

* Changed the markup of the `ReaderShare` component to use a `button` element instead of a `span`. Used the `Button` component from `@automattic/components`.
* Took advantage of `accessible-focus` module to style the button when focused.
* Removed the reset on `box-shadow` in `ReaderPostOptionsMenu` so both the share post button and the post options button look the same when focused using the keyboard.

##### Before
![Grabación de pantalla 2020-08-01 a la(s) 23 09 00](https://user-images.githubusercontent.com/5444806/89113822-2e714680-d44c-11ea-91bd-383dae4f4c39.gif)

##### After
![Grabación de pantalla 2020-08-01 a la(s) 23 06 02](https://user-images.githubusercontent.com/5444806/89113803-df2b1600-d44b-11ea-849e-07b7e6e2dfee.gif)

#### Testing instructions

* Starting at URL: /discover
* Press the Tab key until reaching the share post button, in the first post
* Verify that the share post button can be focused
* Verify that the share post button has a blue outline
* Press the Enter key
* Verify that the share popup menu is displayed
* Press the Escape key
* Verify that the share post button is focused again
* Press the Tab key to go to the post options button
* Verify that the post options button has a blue outline

Similar steps should be followed in /read, /search and in a full post view (for example, /read/feeds/41325786/posts/2836837208)

Fixes #44417 

cc: @bluefuton 