### PR TITLE
Replace usage of deprecated wait call with waitFor in data-stores auth package flows test

### DIFF
--- a/packages/data-stores/src/auth/test/flows.ts
+++ b/packages/data-stores/src/auth/test/flows.ts
@@ -14,7 +14,7 @@ import { parse } from 'qs';
 import wpcomRequest from 'wpcom-proxy-request';
 import 'jest-fetch-mock';
 import nock from 'nock';
-import { wait } from '@testing-library/react';
+import { waitFor } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -237,11 +237,11 @@ describe( 'password login flow', () => {
 		// Don't await the promise, it doesn't resolve until login flow is complete
 		submitPassword( 'passw0rd' );
 
-		await wait( () => expect( getLoginFlowState() ).toBe( 'WAITING_FOR_2FA_APP' ) );
+		await waitFor( () => expect( getLoginFlowState() ).toBe( 'WAITING_FOR_2FA_APP' ) );
 
 		userHandledPushNotification = true;
 
-		await wait( () => expect( getLoginFlowState() ).toBe( 'LOGGED_IN' ) );
+		await waitFor( () => expect( getLoginFlowState() ).toBe( 'LOGGED_IN' ) );
 	} );
 } );
 


### PR DESCRIPTION


#### Changes proposed in this Pull Request

* Replace call to React Testing Library's `wait` with `waitFor` in the data stores auth package's flows test

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch, and run `yarn test-packages packages/data-stores`
* You should not see the `console.warn` warning about usage of the deprecated `wait` function

Fixes #44597 
