### PR TITLE
Gutenboarding: Add use-patterns endpoint params

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/style-preview/preview.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/preview.tsx
@@ -80,12 +80,14 @@ const Preview: React.FunctionComponent< Props > = ( { viewport } ) => {
 						font_headings: selectedFonts.headings,
 						font_base: selectedFonts.base,
 					} ),
+					use_patterns: isEnabled( 'gutenboarding/use-patterns' ),
 				} );
 				if ( isEnabled( 'gutenboarding/style-preview-verticals' ) ) {
 					url = addQueryArgs( url, {
 						vertical: siteVertical?.label,
 					} );
 				}
+
 				let resp;
 
 				try {

--- a/client/landing/gutenboarding/stores/onboard/actions.ts
+++ b/client/landing/gutenboarding/stores/onboard/actions.ts
@@ -16,6 +16,7 @@ import { PLANS_STORE } from '../plans';
 import type { State } from '.';
 import type { FontPair } from '../../constants';
 import type { FeatureId } from '../../onboarding-block/features/data';
+import { isEnabled } from 'config';
 
 type CreateSiteParams = Site.CreateSiteParams;
 type DomainSuggestion = DomainSuggestions.DomainSuggestion;
@@ -165,10 +166,10 @@ export function* createSite(
 				font_base: selectedFonts.base,
 				font_headings: selectedFonts.headings,
 			} ),
+			use_patterns: isEnabled( 'gutenboarding/use-patterns' ),
 		},
 		...( bearerToken && { authToken: bearerToken } ),
 	};
-
 	const success = yield dispatch( SITE_STORE, 'createSite', params );
 
 	return success;

--- a/config/development.json
+++ b/config/development.json
@@ -68,6 +68,7 @@
 		"gutenboarding/alpha-templates": true,
 		"gutenboarding/feature-picker": true,
 		"gutenboarding/new-launch": true,
+		"gutenboarding/use-patterns": false,
 		"help": true,
 		"help/courses": true,
 		"home/layout-dev": true,

--- a/config/production.json
+++ b/config/production.json
@@ -41,6 +41,7 @@
 		"gdpr-banner": true,
 		"google-my-business": true,
 		"gutenboarding/new-launch": true,
+		"gutenboarding/use-patterns": false,
 		"happychat": true,
 		"help": true,
 		"help/courses": true,

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -50,6 +50,7 @@ export interface CreateSiteParams {
 		timezone_string?: string;
 		font_headings?: string;
 		font_base?: string;
+		use_patterns?: boolean;
 	};
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds `gutenboarding/use_pattern` config setting. 
* Updates demo preview and create site params to use the setting to determine whether to switch on pattern api use.

#### Testing instructions

* Apply D46797-code
* Temporarily enable the config with: [?flags=gutenboarding/use-patterns](http://calypso.localhost:3000/new/ko?flags=gutenboarding/use-patterns)

Fixes #43714
