### PR TITLE
Remove the plugin header nested inside the editor toolkit

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/premium-content.php
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/premium-content.php
@@ -1,13 +1,8 @@
 <?php
 /**
- * Plugin Name:     Premium Content
- * Description:     Example block written with ESNext standard and JSX support – build step required.
- * Version:         0.1.0
- * Author:          The WordPress Contributors
- * License:         GPL-2.0-or-later
- * Text Domain:     create-block
+ * Registers premium block types only available on paid plans.
  *
- * @package create-block
+ * @package A8C\FSE\Earn\PremiumContent;
  */
 
 declare( strict_types = 1 );


### PR DESCRIPTION
When activating the 1.15 build of the editing toolkit, WordPress displays a "The plugin nodes not have a valid header" error.

#### Changes proposed in this Pull Request

* Remove the plugin header from `/premium-content/premium-content.php` because it is not a plugin.

It appears that Premium Content began development as a seperate plugin, but then before shipping it was rolled in to `full-site-editing`. When WordPress scans `plugins` it finds this plugin header and the real one in `full-site-editing-plugin.php`. Up until now this hasn't been a problem because "Full Site Editing" comes before "Premium Content" in the alphabet.

The plugin was renamed in #44499 to "WordPress.com Editing Toolkit". "Premium Content" comes first alphabetically so WordPress tries to use it during plugin activation.

It looks like the plugin header in `/premium-content/premium-content.php` was only ever used during development so it should be safe to remove.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Install and activate the 1.15 build of the editing toolkit on a stand alone site to reproduce the issue (go to #44509 and download the build artifact for the "Editing Toolkit Plugin / Build plugin (pull_request)" job)
* Install and activate this build of the editing toolkit on a stand alone confirm the bug is fixed (download the build artifact for the "Editing Toolkit Plugin / Build plugin (pull_request)" job from this PR)
