### PR TITLE
Gutenboarding: remove outline from site title input

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
@@ -133,6 +133,7 @@
 		caret-color: var( --mainColor );
 
 		&:focus {
+			box-shadow: none;
 			outline: none;
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove `box-shadow` in site title input inherited from core component

Perhaps caused by some recent `@wordpress/*` packages update?

##### Before

<img width="1174" alt="Screenshot 2020-08-03 at 12 10 56" src="https://user-images.githubusercontent.com/87168/89169031-5e246980-d586-11ea-8d1e-7381ea010fff.png">

##### After
<img width="1158" alt="Screenshot 2020-08-03 at 12 11 07" src="https://user-images.githubusercontent.com/87168/89169046-62508700-d586-11ea-8c89-cdbb5fdc2756.png">


#### Testing instructions

- Open `/new`
- Focus in site input
