### PR TITLE
Social Previews: Remove i18n-calypso dependency by removing search preview header

### DIFF
--- a/packages/social-previews/CHANGELOG.md
+++ b/packages/social-previews/CHANGELOG.md
@@ -1,9 +1,14 @@
 Changelog
 ========
 
-#### v1.0.1 (2019-07-23)
+#### v1.0.2 (2020-08-03)
+- Remove `i18n-calypso` dependency by removing search preview header.
+- Strip html tags from descriptions for social previews.
+- Add helper function with enhanced regex for stripping html tags.
+
+#### v1.0.1 (2020-07-23)
 - Mark CSS and SCSS files as `sideEffects` to ensure they are not discarded during build processes tree-shaking.
 
 
-#### v1.0.0 (2019-07-22)
+#### v1.0.0 (2020-07-22)
 - Initial release after extracting from Calypso.

--- a/packages/social-previews/package.json
+++ b/packages/social-previews/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/social-previews",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"description": "A suite of components to generate previews for a post for both social and search engines",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",
@@ -9,10 +9,10 @@
 		"*.scss"
 	],
 	"keywords": [
-        "wordpress",
-        "social",
-        "seo",
-        "search"
+		"wordpress",
+		"social",
+		"seo",
+		"search"
 	],
 	"author": "Automattic Inc.",
 	"homepage": "https://github.com/Automattic/wp-calypso",

--- a/packages/social-previews/package.json
+++ b/packages/social-previews/package.json
@@ -38,7 +38,6 @@
 		"prepare": "check-npm-client && transpile && copy-assets"
 	},
 	"dependencies": {
-		"i18n-calypso": "^5.0.0",
 		"lodash": "^4.17.15",
 		"prop-types": "^15.7.2",
 		"@babel/runtime": "^7.9.2"

--- a/packages/social-previews/src/search-preview/index.jsx
+++ b/packages/social-previews/src/search-preview/index.jsx
@@ -3,7 +3,6 @@
  */
 
 import PropTypes from 'prop-types';
-import { useTranslate } from 'i18n-calypso';
 import React from 'react';
 import {
 	firstValid,
@@ -36,11 +35,8 @@ const googleDescription = firstValid(
 const googleUrl = hardTruncation( 79 );
 
 export default function SearchPreview( { description, title, url } ) {
-	const translate = useTranslate();
-
 	return (
 		<div className="search-preview">
-			<h2 className="search-preview__header">{ translate( 'Search Preview' ) }</h2>
 			<div className="search-preview__display">
 				<div className="search-preview__title">{ googleTitle( title ) }</div>
 				<div className="search-preview__url">{ googleUrl( url ) } ▾</div>

--- a/packages/social-previews/src/search-preview/style.scss
+++ b/packages/social-previews/src/search-preview/style.scss
@@ -11,20 +11,6 @@
 
 @import '../variables.scss';
 
-.search-preview__header {
-	margin: 0;
-	padding: 8px 0;
-	background-color: var( --color-neutral-0 );
-	border: 1px solid var( --color-neutral-0 );
-	border-bottom: 0;
-	font-size: $font-body-extra-small;
-	line-height: 1;
-	font-weight: bold;
-	text-transform: uppercase;
-	text-align: center;
-	color: var( --color-neutral-40 );
-}
-
 .search-preview__display {
 	border: 1px solid var( --color-neutral-0 );
 	font-family: arial, sans-serif;

--- a/packages/social-previews/test/index.js
+++ b/packages/social-previews/test/index.js
@@ -190,14 +190,6 @@ describe( 'Search previews', () => {
 		expect( Search ).not.toBe( undefined );
 	} );
 
-	it( 'should display a header', () => {
-		const wrapper = shallow( <Search /> );
-
-		const headingEl = wrapper.find( '.search-preview__header' );
-		expect( headingEl.exists() ).toBeTruthy();
-		expect( headingEl.text() ).toEqual( 'Search Preview' );
-	} );
-
 	describe( 'Title truncation', () => {
 		it( 'should display entire title if short enough ', () => {
 			const wrapper = shallow( <Search title="I am the very model of a modern Major-General" /> );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove Search preview header as per design in https://github.com/Automattic/wp-calypso/issues/44489
* Remove i18n-calypso dependency
* Bump version to 1.0.2

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

| Before | After |
| --- | --- |
| <img width="564" alt="Screenshot 2020-08-03 at 13 28 11" src="https://user-images.githubusercontent.com/1562646/89178625-523ca580-d58e-11ea-93ea-742a01149dae.png"> | <img width="560" alt="Screenshot 2020-08-03 at 13 28 29" src="https://user-images.githubusercontent.com/1562646/89178633-5668c300-d58e-11ea-8d36-0ef903b36c20.png">|

Check if all tests pass:
* run `yarn run jest -c=test/packages/jest.config.js packages/social-previews/test/index.js`

Fixes https://github.com/Automattic/wp-calypso/issues/44489
