### PR TITLE
Fix the issue with the backup schedule, it shows negative hour

### DIFF
--- a/client/components/jetpack/daily-backup-status/index.jsx
+++ b/client/components/jetpack/daily-backup-status/index.jsx
@@ -276,7 +276,7 @@ class DailyBackupStatus extends Component {
 			timezone: timezone,
 			gmtOffset: gmtOffset,
 		} );
-		const yesterday = today.subtract( 1, 'days' );
+		const yesterday = moment( today ).subtract( 1, 'days' );
 
 		const lastBackupDay = lastBackupDate.isSame( yesterday, 'day' )
 			? translate( 'Yesterday ' )
@@ -285,11 +285,10 @@ class DailyBackupStatus extends Component {
 		const lastBackupTime = lastBackupDate.format( 'LT' );
 
 		// Calculates the remaining hours for the next backup + 3 hours of safety margin
-		const hoursForNextBackup =
-			parseInt( lastBackupDate.format( 'H' ) ) - parseInt( today.format( 'H' ) ) + 3;
+		const hoursForNextBackup = 24 - today.diff( lastBackupDate, 'hours' ) + 1;
 
 		const nextBackupHoursText =
-			hoursForNextBackup === 1
+			hoursForNextBackup <= 1
 				? translate( 'In the next hour' )
 				: translate( 'In the next %d hour', 'In the next %d hours', {
 						args: [ hoursForNextBackup ],

--- a/client/components/jetpack/daily-backup-status/index.jsx
+++ b/client/components/jetpack/daily-backup-status/index.jsx
@@ -285,7 +285,8 @@ class DailyBackupStatus extends Component {
 		const lastBackupTime = lastBackupDate.format( 'LT' );
 
 		// Calculates the remaining hours for the next backup + 3 hours of safety margin
-		const hoursForNextBackup = 24 - today.diff( lastBackupDate, 'hours' ) + 1;
+		const DAY_HOURS = 24;
+		const hoursForNextBackup = DAY_HOURS - today.diff( lastBackupDate, 'hours' ) + 3;
 
 		const nextBackupHoursText =
 			hoursForNextBackup <= 1


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fix the issue with the next backup schedule showing up with negative. Sometimes, depending on the site timezone and the next backup schedule, the Backup section shows up a negative hour scheduling:

![image](https://user-images.githubusercontent.com/9832440/89195599-e283e600-d5a0-11ea-9bff-913528770a5d.png)

This PR tries to fix that issue updating the code that probably was introducing it.

**Note:** I've not been able to replicate the issue, but with this fix should resolve the issue.

**More info:** 1164141197617539-as-1177475113319458

#### Testing instructions

- Apply this PR
- Select a site with Backup subscription
- Change the hour site and check the scheduled time for the next backup. 
- See the last backup time, and calculate the remaining hours to the next backup, it should be 24+3 hours from the last backup and check it with what the Backup section says.
