### PR TITLE
EditorFeaturedImagePreview: replace MediaStore.get with getMediaItem thunk: 

### DIFF
--- a/client/post-editor/editor-featured-image/preview.jsx
+++ b/client/post-editor/editor-featured-image/preview.jsx
@@ -34,6 +34,12 @@ class EditorFeaturedImagePreview extends Component {
 
 	state = this.constructor.initialState;
 
+	constructor( props ) {
+		super( props );
+
+		this.previewRef = React.createRef();
+	}
+
 	UNSAFE_componentWillReceiveProps( nextProps ) {
 		const currentSrc = this.src();
 		if ( ! currentSrc || currentSrc === this.src( nextProps ) ) {
@@ -43,7 +49,7 @@ class EditorFeaturedImagePreview extends Component {
 		// To prevent container height from collapsing and expanding rapidly,
 		// we preserve the current height while the next image loads
 		const nextState = {
-			height: this.refs.preview.clientHeight,
+			height: this.previewRef.current.clientHeight,
 		};
 
 		// If the next image is the persisted copy of an in-progress upload, we
@@ -114,7 +120,7 @@ class EditorFeaturedImagePreview extends Component {
 		}
 
 		return (
-			<div ref="preview" className={ classes } style={ { height } }>
+			<div ref={ this.previewRef } className={ classes } style={ { height } }>
 				<Spinner />
 				<ImagePreloader
 					placeholder={ placeholder }
@@ -132,9 +138,9 @@ class EditorFeaturedImagePreview extends Component {
 
 export default connect(
 	( state ) => {
-	return {
-		siteId: getSelectedSiteId( state ),
-	};
+		return {
+			siteId: getSelectedSiteId( state ),
+		};
 	},
 	{ getMediaItem }
 )( EditorFeaturedImagePreview );

--- a/client/post-editor/editor-featured-image/preview.jsx
+++ b/client/post-editor/editor-featured-image/preview.jsx
@@ -11,12 +11,12 @@ import Gridicon from 'components/gridicon';
 /**
  * Internal dependencies
  */
-import MediaStore from 'lib/media/store';
 import { url } from 'lib/media/utils';
 import Spinner from 'components/spinner';
 import SpinnerLine from 'components/spinner-line';
 import ImagePreloader from 'components/image-preloader';
 import { getSelectedSiteId } from 'state/ui/selectors';
+import getMediaItem from 'state/media/thunks/get-media-item';
 
 class EditorFeaturedImagePreview extends Component {
 	static propTypes = {
@@ -70,7 +70,7 @@ class EditorFeaturedImagePreview extends Component {
 		// Compare images by resolving the media store reference for the
 		// transient copy. MediaStore tracks pointers from transient media
 		// to its persisted copy, so we can compare the resolved object IDs
-		const media = MediaStore.get( siteId, image.ID );
+		const media = this.props.getMediaItem( siteId, image.ID );
 		return media && media.ID === nextProps.image.ID;
 	};
 
@@ -130,8 +130,11 @@ class EditorFeaturedImagePreview extends Component {
 	}
 }
 
-export default connect( ( state ) => {
+export default connect(
+	( state ) => {
 	return {
 		siteId: getSelectedSiteId( state ),
 	};
-} )( EditorFeaturedImagePreview );
+	},
+	{ getMediaItem }
+)( EditorFeaturedImagePreview );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* EditorFeaturedImagePreview: replace `MediaStore.get` with `getMediaItem` thunk
* Fix eslint warning related to React refs

#### Testing instructions

* Open up a post with featured image in the classic post editor
* Drag a new image in to the featured image dropzone
* Make sure it looks like shown below

This is how it **should** look like:

![featured-image-preview-should](https://user-images.githubusercontent.com/9202899/89197352-dc473700-d5ab-11ea-9b6e-cc3a9c8c26e0.gif)


This is how it **should not** look like:

![featured-image-preview-should-NOT](https://user-images.githubusercontent.com/9202899/89197370-e0735480-d5ab-11ea-8783-ede5bfa2487f.gif)


related #43663 
