### PR TITLE
Modularise activity log state

### DIFF
--- a/client/state/activity-log/actions.js
+++ b/client/state/activity-log/actions.js
@@ -33,6 +33,7 @@ import 'state/data-layer/wpcom/activity-log/rewind/restore-status';
 import 'state/data-layer/wpcom/activity-log/rewind/to';
 import 'state/data-layer/wpcom/sites/rewind/downloads';
 import 'state/data-layer/wpcom/sites/rewind/restores';
+import 'state/activity-log/init';
 
 /**
  * Turn the 'rewind' feature on for a site.

--- a/client/state/activity-log/init.js
+++ b/client/state/activity-log/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'state/redux-store';
+import reducer from './reducer';
+
+registerReducer( [ 'activityLog' ], reducer );

--- a/client/state/activity-log/package.json
+++ b/client/state/activity-log/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/activity-log/reducer.js
+++ b/client/state/activity-log/reducer.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import { ACTIVITY_LOG_FILTER_SET, ACTIVITY_LOG_FILTER_UPDATE } from 'state/action-types';
-import { combineReducers, keyedReducer } from 'state/utils';
+import { combineReducers, keyedReducer, withStorageKey } from 'state/utils';
 import { activationRequesting } from './activation/reducer';
 import { restoreProgress, restoreRequest } from './restore/reducer';
 import { backupRequest, backupProgress } from './backup/reducer';
@@ -24,7 +24,7 @@ export const filterState = ( state = emptyFilter, { type, filter } ) => {
 	}
 };
 
-export default combineReducers( {
+const combinedReducer = combineReducers( {
 	activationRequesting,
 	filter: keyedReducer( 'siteId', filterState ),
 	restoreProgress,
@@ -32,3 +32,5 @@ export default combineReducers( {
 	backupProgress,
 	backupRequest,
 } );
+
+export default withStorageKey( 'activityLog', combinedReducer );

--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -14,7 +14,6 @@ import { reducer as httpData } from 'state/data-layer/http-data';
 /**
  * Reducers
  */
-import activityLog from './activity-log/reducer';
 import atomicTransfer from './atomic-transfer/reducer';
 import currentUser from './current-user/reducer';
 import { reducer as dataRequests } from './data-layer/wpcom-http/utils';
@@ -59,7 +58,6 @@ import users from './users/reducer';
 // The reducers in this list are not modularized, and are always loaded on boot.
 // Please do not add to this list. See #39261 and p4TIVU-9lM-p2 for more details.
 const reducers = {
-	activityLog,
 	atomicTransfer,
 	currentUser,
 	dataRequests,

--- a/client/state/selectors/get-activity-log-filter.js
+++ b/client/state/selectors/get-activity-log-filter.js
@@ -3,6 +3,8 @@
  */
 import { emptyFilter } from 'state/activity-log/reducer';
 
+import 'state/activity-log/init';
+
 export const getActivityLogFilter = ( state, siteId ) => {
 	try {
 		return state.activityLog.filter[ siteId ] || emptyFilter;

--- a/client/state/selectors/get-backup-progress.js
+++ b/client/state/selectors/get-backup-progress.js
@@ -4,6 +4,11 @@
 import { get } from 'lodash';
 
 /**
+ * Internal dependencies
+ */
+import 'state/activity-log/init';
+
+/**
  * Returns the progress of a backup request
  *
  * @param {object} state Global state tree

--- a/client/state/selectors/get-requested-backup.js
+++ b/client/state/selectors/get-requested-backup.js
@@ -4,6 +4,11 @@
 import { get } from 'lodash';
 
 /**
+ * Internal dependencies
+ */
+import 'state/activity-log/init';
+
+/**
  * Returns the requested backup Activity ID.
  *
  * @param  {object}        state  Global state tree

--- a/client/state/selectors/get-requested-rewind.js
+++ b/client/state/selectors/get-requested-rewind.js
@@ -4,6 +4,11 @@
 import { get } from 'lodash';
 
 /**
+ * Internal dependencies
+ */
+import 'state/activity-log/init';
+
+/**
  * Returns the requested rewind Activity ID.
  *
  * @param  {object}        state  Global state tree

--- a/client/state/selectors/get-restore-error.js
+++ b/client/state/selectors/get-restore-error.js
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import 'state/activity-log/init';
 
 /**
  * Returns the error for a restore request

--- a/client/state/selectors/get-restore-progress.js
+++ b/client/state/selectors/get-restore-progress.js
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import 'state/activity-log/init';
 
 /**
  * Returns the progress of a restore request

--- a/client/state/selectors/is-rewind-activating.js
+++ b/client/state/selectors/is-rewind-activating.js
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import 'state/activity-log/init';
 
 /**
  * Indicates whether the Rewind feature is currently being


### PR DESCRIPTION
This PR is one of many working on modularising state in Calypso. This one handles activity log state.

For more details on state modularisation, see the [modularised state documentation](https://github.com/Automattic/wp-calypso/blob/master/docs/modularized-state.md) and p4TIVU-9lM-p2.

Note: I added all the reviewers that GitHub suggested. Please feel free to ignore the review request or pull in someone else if you're not comfortable reviewing this PR. Thank you!

Fixes #42420.

#### Changes proposed in this Pull Request

* Modularise activity log state

#### Testing instructions

Activity log state gets automatically loaded on boot due to the navigation middleware, so it's difficult to test the automatic loading portion of this PR.

Smoke-testing activity log functionality should be enough to validate this PR, since no actual functional code changes to activity log code have taken place.
