### PR TITLE
desktop: update desktop to latest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -636,8 +636,16 @@ jobs:
 
   wp-desktop-source:
     <<: *desktop_defaults
+    environment:
+      VERSION: << pipeline.git.tag >>
     steps:
       - checkout
+      - when:
+          condition: << pipeline.git.tag >>
+          steps:
+            - run:
+                name: Ensure package.json Version And Tag Match
+                command: cd desktop/bin && node validate_tag.js $VERSION
       - run: *update-node
       - run: *yarn-install
       - restore_cache: *desktop-restore-source-cache

--- a/client/desktop/app-handlers/printer/index.js
+++ b/client/desktop/app-handlers/printer/index.js
@@ -9,16 +9,22 @@ const { BrowserWindow, ipcMain: ipc } = require( 'electron' ); // eslint-disable
 const log = require( 'desktop/lib/logger' )( 'desktop:printer' );
 
 module.exports = function () {
-	ipc.on( 'print', function ( event, title, html ) {
+	ipc.on( 'print', function ( event, title, contents ) {
 		let printer = new BrowserWindow( { width: 350, height: 300, title: title } );
 
-		log.debug( 'Printing HTML' );
+		log.info( `Printing contents '${ title }'...` );
 
-		printer.loadURL( 'data:text/html,' + encodeURIComponent( html ) );
+		const file = 'data:text/html;charset=UTF-8,' + encodeURIComponent( contents );
+		printer.loadURL( file );
 
 		printer.webContents.on( 'dom-ready', function () {
+			const options = { silent: false }; // ask the user for print settings
 			setTimeout( function () {
-				printer.webContents.print();
+				printer.webContents.print( options, ( success, error ) => {
+					if ( ! success ) {
+						log.error( 'Failed to print: ', error );
+					}
+				} );
 			}, 500 );
 		} );
 

--- a/client/desktop/app-handlers/updater/auto-updater/index.js
+++ b/client/desktop/app-handlers/updater/auto-updater/index.js
@@ -84,6 +84,8 @@ class AutoUpdater extends Updater {
 	}
 
 	onConfirm() {
+		log.info( `User selected 'Update & Restart'...` );
+
 		AppQuit.allowQuit();
 		autoUpdater.quitAndInstall();
 

--- a/client/desktop/lib/updater/index.js
+++ b/client/desktop/lib/updater/index.js
@@ -65,7 +65,6 @@ class Updater extends EventEmitter {
 			const button = selected.response;
 
 			if ( button === 0 ) {
-				// Confirm
 				this.onConfirm();
 			} else {
 				this.onCancel();

--- a/client/desktop/lib/updater/index.js
+++ b/client/desktop/lib/updater/index.js
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-const { app, dialog } = require( 'electron' ); // eslint-disable-line import/no-extraneous-dependencies
+const { app, dialog, BrowserWindow } = require( 'electron' ); // eslint-disable-line import/no-extraneous-dependencies
 const { EventEmitter } = require( 'events' );
 
 /**
@@ -48,7 +48,9 @@ class Updater extends EventEmitter {
 
 	onCancel() {}
 
-	notify() {
+	async notify() {
+		const mainWindow = BrowserWindow.getFocusedWindow();
+
 		const updateDialogOptions = {
 			buttons: [ this.sanitizeButtonLabel( this.confirmLabel ), 'Cancel' ],
 			title: 'Update Available',
@@ -59,18 +61,18 @@ class Updater extends EventEmitter {
 		if ( ! this._hasPrompted ) {
 			this._hasPrompted = true;
 
-			dialog.showMessageBox( updateDialogOptions, ( button ) => {
-				this._hasPrompted = false;
+			const selected = await dialog.showMessageBox( mainWindow, updateDialogOptions );
+			const button = selected.response;
 
-				if ( button === 0 ) {
-					// Confirm
-					this.onConfirm();
-				} else {
-					this.onCancel();
-				}
+			if ( button === 0 ) {
+				// Confirm
+				this.onConfirm();
+			} else {
+				this.onCancel();
+			}
 
-				this.emit( 'end' );
-			} );
+			this._hasPrompted = false;
+			this.emit( 'end' );
 		}
 	}
 

--- a/client/desktop/window-handlers/external-links/editor/index.js
+++ b/client/desktop/window-handlers/external-links/editor/index.js
@@ -123,7 +123,7 @@ async function handleJetpackEnableSSO( mainWindow, info ) {
 			message += '\n\n' + 'Please contact the site admin.';
 		}
 
-		const selected = dialog.showMessageBox( mainWindow, {
+		const selected = await dialog.showMessageBox( mainWindow, {
 			type: 'info',
 			buttons: buttons,
 			title: 'Jetpack Authorization Required',
@@ -133,7 +133,9 @@ async function handleJetpackEnableSSO( mainWindow, info ) {
 				'or you can proceed in an external browser.',
 		} );
 
-		switch ( selected ) {
+		const button = selected.response;
+
+		switch ( button ) {
 			case 0:
 				if ( canUserManageOptions ) {
 					selectedEnableSSOandContinue( mainWindow, info );
@@ -159,16 +161,27 @@ async function handleJetpackEnableSSO( mainWindow, info ) {
 }
 
 function handleUndefined( mainWindow, info ) {
-	log.info( 'Cannot use editor, unhandled reason: ', info );
+	log.error( 'Cannot use editor, unhandled reason: ', info );
 
 	dialog.showMessageBox( mainWindow, {
 		type: 'info',
 		buttons: [ 'OK' ],
 		title: 'Unable to Use the Editor',
-		message: 'An unhnadled error occurred. ' + +'Please contact help@wordpress.com for help.',
+		message: 'An unhandled error occurred. ' + 'Please contact help@wordpress.com for help.',
 	} );
 
-	const { origin } = info;
+	const { origin, wpAdminLoginUrl, editorUrl } = info;
+	if ( wpAdminLoginUrl ) {
+		log.info(
+			`Falling back to opening editor in browser with admin login URL: '${ wpAdminLoginUrl }'`
+		);
+		openInBrowser( null, wpAdminLoginUrl );
+	} else if ( editorUrl ) {
+		log.info( `Falling back to opening editor in browser with editor URL: '${ editorUrl }'` );
+		openInBrowser( null, editorUrl );
+	} else {
+		log.error( 'Failed to open editor in browser as fallback: invalid admin and editor urls' );
+	}
 	navigateToShowMySites( mainWindow, origin );
 }
 

--- a/client/desktop/window-handlers/external-links/index.js
+++ b/client/desktop/window-handlers/external-links/index.js
@@ -99,4 +99,9 @@ module.exports = function ( mainWindow ) {
 				handleUndefined( mainWindow, info );
 		}
 	} );
+
+	ipc.on( 'view-post-clicked', ( _, url ) => {
+		log.info( `View Post handler for URL: ${ url }` );
+		openInBrowser( null, url );
+	} );
 };

--- a/desktop/bin/validate_tag.js
+++ b/desktop/bin/validate_tag.js
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+
+/* eslint-disable no-console, import/no-nodejs-modules */
+
+//
+// Checks whether the version value in the package.json is the same as the
+// given input.
+//
+
+if ( process.argv.length === 2 ) {
+	const msg =
+		`Usage: ${ process.argv[ 1 ] } 1.2.3-beta4` + '\nExpected version parameter to check.';
+	throw new Error( msg );
+}
+
+const version = process.argv[ 2 ];
+// Remove the leading v that a tag from version control may have.
+// This regex means "a letter v at the start of the string"
+const sanitizedVersion = version.replace( /^v/, '' );
+
+console.log( `Validating package.json version matches ${ version }...` );
+
+const fs = require( 'fs' );
+const config = JSON.parse( fs.readFileSync( './package.json', 'utf8' ) );
+const packageVersion = config.version;
+
+if ( packageVersion !== sanitizedVersion ) {
+	throw new Error(
+		`Expected version in package.json to match ${ version }, got ${ packageVersion }`
+	);
+}
+
+console.log( `Version in package.json matches expected value ${ version }. 👍` );

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "WordPressDesktop",
-	"version": "5.2.0",
+	"version": "6.0.1",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/Automattic/wp-calypso/"


### PR DESCRIPTION
### Description

This PR updates wp-desktop in the Calypso monorepo to the latest changes in the wp-desktop repo (in preparation for final deprecation of the separate repository).

### Context

The SHA of wp-desktop that was migrated was from Automattic/wp-desktop@e299749. This PR gathers all changes made to the wp-desktop source since then (including the "check version" CI helper).