### PR TITLE
Update/move comment send button

### DIFF
--- a/client/blocks/comments/form.jsx
+++ b/client/blocks/comments/form.jsx
@@ -179,11 +179,6 @@ class PostCommentForm extends React.Component {
 			'is-visible': this.state.haveFocus || this.hasCommentText(),
 		} );
 
-		const formClasses = classNames( {
-			comments__form: true,
-			'is-active': this.state.haveFocus || this.hasCommentText(),
-		} );
-
 		const expandingAreaClasses = classNames( {
 			focused: this.state.haveFocus,
 			'expanding-area': true,
@@ -194,7 +189,7 @@ class PostCommentForm extends React.Component {
 		// How auto expand works for the textarea is covered in this article:
 		// http://alistapart.com/article/expanding-text-areas-made-elegant
 		return (
-			<form className={ formClasses }>
+			<form className="comments__form">
 				<ProtectFormGuard isChanged={ this.hasCommentText() } />
 				<fieldset>
 					<Gravatar user={ this.props.currentUser } />

--- a/client/blocks/comments/form.jsx
+++ b/client/blocks/comments/form.jsx
@@ -11,6 +11,7 @@ import { translate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import { Button } from '@automattic/components';
 import AutoDirection from 'components/auto-direction';
 import FormInputValidation from 'components/forms/form-input-validation';
 import Gravatar from 'components/gravatar';
@@ -178,6 +179,11 @@ class PostCommentForm extends React.Component {
 			'is-visible': this.state.haveFocus || this.hasCommentText(),
 		} );
 
+		const formClasses = classNames( {
+			comments__form: true,
+			'is-active': this.state.haveFocus || this.hasCommentText(),
+		} );
+
 		const expandingAreaClasses = classNames( {
 			focused: this.state.haveFocus,
 			'expanding-area': true,
@@ -188,7 +194,7 @@ class PostCommentForm extends React.Component {
 		// How auto expand works for the textarea is covered in this article:
 		// http://alistapart.com/article/expanding-text-areas-made-elegant
 		return (
-			<form className="comments__form">
+			<form className={ formClasses }>
 				<ProtectFormGuard isChanged={ this.hasCommentText() } />
 				<fieldset>
 					<Gravatar user={ this.props.currentUser } />
@@ -211,13 +217,13 @@ class PostCommentForm extends React.Component {
 							/>
 						</AutoDirection>
 					</div>
-					<button
+					<Button
 						className={ buttonClasses }
 						disabled={ this.state.commentText.length === 0 }
 						onClick={ this.handleSubmit }
 					>
 						{ this.props.error ? translate( 'Resend' ) : translate( 'Send' ) }
-					</button>
+					</Button>
 					{ this.renderError() }
 				</fieldset>
 			</form>

--- a/client/blocks/comments/form.scss
+++ b/client/blocks/comments/form.scss
@@ -59,7 +59,7 @@
 	button {
 		opacity: 0;
 		position: absolute;
-		margin-top: 16px;
+		margin: 16px 0 -19px;
 		transition: all 0.2s ease-in-out;
 
 		&.is-active {
@@ -70,7 +70,6 @@
 			position: static;
 			float: right;
 			opacity: 1;
-			margin-bottom: -19px;
 		}
 	}
 

--- a/client/blocks/comments/form.scss
+++ b/client/blocks/comments/form.scss
@@ -59,7 +59,6 @@
 	button {
 		opacity: 0;
 		position: absolute;
-		float: right;
 		margin-top: 16px;
 		transition: all 0.2s ease-in-out;
 
@@ -69,6 +68,7 @@
 
 		&.is-visible {
 			position: static;
+			float: right;
 			opacity: 1;
 			margin-bottom: -16px;
 		}

--- a/client/blocks/comments/form.scss
+++ b/client/blocks/comments/form.scss
@@ -57,7 +57,8 @@
 	}
 
 	button {
-		display: none;
+		opacity: 0;
+		position: absolute;
 		float: right;
 		margin-top: 16px;
 		transition: all 0.2s ease-in-out;
@@ -67,7 +68,8 @@
 		}
 
 		&.is-visible {
-			display: inline-block;
+			position: static;
+			opacity: 1;
 			margin-bottom: -16px;
 		}
 	}

--- a/client/blocks/comments/form.scss
+++ b/client/blocks/comments/form.scss
@@ -70,7 +70,7 @@
 			position: static;
 			float: right;
 			opacity: 1;
-			margin-bottom: -16px;
+			margin-bottom: -19px;
 		}
 	}
 

--- a/client/blocks/comments/form.scss
+++ b/client/blocks/comments/form.scss
@@ -59,7 +59,7 @@
 	button {
 		opacity: 0;
 		position: absolute;
-		margin: 16px 0 -19px;
+		margin: 16px 0 0;
 		transition: all 0.2s ease-in-out;
 
 		&.is-active {
@@ -81,6 +81,22 @@
 	.comments__cancel-reply {
 		font-size: $font-body-extra-small;
 		cursor: pointer;
+	}
+}
+
+.comments__comment-list {
+	.comments__form {
+		button {
+			margin: 16px 0 -19px;
+		}
+	}
+}
+
+.conversations__comment-list {
+	.comments__form {
+		button {
+			margin: 16px 0 -9px;
+		}
 	}
 }
 

--- a/client/blocks/comments/form.scss
+++ b/client/blocks/comments/form.scss
@@ -4,6 +4,10 @@
 	padding: 0 0 0 42px;
 	margin-top: 24px;
 
+	&.is-active {
+		margin-bottom: -16px;
+	}
+
 	.gravatar {
 		position: absolute;
 		top: 0;
@@ -26,7 +30,7 @@
 			max-height: 400px;
 			min-height: 33px;
 			margin: 0;
-			padding: 5px 60px 5px 5px;
+			padding: 5px;
 			font-size: $font-body-small;
 			font-family: $serif;
 			line-height: 21px;
@@ -57,24 +61,17 @@
 	}
 
 	button {
-		opacity: 0;
-		position: absolute;
-		top: 4px;
-		right: 16px;
-		padding: 4px;
-		font-size: $font-body-extra-small;
-		font-weight: 600;
-		text-transform: uppercase;
-	color: var( --color-text-subtle );
+		display: none;
+		float: right;
+		margin-top: 16px;
 		transition: all 0.2s ease-in-out;
 
 		&.is-active {
-			color: var( --color-primary );
 			cursor: pointer;
 		}
 
 		&.is-visible {
-			opacity: 1;
+			display: inline-block;
 		}
 	}
 

--- a/client/blocks/comments/form.scss
+++ b/client/blocks/comments/form.scss
@@ -59,7 +59,7 @@
 	button {
 		opacity: 0;
 		position: absolute;
-		margin: 16px 0 0;
+		margin: 16px 0 -19px;
 		transition: all 0.2s ease-in-out;
 
 		&.is-active {
@@ -84,18 +84,14 @@
 	}
 }
 
-.comments__comment-list {
-	.comments__form {
-		button {
-			margin: 16px 0 -19px;
-		}
-	}
-}
-
+// On /read/conversations, balance the space below and
+// above the "Send" button.  The default negative margin
+// of -19px is intended for the pages like
+// /read/feeds/123456789/posts/9876543210.
 .conversations__comment-list {
 	.comments__form {
 		button {
-			margin: 16px 0 -9px;
+			margin-bottom: -9px;
 		}
 	}
 }

--- a/client/blocks/comments/form.scss
+++ b/client/blocks/comments/form.scss
@@ -4,10 +4,6 @@
 	padding: 0 0 0 42px;
 	margin-top: 24px;
 
-	&.is-active {
-		margin-bottom: -16px;
-	}
-
 	.gravatar {
 		position: absolute;
 		top: 0;
@@ -72,6 +68,7 @@
 
 		&.is-visible {
 			display: inline-block;
+			margin-bottom: -16px;
 		}
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Inside the comments section in the reader view, move the 'Send' button out of the textarea to a spot below it.

#### Testing instructions

* Visit the reader
* Visit a post with comments enabled
* Type a few characters into the comment box to make the send button appear
* Observe the location of the send button

![2020-08-03_11-10](https://user-images.githubusercontent.com/937354/89203279-f2d49a80-d579-11ea-8517-0e5e214a5d09.png)
