### PR TITLE
Inline support link: use children instead of text prop

### DIFF
--- a/client/components/inline-support-link/README.md
+++ b/client/components/inline-support-link/README.md
@@ -3,6 +3,8 @@ Inline Support Link
 
 This component displays a link and icon. If `props.supportPostId` is supplied, when the link is clicked a SupportArticleDialog is opened with an `ExternalLink` to the `props.supportLink`. If no `props.supportPostId` is supplied, an `ExternalLink` to the `props.supportLink` is rendered.
 
+The component's `children` prop will be used for the link text; if none is supplied, it will defaut to the text "Learn more". The `showText` property (default `true`) can be set to `false` in order to display no text.
+
 ## Example Usage:
 
 ```js
@@ -14,7 +16,7 @@ render() {
 		supportPostId: 38147,
 	};
 	return (
-		<InlineSupportLink { ...inlineSupportProps } />
+		<InlineSupportLink { ...inlineSupportProps }>Link Text</InlineSupportLink>
 	);
 }
 ```
@@ -23,7 +25,6 @@ render() {
 
 - `supportPostId` - (number) The postId of the support document.
 - `supportLink` - (string) The URL of the support document. If left out, no ExternalLink will be given.
-- `text` - *optional* (string) The link text. Default `Learn more`
 - `showText` - *optional* (bool) Whether or not to display the link text. Default `true`.
 - `showIcon` - *optional* (bool) Whether or not to display the "help-outline" Gridicon. Default `true`.
 - `iconSize` - *optional* (number) Gridicon size. Default `14`.

--- a/client/components/inline-support-link/docs/example.jsx
+++ b/client/components/inline-support-link/docs/example.jsx
@@ -16,6 +16,6 @@ export default class extends React.PureComponent {
 			supportPostId: 38147,
 			supportLink: 'https://wordpress.com/support/audio/podcasting/',
 		};
-		return <InlineSupportLink { ...inlineSupportProps } />;
+		return <InlineSupportLink { ...inlineSupportProps }>Link Text</InlineSupportLink>;
 	}
 }

--- a/client/components/inline-support-link/index.jsx
+++ b/client/components/inline-support-link/index.jsx
@@ -30,7 +30,6 @@ class InlineSupportLink extends Component {
 		supportPostId: PropTypes.number,
 		supportLink: PropTypes.string,
 		showText: PropTypes.bool,
-		text: PropTypes.string,
 		showIcon: PropTypes.bool,
 		iconSize: PropTypes.number,
 		tracksEvent: PropTypes.string,
@@ -43,7 +42,6 @@ class InlineSupportLink extends Component {
 		supportPostId: null,
 		supportLink: null,
 		showText: true,
-		text: null,
 		showIcon: true,
 		iconSize: 14,
 	};
@@ -51,7 +49,6 @@ class InlineSupportLink extends Component {
 	render() {
 		const {
 			showText,
-			text,
 			supportPostId,
 			supportLink,
 			showIcon,
@@ -72,10 +69,7 @@ class InlineSupportLink extends Component {
 			iconSize,
 		};
 
-		// props.children overrides text prop if both are provided
-		const displayChildren = children != null;
-		const displayText = ! children && showText;
-		const displayIcon = ! children && supportPostId && showIcon;
+		const text = children ? children : translate( 'Learn more' );
 
 		return (
 			<LinkComponent
@@ -86,9 +80,8 @@ class InlineSupportLink extends Component {
 				rel="noopener noreferrer"
 				{ ...externalLinkProps }
 			>
-				{ displayChildren && children }
-				{ displayText && ( text || translate( 'Learn more' ) ) }
-				{ displayIcon && <Gridicon icon="help-outline" size={ iconSize } /> }
+				{ showText && text }
+				{ supportPostId && showIcon && <Gridicon icon="help-outline" size={ iconSize } /> }
 			</LinkComponent>
 		);
 	}

--- a/client/lib/importer/importer-config.js
+++ b/client/lib/importer/importer-config.js
@@ -42,8 +42,9 @@ function getConfig( { siteTitle = '' } = {} ) {
 							supportPostId={ 67084 }
 							supportLink="https://wordpress.com/support/coming-from-self-hosted/"
 							showIcon={ false }
-							text={ translate( 'Need help exporting your content?' ) }
-						/>
+						>
+							{ translate( 'Need help exporting your content?' ) }
+						</InlineSupportLink>
 					),
 				},
 			}
@@ -84,8 +85,9 @@ function getConfig( { siteTitle = '' } = {} ) {
 							supportPostId={ 66764 }
 							supportLink="https://wordpress.com/support/import/coming-from-blogger/"
 							showIcon={ false }
-							text={ translate( 'Need help exporting your content?' ) }
-						/>
+						>
+							{ translate( 'Need help exporting your content?' ) }
+						</InlineSupportLink>
 					),
 				},
 			}
@@ -117,8 +119,9 @@ function getConfig( { siteTitle = '' } = {} ) {
 						supportPostId={ 154436 }
 						supportLink="https://wordpress.com/support/import/import-from-godaddy/"
 						showIcon={ false }
-						text={ translate( 'Need help?' ) }
-					/>
+					>
+						{ translate( 'Need help?' ) }
+					</InlineSupportLink>
 				),
 			},
 		} ),
@@ -157,8 +160,9 @@ function getConfig( { siteTitle = '' } = {} ) {
 							supportPostId={ 93180 }
 							supportLink="https://wordpress.com/support/import/import-from-medium/"
 							showIcon={ false }
-							text={ translate( 'Need help exporting your content?' ) }
-						/>
+						>
+							{ translate( 'Need help exporting your content?' ) }
+						</InlineSupportLink>
 					),
 				},
 			}
@@ -198,8 +202,9 @@ function getConfig( { siteTitle = '' } = {} ) {
 							supportPostId={ 87696 }
 							supportLink="https://wordpress.com/support/import/import-from-squarespace/"
 							showIcon={ false }
-							text={ translate( 'Need help exporting your content?' ) }
-						/>
+						>
+							{ translate( 'Need help exporting your content?' ) }
+						</InlineSupportLink>
 					),
 				},
 			}
@@ -231,8 +236,9 @@ function getConfig( { siteTitle = '' } = {} ) {
 						supportPostId={ 147777 }
 						supportLink="https://wordpress.com/support/import/import-from-wix/"
 						showIcon={ false }
-						text={ translate( 'Need help?' ) }
-					/>
+					>
+						{ translate( 'Need help?' ) }
+					</InlineSupportLink>
 				),
 			},
 		} ),

--- a/client/my-sites/customer-home/cards/education/educational-content/index.jsx
+++ b/client/my-sites/customer-home/cards/education/educational-content/index.jsx
@@ -51,7 +51,6 @@ const EducationalContent = ( {
 									supportPostId={ postId }
 									supportLink={ url }
 									showIcon={ false }
-									text={ text }
 									tracksEvent="calypso_customer_home_education"
 									statsGroup="calypso_customer_home"
 									tracksOptions={ {
@@ -59,7 +58,9 @@ const EducationalContent = ( {
 										card_name: cardName,
 									} }
 									statsName={ cardName }
-								/>
+								>
+									{ text }
+								</InlineSupportLink>
 							) }
 							{ externalLink && (
 								<ExternalLink

--- a/client/my-sites/customer-home/cards/features/stats/index.jsx
+++ b/client/my-sites/customer-home/cards/features/stats/index.jsx
@@ -88,11 +88,12 @@ export const StatsV2 = ( {
 								supportPostId={ 4454 }
 								supportLink={ localizeUrl( 'https://wordpress.com/support/stats/' ) }
 								showIcon={ false }
-								text={ translate( 'Learn about stats.' ) }
 								tracksEvent="calypso_customer_home_stats_support_page_view"
 								statsGroup="calypso_customer_home"
 								statsName="stats_learn_more"
-							/>
+							>
+								{ translate( 'Learn about stats.' ) }
+							</InlineSupportLink>
 						</div>
 					</Chart>
 				) }
@@ -114,11 +115,12 @@ export const StatsV2 = ( {
 								supportPostId={ 4454 }
 								supportLink={ localizeUrl( 'https://wordpress.com/support/stats/' ) }
 								showIcon={ false }
-								text={ translate( 'Read more.' ) }
 								tracksEvent="calypso_customer_home_stats_support_page_view"
 								statsGroup="calypso_customer_home"
 								statsName="stats_learn_more"
-							/>
+							>
+								{ translate( 'Read more.' ) }
+							</InlineSupportLink>
 						</div>
 					</div>
 				) }

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
@@ -196,11 +196,12 @@ export const getTask = (
 							supportPostId={ 59580 }
 							supportLink={ localizeUrl( 'https://wordpress.com/support/menus/' ) }
 							showIcon={ false }
-							text={ translate( 'View tutorial.' ) }
 							tracksEvent="calypso_customer_home_menus_support_page_view"
 							statsGroup="calypso_customer_home"
 							statsName="menus_view_tutorial"
-						/>
+						>
+							{ translate( 'View tutorial.' ) }
+						</InlineSupportLink>
 					</>
 				),
 				actionText: translate( 'Add a menu' ),

--- a/client/my-sites/earn/memberships/add-edit-plan-modal.jsx
+++ b/client/my-sites/earn/memberships/add-edit-plan-modal.jsx
@@ -306,8 +306,9 @@ const RecurringPaymentsPlanAddEditModal = ( {
 							supportPostId={ 154624 }
 							supportLink="https://wordpress.com/support/wordpress-editor/blocks/recurring-payments-button/" // TODO: Link to specific section once article is update
 							showIcon={ false }
-							text={ translate( 'Learn more.' ) }
-						/>
+						>
+							{ translate( 'Learn more.' ) }
+						</InlineSupportLink>
 					</p>
 					<FormToggle
 						onChange={ ( newValue ) => setEditedPostsEmail( newValue ) }

--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -188,8 +188,9 @@ class ThanksModal extends Component {
 											supportPostId={ 167510 }
 											supportLink="https://wordpress.com/support/replacing-the-older-wordpress-com-editor-with-the-wordpress-block-editor/"
 											showIcon={ false }
-											text={ translate( 'Learn more' ) }
-										/>
+										>
+											{ translate( 'Learn more' ) }
+										</InlineSupportLink>
 									),
 								},
 							}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This pull request follows up on the conversation had in https://github.com/Automattic/wp-calypso/pull/44473, specifically the idea of migrating `InlineSupportLink` to always get its text from the `children` prop rather than supporting both that and the `text` prop it was using previously.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Verify behavior and appearance of existing updated links. Existing usages include:
    * "Need help exporting your content?" link in (e.g.) Import -> Blogger.
    * "Learn more" links under "Learn and Grow" section of "My Home"
    * "Read more" link under "Stats" section of "My Home" (or "Learn about stats" if site is unlaunched)
    * "Testimonials" and "portfolio projects" links on Settings -> Writing
