### PR TITLE
Checkout: Disable concierge upsell thank-you page for 3DS

### DIFF
--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -506,6 +506,7 @@ export class Checkout extends React.Component {
 		// If the user has upgraded a plan from seeing our upsell (we find this by checking the previous route is /offer-plan-upgrade),
 		// then skip this section so that we do not show further upsells.
 		if (
+			! /pending/.test( pendingOrReceiptId ) &&
 			config.isEnabled( 'upsell/concierge-session' ) &&
 			! hasConciergeSession( cart ) &&
 			! hasJetpackPlan( cart ) &&

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
@@ -68,6 +68,24 @@ describe( 'getThankYouPageUrl', () => {
 		expect( url ).toBe( '/checkout/thank-you/foo.bar/pending/1234abcd' );
 	} );
 
+	it( 'redirects to the thank-you pending page with a order id when a site and orderId is set even if the quickstart offer would normally be included', () => {
+		isEnabled.mockImplementation( ( flag ) => flag === 'upsell/concierge-session' );
+		const cart = {
+			products: [
+				{
+					product_slug: 'personal-bundle',
+				},
+			],
+		};
+		const url = getThankYouPageUrl( {
+			...defaultArgs,
+			siteSlug: 'foo.bar',
+			orderId: '1234abcd',
+			cart,
+		} );
+		expect( url ).toBe( '/checkout/thank-you/foo.bar/pending/1234abcd' );
+	} );
+
 	// Note: This just verifies the existing behavior; this URL is invalid unless
 	// placed after a `redirectTo` query string; see the redirect payment
 	// processor

--- a/client/my-sites/checkout/composite-checkout/use-get-thank-you-url.js
+++ b/client/my-sites/checkout/composite-checkout/use-get-thank-you-url.js
@@ -140,6 +140,7 @@ export function getThankYouPageUrl( {
 
 	const redirectPathForConciergeUpsell = getRedirectUrlForConciergeNudge( {
 		pendingOrReceiptId,
+		orderId,
 		cart,
 		siteSlug,
 		hideNudge,
@@ -217,6 +218,7 @@ function getFallbackDestination( {
 
 function maybeShowPlanBumpOfferConcierge( {
 	pendingOrReceiptId,
+	orderId,
 	cart,
 	siteSlug,
 	didPurchaseFail,
@@ -226,7 +228,7 @@ function maybeShowPlanBumpOfferConcierge( {
 		if ( 'variantShowPlanBump' === abtest( 'showBusinessPlanBump' ) ) {
 			return `/checkout/${ siteSlug }/offer-plan-upgrade/business/${ pendingOrReceiptId }`;
 		}
-		return `/checkout/offer-quickstart-session/${ pendingOrReceiptId }/${ siteSlug }`;
+		return getQuickstartUrl( { pendingOrReceiptId, siteSlug, orderId } );
 	}
 
 	return;
@@ -234,6 +236,7 @@ function maybeShowPlanBumpOfferConcierge( {
 
 function getRedirectUrlForConciergeNudge( {
 	pendingOrReceiptId,
+	orderId,
 	cart,
 	siteSlug,
 	hideNudge,
@@ -257,6 +260,7 @@ function getRedirectUrlForConciergeNudge( {
 
 		const upgradePath = maybeShowPlanBumpOfferConcierge( {
 			pendingOrReceiptId,
+			orderId,
 			cart,
 			siteSlug,
 			didPurchaseFail,
@@ -270,11 +274,18 @@ function getRedirectUrlForConciergeNudge( {
 		// being offered and so sold, to be inline with HE availability.
 		// To dial back, uncomment the condition below and modify the test config.
 		if ( 'offer' === abtest( 'conciergeUpsellDial' ) ) {
-			return `/checkout/offer-quickstart-session/${ pendingOrReceiptId }/${ siteSlug }`;
+			return getQuickstartUrl( { pendingOrReceiptId, siteSlug, orderId } );
 		}
 	}
 
 	return;
+}
+
+function getQuickstartUrl( { pendingOrReceiptId, siteSlug, orderId } ) {
+	if ( orderId ) {
+		return;
+	}
+	return `/checkout/offer-quickstart-session/${ pendingOrReceiptId }/${ siteSlug }`;
 }
 
 function getDisplayModeParamFromCart( cart ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This disables the concierge upsell thank-you page that would appear after a Personal plan purchase if the order Id is set. This occurs when we would be showing a "Pending" page before the purchase completes. For example, when paying with a 3D Secure credit card.

There is probably a way to show the upsell even in the "pending" case, but this is a quick fix because the current experience results in an invalid URL that displays a broken page.

Fixes https://github.com/Automattic/wp-calypso/issues/44541 for both new and old checkout.

#### Testing instructions

First make sure that the offer still works:

- Make sure that you're in the `offer` variant of the `conciergeUpsellDial` AB test.
- Visit checkout with a Personal plan in the cart.
- Using a non-3DS card, complete the purchase.
- Verify that you are redirected to the upsell offer page.

Then make sure that it is disabled for 3DS cards:

- Make sure that you're in the `offer` variant of the `conciergeUpsellDial` AB test.
- Visit checkout with a Personal plan in the cart.
- Using a 3DS card, complete the purchase.
- Verify that you are redirected to a "pending" page and then the normal thank-you page.