### PR TITLE
Pre-commit hook: Only use local copies of phpcs and phpcbf

### DIFF
--- a/bin/pre-commit-hook.js
+++ b/bin/pre-commit-hook.js
@@ -41,16 +41,17 @@ function parseGitDiffToPathArray( command ) {
 }
 
 function getPathForCommand( command ) {
-	const composerBinDir = path.join( __dirname, '..', 'vendor', 'bin' );
-	let path_to_command;
-	try {
-		path_to_command = execSync( 'command -v ' + command, { encoding: 'utf8' } );
-	} catch ( e ) {
-		path_to_command = path.join( composerBinDir, command );
-	}
-	if ( typeof path_to_command === 'undefined' || ! path_to_command ) {
-		return false;
-	}
+	/**
+	 * Only look for locally installed commands (phpcs, phpcbf). The reason for this is that we also require
+	 * a number of dependencies, such as WordPress Coding Standards, which we cannot guarantee are installed
+	 * system-wide, and system-wide installs of phpcs and phpcbf cannot find our local copies of those dependencies.
+	 *
+	 * If we cannot find these commands, we ask the user to run `composer install`, which will install all commands
+	 * and dependencies locally.
+	 *
+	 * @see printPhpcsDocs
+	 */
+	const path_to_command = path.join( __dirname, '..', 'vendor', 'bin', command );
 	return _.trim( path_to_command );
 }
 function linterFailure() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In theory, we run the PHPCBF auto-formatter in our pre-commit hook. In practice, this has been failing, and I suspect has been the source of a number of PRs being submitted with PHP lint errors that PHPCBF could auto-fix -- see e.g. #43817.

The reason for this is that our pre-commit hook will preferably use a system-wide installed copy of those tools; however, there's no guarantee that dependencies, such as the WordPress Coding Standards, are also available globally. They will however be installed locally through a simply `compose install`, as will PHPCS and PHPCBF, and our pre-commit hook already has messaging to instruct the user to do so.

The fix is thus to never use the globally installed versions of PHPCS and PHPCBF, but always the locally installed ones, and if they can't be found, instruct the user to run `compose install`.

#### Testing instructions

###### Prerequisites:

- Make sure you _don't_ have WordPress Coding Standards globally installed. You can verify by running `phpcs -i`.

###### To reproduce the issue:

- Remove your `vendor/` subfolder from your local Calypso directory (this holds files installed by Composer).
- Make a change to a PHP file in the WordPress.com Editing Toolkit plugin (formerly known as FSE) that includes something that PHPCS will fix (e.g. some whitespace change). E.g. 

```diff
diff --git a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/call-to-action-02.php b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/call-to-action-02.php
index a67ca71017..4ee456fb24 100644
--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/call-to-action-02.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/call-to-action-02.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Call to Action pattern.
+ * Call to Action pattern. Blahblah
  *
  * @package A8C\FSE
  */
@@ -37,8 +37,8 @@ $markup = '
 ';
 
 return array(
-       'title'         => esc_html__( 'Call to Action', 'full-site-editing' ),
-       'categories'    => array( 'call-to-action' ),
-       'content'       => $markup,
-       'viewportWidth' => 1280,
+       'title'           => esc_html__( 'Call to Action', 'full-site-editing' ),
+       'categories'      => array( 'call-to-action' ),
+       'content'         => $markup,
+       'viewportWidth'   => 1280,
 );

```

Make sure your editor isn't configured to format on save!
- Commit these changes.
- Note that the commit will fail with the following error:

```
PHPCBF formatting staged file: apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/call-to-action-02.php
ERROR: Referenced sniff "WordPress" does not exist
```

Which isn't very helpful :slightly_frowning_face: 

##### To reproduce the fix:

- Now run the same instructions on _this_ branch.
- This time, committing will fail with:

```
PHPCBF formatting staged file: apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/call-to-action-02.php
COMMIT ABORTED: Working with PHP files in this repository requires the PHP Code Sniffer and its dependencies to be installed. Make sure you have composer installed on your machine and from the root of this repository, run `composer install`.
```

- Follow these instructions (run `composer install`).
- Try committing again. This time, it should pass.
- Inspect the commit. The whitespace changes should be formatted according to standard.
