### PR TITLE
Composite checkout: Add postal code auto-formatting

### DIFF
--- a/client/lib/postal-code/index.jsx
+++ b/client/lib/postal-code/index.jsx
@@ -11,7 +11,7 @@ function defaultFormatter( postalCode, delimiter, partLength ) {
  * Tries to convert given postal code based on the country code into a standardised format
  *
  * @param {string} postalCode user inputted postal code
- * @param {string} countryCode user selected country
+ * @param {string|null} countryCode user selected country
  * @returns {string} formatted postal code
  */
 export function tryToGuessPostalCodeFormat( postalCode, countryCode ) {

--- a/client/lib/postal-code/index.jsx
+++ b/client/lib/postal-code/index.jsx
@@ -11,7 +11,7 @@ function defaultFormatter( postalCode, delimiter, partLength ) {
  * Tries to convert given postal code based on the country code into a standardised format
  *
  * @param {string} postalCode user inputted postal code
- * @param {string|null} countryCode user selected country
+ * @param {string|null|undefined} countryCode user selected country
  * @returns {string} formatted postal code
  */
 export function tryToGuessPostalCodeFormat( postalCode, countryCode ) {

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -40,12 +40,9 @@ import {
 	updateContactDetailsCache,
 } from 'state/domains/management/actions';
 import QuerySitePurchases from 'components/data/query-site-purchases';
-import RegistrantExtraInfoForm from 'components/domains/registrant-extra-info';
 import { getCurrentUserCountryCode } from 'state/current-user/selectors';
 import { StateSelect } from 'my-sites/domains/components/form';
-import ManagedContactDetailsFormFields from 'components/domains/contact-details-form-fields/managed-contact-details-form-fields';
 import { getPlan } from 'lib/plans';
-import { getTopLevelOfTld } from 'lib/domains';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import { useStripe } from 'lib/stripe';
 import CheckoutTerms from '../checkout/checkout-terms.jsx';
@@ -63,14 +60,7 @@ import {
 import { useGetThankYouUrl } from './use-get-thank-you-url';
 import createAnalyticsEventHandler from './record-analytics';
 import { fillInSingleCartItemAttributes } from 'lib/cart-values';
-import {
-	hasGoogleApps,
-	hasDomainRegistration,
-	hasTransferProduct,
-	hasRenewalItem,
-	getRenewalItems,
-	hasPlan,
-} from 'lib/cart-values/cart-items';
+import { hasRenewalItem, getRenewalItems, hasPlan } from 'lib/cart-values/cart-items';
 import QueryContactDetailsCache from 'components/data/query-contact-details-cache';
 import QueryStoredCards from 'components/data/query-stored-cards';
 import QuerySitePlans from 'components/data/query-site-plans';
@@ -399,78 +389,6 @@ export default function CompositeCheckout( {
 				serverAllowedPaymentMethods,
 		  } );
 
-	const renderDomainContactFields = (
-		domainNames,
-		contactDetails,
-		contactDetailsErrors,
-		updateDomainContactFields,
-		shouldShowContactDetailsValidationErrors,
-		isDisabled
-	) => {
-		const needsOnlyGoogleAppsDetails =
-			hasGoogleApps( responseCart ) &&
-			! hasDomainRegistration( responseCart ) &&
-			! hasTransferProduct( responseCart );
-		const getIsFieldDisabled = () => isDisabled;
-		const tlds = getAllTopLevelTlds( domainNames );
-
-		return (
-			<React.Fragment>
-				<ManagedContactDetailsFormFields
-					needsOnlyGoogleAppsDetails={ needsOnlyGoogleAppsDetails }
-					contactDetails={ contactDetails }
-					contactDetailsErrors={
-						shouldShowContactDetailsValidationErrors ? contactDetailsErrors : {}
-					}
-					onContactDetailsChange={ updateDomainContactFields }
-					getIsFieldDisabled={ getIsFieldDisabled }
-				/>
-				{ tlds.includes( 'ca' ) && (
-					<RegistrantExtraInfoForm
-						contactDetails={ contactDetails }
-						ccTldDetails={ contactDetails?.extra?.ca ?? {} }
-						onContactDetailsChange={ updateDomainContactFields }
-						contactDetailsValidationErrors={
-							shouldShowContactDetailsValidationErrors ? contactDetailsErrors : {}
-						}
-						tld={ 'ca' }
-						getDomainNames={ () => domainNames }
-						translate={ translate }
-						isManaged={ true }
-					/>
-				) }
-				{ tlds.includes( 'uk' ) && (
-					<RegistrantExtraInfoForm
-						contactDetails={ contactDetails }
-						ccTldDetails={ contactDetails?.extra?.uk ?? {} }
-						onContactDetailsChange={ updateDomainContactFields }
-						contactDetailsValidationErrors={
-							shouldShowContactDetailsValidationErrors ? contactDetailsErrors : {}
-						}
-						tld={ 'uk' }
-						getDomainNames={ () => domainNames }
-						translate={ translate }
-						isManaged={ true }
-					/>
-				) }
-				{ tlds.includes( 'fr' ) && (
-					<RegistrantExtraInfoForm
-						contactDetails={ contactDetails }
-						ccTldDetails={ contactDetails?.extra?.fr ?? {} }
-						onContactDetailsChange={ updateDomainContactFields }
-						contactDetailsValidationErrors={
-							shouldShowContactDetailsValidationErrors ? contactDetailsErrors : {}
-						}
-						tld={ 'fr' }
-						getDomainNames={ () => domainNames }
-						translate={ translate }
-						isManaged={ true }
-					/>
-				) }
-			</React.Fragment>
-		);
-	};
-
 	const getItemVariants = useProductVariants( {
 		siteId,
 		productSlug: getPlanProductSlugs( items )[ 0 ],
@@ -609,7 +527,6 @@ export default function CompositeCheckout( {
 						siteUrl={ siteSlug }
 						countriesList={ countriesList }
 						StateSelect={ StateSelect }
-						renderDomainContactFields={ renderDomainContactFields }
 						variantSelectOverride={ variantSelectOverride }
 						getItemVariants={ getItemVariants }
 						responseCart={ responseCart }
@@ -765,10 +682,6 @@ function getAnalyticsPath( purchaseId, product, selectedSiteSlug, selectedFeatur
 		analyticsPath = '/checkout/no-site';
 	}
 	return { analyticsPath, analyticsProps };
-}
-
-function getAllTopLevelTlds( domainNames ) {
-	return Array.from( new Set( domainNames.map( getTopLevelOfTld ) ) ).sort();
 }
 
 function displayRenewalSuccessNotice( responseCart, purchases, translate, moment ) {

--- a/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
@@ -25,6 +25,7 @@ import {
 	hasTransferProduct,
 } from 'lib/cart-values/cart-items';
 import { createStripePaymentMethod } from 'lib/stripe';
+import { tryToGuessPostalCodeFormat } from 'lib/postal-code';
 
 const debug = debugFactory( 'calypso:composite-checkout:payment-method-helpers' );
 const { select } = defaultRegistry;
@@ -380,4 +381,10 @@ export function createStripePaymentMethodToken( { stripe, name, country, postalC
 			postal_code: postalCode,
 		},
 	} );
+}
+
+export function getPostalCode() {
+	const countryCode = select( 'wpcom' )?.getContactInfo?.()?.countryCode?.value ?? '';
+	const postalCode = select( 'wpcom' )?.getContactInfo?.()?.postalCode?.value;
+	return tryToGuessPostalCodeFormat( postalCode.toUpperCase(), countryCode );
 }

--- a/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
@@ -25,6 +25,8 @@ import {
 	hasTransferProduct,
 } from 'lib/cart-values/cart-items';
 import { createStripePaymentMethod } from 'lib/stripe';
+import { prepareDomainContactDetailsForTransaction } from 'my-sites/checkout/composite-checkout/wpcom/types/wpcom-store-state';
+import { translateCheckoutPaymentMethodToWpcomPaymentMethod } from 'my-sites/checkout/composite-checkout/wpcom';
 import { tryToGuessPostalCodeFormat } from 'lib/postal-code';
 
 const debug = debugFactory( 'calypso:composite-checkout:payment-method-helpers' );
@@ -99,7 +101,7 @@ export async function submitPayPalExpressRequest( transactionData, submit ) {
 
 export function getDomainDetails( { includeDomainDetails, includeGSuiteDetails } ) {
 	const managedContactDetails = select( 'wpcom' )?.getContactInfo?.() ?? {};
-	const domainDetails = prepareDomainContactDetails( managedContactDetails );
+	const domainDetails = prepareDomainContactDetailsForTransaction( managedContactDetails );
 	return includeDomainDetails || includeGSuiteDetails ? domainDetails : null;
 }
 

--- a/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
@@ -387,6 +387,6 @@ export function createStripePaymentMethodToken( { stripe, name, country, postalC
 
 export function getPostalCode() {
 	const countryCode = select( 'wpcom' )?.getContactInfo?.()?.countryCode?.value ?? '';
-	const postalCode = select( 'wpcom' )?.getContactInfo?.()?.postalCode?.value;
+	const postalCode = select( 'wpcom' )?.getContactInfo?.()?.postalCode?.value ?? '';
 	return tryToGuessPostalCodeFormat( postalCode.toUpperCase(), countryCode );
 }

--- a/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
@@ -14,10 +14,7 @@ import {
 	createTransactionEndpointRequestPayloadFromLineItems,
 	createPayPalExpressEndpointRequestPayloadFromLineItems,
 } from './types';
-import {
-	translateCheckoutPaymentMethodToWpcomPaymentMethod,
-	prepareDomainContactDetails,
-} from 'my-sites/checkout/composite-checkout/wpcom';
+import { translateCheckoutPaymentMethodToWpcomPaymentMethod } from 'my-sites/checkout/composite-checkout/wpcom';
 import {
 	hasGoogleApps,
 	hasDomainRegistration,
@@ -26,7 +23,6 @@ import {
 } from 'lib/cart-values/cart-items';
 import { createStripePaymentMethod } from 'lib/stripe';
 import { prepareDomainContactDetailsForTransaction } from 'my-sites/checkout/composite-checkout/wpcom/types/wpcom-store-state';
-import { translateCheckoutPaymentMethodToWpcomPaymentMethod } from 'my-sites/checkout/composite-checkout/wpcom';
 import { tryToGuessPostalCodeFormat } from 'lib/postal-code';
 
 const debug = debugFactory( 'calypso:composite-checkout:payment-method-helpers' );

--- a/client/my-sites/checkout/composite-checkout/payment-method-processors.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-processors.js
@@ -8,6 +8,7 @@ import { format as formatUrl, parse as parseUrl } from 'url'; // eslint-disable-
  * Internal dependencies
  */
 import {
+	getPostalCode,
 	getDomainDetails,
 	createStripePaymentMethodToken,
 	wpcomTransaction,
@@ -60,7 +61,7 @@ export function genericRedirectProcessor(
 			successUrl,
 			cancelUrl,
 			country: select( 'wpcom' )?.getContactInfo?.()?.countryCode?.value,
-			postalCode: select( 'wpcom' )?.getContactInfo?.()?.postalCode?.value,
+			postalCode: getPostalCode(),
 			subdivisionCode: select( 'wpcom' )?.getContactInfo?.()?.state?.value,
 			siteId: select( 'wpcom' )?.getSiteId?.(),
 			domainDetails: getDomainDetails( { includeDomainDetails, includeGSuiteDetails } ),
@@ -81,8 +82,8 @@ export function applePayProcessor( submitData, { includeDomainDetails, includeGS
 			...submitData,
 			siteId: select( 'wpcom' )?.getSiteId?.(),
 			country: select( 'wpcom' )?.getContactInfo?.()?.countryCode?.value,
-			postalCode: select( 'wpcom' )?.getContactInfo?.()?.postalCode?.value,
 			domainDetails: getDomainDetails( { includeDomainDetails, includeGSuiteDetails } ),
+			postalCode: getPostalCode(),
 		},
 		wpcomTransaction
 	);
@@ -101,13 +102,13 @@ export async function stripeCardProcessor(
 	const paymentMethodToken = await createStripePaymentMethodToken( {
 		...submitData,
 		country: select( 'wpcom' )?.getContactInfo?.()?.countryCode?.value,
-		postalCode: select( 'wpcom' )?.getContactInfo?.()?.postalCode?.value,
+		postalCode: getPostalCode(),
 	} );
 	const pending = submitStripeCardTransaction(
 		{
 			...submitData,
 			country: select( 'wpcom' )?.getContactInfo?.()?.countryCode?.value,
-			postalCode: select( 'wpcom' )?.getContactInfo?.()?.postalCode?.value,
+			postalCode: getPostalCode(),
 			subdivisionCode: select( 'wpcom' )?.getContactInfo?.()?.state?.value,
 			siteId: select( 'wpcom' )?.getSiteId?.(),
 			domainDetails: getDomainDetails( { includeDomainDetails, includeGSuiteDetails } ),
@@ -131,7 +132,7 @@ export async function existingCardProcessor(
 		{
 			...submitData,
 			country: select( 'wpcom' )?.getContactInfo?.()?.countryCode?.value,
-			postalCode: select( 'wpcom' )?.getContactInfo?.()?.postalCode?.value,
+			postalCode: getPostalCode(),
 			subdivisionCode: select( 'wpcom' )?.getContactInfo?.()?.state?.value,
 			siteId: select( 'wpcom' )?.getSiteId?.(),
 			domainDetails: getDomainDetails( { includeDomainDetails, includeGSuiteDetails } ),
@@ -217,7 +218,7 @@ export async function payPalProcessor(
 			siteId: select( 'wpcom' )?.getSiteId?.() ?? '',
 			couponId: couponItem?.wpcom_meta?.couponCode,
 			country: select( 'wpcom' )?.getContactInfo?.()?.countryCode?.value ?? '',
-			postalCode: select( 'wpcom' )?.getContactInfo?.()?.postalCode?.value ?? '',
+			postalCode: getPostalCode(),
 			subdivisionCode: select( 'wpcom' )?.getContactInfo?.()?.state?.value ?? '',
 			domainDetails: getDomainDetails( { includeDomainDetails, includeGSuiteDetails } ),
 		},

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -93,7 +93,6 @@ export default function WPCheckout( {
 	CheckoutTerms,
 	countriesList,
 	StateSelect,
-	renderDomainContactFields,
 	variantSelectOverride,
 	getItemVariants,
 	responseCart,
@@ -299,7 +298,6 @@ export default function WPCheckout( {
 									siteUrl={ siteUrl }
 									countriesList={ countriesList }
 									StateSelect={ StateSelect }
-									renderDomainContactFields={ renderDomainContactFields }
 									shouldShowContactDetailsValidationErrors={
 										shouldShowContactDetailsValidationErrors
 									}

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-contact-form-summary.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-contact-form-summary.js
@@ -4,7 +4,6 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import { useSelect, useLineItems } from '@automattic/composite-checkout';
-import { useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -17,7 +16,6 @@ export default function WPContactFormSummary( { showDomainContactSummary } ) {
 	const isGSuiteInCart = items.some( ( item ) =>
 		isGSuiteProductSlug( item.wpcom_meta?.product_slug )
 	);
-	const translate = useTranslate();
 	const contactInfo = useSelect( ( select ) => select( 'wpcom' ).getContactInfo() );
 
 	// Check if paymentData is empty
@@ -79,17 +77,6 @@ export default function WPContactFormSummary( { showDomainContactSummary } ) {
 
 					{ postalAndCountry && <SummaryLine>{ postalAndCountry }</SummaryLine> }
 				</SummaryDetails>
-
-				{ contactInfo.vatId.value?.length > 0 && (
-					<SummaryDetails>
-						{ contactInfo.vatId.value?.length > 0 && (
-							<SummaryLine>
-								{ translate( 'VAT indentification number:' ) }
-								{ contactInfo.vatId.value }
-							</SummaryLine>
-						) }
-					</SummaryDetails>
-				) }
 			</div>
 		</GridRow>
 	);

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-contact-form.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-contact-form.js
@@ -84,13 +84,6 @@ const BillingFormFields = styled.div`
 	}
 `;
 
-const FormField = styled( Field )`
-	margin-top: 16px;
-	:first-of-type {
-		margin-top: 0;
-	}
-`;
-
 const GridRow = styled.div`
 	display: -ms-grid;
 	display: grid;
@@ -108,30 +101,6 @@ const FieldRow = styled( GridRow )`
 		margin-top: 0;
 	}
 `;
-
-function isEligibleForVat( country ) {
-	//TODO: Detect whether people are in EU or AU and return true if they are
-	const countriesWithVAT = [];
-	return countriesWithVAT.includes( country );
-}
-
-function VatIdField() {
-	const translate = useTranslate();
-	const { vatId } = useSelect( ( select ) => select( 'wpcom' ).getContactInfo() );
-	const { updateVatId } = useDispatch( 'wpcom' );
-
-	return (
-		<FormField
-			id="contact-vat-id"
-			type="Number"
-			label={ translate( 'VAT identification number' ) }
-			value={ vatId.value }
-			onChange={ updateVatId }
-			isError={ vatId.isTouched && ! isValid( vatId ) }
-			errorMessage={ translate( 'This field is required.' ) }
-		/>
-	);
-}
 
 function TaxFields( {
 	section,
@@ -196,7 +165,6 @@ function ContactDetailsContainer( {
 	shouldShowContactDetailsValidationErrors,
 	isDisabled,
 } ) {
-	const requiresVatId = isEligibleForVat( contactInfo.countryCode.value );
 	const domainNames = useDomainNamesInCart();
 	const { updateDomainContactFields, updateCountryCode, updatePostalCode } = useDispatch( 'wpcom' );
 	const contactDetails = prepareDomainContactDetails( contactInfo );
@@ -218,24 +186,20 @@ function ContactDetailsContainer( {
 					shouldShowContactDetailsValidationErrors={ shouldShowContactDetailsValidationErrors }
 					isDisabled={ isDisabled }
 				/>
-				{ requiresVatId && <VatIdField /> }
 			</React.Fragment>
 		);
 	}
 
 	if ( isGSuiteInCart ) {
 		return (
-			<React.Fragment>
-				<DomainContactDetails
-					domainNames={ domainNames }
-					contactDetails={ contactDetails }
-					contactDetailsErrors={ contactDetailsErrors }
-					updateDomainContactFields={ updateDomainContactFields }
-					shouldShowContactDetailsValidationErrors={ shouldShowContactDetailsValidationErrors }
-					isDisabled={ isDisabled }
-				/>
-				{ requiresVatId && <VatIdField /> }
-			</React.Fragment>
+			<DomainContactDetails
+				domainNames={ domainNames }
+				contactDetails={ contactDetails }
+				contactDetailsErrors={ contactDetailsErrors }
+				updateDomainContactFields={ updateDomainContactFields }
+				shouldShowContactDetailsValidationErrors={ shouldShowContactDetailsValidationErrors }
+				isDisabled={ isDisabled }
+			/>
 		);
 	}
 
@@ -252,7 +216,6 @@ function ContactDetailsContainer( {
 				countriesList={ countriesList }
 				isDisabled={ isDisabled }
 			/>
-			{ requiresVatId && <VatIdField /> }
 		</React.Fragment>
 	);
 }

--- a/client/my-sites/checkout/composite-checkout/wpcom/types/wpcom-store-state.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/types/wpcom-store-state.ts
@@ -401,7 +401,10 @@ export function prepareDomainContactDetails(
 		address2: details.address2?.value,
 		city: details.city?.value,
 		state: details.state?.value,
-		postalCode: details.postalCode?.value,
+		postalCode: tryToGuessPostalCodeFormat(
+			details.postalCode?.value ?? '',
+			details.countryCode?.value
+		),
 		countryCode: details.countryCode?.value,
 		fax: details.fax?.value,
 		extra: prepareTldExtraContactDetails( details ),

--- a/client/my-sites/checkout/composite-checkout/wpcom/types/wpcom-store-state.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/types/wpcom-store-state.ts
@@ -18,6 +18,7 @@ import {
 	DomainContactValidationRequestExtraFields,
 	DomainContactValidationResponse,
 } from './backend/domain-contact-validation-endpoint';
+import { tryToGuessPostalCodeFormat } from 'lib/postal-code';
 
 export type ManagedContactDetailsShape< T > = {
 	firstName?: T;
@@ -584,7 +585,10 @@ export function prepareDomainContactValidationRequest(
 			address2: details.address2?.value,
 			city: details.city?.value,
 			state: details.state?.value,
-			postalCode: details.postalCode?.value,
+			postalCode: tryToGuessPostalCodeFormat(
+				details.postalCode?.value ?? '',
+				details.countryCode?.value
+			),
 			countryCode: details.countryCode?.value,
 			fax: details.fax?.value,
 			vatId: details.vatId?.value,
@@ -601,7 +605,10 @@ export function prepareGSuiteContactValidationRequest(
 			firstName: details.firstName?.value ?? '',
 			lastName: details.lastName?.value ?? '',
 			alternateEmail: details.alternateEmail?.value ?? '',
-			postalCode: details.postalCode?.value ?? '',
+			postalCode: tryToGuessPostalCodeFormat(
+				details.postalCode?.value ?? '',
+				details.countryCode?.value
+			),
 			countryCode: details.countryCode?.value ?? '',
 		},
 	};

--- a/client/my-sites/checkout/composite-checkout/wpcom/types/wpcom-store-state.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/types/wpcom-store-state.ts
@@ -401,6 +401,27 @@ export function prepareDomainContactDetails(
 		address2: details.address2?.value,
 		city: details.city?.value,
 		state: details.state?.value,
+		postalCode: details.postalCode?.value,
+		countryCode: details.countryCode?.value,
+		fax: details.fax?.value,
+		extra: prepareTldExtraContactDetails( details ),
+	};
+}
+
+export function prepareDomainContactDetailsForTransaction(
+	details: ManagedContactDetails
+): DomainContactDetails {
+	return {
+		firstName: details.firstName?.value,
+		lastName: details.lastName?.value,
+		organization: details.organization?.value,
+		email: details.email?.value,
+		alternateEmail: details.alternateEmail?.value,
+		phone: details.phone?.value,
+		address1: details.address1?.value,
+		address2: details.address2?.value,
+		city: details.city?.value,
+		state: details.state?.value,
 		postalCode: tryToGuessPostalCodeFormat(
 			details.postalCode?.value ?? '',
 			details.countryCode?.value


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This adds postal code formatting in composite checkout to be similar to the behavior in old checkout.

Old checkout modifies the postal code field value itself when the field is blurred. This PR instead formats only when the postal code value sending to the validation and transaction endpoints. This late formatting may be necessary since there are situations where the field is never edited (eg: initial validation on load to skip the step), or it might be edited before we know the country (which is required for the formatting).

Fixes https://github.com/Automattic/wp-calypso/issues/44622

#### Testing instructions

- Add a domain to your cart and visit checkout.
- Choose The Netherlands as your country.
- Enter the postal code `2651BS` (do not type a space between the numbers and letters).
- Press "Continue".
- Verify that no validation errors are reported for the postal code field.
- Complete the purchase and watch the network request to the transactions endpoint; verify that the `domain_details.postal_code` field contains the postal code `2651 BS`, with a space between the numbers and letters.