### PR TITLE
Fix shipping label purchase with WCS 1.24

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
+++ b/client/extensions/woocommerce/woocommerce-services/state/shipping-label/actions.js
@@ -1022,7 +1022,7 @@ export const purchaseLabel = ( orderId, siteId ) => ( dispatch, getState ) => {
 					} );
 					return {
 						...packageFields,
-						shipment_id: form.rates.available[ pckgId ].shipment_id,
+						shipment_id: form.rates.available[ pckgId ].shipment_id || rate.shipment_id,
 						rate_id: rate.rate_id,
 						service_id: form.rates.values[ pckgId ],
 						carrier_id: rate.carrier_id,


### PR DESCRIPTION
WooCommerce Services 1.24 updated the API response for shipping rates which caused a backwards compatibility issue with the Store on WP.com label purchase flow.

#### Changes proposed in this Pull Request

* Retrieve `shipment_id` from new location if it cannot be found in old location

A similar change was made in the WCS plugin here so the wp-admin interface can accept the updated API: https://github.com/Automattic/woocommerce-services/pull/2046/files#diff-09d52b7e14fcd8c2a349cabb5e073666

#### Testing instructions
* Test on a site with Store on WP.com
* Create a shippable order
* Go to order and try to purchase a shipping label
* Shipping label purchase should be successful


Fixes https://github.com/Automattic/woocommerce-shipping-issues/issues/81