### PR TITLE
Disable Jetpack Personal plan in prod

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -60,7 +60,7 @@
 		"jetpack/backups-restore": true,
 		"jetpack/anti-spam-product": true,
 		"jetpack/on-demand-scan": true,
-		"jetpack/personal-plan": true,
+		"jetpack/personal-plan": false,
 		"jitms": true,
 		"keyboard-shortcuts": true,
 		"lasagna": true,

--- a/config/production.json
+++ b/config/production.json
@@ -63,7 +63,7 @@
 		"jetpack/anti-spam-product": true,
 		"jetpack/on-demand-scan": true,
 		"jetpack/backups-restore": true,
-		"jetpack/personal-plan": true,
+		"jetpack/personal-plan": false,
 		"jitms": true,
 		"lasagna": true,
 		"layout/app-banner": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR removes the Jetpack Personal plan from production as part of the Jetpack offer reset project

#### Testing instructions

Visually check that the config flags are changed appropriately, as there is no way to test without shipping this.