### PR TITLE
Rename calypso package from wp-calypso to wp-calypso-client

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -231,7 +231,7 @@ module.exports = {
 				mappings: [
 					{
 						dir: path.join( __dirname, 'client' ),
-						module: 'wp-calypso',
+						module: 'wp-calypso-client',
 					},
 				],
 				warnOnNonLiteralImport: true,

--- a/apps/notifications/index.jsx
+++ b/apps/notifications/index.jsx
@@ -18,13 +18,13 @@ import React, { Component } from 'react';
 import classNames from 'classnames';
 import page from 'page';
 import { connect } from 'react-redux';
-import wpcom from 'wp-calypso/lib/wp';
-import { recordTracksEvent } from 'wp-calypso/lib/analytics/tracks';
-import config from 'wp-calypso/config';
-import { recordTracksEvent as recordTracksEventAction } from 'wp-calypso/state/analytics/actions';
-import getCurrentLocaleSlug from 'wp-calypso/state/selectors/get-current-locale-slug';
-import getCurrentLocaleVariant from 'wp-calypso/state/selectors/get-current-locale-variant';
-import { setUnseenCount } from 'wp-calypso/state/notifications';
+import wpcom from 'wp-calypso-client/lib/wp';
+import { recordTracksEvent } from 'wp-calypso-client/lib/analytics/tracks';
+import config from 'wp-calypso-client/config';
+import { recordTracksEvent as recordTracksEventAction } from 'wp-calypso-client/state/analytics/actions';
+import getCurrentLocaleSlug from 'wp-calypso-client/state/selectors/get-current-locale-slug';
+import getCurrentLocaleVariant from 'wp-calypso-client/state/selectors/get-current-locale-variant';
+import { setUnseenCount } from 'wp-calypso-client/state/notifications';
 
 /**
  * Internal dependencies

--- a/apps/notifications/package.json
+++ b/apps/notifications/package.json
@@ -36,7 +36,7 @@
 		"react-dom": "^16.12.0",
 		"react-redux": "^7.2.0",
 		"redux": "^4.0.5",
-		"wp-calypso": "^0.17.0",
+		"wp-calypso-client": "^0.17.0",
 		"wpcom": "^6.0.0",
 		"wpcom-proxy-request": "^6.0.0"
 	},

--- a/client/package.json
+++ b/client/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "wp-calypso",
+	"name": "wp-calypso-client",
 	"author": "Automattic Inc.",
 	"version": "0.17.0",
 	"description": "A pure REST-API and JS based version of the WordPress.com admin",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "wp-calypso-monorepo",
+	"name": "wp-calypso",
 	"author": "Automattic Inc.",
 	"version": "0.17.0",
 	"description": "A pure REST-API and JS based version of the WordPress.com admin",

--- a/package.json
+++ b/package.json
@@ -375,7 +375,7 @@
 		"webpack-hot-middleware": "^2.25.0",
 		"webpack-node-externals": "^2.1.0",
 		"whybundled": "^1.4.2",
-		"wp-calypso": "^0.17.0",
+		"wp-calypso-client": "^0.17.0",
 		"wp-e2e-tests": "^0.0.1",
 		"wpcom": "^6.0.0",
 		"wpcom-proxy-request": "^6.0.0",

--- a/packages/eslint-plugin-wpcalypso/docs/rules/no-package-relative-imports.md
+++ b/packages/eslint-plugin-wpcalypso/docs/rules/no-package-relative-imports.md
@@ -12,11 +12,11 @@ Those work because Webpack will search for those modules in ./client first, and 
 As an alternative, we can rewrite the above as
 
 ```js
-import config from 'wp-calypso/config';
-import userFactory from 'wp-calypso/lib/user';
+import config from 'wp-calypso-client/config';
+import userFactory from 'wp-calypso-client/lib/user';
 ```
 
-Which works because `wp-calypso` is a valid package in our repository, points to `./client` and is declared as a dependency in the root `package.json`. This will work out of the box in all module resolution systems.
+Which works because `wp-calypso-client` is a valid package in our repository, points to `./client` and is declared as a dependency in the root `package.json`. This will work out of the box in all module resolution systems.
 
 This rule forbids the former approach and can auto-fix it to the latter.
 
@@ -39,15 +39,15 @@ const component = <AsyncLoad require="config"/>
 The following patterns are correct
 
 ```jsx
-import config from 'wp-calypso/config';
-import * as stats from 'wp-calypso/reader/stats';
-import { localizeUrl } from 'wp-calypso/lib/i18n-utils';
-export { default as ActionCard } from 'wp-calypso/components/action-card/docs/example';
-export * from 'wp-calypso/components/AppBar';
-const config1 = require('wp-calypso/config');
-const config2 = asyncRequire('wp-calypso/config');
+import config from 'wp-calypso-client/config';
+import * as stats from 'wp-calypso-client/reader/stats';
+import { localizeUrl } from 'wp-calypso-client/lib/i18n-utils';
+export { default as ActionCard } from 'wp-calypso-client/components/action-card/docs/example';
+export * from 'wp-calypso-client/components/AppBar';
+const config1 = require('wp-calypso-client/config');
+const config2 = asyncRequire('wp-calypso-client/config');
 
-const component = <AsyncLoad require="wp-calypso/config"/>
+const component = <AsyncLoad require="wp-calypso-client/config"/>
 
 import config from './config';
 import config from '../../../config';

--- a/packages/eslint-plugin-wpcalypso/lib/rules/no-package-relative-imports.js
+++ b/packages/eslint-plugin-wpcalypso/lib/rules/no-package-relative-imports.js
@@ -43,9 +43,9 @@ const getRelativeImports = ( relativeDir, automaticExtensions = [ '.js', '.json'
  *
  * Example:
  *
- * With mappings `[ {dir: '/app/client', module: 'wp-calypso'} ]`
+ * With mappings `[ {dir: '/app/client', module: 'wp-calypso-client'} ]`
  * If the code is importing `foo` and `foo` is a subdirectory of `/app/client/`, this rule
- * will warn the user and optionally replace it with `wp-calypso/foo`
+ * will warn the user and optionally replace it with `wp-calypso-client/foo`
  *
  * @param {object} arg Function arguments
  * @param {object} arg.context The context as provided by ESLint (https://eslint.org/docs/developer-guide/working-with-rules#the-context-object)

--- a/packages/eslint-plugin-wpcalypso/lib/rules/test/no-package-relative-imports.js
+++ b/packages/eslint-plugin-wpcalypso/lib/rules/test/no-package-relative-imports.js
@@ -25,7 +25,7 @@ const options = [
 		mappings: [
 			{
 				dir: calypsoDir,
-				module: 'wp-calypso',
+				module: 'wp-calypso-client',
 			},
 		],
 		automaticExtensions,
@@ -44,19 +44,19 @@ new RuleTester( {
 	},
 } ).run( 'no-package-relative-imports', rule, {
 	valid: [
-		{ code: `import config from 'wp-calypso/config';`, options },
-		{ code: "import * as stats from 'wp-calypso/reader/stats';", options },
-		{ code: "import { localizeUrl } from 'wp-calypso/lib/i18n-utils';", options },
+		{ code: `import config from 'wp-calypso-client/config';`, options },
+		{ code: "import * as stats from 'wp-calypso-client/reader/stats';", options },
+		{ code: "import { localizeUrl } from 'wp-calypso-client/lib/i18n-utils';", options },
 		{
 			code:
-				"export { default as ActionCard } from 'wp-calypso/components/action-card/docs/example';",
+				"export { default as ActionCard } from 'wp-calypso-client/components/action-card/docs/example';",
 			options,
 		},
-		{ code: "export * from 'wp-calypso/components/AppBar';", options },
-		{ code: "const config = require('wp-calypso/config');", options },
-		{ code: "const config = asyncRequire('wp-calypso/config');", options },
-		{ code: "const getConfig = async () => await import('wp-calypso/config');", options },
-		{ code: "const component = <AsyncLoad require='wp-calypso/config'/>", options },
+		{ code: "export * from 'wp-calypso-client/components/AppBar';", options },
+		{ code: "const config = require('wp-calypso-client/config');", options },
+		{ code: "const config = asyncRequire('wp-calypso-client/config');", options },
+		{ code: "const getConfig = async () => await import('wp-calypso-client/config');", options },
+		{ code: "const component = <AsyncLoad require='wp-calypso-client/config'/>", options },
 		{ code: "import config from './config';", options },
 		{ code: "import config from '../../../config';", options },
 		{ code: "import config from 'random-directory';", options },
@@ -72,7 +72,7 @@ new RuleTester( {
 					type: 'ImportDeclaration',
 				},
 			],
-			output: `import config from 'wp-calypso/config';`,
+			output: `import config from 'wp-calypso-client/config';`,
 		},
 		{
 			code: `import * as stats from 'reader/stats';`,
@@ -83,7 +83,7 @@ new RuleTester( {
 					type: 'ImportDeclaration',
 				},
 			],
-			output: `import * as stats from 'wp-calypso/reader/stats';`,
+			output: `import * as stats from 'wp-calypso-client/reader/stats';`,
 		},
 		{
 			code: `import { localizeUrl } from 'lib/i18n-utils';`,
@@ -94,7 +94,7 @@ new RuleTester( {
 					type: 'ImportDeclaration',
 				},
 			],
-			output: `import { localizeUrl } from 'wp-calypso/lib/i18n-utils';`,
+			output: `import { localizeUrl } from 'wp-calypso-client/lib/i18n-utils';`,
 		},
 		{
 			code: `export { default as ActionCard } from 'components/action-card/docs/example';`,
@@ -105,7 +105,7 @@ new RuleTester( {
 					type: 'ExportNamedDeclaration',
 				},
 			],
-			output: `export { default as ActionCard } from 'wp-calypso/components/action-card/docs/example';`,
+			output: `export { default as ActionCard } from 'wp-calypso-client/components/action-card/docs/example';`,
 		},
 		{
 			code: `export * from 'components/AppBar';`,
@@ -116,7 +116,7 @@ new RuleTester( {
 					type: 'ExportAllDeclaration',
 				},
 			],
-			output: `export * from 'wp-calypso/components/AppBar';`,
+			output: `export * from 'wp-calypso-client/components/AppBar';`,
 		},
 		{
 			code: `const config = require('config');`,
@@ -127,7 +127,7 @@ new RuleTester( {
 					type: 'CallExpression',
 				},
 			],
-			output: `const config = require('wp-calypso/config');`,
+			output: `const config = require('wp-calypso-client/config');`,
 		},
 		{
 			code: `const config = asyncRequire('config');`,
@@ -138,7 +138,7 @@ new RuleTester( {
 					type: 'CallExpression',
 				},
 			],
-			output: `const config = asyncRequire('wp-calypso/config');`,
+			output: `const config = asyncRequire('wp-calypso-client/config');`,
 		},
 		{
 			code: `const config = async () => await import('config');`,
@@ -149,7 +149,7 @@ new RuleTester( {
 					type: 'ImportExpression',
 				},
 			],
-			output: `const config = async () => await import('wp-calypso/config');`,
+			output: `const config = async () => await import('wp-calypso-client/config');`,
 		},
 		{
 			code: `const component = <AsyncLoad require="config"/>`,
@@ -160,7 +160,7 @@ new RuleTester( {
 					type: 'JSXElement',
 				},
 			],
-			output: `const component = <AsyncLoad require="wp-calypso/config"/>`,
+			output: `const component = <AsyncLoad require="wp-calypso-client/config"/>`,
 		},
 
 		// Dynamic test: test the rule with each subdirectory and file inside `./client`
@@ -189,7 +189,7 @@ new RuleTester( {
 						type: 'ImportDeclaration',
 					},
 				],
-				output: `import * as foo from 'wp-calypso/${ dir }';`,
+				output: `import * as foo from 'wp-calypso-client/${ dir }';`,
 			} ) ),
 	],
 } );


### PR DESCRIPTION
### Background

As part of #44602, we'll be exposing more the name of the `./client/` package. The current name scheme is a bit confusing, as `wp-calypso` is used both as the repo name and an internal npm package:

- Repo -> named `wp-calypso` in Git
- Root project -> npm package named `wp-calypso-monorepo`
- `./client` folder -> npm package named `wp-calypso`

### Changes proposed in this Pull Request

- Repo -> unchanged
- Root project -> renamed to `wp-calypso`, to match the repo name
- `./client` -> renamed to `wp-calypso-client`

### Testing instructions

No functional changes. Verify tests passes and check there are no obvious errors in the live branch.
