### PR TITLE
EditorMediaModalGalleryPreview: replace `MediaStore.get` with `getMediaItem`…

### DIFF
--- a/client/post-editor/media-modal/gallery/index.jsx
+++ b/client/post-editor/media-modal/gallery/index.jsx
@@ -11,7 +11,6 @@ import { noop, assign, omitBy, some, isEqual, partial } from 'lodash';
  * Internal dependencies
  */
 import HeaderCake from 'components/header-cake';
-import MediaStore from 'lib/media/store';
 import EditorMediaModalContent from '../content';
 import EditorMediaModalGalleryDropZone from './drop-zone';
 import EditorMediaModalGalleryFields from './fields';
@@ -20,6 +19,7 @@ import { GalleryDefaultAttrs } from 'lib/media/constants';
 import { ModalViews } from 'state/ui/media-modal/constants';
 import { setEditorMediaModalView } from 'state/editor/actions';
 import { isModuleActive } from 'lib/site/utils';
+import getMediaItem from 'state/media/thunks/get-media-item';
 
 /**
  * Style dependencies
@@ -79,7 +79,7 @@ class EditorMediaModalGallery extends React.Component {
 				} )
 			)
 			.map( ( item ) => {
-				return MediaStore.get( this.props.site.ID, item.ID );
+				return this.props.getMediaItem( this.props.site.ID, item.ID );
 			} );
 
 		if ( ! isEqual( newItems, settings.items ) ) {
@@ -128,6 +128,7 @@ class EditorMediaModalGallery extends React.Component {
 		const { site, items, settings } = this.props;
 
 		return (
+			/* eslint-disable wpcalypso/jsx-classname-namespace */
 			<div className="editor-media-modal-gallery">
 				<EditorMediaModalGalleryDropZone
 					site={ site }
@@ -156,10 +157,12 @@ class EditorMediaModalGallery extends React.Component {
 					</div>
 				</EditorMediaModalContent>
 			</div>
+			/* eslint-enable wpcalypso/jsx-classname-namespace */
 		);
 	}
 }
 
 export default connect( null, {
 	onReturnToList: partial( setEditorMediaModalView, ModalViews.LIST ),
+	getMediaItem,
 } )( localize( EditorMediaModalGallery ) );


### PR DESCRIPTION
… thunk

#### Changes proposed in this Pull Request

* EditorMediaModalGalleryPreview: replace `MediaStore.get` with `getMediaItem` thunk

#### Testing instructions

Please note, that there's a bug (#44640) if do a browser reload on the post editor and then hit _Edit_ on the gallery block. Make sure you do that view switch before checking. Opening the media library also seems to help. The bug exists on prod as well and is therefore not related to this PR specifically. 

1. Use the classic post editor to open a post which contains a gallery block
2. Hit the _Edit_ button on the block and make sure all images are showing up

related #43663 
