### PR TITLE
Hide custom address setting for P2 sites

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -135,11 +135,11 @@ export class SiteSettingsFormGeneral extends Component {
 	}
 
 	blogAddress() {
-		const { site, siteIsJetpack, siteSlug, translate } = this.props;
+		const { site, siteIsJetpack, siteSlug, translate, isWPForTeamsSite } = this.props;
 		let customAddress = '',
 			addressDescription = '';
 
-		if ( ! site || siteIsJetpack ) {
+		if ( ! site || siteIsJetpack || isWPForTeamsSite ) {
 			return null;
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Hide `Custom Address` from General settings for P2 sites

#### Testing instructions
- Go to Manage Settings -> Custom Address should be there
- Switch to a P2 site -> Custom Address setting should not be visible