### PR TITLE
Consolidates checks for reskin variation

### DIFF
--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -32,7 +32,6 @@ import { getProductsList } from 'state/products-list/selectors';
 import Badge from 'components/badge';
 import InfoPopover from 'components/info-popover';
 import { HTTPS_SSL } from 'lib/url/support';
-import { getABTestVariation } from 'lib/abtest';
 
 const NOTICE_GREEN = '#4ab866';
 
@@ -420,7 +419,6 @@ const mapStateToProps = ( state, props ) => {
 			currentUserCurrencyCode,
 			stripZeros
 		),
-		isReskinned: props.isSignupStep && 'reskinned' === getABTestVariation( 'reskinSignupFlow' ),
 	};
 };
 

--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -25,7 +25,6 @@ import { getDesignType } from 'state/signup/steps/design-type/selectors';
 import { DESIGN_TYPE_STORE } from 'signup/constants';
 import { hideSitePreview } from 'state/signup/preview/actions';
 import { isSitePreviewVisible } from 'state/signup/preview/selectors';
-import { getABTestVariation } from 'lib/abtest';
 
 /**
  * Style dependencies
@@ -60,6 +59,7 @@ class DomainSearchResults extends React.Component {
 		fetchAlgo: PropTypes.string,
 		pendingCheckSuggestion: PropTypes.object,
 		unavailableDomains: PropTypes.array,
+		isReskinned: PropTypes.bool,
 	};
 
 	componentDidUpdate() {
@@ -337,7 +337,6 @@ const mapStateToProps = ( state, ownProps ) => {
 		// Set site design type only if we're in signup
 		siteDesignType: ownProps.isSignupStep && getDesignType( state ),
 		isSitePreviewVisible: ownProps.isSignupStep && isSitePreviewVisible( state ),
-		isReskinned: ownProps.isSignupStep && 'reskinned' === getABTestVariation( 'reskinSignupFlow' ),
 	};
 };
 

--- a/client/components/domains/free-domain-explainer/index.jsx
+++ b/client/components/domains/free-domain-explainer/index.jsx
@@ -9,7 +9,6 @@ import { omit } from 'lodash';
  * Internal dependencies
  */
 import { Button } from '@automattic/components';
-import { getABTestVariation } from 'lib/abtest';
 
 /**
  * Style dependencies
@@ -17,6 +16,11 @@ import { getABTestVariation } from 'lib/abtest';
 import './style.scss';
 
 class FreeDomainExplainer extends React.Component {
+	constructor( props ) {
+		super( props );
+		this.TextWrapper = this.TextWrapper.bind( this );
+	}
+
 	handleClick = () => {
 		const hideFreePlan = true;
 
@@ -41,9 +45,8 @@ class FreeDomainExplainer extends React.Component {
 	}
 
 	render() {
-		const { translate } = this.props;
+		const { translate, isReskinned } = this.props;
 		const { TextWrapper } = this;
-		const isReskinned = 'reskinned' === getABTestVariation( 'reskinSignupFlow' );
 
 		return (
 			<div className="free-domain-explainer card is-compact">
@@ -51,12 +54,12 @@ class FreeDomainExplainer extends React.Component {
 					<h1 className="free-domain-explainer__title">
 						{ translate( 'Get a free one-year domain registration with any paid plan.' ) }
 					</h1>
-					<TextWrapper isReskinned={ isReskinned } className="free-domain-explainer__subtitle">
+					<TextWrapper className="free-domain-explainer__subtitle">
 						{ translate(
 							"We'll pay the registration fees for your new domain when you choose a paid plan during the next step."
 						) }
 					</TextWrapper>
-					<TextWrapper isReskinned={ isReskinned } className="free-domain-explainer__subtitle">
+					<TextWrapper className="free-domain-explainer__subtitle">
 						{ translate( "You can claim your free custom domain later if you aren't ready yet." ) }
 						<Button
 							borderless

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -151,6 +151,7 @@ class RegisterDomainStep extends React.Component {
 		recordFiltersSubmit: PropTypes.func.isRequired,
 		recordFiltersReset: PropTypes.func.isRequired,
 		vertical: PropTypes.string,
+		isReskinned: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -1099,6 +1100,7 @@ class RegisterDomainStep extends React.Component {
 						unavailableDomains={ this.state.unavailableDomains }
 						isEligibleVariantForDomainTest={ this.props.isEligibleVariantForDomainTest }
 						shouldHideFreeDomainExplainer={ this.props.shouldHideFreeDomainExplainer }
+						isReskinned={ this.props.isReskinned }
 					/>
 				);
 			}, this );
@@ -1144,7 +1146,12 @@ class RegisterDomainStep extends React.Component {
 	}
 
 	renderFreeDomainExplainer() {
-		return <FreeDomainExplainer onSkip={ this.props.hideFreePlan } />;
+		return (
+			<FreeDomainExplainer
+				onSkip={ this.props.hideFreePlan }
+				isReskinned={ this.props.isReskinned }
+			/>
+		);
 	}
 
 	onAddDomain = ( suggestion ) => {
@@ -1262,6 +1269,7 @@ class RegisterDomainStep extends React.Component {
 					unavailableDomains={ this.state.unavailableDomains }
 					isEligibleVariantForDomainTest={ this.props.isEligibleVariantForDomainTest }
 					shouldHideFreeDomainExplainer={ this.props.shouldHideFreeDomainExplainer }
+					isReskinned={ this.props.isReskinned }
 				>
 					{ this.props.isEligibleVariantForDomainTest &&
 						hasResults &&

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -52,6 +52,7 @@ import { getCurrentOAuth2Client } from 'state/oauth2-clients/ui/selectors';
 import LayoutLoader from './loader';
 import wooDnaConfig from 'jetpack-connect/woo-dna-config';
 import { getABTestVariation } from 'lib/abtest';
+import { getCurrentFlowName } from 'state/signup/flow/selectors';
 
 /**
  * Style dependencies
@@ -154,17 +155,22 @@ class Layout extends Component {
 					config.isEnabled( 'woocommerce/onboarding-oauth' ) &&
 					isWooOAuth2Client( this.props.oauth2Client ) &&
 					this.props.wccomFrom,
-				'is-white-signup':
-					'signup' === this.props.sectionName && //TODO: Check flowName here and remove this comment
-					'reskinned' === getABTestVariation( 'reskinSignupFlow' ),
 			}
 		);
 
 		const optionalBodyProps = () => {
 			const optionalProps = {};
 
-			if ( this.props.isNewLaunchFlow || this.props.isCheckoutFromGutenboarding ) {
-				optionalProps.bodyClass = 'is-new-launch-flow';
+			const bodyClass = classnames( {
+				'is-new-launch-flow': this.props.isNewLaunchFlow || this.props.isCheckoutFromGutenboarding,
+				'is-white-signup':
+					'signup' === this.props.sectionName &&
+					this.props.isOnboardingFlow &&
+					'reskinned' === getABTestVariation( 'reskinSignupFlow' ),
+			} );
+
+			if ( bodyClass ) {
+				optionalProps.bodyClass = bodyClass;
 			}
 
 			return optionalProps;
@@ -278,6 +284,7 @@ export default connect( ( state ) => {
 	const wccomFrom = get( getCurrentQueryArguments( state ), 'wccom-from' );
 	const isEligibleForJITM = [ 'stats', 'plans', 'themes', 'plugins' ].indexOf( sectionName ) >= 0;
 	const isNewLaunchFlow = startsWith( currentRoute, '/start/new-launch' );
+	const isOnboardingFlow = 'onboarding' === getCurrentFlowName( state );
 
 	return {
 		masterbarIsHidden:
@@ -310,5 +317,6 @@ export default connect( ( state ) => {
 		shouldQueryAllSites: currentRoute && currentRoute !== '/jetpack/connect/authorize',
 		isNewLaunchFlow,
 		isCheckoutFromGutenboarding,
+		isOnboardingFlow,
 	};
 } )( Layout );

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -155,7 +155,7 @@ class Layout extends Component {
 					isWooOAuth2Client( this.props.oauth2Client ) &&
 					this.props.wccomFrom,
 				'is-white-signup':
-					'signup' === this.props.sectionName &&
+					'signup' === this.props.sectionName && //TODO: Check flowName here and remove this comment
 					'reskinned' === getABTestVariation( 'reskinSignupFlow' ),
 			}
 		);

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -629,7 +629,9 @@ export default connect(
 		} );
 
 		const isReskinned =
-			props.isInSignup && 'reskinned' === getABTestVariation( 'reskinSignupFlow' );
+			props.isInSignup &&
+			'onboarding' === props.flowName &&
+			'reskinned' === getABTestVariation( 'reskinSignupFlow' );
 
 		return {
 			// This is essentially a hack - discounts are the only endpoint that we can rely on both on /plans and

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -49,7 +49,7 @@ import { fetchUsernameSuggestion } from 'state/signup/optional-dependencies/acti
 import { isSitePreviewVisible } from 'state/signup/preview/selectors';
 import { hideSitePreview, showSitePreview } from 'state/signup/preview/actions';
 import hasInitializedSites from 'state/selectors/has-initialized-sites';
-import { abtest } from 'lib/abtest';
+import { abtest, getABTestVariation } from 'lib/abtest';
 
 /**
  * Style dependencies
@@ -72,6 +72,7 @@ class DomainsStep extends React.Component {
 		stepSectionName: PropTypes.string,
 		selectedSite: PropTypes.object,
 		vertical: PropTypes.string,
+		isReskinned: PropTypes.bool,
 	};
 
 	getDefaultState = () => ( {
@@ -484,6 +485,7 @@ class DomainsStep extends React.Component {
 				onSkip={ this.handleSkip }
 				hideFreePlan={ this.handleSkip }
 				shouldHideFreeDomainExplainer={ shouldHideFreeDomainExplainer }
+				isReskinned={ this.props.isReskinned }
 			/>
 		);
 
@@ -724,6 +726,9 @@ export default connect(
 	( state, ownProps ) => {
 		const productsList = getAvailableProductsList( state );
 		const productsLoaded = ! isEmpty( productsList );
+		const isReskinned =
+			'onboarding' === ownProps.flowName &&
+			'reskinned' === getABTestVariation( 'reskinSignupFlow' );
 
 		return {
 			designType: getDesignType( state ),
@@ -735,6 +740,7 @@ export default connect(
 			selectedSite: getSite( state, ownProps.signupDependencies.siteSlug ),
 			isSitePreviewVisible: isSitePreviewVisible( state ),
 			hasInitializedSitesBackUrl: hasInitializedSites( state ) ? '/sites/' : false,
+			isReskinned,
 		};
 	},
 	{

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -394,7 +394,7 @@ export class UserStep extends Component {
 	}
 
 	renderSignupForm() {
-		const { oauth2Client, wccomFrom } = this.props;
+		const { oauth2Client, wccomFrom, flowName } = this.props;
 		let socialService, socialServiceResponse;
 		let isSocialSignupEnabled = this.props.isSocialSignupEnabled;
 		const hashObject = this.props.initialContext && this.props.initialContext.hash;
@@ -415,6 +415,9 @@ export class UserStep extends Component {
 			isSocialSignupEnabled = true;
 		}
 
+		const isReskinned =
+			'onboarding' === flowName && 'reskinned' === getABTestVariation( 'reskinSignupFlow' );
+
 		return (
 			<>
 				<SignupForm
@@ -432,7 +435,7 @@ export class UserStep extends Component {
 					socialServiceResponse={ socialServiceResponse }
 					recaptchaClientId={ this.state.recaptchaClientId }
 					showRecaptchaToS={ flows.getFlow( this.props.flowName )?.showRecaptcha }
-					horizontal={ 'reskinned' === getABTestVariation( 'reskinSignupFlow' ) }
+					horizontal={ isReskinned }
 				/>
 				<div id="g-recaptcha"></div>
 			</>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The current change ensures that:
1. User is assigned to the reskinned variant.
2. User is not an existing user. (User is in the signup flow)
3. User is in the onboarding flow.

This stops the reskin design from being displayed whenever the component is shared by multiple views.

#### Pending Change:
https://github.com/Automattic/wp-calypso/blob/af5c8f9d9a01955728426083c8944cc0fb4c57a0/client/layout/index.jsx#L158

#### Testing instructions

Happy Path:
* Go to /start/new.
* Make sure you're assigned to reskinned group of reskinSignupFlow a/b test.
  Note: this test is intended to work only for non-EN and non-ES users. (p1596055144383000-slack-marketing-health).
* The screens should look like the ones in the description of #44223

Other Cases:

**Other signup flows should not show reskin elements.** From https://github.com/Automattic/wp-calypso/pull/44223#discussion_r464976764, 
* Go to /start
* Manually assign yourself to the reskin test
* Go to /start/premium.
* Observe the user, domains and plans steps. There should be no reskinned UI elements shown.

**Logged in users should not see reskin elements**
* Go to /start
* Manually assign yourself to the reskin test
* Complete all the steps and create a site
* As a logged in user go to /plans and /domains/add. Both should not show reskin UI elements.

