### PR TITLE
Jetpack Backup: Show 'Latest backup on this day' for dates before today

### DIFF
--- a/client/components/jetpack/daily-backup-status/index.jsx
+++ b/client/components/jetpack/daily-backup-status/index.jsx
@@ -86,11 +86,21 @@ class DailyBackupStatus extends Component {
 			hasRealtimeBackups,
 			siteSlug,
 			deltas,
+			selectedDate,
 			// metaDiff,
 			translate,
+			moment,
+			timezone,
+			gmtOffset,
 		} = this.props;
 		const displayDate = this.getDisplayDate( backup.activityTs );
 		const displayDateNoLatest = this.getDisplayDate( backup.activityTs, false );
+
+		const today = applySiteOffset( moment(), {
+			timezone: timezone,
+			gmtOffset: gmtOffset,
+		} );
+		const isToday = selectedDate.isSame( today, 'day' );
 
 		const meta = get( backup, 'activityDescription[2].children[0]', '' );
 
@@ -104,7 +114,9 @@ class DailyBackupStatus extends Component {
 			<>
 				<div className="daily-backup-status__message-head">
 					<img src={ cloudSuccessIcon } alt="" role="presentation" />
-					<div className="daily-backup-status__hide-mobile">{ translate( 'Latest backup' ) }</div>
+					<div className="daily-backup-status__hide-mobile">
+						{ isToday ? translate( 'Latest backup' ) : translate( 'Latest backup on this day' ) }
+					</div>
 				</div>
 				<div className="daily-backup-status__hide-desktop">
 					<div className="daily-backup-status__title">{ displayDate }</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* (Non-mobile layouts only) When the selected date isn't the same as the current calendar date, show "Latest backups on this day" instead of "Latest backups."

Fixes #44530, `1164141197617539-as-1186718228515397`.

#### Testing instructions

* For a site with Jetpack Backup, go to the Backup page on either Jetpack.com or WordPress.com, using a non-mobile screen layout.
* Observe/verify that for the current calendar date, if a backup exists, the status header reads "Latest backup" (see screenshot for example).
* Observe/verify that for every other date with a backup, the status header reads "Latest backup on this day" (see screenshot for example).

#### Screenshots

##### Previous date

<img width="777" alt="Screen Shot 2020-08-04 at 09 30 29" src="https://user-images.githubusercontent.com/670067/89306762-ec0b5d80-d635-11ea-88f8-6ccb3b584dd5.png">

##### "Today"

<img width="778" alt="Screen Shot 2020-08-04 at 09 30 51" src="https://user-images.githubusercontent.com/670067/89306763-eca3f400-d635-11ea-92ce-0a41a20a0dde.png">
