### PR TITLE
Checkout: Break long domain name in the summary section

### DIFF
--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
@@ -372,6 +372,7 @@ const CheckoutSummaryFeaturesListItem = styled.li`
 	margin-bottom: 4px;
 	padding-left: 24px;
 	position: relative;
+	overflow-wrap: break-word;
 
 	.rtl & {
 		padding-right: 24px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Breaks long domain names to the next line

**BEFORE**

<img width="1035" alt="Screenshot 2020-08-04 at 8 05 45 PM" src="https://user-images.githubusercontent.com/1269602/89307116-5223cf00-d68e-11ea-9dd1-b9c16d4a29e6.png">

<img width="361" alt="Screenshot 2020-08-04 at 8 07 16 PM" src="https://user-images.githubusercontent.com/1269602/89307137-594add00-d68e-11ea-9c1e-2dd300b90424.png">

**AFTER**

<img width="937" alt="Screenshot 2020-08-04 at 8 05 39 PM" src="https://user-images.githubusercontent.com/1269602/89307176-65cf3580-d68e-11ea-82df-d9fb33a4e0e6.png">

<img width="365" alt="Screenshot 2020-08-04 at 8 07 09 PM" src="https://user-images.githubusercontent.com/1269602/89307189-6b2c8000-d68e-11ea-8593-3633f4580813.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Add a domain with a long name to cart and proceed to checkout (you need to be in US/USD to see it)
* Verify that the domain name wraps to the next line.
