### PR TITLE
Checkout: Remove cart message for PWPO users

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.js
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { CheckoutModal, useFormStatus, useEvents, Button } from '@automattic/composite-checkout';
 import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -14,6 +15,8 @@ import joinClasses from './join-classes';
 import { useHasDomainsInCart } from '../hooks/has-domains';
 import { ItemVariationPicker } from './item-variation-picker';
 import { isGSuiteProductSlug } from 'lib/gsuite';
+import { currentUserHasFlag } from 'state/current-user/selectors';
+import { NON_PRIMARY_DOMAINS_TO_FREE_USERS } from 'state/current-user/constants';
 
 export function WPOrderReviewSection( { children, className } ) {
 	return <div className={ joinClasses( [ className, 'order-review-section' ] ) }>{ children }</div>;

--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.js
@@ -393,11 +393,18 @@ function returnModalCopy(
 	switch ( productType ) {
 		case 'plan with dependencies':
 			modalCopy.title = translate( 'You are about to remove your plan from the cart' );
-			modalCopy.description = createUserAndSiteBeforeTransaction
-				? 'When you press Continue, we will remove your plan from the cart. Your site will be created on the free plan when you complete payment for the other product(s) in your cart.'
+
+			if ( createUserAndSiteBeforeTransaction ) {
+				modalCopy.description = 'When you press Continue, we will remove your plan from the cart. Your site will be created on the free plan when you complete payment for the other product(s) in your cart.'	
+			} else {
+				modalCopy.description = isPwpoUser
+				? translate(
+						'When you press Continue, we will remove your plan from the cart and your site will continue to run with its current plan.'
+				  )
 				: translate(
 						'When you press Continue, we will remove your plan from the cart and your site will continue to run with its current plan. Since your other product(s) depend on your plan to be purchased, they will also be removed from the cart and we will take you back to your site.'
 				  );
+			}
 			break;
 		case 'plan':
 			modalCopy.title = translate( 'You are about to remove your plan from the cart' );

--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.js
@@ -43,11 +43,15 @@ function WPLineItem( {
 	const itemSpanId = `checkout-line-item-${ item.id }`;
 	const deleteButtonId = `checkout-delete-button-${ item.id }`;
 	const [ isModalVisible, setIsModalVisible ] = useState( false );
+	const isPwpoUser = useSelector( ( state ) =>
+		currentUserHasFlag( state, NON_PRIMARY_DOMAINS_TO_FREE_USERS )
+	);
 	const modalCopy = returnModalCopy(
 		item.type,
 		translate,
 		hasDomainsInCart,
-		createUserAndSiteBeforeTransaction
+		createUserAndSiteBeforeTransaction,
+		isPwpoUser
 	);
 	const onEvent = useEvents();
 	const isDisabled = formStatus !== 'ready';
@@ -388,7 +392,8 @@ function returnModalCopy(
 	product,
 	translate,
 	hasDomainsInCart,
-	createUserAndSiteBeforeTransaction
+	createUserAndSiteBeforeTransaction,
+	isPwpoUser
 ) {
 	const modalCopy = {};
 	const productType = product === 'plan' && hasDomainsInCart ? 'plan with dependencies' : product;
@@ -398,15 +403,16 @@ function returnModalCopy(
 			modalCopy.title = translate( 'You are about to remove your plan from the cart' );
 
 			if ( createUserAndSiteBeforeTransaction ) {
-				modalCopy.description = 'When you press Continue, we will remove your plan from the cart. Your site will be created on the free plan when you complete payment for the other product(s) in your cart.'	
+				modalCopy.description =
+					'When you press Continue, we will remove your plan from the cart. Your site will be created on the free plan when you complete payment for the other product(s) in your cart.';
 			} else {
 				modalCopy.description = isPwpoUser
-				? translate(
-						'When you press Continue, we will remove your plan from the cart and your site will continue to run with its current plan.'
-				  )
-				: translate(
-						'When you press Continue, we will remove your plan from the cart and your site will continue to run with its current plan. Since your other product(s) depend on your plan to be purchased, they will also be removed from the cart and we will take you back to your site.'
-				  );
+					? translate(
+							'When you press Continue, we will remove your plan from the cart and your site will continue to run with its current plan.'
+					  )
+					: translate(
+							'When you press Continue, we will remove your plan from the cart and your site will continue to run with its current plan. Since your other product(s) depend on your plan to be purchased, they will also be removed from the cart and we will take you back to your site.'
+					  );
 			}
 			break;
 		case 'plan':

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -573,7 +573,6 @@ export default function CompositeCheckout( {
 						isLoggedOutCart={ isLoggedOutCart }
 						createUserAndSiteBeforeTransaction={ createUserAndSiteBeforeTransaction }
 						infoMessage={ infoMessage }
-						isPwpoUser={ isPwpoUser }
 					/>
 				</CheckoutProvider>
 			</CartProvider>

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -573,6 +573,7 @@ export default function CompositeCheckout( {
 						isLoggedOutCart={ isLoggedOutCart }
 						createUserAndSiteBeforeTransaction={ createUserAndSiteBeforeTransaction }
 						infoMessage={ infoMessage }
+						isPwpoUser={ isPwpoUser }
 					/>
 				</CheckoutProvider>
 			</CartProvider>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* When you have a plan and domain in cart, and then try to remove the plan item, the following message is shown:

```
When you press Continue, we will remove your plan from the cart and your site will continue to run with its current plan. Since your other product(s) depend on your plan to be purchased, they will also be removed from the cart and we will take you back to your site.
```

<img width="450" alt="Screenshot 2020-08-04 at 8 54 45 PM" src="https://user-images.githubusercontent.com/1269602/89312314-c19cbd00-d694-11ea-8205-96513e54bc4d.png">


This messaging is not entirely correct, because PWPO users can remove the plan and still purchase only a domain. Also, removing the plan will not remove the domain item from cart and also does not redirect back to site.

* This PR checks if the user has PWPO flag enabled, and then removes the incorrect lines from the messaging. So now, the modal copy will look like this:

<img width="997" alt="Screenshot 2020-08-04 at 8 52 29 PM" src="https://user-images.githubusercontent.com/1269602/89312072-6ff43280-d694-11ea-83f5-7cda670aee04.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On a free plan site, add a domain and plan to cart and proceed to checkout (in US/USD so that the new checkout is seen).
* Click "Edit" on the order, and then the trash icon on the plan item. Verify that the message is as shown in the screenshot in the PR description.
