### PR TITLE
Modifies the domain-only nux flow for all domains

### DIFF
--- a/client/my-sites/domains/domain-management/list/list-all.jsx
+++ b/client/my-sites/domains/domain-management/list/list-all.jsx
@@ -16,7 +16,6 @@ import config from 'config';
 import { Button } from '@automattic/components';
 import canCurrentUserForSites from 'state/selectors/can-current-user-for-sites';
 import { composeAnalytics, recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
-import { domainAddNew } from 'my-sites/domains/paths';
 import DocumentHead from 'components/data/document-head';
 import DomainItem from './domain-item';
 import ListHeader from './list-header';
@@ -62,7 +61,7 @@ class ListAll extends Component {
 
 	clickAddDomain = () => {
 		this.props.addDomainClick();
-		page( domainAddNew( '' ) );
+		page( '/start/add-domain' );
 	};
 
 	handleDomainItemClick = ( domain ) => {

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -298,7 +298,7 @@ export function generateFlows( {
 		destination: getThankYouNoSiteDestination,
 		description: 'An experimental approach for WordPress.com/domains',
 		disallowResume: true,
-		lastModified: '2019-06-21',
+		lastModified: '2020-07-27',
 	};
 
 	flows[ 'site-selected' ] = {

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -286,6 +286,21 @@ export function generateFlows( {
 		lastModified: '2019-06-21',
 	};
 
+	flows[ 'add-domain' ] = {
+		steps: [
+			'domain-only',
+			'site-or-domain',
+			'site-picker',
+			'themes',
+			'plans-site-selected',
+			'user',
+		],
+		destination: getThankYouNoSiteDestination,
+		description: 'An experimental approach for WordPress.com/domains',
+		disallowResume: true,
+		lastModified: '2019-06-21',
+	};
+
 	flows[ 'site-selected' ] = {
 		steps: [ 'themes-site-selected', 'plans-site-selected' ],
 		destination: getSiteDestination,

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -15,7 +15,6 @@ export function generateFlows( {
 	getRedirectDestination = noop,
 	getSignupDestination = noop,
 	getLaunchDestination = noop,
-	getThankYouSiteDestination = noop,
 	getThankYouNoSiteDestination = noop,
 	getChecklistThemeDestination = noop,
 } = {} ) {
@@ -296,7 +295,7 @@ export function generateFlows( {
 			'plans-site-selected',
 			'user',
 		],
-		destination: getThankYouSiteDestination,
+		destination: getThankYouNoSiteDestination,
 		description: 'An approach to add a domain via the all domains view',
 		disallowResume: true,
 		lastModified: '2020-07-30',

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -15,6 +15,7 @@ export function generateFlows( {
 	getRedirectDestination = noop,
 	getSignupDestination = noop,
 	getLaunchDestination = noop,
+	getThankYouSiteDestination = noop,
 	getThankYouNoSiteDestination = noop,
 	getChecklistThemeDestination = noop,
 } = {} ) {
@@ -288,17 +289,17 @@ export function generateFlows( {
 
 	flows[ 'add-domain' ] = {
 		steps: [
-			'domain-only',
+			'select-domain',
 			'site-or-domain',
 			'site-picker',
 			'themes',
 			'plans-site-selected',
 			'user',
 		],
-		destination: getThankYouNoSiteDestination,
-		description: 'An experimental approach for WordPress.com/domains',
+		destination: getThankYouSiteDestination,
+		description: 'An approach to add a domain via the all domains view',
 		disallowResume: true,
-		lastModified: '2020-07-27',
+		lastModified: '2020-07-30',
 	};
 
 	flows[ 'site-selected' ] = {

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -76,6 +76,10 @@ function getThankYouNoSiteDestination() {
 	return `/checkout/thank-you/no-site`;
 }
 
+function getThankYouSiteDestination( dependencies ) {
+	return `/checkout/thank-you/${ dependencies.siteSlug }/${ dependencies.siteSlug }`;
+}
+
 function getChecklistThemeDestination( dependencies ) {
 	return `/home/${ dependencies.siteSlug }`;
 }
@@ -92,6 +96,7 @@ const flows = generateFlows( {
 	getThankYouNoSiteDestination,
 	getChecklistThemeDestination,
 	getEditorDestination,
+	getThankYouSiteDestination,
 } );
 
 function removeUserStepFromFlow( flow ) {

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -76,10 +76,6 @@ function getThankYouNoSiteDestination() {
 	return `/checkout/thank-you/no-site`;
 }
 
-function getThankYouSiteDestination( dependencies ) {
-	return `/checkout/thank-you/${ dependencies.siteSlug }/${ dependencies.siteSlug }`;
-}
-
 function getChecklistThemeDestination( dependencies ) {
 	return `/home/${ dependencies.siteSlug }`;
 }
@@ -96,7 +92,6 @@ const flows = generateFlows( {
 	getThankYouNoSiteDestination,
 	getChecklistThemeDestination,
 	getEditorDestination,
-	getThankYouSiteDestination,
 } );
 
 function removeUserStepFromFlow( flow ) {

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -31,6 +31,7 @@ const stepNameToModuleName = {
 	'plans-premium': 'plans',
 	'plans-site-selected': 'plans',
 	'plans-store-nux': 'plans-atomic-store',
+	'select-domain': 'domains',
 	site: 'site',
 	'rebrand-cities-welcome': 'rebrand-cities-welcome',
 	'rewind-migrate': 'rewind-migrate',

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -331,6 +331,16 @@ export function generateSteps( {
 			},
 		},
 
+		'select-domain': {
+			stepName: 'select-domain',
+			providesDependencies: [ 'siteId', 'siteSlug', 'domainItem', 'receiptId' ],
+			props: {
+				isAllDomains: true,
+				isDomainOnly: true,
+				shouldShowDomainTestCopy: false,
+			},
+		},
+
 		'domains-store': {
 			stepName: 'domains',
 			apiRequestFunction: createSiteWithCart,

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -333,7 +333,7 @@ export function generateSteps( {
 
 		'select-domain': {
 			stepName: 'select-domain',
-			providesDependencies: [ 'siteId', 'siteSlug', 'domainItem', 'receiptId' ],
+			providesDependencies: [ 'siteId', 'siteSlug', 'domainItem' ],
 			props: {
 				isAllDomains: true,
 				isDomainOnly: true,

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -577,7 +577,7 @@ class DomainsStep extends React.Component {
 		const { flowName, isAllDomains, siteType, translate } = this.props;
 
 		if ( isAllDomains ) {
-			return translate( 'Enter a name or keyword to get started.' );
+			return translate( 'Find the domain that defines you' );
 		}
 
 		const subHeaderPropertyName = this.isEligibleVariantForDomainTest()
@@ -601,7 +601,7 @@ class DomainsStep extends React.Component {
 		const { headerText, isAllDomains, siteType, translate } = this.props;
 
 		if ( isAllDomains ) {
-			return translate( 'Add a domain' );
+			return translate( 'Your next big idea starts here' );
 		}
 
 		const headerPropertyName = this.isEligibleVariantForDomainTest()

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -31,6 +31,7 @@ import {
 	recordAddDomainButtonClickInUseYourDomain,
 } from 'state/domains/actions';
 import { composeAnalytics, recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
+import { domainManagementRoot } from 'my-sites/domains/paths';
 import Notice from 'components/notice';
 import { getDesignType } from 'state/signup/steps/design-type/selectors';
 import { setDesignType } from 'state/signup/steps/design-type/actions';
@@ -573,7 +574,12 @@ class DomainsStep extends React.Component {
 	};
 
 	getSubHeaderText() {
-		const { flowName, siteType, translate } = this.props;
+		const { flowName, isAllDomains, siteType, translate } = this.props;
+
+		if ( isAllDomains ) {
+			return translate( 'Enter a name or keyword to get started.' );
+		}
+
 		const subHeaderPropertyName = this.isEligibleVariantForDomainTest()
 			? 'domainsStepSubheaderTestCopy'
 			: 'domainsStepSubheader';
@@ -592,7 +598,12 @@ class DomainsStep extends React.Component {
 	}
 
 	getHeaderText() {
-		const { headerText, siteType } = this.props;
+		const { headerText, isAllDomains, siteType, translate } = this.props;
+
+		if ( isAllDomains ) {
+			return translate( 'Add a domain' );
+		}
+
 		const headerPropertyName = this.isEligibleVariantForDomainTest()
 			? 'domainsStepHeaderTestCopy'
 			: 'domainsStepHeader';
@@ -650,7 +661,7 @@ class DomainsStep extends React.Component {
 			return null;
 		}
 
-		const { flowName, translate, sites } = this.props;
+		const { flowName, isAllDomains, translate, sites } = this.props;
 		const hasSite = Object.keys( sites ).length > 0;
 		let backUrl, backLabelText;
 
@@ -666,6 +677,11 @@ class DomainsStep extends React.Component {
 		} else if ( 0 === this.props.positionInFlow && hasSite ) {
 			backUrl = '/sites/';
 			backLabelText = translate( 'Back to My Sites' );
+
+			if ( isAllDomains ) {
+				backUrl = domainManagementRoot();
+				backLabelText = translate( 'Back to All Domains' );
+			}
 		}
 
 		const headerText = this.getHeaderText();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Replaces the destination to `Add a domain` for the 'all domains' list with a modified NUX flow

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Click on the `Add a domain` button in the all domains list
* Verify that the NUX flow comes up to buy a domain and associates it to a site

