### PR TITLE
Remove mandatory domain step

### DIFF
--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -76,7 +76,6 @@ const Header: React.FunctionComponent = () => {
 		'IntentGathering',
 		'Domains',
 		'DomainsModal',
-		'Plans',
 		'LanguageModal',
 		'CreateSite',
 	].includes( currentStep );

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -6,7 +6,6 @@ import classnames from 'classnames';
 import { useI18n } from '@automattic/react-i18n';
 import { sprintf } from '@wordpress/i18n';
 import { useDebounce } from 'use-debounce';
-
 import { Icon, wordpress } from '@wordpress/icons';
 import { useSelect } from '@wordpress/data';
 
@@ -78,7 +77,6 @@ const Header: React.FunctionComponent = () => {
 		'Domains',
 		'DomainsModal',
 		'Plans',
-		'PlansModal',
 		'LanguageModal',
 		'CreateSite',
 	].includes( currentStep );

--- a/client/landing/gutenboarding/hooks/use-step-navigation.ts
+++ b/client/landing/gutenboarding/hooks/use-step-navigation.ts
@@ -27,14 +27,8 @@ export default function useStepNavigation(): { goBack: () => void; goNext: () =>
 	const makePath = usePath();
 	const history = useHistory();
 	const currentStep = useCurrentStep();
-	const siteTitle = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedSiteTitle() );
 	const { i18nLocale } = useI18n();
-	// If the user enters a site title on Intent Capture step we are showing Domains step next.
-	// Else, we're showing Domains step before Plans step.
-	let steps =
-		siteTitle?.length > 1
-			? [ Step.IntentGathering, Step.Domains, Step.DesignSelection, Step.Style, Step.Plans ]
-			: [ Step.IntentGathering, Step.DesignSelection, Step.Style, Step.Domains, Step.Plans ];
+	let steps = [ Step.IntentGathering, Step.DesignSelection, Step.Style, Step.Plans ];
 
 	// @TODO: move site creation to a separate hook or an action on the ONBOARD store
 	const currentUser = useSelect( ( select ) => select( USER_STORE ).getCurrentUser() );
@@ -47,14 +41,9 @@ export default function useStepNavigation(): { goBack: () => void; goNext: () =>
 			: onSignupDialogOpen();
 
 	// Logic necessary to skip Domains or Plans steps
-	const { domain, hasUsedDomainsStep, hasUsedPlansStep } = useSelect( ( select ) =>
-		select( ONBOARD_STORE ).getState()
-	);
+	const { hasUsedPlansStep } = useSelect( ( select ) => select( ONBOARD_STORE ).getState() );
 	const plan = useSelect( ( select ) => select( ONBOARD_STORE ).getPlan() );
 
-	if ( domain && ! hasUsedDomainsStep ) {
-		steps = steps.filter( ( step ) => step !== Step.Domains );
-	}
 	if ( plan && ! hasUsedPlansStep ) {
 		steps = steps.filter( ( step ) => step !== Step.Plans );
 	}

--- a/client/landing/gutenboarding/onboarding-block/domains/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/domains/index.tsx
@@ -49,7 +49,7 @@ const DomainsStep: React.FunctionComponent< Props > = ( { isModal } ) => {
 
 	React.useEffect( () => {
 		! isModal && setHasUsedDomainsStep( true );
-	}, [] );
+	}, [ isModal, setHasUsedDomainsStep ] );
 
 	// Keep a copy of the selected domain locally so it's available when the component is unmounting
 	const selectedDomainRef = React.useRef< string | undefined >();
@@ -85,12 +85,7 @@ const DomainsStep: React.FunctionComponent< Props > = ( { isModal } ) => {
 			</div>
 			<ActionButtons>
 				<BackButton onClick={ handleBack } />
-				{ ! isModal &&
-					( domain ? (
-						<NextButton onClick={ handleNext } />
-					) : (
-						<SkipButton onClick={ handleNext } />
-					) ) }
+				{ domain ? <NextButton onClick={ handleNext } /> : <SkipButton onClick={ handleNext } /> }
 			</ActionButtons>
 		</div>
 	);

--- a/client/package.json
+++ b/client/package.json
@@ -173,6 +173,7 @@
 		"tracekit": "^0.4.5",
 		"twemoji": "^12.1.4",
 		"url": "^0.11.0",
+		"use-debounce": "^3.4.3",
 		"use-subscription": "^1.3.0",
 		"utility-types": "^3.10.0",
 		"uuid": "^7.0.3",

--- a/test/e2e/specs/wp-gutenboarding-spec.js
+++ b/test/e2e/specs/wp-gutenboarding-spec.js
@@ -92,6 +92,11 @@ describe( 'Gutenboarding: (' + screenSize + ')', function () {
 			await designSelectorPage.selectPaidDesign();
 		} );
 
+		step( 'Can see Style Preview and continue', async function () {
+			const stylePreviewPage = await StylePreviewPage.Expect( driver );
+			await stylePreviewPage.continue();
+		} );
+
 		step( 'Can see Plans Grid with no selected plan', async function () {
 			const plansPage = await PlansPage.Expect( driver );
 			const hasSelectedPlan = await plansPage.hasSelectedPlan();

--- a/test/e2e/specs/wp-gutenboarding-spec.js
+++ b/test/e2e/specs/wp-gutenboarding-spec.js
@@ -12,7 +12,6 @@ import NewPage from '../lib/pages/gutenboarding/new-page.js';
 import AcquireIntentPage from '../lib/pages/gutenboarding/acquire-intent-page.js';
 import DesignSelectorPage from '../lib/pages/gutenboarding/design-selector-page.js';
 import StylePreviewPage from '../lib/pages/gutenboarding/style-preview-page.js';
-import DomainsPage from '../lib/pages/gutenboarding/domains-page.js';
 import PlansPage from '../lib/pages/gutenboarding/plans-page.js';
 
 import * as driverManager from '../lib/driver-manager.js';
@@ -50,11 +49,6 @@ describe( 'Gutenboarding: (' + screenSize + ')', function () {
 			await acquireIntentPage.goToNextStep();
 		} );
 
-		step( 'Can see Domains Page and skip selecting a domain', async function () {
-			const domainsPage = await DomainsPage.Expect( driver );
-			await domainsPage.skipStep();
-		} );
-
 		step( 'Can see Design Selector and select a random free design', async function () {
 			const designSelectorPage = await DesignSelectorPage.Expect( driver );
 			await designSelectorPage.selectFreeDesign();
@@ -82,7 +76,7 @@ describe( 'Gutenboarding: (' + screenSize + ')', function () {
 		} );
 	} );
 
-	describe( 'Skip first step in Gutenboarding, select paid design and see Domains page after Style preview @parallel', function () {
+	describe( 'Skip first step in Gutenboarding, select paid design and see Plans page after Style preview @parallel', function () {
 		before( async function () {
 			await driverManager.ensureNotLoggedIn( driver );
 			await NewPage.Visit( driver );
@@ -98,10 +92,10 @@ describe( 'Gutenboarding: (' + screenSize + ')', function () {
 			await designSelectorPage.selectPaidDesign();
 		} );
 
-		step( 'Can see Domains step after Style Preview step', async function () {
-			const stylePreviewPage = await StylePreviewPage.Expect( driver );
-			await stylePreviewPage.continue();
-			await DomainsPage.Expect( driver );
+		step( 'Can see Plans Grid with no selected plan', async function () {
+			const plansPage = await PlansPage.Expect( driver );
+			const hasSelectedPlan = await plansPage.hasSelectedPlan();
+			assert.strictEqual( hasSelectedPlan, false, 'There is a preselected plan' );
 		} );
 	} );
 } );

--- a/yarn.lock
+++ b/yarn.lock
@@ -27516,6 +27516,11 @@ use-debounce@^3.1.0:
   resolved "https://registry.yarnpkg.com/use-debounce/-/use-debounce-3.1.0.tgz#05a5c8cd3c2f309699f08961d7c8bbe7f68720bb"
   integrity sha512-DEf3L/ZKkOSTARk/DHlC6KAAJKwMqpck8Zx06SM2Wr+LfU1TzhO8hZRzB/qbpSQqREYWQes24n1q9doeTMqF4g==
 
+use-debounce@^3.4.3:
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/use-debounce/-/use-debounce-3.4.3.tgz#5df9322322b3f1b1c263d46413f9facf6d8b56ab"
+  integrity sha512-nxy+opOxDccWfhMl36J5BSCTpvcj89iaQk2OZWLAtBJQj7ISCtx1gh+rFbdjGfMl6vtCZf6gke/kYvrkVfHMoA==
+
 use-memo-one@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/use-memo-one/-/use-memo-one-1.1.1.tgz#39e6f08fe27e422a7d7b234b5f9056af313bd22c"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR removes the mandatory domain step from the onboarding flow. It also puts back the "Continue" CTA to the domain step when it's voluntarily asked for by the user (by clicking the nudge on top).

#### Testing instructions

Go to [/new](https://calypso.live/new?branch=remove/mandatory-domain-step) and you shouldn't be shown the domain step unless you click the nudge.

Fixes part of #44454