### PR TITLE
desktop: update terser

### DIFF
--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -63,30 +63,6 @@ const defaultBrowserslistEnv = isDesktop ? 'defaults' : 'evergreen';
 const browserslistEnv = process.env.BROWSERSLIST_ENV || defaultBrowserslistEnv;
 const extraPath = browserslistEnv === 'defaults' ? 'fallback' : browserslistEnv;
 
-const desktopTerserOpts = isDesktop
-	? {
-			parse: {
-				ecma: 8,
-			},
-			compress: {
-				ecma: 5,
-				warnings: false,
-				comparisons: false,
-				inline: 2,
-				drop_console: true,
-			},
-			output: {
-				ecma: 5,
-				comments: false,
-				ascii_only: true,
-			},
-			parallel: 2,
-			cache: true,
-			sourceMap: false,
-			extractComments: false,
-	  }
-	: {};
-
 function filterEntrypoints( entrypoints ) {
 	/* eslint-disable no-console */
 	if ( ! process.env.ENTRY_LIMIT ) {
@@ -201,7 +177,6 @@ const webpackConfig = {
 			sourceMap: Boolean( process.env.SOURCEMAP ),
 			terserOptions: {
 				mangle: ! isDesktop,
-				...desktopTerserOpts,
 			},
 		} ),
 	},

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -80,7 +80,7 @@ const desktopTerserOpts = isDesktop
 				comments: false,
 				ascii_only: true,
 			},
-			parallel: 1,
+			parallel: 2,
 			cache: true,
 			sourceMap: false,
 			extractComments: false,

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -63,6 +63,30 @@ const defaultBrowserslistEnv = isDesktop ? 'defaults' : 'evergreen';
 const browserslistEnv = process.env.BROWSERSLIST_ENV || defaultBrowserslistEnv;
 const extraPath = browserslistEnv === 'defaults' ? 'fallback' : browserslistEnv;
 
+const desktopTerserOpts = isDesktop
+	? {
+			parse: {
+				ecma: 8,
+			},
+			compress: {
+				ecma: 5,
+				warnings: false,
+				comparisons: false,
+				inline: 2,
+				drop_console: true,
+			},
+			output: {
+				ecma: 5,
+				comments: false,
+				ascii_only: true,
+			},
+			parallel: 2,
+			cache: true,
+			sourceMap: false,
+			extractComments: false,
+	  }
+	: {};
+
 function filterEntrypoints( entrypoints ) {
 	/* eslint-disable no-console */
 	if ( ! process.env.ENTRY_LIMIT ) {
@@ -177,6 +201,7 @@ const webpackConfig = {
 			sourceMap: Boolean( process.env.SOURCEMAP ),
 			terserOptions: {
 				mangle: ! isDesktop,
+				...desktopTerserOpts,
 			},
 		} ),
 	},

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -80,7 +80,7 @@ const desktopTerserOpts = isDesktop
 				comments: false,
 				ascii_only: true,
 			},
-			parallel: 2,
+			parallel: 1,
 			cache: true,
 			sourceMap: false,
 			extractComments: false,

--- a/package.json
+++ b/package.json
@@ -363,7 +363,7 @@
 		"stylelint": "^9.10.1",
 		"supertest": "^4.0.2",
 		"svgstore-cli": "^1.3.1",
-		"terser": "^4.6.13",
+		"terser": "5.0.0",
 		"ts-loader": "^6.2.1",
 		"typescript": "^3.9.7",
 		"vfile-message": "^2.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -26232,6 +26232,15 @@ terser-webpack-plugin@^3.0.3:
     terser "^4.8.0"
     webpack-sources "^1.4.3"
 
+terser@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.0.0.tgz#269640e4e92f15d628de1e5f01c4c61e1ba3d765"
+  integrity sha512-olH2DwGINoSuEpSGd+BsPuAQaA3OrHnHnFL/rDB2TVNc3srUbz/rq/j2BlF4zDXI+JqAvGr86bIm1R2cJgZ3FA==
+  dependencies:
+    commander "^2.20.0"
+    source-map "~0.6.1"
+    source-map-support "~0.5.12"
+
 terser@^4.1.2, terser@^4.4.3, terser@^4.6.13, terser@^4.6.3:
   version "4.6.13"
   resolved "https://registry.yarnpkg.com/terser/-/terser-4.6.13.tgz#e879a7364a5e0db52ba4891ecde007422c56a916"


### PR DESCRIPTION
### Description

Seems we're starting to see intermittent Terser failures again when attempting to build the desktop source:

```
$ check-npm-client && node ${NODE_ARGS:---max_old_space_size=8192} ./node_modules/webpack/bin/webpack.js --config client/webpack.config.js --display errors-only && yarn run build-languages-if-enabled

ERROR in async-load-design-blocks.js from Terser
Error: Call retries were exceeded
    at ChildProcessWorker.initialize (/home/circleci/wp-calypso/node_modules/jest-worker/build/workers/ChildProcessWorker.js:191:21)
    at ChildProcessWorker._onExit (/home/circleci/wp-calypso/node_modules/jest-worker/build/workers/ChildProcessWorker.js:268:12)
    at ChildProcess.emit (events.js:315:20)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:275:12)

ERROR in checkout.js from Terser
Error: Call retries were exceeded
    at ChildProcessWorker.initialize (/home/circleci/wp-calypso/node_modules/jest-worker/build/workers/ChildProcessWorker.js:191:21)
    at ChildProcessWorker._onExit (/home/circleci/wp-calypso/node_modules/jest-worker/build/workers/ChildProcessWorker.js:268:12)
    at ChildProcess.emit (events.js:315:20)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:275:12)

ERROR in entry-main.js from Terser
Error: Call retries were exceeded
```

Attempting to use some recommended config overrides mentioned in `https://github.com/facebook/create-react-app/issues/8320` (Unclear whether this is supposed to be used in tandem with craco (https://www.npmjs.com/package/@craco/craco))