### PR TITLE
Create AB experiment for the Offer Reset project

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -215,4 +215,13 @@ export default {
 		allowExistingUsers: true,
 		localeTargets: 'any',
 	},
+	offerResetFlow: {
+		datestamp: '20200804',
+		variations: {
+			showOfferResetFlow: 0,
+			control: 100,
+		},
+		defaultVariation: 'control',
+		allowExistingUsers: true,
+	},
 };

--- a/client/lib/abtest/getters.ts
+++ b/client/lib/abtest/getters.ts
@@ -1,0 +1,24 @@
+/**
+ * This file is meant to be used to create functions to get the state of an AB test.
+ * We want to avoid writing error-prone code like:
+ *
+ * ```
+ * if ( 'some-variant' === abtest( 'some-experiment' ) ) {
+ *    // do something
+ * }
+ * ```
+ */
+
+/**
+ * Internal dependencies
+ */
+import { abtest } from 'lib/abtest';
+
+/**
+ * Returns whether the Offer Reset AB experiment is active.
+ *
+ * @returns {boolean}  Whether the 'showOfferResetFlow' variant is active.
+ */
+export const shouldShowOfferResetFlow = () => {
+	return 'showOfferResetFlow' === abtest( 'offerResetFlow' );
+};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Introduce an AB experiment so we can develop and test things easily in every environment.

#### How to use
```
import { shouldShowOfferResetFlow } from 'lib/abtest/getters';

if ( shouldShowOfferResetFlow() ) {
	console.log( 'A/B showOfferResetFlow variant is running' );
}
```

#### Testing instructions

* Run this PR.
* Go to `http://calypso.localhost:3000/`.
* Check that on the bottom-right corner of the screen the experiment can be found.

<img src="https://user-images.githubusercontent.com/3418513/89319419-74015f80-d656-11ea-8af1-2798223a3021.png" width="600">

Fixes 1169247016322522-as-1187484764348889.