### PR TITLE
Premium Content: fix duplicate Connect To Stripe message

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/style.css
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/style.css
@@ -16,6 +16,12 @@
 	margin-bottom: 8px;
 }
 
+/* Hide Stripe nudge from Jetpack payments block */
+/* https://github.com/Automattic/wp-calypso/issues/44332 */
+.wp-block-premium-content-container .jetpack-block-nudge {
+	display: none;
+}
+
 /* Legacy Subscribe/Login buttons */
 
 .wp-block-premium-content-logged-out-view__buttons {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This pull request updates styling in the Editing Toolkit's premium content block to hide the "Connect to Stripe" nudge provided by Jetpack's payments block, since the PC block also has one and the user does not need to see two.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure your account is not connected to Stripe.
* Load the version of the full-site-editing plugin from this PR following one of the methods detailed in PCYsg-5Xx-p2.
* Create a new post or edit an existing one, and add a "Premium Content" block. 
* Verify that under the Edit view in the "Non-Subscriber View" section, the user is only presented with a single message indicating they should connect the account to Stripe.

Fixes #44332 
