### PR TITLE
Media: Use hasNextMediaPage selector

### DIFF
--- a/client/lib/media/list-store.js
+++ b/client/lib/media/list-store.js
@@ -109,10 +109,6 @@ function updateActiveQueryStatus( siteId, status ) {
 	assign( MediaListStore._activeQueries[ siteId ], status );
 }
 
-function getNextPageMetaFromResponse( response ) {
-	return response && response.meta && response.meta.next_page ? response.meta.next_page : null;
-}
-
 function isQuerySame( siteId, query ) {
 	if ( ! ( siteId in MediaListStore._activeQueries ) ) {
 		return false;
@@ -195,24 +191,12 @@ MediaListStore.getAll = function ( siteId ) {
 	}
 };
 
-MediaListStore.hasNextPage = function ( siteId ) {
-	return (
-		! ( siteId in MediaListStore._activeQueries ) ||
-		null !== MediaListStore._activeQueries[ siteId ].nextPageHandle
-	);
-};
-
 MediaListStore.dispatchToken = Dispatcher.register( function ( payload ) {
 	const action = payload.action;
 
 	Dispatcher.waitFor( [ MediaStore.dispatchToken ] );
 
 	switch ( action.type ) {
-		case 'CHANGE_MEDIA_SOURCE':
-			clearSite( action.siteId );
-			MediaListStore.emit( 'change' );
-			break;
-
 		case 'SET_MEDIA_QUERY':
 			if ( action.siteId && action.query ) {
 				updateActiveQuery( action.siteId, action.query );
@@ -260,7 +244,6 @@ MediaListStore.dispatchToken = Dispatcher.register( function ( payload ) {
 
 			updateActiveQueryStatus( action.siteId, {
 				isFetchingNextPage: false,
-				nextPageHandle: getNextPageMetaFromResponse( action.data ),
 			} );
 
 			if (

--- a/client/lib/media/store.js
+++ b/client/lib/media/store.js
@@ -75,11 +75,6 @@ function receivePage( siteId, items ) {
 	} );
 }
 
-function clearPointers( siteId ) {
-	MediaStore._pointers[ siteId ] = {};
-	MediaStore._media[ siteId ] = {};
-}
-
 MediaStore.get = function ( siteId, postId ) {
 	if ( ! ( siteId in MediaStore._media ) ) {
 		return;
@@ -104,11 +99,6 @@ MediaStore.dispatchToken = Dispatcher.register( function ( payload ) {
 	const action = payload.action;
 
 	switch ( action.type ) {
-		case 'CHANGE_MEDIA_SOURCE':
-			clearPointers( action.siteId );
-			MediaStore.emit( 'change' );
-			break;
-
 		case 'CREATE_MEDIA_ITEM':
 		case 'RECEIVE_MEDIA_ITEM':
 		case 'RECEIVE_MEDIA_ITEMS':

--- a/client/lib/media/test/list-store.js
+++ b/client/lib/media/test/list-store.js
@@ -200,24 +200,6 @@ describe( 'MediaListStore', () => {
 		} );
 	} );
 
-	describe( '#hasNextPage()', () => {
-		test( 'should return true if the previous response included next_page meta', () => {
-			dispatchReceiveMediaItems();
-
-			expect( MediaListStore.hasNextPage( DUMMY_SITE_ID ) ).to.be.ok;
-		} );
-
-		test( 'should return true if the site is unknown', () => {
-			expect( MediaListStore.hasNextPage( DUMMY_SITE_ID ) ).to.be.ok;
-		} );
-
-		test( 'should return false if the previous response did not include next_page meta', () => {
-			dispatchReceiveMediaItems( { data: { media: [] } } );
-
-			expect( MediaListStore.hasNextPage( DUMMY_SITE_ID ) ).to.not.be.ok;
-		} );
-	} );
-
 	describe( '#isItemMatchingQuery', () => {
 		let isItemMatchingQuery;
 

--- a/client/lib/media/test/store.js
+++ b/client/lib/media/test/store.js
@@ -117,10 +117,12 @@ describe( 'MediaStore', () => {
 			expect( MediaStore.dispatchToken ).to.be.a( 'string' );
 		} );
 
-		test( 'should emit a change event when receiving updates', ( done ) => {
-			MediaStore.once( 'change', done );
+		test( 'should emit a change event when receiving updates', () => {
+			return new Promise( ( done ) => {
+				MediaStore.once( 'change', done );
 
-			dispatchReceiveMediaItems();
+				dispatchReceiveMediaItems();
+			} );
 		} );
 
 		test( 'should blank an item when REMOVE_MEDIA_ITEM is dispatched', () => {
@@ -164,23 +166,6 @@ describe( 'MediaStore', () => {
 			expect( MediaStore.get( DUMMY_SITE_ID, DUMMY_MEDIA_ID ) ).to.eql( {
 				ID: DUMMY_MEDIA_ID,
 			} );
-		} );
-
-		test( 'should clear all pointers when CHANGE_MEDIA_SOURCE called', () => {
-			MediaStore._pointers = {
-				[ DUMMY_SITE_ID ]: {
-					[ DUMMY_MEDIA_ID + 1 ]: DUMMY_MEDIA_ID,
-				},
-			};
-
-			handler( {
-				action: {
-					type: 'CHANGE_MEDIA_SOURCE',
-					siteId: DUMMY_SITE_ID,
-				},
-			} );
-
-			expect( MediaStore._pointers[ DUMMY_SITE_ID ] ).to.eql( {} );
 		} );
 	} );
 } );

--- a/client/state/data-layer/wpcom/sites/media/index.js
+++ b/client/state/data-layer/wpcom/sites/media/index.js
@@ -118,6 +118,7 @@ export const requestMediaSuccess = ( { siteId, query }, data ) => ( dispatch, ge
 		dispatch( successMediaRequest( siteId, query ) );
 		return;
 	}
+
 	dispatch( receiveMedia( siteId, data.media, data.found, query ) );
 	dispatch( successMediaRequest( siteId, query ) );
 	dispatch( setNextPageHandle( siteId, data.meta ) );

--- a/client/state/media/reducer.js
+++ b/client/state/media/reducer.js
@@ -502,7 +502,7 @@ export const fetching = withoutPersistence( ( state = {}, action ) => {
 			return {
 				...state,
 				[ siteId ]: merge( {}, state[ siteId ], {
-					nextPageHandle: mediaRequestMeta?.next_page ?? null,
+					nextPageHandle: mediaRequestMeta?.next_page || null,
 				} ),
 			};
 		}
@@ -514,6 +514,7 @@ export const fetching = withoutPersistence( ( state = {}, action ) => {
 
 			if ( ! isEqual( query, state[ siteId ]?.query ) ) {
 				delete newState.nextPageHandle;
+				newState.nextPage = false;
 			}
 
 			return {

--- a/client/state/selectors/get-current-media-query.js
+++ b/client/state/selectors/get-current-media-query.js
@@ -1,0 +1,9 @@
+/**
+ * Retrieves the current query for media items for a given site.
+ *
+ * @param {object} state The redux state.
+ * @param {number} siteId The site to get the current media query for.
+ */
+export default function getCurrentMediaQuery( state, siteId ) {
+	return state.media.fetching[ siteId ]?.query ?? null;
+}

--- a/client/state/selectors/get-next-page-handle.js
+++ b/client/state/selectors/get-next-page-handle.js
@@ -10,5 +10,5 @@ import { get } from 'lodash';
  * @param {number} siteId The site ID
  */
 export default function getNextPageHandle( state, siteId ) {
-	return get( state.media.fetching, [ siteId, 'nextPageHandle' ], null );
+	return get( state.media.fetching, [ siteId, 'nextPageHandle' ] );
 }

--- a/client/state/selectors/get-next-page-query.js
+++ b/client/state/selectors/get-next-page-query.js
@@ -1,7 +1,13 @@
 /**
+ * External dependencies
+ */
+import { isString, isNumber } from 'lodash';
+
+/**
  * Internal dependencies
  */
 import getNextPageHandle from 'state/selectors/get-next-page-handle';
+import getCurrentMediaQuery from 'state/selectors/get-current-media-query';
 
 const DEFAULT_QUERY = Object.freeze( { number: 20 } );
 
@@ -16,11 +22,20 @@ export default function getNextPageQuery( state, siteId ) {
 		return DEFAULT_QUERY;
 	}
 
-	const currentQuery = state.media.fetching[ siteId ]?.query ?? null;
+	const currentQuery = getCurrentMediaQuery( state, siteId );
+
+	const pageHandle = getNextPageHandle( state, siteId );
+
+	if ( [ isString, isNumber ].some( ( pred ) => pred( pageHandle ) ) ) {
+		return {
+			...DEFAULT_QUERY,
+			...currentQuery,
+			page_handle: pageHandle,
+		};
+	}
 
 	return {
 		...DEFAULT_QUERY,
 		...currentQuery,
-		page_handle: getNextPageHandle( state, siteId ),
 	};
 }

--- a/client/state/selectors/has-next-media-page.js
+++ b/client/state/selectors/has-next-media-page.js
@@ -1,0 +1,20 @@
+/**
+ * Internal dependencies
+ */
+import getNextPageHandle from 'state/selectors/get-next-page-handle';
+
+export default function hasNextMediaPage( state, siteId ) {
+	if (
+		! ( siteId in state.media.fetching ) ||
+		! ( 'nextPageHandle' in state.media.fetching[ siteId ] )
+	) {
+		// in these cases then the next page handle has not yet been set,
+		// usually in the case of when the initial query has not yet returned,
+		// so we assume one exists
+		return true;
+	}
+
+	const nextPageHandle = getNextPageHandle( state, siteId );
+
+	return nextPageHandle !== null;
+}

--- a/client/state/selectors/test/get-next-page-handle.js
+++ b/client/state/selectors/test/get-next-page-handle.js
@@ -12,7 +12,7 @@ describe( 'getNextPageHandle', () => {
 		).toEqual( nextPageHandle );
 	} );
 
-	it( 'should return null when the handle does not exist', () => {
-		expect( getNextPageHandle( { media: { fetching: {} } }, siteId ) ).toBeNull();
+	it( 'should return undefined when the handle does not exist', () => {
+		expect( getNextPageHandle( { media: { fetching: {} } }, siteId ) ).toBeUndefined();
 	} );
 } );

--- a/client/state/selectors/test/get-next-page-query.js
+++ b/client/state/selectors/test/get-next-page-query.js
@@ -21,8 +21,8 @@ describe( 'getNextPageQuery', () => {
 	} );
 
 	// null represents when there is no next page
-	it.each( [ Symbol( 'next page handle' ), null ] )(
-		'should return the existing query with the next page handle',
+	it.each( [ 'the-next-page', 12345 ] )(
+		"should return the existing query with the next page's handle when the nextPageHandle is %s",
 		( nextPageHandle ) => {
 			const state = {
 				media: {

--- a/client/state/selectors/test/has-next-media-page.js
+++ b/client/state/selectors/test/has-next-media-page.js
@@ -1,0 +1,30 @@
+/**
+ * Internal dependencies
+ */
+import hasNextMediaPage from 'state/selectors/has-next-media-page';
+
+describe( 'hasNextMediaPage', () => {
+	const siteId = 23478323;
+
+	it.each( [ {}, { [ siteId ]: {} } ] )(
+		'should be true when the next page handle does not exist; fetching(%s)',
+		( fetching ) => {
+			expect( hasNextMediaPage( { media: { fetching } }, siteId ) ).toBe( true );
+		}
+	);
+
+	it.each( [ true, 'the-next-page', 323 ] )(
+		'should return true when the next page handle is %s',
+		( nextPageHandle ) => {
+			expect(
+				hasNextMediaPage( { media: { fetching: { [ siteId ]: { nextPageHandle } } } }, siteId )
+			).toBe( true );
+		}
+	);
+
+	it( 'should be false when the next page handle is null', () => {
+		expect(
+			hasNextMediaPage( { media: { fetching: { [ siteId ]: { nextPageHandle: null } } } }, siteId )
+		).toBe( false );
+	} );
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Replace usages of `MediaListStore.hasNextPage` with the `hasNextMediaPage` selector

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the media library with enough media items to scroll through multiple pages using site media, google photos, and pexels.
* Ensure that you can scroll to the final page (compare with staging) of each one.

Note: There is a bug with pexels where if you get to the last page (you can do this easily by searching "blue car" and there are only a handful of results if you scroll far enough) where the final placeholder will always exist. I think this is because we can't necessarily currently tell when there is no next page for pexels. This is present in production so not something introduced by these changes.

Part of https://github.com/Automattic/wp-calypso/issues/43663
