### PR TITLE
Adds root components for Offer Reset plan redesign pages

### DIFF
--- a/client/my-sites/plans-v2/README.md
+++ b/client/my-sites/plans-v2/README.md
@@ -1,0 +1,19 @@
+# Plans v2
+This is the React component that renders a newer iteration of the Plans selection screen. This includes multi-step options, including upsells.
+
+See: https://jetpackp2.wordpress.com/2020/03/31/jetpack-offer-reset/
+
+## Components
+There are three main components here:
+
+- **Selector.tsx**: This is where people can select what product they want to purchase. It is typically the first screen people see.
+- **Details.tsx**: This is where people choose the subtype of what product they want. For example: Jetpack Backup Daily or Real-time.
+- **Upsell.tsx**: This is where people are displayed an upsell if there's a product that goes well together.
+
+## Routes
+Routes can have a customizable root, but are by default as follows:
+
+- `/:duration?` - Selector, with optional billing cycle duration selected. Default is annual.
+- `/:product/details` - The details page _without_ the duration set. Used for marketing pages.
+- `/:product/:duration/details` - The details page.
+- `/:product/:duration/additions` - The upsell page.

--- a/client/my-sites/plans-v2/controller.tsx
+++ b/client/my-sites/plans-v2/controller.tsx
@@ -1,0 +1,42 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import SelectorPage from './selector';
+import DetailsPage from './details';
+import UpsellPage from './upsell';
+import { stringToDuration } from './utils';
+
+/**
+ * Type dependencies
+ */
+import type PageJS from 'page';
+
+export const productSelect = ( context: PageJS.Context, next: Function ) => {
+	const duration = stringToDuration( context.params.duration );
+	context.primary = <SelectorPage defaultDuration={ duration } />;
+	next();
+};
+
+export const productDetails = ( context: PageJS.Context, next: Function ) => {
+	const productType: string = context.params.product;
+	const duration = stringToDuration( context.params.duration );
+	context.primary = <DetailsPage productType={ productType } duration={ duration } />;
+	next();
+};
+
+export const productUpsell = ( context: PageJS.Context, next: Function ) => {
+	const productSlug: string = context.params.product;
+	const duration = stringToDuration( context.params.duration );
+	if ( ! duration ) {
+		// TODO: Determine what to do here. Throw an error? Redirect the user?
+		next();
+		return;
+	}
+	context.primary = <UpsellPage productSlug={ productSlug } duration={ duration } />;
+	next();
+};

--- a/client/my-sites/plans-v2/details.tsx
+++ b/client/my-sites/plans-v2/details.tsx
@@ -1,0 +1,22 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { DetailsPageProps } from './types';
+import { TERM_ANNUALLY } from 'lib/plans/constants';
+
+const DetailsPage = ( { duration, productType }: DetailsPageProps ) => {
+	const durationString = duration === TERM_ANNUALLY ? 'annual' : 'monthly';
+	return (
+		<div>
+			<h1>Hello this is the Details Page!</h1>
+			<p>{ `You are currently choosing between types of ${ productType } with a ${ durationString } duration.` }</p>
+		</div>
+	);
+};
+
+export default DetailsPage;

--- a/client/my-sites/plans-v2/index.ts
+++ b/client/my-sites/plans-v2/index.ts
@@ -1,0 +1,22 @@
+/**
+ * External dependencies
+ */
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+import { makeLayout, render as clientRender } from 'controller';
+import { siteSelection } from 'my-sites/controller';
+import { productSelect, productDetails, productUpsell } from './controller';
+
+const trackedPage = ( url: string, ...rest: PageJS.Callback[] ) => {
+	page( url, siteSelection, ...rest, makeLayout, clientRender );
+};
+
+export default function ( rootUrl: string, ...rest: PageJS.Callback[] ) {
+	trackedPage( `${ rootUrl }/:duration?`, productSelect, ...rest );
+	trackedPage( `${ rootUrl }/:product/details`, productDetails, ...rest );
+	trackedPage( `${ rootUrl }/:product/:duration/details`, productDetails, ...rest );
+	trackedPage( `${ rootUrl }/:product/:duration/additions`, productUpsell, ...rest );
+}

--- a/client/my-sites/plans-v2/selector.tsx
+++ b/client/my-sites/plans-v2/selector.tsx
@@ -1,0 +1,28 @@
+/**
+ * External dependencies
+ */
+import React, { useState } from 'react';
+import { Button } from '@automattic/components';
+
+/**
+ * Internal dependencies
+ */
+import { SelectorPageProps } from './types';
+import { TERM_ANNUALLY, TERM_MONTHLY } from 'lib/plans/constants';
+
+const SelectorPage = ( { defaultDuration = TERM_ANNUALLY }: SelectorPageProps ) => {
+	const [ currentDuration, setDuration ] = useState( defaultDuration );
+	const currentDurationString = currentDuration === TERM_ANNUALLY ? 'annual' : 'monthly';
+
+	const toggleDuration = () =>
+		setDuration( currentDuration === TERM_ANNUALLY ? TERM_MONTHLY : TERM_ANNUALLY );
+	return (
+		<div>
+			<h1>Hello this is the Selector Page!</h1>
+			<p>{ `You are currently looking at ${ currentDurationString } products` }</p>
+			<Button onClick={ toggleDuration }>Toggle duration</Button>
+		</div>
+	);
+};
+
+export default SelectorPage;

--- a/client/my-sites/plans-v2/types.ts
+++ b/client/my-sites/plans-v2/types.ts
@@ -1,0 +1,20 @@
+/**
+ * Internal dependencies
+ */
+import { TERM_ANNUALLY, TERM_MONTHLY } from 'lib/plans/constants';
+
+export type Duration = typeof TERM_ANNUALLY | typeof TERM_MONTHLY;
+
+export interface SelectorPageProps {
+	defaultDuration?: Duration;
+}
+
+export interface DetailsPageProps {
+	duration?: Duration;
+	productType: string;
+}
+
+export interface UpsellPageProps {
+	duration: Duration;
+	productSlug: string;
+}

--- a/client/my-sites/plans-v2/upsell.tsx
+++ b/client/my-sites/plans-v2/upsell.tsx
@@ -1,0 +1,22 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { UpsellPageProps } from './types';
+import { TERM_ANNUALLY } from 'lib/plans/constants';
+
+const UpsellPage = ( { duration, productSlug }: UpsellPageProps ) => {
+	const durationString = duration === TERM_ANNUALLY ? 'annual' : 'monthly';
+	return (
+		<div>
+			<h1>Hello this is the Upsell Page!</h1>
+			<p>{ `You are currently being offered to add another product onto ${ productSlug } with a ${ durationString } duration.` }</p>
+		</div>
+	);
+};
+
+export default UpsellPage;

--- a/client/my-sites/plans-v2/utils.ts
+++ b/client/my-sites/plans-v2/utils.ts
@@ -1,0 +1,19 @@
+/**
+ * Internal dependencies
+ */
+import { TERM_ANNUALLY, TERM_MONTHLY } from 'lib/plans/constants';
+
+/**
+ * Type dependencies
+ */
+import type { Duration } from './types';
+
+export function stringToDuration( duration?: string ): Duration | undefined {
+	if ( duration === undefined ) {
+		return undefined;
+	}
+	if ( duration !== 'annual' ) {
+		return TERM_ANNUALLY;
+	}
+	return TERM_MONTHLY;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a new folder where components can be wired together.
* Creates the following components: `SelectorPage`, `DetailsPage`, and `UpsellPage`.
* Provides helper function to add paths.
* Starts typing.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Review code- this isn't loaded anywhere yet. It is intended as a stub for future work.

Fixes 1169247016322522-as-1187480522520329.