### PR TITLE
Checkout: fix jetpack_search to wpcom_search mapping

### DIFF
--- a/client/my-sites/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout-system-decider.js
@@ -18,7 +18,7 @@ import OwnedProductNoticeContent from './checkout/owned-product-notice-content';
 import CompositeCheckout from './composite-checkout/composite-checkout';
 import { fetchStripeConfiguration } from './composite-checkout/payment-method-helpers';
 import { getPlanByPathSlug } from 'lib/plans';
-import { GROUP_JETPACK } from 'lib/plans/constants';
+import { GROUP_JETPACK, JETPACK_PLANS } from 'lib/plans/constants';
 import { JETPACK_PRODUCTS_LIST } from 'lib/products-values/constants';
 import { isJetpackBackup, isJetpackBackupSlug } from 'lib/products-values';
 import { StripeHookProvider } from 'lib/stripe';
@@ -264,10 +264,8 @@ function getCheckoutVariant(
 		'premium-2-years',
 	];
 	const jetpackPseudoSlugsToAllow = [
-		'jetpack_personal',
 		'jetpack-personal',
 		'jetpack-personal-monthly',
-		'jetpack_premium',
 		'premium-monthly',
 		'professional',
 		'professional-monthly',
@@ -276,6 +274,7 @@ function getCheckoutVariant(
 		pseudoSlugsToAllow = [
 			...pseudoSlugsToAllow,
 			...jetpackPseudoSlugsToAllow,
+			...JETPACK_PLANS,
 			...JETPACK_PRODUCTS_LIST,
 		];
 	}

--- a/client/my-sites/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout-system-decider.js
@@ -19,6 +19,7 @@ import CompositeCheckout from './composite-checkout/composite-checkout';
 import { fetchStripeConfiguration } from './composite-checkout/payment-method-helpers';
 import { getPlanByPathSlug } from 'lib/plans';
 import { GROUP_JETPACK } from 'lib/plans/constants';
+import { JETPACK_PRODUCTS_LIST } from 'lib/products-values/constants';
 import { isJetpackBackup, isJetpackBackupSlug } from 'lib/products-values';
 import { StripeHookProvider } from 'lib/stripe';
 import config from 'config';
@@ -263,25 +264,20 @@ function getCheckoutVariant(
 		'premium-2-years',
 	];
 	const jetpackPseudoSlugsToAllow = [
-		'jetpack_anti_spam',
-		'jetpack_antispam_monthly',
-		'jetpack_backup_daily',
-		'jetpack_backup_daily_monthly',
-		'jetpack_backup_realtime',
-		'jetpack_backup_realtime_monthly',
 		'jetpack_personal',
 		'jetpack-personal',
 		'jetpack-personal-monthly',
-		'jetpack_scan',
-		'jetpack_search',
-		'jetpack_search_monthly',
 		'jetpack_premium',
 		'premium-monthly',
 		'professional',
 		'professional-monthly',
 	];
 	if ( config( 'env_id' ) !== 'production' ) {
-		pseudoSlugsToAllow = [ ...pseudoSlugsToAllow, ...jetpackPseudoSlugsToAllow ];
+		pseudoSlugsToAllow = [
+			...pseudoSlugsToAllow,
+			...jetpackPseudoSlugsToAllow,
+			...JETPACK_PRODUCTS_LIST,
+		];
 	}
 	const slugPrefixesToAllow = [ 'domain-mapping:', 'theme:' ];
 	if (

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -34,6 +34,7 @@ import usePrepareProductsForCart, {
 import notices from 'notices';
 import { isJetpackSite } from 'state/sites/selectors';
 import isAtomicSite from 'state/selectors/is-site-automated-transfer';
+import isPrivateSite from 'state/selectors/is-private-site';
 import getContactDetailsCache from 'state/selectors/get-contact-details-cache';
 import {
 	requestContactDetailsCache,
@@ -130,6 +131,7 @@ export default function CompositeCheckout( {
 	const isJetpackNotAtomic = useSelector(
 		( state ) => isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId )
 	);
+	const isPrivate = useSelector( ( state ) => isPrivateSite( state, siteId ) );
 	const { stripe, stripeConfiguration, isStripeLoading, stripeLoadingError } = useStripe();
 	const isLoadingCartSynchronizer =
 		cart && ( ! cart.hasLoadedFromServer || cart.hasPendingServerUpdates );
@@ -184,6 +186,7 @@ export default function CompositeCheckout( {
 		product,
 		purchaseId,
 		isJetpackNotAtomic,
+		isPrivate,
 	} );
 
 	useFetchProductsIfNotLoaded();

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
@@ -172,6 +172,7 @@ describe( 'CompositeCheckout', () => {
 					],
 				},
 				sites: { items: {} },
+				siteSettings: { items: {} },
 				ui: { selectedSiteId: 123 },
 				productsList: {
 					items: {

--- a/client/my-sites/checkout/composite-checkout/use-prepare-product-for-cart.js
+++ b/client/my-sites/checkout/composite-checkout/use-prepare-product-for-cart.js
@@ -28,6 +28,7 @@ export default function usePrepareProductsForCart( {
 	product: productAlias,
 	purchaseId: originalPurchaseId,
 	isJetpackNotAtomic,
+	isPrivate,
 } ) {
 	const planSlug = useSelector( ( state ) =>
 		getUpgradePlanSlugFromPath( state, siteId, productAlias )
@@ -45,6 +46,7 @@ export default function usePrepareProductsForCart( {
 		planSlug,
 		setState,
 		isJetpackNotAtomic,
+		isPrivate,
 		originalPurchaseId,
 	} );
 	useAddRenewalItems( { originalPurchaseId, productAlias, setState } );
@@ -145,6 +147,7 @@ function useAddProductFromSlug( {
 	planSlug,
 	setState,
 	isJetpackNotAtomic,
+	isPrivate,
 	originalPurchaseId,
 } ) {
 	const isFetchingPlans = useSelector( ( state ) => isRequestingPlans( state ) );
@@ -185,6 +188,7 @@ function useAddProductFromSlug( {
 			productAlias,
 			product_id: product.product_id,
 			isJetpackNotAtomic,
+			isPrivate,
 		} );
 		if ( ! cartProduct ) {
 			debug( 'there is a request to add a product but creating an item failed', productAlias );


### PR DESCRIPTION
When a `jetpack_search` product is added to the cart,[ legacy Checkout maps the product to either `jetpack_` or `wpcom_` depending on the selected site](https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/checkout/checkout/index.jsx#L318-L337). This does the same for the new Checkout flow.

**To test:**
- add Jetpack search to a simple site: `calypso.localhost:3000/checkout/[simple site]/jetpack_search_monthly`
- verify that composite checkout loads with the monthly search product
- empty the cart and add Jetpack search (yearly) to a simple site: `calypso.localhost:3000/checkout/[simple site]/jetpack_search`
- verify that composite checkout loads with the yearly search product
- repeat with a Jetpack site: `calypso.localhost:3000/checkout/[jetpack site]/jetpack_search_monthly`
- verify that composite checkout loads with the monthly search product
- empty the cart and add Jetpack search (yearly) to a Jetpack site: `calypso.localhost:3000/checkout/[jetpack site]/jetpack_search`
- verify that composite checkout loads with the yearly search product