### PR TITLE
Jetpack Backup: Refactor ActionButtons, add test coverage

### DIFF
--- a/client/components/jetpack/daily-backup-status/action-buttons.jsx
+++ b/client/components/jetpack/daily-backup-status/action-buttons.jsx
@@ -28,8 +28,8 @@ const DownloadButton = ( { disabled, rewindId } ) => {
 	const tracks = useDispatch( recordTracksEvent );
 	const siteSlug = useSelector( getSelectedSiteSlug );
 
-	const href = ! disabled && backupDownloadPath( siteSlug, rewindId );
-	const onClick = ( event ) => {
+	const href = disabled ? undefined : backupDownloadPath( siteSlug, rewindId );
+	const onDownload = ( event ) => {
 		event.preventDefault();
 		if ( disabled ) {
 			return;
@@ -44,7 +44,7 @@ const DownloadButton = ( { disabled, rewindId } ) => {
 			className="daily-backup-status__download-button"
 			disabled={ disabled }
 			href={ href }
-			onClick={ onClick }
+			onClick={ onDownload }
 		>
 			{ translate( 'Download backup' ) }
 		</Button>
@@ -62,8 +62,8 @@ const RestoreButton = ( { disabled, rewindId } ) => {
 	);
 
 	const canRestore = ! disabled && ! needsCredentials;
-	const href = canRestore && backupRestorePath( siteSlug, rewindId );
-	const onClick = ( event ) => {
+	const href = canRestore ? backupRestorePath( siteSlug, rewindId ) : undefined;
+	const onRestore = ( event ) => {
 		event.preventDefault();
 		if ( ! canRestore ) {
 			return;
@@ -78,7 +78,7 @@ const RestoreButton = ( { disabled, rewindId } ) => {
 			className="daily-backup-status__restore-button"
 			disabled={ ! canRestore }
 			href={ href }
-			onClick={ onClick }
+			onClick={ onRestore }
 		>
 			<div className="daily-backup-status__restore-button-icon">
 				{ needsCredentials && <img src={ missingCredentialsIcon } alt="" role="presentation" /> }
@@ -93,7 +93,7 @@ const MissingCredentials = () => {
 	const tracks = useDispatch( recordTracksEvent );
 	const siteSlug = useSelector( getSelectedSiteSlug );
 
-	const onClick = () => tracks( 'calypso_jetpack_backup_activate_click' );
+	const onActivateRestores = () => tracks( 'calypso_jetpack_backup_activate_click' );
 
 	return (
 		<div className="daily-backup-status__credentials-warning">
@@ -123,7 +123,7 @@ const MissingCredentials = () => {
 					isPrimary={ false }
 					className="daily-backup-status__activate-restores-button"
 					href={ settingsPath( siteSlug ) }
-					onClick={ onClick }
+					onClick={ onActivateRestores }
 				>
 					{ translate( 'Activate restores' ) }
 				</Button>

--- a/client/components/jetpack/daily-backup-status/action-buttons.jsx
+++ b/client/components/jetpack/daily-backup-status/action-buttons.jsx
@@ -1,0 +1,155 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useDispatch, useSelector } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { useTranslate } from 'i18n-calypso';
+import { settingsPath } from 'lib/jetpack/paths';
+import { backupDownloadPath, backupRestorePath } from 'my-sites/backup/paths';
+import { recordTracksEvent } from 'state/analytics/actions';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
+import getDoesRewindNeedCredentials from 'state/selectors/get-does-rewind-need-credentials';
+import Button from 'components/forms/form-button';
+import ExternalLink from 'components/external-link';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+import missingCredentialsIcon from './missing-credentials.svg';
+
+const DownloadButton = ( { disabled, rewindId } ) => {
+	const translate = useTranslate();
+	const tracks = useDispatch( recordTracksEvent );
+	const siteSlug = useSelector( getSelectedSiteSlug );
+
+	const href = ! disabled && backupDownloadPath( siteSlug, rewindId );
+	const onClick = ( event ) => {
+		event.preventDefault();
+		if ( disabled ) {
+			return;
+		}
+
+		tracks( 'calypso_jetpack_backup_download', { rewindId } );
+	};
+
+	return (
+		<Button
+			isPrimary={ false }
+			className="daily-backup-status__download-button"
+			disabled={ disabled }
+			href={ href }
+			onClick={ onClick }
+		>
+			{ translate( 'Download backup' ) }
+		</Button>
+	);
+};
+
+const RestoreButton = ( { disabled, rewindId } ) => {
+	const translate = useTranslate();
+	const tracks = useDispatch( recordTracksEvent );
+
+	const siteId = useSelector( getSelectedSiteId );
+	const siteSlug = useSelector( getSelectedSiteSlug );
+	const needsCredentials = useSelector( ( state ) =>
+		getDoesRewindNeedCredentials( state, siteId )
+	);
+
+	const canRestore = ! disabled && ! needsCredentials;
+	const href = canRestore && backupRestorePath( siteSlug, rewindId );
+	const onClick = ( event ) => {
+		event.preventDefault();
+		if ( ! canRestore ) {
+			return;
+		}
+
+		tracks( 'calypso_jetpack_backup_restore', { rewindId } );
+	};
+
+	return (
+		<Button
+			isPrimary
+			className="daily-backup-status__restore-button"
+			disabled={ ! canRestore }
+			href={ href }
+			onClick={ onClick }
+		>
+			<div className="daily-backup-status__restore-button-icon">
+				{ needsCredentials && <img src={ missingCredentialsIcon } alt="" role="presentation" /> }
+				<div>{ translate( 'Restore to this point' ) }</div>
+			</div>
+		</Button>
+	);
+};
+
+const MissingCredentials = () => {
+	const translate = useTranslate();
+	const tracks = useDispatch( recordTracksEvent );
+	const siteSlug = useSelector( getSelectedSiteSlug );
+
+	const onClick = () => tracks( 'calypso_jetpack_backup_activate_click' );
+
+	return (
+		<div className="daily-backup-status__credentials-warning">
+			<div className="daily-backup-status__credentials-warning-top">
+				<img src={ missingCredentialsIcon } alt="" role="presentation" />
+				<div>{ translate( 'Restore points have not been enabled for your account' ) }</div>
+			</div>
+
+			<div className="daily-backup-status__credentials-warning-bottom">
+				<div className="daily-backup-status__credentials-warning-text">
+					{ translate(
+						'A backup of your data has been made, but you must enter your server credentials to enable one-click restores. {{a}}Find your server credentials{{/a}}',
+						{
+							components: {
+								a: (
+									<ExternalLink
+										icon
+										href="https://jetpack.com/support/ssh-sftp-and-ftp-credentials/"
+										onClick={ () => {} }
+									/>
+								),
+							},
+						}
+					) }
+				</div>
+				<Button
+					isPrimary={ false }
+					className="daily-backup-status__activate-restores-button"
+					href={ settingsPath( siteSlug ) }
+					onClick={ onClick }
+				>
+					{ translate( 'Activate restores' ) }
+				</Button>
+			</div>
+		</div>
+	);
+};
+
+const ActionButtons = ( { rewindId, disabled } ) => {
+	const siteId = useSelector( getSelectedSiteId );
+	const hasCredentials = useSelector(
+		( state ) => ! getDoesRewindNeedCredentials( state, siteId )
+	);
+
+	return (
+		<>
+			<DownloadButton disabled={ disabled || ! rewindId } rewindId={ rewindId } />
+			<RestoreButton disabled={ disabled || ! rewindId } rewindId={ rewindId } />
+			{ ! hasCredentials && <MissingCredentials /> }
+		</>
+	);
+};
+
+ActionButtons.propTypes = {
+	rewindId: PropTypes.string,
+	disabled: PropTypes.bool,
+};
+
+export default ActionButtons;

--- a/client/components/jetpack/daily-backup-status/action-buttons.jsx
+++ b/client/components/jetpack/daily-backup-status/action-buttons.jsx
@@ -25,25 +25,19 @@ import missingCredentialsIcon from './missing-credentials.svg';
 
 const DownloadButton = ( { disabled, rewindId } ) => {
 	const translate = useTranslate();
-	const tracks = useDispatch( recordTracksEvent );
+	const dispatch = useDispatch();
 	const siteSlug = useSelector( getSelectedSiteSlug );
 
 	const href = disabled ? undefined : backupDownloadPath( siteSlug, rewindId );
-	const onDownload = ( event ) => {
-		event.preventDefault();
-		if ( disabled ) {
-			return;
-		}
-
-		tracks( 'calypso_jetpack_backup_download', { rewindId } );
-	};
+	const onDownload = () =>
+		dispatch( recordTracksEvent( 'calypso_jetpack_backup_download', { rewind_id: rewindId } ) );
 
 	return (
 		<Button
 			isPrimary={ false }
 			className="daily-backup-status__download-button"
-			disabled={ disabled }
 			href={ href }
+			disabled={ disabled }
 			onClick={ onDownload }
 		>
 			{ translate( 'Download backup' ) }
@@ -53,7 +47,7 @@ const DownloadButton = ( { disabled, rewindId } ) => {
 
 const RestoreButton = ( { disabled, rewindId } ) => {
 	const translate = useTranslate();
-	const tracks = useDispatch( recordTracksEvent );
+	const dispatch = useDispatch();
 
 	const siteId = useSelector( getSelectedSiteId );
 	const siteSlug = useSelector( getSelectedSiteSlug );
@@ -63,21 +57,15 @@ const RestoreButton = ( { disabled, rewindId } ) => {
 
 	const canRestore = ! disabled && ! needsCredentials;
 	const href = canRestore ? backupRestorePath( siteSlug, rewindId ) : undefined;
-	const onRestore = ( event ) => {
-		event.preventDefault();
-		if ( ! canRestore ) {
-			return;
-		}
-
-		tracks( 'calypso_jetpack_backup_restore', { rewindId } );
-	};
+	const onRestore = () =>
+		dispatch( recordTracksEvent( 'calypso_jetpack_backup_restore', { rewind_id: rewindId } ) );
 
 	return (
 		<Button
 			isPrimary
 			className="daily-backup-status__restore-button"
-			disabled={ ! canRestore }
 			href={ href }
+			disabled={ ! canRestore }
 			onClick={ onRestore }
 		>
 			<div className="daily-backup-status__restore-button-icon">
@@ -90,10 +78,11 @@ const RestoreButton = ( { disabled, rewindId } ) => {
 
 const MissingCredentials = () => {
 	const translate = useTranslate();
-	const tracks = useDispatch( recordTracksEvent );
+	const dispatch = useDispatch();
 	const siteSlug = useSelector( getSelectedSiteSlug );
 
-	const onActivateRestores = () => tracks( 'calypso_jetpack_backup_activate_click' );
+	const onActivateRestores = () =>
+		dispatch( recordTracksEvent( 'calypso_jetpack_backup_activate_click' ) );
 
 	return (
 		<div className="daily-backup-status__credentials-warning">

--- a/client/components/jetpack/daily-backup-status/index.jsx
+++ b/client/components/jetpack/daily-backup-status/index.jsx
@@ -2,33 +2,31 @@
  * External dependencies
  */
 import React, { Component } from 'react';
-import { localize, useTranslate } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { applySiteOffset } from 'lib/site/timezone';
-import { backupDownloadPath, backupRestorePath, backupMainPath } from 'my-sites/backup/paths';
+import { backupMainPath } from 'my-sites/backup/paths';
 import { Card } from '@automattic/components';
 import {
 	isSuccessfulDailyBackup,
 	isSuccessfulRealtimeBackup,
 	INDEX_FORMAT,
 } from 'lib/jetpack/backup-utils';
-import { settingsPath } from 'lib/jetpack/paths';
 import { withLocalizedMoment } from 'components/localized-moment';
 import ActivityCard from 'components/activity-card';
 import BackupChanges from './backup-changes';
 import Button from 'components/forms/form-button';
-import ExternalLink from 'components/external-link';
+import ActionButtons from './action-buttons';
 
 /**
  * Style dependencies
  */
 import './style.scss';
 import contactSupportUrl from 'lib/jetpack/contact-support-url';
-import missingCredentialsIcon from './missing-credentials.svg';
 import cloudErrorIcon from './icons/cloud-error.svg';
 import cloudWarningIcon from './icons/cloud-warning.svg';
 import cloudSuccessIcon from './icons/cloud-success.svg';
@@ -80,11 +78,7 @@ class DailyBackupStatus extends Component {
 
 	renderGoodBackup( backup ) {
 		const {
-			allowRestore,
-			dispatchRecordTracksEvent,
-			doesRewindNeedCredentials,
 			hasRealtimeBackups,
-			siteSlug,
 			deltas,
 			selectedDate,
 			// metaDiff,
@@ -125,13 +119,7 @@ class DailyBackupStatus extends Component {
 					<div className="daily-backup-status__title">{ displayDateNoLatest }</div>
 				</div>
 				<div className="daily-backup-status__meta">{ meta }</div>
-				<ActionButtons
-					rewindId={ backup.rewindId }
-					siteSlug={ siteSlug }
-					disabledRestore={ ! allowRestore }
-					doesRewindNeedCredentials={ doesRewindNeedCredentials }
-					dispatchRecordTracksEvent={ dispatchRecordTracksEvent }
-				/>
+				<ActionButtons rewindId={ backup.rewindId } />
 				{ showBackupDetails && this.renderBackupDetails( backup ) }
 				{ /*{ ! hasRealtimeBackups && <BackupChanges { ...{ deltas, metaDiff } } /> }*/ }
 				{ ! hasRealtimeBackups && <BackupChanges { ...{ deltas } } /> }
@@ -336,7 +324,7 @@ class DailyBackupStatus extends Component {
 						},
 					} ) }
 				</div>
-				<ActionButtons disabledDownload={ true } disabledRestore={ true } />
+				<ActionButtons disabled />
 			</>
 		);
 	}
@@ -398,93 +386,5 @@ class DailyBackupStatus extends Component {
 		);
 	}
 }
-
-const ActionButtons = ( {
-	disabledDownload,
-	disabledRestore,
-	dispatchRecordTracksEvent,
-	doesRewindNeedCredentials,
-	rewindId,
-	siteSlug,
-} ) => {
-	const translate = useTranslate();
-
-	return (
-		<>
-			<Button
-				className="daily-backup-status__download-button"
-				href={ backupDownloadPath( siteSlug, rewindId ) }
-				disabled={ disabledDownload }
-				isPrimary={ false }
-				onClick={ ( event ) => {
-					disabledDownload &&
-						event.preventDefault() &&
-						dispatchRecordTracksEvent( 'calypso_jetpack_backup_download', { rewindId } );
-				} }
-			>
-				{ translate( 'Download backup' ) }
-			</Button>
-			<Button
-				className="daily-backup-status__restore-button"
-				href={ backupRestorePath( siteSlug, rewindId ) }
-				disabled={ disabledRestore || doesRewindNeedCredentials }
-				onClick={ ( event ) => {
-					( disabledRestore || doesRewindNeedCredentials ) &&
-						event.preventDefault() &&
-						dispatchRecordTracksEvent( 'calypso_jetpack_backup_restore', { rewindId } );
-				} }
-			>
-				<div className="daily-backup-status__restore-button-icon">
-					{ doesRewindNeedCredentials && (
-						<img src={ missingCredentialsIcon } alt="" role="presentation" />
-					) }
-					<div>{ translate( 'Restore to this point' ) }</div>
-				</div>
-			</Button>
-			{ doesRewindNeedCredentials && (
-				<div className="daily-backup-status__credentials-warning">
-					<div className="daily-backup-status__credentials-warning-top">
-						<img src={ missingCredentialsIcon } alt="" role="presentation" />
-						<div>{ translate( 'Restore points have not been enabled for your account' ) }</div>
-					</div>
-
-					<div className="daily-backup-status__credentials-warning-bottom">
-						<div className="daily-backup-status__credentials-warning-text">
-							{ translate(
-								'A backup of your data has been made, but you must enter your server credentials to enable one-click restores. {{a}}Find your server credentials{{/a}}',
-								{
-									components: {
-										a: (
-											<ExternalLink
-												icon
-												href="https://jetpack.com/support/ssh-sftp-and-ftp-credentials/"
-												onClick={ () => {} }
-											/>
-										),
-									},
-								}
-							) }
-						</div>
-						<Button
-							className="daily-backup-status__activate-restores-button"
-							href={ settingsPath( siteSlug ) }
-							isPrimary={ false }
-							onClick={ () => {
-								dispatchRecordTracksEvent( 'calypso_jetpack_backup_activate_click' );
-							} }
-						>
-							{ translate( 'Activate restores' ) }
-						</Button>
-					</div>
-				</div>
-			) }
-		</>
-	);
-};
-ActionButtons.defaultProps = {
-	disabledDownload: false,
-	disabledRestore: false,
-	doesRewindNeedCredentials: false,
-};
 
 export default localize( withLocalizedMoment( DailyBackupStatus ) );

--- a/client/components/jetpack/daily-backup-status/index.jsx
+++ b/client/components/jetpack/daily-backup-status/index.jsx
@@ -86,11 +86,21 @@ class DailyBackupStatus extends Component {
 			hasRealtimeBackups,
 			siteSlug,
 			deltas,
+			selectedDate,
 			// metaDiff,
 			translate,
+			moment,
+			timezone,
+			gmtOffset,
 		} = this.props;
 		const displayDate = this.getDisplayDate( backup.activityTs );
 		const displayDateNoLatest = this.getDisplayDate( backup.activityTs, false );
+
+		const today = applySiteOffset( moment(), {
+			timezone: timezone,
+			gmtOffset: gmtOffset,
+		} );
+		const isToday = selectedDate.isSame( today, 'day' );
 
 		const meta = get( backup, 'activityDescription[2].children[0]', '' );
 
@@ -104,7 +114,9 @@ class DailyBackupStatus extends Component {
 			<>
 				<div className="daily-backup-status__message-head">
 					<img src={ cloudSuccessIcon } alt="" role="presentation" />
-					<div className="daily-backup-status__hide-mobile">{ translate( 'Latest backup' ) }</div>
+					<div className="daily-backup-status__hide-mobile">
+						{ isToday ? translate( 'Latest backup' ) : translate( 'Latest backup on this day' ) }
+					</div>
 				</div>
 				<div className="daily-backup-status__hide-desktop">
 					<div className="daily-backup-status__title">{ displayDate }</div>

--- a/client/components/jetpack/daily-backup-status/test/action-buttons.jsx
+++ b/client/components/jetpack/daily-backup-status/test/action-buttons.jsx
@@ -40,42 +40,45 @@ describe( 'ActionButtons', () => {
 
 	test( "disables all buttons when 'rewindId' is not provided", () => {
 		const wrapper = render( <ActionButtons /> );
+		const downloadButton = wrapper.find( '.daily-backup-status__download-button' ).hostNodes();
+		const restoreButton = wrapper.find( '.daily-backup-status__restore-button' ).hostNodes();
 
-		expect(
-			wrapper.find( 'button.daily-backup-status__download-button' ).prop( 'disabled' )
-		).toEqual( true );
+		expect( downloadButton.prop( 'disabled' ) ).toEqual( true );
+		expect( restoreButton.prop( 'disabled' ) ).toEqual( true );
 	} );
 
 	test( "disables all buttons when 'disabled' is true", () => {
 		const wrapper = render( <ActionButtons disabled rewindId="test" /> );
+		const downloadButton = wrapper.find( '.daily-backup-status__download-button' ).hostNodes();
+		const restoreButton = wrapper.find( '.daily-backup-status__restore-button' ).hostNodes();
 
-		expect(
-			wrapper.find( 'button.daily-backup-status__download-button' ).prop( 'disabled' )
-		).toEqual( true );
+		expect( downloadButton.prop( 'disabled' ) ).toEqual( true );
+		expect( restoreButton.prop( 'disabled' ) ).toEqual( true );
 	} );
 
 	test( "enables the download button when 'rewindId' is provided'", () => {
 		const wrapper = render( <ActionButtons rewindId="test" /> );
-		const downloadButton = wrapper.find( 'a.daily-backup-status__download-button' );
+		const downloadButton = wrapper.find( '.daily-backup-status__download-button' ).hostNodes();
 
 		expect( downloadButton.prop( 'href' ) ).toBeTruthy();
+		expect( downloadButton.prop( 'disabled' ) ).toBeFalsy();
 	} );
 
 	test( 'enables the restore button when credentials are not needed', () => {
 		getDoesRewindNeedCredentials.mockImplementation( () => false );
 
 		const wrapper = render( <ActionButtons rewindId="test" /> );
-		const restoreButton = wrapper.find( 'a.daily-backup-status__restore-button' );
+		const restoreButton = wrapper.find( '.daily-backup-status__restore-button' ).hostNodes();
 
-		expect( restoreButton.length ).toEqual( 1 );
 		expect( restoreButton.prop( 'href' ) ).toBeTruthy();
+		expect( restoreButton.prop( 'disabled' ) ).toBeFalsy();
 	} );
 
 	test( 'disables the restore button when credentials are needed', () => {
 		getDoesRewindNeedCredentials.mockImplementation( () => true );
 
 		const wrapper = render( <ActionButtons rewindId="test" /> );
-		const restoreButton = wrapper.find( 'button.daily-backup-status__restore-button' );
+		const restoreButton = wrapper.find( '.daily-backup-status__restore-button' ).hostNodes();
 
 		expect( restoreButton.prop( 'disabled' ) ).toEqual( true );
 	} );
@@ -84,9 +87,11 @@ describe( 'ActionButtons', () => {
 		getDoesRewindNeedCredentials.mockImplementation( () => true );
 
 		const wrapper = render( <ActionButtons rewindId="test" /> );
-		const activateButton = wrapper.find( 'a.daily-backup-status__activate-restores-button' );
+		const activateButton = wrapper
+			.find( '.daily-backup-status__activate-restores-button' )
+			.hostNodes();
 
-		expect( activateButton.length ).toEqual( 1 );
 		expect( activateButton.prop( 'href' ) ).toBeTruthy();
+		expect( activateButton.prop( 'disabled' ) ).toBeFalsy();
 	} );
 } );

--- a/client/components/jetpack/daily-backup-status/test/action-buttons.jsx
+++ b/client/components/jetpack/daily-backup-status/test/action-buttons.jsx
@@ -1,0 +1,92 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { Provider } from 'react-redux';
+import { mount } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import ActionButtons from '../action-buttons';
+
+/**
+ * Mocked dependencies
+ */
+jest.mock( 'state/ui/selectors' );
+import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
+
+jest.mock( 'state/selectors/get-does-rewind-need-credentials' );
+import getDoesRewindNeedCredentials from 'state/selectors/get-does-rewind-need-credentials';
+
+function render( component ) {
+	const store = {
+		getState: () => ( {} ),
+		subscribe: () => {},
+		dispatch: () => {},
+	};
+	return mount( <Provider store={ store }>{ component }</Provider> );
+}
+
+describe( 'ActionButtons', () => {
+	beforeAll( () => {
+		getSelectedSiteId.mockImplementation( () => 0 );
+		getSelectedSiteSlug.mockImplementation( () => '' );
+	} );
+
+	test( "disables all buttons when 'rewindId' is not provided", () => {
+		const wrapper = render( <ActionButtons /> );
+
+		expect(
+			wrapper.find( 'button.daily-backup-status__download-button' ).prop( 'disabled' )
+		).toEqual( true );
+	} );
+
+	test( "disables all buttons when 'disabled' is true", () => {
+		const wrapper = render( <ActionButtons disabled rewindId="test" /> );
+
+		expect(
+			wrapper.find( 'button.daily-backup-status__download-button' ).prop( 'disabled' )
+		).toEqual( true );
+	} );
+
+	test( "enables the download button when 'rewindId' is provided'", () => {
+		const wrapper = render( <ActionButtons rewindId="test" /> );
+		const downloadButton = wrapper.find( 'a.daily-backup-status__download-button' );
+
+		expect( downloadButton.prop( 'href' ) ).toBeTruthy();
+	} );
+
+	test( 'enables the restore button when credentials are not needed', () => {
+		getDoesRewindNeedCredentials.mockImplementation( () => false );
+
+		const wrapper = render( <ActionButtons rewindId="test" /> );
+		const restoreButton = wrapper.find( 'a.daily-backup-status__restore-button' );
+
+		expect( restoreButton.length ).toEqual( 1 );
+		expect( restoreButton.prop( 'href' ) ).toBeTruthy();
+	} );
+
+	test( 'disables the restore button when credentials are needed', () => {
+		getDoesRewindNeedCredentials.mockImplementation( () => true );
+
+		const wrapper = render( <ActionButtons rewindId="test" /> );
+		const restoreButton = wrapper.find( 'button.daily-backup-status__restore-button' );
+
+		expect( restoreButton.prop( 'disabled' ) ).toEqual( true );
+	} );
+
+	test( "shows 'Activate restores' prompt when credentials are needed", () => {
+		getDoesRewindNeedCredentials.mockImplementation( () => true );
+
+		const wrapper = render( <ActionButtons rewindId="test" /> );
+		const activateButton = wrapper.find( 'a.daily-backup-status__activate-restores-button' );
+
+		expect( activateButton.length ).toEqual( 1 );
+		expect( activateButton.prop( 'href' ) ).toBeTruthy();
+	} );
+} );

--- a/client/my-sites/backup/main.jsx
+++ b/client/my-sites/backup/main.jsx
@@ -200,7 +200,6 @@ class BackupsPage extends Component {
 
 							<DailyBackupStatus
 								{ ...{
-									allowRestore,
 									siteUrl,
 									siteSlug,
 									backup: lastBackup,
@@ -212,8 +211,6 @@ class BackupsPage extends Component {
 									onDateChange: this.onDateChange,
 									deltas,
 									// metaDiff, todo: commented because the non-english account issue
-									doesRewindNeedCredentials,
-									dispatchRecordTracksEvent,
 								} }
 							/>
 						</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

(Includes #44648.)

* Move `ActionButtons` from `DailyBackupStatus` into its own component file.
* Add unit tests to cover `ActionButtons`.
* Rely more on selectors than passed-in properties.
* Remove unused property references from `DailyBackupStatus`.

#### Testing instructions

* Run all tests and check that they pass (especially `client/components/jetpack/daily-backup-status/test`).
* Check that the `DailyBackupStatus` card -- specifically the action buttons at the bottom -- work as they do in production. Be sure to cover all possible states, including:
  * backup and restore both being available for a given date;
  * backups being unavailable on a given date; and
  * backup available on a given date but lack of credentials for Restores.
* When checking `DailyBackupStatus`, verify that:
  * all Tracks events still trigger; and
  * all links still work.

#### Reference screenshots

<img width="1162" alt="Screen Shot 2020-08-04 at 15 29 57" src="https://user-images.githubusercontent.com/670067/89341814-8041e880-d667-11ea-9eaa-03a2a52ffacd.png">
<img width="1164" alt="Screen Shot 2020-08-04 at 15 30 25" src="https://user-images.githubusercontent.com/670067/89341815-80da7f00-d667-11ea-978b-bd5b6698de13.png">
<img width="1163" alt="Screen Shot 2020-08-04 at 15 30 46" src="https://user-images.githubusercontent.com/670067/89341817-80da7f00-d667-11ea-8ba9-a0cf2d94b795.png">
