### PR TITLE
Loads new Offer Reset pages with A/B test set

### DIFF
--- a/client/my-sites/plans-v2/utils.ts
+++ b/client/my-sites/plans-v2/utils.ts
@@ -12,8 +12,8 @@ export function stringToDuration( duration?: string ): Duration | undefined {
 	if ( duration === undefined ) {
 		return undefined;
 	}
-	if ( duration !== 'annual' ) {
-		return TERM_ANNUALLY;
+	if ( duration === 'monthly' ) {
+		return TERM_MONTHLY;
 	}
-	return TERM_MONTHLY;
+	return TERM_ANNUALLY;
 }

--- a/client/my-sites/plans/index.js
+++ b/client/my-sites/plans/index.js
@@ -10,6 +10,8 @@ import { features, plans, redirectToCheckout, redirectToPlans } from './controll
 import { currentPlan } from './current-plan/controller';
 import { makeLayout, render as clientRender } from 'controller';
 import { navigation, siteSelection, sites } from 'my-sites/controller';
+import { shouldShowOfferResetFlow } from 'lib/abtest/getters';
+import plansV2 from 'my-sites/plans-v2';
 
 const trackedPage = ( url, ...rest ) => {
 	page( url, ...rest, makeLayout, clientRender );
@@ -17,6 +19,12 @@ const trackedPage = ( url, ...rest ) => {
 
 export default function () {
 	trackedPage( '/plans', siteSelection, sites );
+
+	// Load offer reset plans picker.
+	if ( shouldShowOfferResetFlow() ) {
+		plansV2( '/plans/:site', navigation );
+		return;
+	}
 	trackedPage( '/plans/compare', siteSelection, navigation, redirectToPlans );
 	trackedPage( '/plans/compare/:domain', siteSelection, navigation, redirectToPlans );
 	trackedPage( '/plans/features', siteSelection, navigation, redirectToPlans );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Loads the Offer Reset stub pages when the A/B test is correctly set.

Note: Ideally we'd find a way to dynamically load these pages to let Webpack properly code split. However, in the interest in time, this can be a future revision.

#### Screenshots
Note this is NOT supposed to follow mocks, this is an early implementation.

<img width="373" alt="Screen Shot 2020-08-04 at 4 34 58 PM" src="https://user-images.githubusercontent.com/1760168/89342485-db2c0d80-d670-11ea-9b5b-44cc30d1a66a.png">
<img width="367" alt="Screen Shot 2020-08-04 at 4 35 08 PM" src="https://user-images.githubusercontent.com/1760168/89342486-db2c0d80-d670-11ea-908f-414c469ee606.png">
<img width="651" alt="Screen Shot 2020-08-04 at 4 35 14 PM" src="https://user-images.githubusercontent.com/1760168/89342487-dbc4a400-d670-11ea-835e-3641ffc7f4f9.png">
<img width="774" alt="Screen Shot 2020-08-04 at 4 35 23 PM" src="https://user-images.githubusercontent.com/1760168/89342489-dbc4a400-d670-11ea-965d-1f4a6acba00a.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `/:site/plans` and verify old pages still appear.
* Set A/B test to `showOfferResetFlow`.
* Visit the following URLs:
 - `/:site/plans` - Plan picker page.
 - `/:site/plans/monthly` - Plan picker page with default duration of monthly.
 - `/:site/plans/jetpack_backup/annual/details` - Product details page (daily vs real-time, for example).
 - `/:site/plans/jetpack_backup/annual/additions` - Product upsell page.

Fixes 1169247016322522-as-1187530033739401.