### PR TITLE
Hides the `PlanNavigation` menu under a feature flag

### DIFF
--- a/client/my-sites/email/email-management/index.jsx
+++ b/client/my-sites/email/email-management/index.jsx
@@ -117,12 +117,16 @@ class EmailManagement extends React.Component {
 			);
 		}
 
-		return (
-			<PlansNavigation
-				cart={ cart }
-				path={ emailManagement( selectedSiteSlug, selectedDomainName ) }
-			/>
-		);
+		if ( ! config.isEnabled( 'manage/all-domains' ) ) {
+			return (
+				<PlansNavigation
+					cart={ cart }
+					path={ emailManagement( selectedSiteSlug, selectedDomainName ) }
+				/>
+			);
+		}
+
+		return null;
 	}
 
 	content() {

--- a/client/my-sites/email/email-management/index.jsx
+++ b/client/my-sites/email/email-management/index.jsx
@@ -33,10 +33,9 @@ import GSuiteUsersCard from 'my-sites/email/email-management/gsuite-users-card';
 import Placeholder from 'my-sites/email/email-management/gsuite-users-card/placeholder';
 import VerticalNav from 'components/vertical-nav';
 import VerticalNavItem from 'components/vertical-nav/item';
-import PlansNavigation from 'my-sites/plans/navigation';
 import EmptyContent from 'components/empty-content';
 import { domainManagementEdit, domainManagementList } from 'my-sites/domains/paths';
-import { emailManagement, emailManagementForwarding } from 'my-sites/email/paths';
+import { emailManagementForwarding } from 'my-sites/email/paths';
 import { getSelectedDomain, isMappedDomain, isMappedDomainWithWpcomNameservers } from 'lib/domains';
 import DocumentHead from 'components/data/document-head';
 import QueryEmailAccounts from 'components/data/query-email-accounts';
@@ -107,22 +106,13 @@ class EmailManagement extends React.Component {
 	}
 
 	headerOrPlansNavigation() {
-		const { cart, selectedSiteSlug, selectedDomainName, translate } = this.props;
+		const { selectedDomainName, translate } = this.props;
 
 		if ( selectedDomainName ) {
 			return (
 				<Header onClick={ this.goToEditOrList } selectedDomainName={ selectedDomainName }>
 					{ translate( 'Email' ) }
 				</Header>
-			);
-		}
-
-		if ( ! config.isEnabled( 'manage/all-domains' ) ) {
-			return (
-				<PlansNavigation
-					cart={ cart }
-					path={ emailManagement( selectedSiteSlug, selectedDomainName ) }
-				/>
 			);
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Hides the `PlanNavigation` menu under a feature flag

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to the `/email` page
* Confirm that the plan navigation menu is no longer visible


