### PR TITLE
Composite checkout: Do not run domain validation for GSuite

### DIFF
--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -130,7 +130,7 @@ export default function WPCheckout( {
 
 	const validateContactDetailsAndDisplayErrors = async () => {
 		debug( 'validating contact details with side effects' );
-		if ( shouldShowDomainContactFields ) {
+		if ( areThereDomainProductsInCart ) {
 			const validationResult = await getDomainValidationResult( items, contactInfo );
 			debug( 'validating contact details result', validationResult );
 			handleContactValidationResult( {
@@ -157,7 +157,7 @@ export default function WPCheckout( {
 	};
 	const validateContactDetails = async () => {
 		debug( 'validating contact details' );
-		if ( shouldShowDomainContactFields ) {
+		if ( areThereDomainProductsInCart ) {
 			const validationResult = await getDomainValidationResult( items, contactInfo );
 			debug( 'validating contact details result', validationResult );
 			return isContactValidationResponseValid( validationResult, contactInfo );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This fixes a regression introduced by https://github.com/Automattic/wp-calypso/pull/44533 which caused domain contact validation to be used for G Suite purchases, instead of G Suite validation.

#### Testing instructions

- Add a G Suite product to your cart for a domain you already own (the cart must not contain a domain for this to work).
- Visit checkout with your devtool network tab open.
- Verify that you see a network call to `https://public-api.wordpress.com/rest/v1.1/me/google-apps/validate` and that you do not see a network call to `https://public-api.wordpress.com/rest/v1.2/me/domain-contact-information/validate`.
