### PR TITLE
Checkout: Guard against nonexistent HashChangeEvent

### DIFF
--- a/client/my-sites/checkout/composite-checkout/wpcom/hooks/use-skip-to-last-step-if-form-complete.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/hooks/use-skip-to-last-step-if-form-complete.js
@@ -44,6 +44,13 @@ function saveStepNumberToUrl( stepNumber ) {
 	// composite-checkout uses to change its current step, so we must fire one
 	// manually. (HashChangeEvent is part of the web API so I'm not sure why
 	// eslint reports this as undefined.)
-	const event = new HashChangeEvent( 'hashchange' ); // eslint-disable-line no-undef
-	window.dispatchEvent( event );
+	//
+	// We use try/catch because we support IE11 and that browser does not include
+	// HashChange.
+	try {
+		const event = new HashChangeEvent( 'hashchange' ); // eslint-disable-line no-undef
+		window.dispatchEvent( event );
+	} catch ( error ) {
+		debug( 'hashchange firing failed' );
+	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In IE11, [HashChangeEvent](https://developer.mozilla.org/en-US/docs/Web/API/HashChangeEvent) does not exist. This adds a guard to prevent fatals if it does not exist.

#### Testing instructions

Using IE 11, visit checkout with pre-filled contact details. This will validate the details and cause the URL to change to add `#step2` at the end. Verify that there are no fatal errors (although the step will not actually change).