### PR TITLE
desktop: bump desktop source RAM with Linux machine executor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,6 @@ references:
     environment:
       CONFIG_ENV: release
       DETECT_CHROMEDRIVER_VERSION: 'false'
-      CHROMEDRIVER_FILEPATH: /usr/local/bin/chromedriver
       NODE_ARGS: --max_old_space_size=6144
 
   setup-results-and-artifacts: &setup-results-and-artifacts
@@ -658,6 +657,12 @@ jobs:
                 name: Ensure package.json Version And Tag Match
                 command: cd desktop/bin && node validate_tag.js $VERSION
       # - run: *update-node
+      - run:
+          name: Update Chromedriver
+          command: |
+            wget https://chromedriver.storage.googleapis.com/2.29/chromedriver_linux64.zip
+            unzip chromedriver_linux64.zip
+            sudo cp chromedriver /usr/local/bin/chromedriver
       - run:
           name: Install Node
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -658,16 +658,13 @@ jobs:
       - run:
           name: Install Node
           command: |
-            set +e
-            set +x
-            export NVM_DIR="/opt/circleci/.nvm"
-            [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+            ./desktop/bin/circle-refresh-nvm.sh
             nvm install
             nvm use
       - run:
           name: Install Dependencies
           command: |
-            sh desktop/bin/circle-refresh-nvm.sh
+            ./desktop/bin/circle-refresh-nvm.sh
             nvm use
             npm install -g yarn
 
@@ -684,7 +681,7 @@ jobs:
           name: Build Desktop Source
           no_output_timeout: 15m
           command: |
-            sh desktop/bin/circle-refresh-nvm.sh
+            ./desktop/bin/circle-refresh-nvm.sh
             nvm use
             yarn run build-desktop:source
       - save_cache: *desktop-save-source-cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ references:
     environment:
       CONFIG_ENV: release
       DETECT_CHROMEDRIVER_VERSION: 'false'
-      NODE_ARGS: --max_old_space_size=8192
+      NODE_ARGS: --max_old_space_size=6144
 
   setup-results-and-artifacts: &setup-results-and-artifacts
     name: Create Directories for Results and Artifacts
@@ -655,7 +655,12 @@ jobs:
             - run:
                 name: Ensure package.json Version And Tag Match
                 command: cd desktop/bin && node validate_tag.js $VERSION
-      - run: *update-node
+      - run:
+          name: Update Node
+          command: |
+            nvm install
+            nvm use
+            nvm alias default node
       - run: *yarn-install
       - restore_cache: *desktop-restore-source-cache
       - run: *desktop-decrypt-assets

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -647,7 +647,6 @@ jobs:
     <<: *desktop_machine_defaults
     environment:
       VERSION: << pipeline.git.tag >>
-    shell: /bin/bash --login
     steps:
       - checkout
       - when:
@@ -659,8 +658,6 @@ jobs:
       - run:
           name: Update Node
           command: |
-            export NVM_DIR="/opt/circleci/.nvm"
-            [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
             nvm install
             nvm use
             nvm alias default node

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -658,13 +658,16 @@ jobs:
       - run:
           name: Install Node
           command: |
-            ./desktop/bin/circle-refresh-nvm.sh
+            set +e
+            set +x
+            export NVM_DIR="/opt/circleci/.nvm"
+            [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
             nvm install
             nvm use
       - run:
           name: Install Dependencies
           command: |
-            ./desktop/bin/circle-refresh-nvm.sh
+            sh desktop/bin/circle-refresh-nvm.sh
             nvm use
             npm install -g yarn
 
@@ -681,7 +684,7 @@ jobs:
           name: Build Desktop Source
           no_output_timeout: 15m
           command: |
-            ./desktop/bin/circle-refresh-nvm.sh
+            sh desktop/bin/circle-refresh-nvm.sh
             nvm use
             yarn run build-desktop:source
       - save_cache: *desktop-save-source-cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -656,12 +656,6 @@ jobs:
                 name: Ensure package.json Version And Tag Match
                 command: cd desktop/bin && node validate_tag.js $VERSION
       - run:
-          name: Update Chromedriver
-          command: |
-            wget https://chromedriver.storage.googleapis.com/2.29/chromedriver_linux64.zip
-            unzip chromedriver_linux64.zip
-            sudo cp chromedriver /usr/local/bin/chromedriver
-      - run:
           name: Install Node
           command: |
             set +e
@@ -689,13 +683,12 @@ jobs:
           name: Build Desktop Source
           no_output_timeout: 15m
           command: |
-            # Cannot resolve pre-installed NVM_DIR on Linux machine executor:
-            # https://discuss.circleci.com/t/circleci-forgetting-node-version-on-machine-executor/28813
             set +e
             set +x
             export NVM_DIR="/opt/circleci/.nvm"
             [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
             nvm use
+
             yarn run build-desktop:source
       - save_cache: *desktop-save-source-cache
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,7 @@ references:
     environment:
       CONFIG_ENV: release
       DETECT_CHROMEDRIVER_VERSION: 'false'
+      CHROMEDRIVER_FILEPATH: /usr/local/bin/chromedriver
       NODE_ARGS: --max_old_space_size=6144
 
   setup-results-and-artifacts: &setup-results-and-artifacts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -655,21 +655,31 @@ jobs:
             - run:
                 name: Ensure package.json Version And Tag Match
                 command: cd desktop/bin && node validate_tag.js $VERSION
-      - run: *update-node
-      - run: *yarn-install
+      # - run: *update-node
+      - run:
+          command: |
+            export NVM_DIR="/opt/circleci/.nvm"
+            [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+            nvm use
+            npm install -g yarn
+            yarn install --frozen-lockfile
+      # - run: *yarn-install
       - restore_cache: *desktop-restore-source-cache
       - run: *desktop-decrypt-assets
       - run:
           name: Build Desktop Source
           no_output_timeout: 15m
           command: |
+            export NVM_DIR="/opt/circleci/.nvm"
+            [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+            nvm use
             yarn run build-desktop:source
       - save_cache: *desktop-save-source-cache
       - persist_to_workspace:
           root: /home/circleci/wp-calypso
           paths: *desktop-cache-paths
-      - run: *desktop-notify-github-failure
-      - slack/status: *desktop-notify-slack-failure
+      # - run: *desktop-notify-github-failure
+      # - slack/status: *desktop-notify-slack-failure
 
   wp-desktop-mac:
     macos:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -656,6 +656,12 @@ jobs:
                 name: Ensure package.json Version And Tag Match
                 command: cd desktop/bin && node validate_tag.js $VERSION
       - run:
+          name: Update Chromedriver
+          command: |
+            wget https://chromedriver.storage.googleapis.com/2.29/chromedriver_linux64.zip
+            unzip chromedriver_linux64.zip
+            sudo cp chromedriver /usr/local/bin/chromedriver
+      - run:
           name: Install Node
           command: |
             set +e
@@ -667,12 +673,11 @@ jobs:
       - run:
           name: Install Dependencies
           command: |
-            sh desktop/bin/circle-refresh-nvm.sh
+            export NVM_DIR="/opt/circleci/.nvm"
+            [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
             nvm use
             npm install -g yarn
 
-            # silence chromedriver installation/resolution errors
-            export CALYPSO_DOCTOR_SKIP=true
             yarn config set chromedriver_skip_download true
             yarn config set chromedriver_filepath '/usr/local/bin/chromedriver'
 
@@ -684,7 +689,12 @@ jobs:
           name: Build Desktop Source
           no_output_timeout: 15m
           command: |
-            sh desktop/bin/circle-refresh-nvm.sh
+            # Cannot resolve pre-installed NVM_DIR on Linux machine executor:
+            # https://discuss.circleci.com/t/circleci-forgetting-node-version-on-machine-executor/28813
+            set +e
+            set +x
+            export NVM_DIR="/opt/circleci/.nvm"
+            [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
             nvm use
             yarn run build-desktop:source
       - save_cache: *desktop-save-source-cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ references:
     environment:
       CONFIG_ENV: release
       DETECT_CHROMEDRIVER_VERSION: 'false'
-      NODE_ARGS: --max_old_space_size=3072
+      NODE_ARGS: --max_old_space_size=8192
 
   setup-results-and-artifacts: &setup-results-and-artifacts
     name: Create Directories for Results and Artifacts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,8 +31,6 @@ references:
     resource_class: medium
     environment:
       CONFIG_ENV: release
-      DETECT_CHROMEDRIVER_VERSION: 'false'
-      CHROMEDRIVER_FILEPATH: /usr/local/bin/chromedriver
       NODE_ARGS: --max_old_space_size=6144
 
   setup-results-and-artifacts: &setup-results-and-artifacts
@@ -657,7 +655,6 @@ jobs:
             - run:
                 name: Ensure package.json Version And Tag Match
                 command: cd desktop/bin && node validate_tag.js $VERSION
-      # - run: *update-node
       - run:
           name: Update Chromedriver
           command: |
@@ -680,6 +677,9 @@ jobs:
             [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
             nvm use
             npm install -g yarn
+
+            yarn config set chromedriver_filepath '/usr/local/bin/chromedriver'
+
             yarn install --frozen-lockfile
       # - run: *yarn-install
       - restore_cache: *desktop-restore-source-cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -694,8 +694,8 @@ jobs:
       - persist_to_workspace:
           root: /home/circleci/wp-calypso
           paths: *desktop-cache-paths
-      # - run: *desktop-notify-github-failure
-      # - slack/status: *desktop-notify-slack-failure
+      - run: *desktop-notify-github-failure
+      - slack/status: *desktop-notify-slack-failure
 
   wp-desktop-mac:
     macos:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -657,6 +657,7 @@ jobs:
                 command: cd desktop/bin && node validate_tag.js $VERSION
       # - run: *update-node
       - run:
+          name: Install Dependencies
           command: |
             export NVM_DIR="/opt/circleci/.nvm"
             [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -647,6 +647,7 @@ jobs:
     <<: *desktop_machine_defaults
     environment:
       VERSION: << pipeline.git.tag >>
+    shell: /bin/bash --login
     steps:
       - checkout
       - when:
@@ -658,6 +659,8 @@ jobs:
       - run:
           name: Update Node
           command: |
+            export NVM_DIR="/opt/circleci/.nvm"
+            [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
             nvm install
             nvm use
             nvm alias default node

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -663,6 +663,7 @@ jobs:
             set +x
             export NVM_DIR="/opt/circleci/.nvm"
             [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+            nvm install
             nvm use
             npm install -g yarn
             yarn install --frozen-lockfile

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,15 +23,16 @@ references:
       CONFIG_ENV: release
       DETECT_CHROMEDRIVER_VERSION: 'false'
       NODE_ARGS: --max_old_space_size=3072
-  desktop_machine_defaults: &desktop_machine_defaults
+  desktop_machine_executor_defaults: &desktop_machine_executor_defaults
     working_directory: ~/wp-calypso
+    # Use Linux machine executor, NOT docker image for higher available RAM (7.5GB)
     machine:
       image: ubuntu-1604:201903-01
     resource_class: medium
     environment:
       CONFIG_ENV: release
       DETECT_CHROMEDRIVER_VERSION: 'false'
-      NODE_ARGS: --max_old_space_size=8192
+      NODE_ARGS: --max_old_space_size=6144
 
   setup-results-and-artifacts: &setup-results-and-artifacts
     name: Create Directories for Results and Artifacts
@@ -644,7 +645,7 @@ jobs:
           webhook: << parameters.slack-webhook >>
 
   wp-desktop-source:
-    <<: *desktop_machine_defaults
+    <<: *desktop_machine_executor_defaults
     environment:
       VERSION: << pipeline.git.tag >>
     steps:
@@ -657,13 +658,19 @@ jobs:
                 command: cd desktop/bin && node validate_tag.js $VERSION
       # - run: *update-node
       - run:
-          name: Install Dependencies
+          name: Install Node
           command: |
             set +e
             set +x
             export NVM_DIR="/opt/circleci/.nvm"
             [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
             nvm install
+            nvm use
+      - run:
+          name: Install Dependencies
+          command: |
+            export NVM_DIR="/opt/circleci/.nvm"
+            [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
             nvm use
             npm install -g yarn
             yarn install --frozen-lockfile
@@ -674,6 +681,8 @@ jobs:
           name: Build Desktop Source
           no_output_timeout: 15m
           command: |
+            # Cannot resolve pre-installed NVM_DIR on Linux machine executor:
+            # https://discuss.circleci.com/t/circleci-forgetting-node-version-on-machine-executor/28813
             set +e
             set +x
             export NVM_DIR="/opt/circleci/.nvm"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -656,12 +656,6 @@ jobs:
                 name: Ensure package.json Version And Tag Match
                 command: cd desktop/bin && node validate_tag.js $VERSION
       - run:
-          name: Update Chromedriver
-          command: |
-            wget https://chromedriver.storage.googleapis.com/2.29/chromedriver_linux64.zip
-            unzip chromedriver_linux64.zip
-            sudo cp chromedriver /usr/local/bin/chromedriver
-      - run:
           name: Install Node
           command: |
             set +e
@@ -673,11 +667,12 @@ jobs:
       - run:
           name: Install Dependencies
           command: |
-            export NVM_DIR="/opt/circleci/.nvm"
-            [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+            sh desktop/bin/circle-refresh-nvm.sh
             nvm use
             npm install -g yarn
 
+            # silence chromedriver installation/resolution errors
+            export CALYPSO_DOCTOR_SKIP=true
             yarn config set chromedriver_skip_download true
             yarn config set chromedriver_filepath '/usr/local/bin/chromedriver'
 
@@ -689,12 +684,7 @@ jobs:
           name: Build Desktop Source
           no_output_timeout: 15m
           command: |
-            # Cannot resolve pre-installed NVM_DIR on Linux machine executor:
-            # https://discuss.circleci.com/t/circleci-forgetting-node-version-on-machine-executor/28813
-            set +e
-            set +x
-            export NVM_DIR="/opt/circleci/.nvm"
-            [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+            sh desktop/bin/circle-refresh-nvm.sh
             nvm use
             yarn run build-desktop:source
       - save_cache: *desktop-save-source-cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -678,6 +678,7 @@ jobs:
             nvm use
             npm install -g yarn
 
+            yarn config set chromedriver_skip_download true
             yarn config set chromedriver_filepath '/usr/local/bin/chromedriver'
 
             yarn install --frozen-lockfile

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ references:
     environment:
       CONFIG_ENV: release
       DETECT_CHROMEDRIVER_VERSION: 'false'
-      NODE_ARGS: --max_old_space_size=6144
+      NODE_ARGS: --max_old_space_size=8192
 
   setup-results-and-artifacts: &setup-results-and-artifacts
     name: Create Directories for Results and Artifacts
@@ -655,12 +655,7 @@ jobs:
             - run:
                 name: Ensure package.json Version And Tag Match
                 command: cd desktop/bin && node validate_tag.js $VERSION
-      - run:
-          name: Update Node
-          command: |
-            nvm install
-            nvm use
-            nvm alias default node
+      - run: *update-node
       - run: *yarn-install
       - restore_cache: *desktop-restore-source-cache
       - run: *desktop-decrypt-assets

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,10 +25,9 @@ references:
       NODE_ARGS: --max_old_space_size=3072
   desktop_machine_defaults: &desktop_machine_defaults
     working_directory: ~/wp-calypso
-    build:
-      machine:
-        image: ubuntu-1604:201903-01
-        resource_class: large
+    machine:
+      image: ubuntu-1604:201903-01
+    resource_class: large
     environment:
       CONFIG_ENV: release
       DETECT_CHROMEDRIVER_VERSION: 'false'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,16 @@ references:
       CONFIG_ENV: release
       DETECT_CHROMEDRIVER_VERSION: 'false'
       NODE_ARGS: --max_old_space_size=3072
+  desktop_machine_defaults: &desktop_machine_defaults
+    working_directory: ~/wp-calypso
+    build:
+      machine:
+        image: ubuntu-1604:201903-01
+        resource_class: large
+    environment:
+      CONFIG_ENV: release
+      DETECT_CHROMEDRIVER_VERSION: 'false'
+      NODE_ARGS: --max_old_space_size=3072
 
   setup-results-and-artifacts: &setup-results-and-artifacts
     name: Create Directories for Results and Artifacts
@@ -635,7 +645,7 @@ jobs:
           webhook: << parameters.slack-webhook >>
 
   wp-desktop-source:
-    <<: *desktop_defaults
+    <<: *desktop_machine_defaults
     environment:
       VERSION: << pipeline.git.tag >>
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ references:
     working_directory: ~/wp-calypso
     machine:
       image: ubuntu-1604:201903-01
-    resource_class: large
+    resource_class: medium
     environment:
       CONFIG_ENV: release
       DETECT_CHROMEDRIVER_VERSION: 'false'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -659,6 +659,8 @@ jobs:
       - run:
           name: Install Dependencies
           command: |
+            set +e
+            set +x
             export NVM_DIR="/opt/circleci/.nvm"
             [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
             nvm use
@@ -671,6 +673,8 @@ jobs:
           name: Build Desktop Source
           no_output_timeout: 15m
           command: |
+            set +e
+            set +x
             export NVM_DIR="/opt/circleci/.nvm"
             [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
             nvm use

--- a/desktop/bin/circle-refresh-nvm.sh
+++ b/desktop/bin/circle-refresh-nvm.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-# Resolve pre-installed NVM_DIR on Linux machine executor:
-# https://discuss.circleci.com/t/circleci-forgetting-node-version-on-machine-executor/28813
-
-set +e
-set +x
-export NVM_DIR="/opt/circleci/.nvm"
-[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"

--- a/desktop/bin/circle-refresh-nvm.sh
+++ b/desktop/bin/circle-refresh-nvm.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Resolve pre-installed NVM_DIR on Linux machine executor:
+# https://discuss.circleci.com/t/circleci-forgetting-node-version-on-machine-executor/28813
+
+set +e
+set +x
+export NVM_DIR="/opt/circleci/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"


### PR DESCRIPTION
### Description

This PR amends the `wp-desktop-source` job to use the Linux machine executor to take advantage of the higher available default RAM. In contrast to the default Docker image, the machine executor makes 7.5GB of RAM available instead of 4GB. 

Both types of resources use have 2 CPU cores available so hopefully should be comparable w.r.t base processing power (docs: [docker](https://circleci.com/docs/2.0/executor-types/#available-docker-resource-classes) vs [machine](https://circleci.com/docs/2.0/executor-types/#using-machine)). At this point it's unclear whether the machine instance is definitively faster/slower than docker (when docker works). Either way, the added stability might be worth making this change.

Note: As I've called out in a couple places, the machine executor is not without its very specific (and bizarre) quirks. For the most part we can use existing docker commands ... except when we can't (i.e. refreshing NVM, etc). 🤦‍♂️ 

### Background/Context

We've been observing more frequent intermittent out-of-memory build errors in `wp-desktop-source`, attributed to increasing memory requirements of Terser during source minification. Hopefully the bump in available RAM will mitigate these kinds of errors.

### To Test

Feel free to re-run the `wp-desktop-source` build with SSH enabled and inspect the available RAM with `free -g` to confirm available RAM. 

Note: in comparison, it seems using `free` within the Docker instances is misleading as an absurdly high number can be returned. I believe this is because multiple Docker instances are spun from a single - albeit beefy - machine. Even though each Docker instance is individually resource-constrained (i.e. hard RAM limit of 4GB), using `free` returns the memory available at the hardware level. In contrast, the Machine instance is dedicated for single use and `free` confirms the actual amount of RAM available for the job at hand.