### PR TITLE
Fixes for GitHub Template O2 block

### DIFF
--- a/apps/o2-blocks/src/github-issue-template/editor.js
+++ b/apps/o2-blocks/src/github-issue-template/editor.js
@@ -68,7 +68,7 @@ const Edit = ( {
 
 const View = ( { title, userOrOrg, repo, ...rest } ) => (
 	<Shell
-		title={ `${ __( 'Create Issue:' ) } ${ title }` }
+		title={ __( 'Create Issue' ) + `${ title ? `: ${ title }` : '' }` }
 		subTitle={ `${ userOrOrg }/${ repo }` }
 		{ ...rest }
 	/>
@@ -79,7 +79,7 @@ const Invalid = () => (
 		className="is-warning"
 		title={ __( 'Please fill in the required fields' ) }
 		subTitle={ __(
-			'Title, Org, and Repository are required. Select this block to open the form and fill them.'
+			'Org, and Repository are required. Select this block to open the form and fill them.'
 		) }
 	/>
 );
@@ -121,7 +121,7 @@ registerBlockType( 'a8c/github-issue-template', {
 			},
 		};
 
-		const isValid = title && userOrOrg && repo;
+		const isValid = userOrOrg && repo;
 		const { body, ...viewAttributes } = attributes;
 
 		if ( isSelected ) {
@@ -131,7 +131,7 @@ registerBlockType( 'a8c/github-issue-template', {
 		return isValid ? <View { ...viewAttributes } /> : <Invalid />;
 	},
 	save: ( { attributes: { userOrOrg, repo, title, body } } ) => {
-		const isValid = title && userOrOrg && repo;
+		const isValid = userOrOrg && repo;
 		if ( isValid ) {
 			const url = createIssueUrl( {
 				title,

--- a/apps/o2-blocks/src/github-issue-template/editor.js
+++ b/apps/o2-blocks/src/github-issue-template/editor.js
@@ -4,14 +4,13 @@
 import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
 import { TextControl, TextareaControl } from '@wordpress/components';
-import { Icon } from '@wordpress/icons';
 import * as createIssueUrl from 'new-github-issue-url';
 import { SVG, Rect, Path } from '@wordpress/primitives';
 import classNames from 'classnames';
 
 import './editor.scss';
 
-const githubIcon = (
+const icon = (
 	<SVG
 		xmlns="http://www.w3.org/2000/svg"
 		aria-label="GitHub"
@@ -31,14 +30,10 @@ const githubIcon = (
 const Shell = ( { as: El = 'div', className, title, subTitle, icon, body, ...elementProps } ) => {
 	return (
 		<El { ...elementProps } className={ classNames( 'wp-block-a8c-github-template', className ) }>
-			{ typeof icon === 'string' ? (
-				<div className="github-template__icon">{ icon }</div>
-			) : (
-				<Icon className="github-template__icon" icon={ icon || githubIcon } />
-			) }
-			<span className="github-template__title">{ title }</span>
+			<div className="github-template__icon" />
+			<div className="github-template__title">{ title }</div>
 			<div className="github-template__sub-title">{ subTitle }</div>
-			{ body && <span className="github-template__body">{ body }</span> }
+			{ body && <div className="github-template__body">{ body }</div> }
 		</El>
 	);
 };
@@ -86,13 +81,12 @@ const Invalid = () => (
 		subTitle={ __(
 			'Title, Org, and Repository are required. Select this block to open the form and fill them.'
 		) }
-		icon="⚠"
 	/>
 );
 
 registerBlockType( 'a8c/github-issue-template', {
 	title: __( 'Github Issue Template', 'a8c' ),
-	icon: githubIcon,
+	icon: icon,
 	category: 'layout',
 	attributes: {
 		userOrOrg: {

--- a/apps/o2-blocks/src/github-issue-template/editor.js
+++ b/apps/o2-blocks/src/github-issue-template/editor.js
@@ -27,13 +27,13 @@ const icon = (
 	</SVG>
 );
 
-const Shell = ( { as: El = 'div', className, title, subTitle, icon, body, ...elementProps } ) => {
+const Shell = ( { as: El = 'div', className, title, subtitle, body, ...elementProps } ) => {
 	return (
 		<El { ...elementProps } className={ classNames( 'wp-block-a8c-github-template', className ) }>
-			<div className="github-template__icon" />
-			<div className="github-template__title">{ title }</div>
-			<div className="github-template__sub-title">{ subTitle }</div>
-			{ body && <div className="github-template__body">{ body }</div> }
+			<div className="wp-block-a8c-github-template__icon" />
+			<div className="wp-block-a8c-github-template__title">{ title }</div>
+			<div className="wp-block-a8c-github-template__sub-title">{ subtitle }</div>
+			{ body && <div className="wp-block-a8c-github-template__body">{ body }</div> }
 		</El>
 	);
 };
@@ -51,7 +51,7 @@ const Edit = ( {
 	<Shell
 		className="is-edit"
 		title={ <TextControl placeholder="Issue Title" onChange={ onChangeTitle } value={ title } /> }
-		subTitle={
+		subtitle={
 			<>
 				<TextControl
 					placeholder="User or Organization"
@@ -69,7 +69,7 @@ const Edit = ( {
 const View = ( { title, userOrOrg, repo, ...rest } ) => (
 	<Shell
 		title={ __( 'Create Issue' ) + ( title ? ` "${ title }"` : '' ) }
-		subTitle={ `${ userOrOrg }/${ repo }` }
+		subtitle={ `${ userOrOrg }/${ repo }` }
 		{ ...rest }
 	/>
 );
@@ -78,7 +78,7 @@ const Invalid = () => (
 	<Shell
 		className="is-warning"
 		title={ __( 'Please fill in the required fields' ) }
-		subTitle={ __(
+		subtitle={ __(
 			'Org, and Repository are required. Select this block to open the form and fill them.'
 		) }
 	/>
@@ -102,7 +102,7 @@ registerBlockType( 'a8c/github-issue-template', {
 			type: 'string',
 		},
 	},
-	edit: ( { setAttributes, attributes, attributes: { title, userOrOrg, repo }, isSelected } ) => {
+	edit: ( { setAttributes, attributes, attributes: { userOrOrg, repo }, isSelected } ) => {
 		const handlers = {
 			onChangeUserOrOrg( newUserOrOrg ) {
 				setAttributes( { userOrOrg: newUserOrOrg } );
@@ -121,7 +121,7 @@ registerBlockType( 'a8c/github-issue-template', {
 			},
 		};
 
-		const isValid = userOrOrg && repo;
+		const isValid = Boolean( userOrOrg && repo );
 		const { body, ...viewAttributes } = attributes;
 
 		if ( isSelected ) {
@@ -131,7 +131,7 @@ registerBlockType( 'a8c/github-issue-template', {
 		return isValid ? <View { ...viewAttributes } /> : <Invalid />;
 	},
 	save: ( { attributes: { userOrOrg, repo, title, body } } ) => {
-		const isValid = userOrOrg && repo;
+		const isValid = Boolean( userOrOrg && repo );
 		if ( isValid ) {
 			const url = createIssueUrl( {
 				title,

--- a/apps/o2-blocks/src/github-issue-template/editor.js
+++ b/apps/o2-blocks/src/github-issue-template/editor.js
@@ -86,7 +86,7 @@ const Invalid = () => (
 
 registerBlockType( 'a8c/github-issue-template', {
 	title: __( 'Github Issue Template', 'a8c' ),
-	icon: icon,
+	icon,
 	category: 'layout',
 	attributes: {
 		userOrOrg: {

--- a/apps/o2-blocks/src/github-issue-template/editor.js
+++ b/apps/o2-blocks/src/github-issue-template/editor.js
@@ -68,7 +68,7 @@ const Edit = ( {
 
 const View = ( { title, userOrOrg, repo, ...rest } ) => (
 	<Shell
-		title={ __( 'Create Issue' ) + `${ title ? `: ${ title }` : '' }` }
+		title={ __( 'Create Issue' ) + ( title ? ` "${ title }"` : '' ) }
 		subTitle={ `${ userOrOrg }/${ repo }` }
 		{ ...rest }
 	/>

--- a/apps/o2-blocks/src/github-issue-template/editor.js
+++ b/apps/o2-blocks/src/github-issue-template/editor.js
@@ -79,7 +79,7 @@ const Invalid = () => (
 		className="is-warning"
 		title={ __( 'Please fill in the required fields' ) }
 		subtitle={ __(
-			'Org, and Repository are required. Select this block to open the form and fill them.'
+			'Org and Repository are required. Select this block to open the form and fill them.'
 		) }
 	/>
 );

--- a/apps/o2-blocks/src/github-issue-template/editor.scss
+++ b/apps/o2-blocks/src/github-issue-template/editor.scss
@@ -3,7 +3,8 @@
 .wp-block-a8c-github-template.is-edit {
   padding: 18px 18px 4px 55px;
 
-  .github-template__sub-title {
-     display: flex;
-  }
 };
+
+.wp-block-a8c-github-template__sub-title {
+  display: flex;
+}

--- a/apps/o2-blocks/src/github-issue-template/style.scss
+++ b/apps/o2-blocks/src/github-issue-template/style.scss
@@ -8,7 +8,6 @@
   padding: 4px 6px 8px 50px;
   position: relative;
   text-decoration: none;
-  color: inherit;
 
   &:hover {
     color: #555;
@@ -19,11 +18,11 @@
     background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' aria-label='GitHub' role='img' viewBox='0 0 512 512' width='24' height='24' focusable='false'%3E%3Crect width='512' height='512' rx='15%25' fill='%231B1817'%3E%3C/rect%3E%3Cpath fill='%23fff' d='M335 499c14 0 12 17 12 17H165s-2-17 12-17c13 0 16-6 16-12l-1-50c-71 16-86-28-86-28-12-30-28-37-28-37-24-16 1-16 1-16 26 2 40 26 40 26 22 39 59 28 74 22 2-17 9-28 16-35-57-6-116-28-116-126 0-28 10-51 26-69-3-6-11-32 3-67 0 0 21-7 70 26 42-12 86-12 128 0 49-33 70-26 70-26 14 35 6 61 3 67 16 18 26 41 26 69 0 98-60 120-117 126 10 8 18 24 18 48l-1 70c0 6 3 12 16 12z'%3E%3C/path%3E%3C/svg%3E");
     color: white;
     font-size: large;
+    height: 24px;
     left: 9px;
     position: absolute;
     top: calc(50% - 10px);
     width: 24px;
-    height: 24px;
   }
 
   .github-template__title {
@@ -44,6 +43,7 @@
       color: white;
       font-size: 26px;
       top: calc(50% - 23px);
+
       &:after {
         content: '⚠'
       }
@@ -53,4 +53,8 @@
       line-height: initial;
     }
    }
+}
+
+a.wp-block-a8c-github-template {
+  color: inherit;
 }

--- a/apps/o2-blocks/src/github-issue-template/style.scss
+++ b/apps/o2-blocks/src/github-issue-template/style.scss
@@ -8,6 +8,7 @@
   padding: 4px 6px 8px 50px;
   position: relative;
   text-decoration: none;
+  color: inherit;
 
   &:hover {
     color: #555;

--- a/apps/o2-blocks/src/github-issue-template/style.scss
+++ b/apps/o2-blocks/src/github-issue-template/style.scss
@@ -15,11 +15,14 @@
   }
 
   .github-template__icon {
+    background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' aria-label='GitHub' role='img' viewBox='0 0 512 512' width='24' height='24' focusable='false'%3E%3Crect width='512' height='512' rx='15%25' fill='%231B1817'%3E%3C/rect%3E%3Cpath fill='%23fff' d='M335 499c14 0 12 17 12 17H165s-2-17 12-17c13 0 16-6 16-12l-1-50c-71 16-86-28-86-28-12-30-28-37-28-37-24-16 1-16 1-16 26 2 40 26 40 26 22 39 59 28 74 22 2-17 9-28 16-35-57-6-116-28-116-126 0-28 10-51 26-69-3-6-11-32 3-67 0 0 21-7 70 26 42-12 86-12 128 0 49-33 70-26 70-26 14 35 6 61 3 67 16 18 26 41 26 69 0 98-60 120-117 126 10 8 18 24 18 48l-1 70c0 6 3 12 16 12z'%3E%3C/path%3E%3C/svg%3E");
     color: white;
     font-size: large;
     left: 9px;
     position: absolute;
     top: calc(50% - 10px);
+    width: 24px;
+    height: 24px;
   }
 
   .github-template__title {
@@ -36,9 +39,13 @@
     padding-bottom: 10px;
 
     .github-template__icon {
+      background: none;
       color: white;
       font-size: 26px;
       top: calc(50% - 23px);
+      &:after {
+        content: '⚠'
+      }
     }
 
     .github-template__sub-title {

--- a/apps/o2-blocks/src/github-issue-template/style.scss
+++ b/apps/o2-blocks/src/github-issue-template/style.scss
@@ -3,7 +3,7 @@
   border-radius: 2px;
   border: 1px solid #d8e2e9;
   box-shadow: inset 40px 0px 0px 0px #6cc644;
-  color: #555;
+  color: inherit;
   display: block;
   padding: 4px 6px 8px 50px;
   position: relative;
@@ -14,31 +14,11 @@
     text-decoration: none;
   }
 
-  .github-template__icon {
-    background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' aria-label='GitHub' role='img' viewBox='0 0 512 512' width='24' height='24' focusable='false'%3E%3Crect width='512' height='512' rx='15%25' fill='%231B1817'%3E%3C/rect%3E%3Cpath fill='%23fff' d='M335 499c14 0 12 17 12 17H165s-2-17 12-17c13 0 16-6 16-12l-1-50c-71 16-86-28-86-28-12-30-28-37-28-37-24-16 1-16 1-16 26 2 40 26 40 26 22 39 59 28 74 22 2-17 9-28 16-35-57-6-116-28-116-126 0-28 10-51 26-69-3-6-11-32 3-67 0 0 21-7 70 26 42-12 86-12 128 0 49-33 70-26 70-26 14 35 6 61 3 67 16 18 26 41 26 69 0 98-60 120-117 126 10 8 18 24 18 48l-1 70c0 6 3 12 16 12z'%3E%3C/path%3E%3C/svg%3E");
-    color: white;
-    font-size: large;
-    height: 24px;
-    left: 9px;
-    position: absolute;
-    top: calc(50% - 10px);
-    width: 24px;
-  }
-
-  .github-template__title {
-     font-weight: 700;
-     vertical-align: middle;
-   }
-
-   .github-template__sub-title {
-     font-size: smaller;
-   }
-
-   &.is-warning {
+  &.is-warning {
     box-shadow: inset 40px 0px 0px 0px #FFCC00;
     padding-bottom: 10px;
 
-    .github-template__icon {
+    .wp-block-a8c-github-template__icon {
       background: none;
       color: white;
       font-size: 26px;
@@ -49,10 +29,30 @@
       }
     }
 
-    .github-template__sub-title {
+    .wp-block-a8c-github-template__sub-title {
       line-height: initial;
     }
-   }
+  }
+}
+
+.wp-block-a8c-github-template__icon {
+  background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' aria-label='GitHub' role='img' viewBox='0 0 512 512' width='24' height='24' focusable='false'%3E%3Crect width='512' height='512' rx='15%25' fill='%231B1817'%3E%3C/rect%3E%3Cpath fill='%23fff' d='M335 499c14 0 12 17 12 17H165s-2-17 12-17c13 0 16-6 16-12l-1-50c-71 16-86-28-86-28-12-30-28-37-28-37-24-16 1-16 1-16 26 2 40 26 40 26 22 39 59 28 74 22 2-17 9-28 16-35-57-6-116-28-116-126 0-28 10-51 26-69-3-6-11-32 3-67 0 0 21-7 70 26 42-12 86-12 128 0 49-33 70-26 70-26 14 35 6 61 3 67 16 18 26 41 26 69 0 98-60 120-117 126 10 8 18 24 18 48l-1 70c0 6 3 12 16 12z'%3E%3C/path%3E%3C/svg%3E");
+  color: white;
+  font-size: large;
+  height: 24px;
+  left: 9px;
+  position: absolute;
+  top: calc(50% - 10px);
+  width: 24px;
+}
+
+.wp-block-a8c-github-template__title {
+  font-weight: 700;
+  vertical-align: middle;
+}
+
+.wp-block-a8c-github-template__sub-title {
+  font-size: smaller;
 }
 
 a.wp-block-a8c-github-template {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

After the [first version](https://github.com/Automattic/wp-calypso/pull/43970#discussion_r464590822) of the Github Template Block was merged and deployed to Calypso, I proceeded to create the wpcom diff (D47583-code) and test it in a sandboxed (used the Test P2) site and I've found a couple of issues:

1. Upon saving the block, the SVG tag for the icon was stripped out, leaving the frontend rendering without the icon (more details here: p1596580725082800-slack-C029FPKAY)
2. When editing and saving in the "inline" editor, the block rendering is totally broken unless a full page refresh is done, see the video here: p1596591374469800-slack-C015AL3QL7M

This PR fixes the icon issue by inlining the SVG icon in the CSS as a background-image, introduces a minor CSS fix, and addresses a [suggestion](https://github.com/Automattic/wp-calypso/pull/43970#discussion_r464590822) from the previous PR to make the Title of the block not mandatory.

#### Testing instructions

I've been testing this changeset against the test P2 site in order to use an env as close to production as possible.

1. Checkout this branch;
1. Go to `apps/o2-blocks` and run `yarn build` to build;
1. Rsync this over to a clean sandbox i.e ` rsync -azP dist -e user@sandbox:~/public_html/wp-content/a8c-plugins/a8c-blocks`
1. Access the test P2 that's mapped  to the sanbox, the github block should be available in the inserter
1. Add using the inline editor (if you're using the test P2, scroll to the top of the page and click "Blank Post") and click "Save"
1. Observe how the block rendering is totally broken (this hasn't been fixed yet, still figuring out if this is directly related to the Github Block or a P2tenberg bug (?))
1. Refresh the page
1. Observe how the block now renders correctly with the github icon to its left