### PR TITLE
Remove isLarge prop from NextButton & SkipButton

### DIFF
--- a/packages/onboarding/src/action-buttons/index.tsx
+++ b/packages/onboarding/src/action-buttons/index.tsx
@@ -51,7 +51,6 @@ export const NextButton: React.FunctionComponent< Button.ButtonProps > = ( {
 		<Button
 			className={ classnames( 'action_buttons__button action-buttons__next', className ) }
 			isPrimary
-			isLarge
 			{ ...buttonProps }
 		>
 			{ children ||
@@ -70,7 +69,6 @@ export const SkipButton: React.FunctionComponent< Button.ButtonProps > = ( {
 	return (
 		<Button
 			className={ classnames( 'action_buttons__button action-buttons__skip', className ) }
-			isLarge
 			{ ...buttonProps }
 		>
 			{ children ||


### PR DESCRIPTION
### Issue
The isLarge property was throwing a warning, as it was deprecated in Gutenberg Button component.
Issue: https://github.com/Automattic/wp-calypso/issues/44603

### Changes proposed in this Pull Request

* remove the isLarge prop from [NextButton & SkipButton](packages/onboarding/src/action-buttons/index.tsx), it is no longer needed due to changes in Gutenberg Button component.

### Testing instructions

* Open URL: calypso.localhost:3000/new
* Check the console for warnings related to `isLarge` prop, there should not be warnings
* Continue to the Style step /new/style where the NextButton component is
* Check the console for warnings related to `isLarge` prop, there should be no warnings

