### PR TITLE
Sidebar: Remove Customizer Tab from All Sites View

### DIFF
--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -1042,10 +1042,11 @@ function mapStateToProps( state ) {
 		isAtomicSite: !! isSiteAutomatedTransfer( state, selectedSiteId ),
 		isMigrationInProgress,
 		isVip: isVipSite( state, selectedSiteId ),
-		showCustomizerLink: ! (
-			isSiteUsingFullSiteEditing( state, selectedSiteId ) ||
-			isSiteUsingCoreSiteEditor( state, selectedSiteId )
-		),
+		showCustomizerLink:
+			! (
+				isSiteUsingFullSiteEditing( state, selectedSiteId ) ||
+				isSiteUsingCoreSiteEditor( state, selectedSiteId )
+			) && siteId,
 		showSiteEditor: isSiteUsingCoreSiteEditor( state, selectedSiteId ),
 		siteEditorUrl: getSiteEditorUrl( state, selectedSiteId ),
 		siteId,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This just adds a simple check for a siteId to remove the "Customize" tab from the All Sites View

#### Testing instructions

Verify that at `/stats/day`, "Customize" no longer appears underneath the "Design" tab. 

<img width="267" alt="Screenshot 2020-08-05 at 08 59 56" src="https://user-images.githubusercontent.com/43215253/89387555-8c2aba80-d6fa-11ea-82fe-6ebdd61e6a7d.png">

cc @creativecoder 

Fixes #44663
