### PR TITLE
ImageSelector: replace `MediaStore.get` with `getMediaItem` thunk

### DIFF
--- a/client/blocks/image-selector/dropzone.jsx
+++ b/client/blocks/image-selector/dropzone.jsx
@@ -43,7 +43,7 @@ class ImageSelectorDropZone extends Component {
 			fileContents: droppedImage,
 			fileName: droppedImage.name,
 		};
-		const uploadedMedia = await this.props.addMedia( file, this.props.site );
+		const [ uploadedMedia ] = await this.props.addMedia( file, this.props.site );
 
 		this.props.onDroppedImage( uploadedMedia );
 	};

--- a/client/blocks/image-selector/preview.jsx
+++ b/client/blocks/image-selector/preview.jsx
@@ -15,7 +15,6 @@ import { connect } from 'react-redux';
  */
 import { Button } from '@automattic/components';
 import ImagePreloader from 'components/image-preloader';
-import MediaStore from 'lib/media/store';
 import Spinner from 'components/spinner';
 import { url } from 'lib/media/utils';
 import { fetchMediaItem, getMediaItem } from 'state/media/thunks';
@@ -38,7 +37,6 @@ export class ImageSelectorPreview extends Component {
 
 	componentDidMount() {
 		this.fetchImages();
-		MediaStore.on( 'change', this.updateImageState );
 	}
 
 	componentDidUpdate( prevProps ) {
@@ -46,10 +44,6 @@ export class ImageSelectorPreview extends Component {
 		if ( siteId !== prevProps.siteId || itemIds !== prevProps.itemIds ) {
 			this.fetchImages();
 		}
-	}
-
-	componentWillUnmount() {
-		MediaStore.off( 'change', this.updateImageState );
 	}
 
 	setTransientImages = () => {
@@ -92,12 +86,8 @@ export class ImageSelectorPreview extends Component {
 		this.setTransientImages();
 		const images = uniq(
 			itemIds
-				.map( ( id ) => {
-					return this.props.getMediaItem( siteId, id );
-				} )
-				.filter( function ( e ) {
-					return e;
-				} )
+				.map( ( id ) => this.props.getMediaItem( siteId, id ) )
+				.filter( ( mediaItem ) => mediaItem )
 		);
 
 		this.setState( { images }, () => {

--- a/client/blocks/image-selector/preview.jsx
+++ b/client/blocks/image-selector/preview.jsx
@@ -18,7 +18,7 @@ import ImagePreloader from 'components/image-preloader';
 import MediaStore from 'lib/media/store';
 import Spinner from 'components/spinner';
 import { url } from 'lib/media/utils';
-import { fetchMediaItem } from 'state/media/thunks';
+import { fetchMediaItem, getMediaItem } from 'state/media/thunks';
 
 export class ImageSelectorPreview extends Component {
 	static propTypes = {
@@ -56,7 +56,7 @@ export class ImageSelectorPreview extends Component {
 		const newTransientImages = {};
 		this.state.images.forEach( ( image ) => {
 			if ( image.transient ) {
-				const media = MediaStore.get( this.props.siteId, image.ID );
+				const media = this.props.getMediaItem( this.props.siteId, image.ID );
 				newTransientImages[ media.ID ] = image.URL;
 			}
 		} );
@@ -79,7 +79,7 @@ export class ImageSelectorPreview extends Component {
 
 			itemIds.map( ( id ) => {
 				id = parseInt( id, 10 );
-				const media = MediaStore.get( siteId, id );
+				const media = this.props.getMediaItem( siteId, id );
 				if ( ! media ) {
 					this.props.fetchMediaItem( siteId, id );
 				}
@@ -93,7 +93,7 @@ export class ImageSelectorPreview extends Component {
 		const images = uniq(
 			itemIds
 				.map( ( id ) => {
-					return MediaStore.get( siteId, id );
+					return this.props.getMediaItem( siteId, id );
 				} )
 				.filter( function ( e ) {
 					return e;
@@ -238,4 +238,6 @@ export class ImageSelectorPreview extends Component {
 	}
 }
 
-export default connect( null, { fetchMediaItem } )( localize( ImageSelectorPreview ) );
+export default connect( null, { fetchMediaItem, getMediaItem } )(
+	localize( ImageSelectorPreview )
+);

--- a/client/blocks/image-selector/test/index.jsx
+++ b/client/blocks/image-selector/test/index.jsx
@@ -84,28 +84,6 @@ describe( 'ImageSelector', () => {
 			);
 		} );
 
-		test( 'should not show an uploader when an image exists and multiple images not allowed', () => {
-			const wrapper = mount(
-				<Provider store={ store }>
-					<ImageSelector { ...testProps } imageIds={ [ 100 ] } />
-				</Provider>
-			);
-
-			expect( wrapper.find( '.image-selector__uploader-wrapper' ).hostNodes() ).to.have.lengthOf(
-				0
-			);
-		} );
-
-		test( 'should show image when valid ID is passed', () => {
-			const wrapper = mount(
-				<Provider store={ store }>
-					<ImageSelector { ...testProps } imageIds={ [ 100 ] } />
-				</Provider>
-			);
-
-			expect( wrapper.find( '.image-selector__item' ).hostNodes() ).to.have.lengthOf( 1 );
-		} );
-
 		test( 'should not show image when invalid ID is passed', () => {
 			const wrapper = mount(
 				<Provider store={ store }>
@@ -127,24 +105,6 @@ describe( 'ImageSelector', () => {
 
 			wrapper.find( '.image-selector__uploader-wrapper' ).hostNodes().simulate( 'click' );
 			expect( wrapper.find( 'ImageSelector' ).instance().state.isSelecting ).to.be.true;
-		} );
-
-		test( 'should pass back image for removal when remove button is clicked', () => {
-			const mockOnRemoveImage = sinon.spy();
-			const wrapper = mount(
-				<Provider store={ store }>
-					<ImageSelector
-						{ ...testProps }
-						imageIds={ [ 100 ] }
-						onRemoveImage={ mockOnRemoveImage }
-					/>
-				</Provider>
-			);
-
-			wrapper.find( '.image-selector__remove' ).hostNodes().simulate( 'click' );
-			expect( mockOnRemoveImage ).to.have.been.calledWith(
-				require( './fixtures' ).DUMMY_MEDIA[ 100 ]
-			);
 		} );
 
 		test( 'should pass back image when file is dropped', () => {

--- a/client/blocks/image-selector/test/preview.jsx
+++ b/client/blocks/image-selector/test/preview.jsx
@@ -1,0 +1,80 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+import { noop } from 'lodash';
+import { mount } from 'enzyme';
+import { Provider } from 'react-redux';
+import React from 'react';
+import sinon from 'sinon';
+
+import { ImageSelectorPreview } from '../preview';
+
+describe( 'ImageSelectorPreview', () => {
+	const testProps = {
+		onImageChange: noop,
+		onImageSelected: noop,
+		onRemoveImage: noop,
+		imageIds: [],
+		setMediaLibrarySelectedItems: noop,
+		translate: () => {},
+		getMediaItem: ( siteId, itemId ) => require( './fixtures' ).DUMMY_MEDIA[ itemId ],
+	};
+	const store = {
+		getState: () => ( {
+			media: {
+				selectedItems: {},
+			},
+		} ),
+		subscribe: () => {},
+		dispatch: () => {},
+	};
+
+	describe( 'rendering', () => {
+		test( 'should not show an uploader when an image exists and multiple images not allowed', () => {
+			const wrapper = mount(
+				<Provider store={ store }>
+					<ImageSelectorPreview { ...testProps } itemIds={ [ 100 ] } />
+				</Provider>
+			);
+
+			expect( wrapper.find( '.image-selector__uploader-wrapper' ).hostNodes() ).to.have.lengthOf(
+				0
+			);
+		} );
+
+		test( 'should show image when valid ID is passed', () => {
+			const wrapper = mount(
+				<Provider store={ store }>
+					<ImageSelectorPreview { ...testProps } itemIds={ [ 100 ] } />
+				</Provider>
+			);
+
+			expect( wrapper.find( '.image-selector__item' ).hostNodes() ).to.have.lengthOf( 1 );
+		} );
+	} );
+
+	describe( 'events', () => {
+		test( 'should pass back image for removal when remove button is clicked', () => {
+			const mockOnRemoveImage = sinon.spy();
+			const wrapper = mount(
+				<Provider store={ store }>
+					<ImageSelectorPreview
+						{ ...testProps }
+						itemIds={ [ 100 ] }
+						onRemoveImage={ mockOnRemoveImage }
+					/>
+				</Provider>
+			);
+
+			wrapper.find( '.image-selector__remove' ).hostNodes().simulate( 'click' );
+			expect( mockOnRemoveImage ).to.have.been.calledWith(
+				require( './fixtures' ).DUMMY_MEDIA[ 100 ]
+			);
+		} );
+	} );
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* ImageSelectorPreview: replace usages of `MediaStore.get` with `getMediaItem` thunk
* ImageSelectorPreview: remove `MediaStore` listeners
* ImageSelectorDropzone: destructure return value from `addMedia`
* Move some tests related to `ImageSelectorPreview` to its own file to prevent them from failing

#### Testing instructions

* Open devdocs on `/devdocs/blocks/image-selector`
* Add and remove images and make sure they always load
* After you opened the media library at least once (I don't really know why that is tbh) try to drop an image and make sure it appears after it got uploaded (see gif below)

Here's what it should look like:

![upload-image-selector](https://user-images.githubusercontent.com/9202899/89411453-b9d92900-d725-11ea-89ab-416d35c7fafd.gif)


related #43663 
