### PR TITLE
Apply Calypso Doctor recommendations to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,9 +12,13 @@ references:
     environment:
       CIRCLE_ARTIFACTS: /tmp/artifacts
       CIRCLE_TEST_REPORTS: /tmp/test_results
-      PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: 'true'
+      PUPPETEER_SKIP_DOWNLOAD: 'true'
       DETECT_CHROMEDRIVER_VERSION: 'false'
       CHROMEDRIVER_FILEPATH: /usr/local/bin/chromedriver
+      NODE_OPTIONS: --max-old-space-size=3072
+      CHROMEDRIVER_SKIP_DOWNLOAD: 'true'
+      npm_config_cache: ~/.cache/yarn
+      YARN_CACHE_FOLDER: ~/.cache/yarn
   desktop_defaults: &desktop_defaults
     working_directory: ~/wp-calypso
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,8 +17,8 @@ references:
       CHROMEDRIVER_FILEPATH: /usr/local/bin/chromedriver
       NODE_OPTIONS: --max-old-space-size=3072
       CHROMEDRIVER_SKIP_DOWNLOAD: 'true'
-      npm_config_cache: ~/.cache/yarn
-      YARN_CACHE_FOLDER: ~/.cache/yarn
+      npm_config_cache: /home/circleci/.cache/yarn
+      YARN_CACHE_FOLDER: /home/circleci/.cache/yarn
   desktop_defaults: &desktop_defaults
     working_directory: ~/wp-calypso
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,6 @@ references:
       DETECT_CHROMEDRIVER_VERSION: 'false'
       CHROMEDRIVER_FILEPATH: /usr/local/bin/chromedriver
       NODE_OPTIONS: --max-old-space-size=3072
-      CHROMEDRIVER_SKIP_DOWNLOAD: 'true'
       npm_config_cache: /home/circleci/.cache/yarn
       YARN_CACHE_FOLDER: /home/circleci/.cache/yarn
   desktop_defaults: &desktop_defaults


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Applies recommendations from Calypso Doctor to CircleCI config. Recommendations extracted from 
https://app.circleci.com/pipelines/github/Automattic/wp-calypso/69494/workflows/67a5b84e-3c12-459e-9f8c-3449e54212ca/jobs/839202/parallel-runs/0/steps/0-107

Note that the memory is capped at 3Gb (75% of [default docker image](https://circleci.com/docs/2.0/configuration-reference/#docker-executor)).

#### Testing instructions

Check CircleCI builds passes