### PR TITLE
P2 Signup: Updates to styling

### DIFF
--- a/client/signup/p2-processing-screen/index.jsx
+++ b/client/signup/p2-processing-screen/index.jsx
@@ -23,14 +23,16 @@ function P2SignupProcessingScreen() {
 			</div>
 
 			<div className="p2-processing-screen__text">
-				{ translate( '{{h2}}Hooray!{{br/}}Your new P2 is{{br/}}almost ready.{{/h2}}', {
+				{ translate( '{{h2}}Hooray!{{/h2}} {{p}}Your new P2 is almost ready.{{/p}}', {
 					components: {
 						// eslint-disable-next-line jsx-a11y/heading-has-content
 						h2: <h2 />,
-						br: <br />,
+						p: <p />,
 					},
 				} ) }
 			</div>
+
+			<div className="p2-processing-screen__spinner"></div>
 
 			<div className="p2-processing-screen__footer">
 				<img

--- a/client/signup/p2-processing-screen/style.scss
+++ b/client/signup/p2-processing-screen/style.scss
@@ -1,22 +1,53 @@
 @import url( 'https://fonts.googleapis.com/css2?family=Inter:wght@400;900&display=swap' );
+@import '~@wordpress/base-styles/breakpoints';
+@import '~@wordpress/base-styles/mixins';
 
 .p2-processing-screen {
 	box-sizing: border-box;
 	margin: 0 auto;
-	max-width: 387px;
 	height: 100vh;
 	display: flex;
 	flex-direction: column;
-	padding-top: 80px;
+	padding: 32px 32px 0;
+
+	@include break-mobile {
+		padding: 80px 20px 0;
+		max-width: 400px;
+	}
 
 	font-family: var( --p2-font-inter );
 }
 
 .p2-processing-screen__text {
-	font-weight: bold;
-	font-size: $font-headline-medium;
-	line-height: 58px;
-	margin-top: 111px;
+	font-weight: 700;
+	font-size: $font-headline-small;
+	line-height: 1.3em;
+	margin-top: 88px;
+	margin-bottom: 1.5em;
+
+	h2 {
+		animation: p2-fade 0.9s ease-in-out, p2-jump 0.8s cubic-bezier( 0.21, 0.19, 0.24, 0.99 );
+	}
+
+	p {
+		opacity: 0;
+		animation: p2-fade 0.9s ease-in-out 0.8s forwards, p2-jump 0.8s cubic-bezier( 0.21, 0.19, 0.24, 0.99 ) 0.8s forwards;
+		margin: 0;
+	}
+
+	@include break-mobile {
+		font-size: $font-headline-medium;
+		margin-top: 112px;
+	}
+}
+
+.p2-processing-screen__spinner {
+	width: 66px;
+	height: 66px;
+	position: relative;
+	opacity: 0;
+	background-image: url( 'data:image/svg+xml,%3Csvg width="66" height="66" viewBox="0 0 66 66" fill="none" xmlns="http://www.w3.org/2000/svg"%3E%3Ccircle cx="33" cy="33" r="32" stroke="%23354756" stroke-width="2"/%3E%3Cpath d="M1 33C1 15.3269 15.3269 1 33 1" stroke="white" stroke-width="2"/%3E%3C/svg%3E%0A' );
+	animation: p2-spin 0.75s linear infinite, p2-fade 0.75s ease-in-out 1.8s forwards;
 }
 
 .p2-processing-screen__footer {
@@ -37,4 +68,34 @@
 .p2-processing-screen__footer-text {
 	font-size: 14px;
 	line-height: 17px;
+}
+
+@keyframes p2-spin {
+	from {
+		transform: rotate( 0 );
+	}
+
+	to {
+		transform: rotate( 360deg );
+	}
+}
+
+@keyframes p2-fade {
+	from {
+		opacity: 0;
+	}
+
+	to {
+		opacity: 1;
+	}
+}
+
+@keyframes p2-jump {
+	from {
+		transform: translateY( 20px );
+	}
+	
+	to {
+		transform: none;
+	}
 }

--- a/client/signup/p2-step-wrapper/style.scss
+++ b/client/signup/p2-step-wrapper/style.scss
@@ -1,14 +1,20 @@
 @import url( 'https://fonts.googleapis.com/css2?family=Inter:wght@400;900&display=swap' );
+@import '~@wordpress/base-styles/breakpoints';
+@import '~@wordpress/base-styles/mixins';
 
 .p2-step-wrapper {
 	box-sizing: border-box;
 	margin: 0 auto;
-	max-width: 376px;
 	height: 100vh;
 	display: flex;
 	flex-direction: column;
-	padding: 80px 20px 0;
+	padding: 32px 32px 0;
 	font-family: var( --p2-font-inter );
+
+	@include break-mobile {
+		padding: 80px 20px 0;
+		max-width: 400px;
+	}
 
 	input,
 	button {
@@ -29,7 +35,10 @@
 }
 
 .p2-step-wrapper__header {
-	margin-bottom: 110px;
+	margin-bottom: 40px;
+	@include break-mobile {
+		margin-bottom: 80px;
+	}
 }
 
 .p2-step-wrapper__header-text {
@@ -44,7 +53,10 @@
 .p2-step-wrapper__footer {
 	text-align: center;
 	margin-top: auto;
-	margin-bottom: 35px;
+	margin-bottom: 24px;
+	@include break-mobile {
+		margin-bottom: 32px;
+	}
 }
 
 .p2-step-wrapper__w-logo {

--- a/client/signup/steps/p2-site/style.scss
+++ b/client/signup/steps/p2-site/style.scss
@@ -105,7 +105,7 @@
 }
 
 .p2-site__form .p2-site__site-url.form-text-input {
-	padding-right: 94px;
+	padding-right: 160px;
 }
 
 .p2-site__form .form-input-validation {

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -25,6 +25,15 @@ body.is-section-signup {
 		&.has-loading-screen-signup {
 			background: var( --p2-color-text );
 			color: var( --p2-color-text-white );
+			&::before {
+				content: '';
+				position: absolute;
+				display: block;
+				width: 100%;
+				height: 100%;
+				background: linear-gradient( 126.81deg, #001424 7.92%, #02223a 89.27% );
+				animation: p2-fade 5s ease-in-out infinite alternate;
+			}
 		}
 
 		.layout__content {
@@ -32,7 +41,16 @@ body.is-section-signup {
 		}
 
 		.layout:not( .dops ) .step-wrapper {
-			margin: 0;
+			margin: 0 0 24px;
+		}
+
+		@include breakpoint-deprecated( '<480px' ) {
+			.locale-suggestions {
+				margin-top: 0;
+				.notice {
+					border-radius: 0;
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Small tweaks to the P2 signup flow so it looks better on mobile
* Tweaks to the site creation screen ("Hooray!") so it displays an animation and users know that something is happening.

![image](https://user-images.githubusercontent.com/820374/89409433-f69f2300-d719-11ea-9989-a3b662f2d860.png)


#### Testing instructions

- Switch to this branch
- Go to http://calypso.localhost:3000/start/p2/
- Complete the flow (ideally with a non-A8C user account)
- Make sure that nothing is broken visually.
