### PR TITLE
wp-babel-makepot: Add publish config

### DIFF
--- a/packages/wp-babel-makepot/package.json
+++ b/packages/wp-babel-makepot/package.json
@@ -9,6 +9,9 @@
 		"url": "git+https://github.com/Automattic/wp-calypso.git",
 		"directory": "packages/wp-babel-makepot"
 	},
+	"publishConfig": {
+		"access": "public"
+	},
 	"keywords": [
 		"makepot",
 		"calypso"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add `publishConfig` for @automattic/wp-babel-makepot package.

#### Testing instructions

N/A