### PR TITLE
Remove Node's `url` from entry-main

### DIFF
--- a/client/layout/error.jsx
+++ b/client/layout/error.jsx
@@ -3,10 +3,8 @@
  */
 import debug from 'debug';
 import { localize } from 'i18n-calypso';
-import { assign, noop } from 'lodash';
+import { noop } from 'lodash';
 import React from 'react';
-import url from 'url';
-import { stringify } from 'qs';
 
 /**
  * Internal dependencies
@@ -29,18 +27,19 @@ const LoadingErrorMessage = localize( ( { translate } ) => (
 ) );
 
 export function isRetry() {
-	const parsed = url.parse( window.location.href, true );
-	return parsed.query.retry === '1';
+	const searchParams = new URLSearchParams( window.location.search );
+	return searchParams.get( 'retry' ) === '1';
 }
 
 export function retry( chunkName ) {
 	if ( ! isRetry() ) {
-		const parsed = url.parse( window.location.href, true );
+		const searchParams = new URLSearchParams( window.location.search );
 
 		bumpStat( 'calypso_chunk_retry', chunkName );
 
 		// Trigger a full page load which should include script tags for the current chunk
-		window.location.search = stringify( assign( parsed.query, { retry: '1' } ) );
+		searchParams.set( 'retry', '1' );
+		window.location.search = searchParams.toString();
 	}
 }
 

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -7,8 +7,6 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import Gridicon from 'components/gridicon';
-// eslint-disable-next-line no-restricted-imports
-import { format as formatUrl, parse as parseUrl } from 'url';
 import { memoize } from 'lodash';
 import { ProgressBar } from '@automattic/components';
 
@@ -92,6 +90,7 @@ import JetpackSidebarMenuItems from 'components/jetpack/sidebar/menu-items/calyp
  * Style dependencies
  */
 import './style.scss';
+import { getUrlParts, getUrlFromParts } from 'lib/url';
 
 export class MySitesSidebar extends Component {
 	static propTypes = {
@@ -799,14 +798,18 @@ export class MySitesSidebar extends Component {
 			return null;
 		}
 
-		const adminUrl =
-			this.props.isJetpack && ! this.props.isAtomicSite && ! this.props.isVip
-				? formatUrl( {
-						...parseUrl( site.options.admin_url + 'admin.php' ),
-						query: { page: 'jetpack' },
-						hash: '/my-plan',
-				  } )
-				: site.options.admin_url;
+		let adminUrl = site.options.admin_url;
+
+		if ( this.props.isJetpack && ! this.props.isAtomicSite && ! this.props.isVip ) {
+			const urlParts = getUrlParts( site.options.admin_url + 'admin.php' );
+			delete urlParts.search;
+			adminUrl = getUrlFromParts( {
+				...urlParts,
+				protocol: urlParts.protocol || 'https:',
+				searchParams: new URLSearchParams( { page: 'jetpack' } ),
+				hash: '/my-plan',
+			} ).href;
+		}
 
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (

--- a/client/state/posts/utils/get-preview-url.js
+++ b/client/state/posts/utils/get-preview-url.js
@@ -1,10 +1,10 @@
 /**
- * External dependencies
+ * Internal dependencies
  */
-import url from 'url';
+import { getUrlParts, getUrlFromParts } from 'lib/url';
 
 export function getPreviewURL( site, post, autosavePreviewUrl ) {
-	let parsed, previewUrl;
+	let urlParts, previewUrl;
 
 	if ( ! post || ! post.URL || post.status === 'trash' ) {
 		return '';
@@ -15,10 +15,10 @@ export function getPreviewURL( site, post, autosavePreviewUrl ) {
 	} else if ( post.status === 'publish' ) {
 		previewUrl = post.URL;
 	} else {
-		parsed = url.parse( post.URL, true );
-		parsed.query.preview = 'true';
-		delete parsed.search;
-		previewUrl = url.format( parsed );
+		urlParts = getUrlParts( post.URL );
+		urlParts.searchParams.set( 'preview', 'true' );
+		delete urlParts.search;
+		previewUrl = getUrlFromParts( urlParts ).href;
 	}
 
 	if ( post.site_ID ) {
@@ -30,10 +30,10 @@ export function getPreviewURL( site, post, autosavePreviewUrl ) {
 			previewUrl = previewUrl.replace( site.URL, site.options.unmapped_url );
 		}
 		if ( site.options.frame_nonce ) {
-			parsed = url.parse( previewUrl, true );
-			parsed.query[ 'frame-nonce' ] = site.options.frame_nonce;
-			delete parsed.search;
-			previewUrl = url.format( parsed );
+			urlParts = getUrlParts( previewUrl );
+			urlParts.searchParams.set( 'frame-nonce', site.options.frame_nonce );
+			delete urlParts.search;
+			previewUrl = getUrlFromParts( urlParts ).href;
 		}
 	}
 


### PR DESCRIPTION
This PR removes the last usage of the deprecated `url` module from `entry-main`. This should get us some immediate benefits in making the critical path smaller.

#### Changes proposed in this Pull Request

* Remove the last usage of the deprecated `url` module from `entry-main`

#### Testing instructions

- Ensure that site previews continue to work correctly
- Ensure that the wp-admin link in the sidebar continues to point to the right place for Jetpack-only sites
- Ensure that layout error pages correctly retry once
