### PR TITLE
Checkout: show full domain contact details when invalid cached details exist

### DIFF
--- a/client/my-sites/checkout/composite-checkout/contact-validation.js
+++ b/client/my-sites/checkout/composite-checkout/contact-validation.js
@@ -45,7 +45,6 @@ export function handleContactValidationResult( {
 	paymentMethodId,
 	validationResult,
 	applyDomainContactValidationResults,
-	setshouldShowInvalidContactDetails,
 } ) {
 	recordEvent( {
 		type: 'VALIDATE_DOMAIN_CONTACT_INFO',
@@ -65,7 +64,6 @@ export function handleContactValidationResult( {
 				'We could not validate your contact information. Please review and update all the highlighted fields.'
 			)
 		);
-		setshouldShowInvalidContactDetails( true );
 	}
 	applyDomainContactValidationResults(
 		formatDomainContactValidationResponse( validationResult ?? {} )

--- a/client/my-sites/checkout/composite-checkout/contact-validation.js
+++ b/client/my-sites/checkout/composite-checkout/contact-validation.js
@@ -45,6 +45,7 @@ export function handleContactValidationResult( {
 	paymentMethodId,
 	validationResult,
 	applyDomainContactValidationResults,
+	setshouldShowInvalidContactDetails,
 } ) {
 	recordEvent( {
 		type: 'VALIDATE_DOMAIN_CONTACT_INFO',
@@ -64,6 +65,7 @@ export function handleContactValidationResult( {
 				'We could not validate your contact information. Please review and update all the highlighted fields.'
 			)
 		);
+		setshouldShowInvalidContactDetails( true );
 	}
 	applyDomainContactValidationResults(
 		formatDomainContactValidationResponse( validationResult ?? {} )

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -116,10 +116,11 @@ export default function WPCheckout( {
 	);
 	const shouldShowContactStep =
 		areThereDomainProductsInCart || isGSuiteInCart || total.amount.value > 0;
-	const [ shouldShowInvalidContactDetails, setshouldShowInvalidContactDetails ] = useState( false );
+
+	const [ areContactDetailsInvalid, setAreContactDetailsInvalid ] = useState( false );
+
 	const shouldShowDomainContactFields =
-		shouldShowContactStep &&
-		( needsDomainDetails( responseCart ) || shouldShowInvalidContactDetails );
+		shouldShowContactStep && ( needsDomainDetails( responseCart ) || areContactDetailsInvalid );
 
 	const contactInfo = useSelect( ( sel ) => sel( 'wpcom' ).getContactInfo() ) || {};
 	const { setSiteId, touchContactFields, applyDomainContactValidationResults } = useDispatch(
@@ -132,7 +133,7 @@ export default function WPCheckout( {
 	] = useState( false );
 
 	const validateContactDetailsAndDisplayErrors = async () => {
-		debug( 'validating contact details with side effects' );
+		debug( 'validating contact details and reporting errors' );
 		if ( areThereDomainProductsInCart ) {
 			const validationResult = await getDomainValidationResult( items, contactInfo );
 			debug( 'validating contact details result', validationResult );
@@ -142,9 +143,10 @@ export default function WPCheckout( {
 				paymentMethodId: activePaymentMethod.id,
 				validationResult,
 				applyDomainContactValidationResults,
-				setshouldShowInvalidContactDetails,
 			} );
-			return isContactValidationResponseValid( validationResult, contactInfo );
+			const isValid = isContactValidationResponseValid( validationResult, contactInfo );
+			setAreContactDetailsInvalid( ! isValid );
+			return isValid;
 		} else if ( isGSuiteInCart ) {
 			const validationResult = await getGSuiteValidationResult( items, contactInfo );
 			debug( 'validating contact details result', validationResult );
@@ -154,22 +156,28 @@ export default function WPCheckout( {
 				paymentMethodId: activePaymentMethod.id,
 				validationResult,
 				applyDomainContactValidationResults,
-				setshouldShowInvalidContactDetails,
 			} );
-			return isContactValidationResponseValid( validationResult, contactInfo );
+			const isValid = isContactValidationResponseValid( validationResult, contactInfo );
+			setAreContactDetailsInvalid( ! isValid );
+			return isValid;
 		}
 		return isCompleteAndValid( contactInfo );
 	};
+
 	const validateContactDetails = async () => {
-		debug( 'validating contact details' );
+		debug( 'validating contact details without reporting errors' );
 		if ( areThereDomainProductsInCart ) {
 			const validationResult = await getDomainValidationResult( items, contactInfo );
 			debug( 'validating contact details result', validationResult );
-			return isContactValidationResponseValid( validationResult, contactInfo );
+			const isValid = isContactValidationResponseValid( validationResult, contactInfo );
+			setAreContactDetailsInvalid( ! isValid );
+			return isValid;
 		} else if ( isGSuiteInCart ) {
 			const validationResult = await getGSuiteValidationResult( items, contactInfo );
 			debug( 'validating contact details result', validationResult );
-			return isContactValidationResponseValid( validationResult, contactInfo );
+			const isValid = isContactValidationResponseValid( validationResult, contactInfo );
+			setAreContactDetailsInvalid( ! isValid );
+			return isValid;
 		}
 		return isCompleteAndValid( contactInfo );
 	};

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -134,6 +134,7 @@ export default function WPCheckout( {
 
 	const validateContactDetailsAndDisplayErrors = async () => {
 		debug( 'validating contact details and reporting errors' );
+		let isValid = false;
 		if ( areThereDomainProductsInCart ) {
 			const validationResult = await getDomainValidationResult( items, contactInfo );
 			debug( 'validating contact details result', validationResult );
@@ -144,9 +145,7 @@ export default function WPCheckout( {
 				validationResult,
 				applyDomainContactValidationResults,
 			} );
-			const isValid = isContactValidationResponseValid( validationResult, contactInfo );
-			setAreContactDetailsInvalid( ! isValid );
-			return isValid;
+			isValid = isContactValidationResponseValid( validationResult, contactInfo );
 		} else if ( isGSuiteInCart ) {
 			const validationResult = await getGSuiteValidationResult( items, contactInfo );
 			debug( 'validating contact details result', validationResult );
@@ -157,29 +156,30 @@ export default function WPCheckout( {
 				validationResult,
 				applyDomainContactValidationResults,
 			} );
-			const isValid = isContactValidationResponseValid( validationResult, contactInfo );
-			setAreContactDetailsInvalid( ! isValid );
-			return isValid;
+			isValid = isContactValidationResponseValid( validationResult, contactInfo );
+		} else {
+			isValid = isCompleteAndValid( contactInfo );
 		}
-		return isCompleteAndValid( contactInfo );
+		setAreContactDetailsInvalid( ! isValid );
+		return isValid;
 	};
 
 	const validateContactDetails = async () => {
 		debug( 'validating contact details without reporting errors' );
+		let isValid = false;
 		if ( areThereDomainProductsInCart ) {
 			const validationResult = await getDomainValidationResult( items, contactInfo );
 			debug( 'validating contact details result', validationResult );
-			const isValid = isContactValidationResponseValid( validationResult, contactInfo );
-			setAreContactDetailsInvalid( ! isValid );
-			return isValid;
+			isValid = isContactValidationResponseValid( validationResult, contactInfo );
 		} else if ( isGSuiteInCart ) {
 			const validationResult = await getGSuiteValidationResult( items, contactInfo );
 			debug( 'validating contact details result', validationResult );
-			const isValid = isContactValidationResponseValid( validationResult, contactInfo );
-			setAreContactDetailsInvalid( ! isValid );
-			return isValid;
+			isValid = isContactValidationResponseValid( validationResult, contactInfo );
+		} else {
+			isValid = isCompleteAndValid( contactInfo );
 		}
-		return isCompleteAndValid( contactInfo );
+		setAreContactDetailsInvalid( ! isValid );
+		return isValid;
 	};
 
 	const [ isSummaryVisible, setIsSummaryVisible ] = useState( false );

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -116,7 +116,10 @@ export default function WPCheckout( {
 	);
 	const shouldShowContactStep =
 		areThereDomainProductsInCart || isGSuiteInCart || total.amount.value > 0;
-	const shouldShowDomainContactFields = shouldShowContactStep && needsDomainDetails( responseCart );
+	const [ shouldShowInvalidContactDetails, setshouldShowInvalidContactDetails ] = useState( false );
+	const shouldShowDomainContactFields =
+		shouldShowContactStep &&
+		( needsDomainDetails( responseCart ) || shouldShowInvalidContactDetails );
 
 	const contactInfo = useSelect( ( sel ) => sel( 'wpcom' ).getContactInfo() ) || {};
 	const { setSiteId, touchContactFields, applyDomainContactValidationResults } = useDispatch(
@@ -139,6 +142,7 @@ export default function WPCheckout( {
 				paymentMethodId: activePaymentMethod.id,
 				validationResult,
 				applyDomainContactValidationResults,
+				setshouldShowInvalidContactDetails,
 			} );
 			return isContactValidationResponseValid( validationResult, contactInfo );
 		} else if ( isGSuiteInCart ) {
@@ -150,6 +154,7 @@ export default function WPCheckout( {
 				paymentMethodId: activePaymentMethod.id,
 				validationResult,
 				applyDomainContactValidationResults,
+				setshouldShowInvalidContactDetails,
 			} );
 			return isContactValidationResponseValid( validationResult, contactInfo );
 		}


### PR DESCRIPTION
In #44533, we're hiding the full domain contact details form for renewals to prevent users from submitting invalid data that's already stored. Unfortunately, some old cached domain details might not conform to the validation required for renewals. 

This PR shows the full contact form, with highlighted invalid fields If the server returns an error on validating the cached details.

ref: p1596628478344100-payments-shilling

**To test:**
This is a hard one to test because it requires invalid data from the original domain registration (which was valid at the time). 

- Sandbox the store.
- Apply D47627-code which will return an invalid phone number for cached contact details.
- Add a domain renewal to your cart.
- Verify that you see the full contact details (zip/country).
- Attempt to submit contact step.
- Verify that the invalid field is highlighted.
- Fix invalid data and submit step.
- Verify that step can be submitted and domain renewal can be purchased.