### PR TITLE
i18n: Use `translate` script for CircleCI strings extraction job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -303,8 +303,9 @@ jobs:
       - prepare
       - run:
           name: Extract strings
-          working_directory: wp-babel-makepot
-          command: npx https://github.com/Automattic/wp-babel-makepot "~/wp-calypso/{client,packages,apps}/**/*.{js,jsx,ts,tsx}" --ignore "**/node_modules/**,**/test/**,**/*.d.ts" --base "$HOME/wp-calypso" --output "$CIRCLE_ARTIFACTS/translate/calypso-strings.pot"
+          command: |
+            yarn run translate
+            mv calypso-strings.pot "$CIRCLE_ARTIFACTS/translate"
       - run:
           name: Build New Strings .pot
           when: always


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Replace npx call from remote repo with local `translate` script call for CircleCI string extraction job.

#### Testing instructions

* Check stored artifacts in CircleCI `translate` job and confirm `calypso-strings.pot` exists and its content consists of expected translatable strings.