### PR TITLE
Open post in new tab/window when clicking on "View Post" in publish panel & snackbar notification.

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -308,7 +308,7 @@ class CalypsoifyIframe extends Component<
 			const { postUrl } = payload;
 			config.isEnabled( 'desktop' )
 				? this.props.notifyDesktopViewPostClicked( postUrl )
-				: window.open( postUrl, '_top' );
+				: window.open( postUrl, '_blank' );
 		}
 
 		if ( EditorActions.OpenCustomizer === action ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Open post in new tab/window when clicking on "View Post" in publish panel & snackbar notification. See `openLinksInParentFrame()` in `iframe-bridge-server.js` for affected elements.

#### Testing instructions

You can test this in local calypso. See https://github.com/Automattic/wp-calypso/issues/40061 for test instructions.

![image](https://user-images.githubusercontent.com/1287077/89422187-4dfebc80-d735-11ea-8850-a757ac8b0031.png)

Fixes https://github.com/Automattic/wp-calypso/issues/40061
