### PR TITLE
Composite checkout: Prevent validating contact details for renewals

### DIFF
--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -117,6 +117,7 @@ export default function WPCheckout( {
 	const shouldShowContactStep =
 		areThereDomainProductsInCart || isGSuiteInCart || total.amount.value > 0;
 	const shouldShowDomainContactFields = shouldShowContactStep && needsDomainDetails( responseCart );
+	const areDomainDetailsNeededForTransaction = needsDomainDetails( responseCart ) || isGSuiteInCart;
 
 	const contactInfo = useSelect( ( sel ) => sel( 'wpcom' ).getContactInfo() ) || {};
 	const { setSiteId, touchContactFields, applyDomainContactValidationResults } = useDispatch(
@@ -130,8 +131,7 @@ export default function WPCheckout( {
 
 	const validateContactDetailsAndDisplayErrors = async () => {
 		debug( 'validating contact details and reporting errors' );
-		const areDomainDetailsNeeded = needsDomainDetails( responseCart ) || isGSuiteInCart;
-		if ( ! areDomainDetailsNeeded ) {
+		if ( ! areDomainDetailsNeededForTransaction ) {
 			return isCompleteAndValid( contactInfo );
 		} else if ( areThereDomainProductsInCart ) {
 			const validationResult = await getDomainValidationResult( items, contactInfo );
@@ -160,8 +160,7 @@ export default function WPCheckout( {
 	};
 	const validateContactDetails = async () => {
 		debug( 'validating contact details without reporting errors' );
-		const areDomainDetailsNeeded = needsDomainDetails( responseCart ) || isGSuiteInCart;
-		if ( ! areDomainDetailsNeeded ) {
+		if ( ! areDomainDetailsNeededForTransaction ) {
 			return isCompleteAndValid( contactInfo );
 		} else if ( areThereDomainProductsInCart ) {
 			const validationResult = await getDomainValidationResult( items, contactInfo );

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -129,8 +129,11 @@ export default function WPCheckout( {
 	] = useState( false );
 
 	const validateContactDetailsAndDisplayErrors = async () => {
-		debug( 'validating contact details with side effects' );
-		if ( areThereDomainProductsInCart ) {
+		debug( 'validating contact details and reporting errors' );
+		const areDomainDetailsNeeded = needsDomainDetails( responseCart ) || isGSuiteInCart;
+		if ( ! areDomainDetailsNeeded ) {
+			return isCompleteAndValid( contactInfo );
+		} else if ( areThereDomainProductsInCart ) {
 			const validationResult = await getDomainValidationResult( items, contactInfo );
 			debug( 'validating contact details result', validationResult );
 			handleContactValidationResult( {
@@ -156,8 +159,11 @@ export default function WPCheckout( {
 		return isCompleteAndValid( contactInfo );
 	};
 	const validateContactDetails = async () => {
-		debug( 'validating contact details' );
-		if ( areThereDomainProductsInCart ) {
+		debug( 'validating contact details without reporting errors' );
+		const areDomainDetailsNeeded = needsDomainDetails( responseCart ) || isGSuiteInCart;
+		if ( ! areDomainDetailsNeeded ) {
+			return isCompleteAndValid( contactInfo );
+		} else if ( areThereDomainProductsInCart ) {
 			const validationResult = await getDomainValidationResult( items, contactInfo );
 			debug( 'validating contact details result', validationResult );
 			return isContactValidationResponseValid( validationResult, contactInfo );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Since https://github.com/Automattic/wp-calypso/pull/44533 we do not send `domain_details` (full contact details) to the transactions endpoint when submitting a renewal purchase. However, we were still sending those details to the validation endpoints before purchase, which can cause odd bugs if cached contact details exist that are somehow invalid. 

This was attempted to be fixed by https://github.com/Automattic/wp-calypso/pull/44690 (and then reverted) by not allowing us to have invalid contact details, but it does not really solve the issue because it implies that we can change those contact details, when in fact they are not being used anywhere after validation.

This PR does not send contact details for validation at all if they are not going to be sent to the transactions endpoint.

#### Testing instructions

- Sandbox the store.
- Apply D47627-code which will return an invalid phone number for cached contact details.
- Add a domain renewal to your cart.
- Verify that you do not see the full contact details step (it should have only postal code and country) _and_ that the contact step is skipped.
- Verify that if you go back and edit the contact step, it remains valid.
- Verify that the domain renewal can be purchased.