### PR TITLE
Customer Home: Remove brand font from smaller subheads

### DIFF
--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -79,7 +79,6 @@
 }
 
 .customer-home__section-heading {
-	@extend .wp-brand-font;
 	font-size: 1.25rem;
 	margin: 32px 0 16px;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Our guidelines suggest that we should not overuse the brand font, Recoleta, and using it for all section headings on Customer Home tips into "overuse" territory, IMO. Thoughts?

**Before**

![screencapture-wordpress-home-calobeetesting87-wordpress-com-2020-08-04-14_10_02](https://user-images.githubusercontent.com/2124984/89432228-db7ae600-d70e-11ea-8cac-7b903da82675.png)

**After**

![screencapture-calypso-localhost-3000-home-calobeetesting87-wordpress-com-2020-08-05-11_25_57](https://user-images.githubusercontent.com/2124984/89432255-e03f9a00-d70e-11ea-931f-7d07d83607d3.png)

#### Testing instructions

* Switch to this PR
* Navigate to Customer Home or `/home`
* Note the change in the secondary and tertiary section headings (Stats, Learn and Grow, etc.)