### PR TITLE
Typography: Update instances of 18px to $font-body or $font-title-small

### DIFF
--- a/client/blocks/credit-card-form/style.scss
+++ b/client/blocks/credit-card-form/style.scss
@@ -59,6 +59,6 @@
 }
 
 .credit-card-form__heading {
-	font-size: 18px;
+	font-size: $font-title-small;
 	padding: 0 0 16px;
 }

--- a/client/blocks/get-apps/style.scss
+++ b/client/blocks/get-apps/style.scss
@@ -12,7 +12,7 @@
 	margin-bottom: 4px;
 
 	@include breakpoint-deprecated('>480px') {
-		font-size: 18px;
+		font-size: $font-title-small;
 	}
 }
 

--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -174,7 +174,7 @@
 			}
 
 			.search__input {
-				font-size: 18px;
+				font-size: $font-title-small;
 				padding: 12px 0;
 				color: var( --color-text );
 
@@ -376,7 +376,7 @@
 	font-size: $font-body-small;
 
 	@include breakpoint-deprecated( '>660px' ) {
-		font-size: 18px;
+		font-size: $font-title-small;
 		line-height: 1.3;
 	}
 

--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -174,12 +174,11 @@
 			}
 
 			.search__input {
-				font-size: $font-title-small;
+				font-size: $font-body;
 				padding: 12px 0;
 				color: var( --color-text );
 
 				@include breakpoint-deprecated( '>660px' ) {
-					font-size: $font-body;
 					padding: 16px 0;
 				}
 			}

--- a/client/blocks/post-item/style.scss
+++ b/client/blocks/post-item/style.scss
@@ -79,7 +79,7 @@ $expanded-post-item-outline: 4px solid $post-item-border-color;
 	margin: 0;
 	padding: 0;
 	font-weight: 700;
-	font-size: 18px;
+	font-size: $font-title-small;
 	line-height: 1.2;
 }
 

--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -27,7 +27,7 @@
 	}
 
 	h4 {
-		font-size: 18px;
+		font-size: $font-title-small;
 		font-weight: 700;
 		margin: 0 0 8px;
 	}

--- a/client/blocks/support-article-dialog/content.scss
+++ b/client/blocks/support-article-dialog/content.scss
@@ -27,7 +27,7 @@
 	}
 
 	h4 {
-		font-size: 18px;
+		font-size: $font-title-small;
 		font-weight: 700;
 		margin: 0 0 8px;
 	}

--- a/client/components/activity-card/style.scss
+++ b/client/components/activity-card/style.scss
@@ -64,7 +64,7 @@
 	word-wrap: break-word;
 
 	@include breakpoint-deprecated( '>660px' ) {
-		font-size: 18px;
+		font-size: $font-title-small;
 	}
 }
 

--- a/client/components/community-translator/style.scss
+++ b/client/components/community-translator/style.scss
@@ -22,7 +22,7 @@
 	h2 {
 		font-weight: normal;
 		display: inline-block;
-		font-size: 18px;
+		font-size: $font-title-small;
 	}
 	nav {
 		text-align: right;

--- a/client/components/date-picker/style.scss
+++ b/client/components/date-picker/style.scss
@@ -112,7 +112,7 @@ $date-picker_nav_button_size: 20px;
 	background-position: center;
 	background-size: contain;
 	cursor: pointer;
-	font-size: 18px;
+	font-size: $font-title-small;
 
 	&::before {
 		height: $date-picker_nav_button_size;
@@ -124,7 +124,7 @@ $date-picker_nav_button_size: 20px;
 	text-align: center;
 	height: $date-picker_caption_height;
 	line-height: $date-picker_caption_height;
-	font-size: 18px;
+	font-size: $font-title-small;
 	margin: 0 $date-picker_nav_button_size * 1.5;
 	position: relative;
 	cursor: pointer;

--- a/client/components/date-picker/style.scss
+++ b/client/components/date-picker/style.scss
@@ -124,7 +124,7 @@ $date-picker_nav_button_size: 20px;
 	text-align: center;
 	height: $date-picker_caption_height;
 	line-height: $date-picker_caption_height;
-	font-size: $font-title-small;
+	font-size: $font-body;
 	margin: 0 $date-picker_nav_button_size * 1.5;
 	position: relative;
 	cursor: pointer;

--- a/client/components/domains/domain-search-results/style.scss
+++ b/client/components/domains/domain-search-results/style.scss
@@ -21,7 +21,7 @@
 	}
 
 	@include breakpoint-deprecated( '>660px' ) {
-		font-size: 18px;
+		font-size: $font-title-small;
 
 		p {
 			font-size: $font-body;

--- a/client/components/domains/transfer-domain-step/style.scss
+++ b/client/components/domains/transfer-domain-step/style.scss
@@ -137,7 +137,7 @@
 	border: 1px solid var( --color-neutral-10 );
 	background-color: var( --color-neutral-0 );
 	color: var( --color-neutral-50 );
-	font-size: 18px;
+	font-size: $font-title-small;
 	text-align: center;
 	margin-right: 15px;
 	flex-shrink: 0;

--- a/client/components/gsuite/gsuite-price/style.scss
+++ b/client/components/gsuite/gsuite-price/style.scss
@@ -1,5 +1,5 @@
 .gsuite-price__monthly-price {
-	font-size: 18px;
+	font-size: $font-title-small;
 	font-weight: 600;
 
 	strong {

--- a/client/components/share/style.scss
+++ b/client/components/share/style.scss
@@ -22,7 +22,7 @@
 .facebook-share-preview__title {
 	color: #1d2129;
 	font-family: Georgia, serif;
-	font-size: 18px;
+	font-size: $font-title-small;
 	font-weight: 600;
 	line-height: 22px;
 	max-height: 100px;

--- a/client/components/share/style.scss
+++ b/client/components/share/style.scss
@@ -22,7 +22,7 @@
 .facebook-share-preview__title {
 	color: #1d2129;
 	font-family: Georgia, serif;
-	font-size: $font-title-small;
+	font-size: 18px; /* stylelint-disable-line */
 	font-weight: 600;
 	line-height: 22px;
 	max-height: 100px;

--- a/client/components/thank-you-card/style.scss
+++ b/client/components/thank-you-card/style.scss
@@ -56,7 +56,7 @@
 }
 
 .thank-you-card__name {
-	font-size: 18px;
+	font-size: $font-title-small;
 	font-weight: 600;
 	margin-bottom: 5px;
 
@@ -86,7 +86,7 @@
 }
 
 .thank-you-card__heading {
-	font-size: 18px;
+	font-size: $font-title-small;
 	font-weight: 600;
 	margin-bottom: 8px;
 

--- a/client/components/tinymce/style.scss
+++ b/client/components/tinymce/style.scss
@@ -310,7 +310,7 @@
 
 .mce-window .mce-window-head .mce-title {
 	color: #444;
-	font-size: 18px;
+	font-size: $font-title-small;
 	font-weight: 600;
 	line-height: 36px;
 	margin: 0;
@@ -1615,7 +1615,7 @@ i.mce-i-wp_code::before {
 
 #wp-fullscreen-tagline {
 	color: #82878c;
-	font-size: 18px;
+	font-size: $font-title-small;
 	float: right;
 	padding: 4px 0 0;
 }
@@ -1699,7 +1699,7 @@ i.mce-i-wp_code::before {
 	background: none;
 	color: #32373c;
 	cursor: pointer;
-	font-size: 18px;
+	font-size: $font-title-small;
 	line-height: 20px;
 	overflow: visible;
 	text-align: center;

--- a/client/devdocs/style.scss
+++ b/client/devdocs/style.scss
@@ -11,7 +11,7 @@ $devdocs-max-width: 720px;
 .devdocs__result {
 	.devdocs__result-title {
 		font-weight: 600;
-		font-size: 18px;
+		font-size: $font-title-small;
 
 		.devdocs__result-link {
 			text-decoration: underline;
@@ -104,7 +104,7 @@ $devdocs-max-width: 720px;
 
 	.docs-example__wrapper-header-title {
 		font-family: $code;
-		font-size: 18px;
+		font-size: $font-title-small;
 		letter-spacing: 1px;
 		border-bottom: 1px solid rgba( var( --color-neutral-10-rgb ), 0.65 );
 

--- a/client/extensions/woocommerce/app/settings/email/mailchimp/style.scss
+++ b/client/extensions/woocommerce/app/settings/email/mailchimp/style.scss
@@ -29,7 +29,7 @@
 }
 
 .mailchimp__getting-started-title-text {
-	font-size: 18px;
+	font-size: $font-title-small;
 	font-weight: 600;
 	padding-bottom: 4px;
 }
@@ -124,7 +124,7 @@
 }
 
 .setup-steps__login-title {
-	font-size: 18px;
+	font-size: $font-title-small;
 	font-weight: 600;
 	margin-bottom: 8px;
 }
@@ -212,7 +212,7 @@
 
 .mailchimp__dashboard-title {
 	flex-grow: 1;
-	font-size: 18px;
+	font-size: $font-title-small;
 	font-weight: 400;
 }
 

--- a/client/extensions/woocommerce/app/settings/payments/stripe/style.scss
+++ b/client/extensions/woocommerce/app/settings/payments/stripe/style.scss
@@ -77,7 +77,7 @@
 }
 
 .stripe__method-edit-header {
-	font-size: 18px;
+	font-size: $font-title-small;
 	justify-content: space-between;
 	padding: 0 0 16px;
 	font-weight: 600;

--- a/client/extensions/woocommerce/app/settings/payments/style.scss
+++ b/client/extensions/woocommerce/app/settings/payments/style.scss
@@ -207,7 +207,7 @@
 }
 
 .payments__method-edit-header {
-	font-size: 18px;
+	font-size: $font-title-small;
 	justify-content: space-between;
 	padding: 0 0 16px;
 }

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/style.scss
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/style.scss
@@ -265,7 +265,7 @@
 
 .shipping-zone__method-dialog-header {
 	padding-bottom: 16px;
-	font-size: 18px;
+	font-size: $font-title-small;
 	display: flex;
 	justify-content: space-between;
 	flex-shrink: 0;
@@ -319,7 +319,7 @@
 
 .shipping-zone__location-dialog-header {
 	padding: 0 0 24px;
-	font-size: 18px;
+	font-size: $font-title-small;
 }
 
 .shipping-zone__location-dialog-list-item {

--- a/client/extensions/woocommerce/components/extended-header/style.scss
+++ b/client/extensions/woocommerce/components/extended-header/style.scss
@@ -6,7 +6,7 @@
 	}
 
 	.extended-header__header {
-		font-size: 18px;
+		font-size: $font-title-small;
 		margin-bottom: 0;
 		padding-top: 8px;
 	}

--- a/client/landing/domains/content-card/style.scss
+++ b/client/landing/domains/content-card/style.scss
@@ -30,7 +30,7 @@
 
 	.content-card__footer {
 		color: var( --color-neutral-50 );
-		font-size: 18px;
+		font-size: $font-title-small;
 		font-weight: 400;
 		margin-bottom: 16px;
 

--- a/client/landing/jetpack-cloud/style.scss
+++ b/client/landing/jetpack-cloud/style.scss
@@ -208,7 +208,7 @@ html {
 		line-height: 23px;
 
 		@include breakpoint-deprecated( '>660px' ) {
-			font-size: 18px;
+			font-size: $font-title-small;
 			line-height: 23px;
 		}
 	}
@@ -218,7 +218,7 @@ html {
 		line-height: 24px;
 
 		@include breakpoint-deprecated('>660px') {
-			font-size: 18px;
+			font-size: $font-title-small;
 			line-height: 24px;
 		}
 	}

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -898,7 +898,7 @@
 		}
 
 		.login__form-userdata label {
-			font-size: 18px;
+			font-size: $font-title-small;
 			font-weight: 400;
 		}
 	}

--- a/client/me/memberships/subscription.scss
+++ b/client/me/memberships/subscription.scss
@@ -94,7 +94,7 @@
 .memberships__subscription-title {
 	color: var( --color-primary );
 	display: block;
-	font-size: 18px;
+	font-size: $font-title-small;
 	line-height: 1.2em;
 	padding: 20px;
 	white-space: nowrap;

--- a/client/me/pending-payments/style.scss
+++ b/client/me/pending-payments/style.scss
@@ -33,7 +33,7 @@
 	}
 
 	@include breakpoint-deprecated( '>480px' ) {
-		font-size: 18px;
+		font-size: $font-title-small;
 		max-width: none;
 	}
 }

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -143,7 +143,7 @@
 .manage-purchase__title {
 	color: var( --color-text );
 	display: block;
-	font-size: 18px;
+	font-size: $font-title-small;
 	font-weight: 400;
 	clear: none;
 

--- a/client/me/purchases/purchase-item/style.scss
+++ b/client/me/purchases/purchase-item/style.scss
@@ -91,7 +91,7 @@
 	}
 
 	@include breakpoint-deprecated( '>480px' ) {
-		font-size: 18px;
+		font-size: $font-title-small;
 		max-width: none;
 	}
 }

--- a/client/me/security-2fa-backup-codes-list/style.scss
+++ b/client/me/security-2fa-backup-codes-list/style.scss
@@ -49,7 +49,7 @@ button.security-2fa-backups-codes-list__generate-button {
 .security-2fa-backup-codes-list__codes li {
 	color: var( --color-neutral-70 );
 	float: left;
-	font-size: 18px;
+	font-size: $font-title-small;
 	font-weight: 600;
 	line-height: 28px;
 	width: 50%;

--- a/client/my-sites/activity/activity-log-switch/style.scss
+++ b/client/my-sites/activity/activity-log-switch/style.scss
@@ -35,7 +35,7 @@
 }
 
 .activity-log-switch__header-text {
-	font-size: 18px;
+	font-size: $font-title-small;
 	margin: 24px 64px 32px;
 }
 

--- a/client/my-sites/checkout/checkout-thank-you/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/style.scss
@@ -176,7 +176,7 @@
 
 .checkout-thank-you__header-text,
 .checkout-thank-you__success-message-item {
-	font-size: 18px;
+	font-size: $font-title-small;
 	font-weight: 400;
 	margin-top: 15px;
 }

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -527,7 +527,7 @@
 			.checkout__payment-box-section-content {
 				> h6 {
 					color: var( --color-primary );
-					font-size: 18px;
+					font-size: $font-title-small;
 				}
 
 				> span {

--- a/client/my-sites/checkout/upsell-nudge/concierge-support-session/style.scss
+++ b/client/my-sites/checkout/upsell-nudge/concierge-support-session/style.scss
@@ -96,7 +96,7 @@ main.concierge-support-session.main {
 		margin-bottom: 0.75em;
 
 		@include breakpoint-deprecated( '<660px' ) {
-			font-size: $font-title-small;
+			font-size: $font-body;
 		}
 	}
 

--- a/client/my-sites/checkout/upsell-nudge/concierge-support-session/style.scss
+++ b/client/my-sites/checkout/upsell-nudge/concierge-support-session/style.scss
@@ -96,7 +96,7 @@ main.concierge-support-session.main {
 		margin-bottom: 0.75em;
 
 		@include breakpoint-deprecated( '<660px' ) {
-			font-size: 18px;
+			font-size: $font-title-small;
 		}
 	}
 

--- a/client/my-sites/checkout/upsell-nudge/plan-upgrade-upsell/style.scss
+++ b/client/my-sites/checkout/upsell-nudge/plan-upgrade-upsell/style.scss
@@ -105,7 +105,7 @@ main.plan-upgrade-upsell.main {
 		margin-bottom: 1.6em;
 
 		@include breakpoint-deprecated( '<660px' ) {
-			font-size: 18px;
+			font-size: $font-title-small;
 		}
 	}
 

--- a/client/my-sites/checkout/upsell-nudge/plan-upgrade-upsell/style.scss
+++ b/client/my-sites/checkout/upsell-nudge/plan-upgrade-upsell/style.scss
@@ -105,7 +105,7 @@ main.plan-upgrade-upsell.main {
 		margin-bottom: 1.6em;
 
 		@include breakpoint-deprecated( '<660px' ) {
-			font-size: $font-title-small;
+			font-size: $font-body;
 		}
 	}
 

--- a/client/my-sites/checkout/upsell-nudge/white-glove/style.scss
+++ b/client/my-sites/checkout/upsell-nudge/white-glove/style.scss
@@ -149,7 +149,7 @@ main.white-glove.main {
 		margin-bottom: 1.6em;
 
 		@include breakpoint-deprecated( '<660px' ) {
-			font-size: $font-title-small;
+			font-size: $font-body;
 		}
 	}
 

--- a/client/my-sites/checkout/upsell-nudge/white-glove/style.scss
+++ b/client/my-sites/checkout/upsell-nudge/white-glove/style.scss
@@ -149,7 +149,7 @@ main.white-glove.main {
 		margin-bottom: 1.6em;
 
 		@include breakpoint-deprecated( '<660px' ) {
-			font-size: 18px;
+			font-size: $font-title-small;
 		}
 	}
 

--- a/client/my-sites/customer-home/cards/tasks/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/style.scss
@@ -65,7 +65,7 @@
 		color: var( --color-text );
 
 		@include breakpoint-deprecated( '>800px' ) {
-			font-size: 18px;
+			font-size: $font-title-small;
 			line-height: 28px;
 			margin-bottom: 32px;
 		}

--- a/client/my-sites/domains/domain-management/edit/style.scss
+++ b/client/my-sites/domains/domain-management/edit/style.scss
@@ -10,7 +10,7 @@
 	}
 
 	.edit__transfer-text-fail {
-		font-size: 18px;
+		font-size: $font-title-small;
 		font-weight: 600;
 		margin-bottom: 1em;
 	}

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -81,7 +81,7 @@
 	line-height: normal;
 
 	@include breakpoint-deprecated( '>480px' ) {
-		font-size: 18px;
+		font-size: $font-title-small;
 		font-weight: 600;
 		max-width: none;
 		white-space: normal;

--- a/client/my-sites/email/gsuite-purchase-cta/style.scss
+++ b/client/my-sites/email/gsuite-purchase-cta/style.scss
@@ -48,7 +48,7 @@
 }
 
 .gsuite-purchase-cta__header-description-sub-title {
-	font-size: 18px;
+	font-size: $font-title-small;
 }
 
 .gsuite-purchase-cta__header-image {

--- a/client/my-sites/exporter/guided-transfer-card/style.scss
+++ b/client/my-sites/exporter/guided-transfer-card/style.scss
@@ -25,7 +25,7 @@
 
 .guided-transfer-card__price {
 	font-style: normal;
-	font-size: 18px;
+	font-size: $font-title-small;
 }
 
 .guided-transfer-card__details {

--- a/client/my-sites/marketing/style.scss
+++ b/client/my-sites/marketing/style.scss
@@ -79,7 +79,7 @@
 	}
 
 	select {
-		font-size: 18px;
+		font-size: $font-title-small;
 	}
 
 	input[type='number'] {
@@ -89,7 +89,7 @@
 	}
 
 	h4 {
-		font-size: 18px;
+		font-size: $font-title-small;
 		margin-bottom: 0.5em;
 	}
 
@@ -205,7 +205,7 @@
 	position: relative;
 
 	h3 {
-		font-size: 18px;
+		font-size: $font-title-small;
 		margin-bottom: 10px;
 	}
 

--- a/client/my-sites/migrate/section-migrate.scss
+++ b/client/my-sites/migrate/section-migrate.scss
@@ -129,12 +129,12 @@
 }
 
 .migrate__plan-name {
-	font-size: 18px;
+	font-size: $font-title-small;
 }
 
 .migrate__plan-price {
 	.plan-price__currency-symbol {
-		font-size: 18px;
+		font-size: $font-title-small;
 	}
 
 	.plan-price__integer {

--- a/client/my-sites/pages/blog-posts-page/style.scss
+++ b/client/my-sites/pages/blog-posts-page/style.scss
@@ -23,7 +23,7 @@
 	@extend %content-font;
 	color: var( --color-neutral-70 );
 	font-weight: 700;
-	font-size: 18px;
+	font-size: $font-title-small;
 	line-height: 1.2;
 
 	display: inline;

--- a/client/my-sites/pages/style.scss
+++ b/client/my-sites/pages/style.scss
@@ -125,7 +125,7 @@
 	@extend %content-font;
 	color: var( --color-neutral-70 );
 	font-weight: 700;
-	font-size: 18px;
+	font-size: $font-title-small;
 	line-height: 1.2;
 
 	display: inline;

--- a/client/my-sites/people/people-list-item/style.scss
+++ b/client/my-sites/people/people-list-item/style.scss
@@ -42,7 +42,7 @@
 
 .people-list-item.is-invite .people-profile__username {
 	@include breakpoint-deprecated( '>480px' ) {
-		font-size: 18px;
+		font-size: $font-title-small;
 	}
 }
 

--- a/client/my-sites/plans/current-plan/style.scss
+++ b/client/my-sites/plans/current-plan/style.scss
@@ -68,7 +68,7 @@
 }
 
 .current-plan__header-text {
-	font-size: 18px;
+	font-size: $font-title-small;
 }
 
 .current-plan__header.is-placeholder {

--- a/client/my-sites/plugins/plugin-meta/style.scss
+++ b/client/my-sites/plugins/plugin-meta/style.scss
@@ -39,7 +39,7 @@
 
 .plugin-meta__name {
 	color: var( --color-neutral-70 );
-	font-size: 18px;
+	font-size: $font-title-small;
 	font-weight: 600;
 	line-height: 32px;
 	white-space: pre;

--- a/client/my-sites/stats/annual-site-stats/style.scss
+++ b/client/my-sites/stats/annual-site-stats/style.scss
@@ -55,7 +55,7 @@
 }
 
 .annual-site-stats__stat-figure {
-	font-size: 18px;
+	font-size: $font-title-small;
 
 	@include breakpoint-deprecated( '<480px' ) {
 		font-size: $font-body-small;

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -284,7 +284,7 @@
 	}
 
 	h4 {
-		font-size: 18px;
+		font-size: $font-title-small;
 		font-weight: 400;
 		margin: 40px 0 10px;
 	}

--- a/client/post-editor/editor-gutenberg-opt-in-dialog/style.scss
+++ b/client/post-editor/editor-gutenberg-opt-in-dialog/style.scss
@@ -34,7 +34,7 @@
 			margin-bottom: 24px;
 
 			&.editor-gutenberg-opt-in-dialog__subhead {
-				font-size: 18px;
+				font-size: $font-title-small;
 				color: var( --color-neutral-50 );
 			}
 		}

--- a/client/reader/following/style.scss
+++ b/client/reader/following/style.scss
@@ -68,7 +68,7 @@
 	display: flex;
 	flex: 1 1 0;
 	flex-direction: column;
-	font-size: 18px;
+	font-size: $font-title-small;
 	justify-content: center;
 	margin-left: 24px;
 
@@ -82,7 +82,7 @@
 	}
 
 	@include breakpoint-deprecated( '<660px' ) {
-		font-size: 18px;
+		font-size: $font-title-small;
 	}
 
 	@include breakpoint-deprecated( '<480px' ) {

--- a/client/reader/list-manage/style.scss
+++ b/client/reader/list-manage/style.scss
@@ -9,7 +9,7 @@
 	}
 
 	.list-item__name {
-		font-size: 18px;
+		font-size: $font-title-small;
 	}
 
 	.list-item__url {

--- a/client/reader/style.scss
+++ b/client/reader/style.scss
@@ -75,7 +75,7 @@
 	word-wrap: break-word;
 
 	@include breakpoint-deprecated( '<480px' ) {
-		font-size: 18px;
+		font-size: $font-title-small;
 		line-height: 1.3;
 	}
 

--- a/client/signup/steps/p2-site/style.scss
+++ b/client/signup/steps/p2-site/style.scss
@@ -3,7 +3,7 @@
 	line-height: 22px;
 	pointer-events: none;
 	position: absolute;
-	font-size: 18px;
+	font-size: $font-title-small;
 	top: 62px;
 	right: 24px;
 }
@@ -32,7 +32,7 @@
 	border: none;
 	border-radius: 40px;
 	font-weight: normal;
-	font-size: 18px;
+	font-size: $font-title-small;
 	color: var( --p2-color-text-white );
 	transition: background 0.2s ease;
 
@@ -54,7 +54,7 @@
 .p2-site__form .form-label {
 	color: var( --p2-color-text );
 	font-weight: normal;
-	font-size: 18px;
+	font-size: $font-title-small;
 	letter-spacing: -0.26px;
 	margin-bottom: 16px;
 }
@@ -63,7 +63,7 @@
 	padding: 18px 24px;
 	line-height: 1;
 	border-radius: 2px;
-	font-size: 18px;
+	font-size: $font-title-small;
 	color: var( --p2-color-text );
 	border-color: var( --p2-color-border );
 

--- a/client/signup/steps/site-type/style.scss
+++ b/client/signup/steps/site-type/style.scss
@@ -41,7 +41,7 @@
 	}
 
 	.site-type__option-label {
-		font-size: 18px;
+		font-size: $font-title-small;
 		color: var( --color-text );
 	}
 

--- a/client/signup/steps/upsell/style.scss
+++ b/client/signup/steps/upsell/style.scss
@@ -30,7 +30,7 @@
     }
 
     &__section-title {
-        font-size: 18px;
+        font-size: $font-title-small;
 		font-weight: 700;
 		line-height: 1.4;
     }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* I must have left out `18px` fonts in the previous conversions. Here's a new PR!
* I'm going to check as many instances as I can throughout, since some of these may be better suited to a smaller font size of 16px; 18 is right on the edge.

**Visuals (not exhaustive)**

Before | After
---- | ----
<img width="769" alt="before1" src="https://user-images.githubusercontent.com/2124984/89462185-0b3fe300-d73b-11ea-9693-5211a8325961.png"> | <img width="767" alt="after1" src="https://user-images.githubusercontent.com/2124984/89462173-0a0eb600-d73b-11ea-8b98-ed5d7aac8800.png">
<img width="494" alt="before2" src="https://user-images.githubusercontent.com/2124984/89462189-0b3fe300-d73b-11ea-82d8-a45dd4ca9ffa.png"> | <img width="493" alt="after2" src="https://user-images.githubusercontent.com/2124984/89462174-0a0eb600-d73b-11ea-9763-d819aaf787bb.png">
<img width="1077" alt="before3" src="https://user-images.githubusercontent.com/2124984/89462190-0bd87980-d73b-11ea-896e-f6c591c54382.png"> | <img width="1077" alt="after3" src="https://user-images.githubusercontent.com/2124984/89462176-0a0eb600-d73b-11ea-8c4d-e8e9ee2dd811.png">
<img width="397" alt="before4" src="https://user-images.githubusercontent.com/2124984/89462191-0bd87980-d73b-11ea-9383-0703a5285606.png"> | <img width="377" alt="after4" src="https://user-images.githubusercontent.com/2124984/89462177-0aa74c80-d73b-11ea-86cd-064aec020d90.png">
<img width="1064" alt="before5" src="https://user-images.githubusercontent.com/2124984/89462192-0bd87980-d73b-11ea-84a5-c32fa89125e8.png"> | <img width="1056" alt="after5" src="https://user-images.githubusercontent.com/2124984/89462179-0aa74c80-d73b-11ea-8407-92a9ffbc1519.png">
<img width="1065" alt="before6" src="https://user-images.githubusercontent.com/2124984/89462193-0c711000-d73b-11ea-83a8-5c7a2f1105ca.png"> | <img width="1070" alt="after6" src="https://user-images.githubusercontent.com/2124984/89462180-0aa74c80-d73b-11ea-9558-28d21d314878.png">
<img width="1063" alt="before7" src="https://user-images.githubusercontent.com/2124984/89462194-0c711000-d73b-11ea-9225-784eb5d8e1e2.png"> | <img width="1061" alt="after7" src="https://user-images.githubusercontent.com/2124984/89462182-0aa74c80-d73b-11ea-917a-dfd97c7e7458.png">
<img width="742" alt="before1" src="https://user-images.githubusercontent.com/2124984/89546446-9fa95480-d7d2-11ea-832d-fd04dc294ce5.png"> | <img width="748" alt="after1" src="https://user-images.githubusercontent.com/2124984/89546429-9a4c0a00-d7d2-11ea-9d8c-e14d472c50ed.png">
<img width="744" alt="before2" src="https://user-images.githubusercontent.com/2124984/89546448-a041eb00-d7d2-11ea-8177-d63b4f383dc9.png"> | <img width="751" alt="after2" src="https://user-images.githubusercontent.com/2124984/89546440-9d46fa80-d7d2-11ea-8736-27327cca50a3.png">
<img width="385" alt="before3" src="https://user-images.githubusercontent.com/2124984/89546452-a0da8180-d7d2-11ea-96aa-9865d3b9b98e.png"> | <img width="382" alt="after3" src="https://user-images.githubusercontent.com/2124984/89546445-9f10be00-d7d2-11ea-8b97-654080b1933e.png">

#### Testing instructions

* Switch to this PR
* Navigate around Calypso to note changes in font sizes; 18px has been changed to either 16px (1rem) or 20px (1.25rem) to match our new type scale.
