### PR TITLE
Calypso Colors: add Google Blue color

### DIFF
--- a/packages/calypso-color-schemes/CHANGELOG.md
+++ b/packages/calypso-color-schemes/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 2.2.0
+
+* Introduce Google Color
+
 ## 2.1.1
 
 * Updated the color palette to the most recent version.

--- a/packages/calypso-color-schemes/CHANGELOG.md
+++ b/packages/calypso-color-schemes/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Release Notes
 
-## 2.2.0
+## 2.1.2
 
-* Introduce Google Color
+* Added Google brand color:
+  * `--color-google`
 
 ## 2.1.1
 

--- a/packages/calypso-color-schemes/package.json
+++ b/packages/calypso-color-schemes/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/calypso-color-schemes",
-	"version": "2.1.1",
+	"version": "2.2.0",
 	"description": "Calypso Shared Style Bits",
 	"author": "Automattic Inc.",
 	"license": "GPL-2.0-or-later",

--- a/packages/calypso-color-schemes/package.json
+++ b/packages/calypso-color-schemes/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/calypso-color-schemes",
-	"version": "2.2.0",
+	"version": "2.1.2",
 	"description": "Calypso Shared Style Bits",
 	"author": "Automattic Inc.",
 	"license": "GPL-2.0-or-later",

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_default.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_default.scss
@@ -301,6 +301,7 @@
 	--color-eventbrite: #ff8000;
 	--color-facebook: #39579a;
 	--color-godaddy: #5ea95a;
+	--color-google: #4285f4;
 	--color-google-plus: #df4a32;
 	--color-instagram: #d93174;
 	--color-linkedin: #0976b4;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add Google's Blue color in addition to the existing Social Media colors
* See https://github.com/Automattic/color-studio/pull/30

#### Testing instructions

* Not too sure how to test this within the Calypso repo.

