### PR TITLE
Update colours of the new Jetpack product cards

### DIFF
--- a/client/components/jetpack/card/jetpack-bundle-card/fixture/index.ts
+++ b/client/components/jetpack/card/jetpack-bundle-card/fixture/index.ts
@@ -17,8 +17,8 @@ export const features = {
 };
 
 export const bundleCard = {
-	iconSlug: 'jetpack_anti_spam',
-	productName: 'Security Security',
+	iconSlug: 'jetpack_security_v2',
+	productName: 'Jetpack Security',
 	subheadline: 'Comprehensive WordPress protection',
 	description:
 		'Enjoy the peace of mind of complete site security. Easy-to-use, powerful security tools guard your site, so you can focus on your business.',

--- a/client/components/jetpack/card/jetpack-bundle-card/style.scss
+++ b/client/components/jetpack/card/jetpack-bundle-card/style.scss
@@ -1,5 +1,5 @@
 .jetpack-bundle-card {
-	$jetpack-bundle-card-color: var( --studio-jetpack-green-40 );
+	$jetpack-bundle-card-color: var( --studio-purple-50 );
 
 	.jetpack-product-card__header {
 		border-color: $jetpack-bundle-card-color;

--- a/client/components/jetpack/card/jetpack-individual-product-card/fixture/index.ts
+++ b/client/components/jetpack/card/jetpack-individual-product-card/fixture/index.ts
@@ -17,7 +17,7 @@ export const features = {
 };
 
 export const individualProductCard = {
-	iconSlug: 'jetpack_backup_daily',
+	iconSlug: 'jetpack_backup_v2',
 	productName: 'Jetpack Backup',
 	subheadline: '',
 	description: '',

--- a/client/components/jetpack/card/jetpack-individual-product-card/style.scss
+++ b/client/components/jetpack/card/jetpack-individual-product-card/style.scss
@@ -1,5 +1,5 @@
 .jetpack-individual-product-card {
-	$jetpack-individual-product-card-color: #33b3db;
+	$jetpack-individual-product-card-color: var( --studio-wordpress-blue-30 );
 
 	.jetpack-product-card__header {
 		border-color: $jetpack-individual-product-card-color;

--- a/client/components/jetpack/card/jetpack-plan-card/style.scss
+++ b/client/components/jetpack/card/jetpack-plan-card/style.scss
@@ -1,5 +1,5 @@
 .jetpack-plan-card {
-	$jetpack-plan-card-color: var( --studio-purple-30 );
+	$jetpack-plan-card-color: var( --studio-jetpack-green-40 );
 	$jetpack-deprecated-plan-card-color: var( --studio-yellow-40 );
 
 	.jetpack-product-card__header {


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR updates the colours used for the new Jetpack product cards
- Colors are now all taken from the Color Studio
- Bundles are now purple
- Plans are now green

### Implementation notes

- Updated icons in the dev docs example for consistency
- purple: ` --studio-purple-50` / `#984a9c`
- green: `--studio-jetpack-green-40` / `#069e08`
- blue: `--studio-wordpress-blue-30 ` / `#3895ba`

### Testing instructions

1. Download the PR
2. For each product type, check that the header border, the price stroke, and the badge have the proper colour (see screenshots):
    - `devdocs/design/jetpack-plan-card`
    - `devdocs/design/jetpack-bundle-card`
    - `devdocs/design/jetpack-individual-product-card`

### Screenshots

#### Mockups
<img width="435" alt="Screen Shot 2020-08-05 at 1 18 09 PM" src="https://user-images.githubusercontent.com/1620183/89443326-218b7600-d71e-11ea-983d-f539366f4667.png">


#### Plan
<img width="695" alt="Screen Shot 2020-08-05 at 1 05 53 PM" src="https://user-images.githubusercontent.com/1620183/89442761-5b0fb180-d71d-11ea-9b40-334f2a37db7b.png">

#### Bundle
<img width="696" alt="Screen Shot 2020-08-05 at 1 08 47 PM" src="https://user-images.githubusercontent.com/1620183/89442766-5f3bcf00-d71d-11ea-8ebf-13df34d7ef6f.png">

#### Individual Product
<img width="691" alt="Screen Shot 2020-08-05 at 1 07 11 PM" src="https://user-images.githubusercontent.com/1620183/89442775-6367ec80-d71d-11ea-8e82-a45aa7078de7.png">
