### PR TITLE
Gutenboarding launch flow: add Name your site step

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/common/data-stores/launch/index.ts
+++ b/apps/full-site-editing/full-site-editing-plugin/common/data-stores/launch/index.ts
@@ -24,7 +24,7 @@ registerStore< State >( STORE_KEY, {
 	controls,
 	reducer: reducer as any,
 	selectors,
-	persist: [ 'domain', 'plan' ],
+	persist: [ 'domain', 'domainSearch', 'plan', 'completedSteps' ],
 } );
 
 declare module '@wordpress/data' {

--- a/apps/full-site-editing/full-site-editing-plugin/editor-domain-picker/src/domain-picker-fse/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-domain-picker/src/domain-picker-fse/index.tsx
@@ -22,7 +22,6 @@ interface Props {
 const DomainPickerFSE: React.FunctionComponent< Props > = ( { onSelect } ) => {
 	const site = useSite();
 
-	// TODO: add a new prop on domain Picker to display this value in a disabled state
 	const freeDomain = useCurrentDomainName();
 
 	const { domain, domainSearch } = useSelect( ( select ) => select( LAUNCH_STORE ).getState() );

--- a/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-menu/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-menu/index.tsx
@@ -16,8 +16,8 @@ import './styles.scss';
 
 const LaunchStepMenuItemTitles = {
 	[ LaunchStep.Name ]: __( 'Name your site', 'full-site-editing' ),
-	[ LaunchStep.Domain ]: __( 'Select a domain', 'full-site-editing' ),
-	[ LaunchStep.Plan ]: __( 'Select a plan', 'full-site-editing' ),
+	[ LaunchStep.Domain ]: __( 'Choose a domain', 'full-site-editing' ),
+	[ LaunchStep.Plan ]: __( 'Choose a plan', 'full-site-editing' ),
 	[ LaunchStep.Final ]: __( 'Launch your site', 'full-site-editing' ),
 };
 

--- a/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-menu/item.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-menu/item.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import * as React from 'react';
-import { __ } from '@wordpress/i18n';
 import { Button, SVG, Circle } from '@wordpress/components';
 import { Icon, check } from '@wordpress/icons';
 import classnames from 'classnames';
@@ -19,7 +18,7 @@ const circle = (
 
 interface Props {
 	title: string;
-	isCompleted?: boolean;
+	isCompleted: boolean;
 	isCurrent: boolean;
 	onClick: () => void;
 }

--- a/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-steps/domain-step/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-steps/domain-step/index.tsx
@@ -4,7 +4,7 @@
 import * as React from 'react';
 import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { Title, SubTitle } from '@automattic/onboarding';
+import { Title, SubTitle, ActionButtons, NextButton } from '@automattic/onboarding';
 
 /**
  * Internal dependencies
@@ -20,6 +20,10 @@ const DomainStep: React.FunctionComponent< LaunchStepProps > = ( { onNextStep } 
 
 	const handleSelect = () => {
 		setStepComplete( LaunchStep.Domain );
+	};
+
+	const handleNext = () => {
+		setStepComplete( LaunchStep.Domain );
 		onNextStep?.();
 	};
 
@@ -32,6 +36,9 @@ const DomainStep: React.FunctionComponent< LaunchStepProps > = ( { onNextStep } 
 						{ __( 'Free for the first year with any paid plan', 'full-site-editing' ) }
 					</SubTitle>
 				</div>
+				<ActionButtons>
+					<NextButton onClick={ handleNext } />
+				</ActionButtons>
 			</div>
 			<div className="nux-launch-step__body">
 				<DomainPickerFSE onSelect={ handleSelect } />

--- a/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-steps/name-step/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-steps/name-step/index.tsx
@@ -51,7 +51,7 @@ const NameStep: React.FunctionComponent< LaunchStepProps > = ( { onNextStep } ) 
 					<SubTitle>{ __( 'Pick a name for your site.', 'full-site-editing' ) }</SubTitle>
 				</div>
 				<ActionButtons>
-					<NextButton onClick={ handleNext } disabled={ ! title } />
+					<NextButton onClick={ handleNext } disabled={ ! title?.trim() } />
 				</ActionButtons>
 			</div>
 			<div className="nux-launch-step__body">

--- a/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-steps/name-step/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-steps/name-step/index.tsx
@@ -24,7 +24,10 @@ const NameStep: React.FunctionComponent< LaunchStepProps > = ( { onNextStep } ) 
 
 	const handleSave = () => {
 		saveEditedEntityRecord( 'root', 'site' );
+
+		// update domainSearch only if there is no custom Domain selected
 		! domain && setDomainSearch( title );
+
 		title.length ? setStepComplete( LaunchStep.Name ) : setStepIncomplete( LaunchStep.Name );
 	};
 

--- a/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-steps/name-step/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-steps/name-step/index.tsx
@@ -23,12 +23,19 @@ const NameStep: React.FunctionComponent< LaunchStepProps > = ( { onNextStep } ) 
 	const { saveEditedEntityRecord } = useDispatch( 'core' );
 
 	const handleSave = () => {
+		const newTitle = title.trim();
+
+		setTitle( newTitle );
 		saveEditedEntityRecord( 'root', 'site' );
 
 		// update domainSearch only if there is no custom Domain selected
-		! domain && setDomainSearch( title );
+		! domain && setDomainSearch( newTitle );
 
-		title.length ? setStepComplete( LaunchStep.Name ) : setStepIncomplete( LaunchStep.Name );
+		if ( newTitle ) {
+			setStepComplete( LaunchStep.Name );
+		} else {
+			setStepIncomplete( LaunchStep.Name );
+		}
 	};
 
 	const handleNext = () => {

--- a/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-steps/name-step/styles.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-steps/name-step/styles.scss
@@ -7,7 +7,7 @@
 	input[type='text'].components-text-control__input {
 		padding: 6px 40px 6px 16px;
 		height: 38px;
-		background: #f0f0f0;
+		background: $gray-100;
 		border: none;
 
 		&::placeholder {

--- a/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-steps/name-step/styles.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-steps/name-step/styles.scss
@@ -1,0 +1,41 @@
+@import '~@automattic/onboarding/styles/variables';
+
+.nux-launch-step__input {
+	position: relative;
+	margin-bottom: 20px;
+
+	input[type='text'].components-text-control__input {
+		padding: 6px 40px 6px 16px;
+		height: 38px;
+		background: #f0f0f0;
+		border: none;
+
+		&::placeholder {
+			color: var( --studio-black );
+		}
+
+		&:focus {
+			box-shadow: 0 0 0 2px var( --studio-blue-30 );
+			background: var( --studio-white );
+		}
+	}
+
+	svg {
+		position: absolute;
+		top: 6px;
+		right: 8px;
+	}
+}
+
+.nux-launch-step__input-hint {
+	display: flex;
+	align-items: center;
+	color: var( --studio-gray-50 );
+	font-family: $default-font;
+	font-size: 14px;
+	line-height: 14px;
+
+	& > .components-tip svg {
+		margin-right: 10px;
+	}
+}

--- a/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-steps/plan-step/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-steps/plan-step/index.tsx
@@ -3,7 +3,7 @@
  */
 import * as React from 'react';
 import { __ } from '@wordpress/i18n';
-import { Title, SubTitle, ActionButtons, BackButton } from '@automattic/onboarding';
+import { Title, SubTitle } from '@automattic/onboarding';
 
 /**
  * Internal dependencies
@@ -12,32 +12,23 @@ import LaunchStep, { Props as LaunchStepProps } from '../../launch-step';
 import PlansGridFSE from '../../../../editor-plans-grid/src/plans-grid-fse';
 import './styles.scss';
 
-const PlanStep: React.FunctionComponent< LaunchStepProps > = ( { onPrevStep, onNextStep } ) => {
-	const handleBack = () => {
-		onPrevStep?.();
-	};
-
-	return (
-		<LaunchStep className="nux-launch-plan-step">
-			<div className="nux-launch-step__header">
-				<div>
-					<Title>{ __( 'Choose a plan', 'full-site-editing' ) }</Title>
-					<SubTitle>
-						{ __(
-							'Pick a plan that’s right for you. Switch plans as your needs change. There’s no risk, you can cancel for a full refund within 30 days.',
-							'full-site-editing'
-						) }
-					</SubTitle>
-				</div>
-				<ActionButtons>
-					<BackButton onClick={ handleBack } />
-				</ActionButtons>
+const PlanStep: React.FunctionComponent< LaunchStepProps > = ( { onNextStep } ) => (
+	<LaunchStep className="nux-launch-plan-step">
+		<div className="nux-launch-step__header">
+			<div>
+				<Title>{ __( 'Choose a plan', 'full-site-editing' ) }</Title>
+				<SubTitle>
+					{ __(
+						'Pick a plan that’s right for you. There’s no risk, you can cancel for a full refund within 30 days.',
+						'full-site-editing'
+					) }
+				</SubTitle>
 			</div>
-			<div className="nux-launch-step__body">
-				<PlansGridFSE onSelect={ onNextStep } />
-			</div>
-		</LaunchStep>
-	);
-};
+		</div>
+		<div className="nux-launch-step__body">
+			<PlansGridFSE onSelect={ onNextStep } />
+		</div>
+	</LaunchStep>
+);
 
 export default PlanStep;

--- a/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch/index.tsx
@@ -3,6 +3,7 @@
  */
 import * as React from 'react';
 import { useSelect, useDispatch } from '@wordpress/data';
+import { EntityProvider } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -56,7 +57,9 @@ const Launch: React.FunctionComponent< Props > = ( { onSubmit } ) => {
 
 	return (
 		<div className="nux-launch">
-			<CurrentLaunchStep onPrevStep={ handlePrevStep } onNextStep={ handleNextStep } />
+			<EntityProvider kind="root" type="site">
+				<CurrentLaunchStep onPrevStep={ handlePrevStep } onNextStep={ handleNextStep } />
+			</EntityProvider>
 		</div>
 	);
 };

--- a/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/wp-core-data-types.d.ts
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/wp-core-data-types.d.ts
@@ -1,0 +1,8 @@
+declare module '@wordpress/core-data' {
+	export const EntityProvider: React.ComponentType;
+	export const useEntityProp: (
+		kind: string,
+		type: string,
+		prop: string
+	) => [ string, ( newValue: string ) => void ];
+}

--- a/packages/domain-picker/src/domain-picker/style.scss
+++ b/packages/domain-picker/src/domain-picker/style.scss
@@ -36,7 +36,7 @@
 	input[type='text'].components-text-control__input {
 		padding: 6px 40px 6px 16px;
 		height: 38px;
-		background: #f0f0f0;
+		background: $gray-100;
 		border: none;
 
 		&::placeholder {

--- a/packages/onboarding/src/action-buttons/style.scss
+++ b/packages/onboarding/src/action-buttons/style.scss
@@ -44,6 +44,10 @@ button.action_buttons__button.components-button {
 		outline-color: transparent;
 	}
 
+	&:disabled {
+		opacity: 0.5;
+	}
+
 	&.action-buttons__back {
 		color: var( --studio-gray-50 );
 		white-space: nowrap;


### PR DESCRIPTION
#### Note to anyone reading this while preparing a release of the Editing Toolkit plugin
This change doesn't require any release notes. We're developing a new feature which is currently hidden behind a flag.

#### Changes proposed in this Pull Request
* **Step completion status.** If Site name value is cleared, mark step as incomplete and disable Continue button.
* **Integration with the flow.** When updating Site name, if no custom domain is selected in _Choose a domain_ step, initial query for domain is updated with the new Site name.

#### Design
* First iteration of Site name step doesn’t include Site preview. So current implementation 
would follow the design from Pre-launch i12 with copy from the latest iteration. 
<img width="622" alt="Screenshot 2020-08-05 at 14 23 00" src="https://user-images.githubusercontent.com/14192054/89444193-ffafe480-d759-11ea-8cd8-c8cadcbaadc4.png">


#### Testing instructions
* Follow instruction from Getting started section of #43750 to have the new launch flow enabled.
* Create a site using [wordpress.com/new](https://wordpress.com/new) and sandbox it.
* First step should be the Name your site step and all of the changes mentioned above should work.

#### Follow up
* When opening modal content and the Site name is already provided, jump straight to Choose a domain step.
* If fallback site title is present (for English: _Site Title_), then display first step as incomplete.
* List site name, domain and plan at the last step (to be used in summary).
* [optional, candidate for next release] Site preview with real time update of the site name.

#### Screenshots
**Without site name value:**
<img width="1207" alt="empty-state" src="https://user-images.githubusercontent.com/14192054/89444876-1145bc00-d75b-11ea-89a2-226bd7a12edd.png">

**With value:**
<img width="1206" alt="step-completed" src="https://user-images.githubusercontent.com/14192054/89444893-160a7000-d75b-11ea-936f-247adc6e2899.png">


Fixes #44449
