### PR TITLE
Adjust styles for the new product cards on desktop

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card/style.scss
@@ -44,6 +44,17 @@ $jetpack-product-card-icon-size: 55px;
 
 		background: inherit;
 	}
+
+	@media ( min-width: 660px ) {
+		border-left: 1px solid var( --color-border-subtle );
+		border-right: 1px solid var( --color-border-subtle );
+		border-radius: 5px;
+
+		.foldable-card {
+			border-bottom-left-radius: 5px;
+			border-bottom-right-radius: 5px;
+		}
+	}
 }
 
 .jetpack-product-card__header {
@@ -95,6 +106,10 @@ $jetpack-product-card-icon-size: 55px;
 
 	font-size: $font-body-extra-small;
 	line-height: rem( 16px ) / $font-body-extra-small;
+
+	@media ( min-width: 660px ) {
+		font-size: $font-body;
+	}
 }
 
 .jetpack-product-card__price {


### PR DESCRIPTION
### Changes proposed in this Pull Request

Updated styles of `JetpackProductCard` on desktop.

### Implementation notes

The difference between mobile and desktop seems minor in the mockups. On desktop:
- Card has a 4-side border
- Card has round corners
- Font size of the subheadline is the same as body text

### Testing instructions

- Download the PR
- Visit `/devdocs/design/jetpack-product-card`, in a viewport > 660px
- Check the changes mentioned above

### Screenshots
![screenshot](https://user-images.githubusercontent.com/1620183/89454623-f78e7f80-d72e-11ea-9750-cc885ea13057.png)

