### PR TITLE
Inline Help: FAB Focus Management

### DIFF
--- a/client/blocks/inline-help/inline-help-rich-result.jsx
+++ b/client/blocks/inline-help/inline-help-rich-result.jsx
@@ -103,7 +103,7 @@ class InlineHelpRichResult extends Component {
 
 		return (
 			<div>
-				<h2 className={ classes }>{ preventWidows( decodeEntities( title ) ) }</h2>
+				<h2 className={ classes } tabIndex="-1">{ preventWidows( decodeEntities( title ) ) }</h2>
 				<p>{ preventWidows( decodeEntities( description ) ) }</p>
 				<Button primary onClick={ this.handleClick } href={ link }>
 					{ buttonIcon && <Gridicon icon={ buttonIcon } size={ 12 } /> }

--- a/client/blocks/inline-help/inline-help-rich-result.jsx
+++ b/client/blocks/inline-help/inline-help-rich-result.jsx
@@ -103,7 +103,9 @@ class InlineHelpRichResult extends Component {
 
 		return (
 			<div>
-				<h2 className={ classes } tabIndex="-1">{ preventWidows( decodeEntities( title ) ) }</h2>
+				<h2 className={ classes } tabIndex="-1">
+					{ preventWidows( decodeEntities( title ) ) }
+				</h2>
 				<p>{ preventWidows( decodeEntities( description ) ) }</p>
 				<Button primary onClick={ this.handleClick } href={ link }>
 					{ buttonIcon && <Gridicon icon={ buttonIcon } size={ 12 } /> }

--- a/client/blocks/inline-help/inline-help-search-card.jsx
+++ b/client/blocks/inline-help/inline-help-search-card.jsx
@@ -38,7 +38,7 @@ const InlineHelpSearchCard = ( {
 	useEffect( () => {
 		const inputElement = cardRef.current?.searchInput;
 		// Focuses only in the popover.
-		if ( location !== 'inline-help-popover' || ! inputElement || ! isVisible) {
+		if ( location !== 'inline-help-popover' || ! inputElement || ! isVisible ) {
 			return;
 		}
 

--- a/client/blocks/inline-help/inline-help-search-card.jsx
+++ b/client/blocks/inline-help/inline-help-search-card.jsx
@@ -28,6 +28,7 @@ const InlineHelpSearchCard = ( {
 	location = 'inline-help-popover',
 	setSearchQuery,
 	isSearching,
+	isVisible = true,
 	placeholder,
 	translate = identity,
 } ) => {
@@ -37,14 +38,14 @@ const InlineHelpSearchCard = ( {
 	useEffect( () => {
 		const inputElement = cardRef.current?.searchInput;
 		// Focuses only in the popover.
-		if ( location !== 'inline-help-popover' || ! inputElement ) {
+		if ( location !== 'inline-help-popover' || ! inputElement || ! isVisible) {
 			return;
 		}
 
 		const timerId = setTimeout( () => inputElement.focus(), 0 );
 
 		return () => window.clearTimeout( timerId );
-	}, [ cardRef, location ] );
+	}, [ cardRef, location, isVisible ] );
 
 	const searchHelperHandler = ( searchQuery ) => {
 		const inputQuery = searchQuery.trim();

--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -97,9 +97,8 @@ class InlineHelpPopover extends Component {
 		this.props.recordTracksEvent( `calypso_inlinehelp_${ secondaryViewKey }_show`, {
 			location: 'inline-help-popover',
 		} );
-		this.setState( { showSecondaryView: true } );
-		// Focus the secondary popover contents
-		setTimeout( () => this.secondaryViewRef.current.focus(), 0 );
+		// Focus the secondary popover contents after the state is set
+		this.setState( { showSecondaryView: true }, () => this.secondaryViewRef.current.focus() );
 	};
 
 	closeSecondaryView = () => {

--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -66,6 +66,8 @@ class InlineHelpPopover extends Component {
 		activeSecondaryView: '',
 	};
 
+	secondaryViewRef = React.createRef();
+
 	openResultView = ( event ) => {
 		event.preventDefault();
 		this.openSecondaryView( VIEW_RICH_RESULT );
@@ -96,6 +98,8 @@ class InlineHelpPopover extends Component {
 			location: 'inline-help-popover',
 		} );
 		this.setState( { showSecondaryView: true } );
+		// Focus the secondary popover contents
+		setTimeout( () => this.secondaryViewRef.current.focus(), 0 )
 	};
 
 	closeSecondaryView = () => {
@@ -172,7 +176,7 @@ class InlineHelpPopover extends Component {
 			`inline-help__${ this.state.activeSecondaryView }`
 		);
 		return (
-			<div className={ classes }>
+			<section ref={ this.secondaryViewRef } className={ classes } tabIndex="-1">
 				{
 					{
 						[ VIEW_CONTACT ]: <InlineHelpContactView />,
@@ -185,7 +189,7 @@ class InlineHelpPopover extends Component {
 						),
 					}[ this.state.activeSecondaryView ]
 				}
-			</div>
+			</section>
 		);
 	};
 

--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -11,7 +11,6 @@ import Gridicon from 'components/gridicon';
 import { withMobileBreakpoint } from '@automattic/viewport-react';
 import { __ } from '@wordpress/i18n';
 
-
 /**
  * Internal Dependencies
  */
@@ -101,9 +100,9 @@ class InlineHelpPopover extends Component {
 		} );
 		// Focus the secondary popover contents after the state is set
 		this.setState( { showSecondaryView: true }, () => {
-			const contentTitle = this.secondaryViewRef.current.querySelector('h2');
-			
-			if(contentTitle) {
+			const contentTitle = this.secondaryViewRef.current.querySelector( 'h2' );
+
+			if ( contentTitle ) {
 				contentTitle.focus();
 			}
 		} );
@@ -189,7 +188,9 @@ class InlineHelpPopover extends Component {
 					{
 						[ VIEW_CONTACT ]: (
 							<Fragment>
-								<h2 className="inline-help__title" tabIndex="-1">{ __( 'Get Support' ) }</h2>
+								<h2 className="inline-help__title" tabIndex="-1">
+									{ __( 'Get Support' ) }
+								</h2>
 								<InlineHelpContactView />
 							</Fragment>
 						),

--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -189,7 +189,7 @@ class InlineHelpPopover extends Component {
 					{
 						[ VIEW_CONTACT ]: (
 							<Fragment>
-								<h2 className="inline-help__title" tabIndex="-1">{ __( 'Contact Us' ) }</h2>
+								<h2 className="inline-help__title" tabIndex="-1">{ __( 'Get Support' ) }</h2>
 								<InlineHelpContactView />
 							</Fragment>
 						),

--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -189,7 +189,7 @@ class InlineHelpPopover extends Component {
 					{
 						[ VIEW_CONTACT ]: (
 							<Fragment>
-								<h2 className="help-contact__title" tabIndex="-1">{ __( 'Contact Us' ) }</h2>
+								<h2 className="inline-help__title" tabIndex="-1">{ __( 'Contact Us' ) }</h2>
 								<InlineHelpContactView />
 							</Fragment>
 						),

--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -9,6 +9,8 @@ import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
 import Gridicon from 'components/gridicon';
 import { withMobileBreakpoint } from '@automattic/viewport-react';
+import { __ } from '@wordpress/i18n';
+
 
 /**
  * Internal Dependencies
@@ -98,7 +100,13 @@ class InlineHelpPopover extends Component {
 			location: 'inline-help-popover',
 		} );
 		// Focus the secondary popover contents after the state is set
-		this.setState( { showSecondaryView: true }, () => this.secondaryViewRef.current.focus() );
+		this.setState( { showSecondaryView: true }, () => {
+			const contentTitle = this.secondaryViewRef.current.querySelector('h2');
+			
+			if(contentTitle) {
+				contentTitle.focus();
+			}
+		} );
 	};
 
 	closeSecondaryView = () => {
@@ -176,10 +184,15 @@ class InlineHelpPopover extends Component {
 			`inline-help__${ this.state.activeSecondaryView }`
 		);
 		return (
-			<section ref={ this.secondaryViewRef } className={ classes } tabIndex="-1">
+			<section ref={ this.secondaryViewRef } className={ classes }>
 				{
 					{
-						[ VIEW_CONTACT ]: <InlineHelpContactView />,
+						[ VIEW_CONTACT ]: (
+							<Fragment>
+								<h2 className="help-contact__title" tabIndex="-1">{ __( 'Contact Us' ) }</h2>
+								<InlineHelpContactView />
+							</Fragment>
+						),
 						[ VIEW_RICH_RESULT ]: (
 							<InlineHelpRichResult
 								result={ selectedResult }

--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -149,7 +149,10 @@ class InlineHelpPopover extends Component {
 			<Fragment>
 				<QuerySupportTypes />
 				<div className="inline-help__search">
-					<InlineHelpSearchCard onSelect={ this.openResultView } query={ this.props.searchQuery } />
+					<InlineHelpSearchCard 
+						onSelect={ this.openResultView } 
+						query={ this.props.searchQuery } 
+						isVisible={ ! this.state.showSecondaryView } />
 					<InlineHelpSearchResults
 						onSelect={ this.openResultView }
 						onAdminSectionSelect={ this.setAdminSection }

--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -99,7 +99,7 @@ class InlineHelpPopover extends Component {
 		} );
 		this.setState( { showSecondaryView: true } );
 		// Focus the secondary popover contents
-		setTimeout( () => this.secondaryViewRef.current.focus(), 0 )
+		setTimeout( () => this.secondaryViewRef.current.focus(), 0 );
 	};
 
 	closeSecondaryView = () => {
@@ -153,10 +153,11 @@ class InlineHelpPopover extends Component {
 			<Fragment>
 				<QuerySupportTypes />
 				<div className="inline-help__search">
-					<InlineHelpSearchCard 
-						onSelect={ this.openResultView } 
-						query={ this.props.searchQuery } 
-						isVisible={ ! this.state.showSecondaryView } />
+					<InlineHelpSearchCard
+						onSelect={ this.openResultView }
+						query={ this.props.searchQuery }
+						isVisible={ ! this.state.showSecondaryView }
+					/>
 					<InlineHelpSearchResults
 						onSelect={ this.openResultView }
 						onAdminSectionSelect={ this.setAdminSection }

--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -239,7 +239,7 @@
 
 .inline-help__contact {
 
-	.help-contact__title  {
+	.inline-help__title  {
 		@include hide-content-accessibly;
 	}
 

--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -238,6 +238,11 @@
 }
 
 .inline-help__contact {
+
+	.help-contact__title  {
+		@include hide-content-accessibly;
+	}
+
 	.help-contact__form {
 		margin: 0;
 		padding: 0;


### PR DESCRIPTION
There is currently a focus-loss that happens when clicking to the secondary content of the popover. In this case, the FAB -> Inline Search -> Contact. The focus is lost when clicking the Contact button.

#### Changes proposed in this Pull Request

- [x] When going "Back" from the contact form, the inline help search input should be focused again
- [x] Add a hidden "Contact Us" `<h2>` to the top of the contact form
- [x] Send focus to the inner content's `<h2>`, if present.



#### Testing instructions

* Open the FAB 
* Tab to the Contact button (or use a screen reader)
* Press Enter
* Focus should be on the hidden title. You will only notice this if using a screen reader.
* Press Tab
* You should be within the contact form
* Press Back
* Focus should be on the search input again
* Select a search result
* Focus should be on the search result title. You won't see the focus ring.
* Press Tab
* You should be on the Read more button

Fixes https://github.com/Automattic/wp-calypso/issues/41506
