### PR TITLE
Payments: Remove brand font from smaller section headings

### DIFF
--- a/client/my-sites/earn/memberships/style.scss
+++ b/client/my-sites/earn/memberships/style.scss
@@ -91,7 +91,6 @@
 	}
 }
 .memberships__onboarding-benefits > div > h3 {
-	@extend .wp-brand-font;
 	font-size: $font-title-small;
 	line-height: 27px;
 	color: var( --color-text );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Similar to #44700 and Customer Home, we want to avoid overusing the brand font, Recoleta. In this case, using it on the larger heading in the primary card and for the page title is enough.

**Before**

<img width="1061" alt="Screen Shot 2020-08-05 at 4 37 42 PM" src="https://user-images.githubusercontent.com/2124984/89461470-06c6fa80-d73a-11ea-992a-311358d23fae.png">

**After**

<img width="1068" alt="Screen Shot 2020-08-05 at 4 41 47 PM" src="https://user-images.githubusercontent.com/2124984/89461878-9371b880-d73a-11ea-9f55-ec2b32be14b7.png">

#### Testing instructions

* Switch to this PR and navigate to `/earn/payments/[site]`
* Note the small subheadings below the main card; they should be using the default system font rather than Recoleta
