### PR TITLE
Simple demonstration of multiple Jetpack products in cart

### DIFF
--- a/client/components/multi-cart-prototype/index.tsx
+++ b/client/components/multi-cart-prototype/index.tsx
@@ -1,0 +1,37 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { Button } from '@automattic/components';
+import { addItem, addItems } from 'lib/cart/actions';
+import { jetpackProductItem } from 'lib/cart-values/cart-items';
+import { PRODUCT_JETPACK_BACKUP_DAILY, PRODUCT_JETPACK_SCAN } from 'lib/products-values/constants';
+
+export const MultiCartPrototype: React.FunctionComponent = () => {
+	const addBackupDaily = () => {
+		addItem( jetpackProductItem( PRODUCT_JETPACK_BACKUP_DAILY ) );
+	};
+
+	const addScanDaily = () => {
+		addItem( jetpackProductItem( PRODUCT_JETPACK_SCAN ) );
+	};
+
+	const addBackupAndScanDaily = () => {
+		addItems( [
+			jetpackProductItem( PRODUCT_JETPACK_BACKUP_DAILY ),
+			jetpackProductItem( PRODUCT_JETPACK_SCAN ),
+		] );
+	};
+
+	return (
+		<>
+			<Button onClick={ addBackupDaily }>Add Backup Daily</Button>
+			<Button onClick={ addScanDaily }>Add Scan Daily</Button>
+			<Button onClick={ addBackupAndScanDaily }>Add Backup and Scan Daily</Button>
+		</>
+	);
+};

--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -155,13 +155,13 @@ export function cartItemShouldReplaceCart( cartItem, cart ) {
 	}
 
 	if ( isJetpackPlan( cartItem ) ) {
-		// adding a jetpack bundle should replace the cart
-		return true;
+		// adding a jetpack bundle should not replace the cart
+		return false;
 	}
 
 	if ( isJetpackProduct( cartItem ) ) {
-		// adding a Jetpack product should replace the cart
-		return true;
+		// adding a Jetpack product should not replace the cart
+		return false;
 	}
 
 	return false;

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -11,6 +11,7 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
+import { MultiCartPrototype } from 'components/multi-cart-prototype';
 import AsyncLoad from 'components/async-load';
 import warn from 'lib/warn';
 import PlanFeatures from 'my-sites/plan-features';
@@ -177,7 +178,8 @@ export class PlansFeaturesMain extends Component {
 				data-e2e-plans={ displayJetpackPlans ? 'jetpack' : 'wpcom' }
 			>
 				{ customHeader }
-				{ this.renderSecondaryFormattedHeader() }
+				<FormattedHeader headerText={ 'MultiCart Prototype' } compactOnMobile isSecondary />
+				<MultiCartPrototype />
 				<PlanFeatures
 					basePlansPath={ basePlansPath }
 					disableBloggerPlanWithNonBlogDomain={ disableBloggerPlanWithNonBlogDomain }
@@ -203,6 +205,7 @@ export class PlansFeaturesMain extends Component {
 					} ) }
 					siteId={ siteId }
 				/>
+				{ this.renderSecondaryFormattedHeader() }
 			</div>
 		);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is just here to demonstrate adding multiple Jetpack Products to the cart in Calypso.

To see the demonstration, go to the plans page:
<img width="1156" alt="image" src="https://user-images.githubusercontent.com/42627630/89465041-15f87900-d737-11ea-9c02-ba0c493e784d.png">

The only modification needed to make this possible was switching `cartItemShouldReplaceCart()` to return `false` for Jetpack products and plans.

#### Testing instructions
Visit the /plans page and click any of the 3 buttons to add Jetpack products to the cart. Click the cart in the nav to open a popup cart to remove them.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Fixes #
