### PR TITLE
Save the last-non-editor-route in redux instead of calculating it

### DIFF
--- a/client/state/route/last-non-editor-route/reducer.js
+++ b/client/state/route/last-non-editor-route/reducer.js
@@ -1,0 +1,28 @@
+/**
+ * Internal dependencies
+ */
+import { ROUTE_SET } from 'state/action-types';
+
+/**
+ * Include paths which start in the classic editor because it is common
+ * to redirect from classic to block editor. For example, to create a new
+ * page, you go to `/page`, which then redirects to `/block-editor/page`.
+ * Matching page or post handles that case.
+ */
+const editorPattern = /^\/(block-editor|page[^s]|post[^s])/;
+
+export const lastNonEditorRouteReducer = ( state = '', action ) => {
+	const { path, type } = action;
+	switch ( type ) {
+		case ROUTE_SET:
+			if ( path && ! editorPattern.test( path ) ) {
+				return path;
+			}
+			return state;
+
+		default:
+			return state;
+	}
+};
+
+export default lastNonEditorRouteReducer;

--- a/client/state/route/last-non-editor-route/schema.js
+++ b/client/state/route/last-non-editor-route/schema.js
@@ -1,0 +1,5 @@
+const schema = {
+	type: 'string',
+};
+
+export default schema;

--- a/client/state/route/last-non-editor-route/test/reducer.js
+++ b/client/state/route/last-non-editor-route/test/reducer.js
@@ -1,0 +1,40 @@
+/**
+ * Internal dependencies
+ */
+import { ROUTE_SET } from 'state/action-types';
+import path from '../reducer';
+
+describe( 'reducer', () => {
+	it( 'should set the initial value to empty', () => {
+		const state = path( undefined, {
+			type: 'INIT',
+		} );
+
+		expect( state ).toBe( '' );
+	} );
+
+	it( 'should set the value if the ROUTE_SET action is for a non-editor path', () => {
+		const state = path( undefined, {
+			type: 'INIT',
+		} );
+
+		const nextState = path( state, {
+			type: ROUTE_SET,
+			path: '/plugins',
+		} );
+		expect( nextState ).toBe( '/plugins' );
+	} );
+
+	it( 'should not set the value if the ROUTE_SET action is for an editor path', () => {
+		const state = path( undefined, {
+			type: ROUTE_SET,
+			path: '/plugins',
+		} );
+
+		const nextState = path( state, {
+			type: ROUTE_SET,
+			path: '/block-editor/page/my-test-site.wordpress.com/2',
+		} );
+		expect( nextState ).toBe( '/plugins' );
+	} );
+} );

--- a/client/state/route/reducer.js
+++ b/client/state/route/reducer.js
@@ -1,13 +1,14 @@
 /**
  * Internal dependencies
  */
-import { combineReducers, withStorageKey } from 'state/utils';
+import { combineReducers, withSchemaValidation, withStorageKey } from 'state/utils';
 import lastNonEditorRoute from './last-non-editor-route/reducer';
+import schema from './last-non-editor-route/schema';
 import path from './path/reducer';
 import query from './query/reducer';
 
 const combinedReducer = combineReducers( {
-	lastNonEditorRoute,
+	lastNonEditorRoute: withSchemaValidation( schema, lastNonEditorRoute ),
 	path,
 	query,
 } );

--- a/client/state/route/reducer.js
+++ b/client/state/route/reducer.js
@@ -2,10 +2,12 @@
  * Internal dependencies
  */
 import { combineReducers, withStorageKey } from 'state/utils';
+import lastNonEditorRoute from './last-non-editor-route/reducer';
 import path from './path/reducer';
 import query from './query/reducer';
 
 const combinedReducer = combineReducers( {
+	lastNonEditorRoute,
 	path,
 	query,
 } );

--- a/client/state/selectors/get-last-non-editor-route.js
+++ b/client/state/selectors/get-last-non-editor-route.js
@@ -1,50 +1,9 @@
 /**
- * External dependencies
- */
-import { dropRightWhile, get, last } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import { getRouteHistory } from 'state/ui/action-log/selectors';
-import getPreviousPath from 'state/selectors/get-previous-path';
-import createSelector from 'lib/create-selector';
-
-/**
  * Get the last non-editor route while ignoring navigation in block editor.
  *
  * @param {object} state  Global state tree
  * @returns {string} The last non editor route -- empty string if none.
  */
-const getLastNonEditorRoute = createSelector(
-	( state ) => {
-		const previousPath = getPreviousPath( state );
-
-		/**
-		 * Include paths which start in the classic editor because it is common
-		 * to redirect from classic to block editor. For example, to create a new
-		 * page, you go to `/page`, which then redirects to `/block-editor/page`.
-		 * Matching page or post handles that case.
-		 */
-		const editorPattern = /^\/(block-editor|page[^s]|post[^s])/;
-
-		if ( previousPath && ! editorPattern.test( previousPath ) ) {
-			return previousPath;
-		}
-
-		// Fall back to reading from the action log
-		return get(
-			last(
-				dropRightWhile(
-					getRouteHistory( state ),
-					( { path } ) => path && editorPattern.test( path )
-				)
-			),
-			'path',
-			''
-		);
-	},
-	( state ) => [ getPreviousPath( state ), getRouteHistory( state ) ]
-);
+const getLastNonEditorRoute = ( state ) => state?.route?.lastNonEditorRoute || '';
 
 export default getLastNonEditorRoute;

--- a/client/state/selectors/test/get-editor-close-config.js
+++ b/client/state/selectors/test/get-editor-close-config.js
@@ -5,7 +5,6 @@ import getEditorCloseConfig from 'state/selectors/get-editor-close-config';
 import getPostTypeAllPostsUrl from 'state/selectors/get-post-type-all-posts-url';
 import getGutenbergEditorUrl from 'state/selectors/get-gutenberg-editor-url';
 import PostQueryManager from 'lib/query-manager/post';
-import { ROUTE_SET } from 'state/action-types';
 
 const postType = 'post';
 const pagePostType = 'page';
@@ -16,8 +15,6 @@ const siteSlug = 'fake.url.wordpress.com';
 const siteUrl = `https://${ siteSlug }`;
 const customerHomeUrl = `/home/${ siteSlug }`;
 const themesUrl = `/themes/${ siteSlug }`;
-const blockEditorAction = { type: ROUTE_SET, path: '/block-editor/page/1' };
-const customerHomeAction = { type: ROUTE_SET, path: customerHomeUrl };
 
 describe( 'getEditorCloseConfig()', () => {
 	test( 'should return URL for customer home as default when no previous route is given', () => {
@@ -27,7 +24,7 @@ describe( 'getEditorCloseConfig()', () => {
 					[ siteId ]: { URL: siteUrl },
 				},
 			},
-			ui: { selectedSiteId: siteId, actionLog: [] },
+			ui: { selectedSiteId: siteId },
 		};
 
 		expect( getEditorCloseConfig( state, siteId, postType ).url ).toEqual( customerHomeUrl );
@@ -41,13 +38,10 @@ describe( 'getEditorCloseConfig()', () => {
 				},
 			},
 			route: {
-				path: {
-					previous: '/route-with-no-match',
-				},
+				lastNonEditorRoute: '/route-with-no-match',
 			},
 			ui: {
 				selectedSiteId: siteId,
-				actionLog: [],
 			},
 		};
 
@@ -81,7 +75,7 @@ describe( 'getEditorCloseConfig()', () => {
 					} ),
 				},
 			},
-			ui: { selectedSiteId: siteId, actionLog: [] },
+			ui: { selectedSiteId: siteId },
 		};
 
 		const parentPostEditorUrl = getGutenbergEditorUrl( state, siteId, parentPostId, pagePostType );
@@ -99,13 +93,10 @@ describe( 'getEditorCloseConfig()', () => {
 				},
 			},
 			route: {
-				path: {
-					previous: customerHomeUrl,
-				},
+				lastNonEditorRoute: customerHomeUrl,
 			},
 			ui: {
 				selectedSiteId: siteId,
-				actionLog: [],
 			},
 		};
 
@@ -119,9 +110,11 @@ describe( 'getEditorCloseConfig()', () => {
 					[ siteId ]: { URL: siteUrl },
 				},
 			},
+			route: {
+				lastNonEditorRoute: customerHomeUrl,
+			},
 			ui: {
 				selectedSiteId: siteId,
-				actionLog: [ customerHomeAction, blockEditorAction ],
 			},
 		};
 
@@ -136,13 +129,10 @@ describe( 'getEditorCloseConfig()', () => {
 				},
 			},
 			route: {
-				path: {
-					previous: '/route-with-no-match',
-				},
+				lastNonEditorRoute: '/route-with-no-match',
 			},
 			ui: {
 				selectedSiteId: siteId,
-				actionLog: [],
 			},
 		};
 
@@ -159,13 +149,10 @@ describe( 'getEditorCloseConfig()', () => {
 				},
 			},
 			route: {
-				path: {
-					previous: themesUrl,
-				},
+				lastNonEditorRoute: themesUrl,
 			},
 			ui: {
 				selectedSiteId: siteId,
-				actionLog: [],
 			},
 		};
 

--- a/client/state/selectors/test/get-last-non-editor-route.js
+++ b/client/state/selectors/test/get-last-non-editor-route.js
@@ -2,64 +2,21 @@
  * Internal dependencies
  */
 import getLastNonEditorRoute from 'state/selectors/get-last-non-editor-route';
-import { ROUTE_SET } from 'state/action-types';
-
-function getRouteAndActionLogState( previousPath, actionLogPath ) {
-	return {
-		route: {
-			path: {
-				previous: previousPath,
-			},
-		},
-		ui: {
-			actionLog: [
-				{ type: ROUTE_SET, path: actionLogPath },
-				{ type: ROUTE_SET, path: previousPath },
-			],
-		},
-	};
-}
 
 describe( 'getLastNonEditorRoute()', () => {
-	test( 'should return last path from action log for block editor route', () => {
-		const previousPath = '/block-editor/page/my-test-site.wordpress.com/2';
-		const actionLogPath = '/action-log-path';
-		const state = getRouteAndActionLogState( previousPath, actionLogPath );
-		expect( getLastNonEditorRoute( state ) ).toEqual( actionLogPath );
+	test( 'should return empty if the previous path path is not set', () => {
+		const stateIn = {};
+		const output = getLastNonEditorRoute( stateIn );
+		expect( output ).toBe( '' );
 	} );
 
-	test( 'should return last path from action log for legacy editor page route', () => {
-		const previousPath = '/page/my-test-site.wordpress.com';
-		const actionLogPath = '/action-log-path';
-		const state = getRouteAndActionLogState( previousPath, actionLogPath );
-		expect( getLastNonEditorRoute( state ) ).toEqual( actionLogPath );
-	} );
-
-	test( 'should return last path from action log for legacy editor post route', () => {
-		const previousPath = '/post/my-test-site.wordpress.com';
-		const actionLogPath = '/action-log-path';
-		const state = getRouteAndActionLogState( previousPath, actionLogPath );
-		expect( getLastNonEditorRoute( state ) ).toEqual( actionLogPath );
-	} );
-
-	test( 'should return previousPath for pages route', () => {
-		const previousPath = '/pages/my-test-site.wordpress.com';
-		const actionLogPath = '/action-log-path';
-		const state = getRouteAndActionLogState( previousPath, actionLogPath );
-		expect( getLastNonEditorRoute( state ) ).toEqual( previousPath );
-	} );
-
-	test( 'should return previousPath for posts route', () => {
-		const previousPath = '/posts/my-test-site.wordpress.com';
-		const actionLogPath = '/action-log-path';
-		const state = getRouteAndActionLogState( previousPath, actionLogPath );
-		expect( getLastNonEditorRoute( state ) ).toEqual( previousPath );
-	} );
-
-	test( 'should return previousPath for home route', () => {
-		const previousPath = '/home/my-test-site.wordpress.com';
-		const actionLogPath = '/action-log-path';
-		const state = getRouteAndActionLogState( previousPath, actionLogPath );
-		expect( getLastNonEditorRoute( state ) ).toEqual( previousPath );
+	test( 'should return previous path if one is found', () => {
+		const stateIn = {
+			route: {
+				lastNonEditorRoute: '/hello',
+			},
+		};
+		const output = getLastNonEditorRoute( stateIn );
+		expect( output ).toBe( '/hello' );
 	} );
 } );


### PR DESCRIPTION
When closing the block editor, we take the user back to the last non-editor page they were on. We determine the last non-editor state by searching through the action log.

The problem is that the action log isn't saved to `localStorage`, so if the user refreshes the page then we lose where they came from and just go to a default location. This bug is made even worse by the navigation sidebar because navigating between items in the sidebar refreshes the page too.

We can't persist the whole action log because that's going to grow unbounded. Instead we'll store just the info we want as a new bit of state in the redux store. Unfortunately that means there's data duplication. 🤞 the redux pattern helps us keep it in sync.

#### Changes proposed in this Pull Request

* Add `lastNonEditorRoute` state to redux store
* Persist `lastNonEditorRoute` state using the `withSchemaValidation` higer-order-reducer
* Re-write the `getLastNonEditorRoute` selector so it doesn't depend on the action log
* Update tests

Luckily, block editor navigation is the only user of the `getLastNonEditorRoute` selector, so we don't have to worry about this change breaking any other features.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch
* Open Calypso and navigate to the block editor via the pages list
* Refresh the page
* Exit the block editor
* You should be taken back to the pages list (previously you would have gone to customer home, which is the default location when we don't know where in Calypso came from)
* If you have the nav sidebar enabled then:
  * Navigate to the block editor via the pages list
  * Create a new page using the sidebar
  * Navigate between pages using the sidebar
  * Exit the block editor (the link to do so should say "View Pages" or something similar)
  * You should be taken back to the pages list
