### PR TITLE
Fix gutenboarding /new placeholder translations

### DIFF
--- a/client/landing/gutenboarding/hooks/use-typer.ts
+++ b/client/landing/gutenboarding/hooks/use-typer.ts
@@ -72,7 +72,10 @@ export default function useTyper(
 					// start deleting
 					setMode( 'DELETING' );
 				} else {
-					setWordIndex( ( wordIndex + 1 ) % words.length );
+					// Pick any word except the current one
+					setWordIndex(
+						( wordIndex + Math.ceil( Math.random() * ( words.length - 1 ) ) ) % words.length
+					);
 					setMode( 'TYPING' );
 				}
 			}

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
@@ -7,7 +7,6 @@ import { TextControl } from '@wordpress/components';
 import { useI18n } from '@automattic/react-i18n';
 import { Icon } from '@wordpress/icons';
 import classnames from 'classnames';
-import { _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -21,63 +20,52 @@ interface Props {
 	onSubmit: () => void;
 }
 
-/**
- * Shuffles an array in place
- *
- * @param arr the array to shuffle
- */
-function shuffle( arr: string[] ) {
-	return arr.sort( () => ( Math.random() > 0.5 ? -1 : 1 ) );
-}
-
-/* we have them outside ot the component to avoid re-shuffling on every render */
-const siteTitleExamples = shuffle( [
-	/* translators: This is an example of a site name,
-	   feel free to create your own but please keep it under 22 characters */
-	_x( 'The Local Latest', 'sample site title' ),
-	/* translators: This is an example of a site name,
-	   feel free to create your own but please keep it under 22 characters */
-	_x( 'North Peak Cycling', 'sample site title' ),
-	/* translators: This is an example of a site name,
-	   feel free to create your own but please keep it under 22 characters */
-	_x( 'Sunshine Daycare', 'sample site title' ),
-	/* translators: This is an example of a site name,
-	   feel free to create your own but please keep it under 22 characters */
-	_x( 'Quick Wins Consulting', 'sample site title' ),
-	/* translators: This is an example of a site name,
-	   feel free to create your own but please keep it under 22 characters */
-	_x( 'Puns and Pedantry', 'sample site title' ),
-	/* translators: This is an example of a site name,
-	   feel free to create your own but please keep it under 22 characters */
-	_x( 'Yoga For Everyone', 'sample site title' ),
-	/* translators: This is an example of a site name,
-	   feel free to create your own but please keep it under 22 characters */
-	_x( 'Pugs Wearing Bowties', 'sample site title' ),
-	/* translators: This is an example of a site name,
-	   feel free to create your own but please keep it under 22 characters */
-	_x( 'Behind the Lens', 'sample site title' ),
-	/* translators: This is an example of a site name,
-	   feel free to create your own but please keep it under 22 characters */
-	_x( 'Marketing Magic', 'sample site title' ),
-	/* translators: This is an example of a site name,
-	   feel free to create your own but please keep it under 22 characters */
-	_x( 'Cortado Coffee', 'sample site title' ),
-	/* translators: This is an example of a site name,
-	   feel free to create your own but please keep it under 22 characters */
-	_x( 'Mumbai Bites', 'sample site title' ),
-	/* translators: This is an example of a site name,
-	   feel free to create your own but please keep it under 22 characters */
-	_x( 'RPM Motors', 'sample site title' ),
-	/* translators: This is an example of a site name,
-	   feel free to create your own but please keep it under 22 characters */
-	_x( 'Max’s Burger Bar', 'sample site title' ),
-] );
-
 const SiteTitle: React.FunctionComponent< Props > = ( { onSubmit } ) => {
-	const { __ } = useI18n();
+	const { __, _x } = useI18n();
 	const { siteTitle } = useSelect( ( select ) => select( STORE_KEY ).getState() );
 	const { setSiteTitle } = useDispatch( STORE_KEY );
 	const [ isTouched, setIsTouched ] = React.useState( false );
+	const siteTitleExamples = [
+		/* translators: This is an example of a site name,
+		   feel free to create your own but please keep it under 22 characters */
+		_x( 'The Local Latest', 'sample site title' ),
+		/* translators: This is an example of a site name,
+		   feel free to create your own but please keep it under 22 characters */
+		_x( 'North Peak Cycling', 'sample site title' ),
+		/* translators: This is an example of a site name,
+		   feel free to create your own but please keep it under 22 characters */
+		_x( 'Sunshine Daycare', 'sample site title' ),
+		/* translators: This is an example of a site name,
+		   feel free to create your own but please keep it under 22 characters */
+		_x( 'Quick Wins Consulting', 'sample site title' ),
+		/* translators: This is an example of a site name,
+		   feel free to create your own but please keep it under 22 characters */
+		_x( 'Puns and Pedantry', 'sample site title' ),
+		/* translators: This is an example of a site name,
+		   feel free to create your own but please keep it under 22 characters */
+		_x( 'Yoga For Everyone', 'sample site title' ),
+		/* translators: This is an example of a site name,
+		   feel free to create your own but please keep it under 22 characters */
+		_x( 'Pugs Wearing Bowties', 'sample site title' ),
+		/* translators: This is an example of a site name,
+		   feel free to create your own but please keep it under 22 characters */
+		_x( 'Behind the Lens', 'sample site title' ),
+		/* translators: This is an example of a site name,
+		   feel free to create your own but please keep it under 22 characters */
+		_x( 'Marketing Magic', 'sample site title' ),
+		/* translators: This is an example of a site name,
+		   feel free to create your own but please keep it under 22 characters */
+		_x( 'Cortado Coffee', 'sample site title' ),
+		/* translators: This is an example of a site name,
+		   feel free to create your own but please keep it under 22 characters */
+		_x( 'Mumbai Bites', 'sample site title' ),
+		/* translators: This is an example of a site name,
+		   feel free to create your own but please keep it under 22 characters */
+		_x( 'RPM Motors', 'sample site title' ),
+		/* translators: This is an example of a site name,
+		   feel free to create your own but please keep it under 22 characters */
+		_x( 'Max’s Burger Bar', 'sample site title' ),
+	];
 
 	const handleFormSubmit = ( e: React.FormEvent< HTMLFormElement > ) => {
 		// hitting 'Enter' when focused on the input field should direct to next step.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes missing translations in the typer in the gutenboarding `/new` page:

![WordPress_com](https://user-images.githubusercontent.com/5952255/89502482-6a1f5e00-d808-11ea-81a6-76f4950b7aa4.jpg)

The translations are in glotpress(*), but not being shown because they're evaluated in a `const` at load time before the user's translations are available.

This PR moves the translations inside the react component so they are effected by locale updates.

In order to do this, I've moved the randomization into useTyper (which is awesome, btw 👍 ), and changed the randomness somewhat out of expedience. `useTyper` now chooses the words randomly, rather than going through the whole list before repeating.

@alshakero: Is that ok? I actually liked your old logic better, and considered shuffling indexes to keep the same functionality, but my real concern here is getting the strings translated, so I went with expediency.

Please feel free to take over this PR if you'd like to improve it :)

*

#### Testing instructions

- Change your locale to something non-english
- go to /new (i.e. [calypso.live/new](https://hash-9abec28042518a964263ff6e48d6111d3646b826.calypso.live/new) or http://calypso.localhost:3000/new) and check that the strings are translated

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

![typer-fix](https://user-images.githubusercontent.com/5952255/89503581-131a8880-d80a-11ea-9112-bf884e2f6ef0.gif)

[*] Several of the strings have been mistranslated into English for Korean (one of them shows up in the gif)
```
'Sunshine Daycare'
'Quick Wins Consulting'
'Max’s Burger Bar'
'Mumbai Bites'
```

French looks good, but there are some different missing translations in `zh-cn`. I'll ping Global about getting them re-translated.