### PR TITLE
Editor Deprecation: Remove all editor switching from inline help popover

### DIFF
--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -23,39 +23,18 @@ import InlineHelpSearchCard from './inline-help-search-card';
 import InlineHelpRichResult from './inline-help-rich-result';
 import getSearchQuery from 'state/inline-help/selectors/get-search-query';
 import getInlineHelpCurrentlySelectedResult from 'state/inline-help/selectors/get-inline-help-currently-selected-result';
-import { getHelpSelectedSite } from 'state/help/selectors';
 import QuerySupportTypes from 'blocks/inline-help/inline-help-query-support-types';
 import InlineHelpContactView from 'blocks/inline-help/inline-help-contact-view';
-import isEligibleForDotcomChecklist from 'state/selectors/is-eligible-for-dotcom-checklist';
 import { getSelectedSiteId, getSection } from 'state/ui/selectors';
-import getCurrentRoute from 'state/selectors/get-current-route';
-import { setSelectedEditor } from 'state/selected-editor/actions';
-import {
-	composeAnalytics,
-	recordGoogleEvent,
-	recordTracksEvent,
-	withAnalytics,
-	bumpStat,
-} from 'state/analytics/actions';
-import getGutenbergEditorUrl from 'state/selectors/get-gutenberg-editor-url';
-import { getEditorPostId } from 'state/editor/selectors';
-import { getEditedPostValue } from 'state/posts/selectors';
+import { recordTracksEvent } from 'state/analytics/actions';
 import QueryActiveTheme from 'components/data/query-active-theme';
-import isGutenbergOptInEnabled from 'state/selectors/is-gutenberg-opt-in-enabled';
-import isGutenbergOptOutEnabled from 'state/selectors/is-gutenberg-opt-out-enabled';
-import inEditorDeprecationGroup from 'state/editor-deprecation-group/selectors/in-editor-deprecation-group';
 
 class InlineHelpPopover extends Component {
 	static propTypes = {
 		onClose: PropTypes.func.isRequired,
 		setDialogState: PropTypes.func.isRequired,
-		selectedEditor: PropTypes.string,
-		classicUrl: PropTypes.string,
 		siteId: PropTypes.number,
-		optOut: PropTypes.func,
-		optIn: PropTypes.func,
 		redirect: PropTypes.func,
-		isEligibleForChecklist: PropTypes.bool.isRequired,
 	};
 
 	static defaultProps = {
@@ -208,54 +187,14 @@ class InlineHelpPopover extends Component {
 	};
 
 	renderPrimaryView = () => {
-		const { translate, siteId, showOptIn, showOptOut, isCheckout, isEditorDeprecated } = this.props;
+		const { siteId, isCheckout } = this.props;
 
 		// Don't show additional items inside Checkout.
 		if ( isCheckout ) {
 			return null;
 		}
 
-		return (
-			<>
-				<QueryActiveTheme siteId={ siteId } />
-				{ showOptOut && ! isEditorDeprecated && (
-					<Button
-						onClick={ this.switchToClassicEditor }
-						className="inline-help__classic-editor-toggle"
-					>
-						{ translate( 'Switch to Classic Editor' ) }
-					</Button>
-				) }
-
-				{ showOptIn && ! isEditorDeprecated && (
-					<Button
-						onClick={ this.switchToBlockEditor }
-						className="inline-help__gutenberg-editor-toggle"
-					>
-						{ translate( 'Switch to Block Editor' ) }
-					</Button>
-				) }
-			</>
-		);
-	};
-
-	switchToClassicEditor = () => {
-		const { siteId, onClose, optOut, classicUrl, translate } = this.props;
-
-		const proceed =
-			typeof window === 'undefined' ||
-			window.confirm( translate( 'Are you sure you wish to leave this page?' ) );
-
-		if ( proceed ) {
-			optOut( siteId, classicUrl );
-			onClose();
-		}
-	};
-
-	switchToBlockEditor = () => {
-		const { siteId, onClose, optIn, gutenbergUrl } = this.props;
-		optIn( siteId, gutenbergUrl );
-		onClose();
+		return <QueryActiveTheme siteId={ siteId } />;
 	};
 
 	render() {
@@ -278,74 +217,19 @@ class InlineHelpPopover extends Component {
 	}
 }
 
-const optOut = ( siteId, classicUrl ) => {
-	return withAnalytics(
-		composeAnalytics(
-			recordGoogleEvent(
-				'Gutenberg Opt-Out',
-				'Clicked "Switch to the classic editor" in the help popover.',
-				'Opt-In',
-				false
-			),
-			recordTracksEvent( 'calypso_gutenberg_opt_in', {
-				opt_in: false,
-				location: 'inline-help-popover',
-			} ),
-			bumpStat( 'gutenberg-opt-in', 'Calypso Help Opt Out' )
-		),
-		setSelectedEditor( siteId, 'classic', classicUrl )
-	);
-};
-
-const optIn = ( siteId, gutenbergUrl ) => {
-	return withAnalytics(
-		composeAnalytics(
-			recordGoogleEvent(
-				'Gutenberg Opt-In',
-				'Clicked "Switch to Block editor" in inline help.',
-				'Opt-In',
-				true
-			),
-			recordTracksEvent( 'calypso_gutenberg_opt_in', {
-				opt_in: true,
-				location: 'inline-help-popover',
-			} ),
-			bumpStat( 'gutenberg-opt-in', 'Calypso Help Opt In' )
-		),
-		setSelectedEditor( siteId, 'gutenberg', gutenbergUrl )
-	);
-};
-
 function mapStateToProps( state ) {
 	const siteId = getSelectedSiteId( state );
-	const currentRoute = getCurrentRoute( state );
-	const classicRoute = currentRoute.replace( '/block-editor/', '' );
 	const section = getSection( state );
-	const isCalypsoClassic = section.group && section.group === 'editor';
-	const optInEnabled = isGutenbergOptInEnabled( state, siteId );
-	const postId = getEditorPostId( state );
-	const postType = getEditedPostValue( state, siteId, postId, 'type' );
-	const gutenbergUrl = getGutenbergEditorUrl( state, siteId, postId, postType );
-	const showSwitchEditorButton = currentRoute.match( /^\/(block-editor|post|page)\// );
 
 	return {
 		searchQuery: getSearchQuery( state ),
-		isEligibleForChecklist: isEligibleForDotcomChecklist( state, siteId ),
-		selectedSite: getHelpSelectedSite( state ),
 		selectedResult: getInlineHelpCurrentlySelectedResult( state ),
-		classicUrl: `/${ classicRoute }`,
 		siteId,
-		showOptOut: showSwitchEditorButton && isGutenbergOptOutEnabled( state, siteId ),
-		showOptIn: showSwitchEditorButton && optInEnabled && isCalypsoClassic,
-		gutenbergUrl,
 		isCheckout: section.name && section.name === 'checkout',
-		isEditorDeprecated: inEditorDeprecationGroup( state ),
 	};
 }
 
 const mapDispatchToProps = {
-	optOut,
-	optIn,
 	recordTracksEvent,
 	selectResult,
 	resetContactForm: resetInlineHelpContactForm,

--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -25,16 +25,12 @@ import getSearchQuery from 'state/inline-help/selectors/get-search-query';
 import getInlineHelpCurrentlySelectedResult from 'state/inline-help/selectors/get-inline-help-currently-selected-result';
 import QuerySupportTypes from 'blocks/inline-help/inline-help-query-support-types';
 import InlineHelpContactView from 'blocks/inline-help/inline-help-contact-view';
-import { getSelectedSiteId, getSection } from 'state/ui/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
-import QueryActiveTheme from 'components/data/query-active-theme';
 
 class InlineHelpPopover extends Component {
 	static propTypes = {
 		onClose: PropTypes.func.isRequired,
 		setDialogState: PropTypes.func.isRequired,
-		siteId: PropTypes.number,
-		redirect: PropTypes.func,
 	};
 
 	static defaultProps = {
@@ -150,7 +146,6 @@ class InlineHelpPopover extends Component {
 					/>
 				</div>
 				{ this.renderSecondaryView() }
-				{ ! this.state.showSecondaryView && this.renderPrimaryView() }
 			</Fragment>
 		);
 	};
@@ -186,17 +181,6 @@ class InlineHelpPopover extends Component {
 		);
 	};
 
-	renderPrimaryView = () => {
-		const { siteId, isCheckout } = this.props;
-
-		// Don't show additional items inside Checkout.
-		if ( isCheckout ) {
-			return null;
-		}
-
-		return <QueryActiveTheme siteId={ siteId } />;
-	};
-
 	render() {
 		const popoverClasses = {
 			'is-secondary-view-active': this.state.showSecondaryView,
@@ -218,14 +202,9 @@ class InlineHelpPopover extends Component {
 }
 
 function mapStateToProps( state ) {
-	const siteId = getSelectedSiteId( state );
-	const section = getSection( state );
-
 	return {
 		searchQuery: getSearchQuery( state ),
 		selectedResult: getInlineHelpCurrentlySelectedResult( state ),
-		siteId,
-		isCheckout: section.name && section.name === 'checkout',
 	};
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove all editor switching related code from Inline Help Popover.

After the deprecation of the WordPress.com (Classic/Calypso) Editor, we can remove the ability to switch editors from the inline help popover. #41106

_Note: To see the switch editor button within the inline help popover prior to applying this PR branch, you need a user for whom the classic editor has not been deprecated. This can be done using WPSH to toggle the `editor_deprecation_group` user attribute to false. Just don't forget to set it back to true after testing._

#### Testing instructions

* Checkout this PR
* Edit a post
* Open the inline help popover by clicking the FAB in the bottom right
* Confirm that there is no means within that popover to switch editors at all
* Confirm that searching and results still work
* Test that the contact form still works as well

| Before (user not in deprecation group) | After |
|--------|------|
| <img width="357" alt="Screen Shot 2020-08-06 at 6 57 37 pm" src="https://user-images.githubusercontent.com/60436221/89512660-e0c35800-d816-11ea-9170-8c80a184c361.png"> | <img width="344" alt="Screen Shot 2020-08-06 at 6 58 35 pm" src="https://user-images.githubusercontent.com/60436221/89512663-e325b200-d816-11ea-86d8-eb430cc98167.png"> |



