### PR TITLE
Remove Luna as code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -85,9 +85,3 @@
 # FSE Workflow Files
 /.github/workflows/full-site-editing-plugin.yml @Automattic/cylon
 /.github/workflows/send-calypso-app-build-trigger.sh @Automattic/cylon
-
-# Gutenboarding
-/client/landing/gutenboarding @Automattic/luna
-
-# @automattic/data-stores package
-/packages/data-stores @Automattic/luna


### PR DESCRIPTION
- Gutenboarding things are being re-used are split between here and there now (in packages, in landing and elsewhere)
- Data package should be considered more common ownership at this point
- We'll try to get more automated tests done so that we don't need to manually review when folks change things in these files
- Will help with notification fatigue when we know each request to review is intentional, and not automated
