### PR TITLE
wp-babel-makepot: Add option to filter extracted strings by their source reference

### DIFF
--- a/packages/wp-babel-makepot/cli.js
+++ b/packages/wp-babel-makepot/cli.js
@@ -41,6 +41,10 @@ program
 		'Set the filename for POT concatenation output. Set `false` to disable concatenation.',
 		'build/bundle-strings.pot'
 	)
+	.option(
+		'-l, --lines-filter <file>',
+		'JSON file containing files and line numbers filters. Only included line numbers will be passed.'
+	)
 	.action( ( command, [ files = '.' ] = [] ) => {
 		if ( ! presetsKeys.includes( program.preset ) ) {
 			console.log(
@@ -54,7 +58,7 @@ program
 		const filesGlob = files.replace( /^~/, os.homedir() );
 		const ignore = program.ignore && program.ignore.split( ',' );
 
-		const { dir, base, output } = program;
+		const { dir, base, output, linesFilter } = program;
 
 		glob.sync( filesGlob, { nodir: true, absolute: true, ignore } ).forEach( ( filepath ) =>
 			makePot( filepath, {
@@ -64,7 +68,7 @@ program
 		);
 
 		if ( output && output !== 'false' ) {
-			concatPot( dir, output );
+			concatPot( dir, output, linesFilter );
 		}
 	} )
 	.parse( process.argv );

--- a/packages/wp-babel-makepot/package.json
+++ b/packages/wp-babel-makepot/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/wp-babel-makepot",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "A utility for extracting translatable strings from JavaScript source.",
 	"main": "index.js",
 	"author": "Automattic Inc.",

--- a/packages/wp-babel-makepot/utils/concat-pot.js
+++ b/packages/wp-babel-makepot/utils/concat-pot.js
@@ -30,18 +30,75 @@ const mergeDeep = ( left, right, key ) => {
 	return right || left;
 };
 
+/**
+ * Filter translations from POT data object by reference lines.
+ *
+ * @param   {object} potData POT data object
+ * @param   {string} linesFilterFile File path to JSON file with files and line numbers.
+ * @returns {void}
+ */
+const filterByLines = ( potData, linesFilterFile ) => {
+	let lines;
+
+	try {
+		lines = JSON.parse( fs.readFileSync( linesFilterFile, 'utf8' ) );
+	} catch ( error ) {
+		console.error( 'Failed to line filter file: ', error );
+	}
+
+	if ( typeof lines === 'undefined' ) {
+		return;
+	}
+
+	potData.translations = Object.keys( potData.translations ).reduce( ( acc, context ) => {
+		for ( const key in potData.translations[ context ] ) {
+			const entry = potData.translations[ context ][ key ];
+			const refs =
+				entry.comments && entry.comments.reference && entry.comments.reference.split( '\n' );
+
+			if ( ! refs ) {
+				continue;
+			}
+
+			const shouldPass = refs.some( ( ref ) => {
+				const [ file, line ] = ref.split( ':' );
+
+				return lines[ file ] && lines[ file ].indexOf( parseInt( line ) ) >= 0;
+			} );
+
+			if ( ! shouldPass ) {
+				continue;
+			}
+
+			if ( typeof acc[ context ] === 'undefined' ) {
+				acc[ context ] = {};
+			}
+
+			acc[ context ][ key ] = entry;
+		}
+
+		return acc;
+	}, {} );
+};
+
 const WARNING_COMMENT_START = '# THIS IS A GENERATED FILE. DO NOT EDIT DIRECTLY.\n\n';
 const WARNING_COMMENT_END = '\n\n# THIS IS THE END OF THE GENERATED FILE.';
 const addWarningComments = ( fileContent ) =>
 	''.concat( WARNING_COMMENT_START, fileContent, WARNING_COMMENT_END );
 
-module.exports = ( dir, output ) => {
+module.exports = ( dir, output, linesFilter ) => {
 	const potGlob = path.resolve( dir, '*.pot' );
 	const potFiles = glob.sync( potGlob, { nodir: true, absolute: true } );
 
 	const concatPOT = potFiles.reduce( ( acc, filePath ) => {
 		return mergeDeep( acc, po.parse( fs.readFileSync( filePath, 'utf8' ) ) );
 	}, {} );
+
+	// Apply filter by reference lines if presented
+	if ( typeof linesFilter !== 'undefined' ) {
+		filterByLines( concatPOT, linesFilter );
+	}
+
 	const potFileContent = addWarningComments( po.compile( concatPOT ) );
 	fs.writeFileSync( output, potFileContent );
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add option to filter extracted strings by their source reference. It requires passing path to JSON file that contains file names and line numbers that should only be included in the final POT output.

#### Testing instructions

```
echo "{\"client/me/help/help-search/index.jsx\":[94]}" > lines-filter.json;
npx -d ./packages/wp-babel-makepot wp-babel-makepot "client/me/help/help-search/index.jsx" -l lines-filter.json -d build/tmp/strings -o build/tmp/filtered-strings.pot
```
Check `build/tmp/filtered-strings.pot` and confirm it contains only the filtered translatable string "WordPress.com Documentation" from line 94 of `client/me/help/help-search/index.jsx` 