### PR TITLE
Add backend error messages to credentials update failure events

### DIFF
--- a/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
+++ b/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
@@ -135,6 +135,7 @@ export const failure = ( action, error ) => ( dispatch, getState ) => {
 		const tracksEvent = recordTracksEvent( 'calypso_rewind_creds_update_failure', {
 			site_id: action.siteId,
 			error: error.code,
+			message: error.message,
 			status_code: error.data ?? error.statusCode,
 			host: action.credentials.host,
 			kpri: action.credentials.krpi ? 'provided but [omitted here]' : 'not provided',


### PR DESCRIPTION
#### Changes proposed

When a credentials update fails, we currently map the error code to a localised error message for a notice, throwing away the backend’s non-localised error message.

This pull request adds a property with the backend’s error message to calypso_rewind_creds_update_failure events, giving us more insight into which failure modes aren’t yet handled but ought to be.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Make sure extensions like uBlock Origin are disabled.
1. Open devtools and go to the Network tab.
1. Try to save SSH credentials that are correct except for an incorrect password or private key.
1. Verify that the t.gif request for calypso_rewind_creds_update_failure contains the following message:
   > Could not open connection to [something] with given credentials

![screenshot](https://user-images.githubusercontent.com/465303/89536534-65c06880-d83b-11ea-807f-6f650ed5b9c6.png)

More details at https://wp.me/pbuNQi-uF-p2