### PR TITLE
Defend against undefined `transactionOptions`

### DIFF
--- a/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
@@ -325,9 +325,7 @@ function getErrorMessage( { error, message } ) {
 }
 
 export async function wpcomTransaction( payload, transactionOptions ) {
-	const { createUserAndSiteBeforeTransaction } = transactionOptions;
-
-	if ( createUserAndSiteBeforeTransaction ) {
+	if ( transactionOptions && transactionOptions.createUserAndSiteBeforeTransaction ) {
 		return createAccount().then( ( response ) => {
 			const siteIdFromResponse = response?.blog_details?.blogid;
 
@@ -352,9 +350,7 @@ export async function wpcomTransaction( payload, transactionOptions ) {
 }
 
 export async function wpcomPayPalExpress( payload, transactionOptions ) {
-	const { createUserAndSiteBeforeTransaction } = transactionOptions;
-
-	if ( createUserAndSiteBeforeTransaction ) {
+	if ( transactionOptions && transactionOptions.createUserAndSiteBeforeTransaction ) {
 		return createAccount().then( ( response ) => {
 			const siteIdFromResponse = response?.blog_details?.blogid;
 


### PR DESCRIPTION
Actual fix from @niranjan-uma-shankar

#### Changes proposed in this Pull Request

* This is a quick-fix to avoid destructuring errors due to `transactionOptions` not being an object

#### Testing instructions
* Not sure how to test/reproduce - @niranjan-uma-shankar, did you get a good feel for the flow involved?
