### PR TITLE
react-i18n: Add filter hooks

### DIFF
--- a/packages/react-i18n/README.md
+++ b/packages/react-i18n/README.md
@@ -64,4 +64,60 @@ export default withI18n( MyComponent );
 
 ## API
 
-The translation functions `__`, `_n`, `_nx`, and `_x` are exposed from [`@wordpress/i18n`](https://github.com/WordPress/gutenberg/tree/HEAD/packages/i18n). Refer to their documentation there.
+### Translation Functions
+
+`__`, `_n`, `_nx`, and `_x` are exposed from [`@wordpress/i18n`](https://github.com/WordPress/gutenberg/tree/HEAD/packages/i18n). Refer to their documentation there.
+
+### localeData
+
+Locale data in Jed-formatted JSON object, that is used by the active Tannin instance.
+
+### hasTranslation
+
+A helper function that can be used to determine if translation entry exists in the locale data. It is based on a similar logic as Tannin's translations lookup.
+
+_Parameters_
+
+- _text_ `string`: Text to lookup for.
+- _context_ `[string]`: Context information for the translators.
+
+_Returns_
+
+- `boolean`: Whether translation entry exists in locale data.
+
+```js
+hasTranslation( 'post', 'verb' );
+```
+
+### Filter Functions
+
+`addFilter`, `removeFilter`, `applyFilters` are based on [`@wordpress/hooks`](https://developer.wordpress.org/block-editor/packages/packages-hooks/). Refer to their documentation there.
+
+In order to keep filter hook names short filter and avoid collision with other package in the same time, the exposed filter functions from within the package will prefix the passed hook name with `a8c.reactI18n.{hookName}`:
+
+```js
+addFilter( 'translation', 'namespace', () => {} ); // Hook name will become `a8c.reactI18n.translation`
+```
+
+#### Available Filters
+
+**arguments**
+
+Allows you to modify the arguments passed to a translate function.
+
+_Parameters_
+
+- _args_ `array`: The arguments array passed to the translate function.
+- _fnName_ `string`: The name of the translation function. Could be `__`, `_n`, `_nx`, or `_x`.
+- _options_ `object`: `@automattic/react-i18n` context options object.
+
+**arguments**
+
+Allows you to modify the arguments passed to a translate function.
+
+_Parameters_
+
+- _translation_ `string`: The retrieved translation string.
+- _args_ `array`: The arguments array passed to the translate function.
+- _fnName_ `string`: The name of the translation function. Could be `__`, `_n`, `_nx`, or `_x`.
+- _options_ `object`: `@automattic/react-i18n` context options object.

--- a/packages/react-i18n/README.md
+++ b/packages/react-i18n/README.md
@@ -95,7 +95,7 @@ hasTranslation( 'post', 'verb' );
 
 #### Available Filters
 
-**preTranslation**
+##### preTranslation
 
 Modify the input arguments before the translation lookup.
 
@@ -105,7 +105,7 @@ _Parameters_
 - _fnName_ `string`: The name of the translation function. Could be `__`, `_n`, `_nx`, or `_x`.
 - _filters_ `object`: `@automattic/react-i18n` context filters object.
 
-**postTranslation**
+##### postTranslation
 
 Modify the result of the translate function.
 

--- a/packages/react-i18n/README.md
+++ b/packages/react-i18n/README.md
@@ -91,33 +91,27 @@ hasTranslation( 'post', 'verb' );
 
 ### Filter Functions
 
-`addFilter`, `removeFilter`, `applyFilters` are based on [`@wordpress/hooks`](https://developer.wordpress.org/block-editor/packages/packages-hooks/). Refer to their documentation there.
-
-In order to keep filter hook names short filter and avoid collision with other package in the same time, the exposed filter functions from within the package will prefix the passed hook name with `a8c.reactI18n.{hookName}`:
-
-```js
-addFilter( 'translation', 'namespace', () => {} ); // Hook name will become `a8c.reactI18n.translation`
-```
+`addFilter` and `removeFilter` are based on [`@wordpress/hooks`](https://developer.wordpress.org/block-editor/packages/packages-hooks/). Refer to their documentation there.
 
 #### Available Filters
 
-**arguments**
+**preTranslation**
 
-Allows you to modify the arguments passed to a translate function.
+Modify the input arguments before the translation lookup.
 
 _Parameters_
 
 - _args_ `array`: The arguments array passed to the translate function.
 - _fnName_ `string`: The name of the translation function. Could be `__`, `_n`, `_nx`, or `_x`.
-- _options_ `object`: `@automattic/react-i18n` context options object.
+- _filters_ `object`: `@automattic/react-i18n` context filters object.
 
-**arguments**
+**postTranslation**
 
-Allows you to modify the arguments passed to a translate function.
+Modify the result of the translate function.
 
 _Parameters_
 
 - _translation_ `string`: The retrieved translation string.
-- _args_ `array`: The arguments array passed to the translate function.
+- _args_ `array`: The input arguments array passed to the translate function.
 - _fnName_ `string`: The name of the translation function. Could be `__`, `_n`, `_nx`, or `_x`.
-- _options_ `object`: `@automattic/react-i18n` context options object.
+- _filters_ `object`: `@automattic/react-i18n` context filters object.

--- a/packages/react-i18n/package.json
+++ b/packages/react-i18n/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/react-i18n",
-	"version": "1.0.0-alpha.0",
+	"version": "1.0.0-alpha.1",
 	"description": "React bindings for @wordpress/i18n",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",

--- a/packages/react-i18n/package.json
+++ b/packages/react-i18n/package.json
@@ -33,6 +33,7 @@
 	},
 	"dependencies": {
 		"@wordpress/compose": "1.x.x - 3.x.x",
+		"@wordpress/hooks": "^2.9.0",
 		"@wordpress/i18n": "^3.14.0",
 		"tslib": "^1.10.0"
 	},

--- a/packages/react-i18n/src/index.tsx
+++ b/packages/react-i18n/src/index.tsx
@@ -3,10 +3,25 @@
  */
 import * as React from 'react';
 
-import defaultI18n, { createI18n, I18n, LocaleData } from '@wordpress/i18n';
+import {
+	createI18n,
+	I18n,
+	LocaleData,
+	__,
+	_n,
+	_nx,
+	_x,
+	isRTL,
+	setLocaleData,
+} from '@wordpress/i18n';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { createHooks, addAction as globalAddAction } from '@wordpress/hooks';
 import type { addFilter, removeFilter, hasFilter, applyFilters } from '@wordpress/hooks';
+
+/**
+ * Default i18n instance.
+ */
+const defaultI18n: I18n = { __, _n, _nx, _x, isRTL, setLocaleData };
 
 export interface I18nReact {
 	__: I18n[ '__' ];

--- a/packages/react-i18n/src/index.tsx
+++ b/packages/react-i18n/src/index.tsx
@@ -24,18 +24,29 @@ const I18nContext = React.createContext< I18nReact >( makeContextValue() );
 interface Props {
 	localeData?: LocaleData;
 }
-
+/**
+ * Prefix for filter hook names
+ */
 const FILTER_PREFIX = 'a8c.reactI18n';
 
-const useFilters = (): any => {
-	const [ , setFiltersUpdates ] = React.useState( 0 ); // State is only used to provide reactivity when add/removing filters
-	const { filters, addFilter, removeFilter, applyFilters } = React.useMemo(
-		() => createHooks(),
-		[]
-	);
+interface I18nReactFilters {
+	addFilter: Function;
+	removeFilter: Function;
+	applyFilters: Function;
+}
 
-	const bindFn = ( fn, shouldUpdate = true ) => ( ...args ) => {
-		args[ 0 ] = `${ FILTER_PREFIX }.${ args[ 0 ] }`; // Apply hook name prefix
+/**
+ * React hook for managing filters
+ */
+const useFilters = (): I18nReactFilters => {
+	// State is only used to provide reactivity when add/removing filters
+	const [ , setFiltersUpdates ] = React.useState( 0 );
+	const { addFilter, removeFilter, applyFilters } = React.useMemo( () => createHooks(), [] );
+
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	const bindFn = ( fn: Function, shouldUpdate = true ) => ( ...args: any[] ) => {
+		// Apply filter hook name prefix
+		args[ 0 ] = `${ FILTER_PREFIX }.${ args[ 0 ] }`;
 		const result = fn( ...args );
 
 		if ( shouldUpdate ) {
@@ -46,7 +57,6 @@ const useFilters = (): any => {
 	};
 
 	return {
-		filters,
 		addFilter: bindFn( addFilter ),
 		removeFilter: bindFn( removeFilter ),
 		applyFilters: bindFn( applyFilters, false ),
@@ -100,8 +110,7 @@ export const withI18n = createHigherOrderComponent< I18nReact >( ( InnerComponen
 }, 'withI18n' );
 
 interface MakeContextValueOptions {
-	translation?: I18nTransformHooks;
-	lookup?: I18nTransformHooks;
+	filters: I18nReactFilters;
 }
 
 /**

--- a/packages/react-i18n/src/index.tsx
+++ b/packages/react-i18n/src/index.tsx
@@ -17,7 +17,6 @@ export interface I18nReact {
 	hasTranslation: ( singular: string, context?: string ) => boolean;
 	addFilter: typeof addFilter;
 	removeFilter: typeof removeFilter;
-	applyFilters: typeof applyFilters;
 }
 
 /**
@@ -212,6 +211,5 @@ function makeContextValue( localeData?: LocaleData, options?: MakeContextValueOp
 		hasTranslation: boundHasTranslation,
 		addFilter,
 		removeFilter,
-		applyFilters,
 	};
 }

--- a/packages/react-i18n/src/index.tsx
+++ b/packages/react-i18n/src/index.tsx
@@ -4,6 +4,7 @@
 import * as React from 'react';
 import { createI18n, I18n, LocaleData, __, _n, _nx, _x, isRTL } from '@wordpress/i18n';
 import { createHigherOrderComponent } from '@wordpress/compose';
+import { createHooks } from '@wordpress/hooks';
 
 export interface I18nReact {
 	__: I18n[ '__' ];
@@ -13,8 +14,9 @@ export interface I18nReact {
 	isRTL: I18n[ 'isRTL' ];
 	localeData?: LocaleData;
 	hasTranslation: Function;
-	registerTranslationHook?: Function;
-	unregisterTranslationHook?: Function;
+	addFilter?: Function;
+	removeFilter?: Function;
+	applyFilters?: Function;
 }
 
 const I18nContext = React.createContext< I18nReact >( makeContextValue() );
@@ -23,33 +25,43 @@ interface Props {
 	localeData?: LocaleData;
 }
 
-interface I18nTransformHooks {
-	registerHook: Function;
-	unregisterHook: Function;
-	hooks: Function[];
-}
+const FILTER_PREFIX = 'a8c.reactI18n';
 
-/**
- * React hook for managing I18n transformation hooks
- */
-const useI18nTransformHooks = (): I18nTransformHooks => {
-	const [ hooks, setHooks ] = React.useState< Function[] >( [] );
-	const registerHook = ( hook: Function ) => setHooks( hooks.concat( hook ) );
-	const unregisterHook = ( hook: Function ) =>
-		setHooks( hooks.filter( ( _hook ) => _hook !== hook ) );
+const useFilters = (): any => {
+	const [ , setFiltersUpdates ] = React.useState( 0 ); // State is only used to provide reactivity when add/removing filters
+	const { filters, addFilter, removeFilter, applyFilters } = React.useMemo(
+		() => createHooks(),
+		[]
+	);
 
-	return { hooks, registerHook, unregisterHook };
+	const bindFn = ( fn, shouldUpdate = true ) => ( ...args ) => {
+		args[ 0 ] = `${ FILTER_PREFIX }.${ args[ 0 ] }`; // Apply hook name prefix
+		const result = fn( ...args );
+
+		if ( shouldUpdate ) {
+			setFiltersUpdates( ( i ) => ++i );
+		}
+
+		return result;
+	};
+
+	return {
+		filters,
+		addFilter: bindFn( addFilter ),
+		removeFilter: bindFn( removeFilter ),
+		applyFilters: bindFn( applyFilters, false ),
+	};
 };
 
 export const I18nProvider: React.FunctionComponent< Props > = ( { children, localeData } ) => {
 	const options = {
-		lookup: useI18nTransformHooks(),
-		translation: useI18nTransformHooks(),
+		filters: useFilters(),
 	};
 	const contextValue = React.useMemo< I18nReact >( () => makeContextValue( localeData, options ), [
 		localeData,
 		options,
 	] );
+
 	return <I18nContext.Provider value={ contextValue }>{ children }</I18nContext.Provider>;
 };
 
@@ -107,18 +119,20 @@ function bindI18nFunction(
 ) {
 	const boundFn = i18n[ fnName ].bind( i18n );
 
+	if ( ! options?.filters ) {
+		return boundFn;
+	}
+
 	return ( ...args: ( string | number )[] ) => {
-		const transformedArguments = ( options?.lookup?.hooks || [] ).reduce(
-			( accumulator, hook ) => hook( accumulator, args, fnName, options ),
-			args
-		);
+		const filteredArguments = options.filters.applyFilters( 'arguments', args, fnName, options );
 
-		const transformedTranslation = ( options?.translation?.hooks || [] ).reduce(
-			( accumulator, hook ) => hook( accumulator, transformedArguments, fnName, options ),
-			boundFn( ...transformedArguments )
+		return options.filters.applyFilters(
+			'translation',
+			boundFn( ...filteredArguments ),
+			filteredArguments,
+			fnName,
+			options
 		);
-
-		return transformedTranslation;
 	};
 }
 
@@ -163,7 +177,8 @@ function makeContextValue( localeData?: LocaleData, options?: MakeContextValueOp
 		isRTL: i18n.isRTL.bind( i18n ),
 		localeData,
 		hasTranslation: boundHasTranslation,
-		registerTranslationHook: options?.translation?.registerHook,
-		unregisterTranslationHook: options?.translation?.unregisterHook,
+		addFilter: options?.filters?.addFilter,
+		removeFilter: options?.filters?.removeFilter,
+		applyFilters: options?.filters?.applyFilters,
 	};
 }

--- a/packages/react-i18n/src/index.tsx
+++ b/packages/react-i18n/src/index.tsx
@@ -127,15 +127,16 @@ export const withI18n = createHigherOrderComponent< I18nReact >( ( InnerComponen
  */
 function bindI18nFunction( i18n: I18n, fnName: '__' | '_n' | '_nx' | '_x', filters: I18nFilters ) {
 	const translateFn = i18n[ fnName ];
+	const { hasFilter, applyFilters } = filters;
 
-	if ( ! filters.hasFilter( 'preTranslation' ) && ! filters.hasFilter( 'postTranslation' ) ) {
+	if ( ! hasFilter( 'preTranslation' ) && ! hasFilter( 'postTranslation' ) ) {
 		return translateFn;
 	}
 
 	return ( ...args: ( string | number )[] ) => {
-		const filteredArguments = filters.applyFilters( 'preTranslation', args, fnName, filters );
+		const filteredArguments = applyFilters( 'preTranslation', args, fnName, filters );
 
-		return filters.applyFilters(
+		return applyFilters(
 			'postTranslation',
 			translateFn( ...filteredArguments ),
 			filteredArguments,

--- a/packages/react-i18n/src/index.tsx
+++ b/packages/react-i18n/src/index.tsx
@@ -2,7 +2,8 @@
  * External dependencies
  */
 import * as React from 'react';
-import { createI18n, I18n, LocaleData, __, _n, _nx, _x, isRTL } from '@wordpress/i18n';
+
+import defaultI18n, { createI18n, I18n, LocaleData } from '@wordpress/i18n';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { createHooks, addAction as globalAddAction } from '@wordpress/hooks';
 import type { addFilter, removeFilter, hasFilter, applyFilters } from '@wordpress/hooks';
@@ -14,7 +15,7 @@ export interface I18nReact {
 	_x: I18n[ '_x' ];
 	isRTL: I18n[ 'isRTL' ];
 	localeData?: LocaleData;
-	hasTranslation: ( singular: string, context?: string ) => boolean;
+	hasTranslation?: ( singular: string, context?: string ) => boolean;
 	addFilter: typeof addFilter;
 	removeFilter: typeof removeFilter;
 }
@@ -171,13 +172,10 @@ function hasTranslation( localeData: LocaleData, singular: string, context?: str
  * @returns The context value with bound translation functions
  */
 function makeContextValue( localeData?: LocaleData, filters?: I18nFilters ): I18nReact {
-	if ( ! localeData ) {
-		return { __, _n, _nx, _x, isRTL };
-	}
-
-	const i18n = createI18n( localeData );
-	const boundHasTranslation = ( singular: string, context?: string ) =>
-		hasTranslation( localeData || {}, singular, context );
+	const i18n = localeData ? createI18n( localeData ) : defaultI18n;
+	const boundHasTranslation = localeData
+		? ( singular: string, context?: string ) => hasTranslation( localeData, singular, context )
+		: undefined;
 
 	const { addFilter, removeFilter, hasFilter, applyFilters } = filters ?? createHooks();
 	const i18nFunctionFilters = { addFilter, removeFilter, hasFilter, applyFilters };

--- a/packages/react-i18n/src/index.tsx
+++ b/packages/react-i18n/src/index.tsx
@@ -4,7 +4,7 @@
 import * as React from 'react';
 import { createI18n, I18n, LocaleData, __, _n, _nx, _x, isRTL } from '@wordpress/i18n';
 import { createHigherOrderComponent } from '@wordpress/compose';
-import { createHooks } from '@wordpress/hooks';
+import { addFilter, removeFilter, applyFilters } from '@wordpress/hooks';
 
 export interface I18nReact {
 	__: I18n[ '__' ];
@@ -41,7 +41,6 @@ interface I18nReactFilters {
 const useFilters = (): I18nReactFilters => {
 	// State is only used to provide reactivity when add/removing filters
 	const [ , setFiltersUpdates ] = React.useState( 0 );
-	const { addFilter, removeFilter, applyFilters } = React.useMemo( () => createHooks(), [] );
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	const bindFn = ( fn: Function, shouldUpdate = true ) => ( ...args: any[] ) => {

--- a/packages/react-i18n/src/index.tsx
+++ b/packages/react-i18n/src/index.tsx
@@ -126,10 +126,10 @@ export const withI18n = createHigherOrderComponent< I18nReact >( ( InnerComponen
  * @returns Bound I18n function with applied transformation hooks
  */
 function bindI18nFunction( i18n: I18n, fnName: '__' | '_n' | '_nx' | '_x', filters: I18nFilters ) {
-	const boundFn = i18n[ fnName ].bind( i18n );
+	const translateFn = i18n[ fnName ];
 
 	if ( ! filters.hasFilter( 'preTranslation' ) && ! filters.hasFilter( 'postTranslation' ) ) {
-		return boundFn;
+		return translateFn;
 	}
 
 	return ( ...args: ( string | number )[] ) => {
@@ -137,7 +137,7 @@ function bindI18nFunction( i18n: I18n, fnName: '__' | '_n' | '_nx' | '_x', filte
 
 		return filters.applyFilters(
 			'postTranslation',
-			boundFn( ...filteredArguments ),
+			translateFn( ...filteredArguments ),
 			filteredArguments,
 			fnName,
 			filters
@@ -186,7 +186,7 @@ function makeContextValue( localeData?: LocaleData, filters?: I18nFilters ): I18
 		_n: bindI18nFunction( i18n, '_n', i18nFunctionFilters ),
 		_nx: bindI18nFunction( i18n, '_nx', i18nFunctionFilters ),
 		_x: bindI18nFunction( i18n, '_x', i18nFunctionFilters ),
-		isRTL: i18n.isRTL.bind( i18n ),
+		isRTL: i18n.isRTL,
 		localeData,
 		hasTranslation: boundHasTranslation,
 		addFilter,

--- a/packages/react-i18n/src/index.tsx
+++ b/packages/react-i18n/src/index.tsx
@@ -11,6 +11,10 @@ export interface I18nReact {
 	_nx: I18n[ '_nx' ];
 	_x: I18n[ '_x' ];
 	isRTL: I18n[ 'isRTL' ];
+	localeData?: LocaleData;
+	hasTranslation: Function;
+	registerTranslationHook?: Function;
+	unregisterTranslationHook?: Function;
 }
 
 const I18nContext = React.createContext< I18nReact >( makeContextValue() );
@@ -19,9 +23,32 @@ interface Props {
 	localeData?: LocaleData;
 }
 
+interface I18nTransformHooks {
+	registerHook: Function;
+	unregisterHook: Function;
+	hooks: Function[];
+}
+
+/**
+ * React hook for managing I18n transformation hooks
+ */
+const useI18nTransformHooks = (): I18nTransformHooks => {
+	const [ hooks, setHooks ] = React.useState< Function[] >( [] );
+	const registerHook = ( hook: Function ) => setHooks( hooks.concat( hook ) );
+	const unregisterHook = ( hook: Function ) =>
+		setHooks( hooks.filter( ( _hook ) => _hook !== hook ) );
+
+	return { hooks, registerHook, unregisterHook };
+};
+
 export const I18nProvider: React.FunctionComponent< Props > = ( { children, localeData } ) => {
-	const contextValue = React.useMemo< I18nReact >( () => makeContextValue( localeData ), [
+	const options = {
+		lookup: useI18nTransformHooks(),
+		translation: useI18nTransformHooks(),
+	};
+	const contextValue = React.useMemo< I18nReact >( () => makeContextValue( localeData, options ), [
 		localeData,
+		options,
 	] );
 	return <I18nContext.Provider value={ contextValue }>{ children }</I18nContext.Provider>;
 };
@@ -60,25 +87,83 @@ export const withI18n = createHigherOrderComponent< I18nReact >( ( InnerComponen
 	};
 }, 'withI18n' );
 
+interface MakeContextValueOptions {
+	translation?: I18nTransformHooks;
+	lookup?: I18nTransformHooks;
+}
+
+/**
+ * Bind an I18n function to its instance
+ *
+ * @param i18n I18n instance
+ * @param fnName '__' | '_n' | '_nx' | '_x'
+ * @param options Make context value options object
+ * @returns Bound I18n function with applied transformation hooks
+ */
+function bindI18nFunction(
+	i18n: I18n,
+	fnName: '__' | '_n' | '_nx' | '_x',
+	options?: MakeContextValueOptions
+) {
+	const boundFn = i18n[ fnName ].bind( i18n );
+
+	return ( ...args: ( string | number )[] ) => {
+		const transformedArguments = ( options?.lookup?.hooks || [] ).reduce(
+			( accumulator, hook ) => hook( accumulator, args, fnName, options ),
+			args
+		);
+
+		const transformedTranslation = ( options?.translation?.hooks || [] ).reduce(
+			( accumulator, hook ) => hook( accumulator, transformedArguments, fnName, options ),
+			boundFn( ...transformedArguments )
+		);
+
+		return transformedTranslation;
+	};
+}
+
+const CONTEXT_DELIMETER = '\u0004';
+
+/**
+ * Check if provided translation entry exists in locale data for provided singular and context
+ *
+ * @param localeData Locale data object
+ * @param singular Translation singular string
+ * @param context Gettext context
+ */
+function hasTranslation( localeData: LocaleData, singular: string, context?: string ): boolean {
+	const key =
+		typeof context === 'string' ? ''.concat( context, CONTEXT_DELIMETER, singular ) : singular;
+
+	return key in localeData;
+}
+
 /**
  * Utility to make a new context value
  *
  * @param localeData The localeData
+ * @param options Context options object
  *
  * @returns The context value with bound translation functions
  */
-function makeContextValue( localeData?: LocaleData ): I18nReact {
+function makeContextValue( localeData?: LocaleData, options?: MakeContextValueOptions ): I18nReact {
 	if ( ! localeData ) {
 		return { __, _n, _nx, _x, isRTL };
 	}
 
 	const i18n = createI18n( localeData );
+	const boundHasTranslation = ( singular: string, context?: string ) =>
+		hasTranslation( localeData || {}, singular, context );
 
 	return {
-		__: i18n.__.bind( i18n ),
-		_n: i18n._n.bind( i18n ),
-		_nx: i18n._nx.bind( i18n ),
-		_x: i18n._x.bind( i18n ),
+		__: bindI18nFunction( i18n, '__', options ),
+		_n: bindI18nFunction( i18n, '_n', options ),
+		_nx: bindI18nFunction( i18n, '_nx', options ),
+		_x: bindI18nFunction( i18n, '_x', options ),
 		isRTL: i18n.isRTL.bind( i18n ),
+		localeData,
+		hasTranslation: boundHasTranslation,
+		registerTranslationHook: options?.translation?.registerHook,
+		unregisterTranslationHook: options?.translation?.unregisterHook,
 	};
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add filters based on `@wordpress/hooks` that would allow to modify the input parameters and the output of translation functions. This would provide the required tools for implementing features like community translator, empathy mode, etc. for `@automattic/react-i18n`, that are currently only working with `i18n-calypso` via the package's own hooks implementation.

#### Testing instructions

* Confirm existing translation calls from `@automattic/react-i18n` work as expected and have the same output as before
* Register filter `arguments` that modifies input parameters and confirm it works as expected, example:
```js
	const { addFilter } = useI18n();

	React.useEffect( () => {
		addFilter( 'arguments', 'test', (args, fnName, options) => [ 'Home' ]);
	}, [  ] );
```
_All translation calls should return a result as if they were called with single parameter `__( 'Home' )`_
* Register filter `translation` that modifies the return value from a translation call, example.
```js
	const { addFilter } = useI18n();

	React.useEffect( () => {
		addFilter( 'translation', 'test', (translation, args, fnName, options) => `${fnName}-${translation}`);
	}, [  ] );
```
_All translation calls should return a the translation result prefixed with the translation function name, e.g. `_x( 'Home', 'context' ); // returns: '_x-Home'`_