### PR TITLE
Product card: update colours in the features section

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card/style.scss
@@ -221,9 +221,8 @@ $jetpack-product-card-icon-size: 55px;
 	padding-bottom: 6px;
 
 	border-bottom: solid 1px var( --color-border-subtle );
-	color: var( --color-text-subtle );
-
 	color: var( --studio-gray-70 );
+
 	font-weight: 600;
 }
 

--- a/client/components/jetpack/card/jetpack-product-card/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card/style.scss
@@ -223,6 +223,7 @@ $jetpack-product-card-icon-size: 55px;
 	border-bottom: solid 1px var( --color-border-subtle );
 	color: var( --color-text-subtle );
 
+	color: var( --studio-gray-70 );
 	font-weight: 600;
 }
 
@@ -251,6 +252,8 @@ $jetpack-product-card-icon-size: 55px;
 
 .jetpack-product-card__features-icon {
 	margin-right: 14px;
+
+	fill: var( --studio-gray-50 );
 
 	&.gridicons-checkmark {
 		fill: var( --color-primary-50 );


### PR DESCRIPTION
### Changes proposed in this Pull Request

Minor colour updates to the features section of the product card component.

### Implementation notes

New colours:
- icon: #3C434A
- subheading: #646970

### Testing instructions

- Download the PR
- Visit `/devdocs/design/jetpack-product-card`
- Find the instance "Expanded Jetpack Product Card with Features Categories and More Link"
- Check the new colours (see screenshot below)

### Screenshots
![screenshot](https://user-images.githubusercontent.com/1620183/89556819-eea9b680-d7df-11ea-8bb2-e5d088afa58f.png)
