### PR TITLE
Avoid depending on checkout in masterbar

### DIFF
--- a/client/layout/masterbar/checkout.jsx
+++ b/client/layout/masterbar/checkout.jsx
@@ -1,0 +1,54 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { defaultRegistry } from '@automattic/composite-checkout';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Masterbar from './masterbar';
+import Item from './item';
+import WordPressLogo from 'components/wordpress-logo';
+import WordPressWordmark from 'components/wordpress-wordmark';
+import { recordTracksEvent } from 'state/analytics/actions';
+
+class CheckoutMasterbar extends React.Component {
+	clickClose = () => {
+		const { select } = defaultRegistry;
+		const siteSlug = select( 'wpcom' )?.getSiteSlug();
+		const closeUrl = siteSlug ? '/plans/' + siteSlug : '/start';
+		this.props.recordTracksEvent( 'calypso_masterbar_close_clicked' );
+		window.location = closeUrl;
+	};
+
+	render() {
+		const { translate, title } = this.props;
+		return (
+			<Masterbar>
+				<div className="masterbar__secure-checkout">
+					<Item
+						url={ '#' }
+						icon="cross"
+						className="masterbar__close-button"
+						onClick={ this.clickClose }
+						tooltip={ translate( 'Close Checkout' ) }
+						tipTarget="close"
+					/>
+					<Item className="masterbar__item-logo">
+						<WordPressLogo className="masterbar__wpcom-logo" />
+						<WordPressWordmark className="masterbar__wpcom-wordmark" />
+					</Item>
+					<span className="masterbar__secure-checkout-text">
+						{ translate( 'Secure checkout' ) }
+					</span>
+				</div>
+				<Item className="masterbar__item-title">{ title }</Item>
+			</Masterbar>
+		);
+	}
+}
+
+export default connect( () => (null, { recordTracksEvent }) )( localize( CheckoutMasterbar ) );

--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -1,13 +1,11 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { getLocaleSlug, localize } from 'i18n-calypso';
 import { get, includes, startsWith } from 'lodash';
-import { defaultRegistry } from '@automattic/composite-checkout';
 
 /**
  * Internal dependencies
@@ -23,7 +21,7 @@ import getCurrentRoute from 'state/selectors/get-current-route';
 import { login } from 'lib/paths';
 import { isDomainConnectAuthorizePath } from 'lib/domains/utils';
 import { isDefaultLocale, addLocaleToPath } from 'lib/i18n-utils';
-import { recordTracksEvent } from 'state/analytics/actions';
+import AsyncLoad from 'components/async-load';
 
 class MasterbarLoggedOut extends React.Component {
 	static propTypes = {
@@ -152,40 +150,12 @@ class MasterbarLoggedOut extends React.Component {
 			</Item>
 		);
 	}
-	clickClose = () => {
-		const { select } = defaultRegistry;
-		const siteSlug = select( 'wpcom' )?.getSiteSlug();
-		const closeUrl = siteSlug ? '/plans/' + siteSlug : '/start';
-		this.props.recordTracksEvent( 'calypso_masterbar_close_clicked' );
-		window.location = closeUrl;
-	};
 
 	render() {
-		const { title, isCheckout, translate } = this.props;
+		const { title, isCheckout } = this.props;
 
-		if ( isCheckout === true ) {
-			return (
-				<Masterbar>
-					<div className="masterbar__secure-checkout">
-						<Item
-							url={ '#' }
-							icon="cross"
-							className="masterbar__close-button"
-							onClick={ this.clickClose }
-							tooltip={ translate( 'Close Checkout' ) }
-							tipTarget="close"
-						/>
-						<Item className="masterbar__item-logo">
-							<WordPressLogo className="masterbar__wpcom-logo" />
-							<WordPressWordmark className="masterbar__wpcom-wordmark" />
-						</Item>
-						<span className="masterbar__secure-checkout-text">
-							{ translate( 'Secure checkout' ) }
-						</span>
-					</div>
-					<Item className="masterbar__item-title">{ title }</Item>
-				</Masterbar>
-			);
+		if ( isCheckout ) {
+			return <AsyncLoad require="layout/masterbar/checkout" placeholder={ null } title={ title } />;
 		}
 
 		return (
@@ -204,12 +174,7 @@ class MasterbarLoggedOut extends React.Component {
 	}
 }
 
-export default connect(
-	( state ) => (
-		{
-			currentQuery: getCurrentQueryArguments( state ),
-			currentRoute: getCurrentRoute( state ),
-		},
-		{ recordTracksEvent }
-	)
-)( localize( MasterbarLoggedOut ) );
+export default connect( ( state ) => ( {
+	currentQuery: getCurrentQueryArguments( state ),
+	currentRoute: getCurrentRoute( state ),
+} ) )( localize( MasterbarLoggedOut ) );


### PR DESCRIPTION
This fixes a performance problem introduced in #44206.
That PR added a number of dependencies to the critical path, by adding them to the masterbar. The masterbar is used everywhere, which means that all users will need to pay the cost of checkout's dependencies, regardless of what page they're visiting. This is a problem, since the delta is about 200KB (50KB gzipped).

This PR fixes things, by isolating and loading the checkout parts asynchronously and only when needed.

#### Changes proposed in this Pull Request

* Isolate checkout masterbar into its own component file
* Asynchronously load checkout masterbar only when needed

#### Testing instructions

* Ensure the logged-out masterbar works correctly in e.g. signup
* Ensure the checkout logged-out masterbar works correctly
* Ensure the logged-in masterbar works correctly
