### PR TITLE
EditingToolkit > GlobalStyles: Update Google font pairings

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/global-styles/class-global-styles.php
+++ b/apps/full-site-editing/full-site-editing-plugin/global-styles/class-global-styles.php
@@ -171,27 +171,33 @@ class Global_Styles {
 					'type'    => 'literal',
 					'default' => array(
 						array(
-							'label'    => 'Playfair Display & Roboto',
-							'headings' => 'Playfair Display',
-							'base'     => 'Roboto',
+							'label'    => 'Cabin & Raleway',
+							'headings' => 'Cabin',
+							'base'     => 'Raleway',
 							'preview'  => 'PLAY_ROBOTO', // See font-pairings-panel-previews.js.
 						),
 						array(
-							'label'    => 'Rubik & Work Sans',
-							'headings' => 'Rubik',
-							'base'     => 'Work Sans',
+							'label'    => 'Chivo & Open Sans',
+							'headings' => 'Chivo',
+							'base'     => 'Open Sans',
 							'preview'  => 'RUBIK_WORK', // See font-pairings-panel-previews.js.
 						),
 						array(
-							'label'    => 'System Font & Libre Baskerville',
-							'headings' => self::SYSTEM_FONT,
-							'base'     => 'Libre Baskerville',
+							'label'    => 'Playfair Display & Fira Sans',
+							'headings' => 'Playfair Display',
+							'base'     => 'Fira Sans',
 							'preview'  => 'SYSTEM_BASKER', // See font-pairings-panel-previews.js.
 						),
 						array(
-							'label'    => 'Space Mono & Lora',
+							'label'    => 'Arvo & Montserrat',
+							'headings' => 'Arvo',
+							'base'     => 'Montserrat',
+							'preview'  => 'SPACE_LORA', // See font-pairings-panel-previews.js.
+						),
+						array(
+							'label'    => 'Space Mono & Roboto',
 							'headings' => 'Space Mono',
-							'base'     => 'Lora',
+							'base'     => 'Roboto',
 							'preview'  => 'SPACE_LORA', // See font-pairings-panel-previews.js.
 						),
 					),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update the suggested font pairings in Global Styles

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* The new font pairings should be:
Cabin & Raleway
Chivo & Open Sans
Playfair Display & Fira Sans
Arvo & Montserrat
Space Mono & Roboto
