### PR TITLE
Registrationless checkout: Send transactionOptions for apple pay

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -465,7 +465,7 @@ export default function CompositeCheckout( {
 			'apple-pay': ( transactionData ) =>
 				applePayProcessor( transactionData, dataForProcessor, transactionOptions ),
 			'free-purchase': ( transactionData ) =>
-				freePurchaseProcessor( transactionData, dataForProcessor, transactionOptions ),
+				freePurchaseProcessor( transactionData, dataForProcessor ),
 			card: ( transactionData ) =>
 				multiPartnerCardProcessor( transactionData, dataForProcessor, transactionOptions ),
 			alipay: ( transactionData ) =>

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -462,9 +462,10 @@ export default function CompositeCheckout( {
 
 	const paymentProcessors = useMemo(
 		() => ( {
-			'apple-pay': ( transactionData ) => applePayProcessor( transactionData, dataForProcessor ),
+			'apple-pay': ( transactionData ) =>
+				applePayProcessor( transactionData, dataForProcessor, transactionOptions ),
 			'free-purchase': ( transactionData ) =>
-				freePurchaseProcessor( transactionData, dataForProcessor ),
+				freePurchaseProcessor( transactionData, dataForProcessor, transactionOptions ),
 			card: ( transactionData ) =>
 				multiPartnerCardProcessor( transactionData, dataForProcessor, transactionOptions ),
 			alipay: ( transactionData ) =>

--- a/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
@@ -88,7 +88,7 @@ export async function submitExistingCardPayment( transactionData, submit, transa
 	return submit( formattedTransactionData, transactionOptions );
 }
 
-export async function submitApplePayPayment( transactionData, submit ) {
+export async function submitApplePayPayment( transactionData, submit, transactionOptions ) {
 	debug( 'formatting apple-pay transaction', transactionData );
 	const formattedTransactionData = createTransactionEndpointRequestPayloadFromLineItems( {
 		...transactionData,
@@ -96,7 +96,7 @@ export async function submitApplePayPayment( transactionData, submit ) {
 		paymentPartnerProcessorId: transactionData.stripeConfiguration.processor_id,
 	} );
 	debug( 'submitting apple-pay transaction', formattedTransactionData );
-	return submit( formattedTransactionData );
+	return submit( formattedTransactionData, transactionOptions );
 }
 
 export async function submitPayPalExpressRequest( transactionData, submit, transactionOptions ) {

--- a/client/my-sites/checkout/composite-checkout/payment-method-processors.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-processors.js
@@ -78,7 +78,11 @@ export function genericRedirectProcessor(
 	return pending;
 }
 
-export function applePayProcessor( submitData, { includeDomainDetails, includeGSuiteDetails } ) {
+export function applePayProcessor(
+	submitData,
+	{ includeDomainDetails, includeGSuiteDetails },
+	transactionOptions
+) {
 	const pending = submitApplePayPayment(
 		{
 			...submitData,
@@ -87,7 +91,8 @@ export function applePayProcessor( submitData, { includeDomainDetails, includeGS
 			domainDetails: getDomainDetails( { includeDomainDetails, includeGSuiteDetails } ),
 			postalCode: getPostalCode(),
 		},
-		wpcomTransaction
+		wpcomTransaction,
+		transactionOptions
 	);
 	// save result so we can get receipt_id and failed_purchases in getThankYouPageUrl
 	pending.then( ( result ) => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Registrationless checkout was introduced in https://github.com/Automattic/wp-calypso/pull/44206.
* This PR sends props to allow payments via Apple Pay to complete successfully on the logged out cart.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On Safari, go to /start/onboarding-registrationless and add a plan to cart
* Pay with Apple Pay and verify if the purchase completes successfully

