### PR TITLE
Exporter: Balance Padding on Expanded Accordion

### DIFF
--- a/client/my-sites/exporter/style.scss
+++ b/client/my-sites/exporter/style.scss
@@ -7,7 +7,8 @@
 }
 
 .export-card .foldable-card__header,
-.export-media-card .foldable-card__header {
+.export-media-card .foldable-card__header,
+.export-card .foldable-card.is-expanded .foldable-card__content {
 	padding: 24px;
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This ensures that the expanded accordion also benefits from the custom padding overriding the default padding of the Foldable Card.

#### Testing instructions

Visit `/export/site` and expand the first accordion. Verify that "Export content" and "Select specific content to export" are aligned!

<img width="1000" alt="Screenshot 2020-08-07 at 09 42 38" src="https://user-images.githubusercontent.com/43215253/89627257-7ea83880-d892-11ea-8a8d-c1eecffb144c.png">

cc @sixhours 

Fixes #44741
