### PR TITLE
Handle languages-meta fallback at build time

### DIFF
--- a/client/languages/index.js
+++ b/client/languages/index.js
@@ -3,10 +3,10 @@
  */
 import values from 'lodash/values';
 
-// If `languages-meta.json` is missing, this import will be replaced with
-// `fallback-languages-meta.json` during build.
-// Be sure to keep the exact path (`languages/languages-meta.json`) as is, so
-// that webpack can find and replace it.
-import languagesMeta from 'languages/languages-meta.json';
+// If `languages-meta.json` is available, this import will be replaced with
+// `languages-meta.json` during build.
+// Be sure to keep the exact path (`languages/fallback-languages-meta.json`) as
+// is, so that webpack can find and replace it.
+import languagesMeta from 'languages/fallback-languages-meta.json';
 
 export const languages = values( languagesMeta );

--- a/client/languages/index.js
+++ b/client/languages/index.js
@@ -3,13 +3,10 @@
  */
 import values from 'lodash/values';
 
-let languagesMeta = [];
-
-try {
-	languagesMeta = require( './languages-meta.json' );
-} catch ( error ) {
-	// Use fallback languages meta data if `languages-meta.json` has failed to download.
-	languagesMeta = require( './fallback-languages-meta.json' );
-}
+// If `languages-meta.json` is missing, this import will be replaced with
+// `fallback-languages-meta.json` during build.
+// Be sure to keep the exact path (`languages/languages-meta.json`) as is, so
+// that webpack can find and replace it.
+import languagesMeta from 'languages/languages-meta.json';
 
 export const languages = values( languagesMeta );

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -9,6 +9,7 @@
  * External dependencies
  */
 const path = require( 'path' );
+const fs = require( 'fs' );
 const webpack = require( 'webpack' );
 const AssetsWriter = require( './server/bundler/assets-writer' );
 const ConfigFlagPlugin = require( '@automattic/webpack-config-flag-plugin' );
@@ -62,6 +63,10 @@ const isDesktopMonorepo = isDesktop && process.env.DESKTOP_MONOREPO === 'true';
 const defaultBrowserslistEnv = isDesktop ? 'defaults' : 'evergreen';
 const browserslistEnv = process.env.BROWSERSLIST_ENV || defaultBrowserslistEnv;
 const extraPath = browserslistEnv === 'defaults' ? 'fallback' : browserslistEnv;
+
+const hasLanguagesMeta = fs.existsSync(
+	path.join( __dirname, 'languages', 'languages-meta.json' )
+);
 
 function filterEntrypoints( entrypoints ) {
 	/* eslint-disable no-console */
@@ -329,6 +334,14 @@ const webpackConfig = {
 			new webpack.NormalModuleReplacementPlugin(
 				/^lib[/\\]local-storage-polyfill$/,
 				'lodash-es/noop'
+			),
+		/*
+		 * When not available, replace languages-meta.json with fallback-languages-meta.json.
+		 */
+		! hasLanguagesMeta &&
+			new webpack.NormalModuleReplacementPlugin(
+				/^languages[/\\]languages-meta.json$/,
+				'languages/fallback-languages-meta.json'
 			),
 		/*
 		 * Replace `lodash` with `lodash-es`

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -338,10 +338,10 @@ const webpackConfig = {
 		/*
 		 * When not available, replace languages-meta.json with fallback-languages-meta.json.
 		 */
-		! hasLanguagesMeta &&
+		hasLanguagesMeta &&
 			new webpack.NormalModuleReplacementPlugin(
-				/^languages[/\\]languages-meta.json$/,
-				'languages/fallback-languages-meta.json'
+				/^languages[/\\]fallback-languages-meta.json$/,
+				'languages/languages-meta.json'
 			),
 		/*
 		 * Replace `lodash` with `lodash-es`


### PR DESCRIPTION
The languages-meta fallback is currently handed at runtime, which means that when `languages-meta.json` is available, both it and the fallback get included in the bundle (and notably, in the critical path). This means when the full file is present, we're shipping more JS than we need to be, and making Calypso slower to load for users.

This change will instead perform a replacement at build time when necessary, so that only one of the files ever gets included.

#### Changes proposed in this Pull Request

* Handle languages-meta fallback at build time instead of runtime

#### Testing instructions

* Perform a normal build, with the `languages-meta.json` file getting downloaded
* Ensure that everything works correctly and is consistent with the full languages meta

* Delete the downloaded `languages-meta.json` file
* Perform a build that doesn't download the file, e.g. by modifying the `download-languages-meta` npm script to do nothing (like, say, perform an `ls`)
* Ensure that everything works correctly and is consistent with the fallback languages meta