### PR TITLE
Backup aren't shown when the site has too many activities

### DIFF
--- a/client/my-sites/activity/activity-log/index.jsx
+++ b/client/my-sites/activity/activity-log/index.jsx
@@ -72,7 +72,7 @@ import getSiteTimezoneValue from 'state/selectors/get-site-timezone-value';
 import isAtomicSite from 'state/selectors/is-site-automated-transfer';
 import isVipSite from 'state/selectors/is-vip-site';
 import siteSupportsRealtimeBackup from 'state/selectors/site-supports-realtime-backup';
-import { requestActivityLogs } from 'state/data-getters';
+import { retrieveAllActivities } from 'my-sites/activity/utils';
 import { emptyFilter } from 'state/activity-log/reducer';
 import { recordTracksEvent } from 'lib/analytics/tracks';
 import { applySiteOffset } from 'lib/site/timezone';
@@ -609,7 +609,7 @@ export default connect(
 		const rewindState = getRewindState( state, siteId );
 		const restoreStatus = rewindState.rewind && rewindState.rewind.status;
 		const filter = getActivityLogFilter( state, siteId );
-		const logs = siteId && requestActivityLogs( siteId, filter );
+		const logs = siteId && retrieveAllActivities( siteId, filter );
 		const siteIsOnFreePlan =
 			isFreePlan( get( getCurrentPlan( state, siteId ), 'productSlug' ) ) &&
 			! isVipSite( state, siteId );
@@ -625,7 +625,7 @@ export default connect(
 			filter,
 			isAtomic: isAtomicSite( state, siteId ),
 			isJetpack,
-			logs: ( siteId && logs.data ) || emptyList,
+			logs: ( siteId && logs.activities ) || emptyList,
 			logLoadingState: logs && logs.state,
 			requestedRestore: find( logs, { activityId: requestedRestoreId } ),
 			requestedRestoreId,

--- a/client/my-sites/activity/utils.js
+++ b/client/my-sites/activity/utils.js
@@ -31,11 +31,6 @@ export const retrieveAllActivities = ( siteId, filter ) => {
 			if ( response.state === 'success' ) {
 				areActivitiesRetrieved = true;
 				activities = [ ...activities, ...response.data.activities ];
-
-				if ( response.totalItems === 0 ) {
-					// We don't have more items. Issue: bad pagination from API?
-					break;
-				}
 			} else {
 				areActivitiesRetrieved = false;
 			}

--- a/client/my-sites/activity/utils.js
+++ b/client/my-sites/activity/utils.js
@@ -19,17 +19,23 @@ export const retrieveAllActivities = ( siteId, filter ) => {
 	let response = requestActivityLogs( siteId, filter );
 
 	if ( response.state === 'success' ) {
+		const totalPages = response.data.totalPages;
 		areActivitiesRetrieved = true;
 		activities = [ ...activities, ...response.data.activities ];
 
 		// If after the first result has more pages, let's retrieve all of them
-		for ( let page = 2; page <= response.data.totalPages; page++ ) {
+		for ( let page = 2; page <= totalPages; page++ ) {
 			filter.queryPage = page;
 			response = requestActivityLogs( siteId, filter );
 
 			if ( response.state === 'success' ) {
 				areActivitiesRetrieved = true;
 				activities = [ ...activities, ...response.data.activities ];
+
+				if ( response.totalItems === 0 ) {
+					// We don't have more items. Issue: bad pagination from API?
+					break;
+				}
 			} else {
 				areActivitiesRetrieved = false;
 			}

--- a/client/my-sites/activity/utils.js
+++ b/client/my-sites/activity/utils.js
@@ -40,5 +40,6 @@ export const retrieveAllActivities = ( siteId, filter ) => {
 	return {
 		areActivitiesRetrieved,
 		activities,
+		state: response.state,
 	};
 };

--- a/client/my-sites/activity/utils.js
+++ b/client/my-sites/activity/utils.js
@@ -1,0 +1,44 @@
+/**
+ * External Dependencies
+ */
+import { requestActivityLogs } from 'state/data-getters';
+
+/**
+ * Get all the activities of the site. It queries all the activity pages from the API
+ *
+ * @param siteId The site id
+ * @param filter The active filter for the request
+ * @returns {{activities: [], areActivitiesRetrieved: boolean}} An object with the status and the activities
+ */
+export const retrieveAllActivities = ( siteId, filter ) => {
+	let areActivitiesRetrieved = false;
+	let activities = [];
+
+	filter.queryPage = 1;
+
+	let response = requestActivityLogs( siteId, filter );
+
+	if ( response.state === 'success' ) {
+		const totalPages = response.data.totalPages;
+		areActivitiesRetrieved = true;
+		activities = [ ...activities, ...response.data.activities ];
+
+		// If after the first result has more pages, let's retrieve all of them
+		for ( let page = 2; page <= totalPages; page++ ) {
+			filter.queryPage = page;
+			response = requestActivityLogs( siteId, filter );
+
+			if ( response.state === 'success' ) {
+				areActivitiesRetrieved = true;
+				activities = [ ...activities, ...response.data.activities ];
+			} else {
+				areActivitiesRetrieved = false;
+			}
+		}
+	}
+
+	return {
+		areActivitiesRetrieved,
+		activities,
+	};
+};

--- a/client/my-sites/activity/utils.js
+++ b/client/my-sites/activity/utils.js
@@ -19,12 +19,11 @@ export const retrieveAllActivities = ( siteId, filter ) => {
 	let response = requestActivityLogs( siteId, filter );
 
 	if ( response.state === 'success' ) {
-		const totalPages = response.data.totalPages;
 		areActivitiesRetrieved = true;
 		activities = [ ...activities, ...response.data.activities ];
 
 		// If after the first result has more pages, let's retrieve all of them
-		for ( let page = 2; page <= totalPages; page++ ) {
+		for ( let page = 2; page <= response.data.totalPages; page++ ) {
 			filter.queryPage = page;
 			response = requestActivityLogs( siteId, filter );
 

--- a/client/my-sites/backup/main.jsx
+++ b/client/my-sites/backup/main.jsx
@@ -361,13 +361,25 @@ const getIsEmptyFilter = ( filter ) => {
 const mapStateToProps = ( state ) => {
 	const siteId = getSelectedSiteId( state );
 	const filter = getActivityLogFilter( state, siteId );
-	const logs = requestActivityLogs( siteId, filter );
 	const gmtOffset = getSiteGmtOffset( state, siteId );
 	const timezone = getSiteTimezoneValue( state, siteId );
 	const rewind = getRewindState( state, siteId );
 	const restoreStatus = rewind.rewind && rewind.rewind.status;
 	const doesRewindNeedCredentials = getDoesRewindNeedCredentials( state, siteId );
 	const siteCapabilities = getRewindCapabilities( state, siteId );
+	const hasDailyBackups = includes( siteCapabilities, 'backup-daily' );
+
+	let logs;
+
+	if ( hasDailyBackups ) {
+		// We query only for complete backups
+		logs = requestActivityLogs( siteId, {
+			page: 1,
+			group: [ 'rewind' ],
+		} );
+	} else {
+		logs = requestActivityLogs( siteId, filter );
+	}
 
 	const allowRestore =
 		'active' === rewind.state && ! ( 'queued' === restoreStatus || 'running' === restoreStatus );

--- a/client/state/activity-log/utils.js
+++ b/client/state/activity-log/utils.js
@@ -20,7 +20,8 @@ export const filterStateToApiQuery = ( filter ) => {
 		filter.notGroup && { not_group: filter.notGroup },
 		filter.name && { name: filter.name },
 		{ number: 1000 },
-		filter.queryPage && { page: filter.queryPage }
+		filter.queryPage && { page: filter.queryPage },
+		filter.search_after && { search_after: filter.search_after }
 	);
 };
 

--- a/client/state/activity-log/utils.js
+++ b/client/state/activity-log/utils.js
@@ -19,7 +19,8 @@ export const filterStateToApiQuery = ( filter ) => {
 		filter.group && { group: filter.group },
 		filter.notGroup && { not_group: filter.notGroup },
 		filter.name && { name: filter.name },
-		{ number: 1000 }
+		{ number: 1000 },
+		filter.queryPage && { page: filter.queryPage }
 	);
 };
 

--- a/client/state/data-getters/index.js
+++ b/client/state/data-getters/index.js
@@ -71,8 +71,9 @@ export const getRequestActivityLogsId = ( siteId, filter ) => {
 	const on = filter && filter.on ? filter.on : '';
 	const aggregate = filter && filter.aggregate ? filter.aggregate : '';
 	const queryPage = filter && filter.queryPage ? filter.queryPage : '';
+	const searchAfter = filter && filter.search_after ? filter.search_after : '';
 
-	return `activity-log-${ siteId }-${ group }-${ after }-${ before }-${ on }-${ aggregate }-${ queryPage }`;
+	return `activity-log-${ siteId }-${ group }-${ after }-${ before }-${ on }-${ aggregate }-${ queryPage }-${ searchAfter }`;
 };
 
 export const requestActivityLogs = ( siteId, filter, { freshness = 5 * 60 * 1000 } = {} ) => {

--- a/client/state/data-getters/index.js
+++ b/client/state/data-getters/index.js
@@ -70,8 +70,9 @@ export const getRequestActivityLogsId = ( siteId, filter ) => {
 	const after = filter && filter.after ? filter.after : '';
 	const on = filter && filter.on ? filter.on : '';
 	const aggregate = filter && filter.aggregate ? filter.aggregate : '';
+	const queryPage = filter && filter.queryPage ? filter.queryPage : '';
 
-	return `activity-log-${ siteId }-${ group }-${ after }-${ before }-${ on }-${ aggregate }`;
+	return `activity-log-${ siteId }-${ group }-${ after }-${ before }-${ on }-${ aggregate }-${ queryPage }`;
 };
 
 export const requestActivityLogs = ( siteId, filter, { freshness = 5 * 60 * 1000 } = {} ) => {

--- a/client/state/data-layer/wpcom/sites/activity/from-api.js
+++ b/client/state/data-layer/wpcom/sites/activity/from-api.js
@@ -23,7 +23,13 @@ export const DEFAULT_GRIDICON = 'info-outline';
  * @returns {object}             Object with an entry for proccessed item objects and another for oldest item timestamp
  */
 export function transformer( apiResponse ) {
-	return get( apiResponse, [ 'current', 'orderedItems' ], [] ).map( processItem );
+	const response = {
+		totalItems: apiResponse.totalItems,
+		totalPages: apiResponse.totalPages,
+		page: apiResponse.page,
+		activities: get( apiResponse, [ 'current', 'orderedItems' ], [] ).map( processItem ),
+	};
+	return response;
 }
 
 /**

--- a/client/state/data-layer/wpcom/sites/activity/from-api.js
+++ b/client/state/data-layer/wpcom/sites/activity/from-api.js
@@ -27,6 +27,7 @@ export function transformer( apiResponse ) {
 		totalItems: apiResponse.totalItems,
 		totalPages: apiResponse.totalPages,
 		page: apiResponse.page,
+		nextAfter: get( apiResponse, [ 'nextAfter' ], [] ),
 		activities: get( apiResponse, [ 'current', 'orderedItems' ], [] ).map( processItem ),
 	};
 	return response;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

On Jetpack cloud and Jetpack Wpcom, sites with a bunch of activities in a short period cannot show all the full backups or the activities in either section (Backup or Activity Log) because the API responds with a maximum of 1000 items. We cannot increase this maximum to more than 1000 because the API complains about it, so with this change when we retrieve the activities we can walk through the pages (a maximum of 1000 items per page) that the API provides to us.

**Note:** We should test and monitor this patch because it changes the way we request the activities. If we have the opportunity of checking it with a site with thousands of items (more than 10000 or 20000) would be great, so we could check if it has any performance impact in the API or Calypso side.

**More info:** 1164141197617539-as-1186890594349665
**Related issues:** 5645-gh-jpop-issues

#### Testing instructions

- Apply this patch and go to a Jetpack site with Backup subscription, one with Daily and another with Real-time
- Check that everything works as before, the Backup section, and the Activity Log section.
- Find a site with a bunch of activities (more than 1000), and check that you can see all the backups and the activities
- Bonus: start a support session with a site with this issue and check that now it works well.

**Aditional test (updated: August 28)**

- Test it in several sites:
  - A new site without activities.
  - A site with a few activities.
  - A Sites with Daily Backup, Real-time Backup, and without any Backup subscription.