### PR TITLE
Remove dependency on `qs` from `lib/user`

### DIFF
--- a/client/lib/user/user.js
+++ b/client/lib/user/user.js
@@ -1,13 +1,10 @@
 /**
  * External dependencies
  */
-
 import { entries, isEqual } from 'lodash';
 import store from 'store';
 import debugFactory from 'debug';
-const debug = debugFactory( 'calypso:user' );
 import config from 'config';
-import { stringify } from 'qs';
 
 /**
  * Internal dependencies
@@ -25,6 +22,8 @@ import { getComputedAttributes, filterUserObject } from './shared-utils';
 import { getLanguage } from 'lib/i18n-utils/utils';
 import { clearStorage } from 'lib/browser-storage';
 import { getActiveTestNames, ABTEST_LOCALSTORAGE_KEY } from 'lib/abtest/utility';
+
+const debug = debugFactory( 'calypso:user' );
 
 /**
  * User component
@@ -207,19 +206,17 @@ User.prototype.getLanguage = function () {
  *
  * @returns {string} The user's avatar URL based on the options parameter.
  */
-User.prototype.getAvatarUrl = function ( options ) {
-	const default_options = {
+User.prototype.getAvatarUrl = function ( options = {} ) {
+	const defaultOptions = {
 		s: 80,
 		d: 'mm',
 		r: 'G',
 	};
-	const avatar_URL = this.get().avatar_URL;
-	const avatar = typeof avatar_URL === 'string' ? avatar_URL.split( '?' )[ 0 ] : '';
+	const avatarURL = this.get().avatar_URL;
+	const avatar = typeof avatarURL === 'string' ? avatarURL.split( '?' )[ 0 ] : '';
 
-	options = options || {};
-	options = Object.assign( {}, options, default_options );
-
-	return avatar + '?' + stringify( options );
+	options = { ...options, ...defaultOptions };
+	return avatar + '?' + new URLSearchParams( options ).toString();
 };
 
 /**


### PR DESCRIPTION
`lib/user` is currently making use of the third party `qs` library when basic `URLSearchParams` functionality (which is already polyfilled when necessary) should suffice.

#### Changes proposed in this Pull Request

* Remove dependency on `qs` from `lib/user`

#### Testing instructions

There doesn't seem to be anything to test, since as far as I can tell this method isn't used anywhere in Calypso. As long as the build completes successfully, this should be good to go.
