### PR TITLE
Remove dependency on `qs` from `auth/controller`

### DIFF
--- a/client/auth/controller.js
+++ b/client/auth/controller.js
@@ -3,7 +3,6 @@
  */
 import React from 'react';
 import page from 'page';
-import { stringify } from 'qs';
 
 /**
  * Internal dependencies
@@ -47,15 +46,15 @@ export default {
 			const port = process.env.PORT || config( 'port' );
 			const redirectUri = `${ protocol }://${ host }:${ port }/api/oauth/token`;
 
-			const params = {
+			const params = new URLSearchParams( {
 				response_type: 'token',
 				client_id: config( 'oauth_client_id' ),
 				redirect_uri: redirectUri,
 				scope: 'global',
 				blog_id: 0,
-			};
+			} );
 
-			authUrl = `${ WP_AUTHORIZE_ENDPOINT }?${ stringify( params ) }`;
+			authUrl = `${ WP_AUTHORIZE_ENDPOINT }?${ params.toString() }`;
 		}
 
 		context.primary = <ConnectComponent authUrl={ authUrl } />;


### PR DESCRIPTION
`auth/controller` is currently making use of the third party `qs` library. This was added in #35326, when a different dependency was removed.

While it may have made sense to use `qs` back then, we now ensure that native `URLSearchParams` functionality is always available, polyfilling when needed, so we can make use of that instead.

#### Changes proposed in this Pull Request

* Remove dependency on `qs` from `auth/controller`

#### Testing instructions

This code appears to only be used in the context of the desktop app, when authenticating. It should suffice to test that authentication continues to work correctly (which presumably the desktop E2E tests already handle?)