### PR TITLE
Toolkit plugin: Always enable line-height in Gutenberg settings

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/common/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/common/index.php
@@ -120,3 +120,27 @@ function enqueue_script_and_style() {
 	);
 }
 add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\enqueue_script_and_style' );
+
+/**
+ * Enable line-height settings for all themes with Gutenberg.
+ *
+ * Prior to Gutenberg 8.6, line-height was always enabled, which meant that wpcom
+ * users had been utilizing the feature. With the 8.6 release, though, line-height
+ * was turned off by default unless the theme supported it. As a result, users
+ * suddenly were no longer able to access the settings they previously had access
+ * to. This filter turns the setting on for all wpcom users regardless of theme.
+ *
+ * Note: we use a priority of 11 so that this filter runs after the one which
+ * turns off custom line height depending on theme support.
+ *
+ * @see https://github.com/WordPress/gutenberg/pull/23904
+ *
+ * @param array $settings The associative array of Gutenberg editor settings with
+ *                        line-height sometimes disabled based on theme support.
+ * @return array Gutenberg editor settings with line-height setting always enabled.
+ **/
+function wpcom_gutenberg_enable_custom_line_height( $settings ) {
+	$settings['enableCustomLineHeight'] = true;
+	return $settings;
+}
+add_filter( 'block_editor_settings', 'wpcom_gutenberg_enable_custom_line_height', 11 );

--- a/apps/full-site-editing/full-site-editing-plugin/common/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/common/index.php
@@ -143,4 +143,4 @@ function wpcom_gutenberg_enable_custom_line_height( $settings ) {
 	$settings['enableCustomLineHeight'] = true;
 	return $settings;
 }
-add_filter( 'block_editor_settings', 'wpcom_gutenberg_enable_custom_line_height', 11 );
+add_filter( 'block_editor_settings', __NAMESPACE__ . '\wpcom_gutenberg_enable_custom_line_height', 11 );


### PR DESCRIPTION
_Note: this patch was applied directly to wpcom in our wpcom gutenberg loader files in D47818-code. This additionally makes the patch available for atomic sites. Once deployed, we can remove the existing wpcom patch._

#### Changes proposed in this Pull Request
Always enable the custom line-height setting. This overrides the default Gutenberg setting, which is to rely on theme support. We need this so that existing users on our wpcom simple and atomic infrastructure do not loose functionality when upgrading to the latest Gutenberg version.

#### Testing instructions
1. on a test Atomic site with the latest version of the gutenberg plugin, you will not see line-height settings in the block sidebar.
2. With this update also applied, you will see line-height settings.

##### TODO
- [ ] Once we deploy this as a diff to wpcom, we need to revert the changes here: D47818-code