### PR TITLE
Gutenboarding: Two-click plans grid

### DIFF
--- a/client/landing/gutenboarding/hooks/use-selected-plan.ts
+++ b/client/landing/gutenboarding/hooks/use-selected-plan.ts
@@ -20,6 +20,7 @@ export function useSelectedPlan() {
 	const hasPaidDomain = useSelect( ( select ) => select( ONBOARD_STORE ).hasPaidDomain() );
 	const hasPaidDesign = useSelect( ( select ) => select( ONBOARD_STORE ).hasPaidDesign() );
 
+	const defaultFreePlan = useSelect( ( select ) => select( PLANS_STORE ).getDefaultFreePlan() );
 	const defaultPaidPlan = useSelect( ( select ) => select( PLANS_STORE ).getDefaultPaidPlan() );
 
 	// If the selected plan is not a paid plan and the user selects a premium domain
@@ -28,7 +29,7 @@ export function useSelectedPlan() {
 		return defaultPaidPlan;
 	}
 
-	const defaultPlan = hasPaidDomain || hasPaidDesign ? defaultPaidPlan : undefined;
+	const defaultPlan = hasPaidDomain || hasPaidDesign ? defaultPaidPlan : defaultFreePlan;
 
 	/**
 	 * Plan is decided in this order

--- a/client/landing/gutenboarding/onboarding-block/plans/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/plans/index.tsx
@@ -7,7 +7,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { useI18n } from '@automattic/react-i18n';
 import PlansGrid from '@automattic/plans-grid';
 import type { Plans } from '@automattic/data-stores';
-import { Title, SubTitle, ActionButtons, BackButton } from '@automattic/onboarding';
+import { Title, SubTitle, ActionButtons, BackButton, NextButton } from '@automattic/onboarding';
 
 /**
  * Internal dependencies
@@ -54,6 +54,8 @@ const PlansStep: React.FunctionComponent< Props > = ( { isModal } ) => {
 	const freeDomainSuggestion = useFreeDomainSuggestion();
 
 	const handleBack = () => ( isModal ? history.goBack() : goBack() );
+	const handleNext = () => ( isModal ? history.goBack() : goNext() );
+
 	const handlePlanSelect = ( planSlug: PlanSlug ) => {
 		// When picking a free plan, if there is a paid domain selected, it's changed automatically to a free domain
 		if ( isPlanFree( planSlug ) && ! domain?.is_free ) {
@@ -61,12 +63,6 @@ const PlansStep: React.FunctionComponent< Props > = ( { isModal } ) => {
 		}
 
 		updatePlan( planSlug );
-
-		if ( isModal ) {
-			history.goBack();
-		} else {
-			goNext();
-		}
 	};
 	const handlePickDomain = () => history.push( makePath( Step.DomainsModal ) );
 
@@ -82,6 +78,7 @@ const PlansStep: React.FunctionComponent< Props > = ( { isModal } ) => {
 			</div>
 			<ActionButtons>
 				<BackButton onClick={ handleBack } />
+				<NextButton onClick={ handleNext } />
 			</ActionButtons>
 		</>
 	);

--- a/client/landing/gutenboarding/onboarding-block/plans/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/plans/index.tsx
@@ -93,6 +93,7 @@ const PlansStep: React.FunctionComponent< Props > = ( { isModal } ) => {
 				currentDomain={ domain }
 				onPlanSelect={ handlePlanSelect }
 				onPickDomainClick={ handlePickDomain }
+				currentPlan={ plan }
 			/>
 		</div>
 	);

--- a/packages/data-stores/src/plans/constants.ts
+++ b/packages/data-stores/src/plans/constants.ts
@@ -11,6 +11,7 @@ export const PLAN_ECOMMERCE = 'ecommerce-bundle';
 export const STORE_KEY = 'automattic/onboard/plans';
 
 export const DEFAULT_PAID_PLAN = PLAN_PREMIUM;
+export const DEFAULT_FREE_PLAN = PLAN_FREE;
 
 interface Currency {
 	format: 'SYMBOL_THEN_AMOUNT' | 'AMOUNT_THEN_SYMBOL';

--- a/packages/data-stores/src/plans/selectors.ts
+++ b/packages/data-stores/src/plans/selectors.ts
@@ -3,7 +3,7 @@
  */
 import type { State } from './reducer';
 import { planDetails, PLANS_LIST } from './plans-data';
-import { DEFAULT_PAID_PLAN, PLAN_ECOMMERCE, PLAN_FREE } from './constants';
+import { DEFAULT_FREE_PLAN, DEFAULT_PAID_PLAN, PLAN_ECOMMERCE, PLAN_FREE } from './constants';
 import type { PlanSlug } from './types';
 
 function getPlan( slug: PlanSlug ) {
@@ -13,6 +13,7 @@ function getPlan( slug: PlanSlug ) {
 export const getPlanBySlug = ( _: State, slug: PlanSlug ) => getPlan( slug );
 
 export const getDefaultPaidPlan = () => getPlan( DEFAULT_PAID_PLAN );
+export const getDefaultFreePlan = () => getPlan( DEFAULT_FREE_PLAN );
 
 export const getSupportedPlans = ( state: State ) => state.supportedPlanSlugs.map( getPlan );
 

--- a/packages/plans-grid/src/plans-table/plan-item.tsx
+++ b/packages/plans-grid/src/plans-table/plan-item.tsx
@@ -110,6 +110,7 @@ const PlanItem: React.FunctionComponent< Props > = ( {
 	isFree = false,
 	domain,
 	features,
+	isSelected,
 	onSelect,
 	onPickDomainClick,
 	onToggleExpandAll,
@@ -164,15 +165,23 @@ const PlanItem: React.FunctionComponent< Props > = ( {
 
 						<div className="plan-item__actions">
 							<Button
-								className="plan-item__select-button"
+								className={ classNames( 'plan-item__select-button', {
+									'is-selected': isSelected,
+								} ) }
 								onClick={ () => {
 									onSelect( slug );
 								} }
-								isPrimary
 								isLarge
 								disabled={ !! disabledLabel }
 							>
-								<span>{ __( 'Choose' ) }</span>
+								{ isSelected ? (
+									<>
+										{ TickIcon }
+										<span>{ __( 'Selected' ) }</span>
+									</>
+								) : (
+									<span>{ __( 'Select' ) }</span>
+								) }
 							</Button>
 						</div>
 						<div className="plan-item__features">

--- a/packages/plans-grid/src/plans-table/style.scss
+++ b/packages/plans-grid/src/plans-table/style.scss
@@ -258,12 +258,18 @@ ul.plan-item__feature-item-group {
 	}
 }
 
-.plan-item__select-button.components-button.is-primary {
+.plan-item__select-button.components-button {
+	border: 1px solid var( --studio-blue-40 );
+	border-radius: 4px;
+	color: var( --studio-blue-40 );
 	padding: 0 24px;
 	height: 40px;
 
-	&:disabled {
-		opacity: 0.5;
+	&.is-selected,
+	&.is-selected:active {
+		background: var( --studio-black );
+		color: var( --studio-white );
+		border: 0;
 	}
 
 	svg {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As part of pbAok1-1jD-p2 this PR re-activates the 2-click plans grid. Detailed changes are:

1. Restore the CTA button in plans grid.
2. Automatically select a free plan when a free domain is selected.
3. Automatically select a premium plan when a custom domain is selected.
4. 

#### Testing instructions

1. Go to [/new](https://calypso.live/new?branch=update/two-click-plans-grid) and full the site title.
2. Pick a free domain, then open the plans grid, a free paid should be pre-selected.
3. Pick a custom domain, a premium plan should be pre-selected.

Fixes part of https://github.com/Automattic/wp-calypso/issues/44454
