### PR TITLE
User suggestions: improve resilience when API returns null for suggestions

### DIFF
--- a/client/state/users/suggestions/reducer.js
+++ b/client/state/users/suggestions/reducer.js
@@ -50,7 +50,7 @@ export const items = withSchemaValidation( itemsSchema, ( state = {}, action ) =
 	switch ( action.type ) {
 		case USER_SUGGESTIONS_RECEIVE: {
 			const { siteId, suggestions } = action;
-			return { ...state, [ siteId ]: suggestions };
+			return { ...state, [ siteId ]: suggestions || [] };
 		}
 	}
 

--- a/client/state/users/suggestions/selectors.js
+++ b/client/state/users/suggestions/selectors.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
 
 /**

--- a/client/state/users/suggestions/test/reducer.js
+++ b/client/state/users/suggestions/test/reducer.js
@@ -38,6 +38,19 @@ describe( 'reducer', () => {
 
 			expect( state[ 123 ][ 0 ] ).to.eql( newSuggestion );
 		} );
+
+		test( 'should store an empty array in the event that suggestions is null', () => {
+			const state = items(
+				{},
+				{
+					type: USER_SUGGESTIONS_RECEIVE,
+					suggestions: null,
+					siteId: 123,
+				}
+			);
+
+			expect( state[ 123 ] ).toEqual( [] );
+		} );
 	} );
 
 	describe( '#requesting()', () => {

--- a/client/state/users/suggestions/test/reducer.js
+++ b/client/state/users/suggestions/test/reducer.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
 import deepFreeze from 'deep-freeze';
 
 /**
@@ -20,7 +19,7 @@ describe( 'reducer', () => {
 	describe( '#items()', () => {
 		test( 'should default to an empty object', () => {
 			const state = items( undefined, {} );
-			expect( state ).to.eql( {} );
+			expect( state ).toEqual( {} );
 		} );
 
 		test( 'should insert a new suggestion', () => {
@@ -36,7 +35,7 @@ describe( 'reducer', () => {
 				siteId: 123,
 			} );
 
-			expect( state[ 123 ][ 0 ] ).to.eql( newSuggestion );
+			expect( state[ 123 ][ 0 ] ).toEqual( newSuggestion );
 		} );
 
 		test( 'should store an empty array in the event that suggestions is null', () => {
@@ -56,7 +55,7 @@ describe( 'reducer', () => {
 	describe( '#requesting()', () => {
 		test( 'should default to an empty object', () => {
 			const state = requesting( undefined, {} );
-			expect( state ).to.eql( {} );
+			expect( state ).toEqual( {} );
 		} );
 
 		test( 'should index requesting state by site ID', () => {
@@ -65,7 +64,7 @@ describe( 'reducer', () => {
 				type: USER_SUGGESTIONS_REQUEST,
 				siteId,
 			} );
-			expect( state ).to.eql( {
+			expect( state ).toEqual( {
 				123: true,
 			} );
 		} );
@@ -78,7 +77,7 @@ describe( 'reducer', () => {
 				type: USER_SUGGESTIONS_REQUEST,
 				siteId: 123,
 			} );
-			expect( state ).to.eql( {
+			expect( state ).toEqual( {
 				124: false,
 				123: true,
 			} );
@@ -94,7 +93,7 @@ describe( 'reducer', () => {
 				siteId: 123,
 			} );
 
-			expect( state ).to.eql( {
+			expect( state ).toEqual( {
 				124: false,
 				123: false,
 			} );
@@ -107,7 +106,7 @@ describe( 'reducer', () => {
 					123: true,
 				} );
 				const state = requesting( original, { type: SERIALIZE } );
-				expect( state ).to.be.undefined;
+				expect( state ).toBeUndefined();
 			} );
 
 			test( 'never loads persisted state', () => {
@@ -116,7 +115,7 @@ describe( 'reducer', () => {
 					123: true,
 				} );
 				const state = requesting( original, { type: DESERIALIZE } );
-				expect( state ).to.eql( {} );
+				expect( state ).toEqual( {} );
 			} );
 		} );
 	} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

@ChaosExAnima discovered a blog post that caused a fatal JS error in Reader full post. The culprit was a call to the /users/suggest endpoint for username suggestions, which was returning `suggestions: null` rather than the expected suggestions array.

This PR checks for a null value at the reducer, and stores an empty array in Redux state if `suggestions` is null.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
Internal users can check the following URL:

https://wordpress.com/read/blogs/177698830/posts/1743

With the PR applied locally, it should no longer cause a fatal error.

http://calypso.localhost:3000/read/blogs/177698830/posts/1743

You can also check other internal P2 posts and verify that you are able to use the user suggestions feature as normal in the comments section.
