### PR TITLE
Reorder some discussion points and wording around data-persistence for better clarity to a new reader/automattician

### DIFF
--- a/docs/data-persistence.md
+++ b/docs/data-persistence.md
@@ -5,22 +5,75 @@ Persisting our Redux state to browser storage (IndexedDB) allows us to avoid com
 Redux tree from scratch on each page load and to display cached data in the UI (instead of placeholders)
 while fetching the latest updates from the REST API is still in progress.
 
+Note that the entire Redux state is *not* persisted to the browser. In order to persist state in browser storage the reducer must be wrapped with `withSchemaValidation` as instructed below.
+
 This feature was originally implemented in [#2754](https://github.com/Automattic/wp-calypso/pull/2754).
 
 At a high level, implementing this is straightforward. We subscribe to any Redux store changes, and on change we update
 our browser storage with the new state of the Redux tree. On page load, if we detect stored state in browser storage during
-our initial render, we create our Redux store with that persisted initial state.
+our initial render, we create our Redux store with that persisted initial state. However, significat issues exist that require special solutions:
+* [Subtrees may contain class instances](#problem-subtrees-may-contain-class-instances)
+* [Data shapes change over time ](#problem-data-shapes-change-over-time--3101-)
+* [Some reducers are loaded dynamically](#problem-some-reducers-are-loaded-dynamically)
+
+
+The implementation details for theses solutions are discussed in detail below. 
+
+
+### Opt-in to Persistence
+
+Note that we opt-in to persistence simply by wrapping the reducer with `withSchemaValidation`.
+`withSchemaValidation` returns a wrapped reducer that validates on `DESERIALIZE` if a schema is present and returns
+initial state on both `SERIALIZE` and `DESERIALIZE` if a schema is not present.  [Implementaion](#problem-subtrees-may-contain-class-instances) of `SERIALIZE` and `DESERIALIZE` to handle subtrees with class instances is discussed below.
+
+In Calypso, we combine all of our reducers using `combineReducers` from `state/utils` at every level of the tree instead
+of the default implementation of [combineReducers](http://redux.js.org/docs/api/combineReducers.html) from `redux`.
+The custom `combineReducers` handles persistence for the reducers it's combining.
+
+To opt-out of persistence we simply combine reducers without any attached schema.
+```javascript
+return combineReducers( {
+    age,
+    height,
+} );
+```
+
+To persist, we add the schema by wrapping the reducer with the `withSchemaValidation` util:
+```javascript
+return combineReducers( {
+    age: withSchemaValidation( ageSchema, age ),
+    height,
+} );
+```
+
+For a reducer that has custom handlers (needs to perform transforms), we assume the reducer is checking the schema already,
+on `DESERIALIZE` so all we need to do is set a boolean bit on the reducer, to ensure that we don't return initial state
+incorrectly from the default handling provided by `withSchemaValidation`.
+```javascript
+date.hasCustomPersistence = true;
+return combineReducers( {
+    age,
+    height,
+    date,
+} );
+```
+
+### Not persisting data
+
+Some subtrees may choose to never persist data. One such example of this is our online connection state. If connection
+values are persisted we will not be able to reliably tell when the application is offline or online. Please remember
+to reason about if items should be persisted.
+
 
 However we quickly run into the following problems:
 
 #### Problem: Subtrees may contain class instances
 
-Subtrees may contain class instances. In some cases this is expected, because certain branches have chosen to use
-Immutable.js. Other branches use specialized classes like [QueryManager](https://github.com/Automattic/wp-calypso/tree/HEAD/client/lib/query-manager)
-whose instances are stored in Redux state. However, attempting to serialize class instances will throw errors while saving
-to browser storage.
+Subtrees may contain class instances. In some cases this is expected, because certain state subtrees have chosen to use
+Immutable.js. Other subtrees use specialized classes like [QueryManager](https://github.com/Automattic/wp-calypso/tree/HEAD/client/lib/query-manager)
+whose instances are stored in Redux state. However, IndexedDB storage requires that objects be serialized and thus attempting to store a class instance in IndexedDB will throw an error.  We must create a custom solution to serialize these classes before saving to IndexedDB.
 
-#### Solution: SERIALIZE and DESERIALIZE actions
+[#### Solution: SERIALIZE and DESERIALIZE actions](#solution-serialize-deserialize)
 
 To work around this we create two special action types: `SERIALIZE` and `DESERIALIZE`. These actions are not dispatched,
 but are instead used with the reducer directly to prepare state to be serialized to browser storage, and for
@@ -84,7 +137,7 @@ As time passes, the shape of our data will change very drastically in our Redux 
 persist state, we run into the issue of our persisted data shape no longer matching what the Redux store expects.
 
 As a developer, this case is extremely easy to hit. If Redux persistence is enabled and we are running master, first
-allow  state to be persisted to the browser and then switch to another branch that contains minor refactors for an
+allow  state to be persisted to the browser and then switch to another git branch that contains minor refactors for an
 existing sub-tree. What happens when a selector reaches for a data property that doesn't exist or has been renamed?
 Errors!
 
@@ -170,46 +223,3 @@ and another one for `reader` key. Both objects will be stored as two distinct ro
 When booting Calypso, we initially load only the `root` stored state. The `reader` key is loaded and deserialized only
 when the `reader` reducer is being added dynamically.
 
-### Opt-in to Persistence
-
-Note that we opt-in to persistence simply by wrapping the reducer with `withSchemaValidation`.
-`withSchemaValidation` returns a wrapped reducer that validates on `DESERIALIZE` if a schema is present and returns
-initial state on both `SERIALIZE` and `DESERIALIZE` if a schema is not present.
-
-In Calypso, we combine all of our reducers using `combineReducers` from `state/utils` at every level of the tree instead
-of the default implementation of [combineReducers](http://redux.js.org/docs/api/combineReducers.html) from `redux`.
-The custom `combineReducers` handles persistence for the reducers it's combining.
-
-To opt-out of persistence we simply combine reducers without any attached schema.
-```javascript
-return combineReducers( {
-    age,
-    height,
-} );
-```
-
-To persist, we add the schema by wrapping the reducer with the `withSchemaValidation` util:
-```javascript
-return combineReducers( {
-    age: withSchemaValidation( ageSchema, age ),
-    height,
-} );
-```
-
-For a reducer that has custom handlers (needs to perform transforms), we assume the reducer is checking the schema already,
-on `DESERIALIZE` so all we need to do is set a boolean bit on the reducer, to ensure that we don't return initial state
-incorrectly from the default handling provided by `withSchemaValidation`.
-```javascript
-date.hasCustomPersistence = true;
-return combineReducers( {
-    age,
-    height,
-    date,
-} );
-```
-
-### Not persisting data
-
-Some subtrees may choose to never persist data. One such example of this is our online connection state. If connection
-values are persisted we will not be able to reliably tell when the application is offline or online. Please remember
-to reason about if items should be persisted.

--- a/docs/data-persistence.md
+++ b/docs/data-persistence.md
@@ -11,7 +11,7 @@ This feature was originally implemented in [#2754](https://github.com/Automattic
 
 At a high level, implementing this is straightforward. We subscribe to any Redux store changes, and on change we update
 our browser storage with the new state of the Redux tree. On page load, if we detect stored state in browser storage during
-our initial render, we create our Redux store with that persisted initial state. However, significat issues exist that require special solutions:
+our initial render, we create our Redux store with that persisted initial state. However, significant issues exist that require special solutions:
 * [Subtrees may contain class instances](#problem-subtrees-may-contain-class-instances)
 * [Data shapes change over time ](#problem-data-shapes-change-over-time--3101-)
 * [Some reducers are loaded dynamically](#problem-some-reducers-are-loaded-dynamically)


### PR DESCRIPTION
### Motivation

As a newmattician diving into code documentation, 👋  , I was reading through a number of docs on data concepts and came across the data-persistance doc.  After rereading a few times I felt that the order of information could be slightly updated to provide better clarity to someone reading with no or very little prior knowledge of wp-calypso's data-persistance.  

If my changes are missing context or have confused the flow, I'd love to discuss so I can make sure I have a solid foundation of this topic. This was a great newbie exercise, I learned so much! 🧠

### Changes proposed in this Pull Request

* Clarify that the whole redux store is not stored in browser storage
* Move the opt-in section toward the top, since it is the 'meat' of the usage

### Testing instructions

Have a read.  Does it make sense? It is an improvement? 

