### PR TITLE
Enable showRecaptcha in signup flows

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -31,7 +31,7 @@ export function generateFlows( {
 			steps: [ 'user', 'domains', 'plans-business' ],
 			destination: getSignupDestination,
 			description: 'Create an account and a blog and then add the business plan to the users cart.',
-			lastModified: '2020-03-03',
+			lastModified: '2020-08-11',
 			showRecaptcha: true,
 		},
 
@@ -39,7 +39,7 @@ export function generateFlows( {
 			steps: [ 'user', 'domains', 'plans-premium' ],
 			destination: getSignupDestination,
 			description: 'Create an account and a blog and then add the premium plan to the users cart.',
-			lastModified: '2020-03-03',
+			lastModified: '2020-08-11',
 			showRecaptcha: true,
 		},
 
@@ -47,7 +47,7 @@ export function generateFlows( {
 			steps: [ 'user', 'domains', 'plans-personal' ],
 			destination: getSignupDestination,
 			description: 'Create an account and a blog and then add the personal plan to the users cart.',
-			lastModified: '2020-03-03',
+			lastModified: '2020-08-11',
 			showRecaptcha: true,
 		},
 
@@ -55,7 +55,7 @@ export function generateFlows( {
 			steps: [ 'user', 'domains' ],
 			destination: getSignupDestination,
 			description: 'Create an account and a blog and default to the free plan.',
-			lastModified: '2020-03-03',
+			lastModified: '2020-08-11',
 			showRecaptcha: true,
 		},
 
@@ -72,7 +72,7 @@ export function generateFlows( {
 			steps: [ 'domains-theme-preselected', 'plans', 'user' ],
 			destination: getChecklistThemeDestination,
 			description: 'Preselect a theme to activate/buy from an external source',
-			lastModified: '2019-08-20',
+			lastModified: '2020-08-11',
 			showRecaptcha: true,
 		},
 
@@ -110,6 +110,7 @@ export function generateFlows( {
 			destination: getSignupDestination,
 			description: 'The improved onboarding flow.',
 			lastModified: '2020-03-03',
+			showRecaptcha: true,
 		},
 
 		onboarding: {
@@ -141,7 +142,7 @@ export function generateFlows( {
 			steps: [ 'about', 'themes', 'domains', 'plans', 'user' ],
 			destination: getSignupDestination,
 			description: 'Signup flow for desktop app',
-			lastModified: '2019-06-20',
+			lastModified: '2020-08-11',
 			showRecaptcha: true,
 		},
 
@@ -226,7 +227,7 @@ export function generateFlows( {
 			steps: [ 'user', 'domains', 'plans-ecommerce-fulfilled' ],
 			destination: getSignupDestination,
 			description: 'Signup flow for creating an online store with an Atomic site',
-			lastModified: '2020-03-04',
+			lastModified: '2020-08-11',
 			showRecaptcha: true,
 		};
 
@@ -267,7 +268,7 @@ export function generateFlows( {
 			steps: [ 'p2-site', 'user' ],
 			destination: ( dependencies ) => `https://${ dependencies.siteSlug }`,
 			description: 'P2 signup flow',
-			lastModified: '2020-06-04',
+			lastModified: '2020-08-11',
 			showRecaptcha: true,
 		};
 
@@ -290,7 +291,7 @@ export function generateFlows( {
 		destination: getThankYouNoSiteDestination,
 		description: 'An experimental approach for WordPress.com/domains',
 		disallowResume: true,
-		lastModified: '2019-06-21',
+		lastModified: '2020-08-11',
 		showRecaptcha: true,
 	};
 
@@ -306,7 +307,7 @@ export function generateFlows( {
 		destination: getThankYouNoSiteDestination,
 		description: 'An approach to add a domain via the all domains view',
 		disallowResume: true,
-		lastModified: '2020-07-30',
+		lastModified: '2020-08-11',
 		showRecaptcha: true,
 	};
 
@@ -344,7 +345,7 @@ export function generateFlows( {
 		destination: importDestination,
 		description: 'A flow to kick off an import during signup',
 		disallowResume: true,
-		lastModified: '2019-07-30',
+		lastModified: '2020-08-11',
 		showRecaptcha: true,
 	};
 
@@ -355,7 +356,7 @@ export function generateFlows( {
 		destination: importDestination,
 		description: 'Import flow that can be used from the onboarding flow',
 		disallowResume: true,
-		lastModified: '2019-08-01',
+		lastModified: '2020-08-11',
 		showRecaptcha: true,
 	};
 
@@ -363,7 +364,7 @@ export function generateFlows( {
 		steps: [ 'reader-landing', 'user' ],
 		destination: '/',
 		description: 'Signup for an account and migrate email subs to the Reader.',
-		lastModified: '2018-10-29',
+		lastModified: '2020-08-11',
 		showRecaptcha: true,
 	};
 
@@ -380,7 +381,7 @@ export function generateFlows( {
 		steps: [ 'user', 'site', 'plans' ],
 		destination: getSiteDestination,
 		description: 'Allow users to select a plan without a domain',
-		lastModified: '2018-12-12',
+		lastModified: '2020-08-11',
 		showRecaptcha: true,
 	};
 

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -25,7 +25,6 @@ export function generateFlows( {
 			description: 'Create an account without a blog.',
 			lastModified: '2015-07-07',
 			pageTitle: translate( 'Create an account' ),
-			showRecaptcha: true,
 		},
 
 		business: {
@@ -67,7 +66,6 @@ export function generateFlows( {
 			},
 			description: 'Create an account for REBRAND cities partnership',
 			lastModified: '2019-06-17',
-			showRecaptcha: true,
 		},
 
 		'with-theme': {
@@ -91,7 +89,6 @@ export function generateFlows( {
 			destination: getChecklistThemeDestination,
 			description: 'Start with one of our template-first (Gutenberg) themes.',
 			lastModified: '2019-10-16',
-			showRecaptcha: true,
 		},
 
 		main: {
@@ -99,7 +96,6 @@ export function generateFlows( {
 			destination: getSignupDestination,
 			description: 'The current best performing flow in AB tests',
 			lastModified: '2019-06-20',
-			showRecaptcha: true,
 		},
 
 		'onboarding-with-preview': {
@@ -114,7 +110,6 @@ export function generateFlows( {
 			destination: getSignupDestination,
 			description: 'The improved onboarding flow.',
 			lastModified: '2020-03-03',
-			showRecaptcha: true,
 		},
 
 		onboarding: {
@@ -205,7 +200,6 @@ export function generateFlows( {
 			destination: '/',
 			description: 'A very simple signup flow',
 			lastModified: '2019-05-09',
-			showRecaptcha: true,
 		},
 	};
 
@@ -241,7 +235,6 @@ export function generateFlows( {
 			destination: getSignupDestination,
 			description: 'Signup flow for creating an online store with an Atomic site',
 			lastModified: '2020-03-04',
-			showRecaptcha: true,
 		};
 
 		flows[ 'ecommerce-design-first' ] = {
@@ -256,7 +249,6 @@ export function generateFlows( {
 			description:
 				'Signup flow for creating an online store with an Atomic site, forked from the design-first flow',
 			lastModified: '2019-11-27',
-			showRecaptcha: true,
 		};
 	}
 
@@ -398,7 +390,6 @@ export function generateFlows( {
 			destination: getSignupDestination,
 			description: 'User testing Signup flow for Full Site Editing',
 			lastModified: '2019-12-02',
-			showRecaptcha: true,
 		};
 	}
 

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -25,6 +25,7 @@ export function generateFlows( {
 			description: 'Create an account without a blog.',
 			lastModified: '2015-07-07',
 			pageTitle: translate( 'Create an account' ),
+			showRecaptcha: true,
 		},
 
 		business: {
@@ -32,6 +33,7 @@ export function generateFlows( {
 			destination: getSignupDestination,
 			description: 'Create an account and a blog and then add the business plan to the users cart.',
 			lastModified: '2020-03-03',
+			showRecaptcha: true,
 		},
 
 		premium: {
@@ -39,6 +41,7 @@ export function generateFlows( {
 			destination: getSignupDestination,
 			description: 'Create an account and a blog and then add the premium plan to the users cart.',
 			lastModified: '2020-03-03',
+			showRecaptcha: true,
 		},
 
 		personal: {
@@ -46,6 +49,7 @@ export function generateFlows( {
 			destination: getSignupDestination,
 			description: 'Create an account and a blog and then add the personal plan to the users cart.',
 			lastModified: '2020-03-03',
+			showRecaptcha: true,
 		},
 
 		free: {
@@ -53,6 +57,7 @@ export function generateFlows( {
 			destination: getSignupDestination,
 			description: 'Create an account and a blog and default to the free plan.',
 			lastModified: '2020-03-03',
+			showRecaptcha: true,
 		},
 
 		'rebrand-cities': {
@@ -62,6 +67,7 @@ export function generateFlows( {
 			},
 			description: 'Create an account for REBRAND cities partnership',
 			lastModified: '2019-06-17',
+			showRecaptcha: true,
 		},
 
 		'with-theme': {
@@ -69,6 +75,7 @@ export function generateFlows( {
 			destination: getChecklistThemeDestination,
 			description: 'Preselect a theme to activate/buy from an external source',
 			lastModified: '2019-08-20',
+			showRecaptcha: true,
 		},
 
 		'design-first': {
@@ -84,6 +91,7 @@ export function generateFlows( {
 			destination: getChecklistThemeDestination,
 			description: 'Start with one of our template-first (Gutenberg) themes.',
 			lastModified: '2019-10-16',
+			showRecaptcha: true,
 		},
 
 		main: {
@@ -91,6 +99,7 @@ export function generateFlows( {
 			destination: getSignupDestination,
 			description: 'The current best performing flow in AB tests',
 			lastModified: '2019-06-20',
+			showRecaptcha: true,
 		},
 
 		'onboarding-with-preview': {
@@ -138,6 +147,7 @@ export function generateFlows( {
 			destination: getSignupDestination,
 			description: 'Signup flow for desktop app',
 			lastModified: '2019-06-20',
+			showRecaptcha: true,
 		},
 
 		developer: {
@@ -195,6 +205,7 @@ export function generateFlows( {
 			destination: '/',
 			description: 'A very simple signup flow',
 			lastModified: '2019-05-09',
+			showRecaptcha: true,
 		},
 	};
 
@@ -222,6 +233,7 @@ export function generateFlows( {
 			destination: getSignupDestination,
 			description: 'Signup flow for creating an online store with an Atomic site',
 			lastModified: '2020-03-04',
+			showRecaptcha: true,
 		};
 
 		flows[ 'ecommerce-onboarding' ] = {
@@ -229,6 +241,7 @@ export function generateFlows( {
 			destination: getSignupDestination,
 			description: 'Signup flow for creating an online store with an Atomic site',
 			lastModified: '2020-03-04',
+			showRecaptcha: true,
 		};
 
 		flows[ 'ecommerce-design-first' ] = {
@@ -243,6 +256,7 @@ export function generateFlows( {
 			description:
 				'Signup flow for creating an online store with an Atomic site, forked from the design-first flow',
 			lastModified: '2019-11-27',
+			showRecaptcha: true,
 		};
 	}
 
@@ -262,6 +276,7 @@ export function generateFlows( {
 			destination: ( dependencies ) => `https://${ dependencies.siteSlug }`,
 			description: 'P2 signup flow',
 			lastModified: '2020-06-04',
+			showRecaptcha: true,
 		};
 
 		// Original name for the project was "WP for Teams". Since then, we've renamed it to "P2".
@@ -284,6 +299,7 @@ export function generateFlows( {
 		description: 'An experimental approach for WordPress.com/domains',
 		disallowResume: true,
 		lastModified: '2019-06-21',
+		showRecaptcha: true,
 	};
 
 	flows[ 'add-domain' ] = {
@@ -299,6 +315,7 @@ export function generateFlows( {
 		description: 'An approach to add a domain via the all domains view',
 		disallowResume: true,
 		lastModified: '2020-07-30',
+		showRecaptcha: true,
 	};
 
 	flows[ 'site-selected' ] = {
@@ -336,6 +353,7 @@ export function generateFlows( {
 		description: 'A flow to kick off an import during signup',
 		disallowResume: true,
 		lastModified: '2019-07-30',
+		showRecaptcha: true,
 	};
 
 	flows[ 'import-onboarding' ] = {
@@ -346,6 +364,7 @@ export function generateFlows( {
 		description: 'Import flow that can be used from the onboarding flow',
 		disallowResume: true,
 		lastModified: '2019-08-01',
+		showRecaptcha: true,
 	};
 
 	flows.reader = {
@@ -353,6 +372,7 @@ export function generateFlows( {
 		destination: '/',
 		description: 'Signup for an account and migrate email subs to the Reader.',
 		lastModified: '2018-10-29',
+		showRecaptcha: true,
 	};
 
 	flows.crowdsignal = {
@@ -369,6 +389,7 @@ export function generateFlows( {
 		destination: getSiteDestination,
 		description: 'Allow users to select a plan without a domain',
 		lastModified: '2018-12-12',
+		showRecaptcha: true,
 	};
 
 	if ( isEnabled( 'signup/full-site-editing' ) ) {
@@ -377,6 +398,7 @@ export function generateFlows( {
 			destination: getSignupDestination,
 			description: 'User testing Signup flow for Full Site Editing',
 			lastModified: '2019-12-02',
+			showRecaptcha: true,
 		};
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Set the showRecaptcha option as true for all flows that involve a user step. Effected flows are as follows.

<details><summary> Flows that contains / will contain the recaptcha </summary>
<p>

- business: Create an account and a blog and then add the business plan to the users cart.
- premium: Create an account and a blog and then add the premium plan to the users cart.
- personal: Create an account and a blog and then add the personal plan to the users cart.
- free: Create an account and a blog and default to the free plan.
- with-theme: Preselect a theme to activate/buy from an external source
- onboarding: Abridged version of the onboarding flow. Read more in https://wp.me/pau2Xa-Vs.
- onboarding-plan-first: Shows the plan step before the domains step. Read more in https://wp.me/pbxNRc-cj.
- onboarding-registrationless: Checkout without user account or site. Read more https://wp.me/pau2Xa-1hW
- desktop: Signup flow for desktop app
- ecommerce: Signup flow for creating an online store with an Atomic site
- domain: An experimental approach for WordPress.com/domains
- add-domain: An approach to add a domain via the all domains view
- import: A flow to kick off an import during signup
- import-onboarding: Import flow that can be used from the onboarding flow
- reader: Signup for an account and migrate email subs to the Reader.
- p2: P2 signup flow
- wp-for-teams: P2 signup flow
- onboarding-with-preview: The improved onboarding flow.
</p>
</details>


<details><summary> Flows left out of recaptcha </summary>
<p>

##### Flows without recaptcha

- developer: Signup flow for developers in developer environment
- pressable-nux: Allow new Pressable users to grant permission to server credentials
- rewind-switch: Allows users with Jetpack plan with VaultPress credentials to migrate credentials
- rewind-setup: Allows users with Jetpack plan to setup credentials
- rewind-auto-config: Allow users of sites that can auto-config to grant permission to server credentials
- clone-site: Allow Jetpack users to clone a site via Rewind (alternate restore)
- wpcc: WordPress.com Connect signup flow
- site-selected: A flow to test updating an existing site with `Signup`
- launch-site: A flow to launch a private site.
- crowdsignal: Crowdsignal's custom WordPress.com Connect signup flow
- new-launch: Launch flow for a site created from /new
- simple: A very simple signup flow

##### Flows with user that were left out

- account: Create an account without a blog.
- test-fse: User testing Signup flow for Full Site Editing
- ecommerce-onboarding: Signup flow for creating an online store with an Atomic site
- ecommerce-design-first: Signup flow for creating an online store with an Atomic site, forked from the design-first flow
- rebrand-cities: Create an account for REBRAND cities partnership
- design-first: Start with one of our template-first (Gutenberg) themes.
- main: The current best performing flow in AB tests

</p>
</details>

#### Flows yet to be finalized
- plan-no-domain: Allow users to select a plan without a domain




#### Testing instructions

1.  Go to the url ```https://${host}/start/${flow_name}```. For example for the `main` flow in `production` go to the ```https://wordpress.com/start/user``` url.
2. Reach the user step in the relevant flow.
3. Check if the "reCaptcha" icon is available in the bottom right corner.
![image](https://user-images.githubusercontent.com/3422709/89770296-31d79280-db1c-11ea-87c6-5a5070a3aa38.png)
3. For all the flows in the first list recaptcha should be available in the user step.
4. For all the flows in the second list reCaptcha should not be available in the flow. 