### PR TITLE
P2: prevent accessing the domain management section

### DIFF
--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -38,6 +38,7 @@ import { canUserPurchaseGSuite } from 'lib/gsuite';
 import { addItem } from 'lib/cart/actions';
 import { planItem } from 'lib/cart-values/cart-items';
 import { PLAN_PERSONAL } from 'lib/plans/constants';
+import isSiteWPForTeams from 'state/selectors/is-site-wpforteams';
 
 const domainsAddHeader = ( context, next ) => {
 	context.getSiteSelectionHeaderText = () => {
@@ -270,11 +271,23 @@ const jetpackNoDomainsWarning = ( context, next ) => {
 	}
 };
 
+const wpForTeamsNoDomainsWarning = ( context, next ) => {
+	const state = context.store.getState();
+	const selectedSite = getSelectedSite( state );
+
+	if ( selectedSite && isSiteWPForTeams( state, selectedSite.ID ) ) {
+		return page.redirect( '/' );
+	}
+
+	next();
+};
+
 export default {
 	domainsAddHeader,
 	domainsAddRedirectHeader,
 	domainSearch,
 	jetpackNoDomainsWarning,
+	wpForTeamsNoDomainsWarning,
 	siteRedirect,
 	mapDomain,
 	googleAppsWithRegistration,

--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -271,7 +271,7 @@ const jetpackNoDomainsWarning = ( context, next ) => {
 	}
 };
 
-const wpForTeamsNoDomainsWarning = ( context, next ) => {
+const wpForTeamsNoDomainsRedirect = ( context, next ) => {
 	const state = context.store.getState();
 	const selectedSite = getSelectedSite( state );
 
@@ -287,7 +287,7 @@ export default {
 	domainsAddRedirectHeader,
 	domainSearch,
 	jetpackNoDomainsWarning,
-	wpForTeamsNoDomainsWarning,
+	wpForTeamsNoDomainsRedirect,
 	siteRedirect,
 	mapDomain,
 	googleAppsWithRegistration,

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -32,7 +32,7 @@ function getCommonHandlers( {
 	noSitePath = paths.domainManagementRoot(),
 	warnIfJetpack = true,
 } = {} ) {
-	const handlers = [ siteSelection, navigation ];
+	const handlers = [ siteSelection, navigation, domainsController.wpForTeamsNoDomainsWarning ];
 
 	if ( noSitePath ) {
 		handlers.push( domainsController.redirectIfNoSite( noSitePath ) );

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -32,7 +32,7 @@ function getCommonHandlers( {
 	noSitePath = paths.domainManagementRoot(),
 	warnIfJetpack = true,
 } = {} ) {
-	const handlers = [ siteSelection, navigation, domainsController.wpForTeamsNoDomainsWarning ];
+	const handlers = [ siteSelection, navigation, domainsController.wpForTeamsNoDomainsRedirect ];
 
 	if ( noSitePath ) {
 		handlers.push( domainsController.redirectIfNoSite( noSitePath ) );


### PR DESCRIPTION
In this PR we prevent all access to the domain management section for P2 sites. @klimeryk suggested doing this so that users don't accidentally end up with a custom domain for their P2 site which is non-manageable and will expire in a year.

## Testing instructions

Using a non-P2 site, navigate to domain management screen (i.e. `/domains/manage/lamosty.com`). You should be able to manage the domain. Now, switch to a P2 site. You should be redirected to `/`.

