### PR TITLE
Hide the “Plans” sidebar item in the WPMobile apps

### DIFF
--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -35,6 +35,7 @@ import ToolsMenu from './tools-menu';
 import isCurrentPlanPaid from 'state/sites/selectors/is-current-plan-paid';
 import { siteHasJetpackProductPurchase } from 'state/purchases/selectors';
 import { isFreeTrial, isEcommerce } from 'lib/products-values';
+import { isWpMobileApp } from 'lib/mobile-app';
 import isJetpackSectionEnabledForSite from 'state/selectors/is-jetpack-section-enabled-for-site';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -554,6 +555,7 @@ export class MySitesSidebar extends Component {
 			path,
 			site,
 			translate,
+			isWpMobile,
 		} = this.props;
 
 		if ( ! site ) {
@@ -601,6 +603,11 @@ export class MySitesSidebar extends Component {
 					size={ 24 }
 				/>
 			);
+		}
+
+		// Don't show the "Plans" sidebar item in WP Mobile App WebViews to avoid them being rejected
+		if ( isWpMobile ) {
+			return;
 		}
 
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
@@ -1064,6 +1071,7 @@ function mapStateToProps( state ) {
 		rewindState: getRewindState( state, siteId ),
 		isCloudEligible: isJetpackCloudEligible( state, siteId ),
 		isAllSitesView: isAllDomainsView || getSelectedSiteId( state ) === null,
+		isWpMobile: isWpMobileApp(),
 	};
 }
 

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -605,7 +605,7 @@ export class MySitesSidebar extends Component {
 			);
 		}
 
-		// Don't show the "Plans" sidebar item in WP Mobile App WebViews to avoid them being rejected
+		// Hide "Plans" because the App/Play Stores reject apps that present non In-App Purchase flows, even in a WebView
 		if ( isWpMobile ) {
 			return;
 		}
@@ -1071,7 +1071,7 @@ function mapStateToProps( state ) {
 		rewindState: getRewindState( state, siteId ),
 		isCloudEligible: isJetpackCloudEligible( state, siteId ),
 		isAllSitesView: isAllDomainsView || getSelectedSiteId( state ) === null,
-		isWpMobile: isWpMobileApp(),
+		isWpMobile: isWpMobileApp(), // This doesn't rely on state, but we inject it here for future testability
 	};
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Hides the "Plans" sidebar item in the WordPress iOS and Android apps – having it present can cause the app to be rejected.

#### Testing instructions
- Switch to this branch, then view it in your browser of choice (or use Calypso.live)
- Note that by default, the "Plans" page is still visible
- Adjust your user agent string, adding `wp-iphone` anywhere in the string
- Refresh the page – the plans menu item should no longer be visible.