### PR TITLE
InlineHelp: Anchor to appropriate sections from admin results (#44059)

### DIFF
--- a/client/blocks/inline-help/admin-sections.js
+++ b/client/blocks/inline-help/admin-sections.js
@@ -173,21 +173,21 @@ export const adminSections = memoize( ( siteId, siteSlug, state ) => [
 	},
 	{
 		title: translate( "Change my site's timezone" ),
-		link: `/settings/general/${ siteSlug }`,
+		link: `/settings/general/${ siteSlug }#site-settings__blogtimezone`,
 		synonyms: [ 'time', 'date' ],
 		icon: 'cog',
 	},
 	{
 		title: translate( 'Launch my site' ),
 		description: translate( 'Switch your site from private to public.' ),
-		link: `/settings/general/${ siteSlug }`,
+		link: `/settings/general/${ siteSlug }#site-privacy-settings`,
 		synonyms: [ 'private', 'public' ],
 		icon: 'cog',
 	},
 	{
 		title: translate( "Delete a site or a site's content" ),
 		description: translate( 'Remove all posts, pages, and media, or delete a site completely.' ),
-		link: `/settings/general/${ siteSlug }`,
+		link: `/settings/general/${ siteSlug }#site-tools__header`,
 		icon: 'cog',
 	},
 	{
@@ -201,7 +201,7 @@ export const adminSections = memoize( ( siteId, siteSlug, state ) => [
 		description: translate(
 			'You can customize your website by changing the footer credit in customizer.'
 		),
-		link: `/settings/general/${ siteSlug }`,
+		link: `/settings/general/${ siteSlug }#site-settings__footer-credit-header`,
 		synonyms: [ 'remove footer', 'update footer' ],
 		icon: 'cog',
 	},
@@ -265,13 +265,13 @@ export const adminSections = memoize( ( siteId, siteSlug, state ) => [
 	},
 	{
 		title: translate( 'Set up a podcast' ),
-		link: `/settings/writing/${ siteSlug }`,
+		link: `/settings/writing/${ siteSlug }#podcasting-details__link-header`,
 		synonyms: [ 'podcast', 'radio', 'audio' ],
 		icon: 'cog',
 	},
 	{
 		title: translate( "Change my site's privacy settings" ),
-		link: `/settings/general/${ siteSlug }`,
+		link: `/settings/general/${ siteSlug }#site-privacy-settings`,
 		synonyms: [ 'privacy' ],
 		icon: 'cog',
 	},
@@ -296,7 +296,7 @@ export const adminSections = memoize( ( siteId, siteSlug, state ) => [
 	},
 	{
 		title: translate( 'Change the dashboard color scheme' ),
-		link: '/me/account',
+		link: '/me/account#account__color_scheme',
 		synonyms: [ 'theme' ],
 		icon: 'cog',
 	},
@@ -305,7 +305,7 @@ export const adminSections = memoize( ( siteId, siteSlug, state ) => [
 		description: translate(
 			'Update the language of the interface you see across WordPress.com as a whole.'
 		),
-		link: '/me/account',
+		link: '/me/account#account__language',
 		synonyms: [ 'dashboard', 'change', 'language' ],
 		icon: 'cog',
 	},

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -609,7 +609,9 @@ const Account = createReactClass( {
 				</FormFieldset>
 
 				<FormFieldset>
-					<FormLabel htmlFor="language">{ translate( 'Interface language' ) }</FormLabel>
+					<FormLabel id="account__language" htmlFor="language">
+						{ translate( 'Interface language' ) }
+					</FormLabel>
 					<LanguagePicker
 						disabled={ this.getDisabledState() }
 						languages={ languages }
@@ -637,7 +639,9 @@ const Account = createReactClass( {
 
 				{ config.isEnabled( 'me/account/color-scheme-picker' ) && supportsCssCustomProperties() && (
 					<FormFieldset>
-						<FormLabel htmlFor="color_scheme">{ translate( 'Dashboard color scheme' ) }</FormLabel>
+						<FormLabel id="account__color_scheme" htmlFor="color_scheme">
+							{ translate( 'Dashboard color scheme' ) }
+						</FormLabel>
 						<ColorSchemePicker temporarySelection onSelection={ this.updateColorScheme } />
 					</FormFieldset>
 				) }

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -429,7 +429,9 @@ export class SiteSettingsFormGeneral extends Component {
 
 		return (
 			<FormFieldset>
-				<FormLabel htmlFor="blogtimezone">{ translate( 'Site timezone' ) }</FormLabel>
+				<FormLabel htmlFor="blogtimezone" id="site-settings__blogtimezone">
+					{ translate( 'Site timezone' ) }
+				</FormLabel>
 
 				<Timezone
 					selectedZone={ fields.timezone_string }
@@ -605,7 +607,10 @@ export class SiteSettingsFormGeneral extends Component {
 
 				{ ! isWPForTeamsSite && ! siteIsJetpack && (
 					<div className="site-settings__footer-credit-container">
-						<SettingsSectionHeader title={ translate( 'Footer credit' ) } />
+						<SettingsSectionHeader
+							title={ translate( 'Footer credit' ) }
+							id="site-settings__footer-credit-header"
+						/>
 						<CompactCard className="site-settings__footer-credit-explanation">
 							<p>
 								{ preventWidows(

--- a/client/my-sites/site-settings/podcasting-details/link.jsx
+++ b/client/my-sites/site-settings/podcasting-details/link.jsx
@@ -29,7 +29,10 @@ class PodcastingLink extends Component {
 
 		return (
 			<div className={ classes }>
-				<SettingsSectionHeader title={ translate( 'Podcasting' ) } />
+				<SettingsSectionHeader
+					id="podcasting-details__link-header"
+					title={ translate( 'Podcasting' ) }
+				/>
 				<Card className="podcasting-details__link-card">{ this.renderCardBody() }</Card>
 			</div>
 		);

--- a/client/my-sites/site-settings/site-tools/index.jsx
+++ b/client/my-sites/site-settings/site-tools/index.jsx
@@ -94,7 +94,7 @@ class SiteTools extends Component {
 		return (
 			<div className="site-tools">
 				<QueryRewindState siteId={ siteId } />
-				<SettingsSectionHeader title={ translate( 'Site tools' ) } />
+				<SettingsSectionHeader id="site-tools__header" title={ translate( 'Site tools' ) } />
 				{ showChangeAddress && (
 					<SiteToolsLink
 						href={ changeAddressLink }


### PR DESCRIPTION
fixes #44059

#### Changes proposed in this Pull Request

* Some inline help results will now link to specific sections of a page, now using anchors.  For example, "Delete a site or site's content":
  * Old link: `/settings/general/${ siteSlug }`
  * New link: `/settings/general/${ siteSlug }#site-tools__header`
* In some cases, `id`s needed to be added for the links to have something to go to.

#### Testing instructions

1. Click on the Help FAB
2. Type in a query - For example: `footer text`
3. Click on "Change my site's footer text" from the admin results:

![footer-text](https://user-images.githubusercontent.com/937354/89815124-ddc3b280-db09-11ea-97b6-bfaa81f66ec8.png)

4. You should be taken to `/settings/general/${ siteSlug }#site-settings__footer-credit-header`, which should scroll such that the footer section is visible.
5. All answers modified:
  * Change my site's footer text
  * Change my site's timezone
  * Launch my site
  * Delete a site or site's content
  * Set up a podcast
  * Change my site's privacy settings
  * Change the dashboard color scheme
  * Switch the interface language

In some cases, I had to add `id`s.  I namespaced them off the component, the same way our css classes are built.  Example: `site-settings__footer-credit-header`.  Some `id`s without namespaces already existed, so I used them instead of changing them.  Example: `site-privacy-settings`.


