### PR TITLE
Composite checkout: Improve styling of ebanx contact fields

### DIFF
--- a/client/my-sites/checkout/checkout/country-specific-payment-fields.jsx
+++ b/client/my-sites/checkout/checkout/country-specific-payment-fields.jsx
@@ -25,6 +25,7 @@ export class CountrySpecificPaymentFields extends Component {
 		handleFieldChange: PropTypes.func.isRequired,
 		fieldClassName: PropTypes.string,
 		disableFields: PropTypes.bool,
+		className: PropTypes.string,
 	};
 
 	static defaultProps = {
@@ -101,13 +102,14 @@ export class CountrySpecificPaymentFields extends Component {
 		this.props.handleFieldChange( event.target.name, event.target.value );
 
 	render() {
-		const { translate, countriesList, countryCode } = this.props;
+		const { translate, countriesList, countryCode, className } = this.props;
 		const { userSelectedPhoneCountryCode } = this.state;
 		const countryData = find( countriesList, { code: countryCode } );
 		const countryName = countryData && countryData.name ? countryData.name : '';
 		const containerClassName = classNames(
 			'checkout__country-payment-fields',
-			`checkout__country-${ countryCode.toLowerCase() }`
+			`checkout__country-${ countryCode.toLowerCase() }`,
+			className
 		);
 
 		return (

--- a/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/contact-fields.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/contact-fields.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import styled from '@emotion/styled';
 import { useFormStatus } from '@automattic/composite-checkout';
 
 /**
@@ -21,9 +22,9 @@ export default function ContactFields( {
 	const countriesList = useCountryList( [] );
 
 	return (
-		<div>
+		<div className="contact-fields">
 			{ shouldRenderAdditionalCountryFields( getFieldValue( 'countryCode' ) ) && (
-				<CountrySpecificPaymentFields
+				<CountrySpecificPaymentFieldsUI
 					countryCode={ getFieldValue( 'countryCode' ) }
 					countriesList={ countriesList }
 					getErrorMessage={ getErrorMessagesForField }
@@ -35,3 +36,21 @@ export default function ContactFields( {
 		</div>
 	);
 }
+
+const CountrySpecificPaymentFieldsUI = styled( CountrySpecificPaymentFields )`
+	& .document,
+	& .phone,
+	& .postal-code,
+	& .checkout__form-state-field {
+		flex-basis: auto;
+	}
+
+	& .checkout__checkout-field,
+	& .checkout__form-state-field {
+		margin-left: 0;
+	}
+
+	& .checkout__form-info-text {
+		margin-left: 0;
+	}
+`;

--- a/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/contact-fields.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/contact-fields.js
@@ -38,6 +38,12 @@ export default function ContactFields( {
 }
 
 const CountrySpecificPaymentFieldsUI = styled( CountrySpecificPaymentFields )`
+	margin-top: 0;
+
+	& .checkout__form-info-text {
+		display: none;
+	}
+
 	& .document,
 	& .phone,
 	& .postal-code,
@@ -50,7 +56,15 @@ const CountrySpecificPaymentFieldsUI = styled( CountrySpecificPaymentFields )`
 		margin-left: 0;
 	}
 
-	& .checkout__form-info-text {
+	& .checkout__form-info-text,
+	& .form__hidden-input a {
 		margin-left: 0;
+	}
+
+	@media ( ${ ( props ) => props.theme.breakpoints.bigPhoneUp } ) {
+		& .address-1,
+		& .state {
+			margin-right: 15px;
+		}
 	}
 `;

--- a/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-fields.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-fields.js
@@ -119,15 +119,6 @@ export default function CreditCardFields() {
 					disabled={ isDisabled }
 				/>
 
-				{ shouldShowContactFields && (
-					<ContactFields
-						getField={ getField }
-						getFieldValue={ getFieldValue }
-						setFieldValue={ setFieldValue }
-						getErrorMessagesForField={ getErrorMessagesForField }
-					/>
-				) }
-
 				<FieldRow>
 					<CreditCardNumberField
 						setIsStripeFullyLoaded={ setIsStripeFullyLoaded }
@@ -162,6 +153,15 @@ export default function CreditCardFields() {
 						</RightColumn>
 					</FieldRow>
 				</FieldRow>
+
+				{ shouldShowContactFields && (
+					<ContactFields
+						getField={ getField }
+						getFieldValue={ getFieldValue }
+						setFieldValue={ setFieldValue }
+						getErrorMessagesForField={ getErrorMessagesForField }
+					/>
+				) }
 			</CreditCardFieldsWrapper>
 		</StripeFields>
 	);

--- a/packages/composite-checkout/src/theme.js
+++ b/packages/composite-checkout/src/theme.js
@@ -42,6 +42,7 @@ const theme = {
 	breakpoints: {
 		desktopUp: 'min-width: 960px',
 		tabletUp: 'min-width: 700px',
+		bigPhoneUp: 'min-width: 480px',
 		smallPhoneUp: 'min-width: 400px',
 	},
 	weights: {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In https://github.com/Automattic/wp-calypso/pull/43841 we modified the credit card payment method to support showing additional contact fields within its box for specific payment partners, specifically Ebanx in Brazil. However, these contact fields are not styled to appear inside a box in this way, so they don't look very good. This PR attempts to fix those styles for composite checkout without breaking their styles in old checkout.

#### Screenshots

Before:

![Screen Shot 2020-08-10 at 2 23 08 PM](https://user-images.githubusercontent.com/2036909/89816709-08673880-db15-11ea-910a-d9b24ea68a73.png)


#### Testing instructions

- Apply D45663-code to force Ebanx to be available and sandbox the API and the store.
- Visit composite checkout with a product in the cart.
- In the contact step, choose "Brazil" for the country.
- In the payment method step, choose "Credit or debit card".
- Verify that you see additional contact fields appear below the existing fields in the same step.
- Verify that those fields look good and do not have awkward margins or spacing.