### PR TITLE
Product card: make subheadline and description optional

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card/README.md
+++ b/client/components/jetpack/card/jetpack-product-card/README.md
@@ -36,8 +36,8 @@ export default function JetpackBundleCard() {
 | `productName`\*      | `string`     | none    | Name of the product, shown as the title of the card                                        |
 | `productType`        | `string`     | none    | Product type (e.g. 'Daily', or 'Real Time'), appended to its name                          |
 | `headingLevel`       | `number`     | 2       | Heading level of the HTML element wrapping the product name                                |
-| `subheadline`\*      | `string`     | none    | Summary of the product                                                                     |
-| `description`\*      | `React.Node` | none    | Description of the product                                                                 |
+| `subheadline`        | `string`     | none    | Summary of the product                                                                     |
+| `description`        | `React.Node` | none    | Description of the product                                                                 |
 | `currencyCode`\*     | `string`     | none    | Code of the currency in which to display the price                                         |
 | `originalPrice`\*    | `number`     | none    | Price of the product                                                                       |
 | `discountedPrice`    | `number`     | none    | Discounted price of the product                                                            |

--- a/client/components/jetpack/card/jetpack-product-card/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/index.tsx
@@ -97,7 +97,9 @@ const JetpackProductCard: FunctionComponent< Props > = ( {
 								) }
 							</>
 						) }
-						<p className="jetpack-product-card__subheadline">{ preventWidows( subheadline ) }</p>
+						{ subheadline && (
+							<p className="jetpack-product-card__subheadline">{ preventWidows( subheadline ) }</p>
+						) }
 					</div>
 					<div
 						className={ classNames( 'jetpack-product-card__price', {
@@ -141,7 +143,7 @@ const JetpackProductCard: FunctionComponent< Props > = ( {
 						{ cancelLabel }
 					</Button>
 				) }
-				<p className="jetpack-product-card__description">{ description }</p>
+				{ description && <p className="jetpack-product-card__description">{ description }</p> }
 			</div>
 			<JetpackProductCardFeatures features={ features } isExpanded={ isExpanded } />
 		</div>

--- a/client/components/jetpack/card/jetpack-product-card/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/index.tsx
@@ -26,8 +26,8 @@ type OwnProps = {
 	productName: TranslateResult;
 	productType?: string;
 	headingLevel?: number;
-	subheadline: TranslateResult;
-	description: ReactNode;
+	subheadline?: TranslateResult;
+	description?: ReactNode;
 	currencyCode: string;
 	originalPrice: number;
 	discountedPrice?: number;


### PR DESCRIPTION
### Changes proposed in this Pull Request

Products don't have a description or tagline/subheadline in the current copy. This PR reflects this in the code.

### Testing instructions

- Check that you can still see the subheadline and description in the Jetpack Plan Card (`/devdocs/design/jetpack-plan-card`)

### Screenshot

![screenshot](https://user-images.githubusercontent.com/1620183/89817426-1a95a680-db16-11ea-9f7d-b9f34a253205.png)

