### PR TITLE
InlineHelp: Remove incorrect descriptions

### DIFF
--- a/client/blocks/inline-help/admin-sections.js
+++ b/client/blocks/inline-help/admin-sections.js
@@ -214,9 +214,6 @@ export const adminSections = memoize( ( siteId, siteSlug, state ) => [
 	},
 	{
 		title: translate( 'Manage sharing and social media connections' ),
-		description: translate(
-			'You can customize your website by changing the footer credit in customizer.'
-		),
 		link: `/sharing/${ siteSlug }`,
 		synonyms: [ 'facebook', 'twitter', 'twitter', 'tumblr', 'eventbrite' ],
 		icon: 'share',
@@ -232,9 +229,6 @@ export const adminSections = memoize( ( siteId, siteSlug, state ) => [
 	},
 	{
 		title: translate( 'Install, manage, and search for site Plugins' ),
-		description: translate(
-			'You can customize your website by changing the footer credit in customizer.'
-		),
 		link: `/plugins/${ siteSlug }`,
 		synonyms: [ 'upload' ],
 		icon: 'plugins',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In the InlineHelp admin sections, it looks like some descriptions related to "Change my site's footer text" were copy and pasted and not changed. 

For example, it doesn't make sense for the description for "Install, manage, and search for site Plugins" to be "You can customize your website by changing the footer credit in customizer."   I talked to @retrofox who worked on the original addition of these and he confirmed that it's not something done on purpose, and that they're okay to remove.

This removes the non-matching descriptions from the code.  Not all entries have descriptions, so it should be okay.

#### Testing instructions

There are no functional changes, so it just needs to be confirmed that the PR doesn't break existing functionality.

1. Click on the Help FAB
2. Type in a query - For example: `site plugins`
3. Confirm the answer is still listed and the link still works
![2020-08-10_13-33](https://user-images.githubusercontent.com/937354/89817624-1d8c9900-db0e-11ea-8c1a-a49dec0149ac.png)

(Found while working on #44059)