### PR TITLE
Product card: handle deprecated state

### DIFF
--- a/client/components/jetpack/card/jetpack-plan-card/README.md
+++ b/client/components/jetpack/card/jetpack-plan-card/README.md
@@ -20,8 +20,4 @@ export default function JetpackPlanCardExample() {
 
 #### Props
 
-| Name         | Type      | Default | Description                            |
-| ------------ | --------- | ------- | -------------------------------------- |
-| `deprecated` | `boolean` | `false` | Use to identify the plan as deprecated |
-
-See other props at `components/jetpack/card/jetpack-product-card`;
+See props at `components/jetpack/card/jetpack-product-card`;

--- a/client/components/jetpack/card/jetpack-plan-card/fixture/index.ts
+++ b/client/components/jetpack/card/jetpack-plan-card/fixture/index.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { noop } from 'lodash';
+import moment from 'moment';
 
 export const featuresItems = [
 	{
@@ -45,5 +46,6 @@ export const deprecatedPlanCard = {
 	badgeLabel: 'Best value',
 	discountedPrice: 80,
 	withStartingPrice: true,
-	deprecated: true,
+	isDeprecated: true,
+	expiryDate: moment( '2021-01-01' ),
 };

--- a/client/components/jetpack/card/jetpack-plan-card/index.tsx
+++ b/client/components/jetpack/card/jetpack-plan-card/index.tsx
@@ -16,17 +16,13 @@ import JetpackProductCard, {
  */
 import './style.scss';
 
-type Props = JetpackProductCardProps & {
-	deprecated?: boolean;
-};
+type Props = JetpackProductCardProps;
 
 const JetpackPlanCard: FunctionComponent< Props > = ( props ) => {
 	return (
 		<JetpackProductCard
 			{ ...props }
-			className={ classNames( props.className, 'jetpack-plan-card', {
-				'is-deprecated': props.deprecated,
-			} ) }
+			className={ classNames( props.className, 'jetpack-plan-card' ) }
 		/>
 	);
 };

--- a/client/components/jetpack/card/jetpack-plan-card/style.scss
+++ b/client/components/jetpack/card/jetpack-plan-card/style.scss
@@ -20,7 +20,7 @@
 		}
 
 		.plan-price {
-			border-color: $jetpack-deprecated-plan-card-color;
+			border-color: var( --color-text );
 		}
 
 		.jetpack-product-card__badge {

--- a/client/components/jetpack/card/jetpack-product-card/README.md
+++ b/client/components/jetpack/card/jetpack-product-card/README.md
@@ -14,8 +14,6 @@ export default function JetpackProductCardExample() {
         <JetpackProductCard
             iconSlug="jetpack_backup_v2"
             productName="Jetpack Backup"
-            subheadline=""
-            description=""
             currencyCode="USD"
             originalPrice={10}
             billingTimeFrame="per month, billed monthly"
@@ -53,3 +51,5 @@ export default function JetpackProductCardExample() {
 | `isOwned`            | `boolean`    | `false` | Use when the product is already owned or included in another product owned by the customer |
 | `features`\*         | `Features`   | none    | Features of the product                                                                    |
 | `isExpanded`         | `boolean`    | `false` | Use to expand the card and show the product features                                       |
+| `isDeprecated`       | `boolean`    | `false` | Use to identify the plan as deprecated                                                     |
+| `expiryDate`         | `Moment`     | none    | Expiry date of the product                                                                 |

--- a/client/components/jetpack/card/jetpack-product-card/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/index.tsx
@@ -4,17 +4,22 @@
 import classNames from 'classnames';
 import { useTranslate, TranslateResult } from 'i18n-calypso';
 import { isFinite, isNumber } from 'lodash';
-import moment, { Moment } from 'moment';
 import React, { createElement, useRef, FunctionComponent, ReactNode } from 'react';
 
 /**
  * Internal dependencies
  */
 import { Button, ProductIcon } from '@automattic/components';
+import { useLocalizedMoment } from 'components/localized-moment';
 import { preventWidows } from 'lib/formatting';
 import PlanPrice from 'my-sites/plan-price';
 import JetpackProductCardFeatures, { Props as FeaturesProps } from './features';
 import useFlexboxWrapDetection from './lib/use-flexbox-wrap-detection';
+
+/**
+ * Type dependencies
+ */
+import type { Moment } from 'moment';
 
 /**
  * Style dependencies
@@ -77,6 +82,7 @@ const JetpackProductCard: FunctionComponent< Props > = ( {
 	const translate = useTranslate();
 	const priceEl = useRef( null );
 	const isHeaderWrapped = useFlexboxWrapDetection( priceEl );
+	const moment = useLocalizedMoment();
 
 	const isDiscounted = isFinite( discountedPrice );
 	const parsedHeadingLevel = isNumber( headingLevel )

--- a/client/components/jetpack/card/jetpack-product-card/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/index.tsx
@@ -4,6 +4,7 @@
 import classNames from 'classnames';
 import { useTranslate, TranslateResult } from 'i18n-calypso';
 import { isFinite, isNumber } from 'lodash';
+import moment, { Moment } from 'moment';
 import React, { createElement, useRef, FunctionComponent, ReactNode } from 'react';
 
 /**
@@ -41,6 +42,8 @@ type OwnProps = {
 	onCancelClick?: () => void;
 	isHighlighted?: boolean;
 	isOwned?: boolean;
+	isDeprecated?: boolean;
+	expiryDate?: Moment;
 };
 
 export type Props = OwnProps & FeaturesProps;
@@ -66,6 +69,8 @@ const JetpackProductCard: FunctionComponent< Props > = ( {
 	onCancelClick,
 	isHighlighted,
 	isOwned,
+	isDeprecated,
+	expiryDate,
 	features,
 	isExpanded,
 } ) => {
@@ -77,9 +82,16 @@ const JetpackProductCard: FunctionComponent< Props > = ( {
 	const parsedHeadingLevel = isNumber( headingLevel )
 		? Math.min( Math.max( Math.floor( headingLevel ), 1 ), 6 )
 		: 2;
+	const parsedExpiryDate =
+		moment.isMoment( expiryDate ) && expiryDate.isValid() ? expiryDate : null;
 
 	return (
-		<div className={ classNames( className, 'jetpack-product-card', { 'is-owned': isOwned } ) }>
+		<div
+			className={ classNames( className, 'jetpack-product-card', {
+				'is-owned': isOwned,
+				'is-deprecated': isDeprecated,
+			} ) }
+		>
 			<header className="jetpack-product-card__header">
 				<ProductIcon className="jetpack-product-card__icon" slug={ iconSlug } />
 				<div className="jetpack-product-card__summary">
@@ -120,7 +132,20 @@ const JetpackProductCard: FunctionComponent< Props > = ( {
 								<PlanPrice rawPrice={ discountedPrice } discounted currencyCode={ currencyCode } />
 							) }
 						</span>
-						<span className="jetpack-product-card__billing-time-frame">{ billingTimeFrame }</span>
+						{ parsedExpiryDate ? (
+							<time
+								className="jetpack-product-card__expiration-date"
+								dateTime={ parsedExpiryDate.format( 'YYYY-DD-YY' ) }
+							>
+								{ translate( 'expires %(date)s', {
+									args: {
+										date: parsedExpiryDate.format( 'L' ),
+									},
+								} ) }
+							</time>
+						) : (
+							<span className="jetpack-product-card__billing-time-frame">{ billingTimeFrame }</span>
+						) }
 					</div>
 				</div>
 				{ badgeLabel && <div className="jetpack-product-card__badge">{ badgeLabel }</div> }

--- a/client/components/jetpack/card/jetpack-product-card/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card/style.scss
@@ -1,4 +1,4 @@
-$jetpack-product-card-color: #33b3db;
+$jetpack-product-card-color: var( --studio-wordpress-blue-30 );
 $jetpack-product-card-circle-size: 65px;
 $jetpack-product-card-icon-size: 55px;
 
@@ -122,7 +122,8 @@ $jetpack-product-card-icon-size: 55px;
 }
 
 .jetpack-product-card__from,
-.jetpack-product-card__billing-time-frame {
+.jetpack-product-card__billing-time-frame,
+.jetpack-product-card__expiration-date {
 	display: block;
 
 	color: var( --color-text-subtle );
@@ -130,6 +131,14 @@ $jetpack-product-card-icon-size: 55px;
 	font-size: $font-body-extra-small;
 	font-style: italic;
 	line-height: 1;
+}
+
+.jetpack-product-card__expiration-date {
+	margin-top: 10px;
+
+	color: var( --studio-pink-50 );
+
+	text-align: right;
 }
 
 .jetpack-product-card__from {

--- a/client/my-sites/plans-v2/plans-column/index.tsx
+++ b/client/my-sites/plans-v2/plans-column/index.tsx
@@ -67,7 +67,7 @@ const PlanComponent = ( {
 			features={ { items: [] } }
 			originalPrice={ price }
 			isOwned={ plan.owned }
-			deprecated={ plan.legacy }
+			isDeprecated={ plan.legacy }
 		/>
 	);
 };


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR adds an expiry date to the product card, and applies minor CSS updates.

### Implementation notes

- the `deprecated` prop has been renamed to `isDeprecated` to match the convention used for other props
- `isDeprecated` is now passed to `JetpackProductCard` instead of `JetpackPlanCard`, for better reusability
- the expiry date is shown using the `moment` local format for dates (i.e. `L`)

### Testing instructions

- Visit `/devdocs/design/jetpack-plan-card`
- Find the card for the deprecated plan at the bottom of the page
- Notice the stroke of the original price is now black (see screenshot)
- Check that the expiry date is displayed (see screenshot)

### Screenshots

#### Implementation
![screenshot](https://user-images.githubusercontent.com/1620183/89828764-82082200-db27-11ea-8813-cddadd9da5f0.png)


#### Mockups
<img width="503" alt="Screen Shot 2020-08-10 at 4 28 48 PM" src="https://user-images.githubusercontent.com/1620183/89828489-1cb43100-db27-11ea-94ed-708710bb41a7.png">
