### PR TITLE
Support: Add generic chat closure notices

### DIFF
--- a/client/me/concierge/shared/primary-header.js
+++ b/client/me/concierge/shared/primary-header.js
@@ -7,10 +7,8 @@ import React, { Component, Fragment } from 'react';
  * Internal dependencies
  */
 import { Card } from '@automattic/components';
-import ClosureNotice from '../shared/closure-notice';
 import FormattedHeader from 'components/formatted-header';
 import ExternalLink from 'components/external-link';
-import { easterHolidayName } from 'me/help/contact-form-notice/live-chat-closure';
 import { localize } from 'i18n-calypso';
 import { CONCIERGE_SUPPORT } from 'lib/url/support';
 
@@ -20,12 +18,6 @@ class PrimaryHeader extends Component {
 
 		return (
 			<Fragment>
-				<ClosureNotice
-					displayAt="2020-04-09 00:00Z"
-					closesAt="2020-04-12 06:00Z"
-					reopensAt="2020-04-13 06:00Z"
-					holidayName={ easterHolidayName }
-				/>
 				<Card>
 					<img
 						className="shared__info-illustration"

--- a/client/me/help/contact-form-notice/chat-covid-limited-availability.jsx
+++ b/client/me/help/contact-form-notice/chat-covid-limited-availability.jsx
@@ -1,4 +1,11 @@
 /**
+ * NOTE: This notice was created early in the COVID pandemic while we were still trying to understand
+ * the long-term impacts on support volume. I'm leaving it here in case this specific language is useful
+ * again in the future (it's already translated). But for other cases you can use the more generic
+ * <ChatReducedAvailabilityNotice /> component instead.
+ */
+
+/**
  * External dependencies
  */
 
@@ -11,7 +18,7 @@ import 'moment-timezone'; // monkey patches the existing moment.js
  */
 import ContactFormNotice from 'me/help/contact-form-notice/index';
 
-const LimitedChatAvailabilityNotice = ( { showAt, hideAt, compact } ) => {
+const ChatCovidLimitedAvailabilityNotice = ( { showAt, hideAt, compact } ) => {
 	const translate = useTranslate();
 
 	const heading = translate( 'Limited chat availability' );
@@ -36,4 +43,4 @@ const LimitedChatAvailabilityNotice = ( { showAt, hideAt, compact } ) => {
 	);
 };
 
-export default LimitedChatAvailabilityNotice;
+export default ChatCovidLimitedAvailabilityNotice;

--- a/client/me/help/contact-form-notice/chat-generic-closure.jsx
+++ b/client/me/help/contact-form-notice/chat-generic-closure.jsx
@@ -1,0 +1,71 @@
+/**
+ * External dependencies
+ */
+
+import React from 'react';
+import { translate } from 'i18n-calypso';
+import 'moment-timezone'; // monkey patches the existing moment.js
+
+/**
+ * Internal dependencies
+ */
+import ContactFormNotice from 'me/help/contact-form-notice/index';
+import { useLocalizedMoment } from 'components/localized-moment';
+
+const DATE_FORMAT = 'LLL';
+
+const ChatGenericClosureNotice = ( { compact, endsAt, showAt, startsAt } ) => {
+	const moment = useLocalizedMoment();
+
+	const currentDate = moment();
+	const guessedTimezone = moment.tz.guess();
+	const startsAtFormatted = moment.tz( startsAt, guessedTimezone ).format( DATE_FORMAT );
+	const endsAtFormatted = moment.tz( endsAt, guessedTimezone ).format( DATE_FORMAT );
+
+	let heading, message;
+
+	if ( currentDate.isBefore( startsAt ) ) {
+		heading = translate( 'Upcoming live chat closure' );
+		if ( endsAt ) {
+			message = translate( 'Live chat will be closed from %(startsAt)s until %(endsAt)s.', {
+				args: { startsAt: startsAtFormatted, endsAt: endsAtFormatted },
+			} );
+		} else {
+			message = translate( 'Live chat will be temporarily closed starting %(startsAt)s.', {
+				args: { startsAt: startsAtFormatted },
+			} );
+		}
+		message +=
+			' ' +
+			translate(
+				'If you need to get in touch during that time, you can send a message from this form and our Happiness Engineers will reply by email as quickly as we can.'
+			);
+	} else {
+		heading = translate( 'Live chat is closed' );
+		if ( endsAt ) {
+			message = translate( 'Live chat is closed until %(endsAt)s.', {
+				args: { endsAt: endsAtFormatted },
+			} );
+		} else {
+			message = translate( 'Live chat is temporarily closed.' );
+		}
+
+		message +=
+			' ' +
+			translate(
+				'If you need to get in touch, send a message from this form and our Happiness Engineers will reply by email as quickly as we can. Thank you for your patience.'
+			);
+	}
+
+	return (
+		<ContactFormNotice
+			showAt={ showAt }
+			hideAt={ endsAt }
+			heading={ heading }
+			message={ <p>{ message }</p> }
+			compact={ compact }
+		/>
+	);
+};
+
+export default ChatGenericClosureNotice;

--- a/client/me/help/contact-form-notice/chat-holiday-closure.jsx
+++ b/client/me/help/contact-form-notice/chat-holiday-closure.jsx
@@ -22,7 +22,7 @@ export const xmasHolidayName = translate( 'Christmas', {
 	context: 'Holiday name',
 } );
 
-const LiveChatClosureNotice = ( { closesAt, compact, displayAt, holidayName, reopensAt } ) => {
+const ChatHolidayClosureNotice = ( { closesAt, compact, displayAt, holidayName, reopensAt } ) => {
 	const moment = useLocalizedMoment();
 
 	const currentDate = moment();
@@ -74,4 +74,4 @@ const LiveChatClosureNotice = ( { closesAt, compact, displayAt, holidayName, reo
 	);
 };
 
-export default LiveChatClosureNotice;
+export default ChatHolidayClosureNotice;

--- a/client/me/help/contact-form-notice/chat-reduced-availability.jsx
+++ b/client/me/help/contact-form-notice/chat-reduced-availability.jsx
@@ -1,0 +1,79 @@
+/**
+ * External dependencies
+ */
+
+import React from 'react';
+import { translate } from 'i18n-calypso';
+import 'moment-timezone'; // monkey patches the existing moment.js
+
+/**
+ * Internal dependencies
+ */
+import ContactFormNotice from 'me/help/contact-form-notice/index';
+import { useLocalizedMoment } from 'components/localized-moment';
+
+const DATE_FORMAT = 'LLL';
+
+const ChatReducedAvailabilityNotice = ( { compact, endsAt, showAt, startsAt } ) => {
+	const moment = useLocalizedMoment();
+
+	const currentDate = moment();
+	const guessedTimezone = moment.tz.guess();
+	const startsAtFormatted = moment.tz( startsAt, guessedTimezone ).format( DATE_FORMAT );
+	const endsAtFormatted = moment.tz( endsAt, guessedTimezone ).format( DATE_FORMAT );
+
+	const heading = translate( 'Limited chat availability' );
+	let message;
+
+	if ( currentDate.isBefore( startsAt ) ) {
+		if ( endsAt ) {
+			message = translate(
+				'Our live chat availability may be lower than normal from %(startsAt)s until %(endsAt)s.',
+				{
+					args: { startsAt: startsAtFormatted, endsAt: endsAtFormatted },
+				}
+			);
+		} else {
+			message = translate(
+				'Our live chat availability may be lower than normal starting %(startsAt)s.',
+				{
+					args: { startsAt: startsAtFormatted },
+				}
+			);
+		}
+		message +=
+			' ' +
+			translate(
+				'If you are unable to access chat during that time, you can send a message from this form and our Happiness Engineers will reply by email as quickly as we can.'
+			);
+	} else {
+		if ( endsAt ) {
+			message = translate(
+				'Our live chat availability may be lower than normal until %(endsAt)s.',
+				{
+					args: { endsAt: endsAtFormatted },
+				}
+			);
+		} else {
+			message = translate( 'Our live chat availability may temporarily be lower than normal.' );
+		}
+
+		message +=
+			' ' +
+			translate(
+				'If you are unable to access chat, send a message from this form and our Happiness Engineers will reply by email as quickly as we can. Thank you for your patience.'
+			);
+	}
+
+	return (
+		<ContactFormNotice
+			showAt={ showAt }
+			hideAt={ endsAt }
+			heading={ heading }
+			message={ <p>{ message }</p> }
+			compact={ compact }
+		/>
+	);
+};
+
+export default ChatReducedAvailabilityNotice;

--- a/client/me/help/contact-form-notice/index.jsx
+++ b/client/me/help/contact-form-notice/index.jsx
@@ -21,7 +21,12 @@ const ContactFormNotice = ( { showAt, hideAt, heading, message, compact } ) => {
 	const moment = useLocalizedMoment();
 	const currentDate = moment();
 
-	if ( ! currentDate.isBetween( showAt, hideAt ) ) {
+	// Don't display anything if we're before showAt or after hideAt
+	if ( currentDate.isBefore( showAt ) ) {
+		return null;
+	}
+
+	if ( hideAt && currentDate.isAfter( hideAt ) ) {
 		return null;
 	}
 

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -584,9 +584,9 @@ class HelpContact extends React.Component {
 			this.contactFormPropsCompactFilter( this.getContactFormPropsVariation( supportVariation ) )
 		);
 
-		// Customers sent to Directly and Forum are not affected by live chat closures
+		// Customers sent to Directly, Forums, and Upwork are not affected by live chat closures
 		// const isUserAffectedByLiveChatClosure =
-		// 	supportVariation !== SUPPORT_DIRECTLY && supportVariation !== SUPPORT_FORUM;
+		// 	[ SUPPORT_DIRECTLY, SUPPORT_FORUM, SUPPORT_UPWORK_TICKET ].indexOf( supportVariation ) === -1;
 
 		const activeTicketCount = activeSupportTickets.length;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Primary purpose: Add a few more general-purpose notices we can put on the Contact page in case we need to close chat or know our coverage won't be up to standards (for various reasons). I'm putting these up without being used yet, so that translations can be completed on them by the time we do need them.

Also done in this PR:
- Removes an expired notice from Quick Start
- Renames a few existing notices
- Makes `hideAt` optional for `ContactFormNotice`
- Updates the `isUserAffectedByLiveChatClosure` to hide Upwork as well (I missed this when I added that new support type)

#### Testing instructions

Drop both notices [into the contact widget](https://github.com/Automattic/wp-calypso/blob/master/client/me/help/help-contact/index.jsx#L598), try both with and without `endsAt` params, and adjust your computer clock to see the various states (before closure starts, during closure, and after closure).

Fixes 791-gh-hg