### PR TITLE
Bump WordPress.com Editing Toolkit version to 1.16.

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WordPress.com Editing Toolkit
  * Description: Enhances your page creation workflow within the Block Editor.
- * Version: 1.15
+ * Version: 1.16
  * Author: Automattic
  * Author URI: https://automattic.com/wordpress-plugins/
  * License: GPLv2 or later
@@ -35,7 +35,7 @@ namespace A8C\FSE;
  *
  * @var string
  */
-define( 'PLUGIN_VERSION', '1.15' );
+define( 'PLUGIN_VERSION', '1.16' );
 
 // Always include these helper files for dotcom FSE.
 require_once __DIR__ . '/dotcom-fse/helpers.php';

--- a/apps/full-site-editing/full-site-editing-plugin/readme.txt
+++ b/apps/full-site-editing/full-site-editing-plugin/readme.txt
@@ -40,7 +40,12 @@ This plugin is experimental, so we don't provide any support for it outside of w
 
 == Changelog ==
 
-= 1.15
+= 1.16 =
+* Enable site launch flow for dev & horizon environment.
+* Premium Content: Remove Paid wording from title.
+* Premium Content: Fix duplicate Connect To Stripe message.
+
+= 1.15 =
 * Plugin display name changed to WordPress.com Editing Toolkit.
 * The donation block has been removed from the plugin.
 * Add a launch sidebar to the editor to walk the user through the launch flows.

--- a/apps/full-site-editing/package.json
+++ b/apps/full-site-editing/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/full-site-editing",
-	"version": "1.15.0",
+	"version": "1.16.0",
 	"description": "Plugin for editing-related features.",
 	"sideEffects": true,
 	"repository": {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Bumps version of the editing toolkit to 1.16.

New Release notes:

* Enable site launch flow for dev & horizon environment.
* Premium Content: Remove Paid wording from title.
* Premium Content: Fix duplicate Connect To Stripe message.

Changes included in this release:
https://github.com/Automattic/wp-calypso/pull/44476
https://github.com/Automattic/wp-calypso/pull/44638
https://github.com/Automattic/wp-calypso/pull/44551
https://github.com/Automattic/wp-calypso/pull/43312
https://github.com/Automattic/wp-calypso/pull/44659
https://github.com/Automattic/wp-calypso/pull/44708
https://github.com/Automattic/wp-calypso/pull/44748
https://github.com/Automattic/wp-calypso/pull/44768
https://github.com/Automattic/wp-calypso/pull/44821

See also:
https://github.com/Automattic/wp-calypso/commits/master/apps/full-site-editing

#### Testing instructions

* To be updated.

