### PR TITLE
Deduplicate react-resize-aware

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -23153,12 +23153,7 @@ react-redux@^7.2.0:
     prop-types "^15.7.2"
     react-is "^16.9.0"
 
-react-resize-aware@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/react-resize-aware/-/react-resize-aware-3.0.0.tgz#fee9e1c61ac5bb2dd87c59e03703070d01601269"
-  integrity sha512-UyLk1KNbFHDye9AFLyr7HBGmzkRDGz2mYp6LDS+LCxM6DXGpviwS5Q4JRzXWdw0tk+n46UE/Kotku/cb8HCh0Q==
-
-react-resize-aware@^3.0.1:
+react-resize-aware@^3.0.0, react-resize-aware@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/react-resize-aware/-/react-resize-aware-3.0.1.tgz#39d6f264ad3b85dec461a5e04d9760860d14f44c"
   integrity sha512-HdPzwdcAv+BMFQEgyacFB40G4IxNMO7tSqaMjbnAouot8LXi5/Rx3/Fv+LU2cQekqiivE1LF4sGnwQ7SnoHrpg==


### PR DESCRIPTION
### Background

The library `react-resize-aware` is duplicated in our final bundle:

```
WARNING in react-resize-aware
  Multiple versions of react-resize-aware found:
    3.0.0 /Users/sergio/src/automattic/wp-calypso/packages/react-i18n/~/react-resize-aware
    3.0.1 /Users/sergio/src/automattic/wp-calypso/~/react-resize-aware
```

### Changes proposed in this Pull Request

* Deduplicate `react-resize-aware` (done automatically with `npx yarn-deduplicate --packages react-resize-aware`)

[Changelog](https://github.com/FezVrasta/react-resize-aware/releases/tag/v3.0.1)

### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
< Before
> After
---
< wp-calypso@0.17.0 -> @automattic/composite-checkout@1.0.0 -> ... -> react-resize-aware@3.0.0
< wp-calypso@0.17.0 -> @automattic/full-site-editing@1.15.0 -> ... -> react-resize-aware@3.0.0
< wp-calypso@0.17.0 -> @automattic/notifications@1.0.0 -> ... -> react-resize-aware@3.0.0
< wp-calypso@0.17.0 -> @automattic/react-i18n@1.0.0-alpha.0 -> ... -> react-resize-aware@3.0.0
< wp-calypso@0.17.0 -> wp-calypso-client@0.17.0 -> ... -> react-resize-aware@3.0.0
> wp-calypso@0.17.0 -> @automattic/composite-checkout@1.0.0 -> ... -> react-resize-aware@3.0.1
> wp-calypso@0.17.0 -> @automattic/full-site-editing@1.15.0 -> ... -> react-resize-aware@3.0.1
> wp-calypso@0.17.0 -> @automattic/notifications@1.0.0 -> ... -> react-resize-aware@3.0.1
> wp-calypso@0.17.0 -> @automattic/react-i18n@1.0.0-alpha.0 -> ... -> react-resize-aware@3.0.1
> wp-calypso@0.17.0 -> wp-calypso-client@0.17.0 -> ... -> react-resize-aware@3.0.1
```