### PR TITLE
Gutenboarding: V2 Onboarding

### DIFF
--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -4,6 +4,8 @@
 import * as React from 'react';
 import classnames from 'classnames';
 import { useI18n } from '@automattic/react-i18n';
+import { sprintf } from '@wordpress/i18n';
+import { useDebounce } from 'use-debounce';
 import { Icon, wordpress } from '@wordpress/icons';
 import { useSelect } from '@wordpress/data';
 
@@ -28,21 +30,52 @@ const Header: React.FunctionComponent = () => {
 
 	const { domain, siteTitle } = useSelect( ( select ) => select( ONBOARD_STORE ).getState() );
 
+	const [ domainSearch ] = useDebounce( siteTitle, 1000 /*ms*/ );
+
+	const recommendedDomain = useSelect(
+		( select ) => {
+			if ( ! domainSearch || domainSearch.length < 2 ) {
+				return;
+			}
+			return select( 'automattic/domains/suggestions' ).getDomainSuggestions( domainSearch, {
+				// Avoid `only_wordpressdotcom` — it seems to fail to find results sometimes
+				include_wordpressdotcom: false,
+				include_dotblogsubdomain: false,
+				quantity: 1, // this will give the recommended domain only
+				locale: i18nLocale,
+			} );
+		},
+		[ domainSearch ]
+	)?.[ 0 ];
+
+	const getDomainElementContent = () => {
+		// If no site title entered (user skips intent gathering)
+		// and no domain was selected, show "Pick a domain"
+		if ( ! siteTitle && ! domain ) {
+			return null;
+		}
+
+		if ( recommendedDomain && ! domain ) {
+			/* translators: domain name is available, eg: "yourname.com is available" */
+			return sprintf( __( '%s is available' ), recommendedDomain.domain_name );
+		}
+
+		return __( 'Choose a domain' );
+	};
+
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
-	const domainElement = domain ? (
-		domain.domain_name
-	) : (
-		<span className="gutenboarding__header-domain-picker-button-domain">
-			{ __( 'Choose a domain' ) }
-		</span>
-	);
+	const domainElement = domain
+		? domain.domain_name
+		: getDomainElementContent() && (
+				<span className="gutenboarding__header-domain-picker-button-domain">
+					{ getDomainElementContent() }
+				</span>
+		  );
 
 	const hideFullHeader = [
 		'IntentGathering',
 		'Domains',
 		'DomainsModal',
-		'Plans',
-		'PlansModal',
 		'LanguageModal',
 		'CreateSite',
 	].includes( currentStep );

--- a/client/landing/gutenboarding/hooks/use-show-vertical-input.ts
+++ b/client/landing/gutenboarding/hooks/use-show-vertical-input.ts
@@ -1,0 +1,24 @@
+/**
+ * External dependencies
+ */
+import { useSelect, useDispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { STORE_KEY } from '../stores/onboard';
+import { useVerticalQueryParam } from '../path';
+
+export function useShowVerticalInput() {
+	const hasVerticalQueryParam = useVerticalQueryParam();
+
+	const { showVerticalInput } = useDispatch( STORE_KEY );
+
+	if ( hasVerticalQueryParam ) {
+		showVerticalInput( true );
+	}
+
+	const { shouldShowVerticalInput } = useSelect( ( select ) => select( STORE_KEY ).getState() );
+
+	return hasVerticalQueryParam || shouldShowVerticalInput;
+}

--- a/client/landing/gutenboarding/hooks/use-step-navigation.ts
+++ b/client/landing/gutenboarding/hooks/use-step-navigation.ts
@@ -27,14 +27,8 @@ export default function useStepNavigation(): { goBack: () => void; goNext: () =>
 	const makePath = usePath();
 	const history = useHistory();
 	const currentStep = useCurrentStep();
-	const siteTitle = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedSiteTitle() );
 	const { i18nLocale } = useI18n();
-	// If the user enters a site title on Intent Capture step we are showing Domains step next.
-	// Else, we're showing Domains step before Plans step.
-	let steps =
-		siteTitle?.length > 1
-			? [ Step.IntentGathering, Step.Domains, Step.DesignSelection, Step.Style, Step.Plans ]
-			: [ Step.IntentGathering, Step.DesignSelection, Step.Style, Step.Domains, Step.Plans ];
+	let steps = [ Step.IntentGathering, Step.DesignSelection, Step.Style, Step.Plans ];
 
 	// @TODO: move site creation to a separate hook or an action on the ONBOARD store
 	const currentUser = useSelect( ( select ) => select( USER_STORE ).getCurrentUser() );
@@ -47,14 +41,9 @@ export default function useStepNavigation(): { goBack: () => void; goNext: () =>
 			: onSignupDialogOpen();
 
 	// Logic necessary to skip Domains or Plans steps
-	const { domain, hasUsedDomainsStep, hasUsedPlansStep } = useSelect( ( select ) =>
-		select( ONBOARD_STORE ).getState()
-	);
+	const { hasUsedPlansStep } = useSelect( ( select ) => select( ONBOARD_STORE ).getState() );
 	const plan = useSelect( ( select ) => select( ONBOARD_STORE ).getPlan() );
 
-	if ( domain && ! hasUsedDomainsStep ) {
-		steps = steps.filter( ( step ) => step !== Step.Domains );
-	}
 	if ( plan && ! hasUsedPlansStep ) {
 		steps = steps.filter( ( step ) => step !== Step.Plans );
 	}

--- a/client/landing/gutenboarding/lib/analytics/index.ts
+++ b/client/landing/gutenboarding/lib/analytics/index.ts
@@ -143,6 +143,13 @@ export function recordSiteTitleSelection( hasValue: boolean ) {
 }
 
 /**
+ * Records site topic input skip on Intent Gathering step
+ */
+export function recordVerticalSkip() {
+	trackEventWithFlow( 'calypso_newsite_vertical_skipped' );
+}
+
+/**
  * Records site title input skip on Intent Gathering step
  */
 export function recordSiteTitleSkip() {

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/acquire-intent-text-input/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/acquire-intent-text-input/index.tsx
@@ -1,0 +1,110 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import classnames from 'classnames';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+interface Props {
+	value: string;
+	onChange: ( value: string ) => void;
+	onFocus?: () => void;
+	onBlur?: () => void;
+	onKeyDown?: ( event: React.KeyboardEvent< HTMLInputElement > ) => void;
+	onKeyUp?: ( event: React.KeyboardEvent< HTMLInputElement > ) => void;
+	autoFocus?: boolean;
+	placeholder?: string;
+	id?: string;
+	forwardedRef: React.MutableRefObject< HTMLInputElement | undefined >;
+}
+
+/**
+ * A canvas to use to create text and measure its width.
+ * This is needed for the underline width.
+ */
+const textSizingCanvas = document.createElement( 'canvas' );
+textSizingCanvas.width = textSizingCanvas.height = 2000;
+const canvasContext = textSizingCanvas.getContext( '2d' ) as CanvasRenderingContext2D;
+
+/**
+ * Gets the font info from an input field then measures the width of the text within
+ *
+ * @param text the string
+ * @param element The input element
+ */
+function getTextWidth( text: string, element: HTMLInputElement | undefined ) {
+	if ( ! element ) {
+		return 0;
+	}
+	const computedCSS = window.getComputedStyle( element );
+
+	// FF returns an empty strong in font prop
+	canvasContext.font = computedCSS.font || `${ computedCSS.fontSize } ${ computedCSS.fontFamily }`;
+	return canvasContext.measureText( text ).width;
+}
+
+const AcquireIntentTextInput: React.FunctionComponent< Props > = ( {
+	value,
+	onChange,
+	onFocus,
+	onBlur,
+	autoFocus,
+	placeholder,
+	onKeyDown,
+	onKeyUp,
+	id,
+	forwardedRef,
+} ) => {
+	const defaultRef = React.useRef< HTMLInputElement >();
+	const ref = ( forwardedRef || defaultRef ) as React.MutableRefObject< HTMLInputElement >;
+
+	const underlineWidth = getTextWidth( value || '', ref.current );
+
+	const handleChange = ( event: React.ChangeEvent< HTMLInputElement > ) => {
+		onChange?.( event.target.value );
+	};
+
+	return (
+		<div className="acquire-intent-text-input__wrapper">
+			<input
+				key="acquire-intent__input"
+				className={ classnames( 'acquire-intent-text-input__input', {
+					'is-empty': ! ( value as string ).length,
+				} ) }
+				id={ id }
+				ref={ ref }
+				autoComplete="off"
+				autoCorrect="off"
+				onChange={ handleChange }
+				data-hj-whitelist
+				spellCheck={ false }
+				value={ value }
+				onFocus={ onFocus }
+				onBlur={ onBlur }
+				onKeyDown={ onKeyDown }
+				onKeyUp={ onKeyUp }
+				autoFocus={ autoFocus } // eslint-disable-line jsx-a11y/no-autofocus
+				placeholder={ placeholder }
+			/>
+			<div
+				className={ classnames( 'acquire-intent-text-input__underline', {
+					'is-empty': ! ( value as string ).length,
+				} ) }
+				style={ { width: underlineWidth || '100%' } }
+			></div>
+		</div>
+	);
+};
+
+export default React.forwardRef< HTMLInputElement, Omit< Props, 'forwardedRef' > >(
+	( props, ref ) => (
+		<AcquireIntentTextInput
+			{ ...props }
+			forwardedRef={ ref as React.MutableRefObject< HTMLInputElement | undefined > }
+		/>
+	)
+);

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/acquire-intent-text-input/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/acquire-intent-text-input/style.scss
@@ -1,0 +1,64 @@
+@import '../../../variables.scss';
+@import '../../../mixins';
+
+.acquire-intent-text-input__wrapper {
+	display: block;
+}
+
+.acquire-intent-text-input__input {
+	width: 100%;
+
+	@include onboarding-heading-text-mobile;
+	height: auto;
+	background: transparent;
+	border: none;
+	padding: 0;
+	color: var( --mainColor );
+	caret-color: var( --mainColor );
+
+	&:focus {
+		box-shadow: none;
+		outline: none;
+	}
+
+	&::-ms-clear {
+		display: none;
+	}
+
+	@include break-small {
+		@include onboarding-heading-text;
+	}
+
+	@include break-medium {
+		font-size: 64px;
+	}
+
+	&::placeholder {
+		color: $light-gray-700;
+		line-height: normal;
+	}
+
+	&::-ms-clear {
+		display: none;
+	}
+}
+
+.acquire-intent-text-input__underline {
+	height: 2px;
+	background: var( --mainColor );
+	margin-top: -5px;
+	max-width: 100%;
+
+	@include break-medium {
+		margin-top: -12px;
+	}
+
+	&.is-empty {
+		max-width: 550px;
+		background: linear-gradient(
+			90deg,
+			$light-gray-700 0%,
+			lighten( $light-gray-700, 10% ) 100%
+		);
+	}
+}

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
@@ -12,11 +12,12 @@ import { useI18n } from '@automattic/react-i18n';
  * Internal dependencies
  */
 import { STORE_KEY } from '../../stores/onboard';
-import { Step, usePath, useVerticalQueryParam } from '../../path';
+import { Step, usePath } from '../../path';
 import Link from '../../components/link';
 import VerticalSelect from './vertical-select';
 import SiteTitle from './site-title';
 import { useTrackStep } from '../../hooks/use-track-step';
+import { useShowVerticalInput } from '../../hooks/use-show-vertical-input';
 import { recordVerticalSkip, recordSiteTitleSkip } from '../../lib/analytics';
 import Arrow from './arrow';
 
@@ -103,11 +104,11 @@ const AcquireIntent: React.FunctionComponent = () => {
 
 	const siteVertical = getSelectedVertical();
 
-	const shouldShowVerticalInput = useVerticalQueryParam();
+	const showVerticalInput = useShowVerticalInput();
 
 	return (
 		<div className="gutenboarding-page acquire-intent">
-			{ shouldShowVerticalInput ? (
+			{ showVerticalInput ? (
 				<>
 					{ isMobile &&
 						( isSiteTitleActive ? (

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
@@ -2,19 +2,23 @@
  * External dependencies
  */
 import * as React from 'react';
-import classnames from 'classnames';
+import { useHistory } from 'react-router-dom';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { NextButton, SkipButton } from '@automattic/onboarding';
+import { useViewportMatch } from '@wordpress/compose';
+import { Button } from '@wordpress/components';
+import { useI18n } from '@automattic/react-i18n';
 
 /**
  * Internal dependencies
  */
 import { STORE_KEY } from '../../stores/onboard';
+import { Step, usePath } from '../../path';
+import Link from '../../components/link';
+import VerticalSelect from './vertical-select';
 import SiteTitle from './site-title';
 import { useTrackStep } from '../../hooks/use-track-step';
-import useStepNavigation from '../../hooks/use-step-navigation';
-import { prefetchDesignThumbs } from '../../available-designs';
-import { recordSiteTitleSkip } from '../../lib/analytics';
+import { recordVerticalSkip, recordSiteTitleSkip } from '../../lib/analytics';
+import Arrow from './arrow';
 
 /**
  * Style dependencies
@@ -22,43 +26,111 @@ import { recordSiteTitleSkip } from '../../lib/analytics';
 import './style.scss';
 
 const AcquireIntent: React.FunctionComponent = () => {
-	const { getSelectedSiteTitle } = useSelect( ( select ) => select( STORE_KEY ) );
-	const { setSiteTitle, setDomainSearch } = useDispatch( STORE_KEY );
+	const { __ } = useI18n();
+	const { getSelectedVertical, getSelectedSiteTitle, wasVerticalSkipped } = useSelect( ( select ) =>
+		select( STORE_KEY )
+	);
 
-	const { goNext } = useStepNavigation();
+	const siteTitleRef = React.useRef< HTMLInputElement >();
+
+	const { skipSiteVertical } = useDispatch( STORE_KEY );
+
+	const history = useHistory();
+	const makePath = usePath();
+	const nextStepPath = makePath( Step.DesignSelection );
+
+	const [ isSiteTitleActive, setIsSiteTitleActive ] = React.useState( false );
+
+	const isMobile = useViewportMatch( 'small', '<' );
 
 	useTrackStep( 'IntentGathering', () => ( {
+		selected_vertical_slug: getSelectedVertical()?.slug,
+		selected_vertical_label: getSelectedVertical()?.label,
 		has_selected_site_title: !! getSelectedSiteTitle(),
 	} ) );
 
-	const hasSiteTitle = getSelectedSiteTitle()?.trim().length > 1; // for domain results, we need at least 2 characters
+	const hasSiteTitle = !! getSelectedSiteTitle();
+	const showSiteTitleAndNext = !! ( getSelectedVertical() || hasSiteTitle || wasVerticalSkipped() );
 
-	React.useEffect( prefetchDesignThumbs, [] );
-
-	const handleContinue = () => {
-		hasSiteTitle && setDomainSearch( getSelectedSiteTitle() );
-		goNext();
-	};
+	// translators: Button label for skipping filling an optional input in onboarding
+	const skipLabel = __( 'I donʼt know' );
 
 	const handleSkip = () => {
-		setSiteTitle( '' ); // reset site title if there is no valid entry
-		recordSiteTitleSkip();
-		handleContinue();
+		skipSiteVertical();
+		recordVerticalSkip();
+		setIsSiteTitleActive( true );
 	};
 
-	return (
-		<div
-			className={ classnames( 'gutenboarding-page acquire-intent', {
-				'acquire-intent--with-skip': ! hasSiteTitle,
-			} ) }
+	const onNext = () => {
+		if ( isMobile ) {
+			window.scrollTo( 0, 0 );
+		}
+		setIsSiteTitleActive( true );
+		siteTitleRef.current?.focus();
+	};
+
+	const handleSiteTitleSubmit = () => {
+		history.push( nextStepPath );
+		! hasSiteTitle && recordSiteTitleSkip();
+	};
+
+	// declare UI elements here to avoid duplication when returning for mobile/desktop layouts
+	const verticalSelect = <VerticalSelect onNext={ onNext } />;
+	const siteTitleInput = showSiteTitleAndNext && (
+		<SiteTitle inputRef={ siteTitleRef } onSubmit={ handleSiteTitleSubmit } />
+	);
+	const nextStepButton = (
+		<Link
+			className="acquire-intent__question-skip"
+			isPrimary
+			onClick={ () => ! hasSiteTitle && recordSiteTitleSkip() }
+			to={ nextStepPath }
 		>
-			<SiteTitle onSubmit={ handleContinue } />
-			<div className="acquire-intent__footer">
-				{ hasSiteTitle ? (
-					<NextButton onClick={ handleContinue } />
+			{ hasSiteTitle ? __( 'Choose a design' ) : skipLabel }
+		</Link>
+	);
+	const skipButton = (
+		<Button isLink onClick={ handleSkip } className="acquire-intent__skip-vertical">
+			{ skipLabel }
+		</Button>
+	);
+
+	const siteVertical = getSelectedVertical();
+
+	return (
+		<div className="gutenboarding-page acquire-intent">
+			{ isMobile &&
+				( isSiteTitleActive ? (
+					<div>
+						<Arrow
+							className="acquire-intent__mobile-back-arrow"
+							onClick={ () => setIsSiteTitleActive( false ) }
+							transform="rotate(180)"
+						/>
+						{ siteTitleInput }
+					</div>
 				) : (
-					<SkipButton onClick={ handleSkip } />
-				) }
+					verticalSelect
+				) ) }
+			{ ! isMobile && (
+				<>
+					{ ! wasVerticalSkipped() && verticalSelect }
+					{ siteTitleInput }
+				</>
+			) }
+			<div className="acquire-intent__footer">
+				{ /* On mobile we render skipButton on vertical step when there is no vertical with more than 2 characters selected which is the
+				case when we render the Next arrow button next to the input. On site title step we always render nextStepButton */ }
+				{ isMobile &&
+					( isSiteTitleActive
+						? nextStepButton
+						: ( ( ! siteVertical || siteVertical?.label?.length < 3 ) && skipButton ) || (
+								<Arrow className="acquire-intent__mobile-next-arrow" onClick={ onNext } />
+						  ) ) }
+
+				{ /* On desktop we always render nextStepButton when we render site title
+				Otherwise we render skipButton  */ }
+				{ ! isMobile && ( showSiteTitleAndNext ? nextStepButton : skipButton ) }
 			</div>
 		</div>
 	);

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
@@ -15,7 +15,7 @@ import { recordSiteTitleSelection } from '../../lib/analytics';
 import tip from './tip';
 import AcquireIntentTextInput from './acquire-intent-text-input';
 import useTyper from '../../hooks/use-typer';
-import { useVerticalQueryParam } from '../../path';
+import { useShowVerticalInput } from '../../hooks/use-show-vertical-input';
 
 interface Props {
 	onSubmit: () => void;
@@ -27,6 +27,7 @@ const SiteTitle: React.FunctionComponent< Props > = ( { onSubmit, inputRef } ) =
 	const { siteTitle } = useSelect( ( select ) => select( STORE_KEY ).getState() );
 	const { setSiteTitle } = useDispatch( STORE_KEY );
 	const [ isTouched, setIsTouched ] = React.useState( false );
+	const showVerticalInput = useShowVerticalInput();
 	const siteTitleExamples = [
 		/* translators: This is an example of a site name,
 		   feel free to create your own but please keep it under 22 characters */
@@ -83,10 +84,8 @@ const SiteTitle: React.FunctionComponent< Props > = ( { onSubmit, inputRef } ) =
 		setIsTouched( true );
 	};
 
-	const shouldShowVerticalInput = useVerticalQueryParam();
-
 	// translators: label for site title input in Gutenboarding
-	const inputLabel = shouldShowVerticalInput ? __( "It's called" ) : __( 'My site is called' );
+	const inputLabel = showVerticalInput ? __( "It's called" ) : __( 'My site is called' );
 
 	const placeHolder = useTyper( siteTitleExamples, ! siteTitle, {
 		delayBetweenCharacters: 70,

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
@@ -14,8 +14,8 @@ import { STORE_KEY } from '../../stores/onboard';
 import { recordSiteTitleSelection } from '../../lib/analytics';
 import tip from './tip';
 import AcquireIntentTextInput from './acquire-intent-text-input';
-
 import useTyper from '../../hooks/use-typer';
+import { useVerticalQueryParam } from '../../path';
 
 interface Props {
 	onSubmit: () => void;
@@ -83,8 +83,10 @@ const SiteTitle: React.FunctionComponent< Props > = ( { onSubmit, inputRef } ) =
 		setIsTouched( true );
 	};
 
+	const shouldShowVerticalInput = useVerticalQueryParam();
+
 	// translators: label for site title input in Gutenboarding
-	const inputLabel = __( "It's called" );
+	const inputLabel = shouldShowVerticalInput ? __( "It's called" ) : __( 'My site is called' );
 
 	const placeHolder = useTyper( siteTitleExamples, ! siteTitle, {
 		delayBetweenCharacters: 70,

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
@@ -3,7 +3,6 @@
  */
 import * as React from 'react';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { TextControl } from '@wordpress/components';
 import { useI18n } from '@automattic/react-i18n';
 import { Icon } from '@wordpress/icons';
 import classnames from 'classnames';
@@ -14,13 +13,16 @@ import classnames from 'classnames';
 import { STORE_KEY } from '../../stores/onboard';
 import { recordSiteTitleSelection } from '../../lib/analytics';
 import tip from './tip';
+import AcquireIntentTextInput from './acquire-intent-text-input';
 
 import useTyper from '../../hooks/use-typer';
+
 interface Props {
 	onSubmit: () => void;
+	inputRef: React.MutableRefObject< HTMLInputElement | undefined >;
 }
 
-const SiteTitle: React.FunctionComponent< Props > = ( { onSubmit } ) => {
+const SiteTitle: React.FunctionComponent< Props > = ( { onSubmit, inputRef } ) => {
 	const { __, _x } = useI18n();
 	const { siteTitle } = useSelect( ( select ) => select( STORE_KEY ).getState() );
 	const { setSiteTitle } = useDispatch( STORE_KEY );
@@ -82,7 +84,7 @@ const SiteTitle: React.FunctionComponent< Props > = ( { onSubmit } ) => {
 	};
 
 	// translators: label for site title input in Gutenboarding
-	const inputLabel = __( 'My site is called' );
+	const inputLabel = __( "It's called" );
 
 	const placeHolder = useTyper( siteTitleExamples, ! siteTitle, {
 		delayBetweenCharacters: 70,
@@ -101,21 +103,16 @@ const SiteTitle: React.FunctionComponent< Props > = ( { onSubmit } ) => {
 					because without it the element is recreated
 					for every letter in the typing animation
 					*/ }
-				<TextControl
+				<AcquireIntentTextInput
+					ref={ inputRef as React.MutableRefObject< HTMLInputElement | null > }
 					key="site-title__input"
-					id="site-title__input"
-					className="site-title__input"
 					onChange={ setSiteTitle }
 					onFocus={ handleFocus }
 					onBlur={ handleBlur }
 					value={ siteTitle }
 					autoFocus // eslint-disable-line jsx-a11y/no-autofocus
-					spellCheck={ false }
-					autoComplete="off"
 					placeholder={ placeHolder }
-					autoCorrect="off"
-					data-hj-whitelist
-				></TextControl>
+				></AcquireIntentTextInput>
 				<p className="site-title__input-hint">
 					<Icon icon={ tip } size={ 18 } />
 					{ /* translators: The "it" here refers to the site title. */ }

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
@@ -48,19 +48,16 @@
 .site-title__input-wrapper {
 	position: relative;
 	flex: 1;
-	height: 42px;
-	margin-top: 10px;
 
 	@include break-small {
 		margin-top: 0;
 		min-width: 300px;
 		max-width: 400px;
-		height: 57px;
 	}
 
 	@include break-medium {
-		height: 80px;
 		max-width: 750px;
+		margin-top: 20px;
 	}
 }
 
@@ -72,6 +69,11 @@
 	line-height: 14px;
 	opacity: 0;
 	transition: opacity $acquire-intent-transition-duration $acquire-intent-transition-algorithm;
+	margin-top: 10px;
+
+	@include break-medium {
+		margin-top: 15px;
+	}
 
 	.site-title.is-touched & {
 		opacity: 1;
@@ -93,69 +95,14 @@
 	@include break-small {
 		justify-content: flex-start;
 	}
-}
 
-.acquire-intent--with-skip {
-	.site-title__input::after {
-		background-image: linear-gradient( to right, $light-gray-700, $gray-100 );
-	}
-}
-
-.site-title__input {
-	height: 100%;
-	margin-bottom: 10px;
-
-	&::after {
-		content: '';
-		position: absolute;
-		left: 0;
-		right: 0;
-		bottom: 1px;
-		height: 2px;
-		background: var( --mainColor );
-
-		@include break-small {
-			bottom: 4px;
-		}
-	}
-
-	& > div {
-		height: 100%;
-	}
-
-	input[type='text'].components-text-control__input {
-		@include onboarding-heading-text-mobile;
-		height: auto;
-		background: transparent;
-		border: none;
+	.components-button.acquire-intent__skip-vertical.is-link {
 		padding: 0;
-		color: var( --mainColor );
-		caret-color: var( --mainColor );
-
-		&:focus {
-			box-shadow: none;
-			outline: none;
-		}
-
-		&::-ms-clear {
-			display: none;
-		}
-
-		@include break-small {
-			@include onboarding-heading-text;
-		}
-
-		@include break-medium {
-			font-size: 64px;
-		}
-
-		&::placeholder {
-			color: $light-gray-700;
-			line-height: normal;
-		}
-
-		&::-ms-clear {
-			display: none;
-		}
+		color: $dark-gray-600;
 	}
+}
+
+.acquire-intent__mobile-vertical-input {
+	display: flex;
+	flex-wrap: wrap;
 }

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
@@ -100,6 +100,25 @@
 		padding: 0;
 		color: $dark-gray-600;
 	}
+
+	// Applies to both
+	// - .components-button.acquire-intent__skip-vertical
+	// - .components-button.acquire-intent__question-skip
+	.components-button.is-secondary {
+		color: var( --studio-gray-50 );
+		box-shadow: inset 0 0 0 1px var( --studio-gray-50 );
+
+		&:active,
+		&:hover {
+			color: var( --studio-gray-60 );
+			box-shadow: inset 0 0 0 1px var( --studio-gray-60 );
+		}
+
+		&:focus {
+			color: var( --studio-gray-60 );
+			box-shadow: inset 0 0 0 1px #fff, 0 0 0 1.5px var( --highlightColor );
+		}
+	}
 }
 
 .acquire-intent__mobile-vertical-input {

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
@@ -1,0 +1,224 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { remove } from 'lodash';
+import classnames from 'classnames';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { ENTER, TAB } from '@wordpress/keycodes';
+import { useViewportMatch } from '@wordpress/compose';
+import { Suggestions } from '@automattic/components';
+import { useI18n } from '@automattic/react-i18n';
+import AcquireIntentTextInput from '../acquire-intent-text-input';
+
+/**
+ * Internal dependencies
+ */
+import { STORE_KEY as ONBOARD_STORE } from '../../../stores/onboard';
+import { Verticals } from '@automattic/data-stores';
+import useTyper from '../../../hooks/use-typer';
+import { recordVerticalSelection } from '../../../lib/analytics';
+import type { SiteVertical } from '../../../stores/onboard/types';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+type Suggestion = SiteVertical & { category?: string };
+
+const VERTICALS_STORE = Verticals.register();
+
+interface Props {
+	onNext: () => void;
+}
+
+const VerticalSelect: React.FunctionComponent< Props > = ( { onNext } ) => {
+	const { __ } = useI18n();
+	const [ isFocused, setIsFocused ] = React.useState< boolean >( false );
+	const [ suggestions, setSuggestions ] = React.useState< Suggestion[] >( [] );
+	const [ textValue, setTextValue ] = React.useState< string >( '' );
+
+	/**
+	 * Ref to the <Suggestions />, necessary for handling input events
+	 *
+	 * This ref is effectively `any` and should therefore be considered _dangerous_.
+	 *
+	 * TODO: This should be a typed ref to Suggestions, but the component is not typed.
+	 *
+	 * Using `Suggestions` here would effectively be `any`.
+	 */
+	const suggestionRef = React.createRef< any >();
+
+	const verticals = useSelect( ( select ) =>
+		select( VERTICALS_STORE )
+			.getVerticals()
+			.map( ( x ) => ( {
+				label: x.vertical_name,
+				id: x.vertical_id,
+				slug: x.vertical_slug,
+			} ) )
+	);
+
+	const { siteVertical } = useSelect( ( select ) => select( ONBOARD_STORE ).getState() );
+	const { setSiteVertical, resetSiteVertical } = useDispatch( ONBOARD_STORE );
+	const isMobile = useViewportMatch( 'small', '<' );
+
+	const inputText = textValue ?? '';
+	const isInputEmpty = ! textValue.length;
+
+	const animatedPlaceholder = useTyper(
+		[
+			/* translators: Input placeholder content, e.g. "My site is about [[ photography ]]" */
+			__( 'photography' ),
+			/* translators: Input placeholder content, e.g. "My site is about [[ blogging ]]" */
+			__( 'blogging' ),
+			/* translators: Input placeholder content, e.g. "My site is about [[ travel ]]" */
+			__( 'travel' ),
+			/* translators: Input placeholder content, e.g. "My site is about [[ marketing ]]" */
+			__( 'marketing' ),
+			/* translators: Input placeholder content, e.g. "My site is about [[ fashion ]]" */
+			__( 'fashion' ),
+			/* translators: Input placeholder content, e.g. "My site is about [[ shopping ]]" */
+			__( 'shopping' ),
+			/* translators: Input placeholder content, e.g. "My site is about [[ design ]]" */
+			__( 'design' ),
+			/* translators: Input placeholder content, e.g. "My site is about [[ real estate ]]" */
+			__( 'real estate' ),
+			/* translators: Input placeholder content, e.g. "My site is about [[ food ]]" */
+			__( 'food' ),
+			/* translators: Input placeholder content, e.g. "My site is about [[ sports ]]" */
+			__( 'sports' ),
+		],
+		isInputEmpty,
+		{ delayBetweenWords: 800, delayBetweenCharacters: 110 }
+	);
+
+	const updateSuggestions = ( inputValue: string ) => {
+		if ( inputValue.length < 3 ) {
+			setSuggestions( [] );
+			return;
+		}
+
+		const normalizedInputValue = inputValue.toLowerCase();
+
+		// TODO: write a more advanced compare fn https://github.com/Automattic/wp-calypso/pull/40645#discussion_r402156751
+		const newSuggestions = verticals.filter( ( vertical ) =>
+			vertical.label.toLowerCase().includes( normalizedInputValue )
+		);
+
+		// Does the verticals list include an exact match?
+		// If yes, we store it in firstSuggestion (for later use), and remove it from newSuggestions...
+		const firstSuggestion = remove(
+			newSuggestions,
+			( suggestion ) => suggestion.label.toLowerCase() === normalizedInputValue
+		)[ 0 ] ?? {
+			// ...otherwise, we set firstSuggestion to the user-supplied vertical...
+			label: inputValue.trim(),
+			id: '', // User-supplied verticals don't have IDs or slugs
+			slug: '',
+		};
+
+		// ...and finally, we prepend firstSuggestion to our suggestions list.
+		newSuggestions.unshift( firstSuggestion );
+
+		setSuggestions( newSuggestions );
+	};
+
+	const handleSelect = ( vertical: SiteVertical ) => {
+		setSiteVertical( vertical );
+		setIsFocused( false ); // prevent executing handleBlur()
+		// empty suggestions cache once a vertical is selected
+		setSuggestions( [] );
+	};
+
+	const selectLastInputValue = () => {
+		const lastQuery = inputText.trim();
+		if ( ! siteVertical && isFocused && lastQuery.length ) {
+			const vertical = suggestions[ 0 ] ?? { label: lastQuery, id: '', slug: '' };
+			handleSelect( vertical );
+		}
+	};
+
+	const handleSuggestAction = ( vertical: SiteVertical ) => {
+		handleSelect( vertical );
+		onNext();
+	};
+
+	const handleInputKeyUpEvent = ( e: React.KeyboardEvent< HTMLInputElement > ) => {
+		const input = e.currentTarget.value.trim();
+		if ( ! input.length ) {
+			resetSiteVertical();
+		}
+		updateSuggestions( input );
+	};
+
+	const handleInputKeyDownEvent = ( e: React.KeyboardEvent< HTMLInputElement > ) => {
+		const input = e.currentTarget.value.trim();
+
+		if ( suggestionRef.current ) {
+			suggestionRef.current.handleKeyEvent( e );
+		}
+
+		if ( e.keyCode === ENTER ) {
+			e.preventDefault();
+			if ( input.length && ! suggestions.length ) {
+				handleSelect( { label: input } );
+			}
+			return;
+		}
+		if ( e.keyCode === TAB && input.length ) {
+			e.preventDefault();
+			selectLastInputValue();
+		}
+	};
+
+	React.useEffect( () => {
+		const { slug, label } = siteVertical || {};
+		setTextValue( label ?? '' );
+		recordVerticalSelection( slug, label );
+	}, [ siteVertical ] );
+
+	React.useEffect( () => {
+		if ( isMobile ) {
+			window.scrollTo( 0, 0 );
+		}
+	}, [ suggestions, isMobile ] );
+
+	return (
+		/* eslint-disable jsx-a11y/click-events-have-key-events */
+		/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
+		<form
+			className={ classnames( 'vertical-select', {
+				'vertical-select--with-suggestions': !! suggestions.length && isMobile,
+			} ) }
+		>
+			<label htmlFor="vertical-input">{ __( 'My site is about' ) } </label>
+			<span className="vertical-select__suggestions-wrapper">
+				{ ! isMobile && <span className="vertical-select__whitespace"></span> }
+				<AcquireIntentTextInput
+					placeholder={ animatedPlaceholder }
+					value={ textValue }
+					onKeyDown={ handleInputKeyDownEvent }
+					onKeyUp={ handleInputKeyUpEvent }
+					onFocus={ () => setIsFocused( true ) }
+					onChange={ setTextValue }
+					onBlur={ selectLastInputValue }
+				/>
+				{ !! suggestions.length && isFocused && (
+					<div className="vertical-select__suggestions">
+						<Suggestions
+							ref={ suggestionRef }
+							query={ inputText }
+							suggestions={ suggestions }
+							suggest={ handleSuggestAction }
+							title={ __( 'Suggestions' ) }
+						/>
+					</div>
+				) }
+			</span>
+		</form>
+	);
+};
+
+export default VerticalSelect;

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/style.scss
@@ -1,0 +1,81 @@
+@import 'assets/stylesheets/gutenberg-base-styles';
+@import '../../../variables.scss';
+@import '../../../mixins';
+@import '~@automattic/onboarding/styles/z-index';
+
+// Restyle `<Suggestion />` component
+.vertical-select {
+	transition: flex-grow $acquire-intent-transition-duration $acquire-intent-transition-algorithm;
+	display: flex;
+	flex-direction: column;
+
+	@include break-small {
+		display: block;
+		margin-top: 0;
+	}
+
+	.suggestions__category-heading {
+		display: none;
+	}
+	.suggestions__title {
+		line-height: normal;
+		padding: 10px 16px;
+	}
+	.suggestions__item {
+		border: none;
+		background-color: var( --studio-white );
+
+		&.has-highlight {
+			box-shadow: none;
+			background-color: var( --studio-white );
+
+			@include break-small {
+				box-shadow: inset 0 0 0 1px var( --studio-blue-30 );
+				border-radius: 2px;
+			}
+		}
+	}
+}
+
+.vertical-select__whitespace {
+	display: inline-block;
+	visibility: hidden;
+	width: 0;
+	height: 0;
+}
+
+.vertical-select__suggestions-wrapper {
+	position: relative;
+	display: block;
+	flex: 1;
+	z-index: z-index( '.vertical-select__suggestions-wrapper' );
+
+	@include break-small {
+		display: inline-block;
+		padding-bottom: 5px;
+	}
+}
+
+.vertical-select__suggestions {
+	position: absolute;
+	left: -16px;
+	min-height: 300px;
+	max-height: calc( 100% - 50px );
+	overflow: auto;
+
+	@include break-small {
+		width: 250px;
+		max-height: 400px;
+	}
+}
+
+.vertical-select__input-wrapper {
+	position: relative;
+}
+
+.vertical-select__input {
+	height: 100%;
+	display: inline-block;
+	line-height: 1;
+	padding-bottom: 5px;
+}

--- a/client/landing/gutenboarding/onboarding-block/domains/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/domains/index.tsx
@@ -49,7 +49,7 @@ const DomainsStep: React.FunctionComponent< Props > = ( { isModal } ) => {
 
 	React.useEffect( () => {
 		! isModal && setHasUsedDomainsStep( true );
-	}, [] );
+	}, [ isModal, setHasUsedDomainsStep ] );
 
 	// Keep a copy of the selected domain locally so it's available when the component is unmounting
 	const selectedDomainRef = React.useRef< string | undefined >();

--- a/client/landing/gutenboarding/path.ts
+++ b/client/landing/gutenboarding/path.ts
@@ -96,3 +96,7 @@ export function useCurrentStep() {
 export function useNewQueryParam() {
 	return new URLSearchParams( useLocation().search ).has( 'new' );
 }
+
+export function useVerticalQueryParam() {
+	return new URLSearchParams( useLocation().search ).has( 'vertical' );
+}

--- a/client/landing/gutenboarding/stores/onboard/actions.ts
+++ b/client/landing/gutenboarding/stores/onboard/actions.ts
@@ -49,6 +49,10 @@ export const setSiteVertical = ( siteVertical: SiteVertical ) => ( {
 	siteVertical,
 } );
 
+export const skipSiteVertical = () => ( {
+	type: 'SKIP_SITE_VERTICAL' as const,
+} );
+
 export const resetSiteVertical = () => ( {
 	type: 'RESET_SITE_VERTICAL' as const,
 } );
@@ -182,6 +186,7 @@ export type OnboardAction = ReturnType<
 	| typeof setDomain
 	| typeof setDomainSearch
 	| typeof setDomainCategory
+	| typeof skipSiteVertical
 	| typeof setFonts
 	| typeof setIsRedirecting
 	| typeof setHasUsedDomainsStep

--- a/client/landing/gutenboarding/stores/onboard/actions.ts
+++ b/client/landing/gutenboarding/stores/onboard/actions.ts
@@ -57,6 +57,11 @@ export const resetSiteVertical = () => ( {
 	type: 'RESET_SITE_VERTICAL' as const,
 } );
 
+export const showVerticalInput = ( shouldShowVerticalInput: boolean ) => ( {
+	type: 'SET_SHOW_SITE_VERTICAL_INPUT' as const,
+	shouldShowVerticalInput,
+} );
+
 export const setSiteTitle = ( siteTitle: string ) => ( {
 	type: 'SET_SITE_TITLE' as const,
 	siteTitle,
@@ -187,6 +192,7 @@ export type OnboardAction = ReturnType<
 	| typeof setDomainSearch
 	| typeof setDomainCategory
 	| typeof skipSiteVertical
+	| typeof showVerticalInput
 	| typeof setFonts
 	| typeof setIsRedirecting
 	| typeof setHasUsedDomainsStep

--- a/client/landing/gutenboarding/stores/onboard/index.ts
+++ b/client/landing/gutenboarding/stores/onboard/index.ts
@@ -29,6 +29,7 @@ registerStore< State >( STORE_KEY, {
 		'domainSearch',
 		'siteTitle',
 		'siteVertical',
+		'wasVerticalSkipped',
 		'hasUsedDomainsStep',
 		'hasUsedPlansStep',
 		'pageLayouts',

--- a/client/landing/gutenboarding/stores/onboard/index.ts
+++ b/client/landing/gutenboarding/stores/onboard/index.ts
@@ -29,6 +29,7 @@ registerStore< State >( STORE_KEY, {
 		'domainSearch',
 		'siteTitle',
 		'siteVertical',
+		'shouldShowVerticalInput',
 		'wasVerticalSkipped',
 		'hasUsedDomainsStep',
 		'hasUsedPlansStep',

--- a/client/landing/gutenboarding/stores/onboard/reducer.ts
+++ b/client/landing/gutenboarding/stores/onboard/reducer.ts
@@ -76,6 +76,16 @@ const siteVertical: Reducer< SiteVertical | undefined, OnboardAction > = ( state
 	return state;
 };
 
+const wasVerticalSkipped: Reducer< boolean, OnboardAction > = ( state = false, action ) => {
+	if ( action.type === 'SKIP_SITE_VERTICAL' ) {
+		return true;
+	}
+	if ( action.type === 'RESET_ONBOARD_STORE' ) {
+		return false;
+	}
+	return state;
+};
+
 const pageLayouts: Reducer< string[], OnboardAction > = ( state = [], action ) => {
 	if ( action.type === 'TOGGLE_PAGE_LAYOUT' ) {
 		const layout = action.pageLayout;
@@ -196,6 +206,7 @@ const reducer = combineReducers( {
 	showSignupDialog,
 	plan,
 	selectedFeatures,
+	wasVerticalSkipped,
 } );
 
 export type State = ReturnType< typeof reducer >;

--- a/client/landing/gutenboarding/stores/onboard/reducer.ts
+++ b/client/landing/gutenboarding/stores/onboard/reducer.ts
@@ -86,6 +86,16 @@ const wasVerticalSkipped: Reducer< boolean, OnboardAction > = ( state = false, a
 	return state;
 };
 
+const shouldShowVerticalInput: Reducer< boolean, OnboardAction > = ( state = false, action ) => {
+	if ( action.type === 'SET_SHOW_SITE_VERTICAL_INPUT' ) {
+		return action.shouldShowVerticalInput;
+	}
+	if ( action.type === 'RESET_ONBOARD_STORE' ) {
+		return false;
+	}
+	return state;
+};
+
 const pageLayouts: Reducer< string[], OnboardAction > = ( state = [], action ) => {
 	if ( action.type === 'TOGGLE_PAGE_LAYOUT' ) {
 		const layout = action.pageLayout;
@@ -207,6 +217,7 @@ const reducer = combineReducers( {
 	plan,
 	selectedFeatures,
 	wasVerticalSkipped,
+	shouldShowVerticalInput,
 } );
 
 export type State = ReturnType< typeof reducer >;

--- a/client/landing/gutenboarding/stores/onboard/selectors.ts
+++ b/client/landing/gutenboarding/stores/onboard/selectors.ts
@@ -27,3 +27,4 @@ export const getDomainSearch = ( state: State ) =>
 	state.domainSearch || getSelectedSiteTitle( state );
 export const getPlan = ( state: State ) => state.plan;
 export const getSelectedFeatures = ( state: State ) => state.selectedFeatures;
+export const wasVerticalSkipped = ( state: State ): boolean => state.wasVerticalSkipped;

--- a/client/landing/gutenboarding/variables.scss
+++ b/client/landing/gutenboarding/variables.scss
@@ -2,3 +2,4 @@
 
 $acquire-intent-transition-duration: 200ms;
 $acquire-intent-transition-algorithm: ease-in-out;
+$gutenboarding-header-height: 64px;

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -118,7 +118,7 @@ export default {
 		allowExistingUsers: true,
 	},
 	newSiteGutenbergOnboarding: {
-		datestamp: '20200731',
+		datestamp: '20200811',
 		variations: {
 			gutenberg: 50,
 			control: 50,

--- a/client/package.json
+++ b/client/package.json
@@ -173,6 +173,7 @@
 		"tracekit": "^0.4.5",
 		"twemoji": "^12.1.4",
 		"url": "^0.11.0",
+		"use-debounce": "^3.4.3",
 		"use-subscription": "^1.3.0",
 		"utility-types": "^3.10.0",
 		"uuid": "^7.0.3",

--- a/config/production.json
+++ b/config/production.json
@@ -40,6 +40,7 @@
 		"external-media/free-photo-library": true,
 		"gdpr-banner": true,
 		"google-my-business": true,
+		"gutenboarding/new-launch": true,
 		"happychat": true,
 		"help": true,
 		"help/courses": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -46,6 +46,7 @@
 		"gutenboarding/mshot-preview": false,
 		"gutenboarding/style-preview-verticals": false,
 		"gutenboarding/language-picker": false,
+		"gutenboarding/new-launch": true,
 		"happychat": true,
 		"help": true,
 		"help/courses": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -53,6 +53,7 @@
 		"gutenboarding/style-preview-verticals": false,
 		"gutenboarding/alpha-templates": true,
 		"gutenboarding/language-picker": false,
+		"gutenboarding/new-launch": true,
 		"happychat": true,
 		"help": true,
 		"help/courses": true,

--- a/packages/onboarding/styles/z-index.scss
+++ b/packages/onboarding/styles/z-index.scss
@@ -33,6 +33,7 @@
 $z-layers: (
 	'.onboarding__header': 30,
 	'.onboarding__footer': 30,
+	'.vertical-select__suggestions-wrapper': 2,
 );
 
 @function onboarding-z-index( $keys... ) {

--- a/test/e2e/lib/pages/gutenboarding/acquire-intent-page.js
+++ b/test/e2e/lib/pages/gutenboarding/acquire-intent-page.js
@@ -15,7 +15,7 @@ export default class AcquireIntentPage extends AsyncBaseContainer {
 	}
 
 	async enterSiteTitle( siteTitle ) {
-		const siteTitleSelector = By.css( '#site-title__input' );
+		const siteTitleSelector = By.css( '.acquire-intent-text-input__input' );
 		return await driverHelper.setWhenSettable( this.driver, siteTitleSelector, siteTitle );
 	}
 
@@ -25,7 +25,7 @@ export default class AcquireIntentPage extends AsyncBaseContainer {
 	}
 
 	async skipStep() {
-		const skipButtonSelector = By.css( '.action-buttons__skip' );
+		const skipButtonSelector = By.css( '.acquire-intent__question-skip' );
 		return await driverHelper.clickWhenClickable( this.driver, skipButtonSelector );
 	}
 }

--- a/test/e2e/lib/pages/gutenboarding/acquire-intent-page.js
+++ b/test/e2e/lib/pages/gutenboarding/acquire-intent-page.js
@@ -20,7 +20,7 @@ export default class AcquireIntentPage extends AsyncBaseContainer {
 	}
 
 	async goToNextStep() {
-		const nextButtonSelector = By.css( '.action-buttons__next' );
+		const nextButtonSelector = By.css( '.acquire-intent__question-skip.is-primary' );
 		return await driverHelper.clickWhenClickable( this.driver, nextButtonSelector );
 	}
 

--- a/test/e2e/specs/wp-gutenboarding-spec.js
+++ b/test/e2e/specs/wp-gutenboarding-spec.js
@@ -12,7 +12,6 @@ import NewPage from '../lib/pages/gutenboarding/new-page.js';
 import AcquireIntentPage from '../lib/pages/gutenboarding/acquire-intent-page.js';
 import DesignSelectorPage from '../lib/pages/gutenboarding/design-selector-page.js';
 import StylePreviewPage from '../lib/pages/gutenboarding/style-preview-page.js';
-import DomainsPage from '../lib/pages/gutenboarding/domains-page.js';
 import PlansPage from '../lib/pages/gutenboarding/plans-page.js';
 
 import * as driverManager from '../lib/driver-manager.js';
@@ -50,11 +49,6 @@ describe( 'Gutenboarding: (' + screenSize + ')', function () {
 			await acquireIntentPage.goToNextStep();
 		} );
 
-		step( 'Can see Domains Page and skip selecting a domain', async function () {
-			const domainsPage = await DomainsPage.Expect( driver );
-			await domainsPage.skipStep();
-		} );
-
 		step( 'Can see Design Selector and select a random free design', async function () {
 			const designSelectorPage = await DesignSelectorPage.Expect( driver );
 			await designSelectorPage.selectFreeDesign();
@@ -82,7 +76,7 @@ describe( 'Gutenboarding: (' + screenSize + ')', function () {
 		} );
 	} );
 
-	describe( 'Skip first step in Gutenboarding, select paid design and see Domains page after Style preview @parallel', function () {
+	describe( 'Skip first step in Gutenboarding, select paid design and see Plans page after Style preview @parallel', function () {
 		before( async function () {
 			await driverManager.ensureNotLoggedIn( driver );
 			await NewPage.Visit( driver );
@@ -98,10 +92,15 @@ describe( 'Gutenboarding: (' + screenSize + ')', function () {
 			await designSelectorPage.selectPaidDesign();
 		} );
 
-		step( 'Can see Domains step after Style Preview step', async function () {
+		step( 'Can see Style Preview and continue', async function () {
 			const stylePreviewPage = await StylePreviewPage.Expect( driver );
 			await stylePreviewPage.continue();
-			await DomainsPage.Expect( driver );
+		} );
+
+		step( 'Can see Plans Grid with no selected plan', async function () {
+			const plansPage = await PlansPage.Expect( driver );
+			const hasSelectedPlan = await plansPage.hasSelectedPlan();
+			assert.strictEqual( hasSelectedPlan, false, 'There is a preselected plan' );
 		} );
 	} );
 } );

--- a/yarn.lock
+++ b/yarn.lock
@@ -27872,6 +27872,11 @@ use-debounce@^3.1.0:
   resolved "https://registry.yarnpkg.com/use-debounce/-/use-debounce-3.1.0.tgz#05a5c8cd3c2f309699f08961d7c8bbe7f68720bb"
   integrity sha512-DEf3L/ZKkOSTARk/DHlC6KAAJKwMqpck8Zx06SM2Wr+LfU1TzhO8hZRzB/qbpSQqREYWQes24n1q9doeTMqF4g==
 
+use-debounce@^3.4.3:
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/use-debounce/-/use-debounce-3.4.3.tgz#5df9322322b3f1b1c263d46413f9facf6d8b56ab"
+  integrity sha512-nxy+opOxDccWfhMl36J5BSCTpvcj89iaQk2OZWLAtBJQj7ISCtx1gh+rFbdjGfMl6vtCZf6gke/kYvrkVfHMoA==
+
 use-memo-one@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/use-memo-one/-/use-memo-one-1.1.1.tgz#39e6f08fe27e422a7d7b234b5f9056af313bd22c"


### PR DESCRIPTION
After merging this PR, remember to also merge this PR to enable ab testing on verticals: https://github.com/Automattic/wp-calypso/pull/44256

#### Changes proposed in this Pull Request

This is a feature branch PR, including these PRs that were tested separately:

- https://github.com/Automattic/wp-calypso/pull/44655 remove domain as a step
- https://github.com/Automattic/wp-calypso/pull/44701 add vertical input
- https://github.com/Automattic/wp-calypso/pull/44822 https://github.com/Automattic/wp-calypso/pull/44837 vertical gating with `?vertical` URL arg
- https://github.com/Automattic/wp-calypso/pull/44833 enable launch flow in production and bump AB test slug
- https://github.com/Automattic/wp-calypso/pull/44837 persistent show vertical input

#### Does not include:
- https://github.com/Automattic/wp-calypso/pull/44256 A/B test for vertical
    - A/B test to be merged separately.
- https://github.com/Automattic/wp-calypso/pull/44775 plans grid modification
    - Plans grid modification might be clashing with plans grid in launch flow, so we might need to do some separation work here or roll this only once we have an accordion grid in launch flow.



#### Testing instructions

- Go `/new` and observe new vertical input and no mandatory domain step
- Test domain picker from the header

See more pbAok1-1lr-p2