### PR TITLE
Gutenboarding launch flow: add final step summary

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/common/data-stores/launch/reducer.ts
+++ b/apps/full-site-editing/full-site-editing-plugin/common/data-stores/launch/reducer.ts
@@ -20,7 +20,7 @@ const step: Reducer< LaunchStepType, LaunchAction > = ( state = LaunchStep.Name,
 };
 
 const completedSteps: Reducer< LaunchStepType[], LaunchAction > = ( state = [], action ) => {
-	if ( action.type === 'SET_STEP_COMPLETE' ) {
+	if ( action.type === 'SET_STEP_COMPLETE' && state.indexOf( action.step ) === -1 ) {
 		return [ ...state, action.step ];
 	}
 	if ( action.type === 'SET_STEP_INCOMPLETE' ) {

--- a/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/hooks/use-site.ts
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/hooks/use-site.ts
@@ -23,5 +23,6 @@ export function useSite() {
 	return {
 		isFreePlan: site?.plan.is_free,
 		launchStatus,
+		currentDomainName: site?.URL && new URL( site?.URL ).hostname,
 	};
 }

--- a/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-menu/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-menu/index.tsx
@@ -39,6 +39,7 @@ const LaunchMenu = () => {
 						isCompleted={ completedSteps.includes( step ) }
 						isCurrent={ step === currentStep }
 						onClick={ () => setStep( step ) }
+						isDisabled={ step === LaunchStep.Final && ! completedSteps.length }
 					/>
 				) ) }
 			</div>

--- a/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-menu/item.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-menu/item.tsx
@@ -20,6 +20,7 @@ interface Props {
 	title: string;
 	isCompleted: boolean;
 	isCurrent: boolean;
+	isDisabled: boolean;
 	onClick: () => void;
 }
 
@@ -27,6 +28,7 @@ const LaunchMenuItem: React.FunctionComponent< Props > = ( {
 	title,
 	isCompleted,
 	isCurrent,
+	isDisabled,
 	onClick,
 } ) => {
 	return (
@@ -36,6 +38,7 @@ const LaunchMenuItem: React.FunctionComponent< Props > = ( {
 				'is-completed': isCompleted,
 			} ) }
 			onClick={ onClick }
+			disabled={ isDisabled }
 			isLink
 		>
 			<Icon icon={ isCompleted ? check : circle } size={ 16 } />

--- a/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-steps/final-step/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-steps/final-step/index.tsx
@@ -68,6 +68,12 @@ const FinalStep: React.FunctionComponent< LaunchStepProps > = ( { onNextStep } )
 											</li>
 										) ) }
 									</ul>
+									<p>
+										{ __( 'Questions?', 'full-site-editing' ) }{ ' ' }
+										<Button isLink href="https://wordpress.com/help/contact" target="_blank">
+											{ __( 'Ask a Happiness Engineer', 'full-site-editing' ) }
+										</Button>
+									</p>
 								</CheckoutSummaryCard>
 							</CheckoutSummaryArea>
 						) }

--- a/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-steps/final-step/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-steps/final-step/index.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 import { ThemeProvider } from 'emotion-theming';
 import { __ } from '@wordpress/i18n';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { Button } from '@wordpress/components';
+import { Button, Tip } from '@wordpress/components';
 import { Icon, check } from '@wordpress/icons';
 import { useEntityProp } from '@wordpress/core-data';
 import { Title, SubTitle } from '@automattic/onboarding';
@@ -24,7 +24,7 @@ import {
  */
 import { LaunchStep } from '../../../../common/data-stores/launch/data';
 import LaunchStepContainer, { Props as LaunchStepProps } from '../../launch-step';
-import { LAUNCH_STORE } from '../../stores';
+import { LAUNCH_STORE, PLANS_STORE } from '../../stores';
 import { useSite } from '../../hooks';
 
 import './styles.scss';
@@ -38,6 +38,60 @@ const FinalStep: React.FunctionComponent< LaunchStepProps > = ( { onNextStep } )
 	const plan = useSelect( ( select ) => select( LAUNCH_STORE ).getSelectedPlan() );
 	const { completedSteps } = useSelect( ( select ) => select( LAUNCH_STORE ).getState() );
 	const { setStep } = useDispatch( LAUNCH_STORE );
+	const prices = useSelect( ( select ) => select( PLANS_STORE ).getPrices() );
+
+	const nameSummary = (
+		<div className="nux-launch__summary-item">
+			<p>
+				{ __( 'Site', 'full-site-editing' ) }: { title }
+			</p>
+		</div>
+	);
+
+	const domainSummary = (
+		<div className="nux-launch__summary-item">
+			{ domain?.domain_name ? (
+				<p>
+					{ __( 'Custom domain', 'full-site-editing' ) }: { domain.domain_name }
+				</p>
+			) : (
+				<>
+					<p>
+						{ __( 'Free site address', 'full-site-editing' ) }: { currentDomainName }
+					</p>
+					<Tip>
+						{ __(
+							'A custom site address like madefreshbakery.com (now available!) is more unique and can help with your SEO ranking.',
+							'full-site-editing'
+						) }
+					</Tip>
+				</>
+			) }
+		</div>
+	);
+
+	const planSummary = (
+		<div className="nux-launch__summary-item">
+			{ plan && ! plan?.isFree ? (
+				<>
+					<p className="nux-launch__summary-item__plan-name">WordPress.com { plan.title }</p>
+					{ __( 'Plan subscription', 'full-site-editing' ) }: { prices[ plan.storeSlug ] }{ ' ' }
+					{ __( 'per month, billed yearly', 'full-site-editing' ) }
+				</>
+			) : (
+				<>
+					<p className="nux-launch__summary-item__plan-name">WordPress.com Free</p>
+					<p>{ __( 'Plan subscription: Free forever', 'full-site-editing' ) }</p>
+					<Tip>
+						{ __(
+							'Upgrade to Premium to get access to 13GB storage space, payment collection options, 24/7 Live Chat support, and more. Not sure? Give it a spin—we offer 30-day full-refunds, guaranteed.',
+							'full-site-editing'
+						) }
+					</Tip>
+				</>
+			) }
+		</div>
+	);
 
 	return (
 		<LaunchStepContainer className="nux-launch-final-step">
@@ -82,7 +136,7 @@ const FinalStep: React.FunctionComponent< LaunchStepProps > = ( { onNextStep } )
 								titleContent={ __( 'Your site name', 'full-site-editing' ) }
 								isStepComplete={ completedSteps.includes( LaunchStep.Name ) }
 								goToThisStep={ () => setStep( LaunchStep.Name ) }
-								completeStepContent={ title }
+								completeStepContent={ nameSummary }
 								stepId="name"
 								formStatus="ready"
 							/>
@@ -90,7 +144,7 @@ const FinalStep: React.FunctionComponent< LaunchStepProps > = ( { onNextStep } )
 								titleContent={ __( 'Your domain', 'full-site-editing' ) }
 								isStepComplete={ completedSteps.includes( LaunchStep.Domain ) }
 								goToThisStep={ () => setStep( LaunchStep.Domain ) }
-								completeStepContent={ domain?.domain_name || currentDomainName }
+								completeStepContent={ domainSummary }
 								stepId="domain"
 								formStatus="ready"
 							/>
@@ -98,7 +152,7 @@ const FinalStep: React.FunctionComponent< LaunchStepProps > = ( { onNextStep } )
 								titleContent={ __( 'Your plan', 'full-site-editing' ) }
 								isStepComplete={ completedSteps.includes( LaunchStep.Plan ) }
 								goToThisStep={ () => setStep( LaunchStep.Plan ) }
-								completeStepContent={ plan?.title }
+								completeStepContent={ planSummary }
 								stepId="plan"
 								formStatus="ready"
 							/>

--- a/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-steps/final-step/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-steps/final-step/index.tsx
@@ -2,29 +2,113 @@
  * External dependencies
  */
 import * as React from 'react';
+import { ThemeProvider } from 'emotion-theming';
+import { __ } from '@wordpress/i18n';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { Button } from '@wordpress/components';
+import { Icon, check } from '@wordpress/icons';
+import { useEntityProp } from '@wordpress/core-data';
+import { Title, SubTitle } from '@automattic/onboarding';
+import {
+	CheckoutStepBody,
+	checkoutTheme,
+	CheckoutSummaryArea,
+	CheckoutSummaryCard,
+	MainContentUI,
+	CheckoutStepAreaUI,
+	SubmitButtonWrapperUI,
+} from '@automattic/composite-checkout';
+
 /**
  * Internal dependencies
  */
+import { LaunchStep } from '../../../../common/data-stores/launch/data';
 import LaunchStepContainer, { Props as LaunchStepProps } from '../../launch-step';
+import { LAUNCH_STORE } from '../../stores';
+import { useSite } from '../../hooks';
 
 import './styles.scss';
 
+const TickIcon = <Icon icon={ check } size={ 17 } />;
+
 const FinalStep: React.FunctionComponent< LaunchStepProps > = ( { onNextStep } ) => {
-	const handleClick = () => {
-		onNextStep?.();
-	};
+	const [ title ] = useEntityProp( 'root', 'site', 'title' );
+	const { currentDomainName } = useSite();
+	const domain = useSelect( ( select ) => select( LAUNCH_STORE ).getSelectedDomain() );
+	const plan = useSelect( ( select ) => select( LAUNCH_STORE ).getSelectedPlan() );
+	const { completedSteps } = useSelect( ( select ) => select( LAUNCH_STORE ).getState() );
+	const { setStep } = useDispatch( LAUNCH_STORE );
 
 	return (
 		<LaunchStepContainer className="nux-launch-final-step">
-			<div className="nux-final-preview-hint">
+			<div className="nux-launch-step__header">
 				<div>
-					This is just a demo of how to reveal the site content behind to let user preview one more
-					time before submitting.
+					<Title>{ __( 'Launch your site', 'full-site-editing' ) }</Title>
+					<SubTitle>
+						{ __(
+							'Your site will be made public and ready to share with others.',
+							'full-site-editing'
+						) }
+					</SubTitle>
 				</div>
-				<Button isPrimary onClick={ handleClick }>
-					Confirm &amp; Launch
-				</Button>
+			</div>
+			<div className="nux-launch-step__body">
+				<ThemeProvider theme={ checkoutTheme }>
+					<MainContentUI>
+						{ completedSteps.includes( LaunchStep.Plan ) && (
+							<CheckoutSummaryArea>
+								<CheckoutSummaryCard className="nux-launch__feature-list">
+									<h3 className="nux-launch__feature-list-title">
+										{ __( 'Included in your plan', 'full-site-editing' ) }
+									</h3>
+									<ul className="nux-launch__feature-item-group">
+										{ plan?.features.map( ( feature, i ) => (
+											<li key={ i } className="nux-launch__feature-item">
+												{ TickIcon } { feature }
+											</li>
+										) ) }
+									</ul>
+								</CheckoutSummaryCard>
+							</CheckoutSummaryArea>
+						) }
+						<CheckoutStepAreaUI>
+							<CheckoutStepBody
+								titleContent={ __( 'Your site name', 'full-site-editing' ) }
+								isStepComplete={ completedSteps.includes( LaunchStep.Name ) }
+								goToThisStep={ () => setStep( LaunchStep.Name ) }
+								completeStepContent={ title }
+								stepId="name"
+								formStatus="ready"
+							/>
+							<CheckoutStepBody
+								titleContent={ __( 'Your domain', 'full-site-editing' ) }
+								isStepComplete={ completedSteps.includes( LaunchStep.Domain ) }
+								goToThisStep={ () => setStep( LaunchStep.Domain ) }
+								completeStepContent={ domain?.domain_name || currentDomainName }
+								stepId="domain"
+								formStatus="ready"
+							/>
+							<CheckoutStepBody
+								titleContent={ __( 'Your plan', 'full-site-editing' ) }
+								isStepComplete={ completedSteps.includes( LaunchStep.Plan ) }
+								goToThisStep={ () => setStep( LaunchStep.Plan ) }
+								completeStepContent={ plan?.title }
+								stepId="plan"
+								formStatus="ready"
+							/>
+							<SubmitButtonWrapperUI>
+								<Button
+									isPrimary
+									disabled={ completedSteps.length < 3 }
+									onClick={ onNextStep }
+									className="nux-launch__submit-button"
+								>
+									{ __( 'Launch your site', 'full-site-editing' ) }
+								</Button>
+							</SubmitButtonWrapperUI>
+						</CheckoutStepAreaUI>
+					</MainContentUI>
+				</ThemeProvider>
 			</div>
 		</LaunchStepContainer>
 	);

--- a/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-steps/final-step/styles.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-steps/final-step/styles.scss
@@ -54,3 +54,20 @@ ul.nux-launch__feature-item-group {
 		}
 	}
 }
+
+.nux-launch__summary-item {
+	p {
+		margin: 0;
+		word-break: break-word;
+	}
+	.components-tip {
+		margin-top: 10px;
+
+		svg {
+			align-self: flex-start;
+		}
+	}
+	&__plan-name {
+		color: var( --color-text );
+	}
+}

--- a/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-steps/final-step/styles.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-steps/final-step/styles.scss
@@ -1,14 +1,56 @@
-.nux-launch-modal.step-final {
-	// Try: Reveal site content behind
-	.nux-launch-modal-body {
-		background: transparent;
+@import '~@automattic/typography/styles/variables';
+@import '~@automattic/onboarding/styles/mixins';
+
+.nux-launch__feature-list {
+	padding: 20px;
+}
+.nux-launch__feature-list-title {
+	margin: 0 0 10px;
+	color: $dark-gray-500;
+	font-weight: 400;
+}
+ul.nux-launch__feature-item-group {
+	margin: 0;
+}
+.nux-launch__feature-item {
+	font-size: $font-body-small;
+	line-height: 20px;
+	letter-spacing: 0.2px;
+	margin: 4px 0;
+	vertical-align: middle;
+	color: $dark-gray-500;
+	display: flex;
+	align-items: flex-start;
+
+	svg {
+		display: block;
+		margin-right: 6px;
+		margin-top: 2px;
+	}
+
+	// the tick
+	svg path {
+		fill: rgb( 74, 161, 80 );
+		stroke: rgb( 74, 161, 80 );
 	}
 }
-
-.nux-final-preview-hint {
-	background: var( --studio-blue-0 );
+.nux-launch__submit-button.components-button.is-primary {
+	background: var( --color-accent );
+	border: 1px solid var( --color-accent-dark );
 	width: 100%;
-	position: absolute;
-	left: 0;
-	padding: 20px;
+	justify-content: center;
+
+	&:hover,
+	&:active {
+		background: var( --color-accent-dark );
+	}
+
+	&:disabled {
+		color: $white;
+		opacity: 0.5;
+
+		&:hover {
+			background: var( --color-accent );
+		}
+	}
 }

--- a/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/stores/index.ts
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/stores/index.ts
@@ -5,3 +5,4 @@ import 'a8c-fse-common-data-stores';
 
 export const SITE_STORE = 'automattic/site';
 export const LAUNCH_STORE = 'automattic/launch';
+export const PLANS_STORE = 'automattic/onboard/plans';

--- a/apps/full-site-editing/package.json
+++ b/apps/full-site-editing/package.json
@@ -131,6 +131,7 @@
 		"@wordpress/server-side-render": "^1.16.3",
 		"@wordpress/url": "*",
 		"classnames": "^2.2.6",
+		"emotion-theming": "^10.0.27",
 		"enzyme": "^3.11.0",
 		"eslint": "^6.8.0",
 		"jest": "^26.0.1",

--- a/apps/full-site-editing/package.json
+++ b/apps/full-site-editing/package.json
@@ -90,6 +90,7 @@
 	"dependencies": {
 		"@automattic/calypso-analytics": "^1.0.0-alpha.1",
 		"@automattic/calypso-build": "*",
+		"@automattic/composite-checkout": "*",
 		"@automattic/data-stores": "^1.0.0-alpha.1",
 		"@automattic/domain-picker": "^1.0.0-alpha.0",
 		"@automattic/format-currency": "^1.0.0-alpha.0",

--- a/packages/composite-checkout/src/components/checkout-steps.js
+++ b/packages/composite-checkout/src/components/checkout-steps.js
@@ -444,7 +444,7 @@ const ContainerUI = styled.div`
 	}
 `;
 
-const MainContentUI = styled.div`
+export const MainContentUI = styled.div`
 	display: flex;
 	flex-direction: column;
 	width: 100%;
@@ -483,7 +483,7 @@ const CheckoutSummaryUI = styled.div`
 	}
 `;
 
-const CheckoutStepAreaUI = styled.div`
+export const CheckoutStepAreaUI = styled.div`
 	background: ${ ( props ) => props.theme.colors.surface };
 	box-sizing: border-box;
 	margin: 0 auto;
@@ -508,7 +508,7 @@ const CheckoutStepAreaUI = styled.div`
 	}
 `;
 
-const SubmitButtonWrapperUI = styled.div`
+export const SubmitButtonWrapperUI = styled.div`
 	background: ${ ( props ) => props.theme.colors.background };
 	padding: 24px;
 	bottom: 0;

--- a/packages/composite-checkout/src/public-api.js
+++ b/packages/composite-checkout/src/public-api.js
@@ -17,6 +17,9 @@ import {
 	useIsStepActive,
 	useIsStepComplete,
 	useSetStepComplete,
+	MainContentUI,
+	CheckoutStepAreaUI,
+	SubmitButtonWrapperUI,
 } from './components/checkout-steps';
 import CheckoutPaymentMethods from './components/checkout-payment-methods';
 import {
@@ -142,4 +145,7 @@ export {
 	useTotal,
 	useTransactionStatus,
 	checkoutTheme,
+	MainContentUI,
+	CheckoutStepAreaUI,
+	SubmitButtonWrapperUI,
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Add summary to final step of the launch flow
* Link to each of the previous step from summary items
* Show completion status of each step
* Enable _Launch_ button only if all steps are completed 

#### Testing instructions
* Create a site using `/new` flow.
* Sandbox the site.
* Click _Complete Setup_ in editor,
* Check the last step in the sidebar with various combinations of completed steps,

#### Screenshots
* **No step completed (disabled sidebar button)**
<img width="1048" alt="Screenshot 2020-08-11 at 13 41 48" src="https://user-images.githubusercontent.com/14192054/89888753-1f6f5e80-dbd9-11ea-9ad1-f1971ece9a85.png">

* **Without a selected plan**
<img width="1049" alt="Screenshot 2020-08-11 at 13 42 45" src="https://user-images.githubusercontent.com/14192054/89888561-cf909780-dbd8-11ea-910f-add8d93b8fc8.png">

* **Without site name**
<img width="1220" alt="Screenshot 2020-08-11 at 13 44 04" src="https://user-images.githubusercontent.com/14192054/89888533-c1db1200-dbd8-11ea-9851-3881fda952b2.png">

* **All steps completed (Custom domain and paid plan)**
<img width="878" alt="Screenshot 2020-08-11 at 13 31 27" src="https://user-images.githubusercontent.com/14192054/89888629-f0f18380-dbd8-11ea-9fc4-8d2763dcc308.png">

* **All steps completed (sub-domain and Free plan)**
<img width="855" alt="Screenshot 2020-08-11 at 13 31 38" src="https://user-images.githubusercontent.com/14192054/89888601-e33bfe00-dbd8-11ea-9f41-de16d06e6026.png">

Fixes #44450 
