### PR TITLE
Gutenboarding: Show vertical input only when ?vertical param exists.

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
@@ -12,7 +12,7 @@ import { useI18n } from '@automattic/react-i18n';
  * Internal dependencies
  */
 import { STORE_KEY } from '../../stores/onboard';
-import { Step, usePath } from '../../path';
+import { Step, usePath, useVerticalQueryParam } from '../../path';
 import Link from '../../components/link';
 import VerticalSelect from './vertical-select';
 import SiteTitle from './site-title';
@@ -97,6 +97,8 @@ const AcquireIntent: React.FunctionComponent = () => {
 
 	const siteVertical = getSelectedVertical();
 
+	const shouldShowVerticalInput = useVerticalQueryParam();
+
 	return (
 		<div className="gutenboarding-page acquire-intent">
 			{ isMobile &&
@@ -114,7 +116,7 @@ const AcquireIntent: React.FunctionComponent = () => {
 				) ) }
 			{ ! isMobile && (
 				<>
-					{ ! wasVerticalSkipped() && verticalSelect }
+					{ ! wasVerticalSkipped() && shouldShowVerticalInput && verticalSelect }
 					{ siteTitleInput }
 				</>
 			) }

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
@@ -101,39 +101,50 @@ const AcquireIntent: React.FunctionComponent = () => {
 
 	return (
 		<div className="gutenboarding-page acquire-intent">
-			{ isMobile &&
-				( isSiteTitleActive ? (
-					<div>
-						<Arrow
-							className="acquire-intent__mobile-back-arrow"
-							onClick={ () => setIsSiteTitleActive( false ) }
-							transform="rotate(180)"
-						/>
-						{ siteTitleInput }
-					</div>
-				) : (
-					verticalSelect
-				) ) }
-			{ ! isMobile && (
+			{ shouldShowVerticalInput ? (
 				<>
-					{ ! wasVerticalSkipped() && shouldShowVerticalInput && verticalSelect }
-					{ siteTitleInput }
+					{ isMobile &&
+						( isSiteTitleActive ? (
+							<div>
+								<Arrow
+									className="acquire-intent__mobile-back-arrow"
+									onClick={ () => setIsSiteTitleActive( false ) }
+									transform="rotate(180)"
+								/>
+								{ siteTitleInput }
+							</div>
+						) : (
+							verticalSelect
+						) ) }
+					{ ! isMobile && (
+						<>
+							{ ! wasVerticalSkipped() && verticalSelect }
+							{ siteTitleInput }
+						</>
+					) }
+					<div className="acquire-intent__footer">
+						{ /* On mobile we render skipButton on vertical step when there is no vertical with more than 2 characters selected which is the
+						case when we render the Next arrow button next to the input. On site title step we always render nextStepButton */ }
+						{ isMobile &&
+							( isSiteTitleActive
+								? nextStepButton
+								: ( ( ! siteVertical || siteVertical?.label?.length < 3 ) && skipButton ) || (
+										<Arrow className="acquire-intent__mobile-next-arrow" onClick={ onNext } />
+								  ) ) }
+
+						{ /* On desktop we always render nextStepButton when we render site title
+						Otherwise we render skipButton  */ }
+						{ ! isMobile && ( showSiteTitleAndNext ? nextStepButton : skipButton ) }
+					</div>
+				</>
+			) : (
+				<>
+					<SiteTitle inputRef={ siteTitleRef } onSubmit={ handleSiteTitleSubmit } />
+					<div className="acquire-intent__footer">
+						{ hasSiteTitle ? nextStepButton : skipButton }
+					</div>
 				</>
 			) }
-			<div className="acquire-intent__footer">
-				{ /* On mobile we render skipButton on vertical step when there is no vertical with more than 2 characters selected which is the
-				case when we render the Next arrow button next to the input. On site title step we always render nextStepButton */ }
-				{ isMobile &&
-					( isSiteTitleActive
-						? nextStepButton
-						: ( ( ! siteVertical || siteVertical?.label?.length < 3 ) && skipButton ) || (
-								<Arrow className="acquire-intent__mobile-next-arrow" onClick={ onNext } />
-						  ) ) }
-
-				{ /* On desktop we always render nextStepButton when we render site title
-				Otherwise we render skipButton  */ }
-				{ ! isMobile && ( showSiteTitleAndNext ? nextStepButton : skipButton ) }
-			</div>
 		</div>
 	);
 };

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
@@ -82,7 +82,8 @@ const AcquireIntent: React.FunctionComponent = () => {
 	const nextStepButton = (
 		<Link
 			className="acquire-intent__question-skip"
-			isPrimary
+			isPrimary={ hasSiteTitle }
+			isDefault={ ! hasSiteTitle }
 			onClick={ () => ! hasSiteTitle && recordSiteTitleSkip() }
 			to={ nextStepPath }
 		>
@@ -90,7 +91,12 @@ const AcquireIntent: React.FunctionComponent = () => {
 		</Link>
 	);
 	const skipButton = (
-		<Button isLink onClick={ handleSkip } className="acquire-intent__skip-vertical">
+		<Button
+			isLink={ isMobile }
+			isDefault={ ! isMobile }
+			onClick={ handleSkip }
+			className="acquire-intent__skip-vertical"
+		>
 			{ skipLabel }
 		</Button>
 	);
@@ -140,9 +146,7 @@ const AcquireIntent: React.FunctionComponent = () => {
 			) : (
 				<>
 					<SiteTitle inputRef={ siteTitleRef } onSubmit={ handleSiteTitleSubmit } />
-					<div className="acquire-intent__footer">
-						{ hasSiteTitle ? nextStepButton : skipButton }
-					</div>
+					<div className="acquire-intent__footer">{ nextStepButton }</div>
 				</>
 			) }
 		</div>

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
@@ -14,8 +14,8 @@ import { STORE_KEY } from '../../stores/onboard';
 import { recordSiteTitleSelection } from '../../lib/analytics';
 import tip from './tip';
 import AcquireIntentTextInput from './acquire-intent-text-input';
-
 import useTyper from '../../hooks/use-typer';
+import { useVerticalQueryParam } from '../../path';
 
 interface Props {
 	onSubmit: () => void;
@@ -83,8 +83,10 @@ const SiteTitle: React.FunctionComponent< Props > = ( { onSubmit, inputRef } ) =
 		setIsTouched( true );
 	};
 
+	const shouldShowVerticalInput = useVerticalQueryParam();
+
 	// translators: label for site title input in Gutenboarding
-	const inputLabel = __( "It's called" );
+	const inputLabel = shouldShowVerticalInput ? __( "It's called" ) : __( 'My site is called' );
 
 	const placeHolder = useTyper( siteTitleExamples, ! siteTitle, {
 		delayBetweenCharacters: 70,

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
@@ -100,6 +100,25 @@
 		padding: 0;
 		color: $dark-gray-600;
 	}
+
+	// Applies to both
+	// - .components-button.acquire-intent__skip-vertical
+	// - .components-button.acquire-intent__question-skip
+	.components-button.is-secondary {
+		color: var( --studio-gray-50 );
+		box-shadow: inset 0 0 0 1px var( --studio-gray-50 );
+
+		&:active,
+		&:hover {
+			color: var( --studio-gray-60 );
+			box-shadow: inset 0 0 0 1px var( --studio-gray-60 );
+		}
+
+		&:focus {
+			color: var( --studio-gray-60 );
+			box-shadow: inset 0 0 0 1px #fff, 0 0 0 1.5px var( --highlightColor );
+		}
+	}
 }
 
 .acquire-intent__mobile-vertical-input {

--- a/client/landing/gutenboarding/path.ts
+++ b/client/landing/gutenboarding/path.ts
@@ -96,3 +96,7 @@ export function useCurrentStep() {
 export function useNewQueryParam() {
 	return new URLSearchParams( useLocation().search ).has( 'new' );
 }
+
+export function useVerticalQueryParam() {
+	return new URLSearchParams( useLocation().search ).has( 'vertical' );
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Show vertical input only when `/new?vertical` param exists.

#### Testing instructions

* Open `/new` and `/new?vertical`.
* On `/new?vertical`, you should see **"My site is about..."** and **"It's called..."**.
* On `/new`, you should see only **"My site is called..."**.
* Test layout on both desktop & mobile view.

#### Screenshots

![image](https://user-images.githubusercontent.com/1287077/89880397-7b7bb800-dbc4-11ea-9837-d460932c2469.png)

![image](https://user-images.githubusercontent.com/1287077/89880404-7dde1200-dbc4-11ea-87d9-f7540ede799d.png)

![image](https://user-images.githubusercontent.com/1287077/89880411-80406c00-dbc4-11ea-9230-4446b17ae263.png)

![image](https://user-images.githubusercontent.com/1287077/89880421-83d3f300-dbc4-11ea-9bf6-771fe550c307.png)

![image](https://user-images.githubusercontent.com/1287077/89880430-859db680-dbc4-11ea-99fb-4f65e0160f94.png)

Fixes #
