### PR TITLE
Gutenboarding Site Launch: When on mobile, do not open launch sidebar.

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/editor-gutenboarding-launch/index.ts
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-gutenboarding-launch/index.ts
@@ -85,7 +85,7 @@ function updateEditor() {
 
 			recordTracksEvent( 'calypso_newsite_editor_launch_click' );
 
-			if ( isNewLaunch && window.innerWidth < 768 ) {
+			if ( isNewLaunch && ! ( window.innerWidth < 768 ) ) {
 				// Open editor-site-launch sidebar
 				dispatch( 'automattic/launch' ).openSidebar();
 			} else {

--- a/apps/full-site-editing/full-site-editing-plugin/editor-gutenboarding-launch/index.ts
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-gutenboarding-launch/index.ts
@@ -7,7 +7,7 @@ import { addAction } from '@wordpress/hooks';
 import { dispatch } from '@wordpress/data';
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import 'a8c-fse-common-data-stores';
-import { isMobile } from '@automattic/viewport';
+import { isWithinBreakpoint } from '@automattic/viewport';
 
 // Depend on `core/editor` store.
 import '@wordpress/editor';
@@ -86,7 +86,7 @@ function updateEditor() {
 
 			recordTracksEvent( 'calypso_newsite_editor_launch_click' );
 
-			if ( isNewLaunch && ! isMobile() ) {
+			if ( isNewLaunch && ! isWithinBreakpoint( '<768px' ) ) {
 				// Open editor-site-launch sidebar
 				dispatch( 'automattic/launch' ).openSidebar();
 			} else {

--- a/apps/full-site-editing/full-site-editing-plugin/editor-gutenboarding-launch/index.ts
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-gutenboarding-launch/index.ts
@@ -7,7 +7,6 @@ import { addAction } from '@wordpress/hooks';
 import { dispatch } from '@wordpress/data';
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import 'a8c-fse-common-data-stores';
-import { isWithinBreakpoint } from '@automattic/viewport';
 
 // Depend on `core/editor` store.
 import '@wordpress/editor';
@@ -86,7 +85,7 @@ function updateEditor() {
 
 			recordTracksEvent( 'calypso_newsite_editor_launch_click' );
 
-			if ( isNewLaunch && ! isWithinBreakpoint( '<800px' ) ) {
+			if ( isNewLaunch && window.innerWidth < 768 ) {
 				// Open editor-site-launch sidebar
 				dispatch( 'automattic/launch' ).openSidebar();
 			} else {

--- a/apps/full-site-editing/full-site-editing-plugin/editor-gutenboarding-launch/index.ts
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-gutenboarding-launch/index.ts
@@ -7,6 +7,7 @@ import { addAction } from '@wordpress/hooks';
 import { dispatch } from '@wordpress/data';
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import 'a8c-fse-common-data-stores';
+import { isMobile } from '@automattic/viewport';
 
 // Depend on `core/editor` store.
 import '@wordpress/editor';
@@ -85,7 +86,7 @@ function updateEditor() {
 
 			recordTracksEvent( 'calypso_newsite_editor_launch_click' );
 
-			if ( isNewLaunch ) {
+			if ( isNewLaunch && ! isMobile() ) {
 				// Open editor-site-launch sidebar
 				dispatch( 'automattic/launch' ).openSidebar();
 			} else {

--- a/apps/full-site-editing/full-site-editing-plugin/editor-gutenboarding-launch/index.ts
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-gutenboarding-launch/index.ts
@@ -86,7 +86,7 @@ function updateEditor() {
 
 			recordTracksEvent( 'calypso_newsite_editor_launch_click' );
 
-			if ( isNewLaunch && ! isWithinBreakpoint( '<768px' ) ) {
+			if ( isNewLaunch && ! isWithinBreakpoint( '<800px' ) ) {
 				// Open editor-site-launch sidebar
 				dispatch( 'automattic/launch' ).openSidebar();
 			} else {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* When on mobile, do not open launch sidebar.

#### Testing instructions

* Resize to mobile view.
* Click "Complete setup" button.
* It should just launch the site.

Fixes https://github.com/Automattic/wp-calypso/issues/44692
