### PR TITLE
Premium Content: load assets using proper hook

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/premium-content.php
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/premium-content.php
@@ -25,6 +25,9 @@ const PAYWALL_FILTER = 'earn_premium_content_subscription_service';
 
 require_once __DIR__ . '/subscription-service/include.php';
 
+define( 'PREMIUM_CONTENT__URL_PATH', rtrim( plugin_dir_url( __FILE__ ), '/' ) );
+define( 'PREMIUM_CONTENT__PLUGIN_DIR', __DIR__ );
+
 /**
  * Register blocks and load block translations. If not done on init, the render
  * callbacks of the dynamic blocks won't be executed in the front-end.
@@ -47,8 +50,8 @@ function premium_content_block_init() {
 function premium_content_block_enqueue_block_editor_assets() {
 	$info         = get_script_info();
 	$script_asset = $info['script_asset'];
-	$url_path     = $info['url_path'];
-	$dir          = $info['dir'];
+	$url_path     = PREMIUM_CONTENT__URL_PATH;
+	$dir          = PREMIUM_CONTENT__PLUGIN_DIR;
 
 	$index_js = 'dist/premium-content.js';
 	wp_register_script(
@@ -78,8 +81,8 @@ function premium_content_block_enqueue_block_editor_assets() {
 function premium_content_block_enqueue_block_assets() {
 	$info         = get_script_info();
 	$script_asset = $info['script_asset'];
-	$url_path     = $info['url_path'];
-	$dir          = $info['dir'];
+	$url_path     = PREMIUM_CONTENT__URL_PATH;
+	$dir          = PREMIUM_CONTENT__PLUGIN_DIR;
 
 	$style_css = 'style.css';
 	wp_register_style(
@@ -101,16 +104,14 @@ function premium_content_block_enqueue_block_assets() {
 
 
 /**
- * Helper; Get the 'script_asset', 'url_path', and 'dir'
+ * Helper; Get the 'script_asset'
  * Used by enqueue_block_assets and enqueue_block_editor_assets
  *
  * @throws RuntimeException If block assets files are not found.
  * @return array
  */
 function get_script_info() {
-	$url_path = rtrim( plugin_dir_url( __FILE__ ), '/' );
-	$dir      = __DIR__;
-
+	$dir               = PREMIUM_CONTENT__PLUGIN_DIR;
 	$script_asset_path = "$dir/dist/premium-content.asset.php";
 	if ( ! file_exists( $script_asset_path ) ) {
 		throw new RuntimeException(
@@ -120,8 +121,6 @@ function get_script_info() {
 	$script_asset = include $script_asset_path;
 	return array(
 		'script_asset' => $script_asset,
-		'url_path'     => $url_path,
-		'dir'          => $dir,
 	);
 }
 
@@ -444,3 +443,4 @@ add_action( 'enqueue_block_editor_assets', 'A8C\FSE\Earn\PremiumContent\premium_
 add_action( 'enqueue_block_assets', 'A8C\FSE\Earn\PremiumContent\premium_content_block_enqueue_block_assets' );
 
 add_filter( PAYWALL_FILTER, 'A8C\FSE\Earn\PremiumContent\premium_content_default_service' );
+file_put_contents( '/tmp/1.log', "¡hola! 5\n", FILE_APPEND );

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/premium-content.php
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/premium-content.php
@@ -49,13 +49,12 @@ function premium_content_block_init() {
  */
 function premium_content_block_enqueue_block_editor_assets() {
 	$script_asset = get_script_asset();
-	$url_path     = PREMIUM_CONTENT__URL_PATH;
 	$dir          = PREMIUM_CONTENT__PLUGIN_DIR;
 
 	$index_js = 'dist/premium-content.js';
 	wp_register_script(
 		'premium-content-editor',
-		"$url_path/$index_js",
+		PREMIUM_CONTENT__URL_PATH . '/' . $index_js,
 		$script_asset['dependencies'],
 		$script_asset['version'],
 		false
@@ -64,7 +63,7 @@ function premium_content_block_enqueue_block_editor_assets() {
 	$editor_css = 'editor.css';
 	wp_register_style(
 		'premium-content-editor',
-		"$url_path/$editor_css",
+		PREMIUM_CONTENT__URL_PATH . '/' . $editor_css,
 		array(),
 		filemtime( "$dir/$editor_css" ),
 		false
@@ -79,20 +78,19 @@ function premium_content_block_enqueue_block_editor_assets() {
  */
 function premium_content_block_enqueue_block_assets() {
 	$script_asset = get_script_asset();
-	$url_path     = PREMIUM_CONTENT__URL_PATH;
 	$dir          = PREMIUM_CONTENT__PLUGIN_DIR;
 
 	$style_css = 'style.css';
 	wp_register_style(
 		'premium-content-frontend',
-		"$url_path/$style_css",
+		PREMIUM_CONTENT__URL_PATH . '/' . $style_css,
 		array(),
 		filemtime( "$dir/$style_css" )
 	);
 
 	wp_register_script(
 		'premium-content-frontend',
-		"$url_path/view.js",
+		PREMIUM_CONTENT__URL_PATH . '/view.js',
 		array(),
 		$script_asset['version'],
 		false

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/premium-content.php
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/premium-content.php
@@ -45,7 +45,28 @@ function premium_content_block_init() {
  * @return void
  */
 function premium_content_block_enqueue_block_editor_assets() {
-	load_static_editor();
+	$info         = get_script_info();
+	$script_asset = $info['script_asset'];
+	$url_path     = $info['url_path'];
+	$dir          = $info['dir'];
+
+	$index_js = 'dist/premium-content.js';
+	wp_register_script(
+		'premium-content-editor',
+		"$url_path/$index_js",
+		$script_asset['dependencies'],
+		$script_asset['version'],
+		false
+	);
+
+	$editor_css = 'editor.css';
+	wp_register_style(
+		'premium-content-editor',
+		"$url_path/$editor_css",
+		array(),
+		filemtime( "$dir/$editor_css" ),
+		false
+	);
 }
 
 /**
@@ -55,7 +76,27 @@ function premium_content_block_enqueue_block_editor_assets() {
  * @return void
  */
 function premium_content_block_enqueue_block_assets() {
-	load_static_frontend();
+	$info         = get_script_info();
+	$script_asset = $info['script_asset'];
+	$url_path     = $info['url_path'];
+	$dir          = $info['dir'];
+
+	$style_css = 'style.css';
+	wp_register_style(
+		'premium-content-frontend',
+		"$url_path/$style_css",
+		array(),
+		filemtime( "$dir/$style_css" )
+	);
+
+	wp_register_script(
+		'premium-content-frontend',
+		"$url_path/view.js",
+		array(),
+		$script_asset['version'],
+		false
+	);
+
 }
 
 
@@ -137,61 +178,6 @@ function register_blocks() {
 			'style'           => 'premium-content-frontend',
 		)
 	);
-}
-
-/**
- * Load static assets for the editor.
- */
-function load_static_editor() {
-	$info         = get_script_info();
-	$script_asset = $info['script_asset'];
-	$url_path     = $info['url_path'];
-	$dir          = $info['dir'];
-
-	$index_js = 'dist/premium-content.js';
-	wp_register_script(
-		'premium-content-editor',
-		"$url_path/$index_js",
-		$script_asset['dependencies'],
-		$script_asset['version'],
-		false
-	);
-
-	$editor_css = 'editor.css';
-	wp_register_style(
-		'premium-content-editor',
-		"$url_path/$editor_css",
-		array(),
-		filemtime( "$dir/$editor_css" ),
-		false
-	);
-}
-
-/**
- * Load static assets for the frontend.
- */
-function load_static_frontend() {
-	$info         = get_script_info();
-	$script_asset = $info['script_asset'];
-	$url_path     = $info['url_path'];
-	$dir          = $info['dir'];
-
-	$style_css = 'style.css';
-	wp_register_style(
-		'premium-content-frontend',
-		"$url_path/$style_css",
-		array(),
-		filemtime( "$dir/$style_css" )
-	);
-
-	wp_register_script(
-		'premium-content-frontend',
-		"$url_path/view.js",
-		array(),
-		$script_asset['version'],
-		false
-	);
-
 }
 
 /**

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/premium-content.php
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/premium-content.php
@@ -380,5 +380,5 @@ function premium_content_default_service( $service ) {
 }
 
 add_action( 'init', 'A8C\FSE\Earn\PremiumContent\premium_content_paywall_initialize', 9 );
-add_action( 'init', 'A8C\FSE\Earn\PremiumContent\premium_content_block_init' );
+add_action( 'enqueue_block_editor_assets', 'A8C\FSE\Earn\PremiumContent\premium_content_block_init' );
 add_filter( PAYWALL_FILTER, 'A8C\FSE\Earn\PremiumContent\premium_content_default_service' );

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/premium-content.php
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/premium-content.php
@@ -49,7 +49,6 @@ function premium_content_block_init() {
  */
 function premium_content_block_enqueue_block_editor_assets() {
 	$script_asset = get_script_asset();
-	$dir          = PREMIUM_CONTENT__PLUGIN_DIR;
 
 	$index_js = 'dist/premium-content.js';
 	wp_register_script(
@@ -65,7 +64,7 @@ function premium_content_block_enqueue_block_editor_assets() {
 		'premium-content-editor',
 		PREMIUM_CONTENT__URL_PATH . '/' . $editor_css,
 		array(),
-		filemtime( "$dir/$editor_css" ),
+		filemtime( PREMIUM_CONTENT__PLUGIN_DIR . '/' . $editor_css ),
 		false
 	);
 }
@@ -78,14 +77,13 @@ function premium_content_block_enqueue_block_editor_assets() {
  */
 function premium_content_block_enqueue_block_assets() {
 	$script_asset = get_script_asset();
-	$dir          = PREMIUM_CONTENT__PLUGIN_DIR;
 
 	$style_css = 'style.css';
 	wp_register_style(
 		'premium-content-frontend',
 		PREMIUM_CONTENT__URL_PATH . '/' . $style_css,
 		array(),
-		filemtime( "$dir/$style_css" )
+		filemtime( PREMIUM_CONTENT__PLUGIN_DIR . '/' . $style_css )
 	);
 
 	wp_register_script(

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/premium-content.php
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/premium-content.php
@@ -48,8 +48,7 @@ function premium_content_block_init() {
  * @return void
  */
 function premium_content_block_enqueue_block_editor_assets() {
-	$info         = get_script_info();
-	$script_asset = $info['script_asset'];
+	$script_asset = get_script_asset();
 	$url_path     = PREMIUM_CONTENT__URL_PATH;
 	$dir          = PREMIUM_CONTENT__PLUGIN_DIR;
 
@@ -79,8 +78,7 @@ function premium_content_block_enqueue_block_editor_assets() {
  * @return void
  */
 function premium_content_block_enqueue_block_assets() {
-	$info         = get_script_info();
-	$script_asset = $info['script_asset'];
+	$script_asset = get_script_asset();
 	$url_path     = PREMIUM_CONTENT__URL_PATH;
 	$dir          = PREMIUM_CONTENT__PLUGIN_DIR;
 
@@ -108,9 +106,9 @@ function premium_content_block_enqueue_block_assets() {
  * Used by enqueue_block_assets and enqueue_block_editor_assets
  *
  * @throws RuntimeException If block assets files are not found.
- * @return array
+ * @return mixed
  */
-function get_script_info() {
+function get_script_asset() {
 	$dir               = PREMIUM_CONTENT__PLUGIN_DIR;
 	$script_asset_path = "$dir/dist/premium-content.asset.php";
 	if ( ! file_exists( $script_asset_path ) ) {
@@ -119,9 +117,7 @@ function get_script_info() {
 		);
 	}
 	$script_asset = include $script_asset_path;
-	return array(
-		'script_asset' => $script_asset,
-	);
+	return $script_asset;
 }
 
 
@@ -443,4 +439,3 @@ add_action( 'enqueue_block_editor_assets', 'A8C\FSE\Earn\PremiumContent\premium_
 add_action( 'enqueue_block_assets', 'A8C\FSE\Earn\PremiumContent\premium_content_block_enqueue_block_assets' );
 
 add_filter( PAYWALL_FILTER, 'A8C\FSE\Earn\PremiumContent\premium_content_default_service' );
-file_put_contents( '/tmp/1.log', "¡hola! 5\n", FILE_APPEND );

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/premium-content.php
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/premium-content.php
@@ -102,7 +102,7 @@ function premium_content_block_enqueue_block_assets() {
 
 /**
  * Helper; Get the 'script_asset', 'url_path', and 'dir'
- * Used by init, enqueue_block_assets, and enqueue_block_editor_assets
+ * Used by enqueue_block_assets and enqueue_block_editor_assets
  *
  * @throws RuntimeException If block assets files are not found.
  * @return array


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR changes the hook used to load the assets files for the premium blocks plugin.

#### The issue

It is not possible to hook a function when the app (block editor) registers the block, at least when the code lives in Jetpack.

```es6
const extendPremiumBlock = ( settings, name ) => {
	// `premium-content` has registered before to this hook :-(
};

addFilter(
	'blocks.registerBlockType',
	'jetpack/extend-premium-content-block',
	extendPremiumBlock
);
```
Changing the hook from `init` to `enqueue_block_editor_assets` fixes this issue. And also, in the end, [enqueue_block_editor_assets](https://developer.wordpress.org/reference/hooks/enqueue_block_editor_assets/) is the proper hook to use when we want to add these assets files.

#### Testing instructions

Nothing should change after applying these modifications in terms of functionality. Confirm the Premium Content block is still working rightly.

Instructions on how to properly test the `premium-content` block here: p58i-8VC-p2

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->