### PR TITLE
media-storage: completely replace flux usage with redux

### DIFF
--- a/client/components/data/query-media-storage/index.jsx
+++ b/client/components/data/query-media-storage/index.jsx
@@ -11,39 +11,22 @@ import { connect } from 'react-redux';
  */
 import { isRequestingMediaStorage } from 'state/sites/media-storage/selectors';
 import { requestMediaStorage } from 'state/sites/media-storage/actions';
-// until we port media over to redux:
-import MediaStore from 'lib/media/store';
 
 class QueryMediaStorage extends Component {
-	constructor( props ) {
-		super( props );
-		this.requestStorage = this.requestStorage.bind( this );
+	componentDidMount() {
+		this.props.requestMediaStorage( this.props.siteId );
 	}
 
-	requestStorage( props = this.props ) {
-		if ( ! props.requestingMediaStorage && props.siteId ) {
-			props.requestMediaStorage( props.siteId );
-		}
-	}
-
-	UNSAFE_componentWillMount() {
-		this.requestStorage();
-		MediaStore.on( 'fetch-media-limits', this.requestStorage );
-	}
-
-	componentWillUnmount() {
-		MediaStore.off( 'fetch-media-limits', this.requestStorage );
-	}
-
-	UNSAFE_componentWillReceiveProps( nextProps ) {
+	componentDidUpdate( prevProps ) {
 		if (
-			nextProps.requestingMediaStorage ||
-			! nextProps.siteId ||
-			this.props.siteId === nextProps.siteId
+			this.props.requestingMediaStorage ||
+			! this.props.siteId ||
+			this.props.siteId === prevProps.siteId
 		) {
 			return;
 		}
-		this.requestStorage( nextProps );
+
+		this.props.requestMediaStorage( this.props.siteId );
 	}
 
 	render() {
@@ -61,9 +44,8 @@ QueryMediaStorage.defaultProps = {
 	requestMediaStorage: () => {},
 };
 
-export default connect(
-	( state, ownProps ) => ( {
-		requestingMediaStorage: isRequestingMediaStorage( state, ownProps.siteId ),
-	} ),
-	{ requestMediaStorage }
-)( QueryMediaStorage );
+const mapStateToProps = ( state, ownProps ) => ( {
+	requestingMediaStorage: isRequestingMediaStorage( state, ownProps.siteId ),
+} );
+
+export default connect( mapStateToProps, { requestMediaStorage } )( QueryMediaStorage );

--- a/client/lib/media/store.js
+++ b/client/lib/media/store.js
@@ -158,12 +158,6 @@ MediaStore.dispatchToken = Dispatcher.register( function ( payload ) {
 
 			MediaStore.emit( 'change' );
 			break;
-		case 'FETCH_MEDIA_LIMITS':
-			if ( ! action.siteId ) {
-				break;
-			}
-			MediaStore.emit( 'fetch-media-limits' );
-			break;
 	}
 } );
 

--- a/client/state/media/thunks/test/upload-media.js
+++ b/client/state/media/thunks/test/upload-media.js
@@ -3,11 +3,11 @@
  */
 import { uploadMedia as uploadMediaThunk } from 'state/media/thunks/upload-media';
 import {
-	dispatchFluxFetchMediaLimits,
 	dispatchFluxReceiveMediaItemError,
 	dispatchFluxReceiveMediaItemSuccess,
 } from 'state/media/utils/flux-adapter';
 import * as syncActions from 'state/media/actions';
+import { requestMediaStorage } from 'state/sites/media-storage/actions';
 import { createTransientMediaItems } from 'state/media/thunks/create-transient-media-items';
 
 jest.mock( 'state/media/utils/is-file-list', () => ( {
@@ -19,9 +19,12 @@ jest.mock( 'state/media/thunks/create-transient-media-items', () => ( {
 } ) );
 
 jest.mock( 'state/media/utils/flux-adapter', () => ( {
-	dispatchFluxFetchMediaLimits: jest.fn(),
 	dispatchFluxReceiveMediaItemError: jest.fn(),
 	dispatchFluxReceiveMediaItemSuccess: jest.fn(),
+} ) );
+
+jest.mock( 'state/sites/media-storage/actions', () => ( {
+	requestMediaStorage: jest.fn(),
 } ) );
 
 describe( 'media - thunks - uploadMedia', () => {
@@ -113,7 +116,7 @@ describe( 'media - thunks - uploadMedia', () => {
 						ID: savedId,
 					}
 				);
-				expect( dispatchFluxFetchMediaLimits ).toHaveBeenCalledWith( siteId );
+				expect( requestMediaStorage ).toHaveBeenCalledWith( siteId );
 			} );
 		} );
 	} );

--- a/client/state/media/thunks/upload-media.js
+++ b/client/state/media/thunks/upload-media.js
@@ -7,11 +7,11 @@ import { castArray, noop, zip } from 'lodash';
  * Internal dependencies
  */
 import {
-	dispatchFluxFetchMediaLimits,
 	dispatchFluxReceiveMediaItemError,
 	dispatchFluxReceiveMediaItemSuccess,
 } from 'state/media/utils/flux-adapter';
 import { receiveMedia, successMediaItemRequest, failMediaItemRequest } from 'state/media/actions';
+import { requestMediaStorage } from 'state/sites/media-storage/actions';
 import { createTransientMediaItems } from 'state/media/thunks/create-transient-media-items';
 import { isFileList } from 'state/media/utils/is-file-list';
 
@@ -73,7 +73,7 @@ export const uploadMedia = (
 			dispatch( successMediaItemRequest( siteId, transientMedia.ID ) );
 			dispatch( receiveMedia( siteId, uploadedMediaWithTransientId, found ) );
 
-			dispatchFluxFetchMediaLimits( siteId );
+			dispatch( requestMediaStorage( siteId ) );
 
 			onItemUploaded( uploadedMediaWithTransientId, file );
 			uploadedItems.push( uploadedMediaWithTransientId );

--- a/client/state/media/utils/flux-adapter.js
+++ b/client/state/media/utils/flux-adapter.js
@@ -114,6 +114,3 @@ export const dispatchFluxRequestMediaItemsSuccess = ( siteId, data, query ) => {
 		query,
 	} );
 };
-
-export const dispatchFluxFetchMediaLimits = ( siteId ) =>
-	Dispatcher.handleServerAction( { type: 'FETCH_MEDIA_LIMITS', siteId } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove any flux code related to media storage

#### Testing instructions

1. Go to `/media` and make sure media storage usage is shown on the top right (see screenshot)
2. Add media items and make sure media storage usage is updated (it's easier to see by uploading a huge image on a site without a plan)
3. Remove media items and make sure those updates are applied as well

<img width="157" alt="Screenshot 2020-08-11 at 13 41 38" src="https://user-images.githubusercontent.com/9202899/89893322-6577f280-dbd8-11ea-83fd-6b51bcf93d98.png">

related #43663 
