### PR TITLE
Gutenboarding: enable new launch flow in production

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -118,7 +118,7 @@ export default {
 		allowExistingUsers: true,
 	},
 	newSiteGutenbergOnboarding: {
-		datestamp: '20200731',
+		datestamp: '20200811',
 		variations: {
 			gutenberg: 50,
 			control: 50,

--- a/config/production.json
+++ b/config/production.json
@@ -40,6 +40,7 @@
 		"external-media/free-photo-library": true,
 		"gdpr-banner": true,
 		"google-my-business": true,
+		"gutenboarding/new-launch": true,
 		"happychat": true,
 		"help": true,
 		"help/courses": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -46,6 +46,7 @@
 		"gutenboarding/mshot-preview": false,
 		"gutenboarding/style-preview-verticals": false,
 		"gutenboarding/language-picker": false,
+		"gutenboarding/new-launch": true,
 		"happychat": true,
 		"help": true,
 		"help/courses": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -53,6 +53,7 @@
 		"gutenboarding/style-preview-verticals": false,
 		"gutenboarding/alpha-templates": true,
 		"gutenboarding/language-picker": false,
+		"gutenboarding/new-launch": true,
 		"happychat": true,
 		"help": true,
 		"help/courses": true,


### PR DESCRIPTION
To be merged into https://github.com/Automattic/wp-calypso/pull/44820 and thus together with Gutenboarding V2 mechanic changes. 

#### Changes proposed in this Pull Request

* Enable new launch flow in Gutenboarding via feature flags
* Bump AB test slug

#### Testing instructions

- Create site via `/new`
- If you go via `/new?vertical` instead, you'll see vertical input
- You should not see domain step
- Once in editor, you should have "complete setup" button in the header
    ![image](https://user-images.githubusercontent.com/87168/89901792-4ab07880-dbee-11ea-9784-0abab5c13c92.png)
- Clicking that and going through steps will launch your site