### PR TITLE
Tweaking the tracking names for the quick start video card on My Home

### DIFF
--- a/client/my-sites/customer-home/cards/education/quick-start-video/index.jsx
+++ b/client/my-sites/customer-home/cards/education/quick-start-video/index.jsx
@@ -34,7 +34,7 @@ export const QuickStartVideo = ( { trackQuickStartImpression } ) => {
 				{ translate( 'Watch this video to get started' ) }
 			</h2>
 			<Card>
-				<div class="quick-start-video__content educational-content">
+				<div className="quick-start-video__content educational-content">
 					<div className="quick-start-video__content-wrapper educational-content__wrapper">
 						<h3>{ translate( 'Video: Getting started on WordPress.com' ) }</h3>
 						<p className="quick-start-video__content-description educational-content__description customer-home__card-subheader">
@@ -58,9 +58,9 @@ export const QuickStartVideo = ( { trackQuickStartImpression } ) => {
 										url: localizeUrl(
 											'https://wordpress.com/support/getting-started-with-wordpress-com/#video-getting-started-with-word-press-com'
 										),
-										card_name: 'FEATURE_QUICK_START_VIDEO',
+										card_name: FEATURE_QUICK_START_VIDEO,
 									} }
-									statsName="QuickStartVideo"
+									statsName={ FEATURE_QUICK_START_VIDEO }
 								>
 									{ translate( 'Watch the video' ) }
 								</InlineSupportLink>
@@ -82,9 +82,9 @@ export const QuickStartVideo = ( { trackQuickStartImpression } ) => {
 									url: localizeUrl(
 										'https://wordpress.com/support/getting-started-with-wordpress-com/#video-getting-started-with-word-press-com'
 									),
-									card_name: 'FEATURE_QUICK_START_VIDEO',
+									card_name: FEATURE_QUICK_START_VIDEO,
 								} }
-								statsName="QuickStartVideo"
+								statsName={ FEATURE_QUICK_START_VIDEO }
 							>
 								<img src={ quickStartVideoImage } alt="" width="186px" />
 							</InlineSupportLink>


### PR DESCRIPTION
This PR completes the client portion of the Quick Start video on My Home, by addressing [these comments](https://github.com/Automattic/wp-calypso/pull/44422#pullrequestreview-464991504) I missed in the [original PR](https://github.com/Automattic/wp-calypso/pull/44422#). 


#### Testing instructions

* Start this branch on your machine
* Point API calls to your sandbox
* Patch your sandbox with D46859
* Confirm that API calls are hitting your sandbox
* Load My Home with a site that hasn't completed site setup (and loads the Site Setup view)
* Check your cookies to confirm that you're allocated to the 'quick-start' variant
* Confirm that the Quick Start card loads, and that inline support modal works properly when you click the video image.
