### PR TITLE
Gutenboarding: Persistent show vertical input.

### DIFF
--- a/client/landing/gutenboarding/hooks/use-show-vertical-input.ts
+++ b/client/landing/gutenboarding/hooks/use-show-vertical-input.ts
@@ -1,0 +1,24 @@
+/**
+ * External dependencies
+ */
+import { useSelect, useDispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { STORE_KEY } from '../stores/onboard';
+import { useVerticalQueryParam } from '../path';
+
+export function useShowVerticalInput() {
+	const hasVerticalQueryParam = useVerticalQueryParam();
+
+	const { showVerticalInput } = useDispatch( STORE_KEY );
+
+	if ( hasVerticalQueryParam ) {
+		showVerticalInput( true );
+	}
+
+	const { shouldShowVerticalInput } = useSelect( ( select ) => select( STORE_KEY ).getState() );
+
+	return hasVerticalQueryParam || shouldShowVerticalInput;
+}

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
@@ -12,11 +12,12 @@ import { useI18n } from '@automattic/react-i18n';
  * Internal dependencies
  */
 import { STORE_KEY } from '../../stores/onboard';
-import { Step, usePath, useVerticalQueryParam } from '../../path';
+import { Step, usePath } from '../../path';
 import Link from '../../components/link';
 import VerticalSelect from './vertical-select';
 import SiteTitle from './site-title';
 import { useTrackStep } from '../../hooks/use-track-step';
+import { useShowVerticalInput } from '../../hooks/use-show-vertical-input';
 import { recordVerticalSkip, recordSiteTitleSkip } from '../../lib/analytics';
 import Arrow from './arrow';
 
@@ -103,11 +104,11 @@ const AcquireIntent: React.FunctionComponent = () => {
 
 	const siteVertical = getSelectedVertical();
 
-	const shouldShowVerticalInput = useVerticalQueryParam();
+	const showVerticalInput = useShowVerticalInput();
 
 	return (
 		<div className="gutenboarding-page acquire-intent">
-			{ shouldShowVerticalInput ? (
+			{ showVerticalInput ? (
 				<>
 					{ isMobile &&
 						( isSiteTitleActive ? (

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
@@ -15,7 +15,7 @@ import { recordSiteTitleSelection } from '../../lib/analytics';
 import tip from './tip';
 import AcquireIntentTextInput from './acquire-intent-text-input';
 import useTyper from '../../hooks/use-typer';
-import { useVerticalQueryParam } from '../../path';
+import { useShowVerticalInput } from '../../hooks/use-show-vertical-input';
 
 interface Props {
 	onSubmit: () => void;
@@ -27,6 +27,7 @@ const SiteTitle: React.FunctionComponent< Props > = ( { onSubmit, inputRef } ) =
 	const { siteTitle } = useSelect( ( select ) => select( STORE_KEY ).getState() );
 	const { setSiteTitle } = useDispatch( STORE_KEY );
 	const [ isTouched, setIsTouched ] = React.useState( false );
+	const showVerticalInput = useShowVerticalInput();
 	const siteTitleExamples = [
 		/* translators: This is an example of a site name,
 		   feel free to create your own but please keep it under 22 characters */
@@ -83,10 +84,8 @@ const SiteTitle: React.FunctionComponent< Props > = ( { onSubmit, inputRef } ) =
 		setIsTouched( true );
 	};
 
-	const shouldShowVerticalInput = useVerticalQueryParam();
-
 	// translators: label for site title input in Gutenboarding
-	const inputLabel = shouldShowVerticalInput ? __( "It's called" ) : __( 'My site is called' );
+	const inputLabel = showVerticalInput ? __( "It's called" ) : __( 'My site is called' );
 
 	const placeHolder = useTyper( siteTitleExamples, ! siteTitle, {
 		delayBetweenCharacters: 70,

--- a/client/landing/gutenboarding/stores/onboard/actions.ts
+++ b/client/landing/gutenboarding/stores/onboard/actions.ts
@@ -57,6 +57,11 @@ export const resetSiteVertical = () => ( {
 	type: 'RESET_SITE_VERTICAL' as const,
 } );
 
+export const showVerticalInput = ( shouldShowVerticalInput: boolean ) => ( {
+	type: 'SET_SHOW_SITE_VERTICAL_INPUT' as const,
+	shouldShowVerticalInput,
+} );
+
 export const setSiteTitle = ( siteTitle: string ) => ( {
 	type: 'SET_SITE_TITLE' as const,
 	siteTitle,
@@ -187,6 +192,7 @@ export type OnboardAction = ReturnType<
 	| typeof setDomainSearch
 	| typeof setDomainCategory
 	| typeof skipSiteVertical
+	| typeof showVerticalInput
 	| typeof setFonts
 	| typeof setIsRedirecting
 	| typeof setHasUsedDomainsStep

--- a/client/landing/gutenboarding/stores/onboard/index.ts
+++ b/client/landing/gutenboarding/stores/onboard/index.ts
@@ -29,6 +29,7 @@ registerStore< State >( STORE_KEY, {
 		'domainSearch',
 		'siteTitle',
 		'siteVertical',
+		'shouldShowVerticalInput',
 		'wasVerticalSkipped',
 		'hasUsedDomainsStep',
 		'hasUsedPlansStep',

--- a/client/landing/gutenboarding/stores/onboard/reducer.ts
+++ b/client/landing/gutenboarding/stores/onboard/reducer.ts
@@ -86,6 +86,16 @@ const wasVerticalSkipped: Reducer< boolean, OnboardAction > = ( state = false, a
 	return state;
 };
 
+const shouldShowVerticalInput: Reducer< boolean, OnboardAction > = ( state = false, action ) => {
+	if ( action.type === 'SET_SHOW_SITE_VERTICAL_INPUT' ) {
+		return action.shouldShowVerticalInput;
+	}
+	if ( action.type === 'RESET_ONBOARD_STORE' ) {
+		return false;
+	}
+	return state;
+};
+
 const pageLayouts: Reducer< string[], OnboardAction > = ( state = [], action ) => {
 	if ( action.type === 'TOGGLE_PAGE_LAYOUT' ) {
 		const layout = action.pageLayout;
@@ -207,6 +217,7 @@ const reducer = combineReducers( {
 	plan,
 	selectedFeatures,
 	wasVerticalSkipped,
+	shouldShowVerticalInput,
 } );
 
 export type State = ReturnType< typeof reducer >;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Make vertical input persistent by moving it to the data store.

#### Testing instructions

* Go to `/new`.
  * It should show **My site is called...**.
* Go to `/new?vertical`.
  * It should show **My site is about...**.
* Go to `/new` again.
  * It should still show **My site is about...**.
* Go to `/new?fresh`.
  * It should show **My site is called...**.