### PR TITLE
Editing toolkit plugin: update version in readme.txt to 1.16

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/readme.txt
+++ b/apps/full-site-editing/full-site-editing-plugin/readme.txt
@@ -3,7 +3,7 @@ Contributors: alexislloyd, allancole, automattic, bartkalisz, codebykat, copons,
 Tags: block, blocks, editor, gutenberg, page
 Requires at least: 5.0
 Tested up to: 5.4
-Stable tag: 1.15
+Stable tag: 1.16
 Requires PHP: 5.6.20
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Leftover from https://github.com/Automattic/wp-calypso/pull/44817

> The new version (1.16) does not match the stable tag (1.15) in readme.txt.
> Version info:
>	Previous Version: 1.15
>	New Version (defined in plugin loader): 1.16
>	Stable Tag (defined in readme.txt): 1.15

#### Testing instructions

Nothing to test. :-)