### PR TITLE
Gutenboarding launch flow: add domain suggestion to summary step

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/common/data-stores/launch/reducer.ts
+++ b/apps/full-site-editing/full-site-editing-plugin/common/data-stores/launch/reducer.ts
@@ -43,7 +43,7 @@ const domain: Reducer< DomainSuggestions.DomainSuggestion | undefined, LaunchAct
 };
 
 const domainSearch: Reducer< string, LaunchAction > = ( state = '', action ) => {
-	if ( action.type === 'SET_DOMAIN_SEARCH' ) {
+	if ( action.type === 'SET_DOMAIN_SEARCH' && action.domainSearch?.length > 1 ) {
 		return action.domainSearch;
 	}
 	return state;

--- a/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/hooks/index.ts
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/hooks/index.ts
@@ -1,2 +1,3 @@
 export * from './use-site';
 export * from './use-on-launch';
+export * from './use-domain-suggestion';

--- a/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/hooks/use-domain-suggestion.ts
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/hooks/use-domain-suggestion.ts
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import { useSelect } from '@wordpress/data';
+
+/**
+ * External dependencies
+ */
+import { DOMAINS_STORE, LAUNCH_STORE } from '../stores';
+
+export function useDomainSuggestion() {
+	const { domainSearch } = useSelect( ( select ) => select( LAUNCH_STORE ).getState() );
+	const suggestion = useSelect(
+		( select ) => {
+			if ( ! domainSearch || domainSearch.length < 2 ) {
+				return;
+			}
+			return select( DOMAINS_STORE ).getDomainSuggestions( domainSearch, {
+				// Avoid `only_wordpressdotcom` — it seems to fail to find results sometimes
+				include_wordpressdotcom: false,
+				include_dotblogsubdomain: false,
+				quantity: 1, // this will give the recommended domain only
+				// TODO: support i18n
+				locale: 'en',
+			} );
+		},
+		[ domainSearch ]
+	)?.[ 0 ];
+
+	return suggestion;
+}

--- a/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/hooks/use-on-launch.ts
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/hooks/use-on-launch.ts
@@ -64,7 +64,7 @@ export const useOnLaunch = () => {
 				go();
 				return;
 			}
-			window.location.href = `https://wordpress.com/home/${ window._currentSiteId }`;
+			window.top.location.href = `https://wordpress.com/home/${ window._currentSiteId }`;
 		}
 	}, [ launchStatus ] );
 };

--- a/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-steps/final-step/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-steps/final-step/index.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import * as React from 'react';
+import classnames from 'classnames';
 import { ThemeProvider } from 'emotion-theming';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -26,7 +27,7 @@ import {
 import { LaunchStep } from '../../../../common/data-stores/launch/data';
 import LaunchStepContainer, { Props as LaunchStepProps } from '../../launch-step';
 import { LAUNCH_STORE, PLANS_STORE } from '../../stores';
-import { useSite } from '../../hooks';
+import { useSite, useDomainSuggestion } from '../../hooks';
 
 import './styles.scss';
 
@@ -40,6 +41,7 @@ const FinalStep: React.FunctionComponent< LaunchStepProps > = ( { onNextStep } )
 	const { completedSteps } = useSelect( ( select ) => select( LAUNCH_STORE ).getState() );
 	const { setStep } = useDispatch( LAUNCH_STORE );
 	const prices = useSelect( ( select ) => select( PLANS_STORE ).getPrices() );
+	const domainSuggestion = useDomainSuggestion();
 
 	const nameSummary = (
 		<div className="nux-launch__summary-item">
@@ -61,9 +63,24 @@ const FinalStep: React.FunctionComponent< LaunchStepProps > = ( { onNextStep } )
 						{ __( 'Free site address', 'full-site-editing' ) }: { currentDomainName }
 					</p>
 					<Tip>
-						{ __(
-							'A custom site address like madefreshbakery.com (now available!) is more unique and can help with your SEO ranking.',
-							'full-site-editing'
+						{ createInterpolateElement(
+							/* translators: <DomainName /> is the suggested custom domain name; <Link> will redirect users to domain selection step */
+							__(
+								'A custom site address like <DomainName /> (<Link>now available!</Link>) is more unique and can help with your SEO ranking.',
+								'full-site-editing'
+							),
+							{
+								DomainName: (
+									<span
+										className={ classnames( 'nux-launch__summary-item__domain-name', {
+											'is-loading': ! domainSuggestion,
+										} ) }
+									>
+										{ domainSuggestion?.domain_name || 'loading-example.com' }
+									</span>
+								),
+								Link: <Button isLink onClick={ () => setStep( LaunchStep.Domain ) } />,
+							}
 						) }
 					</Tip>
 				</>
@@ -85,13 +102,13 @@ const FinalStep: React.FunctionComponent< LaunchStepProps > = ( { onNextStep } )
 					<p>{ __( 'Plan subscription: Free forever', 'full-site-editing' ) }</p>
 					<Tip>
 						{ createInterpolateElement(
-							/* translators: pressing <link> will redirect user to plan selection step */
+							/* translators: pressing <Link> will redirect user to plan selection step */
 							__(
-								'<link>Upgrade to Premium</link> to get access to 13GB storage space, payment collection options, 24/7 Live Chat support, and more. Not sure? Give it a spin—we offer 30-day full-refunds, guaranteed.',
+								'<Link>Upgrade to Premium</Link> to get access to 13GB storage space, payment collection options, 24/7 Live Chat support, and more. Not sure? Give it a spin—we offer 30-day full-refunds, guaranteed.',
 								'full-site-editing'
 							),
 							{
-								link: <Button isLink onClick={ () => setStep( LaunchStep.Plan ) } />,
+								Link: <Button isLink onClick={ () => setStep( LaunchStep.Plan ) } />,
 							}
 						) }
 					</Tip>

--- a/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-steps/final-step/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-steps/final-step/index.tsx
@@ -3,6 +3,7 @@
  */
 import * as React from 'react';
 import { ThemeProvider } from 'emotion-theming';
+import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { Button, Tip } from '@wordpress/components';
@@ -83,9 +84,15 @@ const FinalStep: React.FunctionComponent< LaunchStepProps > = ( { onNextStep } )
 					<p className="nux-launch__summary-item__plan-name">WordPress.com Free</p>
 					<p>{ __( 'Plan subscription: Free forever', 'full-site-editing' ) }</p>
 					<Tip>
-						{ __(
-							'Upgrade to Premium to get access to 13GB storage space, payment collection options, 24/7 Live Chat support, and more. Not sure? Give it a spin—we offer 30-day full-refunds, guaranteed.',
-							'full-site-editing'
+						{ createInterpolateElement(
+							/* translators: pressing <link> will redirect user to plan selection step */
+							__(
+								'<link>Upgrade to Premium</link> to get access to 13GB storage space, payment collection options, 24/7 Live Chat support, and more. Not sure? Give it a spin—we offer 30-day full-refunds, guaranteed.',
+								'full-site-editing'
+							),
+							{
+								link: <Button isLink onClick={ () => setStep( LaunchStep.Plan ) } />,
+							}
 						) }
 					</Tip>
 				</>

--- a/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-steps/final-step/styles.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-steps/final-step/styles.scss
@@ -3,6 +3,10 @@
 
 .nux-launch__feature-list {
 	padding: 20px;
+
+	p {
+		margin: 10px 0 0;
+	}
 }
 .nux-launch__feature-list-title {
 	margin: 0 0 10px;

--- a/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-steps/final-step/styles.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-steps/final-step/styles.scss
@@ -74,4 +74,11 @@ ul.nux-launch__feature-item-group {
 	&__plan-name {
 		color: var( --color-text );
 	}
+	&__domain-name {
+		font-weight: 600;
+
+		&.is-loading {
+			@include onboarding-placeholder();
+		}
+	}
 }

--- a/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/stores/index.ts
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/stores/index.ts
@@ -6,3 +6,4 @@ import 'a8c-fse-common-data-stores';
 export const SITE_STORE = 'automattic/site';
 export const LAUNCH_STORE = 'automattic/launch';
 export const PLANS_STORE = 'automattic/onboard/plans';
+export const DOMAINS_STORE = 'automattic/domains/suggestions';

--- a/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/wp-components-types.d.ts
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/wp-components-types.d.ts
@@ -1,0 +1,5 @@
+declare module '@wordpress/components' {
+	const Tip: React.ComponentType;
+}
+
+export {};

--- a/apps/full-site-editing/typings/fse/index.d.ts
+++ b/apps/full-site-editing/typings/fse/index.d.ts
@@ -1,3 +1,13 @@
 // This empty module corresponds to a WordPress script handle of the same name.
 // Our build system externalizes and adds it to the script dependencies when it's imported.
 declare module 'a8c-fse-common-data-stores' {}
+
+declare module '@automattic/composite-checkout' {
+	const CheckoutStepBody: React.ComponentType< any >;
+	const CheckoutSummaryArea: React.ComponentType< any >;
+	const CheckoutSummaryCard: React.ComponentType< any >;
+	const MainContentUI: React.ComponentType< any >;
+	const CheckoutStepAreaUI: React.ComponentType< any >;
+	const SubmitButtonWrapperUI: React.ComponentType< any >;
+	const checkoutTheme: {};
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* When a free domain is selected, add a domain suggestion to summary step and a link to domain selection step https://cloudup.com/cnYQcB85Vrm
* Add a link _Upgrade to premium_ on plan summary if Free plan is selected.

#### Testing instructions

* Create a site starting from [horizon.wordpress.com/new](https://horizon.wordpress.com/new).
* Press Complete setup button to open launch flow.
* Choose a free domain and advance to Launch you site step. A custom domain suggestion should appear.

#### Screenshot
<img width="1417" alt="Screenshot 2020-08-11 at 18 36 05" src="https://user-images.githubusercontent.com/14192054/89918650-f9f74a80-dc02-11ea-93cf-30bde276784c.png">

Fixes part of #43750 
