### PR TITLE
e2e tests: Add composite checkout support to CheckOutPage helper

### DIFF
--- a/test/e2e/lib/components/secure-payment-component.js
+++ b/test/e2e/lib/components/secure-payment-component.js
@@ -57,7 +57,14 @@ export default class SecurePaymentComponent extends AsyncBaseContainer {
 		return await this.driver.switchTo().defaultContent();
 	}
 
-	async enterTestCreditCardDetails( { cardHolder, cardNumber, cardExpiry, cardCVV } ) {
+	async enterTestCreditCardDetails( {
+		cardHolder,
+		cardNumber,
+		cardExpiry,
+		cardCVV,
+		cardPostCode,
+		cardCountryCode,
+	} ) {
 		// This PR introduced an issue with older browsers, specifically IE11:
 		//   https://github.com/Automattic/wp-calypso/pull/22239
 		const pauseBetweenKeysMS = 1;
@@ -67,7 +74,7 @@ export default class SecurePaymentComponent extends AsyncBaseContainer {
 		// are part of the contact form and must be filled out explicitly before
 		// calling this function by using
 		// SecurePaymentComponent.completeTaxDetailsInContactSection.
-		await this.completeTaxDetailsForCreditCard();
+		await this.completeTaxDetailsForCreditCard( { cardPostCode, cardCountryCode } );
 
 		await driverHelper.setWhenSettable(
 			this.driver,

--- a/test/e2e/lib/pages/signup/checkout-page.js
+++ b/test/e2e/lib/pages/signup/checkout-page.js
@@ -57,15 +57,6 @@ export default class CheckOutPage extends AsyncBaseContainer {
 		);
 
 		await driverHelper.setWhenSettable( this.driver, By.id( 'postal-code' ), postalCode );
-
-		const isCompositeCheckout = await this.isCompositeCheckout();
-
-		if ( isCompositeCheckout ) {
-			await driverHelper.clickWhenClickable(
-				this.driver,
-				By.css( 'button[aria-label="Continue with the entered contact details"]' )
-			);
-		}
 	}
 
 	async isCompositeCheckout() {
@@ -73,14 +64,13 @@ export default class CheckOutPage extends AsyncBaseContainer {
 	}
 
 	async submitForm() {
-		const disabledPaymentButton = By.css(
-			'.credit-card-payment-box button[disabled],.composite-checkout .checkout-submit-button button[disabled]'
-		);
-		const paymentButtonSelector = By.css(
-			'.credit-card-payment-box button.is-primary:not([disabled]),.composite-checkout .checkout-submit-button button'
-		);
-
-		await driverHelper.waitTillNotPresent( this.driver, disabledPaymentButton );
-		await driverHelper.clickWhenClickable( this.driver, paymentButtonSelector );
+		const isCompositeCheckout = await this.isCompositeCheckout();
+		if ( isCompositeCheckout ) {
+			return await driverHelper.clickWhenClickable(
+				this.driver,
+				By.css( 'button[aria-label="Continue with the entered contact details"]' )
+			);
+		}
+		return await driverHelper.clickWhenClickable( this.driver, By.css( 'button[type="submit"]' ) );
 	}
 }

--- a/test/e2e/lib/pages/signup/checkout-page.js
+++ b/test/e2e/lib/pages/signup/checkout-page.js
@@ -15,7 +15,7 @@ export default class CheckOutPage extends AsyncBaseContainer {
 	constructor( driver, url = null ) {
 		super(
 			driver,
-			By.css( '.checkout__secure-payment-form,.secure-payment-form,.composite-checkout' ),
+			By.css( '.checkout,.composite-checkout' ),
 			url,
 			2 * config.get( 'explicitWaitMS' )
 		);

--- a/test/e2e/specs/wp-signup-spec.js
+++ b/test/e2e/specs/wp-signup-spec.js
@@ -17,7 +17,7 @@ import StartPage from '../lib/pages/signup/start-page.js';
 import JetpackAddNewSitePage from '../lib/pages/signup/jetpack-add-new-site-page';
 
 import AboutPage from '../lib/pages/signup/about-page.js';
-import CustomerHomePage from '../lib/pages/customer-home-page'
+import CustomerHomePage from '../lib/pages/customer-home-page';
 import DomainFirstPage from '../lib/pages/signup/domain-first-page';
 import ReaderLandingPage from '../lib/pages/signup/reader-landing-page';
 import PickAPlanPage from '../lib/pages/signup/pick-a-plan-page.js';
@@ -182,7 +182,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 			try {
 				await CustomerHomePage.Expect( driver );
 			} catch ( e ) {
-				await ReaderPage.Expect( driver )
+				await ReaderPage.Expect( driver );
 			}
 		} );
 
@@ -464,6 +464,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 		step( 'Can enter and submit test payment details', async function () {
 			const testCreditCardDetails = dataHelper.getTestCreditCardDetails();
 			const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
+			await securePaymentComponent.completeContactDetails( testCreditCardDetails );
 			await securePaymentComponent.enterTestCreditCardDetails( testCreditCardDetails );
 			await securePaymentComponent.submitPaymentDetails();
 			return await securePaymentComponent.waitForPageToDisappear();
@@ -599,6 +600,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 		step( 'Can submit test payment details', async function () {
 			const testCreditCardDetails = dataHelper.getTestCreditCardDetails();
 			const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
+			await securePaymentComponent.completeContactDetails( testCreditCardDetails );
 			await securePaymentComponent.enterTestCreditCardDetails( testCreditCardDetails );
 			await securePaymentComponent.submitPaymentDetails();
 			return await securePaymentComponent.waitForPageToDisappear();
@@ -708,6 +710,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 		step( 'Can submit test payment details', async function () {
 			const testCreditCardDetails = dataHelper.getTestCreditCardDetails();
 			const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
+			await securePaymentComponent.completeContactDetails( testCreditCardDetails );
 			await securePaymentComponent.enterTestCreditCardDetails( testCreditCardDetails );
 			await securePaymentComponent.submitPaymentDetails();
 			return await securePaymentComponent.waitForPageToDisappear();
@@ -844,6 +847,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 		step( 'Can enter/submit test payment details', async function () {
 			const testCreditCardDetails = dataHelper.getTestCreditCardDetails();
 			const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
+			// No need to fill out contact details here as they already have been completed
 			await securePaymentComponent.enterTestCreditCardDetails( testCreditCardDetails );
 			await securePaymentComponent.submitPaymentDetails();
 			await securePaymentComponent.waitForCreditCardPaymentProcessing();
@@ -1035,6 +1039,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 		step( 'Can enter/submit test payment details', async function () {
 			const testCreditCardDetails = dataHelper.getTestCreditCardDetails();
 			const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
+			// No need to fill out contact details here as they already have been completed
 			await securePaymentComponent.enterTestCreditCardDetails( testCreditCardDetails );
 			await securePaymentComponent.submitPaymentDetails();
 			await securePaymentComponent.waitForCreditCardPaymentProcessing();
@@ -1252,6 +1257,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 		step( 'Can submit test payment details', async function () {
 			const testCreditCardDetails = dataHelper.getTestCreditCardDetails();
 			const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
+			await securePaymentComponent.completeContactDetails( testCreditCardDetails );
 			await securePaymentComponent.enterTestCreditCardDetails( testCreditCardDetails );
 			await securePaymentComponent.submitPaymentDetails();
 			return await securePaymentComponent.waitForPageToDisappear();

--- a/test/e2e/specs/wp-signup-spec.js
+++ b/test/e2e/specs/wp-signup-spec.js
@@ -464,7 +464,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 		step( 'Can enter and submit test payment details', async function () {
 			const testCreditCardDetails = dataHelper.getTestCreditCardDetails();
 			const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
-			await securePaymentComponent.completeContactDetails( testCreditCardDetails );
+			await securePaymentComponent.completeTaxDetailsInContactSection( testCreditCardDetails );
 			await securePaymentComponent.enterTestCreditCardDetails( testCreditCardDetails );
 			await securePaymentComponent.submitPaymentDetails();
 			return await securePaymentComponent.waitForPageToDisappear();
@@ -600,7 +600,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 		step( 'Can submit test payment details', async function () {
 			const testCreditCardDetails = dataHelper.getTestCreditCardDetails();
 			const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
-			await securePaymentComponent.completeContactDetails( testCreditCardDetails );
+			await securePaymentComponent.completeTaxDetailsInContactSection( testCreditCardDetails );
 			await securePaymentComponent.enterTestCreditCardDetails( testCreditCardDetails );
 			await securePaymentComponent.submitPaymentDetails();
 			return await securePaymentComponent.waitForPageToDisappear();
@@ -710,7 +710,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 		step( 'Can submit test payment details', async function () {
 			const testCreditCardDetails = dataHelper.getTestCreditCardDetails();
 			const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
-			await securePaymentComponent.completeContactDetails( testCreditCardDetails );
+			await securePaymentComponent.completeTaxDetailsInContactSection( testCreditCardDetails );
 			await securePaymentComponent.enterTestCreditCardDetails( testCreditCardDetails );
 			await securePaymentComponent.submitPaymentDetails();
 			return await securePaymentComponent.waitForPageToDisappear();
@@ -1257,7 +1257,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 		step( 'Can submit test payment details', async function () {
 			const testCreditCardDetails = dataHelper.getTestCreditCardDetails();
 			const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
-			await securePaymentComponent.completeContactDetails( testCreditCardDetails );
+			await securePaymentComponent.completeTaxDetailsInContactSection( testCreditCardDetails );
 			await securePaymentComponent.enterTestCreditCardDetails( testCreditCardDetails );
 			await securePaymentComponent.submitPaymentDetails();
 			return await securePaymentComponent.waitForPageToDisappear();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When the e2e tests were updated to work with both old and new checkout in https://github.com/Automattic/wp-calypso/pull/43223 we never updated the `CheckOutPage` helper which is used on a few tests. Because we still have an AB Test which divides old and new checkout for non-USD currencies, those tests _sometimes_ continued to pass when they were using old checkout. 

This PR updates the `CheckOutPage` helper to handle new checkout as well as old checkout.

To do this, we had to separate out the concept of filling out the postal code and country fields that are part of the credit card form in old checkout versus the postal code and country fields that are part of the contact step in new checkout.

#### Testing instructions

When running these tests locally, I always end up in old checkout, however, we can force new checkout to happen by applying the following patch in addition to this PR:

```diff
diff --git a/client/my-sites/checkout/checkout-system-decider.js b/client/my-sites/checkout/checkout-system-decider.js
index db10317bcf..924e420704 100644
--- a/client/my-sites/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout-system-decider.js
@@ -242,6 +242,7 @@ function getCheckoutVariant(
        isAtomic,
        isLoggedOutCart
 ) {
+       return 'composite-checkout';
        if ( config.isEnabled( 'old-checkout-force' ) ) {
                debug( 'shouldShowCompositeCheckout false because old-checkout-force flag is set' );
                return 'old-checkout';
```

Then run the e2e tests normally, as follows. If you haven't run e2e tests before, you may need to follow the setup instructions in the field guide.

```
cd tests/e2e
env BROWSERSIZE=desktop ./node_modules/.bin/mocha --grep "Sign up for a site on a business paid plan w/ domain name coming" specs/wp-signup-spec.js
```