### PR TITLE
Product card: prevent early price wrapping

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card/style.scss
@@ -84,6 +84,7 @@ $jetpack-product-card-icon-size: 55px;
 }
 
 .jetpack-product-card__headings {
+	width: 66%;
 	margin-right: 16px;
 }
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

In the final copy, the taglines of some new products are longer than what initially thought, pushing the price on a new line in a strange way (see screenshots). This PR fixes it.

### Testing instructions

- Visit the _Plans_ page with the Offer Reset flow enabled
- Check that the tagline never takes the full width of the card, pushing the price on a new line

### Screenshots

#### Before
<img width="565" alt="Screen Shot 2020-08-11 at 9 08 01 AM" src="https://user-images.githubusercontent.com/1620183/89930635-0bc3f800-dbd9-11ea-8c2d-23ca8627bb6e.png">


#### After
<img width="437" alt="Screen Shot 2020-08-11 at 1 42 54 PM" src="https://user-images.githubusercontent.com/1620183/89930648-11b9d900-dbd9-11ea-8a5c-124e0cf3d1bf.png">
