### PR TITLE
Product card: prepend price with 'from' when options available

### DIFF
--- a/client/my-sites/plans-v2/plans-column/index.tsx
+++ b/client/my-sites/plans-v2/plans-column/index.tsx
@@ -1,20 +1,14 @@
 /**
  * External dependencies
  */
-import React, { useMemo } from 'react';
 import { translate } from 'i18n-calypso';
+import React, { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
 /**
  * Internal dependencies
  */
-import {
-	durationToText,
-	slugToItem,
-	itemToSelectorProduct,
-	productButtonLabel,
-	slugIsSelectorProductSlug,
-} from '../utils';
+import { durationToText, slugToItem, itemToSelectorProduct, productButtonLabel } from '../utils';
 import {
 	PRODUCTS_TYPES,
 	SELECTOR_PLANS,
@@ -72,7 +66,7 @@ const PlanComponent = ( {
 			onButtonClick={ () => onClick( plan ) }
 			features={ { items: [] } }
 			originalPrice={ price }
-			withStartingPrice={ slugIsSelectorProductSlug( plan.productSlug ) }
+			withStartingPrice={ Array.isArray( plan.subtypes ) && plan.subtypes.length > 0 }
 			isOwned={ plan.owned }
 			isDeprecated={ plan.legacy }
 		/>

--- a/client/my-sites/plans-v2/plans-column/index.tsx
+++ b/client/my-sites/plans-v2/plans-column/index.tsx
@@ -8,7 +8,13 @@ import { useSelector } from 'react-redux';
 /**
  * Internal dependencies
  */
-import { durationToText, slugToItem, itemToSelectorProduct, productButtonLabel } from '../utils';
+import {
+	durationToText,
+	slugToItem,
+	itemToSelectorProduct,
+	productButtonLabel,
+	slugIsSelectorProductSlug,
+} from '../utils';
 import {
 	PRODUCTS_TYPES,
 	SELECTOR_PLANS,
@@ -66,6 +72,7 @@ const PlanComponent = ( {
 			onButtonClick={ () => onClick( plan ) }
 			features={ { items: [] } }
 			originalPrice={ price }
+			withStartingPrice={ slugIsSelectorProductSlug( plan.productSlug ) }
 			isOwned={ plan.owned }
 			isDeprecated={ plan.legacy }
 		/>

--- a/client/my-sites/plans-v2/plans-column/index.tsx
+++ b/client/my-sites/plans-v2/plans-column/index.tsx
@@ -66,7 +66,7 @@ const PlanComponent = ( {
 			onButtonClick={ () => onClick( plan ) }
 			features={ { items: [] } }
 			originalPrice={ price }
-			withStartingPrice={ Array.isArray( plan.subtypes ) && plan.subtypes.length > 0 }
+			withStartingPrice={ plan.subtypes && plan.subtypes.length > 0 }
 			isOwned={ plan.owned }
 			isDeprecated={ plan.legacy }
 		/>

--- a/client/my-sites/plans-v2/products-column/index.tsx
+++ b/client/my-sites/plans-v2/products-column/index.tsx
@@ -55,7 +55,7 @@ const ProductComponent = ( {
 		features={ { items: [] } }
 		discountedPrice={ product.discountCost }
 		originalPrice={ product.cost || 0 }
-		withStartingPrice={ Array.isArray( product.subtypes ) && product.subtypes.length > 0 }
+		withStartingPrice={ product.subtypes && product.subtypes.length > 0 }
 		isOwned={ product.owned }
 	/>
 );

--- a/client/my-sites/plans-v2/products-column/index.tsx
+++ b/client/my-sites/plans-v2/products-column/index.tsx
@@ -1,8 +1,8 @@
 /**
  * External dependencies
  */
-import React, { useMemo } from 'react';
 import { translate } from 'i18n-calypso';
+import React, { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
 /**
@@ -14,7 +14,6 @@ import {
 	itemToSelectorProduct,
 	productButtonLabel,
 	getProductPrices,
-	slugIsSelectorProductSlug,
 } from '../utils';
 import { PRODUCTS_TYPES, SELECTOR_PRODUCTS } from '../constants';
 import { isProductsListFetching, getAvailableProductsList } from 'state/products-list/selectors';
@@ -56,7 +55,7 @@ const ProductComponent = ( {
 		features={ { items: [] } }
 		discountedPrice={ product.discountCost }
 		originalPrice={ product.cost || 0 }
-		withStartingPrice={ slugIsSelectorProductSlug( product.productSlug ) }
+		withStartingPrice={ Array.isArray( product.subtypes ) && product.subtypes.length > 0 }
 		isOwned={ product.owned }
 	/>
 );

--- a/client/my-sites/plans-v2/products-column/index.tsx
+++ b/client/my-sites/plans-v2/products-column/index.tsx
@@ -14,6 +14,7 @@ import {
 	itemToSelectorProduct,
 	productButtonLabel,
 	getProductPrices,
+	slugIsSelectorProductSlug,
 } from '../utils';
 import { PRODUCTS_TYPES, SELECTOR_PRODUCTS } from '../constants';
 import { isProductsListFetching, getAvailableProductsList } from 'state/products-list/selectors';
@@ -55,6 +56,7 @@ const ProductComponent = ( {
 		features={ { items: [] } }
 		discountedPrice={ product.discountCost }
 		originalPrice={ product.cost || 0 }
+		withStartingPrice={ slugIsSelectorProductSlug( product.productSlug ) }
 		isOwned={ product.owned }
 	/>
 );


### PR DESCRIPTION
### Changes proposed in this Pull Request

Prepends _from_ to the price of a product if it has available options (i.e. Real-Time or Daily)

### Testing instructions

- Visit the _Plans_ section with the Offer Reset flow enabled.
- Check that the price of **Jetpack Backup** is prepended by _from_.
- If you want to check plans too, you'll have to run the PR locally and update `PRODUCTS_WITH_OPTIONS` in `
client/my-sites/plans-v2/constants.ts` with the plan you're testing.

### Screenshots

#### Before
<img width="412" alt="Screen Shot 2020-08-11 at 2 40 34 PM" src="https://user-images.githubusercontent.com/1620183/89936742-15059280-dbe2-11ea-8d7b-dd9241e9b5b8.png">

#### After
<img width="369" alt="Screen Shot 2020-08-11 at 2 43 07 PM" src="https://user-images.githubusercontent.com/1620183/89936749-18991980-dbe2-11ea-9f47-ac8fb513e382.png">
