### PR TITLE
Product card: add logic to build labels

### DIFF
--- a/client/components/jetpack/card/jetpack-plan-card/style.scss
+++ b/client/components/jetpack/card/jetpack-plan-card/style.scss
@@ -28,7 +28,7 @@
 			border-color: $jetpack-free-plan-color;
 		}
 
-		.jetpack-product-card__badge {
+		&:not( .is-owned ) .jetpack-product-card__badge {
 			color: $jetpack-free-plan-color;
 		}
 	}
@@ -38,7 +38,7 @@
 			border-color: $jetpack-personal-plan-color;
 		}
 
-		.jetpack-product-card__badge {
+		&:not( .is-owned ) .jetpack-product-card__badge {
 			color: $jetpack-personal-plan-color;
 		}
 	}
@@ -48,7 +48,7 @@
 			border-color: $jetpack-premium-plan-color;
 		}
 
-		.jetpack-product-card__badge {
+		&:not( .is-owned ) .jetpack-product-card__badge {
 			color: $jetpack-premium-plan-color;
 		}
 	}
@@ -58,7 +58,7 @@
 			border-color: $jetpack-professional-plan-color;
 		}
 
-		.jetpack-product-card__badge {
+		&:not( .is-owned ) .jetpack-product-card__badge {
 			color: $jetpack-professional-plan-color;
 		}
 	}

--- a/client/components/jetpack/card/jetpack-product-card/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/index.tsx
@@ -39,7 +39,7 @@ type OwnProps = {
 	discountedPrice?: number;
 	withStartingPrice?: boolean;
 	billingTimeFrame: TranslateResult;
-	badgeLabel?: string;
+	badgeLabel?: TranslateResult;
 	discountMessage?: string;
 	buttonLabel: TranslateResult;
 	onButtonClick: () => void;

--- a/client/components/jetpack/card/jetpack-product-card/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card/style.scss
@@ -212,6 +212,7 @@ $jetpack-product-card-icon-size: 55px;
 
 .jetpack-product-card.is-owned .jetpack-product-card__badge {
 	background-color: var( --color-neutral-40 );
+	border: none;
 	color: var( --color-text-inverted );
 }
 

--- a/client/my-sites/plans-v2/constants.ts
+++ b/client/my-sites/plans-v2/constants.ts
@@ -24,6 +24,7 @@ import {
 	PLAN_JETPACK_SECURITY_DAILY_MONTHLY,
 	PLAN_JETPACK_SECURITY_REALTIME,
 	PLAN_JETPACK_SECURITY_REALTIME_MONTHLY,
+	PLAN_JETPACK_PREMIUM,
 } from 'lib/plans/constants';
 
 /**
@@ -191,3 +192,16 @@ export const UPGRADEABLE_WITH_NUDGE = [
 
 export const JETPACK_OFFER_RESET_UPGRADE_NUDGE_DISMISS =
 	'jetpack-offer-reset-upgrade-nudge-dismiss';
+
+/**
+ * Products included in each plan
+ */
+
+export const PLANS_INCLUDED_PRODUCTS: Record< string, string[] > = {
+	[ PLAN_JETPACK_PREMIUM ]: [
+		...JETPACK_SCAN_PRODUCTS,
+		...JETPACK_ANTI_SPAM_PRODUCTS,
+		PRODUCT_JETPACK_BACKUP_DAILY,
+		PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY,
+	],
+};

--- a/client/my-sites/plans-v2/constants.ts
+++ b/client/my-sites/plans-v2/constants.ts
@@ -24,7 +24,6 @@ import {
 	PLAN_JETPACK_SECURITY_DAILY_MONTHLY,
 	PLAN_JETPACK_SECURITY_REALTIME,
 	PLAN_JETPACK_SECURITY_REALTIME_MONTHLY,
-	PLAN_JETPACK_PREMIUM,
 } from 'lib/plans/constants';
 
 /**
@@ -192,16 +191,3 @@ export const UPGRADEABLE_WITH_NUDGE = [
 
 export const JETPACK_OFFER_RESET_UPGRADE_NUDGE_DISMISS =
 	'jetpack-offer-reset-upgrade-nudge-dismiss';
-
-/**
- * Products included in each plan
- */
-
-export const PLANS_INCLUDED_PRODUCTS: Record< string, string[] > = {
-	[ PLAN_JETPACK_PREMIUM ]: [
-		...JETPACK_SCAN_PRODUCTS,
-		...JETPACK_ANTI_SPAM_PRODUCTS,
-		PRODUCT_JETPACK_BACKUP_DAILY,
-		PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY,
-	],
-};

--- a/client/my-sites/plans-v2/plans-column/index.tsx
+++ b/client/my-sites/plans-v2/plans-column/index.tsx
@@ -14,6 +14,7 @@ import {
 	slugToSelectorProduct,
 	itemToSelectorProduct,
 	productButtonLabel,
+	productBadgeLabel,
 	isUpgradeable,
 	getRealtimeFromDaily,
 } from '../utils';
@@ -104,6 +105,7 @@ const PlanComponent = ( {
 			description={ plan.description }
 			currencyCode={ currencyCode }
 			billingTimeFrame={ durationToText( plan.term ) }
+			badgeLabel={ productBadgeLabel( plan ) }
 			buttonLabel={ productButtonLabel( plan ) }
 			onButtonClick={ () => onClick( plan ) }
 			features={ { items: [] } }

--- a/client/my-sites/plans-v2/products-column/index.tsx
+++ b/client/my-sites/plans-v2/products-column/index.tsx
@@ -13,11 +13,13 @@ import {
 	slugToItem,
 	itemToSelectorProduct,
 	productButtonLabel,
+	productBadgeLabel,
 	getProductPrices,
 } from '../utils';
 import { PRODUCTS_TYPES, SELECTOR_PRODUCTS } from '../constants';
 import { isProductsListFetching, getAvailableProductsList } from 'state/products-list/selectors';
 import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
+import getSitePlan from 'state/sites/selectors/get-site-plan';
 import getSiteProducts from 'state/sites/selectors/get-site-products';
 import JetpackProductCard from 'components/jetpack/card/jetpack-product-card';
 import FormattedHeader from 'components/formatted-header';
@@ -36,10 +38,12 @@ interface ProductsColumnType {
 
 const ProductComponent = ( {
 	product,
+	currentPlan,
 	onClick,
 	currencyCode,
 }: {
 	product: SelectorProduct;
+	currentPlan: string | null;
 	onClick: PurchaseCallback;
 	currencyCode: string;
 } ) => (
@@ -50,6 +54,7 @@ const ProductComponent = ( {
 		description={ product.description }
 		currencyCode={ currencyCode }
 		billingTimeFrame={ durationToText( product.term ) }
+		badgeLabel={ productBadgeLabel( product, currentPlan ) }
 		buttonLabel={ productButtonLabel( product ) }
 		onButtonClick={ () => onClick( product ) }
 		features={ { items: [] } }
@@ -72,6 +77,8 @@ const ProductsColumn = ( {
 	const currentProducts = (
 		useSelector( ( state ) => getSiteProducts( state, siteId ) ) || []
 	).map( ( product ) => product.productSlug );
+	const currentPlan =
+		useSelector( ( state ) => getSitePlan( state, siteId ) )?.product_slug || null;
 
 	// Gets all products in an array to be parsed.
 	const productObjects: SelectorProduct[] = useMemo(
@@ -109,6 +116,7 @@ const ProductsColumn = ( {
 					key={ product.productSlug }
 					onClick={ onProductClick }
 					product={ product }
+					currentPlan={ currentPlan }
 					currencyCode={ currencyCode }
 				/>
 			) ) }

--- a/client/my-sites/plans-v2/utils.ts
+++ b/client/my-sites/plans-v2/utils.ts
@@ -12,7 +12,6 @@ import {
 	PRODUCTS_WITH_OPTIONS,
 	OPTIONS_SLUG_MAP,
 	UPGRADEABLE_WITH_NUDGE,
-	PLANS_INCLUDED_PRODUCTS,
 } from './constants';
 import {
 	TERM_ANNUALLY,
@@ -21,7 +20,7 @@ import {
 	JETPACK_LEGACY_PLANS,
 	JETPACK_RESET_PLANS,
 } from 'lib/plans/constants';
-import { getPlan, getMonthlyPlanByYearly } from 'lib/plans';
+import { getPlan, getMonthlyPlanByYearly, planHasFeature } from 'lib/plans';
 import { JETPACK_PRODUCT_PRICE_MATRIX } from 'lib/products-values/constants';
 import { Product, JETPACK_PRODUCTS_LIST, objectIsProduct } from 'lib/products-values/products-list';
 import { getJetpackProductDisplayName } from 'lib/products-values/get-jetpack-product-display-name';
@@ -106,11 +105,7 @@ export function productBadgeLabel(
 			: translate( 'You own this' );
 	}
 
-	if (
-		currentPlan &&
-		PLANS_INCLUDED_PRODUCTS[ currentPlan ] &&
-		PLANS_INCLUDED_PRODUCTS[ currentPlan ].includes( product.productSlug )
-	) {
+	if ( currentPlan && planHasFeature( currentPlan, product.productSlug ) ) {
 		return translate( 'Included in your plan' );
 	}
 }

--- a/client/my-sites/plans-v2/utils.ts
+++ b/client/my-sites/plans-v2/utils.ts
@@ -12,6 +12,7 @@ import {
 	PRODUCTS_WITH_OPTIONS,
 	OPTIONS_SLUG_MAP,
 	UPGRADEABLE_WITH_NUDGE,
+	PLANS_INCLUDED_PRODUCTS,
 } from './constants';
 import {
 	TERM_ANNUALLY,
@@ -80,6 +81,12 @@ export function durationToText( duration: Duration ): TranslateResult {
  */
 
 export function productButtonLabel( product: SelectorProduct ): TranslateResult {
+	if ( product.owned ) {
+		return slugIsJetpackPlanSlug( product.productSlug )
+			? translate( 'Manage Plan' )
+			: translate( 'Manage Subscription' );
+	}
+
 	return (
 		product.buttonLabel ??
 		translate( 'Get %s', {
@@ -87,6 +94,25 @@ export function productButtonLabel( product: SelectorProduct ): TranslateResult 
 			context: '%s is the name of a product',
 		} )
 	);
+}
+
+export function productBadgeLabel(
+	product: SelectorProduct,
+	currentPlan?: string | null
+): TranslateResult | undefined {
+	if ( product.owned ) {
+		return slugIsJetpackPlanSlug( product.productSlug )
+			? translate( 'Your plan' )
+			: translate( 'You own this' );
+	}
+
+	if (
+		currentPlan &&
+		PLANS_INCLUDED_PRODUCTS[ currentPlan ] &&
+		PLANS_INCLUDED_PRODUCTS[ currentPlan ].includes( product.productSlug )
+	) {
+		return translate( 'Included in your plan' );
+	}
 }
 
 export function getProductPrices(


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR adds the logic to build the button and badge labels of the product card.

### Testing instructions

Visit the _Plans_ page with the Offer Reset flow enabled.

#### Button

- If you own a plan, the label should be "Manage Plan"
- If you own a product, the label should be "Manage Subscription"

#### Badge

- If you own a plan, the label should be "Your plan"
- If you own a product, the label should be "You own this"
- If a product is included in a plan you own, the label should be "Included in your plan"

### Screenshots

![screenshot](https://user-images.githubusercontent.com/1620183/89950411-90be0a00-dbf7-11ea-8194-6330c69f03c7.png)



