### PR TITLE
Site Setup: Stop the lack of mobile app setup from affecting the site setup indicator

### DIFF
--- a/client/state/selectors/is-site-checklist-complete.js
+++ b/client/state/selectors/is-site-checklist-complete.js
@@ -47,6 +47,11 @@ export default function isSiteChecklistComplete( state, siteId ) {
 			return true;
 		}
 
+		// The mobile app setup task shouldn't affect the site setup status.
+		if ( CHECKLIST_KNOWN_TASKS.MOBILE_APP_INSTALLED === task.id ) {
+			return true;
+		}
+
 		return false;
 	};
 


### PR DESCRIPTION
Currently if a user has not installed the mobile app the Site setup progress indicator shows as incomplete, but there is no indication why on the site home cards in some cases:

<img width="1210" alt="Screen Shot 2020-08-12 at 10 42 44 AM" src="https://user-images.githubusercontent.com/3629020/89956092-96176500-dc88-11ea-8f65-c69ff42ed4f7.png">

It doesn't seem like the installation of the mobile app should be considered part of site setup completion.

#### Changes proposed in this Pull Request

*  Flag the mobile app installation as true when calculating if site setup is complete.

#### Testing instructions

* With a user that does not have mobile app installed, but other tasks complete, load a site homepage and see that the Setup progress bar displays as above
* Apply this patch and check that the site setup progress no longer displays

With this fix in place the 'Get the WordPress app' task still displays for the user, and can be dismissed, but the Site Setup progress indicator does not show if all other site setup tasks are complete.

<img width="967" alt="Screen Shot 2020-08-12 at 11 41 29 AM" src="https://user-images.githubusercontent.com/3629020/89959644-075b1600-dc91-11ea-8a54-0d6c99f7ea84.png">

Fixes #44788
