### PR TITLE
Recoleta font usage: source from typography package

### DIFF
--- a/client/landing/gutenboarding/style.scss
+++ b/client/landing/gutenboarding/style.scss
@@ -1,18 +1,8 @@
 // @TODO: Remove this line and restore the import in `./gutenboard.tsx` when a release after @wordpress/components@8.5.0 is published.
 // See https://github.com/WordPress/gutenberg/pull/19535
 @import '~@wordpress/components/build-style/style';
+@import '~@automattic/typography/styles/fonts';
 @import 'assets/stylesheets/gutenberg-base-styles';
-
-@font-face {
-	font-display: swap;
-	font-family: 'Recoleta';
-	font-weight: 400;
-	src: url( 'https://s1.wp.com/i/fonts/recoleta/400.eot' );
-	src: url( 'https://s1.wp.com/i/fonts/recoleta/400.eot?#iefix' ) format( 'embedded-opentype' ),
-		url( 'https://s1.wp.com/i/fonts/recoleta/400.woff2' ) format( 'woff2' ),
-		url( 'https://s1.wp.com/i/fonts/recoleta/400.woff' ) format( 'woff' ),
-		url( 'https://s1.wp.com/i/fonts/recoleta/400.ttf' ) format( 'truetype' );
-}
 
 // Override core variables: we don't have wp-admin header and sidebar in Calypso
 // Targetting styles from `@wordpress/edit-post`

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -1,19 +1,9 @@
 @import 'jetpack-connect/colors.scss';
 @import 'woocommerce/components/text-control/style.scss';
 @import '~@automattic/onboarding/styles/mixins';
+@import '~@automattic/typography/styles/fonts';
 @import '~@wordpress/base-styles/breakpoints';
 @import '~@wordpress/base-styles/mixins';
-
-@font-face {
-	font-display: swap;
-	font-family: 'Recoleta';
-	font-weight: 400;
-	src: url( 'https://s1.wp.com/i/fonts/recoleta/400.eot' );
-	src: url( 'https://s1.wp.com/i/fonts/recoleta/400.eot?#iefix' ) format( 'embedded-opentype' ),
-		url( 'https://s1.wp.com/i/fonts/recoleta/400.woff2' ) format( 'woff2' ),
-		url( 'https://s1.wp.com/i/fonts/recoleta/400.woff' ) format( 'woff' ),
-		url( 'https://s1.wp.com/i/fonts/recoleta/400.ttf' ) format( 'truetype' );
-}
 
 $image-height: 47px;
 

--- a/packages/onboarding/styles/mixins.scss
+++ b/packages/onboarding/styles/mixins.scss
@@ -2,7 +2,8 @@
 @import './variables';
 
 @mixin onboarding-font-recoleta {
-	@extend .wp-brand-font;
+	font-family: $brand-serif;
+	font-weight: 400;
 	letter-spacing: -0.4px;
 }
 

--- a/packages/onboarding/styles/mixins.scss
+++ b/packages/onboarding/styles/mixins.scss
@@ -2,8 +2,7 @@
 @import './variables';
 
 @mixin onboarding-font-recoleta {
-	font-family: $brand-serif;
-	font-weight: 400;
+	@extend .wp-brand-font;
 	letter-spacing: -0.4px;
 }
 

--- a/packages/typography/README.md
+++ b/packages/typography/README.md
@@ -1,6 +1,9 @@
 # Typography
 
-@automattic/typography is a Sass file for shared typographic elements across WordPress.com products. Right now, this package contains the `@font-face` declaration for the WordPress.com brand font.
+@automattic/typography is a Sass file for shared typographic elements across WordPress.com products. This package contains
+*  the `@font-face` declaration for the WordPress.com brand font
+*  font-size sass variables
+*  font-family sass variables
 
 ## Installation
 
@@ -10,10 +13,43 @@ yarn add @automattic/typography
 
 ## Usage
 
-Import the Sass file:
+Note that this package contains two sass files and there are use cases for `@import`ing either file.
+
+### Import the `variables.scss` file:
+
+`@import '~@automattic/typography/styles/variables';`
+
+Apply font variables as needed:
+
+```
+.my-text {
+    font-size: $font-body-small;
+}
+```
+
+### Import the `fonts.sccc` file:
 
 `@import '~@automattic/typography/styles/fonts';`
 
-Then apply the class name `wp-brand-font` to any elements that should display with Recoleta:
+Extend the .wp-brand-font selector in your SCSS:
+
+```
+.design__typography-branded {
+	@extend .wp-brand-font;
+	font-size: $font-title-medium;
+}
+```
+
+Or apply the class name `wp-brand-font` to any elements that should display with Recoleta:
 
 `<h1 className="wp-brand-font">Brand font heading</h1>`
+
+Note that the `fonts.scss` file imports the `variables.scss` file.
+
+<br>
+
+
+Please refer to the [Calypso Typography Docs](https://wpcalypso.wordpress.com/devdocs/typography) for more information.
+
+// Add usage about @import for both fonts.scss and variables.scss
+// link to https://wpcalypso.wordpress.com/devdocs/typography

--- a/packages/typography/README.md
+++ b/packages/typography/README.md
@@ -50,6 +50,3 @@ Note that the `fonts.scss` file imports the `variables.scss` file.
 
 
 Please refer to the [Calypso Typography Docs](https://wpcalypso.wordpress.com/devdocs/typography) for more information.
-
-// Add usage about @import for both fonts.scss and variables.scss
-// link to https://wpcalypso.wordpress.com/devdocs/typography


### PR DESCRIPTION
### Motivation
Make use of the Recoleta font declaration in the @automattic/typography package
https://github.com/Automattic/wp-calypso/issues/44683

Background/Related:
p9Jlb4-1vU-pe#comment-2683

### Changes proposed in this Pull Request

* Remove @font-face declarations in `wp-calypso/client/login/wp-login/style.scss` &
`client/landing/gutenboarding/style.scss`  and instead `@import` the typography package.
* ~Replace font variable with `@extend` in `packages/onboarding/styles/mixins.scss`~. See sass error posted below.
* Update the package README with usage instructions

### Testing instructions

* Ensure code changes are the desired font implementation
* Review areas of site affected by code changes to ensure Recoleta font is unchanged:
  - /new
  - /log-in/new


 Fixes  https://github.com/Automattic/wp-calypso/issues/44683
