### PR TITLE
Wires up details page

### DIFF
--- a/client/my-sites/plans-v2/controller.tsx
+++ b/client/my-sites/plans-v2/controller.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-import page from 'page';
 
 /**
  * Internal dependencies
@@ -10,12 +9,7 @@ import page from 'page';
 import SelectorPage from './selector';
 import DetailsPage from './details';
 import UpsellPage from './upsell';
-import {
-	stringToDuration,
-	stringToDurationString,
-	slugToSelectorProduct,
-	durationToString,
-} from './utils';
+import { stringToDuration } from './utils';
 
 export const productSelect = ( rootUrl: string ) => ( context: PageJS.Context, next: Function ) => {
 	const duration = stringToDuration( context.params.duration );
@@ -28,42 +22,18 @@ export const productDetails = ( rootUrl: string ) => (
 	next: Function
 ) => {
 	const productType: string = context.params.product;
-	const durationString = stringToDurationString( context.params.duration );
-	const product = slugToSelectorProduct( productType );
-
-	// If the product slug does not parse to as product, send the user back to the selector page.
-	if ( ! product ) {
-		page.redirect( `${ rootUrl }/${ durationString }` );
-		return;
-	} else if ( ! product.subtypes.length ) {
-		// Otherwise, if the product has no subtypes, send them to the upsell page.
-		page.redirect( `${ rootUrl }/${ product.productSlug }/${ durationString }/additions` );
-		return;
-	}
-
-	// We now know the product has subtypes, let the user select them.
-	context.primary = <DetailsPage product={ product } rootUrl={ rootUrl } />;
+	const duration = stringToDuration( context.params.duration );
+	context.primary = (
+		<DetailsPage productSlug={ productType } duration={ duration } rootUrl={ rootUrl } />
+	);
 	next();
 };
 
 export const productUpsell = ( rootUrl: string ) => ( context: PageJS.Context, next: Function ) => {
 	const productSlug: string = context.params.product;
 	const duration = stringToDuration( context.params.duration );
-	const product = slugToSelectorProduct( productSlug );
-
-	// If there is no duration, send the user back to the selector page.
-	if ( ! duration ) {
-		page.redirect( rootUrl );
-		return;
-	} else if ( ! product ) {
-		// Else if the product cannot be parsed, send the user to the selector page with the duration.
-		const durationString = durationToString( duration );
-		page.redirect( `${ rootUrl }/${ durationString }` );
-		return;
-	}
-
-	// Otherwise, show the upsell page.
-	// We determine if there *is* an available upsell within this component.
-	context.primary = <UpsellPage productSlug={ productSlug } rootUrl={ rootUrl } />;
+	context.primary = (
+		<UpsellPage productSlug={ productSlug } duration={ duration } rootUrl={ rootUrl } />
+	);
 	next();
 };

--- a/client/my-sites/plans-v2/details.tsx
+++ b/client/my-sites/plans-v2/details.tsx
@@ -2,19 +2,38 @@
  * External dependencies
  */
 import React from 'react';
+import { useSelector } from 'react-redux';
+import page from 'page';
 
 /**
  * Internal dependencies
  */
-import { DetailsPageProps } from './types';
-import { TERM_ANNUALLY } from 'lib/plans/constants';
+import { slugToSelectorProduct, durationToString } from './utils';
+import { getSelectedSiteSlug } from 'state/ui/selectors';
 
-const DetailsPage = ( { duration, productType }: DetailsPageProps ) => {
-	const durationString = duration === TERM_ANNUALLY ? 'annual' : 'monthly';
+/**
+ * Type dependencies
+ */
+import type { DetailsPageProps } from './types';
+
+const DetailsPage = ( { duration, productSlug, rootUrl }: DetailsPageProps ) => {
+	const siteSlug = useSelector( ( state ) => getSelectedSiteSlug( state ) ) || '';
+
+	// If the product is not valid, send the user to the selector page.
+	const product = slugToSelectorProduct( productSlug );
+	if ( ! product ) {
+		// The duration is optional, but if we have it keep it.
+		let durationSuffix = '';
+		if ( duration ) {
+			durationSuffix = '/' + durationToString( duration );
+		}
+		page.redirect( rootUrl.replace( ':site', siteSlug ) + durationSuffix );
+		return null;
+	}
+
 	return (
 		<div>
 			<h1>Hello this is the Details Page!</h1>
-			<p>{ `You are currently choosing between types of ${ productType } with a ${ durationString } duration.` }</p>
 		</div>
 	);
 };

--- a/client/my-sites/plans-v2/details.tsx
+++ b/client/my-sites/plans-v2/details.tsx
@@ -57,6 +57,7 @@ const ProductComponent = ( {
 	const price = useSelector( ( state ) => getProductCost( state, productSlug ) ) || 0;
 	const product = slugToSelectorProduct( productSlug );
 	if ( ! product ) {
+		// Exit if invalid product.
 		return null;
 	}
 	const isBundle = [ OPTIONS_JETPACK_SECURITY, OPTIONS_JETPACK_SECURITY_MONTHLY ].includes(
@@ -64,6 +65,8 @@ const ProductComponent = ( {
 	);
 	const JetpackCard = isBundle ? JetpackBundleCard : JetpackProductCard;
 
+	// Gets the cost of the product/plan.
+	// TODO: Pull this all from the API.
 	let cost: Cost = { originalPrice: 0 };
 	if ( isBundle ) {
 		cost = { originalPrice: price || 0 };

--- a/client/my-sites/plans-v2/details.tsx
+++ b/client/my-sites/plans-v2/details.tsx
@@ -4,37 +4,150 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
 import page from 'page';
+import { useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import { slugToSelectorProduct, durationToString } from './utils';
+import {
+	slugToSelectorProduct,
+	durationToString,
+	durationToText,
+	productButtonLabel,
+	getProductPrices,
+} from './utils';
+import {
+	PRODUCTS_WITH_OPTIONS,
+	OPTIONS_JETPACK_SECURITY,
+	OPTIONS_JETPACK_SECURITY_MONTHLY,
+} from './constants';
+import FormattedHeader from 'components/formatted-header';
+import HeaderCake from 'components/header-cake';
+import Main from 'components/main';
+import JetpackBundleCard from 'components/jetpack/card/jetpack-bundle-card';
+import JetpackProductCard from 'components/jetpack/card/jetpack-product-card';
+import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
+import { getAvailableProductsList } from 'state/products-list/selectors/get-available-products-list';
+import { isProductsListFetching } from 'state/products-list/selectors/is-products-list-fetching';
+import { getProductCost } from 'state/products-list/selectors/get-product-cost';
 import { getSelectedSiteSlug } from 'state/ui/selectors';
 
 /**
  * Type dependencies
  */
-import type { DetailsPageProps } from './types';
+import type { DetailsPageProps, PurchaseCallback, SelectorProduct } from './types';
+
+import './style.scss';
+
+type Cost = {
+	originalPrice: number;
+	discountedPrice?: number;
+};
+
+const ProductComponent = ( {
+	productSlug,
+	onClick,
+	currencyCode,
+}: {
+	productSlug: string;
+	onClick: PurchaseCallback;
+	currencyCode: string;
+} ) => {
+	const availableProducts = useSelector( ( state ) => getAvailableProductsList( state ) );
+	const price = useSelector( ( state ) => getProductCost( state, productSlug ) ) || 0;
+	const product = slugToSelectorProduct( productSlug );
+	if ( ! product ) {
+		return null;
+	}
+	const isBundle = [ OPTIONS_JETPACK_SECURITY, OPTIONS_JETPACK_SECURITY_MONTHLY ].includes(
+		productSlug
+	);
+	const JetpackCard = isBundle ? JetpackBundleCard : JetpackProductCard;
+
+	let cost: Cost = { originalPrice: 0 };
+	if ( isBundle ) {
+		cost = { originalPrice: price || 0 };
+	} else {
+		const productPrices = getProductPrices( product, availableProducts );
+		cost = {
+			originalPrice: productPrices.cost || 0,
+			discountedPrice: productPrices.discountCost,
+		};
+	}
+
+	return (
+		<JetpackCard
+			key={ productSlug }
+			iconSlug={ product.iconSlug }
+			productName={ product.displayName }
+			subheadline={ product.tagline }
+			description={ product.description }
+			currencyCode={ currencyCode }
+			billingTimeFrame={ durationToText( product.term ) }
+			buttonLabel={ productButtonLabel( product ) }
+			onButtonClick={ () => onClick( product ) }
+			features={ { items: [] } }
+			className="details__column"
+			{ ...cost }
+		/>
+	);
+};
 
 const DetailsPage = ( { duration, productSlug, rootUrl }: DetailsPageProps ) => {
 	const siteSlug = useSelector( ( state ) => getSelectedSiteSlug( state ) ) || '';
+	const currencyCode = useSelector( ( state ) => getCurrentUserCurrencyCode( state ) );
+	const isFetchingProducts = useSelector( ( state ) => isProductsListFetching( state ) );
+	const translate = useTranslate();
+	const root = rootUrl.replace( ':site', siteSlug );
+	const durationSuffix = duration ? '/' + durationToString( duration ) : '';
+
+	// If the product slug isn't one that has options, proceed to the upsell.
+	if ( ! ( PRODUCTS_WITH_OPTIONS as readonly string[] ).includes( productSlug ) ) {
+		page.redirect( `${ root }/${ productSlug }${ durationSuffix }` );
+		return null;
+	}
 
 	// If the product is not valid, send the user to the selector page.
 	const product = slugToSelectorProduct( productSlug );
 	if ( ! product ) {
-		// The duration is optional, but if we have it keep it.
-		let durationSuffix = '';
-		if ( duration ) {
-			durationSuffix = '/' + durationToString( duration );
-		}
-		page.redirect( rootUrl.replace( ':site', siteSlug ) + durationSuffix );
+		page.redirect( root + durationSuffix );
 		return null;
 	}
 
+	if ( ! currencyCode || isFetchingProducts ) {
+		return null; // TODO: Loading component!
+	}
+
+	// Go to a new page for upsells.
+	const selectProduct: PurchaseCallback = ( selectedProduct: SelectorProduct ) => {
+		page(
+			`${ root }/${ selectedProduct.productSlug }/` +
+				`${ durationToString( selectedProduct.term ) }/additions`
+		);
+	};
+
+	const isBundle = [ OPTIONS_JETPACK_SECURITY, OPTIONS_JETPACK_SECURITY_MONTHLY ].includes(
+		productSlug
+	);
+	const backButton = () => page( root + durationSuffix );
+
 	return (
-		<div>
-			<h1>Hello this is the Details Page!</h1>
-		</div>
+		<Main className="details__main" wideLayout>
+			<HeaderCake onClick={ backButton }>
+				{ isBundle ? translate( 'Bundle Options' ) : translate( 'Product Options' ) }
+			</HeaderCake>
+			<FormattedHeader headerText="Great choice! Now select a backup option:" brandFont />
+			<div className="plans-v2__columns">
+				{ product.subtypes.map( ( subtypeSlug ) => (
+					<ProductComponent
+						key={ subtypeSlug }
+						productSlug={ subtypeSlug }
+						onClick={ selectProduct }
+						currencyCode={ currencyCode }
+					/>
+				) ) }
+			</div>
+		</Main>
 	);
 };
 

--- a/client/my-sites/plans-v2/index.ts
+++ b/client/my-sites/plans-v2/index.ts
@@ -15,8 +15,8 @@ const trackedPage = ( url: string, ...rest: PageJS.Callback[] ) => {
 };
 
 export default function ( rootUrl: string, ...rest: PageJS.Callback[] ) {
-	trackedPage( `${ rootUrl }/:duration?`, productSelect, ...rest );
-	trackedPage( `${ rootUrl }/:product/details`, productDetails, ...rest );
-	trackedPage( `${ rootUrl }/:product/:duration/details`, productDetails, ...rest );
-	trackedPage( `${ rootUrl }/:product/:duration/additions`, productUpsell, ...rest );
+	trackedPage( `${ rootUrl }/:duration?`, productSelect( rootUrl ), ...rest );
+	trackedPage( `${ rootUrl }/:product/details`, productDetails( rootUrl ), ...rest );
+	trackedPage( `${ rootUrl }/:product/:duration/details`, productDetails( rootUrl ), ...rest );
+	trackedPage( `${ rootUrl }/:product/:duration/additions`, productUpsell( rootUrl ), ...rest );
 }

--- a/client/my-sites/plans-v2/plans-column/index.tsx
+++ b/client/my-sites/plans-v2/plans-column/index.tsx
@@ -63,7 +63,7 @@ const PlanComponent = ( {
 			currencyCode={ currencyCode }
 			billingTimeFrame={ durationToText( plan.term ) }
 			buttonLabel={ productButtonLabel( plan ) }
-			onButtonClick={ () => onClick( plan.productSlug ) }
+			onButtonClick={ () => onClick( plan ) }
 			features={ { items: [] } }
 			originalPrice={ price }
 			isOwned={ plan.owned }

--- a/client/my-sites/plans-v2/products-column/index.tsx
+++ b/client/my-sites/plans-v2/products-column/index.tsx
@@ -51,7 +51,7 @@ const ProductComponent = ( {
 		currencyCode={ currencyCode }
 		billingTimeFrame={ durationToText( product.term ) }
 		buttonLabel={ productButtonLabel( product ) }
-		onButtonClick={ () => onClick( product.productSlug ) }
+		onButtonClick={ () => onClick( product ) }
 		features={ { items: [] } }
 		discountedPrice={ product.discountCost }
 		originalPrice={ product.cost || 0 }

--- a/client/my-sites/plans-v2/selector.tsx
+++ b/client/my-sites/plans-v2/selector.tsx
@@ -15,6 +15,7 @@ import { SECURITY } from './constants';
 import { durationToString } from './utils';
 import { TERM_ANNUALLY } from 'lib/plans/constants';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
+import Main from 'components/main';
 import QueryProductsList from 'components/data/query-products-list';
 import QuerySites from 'components/data/query-sites';
 
@@ -49,7 +50,7 @@ const SelectorPage = ( { defaultDuration = TERM_ANNUALLY, rootUrl }: SelectorPag
 	};
 
 	return (
-		<div>
+		<Main className="selector__main" wideLayout>
 			<PlansFilterBar
 				onProductTypeChange={ setProductType }
 				productType={ productType }
@@ -72,7 +73,7 @@ const SelectorPage = ( { defaultDuration = TERM_ANNUALLY, rootUrl }: SelectorPag
 			</div>
 			<QueryProductsList />
 			{ siteId && <QuerySites siteId={ siteId } /> }
-		</div>
+		</Main>
 	);
 };
 

--- a/client/my-sites/plans-v2/selector.tsx
+++ b/client/my-sites/plans-v2/selector.tsx
@@ -3,6 +3,7 @@
  */
 import React, { useState } from 'react';
 import { useSelector } from 'react-redux';
+import page from 'page';
 
 /**
  * Internal dependencies
@@ -11,22 +12,41 @@ import PlansFilterBar from './plans-filter-bar';
 import PlansColumn from './plans-column';
 import ProductsColumn from './products-column';
 import { SECURITY } from './constants';
+import { durationToString } from './utils';
 import { TERM_ANNUALLY } from 'lib/plans/constants';
-import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import QueryProductsList from 'components/data/query-products-list';
 import QuerySites from 'components/data/query-sites';
 
 /**
  * Type dependencies
  */
-import type { Duration, ProductType, SelectorPageProps } from './types';
+import type {
+	Duration,
+	ProductType,
+	SelectorPageProps,
+	SelectorProduct,
+	PurchaseCallback,
+} from './types';
 
 import './style.scss';
 
-const SelectorPage = ( { defaultDuration = TERM_ANNUALLY }: SelectorPageProps ) => {
+const SelectorPage = ( { defaultDuration = TERM_ANNUALLY, rootUrl }: SelectorPageProps ) => {
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	const siteSlug = useSelector( ( state ) => getSelectedSiteSlug( state ) ) || '';
 	const [ productType, setProductType ] = useState< ProductType >( SECURITY );
 	const [ currentDuration, setDuration ] = useState< Duration >( defaultDuration );
+
+	// Sends a user to a page based on whether there are subtypes.
+	const selectProduct: PurchaseCallback = ( product: SelectorProduct ) => {
+		const durationString = durationToString( currentDuration );
+		const root = rootUrl.replace( ':site', siteSlug );
+		if ( product.subtypes ) {
+			page( `${ root }/${ product.productSlug }/${ durationString }/details` );
+		} else {
+			page( `${ root }/${ product.productSlug }/${ durationString }/additions` );
+		}
+	};
 
 	return (
 		<div>
@@ -39,13 +59,13 @@ const SelectorPage = ( { defaultDuration = TERM_ANNUALLY }: SelectorPageProps ) 
 			<div className="plans-v2__columns">
 				<PlansColumn
 					duration={ currentDuration }
-					onPlanClick={ () => null }
+					onPlanClick={ selectProduct }
 					productType={ productType }
 					siteId={ siteId }
 				/>
 				<ProductsColumn
 					duration={ currentDuration }
-					onProductClick={ () => null }
+					onProductClick={ selectProduct }
 					productType={ productType }
 					siteId={ siteId }
 				/>

--- a/client/my-sites/plans-v2/selector.tsx
+++ b/client/my-sites/plans-v2/selector.tsx
@@ -41,7 +41,7 @@ const SelectorPage = ( { defaultDuration = TERM_ANNUALLY, rootUrl }: SelectorPag
 	const selectProduct: PurchaseCallback = ( product: SelectorProduct ) => {
 		const durationString = durationToString( currentDuration );
 		const root = rootUrl.replace( ':site', siteSlug );
-		if ( product.subtypes ) {
+		if ( product.subtypes.length ) {
 			page( `${ root }/${ product.productSlug }/${ durationString }/details` );
 		} else {
 			page( `${ root }/${ product.productSlug }/${ durationString }/additions` );

--- a/client/my-sites/plans-v2/style.scss
+++ b/client/my-sites/plans-v2/style.scss
@@ -5,12 +5,14 @@
 	.plans-v2__columns {
 		display: flex;
 
-		& > .plans-column {
+		& > .plans-column,
+		& > .details__column {
 			flex-basis: 50%;
 			flex-grow: 0;
 		}
 
-		& > .products-column {
+		& > .products-column,
+		& > .details__column:not( :first-of-type ) {
 			margin-left: 24px;
 		}
 	}

--- a/client/my-sites/plans-v2/types.ts
+++ b/client/my-sites/plans-v2/types.ts
@@ -11,20 +11,25 @@ import type { ReactNode } from 'react';
 import type { TERM_ANNUALLY, TERM_MONTHLY } from 'lib/plans/constants';
 
 export type Duration = typeof TERM_ANNUALLY | typeof TERM_MONTHLY;
+export type DurationString = 'annual' | 'monthly';
 export type ProductType = typeof ALL | typeof PERFORMANCE | typeof SECURITY;
-export type PurchaseCallback = ( arg0: string ) => null;
+export type PurchaseCallback = ( arg0: SelectorProduct ) => void;
 
-export interface SelectorPageProps {
+interface BasePageProps {
+	rootUrl: string;
+}
+
+export interface SelectorPageProps extends BasePageProps {
 	defaultDuration?: Duration;
 }
 
-export interface DetailsPageProps {
+export interface DetailsPageProps extends BasePageProps {
 	duration?: Duration;
-	productType: string;
+	productSlug: string;
 }
 
-export interface UpsellPageProps {
-	duration: Duration;
+export interface UpsellPageProps extends BasePageProps {
+	duration?: Duration;
 	productSlug: string;
 }
 
@@ -46,7 +51,7 @@ export interface SelectorProduct extends SelectorProductCost {
 	term: Duration;
 	buttonLabel?: TranslateResult;
 	features: string[];
-	subtypes?: string[];
+	subtypes: string[];
 	owned?: boolean;
 	legacy?: boolean;
 }

--- a/client/my-sites/plans-v2/upsell.tsx
+++ b/client/my-sites/plans-v2/upsell.tsx
@@ -2,19 +2,39 @@
  * External dependencies
  */
 import React from 'react';
+import { useSelector } from 'react-redux';
+import page from 'page';
 
 /**
  * Internal dependencies
  */
-import { UpsellPageProps } from './types';
-import { TERM_ANNUALLY } from 'lib/plans/constants';
+import { slugToSelectorProduct, durationToString } from './utils';
+import { getSelectedSiteSlug } from 'state/ui/selectors';
 
-const UpsellPage = ( { duration, productSlug }: UpsellPageProps ) => {
-	const durationString = duration === TERM_ANNUALLY ? 'annual' : 'monthly';
+/**
+ * Type dependencies
+ */
+import type { UpsellPageProps } from './types';
+
+const UpsellPage = ( { duration, productSlug, rootUrl }: UpsellPageProps ) => {
+	const siteSlug = useSelector( ( state ) => getSelectedSiteSlug( state ) ) || '';
+	// TODO: Get upsells via API.
+
+	// If the product is not valid, send the user to the selector page.
+	const product = slugToSelectorProduct( productSlug );
+	if ( ! product ) {
+		// The duration is optional, but if we have it keep it.
+		let durationSuffix = '';
+		if ( duration ) {
+			durationSuffix = '/' + durationToString( duration );
+		}
+		page.redirect( rootUrl.replace( ':site', siteSlug ) + durationSuffix );
+		return null;
+	}
+
 	return (
 		<div>
 			<h1>Hello this is the Upsell Page!</h1>
-			<p>{ `You are currently being offered to add another product onto ${ productSlug } with a ${ durationString } duration.` }</p>
 		</div>
 	);
 };

--- a/client/my-sites/plans-v2/utils.ts
+++ b/client/my-sites/plans-v2/utils.ts
@@ -182,3 +182,17 @@ export function itemToSelectorProduct(
 	}
 	return null;
 }
+
+/**
+ * Converts an item slug to a SelectorProduct item type.
+ *
+ * @param slug string
+ * @returns SelectorProduct | null
+ */
+export function slugToSelectorProduct( slug: string ): SelectorProduct | null {
+	const item = slugToItem( slug );
+	if ( ! item ) {
+		return null;
+	}
+	return itemToSelectorProduct( item );
+}

--- a/client/my-sites/plans-v2/utils.ts
+++ b/client/my-sites/plans-v2/utils.ts
@@ -32,9 +32,14 @@ import type {
 	SelectorProductSlug,
 	AvailableProductData,
 	SelectorProductCost,
+	DurationString,
 } from './types';
 import type { JetpackPlanSlugs, Plan } from 'lib/plans/types';
 import type { JetpackProductSlug } from 'lib/products-values/types';
+
+/**
+ * Duration utils.
+ */
 
 export function stringToDuration( duration?: string ): Duration | undefined {
 	if ( duration === undefined ) {
@@ -46,11 +51,23 @@ export function stringToDuration( duration?: string ): Duration | undefined {
 	return TERM_ANNUALLY;
 }
 
+export function stringToDurationString( duration?: string ): DurationString {
+	return duration !== 'monthly' ? 'annual' : 'monthly';
+}
+
+export function durationToString( duration: Duration ): DurationString {
+	return duration === TERM_MONTHLY ? 'monthly' : 'annual';
+}
+
 export function durationToText( duration: Duration ): TranslateResult {
 	return duration === TERM_MONTHLY
 		? translate( 'per month, billed monthly' )
 		: translate( 'per year' );
 }
+
+/**
+ * Product UI utils.
+ */
 
 export function productButtonLabel( product: SelectorProduct ): TranslateResult {
 	return (
@@ -81,6 +98,10 @@ export function getProductPrices(
 	};
 }
 
+/**
+ * Type guards.
+ */
+
 function slugIsSelectorProductSlug( slug: string ): slug is SelectorProductSlug {
 	return PRODUCTS_WITH_OPTIONS.includes( slug as typeof PRODUCTS_WITH_OPTIONS[ number ] );
 }
@@ -90,6 +111,10 @@ function slugIsJetpackProductSlug( slug: string ): slug is JetpackProductSlug {
 function slugIsJetpackPlanSlug( slug: string ): slug is JetpackPlanSlugs {
 	return [ ...JETPACK_LEGACY_PLANS, ...JETPACK_RESET_PLANS ].includes( slug );
 }
+
+/**
+ * Product parsing and data normalization utils.
+ */
 
 export function slugToItem( slug: string ): Plan | Product | SelectorProduct | null {
 	if ( slugIsSelectorProductSlug( slug ) ) {
@@ -162,6 +187,7 @@ export function itemToSelectorProduct(
 			} ),
 			term: item.term,
 			features: [],
+			subtypes: [],
 		};
 	} else if ( objectIsPlan( item ) ) {
 		const productSlug = item.getStoreSlug();
@@ -178,6 +204,7 @@ export function itemToSelectorProduct(
 			monthlyProductSlug,
 			term: item.term === TERM_BIENNIALLY ? TERM_ANNUALLY : item.term,
 			features: [],
+			subtypes: [],
 		};
 	}
 	return null;

--- a/client/my-sites/plans-v2/utils.ts
+++ b/client/my-sites/plans-v2/utils.ts
@@ -195,9 +195,10 @@ export function itemToSelectorProduct(
 		if ( item.term === TERM_ANNUALLY ) {
 			monthlyProductSlug = getMonthlyPlanByYearly( productSlug );
 		}
+		const iconAppend = JETPACK_RESET_PLANS.includes( productSlug ) ? '_v2' : '';
 		return {
 			productSlug,
-			iconSlug: productSlug,
+			iconSlug: productSlug + iconAppend,
 			displayName: item.getTitle(),
 			tagline: get( item, 'getTagline', () => '' )(),
 			description: item.getDescription(),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Wires up the details page, which allows users to select the plan/product subtype.
* Adds error catching for cases where the data is invalid for a given slug.
* Ensures picking a product on the selector page sends the user to the appropriate spot.

#### Screenshots
<img width="1075" alt="Screen Shot 2020-08-11 at 6 49 24 PM" src="https://user-images.githubusercontent.com/1760168/89957023-6757ab00-dc04-11ea-9da5-ecdbf6ac25a3.png">
<img width="1079" alt="Screen Shot 2020-08-11 at 6 49 33 PM" src="https://user-images.githubusercontent.com/1760168/89957024-6757ab00-dc04-11ea-8386-eee6d74b8a4f.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the new plans page.
* Select a product that has subtypes (Jetpack Security or Jetpack Backup).
* Verify you are directed to the details page and cards are correct products.
* Click on a product and verify you are taken to the correct upsell page.
* Alter the duration in the selector page and verify the details page has the correct duration.
* Alter a product slug in the URL and verify the details page responds correctly.

**Notes**
- Text for "Great choice! [...]" string is hard-coded and not translated as it's not clear what determines that.
- This does not account for plans that aren't bundles. This is not a case right now, but an edge case to be aware of.
- Features are still not wired up!
- Pricing data retrieval is messy and should be improved.

Fixes 1169247016322522-as-1188472884326553.