### PR TITLE
Gutenboarding launch flow: fix mobile flow

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/editor-gutenboarding-launch/index.ts
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-gutenboarding-launch/index.ts
@@ -49,6 +49,10 @@ function updateEditor() {
 			return;
 		}
 		clearInterval( awaitSettingsBar );
+
+		const isMobile = window.innerWidth < 768;
+		const isNewLaunch = ! window?.calypsoifyGutenberg?.isNewLaunch;
+
 		const body = document.querySelector( 'body' );
 		body.classList.add( 'editor-gutenberg-launch__fse-overrides' );
 
@@ -64,16 +68,14 @@ function updateEditor() {
 		// Assert reason: We have an early return above with optional and falsy values. This should be a string.
 		const launchHref = window?.calypsoifyGutenberg?.frankenflowUrl as string;
 
-		// Temporary solution to test new launch flow
-		const isNewLaunch = launchHref === 'new-launch';
-
 		launchLink.href = launchHref;
 		launchLink.target = '_top';
 		launchLink.className = 'editor-gutenberg-launch__launch-button components-button is-primary';
 
-		const launchLabel = isNewLaunch
-			? __( 'Complete setup', 'full-site-editing' )
-			: __( 'Launch', 'full-site-editing' );
+		// On mobile there is not enough space to display "Complete setup" label.
+		const launchLabel = isMobile
+			? __( 'Launch', 'full-site-editing' )
+			: __( 'Complete setup', 'full-site-editing' );
 
 		const textContent = document.createTextNode( launchLabel );
 		launchLink.appendChild( textContent );
@@ -85,7 +87,7 @@ function updateEditor() {
 
 			recordTracksEvent( 'calypso_newsite_editor_launch_click' );
 
-			if ( isNewLaunch && ! ( window.innerWidth < 768 ) ) {
+			if ( isNewLaunch && ! isMobile ) {
 				// Open editor-site-launch sidebar
 				dispatch( 'automattic/launch' ).openSidebar();
 			} else {

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -333,20 +333,13 @@ class CalypsoifyIframe extends Component<
 		if ( EditorActions.GetGutenboardingStatus === action ) {
 			const isGutenboarding =
 				this.props.siteCreationFlow === 'gutenboarding' && this.props.isSiteUnlaunched;
-
-			// Temporary solution for new launch testing
-			let frankenflowUrl = `${ window.location.origin }/start/new-launch?siteSlug=${ this.props.siteSlug }&source=editor`;
-
+			const frankenflowUrl = `${ window.location.origin }/start/new-launch?siteSlug=${ this.props.siteSlug }&source=editor`;
 			const isGutenboardingNewLaunch = config.isEnabled( 'gutenboarding/new-launch' );
-			// END Temporary solution for new launch testing
-
-			if ( isGutenboardingNewLaunch ) {
-				frankenflowUrl = 'new-launch';
-			}
 
 			ports[ 0 ].postMessage( {
 				isGutenboarding,
 				frankenflowUrl,
+				isNewLaunch: isGutenboardingNewLaunch,
 			} );
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Fix 404 on mobile when pressing _Complete Setup_
* Use _Launch_ label on mobile to prevent breaking the header layout.

#### Testing instructions
* Create a site using `/new`
* Launching from editor should work for both desktop (new launch with the sidebar) and mobile (Calypso launch flow).
