### PR TITLE
Bump WordPress.com Editing Toolkit plugin to v1.18

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WordPress.com Editing Toolkit
  * Description: Enhances your page creation workflow within the Block Editor.
- * Version: 1.17
+ * Version: 1.18
  * Author: Automattic
  * Author URI: https://automattic.com/wordpress-plugins/
  * License: GPLv2 or later
@@ -35,7 +35,7 @@ namespace A8C\FSE;
  *
  * @var string
  */
-define( 'PLUGIN_VERSION', '1.17' );
+define( 'PLUGIN_VERSION', '1.18' );
 
 // Always include these helper files for dotcom FSE.
 require_once __DIR__ . '/dotcom-fse/helpers.php';

--- a/apps/full-site-editing/full-site-editing-plugin/readme.txt
+++ b/apps/full-site-editing/full-site-editing-plugin/readme.txt
@@ -3,7 +3,7 @@ Contributors: alexislloyd, allancole, automattic, bartkalisz, codebykat, copons,
 Tags: block, blocks, editor, gutenberg, page
 Requires at least: 5.0
 Tested up to: 5.4
-Stable tag: 1.17
+Stable tag: 1.18
 Requires PHP: 5.6.20
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -39,6 +39,9 @@ This plugin is experimental, so we don't provide any support for it outside of w
 
 
 == Changelog ==
+
+= 1.18 =
+* Fix broken link on mobile when selecting launch flow.
 
 = 1.17 =
 * Site setup list: fix bug opening customer home inside iframe

--- a/apps/full-site-editing/package.json
+++ b/apps/full-site-editing/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/full-site-editing",
-	"version": "1.17.0",
+	"version": "1.18.0",
 	"description": "Plugin for editing-related features.",
 	"sideEffects": true,
 	"repository": {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Bump WordPress.com Editing Toolkit plugin to v1.18

This change includes the changes from this PR:

https://github.com/Automattic/wp-calypso/pull/44850 (Gutenboarding launch flow: fix mobile flow)
https://github.com/Automattic/wp-calypso/pull/44855

Change log:

- Fixed a bug on mobile whereby the launch flow redirecting to `new-launch` and returning a 404 #44850
- Use _Launch_ label for the Launch button (desktop uses _Complete setup_) on mobile to prevent breaking the header layout #44850

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply the corresponding diff to this PR (D47993-code) and ensure that #44850 functions as expected.

Fixes #