### PR TITLE
Gutenboarding launch flow: update calypsoifyGutenberg with flag 

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/editor-gutenboarding-launch/index.ts
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-gutenboarding-launch/index.ts
@@ -51,7 +51,7 @@ function updateEditor() {
 		clearInterval( awaitSettingsBar );
 
 		const isMobile = window.innerWidth < 768;
-		const isNewLaunch = ! window?.calypsoifyGutenberg?.isNewLaunch;
+		const isNewLaunch = window?.calypsoifyGutenberg?.isNewLaunch;
 
 		const body = document.querySelector( 'body' );
 		body.classList.add( 'editor-gutenberg-launch__fse-overrides' );

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -755,9 +755,10 @@ function getGutenboardingStatus( calypsoPort ) {
 		[ port2 ]
 	);
 	port1.onmessage = ( { data } ) => {
-		const { isGutenboarding, frankenflowUrl } = data;
+		const { isGutenboarding, frankenflowUrl, isNewLaunch } = data;
 		calypsoifyGutenberg.isGutenboarding = isGutenboarding;
 		calypsoifyGutenberg.frankenflowUrl = frankenflowUrl;
+		calypsoifyGutenberg.isNewLaunch = isNewLaunch;
 		// Hook necessary if message recieved after editor has loaded.
 		window.wp.hooks.doAction( 'setGutenboardingStatus', isGutenboarding );
 	};


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Add `isNewLaunch` flag on `calypsoifyGutenberg` object to be used in editor.

#### Testing instructions
* Apply patch D47997-code and follow its test plan.
* Testing instruction from #44850 still apply