### PR TITLE
Add gutenberg onboarding existing users test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -253,4 +253,14 @@ export default {
 		localeTargets: 'any',
 		localeExceptions: [ 'en', 'es' ],
 	},
+	existingUsersGutenbergOnboard: {
+		datestamp: '20200812',
+		variations: {
+			gutenberg: 50,
+			control: 50,
+		},
+		defaultVariation: 'control',
+		allowExistingUsers: true,
+		localeTargets: [ 'en' ],
+	},
 };

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -65,7 +65,11 @@ const removeWhiteBackground = function () {
 
 const gutenbergRedirect = function () {
 	if ( 'verticals' === abtest( 'verticalsOnGutenboarding' ) ) {
-		window.location.replace( window.location.origin + '/new?vertical' + window.location.search );
+		window.location.replace(
+			`${ window.location.origin }/new${
+				window.location.search ? window.location.search + '&vertical' : '?vertical'
+			}`
+		);
 	} else {
 		window.location.replace( window.location.origin + '/new' + window.location.search );
 	}

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -63,6 +63,14 @@ const removeWhiteBackground = function () {
 	document.body.classList.remove( 'is-white-signup' );
 };
 
+const gutenbergRedirect = function () {
+	if ( 'verticals' === abtest( 'verticalsOnGutenboarding' ) ) {
+		window.location.replace( window.location.origin + '/new?vertical' + window.location.search );
+	} else {
+		window.location.replace( window.location.origin + '/new' + window.location.search );
+	}
+};
+
 export const addP2SignupClassName = () => {
 	if ( ! document ) {
 		return;
@@ -109,19 +117,18 @@ export default {
 
 			next();
 		} else {
+			const userLoggedIn = isUserLoggedIn( context.store.getState() );
+			if ( userLoggedIn && 'gutenberg' === abtest( 'existingUsersGutenbergOnboard' ) ) {
+				gutenbergRedirect();
+			}
+
 			waitForData( {
 				geo: () => requestGeoLocation(),
 			} )
 				.then( ( { geo } ) => {
 					const countryCode = geo.data.body.country_short;
 					if ( 'gutenberg' === abtest( 'newSiteGutenbergOnboarding', countryCode ) ) {
-						if ( 'verticals' === abtest( 'verticalsOnGutenboarding' ) ) {
-							window.location.replace(
-								window.location.origin + '/new?vertical&' + window.location.search
-							);
-						} else {
-							window.location.replace( window.location.origin + '/new' + window.location.search );
-						}
+						gutenbergRedirect();
 					} else if (
 						( ! user() || ! user().get() ) &&
 						-1 === context.pathname.indexOf( 'free' ) &&

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -64,15 +64,14 @@ const removeWhiteBackground = function () {
 };
 
 const gutenbergRedirect = function () {
+	const url = new URL( window.location );
+	url.pathname = '/new';
+
 	if ( 'verticals' === abtest( 'verticalsOnGutenboarding' ) ) {
-		window.location.replace(
-			`${ window.location.origin }/new${
-				window.location.search ? window.location.search + '&vertical' : '?vertical'
-			}`
-		);
-	} else {
-		window.location.replace( window.location.origin + '/new' + window.location.search );
+		url.searchParams.append( 'vertical', '' );
 	}
+
+	window.location.replace( url.toString() );
 };
 
 export const addP2SignupClassName = () => {


### PR DESCRIPTION
This PR adds a new A/B test that sends 50% the English-speaking existing users who are creating a new WordPress.com through the gutenberg-version of the onboarding experience.

How to test
=====

1. Go to  https://hash-136d7cddf698f5843f78ae2a3c839b273c9f963c.calypso.live/ and open the developer tools
2. Run this command:  `localStorage.setItem( 'ABTests', '{"existingUsersGutenbergOnboard_20200812":"gutenberg", "newSiteGutenbergOnboarding_20200811":"control"}' );` and reload the page;
3. Go to https://hash-136d7cddf698f5843f78ae2a3c839b273c9f963c.calypso.live/start
4. You should be redirected to https://hash-136d7cddf698f5843f78ae2a3c839b273c9f963c.calypso.live/new
5. Open https://hash-136d7cddf698f5843f78ae2a3c839b273c9f963c.calypso.live/start in an incognito window. You should be redirected to https://hash-136d7cddf698f5843f78ae2a3c839b273c9f963c.calypso.live/start/user. 
4. Go back to https://hash-136d7cddf698f5843f78ae2a3c839b273c9f963c.calypso.live/ in the browser where you are logged to .com
5. Run this command: `localStorage.setItem( 'ABTests', '{"existingUsersGutenbergOnboard_20200812":"control", "newSiteGutenbergOnboarding_20200811":"control"}' );` and reload the page
6. Go to https://hash-136d7cddf698f5843f78ae2a3c839b273c9f963c.calypso.live//start. You should be redirected to https://hash-136d7cddf698f5843f78ae2a3c839b273c9f963c.calypso.live//start/domains this time
