### PR TITLE
Fix incomplete site SEO previews

### DIFF
--- a/client/state/sites/constants.js
+++ b/client/state/sites/constants.js
@@ -21,6 +21,7 @@ export const SITE_REQUEST_FIELDS = [
 	'is_fse_active',
 	'is_fse_eligible',
 	'is_core_site_editor_enabled',
+	'description',
 ].join();
 
 export const SITE_REQUEST_OPTIONS = [


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This adds the site description back into the site seo preview. It was already implemented to read the `description` property of the site object as one of the sources for this, however, this `desription` was not pulled from the API and was completely missing from the object. 

I have added it to the list of fields we request from the API and now it automatically ends up in the preview.

#### Testing instructions

- `yarn start`
- http://calypso.localhost:3000/view and pick a site
- once loaded, switch to the "Search & Social" preview and check if the site description aka tagline (configurable in http://calypso.localhost:3000/settings/general) is visible in previews:

| Before (WordPress.com produciton) | After (This PR) |
| - | - |
| <img width="413" alt="Screenshot 2020-08-12 at 12 17 06" src="https://user-images.githubusercontent.com/156676/90004348-c3b6db00-dc95-11ea-9054-7b1524237324.png"> | <img width="446" alt="Screenshot 2020-08-12 at 11 54 41" src="https://user-images.githubusercontent.com/156676/90004273-a3871c00-dc95-11ea-95c6-e2777c6fd722.png">
