### PR TITLE
Adds cache-loader to speed up sass related loaders

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 Dockerfile
 /.tsc-cache
+/.cache
 .dockerignore
 .git
 .npm-debug.log*

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 *.iml
 *.iws
 /.tsc-cache/
+/.cache/
 /tags
 node_modules
 /npm-debug.log*

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ ARG        commit_sha="(unknown)"
 ENV        COMMIT_SHA $commit_sha
 
 ARG        workers
-RUN        WORKERS=$workers CALYPSO_ENV=production BUILD_TRANSLATION_CHUNKS=true yarn run build
+RUN        WORKERS=$workers CALYPSO_ENV=production BUILD_TRANSLATION_CHUNKS=true yarn run build && rm -fr .cache
 
 USER       nobody
 CMD        NODE_ENV=production node build/bundle.js

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -63,7 +63,7 @@ const isDesktopMonorepo = isDesktop && process.env.DESKTOP_MONOREPO === 'true';
 const defaultBrowserslistEnv = isDesktop ? 'defaults' : 'evergreen';
 const browserslistEnv = process.env.BROWSERSLIST_ENV || defaultBrowserslistEnv;
 const extraPath = browserslistEnv === 'defaults' ? 'fallback' : browserslistEnv;
-
+const cachePath = path.resolve( '.cache', extraPath );
 const hasLanguagesMeta = fs.existsSync(
 	path.join( __dirname, 'languages', 'languages-meta.json' )
 );
@@ -212,6 +212,7 @@ const webpackConfig = {
 					},
 				},
 				prelude: `@import '${ path.join( __dirname, 'assets/stylesheets/shared/_utils.scss' ) }';`,
+				cacheDirectory: path.resolve( cachePath, 'css-loader' ),
 			} ),
 			{
 				include: path.join( __dirname, 'sections.js' ),

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
 		"clean:packages": "npx lerna run clean --stream",
 		"clean:public": "npx rimraf public",
 		"clean:translations": "npx rimraf build/strings calypso-strings.pot chunks-map.*.json",
-		"distclean": "yarn run clean && npx rimraf node_modules client/node_modules desktop/node_modules apps/*/node_modules packages/*/node_modules test/e2e/node_modules .tsc-cache vendor",
+		"distclean": "yarn run clean && npx rimraf node_modules client/node_modules desktop/node_modules apps/*/node_modules packages/*/node_modules test/e2e/node_modules .tsc-cache .cache vendor",
 		"docker": "docker run -it --name wp-calypso --rm -p 80:3000 wp-calypso",
 		"docker-jetpack-cloud": "docker run -it --env CALYPSO_ENV=jetpack-cloud-production --name wp-calypso --rm -p 80:3000 wp-calypso",
 		"download-languages-meta": "node bin/download-languages-meta.js",

--- a/packages/calypso-build/package.json
+++ b/packages/calypso-build/package.json
@@ -37,13 +37,13 @@
 		"@automattic/mini-css-extract-plugin-with-rtl": "^0.8.0",
 		"@babel/cli": "^7.10.5",
 		"@babel/core": "^7.11.1",
+		"@babel/helpers": "^7.10.4",
 		"@babel/plugin-proposal-class-properties": "^7.10.4",
 		"@babel/plugin-transform-react-jsx": "^7.10.4",
 		"@babel/plugin-transform-runtime": "^7.11.0",
 		"@babel/preset-env": "^7.11.0",
 		"@babel/preset-react": "^7.10.4",
 		"@babel/preset-typescript": "^7.10.4",
-		"@babel/helpers": "^7.10.4",
 		"@types/webpack-env": "^1.15.2",
 		"@wordpress/babel-plugin-import-jsx-pragma": "^2.7.0",
 		"@wordpress/browserslist-config": "^2.7.0",
@@ -75,8 +75,8 @@
 	},
 	"peerDependencies": {
 		"enzyme": "^3.11.0",
+		"jest": ">=22.0.0",
 		"react": "^16.0.0",
-		"react-dom": "^16.0.0",
-		"jest": ">=22.0.0"
+		"react-dom": "^16.0.0"
 	}
 }

--- a/packages/calypso-build/package.json
+++ b/packages/calypso-build/package.json
@@ -52,6 +52,7 @@
 		"babel-jest": "^26.0.0",
 		"babel-loader": "^8.1.0",
 		"browserslist": "^4.8.2",
+		"cache-loader": "^4.1.0",
 		"caniuse-api": "^3.0.0",
 		"css-loader": "^3.4.2",
 		"duplicate-package-checker-webpack-plugin": "^3.0.0",

--- a/packages/calypso-build/webpack/sass.js
+++ b/packages/calypso-build/webpack/sass.js
@@ -11,13 +11,20 @@ const WebpackRTLPlugin = require( 'webpack-rtl-plugin' );
  * @param  {string[]}  _.includePaths                 Sass files lookup paths
  * @param  {string}    _.prelude                      String to prepend to each Sass file
  * @param  {object}    _.postCssConfig                PostCSS config
+ * @param  {object}    _.cacheDirectory               Directory used to store the cache
  *
  * @returns {object}                                  webpack loader object
  */
-module.exports.loader = ( { includePaths, prelude, postCssConfig = {} } ) => ( {
+module.exports.loader = ( { includePaths, prelude, postCssConfig = {}, cacheDirectory } ) => ( {
 	test: /\.(sc|sa|c)ss$/,
 	use: [
 		MiniCssExtractPluginWithRTL.loader,
+		{
+			loader: require.resolve( 'cache-loader' ),
+			options: {
+				cacheDirectory: cacheDirectory,
+			},
+		},
 		{
 			loader: require.resolve( 'css-loader' ),
 			options: {

--- a/packages/calypso-build/webpack/sass.js
+++ b/packages/calypso-build/webpack/sass.js
@@ -19,12 +19,16 @@ module.exports.loader = ( { includePaths, prelude, postCssConfig = {}, cacheDire
 	test: /\.(sc|sa|c)ss$/,
 	use: [
 		MiniCssExtractPluginWithRTL.loader,
-		{
-			loader: require.resolve( 'cache-loader' ),
-			options: {
-				cacheDirectory: cacheDirectory,
-			},
-		},
+		...( cacheDirectory
+			? [
+					{
+						loader: require.resolve( 'cache-loader' ),
+						options: {
+							cacheDirectory: cacheDirectory,
+						},
+					},
+			  ]
+			: [] ),
 		{
 			loader: require.resolve( 'css-loader' ),
 			options: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8177,6 +8177,11 @@ buffer-indexof@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-indexof/-/buffer-indexof-1.1.1.tgz#52fabcc6a606d1a00302802648ef68f639da268c"
   integrity sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g==
 
+buffer-json@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/buffer-json/-/buffer-json-2.0.0.tgz#f73e13b1e42f196fe2fd67d001c7d7107edd7c23"
+  integrity sha512-+jjPFVqyfF1esi9fvfUs3NqM0pH1ziZ36VP4hmA/y/Ssfo/5w5xHKfTw9BwQjoJ1w/oVtpLomqwUHKdefGyuHw==
+
 buffer-xor@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/buffer-xor/-/buffer-xor-1.0.3.tgz#26e61ed1422fb70dd42e6e36729ed51d855fe8d9"
@@ -8373,6 +8378,18 @@ cache-base@^1.0.1:
     to-object-path "^0.3.0"
     union-value "^1.0.0"
     unset-value "^1.0.0"
+
+cache-loader@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/cache-loader/-/cache-loader-4.1.0.tgz#9948cae353aec0a1fcb1eafda2300816ec85387e"
+  integrity sha512-ftOayxve0PwKzBF/GLsZNC9fJBXl8lkZE3TOsjkboHfVHVkL39iUEs1FO07A33mizmci5Dudt38UZrrYXDtbhw==
+  dependencies:
+    buffer-json "^2.0.0"
+    find-cache-dir "^3.0.0"
+    loader-utils "^1.2.3"
+    mkdirp "^0.5.1"
+    neo-async "^2.6.1"
+    schema-utils "^2.0.0"
 
 cacheable-lookup@^2.0.0:
   version "2.0.1"
@@ -24685,21 +24702,21 @@ schema-utils@^1.0.0:
     ajv-errors "^1.0.0"
     ajv-keywords "^3.1.0"
 
-schema-utils@^2.0.1, schema-utils@^2.1.0, schema-utils@^2.5.0, schema-utils@^2.6.0, schema-utils@^2.6.1, schema-utils@^2.6.4, schema-utils@^2.6.5, schema-utils@^2.6.6:
-  version "2.6.6"
-  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-2.6.6.tgz#299fe6bd4a3365dc23d99fd446caff8f1d6c330c"
-  integrity sha512-wHutF/WPSbIi9x6ctjGGk2Hvl0VOz5l3EKEuKbjPlB30mKZUzb9A5k9yEXRX3pwyqVLPvpfZZEllaFq/M718hA==
-  dependencies:
-    ajv "^6.12.0"
-    ajv-keywords "^3.4.1"
-
-schema-utils@^2.7.0:
+schema-utils@^2.0.0, schema-utils@^2.7.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-2.7.0.tgz#17151f76d8eae67fbbf77960c33c676ad9f4efc7"
   integrity sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==
   dependencies:
     "@types/json-schema" "^7.0.4"
     ajv "^6.12.2"
+    ajv-keywords "^3.4.1"
+
+schema-utils@^2.0.1, schema-utils@^2.1.0, schema-utils@^2.5.0, schema-utils@^2.6.0, schema-utils@^2.6.1, schema-utils@^2.6.4, schema-utils@^2.6.5, schema-utils@^2.6.6:
+  version "2.6.6"
+  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-2.6.6.tgz#299fe6bd4a3365dc23d99fd446caff8f1d6c330c"
+  integrity sha512-wHutF/WPSbIi9x6ctjGGk2Hvl0VOz5l3EKEuKbjPlB30mKZUzb9A5k9yEXRX3pwyqVLPvpfZZEllaFq/M718hA==
+  dependencies:
+    ajv "^6.12.0"
     ajv-keywords "^3.4.1"
 
 scrollparent@^2.0.1:


### PR DESCRIPTION
### Background

`cache-loader` is a [Webpack loader](https://webpack.js.org/loaders/cache-loader/#root) used to cache the result of other loaders, but we are not using it!

Found by @nsakaimbo in #44696

### Changes

Introduce `cache-loader` for SassLoader. The other expensive loader (babel) already implements its own caching mechanism.

On my machine, it saves almost 1 minute when building the evergreen bundle for production. I assume there are similar savings in all webpack operations in general:

```
Command: time NODE_ENV=production CALYPSO_ENV=production yarn run build-client-evergreen

Without cache-loader (first run is with cold cache):
	1st run (cold cache): 356.33s user 31.47s system 190% cpu 3:23.74 total
	2nd run (warm cache): 214.09s user 22.98s system 140% cpu 2:48.21 total <--
	3rd run (warm cache): 210.78s user 23.25s system 142% cpu 2:43.75 total <--

With cache-loader for css (first run is with cold cache):
	1st run (cold cache): 321.52s user 26.28s system 146% cpu 3:57.37 total
	2nd run (warm cache): 146.36s user 14.46s system 139% cpu 1:54.93 total <--
	3rd run (warm cache): 144.11s user 14.23s system 141% cpu 1:51.82 total <--
```

### Testing instructions

* Run any webpack related command (`yarn build-client-evergreen`, `yarn start`...) and verify it is faster now.
