### PR TITLE
Update Gutenberg e2e helper `addBlock` to check for custom aria label

### DIFF
--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -217,6 +217,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		name = name.charAt( 0 ).toUpperCase() + name.slice( 1 ); // Capitalize block name
 		let blockClass = kebabCase( name.toLowerCase() );
 		let hasChildBlocks = false;
+		let ariaLabel;
 		let prefix = '';
 		switch ( name ) {
 			case 'Instagram':
@@ -255,13 +256,15 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 				break;
 		}
 
+		const selectorAriaLabel = ariaLabel || `Block: ${ name }`;
+
 		const inserterBlockItemSelector = By.css(
 			`.edit-post-layout__inserter-panel .block-editor-inserter__block-list button.editor-block-list-item-${ prefix }${ blockClass }`
 		);
 		const insertedBlockSelector = By.css(
 			`.block-editor-block-list__block.${
 				hasChildBlocks ? 'has-child-selected' : 'is-selected'
-			}[aria-label*='Block: ${ name }']`
+			}[aria-label*='${ selectorAriaLabel }']`
 		);
 
 		await this.openBlockInserterAndSearch( name );

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -254,6 +254,9 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 				prefix = 'coblocks-';
 				blockClass = 'dynamic-separator';
 				break;
+			case 'Heading':
+				ariaLabel = 'Write heading…';
+				break;
 		}
 
 		const selectorAriaLabel = ariaLabel || `Block: ${ name }`;


### PR DESCRIPTION
This PR was spawned from https://github.com/Automattic/wp-calypso/pull/41329 where I needed to insert some core blocks and I couldn't do it due to this issue.

Currently the `GutenbergEditorComponent` expects all blocks to have a `aria-label` value in the format `Block: ${ name }']`.

https://github.com/Automattic/wp-calypso/blob/b8379e1ff7e41558e22677ee51dc591f2808d1e7/test/e2e/lib/gutenberg/gutenberg-editor-component.js#L261-L265

However some core blocks (and possibly others?) use a custom aria label. For example [`core/heading` has `Write heading…` as it's value](https://github.com/WordPress/gutenberg/blob/48ff9a111c979455c47013f2ea1991270b9be10a/packages/block-library/src/heading/edit.js#L73).

To fix this we add an exception to the `switch` statement which allows blocks to define a custom aria label. This is then used in the selector which validates that the block has been correctly inserted. This ensures we can insert blocks such as `core/heading` which don't follow the `Block: ${ name }']` pattern for `aria-label`.

This PR also adds a condition to account for said `core/heading` block. Others may follow as use cases arrise.

#### Alternatives considered

I did consider using a more robust selector that was guaranteed not to change. However, this would be less reflective of real-world user interaction. `aria-label` is a user _perceivable_ value and therefore it is better to use this to assert on the presence of the block in the editor rather than rely on some other selector target.


#### Changes proposed in this Pull Request

* Allow for a custom `aria-label` value for blocks which provide a custom value which doesn't follow the `Block: ${ name }']` format.

#### Testing instructions

* Check existing e2e tests do not fail. This PR should preserve _all_ existing functionality.
* There's not an easy way to test this other than try out https://github.com/Automattic/wp-calypso/pull/41329 which has the exact same change.

