### PR TITLE
Coalesce build caches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -217,10 +217,10 @@ references:
   desktop-restore-calypso-build-cache: &desktop-restore-calypso-build-cache
     name: Restore Calypso build cache
     keys:
-      - v6-desktop-calypso-build-{{ .Environment.CIRCLE_JOB }}-{{ arch }}
+      - v7-desktop-calypso-build-{{ .Environment.CIRCLE_JOB }}-{{ arch }}
   desktop-save-calypso-build-cache: &desktop-save-calypso-build-cache
     name: Save Calypso build cache
-    key: v6-desktop-calypso-build-{{ .Environment.CIRCLE_JOB }}-{{ arch }}
+    key: v7-desktop-calypso-build-{{ .Environment.CIRCLE_JOB }}-{{ arch }}
     paths:
       - .cache
   desktop-notify-github-success: &desktop-notify-github-success

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,21 +160,6 @@ references:
     paths:
       - ~/.cache/yarn
 
-  # Babel cache
-  # More about the CircleCI cache: https://circleci.com/docs/2.0/caching
-  restore-babel-client-cache: &restore-babel-client-cache
-    name: Restore Babel Client Cache
-    keys:
-      - v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v1-babel-client-{{ .Branch }}-{{ .Revision }}
-      - v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v1-babel-client-{{ .Branch }}
-      - v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v1-babel-client-trunk
-      - v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v1-babel-client
-  save-babel-client-cache: &save-babel-client-cache
-    name: Save Babel Client Cache
-    key: v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v1-babel-client-{{ .Branch }}-{{ .Revision }}
-    paths:
-      - 'build/.babel-client-cache'
-
   set-e2e-variables: &set-e2e-variables
     name: Set e2e environment variables
     command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,33 +197,33 @@ references:
   desktop-restore-yarn-cache: &desktop-restore-yarn-cache
     name: Restore yarn cache
     keys:
-      - v6-desktop-yarn-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ checksum ".nvmrc" }}
-      - v6-desktop-yarn-{{ .Environment.CIRCLE_JOB }}-{{ arch }}
+      - v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v0-desktop-yarn-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ checksum ".nvmrc" }}
+      - v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v0-desktop-yarn-{{ .Environment.CIRCLE_JOB }}-{{ arch }}
   desktop-save-yarn-cache: &desktop-save-yarn-cache
     name: Save yarn cache
-    key: v6-desktop-yarn-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ checksum ".nvmrc" }}
+    key: v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v0-desktop-yarn-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ checksum ".nvmrc" }}
     paths:
       - ~/.cache/yarn
   desktop-restore-packages-cache: &desktop-restore-packages-cache
     name: Restore packages cache
     keys:
-      - v6-desktop-packages-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ checksum "packages-hash" }}
+      - v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v0-desktop-packages-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ checksum "packages-hash" }}
   desktop-save-packages-cache: &desktop-save-packages-cache
     name: Save packages cache
-    key: v6-desktop-packages-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ checksum "packages-hash" }}
+    key: v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v0-desktop-packages-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ checksum "packages-hash" }}
     paths:
       - packages
       - packages-cache-restored
   desktop-restore-calypso-build-cache: &desktop-restore-calypso-build-cache
     name: Restore Calypso build cache
     keys:
-      - v7-desktop-calypso-build-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ .Branch }}-{{ .Revision }}
-      - v7-desktop-calypso-build-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ .Branch }}
-      - v7-desktop-calypso-build-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-trunk
-      - v7-desktop-calypso-build-{{ .Environment.CIRCLE_JOB }}-{{ arch }}
+      - v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v0-desktop-calypso-build-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ .Branch }}-{{ .Revision }}
+      - v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v0-desktop-calypso-build-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ .Branch }}
+      - v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v0-desktop-calypso-build-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-trunk
+      - v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v0-desktop-calypso-build-{{ .Environment.CIRCLE_JOB }}-{{ arch }}
   desktop-save-calypso-build-cache: &desktop-save-calypso-build-cache
     name: Save Calypso build cache
-    key: v7-desktop-calypso-build-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ .Branch }}-{{ .Revision }}
+    key: v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v0-desktop-calypso-build-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ .Branch }}-{{ .Revision }}
     paths:
       - .cache
   desktop-notify-github-success: &desktop-notify-github-success

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,8 +35,7 @@ references:
         "$CIRCLE_TEST_REPORTS/packages"         \
         "$CIRCLE_TEST_REPORTS/server"           \
         "$CIRCLE_TEST_REPORTS/e2ereports"       \
-        "$HOME/jest-cache"                      \
-        "$HOME/terser-cache"
+        "$HOME/jest-cache"
 
   # Jest cache caching
   #
@@ -68,20 +67,21 @@ references:
       - ~/jest-cache
 
   #
-  # Terser cache caching
+  # Build cache
   #
-  restore-terser-cache: &restore-terser-cache
-    name: Restore Terser cache
+  # This contains caches used by the build process (mainly webpack loaders and plugins)
+  restore-build-cache: &restore-build-cache
+    name: Restore build cache
     keys:
-      - v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v0-terser-{{ .Branch }}-{{ .Revision }}
-      - v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v0-terser-{{ .Branch }}
-      - v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v0-terser-trunk
-      - v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v0-terser
-  save-terser-cache: &save-terser-cache
-    name: Save Terser cache
-    key: v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v0-terser-{{ .Branch }}-{{ .Revision }}
+      - v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v0-build-{{ .Branch }}-{{ .Revision }}
+      - v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v0-build-{{ .Branch }}
+      - v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v0-build-trunk
+      - v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v0-build
+  save-build-cache: &save-build-cache
+    name: Save build cache
+    key: v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v0-build-{{ .Branch }}-{{ .Revision }}
     paths:
-      - ~/terser-cache
+      - .cache
 
   # Git cache
   #

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -214,15 +214,15 @@ references:
     paths:
       - packages
       - packages-cache-restored
-  desktop-restore-webpack-css-loader-cache: &desktop-restore-webpack-css-loader-cache
-    name: Restore webpack cache-loader cache
+  desktop-restore-calypso-build-cache: &desktop-restore-calypso-build-cache
+    name: Restore Calypso build cache
     keys:
-      - v6-desktop-webpack-css-loader-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ checksum "webpack-css-loader-hash" }}
-  desktop-save-webpack-css-loader-cache: &desktop-save-webpack-css-loader-cache
-    name: Save webpack cache-loader cache
-    key: v6-desktop-webpack-css-loader-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ checksum "webpack-css-loader-hash" }}
+      - v6-desktop-calypso-build-{{ .Environment.CIRCLE_JOB }}-{{ arch }}
+  desktop-save-calypso-build-cache: &desktop-save-calypso-build-cache
+    name: Save Calypso build cache
+    key: v6-desktop-calypso-build-{{ .Environment.CIRCLE_JOB }}-{{ arch }}
     paths:
-      - ~/.cache/webpack/css
+      - .cache
   desktop-notify-github-success: &desktop-notify-github-success
     name: Notify Github Success
     when: on_success
@@ -657,12 +657,9 @@ jobs:
           command: |
             # Get latest commit that modified packages directory
             echo "$(git log -n 1 --format='%h' -- packages .nvmrc yarn.lock)" > packages-hash
-
-            # Get latest commit that modified .css and related files
-            echo "$(git log -n 1 --format='%h' -- '*.css' '*.scss' '*.sass')" > webpack-css-loader-hash
       - restore_cache: *desktop-restore-yarn-cache
       - restore_cache: *desktop-restore-packages-cache
-      - restore_cache: *desktop-restore-webpack-css-loader-cache
+      - restore_cache: *desktop-restore-calypso-build-cache
       - run:
           name: Install Linux deps
           command: |
@@ -712,7 +709,7 @@ jobs:
 
             yarn run build-desktop:source
       - save_cache: *desktop-save-packages-cache
-      - save_cache: *desktop-save-webpack-css-loader-cache
+      - save_cache: *desktop-save-calypso-build-cache
       - persist_to_workspace:
           root: /home/circleci/wp-calypso
           paths: *desktop-cache-paths

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -217,10 +217,13 @@ references:
   desktop-restore-calypso-build-cache: &desktop-restore-calypso-build-cache
     name: Restore Calypso build cache
     keys:
+      - v7-desktop-calypso-build-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ .Branch }}-{{ .Revision }}
+      - v7-desktop-calypso-build-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ .Branch }}
+      - v7-desktop-calypso-build-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-trunk
       - v7-desktop-calypso-build-{{ .Environment.CIRCLE_JOB }}-{{ arch }}
   desktop-save-calypso-build-cache: &desktop-save-calypso-build-cache
     name: Save Calypso build cache
-    key: v7-desktop-calypso-build-{{ .Environment.CIRCLE_JOB }}-{{ arch }}
+    key: v7-desktop-calypso-build-{{ .Environment.CIRCLE_JOB }}-{{ arch }}-{{ .Branch }}-{{ .Revision }}
     paths:
       - .cache
   desktop-notify-github-success: &desktop-notify-github-success

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -208,14 +208,14 @@ const webpackConfig = {
 			TranspileConfig.loader( {
 				workerCount,
 				configFile: path.resolve( 'babel.config.js' ),
-				cacheDirectory: path.resolve( 'build', '.babel-client-cache', extraPath ),
+				cacheDirectory: path.resolve( cachePath, 'babel-client' ),
 				cacheIdentifier,
 				exclude: /node_modules\//,
 			} ),
 			TranspileConfig.loader( {
 				workerCount,
 				presets: [ require.resolve( '@automattic/calypso-build/babel/dependencies' ) ],
-				cacheDirectory: path.resolve( 'build', '.babel-client-cache', extraPath ),
+				cacheDirectory: path.resolve( cachePath, 'babel-client' ),
 				cacheIdentifier,
 				include: shouldTranspileDependency,
 			} ),

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -180,9 +180,7 @@ const webpackConfig = {
 		chunkIds: isDevelopment || shouldEmitStats ? 'named' : 'natural',
 		minimize: shouldMinify,
 		minimizer: Minify( {
-			cache: process.env.CIRCLECI
-				? `${ process.env.HOME }/terser-cache/${ extraPath }`
-				: 'docker' !== process.env.CONTAINER,
+			cache: path.resolve( cachePath, 'terser' ),
 			// Desktop: number of workers should *not* exceed # of vCPUs available.
 			// For both medium Machine and Docker images, number of vCPUs == 2.
 			// Ref: https://support.circleci.com/hc/en-us/articles/360038192673-NodeJS-Builds-or-Test-Suites-Fail-With-ENOMEM-or-a-Timeout

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -318,7 +318,7 @@ const webpackConfig = {
 		shouldShowProgress && new IncrementalProgressPlugin(),
 		new MomentTimezoneDataPlugin( {
 			startYear: 2000,
-			cacheDir: path.resolve( 'build', '.moment-timezone-data-webpack-plugin-cache', extraPath ),
+			cacheDir: path.resolve( cachePath, 'moment-timezone' ),
 		} ),
 		new ConfigFlagPlugin( {
 			flags: { desktop: config.isEnabled( 'desktop' ) },

--- a/packages/calypso-build/webpack/sass.js
+++ b/packages/calypso-build/webpack/sass.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-const path = require( 'path' );
 const MiniCssExtractPluginWithRTL = require( '@automattic/mini-css-extract-plugin-with-rtl' );
 const WebpackRTLPlugin = require( 'webpack-rtl-plugin' );
 
@@ -40,7 +39,7 @@ module.exports.loader = ( {
 		{
 			loader: require.resolve( 'cache-loader' ),
 			options: {
-				cacheDirectory: path.resolve( process.env.HOME, '.cache', 'webpack', 'css' ),
+				cacheDirectory: cacheDirectory,
 			},
 		},
 		{

--- a/packages/calypso-build/webpack/sass.js
+++ b/packages/calypso-build/webpack/sass.js
@@ -37,12 +37,6 @@ module.exports.loader = ( {
 			  ]
 			: [] ),
 		{
-			loader: require.resolve( 'cache-loader' ),
-			options: {
-				cacheDirectory: cacheDirectory,
-			},
-		},
-		{
 			loader: require.resolve( 'css-loader' ),
 			options: {
 				importLoaders: 2,

--- a/packages/composite-checkout/webpack.config.js
+++ b/packages/composite-checkout/webpack.config.js
@@ -1,4 +1,5 @@
 const path = require( 'path' );
+const cachePath = path.resolve( '.cache', 'composite-checkout' );
 
 module.exports = {
 	entry: './src/public-api.js',
@@ -17,7 +18,7 @@ module.exports = {
 					{
 						loader: 'cache-loader',
 						options: {
-							cacheDirectory: path.resolve( process.env.HOME, '.cache', 'webpack', 'css' ),
+							cacheDirectory: path.resolve( cachePath, 'css' ),
 						},
 					},
 					'style-loader',


### PR DESCRIPTION
### Background

We have a few caches all over the place:
* TypeScript caches are in `.tsc-cache`
* css-loader caches are in `.cache/css`
* Babel caches are in `./build/.babel-client-cache`
* Moment caches are in `./build/.moment-timezone-data-webpack-plugin-cache`

### Changes

This PR moves all those caches into directories inside `./cache` for easier cleanup

### Testing instructions

* Verify tests passes
* Checkout the branch and run `yarn start` two times. Verify `.cache` has some content, and the second time was faster than the first one.
