### PR TITLE
Gutenboarding: v2 improvements for header and domain search

### DIFF
--- a/client/landing/gutenboarding/components/domain-picker-button/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-button/index.tsx
@@ -24,7 +24,7 @@ import './style.scss';
 const DomainPickerButton: React.FunctionComponent = () => {
 	const { __, i18nLocale } = useI18n();
 	const makePath = usePath();
-	const { domain, domainSearch, siteTitle, siteVertical } = useSelect( ( select ) =>
+	const { domain, domainSearch, selectedDesign, siteTitle, siteVertical } = useSelect( ( select ) =>
 		select( ONBOARD_STORE ).getState()
 	);
 
@@ -50,14 +50,14 @@ const DomainPickerButton: React.FunctionComponent = () => {
 	const isLoadingSuggestion = suggestionQuery && ! domainSuggestion && ! domain;
 
 	// Show slide-in animation when a domain suggestion is loaded only if the user didn't interacted with Domain Picker
-	const showAnimation = ! domain && ! domainSearch && domainSuggestion;
+	const showAnimation = ! domain && ! domainSearch && ! selectedDesign && domainSuggestion;
 
 	const getDomainElementContent = () => {
+		if ( isLoadingSuggestion ) {
+			return null;
+		}
 		if ( domain ) {
 			return domain.domain_name;
-		}
-		if ( isLoadingSuggestion ) {
-			return 'example.wordpress.com';
 		}
 		if ( domainSuggestion ) {
 			/* translators: domain name is available, eg: "yourname.com is available" */
@@ -68,14 +68,13 @@ const DomainPickerButton: React.FunctionComponent = () => {
 	};
 
 	return (
-		<div>
-			<Link
-				to={ makePath( Step.DomainsModal ) }
-				className={ classnames( 'domain-picker-button', {
-					'domain-picker-button--has-first-content': showAnimation,
-					'domain-picker-button--has-placeholder': isLoadingSuggestion,
-				} ) }
-			>
+		<div
+			className={ classnames( 'domain-picker-button', {
+				'domain-picker-button--has-first-content': showAnimation,
+				'domain-picker-button--has-content': ! isLoadingSuggestion,
+			} ) }
+		>
+			<Link to={ makePath( Step.DomainsModal ) }>
 				<span className="domain-picker-button__label">{ getDomainElementContent() }</span>
 				<Icon icon={ chevronDown } size={ 22 } />
 			</Link>

--- a/client/landing/gutenboarding/components/domain-picker-button/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-button/index.tsx
@@ -3,41 +3,83 @@
  */
 import * as React from 'react';
 import classnames from 'classnames';
+import { useSelect } from '@wordpress/data';
 import { Icon, chevronDown } from '@wordpress/icons';
+import { sprintf } from '@wordpress/i18n';
+import { useI18n } from '@automattic/react-i18n';
 
 /**
  * Internal dependencies
  */
-import Link, { Props as LinkProps } from '../link';
+import Link from '../link';
 import { usePath, Step } from '../../path';
+import { STORE_KEY as ONBOARD_STORE } from '../../stores/onboard';
+import { DOMAIN_SUGGESTIONS_STORE } from '../../stores/domain-suggestions';
 
 /**
  * Style dependencies
  */
 import './style.scss';
 
-interface Props extends LinkProps {
-	children: string | React.ReactElement;
-}
-
-const DomainPickerButton: React.FunctionComponent< Props > = ( {
-	children,
-	className,
-	...buttonProps
-} ) => {
+const DomainPickerButton: React.FunctionComponent = () => {
+	const { __, i18nLocale } = useI18n();
 	const makePath = usePath();
+	const { domain, domainSearch, siteTitle, siteVertical } = useSelect( ( select ) =>
+		select( ONBOARD_STORE ).getState()
+	);
+
+	// Use site title or vertical as search query for a domain suggestion
+	const suggestionQuery = siteTitle || siteVertical?.label;
+	const domainSuggestion = useSelect(
+		( select ) => {
+			// Get suggestion only if the query is valid and if there isn't a selected domain
+			if ( ! suggestionQuery || suggestionQuery.length < 2 || domain ) {
+				return;
+			}
+			return select( DOMAIN_SUGGESTIONS_STORE ).getDomainSuggestions( suggestionQuery, {
+				// Avoid `only_wordpressdotcom` — it seems to fail to find results sometimes
+				include_wordpressdotcom: false,
+				include_dotblogsubdomain: false,
+				quantity: 1, // this will give the recommended domain only
+				locale: i18nLocale,
+			} );
+		},
+		[ suggestionQuery ]
+	)?.[ 0 ];
+
+	const isLoadingSuggestion = suggestionQuery && ! domainSuggestion && ! domain;
+
+	// Show slide-in animation when a domain suggestion is loaded only if the user didn't interacted with Domain Picker
+	const showAnimation = ! domain && ! domainSearch && domainSuggestion;
+
+	const getDomainElementContent = () => {
+		if ( domain ) {
+			return domain.domain_name;
+		}
+		if ( isLoadingSuggestion ) {
+			return 'example.wordpress.com';
+		}
+		if ( domainSuggestion ) {
+			/* translators: domain name is available, eg: "yourname.com is available" */
+			return sprintf( __( '%s is available' ), domainSuggestion.domain_name );
+		}
+		// If there is no selected domain and no site title / vertical, show a static button
+		return __( 'Choose a domain' );
+	};
 
 	return (
-		<>
+		<div>
 			<Link
-				{ ...buttonProps }
 				to={ makePath( Step.DomainsModal ) }
-				className={ classnames( 'domain-picker-button', className ) }
+				className={ classnames( 'domain-picker-button', {
+					'domain-picker-button--has-first-content': showAnimation,
+					'domain-picker-button--has-placeholder': isLoadingSuggestion,
+				} ) }
 			>
-				<span className="domain-picker-button__label">{ children }</span>
+				<span className="domain-picker-button__label">{ getDomainElementContent() }</span>
 				<Icon icon={ chevronDown } size={ 22 } />
 			</Link>
-		</>
+		</div>
 	);
 };
 

--- a/client/landing/gutenboarding/components/domain-picker-button/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker-button/style.scss
@@ -1,5 +1,6 @@
 @import 'assets/stylesheets/gutenberg-base-styles';
 @import '../../mixins.scss';
+@import '../../variables.scss';
 
 @keyframes domain-picker-button-slide-in {
 	from {
@@ -8,7 +9,13 @@
 		padding: 5px 0;
 	}
 
-	20% {
+	79% {
+		max-width: 0;
+		opacity: 0;
+		padding: 5px;
+	}
+
+	80% {
 		max-width: 0;
 		opacity: 0;
 		padding: 5px 12px;
@@ -22,24 +29,21 @@
 }
 
 .domain-picker-button {
+	opacity: 0;
+	transition: opacity $acquire-intent-transition-duration $acquire-intent-transition-algorithm;
+
+	&--has-content {
+		opacity: 1;
+	}
+
 	&--has-first-content {
-		animation-duration: 1.6s;
+		animation-duration: 4s;
 		animation-name: domain-picker-button-slide-in;
 		max-width: 1500px;
 		@include reduce-motion( 'animation' );
 	}
 
-	&--has-placeholder {
-		@include onboarding-placeholder;
-		@include reduce-motion( 'animation' );
-
-		& > span,
-		& > svg {
-			opacity: 0;
-		}
-	}
-
-	&.components-button {
+	.components-button {
 		@include onboarding-medium-text;
 		background: var( --studio-blue-0 );
 		border-radius: $radius-block-ui;

--- a/client/landing/gutenboarding/components/domain-picker-button/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker-button/style.scss
@@ -1,24 +1,44 @@
 @import 'assets/stylesheets/gutenberg-base-styles';
 @import '../../mixins.scss';
 
-@keyframes gutenboarding_wriggle {
+@keyframes domain-picker-button-slide-in {
 	from {
-		transform: scale( 1 );
-		padding: 0;
+		max-width: 0;
+		opacity: 0;
+		padding: 5px 0;
 	}
 
-	50% {
-		transform: scale( 1.05 );
-		padding: 2px;
+	20% {
+		max-width: 0;
+		opacity: 0;
+		padding: 5px 12px;
 	}
 
 	to {
-		transform: scale( 1 );
-		padding: 0;
+		max-width: 500px;
+		opacity: 1;
+		padding: 5px 12px;
 	}
 }
 
 .domain-picker-button {
+	&--has-first-content {
+		animation-duration: 1.6s;
+		animation-name: domain-picker-button-slide-in;
+		max-width: 1500px;
+		@include reduce-motion( 'animation' );
+	}
+
+	&--has-placeholder {
+		@include onboarding-placeholder;
+		@include reduce-motion( 'animation' );
+
+		& > span,
+		& > svg {
+			opacity: 0;
+		}
+	}
+
 	&.components-button {
 		@include onboarding-medium-text;
 		background: var( --studio-blue-0 );

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -2,10 +2,7 @@
  * External dependencies
  */
 import * as React from 'react';
-import classnames from 'classnames';
 import { useI18n } from '@automattic/react-i18n';
-import { sprintf } from '@wordpress/i18n';
-import { useDebounce } from 'use-debounce';
 import { Icon, wordpress } from '@wordpress/icons';
 import { useSelect } from '@wordpress/data';
 
@@ -28,60 +25,20 @@ const Header: React.FunctionComponent = () => {
 	const { __, i18nLocale } = useI18n();
 	const currentStep = useCurrentStep();
 
-	const { domain, siteTitle } = useSelect( ( select ) => select( ONBOARD_STORE ).getState() );
+	const { siteTitle } = useSelect( ( select ) => select( ONBOARD_STORE ).getState() );
 
-	const [ domainSearch ] = useDebounce( siteTitle, 1000 /*ms*/ );
+	// steps (including modals) where we show Domains button
+	const showDomainsButton = [ 'DesignSelection', 'Style', 'Features', 'Plans' ].includes(
+		currentStep
+	);
 
-	const recommendedDomain = useSelect(
-		( select ) => {
-			if ( ! domainSearch || domainSearch.length < 2 ) {
-				return;
-			}
-			return select( 'automattic/domains/suggestions' ).getDomainSuggestions( domainSearch, {
-				// Avoid `only_wordpressdotcom` — it seems to fail to find results sometimes
-				include_wordpressdotcom: false,
-				include_dotblogsubdomain: false,
-				quantity: 1, // this will give the recommended domain only
-				locale: i18nLocale,
-			} );
-		},
-		[ domainSearch ]
-	)?.[ 0 ];
-
-	const getDomainElementContent = () => {
-		// If no site title entered (user skips intent gathering)
-		// and no domain was selected, show "Pick a domain"
-		if ( ! siteTitle && ! domain ) {
-			return null;
-		}
-
-		if ( recommendedDomain && ! domain ) {
-			/* translators: domain name is available, eg: "yourname.com is available" */
-			return sprintf( __( '%s is available' ), recommendedDomain.domain_name );
-		}
-
-		return __( 'Choose a domain' );
-	};
-
-	/* eslint-disable wpcalypso/jsx-classname-namespace */
-	const domainElement = domain
-		? domain.domain_name
-		: getDomainElementContent() && (
-				<span className="gutenboarding__header-domain-picker-button-domain">
-					{ getDomainElementContent() }
-				</span>
-		  );
-
-	const hideFullHeader = [
-		'IntentGathering',
-		'Domains',
-		'DomainsModal',
-		'LanguageModal',
-		'CreateSite',
-	].includes( currentStep );
+	// steps (including modals) where we hide Plans button
+	const showPlansButton = [ 'DesignSelection', 'Style', 'Features' ].includes( currentStep );
 
 	// CreateSite step clears state before redirecting, don't show the default text in this case
 	const siteTitleDefault = 'CreateSite' === currentStep ? '' : __( 'Start your website' );
+
+	/* eslint-disable wpcalypso/jsx-classname-namespace */
 
 	const changeLocaleButton = () => {
 		if ( isEnabled( 'gutenboarding/language-picker' ) ) {
@@ -104,11 +61,7 @@ const Header: React.FunctionComponent = () => {
 			aria-label={ __( 'Top bar' ) }
 			tabIndex={ -1 }
 		>
-			<section
-				className={ classnames( 'gutenboarding__header-section', {
-					'gutenboarding__header-section--compact': hideFullHeader,
-				} ) }
-			>
+			<section className="gutenboarding__header-section">
 				<div className="gutenboarding__header-section-item">
 					<div className="gutenboarding__header-wp-logo">
 						<Icon icon={ wordpress } size={ 28 } />
@@ -120,26 +73,11 @@ const Header: React.FunctionComponent = () => {
 					</div>
 				</div>
 				<div className="gutenboarding__header-section-item gutenboarding__header-domain-section">
-					{
-						// We display the DomainPickerButton as soon as we have a domain suggestion,
-						// unless we're still at the IntentGathering step. In that case, we only
-						// show it comes from a site title (but hide it if it comes from a vertical).
-						domainElement && (
-							<div
-								className={ classnames( 'gutenboarding__header-domain-picker-button-container', {
-									'no-domain': ! domain,
-								} ) }
-							>
-								<DomainPickerButton className="gutenboarding__header-domain-picker-button">
-									{ domainElement }
-								</DomainPickerButton>
-							</div>
-						)
-					}
+					{ showDomainsButton && <DomainPickerButton /> }
 				</div>
 				{ changeLocaleButton() }
 				<div className="gutenboarding__header-section-item gutenboarding__header-plan-section gutenboarding__header-section-item--right">
-					<PlansButton />
+					{ showPlansButton && <PlansButton /> }
 				</div>
 			</section>
 		</div>

--- a/client/landing/gutenboarding/components/header/style.scss
+++ b/client/landing/gutenboarding/components/header/style.scss
@@ -1,33 +1,9 @@
 @import 'assets/stylesheets/gutenberg-base-styles';
-@import 'assets/stylesheets/shared/mixins/placeholder'; // Contains the placeholder mixin
-@import 'assets/stylesheets/shared/animation'; // Needed for the placeholder
 @import '../../variables.scss';
 @import '~@automattic/onboarding/styles/z-index';
 
 $margin-left--gutenboarding__header-section-item: 13px; // matches design
 $padding--gutenboarding__header: $grid-unit-10;
-
-@keyframes gutenboarding_domain-slide-in {
-	from {
-		max-width: 0;
-		opacity: 0;
-	}
-
-	79% {
-		max-width: 0;
-		opacity: 0;
-	}
-
-	80% {
-		max-width: 0;
-		opacity: 0.5;
-	}
-
-	to {
-		max-width: 500px;
-		opacity: 1;
-	}
-}
 
 // Copied from https://github.com/WordPress/gutenberg/blob/8c0c7b7267473b5c197dd3052e9707f75f4e6448/packages/edit-widgets/src/components/header/style.scss
 .gutenboarding__header {
@@ -68,13 +44,6 @@ $padding--gutenboarding__header: $grid-unit-10;
 	width: 100%;
 	align-items: center;
 	font-size: $font-body-small;
-
-	&--compact {
-		.gutenboarding__header-domain-section,
-		.gutenboarding__header-plan-section {
-			visibility: hidden;
-		}
-	}
 }
 
 .gutenboarding__header-section-item {
@@ -106,13 +75,6 @@ $padding--gutenboarding__header: $grid-unit-10;
 	// Ensure flex item doesn't exceed 100% of th
 	// available width, allowing content to have ellipsis.
 	min-width: 0;
-}
-
-.gutenboarding__header-domain-picker-button-container.no-domain {
-	animation-duration: 5s;
-	animation-name: gutenboarding_domain-slide-in;
-	max-width: 1500px;
-	@include reduce-motion( 'animation' );
 }
 
 .gutenboarding__header-site-title-section {

--- a/client/landing/gutenboarding/onboarding-block/domains/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/domains/index.tsx
@@ -43,6 +43,8 @@ const DomainsStep: React.FunctionComponent< Props > = ( { isModal } ) => {
 	const { goBack, goNext } = useStepNavigation();
 
 	const domain = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedDomain() );
+
+	// using the selector will get the explicit domain search query with site title and vertical as fallbacks
 	const domainSearch = useSelect( ( select ) => select( ONBOARD_STORE ).getDomainSearch() );
 
 	const { setDomain, setDomainSearch, setHasUsedDomainsStep } = useDispatch( ONBOARD_STORE );

--- a/client/landing/gutenboarding/stores/onboard/selectors.ts
+++ b/client/landing/gutenboarding/stores/onboard/selectors.ts
@@ -24,7 +24,7 @@ export const getSelectedVertical = ( state: State ) => state.siteVertical;
 export const getSelectedDomain = ( state: State ) => state.domain;
 export const getSelectedSiteTitle = ( state: State ) => state.siteTitle;
 export const getDomainSearch = ( state: State ) =>
-	state.domainSearch || getSelectedSiteTitle( state );
+	state.domainSearch || getSelectedSiteTitle( state ) || getSelectedVertical( state )?.label;
 export const getPlan = ( state: State ) => state.plan;
 export const getSelectedFeatures = ( state: State ) => state.selectedFeatures;
 export const wasVerticalSkipped = ( state: State ): boolean => state.wasVerticalSkipped;

--- a/client/package.json
+++ b/client/package.json
@@ -173,7 +173,6 @@
 		"tracekit": "^0.4.5",
 		"twemoji": "^12.1.4",
 		"url": "^0.11.0",
-		"use-debounce": "^3.4.3",
 		"use-subscription": "^1.3.0",
 		"utility-types": "^3.10.0",
 		"uuid": "^7.0.3",

--- a/packages/plans-grid/src/plans-details/index.tsx
+++ b/packages/plans-grid/src/plans-details/index.tsx
@@ -94,7 +94,6 @@ const PlansDetails: React.FunctionComponent< Props > = ( { onSelect } ) => {
 										onSelect( plan.storeSlug );
 									} }
 									isPrimary
-									isLarge
 								>
 									<span>{ __( 'Choose' ) }</span>
 								</Button>

--- a/packages/plans-grid/src/plans-table/plan-item.tsx
+++ b/packages/plans-grid/src/plans-table/plan-item.tsx
@@ -169,7 +169,6 @@ const PlanItem: React.FunctionComponent< Props > = ( {
 									onSelect( slug );
 								} }
 								isPrimary
-								isLarge
 								disabled={ !! disabledLabel }
 							>
 								<span>{ __( 'Choose' ) }</span>

--- a/yarn.lock
+++ b/yarn.lock
@@ -28022,11 +28022,6 @@ use-debounce@^3.1.0:
   resolved "https://registry.yarnpkg.com/use-debounce/-/use-debounce-3.1.0.tgz#05a5c8cd3c2f309699f08961d7c8bbe7f68720bb"
   integrity sha512-DEf3L/ZKkOSTARk/DHlC6KAAJKwMqpck8Zx06SM2Wr+LfU1TzhO8hZRzB/qbpSQqREYWQes24n1q9doeTMqF4g==
 
-use-debounce@^3.4.3:
-  version "3.4.3"
-  resolved "https://registry.yarnpkg.com/use-debounce/-/use-debounce-3.4.3.tgz#5df9322322b3f1b1c263d46413f9facf6d8b56ab"
-  integrity sha512-nxy+opOxDccWfhMl36J5BSCTpvcj89iaQk2OZWLAtBJQj7ISCtx1gh+rFbdjGfMl6vtCZf6gke/kYvrkVfHMoA==
-
 use-memo-one@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/use-memo-one/-/use-memo-one-1.1.1.tgz#39e6f08fe27e422a7d7b234b5f9056af313bd22c"


### PR DESCRIPTION
### Changes proposed in this Pull Request

**Domain nudge and header updates**
* Show correct states of Domain Button with correct data fixing issues mentioned in https://github.com/Automattic/wp-calypso/pull/44655#issuecomment-671375706
* Refactor header and extract `DomainPickerButton` to load domain suggestion only after mounting the component and only if there is no selected domain. This means no more domain requests on Intent Capture step and also removing `useDebounce` dependency.

**Animation**
* Re-add loading status of domain button. 
* Re-add slide-in animation to highlight domain button until Domain Picker is used.
Demo: https://cloudup.com/c7ceOH98tvx

**Other**
* Use vertical as fallback for DomainPicker initial input value.
* Hide Plans button on Plans step and PlansModal (is causing a navigation bug).

### Testing instructions
* Go to /new
* Test all the possible cases described above
  * with a value for site title / vertical
  * with no value on intent capture step
  * with a changed value
  * before / after interacting with the domain picker (custom query or selecting a domain)

Fixes part of #44655
