### PR TITLE
Adds tracking events stack to wpcom editor on e2e test envs only

### DIFF
--- a/apps/wpcom-block-editor/src/utils.js
+++ b/apps/wpcom-block-editor/src/utils.js
@@ -67,3 +67,10 @@ export const getPages = async () =>
 			}
 		} );
 	} );
+
+// All end-to-end tests use a custom user agent containing this string.
+const E2E_USER_AGENT = 'wp-e2e-tests';
+
+export const isE2ETest = () => {
+	return typeof navigator !== 'undefined' && navigator.userAgent.includes( E2E_USER_AGENT ); //eslint-disable-line no-undef
+};

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/track-record-event.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/track-record-event.js
@@ -5,11 +5,26 @@
 import { isObjectLike, isUndefined, omit } from 'lodash';
 import debug from 'debug';
 
+/**
+ * Internal dependencies
+ */
+import { isE2ETest } from '../../../utils';
+
 const tracksDebug = debug( 'wpcom-block-editor:analytics:tracks' );
+const e2ETracksDebug = debug( 'wpcom-block-editor:e2e' );
 
 // In case Tracks hasn't loaded.
 if ( typeof window !== 'undefined' ) {
 	window._tkq = window._tkq || [];
+}
+
+// Enable a events stack for e2e testing purposes
+// on e2e test environments only.
+// see https://github.com/Automattic/wp-calypso/pull/41329.
+const E2E_STACK_SIZE = 20;
+if ( isE2ETest() ) {
+	e2ETracksDebug( 'E2E env' );
+	window._e2eEventsStack = [];
 }
 
 // Adapted from the analytics lib :(
@@ -60,5 +75,24 @@ export default ( eventName, eventProperties ) => {
 
 	tracksDebug( 'Recording event %o with actual props %o', eventName, eventProperties );
 
-	window._tkq.push( [ 'recordEvent', eventName, eventProperties ] );
+	const record = [ 'recordEvent', eventName, eventProperties ];
+
+	if ( isE2ETest() ) {
+		e2ETracksDebug(
+			'pushing %s event to E2E stack - current size: %o',
+			record[ 0 ],
+			window._e2eEventsStack.length
+		);
+		// Add the record at the beginning of the stack.
+		window._e2eEventsStack.unshift( record );
+
+		// Apply FIFO behaviour to E2E stack.
+		if ( window._e2eEventsStack.length > E2E_STACK_SIZE ) {
+			// Remove the last item.
+			const removeRecord = window._e2eEventsStack.pop();
+			e2ETracksDebug( 'removing %s last event from E2E stack', removeRecord[ 0 ] );
+		}
+	}
+
+	window._tkq.push( record );
 };


### PR DESCRIPTION
Sub PR of https://github.com/Automattic/wp-calypso/pull/41329. Accompanying diff D48009-code.

⚠️ **Note**: this PR contains the changes are to the _src_ files for the WPcom Editor. Therefore you will need to test against the built files which are in the accompanying diff D48009-code. The built files are what needs to be deployed to Dotcom Simple and they need to be generated from the Circle CI builds as per the FG.

These changes prepare the ground for introducing e2e tests that assert that certain tracking events are being fired within the Block Editor.

We add a "events stack" array on e2e envs only in order that the tests can assert that events are being fired. For the reasoning behind _why_ we need to introduce a stack like this please see [the parent PR](https://github.com/Automattic/wp-calypso/pull/41329).

#### Changes proposed in this Pull Request

* Add util to determine whether the code is running on an e2e test env.
* Add events stack to the WPCom Block Editor tracking suite.

#### Testing instructions

First, apply the Dotcom diff of the built version of these files from D48009-code to your sandbox.

The key thing is to ensure the variable `window._e2eEventsStack` is not present on any environment which is _not_ an e2e test environment.

To do this:

* Go to WordPress.com _**Staging**_ (remember this runs from your SB so it will use the patched files from the applied diff).
* Go to WP Admin.
* Create a new Post.
* Open your devtools console.
* Type `window._e2eEventsStack` - confirm that it is `undefined`.

Bonus points: to test that the stack _is_ available on an e2e test environment you should [`git checkout` on the parent PR](https://github.com/Automattic/wp-calypso/pull/41329) with D42393-code on your sandbox and then follow the testing instructions from the heading `Configure e2e tests`.