### PR TITLE
Registrationless checkout: Add signup tracking events

### DIFF
--- a/client/lib/analytics/signup.js
+++ b/client/lib/analytics/signup.js
@@ -64,9 +64,7 @@ export function recordSignupComplete(
 
 	gaRecordEvent( 'Signup', 'calypso_signup_complete:' + flags.join( ',' ) );
 
-	// We will not record this tracks event for a registrationless checkout user since we want this event
-	// to be fired only after account creation is complete.
-	if ( isNew7DUserSite && ! isRegistrationlessCheckoutUser ) {
+	if ( isNew7DUserSite ) {
 		// Tracks
 		recordTracksEvent( 'calypso_new_user_site_creation', { flow } );
 

--- a/client/lib/analytics/signup.js
+++ b/client/lib/analytics/signup.js
@@ -38,7 +38,7 @@ export function recordSignupComplete(
 		return addToQueue(
 			'signup',
 			'recordSignupComplete',
-			{ flow, siteId, isNewUser, hasCartItems, isNew7DUserSite },
+			{ flow, siteId, isNewUser, hasCartItems, isNew7DUserSite, isRegistrationlessCheckoutUser },
 			true
 		);
 	}

--- a/client/lib/analytics/signup.js
+++ b/client/lib/analytics/signup.js
@@ -28,7 +28,7 @@ export function recordSignupStart( flow, ref ) {
 }
 
 export function recordSignupComplete(
-	{ flow, siteId, isNewUser, hasCartItems, isNew7DUserSite },
+	{ flow, siteId, isNewUser, hasCartItems, isNew7DUserSite, isRegistrationlessCheckoutUser },
 	now
 ) {
 	const isNewSite = !! siteId;
@@ -64,7 +64,9 @@ export function recordSignupComplete(
 
 	gaRecordEvent( 'Signup', 'calypso_signup_complete:' + flags.join( ',' ) );
 
-	if ( isNew7DUserSite ) {
+	// We will not record this tracks event for a registrationless checkout user since we want this event
+	// to be fired only after account creation is complete.
+	if ( isNew7DUserSite && ! isRegistrationlessCheckoutUser ) {
 		// Tracks
 		recordTracksEvent( 'calypso_new_user_site_creation', { flow } );
 

--- a/client/lib/analytics/signup.js
+++ b/client/lib/analytics/signup.js
@@ -31,7 +31,7 @@ export function recordSignupComplete(
 	{ flow, siteId, isNewUser, hasCartItems, isNew7DUserSite, isRegistrationlessCheckoutUser },
 	now
 ) {
-	const isNewSite = !! siteId;
+	const isNewSite = !! ( siteId || isRegistrationlessCheckoutUser );
 
 	if ( ! now ) {
 		// Delay using the analytics localStorage queue.

--- a/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
@@ -27,8 +27,6 @@ import { tryToGuessPostalCodeFormat } from 'lib/postal-code';
 import { getSavedVariations } from 'lib/abtest';
 import { stringifyBody } from 'state/login/utils';
 import { recordGoogleRecaptchaAction } from 'lib/analytics/recaptcha';
-import { recordTracksEvent } from 'lib/analytics/tracks';
-import { gaRecordEvent } from 'lib/analytics/ga';
 
 const debug = debugFactory( 'calypso:composite-checkout:payment-method-helpers' );
 const { select } = defaultRegistry;
@@ -245,11 +243,6 @@ async function createAccountCallback( response ) {
 	if ( ! response.bearer_token ) {
 		return;
 	}
-
-	// Tracks
-	recordTracksEvent( 'calypso_new_user_site_creation', { flow: 'onboarding-registrationless' } );
-	// Google Analytics
-	gaRecordEvent( 'Signup', 'calypso_new_user_site_creation' );
 
 	// Log in the user
 	wp.loadToken( response.bearer_token );

--- a/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
@@ -27,6 +27,8 @@ import { tryToGuessPostalCodeFormat } from 'lib/postal-code';
 import { getSavedVariations } from 'lib/abtest';
 import { stringifyBody } from 'state/login/utils';
 import { recordGoogleRecaptchaAction } from 'lib/analytics/recaptcha';
+import { recordTracksEvent } from 'lib/analytics/tracks';
+import { gaRecordEvent } from 'lib/analytics/ga';
 
 const debug = debugFactory( 'calypso:composite-checkout:payment-method-helpers' );
 const { select } = defaultRegistry;
@@ -243,6 +245,11 @@ async function createAccountCallback( response ) {
 	if ( ! response.bearer_token ) {
 		return;
 	}
+
+	// Tracks
+	recordTracksEvent( 'calypso_new_user_site_creation', { flow: 'onboarding-registrationless' } );
+	// Google Analytics
+	gaRecordEvent( 'Signup', 'calypso_new_user_site_creation' );
 
 	// Log in the user
 	wp.loadToken( response.bearer_token );

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -356,8 +356,13 @@ class Signup extends React.Component {
 		debug( 'The flow is completed. Destination: %s', destination );
 
 		const { isNewishUser, existingSiteCount } = this.props;
+		const isRegistrationlessCheckoutUser =
+			'onboarding-registrationless' === this.props.flowName && null === dependencies.bearer_token;
 
-		const isNewUser = !! ( dependencies && dependencies.username );
+		const isNewUser = !! (
+			isRegistrationlessCheckoutUser ||
+			( dependencies && dependencies.username )
+		);
 		const siteId = dependencies && dependencies.siteId;
 		const isNew7DUserSite = !! (
 			isNewUser ||
@@ -382,6 +387,7 @@ class Signup extends React.Component {
 			isNewUser,
 			hasCartItems,
 			isNew7DUserSite,
+			isRegistrationlessCheckoutUser,
 		} );
 
 		this.handleLogin( dependencies, destination );

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -378,6 +378,7 @@ class Signup extends React.Component {
 			isNew7DUserSite,
 			flow: this.props.flowName,
 			siteId,
+			isRegistrationlessCheckoutUser,
 		};
 		debug( 'Tracking signup completion.', debugProps );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Following the suggestions in the comment pbxNRc-p4-p2#comment-625, this PR does two things:
- In the registrationless checkout flow, selecting a paid plan will fire `calypso_signup_complete` fired with is_new_user and is_new_site prop set to true.
- In the registrationless checkout flow, selecting a paid plan will fire `calypso_new_user_site_creation ` only after user account is created(i.e upon clicking the Pay button)
#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Begin at https://wordpress.com/start/onboarding-registrationless. Verify that the events calypso_signup_complete and calypso_new_user_site_creation fire right after signup flow completes and before checkout page loads when selecting a paid plan. When selecting a free plan, these events should fire right after the registration step.
