### PR TITLE
Gutenboarding: Some acquire intent post V2 fixes.

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
@@ -5,15 +5,14 @@ import * as React from 'react';
 import { useHistory } from 'react-router-dom';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useViewportMatch } from '@wordpress/compose';
-import { Button } from '@wordpress/components';
 import { useI18n } from '@automattic/react-i18n';
+import { SkipButton, NextButton } from '@automattic/onboarding';
 
 /**
  * Internal dependencies
  */
 import { STORE_KEY } from '../../stores/onboard';
 import { Step, usePath } from '../../path';
-import Link from '../../components/link';
 import VerticalSelect from './vertical-select';
 import SiteTitle from './site-title';
 import { useTrackStep } from '../../hooks/use-track-step';
@@ -53,9 +52,6 @@ const AcquireIntent: React.FunctionComponent = () => {
 	const hasSiteTitle = !! getSelectedSiteTitle();
 	const showSiteTitleAndNext = !! ( getSelectedVertical() || hasSiteTitle || wasVerticalSkipped() );
 
-	// translators: Button label for skipping filling an optional input in onboarding
-	const skipLabel = __( 'I donʼt know' );
-
 	const handleSkip = () => {
 		skipSiteVertical();
 		recordVerticalSkip();
@@ -80,26 +76,16 @@ const AcquireIntent: React.FunctionComponent = () => {
 	const siteTitleInput = showSiteTitleAndNext && (
 		<SiteTitle inputRef={ siteTitleRef } onSubmit={ handleSiteTitleSubmit } />
 	);
-	const nextStepButton = (
-		<Link
-			className="acquire-intent__question-skip"
-			isPrimary={ hasSiteTitle }
-			isDefault={ ! hasSiteTitle }
-			onClick={ () => ! hasSiteTitle && recordSiteTitleSkip() }
-			to={ nextStepPath }
-		>
-			{ hasSiteTitle ? __( 'Choose a design' ) : skipLabel }
-		</Link>
+	const nextStepButton = hasSiteTitle ? (
+		<NextButton onClick={ handleSiteTitleSubmit }>{ __( 'Choose a design' ) }</NextButton>
+	) : (
+		<SkipButton onClick={ handleSiteTitleSubmit }>{ __( 'I donʼt know' ) }</SkipButton>
 	);
+
 	const skipButton = (
-		<Button
-			isLink={ isMobile }
-			isDefault={ ! isMobile }
-			onClick={ handleSkip }
-			className="acquire-intent__skip-vertical"
-		>
-			{ skipLabel }
-		</Button>
+		<SkipButton className="acquire-intent__skip-vertical" onClick={ handleSkip }>
+			{ __( 'I donʼt know' ) }
+		</SkipButton>
 	);
 
 	const siteVertical = getSelectedVertical();
@@ -115,9 +101,11 @@ const AcquireIntent: React.FunctionComponent = () => {
 							<div>
 								<Arrow
 									className="acquire-intent__mobile-back-arrow"
-									onClick={ () => setIsSiteTitleActive( false ) }
 									transform="rotate(180)"
+									onClick={ () => setIsSiteTitleActive( false ) }
+									role="button"
 								/>
+
 								{ siteTitleInput }
 							</div>
 						) : (
@@ -136,7 +124,11 @@ const AcquireIntent: React.FunctionComponent = () => {
 							( isSiteTitleActive
 								? nextStepButton
 								: ( ( ! siteVertical || siteVertical?.label?.length < 3 ) && skipButton ) || (
-										<Arrow className="acquire-intent__mobile-next-arrow" onClick={ onNext } />
+										<Arrow
+											className="acquire-intent__mobile-next-arrow"
+											onClick={ onNext }
+											role="button"
+										/>
 								  ) ) }
 
 						{ /* On desktop we always render nextStepButton when we render site title

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
@@ -6,6 +6,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { useI18n } from '@automattic/react-i18n';
 import { Icon } from '@wordpress/icons';
 import classnames from 'classnames';
+import { useViewportMatch } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -84,8 +85,11 @@ const SiteTitle: React.FunctionComponent< Props > = ( { onSubmit, inputRef } ) =
 		setIsTouched( true );
 	};
 
+	const isMobile = useViewportMatch( 'small', '<' );
+
 	// translators: label for site title input in Gutenboarding
-	const inputLabel = showVerticalInput ? __( "It's called" ) : __( 'My site is called' );
+	const inputLabel =
+		showVerticalInput && ! isMobile ? __( "It's called" ) : __( 'My site is called' );
 
 	const placeHolder = useTyper( siteTitleExamples, ! siteTitle, {
 		delayBetweenCharacters: 70,

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
@@ -34,6 +34,12 @@
 		flex-wrap: wrap;
 		align-items: baseline;
 	}
+
+	.vertical-select + & {
+		@include break-medium {
+			margin-top: 20px;
+		}
+	}
 }
 
 .site-title__input-label {
@@ -50,14 +56,12 @@
 	flex: 1;
 
 	@include break-small {
-		margin-top: 0;
 		min-width: 300px;
 		max-width: 400px;
 	}
 
 	@include break-medium {
 		max-width: 750px;
-		margin-top: 20px;
 	}
 }
 

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
@@ -88,11 +88,12 @@
 }
 
 .acquire-intent__footer {
-	margin-top: 40px;
+	margin-top: 20px;
 	display: flex;
 	justify-content: flex-end;
 
 	@include break-small {
+		margin-top: 40px;
 		justify-content: flex-start;
 	}
 

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
@@ -100,33 +100,18 @@
 		margin-top: 40px;
 		justify-content: flex-start;
 	}
-
-	.components-button.acquire-intent__skip-vertical.is-link {
-		padding: 0;
-		color: $dark-gray-600;
-	}
-
-	// Applies to both
-	// - .components-button.acquire-intent__skip-vertical
-	// - .components-button.acquire-intent__question-skip
-	.components-button.is-secondary {
-		color: var( --studio-gray-50 );
-		box-shadow: inset 0 0 0 1px var( --studio-gray-50 );
-
-		&:active,
-		&:hover {
-			color: var( --studio-gray-60 );
-			box-shadow: inset 0 0 0 1px var( --studio-gray-60 );
-		}
-
-		&:focus {
-			color: var( --studio-gray-60 );
-			box-shadow: inset 0 0 0 1px #fff, 0 0 0 1.5px var( --highlightColor );
-		}
-	}
 }
 
 .acquire-intent__mobile-vertical-input {
 	display: flex;
 	flex-wrap: wrap;
+}
+
+.acquire-intent__mobile-next-arrow,
+.acquire-intent__mobile-back-arrow {
+	cursor: pointer;
+}
+
+.acquire-intent__mobile-back-arrow {
+	margin-bottom: 20px;
 }

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
@@ -195,7 +195,6 @@ const VerticalSelect: React.FunctionComponent< Props > = ( { onNext } ) => {
 		>
 			<label htmlFor="vertical-input">{ __( 'My site is about' ) } </label>
 			<span className="vertical-select__suggestions-wrapper">
-				{ ! isMobile && <span className="vertical-select__whitespace"></span> }
 				<AcquireIntentTextInput
 					placeholder={ animatedPlaceholder }
 					value={ textValue }

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/style.scss
@@ -58,7 +58,6 @@
 
 .vertical-select__suggestions {
 	position: absolute;
-	left: -16px;
 	min-height: 300px;
 	max-height: calc( 100% - 50px );
 	overflow: auto;

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/style.scss
@@ -58,6 +58,7 @@
 
 .vertical-select__suggestions {
 	position: absolute;
+	left: -16px;
 	min-height: 300px;
 	max-height: calc( 100% - 50px );
 	overflow: auto;
@@ -65,6 +66,10 @@
 	@include break-small {
 		width: 250px;
 		max-height: 400px;
+	}
+
+	@include break-medium {
+		left: 0;
 	}
 }
 

--- a/test/e2e/lib/pages/gutenboarding/acquire-intent-page.js
+++ b/test/e2e/lib/pages/gutenboarding/acquire-intent-page.js
@@ -20,12 +20,12 @@ export default class AcquireIntentPage extends AsyncBaseContainer {
 	}
 
 	async goToNextStep() {
-		const nextButtonSelector = By.css( '.acquire-intent__question-skip.is-primary' );
+		const nextButtonSelector = By.css( '.action-buttons__next' );
 		return await driverHelper.clickWhenClickable( this.driver, nextButtonSelector );
 	}
 
 	async skipStep() {
-		const skipButtonSelector = By.css( '.acquire-intent__question-skip' );
+		const skipButtonSelector = By.css( '.action-buttons__skip' );
 		return await driverHelper.clickWhenClickable( this.driver, skipButtonSelector );
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove extra vertical whitespace between site input label and site input when site input is on the next line.
* Use SkipButton & NextButton.
* Update E2E test to use SkipButton & NextButton.
* When on mobile, use "My site is called..." on the second page instead of "It's called..." to help user understand what to enter.
* Add `role=button` & styling adjustments on back and next arrow buttons for mobile.
* Remove extra spacing between acquire intent footer and acquire intent body on mobile.	
* Remove extra margin left on vertical suggestion on desktop.

#### Testing instructions

* Test all of the above on `/new`.

