### PR TITLE
Checkout: Use stylized display names for Jetpack products in notices

### DIFF
--- a/client/my-sites/checkout/checkout/included-product-notice-content.tsx
+++ b/client/my-sites/checkout/checkout/included-product-notice-content.tsx
@@ -3,13 +3,14 @@
  */
 import { useTranslate } from 'i18n-calypso';
 import { isArray } from 'lodash';
-import React, { FunctionComponent } from 'react';
+import React, { ReactElement, FunctionComponent } from 'react';
 import { useSelector } from 'react-redux';
 
 /**
  * Internal Dependencies
  */
 import { getProductBySlug } from 'state/products-list/selectors';
+import { getJetpackProductDisplayName } from 'lib/products-values/get-jetpack-product-display-name';
 import { getSitePurchases } from 'state/purchases/selectors';
 import type { Plan } from 'state/plans/types';
 import type { RawSiteProduct } from 'state/sites/selectors/get-site-products';
@@ -47,11 +48,13 @@ const IncludedProductNoticeContent: FunctionComponent< Props > = ( {
 		<div className="checkout__duplicate-notice">
 			<p className="checkout__duplicate-notice-message">
 				{ translate(
-					'You currently own Jetpack %(plan)s. The product you are about to purchase, %(product)s, is already included in this plan.',
+					'You currently own Jetpack %(plan)s. The product you are about to purchase, {{product/}}, is already included in this plan.',
 					{
 						args: {
 							plan: plan.product_name_short,
-							product: product?.product_name,
+						},
+						components: {
+							product: getJetpackProductDisplayName( product ) as ReactElement,
 						},
 						comment:
 							'The `plan` variable refers to the short name of the plan the customer owns already. `product` refers to the product in the cart that is already included in the plan.',

--- a/client/my-sites/checkout/checkout/owned-product-notice-content.tsx
+++ b/client/my-sites/checkout/checkout/owned-product-notice-content.tsx
@@ -3,12 +3,13 @@
  */
 import { useTranslate } from 'i18n-calypso';
 import { isArray } from 'lodash';
-import React, { FunctionComponent } from 'react';
+import React, { ReactElement, FunctionComponent } from 'react';
 import { useSelector } from 'react-redux';
 
 /**
  * Internal Dependencies
  */
+import { getJetpackProductDisplayName } from 'lib/products-values/get-jetpack-product-display-name';
 import { getSitePurchases } from 'state/purchases/selectors';
 import type { SiteProduct } from 'state/sites/selectors/get-site-products';
 
@@ -37,14 +38,12 @@ const OwnedProductNoticeContent: FunctionComponent< Props > = ( { product, selec
 		<div className="checkout__duplicate-notice">
 			<p className="checkout__duplicate-notice-message">
 				{ translate(
-					'You currently own %(product)s. The plan you are about to purchase also includes this product. Consider removing your {{link}}%(product)s subscription{{/link}}.',
+					'You currently own {{product/}}. The plan you are about to purchase also includes this product. Consider removing your {{link}}{{product/}} subscription{{/link}}.',
 					{
-						args: {
-							product: product.productName,
-						},
 						comment: 'The `product` variable refers to the product the customer owns already',
 						components: {
 							link: <a href={ subscriptionUrl } />,
+							product: getJetpackProductDisplayName( product ) as ReactElement,
 						},
 					}
 				) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update pre-purchase notices/warnings for Jetpack products to use their stylized "display" name instead of their plain-text product name.

#### Known issues

* There's some extra whitespace around the product names. I'm investigating whether this is intentional, and if not, I'll create a new PR to address it.

#### Testing instructions

* Attempt to check out with Jetpack Backup, for a site that has a plan with Jetpack Backup included.
  * Verify that a pre-purchase notice appears, and that the product name is mentioned as **Jetpack Backup *Italic*** instead of **Jetpack Backup (Parentheses)**.
* Attempt to check out with a Jetpack plan that includes Backup, for a site that already owns Jetpack Backup individually.
  * Verify that a pre-purchase notice appears, and that the product name is mentioned as **Jetpack Backup *Italic*** instead of **Jetpack Backup (Parentheses)**.

#### Screenshots

<img width="570" alt="Screen Shot 2020-08-12 at 08 24 33" src="https://user-images.githubusercontent.com/670067/90031847-526e2c80-dc83-11ea-8edd-976f3e9356bb.png">
<img width="573" alt="Screen Shot 2020-08-12 at 08 30 05" src="https://user-images.githubusercontent.com/670067/90031856-55691d00-dc83-11ea-8fe5-63f3ae6f4ba6.png">
