### PR TITLE
Composite checkout: Hide domain contact details summary for renewals

### DIFF
--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -515,11 +515,13 @@ export function getDomainTransfers( cart ) {
 /**
  * Determines whether all items are renewal items in the specified shopping cart.
  *
+ * Ignores partial credits, which aren't really a line item in this sense.
+ *
  * @param {CartValue} cart - cart as `CartValue` object
  * @returns {boolean} true if there are only renewal items, false otherwise
  */
 export function hasOnlyRenewalItems( cart ) {
-	return every( getAllCartItems( cart ), isRenewal );
+	return getAllCartItems( cart ).every( ( item ) => isRenewal( item ) || isPartialCredits( item ) );
 }
 
 /**
@@ -1097,6 +1099,16 @@ export function removePrivacyFromAllDomains( cart ) {
 		replaceItem,
 		false
 	);
+}
+
+/**
+ * Determines whether a cart item is partial credits
+ *
+ * @param {CartItemValue} cartItem - `CartItemValue` object
+ * @returns {boolean} true if item is credits
+ */
+export function isPartialCredits( cartItem ) {
+	return cartItem.product_slug === 'wordpress-com-credits';
 }
 
 /**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When a cart is only renewals, we do not show the domain contact fields (see https://github.com/Automattic/wp-calypso/pull/44533), but we still show those fields in the summary if they have been previously filled-out. This, however, is poor UX since those fields cannot be edited.

In this PR, we hide the domain contact details from the summary (the completed step) if the cart is only renewals.

Fixes https://github.com/Automattic/wp-calypso/issues/44867

#### Screenshots

Only postal code and country (renewal or plan):

![Screen Shot 2020-08-12 at 12 47 44 PM](https://user-images.githubusercontent.com/2036909/90043588-4e013e00-dc9a-11ea-8a73-520be2f3de47.png)

Full contact details (non-renewal domain):

![Screen Shot 2020-08-12 at 12 46 52 PM](https://user-images.githubusercontent.com/2036909/90043712-79842880-dc9a-11ea-9143-f9474eb20caa.png)

G Suite only details:

![Screen Shot 2020-08-12 at 12 46 05 PM](https://user-images.githubusercontent.com/2036909/90043788-9a4c7e00-dc9a-11ea-8683-7b7afd168251.png)


#### Testing instructions

- Visit checkout with just a domain renewal in your cart.
- Verify that the contact details step summary shows only postal code and country.
- Visit checkout with just a plan in your cart.
- Verify that the contact details step summary shows only postal code and country.
- Visit checkout with a new domain in your cart (a plan can also be in your cart if you like).
- Verify that the contact details step summary shows all the domain contact information (name, phone number, email, etc.).
- Visit checkout with only G Suite in your cart (not a domain; this requires you to already own a domain).
- Verify that the contact details step summary shows only name, email, postal code, and country.