### PR TITLE
Changes translation to use comment instead of context

### DIFF
--- a/client/my-sites/plans-v2/utils.ts
+++ b/client/my-sites/plans-v2/utils.ts
@@ -74,7 +74,7 @@ export function productButtonLabel( product: SelectorProduct ): TranslateResult 
 		product.buttonLabel ??
 		translate( 'Get %s', {
 			args: product.displayName,
-			context: '%s is the name of a product',
+			comment: '%s is the name of a product',
 		} )
 	);
 }
@@ -183,7 +183,7 @@ export function itemToSelectorProduct(
 			monthlyProductSlug,
 			buttonLabel: translate( 'Get %s', {
 				args: getJetpackProductShortName( item ),
-				context: '%s is the name of a product',
+				comment: '%s is the name of a product',
 			} ),
 			term: item.term,
 			features: [],


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This fixes a bug introduced in #44754 that used `context` instead of `comment`.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Review code and ensure expected tests pass.

Ref: p1596898671053300-slack-C02AED43D