### PR TITLE
Gutenboarding: Ensure checkout always lands in customer home.

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/hooks/use-on-launch.ts
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/hooks/use-on-launch.ts
@@ -56,8 +56,7 @@ export const useOnLaunch = () => {
 					// 	? `site-editor%2F${ newSite.site_slug }`
 					// 	: `block-editor%2Fpage%2F${ newSite.site_slug }%2Fhome`;
 					// window.location.href = `https://wordpress.com/checkout/${ window._currentSiteId }?preLaunch=1&isGutenboardingCreate=1&redirect_to=%2F${ editorUrl }`;
-
-					window.top.location.href = `https://wordpress.com/checkout/${ window._currentSiteId }?preLaunch=1`;
+					window.top.location.href = `https://wordpress.com/checkout/${ window._currentSiteId }?preLaunch=1&redirect_to=%2Fhome%2F${ window._currentSiteId }`;
 				};
 
 				// TODO: record tracks event

--- a/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/hooks/use-on-launch.ts
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/hooks/use-on-launch.ts
@@ -3,12 +3,13 @@
  */
 import * as React from 'react';
 import { useSelect, useDispatch } from '@wordpress/data';
+import { addQueryArgs } from '@wordpress/url';
 
 /**
  * Internal dependencies
  */
 import { useSite } from './';
-import { LAUNCH_STORE, SITE_STORE } from '../stores';
+import { LAUNCH_STORE, SITE_STORE, PLANS_STORE } from '../stores';
 
 declare global {
 	interface Window {
@@ -19,6 +20,9 @@ declare global {
 export const useOnLaunch = () => {
 	const { launchStatus } = useSite();
 	const { plan, domain } = useSelect( ( select ) => select( LAUNCH_STORE ).getState() );
+	const isEcommercePlan = useSelect( ( select ) =>
+		select( PLANS_STORE ).isPlanEcommerce( plan?.storeSlug )
+	);
 
 	const { getCart, setCart } = useDispatch( SITE_STORE );
 
@@ -56,7 +60,17 @@ export const useOnLaunch = () => {
 					// 	? `site-editor%2F${ newSite.site_slug }`
 					// 	: `block-editor%2Fpage%2F${ newSite.site_slug }%2Fhome`;
 					// window.location.href = `https://wordpress.com/checkout/${ window._currentSiteId }?preLaunch=1&isGutenboardingCreate=1&redirect_to=%2F${ editorUrl }`;
-					window.top.location.href = `https://wordpress.com/checkout/${ window._currentSiteId }?preLaunch=1&redirect_to=%2Fhome%2F${ window._currentSiteId }`;
+
+					const checkoutUrl = addQueryArgs(
+						`https://wordpress.com/checkout/${ window._currentSiteId }`,
+						{
+							preLaunch: 1,
+							// Redirect to My Home after checkout only if the selected plan is not eCommerce
+							...( ! isEcommercePlan && { redirect_to: `/home/${ window._currentSiteId }` } ),
+						}
+					);
+
+					window.top.location.href = checkoutUrl;
 				};
 
 				// TODO: record tracks event

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -545,7 +545,12 @@ export class Checkout extends React.Component {
 			selectedSiteSlug,
 			transaction: { step: { data: stepResult = null } = {} } = {},
 			isJetpackNotAtomic,
+			returnToHome,
 		} = this.props;
+
+		if ( returnToHome ) {
+			return `/home/${ selectedSiteSlug }`;
+		}
 
 		const adminUrl = get( selectedSite, [ 'options', 'admin_url' ] );
 

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -545,12 +545,7 @@ export class Checkout extends React.Component {
 			selectedSiteSlug,
 			transaction: { step: { data: stepResult = null } = {} } = {},
 			isJetpackNotAtomic,
-			returnToHome,
 		} = this.props;
-
-		if ( returnToHome ) {
-			return `/home/${ selectedSiteSlug }`;
-		}
 
 		const adminUrl = get( selectedSite, [ 'options', 'admin_url' ] );
 

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -23,7 +23,10 @@ function getCheckoutUrl( dependencies, localeSlug ) {
 	return addQueryArgs(
 		{
 			signup: 1,
-			...( dependencies.isPreLaunch && { preLaunch: 1 } ),
+			...( dependencies.isPreLaunch && {
+				preLaunch: 1,
+				redirect_to: `/home/${ dependencies.siteSlug }`,
+			} ),
 			...( dependencies.isGutenboardingCreate && { isGutenboardingCreate: 1 } ),
 		},
 		checkoutURL

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -9,6 +9,7 @@ import { assign, get, includes, indexOf, reject } from 'lodash';
 import config from 'config';
 import stepConfig from './steps';
 import user from 'lib/user';
+import { isEcommercePlan } from 'lib/plans';
 import { generateFlows } from 'signup/config/flows-pure';
 import { addQueryArgs } from 'lib/url';
 
@@ -25,8 +26,11 @@ function getCheckoutUrl( dependencies, localeSlug ) {
 			signup: 1,
 			...( dependencies.isPreLaunch && {
 				preLaunch: 1,
-				redirect_to: `/home/${ dependencies.siteSlug }`,
 			} ),
+			...( dependencies.isPreLaunch &&
+				! isEcommercePlan( dependencies.cartItem.product_slug ) && {
+					redirect_to: `/home/${ dependencies.siteSlug }`,
+				} ),
 			...( dependencies.isGutenboardingCreate && { isGutenboardingCreate: 1 } ),
 		},
 		checkoutURL


### PR DESCRIPTION
## Changes proposed in this Pull Request

* Ensure gutenboarding checkout always lands in customer home.

## Testing instructions


**Setup** 

* For **old checkout**, set `"old-checkout-force": true` in `development.json` and run `yarn start`.
  * Alternatively, you can add `return 'old-checkout';` on `getCheckoutVariant()` function in `checkout-system-decider.js` to avoid restarting yarn.
* For **composite checkout**, set `"composite-checkout-force": true` in `development.json` and run `yarn start`.
  * Alternatively, you can add `return 'composite-checkout';` on `getCheckoutVariant()` function in `checkout-system-decider.js` to avoid restarting yarn.
* Go to `apps/full-site-editing` and run `yarn dev --sync`.

**Test twice, once with Old Checkout, once with Composite Checkout**

* Go through the `calypso.localhost:3000/new` flow.
  * Be sure to choose Free plan so you land in editor with launch flow.
* Once you land in the editor, you have a site url. Sandbox the new site url, restart your browser and reload the page.
* During the launch flow, pick a paid plan.
* When you land in the checkout page, you should see `redirect_to` query param on the checkout url.
* Clicking on Pay button it should redirect back to customer home.

**Test launch from site home**

* Go through the `calypso.localhost:3000/new` flow.
* When you land in editor, go to customer site home (click W on the upper left corner, then My Home).
* Then click on Launch your site, and click Launch (see screenshot).
* Go through the checkout process.
* Clicking on Pay button should redirect back to customer home.

![image](https://user-images.githubusercontent.com/1287077/90261112-cc9ddd00-de4c-11ea-8ff5-a86edd9e3e9f.png)
