### PR TITLE
Composite checkout: Disable the submit button while the order review step is active

### DIFF
--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -296,7 +296,10 @@ export default function WPCheckout( {
 					<SecondaryCartPromotions responseCart={ responseCart } addItemToCart={ addItemToCart } />
 				</CheckoutSummaryBody>
 			</CheckoutSummaryAreaUI>
-			<CheckoutStepArea submitButtonHeader={ <SubmitButtonHeader /> }>
+			<CheckoutStepArea
+				submitButtonHeader={ <SubmitButtonHeader /> }
+				disableSubmitButton={ isOrderReviewActive }
+			>
 				{ infoMessage && (
 					<CheckoutNoticeWrapper>
 						<Notice status="is-info" showDismiss={ false }>

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -208,6 +208,7 @@ Creates the Checkout form and provides a wrapper for [CheckoutStep](#CheckoutSte
 This component's props are:
 
 - `submitButtonHeader: React.ReactNode`. Displays with the Checkout submit button.
+- `disableSubmitButton: boolean`. If true, the submit button will always be disabled. If false (the default), the submit button will be enabled only on the last step and only if the [formStatus](#useFormStatus) is 'ready'.
 
 ## CheckoutStepBody
 

--- a/packages/composite-checkout/src/components/checkout-steps.js
+++ b/packages/composite-checkout/src/components/checkout-steps.js
@@ -147,7 +147,12 @@ export const CheckoutSummaryCard = styled.div`
 	}
 `;
 
-export function CheckoutStepArea( { children, className, submitButtonHeader } ) {
+export function CheckoutStepArea( {
+	children,
+	className,
+	submitButtonHeader,
+	disableSubmitButton,
+} ) {
 	const { __ } = useI18n();
 	const onEvent = useEvents();
 	const { formStatus } = useFormStatus();
@@ -177,7 +182,9 @@ export function CheckoutStepArea( { children, className, submitButtonHeader } ) 
 					errorMessage={ __( 'There was a problem with the submit button.' ) }
 					onError={ onSubmitButtonLoadError }
 				>
-					<CheckoutSubmitButton disabled={ isThereAnotherNumberedStep || formStatus !== 'ready' } />
+					<CheckoutSubmitButton
+						disabled={ isThereAnotherNumberedStep || formStatus !== 'ready' || disableSubmitButton }
+					/>
 				</CheckoutErrorBoundary>
 			</SubmitButtonWrapperUI>
 		</CheckoutStepAreaUI>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The "Pay" submit button in composite checkout is inserted by the `CheckoutStepArea` component from `@automattic/composite-checkout`. Its `disabled` status is currently controlled by two factors: the button is disabled if the active step is not the last step, or if the form status is not 'ready' (eg: loading, validating, etc.). However, the "active step" for this purpose is a step inside a `CheckoutSteps` step group, and if you manually create steps outside such a group, then it's possible for an "active step" to be hidden. For example, if you use the `areStepsActive` prop of `CheckoutSteps`, it will hide all the steps, but one of them may still be "active". The result is that the button may be enabled when it should not be enabled.

To handle this edge case, this PR adds a new optional prop to `CheckoutStepArea` called `disableSubmitButton` which, if truthy, will disable the submit button even if it would otherwise be enabled.

Finally, this PR uses that prop in calypso to disable the button when the review step (that exists outside of a `CheckoutSteps`) is active.

Fixes https://github.com/Automattic/wp-calypso/issues/44393

#### Testing instructions

- Visit checkout with pre-filled contact information (or complete the contact step) so that you see the final step.
- Verify that the submit button is active.
- Click "edit" on the first step (the order).
- Verify that the submit button is inactive.
- Click "Save order" to return to the final step.
- Verify that the submit button is active.