### PR TITLE
Use speak for inline help with more concise announcements

### DIFF
--- a/client/blocks/inline-help/inline-help-search-results.jsx
+++ b/client/blocks/inline-help/inline-help-search-results.jsx
@@ -188,16 +188,9 @@ function HelpSearchResults( {
 
 	const renderSearchResults = () => {
 		if ( isSearching && ! searchResults.length ) {
-			// debounceSpeak('Loading search results.');
 			// search, but no results so far
 			return <PlaceholderLines lines={ placeholderLines } />;
 		}
-
-		// if ( ! isEmpty( searchQuery ) && ! hasAPIResults ) {
-		// 	debounceSpeak('No search results found.');
-		// } else if (! isEmpty( searchQuery ) && hasAPIResults ) {
-		// 	debounceSpeak('Search results loaded.');
-		// }
 
 		return (
 			<>

--- a/client/blocks/inline-help/inline-help-search-results.jsx
+++ b/client/blocks/inline-help/inline-help-search-results.jsx
@@ -8,6 +8,8 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
 import page from 'page';
+import { speak } from '@wordpress/a11y';
+import { useEffect } from 'react';
 
 /**
  * Internal Dependencies
@@ -43,6 +45,22 @@ function HelpSearchResults( {
 	placeholderLines,
 	track,
 } ) {
+
+
+	useEffect( () => {
+		// If there's no query, then we don't need to announce anything.
+		if( ! searchQuery.length ) {
+			return;
+		}
+
+		if ( isSearching ) {
+			speak( 'Loading search results.', 'polite' );
+		} else if ( searchResults.length ) {
+			speak( 'Search results loaded.', 'polite' );
+		}
+
+	}, [isSearching, searchResults]);
+
 	function getTitleBySectionType( type, query = '' ) {
 		let title = '';
 		switch ( type ) {
@@ -155,14 +173,10 @@ function HelpSearchResults( {
 
 	const renderSearchResults = () => {
 		if ( isSearching && ! searchResults.length ) {
+
 			// search, but no results so far
 			return (
-				<>
-					<div className="inline-help__visually-hidden">
-						{ translate( 'Loading search results' ) }
-					</div>
-					<PlaceholderLines lines={ placeholderLines } />
-				</>
+				<PlaceholderLines lines={ placeholderLines } />
 			);
 		}
 
@@ -175,6 +189,7 @@ function HelpSearchResults( {
 						) }
 					</p>
 				) }
+				
 
 				<div className="inline-help__results" aria-label={ translate( 'Search Results' ) }>
 					{ renderSearchSections( searchResults, searchQuery ) }
@@ -186,7 +201,7 @@ function HelpSearchResults( {
 	return (
 		<>
 			<QueryInlineHelpSearch query={ searchQuery } />
-			<div aria-live="polite">{ renderSearchResults() }</div>
+			{ renderSearchResults() }
 		</>
 	);
 }

--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -482,10 +482,6 @@
 	}
 }
 
-.inline-help__visually-hidden {
-	@include hide-content-accessibly;
-}
-
 @keyframes inline-help__results-placeholder-loading {
 	0% {
 		opacity: 0.3;

--- a/client/package.json
+++ b/client/package.json
@@ -45,6 +45,7 @@
 		"@github/webauthn-json": "^0.4.1",
 		"@testing-library/jest-dom": "^5.9.0",
 		"@testing-library/react": "^10.0.5",
+		"@wordpress/a11y": "^2.11.0",
 		"@wordpress/api-fetch": "^3.18.0",
 		"@wordpress/base-styles": "^2.0.1",
 		"@wordpress/block-editor": "^4.3.3",


### PR DESCRIPTION
Removes the aria-live region in order to make spoken announcements more concise and timely.

![speak-search-result-improvement](https://user-images.githubusercontent.com/967608/90171647-6723f080-dd67-11ea-8a3c-13650b1948e4.gif)
*This gif is edited to not take up as much bandwidth*

#### Changes proposed in this Pull Request

* Removes aria-live region
* Adds `@wordpress/a11y` package
* Uses `speak()` for search announcements

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Turn on a screen reader, such as VoiceOver (ask siri to turn on VoiceOver or Command + F5)
* Open up Safari (if using VoiceOver)
* Enter a search result that will return results
* A little after the results are loaded, you should hear "Search results loaded."
* If the results are taking awhile to return, you should hear "Loading search results." The loading message only appears on longer running searches and should not announce otherwise.
* Enter a search that will not return results from the API, such as "asdfkasdfjlaskdf"
* After 1.5s, you should hear "Loading search results."
* When the search finishes, you should hear "No search results found."

Fixes https://github.com/Automattic/wp-calypso/issues/44620
