### PR TITLE
Checkout: Warn that Jetpack Backup requires plugin version >= 8.5

### DIFF
--- a/client/my-sites/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout-system-decider.js
@@ -88,7 +88,7 @@ export default function CheckoutSystemDecider( {
 			: null
 	);
 
-	const BACKUP_MINIMUM_PLUGIN_VERSION = '8.9';
+	const BACKUP_MINIMUM_PLUGIN_VERSION = '8.5';
 	const siteHasBackupMinPluginVersion = useSelector( ( state ) =>
 		isJetpackMinimumVersion( state, siteId, BACKUP_MINIMUM_PLUGIN_VERSION )
 	);

--- a/client/my-sites/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout-system-decider.js
@@ -16,6 +16,7 @@ import { isArray } from 'lodash';
 import CheckoutContainer from './checkout/checkout-container';
 import IncludedProductNoticeContent from './checkout/included-product-notice-content';
 import OwnedProductNoticeContent from './checkout/owned-product-notice-content';
+import JetpackMinimumPluginVersionNoticeContent from './checkout/jetpack-minimum-plugin-version-notice-content';
 import CompositeCheckout from './composite-checkout/composite-checkout';
 import { fetchStripeConfiguration } from './composite-checkout/payment-method-helpers';
 import { getPlanByPathSlug } from 'lib/plans';
@@ -26,7 +27,12 @@ import { StripeHookProvider } from 'lib/stripe';
 import config from 'config';
 import { getCurrentUserCountryCode } from 'state/current-user/selectors';
 import getCurrentLocaleSlug from 'state/selectors/get-current-locale-slug';
-import { isJetpackSite, getSiteProducts, getSitePlan } from 'state/sites/selectors';
+import {
+	isJetpackSite,
+	isJetpackMinimumVersion,
+	getSiteProducts,
+	getSitePlan,
+} from 'state/sites/selectors';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import { logToLogstash } from 'state/logstash/actions';
 import {
@@ -81,6 +87,11 @@ export default function CheckoutSystemDecider( {
 			? isBackupProductIncludedInSitePlan( state, siteId, product )
 			: null
 	);
+
+	const BACKUP_MINIMUM_PLUGIN_VERSION = '8.9';
+	const siteHasBackupMinPluginVersion = useSelector( ( state ) =>
+		isJetpackMinimumVersion( state, siteId, BACKUP_MINIMUM_PLUGIN_VERSION )
+	);
 	const currentProducts = useSelector( ( state ) => getSiteProducts( state, siteId ) );
 	const currentPlan = useSelector( ( state ) => getSitePlan( state, siteId ) );
 	const reduxDispatch = useDispatch();
@@ -88,9 +99,17 @@ export default function CheckoutSystemDecider( {
 
 	let infoMessage;
 
-	if ( isJetpackPlanIncludingSiteBackup && selectedSite ) {
-		const backupProduct = isArray( currentProducts ) && currentProducts.find( isJetpackBackup );
+	const backupProduct = isArray( currentProducts ) && currentProducts.find( isJetpackBackup );
+	if ( backupProduct && ! siteHasBackupMinPluginVersion ) {
+		infoMessage = (
+			<JetpackMinimumPluginVersionNoticeContent
+				product={ backupProduct }
+				minVersion={ BACKUP_MINIMUM_PLUGIN_VERSION }
+			/>
+		);
+	}
 
+	if ( isJetpackPlanIncludingSiteBackup && selectedSite ) {
 		infoMessage = backupProduct && (
 			<OwnedProductNoticeContent product={ backupProduct } selectedSite={ selectedSite } />
 		);

--- a/client/my-sites/checkout/checkout/included-product-notice-content.tsx
+++ b/client/my-sites/checkout/checkout/included-product-notice-content.tsx
@@ -45,8 +45,8 @@ const IncludedProductNoticeContent: FunctionComponent< Props > = ( {
 		: '/me/purchases/';
 
 	return (
-		<div className="checkout__duplicate-notice">
-			<p className="checkout__duplicate-notice-message">
+		<div className="checkout__conflict-notice">
+			<p className="checkout__conflict-notice-message">
 				{ translate(
 					'You currently own Jetpack %(plan)s. The product you are about to purchase, {{product/}}, is already included in this plan.',
 					{
@@ -61,7 +61,7 @@ const IncludedProductNoticeContent: FunctionComponent< Props > = ( {
 					}
 				) }
 			</p>
-			<a className="checkout__duplicate-notice-link" href={ subscriptionUrl }>
+			<a className="checkout__conflict-notice-link" href={ subscriptionUrl }>
 				{ translate( 'Manage subscription' ) }
 			</a>
 		</div>

--- a/client/my-sites/checkout/checkout/jetpack-minimum-plugin-version-notice-content.jsx
+++ b/client/my-sites/checkout/checkout/jetpack-minimum-plugin-version-notice-content.jsx
@@ -14,6 +14,39 @@ import getSelectedSiteId from 'state/ui/selectors/get-selected-site-id';
 import getSiteOption from 'state/sites/selectors/get-site-option';
 import getSiteAdminUrl from 'state/sites/selectors/get-site-admin-url';
 
+const getMessage = ( translate, product, siteVersion, minVersion ) => {
+	const displayName = getJetpackProductDisplayName( product );
+
+	if ( ! siteVersion ) {
+		return translate(
+			'{{productName/}} requires version {{strong}}%(minVersion)s{{/strong}} of the Jetpack plugin.',
+			{
+				args: {
+					minVersion: minVersion,
+				},
+				components: {
+					productName: displayName,
+					strong: <strong />,
+				},
+			}
+		);
+	}
+
+	return translate(
+		'{{productName/}} requires version {{strong}}%(minVersion)s{{/strong}} of the Jetpack plugin; your site is using version {{strong}}%(siteVersion)s{{/strong}}.',
+		{
+			args: {
+				minVersion: minVersion,
+				siteVersion: siteVersion,
+			},
+			components: {
+				productName: displayName,
+				strong: <strong />,
+			},
+		}
+	);
+};
+
 const JetpackMinimumPluginVersionNoticeContent = ( { product, minVersion } ) => {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId );
@@ -26,25 +59,11 @@ const JetpackMinimumPluginVersionNoticeContent = ( { product, minVersion } ) => 
 		getSiteAdminUrl( state, siteId, 'update-core.php#update-plugins-table' )
 	);
 
-	const displayName = getJetpackProductDisplayName( product );
+	const message = getMessage( translate, product, siteJetpackVersion, minVersion );
 
 	return (
 		<div className="checkout__conflict-notice">
-			<p className="checkout__conflict-notice-message">
-				{ translate(
-					'{{productName/}} requires Jetpack version {{strong}}%(minVersion)s{{/strong}}; your site is using version {{strong}}%(siteVersion)s{{/strong}}.',
-					{
-						args: {
-							minVersion: minVersion,
-							siteVersion: siteJetpackVersion,
-						},
-						components: {
-							productName: displayName,
-							strong: <strong />,
-						},
-					}
-				) }
-			</p>
+			<p className="checkout__conflict-notice-message">{ message }</p>
 			{ pluginUpgradeUrl && (
 				<a className="checkout__conflict-notice-link" href={ pluginUpgradeUrl }>
 					{ preventWidows( translate( 'Upgrade now' ) ) }

--- a/client/my-sites/checkout/checkout/jetpack-minimum-plugin-version-notice-content.jsx
+++ b/client/my-sites/checkout/checkout/jetpack-minimum-plugin-version-notice-content.jsx
@@ -1,0 +1,57 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { useSelector } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { useTranslate } from 'i18n-calypso';
+import { preventWidows } from 'lib/formatting';
+import { getJetpackProductDisplayName } from 'lib/products-values/get-jetpack-product-display-name';
+import getSelectedSiteId from 'state/ui/selectors/get-selected-site-id';
+import getSiteOption from 'state/sites/selectors/get-site-option';
+import getSiteAdminUrl from 'state/sites/selectors/get-site-admin-url';
+
+const JetpackMinimumPluginVersionNoticeContent = ( { product, minVersion } ) => {
+	const translate = useTranslate();
+	const siteId = useSelector( getSelectedSiteId );
+
+	const siteJetpackVersion = useSelector( ( state ) =>
+		getSiteOption( state, siteId, 'jetpack_version' )
+	);
+
+	const pluginUpgradeUrl = useSelector( ( state ) =>
+		getSiteAdminUrl( state, siteId, 'update-core.php#update-plugins-table' )
+	);
+
+	const displayName = getJetpackProductDisplayName( product );
+
+	return (
+		<div className="checkout__conflict-notice">
+			<p className="checkout__conflict-notice-message">
+				{ translate(
+					'{{productName/}} requires Jetpack version {{strong}}%(minVersion)s{{/strong}}; your site is using version {{strong}}%(siteVersion)s{{/strong}}.',
+					{
+						args: {
+							minVersion: minVersion,
+							siteVersion: siteJetpackVersion,
+						},
+						components: {
+							productName: displayName,
+							strong: <strong />,
+						},
+					}
+				) }
+			</p>
+			{ pluginUpgradeUrl && (
+				<a className="checkout__conflict-notice-link" href={ pluginUpgradeUrl }>
+					{ preventWidows( translate( 'Upgrade now' ) ) }
+				</a>
+			) }
+		</div>
+	);
+};
+
+export default JetpackMinimumPluginVersionNoticeContent;

--- a/client/my-sites/checkout/checkout/owned-product-notice-content.tsx
+++ b/client/my-sites/checkout/checkout/owned-product-notice-content.tsx
@@ -35,8 +35,8 @@ const OwnedProductNoticeContent: FunctionComponent< Props > = ( { product, selec
 		: '/me/purchases/';
 
 	return (
-		<div className="checkout__duplicate-notice">
-			<p className="checkout__duplicate-notice-message">
+		<div className="checkout__conflict-notice">
+			<p className="checkout__conflict-notice-message">
 				{ translate(
 					'You currently own {{product/}}. The plan you are about to purchase also includes this product. Consider removing your {{link}}{{product/}} subscription{{/link}}.',
 					{
@@ -48,7 +48,7 @@ const OwnedProductNoticeContent: FunctionComponent< Props > = ( { product, selec
 					}
 				) }
 			</p>
-			<a className="checkout__duplicate-notice-link" href={ subscriptionUrl }>
+			<a className="checkout__conflict-notice-link" href={ subscriptionUrl }>
 				{ translate( 'Manage subscription' ) }
 			</a>
 		</div>

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -1184,17 +1184,17 @@
 	background-color: var( --color-accent-40 );
 }
 
-.checkout__duplicate-notice {
+.checkout__conflict-notice {
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
 }
 
-.checkout__duplicate-notice-message {
+.checkout__conflict-notice-message {
 	max-width: 600px;
 }
 
-.checkout .notice__text .checkout__duplicate-notice-link {
+.checkout .notice__text .checkout__conflict-notice-link {
 	margin-left: 20px;
 
 	color: var( --color-neutral-10 );

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -654,7 +654,7 @@ const CheckoutNoticeWrapper = styled.div`
 		background-color: var( --color-accent-40 );
 	}
 
-	.notice__text .checkout__duplicate-notice-link {
+	.notice__text .checkout__conflict-notice-link {
 		margin-left: 20px;
 
 		color: var( --color-neutral-10 );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add a new warning/notice to the checkout process to inform people that Jetpack Backup requires a Jetpack plugin version of at least 8.5. Sites with version 8.5 or higher will not see this message.

Fixes `1164141197617539-as-1185663038055927`.

#### Implementation notes

* I've got a follow-up PR planned to make these notices more extendable and move the if-else logic into its own component.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

##### Negative/non-visible case (site has plugin version >= 8.5)

* Create or select a site that has version 8.5+ of the Jetpack plugin, but that does not have Jetpack Backup or a plan that includes it.
* Attempt to purchase Jetpack Backup individually (any term or type) for this site.
* Verify that no minimum-version notice appears during checkout.

##### Positive/visible case 1 (site has plugin version < 8.5)

* Create or select a site that has a version of the Jetpack plugin prior to 8.5, but that does not have Jetpack Backup or a plan that includes it.
* Attempt to purchase Jetpack Backup individually (any term or type) for this site.
* Verify that you see a notice during checkout explaining that <product> requires Jetpack plugin version >= 8.5, but the selected site has <site version>. The notice should also supply a link to the site's admin page to upgrade Jetpack ("Upgrade now"). See the screenshot below for an example of this notice.

##### Positive/visible case 2 (site plugin version is unknown)

* Create or select a site that has the Jetpack plugin installed but not activated, and that does not have Jetpack Backup or a plan that includes it.
* Modify the `jetpack.php` file in the Jetpack plugin, such that the `JETPACK__VERSION` constant is defined as `null`.
* Activate and connect Jetpack.
* Attempt to purchase Jetpack Backup individually (any term or type) for this site.
* Verify that you see a notice during checkout explaining that <product> requires Jetpack plugin version >= 8.5 (the site's Jetpack version should not be mentioned). The notice should also supply a link to the site's admin page to upgrade Jetpack ("Upgrade now"). See the screenshot below for an example of this notice.

##### Regression case (site has plan that includes Backup, and Jetpack plugin <8.5)

* Create or select a site that has a plan that includes Backup (e.g., Jetpack Premium), and that also has a version of the Jetpack plugin prior to 8.5.
* Attempt to purchase Jetpack Backup individually (any term or type) for this site.
* Verify that instead of the minimum-version notice, you see a notice explaining that the site's current plan includes Jetpack Backup.

#### Screenshots

##### Site plugin version is known

<img width="566" alt="Screen Shot 2020-08-12 at 15 19 31" src="https://user-images.githubusercontent.com/670067/90063615-45ffc900-dcaf-11ea-8277-4e412f27d729.png">

##### Site plugin version is not known

<img width="567" alt="Screen Shot 2020-08-12 at 15 36 00" src="https://user-images.githubusercontent.com/670067/90065318-b7d91200-dcb1-11ea-9e1d-d78c0a87f2b9.png">
