### PR TITLE
Coming Soon: Render a coming soon page if the user is logged out

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Coming Soon
+ *
+ * @package A8C\FSE\Coming_soon
+ */
+
+namespace A8C\FSE\Coming_soon;
+
+/**
+ * Determines whether the coming soon page should be shown.
+ *
+ * @return boolean
+ */
+function show_coming_soon_page() {
+	global $post;
+
+	// Handle the case where we are not rendering a post.
+	if ( ! isset( $post ) ) {
+		return false;
+	}
+
+	$should_show = true;
+
+	// TODO: Is this dealing with the case where they're logged in but aren't a member of the site?
+	if ( is_user_logged_in() ) {
+		$should_show = false;
+	}
+
+	return apply_filters( 'a8c_show_coming_soon_page', $should_show );
+}
+
+/**
+ * Decides whether to redirect to the site's coming soon page and performs
+ * the redirect.
+ */
+function coming_soon_page() {
+	global $post;
+
+	if ( ! show_coming_soon_page() ) {
+		return;
+	}
+
+	$id = (int) get_option( 'page_for_coming_soon', 0 );
+
+	if ( empty( $id ) ) {
+		return;
+	}
+
+	if ( $post->ID === $id ) {
+		// We're already viewing the coming soon page, don't redirect.
+		return;
+	}
+
+	$coming_soon_page_url = get_page_link( $id );
+
+	if ( wp_safe_redirect( $coming_soon_page_url ) ) {
+		exit;
+	}
+}
+add_action( 'template_redirect', __NAMESPACE__ . '\coming_soon_page' );

--- a/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
@@ -41,7 +41,7 @@ function coming_soon_page() {
 		return;
 	}
 
-	$id = (int) get_option( 'page_for_coming_soon', 0 );
+	$id = (int) get_option( 'wpcom_coming_soon_page', 0 );
 
 	if ( empty( $id ) ) {
 		return;

--- a/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
@@ -86,8 +86,14 @@ function coming_soon_page() {
 		</head>
 		<body>
 			<?php
+				// Replicates the core `the_content()` function except using the custom
+				// coming soon page instead of the current page.
+				$content = get_the_content( null, false, $custom_coming_soon_page );
+				$content = apply_filters( 'the_content', $content );
+
+				// Perform the same escaping done by the `the_content()` function.
 				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-				echo apply_filters( 'the_content', $custom_coming_soon_page->post_content );
+				echo str_replace( ']]>', ']]&gt;', $content );
 			?>
 			<?php wp_footer(); ?>
 		</body>

--- a/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
@@ -20,7 +20,7 @@ function show_coming_soon_page() {
 		return false;
 	}
 
-	$should_show = ( (int) get_option( 'wpcom_coming_soon' ) === 1 );
+	$should_show = ( (int) get_option( 'wpcom_public_coming_soon' ) === 1 );
 
 	if ( is_user_logged_in() && current_user_can( 'read' ) ) {
 		$should_show = false;
@@ -61,7 +61,7 @@ function coming_soon_page() {
 
 	$should_show_fallback = false;
 
-	$id = (int) get_option( 'wpcom_coming_soon_page_id', 0 );
+	$id = (int) get_option( 'wpcom_public_coming_soon_page_id', 0 );
 	if ( empty( $id ) ) {
 		$should_show_fallback = true;
 	}

--- a/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
@@ -50,8 +50,6 @@ function render_fallback_coming_soon_page() {
  * the redirect.
  */
 function coming_soon_page() {
-	global $post;
-
 	if ( ! show_coming_soon_page() ) {
 		return;
 	}

--- a/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/coming-soon.php
@@ -20,14 +20,29 @@ function show_coming_soon_page() {
 		return false;
 	}
 
-	$should_show = true;
+	$should_show = ( (int) get_option( 'wpcom_coming_soon' ) === 1 );
 
-	// TODO: Is this dealing with the case where they're logged in but aren't a member of the site?
-	if ( is_user_logged_in() ) {
+	if ( is_user_logged_in() && current_user_can( 'read' ) ) {
 		$should_show = false;
 	}
 
 	return apply_filters( 'a8c_show_coming_soon_page', $should_show );
+}
+
+/**
+ * Renders a fallback coming soon page
+ */
+function render_fallback_coming_soon_page() {
+	remove_action( 'wp_enqueue_scripts', 'wpcom_actionbar_enqueue_scripts', 101 );
+	remove_action( 'wp_head', 'print_emoji_detection_script', 7 );
+	remove_action( 'wp_print_styles', 'print_emoji_styles' );
+	remove_action( 'wp_head', 'header_js', 5 );
+	remove_action( 'wp_head', 'global_css', 5 );
+	remove_action( 'wp_footer', 'wpcom_subs_js' );
+	remove_action( 'wp_footer', 'stats_footer', 101 );
+	wp_enqueue_style( 'recoleta-font', '//s1.wp.com/i/fonts/recoleta/css/400.min.css', array(), PLUGIN_VERSION );
+
+	include __DIR__ . '/fallback-coming-soon-page.php';
 }
 
 /**
@@ -41,10 +56,11 @@ function coming_soon_page() {
 		return;
 	}
 
-	$id = (int) get_option( 'wpcom_coming_soon_page', 0 );
+	$id = (int) get_option( 'wpcom_coming_soon_page_id', 0 );
 
 	if ( empty( $id ) ) {
-		return;
+		render_fallback_coming_soon_page();
+		die();
 	}
 
 	if ( $post->ID === $id ) {

--- a/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/fallback-coming-soon-page.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/coming-soon/fallback-coming-soon-page.php
@@ -1,0 +1,208 @@
+<?php
+/**
+ * Coming Soon fallback page.
+ *
+ * This page is used when the site is set to Coming Soon mode, but no
+ * Coming Soon page id has been set.
+ *
+ * @package A8C\FSE\Coming_soon
+ */
+
+namespace A8C\FSE\Coming_soon;
+
+?>
+<!DOCTYPE html>
+<html <?php language_attributes(); ?>>
+	<head>
+		<title><?php echo esc_html( get_bloginfo( 'name' ) ); ?></title>
+		<meta charset="<?php esc_attr( bloginfo( 'charset' ) ); ?>" />
+		<meta name="description" content="<?php echo esc_attr( get_bloginfo( 'description' ) ); ?>" />
+		<meta name="viewport" content="width=device-width" />
+		<?php wp_head(); ?>
+		<style type="text/css">
+			html {
+				/* No admin bar nor marketing bar on this page */
+				margin-top: 0 !important;
+			}
+			.body {
+				background: #117ac9;
+				color: #fff;
+				display: grid;
+				font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif;
+				grid-gap: 24px;
+				-ms-grid-columns: (1fr)[1];
+				grid-template-columns: repeat(1, 1fr);
+				padding-right: 24px;
+				padding-left: 24px;
+			}
+			.inner {
+				align-items: flex-end;
+				display: flex;
+				flex-wrap: wrap;
+				-ms-grid-column: 1;
+				grid-column-start: 1;
+				-ms-grid-column-span: 1;
+				grid-column-end: span 1;
+				height: 100vh;
+				justify-content: space-between;
+			}
+			.main,
+			.marketing {
+				flex: 0 0 100%;
+			}
+			.name {
+				color: #fff;
+				font-size: 19px;
+				line-height: 1.3;
+				margin-bottom: 8px;
+				padding: 0;
+				text-align: left;
+			}
+			.description {
+				color: #fff;
+				font-size: 40px;
+				line-height: 1.15;
+				padding: 0;
+				text-align: left;
+			}
+			.description,
+			.copy {
+				font-family: Georgia, "Times New Roman", Times, serif;
+			}
+			.marketing {
+				padding-bottom: 8px;
+			}
+			.marketing-copy {
+				display: flex;
+				align-items: center;
+			}
+			.logo {
+				height: 32px;
+				margin-right: 16px;
+				width: 32px;
+			}
+			.copy {
+				line-height: 1.4;
+				margin: 0;
+			}
+			.marketing-buttons .button {
+				background: #fff;
+				border-radius: 2px;
+				border: 1px solid #fff;
+				box-sizing: border-box;
+				color: #117ac9;
+				display: block;
+				font-size: 16px;
+				font-weight: 700;
+				line-height: 21px;
+				padding: 13px;
+				text-align: center;
+				text-overflow: ellipsis;
+				text-decoration: none;
+				transition: opacity .15s ease-out;
+				white-space: nowrap;
+				width: 100%;
+			}
+			.marketing-buttons .button-secondary,
+			.marketing-buttons .button-secondary:hover,
+			.marketing-buttons .button-secondary:focus {
+				background: transparent;
+				color: #fff;
+			}
+			.marketing-buttons .button:hover,
+			.marketing-buttons .button:focus {
+				opacity: .85;
+			}
+			@media screen and ( min-width: 660px ) {
+				.description,
+				.copy {
+					font-family: Recoleta, Georgia, "Times New Roman", Times, serif;
+				}
+				.name {
+					font-size: 23px;
+				}
+				.description {
+					font-size: 69px;
+				}
+				.marketing {
+					align-items: center;
+					display: flex;
+					justify-content: space-between;
+					padding-bottom: 24px;
+				}
+				.marketing-copy {
+					margin-right: 16px;
+				}
+				.marketing-buttons {
+					display: flex;
+				}
+				.marketing-buttons p {
+					margin: 0;
+				}
+				.marketing-buttons p:nth-child(2) {
+					margin-left: 8px;
+				}
+				.marketing-buttons .button {
+					font-size: 13px;
+					padding: 7px 13px;
+					min-width: 145px;
+				}
+			}
+			@media screen and ( min-width: 661px ) {
+				p, ul, ol {
+					font-size: 16px;
+					letter-spacing: 0;
+				}
+			}
+			@media screen and ( min-width: 960px ) {
+				.name {
+					font-size: 28px;
+					margin-bottom: 16px;
+				}
+				.description {
+					font-size: 99px;
+				}
+				.copy {
+					font-size: 19px;
+				}
+			}
+			@media screen and ( min-width: 1040px ) {
+				.body {
+					-ms-grid-columns: (1fr)[12];
+					grid-template-columns: repeat(12, 1fr);
+				}
+				.inner {
+					-ms-grid-column: 2;
+					grid-column-start: 2;
+					-ms-grid-column-span: 10;
+					grid-column-end: span 10;
+				}
+				.marketing {
+					padding-bottom: 32px;
+				}
+			}
+		</style>
+	</head>
+	<body class="body">
+		<div class="inner">
+			<div class="main">
+				<div class="name"><?php echo esc_html( get_bloginfo( 'name' ) ); ?></div>
+				<div class="description"><?php esc_html_e( 'Coming Soon', 'full-site-editing' ); ?></div>
+				<p>(v2 — remove this line when finished testing)</p>
+			</div>
+			<div class="marketing">
+				<?php if ( ! is_user_logged_in() ) : ?>
+					<div class="marketing-copy">
+						<img src="/wp-content/themes/a8c/domain-landing-page/wpcom-wmark-white.svg" alt="WordPress.com" class="logo" />
+						<p class="copy"><?php echo esc_html( fix_widows( __( 'Build a website. Sell your stuff. Write a blog. And so much more.', 'full-site-editing' ), array( 'mobile_enable' => true ) ) ); ?></p>
+					</div>
+					<div class="marketing-buttons">
+						<p><a class="button button-secondary" href="<?php echo esc_url( $login_url ); ?>"><?php esc_html_e( 'Log in', 'full-site-editing' ); ?></a></p>
+						<p><a class="button button-primary " href="<?php echo esc_url( localized_wpcom_url( 'https://wordpress.com/?ref=coming_soon' ) ); ?>"><?php esc_html_e( 'Start your website', 'full-site-editing' ); ?></a></p>
+					</div>
+				<?php endif; ?>
+			</div>
+		</div>
+		<?php wp_footer(); ?>
+	</body>
+</html>

--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -315,3 +315,11 @@ function load_wpcom_block_editor_sidebar() {
 	}
 }
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_wpcom_block_editor_sidebar' );
+
+/**
+ * Coming soon
+ */
+function load_coming_soon() {
+	require_once __DIR__ . '/coming-soon/coming-soon.php';
+}
+add_action( 'plugins_loaded', __NAMESPACE__ . '\load_coming_soon' );

--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -320,6 +320,8 @@ add_action( 'plugins_loaded', __NAMESPACE__ . '\load_wpcom_block_editor_sidebar'
  * Coming soon
  */
 function load_coming_soon() {
-	require_once __DIR__ . '/coming-soon/coming-soon.php';
+	if ( defined( 'WPCOM_PUBLIC_COMING_SOON' ) && WPCOM_PUBLIC_COMING_SOON ) {
+		require_once __DIR__ . '/coming-soon/coming-soon.php';
+	}
 }
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_coming_soon' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Gate feature behind a `WPCOM_PUBLIC_COMING_SOON` config flag
* Render coming soon page if `wpcom_public_coming_soon` is `1` and user isn't a logged in site user
* Render `wpcom_public_coming_soon_page_id` if it exists
* Render a fallback coming soon page if `wpcom_public_coming_soon_page_id` doesn't exist

Based off @simison's prototype #43831

What it doesn't do:
* check if the page is published
* check if it's a post vs. a page, maybe this doesn't matter?

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch and `cd apps/editing-toolkit && yarn dev`
* Add `"WPCOM_PUBLIC_COMING_SOON": "1"` to your `.wp-env.override.json`
* `npx wp-env start`
* Visit `http://localhost:4013/wp-admin` and create a coming soon page in the block editor
* `npx wp-env run cli wp option add wpcom_public_coming_soon 1`
* Visit `http://localhost:4013` in an incognito window, it should always show a generic coming soon page
* `npx wp-env run cli wp option add wpcom_public_coming_soon_page_id {{ YOUR PAGE ID }}`
* Visit `http://localhost:4013` in an incognito window, it should render a page that's generally like the page you created (it doesn't show some menus or footers, but it should look generally correct)
