### PR TITLE
Remove showCompositeCheckoutI18N abtest

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -205,16 +205,6 @@ export default {
 		defaultVariation: 'control',
 		allowExistingUsers: true,
 	},
-	showCompositeCheckoutI18N: {
-		datestamp: '20200710',
-		variations: {
-			composite: 90,
-			regular: 10,
-		},
-		defaultVariation: 'regular',
-		allowExistingUsers: true,
-		localeTargets: 'any',
-	},
 	offerResetFlow: {
 		datestamp: '20200804',
 		variations: {

--- a/client/my-sites/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout-system-decider.js
@@ -132,8 +132,7 @@ export default function CheckoutSystemDecider( {
 		product,
 		purchaseId,
 		isJetpack,
-		isAtomic,
-		isLoggedOutCart
+		isAtomic
 	);
 
 	useEffect( () => {
@@ -258,8 +257,7 @@ function getCheckoutVariant(
 	productSlug,
 	purchaseId,
 	isJetpack,
-	isAtomic,
-	isLoggedOutCart
+	isAtomic
 ) {
 	if ( config.isEnabled( 'old-checkout-force' ) ) {
 		debug( 'shouldShowCompositeCheckout false because old-checkout-force flag is set' );
@@ -339,23 +337,6 @@ function getCheckoutVariant(
 			productSlug
 		);
 		return 'disallowed-product';
-	}
-
-	// Removes users from initial AB test
-	if (
-		cart.currency === 'USD' &&
-		countryCode?.toLowerCase() === 'us' &&
-		locale?.toLowerCase().startsWith( 'en' )
-	) {
-		debug( 'shouldShowCompositeCheckout true' );
-		return 'composite-checkout';
-	}
-
-	// Show composite checkout for registrationless checkout users
-	const urlParams = new URLSearchParams( window.location.search );
-	if ( isLoggedOutCart || 'no-user' === urlParams.get( 'cart' ) ) {
-		debug( 'shouldShowCompositeCheckout true' );
-		return 'composite-checkout';
 	}
 
 	debug( 'shouldShowCompositeCheckout true' );

--- a/client/my-sites/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout-system-decider.js
@@ -39,7 +39,6 @@ import {
 	isPlanIncludingSiteBackup,
 	isBackupProductIncludedInSitePlan,
 } from 'state/sites/products/conflicts';
-import { abtest } from 'lib/abtest';
 import Recaptcha from 'signup/recaptcha';
 
 const debug = debugFactory( 'calypso:checkout-system-decider' );
@@ -357,12 +356,6 @@ function getCheckoutVariant(
 	if ( isLoggedOutCart || 'no-user' === urlParams.get( 'cart' ) ) {
 		debug( 'shouldShowCompositeCheckout true' );
 		return 'composite-checkout';
-	}
-
-	// Add remaining users to new AB test with 10% holdout
-	if ( abtest( 'showCompositeCheckoutI18N' ) !== 'composite' ) {
-		debug( 'shouldShowCompositeCheckout false because user is in abtest control variant' );
-		return 'control-variant';
 	}
 
 	debug( 'shouldShowCompositeCheckout true' );

--- a/test/e2e/lib/components/secure-payment-component.js
+++ b/test/e2e/lib/components/secure-payment-component.js
@@ -128,7 +128,7 @@ export default class SecurePaymentComponent extends AsyncBaseContainer {
 		// (ignoring G Suite for the moment), so we do not need to fill them out in
 		// this step, we just need to fill out the tax fields in the contact
 		// section. If they need to be filled out for either checkout, see
-		// CheckOutPage.enterRegistarDetails.
+		// CheckOutPage.enterRegistrarDetails.
 		const isCompositeCheckout = await this.isCompositeCheckout();
 		if ( ! isCompositeCheckout ) {
 			return;

--- a/test/e2e/lib/pages/domain-map-checkout-page.js
+++ b/test/e2e/lib/pages/domain-map-checkout-page.js
@@ -10,6 +10,6 @@ import AsyncBaseContainer from '../async-base-container';
 
 export default class MapADomainCheckoutPage extends AsyncBaseContainer {
 	constructor( driver ) {
-		super( driver, By.css( '.checkout__payment-box-container' ) );
+		super( driver, By.css( '.checkout__payment-box-container,.composite-checkout' ) );
 	}
 }

--- a/test/e2e/lib/pages/signup/checkout-page.js
+++ b/test/e2e/lib/pages/signup/checkout-page.js
@@ -32,6 +32,26 @@ export default class CheckOutPage extends AsyncBaseContainer {
 		stateCode,
 		postalCode,
 	} ) {
+		const isCompositeCheckout = await this.isCompositeCheckout();
+		if ( isCompositeCheckout ) {
+			await driverHelper.waitTillPresentAndDisplayed(
+				this.driver,
+				By.css( '.checkout-line-item' )
+			);
+			const contactDetailsEditButtons = await this.driver.findElements(
+				By.css( 'button[aria-label="Edit the contact details"]' )
+			);
+			if ( contactDetailsEditButtons.length === 1 ) {
+				// If the contact details are already pre-filled and valid, the contact
+				// details step will be skipped in composite checkout. Therefore we'll
+				// need to click to edit that step before being able to modify it.
+				await driverHelper.clickWhenClickable(
+					this.driver,
+					By.css( 'button[aria-label="Edit the contact details"]' )
+				);
+			}
+		}
+
 		await driverHelper.setWhenSettable( this.driver, By.id( 'first-name' ), firstName );
 		await driverHelper.setWhenSettable( this.driver, By.id( 'last-name' ), lastName );
 		await driverHelper.setWhenSettable( this.driver, By.id( 'email' ), emailAddress );

--- a/test/e2e/lib/pages/signup/checkout-page.js
+++ b/test/e2e/lib/pages/signup/checkout-page.js
@@ -21,7 +21,7 @@ export default class CheckOutPage extends AsyncBaseContainer {
 		);
 	}
 
-	async enterRegistarDetails( {
+	async enterRegistrarDetails( {
 		firstName,
 		lastName,
 		emailAddress,

--- a/test/e2e/specs/wp-manage-domains-spec.js
+++ b/test/e2e/specs/wp-manage-domains-spec.js
@@ -100,7 +100,7 @@ describe( `[${ host }] Managing Domains: (${ screenSize })`, function () {
 
 		step( 'Can see checkout page and enter registrar details', async function () {
 			const checkOutPage = await CheckOutPage.Expect( driver );
-			await checkOutPage.enterRegistarDetails( testDomainRegistarDetails );
+			await checkOutPage.enterRegistrarDetails( testDomainRegistarDetails );
 			return await checkOutPage.submitForm();
 		} );
 

--- a/test/e2e/specs/wp-signup-spec.js
+++ b/test/e2e/specs/wp-signup-spec.js
@@ -801,7 +801,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 					return this.skip();
 				}
 			}
-			await checkOutPage.enterRegistarDetails( testDomainRegistarDetails );
+			await checkOutPage.enterRegistrarDetails( testDomainRegistarDetails );
 			return await checkOutPage.submitForm();
 		} );
 
@@ -986,7 +986,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 
 		step( 'Can see checkout page and enter registrar details', async function () {
 			const checkOutPage = await CheckOutPage.Expect( driver );
-			await checkOutPage.enterRegistarDetails( testDomainRegistarDetails );
+			await checkOutPage.enterRegistrarDetails( testDomainRegistarDetails );
 			return await checkOutPage.submitForm();
 		} );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This removes the `showCompositeCheckoutI18N` abtest which was still segmenting a few i18n users to our old checkout flow. That test is long since complete so we can disable this now.

Fixes https://github.com/Automattic/wp-calypso/issues/44868

#### Testing instructions

Visit checkout with a non-USD and/or non-EN account and be sure that you see new checkout.