### PR TITLE
Fix renewal of no-ads product in composite checkout

### DIFF
--- a/client/my-sites/checkout/composite-checkout/use-prepare-product-for-cart.js
+++ b/client/my-sites/checkout/composite-checkout/use-prepare-product-for-cart.js
@@ -76,7 +76,13 @@ function useAddRenewalItems( { originalPurchaseId, productAlias, setState } ) {
 				if ( ! productSlug ) {
 					return null;
 				}
-				const [ slug ] = productSlug.split( ':' );
+				let [ slug ] = productSlug.split( ':' );
+
+				// See https://github.com/Automattic/wp-calypso/pull/15043 for explanation of
+				// the no-ads alias (seems a little strange to me that the product slug is a
+				// php file).
+				slug = slug === 'no-ads' ? 'no-adverts/no-adverts.php' : slug;
+
 				const product = products[ slug ];
 				if ( ! product ) {
 					debug( 'no product found with slug', productSlug );

--- a/client/my-sites/checkout/composite-checkout/use-prepare-product-for-cart.js
+++ b/client/my-sites/checkout/composite-checkout/use-prepare-product-for-cart.js
@@ -208,6 +208,7 @@ function useAddProductFromSlug( {
 		);
 		setState( { productsForCart: [ cartProduct ], canInitializeCart: true } );
 	}, [
+		isPrivate,
 		plans,
 		products,
 		originalPurchaseId,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The "No ads" product is old and it has an unusual product slug, `no-adverts/no-adverts.php` which is very difficult to put inside a URL since it contains URL-like elements. As a result, there is code in calypso to use the alias `no-ads` when serializing that product for renewals. In new checkout, I missed a place where that alias should have been used. This PR fixes that oversight.

Fixes https://github.com/Automattic/wp-calypso/issues/44890

#### Testing instructions

- Add the "No ads" product to a site.
- Visit http://calypso.localhost:3000/me/purchases
- Click on the "No ads" product in the list.
- Click "Renew now".
- Verify that you are taken to the checkout page with the "No ads" product in your cart.
