### PR TITLE
Reset: Ensure both old and new plan picker can appear

### DIFF
--- a/client/my-sites/plans-v2/index.ts
+++ b/client/my-sites/plans-v2/index.ts
@@ -6,17 +6,15 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import { makeLayout, render as clientRender } from 'controller';
-import { siteSelection } from 'my-sites/controller';
+import { makeLayout, render as clientRender } from 'controller/index.web';
 import { productSelect, productDetails, productUpsell } from './controller';
 
 const trackedPage = ( url: string, ...rest: PageJS.Callback[] ) => {
-	page( url, siteSelection, ...rest, makeLayout, clientRender );
+	page( url, ...rest, makeLayout, clientRender );
 };
 
 export default function ( rootUrl: string, ...rest: PageJS.Callback[] ) {
-	trackedPage( `${ rootUrl }/:duration?`, productSelect( rootUrl ), ...rest );
-	trackedPage( `${ rootUrl }/:product/details`, productDetails( rootUrl ), ...rest );
-	trackedPage( `${ rootUrl }/:product/:duration/details`, productDetails( rootUrl ), ...rest );
-	trackedPage( `${ rootUrl }/:product/:duration/additions`, productUpsell( rootUrl ), ...rest );
+	trackedPage( `${ rootUrl }/:duration?`, ...rest, productSelect( rootUrl ) );
+	trackedPage( `${ rootUrl }/:product/:duration/details`, ...rest, productDetails( rootUrl ) );
+	trackedPage( `${ rootUrl }/:product/:duration/additions`, ...rest, productUpsell( rootUrl ) );
 }

--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -10,8 +10,26 @@ import { get } from 'lodash';
  */
 import Plans from './plans';
 import { isValidFeatureKey } from 'lib/plans/features-list';
+import { shouldShowOfferResetFlow } from 'lib/abtest/getters';
+import isSiteWpcom from 'state/selectors/is-site-wpcom';
+import getSelectedSiteId from 'state/ui/selectors/get-selected-site-id';
+import { productSelect } from 'my-sites/plans-v2/controller';
+
+function showJetpackPlans( context ) {
+	const getState = context.store.getState();
+	const siteId = getSelectedSiteId( getState );
+	const isWpcom = isSiteWpcom( getState, siteId );
+	return shouldShowOfferResetFlow() && ! isWpcom;
+}
 
 export function plans( context, next ) {
+	if ( showJetpackPlans( context ) ) {
+		if ( context.params.intervalType ) {
+			return page.redirect( `/plans/${ context.params.site }` );
+		}
+		return productSelect( '/plans/:site' )( context, next );
+	}
+
 	context.primary = (
 		<Plans
 			context={ context }
@@ -53,4 +71,10 @@ export function redirectToPlans( context ) {
 	}
 
 	return page.redirect( '/plans' );
+}
+
+export function redirectToPlansIfNotJetpack( context ) {
+	if ( ! showJetpackPlans( context ) ) {
+		page.redirect( `/plans/${ context.params.site }` );
+	}
 }

--- a/client/my-sites/plans/index.js
+++ b/client/my-sites/plans/index.js
@@ -6,7 +6,13 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import { features, plans, redirectToCheckout, redirectToPlans } from './controller';
+import {
+	features,
+	plans,
+	redirectToCheckout,
+	redirectToPlans,
+	redirectToPlansIfNotJetpack,
+} from './controller';
 import { currentPlan } from './current-plan/controller';
 import { makeLayout, render as clientRender } from 'controller';
 import { navigation, siteSelection, sites } from 'my-sites/controller';
@@ -19,12 +25,6 @@ const trackedPage = ( url, ...rest ) => {
 
 export default function () {
 	trackedPage( '/plans', siteSelection, sites );
-
-	// Load offer reset plans picker.
-	if ( shouldShowOfferResetFlow() ) {
-		plansV2( '/plans/:site', navigation );
-		return;
-	}
 	trackedPage( '/plans/compare', siteSelection, navigation, redirectToPlans );
 	trackedPage( '/plans/compare/:domain', siteSelection, navigation, redirectToPlans );
 	trackedPage( '/plans/features', siteSelection, navigation, redirectToPlans );
@@ -36,4 +36,7 @@ export default function () {
 
 	// This route renders the plans page for both WPcom and Jetpack sites.
 	trackedPage( '/plans/:intervalType?/:site', siteSelection, navigation, plans );
+	if ( shouldShowOfferResetFlow() ) {
+		plansV2( '/plans/:site', siteSelection, redirectToPlansIfNotJetpack, navigation );
+	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This alters controllers and routes to ensure that Jetpack sites get shown the Reset plans, and Simple and Atomic sites get shown the old versions.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load this PR and set A/B tests to show the offer reset.
* Navigate to a Simple site's plans page.
* Verify that plans page matches production.
* Repeat above two steps for Atomic sites.
* Navigate to a Jetpack site's plans page.
* Verify it matches the offer reset design.

Other paths to test:
* `/plans/yearly/:site` - Should work fine for non-JP sites, redirect to `/plans/:site` for JP sites.
* `/plans/:site/annual` - Should redirect to `/plans/:site` for non-JP sites.
* `/plans/:site/jetpack_backup/annual/details` - Should redirect to `/plans/:site` for non-JP sites.
* `/plans/:site/jetpack_backup_daily/annual/additions` - Should redirect to `/plans/:site` for non-JP sites.

Fixes 1169247016322522-as-1188300633711233.