### PR TITLE
In useSite add optional chaining to site?.plan as sometimes the plan key will not be available

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/hooks/use-site.ts
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/hooks/use-site.ts
@@ -21,7 +21,7 @@ export function useSite() {
 	);
 
 	return {
-		isFreePlan: site?.plan.is_free,
+		isFreePlan: site?.plan?.is_free,
 		launchStatus,
 		currentDomainName: site?.URL && new URL( site?.URL ).hostname,
 	};

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -62,7 +62,7 @@ export interface SiteDetails {
 	options: {
 		created_at: string;
 	};
-	plan: {
+	plan?: {
 		is_free: boolean;
 	};
 }


### PR DESCRIPTION
This resolves an issue reported in p1597266153146700-slack-CRNF6A9DX CC: @ianstewart 

As a super admin, if you attempt to open the page editor for a site that you aren't a member of, it would cause a fatal error because the `plan` key isn't available on the `site` object, when checking for `is_free`.

## Screenshot of the issue

![image](https://user-images.githubusercontent.com/14988353/90083901-22905900-dd57-11ea-8acc-2c235d0d0200.png)

#### Changes proposed in this Pull Request

* Check for the existence of the `plan` key on the site object before looking for the `is_free` sub-key (add optional chaining here)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Verify that you can recreate the issue by (as a super admin) going to a site that you're not a member of, but still have access to e.g. casselstarter
* Open up the home page in the page editor
* Once the page has loaded, after a second or two, it'll throw a fatal error as in the screenshot above
* Apply the diff associated with this PR (D48052-code), and sandbox that site, e.g. casselstarter
* Go to open the home page in the editor via `/wp-admin` again and the fatal should no longer be thrown. There will still be other warnings in the console about unauthorized requests, but the editor should no longer throw the fatal error.

Check that this doesn't introduce a regression:

* Create a new site via Gutenboarding (`/new`)
* Once the site is created and you're landed in the editor, sandbox the freshly created site and reload the page
* Go to launch the site and ensure the new launch flow still works correctly (domain selection, etc)

Fixes #