### PR TITLE
Bump WordPress.com Editing Toolkit plugin to v1.19

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WordPress.com Editing Toolkit
  * Description: Enhances your page creation workflow within the Block Editor.
- * Version: 1.18
+ * Version: 1.19
  * Author: Automattic
  * Author URI: https://automattic.com/wordpress-plugins/
  * License: GPLv2 or later
@@ -35,7 +35,7 @@ namespace A8C\FSE;
  *
  * @var string
  */
-define( 'PLUGIN_VERSION', '1.18' );
+define( 'PLUGIN_VERSION', '1.19' );
 
 // Always include these helper files for dotcom FSE.
 require_once __DIR__ . '/dotcom-fse/helpers.php';

--- a/apps/full-site-editing/full-site-editing-plugin/readme.txt
+++ b/apps/full-site-editing/full-site-editing-plugin/readme.txt
@@ -3,7 +3,7 @@ Contributors: alexislloyd, allancole, automattic, bartkalisz, codebykat, copons,
 Tags: block, blocks, editor, gutenberg, page
 Requires at least: 5.0
 Tested up to: 5.4
-Stable tag: 1.18
+Stable tag: 1.19
 Requires PHP: 5.6.20
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -39,6 +39,9 @@ This plugin is experimental, so we don't provide any support for it outside of w
 
 
 == Changelog ==
+
+= 1.19 =
+* Fix error in editor when accessing page as a non-user super admin.
 
 = 1.18 =
 * Fix broken link on mobile when selecting launch flow.

--- a/apps/full-site-editing/package.json
+++ b/apps/full-site-editing/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/full-site-editing",
-	"version": "1.18.0",
+	"version": "1.19.0",
 	"description": "Plugin for editing-related features.",
 	"sideEffects": true,
 	"repository": {


### PR DESCRIPTION
This release includes only a single change (#44895)

In `editor-site-launch` add optional chaining for accessing the `plan` key on the `site` object as in some contexts the `plan` key will not be available (e.g. a super admin user accessing the editor on a site they are not a user of). Also update the type for that key to flag that it is potentially undefined.

#### Changes proposed in this Pull Request

* Bump editing toolkit plugin version, which includes: https://github.com/Automattic/wp-calypso/pull/44895

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox the diff associated with this PR (D48053-code) and double-check that the testing steps in https://github.com/Automattic/wp-calypso/pull/44895/
* If you're approving this PR, please also approve the corresponding diff 🙇‍♂️

Fixes #
