### PR TITLE
Only call unregister on the columns category if currently registered

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/class-block-patterns.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/class-block-patterns.php
@@ -56,7 +56,9 @@ class Block_Patterns {
 
 			// The 'Two Columns of Text' pattern is in the 'columns' and 'text' categories.
 			// Removing 'columns' so it doesn't appear as a category with only a single item.
-			unregister_block_pattern_category( 'columns' );
+			if ( \WP_Block_Pattern_Categories_Registry::get_instance()->is_registered( 'columns' ) ) {
+				unregister_block_pattern_category( 'columns' );
+			}
 		}
 
 		if ( class_exists( 'WP_Block_Patterns_Registry' ) ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Check the columns category is currently registered before calling unregister

```
PHP Notice:  WP_Block_Pattern_Categories_Registry::unregister was called <strong>incorrectly</strong>...
...Notice: WP_Block_Pattern_Categories_Registry::unregister was called <strong>incorrectly</strong>. Block pattern category "columns" not found...
```

#### Testing instructions

For context, before applying the diff:
* Open the block editor on a simple site
* Take a look at the block patterns (click the (+) inserter button and switch to the patterns tab)
* Scroll down the list of patterns and see the COLUMNS heading, the purpose of the line that's causing this warning was to remove that category but it's stopped working for some reason.

Testing the warning has been fixed:
* Check out code and `npx wp-env start`
* Go to `localhost:4013/wp-admin` and verify there's no warning rendered at the top of the page

Testing nothing has broken on wpcom:
* Apply D48066-code and sandbox a test site (build code locally and sync to sandbox)
* Open the block patterns list in the block editor and see it still works, the COLUMNS category will still be there
* Follow PCYsg-ly5-p2#atomic-testing to test changes on an atomic site
* Test the patterns list to make sure nothing's broken
* Ensure you try it both with the GB plugin activated and deactivated

Fixes #44851
