### PR TITLE
Move all Jest caches to `./cache/jest`

### DIFF
--- a/packages/babel-plugin-transform-wpcalypso-async/jest.config.js
+++ b/packages/babel-plugin-transform-wpcalypso-async/jest.config.js
@@ -1,1 +1,5 @@
-module.exports = { preset: '@automattic/calypso-build', rootDir: __dirname };
+module.exports = {
+	preset: '@automattic/calypso-build',
+	rootDir: __dirname,
+	cacheDirectory: '<rootDir>/../../.cache/jest',
+};

--- a/packages/calypso-analytics/jest.config.js
+++ b/packages/calypso-analytics/jest.config.js
@@ -1,1 +1,5 @@
-module.exports = { preset: '@automattic/calypso-build', rootDir: __dirname };
+module.exports = {
+	preset: '@automattic/calypso-build',
+	rootDir: __dirname,
+	cacheDirectory: '<rootDir>/../../.cache/jest',
+};

--- a/packages/calypso-codemods/jest.config.js
+++ b/packages/calypso-codemods/jest.config.js
@@ -3,4 +3,5 @@ module.exports = {
 	rootDir: __dirname,
 	testMatch: [ '<rootDir>/tests/*/codemod.spec.js' ],
 	setupFiles: [ '<rootDir>/setup-tests.js' ],
+	cacheDirectory: '<rootDir>/../../.cache/jest',
 };

--- a/packages/components/jest.config.js
+++ b/packages/components/jest.config.js
@@ -1,1 +1,5 @@
-module.exports = { preset: '@automattic/calypso-build', rootDir: __dirname };
+module.exports = {
+	preset: '@automattic/calypso-build',
+	rootDir: __dirname,
+	cacheDirectory: '<rootDir>/../../.cache/jest',
+};

--- a/packages/composite-checkout/jest.config.js
+++ b/packages/composite-checkout/jest.config.js
@@ -3,4 +3,5 @@ module.exports = {
 	rootDir: __dirname,
 	testEnvironment: 'jsdom',
 	globals: { window: { navigator: { userAgent: 'jest' } } },
+	cacheDirectory: '<rootDir>/../../.cache/jest',
 };

--- a/packages/data-stores/jest.config.js
+++ b/packages/data-stores/jest.config.js
@@ -2,4 +2,5 @@ module.exports = {
 	preset: '@automattic/calypso-build',
 	rootDir: __dirname,
 	setupFiles: [ 'regenerator-runtime/runtime' ],
+	cacheDirectory: '<rootDir>/../../.cache/jest',
 };

--- a/packages/effective-module-tree/jest.config.js
+++ b/packages/effective-module-tree/jest.config.js
@@ -3,4 +3,5 @@ module.exports = {
 	rootDir: __dirname,
 	// Node project, no need to transform anything
 	transformIgnorePatterns: [ '<rootDir>/', '/node_modules/' ],
+	cacheDirectory: '<rootDir>/../../.cache/jest',
 };

--- a/packages/eslint-config-wpcalypso/jest.config.js
+++ b/packages/eslint-config-wpcalypso/jest.config.js
@@ -1,1 +1,5 @@
-module.exports = { preset: '@automattic/calypso-build', rootDir: __dirname };
+module.exports = {
+	preset: '@automattic/calypso-build',
+	rootDir: __dirname,
+	cacheDirectory: '<rootDir>/../../.cache/jest',
+};

--- a/packages/eslint-plugin-wpcalypso/jest.config.js
+++ b/packages/eslint-plugin-wpcalypso/jest.config.js
@@ -1,1 +1,5 @@
-module.exports = { preset: '@automattic/calypso-build', rootDir: __dirname };
+module.exports = {
+	preset: '@automattic/calypso-build',
+	rootDir: __dirname,
+	cacheDirectory: '<rootDir>/../../.cache/jest',
+};

--- a/packages/format-currency/jest.config.js
+++ b/packages/format-currency/jest.config.js
@@ -1,1 +1,5 @@
-module.exports = { preset: '@automattic/calypso-build', rootDir: __dirname };
+module.exports = {
+	preset: '@automattic/calypso-build',
+	rootDir: __dirname,
+	cacheDirectory: '<rootDir>/../../.cache/jest',
+};

--- a/packages/i18n-calypso-cli/jest.config.js
+++ b/packages/i18n-calypso-cli/jest.config.js
@@ -1,1 +1,5 @@
-module.exports = { preset: '@automattic/calypso-build', rootDir: __dirname };
+module.exports = {
+	preset: '@automattic/calypso-build',
+	rootDir: __dirname,
+	cacheDirectory: '<rootDir>/../../.cache/jest',
+};

--- a/packages/i18n-calypso/jest.config.js
+++ b/packages/i18n-calypso/jest.config.js
@@ -1,1 +1,5 @@
-module.exports = { preset: '@automattic/calypso-build', rootDir: __dirname };
+module.exports = {
+	preset: '@automattic/calypso-build',
+	rootDir: __dirname,
+	cacheDirectory: '<rootDir>/../../.cache/jest',
+};

--- a/packages/load-script/jest.config.js
+++ b/packages/load-script/jest.config.js
@@ -1,1 +1,5 @@
-module.exports = { preset: '@automattic/calypso-build', rootDir: __dirname };
+module.exports = {
+	preset: '@automattic/calypso-build',
+	rootDir: __dirname,
+	cacheDirectory: '<rootDir>/../../.cache/jest',
+};

--- a/packages/media-library/jest.config.js
+++ b/packages/media-library/jest.config.js
@@ -1,1 +1,5 @@
-module.exports = { preset: '@automattic/calypso-build', rootDir: __dirname };
+module.exports = {
+	preset: '@automattic/calypso-build',
+	rootDir: __dirname,
+	cacheDirectory: '<rootDir>/../../.cache/jest',
+};

--- a/packages/photon/jest.config.js
+++ b/packages/photon/jest.config.js
@@ -1,1 +1,5 @@
-module.exports = { preset: '@automattic/calypso-build', rootDir: __dirname };
+module.exports = {
+	preset: '@automattic/calypso-build',
+	rootDir: __dirname,
+	cacheDirectory: '<rootDir>/../../.cache/jest',
+};

--- a/packages/request-external-access/jest.config.js
+++ b/packages/request-external-access/jest.config.js
@@ -1,1 +1,5 @@
-module.exports = { preset: '@automattic/calypso-build', rootDir: __dirname };
+module.exports = {
+	preset: '@automattic/calypso-build',
+	rootDir: __dirname,
+	cacheDirectory: '<rootDir>/../../.cache/jest',
+};

--- a/packages/social-previews/jest.config.js
+++ b/packages/social-previews/jest.config.js
@@ -1,1 +1,5 @@
-module.exports = { preset: '@automattic/calypso-build', rootDir: __dirname };
+module.exports = {
+	preset: '@automattic/calypso-build',
+	rootDir: __dirname,
+	cacheDirectory: '<rootDir>/../../.cache/jest',
+};

--- a/packages/tree-select/jest.config.js
+++ b/packages/tree-select/jest.config.js
@@ -1,1 +1,5 @@
-module.exports = { preset: '@automattic/calypso-build', rootDir: __dirname };
+module.exports = {
+	preset: '@automattic/calypso-build',
+	rootDir: __dirname,
+	cacheDirectory: '<rootDir>/../../.cache/jest',
+};

--- a/packages/viewport-react/jest.config.js
+++ b/packages/viewport-react/jest.config.js
@@ -1,1 +1,5 @@
-module.exports = { preset: '@automattic/calypso-build', rootDir: __dirname };
+module.exports = {
+	preset: '@automattic/calypso-build',
+	rootDir: __dirname,
+	cacheDirectory: '<rootDir>/../../.cache/jest',
+};

--- a/packages/viewport/jest.config.js
+++ b/packages/viewport/jest.config.js
@@ -1,1 +1,5 @@
-module.exports = { preset: '@automattic/calypso-build', rootDir: __dirname };
+module.exports = {
+	preset: '@automattic/calypso-build',
+	rootDir: __dirname,
+	cacheDirectory: '<rootDir>/../../.cache/jest',
+};

--- a/packages/webpack-config-flag-plugin/jest.config.js
+++ b/packages/webpack-config-flag-plugin/jest.config.js
@@ -1,1 +1,5 @@
-module.exports = { preset: '@automattic/calypso-build', rootDir: __dirname };
+module.exports = {
+	preset: '@automattic/calypso-build',
+	rootDir: __dirname,
+	cacheDirectory: '<rootDir>/../../.cache/jest',
+};

--- a/packages/webpack-inline-constant-exports-plugin/jest.config.js
+++ b/packages/webpack-inline-constant-exports-plugin/jest.config.js
@@ -1,1 +1,5 @@
-module.exports = { preset: '@automattic/calypso-build', rootDir: __dirname };
+module.exports = {
+	preset: '@automattic/calypso-build',
+	rootDir: __dirname,
+	cacheDirectory: '<rootDir>/../../.cache/jest',
+};

--- a/packages/wp-babel-makepot/jest.config.js
+++ b/packages/wp-babel-makepot/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
 	rootDir: __dirname,
 	testMatch: [ '<rootDir>/**/test/*.[jt]s?(x)', '!**/.eslintrc.*', '!**/examples/**' ],
+	cacheDirectory: '<rootDir>/../../.cache/jest',
 };

--- a/test/client/jest.config.js
+++ b/test/client/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+	cacheDirectory: '<rootDir>/../.cache/jest',
 	moduleNameMapper: {
 		'^config$': '<rootDir>/server/config/index.js',
 		'^wp-calypso-client/config$': '<rootDir>/server/config/index.js',

--- a/test/packages/jest.config.js
+++ b/test/packages/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+	cacheDirectory: '<rootDir>/.cache/jest',
 	rootDir: './../../',
 	// run tests for all packages that have a Jest config file
 	projects: [ '<rootDir>/packages/*/jest.config.js' ],

--- a/test/server/jest.config.js
+++ b/test/server/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+	cacheDirectory: '<rootDir>/../.cache/jest',
 	modulePaths: [ '<rootDir>/../test', '<rootDir>/server', '<rootDir>', '<rootDir>/extensions' ],
 	rootDir: '../../client',
 	roots: [ '<rootDir>/server' ],


### PR DESCRIPTION
### Background

On the developer machines, Jest cache is not configured, so it uses a temporary directory. This temporary directory is (usually) clean up, so often the developer runs the test with a cold cache.

In CI this cache is configured to `$HOME/.jest-cache`, where it is cached using CircleCI specific config for the cache key. This PR doesn't change anything CI related.

### Changes

Centralize all Jest caches into `./cache/jest`.

On my local machine, I get the following improvements:

```
# COLD caches
	yarn test-packages  89.19s user 13.79s system 285% cpu 36.026 total
	yarn test-packages  89.61s user 13.77s system 312% cpu 33.096 total
	yarn test-packages  90.87s user 14.01s system 294% cpu 35.573 total

	yarn test-integration  15.88s user 5.52s system 149% cpu 14.299 total
	yarn test-integration  15.54s user 5.48s system 133% cpu 15.782 total
	yarn test-integration  15.48s user 5.27s system 161% cpu 12.816 total

	yarn test-server  48.99s user 5.29s system 270% cpu 20.058 total
	yarn test-server  49.69s user 5.14s system 271% cpu 20.216 total
	yarn test-server  50.51s user 5.11s system 276% cpu 20.102 total

	yarn test-client  810.80s user 169.85s system 281% cpu 5:48.62 total
	yarn test-client  817.06s user 146.33s system 297% cpu 5:23.82 total
	yarn test-client  821.10s user 138.25s system 287% cpu 5:33.25 total

# WARM caches
	yarn test-packages  68.43s user 12.69s system 299% cpu 27.050 total
	yarn test-packages  68.34s user 12.52s system 297% cpu 27.153 total
	yarn test-packages  66.70s user 12.18s system 308% cpu 25.558 total

	yarn test-integration  7.15s user 3.54s system 101% cpu 10.561 total
	yarn test-integration  7.22s user 3.62s system 99% cpu 10.851 total
	yarn test-integration  7.50s user 3.90s system 98% cpu 11.593 total

	yarn test-server  17.26s user 3.05s system 209% cpu 9.699 total
	yarn test-server  17.52s user 3.07s system 218% cpu 9.404 total
	yarn test-server  17.97s user 3.17s system 214% cpu 9.867 total

	yarn test-client  635.25s user 142.84s system 266% cpu 4:52.14 total
	yarn test-client  627.28s user 137.04s system 283% cpu 4:29.34 total
	yarn test-client  624.24s user 141.12s system 295% cpu 4:19.28 total
```

### Testing instructions

Check that tests pass.