### PR TITLE
Registrationless checkout: Pause test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -227,8 +227,8 @@ export default {
 	userlessCheckout: {
 		datestamp: '20200806',
 		variations: {
-			variantUserless: 50,
-			control: 50,
+			variantUserless: 0,
+			control: 100,
 		},
 		defaultVariation: 'control',
 		allowExistingUsers: false,

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -225,10 +225,10 @@ export default {
 		allowExistingUsers: true,
 	},
 	userlessCheckout: {
-		datestamp: '20200806',
+		datestamp: '20210806',
 		variations: {
-			variantUserless: 0,
-			control: 100,
+			variantUserless: 50,
+			control: 50,
 		},
 		defaultVariation: 'control',
 		allowExistingUsers: false,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* For the registrationless checkout introduced in https://github.com/Automattic/wp-calypso/pull/44206, we are pausing the test. 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open an incognito or private browser window. Using a USA or Canada IP address in EN locale, navigate to the signup flow at https://wordpress.com/start. 
* Verify that you are not assigned to the `userlessCheckout` A/B test. In your browser console, `localstorage.ABTests` should not contain `userlessCheckout`.
