### PR TITLE
featured image preview: remove MediaStore reference from comment

### DIFF
--- a/client/post-editor/editor-featured-image/preview.jsx
+++ b/client/post-editor/editor-featured-image/preview.jsx
@@ -74,7 +74,7 @@ class EditorFeaturedImagePreview extends Component {
 		}
 
 		// Compare images by resolving the media store reference for the
-		// transient copy. MediaStore tracks pointers from transient media
+		// transient copy. Media state tracks pointers from transient media
 		// to its persisted copy, so we can compare the resolved object IDs
 		const media = this.props.getMediaItem( siteId, image.ID );
 		return media && media.ID === nextProps.image.ID;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

One line comment wording change.

* EditorFeaturedImagePreview: replace `MediaStore` with `Media state` to reflect recent migration from flux to redux

#### Testing instructions

* there's nothing to test here, only make sure wording makes sense

related #43663 
