### PR TITLE
Gutenboarding launch flow: remove delay when starting the flow

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/editor-gutenboarding-launch/index.ts
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-gutenboarding-launch/index.ts
@@ -53,6 +53,42 @@ function updateEditor() {
 		const isMobile = window.innerWidth < 768;
 		const isNewLaunch = window?.calypsoifyGutenberg?.isNewLaunch;
 
+		// Assert reason: We have an early return above with optional and falsy values. This should be a string.
+		const launchHref = window?.calypsoifyGutenberg?.frankenflowUrl as string;
+
+		// On mobile there is not enough space to display "Complete setup" label.
+		const launchLabel = isMobile
+			? __( 'Launch', 'full-site-editing' )
+			: __( 'Complete setup', 'full-site-editing' );
+
+		const saveAndNavigate = async () => {
+			await dispatch( 'core/editor' ).savePost();
+			// Using window.top to escape from the editor iframe on WordPress.com
+			window.top.location.href = launchHref;
+		};
+
+		const handleLaunch = ( e: Event ) => {
+			// Disable href navigation
+			e.preventDefault();
+
+			const shouldOpenNewFlow = isNewLaunch && ! isMobile;
+
+			recordTracksEvent( 'calypso_newsite_editor_launch_click', {
+				is_new_flow: shouldOpenNewFlow,
+			} );
+
+			if ( shouldOpenNewFlow ) {
+				// Open editor-site-launch sidebar
+				dispatch( 'automattic/launch' ).openSidebar();
+				setTimeout( () => {
+					dispatch( 'core/editor' ).savePost();
+				}, 1000 );
+			} else {
+				// Redirect to Calypso launch flow
+				saveAndNavigate();
+			}
+		};
+
 		const body = document.querySelector( 'body' );
 		body.classList.add( 'editor-gutenberg-launch__fse-overrides' );
 
@@ -65,37 +101,14 @@ function updateEditor() {
 		// Wrap 'Launch' button link to frankenflow.
 		const launchLink = document.createElement( 'a' );
 
-		// Assert reason: We have an early return above with optional and falsy values. This should be a string.
-		const launchHref = window?.calypsoifyGutenberg?.frankenflowUrl as string;
-
 		launchLink.href = launchHref;
 		launchLink.target = '_top';
 		launchLink.className = 'editor-gutenberg-launch__launch-button components-button is-primary';
 
-		// On mobile there is not enough space to display "Complete setup" label.
-		const launchLabel = isMobile
-			? __( 'Launch', 'full-site-editing' )
-			: __( 'Complete setup', 'full-site-editing' );
-
 		const textContent = document.createTextNode( launchLabel );
 		launchLink.appendChild( textContent );
 
-		const saveAndNavigate = async ( e: Event ) => {
-			// Disable href navigation
-			e.preventDefault();
-			await dispatch( 'core/editor' ).savePost();
-
-			recordTracksEvent( 'calypso_newsite_editor_launch_click' );
-
-			if ( isNewLaunch && ! isMobile ) {
-				// Open editor-site-launch sidebar
-				dispatch( 'automattic/launch' ).openSidebar();
-			} else {
-				// Using window.top to escape from the editor iframe on WordPress.com
-				window.top.location.href = launchHref;
-			}
-		};
-		launchLink.addEventListener( 'click', saveAndNavigate );
+		launchLink.addEventListener( 'click', handleLaunch );
 
 		// Put 'Launch' and 'Save' back on bar in desired order.
 		settingsBar.prepend( launchLink );

--- a/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/hooks/use-site.ts
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/hooks/use-site.ts
@@ -21,7 +21,7 @@ export function useSite() {
 	);
 
 	return {
-		isPaidPlan: site && ! site.plan.is_free,
+		isPaidPlan: site && ! site.plan?.is_free, // sometimes plan will not be available: https://github.com/Automattic/wp-calypso/pull/44895
 		launchStatus,
 		currentDomainName: site?.URL && new URL( site?.URL ).hostname,
 	};

--- a/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/hooks/use-site.ts
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/hooks/use-site.ts
@@ -21,7 +21,7 @@ export function useSite() {
 	);
 
 	return {
-		isFreePlan: site?.plan?.is_free,
+		isPaidPlan: site && ! site.plan.is_free,
 		launchStatus,
 		currentDomainName: site?.URL && new URL( site?.URL ).hostname,
 	};

--- a/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-modal/index.tsx
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-modal/index.tsx
@@ -29,14 +29,14 @@ const LaunchModal: React.FunctionComponent< Props > = ( { onClose } ) => {
 
 	const [ isLaunching, setIsLaunching ] = React.useState( false );
 
-	const { isFreePlan } = useSite();
+	const { isPaidPlan } = useSite();
 
 	const handleLaunch = () => {
 		setIsLaunching( true );
 		launchSite();
 	};
 
-	if ( ! isFreePlan && ! isLaunching ) {
+	if ( isPaidPlan && ! isLaunching ) {
 		handleLaunch();
 	}
 

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WordPress.com Editing Toolkit
  * Description: Enhances your page creation workflow within the Block Editor.
- * Version: 1.19
+ * Version: 1.20
  * Author: Automattic
  * Author URI: https://automattic.com/wordpress-plugins/
  * License: GPLv2 or later
@@ -35,7 +35,7 @@ namespace A8C\FSE;
  *
  * @var string
  */
-define( 'PLUGIN_VERSION', '1.19' );
+define( 'PLUGIN_VERSION', '1.20' );
 
 // Always include these helper files for dotcom FSE.
 require_once __DIR__ . '/dotcom-fse/helpers.php';

--- a/apps/full-site-editing/full-site-editing-plugin/readme.txt
+++ b/apps/full-site-editing/full-site-editing-plugin/readme.txt
@@ -40,6 +40,10 @@ This plugin is experimental, so we don't provide any support for it outside of w
 
 == Changelog ==
 
+= 1.20 =
+* Fix delay when starting the Complete Setup flow because of the editor save action.
+* Fix possible race condition causing the site to be immediately launched when pressing Complete Setup button.
+
 = 1.19 =
 * Fix error in editor when accessing page as a non-user super admin.
 
@@ -47,8 +51,8 @@ This plugin is experimental, so we don't provide any support for it outside of w
 * Fix broken link on mobile when selecting launch flow.
 
 = 1.17 =
-* Site setup list: fix bug opening customer home inside iframe
-* Site setup list: show clickable links in launch summary step
+* Site setup list: fix bug opening customer home inside iframe.
+* Site setup list: show clickable links in launch summary step.
 
 = 1.16 =
 * Enable site launch flow for dev & horizon environment.

--- a/apps/full-site-editing/full-site-editing-plugin/readme.txt
+++ b/apps/full-site-editing/full-site-editing-plugin/readme.txt
@@ -41,8 +41,12 @@ This plugin is experimental, so we don't provide any support for it outside of w
 == Changelog ==
 
 = 1.20 =
-* Fix delay when starting the Complete Setup flow because of the editor save action.
-* Fix possible race condition causing the site to be immediately launched when pressing Complete Setup button.
+* Site setup: Fix delay when starting the flow because of the editor save action.
+* Site setup: Fix possible race condition causing the site to be immediately launched when pressing Complete Setup button.
+* Site setup: Clear Free plan selection when a custom domain is selected.
+* Site setup: Start the flow at the first incomplete step.
+* Site setup: Use site title and existing subdomain as fallbacks for domain search.
+* Site setup: Update step completion to be derived from state instead on saved in Launch store.
 
 = 1.19 =
 * Fix error in editor when accessing page as a non-user super admin.

--- a/apps/full-site-editing/package.json
+++ b/apps/full-site-editing/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/full-site-editing",
-	"version": "1.19.0",
+	"version": "1.20.0",
 	"description": "Plugin for editing-related features.",
 	"sideEffects": true,
 	"repository": {


### PR DESCRIPTION
#### Editing Toolkit release notes
- New version: 1.20
- Other changes included:
#44901
#44882 

#### Changes proposed in this Pull Request
* Handle save action async for the new launch flow so it won't keep the modal from opening.
* Fix possible race condition causing the site to be immediately launched when pressing _Complete Setup_ button. mentioned in https://github.com/Automattic/wp-calypso/pull/44909#pullrequestreview-466642142

#### Testing instructions
* Create a site using /new
* Press Complete Setup button from editor top bar on desktop. Launch modal should open immediately
* On mobile the redirect to Calypso launch flow should be done after saving the page content

Fixes #44836
