### PR TITLE
Language Switcher: Replace single percentage sign with double for printf

### DIFF
--- a/client/components/language-picker/modal.jsx
+++ b/client/components/language-picker/modal.jsx
@@ -242,7 +242,7 @@ export class LanguagePickerModal extends PureComponent {
 		}
 
 		return translate(
-			'%(language)s is only %(percentTranslated)d% translated :(. You can help translate WordPress.com into your language. {{a}}Learn more.{{/a}}',
+			'%(language)s is only %(percentTranslated)d%% translated :(. You can help translate WordPress.com into your language. {{a}}Learn more.{{/a}}',
 			{
 				components: {
 					a: <a href="https://translate.wordpress.com/faq/" />,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* When using printf `%` signs need to be escaped with another `%`, thus `%%`. Because of GlotPress warnings, some languages have omitted the separate percentage sign.