### PR TITLE
calypso-build: add missing changelog entries and publish 6.2.0

### DIFF
--- a/packages/calypso-build/CHANGELOG.md
+++ b/packages/calypso-build/CHANGELOG.md
@@ -1,7 +1,59 @@
-# Next
+# 6.2.0
 
 - Set `strictExportPresence` in webpack so missing exports error the build.
   See [#43619](https://github.com/Automattic/wp-calypso/pull/43619).
+- Enable ES2017 syntax support in Terser output.
+- Change documentation to use `yarn` instead of `npm`
+- Lint files with wp-prettier:2.0.5
+- Use `cache-loader` for Sass (optional)
+- Updated a number of dependencies
+	- @automattic/mini-css-extract-plugin-with-rtl to ^0.8.0,
+	- @babel/cli to ^7.10.5,
+	- @babel/core to ^7.11.1,
+	- @babel/plugin-proposal-class-properties to ^7.10.4,
+	- @babel/plugin-transform-react-jsx to ^7.10.4,
+	- @babel/plugin-transform-runtime to ^7.11.0,
+	- @babel/preset-env to ^7.11.0,
+	- @babel/preset-react to ^7.10.4,
+	- @babel/preset-typescript to ^7.10.4,
+	- @types/webpack-env to ^1.15.2,
+	- @wordpress/babel-plugin-import-jsx-pragma to ^2.7.0,
+	- @wordpress/browserslist-config to ^2.7.0,
+	- @wordpress/dependency-extraction-webpack-plugin to ^2.8.0,
+	- autoprefixer to ^9.7.3,
+	- babel-jest to ^26.3.0,
+	- babel-loader to ^8.1.0,
+	- cache-loader to ^4.1.0,
+	- css-loader to ^3.4.2,
+	- duplicate-package-checker-webpack-plugin to ^3.0.0,
+	- enzyme-adapter-react-16 to ^1.15.1,
+	- enzyme-to-json to ^3.4.3,
+	- file-loader to ^4.3.0,
+	- jest-config to ^26.4.0,
+	- jest-enzyme to ^7.1.2,
+	- node-sass to ^4.13.0,
+	- postcss-custom-properties to ^9.1.1,
+	- postcss-loader to ^3.0.0,
+	- recursive-copy to ^2.0.10,
+	- sass-loader to ^8.0.0,
+	- terser-webpack-plugin to ^3.0.1,
+	- thread-loader to ^2.1.3,
+	- typescript to ^3.9.7,
+	- webpack to ^4.44.1,
+	- webpack-cli to ^3.3.11,
+	- webpack-rtl-plugin to ^2.0.0
+- Added new dependencies
+	- @babel/helpers (^7.10.4)
+	- cache-loader (^4.1.0)
+- Added peerDependencies
+	- enzyme (^3.11.0)
+	- jest (>=26.4.0)
+	- react (^16.0.0)
+	- react-dom (^16.0.0
+- Added packages to transpile:
+	- @automattic/lasagna
+	- gridicons
+	- wp-calypso-client
 
 # 6.1.0
 

--- a/packages/calypso-build/package.json
+++ b/packages/calypso-build/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/calypso-build",
-	"version": "6.1.0",
+	"version": "6.2.0",
 	"description": "Shared Calypso build configuration files",
 	"keywords": [
 		"babel",


### PR DESCRIPTION
Props to @scinos for compiling the list of changes.

Bump `calpyso-build` package version to 6.2.0.