### PR TITLE
Jetpack Cloud: Remove extra whitespace around Jetpack product display names

### DIFF
--- a/client/lib/products-values/translations.js
+++ b/client/lib/products-values/translations.js
@@ -35,17 +35,16 @@ export const getJetpackProductsDisplayNames = () => {
 				components: {
 					em: <em />,
 				},
-			} ) }{ ' ' }
+			} ) }
 		</>
 	);
 	const backupRealtime = (
 		<>
-			{ ' ' }
 			{ translate( 'Jetpack Backup {{em}}Real-Time{{/em}}', {
 				components: {
 					em: <em />,
 				},
-			} ) }{ ' ' }
+			} ) }
 		</>
 	);
 	const search = translate( 'Jetpack Search' );
@@ -55,7 +54,7 @@ export const getJetpackProductsDisplayNames = () => {
 				components: {
 					em: <em />,
 				},
-			} ) }{ ' ' }
+			} ) }
 		</>
 	);
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove extra whitespace surrounding some Jetpack product display names.

#### Testing instructions

* Verify that anywhere `getJetpackProductDisplayName` is called, the resulting markup appears correct and does not have extra leading or trailing whitespace.