### PR TITLE
media-basics-tour(select-image): derive state from redux

### DIFF
--- a/client/state/guided-tours/contexts/does-selected-site-have-media-files.js
+++ b/client/state/guided-tours/contexts/does-selected-site-have-media-files.js
@@ -1,10 +1,8 @@
 /**
  * Internal dependencies
  */
-import MediaStore from 'lib/media/store';
 import { getSelectedSiteId } from 'state/ui/selectors';
-
-const { getAll: getAllMedia } = MediaStore;
+import getAllMedia from 'state/selectors/get-media';
 
 /**
  * Returns true if the selected site has any media files.
@@ -17,6 +15,6 @@ export const doesSelectedSiteHaveMediaFiles = ( state ) => {
 	if ( ! siteId ) {
 		return false;
 	}
-	const media = getAllMedia( siteId );
+	const media = getAllMedia( state, siteId );
 	return media && media.length && media.length > 0;
 };

--- a/client/state/guided-tours/contexts/test/does-selected-site-have-media-files.js
+++ b/client/state/guided-tours/contexts/test/does-selected-site-have-media-files.js
@@ -1,0 +1,57 @@
+/**
+ * Internal dependencies
+ */
+import { doesSelectedSiteHaveMediaFiles } from '../does-selected-site-have-media-files';
+import MediaQueryManager from 'lib/query-manager/media/index.js';
+
+describe( 'doesSelectedSiteHaveMediaFiles', () => {
+	test( '1 + 1 = 2', () => {
+		expect( 1 + 1 ).toBe( 2 );
+	} );
+
+	test( 'should return false if no site is selected', () => {
+		const state = {
+			ui: {
+				selectedSiteId: null,
+			},
+		};
+
+		expect( doesSelectedSiteHaveMediaFiles( state ) ).toBe( false );
+	} );
+
+	test( 'should return falsy value if selected site has no media items', () => {
+		const state = {
+			ui: {
+				selectedSiteId: 123456,
+			},
+			media: {
+				queries: {
+					123456: new MediaQueryManager(),
+				},
+			},
+		};
+
+		expect( doesSelectedSiteHaveMediaFiles( state ) ).toBeFalsy();
+	} );
+
+	test( 'should return true if selected site has media items', () => {
+		const queryManager = new MediaQueryManager().receive( [
+			{
+				ID: 42,
+				title: 'arbitrary media item',
+			},
+		] );
+		const state = {
+			ui: {
+				selectedSiteId: 123456,
+			},
+			media: {
+				queries: {
+					123456: queryManager,
+				},
+			},
+		};
+
+		expect( doesSelectedSiteHaveMediaFiles( state ) ).toBe( true );
+	} );
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* `doesSelectedSiteHaveMediaFiles`: remove usage of `MediaStore.getAll` and use redux selector instead

#### Testing instructions

I don't exactly know how to trigger a certain guided tour manually, but I was able to trigger the media basics tour by creating a new account, following the onboarding process, and then open up the media library `/media`.

1. Once you opened `/media` on a new users account the guided tour should start.
2. Hit _Next_ twice and you should reach the step which is relevant to this PR, it should look like this:

<img width="533" alt="Screenshot 2020-08-13 at 16 43 05" src="https://user-images.githubusercontent.com/9202899/90149846-44a0d000-dd85-11ea-9ea2-6ae2aea5ed19.png">

3. To verify it's not shown if there's no images delete all the images and hit reload.
4. The tour should trigger again, but show a different popup this time:

<img width="448" alt="Screenshot 2020-08-13 at 16 43 38" src="https://user-images.githubusercontent.com/9202899/90149962-639f6200-dd85-11ea-85f7-7c5187a87a92.png">


related #43663 
