### PR TITLE
Product card: remove features section when no features

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/index.tsx
@@ -52,7 +52,7 @@ type OwnProps = {
 	UpgradeNudge?: ReactNode;
 };
 
-export type Props = OwnProps & FeaturesProps;
+export type Props = OwnProps & Partial< FeaturesProps >;
 
 const JetpackProductCard: FunctionComponent< Props > = ( {
 	className,
@@ -179,7 +179,7 @@ const JetpackProductCard: FunctionComponent< Props > = ( {
 				) }
 				{ description && <p className="jetpack-product-card__description">{ description }</p> }
 			</div>
-			{ features.items.length > 0 && (
+			{ features && features.items.length > 0 && (
 				<JetpackProductCardFeatures features={ features } isExpanded={ isExpanded } />
 			) }
 			{ UpgradeNudge }

--- a/client/components/jetpack/card/jetpack-product-card/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/index.tsx
@@ -179,13 +179,9 @@ const JetpackProductCard: FunctionComponent< Props > = ( {
 				) }
 				{ description && <p className="jetpack-product-card__description">{ description }</p> }
 			</div>
-
-			<JetpackProductCardFeatures
-				features={ features }
-				isExpanded={ isExpanded }
-				className={ UpgradeNudge ? 'foldable-card--square-border' : undefined }
-			/>
-
+			{ features.items.length > 0 && (
+				<JetpackProductCardFeatures features={ features } isExpanded={ isExpanded } />
+			) }
 			{ UpgradeNudge }
 		</div>
 	);


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR removes the features section in the product card when no feature is passed, in which case an annoying bottom padding appears. This should not be the case once the final copy is integrated, but it's an easy and quick fix.

### Testing instructions

- Visit the _Plans_ page
- Check that the cards don't have an odd bottom padding

### Screenshots

#### Before
<img width="344" alt="Screen Shot 2020-08-13 at 2 01 33 PM" src="https://user-images.githubusercontent.com/1620183/90170554-3c896600-dd6e-11ea-8983-be4f6dfa5d0b.png">


#### After
<img width="356" alt="Screen Shot 2020-08-13 at 2 00 35 PM" src="https://user-images.githubusercontent.com/1620183/90170563-401ced00-dd6e-11ea-8a8f-40c343e6ba90.png">
