### PR TITLE
Product card: update colours of legacy plans cards

### DIFF
--- a/client/components/jetpack/card/jetpack-plan-card/fixture/index.ts
+++ b/client/components/jetpack/card/jetpack-plan-card/fixture/index.ts
@@ -43,6 +43,7 @@ export const planCardWithDiscount = {
 
 export const deprecatedPlanCard = {
 	...planCard,
+	iconSlug: 'jetpack_business',
 	badgeLabel: 'Best value',
 	discountedPrice: 80,
 	withStartingPrice: true,

--- a/client/components/jetpack/card/jetpack-plan-card/style.scss
+++ b/client/components/jetpack/card/jetpack-plan-card/style.scss
@@ -1,6 +1,9 @@
 .jetpack-plan-card {
 	$jetpack-plan-card-color: var( --studio-jetpack-green-40 );
-	$jetpack-deprecated-plan-card-color: var( --studio-yellow-40 );
+	$jetpack-free-plan-color: var( --studio-blue-30 );
+	$jetpack-personal-plan-color: var( --studio-yellow-40 );
+	$jetpack-premium-plan-color: var( --studio-jetpack-green-30 );
+	$jetpack-professional-plan-color: var( --studio-purple-30 );
 
 	.jetpack-product-card__header {
 		border-color: $jetpack-plan-card-color;
@@ -15,16 +18,48 @@
 	}
 
 	&.is-deprecated {
-		.jetpack-product-card__header {
-			border-color: $jetpack-deprecated-plan-card-color;
-		}
-
 		.plan-price {
 			border-color: var( --color-text );
 		}
+	}
+
+	&[data-icon^='jetpack_free'] {
+		.jetpack-product-card__header {
+			border-color: $jetpack-free-plan-color;
+		}
 
 		.jetpack-product-card__badge {
-			color: $jetpack-deprecated-plan-card-color;
+			color: $jetpack-free-plan-color;
+		}
+	}
+
+	&[data-icon^='jetpack_personal'] {
+		.jetpack-product-card__header {
+			border-color: $jetpack-personal-plan-color;
+		}
+
+		.jetpack-product-card__badge {
+			color: $jetpack-personal-plan-color;
+		}
+	}
+
+	&[data-icon^='jetpack_premium'] {
+		.jetpack-product-card__header {
+			border-color: $jetpack-premium-plan-color;
+		}
+
+		.jetpack-product-card__badge {
+			color: $jetpack-premium-plan-color;
+		}
+	}
+
+	&[data-icon^='jetpack_business'] {
+		.jetpack-product-card__header {
+			border-color: $jetpack-professional-plan-color;
+		}
+
+		.jetpack-product-card__badge {
+			color: $jetpack-professional-plan-color;
 		}
 	}
 }

--- a/client/components/jetpack/card/jetpack-product-card/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/index.tsx
@@ -97,6 +97,7 @@ const JetpackProductCard: FunctionComponent< Props > = ( {
 				'is-owned': isOwned,
 				'is-deprecated': isDeprecated,
 			} ) }
+			data-icon={ iconSlug }
 		>
 			<header className="jetpack-product-card__header">
 				<ProductIcon className="jetpack-product-card__icon" slug={ iconSlug } />


### PR DESCRIPTION
### Changes proposed in this Pull Request

I misinterpreted how product cards for legacy plans should be styled. Instead of all of them being yellow, they should take the colour of the corresponding icon.

### Implementation notes

- I added the code for the Free plan, though it's never shown in the _Plans_ page.

### Testing instructions

- Make sure the offer reset flow is enabled
- Visit the _Plans_ page with a Personal, Premium, and Professional plan successively (you can easily change plans in the store admin)
- For each plan, check that the coloured line has the same colour than the icon background

### Screenshots

#### Personal
<img width="446" alt="Screen Shot 2020-08-13 at 2 36 04 PM" src="https://user-images.githubusercontent.com/1620183/90174758-7b221f00-dd74-11ea-8929-d5d18415f50b.png">

#### Premium
<img width="442" alt="Screen Shot 2020-08-13 at 2 32 32 PM" src="https://user-images.githubusercontent.com/1620183/90174771-7eb5a600-dd74-11ea-89ee-b0d2136ea10b.png">

#### Professional
<img width="455" alt="Screen Shot 2020-08-13 at 2 30 52 PM" src="https://user-images.githubusercontent.com/1620183/90174783-82e1c380-dd74-11ea-9a77-2186f3e6c9e6.png">
