### PR TITLE
Editing toolkit: update stable tag to 1.20

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/readme.txt
+++ b/apps/full-site-editing/full-site-editing-plugin/readme.txt
@@ -3,7 +3,7 @@ Contributors: alexislloyd, allancole, automattic, bartkalisz, codebykat, copons,
 Tags: block, blocks, editor, gutenberg, page
 Requires at least: 5.0
 Tested up to: 5.4
-Stable tag: 1.19
+Stable tag: 1.20
 Requires PHP: 5.6.20
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Leftover from #44909 
> The new version (1.20) does not match the stable tag (1.19) in readme.txt.
> Version info:
        Previous Version: 1.19
        New Version (defined in plugin loader): 1.20
        Stable Tag (defined in readme.txt): 1.19
* Same as #44838 🤦 

#### Testing instructions
* Nothing to test.  

