### PR TITLE
Consolidates wiring for Jetpack product cards

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/index.tsx
@@ -40,10 +40,10 @@ type OwnProps = {
 	withStartingPrice?: boolean;
 	billingTimeFrame: TranslateResult;
 	badgeLabel?: TranslateResult;
-	discountMessage?: string;
+	discountMessage?: TranslateResult;
 	buttonLabel: TranslateResult;
 	onButtonClick: () => void;
-	cancelLabel?: string;
+	cancelLabel?: TranslateResult;
 	onCancelClick?: () => void;
 	isHighlighted?: boolean;
 	isOwned?: boolean;

--- a/client/my-sites/plans-v2/constants.ts
+++ b/client/my-sites/plans-v2/constants.ts
@@ -36,7 +36,7 @@ import {
 /**
  * Type dependencies
  */
-import type { JetpackOfferDailyPlans, JetpackOfferRealtimePlans } from 'lib/plans/types';
+import type { JetpackDailyPlan, JetpackRealtimePlan } from 'lib/plans/types';
 import type { SelectorProduct, SelectorProductSlug, ProductType } from './types';
 
 export const ALL = 'all';
@@ -99,7 +99,7 @@ export const OPTION_PLAN_SECURITY: SelectorProduct = {
 		'Enjoy the peace of mind of complete site security. ' +
 			'Easy-to-use, powerful security tools guard your site, so you can focus on your business.'
 	),
-	features: [],
+	features: { items: [] },
 };
 export const OPTION_PLAN_SECURITY_MONTHLY: SelectorProduct = {
 	...OPTION_PLAN_SECURITY,
@@ -121,7 +121,7 @@ export const OPTION_PRODUCT_BACKUP: SelectorProduct = {
 	displayName: translate( 'Jetpack Backup' ),
 	tagline: '',
 	description: '',
-	features: [],
+	features: { items: [] },
 };
 export const OPTION_PRODUCT_BACKUP_MONTHLY: SelectorProduct = {
 	...OPTION_PRODUCT_BACKUP,
@@ -183,17 +183,14 @@ export const SELECTOR_PLANS = [
 	PLAN_JETPACK_COMPLETE_MONTHLY,
 ];
 
-export const DAILY_PLAN_TO_REALTIME_PLAN: Record<
-	JetpackOfferDailyPlans,
-	JetpackOfferRealtimePlans
-> = {
+export const DAILY_PLAN_TO_REALTIME_PLAN: Record< JetpackDailyPlan, JetpackRealtimePlan > = {
 	[ PLAN_JETPACK_SECURITY_DAILY ]: PLAN_JETPACK_SECURITY_REALTIME,
 	[ PLAN_JETPACK_SECURITY_DAILY_MONTHLY ]: PLAN_JETPACK_SECURITY_REALTIME_MONTHLY,
 };
 
 /**
  * List of plans and products that can be upgraded from daily to real-time
- * through an upgrade nunge.
+ * through an upgrade nudge.
  */
 export const UPGRADEABLE_WITH_NUDGE = [
 	PLAN_JETPACK_SECURITY_DAILY,

--- a/client/my-sites/plans-v2/constants.ts
+++ b/client/my-sites/plans-v2/constants.ts
@@ -36,7 +36,7 @@ import {
 /**
  * Type dependencies
  */
-import type { JetpackDailyPlan, JetpackRealtimePlan } from 'lib/plans/types';
+import type { JetpackRealtimePlan } from 'lib/plans/types';
 import type { SelectorProduct, SelectorProductSlug, ProductType } from './types';
 
 export const ALL = 'all';
@@ -183,7 +183,7 @@ export const SELECTOR_PLANS = [
 	PLAN_JETPACK_COMPLETE_MONTHLY,
 ];
 
-export const DAILY_PLAN_TO_REALTIME_PLAN: Record< JetpackDailyPlan, JetpackRealtimePlan > = {
+export const DAILY_PLAN_TO_REALTIME_PLAN: Record< string, JetpackRealtimePlan > = {
 	[ PLAN_JETPACK_SECURITY_DAILY ]: PLAN_JETPACK_SECURITY_REALTIME,
 	[ PLAN_JETPACK_SECURITY_DAILY_MONTHLY ]: PLAN_JETPACK_SECURITY_REALTIME_MONTHLY,
 };

--- a/client/my-sites/plans-v2/constants.ts
+++ b/client/my-sites/plans-v2/constants.ts
@@ -72,6 +72,11 @@ export const OPTIONS_JETPACK_SECURITY_MONTHLY = 'jetpack_security_monthly';
 export const OPTIONS_JETPACK_BACKUP = 'jetpack_backup';
 export const OPTIONS_JETPACK_BACKUP_MONTHLY = 'jetpack_backup_monthly';
 
+// Types of items. This determines the card UI.
+export const ITEM_TYPE_PLAN = 'item-type-plan';
+export const ITEM_TYPE_BUNDLE = 'item-type-bundle';
+export const ITEM_TYPE_PRODUCT = 'item-type-product';
+
 export const PRODUCTS_WITH_OPTIONS = [
 	OPTIONS_JETPACK_SECURITY,
 	OPTIONS_JETPACK_SECURITY_MONTHLY,
@@ -83,6 +88,7 @@ export const PRODUCTS_WITH_OPTIONS = [
 export const OPTION_PLAN_SECURITY: SelectorProduct = {
 	productSlug: OPTIONS_JETPACK_SECURITY,
 	term: TERM_ANNUALLY,
+	type: ITEM_TYPE_BUNDLE,
 	subtypes: [ PLAN_JETPACK_SECURITY_DAILY, PLAN_JETPACK_SECURITY_REALTIME ],
 	costProductSlug: PLAN_JETPACK_SECURITY_DAILY,
 	monthlyProductSlug: PLAN_JETPACK_SECURITY_DAILY_MONTHLY,
@@ -107,6 +113,7 @@ export const OPTION_PLAN_SECURITY_MONTHLY: SelectorProduct = {
 export const OPTION_PRODUCT_BACKUP: SelectorProduct = {
 	productSlug: OPTIONS_JETPACK_BACKUP,
 	term: TERM_ANNUALLY,
+	type: ITEM_TYPE_PRODUCT,
 	subtypes: [ PRODUCT_JETPACK_BACKUP_DAILY, PRODUCT_JETPACK_BACKUP_REALTIME ],
 	costProductSlug: PRODUCT_JETPACK_BACKUP_DAILY,
 	monthlyProductSlug: PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY,

--- a/client/my-sites/plans-v2/details.tsx
+++ b/client/my-sites/plans-v2/details.tsx
@@ -21,7 +21,7 @@ import HeaderCake from 'components/header-cake';
 import Main from 'components/main';
 import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
 import { isProductsListFetching } from 'state/products-list/selectors/is-products-list-fetching';
-import { getSelectedSiteSlug } from 'state/ui/selectors';
+import { getSelectedSiteSlug, getSelectedSiteId } from 'state/ui/selectors';
 
 /**
  * Type dependencies
@@ -31,6 +31,7 @@ import type { DetailsPageProps, PurchaseCallback, SelectorProduct } from './type
 import './style.scss';
 
 const DetailsPage = ( { duration, productSlug, rootUrl }: DetailsPageProps ) => {
+	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
 	const siteSlug = useSelector( ( state ) => getSelectedSiteSlug( state ) ) || '';
 	const currencyCode = useSelector( ( state ) => getCurrentUserCurrencyCode( state ) );
 	const isFetchingProducts = useSelector( ( state ) => isProductsListFetching( state ) );
@@ -85,6 +86,7 @@ const DetailsPage = ( { duration, productSlug, rootUrl }: DetailsPageProps ) => 
 						<ProductCard
 							key={ subtypeSlug }
 							item={ subtypeItem }
+							siteId={ siteId }
 							currencyCode={ currencyCode }
 							onClick={ () => selectProduct( subtypeItem ) }
 							className="details__column"

--- a/client/my-sites/plans-v2/details.tsx
+++ b/client/my-sites/plans-v2/details.tsx
@@ -10,26 +10,17 @@ import { useTranslate } from 'i18n-calypso';
  * Internal dependencies
  */
 import {
-	slugToSelectorProduct,
-	durationToString,
-	durationToText,
-	productButtonLabel,
-	getProductPrices,
-} from './utils';
-import {
 	PRODUCTS_WITH_OPTIONS,
 	OPTIONS_JETPACK_SECURITY,
 	OPTIONS_JETPACK_SECURITY_MONTHLY,
 } from './constants';
+import ProductCard from './product-card';
+import { slugToSelectorProduct, durationToString } from './utils';
 import FormattedHeader from 'components/formatted-header';
 import HeaderCake from 'components/header-cake';
 import Main from 'components/main';
-import JetpackBundleCard from 'components/jetpack/card/jetpack-bundle-card';
-import JetpackProductCard from 'components/jetpack/card/jetpack-product-card';
 import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
-import { getAvailableProductsList } from 'state/products-list/selectors/get-available-products-list';
 import { isProductsListFetching } from 'state/products-list/selectors/is-products-list-fetching';
-import { getProductCost } from 'state/products-list/selectors/get-product-cost';
 import { getSelectedSiteSlug } from 'state/ui/selectors';
 
 /**
@@ -38,63 +29,6 @@ import { getSelectedSiteSlug } from 'state/ui/selectors';
 import type { DetailsPageProps, PurchaseCallback, SelectorProduct } from './types';
 
 import './style.scss';
-
-type Cost = {
-	originalPrice: number;
-	discountedPrice?: number;
-};
-
-const ProductComponent = ( {
-	productSlug,
-	onClick,
-	currencyCode,
-}: {
-	productSlug: string;
-	onClick: PurchaseCallback;
-	currencyCode: string;
-} ) => {
-	const availableProducts = useSelector( ( state ) => getAvailableProductsList( state ) );
-	const price = useSelector( ( state ) => getProductCost( state, productSlug ) ) || 0;
-	const product = slugToSelectorProduct( productSlug );
-	if ( ! product ) {
-		// Exit if invalid product.
-		return null;
-	}
-	const isBundle = [ OPTIONS_JETPACK_SECURITY, OPTIONS_JETPACK_SECURITY_MONTHLY ].includes(
-		productSlug
-	);
-	const JetpackCard = isBundle ? JetpackBundleCard : JetpackProductCard;
-
-	// Gets the cost of the product/plan.
-	// TODO: Pull this all from the API.
-	let cost: Cost = { originalPrice: 0 };
-	if ( isBundle ) {
-		cost = { originalPrice: price || 0 };
-	} else {
-		const productPrices = getProductPrices( product, availableProducts );
-		cost = {
-			originalPrice: productPrices.cost || 0,
-			discountedPrice: productPrices.discountCost,
-		};
-	}
-
-	return (
-		<JetpackCard
-			key={ productSlug }
-			iconSlug={ product.iconSlug }
-			productName={ product.displayName }
-			subheadline={ product.tagline }
-			description={ product.description }
-			currencyCode={ currencyCode }
-			billingTimeFrame={ durationToText( product.term ) }
-			buttonLabel={ productButtonLabel( product ) }
-			onButtonClick={ () => onClick( product ) }
-			features={ { items: [] } }
-			className="details__column"
-			{ ...cost }
-		/>
-	);
-};
 
 const DetailsPage = ( { duration, productSlug, rootUrl }: DetailsPageProps ) => {
 	const siteSlug = useSelector( ( state ) => getSelectedSiteSlug( state ) ) || '';
@@ -141,14 +75,22 @@ const DetailsPage = ( { duration, productSlug, rootUrl }: DetailsPageProps ) => 
 			</HeaderCake>
 			<FormattedHeader headerText="Great choice! Now select a backup option:" brandFont />
 			<div className="plans-v2__columns">
-				{ product.subtypes.map( ( subtypeSlug ) => (
-					<ProductComponent
-						key={ subtypeSlug }
-						productSlug={ subtypeSlug }
-						onClick={ selectProduct }
-						currencyCode={ currencyCode }
-					/>
-				) ) }
+				{ product.subtypes.map( ( subtypeSlug ) => {
+					const subtypeItem = slugToSelectorProduct( subtypeSlug );
+					if ( ! subtypeItem ) {
+						// Exit if invalid product.
+						return null;
+					}
+					return (
+						<ProductCard
+							key={ subtypeSlug }
+							item={ subtypeItem }
+							currencyCode={ currencyCode }
+							onClick={ () => selectProduct( subtypeItem ) }
+							className="details__column"
+						/>
+					);
+				} ) }
 			</div>
 		</Main>
 	);

--- a/client/my-sites/plans-v2/plans-column/index.tsx
+++ b/client/my-sites/plans-v2/plans-column/index.tsx
@@ -2,51 +2,24 @@
  * External dependencies
  */
 import { translate } from 'i18n-calypso';
-import React, { useMemo, ReactNode } from 'react';
+import React, { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
 /**
  * Internal dependencies
  */
-import {
-	durationToText,
-	slugToItem,
-	slugToSelectorProduct,
-	itemToSelectorProduct,
-	productButtonLabel,
-	productBadgeLabel,
-	isUpgradeable,
-	getRealtimeFromDaily,
-} from '../utils';
-import {
-	PRODUCTS_TYPES,
-	SELECTOR_PLANS,
-	OPTIONS_JETPACK_SECURITY,
-	OPTIONS_JETPACK_SECURITY_MONTHLY,
-} from '../constants';
-import PlanRenewalMessage from '../plan-renewal-message';
-import { useLocalizedMoment } from 'components/localized-moment';
-import {
-	PLAN_JETPACK_FREE,
-	PLAN_JETPACK_SECURITY_DAILY,
-	PLAN_JETPACK_SECURITY_DAILY_MONTHLY,
-} from 'lib/plans/constants';
-import { isCloseToExpiration } from 'lib/purchases';
-import { getPurchaseByProductSlug } from 'lib/purchases/utils';
-import { getProductCost, isProductsListFetching } from 'state/products-list/selectors';
+import { PRODUCTS_TYPES, SELECTOR_PLANS } from '../constants';
+import { slugToSelectorProduct } from '../utils';
+import ProductCard from '../product-card';
+import { PLAN_JETPACK_FREE } from 'lib/plans/constants';
 import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
-import { getSitePurchases } from 'state/purchases/selectors';
 import getSitePlan from 'state/sites/selectors/get-site-plan';
-import JetpackBundleCard from 'components/jetpack/card/jetpack-bundle-card';
-import JetpackPlanCard from 'components/jetpack/card/jetpack-plan-card';
 import FormattedHeader from 'components/formatted-header';
-import JetpackProductCardUpgradeNudge from 'components/jetpack/card/jetpack-product-card/upgrade-nudge';
 
 /**
  * Type dependencies
  */
 import type { Duration, PurchaseCallback, ProductType, SelectorProduct } from '../types';
-import type { Purchase } from 'lib/purchases/types';
 
 interface PlanColumnType {
 	duration: Duration;
@@ -55,141 +28,34 @@ interface PlanColumnType {
 	siteId: number | null;
 }
 
-type PlanWithBought = SelectorProduct & { owned: boolean; legacy: boolean } & {
-	upgradeable: boolean;
-	UpgradeNudge?: ReactNode;
-};
-
-const PlanComponent = ( {
-	plan,
-	purchases,
-	onClick,
-	currencyCode,
-}: {
-	plan: PlanWithBought;
-	purchases: Purchase[];
-	onClick: PurchaseCallback;
-	currencyCode: string;
-} ) => {
-	const moment = useLocalizedMoment();
-	const price =
-		useSelector( ( state ) => getProductCost( state, plan.costProductSlug || plan.productSlug ) ) ||
-		0;
-	const CardComponent = [ OPTIONS_JETPACK_SECURITY, OPTIONS_JETPACK_SECURITY_MONTHLY ].includes(
-		plan.productSlug
-	)
-		? JetpackBundleCard
-		: JetpackPlanCard;
-	const purchase = getPurchaseByProductSlug( purchases, plan.productSlug );
-	const isExpiring = purchase && isCloseToExpiration( purchase );
-	const showExpiryNotice = plan.legacy && isExpiring;
-
-	if ( plan.upgradeable ) {
-		// TODO: remove this once we can purchase new plans.
-		// We need this now to make the nudge appear inside the Jetpack Security Bundle card
-		// and make it work as it was Jetpack Security Daily (monthly or annually).
-		const productSlug =
-			plan.productSlug === OPTIONS_JETPACK_SECURITY
-				? PLAN_JETPACK_SECURITY_DAILY
-				: PLAN_JETPACK_SECURITY_DAILY_MONTHLY;
-
-		const upgradeToProductSlug = productSlug && getRealtimeFromDaily( productSlug );
-		const selectorProductToUpgrade =
-			upgradeToProductSlug && slugToSelectorProduct( upgradeToProductSlug );
-
-		plan.UpgradeNudge = selectorProductToUpgrade ? (
-			<JetpackProductCardUpgradeNudge
-				billingTimeFrame={ durationToText( plan.term ) }
-				currencyCode={ currencyCode }
-				discountedPrice={ 67 }
-				originalPrice={ price || 100 }
-				onUpgradeClick={ () => null }
-				selectorProduct={ selectorProductToUpgrade }
-			/>
-		) : undefined;
-	}
-
-	return (
-		<CardComponent
-			iconSlug={ plan.iconSlug }
-			productName={ plan.displayName }
-			subheadline={ plan.tagline }
-			description={
-				showExpiryNotice ? (
-					<PlanRenewalMessage purchase={ purchase as Purchase } />
-				) : (
-					plan.description
-				)
-			}
-			currencyCode={ currencyCode }
-			billingTimeFrame={ durationToText( plan.term ) }
-			badgeLabel={ productBadgeLabel( plan ) }
-			buttonLabel={ productButtonLabel( plan ) }
-			onButtonClick={ () => onClick( plan ) }
-			features={ { items: [] } }
-			originalPrice={ price }
-			withStartingPrice={ plan.subtypes && plan.subtypes.length > 0 }
-			isOwned={ plan.owned }
-			isDeprecated={ plan.legacy }
-			UpgradeNudge={ plan.UpgradeNudge }
-			expiryDate={ showExpiryNotice ? moment( ( purchase as Purchase ).expiryDate ) : undefined }
-		/>
-	);
-};
-
 const PlansColumn = ( { duration, onPlanClick, productType, siteId }: PlanColumnType ) => {
 	const currencyCode = useSelector( ( state ) => getCurrentUserCurrencyCode( state ) );
-	const isFetchingProducts = useSelector( ( state ) => isProductsListFetching( state ) );
 	const currentPlan =
 		useSelector( ( state ) => getSitePlan( state, siteId ) )?.product_slug || null;
-	const purchases = useSelector( ( state ) => getSitePurchases( state, siteId ) );
 
 	// This gets all plan objects for us to parse.
-	const planObjects: PlanWithBought[] = useMemo( () => {
-		let owned = false;
+	const planObjects: SelectorProduct[] = useMemo( () => {
 		// Map over all plan slugs and convert them to SelectorProduct types.
-		const plans: PlanWithBought[] = SELECTOR_PLANS.map( ( productSlug ) => {
-			const item = slugToItem( productSlug );
-			if ( ! owned && currentPlan ) {
-				// Check if we own a plan in here. If we don't the user has a legacy plan, handled below.
-				owned = productSlug === currentPlan;
-			}
-			return item && itemToSelectorProduct( item );
-		} )
+		const plans: SelectorProduct[] = SELECTOR_PLANS.map( slugToSelectorProduct )
 			// Remove plans that don't fit the filters or have invalid data.
 			.filter(
 				( product: SelectorProduct | null ): product is SelectorProduct =>
 					!! product &&
 					duration === product.term &&
 					PRODUCTS_TYPES[ productType ].includes( product.productSlug )
-			)
-			// Iterate over plans and set whether they are legacy and if the user owns them.
-			// Verify if plan is upgradeable.
-			.map( ( product: SelectorProduct ) => {
-				const isOwned = product.productSlug === currentPlan;
-				return {
-					...product,
-					owned: isOwned,
-					legacy: false,
-					// TODO: since we can't own Jetpack Security Bundle, we have to disable
-					// this check while we can't purchase the real plan.
-					// upgradeable: isOwned && isUpgradeable( product.productSlug ),
-					upgradeable: isUpgradeable( product.productSlug ),
-				};
-			} );
+			);
 
 		// If the user does not own a current plan, get it and insert it on the top of the plan array.
-		if ( ! owned && currentPlan && currentPlan !== PLAN_JETPACK_FREE ) {
-			const item = slugToItem( currentPlan );
-			const currentPlanSelector = item && itemToSelectorProduct( item );
-			if ( currentPlanSelector ) {
-				plans.unshift( { ...currentPlanSelector, owned: true, legacy: true, upgradeable: false } );
+		if ( currentPlan && currentPlan !== PLAN_JETPACK_FREE ) {
+			const item = slugToSelectorProduct( currentPlan );
+			if ( item ) {
+				plans.unshift( { ...item, owned: true, legacy: true } );
 			}
 		}
 		return plans;
 	}, [ duration, productType, currentPlan ] );
 
-	if ( ! currencyCode || isFetchingProducts ) {
+	if ( ! currencyCode ) {
 		return null; // TODO: Loading component!
 	}
 
@@ -197,11 +63,10 @@ const PlansColumn = ( { duration, onPlanClick, productType, siteId }: PlanColumn
 		<div className="plans-column">
 			<FormattedHeader headerText={ translate( 'Plans' ) } brandFont />
 			{ planObjects.map( ( plan ) => (
-				<PlanComponent
+				<ProductCard
 					key={ plan.productSlug }
 					onClick={ onPlanClick }
-					plan={ plan }
-					purchases={ purchases }
+					item={ plan }
 					currencyCode={ currencyCode }
 				/>
 			) ) }

--- a/client/my-sites/plans-v2/plans-column/index.tsx
+++ b/client/my-sites/plans-v2/plans-column/index.tsx
@@ -49,7 +49,7 @@ const PlansColumn = ( { duration, onPlanClick, productType, siteId }: PlanColumn
 		if ( currentPlan && currentPlan !== PLAN_JETPACK_FREE ) {
 			const item = slugToSelectorProduct( currentPlan );
 			if ( item ) {
-				plans.unshift( { ...item, owned: true, legacy: true } );
+				plans.unshift( item );
 			}
 		}
 		return plans;
@@ -65,8 +65,9 @@ const PlansColumn = ( { duration, onPlanClick, productType, siteId }: PlanColumn
 			{ planObjects.map( ( plan ) => (
 				<ProductCard
 					key={ plan.productSlug }
-					onClick={ onPlanClick }
 					item={ plan }
+					siteId={ siteId }
+					onClick={ onPlanClick }
 					currencyCode={ currencyCode }
 				/>
 			) ) }

--- a/client/my-sites/plans-v2/product-card/index.tsx
+++ b/client/my-sites/plans-v2/product-card/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
 /**
@@ -10,10 +10,13 @@ import { useSelector } from 'react-redux';
 import { ITEM_TYPE_PLAN, ITEM_TYPE_BUNDLE, ITEM_TYPE_PRODUCT } from '../constants';
 import { durationToText, productButtonLabel } from '../utils';
 import { isProductsListFetching } from 'state/products-list/selectors/is-products-list-fetching';
-import { getProductCost } from 'state/products-list/selectors';
+import { getProductCost } from 'state/products-list/selectors/get-product-cost';
+import getSitePlan from 'state/sites/selectors/get-site-plan';
+import getSiteProducts from 'state/sites/selectors/get-site-products';
 import JetpackPlanCard from 'components/jetpack/card/jetpack-plan-card';
 import JetpackBundleCard from 'components/jetpack/card/jetpack-bundle-card';
 import JetpackProductCard from 'components/jetpack/card/jetpack-product-card';
+import { TERM_MONTHLY } from 'lib/plans/constants';
 
 /**
  * Type dependencies
@@ -35,11 +38,28 @@ const itemToCard = ( { type }: SelectorProduct ) => {
 interface ProductCardProps {
 	item: SelectorProduct;
 	onClick: PurchaseCallback;
+	siteId: number | null;
 	currencyCode: string;
 	className?: string;
 }
 
-const ProductCard = ( { item, onClick, currencyCode, className }: ProductCardProps ) => {
+const ProductCard = ( { item, onClick, siteId, currencyCode, className }: ProductCardProps ) => {
+	// Determine whether product is owned.
+	const sitePlan = useSelector( ( state ) => getSitePlan( state, siteId ) );
+	const siteProducts = useSelector( ( state ) => getSiteProducts( state, siteId ) );
+	const isOwned = useMemo( () => {
+		if ( sitePlan && sitePlan.product_slug === item.productSlug ) {
+			return true;
+		} else if ( siteProducts ) {
+			return siteProducts
+				.filter( ( product ) => ! product.expired )
+				.map( ( product ) => product.productSlug )
+				.includes( item.productSlug );
+		}
+		return false;
+	}, [ item.productSlug, sitePlan, siteProducts ] );
+
+	// Calculate the product price.
 	const isFetchingPrices = useSelector( ( state ) => isProductsListFetching( state ) );
 	const itemCost = useSelector( ( state ) =>
 		getProductCost( state, item.costProductSlug || item.productSlug )
@@ -48,17 +68,17 @@ const ProductCard = ( { item, onClick, currencyCode, className }: ProductCardPro
 		getProductCost( state, item.monthlyProductSlug || '' )
 	);
 
-	let originalPrice = 0;
+	let originalPrice = 999; // NOTE: Temp cost for products who are not in API yet.
 	let discountedPrice = undefined;
 	if ( ! isFetchingPrices && itemCost ) {
 		originalPrice = itemCost;
-		if ( monthlyItemCost ) {
+		if ( monthlyItemCost && item.term !== TERM_MONTHLY ) {
 			originalPrice = monthlyItemCost * 12;
 			discountedPrice = itemCost;
 		}
 	}
 
-	const CardComponent = itemToCard( item );
+	const CardComponent = itemToCard( item ); // Get correct card component.
 	return (
 		<CardComponent
 			iconSlug={ item.iconSlug }
@@ -73,7 +93,7 @@ const ProductCard = ( { item, onClick, currencyCode, className }: ProductCardPro
 			originalPrice={ originalPrice }
 			discountedPrice={ discountedPrice }
 			withStartingPrice={ item.subtypes.length > 0 }
-			isOwned={ item.owned }
+			isOwned={ isOwned }
 			isDeprecated={ item.legacy }
 			className={ className }
 		/>

--- a/client/my-sites/plans-v2/product-card/index.tsx
+++ b/client/my-sites/plans-v2/product-card/index.tsx
@@ -3,7 +3,7 @@
  */
 import React, { useMemo } from 'react';
 import { useSelector } from 'react-redux';
-import { useTranslate, TranslateResult } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -81,12 +81,6 @@ const ProductCard = ( { item, onClick, siteId, currencyCode, className }: Produc
 		}
 	}
 
-	// Handle badge label.
-	let badgeLabel: TranslateResult = '';
-	if ( isOwned ) {
-		badgeLabel = translate( 'You own this' );
-	}
-
 	const CardComponent = itemToCard( item ); // Get correct card component.
 	return (
 		<CardComponent
@@ -98,7 +92,6 @@ const ProductCard = ( { item, onClick, siteId, currencyCode, className }: Produc
 			billingTimeFrame={ durationToText( item.term ) }
 			buttonLabel={ isOwned ? translate( 'Manage subscription' ) : productButtonLabel( item ) }
 			onButtonClick={ () => onClick( item ) }
-			badgeLabel={ badgeLabel }
 			features={ item.features }
 			originalPrice={ originalPrice }
 			discountedPrice={ discountedPrice }

--- a/client/my-sites/plans-v2/product-card/index.tsx
+++ b/client/my-sites/plans-v2/product-card/index.tsx
@@ -3,7 +3,7 @@
  */
 import React, { useMemo } from 'react';
 import { useSelector } from 'react-redux';
-import { useTranslate } from 'i18n-calypso';
+import { useTranslate, TranslateResult } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -81,6 +81,12 @@ const ProductCard = ( { item, onClick, siteId, currencyCode, className }: Produc
 		}
 	}
 
+	// Handle badge label.
+	let badgeLabel: TranslateResult = '';
+	if ( isOwned ) {
+		badgeLabel = translate( 'You own this' );
+	}
+
 	const CardComponent = itemToCard( item ); // Get correct card component.
 	return (
 		<CardComponent
@@ -92,6 +98,7 @@ const ProductCard = ( { item, onClick, siteId, currencyCode, className }: Produc
 			billingTimeFrame={ durationToText( item.term ) }
 			buttonLabel={ isOwned ? translate( 'Manage subscription' ) : productButtonLabel( item ) }
 			onButtonClick={ () => onClick( item ) }
+			badgeLabel={ badgeLabel }
 			features={ item.features }
 			originalPrice={ originalPrice }
 			discountedPrice={ discountedPrice }

--- a/client/my-sites/plans-v2/product-card/index.tsx
+++ b/client/my-sites/plans-v2/product-card/index.tsx
@@ -3,6 +3,7 @@
  */
 import React, { useMemo } from 'react';
 import { useSelector } from 'react-redux';
+import { useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -44,6 +45,8 @@ interface ProductCardProps {
 }
 
 const ProductCard = ( { item, onClick, siteId, currencyCode, className }: ProductCardProps ) => {
+	const translate = useTranslate();
+
 	// Determine whether product is owned.
 	const sitePlan = useSelector( ( state ) => getSitePlan( state, siteId ) );
 	const siteProducts = useSelector( ( state ) => getSiteProducts( state, siteId ) );
@@ -87,7 +90,7 @@ const ProductCard = ( { item, onClick, siteId, currencyCode, className }: Produc
 			description={ item.description }
 			currencyCode={ currencyCode }
 			billingTimeFrame={ durationToText( item.term ) }
-			buttonLabel={ productButtonLabel( item ) }
+			buttonLabel={ isOwned ? translate( 'Manage subscription' ) : productButtonLabel( item ) }
 			onButtonClick={ () => onClick( item ) }
 			features={ item.features }
 			originalPrice={ originalPrice }

--- a/client/my-sites/plans-v2/product-card/index.tsx
+++ b/client/my-sites/plans-v2/product-card/index.tsx
@@ -3,7 +3,6 @@
  */
 import React, { useMemo } from 'react';
 import { useSelector } from 'react-redux';
-import { useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -15,6 +14,7 @@ import {
 	isUpgradeable,
 	getRealtimeFromDaily,
 	slugToSelectorProduct,
+	productBadgeLabel,
 } from '../utils';
 import { isProductsListFetching } from 'state/products-list/selectors/is-products-list-fetching';
 import { getProductCost } from 'state/products-list/selectors/get-product-cost';
@@ -95,9 +95,13 @@ interface ProductCardProps {
 	className?: string;
 }
 
-const ProductCard = ( { item, onClick, siteId, currencyCode, className }: ProductCardProps ) => {
-	const translate = useTranslate();
-
+const ProductCardWrapper = ( {
+	item,
+	onClick,
+	siteId,
+	currencyCode,
+	className,
+}: ProductCardProps ) => {
 	// Determine whether product is owned.
 	const sitePlan = useSelector( ( state ) => getSitePlan( state, siteId ) );
 	const siteProducts = useSelector( ( state ) => getSiteProducts( state, siteId ) );
@@ -141,7 +145,8 @@ const ProductCard = ( { item, onClick, siteId, currencyCode, className }: Produc
 			description={ item.description }
 			currencyCode={ currencyCode }
 			billingTimeFrame={ durationToText( item.term ) }
-			buttonLabel={ isOwned ? translate( 'Manage subscription' ) : productButtonLabel( item ) }
+			buttonLabel={ productButtonLabel( item, isOwned ) }
+			badgeLabel={ productBadgeLabel( item, isOwned, sitePlan ) }
 			onButtonClick={ () => onClick( item ) }
 			features={ item.features }
 			originalPrice={ originalPrice }
@@ -157,4 +162,4 @@ const ProductCard = ( { item, onClick, siteId, currencyCode, className }: Produc
 	);
 };
 
-export default ProductCard;
+export default ProductCardWrapper;

--- a/client/my-sites/plans-v2/product-card/index.tsx
+++ b/client/my-sites/plans-v2/product-card/index.tsx
@@ -1,0 +1,81 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { useSelector } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { ITEM_TYPE_PLAN, ITEM_TYPE_BUNDLE, ITEM_TYPE_PRODUCT } from '../constants';
+import { durationToText, productButtonLabel } from '../utils';
+import { isProductsListFetching } from 'state/products-list/selectors/is-products-list-fetching';
+import { getProductCost } from 'state/products-list/selectors';
+import JetpackPlanCard from 'components/jetpack/card/jetpack-plan-card';
+import JetpackBundleCard from 'components/jetpack/card/jetpack-bundle-card';
+import JetpackProductCard from 'components/jetpack/card/jetpack-product-card';
+
+/**
+ * Type dependencies
+ */
+import type { PurchaseCallback, SelectorProduct } from '../types';
+
+const itemToCard = ( { type }: SelectorProduct ) => {
+	switch ( type ) {
+		case ITEM_TYPE_PLAN:
+			return JetpackPlanCard;
+		case ITEM_TYPE_BUNDLE:
+			return JetpackBundleCard;
+		case ITEM_TYPE_PRODUCT:
+		default:
+			return JetpackProductCard;
+	}
+};
+
+interface ProductCardProps {
+	item: SelectorProduct;
+	onClick: PurchaseCallback;
+	currencyCode: string;
+}
+
+const ProductCard = ( { item, onClick, currencyCode }: ProductCardProps ) => {
+	const isFetchingPrices = useSelector( ( state ) => isProductsListFetching( state ) );
+	const itemCost = useSelector( ( state ) =>
+		getProductCost( state, item.costProductSlug || item.productSlug )
+	);
+	const monthlyItemCost = useSelector( ( state ) =>
+		getProductCost( state, item.monthlyProductSlug || '' )
+	);
+
+	let originalPrice = 0;
+	let discountedPrice = undefined;
+	if ( ! isFetchingPrices && itemCost ) {
+		originalPrice = itemCost;
+		if ( monthlyItemCost ) {
+			originalPrice = monthlyItemCost * 12;
+			discountedPrice = itemCost;
+		}
+	}
+
+	const CardComponent = itemToCard( item );
+	return (
+		<CardComponent
+			iconSlug={ item.iconSlug }
+			productName={ item.displayName }
+			subheadline={ item.tagline }
+			description={ item.description }
+			currencyCode={ currencyCode }
+			billingTimeFrame={ durationToText( item.term ) }
+			buttonLabel={ productButtonLabel( item ) }
+			onButtonClick={ () => onClick( item ) }
+			features={ item.features }
+			originalPrice={ originalPrice }
+			discountedPrice={ discountedPrice }
+			withStartingPrice={ item.subtypes.length > 0 }
+			isOwned={ item.owned }
+			isDeprecated={ item.legacy }
+		/>
+	);
+};
+
+export default ProductCard;

--- a/client/my-sites/plans-v2/product-card/index.tsx
+++ b/client/my-sites/plans-v2/product-card/index.tsx
@@ -36,9 +36,10 @@ interface ProductCardProps {
 	item: SelectorProduct;
 	onClick: PurchaseCallback;
 	currencyCode: string;
+	className?: string;
 }
 
-const ProductCard = ( { item, onClick, currencyCode }: ProductCardProps ) => {
+const ProductCard = ( { item, onClick, currencyCode, className }: ProductCardProps ) => {
 	const isFetchingPrices = useSelector( ( state ) => isProductsListFetching( state ) );
 	const itemCost = useSelector( ( state ) =>
 		getProductCost( state, item.costProductSlug || item.productSlug )
@@ -74,6 +75,7 @@ const ProductCard = ( { item, onClick, currencyCode }: ProductCardProps ) => {
 			withStartingPrice={ item.subtypes.length > 0 }
 			isOwned={ item.owned }
 			isDeprecated={ item.legacy }
+			className={ className }
 		/>
 	);
 };

--- a/client/my-sites/plans-v2/product-card/index.tsx
+++ b/client/my-sites/plans-v2/product-card/index.tsx
@@ -16,7 +16,7 @@ import {
 	slugToSelectorProduct,
 	productBadgeLabel,
 } from '../utils';
-import RenewalNotice from '../plan-renewal-notice';
+import PlanRenewalMessage from '../plan-renewal-message';
 import { getPurchaseByProductSlug } from 'lib/purchases/utils';
 import { isProductsListFetching } from 'state/products-list/selectors/is-products-list-fetching';
 import { getProductCost } from 'state/products-list/selectors/get-product-cost';
@@ -155,7 +155,11 @@ const ProductCardWrapper = ( {
 			productName={ item.displayName }
 			subheadline={ item.tagline }
 			description={
-				showExpiryNotice && purchase ? <RenewalNotice purchase={ purchase } /> : item.description
+				showExpiryNotice && purchase ? (
+					<PlanRenewalMessage purchase={ purchase } />
+				) : (
+					item.description
+				)
 			}
 			currencyCode={ currencyCode }
 			billingTimeFrame={ durationToText( item.term ) }

--- a/client/my-sites/plans-v2/product-card/index.tsx
+++ b/client/my-sites/plans-v2/product-card/index.tsx
@@ -147,7 +147,7 @@ const ProductCardWrapper = ( {
 			billingTimeFrame={ durationToText( item.term ) }
 			buttonLabel={ productButtonLabel( item, isOwned ) }
 			badgeLabel={ productBadgeLabel( item, isOwned, sitePlan ) }
-			onButtonClick={ () => onClick( item ) }
+			onButtonClick={ () => onClick( item, isOwned ) }
 			features={ item.features }
 			originalPrice={ originalPrice }
 			discountedPrice={ discountedPrice }

--- a/client/my-sites/plans-v2/products-column/index.tsx
+++ b/client/my-sites/plans-v2/products-column/index.tsx
@@ -26,7 +26,12 @@ interface ProductsColumnType {
 	siteId: number | null;
 }
 
-const ProductsColumn = ( { duration, onProductClick, productType }: ProductsColumnType ) => {
+const ProductsColumn = ( {
+	duration,
+	onProductClick,
+	productType,
+	siteId,
+}: ProductsColumnType ) => {
 	const currencyCode = useSelector( ( state ) => getCurrentUserCurrencyCode( state ) );
 
 	// Gets all products in an array to be parsed.
@@ -54,8 +59,9 @@ const ProductsColumn = ( { duration, onProductClick, productType }: ProductsColu
 			{ productObjects.map( ( product ) => (
 				<ProductCard
 					key={ product.productSlug }
-					onClick={ onProductClick }
 					item={ product }
+					onClick={ onProductClick }
+					siteId={ siteId }
 					currencyCode={ currencyCode }
 				/>
 			) ) }

--- a/client/my-sites/plans-v2/products-column/index.tsx
+++ b/client/my-sites/plans-v2/products-column/index.tsx
@@ -8,20 +8,10 @@ import { useSelector } from 'react-redux';
 /**
  * Internal dependencies
  */
-import {
-	durationToText,
-	slugToItem,
-	itemToSelectorProduct,
-	productButtonLabel,
-	productBadgeLabel,
-	getProductPrices,
-} from '../utils';
+import { slugToSelectorProduct } from '../utils';
 import { PRODUCTS_TYPES, SELECTOR_PRODUCTS } from '../constants';
-import { isProductsListFetching, getAvailableProductsList } from 'state/products-list/selectors';
+import ProductCard from '../product-card';
 import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
-import getSitePlan from 'state/sites/selectors/get-site-plan';
-import getSiteProducts from 'state/sites/selectors/get-site-products';
-import JetpackProductCard from 'components/jetpack/card/jetpack-product-card';
 import FormattedHeader from 'components/formatted-header';
 
 /**
@@ -36,75 +26,25 @@ interface ProductsColumnType {
 	siteId: number | null;
 }
 
-const ProductComponent = ( {
-	product,
-	currentPlan,
-	onClick,
-	currencyCode,
-}: {
-	product: SelectorProduct;
-	currentPlan: string | null;
-	onClick: PurchaseCallback;
-	currencyCode: string;
-} ) => (
-	<JetpackProductCard
-		iconSlug={ product.iconSlug }
-		productName={ product.displayName }
-		subheadline={ product.tagline }
-		description={ product.description }
-		currencyCode={ currencyCode }
-		billingTimeFrame={ durationToText( product.term ) }
-		badgeLabel={ productBadgeLabel( product, currentPlan ) }
-		buttonLabel={ productButtonLabel( product ) }
-		onButtonClick={ () => onClick( product ) }
-		features={ { items: [] } }
-		discountedPrice={ product.discountCost }
-		originalPrice={ product.cost || 0 }
-		withStartingPrice={ product.subtypes && product.subtypes.length > 0 }
-		isOwned={ product.owned }
-	/>
-);
-
-const ProductsColumn = ( {
-	duration,
-	onProductClick,
-	productType,
-	siteId,
-}: ProductsColumnType ) => {
+const ProductsColumn = ( { duration, onProductClick, productType }: ProductsColumnType ) => {
 	const currencyCode = useSelector( ( state ) => getCurrentUserCurrencyCode( state ) );
-	const isFetchingProducts = useSelector( ( state ) => isProductsListFetching( state ) );
-	const availableProducts = useSelector( ( state ) => getAvailableProductsList( state ) );
-	const currentProducts = (
-		useSelector( ( state ) => getSiteProducts( state, siteId ) ) || []
-	).map( ( product ) => product.productSlug );
-	const currentPlan =
-		useSelector( ( state ) => getSitePlan( state, siteId ) )?.product_slug || null;
 
 	// Gets all products in an array to be parsed.
 	const productObjects: SelectorProduct[] = useMemo(
 		() =>
 			// Convert product slugs to ProductSelector types.
-			SELECTOR_PRODUCTS.map( ( productSlug ) => {
-				const item = slugToItem( productSlug );
-				return item && itemToSelectorProduct( item );
-			} )
+			SELECTOR_PRODUCTS.map( slugToSelectorProduct )
 				// Remove products that don't fit the filters or have invalid data.
 				.filter(
 					( product: SelectorProduct | null ): product is SelectorProduct =>
 						!! product &&
 						duration === product.term &&
 						PRODUCTS_TYPES[ productType ].includes( product.productSlug )
-				)
-				// Insert product prices as well as whether they are owned already.
-				.map( ( product: SelectorProduct ) => ( {
-					...product,
-					...getProductPrices( product, availableProducts ),
-					owned: currentProducts.includes( product.productSlug ),
-				} ) ),
-		[ duration, productType, currentProducts, availableProducts ]
+				),
+		[ duration, productType ]
 	);
 
-	if ( ! currencyCode || isFetchingProducts ) {
+	if ( ! currencyCode ) {
 		return null; // TODO: Loading component!
 	}
 
@@ -112,11 +52,10 @@ const ProductsColumn = ( {
 		<div className="plans-column products-column">
 			<FormattedHeader headerText={ translate( 'Individual Products' ) } brandFont />
 			{ productObjects.map( ( product ) => (
-				<ProductComponent
+				<ProductCard
 					key={ product.productSlug }
 					onClick={ onProductClick }
-					product={ product }
-					currentPlan={ currentPlan }
+					item={ product }
 					currencyCode={ currencyCode }
 				/>
 			) ) }

--- a/client/my-sites/plans-v2/selector.tsx
+++ b/client/my-sites/plans-v2/selector.tsx
@@ -41,10 +41,10 @@ const SelectorPage = ( { defaultDuration = TERM_ANNUALLY, rootUrl }: SelectorPag
 	const [ currentDuration, setDuration ] = useState< Duration >( defaultDuration );
 
 	// Sends a user to a page based on whether there are subtypes.
-	const selectProduct: PurchaseCallback = ( product: SelectorProduct, isOwned = false ) => {
+	const selectProduct: PurchaseCallback = ( product: SelectorProduct, purchase ) => {
 		const root = rootUrl.replace( ':site', siteSlug );
-		if ( isOwned ) {
-			page( managePurchase( siteSlug, 0 ) ); // TODO: Get purchase once #44942 is merged.
+		if ( purchase ) {
+			page( managePurchase( siteSlug, purchase.id ) );
 			return;
 		}
 		const durationString = durationToString( currentDuration );

--- a/client/my-sites/plans-v2/selector.tsx
+++ b/client/my-sites/plans-v2/selector.tsx
@@ -15,8 +15,10 @@ import { SECURITY } from './constants';
 import { durationToString } from './utils';
 import { TERM_ANNUALLY } from 'lib/plans/constants';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
+import { managePurchase } from 'me/purchases/paths';
 import Main from 'components/main';
 import QueryProductsList from 'components/data/query-products-list';
+import QuerySitePurchases from 'components/data/query-site-purchases';
 import QuerySites from 'components/data/query-sites';
 
 /**
@@ -39,9 +41,13 @@ const SelectorPage = ( { defaultDuration = TERM_ANNUALLY, rootUrl }: SelectorPag
 	const [ currentDuration, setDuration ] = useState< Duration >( defaultDuration );
 
 	// Sends a user to a page based on whether there are subtypes.
-	const selectProduct: PurchaseCallback = ( product: SelectorProduct ) => {
-		const durationString = durationToString( currentDuration );
+	const selectProduct: PurchaseCallback = ( product: SelectorProduct, isOwned = false ) => {
 		const root = rootUrl.replace( ':site', siteSlug );
+		if ( isOwned ) {
+			page( managePurchase( siteSlug, 0 ) ); // TODO: Get purchase once #44942 is merged.
+			return;
+		}
+		const durationString = durationToString( currentDuration );
 		if ( product.subtypes.length ) {
 			page( `${ root }/${ product.productSlug }/${ durationString }/details` );
 		} else {
@@ -72,6 +78,7 @@ const SelectorPage = ( { defaultDuration = TERM_ANNUALLY, rootUrl }: SelectorPag
 				/>
 			</div>
 			<QueryProductsList />
+			{ siteId && <QuerySitePurchases siteId={ siteId } /> }
 			{ siteId && <QuerySites siteId={ siteId } /> }
 		</Main>
 	);

--- a/client/my-sites/plans-v2/types.ts
+++ b/client/my-sites/plans-v2/types.ts
@@ -14,6 +14,7 @@ import type {
 	ITEM_TYPE_BUNDLE,
 	ITEM_TYPE_PRODUCT,
 } from './constants';
+import type { Features } from 'components/jetpack/card/jetpack-product-card/types';
 
 export type Duration = typeof TERM_ANNUALLY | typeof TERM_MONTHLY;
 export type DurationString = 'annual' | 'monthly';
@@ -44,6 +45,7 @@ export type SelectorProductSlug = typeof PRODUCTS_WITH_OPTIONS[ number ];
 export type SelectorProductCost = {
 	cost?: number;
 	discountCost?: number;
+	loadingCost?: boolean;
 };
 
 export interface SelectorProduct extends SelectorProductCost {
@@ -57,7 +59,7 @@ export interface SelectorProduct extends SelectorProductCost {
 	description: TranslateResult | ReactNode;
 	term: Duration;
 	buttonLabel?: TranslateResult;
-	features: string[];
+	features: Features;
 	subtypes: string[];
 	owned?: boolean;
 	legacy?: boolean;

--- a/client/my-sites/plans-v2/types.ts
+++ b/client/my-sites/plans-v2/types.ts
@@ -20,7 +20,7 @@ export type Duration = typeof TERM_ANNUALLY | typeof TERM_MONTHLY;
 export type DurationString = 'annual' | 'monthly';
 export type ProductType = typeof ALL | typeof PERFORMANCE | typeof SECURITY;
 export type ItemType = typeof ITEM_TYPE_PLAN | typeof ITEM_TYPE_BUNDLE | typeof ITEM_TYPE_PRODUCT;
-export type PurchaseCallback = ( arg0: SelectorProduct ) => void;
+export type PurchaseCallback = ( arg0: SelectorProduct, arg1?: boolean ) => void;
 
 interface BasePageProps {
 	rootUrl: string;

--- a/client/my-sites/plans-v2/types.ts
+++ b/client/my-sites/plans-v2/types.ts
@@ -1,18 +1,24 @@
-/**
- * Internal dependencies
- */
-import { ALL, PERFORMANCE, SECURITY, PRODUCTS_WITH_OPTIONS } from './constants';
-
+/* eslint-disable wpcalypso/import-docblock */
 /**
  * Type dependencies
  */
 import type { TranslateResult } from 'i18n-calypso';
 import type { ReactNode } from 'react';
 import type { TERM_ANNUALLY, TERM_MONTHLY } from 'lib/plans/constants';
+import type {
+	ALL,
+	PERFORMANCE,
+	SECURITY,
+	PRODUCTS_WITH_OPTIONS,
+	ITEM_TYPE_PLAN,
+	ITEM_TYPE_BUNDLE,
+	ITEM_TYPE_PRODUCT,
+} from './constants';
 
 export type Duration = typeof TERM_ANNUALLY | typeof TERM_MONTHLY;
 export type DurationString = 'annual' | 'monthly';
 export type ProductType = typeof ALL | typeof PERFORMANCE | typeof SECURITY;
+export type ItemType = typeof ITEM_TYPE_PLAN | typeof ITEM_TYPE_BUNDLE | typeof ITEM_TYPE_PRODUCT;
 export type PurchaseCallback = ( arg0: SelectorProduct ) => void;
 
 interface BasePageProps {
@@ -43,6 +49,7 @@ export type SelectorProductCost = {
 export interface SelectorProduct extends SelectorProductCost {
 	productSlug: string;
 	iconSlug: string;
+	type: ItemType;
 	costProductSlug?: string;
 	monthlyProductSlug?: string;
 	displayName: TranslateResult;

--- a/client/my-sites/plans-v2/types.ts
+++ b/client/my-sites/plans-v2/types.ts
@@ -5,6 +5,7 @@
 import type { TranslateResult } from 'i18n-calypso';
 import type { ReactNode } from 'react';
 import type { TERM_ANNUALLY, TERM_MONTHLY } from 'lib/plans/constants';
+import type { Purchase } from 'lib/purchases/types';
 import type {
 	ALL,
 	PERFORMANCE,
@@ -20,7 +21,7 @@ export type Duration = typeof TERM_ANNUALLY | typeof TERM_MONTHLY;
 export type DurationString = 'annual' | 'monthly';
 export type ProductType = typeof ALL | typeof PERFORMANCE | typeof SECURITY;
 export type ItemType = typeof ITEM_TYPE_PLAN | typeof ITEM_TYPE_BUNDLE | typeof ITEM_TYPE_PRODUCT;
-export type PurchaseCallback = ( arg0: SelectorProduct, arg1?: boolean ) => void;
+export type PurchaseCallback = ( arg0: SelectorProduct, arg1?: Purchase ) => void;
 
 interface BasePageProps {
 	rootUrl: string;

--- a/client/my-sites/plans-v2/types.ts
+++ b/client/my-sites/plans-v2/types.ts
@@ -61,7 +61,6 @@ export interface SelectorProduct extends SelectorProductCost {
 	buttonLabel?: TranslateResult;
 	features: Features;
 	subtypes: string[];
-	owned?: boolean;
 	legacy?: boolean;
 }
 

--- a/client/my-sites/plans-v2/use-item-price.ts
+++ b/client/my-sites/plans-v2/use-item-price.ts
@@ -1,0 +1,55 @@
+/**
+ * External dependencies
+ */
+import { useSelector } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { isProductsListFetching } from 'state/products-list/selectors/is-products-list-fetching';
+import { getProductCost } from 'state/products-list/selectors/get-product-cost';
+import { TERM_MONTHLY } from 'lib/plans/constants';
+
+/**
+ * Type dependencies
+ */
+import type { SelectorProduct } from './types';
+
+interface ItemPrices {
+	isFetching: boolean;
+	originalPrice: number;
+	discountedPrice?: number;
+}
+
+const useItemPrice = ( item: SelectorProduct | null, monthlyItemSlug = '' ): ItemPrices => {
+	const isFetching = useSelector( ( state ) => !! isProductsListFetching( state ) );
+	const itemCost = useSelector(
+		( state ) => item && getProductCost( state, item.costProductSlug || item.productSlug )
+	);
+	const monthlyItemCost = useSelector( ( state ) => getProductCost( state, monthlyItemSlug ) );
+
+	if ( isFetching ) {
+		return {
+			isFetching,
+			originalPrice: 0,
+		};
+	}
+
+	let originalPrice = 0;
+	let discountedPrice = undefined;
+	if ( item && itemCost ) {
+		originalPrice = itemCost;
+		if ( monthlyItemCost && item.term !== TERM_MONTHLY ) {
+			originalPrice = monthlyItemCost * 12;
+			discountedPrice = itemCost;
+		}
+	}
+
+	return {
+		isFetching,
+		originalPrice,
+		discountedPrice,
+	};
+};
+
+export default useItemPrice;

--- a/client/my-sites/plans-v2/utils.ts
+++ b/client/my-sites/plans-v2/utils.ts
@@ -36,13 +36,9 @@ import { getJetpackProductShortName } from 'lib/products-values/get-jetpack-prod
  * Type dependencies
  */
 import type { Duration, SelectorProduct, SelectorProductSlug, DurationString } from './types';
-import type {
-	JetpackDailyPlan,
-	JetpackRealtimePlan,
-	JetpackPlanSlugs,
-	Plan,
-} from 'lib/plans/types';
+import type { JetpackRealtimePlan, JetpackPlanSlugs, Plan } from 'lib/plans/types';
 import type { JetpackProductSlug } from 'lib/products-values/types';
+import type { SitePlan } from 'state/sites/selectors/get-site-plan';
 
 /**
  * Duration utils.
@@ -76,11 +72,11 @@ export function durationToText( duration: Duration ): TranslateResult {
  * Product UI utils.
  */
 
-export function productButtonLabel( product: SelectorProduct ): TranslateResult {
-	if ( product.owned ) {
-		return slugIsJetpackPlanSlug( product.productSlug )
-			? translate( 'Manage plan' )
-			: translate( 'Manage subscription' );
+export function productButtonLabel( product: SelectorProduct, isOwned: boolean ): TranslateResult {
+	if ( isOwned ) {
+		return product.type !== ITEM_TYPE_PRODUCT
+			? translate( 'Manage Plan' )
+			: translate( 'Manage Subscription' );
 	}
 
 	return (
@@ -94,9 +90,10 @@ export function productButtonLabel( product: SelectorProduct ): TranslateResult 
 
 export function productBadgeLabel(
 	product: SelectorProduct,
-	currentPlan?: string | null
+	isOwned: boolean,
+	currentPlan?: SitePlan | null
 ): TranslateResult | undefined {
-	if ( product.owned ) {
+	if ( isOwned ) {
 		return slugIsJetpackPlanSlug( product.productSlug )
 			? translate( 'Your plan' )
 			: translate( 'You own this' );
@@ -245,7 +242,7 @@ export function slugToSelectorProduct( slug: string ): SelectorProduct | null {
  * @param slug string
  * @returns string | null
  */
-export function getRealtimeFromDaily( slug: JetpackDailyPlan ): JetpackRealtimePlan | null {
+export function getRealtimeFromDaily( slug: string ): JetpackRealtimePlan | null {
 	return DAILY_PLAN_TO_REALTIME_PLAN[ slug ];
 }
 

--- a/client/my-sites/plans-v2/utils.ts
+++ b/client/my-sites/plans-v2/utils.ts
@@ -35,14 +35,7 @@ import { getJetpackProductShortName } from 'lib/products-values/get-jetpack-prod
 /**
  * Type dependencies
  */
-import type {
-	Duration,
-	SelectorProduct,
-	SelectorProductSlug,
-	AvailableProductData,
-	SelectorProductCost,
-	DurationString,
-} from './types';
+import type { Duration, SelectorProduct, SelectorProductSlug, DurationString } from './types';
 import type {
 	JetpackDailyPlan,
 	JetpackRealtimePlan,
@@ -112,25 +105,6 @@ export function productBadgeLabel(
 	if ( currentPlan && planHasFeature( currentPlan, product.productSlug ) ) {
 		return translate( 'Included in your plan' );
 	}
-}
-
-export function getProductPrices(
-	product: SelectorProduct,
-	availableProducts: Record< string, AvailableProductData >
-): SelectorProductCost {
-	const availableProduct = availableProducts[ product.costProductSlug || product.productSlug ];
-	// Return if not annual price.
-	if ( product.term !== TERM_ANNUALLY || ! availableProduct || ! product.monthlyProductSlug ) {
-		return {
-			cost: get( availableProduct, 'cost', 0 ),
-		};
-	}
-
-	const relatedAvailableProduct = availableProducts[ product.monthlyProductSlug ];
-	return {
-		discountCost: get( availableProduct, 'cost', 0 ),
-		cost: get( relatedAvailableProduct, 'cost', 0 ) * 12,
-	};
 }
 
 /**
@@ -276,7 +250,7 @@ export function getRealtimeFromDaily( slug: JetpackDailyPlan ): JetpackRealtimeP
 }
 
 /**
- * Returns wheter an item is upgradeable by a nudge.
+ * Returns whether an item is upgradeable by a nudge.
  *
  * @param slug string
  * @returns boolean | null

--- a/client/my-sites/plans-v2/utils.ts
+++ b/client/my-sites/plans-v2/utils.ts
@@ -223,7 +223,7 @@ export function itemToSelectorProduct(
 				comment: '%s is the name of a product',
 			} ),
 			term: item.term,
-			features: [],
+			features: { items: [] },
 		};
 	} else if ( objectIsPlan( item ) ) {
 		const productSlug = item.getStoreSlug();
@@ -231,7 +231,8 @@ export function itemToSelectorProduct(
 		if ( item.term === TERM_ANNUALLY ) {
 			monthlyProductSlug = getMonthlyPlanByYearly( productSlug );
 		}
-		const iconAppend = JETPACK_RESET_PLANS.includes( productSlug ) ? '_v2' : '';
+		const isResetPlan = JETPACK_RESET_PLANS.includes( productSlug );
+		const iconAppend = isResetPlan ? '_v2' : '';
 		const type = JETPACK_SECURITY_PLANS.includes( productSlug ) ? ITEM_TYPE_BUNDLE : ITEM_TYPE_PLAN;
 		return {
 			productSlug,
@@ -243,7 +244,8 @@ export function itemToSelectorProduct(
 			description: item.getDescription(),
 			monthlyProductSlug,
 			term: item.term === TERM_BIENNIALLY ? TERM_ANNUALLY : item.term,
-			features: [],
+			features: { items: [] },
+			legacy: ! isResetPlan,
 		};
 	}
 	return null;

--- a/client/my-sites/plans-v2/utils.ts
+++ b/client/my-sites/plans-v2/utils.ts
@@ -12,6 +12,9 @@ import {
 	PRODUCTS_WITH_OPTIONS,
 	OPTIONS_SLUG_MAP,
 	UPGRADEABLE_WITH_NUDGE,
+	ITEM_TYPE_PRODUCT,
+	ITEM_TYPE_BUNDLE,
+	ITEM_TYPE_PLAN,
 } from './constants';
 import {
 	TERM_ANNUALLY,
@@ -19,6 +22,7 @@ import {
 	TERM_BIENNIALLY,
 	JETPACK_LEGACY_PLANS,
 	JETPACK_RESET_PLANS,
+	JETPACK_SECURITY_PLANS,
 } from 'lib/plans/constants';
 import { getPlan, getMonthlyPlanByYearly, planHasFeature } from 'lib/plans';
 import { JETPACK_PRODUCT_PRICE_MATRIX } from 'lib/products-values/constants';
@@ -209,6 +213,8 @@ export function itemToSelectorProduct(
 			productSlug: item.product_slug,
 			iconSlug: `${ item.product_slug }_v2`,
 			displayName: getJetpackProductDisplayName( item ),
+			type: ITEM_TYPE_PRODUCT,
+			subtypes: [],
 			tagline: getJetpackProductTagline( item ),
 			description: getJetpackProductDescription( item ),
 			monthlyProductSlug,
@@ -218,7 +224,6 @@ export function itemToSelectorProduct(
 			} ),
 			term: item.term,
 			features: [],
-			subtypes: [],
 		};
 	} else if ( objectIsPlan( item ) ) {
 		const productSlug = item.getStoreSlug();
@@ -227,16 +232,18 @@ export function itemToSelectorProduct(
 			monthlyProductSlug = getMonthlyPlanByYearly( productSlug );
 		}
 		const iconAppend = JETPACK_RESET_PLANS.includes( productSlug ) ? '_v2' : '';
+		const type = JETPACK_SECURITY_PLANS.includes( productSlug ) ? ITEM_TYPE_BUNDLE : ITEM_TYPE_PLAN;
 		return {
 			productSlug,
 			iconSlug: productSlug + iconAppend,
 			displayName: item.getTitle(),
+			type,
+			subtypes: [],
 			tagline: get( item, 'getTagline', () => '' )(),
 			description: item.getDescription(),
 			monthlyProductSlug,
 			term: item.term === TERM_BIENNIALLY ? TERM_ANNUALLY : item.term,
 			features: [],
-			subtypes: [],
 		};
 	}
 	return null;

--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -73,8 +73,9 @@ export function redirectToPlans( context ) {
 	return page.redirect( '/plans' );
 }
 
-export function redirectToPlansIfNotJetpack( context ) {
+export function redirectToPlansIfNotJetpack( context, next ) {
 	if ( ! showJetpackPlans( context ) ) {
 		page.redirect( `/plans/${ context.params.site }` );
 	}
+	next();
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This extracts repeated code for wiring `SelectorProduct` data to cards into a new component, `ProductCard`.
* Logic around whether a given item is owned is extracted into the new component.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Code review.
* Do regression testing on the new plans page.

Fixes 1169247016322522-as-1188698065630107