### PR TITLE
Site Settings: Add Instant Search toggle for WPCOM sites

### DIFF
--- a/client/my-sites/site-settings/search.jsx
+++ b/client/my-sites/site-settings/search.jsx
@@ -126,8 +126,23 @@ class Search extends Component {
 				>
 					{ translate( 'Replace WordPress built-in search with an improved search experience' ) }
 				</CompactFormToggle>
-
 				{ this.renderSettingsContent( isSavingSettings, fields.jetpack_search_enabled ) }
+
+				<div className="site-settings__jetpack-instant-search-toggle">
+					<CompactFormToggle
+						checked={ !! fields.instant_search_enabled }
+						disabled={
+							isRequestingSettings ||
+							isSavingSettings ||
+							! fields.jetpack_search_enabled ||
+							! this.props.hasSearchProduct
+						}
+						onChange={ handleAutosavingToggle( 'instant_search_enabled' ) }
+					>
+						{ translate( 'Enable instant search experience (recommended)' ) }
+					</CompactFormToggle>
+					{ this.renderInstantSearchExplanation() }
+				</div>
 			</FormFieldset>
 		);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adds an Instant Search toggle for WordPress.com sites, requires D48122-code.

> Before
> <img width="733" alt="Screen Shot 2020-08-13 at 3 34 01 PM" src="https://user-images.githubusercontent.com/4044428/90189496-87a97600-dd7a-11ea-8a94-a6aea5a429a1.png">


> After
> <img width="733" alt="Screen Shot 2020-08-13 at 3 34 10 PM" src="https://user-images.githubusercontent.com/4044428/90189504-8b3cfd00-dd7a-11ea-8584-4d1abfa2b204.png">


#### Testing instructions

1. Navigate to `/settings/performance/:siteSlug`, where :siteSlug corresponds to a WordPress.com site.
2. Ensure that you see a toggle for Instant Search that reads `Enable instant search experience (recommended)`.
3. Repeat step 1, but for a Jetpack connected site. 
4. Ensure that the Instant Search toggle is still there.