### PR TITLE
Gutenboarding domains: view more results button

### DIFF
--- a/package.json
+++ b/package.json
@@ -215,7 +215,7 @@
 		"@types/wordpress__api-fetch": "^3.2.2",
 		"@types/wordpress__block-editor": "^2.2.8",
 		"@types/wordpress__block-library": "^2.6.0",
-		"@types/wordpress__components": "^8.5.4",
+		"@types/wordpress__components": "^9.0.0",
 		"@types/wordpress__compose": "^3.4.2",
 		"@types/wordpress__data": "^4.6.7",
 		"@types/wordpress__data-controls": "^1.0.3",

--- a/packages/domain-picker/src/domain-picker/index.tsx
+++ b/packages/domain-picker/src/domain-picker/index.tsx
@@ -258,7 +258,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 							allDomainSuggestions?.length &&
 							allDomainSuggestions?.length > quantity && (
 								<div className="domain-picker__show-more">
-									<Button onClick={ () => setIsExpanded( true ) } isSecondary>
+									<Button onClick={ () => setIsExpanded( true ) } isLink>
 										{ __( 'View more results' ) }
 									</Button>
 								</div>

--- a/packages/domain-picker/src/domain-picker/index.tsx
+++ b/packages/domain-picker/src/domain-picker/index.tsx
@@ -258,7 +258,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 							allDomainSuggestions?.length &&
 							allDomainSuggestions?.length > quantity && (
 								<div className="domain-picker__show-more">
-									<Button onClick={ () => setIsExpanded( true ) }>
+									<Button onClick={ () => setIsExpanded( true ) } isSecondary>
 										{ __( 'View more results' ) }
 									</Button>
 								</div>

--- a/packages/domain-picker/src/domain-picker/style.scss
+++ b/packages/domain-picker/src/domain-picker/style.scss
@@ -9,7 +9,7 @@
 
 	&--text {
 		max-width: 320px;
-		font-size: 0.9em;
+		font-size: $font-body-small;
 		margin: 10px 0;
 		color: $dark-gray-500;
 	}
@@ -19,13 +19,13 @@
 		align-items: center;
 
 		&--text {
-			margin: 15px 0;
+			margin: 15px 10px;
 		}
 	}
 }
 
 .domain-picker__show-more {
-	padding: 10px;
+	margin-top: 20px;
 	text-align: center;
 }
 
@@ -70,7 +70,7 @@
 	margin-bottom: 0.5em;
 	text-transform: uppercase;
 	color: var( --studio-gray-40 );
-	font-size: 12px;
+	font-size: $font-body-extra-small;
 	letter-spacing: 1px;
 	font-weight: bold;
 }
@@ -229,7 +229,8 @@
 	line-height: 20px;
 	height: 20px;
 	align-items: center;
-	font-size: 10px;
+	// stylelint-disable-next-line scales/font-size
+	font-size: 10px; //typography-exception smaller size needed
 	text-transform: uppercase;
 	vertical-align: middle;
 	background-color: var( --studio-blue-50 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -4186,10 +4186,10 @@
     "@types/wordpress__rich-text" "*"
     re-resizable "^4.7.1"
 
-"@types/wordpress__components@^8.5.4":
-  version "8.5.4"
-  resolved "https://registry.yarnpkg.com/@types/wordpress__components/-/wordpress__components-8.5.4.tgz#4583a3e07a1ff08c5745c991dc034fa07fced733"
-  integrity sha512-jjdR9zhOwj5EAVOdh/6z6qDDjHCANXLdmX4P0P01RAOIo3L5BMPJjEgo+xOZATCaLmZEufOHqN9tbPGLgYXj1Q==
+"@types/wordpress__components@^9.0.0":
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/@types/wordpress__components/-/wordpress__components-9.0.0.tgz#51988818f6c4aa8abb5fadd39f9f5ac1ede7ed43"
+  integrity sha512-bYTEGINPQcAJ6/dABZQXBZfPrLz3T4+B8sVopFiT99qMxOR0Mt8x3VsdaFUxh/ArLjI8bgf1uBYzvx/PSQpjSA==
   dependencies:
     "@types/react" "*"
     "@types/wordpress__components" "*"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change "View more results" to a button in Gutenboarding, based on Rick's feedback at pbAok1-1lr-p2#comment-2734

These are just core component styles and you can see we've modified them to be grey-bordered at some places, which makes the default button style look a bit out of place.

### Before
<img width="970" alt="Screenshot 2020-08-14 at 10 22 21" src="https://user-images.githubusercontent.com/87168/90224258-10c2ba80-de18-11ea-8d88-8a89c6cba0c5.png">

<img width="375" alt="Screenshot 2020-08-14 at 10 20 55" src="https://user-images.githubusercontent.com/87168/90224216-fee11780-de17-11ea-8754-749f7769f403.png">


### After
<img width="967" alt="Screenshot 2020-08-14 at 10 21 30" src="https://user-images.githubusercontent.com/87168/90224355-318b1000-de18-11ea-95fd-120a384a78a5.png">
<img width="379" alt="Screenshot 2020-08-14 at 10 20 37" src="https://user-images.githubusercontent.com/87168/90224359-351e9700-de18-11ea-8544-3e9025333164.png">


#### Testing instructions
* In `/new` flow, open button modal from header domain suggestion after entering the site name

