### PR TITLE
Gutenboarding: use color studio variables

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-steps/final-step/styles.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/editor-site-launch/src/launch-steps/final-step/styles.scss
@@ -34,8 +34,8 @@ ul.nux-launch__feature-item-group {
 
 	// the tick
 	svg path {
-		fill: rgb( 74, 161, 80 );
-		stroke: rgb( 74, 161, 80 );
+		fill: var( --studio-green-40 );
+		stroke: var( --studio-green-40 );
 	}
 }
 .nux-launch__submit-button.components-button.is-primary {

--- a/packages/plans-grid/src/plans-table/style.scss
+++ b/packages/plans-grid/src/plans-table/style.scss
@@ -206,10 +206,10 @@ ul.plan-item__feature-item-group {
 	}
 
 	svg:first-child path {
-		fill: rgb( 74, 161, 80 );
+		fill: var( --studio-green-40 );
 
 		// to make the tick thicker
-		stroke: rgb( 74, 161, 80 );
+		stroke: var( --studio-green-40 );
 	}
 }
 
@@ -234,8 +234,8 @@ ul.plan-item__feature-item-group {
 
 	// the tick
 	svg:first-child path {
-		fill: rgb( 74, 161, 80 );
-		stroke: rgb( 74, 161, 80 );
+		fill: var( --studio-green-40 );
+		stroke: var( --studio-green-40 );
 		margin-top: 5px;
 	}
 
@@ -250,11 +250,11 @@ ul.plan-item__feature-item-group {
 
 .plan-item__domain-summary.components-button.is-link.is-free {
 	font-weight: bold;
-	color: rgb( 206, 134, 61 );
+	color: var( --studio-orange-40 );
 	text-decoration: line-through; // the tick
 	svg path {
-		fill: rgb( 206, 134, 61 );
-		stroke: rgb( 206, 134, 61 );
+		fill: var( --studio-orange-40 );
+		stroke: var( --studio-orange-40 );
 	}
 }
 
@@ -306,8 +306,8 @@ ul.plan-item__feature-item-group {
 
 	// the tick
 	svg path {
-		fill: rgb( 74, 161, 80 );
-		stroke: rgb( 74, 161, 80 );
+		fill: var( --studio-green-40 );
+		stroke: var( --studio-green-40 );
 	}
 
 	.plan-item__disabled-message {
@@ -317,8 +317,8 @@ ul.plan-item__feature-item-group {
 			height: 18px;
 
 			path {
-				fill: rgb( 206, 134, 61 );
-				stroke: rgb( 206, 134, 61 );
+				fill: var( --studio-orange-40 );
+				stroke: var( --studio-orange-40 );
 			}
 		}
 
@@ -327,7 +327,7 @@ ul.plan-item__feature-item-group {
 			line-height: 20px;
 			letter-spacing: 0.2px;
 			font-weight: bold;
-			color: rgb( 206, 134, 61 );
+			color: var( --studio-orange-40 );
 		}
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Use green-40 and orange-40 color studio variables where needed.

#### Testing instructions
* Correct colors should appear for the cross / warning and checkmarks on Plans Grid and summary step of the Site setup flow.