### PR TITLE
PlansGrid: fix domain name overflowing from plan column

### DIFF
--- a/packages/plans-grid/src/plans-table/plan-item.tsx
+++ b/packages/plans-grid/src/plans-table/plan-item.tsx
@@ -3,10 +3,10 @@
  */
 import * as React from 'react';
 import classNames from 'classnames';
+import { createInterpolateElement } from '@wordpress/element';
 import { Button, Tip } from '@wordpress/components';
 import { Icon, check, close } from '@wordpress/icons';
 import { useViewportMatch } from '@wordpress/compose';
-import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@automattic/react-i18n';
 import type { DomainSuggestions } from '@automattic/data-stores';
 
@@ -69,14 +69,26 @@ function domainMessageStateMachine(
 			FREE_PLAN: {
 				className: 'plan-item__domain-summary is-free',
 				icon: CrossIcon,
-				// translators: %s is a domain name eg: example.com is not included
-				domainMessage: sprintf( __( '%s is not included' ), domain?.domain_name ),
+				// translators: <url /> is a domain name eg: example.com is not included
+				domainMessage: (
+					<span>
+						{ createInterpolateElement( __( '<url /> is not included' ), {
+							url: <span className="plan-item__url">{ domain?.domain_name }</span>,
+						} ) }
+					</span>
+				),
 			},
 			PAID_PLAN: {
 				className: 'plan-item__domain-summary is-picked',
 				icon: TickIcon,
-				// translators: %s is a domain name eg: example.com is included
-				domainMessage: sprintf( __( '%s is included' ), domain?.domain_name ),
+				// translators: <url /> is a domain name eg: example.com is included
+				domainMessage: (
+					<span>
+						{ createInterpolateElement( __( '<url /> is included' ), {
+							url: <span className="plan-item__url">{ domain?.domain_name }</span>,
+						} ) }
+					</span>
+				),
 			},
 		},
 	};

--- a/packages/plans-grid/src/plans-table/style.scss
+++ b/packages/plans-grid/src/plans-table/style.scss
@@ -195,6 +195,10 @@ ul.plan-item__feature-item-group {
 		padding: 0;
 	}
 
+	.plan-item__url {
+		word-break: break-all;
+	}
+
 	// the tick
 	svg:first-child {
 		// we use a margin because there is a space,


### PR DESCRIPTION
When included in the Site setup flow, the free sub-domain is displayed in the plan column instead of a static text and this cause it to overflow because of the length.

#### Changes proposed in this Pull Request
* Prevent longer domain name overflowing from a plan column.

#### Testing instructions
* When reaching the Plans step with a longer domain name selected, it should be wrapped at the end of the line.
* Everything else on the PlansGrid should stay the same. Static texts should be wrapped without breaking words.

#### Screenshots
**Before**
![Screenshot 2020-08-14 at 11 47 47](https://user-images.githubusercontent.com/14192054/90233873-710d2880-de27-11ea-85da-7212e9e948f2.png)

**After**
![Screenshot 2020-08-14 at 11 46 52](https://user-images.githubusercontent.com/14192054/90233899-7a969080-de27-11ea-8add-05141cbd0fe8.png)
