### PR TITLE
Remove unused prop passed to CardComponent in the plans page

### DIFF
--- a/client/my-sites/plans-v2/plans-column/index.tsx
+++ b/client/my-sites/plans-v2/plans-column/index.tsx
@@ -113,7 +113,6 @@ const PlanComponent = ( {
 			withStartingPrice={ plan.subtypes && plan.subtypes.length > 0 }
 			isOwned={ plan.owned }
 			isDeprecated={ plan.legacy }
-			deprecated={ plan.legacy }
 			UpgradeNudge={ plan.UpgradeNudge }
 		/>
 	);


### PR DESCRIPTION
### Changes proposed in this Pull Request

There was a deprecated prop (ironically, `deprecated`) passed to `CardComponent` in `client/my-sites/plans-v2/plans-column/index.tsx`. It must have been left here in a conflict solving.

### Testing instructions

Check in the code that `JetpackProductCard` doesn't take any `deprecated` prop anymore