### PR TITLE
Allow Brazil countryCode to access composite checkout

### DIFF
--- a/client/my-sites/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout-system-decider.js
@@ -171,8 +171,8 @@ function getCheckoutVariant( countryCode ) {
 		return 'composite-checkout';
 	}
 
-	// Disable for Brazil and India
-	if ( countryCode?.toLowerCase() === 'br' || countryCode?.toLowerCase() === 'in' ) {
+	// Disable for India
+	if ( countryCode?.toLowerCase() === 'in' ) {
 		debug(
 			'shouldShowCompositeCheckout false because country is not allowed',
 			countryCode?.toLowerCase()

--- a/client/my-sites/checkout/composite-checkout/payment-methods/ebanx-tef.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/ebanx-tef.js
@@ -323,8 +323,8 @@ function EbanxTefPayButton( { disabled, store } ) {
 						payload: { paymentMethodId: 'ebanx-tef' },
 					} );
 					submitTransaction( {
-						name: customerName?.value,
 						...massagedFields,
+						name: customerName?.value, // this needs to come after massagedFields to prevent it from being overridden
 						address: massagedFields?.address1,
 						tefBank: customerBank?.value,
 						items,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This removes the gating that prevented users with a Brazil country code to access new ("composite") checkout. The gating was in place because Brazil allows two payment methods that are unique: credit card processing through Ebanx and bank transfers with Ebanx-TEF. As those are both now implemented (see #44752 and #43812), it should now be possible to enable them.

Requires https://github.com/Automattic/wp-calypso/pull/44978 to be merged to fix the TEF method first!

#### Screenshots

![Screen Shot 2020-08-14 at 12 01 53 PM](https://user-images.githubusercontent.com/2036909/90269197-3eaefb80-de26-11ea-84eb-27a03bb0e275.png)


#### Testing instructions

- First you'll need to convince checkout that your country code is 'BR'. You can do this with a VPN or by sandboxing the API and applying the backend patch D48147-code.
- Set your currency to BRL.
- Visit checkout and verify that you see new checkout.
- When choosing your country, select "Brazil".
- Verify that when you get to the payment method step and select "Credit card" you see additional contact details fields.
- Verify that "Transferência bancária" is a payment method option.
- Test completing a purchase with a new credit card and with Transferência bancária.