### PR TITLE
Composite checkout: clean up useShoppingCartManager props and types

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -395,6 +395,7 @@ export default function CompositeCheckout( {
 		storedCards,
 		siteSlug,
 	} );
+	debug( 'created payment method objects', paymentMethodObjects );
 
 	// Once we pass paymentMethods into CompositeCheckout, we should try to avoid
 	// changing them because it can cause awkward UX. Here we try to wait for
@@ -417,6 +418,7 @@ export default function CompositeCheckout( {
 				allowedPaymentMethods,
 				serverAllowedPaymentMethods,
 		  } );
+	debug( 'filtered payment method objects', paymentMethods );
 
 	const getItemVariants = useProductVariants( {
 		siteId,
@@ -527,6 +529,18 @@ export default function CompositeCheckout( {
 		: {};
 	const theme = { ...checkoutTheme, colors: { ...checkoutTheme.colors, ...jetpackColors } };
 
+	const isLoading =
+		isLoadingCart || isLoadingStoredCards || paymentMethods.length < 1 || items.length < 1;
+	if ( isLoading ) {
+		debug( 'still loading because one of these is true', {
+			isLoadingCart,
+			isLoadingStoredCards,
+			paymentMethods: paymentMethods.length < 1,
+			arePaymentMethodsLoading: arePaymentMethodsLoading,
+			items: items.length < 1,
+		} );
+	}
+
 	return (
 		<React.Fragment>
 			<QuerySitePlans siteId={ siteId } />
@@ -547,9 +561,7 @@ export default function CompositeCheckout( {
 					paymentMethods={ paymentMethods }
 					paymentProcessors={ paymentProcessors }
 					registry={ defaultRegistry }
-					isLoading={
-						isLoadingCart || isLoadingStoredCards || paymentMethods.length < 1 || items.length < 1
-					}
+					isLoading={ isLoading }
 					isValidating={ isCartPendingUpdate }
 					theme={ theme }
 				>

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -201,8 +201,8 @@ export default function CompositeCheckout( {
 	} = useShoppingCartManager( {
 		cartKey: isLoggedOutCart || isNoSiteCart ? siteSlug : siteId,
 		canInitializeCart: canInitializeCart && ! isLoadingCartSynchronizer && ! isFetchingProducts,
-		productsToAdd: productsForCart,
-		couponToAdd: couponCodeFromUrl,
+		productsToAddOnInitialize: productsForCart,
+		couponToAddOnInitialize: couponCodeFromUrl,
 		setCart: setCart || wpcomSetCart,
 		getCart: getCart || wpcomGetCart,
 		onEvent: recordEvent,

--- a/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/index.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/index.ts
@@ -31,7 +31,7 @@ export default function useShoppingCartManager( {
 	getCart,
 	onEvent,
 }: ShoppingCartManagerArguments ): ShoppingCartManager {
-	const cartKeyString: string = cartKey || 'no-site';
+	const cartKeyString = String( cartKey || 'no-site' );
 	const setServerCart = useCallback( ( cartParam ) => setCart( cartKeyString, cartParam ), [
 		cartKeyString,
 		setCart,
@@ -43,7 +43,7 @@ export default function useShoppingCartManager( {
 	const responseCart: ResponseCart = hookState.responseCart;
 	const couponStatus: CouponStatus = hookState.couponStatus;
 	const cacheStatus: CacheStatus = hookState.cacheStatus;
-	const loadingError: string = hookState.loadingError;
+	const loadingError: string | undefined = hookState.loadingError;
 	const variantRequestStatus: VariantRequestStatus = hookState.variantRequestStatus;
 	const variantSelectOverride = hookState.variantSelectOverride;
 

--- a/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/index.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/index.ts
@@ -25,8 +25,8 @@ import useCartUpdateAndRevalidate from './use-cart-update-and-revalidate';
 export default function useShoppingCartManager( {
 	cartKey,
 	canInitializeCart,
-	productsToAdd,
-	couponToAdd,
+	productsToAddOnInitialize,
+	couponToAddOnInitialize,
 	setCart,
 	getCart,
 	onEvent,
@@ -51,8 +51,8 @@ export default function useShoppingCartManager( {
 	useInitializeCartFromServer(
 		cacheStatus,
 		canInitializeCart,
-		productsToAdd,
-		couponToAdd,
+		productsToAddOnInitialize,
+		couponToAddOnInitialize,
 		getServerCart,
 		setServerCart,
 		hookDispatch,

--- a/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/types.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/types.ts
@@ -13,8 +13,8 @@ export type ReactStandardAction = { type: string; payload?: any }; // eslint-dis
 export interface ShoppingCartManagerArguments {
 	cartKey: string | number | null;
 	canInitializeCart: boolean;
-	productsToAdd: RequestCartProduct[] | null;
-	couponToAdd: string | null;
+	productsToAddOnInitialize: RequestCartProduct[] | null;
+	couponToAddOnInitialize: string | null;
 	setCart: ( cartKey: string, arg1: RequestCart ) => Promise< ResponseCart >;
 	getCart: ( cartKey: string ) => Promise< ResponseCart >;
 	onEvent?: ( action: ReactStandardAction ) => void;

--- a/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/types.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/types.ts
@@ -27,7 +27,7 @@ export interface VariantSelectOverride {
 
 export interface ShoppingCartManager {
 	isLoading: boolean;
-	loadingError: string | null;
+	loadingError: string | null | undefined;
 	isPendingUpdate: boolean;
 	addItem: ( arg0: RequestCartProduct ) => void;
 	removeItem: ( arg0: string ) => void;
@@ -119,6 +119,7 @@ export type ShoppingCartState = {
 	responseCart: ResponseCart;
 	couponStatus: CouponStatus;
 	cacheStatus: CacheStatus;
+	loadingError?: string;
 	variantRequestStatus: VariantRequestStatus;
 	variantSelectOverride: { uuid: string; overrideSelectedProductSlug: string }[];
 };

--- a/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/use-initialize-cart-from-server.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/use-initialize-cart-from-server.ts
@@ -89,7 +89,6 @@ export default function useInitializeCartFromServer(
 				} );
 			} )
 			.catch( ( error ) => {
-				// TODO: figure out what to do here
 				debug( 'error while initializing cart', error );
 				hookDispatch( { type: 'RAISE_ERROR', error: 'GET_SERVER_CART_ERROR', message: error } );
 				onEvent?.( {

--- a/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/use-initialize-cart-from-server.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/use-initialize-cart-from-server.ts
@@ -23,8 +23,8 @@ const debug = debugFactory( 'calypso:composite-checkout:use-initialize-cart-from
 export default function useInitializeCartFromServer(
 	cacheStatus: CacheStatus,
 	canInitializeCart: boolean,
-	productsToAdd: RequestCartProduct[] | null,
-	couponToAdd: string | null,
+	productsToAddOnInitialize: RequestCartProduct[] | null,
+	couponToAddOnInitialize: string | null,
 	getCart: () => Promise< ResponseCart >,
 	setCart: ( arg0: RequestCart ) => Promise< ResponseCart >,
 	hookDispatch: ( arg0: ShoppingCartAction ) => void,
@@ -50,18 +50,18 @@ export default function useInitializeCartFromServer(
 
 		getCart()
 			.then( ( response ) => {
-				if ( productsToAdd?.length || couponToAdd ) {
+				if ( productsToAddOnInitialize?.length || couponToAddOnInitialize ) {
 					debug(
 						'initialized cart is',
 						response,
 						'; proceeding to add initial products',
-						productsToAdd,
+						productsToAddOnInitialize,
 						' and coupons',
-						couponToAdd
+						couponToAddOnInitialize
 					);
 					let responseCart = convertRawResponseCartToResponseCart( response );
-					if ( productsToAdd?.length ) {
-						responseCart = productsToAdd.reduce( ( updatedCart, productToAdd ) => {
+					if ( productsToAddOnInitialize?.length ) {
+						responseCart = productsToAddOnInitialize.reduce( ( updatedCart, productToAdd ) => {
 							onEvent?.( {
 								type: 'CART_ADD_ITEM',
 								payload: productToAdd,
@@ -69,8 +69,8 @@ export default function useInitializeCartFromServer(
 							return addItemToResponseCart( updatedCart, productToAdd );
 						}, responseCart );
 					}
-					if ( couponToAdd ) {
-						responseCart = addCouponToResponseCart( responseCart, couponToAdd );
+					if ( couponToAddOnInitialize ) {
+						responseCart = addCouponToResponseCart( responseCart, couponToAddOnInitialize );
 					}
 					return setCart( convertResponseCartToRequestCart( responseCart ) );
 				}
@@ -103,8 +103,8 @@ export default function useInitializeCartFromServer(
 		hookDispatch,
 		onEvent,
 		getCart,
-		productsToAdd,
-		couponToAdd,
+		productsToAddOnInitialize,
+		couponToAddOnInitialize,
 		setCart,
 	] );
 }

--- a/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
@@ -471,7 +471,15 @@ export function filterAppropriatePaymentMethods( {
 	const isPurchaseFree = total.amount.value === 0;
 	const isFullCredits =
 		! isPurchaseFree && credits?.amount.value > 0 && credits?.amount.value >= subtotal.amount.value;
-	debug( 'is purchase free?', isPurchaseFree, 'is full credits?', isFullCredits );
+	debug( 'filtering payment methods with this input', {
+		total,
+		credits,
+		subtotal,
+		allowedPaymentMethods,
+		serverAllowedPaymentMethods,
+		isPurchaseFree,
+		isFullCredits,
+	} );
 
 	return paymentMethodObjects
 		.filter( ( methodObject ) => {

--- a/client/my-sites/checkout/composite-checkout/types/backend/shopping-cart-endpoint.ts
+++ b/client/my-sites/checkout/composite-checkout/types/backend/shopping-cart-endpoint.ts
@@ -57,6 +57,7 @@ export interface RequestCartProduct {
  * Response schema for the shopping cart endpoint
  */
 export interface ResponseCart {
+	cart_key: string;
 	products: ( TempResponseCartProduct | ResponseCartProduct )[];
 	total_tax_integer: number;
 	total_tax_display: string;
@@ -94,6 +95,7 @@ export interface ResponseCartError {
 }
 
 export const emptyResponseCart = {
+	cart_key: '',
 	products: [],
 	total_tax_integer: 0,
 	total_tax_display: '0',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is just a clean-up PR that fixes some broken types used by `useShoppingCartManager` and renames a couple of the properties of that hook (`productsToAdd`, `couponToAdd`) to make it clear that they only happen on init.

#### Testing instructions

- Add products to cart via URL, like https://calypso.localhost:3000/checkout/example.com/business
- Verify that you are taken to checkout with that product in your cart.
- Add a coupon to your cart via URL, like https://calypso.localhost:3000/checkout/example.com?coupon=FOOBAR
- Verify that you are taken to checkout with that coupon applied to your cart.