### PR TITLE
Update logic to decide if customer can renew at old rate

### DIFF
--- a/client/my-sites/plans-v2/constants.ts
+++ b/client/my-sites/plans-v2/constants.ts
@@ -44,8 +44,6 @@ export const PERFORMANCE = 'performance';
 export const SECURITY = 'security';
 
 // TODO: update before offer reset launch
-export const OFFER_RESET_EFFECTIVE_DATE = '2020-09-01T00:00:00+00:00';
-// TODO: update before offer reset launch
 export const OFFER_RESET_SUPPORT_PAGE = 'https://jetpack.com/support/';
 
 /*

--- a/client/my-sites/plans-v2/plan-renewal-notice/index.tsx
+++ b/client/my-sites/plans-v2/plan-renewal-notice/index.tsx
@@ -8,9 +8,9 @@ import React, { FunctionComponent, ReactElement } from 'react';
  * Internal dependencies
  */
 import { OFFER_RESET_SUPPORT_PAGE, PLAN_RENEWAL_RECOMMENDATION } from '../constants';
-import { isEligibleForRenewalAtOldRate, slugToSelectorProduct } from '../utils';
+import { slugToSelectorProduct } from '../utils';
 import ExternalLink from 'components/external-link';
-import { useLocalizedMoment } from 'components/localized-moment';
+import { isRenewable } from 'lib/purchases';
 
 /**
  * Type dependencies
@@ -23,12 +23,11 @@ type Props = {
 };
 
 const PlanRenewalNotice: FunctionComponent< Props > = ( { purchase } ) => {
-	const moment = useLocalizedMoment();
 	const translate = useTranslate();
 
 	let notice;
 
-	if ( isEligibleForRenewalAtOldRate( purchase, moment ) ) {
+	if ( isRenewable( purchase ) ) {
 		notice = translate(
 			"We're updating our plans to include new features and improved functionality. " +
 				'As a thank you for being a loyal Jetpack subscriber, you can renew your current plan one time – your choice, for one month or one year. ' +

--- a/client/my-sites/plans-v2/utils.ts
+++ b/client/my-sites/plans-v2/utils.ts
@@ -12,7 +12,6 @@ import {
 	PRODUCTS_WITH_OPTIONS,
 	OPTIONS_SLUG_MAP,
 	UPGRADEABLE_WITH_NUDGE,
-	OFFER_RESET_EFFECTIVE_DATE,
 } from './constants';
 import {
 	TERM_ANNUALLY,
@@ -47,7 +46,6 @@ import type {
 	Plan,
 } from 'lib/plans/types';
 import type { JetpackProductSlug } from 'lib/products-values/types';
-import type { Purchase } from 'lib/purchases/types';
 
 /**
  * Duration utils.
@@ -75,27 +73,6 @@ export function durationToText( duration: Duration ): TranslateResult {
 	return duration === TERM_MONTHLY
 		? translate( 'per month, billed monthly' )
 		: translate( 'per year' );
-}
-
-/**
- * Renewal utils.
- */
-
-// TODO: implementation will most likely change with information coming from the API
-export function isEligibleForRenewalAtOldRate(
-	{ mostRecentRenewDate }: Purchase,
-	moment: any
-): boolean {
-	if ( mostRecentRenewDate ) {
-		const mostRecentRenewMoment = moment( mostRecentRenewDate );
-
-		return (
-			mostRecentRenewMoment.isValid() &&
-			mostRecentRenewMoment.isBefore( moment( OFFER_RESET_EFFECTIVE_DATE ) )
-		);
-	}
-
-	return false;
 }
 
 /**


### PR DESCRIPTION
### Changes proposed in this Pull Request

Some elements of the UI, such the expiry notice, show a different content whether or not the customer is eligible to renew their Jetpack legacy plan at the old rate. The eligibility logic was temporarily implemented in the frontend, but is now delegated to the backend. This PR reflects this change.

### Implementation notes

The `/purchase` endpoint returns a `isRenewable`, the value of which can be used directly to determine the eligibility.

### Testing instructions

I don't think it's possible to currently test that without editing the code locally. You'll need to update the return value of `isRenewable` in `client/lib/purchases/index.js`.

- Select a self-hosted Jetpack site with a legacy plan (Personal, Premium, or Professional)
- Visit the Plans section with the offer reset flow enabled
- Check that you see your plan in the plan column
- If your plan expires in less than 30 days for a monthly term, or 3 months for a yearly term, you should see the expiry date and a notice in place of the description
- If you haven't renewed your plan since the offer reset, the notice should mention that you can renew it once (see screenshot below)
- Otherwise, the notice should recommend a new product/plan (see screenshot below)

### Screenshots

#### Not eligible
<img width="371" alt="Screen Shot 2020-08-14 at 12 56 18 PM" src="https://user-images.githubusercontent.com/1620183/90274199-25aa4880-de2e-11ea-9d32-c979d7ca7f74.png">

#### Eligible
<img width="398" alt="Screen Shot 2020-08-14 at 12 56 15 PM" src="https://user-images.githubusercontent.com/1620183/90274211-2d69ed00-de2e-11ea-822f-2085f1ec614a.png">
