### PR TITLE
Composite checkout: Add Netbanking payment method (3)

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -478,6 +478,8 @@ export default function CompositeCheckout( {
 				genericRedirectProcessor( 'giropay', transactionData, dataForRedirectProcessor ),
 			wechat: ( transactionData ) =>
 				genericRedirectProcessor( 'wechat', transactionData, dataForRedirectProcessor ),
+			netbanking: ( transactionData ) =>
+				genericRedirectProcessor( 'netbanking', transactionData, dataForRedirectProcessor ),
 			ideal: ( transactionData ) =>
 				genericRedirectProcessor( 'ideal', transactionData, dataForRedirectProcessor ),
 			sofort: ( transactionData ) =>

--- a/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
@@ -147,10 +147,7 @@ export async function submitRedirectTransaction( paymentMethodId, transactionDat
 		paymentMethodType,
 		paymentPartnerProcessorId: transactionData.stripeConfiguration?.processor_id,
 	} );
-	debug(
-		`sending stripe redirect transaction for type: ${ paymentMethodId }`,
-		formattedTransactionData
-	);
+	debug( `sending redirect transaction for type: ${ paymentMethodId }`, formattedTransactionData );
 	return submit( formattedTransactionData );
 }
 

--- a/client/my-sites/checkout/composite-checkout/payment-methods/netbanking.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/netbanking.js
@@ -81,7 +81,7 @@ export function createNetBankingPaymentMethodStore() {
 							[ action.payload.key ]: {
 								value: maskField(
 									action.payload.key,
-									state[ action.payload.key ],
+									state.fields[ action.payload.key ],
 									action.payload.value
 								),
 								isTouched: true,
@@ -95,7 +95,7 @@ export function createNetBankingPaymentMethodStore() {
 						fields: {
 							...state.fields,
 							[ action.payload.key ]: {
-								...state[ action.payload.key ],
+								...state.fields[ action.payload.key ],
 								errors: [ action.payload.message ],
 							},
 						},
@@ -103,13 +103,16 @@ export function createNetBankingPaymentMethodStore() {
 				case 'TOUCH_ALL_FIELDS':
 					return {
 						...state,
-						fields: Object.entries( state.fields ).reduce( ( obj, [ key, value ] ) => {
-							obj[ key ] = {
-								value: value.value,
-								isTouched: true,
-							};
-							return obj;
-						}, {} ),
+						fields: Object.keys( state.fields ).reduce(
+							( obj, key ) => ( {
+								...obj,
+								[ key ]: {
+									...state.fields[ key ],
+									isTouched: true,
+								},
+							} ),
+							{}
+						),
 					};
 			}
 			return state;

--- a/client/my-sites/checkout/composite-checkout/payment-methods/netbanking.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/netbanking.js
@@ -256,8 +256,8 @@ function NetBankingPayButton( { disabled, store } ) {
 						items,
 						total,
 					} )
-						.then( ( stripeResponse ) => {
-							if ( ! stripeResponse?.redirect_url ) {
+						.then( ( transactionResponse ) => {
+							if ( ! transactionResponse?.redirect_url ) {
 								setTransactionError(
 									__(
 										'There was an error processing your payment. Please try again or contact support.'
@@ -265,8 +265,8 @@ function NetBankingPayButton( { disabled, store } ) {
 								);
 								return;
 							}
-							debug( 'netbanking transaction requires redirect', stripeResponse.redirect_url );
-							setTransactionRedirecting( stripeResponse.redirect_url );
+							debug( 'netbanking transaction requires redirect', transactionResponse.redirect_url );
+							setTransactionRedirecting( transactionResponse.redirect_url );
 						} )
 						.catch( ( error ) => {
 							setTransactionError( error.message );

--- a/client/my-sites/checkout/composite-checkout/payment-methods/netbanking.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/netbanking.js
@@ -24,15 +24,15 @@ import { camelCase } from 'lodash';
  */
 import notices from 'notices';
 import { validatePaymentDetails } from 'lib/checkout/validation';
-import useCountryList from 'my-sites/checkout/composite-checkout/wpcom/hooks/use-country-list';
-import Field from 'my-sites/checkout/composite-checkout/wpcom/components/field';
+import useCountryList from 'my-sites/checkout/composite-checkout/hooks/use-country-list';
+import Field from 'my-sites/checkout/composite-checkout/components/field';
 import {
 	SummaryLine,
 	SummaryDetails,
-} from 'my-sites/checkout/composite-checkout/wpcom/components/summary-details';
-import { PaymentMethodLogos } from 'my-sites/checkout/composite-checkout/wpcom/components/payment-method-logos';
+} from 'my-sites/checkout/composite-checkout/components/summary-details';
+import { PaymentMethodLogos } from 'my-sites/checkout/composite-checkout/components/payment-method-logos';
 import { maskField } from 'lib/checkout';
-import CountrySpecificPaymentFieldsUI from '../wpcom/components/country-specific-payment-fields-ui';
+import CountrySpecificPaymentFieldsUI from '../components/country-specific-payment-fields-ui';
 
 const debug = debugFactory( 'composite-checkout:netbanking-payment-method' );
 

--- a/client/my-sites/checkout/composite-checkout/payment-methods/netbanking.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/netbanking.js
@@ -1,0 +1,367 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import styled from '@emotion/styled';
+import debugFactory from 'debug';
+import { sprintf } from '@wordpress/i18n';
+import { useI18n } from '@automattic/react-i18n';
+import {
+	Button,
+	usePaymentProcessor,
+	useTransactionStatus,
+	useLineItems,
+	useEvents,
+	useFormStatus,
+	registerStore,
+	useSelect,
+	useDispatch,
+} from '@automattic/composite-checkout';
+import { camelCase } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import notices from 'notices';
+import { validatePaymentDetails } from 'lib/checkout/validation';
+import useCountryList from 'my-sites/checkout/composite-checkout/wpcom/hooks/use-country-list';
+import Field from 'my-sites/checkout/composite-checkout/wpcom/components/field';
+import {
+	SummaryLine,
+	SummaryDetails,
+} from 'my-sites/checkout/composite-checkout/wpcom/components/summary-details';
+import { PaymentMethodLogos } from 'my-sites/checkout/composite-checkout/wpcom/components/payment-method-logos';
+import { maskField } from 'lib/checkout';
+import CountrySpecificPaymentFieldsUI from '../wpcom/components/country-specific-payment-fields-ui';
+
+const debug = debugFactory( 'composite-checkout:netbanking-payment-method' );
+
+export function createNetBankingPaymentMethodStore() {
+	debug( 'creating a new netbanking payment method store' );
+	const actions = {
+		changeCustomerName( payload ) {
+			return { type: 'CUSTOMER_NAME_SET', payload };
+		},
+		setFieldValue( key, value ) {
+			return { type: 'FIELD_VALUE_SET', payload: { key, value } };
+		},
+		setFieldError( key, message ) {
+			return { type: 'FIELD_ERROR_SET', payload: { key, message } };
+		},
+		touchAllFields() {
+			return { type: 'TOUCH_ALL_FIELDS' };
+		},
+	};
+
+	const selectors = {
+		getCustomerName( state ) {
+			return state.customerName;
+		},
+		getFields( state ) {
+			return state.fields;
+		},
+	};
+
+	const store = registerStore( 'netbanking', {
+		reducer(
+			state = {
+				customerName: { value: '', isTouched: false },
+				fields: {},
+			},
+			action
+		) {
+			switch ( action.type ) {
+				case 'CUSTOMER_NAME_SET':
+					return { ...state, customerName: { value: action.payload, isTouched: true } };
+				case 'FIELD_VALUE_SET':
+					return {
+						...state,
+						fields: {
+							...state.fields,
+							[ action.payload.key ]: {
+								value: maskField(
+									action.payload.key,
+									state[ action.payload.key ],
+									action.payload.value
+								),
+								isTouched: true,
+								errors: [],
+							},
+						},
+					};
+				case 'FIELD_ERROR_SET':
+					return {
+						...state,
+						fields: {
+							...state.fields,
+							[ action.payload.key ]: {
+								...state[ action.payload.key ],
+								errors: [ action.payload.message ],
+							},
+						},
+					};
+				case 'TOUCH_ALL_FIELDS':
+					return {
+						...state,
+						fields: Object.entries( state.fields ).reduce( ( obj, [ key, value ] ) => {
+							obj[ key ] = {
+								value: value.value,
+								isTouched: true,
+							};
+							return obj;
+						}, {} ),
+					};
+			}
+			return state;
+		},
+		actions,
+		selectors,
+	} );
+
+	return { ...store, actions, selectors };
+}
+
+export function createNetBankingMethod( { store, stripe, stripeConfiguration } ) {
+	return {
+		id: 'netbanking',
+		label: <NetBankingLabel />,
+		activeContent: (
+			<NetBankingFields stripe={ stripe } stripeConfiguration={ stripeConfiguration } />
+		),
+		submitButton: (
+			<NetBankingPayButton
+				store={ store }
+				stripe={ stripe }
+				stripeConfiguration={ stripeConfiguration }
+			/>
+		),
+		inactiveContent: <NetBankingSummary />,
+		getAriaLabel: () => 'Transferência bancária',
+	};
+}
+
+function NetBankingFields() {
+	const { __ } = useI18n();
+
+	const fields = useSelect( ( select ) => select( 'netbanking' ).getFields() );
+	const getField = ( key ) => fields[ key ] || {};
+	const getFieldValue = ( key ) => getField( key ).value ?? '';
+	const getErrorMessagesForField = ( key ) => {
+		const managedValue = getField( key );
+		if ( managedValue?.isRequired && managedValue?.value === '' ) {
+			return [ __( 'This field is required.' ) ];
+		}
+		return managedValue.errors ?? [];
+	};
+	const { setFieldValue } = useDispatch( 'netbanking' );
+
+	const customerName = useSelect( ( select ) => select( 'netbanking' ).getCustomerName() );
+	const { changeCustomerName } = useDispatch( 'netbanking' );
+	const { formStatus } = useFormStatus();
+	const isDisabled = formStatus !== 'ready';
+	const countriesList = useCountryList( [] );
+
+	return (
+		<NetBankingFormWrapper>
+			<NetBankingField
+				id="netbanking-cardholder-name"
+				type="Text"
+				autoComplete="cc-name"
+				label={ __( 'Your name' ) }
+				value={ customerName?.value ?? '' }
+				onChange={ changeCustomerName }
+				isError={ customerName?.isTouched && customerName?.value.length === 0 }
+				errorMessage={ __( 'This field is required' ) }
+				disabled={ isDisabled }
+			/>
+			<div className="netbanking__contact-fields">
+				<CountrySpecificPaymentFieldsUI
+					countryCode={ 'IN' } // If this payment method is available and the country is not India, we have other problems
+					countriesList={ countriesList }
+					getErrorMessage={ getErrorMessagesForField }
+					getFieldValue={ getFieldValue }
+					handleFieldChange={ setFieldValue }
+					disableFields={ isDisabled }
+				/>
+			</div>
+		</NetBankingFormWrapper>
+	);
+}
+
+const NetBankingFormWrapper = styled.div`
+	padding: 16px;
+	position: relative;
+
+	::after {
+		display: block;
+		width: calc( 100% - 6px );
+		height: 1px;
+		content: '';
+		background: ${ ( props ) => props.theme.colors.borderColorLight };
+		position: absolute;
+		top: 0;
+		left: 3px;
+
+		.rtl & {
+			right: 3px;
+			left: auto;
+		}
+	}
+`;
+
+const NetBankingField = styled( Field )`
+	margin-top: 16px;
+
+	:first-of-type {
+		margin-top: 0;
+	}
+`;
+
+function NetBankingPayButton( { disabled, store } ) {
+	const { __ } = useI18n();
+	const [ items, total ] = useLineItems();
+	const { formStatus } = useFormStatus();
+	const {
+		setTransactionRedirecting,
+		setTransactionError,
+		setTransactionPending,
+	} = useTransactionStatus();
+	const submitTransaction = usePaymentProcessor( 'netbanking' );
+	const onEvent = useEvents();
+	const customerName = useSelect( ( select ) => select( 'netbanking' ).getCustomerName() );
+	const fields = useSelect( ( select ) => select( 'netbanking' ).getFields() );
+	const massagedFields = Object.entries( fields ).reduce(
+		( accum, [ key, managedValue ] ) => ( { ...accum, [ camelCase( key ) ]: managedValue.value } ),
+		{}
+	);
+	const contactCountryCode = useSelect(
+		( select ) => select( 'wpcom' )?.getContactInfo().countryCode?.value
+	);
+
+	return (
+		<Button
+			disabled={ disabled }
+			onClick={ () => {
+				if ( isFormValid( store, contactCountryCode, __ ) ) {
+					debug( 'submitting netbanking payment' );
+					setTransactionPending();
+					onEvent( {
+						type: 'REDIRECT_TRANSACTION_BEGIN',
+						payload: { paymentMethodId: 'netbanking' },
+					} );
+					submitTransaction( {
+						name: customerName?.value,
+						...massagedFields,
+						address: massagedFields?.address1,
+						items,
+						total,
+					} )
+						.then( ( stripeResponse ) => {
+							if ( ! stripeResponse?.redirect_url ) {
+								setTransactionError(
+									__(
+										'There was an error processing your payment. Please try again or contact support.'
+									)
+								);
+								return;
+							}
+							debug( 'netbanking transaction requires redirect', stripeResponse.redirect_url );
+							setTransactionRedirecting( stripeResponse.redirect_url );
+						} )
+						.catch( ( error ) => {
+							setTransactionError( error.message );
+						} );
+				}
+			} }
+			buttonType="primary"
+			isBusy={ 'submitting' === formStatus }
+			fullWidth
+		>
+			<ButtonContents formStatus={ formStatus } total={ total } />
+		</Button>
+	);
+}
+
+function ButtonContents( { formStatus, total } ) {
+	const { __ } = useI18n();
+	if ( formStatus === 'submitting' ) {
+		return __( 'Processing…' );
+	}
+	if ( formStatus === 'ready' ) {
+		return sprintf( __( 'Pay %s' ), total.amount.displayValue );
+	}
+	return __( 'Please wait…' );
+}
+
+function NetBankingSummary() {
+	const customerName = useSelect( ( select ) => select( 'netbanking' ).getCustomerName() );
+
+	return (
+		<SummaryDetails>
+			<SummaryLine>{ customerName?.value }</SummaryLine>
+		</SummaryDetails>
+	);
+}
+
+function isFormValid( store, contactCountryCode, __ ) {
+	// Touch fields so that we show errors
+	store.dispatch( store.actions.touchAllFields() );
+	let isValid = true;
+
+	const customerName = store.selectors.getCustomerName( store.getState() );
+
+	if ( ! customerName?.value.length ) {
+		// Touch the field so it displays a validation error
+		store.dispatch( store.actions.changeCustomerName( '' ) );
+		isValid = false;
+	}
+
+	const rawState = store.selectors.getFields( store.getState() );
+
+	const validationResults = validatePaymentDetails(
+		Object.entries( {
+			...rawState,
+			country: { value: contactCountryCode },
+			name: customerName,
+		} ).reduce( ( accum, [ key, managedValue ] ) => {
+			accum[ key ] = managedValue.value;
+			return accum;
+		}, {} ),
+		'netbanking'
+	);
+
+	Object.entries( validationResults.errors ).map( ( [ key, errors ] ) => {
+		errors.map( ( error ) => {
+			isValid = false;
+			store.dispatch( store.actions.setFieldError( key, error ) );
+		} );
+	} );
+	debug( 'netbanking card details validation results: ', validationResults );
+
+	if ( validationResults.errors?.country?.length > 0 ) {
+		const countryErrorMessage = validationResults.errors.country[ 0 ];
+		notices.error( countryErrorMessage || __( 'An error occurred during your purchase.' ) );
+	}
+	return isValid;
+}
+
+function NetBankingLabel() {
+	return (
+		<React.Fragment>
+			<span>Net Banking</span>
+			<PaymentMethodLogos className="netbanking__logo payment-logos">
+				<NetBankingLogoUI />
+			</PaymentMethodLogos>
+		</React.Fragment>
+	);
+}
+
+const NetBankingLogoUI = styled( NetBankingLogo )`
+	width: 76px;
+`;
+
+function NetBankingLogo( { className } ) {
+	return (
+		<img src="/calypso/images/upgrades/netbanking.svg" alt="NetBanking" className={ className } />
+	);
+}

--- a/client/my-sites/checkout/composite-checkout/types/backend/payment-method.ts
+++ b/client/my-sites/checkout/composite-checkout/types/backend/payment-method.ts
@@ -26,6 +26,7 @@ import { CheckoutPaymentMethodSlug } from '../checkout-payment-method-slug';
 export type WPCOMPaymentMethodClass =
 	| WPCOMBillingEbanx
 	| WPCOMBillingEbanxRedirectBrazilTef
+	| WPCOMBillingDlocalRedirectIndiaNetbanking
 	| WPCOMBillingPayPalDirect
 	| WPCOMBillingPayPalExpress
 	| WPCOMBillingStripePaymentMethod
@@ -50,6 +51,9 @@ export interface WPCOMBillingFree {
 }
 export interface WPCOMBillingEbanx {
 	name: 'WPCOM_Billing_Ebanx';
+}
+export interface WPCOMBillingDlocalRedirectIndiaNetbanking {
+	name: 'WPCOM_Billing_Dlocal_Redirect_India_Netbanking';
 }
 export interface WPCOMBillingEbanxRedirectBrazilTef {
 	name: 'WPCOM_Billing_Ebanx_Redirect_Brazil_Tef';
@@ -112,6 +116,7 @@ export function readWPCOMPaymentMethodClass( slug: string ): WPCOMPaymentMethodC
 		case 'WPCOM_Billing_WPCOM':
 		case 'WPCOM_Billing_Ebanx':
 		case 'WPCOM_Billing_Ebanx_Redirect_Brazil_Tef':
+		case 'WPCOM_Billing_Dlocal_Redirect_India_Netbanking':
 		case 'WPCOM_Billing_PayPal_Direct':
 		case 'WPCOM_Billing_PayPal_Express':
 		case 'WPCOM_Billing_Stripe_Payment_Method':
@@ -170,6 +175,8 @@ export function translateWpcomPaymentMethodToCheckoutPaymentMethod(
 			return 'stripe-three-d-secure';
 		case 'WPCOM_Billing_Stripe_Source_Wechat':
 			return 'wechat';
+		case 'WPCOM_Billing_Dlocal_Redirect_India_Netbanking':
+			return 'netbanking';
 		case 'WPCOM_Billing_Web_Payment':
 			return 'apple-pay';
 	}
@@ -187,6 +194,8 @@ export function translateCheckoutPaymentMethodToWpcomPaymentMethod(
 			return { name: 'WPCOM_Billing_Ebanx' };
 		case 'brazil-tef':
 			return { name: 'WPCOM_Billing_Ebanx_Redirect_Brazil_Tef' };
+		case 'netbanking':
+			return { name: 'WPCOM_Billing_Dlocal_Redirect_India_Netbanking' };
 		case 'paypal-direct':
 			return { name: 'WPCOM_Billing_PayPal_Direct' };
 		case 'paypal':

--- a/client/my-sites/checkout/composite-checkout/types/checkout-payment-method-slug.ts
+++ b/client/my-sites/checkout/composite-checkout/types/checkout-payment-method-slug.ts
@@ -15,6 +15,7 @@ export type CheckoutPaymentMethodSlug =
 	| 'card'
 	| 'ebanx'
 	| 'brazil-tef'
+	| 'netbanking'
 	| 'eps'
 	| 'giropay'
 	| 'ideal'
@@ -30,15 +31,16 @@ export type CheckoutPaymentMethodSlug =
 export function translateCheckoutPaymentMethodToTracksPaymentMethod(
 	paymentMethod: CheckoutPaymentMethodSlug
 ): string {
+	let paymentMethodSlug: string = paymentMethod;
 	// existing cards have unique paymentMethodIds
 	if ( paymentMethod.startsWith( 'existingCard' ) ) {
-		paymentMethod = 'credit_card';
+		paymentMethodSlug = 'credit_card';
 	}
-	switch ( paymentMethod ) {
+	switch ( paymentMethodSlug ) {
 		case 'card':
 			return 'credit_card';
 		case 'apple-pay':
 			return 'web_payment';
 	}
-	return snakeCase( paymentMethod );
+	return snakeCase( paymentMethodSlug );
 }

--- a/client/my-sites/checkout/composite-checkout/types/transaction-endpoint.ts
+++ b/client/my-sites/checkout/composite-checkout/types/transaction-endpoint.ts
@@ -29,13 +29,21 @@ export type WPCOMTransactionEndpointRequestPayload = {
 export type WPCOMTransactionEndpointPaymentDetails = {
 	paymentMethod: string;
 	paymentKey?: string;
-	paymentPartner: string;
+	paymentPartner?: string;
 	storedDetailsId?: string;
 	name: string;
 	email?: string;
 	zip: string;
 	postalCode: string;
 	country: string;
+	countryCode: string;
+	state?: string;
+	city?: string;
+	address?: string;
+	streetNumber?: string;
+	phoneNumber?: string;
+	document?: string;
+	deviceId?: string;
 	successUrl?: string;
 	cancelUrl?: string;
 	idealBank?: string;

--- a/client/my-sites/checkout/composite-checkout/types/transaction-endpoint.ts
+++ b/client/my-sites/checkout/composite-checkout/types/transaction-endpoint.ts
@@ -48,6 +48,8 @@ export type WPCOMTransactionEndpointPaymentDetails = {
 	cancelUrl?: string;
 	idealBank?: string;
 	tefBank?: string;
+	pan?: string;
+	gstin?: string;
 };
 
 export type WPCOMTransactionEndpointCart = {
@@ -177,6 +179,8 @@ export function createTransactionEndpointRequestPayloadFromLineItems( {
 	successUrl,
 	idealBank,
 	tefBank,
+	pan,
+	gstin,
 }: {
 	siteId: string;
 	couponId?: string;
@@ -202,6 +206,8 @@ export function createTransactionEndpointRequestPayloadFromLineItems( {
 	cancelUrl?: string;
 	idealBank?: string;
 	tefBank?: string;
+	pan?: string;
+	gstin?: string;
 } ): WPCOMTransactionEndpointRequestPayload {
 	return {
 		cart: createTransactionEndpointCartFromLineItems( {
@@ -236,6 +242,8 @@ export function createTransactionEndpointRequestPayloadFromLineItems( {
 			cancelUrl,
 			idealBank,
 			tefBank,
+			pan,
+			gstin,
 		},
 	};
 }

--- a/client/my-sites/checkout/composite-checkout/use-create-payment-methods.js
+++ b/client/my-sites/checkout/composite-checkout/use-create-payment-methods.js
@@ -42,6 +42,10 @@ import {
 	createEbanxTefPaymentMethodStore,
 	createEbanxTefMethod,
 } from './payment-methods/ebanx-tef';
+import {
+	createNetBankingPaymentMethodStore,
+	createNetBankingMethod,
+} from './payment-methods/netbanking';
 
 function useCreatePayPal( { onlyLoadPaymentMethods } ) {
 	const shouldLoadPayPalMethod = onlyLoadPaymentMethods
@@ -289,6 +293,24 @@ function useCreateEps( {
 	);
 }
 
+function useCreateNetbanking( { onlyLoadPaymentMethods } ) {
+	// If this PM is allowed by props and allowed by the cart, then create the PM.
+	const isMethodAllowed = onlyLoadPaymentMethods
+		? onlyLoadPaymentMethods.includes( 'netbanking' )
+		: true;
+	const shouldLoad = isMethodAllowed;
+	const paymentMethodStore = useMemo( () => createNetBankingPaymentMethodStore(), [] );
+	return useMemo(
+		() =>
+			shouldLoad
+				? createNetBankingMethod( {
+						store: paymentMethodStore,
+				  } )
+				: null,
+		[ shouldLoad, paymentMethodStore ]
+	);
+}
+
 function useCreateEbanxTef( { onlyLoadPaymentMethods } ) {
 	// If this PM is allowed by props and allowed by the cart, then create the PM.
 	const isMethodAllowed = onlyLoadPaymentMethods
@@ -470,6 +492,8 @@ export default function useCreatePaymentMethods( {
 
 	const ebanxTefMethod = useCreateEbanxTef( { onlyLoadPaymentMethods } );
 
+	const netbankingMethod = useCreateNetbanking( { onlyLoadPaymentMethods } );
+
 	const sofortMethod = useCreateSofort( {
 		onlyLoadPaymentMethods,
 		isStripeLoading,
@@ -529,6 +553,7 @@ export default function useCreatePaymentMethods( {
 		giropayMethod,
 		sofortMethod,
 		ebanxTefMethod,
+		netbankingMethod,
 		alipayMethod,
 		p24Method,
 		epsMethod,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This adds the Netbanking payment method to new checkout.

Fixes https://github.com/Automattic/wp-calypso/issues/44831

#### Screenshots

![Screen Shot 2020-08-17 at 5 25 22 PM](https://user-images.githubusercontent.com/2036909/90446034-aa0afe80-e0ae-11ea-8f25-d0e5422a51ac.png)

#### Testing instructions

- Set your currency to INR.
- Apply D48222-code and sandbox the API; this will make it appear that you are in India.
- Visit checkout with a product in your cart.
- Verify that you see new checkout.
- Select "India" as a country in the contact form.
- Complete the form until you reach the final step where you select a payment method.
- Verify that "Netbanking" is an option.
- Select "Netbanking" and verify that you see the form fields for PAN, GSTIN, and other contact data appear.
- Try to submit the form without filling out the fields. Verify that you see error messages under each field.
- Fill in each field, but use invalid data for the PAN and GSTIN.
- Try to submit the form without filling out the fields. Verify that you see error messages under the invalid fields.
- Fill in valid PAN (eg: `ABCDE1234F`) and GSTIN (eg: `22AAAAA0000A1Z5`) data.
- Open your network tab in Devtools and make sure you have "Preserve log" checked so you don't lose data when redirecting.
- Try to submit the form. Verify that you are taken to the dLocal page.
- Verify that the data sent to the `/me/transactions` endpoint includes all the data from the form.