### PR TITLE
Jetpack Offer Reset: Plans Page visual tweaks

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card/style.scss
@@ -112,13 +112,13 @@ $jetpack-product-card-icon-size: 55px;
 .jetpack-product-card__subheadline {
 	margin-bottom: 24px;
 
-	color: var( --color-text-subtle );
+	color: var( --color-neutral-50 );
 
 	font-size: $font-body-extra-small;
 	line-height: rem( 16px ) / $font-body-extra-small;
 
 	@media ( min-width: 660px ) {
-		font-size: $font-body;
+		font-size: $font-body-small;
 	}
 }
 

--- a/client/my-sites/plans-v2/plans-column/index.tsx
+++ b/client/my-sites/plans-v2/plans-column/index.tsx
@@ -61,7 +61,7 @@ const PlansColumn = ( { duration, onPlanClick, productType, siteId }: PlanColumn
 
 	return (
 		<div className="plans-column">
-			<FormattedHeader headerText={ translate( 'Plans' ) } isSecondary={ true } brandFont />
+			<FormattedHeader headerText={ translate( 'Plans' ) } isSecondary brandFont />
 			{ planObjects.map( ( plan ) => (
 				<ProductCard
 					key={ plan.productSlug }

--- a/client/my-sites/plans-v2/plans-column/index.tsx
+++ b/client/my-sites/plans-v2/plans-column/index.tsx
@@ -61,7 +61,7 @@ const PlansColumn = ( { duration, onPlanClick, productType, siteId }: PlanColumn
 
 	return (
 		<div className="plans-column">
-			<FormattedHeader headerText={ translate( 'Plans' ) } brandFont />
+			<FormattedHeader headerText={ translate( 'Plans' ) } isSecondary={ true } brandFont />
 			{ planObjects.map( ( plan ) => (
 				<ProductCard
 					key={ plan.productSlug }

--- a/client/my-sites/plans-v2/product-card/index.tsx
+++ b/client/my-sites/plans-v2/product-card/index.tsx
@@ -126,6 +126,7 @@ const ProductCardWrapper = ( {
 
 	return (
 		<CardComponent
+			headingLevel={ 3 }
 			iconSlug={ item.iconSlug }
 			productName={ item.displayName }
 			subheadline={ item.tagline }

--- a/client/my-sites/plans-v2/products-column/index.tsx
+++ b/client/my-sites/plans-v2/products-column/index.tsx
@@ -55,7 +55,11 @@ const ProductsColumn = ( {
 
 	return (
 		<div className="plans-column products-column">
-			<FormattedHeader headerText={ translate( 'Individual Products' ) } brandFont />
+			<FormattedHeader
+				headerText={ translate( 'Individual Products' ) }
+				isSecondary={ true }
+				brandFont
+			/>
 			{ productObjects.map( ( product ) => (
 				<ProductCard
 					key={ product.productSlug }

--- a/client/my-sites/plans-v2/products-column/index.tsx
+++ b/client/my-sites/plans-v2/products-column/index.tsx
@@ -55,11 +55,7 @@ const ProductsColumn = ( {
 
 	return (
 		<div className="plans-column products-column">
-			<FormattedHeader
-				headerText={ translate( 'Individual Products' ) }
-				isSecondary={ true }
-				brandFont
-			/>
+			<FormattedHeader headerText={ translate( 'Individual Products' ) } isSecondary brandFont />
 			{ productObjects.map( ( product ) => (
 				<ProductCard
 					key={ product.productSlug }

--- a/client/my-sites/plans-v2/selector.tsx
+++ b/client/my-sites/plans-v2/selector.tsx
@@ -3,11 +3,13 @@
  */
 import React, { useState } from 'react';
 import { useSelector } from 'react-redux';
+import { translate } from 'i18n-calypso';
 import page from 'page';
 
 /**
  * Internal dependencies
  */
+import FormattedHeader from 'components/formatted-header';
 import PlansFilterBar from './plans-filter-bar';
 import PlansColumn from './plans-column';
 import ProductsColumn from './products-column';
@@ -61,6 +63,7 @@ const SelectorPage = ( {
 
 	return (
 		<Main className="selector__main" wideLayout>
+			<FormattedHeader headerText={ translate( 'Plans' ) } align="left" brandFont />
 			{ header }
 			<PlansFilterBar
 				onProductTypeChange={ setProductType }

--- a/client/my-sites/plans-v2/style.scss
+++ b/client/my-sites/plans-v2/style.scss
@@ -18,14 +18,15 @@
 		.formatted-header {
 			margin-top: 40px;
 		}
-		.formatted-header__title {
-			font-size: 1.25rem;
-			color: var( --studio-color-gray-70 );
-		}
 		.plan-price {
 			font-size: $font-title-medium;
 		}
 	}
+}
+
+.plans-v2__columns .formatted-header__title {
+	font-size: 1.25rem;
+	color: var( --studio-color-gray-70 );
 }
 
 .upsell__header {

--- a/client/my-sites/plans-v2/style.scss
+++ b/client/my-sites/plans-v2/style.scss
@@ -19,11 +19,8 @@
 			margin-top: 40px;
 		}
 		.formatted-header__title {
-			font-size: 1rem;
-			color: #3c434a;
-			@media ( min-width: 660px ) {
-				font-size: 18px;
-			}
+			font-size: 1.25rem;
+			color: var( --studio-color-gray-70 );
 		}
 		.plan-price {
 			font-size: $font-title-medium;

--- a/client/my-sites/plans-v2/style.scss
+++ b/client/my-sites/plans-v2/style.scss
@@ -15,6 +15,16 @@
 		& > .details__column:not( :first-of-type ) {
 			margin-left: 24px;
 		}
+		.formatted-header {
+			margin-top: 40px;
+		}
+		.formatted-header__title {
+			font-size: 1rem;
+			color: #3c434a;
+			@media ( min-width: 660px ) {
+				font-size: 18px;
+			}
+		}
 	}
 }
 

--- a/client/my-sites/plans-v2/style.scss
+++ b/client/my-sites/plans-v2/style.scss
@@ -25,6 +25,9 @@
 				font-size: 18px;
 			}
 		}
+		.plan-price {
+			font-size: $font-title-medium;
+		}
 	}
 }
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

**Visual Tweaks to the Jetpack Plans Page:**
(for Jetpack Offer Reset)

1. Page heading should be on top (in page heading font)
2. Sub heads (over columns should be 18px/1rem #3C434A
3. 40px vertical space between action bar (w/toggles) & plans sub heads
4. Price size should match product heading size, it looks like it's bigger at the moment.
5. Let's make the product card subhead match the subheads on the my plan page. I believe it's .9rem (see attached

**See Screenshots Below:**

![topofpage](https://user-images.githubusercontent.com/11078128/90297447-58127080-de43-11ea-8b18-d1c76c389da2.png)
![card](https://user-images.githubusercontent.com/11078128/90297472-70828b00-de43-11ea-8d38-7ddf2d1a6ada.png)


### Testing instructions

1. Open your sandbox site
2. Enable the _Offer Reset Flow_ in A/B tests.
3. Visit the **Plans** section.

- Verify page heading is added (and in page heading font)
- Verify sub heads over columns are 18px/1rem #3C434A.
- Verify 40px vertical space between action bar & plans sub heads.
- Verify Price size is same font and size as product heading.
- Verify product card subhead match the subheads on 'My Home' page.

![screenshot](https://user-images.githubusercontent.com/11078128/90541664-d323a180-e137-11ea-83b3-59ba4c2aa73b.png)

