### PR TITLE
Plugins: Fix Styling for "Available Sites"

### DIFF
--- a/client/my-sites/plugins/plugin-site-jetpack/style.scss
+++ b/client/my-sites/plugins/plugin-site-jetpack/style.scss
@@ -1,7 +1,4 @@
-.plugin-site-jetpack {
-	padding: 8px;
-	margin: 0;
-
+.plugin-site-jetpack.foldable-card {
 	.site-icon {
 		display: inline-block;
 		margin-right: 8px;
@@ -9,25 +6,14 @@
 
 	&.is-compact .foldable-card__header {
 		padding: 16px;
-	}
 
-	.plugin-site__activate-manage {
-		position: absolute;
-			right: 0;
-			top: 0;
-		margin: 8px;
-		height: 32px;
-		display: flex;
-		align-items: center;
-
-		button {
-			line-height: 32px;
-			margin-top: 0;
+		.foldable-card__action {
+			display: flex;
 		}
-	}
 
-	.site__info {
-		width: auto;
+		.plugin-install-button__install.embed {
+			margin: auto 16px;
+		}
 	}
 
 	.site__content {
@@ -38,24 +24,10 @@
 	.plugin-activate-toggle__link {
 		margin-left: 12px;
 	}
-
-	.is-compact {
-		margin-left: 12px;
-		margin-top: 16px;
-	}
 }
 
 .plugin-site-jetpack .plugin-action__disabled-info.info-popover .gridicons-info-outline {
-	    transform: translate( 2px, -2px );
-}
-
-.plugin-site-jetpack__embed-action {
-	height: 32px;
-	position: absolute;
-		top: 8px;
-		right: 8px;
-	display: flex;
-	align-items: center;
+	transform: translate( 2px, -2px );
 }
 
 .plugin-site-jetpack__automanage-notice {

--- a/client/my-sites/plugins/plugin-site-jetpack/style.scss
+++ b/client/my-sites/plugins/plugin-site-jetpack/style.scss
@@ -16,6 +16,10 @@
 		}
 	}
 
+	.foldable-card__expand .gridicon {
+		margin: auto;
+	}
+
 	.site__content {
 		padding: 0;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* It appears that the styling for the "Available Sites" section on Plugins is being overriden sometimes, but that often results in the page looking pretty broken. This just reworks the styling to what it was before (at least what it was in #39020), which is probably better. 

#### Testing instructions

Visit `/plugins/under-construction-page` (or any slug - ideally one which you haven't installed and one which you have) and scroll to the bottom. 

**Before:**
<img width="838" alt="Screenshot 2020-08-16 at 17 52 09" src="https://user-images.githubusercontent.com/43215253/90340063-600e1400-dfed-11ea-9e9e-8ccfc55b21be.png">

**After - effectively reverting to what it was before:**
<img width="803" alt="Screenshot 2020-08-16 at 18 23 01" src="https://user-images.githubusercontent.com/43215253/90340089-9186df80-dfed-11ea-80ec-c6afd96a973b.png">

cc @sixhours, @arunsathiya 

Fixes #42400
