### PR TITLE
A/b test: Fix race condition

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -254,7 +254,7 @@ export default {
 		localeExceptions: [ 'en', 'es' ],
 	},
 	existingUsersGutenbergOnboard: {
-		datestamp: '20200812',
+		datestamp: '20200817',
 		variations: {
 			gutenberg: 50,
 			control: 50,

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -123,6 +123,7 @@ export default {
 			const userLoggedIn = isUserLoggedIn( context.store.getState() );
 			if ( userLoggedIn && 'gutenberg' === abtest( 'existingUsersGutenbergOnboard' ) ) {
 				gutenbergRedirect();
+				return;
 			}
 
 			waitForData( {


### PR DESCRIPTION
There's a race condition that allows users that have been allocated to the variant of the `existingUsersGutenbergOnboard` to end experiencing control instead because being allocated to a different test downstream. They shouldn't ever get to the point that allocation happens, but a `return;` was missing.