### PR TITLE
Mass migration from package-relative imports to wp-calypso-client

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -312,7 +312,7 @@ module.exports = {
 		],
 		// Disabled for now until we finish the migration
 		'wpcalypso/no-package-relative-imports': [
-			'off',
+			'error',
 			{
 				mappings: [
 					{

--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -1,9 +1,14 @@
+const path = require( 'path' );
+
 module.exports = {
 	rules: {
 		// We have lots of "fake" packages (directories with a package.json that don't declare dependencies),
 		// we need to configure this rule to look into __dirname/node_modules, otherwise it will stop
 		// looking up when it finds a package.json
-		'import/no-extraneous-dependencies': [ 'error', { packageDir: [ __dirname ] } ],
+		'import/no-extraneous-dependencies': [
+			'error',
+			{ packageDir: [ __dirname, path.join( __dirname, '..' ) ] },
+		],
 	},
 	overrides: [
 		{

--- a/client/me/account-close/closed.jsx
+++ b/client/me/account-close/closed.jsx
@@ -9,10 +9,10 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import EmptyContent from 'components/empty-content';
-import Spinner from 'components/spinner';
-import getPreviousRoute from 'state/selectors/get-previous-route';
-import isAccountClosed from 'state/selectors/is-account-closed';
+import EmptyContent from 'calypso/components/empty-content';
+import Spinner from 'calypso/components/spinner';
+import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
+import isAccountClosed from 'calypso/state/selectors/is-account-closed';
 
 /**
  * Style dependencies

--- a/client/me/account-close/confirm-dialog.jsx
+++ b/client/me/account-close/confirm-dialog.jsx
@@ -10,15 +10,15 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import config from 'config';
+import config from 'calypso/config';
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Dialog, Button } from '@automattic/components';
-import Gridicon from 'components/gridicon';
-import FormTextInput from 'components/forms/form-text-input';
-import FormLabel from 'components/forms/form-label';
-import InlineSupportLink from 'components/inline-support-link';
-import { getCurrentUser } from 'state/current-user/selectors';
-import { closeAccount } from 'state/account/actions';
+import Gridicon from 'calypso/components/gridicon';
+import FormTextInput from 'calypso/components/forms/form-text-input';
+import FormLabel from 'calypso/components/forms/form-label';
+import InlineSupportLink from 'calypso/components/inline-support-link';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import { closeAccount } from 'calypso/state/account/actions';
 
 /**
  * Style dependencies

--- a/client/me/account-close/controller.js
+++ b/client/me/account-close/controller.js
@@ -6,8 +6,8 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import AccountSettingsCloseComponent from 'me/account-close/main';
-import AccountSettingsClosedComponent from 'me/account-close/closed';
+import AccountSettingsCloseComponent from 'calypso/me/account-close/main';
+import AccountSettingsClosedComponent from 'calypso/me/account-close/closed';
 
 export function accountClose( context, next ) {
 	context.primary = React.createElement( AccountSettingsCloseComponent );

--- a/client/me/account-close/index.js
+++ b/client/me/account-close/index.js
@@ -7,9 +7,9 @@ import page from 'page';
  * Internal dependencies
  */
 import { accountClose, accountClosed } from './controller';
-import { makeLayout, render as clientRender } from 'controller';
-import { sidebar } from 'me/controller';
-import { isEnabled } from 'config';
+import { makeLayout, render as clientRender } from 'calypso/controller';
+import { sidebar } from 'calypso/me/controller';
+import { isEnabled } from 'calypso/config';
 
 export default function () {
 	if ( isEnabled( 'me/account-close' ) ) {

--- a/client/me/account-close/main.jsx
+++ b/client/me/account-close/main.jsx
@@ -3,7 +3,7 @@
  */
 import React, { Component, Fragment } from 'react';
 import page from 'page';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import classnames from 'classnames';
@@ -12,28 +12,28 @@ import { map } from 'lodash';
 /**
  * Internal dependencies
  */
-import HeaderCake from 'components/header-cake';
-import ActionPanel from 'components/action-panel';
-import ActionPanelTitle from 'components/action-panel/title';
-import ActionPanelBody from 'components/action-panel/body';
-import ActionPanelFigure from 'components/action-panel/figure';
-import ActionPanelFigureHeader from 'components/action-panel/figure-header';
-import ActionPanelFigureList from 'components/action-panel/figure-list';
-import ActionPanelFigureListItem from 'components/action-panel/figure-list-item';
-import ActionPanelLink from 'components/action-panel/link';
-import ActionPanelFooter from 'components/action-panel/footer';
+import HeaderCake from 'calypso/components/header-cake';
+import ActionPanel from 'calypso/components/action-panel';
+import ActionPanelTitle from 'calypso/components/action-panel/title';
+import ActionPanelBody from 'calypso/components/action-panel/body';
+import ActionPanelFigure from 'calypso/components/action-panel/figure';
+import ActionPanelFigureHeader from 'calypso/components/action-panel/figure-header';
+import ActionPanelFigureList from 'calypso/components/action-panel/figure-list';
+import ActionPanelFigureListItem from 'calypso/components/action-panel/figure-list-item';
+import ActionPanelLink from 'calypso/components/action-panel/link';
+import ActionPanelFooter from 'calypso/components/action-panel/footer';
 import { Button } from '@automattic/components';
 import AccountCloseConfirmDialog from './confirm-dialog';
-import QueryUserPurchases from 'components/data/query-user-purchases';
-import { getCurrentUser } from 'state/current-user/selectors';
-import hasLoadedSites from 'state/selectors/has-loaded-sites';
-import getAccountClosureSites from 'state/selectors/get-account-closure-sites';
-import userHasAnyAtomicSites from 'state/selectors/user-has-any-atomic-sites';
-import isAccountClosed from 'state/selectors/is-account-closed';
-import { hasLoadedUserPurchasesFromServer } from 'state/purchases/selectors';
-import hasCancelableUserPurchases from 'state/selectors/has-cancelable-user-purchases';
-import getUserPurchasedPremiumThemes from 'state/selectors/get-user-purchased-premium-themes';
-import userUtils from 'lib/user/utils';
+import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import hasLoadedSites from 'calypso/state/selectors/has-loaded-sites';
+import getAccountClosureSites from 'calypso/state/selectors/get-account-closure-sites';
+import userHasAnyAtomicSites from 'calypso/state/selectors/user-has-any-atomic-sites';
+import isAccountClosed from 'calypso/state/selectors/is-account-closed';
+import { hasLoadedUserPurchasesFromServer } from 'calypso/state/purchases/selectors';
+import hasCancelableUserPurchases from 'calypso/state/selectors/has-cancelable-user-purchases';
+import getUserPurchasedPremiumThemes from 'calypso/state/selectors/get-user-purchased-premium-themes';
+import userUtils from 'calypso/lib/user/utils';
 
 /**
  * Style dependencies

--- a/client/me/account-password/index.jsx
+++ b/client/me/account-password/index.jsx
@@ -14,18 +14,18 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import { ProtectFormGuard } from 'lib/protect-form';
-import FormFieldset from 'components/forms/form-fieldset';
-import FormLabel from 'components/forms/form-label';
-import FormPasswordInput from 'components/forms/form-password-input';
-import FormButton from 'components/forms/form-button';
-import FormButtonsBar from 'components/forms/form-buttons-bar';
-import FormSettingExplanation from 'components/forms/form-setting-explanation';
-import FormInputValidation from 'components/forms/form-input-validation';
+import { ProtectFormGuard } from 'calypso/lib/protect-form';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormPasswordInput from 'calypso/components/forms/form-password-input';
+import FormButton from 'calypso/components/forms/form-button';
+import FormButtonsBar from 'calypso/components/forms/form-buttons-bar';
+import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
+import FormInputValidation from 'calypso/components/forms/form-input-validation';
 /* eslint-disable no-restricted-imports */
-import observe from 'lib/mixins/data-observe';
-import { errorNotice } from 'state/notices/actions';
-import { recordGoogleEvent } from 'state/analytics/actions';
+import observe from 'calypso/lib/mixins/data-observe';
+import { errorNotice } from 'calypso/state/notices/actions';
+import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 
 /**
  * Style dependencies

--- a/client/me/account/controller.js
+++ b/client/me/account/controller.js
@@ -9,10 +9,10 @@ import i18n from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import userSettings from 'lib/user-settings';
-import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
-import AccountComponent from 'me/account/main';
-import username from 'lib/username';
+import userSettings from 'calypso/lib/user-settings';
+import { setDocumentHeadTitle as setTitle } from 'calypso/state/document-head/actions';
+import AccountComponent from 'calypso/me/account/main';
+import username from 'calypso/lib/username';
 
 export function account( context, next ) {
 	let showNoticeInitially = false;

--- a/client/me/account/index.js
+++ b/client/me/account/index.js
@@ -7,8 +7,8 @@ import page from 'page';
  * Internal dependencies
  */
 import { account } from './controller';
-import { makeLayout, render as clientRender } from 'controller';
-import { sidebar } from 'me/controller';
+import { makeLayout, render as clientRender } from 'calypso/controller';
+import { sidebar } from 'calypso/me/controller';
 
 export default function () {
 	page( '/me/account', sidebar, account, makeLayout, clientRender );

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -15,49 +15,49 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import LanguagePicker from 'components/language-picker';
-import MeSidebarNavigation from 'me/sidebar-navigation';
-import { protectForm } from 'lib/protect-form';
-import formBase from 'me/form-base';
-import config from 'config';
-import { languages } from 'languages';
-import { supportsCssCustomProperties } from 'lib/feature-detection';
+import LanguagePicker from 'calypso/components/language-picker';
+import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
+import { protectForm } from 'calypso/lib/protect-form';
+import formBase from 'calypso/me/form-base';
+import config from 'calypso/config';
+import { languages } from 'calypso/languages';
+import { supportsCssCustomProperties } from 'calypso/lib/feature-detection';
 import { Card, Button } from '@automattic/components';
-import FormTextInput from 'components/forms/form-text-input';
-import FormTextValidation from 'components/forms/form-input-validation';
-import FormCheckbox from 'components/forms/form-checkbox';
-import FormFieldset from 'components/forms/form-fieldset';
-import FormLabel from 'components/forms/form-label';
-import FormLegend from 'components/forms/form-legend';
-import FormSettingExplanation from 'components/forms/form-setting-explanation';
-import FormButton from 'components/forms/form-button';
-import FormButtonsBar from 'components/forms/form-buttons-bar';
-import FormSectionHeading from 'components/forms/form-section-heading';
-import FormRadio from 'components/forms/form-radio';
-import { recordGoogleEvent, recordTracksEvent, bumpStat } from 'state/analytics/actions';
-import ReauthRequired from 'me/reauth-required';
-import twoStepAuthorization from 'lib/two-step-authorization';
-import Notice from 'components/notice';
-import NoticeAction from 'components/notice/notice-action';
-import observe from 'lib/mixins/data-observe'; // eslint-disable-line no-restricted-imports
-import Main from 'components/main';
-import SitesDropdown from 'components/sites-dropdown';
-import ColorSchemePicker from 'blocks/color-scheme-picker';
-import { successNotice, errorNotice } from 'state/notices/actions';
-import { getLanguage, isLocaleVariant, canBeTranslated } from 'lib/i18n-utils';
-import isRequestingMissingSites from 'state/selectors/is-requesting-missing-sites';
-import PageViewTracker from 'lib/analytics/page-view-tracker';
-import { canDisplayCommunityTranslator } from 'components/community-translator/utils';
-import { ENABLE_TRANSLATOR_KEY } from 'lib/i18n-utils/constants';
+import FormTextInput from 'calypso/components/forms/form-text-input';
+import FormTextValidation from 'calypso/components/forms/form-input-validation';
+import FormCheckbox from 'calypso/components/forms/form-checkbox';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormLegend from 'calypso/components/forms/form-legend';
+import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
+import FormButton from 'calypso/components/forms/form-button';
+import FormButtonsBar from 'calypso/components/forms/form-buttons-bar';
+import FormSectionHeading from 'calypso/components/forms/form-section-heading';
+import FormRadio from 'calypso/components/forms/form-radio';
+import { recordGoogleEvent, recordTracksEvent, bumpStat } from 'calypso/state/analytics/actions';
+import ReauthRequired from 'calypso/me/reauth-required';
+import twoStepAuthorization from 'calypso/lib/two-step-authorization';
+import Notice from 'calypso/components/notice';
+import NoticeAction from 'calypso/components/notice/notice-action';
+import observe from 'calypso/lib/mixins/data-observe'; // eslint-disable-line no-restricted-imports
+import Main from 'calypso/components/main';
+import SitesDropdown from 'calypso/components/sites-dropdown';
+import ColorSchemePicker from 'calypso/blocks/color-scheme-picker';
+import { successNotice, errorNotice } from 'calypso/state/notices/actions';
+import { getLanguage, isLocaleVariant, canBeTranslated } from 'calypso/lib/i18n-utils';
+import isRequestingMissingSites from 'calypso/state/selectors/is-requesting-missing-sites';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { canDisplayCommunityTranslator } from 'calypso/components/community-translator/utils';
+import { ENABLE_TRANSLATOR_KEY } from 'calypso/lib/i18n-utils/constants';
 import AccountSettingsCloseLink from './close-link';
-import { requestGeoLocation } from 'state/data-getters';
-import { withLocalizedMoment } from 'components/localized-moment';
+import { requestGeoLocation } from 'calypso/state/data-getters';
+import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import {
 	getCurrentUserDate,
 	getCurrentUserDisplayName,
 	getCurrentUserName,
 	getCurrentUserVisibleSiteCount,
-} from 'state/current-user/selectors';
+} from 'calypso/state/current-user/selectors';
 
 /**
  * Style dependencies

--- a/client/me/application-password-item/index.jsx
+++ b/client/me/application-password-item/index.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
@@ -10,10 +10,10 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import { Button } from '@automattic/components';
-import { withLocalizedMoment } from 'components/localized-moment';
-import { deleteApplicationPassword } from 'state/application-passwords/actions';
-import { errorNotice } from 'state/notices/actions';
-import { recordGoogleEvent } from 'state/analytics/actions';
+import { withLocalizedMoment } from 'calypso/components/localized-moment';
+import { deleteApplicationPassword } from 'calypso/state/application-passwords/actions';
+import { errorNotice } from 'calypso/state/notices/actions';
+import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 
 /**
  * Style dependencies

--- a/client/me/application-passwords/index.jsx
+++ b/client/me/application-passwords/index.jsx
@@ -3,30 +3,30 @@
  */
 import React, { Component, Fragment } from 'react';
 import classNames from 'classnames';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import AppPasswordItem from 'me/application-password-item';
+import AppPasswordItem from 'calypso/me/application-password-item';
 import { Button, Card } from '@automattic/components';
-import FormButton from 'components/forms/form-button';
-import FormButtonsBar from 'components/forms/form-buttons-bar';
-import FormFieldset from 'components/forms/form-fieldset';
-import FormLabel from 'components/forms/form-label';
-import FormSectionHeading from 'components/forms/form-section-heading';
-import FormTextInput from 'components/forms/form-text-input';
-import QueryApplicationPasswords from 'components/data/query-application-passwords';
-import SectionHeader from 'components/section-header';
+import FormButton from 'calypso/components/forms/form-button';
+import FormButtonsBar from 'calypso/components/forms/form-buttons-bar';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormSectionHeading from 'calypso/components/forms/form-section-heading';
+import FormTextInput from 'calypso/components/forms/form-text-input';
+import QueryApplicationPasswords from 'calypso/components/data/query-application-passwords';
+import SectionHeader from 'calypso/components/section-header';
 import {
 	clearNewApplicationPassword,
 	createApplicationPassword,
-} from 'state/application-passwords/actions';
-import getApplicationPasswords from 'state/selectors/get-application-passwords';
-import getNewApplicationPassword from 'state/selectors/get-new-application-password';
-import { recordGoogleEvent } from 'state/analytics/actions';
+} from 'calypso/state/application-passwords/actions';
+import getApplicationPasswords from 'calypso/state/selectors/get-application-passwords';
+import getNewApplicationPassword from 'calypso/state/selectors/get-new-application-password';
+import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 
 /**
  * Style dependencies

--- a/client/me/billing-history/billing-history-table.jsx
+++ b/client/me/billing-history/billing-history-table.jsx
@@ -8,11 +8,11 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal Dependencies
  */
-import { billingHistoryReceipt } from 'me/purchases/paths';
+import { billingHistoryReceipt } from 'calypso/me/purchases/paths';
 import TransactionsTable from './transactions-table';
-import isSendingBillingReceiptEmail from 'state/selectors/is-sending-billing-receipt-email';
-import { recordGoogleEvent } from 'state/analytics/actions';
-import { sendBillingReceiptEmail as sendBillingReceiptEmailAction } from 'state/billing-transactions/actions';
+import isSendingBillingReceiptEmail from 'calypso/state/selectors/is-sending-billing-receipt-email';
+import { recordGoogleEvent } from 'calypso/state/analytics/actions';
+import { sendBillingReceiptEmail as sendBillingReceiptEmailAction } from 'calypso/state/billing-transactions/actions';
 
 class BillingHistoryTable extends React.Component {
 	recordClickEvent = ( eventAction ) => {

--- a/client/me/billing-history/main.jsx
+++ b/client/me/billing-history/main.jsx
@@ -8,15 +8,15 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import { Card } from '@automattic/components';
-import MeSidebarNavigation from 'me/sidebar-navigation';
-import config from 'config';
-import CreditCards from 'me/purchases/credit-cards';
+import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
+import config from 'calypso/config';
+import CreditCards from 'calypso/me/purchases/credit-cards';
 import PurchasesHeader from '../purchases/purchases-list/header';
 import BillingHistoryTable from './billing-history-table';
-import Main from 'components/main';
-import DocumentHead from 'components/data/document-head';
-import PageViewTracker from 'lib/analytics/page-view-tracker';
-import QueryBillingTransactions from 'components/data/query-billing-transactions';
+import Main from 'calypso/components/main';
+import DocumentHead from 'calypso/components/data/document-head';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import QueryBillingTransactions from 'calypso/components/data/query-billing-transactions';
 
 /**
  * Style dependencies

--- a/client/me/billing-history/receipt.jsx
+++ b/client/me/billing-history/receipt.jsx
@@ -10,24 +10,24 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import { Button, Card } from '@automattic/components';
-import TextareaAutosize from 'components/textarea-autosize';
-import DocumentHead from 'components/data/document-head';
-import HeaderCake from 'components/header-cake';
-import Main from 'components/main';
-import { withLocalizedMoment } from 'components/localized-moment';
-import PageViewTracker from 'lib/analytics/page-view-tracker';
-import { billingHistory } from 'me/purchases/paths';
-import QueryBillingTransaction from 'components/data/query-billing-transaction';
+import TextareaAutosize from 'calypso/components/textarea-autosize';
+import DocumentHead from 'calypso/components/data/document-head';
+import HeaderCake from 'calypso/components/header-cake';
+import Main from 'calypso/components/main';
+import { withLocalizedMoment } from 'calypso/components/localized-moment';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { billingHistory } from 'calypso/me/purchases/paths';
+import QueryBillingTransaction from 'calypso/components/data/query-billing-transaction';
 import { groupDomainProducts, renderTransactionAmount } from './utils';
-import getPastBillingTransaction from 'state/selectors/get-past-billing-transaction';
-import isPastBillingTransactionError from 'state/selectors/is-past-billing-transaction-error';
+import getPastBillingTransaction from 'calypso/state/selectors/get-past-billing-transaction';
+import isPastBillingTransactionError from 'calypso/state/selectors/is-past-billing-transaction-error';
 import {
 	clearBillingTransactionError,
 	requestBillingTransaction,
-} from 'state/billing-transactions/individual-transactions/actions';
-import { recordGoogleEvent } from 'state/analytics/actions';
-import { getPlanTermLabel } from 'lib/plans';
-import { PARTNER_PAYPAL_EXPRESS } from 'lib/checkout/payment-methods';
+} from 'calypso/state/billing-transactions/individual-transactions/actions';
+import { recordGoogleEvent } from 'calypso/state/analytics/actions';
+import { getPlanTermLabel } from 'calypso/lib/plans';
+import { PARTNER_PAYPAL_EXPRESS } from 'calypso/lib/checkout/payment-methods';
 
 class BillingReceipt extends React.Component {
 	componentDidMount() {

--- a/client/me/billing-history/transactions-header.jsx
+++ b/client/me/billing-history/transactions-header.jsx
@@ -11,13 +11,13 @@ import { find, isEqual } from 'lodash';
 /**
  * Internal dependencies
  */
-import SelectDropdown from 'components/select-dropdown';
-import { withLocalizedMoment } from 'components/localized-moment';
-import { recordGoogleEvent } from 'state/analytics/actions';
-import { setApp, setDate } from 'state/billing-transactions/ui/actions';
-import getBillingTransactionAppFilterValues from 'state/selectors/get-billing-transaction-app-filter-values';
-import getBillingTransactionDateFilterValues from 'state/selectors/get-billing-transaction-date-filter-values';
-import getBillingTransactionFilters from 'state/selectors/get-billing-transaction-filters';
+import SelectDropdown from 'calypso/components/select-dropdown';
+import { withLocalizedMoment } from 'calypso/components/localized-moment';
+import { recordGoogleEvent } from 'calypso/state/analytics/actions';
+import { setApp, setDate } from 'calypso/state/billing-transactions/ui/actions';
+import getBillingTransactionAppFilterValues from 'calypso/state/selectors/get-billing-transaction-app-filter-values';
+import getBillingTransactionDateFilterValues from 'calypso/state/selectors/get-billing-transaction-date-filter-values';
+import getBillingTransactionFilters from 'calypso/state/selectors/get-billing-transaction-filters';
 
 class TransactionsHeader extends React.Component {
 	state = {

--- a/client/me/billing-history/transactions-table.jsx
+++ b/client/me/billing-history/transactions-table.jsx
@@ -7,21 +7,21 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import titleCase from 'to-title-case';
-import { capitalPDangit } from 'lib/formatting';
+import { capitalPDangit } from 'calypso/lib/formatting';
 
 /**
  * Internal dependencies
  */
 import { CompactCard } from '@automattic/components';
-import Pagination from 'components/pagination';
+import Pagination from 'calypso/components/pagination';
 import TransactionsHeader from './transactions-header';
 import { groupDomainProducts, renderTransactionAmount } from './utils';
-import SearchCard from 'components/search-card';
-import { withLocalizedMoment } from 'components/localized-moment';
-import { setPage, setQuery } from 'state/billing-transactions/ui/actions';
-import getBillingTransactionFilters from 'state/selectors/get-billing-transaction-filters';
-import getFilteredBillingTransactions from 'state/selectors/get-filtered-billing-transactions';
-import { getPlanTermLabel } from 'lib/plans';
+import SearchCard from 'calypso/components/search-card';
+import { withLocalizedMoment } from 'calypso/components/localized-moment';
+import { setPage, setQuery } from 'calypso/state/billing-transactions/ui/actions';
+import getBillingTransactionFilters from 'calypso/state/selectors/get-billing-transaction-filters';
+import getFilteredBillingTransactions from 'calypso/state/selectors/get-filtered-billing-transactions';
+import { getPlanTermLabel } from 'calypso/lib/plans';
 
 class TransactionsTable extends React.Component {
 	static displayName = 'TransactionsTable';

--- a/client/me/billing-history/upcoming-charges-table.jsx
+++ b/client/me/billing-history/upcoming-charges-table.jsx
@@ -9,9 +9,9 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal Dependencies
  */
-import { managePurchase, purchasesRoot } from 'me/purchases/paths';
+import { managePurchase, purchasesRoot } from 'calypso/me/purchases/paths';
 import TransactionsTable from './transactions-table';
-import getSiteSlugsForUpcomingTransactions from 'state/selectors/get-site-slugs-for-upcoming-transactions';
+import getSiteSlugsForUpcomingTransactions from 'calypso/state/selectors/get-site-slugs-for-upcoming-transactions';
 
 class UpcomingChargesTable extends Component {
 	static propTypes = {

--- a/client/me/billing-history/upcoming-charges.jsx
+++ b/client/me/billing-history/upcoming-charges.jsx
@@ -8,13 +8,13 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import { Card } from '@automattic/components';
-import MeSidebarNavigation from 'me/sidebar-navigation';
+import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
 import PurchasesHeader from '../purchases/purchases-list/header';
 import UpcomingChargesTable from './upcoming-charges-table';
-import Main from 'components/main';
-import DocumentHead from 'components/data/document-head';
-import PageViewTracker from 'lib/analytics/page-view-tracker';
-import QueryBillingTransactions from 'components/data/query-billing-transactions';
+import Main from 'calypso/components/main';
+import DocumentHead from 'calypso/components/data/document-head';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import QueryBillingTransactions from 'calypso/components/data/query-billing-transactions';
 
 /**
  * Style dependencies

--- a/client/me/concierge/book/calendar-step.js
+++ b/client/me/concierge/book/calendar-step.js
@@ -9,21 +9,21 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import HeaderCake from 'components/header-cake';
+import HeaderCake from 'calypso/components/header-cake';
 import { CompactCard } from '@automattic/components';
-import getConciergeSignupForm from 'state/selectors/get-concierge-signup-form';
-import getConciergeScheduleId from 'state/selectors/get-concierge-schedule-id';
-import getConciergeAppointmentTimespan from 'state/selectors/get-concierge-appointment-timespan';
-import { getCurrentUserId, getCurrentUserLocale } from 'state/current-user/selectors';
-import { bookConciergeAppointment, requestConciergeInitial } from 'state/concierge/actions';
+import getConciergeSignupForm from 'calypso/state/selectors/get-concierge-signup-form';
+import getConciergeScheduleId from 'calypso/state/selectors/get-concierge-schedule-id';
+import getConciergeAppointmentTimespan from 'calypso/state/selectors/get-concierge-appointment-timespan';
+import { getCurrentUserId, getCurrentUserLocale } from 'calypso/state/current-user/selectors';
+import { bookConciergeAppointment, requestConciergeInitial } from 'calypso/state/concierge/actions';
 import AvailableTimePicker from '../shared/available-time-picker';
 import {
 	CONCIERGE_STATUS_BOOKED,
 	CONCIERGE_STATUS_BOOKING,
 	CONCIERGE_STATUS_BOOKING_ERROR,
 } from '../constants';
-import { recordTracksEvent } from 'state/analytics/actions';
-import ExternalLinkWithTracking from 'components/external-link/with-tracking';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import ExternalLinkWithTracking from 'calypso/components/external-link/with-tracking';
 
 class CalendarStep extends Component {
 	static propTypes = {

--- a/client/me/concierge/book/confirmation-step.js
+++ b/client/me/concierge/book/confirmation-step.js
@@ -10,7 +10,7 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { Button } from '@automattic/components';
 import Confirmation from '../shared/confirmation';
-import { recordTracksEvent } from 'state/analytics/actions';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 class ConfirmationStep extends Component {
 	componentDidMount() {

--- a/client/me/concierge/book/info-step.js
+++ b/client/me/concierge/book/info-step.js
@@ -4,35 +4,35 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import config from 'config';
+import config from 'calypso/config';
 import { includes } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import Notice from 'components/notice';
+import Notice from 'calypso/components/notice';
 import { CompactCard } from '@automattic/components';
-import FormButton from 'components/forms/form-button';
-import FormFieldset from 'components/forms/form-fieldset';
-import FormLabel from 'components/forms/form-label';
-import FormSettingExplanation from 'components/forms/form-setting-explanation';
-import FormTextarea from 'components/forms/form-textarea';
-import FormTextInput from 'components/forms/form-text-input';
-import FormPhoneInput from 'components/forms/form-phone-input';
+import FormButton from 'calypso/components/forms/form-button';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
+import FormTextarea from 'calypso/components/forms/form-textarea';
+import FormTextInput from 'calypso/components/forms/form-text-input';
+import FormPhoneInput from 'calypso/components/forms/form-phone-input';
 import IsRebrandCitiesSite from './is-rebrand-cities-site';
-import Timezone from 'components/timezone';
-import Site from 'blocks/site';
+import Timezone from 'calypso/components/timezone';
+import Site from 'calypso/blocks/site';
 import { localize } from 'i18n-calypso';
-import { updateConciergeSignupForm } from 'state/concierge/actions';
-import getConciergeSignupForm from 'state/selectors/get-concierge-signup-form';
-import getUserSettings from 'state/selectors/get-user-settings';
-import { getCurrentUserLocale } from 'state/current-user/selectors';
+import { updateConciergeSignupForm } from 'calypso/state/concierge/actions';
+import getConciergeSignupForm from 'calypso/state/selectors/get-concierge-signup-form';
+import getUserSettings from 'calypso/state/selectors/get-user-settings';
+import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import PrimaryHeader from '../shared/primary-header';
-import { recordTracksEvent } from 'state/analytics/actions';
-import { getLanguage } from 'lib/i18n-utils';
-import getCountries from 'state/selectors/get-countries';
-import QuerySmsCountries from 'components/data/query-countries/sms';
-import FormInputValidation from 'components/forms/form-input-validation';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getLanguage } from 'calypso/lib/i18n-utils';
+import getCountries from 'calypso/state/selectors/get-countries';
+import QuerySmsCountries from 'calypso/components/data/query-countries/sms';
+import FormInputValidation from 'calypso/components/forms/form-input-validation';
 
 class InfoStep extends Component {
 	static propTypes = {

--- a/client/me/concierge/book/is-rebrand-cities-site.js
+++ b/client/me/concierge/book/is-rebrand-cities-site.js
@@ -23,7 +23,7 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import SiteUsersFetcher from 'components/site-users-fetcher';
+import SiteUsersFetcher from 'calypso/components/site-users-fetcher';
 
 const REBRAND_CITIES_ACCOUNT_USERNAME = 'rebrandcities';
 

--- a/client/me/concierge/book/skeleton.js
+++ b/client/me/concierge/book/skeleton.js
@@ -8,7 +8,7 @@ import React, { Component } from 'react';
  */
 import { CompactCard } from '@automattic/components';
 import PrimaryHeader from '../shared/primary-header';
-import SitePlaceholder from 'blocks/site/placeholder';
+import SitePlaceholder from 'calypso/blocks/site/placeholder';
 
 class Skeleton extends Component {
 	render() {

--- a/client/me/concierge/cancel/index.js
+++ b/client/me/concierge/cancel/index.js
@@ -9,22 +9,22 @@ import { includes } from 'lodash';
 /**
  * Internal dependencies
  */
-import HeaderCake from 'components/header-cake';
-import QuerySites from 'components/data/query-sites';
-import QueryConciergeInitial from 'components/data/query-concierge-initial';
-import QueryConciergeAppointmentDetails from 'components/data/query-concierge-appointment-details';
+import HeaderCake from 'calypso/components/header-cake';
+import QuerySites from 'calypso/components/data/query-sites';
+import QueryConciergeInitial from 'calypso/components/data/query-concierge-initial';
+import QueryConciergeAppointmentDetails from 'calypso/components/data/query-concierge-appointment-details';
 import { Button, CompactCard } from '@automattic/components';
-import Main from 'components/main';
+import Main from 'calypso/components/main';
 import { localize } from 'i18n-calypso';
 import Confirmation from '../shared/confirmation';
-import { cancelConciergeAppointment } from 'state/concierge/actions';
+import { cancelConciergeAppointment } from 'calypso/state/concierge/actions';
 import { CONCIERGE_STATUS_CANCELLED, CONCIERGE_STATUS_CANCELLING } from '../constants';
-import { getSite } from 'state/sites/selectors';
-import getConciergeAppointmentDetails from 'state/selectors/get-concierge-appointment-details';
-import getConciergeScheduleId from 'state/selectors/get-concierge-schedule-id';
-import getConciergeSignupForm from 'state/selectors/get-concierge-signup-form';
-import { recordTracksEvent } from 'state/analytics/actions';
-import PageViewTracker from 'lib/analytics/page-view-tracker';
+import { getSite } from 'calypso/state/sites/selectors';
+import getConciergeAppointmentDetails from 'calypso/state/selectors/get-concierge-appointment-details';
+import getConciergeScheduleId from 'calypso/state/selectors/get-concierge-schedule-id';
+import getConciergeSignupForm from 'calypso/state/selectors/get-concierge-signup-form';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 
 class ConciergeCancel extends Component {
 	static propTypes = {

--- a/client/me/concierge/controller.js
+++ b/client/me/concierge/controller.js
@@ -16,7 +16,7 @@ import RescheduleCalendarStep from './reschedule/calendar-step';
 import RescheduleConfirmationStep from './reschedule/confirmation-step';
 import RescheduleSkeleton from './reschedule/skeleton';
 import i18n from 'i18n-calypso';
-import { recordTracksEvent } from 'state/analytics/actions';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 /**
  * Style dependencies

--- a/client/me/concierge/index.js
+++ b/client/me/concierge/index.js
@@ -8,8 +8,8 @@ import page from 'page';
  * Internal dependencies
  */
 import controller from './controller';
-import { makeLayout, render as clientRender } from 'controller';
-import { siteSelection, sites } from 'my-sites/controller';
+import { makeLayout, render as clientRender } from 'calypso/controller';
+import { siteSelection, sites } from 'calypso/my-sites/controller';
 
 const redirectToBooking = ( context ) => {
 	page.redirect( `/me/concierge/${ context.params.siteSlug }/book` );

--- a/client/me/concierge/main.js
+++ b/client/me/concierge/main.js
@@ -19,22 +19,22 @@ import { isEmpty } from 'lodash';
 /**
  * Internal dependencies
  */
-import Main from 'components/main';
-import QueryConciergeInitial from 'components/data/query-concierge-initial';
-import QueryUserSettings from 'components/data/query-user-settings';
-import QuerySites from 'components/data/query-sites';
-import QuerySitePlans from 'components/data/query-site-plans';
-import getConciergeAvailableTimes from 'state/selectors/get-concierge-available-times';
-import getConciergeScheduleId from 'state/selectors/get-concierge-schedule-id';
-import getConciergeNextAppointment from 'state/selectors/get-concierge-next-appointment';
-import getUserSettings from 'state/selectors/get-user-settings';
-import { getSite } from 'state/sites/selectors';
+import Main from 'calypso/components/main';
+import QueryConciergeInitial from 'calypso/components/data/query-concierge-initial';
+import QueryUserSettings from 'calypso/components/data/query-user-settings';
+import QuerySites from 'calypso/components/data/query-sites';
+import QuerySitePlans from 'calypso/components/data/query-site-plans';
+import getConciergeAvailableTimes from 'calypso/state/selectors/get-concierge-available-times';
+import getConciergeScheduleId from 'calypso/state/selectors/get-concierge-schedule-id';
+import getConciergeNextAppointment from 'calypso/state/selectors/get-concierge-next-appointment';
+import getUserSettings from 'calypso/state/selectors/get-user-settings';
+import { getSite } from 'calypso/state/sites/selectors';
 import NoAvailableTimes from './shared/no-available-times';
 import Upsell from './shared/upsell';
 import AppointmentInfo from './shared/appointment-info';
-import PageViewTracker from 'lib/analytics/page-view-tracker';
-import ReauthRequired from 'me/reauth-required';
-import twoStepAuthorization from 'lib/two-step-authorization';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import ReauthRequired from 'calypso/me/reauth-required';
+import twoStepAuthorization from 'calypso/lib/two-step-authorization';
 
 export class ConciergeMain extends Component {
 	constructor( props ) {

--- a/client/me/concierge/reschedule/calendar-step.js
+++ b/client/me/concierge/reschedule/calendar-step.js
@@ -11,23 +11,23 @@ import { without } from 'lodash';
  * Internal dependencies
  */
 import { CompactCard } from '@automattic/components';
-import Timezone from 'components/timezone';
-import FormFieldset from 'components/forms/form-fieldset';
-import FormLabel from 'components/forms/form-label';
-import FormSettingExplanation from 'components/forms/form-setting-explanation';
-import QueryConciergeAppointmentDetails from 'components/data/query-concierge-appointment-details';
-import getConciergeAppointmentDetails from 'state/selectors/get-concierge-appointment-details';
-import getConciergeSignupForm from 'state/selectors/get-concierge-signup-form';
-import getConciergeScheduleId from 'state/selectors/get-concierge-schedule-id';
-import getConciergeAppointmentTimespan from 'state/selectors/get-concierge-appointment-timespan';
-import { getCurrentUserLocale } from 'state/current-user/selectors';
+import Timezone from 'calypso/components/timezone';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
+import QueryConciergeAppointmentDetails from 'calypso/components/data/query-concierge-appointment-details';
+import getConciergeAppointmentDetails from 'calypso/state/selectors/get-concierge-appointment-details';
+import getConciergeSignupForm from 'calypso/state/selectors/get-concierge-signup-form';
+import getConciergeScheduleId from 'calypso/state/selectors/get-concierge-schedule-id';
+import getConciergeAppointmentTimespan from 'calypso/state/selectors/get-concierge-appointment-timespan';
+import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import {
 	rescheduleConciergeAppointment,
 	updateConciergeAppointmentDetails,
-} from 'state/concierge/actions';
+} from 'calypso/state/concierge/actions';
 import AvailableTimePicker from '../shared/available-time-picker';
 import { CONCIERGE_STATUS_BOOKING, CONCIERGE_STATUS_BOOKED } from '../constants';
-import { recordTracksEvent } from 'state/analytics/actions';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 class CalendarStep extends Component {
 	static propTypes = {

--- a/client/me/concierge/reschedule/confirmation-step.js
+++ b/client/me/concierge/reschedule/confirmation-step.js
@@ -10,7 +10,7 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { Button } from '@automattic/components';
 import Confirmation from '../shared/confirmation';
-import { recordTracksEvent } from 'state/analytics/actions';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 class ConfirmationStep extends Component {
 	componentDidMount() {

--- a/client/me/concierge/shared/appointment-info.js
+++ b/client/me/concierge/shared/appointment-info.js
@@ -11,14 +11,14 @@ import 'moment-timezone';
  */
 import Confirmation from './confirmation';
 import { CompactCard } from '@automattic/components';
-import Site from 'blocks/site';
-import FormattedHeader from 'components/formatted-header';
-import FormSettingExplanation from 'components/forms/form-setting-explanation';
-import FormFieldset from 'components/forms/form-fieldset';
-import FormLabel from 'components/forms/form-label';
-import FormTextInput from 'components/forms/form-text-input';
-import FormButton from 'components/forms/form-button';
-import { withLocalizedMoment } from 'components/localized-moment';
+import Site from 'calypso/blocks/site';
+import FormattedHeader from 'calypso/components/formatted-header';
+import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormTextInput from 'calypso/components/forms/form-text-input';
+import FormButton from 'calypso/components/forms/form-button';
+import { withLocalizedMoment } from 'calypso/components/localized-moment';
 
 class AppointmentInfo extends Component {
 	static propTypes = {

--- a/client/me/concierge/shared/available-time-card.js
+++ b/client/me/concierge/shared/available-time-card.js
@@ -8,25 +8,25 @@
 /**
  * External dependencies
  */
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { isEmpty } from 'lodash';
 import { localize } from 'i18n-calypso';
-import config from 'config';
+import config from 'calypso/config';
 import 'moment-timezone'; // monkey patches the existing moment.js
 
 /**
  * Internal dependencies
  */
 import { Button } from '@automattic/components';
-import FoldableCard from 'components/foldable-card';
-import FormFieldset from 'components/forms/form-fieldset';
-import FormLabel from 'components/forms/form-label';
-import FormSelect from 'components/forms/form-select';
-import FormSettingExplanation from 'components/forms/form-setting-explanation';
-import { withLocalizedMoment } from 'components/localized-moment';
-import { getLanguage } from 'lib/i18n-utils';
+import FoldableCard from 'calypso/components/foldable-card';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormSelect from 'calypso/components/forms/form-select';
+import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
+import { withLocalizedMoment } from 'calypso/components/localized-moment';
+import { getLanguage } from 'calypso/lib/i18n-utils';
 
 const defaultLanguage = getLanguage( config( 'i18n_default_locale_slug' ) ).name;
 

--- a/client/me/concierge/shared/available-time-picker.js
+++ b/client/me/concierge/shared/available-time-picker.js
@@ -9,7 +9,7 @@ import moment from 'moment-timezone';
  * Internal dependencies
  */
 import AvailableTimeCard from './available-time-card';
-import { isDefaultLocale } from 'lib/i18n-utils';
+import { isDefaultLocale } from 'calypso/lib/i18n-utils';
 
 const groupAvailableTimesByDate = ( availableTimes, timezone ) => {
 	const dates = {};

--- a/client/me/concierge/shared/closure-notice.js
+++ b/client/me/concierge/shared/closure-notice.js
@@ -10,7 +10,7 @@ import 'moment-timezone'; // monkey patches the existing moment.js
  * Internal dependencies
  */
 import { CompactCard as Card } from '@automattic/components';
-import { useLocalizedMoment } from 'components/localized-moment';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
 
 const DATE_FORMAT = 'LLL';
 

--- a/client/me/concierge/shared/confirmation.js
+++ b/client/me/concierge/shared/confirmation.js
@@ -8,7 +8,7 @@ import React, { Component } from 'react';
  * Internal dependencies
  */
 import { Card } from '@automattic/components';
-import FormattedHeader from 'components/formatted-header';
+import FormattedHeader from 'calypso/components/formatted-header';
 
 class Confirmation extends Component {
 	static propTypes = {

--- a/client/me/concierge/shared/gm-closure-notice.js
+++ b/client/me/concierge/shared/gm-closure-notice.js
@@ -10,7 +10,7 @@ import 'moment-timezone'; // monkey patches the existing moment.js
  * Internal dependencies
  */
 import { CompactCard as Card } from '@automattic/components';
-import { useLocalizedMoment } from 'components/localized-moment';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
 
 const DATE_FORMAT = 'dddd, MMMM Do LT';
 

--- a/client/me/concierge/shared/no-available-times.js
+++ b/client/me/concierge/shared/no-available-times.js
@@ -10,8 +10,8 @@ import { localize } from 'i18n-calypso';
  */
 import { Card } from '@automattic/components';
 import PrimaryHeader from './primary-header';
-import { recordTracksEvent } from 'state/analytics/actions';
-import ExternalLinkWithTracking from 'components/external-link/with-tracking';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import ExternalLinkWithTracking from 'calypso/components/external-link/with-tracking';
 
 class NoAvailableTimes extends Component {
 	componentDidMount() {

--- a/client/me/concierge/shared/primary-header.js
+++ b/client/me/concierge/shared/primary-header.js
@@ -7,10 +7,10 @@ import React, { Component, Fragment } from 'react';
  * Internal dependencies
  */
 import { Card } from '@automattic/components';
-import FormattedHeader from 'components/formatted-header';
-import ExternalLink from 'components/external-link';
+import FormattedHeader from 'calypso/components/formatted-header';
+import ExternalLink from 'calypso/components/external-link';
 import { localize } from 'i18n-calypso';
-import { CONCIERGE_SUPPORT } from 'lib/url/support';
+import { CONCIERGE_SUPPORT } from 'calypso/lib/url/support';
 
 class PrimaryHeader extends Component {
 	render() {

--- a/client/me/concierge/shared/upsell.js
+++ b/client/me/concierge/shared/upsell.js
@@ -11,8 +11,8 @@ import { localize } from 'i18n-calypso';
  */
 import { Button, CompactCard } from '@automattic/components';
 import PrimaryHeader from './primary-header';
-import Site from 'blocks/site';
-import { recordTracksEvent } from 'state/analytics/actions';
+import Site from 'calypso/blocks/site';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 class Upsell extends Component {
 	static propTypes = {

--- a/client/me/connected-application-icon/index.jsx
+++ b/client/me/connected-application-icon/index.jsx
@@ -7,7 +7,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import PluginIcon from 'my-sites/plugins/plugin-icon/plugin-icon';
+import PluginIcon from 'calypso/my-sites/plugins/plugin-icon/plugin-icon';
 
 /**
  * Style dependencies

--- a/client/me/connected-application-item/index.jsx
+++ b/client/me/connected-application-item/index.jsx
@@ -10,12 +10,12 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import { Button } from '@automattic/components';
-import ConnectedApplicationIcon from 'me/connected-application-icon';
-import FoldableCard from 'components/foldable-card';
-import { withLocalizedMoment } from 'components/localized-moment';
-import safeProtocolUrl from 'lib/safe-protocol-url';
-import { deleteConnectedApplication } from 'state/connected-applications/actions';
-import { recordGoogleEvent } from 'state/analytics/actions';
+import ConnectedApplicationIcon from 'calypso/me/connected-application-icon';
+import FoldableCard from 'calypso/components/foldable-card';
+import { withLocalizedMoment } from 'calypso/components/localized-moment';
+import safeProtocolUrl from 'calypso/lib/safe-protocol-url';
+import { deleteConnectedApplication } from 'calypso/state/connected-applications/actions';
+import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 
 /**
  * Style dependencies

--- a/client/me/connected-applications/index.jsx
+++ b/client/me/connected-applications/index.jsx
@@ -10,19 +10,19 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import config from 'config';
-import ConnectedAppItem from 'me/connected-application-item';
-import DocumentHead from 'components/data/document-head';
-import EmptyContent from 'components/empty-content';
-import getConnectedApplications from 'state/selectors/get-connected-applications';
-import HeaderCake from 'components/header-cake';
-import Main from 'components/main';
-import MeSidebarNavigation from 'me/sidebar-navigation';
-import PageViewTracker from 'lib/analytics/page-view-tracker';
-import QueryConnectedApplications from 'components/data/query-connected-applications';
-import ReauthRequired from 'me/reauth-required';
-import SecuritySectionNav from 'me/security-section-nav';
-import twoStepAuthorization from 'lib/two-step-authorization';
+import config from 'calypso/config';
+import ConnectedAppItem from 'calypso/me/connected-application-item';
+import DocumentHead from 'calypso/components/data/document-head';
+import EmptyContent from 'calypso/components/empty-content';
+import getConnectedApplications from 'calypso/state/selectors/get-connected-applications';
+import HeaderCake from 'calypso/components/header-cake';
+import Main from 'calypso/components/main';
+import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import QueryConnectedApplications from 'calypso/components/data/query-connected-applications';
+import ReauthRequired from 'calypso/me/reauth-required';
+import SecuritySectionNav from 'calypso/me/security-section-nav';
+import twoStepAuthorization from 'calypso/lib/two-step-authorization';
 
 /**
  * Style dependencies

--- a/client/me/controller.js
+++ b/client/me/controller.js
@@ -8,10 +8,10 @@ import i18n from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import userSettings from 'lib/user-settings';
-import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
-import SidebarComponent from 'me/sidebar';
-import AppsComponent from 'me/get-apps';
+import userSettings from 'calypso/lib/user-settings';
+import { setDocumentHeadTitle as setTitle } from 'calypso/state/document-head/actions';
+import SidebarComponent from 'calypso/me/sidebar';
+import AppsComponent from 'calypso/me/get-apps';
 
 export function sidebar( context, next ) {
 	context.secondary = React.createElement( SidebarComponent, {
@@ -25,7 +25,7 @@ export function profile( context, next ) {
 	// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 	context.store.dispatch( setTitle( i18n.translate( 'My Profile', { textOnly: true } ) ) );
 
-	const ProfileComponent = require( 'me/profile' ).default;
+	const ProfileComponent = require( 'calypso/me/profile' ).default;
 
 	context.primary = React.createElement( ProfileComponent, {
 		userSettings: userSettings,

--- a/client/me/form-base/index.js
+++ b/client/me/form-base/index.js
@@ -8,8 +8,8 @@ const debug = debugFactory( 'calypso:me:form-base' );
 /**
  * Internal dependencies
  */
-import notices from 'notices';
-import user from 'lib/user';
+import notices from 'calypso/notices';
+import user from 'calypso/lib/user';
 
 export default {
 	componentDidMount: function () {

--- a/client/me/get-apps/index.jsx
+++ b/client/me/get-apps/index.jsx
@@ -7,10 +7,10 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import MeSidebarNavigation from 'me/sidebar-navigation';
-import Main from 'components/main';
-import PageViewTracker from 'lib/analytics/page-view-tracker';
-import GetAppsBlock from 'blocks/get-apps';
+import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
+import Main from 'calypso/components/main';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import GetAppsBlock from 'calypso/blocks/get-apps';
 
 export const GetApps = () => {
 	return (

--- a/client/me/happychat/index.jsx
+++ b/client/me/happychat/index.jsx
@@ -8,12 +8,12 @@ import { translate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import config from 'config';
-import { sidebar } from 'me/controller';
+import config from 'calypso/config';
+import { sidebar } from 'calypso/me/controller';
 import Happychat from './main';
-import { setDocumentHeadTitle } from 'state/document-head/actions';
-import { makeLayout, render as clientRender } from 'controller';
-import PageViewTracker from 'lib/analytics/page-view-tracker';
+import { setDocumentHeadTitle } from 'calypso/state/document-head/actions';
+import { makeLayout, render as clientRender } from 'calypso/controller';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 
 const renderChat = ( context, next ) => {
 	context.store.dispatch( setDocumentHeadTitle( translate( 'Chat', { textOnly: true } ) ) );

--- a/client/me/happychat/main.jsx
+++ b/client/me/happychat/main.jsx
@@ -9,24 +9,24 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import config from 'config';
-import { isOutsideCalypso } from 'lib/url';
+import config from 'calypso/config';
+import { isOutsideCalypso } from 'calypso/lib/url';
 // actions
-import { sendMessage, sendNotTyping, sendTyping } from 'state/happychat/connection/actions';
-import { blur, focus, setCurrentMessage } from 'state/happychat/ui/actions';
+import { sendMessage, sendNotTyping, sendTyping } from 'calypso/state/happychat/connection/actions';
+import { blur, focus, setCurrentMessage } from 'calypso/state/happychat/ui/actions';
 // selectors
-import canUserSendMessages from 'state/happychat/selectors/can-user-send-messages';
-import { getCurrentUser } from 'state/current-user/selectors';
-import getCurrentMessage from 'state/happychat/selectors/get-happychat-current-message';
-import getHappychatChatStatus from 'state/happychat/selectors/get-happychat-chat-status';
-import getHappychatConnectionStatus from 'state/happychat/selectors/get-happychat-connection-status';
-import getHappychatTimeline from 'state/happychat/selectors/get-happychat-timeline';
-import isHappychatServerReachable from 'state/happychat/selectors/is-happychat-server-reachable';
+import canUserSendMessages from 'calypso/state/happychat/selectors/can-user-send-messages';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import getCurrentMessage from 'calypso/state/happychat/selectors/get-happychat-current-message';
+import getHappychatChatStatus from 'calypso/state/happychat/selectors/get-happychat-chat-status';
+import getHappychatConnectionStatus from 'calypso/state/happychat/selectors/get-happychat-connection-status';
+import getHappychatTimeline from 'calypso/state/happychat/selectors/get-happychat-timeline';
+import isHappychatServerReachable from 'calypso/state/happychat/selectors/is-happychat-server-reachable';
 // UI components
-import HappychatConnection from 'components/happychat/connection-connected';
-import { Composer } from 'components/happychat/composer';
-import { Notices } from 'components/happychat/notices';
-import { Timeline } from 'components/happychat/timeline';
+import HappychatConnection from 'calypso/components/happychat/connection-connected';
+import { Composer } from 'calypso/components/happychat/composer';
+import { Notices } from 'calypso/components/happychat/notices';
+import { Timeline } from 'calypso/components/happychat/timeline';
 
 /**
  * Style dependencies

--- a/client/me/help/active-tickets-notice/index.jsx
+++ b/client/me/help/active-tickets-notice/index.jsx
@@ -8,8 +8,8 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import Notice from 'components/notice';
-import { recordTracksEvent } from 'lib/analytics/tracks';
+import Notice from 'calypso/components/notice';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 
 /**
  * Style dependencies

--- a/client/me/help/contact-form-notice/chat-covid-limited-availability.jsx
+++ b/client/me/help/contact-form-notice/chat-covid-limited-availability.jsx
@@ -16,7 +16,7 @@ import 'moment-timezone'; // monkey patches the existing moment.js
 /**
  * Internal dependencies
  */
-import ContactFormNotice from 'me/help/contact-form-notice/index';
+import ContactFormNotice from 'calypso/me/help/contact-form-notice/index';
 
 const ChatCovidLimitedAvailabilityNotice = ( { showAt, hideAt, compact } ) => {
 	const translate = useTranslate();

--- a/client/me/help/contact-form-notice/chat-generic-closure.jsx
+++ b/client/me/help/contact-form-notice/chat-generic-closure.jsx
@@ -9,8 +9,8 @@ import 'moment-timezone'; // monkey patches the existing moment.js
 /**
  * Internal dependencies
  */
-import ContactFormNotice from 'me/help/contact-form-notice/index';
-import { useLocalizedMoment } from 'components/localized-moment';
+import ContactFormNotice from 'calypso/me/help/contact-form-notice/index';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
 
 const DATE_FORMAT = 'LLL';
 

--- a/client/me/help/contact-form-notice/chat-holiday-closure.jsx
+++ b/client/me/help/contact-form-notice/chat-holiday-closure.jsx
@@ -9,8 +9,8 @@ import 'moment-timezone'; // monkey patches the existing moment.js
 /**
  * Internal dependencies
  */
-import ContactFormNotice from 'me/help/contact-form-notice/index';
-import { useLocalizedMoment } from 'components/localized-moment';
+import ContactFormNotice from 'calypso/me/help/contact-form-notice/index';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
 
 const DATE_FORMAT = 'LLL';
 

--- a/client/me/help/contact-form-notice/chat-reduced-availability.jsx
+++ b/client/me/help/contact-form-notice/chat-reduced-availability.jsx
@@ -9,8 +9,8 @@ import 'moment-timezone'; // monkey patches the existing moment.js
 /**
  * Internal dependencies
  */
-import ContactFormNotice from 'me/help/contact-form-notice/index';
-import { useLocalizedMoment } from 'components/localized-moment';
+import ContactFormNotice from 'calypso/me/help/contact-form-notice/index';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
 
 const DATE_FORMAT = 'LLL';
 

--- a/client/me/help/contact-form-notice/index.jsx
+++ b/client/me/help/contact-form-notice/index.jsx
@@ -8,9 +8,9 @@ import 'moment-timezone'; // monkey patches the existing moment.js
 /**
  * Internal dependencies
  */
-import FoldableCard from 'components/foldable-card';
-import FormSectionHeading from 'components/forms/form-section-heading';
-import { useLocalizedMoment } from 'components/localized-moment';
+import FoldableCard from 'calypso/components/foldable-card';
+import FormSectionHeading from 'calypso/components/forms/form-section-heading';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
 
 /**
  * Style dependencies

--- a/client/me/help/controller.js
+++ b/client/me/help/controller.js
@@ -8,14 +8,14 @@ import i18n from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { login } from 'lib/paths';
-import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
-import config from 'config';
+import { login } from 'calypso/lib/paths';
+import { setDocumentHeadTitle as setTitle } from 'calypso/state/document-head/actions';
+import config from 'calypso/config';
 import HelpComponent from './main';
 import CoursesComponent from './help-courses';
 import ContactComponent from './help-contact';
-import { CONTACT, SUPPORT_ROOT } from 'lib/url/support';
-import userUtils from 'lib/user/utils';
+import { CONTACT, SUPPORT_ROOT } from 'calypso/lib/url/support';
+import userUtils from 'calypso/lib/user/utils';
 
 export function loggedOut( context, next ) {
 	if ( userUtils.isLoggedIn() ) {

--- a/client/me/help/gm-closure-notice/index.jsx
+++ b/client/me/help/gm-closure-notice/index.jsx
@@ -11,13 +11,13 @@ import { some } from 'lodash';
 /**
  * Internal dependencies
  */
-import { isEcommercePlan, isBusinessPlan, isPremiumPlan, isPersonalPlan } from 'lib/plans';
-import FoldableCard from 'components/foldable-card';
-import FormSectionHeading from 'components/forms/form-section-heading';
-import { useLocalizedMoment } from 'components/localized-moment';
-import { getCurrentUserId } from 'state/current-user/selectors';
-import { getUserPurchases } from 'state/purchases/selectors';
-import { localizeUrl } from 'lib/i18n-utils';
+import { isEcommercePlan, isBusinessPlan, isPremiumPlan, isPersonalPlan } from 'calypso/lib/plans';
+import FoldableCard from 'calypso/components/foldable-card';
+import FormSectionHeading from 'calypso/components/forms/form-section-heading';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
+import { getUserPurchases } from 'calypso/state/purchases/selectors';
+import { localizeUrl } from 'calypso/lib/i18n-utils';
 
 /**
  * Style dependencies

--- a/client/me/help/help-contact-confirmation/index.jsx
+++ b/client/me/help/help-contact-confirmation/index.jsx
@@ -4,12 +4,12 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 
 /**
  * Internal dependencies
  */
-import FormSectionHeading from 'components/forms/form-section-heading';
+import FormSectionHeading from 'calypso/components/forms/form-section-heading';
 
 /**
  * Style dependencies

--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -6,35 +6,35 @@ import React from 'react';
 import { debounce, isEqual, find, isEmpty, isArray } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 
 /**
  * Internal dependencies
  */
-import { recordTracksEvent } from 'lib/analytics/tracks';
-import { preventWidows } from 'lib/formatting';
-import config from 'config';
-import FormLabel from 'components/forms/form-label';
-import SegmentedControl from 'components/segmented-control';
-import SelectDropdown from 'components/select-dropdown';
-import FormTextarea from 'components/forms/form-textarea';
-import FormTextInput from 'components/forms/form-text-input';
-import FormButton from 'components/forms/form-button';
-import SitesDropdown from 'components/sites-dropdown';
-import InlineHelpCompactResults from 'blocks/inline-help/inline-help-compact-results';
-import { selectSiteId } from 'state/help/actions';
-import { getHelpSelectedSite, getHelpSelectedSiteId } from 'state/help/selectors';
-import wpcomLib from 'lib/wp';
-import HelpResults from 'me/help/help-results';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { preventWidows } from 'calypso/lib/formatting';
+import config from 'calypso/config';
+import FormLabel from 'calypso/components/forms/form-label';
+import SegmentedControl from 'calypso/components/segmented-control';
+import SelectDropdown from 'calypso/components/select-dropdown';
+import FormTextarea from 'calypso/components/forms/form-textarea';
+import FormTextInput from 'calypso/components/forms/form-text-input';
+import FormButton from 'calypso/components/forms/form-button';
+import SitesDropdown from 'calypso/components/sites-dropdown';
+import InlineHelpCompactResults from 'calypso/blocks/inline-help/inline-help-compact-results';
+import { selectSiteId } from 'calypso/state/help/actions';
+import { getHelpSelectedSite, getHelpSelectedSiteId } from 'calypso/state/help/selectors';
+import wpcomLib from 'calypso/lib/wp';
+import HelpResults from 'calypso/me/help/help-results';
 import {
 	bumpStat,
 	recordTracksEvent as recordTracksEventAction,
 	composeAnalytics,
-} from 'state/analytics/actions';
-import { getCurrentUserLocale } from 'state/current-user/selectors';
-import isShowingQandAInlineHelpContactForm from 'state/selectors/is-showing-q-and-a-inline-help-contact-form';
-import { showQandAOnInlineHelpContactForm } from 'state/inline-help/actions';
-import { getNpsSurveyFeedback } from 'state/nps-survey/selectors';
+} from 'calypso/state/analytics/actions';
+import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
+import isShowingQandAInlineHelpContactForm from 'calypso/state/selectors/is-showing-q-and-a-inline-help-contact-form';
+import { showQandAOnInlineHelpContactForm } from 'calypso/state/inline-help/actions';
+import { getNpsSurveyFeedback } from 'calypso/state/nps-survey/selectors';
 import { generateSubjectFromMessage } from './utils';
 
 /**

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -12,60 +12,60 @@ import debugFactory from 'debug';
 /**
  * Internal dependencies
  */
-import config from 'config';
-import Main from 'components/main';
+import config from 'calypso/config';
+import Main from 'calypso/components/main';
 import { Card } from '@automattic/components';
-import Notice from 'components/notice';
-import HelpContactForm from 'me/help/help-contact-form';
-import ActiveTicketsNotice from 'me/help/active-tickets-notice';
-import HelpContactConfirmation from 'me/help/help-contact-confirmation';
-import HeaderCake from 'components/header-cake';
-import wpcomLib from 'lib/wp';
-import notices from 'notices';
-import ChatCovidLimitedAvailabilityNotice from 'me/help/contact-form-notice/chat-covid-limited-availability';
-import { recordTracksEvent } from 'lib/analytics/tracks';
-import getHappychatUserInfo from 'state/happychat/selectors/get-happychat-userinfo';
-import isHappychatUserEligible from 'state/happychat/selectors/is-happychat-user-eligible';
-import hasHappychatLocalizedSupport from 'state/happychat/selectors/has-happychat-localized-support';
+import Notice from 'calypso/components/notice';
+import HelpContactForm from 'calypso/me/help/help-contact-form';
+import ActiveTicketsNotice from 'calypso/me/help/active-tickets-notice';
+import HelpContactConfirmation from 'calypso/me/help/help-contact-confirmation';
+import HeaderCake from 'calypso/components/header-cake';
+import wpcomLib from 'calypso/lib/wp';
+import notices from 'calypso/notices';
+import ChatCovidLimitedAvailabilityNotice from 'calypso/me/help/contact-form-notice/chat-covid-limited-availability';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import getHappychatUserInfo from 'calypso/state/happychat/selectors/get-happychat-userinfo';
+import isHappychatUserEligible from 'calypso/state/happychat/selectors/is-happychat-user-eligible';
+import hasHappychatLocalizedSupport from 'calypso/state/happychat/selectors/has-happychat-localized-support';
 import {
 	isTicketSupportConfigurationReady,
 	getTicketSupportRequestError,
-} from 'state/help/ticket/selectors';
-import HappychatConnection from 'components/happychat/connection-connected';
-import QueryTicketSupportConfiguration from 'components/data/query-ticket-support-configuration';
-import QuerySupportHistory from 'components/data/query-support-history';
+} from 'calypso/state/help/ticket/selectors';
+import HappychatConnection from 'calypso/components/happychat/connection-connected';
+import QueryTicketSupportConfiguration from 'calypso/components/data/query-ticket-support-configuration';
+import QuerySupportHistory from 'calypso/components/data/query-support-history';
 import HelpUnverifiedWarning from '../help-unverified-warning';
 import {
 	sendMessage as sendHappychatMessage,
 	sendUserInfo,
-} from 'state/happychat/connection/actions';
-import { openChat as openHappychat } from 'state/happychat/ui/actions';
+} from 'calypso/state/happychat/connection/actions';
+import { openChat as openHappychat } from 'calypso/state/happychat/ui/actions';
 import {
 	getCurrentUser,
 	getCurrentUserLocale,
 	getCurrentUserSiteCount,
 	isCurrentUserEmailVerified,
-} from 'state/current-user/selectors';
+} from 'calypso/state/current-user/selectors';
 import {
 	askQuestion as askDirectlyQuestion,
 	initialize as initializeDirectly,
-} from 'state/help/directly/actions';
-import { isRequestingSites } from 'state/sites/selectors';
-import getLocalizedLanguageNames from 'state/selectors/get-localized-language-names';
+} from 'calypso/state/help/directly/actions';
+import { isRequestingSites } from 'calypso/state/sites/selectors';
+import getLocalizedLanguageNames from 'calypso/state/selectors/get-localized-language-names';
 import getSupportLevel, {
 	SUPPORT_LEVEL_PERSONAL,
 	SUPPORT_LEVEL_PERSONAL_WITH_LEGACY_CHAT,
-} from 'state/selectors/get-support-level';
-import hasUserAskedADirectlyQuestion from 'state/selectors/has-user-asked-a-directly-question';
-import isDirectlyReady from 'state/selectors/is-directly-ready';
-import isDirectlyUninitialized from 'state/selectors/is-directly-uninitialized';
-import getActiveSupportTickets from 'state/selectors/get-active-support-tickets';
-import QueryUserPurchases from 'components/data/query-user-purchases';
-import { getHelpSelectedSiteId } from 'state/help/selectors';
-import { isDefaultLocale, localizeUrl } from 'lib/i18n-utils';
-import { recordTracksEvent as recordTracksEventAction } from 'state/analytics/actions';
-import PageViewTracker from 'lib/analytics/page-view-tracker';
-import QueryLanguageNames from 'components/data/query-language-names';
+} from 'calypso/state/selectors/get-support-level';
+import hasUserAskedADirectlyQuestion from 'calypso/state/selectors/has-user-asked-a-directly-question';
+import isDirectlyReady from 'calypso/state/selectors/is-directly-ready';
+import isDirectlyUninitialized from 'calypso/state/selectors/is-directly-uninitialized';
+import getActiveSupportTickets from 'calypso/state/selectors/get-active-support-tickets';
+import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
+import { getHelpSelectedSiteId } from 'calypso/state/help/selectors';
+import { isDefaultLocale, localizeUrl } from 'calypso/lib/i18n-utils';
+import { recordTracksEvent as recordTracksEventAction } from 'calypso/state/analytics/actions';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import QueryLanguageNames from 'calypso/components/data/query-language-names';
 import getInlineHelpSupportVariation, {
 	SUPPORT_CHAT_OVERFLOW,
 	SUPPORT_DIRECTLY,
@@ -73,7 +73,7 @@ import getInlineHelpSupportVariation, {
 	SUPPORT_HAPPYCHAT,
 	SUPPORT_TICKET,
 	SUPPORT_UPWORK_TICKET,
-} from 'state/selectors/get-inline-help-support-variation';
+} from 'calypso/state/selectors/get-inline-help-support-variation';
 
 /**
  * Style dependencies

--- a/client/me/help/help-courses/course-schedule-item.jsx
+++ b/client/me/help/help-courses/course-schedule-item.jsx
@@ -4,13 +4,13 @@
 
 import React from 'react';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 
 /**
  * Internal dependencies
  */
 import { Card, Button } from '@automattic/components';
-import { recordTracksEvent } from 'lib/analytics/tracks';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 
 export default localize( ( props ) => {
 	const { date, registrationUrl, isBusinessPlanUser, translate } = props;

--- a/client/me/help/help-courses/course.jsx
+++ b/client/me/help/help-courses/course.jsx
@@ -13,9 +13,9 @@ import { Card } from '@automattic/components';
 import CourseScheduleItem from './course-schedule-item';
 import HelpTeaserButton from '../help-teaser-button';
 import CourseVideo from './course-video';
-import { recordTracksEvent } from 'lib/analytics/tracks';
-import getPrimarySiteId from 'state/selectors/get-primary-site-id';
-import { getSiteSlug } from 'state/sites/selectors';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
 
 class Course extends Component {
 	componentDidMount() {

--- a/client/me/help/help-courses/index.jsx
+++ b/client/me/help/help-courses/index.jsx
@@ -10,21 +10,21 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import CourseList, { CourseListPlaceholder } from './course-list';
-import HeaderCake from 'components/header-cake';
-import Main from 'components/main';
-import QueryUserPurchases from 'components/data/query-user-purchases';
-import { getCurrentUserId } from 'state/current-user/selectors';
-import { getHelpCourses } from 'state/help/courses/selectors';
+import HeaderCake from 'calypso/components/header-cake';
+import Main from 'calypso/components/main';
+import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
+import { getHelpCourses } from 'calypso/state/help/courses/selectors';
 import { helpCourses } from './constants';
-import { planHasFeature } from 'lib/plans';
-import { FEATURE_BUSINESS_ONBOARDING } from 'lib/plans/constants';
-import { receiveHelpCourses } from 'state/help/courses/actions';
+import { planHasFeature } from 'calypso/lib/plans';
+import { FEATURE_BUSINESS_ONBOARDING } from 'calypso/lib/plans/constants';
+import { receiveHelpCourses } from 'calypso/state/help/courses/actions';
 import {
 	getUserPurchases,
 	isFetchingUserPurchases,
 	hasLoadedUserPurchasesFromServer,
-} from 'state/purchases/selectors';
-import PageViewTracker from 'lib/analytics/page-view-tracker';
+} from 'calypso/state/purchases/selectors';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 
 /**
  * Style dependencies

--- a/client/me/help/help-courses/test/index.jsx
+++ b/client/me/help/help-courses/test/index.jsx
@@ -27,7 +27,7 @@ import {
 	PLAN_JETPACK_PREMIUM_MONTHLY,
 	PLAN_JETPACK_BUSINESS,
 	PLAN_JETPACK_BUSINESS_MONTHLY,
-} from 'lib/plans/constants';
+} from 'calypso/lib/plans/constants';
 
 jest.mock( 'lib/analytics/page-view', () => ( {} ) );
 jest.mock( 'lib/user', () => () => {} );
@@ -62,7 +62,7 @@ jest.mock( 'i18n-calypso', () => ( {
 	numberFormat: ( x ) => x,
 } ) );
 
-import purchasesSelectors from 'state/purchases/selectors';
+import purchasesSelectors from 'calypso/state/purchases/selectors';
 
 describe( 'mapStateToProps should return correct value for isBusinessPlanUser', () => {
 	[

--- a/client/me/help/help-happiness-engineers/index.jsx
+++ b/client/me/help/help-happiness-engineers/index.jsx
@@ -7,8 +7,8 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import FormSectionHeading from 'components/forms/form-section-heading';
-import HappinessEngineersTray from 'components/happiness-engineers-tray';
+import FormSectionHeading from 'calypso/components/forms/form-section-heading';
+import HappinessEngineersTray from 'calypso/components/happiness-engineers-tray';
 
 /**
  * Style dependencies

--- a/client/me/help/help-results/index.jsx
+++ b/client/me/help/help-results/index.jsx
@@ -9,7 +9,7 @@ import React from 'react';
  */
 import { CompactCard } from '@automattic/components';
 import HelpResult from './item';
-import SectionHeader from 'components/section-header';
+import SectionHeader from 'calypso/components/section-header';
 
 /**
  * Style dependencies

--- a/client/me/help/help-results/item.jsx
+++ b/client/me/help/help-results/item.jsx
@@ -3,14 +3,14 @@
  */
 
 import React from 'react';
-import Gridicon from 'components/gridicon';
-import { decodeEntities } from 'lib/formatting';
+import Gridicon from 'calypso/components/gridicon';
+import { decodeEntities } from 'calypso/lib/formatting';
 
 /**
  * Internal dependencies
  */
 import { CompactCard } from '@automattic/components';
-import { localizeUrl } from 'lib/i18n-utils';
+import { localizeUrl } from 'calypso/lib/i18n-utils';
 
 export default class extends React.PureComponent {
 	static displayName = 'HelpResult';

--- a/client/me/help/help-search/index.jsx
+++ b/client/me/help/help-search/index.jsx
@@ -10,13 +10,13 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import { CompactCard } from '@automattic/components';
-import getHelpLinks from 'state/selectors/get-help-links';
-import HelpResults from 'me/help/help-results';
-import NoResults from 'my-sites/no-results';
-import QueryHelpLinks from 'components/data/query-help-links';
-import SearchCard from 'components/search-card';
-import { localizeUrl } from 'lib/i18n-utils';
-import { recordTracksEvent } from 'state/analytics/actions';
+import getHelpLinks from 'calypso/state/selectors/get-help-links';
+import HelpResults from 'calypso/me/help/help-results';
+import NoResults from 'calypso/my-sites/no-results';
+import QueryHelpLinks from 'calypso/components/data/query-help-links';
+import SearchCard from 'calypso/components/search-card';
+import { localizeUrl } from 'calypso/lib/i18n-utils';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 /**
  * Style dependencies

--- a/client/me/help/help-teaser-button.jsx
+++ b/client/me/help/help-teaser-button.jsx
@@ -4,7 +4,7 @@
 
 import React from 'react';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/me/help/help-unverified-warning/index.jsx
+++ b/client/me/help/help-unverified-warning/index.jsx
@@ -3,14 +3,14 @@
  */
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
-import user from 'lib/user';
+import user from 'calypso/lib/user';
 
 /**
  * Internal dependencies
  */
-import Notice from 'components/notice';
-import NoticeAction from 'components/notice/notice-action';
-import notices from 'notices';
+import Notice from 'calypso/components/notice';
+import NoticeAction from 'calypso/components/notice/notice-action';
+import notices from 'calypso/notices';
 
 /**
  * Style dependencies

--- a/client/me/help/index.js
+++ b/client/me/help/index.js
@@ -2,10 +2,10 @@
  * Internal dependencies
  */
 import * as helpController from './controller';
-import config from 'config';
+import config from 'calypso/config';
 import page from 'page';
-import { makeLayout, render as clientRender } from 'controller';
-import { sidebar } from 'me/controller';
+import { makeLayout, render as clientRender } from 'calypso/controller';
+import { sidebar } from 'calypso/me/controller';
 
 export default function () {
 	if ( config.isEnabled( 'help' ) ) {

--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -10,23 +10,23 @@ import { some } from 'lodash';
 /**
  * Internal dependencies
  */
-import { recordTracksEvent } from 'lib/analytics/tracks';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { Button, CompactCard } from '@automattic/components';
-import HappinessEngineers from 'me/help/help-happiness-engineers';
+import HappinessEngineers from 'calypso/me/help/help-happiness-engineers';
 import HelpResult from './help-results/item';
 import HelpSearch from './help-search';
 import HelpTeaserButton from './help-teaser-button';
 import HelpUnverifiedWarning from './help-unverified-warning';
-import Main from 'components/main';
-import MeSidebarNavigation from 'me/sidebar-navigation';
-import PageViewTracker from 'lib/analytics/page-view-tracker';
-import QueryUserPurchases from 'components/data/query-user-purchases';
-import SectionHeader from 'components/section-header';
-import { getCurrentUserId, isCurrentUserEmailVerified } from 'state/current-user/selectors';
-import { localizeUrl } from 'lib/i18n-utils';
-import { getUserPurchases, isFetchingUserPurchases } from 'state/purchases/selectors';
-import { planHasFeature } from 'lib/plans';
-import { FEATURE_BUSINESS_ONBOARDING } from 'lib/plans/constants';
+import Main from 'calypso/components/main';
+import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
+import SectionHeader from 'calypso/components/section-header';
+import { getCurrentUserId, isCurrentUserEmailVerified } from 'calypso/state/current-user/selectors';
+import { localizeUrl } from 'calypso/lib/i18n-utils';
+import { getUserPurchases, isFetchingUserPurchases } from 'calypso/state/purchases/selectors';
+import { planHasFeature } from 'calypso/lib/plans';
+import { FEATURE_BUSINESS_ONBOARDING } from 'calypso/lib/plans/constants';
 
 /**
  * Style dependencies

--- a/client/me/help/test/main.jsx
+++ b/client/me/help/test/main.jsx
@@ -26,7 +26,7 @@ import {
 	PLAN_JETPACK_PREMIUM_MONTHLY,
 	PLAN_JETPACK_BUSINESS,
 	PLAN_JETPACK_BUSINESS_MONTHLY,
-} from 'lib/plans/constants';
+} from 'calypso/lib/plans/constants';
 import { mapStateToProps } from '../main';
 
 jest.mock( 'lib/analytics/tracks', () => ( {} ) );
@@ -58,7 +58,7 @@ jest.mock( 'i18n-calypso', () => ( {
 	numberFormat: ( x ) => x,
 } ) );
 
-import purchasesSelectors from 'state/purchases/selectors';
+import purchasesSelectors from 'calypso/state/purchases/selectors';
 
 describe( 'mapStateToProps should return correct value for isBusinessPlanUser', () => {
 	[

--- a/client/me/index.js
+++ b/client/me/index.js
@@ -2,14 +2,14 @@
  * External dependencies
  */
 
-import config from 'config';
+import config from 'calypso/config';
 import page from 'page';
 
 /**
  * Internal dependencies
  */
 import * as controller from './controller';
-import { makeLayout, render as clientRender } from 'controller';
+import { makeLayout, render as clientRender } from 'calypso/controller';
 
 export default function () {
 	if ( config.isEnabled( 'me/my-profile' ) ) {

--- a/client/me/memberships/main.jsx
+++ b/client/me/memberships/main.jsx
@@ -9,17 +9,17 @@ import formatCurrency from '@automattic/format-currency';
 /**
  * Internal dependencies
  */
-import MeSidebarNavigation from 'me/sidebar-navigation';
+import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
 import PurchasesHeader from '../purchases/purchases-list/header';
-import Main from 'components/main';
-import DocumentHead from 'components/data/document-head';
-import PageViewTracker from 'lib/analytics/page-view-tracker';
-import QueryMembershipsSubscriptions from 'components/data/query-memberships-subscriptions';
-import SectionHeader from 'components/section-header';
+import Main from 'calypso/components/main';
+import DocumentHead from 'calypso/components/data/document-head';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import QueryMembershipsSubscriptions from 'calypso/components/data/query-memberships-subscriptions';
+import SectionHeader from 'calypso/components/section-header';
 import { CompactCard } from '@automattic/components';
-import EmptyContent from 'components/empty-content';
-import { withLocalizedMoment } from 'components/localized-moment';
-import { getAllSubscriptions } from 'state/memberships/subscriptions/selectors';
+import EmptyContent from 'calypso/components/empty-content';
+import { withLocalizedMoment } from 'calypso/components/localized-moment';
+import { getAllSubscriptions } from 'calypso/state/memberships/subscriptions/selectors';
 
 /**
  * Style dependencies
@@ -29,7 +29,7 @@ import './main.scss';
 /**
  * Image dependencies
  */
-import noMembershipsImage from 'assets/images/illustrations/no-memberships.svg';
+import noMembershipsImage from 'calypso/assets/images/illustrations/no-memberships.svg';
 
 const getMembershipEndDate = ( translate, endDate, moment ) => {
 	if ( ! endDate ) {

--- a/client/me/memberships/subscription.jsx
+++ b/client/me/memberships/subscription.jsx
@@ -10,19 +10,22 @@ import formatCurrency from '@automattic/format-currency';
  * Internal dependencies
  */
 import { Card, CompactCard } from '@automattic/components';
-import MeSidebarNavigation from 'me/sidebar-navigation';
+import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
 import PurchasesHeader from '../purchases/purchases-list/header';
-import Main from 'components/main';
-import DocumentHead from 'components/data/document-head';
-import QueryMembershipsSubscriptions from 'components/data/query-memberships-subscriptions';
-import HeaderCake from 'components/header-cake';
+import Main from 'calypso/components/main';
+import DocumentHead from 'calypso/components/data/document-head';
+import QueryMembershipsSubscriptions from 'calypso/components/data/query-memberships-subscriptions';
+import HeaderCake from 'calypso/components/header-cake';
 import { purchasesRoot } from '../purchases/paths';
-import Site from 'blocks/site';
-import Gridicon from 'components/gridicon';
-import { requestSubscriptionStop } from 'state/memberships/subscriptions/actions';
-import Notice from 'components/notice';
-import { withLocalizedMoment } from 'components/localized-moment';
-import { getSubscription, getStoppingStatus } from 'state/memberships/subscriptions/selectors';
+import Site from 'calypso/blocks/site';
+import Gridicon from 'calypso/components/gridicon';
+import { requestSubscriptionStop } from 'calypso/state/memberships/subscriptions/actions';
+import Notice from 'calypso/components/notice';
+import { withLocalizedMoment } from 'calypso/components/localized-moment';
+import {
+	getSubscription,
+	getStoppingStatus,
+} from 'calypso/state/memberships/subscriptions/selectors';
 
 /**
  * Style dependencies

--- a/client/me/notification-settings/blogs-settings/blog.jsx
+++ b/client/me/notification-settings/blogs-settings/blog.jsx
@@ -10,10 +10,10 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
-import { getSite } from 'state/sites/selectors';
+import { getSite } from 'calypso/state/sites/selectors';
 import { Card } from '@automattic/components';
 import Header from './header';
-import SettingsForm from 'me/notification-settings/settings-form';
+import SettingsForm from 'calypso/me/notification-settings/settings-form';
 
 class BlogSettings extends Component {
 	static propTypes = {

--- a/client/me/notification-settings/blogs-settings/header.jsx
+++ b/client/me/notification-settings/blogs-settings/header.jsx
@@ -12,9 +12,9 @@ import { countBy, map, omit, values, flatten } from 'lodash';
 /**
  * Internal dependencies
  */
-import Gridicon from 'components/gridicon';
-import { gaRecordEvent } from 'lib/analytics/ga';
-import SiteInfo from 'blocks/site';
+import Gridicon from 'calypso/components/gridicon';
+import { gaRecordEvent } from 'calypso/lib/analytics/ga';
+import SiteInfo from 'calypso/blocks/site';
 
 class BlogSettingsHeader extends PureComponent {
 	static propTypes = {

--- a/client/me/notification-settings/blogs-settings/index.jsx
+++ b/client/me/notification-settings/blogs-settings/index.jsx
@@ -10,13 +10,13 @@ import { find, noop } from 'lodash';
 /**
  * Internal dependencies
  */
-import getSites from 'state/selectors/get-sites';
-import { isRequestingSites } from 'state/sites/selectors';
-import EmptyContentComponent from 'components/empty-content';
+import getSites from 'calypso/state/selectors/get-sites';
+import { isRequestingSites } from 'calypso/state/sites/selectors';
+import EmptyContentComponent from 'calypso/components/empty-content';
 import Blog from './blog';
-import InfiniteList from 'components/infinite-list';
+import InfiniteList from 'calypso/components/infinite-list';
 import Placeholder from './placeholder';
-import config from 'config';
+import config from 'calypso/config';
 
 /**
  * Style dependencies

--- a/client/me/notification-settings/blogs-settings/placeholder.jsx
+++ b/client/me/notification-settings/blogs-settings/placeholder.jsx
@@ -5,7 +5,7 @@
  */
 
 import React from 'react';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/me/notification-settings/comment-settings/index.jsx
+++ b/client/me/notification-settings/comment-settings/index.jsx
@@ -8,21 +8,21 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import Main from 'components/main';
-import ReauthRequired from 'me/reauth-required';
-import twoStepAuthorization from 'lib/two-step-authorization';
-import MeSidebarNavigation from 'me/sidebar-navigation';
+import Main from 'calypso/components/main';
+import ReauthRequired from 'calypso/me/reauth-required';
+import twoStepAuthorization from 'calypso/lib/two-step-authorization';
+import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
 import Navigation from '../navigation';
 import { Card } from '@automattic/components';
-import FormSectionHeading from 'components/forms/form-section-heading';
-import SettingsForm from 'me/notification-settings/settings-form';
-import QueryUserDevices from 'components/data/query-user-devices';
-import PageViewTracker from 'lib/analytics/page-view-tracker';
-import { fetchSettings, toggle, saveSettings } from 'state/notification-settings/actions';
+import FormSectionHeading from 'calypso/components/forms/form-section-heading';
+import SettingsForm from 'calypso/me/notification-settings/settings-form';
+import QueryUserDevices from 'calypso/components/data/query-user-devices';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { fetchSettings, toggle, saveSettings } from 'calypso/state/notification-settings/actions';
 import {
 	getNotificationSettings,
 	hasUnsavedNotificationSettingsChanges,
-} from 'state/notification-settings/selectors';
+} from 'calypso/state/notification-settings/selectors';
 
 /**
  * Style dependencies

--- a/client/me/notification-settings/controller.js
+++ b/client/me/notification-settings/controller.js
@@ -7,12 +7,12 @@ import i18n from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import userSettings from 'lib/user-settings';
-import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
-import NotificationsComponent from 'me/notification-settings/main';
-import CommentSettingsComponent from 'me/notification-settings/comment-settings';
-import WPcomSettingsComponent from 'me/notification-settings/wpcom-settings';
-import NotificationSubscriptions from 'me/notification-settings/reader-subscriptions';
+import userSettings from 'calypso/lib/user-settings';
+import { setDocumentHeadTitle as setTitle } from 'calypso/state/document-head/actions';
+import NotificationsComponent from 'calypso/me/notification-settings/main';
+import CommentSettingsComponent from 'calypso/me/notification-settings/comment-settings';
+import WPcomSettingsComponent from 'calypso/me/notification-settings/wpcom-settings';
+import NotificationSubscriptions from 'calypso/me/notification-settings/reader-subscriptions';
 
 export function notifications( context, next ) {
 	// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.

--- a/client/me/notification-settings/index.js
+++ b/client/me/notification-settings/index.js
@@ -7,8 +7,8 @@ import page from 'page';
  * Internal dependencies
  */
 import { notifications, comments, updates, subscriptions } from './controller';
-import { sidebar } from 'me/controller';
-import { makeLayout, render as clientRender } from 'controller';
+import { sidebar } from 'calypso/me/controller';
+import { makeLayout, render as clientRender } from 'calypso/controller';
 
 export default function () {
 	page( '/me/notifications', sidebar, notifications, makeLayout, clientRender );

--- a/client/me/notification-settings/main.jsx
+++ b/client/me/notification-settings/main.jsx
@@ -9,20 +9,20 @@ import { find } from 'lodash';
 /**
  * Internal dependencies
  */
-import Main from 'components/main';
-import ReauthRequired from 'me/reauth-required';
-import twoStepAuthorization from 'lib/two-step-authorization';
-import MeSidebarNavigation from 'me/sidebar-navigation';
+import Main from 'calypso/components/main';
+import ReauthRequired from 'calypso/me/reauth-required';
+import twoStepAuthorization from 'calypso/lib/two-step-authorization';
+import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
 import Navigation from './navigation';
 import BlogsSettings from './blogs-settings';
 import PushNotificationSettings from './push-notification-settings';
-import QueryUserDevices from 'components/data/query-user-devices';
-import PageViewTracker from 'lib/analytics/page-view-tracker';
-import { fetchSettings, toggle, saveSettings } from 'state/notification-settings/actions';
+import QueryUserDevices from 'calypso/components/data/query-user-devices';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { fetchSettings, toggle, saveSettings } from 'calypso/state/notification-settings/actions';
 import {
 	getNotificationSettings,
 	hasUnsavedNotificationSettingsChanges,
-} from 'state/notification-settings/selectors';
+} from 'calypso/state/notification-settings/selectors';
 
 class NotificationSettings extends Component {
 	componentDidMount() {

--- a/client/me/notification-settings/navigation.jsx
+++ b/client/me/notification-settings/navigation.jsx
@@ -9,9 +9,9 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import SectionNav from 'components/section-nav';
-import NavTabs from 'components/section-nav/tabs';
-import NavItem from 'components/section-nav/item';
+import SectionNav from 'calypso/components/section-nav';
+import NavTabs from 'calypso/components/section-nav/tabs';
+import NavItem from 'calypso/components/section-nav/item';
 
 class NotificationSettingsNavigation extends React.Component {
 	static displayName = 'NotificationSettingsNavigation';

--- a/client/me/notification-settings/push-notification-settings/index.jsx
+++ b/client/me/notification-settings/push-notification-settings/index.jsx
@@ -7,20 +7,20 @@ import { localize } from 'i18n-calypso';
 import React from 'react';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 
 /**
  * Internal dependencies
  */
 import { Card, Button, Dialog, ScreenReaderText } from '@automattic/components';
-import Notice from 'components/notice';
+import Notice from 'calypso/components/notice';
 import {
 	getStatus,
 	isApiReady,
 	isShowingUnblockInstructions,
 	isEnabled,
-} from 'state/push-notifications/selectors';
-import { toggleEnabled, toggleUnblockInstructions } from 'state/push-notifications/actions';
+} from 'calypso/state/push-notifications/selectors';
+import { toggleEnabled, toggleUnblockInstructions } from 'calypso/state/push-notifications/actions';
 
 /**
  * Style dependencies

--- a/client/me/notification-settings/reader-subscriptions/index.jsx
+++ b/client/me/notification-settings/reader-subscriptions/index.jsx
@@ -10,26 +10,26 @@ import { flowRight } from 'lodash';
 /**
  * Internal dependencies
  */
-import MeSidebarNavigation from 'me/sidebar-navigation';
-import { protectForm } from 'lib/protect-form';
-import formBase from 'me/form-base';
+import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
+import { protectForm } from 'calypso/lib/protect-form';
+import formBase from 'calypso/me/form-base';
 import { Card } from '@automattic/components';
-import Navigation from 'me/notification-settings/navigation';
-import FormCheckbox from 'components/forms/form-checkbox';
-import FormFieldset from 'components/forms/form-fieldset';
-import FormLabel from 'components/forms/form-label';
-import FormLegend from 'components/forms/form-legend';
-import FormSettingExplanation from 'components/forms/form-setting-explanation';
-import FormButton from 'components/forms/form-button';
-import FormSelect from 'components/forms/form-select';
-import FormSectionHeading from 'components/forms/form-section-heading';
-import ReauthRequired from 'me/reauth-required';
-import twoStepAuthorization from 'lib/two-step-authorization';
-import observe from 'lib/mixins/data-observe'; //eslint-disable-line no-restricted-imports
-import Main from 'components/main';
-import { withLocalizedMoment } from 'components/localized-moment';
-import { recordGoogleEvent } from 'state/analytics/actions';
-import PageViewTracker from 'lib/analytics/page-view-tracker';
+import Navigation from 'calypso/me/notification-settings/navigation';
+import FormCheckbox from 'calypso/components/forms/form-checkbox';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormLegend from 'calypso/components/forms/form-legend';
+import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
+import FormButton from 'calypso/components/forms/form-button';
+import FormSelect from 'calypso/components/forms/form-select';
+import FormSectionHeading from 'calypso/components/forms/form-section-heading';
+import ReauthRequired from 'calypso/me/reauth-required';
+import twoStepAuthorization from 'calypso/lib/two-step-authorization';
+import observe from 'calypso/lib/mixins/data-observe'; //eslint-disable-line no-restricted-imports
+import Main from 'calypso/components/main';
+import { withLocalizedMoment } from 'calypso/components/localized-moment';
+import { recordGoogleEvent } from 'calypso/state/analytics/actions';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 
 /* eslint-disable react/prefer-es6-class */
 const NotificationSubscriptions = createReactClass( {

--- a/client/me/notification-settings/settings-form/actions.jsx
+++ b/client/me/notification-settings/settings-form/actions.jsx
@@ -9,7 +9,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import FormButton from 'components/forms/form-button';
+import FormButton from 'calypso/components/forms/form-button';
 
 /**
  * Style dependencies

--- a/client/me/notification-settings/settings-form/device-selector.jsx
+++ b/client/me/notification-settings/settings-form/device-selector.jsx
@@ -10,9 +10,9 @@ import { size, map, first } from 'lodash';
 /**
  * Internal dependencies
  */
-import getUserDevices from 'state/selectors/get-user-devices';
+import getUserDevices from 'calypso/state/selectors/get-user-devices';
 import StreamHeader from './stream-header';
-import FormSelect from 'components/forms/form-select';
+import FormSelect from 'calypso/components/forms/form-select';
 
 class NotificationSettingsFormDeviceSelector extends PureComponent {
 	static propTypes = {

--- a/client/me/notification-settings/settings-form/settings.jsx
+++ b/client/me/notification-settings/settings-form/settings.jsx
@@ -13,7 +13,7 @@ import { find, get } from 'lodash';
 import Labels from './labels';
 import Stream from './stream';
 import StreamSelector from './stream-selector';
-import getUserDevices from 'state/selectors/get-user-devices';
+import getUserDevices from 'calypso/state/selectors/get-user-devices';
 
 /**
  * Module variables

--- a/client/me/notification-settings/settings-form/stream-header.jsx
+++ b/client/me/notification-settings/settings-form/stream-header.jsx
@@ -4,7 +4,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 
 /**
  * Internal dependencies

--- a/client/me/notification-settings/settings-form/stream-options.jsx
+++ b/client/me/notification-settings/settings-form/stream-options.jsx
@@ -10,7 +10,7 @@ import { get } from 'lodash';
  * Internal dependencies
  */
 import { NOTIFICATIONS_EXCEPTIONS } from './constants';
-import FormCheckbox from 'components/forms/form-checkbox';
+import FormCheckbox from 'calypso/components/forms/form-checkbox';
 
 export default class extends React.PureComponent {
 	static displayName = 'NotificationSettingsFormStreamOptions';

--- a/client/me/notification-settings/settings-form/stream-selector.jsx
+++ b/client/me/notification-settings/settings-form/stream-selector.jsx
@@ -10,9 +10,9 @@ import { map } from 'lodash';
 /**
  * Internal dependencies
  */
-import FormSelect from 'components/forms/form-select';
+import FormSelect from 'calypso/components/forms/form-select';
 import { getLabelForStream } from './locales';
-import getUserDevices from 'state/selectors/get-user-devices';
+import getUserDevices from 'calypso/state/selectors/get-user-devices';
 
 class NotificationSettingsFormStreamSelector extends PureComponent {
 	static propTypes = {

--- a/client/me/notification-settings/wpcom-settings/email-category.jsx
+++ b/client/me/notification-settings/wpcom-settings/email-category.jsx
@@ -8,11 +8,11 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import FormCheckbox from 'components/forms/form-checkbox';
-import FormFieldset from 'components/forms/form-fieldset';
-import FormLegend from 'components/forms/form-legend';
-import FormLabel from 'components/forms/form-label';
-import { toggleWPcomEmailSetting } from 'state/notification-settings/actions';
+import FormCheckbox from 'calypso/components/forms/form-checkbox';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormLegend from 'calypso/components/forms/form-legend';
+import FormLabel from 'calypso/components/forms/form-label';
+import { toggleWPcomEmailSetting } from 'calypso/state/notification-settings/actions';
 
 class EmailCategory extends React.Component {
 	static propTypes = {

--- a/client/me/notification-settings/wpcom-settings/index.jsx
+++ b/client/me/notification-settings/wpcom-settings/index.jsx
@@ -9,26 +9,26 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
-import Main from 'components/main';
-import ReauthRequired from 'me/reauth-required';
-import twoStepAuthorization from 'lib/two-step-authorization';
-import MeSidebarNavigation from 'me/sidebar-navigation';
+import Main from 'calypso/components/main';
+import ReauthRequired from 'calypso/me/reauth-required';
+import twoStepAuthorization from 'calypso/lib/two-step-authorization';
+import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
 import Navigation from '../navigation';
 import { Card } from '@automattic/components';
-import FormSectionHeading from 'components/forms/form-section-heading';
+import FormSectionHeading from 'calypso/components/forms/form-section-heading';
 import ActionButtons from '../settings-form/actions';
 import {
 	fetchSettings,
 	toggleWPcomEmailSetting,
 	saveSettings,
-} from 'state/notification-settings/actions';
+} from 'calypso/state/notification-settings/actions';
 import {
 	getNotificationSettings,
 	hasUnsavedNotificationSettingsChanges,
-} from 'state/notification-settings/selectors';
+} from 'calypso/state/notification-settings/selectors';
 import EmailCategory from './email-category';
-import PageViewTracker from 'lib/analytics/page-view-tracker';
-import hasJetpackSites from 'state/selectors/has-jetpack-sites';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import hasJetpackSites from 'calypso/state/selectors/has-jetpack-sites';
 
 /**
  * Style dependencies

--- a/client/me/pending-payments/index.jsx
+++ b/client/me/pending-payments/index.jsx
@@ -10,23 +10,23 @@ import { localize } from 'i18n-calypso';
  * Internal Dependencies
  */
 import { CompactCard } from '@automattic/components';
-import EmptyContent from 'components/empty-content';
-import Main from 'components/main';
-import MeSidebarNavigation from 'me/sidebar-navigation';
-import PageViewTracker from 'lib/analytics/page-view-tracker';
+import EmptyContent from 'calypso/components/empty-content';
+import Main from 'calypso/components/main';
+import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import PendingListItem from './pending-list-item';
 import PurchasesHeader from '../purchases/purchases-list/header';
 import PurchasesSite from '../purchases/purchases-site';
-import { getCurrentUserId } from 'state/current-user/selectors';
-import { getHttpData, requestHttpData } from 'state/data-layer/http-data';
-import { http } from 'state/data-layer/wpcom-http/actions';
-import { errorNotice } from 'state/notices/actions';
-import Banner from 'components/banner';
-import { convertToCamelCase } from 'state/data-layer/utils';
-import { getSelectedSiteId } from 'state/ui/selectors';
-import getPrimarySiteId from 'state/selectors/get-primary-site-id';
-import { getSiteSlug } from 'state/sites/selectors';
-import { getStatsPathForTab } from 'lib/route';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
+import { getHttpData, requestHttpData } from 'calypso/state/data-layer/http-data';
+import { http } from 'calypso/state/data-layer/wpcom-http/actions';
+import { errorNotice } from 'calypso/state/notices/actions';
+import Banner from 'calypso/components/banner';
+import { convertToCamelCase } from 'calypso/state/data-layer/utils';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
+import { getStatsPathForTab } from 'calypso/lib/route';
 
 /**
  * Style dependencies

--- a/client/me/pending-payments/pending-list-item.jsx
+++ b/client/me/pending-payments/pending-list-item.jsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import { useTranslate } from 'i18n-calypso';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { get } from 'lodash';
@@ -13,11 +13,11 @@ import formatCurrency from '@automattic/format-currency';
  * Internal dependencies
  */
 import { Card, Button } from '@automattic/components';
-import { useLocalizedMoment } from 'components/localized-moment';
-import { getSite, getSiteTitle, getSiteDomain } from 'state/sites/selectors';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import { getSite, getSiteTitle, getSiteDomain } from 'calypso/state/sites/selectors';
 import PurchaseSiteHeader from '../purchases/purchases-site/header';
-import { purchaseType as getPurchaseType, getName } from 'lib/purchases';
-import { paymentMethodName } from 'lib/cart-values';
+import { purchaseType as getPurchaseType, getName } from 'calypso/lib/purchases';
+import { paymentMethodName } from 'calypso/lib/cart-values';
 
 export function PendingListItem( {
 	paymentType,

--- a/client/me/pending-payments/test/pending-list-item.js
+++ b/client/me/pending-payments/test/pending-list-item.js
@@ -9,8 +9,8 @@ import moment from 'moment';
  * Internal dependencies
  */
 import { PendingListItem } from '../pending-list-item';
-import { PLAN_BUSINESS } from 'lib/plans/constants';
-import * as localizedMoment from 'components/localized-moment';
+import { PLAN_BUSINESS } from 'calypso/lib/plans/constants';
+import * as localizedMoment from 'calypso/components/localized-moment';
 
 jest.mock( 'components/localized-moment' );
 localizedMoment.useLocalizedMoment.mockReturnValue( moment );

--- a/client/me/privacy/controller.js
+++ b/client/me/privacy/controller.js
@@ -6,8 +6,8 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import userSettings from 'lib/user-settings';
-import PrivacyComponent from 'me/privacy/main';
+import userSettings from 'calypso/lib/user-settings';
+import PrivacyComponent from 'calypso/me/privacy/main';
 
 export function privacy( context, next ) {
 	context.primary = React.createElement( PrivacyComponent, {

--- a/client/me/privacy/index.js
+++ b/client/me/privacy/index.js
@@ -7,9 +7,9 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import { makeLayout, render as clientRender } from 'controller';
+import { makeLayout, render as clientRender } from 'calypso/controller';
 import { privacy } from './controller';
-import { sidebar } from 'me/controller';
+import { sidebar } from 'calypso/me/controller';
 
 export default function () {
 	page( '/me/privacy', sidebar, privacy, makeLayout, clientRender );

--- a/client/me/privacy/main.jsx
+++ b/client/me/privacy/main.jsx
@@ -12,24 +12,24 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import { Button, Card } from '@automattic/components';
-import DocumentHead from 'components/data/document-head';
-import ExternalLink from 'components/external-link';
-import FormButton from 'components/forms/form-button';
-import FormFieldset from 'components/forms/form-fieldset';
-import FormToggle from 'components/forms/form-toggle';
-import Main from 'components/main';
-import observe from 'lib/mixins/data-observe'; //eslint-disable-line no-restricted-imports
-import { protectForm } from 'lib/protect-form';
-import { localizeUrl } from 'lib/i18n-utils';
-import twoStepAuthorization from 'lib/two-step-authorization';
-import ReauthRequired from 'me/reauth-required';
-import SectionHeader from 'components/section-header';
-import formBase from 'me/form-base';
-import MeSidebarNavigation from 'me/sidebar-navigation';
-import PageViewTracker from 'lib/analytics/page-view-tracker';
-import { requestHttpData, getHttpData } from 'state/data-layer/http-data';
-import { http } from 'state/data-layer/wpcom-http/actions';
-import { successNotice, errorNotice } from 'state/notices/actions';
+import DocumentHead from 'calypso/components/data/document-head';
+import ExternalLink from 'calypso/components/external-link';
+import FormButton from 'calypso/components/forms/form-button';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormToggle from 'calypso/components/forms/form-toggle';
+import Main from 'calypso/components/main';
+import observe from 'calypso/lib/mixins/data-observe'; //eslint-disable-line no-restricted-imports
+import { protectForm } from 'calypso/lib/protect-form';
+import { localizeUrl } from 'calypso/lib/i18n-utils';
+import twoStepAuthorization from 'calypso/lib/two-step-authorization';
+import ReauthRequired from 'calypso/me/reauth-required';
+import SectionHeader from 'calypso/components/section-header';
+import formBase from 'calypso/me/form-base';
+import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { requestHttpData, getHttpData } from 'calypso/state/data-layer/http-data';
+import { http } from 'calypso/state/data-layer/wpcom-http/actions';
+import { successNotice, errorNotice } from 'calypso/state/notices/actions';
 
 /**
  * Style dependencies

--- a/client/me/profile-gravatar/index.jsx
+++ b/client/me/profile-gravatar/index.jsx
@@ -8,9 +8,9 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import Animate from 'components/animate';
-import Gravatar from 'components/gravatar';
-import { recordGoogleEvent } from 'state/analytics/actions';
+import Animate from 'calypso/components/animate';
+import Gravatar from 'calypso/components/gravatar';
+import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 
 /**
  * Style dependencies

--- a/client/me/profile-link/index.jsx
+++ b/client/me/profile-link/index.jsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import classNames from 'classnames';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
@@ -11,9 +11,9 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import { Button } from '@automattic/components';
-import safeProtocolUrl from 'lib/safe-protocol-url';
-import { recordGoogleEvent } from 'state/analytics/actions';
-import { withoutHttp } from 'lib/url';
+import safeProtocolUrl from 'calypso/lib/safe-protocol-url';
+import { recordGoogleEvent } from 'calypso/state/analytics/actions';
+import { withoutHttp } from 'calypso/lib/url';
 
 /**
  * Style dependencies

--- a/client/me/profile-links-add-other/index.jsx
+++ b/client/me/profile-links-add-other/index.jsx
@@ -8,11 +8,11 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import FormButton from 'components/forms/form-button';
-import FormFieldset from 'components/forms/form-fieldset';
-import FormTextInput from 'components/forms/form-text-input';
-import { addUserProfileLinks } from 'state/profile-links/actions';
-import { recordGoogleEvent } from 'state/analytics/actions';
+import FormButton from 'calypso/components/forms/form-button';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormTextInput from 'calypso/components/forms/form-text-input';
+import { addUserProfileLinks } from 'calypso/state/profile-links/actions';
+import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 
 /**
  * Style dependencies

--- a/client/me/profile-links-add-wordpress/index.jsx
+++ b/client/me/profile-links-add-wordpress/index.jsx
@@ -10,14 +10,14 @@ import { find, map, pickBy } from 'lodash';
 /**
  * Internal dependencies
  */
-import config from 'config';
-import FormButton from 'components/forms/form-button';
+import config from 'calypso/config';
+import FormButton from 'calypso/components/forms/form-button';
 import ProfileLinksAddWordPressSite from './site';
-import { addUserProfileLinks } from 'state/profile-links/actions';
-import getPublicSites from 'state/selectors/get-public-sites';
-import getSites from 'state/selectors/get-sites';
-import isSiteInProfileLinks from 'state/selectors/is-site-in-profile-links';
-import { recordGoogleEvent } from 'state/analytics/actions';
+import { addUserProfileLinks } from 'calypso/state/profile-links/actions';
+import getPublicSites from 'calypso/state/selectors/get-public-sites';
+import getSites from 'calypso/state/selectors/get-sites';
+import isSiteInProfileLinks from 'calypso/state/selectors/is-site-in-profile-links';
+import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 
 /**
  * Style dependencies

--- a/client/me/profile-links-add-wordpress/site.jsx
+++ b/client/me/profile-links-add-wordpress/site.jsx
@@ -8,9 +8,9 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import FormInputCheckbox from 'components/forms/form-checkbox';
-import Site from 'blocks/site';
-import { recordGoogleEvent } from 'state/analytics/actions';
+import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
+import Site from 'calypso/blocks/site';
+import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 
 class ProfileLinksAddWordPressSite extends Component {
 	static propTypes = {

--- a/client/me/profile-links/add-buttons.jsx
+++ b/client/me/profile-links/add-buttons.jsx
@@ -3,7 +3,7 @@
  */
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
@@ -11,9 +11,9 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import { Button } from '@automattic/components';
-import PopoverMenu from 'components/popover/menu';
-import PopoverMenuItem from 'components/popover/menu-item';
-import { recordGoogleEvent } from 'state/analytics/actions';
+import PopoverMenu from 'calypso/components/popover/menu';
+import PopoverMenuItem from 'calypso/components/popover/menu-item';
+import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 
 class AddProfileLinksButtons extends React.Component {
 	static propTypes = {

--- a/client/me/profile-links/index.jsx
+++ b/client/me/profile-links/index.jsx
@@ -9,17 +9,20 @@ import { times } from 'lodash';
 /**
  * Internal dependencies
  */
-import ProfileLink from 'me/profile-link';
-import QueryProfileLinks from 'components/data/query-profile-links';
-import AddProfileLinksButtons from 'me/profile-links/add-buttons';
-import SectionHeader from 'components/section-header';
+import ProfileLink from 'calypso/me/profile-link';
+import QueryProfileLinks from 'calypso/components/data/query-profile-links';
+import AddProfileLinksButtons from 'calypso/me/profile-links/add-buttons';
+import SectionHeader from 'calypso/components/section-header';
 import { Card } from '@automattic/components';
-import Notice from 'components/notice';
-import ProfileLinksAddWordPress from 'me/profile-links-add-wordpress';
-import ProfileLinksAddOther from 'me/profile-links-add-other';
-import { deleteUserProfileLink, resetUserProfileLinkErrors } from 'state/profile-links/actions';
-import getProfileLinks from 'state/selectors/get-profile-links';
-import getProfileLinksErrorType from 'state/selectors/get-profile-links-error-type';
+import Notice from 'calypso/components/notice';
+import ProfileLinksAddWordPress from 'calypso/me/profile-links-add-wordpress';
+import ProfileLinksAddOther from 'calypso/me/profile-links-add-other';
+import {
+	deleteUserProfileLink,
+	resetUserProfileLinkErrors,
+} from 'calypso/state/profile-links/actions';
+import getProfileLinks from 'calypso/state/selectors/get-profile-links';
+import getProfileLinksErrorType from 'calypso/state/selectors/get-profile-links-error-type';
 
 /**
  * Style dependencies

--- a/client/me/profile/index.jsx
+++ b/client/me/profile/index.jsx
@@ -12,24 +12,24 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import { Card } from '@automattic/components';
-import EditGravatar from 'blocks/edit-gravatar';
-import formBase from 'me/form-base';
-import FormButton from 'components/forms/form-button';
-import FormFieldset from 'components/forms/form-fieldset';
-import FormLabel from 'components/forms/form-label';
-import FormTextarea from 'components/forms/form-textarea';
-import FormTextInput from 'components/forms/form-text-input';
-import Main from 'components/main';
-import MeSidebarNavigation from 'me/sidebar-navigation';
-import observe from 'lib/mixins/data-observe'; //eslint-disable-line no-restricted-imports
-import ProfileLinks from 'me/profile-links';
-import ReauthRequired from 'me/reauth-required';
-import SectionHeader from 'components/section-header';
-import { localizeUrl } from 'lib/i18n-utils';
-import twoStepAuthorization from 'lib/two-step-authorization';
-import { protectForm } from 'lib/protect-form';
-import { recordGoogleEvent } from 'state/analytics/actions';
-import PageViewTracker from 'lib/analytics/page-view-tracker';
+import EditGravatar from 'calypso/blocks/edit-gravatar';
+import formBase from 'calypso/me/form-base';
+import FormButton from 'calypso/components/forms/form-button';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormTextarea from 'calypso/components/forms/form-textarea';
+import FormTextInput from 'calypso/components/forms/form-text-input';
+import Main from 'calypso/components/main';
+import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
+import observe from 'calypso/lib/mixins/data-observe'; //eslint-disable-line no-restricted-imports
+import ProfileLinks from 'calypso/me/profile-links';
+import ReauthRequired from 'calypso/me/reauth-required';
+import SectionHeader from 'calypso/components/section-header';
+import { localizeUrl } from 'calypso/lib/i18n-utils';
+import twoStepAuthorization from 'calypso/lib/two-step-authorization';
+import { protectForm } from 'calypso/lib/protect-form';
+import { recordGoogleEvent } from 'calypso/state/analytics/actions';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 
 /**
  * Style dependencies

--- a/client/me/purchases/add-credit-card/index.jsx
+++ b/client/me/purchases/add-credit-card/index.jsx
@@ -9,18 +9,18 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import { addStoredCard } from 'state/stored-cards/actions';
-import { recordTracksEvent } from 'lib/analytics/tracks';
-import { concatTitle } from 'lib/react-helpers';
-import { createCardToken } from 'lib/store-transactions';
-import CreditCardForm from 'blocks/credit-card-form';
-import DocumentHead from 'components/data/document-head';
-import HeaderCake from 'components/header-cake';
-import Main from 'components/main';
-import titles from 'me/purchases/titles';
-import { billingHistory } from 'me/purchases/paths';
-import PageViewTracker from 'lib/analytics/page-view-tracker';
-import { StripeHookProvider } from 'lib/stripe';
+import { addStoredCard } from 'calypso/state/stored-cards/actions';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { concatTitle } from 'calypso/lib/react-helpers';
+import { createCardToken } from 'calypso/lib/store-transactions';
+import CreditCardForm from 'calypso/blocks/credit-card-form';
+import DocumentHead from 'calypso/components/data/document-head';
+import HeaderCake from 'calypso/components/header-cake';
+import Main from 'calypso/components/main';
+import titles from 'calypso/me/purchases/titles';
+import { billingHistory } from 'calypso/me/purchases/paths';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { StripeHookProvider } from 'calypso/lib/stripe';
 
 function AddCreditCard( props ) {
 	const createAddCardToken = ( ...args ) => createCardToken( 'card_add', ...args );

--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -12,23 +12,23 @@ import { getCurrencyDefaults } from '@automattic/format-currency';
  * Internal Dependencies
  */
 import { Button } from '@automattic/components';
-import { cancelAndRefundPurchase, cancelPurchase } from 'lib/purchases/actions';
-import { clearPurchases } from 'state/purchases/actions';
-import CancelPurchaseForm from 'components/marketing-survey/cancel-purchase-form';
-import { CANCEL_FLOW_TYPE } from 'components/marketing-survey/cancel-purchase-form/constants';
+import { cancelAndRefundPurchase, cancelPurchase } from 'calypso/lib/purchases/actions';
+import { clearPurchases } from 'calypso/state/purchases/actions';
+import CancelPurchaseForm from 'calypso/components/marketing-survey/cancel-purchase-form';
+import { CANCEL_FLOW_TYPE } from 'calypso/components/marketing-survey/cancel-purchase-form/constants';
 import {
 	getName,
 	getSubscriptionEndDate,
 	hasAmountAvailableToRefund,
 	isOneTimePurchase,
 	isSubscription,
-} from 'lib/purchases';
-import { isDomainRegistration } from 'lib/products-values';
-import notices from 'notices';
-import { confirmCancelDomain, purchasesRoot } from 'me/purchases/paths';
-import { refreshSitePlans } from 'state/sites/plans/actions';
+} from 'calypso/lib/purchases';
+import { isDomainRegistration } from 'calypso/lib/products-values';
+import notices from 'calypso/notices';
+import { confirmCancelDomain, purchasesRoot } from 'calypso/me/purchases/paths';
+import { refreshSitePlans } from 'calypso/state/sites/plans/actions';
 import { cancellationEffectDetail, cancellationEffectHeadline } from './cancellation-effect';
-import { getDowngradePlanFromPurchase } from 'state/purchases/selectors';
+import { getDowngradePlanFromPurchase } from 'calypso/state/purchases/selectors';
 
 class CancelPurchaseButton extends Component {
 	static propTypes = {

--- a/client/me/purchases/cancel-purchase/cancellation-effect.jsx
+++ b/client/me/purchases/cancel-purchase/cancellation-effect.jsx
@@ -7,7 +7,7 @@ import React from 'react';
 /**
  * Internal Dependencies
  */
-import { getName, getSubscriptionEndDate, isRefundable } from 'lib/purchases';
+import { getName, getSubscriptionEndDate, isRefundable } from 'calypso/lib/purchases';
 import {
 	isDomainMapping,
 	isGoogleApps,
@@ -15,7 +15,7 @@ import {
 	isDotComPlan,
 	isPlan,
 	isTheme,
-} from 'lib/products-values';
+} from 'calypso/lib/products-values';
 
 export function cancellationEffectHeadline( purchase, translate ) {
 	const { domain } = purchase;

--- a/client/me/purchases/cancel-purchase/index.jsx
+++ b/client/me/purchases/cancel-purchase/index.jsx
@@ -12,7 +12,7 @@ import React, { Fragment } from 'react';
  */
 import { Card, CompactCard } from '@automattic/components';
 import CancelPurchaseButton from './button';
-import CancelPurchaseLoadingPlaceholder from 'me/purchases/cancel-purchase/loading-placeholder';
+import CancelPurchaseLoadingPlaceholder from 'calypso/me/purchases/cancel-purchase/loading-placeholder';
 import CancelPurchaseRefundInformation from './refund-information';
 import {
 	getName,
@@ -21,23 +21,23 @@ import {
 	isOneTimePurchase,
 	isRefundable,
 	isSubscription,
-} from 'lib/purchases';
-import { isDataLoading } from 'me/purchases/utils';
+} from 'calypso/lib/purchases';
+import { isDataLoading } from 'calypso/me/purchases/utils';
 import {
 	getByPurchaseId,
 	hasLoadedUserPurchasesFromServer,
 	getIncludedDomainPurchase,
-} from 'state/purchases/selectors';
-import HeaderCake from 'components/header-cake';
-import { isDomainRegistration, isDomainTransfer } from 'lib/products-values';
-import { isRequestingSites, getSite } from 'state/sites/selectors';
-import { managePurchase, purchasesRoot } from 'me/purchases/paths';
-import QueryUserPurchases from 'components/data/query-user-purchases';
-import { withLocalizedMoment } from 'components/localized-moment';
-import ProductLink from 'me/purchases/product-link';
-import titles from 'me/purchases/titles';
-import TrackPurchasePageView from 'me/purchases/track-purchase-page-view';
-import { getCurrentUserId } from 'state/current-user/selectors';
+} from 'calypso/state/purchases/selectors';
+import HeaderCake from 'calypso/components/header-cake';
+import { isDomainRegistration, isDomainTransfer } from 'calypso/lib/products-values';
+import { isRequestingSites, getSite } from 'calypso/state/sites/selectors';
+import { managePurchase, purchasesRoot } from 'calypso/me/purchases/paths';
+import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
+import { withLocalizedMoment } from 'calypso/components/localized-moment';
+import ProductLink from 'calypso/me/purchases/product-link';
+import titles from 'calypso/me/purchases/titles';
+import TrackPurchasePageView from 'calypso/me/purchases/track-purchase-page-view';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 
 /**
  * Style dependencies

--- a/client/me/purchases/cancel-purchase/loading-placeholder.jsx
+++ b/client/me/purchases/cancel-purchase/loading-placeholder.jsx
@@ -9,8 +9,8 @@ import React from 'react';
  * Internal dependencies
  */
 import { Button, Card, CompactCard } from '@automattic/components';
-import LoadingPlaceholder from 'me/purchases/components/loading-placeholder';
-import titles from 'me/purchases/titles';
+import LoadingPlaceholder from 'calypso/me/purchases/components/loading-placeholder';
+import titles from 'calypso/me/purchases/titles';
 
 const CancelPurchaseLoadingPlaceholder = ( { purchaseId, siteSlug, getManagePurchaseUrlFor } ) => {
 	let path;

--- a/client/me/purchases/cancel-purchase/refund-information.jsx
+++ b/client/me/purchases/cancel-purchase/refund-information.jsx
@@ -16,13 +16,13 @@ import {
 	isSubscription,
 	isOneTimePurchase,
 	maybeWithinRefundPeriod,
-} from 'lib/purchases';
-import { isDomainRegistration, isDomainMapping } from 'lib/products-values';
-import { getIncludedDomainPurchase } from 'state/purchases/selectors';
-import { CALYPSO_CONTACT, UPDATE_NAMESERVERS } from 'lib/url/support';
-import FormLabel from 'components/forms/form-label';
-import FormRadio from 'components/forms/form-radio';
-import FormCheckbox from 'components/forms/form-checkbox';
+} from 'calypso/lib/purchases';
+import { isDomainRegistration, isDomainMapping } from 'calypso/lib/products-values';
+import { getIncludedDomainPurchase } from 'calypso/state/purchases/selectors';
+import { CALYPSO_CONTACT, UPDATE_NAMESERVERS } from 'calypso/lib/url/support';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormRadio from 'calypso/components/forms/form-radio';
+import FormCheckbox from 'calypso/components/forms/form-checkbox';
 
 const CancelPurchaseRefundInformation = ( {
 	purchase,

--- a/client/me/purchases/cancel-purchase/test/cancellation-effect.jsx
+++ b/client/me/purchases/cancel-purchase/test/cancellation-effect.jsx
@@ -7,8 +7,8 @@ import { expect } from 'chai';
  * Internal dependencies
  */
 import { cancellationEffectDetail, cancellationEffectHeadline } from '../cancellation-effect';
-import productsValues from 'lib/products-values';
-import purchases from 'lib/purchases';
+import productsValues from 'calypso/lib/products-values';
+import purchases from 'calypso/lib/purchases';
 
 jest.mock( 'lib/products-values', () => ( {} ) );
 jest.mock( 'lib/purchases', () => ( {} ) );

--- a/client/me/purchases/components/loading-placeholder/index.jsx
+++ b/client/me/purchases/components/loading-placeholder/index.jsx
@@ -10,8 +10,8 @@ import classnames from 'classnames';
 /**
  * Internal dependencies
  */
-import HeaderCake from 'components/header-cake';
-import Main from 'components/main';
+import HeaderCake from 'calypso/components/header-cake';
+import Main from 'calypso/components/main';
 
 /**
  * Style dependencies

--- a/client/me/purchases/concierge-banner/index.jsx
+++ b/client/me/purchases/concierge-banner/index.jsx
@@ -10,15 +10,15 @@ import PropTypes from 'prop-types';
  * Internal Dependencies
  */
 import { Card } from '@automattic/components';
-import ActionCard from 'components/action-card';
-import TrackComponentView from 'lib/analytics/track-component-view';
-import conciergeImage from 'assets/images/illustrations/jetpack-concierge.svg';
+import ActionCard from 'calypso/components/action-card';
+import TrackComponentView from 'calypso/lib/analytics/track-component-view';
+import conciergeImage from 'calypso/assets/images/illustrations/jetpack-concierge.svg';
 import {
 	CONCIERGE_HAS_UPCOMING_APPOINTMENT,
 	CONCIERGE_HAS_AVAILABLE_INCLUDED_SESSION,
 	CONCIERGE_HAS_AVAILABLE_PURCHASED_SESSION,
 	CONCIERGE_SUGGEST_PURCHASE_CONCIERGE,
-} from 'me/concierge/constants';
+} from 'calypso/me/concierge/constants';
 
 /**
  * Style dependencies

--- a/client/me/purchases/confirm-cancel-domain/cancellation-reasons.js
+++ b/client/me/purchases/confirm-cancel-domain/cancellation-reasons.js
@@ -8,7 +8,7 @@ import i18n from 'i18n-calypso';
 /**
  * Internal Dependencies
  */
-import { TRANSFER_DOMAIN_REGISTRATION, UPDATE_NAMESERVERS } from 'lib/url/support';
+import { TRANSFER_DOMAIN_REGISTRATION, UPDATE_NAMESERVERS } from 'calypso/lib/url/support';
 
 export default [
 	{

--- a/client/me/purchases/confirm-cancel-domain/index.jsx
+++ b/client/me/purchases/confirm-cancel-domain/index.jsx
@@ -10,42 +10,45 @@ import { map, find } from 'lodash';
 /**
  * Internal Dependencies
  */
-import { recordTracksEvent } from 'lib/analytics/tracks';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import cancellationReasons from './cancellation-reasons';
-import { cancelAndRefundPurchase } from 'lib/purchases/actions';
+import { cancelAndRefundPurchase } from 'calypso/lib/purchases/actions';
 import { Card } from '@automattic/components';
-import { clearPurchases } from 'state/purchases/actions';
+import { clearPurchases } from 'calypso/state/purchases/actions';
 import ConfirmCancelDomainLoadingPlaceholder from './loading-placeholder';
 import { connect } from 'react-redux';
-import FormButton from 'components/forms/form-button';
-import FormCheckbox from 'components/forms/form-checkbox';
-import FormLabel from 'components/forms/form-label';
-import FormSectionHeading from 'components/forms/form-section-heading';
-import FormTextarea from 'components/forms/form-textarea';
-import HeaderCake from 'components/header-cake';
-import isDomainOnly from 'state/selectors/is-domain-only-site';
-import { getByPurchaseId, hasLoadedUserPurchasesFromServer } from 'state/purchases/selectors';
-import { getName as getDomainName } from 'lib/purchases';
+import FormButton from 'calypso/components/forms/form-button';
+import FormCheckbox from 'calypso/components/forms/form-checkbox';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormSectionHeading from 'calypso/components/forms/form-section-heading';
+import FormTextarea from 'calypso/components/forms/form-textarea';
+import HeaderCake from 'calypso/components/header-cake';
+import isDomainOnly from 'calypso/state/selectors/is-domain-only-site';
+import {
+	getByPurchaseId,
+	hasLoadedUserPurchasesFromServer,
+} from 'calypso/state/purchases/selectors';
+import { getName as getDomainName } from 'calypso/lib/purchases';
 import { isDataLoading } from '../utils';
-import { getSelectedSite } from 'state/ui/selectors';
-import { isDomainRegistration } from 'lib/products-values';
-import { isRequestingSites } from 'state/sites/selectors';
-import notices from 'notices';
-import { cancelPurchase, purchasesRoot } from 'me/purchases/paths';
-import QueryUserPurchases from 'components/data/query-user-purchases';
-import { receiveDeletedSite } from 'state/sites/actions';
-import { refreshSitePlans } from 'state/sites/plans/actions';
-import { setAllSitesSelected } from 'state/ui/actions';
-import titles from 'me/purchases/titles';
-import PageViewTracker from 'lib/analytics/page-view-tracker';
-import TrackPurchasePageView from 'me/purchases/track-purchase-page-view';
-import { getCurrentUserId } from 'state/current-user/selectors';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+import { isDomainRegistration } from 'calypso/lib/products-values';
+import { isRequestingSites } from 'calypso/state/sites/selectors';
+import notices from 'calypso/notices';
+import { cancelPurchase, purchasesRoot } from 'calypso/me/purchases/paths';
+import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
+import { receiveDeletedSite } from 'calypso/state/sites/actions';
+import { refreshSitePlans } from 'calypso/state/sites/plans/actions';
+import { setAllSitesSelected } from 'calypso/state/ui/actions';
+import titles from 'calypso/me/purchases/titles';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import TrackPurchasePageView from 'calypso/me/purchases/track-purchase-page-view';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 
 /**
  * Style dependencies
  */
 import './style.scss';
-import FormSelect from 'components/forms/form-select';
+import FormSelect from 'calypso/components/forms/form-select';
 
 class ConfirmCancelDomain extends React.Component {
 	static propTypes = {

--- a/client/me/purchases/confirm-cancel-domain/loading-placeholder.jsx
+++ b/client/me/purchases/confirm-cancel-domain/loading-placeholder.jsx
@@ -9,9 +9,9 @@ import React from 'react';
  * Internal dependencies
  */
 import { Button, Card, CompactCard } from '@automattic/components';
-import { cancelPurchase } from 'me/purchases/paths';
-import LoadingPlaceholder from 'me/purchases/components/loading-placeholder';
-import titles from 'me/purchases/titles';
+import { cancelPurchase } from 'calypso/me/purchases/paths';
+import LoadingPlaceholder from 'calypso/me/purchases/components/loading-placeholder';
+import titles from 'calypso/me/purchases/titles';
 
 const ConfirmCancelDomainLoadingPlaceholder = ( { purchaseId, selectedSite } ) => {
 	let path;

--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -12,18 +12,18 @@ import AddCreditCard from './add-credit-card';
 import CancelPurchase from './cancel-purchase';
 import ConfirmCancelDomain from './confirm-cancel-domain';
 import EditCardDetails from './payment/edit-card-details';
-import Main from 'components/main';
+import Main from 'calypso/components/main';
 import ManagePurchase from './manage-purchase';
-import NoSitesMessage from 'components/empty-content/no-sites-message';
+import NoSitesMessage from 'calypso/components/empty-content/no-sites-message';
 import PurchasesHeader from './purchases-list/header';
 import PurchasesList from './purchases-list';
-import { concatTitle } from 'lib/react-helpers';
-import { setDocumentHeadTitle } from 'state/document-head/actions';
+import { concatTitle } from 'calypso/lib/react-helpers';
+import { setDocumentHeadTitle } from 'calypso/state/document-head/actions';
 import titles from './titles';
-import { makeLayout, render as clientRender } from 'controller';
-import PageViewTracker from 'lib/analytics/page-view-tracker';
-import { getCurrentUserSiteCount } from 'state/current-user/selectors';
-import { managePurchase as managePurchaseUrl, purchasesRoot } from 'me/purchases/paths';
+import { makeLayout, render as clientRender } from 'calypso/controller';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { getCurrentUserSiteCount } from 'calypso/state/current-user/selectors';
+import { managePurchase as managePurchaseUrl, purchasesRoot } from 'calypso/me/purchases/paths';
 
 // FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 function setTitle( context, ...title ) {

--- a/client/me/purchases/credit-cards/credit-card-delete.tsx
+++ b/client/me/purchases/credit-cards/credit-card-delete.tsx
@@ -9,17 +9,17 @@ import { useTranslate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { ReduxDispatch } from 'state/redux-store';
-import { deleteStoredCard } from 'state/stored-cards/actions';
-import { errorNotice, successNotice } from 'state/notices/actions';
-import { isDeletingStoredCard } from 'state/stored-cards/selectors';
+import { ReduxDispatch } from 'calypso/state/redux-store';
+import { deleteStoredCard } from 'calypso/state/stored-cards/actions';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+import { isDeletingStoredCard } from 'calypso/state/stored-cards/selectors';
 import { Button } from '@automattic/components';
 import {
 	isPaymentAgreement,
 	getPaymentMethodSummary,
 	PaymentMethod,
-} from 'lib/checkout/payment-methods';
-import StoredCard from 'components/credit-card/stored-card';
+} from 'calypso/lib/checkout/payment-methods';
+import StoredCard from 'calypso/components/credit-card/stored-card';
 import PaymentMethodDeleteDialog from './payment-method-delete-dialog';
 
 /**

--- a/client/me/purchases/credit-cards/index.jsx
+++ b/client/me/purchases/credit-cards/index.jsx
@@ -11,18 +11,18 @@ import React, { Component } from 'react';
  * Internal dependencies
  */
 import { Button, Card } from '@automattic/components';
-import config from 'config';
-import CreditCard from 'components/credit-card';
+import config from 'calypso/config';
+import CreditCard from 'calypso/components/credit-card';
 import CreditCardDelete from './credit-card-delete';
 import {
 	getStoredCards,
 	getUniquePaymentAgreements,
 	hasLoadedStoredCardsFromServer,
 	isFetchingStoredCards,
-} from 'state/stored-cards/selectors';
-import QueryStoredCards from 'components/data/query-stored-cards';
-import { addCreditCard } from 'me/purchases/paths';
-import SectionHeader from 'components/section-header';
+} from 'calypso/state/stored-cards/selectors';
+import QueryStoredCards from 'calypso/components/data/query-stored-cards';
+import { addCreditCard } from 'calypso/me/purchases/paths';
+import SectionHeader from 'calypso/components/section-header';
 
 /**
  * Style dependencies

--- a/client/me/purchases/index.js
+++ b/client/me/purchases/index.js
@@ -1,20 +1,20 @@
 /**
  * External dependencies
  */
-import config from 'config';
+import config from 'calypso/config';
 import page from 'page';
 
 /**
  * Internal Dependencies
  */
-import * as billingController from 'me/billing-history/controller';
-import * as pendingController from 'me/pending-payments/controller';
-import * as membershipsController from 'me/memberships/controller';
+import * as billingController from 'calypso/me/billing-history/controller';
+import * as pendingController from 'calypso/me/pending-payments/controller';
+import * as membershipsController from 'calypso/me/memberships/controller';
 import * as controller from './controller';
 import * as paths from './paths';
-import { makeLayout, render as clientRender } from 'controller';
-import { sidebar } from 'me/controller';
-import { siteSelection } from 'my-sites/controller';
+import { makeLayout, render as clientRender } from 'calypso/controller';
+import { sidebar } from 'calypso/me/controller';
+import { siteSelection } from 'calypso/my-sites/controller';
 
 export default ( router ) => {
 	if ( config.isEnabled( 'manage/payment-methods' ) ) {

--- a/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.jsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.jsx
@@ -10,11 +10,11 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import { Button, Dialog } from '@automattic/components';
-import CancelAutoRenewalForm from 'components/marketing-survey/cancel-auto-renewal-form';
-import { withLocalizedMoment } from 'components/localized-moment';
-import { isDomainRegistration, isPlan } from 'lib/products-values';
-import isSiteAtomic from 'state/selectors/is-site-automated-transfer';
-import { getSite } from 'state/sites/selectors';
+import CancelAutoRenewalForm from 'calypso/components/marketing-survey/cancel-auto-renewal-form';
+import { withLocalizedMoment } from 'calypso/components/localized-moment';
+import { isDomainRegistration, isPlan } from 'calypso/lib/products-values';
+import isSiteAtomic from 'calypso/state/selectors/is-site-automated-transfer';
+import { getSite } from 'calypso/state/sites/selectors';
 import './style.scss';
 
 const DIALOG = {

--- a/client/me/purchases/manage-purchase/auto-renew-toggle/index.jsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/index.jsx
@@ -10,21 +10,21 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import { isExpiring } from 'lib/purchases';
-import { disableAutoRenew, enableAutoRenew } from 'lib/purchases/actions';
-import { getCurrentUserId } from 'state/current-user/selectors';
-import { isFetchingUserPurchases } from 'state/purchases/selectors';
-import { fetchUserPurchases } from 'state/purchases/actions';
-import { recordTracksEvent } from 'state/analytics/actions';
-import isSiteAtomic from 'state/selectors/is-site-automated-transfer';
-import { createNotice } from 'state/notices/actions';
+import { isExpiring } from 'calypso/lib/purchases';
+import { disableAutoRenew, enableAutoRenew } from 'calypso/lib/purchases/actions';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
+import { isFetchingUserPurchases } from 'calypso/state/purchases/selectors';
+import { fetchUserPurchases } from 'calypso/state/purchases/actions';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import isSiteAtomic from 'calypso/state/selectors/is-site-automated-transfer';
+import { createNotice } from 'calypso/state/notices/actions';
 import AutoRenewDisablingDialog from './auto-renew-disabling-dialog';
 import AutoRenewPaymentMethodDialog from './auto-renew-payment-method-dialog';
-import FormToggle from 'components/forms/form-toggle';
-import CompactFormToggle from 'components/forms/form-toggle/compact';
+import FormToggle from 'calypso/components/forms/form-toggle';
+import CompactFormToggle from 'calypso/components/forms/form-toggle/compact';
 import { isExpired, isOneTimePurchase, isRechargeable } from '../../../../lib/purchases';
 import { getEditCardDetailsPath } from '../../utils';
-import { getSelectedSiteSlug } from 'state/ui/selectors';
+import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
 class AutoRenewToggle extends Component {
 	static propTypes = {

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -11,13 +11,13 @@ import React, { Component, Fragment } from 'react';
 /**
  * Internal Dependencies
  */
-import AsyncLoad from 'components/async-load';
-import { abtest } from 'lib/abtest';
-import { recordTracksEvent } from 'lib/analytics/tracks';
-import { applyTestFiltersToPlansList } from 'lib/plans';
+import AsyncLoad from 'calypso/components/async-load';
+import { abtest } from 'calypso/lib/abtest';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { applyTestFiltersToPlansList } from 'calypso/lib/plans';
 import { Button, Card, CompactCard, ProductIcon } from '@automattic/components';
-import config from 'config';
-import { shouldShowOfferResetFlow } from 'lib/plans/config';
+import config from 'calypso/config';
+import { shouldShowOfferResetFlow } from 'calypso/lib/plans/config';
 import {
 	cardProcessorSupportsUpdates,
 	getDomainRegistrationAgreementUrl,
@@ -39,19 +39,19 @@ import {
 	isCloseToExpiration,
 	purchaseType,
 	getName,
-} from 'lib/purchases';
+} from 'calypso/lib/purchases';
 import { canEditPaymentDetails, getEditCardDetailsPath, isDataLoading } from '../utils';
 import {
 	getByPurchaseId,
 	hasLoadedUserPurchasesFromServer,
 	getRenewableSitePurchases,
-} from 'state/purchases/selectors';
-import { getCanonicalTheme } from 'state/themes/selectors';
-import isSiteAtomic from 'state/selectors/is-site-automated-transfer';
-import Gridicon from 'components/gridicon';
-import HeaderCake from 'components/header-cake';
-import Notice from 'components/notice';
-import NoticeAction from 'components/notice/notice-action';
+} from 'calypso/state/purchases/selectors';
+import { getCanonicalTheme } from 'calypso/state/themes/selectors';
+import isSiteAtomic from 'calypso/state/selectors/is-site-automated-transfer';
+import Gridicon from 'calypso/components/gridicon';
+import HeaderCake from 'calypso/components/header-cake';
+import Notice from 'calypso/components/notice';
+import NoticeAction from 'calypso/components/notice/notice-action';
 import {
 	isPersonal,
 	isPremium,
@@ -65,33 +65,37 @@ import {
 	isTheme,
 	isJetpackProduct,
 	isConciergeSession,
-} from 'lib/products-values';
-import { getSite, isRequestingSites } from 'state/sites/selectors';
-import { JETPACK_PRODUCTS_LIST } from 'lib/products-values/constants';
-import { JETPACK_PLANS, JETPACK_LEGACY_PLANS } from 'lib/plans/constants';
-import PlanPrice from 'my-sites/plan-price';
-import ProductLink from 'me/purchases/product-link';
+} from 'calypso/lib/products-values';
+import { getSite, isRequestingSites } from 'calypso/state/sites/selectors';
+import { JETPACK_PRODUCTS_LIST } from 'calypso/lib/products-values/constants';
+import { JETPACK_PLANS, JETPACK_LEGACY_PLANS } from 'calypso/lib/plans/constants';
+import PlanPrice from 'calypso/my-sites/plan-price';
+import ProductLink from 'calypso/me/purchases/product-link';
 import PurchaseMeta from './purchase-meta';
 import PurchaseNotice from './notices';
 import PurchasePlanDetails from './plan-details';
 import PurchaseSiteHeader from '../purchases-site/header';
-import QueryCanonicalTheme from 'components/data/query-canonical-theme';
-import QuerySiteDomains from 'components/data/query-site-domains';
-import QueryUserPurchases from 'components/data/query-user-purchases';
+import QueryCanonicalTheme from 'calypso/components/data/query-canonical-theme';
+import QuerySiteDomains from 'calypso/components/data/query-site-domains';
+import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
 import RemovePurchase from '../remove-purchase';
-import VerticalNavItem from 'components/vertical-nav/item';
+import VerticalNavItem from 'calypso/components/vertical-nav/item';
 import { cancelPurchase, managePurchase, purchasesRoot } from '../paths';
-import { CALYPSO_CONTACT } from 'lib/url/support';
-import titles from 'me/purchases/titles';
-import PageViewTracker from 'lib/analytics/page-view-tracker';
-import TrackPurchasePageView from 'me/purchases/track-purchase-page-view';
-import PlanRenewalMessage from 'my-sites/plans-v2/plan-renewal-message';
-import { currentUserHasFlag, getCurrentUser, getCurrentUserId } from 'state/current-user/selectors';
-import CartStore from 'lib/cart/store';
-import { NON_PRIMARY_DOMAINS_TO_FREE_USERS } from 'state/current-user/constants';
-import { hasCustomDomain } from 'lib/site/utils';
-import { hasLoadedSiteDomains } from 'state/sites/domains/selectors';
-import NonPrimaryDomainDialog from 'me/purchases/non-primary-domain-dialog';
+import { CALYPSO_CONTACT } from 'calypso/lib/url/support';
+import titles from 'calypso/me/purchases/titles';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import TrackPurchasePageView from 'calypso/me/purchases/track-purchase-page-view';
+import PlanRenewalMessage from 'calypso/my-sites/plans-v2/plan-renewal-message';
+import {
+	currentUserHasFlag,
+	getCurrentUser,
+	getCurrentUserId,
+} from 'calypso/state/current-user/selectors';
+import CartStore from 'calypso/lib/cart/store';
+import { NON_PRIMARY_DOMAINS_TO_FREE_USERS } from 'calypso/state/current-user/constants';
+import { hasCustomDomain } from 'calypso/lib/site/utils';
+import { hasLoadedSiteDomains } from 'calypso/state/sites/domains/selectors';
+import NonPrimaryDomainDialog from 'calypso/me/purchases/non-primary-domain-dialog';
 
 /**
  * Style dependencies
@@ -670,7 +674,7 @@ class ManagePurchase extends Component {
 					/>
 				) }
 				<AsyncLoad
-					require="blocks/product-plan-overlap-notices"
+					require="calypso/blocks/product-plan-overlap-notices"
 					placeholder={ null }
 					plans={ JETPACK_PLANS }
 					products={ JETPACK_PRODUCTS_LIST }

--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -10,8 +10,8 @@ import { isEmpty, merge, minBy } from 'lodash';
 /**
  * Internal Dependencies
  */
-import { recordTracksEvent } from 'state/analytics/actions';
-import config from 'config';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import config from 'calypso/config';
 import { getEditCardDetailsPath } from '../utils';
 import {
 	canExplicitRenew,
@@ -32,20 +32,20 @@ import {
 	showCreditCardExpiringWarning,
 	isPaidWithCredits,
 	shouldAddPaymentSourceInsteadOfRenewingNow,
-} from 'lib/purchases';
+} from 'calypso/lib/purchases';
 import {
 	isDomainTransfer,
 	isConciergeSession,
 	isPlan,
 	isDomainRegistration,
-} from 'lib/products-values';
-import Notice from 'components/notice';
-import NoticeAction from 'components/notice/notice-action';
-import { withLocalizedMoment } from 'components/localized-moment';
-import { isMonthly } from 'lib/plans/constants';
-import TrackComponentView from 'lib/analytics/track-component-view';
-import { managePurchase } from 'me/purchases/paths';
-import UpcomingRenewalsDialog from 'me/purchases/upcoming-renewals/upcoming-renewals-dialog';
+} from 'calypso/lib/products-values';
+import Notice from 'calypso/components/notice';
+import NoticeAction from 'calypso/components/notice/notice-action';
+import { withLocalizedMoment } from 'calypso/components/localized-moment';
+import { isMonthly } from 'calypso/lib/plans/constants';
+import TrackComponentView from 'calypso/lib/analytics/track-component-view';
+import { managePurchase } from 'calypso/me/purchases/paths';
+import UpcomingRenewalsDialog from 'calypso/me/purchases/upcoming-renewals/upcoming-renewals-dialog';
 
 /**
  * Style dependencies

--- a/client/me/purchases/manage-purchase/plan-details/billing-period.jsx
+++ b/client/me/purchases/manage-purchase/plan-details/billing-period.jsx
@@ -12,17 +12,22 @@ import page from 'page';
  * Internal Dependencies
  */
 import { Button } from '@automattic/components';
-import FormFieldset from 'components/forms/form-fieldset';
-import FormLabel from 'components/forms/form-label';
-import FormSettingExplanation from 'components/forms/form-setting-explanation';
-import { withLocalizedMoment } from 'components/localized-moment';
-import { isMonthly } from 'lib/plans/constants';
-import { getYearlyPlanByMonthly } from 'lib/plans';
-import { planItem } from 'lib/cart-values/cart-items';
-import { addItem } from 'lib/cart/actions';
-import { isExpired, isExpiring, isRenewing, showCreditCardExpiringWarning } from 'lib/purchases';
-import { JETPACK_SUPPORT } from 'lib/url/support';
-import { recordTracksEvent } from 'state/analytics/actions';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
+import { withLocalizedMoment } from 'calypso/components/localized-moment';
+import { isMonthly } from 'calypso/lib/plans/constants';
+import { getYearlyPlanByMonthly } from 'calypso/lib/plans';
+import { planItem } from 'calypso/lib/cart-values/cart-items';
+import { addItem } from 'calypso/lib/cart/actions';
+import {
+	isExpired,
+	isExpiring,
+	isRenewing,
+	showCreditCardExpiringWarning,
+} from 'calypso/lib/purchases';
+import { JETPACK_SUPPORT } from 'calypso/lib/url/support';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 export class PlanBillingPeriod extends Component {
 	static propTypes = {

--- a/client/me/purchases/manage-purchase/plan-details/index.jsx
+++ b/client/me/purchases/manage-purchase/plan-details/index.jsx
@@ -10,18 +10,21 @@ import { localize } from 'i18n-calypso';
  * Internal Dependencies
  */
 import { Card } from '@automattic/components';
-import ClipboardButtonInput from 'components/clipboard-button-input';
-import FormFieldset from 'components/forms/form-fieldset';
-import FormLabel from 'components/forms/form-label';
-import QueryPluginKeys from 'components/data/query-plugin-keys';
-import SectionHeader from 'components/section-header';
+import ClipboardButtonInput from 'calypso/components/clipboard-button-input';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormLabel from 'calypso/components/forms/form-label';
+import QueryPluginKeys from 'calypso/components/data/query-plugin-keys';
+import SectionHeader from 'calypso/components/section-header';
 import PlanBillingPeriod from './billing-period';
-import { isRequestingSites, getSite } from 'state/sites/selectors';
-import { getByPurchaseId, hasLoadedUserPurchasesFromServer } from 'state/purchases/selectors';
-import { isDataLoading } from 'me/purchases/utils';
-import { getName, isExpired, isPartnerPurchase } from 'lib/purchases';
-import { isJetpackPlan, isFreeJetpackPlan } from 'lib/products-values';
-import { getPluginsForSite } from 'state/plugins/premium/selectors';
+import { isRequestingSites, getSite } from 'calypso/state/sites/selectors';
+import {
+	getByPurchaseId,
+	hasLoadedUserPurchasesFromServer,
+} from 'calypso/state/purchases/selectors';
+import { isDataLoading } from 'calypso/me/purchases/utils';
+import { getName, isExpired, isPartnerPurchase } from 'calypso/lib/purchases';
+import { isJetpackPlan, isFreeJetpackPlan } from 'calypso/lib/products-values';
+import { getPluginsForSite } from 'calypso/state/plugins/premium/selectors';
 
 /**
  * Style dependencies

--- a/client/me/purchases/manage-purchase/plan-details/test/billing-period.jsx
+++ b/client/me/purchases/manage-purchase/plan-details/test/billing-period.jsx
@@ -11,8 +11,8 @@ import { translate } from 'i18n-calypso';
  */
 import { PlanBillingPeriod } from '../billing-period';
 import page from 'page';
-import { planItem } from 'lib/cart-values/cart-items';
-import { addItem } from 'lib/cart/actions';
+import { planItem } from 'calypso/lib/cart-values/cart-items';
+import { addItem } from 'calypso/lib/cart/actions';
 
 const props = {
 	purchase: {

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -11,7 +11,7 @@ import { times } from 'lodash';
 /**
  * Internal Dependencies
  */
-import { shouldShowOfferResetFlow } from 'lib/plans/config';
+import { shouldShowOfferResetFlow } from 'calypso/lib/plans/config';
 import {
 	getName,
 	isExpired,
@@ -28,7 +28,7 @@ import {
 	paymentLogoType,
 	hasPaymentMethod,
 	isRenewable,
-} from 'lib/purchases';
+} from 'calypso/lib/purchases';
 import {
 	isDomainRegistration,
 	isDomainTransfer,
@@ -38,20 +38,23 @@ import {
 	isJetpackProduct,
 	isPlan,
 	getProductFromSlug,
-} from 'lib/products-values';
-import { getPlan } from 'lib/plans';
-import { getByPurchaseId, hasLoadedUserPurchasesFromServer } from 'state/purchases/selectors';
-import { getSite, isRequestingSites } from 'state/sites/selectors';
-import { getUser } from 'state/users/selectors';
+} from 'calypso/lib/products-values';
+import { getPlan } from 'calypso/lib/plans';
+import {
+	getByPurchaseId,
+	hasLoadedUserPurchasesFromServer,
+} from 'calypso/state/purchases/selectors';
+import { getSite, isRequestingSites } from 'calypso/state/sites/selectors';
+import { getUser } from 'calypso/state/users/selectors';
 import { managePurchase } from '../paths';
 import AutoRenewToggle from './auto-renew-toggle';
-import PaymentLogo from 'components/payment-logo';
-import { CALYPSO_CONTACT, JETPACK_SUPPORT } from 'lib/url/support';
-import UserItem from 'components/user';
-import { withLocalizedMoment } from 'components/localized-moment';
+import PaymentLogo from 'calypso/components/payment-logo';
+import { CALYPSO_CONTACT, JETPACK_SUPPORT } from 'calypso/lib/url/support';
+import UserItem from 'calypso/components/user';
+import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import { canEditPaymentDetails, isDataLoading } from '../utils';
-import { TERM_BIENNIALLY, TERM_MONTHLY, JETPACK_LEGACY_PLANS } from 'lib/plans/constants';
-import { getCurrentUserId } from 'state/current-user/selectors';
+import { TERM_BIENNIALLY, TERM_MONTHLY, JETPACK_LEGACY_PLANS } from 'calypso/lib/plans/constants';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 
 class PurchaseMeta extends Component {
 	static propTypes = {

--- a/client/me/purchases/non-primary-domain-dialog/index.jsx
+++ b/client/me/purchases/non-primary-domain-dialog/index.jsx
@@ -9,7 +9,7 @@ import React, { Component, Fragment } from 'react';
  * Internal dependencies
  */
 import { Dialog } from '@automattic/components';
-import FormSectionHeading from 'components/forms/form-section-heading';
+import FormSectionHeading from 'calypso/components/forms/form-section-heading';
 
 /**
  * Style dependencies

--- a/client/me/purchases/payment/add-card-details/index.jsx
+++ b/client/me/purchases/payment/add-card-details/index.jsx
@@ -9,21 +9,24 @@ import { connect } from 'react-redux';
 /**
  * Internal Dependencies
  */
-import CreditCardForm from 'blocks/credit-card-form';
-import CreditCardFormLoadingPlaceholder from 'blocks/credit-card-form/loading-placeholder';
-import HeaderCake from 'components/header-cake';
-import PageViewTracker from 'lib/analytics/page-view-tracker';
-import QueryUserPurchases from 'components/data/query-user-purchases';
-import titles from 'me/purchases/titles';
-import TrackPurchasePageView from 'me/purchases/track-purchase-page-view';
-import { clearPurchases } from 'state/purchases/actions';
-import { createCardToken } from 'lib/store-transactions';
-import { getByPurchaseId, hasLoadedUserPurchasesFromServer } from 'state/purchases/selectors';
-import { getCurrentUserId } from 'state/current-user/selectors';
-import { getSelectedSite } from 'state/ui/selectors';
-import { isRequestingSites } from 'state/sites/selectors';
-import { recordTracksEvent } from 'state/analytics/actions';
-import { StripeHookProvider } from 'lib/stripe';
+import CreditCardForm from 'calypso/blocks/credit-card-form';
+import CreditCardFormLoadingPlaceholder from 'calypso/blocks/credit-card-form/loading-placeholder';
+import HeaderCake from 'calypso/components/header-cake';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
+import titles from 'calypso/me/purchases/titles';
+import TrackPurchasePageView from 'calypso/me/purchases/track-purchase-page-view';
+import { clearPurchases } from 'calypso/state/purchases/actions';
+import { createCardToken } from 'calypso/lib/store-transactions';
+import {
+	getByPurchaseId,
+	hasLoadedUserPurchasesFromServer,
+} from 'calypso/state/purchases/selectors';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+import { isRequestingSites } from 'calypso/state/sites/selectors';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { StripeHookProvider } from 'calypso/lib/stripe';
 
 function AddCardDetails( props ) {
 	const createCardUpdateToken = ( ...args ) => createCardToken( 'card_update', ...args );

--- a/client/me/purchases/payment/edit-card-details/index.jsx
+++ b/client/me/purchases/payment/edit-card-details/index.jsx
@@ -9,23 +9,29 @@ import { connect } from 'react-redux';
 /**
  * Internal Dependencies
  */
-import CreditCardForm from 'blocks/credit-card-form';
-import CreditCardFormLoadingPlaceholder from 'blocks/credit-card-form/loading-placeholder';
-import HeaderCake from 'components/header-cake';
-import PageViewTracker from 'lib/analytics/page-view-tracker';
-import QueryStoredCards from 'components/data/query-stored-cards';
-import QueryUserPurchases from 'components/data/query-user-purchases';
-import titles from 'me/purchases/titles';
-import TrackPurchasePageView from 'me/purchases/track-purchase-page-view';
-import { clearPurchases } from 'state/purchases/actions';
-import { createCardToken } from 'lib/store-transactions';
-import { getByPurchaseId, hasLoadedUserPurchasesFromServer } from 'state/purchases/selectors';
-import { getCurrentUserId } from 'state/current-user/selectors';
-import { getSelectedSite } from 'state/ui/selectors';
-import { getStoredCardById, hasLoadedStoredCardsFromServer } from 'state/stored-cards/selectors';
-import { isRequestingSites } from 'state/sites/selectors';
-import { recordTracksEvent } from 'state/analytics/actions';
-import { StripeHookProvider } from 'lib/stripe';
+import CreditCardForm from 'calypso/blocks/credit-card-form';
+import CreditCardFormLoadingPlaceholder from 'calypso/blocks/credit-card-form/loading-placeholder';
+import HeaderCake from 'calypso/components/header-cake';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import QueryStoredCards from 'calypso/components/data/query-stored-cards';
+import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
+import titles from 'calypso/me/purchases/titles';
+import TrackPurchasePageView from 'calypso/me/purchases/track-purchase-page-view';
+import { clearPurchases } from 'calypso/state/purchases/actions';
+import { createCardToken } from 'calypso/lib/store-transactions';
+import {
+	getByPurchaseId,
+	hasLoadedUserPurchasesFromServer,
+} from 'calypso/state/purchases/selectors';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+import {
+	getStoredCardById,
+	hasLoadedStoredCardsFromServer,
+} from 'calypso/state/stored-cards/selectors';
+import { isRequestingSites } from 'calypso/state/sites/selectors';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { StripeHookProvider } from 'calypso/lib/stripe';
 
 function EditCardDetails( props ) {
 	const isDataLoading = ! props.hasLoadedSites || ! props.hasLoadedUserPurchasesFromServer;

--- a/client/me/purchases/product-link/index.jsx
+++ b/client/me/purchases/product-link/index.jsx
@@ -10,17 +10,17 @@ import i18n from 'i18n-calypso';
 /**
  * Internal Dependencies
  */
-import config from 'config';
-import { domainManagementEdit } from 'my-sites/domains/paths';
-import { emailManagement } from 'my-sites/email/paths';
-import { getThemeDetailsUrl } from 'state/themes/selectors';
+import config from 'calypso/config';
+import { domainManagementEdit } from 'calypso/my-sites/domains/paths';
+import { emailManagement } from 'calypso/my-sites/email/paths';
+import { getThemeDetailsUrl } from 'calypso/state/themes/selectors';
 import {
 	isDomainProduct,
 	isGoogleApps,
 	isPlan,
 	isSiteRedirect,
 	isTheme,
-} from 'lib/products-values';
+} from 'calypso/lib/products-values';
 
 const ProductLink = ( { productUrl, purchase, selectedSite } ) => {
 	let props = {},

--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -22,7 +22,7 @@ import {
 	purchaseType,
 	showCreditCardExpiringWarning,
 	getPartnerName,
-} from 'lib/purchases';
+} from 'calypso/lib/purchases';
 import {
 	isDomainProduct,
 	isDomainTransfer,
@@ -31,12 +31,12 @@ import {
 	isTheme,
 	isJetpackProduct,
 	isConciergeSession,
-} from 'lib/products-values';
-import Notice from 'components/notice';
-import Gridicon from 'components/gridicon';
-import { withLocalizedMoment } from 'components/localized-moment';
-import TrackComponentView from 'lib/analytics/track-component-view';
-import { getPlanClass, getPlanTermLabel } from 'lib/plans';
+} from 'calypso/lib/products-values';
+import Notice from 'calypso/components/notice';
+import Gridicon from 'calypso/components/gridicon';
+import { withLocalizedMoment } from 'calypso/components/localized-moment';
+import TrackComponentView from 'calypso/lib/analytics/track-component-view';
+import { getPlanClass, getPlanTermLabel } from 'calypso/lib/plans';
 
 /**
  * Style dependencies

--- a/client/me/purchases/purchases-list/header/index.jsx
+++ b/client/me/purchases/purchases-list/header/index.jsx
@@ -10,8 +10,8 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import NavItem from 'components/section-nav/item';
-import NavTabs from 'components/section-nav/tabs';
+import NavItem from 'calypso/components/section-nav/item';
+import NavTabs from 'calypso/components/section-nav/tabs';
 import {
 	billingHistory,
 	upcomingCharges,
@@ -19,9 +19,9 @@ import {
 	myMemberships,
 	purchasesRoot,
 } from '../../paths.js';
-import SectionNav from 'components/section-nav';
-import config from 'config';
-import getPastBillingTransactions from 'state/selectors/get-past-billing-transactions';
+import SectionNav from 'calypso/components/section-nav';
+import config from 'calypso/config';
+import getPastBillingTransactions from 'calypso/state/selectors/get-past-billing-transactions';
 
 const PurchasesHeader = ( { section, translate } ) => {
 	let text = translate( 'Billing History' );

--- a/client/me/purchases/purchases-list/index.jsx
+++ b/client/me/purchases/purchases-list/index.jsx
@@ -11,26 +11,26 @@ import { localize } from 'i18n-calypso';
  */
 import { CompactCard } from '@automattic/components';
 import ConciergeBanner from '../concierge-banner';
-import EmptyContent from 'components/empty-content';
-import isBusinessPlanUser from 'state/selectors/is-business-plan-user';
-import Main from 'components/main';
-import MeSidebarNavigation from 'me/sidebar-navigation';
-import PageViewTracker from 'lib/analytics/page-view-tracker';
+import EmptyContent from 'calypso/components/empty-content';
+import isBusinessPlanUser from 'calypso/state/selectors/is-business-plan-user';
+import Main from 'calypso/components/main';
+import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import PurchasesHeader from './header';
 import PurchasesSite from '../purchases-site';
-import QueryUserPurchases from 'components/data/query-user-purchases';
-import { getCurrentUserId } from 'state/current-user/selectors';
-import { getPurchasesBySite } from 'lib/purchases';
-import getSites from 'state/selectors/get-sites';
+import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
+import { getPurchasesBySite } from 'calypso/lib/purchases';
+import getSites from 'calypso/state/selectors/get-sites';
 import {
 	getUserPurchases,
 	hasLoadedUserPurchasesFromServer,
 	isFetchingUserPurchases,
-} from 'state/purchases/selectors';
-import { recordTracksEvent } from 'state/analytics/actions';
-import getConciergeNextAppointment from 'state/selectors/get-concierge-next-appointment';
-import getConciergeScheduleId from 'state/selectors/get-concierge-schedule-id.js';
-import QueryConciergeInitial from 'components/data/query-concierge-initial';
+} from 'calypso/state/purchases/selectors';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import getConciergeNextAppointment from 'calypso/state/selectors/get-concierge-next-appointment';
+import getConciergeScheduleId from 'calypso/state/selectors/get-concierge-schedule-id.js';
+import QueryConciergeInitial from 'calypso/components/data/query-concierge-initial';
 import {
 	CONCIERGE_HAS_UPCOMING_APPOINTMENT,
 	CONCIERGE_HAS_AVAILABLE_INCLUDED_SESSION,
@@ -38,8 +38,8 @@ import {
 	CONCIERGE_SUGGEST_PURCHASE_CONCIERGE,
 	CONCIERGE_WPCOM_BUSINESS_ID,
 	CONCIERGE_WPCOM_SESSION_PRODUCT_ID,
-} from 'me/concierge/constants';
-import NoSitesMessage from 'components/empty-content/no-sites-message';
+} from 'calypso/me/concierge/constants';
+import NoSitesMessage from 'calypso/components/empty-content/no-sites-message';
 
 class PurchasesList extends Component {
 	isDataLoading() {

--- a/client/me/purchases/purchases-site/header.jsx
+++ b/client/me/purchases/purchases-site/header.jsx
@@ -5,16 +5,16 @@
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 
 /**
  * Internal dependencies
  */
 import { CompactCard } from '@automattic/components';
-import { getSite } from 'state/sites/selectors';
-import QuerySites from 'components/data/query-sites';
-import Site from 'blocks/site';
-import SitePlaceholder from 'blocks/site/placeholder';
+import { getSite } from 'calypso/state/sites/selectors';
+import QuerySites from 'calypso/components/data/query-sites';
+import Site from 'calypso/blocks/site';
+import SitePlaceholder from 'calypso/blocks/site/placeholder';
 
 /**
  * Style dependencies

--- a/client/me/purchases/purchases-site/index.jsx
+++ b/client/me/purchases/purchases-site/index.jsx
@@ -11,12 +11,12 @@ import { some, times } from 'lodash';
 /**
  * Internal dependencies
  */
-import AsyncLoad from 'components/async-load';
-import { getSite, isRequestingSite } from 'state/sites/selectors';
-import { isJetpackPlan } from 'lib/products-values';
-import { JETPACK_PLANS } from 'lib/plans/constants';
-import { JETPACK_PRODUCTS_LIST } from 'lib/products-values/constants';
-import QuerySites from 'components/data/query-sites';
+import AsyncLoad from 'calypso/components/async-load';
+import { getSite, isRequestingSite } from 'calypso/state/sites/selectors';
+import { isJetpackPlan } from 'calypso/lib/products-values';
+import { JETPACK_PLANS } from 'calypso/lib/plans/constants';
+import { JETPACK_PRODUCTS_LIST } from 'calypso/lib/products-values/constants';
+import QuerySites from 'calypso/components/data/query-sites';
 import PurchaseItem from '../purchase-item';
 import PurchaseSiteHeader from './header';
 import PurchaseReconnectNotice from './reconnect-notice';
@@ -74,7 +74,7 @@ const PurchasesSite = ( {
 			{ items }
 
 			<AsyncLoad
-				require="blocks/product-plan-overlap-notices"
+				require="calypso/blocks/product-plan-overlap-notices"
 				placeholder={ null }
 				plans={ JETPACK_PLANS }
 				products={ JETPACK_PRODUCTS_LIST }

--- a/client/me/purchases/purchases-site/reconnect-notice.jsx
+++ b/client/me/purchases/purchases-site/reconnect-notice.jsx
@@ -9,9 +9,9 @@ import React, { Component } from 'react';
 /**
  * Internal dependencies
  */
-import Notice from 'components/notice';
-import NoticeAction from 'components/notice/notice-action';
-import { CALYPSO_CONTACT } from 'lib/url/support';
+import Notice from 'calypso/components/notice';
+import NoticeAction from 'calypso/components/notice/notice-action';
+import { CALYPSO_CONTACT } from 'calypso/lib/url/support';
 
 class PurchaseReconnectNotice extends Component {
 	static propTypes = {

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 import page from 'page';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
 
@@ -13,12 +13,12 @@ import classNames from 'classnames';
  * Internal dependencies
  */
 import { Dialog, Button, CompactCard } from '@automattic/components';
-import config from 'config';
-import CancelPurchaseForm from 'components/marketing-survey/cancel-purchase-form';
-import PrecancellationChatButton from 'components/marketing-survey/cancel-purchase-form/precancellation-chat-button';
-import { CANCEL_FLOW_TYPE } from 'components/marketing-survey/cancel-purchase-form/constants';
-import GSuiteCancellationPurchaseDialog from 'components/marketing-survey/gsuite-cancel-purchase-dialog';
-import { getIncludedDomain, getName, hasIncludedDomain, isRemovable } from 'lib/purchases';
+import config from 'calypso/config';
+import CancelPurchaseForm from 'calypso/components/marketing-survey/cancel-purchase-form';
+import PrecancellationChatButton from 'calypso/components/marketing-survey/cancel-purchase-form/precancellation-chat-button';
+import { CANCEL_FLOW_TYPE } from 'calypso/components/marketing-survey/cancel-purchase-form/constants';
+import GSuiteCancellationPurchaseDialog from 'calypso/components/marketing-survey/gsuite-cancel-purchase-dialog';
+import { getIncludedDomain, getName, hasIncludedDomain, isRemovable } from 'calypso/lib/purchases';
 import { isDataLoading } from '../utils';
 import {
 	isDomainMapping,
@@ -28,23 +28,23 @@ import {
 	isJetpackPlan,
 	isJetpackProduct,
 	isPlan,
-} from 'lib/products-values';
-import { isJetpackSearch } from 'lib/products-values/constants';
-import notices from 'notices';
+} from 'calypso/lib/products-values';
+import { isJetpackSearch } from 'calypso/lib/products-values/constants';
+import notices from 'calypso/notices';
 import { purchasesRoot } from '../paths';
-import { getPurchasesError } from 'state/purchases/selectors';
-import { removePurchase } from 'state/purchases/actions';
-import isHappychatAvailable from 'state/happychat/selectors/is-happychat-available';
-import FormSectionHeading from 'components/forms/form-section-heading';
-import isDomainOnly from 'state/selectors/is-domain-only-site';
-import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
-import { receiveDeletedSite } from 'state/sites/actions';
-import { setAllSitesSelected } from 'state/ui/actions';
-import { recordTracksEvent } from 'state/analytics/actions';
-import { getCurrentUserId } from 'state/current-user/selectors';
+import { getPurchasesError } from 'calypso/state/purchases/selectors';
+import { removePurchase } from 'calypso/state/purchases/actions';
+import isHappychatAvailable from 'calypso/state/happychat/selectors/is-happychat-available';
+import FormSectionHeading from 'calypso/components/forms/form-section-heading';
+import isDomainOnly from 'calypso/state/selectors/is-domain-only-site';
+import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
+import { receiveDeletedSite } from 'calypso/state/sites/actions';
+import { setAllSitesSelected } from 'calypso/state/ui/actions';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import RemoveDomainDialog from './remove-domain-dialog';
-import NonPrimaryDomainDialog from 'me/purchases/non-primary-domain-dialog';
-import VerticalNavItem from 'components/vertical-nav/item';
+import NonPrimaryDomainDialog from 'calypso/me/purchases/non-primary-domain-dialog';
+import VerticalNavItem from 'calypso/components/vertical-nav/item';
 
 /**
  * Style dependencies

--- a/client/me/purchases/remove-purchase/remove-domain-dialog/index.jsx
+++ b/client/me/purchases/remove-purchase/remove-domain-dialog/index.jsx
@@ -9,14 +9,14 @@ import React, { Component, Fragment } from 'react';
  * Internal dependencies
  */
 import { Dialog } from '@automattic/components';
-import FormSectionHeading from 'components/forms/form-section-heading';
-import FormFieldset from 'components/forms/form-fieldset';
-import FormLabel from 'components/forms/form-label';
-import FormTextInput from 'components/forms/form-text-input';
-import FormInputValidation from 'components/forms/form-input-validation';
-import FormCheckbox from 'components/forms/form-checkbox';
-import { MOVE_DOMAIN } from 'lib/url/support';
-import { getName } from 'lib/purchases';
+import FormSectionHeading from 'calypso/components/forms/form-section-heading';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormTextInput from 'calypso/components/forms/form-text-input';
+import FormInputValidation from 'calypso/components/forms/form-input-validation';
+import FormCheckbox from 'calypso/components/forms/form-checkbox';
+import { MOVE_DOMAIN } from 'calypso/lib/url/support';
+import { getName } from 'calypso/lib/purchases';
 
 class RemoveDomainDialog extends Component {
 	static propTypes = {

--- a/client/me/purchases/track-purchase-page-view/index.js
+++ b/client/me/purchases/track-purchase-page-view/index.js
@@ -8,8 +8,8 @@ import { connect } from 'react-redux';
 /**
  * Internal Dependencies
  */
-import { getByPurchaseId } from 'state/purchases/selectors';
-import { recordTracksEvent } from 'state/analytics/actions';
+import { getByPurchaseId } from 'calypso/state/purchases/selectors';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 export class TrackPurchasePageView extends Component {
 	static propTypes = {

--- a/client/me/purchases/upcoming-renewals/upcoming-renewals-dialog.tsx
+++ b/client/me/purchases/upcoming-renewals/upcoming-renewals-dialog.tsx
@@ -16,17 +16,23 @@ import { capitalize } from 'lodash';
 /**
  * Internal dependencies
  */
-import { getName, getRenewalPrice, purchaseType, isExpired, isRenewing } from 'lib/purchases';
-import FormLabel from 'components/forms/form-label';
-import FormInputCheckbox from 'components/forms/form-checkbox';
+import {
+	getName,
+	getRenewalPrice,
+	purchaseType,
+	isExpired,
+	isRenewing,
+} from 'calypso/lib/purchases';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
 import { Button, Dialog } from '@automattic/components';
-import { useLocalizedMoment } from 'components/localized-moment';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { managePurchase } from '../paths';
 
 /**
  * Type dependencies
  */
-import type { Purchase } from 'lib/purchases/types';
+import type { Purchase } from 'calypso/lib/purchases/types';
 
 /**
  * Style dependencies

--- a/client/me/purchases/utils.js
+++ b/client/me/purchases/utils.js
@@ -1,15 +1,15 @@
 /**
  * Internal dependencies
  */
-import config from 'config';
+import config from 'calypso/config';
 import { addCardDetails, editCardDetails } from './paths';
 import {
 	isExpired,
 	isIncludedWithPlan,
 	isOneTimePurchase,
 	isPaidWithCreditCard,
-} from 'lib/purchases';
-import { isDomainTransfer } from 'lib/products-values';
+} from 'calypso/lib/purchases';
+import { isDomainTransfer } from 'calypso/lib/products-values';
 
 function isDataLoading( props ) {
 	return ! props.hasLoadedSites || ! props.hasLoadedUserPurchasesFromServer;

--- a/client/me/reauth-required/index.jsx
+++ b/client/me/reauth-required/index.jsx
@@ -15,21 +15,21 @@ const debug = debugFactory( 'calypso:me:reauth-required' );
  * Internal Dependencies
  */
 import { Card, Dialog } from '@automattic/components';
-import FormButton from 'components/forms/form-button';
-import FormCheckbox from 'components/forms/form-checkbox';
-import FormFieldset from 'components/forms/form-fieldset';
-import FormInputValidation from 'components/forms/form-input-validation';
-import FormLabel from 'components/forms/form-label';
-import FormVerificationCodeInput from 'components/forms/form-verification-code-input';
-import { getCurrentUserId } from 'state/current-user/selectors';
-import Notice from 'components/notice';
+import FormButton from 'calypso/components/forms/form-button';
+import FormCheckbox from 'calypso/components/forms/form-checkbox';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormInputValidation from 'calypso/components/forms/form-input-validation';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormVerificationCodeInput from 'calypso/components/forms/form-verification-code-input';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
+import Notice from 'calypso/components/notice';
 /* eslint-disable no-restricted-imports */
-import observe from 'lib/mixins/data-observe';
+import observe from 'calypso/lib/mixins/data-observe';
 /* eslint-enable no-restricted-imports */
-import { recordGoogleEvent } from 'state/analytics/actions';
-import SecurityKeyForm from 'me/reauth-required/security-key-form';
-import TwoFactorActions from 'me/reauth-required/two-factor-actions';
-import userUtilities from 'lib/user/utils';
+import { recordGoogleEvent } from 'calypso/state/analytics/actions';
+import SecurityKeyForm from 'calypso/me/reauth-required/security-key-form';
+import TwoFactorActions from 'calypso/me/reauth-required/two-factor-actions';
+import userUtilities from 'calypso/lib/user/utils';
 
 /**
  * Style dependencies

--- a/client/me/reauth-required/security-key-form.jsx
+++ b/client/me/reauth-required/security-key-form.jsx
@@ -9,10 +9,10 @@ import React, { Component } from 'react';
  * Internal dependencies
  */
 import { Card } from '@automattic/components';
-import FormButton from 'components/forms/form-button';
-import FormInputValidation from 'components/forms/form-input-validation';
+import FormButton from 'calypso/components/forms/form-button';
+import FormInputValidation from 'calypso/components/forms/form-input-validation';
 import { localize } from 'i18n-calypso';
-import Spinner from 'components/spinner';
+import Spinner from 'calypso/components/spinner';
 
 /**
  * Style dependencies

--- a/client/me/reauth-required/two-factor-actions.jsx
+++ b/client/me/reauth-required/two-factor-actions.jsx
@@ -11,7 +11,7 @@ import React, { Component } from 'react';
 
 import { Button, Card } from '@automattic/components';
 import { localize } from 'i18n-calypso';
-import { recordTracksEventWithClientId } from 'state/analytics/actions';
+import { recordTracksEventWithClientId } from 'calypso/state/analytics/actions';
 
 /**
  * Style dependencies

--- a/client/me/security-2fa-backup-codes-list/index.jsx
+++ b/client/me/security-2fa-backup-codes-list/index.jsx
@@ -8,26 +8,26 @@ import React from 'react';
 import ReactDom from 'react-dom';
 import { connect } from 'react-redux';
 import Clipboard from 'clipboard';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 import { saveAs } from 'browser-filesaver';
 import { flowRight as compose } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import FormButton from 'components/forms/form-button';
-import FormButtonBar from 'components/forms/form-buttons-bar';
-import FormCheckbox from 'components/forms/form-checkbox';
-import FormLabel from 'components/forms/form-label';
-import config from 'config';
-import Notice from 'components/notice';
-import ButtonGroup from 'components/button-group';
+import FormButton from 'calypso/components/forms/form-button';
+import FormButtonBar from 'calypso/components/forms/form-buttons-bar';
+import FormCheckbox from 'calypso/components/forms/form-checkbox';
+import FormLabel from 'calypso/components/forms/form-label';
+import config from 'calypso/config';
+import Notice from 'calypso/components/notice';
+import ButtonGroup from 'calypso/components/button-group';
 import { Button } from '@automattic/components';
-import Tooltip from 'components/tooltip';
-import { withLocalizedMoment } from 'components/localized-moment';
-import { getCurrentUserName } from 'state/current-user/selectors';
-import { recordGoogleEvent } from 'state/analytics/actions';
-import { notifyDesktopSendToPrinter } from 'state/desktop/actions';
+import Tooltip from 'calypso/components/tooltip';
+import { withLocalizedMoment } from 'calypso/components/localized-moment';
+import { getCurrentUserName } from 'calypso/state/current-user/selectors';
+import { recordGoogleEvent } from 'calypso/state/analytics/actions';
+import { notifyDesktopSendToPrinter } from 'calypso/state/desktop/actions';
 
 /**
  * Style dependencies

--- a/client/me/security-2fa-backup-codes-prompt/index.jsx
+++ b/client/me/security-2fa-backup-codes-prompt/index.jsx
@@ -11,13 +11,13 @@ const debug = debugFactory( 'calypso:me:security:2fa-backup-codes-prompt' );
 /**
  * Internal dependencies
  */
-import { gaRecordEvent } from 'lib/analytics/ga';
-import FormButton from 'components/forms/form-button';
-import FormFieldset from 'components/forms/form-fieldset';
-import FormLabel from 'components/forms/form-label';
-import FormVerificationCodeInput from 'components/forms/form-verification-code-input';
-import Notice from 'components/notice';
-import twoStepAuthorization from 'lib/two-step-authorization';
+import { gaRecordEvent } from 'calypso/lib/analytics/ga';
+import FormButton from 'calypso/components/forms/form-button';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormVerificationCodeInput from 'calypso/components/forms/form-verification-code-input';
+import Notice from 'calypso/components/notice';
+import twoStepAuthorization from 'calypso/lib/two-step-authorization';
 
 /**
  * Style dependencies

--- a/client/me/security-2fa-backup-codes/index.jsx
+++ b/client/me/security-2fa-backup-codes/index.jsx
@@ -9,12 +9,12 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import { Button, Card } from '@automattic/components';
-import Notice from 'components/notice';
-import SectionHeader from 'components/section-header';
-import Security2faBackupCodesList from 'me/security-2fa-backup-codes-list';
-import Security2faBackupCodesPrompt from 'me/security-2fa-backup-codes-prompt';
-import twoStepAuthorization from 'lib/two-step-authorization';
-import { recordGoogleEvent } from 'state/analytics/actions';
+import Notice from 'calypso/components/notice';
+import SectionHeader from 'calypso/components/section-header';
+import Security2faBackupCodesList from 'calypso/me/security-2fa-backup-codes-list';
+import Security2faBackupCodesPrompt from 'calypso/me/security-2fa-backup-codes-prompt';
+import twoStepAuthorization from 'calypso/lib/two-step-authorization';
+import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 
 /**
  * Style dependencies

--- a/client/me/security-2fa-code-prompt/index.jsx
+++ b/client/me/security-2fa-code-prompt/index.jsx
@@ -11,15 +11,15 @@ const debug = debugFactory( 'calypso:me:security:2fa-code-prompt' );
 /**
  * Internal dependencies
  */
-import { gaRecordEvent } from 'lib/analytics/ga';
-import FormButton from 'components/forms/form-button';
-import FormButtonsBar from 'components/forms/form-buttons-bar';
-import FormFieldset from 'components/forms/form-fieldset';
-import FormLabel from 'components/forms/form-label';
-import FormSettingExplanation from 'components/forms/form-setting-explanation';
-import FormVerificationCodeInput from 'components/forms/form-verification-code-input';
-import Notice from 'components/notice';
-import twoStepAuthorization from 'lib/two-step-authorization';
+import { gaRecordEvent } from 'calypso/lib/analytics/ga';
+import FormButton from 'calypso/components/forms/form-button';
+import FormButtonsBar from 'calypso/components/forms/form-buttons-bar';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
+import FormVerificationCodeInput from 'calypso/components/forms/form-verification-code-input';
+import Notice from 'calypso/components/notice';
+import twoStepAuthorization from 'calypso/lib/two-step-authorization';
 
 /**
  * Style dependencies

--- a/client/me/security-2fa-disable/index.jsx
+++ b/client/me/security-2fa-disable/index.jsx
@@ -10,13 +10,13 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import FormButton from 'components/forms/form-button';
-import FormSectionHeading from 'components/forms/form-section-heading';
-import Security2faStatus from 'me/security-2fa-status';
-import Security2faCodePrompt from 'me/security-2fa-code-prompt';
-import { recordGoogleEvent } from 'state/analytics/actions';
-import { successNotice } from 'state/notices/actions';
-import { localizeUrl } from 'lib/i18n-utils';
+import FormButton from 'calypso/components/forms/form-button';
+import FormSectionHeading from 'calypso/components/forms/form-section-heading';
+import Security2faStatus from 'calypso/me/security-2fa-status';
+import Security2faCodePrompt from 'calypso/me/security-2fa-code-prompt';
+import { recordGoogleEvent } from 'calypso/state/analytics/actions';
+import { successNotice } from 'calypso/state/notices/actions';
+import { localizeUrl } from 'calypso/lib/i18n-utils';
 
 /**
  * Style dependencies

--- a/client/me/security-2fa-enable/index.jsx
+++ b/client/me/security-2fa-enable/index.jsx
@@ -13,15 +13,15 @@ const debug = debugFactory( 'calypso:me:security:2fa-enable' );
 /**
  * Internal dependencies
  */
-import { gaRecordEvent } from 'lib/analytics/ga';
-import FormButton from 'components/forms/form-button';
-import FormButtonsBar from 'components/forms/form-buttons-bar';
-import FormLabel from 'components/forms/form-label';
-import FormSettingExplanation from 'components/forms/form-setting-explanation';
-import FormVerificationCodeInput from 'components/forms/form-verification-code-input';
-import Notice from 'components/notice';
-import Security2faProgress from 'me/security-2fa-progress';
-import twoStepAuthorization from 'lib/two-step-authorization';
+import { gaRecordEvent } from 'calypso/lib/analytics/ga';
+import FormButton from 'calypso/components/forms/form-button';
+import FormButtonsBar from 'calypso/components/forms/form-buttons-bar';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
+import FormVerificationCodeInput from 'calypso/components/forms/form-verification-code-input';
+import Notice from 'calypso/components/notice';
+import Security2faProgress from 'calypso/me/security-2fa-progress';
+import twoStepAuthorization from 'calypso/lib/two-step-authorization';
 
 /**
  * Style dependencies

--- a/client/me/security-2fa-initial-setup/index.jsx
+++ b/client/me/security-2fa-initial-setup/index.jsx
@@ -10,8 +10,8 @@ const debug = debugFactory( 'calypso:me:security:2fa-initial-setup' );
 /**
  * Internal dependencies
  */
-import FormButton from 'components/forms/form-button';
-import { gaRecordEvent } from 'lib/analytics/ga';
+import FormButton from 'calypso/components/forms/form-button';
+import { gaRecordEvent } from 'calypso/lib/analytics/ga';
 
 class Security2faInitialSetup extends React.Component {
 	static displayName = 'Security2faInitialSetup';

--- a/client/me/security-2fa-key/add.jsx
+++ b/client/me/security-2fa-key/add.jsx
@@ -11,8 +11,8 @@ import debugFactory from 'debug';
  * Internal dependencies
  */
 import { Card } from '@automattic/components';
-import { errorNotice, warningNotice, successNotice } from 'state/notices/actions';
-import { registerSecurityKey } from 'lib/webauthn';
+import { errorNotice, warningNotice, successNotice } from 'calypso/state/notices/actions';
+import { registerSecurityKey } from 'calypso/lib/webauthn';
 import Security2faKeyAddName from './name';
 import WaitForKey from './wait-for-key';
 

--- a/client/me/security-2fa-key/delete-item-button.jsx
+++ b/client/me/security-2fa-key/delete-item-button.jsx
@@ -12,7 +12,7 @@ import PropTypes from 'prop-types';
 import { Button, Dialog } from '@automattic/components';
 import { successNotice } from '../../state/notices/actions';
 import { recordGoogleEvent } from '../../state/analytics/actions';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 
 class Security2faKeyDeleteButton extends Component {
 	static propTypes = {

--- a/client/me/security-2fa-key/index.jsx
+++ b/client/me/security-2fa-key/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 import React from 'react';
 import { connect } from 'react-redux';
 import { get } from 'lodash';
@@ -11,13 +11,13 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import { Button, Card } from '@automattic/components';
-import SectionHeader from 'components/section-header';
+import SectionHeader from 'calypso/components/section-header';
 import Security2faKeyAdd from './add';
 import Security2faKeyList from './list';
-import { recordGoogleEvent } from 'state/analytics/actions';
-import { isWebAuthnSupported } from 'lib/webauthn';
-import wpcom from 'lib/wp';
-import Notice from 'components/notice';
+import { recordGoogleEvent } from 'calypso/state/analytics/actions';
+import { isWebAuthnSupported } from 'calypso/lib/webauthn';
+import wpcom from 'calypso/lib/wp';
+import Notice from 'calypso/components/notice';
 
 class Security2faKey extends React.Component {
 	state = {

--- a/client/me/security-2fa-key/name.jsx
+++ b/client/me/security-2fa-key/name.jsx
@@ -9,10 +9,10 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import { Button } from '@automattic/components';
-import FormButton from 'components/forms/form-button';
-import FormFieldset from 'components/forms/form-fieldset';
-import FormLabel from 'components/forms/form-label';
-import FormTextInput from 'components/forms/form-text-input';
+import FormButton from 'calypso/components/forms/form-button';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormTextInput from 'calypso/components/forms/form-text-input';
 
 class Security2faKeyAddName extends React.Component {
 	static propTypes = {

--- a/client/me/security-2fa-key/wait-for-key.jsx
+++ b/client/me/security-2fa-key/wait-for-key.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import Spinner from 'components/spinner';
+import Spinner from 'calypso/components/spinner';
 import { useTranslate } from 'i18n-calypso';
 
 export default function WaitForKey() {

--- a/client/me/security-2fa-progress/progress-item.jsx
+++ b/client/me/security-2fa-progress/progress-item.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 import debugFactory from 'debug';
 const debug = debugFactory( 'calypso:me:security:2fa-progress' );
 import classNames from 'classnames';
-import Gridicon from 'components/gridicon';
+import Gridicon from 'calypso/components/gridicon';
 
 export default class extends React.Component {
 	static displayName = 'Security2faProgressItem';

--- a/client/me/security-2fa-setup-backup-codes/index.jsx
+++ b/client/me/security-2fa-setup-backup-codes/index.jsx
@@ -9,12 +9,12 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import Notice from 'components/notice';
-import Security2faBackupCodesList from 'me/security-2fa-backup-codes-list';
-import Security2faProgress from 'me/security-2fa-progress';
-import { CALYPSO_CONTACT } from 'lib/url/support';
-import twoStepAuthorization from 'lib/two-step-authorization';
-import { recordGoogleEvent } from 'state/analytics/actions';
+import Notice from 'calypso/components/notice';
+import Security2faBackupCodesList from 'calypso/me/security-2fa-backup-codes-list';
+import Security2faProgress from 'calypso/me/security-2fa-progress';
+import { CALYPSO_CONTACT } from 'calypso/lib/url/support';
+import twoStepAuthorization from 'calypso/lib/two-step-authorization';
+import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 
 class Security2faSetupBackupCodes extends React.Component {
 	state = {

--- a/client/me/security-2fa-setup/index.jsx
+++ b/client/me/security-2fa-setup/index.jsx
@@ -10,11 +10,11 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import Security2faEnable from 'me/security-2fa-enable';
-import Security2faSetupBackupCodes from 'me/security-2fa-setup-backup-codes';
-import Security2faSMSSettings from 'me/security-2fa-sms-settings';
-import Security2faInitialSetup from 'me/security-2fa-initial-setup';
-import { successNotice } from 'state/notices/actions';
+import Security2faEnable from 'calypso/me/security-2fa-enable';
+import Security2faSetupBackupCodes from 'calypso/me/security-2fa-setup-backup-codes';
+import Security2faSMSSettings from 'calypso/me/security-2fa-sms-settings';
+import Security2faInitialSetup from 'calypso/me/security-2fa-initial-setup';
+import { successNotice } from 'calypso/state/notices/actions';
 
 class Security2faSetup extends Component {
 	static propTypes = {

--- a/client/me/security-2fa-sms-settings/index.jsx
+++ b/client/me/security-2fa-sms-settings/index.jsx
@@ -12,17 +12,17 @@ import { flowRight } from 'lodash';
 /**
  * Internal dependencies
  */
-import FormPhoneInput from 'components/forms/form-phone-input';
-import FormButton from 'components/forms/form-button';
-import FormButtonsBar from 'components/forms/form-buttons-bar';
-import Notice from 'components/notice';
-import formBase from 'me/form-base';
-import Security2faProgress from 'me/security-2fa-progress';
-import { gaRecordEvent } from 'lib/analytics/ga';
-import observe from 'lib/mixins/data-observe';
-import { protectForm } from 'lib/protect-form';
-import getCountries from 'state/selectors/get-countries';
-import QuerySmsCountries from 'components/data/query-countries/sms';
+import FormPhoneInput from 'calypso/components/forms/form-phone-input';
+import FormButton from 'calypso/components/forms/form-button';
+import FormButtonsBar from 'calypso/components/forms/form-buttons-bar';
+import Notice from 'calypso/components/notice';
+import formBase from 'calypso/me/form-base';
+import Security2faProgress from 'calypso/me/security-2fa-progress';
+import { gaRecordEvent } from 'calypso/lib/analytics/ga';
+import observe from 'calypso/lib/mixins/data-observe';
+import { protectForm } from 'calypso/lib/protect-form';
+import getCountries from 'calypso/state/selectors/get-countries';
+import QuerySmsCountries from 'calypso/components/data/query-countries/sms';
 
 /**
  * Style dependencies

--- a/client/me/security-account-recovery/buttons.jsx
+++ b/client/me/security-account-recovery/buttons.jsx
@@ -9,9 +9,9 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import FormButtonsBar from 'components/forms/form-buttons-bar';
-import FormButton from 'components/forms/form-button';
-import Gridicon from 'components/gridicon';
+import FormButtonsBar from 'calypso/components/forms/form-buttons-bar';
+import FormButton from 'calypso/components/forms/form-button';
+import Gridicon from 'calypso/components/gridicon';
 
 class SecurityAccountRecoveryManageContactButtons extends React.Component {
 	static displayName = 'SecurityAccountRecoveryManageContactButtons';

--- a/client/me/security-account-recovery/edit-email.jsx
+++ b/client/me/security-account-recovery/edit-email.jsx
@@ -11,10 +11,10 @@ import emailValidator from 'email-validator';
 /**
  * Internal dependencies
  */
-import FormFieldset from 'components/forms/form-fieldset';
-import FormTextInput from 'components/forms/form-text-input';
-import FormInputValidation from 'components/forms/form-input-validation';
-import FormSettingExplanation from 'components/forms/form-setting-explanation';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormTextInput from 'calypso/components/forms/form-text-input';
+import FormInputValidation from 'calypso/components/forms/form-input-validation';
+import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import Buttons from './buttons';
 
 class SecurityAccountRecoveryRecoveryEmailEdit extends React.Component {

--- a/client/me/security-account-recovery/edit-phone.jsx
+++ b/client/me/security-account-recovery/edit-phone.jsx
@@ -10,12 +10,12 @@ import { isEmpty } from 'lodash';
 /**
  * Internal dependencies
  */
-import FormFieldset from 'components/forms/form-fieldset';
-import FormPhoneInput from 'components/forms/form-phone-input';
-import FormInputValidation from 'components/forms/form-input-validation';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormPhoneInput from 'calypso/components/forms/form-phone-input';
+import FormInputValidation from 'calypso/components/forms/form-input-validation';
 import Buttons from './buttons';
-import getCountries from 'state/selectors/get-countries';
-import QuerySmsCountries from 'components/data/query-countries/sms';
+import getCountries from 'calypso/state/selectors/get-countries';
+import QuerySmsCountries from 'calypso/components/data/query-countries/sms';
 
 class SecurityAccountRecoveryRecoveryPhoneEdit extends React.Component {
 	static displayName = 'SecurityAccountRecoveryRecoveryPhoneEdit';

--- a/client/me/security-account-recovery/index.jsx
+++ b/client/me/security-account-recovery/index.jsx
@@ -10,19 +10,19 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import { CompactCard } from '@automattic/components';
-import config from 'config';
-import DocumentHead from 'components/data/document-head';
-import HeaderCake from 'components/header-cake';
-import Main from 'components/main';
-import MeSidebarNavigation from 'me/sidebar-navigation';
-import QueryAccountRecoverySettings from 'components/data/query-account-recovery-settings';
-import ReauthRequired from 'me/reauth-required';
+import config from 'calypso/config';
+import DocumentHead from 'calypso/components/data/document-head';
+import HeaderCake from 'calypso/components/header-cake';
+import Main from 'calypso/components/main';
+import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
+import QueryAccountRecoverySettings from 'calypso/components/data/query-account-recovery-settings';
+import ReauthRequired from 'calypso/me/reauth-required';
 import RecoveryEmail from './recovery-email';
 import RecoveryEmailValidationNotice from './recovery-email-validation-notice';
 import RecoveryPhone from './recovery-phone';
 import RecoveryPhoneValidationNotice from './recovery-phone-validation-notice';
-import SecuritySectionNav from 'me/security-section-nav';
-import twoStepAuthorization from 'lib/two-step-authorization';
+import SecuritySectionNav from 'calypso/me/security-section-nav';
+import twoStepAuthorization from 'calypso/lib/two-step-authorization';
 import {
 	updateAccountRecoveryEmail,
 	updateAccountRecoveryPhone,
@@ -31,7 +31,7 @@ import {
 	resendAccountRecoveryEmailValidation,
 	resendAccountRecoveryPhoneValidation,
 	validateAccountRecoveryPhone,
-} from 'state/account-recovery/settings/actions';
+} from 'calypso/state/account-recovery/settings/actions';
 import {
 	getAccountRecoveryEmail,
 	getAccountRecoveryPhone,
@@ -44,9 +44,9 @@ import {
 	hasSentAccountRecoveryPhoneValidation,
 	shouldPromptAccountRecoveryEmailValidationNotice,
 	shouldPromptAccountRecoveryPhoneValidationNotice,
-} from 'state/account-recovery/settings/selectors';
-import { getCurrentUserEmail } from 'state/current-user/selectors';
-import PageViewTracker from 'lib/analytics/page-view-tracker';
+} from 'calypso/state/account-recovery/settings/selectors';
+import { getCurrentUserEmail } from 'calypso/state/current-user/selectors';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 
 /**
  * Style dependencies

--- a/client/me/security-account-recovery/manage-contact.jsx
+++ b/client/me/security-account-recovery/manage-contact.jsx
@@ -8,8 +8,8 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import FormButton from 'components/forms/form-button';
-import { recordTracksEvent } from 'lib/analytics/tracks';
+import FormButton from 'calypso/components/forms/form-button';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 
 const views = {
 	VIEWING: 'VIEWING',

--- a/client/me/security-account-recovery/recovery-email-validation-notice.jsx
+++ b/client/me/security-account-recovery/recovery-email-validation-notice.jsx
@@ -8,8 +8,8 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import Notice from 'components/notice';
-import NoticeAction from 'components/notice/notice-action';
+import Notice from 'calypso/components/notice';
+import NoticeAction from 'calypso/components/notice/notice-action';
 
 class RecoveryEmailValidationNotice extends Component {
 	render() {

--- a/client/me/security-account-recovery/recovery-email.jsx
+++ b/client/me/security-account-recovery/recovery-email.jsx
@@ -10,7 +10,7 @@ import { localize } from 'i18n-calypso';
  */
 import ManageContact from './manage-contact';
 import EditEmail from './edit-email';
-import accept from 'lib/accept';
+import accept from 'calypso/lib/accept';
 
 class RecoveryEmail extends Component {
 	render() {

--- a/client/me/security-account-recovery/recovery-phone-validation-notice.jsx
+++ b/client/me/security-account-recovery/recovery-phone-validation-notice.jsx
@@ -7,12 +7,12 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import FormButton from 'components/forms/form-button';
-import FormButtonsBar from 'components/forms/form-buttons-bar';
-import FormLabel from 'components/forms/form-label';
-import FormVerificationCodeInput from 'components/forms/form-verification-code-input';
-import Notice from 'components/notice';
-import NoticeAction from 'components/notice/notice-action';
+import FormButton from 'calypso/components/forms/form-button';
+import FormButtonsBar from 'calypso/components/forms/form-buttons-bar';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormVerificationCodeInput from 'calypso/components/forms/form-verification-code-input';
+import Notice from 'calypso/components/notice';
+import NoticeAction from 'calypso/components/notice/notice-action';
 
 class RecoveryPhoneValidationNotice extends Component {
 	constructor() {

--- a/client/me/security-account-recovery/recovery-phone.jsx
+++ b/client/me/security-account-recovery/recovery-phone.jsx
@@ -10,7 +10,7 @@ import { localize } from 'i18n-calypso';
  */
 import ManageContact from './manage-contact';
 import EditPhone from './edit-phone';
-import accept from 'lib/accept';
+import accept from 'calypso/lib/accept';
 
 class RecoveryPhone extends Component {
 	render() {

--- a/client/me/security-checkup/account-email.jsx
+++ b/client/me/security-checkup/account-email.jsx
@@ -9,7 +9,10 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { getCurrentUserEmail, isCurrentUserEmailVerified } from 'state/current-user/selectors';
+import {
+	getCurrentUserEmail,
+	isCurrentUserEmailVerified,
+} from 'calypso/state/current-user/selectors';
 import { getOKIcon, getWarningIcon } from './icons.js';
 import SecurityCheckupNavigationItem from './navigation-item';
 

--- a/client/me/security-checkup/account-recovery-email.jsx
+++ b/client/me/security-checkup/account-recovery-email.jsx
@@ -13,9 +13,9 @@ import {
 	getAccountRecoveryEmail,
 	isAccountRecoveryEmailActionInProgress,
 	isAccountRecoveryEmailValidated,
-} from 'state/account-recovery/settings/selectors';
+} from 'calypso/state/account-recovery/settings/selectors';
 import { getOKIcon, getWarningIcon } from './icons.js';
-import QueryAccountRecoverySettings from 'components/data/query-account-recovery-settings';
+import QueryAccountRecoverySettings from 'calypso/components/data/query-account-recovery-settings';
 import SecurityCheckupNavigationItem from './navigation-item';
 
 class SecurityCheckupAccountRecoveryEmail extends React.Component {

--- a/client/me/security-checkup/account-recovery-phone.jsx
+++ b/client/me/security-checkup/account-recovery-phone.jsx
@@ -13,9 +13,9 @@ import {
 	getAccountRecoveryPhone,
 	isAccountRecoveryPhoneActionInProgress,
 	isAccountRecoveryPhoneValidated,
-} from 'state/account-recovery/settings/selectors';
+} from 'calypso/state/account-recovery/settings/selectors';
 import { getOKIcon, getWarningIcon } from './icons.js';
-import QueryAccountRecoverySettings from 'components/data/query-account-recovery-settings';
+import QueryAccountRecoverySettings from 'calypso/components/data/query-account-recovery-settings';
 import SecurityCheckupNavigationItem from './navigation-item';
 
 class SecurityCheckupAccountRecoveryPhone extends React.Component {

--- a/client/me/security-checkup/connected-applications.jsx
+++ b/client/me/security-checkup/connected-applications.jsx
@@ -9,8 +9,8 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import getConnectedApplications from 'state/selectors/get-connected-applications';
-import QueryConnectedApplications from 'components/data/query-connected-applications';
+import getConnectedApplications from 'calypso/state/selectors/get-connected-applications';
+import QueryConnectedApplications from 'calypso/components/data/query-connected-applications';
 import SecurityCheckupNavigationItem from './navigation-item';
 
 class SecurityCheckupConnectedApplications extends React.Component {

--- a/client/me/security-checkup/index.jsx
+++ b/client/me/security-checkup/index.jsx
@@ -8,13 +8,13 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import DocumentHead from 'components/data/document-head';
-import FormattedHeader from 'components/formatted-header';
-import Main from 'components/main';
-import MeSidebarNavigation from 'me/sidebar-navigation';
-import PageViewTracker from 'lib/analytics/page-view-tracker';
-import ReauthRequired from 'me/reauth-required';
-import SectionHeader from 'components/section-header';
+import DocumentHead from 'calypso/components/data/document-head';
+import FormattedHeader from 'calypso/components/formatted-header';
+import Main from 'calypso/components/main';
+import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import ReauthRequired from 'calypso/me/reauth-required';
+import SectionHeader from 'calypso/components/section-header';
 import SecurityCheckupAccountEmail from './account-email';
 import SecurityCheckupAccountRecoveryEmail from './account-recovery-email';
 import SecurityCheckupAccountRecoveryPhone from './account-recovery-phone';
@@ -23,8 +23,8 @@ import SecurityCheckupPassword from './password';
 import SecurityCheckupSocialLogins from './social-logins';
 import SecurityCheckupTwoFactorAuthentication from './two-factor-authentication';
 import SecurityCheckupTwoFactorBackupCodes from './two-factor-backup-codes';
-import twoStepAuthorization from 'lib/two-step-authorization';
-import VerticalNav from 'components/vertical-nav';
+import twoStepAuthorization from 'calypso/lib/two-step-authorization';
+import VerticalNav from 'calypso/components/vertical-nav';
 
 /**
  * Style dependencies

--- a/client/me/security-checkup/navigation-item.jsx
+++ b/client/me/security-checkup/navigation-item.jsx
@@ -7,8 +7,8 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import MaterialIcon from 'components/material-icon';
-import VerticalNavItem from 'components/vertical-nav/item';
+import MaterialIcon from 'calypso/components/material-icon';
+import VerticalNavItem from 'calypso/components/vertical-nav/item';
 
 const SecurityCheckupNavigationItemContents = function ( props ) {
 	const { materialIcon, materialIconStyle, text, description } = props;

--- a/client/me/security-checkup/social-logins.jsx
+++ b/client/me/security-checkup/social-logins.jsx
@@ -9,7 +9,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { getCurrentUser } from 'state/current-user/selectors';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import SecurityCheckupNavigationItem from './navigation-item';
 
 class SecurityCheckupSocialLogins extends React.Component {

--- a/client/me/security-checkup/two-factor-authentication.jsx
+++ b/client/me/security-checkup/two-factor-authentication.jsx
@@ -10,11 +10,11 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import { getOKIcon, getWarningIcon } from './icons.js';
-import getUserSetting from 'state/selectors/get-user-setting';
-import hasUserSettings from 'state/selectors/has-user-settings';
-import isTwoStepEnabled from 'state/selectors/is-two-step-enabled';
-import isTwoStepSmsEnabled from 'state/selectors/is-two-step-sms-enabled';
-import QueryUserSettings from 'components/data/query-user-settings';
+import getUserSetting from 'calypso/state/selectors/get-user-setting';
+import hasUserSettings from 'calypso/state/selectors/has-user-settings';
+import isTwoStepEnabled from 'calypso/state/selectors/is-two-step-enabled';
+import isTwoStepSmsEnabled from 'calypso/state/selectors/is-two-step-sms-enabled';
+import QueryUserSettings from 'calypso/components/data/query-user-settings';
 import SecurityCheckupNavigationItem from './navigation-item';
 
 class SecurityCheckupTwoFactorAuthentication extends React.Component {

--- a/client/me/security-checkup/two-factor-backup-codes.jsx
+++ b/client/me/security-checkup/two-factor-backup-codes.jsx
@@ -10,10 +10,10 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import { getOKIcon, getWarningIcon } from './icons.js';
-import getUserSetting from 'state/selectors/get-user-setting';
-import hasUserSettings from 'state/selectors/has-user-settings';
-import isTwoStepEnabled from 'state/selectors/is-two-step-enabled';
-import QueryUserSettings from 'components/data/query-user-settings';
+import getUserSetting from 'calypso/state/selectors/get-user-setting';
+import hasUserSettings from 'calypso/state/selectors/has-user-settings';
+import isTwoStepEnabled from 'calypso/state/selectors/is-two-step-enabled';
+import QueryUserSettings from 'calypso/components/data/query-user-settings';
 import SecurityCheckupNavigationItem from './navigation-item';
 
 class SecurityCheckupTwoFactorBackupCodes extends React.Component {

--- a/client/me/security-section-nav/index.jsx
+++ b/client/me/security-section-nav/index.jsx
@@ -10,10 +10,10 @@ import i18n from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import config from 'config';
-import NavItem from 'components/section-nav/item';
-import NavTabs from 'components/section-nav/tabs';
-import SectionNav from 'components/section-nav';
+import config from 'calypso/config';
+import NavItem from 'calypso/components/section-nav/item';
+import NavTabs from 'calypso/components/section-nav/tabs';
+import SectionNav from 'calypso/components/section-nav';
 
 export default class extends React.Component {
 	static displayName = 'SecuritySectionNav';

--- a/client/me/security/controller.js
+++ b/client/me/security/controller.js
@@ -8,15 +8,15 @@ import i18n from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import notices from 'notices';
-import userSettings from 'lib/user-settings';
-import PasswordComponent from 'me/security/main';
-import accountPasswordData from 'lib/account-password-data';
-import SocialLoginComponent from 'me/social-login';
-import ConnectedAppsComponent from 'me/connected-applications';
-import AccountRecoveryComponent from 'me/security-account-recovery';
-import SecurityCheckupComponent from 'me/security-checkup';
-import { getSocialServiceFromClientId } from 'lib/login';
+import notices from 'calypso/notices';
+import userSettings from 'calypso/lib/user-settings';
+import PasswordComponent from 'calypso/me/security/main';
+import accountPasswordData from 'calypso/lib/account-password-data';
+import SocialLoginComponent from 'calypso/me/social-login';
+import ConnectedAppsComponent from 'calypso/me/connected-applications';
+import AccountRecoveryComponent from 'calypso/me/security-account-recovery';
+import SecurityCheckupComponent from 'calypso/me/security-checkup';
+import { getSocialServiceFromClientId } from 'calypso/lib/login';
 
 export function password( context, next ) {
 	if ( context.query && context.query.updated === 'password' ) {
@@ -36,7 +36,7 @@ export function password( context, next ) {
 }
 
 export function twoStep( context, next ) {
-	const TwoStepComponent = require( 'me/two-step' ).default;
+	const TwoStepComponent = require( 'calypso/me/two-step' ).default;
 
 	context.primary = React.createElement( TwoStepComponent, {
 		userSettings: userSettings,

--- a/client/me/security/index.js
+++ b/client/me/security/index.js
@@ -6,9 +6,9 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import config from 'config';
-import { makeLayout, render as clientRender } from 'controller';
-import { sidebar } from 'me/controller';
+import config from 'calypso/config';
+import { makeLayout, render as clientRender } from 'calypso/controller';
+import { sidebar } from 'calypso/me/controller';
 import {
 	accountRecovery,
 	connectedApplications,

--- a/client/me/security/main.jsx
+++ b/client/me/security/main.jsx
@@ -10,17 +10,17 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import AccountPassword from 'me/account-password';
+import AccountPassword from 'calypso/me/account-password';
 import { Card } from '@automattic/components';
-import config from 'config';
-import DocumentHead from 'components/data/document-head';
-import HeaderCake from 'components/header-cake';
-import Main from 'components/main';
-import MeSidebarNavigation from 'me/sidebar-navigation';
-import ReauthRequired from 'me/reauth-required';
-import SecuritySectionNav from 'me/security-section-nav';
-import twoStepAuthorization from 'lib/two-step-authorization';
-import PageViewTracker from 'lib/analytics/page-view-tracker';
+import config from 'calypso/config';
+import DocumentHead from 'calypso/components/data/document-head';
+import HeaderCake from 'calypso/components/header-cake';
+import Main from 'calypso/components/main';
+import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
+import ReauthRequired from 'calypso/me/reauth-required';
+import SecuritySectionNav from 'calypso/me/security-section-nav';
+import twoStepAuthorization from 'calypso/lib/two-step-authorization';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 
 const debug = debugFactory( 'calypso:me:security:password' );
 

--- a/client/me/sidebar-navigation/index.jsx
+++ b/client/me/sidebar-navigation/index.jsx
@@ -8,9 +8,9 @@ import { useTranslate } from 'i18n-calypso';
 /**
  * Internal Dependencies
  */
-import SidebarNavigation from 'components/sidebar-navigation';
-import Gravatar from 'components/gravatar';
-import { getCurrentUser } from 'state/current-user/selectors';
+import SidebarNavigation from 'calypso/components/sidebar-navigation';
+import Gravatar from 'calypso/components/gravatar';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
 
 /**
  * Style dependencies

--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -10,8 +10,8 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import { Button } from '@automattic/components';
-import config from 'config';
-import ProfileGravatar from 'me/profile-gravatar';
+import config from 'calypso/config';
+import ProfileGravatar from 'calypso/me/profile-gravatar';
 import {
 	addCreditCard,
 	billingHistory,
@@ -19,19 +19,19 @@ import {
 	pendingPayments,
 	myMemberships,
 	purchasesRoot,
-} from 'me/purchases/paths';
-import Sidebar from 'layout/sidebar';
-import SidebarFooter from 'layout/sidebar/footer';
-import SidebarHeading from 'layout/sidebar/heading';
-import SidebarItem from 'layout/sidebar/item';
-import SidebarMenu from 'layout/sidebar/menu';
-import SidebarRegion from 'layout/sidebar/region';
-import user from 'lib/user';
-import userUtilities from 'lib/user/utils';
-import { getCurrentUser } from 'state/current-user/selectors';
-import { logoutUser } from 'state/logout/actions';
-import { recordGoogleEvent } from 'state/analytics/actions';
-import { setNextLayoutFocus } from 'state/ui/layout-focus/actions';
+} from 'calypso/me/purchases/paths';
+import Sidebar from 'calypso/layout/sidebar';
+import SidebarFooter from 'calypso/layout/sidebar/footer';
+import SidebarHeading from 'calypso/layout/sidebar/heading';
+import SidebarItem from 'calypso/layout/sidebar/item';
+import SidebarMenu from 'calypso/layout/sidebar/menu';
+import SidebarRegion from 'calypso/layout/sidebar/region';
+import user from 'calypso/lib/user';
+import userUtilities from 'calypso/lib/user/utils';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import { logoutUser } from 'calypso/state/logout/actions';
+import { recordGoogleEvent } from 'calypso/state/analytics/actions';
+import { setNextLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
 
 /**
  * Style dependencies

--- a/client/me/site-blocks/controller.js
+++ b/client/me/site-blocks/controller.js
@@ -6,7 +6,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import SiteBlockListComponent from 'me/site-blocks/main';
+import SiteBlockListComponent from 'calypso/me/site-blocks/main';
 
 export function siteBlockList( context, next ) {
 	context.primary = React.createElement( SiteBlockListComponent );

--- a/client/me/site-blocks/index.js
+++ b/client/me/site-blocks/index.js
@@ -7,8 +7,8 @@ import page from 'page';
  * Internal dependencies
  */
 import { siteBlockList } from './controller';
-import { makeLayout, render as clientRender } from 'controller';
-import { sidebar } from 'me/controller';
+import { makeLayout, render as clientRender } from 'calypso/controller';
+import { sidebar } from 'calypso/me/controller';
 
 export default function () {
 	page( '/me/site-blocks', sidebar, siteBlockList, makeLayout, clientRender );

--- a/client/me/site-blocks/list-item.jsx
+++ b/client/me/site-blocks/list-item.jsx
@@ -8,11 +8,11 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import { getSite } from 'state/reader/sites/selectors';
-import ExternalLink from 'components/external-link';
+import { getSite } from 'calypso/state/reader/sites/selectors';
+import ExternalLink from 'calypso/components/external-link';
 import { Button } from '@automattic/components';
-import { unblockSite } from 'state/reader/site-blocks/actions';
-import { recordTracksEvent } from 'state/analytics/actions';
+import { unblockSite } from 'calypso/state/reader/site-blocks/actions';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 class SiteBlockListItem extends Component {
 	unblockSite = () => {

--- a/client/me/site-blocks/main.jsx
+++ b/client/me/site-blocks/main.jsx
@@ -10,23 +10,23 @@ import { times } from 'lodash';
  * Internal dependencies
  */
 import { Card } from '@automattic/components';
-import DocumentHead from 'components/data/document-head';
-import Main from 'components/main';
-import SectionHeader from 'components/section-header';
-import MeSidebarNavigation from 'me/sidebar-navigation';
-import PageViewTracker from 'lib/analytics/page-view-tracker';
-import QuerySiteBlocks from 'components/data/query-site-blocks';
+import DocumentHead from 'calypso/components/data/document-head';
+import Main from 'calypso/components/main';
+import SectionHeader from 'calypso/components/section-header';
+import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import QuerySiteBlocks from 'calypso/components/data/query-site-blocks';
 import {
 	getBlockedSites,
 	isFetchingSiteBlocks,
 	getSiteBlocksCurrentPage,
 	getSiteBlocksLastPage,
-} from 'state/reader/site-blocks/selectors';
+} from 'calypso/state/reader/site-blocks/selectors';
 import SiteBlockListItem from './list-item';
-import InfiniteList from 'components/infinite-list';
-import { requestSiteBlocks } from 'state/reader/site-blocks/actions';
+import InfiniteList from 'calypso/components/infinite-list';
+import { requestSiteBlocks } from 'calypso/state/reader/site-blocks/actions';
 import SiteBlockListItemPlaceholder from './list-item-placeholder';
-import { localizeUrl } from 'lib/i18n-utils';
+import { localizeUrl } from 'calypso/lib/i18n-utils';
 
 /**
  * Style dependencies

--- a/client/me/social-login/action-button.jsx
+++ b/client/me/social-login/action-button.jsx
@@ -9,13 +9,13 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import config from 'config';
-import { isRequesting } from 'state/login/selectors';
-import { connectSocialUser, disconnectSocialUser } from 'state/login/actions';
-import FormButton from 'components/forms/form-button';
-import GoogleLoginButton from 'components/social-buttons/google';
-import AppleLoginButton from 'components/social-buttons/apple';
-import user from 'lib/user';
+import config from 'calypso/config';
+import { isRequesting } from 'calypso/state/login/selectors';
+import { connectSocialUser, disconnectSocialUser } from 'calypso/state/login/actions';
+import FormButton from 'calypso/components/forms/form-button';
+import GoogleLoginButton from 'calypso/components/social-buttons/google';
+import AppleLoginButton from 'calypso/components/social-buttons/apple';
+import user from 'calypso/lib/user';
 
 class SocialLoginActionButton extends Component {
 	static propTypes = {

--- a/client/me/social-login/index.jsx
+++ b/client/me/social-login/index.jsx
@@ -9,20 +9,20 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import AppleIcon from 'components/social-icons/apple';
+import AppleIcon from 'calypso/components/social-icons/apple';
 import { CompactCard } from '@automattic/components';
-import config from 'config';
-import DocumentHead from 'components/data/document-head';
-import { getRequestError } from 'state/login/selectors';
-import GoogleIcon from 'components/social-icons/google';
-import HeaderCake from 'components/header-cake';
-import Main from 'components/main';
-import MeSidebarNavigation from 'me/sidebar-navigation';
-import Notice from 'components/notice';
-import PageViewTracker from 'lib/analytics/page-view-tracker';
-import ReauthRequired from 'me/reauth-required';
-import SecuritySectionNav from 'me/security-section-nav';
-import twoStepAuthorization from 'lib/two-step-authorization';
+import config from 'calypso/config';
+import DocumentHead from 'calypso/components/data/document-head';
+import { getRequestError } from 'calypso/state/login/selectors';
+import GoogleIcon from 'calypso/components/social-icons/google';
+import HeaderCake from 'calypso/components/header-cake';
+import Main from 'calypso/components/main';
+import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
+import Notice from 'calypso/components/notice';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import ReauthRequired from 'calypso/me/reauth-required';
+import SecuritySectionNav from 'calypso/me/security-section-nav';
+import twoStepAuthorization from 'calypso/lib/two-step-authorization';
 import SocialLoginService from './service';
 
 /**

--- a/client/me/social-login/service.jsx
+++ b/client/me/social-login/service.jsx
@@ -9,7 +9,7 @@ import { find, get } from 'lodash';
  * Internal dependencies
  */
 import { CompactCard } from '@automattic/components';
-import { getCurrentUser } from 'state/current-user/selectors';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import SocialLoginActionButton from './action-button';
 
 const SocialLoginService = ( {

--- a/client/me/two-step/index.jsx
+++ b/client/me/two-step/index.jsx
@@ -10,21 +10,21 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import AppPasswords from 'me/application-passwords';
+import AppPasswords from 'calypso/me/application-passwords';
 import { Card } from '@automattic/components';
-import config from 'config';
-import DocumentHead from 'components/data/document-head';
-import HeaderCake from 'components/header-cake';
-import Main from 'components/main';
-import MeSidebarNavigation from 'me/sidebar-navigation';
-import ReauthRequired from 'me/reauth-required';
-import Security2faBackupCodes from 'me/security-2fa-backup-codes';
-import Security2faDisable from 'me/security-2fa-disable';
-import Security2faSetup from 'me/security-2fa-setup';
-import SecuritySectionNav from 'me/security-section-nav';
-import Security2faKey from 'me/security-2fa-key';
-import twoStepAuthorization from 'lib/two-step-authorization';
-import PageViewTracker from 'lib/analytics/page-view-tracker';
+import config from 'calypso/config';
+import DocumentHead from 'calypso/components/data/document-head';
+import HeaderCake from 'calypso/components/header-cake';
+import Main from 'calypso/components/main';
+import MeSidebarNavigation from 'calypso/me/sidebar-navigation';
+import ReauthRequired from 'calypso/me/reauth-required';
+import Security2faBackupCodes from 'calypso/me/security-2fa-backup-codes';
+import Security2faDisable from 'calypso/me/security-2fa-disable';
+import Security2faSetup from 'calypso/me/security-2fa-setup';
+import SecuritySectionNav from 'calypso/me/security-section-nav';
+import Security2faKey from 'calypso/me/security-2fa-key';
+import twoStepAuthorization from 'calypso/lib/two-step-authorization';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 
 /**
  * Style dependencies


### PR DESCRIPTION
### Background

See #44602
 
### Changes

* Enable rule `wpcalypso/no-package-relative-imports` in `./eslintrc.js`
* Allow imports from parent `node_modules`. This is not ideal, but afaik is the only way to tell eslint that importing from `calypso/...` is fine.
* Apply auto-fix for the rule `wpcalypso/no-package-relative-imports` in `./client/me/**/*`
* Run prettier in the affected files

After this PR is merged, `wpcalypso/no-package-relative-imports` becomes like any other eslint rule in our repo: there are many files that violate that rule, and as soon as a developer change one of those files, eslint will complain and they will have to migrate it.

Meanwhile I'll continue creating PRs with auto-fixer applied in batch to some folders to reduce the violations of this rule.

### Testing instructions

* Check all tests passes (ignore lint errors, there will be a ton).
* Do a smoke test on the live branch
* Verify there are no huge changes in package size in ICFY report.
