### PR TITLE
Fix: Second domain-only site not created

### DIFF
--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -35,8 +35,10 @@ export function checkout( context, next ) {
 	const selectedSite = getSelectedSite( state );
 	const currentUser = getCurrentUser( state );
 	const hasSite = currentUser && currentUser.visible_site_count >= 1;
+	const isDomainOnlyFlow = context.query?.isDomainOnly === '1';
 	const isDisallowedForSitePicker =
-		context.pathname.includes( '/checkout/no-site' ) && ( isLoggedOut || ! hasSite );
+		context.pathname.includes( '/checkout/no-site' ) &&
+		( isLoggedOut || ! hasSite || isDomainOnlyFlow );
 
 	if ( ! selectedSite && ! isDisallowedForSitePicker ) {
 		sites( context, next );

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -324,8 +324,9 @@ export function noSite( context, next ) {
 	const { getState } = getStore( context );
 	const currentUser = getCurrentUser( getState() );
 	const hasSite = currentUser && currentUser.visible_site_count >= 1;
+	const isDomainOnlyFlow = context.query?.isDomainOnly === '1';
 
-	if ( hasSite ) {
+	if ( ! isDomainOnlyFlow && hasSite ) {
 		siteSelection( context, next );
 	} else {
 		context.store.dispatch( setSelectedSiteId( null ) );

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -12,7 +12,7 @@ import user from 'lib/user';
 import { generateFlows } from 'signup/config/flows-pure';
 import { addQueryArgs } from 'lib/url';
 
-function getCheckoutUrl( dependencies, localeSlug ) {
+function getCheckoutUrl( dependencies, localeSlug, flowName ) {
 	let checkoutURL = `/checkout/${ dependencies.siteSlug }`;
 
 	// Append the locale slug for the userless checkout page.
@@ -25,6 +25,7 @@ function getCheckoutUrl( dependencies, localeSlug ) {
 			signup: 1,
 			...( dependencies.isPreLaunch && { preLaunch: 1 } ),
 			...( dependencies.isGutenboardingCreate && { isGutenboardingCreate: 1 } ),
+			...( 'domain' === flowName && { isDomainOnly: 1 } ),
 		},
 		checkoutURL
 	);
@@ -106,7 +107,7 @@ function removeUserStepFromFlow( flow ) {
 
 function filterDestination( destination, dependencies, flowName, localeSlug ) {
 	if ( dependenciesContainCartItem( dependencies ) ) {
-		return getCheckoutUrl( dependencies, localeSlug );
+		return getCheckoutUrl( dependencies, localeSlug, flowName );
 	}
 
 	return destination;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes the issue of not being able to create a second domain-only site. This issue was reported in wp.me/p2MSmN-7Zp-p2.
* In registrationless checkout, we redirect /checkout/no-site URLs to /checkout/{SITE_SLUG} for logged in users. This PR will now redirect only if the user is not in the domain-only flow.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* While logged out, create a domain-only site by navigating to /start/domain
* After completing the purchase, navigate to /start/domain again, logged in, and try to purchase another domain-only site. You should be able to successfully complete purchase. 
