### PR TITLE
Remove variables and references to variables of the AB test parameter isEligibleVariantForDomainTest

### DIFF
--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -35,12 +35,7 @@ class DomainProductPrice extends React.Component {
 	};
 
 	renderFreeWithPlanText() {
-		const {
-			isMappingProduct,
-			isEligibleVariantForDomainTest,
-			selectedPaidPlanInSwapFlow,
-			translate,
-		} = this.props;
+		const { isMappingProduct, isSignupStep, selectedPaidPlanInSwapFlow, translate } = this.props;
 
 		let message;
 		switch ( this.props.rule ) {
@@ -51,7 +46,8 @@ class DomainProductPrice extends React.Component {
 				}
 				break;
 			case 'INCLUDED_IN_HIGHER_PLAN':
-				if ( isEligibleVariantForDomainTest ) {
+				//TODO: TEST_PENDING
+				if ( isSignupStep ) {
 					if ( selectedPaidPlanInSwapFlow ) {
 						message = translate(
 							'Registration fee: {{del}}%(cost)s{{/del}} {{span}}Free with your plan{{/span}}',
@@ -96,7 +92,10 @@ class DomainProductPrice extends React.Component {
 			return;
 		}
 
-		const priceText = this.props.isEligibleVariantForDomainTest
+		//TODO: TEST_PENDING
+		// This function can only be reached inside a sign up flow based on current implementation of site rule
+		// Hence the else might not be possible to be tested
+		const priceText = this.props.isSignupStep
 			? this.props.translate( 'Renews at %(cost)s / year', {
 					args: { cost: this.props.price },
 			  } )
@@ -108,9 +107,10 @@ class DomainProductPrice extends React.Component {
 		return <div className="domain-product-price__price">{ priceText }</div>;
 	}
 
+	//TODO: TEST_PENDING , can this flow be reached outside of signup?
 	renderFreeWithPlan() {
 		const className = classnames( 'domain-product-price', 'is-free-domain', {
-			'domain-product-price__domain-step-copy-updates': this.props.isEligibleVariantForDomainTest,
+			'domain-product-price__domain-step-copy-updates': this.props.isSignupStep,
 		} );
 
 		return (
@@ -121,15 +121,16 @@ class DomainProductPrice extends React.Component {
 		);
 	}
 
+	//TODO: TEST_PENDING , can this flow be reached outside of signup?
 	renderFree() {
-		const { isEligibleVariantForDomainTest, translate } = this.props;
+		const { isSignupStep, translate } = this.props;
 
 		const className = classnames( 'domain-product-price', {
-			'domain-product-price__domain-step-copy-updates': isEligibleVariantForDomainTest,
+			'domain-product-price__domain-step-copy-updates': isSignupStep,
 		} );
 
 		const productPriceClassName = classnames( 'domain-product-price__price', {
-			'domain-product-price__free-price': isEligibleVariantForDomainTest,
+			'domain-product-price__free-price': isSignupStep,
 		} );
 
 		return (
@@ -141,11 +142,12 @@ class DomainProductPrice extends React.Component {
 		);
 	}
 
+	//TODO: TEST_PENDING , can this flow be reached outside of signup?
 	renderSalePrice() {
 		const { price, salePrice, translate } = this.props;
 
 		const className = classnames( 'domain-product-price', 'is-free-domain', {
-			'domain-product-price__domain-step-copy-updates': this.props.isEligibleVariantForDomainTest,
+			'domain-product-price__domain-step-copy-updates': this.props.isSignupStep,
 		} );
 
 		return (
@@ -161,22 +163,21 @@ class DomainProductPrice extends React.Component {
 		);
 	}
 
+	//VERIFIED_WORKING
 	renderPrice() {
-		const { salePrice, isEligibleVariantForDomainTest, price, translate } = this.props;
+		const { salePrice, isSignupStep, price, translate } = this.props;
 		if ( salePrice ) {
 			return this.renderSalePrice();
 		}
 
 		const className = classnames( 'domain-product-price', {
-			'is-free-domain': isEligibleVariantForDomainTest,
-			'domain-product-price__domain-step-copy-updates': isEligibleVariantForDomainTest,
+			'is-free-domain': isSignupStep,
+			'domain-product-price__domain-step-copy-updates': isSignupStep,
 		} );
 
-		const productPriceClassName = isEligibleVariantForDomainTest
-			? ''
-			: 'domain-product-price__price';
+		const productPriceClassName = isSignupStep ? '' : 'domain-product-price__price';
 
-		const renewalPrice = isEligibleVariantForDomainTest && (
+		const renewalPrice = isSignupStep && (
 			<div className="domain-product-price__renewal-price">
 				{ translate( 'Renews at: %(cost)s {{small}}/year{{/small}}', {
 					args: { cost: price },

--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -46,7 +46,6 @@ class DomainProductPrice extends React.Component {
 				}
 				break;
 			case 'INCLUDED_IN_HIGHER_PLAN':
-				//TODO: TEST_PENDING
 				if ( isSignupStep ) {
 					if ( selectedPaidPlanInSwapFlow ) {
 						message = translate(
@@ -92,9 +91,6 @@ class DomainProductPrice extends React.Component {
 			return;
 		}
 
-		//TODO: TEST_PENDING
-		// This function can only be reached inside a sign up flow based on current implementation of site rule
-		// Hence the else might not be possible to be tested
 		const priceText = this.props.isSignupStep
 			? this.props.translate( 'Renews at %(cost)s / year', {
 					args: { cost: this.props.price },
@@ -107,10 +103,9 @@ class DomainProductPrice extends React.Component {
 		return <div className="domain-product-price__price">{ priceText }</div>;
 	}
 
-	//TODO: TEST_PENDING , can this flow be reached outside of signup?
 	renderFreeWithPlan() {
 		const className = classnames( 'domain-product-price', 'is-free-domain', {
-			'domain-product-price__domain-step-copy-updates': this.props.isSignupStep,
+			'domain-product-price__domain-step-signup-flow': this.props.isSignupStep,
 		} );
 
 		return (
@@ -121,12 +116,11 @@ class DomainProductPrice extends React.Component {
 		);
 	}
 
-	//TODO: TEST_PENDING , can this flow be reached outside of signup?
 	renderFree() {
 		const { isSignupStep, translate } = this.props;
 
 		const className = classnames( 'domain-product-price', {
-			'domain-product-price__domain-step-copy-updates': isSignupStep,
+			'domain-product-price__domain-step-signup-flow': isSignupStep,
 		} );
 
 		const productPriceClassName = classnames( 'domain-product-price__price', {
@@ -142,12 +136,11 @@ class DomainProductPrice extends React.Component {
 		);
 	}
 
-	//TODO: TEST_PENDING , can this flow be reached outside of signup?
 	renderSalePrice() {
 		const { price, salePrice, translate } = this.props;
 
 		const className = classnames( 'domain-product-price', 'is-free-domain', {
-			'domain-product-price__domain-step-copy-updates': this.props.isSignupStep,
+			'domain-product-price__domain-step-signup-flow': this.props.isSignupStep,
 		} );
 
 		return (
@@ -163,7 +156,6 @@ class DomainProductPrice extends React.Component {
 		);
 	}
 
-	//VERIFIED_WORKING
 	renderPrice() {
 		const { salePrice, isSignupStep, price, translate } = this.props;
 		if ( salePrice ) {
@@ -172,7 +164,7 @@ class DomainProductPrice extends React.Component {
 
 		const className = classnames( 'domain-product-price', {
 			'is-free-domain': isSignupStep,
-			'domain-product-price__domain-step-copy-updates': isSignupStep,
+			'domain-product-price__domain-step-signup-flow': isSignupStep,
 		} );
 
 		const productPriceClassName = isSignupStep ? '' : 'domain-product-price__price';

--- a/client/components/domains/domain-product-price/style.scss
+++ b/client/components/domains/domain-product-price/style.scss
@@ -15,12 +15,12 @@
 			align-items: flex-start;
 		}
 
-		&.domain-product-price__domain-step-copy-updates {
+		&.domain-product-price__domain-step-signup-flow {
 			align-items: flex-start;
 		}
 	}
 
-	.is-section-signup &:not( .domain-product-price__domain-step-copy-updates ) {
+	.is-section-signup &:not( .domain-product-price__domain-step-signup-flow ) {
 		@include breakpoint-deprecated( '>660px' ) {
 			padding-left: 1em;
 			padding-right: 2em;

--- a/client/components/domains/domain-product-price/style.scss
+++ b/client/components/domains/domain-product-price/style.scss
@@ -99,3 +99,11 @@
 		}
 	}
 }
+
+.featured-domain-suggestions {
+	.domain-product-price {
+		.is-section-domains & {
+			padding-left: 0;
+		}
+	}
+}

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -246,9 +246,11 @@ class DomainRegistrationSuggestion extends React.Component {
 			comment: 'Shown next to a domain that has a special discounted sale price',
 		} );
 		const infoPopoverSize = isFeatured ? 22 : 18;
+
+		//VERIFIED_WORKING
 		const titleWrapperClassName = classNames( 'domain-registration-suggestion__title-wrapper', {
 			'domain-registration-suggestion__title-domain-copy-test':
-				this.props.isEligibleVariantForDomainTest && ! this.props.isFeatured,
+				this.props.isSignupStep && ! this.props.isFeatured,
 		} );
 
 		return (
@@ -304,7 +306,8 @@ class DomainRegistrationSuggestion extends React.Component {
 
 		let title, progressBarProps;
 		if ( isRecommended ) {
-			title = this.props.isEligibleVariantForDomainTest
+			//VERIFIED_WORKING
+			title = this.props.isSignupStep
 				? translate( 'Our Recommendation' )
 				: translate( 'Best Match' );
 			progressBarProps = {
@@ -323,7 +326,8 @@ class DomainRegistrationSuggestion extends React.Component {
 		}
 
 		if ( title ) {
-			if ( this.props.isEligibleVariantForDomainTest ) {
+			//VERIFIED_WORKING
+			if ( this.props.isSignupStep ) {
 				const badgeClassName = classNames( '', {
 					success: isRecommended,
 					'info-blue': isBestAlternative,
@@ -346,7 +350,8 @@ class DomainRegistrationSuggestion extends React.Component {
 	}
 
 	renderMatchReason() {
-		if ( this.props.isEligibleVariantForDomainTest ) {
+		//TODO: TEST_PENDING
+		if ( this.props.isSignupStep ) {
 			return null;
 		}
 
@@ -401,7 +406,7 @@ class DomainRegistrationSuggestion extends React.Component {
 				domainsWithPlansOnly={ domainsWithPlansOnly }
 				onButtonClick={ this.onButtonClick }
 				{ ...this.getButtonProps() }
-				isEligibleVariantForDomainTest={ this.props.isEligibleVariantForDomainTest }
+				isSignupStep={ this.props.isSignupStep }
 				isFeatured={ isFeatured }
 				selectedPaidPlanInSwapFlow={ this.props.selectedPaidPlanInSwapFlow }
 			>
@@ -417,7 +422,7 @@ const mapStateToProps = ( state, props ) => {
 	const productSlug = get( props, 'suggestion.product_slug' );
 	const productsList = getProductsList( state );
 	const currentUserCurrencyCode = getCurrentUserCurrencyCode( state );
-	const stripZeros = props.isEligibleVariantForDomainTest ? true : false;
+	const stripZeros = props.isSignupStep ? true : false;
 	const isPremium = props.premiumDomain?.is_premium || props.suggestion?.is_premium;
 
 	let productCost;

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -247,7 +247,6 @@ class DomainRegistrationSuggestion extends React.Component {
 		} );
 		const infoPopoverSize = isFeatured ? 22 : 18;
 
-		//VERIFIED_WORKING
 		const titleWrapperClassName = classNames( 'domain-registration-suggestion__title-wrapper', {
 			'domain-registration-suggestion__title-domain-copy-test':
 				this.props.isSignupStep && ! this.props.isFeatured,
@@ -306,7 +305,6 @@ class DomainRegistrationSuggestion extends React.Component {
 
 		let title, progressBarProps;
 		if ( isRecommended ) {
-			//VERIFIED_WORKING
 			title = this.props.isSignupStep
 				? translate( 'Our Recommendation' )
 				: translate( 'Best Match' );
@@ -326,7 +324,6 @@ class DomainRegistrationSuggestion extends React.Component {
 		}
 
 		if ( title ) {
-			//VERIFIED_WORKING
 			if ( this.props.isSignupStep ) {
 				const badgeClassName = classNames( '', {
 					success: isRecommended,
@@ -350,7 +347,6 @@ class DomainRegistrationSuggestion extends React.Component {
 	}
 
 	renderMatchReason() {
-		//TODO: TEST_PENDING
 		if ( this.props.isSignupStep ) {
 			return null;
 		}

--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -264,7 +264,6 @@ class DomainSearchResults extends React.Component {
 					selectedSite={ this.props.selectedSite }
 					pendingCheckSuggestion={ this.props.pendingCheckSuggestion }
 					unavailableDomains={ this.props.unavailableDomains }
-					isEligibleVariantForDomainTest={ this.props.isEligibleVariantForDomainTest }
 					selectedFreePlanInSwapFlow={ this.props.selectedFreePlanInSwapFlow }
 					selectedPaidPlanInSwapFlow={ this.props.selectedPaidPlanInSwapFlow }
 				/>
@@ -292,7 +291,6 @@ class DomainSearchResults extends React.Component {
 						premiumDomain={ this.props.premiumDomains[ suggestion.domain_name ] }
 						pendingCheckSuggestion={ this.props.pendingCheckSuggestion }
 						unavailableDomains={ this.props.unavailableDomains }
-						isEligibleVariantForDomainTest={ this.props.isEligibleVariantForDomainTest }
 						selectedFreePlanInSwapFlow={ this.props.selectedFreePlanInSwapFlow }
 						selectedPaidPlanInSwapFlow={ this.props.selectedPaidPlanInSwapFlow }
 					/>

--- a/client/components/domains/domain-suggestion/index.jsx
+++ b/client/components/domains/domain-suggestion/index.jsx
@@ -38,14 +38,7 @@ class DomainSuggestion extends React.Component {
 	};
 
 	renderPrice() {
-		const {
-			hidePrice,
-			premiumDomain,
-			price,
-			priceRule,
-			salePrice,
-			isEligibleVariantForDomainTest,
-		} = this.props;
+		const { hidePrice, premiumDomain, price, priceRule, salePrice, isSignupStep } = this.props;
 
 		if ( hidePrice ) {
 			return null;
@@ -60,20 +53,14 @@ class DomainSuggestion extends React.Component {
 				price={ price }
 				salePrice={ salePrice }
 				rule={ priceRule }
-				isEligibleVariantForDomainTest={ isEligibleVariantForDomainTest }
+				isSignupStep={ isSignupStep }
 				selectedPaidPlanInSwapFlow={ this.props.selectedPaidPlanInSwapFlow }
 			/>
 		);
 	}
 
 	render() {
-		const {
-			children,
-			extraClasses,
-			isAdded,
-			isEligibleVariantForDomainTest,
-			isFeatured,
-		} = this.props;
+		const { children, extraClasses, isAdded, isFeatured } = this.props;
 		const classes = classNames(
 			'domain-suggestion',
 			'card',
@@ -86,7 +73,7 @@ class DomainSuggestion extends React.Component {
 		);
 
 		const contentClassName = classNames( 'domain-suggestion__content', {
-			'domain-suggestion__content-domain-copy-test': isEligibleVariantForDomainTest && ! isFeatured,
+			'domain-suggestion__content-domain-copy-test': isSignupStep && ! isFeatured,
 		} );
 
 		/* eslint-disable jsx-a11y/click-events-have-key-events */

--- a/client/components/domains/domain-suggestion/index.jsx
+++ b/client/components/domains/domain-suggestion/index.jsx
@@ -60,7 +60,7 @@ class DomainSuggestion extends React.Component {
 	}
 
 	render() {
-		const { children, extraClasses, isAdded, isFeatured } = this.props;
+		const { children, extraClasses, isAdded, isFeatured, isSignupStep } = this.props;
 		const classes = classNames(
 			'domain-suggestion',
 			'card',

--- a/client/components/domains/featured-domain-suggestions/index.jsx
+++ b/client/components/domains/featured-domain-suggestions/index.jsx
@@ -122,7 +122,6 @@ export class FeaturedDomainSuggestions extends Component {
 						fetchAlgo={ this.getFetchAlgorithm( primarySuggestion ) }
 						buttonStyles={ { primary: true } }
 						{ ...childProps }
-						isSignupStep={ this.props.isSignupStep }
 						selectedFreePlanInSwapFlow={ this.props.selectedFreePlanInSwapFlow }
 						selectedPaidPlanInSwapFlow={ this.props.selectedPaidPlanInSwapFlow }
 					/>

--- a/client/components/domains/featured-domain-suggestions/index.jsx
+++ b/client/components/domains/featured-domain-suggestions/index.jsx
@@ -122,7 +122,7 @@ export class FeaturedDomainSuggestions extends Component {
 						fetchAlgo={ this.getFetchAlgorithm( primarySuggestion ) }
 						buttonStyles={ { primary: true } }
 						{ ...childProps }
-						isEligibleVariantForDomainTest={ this.props.isEligibleVariantForDomainTest }
+						isSignupStep={ this.props.isSignupStep }
 						selectedFreePlanInSwapFlow={ this.props.selectedFreePlanInSwapFlow }
 						selectedPaidPlanInSwapFlow={ this.props.selectedPaidPlanInSwapFlow }
 					/>
@@ -137,7 +137,6 @@ export class FeaturedDomainSuggestions extends Component {
 						premiumDomain={ this.props.premiumDomains[ secondarySuggestion.domain_name ] }
 						fetchAlgo={ this.getFetchAlgorithm( secondarySuggestion ) }
 						{ ...childProps }
-						isEligibleVariantForDomainTest={ this.props.isEligibleVariantForDomainTest }
 						selectedFreePlanInSwapFlow={ this.props.selectedFreePlanInSwapFlow }
 						selectedPaidPlanInSwapFlow={ this.props.selectedPaidPlanInSwapFlow }
 					/>

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -1308,8 +1308,11 @@ class RegisterDomainStep extends React.Component {
 			<Notice text={ domainForwardingExplainer } showDismiss={ false } />
 		);
 
+		const { isPlanSelectionUnavailableInFlow = false } = this.props;
 		const shouldHideFreeDomainExplainer =
-			this.props.selectedFreePlanInSwapFlow || this.props.selectedPaidPlanInSwapFlow;
+			isPlanSelectionUnavailableInFlow ||
+			this.props.selectedFreePlanInSwapFlow ||
+			this.props.selectedPaidPlanInSwapFlow;
 		return (
 			<>
 				{ renderCustomDomainForFreePlanExplainer }

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -141,7 +141,6 @@ class RegisterDomainStep extends React.Component {
 		includeWordPressDotCom: PropTypes.bool,
 		includeDotBlogSubdomain: PropTypes.bool,
 		showExampleSuggestions: PropTypes.bool,
-		isEligibleVariantForDomainTest: PropTypes.bool,
 		onSave: PropTypes.func,
 		onAddMapping: PropTypes.func,
 		onAddDomain: PropTypes.func,
@@ -398,9 +397,9 @@ class RegisterDomainStep extends React.Component {
 	}
 
 	getPlaceholderText() {
-		const { isEligibleVariantForDomainTest, translate } = this.props;
-
-		return isEligibleVariantForDomainTest
+		const { isSignupStep, translate } = this.props;
+		//VERIFIED_WORKING
+		return isSignupStep
 			? translate( 'Type the domain you want here' )
 			: translate( 'Enter a name or keyword' );
 	}
@@ -431,7 +430,7 @@ class RegisterDomainStep extends React.Component {
 			: {};
 
 		const searchBoxClassName = classNames( 'register-domain-step__search', {
-			'register-domain-step__search-domain-step-test': this.props.isEligibleVariantForDomainTest,
+			'register-domain-step__search-domain-step-test': this.props.isSignupStep,
 		} );
 
 		return (
@@ -1163,7 +1162,6 @@ class RegisterDomainStep extends React.Component {
 						onButtonClick={ this.onAddDomain }
 						pendingCheckSuggestion={ this.state.pendingCheckSuggestion }
 						unavailableDomains={ this.state.unavailableDomains }
-						isEligibleVariantForDomainTest={ this.props.isEligibleVariantForDomainTest }
 						selectedFreePlanInSwapFlow={ this.props.selectedFreePlanInSwapFlow }
 						selectedPaidPlanInSwapFlow={ this.props.selectedPaidPlanInSwapFlow }
 						isReskinned={ this.props.isReskinned }
@@ -1313,7 +1311,6 @@ class RegisterDomainStep extends React.Component {
 
 		const shouldHideFreeDomainExplainer =
 			this.props.selectedFreePlanInSwapFlow || this.props.selectedPaidPlanInSwapFlow;
-
 		return (
 			<>
 				{ renderCustomDomainForFreePlanExplainer }
@@ -1345,15 +1342,16 @@ class RegisterDomainStep extends React.Component {
 					cart={ this.props.cart }
 					pendingCheckSuggestion={ this.state.pendingCheckSuggestion }
 					unavailableDomains={ this.state.unavailableDomains }
-					isEligibleVariantForDomainTest={ this.props.isEligibleVariantForDomainTest }
 					selectedFreePlanInSwapFlow={ this.props.selectedFreePlanInSwapFlow }
 					selectedPaidPlanInSwapFlow={ this.props.selectedPaidPlanInSwapFlow }
 				>
-					{ this.props.isEligibleVariantForDomainTest &&
-						hasResults &&
-						! shouldHideFreeDomainExplainer &&
-						this.renderFreeDomainExplainer() }
-
+					{
+						//TODO: TEST_PENDING
+						this.props.isSignupStep &&
+							hasResults &&
+							! shouldHideFreeDomainExplainer &&
+							this.renderFreeDomainExplainer()
+					}
 					{ showTldFilterBar && (
 						<TldFilterBar
 							availableTlds={ this.state.availableTlds }

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -1492,7 +1492,6 @@ export default connect(
 			currentUser: getCurrentUser( state ),
 			defaultSuggestions: getDomainsSuggestions( state, queryObject ),
 			defaultSuggestionsError: getDomainsSuggestionsError( state, queryObject ),
-			showSkipButton: true,
 		};
 	},
 	{

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -398,7 +398,6 @@ class RegisterDomainStep extends React.Component {
 
 	getPlaceholderText() {
 		const { isSignupStep, translate } = this.props;
-		//VERIFIED_WORKING
 		return isSignupStep
 			? translate( 'Type the domain you want here' )
 			: translate( 'Enter a name or keyword' );
@@ -1345,13 +1344,10 @@ class RegisterDomainStep extends React.Component {
 					selectedFreePlanInSwapFlow={ this.props.selectedFreePlanInSwapFlow }
 					selectedPaidPlanInSwapFlow={ this.props.selectedPaidPlanInSwapFlow }
 				>
-					{
-						//TODO: TEST_PENDING
-						this.props.isSignupStep &&
-							hasResults &&
-							! shouldHideFreeDomainExplainer &&
-							this.renderFreeDomainExplainer()
-					}
+					{ this.props.isSignupStep &&
+						hasResults &&
+						! shouldHideFreeDomainExplainer &&
+						this.renderFreeDomainExplainer() }
 					{ showTldFilterBar && (
 						<TldFilterBar
 							availableTlds={ this.state.availableTlds }
@@ -1496,6 +1492,7 @@ export default connect(
 			currentUser: getCurrentUser( state ),
 			defaultSuggestions: getDomainsSuggestions( state, queryObject ),
 			defaultSuggestionsError: getDomainsSuggestionsError( state, queryObject ),
+			showSkipButton: true,
 		};
 	},
 	{

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -94,15 +94,6 @@ export default {
 		},
 		defaultVariation: 'default',
 	},
-	domainStepCopyUpdates: {
-		datestamp: '20191121',
-		variations: {
-			variantShowUpdates: 100,
-			control: 0,
-		},
-		defaultVariation: 'variantShowUpdates',
-		allowExistingUsers: true,
-	},
 	domainStepPlanStepSwap: {
 		datestamp: '20210513',
 		variations: {

--- a/client/lib/signup/site-type.js
+++ b/client/lib/signup/site-type.js
@@ -8,9 +8,6 @@ import { find, get } from 'lodash';
  * Internal dependencies
  */
 
-//TODO: TEST_PENDING
-//Can the attribute domainsStepHeader, domainsStepSubheader completely replaced with the new text? since
-//these headers cannot be seen outside the signup flow.
 const getSiteTypePropertyDefaults = ( propertyKey ) =>
 	get(
 		{
@@ -35,10 +32,6 @@ const getSiteTypePropertyDefaults = ( propertyKey ) =>
 			),
 			siteTopicInputPlaceholder: i18n.translate( 'Enter a topic or choose one from below.' ),
 			// Domains step
-			domainsStepHeader: i18n.translate( 'Give your site an address' ),
-			domainsStepSubheader: i18n.translate(
-				'Enter a keyword that describes your site to get started.'
-			),
 			signUpFlowDomainsStepHeader: i18n.translate( "Let's get your site a domain!" ),
 			signUpFlowDomainsStepSubheader: i18n.translate(
 				"Tell us your site's name or a few keywords, and we'll come up with some suggestions."
@@ -105,10 +98,6 @@ export function getAllSiteTypes() {
 				'Scroll down to see your blog. Once you complete setup you’ll be able to customize it further.'
 			),
 			siteMockupTitleFallback: i18n.translate( 'Your New Blog' ),
-			domainsStepHeader: i18n.translate( 'Give your blog an address' ),
-			domainsStepSubheader: i18n.translate(
-				"Enter your blog's name or some keywords that describe it to get started."
-			),
 			signUpFlowDomainsStepHeader: i18n.translate( "Let's get your blog a domain!" ),
 			signUpFlowDomainsStepSubheader: i18n.translate(
 				"Tell us your blog's name or a few keywords, and we'll come up with some suggestions."
@@ -126,9 +115,7 @@ export function getAllSiteTypes() {
 			siteTitlePlaceholder: i18n.translate( 'E.g., Vail Renovations' ),
 			siteTopicHeader: i18n.translate( 'What does your business do?' ),
 			siteTopicLabel: i18n.translate( 'What type of business do you have?' ),
-			domainsStepSubheader: i18n.translate(
-				"Enter your business's name or some keywords that describe it to get started."
-			),
+
 			signUpFlowDomainsStepHeader: i18n.translate( "Let's get your business a domain!" ),
 			signUpFlowDomainsStepSubheader: i18n.translate(
 				"Tell us your business's name or a few keywords, and we'll come up with some suggestions."
@@ -168,9 +155,6 @@ export function getAllSiteTypes() {
 			siteTopicLabel: i18n.translate( 'What type of products do you sell?' ),
 			customerType: 'business',
 			purchaseRequired: true,
-			domainsStepSubheader: i18n.translate(
-				"Enter your site's name or some keywords that describe it to get started."
-			),
 			signUpFlowDomainsStepHeader: i18n.translate( "Let's get your store a domain!" ),
 			signUpFlowDomainsStepSubheader: i18n.translate(
 				"Tell us your store's name or a few keywords, and we'll come up with some suggestions."

--- a/client/lib/signup/site-type.js
+++ b/client/lib/signup/site-type.js
@@ -8,6 +8,9 @@ import { find, get } from 'lodash';
  * Internal dependencies
  */
 
+//TODO: TEST_PENDING
+//Can the attribute domainsStepHeader, domainsStepSubheader completely replaced with the new text? since
+//these headers cannot be seen outside the signup flow.
 const getSiteTypePropertyDefaults = ( propertyKey ) =>
 	get(
 		{
@@ -36,8 +39,8 @@ const getSiteTypePropertyDefaults = ( propertyKey ) =>
 			domainsStepSubheader: i18n.translate(
 				'Enter a keyword that describes your site to get started.'
 			),
-			domainsStepHeaderTestCopy: i18n.translate( "Let's get your site a domain!" ),
-			domainsStepSubheaderTestCopy: i18n.translate(
+			signUpFlowDomainsStepHeader: i18n.translate( "Let's get your site a domain!" ),
+			signUpFlowDomainsStepSubheader: i18n.translate(
 				"Tell us your site's name or a few keywords, and we'll come up with some suggestions."
 			),
 			// Site styles step
@@ -106,8 +109,8 @@ export function getAllSiteTypes() {
 			domainsStepSubheader: i18n.translate(
 				"Enter your blog's name or some keywords that describe it to get started."
 			),
-			domainsStepHeaderTestCopy: i18n.translate( "Let's get your blog a domain!" ),
-			domainsStepSubheaderTestCopy: i18n.translate(
+			signUpFlowDomainsStepHeader: i18n.translate( "Let's get your blog a domain!" ),
+			signUpFlowDomainsStepSubheader: i18n.translate(
 				"Tell us your blog's name or a few keywords, and we'll come up with some suggestions."
 			),
 		},
@@ -126,8 +129,8 @@ export function getAllSiteTypes() {
 			domainsStepSubheader: i18n.translate(
 				"Enter your business's name or some keywords that describe it to get started."
 			),
-			domainsStepHeaderTestCopy: i18n.translate( "Let's get your business a domain!" ),
-			domainsStepSubheaderTestCopy: i18n.translate(
+			signUpFlowDomainsStepHeader: i18n.translate( "Let's get your business a domain!" ),
+			signUpFlowDomainsStepSubheader: i18n.translate(
 				"Tell us your business's name or a few keywords, and we'll come up with some suggestions."
 			),
 			customerType: 'business',
@@ -168,8 +171,8 @@ export function getAllSiteTypes() {
 			domainsStepSubheader: i18n.translate(
 				"Enter your site's name or some keywords that describe it to get started."
 			),
-			domainsStepHeaderTestCopy: i18n.translate( "Let's get your store a domain!" ),
-			domainsStepSubheaderTestCopy: i18n.translate(
+			signUpFlowDomainsStepHeader: i18n.translate( "Let's get your store a domain!" ),
+			signUpFlowDomainsStepSubheader: i18n.translate(
 				"Tell us your store's name or a few keywords, and we'll come up with some suggestions."
 			),
 		},

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -111,7 +111,7 @@ export function generateSteps( {
 				headerText: i18n.translate( 'Getting ready to launch, pick a domain' ),
 				subHeaderText: i18n.translate( 'Select a domain name for your website' ),
 			},
-			dependencies: [ 'siteSlug' ],
+			dependencies: [ 'siteSlug', 'shouldHideFreePlan' ],
 		},
 
 		'plans-site-selected': {

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -580,7 +580,8 @@ class Signup extends React.Component {
 			( isDomainRegistration( domainItem ) ||
 				isDomainTransfer( domainItem ) ||
 				isDomainMapping( domainItem ) );
-		// Hide the free option as part of 'domainStepCopyUpdates' a/b test
+
+		// Hide the free option in the signup flow
 		const selectedHideFreePlan = get( this.props, 'signupDependencies.shouldHideFreePlan', false );
 		const hideFreePlan = planWithDomain || this.props.isDomainOnlySite || selectedHideFreePlan;
 		const shouldRenderLocaleSuggestions = 0 === this.getPositionInFlow() && ! this.props.isLoggedIn;

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -486,7 +486,6 @@ class DomainsStep extends React.Component {
 				includeDotBlogSubdomain={ this.shouldIncludeDotBlogSubdomain() }
 				isSignupStep
 				showExampleSuggestions={ showExampleSuggestions }
-				isEligibleVariantForDomainTest={ this.isEligibleVariantForDomainTest() }
 				suggestion={ initialQuery }
 				designType={ this.getDesignType() }
 				vendor={ getSuggestionsVendor( { isSignup: true, isDomainOnly: this.props.isDomainOnly } ) }

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -57,8 +57,6 @@ import getSitesItems from 'state/selectors/get-sites-items';
  */
 import './style.scss';
 
-//TODO: TEST_PENDING can the isSignUp flag be removed here completely since
-// this component cannot be reached outside the signup flow?
 class DomainsStep extends React.Component {
 	static propTypes = {
 		forceDesignType: PropTypes.string,
@@ -203,11 +201,8 @@ class DomainsStep extends React.Component {
 		return this.getThemeSlug() ? true : false;
 	}
 
-	//TODO: TEST_PENDING
 	handleSkip = ( googleAppsCartItem, shouldHideFreePlan = false ) => {
-		const hideFreePlanTracksProp = this.props.isSignupStep()
-			? { should_hide_free_plan: shouldHideFreePlan }
-			: {};
+		const hideFreePlanTracksProp = { should_hide_free_plan: shouldHideFreePlan };
 
 		const tracksProperties = Object.assign(
 			{
@@ -232,9 +227,8 @@ class DomainsStep extends React.Component {
 		} );
 	};
 
-	//TODO: TEST_PENDING
 	submitWithDomain = ( googleAppsCartItem, shouldHideFreePlan = false ) => {
-		const shouldHideFreePlanItem = this.props.isSignupStep ? { shouldHideFreePlan } : {};
+		const shouldHideFreePlanItem = { shouldHideFreePlan };
 		const shouldUseThemeAnnotation = this.shouldUseThemeAnnotation();
 		const useThemeHeadstartItem = shouldUseThemeAnnotation
 			? { useThemeHeadstart: shouldUseThemeAnnotation }
@@ -551,18 +545,14 @@ class DomainsStep extends React.Component {
 		);
 	};
 
-	//TODO: TEST_PENDING
-	//is SubHeaderText is shown only in signup step?
 	getSubHeaderText() {
-		const { flowName, isAllDomains, siteType, translate, isSignupStep } = this.props;
+		const { flowName, isAllDomains, siteType, translate } = this.props;
 
 		if ( isAllDomains ) {
 			return translate( 'Find the domain that defines you' );
 		}
 
-		const subHeaderPropertyName = isSignupStep
-			? 'signUpFlowDomainsStepSubheader'
-			: 'domainsStepSubheader';
+		const subHeaderPropertyName = 'signUpFlowDomainsStepSubheader';
 		const onboardingSubHeaderCopy =
 			siteType &&
 			includes( [ 'onboarding', 'ecommerce-onboarding' ], flowName ) &&
@@ -577,16 +567,14 @@ class DomainsStep extends React.Component {
 			: translate( "Enter your site's name or some keywords that describe it to get started." );
 	}
 
-	//TODO: TEST_PENDING
-	//is headerText shown only in the signup step?
 	getHeaderText() {
-		const { headerText, isAllDomains, siteType, translate, isSignupStep } = this.props;
+		const { headerText, isAllDomains, siteType, translate } = this.props;
 
 		if ( isAllDomains ) {
 			return translate( 'Your next big idea starts here' );
 		}
 
-		const headerPropertyName = isSignupStep ? 'signUpFlowDomainsStepHeader' : 'domainsStepHeader';
+		const headerPropertyName = 'signUpFlowDomainsStepHeader';
 
 		return getSiteTypePropertyValue( 'slug', siteType, headerPropertyName ) || headerText;
 	}
@@ -625,12 +613,11 @@ class DomainsStep extends React.Component {
 			);
 		}
 
-		const stepContentClassName = classNames( 'domains__step-content', {
-			'domains__step-content-domain-step-test': this.props.isSignupStep,
-		} );
-
 		return (
-			<div key={ this.props.step + this.props.stepSectionName } className={ stepContentClassName }>
+			<div
+				key={ this.props.step + this.props.stepSectionName }
+				className="domains__step-content domains__step-content-domain-step-test"
+			>
 				{ content }
 			</div>
 		);

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -49,7 +49,7 @@ import { isDomainStepSkippable } from 'signup/config/steps';
 import { fetchUsernameSuggestion } from 'state/signup/optional-dependencies/actions';
 import { isSitePreviewVisible } from 'state/signup/preview/selectors';
 import { hideSitePreview, showSitePreview } from 'state/signup/preview/actions';
-import { abtest, getABTestVariation } from 'lib/abtest';
+import { getABTestVariation } from 'lib/abtest';
 import getSitesItems from 'state/selectors/get-sites-items';
 
 /**
@@ -122,27 +122,6 @@ class DomainsStep extends React.Component {
 			);
 
 			props.goToNextStep();
-		}
-
-		this.showTestCopy = false;
-
-		const isEligibleFlowForDomainTest = includes(
-			[
-				'onboarding',
-				'onboarding-plan-first',
-				'onboarding-passwordless',
-				'onboarding-registrationless',
-			],
-			props.flowName
-		);
-
-		// Do not assign user to the test if either in the launch flow or in /start/{PLAN_SLUG} flow
-		if (
-			false !== this.props.shouldShowDomainTestCopy &&
-			isEligibleFlowForDomainTest &&
-			'variantShowUpdates' === abtest( 'domainStepCopyUpdates' )
-		) {
-			this.showTestCopy = true;
 		}
 	}
 

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -6,7 +6,6 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { defer, endsWith, get, has, includes, isEmpty } from 'lodash';
 import { localize, getLocaleSlug } from 'i18n-calypso';
-import classNames from 'classnames';
 
 /**
  * Internal dependencies

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -57,6 +57,8 @@ import getSitesItems from 'state/selectors/get-sites-items';
  */
 import './style.scss';
 
+//TODO: TEST_PENDING can the isSignUp flag be removed here completely since
+// this component cannot be reached outside the signup flow?
 class DomainsStep extends React.Component {
 	static propTypes = {
 		forceDesignType: PropTypes.string,
@@ -163,10 +165,6 @@ class DomainsStep extends React.Component {
 		}
 	}
 
-	isEligibleVariantForDomainTest() {
-		return this.showTestCopy;
-	}
-
 	getMapDomainUrl = () => {
 		return getStepUrl( this.props.flowName, this.props.stepName, 'mapping', this.props.locale );
 	};
@@ -226,8 +224,9 @@ class DomainsStep extends React.Component {
 		return this.getThemeSlug() ? true : false;
 	}
 
+	//TODO: TEST_PENDING
 	handleSkip = ( googleAppsCartItem, shouldHideFreePlan = false ) => {
-		const hideFreePlanTracksProp = this.isEligibleVariantForDomainTest()
+		const hideFreePlanTracksProp = this.props.isSignupStep()
 			? { should_hide_free_plan: shouldHideFreePlan }
 			: {};
 
@@ -254,10 +253,9 @@ class DomainsStep extends React.Component {
 		} );
 	};
 
+	//TODO: TEST_PENDING
 	submitWithDomain = ( googleAppsCartItem, shouldHideFreePlan = false ) => {
-		const shouldHideFreePlanItem = this.isEligibleVariantForDomainTest()
-			? { shouldHideFreePlan }
-			: {};
+		const shouldHideFreePlanItem = this.props.isSignupStep ? { shouldHideFreePlan } : {};
 		const shouldUseThemeAnnotation = this.shouldUseThemeAnnotation();
 		const useThemeHeadstartItem = shouldUseThemeAnnotation
 			? { useThemeHeadstart: shouldUseThemeAnnotation }
@@ -574,15 +572,17 @@ class DomainsStep extends React.Component {
 		);
 	};
 
+	//TODO: TEST_PENDING
+	//is SubHeaderText is shown only in signup step?
 	getSubHeaderText() {
-		const { flowName, isAllDomains, siteType, translate } = this.props;
+		const { flowName, isAllDomains, siteType, translate, isSignupStep } = this.props;
 
 		if ( isAllDomains ) {
 			return translate( 'Find the domain that defines you' );
 		}
 
-		const subHeaderPropertyName = this.isEligibleVariantForDomainTest()
-			? 'domainsStepSubheaderTestCopy'
+		const subHeaderPropertyName = isSignupStep
+			? 'signUpFlowDomainsStepSubheader'
 			: 'domainsStepSubheader';
 		const onboardingSubHeaderCopy =
 			siteType &&
@@ -598,16 +598,16 @@ class DomainsStep extends React.Component {
 			: translate( "Enter your site's name or some keywords that describe it to get started." );
 	}
 
+	//TODO: TEST_PENDING
+	//is headerText shown only in the signup step?
 	getHeaderText() {
-		const { headerText, isAllDomains, siteType, translate } = this.props;
+		const { headerText, isAllDomains, siteType, translate, isSignupStep } = this.props;
 
 		if ( isAllDomains ) {
 			return translate( 'Your next big idea starts here' );
 		}
 
-		const headerPropertyName = this.isEligibleVariantForDomainTest()
-			? 'domainsStepHeaderTestCopy'
-			: 'domainsStepHeader';
+		const headerPropertyName = isSignupStep ? 'signUpFlowDomainsStepHeader' : 'domainsStepHeader';
 
 		return getSiteTypePropertyValue( 'slug', siteType, headerPropertyName ) || headerText;
 	}
@@ -647,7 +647,7 @@ class DomainsStep extends React.Component {
 		}
 
 		const stepContentClassName = classNames( 'domains__step-content', {
-			'domains__step-content-domain-step-test': this.isEligibleVariantForDomainTest(),
+			'domains__step-content-domain-step-test': this.props.isSignupStep,
 		} );
 
 		return (

--- a/client/state/signup/preview/selectors.js
+++ b/client/state/signup/preview/selectors.js
@@ -16,3 +16,17 @@ import 'state/signup/init';
  */
 export const isSitePreviewVisible = ( state ) =>
 	get( state, [ 'signup', 'preview', 'isVisible' ], false );
+
+/**
+ * Returns true if a plans step exists and is skipped in the signup flow
+ *
+ * @param   {object}  state The current client state
+ * @returns  {boolean} denoting whether the plans step existed AND it was skipped
+ */
+export const isPlanStepExistsAndSkipped = ( state ) => {
+	const { signup: { progress = {} } = {} } = state;
+	const planName = Object.keys( progress ).find( ( stepName ) => stepName.includes( 'plans' ) );
+	const plan = progress[ planName ] ?? {};
+	const { wasSkipped = false } = plan;
+	return wasSkipped;
+};


### PR DESCRIPTION
### Changes proposed in this Pull Request
* Remove all references to AB test initiated at #37661

### Testing instructions

1. In an incognito window, select a signup flow, for example the business flow : [/start/business](http://calypso.localhost:3000/start/business/)
2. Signup and go into the domain step
3. In another window login to an existing wordpress account and go to the [add domain page](http://calypso.localhost:3000/domains/add/dehan91.wordpress.com)

#### FreeDomainExplainer Component
- An explanation on free domain should be visible only in the sign up flow

#### DomainRegistrationSuggestion Component

- Match indicator is a badge in the sign up flow while it is a progress bar  in the mysite flow with different texts as shown below
- Render match reasons should not be visible in the signup flow
- The renew text should be left or right aligned based on the flow 
- In the signup flow zeroes are removed from the domain price if the decimals are zero

| My Site Flow   |      Sign Up Flow      |
|----------|:-------------:|
| ![image](https://user-images.githubusercontent.com/3422709/91007975-ea143900-e5fa-11ea-845d-37b36a27a0ec.png)  |  ![image](https://user-images.githubusercontent.com/3422709/91007940-d668d280-e5fa-11ea-919d-6cbe9bb51d57.png) | 
| ![image](https://user-images.githubusercontent.com/3422709/91034083-08d9f600-e622-11ea-8f97-0d900588fb33.png)  | ![image](https://user-images.githubusercontent.com/3422709/91034101-0d9eaa00-e622-11ea-9e2f-0441e15eba66.png) |

#### RegisterDomainStep Component
- Caption on the search bar should be different.

| My Site Flow   |      Sign Up Flow      |
|----------|:-------------:|
| ![image](https://user-images.githubusercontent.com/3422709/91027157-5867f400-e619-11ea-9e93-56c60ebf80a7.png) |  ![image](https://user-images.githubusercontent.com/3422709/91026923-0e7f0e00-e619-11ea-88bf-b21d820ed9cf.png) | 

#### DomainProductPrice Component
- Free domains should be green in signup flow (Some parameters were hard coded to view this in the mysite flow)

| My Site Flow   |      Sign Up Flow      |
|----------|:-------------:|
| ![image](https://user-images.githubusercontent.com/3422709/91037804-43925d00-e627-11ea-8492-3b76735c213e.png) | ![image](https://user-images.githubusercontent.com/3422709/91037773-3a08f500-e627-11ea-9699-8f4012bdad10.png) | 