### PR TITLE
Prevent Widows: Handle interpolated components

### DIFF
--- a/client/lib/formatting/prevent-widows.js
+++ b/client/lib/formatting/prevent-widows.js
@@ -11,7 +11,10 @@ import React from 'react';
  * @returns {string}             the widow-prevented string
  */
 export function preventWidows( text, wordsToKeep = 2 ) {
-	return preventWidowsInPart( text, Math.max( 1, wordsToKeep - 1 ) ).part;
+	return preventWidowsInPart(
+		'string' === typeof text ? text.trim() : text,
+		Math.max( 1, wordsToKeep - 1 )
+	).part;
 }
 
 const reverseSpaceRegex = /\s+(\S*)$/;
@@ -28,23 +31,28 @@ const reverseSpaceRegex = /\s+(\S*)$/;
 function preventWidowsInPart( part, spacesToSubstitute ) {
 	let substituted = 0;
 
-	if ( 'string' === typeof part ) {
+	if ( 'string' === typeof part && part.length > 0 ) {
 		let text = part;
+		let retVal = '';
+
 		// If the part is a string, work from the right looking for spaces
 		// TODO Work out if we can tell that this is a RTL language, and if it's appropriate to join words in this way
-		while ( substituted < spacesToSubstitute && text.match( reverseSpaceRegex ) ) {
-			text = text.replace( reverseSpaceRegex, '\xA0$1' ); //
+		while ( substituted < spacesToSubstitute && reverseSpaceRegex.test( text ) ) {
+			const match = reverseSpaceRegex.exec( text );
+			retVal = '\xA0' + match[ 1 ] + retVal;
+			text = text.replace( reverseSpaceRegex, '' );
 			substituted++;
 		}
+		retVal = text + retVal;
 		// Return the modified string and the number of spaces substituted
-		return { part: text, substituted };
+		return { part: retVal, substituted };
 	}
 
 	/* If we're called with an array construct a copy of the array by calling
 	 * ourself on each element until we have substituted enough spaces. Then
 	 * concatentate the rest of the array
 	 */
-	if ( Array.isArray( part ) ) {
+	if ( Array.isArray( part ) && part.length > 0 ) {
 		let elements = [];
 		let idx = part.length - 1;
 		while ( substituted < spacesToSubstitute && idx >= 0 ) {

--- a/client/lib/formatting/prevent-widows.js
+++ b/client/lib/formatting/prevent-widows.js
@@ -17,7 +17,7 @@ export function preventWidows( text, wordsToKeep = 2 ) {
 const reverseSpaceRegex = /\s+(\S*)$/;
 
 /**
- * The hulper function to preventWidows that calls itself rucursively searching for spaces to substitute with
+ * The helper function to preventWidows that calls itself recursively searching for spaces to substitute with
  * non-breaking spaces.
  *
  * @param {string|@i18n-calypso/TranslateResult} part The section of the content to search, a string or a component

--- a/client/my-sites/customer-home/cards/features/stats/index.jsx
+++ b/client/my-sites/customer-home/cards/features/stats/index.jsx
@@ -17,6 +17,7 @@ import Spinner from 'components/spinner';
 import QuerySiteStats from 'components/data/query-site-stats';
 import InlineSupportLink from 'components/inline-support-link';
 import { localizeUrl } from 'lib/i18n-utils';
+import { preventWidows } from 'lib/formatting';
 import { buildChartData } from 'my-sites/stats/stats-chart-tabs/utility';
 import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
 import { getSiteOption } from 'state/sites/selectors';
@@ -99,7 +100,7 @@ export const StatsV2 = ( {
 								statsGroup="calypso_customer_home"
 								statsName="stats_learn_more"
 							>
-								{ translate( 'Learn about stats.' ) }
+								{ preventWidows( translate( 'Learn about stats.' ) ) }
 							</InlineSupportLink>
 						</div>
 					</Chart>

--- a/client/post-editor/editor-deprecation-dialog/index.jsx
+++ b/client/post-editor/editor-deprecation-dialog/index.jsx
@@ -24,6 +24,7 @@ import { getEditedPostValue } from 'state/posts/selectors';
 import getGutenbergEditorUrl from 'state/selectors/get-gutenberg-editor-url';
 import InlineSupportLink from 'components/inline-support-link';
 import { localizeUrl } from 'lib/i18n-utils';
+import { preventWidows } from 'lib/formatting';
 import FormattedDate from 'components/formatted-date';
 import { withLocalizedMoment } from 'components/localized-moment';
 
@@ -77,29 +78,31 @@ class EditorDeprecationDialog extends Component {
 				<div className="editor-deprecation-dialog__illustration" />
 
 				<p className="editor-deprecation-dialog__subhead">
-					{ translate(
-						'Get a head start before we activate it for everyone in the near future. {{support}}Read more{{/support}}.',
-						{
-							components: {
-								date: (
-									<strong>
-										<FormattedDate date="2020-07-01" format={ dateFormat } />
-									</strong>
-								),
-								support: (
-									<InlineSupportLink
-										supportPostId={ 167510 }
-										supportLink={ localizeUrl(
-											'https://wordpress.com/support/replacing-the-older-wordpress-com-editor-with-the-wordpress-block-editor/'
-										) }
-										showIcon={ false }
-										tracksEvent="calypso_editor_deprecate_support_page_view"
-										statsGroup="calypso_editor"
-										statsName="editor_deprecate_learn_more"
-									/>
-								),
-							},
-						}
+					{ preventWidows(
+						translate(
+							'Get a head start before we activate it for everyone in the near future. {{support}}Read more{{/support}}.',
+							{
+								components: {
+									date: (
+										<strong>
+											<FormattedDate date="2020-07-01" format={ dateFormat } />
+										</strong>
+									),
+									support: (
+										<InlineSupportLink
+											supportPostId={ 167510 }
+											supportLink={ localizeUrl(
+												'https://wordpress.com/support/replacing-the-older-wordpress-com-editor-with-the-wordpress-block-editor/'
+											) }
+											showIcon={ false }
+											tracksEvent="calypso_editor_deprecate_support_page_view"
+											statsGroup="calypso_editor"
+											statsName="editor_deprecate_learn_more"
+										/>
+									),
+								},
+							}
+						)
 					) }
 				</p>
 				<Button onClick={ this.optInToGutenberg } isPrimary>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The card which warned users of the upcoming deprecation of the Calypso
editor had a message that ended with `<a...>Read more</a>.` The way we
were handling components when searching for spaces to replace with a
non-breaking space, meant we just took the last piece of text from the
array. In this case, that was a `.` and so a non-breaking space was never
added. If there was no `.` then the component would have been used,
but as it was not an array or a string, nothing would have happened.

This change reimplements the algorithm and recursively walks the tree of
strings and elements, working from the end, until the correct number of
substitutions have been made, or we run out of content.

There looks to be a possible bug in Firefox, that means in some
circumstances, word-wrap occurs still on a non-breaking space at the
boundary of an HTML element, but that's a separate issue. There might be
reasons for it, and if not, then any patch for it should live elsewhere.

#### Testing instructions

It seems that this particular problem has bee patched by increasing the font size of the text in the card, but it can still be seen at certain screen sizes.

* Ensure that you haven't had the classic editor deprecated by setting the user attribute to false for your user ID in `wpsh`. `update_user_attribute( YOUR_USER_ID, 'editor_deprecation_group', false );`
* Either switch to a site set to use the Calypso editor or click the 'Switch to Classic' option in the three-dot menu in the top right, whilst editing a post on a test site.
* Go to 'Home' for the site, and you should see the deprecation message card at the top
<img width="1021" alt="image" src="https://user-images.githubusercontent.com/96462/90381448-4d3f2200-e075-11ea-899b-0c25bde87713.png">

* Set your viewport to around 500px width and you should see a widow of the 'more' wrapping to the next line
<img width="501" alt="image" src="https://user-images.githubusercontent.com/96462/90381585-7a8bd000-e075-11ea-910f-e61590c63547.png">

* With this branch the text should wrap before the 'Read'.

![widow](https://user-images.githubusercontent.com/96462/90382218-5bda0900-e076-11ea-8f91-ce54c1bc8f5b.gif)
* Also check that other pieces of text are still displaying correctly

