### PR TITLE
classic-post-editor(media): replace MediaStore listener with redux's store.subscribe

### DIFF
--- a/client/components/tinymce/plugins/media/plugin.jsx
+++ b/client/components/tinymce/plugins/media/plugin.jsx
@@ -22,7 +22,7 @@ import notices from 'notices';
 import TinyMCEDropZone from './drop-zone';
 import restrictSize from './restrict-size';
 import config from 'config';
-import { getSelectedSite } from 'state/ui/selectors';
+import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { setEditorMediaModalView } from 'state/editor/actions';
 import { unblockSave } from 'state/editor/save-blockers/actions';
 import { getEditorRawContent, isEditorSaveBlocked } from 'state/editor/selectors';
@@ -882,12 +882,14 @@ function mediaButton( editor ) {
 
 	editor.on( 'init', function () {
 		unsubscribeFromReduxStore = store.subscribe( () => {
-			const { ID: siteId } = getSelectedSite( store.getState() );
+			const siteId = getSelectedSiteId( store.getState() );
 			if ( ! siteId ) {
 				return;
 			}
+
 			previousMediaReference = currentMediaReference;
 			currentMediaReference = getMedia( store.getState(), siteId );
+
 			if ( ! isEqual( previousMediaReference, currentMediaReference ) ) {
 				updateMedia();
 			}

--- a/client/components/tinymce/plugins/media/plugin.jsx
+++ b/client/components/tinymce/plugins/media/plugin.jsx
@@ -5,7 +5,7 @@ import ReactDom from 'react-dom';
 import ReactDomServer from 'react-dom/server';
 import React from 'react';
 import tinymce from 'tinymce/tinymce';
-import { assign, debounce, find, findLast, pick, values, isEqual } from 'lodash';
+import { assign, debounce, find, findLast, pick, values } from 'lodash';
 import i18n from 'i18n-calypso';
 import { parse, stringify } from 'lib/shortcode';
 import closest from 'component-closest';
@@ -890,7 +890,7 @@ function mediaButton( editor ) {
 			previousMediaReference = currentMediaReference;
 			currentMediaReference = getMedia( store.getState(), siteId );
 
-			if ( ! isEqual( previousMediaReference, currentMediaReference ) ) {
+			if ( previousMediaReference !== currentMediaReference ) {
 				updateMedia();
 			}
 		} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* In `tinymce/plugins/media/plugin.jsx` replace usage of `MediaStore` change listener with redux `store.subscribe` and call `updateMedia` in case something in media state changed

#### Testing instructions

1. Open the  classic post editor on a post which contains the same image at least twice
2. Edit that image (crop, flip, rotate, etc)
3. Make sure all copies of that image are updated


related #43663 