### PR TITLE
fix(media): ensure order by ID if date is invalid

### DIFF
--- a/client/state/selectors/get-media-sorted-by-date.js
+++ b/client/state/selectors/get-media-sorted-by-date.js
@@ -1,12 +1,13 @@
 /**
  * External dependencies
  */
-import { orderBy, values } from 'lodash';
+import { values } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import getMediaQueryManager from './get-media-query-manager';
+import { sortItemsByDate } from 'lib/media/utils/sort-items-by-date';
 
 /**
  * Returns media for a specified site ID and query.
@@ -27,9 +28,5 @@ export default function getMediaSortedByDate( state, siteId ) {
 	const mediaItems = queryManager.getItemsIgnoringPage( query );
 	const transientItems = values( state.media.transientItems[ siteId ]?.transientItems );
 
-	return orderBy(
-		transientItems.concat( mediaItems ).filter( ( i ) => i ),
-		( item ) => Date.parse( item?.date ),
-		[ 'desc' ]
-	);
+	return sortItemsByDate( transientItems.concat( mediaItems ).filter( ( i ) => i ) );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Reported via p1597667307093300-slack-C02DQP0FP

In https://github.com/Automattic/wp-calypso/pull/44790 we switched to retrieving media items from the redux store rather than the flux store. With that, we had to introduce a sort function to make sure items appear in the right order (newest first). However, if there's no date set or for a reason the date is invalid that function to order media items doesn't work. For now, switching back to the old function used by the flux store which sorts by `ID` in that specific case (and what I was missing in mentioned PR).

* Switch back to use `sortItemsByDate` to order items retrieved from the store

#### Testing instructions

1. Open up the media library on any site and make sure items appear in the right order
2. Try to add a new item and make sure it's added as first item
