### PR TITLE
Removes signup state from the main layout

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -51,8 +51,6 @@ import { isWooOAuth2Client } from 'lib/oauth2-clients';
 import { getCurrentOAuth2Client } from 'state/oauth2-clients/ui/selectors';
 import LayoutLoader from './loader';
 import wooDnaConfig from 'jetpack-connect/woo-dna-config';
-import { getABTestVariation } from 'lib/abtest';
-import { getCurrentFlowName } from 'state/signup/flow/selectors';
 
 /**
  * Style dependencies
@@ -161,16 +159,8 @@ class Layout extends Component {
 		const optionalBodyProps = () => {
 			const optionalProps = {};
 
-			const bodyClass = classnames( {
-				'is-new-launch-flow': this.props.isNewLaunchFlow || this.props.isCheckoutFromGutenboarding,
-				'is-white-signup':
-					'signup' === this.props.sectionName &&
-					this.props.isOnboardingFlow &&
-					'reskinned' === getABTestVariation( 'reskinSignupFlow' ),
-			} );
-
-			if ( bodyClass ) {
-				optionalProps.bodyClass = bodyClass;
+			if ( this.props.isNewLaunchFlow || this.props.isCheckoutFromGutenboarding ) {
+				optionalProps.bodyClass = 'is-new-launch-flow';
 			}
 
 			return optionalProps;
@@ -285,7 +275,6 @@ export default connect( ( state ) => {
 	const isEligibleForJITM =
 		[ 'stats', 'plans', 'themes', 'plugins', 'comments' ].indexOf( sectionName ) >= 0;
 	const isNewLaunchFlow = startsWith( currentRoute, '/start/new-launch' );
-	const isOnboardingFlow = 'onboarding' === getCurrentFlowName( state );
 
 	return {
 		masterbarIsHidden:
@@ -318,6 +307,5 @@ export default connect( ( state ) => {
 		shouldQueryAllSites: currentRoute && currentRoute !== '/jetpack/connect/authorize',
 		isNewLaunchFlow,
 		isCheckoutFromGutenboarding,
-		isOnboardingFlow,
 	};
 } )( Layout );

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -197,7 +197,7 @@ class Signup extends React.Component {
 	}
 
 	UNSAFE_componentWillReceiveProps( nextProps ) {
-		const { stepName, flowName, progress, isReskinned, path } = nextProps;
+		const { stepName, flowName, progress, isReskinned } = nextProps;
 
 		if ( this.props.stepName !== stepName ) {
 			this.removeFulfilledSteps( nextProps );
@@ -214,7 +214,7 @@ class Signup extends React.Component {
 		if ( ! this.state.controllerHasReset && ! isEqual( this.props.progress, progress ) ) {
 			this.updateShouldShowLoadingScreen( progress );
 		}
-		if ( isReskinned && ( ! this.props.isReskinned || path !== this.props.path ) ) {
+		if ( isReskinned ) {
 			this.addCssClassToBodyForReskinnedFlow();
 		}
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The signup reskin (#44223) introduced a change in which the the entire signup state was downloaded & executed on almost all the pages. This change reverts the changes to the `layout/index.jsx`. However, it also introduced an issue where the `is-white-signup` class was not applied to the body element on refreshing the page. This change also fixes it.

#### Testing instructions
* Go to /start/new.
* Make sure you're assigned to reskinned group of reskinSignupFlow a/b test. Note: this test is intended to work only for non-EN and non-ES users.
* The signup screens should look like the ones in the description of #44223.
* Refreshing the page on any of the steps should not change the design on the page.

cc: @sgomes 