### PR TITLE
Retain cursor focus on user-mentions block when the popover opens

### DIFF
--- a/client/blocks/user-mentions/suggestion-list.jsx
+++ b/client/blocks/user-mentions/suggestion-list.jsx
@@ -31,6 +31,7 @@ const UserMentionsSuggestionList = ( {
 		className="user-mentions__suggestions"
 		context={ popoverContext }
 		isVisible={ true }
+		isFocusEnabled={ false }
 		autoPosition={ false }
 		position="bottom right"
 		onClose={ onClose }

--- a/client/components/popover/index.jsx
+++ b/client/components/popover/index.jsx
@@ -38,6 +38,7 @@ class PopoverInner extends Component {
 		className: '',
 		closeOnEsc: true,
 		isRtl: false,
+		isFocusEnabled: true,
 		position: 'top',
 		onClose: noop,
 	};
@@ -189,7 +190,9 @@ class PopoverInner extends Component {
 
 	setPositionAndFocus() {
 		this.setPosition();
-		this.focusPopover();
+		if ( this.props.isFocusEnabled ) {
+			this.focusPopover();
+		}
 	}
 
 	focusPopover() {
@@ -412,6 +415,7 @@ Popover.propTypes = {
 	context: PropTypeElement,
 	ignoreContext: PropTypeElement,
 	isVisible: PropTypes.bool,
+	isFocusEnabled: PropTypes.bool,
 	position: PropTypes.oneOf( [
 		'top',
 		'top right',

--- a/client/components/popover/menu.jsx
+++ b/client/components/popover/menu.jsx
@@ -46,6 +46,7 @@ class PopoverMenu extends Component {
 			context,
 			customPosition,
 			isVisible,
+			isFocusEnabled,
 			popoverTitle,
 			position,
 		} = this.props;
@@ -59,6 +60,7 @@ class PopoverMenu extends Component {
 				context={ context }
 				customPosition={ customPosition }
 				isVisible={ isVisible }
+				isFocusEnabled={ isFocusEnabled }
 				popoverTitle={ popoverTitle }
 				position={ position }
 			>


### PR DESCRIPTION
Typing "@" in a textarea wrapped with the withUserMentions HOC would open a popover containing a
user suggestion list that would cause the textarea to lose focus, requiring the user to manually
place the cursor back to continue default behavior. Adding a default prop isFocusEnabled which
defaults to true to check if the deferred focusPopover method should be called.

#### Changes proposed in this Pull Request

* Add default prop isFocusEnabled
* Add check before calling focusPopover
* Default isFocusEnabled for Popover to true
* Pass isFocusEnabled as false to the popover in the UserMentions component

#### Testing instructions

* Visit http://calypso.localhost:3000/devdocs/blocks/user-mentions
* Press '@' and start typing for user matches
* User suggestions show up and textarea remains in focus, allowing the user to perform keyboard operations as expected.

Fixes #37625
