### PR TITLE
Site setup list: Fix nav item styles for Safari

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
@@ -48,6 +48,8 @@
 		transition: all 0.1s;
 		cursor: pointer;
 		width: 100%;
+		margin: 0;
+		color: var( --color-text );
 
 		&:last-child {
 			border-bottom: none;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes the `.nav-item` styles for Safari, so the button rendered does not apply the margin and color provided by default in Safari.

Before | After
--- | ---
<img width="357" alt="Screen Shot 2020-08-17 at 16 35 45" src="https://user-images.githubusercontent.com/1233880/90408884-c1df8400-e0a8-11ea-8b83-c6d7cf2fbf16.png"> | <img width="362" alt="Screen Shot 2020-08-17 at 16 43 46" src="https://user-images.githubusercontent.com/1233880/90408950-d754ae00-e0a8-11ea-8da6-adf5bdc21c6e.png">


#### Testing instructions

* Go to  `/start` and create a new site.
* Check the Site setup list in My Home.
* Make sure the navigation items look like the after screenshot above in all browsers (the issue was specific to Safari).

Fixes https://github.com/Automattic/wp-calypso/issues/42369
