### PR TITLE
Bump WordPress.com Editing Toolkit plugin to v1.21

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WordPress.com Editing Toolkit
  * Description: Enhances your page creation workflow within the Block Editor.
- * Version: 1.20
+ * Version: 1.21
  * Author: Automattic
  * Author URI: https://automattic.com/wordpress-plugins/
  * License: GPLv2 or later
@@ -35,7 +35,7 @@ namespace A8C\FSE;
  *
  * @var string
  */
-define( 'PLUGIN_VERSION', '1.20' );
+define( 'PLUGIN_VERSION', '1.21' );
 
 // Always include these helper files for dotcom FSE.
 require_once __DIR__ . '/dotcom-fse/helpers.php';

--- a/apps/full-site-editing/full-site-editing-plugin/readme.txt
+++ b/apps/full-site-editing/full-site-editing-plugin/readme.txt
@@ -3,7 +3,7 @@ Contributors: alexislloyd, allancole, automattic, bartkalisz, codebykat, copons,
 Tags: block, blocks, editor, gutenberg, page
 Requires at least: 5.0
 Tested up to: 5.4
-Stable tag: 1.20
+Stable tag: 1.21
 Requires PHP: 5.6.20
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -39,6 +39,11 @@ This plugin is experimental, so we don't provide any support for it outside of w
 
 
 == Changelog ==
+
+= 1.21 =
+* Site setup: Redirect to user's home after checkout. For both composite and old checkouts. And for simple and atomic (e-commerce) sites. See (https://github.com/Automattic/wp-calypso/pull/44881).
+* Block patterns: Only call unregister on the columns category if currently registered. See (https://github.com/Automattic/wp-calypso/pull/44903)
+* Block editor: Always enable line-height in Gutenberg settings. See (https://github.com/Automattic/wp-calypso/pull/44772)
 
 = 1.20 =
 * Site setup: Fix delay when starting the flow because of the editor save action.

--- a/apps/full-site-editing/package.json
+++ b/apps/full-site-editing/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/full-site-editing",
-	"version": "1.20.0",
+	"version": "1.21.0",
 	"description": "Plugin for editing-related features.",
 	"sideEffects": true,
 	"repository": {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This release's changelog is:


* Site setup: Redirect to user's home after checkout. For both composite and old checkouts. And for simple and atomic (e-commerce) sites. See (https://github.com/Automattic/wp-calypso/pull/44881).
* Block patterns: Only call unregister on the columns category if currently registered. See (https://github.com/Automattic/wp-calypso/pull/44903)
* Block editor: Always enable line-height in Gutenberg settings. See (https://github.com/Automattic/wp-calypso/pull/44772)

Other included PRs:
- https://github.com/Automattic/wp-calypso/pull/44935