### PR TITLE
e2e: Fixing some broken tests

### DIFF
--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -441,10 +441,16 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		if ( driverManager.currentScreenSize() === 'mobile' ) {
 			return await this.driver.navigate().back();
 		}
-		return await driverHelper.clickWhenClickable(
+		await driverHelper.clickWhenClickable(
 			this.driver,
 			By.css(
 				'.edit-post-header .edit-post-fullscreen-mode-close, .edit-post-header-toolbar__back'
+			)
+		);
+		return await driverHelper.clickWhenClickable(
+			this.driver,
+			By.css(
+				'.wpcom-block-editor-nav-sidebar-nav-sidebar__home-button'
 			)
 		);
 	}

--- a/test/e2e/lib/pages/cancel-domain-page.js
+++ b/test/e2e/lib/pages/cancel-domain-page.js
@@ -15,21 +15,21 @@ const by = webdriver.By;
 export default class CancelDomainPage extends AsyncBaseContainer {
 	constructor( driver ) {
 		super( driver, by.css( '.confirm-cancel-domain.main' ) );
-		this.confirmButtonSelector = by.css( 'button[type="submit"]' );
+		this.confirmButtonSelector = by.css( '.confirm-cancel-domain .button.is-primary' );
 	}
 
 	async completeSurveyAndConfirm() {
 		await this.driver.sleep( 2000 ); // since this is in after block, wait before open survey
-		await driverHelper.clickWhenClickable( this.driver, by.css( '.select-dropdown__header' ) );
-		await driverHelper.clickWhenClickable( this.driver, by.css( '.select-dropdown__item' ) );
-		await driverHelper.setCheckbox(
+		await driverHelper.clickWhenClickable( this.driver, by.css( '.confirm-cancel-domain__reasons-dropdown' ) );
+		await driverHelper.clickWhenClickable( this.driver, by.css( 'option[value="other"]' ) );
+		await driverHelper.setWhenSettable(
+			this.driver,
+			by.css( '.confirm-cancel-domain__reason-details' ),
+			'e2e testing'
+		);
+		await driverHelper.clickWhenClickable(
 			this.driver,
 			by.css( '.confirm-cancel-domain__confirm-container input[type="checkbox"]' )
-		);
-		await driverHelper.verifyTextPresent(
-			this.driver,
-			this.confirmButtonSelector,
-			'Cancel Anyway'
 		);
 		await driverHelper.clickWhenClickable( this.driver, this.confirmButtonSelector );
 		const noticesComponent = await NoticesComponent.Expect( this.driver );

--- a/test/e2e/lib/pages/domain-details-page.js
+++ b/test/e2e/lib/pages/domain-details-page.js
@@ -20,4 +20,11 @@ export default class DomainDetailsPage extends AsyncBaseContainer {
 			By.css( 'a.subscription-settings' )
 		);
 	}
+
+	async cancelDomain() {
+		return await DriverHelper.clickWhenClickable(
+			this.driver,
+			By.css( 'a svg.material-icon-delete' )
+		);
+	}
 }

--- a/test/e2e/specs/wp-signup-spec.js
+++ b/test/e2e/specs/wp-signup-spec.js
@@ -31,7 +31,7 @@ import MagicLoginPage from '../lib/pages/magic-login-page';
 import ReaderPage from '../lib/pages/reader-page';
 import DomainOnlySettingsPage from '../lib/pages/domain-only-settings-page';
 import DomainDetailsPage from '../lib/pages/domain-details-page';
-import ManagePurchasePage from '../lib/pages/manage-purchase-page';
+import ProfilePage from '../lib/pages/profile-page';
 import CancelPurchasePage from '../lib/pages/cancel-purchase-page';
 import CancelDomainPage from '../lib/pages/cancel-domain-page';
 import ThemesPage from '../lib/pages/themes-page';
@@ -854,15 +854,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 			return await securePaymentComponent.waitForPageToDisappear();
 		} );
 
-		step(
-			'Can see the domain is ready page and click "Manage Domain" button to see the domain only settings page',
-			async function () {
-				const domainOnlySettingsPage = await DomainOnlySettingsPage.Expect( driver );
-				await domainOnlySettingsPage.manageDomain();
-				return await DomainDetailsPage.Expect( driver );
-			}
-		);
-
 		step( 'Can open the sidebar', async function () {
 			const navBarComponent = await NavBarComponent.Expect( driver );
 			await navBarComponent.clickMySites();
@@ -890,16 +881,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 				const domainOnlySettingsPage = await DomainOnlySettingsPage.Expect( driver );
 				await domainOnlySettingsPage.manageDomain();
 				const domainDetailsPage = await DomainDetailsPage.Expect( driver );
-				await domainDetailsPage.viewPaymentSettings();
-
-				const managePurchasePage = await ManagePurchasePage.Expect( driver );
-				const domainDisplayed = await managePurchasePage.domainDisplayed();
-				assert.strictEqual(
-					domainDisplayed,
-					expectedDomainName,
-					'The domain displayed on the manage purchase page is unexpected'
-				);
-				await managePurchasePage.chooseCancelAndRefund();
+				await domainDetailsPage.cancelDomain();
 
 				const cancelPurchasePage = await CancelPurchasePage.Expect( driver );
 				await cancelPurchasePage.clickCancelPurchase();

--- a/test/e2e/specs/wp-signup-spec.js
+++ b/test/e2e/specs/wp-signup-spec.js
@@ -31,7 +31,6 @@ import MagicLoginPage from '../lib/pages/magic-login-page';
 import ReaderPage from '../lib/pages/reader-page';
 import DomainOnlySettingsPage from '../lib/pages/domain-only-settings-page';
 import DomainDetailsPage from '../lib/pages/domain-details-page';
-import ProfilePage from '../lib/pages/profile-page';
 import CancelPurchasePage from '../lib/pages/cancel-purchase-page';
 import CancelDomainPage from '../lib/pages/cancel-domain-page';
 import ThemesPage from '../lib/pages/themes-page';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR fixes some broken e2e tests. 
 - Somewhere along the way, there was a change made to closing the Gutenberg editor and it caused one test to break
 - The flow to canceling a domain only plan changed so I updated and made sure the cleanup was working. 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

 * Ensure e2e tests pass
