### PR TITLE
Gutenboarding: Add Ibis (FSE) to the available designs

### DIFF
--- a/client/landing/gutenboarding/available-designs-config.json
+++ b/client/landing/gutenboarding/available-designs-config.json
@@ -27,6 +27,19 @@
 			"is_fse": true
 		},
 		{
+			"title": "Ibis (FSE)",
+			"slug": "ibis-fse",
+			"template": "ibis",
+			"theme": "ibis",
+			"fonts": {
+				"headings": "Lora",
+				"base": "Lora"
+			},
+			"categories": [ "featured", "portfolio" ],
+			"is_premium": false,
+			"is_fse": true
+		},
+		{
 			"title": "Cassel",
 			"slug": "cassel",
 			"template": "cassel",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Requires D48207-code

* Add the `Ibis (FSE)` design, based on the Ibis theme, to the Gutenboarding available designs list.

<img width="1401" alt="Screenshot 2020-08-17 at 18 55 37" src="https://user-images.githubusercontent.com/2070010/90428008-420ee500-e0bb-11ea-8b1a-cd9e892c00fc.png">

#### Known Issues (aka Help Request 🙂 )

- I'm having troubles generating the thumbnail as outlined in PCYsg-r7w-p2.
The `https://public-api.wordpress.com/rest/v1/template/demo/ibis/ibis` returns "no demo site", even though I've got the WPCOM changes ready and the API sandboxed. 🤔 

- Changing fonts in the live preview doesn't work. I haven't investigated it yet, but maybe there's a very simple reason.

#### Testing instructions

* Apply D48207-code and sandbox the API.
* Run Calypso and open `http://calypso.localhost:3000/new?flags=gutenboarding/site-editor`.
* Skip the first step and make sure there is an "Ibis (FSE)" design to choose.
  - Note: there is no thumbnail at the moment.
* Select "Ibis (FSE)" and proceed to the next step.
* Make sure the preview uses the Ibis theme with the [Ibis starter content](https://ibisstarter.wordpress.com/).
  - Note: changing font pairings doesn't work.

Fixes #44769
