### PR TITLE
Jetpack Cloud: Require users to log in to reach /backup and /scan routes

### DIFF
--- a/client/sections.js
+++ b/client/sections.js
@@ -490,7 +490,6 @@ const sections = [
 		module: 'wp-calypso-client/my-sites/backup',
 		secondary: true,
 		group: 'sites',
-		enableLoggedOut: true,
 	},
 	{
 		name: 'scan',
@@ -498,7 +497,6 @@ const sections = [
 		module: 'wp-calypso-client/my-sites/scan',
 		secondary: true,
 		group: 'sites',
-		enableLoggedOut: true,
 	},
 	{
 		name: 'jetpack-cloud',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove the `enabledLoggedOut` attribute from the `/backup` and `/scan` sections in Calypso, so that users are required to log in before seeing those pages.

Fixes `1164141197617539-as-1188931267678623`.

#### Testing instructions

NOTE: Because this pull request affects server code, you must restart any running instances of Calypso to test.

* From a private browsing window, attempt to access `calypso.localhost:3000/backup` and `calypso.localhost:3000/scan`.
* Verify that going to either route results in a redirect to the login page. (Previous behavior showed an empty site selector with no option to go elsewhere.)