### PR TITLE
Inline Help: Add e2e tests for inline help admin section

### DIFF
--- a/client/blocks/inline-help/inline-help-search-results.jsx
+++ b/client/blocks/inline-help/inline-help-search-results.jsx
@@ -186,6 +186,10 @@ function HelpSearchResults( {
 		} );
 	};
 
+	const resultsLabel = hasAPIResults
+		? translate( 'Search Results' )
+		: translate( 'Helpful resources for this section' );
+
 	const renderSearchResults = () => {
 		if ( isSearching && ! searchResults.length ) {
 			// search, but no results so far
@@ -202,7 +206,7 @@ function HelpSearchResults( {
 					</p>
 				) }
 
-				<div className="inline-help__results" aria-label={ translate( 'Search Results' ) }>
+				<div className="inline-help__results" aria-label={ resultsLabel }>
 					{ renderSearchSections( searchResults, searchQuery ) }
 				</div>
 			</>

--- a/test/e2e/lib/components/support-search-component.js
+++ b/test/e2e/lib/components/support-search-component.js
@@ -56,6 +56,10 @@ class SupportSearchComponent extends AsyncBaseContainer {
 		return results.length;
 	}
 
+	async waitForDefaultResultsNotToBePresent() {
+		return driverHelper.waitTillNotPresent( this.driver, defaultResultsSelectors );
+	}
+
 	async getErrorResults() {
 		return await this.driver.findElements( errorResultsSelectors );
 	}
@@ -63,6 +67,10 @@ class SupportSearchComponent extends AsyncBaseContainer {
 	async getErrorResultsCount() {
 		const results = await this.getErrorResults();
 		return results.length;
+	}
+
+	async waitForErrorResultsNotToBePresent() {
+		return driverHelper.waitTillNotPresent( this.driver, errorResultsSelectors );
 	}
 
 	async getSearchResults() {
@@ -74,6 +82,10 @@ class SupportSearchComponent extends AsyncBaseContainer {
 		return results.length;
 	}
 
+	async waitForSearchResultsNotToBePresent() {
+		return driverHelper.waitTillNotPresent( this.driver, searchResultsSelectors );
+	}
+
 	async getAdminSearchResults() {
 		return await this.driver.findElements( adminSearchResultsSelectors );
 	}
@@ -81,6 +93,10 @@ class SupportSearchComponent extends AsyncBaseContainer {
 	async getAdminSearchResultsCount() {
 		const results = await this.getAdminSearchResults();
 		return results.length;
+	}
+
+	async waitForAdminResultsNotToBePresent() {
+		return driverHelper.waitTillNotPresent( this.driver, adminSearchResultsSelectors );
 	}
 
 	async searchFor( query = '' ) {

--- a/test/e2e/lib/components/support-search-component.js
+++ b/test/e2e/lib/components/support-search-component.js
@@ -13,9 +13,11 @@ import * as driverHelper from '../driver-helper.js';
 const searchInputSelectors = By.css(
 	'.inline-help__search input[type="search"], .help-search__search input[type="search"]'
 );
-const searchResultsSelectors = By.css(
-	'.inline-help__results-list .inline-help__results-item, .help-search__results-list .help-search__results-item'
+const defaultResultsSelectors = By.css(
+	'.inline-help__results-list li, .help-search__results-list li'
 );
+const searchResultsSelectors = By.css( '[aria-labelledby="inline-search--api_help"] li' );
+const adminSearchResultsSelectors = By.css( '[aria-labelledby="inline-search--admin_section"] li' );
 
 class SupportSearchComponent extends AsyncBaseContainer {
 	constructor( driver ) {
@@ -42,12 +44,30 @@ class SupportSearchComponent extends AsyncBaseContainer {
 		);
 	}
 
+	async getDefaultResults() {
+		return await this.driver.findElements( defaultResultsSelectors );
+	}
+
+	async getDefaultResultsCount() {
+		const results = await this.getDefaultResults();
+		return results.length;
+	}
+
 	async getSearchResults() {
 		return await this.driver.findElements( searchResultsSelectors );
 	}
 
 	async getSearchResultsCount() {
 		const results = await this.getSearchResults();
+		return results.length;
+	}
+
+	async getAdminSearchResults() {
+		return await this.driver.findElements( adminSearchResultsSelectors );
+	}
+
+	async getAdminSearchResultsCount() {
+		const results = await this.getAdminSearchResults();
 		return results.length;
 	}
 

--- a/test/e2e/lib/components/support-search-component.js
+++ b/test/e2e/lib/components/support-search-component.js
@@ -13,11 +13,14 @@ import * as driverHelper from '../driver-helper.js';
 const searchInputSelectors = By.css(
 	'.inline-help__search input[type="search"], .help-search__search input[type="search"]'
 );
+// A little confusing, but this is specific to the default results and _not_ including the errored results (which are the same results).
+// We're checking for the aria-label is set correctly and that the title for the error section is not present.
 const defaultResultsSelectors = By.css(
-	'.inline-help__results-list li, .help-search__results-list li'
+	'[aria-label="Helpful resources for this section"] ul:not([aria-labelledby="inline-search--contextual_help"]) li'
 );
 const searchResultsSelectors = By.css( '[aria-labelledby="inline-search--api_help"] li' );
 const adminSearchResultsSelectors = By.css( '[aria-labelledby="inline-search--admin_section"] li' );
+const errorResultsSelectors = By.css( '[aria-labelledby="inline-search--contextual_help"] li' );
 
 class SupportSearchComponent extends AsyncBaseContainer {
 	constructor( driver ) {
@@ -50,6 +53,15 @@ class SupportSearchComponent extends AsyncBaseContainer {
 
 	async getDefaultResultsCount() {
 		const results = await this.getDefaultResults();
+		return results.length;
+	}
+
+	async getErrorResults() {
+		return await this.driver.findElements( errorResultsSelectors );
+	}
+
+	async getErrorResultsCount() {
+		const results = await this.getErrorResults();
 		return results.length;
 	}
 

--- a/test/e2e/specs/wp-inline-help-support-search-spec.js
+++ b/test/e2e/specs/wp-inline-help-support-search-spec.js
@@ -43,20 +43,15 @@ describe( `[${ host }] Inline Help: (${ screenSize }) @parallel`, async function
 
 	describe( 'Popover UI visibility', function () {
 		step( 'Check help toggle is not visible on My Home page', async function () {
+			const sidebarComponent = await SidebarComponent.Expect( driver );
+			await sidebarComponent.selectMyHome();
+
 			// The toggle only hides once the "Get help" card is rendered so
 			// we need to give it a little time to be removed.
 			await inlineHelpPopoverComponent.waitForToggleNotToBePresent();
-
-			// Once removed we can assert is is invisible.
-			const isToggleVisible = await inlineHelpPopoverComponent.isToggleVisible();
-			assert.equal(
-				isToggleVisible,
-				false,
-				'Inline Help support search was not correctly hidden on Home page.'
-			);
 		} );
 
-		step( 'Switch to non My Home page', async function () {
+		step( 'Check help toggle is visible on Theme page', async function () {
 			const sidebarComponent = await SidebarComponent.Expect( driver );
 
 			// The "inline help" FAB should not appear on the My Home
@@ -65,10 +60,14 @@ describe( `[${ host }] Inline Help: (${ screenSize }) @parallel`, async function
 			// and then we will switch away to the Homepage to verify
 			// that the Inline Help is not shown
 			await sidebarComponent.selectThemes();
-		} );
 
-		step( 'Check help toggle is visible on non My Home page', async function () {
-			await inlineHelpPopoverComponent.isToggleVisible();
+			// Once removed we can assert is is invisible.
+			const isToggleVisible = await inlineHelpPopoverComponent.isToggleVisible();
+			assert.equal(
+				isToggleVisible,
+				true,
+				'Inline Help support search was not shown on Theme page.'
+			);
 		} );
 	} );
 

--- a/test/e2e/specs/wp-inline-help-support-search-spec.js
+++ b/test/e2e/specs/wp-inline-help-support-search-spec.js
@@ -40,7 +40,6 @@ describe( `[${ host }] Inline Help support search: (${ screenSize }) @parallel`,
 		await loginFlow.loginAndSelectSettings();
 
 		// Initialize the helper component
-
 		inlineHelpPopoverComponent = await InlineHelpPopoverComponent.Expect( driver );
 	} );
 
@@ -70,7 +69,7 @@ describe( `[${ host }] Inline Help support search: (${ screenSize }) @parallel`,
 		} );
 
 		step( 'Displays contextual search results by default', async function () {
-			const resultsCount = await supportSearchComponent.getSearchResultsCount();
+			const resultsCount = await supportSearchComponent.getDefaultResultsCount();
 			assert.equal( resultsCount, 5, 'There are no contextual results displayed' );
 		} );
 
@@ -81,19 +80,19 @@ describe( `[${ host }] Inline Help support search: (${ screenSize }) @parallel`,
 			assert.equal(
 				resultsCount <= 5,
 				true,
-				`Too many search results displayed. Should be less than or equal to 5 (was ${ resultsCount }).`
+				`Too many search results displayed. Should be less than or equal to 5.`
 			);
 			assert.equal(
 				resultsCount >= 1,
 				true,
-				`Too few search results displayed. Should be more than or equal to 1 (was ${ resultsCount }).`
+				`Too few search results displayed. Should be more than or equal to 1.`
 			);
 		} );
 
 		step( 'Resets search UI to default state when search input is cleared ', async function () {
 			await supportSearchComponent.clearSearchField();
 
-			const resultsCount = await supportSearchComponent.getSearchResultsCount();
+			const resultsCount = await supportSearchComponent.getDefaultResultsCount();
 
 			assert.equal( resultsCount, 5, 'There are no contextual results displayed' );
 		} );
@@ -104,7 +103,7 @@ describe( `[${ host }] Inline Help support search: (${ screenSize }) @parallel`,
 				const invalidSearchQueryReturningNoResults = ';;;ppp;;;';
 
 				await supportSearchComponent.searchFor( invalidSearchQueryReturningNoResults );
-				const resultsCount = await supportSearchComponent.getSearchResultsCount();
+				const resultsCount = await supportSearchComponent.getDefaultResultsCount();
 
 				const hasNoResultsMessage = await supportSearchComponent.hasNoResultsMessage();
 

--- a/test/e2e/specs/wp-inline-help-support-search-spec.js
+++ b/test/e2e/specs/wp-inline-help-support-search-spec.js
@@ -36,8 +36,8 @@ describe( `[${ host }] Inline Help support search: (${ screenSize }) @parallel`,
 
 		// The "inline help" FAB should not appear on the My Home
 		// because there is already a support search "Card" on that
-		// page. Therefore we select the "Themes" page for our tests.
-		await loginFlow.loginAndSelectThemes();
+		// page. Therefore we select the "Settings" page for our tests.
+		await loginFlow.loginAndSelectSettings();
 
 		// Initialize the helper component
 

--- a/test/e2e/specs/wp-inline-help-support-search-spec.js
+++ b/test/e2e/specs/wp-inline-help-support-search-spec.js
@@ -112,7 +112,7 @@ describe( `[${ host }] Inline Help: (${ screenSize }) @parallel`, async function
 				const invalidSearchQueryReturningNoResults = ';;;ppp;;;';
 
 				await supportSearchComponent.searchFor( invalidSearchQueryReturningNoResults );
-				const resultsCount = await supportSearchComponent.getDefaultResultsCount();
+				const resultsCount = await supportSearchComponent.getErrorResultsCount();
 
 				const hasNoResultsMessage = await supportSearchComponent.hasNoResultsMessage();
 

--- a/test/e2e/specs/wp-inline-help-support-search-spec.js
+++ b/test/e2e/specs/wp-inline-help-support-search-spec.js
@@ -56,9 +56,9 @@ describe( `[${ host }] Inline Help: (${ screenSize }) @parallel`, async function
 
 			// The "inline help" FAB should not appear on the My Home
 			// because there is already a support search "Card" on that
-			// page. Therefore we select the "Themes" page for our tests
-			// and then we will switch away to the Homepage to verify
-			// that the Inline Help is not shown
+			// page. Any other non-home page should show the FAB. There
+			// is nothing special about Themes page other than it's not
+			// the `/home` route :)
 			await sidebarComponent.selectThemes();
 
 			// Once removed we can assert is is invisible.

--- a/test/e2e/specs/wp-my-home-support-search-spec.js
+++ b/test/e2e/specs/wp-my-home-support-search-spec.js
@@ -14,6 +14,8 @@ import * as driverHelper from '../lib/driver-helper.js';
 import LoginFlow from '../lib/flows/login-flow.js';
 import * as dataHelper from '../lib/data-helper';
 import SupportSearchComponent from '../lib/components/support-search-component';
+import SidebarComponent from '../lib/components/sidebar-component';
+
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
 const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
@@ -35,9 +37,12 @@ describe( `[${ host }] My Home "Get help" support search card: (${ screenSize })
 	step( 'Login and select a non My Home page', async function () {
 		const loginFlow = new LoginFlow( driver );
 
+		await loginFlow.loginAndSelectMySite();
+
 		// The "/home" route is the only one this support search
 		// "Card" will show on
-		await loginFlow.loginAndSelectMySite();
+		const sidebarComponent = await SidebarComponent.Expect( driver );
+		await sidebarComponent.selectMyHome();
 	} );
 
 	step( 'Verify "Get help" support card is displayed', async function () {
@@ -92,7 +97,7 @@ describe( `[${ host }] My Home "Get help" support search card: (${ screenSize })
 			const invalidSearchQueryReturningNoResults = ';;;ppp;;;';
 
 			await supportSearchComponent.searchFor( invalidSearchQueryReturningNoResults );
-			const resultsCount = await supportSearchComponent.getDefaultResultsCount();
+			const resultsCount = await supportSearchComponent.getErrorResultsCount();
 
 			const hasNoResultsMessage = await supportSearchComponent.hasNoResultsMessage();
 

--- a/test/e2e/specs/wp-my-home-support-search-spec.js
+++ b/test/e2e/specs/wp-my-home-support-search-spec.js
@@ -61,13 +61,13 @@ describe( `[${ host }] My Home "Get help" support search card: (${ screenSize })
 		);
 	} );
 
-	step( 'Displays contextual search results by default', async function () {
+	step( 'Displays Default Results initially', async function () {
 		supportSearchComponent = await SupportSearchComponent.Expect( driver );
 		const resultsCount = await supportSearchComponent.getDefaultResultsCount();
-		assert.equal( resultsCount, 5, 'The default results are displayed' );
+		assert.equal( resultsCount, 5, 'There are not 5 Default Results displayed.' );
 	} );
 
-	step( 'Returns search results for valid search query', async function () {
+	step( 'Returns API Search Results for valid search query', async function () {
 		await supportSearchComponent.searchFor( 'Domain' );
 
 		const searchResultsCount = await supportSearchComponent.getSearchResultsCount();
@@ -76,31 +76,35 @@ describe( `[${ host }] My Home "Get help" support search card: (${ screenSize })
 
 		const defaultResults = await supportSearchComponent.waitForDefaultResultsNotToBePresent();
 
-		assert.equal( defaultResults, true, 'The default results are not displayed.' );
+		assert.equal(
+			defaultResults,
+			true,
+			'The Default Results are displayed. They should not be present after we have API Search Results.'
+		);
 
 		assert.equal(
 			searchResultsCount <= 5,
 			true,
-			`Too many search results displayed. Should be less than or equal to 5.`
+			`Too many API Search Results displayed. Should be less than or equal to 5.`
 		);
 		assert.equal(
 			searchResultsCount >= 1,
 			true,
-			`Too few search results displayed. Should be more than or equal to 1.`
+			`Too few API Search Results displayed. Should be more than or equal to 1.`
 		);
 		assert.equal(
 			adminResultsCount <= 3,
 			true,
-			`Too many admin results displayed. Should be less than or equal to 3.`
+			`Too many Admin Results displayed. Should be less than or equal to 3.`
 		);
 		assert.equal(
 			adminResultsCount >= 1,
 			true,
-			`Too few admin results displayed. Should be more than or equal to 1.`
+			`Too few Admin Results displayed. Should be more than or equal to 1.`
 		);
 	} );
 
-	step( 'Resets search UI to default state when search input is cleared ', async function () {
+	step( 'Resets search UI to default state when search input is cleared', async function () {
 		await supportSearchComponent.clearSearchField();
 
 		const searchResults = await supportSearchComponent.waitForSearchResultsNotToBePresent();
@@ -113,7 +117,7 @@ describe( `[${ host }] My Home "Get help" support search card: (${ screenSize })
 
 		assert.equal( adminResults, true, 'The Admin Results are not displayed.' );
 
-		assert.equal( defaultResultsCount, 5, 'The default results displayed' );
+		assert.equal( defaultResultsCount, 5, 'The 5 Default Results are not displayed.' );
 	} );
 
 	step(
@@ -133,7 +137,7 @@ describe( `[${ host }] My Home "Get help" support search card: (${ screenSize })
 
 			assert.equal( hasNoResultsMessage, true, 'The "No results" message was not displayed.' );
 
-			assert.equal( resultsCount, 5, 'The default error results are displayed.' );
+			assert.equal( resultsCount, 5, 'The 5 default Error Results are not displayed.' );
 		}
 	);
 
@@ -144,12 +148,12 @@ describe( `[${ host }] My Home "Get help" support search card: (${ screenSize })
 
 		const resultsCount = await supportSearchComponent.getDefaultResultsCount();
 
-		assert.equal( errorResults, true, 'The default error results are not displayed.' );
+		assert.equal( errorResults, true, 'The default Error Results are not displayed.' );
 
-		assert.equal( resultsCount, 5, 'The default results are displayed' );
+		assert.equal( resultsCount, 5, 'The 5 Default Results are not displayed.' );
 	} );
 
-	step( 'Does not request search results for empty search queries', async function () {
+	step( 'Does not request API Search Results for empty search queries', async function () {
 		const emptyWhitespaceQuery = '         ';
 
 		await supportSearchComponent.searchFor( emptyWhitespaceQuery );

--- a/test/e2e/specs/wp-my-home-support-search-spec.js
+++ b/test/e2e/specs/wp-my-home-support-search-spec.js
@@ -64,31 +64,56 @@ describe( `[${ host }] My Home "Get help" support search card: (${ screenSize })
 	step( 'Displays contextual search results by default', async function () {
 		supportSearchComponent = await SupportSearchComponent.Expect( driver );
 		const resultsCount = await supportSearchComponent.getDefaultResultsCount();
-		assert.equal( resultsCount, 5, 'There are no contextual results displayed' );
+		assert.equal( resultsCount, 5, 'The default results are displayed' );
 	} );
 
 	step( 'Returns search results for valid search query', async function () {
 		await supportSearchComponent.searchFor( 'Domain' );
-		const resultsCount = await supportSearchComponent.getSearchResultsCount();
+
+		const searchResultsCount = await supportSearchComponent.getSearchResultsCount();
+
+		const adminResultsCount = await supportSearchComponent.getAdminSearchResultsCount();
+
+		const defaultResults = await supportSearchComponent.waitForDefaultResultsNotToBePresent();
+
+		assert.equal( defaultResults, true, 'The default results are not displayed.' );
 
 		assert.equal(
-			resultsCount <= 5,
+			searchResultsCount <= 5,
 			true,
 			`Too many search results displayed. Should be less than or equal to 5.`
 		);
 		assert.equal(
-			resultsCount >= 1,
+			searchResultsCount >= 1,
 			true,
 			`Too few search results displayed. Should be more than or equal to 1.`
+		);
+		assert.equal(
+			adminResultsCount <= 3,
+			true,
+			`Too many admin results displayed. Should be less than or equal to 3.`
+		);
+		assert.equal(
+			adminResultsCount >= 1,
+			true,
+			`Too few admin results displayed. Should be more than or equal to 1.`
 		);
 	} );
 
 	step( 'Resets search UI to default state when search input is cleared ', async function () {
 		await supportSearchComponent.clearSearchField();
 
-		const resultsCount = await supportSearchComponent.getDefaultResultsCount();
+		const searchResults = await supportSearchComponent.waitForSearchResultsNotToBePresent();
 
-		assert.equal( resultsCount, 5, 'There are no contextual results displayed' );
+		const adminResults = await supportSearchComponent.waitForAdminResultsNotToBePresent();
+
+		const defaultResultsCount = await supportSearchComponent.getDefaultResultsCount();
+
+		assert.equal( searchResults, true, 'The API Search Results are not displayed.' );
+
+		assert.equal( adminResults, true, 'The Admin Results are not displayed.' );
+
+		assert.equal( defaultResultsCount, 5, 'The default results displayed' );
 	} );
 
 	step(
@@ -97,19 +122,34 @@ describe( `[${ host }] My Home "Get help" support search card: (${ screenSize })
 			const invalidSearchQueryReturningNoResults = ';;;ppp;;;';
 
 			await supportSearchComponent.searchFor( invalidSearchQueryReturningNoResults );
+
+			const searchResults = await supportSearchComponent.waitForSearchResultsNotToBePresent();
+
 			const resultsCount = await supportSearchComponent.getErrorResultsCount();
 
 			const hasNoResultsMessage = await supportSearchComponent.hasNoResultsMessage();
 
+			assert.equal( searchResults, true, 'The API Search Results are not displayed.' );
+
 			assert.equal( hasNoResultsMessage, true, 'The "No results" message was not displayed.' );
 
-			assert.equal( resultsCount, 5, 'There are no contextual results displayed.' );
+			assert.equal( resultsCount, 5, 'The default error results are displayed.' );
 		}
 	);
 
-	step( 'Does not request search results for empty search queries', async function () {
+	step( 'Clearing search resets to default state', async function () {
 		await supportSearchComponent.clearSearchField();
 
+		const errorResults = await supportSearchComponent.waitForErrorResultsNotToBePresent();
+
+		const resultsCount = await supportSearchComponent.getDefaultResultsCount();
+
+		assert.equal( errorResults, true, 'The default error results are not displayed.' );
+
+		assert.equal( resultsCount, 5, 'The default results are displayed' );
+	} );
+
+	step( 'Does not request search results for empty search queries', async function () {
 		const emptyWhitespaceQuery = '         ';
 
 		await supportSearchComponent.searchFor( emptyWhitespaceQuery );


### PR DESCRIPTION
When we added the [admin section search results](https://github.com/Automattic/wp-calypso/pull/43862), we didn't update the e2e tests to account for them. This PR checks for the admin search results section as well as adds more assertions over what should and not be present at different times.

 
#### Changes proposed in this Pull Request
- [ ] ~~The test for the "No results" message needs to assert on the text content not the CSS selector. This will be more consistent with what a user sees.~~ I'm relying on the CSS selector for now.
- [x] Assert on the presence of the two sections `Support articles` and `Show me where to`.
- [x] Assert on the presence of admin links in search results.
- [x] Assert on variations and combinations of support links and admins links being shown or not shown.
- [x] Improve selectors in the `SupportSearchComponent` to prefer selecting by `aria-role` or text instead of CSS selector. This will make them more in line with what a user perceives rather than testing the implementation details.
- [x] Changes the `aria-label` on the no-search state to be `Helpful resources for this section` instead of `Search Results`. It becomes `Search Results` only if a search has API results.


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* Boot Calypso from the project root `yarn && yarn start`.
* Set-up e2e testing for Calypso
* `cd test/e2e`
* `yarn`
* `./node_modules/.bin/mocha specs/wp-inline-help-support-search-spec.js` <-- All should pass
* `./node_modules/.bin/mocha specs/wp-my-home-support-search-spec.js`<--- All should pass

* Manual for the `aria-label`: Go to https://calypso.live/?branch=add/admin-search-e2e
* Click "My Home"
* Inspect the search card component "results" and see the `aria-label` for the results says `Helpful resources for this section`.
* Perform a search with results, like "Domain"
* The `aria-label` should now be "Search results"
* Search for something that will not return results, like "lkjakdfjasdf"
* The `aria-label` for the results should be `Helpful resources for this section` again.

Fixes https://github.com/Automattic/wp-calypso/issues/44169
