### PR TITLE
Checkout: Fix store actions for fields in ebanx-tef payment method

### DIFF
--- a/client/my-sites/checkout/composite-checkout/payment-methods/ebanx-tef.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/ebanx-tef.js
@@ -90,7 +90,7 @@ export function createEbanxTefPaymentMethodStore() {
 							[ action.payload.key ]: {
 								value: maskField(
 									action.payload.key,
-									state[ action.payload.key ],
+									state.fields[ action.payload.key ],
 									action.payload.value
 								),
 								isTouched: true,
@@ -104,7 +104,7 @@ export function createEbanxTefPaymentMethodStore() {
 						fields: {
 							...state.fields,
 							[ action.payload.key ]: {
-								...state[ action.payload.key ],
+								...state.fields[ action.payload.key ],
 								errors: [ action.payload.message ],
 							},
 						},
@@ -112,13 +112,16 @@ export function createEbanxTefPaymentMethodStore() {
 				case 'TOUCH_ALL_FIELDS':
 					return {
 						...state,
-						fields: Object.entries( state.fields ).reduce( ( obj, [ key, value ] ) => {
-							obj[ key ] = {
-								value: value.value,
-								isTouched: true,
-							};
-							return obj;
-						}, {} ),
+						fields: Object.keys( state.fields ).reduce(
+							( obj, key ) => ( {
+								...obj,
+								[ key ]: {
+									...state.fields[ key ],
+									isTouched: true,
+								},
+							} ),
+							{}
+						),
 					};
 			}
 			return state;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This fixes a bug in the Ebanx-TEF payment method store where masking and setting errors on fields would probably not work some of the time.

This store code was copied from a location where multiple reducers were merged together for different parts of the state, but in this store, there is only one reducer so every time we access the `state.fields` subtree, we need to be sure to do so explicitly. Instead, the data was sometimes being accessed as `state[key]` instead of `state.fields[key]`. This was probably easy to miss because it only happens for masking and for errors.

This PR also prevents `TOUCH_ALL_FIELDS` from erasing error messages.

#### Testing instructions

Follow the testing instructions in #44752 