### PR TITLE
Shuffle the list of available site designs during gutenboarding to prevent bias in user design selection

### DIFF
--- a/client/landing/gutenboarding/available-designs.ts
+++ b/client/landing/gutenboarding/available-designs.ts
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { addQueryArgs } from '@wordpress/url';
-import { shuffle } from 'lodash';
 
 /**
  * Internal dependencies
@@ -75,9 +74,7 @@ export function getAvailableDesigns(
 	includeAlphaDesigns: boolean = isEnabled( 'gutenboarding/alpha-templates' ),
 	useFseDesigns: boolean = isEnabled( 'gutenboarding/site-editor' )
 ) {
-	// Randomize the list of designs to prevent bias in user selection
-	let designs = { ...availableDesigns, featured: shuffle( availableDesigns.featured ) };
-
+	let designs = availableDesigns;
 	if ( ! includeAlphaDesigns ) {
 		designs = {
 			...designs,

--- a/client/landing/gutenboarding/available-designs.ts
+++ b/client/landing/gutenboarding/available-designs.ts
@@ -75,6 +75,7 @@ export function getAvailableDesigns(
 	useFseDesigns: boolean = isEnabled( 'gutenboarding/site-editor' )
 ) {
 	let designs = availableDesigns;
+
 	if ( ! includeAlphaDesigns ) {
 		designs = {
 			...designs,

--- a/client/landing/gutenboarding/available-designs.ts
+++ b/client/landing/gutenboarding/available-designs.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { addQueryArgs } from '@wordpress/url';
+import { shuffle } from 'lodash';
 
 /**
  * Internal dependencies
@@ -74,7 +75,8 @@ export function getAvailableDesigns(
 	includeAlphaDesigns: boolean = isEnabled( 'gutenboarding/alpha-templates' ),
 	useFseDesigns: boolean = isEnabled( 'gutenboarding/site-editor' )
 ) {
-	let designs = availableDesigns;
+	// Randomize the list of designs to prevent bias in user selection
+	let designs = { ...availableDesigns, featured: shuffle( availableDesigns.featured ) };
 
 	if ( ! includeAlphaDesigns ) {
 		designs = {

--- a/client/landing/gutenboarding/index.tsx
+++ b/client/landing/gutenboarding/index.tsx
@@ -9,6 +9,7 @@ import config from '../../config';
 import { subscribe, select, dispatch } from '@wordpress/data';
 import { initializeAnalytics } from '@automattic/calypso-analytics';
 import type { Site as SiteStore } from '@automattic/data-stores';
+import { xorWith, isEqual, isEmpty, shuffle } from 'lodash';
 
 /**
  * Internal dependencies
@@ -17,11 +18,13 @@ import Gutenboard from './gutenboard';
 import { LocaleContext } from './components/locale-context';
 import { setupWpDataDebug } from './devtools';
 import accessibleFocus from 'lib/accessible-focus';
+import availableDesigns from './available-designs';
 import { Step, path } from './path';
 import { SITE_STORE } from './stores/site';
 import { STORE_KEY as ONBOARD_STORE } from './stores/onboard';
 import { addHotJarScript } from 'lib/analytics/hotjar';
 import { WindowLocaleEffectManager } from './components/window-locale-effect-manager';
+import type { Design } from './stores/onboard/types';
 
 /**
  * Style dependencies
@@ -74,6 +77,9 @@ window.AppBoot = async () => {
 	try {
 		checkAndRedirectIfSiteWasCreatedRecently();
 	} catch {}
+
+	// Update list of randomized designs in the gutenboarding session store
+	checkIfRandomizedDesignsAreUpToDate();
 
 	ReactDom.render(
 		<LocaleContext>
@@ -143,4 +149,29 @@ function waitForSelectedSite(): Promise< Site | undefined > {
 		} );
 		select( SITE_STORE ).getSite( selectedSite );
 	} ).finally( unsubscribe );
+}
+/**
+ * If available-designs-config.json has been updated, replace the cached list
+ * of designs with the updated designs
+ */
+function checkIfRandomizedDesignsAreUpToDate() {
+	const designsInStore = select( ONBOARD_STORE ).getRandomizedDesigns();
+	if ( ! isUpToDate( designsInStore.featured, availableDesigns.featured ) ) {
+		dispatch( ONBOARD_STORE ).setRandomizedDesigns( {
+			...availableDesigns,
+			featured: shuffle( availableDesigns.featured ),
+		} );
+	}
+}
+
+/**
+ *
+ * Compare cached designs in the ONBOARD_STORE to the source of designs in
+ * available-designs-config.json
+ *
+ * @param stored randomizedDesigns cached in WP_ONBOARD
+ * @param available designs sourced from available-designs-config.json
+ */
+function isUpToDate( stored: Design[], available: Design[] ): boolean {
+	return isEmpty( xorWith( stored, available, isEqual ) );
 }

--- a/client/landing/gutenboarding/index.tsx
+++ b/client/landing/gutenboarding/index.tsx
@@ -79,7 +79,7 @@ window.AppBoot = async () => {
 	} catch {}
 
 	// Update list of randomized designs in the gutenboarding session store
-	checkIfRandomizedDesignsAreUpToDate();
+	ensureRandomizedDesignsAreUpToDate();
 
 	ReactDom.render(
 		<LocaleContext>
@@ -154,9 +154,9 @@ function waitForSelectedSite(): Promise< Site | undefined > {
  * If available-designs-config.json has been updated, replace the cached list
  * of designs with the updated designs
  */
-function checkIfRandomizedDesignsAreUpToDate() {
+function ensureRandomizedDesignsAreUpToDate() {
 	const designsInStore = select( ONBOARD_STORE ).getRandomizedDesigns();
-	if ( ! isUpToDate( designsInStore.featured, availableDesigns.featured ) ) {
+	if ( ! isDeepEqual( designsInStore.featured, availableDesigns.featured ) ) {
 		dispatch( ONBOARD_STORE ).setRandomizedDesigns( {
 			...availableDesigns,
 			featured: shuffle( availableDesigns.featured ),
@@ -172,6 +172,6 @@ function checkIfRandomizedDesignsAreUpToDate() {
  * @param stored randomizedDesigns cached in WP_ONBOARD
  * @param available designs sourced from available-designs-config.json
  */
-function isUpToDate( stored: Design[], available: Design[] ): boolean {
+function isDeepEqual( stored: Design[], available: Design[] ): boolean {
 	return isEmpty( xorWith( stored, available, isEqual ) );
 }

--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -15,7 +15,7 @@ import { STORE_KEY as ONBOARD_STORE } from '../../stores/onboard';
 import { useTrackStep } from '../../hooks/use-track-step';
 import useStepNavigation from '../../hooks/use-step-navigation';
 import Badge from '../../components/badge';
-import designs, { getDesignImageUrl } from '../../available-designs';
+import { getDesignImageUrl } from '../../available-designs';
 import JetpackLogo from 'components/jetpack-logo'; // @TODO: extract to @automattic package
 import type { Design } from '../../stores/onboard/types';
 
@@ -31,7 +31,9 @@ const DesignSelector: React.FunctionComponent = () => {
 	const { goBack, goNext } = useStepNavigation();
 
 	const { setSelectedDesign, setFonts } = useDispatch( ONBOARD_STORE );
-	const { getSelectedDesign, hasPaidDesign } = useSelect( ( select ) => select( ONBOARD_STORE ) );
+	const { getSelectedDesign, hasPaidDesign, getRandomizedDesigns } = useSelect( ( select ) =>
+		select( ONBOARD_STORE )
+	);
 
 	useTrackStep( 'DesignSelection', () => ( {
 		selected_design: getSelectedDesign()?.slug,
@@ -53,7 +55,7 @@ const DesignSelector: React.FunctionComponent = () => {
 			</div>
 			<div className="design-selector__design-grid">
 				<div className="design-selector__grid">
-					{ designs.featured.map( ( design ) => (
+					{ getRandomizedDesigns().featured.map( ( design ) => (
 						<button
 							key={ design.slug }
 							className="design-selector__design-option"

--- a/client/landing/gutenboarding/onboarding-block/style-preview/font-select.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/font-select.tsx
@@ -14,19 +14,20 @@ import { useI18n } from '@automattic/react-i18n';
  */
 import { fontPairings, getFontTitle, FontPair } from '../../constants';
 import { STORE_KEY } from '../../stores/onboard';
-import designs from '../../available-designs';
+import type { Design } from '../../stores/onboard/types';
 
 const FontSelect: React.FunctionComponent = () => {
 	const { __ } = useI18n();
 	const { selectedDesign, selectedFonts } = useSelect( ( select ) =>
 		select( STORE_KEY ).getState()
 	);
+	const { getRandomizedDesigns } = useSelect( ( select ) => select( STORE_KEY ) );
 	const { setFonts } = useDispatch( STORE_KEY );
 	const [ isOpen, setIsOpen ] = React.useState( false );
 
 	// TODO: Add font loading for unknown fonts
-	const selectedDesignDefaultFonts = designs.featured.find(
-		( design ) => design.slug === selectedDesign?.slug
+	const selectedDesignDefaultFonts = getRandomizedDesigns().featured.find(
+		( design: Design ) => design.slug === selectedDesign?.slug
 	)?.fonts;
 
 	const defaultFontOption = selectedDesignDefaultFonts ? (

--- a/client/landing/gutenboarding/onboarding-block/style-preview/font-select.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/font-select.tsx
@@ -13,16 +13,16 @@ import { useI18n } from '@automattic/react-i18n';
  * Internal dependencies
  */
 import { fontPairings, getFontTitle, FontPair } from '../../constants';
-import { STORE_KEY } from '../../stores/onboard';
+import { STORE_KEY as ONBOARD_STORE } from '../../stores/onboard';
 import type { Design } from '../../stores/onboard/types';
 
 const FontSelect: React.FunctionComponent = () => {
 	const { __ } = useI18n();
 	const { selectedDesign, selectedFonts } = useSelect( ( select ) =>
-		select( STORE_KEY ).getState()
+		select( ONBOARD_STORE ).getState()
 	);
-	const { getRandomizedDesigns } = useSelect( ( select ) => select( STORE_KEY ) );
-	const { setFonts } = useDispatch( STORE_KEY );
+	const { getRandomizedDesigns } = useSelect( ( select ) => select( ONBOARD_STORE ) );
+	const { setFonts } = useDispatch( ONBOARD_STORE );
 	const [ isOpen, setIsOpen ] = React.useState( false );
 
 	// TODO: Add font loading for unknown fonts

--- a/client/landing/gutenboarding/onboarding-block/style-preview/font-select.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/font-select.tsx
@@ -14,7 +14,6 @@ import { useI18n } from '@automattic/react-i18n';
  */
 import { fontPairings, getFontTitle, FontPair } from '../../constants';
 import { STORE_KEY as ONBOARD_STORE } from '../../stores/onboard';
-import type { Design } from '../../stores/onboard/types';
 
 const FontSelect: React.FunctionComponent = () => {
 	const { __ } = useI18n();
@@ -27,7 +26,7 @@ const FontSelect: React.FunctionComponent = () => {
 
 	// TODO: Add font loading for unknown fonts
 	const selectedDesignDefaultFonts = getRandomizedDesigns().featured.find(
-		( design: Design ) => design.slug === selectedDesign?.slug
+		( design ) => design.slug === selectedDesign?.slug
 	)?.fonts;
 
 	const defaultFontOption = selectedDesignDefaultFonts ? (

--- a/client/landing/gutenboarding/stores/onboard/actions.ts
+++ b/client/landing/gutenboarding/stores/onboard/actions.ts
@@ -184,6 +184,11 @@ export const enableExperimental = () => ( {
 	type: 'SET_ENABLE_EXPERIMENTAL' as const,
 } );
 
+export const setRandomizedDesigns = ( randomizedDesigns: { featured: Design[] } ) => ( {
+	type: 'SET_RANDOMIZED_DESIGNS' as const,
+	randomizedDesigns,
+} );
+
 export type OnboardAction = ReturnType<
 	| typeof resetFonts
 	| typeof resetOnboardStore
@@ -206,4 +211,5 @@ export type OnboardAction = ReturnType<
 	| typeof addFeature
 	| typeof removeFeature
 	| typeof enableExperimental
+	| typeof setRandomizedDesigns
 >;

--- a/client/landing/gutenboarding/stores/onboard/index.ts
+++ b/client/landing/gutenboarding/stores/onboard/index.ts
@@ -39,6 +39,7 @@ registerStore< State >( STORE_KEY, {
 		'selectedFeatures',
 		'plan',
 		'isExperimental',
+		'randomizedDesigns',
 	],
 } );
 

--- a/client/landing/gutenboarding/stores/onboard/reducer.ts
+++ b/client/landing/gutenboarding/stores/onboard/reducer.ts
@@ -211,6 +211,19 @@ const isExperimental: Reducer< boolean, OnboardAction > = (
 	return state;
 };
 
+const randomizedDesigns: Reducer< { featured: Design[] }, OnboardAction > = (
+	state = { featured: [] },
+	action
+) => {
+	if ( action.type === 'SET_RANDOMIZED_DESIGNS' ) {
+		return action.randomizedDesigns;
+	}
+	if ( action.type === 'RESET_ONBOARD_STORE' ) {
+		return { featured: [] };
+	}
+	return state;
+};
+
 const reducer = combineReducers( {
 	domain,
 	domainSearch,
@@ -229,6 +242,7 @@ const reducer = combineReducers( {
 	selectedFeatures,
 	wasVerticalSkipped,
 	isExperimental,
+	randomizedDesigns,
 } );
 
 export type State = ReturnType< typeof reducer >;

--- a/client/landing/gutenboarding/stores/onboard/selectors.ts
+++ b/client/landing/gutenboarding/stores/onboard/selectors.ts
@@ -29,3 +29,4 @@ export const getDomainSearch = ( state: State ) =>
 export const getPlan = ( state: State ) => state.plan;
 export const getSelectedFeatures = ( state: State ) => state.selectedFeatures;
 export const wasVerticalSkipped = ( state: State ): boolean => state.wasVerticalSkipped;
+export const getRandomizedDesigns = ( state: State ) => state.randomizedDesigns;


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Randomize the list of available designs during gutenboarding /new/design step
* Persist the `randomizedDesigns` array in localStorage to maintain the same order of designs during a user's gutenboarding session
* on boot, verify that the cached list of designs is up to date with designs in available-designs-config.json

### Testing instructions

* Go to /new , proceed through flow
* When you arrive at http://calypso.localhost:3000/new/design
  * note the oder of the designs
  * check the WP_ONBOARD store 
* Continue on through flow for a page or two
* Click Go back link to go back to /new/design
  * ensure that the design order is the same
* Refresh the page at /new/design
  * ensure that the design order is the same
* Clear the WP_OBOARD store
 * ensure that the design order is NOT the same, should be a new random order


### Fixes 
Issue  https://github.com/Automattic/wp-calypso/issues/44874

### Follow up
Follow up work noted in comment below https://github.com/Automattic/wp-calypso/pull/44979#issuecomment-678031264
