### PR TITLE
Format WP Stories on the reader and open in a new tab on click

### DIFF
--- a/client/components/embed-container/index.jsx
+++ b/client/components/embed-container/index.jsx
@@ -21,6 +21,7 @@ const embedsToLookFor = {
 	'fb\\:post, [class^=fb-]': embedFacebook,
 	'[class^=tumblr-]': embedTumblr,
 	'.jetpack-slideshow': embedSlideshow,
+	'.wp-block-jetpack-story': embedStory,
 	'.embed-reddit': embedReddit,
 };
 
@@ -196,6 +197,31 @@ function embedSlideshow( domNode ) {
 		loadjQueryDependentScriptDesktopWrapper( SLIDESHOW_URLS.CYCLE_JS, () => {
 			createSlideshow();
 		} );
+	}
+}
+
+function embedStory( domNode ) {
+	debug( 'processing story for ', domNode );
+
+	loadCSS(
+		`https://s0.wp.com/wp-content/mu-plugins/jetpack/_inc/blocks/story/view.css${ cacheBustQuery }`
+	);
+
+	const articleUrl = domNode
+		.closest( 'article.reader-full-post__story' )
+		.querySelector( '.reader-full-post__header a' ).href;
+	const storyButton = domNode.querySelector( 'div.wp-story-overlay.wp-story-clickable' );
+
+	if ( storyButton ) {
+		// replace button with hyperlink
+		const link = document.createElement( 'a' );
+		link.setAttribute( 'target', '_blank' );
+		link.className = storyButton.className;
+		const articleUrlObject = new URL( articleUrl );
+		articleUrlObject.searchParams.set( 'wp-story-load-in-fullscreen', 'true' );
+		link.href = articleUrlObject.href;
+		link.innerHTML = storyButton.innerHTML;
+		storyButton.parentNode.replaceChild( link, storyButton );
 	}
 }
 

--- a/client/components/embed-container/index.jsx
+++ b/client/components/embed-container/index.jsx
@@ -207,22 +207,15 @@ function embedStory( domNode ) {
 		`https://s0.wp.com/wp-content/mu-plugins/jetpack/_inc/blocks/story/view.css${ cacheBustQuery }`
 	);
 
-	const articleUrl = domNode
-		.closest( 'article.reader-full-post__story' )
-		.querySelector( '.reader-full-post__header a' ).href;
-	const storyButton = domNode.querySelector( 'div.wp-story-overlay.wp-story-clickable' );
+	const storyLink = domNode.querySelector( 'a.wp-story-overlay' );
 
-	if ( storyButton ) {
-		// replace button with hyperlink
-		const link = document.createElement( 'a' );
-		link.setAttribute( 'target', '_blank' );
-		link.className = storyButton.className;
-		const articleUrlObject = new URL( articleUrl );
-		articleUrlObject.searchParams.set( 'wp-story-load-in-fullscreen', 'true' );
-		articleUrlObject.searchParams.set( 'wp-story-play-on-load', 'true' );
-		link.href = articleUrlObject.href;
-		link.innerHTML = storyButton.innerHTML;
-		storyButton.parentNode.replaceChild( link, storyButton );
+	// open story in a new tab and play it automatically in fullscreen
+	if ( storyLink ) {
+		storyLink.setAttribute( 'target', '_blank' );
+		const storyLinkUrl = new URL( storyLink.href );
+		storyLinkUrl.searchParams.set( 'wp-story-load-in-fullscreen', 'true' );
+		storyLinkUrl.searchParams.set( 'wp-story-play-on-load', 'true' );
+		storyLink.href = storyLinkUrl.href;
 	}
 }
 

--- a/client/components/embed-container/index.jsx
+++ b/client/components/embed-container/index.jsx
@@ -219,6 +219,7 @@ function embedStory( domNode ) {
 		link.className = storyButton.className;
 		const articleUrlObject = new URL( articleUrl );
 		articleUrlObject.searchParams.set( 'wp-story-load-in-fullscreen', 'true' );
+		articleUrlObject.searchParams.set( 'wp-story-play-on-load', 'true' );
 		link.href = articleUrlObject.href;
 		link.innerHTML = storyButton.innerHTML;
 		storyButton.parentNode.replaceChild( link, storyButton );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds some formatting in the reader for full posts that contains a story.
It slightly modifies the story markup to make transform the story into a link and open a new tab so that you can play it from the user's site.

Importing the JS does not work as we depend too much on `@wordpress/*` dependencies. Rendering the story from an iframe an using preact are solutions that will be investigated in the future. 

![image](https://user-images.githubusercontent.com/230230/90501623-ec831880-e14c-11ea-8252-5a72b86699bd.png)

#### Testing instructions

Open the reader at http://calypso.localhost:3000/
Subscribe to a site that has stories. You can subscribe to http://dekervit.wpsandbox.me/
Open a story in full page, click on the embed, a new tab should open and the story should load in fullscreen.

