### PR TITLE
QueryManager: memoize result of getItems, based on items and itemKeys

### DIFF
--- a/client/lib/query-manager/index.js
+++ b/client/lib/query-manager/index.js
@@ -20,6 +20,41 @@ import QueryKey from './key';
  */
 export const DELETE_PATCH_KEY = '__DELETE';
 
+/*
+ * Construct an array of items from an array of keys and a map of key/item pairs.
+ * There is a two-level memoization cache for the `items` and `itemKeys` params.
+ * `itemKeys` can also be `null`, which means a request to return an array of all items.
+ */
+const itemsCache = new WeakMap();
+const ALL_ITEMS_KEY = [];
+
+function getItemsForKeys( items, itemKeys ) {
+	// Get the cache record for the `items` instance, construct a new one if doesn't exist yet.
+	let cacheForItems = itemsCache.get( items );
+	if ( ! cacheForItems ) {
+		cacheForItems = new WeakMap();
+		itemsCache.set( items, cacheForItems );
+	}
+
+	// `itemKeys === null` means a request for array of all items. Cache them with a special key.
+	if ( ! itemKeys ) {
+		let resultForAllKeys = cacheForItems.get( ALL_ITEMS_KEY );
+		if ( ! resultForAllKeys ) {
+			resultForAllKeys = values( items );
+			cacheForItems.set( ALL_ITEMS_KEY, resultForAllKeys );
+		}
+		return resultForAllKeys;
+	}
+
+	// compute result from `items` and `itemKeys`, cached for unique `itemKeys` instances
+	let resultForItemKeys = cacheForItems.get( itemKeys );
+	if ( ! resultForItemKeys ) {
+		resultForItemKeys = itemKeys.map( ( itemKey ) => items[ itemKey ] );
+		cacheForItems.set( itemKeys, resultForItemKeys );
+	}
+	return resultForItemKeys;
+}
+
 /**
  * QueryManager manages items which can be queried and change over time. It is
  * intended to be extended by a more specific implementation which is
@@ -147,17 +182,16 @@ export default class QueryManager {
 	 * @returns {object[]|null}       Items tracked, if known
 	 */
 	getItems( query ) {
-		if ( ! query ) {
-			return values( this.data.items );
+		let itemKeys = null;
+		if ( query ) {
+			const queryKey = this.constructor.QueryKey.stringify( query );
+			itemKeys = this.data.queries[ queryKey ]?.itemKeys;
+			if ( ! itemKeys ) {
+				return null;
+			}
 		}
 
-		const queryKey = this.constructor.QueryKey.stringify( query );
-		const itemKeys = get( this.data.queries, [ queryKey, 'itemKeys' ] );
-		if ( ! itemKeys ) {
-			return null;
-		}
-
-		return itemKeys.map( ( itemKey ) => this.getItem( itemKey ) );
+		return getItemsForKeys( this.data.items, itemKeys );
 	}
 
 	/**

--- a/client/lib/query-manager/index.js
+++ b/client/lib/query-manager/index.js
@@ -36,8 +36,8 @@ function getItemsForKeys( items, itemKeys ) {
 		itemsCache.set( items, cacheForItems );
 	}
 
-	// `itemKeys === null` means a request for array of all items. Cache them with a special key.
-	if ( ! itemKeys ) {
+	// `itemKeys == null` means a request for array of all items. Cache them with a special key.
+	if ( itemKeys == null ) {
 		let resultForAllKeys = cacheForItems.get( ALL_ITEMS_KEY );
 		if ( ! resultForAllKeys ) {
 			resultForAllKeys = values( items );

--- a/client/lib/query-manager/test/index.js
+++ b/client/lib/query-manager/test/index.js
@@ -118,6 +118,21 @@ describe( 'QueryManager', () => {
 
 			expect( manager.getItems( {} ) ).toBeNull();
 		} );
+
+		test( 'should memoize results unless items change', () => {
+			manager = manager.receive( { ID: 144 } ).receive( { ID: 152 }, { query: {} } );
+
+			const allItems1 = manager.getItems();
+			const queryItems1 = manager.getItems( {} );
+			const allItems2 = manager.getItems();
+			const queryItems2 = manager.getItems( {} );
+
+			expect( allItems1.map( ( item ) => item.ID ) ).toEqual( [ 144, 152 ] );
+			expect( allItems1 ).toBe( allItems2 );
+
+			expect( queryItems1.map( ( item ) => item.ID ) ).toEqual( [ 152 ] );
+			expect( queryItems1 ).toBe( queryItems2 );
+		} );
 	} );
 
 	describe( '#getFound()', () => {

--- a/client/lib/query-manager/test/index.js
+++ b/client/lib/query-manager/test/index.js
@@ -119,7 +119,7 @@ describe( 'QueryManager', () => {
 			expect( manager.getItems( {} ) ).toBeNull();
 		} );
 
-		test( 'should memoize results unless items change', () => {
+		test( 'should memoize results', () => {
 			manager = manager.receive( { ID: 144 } ).receive( { ID: 152 }, { query: {} } );
 
 			const allItems1 = manager.getItems();
@@ -132,6 +132,19 @@ describe( 'QueryManager', () => {
 
 			expect( queryItems1.map( ( item ) => item.ID ) ).toEqual( [ 152 ] );
 			expect( queryItems1 ).toBe( queryItems2 );
+		} );
+
+		test( 'should invalidate memoized results when underlying data change', () => {
+			manager = manager.receive( { ID: 144 } );
+			const allItems1 = manager.getItems();
+
+			// receive new item, invalidating the memoized data
+			manager = manager.receive( { ID: 152 } );
+			const allItems2 = manager.getItems();
+
+			// verify that the second results are different, not accidentally returning stale results
+			expect( allItems1.map( ( item ) => item.ID ) ).toEqual( [ 144 ] );
+			expect( allItems2.map( ( item ) => item.ID ) ).toEqual( [ 144, 152 ] );
 		} );
 	} );
 


### PR DESCRIPTION
Fixes a `QueryManager.getItems` memoization issue identified in https://github.com/Automattic/wp-calypso/pull/44963#discussion_r472069325

Adds a two-level memoization cache (`items` + `itemKeys`) when computing the `getItems` result.

That should make subsequent `getMedia` selector results `===` to each other more often.

**Todo:**
- [x] add unit tests
- [x] memoize the `PaginatedQueryManager`
