### PR TITLE
P2 signup: add domain suggestions

### DIFF
--- a/client/assets/stylesheets/_p2-vars.scss
+++ b/client/assets/stylesheets/_p2-vars.scss
@@ -15,4 +15,7 @@
 	--p2-font-inter: 'Inter', -apple-system, system-ui, blinkmacsystemfont, 'Segoe UI', 'Roboto', 'Oxygen-Sans', 'Ubuntu', 'Cantarell', 'Helvetica Neue', sans-serif;
 
 	--p2-font-size-form: 18px;
+	--p2-font-size-form-s: 16px;
+	--p2-font-size-form-xs: 14px;
+	--p2-font-size-form-xl: 26px;
 }

--- a/client/assets/stylesheets/_p2-vars.scss
+++ b/client/assets/stylesheets/_p2-vars.scss
@@ -13,4 +13,6 @@
 	--p2-color-button: #f3f3f3;
 
 	--p2-font-inter: 'Inter', -apple-system, system-ui, blinkmacsystemfont, 'Segoe UI', 'Roboto', 'Oxygen-Sans', 'Ubuntu', 'Cantarell', 'Helvetica Neue', sans-serif;
+
+	--p2-font-size-form: 18px;
 }

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -2638,4 +2638,15 @@ Undocumented.prototype.getAtomicSiteMediaViaProxyRetry = function (
 	return request();
 };
 
+/**
+ * Retrieves information about a domain.
+ *
+ * @param {string} domain - The domain name to check.
+ * @param {Function} fn The callback function
+ * @returns {Promise} A promise that resolves when the request completes
+ */
+Undocumented.prototype.getDomainInfo = function ( domain, fn ) {
+	return this.wpcom.req.get( `/domains/${ encodeURIComponent( domain ) }`, fn );
+};
+
 export default Undocumented;

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -2638,15 +2638,4 @@ Undocumented.prototype.getAtomicSiteMediaViaProxyRetry = function (
 	return request();
 };
 
-/**
- * Retrieves information about a domain.
- *
- * @param {string} domain - The domain name to check.
- * @param {Function} fn The callback function
- * @returns {Promise} A promise that resolves when the request completes
- */
-Undocumented.prototype.getDomainInfo = function ( domain, fn ) {
-	return this.wpcom.req.get( `/domains/${ encodeURIComponent( domain ) }`, fn );
-};
-
 export default Undocumented;

--- a/client/signup/p2-step-wrapper/style.scss
+++ b/client/signup/p2-step-wrapper/style.scss
@@ -10,6 +10,7 @@
 	flex-direction: column;
 	padding: 32px 32px 0;
 	font-family: var( --p2-font-inter );
+	line-height: 1.8;
 
 	@include break-mobile {
 		padding: 80px 20px 0;
@@ -42,8 +43,7 @@
 }
 
 .p2-step-wrapper__header-text {
-	font-size: 16px;
-	line-height: 28px;
+	font-size: var( --p2-font-size-form-s );
 }
 
 .p2-step-wrapper__header-logo {
@@ -69,7 +69,7 @@
 }
 
 .p2-step-wrapper__footer-text {
-	font-size: 14px;
+	font-size: var( --p2-font-size-form-xs );
 	line-height: 17px;
 }
 
@@ -83,7 +83,7 @@
 	border: none;
 	border-radius: 40px;
 	font-weight: normal;
-	font-size: 18px;
+	font-size: var( --p2-font-size-form );
 	transition: background 0.2s ease;
 
 	&.is-primary {

--- a/client/signup/steps/p2-details/style.scss
+++ b/client/signup/steps/p2-details/style.scss
@@ -1,21 +1,23 @@
 .p2-details__site-part {
 	border-left: 3px solid var( --p2-color-link );
 	padding-left: 24px;
-	margin-bottom: 44px;
+	margin-bottom: 40px;
 }
 
 .p2-details__site-title {
 	font-weight: bold;
-	font-size: 26px;
+	font-size: var( --p2-font-size-form-xl );
 	color: var( --p2-color-text );
+	line-height: 1.3;
+	margin-bottom: 4px;
 }
 
 .p2-details__blog-name {
-	margin-bottom: 25px;
+	margin-bottom: 24px;
 }
 
 .p2-details__change-details-link {
-	font-size: 14px;
+	font-size: var( --p2-font-size-form-xs );
 }
 
 .p2-details__actions {

--- a/client/signup/steps/p2-site/index.jsx
+++ b/client/signup/steps/p2-site/index.jsx
@@ -202,7 +202,7 @@ class P2Site extends React.Component {
 
 						if ( error.error && SITE_TAKEN_ERROR_CODES.includes( error.error ) ) {
 							WPCOM_SUBDOMAIN_SUFFIX_SUGGESTIONS.forEach( ( suffix ) => {
-								const suggestedSubdomain = `${ fields.site }${ suffix }.wordpress.com`;
+								const suggestedSubdomain = `${ fields.site }${ suffix }`;
 
 								wpcom
 									.domains()

--- a/client/signup/steps/p2-site/index.jsx
+++ b/client/signup/steps/p2-site/index.jsx
@@ -299,6 +299,10 @@ class P2Site extends React.Component {
 			name: event.target.name,
 			value: event.target.value,
 		} );
+
+		if ( event.target.name === 'site' ) {
+			this.setState( { suggestedSubdomains: [] } );
+		}
 	};
 
 	handleFormControllerError = ( error ) => {
@@ -347,6 +351,10 @@ class P2Site extends React.Component {
 		this.formStateController.handleFieldChange( {
 			name: 'site',
 			value: site,
+		} );
+
+		this.setState( {
+			suggestedSubdomains: [],
 		} );
 	};
 

--- a/client/signup/steps/p2-site/index.jsx
+++ b/client/signup/steps/p2-site/index.jsx
@@ -423,6 +423,7 @@ class P2Site extends React.Component {
 				{ map( suggestedSubdomains, ( suggestion, index ) => {
 					return (
 						<li
+							role="presentation"
 							key={ index }
 							className="p2-site__subdomain-suggestions-item"
 							onClick={ () => this.handleSubdomainSuggestionClick( suggestion ) }

--- a/client/signup/steps/p2-site/index.jsx
+++ b/client/signup/steps/p2-site/index.jsx
@@ -22,7 +22,6 @@ import FormTextInput from 'components/forms/form-text-input';
 import P2StepWrapper from 'signup/p2-step-wrapper';
 import { saveSignupStep, submitSignupStep } from 'state/signup/progress/actions';
 import { logToLogstash } from 'state/logstash/actions';
-import QueryDomainsSuggestions from 'components/data/query-domains-suggestions';
 
 /**
  * Style dependencies
@@ -93,7 +92,6 @@ class P2Site extends React.Component {
 			submitting: false,
 			suggestedSubdomains: [],
 			lastInvalidSite: '',
-			queryWpcomSubdomains: false,
 		};
 	}
 
@@ -229,7 +227,19 @@ class P2Site extends React.Component {
 										suggestedSubdomains: suggestions,
 									} );
 								} else {
-									this.setState( { queryWpcomSubdomains: true } );
+									wpcom
+										.domains()
+										.suggestions( {
+											quantity: 3,
+											query: fields.site,
+											only_wordpressdotcom: true,
+										} )
+										.then( ( suggestionObjects ) => {
+											this.setState( {
+												suggestedSubdomains: map( suggestionObjects, ( obj ) => obj.domain_name ),
+											} );
+										} )
+										.catch( () => {} );
 								}
 							} );
 						}
@@ -461,8 +471,6 @@ class P2Site extends React.Component {
 	}
 
 	render() {
-		const { queryWpcomSubdomains } = this.state;
-
 		return (
 			<P2StepWrapper
 				flowName={ this.props.flowName }
@@ -472,12 +480,6 @@ class P2Site extends React.Component {
 					'Share, discuss, review, and collaborate across time zones, without interruptions.'
 				) }
 			>
-				{ queryWpcomSubdomains && (
-					<QueryDomainsSuggestions
-						includeSubdomain
-						query={ formState.getFieldValue( this.state.form, 'site' ) }
-					/>
-				) }
 				<form className="p2-site__form" onSubmit={ this.handleSubmit } noValidate>
 					{ this.formFields() }
 					{ this.renderSubdomainSuggestions() }

--- a/client/signup/steps/p2-site/index.jsx
+++ b/client/signup/steps/p2-site/index.jsx
@@ -341,6 +341,15 @@ class P2Site extends React.Component {
 		} );
 	};
 
+	handleSubdomainSuggestionClick = ( suggestedSubdomain ) => {
+		const site = suggestedSubdomain.substring( 0, suggestedSubdomain.indexOf( '.' ) );
+
+		this.formStateController.handleFieldChange( {
+			name: 'site',
+			value: site,
+		} );
+	};
+
 	formFields = () => {
 		const fieldDisabled = this.state.submitting;
 
@@ -413,7 +422,11 @@ class P2Site extends React.Component {
 			<ul className="p2-site__subdomain-suggestions">
 				{ map( suggestedSubdomains, ( suggestion, index ) => {
 					return (
-						<li className="p2-site__subdomain-suggestions-item" key={ index }>
+						<li
+							key={ index }
+							className="p2-site__subdomain-suggestions-item"
+							onClick={ () => this.handleSubdomainSuggestionClick( suggestion ) }
+						>
 							{ suggestion }
 						</li>
 					);

--- a/client/signup/steps/p2-site/index.jsx
+++ b/client/signup/steps/p2-site/index.jsx
@@ -427,20 +427,19 @@ class P2Site extends React.Component {
 		}
 
 		return (
-			<ul className="p2-site__subdomain-suggestions">
+			<div className="p2-site__subdomain-suggestions">
 				{ map( suggestedSubdomains, ( suggestion, index ) => {
 					return (
-						<li
-							role="presentation"
+						<button
 							key={ index }
 							className="p2-site__subdomain-suggestions-item"
 							onClick={ () => this.handleSubdomainSuggestionClick( suggestion ) }
 						>
 							{ suggestion }
-						</li>
+						</button>
 					);
 				} ) }
-			</ul>
+			</div>
 		);
 	}
 

--- a/client/signup/steps/p2-site/style.scss
+++ b/client/signup/steps/p2-site/style.scss
@@ -140,6 +140,7 @@
 .p2-site__subdomain-suggestions {
 	display: flex;
 	flex-direction: column;
+	margin-top: 24px;
 }
 
 .p2-site__subdomain-suggestions button.p2-site__subdomain-suggestions-item {

--- a/client/signup/steps/p2-site/style.scss
+++ b/client/signup/steps/p2-site/style.scss
@@ -3,7 +3,7 @@
 	line-height: 22px;
 	pointer-events: none;
 	position: absolute;
-	font-size: $font-title-small;
+	font-size: 18px;
 	top: 62px;
 	right: 24px;
 }
@@ -32,7 +32,7 @@
 	border: none;
 	border-radius: 40px;
 	font-weight: normal;
-	font-size: $font-title-small;
+	font-size: 18px;
 	color: var( --p2-color-text-white );
 	transition: background 0.2s ease;
 
@@ -54,7 +54,7 @@
 .p2-site__form .form-label {
 	color: var( --p2-color-text );
 	font-weight: normal;
-	font-size: $font-title-small;
+	font-size: 18px;
 	letter-spacing: -0.26px;
 	margin-bottom: 16px;
 }
@@ -63,7 +63,7 @@
 	padding: 18px 24px;
 	line-height: 1;
 	border-radius: 2px;
-	font-size: $font-title-small;
+	font-size: 18px;
 	color: var( --p2-color-text );
 	border-color: var( --p2-color-border );
 
@@ -109,11 +109,15 @@
 }
 
 .p2-site__form .form-input-validation {
-	color: var( --p2-color-text-red );
+	color: var( --p2-color-error );
 	font-size: 14px;
 	padding: 0;
 	padding-top: 9px;
 	padding-left: 2px;
+
+	&.is-error {
+		color: var( --p2-color-error );
+	}
 
 	svg {
 		display: none;
@@ -132,19 +136,24 @@
 	line-height: 28px;
 }
 
-.p2-site__subdomain-suggestions {
-	border: 1px solid var( --p2-color-border );
-}
-
 .p2-site__subdomain-suggestions-item {
-	border-bottom: 1px solid var( --p2-color-border );
+	border: 1px solid var( --p2-color-border );
 	padding: 18px 24px;
+	transition: border 0.2s ease;
+	margin-top: -1px;
+	position: relative;
+
+	&:first-child {
+		border-radius: 2px 2px 0 0;
+	}
 
 	&:last-child {
-		border-bottom: none;
+		border-radius: 0 0 2px 2px;
 	}
 
 	&:hover {
 		cursor: pointer;
+		border-color: var( --p2-color-link );
+		z-index: 1;
 	}
 }

--- a/client/signup/steps/p2-site/style.scss
+++ b/client/signup/steps/p2-site/style.scss
@@ -109,8 +109,9 @@
 }
 
 .p2-site__form .form-input-validation {
-	color: var( --p2-color-error );
+	color: var( --p2-color-text );
 	font-size: var( --p2-font-size-form-xs );
+	line-height: 1.5;
 	padding: 0;
 	padding-top: 9px;
 	padding-left: 2px;
@@ -134,6 +135,11 @@
 	text-decoration-line: underline;
 	font-size: var( --p2-font-size-form-xs );
 	line-height: 28px;
+}
+
+.p2-site__subdomain-suggestions {
+	display: flex;
+	flex-direction: column;
 }
 
 .p2-site__subdomain-suggestions button.p2-site__subdomain-suggestions-item {

--- a/client/signup/steps/p2-site/style.scss
+++ b/client/signup/steps/p2-site/style.scss
@@ -143,4 +143,8 @@
 	&:last-child {
 		border-bottom: none;
 	}
+
+	&:hover {
+		cursor: pointer;
+	}
 }

--- a/client/signup/steps/p2-site/style.scss
+++ b/client/signup/steps/p2-site/style.scss
@@ -131,3 +131,16 @@
 	font-size: 15px;
 	line-height: 28px;
 }
+
+.p2-site__subdomain-suggestions {
+	border: 1px solid var( --p2-color-border );
+}
+
+.p2-site__subdomain-suggestions-item {
+	border-bottom: 1px solid var( --p2-color-border );
+	padding: 18px 24px;
+
+	&:last-child {
+		border-bottom: none;
+	}
+}

--- a/client/signup/steps/p2-site/style.scss
+++ b/client/signup/steps/p2-site/style.scss
@@ -3,7 +3,7 @@
 	line-height: 22px;
 	pointer-events: none;
 	position: absolute;
-	font-size: 18px;
+	font-size: var( --p2-font-size-form );
 	top: 62px;
 	right: 24px;
 }
@@ -32,7 +32,7 @@
 	border: none;
 	border-radius: 40px;
 	font-weight: normal;
-	font-size: 18px;
+	font-size: var( --p2-font-size-form );
 	color: var( --p2-color-text-white );
 	transition: background 0.2s ease;
 
@@ -54,7 +54,7 @@
 .p2-site__form .form-label {
 	color: var( --p2-color-text );
 	font-weight: normal;
-	font-size: 18px;
+	font-size: var( --p2-font-size-form );
 	letter-spacing: -0.26px;
 	margin-bottom: 16px;
 }
@@ -63,7 +63,7 @@
 	padding: 18px 24px;
 	line-height: 1;
 	border-radius: 2px;
-	font-size: 18px;
+	font-size: var( --p2-font-size-form );
 	color: var( --p2-color-text );
 	border-color: var( --p2-color-border );
 

--- a/client/signup/steps/p2-site/style.scss
+++ b/client/signup/steps/p2-site/style.scss
@@ -4,7 +4,7 @@
 	pointer-events: none;
 	position: absolute;
 	font-size: var( --p2-font-size-form );
-	top: 62px;
+	top: 67px;
 	right: 24px;
 }
 
@@ -110,7 +110,7 @@
 
 .p2-site__form .form-input-validation {
 	color: var( --p2-color-error );
-	font-size: 14px;
+	font-size: var( --p2-font-size-form-xs );
 	padding: 0;
 	padding-top: 9px;
 	padding-left: 2px;
@@ -132,18 +132,23 @@
 .p2-site__learn-more-link {
 	color: var( --p2-color-link );
 	text-decoration-line: underline;
-	font-size: 15px;
+	font-size: var( --p2-font-size-form-xs );
 	line-height: 28px;
 }
 
 .p2-site__subdomain-suggestions button.p2-site__subdomain-suggestions-item {
 	background: var( --p2-color-text-white );
 	border: 1px solid var( --p2-color-border );
-	border-bottom: none;
+	border-radius: 0;
+	text-align: left;
 	padding: 18px 24px;
 	transition: border 0.2s ease;
 	margin-top: -1px;
 	position: relative;
+	font-size: 15px; /* stylelint-disable-line */
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 
 	&:first-child {
 		border-radius: 2px 2px 0 0;
@@ -151,10 +156,10 @@
 
 	&:last-child {
 		border-radius: 0 0 2px 2px;
-		border-bottom: 1px solid var( --p2-color-border );
 	}
 
-	&:hover {
+	&:hover,
+	&:focus {
 		cursor: pointer;
 		border-color: var( --p2-color-link );
 		z-index: 1;

--- a/client/signup/steps/p2-site/style.scss
+++ b/client/signup/steps/p2-site/style.scss
@@ -136,8 +136,10 @@
 	line-height: 28px;
 }
 
-.p2-site__subdomain-suggestions-item {
+.p2-site__subdomain-suggestions button.p2-site__subdomain-suggestions-item {
+	background: var( --p2-color-text-white );
 	border: 1px solid var( --p2-color-border );
+	border-bottom: none;
 	padding: 18px 24px;
 	transition: border 0.2s ease;
 	margin-top: -1px;
@@ -149,6 +151,7 @@
 
 	&:last-child {
 		border-radius: 0 0 2px 2px;
+		border-bottom: 1px solid var( --p2-color-border );
 	}
 
 	&:hover {


### PR DESCRIPTION
In this PR, we add a simple available domain suggestion to the P2 signup site step:

![image](https://user-images.githubusercontent.com/4988512/90531428-57951500-e176-11ea-9867-ed2e8f99cbda.png)

If you input a domain which is not available, it will suggest 3 alternatives if they are available:
- `<domain><petwo>.wordpress.com`
- `<domain>team.wordpress.com` 
- `<domain>work.wordpress.com`

/cc @evilluendas could you check the styling, please? :)

## Testing

Open an incognito window and navigate to `/start/p2`. Input an already taken domain like `lamosty.wordpress.com`. It should suggest a few alternatives. Click on a suggestion and it should fill in the site input field. If you change the domain, it should clear previous suggestions and add new ones from the new domain.