### PR TITLE
Gutenboarding: re-enable domain picker button animation

### DIFF
--- a/client/landing/gutenboarding/components/domain-picker-button/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-button/index.tsx
@@ -24,16 +24,18 @@ import './style.scss';
 const DomainPickerButton: React.FunctionComponent = () => {
 	const { __, i18nLocale } = useI18n();
 	const makePath = usePath();
-	const { domain, domainSearch, selectedDesign, siteTitle, siteVertical } = useSelect( ( select ) =>
+	const { domain, selectedDesign, siteTitle, siteVertical } = useSelect( ( select ) =>
 		select( ONBOARD_STORE ).getState()
 	);
 
 	// Use site title or vertical as search query for a domain suggestion
-	const suggestionQuery = siteTitle || siteVertical?.label;
+	const suggestionQuery = siteTitle || siteVertical?.label || '';
+	const isValidQuery = suggestionQuery.length > 1;
+
 	const domainSuggestion = useSelect(
 		( select ) => {
 			// Get suggestion only if the query is valid and if there isn't a selected domain
-			if ( ! suggestionQuery || suggestionQuery.length < 2 || domain ) {
+			if ( domain || ! isValidQuery ) {
 				return;
 			}
 			return select( DOMAIN_SUGGESTIONS_STORE ).getDomainSuggestions( suggestionQuery, {
@@ -47,10 +49,10 @@ const DomainPickerButton: React.FunctionComponent = () => {
 		[ suggestionQuery ]
 	)?.[ 0 ];
 
-	const isLoadingSuggestion = suggestionQuery && ! domainSuggestion && ! domain;
+	const isLoadingSuggestion = ! domain && ! domainSuggestion && isValidQuery;
 
 	// Show slide-in animation when a domain suggestion is loaded only if the user didn't interacted with Domain Picker
-	const showAnimation = ! domain && ! domainSearch && ! selectedDesign && domainSuggestion;
+	const showAnimation = ! domain && ! selectedDesign && domainSuggestion;
 
 	const getDomainElementContent = () => {
 		if ( isLoadingSuggestion ) {

--- a/client/landing/gutenboarding/components/domain-picker-button/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker-button/style.scss
@@ -6,25 +6,16 @@
 	from {
 		max-width: 0;
 		opacity: 0;
-		padding: 5px 0;
-	}
-
-	79% {
-		max-width: 0;
-		opacity: 0;
-		padding: 5px;
 	}
 
 	80% {
 		max-width: 0;
 		opacity: 0;
-		padding: 5px 12px;
 	}
 
 	to {
 		max-width: 500px;
 		opacity: 1;
-		padding: 5px 12px;
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* As a follow up of #44983, re-enable slide-in animation of domain picker button if a site title has been entered and domain step was skipped. The animation has been re-introduced recently in #44864 
* Animation should run only the first time when going through the flow. Once a domain or a design is selected, animation is disabled.

#### Testing instructions
* Go to [/new](https://calypso.live/new?branch=update/gutenboarding-domain-picker-slide-in)
* Enter a site title and advance.
* Skip domain selection step.
* After landing on design selection step, the domain picker button containing a suggestion derived from the site title should appear with a sliding animation.

Demo: https://cloudup.com/cZkTE_ONHE8