### PR TITLE
Move Disconnect Stripe Account to its own section, Manage Plans content update

### DIFF
--- a/client/my-sites/earn/memberships/index.jsx
+++ b/client/my-sites/earn/memberships/index.jsx
@@ -13,7 +13,7 @@ import { saveAs } from 'browser-filesaver';
  */
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
-import { Card, Button, CompactCard, Dialog } from '@automattic/components';
+import { Card, Button, Dialog } from '@automattic/components';
 import InfiniteScroll from 'components/infinite-scroll';
 import QueryMembershipsEarnings from 'components/data/query-memberships-earnings';
 import QueryMembershipsSettings from 'components/data/query-memberships-settings';
@@ -302,37 +302,51 @@ class MembershipsSection extends Component {
 		);
 	}
 
+	renderManagePlans() {
+		return (
+			<div>
+				<SectionHeader label={ this.props.translate( 'Manage plans' ) } />
+				<Card href={ '/earn/payments-plans/' + this.props.siteSlug }>
+					<QueryMembershipProducts siteId={ this.props.siteId } />
+					<div className="memberships__module-plans-content">
+						<div className="memberships__module-plans-icon">
+							<Gridicon size={ 36 } icon={ 'credit-card' } />
+						</div>
+						<div>
+							<div className="memberships__module-plans-title">
+								{ this.props.translate( 'Payment plans' ) }
+							</div>
+							<div className="memberships__module-plans-description">
+								{ this.props.translate(
+									'Single and recurring payments for goods, services, and subscriptions'
+								) }
+							</div>
+						</div>
+					</div>
+				</Card>
+			</div>
+		);
+	}
+
 	renderSettings() {
 		return (
 			<div>
 				<SectionHeader label={ this.props.translate( 'Settings' ) } />
-				<CompactCard href={ '/earn/payments-plans/' + this.props.siteSlug }>
-					<QueryMembershipProducts siteId={ this.props.siteId } />
-					<div className="memberships__module-products-title">
-						{ this.props.translate( 'Payment plans' ) }
-					</div>
-					<div className="memberships__module-products-list">
-						<Gridicon icon="tag" size={ 12 } className="memberships__module-products-list-icon" />
-						{ this.props.products
-							.map( ( product ) => formatCurrency( product.price, product.currency ) )
-							.join( ', ' ) }
-					</div>
-				</CompactCard>
-				<CompactCard
+				<Card
 					onClick={ () =>
 						this.setState( { disconnectedConnectedAccountId: this.props.connectedAccountId } )
 					}
 					className="memberships__settings-link"
 				>
-					<div className="memberships__settings-content">
-						<p className="memberships__settings-section-title is-warning">
+					<div className="memberships__module-plans-content">
+						<div className="memberships__module-plans-icon">
+							<Gridicon size={ 36 } icon={ 'link-break' } />
+						</div>
+						<div className="memberships__module-settings-title">
 							{ this.props.translate( 'Disconnect Stripe Account' ) }
-						</p>
-						<p className="memberships__settings-section-desc">
-							{ this.props.translate( 'Disconnect Payments from your Stripe account' ) }
-						</p>
+						</div>
 					</div>
-				</CompactCard>
+				</Card>
 				<Dialog
 					isVisible={ !! this.state.disconnectedConnectedAccountId }
 					buttons={ [
@@ -479,6 +493,7 @@ class MembershipsSection extends Component {
 				) }
 				{ this.renderEarnings() }
 				{ this.renderSubscriberList() }
+				{ this.renderManagePlans() }
 				{ this.renderSettings() }
 			</div>
 		);

--- a/client/my-sites/earn/memberships/index.jsx
+++ b/client/my-sites/earn/memberships/index.jsx
@@ -310,7 +310,7 @@ class MembershipsSection extends Component {
 					<QueryMembershipProducts siteId={ this.props.siteId } />
 					<div className="memberships__module-plans-content">
 						<div className="memberships__module-plans-icon">
-							<Gridicon size={ 36 } icon={ 'credit-card' } />
+							<Gridicon size={ 24 } icon={ 'credit-card' } />
 						</div>
 						<div>
 							<div className="memberships__module-plans-title">
@@ -340,7 +340,7 @@ class MembershipsSection extends Component {
 				>
 					<div className="memberships__module-plans-content">
 						<div className="memberships__module-plans-icon">
-							<Gridicon size={ 36 } icon={ 'link-break' } />
+							<Gridicon size={ 24 } icon={ 'link-break' } />
 						</div>
 						<div className="memberships__module-settings-title">
 							{ this.props.translate( 'Disconnect Stripe Account' ) }

--- a/client/my-sites/earn/memberships/index.jsx
+++ b/client/my-sites/earn/memberships/index.jsx
@@ -44,7 +44,6 @@ import {
 	getConnectedAccountIdForSiteId,
 	getConnectUrlForSiteId,
 } from 'state/memberships/settings/selectors';
-import { getProductsForSiteId } from 'state/memberships/product-list/selectors';
 
 /**
  * Image dependencies
@@ -636,8 +635,6 @@ class MembershipsSection extends Component {
 		);
 	}
 }
-//Used to avoid re-renders. Do not mutate!
-const emptyArray = [];
 
 const mapStateToProps = ( state ) => {
 	const site = getSelectedSite( state );
@@ -659,7 +656,6 @@ const mapStateToProps = ( state ) => {
 		connectUrl: getConnectUrlForSiteId( state, siteId ),
 		paidPlan: isSiteOnPaidPlan( state, siteId ),
 		isJetpack: isJetpackSite( state, siteId ),
-		products: getProductsForSiteId( state, siteId ) ?? emptyArray,
 	};
 };
 

--- a/client/my-sites/earn/memberships/style.scss
+++ b/client/my-sites/earn/memberships/style.scss
@@ -233,15 +233,34 @@
 	margin-top: 20px;
 }
 
-.memberships__module-products-title {
-	margin-bottom: 10px;
+.memberships__module-plans-title {
 	color: var( --color-neutral-100 );
 }
 
-.memberships__module-products-list {
-	color: var( --color-neutral );
+.memberships__module-settings-title {
+	color: var( --color-neutral-100 );
+	display: flex;
+	align-items: center;
+}
+
+.memberships__module-plans-description {
+	color: var( --color-neutral-100 );
 	font-size: $font-body-small;
 }
+
+.memberships__module-plans-content {
+	display: flex;
+	flex-direction: row;
+}
+
+.memberships__module-plans-icon {
+	padding-right: 24px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	color: black;
+}
+
 .memberships__module-products-list-icon {
 	margin-right: 6px;
 }

--- a/client/my-sites/earn/memberships/style.scss
+++ b/client/my-sites/earn/memberships/style.scss
@@ -258,7 +258,7 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	color: black;
+	color: var( --color-neutral-60 );
 }
 
 .memberships__module-products-list-icon {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Move the "Disconnect Stripe Account" button to its own section, and updates the content in "Manage Plans".

Before | After
--- | ---
<img width="1010" alt="84551219-c612ae00-acc1-11ea-96ab-3a9d755d9c79" src="https://user-images.githubusercontent.com/66652282/90537702-a11c3a80-e14b-11ea-914c-207366490552.png"> | <img width="790" alt="Screen Shot 2020-08-18 at 11 56 02 AM" src="https://user-images.githubusercontent.com/66652282/90537727-a8434880-e14b-11ea-99ea-b568b360d278.png">

#### Testing instructions

* Go to `/earn/payments/{siteSlug}`
* Make sure "Payment Plans" and "Disconnect Stripe" are on different sections

Notes: 

1. Depending on your environment, you may need to uncomment some code and add mock data to `client/my-sites/earn/memberships/index.jsx` so that you see these sections
2. Spoke to @sixhours about the icons we should be using. Since we're moving away from MaterialIcons, I chose the appropriate icons from GridIcons
3. Decided that "Disconnect Stripe Account" should not have a right chevron, because it doesn't "go" anywhere. It just disconnects, unlike "Payment Plans", which goes somewhere.

Fixes https://github.com/Automattic/wp-calypso/issues/43256
