### PR TITLE
Adds new Jetpack plans to Jetpack Connect

### DIFF
--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -23,6 +23,7 @@ import OrgCredentialsForm from './remote-credentials';
 import Plans from './plans';
 import PlansLanding from './plans-landing';
 import SearchPurchase from './search';
+import StoreHeader from './store-header';
 import { addQueryArgs, sectionify } from 'lib/route';
 import { getCurrentUserId } from 'state/current-user/selectors';
 import { getLocaleFromPath, removeLocaleFromPath, getPathParts } from 'lib/i18n-utils';
@@ -72,6 +73,12 @@ const analyticsPageTitleByType = {
 };
 
 const removeSidebar = ( context ) => context.store.dispatch( hideSidebar() );
+
+export function offerResetContext( context, next ) {
+	removeSidebar( context );
+	context.header = <StoreHeader />;
+	next();
+}
 
 const getPlanSlugFromFlowType = ( type, interval = 'yearly' ) => {
 	const planSlugs = {

--- a/client/jetpack-connect/index.js
+++ b/client/jetpack-connect/index.js
@@ -13,6 +13,8 @@ import { login } from 'lib/paths';
 import { siteSelection } from 'my-sites/controller';
 import { makeLayout, render as clientRender } from 'controller';
 import { getLanguageRouteParam } from 'lib/i18n-utils';
+import { shouldShowOfferResetFlow } from 'lib/abtest/getters';
+import plansV2 from 'my-sites/plans-v2';
 
 /**
  * Style dependencies
@@ -115,13 +117,17 @@ export default function () {
 		clientRender
 	);
 
-	page(
-		`/jetpack/connect/store/:interval(yearly|monthly)?/${ locale }`,
-		controller.setLoggedOutLocale,
-		controller.plansLanding,
-		makeLayout,
-		clientRender
-	);
+	if ( shouldShowOfferResetFlow() ) {
+		plansV2( `/jetpack/connect/store`, controller.offerResetContext );
+	} else {
+		page(
+			`/jetpack/connect/store/:interval(yearly|monthly)?/${ locale }`,
+			controller.setLoggedOutLocale,
+			controller.plansLanding,
+			makeLayout,
+			clientRender
+		);
+	}
 
 	page(
 		'/jetpack/connect/:_(akismet|plans|vaultpress)/:interval(yearly|monthly)?',

--- a/client/jetpack-connect/index.js
+++ b/client/jetpack-connect/index.js
@@ -141,13 +141,17 @@ export default function () {
 		);
 	}
 
-	page(
-		'/jetpack/connect/plans/:interval(yearly|monthly)?/:site',
-		siteSelection,
-		controller.plansSelection,
-		makeLayout,
-		clientRender
-	);
+	if ( shouldShowOfferResetFlow() ) {
+		plansV2( `/jetpack/connect/plans/:site`, siteSelection, controller.offerResetContext );
+	} else {
+		page(
+			'/jetpack/connect/plans/:interval(yearly|monthly)?/:site',
+			siteSelection,
+			controller.plansSelection,
+			makeLayout,
+			clientRender
+		);
+	}
 
 	page(
 		`/jetpack/connect/:type(${ planTypeString })?/${ locale }`,

--- a/client/jetpack-connect/store-header.tsx
+++ b/client/jetpack-connect/store-header.tsx
@@ -21,7 +21,9 @@ function StoreHeader() {
 	const translate = useTranslate();
 	const partnerSlug = useSelector( ( state ) => getPartnerSlugFromQuery( state ) );
 	const currentRoute = useSelector( ( state ) => getCurrentRoute( state ) );
-	const isStoreLanding = currentRoute === '/jetpack/connect/store';
+	const isStoreLanding =
+		currentRoute === '/jetpack/connect/store' ||
+		currentRoute.startsWith( '/jetpack/connect/plans/' );
 
 	const headerClass = classNames( 'jetpack-connect__main-logo', {
 		'add-bottom-margin': ! isStoreLanding,

--- a/client/jetpack-connect/store-header.tsx
+++ b/client/jetpack-connect/store-header.tsx
@@ -1,0 +1,51 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { useSelector } from 'react-redux';
+import classNames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import FormattedHeader from 'components/formatted-header';
+import JetpackHeader from 'components/jetpack-header';
+import DocumentHead from 'components/data/document-head';
+import getPartnerSlugFromQuery from 'state/selectors/get-partner-slug-from-query';
+import getCurrentRoute from 'state/selectors/get-current-route';
+
+import './style.scss';
+
+function StoreHeader() {
+	const translate = useTranslate();
+	const partnerSlug = useSelector( ( state ) => getPartnerSlugFromQuery( state ) );
+	const currentRoute = useSelector( ( state ) => getCurrentRoute( state ) );
+	const isStoreLanding = currentRoute === '/jetpack/connect/store';
+
+	const headerClass = classNames( 'jetpack-connect__main-logo', {
+		'add-bottom-margin': ! isStoreLanding,
+	} );
+	return (
+		<>
+			<DocumentHead title={ translate( 'Jetpack Connect' ) } />
+			<div className={ headerClass }>
+				<JetpackHeader
+					partnerSlug={ partnerSlug }
+					isWoo={ false }
+					isWooDna={ false }
+					darkColorScheme
+				/>
+			</div>
+			{ isStoreLanding && (
+				<FormattedHeader
+					headerText={ translate( 'Explore our Jetpack plans' ) }
+					subHeaderText={ translate( 'Pick a plan that fits your needs.' ) }
+					brandFont
+				/>
+			) }
+		</>
+	);
+}
+
+export default StoreHeader;

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -106,6 +106,9 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 		margin-top: 20px;
 	}
 }
+.jetpack-connect__main-logo.add-bottom-margin {
+	margin-bottom: 35px;
+}
 
 .jetpack-connect__main.is-wide {
 	max-width: 100%;
@@ -654,7 +657,7 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 
 	.plan-features .plan-price.is-original .plan-price__currency-symbol,
 	.plan-features .plan-price.is-original .plan-price__fraction {
-		font-size: 8px;
+		font-size: 1rem;
 	}
 
 	.plan-features .plan-price.is-discounted {

--- a/client/my-sites/plans-v2/controller.tsx
+++ b/client/my-sites/plans-v2/controller.tsx
@@ -13,7 +13,9 @@ import { stringToDuration } from './utils';
 
 export const productSelect = ( rootUrl: string ) => ( context: PageJS.Context, next: Function ) => {
 	const duration = stringToDuration( context.params.duration );
-	context.primary = <SelectorPage defaultDuration={ duration } rootUrl={ rootUrl } />;
+	context.primary = (
+		<SelectorPage defaultDuration={ duration } rootUrl={ rootUrl } header={ context.header } />
+	);
 	next();
 };
 
@@ -24,7 +26,12 @@ export const productDetails = ( rootUrl: string ) => (
 	const productType: string = context.params.product;
 	const duration = stringToDuration( context.params.duration );
 	context.primary = (
-		<DetailsPage productSlug={ productType } duration={ duration } rootUrl={ rootUrl } />
+		<DetailsPage
+			productSlug={ productType }
+			duration={ duration }
+			rootUrl={ rootUrl }
+			header={ context.header }
+		/>
 	);
 	next();
 };
@@ -33,7 +40,12 @@ export const productUpsell = ( rootUrl: string ) => ( context: PageJS.Context, n
 	const productSlug: string = context.params.product;
 	const duration = stringToDuration( context.params.duration );
 	context.primary = (
-		<UpsellPage productSlug={ productSlug } duration={ duration } rootUrl={ rootUrl } />
+		<UpsellPage
+			productSlug={ productSlug }
+			duration={ duration }
+			rootUrl={ rootUrl }
+			header={ context.header }
+		/>
 	);
 	next();
 };

--- a/client/my-sites/plans-v2/details.tsx
+++ b/client/my-sites/plans-v2/details.tsx
@@ -30,7 +30,7 @@ import type { DetailsPageProps, PurchaseCallback, SelectorProduct } from './type
 
 import './style.scss';
 
-const DetailsPage = ( { duration, productSlug, rootUrl }: DetailsPageProps ) => {
+const DetailsPage = ( { duration, productSlug, rootUrl, header }: DetailsPageProps ) => {
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
 	const siteSlug = useSelector( ( state ) => getSelectedSiteSlug( state ) ) || '';
 	const currencyCode = useSelector( ( state ) => getCurrentUserCurrencyCode( state ) );
@@ -71,6 +71,7 @@ const DetailsPage = ( { duration, productSlug, rootUrl }: DetailsPageProps ) => 
 
 	return (
 		<Main className="details__main" wideLayout>
+			{ header }
 			<HeaderCake onClick={ backButton }>
 				{ isBundle ? translate( 'Bundle Options' ) : translate( 'Product Options' ) }
 			</HeaderCake>

--- a/client/my-sites/plans-v2/plans-header.tsx
+++ b/client/my-sites/plans-v2/plans-header.tsx
@@ -1,0 +1,22 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import PlansNavigation from 'my-sites/plans/navigation';
+import CartData from 'components/data/cart';
+
+const PlansHeader = () => {
+	return (
+		<CartData>
+			<PlansNavigation path={ '/plans' } />
+		</CartData>
+	);
+};
+
+export default function setJetpackHeader( context: PageJS.Context ) {
+	context.header = <PlansHeader />;
+}

--- a/client/my-sites/plans-v2/selector.tsx
+++ b/client/my-sites/plans-v2/selector.tsx
@@ -16,12 +16,10 @@ import { durationToString } from './utils';
 import { TERM_ANNUALLY } from 'lib/plans/constants';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { managePurchase } from 'me/purchases/paths';
-import CartData from 'components/data/cart';
 import Main from 'components/main';
 import QueryProductsList from 'components/data/query-products-list';
 import QuerySitePurchases from 'components/data/query-site-purchases';
 import QuerySites from 'components/data/query-sites';
-import PlansNavigation from 'my-sites/plans/navigation';
 
 /**
  * Type dependencies
@@ -36,7 +34,11 @@ import type {
 
 import './style.scss';
 
-const SelectorPage = ( { defaultDuration = TERM_ANNUALLY, rootUrl }: SelectorPageProps ) => {
+const SelectorPage = ( {
+	defaultDuration = TERM_ANNUALLY,
+	rootUrl,
+	header,
+}: SelectorPageProps ) => {
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
 	const siteSlug = useSelector( ( state ) => getSelectedSiteSlug( state ) ) || '';
 	const [ productType, setProductType ] = useState< ProductType >( SECURITY );
@@ -59,9 +61,7 @@ const SelectorPage = ( { defaultDuration = TERM_ANNUALLY, rootUrl }: SelectorPag
 
 	return (
 		<Main className="selector__main" wideLayout>
-			<CartData>
-				<PlansNavigation path={ '/plans' } />
-			</CartData>
+			{ header }
 			<PlansFilterBar
 				onProductTypeChange={ setProductType }
 				productType={ productType }

--- a/client/my-sites/plans-v2/types.ts
+++ b/client/my-sites/plans-v2/types.ts
@@ -25,6 +25,7 @@ export type PurchaseCallback = ( arg0: SelectorProduct, arg1?: Purchase ) => voi
 
 interface BasePageProps {
 	rootUrl: string;
+	header: ReactNode;
 }
 
 export interface SelectorPageProps extends BasePageProps {

--- a/client/my-sites/plans-v2/upsell.tsx
+++ b/client/my-sites/plans-v2/upsell.tsx
@@ -138,7 +138,7 @@ const UpsellComponent = ( {
 	);
 };
 
-const UpsellPage = ( { duration, productSlug, rootUrl }: UpsellPageProps ) => {
+const UpsellPage = ( { duration, productSlug, rootUrl, header }: UpsellPageProps ) => {
 	const selectedSiteSlug = useSelector( ( state ) => getSelectedSiteSlug( state ) ) || '';
 	const isFetchingProducts = useSelector( ( state ) => isProductsListFetching( state ) );
 	const currencyCode = useSelector( ( state ) => getCurrentUserCurrencyCode( state ) );
@@ -187,13 +187,16 @@ const UpsellPage = ( { duration, productSlug, rootUrl }: UpsellPageProps ) => {
 	}
 
 	return (
-		<UpsellComponent
-			currencyCode={ currencyCode }
-			mainProduct={ mainProduct }
-			upsellProduct={ upsellProduct }
-			onPurchaseSingleProduct={ onPurchaseSingleProduct }
-			onPurchaseBothProducts={ onPurchaseBothProducts }
-		/>
+		<>
+			{ header }
+			<UpsellComponent
+				currencyCode={ currencyCode }
+				mainProduct={ mainProduct }
+				upsellProduct={ upsellProduct }
+				onPurchaseSingleProduct={ onPurchaseSingleProduct }
+				onPurchaseBothProducts={ onPurchaseBothProducts }
+			/>
+		</>
 	);
 };
 

--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -14,6 +14,7 @@ import { shouldShowOfferResetFlow } from 'lib/abtest/getters';
 import isSiteWpcom from 'state/selectors/is-site-wpcom';
 import getSelectedSiteId from 'state/ui/selectors/get-selected-site-id';
 import { productSelect } from 'my-sites/plans-v2/controller';
+import setJetpackPlansHeader from 'my-sites/plans-v2/plans-header';
 
 function showJetpackPlans( context ) {
 	const getState = context.store.getState();
@@ -27,6 +28,7 @@ export function plans( context, next ) {
 		if ( context.params.intervalType ) {
 			return page.redirect( `/plans/${ context.params.site }` );
 		}
+		setJetpackPlansHeader( context );
 		return productSelect( '/plans/:site' )( context, next );
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Moves new Jetpack plan design to Jetpack Connect.

**Notes**
- Currently locale cannot be set. A ticket will be made to rectify this.
- This is a best-guess design, and will need further iteration. Mobile has not been tested.
- Checkout does not work yet, as that will need logic to be pulled out like the header.
- The Free option is not visible yet. That will also be added in a later iteration.

#### Screenshots
<img width="1087" alt="Screen Shot 2020-08-18 at 1 38 53 PM" src="https://user-images.githubusercontent.com/1760168/90547279-42f65400-e159-11ea-938e-8d73b15cfe6b.png">
<img width="1065" alt="Screen Shot 2020-08-18 at 1 45 34 PM" src="https://user-images.githubusercontent.com/1760168/90547280-438eea80-e159-11ea-8cb1-4d2b01462fdb.png">
<img width="787" alt="Screen Shot 2020-08-18 at 1 45 40 PM" src="https://user-images.githubusercontent.com/1760168/90547282-438eea80-e159-11ea-9dba-61c1e89e464b.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Enable A/B test for Offer Reset.
* Navigate to /jetpack/connect/store.
* Verify Offer Reset appears and works (with caveats above).
* Navigate to /jetpack/connect/plans/[site].
* Verify Offer Reset appears and works (with same caveats).

Fixes 1169247016322522-as-1189391103463219.