### PR TITLE
Fix: remove duplicated Notice wrapper

### DIFF
--- a/client/my-sites/checkout/checkout/payment-box.jsx
+++ b/client/my-sites/checkout/checkout/payment-box.jsx
@@ -13,7 +13,6 @@ import { localize } from 'i18n-calypso';
 import { Card } from '@automattic/components';
 import NavItem from 'components/section-nav/item';
 import NavTabs from 'components/section-nav/tabs';
-import Notice from 'components/notice';
 import SectionNav from 'components/section-nav';
 import SectionHeader from 'components/section-header';
 import { recordTracksEvent } from 'lib/analytics/tracks';
@@ -189,11 +188,7 @@ export class PaymentBox extends PureComponent {
 				<Card className={ cardClass }>
 					<div className="checkout__box-padding">
 						<div className={ contentClass }>
-							{ infoMessage && (
-								<Notice status="is-info" showDismiss={ false }>
-									{ this.props.infoMessage }
-								</Notice>
-							) }
+							{ infoMessage && this.props.infoMessage }
 							<IncompatibleProductNotice incompatibleProducts={ this.props.incompatibleProducts } />
 							{ this.props.children }
 						</div>

--- a/client/my-sites/checkout/checkout/prepurchase-notices/style.scss
+++ b/client/my-sites/checkout/checkout/prepurchase-notices/style.scss
@@ -4,7 +4,7 @@
 	border-bottom: solid 1px var( --color-border-subtle );
 
 	.notice {
-		margin-bottom: 0;
+		margin: 0;
 	}
 
 	.notice.is-info .notice__icon-wrapper-drop {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove duplicated nested Notice boxes.

#### Testing instructions

* On WordPress.com (do not run this PR yet), go to the checkout page with any product in the cart.
* Verify that you see an empty Notice box.
* On a site that has Jetpack Backup or a plan that includes it, visit `https://wordpress.com/checkout/:site/jetpack_backup_daily`.
* Verify that you see a nested Notice box.
* Run this PR.
* Go to the checkout page with any product in the cart.
* Verify that you don't see an empty Notice box.
* On a site that has Jetpack Backup or a plan that includes it, visit `https://calypso.localhost:3000/checkout/:site/jetpack_backup_daily`.
* Verify that you don't see a nested Notice box. You should only see one conflict Notice box.

Fixes 1169247016322522-as-1189567814793697

#### Demo

##### Before
![image](https://user-images.githubusercontent.com/3418513/90549350-c10c2800-e164-11ea-9385-797b3e0ea91a.png)

![image](https://user-images.githubusercontent.com/3418513/90549318-b356a280-e164-11ea-9064-81ebdf3ad11e.png)

##### After
![image](https://user-images.githubusercontent.com/3418513/90549499-fe70b580-e164-11ea-8467-43f87c2dd790.png)

![image](https://user-images.githubusercontent.com/3418513/90549582-13e5df80-e165-11ea-9eb5-9852d82ca43a.png)
