### PR TITLE
Offer Reset: allow multiple products only when in Offer Reset

### DIFF
--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -67,6 +67,7 @@ import {
 	isWpComBloggerPlan,
 } from 'lib/plans';
 import { getTermDuration } from 'lib/plans/constants';
+import { shouldShowOfferResetFlow } from 'lib/abtest/getters';
 
 /**
  * @typedef { import("./types").CartItemValue} CartItemValue
@@ -161,7 +162,13 @@ export function cartItemShouldReplaceCart( cartItem, cart ) {
 
 	if ( isJetpackProduct( cartItem ) ) {
 		// adding a Jetpack product should replace the cart
-		return false;
+
+		// Jetpack Offer Reset allows users to purchase multiple Jetpack products at the same time.
+		if ( shouldShowOfferResetFlow() ) {
+			return false;
+		}
+
+		return true;
 	}
 
 	return false;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* In #44954 I allowed users add multiple Jetpack products to the cart at the same time. Here I'm making that work only when the Offer Reset AB experiment is on because we don't want to inadvertently cause troubles to users or support.

#### Testing instructions

* Run this PR.
* Make sure the Offer Reset AB experiment is off.
* Try to add more than one Jetpack product to the cart.
* Verify that is not possible to add more than one Jetpack product to the cart.
* Enable the Offer Reset AB experiment.
* Try to add more than one Jetpack product to the cart.
* Verify that is possible to add more than one Jetpack product to the cart.

