### PR TITLE
Add premium domain support in the domain suggestions page

### DIFF
--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -50,6 +50,7 @@ class DomainRegistrationSuggestion extends React.Component {
 		} ).isRequired,
 		onButtonClick: PropTypes.func.isRequired,
 		domainsWithPlansOnly: PropTypes.bool.isRequired,
+		premiumDomain: PropTypes.object,
 		selectedSite: PropTypes.object,
 		railcarId: PropTypes.string,
 		recordTracksEvent: PropTypes.func,
@@ -374,6 +375,7 @@ class DomainRegistrationSuggestion extends React.Component {
 			suggestion: { domain_name: domain },
 			productCost,
 			productSaleCost,
+			premiumDomain,
 		} = this.props;
 
 		const isUnavailableDomain = this.isUnavailableDomain( domain );
@@ -386,6 +388,7 @@ class DomainRegistrationSuggestion extends React.Component {
 		return (
 			<DomainSuggestion
 				extraClasses={ extraClasses }
+				premiumDomain={ premiumDomain }
 				priceRule={ this.getPriceRule() }
 				price={ productCost }
 				salePrice={ productSaleCost }
@@ -411,9 +414,17 @@ const mapStateToProps = ( state, props ) => {
 	const currentUserCurrencyCode = getCurrentUserCurrencyCode( state );
 	const stripZeros = props.isEligibleVariantForDomainTest ? true : false;
 
+	let productCost;
+
+	if ( props.premiumDomain?.is_premium ) {
+		productCost = props.premiumDomain?.cost;
+	} else {
+		productCost = getDomainPrice( productSlug, productsList, currentUserCurrencyCode, stripZeros );
+	}
+
 	return {
 		showHstsNotice: isHstsRequired( productSlug, productsList ),
-		productCost: getDomainPrice( productSlug, productsList, currentUserCurrencyCode, stripZeros ),
+		productCost: productCost,
 		productSaleCost: getDomainSalePrice(
 			productSlug,
 			productsList,

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -30,6 +30,7 @@ import { getDomainPrice, getDomainSalePrice, getTld, isHstsRequired } from 'lib/
 import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
 import { getProductsList } from 'state/products-list/selectors';
 import Badge from 'components/badge';
+import PremiumBadge from '../premium-badge';
 import InfoPopover from 'components/info-popover';
 import { HTTPS_SSL } from 'lib/url/support';
 
@@ -220,7 +221,7 @@ class DomainRegistrationSuggestion extends React.Component {
 			isFeatured,
 			showHstsNotice,
 			productSaleCost,
-			suggestion: { domain_name: domain },
+			suggestion: { domain_name: domain, is_premium: isPremium },
 			translate,
 			isReskinned,
 		} = this.props;
@@ -250,6 +251,7 @@ class DomainRegistrationSuggestion extends React.Component {
 		return (
 			<div className={ titleWrapperClassName }>
 				<h3 className="domain-registration-suggestion__title">{ title }</h3>
+				{ isPremium && <PremiumBadge /> }
 				{ productSaleCost && paidDomain && <Badge>{ saleBadgeText }</Badge> }
 				{ showHstsNotice && (
 					<InfoPopover

--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -38,6 +38,7 @@ class DomainSearchResults extends React.Component {
 		lastDomainStatus: PropTypes.string,
 		lastDomainSearched: PropTypes.string,
 		cart: PropTypes.object,
+		premiumDomains: PropTypes.object,
 		products: PropTypes.object,
 		selectedSite: PropTypes.object,
 		availableDomain: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ),
@@ -255,6 +256,7 @@ class DomainSearchResults extends React.Component {
 					isSignupStep={ this.props.isSignupStep }
 					key="featured"
 					onButtonClick={ this.props.onClickResult }
+					premiumDomains={ this.props.premiumDomains }
 					primarySuggestion={ first( bestMatchSuggestions ) }
 					query={ this.props.lastDomainSearched }
 					railcarId={ this.props.railcarId }
@@ -287,6 +289,7 @@ class DomainSearchResults extends React.Component {
 						fetchAlgo={ suggestion.fetch_algo ? suggestion.fetch_algo : this.props.fetchAlgo }
 						query={ this.props.lastDomainSearched }
 						onButtonClick={ this.props.onClickResult }
+						premiumDomain={ this.props.premiumDomains[ suggestion.domain_name ] }
 						pendingCheckSuggestion={ this.props.pendingCheckSuggestion }
 						unavailableDomains={ this.props.unavailableDomains }
 						isEligibleVariantForDomainTest={ this.props.isEligibleVariantForDomainTest }

--- a/client/components/domains/domain-suggestion/index.jsx
+++ b/client/components/domains/domain-suggestion/index.jsx
@@ -25,6 +25,7 @@ class DomainSuggestion extends React.Component {
 		buttonStyles: PropTypes.object,
 		extraClasses: PropTypes.string,
 		onButtonClick: PropTypes.func.isRequired,
+		premiumDomain: PropTypes.object,
 		priceRule: PropTypes.string,
 		price: PropTypes.string,
 		domain: PropTypes.string,
@@ -36,15 +37,40 @@ class DomainSuggestion extends React.Component {
 		showChevron: false,
 	};
 
+	renderPrice() {
+		const {
+			hidePrice,
+			premiumDomain,
+			price,
+			priceRule,
+			salePrice,
+			isEligibleVariantForDomainTest,
+		} = this.props;
+
+		if ( hidePrice ) {
+			return null;
+		}
+
+		if ( premiumDomain?.pending ) {
+			return <div className="domain-suggestion__price-placeholder" />;
+		}
+
+		return (
+			<DomainProductPrice
+				price={ price }
+				salePrice={ salePrice }
+				rule={ priceRule }
+				isEligibleVariantForDomainTest={ isEligibleVariantForDomainTest }
+				selectedPaidPlanInSwapFlow={ this.props.selectedPaidPlanInSwapFlow }
+			/>
+		);
+	}
+
 	render() {
 		const {
 			children,
 			extraClasses,
-			hidePrice,
 			isAdded,
-			price,
-			priceRule,
-			salePrice,
 			isEligibleVariantForDomainTest,
 			isFeatured,
 		} = this.props;
@@ -75,15 +101,7 @@ class DomainSuggestion extends React.Component {
 			>
 				<div className={ contentClassName }>
 					{ children }
-					{ ! hidePrice && (
-						<DomainProductPrice
-							price={ price }
-							salePrice={ salePrice }
-							rule={ priceRule }
-							isEligibleVariantForDomainTest={ isEligibleVariantForDomainTest }
-							selectedPaidPlanInSwapFlow={ this.props.selectedPaidPlanInSwapFlow }
-						/>
-					) }
+					{ this.renderPrice() }
 				</div>
 				<Button className="domain-suggestion__action" { ...this.props.buttonStyles }>
 					{ this.props.buttonContent }

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -296,7 +296,7 @@ body.is-section-signup.is-white-signup {
 
 			.domain-product-price__free-price {
 				font-size: $font-body;
-				
+
 				@include break-mobile {
 					font-size: $font-body-small;
 				}
@@ -304,7 +304,7 @@ body.is-section-signup.is-white-signup {
 
 			.domain-product-price__free-text {
 				font-size: $font-body;
-				
+
 				@include break-mobile {
 					font-size: $font-body-small;
 				}
@@ -346,4 +346,13 @@ body.is-section-signup.is-white-signup {
 			}
 		}
 	}
+}
+
+.domain-suggestion__price-placeholder {
+	animation: loading-fade 1.6s ease-in-out infinite;
+	background-color: var( --color-neutral-0 );
+	color: transparent;
+	height: 16px;
+	margin: auto 0;
+	width: 20%;
 }

--- a/client/components/domains/featured-domain-suggestions/index.jsx
+++ b/client/components/domains/featured-domain-suggestions/index.jsx
@@ -118,6 +118,7 @@ export class FeaturedDomainSuggestions extends Component {
 						railcarId={ this.props.railcarId + '-0' }
 						isSignupStep={ this.props.isSignupStep }
 						uiPosition={ 0 }
+						premiumDomain={ this.props.premiumDomains[ primarySuggestion.domain_name ] }
 						fetchAlgo={ this.getFetchAlgorithm( primarySuggestion ) }
 						buttonStyles={ { primary: true } }
 						{ ...childProps }
@@ -133,6 +134,7 @@ export class FeaturedDomainSuggestions extends Component {
 						railcarId={ this.props.railcarId + '-1' }
 						isSignupStep={ this.props.isSignupStep }
 						uiPosition={ 1 }
+						premiumDomain={ this.props.premiumDomains[ secondarySuggestion.domain_name ] }
 						fetchAlgo={ this.getFetchAlgorithm( secondarySuggestion ) }
 						{ ...childProps }
 						isEligibleVariantForDomainTest={ this.props.isEligibleVariantForDomainTest }

--- a/client/components/domains/premium-badge/index.jsx
+++ b/client/components/domains/premium-badge/index.jsx
@@ -1,0 +1,29 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Badge from 'components/badge';
+import InfoPopover from 'components/info-popover';
+
+import './style.scss';
+
+class PremiumBadge extends React.Component {
+	render() {
+		const { translate } = this.props;
+		return (
+			<Badge className="premium-badge">
+				{ translate( 'Premium domain' ) }
+				<InfoPopover iconSize="16">
+					{ translate( 'Premium domain names are short and easy to remember' ) }
+				</InfoPopover>
+			</Badge>
+		);
+	}
+}
+
+export default localize( PremiumBadge );

--- a/client/components/domains/premium-badge/index.jsx
+++ b/client/components/domains/premium-badge/index.jsx
@@ -18,9 +18,7 @@ class PremiumBadge extends React.Component {
 		return (
 			<Badge className="premium-badge">
 				{ translate( 'Premium domain' ) }
-				<InfoPopover iconSize="16">
-					{ translate( 'Premium domain names are short and easy to remember' ) }
-				</InfoPopover>
+				<InfoPopover iconSize="16">Premium domain names are short and easy to remember</InfoPopover>
 			</Badge>
 		);
 	}

--- a/client/components/domains/premium-badge/style.scss
+++ b/client/components/domains/premium-badge/style.scss
@@ -1,0 +1,14 @@
+div.premium-badge {
+	background-color: var( --color-link );
+	padding-right: 6px;
+	color: var( --color-text-inverted );
+	.info-popover {
+		height: 16px;
+		vertical-align: middle;
+		margin-bottom: 1px;
+		margin-left: 5px;
+		.gridicon {
+			color: var( --color-text-inverted );
+		}
+	}
+}

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -829,7 +829,10 @@ class RegisterDomainStep extends React.Component {
 						TRANSFERRABLE_PREMIUM,
 						UNKNOWN,
 					} = domainAvailability;
-					const isDomainAvailable = includes( [ AVAILABLE, UNKNOWN ], status );
+					const availableStatuses = config.isEnabled( 'domains/premium-domain-purchases' )
+						? [ AVAILABLE, AVAILABLE_PREMIUM, UNKNOWN ]
+						: [ AVAILABLE, UNKNOWN ];
+					const isDomainAvailable = includes( availableStatuses, status );
 					const isDomainTransferrable = TRANSFERRABLE === status;
 					const isDomainMapped = MAPPED === mappable;
 

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -785,8 +785,11 @@ class RegisterDomainStep extends React.Component {
 				},
 				( error, result ) => {
 					const status = get( result, 'status', error );
+					const allowedAvailableStatuses = config.isEnabled( 'domains/premium-domain-purchases' )
+						? [ domainAvailability.AVAILABLE, domainAvailability.AVAILABLE_PREMIUM ]
+						: [ domainAvailability.AVAILABLE ];
 					resolve( {
-						status: status !== domainAvailability.AVAILABLE ? status : null,
+						status: ! allowedAvailableStatuses.includes( status ) ? status : null,
 						trademarkClaimsNoticeInfo: get( result, 'trademark_claims_notice_info', null ),
 					} );
 				}

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -640,6 +640,20 @@ Undocumented.prototype.getDomainContactInformation = function ( fn ) {
 		}
 	);
 };
+/**
+ *
+ * @param domain {string}
+ * @param fn {function}
+ */
+Undocumented.prototype.getDomainPrice = function ( domain, fn ) {
+	return this.wpcom.req.get(
+		`/domains/${ encodeURIComponent( domain ) }/price`,
+		{
+			apiVersion: '1.1',
+		},
+		fn
+	);
+};
 
 Undocumented.prototype.getDomainRegistrationSupportedStates = function ( countryCode, fn ) {
 	debug( '/domains/supported-states/ query' );


### PR DESCRIPTION
We want to start selling premium domains to our users. The domain suggestion endpoint is capable of returning premium domains but we need to fetch the premium price and render a premium badge next to the domain name.

#### Changes proposed in this Pull Request

* render the "Premium domain" badge next to premium domains in the domain suggestions
* Implement the new price REST API and call it for premium domains
* render placeholder while the premium price is loaded
* override the default price for premium domains
* allow the `available_premium` domain status for the domain availability precheck and the availabilty check for FQDNs

Here's how it looks in NUX and Calypso:

<img width="1072" alt="Screenshot 2020-08-20 at 17 02 12" src="https://user-images.githubusercontent.com/1355045/90783231-804d1400-e308-11ea-8387-9f9d67c327ac.png">
<img width="1017" alt="Screenshot 2020-08-20 at 17 06 17" src="https://user-images.githubusercontent.com/1355045/90783246-83480480-e308-11ea-8cf8-05f63f2815d6.png">

#### Testing instructions

* Depends on D48244-code which introduces a new REST API endpoint
* Search for anna/soda/dale and try limiting the results to .blog only