### PR TITLE
Add copy and features to Jetpack Complete product card

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card/features-item.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/features-item.tsx
@@ -9,10 +9,14 @@ import React, { FunctionComponent } from 'react';
 import Gridicon from 'components/gridicon';
 import InfoPopover from 'components/info-popover';
 import { preventWidows } from 'lib/formatting';
-import type { FeaturesItem } from './types';
+
+/**
+ * Type dependencies
+ */
+import type { ProductCardFeaturesItem } from './types';
 
 export type Props = {
-	item: FeaturesItem;
+	item: ProductCardFeaturesItem;
 };
 
 const DEFAULT_ICON = 'checkmark';

--- a/client/components/jetpack/card/jetpack-product-card/features-item.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/features-item.tsx
@@ -18,15 +18,24 @@ export type Props = {
 const DEFAULT_ICON = 'checkmark';
 
 const JetpackProductCardFeaturesItem: FunctionComponent< Props > = ( { item } ) => {
-	const { icon, text, description } = item;
+	const { icon, text, description, subitems } = item;
 
 	return (
 		<li className="jetpack-product-card__features-item">
-			<div className="jetpack-product-card__features-summary">
-				<Gridicon className="jetpack-product-card__features-icon" icon={ icon || DEFAULT_ICON } />
-				<p className="jetpack-product-card__features-text">{ preventWidows( text ) }</p>
+			<div className="jetpack-product-card__features-main">
+				<div className="jetpack-product-card__features-summary">
+					<Gridicon className="jetpack-product-card__features-icon" icon={ icon || DEFAULT_ICON } />
+					<p className="jetpack-product-card__features-text">{ preventWidows( text ) }</p>
+				</div>
+				{ description && <InfoPopover>{ preventWidows( description ) }</InfoPopover> }
 			</div>
-			{ description && <InfoPopover>{ preventWidows( description ) }</InfoPopover> }
+			{ subitems && subitems?.length > 0 && (
+				<ul className="jetpack-product-card__features-subitems">
+					{ subitems.map( ( subitem, index ) => (
+						<JetpackProductCardFeaturesItem key={ index } item={ subitem } />
+					) ) }
+				</ul>
+			) }
 		</li>
 	);
 };

--- a/client/components/jetpack/card/jetpack-product-card/features.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/features.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { useTranslate } from 'i18n-calypso';
-import { isArray, isObject } from 'lodash';
 import React, { useState, useCallback, FunctionComponent } from 'react';
 
 /**
@@ -12,11 +11,19 @@ import ExternalLink from 'components/external-link';
 import FoldableCard from 'components/foldable-card';
 import useTrackCallback from 'lib/jetpack/use-track-callback';
 import FeaturesItem from './features-item';
-import type { Features } from './types';
+
+/**
+ * Type dependencies
+ */
+import type {
+	ProductCardFeatures,
+	ProductCardFeaturesSection,
+	ProductCardFeaturesItem,
+} from './types';
 
 export type Props = {
 	className?: string;
-	features: Features;
+	features: ProductCardFeatures;
 	isExpanded?: boolean;
 };
 
@@ -46,23 +53,6 @@ const JetpackProductCardFeatures: FunctionComponent< Props > = ( {
 
 	const { items, more } = features;
 
-	let itemsEl;
-
-	if ( isArray( items ) ) {
-		itemsEl = items.map( ( item ) => <FeaturesItem item={ item } key={ item.text } /> );
-	} else if ( isObject( items ) ) {
-		itemsEl = Object.keys( items ).map( ( category ) => (
-			<li key={ category }>
-				<p className="jetpack-product-card__features-category">{ category }</p>
-				<ul className="jetpack-product-card__features-list">
-					{ items[ category ].map( ( item ) => (
-						<FeaturesItem item={ item } key={ item.text } />
-					) ) }
-				</ul>
-			</li>
-		) );
-	}
-
 	return (
 		<FoldableCard
 			className={ className }
@@ -72,7 +62,26 @@ const JetpackProductCardFeatures: FunctionComponent< Props > = ( {
 			onOpen={ onOpen }
 			onClose={ onClose }
 		>
-			<ul className="jetpack-product-card__features-list">{ itemsEl }</ul>
+			<ul className="jetpack-product-card__features-list">
+				{ ( items as ( ProductCardFeaturesItem | ProductCardFeaturesSection )[] ).map(
+					( item, i ) => {
+						if ( 'heading' in item && 'list' in item ) {
+							return (
+								<li key={ i }>
+									<p className="jetpack-product-card__features-category">{ item.heading }</p>
+									<ul className="jetpack-product-card__features-list">
+										{ item.list.map( ( subitem, j ) => (
+											<FeaturesItem key={ j } item={ subitem } />
+										) ) }
+									</ul>
+								</li>
+							);
+						}
+
+						return <FeaturesItem key={ i } item={ item } />;
+					}
+				) }
+			</ul>
 			{ more && (
 				<div className="jetpack-product-card__feature-more">
 					<ExternalLink icon={ true } href={ more.url }>

--- a/client/components/jetpack/card/jetpack-product-card/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card/style.scss
@@ -238,6 +238,10 @@ $jetpack-product-card-icon-size: 55px;
 	padding: 0 4px;
 }
 
+.jetpack-product-card .foldable-card.card.is-expanded {
+	margin-bottom: 0;
+}
+
 .jetpack-product-card__features-category {
 	margin: 8px 0 12px;
 	padding-bottom: 6px;

--- a/client/components/jetpack/card/jetpack-product-card/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card/style.scss
@@ -205,7 +205,7 @@ $jetpack-product-card-icon-size: 55px;
 	border-radius: 4px;
 	color: $jetpack-product-card-color;
 
-	font-size: rem( 13px );
+	font-size: 0.75rem;
 	line-height: $jetpack-product-card-badge-height;
 	text-transform: uppercase;
 }
@@ -254,11 +254,17 @@ $jetpack-product-card-icon-size: 55px;
 	list-style-type: none;
 }
 
-.jetpack-product-card__features-item {
+.jetpack-product-card__features-main {
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
 	padding: 12px 0;
+}
+
+.jetpack-product-card__features-subitems {
+	margin-left: 36px;
+
+	list-style-type: none;
 }
 
 .jetpack-product-card__features-summary {
@@ -288,8 +294,8 @@ $jetpack-product-card-icon-size: 55px;
 	border-top: solid 1px var( --color-border-subtle );
 }
 
-/**/
-/* Upgrade Nudge styles
+/**
+ * Upgrade Nudge styles
  */
 .jetpack-product-card__nudge {
 	margin: 16px;

--- a/client/components/jetpack/card/jetpack-product-card/types.ts
+++ b/client/components/jetpack/card/jetpack-product-card/types.ts
@@ -5,29 +5,12 @@
 /**
  * Type dependencies
  */
+import type {
+	SelectorProductFeaturesItem,
+	SelectorProductFeaturesSection,
+	SelectorProductFeatures,
+} from 'my-sites/plans-v2/types';
 
-import type { TranslateResult } from 'i18n-calypso';
-
-export type ProductCardFeaturesItem = {
-	icon?: string;
-	text: TranslateResult;
-	description?: TranslateResult;
-	subitems?: ProductCardFeaturesItem[];
-};
-
-export type ProductCardFeaturesSection = {
-	heading: TranslateResult;
-	list: ProductCardFeaturesItem[];
-};
-
-export type ProductCardFeaturesItems = ProductCardFeaturesItem[] | ProductCardFeaturesSection[];
-
-export type ProductCardFeaturesLink = {
-	url: string;
-	label: TranslateResult;
-};
-
-export type ProductCardFeatures = {
-	items: ProductCardFeaturesItems;
-	more?: ProductCardFeaturesLink;
-};
+export type ProductCardFeaturesItem = SelectorProductFeaturesItem;
+export type ProductCardFeaturesSection = SelectorProductFeaturesSection;
+export type ProductCardFeatures = SelectorProductFeatures;

--- a/client/components/jetpack/card/jetpack-product-card/types.ts
+++ b/client/components/jetpack/card/jetpack-product-card/types.ts
@@ -1,15 +1,33 @@
-export type FeaturesItem = {
+/**
+ * Internal dependencies
+ */
+
+/**
+ * Type dependencies
+ */
+
+import type { TranslateResult } from 'i18n-calypso';
+
+export type ProductCardFeaturesItem = {
 	icon?: string;
-	text: string;
-	description?: string;
+	text: TranslateResult;
+	description?: TranslateResult;
+	subitems?: ProductCardFeaturesItem[];
 };
 
-export type FeaturesMoreLink = {
+export type ProductCardFeaturesSection = {
+	heading: TranslateResult;
+	list: ProductCardFeaturesItem[];
+};
+
+export type ProductCardFeaturesItems = ProductCardFeaturesItem[] | ProductCardFeaturesSection[];
+
+export type ProductCardFeaturesLink = {
 	url: string;
-	label: string;
+	label: TranslateResult;
 };
 
-export type Features = {
-	items: FeaturesItem[] | { [ category: string ]: FeaturesItem[] };
-	more?: FeaturesMoreLink;
+export type ProductCardFeatures = {
+	items: ProductCardFeaturesItems;
+	more?: ProductCardFeaturesLink;
 };

--- a/client/components/jetpack/card/jetpack-product-card/upgrade-nudge.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/upgrade-nudge.tsx
@@ -23,14 +23,14 @@ import { DEFAULT_UPGRADE_NUDGE_FEATURES } from './fixtures';
  * Type dependencies
  */
 import type { SelectorProduct } from 'my-sites/plans-v2/types';
-import type { FeaturesItem } from './types';
+import type { ProductCardFeaturesItem } from './types';
 
 type OwnProps = {
 	billingTimeFrame: TranslateResult;
 	className?: string;
 	currencyCode: string;
 	discountedPrice?: number;
-	features?: FeaturesItem[];
+	features?: ProductCardFeaturesItem[];
 	onUpgradeClick: () => void;
 	originalPrice: number;
 	productType?: TranslateResult;

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -154,6 +154,13 @@ export const FEATURE_BACKUP_STORAGE_SPACE_UNLIMITED_SIGNUP = 'unlimited-backup';
 export const FEATURE_MEMBERSHIPS = 'memberships';
 export const FEATURE_PREMIUM_CONTENT_BLOCK = 'premium-content-block';
 
+// jetpack features category
+export const FEATURE_CATEGORY_SECURITY = Symbol();
+export const FEATURE_CATEGORY_PERFORMANCE = Symbol();
+export const FEATURE_CATEGORY_GROWTH = Symbol();
+export const FEATURE_CATEGORY_DESIGN = Symbol();
+export const FEATURE_CATEGORY_OTHER = Symbol();
+
 // jetpack features constants
 export const FEATURE_BLANK = 'blank-feature';
 export const FEATURE_STANDARD_SECURITY_TOOLS = 'standard-security-tools';
@@ -212,6 +219,21 @@ export const FEATURE_JETPACK_ANTI_SPAM = PRODUCT_JETPACK_ANTI_SPAM;
 export const FEATURE_JETPACK_ANTI_SPAM_MONTHLY = PRODUCT_JETPACK_ANTI_SPAM_MONTHLY;
 export const FEATURE_JETPACK_SEARCH = PRODUCT_JETPACK_SEARCH;
 export const FEATURE_JETPACK_SEARCH_MONTHLY = PRODUCT_JETPACK_SEARCH_MONTHLY;
+
+// jetpack features constants (offer reset)
+export const FEATURE_SECURITY_REALTIME_V2 = Symbol();
+export const FEATURE_BACKUP_REALTIME_V2 = Symbol();
+export const FEATURE_SCAN_REALTIME_V2 = Symbol();
+export const FEATURE_ANTISPAM_V2 = Symbol();
+export const FEATURE_ACTIVITY_LOG_ARCHIVE_V2 = Symbol();
+export const FEATURE_SEARCH_V2 = Symbol();
+export const FEATURE_VIDEO_HOSTING_V2 = Symbol();
+export const FEATURE_CRM_V2 = Symbol();
+export const FEATURE_SOCIAL_MEDIA_POSTING_V2 = Symbol();
+export const FEATURE_COLLECT_PAYMENTS_V2 = Symbol();
+export const FEATURE_SITE_MONETIZATION_V2 = Symbol();
+export const FEATURE_PREMIUM_THEMES_V2 = Symbol();
+export const FEATURE_PRIORITY_SUPPORT_V2 = Symbol();
 
 // Meta grouping constants
 export const GROUP_WPCOM = 'GROUP_WPCOM';

--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -12,6 +12,29 @@ import * as constants from './constants';
 import { DOMAIN_PRICING_AND_AVAILABLE_TLDS } from 'lib/url/support';
 import ExternalLinkWithTracking from 'components/external-link/with-tracking';
 
+export const FEATURE_CATEGORIES = {
+	[ constants.FEATURE_CATEGORY_SECURITY ]: {
+		getSlug: () => constants.FEATURE_CATEGORY_SECURITY,
+		getTitle: () => i18n.translate( 'Security' ),
+	},
+	[ constants.FEATURE_CATEGORY_PERFORMANCE ]: {
+		getSlug: () => constants.FEATURE_CATEGORY_PERFORMANCE,
+		getTitle: () => i18n.translate( 'Performance' ),
+	},
+	[ constants.FEATURE_CATEGORY_GROWTH ]: {
+		getSlug: () => constants.FEATURE_CATEGORY_GROWTH,
+		getTitle: () => i18n.translate( 'Growth' ),
+	},
+	[ constants.FEATURE_CATEGORY_DESIGN ]: {
+		getSlug: () => constants.FEATURE_CATEGORY_DESIGN,
+		getTitle: () => i18n.translate( 'Design' ),
+	},
+	[ constants.FEATURE_CATEGORY_OTHER ]: {
+		getSlug: () => constants.FEATURE_CATEGORY_OTHER,
+		getTitle: () => i18n.translate( 'Other' ),
+	},
+};
+
 export const FEATURES_LIST = {
 	[ constants.FEATURE_BLANK ]: {
 		getSlug: () => constants.FEATURE_BLANK,
@@ -988,6 +1011,195 @@ export const FEATURES_LIST = {
 		getTitle: () => i18n.translate( 'Subscriber-only Content' ),
 		getDescription: () => i18n.translate( 'Limit content to paying subscribers.' ),
 	},
+
+	[ constants.FEATURE_SECURITY_REALTIME_V2 ]: {
+		getSlug: () => constants.FEATURE_SECURITY_REALTIME_V2,
+		getIcon: () => 'lock',
+		getTitle: () =>
+			i18n.translate( 'Security {{em}}Real-time{{/em}}', {
+				components: {
+					em: <em />,
+				},
+			} ),
+		getDescription: () =>
+			i18n.translate(
+				'Includes all Jetpack security features to protect your site in real-time: backups, malware scanning, spam protection. {{link}}Learn more{{/link}}.',
+				{
+					components: {
+						link: <a href="https://jetpack.com/features/security/"></a>,
+					},
+				}
+			),
+	},
+
+	[ constants.FEATURE_BACKUP_REALTIME_V2 ]: {
+		getSlug: () => constants.FEATURE_BACKUP_REALTIME_V2,
+		getIcon: () => 'cloud-upload',
+		getTitle: () =>
+			i18n.translate( 'Backup {{em}}Real-time{{/em}}', {
+				components: {
+					em: <em />,
+				},
+			} ),
+		getDescription: () =>
+			i18n.translate(
+				'Real-time backups of your entire site and database with unlimited secure storage. {{link}}Learn more{{/link}}.',
+				{
+					components: {
+						link: <a href="https://jetpack.com/upgrade/backup/"></a>,
+					},
+				}
+			),
+	},
+
+	[ constants.FEATURE_SCAN_REALTIME_V2 ]: {
+		getSlug: () => constants.FEATURE_SCAN_REALTIME_V2,
+		getIcon: () => '',
+		getTitle: () =>
+			i18n.translate( 'Scan {{em}}Real-time{{/em}}', {
+				components: {
+					em: <em />,
+				},
+			} ),
+		getDescription: () =>
+			i18n.translate(
+				'Automated real-time scanning for security vulnerabilities or threats on your site. Includes instant notifications and automatic security fixes. {{link}}Learn more{{/link}}.',
+				{
+					components: {
+						link: <a href="https://jetpack.com/upgrade/scan/"></a>,
+					},
+				}
+			),
+	},
+
+	[ constants.FEATURE_ANTISPAM_V2 ]: {
+		getSlug: () => constants.FEATURE_ANTISPAM_V2,
+		getIcon: () => 'bug',
+		getTitle: () => i18n.translate( 'Anti-spam' ),
+		getDescription: () =>
+			i18n.translate(
+				'Automated spam protection for comments and forms, powered by Akismet. Save time, get more responses, and give your visitors a better experience. {{link}}Learn more{{/link}}.',
+				{
+					components: {
+						link: <a href="https://jetpack.com/upgrade/anti-spam/"></a>,
+					},
+				}
+			),
+	},
+
+	[ constants.FEATURE_ACTIVITY_LOG_ARCHIVE_V2 ]: {
+		getSlug: () => constants.FEATURE_ACTIVITY_LOG_ARCHIVE_V2,
+		getTitle: () => i18n.translate( 'Activity log: 1-year archive' ),
+		getDescription: () =>
+			i18n.translate(
+				'View every change to your site in the last year. Pairs with Backup to restore your site to any earlier version. {{link}}Learn more.{{/link}}',
+				{
+					components: {
+						link: <a href="https://jetpack.com/features/security/activity-log/"></a>,
+					},
+				}
+			),
+	},
+
+	[ constants.FEATURE_SEARCH_V2 ]: {
+		getSlug: () => constants.FEATURE_SEARCH_V2,
+		getTitle: () => i18n.translate( 'Search' ),
+		getDescription: () =>
+			i18n.translate(
+				'Help your site visitors find answers instantly so they keep reading and buying. Powerful filtering and customization options. {{link}}Learn more.{{/link}}',
+				{
+					components: {
+						link: <a href="https://jetpack.com/upgrade/search/"></a>,
+					},
+				}
+			),
+	},
+
+	[ constants.FEATURE_VIDEO_HOSTING_V2 ]: {
+		getSlug: () => constants.FEATURE_VIDEO_HOSTING_V2,
+		getTitle: () => i18n.translate( 'Unlimited video hosting' ),
+		getDescription: () =>
+			i18n.translate(
+				'Easy video uploads through an unbranded, customizable video player, enhanced with rich stats and unlimited storage space. {{link}}Learn more{{/link}}.',
+				{
+					components: {
+						link: <a href="https://jetpack.com/features/writing/video-hosting/"></a>,
+					},
+				}
+			),
+	},
+
+	[ constants.FEATURE_CRM_V2 ]: {
+		getSlug: () => constants.FEATURE_CRM_V2,
+		getTitle: () => i18n.translate( 'CRM' ),
+		getDescription: () =>
+			i18n.translate(
+				'The most simple and powerful WordPress CRM. Improve customer relationships and increase profits. {{link}}Learn more{{/link}}.',
+				{
+					components: {
+						link: <a href="https://jetpackcrm.com"></a>,
+					},
+				}
+			),
+	},
+
+	[ constants.FEATURE_SOCIAL_MEDIA_POSTING_V2 ]: {
+		getSlug: () => constants.FEATURE_SOCIAL_MEDIA_POSTING_V2,
+		getTitle: () => i18n.translate( 'Scheduled social media posting' ),
+		getDescription: () =>
+			i18n.translate(
+				'Automate and schedule your social media content on Facebook, Instagram, Twitter, LinkedIn, and Tumblr. {{link}}Learn more.{{/link}}',
+				{
+					components: {
+						link: <a href="https://jetpack.com/features/traffic/automatic-publishing/"></a>,
+					},
+				}
+			),
+	},
+
+	[ constants.FEATURE_COLLECT_PAYMENTS_V2 ]: {
+		getSlug: () => constants.FEATURE_COLLECT_PAYMENTS_V2,
+		getTitle: () => i18n.translate( 'Collect payments' ),
+		getDescription: () =>
+			i18n.translate(
+				'Accept payments from credit or debit cards via Stripe. Sell products, collect donations, and set up recurring payments for subscriptions or memberships. {{link}}Learn more{{/link}}.',
+				{
+					components: {
+						link: <a href="https://jetpack.com/support/jetpack-blocks/payments-block/"></a>,
+					},
+				}
+			),
+	},
+
+	[ constants.FEATURE_SITE_MONETIZATION_V2 ]: {
+		getSlug: () => constants.FEATURE_SITE_MONETIZATION_V2,
+		getTitle: () => i18n.translate( 'Site monetization' ),
+		getDescription: () =>
+			i18n.translate(
+				'Earn money on your site by displaying ads from the WordPress.com ad network. {{link}}Learn more.{{/link}}',
+				{
+					components: {
+						link: <a href="https://jetpack.com/features/traffic/ads/"></a>,
+					},
+				}
+			),
+	},
+
+	[ constants.FEATURE_PREMIUM_THEMES_V2 ]: {
+		getSlug: () => constants.FEATURE_PREMIUM_THEMES_V2,
+		getTitle: () => i18n.translate( 'Unlimited premium themes' ),
+		getDescription: () =>
+			i18n.translate(
+				'Unlimited access to all of our advanced premium themes, including designs specifically tailored for businesses.'
+			),
+	},
+
+	[ constants.FEATURE_PRIORITY_SUPPORT_V2 ]: {
+		getSlug: () => constants.FEATURE_PRIORITY_SUPPORT_V2,
+		getTitle: () => i18n.translate( 'Priority support' ),
+		getDescription: () =>
+			i18n.translate( 'Get fast WordPress support from the WordPress experts. ' ),
+	},
 };
 
 export const getPlanFeaturesObject = ( planFeaturesList ) => {
@@ -1004,6 +1216,10 @@ export function isValidFeatureKey( feature ) {
 
 export function getFeatureByKey( feature ) {
 	return FEATURES_LIST[ feature ];
+}
+
+export function getFeatureCategoryByKey( category ) {
+	return FEATURE_CATEGORIES[ category ];
 }
 
 export function getFeatureTitle( feature ) {

--- a/client/lib/plans/plans-list.js
+++ b/client/lib/plans/plans-list.js
@@ -443,9 +443,36 @@ const getPlanJetpackCompleteDetails = () => ( {
 			...constants.JETPACK_LEGACY_PLANS,
 		].includes( plan ),
 	getDescription: () =>
-		translate( 'The most powerful WordPress sites: Top-tier security bundle, enhanced search' ),
-	getTagline: () => translate( 'Complete WordPress security, performance, and growth' ),
+		translate(
+			'Superpower your site with everything Jetpack has to offer: real-time security, enhanced search, CRM, and marketing, growth, and design tools.'
+		),
+	getTagline: () => translate( 'For best-in-class WordPress sites' ),
 	getPlanCompareFeatures: () => [],
+	getPlanCardFeatures: () => ( {
+		[ constants.FEATURE_CATEGORY_SECURITY ]: [
+			[
+				constants.FEATURE_SECURITY_REALTIME_V2,
+				[
+					constants.FEATURE_BACKUP_REALTIME_V2,
+					constants.FEATURE_SCAN_REALTIME_V2,
+					constants.FEATURE_ANTISPAM_V2,
+					constants.FEATURE_ACTIVITY_LOG_ARCHIVE_V2,
+				],
+			],
+		],
+		[ constants.FEATURE_CATEGORY_PERFORMANCE ]: [
+			constants.FEATURE_SEARCH_V2,
+			constants.FEATURE_VIDEO_HOSTING_V2,
+		],
+		[ constants.FEATURE_CATEGORY_GROWTH ]: [
+			constants.FEATURE_CRM_V2,
+			constants.FEATURE_SOCIAL_MEDIA_POSTING_V2,
+			constants.FEATURE_COLLECT_PAYMENTS_V2,
+			constants.FEATURE_SITE_MONETIZATION_V2,
+		],
+		[ constants.FEATURE_CATEGORY_DESIGN ]: [ constants.FEATURE_PREMIUM_THEMES_V2 ],
+		[ constants.FEATURE_CATEGORY_OTHER ]: [ constants.FEATURE_PRIORITY_SUPPORT_V2 ],
+	} ),
 	getSignupFeatures: () => [],
 	getHiddenFeatures: () => [],
 	getInferiorHiddenFeatures: () => [

--- a/client/lib/plans/types.ts
+++ b/client/lib/plans/types.ts
@@ -26,6 +26,9 @@ export type JetpackPlanSlugs =
 	| JetpackResetPlanSlugs
 	| JetpackLegacyPlanSlugs;
 
+export type JetpackPlanCardFeature = symbol | [ symbol, symbol[] ];
+export type JetpackPlanCardFeatureSection = Record< symbol, JetpackPlanCardFeature[] >;
+
 export type Plan = {
 	group: typeof constants.GROUP_WPCOM | typeof constants.GROUP_JETPACK;
 	type: string;
@@ -47,6 +50,7 @@ export type Plan = {
 	getStoreSlug: () => JetpackPlanSlugs | string;
 	getPathSlug?: () => string;
 	getPlanCompareFeatures?: () => string[];
+	getPlanCardFeatures?: () => JetpackPlanCardFeature[] | JetpackPlanCardFeatureSection;
 	getSignupFeatures?: () => string[];
 	getBlogSignupFeatures?: () => string[];
 	getPortfolioSignupFeatures?: () => string[];

--- a/client/my-sites/plans-v2/constants.ts
+++ b/client/my-sites/plans-v2/constants.ts
@@ -47,6 +47,7 @@ export const SECURITY = 'security';
 
 // TODO: update before offer reset launch
 export const OFFER_RESET_SUPPORT_PAGE = 'https://jetpack.com/support/';
+export const PLAN_COMPARISON_PAGE = 'https://jetpack.com/features/comparison/';
 
 /*
  * Options displayed in the Product Type filter in the Plans page.

--- a/client/my-sites/plans-v2/types.ts
+++ b/client/my-sites/plans-v2/types.ts
@@ -15,7 +15,7 @@ import type {
 	ITEM_TYPE_BUNDLE,
 	ITEM_TYPE_PRODUCT,
 } from './constants';
-import type { Features } from 'components/jetpack/card/jetpack-product-card/types';
+import type { ProductCardFeatures } from 'components/jetpack/card/jetpack-product-card/types';
 
 export type Duration = typeof TERM_ANNUALLY | typeof TERM_MONTHLY;
 export type DurationString = 'annual' | 'monthly';
@@ -62,7 +62,7 @@ export interface SelectorProduct extends SelectorProductCost {
 	description: TranslateResult | ReactNode;
 	term: Duration;
 	buttonLabel?: TranslateResult;
-	features: Features;
+	features: ProductCardFeatures;
 	subtypes: string[];
 	legacy?: boolean;
 }

--- a/client/my-sites/plans-v2/types.ts
+++ b/client/my-sites/plans-v2/types.ts
@@ -15,7 +15,6 @@ import type {
 	ITEM_TYPE_BUNDLE,
 	ITEM_TYPE_PRODUCT,
 } from './constants';
-import type { ProductCardFeatures } from 'components/jetpack/card/jetpack-product-card/types';
 
 export type Duration = typeof TERM_ANNUALLY | typeof TERM_MONTHLY;
 export type DurationString = 'annual' | 'monthly';
@@ -50,6 +49,26 @@ export type SelectorProductCost = {
 	loadingCost?: boolean;
 };
 
+export type SelectorProductFeaturesItem = {
+	icon?: string;
+	text: TranslateResult;
+	description?: TranslateResult;
+	subitems?: SelectorProductFeaturesItem[];
+};
+
+export type SelectorProductFeaturesSection = {
+	heading: TranslateResult;
+	list: SelectorProductFeaturesItem[];
+};
+
+export type SelectorProductFeatures = {
+	items: SelectorProductFeaturesItem[] | SelectorProductFeaturesSection[];
+	more?: {
+		url: string;
+		label: TranslateResult;
+	};
+};
+
 export interface SelectorProduct extends SelectorProductCost {
 	productSlug: string;
 	iconSlug: string;
@@ -62,7 +81,7 @@ export interface SelectorProduct extends SelectorProductCost {
 	description: TranslateResult | ReactNode;
 	term: Duration;
 	buttonLabel?: TranslateResult;
-	features: ProductCardFeatures;
+	features: SelectorProductFeatures;
 	subtypes: string[];
 	legacy?: boolean;
 }

--- a/client/my-sites/plans-v2/utils.ts
+++ b/client/my-sites/plans-v2/utils.ts
@@ -38,12 +38,14 @@ import { PLAN_COMPARISON_PAGE } from 'my-sites/plans-v2/constants';
 /**
  * Type dependencies
  */
-import type { Duration, SelectorProduct, SelectorProductSlug, DurationString } from './types';
 import type {
-	ProductCardFeaturesItems,
-	ProductCardFeaturesItem,
-	ProductCardFeaturesSection,
-} from 'components/jetpack/card/jetpack-product-card/types';
+	Duration,
+	SelectorProduct,
+	SelectorProductSlug,
+	DurationString,
+	SelectorProductFeaturesItem,
+	SelectorProductFeaturesSection,
+} from './types';
 import type {
 	JetpackRealtimePlan,
 	JetpackPlanSlugs,
@@ -246,11 +248,11 @@ export function itemToSelectorProduct(
  * Builds a feature object of a product card, from a feature key.
  *
  * @param {JetpackPlanCardFeature} featureKey Key of the feature
- * @returns {ProductCardFeaturesItem} Feature item
+ * @returns {SelectorProductFeaturesItem} Feature item
  */
 export function buildCardFeatureItemFromFeatureKey(
 	featureKey: JetpackPlanCardFeature
-): ProductCardFeaturesItem | undefined {
+): SelectorProductFeaturesItem | undefined {
 	let feature;
 	let subFeaturesKeys;
 
@@ -279,9 +281,11 @@ export function buildCardFeatureItemFromFeatureKey(
  * Builds the features object passed to the product card, from a plan or product.
  *
  * @param { Plan | Product} item Product or plan
- * @returns {ProductCardFeaturesItems} Features
+ * @returns {SelectorProductFeaturesItem[] | SelectorProductFeaturesSection[]} Features
  */
-export function buildCardFeaturesFromItem( item: Plan | Product ): ProductCardFeaturesItems {
+export function buildCardFeaturesFromItem(
+	item: Plan | Product
+): SelectorProductFeaturesItem[] | SelectorProductFeaturesSection[] {
 	if ( objectIsPlan( item ) ) {
 		const features = item.getPlanCardFeatures?.();
 
@@ -292,18 +296,17 @@ export function buildCardFeaturesFromItem( item: Plan | Product ): ProductCardFe
 
 		// With sections
 		if ( isObject( features ) ) {
-			const result = [] as ProductCardFeaturesSection[];
+			const result = [] as SelectorProductFeaturesSection[];
 
 			Object.getOwnPropertySymbols( features ).map( ( key ) => {
 				const category = getFeatureCategoryByKey( key );
-				// TODO: fix TS error
 				const subfeatures = features[ key ];
 
 				if ( category ) {
 					result.push( {
 						heading: category.getTitle(),
 						list: subfeatures.map( buildCardFeatureItemFromFeatureKey ),
-					} as ProductCardFeaturesSection );
+					} as SelectorProductFeaturesSection );
 				}
 			} );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR includes the final copy for the Jetpack Complete product card. It changes the features section notably.

### Implementation notes

The features section in the product required some refactoring to match the data structure of features in Calypso, and to have a third level of nested items (e.g. Security > Security Real-time > Backup Real-time). Types were renamed to avoid confusion too.

I didn't want to split from the current implementation of features, so I added constants in `client/lib/plans/constants.js` and copy in `client/lib/plans/features-list.js` to match the current structure. Features for each plan are defined in the `getPlanCompareFeatures` functions inside `client/lib/plans/plans-list.js`, however this didn't allow us to have nested levels of features. Instead of trying to modify `getPlanCompareFeatures`, which seemed to be opening a Pandora box, I created a new method `getPlanCardFeatures`. It helps isolating this PR, but `planHasFeature` doesn't work with the newly added features. It might need some more rework later, whether we want to keep the features hardcoded in Calypso or having it delivered by the API.

Todos:
- Add icons for Scan Real-time and Activity log
- Fix TS error

### Testing instructions

- Visit the _Plans_ page with the offer reset flow enabled
- Check the copy of the Jetpack Complete product card against the copydeck
- Don't forget to check the descriptions and links in the tooltips

### Screenshots

Implementation of the Jetpack Compete card (cropped)
<img width="457" alt="Screen Shot 2020-08-18 at 4 32 24 PM" src="https://user-images.githubusercontent.com/1620183/90562600-78f30280-e170-11ea-96c7-a1b62f265dd2.png">
