### PR TITLE
Add a fallback for site_vertical

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/class-starter-page-templates.php
@@ -203,7 +203,7 @@ class Starter_Page_Templates {
 
 		// Load fresh data if we don't have any or vertical_id doesn't match.
 		if ( false === $vertical_templates || ( defined( 'WP_DEBUG' ) && WP_DEBUG ) ) {
-			$vertical_id = get_option( 'site_vertical', 'default' );
+			$vertical_id = get_option( 'site_vertical' ) ?: 'default';
 			$request_url = add_query_arg(
 				array( '_locale' => $this->get_iso_639_locale() ),
 				'https://public-api.wordpress.com/wpcom/v2/verticals/' . $vertical_id . '/templates'

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/class-starter-page-templates.php
@@ -203,7 +203,7 @@ class Starter_Page_Templates {
 
 		// Load fresh data if we don't have any or vertical_id doesn't match.
 		if ( false === $vertical_templates || ( defined( 'WP_DEBUG' ) && WP_DEBUG ) ) {
-			$vertical_id = get_option( 'site_vertical' ) ?: 'default';
+			$vertical_id = get_option( 'site_vertical' ) ? get_option( 'site_vertical' ) : 'default';
 			$request_url = add_query_arg(
 				array( '_locale' => $this->get_iso_639_locale() ),
 				'https://public-api.wordpress.com/wpcom/v2/verticals/' . $vertical_id . '/templates'


### PR DESCRIPTION
Prevents SPTs from not showing up if `site_verticals` has an unexpected value.

#### Changes proposed in this Pull Request

* Provides a fallback for `site_vertical` for any falsy value, not just when the option doesn't exist.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On your test site update `site_vertical` to various falsy values (`false`, `null`, `''`) and make sure SPT still gets loaded correctly.

See p2EDhh-18e-p2