### PR TITLE
wp-babel-makepot: Handle multiple file inputs

### DIFF
--- a/packages/wp-babel-makepot/cli.js
+++ b/packages/wp-babel-makepot/cli.js
@@ -55,17 +55,19 @@ program
 		}
 
 		// Replace `~` with actual home directory as glob can't use it.
-		const filesGlob = files.replace( /^~/, os.homedir() );
+		const filesGlob = files.trim().replace( /^~/, os.homedir() ).split( /\s/gm );
 		const ignore = program.ignore && program.ignore.split( ',' );
 
 		const { dir, base, output, linesFilter } = program;
 
-		glob.sync( filesGlob, { nodir: true, absolute: true, ignore } ).forEach( ( filepath ) =>
-			makePot( filepath, {
-				base,
-				dir,
-			} )
-		);
+		filesGlob.forEach( ( pattern ) => {
+			glob.sync( pattern, { nodir: true, absolute: true, ignore } ).forEach( ( filepath ) =>
+				makePot( filepath, {
+					base,
+					dir,
+				} )
+			);
+		} );
 
 		if ( output && output !== 'false' ) {
 			concatPot( dir, output, linesFilter );

--- a/packages/wp-babel-makepot/package.json
+++ b/packages/wp-babel-makepot/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/wp-babel-makepot",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"description": "A utility for extracting translatable strings from JavaScript source.",
 	"main": "index.js",
 	"author": "Automattic Inc.",

--- a/packages/wp-babel-makepot/test/__snapshots__/index.js.snap
+++ b/packages/wp-babel-makepot/test/__snapshots__/index.js.snap
@@ -81,6 +81,29 @@ msgstr[1] \\"\\"
 # THIS IS THE END OF THE GENERATED FILE."
 `;
 
+exports[`makePot concatenated pot should only contain allowed strings when line filter is provided 1`] = `
+"# THIS IS A GENERATED FILE. DO NOT EDIT DIRECTLY.
+
+msgid \\"\\"
+msgstr \\"Content-Type: text/plain; charset=utf-8\\\\n\\"
+
+#: test/examples/translate-1.js:2
+#: test/examples/translate-2.js:7
+#: test/examples/wordpress-i18n.js:2
+#. Second occurrence of \`Simple string\` should also be extracted.
+msgid \\"Simple string\\"
+msgstr \\"\\"
+
+#: test/examples/translate-1.js:4
+#: test/examples/wordpress-i18n.js:4
+msgid \\"Singular\\"
+msgid_plural \\"Plural\\"
+msgstr[0] \\"\\"
+msgstr[1] \\"\\"
+
+# THIS IS THE END OF THE GENERATED FILE."
+`;
+
 exports[`makePot pot files should match their snapshots 1`] = `
 Array [
   "output/test-examples-react-1.jsx.pot",

--- a/packages/wp-babel-makepot/test/examples/filter-lines.json
+++ b/packages/wp-babel-makepot/test/examples/filter-lines.json
@@ -1,0 +1,3 @@
+{
+	"test/examples/translate-1.js": [ 2, 4 ]
+}

--- a/packages/wp-babel-makepot/test/index.js
+++ b/packages/wp-babel-makepot/test/index.js
@@ -15,11 +15,17 @@ const concatPot = require( '../utils/concat-pot' );
 describe( 'makePot', () => {
 	const potOutputDir = path.join( __dirname, 'output/' );
 	const baseDir = path.resolve( __dirname, '..' );
-	const concatenatedPotOutputPath = path.join( potOutputDir, 'concatenated-strings.pot' );
+	const concatenatedPotOutputPath = path.join(
+		potOutputDir,
+		'payload',
+		'concatenated-strings.pot'
+	);
 
 	beforeAll( () => {
 		const examplesGlob = path.join( __dirname, 'examples', '*.{js,jsx,ts,tsx}' );
 		const examplesPaths = glob.sync( examplesGlob );
+
+		fs.mkdirSync( path.join( potOutputDir, 'payload' ), { recursive: true } );
 
 		examplesPaths.forEach( ( filepath ) =>
 			makePot( filepath, { dir: potOutputDir, base: baseDir } )
@@ -52,6 +58,17 @@ describe( 'makePot', () => {
 	test( 'concatenated pot should match its snapshot', () => {
 		// Test combined POT file snapshot.
 		const potFileContent = fs.readFileSync( concatenatedPotOutputPath, 'utf-8' );
+		expect( potFileContent ).toMatchSnapshot();
+	} );
+
+	test( 'concatenated pot should only contain allowed strings when line filter is provided', () => {
+		const filterExamplesLines = path.join( __dirname, 'examples', 'filter-lines.json' );
+		const filterPotOutputPath = path.join( potOutputDir, 'payload', 'filtered-strings.pot' );
+
+		concatPot( potOutputDir, filterPotOutputPath, filterExamplesLines );
+
+		// Test combined POT file snapshot.
+		const potFileContent = fs.readFileSync( filterPotOutputPath, 'utf-8' );
 		expect( potFileContent ).toMatchSnapshot();
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix handling for multiple file or glob pattern inputs separate by single space character.
* Add missing unit test for filter option.

#### Testing instructions

* Check `localci-new-strings.pot` artifact from `translate` CircleCI job and confirm it contains the newly added and updated strings proposed in this PR. Note that these string updates are only used for testing and **should be dropped** before merging the PR.
* Run with multiple file inputs, e.g. `npx @automattic/wp-babel-makepot "./client/signup/steps/about/*.jsx ./client/signup/steps/domains/*.jsx ./client/signup/steps/plans/*.jsx"` and confirm `./build/bundle-strings.pot` contains the extracted strings from all source files.
* Confirm existing CLI calls are working as they were before, e.g. `yarn run translate`.


#### Merge instructions
Drop https://github.com/Automattic/wp-calypso/pull/45024/commits/e2deb30f2e4f9651636146ab4f412234604d0a09 before merging the PR.