### PR TITLE
Gutenboarding: enable experimental features

### DIFF
--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -36,7 +36,7 @@ const Header: React.FunctionComponent = () => {
 		'PlansModal',
 	].includes( currentStep );
 
-	// steps (including modals) where we hide Plans button
+	// steps (including modals) where we show Plans button
 	const showPlansButton = [ 'DesignSelection', 'Style', 'Features' ].includes( currentStep );
 
 	// CreateSite step clears state before redirecting, don't show the default text in this case

--- a/client/landing/gutenboarding/gutenboard.tsx
+++ b/client/landing/gutenboarding/gutenboard.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import * as React from 'react';
-import { useDispatch } from '@wordpress/data';
 import { BlockEditorProvider, BlockList } from '@wordpress/block-editor';
 import { Popover, DropZoneProvider } from '@wordpress/components';
 import { createBlock, registerBlockType } from '@wordpress/blocks';
@@ -26,8 +25,6 @@ import { usePageViewTracksEvents } from './hooks/use-page-view-tracks-events';
 import useSignup from './hooks/use-signup';
 import useOnSignup from './hooks/use-on-signup';
 import useOnLogin from './hooks/use-on-login';
-import { useExperimentalQueryParam } from './path';
-import { STORE_KEY as ONBOARD_STORE } from './stores/onboard';
 
 import './style.scss';
 
@@ -40,8 +37,6 @@ const Gutenboard: React.FunctionComponent = () => {
 	useOnSiteCreation();
 	usePageViewTracksEvents();
 	const { showSignupDialog, onSignupDialogClose } = useSignup();
-	const shouldEnableExperimental = useExperimentalQueryParam();
-	const { enableExperimental } = useDispatch( ONBOARD_STORE );
 
 	// TODO: Explore alternatives for loading fonts and optimizations
 	// TODO: Don't load like this
@@ -66,9 +61,7 @@ const Gutenboard: React.FunctionComponent = () => {
 			document.head.appendChild( linkBase );
 			document.head.appendChild( linkHeadings );
 		} );
-		if ( shouldEnableExperimental ) {
-			enableExperimental();
-		}
+
 		recordOnboardingStart();
 	}, [] ); // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/client/landing/gutenboarding/gutenboard.tsx
+++ b/client/landing/gutenboarding/gutenboard.tsx
@@ -1,12 +1,13 @@
 /**
  * External dependencies
  */
-import { useI18n } from '@automattic/react-i18n';
+import * as React from 'react';
+import { useDispatch } from '@wordpress/data';
 import { BlockEditorProvider, BlockList } from '@wordpress/block-editor';
 import { Popover, DropZoneProvider } from '@wordpress/components';
 import { createBlock, registerBlockType } from '@wordpress/blocks';
 import '@wordpress/format-library';
-import React, { useRef, useEffect } from 'react';
+import { useI18n } from '@automattic/react-i18n';
 
 // Uncomment and remove the redundant sass import from `./style.css` when a release after @wordpress/components@8.5.0 is published.
 // See https://github.com/WordPress/gutenberg/pull/19535
@@ -18,7 +19,6 @@ import React, { useRef, useEffect } from 'react';
 import Header from './components/header';
 import SignupForm from './components/signup-form';
 import { name, settings } from './onboarding-block';
-import './style.scss';
 import { fontPairings, getFontTitle } from './constants';
 import { recordOnboardingStart } from './lib/analytics';
 import useOnSiteCreation from './hooks/use-on-site-creation';
@@ -26,6 +26,10 @@ import { usePageViewTracksEvents } from './hooks/use-page-view-tracks-events';
 import useSignup from './hooks/use-signup';
 import useOnSignup from './hooks/use-on-signup';
 import useOnLogin from './hooks/use-on-login';
+import { useExperimentalQueryParam } from './path';
+import { STORE_KEY as ONBOARD_STORE } from './stores/onboard';
+
+import './style.scss';
 
 registerBlockType( name, settings );
 
@@ -36,10 +40,12 @@ const Gutenboard: React.FunctionComponent = () => {
 	useOnSiteCreation();
 	usePageViewTracksEvents();
 	const { showSignupDialog, onSignupDialogClose } = useSignup();
+	const shouldEnableExperimental = useExperimentalQueryParam();
+	const { enableExperimental } = useDispatch( ONBOARD_STORE );
 
 	// TODO: Explore alternatives for loading fonts and optimizations
 	// TODO: Don't load like this
-	useEffect( () => {
+	React.useEffect( () => {
 		fontPairings.forEach( ( { base, headings } ) => {
 			const linkBase = document.createElement( 'link' );
 			const linkHeadings = document.createElement( 'link' );
@@ -60,9 +66,11 @@ const Gutenboard: React.FunctionComponent = () => {
 			document.head.appendChild( linkBase );
 			document.head.appendChild( linkHeadings );
 		} );
-
+		if ( shouldEnableExperimental ) {
+			enableExperimental();
+		}
 		recordOnboardingStart();
-	}, [] );
+	}, [] ); // eslint-disable-line react-hooks/exhaustive-deps
 
 	// @TODO: This is currently needed in addition to the routing (inside the Onboarding Block)
 	// for the 'Back' and 'Next' buttons in the header. If we remove those (and move navigation
@@ -71,7 +79,7 @@ const Gutenboard: React.FunctionComponent = () => {
 	// We're persisting the block via `useRef` in order to prevent re-renders
 	// which would collide with the routing done inside of the block
 	// (and would lead to weird mounting/unmounting behavior).
-	const onboardingBlock = useRef( createBlock( name, {} ) );
+	const onboardingBlock = React.useRef( createBlock( name, {} ) );
 
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (

--- a/client/landing/gutenboarding/hooks/use-step-navigation.ts
+++ b/client/landing/gutenboarding/hooks/use-step-navigation.ts
@@ -9,7 +9,7 @@ import { useI18n } from '@automattic/react-i18n';
 /**
  * Internal dependencies
  */
-import { Step, usePath, useCurrentStep } from '../path';
+import { Step, usePath, useCurrentStep, StepType } from '../path';
 import { STORE_KEY as ONBOARD_STORE } from '../stores/onboard';
 import { USER_STORE } from '../stores/user';
 import { useShouldSiteBePublic } from './use-selected-plan';
@@ -35,10 +35,13 @@ export default function useStepNavigation(): { goBack: () => void; goNext: () =>
 
 	// If the user enters a site title on Intent Capture step we are showing Domains step next.
 	// Else, we're showing Domains step before Plans step.
-	let steps = hasSiteTitle()
+	let steps: StepType[];
+
+	steps = hasSiteTitle()
 		? [ Step.IntentGathering, Step.Domains, Step.DesignSelection, Step.Style, Step.Plans ]
 		: [ Step.IntentGathering, Step.DesignSelection, Step.Style, Step.Domains, Step.Plans ];
 
+	// When feature picker experiment is enabled, if site title is skipped, we're showing Domains step before Features step.
 	if ( isExperimental && isEnabled( 'gutenboarding/feature-picker' ) ) {
 		steps = hasSiteTitle()
 			? [

--- a/client/landing/gutenboarding/hooks/use-step-navigation.ts
+++ b/client/landing/gutenboarding/hooks/use-step-navigation.ts
@@ -1,8 +1,9 @@
 /**
  * External dependencies
  */
-import { useSelect, useDispatch } from '@wordpress/data';
+import { isEnabled } from 'config';
 import { useHistory } from 'react-router-dom';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { useI18n } from '@automattic/react-i18n';
 
 /**
@@ -25,6 +26,7 @@ import useSignup from './use-signup';
  */
 export default function useStepNavigation(): { goBack: () => void; goNext: () => void } {
 	const { hasSiteTitle } = useSelect( ( select ) => select( ONBOARD_STORE ) );
+	const { isExperimental } = useSelect( ( select ) => select( ONBOARD_STORE ).getState() );
 
 	const makePath = usePath();
 	const history = useHistory();
@@ -36,6 +38,26 @@ export default function useStepNavigation(): { goBack: () => void; goNext: () =>
 	let steps = hasSiteTitle()
 		? [ Step.IntentGathering, Step.Domains, Step.DesignSelection, Step.Style, Step.Plans ]
 		: [ Step.IntentGathering, Step.DesignSelection, Step.Style, Step.Domains, Step.Plans ];
+
+	if ( isExperimental && isEnabled( 'gutenboarding/feature-picker' ) ) {
+		steps = hasSiteTitle()
+			? [
+					Step.IntentGathering,
+					Step.Domains,
+					Step.DesignSelection,
+					Step.Style,
+					Step.Features,
+					Step.Plans,
+			  ]
+			: [
+					Step.IntentGathering,
+					Step.DesignSelection,
+					Step.Style,
+					Step.Domains,
+					Step.Features,
+					Step.Plans,
+			  ];
+	}
 
 	// @TODO: move site creation to a separate hook or an action on the ONBOARD store
 	const currentUser = useSelect( ( select ) => select( USER_STORE ).getCurrentUser() );

--- a/client/landing/gutenboarding/onboarding-block/edit.tsx
+++ b/client/landing/gutenboarding/onboarding-block/edit.tsx
@@ -28,7 +28,9 @@ import './colors.scss';
 import './style.scss';
 
 const OnboardingEdit: React.FunctionComponent< BlockEditProps< Attributes > > = () => {
-	const { selectedDesign, siteTitle } = useSelect( ( select ) => select( STORE_KEY ).getState() );
+	const { selectedDesign, siteTitle, isExperimental } = useSelect( ( select ) =>
+		select( STORE_KEY ).getState()
+	);
 	const isRedirecting = useSelect( ( select ) => select( STORE_KEY ).getIsRedirecting() );
 	const isCreatingSite = useSelect( ( select ) => select( SITE_STORE ).isFetchingSite() );
 	const newSiteError = useSelect( ( select ) => select( SITE_STORE ).getNewSiteError() );
@@ -100,7 +102,11 @@ const OnboardingEdit: React.FunctionComponent< BlockEditProps< Attributes > > = 
 				</Route>
 
 				<Route path={ makePath( Step.Features ) }>
-					{ isEnabled( 'gutenboarding/feature-picker' ) ? <Features /> : redirectToLatestStep }
+					{ isEnabled( 'gutenboarding/feature-picker' ) && isExperimental ? (
+						<Features />
+					) : (
+						redirectToLatestStep
+					) }
 				</Route>
 
 				<Route path={ makePath( Step.Domains ) }>

--- a/client/landing/gutenboarding/onboarding-block/plans/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/plans/index.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import * as React from 'react';
+import { isEnabled } from 'config';
 import { useHistory } from 'react-router-dom';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useI18n } from '@automattic/react-i18n';
@@ -34,6 +35,7 @@ const PlansStep: React.FunctionComponent< Props > = ( { isModal } ) => {
 
 	const plan = useSelectedPlan();
 	const domain = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedDomain() );
+	const { isExperimental } = useSelect( ( select ) => select( ONBOARD_STORE ).getState() );
 	const isPlanFree = useSelect( ( select ) => select( PLANS_STORE ).isPlanFree );
 
 	const { setDomain, updatePlan, setHasUsedPlansStep } = useDispatch( ONBOARD_STORE );
@@ -93,6 +95,7 @@ const PlansStep: React.FunctionComponent< Props > = ( { isModal } ) => {
 				currentDomain={ domain }
 				onPlanSelect={ handlePlanSelect }
 				onPickDomainClick={ handlePickDomain }
+				singleColumn={ isExperimental && isEnabled( 'gutenboarding/feature-picker' ) }
 			/>
 		</div>
 	);

--- a/client/landing/gutenboarding/path.ts
+++ b/client/landing/gutenboarding/path.ts
@@ -96,8 +96,3 @@ export function useCurrentStep() {
 export function useNewQueryParam() {
 	return new URLSearchParams( useLocation().search ).has( 'new' );
 }
-
-// Returns true if the url has a `?v=1`, which is used to enable experimental features
-export function useExperimentalQueryParam() {
-	return new URLSearchParams( useLocation().search ).has( 'latest' );
-}

--- a/client/landing/gutenboarding/path.ts
+++ b/client/landing/gutenboarding/path.ts
@@ -96,3 +96,8 @@ export function useCurrentStep() {
 export function useNewQueryParam() {
 	return new URLSearchParams( useLocation().search ).has( 'new' );
 }
+
+// Returns true if the url has a `?v=1`, which is used to enable experimental features
+export function useExperimentalQueryParam() {
+	return new URLSearchParams( useLocation().search ).has( 'latest' );
+}

--- a/client/landing/gutenboarding/stores/onboard/actions.ts
+++ b/client/landing/gutenboarding/stores/onboard/actions.ts
@@ -58,11 +58,6 @@ export const resetSiteVertical = () => ( {
 	type: 'RESET_SITE_VERTICAL' as const,
 } );
 
-export const showVerticalInput = ( shouldShowVerticalInput: boolean ) => ( {
-	type: 'SET_SHOW_SITE_VERTICAL_INPUT' as const,
-	shouldShowVerticalInput,
-} );
-
 export const setSiteTitle = ( siteTitle: string ) => ( {
 	type: 'SET_SITE_TITLE' as const,
 	siteTitle,
@@ -185,6 +180,10 @@ export const removeFeature = ( featureId: FeatureId ) => ( {
 	featureId,
 } );
 
+export const enableExperimental = () => ( {
+	type: 'SET_ENABLE_EXPERIMENTAL' as const,
+} );
+
 export type OnboardAction = ReturnType<
 	| typeof resetFonts
 	| typeof resetOnboardStore
@@ -193,7 +192,6 @@ export type OnboardAction = ReturnType<
 	| typeof setDomainSearch
 	| typeof setDomainCategory
 	| typeof skipSiteVertical
-	| typeof showVerticalInput
 	| typeof setFonts
 	| typeof setIsRedirecting
 	| typeof setHasUsedDomainsStep
@@ -207,4 +205,5 @@ export type OnboardAction = ReturnType<
 	| typeof setPlan
 	| typeof addFeature
 	| typeof removeFeature
+	| typeof enableExperimental
 >;

--- a/client/landing/gutenboarding/stores/onboard/index.ts
+++ b/client/landing/gutenboarding/stores/onboard/index.ts
@@ -29,7 +29,6 @@ registerStore< State >( STORE_KEY, {
 		'domainSearch',
 		'siteTitle',
 		'siteVertical',
-		'shouldShowVerticalInput',
 		'wasVerticalSkipped',
 		'hasUsedDomainsStep',
 		'hasUsedPlansStep',
@@ -39,6 +38,7 @@ registerStore< State >( STORE_KEY, {
 		'selectedSite',
 		'selectedFeatures',
 		'plan',
+		'isExperimental',
 	],
 } );
 

--- a/client/landing/gutenboarding/stores/onboard/reducer.ts
+++ b/client/landing/gutenboarding/stores/onboard/reducer.ts
@@ -13,6 +13,14 @@ import type { OnboardAction } from './actions';
 import type { FontPair } from '../../constants';
 import type { FeatureId } from '../../onboarding-block/features/data';
 
+// Returns true if the url has a `?latest`, which is used to enable experimental features
+export function hasExperimentalQueryParam() {
+	if ( typeof window !== 'undefined' ) {
+		return new URLSearchParams( window.location.search ).has( 'latest' );
+	}
+	return false;
+}
+
 const domain: Reducer< DomainSuggestions.DomainSuggestion | undefined, OnboardAction > = (
 	state,
 	action
@@ -190,7 +198,10 @@ const selectedFeatures: Reducer< FeatureId[], OnboardAction > = (
 	return state;
 };
 
-const isExperimental: Reducer< boolean, OnboardAction > = ( state = false, action ) => {
+const isExperimental: Reducer< boolean, OnboardAction > = (
+	state = hasExperimentalQueryParam(),
+	action
+) => {
 	if ( action.type === 'SET_ENABLE_EXPERIMENTAL' ) {
 		return true;
 	}

--- a/client/landing/gutenboarding/stores/onboard/reducer.ts
+++ b/client/landing/gutenboarding/stores/onboard/reducer.ts
@@ -86,16 +86,6 @@ const wasVerticalSkipped: Reducer< boolean, OnboardAction > = ( state = false, a
 	return state;
 };
 
-const shouldShowVerticalInput: Reducer< boolean, OnboardAction > = ( state = false, action ) => {
-	if ( action.type === 'SET_SHOW_SITE_VERTICAL_INPUT' ) {
-		return action.shouldShowVerticalInput;
-	}
-	if ( action.type === 'RESET_ONBOARD_STORE' ) {
-		return false;
-	}
-	return state;
-};
-
 const pageLayouts: Reducer< string[], OnboardAction > = ( state = [], action ) => {
 	if ( action.type === 'TOGGLE_PAGE_LAYOUT' ) {
 		const layout = action.pageLayout;
@@ -200,6 +190,16 @@ const selectedFeatures: Reducer< FeatureId[], OnboardAction > = (
 	return state;
 };
 
+const isExperimental: Reducer< boolean, OnboardAction > = ( state = false, action ) => {
+	if ( action.type === 'SET_ENABLE_EXPERIMENTAL' ) {
+		return true;
+	}
+	if ( action.type === 'RESET_ONBOARD_STORE' ) {
+		return false;
+	}
+	return state;
+};
+
 const reducer = combineReducers( {
 	domain,
 	domainSearch,
@@ -217,7 +217,7 @@ const reducer = combineReducers( {
 	plan,
 	selectedFeatures,
 	wasVerticalSkipped,
-	shouldShowVerticalInput,
+	isExperimental,
 } );
 
 export type State = ReturnType< typeof reducer >;

--- a/packages/plans-grid/src/plans-grid/index.tsx
+++ b/packages/plans-grid/src/plans-grid/index.tsx
@@ -26,6 +26,7 @@ export interface Props {
 	onPickDomainClick?: () => void;
 	currentDomain?: DomainSuggestions.DomainSuggestion;
 	disabledPlans?: { [ planSlug: string ]: string };
+	singleColumn?: boolean;
 }
 
 const PlansGrid: React.FunctionComponent< Props > = ( {
@@ -35,8 +36,13 @@ const PlansGrid: React.FunctionComponent< Props > = ( {
 	onPlanSelect,
 	onPickDomainClick,
 	disabledPlans,
+	singleColumn,
 } ) => {
 	const { __ } = useI18n();
+
+	// Note: singleColumn prop would be always false until "gutenboarding/feature-picker" feature flag is enabled
+	// and Gutenboarding flow is started with ?latest query param
+	singleColumn && console.log( 'display accordion' ); // eslint-disable-line no-console
 
 	return (
 		<div className="plans-grid">


### PR DESCRIPTION

#### Changes proposed in this Pull Request
- Add `isExperimental` property to Onboard store and enable it using `?latest` query param.
- Enable feature picker as experimental feature in development using feature flag.
- Pass `singleColumn` placeholder prop to PlansGrid preparing for #44201

#### Testing instructions
* go to `/new?latest` on localhost
* feature picker step should appear after style preview

Fixes #44981
