### PR TITLE
Gutenboarding: update existing users test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -236,7 +236,7 @@ export default {
 		localeExceptions: [ 'en', 'es' ],
 	},
 	existingUsersGutenbergOnboard: {
-		datestamp: '20200818',
+		datestamp: '20200819',
 		variations: {
 			gutenberg: 50,
 			control: 50,
@@ -244,5 +244,6 @@ export default {
 		defaultVariation: 'control',
 		allowExistingUsers: true,
 		localeTargets: [ 'en' ],
+		countryCodeTargets: [ 'US', 'CA' ],
 	},
 };

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -117,17 +117,18 @@ export default {
 			next();
 		} else {
 			const userLoggedIn = isUserLoggedIn( context.store.getState() );
-			if ( userLoggedIn && 'gutenberg' === abtest( 'existingUsersGutenbergOnboard' ) ) {
-				gutenbergRedirect();
-				return;
-			}
 
 			waitForData( {
 				geo: () => requestGeoLocation(),
 			} )
 				.then( ( { geo } ) => {
 					const countryCode = geo.data.body.country_short;
-					if ( 'gutenberg' === abtest( 'newSiteGutenbergOnboarding', countryCode ) ) {
+					if (
+						userLoggedIn &&
+						'gutenberg' === abtest( 'existingUsersGutenbergOnboard', countryCode )
+					) {
+						gutenbergRedirect();
+					} else if ( 'gutenberg' === abtest( 'newSiteGutenbergOnboarding', countryCode ) ) {
 						gutenbergRedirect();
 					} else if (
 						( ! user() || ! user().get() ) &&


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* update existingUsersGutenbergOnboard to target country codes 'US' and 'CA'.
* update datestamp

#### Testing instructions
Check instructions from #44858 but with the updated test slugs:
`existingUsersGutenbergOnboard_20200812` => `existingUsersGutenbergOnboard_20200819`
`newSiteGutenbergOnboarding_20200811` => `newSiteGutenbergOnboarding_20200818`
