### PR TITLE
Block Editor: Stop initializing the iframe with `display: none`

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -670,8 +670,6 @@ class CalypsoifyIframe extends Component<
 						/* eslint-disable jsx-a11y/iframe-has-title */
 						<iframe
 							ref={ this.iframeRef }
-							/* eslint-disable-next-line wpcalypso/jsx-classname-namespace */
-							className={ isIframeLoaded ? 'is-iframe-loaded' : undefined }
 							src={ isIframeLoaded ? currentIFrameUrl : iframeUrl }
 							// Iframe url needs to be kept in state to prevent editor reloading if frame_nonce changes
 							// in Jetpack sites

--- a/client/gutenberg/editor/style.scss
+++ b/client/gutenberg/editor/style.scss
@@ -1,4 +1,3 @@
-
 @import '~@wordpress/edit-post/build-style/style';
 
 .is-group-gutenberg.layout {
@@ -43,7 +42,6 @@
 }
 
 .layout.is-section-gutenberg-editor {
-
 	.edit-post-layout {
 		.edit-post-layout__content {
 			//fixes a notice display issue in Safari
@@ -75,7 +73,6 @@
 		left: 0;
 		top: 0;
 	}
-
 }
 
 // End Placeholder styles
@@ -100,7 +97,7 @@ html.is-iframe {
 	top: 0;
 	width: auto;
 
-	@supports (-webkit-overflow-scrolling: touch) {
+	@supports ( -webkit-overflow-scrolling: touch ) {
 		/* iOS devices only */
 		-webkit-overflow-scrolling: touch;
 		overflow: auto;
@@ -111,11 +108,6 @@ html.is-iframe {
 		top: 0;
 		width: 100%;
 		height: 100%;
-		display: none;
-
-		&.is-iframe-loaded {
-			display: block;
-		}
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This technically affects any iframed Block Editor, but since the _Post Editor_ uses custom previews, this is only testable with the _Site Editor_.

* Stop initializing the iframed Block Editor with `display: none`.

#### Looooong explanation

Gutenberg's own previews use the [`useResizeCanvas`](https://github.com/WordPress/gutenberg/blob/823e5d7dd2d319fea68cc7ca4480abb2fb7f5a33/packages/block-editor/src/components/use-resize-canvas/index.js) hook, which initializes the screen's `actualWidth` with `window.innerWidth`.
This hook is used to determine the visual editor size, so it's triggered very early during the first load, which works well in most cases.

The iframe complicates things, as the `window.innerWidth` doesn't refer to the browser anymore, but to the iframe element itself.

We used to [initialize the iframe hidden in order to show the loading animation](https://github.com/Automattic/wp-calypso/pull/31079), but eventually we [also stopped rendering it altogether while loading](https://github.com/Automattic/wp-calypso/pull/34829).

For a brief moment, the iframe is rendered with `display: none`, which means that its `window.innerWidth` is 0.
The `useResizeCanvas` hook initializes `actualWidth` to 0, and will only update it on window resize.
When changing preview, we use the narrowest width between device and actual, and since actual is 0, the preview will always have `width: 0`, which looks like it's not loading at all.

cc @mmtr @glendaviesnz for a regression check.
I've tried loading both post and site editor, with or without cache, and it seems to be working just fine, without any visual conflicts with the loading animations.

#### Testing instructions

* Open the Site Editor on a site with the FSE experiment.
* Try changing the preview to tablet or mobile. (Don't resize the screen first, as it affects the test.)
* Make sure the previews show up correctly.
* Smoke test the Post Editor as well, and make sure there are no regressions. 

Fixes #44105
