### PR TITLE
i18n: Fix module reference rewrite for building translation chunks

### DIFF
--- a/bin/build-languages.js
+++ b/bin/build-languages.js
@@ -151,10 +151,7 @@ function createLanguagesDir() {
 function getModuleReference( module ) {
 	// Rewrite module from `packages/` to match references in POT
 	if ( module.indexOf( 'packages/' ) === 0 ) {
-		return module
-			.replace( /^packages\//, '' )
-			.replace( '/dist/esm/', '/src/' )
-			.replace( /\.\w+/, '' );
+		return module.replace( '/dist/esm/', '/src/' ).replace( /\.\w+/, '' );
 	}
 
 	return module;


### PR DESCRIPTION
It's no longer needed to remove the leading `packages/` path from the module reference, since Calypso has switched from `i18n-calypso` to `wp-babel-makepot` for string extraction as strings are currently being extracted with their full reference path.

#### Changes proposed in this Pull Request

* Remove `packages/` string replacement in `getModuleReference` of the build-languages script.

#### Testing instructions

* Build Calypso locally and search for a translatable string from `packages/**` (e.g. `Pick a payment method`)  in the translation chunks output directory `public/evergreen/languages` and confirm it's included in the generated translation chunks. 
* Test calypso.live build with `?useTranslationChunks` flag and confirm it's now showing translations for strings that were previously rendered untranslated. E.g. **Pick a payment method** on `/checkout/premium/{SITE}#step2`

Fixes https://github.com/Automattic/wp-calypso/issues/44827
