### PR TITLE
Jetpack Cloud: Don't show upsells after product purchase

### DIFF
--- a/client/components/jetpack/upsell-switch/index.tsx
+++ b/client/components/jetpack/upsell-switch/index.tsx
@@ -121,15 +121,26 @@ function UpsellSwitch( props: Props ): React.ReactElement {
 	}, [ uiState, isRequesting, state ] );
 
 	useEffect( () => {
-		// Show the expected content only if the state is distinct to unavailable
-		// (active, inactive, provisioning) or if the site is Atomic
-		if (
-			UI_STATE_LOADED === uiState &&
-			! atomicSite &&
-			( ! state || state === 'unavailable' || ! hasProduct )
-		) {
-			setUpsell( true );
+		// Don't show an upsell until the page is loaded
+		if ( UI_STATE_LOADED !== uiState ) {
+			setUpsell( false );
+			return;
 		}
+
+		// Don't show an upsell if this site already has the product in question
+		if ( hasProduct ) {
+			setUpsell( false );
+			return;
+		}
+
+		// Don't show an upsell if this is an Atomic site
+		if ( atomicSite ) {
+			setUpsell( false );
+			return;
+		}
+
+		// Only show an upsell if the state is 'unavailable'
+		setUpsell( state === 'unavailable' );
 	}, [ uiState, atomicSite, hasProduct, state ] );
 
 	if ( UI_STATE_LOADED !== uiState ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Tweak the logic in `UpsellSwitch` so that the "show upsell" state variable can be set to either true or false depending on the current app state (especially after a product purchase or when the Rewind state changes).

Fixes `1164141197617539-as-1185831244882330`.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Before testing this PR, or in a different environment:

* Create or a select a site that does not have Jetpack Backup and/or Scan.
* From anywhere in Calypso *except* their respective upsell pages (e.g., from the **Plans** page), purchase one of these products.
* Without manually refreshing the browser at any point, go to **Jetpack > Backup** or **Jetpack > Scan** (depending on which you purchased).
* Observe that the product upsell is displayed on page load.

To test this PR:

* Remove any existing purchases, then follow the same same steps as above.
* Observe that when the product page loads, the upsell is no longer visible.

#### Upsell reference screenshots

<img width="740" alt="image" src="https://user-images.githubusercontent.com/670067/90649644-92438f80-e200-11ea-902c-94184c976f79.png">

<img width="739" alt="image" src="https://user-images.githubusercontent.com/670067/90649699-9c658e00-e200-11ea-9454-4bd62bf74bf5.png">