### PR TITLE
Social Previews: update Facebook preview to reflect current look

### DIFF
--- a/packages/social-previews/src/facebook-preview/index.jsx
+++ b/packages/social-previews/src/facebook-preview/index.jsx
@@ -39,12 +39,12 @@ export class FacebookPreview extends PureComponent {
 						{ image && <img alt="Facebook Preview Thumbnail" src={ image } /> }
 					</div>
 					<div className="facebook-preview__body">
+						<div className="facebook-preview__url">
+							{ compact( [ baseDomain( url ), author ] ).join( ' | ' ) }
+						</div>
 						<div className="facebook-preview__title">{ facebookTitle( title || '' ) }</div>
 						<div className="facebook-preview__description">
 							{ facebookDescription( stripHtmlTags( description ) ) }
-						</div>
-						<div className="facebook-preview__url">
-							{ compact( [ baseDomain( url ), author ] ).join( ' | ' ) }
 						</div>
 					</div>
 				</div>

--- a/packages/social-previews/src/facebook-preview/style.scss
+++ b/packages/social-previews/src/facebook-preview/style.scss
@@ -13,7 +13,6 @@
 
 .facebook-preview {
 	border: none;
-	box-shadow: 0 0 0 1px rgba( 0, 0, 0, 0.15 ) inset, 0 1px 4px rgba( 0, 0, 0, 0.1 );
 	display: flex;
 	overflow-x: auto;
 	max-width: 527px;

--- a/packages/social-previews/src/facebook-preview/style.scss
+++ b/packages/social-previews/src/facebook-preview/style.scss
@@ -114,6 +114,10 @@
 		height: 158px;
 		width: 158px;
 
+		box-sizing: border-box;
+		border: 1px solid #dadde1;
+		border-right: 0;
+
 		& img {
 			display: block;
 			font-size: $font-body-small;
@@ -126,9 +130,6 @@
 			display: block;
 			height: 100%;
 			width: 100%;
-			box-sizing: border-box;
-			border: 1px solid #dadde1;
-			border-right: 0;
 			background: #ffffff;
 		}
 	}

--- a/packages/social-previews/src/facebook-preview/style.scss
+++ b/packages/social-previews/src/facebook-preview/style.scss
@@ -18,19 +18,21 @@
 	display: flex;
 	overflow-x: auto;
 	max-width: 527px;
-	margin: 0 auto;
+	margin: 20px;
 	-webkit-overflow-scrolling: touch;
 }
 
 .facebook-preview__content {
 	display: flex;
 	max-width: 100%;
+	background-color: #f2f3f5;
 }
 
 .facebook-preview__body {
 	display: flex;
 	flex-direction: column;
-	margin: 10px 12px;
+	padding: 10px 12px;
+	border: 1px solid #dadde1;
 	overflow: hidden;
 	font-family: Helvetica, Arial, sans-serif;
 }

--- a/packages/social-previews/src/facebook-preview/style.scss
+++ b/packages/social-previews/src/facebook-preview/style.scss
@@ -61,6 +61,7 @@
 	text-transform: uppercase;
 	text-overflow: ellipsis;
 	white-space: nowrap;
+	overflow: hidden;
 }
 
 .facebook-preview__article {

--- a/packages/social-previews/src/facebook-preview/style.scss
+++ b/packages/social-previews/src/facebook-preview/style.scss
@@ -34,8 +34,9 @@
 .facebook-preview__title {
 	color: #1d2129;
 	font-family: Georgia, serif;
-	/* stylelint-disable-next-line scales/font-weight */
+	/* stylelint-disable-next-line scales/font-size */
 	font-size: 18px;
+	/* stylelint-disable-next-line scales/font-weight */
 	font-weight: 600;
 	line-height: 22px;
 	max-height: 100px;

--- a/packages/social-previews/src/facebook-preview/style.scss
+++ b/packages/social-previews/src/facebook-preview/style.scss
@@ -129,6 +129,7 @@
 			box-sizing: border-box;
 			border: 1px solid #dadde1;
 			border-right: 0;
+			background: #ffffff;
 		}
 	}
 

--- a/packages/social-previews/src/facebook-preview/style.scss
+++ b/packages/social-previews/src/facebook-preview/style.scss
@@ -89,7 +89,13 @@
 	}
 
 	.facebook-preview__title {
-		margin-bottom: 6px;
+		margin-bottom: 1px;
+	}
+
+	.facebook-preview__description {
+		display: -webkit-box;
+		-webkit-line-clamp: 1;
+		-webkit-box-orient: vertical;
 	}
 
 	.facebook-preview__url {

--- a/packages/social-previews/src/facebook-preview/style.scss
+++ b/packages/social-previews/src/facebook-preview/style.scss
@@ -30,11 +30,11 @@
 	flex-direction: column;
 	margin: 10px 12px;
 	overflow: hidden;
+	font-family: Helvetica, Arial, sans-serif;
 }
 
 .facebook-preview__title {
 	color: #1d2129;
-	font-family: Georgia, serif;
 	/* stylelint-disable-next-line scales/font-size */
 	font-size: 16px;
 	/* stylelint-disable-next-line scales/font-weight */
@@ -46,7 +46,6 @@
 
 .facebook-preview__description {
 	color: #606770;
-	font-family: helvetica, arial, sans-serif;
 	font-size: $font-body-extra-small;
 	line-height: 16px;
 	overflow-y: hidden;
@@ -54,7 +53,6 @@
 
 .facebook-preview__url {
 	color: #606770;
-	font-family: helvetica, arial, sans-serif;
 	font-size: $font-body-extra-small;
 	line-height: 12px;
 	text-transform: uppercase;

--- a/packages/social-previews/src/facebook-preview/style.scss
+++ b/packages/social-previews/src/facebook-preview/style.scss
@@ -133,6 +133,7 @@
 	.facebook-preview__title {
 		margin-bottom: 5px;
 		max-height: 110px;
+		overflow-wrap: break-word;
 	}
 
 	.facebook-preview__url {

--- a/packages/social-previews/src/facebook-preview/style.scss
+++ b/packages/social-previews/src/facebook-preview/style.scss
@@ -34,8 +34,8 @@
 .facebook-preview__title {
 	color: #1d2129;
 	font-family: Georgia, serif;
-	font-size: 18px;
 	/* stylelint-disable-next-line scales/font-weight */
+	font-size: 18px;
 	font-weight: 600;
 	line-height: 22px;
 	max-height: 100px;
@@ -44,7 +44,6 @@
 
 .facebook-preview__description {
 	color: #1d2129;
-	flex-grow: 1;
 	font-family: helvetica, arial, sans-serif;
 	font-size: $font-body-extra-small;
 	line-height: 16px;
@@ -91,7 +90,7 @@
 	}
 
 	.facebook-preview__url {
-		margin-top: 9px;
+		margin-bottom: 5px;
 	}
 }
 
@@ -123,6 +122,8 @@
 
 	.facebook-preview__body {
 		width: 100%;
+		height: 136px; //value in Facebook's styles
+		justify-content: center;
 	}
 
 	.facebook-preview__title {
@@ -131,7 +132,9 @@
 	}
 
 	.facebook-preview__url {
-		margin-top: auto;
 		margin-bottom: 5px;
+	}
+	.facebook-preview__description {
+		max-height: 80px; //value in Facebook's styles
 	}
 }

--- a/packages/social-previews/src/facebook-preview/style.scss
+++ b/packages/social-previews/src/facebook-preview/style.scss
@@ -45,7 +45,7 @@
 }
 
 .facebook-preview__description {
-	color: #1d2129;
+	color: #606770;
 	font-family: helvetica, arial, sans-serif;
 	font-size: $font-body-extra-small;
 	line-height: 16px;

--- a/packages/social-previews/src/facebook-preview/style.scss
+++ b/packages/social-previews/src/facebook-preview/style.scss
@@ -11,6 +11,8 @@
 
 @import '../variables.scss';
 
+/* stylelint-disable scales/font-size */
+
 .facebook-preview {
 	border: none;
 	display: flex;
@@ -35,7 +37,7 @@
 
 .facebook-preview__title {
 	color: #1d2129;
-	/* stylelint-disable-next-line scales/font-size */
+	
 	font-size: 16px;
 	/* stylelint-disable-next-line scales/font-weight */
 	font-weight: 600;
@@ -46,15 +48,15 @@
 
 .facebook-preview__description {
 	color: #606770;
-	font-size: $font-body-extra-small;
-	line-height: 16px;
+	font-size: 14px; //value in Facebook's styles
+	line-height: 20px; //value in Facebook's styles
 	overflow-y: hidden;
 }
 
 .facebook-preview__url {
 	color: #606770;
-	font-size: $font-body-extra-small;
-	line-height: 12px;
+	font-size: 12px; //value in Facebook's styles
+	line-height: 11px; //value in Facebook's styles
 	text-transform: uppercase;
 	text-overflow: ellipsis;
 	white-space: nowrap;
@@ -87,7 +89,7 @@
 	}
 
 	.facebook-preview__title {
-		margin-bottom: 5px;
+		margin-bottom: 6px;
 	}
 
 	.facebook-preview__url {

--- a/packages/social-previews/src/facebook-preview/style.scss
+++ b/packages/social-previews/src/facebook-preview/style.scss
@@ -36,10 +36,10 @@
 	color: #1d2129;
 	font-family: Georgia, serif;
 	/* stylelint-disable-next-line scales/font-size */
-	font-size: 18px;
+	font-size: 16px;
 	/* stylelint-disable-next-line scales/font-weight */
 	font-weight: 600;
-	line-height: 22px;
+	line-height: 20px;
 	max-height: 100px;
 	transition: color 0.1s ease-in-out;
 }

--- a/packages/social-previews/src/facebook-preview/style.scss
+++ b/packages/social-previews/src/facebook-preview/style.scss
@@ -122,12 +122,13 @@
 		}
 
 		&::after {
-			border: 1px solid;
-			border-color: rgba( 0, 0, 0, 0.098 ) rgba( 0, 0, 0, 0.149 ) rgba( 0, 0, 0, 0.231 );
 			content: '';
 			display: block;
 			height: 100%;
 			width: 100%;
+			box-sizing: border-box;
+			border: 1px solid #dadde1;
+			border-right: 0;
 		}
 	}
 

--- a/packages/social-previews/src/facebook-preview/style.scss
+++ b/packages/social-previews/src/facebook-preview/style.scss
@@ -23,12 +23,14 @@
 
 .facebook-preview__content {
 	display: flex;
+	max-width: 100%;
 }
 
 .facebook-preview__body {
 	display: flex;
 	flex-direction: column;
 	margin: 10px 12px;
+	overflow: hidden;
 }
 
 .facebook-preview__title {


### PR DESCRIPTION

This PR aims to bring the Facebook Preview of Social Previews in line with the current look of Facebook's preview.

The related issue is https://github.com/Automattic/wp-calypso/issues/44799

## Screenshots

**Website - Facebook Sharing Debugger**

<img width="552" alt="Screenshot 2020-08-19 at 16 29 17" src="https://user-images.githubusercontent.com/1562646/90648380-bbccdd00-e239-11ea-9beb-1fc433998503.png">

**Website - Facebook Social Preview**

|Before|After|
|-|-|
| <img width="553" alt="Screenshot 2020-08-19 at 16 31 48" src="https://user-images.githubusercontent.com/1562646/90648591-04849600-e23a-11ea-853b-947b2bac0f64.png"> | <img width="591" alt="Screenshot 2020-08-19 at 16 29 26" src="https://user-images.githubusercontent.com/1562646/90648666-1b2aed00-e23a-11ea-8eba-23166923f777.png"> |


---

**Article - Facebook Sharing Debugger**

<img width="551" alt="Screenshot 2020-08-19 at 16 29 20" src="https://user-images.githubusercontent.com/1562646/90649360-e9feec80-e23a-11ea-8f93-7a0374b847c8.png">


**Article - Facebook Social Preview**

|Before|After|
|-|-|
| ![Screenshot 2020-08-19 at 16 32 00](https://user-images.githubusercontent.com/1562646/90649117-9f7d7000-e23a-11ea-8789-96f8ef166aad.jpg) |![Screenshot 2020-08-19 at 16 29 23](https://user-images.githubusercontent.com/1562646/90649263-d0f63b80-e23a-11ea-8e96-17254a2c0740.jpg) |


## Changes proposed in this Pull Request

This PR introduces the following changes to the Facebook Preview:

1. Changes to both the `website` and `article` previews:
- Move URL to the top
- Add background and border
- Ensure text content stays within body boundaries
- Add ellipsis to long URLs
- Change description color
- Remove box shadow around preview area
- Update title font size, line height and font family
- Update URL & description font size and line height

2. Changes the `website` preview
- Center text content when site tagline is short
- Ensure title wraps for very long words

3. Changes the `article` preview
- Clamp description after one line


## Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

For both previews:

- check out branch and `yarn start`

For Website preview:
- Navigate to http://calypso.localhost:3000/view and pick a site
- once loaded, switch to the "Search & Social" Facebook preview and check changes described above

For Article preview:
- Navigate to a post or page with adequate content and select Preview
- once loaded, switch to the "Search & Social" Facebook preview and check changes described above
