### PR TITLE
Update copy for plans product cards

### DIFF
--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -222,9 +222,12 @@ export const FEATURE_JETPACK_SEARCH_MONTHLY = PRODUCT_JETPACK_SEARCH_MONTHLY;
 
 // jetpack features constants (offer reset)
 export const FEATURE_SECURITY_REALTIME_V2 = Symbol();
+export const FEATURE_BACKUP_V2 = Symbol();
 export const FEATURE_BACKUP_REALTIME_V2 = Symbol();
+export const FEATURE_SCAN_V2 = Symbol();
 export const FEATURE_SCAN_REALTIME_V2 = Symbol();
 export const FEATURE_ANTISPAM_V2 = Symbol();
+export const FEATURE_ACTIVITY_LOG_V2 = Symbol();
 export const FEATURE_ACTIVITY_LOG_ARCHIVE_V2 = Symbol();
 export const FEATURE_SEARCH_V2 = Symbol();
 export const FEATURE_VIDEO_HOSTING_V2 = Symbol();

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -223,12 +223,15 @@ export const FEATURE_JETPACK_SEARCH_MONTHLY = PRODUCT_JETPACK_SEARCH_MONTHLY;
 // jetpack features constants (offer reset)
 export const FEATURE_SECURITY_REALTIME_V2 = Symbol();
 export const FEATURE_BACKUP_V2 = Symbol();
+export const FEATURE_BACKUP_DAILY_V2 = Symbol();
 export const FEATURE_BACKUP_REALTIME_V2 = Symbol();
 export const FEATURE_SCAN_V2 = Symbol();
+export const FEATURE_SCAN_DAILY_V2 = Symbol();
 export const FEATURE_SCAN_REALTIME_V2 = Symbol();
 export const FEATURE_ANTISPAM_V2 = Symbol();
 export const FEATURE_ACTIVITY_LOG_V2 = Symbol();
-export const FEATURE_ACTIVITY_LOG_ARCHIVE_V2 = Symbol();
+export const FEATURE_ACTIVITY_LOG_1_YEAR_V2 = Symbol();
+export const FEATURE_ACTIVITY_LOG_30_DAYS_V2 = Symbol();
 export const FEATURE_SEARCH_V2 = Symbol();
 export const FEATURE_VIDEO_HOSTING_V2 = Symbol();
 export const FEATURE_CRM_V2 = Symbol();

--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -1032,6 +1032,21 @@ export const FEATURES_LIST = {
 			),
 	},
 
+	[ constants.FEATURE_BACKUP_V2 ]: {
+		getSlug: () => constants.FEATURE_BACKUP_V2,
+		getIcon: () => 'cloud-upload',
+		getTitle: () => i18n.translate( 'Backup' ),
+		getDescription: () =>
+			i18n.translate(
+				'Automatic backups of your entire site, with unlimited, WordPress-optimized secure storage. {{link}}Learn more{{/link}}.',
+				{
+					components: {
+						link: <a href="https://jetpack.com/upgrade/backup/"></a>,
+					},
+				}
+			),
+	},
+
 	[ constants.FEATURE_BACKUP_REALTIME_V2 ]: {
 		getSlug: () => constants.FEATURE_BACKUP_REALTIME_V2,
 		getIcon: () => 'cloud-upload',
@@ -1047,6 +1062,20 @@ export const FEATURES_LIST = {
 				{
 					components: {
 						link: <a href="https://jetpack.com/upgrade/backup/"></a>,
+					},
+				}
+			),
+	},
+
+	[ constants.FEATURE_SCAN_V2 ]: {
+		getSlug: () => constants.FEATURE_SCAN_V2,
+		getTitle: () => i18n.translate( 'Scan' ),
+		getDescription: () =>
+			i18n.translate(
+				'Automated scanning for security vulnerabilities or threats on your site. Includes instant notifications and automatic security fixes. {{link}}Learn more{{/link}}.',
+				{
+					components: {
+						link: <a href="https://jetpack.com/upgrade/scan/"></a>,
 					},
 				}
 			),
@@ -1082,6 +1111,20 @@ export const FEATURES_LIST = {
 				{
 					components: {
 						link: <a href="https://jetpack.com/upgrade/anti-spam/"></a>,
+					},
+				}
+			),
+	},
+
+	[ constants.FEATURE_ACTIVITY_LOG_V2 ]: {
+		getSlug: () => constants.FEATURE_ACTIVITY_LOG_V2,
+		getTitle: () => i18n.translate( 'Activity log' ),
+		getDescription: () =>
+			i18n.translate(
+				'View every change to your site. Pairs with Backup to restore your site to any earlier version. {{link}}Learn more.{{/link}}',
+				{
+					components: {
+						link: <a href="https://jetpack.com/features/security/activity-log/"></a>,
 					},
 				}
 			),

--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -1047,6 +1047,26 @@ export const FEATURES_LIST = {
 			),
 	},
 
+	[ constants.FEATURE_BACKUP_DAILY_V2 ]: {
+		getSlug: () => constants.FEATURE_BACKUP_DAILY_V2,
+		getIcon: () => 'cloud-upload',
+		getTitle: () =>
+			i18n.translate( 'Backup {{em}}Daily{{/em}}', {
+				components: {
+					em: <em />,
+				},
+			} ),
+		getDescription: () =>
+			i18n.translate(
+				'Automatic daily backups of your entire site, with unlimited, WordPress-optimized secure storage. {{link}}Learn more{{/link}}.',
+				{
+					components: {
+						link: <a href="https://jetpack.com/upgrade/backup/"></a>,
+					},
+				}
+			),
+	},
+
 	[ constants.FEATURE_BACKUP_REALTIME_V2 ]: {
 		getSlug: () => constants.FEATURE_BACKUP_REALTIME_V2,
 		getIcon: () => 'cloud-upload',
@@ -1069,10 +1089,31 @@ export const FEATURES_LIST = {
 
 	[ constants.FEATURE_SCAN_V2 ]: {
 		getSlug: () => constants.FEATURE_SCAN_V2,
+		getIcon: () => '',
 		getTitle: () => i18n.translate( 'Scan' ),
 		getDescription: () =>
 			i18n.translate(
 				'Automated scanning for security vulnerabilities or threats on your site. Includes instant notifications and automatic security fixes. {{link}}Learn more{{/link}}.',
+				{
+					components: {
+						link: <a href="https://jetpack.com/upgrade/scan/"></a>,
+					},
+				}
+			),
+	},
+
+	[ constants.FEATURE_SCAN_DAILY_V2 ]: {
+		getSlug: () => constants.FEATURE_SCAN_DAILY_V2,
+		getIcon: () => '',
+		getTitle: () =>
+			i18n.translate( 'Scan {{em}}Daily{{/em}}', {
+				components: {
+					em: <em />,
+				},
+			} ),
+		getDescription: () =>
+			i18n.translate(
+				'Automated daily scanning for security vulnerabilities or threats on your site. Includes instant notifications and automatic security fixes. {{link}}Learn more{{/link}}.',
 				{
 					components: {
 						link: <a href="https://jetpack.com/upgrade/scan/"></a>,
@@ -1130,8 +1171,22 @@ export const FEATURES_LIST = {
 			),
 	},
 
-	[ constants.FEATURE_ACTIVITY_LOG_ARCHIVE_V2 ]: {
-		getSlug: () => constants.FEATURE_ACTIVITY_LOG_ARCHIVE_V2,
+	[ constants.FEATURE_ACTIVITY_LOG_30_DAYS_V2 ]: {
+		getSlug: () => constants.FEATURE_ACTIVITY_LOG_30_DAYS_V2,
+		getTitle: () => i18n.translate( 'Activity log: 30-day archive' ),
+		getDescription: () =>
+			i18n.translate(
+				'View every change to your site in the last 30 days. Pairs with Backup to restore your site to any earlier version. {{link}}Learn more.{{/link}}',
+				{
+					components: {
+						link: <a href="https://jetpack.com/features/security/activity-log/"></a>,
+					},
+				}
+			),
+	},
+
+	[ constants.FEATURE_ACTIVITY_LOG_1_YEAR_V2 ]: {
+		getSlug: () => constants.FEATURE_ACTIVITY_LOG_1_YEAR_V2,
 		getTitle: () => i18n.translate( 'Activity log: 1-year archive' ),
 		getDescription: () =>
 			i18n.translate(

--- a/client/lib/plans/plans-list.js
+++ b/client/lib/plans/plans-list.js
@@ -372,8 +372,7 @@ const getPlanBusinessDetails = () => ( {
 const getPlanJetpackSecurityDailyDetails = () => ( {
 	group: constants.GROUP_JETPACK,
 	type: constants.TYPE_SECURITY,
-	getTitle: () =>
-		translate( 'Jetpack Security {{em}}Daily{{/em}}', { components: { em: <em /> } } ),
+	getTitle: () => translate( 'Security {{em}}Daily{{/em}}', { components: { em: <em /> } } ),
 	getAudience: () => translate(),
 	availableFor: ( plan ) =>
 		[ constants.PLAN_JETPACK_FREE, ...constants.JETPACK_LEGACY_PLANS ].includes( plan ),
@@ -384,6 +383,21 @@ const getPlanJetpackSecurityDailyDetails = () => ( {
 		),
 	getTagline: () => translate( 'Best for sites with occasional updates' ),
 	getPlanCompareFeatures: () => [],
+	getPlanCardFeatures: () => ( {
+		[ constants.FEATURE_CATEGORY_SECURITY ]: [
+			constants.FEATURE_BACKUP_DAILY_V2,
+			constants.FEATURE_SCAN_DAILY_V2,
+			constants.FEATURE_ANTISPAM_V2,
+			constants.FEATURE_ACTIVITY_LOG_30_DAYS_V2,
+		],
+		[ constants.FEATURE_CATEGORY_OTHER ]: [
+			constants.FEATURE_VIDEO_HOSTING_V2,
+			constants.FEATURE_SOCIAL_MEDIA_POSTING_V2,
+			constants.FEATURE_COLLECT_PAYMENTS_V2,
+			constants.FEATURE_SITE_MONETIZATION_V2,
+			constants.FEATURE_PRIORITY_SUPPORT_V2,
+		],
+	} ),
 	getSignupFeatures: () => [],
 	getHiddenFeatures: () => [
 		constants.FEATURE_JETPACK_BACKUP_DAILY,
@@ -456,7 +470,7 @@ const getPlanJetpackCompleteDetails = () => ( {
 					constants.FEATURE_BACKUP_REALTIME_V2,
 					constants.FEATURE_SCAN_REALTIME_V2,
 					constants.FEATURE_ANTISPAM_V2,
-					constants.FEATURE_ACTIVITY_LOG_ARCHIVE_V2,
+					constants.FEATURE_ACTIVITY_LOG_1_YEAR_V2,
 				],
 			],
 		],

--- a/client/lib/plans/plans-list.js
+++ b/client/lib/plans/plans-list.js
@@ -413,8 +413,7 @@ const getPlanJetpackSecurityDailyDetails = () => ( {
 const getPlanJetpackSecurityRealtimeDetails = () => ( {
 	group: constants.GROUP_JETPACK,
 	type: constants.TYPE_SECURITY,
-	getTitle: () =>
-		translate( 'Jetpack Security {{em}}Real-time{{/em}}', { components: { em: <em /> } } ),
+	getTitle: () => translate( 'Security {{em}}Real-time{{/em}}', { components: { em: <em /> } } ),
 	getAudience: () => translate(),
 	availableFor: ( plan ) =>
 		[
@@ -430,6 +429,22 @@ const getPlanJetpackSecurityRealtimeDetails = () => ( {
 		),
 	getTagline: () => translate( 'Best for sites with frequent updates' ),
 	getPlanCompareFeatures: () => [],
+	getPlanCardFeatures: () => ( {
+		[ constants.FEATURE_CATEGORY_SECURITY ]: [
+			constants.FEATURE_BACKUP_REALTIME_V2,
+			constants.FEATURE_SCAN_REALTIME_V2,
+			constants.FEATURE_ANTISPAM_V2,
+			constants.FEATURE_ACTIVITY_LOG_1_YEAR_V2,
+		],
+		[ constants.FEATURE_CATEGORY_OTHER ]: [
+			constants.FEATURE_PREMIUM_THEMES_V2,
+			constants.FEATURE_VIDEO_HOSTING_V2,
+			constants.FEATURE_SOCIAL_MEDIA_POSTING_V2,
+			constants.FEATURE_COLLECT_PAYMENTS_V2,
+			constants.FEATURE_SITE_MONETIZATION_V2,
+			constants.FEATURE_PRIORITY_SUPPORT_V2,
+		],
+	} ),
 	getSignupFeatures: () => [],
 	getHiddenFeatures: () => [
 		constants.FEATURE_JETPACK_BACKUP_REALTIME,

--- a/client/my-sites/plans-v2/constants.ts
+++ b/client/my-sites/plans-v2/constants.ts
@@ -33,7 +33,19 @@ import {
 	PLAN_JETPACK_PREMIUM_MONTHLY,
 	PLAN_JETPACK_BUSINESS,
 	PLAN_JETPACK_BUSINESS_MONTHLY,
+	FEATURE_CATEGORY_SECURITY,
+	FEATURE_BACKUP_V2,
+	FEATURE_SCAN_V2,
+	FEATURE_ANTISPAM_V2,
+	FEATURE_ACTIVITY_LOG_V2,
+	FEATURE_CATEGORY_OTHER,
+	FEATURE_VIDEO_HOSTING_V2,
+	FEATURE_SOCIAL_MEDIA_POSTING_V2,
+	FEATURE_COLLECT_PAYMENTS_V2,
+	FEATURE_SITE_MONETIZATION_V2,
+	FEATURE_PRIORITY_SUPPORT_V2,
 } from 'lib/plans/constants';
+import { buildCardFeaturesFromItem } from './utils';
 
 /**
  * Type dependencies
@@ -48,6 +60,14 @@ export const SECURITY = 'security';
 // TODO: update before offer reset launch
 export const OFFER_RESET_SUPPORT_PAGE = 'https://jetpack.com/support/';
 export const PLAN_COMPARISON_PAGE = 'https://jetpack.com/features/comparison/';
+
+/**
+ * Link to plan comparison page.
+ */
+export const MORE_FEATURES_LINK = {
+	url: PLAN_COMPARISON_PAGE,
+	label: translate( 'See all features' ),
+};
 
 /*
  * Options displayed in the Product Type filter in the Plans page.
@@ -102,7 +122,24 @@ export const OPTION_PLAN_SECURITY: SelectorProduct = {
 		'Enjoy the peace of mind of complete site security. ' +
 			'Easy-to-use, powerful security tools guard your site, so you can focus on your business.'
 	),
-	features: { items: [] },
+	features: {
+		items: buildCardFeaturesFromItem( {
+			[ FEATURE_CATEGORY_SECURITY ]: [
+				FEATURE_BACKUP_V2,
+				FEATURE_SCAN_V2,
+				FEATURE_ANTISPAM_V2,
+				FEATURE_ACTIVITY_LOG_V2,
+			],
+			[ FEATURE_CATEGORY_OTHER ]: [
+				FEATURE_VIDEO_HOSTING_V2,
+				FEATURE_SOCIAL_MEDIA_POSTING_V2,
+				FEATURE_COLLECT_PAYMENTS_V2,
+				FEATURE_SITE_MONETIZATION_V2,
+				FEATURE_PRIORITY_SUPPORT_V2,
+			],
+		} ),
+		more: MORE_FEATURES_LINK,
+	},
 };
 export const OPTION_PLAN_SECURITY_MONTHLY: SelectorProduct = {
 	...OPTION_PLAN_SECURITY,

--- a/client/my-sites/plans-v2/style.scss
+++ b/client/my-sites/plans-v2/style.scss
@@ -9,6 +9,7 @@
 		& > .details__column {
 			flex-basis: 50%;
 			flex-grow: 0;
+			align-self: flex-start;
 		}
 
 		& > .products-column,

--- a/client/my-sites/plans-v2/utils.ts
+++ b/client/my-sites/plans-v2/utils.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { translate, TranslateResult } from 'i18n-calypso';
-import { compact, get, isArray, isObject } from 'lodash';
+import { compact, get, isArray, isObject, isString } from 'lodash';
 
 /**
  * Internal dependencies
@@ -38,6 +38,7 @@ import { MORE_FEATURES_LINK } from 'my-sites/plans-v2/constants';
 /**
  * Type dependencies
  */
+import type { ReactElement } from 'react';
 import type {
 	Duration,
 	SelectorProduct,
@@ -95,13 +96,19 @@ export function productButtonLabel( product: SelectorProduct, isOwned: boolean )
 			: translate( 'Manage Subscription' );
 	}
 
-	return (
-		product.buttonLabel ??
-		translate( 'Get %s', {
-			args: product.displayName,
-			comment: '%s is the name of a product',
-		} )
-	);
+	const { buttonLabel, displayName } = product;
+
+	return buttonLabel ?? isString( displayName )
+		? translate( 'Get %s', {
+				args: displayName,
+				comment: '%s is the name of a product',
+		  } )
+		: translate( 'Get {{name/}}', {
+				components: {
+					name: displayName as ReactElement,
+				},
+				comment: '{{name/}} is the name of a product',
+		  } );
 }
 
 export function productBadgeLabel(
@@ -283,11 +290,11 @@ export function buildCardFeatureItemFromFeatureKey(
  * Builds the feature items passed to the product card, from feature keys.
  *
  * @param {JetpackPlanCardFeature[] | JetpackPlanCardFeatureSection} features Feature keys
- * @returns {ProductCardFeaturesItems} Features
+ * @returns {SelectorProductFeaturesItem[] | SelectorProductFeaturesSection[]} Features
  */
 export function buildCardFeaturesFromFeatureKeys(
 	features: JetpackPlanCardFeature[] | JetpackPlanCardFeatureSection
-): ProductCardFeaturesItems {
+): SelectorProductFeaturesItem[] | SelectorProductFeaturesSection[] {
 	// Without sections (JetpackPlanCardFeature[])
 	if ( isArray( features ) ) {
 		return compact( features.map( buildCardFeatureItemFromFeatureKey ) );
@@ -309,7 +316,7 @@ export function buildCardFeaturesFromFeatureKeys(
 			}
 		} );
 
-		return compact( result );
+		return result;
 	}
 
 	return [];
@@ -319,11 +326,11 @@ export function buildCardFeaturesFromFeatureKeys(
  * Builds the feature items passed to the product card, from a plan, product, or object.
  *
  * @param {Plan | Product | object} item Product, plan, or object
- * @returns {ProductCardFeaturesItems} Features
+ * @returns {SelectorProductFeaturesItem[] | SelectorProductFeaturesSection[]} Features
  */
 export function buildCardFeaturesFromItem(
 	item: Plan | Product | object
-): ProductCardFeaturesItems {
+): SelectorProductFeaturesItem[] | SelectorProductFeaturesSection[] {
 	if ( objectIsPlan( item ) ) {
 		const features = item.getPlanCardFeatures?.();
 

--- a/client/my-sites/plans-v2/utils.ts
+++ b/client/my-sites/plans-v2/utils.ts
@@ -2,7 +2,8 @@
  * External dependencies
  */
 import { translate, TranslateResult } from 'i18n-calypso';
-import { compact, get, isArray, isObject, isString } from 'lodash';
+import { compact, get, isArray, isObject } from 'lodash';
+import { createElement, Fragment } from 'react';
 
 /**
  * Internal dependencies
@@ -38,7 +39,6 @@ import { MORE_FEATURES_LINK } from 'my-sites/plans-v2/constants';
 /**
  * Type dependencies
  */
-import type { ReactElement } from 'react';
 import type {
 	Duration,
 	SelectorProduct,
@@ -98,17 +98,15 @@ export function productButtonLabel( product: SelectorProduct, isOwned: boolean )
 
 	const { buttonLabel, displayName } = product;
 
-	return buttonLabel ?? isString( displayName )
-		? translate( 'Get %s', {
-				args: displayName,
-				comment: '%s is the name of a product',
-		  } )
-		: translate( 'Get {{name/}}', {
-				components: {
-					name: displayName as ReactElement,
-				},
-				comment: '{{name/}} is the name of a product',
-		  } );
+	return (
+		buttonLabel ??
+		translate( 'Get {{name/}}', {
+			components: {
+				name: createElement( Fragment, {}, displayName ),
+			},
+			comment: '{{name/}} is the name of a product',
+		} )
+	);
 }
 
 export function productBadgeLabel(


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR includes the final copy for the Jetpack Security, Security _Daily_, and Security _Real-time_ product cards.

Jetpack Complete was handled in https://github.com/Automattic/wp-calypso/pull/45009.

### Implementation notes

I did some refactoring in `client/my-sites/plans-v2/utils.ts` to handle Jetpack Security that's not a plan, codewise. The diff is hard to read, check the file instead.

_Note: Missing icons will be added in a separate PR._

### Testing instructions

- Visit the _Plans_ page with the offer reset flow enabled
- Check the copy of the Jetpack Security product card against the copydeck
- Don't forget to check the descriptions and links in the tooltips
- Click on "Get Jetpack Security"
- Check the copy of the Security _Daily_ and _Real-time_ cards against the copydeck

### Screenshots

Security
<img width="529" alt="Screen Shot 2020-08-19 at 2 47 18 PM" src="https://user-images.githubusercontent.com/1620183/90677169-f67b4900-e22a-11ea-9540-d2d6b9f8abbd.png">

Security options
<img width="1081" alt="Screen Shot 2020-08-19 at 2 47 02 PM" src="https://user-images.githubusercontent.com/1620183/90677147-f24f2b80-e22a-11ea-8ec4-de42be6d2e6c.png">
