### PR TITLE
G Suite: Enables self-cancelations for subscriptions attached to an AT site

### DIFF
--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -61,6 +61,7 @@ import {
 	isDomainRegistration,
 	isDomainMapping,
 	isDomainTransfer,
+	isGoogleApps,
 	isTheme,
 	isJetpackProduct,
 	isConciergeSession,
@@ -319,7 +320,7 @@ class ManagePurchase extends Component {
 		let text,
 			link = cancelPurchase( this.props.siteSlug, id );
 
-		if ( isAtomicSite && isSubscription( purchase ) ) {
+		if ( isAtomicSite && isSubscription( purchase ) && ! isGoogleApps( purchase ) ) {
 			text = translate( 'Contact Support to Cancel your Subscription' );
 			link = CALYPSO_CONTACT;
 		} else if ( hasAmountAvailableToRefund( purchase ) ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is a complement to #39275 which deals with removing a purchase. This more specifically deals with canceling a refundable purchase. It handles another manifestation of the issue where refundable subscriptions associated with an AT site aren't allowed to cancel without support.

Where users should be able to cancel, instead they see:

<img width="545" alt="Screenshot 2020-08-20 at 2 34 51 AM" src="https://user-images.githubusercontent.com/277661/90706766-dd57b400-e28d-11ea-8aef-789d885a542d.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* An AT side is needed for testing, with an associated G Suite subscription. The G Suite subscription should be within the refundable window. Ensure your site is launched/public, and that the hosting configuration is activated. 
* Create or access a  G Suite account in **Manage Purchases**
* Confirm that you are presented with a button to `Cancel Subscription and Refund`
* Confirm canceling the subscription is successful.




