### PR TITLE
Pauses the reskin signup flow abtest

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -225,7 +225,7 @@ export default {
 		countryCodeTargets: [ 'US', 'CA' ],
 	},
 	reskinSignupFlow: {
-		datestamp: '20200812',
+		datestamp: '20210812',
 		variations: {
 			reskinned: 50,
 			control: 50,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Changes the datestamp so that users are not assigned to either control or variant.

#### Testing instructions

* Using private browsing mode, go to https://wordpress.com/start using a non EN/ES locale. You should not be assigned to the `reskinSignupFlow` abtest.
* `localstorage.ABTests` should not contain`reskinSignupFlow`.