### PR TITLE
Signup: Updates to the reskinned flow abtest

### DIFF
--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -7,7 +7,6 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
 import { get, includes, times, first } from 'lodash';
-import { isMobile } from '@automattic/viewport';
 
 /**
  * Internal dependencies
@@ -59,7 +58,6 @@ class DomainSearchResults extends React.Component {
 		fetchAlgo: PropTypes.string,
 		pendingCheckSuggestion: PropTypes.object,
 		unavailableDomains: PropTypes.array,
-		isReskinned: PropTypes.bool,
 	};
 
 	componentDidUpdate() {
@@ -226,8 +224,7 @@ class DomainSearchResults extends React.Component {
 	}
 
 	renderDomainSuggestions() {
-		const { isDomainOnly, suggestions, isReskinned } = this.props;
-		const isReskinnedAndNotOnMobile = isReskinned && ! isMobile();
+		const { isDomainOnly, suggestions } = this.props;
 		let suggestionCount;
 		let featuredSuggestionElement;
 		let suggestionElements;
@@ -295,7 +292,6 @@ class DomainSearchResults extends React.Component {
 						isEligibleVariantForDomainTest={ this.props.isEligibleVariantForDomainTest }
 						selectedFreePlanInSwapFlow={ this.props.selectedFreePlanInSwapFlow }
 						selectedPaidPlanInSwapFlow={ this.props.selectedPaidPlanInSwapFlow }
-						buttonStyles={ { primary: isReskinnedAndNotOnMobile } }
 					/>
 				);
 			} );

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -259,7 +259,7 @@
 body.is-section-signup.is-white-signup {
 	.featured-domain-suggestions {
 		.domain-registration-suggestion__title {
-			font-size: 1.625rem;
+			font-size: $font-title-medium;
 		}
 	}
 
@@ -286,14 +286,6 @@ body.is-section-signup.is-white-signup {
 		}
 
 		&:not( .featured-domain-suggestion ) {
-
-			.domain-suggestion__content {
-				@include breakpoint-deprecated( '>660px' ) {
-					&.domain-suggestion__content-domain-copy-test {
-						justify-content: space-between;
-					}
-				}
-			}
 
 			.domain-registration-suggestion__domain-title {
 				line-height: 3rem;
@@ -330,28 +322,16 @@ body.is-section-signup.is-white-signup {
 				@include break-mobile {
 					background: var( --color-primary-0 );
 					box-shadow: 0 0 0 1px var( --color-primary-40 );
-
-					.domain-suggestion__action:not( .is-borderless ) {
-						border-radius: 4px;
-						display: block;
-						line-height: 17px;
-						padding: 11px 24px 10px;
-					}
-
-					.domain-product-price {
-						display: none;
-					}
 				}
 			}
 
-			&:not( .domain-transfer-suggestion ) {
-				.domain-suggestion__action {
-					@include break-mobile {
-						display: none;
-					}
-				}
+			.domain-suggestion__action:not( .is-borderless ) {
+				border-radius: 4px;
+				line-height: 17px;
+				padding-top: 11px;
+				padding-bottom: 10px;
 			}
-	
+
 			&.domain-transfer-suggestion {
 				$cod-grey: #2b2d2f;
 

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -1274,7 +1274,6 @@ class RegisterDomainStep extends React.Component {
 					isEligibleVariantForDomainTest={ this.props.isEligibleVariantForDomainTest }
 					selectedFreePlanInSwapFlow={ this.props.selectedFreePlanInSwapFlow }
 					selectedPaidPlanInSwapFlow={ this.props.selectedPaidPlanInSwapFlow }
-					isReskinned={ this.props.isReskinned }
 				>
 					{ this.props.isEligibleVariantForDomainTest &&
 						hasResults &&

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -225,7 +225,7 @@ export default {
 		countryCodeTargets: [ 'US', 'CA' ],
 	},
 	reskinSignupFlow: {
-		datestamp: '20210812',
+		datestamp: '20200824',
 		variations: {
 			reskinned: 50,
 			control: 50,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* As a part of the reskinning signup flow abtest (#44223), this change makes the "Select" CTA always visible in the domains step. Earlier it was shown only on hover.
* Also sets the font size of featured domain suggestions to `$font-title-medium` to adhere to the new stylelint rules.

#### Testing instructions
* Go to /start/new.
* Make sure you're assigned to reskinned group of reskinSignupFlow a/b test.
Note: this test is intended to work only for non-EN and non-ES users.
* On the domains step, the "Select" button CTA for each domain suggestion should always be visible. Screenshot:
![image](https://user-images.githubusercontent.com/5436027/90749785-81267b80-e2f1-11ea-939d-64f69e55f1eb.png)
* There should be no changes to the mobile version of the page.

