### PR TITLE
Fix failing inline help e2e tests

### DIFF
--- a/test/e2e/specs/wp-inline-help-support-search-spec.js
+++ b/test/e2e/specs/wp-inline-help-support-search-spec.js
@@ -32,11 +32,13 @@ before( async function () {
 describe( `[${ host }] Inline Help: (${ screenSize }) @parallel`, async function () {
 	this.timeout( mochaTimeOut );
 
-	step( 'Login and select a non My Home page', async function () {
+	step( 'Login and select a page that is not the My Home page', async function () {
 		const loginFlow = new LoginFlow( driver );
 
 		await loginFlow.loginAndSelectMySite();
 
+		// The "/home" route is the only one where the "FAB" inline help
+		// is not shown.
 		const sidebarComponent = await SidebarComponent.Expect( driver );
 		await sidebarComponent.selectSettings();
 

--- a/test/e2e/specs/wp-inline-help-support-search-spec.js
+++ b/test/e2e/specs/wp-inline-help-support-search-spec.js
@@ -37,6 +37,9 @@ describe( `[${ host }] Inline Help: (${ screenSize }) @parallel`, async function
 
 		await loginFlow.loginAndSelectMySite();
 
+		const sidebarComponent = await SidebarComponent.Expect( driver );
+		await sidebarComponent.selectSettings();
+
 		// Initialize the helper component
 		inlineHelpPopoverComponent = await InlineHelpPopoverComponent.Expect( driver );
 	} );

--- a/test/e2e/specs/wp-inline-help-support-search-spec.js
+++ b/test/e2e/specs/wp-inline-help-support-search-spec.js
@@ -35,12 +35,9 @@ describe( `[${ host }] Inline Help: (${ screenSize }) @parallel`, async function
 	step( 'Login and select a page that is not the My Home page', async function () {
 		const loginFlow = new LoginFlow( driver );
 
-		await loginFlow.loginAndSelectMySite();
-
 		// The "/home" route is the only one where the "FAB" inline help
 		// is not shown.
-		const sidebarComponent = await SidebarComponent.Expect( driver );
-		await sidebarComponent.selectSettings();
+		await loginFlow.loginAndSelectSettings();
 
 		// Initialize the helper component
 		inlineHelpPopoverComponent = await InlineHelpPopoverComponent.Expect( driver );
@@ -56,22 +53,22 @@ describe( `[${ host }] Inline Help: (${ screenSize }) @parallel`, async function
 			await inlineHelpPopoverComponent.waitForToggleNotToBePresent();
 		} );
 
-		step( 'Check help toggle is visible on Theme page', async function () {
+		step( 'Check help toggle is visible on Settings page', async function () {
 			const sidebarComponent = await SidebarComponent.Expect( driver );
 
 			// The "inline help" FAB should not appear on the My Home
 			// because there is already a support search "Card" on that
 			// page. Any other non-home page should show the FAB. There
-			// is nothing special about Themes page other than it's not
+			// is nothing special about Settings page other than it's not
 			// the `/home` route :)
-			await sidebarComponent.selectThemes();
+			await sidebarComponent.selectSettings();
 
 			// Once removed we can assert is is invisible.
 			const isToggleVisible = await inlineHelpPopoverComponent.isToggleVisible();
 			assert.equal(
 				isToggleVisible,
 				true,
-				'Inline Help support search was not shown on Theme page.'
+				'Inline Help support search was not shown on Settings page.'
 			);
 		} );
 	} );

--- a/test/e2e/specs/wp-my-home-support-search-spec.js
+++ b/test/e2e/specs/wp-my-home-support-search-spec.js
@@ -34,7 +34,7 @@ before( async function () {
 describe( `[${ host }] My Home "Get help" support search card: (${ screenSize }) @parallel`, async function () {
 	this.timeout( mochaTimeOut );
 
-	step( 'Login and select a non My Home page', async function () {
+	step( 'Login and select a the My Home page', async function () {
 		const loginFlow = new LoginFlow( driver );
 
 		await loginFlow.loginAndSelectMySite();

--- a/test/e2e/specs/wp-my-home-support-search-spec.js
+++ b/test/e2e/specs/wp-my-home-support-search-spec.js
@@ -34,7 +34,7 @@ before( async function () {
 describe( `[${ host }] My Home "Get help" support search card: (${ screenSize }) @parallel`, async function () {
 	this.timeout( mochaTimeOut );
 
-	step( 'Login and select a the My Home page', async function () {
+	step( 'Login and select the My Home page', async function () {
 		const loginFlow = new LoginFlow( driver );
 
 		await loginFlow.loginAndSelectMySite();


### PR DESCRIPTION
Fixes e2e test failures (likely introduced in https://github.com/Automattic/wp-calypso/pull/44976) due to missing `.inline-help` selector. The error manifests as:

> Timed out waiting for element with css selector of '.inline-help' to be present and displayed
> Wait timed out after 22189ms
> TimeoutError: Timed out waiting for element with css selector of '.inline-help' to be present and displayed
> Wait timed out after 22189ms

Here is [an example of a failing e2e test](https://app.circleci.com/pipelines/github/Automattic/wp-e2e-tests-for-branches/35245/workflows/acf73858-1a9f-40ef-a175-9dc6bdd5c8ec/jobs/95469/tests).

The error was caused by not actually _selecting_ a page when logging in to the site. This is because the test was using `loginFlow.loginAndSelectMySite();` which doesn't actually guarantee that a page is selected. 

https://github.com/Automattic/wp-calypso/blob/9f2e5af6679b21a80f22b164dfbf081d10f44e10/test/e2e/lib/flows/login-flow.js#L195-L211

This PR changes this to actually select the `Settings` sidebar menu item. This is reliably selected via the sidebar component and so ensures we navigate to the Settings page before attempting to assert that the Inline Help "FAB" is present.

https://github.com/Automattic/wp-calypso/blob/9f2e5af6679b21a80f22b164dfbf081d10f44e10/test/e2e/lib/flows/login-flow.js#L244-L249

As a side, it also fixes a misnamed test `step` description from `test/e2e/specs/wp-my-home-support-search-spec.js`.


#### Testing instructions

* On `master` you may notice intermittent failures such as:

```
Timed out waiting for element with css selector of '.inline-help' to be present and displayed
Wait timed out after 22189ms
TimeoutError: Timed out waiting for element with css selector of '.inline-help' to be present and displayed
Wait timed out after 22189ms
```
These all mention missing `.inline-help` selector.

* On this branch e2e test failures will not be related to `.inline-help`. 
* Also check that the e2e tests run and pass locally. To do this: 
    - Boot Calypso from the project root yarn && yarn start.
    - Set-up e2e testing for Calypso
    - cd `test/e2e`
    - Run `yarn`
    - `./node_modules/.bin/mocha specs/wp-inline-help-support-search-spec.js` should pass


