### PR TITLE
Social Previews: update Twitter preview to reflect current look

### DIFF
--- a/packages/social-previews/src/twitter-preview/index.jsx
+++ b/packages/social-previews/src/twitter-preview/index.jsx
@@ -9,17 +9,24 @@ import React, { PureComponent } from 'react';
  * Internal dependencies
  */
 
-import { stripHtmlTags } from '../helpers';
+import { firstValid, hardTruncation, shortEnough, stripHtmlTags } from '../helpers';
 
 /**
  * Style dependencies
  */
 import './style.scss';
 
+const DESCRIPTION_LENGTH = 200;
+
 const baseDomain = ( url ) =>
 	url
 		.replace( /^[^/]+[/]*/, '' ) // strip leading protocol
 		.replace( /\/.*$/, '' ); // strip everything after the domain
+
+const twitterDescription = firstValid(
+	shortEnough( DESCRIPTION_LENGTH ),
+	hardTruncation( DESCRIPTION_LENGTH )
+);
 
 export class TwitterPreview extends PureComponent {
 	render() {
@@ -35,7 +42,9 @@ export class TwitterPreview extends PureComponent {
 					{ image && <div className="twitter-preview__image" style={ previewImageStyle } /> }
 					<div className="twitter-preview__body">
 						<div className="twitter-preview__title">{ title }</div>
-						<div className="twitter-preview__description">{ stripHtmlTags( description ) }</div>
+						<div className="twitter-preview__description">
+							{ twitterDescription( stripHtmlTags( description ) ) }
+						</div>
 						<div className="twitter-preview__url">{ baseDomain( url || '' ) }</div>
 					</div>
 				</div>

--- a/packages/social-previews/src/twitter-preview/style.scss
+++ b/packages/social-previews/src/twitter-preview/style.scss
@@ -26,7 +26,7 @@
 	margin: 0 auto;
 	overflow: hidden;
 	border: 1px solid #e1e8ed;
-	border-radius: 0.42857em;
+	border-radius: 12px;
 }
 
 .twitter-preview__large_image_summary {
@@ -35,7 +35,7 @@
 	margin: 0 auto;
 	overflow: hidden;
 	border: 1px solid #e1e8ed;
-	border-radius: 0.42857em;
+	border-radius: 12px;
 }
 
 .twitter-preview__image {

--- a/packages/social-previews/src/twitter-preview/style.scss
+++ b/packages/social-previews/src/twitter-preview/style.scss
@@ -11,6 +11,8 @@
 
 @import '../variables.scss';
 
+/* stylelint-disable scales/font-size */
+
 .twitter-preview {
 	width: inherit;
 	overflow-x: auto;
@@ -92,8 +94,12 @@
 .twitter-preview__description {
 	margin-top: 0.32333em;
 	max-height: 3.9em;
-	overflow: hidden;
 	text-overflow: ellipsis;
+	//clamp after two lines
+	display: -webkit-box;
+	-webkit-line-clamp: 2;
+	-webkit-box-orient: vertical;
+	overflow: hidden;
 }
 
 .twitter-preview__url {

--- a/packages/social-previews/src/twitter-preview/style.scss
+++ b/packages/social-previews/src/twitter-preview/style.scss
@@ -31,7 +31,6 @@
 
 .twitter-preview__summary {
 	height: 125px;
-	
 }
 
 .twitter-preview__large_image_summary {
@@ -100,6 +99,10 @@
 	-webkit-line-clamp: 2;
 	-webkit-box-orient: vertical;
 	overflow: hidden;
+}
+
+.twitter-preview__summary .twitter-preview__description {
+	-webkit-line-clamp: 3;
 }
 
 .twitter-preview__url {

--- a/packages/social-previews/src/twitter-preview/style.scss
+++ b/packages/social-previews/src/twitter-preview/style.scss
@@ -20,22 +20,22 @@
 	margin: 20px;
 }
 
-.twitter-preview__summary {
+.twitter-preview__summary,
+.twitter-preview__large_image_summary {
 	width: 506px;
-	height: 125px;
 	margin: 0 auto;
 	overflow: hidden;
 	border: 1px solid #e1e8ed;
 	border-radius: 12px;
 }
 
+.twitter-preview__summary {
+	height: 125px;
+	
+}
+
 .twitter-preview__large_image_summary {
-	width: 506px;
 	height: auto;
-	margin: 0 auto;
-	overflow: hidden;
-	border: 1px solid #e1e8ed;
-	border-radius: 12px;
 }
 
 .twitter-preview__image {

--- a/packages/social-previews/test/index.js
+++ b/packages/social-previews/test/index.js
@@ -129,7 +129,7 @@ describe( 'Twitter previews', () => {
 		);
 	} );
 
-	it( 'should display a untruncated description', () => {
+	it( 'should display a truncated description', () => {
 		const wrapper = shallow(
 			<Twitter description="I know the kings of England, and I quote the fights historical, From Marathon to Waterloo, in order categorical; I'm very well acquainted, too, with matters mathematical, I understand equations, both the simple and quadratical; About binomial theorem I'm teeming with a lot o' news, With many cheerful facts about the square of the hypotenuse." />
 		);
@@ -137,11 +137,14 @@ describe( 'Twitter previews', () => {
 		const descEl = wrapper.find( '.twitter-preview__description' );
 		expect( descEl.exists() ).toBeTruthy();
 		expect( descEl.text() ).toEqual(
-			"I know the kings of England, and I quote the fights historical, From Marathon to Waterloo, in order categorical; I'm very well acquainted, too, with matters mathematical, I understand equations, both the simple and quadratical; About binomial theorem I'm teeming with a lot o' news, With many cheerful facts about the square of the hypotenuse."
+			"I know the kings of England, and I quote the fights historical, From Marathon to Waterloo, in order categorical; I'm very well acquainted, too, with matters mathematical, I understand equations, both …"
 		);
+
+		const descTextNoEllipsis = descEl.text().replace( '…', '' );
+		expect( descTextNoEllipsis ).toHaveLength( 200 );
 	} );
 
-	it( 'should strip html tasgs from the description', () => {
+	it( 'should strip html tags from the description', () => {
 		const wrapper = shallow(
 			<Twitter description="<p style='color:red'>I know the kings of <span>England, and I quote the fights historical, From Marathon to Waterloo, in order categorical; I'm very well acquainted, too, with matters mathematical, I understand equations, <span>both</span> the simple and quadratical; About binomial theorem I'm teeming with a lot o' news, With many cheerful facts about the square of the hypotenuse." />
 		);
@@ -149,7 +152,7 @@ describe( 'Twitter previews', () => {
 		const descEl = wrapper.find( '.twitter-preview__description' );
 		expect( descEl.exists() ).toBeTruthy();
 		expect( descEl.text() ).toEqual(
-			"I know the kings of England, and I quote the fights historical, From Marathon to Waterloo, in order categorical; I'm very well acquainted, too, with matters mathematical, I understand equations, both the simple and quadratical; About binomial theorem I'm teeming with a lot o' news, With many cheerful facts about the square of the hypotenuse."
+			"I know the kings of England, and I quote the fights historical, From Marathon to Waterloo, in order categorical; I'm very well acquainted, too, with matters mathematical, I understand equations, both …"
 		);
 	} );
 


### PR DESCRIPTION
This PR aims to bring the Twitter Preview of Social Previews in line with the current look of Twitter's preview.

The related issue is https://github.com/Automattic/wp-calypso/issues/44799 and fixes https://github.com/Automattic/jetpack/issues/16896

Note: I've been getting different results between the [Twitter Card validator](https://cards-dev.twitter.com/validator) and testing in the Twitter interface directly. For this PR we'll use the Twitter Card validator as a reference as it's the tool Twitter provides to check how content will look like on their platform.

## Screenshots

**Summary - Twitter Card Validator**

<img width="578" alt="Screenshot 2020-08-20 at 13 46 43" src="https://user-images.githubusercontent.com/1562646/90768754-7965d780-e2ef-11ea-8d1b-63b79e4df29f.png">


**Summary - Twitter Social Preview**

|Before|After|
|-|-|
| <img width="572" alt="Screenshot 2020-08-20 at 14 20 28" src="https://user-images.githubusercontent.com/1562646/90769341-5982e380-e2f0-11ea-8d5e-d3568952e6ae.png"> | <img width="578" alt="Screenshot 2020-08-20 at 14 16 00" src="https://user-images.githubusercontent.com/1562646/90768937-bc27af80-e2ef-11ea-8ca0-1d6b67b4188f.png"> |


---

**Large Image Summary - Twitter Card Validator**

<img width="575" alt="Screenshot 2020-08-20 at 13 40 15" src="https://user-images.githubusercontent.com/1562646/90768798-871b5d00-e2ef-11ea-99c7-cd6e367aa2b9.png">


**Large Image Summary - Twitter Social Preview**

|Before|After|
|-|-|
| ![Screenshot 2020-08-20 at 14 21 56](https://user-images.githubusercontent.com/1562646/90769460-9058f980-e2f0-11ea-8f35-9959ab9328a6.jpg) | ![Screenshot 2020-08-20 at 14 17 23](https://user-images.githubusercontent.com/1562646/90769078-f2652f00-e2ef-11ea-8394-f5d0aaf34599.jpg) |


## Changes proposed in this Pull Request

This PR introduces the following changes to the Twitter Preview:

1. Changes to both the `summary` and `large_image_summary` previews:
- Truncate description for improved a11y
- Increase border radius

2. Changes the `summary` preview
- Visually clamp description after three lines

3. Changes the `large_image_summary` preview
- Visually clamp description after two lines


## Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

For both previews:

- check out branch and `yarn start`

For Summary preview:
- Navigate to http://calypso.localhost:3000/view and pick a site
- once loaded, switch to the "Search & Social" Twitter preview and check changes described above

For Large Image Summary preview:
- Navigate to a post or page with adequate content and select Preview
- once loaded, switch to the "Search & Social" Twitter preview and check changes described above
