### PR TITLE
P2 signup: remove P2Details step if logged in

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -111,6 +111,16 @@ function removeUserStepFromFlow( flow ) {
 	} );
 }
 
+function removeP2DetailsStepFromFlow( flow ) {
+	if ( ! flow ) {
+		return;
+	}
+
+	return assign( {}, flow, {
+		steps: reject( flow.steps, ( stepName ) => stepName === 'p2-details' ),
+	} );
+}
+
 function filterDestination( destination, dependencies, flowName, localeSlug ) {
 	if ( dependenciesContainCartItem( dependencies ) ) {
 		return getCheckoutUrl( dependencies, localeSlug );
@@ -147,6 +157,10 @@ const Flows = {
 
 		if ( user() && user().get() ) {
 			flow = removeUserStepFromFlow( flow );
+		}
+
+		if ( flowName === 'p2' && user() && user().get() ) {
+			flow = removeP2DetailsStepFromFlow( flow );
 		}
 
 		return Flows.filterExcludedSteps( flow );


### PR DESCRIPTION
In this PR, we remove the `P2Details` step if you are already logged in and you go to `/start/p2`

## Testing instructions

Log in and navigate to `/start/p2`. You should see only the first step where you fill in the site and then the Hooray screen.

Log out and do the same. You should see the `P2Details` step.

Also, try a completely different flow than the p2 one to see if it works as before.