### PR TITLE
ABTest: Call bumpStat when abtest starts.

### DIFF
--- a/client/lib/abtest/index.js
+++ b/client/lib/abtest/index.js
@@ -351,8 +351,7 @@ ABTest.prototype.saveVariation = function ( variation ) {
 	}
 	this.saveVariationInLocalStorage( variation );
 
-	const experimentId = this.experimentId.replace( /[A-Z]/g, ( s ) => `_${ s.toLowerCase() }` );
-	bumpStat( experimentId, variation );
+	bumpStat( this.experimentId, variation );
 };
 
 ABTest.prototype.saveVariationOnBackend = function ( variation ) {

--- a/client/lib/abtest/index.js
+++ b/client/lib/abtest/index.js
@@ -11,6 +11,7 @@ import { getLocaleSlug } from 'i18n-calypso';
  */
 import activeTests from 'lib/abtest/active-tests';
 import { recordTracksEvent } from 'lib/analytics/tracks';
+import { bumpStat } from 'lib/analytics/mc';
 import user from 'lib/user';
 import wpcom from 'lib/wp';
 import { ABTEST_LOCALSTORAGE_KEY } from 'lib/abtest/utility';
@@ -349,6 +350,9 @@ ABTest.prototype.saveVariation = function ( variation ) {
 		this.recordVariation( variation );
 	}
 	this.saveVariationInLocalStorage( variation );
+
+	const experimentId = this.experimentId.replace( /[A-Z]/g, ( s ) => `_${ s.toLowerCase() }` );
+	bumpStat( experimentId, variation );
 };
 
 ABTest.prototype.saveVariationOnBackend = function ( variation ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Send a request with `bumpStat` when a a/btest is assigned to a user. Since the Tracks shows delayed data only, it is not possible to watch early data to check if a specific a/b test properly works. This PR will record ad hoc stats in addition to Tracks so we can see early stats as well as Tracks analytics. Check pbxNRc-pJ-p2#comment-673 for more details.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Set `mc_analytics_enabled` to `true` in `config/development.local.json` to override the flag. (create the file if it doesn't exist) The feature currently is enabled only in production.
* Open the browser console.
* Visit `/start/new` without loggen in user. Also, your locale should be neither EN nor ES.
* Make sure there's a request for bumping stats of the ongoing a/b tests. For example, the following request records a stat for `reskinSignupFlow` a/b test assignment.
<img width="800" alt="Create_a_site_—_WordPress_com_및_Comparing_master___add_bump_stat_for_abtest_·_Automattic_wp-calypso" src="https://user-images.githubusercontent.com/212034/90770988-99b48700-e32d-11ea-84ab-9824926fcf49.png">


_Note: the group name does intentionally not have any prefix/suffix since it limits to 32 characters. ( see PCYsg-G3-p2#caveats-constraints-and-best-practices )_