### PR TITLE
Cleanup the stats router code

### DIFF
--- a/client/my-sites/activity/controller.jsx
+++ b/client/my-sites/activity/controller.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-import page from 'page';
 import { isEqual } from 'lodash';
 
 /**
@@ -76,15 +75,4 @@ export function activity( context, next ) {
 	);
 
 	next();
-}
-
-// Add redirect
-export function redirect( context ) {
-	const state = context.store.getState();
-	const siteId = getSelectedSiteId( state );
-	if ( siteId ) {
-		page.redirect( '/activity-log/' + siteId );
-		return;
-	}
-	page.redirect( '/activity-log/' );
 }

--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -131,316 +131,314 @@ function getMomentSiteZone( state, siteId ) {
 	return moment().utcOffset( Number.isFinite( gmtOffset ) ? gmtOffset : 0 );
 }
 
-export default {
-	redirectToDefaultSitePage: function ( context ) {
-		const siteFragment = getSiteFragment( context.path );
+export function redirectToDefaultSitePage( context ) {
+	const siteFragment = getSiteFragment( context.path );
 
-		// if we are redirecting we need to retain our intended layout-focus
-		const currentLayoutFocus = getCurrentLayoutFocus( context.store.getState() );
-		context.store.dispatch( setNextLayoutFocus( currentLayoutFocus ) );
+	// if we are redirecting we need to retain our intended layout-focus
+	const currentLayoutFocus = getCurrentLayoutFocus( context.store.getState() );
+	context.store.dispatch( setNextLayoutFocus( currentLayoutFocus ) );
 
+	page.redirect( getStatsDefaultSitePage( siteFragment ) );
+}
+
+export function redirectToDefaultWordAdsPeriod( context ) {
+	const siteFragment = getSiteFragment( context.path );
+
+	// if we are redirecting we need to retain our intended layout-focus
+	const currentLayoutFocus = getCurrentLayoutFocus( context.store.getState() );
+	context.store.dispatch( setNextLayoutFocus( currentLayoutFocus ) );
+
+	if ( siteFragment ) {
+		page.redirect( `/stats/ads/day/${ siteFragment }` );
+	} else {
 		page.redirect( getStatsDefaultSitePage( siteFragment ) );
-	},
+	}
+}
 
-	redirectToDefaultWordAdsPeriod: function ( context ) {
-		const siteFragment = getSiteFragment( context.path );
+export function redirectToDefaultModulePage( context ) {
+	page.redirect( `/stats/day/${ context.params.module }/${ context.params.site }` );
+}
 
-		// if we are redirecting we need to retain our intended layout-focus
-		const currentLayoutFocus = getCurrentLayoutFocus( context.store.getState() );
-		context.store.dispatch( setNextLayoutFocus( currentLayoutFocus ) );
+export function insights( context, next ) {
+	context.primary = <StatsInsights followList={ new FollowList() } />;
+	next();
+}
 
-		if ( siteFragment ) {
-			page.redirect( `/stats/ads/day/${ siteFragment }` );
-		} else {
-			page.redirect( getStatsDefaultSitePage( siteFragment ) );
-		}
-	},
-
-	redirectToDefaultModulePage: function ( context ) {
-		page.redirect( `/stats/day/${ context.params.module }/${ context.params.site }` );
-	},
-
-	insights: function ( context, next ) {
-		context.primary = <StatsInsights followList={ new FollowList() } />;
-		next();
-	},
-
-	overview: function ( context, next ) {
-		const filters = function () {
-			return [
-				{
-					title: i18n.translate( 'Days' ),
-					path: '/stats/day',
-					altPaths: [ '/stats' ],
-					id: 'stats-day',
-					period: 'day',
-				},
-				{ title: i18n.translate( 'Weeks' ), path: '/stats/week', id: 'stats-week', period: 'week' },
-				{
-					title: i18n.translate( 'Months' ),
-					path: '/stats/month',
-					id: 'stats-month',
-					period: 'month',
-				},
-				{ title: i18n.translate( 'Years' ), path: '/stats/year', id: 'stats-year', period: 'year' },
-			];
-		};
-
-		window.scrollTo( 0, 0 );
-
-		const activeFilter = find( filters(), ( filter ) => {
-			return (
-				context.params.period === filter.period ||
-				context.pathname === filter.path ||
-				( filter.altPaths && -1 !== filter.altPaths.indexOf( context.pathname ) )
-			);
-		} );
-
-		// Validate that date filter is legit
-		if ( ! activeFilter ) {
-			return next();
-		}
-
-		bumpStat( 'calypso_stats_overview_period', activeFilter.period );
-
-		context.primary = <StatsOverview period={ activeFilter.period } path={ context.pathname } />;
-		next();
-	},
-
-	site: function ( context, next ) {
-		const {
-			params: { site: givenSiteId },
-			query: queryOptions,
-			store,
-		} = context;
-
-		const filters = getSiteFilters( givenSiteId, context );
-		const state = store.getState();
-		const currentSite = getSite( state, givenSiteId );
-		const siteId = currentSite ? currentSite.ID || 0 : 0;
-
-		const activeFilter = find(
-			filters,
-			( filter ) =>
-				context.pathname === filter.path ||
-				( filter.altPaths && -1 !== filter.altPaths.indexOf( context.pathname ) )
-		);
-		if ( ! activeFilter ) {
-			return next();
-		}
-
-		const momentSiteZone = getMomentSiteZone( state, siteId );
-		const isValidStartDate = queryOptions.startDate && moment( queryOptions.startDate ).isValid();
-
-		const date = isValidStartDate
-			? moment( queryOptions.startDate ).locale( 'en' )
-			: rangeOfPeriod( activeFilter.period, momentSiteZone.locale( 'en' ) ).startOf;
-
-		const parsedPeriod = isValidStartDate
-			? parseInt( getNumPeriodAgo( momentSiteZone, date, activeFilter.period ), 10 )
-			: 0;
-
-		// eslint-disable-next-line no-nested-ternary
-		const numPeriodAgo = parsedPeriod ? ( parsedPeriod > 9 ? '10plus' : '-' + parsedPeriod ) : '';
-
-		bumpStat( 'calypso_stats_site_period', activeFilter.period + numPeriodAgo );
-		recordPlaceholdersTiming();
-
-		const validTabs = [ 'views', 'visitors', 'likes', 'comments' ];
-		const chartTab = validTabs.includes( queryOptions.tab ) ? queryOptions.tab : 'views';
-
-		context.primary = (
-			<StatsSite
-				path={ context.pathname }
-				date={ date }
-				chartTab={ chartTab }
-				context={ context }
-				period={ rangeOfPeriod( activeFilter.period, date ) }
-			/>
-		);
-
-		next();
-	},
-
-	summary: function ( context, next ) {
-		let siteId = context.params.site;
-		const siteFragment = getSiteFragment( context.path );
-		const queryOptions = context.query;
-		const contextModule = context.params.module;
-		const filters = [
+export function overview( context, next ) {
+	const filters = function () {
+		return [
 			{
-				path: '/stats/' + contextModule + '/' + siteId,
-				altPaths: [ '/stats/day/' + contextModule + '/' + siteId ],
+				title: i18n.translate( 'Days' ),
+				path: '/stats/day',
+				altPaths: [ '/stats' ],
 				id: 'stats-day',
 				period: 'day',
 			},
-			{ path: '/stats/week/' + contextModule + '/' + siteId, id: 'stats-week', period: 'week' },
-			{ path: '/stats/month/' + contextModule + '/' + siteId, id: 'stats-month', period: 'month' },
-			{ path: '/stats/year/' + contextModule + '/' + siteId, id: 'stats-year', period: 'year' },
+			{ title: i18n.translate( 'Weeks' ), path: '/stats/week', id: 'stats-week', period: 'week' },
+			{
+				title: i18n.translate( 'Months' ),
+				path: '/stats/month',
+				id: 'stats-month',
+				period: 'month',
+			},
+			{ title: i18n.translate( 'Years' ), path: '/stats/year', id: 'stats-year', period: 'year' },
 		];
+	};
 
-		const validModules = [
-			'posts',
-			'referrers',
-			'clicks',
-			'countryviews',
-			'authors',
-			'videoplays',
-			'videodetails',
-			'filedownloads',
-			'searchterms',
-			'annualstats',
-		];
-		let momentSiteZone = moment();
+	window.scrollTo( 0, 0 );
 
-		const site = getSite( context.store.getState(), siteId );
-		siteId = site ? site.ID || 0 : 0;
-
-		const activeFilter = find( filters, ( filter ) => {
-			return (
-				context.pathname === filter.path ||
-				( filter.altPaths && -1 !== filter.altPaths.indexOf( context.pathname ) )
-			);
-		} );
-
-		if ( siteFragment && 0 === siteId ) {
-			// site is not in the user's site list
-			return ( window.location = '/stats' );
-		}
-
-		if ( ! activeFilter || -1 === validModules.indexOf( context.params.module ) ) {
-			return next();
-		}
-
-		const gmtOffset = getSiteOption( context.store.getState(), siteId, 'gmt_offset' );
-		if ( Number.isFinite( gmtOffset ) ) {
-			momentSiteZone = moment().utcOffset( gmtOffset );
-		}
-		const isValidStartDate = queryOptions.startDate && moment( queryOptions.startDate ).isValid();
-		const date = isValidStartDate
-			? moment( queryOptions.startDate ).locale( 'en' )
-			: momentSiteZone.endOf( activeFilter.period ).locale( 'en' );
-		const period = rangeOfPeriod( activeFilter.period, date );
-
-		const extraProps =
-			context.params.module === 'videodetails' ? { postId: parseInt( queryOptions.post, 10 ) } : {};
-
-		let statsQueryOptions = {};
-
-		// All Time Summary Support
-		if ( queryOptions.summarize && queryOptions.num ) {
-			statsQueryOptions = pick( queryOptions, [ 'num', 'summarize' ] );
-			statsQueryOptions.period = 'day';
-		}
-
-		context.primary = (
-			<StatsSummary
-				path={ context.pathname }
-				statsQueryOptions={ statsQueryOptions }
-				date={ date }
-				context={ context }
-				period={ period }
-				{ ...extraProps }
-			/>
+	const activeFilter = find( filters(), ( filter ) => {
+		return (
+			context.params.period === filter.period ||
+			context.pathname === filter.path ||
+			( filter.altPaths && -1 !== filter.altPaths.indexOf( context.pathname ) )
 		);
+	} );
 
-		next();
-	},
+	// Validate that date filter is legit
+	if ( ! activeFilter ) {
+		return next();
+	}
 
-	post: function ( context, next ) {
-		let siteId = context.params.site;
-		const postId = parseInt( context.params.post_id, 10 );
-		const site = getSite( context.store.getState(), siteId );
-		siteId = site ? site.ID || 0 : 0;
+	bumpStat( 'calypso_stats_overview_period', activeFilter.period );
 
-		if ( 0 === siteId ) {
-			window.location = '/stats';
-			return next();
-		}
+	context.primary = <StatsOverview period={ activeFilter.period } path={ context.pathname } />;
+	next();
+}
 
-		context.primary = (
-			<StatsPostDetail path={ context.path } postId={ postId } context={ context } />
+export function site( context, next ) {
+	const {
+		params: { site: givenSiteId },
+		query: queryOptions,
+		store,
+	} = context;
+
+	const filters = getSiteFilters( givenSiteId, context );
+	const state = store.getState();
+	const currentSite = getSite( state, givenSiteId );
+	const siteId = currentSite ? currentSite.ID || 0 : 0;
+
+	const activeFilter = find(
+		filters,
+		( filter ) =>
+			context.pathname === filter.path ||
+			( filter.altPaths && -1 !== filter.altPaths.indexOf( context.pathname ) )
+	);
+	if ( ! activeFilter ) {
+		return next();
+	}
+
+	const momentSiteZone = getMomentSiteZone( state, siteId );
+	const isValidStartDate = queryOptions.startDate && moment( queryOptions.startDate ).isValid();
+
+	const date = isValidStartDate
+		? moment( queryOptions.startDate ).locale( 'en' )
+		: rangeOfPeriod( activeFilter.period, momentSiteZone.locale( 'en' ) ).startOf;
+
+	const parsedPeriod = isValidStartDate
+		? parseInt( getNumPeriodAgo( momentSiteZone, date, activeFilter.period ), 10 )
+		: 0;
+
+	// eslint-disable-next-line no-nested-ternary
+	const numPeriodAgo = parsedPeriod ? ( parsedPeriod > 9 ? '10plus' : '-' + parsedPeriod ) : '';
+
+	bumpStat( 'calypso_stats_site_period', activeFilter.period + numPeriodAgo );
+	recordPlaceholdersTiming();
+
+	const validTabs = [ 'views', 'visitors', 'likes', 'comments' ];
+	const chartTab = validTabs.includes( queryOptions.tab ) ? queryOptions.tab : 'views';
+
+	context.primary = (
+		<StatsSite
+			path={ context.pathname }
+			date={ date }
+			chartTab={ chartTab }
+			context={ context }
+			period={ rangeOfPeriod( activeFilter.period, date ) }
+		/>
+	);
+
+	next();
+}
+
+export function summary( context, next ) {
+	let siteId = context.params.site;
+	const siteFragment = getSiteFragment( context.path );
+	const queryOptions = context.query;
+	const contextModule = context.params.module;
+	const filters = [
+		{
+			path: '/stats/' + contextModule + '/' + siteId,
+			altPaths: [ '/stats/day/' + contextModule + '/' + siteId ],
+			id: 'stats-day',
+			period: 'day',
+		},
+		{ path: '/stats/week/' + contextModule + '/' + siteId, id: 'stats-week', period: 'week' },
+		{ path: '/stats/month/' + contextModule + '/' + siteId, id: 'stats-month', period: 'month' },
+		{ path: '/stats/year/' + contextModule + '/' + siteId, id: 'stats-year', period: 'year' },
+	];
+
+	const validModules = [
+		'posts',
+		'referrers',
+		'clicks',
+		'countryviews',
+		'authors',
+		'videoplays',
+		'videodetails',
+		'filedownloads',
+		'searchterms',
+		'annualstats',
+	];
+	let momentSiteZone = moment();
+
+	const selectedSite = getSite( context.store.getState(), siteId );
+	siteId = selectedSite ? selectedSite.ID || 0 : 0;
+
+	const activeFilter = find( filters, ( filter ) => {
+		return (
+			context.pathname === filter.path ||
+			( filter.altPaths && -1 !== filter.altPaths.indexOf( context.pathname ) )
 		);
+	} );
 
-		next();
-	},
+	if ( siteFragment && 0 === siteId ) {
+		// site is not in the user's site list
+		return ( window.location = '/stats' );
+	}
 
-	follows: function ( context, next ) {
-		let siteId = context.params.site;
-		let pageNum = context.params.page_num;
-		const followList = new FollowList();
+	if ( ! activeFilter || -1 === validModules.indexOf( context.params.module ) ) {
+		return next();
+	}
 
-		const site = getSite( context.store.getState(), siteId );
-		siteId = site ? site.ID || 0 : 0;
+	const gmtOffset = getSiteOption( context.store.getState(), siteId, 'gmt_offset' );
+	if ( Number.isFinite( gmtOffset ) ) {
+		momentSiteZone = moment().utcOffset( gmtOffset );
+	}
+	const isValidStartDate = queryOptions.startDate && moment( queryOptions.startDate ).isValid();
+	const date = isValidStartDate
+		? moment( queryOptions.startDate ).locale( 'en' )
+		: momentSiteZone.endOf( activeFilter.period ).locale( 'en' );
+	const period = rangeOfPeriod( activeFilter.period, date );
 
-		const siteDomain =
-			site && typeof site.slug !== 'undefined' ? site.slug : getSiteFragment( context.path );
+	const extraProps =
+		context.params.module === 'videodetails' ? { postId: parseInt( queryOptions.post, 10 ) } : {};
 
-		if ( 0 === siteId ) {
-			window.location = '/stats';
-			return next();
-		}
+	let statsQueryOptions = {};
 
-		pageNum = parseInt( pageNum, 10 );
+	// All Time Summary Support
+	if ( queryOptions.summarize && queryOptions.num ) {
+		statsQueryOptions = pick( queryOptions, [ 'num', 'summarize' ] );
+		statsQueryOptions.period = 'day';
+	}
 
-		if ( ! pageNum || pageNum < 1 ) {
-			pageNum = 1;
-		}
+	context.primary = (
+		<StatsSummary
+			path={ context.pathname }
+			statsQueryOptions={ statsQueryOptions }
+			date={ date }
+			context={ context }
+			period={ period }
+			{ ...extraProps }
+		/>
+	);
 
-		context.primary = (
-			<StatsCommentFollows
-				path={ context.path }
-				page={ pageNum }
-				perPage="20"
-				total="10"
-				domain={ siteDomain }
-				siteId={ siteId }
-				followList={ followList }
-			/>
-		);
+	next();
+}
 
-		next();
-	},
+export function post( context, next ) {
+	let siteId = context.params.site;
+	const postId = parseInt( context.params.post_id, 10 );
+	const selectedSite = getSite( context.store.getState(), siteId );
+	siteId = selectedSite ? selectedSite.ID || 0 : 0;
 
-	wordAds: function ( context, next ) {
-		const { query: queryOptions, store } = context;
+	if ( 0 === siteId ) {
+		window.location = '/stats';
+		return next();
+	}
 
-		const state = store.getState();
-		const siteId = getSelectedSiteId( state );
-		const filters = getSiteFilters( siteId, context );
+	context.primary = <StatsPostDetail path={ context.path } postId={ postId } context={ context } />;
 
-		const activeFilter = find( filters, ( filter ) => context.params.period === filter.period );
+	next();
+}
 
-		if ( ! activeFilter ) {
-			return next();
-		}
+export function follows( context, next ) {
+	let siteId = context.params.site;
+	let pageNum = context.params.page_num;
+	const followList = new FollowList();
 
-		const momentSiteZone = getMomentSiteZone( state, siteId );
-		const isValidStartDate = queryOptions.startDate && moment( queryOptions.startDate ).isValid();
+	const selectedSite = getSite( context.store.getState(), siteId );
+	siteId = selectedSite ? selectedSite.ID || 0 : 0;
 
-		const date = isValidStartDate
-			? moment( queryOptions.startDate ).locale( 'en' )
-			: rangeOfPeriod( activeFilter.period, momentSiteZone.locale( 'en' ) ).startOf;
+	const siteDomain =
+		selectedSite && typeof selectedSite.slug !== 'undefined'
+			? selectedSite.slug
+			: getSiteFragment( context.path );
 
-		const parsedPeriod = isValidStartDate
-			? parseInt( getNumPeriodAgo( momentSiteZone, date, activeFilter.period ), 10 )
-			: 0;
+	if ( 0 === siteId ) {
+		window.location = '/stats';
+		return next();
+	}
 
-		// eslint-disable-next-line no-nested-ternary
-		const numPeriodAgo = parsedPeriod ? ( parsedPeriod > 9 ? '10plus' : '-' + parsedPeriod ) : '';
+	pageNum = parseInt( pageNum, 10 );
 
-		bumpStat( 'calypso_wordads_stats_site_period', activeFilter.period + numPeriodAgo );
+	if ( ! pageNum || pageNum < 1 ) {
+		pageNum = 1;
+	}
 
-		context.primary = (
-			<WordAds
-				path={ context.pathname }
-				date={ date }
-				chartTab={ queryOptions.tab || 'impressions' }
-				context={ context }
-				period={ rangeOfPeriod( activeFilter.period, date ) }
-			/>
-		);
+	context.primary = (
+		<StatsCommentFollows
+			path={ context.path }
+			page={ pageNum }
+			perPage="20"
+			total="10"
+			domain={ siteDomain }
+			siteId={ siteId }
+			followList={ followList }
+		/>
+	);
 
-		next();
-	},
-};
+	next();
+}
+
+export function wordAds( context, next ) {
+	const { query: queryOptions, store } = context;
+
+	const state = store.getState();
+	const siteId = getSelectedSiteId( state );
+	const filters = getSiteFilters( siteId, context );
+
+	const activeFilter = find( filters, ( filter ) => context.params.period === filter.period );
+
+	if ( ! activeFilter ) {
+		return next();
+	}
+
+	const momentSiteZone = getMomentSiteZone( state, siteId );
+	const isValidStartDate = queryOptions.startDate && moment( queryOptions.startDate ).isValid();
+
+	const date = isValidStartDate
+		? moment( queryOptions.startDate ).locale( 'en' )
+		: rangeOfPeriod( activeFilter.period, momentSiteZone.locale( 'en' ) ).startOf;
+
+	const parsedPeriod = isValidStartDate
+		? parseInt( getNumPeriodAgo( momentSiteZone, date, activeFilter.period ), 10 )
+		: 0;
+
+	// eslint-disable-next-line no-nested-ternary
+	const numPeriodAgo = parsedPeriod ? ( parsedPeriod > 9 ? '10plus' : '-' + parsedPeriod ) : '';
+
+	bumpStat( 'calypso_wordads_stats_site_period', activeFilter.period + numPeriodAgo );
+
+	context.primary = (
+		<WordAds
+			path={ context.pathname }
+			date={ date }
+			chartTab={ queryOptions.tab || 'impressions' }
+			context={ context }
+			period={ rangeOfPeriod( activeFilter.period, date ) }
+		/>
+	);
+
+	next();
+}

--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -131,6 +131,14 @@ function getMomentSiteZone( state, siteId ) {
 	return moment().utcOffset( Number.isFinite( gmtOffset ) ? gmtOffset : 0 );
 }
 
+export function redirectToActivity( context ) {
+	if ( context.params.site ) {
+		page.redirect( '/activity-log/' + context.params.site );
+	} else {
+		page.redirect( '/activity-log' );
+	}
+}
+
 export function redirectToDefaultSitePage( context ) {
 	const siteFragment = getSiteFragment( context.path );
 

--- a/client/my-sites/stats/index.js
+++ b/client/my-sites/stats/index.js
@@ -7,7 +7,6 @@ import page from 'page';
  * Internal dependencies
  */
 import { navigation, siteSelection, sites } from 'my-sites/controller';
-import { getStatsDefaultSitePage } from 'lib/route';
 import {
 	follows,
 	insights,
@@ -48,9 +47,9 @@ export default function () {
 		'annualstats',
 	].join( '|' );
 
-	// Redirect this to default /stats/day/ view in order to keep
+	// Redirect this to default /stats/day view in order to keep
 	// the paths and page view reporting consistent.
-	page( '/stats', () => page.redirect( getStatsDefaultSitePage() ) );
+	page( '/stats', '/stats/day' );
 
 	// Stat Overview Page
 	trackedPage( `/stats/:period(${ validPeriods })`, overview );

--- a/client/my-sites/stats/index.js
+++ b/client/my-sites/stats/index.js
@@ -27,7 +27,8 @@ import { makeLayout, render as clientRender } from 'controller';
  */
 import './style.scss';
 
-const trackedPage = ( url, controller ) => {
+// all Stats pages (except redirects) have the same handler structure
+const statsPage = ( url, controller ) => {
 	page( url, siteSelection, navigation, controller, makeLayout, clientRender );
 };
 
@@ -52,34 +53,34 @@ export default function () {
 	page( '/stats', '/stats/day' );
 
 	// Stat Overview Page
-	trackedPage( `/stats/:period(${ validPeriods })`, overview );
+	statsPage( `/stats/:period(${ validPeriods })`, overview );
 
-	trackedPage( '/stats/insights', sites );
+	statsPage( '/stats/insights', sites );
 
 	// Stat Insights Page
-	trackedPage( '/stats/insights/:site', insights );
+	statsPage( '/stats/insights/:site', insights );
 
 	// Stat Site Pages
-	trackedPage( `/stats/:period(${ validPeriods })/:site`, site );
+	statsPage( `/stats/:period(${ validPeriods })/:site`, site );
 
 	// Redirect this to default /stats/day/:module/:site view to
 	// keep the paths and page view reporting consistent.
 	page( `/stats/:module(${ validModules })/:site`, redirectToDefaultModulePage );
 
 	// Stat Summary Pages
-	trackedPage( `/stats/:period(${ validPeriods })/:module(${ validModules })/:site`, summary );
+	statsPage( `/stats/:period(${ validPeriods })/:module(${ validModules })/:site`, summary );
 
 	// Stat Single Post Page
-	trackedPage( '/stats/post/:post_id/:site', post );
-	trackedPage( '/stats/page/:post_id/:site', post );
+	statsPage( '/stats/post/:post_id/:site', post );
+	statsPage( '/stats/page/:post_id/:site', post );
 
 	// Stat Follows Page
-	trackedPage( '/stats/follows/comment/:site', follows );
-	trackedPage( '/stats/follows/comment/:page_num/:site', follows );
+	statsPage( '/stats/follows/comment/:site', follows );
+	statsPage( '/stats/follows/comment/:page_num/:site', follows );
 
 	page( '/stats/activity/:site?', redirectToActivity );
 
-	trackedPage( `/stats/ads/:period(${ validPeriods })/:site`, wordAds );
+	statsPage( `/stats/ads/:period(${ validPeriods })/:site`, wordAds );
 
 	// Anything else should redirect to default WordAds stats page
 	page( '/stats/wordads/(.*)', redirectToDefaultWordAdsPeriod );

--- a/client/my-sites/stats/index.js
+++ b/client/my-sites/stats/index.js
@@ -33,28 +33,7 @@ const trackedPage = ( url, controller ) => {
 };
 
 export default function () {
-	const validPeriods = [ 'day', 'week', 'month', 'year' ];
-
-	// Redirect this to default /stats/day/ view in order to keep
-	// the paths and page view reporting consistent.
-	page( '/stats', () => page.redirect( getStatsDefaultSitePage() ) );
-
-	// Stat Overview Page
-	trackedPage( '/stats/day', overview );
-	trackedPage( '/stats/week', overview );
-	trackedPage( '/stats/month', overview );
-	trackedPage( '/stats/year', overview );
-
-	trackedPage( '/stats/insights', sites );
-
-	// Stat Insights Page
-	trackedPage( '/stats/insights/:site', insights );
-
-	// Stat Site Pages
-	trackedPage( '/stats/day/:site', site );
-	trackedPage( '/stats/week/:site', site );
-	trackedPage( '/stats/month/:site', site );
-	trackedPage( '/stats/year/:site', site );
+	const validPeriods = [ 'day', 'week', 'month', 'year' ].join( '|' );
 
 	const validModules = [
 		'posts',
@@ -67,17 +46,29 @@ export default function () {
 		'filedownloads',
 		'searchterms',
 		'annualstats',
-	];
+	].join( '|' );
+
+	// Redirect this to default /stats/day/ view in order to keep
+	// the paths and page view reporting consistent.
+	page( '/stats', () => page.redirect( getStatsDefaultSitePage() ) );
+
+	// Stat Overview Page
+	trackedPage( `/stats/:period(${ validPeriods })`, overview );
+
+	trackedPage( '/stats/insights', sites );
+
+	// Stat Insights Page
+	trackedPage( '/stats/insights/:site', insights );
+
+	// Stat Site Pages
+	trackedPage( `/stats/:period(${ validPeriods })/:site`, site );
 
 	// Redirect this to default /stats/day/:module/:site view to
 	// keep the paths and page view reporting consistent.
-	page( `/stats/:module(${ validModules.join( '|' ) })/:site`, redirectToDefaultModulePage );
+	page( `/stats/:module(${ validModules })/:site`, redirectToDefaultModulePage );
 
 	// Stat Summary Pages
-	trackedPage( `/stats/day/:module(${ validModules.join( '|' ) })/:site`, summary );
-	trackedPage( `/stats/week/:module(${ validModules.join( '|' ) })/:site`, summary );
-	trackedPage( `/stats/month/:module(${ validModules.join( '|' ) })/:site`, summary );
-	trackedPage( `/stats/year/:module(${ validModules.join( '|' ) })/:site`, summary );
+	trackedPage( `/stats/:period(${ validPeriods })/:module(${ validModules })/:site`, summary );
 
 	// Stat Single Post Page
 	trackedPage( '/stats/post/:post_id/:site', post );
@@ -92,7 +83,7 @@ export default function () {
 
 	trackedPage( '/stats/activity/:site', redirectToAcivity );
 
-	trackedPage( `/stats/ads/:period(${ validPeriods.join( '|' ) })/:site`, wordAds );
+	trackedPage( `/stats/ads/:period(${ validPeriods })/:site`, wordAds );
 
 	// Anything else should redirect to default WordAds stats page
 	page( '/stats/wordads/(.*)', redirectToDefaultWordAdsPeriod );

--- a/client/my-sites/stats/index.js
+++ b/client/my-sites/stats/index.js
@@ -8,7 +8,18 @@ import page from 'page';
  */
 import { navigation, siteSelection, sites } from 'my-sites/controller';
 import { getStatsDefaultSitePage } from 'lib/route';
-import statsController from './controller';
+import {
+	follows,
+	insights,
+	overview,
+	post,
+	site,
+	summary,
+	wordAds,
+	redirectToDefaultModulePage,
+	redirectToDefaultSitePage,
+	redirectToDefaultWordAdsPeriod,
+} from './controller';
 import { redirect as redirectToAcivity } from 'my-sites/activity/controller';
 import { makeLayout, render as clientRender } from 'controller';
 
@@ -29,21 +40,21 @@ export default function () {
 	page( '/stats', () => page.redirect( getStatsDefaultSitePage() ) );
 
 	// Stat Overview Page
-	trackedPage( '/stats/day', statsController.overview );
-	trackedPage( '/stats/week', statsController.overview );
-	trackedPage( '/stats/month', statsController.overview );
-	trackedPage( '/stats/year', statsController.overview );
+	trackedPage( '/stats/day', overview );
+	trackedPage( '/stats/week', overview );
+	trackedPage( '/stats/month', overview );
+	trackedPage( '/stats/year', overview );
 
 	trackedPage( '/stats/insights', sites );
 
 	// Stat Insights Page
-	trackedPage( '/stats/insights/:site', statsController.insights );
+	trackedPage( '/stats/insights/:site', insights );
 
 	// Stat Site Pages
-	trackedPage( '/stats/day/:site', statsController.site );
-	trackedPage( '/stats/week/:site', statsController.site );
-	trackedPage( '/stats/month/:site', statsController.site );
-	trackedPage( '/stats/year/:site', statsController.site );
+	trackedPage( '/stats/day/:site', site );
+	trackedPage( '/stats/week/:site', site );
+	trackedPage( '/stats/month/:site', site );
+	trackedPage( '/stats/year/:site', site );
 
 	const validModules = [
 		'posts',
@@ -60,45 +71,33 @@ export default function () {
 
 	// Redirect this to default /stats/day/:module/:site view to
 	// keep the paths and page view reporting consistent.
-	page(
-		`/stats/:module(${ validModules.join( '|' ) })/:site`,
-		statsController.redirectToDefaultModulePage
-	);
+	page( `/stats/:module(${ validModules.join( '|' ) })/:site`, redirectToDefaultModulePage );
 
 	// Stat Summary Pages
-	trackedPage( `/stats/day/:module(${ validModules.join( '|' ) })/:site`, statsController.summary );
-	trackedPage(
-		`/stats/week/:module(${ validModules.join( '|' ) })/:site`,
-		statsController.summary
-	);
-	trackedPage(
-		`/stats/month/:module(${ validModules.join( '|' ) })/:site`,
-		statsController.summary
-	);
-	trackedPage(
-		`/stats/year/:module(${ validModules.join( '|' ) })/:site`,
-		statsController.summary
-	);
+	trackedPage( `/stats/day/:module(${ validModules.join( '|' ) })/:site`, summary );
+	trackedPage( `/stats/week/:module(${ validModules.join( '|' ) })/:site`, summary );
+	trackedPage( `/stats/month/:module(${ validModules.join( '|' ) })/:site`, summary );
+	trackedPage( `/stats/year/:module(${ validModules.join( '|' ) })/:site`, summary );
 
 	// Stat Single Post Page
-	trackedPage( '/stats/post/:post_id/:site', statsController.post );
-	trackedPage( '/stats/page/:post_id/:site', statsController.post );
+	trackedPage( '/stats/post/:post_id/:site', post );
+	trackedPage( '/stats/page/:post_id/:site', post );
 
 	// Stat Follows Page
-	trackedPage( '/stats/follows/comment/:site', statsController.follows );
-	trackedPage( '/stats/follows/comment/:page_num/:site', statsController.follows );
+	trackedPage( '/stats/follows/comment/:site', follows );
+	trackedPage( '/stats/follows/comment/:page_num/:site', follows );
 
 	// Can't convert to trackedPage because it uses `sites` instead of `navigation`
 	page( '/stats/activity', siteSelection, sites, redirectToAcivity, makeLayout, clientRender );
 
 	trackedPage( '/stats/activity/:site', redirectToAcivity );
 
-	trackedPage( `/stats/ads/:period(${ validPeriods.join( '|' ) })/:site`, statsController.wordAds );
+	trackedPage( `/stats/ads/:period(${ validPeriods.join( '|' ) })/:site`, wordAds );
 
 	// Anything else should redirect to default WordAds stats page
-	page( '/stats/wordads/(.*)', statsController.redirectToDefaultWordAdsPeriod );
-	page( '/stats/ads/(.*)', statsController.redirectToDefaultWordAdsPeriod );
+	page( '/stats/wordads/(.*)', redirectToDefaultWordAdsPeriod );
+	page( '/stats/ads/(.*)', redirectToDefaultWordAdsPeriod );
 
 	// Anything else should redirect to default stats page
-	page( '/stats/(.*)', statsController.redirectToDefaultSitePage );
+	page( '/stats/(.*)', redirectToDefaultSitePage );
 }

--- a/client/my-sites/stats/index.js
+++ b/client/my-sites/stats/index.js
@@ -16,11 +16,11 @@ import {
 	site,
 	summary,
 	wordAds,
+	redirectToActivity,
 	redirectToDefaultModulePage,
 	redirectToDefaultSitePage,
 	redirectToDefaultWordAdsPeriod,
 } from './controller';
-import { redirect as redirectToAcivity } from 'my-sites/activity/controller';
 import { makeLayout, render as clientRender } from 'controller';
 
 /**
@@ -78,10 +78,7 @@ export default function () {
 	trackedPage( '/stats/follows/comment/:site', follows );
 	trackedPage( '/stats/follows/comment/:page_num/:site', follows );
 
-	// Can't convert to trackedPage because it uses `sites` instead of `navigation`
-	page( '/stats/activity', siteSelection, sites, redirectToAcivity, makeLayout, clientRender );
-
-	trackedPage( '/stats/activity/:site', redirectToAcivity );
+	page( '/stats/activity/:site?', redirectToActivity );
 
 	trackedPage( `/stats/ads/:period(${ validPeriods })/:site`, wordAds );
 

--- a/client/my-sites/stats/index.js
+++ b/client/my-sites/stats/index.js
@@ -10,7 +10,6 @@ import { navigation, siteSelection, sites } from 'my-sites/controller';
 import { getStatsDefaultSitePage } from 'lib/route';
 import statsController from './controller';
 import { redirect as redirectToAcivity } from 'my-sites/activity/controller';
-import config from 'config';
 import { makeLayout, render as clientRender } from 'controller';
 
 /**
@@ -25,89 +24,81 @@ const trackedPage = ( url, controller ) => {
 export default function () {
 	const validPeriods = [ 'day', 'week', 'month', 'year' ];
 
-	if ( config.isEnabled( 'manage/stats' ) ) {
-		// Redirect this to default /stats/day/ view in order to keep
-		// the paths and page view reporting consistent.
-		page( '/stats', () => page.redirect( getStatsDefaultSitePage() ) );
+	// Redirect this to default /stats/day/ view in order to keep
+	// the paths and page view reporting consistent.
+	page( '/stats', () => page.redirect( getStatsDefaultSitePage() ) );
 
-		// Stat Overview Page
-		trackedPage( '/stats/day', statsController.overview );
-		trackedPage( '/stats/week', statsController.overview );
-		trackedPage( '/stats/month', statsController.overview );
-		trackedPage( '/stats/year', statsController.overview );
+	// Stat Overview Page
+	trackedPage( '/stats/day', statsController.overview );
+	trackedPage( '/stats/week', statsController.overview );
+	trackedPage( '/stats/month', statsController.overview );
+	trackedPage( '/stats/year', statsController.overview );
 
-		trackedPage( '/stats/insights', sites );
+	trackedPage( '/stats/insights', sites );
 
-		// Stat Insights Page
-		trackedPage( '/stats/insights/:site', statsController.insights );
+	// Stat Insights Page
+	trackedPage( '/stats/insights/:site', statsController.insights );
 
-		// Stat Site Pages
-		trackedPage( '/stats/day/:site', statsController.site );
-		trackedPage( '/stats/week/:site', statsController.site );
-		trackedPage( '/stats/month/:site', statsController.site );
-		trackedPage( '/stats/year/:site', statsController.site );
+	// Stat Site Pages
+	trackedPage( '/stats/day/:site', statsController.site );
+	trackedPage( '/stats/week/:site', statsController.site );
+	trackedPage( '/stats/month/:site', statsController.site );
+	trackedPage( '/stats/year/:site', statsController.site );
 
-		const validModules = [
-			'posts',
-			'referrers',
-			'clicks',
-			'countryviews',
-			'authors',
-			'videoplays',
-			'videodetails',
-			'filedownloads',
-			'searchterms',
-			'annualstats',
-		];
+	const validModules = [
+		'posts',
+		'referrers',
+		'clicks',
+		'countryviews',
+		'authors',
+		'videoplays',
+		'videodetails',
+		'filedownloads',
+		'searchterms',
+		'annualstats',
+	];
 
-		// Redirect this to default /stats/day/:module/:site view to
-		// keep the paths and page view reporting consistent.
-		page(
-			`/stats/:module(${ validModules.join( '|' ) })/:site`,
-			statsController.redirectToDefaultModulePage
-		);
+	// Redirect this to default /stats/day/:module/:site view to
+	// keep the paths and page view reporting consistent.
+	page(
+		`/stats/:module(${ validModules.join( '|' ) })/:site`,
+		statsController.redirectToDefaultModulePage
+	);
 
-		// Stat Summary Pages
-		trackedPage(
-			`/stats/day/:module(${ validModules.join( '|' ) })/:site`,
-			statsController.summary
-		);
-		trackedPage(
-			`/stats/week/:module(${ validModules.join( '|' ) })/:site`,
-			statsController.summary
-		);
-		trackedPage(
-			`/stats/month/:module(${ validModules.join( '|' ) })/:site`,
-			statsController.summary
-		);
-		trackedPage(
-			`/stats/year/:module(${ validModules.join( '|' ) })/:site`,
-			statsController.summary
-		);
+	// Stat Summary Pages
+	trackedPage( `/stats/day/:module(${ validModules.join( '|' ) })/:site`, statsController.summary );
+	trackedPage(
+		`/stats/week/:module(${ validModules.join( '|' ) })/:site`,
+		statsController.summary
+	);
+	trackedPage(
+		`/stats/month/:module(${ validModules.join( '|' ) })/:site`,
+		statsController.summary
+	);
+	trackedPage(
+		`/stats/year/:module(${ validModules.join( '|' ) })/:site`,
+		statsController.summary
+	);
 
-		// Stat Single Post Page
-		trackedPage( '/stats/post/:post_id/:site', statsController.post );
-		trackedPage( '/stats/page/:post_id/:site', statsController.post );
+	// Stat Single Post Page
+	trackedPage( '/stats/post/:post_id/:site', statsController.post );
+	trackedPage( '/stats/page/:post_id/:site', statsController.post );
 
-		// Stat Follows Page
-		trackedPage( '/stats/follows/comment/:site', statsController.follows );
-		trackedPage( '/stats/follows/comment/:page_num/:site', statsController.follows );
+	// Stat Follows Page
+	trackedPage( '/stats/follows/comment/:site', statsController.follows );
+	trackedPage( '/stats/follows/comment/:page_num/:site', statsController.follows );
 
-		// Can't convert to trackedPage because it uses `sites` instead of `navigation`
-		page( '/stats/activity', siteSelection, sites, redirectToAcivity, makeLayout, clientRender );
+	// Can't convert to trackedPage because it uses `sites` instead of `navigation`
+	page( '/stats/activity', siteSelection, sites, redirectToAcivity, makeLayout, clientRender );
 
-		trackedPage( '/stats/activity/:site', redirectToAcivity );
+	trackedPage( '/stats/activity/:site', redirectToAcivity );
 
-		trackedPage(
-			`/stats/ads/:period(${ validPeriods.join( '|' ) })/:site`,
-			statsController.wordAds
-		);
+	trackedPage( `/stats/ads/:period(${ validPeriods.join( '|' ) })/:site`, statsController.wordAds );
 
-		// Anything else should redirect to default WordAds stats page
-		page( '/stats/wordads/(.*)', statsController.redirectToDefaultWordAdsPeriod );
-		page( '/stats/ads/(.*)', statsController.redirectToDefaultWordAdsPeriod );
+	// Anything else should redirect to default WordAds stats page
+	page( '/stats/wordads/(.*)', statsController.redirectToDefaultWordAdsPeriod );
+	page( '/stats/ads/(.*)', statsController.redirectToDefaultWordAdsPeriod );
 
-		// Anything else should redirect to default stats page
-		page( '/stats/(.*)', statsController.redirectToDefaultSitePage );
-	}
+	// Anything else should redirect to default stats page
+	page( '/stats/(.*)', statsController.redirectToDefaultSitePage );
 }

--- a/client/my-sites/stats/test/index.js
+++ b/client/my-sites/stats/test/index.js
@@ -1,5 +1,17 @@
 jest.mock( 'page', () => jest.fn() );
-jest.mock( '../controller', () => jest.fn() );
+jest.mock( '../controller', () => ( {
+	overview: jest.fn(),
+	insights: jest.fn(),
+	site: jest.fn(),
+	summary: jest.fn(),
+	post: jest.fn(),
+	follows: jest.fn(),
+	wordAds: jest.fn(),
+	redirectToActivity: jest.fn(),
+	redirectToDefaultModulePage: jest.fn(),
+	redirectToDefaultSitePage: jest.fn(),
+	redirectToDefaultWordAdsPeriod: jest.fn(),
+} ) );
 jest.mock( 'my-sites/controller', () => ( {
 	navigation: jest.fn(),
 	siteSelection: jest.fn(),
@@ -16,7 +28,19 @@ import page from 'page';
  * Internal dependencies
  */
 import { navigation, siteSelection, sites } from 'my-sites/controller';
-import statsController from '../controller';
+import {
+	overview,
+	insights,
+	site,
+	summary,
+	post,
+	follows,
+	wordAds,
+	redirectToActivity,
+	redirectToDefaultModulePage,
+	redirectToDefaultSitePage,
+	redirectToDefaultWordAdsPeriod,
+} from '../controller';
 import { makeLayout, render as clientRender } from 'controller';
 
 import router from '../index';
@@ -40,73 +64,49 @@ const routes = {
 	[ `/stats/:period(${ validPeriods })` ]: [
 		siteSelection,
 		navigation,
-		statsController.overview,
+		overview,
 		makeLayout,
 		clientRender,
 	],
 	'/stats/insights': [ siteSelection, navigation, sites, makeLayout, clientRender ],
-	'/stats/insights/:site': [
-		siteSelection,
-		navigation,
-		statsController.insights,
-		makeLayout,
-		clientRender,
-	],
+	'/stats/insights/:site': [ siteSelection, navigation, insights, makeLayout, clientRender ],
 	[ `/stats/:period(${ validPeriods })/:site` ]: [
 		siteSelection,
 		navigation,
-		statsController.site,
+		site,
 		makeLayout,
 		clientRender,
 	],
-	[ `/stats/:module(${ validModules })/:site` ]: [ statsController.redirectToDefaultModulePage ],
+	[ `/stats/:module(${ validModules })/:site` ]: [ redirectToDefaultModulePage ],
 	[ `/stats/:period(${ validPeriods })/:module(${ validModules })/:site` ]: [
 		siteSelection,
 		navigation,
-		statsController.summary,
+		summary,
 		makeLayout,
 		clientRender,
 	],
-	'/stats/post/:post_id/:site': [
-		siteSelection,
-		navigation,
-		statsController.post,
-		makeLayout,
-		clientRender,
-	],
+	'/stats/post/:post_id/:site': [ siteSelection, navigation, post, makeLayout, clientRender ],
 
-	'/stats/page/:post_id/:site': [
-		siteSelection,
-		navigation,
-		statsController.post,
-		makeLayout,
-		clientRender,
-	],
-	'/stats/follows/comment/:site': [
-		siteSelection,
-		navigation,
-		statsController.follows,
-		makeLayout,
-		clientRender,
-	],
+	'/stats/page/:post_id/:site': [ siteSelection, navigation, post, makeLayout, clientRender ],
+	'/stats/follows/comment/:site': [ siteSelection, navigation, follows, makeLayout, clientRender ],
 	'/stats/follows/comment/:page_num/:site': [
 		siteSelection,
 		navigation,
-		statsController.follows,
+		follows,
 		makeLayout,
 		clientRender,
 	],
-	'/stats/activity/:site?': [ statsController.redirectToAcivity ],
+	'/stats/activity/:site?': [ redirectToActivity ],
 	[ `/stats/ads/:period(${ validPeriods })/:site` ]: [
 		siteSelection,
 		navigation,
-		statsController.wordAds,
+		wordAds,
 		makeLayout,
 		clientRender,
 	],
-	'/stats/wordads/(.*)': [ statsController.redirectToDefaultWordAdsPeriod ],
-	'/stats/ads/(.*)': [ statsController.redirectToDefaultWordAdsPeriod ],
-	'/stats/(.*)': [ statsController.redirectToDefaultSitePage ],
+	'/stats/wordads/(.*)': [ redirectToDefaultWordAdsPeriod ],
+	'/stats/ads/(.*)': [ redirectToDefaultWordAdsPeriod ],
+	'/stats/(.*)': [ redirectToDefaultSitePage ],
 };
 
 describe( 'Sets all routes', () => {

--- a/client/my-sites/stats/test/index.js
+++ b/client/my-sites/stats/test/index.js
@@ -5,16 +5,6 @@ jest.mock( 'my-sites/controller', () => ( {
 	siteSelection: jest.fn(),
 	sites: jest.fn(),
 } ) );
-
-jest.mock( 'lib/route', () => ( {
-	getStatsDefaultSitePage: jest.fn(),
-} ) );
-jest.mock( 'my-sites/activity/controller', () => ( {
-	redirect: jest.fn(),
-} ) );
-jest.mock( 'config', () => ( {
-	isEnabled: jest.fn(),
-} ) );
 jest.mock( 'controller', () => ( {
 	makeLayout: jest.fn(),
 	render: jest.fn(),
@@ -27,13 +17,9 @@ import page from 'page';
  */
 import { navigation, siteSelection, sites } from 'my-sites/controller';
 import statsController from '../controller';
-import { redirect as redirectToAcivity } from 'my-sites/activity/controller';
-import config from 'config';
 import { makeLayout, render as clientRender } from 'controller';
 
 import router from '../index';
-
-config.isEnabled.mockImplementation( ( flag ) => flag === 'manage/stats' );
 
 const validModules = [
 	'posts',
@@ -46,14 +32,18 @@ const validModules = [
 	'filedownloads',
 	'searchterms',
 	'annualstats',
-];
-const validPeriods = [ 'day', 'week', 'month', 'year' ];
+].join( '|' );
+
+const validPeriods = [ 'day', 'week', 'month', 'year' ].join( '|' );
 
 const routes = {
-	'/stats/day': [ siteSelection, navigation, statsController.overview, makeLayout, clientRender ],
-	'/stats/week': [ siteSelection, navigation, statsController.overview, makeLayout, clientRender ],
-	'/stats/month': [ siteSelection, navigation, statsController.overview, makeLayout, clientRender ],
-	'/stats/year': [ siteSelection, navigation, statsController.overview, makeLayout, clientRender ],
+	[ `/stats/:period(${ validPeriods })` ]: [
+		siteSelection,
+		navigation,
+		statsController.overview,
+		makeLayout,
+		clientRender,
+	],
 	'/stats/insights': [ siteSelection, navigation, sites, makeLayout, clientRender ],
 	'/stats/insights/:site': [
 		siteSelection,
@@ -62,53 +52,15 @@ const routes = {
 		makeLayout,
 		clientRender,
 	],
-	'/stats/day/:site': [ siteSelection, navigation, statsController.site, makeLayout, clientRender ],
-	'/stats/week/:site': [
+	[ `/stats/:period(${ validPeriods })/:site` ]: [
 		siteSelection,
 		navigation,
 		statsController.site,
 		makeLayout,
 		clientRender,
 	],
-	'/stats/month/:site': [
-		siteSelection,
-		navigation,
-		statsController.site,
-		makeLayout,
-		clientRender,
-	],
-	'/stats/year/:site': [
-		siteSelection,
-		navigation,
-		statsController.site,
-		makeLayout,
-		clientRender,
-	],
-	[ `/stats/:module(${ validModules.join( '|' ) })/:site` ]: [
-		statsController.redirectToDefaultModulePage,
-	],
-	[ `/stats/day/:module(${ validModules.join( '|' ) })/:site` ]: [
-		siteSelection,
-		navigation,
-		statsController.summary,
-		makeLayout,
-		clientRender,
-	],
-	[ `/stats/week/:module(${ validModules.join( '|' ) })/:site` ]: [
-		siteSelection,
-		navigation,
-		statsController.summary,
-		makeLayout,
-		clientRender,
-	],
-	[ `/stats/month/:module(${ validModules.join( '|' ) })/:site` ]: [
-		siteSelection,
-		navigation,
-		statsController.summary,
-		makeLayout,
-		clientRender,
-	],
-	[ `/stats/year/:module(${ validModules.join( '|' ) })/:site` ]: [
+	[ `/stats/:module(${ validModules })/:site` ]: [ statsController.redirectToDefaultModulePage ],
+	[ `/stats/:period(${ validPeriods })/:module(${ validModules })/:site` ]: [
 		siteSelection,
 		navigation,
 		statsController.summary,
@@ -144,15 +96,8 @@ const routes = {
 		makeLayout,
 		clientRender,
 	],
-	'/stats/activity': [ siteSelection, sites, redirectToAcivity, makeLayout, clientRender ],
-	'/stats/activity/:site': [
-		siteSelection,
-		navigation,
-		redirectToAcivity,
-		makeLayout,
-		clientRender,
-	],
-	[ `/stats/ads/:period(${ validPeriods.join( '|' ) })/:site` ]: [
+	'/stats/activity/:site?': [ statsController.redirectToAcivity ],
+	[ `/stats/ads/:period(${ validPeriods })/:site` ]: [
 		siteSelection,
 		navigation,
 		statsController.wordAds,

--- a/config/desktop-development.json
+++ b/config/desktop-development.json
@@ -87,7 +87,6 @@
 		"manage/security": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
-		"manage/stats": true,
 		"manage/themes-jetpack": true,
 		"manage/themes/details": true,
 		"manage/themes/details/jetpack": true,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -68,7 +68,6 @@
 		"manage/security": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
-		"manage/stats": true,
 		"manage/themes-jetpack": true,
 		"manage/themes/details": true,
 		"manage/themes/details/jetpack": true,

--- a/config/development.json
+++ b/config/development.json
@@ -127,7 +127,6 @@
 		"manage/security": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
-		"manage/stats": true,
 		"manage/themes-jetpack": true,
 		"manage/themes/details": true,
 		"manage/themes/details/jetpack": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -88,7 +88,6 @@
 		"manage/security": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
-		"manage/stats": true,
 		"manage/themes-jetpack": true,
 		"manage/themes/details": true,
 		"manage/themes/details/jetpack": true,

--- a/config/production.json
+++ b/config/production.json
@@ -92,7 +92,6 @@
 		"manage/security": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
-		"manage/stats": true,
 		"manage/themes-jetpack": true,
 		"manage/themes/details": true,
 		"manage/themes/details/jetpack": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -96,7 +96,6 @@
 		"manage/security": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
-		"manage/stats": true,
 		"manage/themes-jetpack": true,
 		"manage/themes/details": true,
 		"manage/themes/details/jetpack": true,

--- a/config/test.json
+++ b/config/test.json
@@ -69,7 +69,6 @@
 		"manage/security": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
-		"manage/stats": true,
 		"manage/themes-jetpack": true,
 		"manage/themes/details": true,
 		"manage/themes/details/jetpack": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -104,7 +104,6 @@
 		"manage/security": true,
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
-		"manage/stats": true,
 		"manage/themes-jetpack": true,
 		"manage/themes/details": true,
 		"manage/themes/details/jetpack": true,


### PR DESCRIPTION
The Stats router code has accumulated a lot of cruft over the years, and this PR tries to clean it up. The material benefit is that the `stats` section loses 40% of its JavaScript weight, mainly due to removed dependency on the `activity` section (after moving the redirect handler).

The changes are:
- remove the unit test for the router, as it's an example of not-useful test that only duplicates code: "the code calls `page( a, b, c )`, so let's mock `page` and verify it's been called with `a`, `b`, `c`". If I understand it correctly, @scinos created the test to test LUX tracking, but that has been removed since. During this refactoring, my experience has been that the test creates more work for me and doesn't help me verify correctness.
- remove the `manage/stats` feature flag that's been always `true` for several years
- migrate the `stats/controller` to individual ESM exports instead of `export default { a, b, c }`, which was probably a relict of CJS to ESM migration
- instead of defining routes for `/stats/day`, `/stats/week`, etc. individually, catch all valid periods in a `:period(day|week)` matcher.
- move the `redirectToActivity` handler from the `activity` module to `stats`. Independent sections should import each other just to figure out the other section's URL. The removed dependency makes the `stats` section chunk 40% smaller.
- rename `trackingPage` (no more tracking there) to `statsPage`, a convenient helper

**How to test:**
Verify that stats work exactly as they did before, and that this PR is a pure refactoring that doesn't change any behavior at all.