### PR TITLE
Adjust discount calculation in /plans

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.js
@@ -20,6 +20,8 @@ import joinClasses from './join-classes';
 import { useHasDomainsInCart } from '../hooks/has-domains';
 import { ItemVariationPicker } from './item-variation-picker';
 import { isGSuiteProductSlug } from 'lib/gsuite';
+import { planMatches } from 'lib/plans';
+import { GROUP_WPCOM, TERM_ANNUALLY, TERM_BIENNIALLY } from 'lib/plans/constants';
 
 export function WPOrderReviewSection( { children, className } ) {
 	return <div className={ joinClasses( [ className, 'order-review-section' ] ) }>{ children }</div>;
@@ -76,10 +78,15 @@ function WPLineItem( {
 				<LineItemPrice item={ item } isSummary={ isSummary } />
 			</span>
 			{ item.sublabel && (
-				<LineItemMeta>
-					<LineItemSublabelAndPrice item={ item } />
-					<DomainDiscountCallout item={ item } />
-				</LineItemMeta>
+				<>
+					<LineItemMeta>
+						<LineItemSublabelAndPrice item={ item } />
+						<DomainDiscountCallout item={ item } />
+					</LineItemMeta>
+					<LineItemMeta>
+						<DiscountForFirstYearOnly item={ item } />
+					</LineItemMeta>
+				</>
 			) }
 			{ isGSuite && <GSuiteUsersList item={ item } /> }
 			{ hasDeleteButton && formStatus === FormStatus.READY && (
@@ -519,5 +526,40 @@ function GSuiteDiscountCallout( { item } ) {
 	) {
 		return <DiscountCalloutUI>{ translate( 'Discount for first year' ) }</DiscountCalloutUI>;
 	}
+	return null;
+}
+function DiscountForFirstYearOnly( { item } ) {
+	const translate = useTranslate();
+	const hasDiscount = !! item.wpcom_meta.item_original_cost_integer;
+	if ( ! hasDiscount ) {
+		return null;
+	}
+	const isWpcomOneYearPlan = planMatches( item.wpcom_meta.product_slug, {
+		term: TERM_ANNUALLY,
+		group: GROUP_WPCOM,
+	} );
+	if ( isWpcomOneYearPlan ) {
+		return (
+			<div>
+				{ translate(
+					'Promotional pricing is for the first year only. Your plan will renew at the regular price.'
+				) }
+			</div>
+		);
+	}
+	const isWpcomTwoYearPlan = planMatches( item.wpcom_meta.product_slug, {
+		term: TERM_BIENNIALLY,
+		group: GROUP_WPCOM,
+	} );
+	if ( isWpcomTwoYearPlan ) {
+		return (
+			<div>
+				{ translate(
+					'Promotional pricing is for the first 2 years only. Your plan will renew at the regular price.'
+				) }
+			</div>
+		);
+	}
+
 	return null;
 }

--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.js
@@ -530,8 +530,9 @@ function GSuiteDiscountCallout( { item } ) {
 }
 function DiscountForFirstYearOnly( { item } ) {
 	const translate = useTranslate();
-	const hasDiscount = !! item.wpcom_meta.item_original_cost_integer;
-	if ( ! hasDiscount ) {
+	const origCost = item.wpcom_meta.item_original_cost_integer;
+	const cost = item.wpcom_meta.product_cost_integer;
+	if ( origCost <= cost ) {
 		return null;
 	}
 	const isWpcomOneYearPlan = planMatches( item.wpcom_meta.product_slug, {

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -143,20 +143,17 @@ export class PlanFeaturesHeader extends Component {
 	}
 
 	getDiscountTooltipMessage() {
-		const { currencyCode, currentSitePlan, translate, rawPrice } = this.props;
-		const isUserCurrentlyOnAFreePlan =
-			currentSitePlan && planMatches( currentSitePlan.productSlug, { type: TYPE_FREE } );
+		const { currencyCode, currentSitePlan, translate, rawPrice, discountPrice } = this.props;
 		const price = formatCurrency( rawPrice, currencyCode );
-
-		if ( isUserCurrentlyOnAFreePlan ) {
-			return translate(
-				"You'll receive a discount for the first year. The plan will renew at %(price)s.",
-				{ args: { price } }
-			);
-		}
+		const isDiscounted = !! discountPrice;
 
 		if ( planMatches( currentSitePlan.productSlug, { type: TYPE_FREE } ) ) {
-			return translate( 'Price for the next 12 months' );
+			return isDiscounted
+				? translate(
+						"You'll receive a discount for the first year. The plan will renew at %(price)s.",
+						{ args: { price } }
+				  )
+				: translate( 'Price for the next 12 months' );
 		}
 
 		return translate(

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -19,7 +19,7 @@ import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer'
 import PlanPrice from 'my-sites/plan-price';
 import PlanIntervalDiscount from 'my-sites/plan-interval-discount';
 import PlanPill from 'components/plans/plan-pill';
-import { TYPE_FREE } from 'lib/plans/constants';
+import { TYPE_FREE, GROUP_WPCOM, TERM_ANNUALLY } from 'lib/plans/constants';
 import { PLANS_LIST } from 'lib/plans/plans-list';
 import { getYearlyPlanByMonthly, planMatches, getPlanClass } from 'lib/plans';
 import { getCurrentPlan } from 'state/sites/plans/selectors';
@@ -165,6 +165,27 @@ export class PlanFeaturesHeader extends Component {
 		);
 	}
 
+	getPerMonthDescription() {
+		const { discountPrice, rawPrice, translate, planType } = this.props;
+		if ( typeof discountPrice !== 'number' || typeof rawPrice !== 'number' ) {
+			return null;
+		}
+		if ( ! planMatches( planType, { group: GROUP_WPCOM, term: TERM_ANNUALLY } ) ) {
+			return null;
+		}
+		const discountPercent = Math.round( ( 100 * ( rawPrice - discountPrice ) ) / rawPrice );
+		if ( discountPercent <= 0 ) {
+			return null;
+		}
+		return translate(
+			'Save %(discountPercent)s%% for 12 months!{{br/}} Per month, billed yearly.',
+			{
+				args: { discountPercent },
+				components: { br: <br /> },
+			}
+		);
+	}
+
 	getBillingTimeframe() {
 		const {
 			billingTimeFrame,
@@ -182,11 +203,11 @@ export class PlanFeaturesHeader extends Component {
 			'is-discounted': isDiscounted,
 			'is-placeholder': isPlaceholder,
 		} );
-
+		const perMonthDescription = this.getPerMonthDescription() || billingTimeFrame;
 		if ( isInSignup || plansWithScroll ) {
 			return (
 				<div className={ 'plan-features__header-billing-info' }>
-					<span>{ billingTimeFrame }</span>
+					<span>{ perMonthDescription }</span>
 				</div>
 			);
 		}
@@ -199,7 +220,7 @@ export class PlanFeaturesHeader extends Component {
 		) {
 			return (
 				<p className={ timeframeClasses }>
-					{ ! isPlaceholder ? billingTimeFrame : '' }
+					{ ! isPlaceholder ? perMonthDescription : '' }
 					{ isDiscounted && ! isPlaceholder && (
 						<InfoPopover
 							className="plan-features__header-tip-info"

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -144,12 +144,20 @@ export class PlanFeaturesHeader extends Component {
 
 	getDiscountTooltipMessage() {
 		const { currencyCode, currentSitePlan, translate, rawPrice } = this.props;
+		const isUserCurrentlyOnAFreePlan =
+			currentSitePlan && planMatches( currentSitePlan.productSlug, { type: TYPE_FREE } );
+		const price = formatCurrency( rawPrice, currencyCode );
+
+		if ( isUserCurrentlyOnAFreePlan ) {
+			return translate(
+				"You'll receive a discount for the first year. The plan will renew at %(price)s.",
+				{ args: { price } }
+			);
+		}
 
 		if ( planMatches( currentSitePlan.productSlug, { type: TYPE_FREE } ) ) {
 			return translate( 'Price for the next 12 months' );
 		}
-
-		const price = formatCurrency( rawPrice, currencyCode );
 
 		return translate(
 			"You'll receive a discount from the full price of %(price)s because you already have a plan.",
@@ -159,7 +167,6 @@ export class PlanFeaturesHeader extends Component {
 
 	getBillingTimeframe() {
 		const {
-			currentSitePlan,
 			billingTimeFrame,
 			discountPrice,
 			isPlaceholder,
@@ -184,8 +191,6 @@ export class PlanFeaturesHeader extends Component {
 			);
 		}
 
-		const isUserCurrentlyOnAFreePlan =
-			currentSitePlan && planMatches( currentSitePlan.productSlug, { type: TYPE_FREE } );
 		if (
 			isSiteAT ||
 			! isJetpack ||
@@ -195,7 +200,7 @@ export class PlanFeaturesHeader extends Component {
 			return (
 				<p className={ timeframeClasses }>
 					{ ! isPlaceholder ? billingTimeFrame : '' }
-					{ isDiscounted && ! isUserCurrentlyOnAFreePlan && ! isPlaceholder && (
+					{ isDiscounted && ! isPlaceholder && (
 						<InfoPopover
 							className="plan-features__header-tip-info"
 							position={ isMobile() ? 'top' : 'bottom left' }

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -43,6 +43,7 @@ import {
 } from 'lib/plans';
 import {
 	getPlanDiscountedRawPrice,
+	getSitePlanRawPrice,
 	getPlansBySiteId,
 	isCurrentUserCurrentPlanOwner,
 } from 'state/sites/plans/selectors';
@@ -904,7 +905,9 @@ export default connect(
 						newPlan ||
 						bestValue ||
 						plans.length === 1,
-					rawPrice: getPlanRawPrice( state, planProductId, showMonthlyPrice ),
+					rawPrice: getSitePlanRawPrice( state, selectedSiteId, plan, {
+						isMonthly: showMonthlyPrice,
+					} ),
 					relatedMonthlyPlan,
 					siteIsPrivateAndGoingAtomic,
 				};

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -894,7 +894,7 @@ export default connect(
 					checkoutUrl,
 					currencyCode: getCurrentUserCurrencyCode( state ),
 					current: isCurrentSitePlan( state, selectedSiteId, planProductId ),
-					discountPrice: discountPrice,
+					discountPrice,
 					features: planFeatures,
 					isLandingPage,
 					isPlaceholder,
@@ -912,7 +912,7 @@ export default connect(
 						newPlan ||
 						bestValue ||
 						plans.length === 1,
-					rawPrice: rawPrice,
+					rawPrice,
 					relatedMonthlyPlan,
 					siteIsPrivateAndGoingAtomic,
 				};

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -23,7 +23,7 @@ import SpinnerLine from 'components/spinner-line';
 import QueryActivePromotions from 'components/data/query-active-promotions';
 import { abtest } from 'lib/abtest';
 import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
-import { getPlan, getPlanBySlug, getPlanRawPrice, getPlanSlug } from 'state/plans/selectors';
+import { getPlan, getPlanBySlug, getPlanSlug } from 'state/plans/selectors';
 import { getSignupDependencyStore } from 'state/signup/dependency-store/selectors';
 import { planItem as getCartItemForPlan } from 'lib/cart-values/cart-items';
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -755,17 +755,13 @@ export const isPrimaryUpgradeByPlanDelta = ( currentPlan, plan ) =>
 
 export const calculatePlanCredits = ( state, siteId, planProperties ) =>
 	planProperties
-		.map( ( { planName, planConstantObj, availableForPurchase } ) => {
+		.map( ( { planName, availableForPurchase } ) => {
 			if ( ! availableForPurchase ) {
 				return 0;
 			}
-			const planProductId = planConstantObj.getProductId();
-			const annualDiscountPrice = getPlanDiscountedRawPrice( state, siteId, planName, {
-				isMonthly: false,
-			} );
-			const annualRawPrice = getPlanRawPrice( state, planProductId, false );
-
-			if ( typeof annualDiscountPrice !== 'number' || typeof annualDiscountPrice !== 'number' ) {
+			const annualDiscountPrice = getPlanDiscountedRawPrice( state, siteId, planName );
+			const annualRawPrice = getSitePlanRawPrice( state, siteId, planName );
+			if ( typeof annualDiscountPrice !== 'number' || typeof annualRawPrice !== 'number' ) {
 				return 0;
 			}
 

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -23,7 +23,13 @@ import SpinnerLine from 'components/spinner-line';
 import QueryActivePromotions from 'components/data/query-active-promotions';
 import { abtest } from 'lib/abtest';
 import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
-import { getPlan, getPlanBySlug, getPlanRawPrice, getPlanSlug } from 'state/plans/selectors';
+import {
+	getPlan,
+	getPlanBySlug,
+	getPlanRawPrice,
+	getPlanSlug,
+	getDiscountedRawPrice,
+} from 'state/plans/selectors';
 import { getSignupDependencyStore } from 'state/signup/dependency-store/selectors';
 import { planItem as getCartItemForPlan } from 'lib/cart-values/cart-items';
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -874,9 +880,13 @@ export default connect(
 					planFeatures = getPlanFeaturesObject( planConstantObj.getSignupFeatures( currentPlan ) );
 				}
 				const siteIsPrivateAndGoingAtomic = siteIsPrivate && isWpComEcommercePlan( plan );
+				const isMonthlyObj = { isMonthly: showMonthlyPrice };
 				const rawPrice = siteId
-					? getSitePlanRawPrice( state, selectedSiteId, plan, { isMonthly: showMonthlyPrice } )
+					? getSitePlanRawPrice( state, selectedSiteId, plan, isMonthlyObj )
 					: getPlanRawPrice( state, planProductId, showMonthlyPrice );
+				const discountPrice = siteId
+					? getPlanDiscountedRawPrice( state, selectedSiteId, plan, isMonthlyObj )
+					: getDiscountedRawPrice( state, planProductId, showMonthlyPrice );
 
 				return {
 					availableForPurchase,
@@ -884,9 +894,7 @@ export default connect(
 					checkoutUrl,
 					currencyCode: getCurrentUserCurrencyCode( state ),
 					current: isCurrentSitePlan( state, selectedSiteId, planProductId ),
-					discountPrice: getPlanDiscountedRawPrice( state, selectedSiteId, plan, {
-						isMonthly: showMonthlyPrice,
-					} ),
+					discountPrice: discountPrice,
 					features: planFeatures,
 					isLandingPage,
 					isPlaceholder,

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -23,7 +23,7 @@ import SpinnerLine from 'components/spinner-line';
 import QueryActivePromotions from 'components/data/query-active-promotions';
 import { abtest } from 'lib/abtest';
 import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
-import { getPlan, getPlanBySlug, getPlanSlug } from 'state/plans/selectors';
+import { getPlan, getPlanBySlug, getPlanRawPrice, getPlanSlug } from 'state/plans/selectors';
 import { getSignupDependencyStore } from 'state/signup/dependency-store/selectors';
 import { planItem as getCartItemForPlan } from 'lib/cart-values/cart-items';
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -874,6 +874,9 @@ export default connect(
 					planFeatures = getPlanFeaturesObject( planConstantObj.getSignupFeatures( currentPlan ) );
 				}
 				const siteIsPrivateAndGoingAtomic = siteIsPrivate && isWpComEcommercePlan( plan );
+				const rawPrice = siteId
+					? getSitePlanRawPrice( state, selectedSiteId, plan, { isMonthly: showMonthlyPrice } )
+					: getPlanRawPrice( state, planProductId, showMonthlyPrice );
 
 				return {
 					availableForPurchase,
@@ -901,9 +904,7 @@ export default connect(
 						newPlan ||
 						bestValue ||
 						plans.length === 1,
-					rawPrice: getSitePlanRawPrice( state, selectedSiteId, plan, {
-						isMonthly: showMonthlyPrice,
-					} ),
+					rawPrice: rawPrice,
 					relatedMonthlyPlan,
 					siteIsPrivateAndGoingAtomic,
 				};

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -870,6 +870,7 @@ body.is-section-signup #primary .segmented-control.is-customer-type-toggle {
 		padding: 8px 16px;
 		margin: 0;
 		border-top: solid 1px var( --color-neutral-10 );
+		text-align: left;
 
 		.plan-price {
 			font-weight: 600;

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -730,7 +730,7 @@ body.is-section-signup #primary .segmented-control.is-customer-type-toggle {
 	}
 
 	.plan-features__header-price-group-prices {
-		display: inline;
+		display: inline-block;
 	}
 }
 

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -870,7 +870,6 @@ body.is-section-signup #primary .segmented-control.is-customer-type-toggle {
 		padding: 8px 16px;
 		margin: 0;
 		border-top: solid 1px var( --color-neutral-10 );
-		text-align: left;
 
 		.plan-price {
 			font-weight: 600;

--- a/client/my-sites/plan-features/test/header.jsx
+++ b/client/my-sites/plan-features/test/header.jsx
@@ -78,6 +78,19 @@ describe( 'PlanFeaturesHeader.getDiscountTooltipMessage()', () => {
 		} );
 	} );
 
+	[ PLAN_FREE, PLAN_JETPACK_FREE ].forEach( ( productSlug ) => {
+		test( `Should return a particular message for free plans with discount (${ productSlug })`, () => {
+			const comp = new PlanFeaturesHeader( {
+				...props,
+				currentSitePlan: { productSlug },
+				discountPrice: 3,
+			} );
+			expect( comp.getDiscountTooltipMessage() ).toBe(
+				"You'll receive a discount for the first year. The plan will renew at %(price)s."
+			);
+		} );
+	} );
+
 	[
 		PLAN_PERSONAL,
 		PLAN_PERSONAL_2_YEARS,

--- a/client/my-sites/plan-features/test/index.jsx
+++ b/client/my-sites/plan-features/test/index.jsx
@@ -22,10 +22,7 @@ jest.mock( 'i18n-calypso', () => ( {
 
 jest.mock( 'state/sites/plans/selectors', () => ( {
 	getPlanDiscountedRawPrice: jest.fn(),
-} ) );
-
-jest.mock( 'state/plans/selectors', () => ( {
-	getPlanRawPrice: jest.fn(),
+	getSitePlanRawPrice: jest.fn(),
 } ) );
 
 /**
@@ -57,8 +54,7 @@ import {
  */
 import { calculatePlanCredits, isPrimaryUpgradeByPlanDelta, PlanFeatures } from '../index';
 
-import { getPlanDiscountedRawPrice } from 'state/sites/plans/selectors';
-import { getPlanRawPrice } from 'state/plans/selectors';
+import { getPlanDiscountedRawPrice, getSitePlanRawPrice } from 'state/sites/plans/selectors';
 
 const identity = ( x ) => x;
 
@@ -176,11 +172,11 @@ describe( 'calculatePlanCredits', () => {
 	};
 	beforeEach( () => {
 		getPlanDiscountedRawPrice.mockReset();
-		getPlanRawPrice.mockReset();
+		getSitePlanRawPrice.mockReset();
 	} );
 	test( 'Should return max annual price difference between all available plans - 1 plan', () => {
 		getPlanDiscountedRawPrice.mockReturnValueOnce( 80 );
-		getPlanRawPrice.mockReturnValueOnce( 100 );
+		getSitePlanRawPrice.mockReturnValueOnce( 100 );
 		const credits = calculatePlanCredits( {}, 1, [ { ...baseProps, availableForPurchase: true } ] );
 		expect( credits ).toBe( 20 );
 	} );
@@ -190,7 +186,10 @@ describe( 'calculatePlanCredits', () => {
 			.mockReturnValueOnce( 60 )
 			.mockReturnValueOnce( 70 );
 
-		getPlanRawPrice.mockReturnValueOnce( 100 ).mockReturnValueOnce( 90 ).mockReturnValueOnce( 130 );
+		getSitePlanRawPrice
+			.mockReturnValueOnce( 100 )
+			.mockReturnValueOnce( 90 )
+			.mockReturnValueOnce( 130 );
 		const credits = calculatePlanCredits( {}, 1, [
 			{ ...baseProps, availableForPurchase: true },
 			{ ...baseProps, availableForPurchase: true },
@@ -204,7 +203,10 @@ describe( 'calculatePlanCredits', () => {
 			.mockReturnValueOnce( 60 )
 			.mockReturnValueOnce( 70 );
 
-		getPlanRawPrice.mockReturnValueOnce( 100 ).mockReturnValueOnce( 90 ).mockReturnValueOnce( 130 );
+		getSitePlanRawPrice
+			.mockReturnValueOnce( 100 )
+			.mockReturnValueOnce( 90 )
+			.mockReturnValueOnce( 130 );
 		const credits = calculatePlanCredits( {}, 1, [
 			{ ...baseProps, availableForPurchase: true },
 			{ ...baseProps, availableForPurchase: false },
@@ -214,7 +216,7 @@ describe( 'calculatePlanCredits', () => {
 	} );
 	test( 'Should return 0 when no plan is available', () => {
 		getPlanDiscountedRawPrice.mockReturnValueOnce( 70 );
-		getPlanRawPrice.mockReturnValueOnce( 130 );
+		getSitePlanRawPrice.mockReturnValueOnce( 130 );
 		const credits = calculatePlanCredits( {}, 1, [
 			{ ...baseProps, availableForPurchase: false },
 		] );
@@ -226,7 +228,10 @@ describe( 'calculatePlanCredits', () => {
 			.mockReturnValueOnce( 90 )
 			.mockReturnValueOnce( 130 );
 
-		getPlanRawPrice.mockReturnValueOnce( 80 ).mockReturnValueOnce( 60 ).mockReturnValueOnce( 70 );
+		getSitePlanRawPrice
+			.mockReturnValueOnce( 80 )
+			.mockReturnValueOnce( 60 )
+			.mockReturnValueOnce( 70 );
 
 		const credits = calculatePlanCredits( {}, 1, [
 			{ ...baseProps, availableForPurchase: true },

--- a/client/my-sites/plan-features/test/index.jsx
+++ b/client/my-sites/plan-features/test/index.jsx
@@ -53,7 +53,6 @@ import {
  * Internal dependencies
  */
 import { calculatePlanCredits, isPrimaryUpgradeByPlanDelta, PlanFeatures } from '../index';
-
 import { getPlanDiscountedRawPrice, getSitePlanRawPrice } from 'state/sites/plans/selectors';
 
 const identity = ( x ) => x;

--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -196,6 +196,7 @@ body.is-section-signup.is-white-signup {
 			
 				.plan-features__pricing {
 					border-color: #e2e4e7;
+					text-align: left;
 		
 					.plan-price {
 						text-align: left;

--- a/client/state/plans/selectors/get-discounted-raw-price.js
+++ b/client/state/plans/selectors/get-discounted-raw-price.js
@@ -12,19 +12,20 @@ import { getPlan } from './plan';
 import 'state/plans/init';
 
 /**
- * Returns the full plan price if a discount is available and the raw price if a discount is not available
+ * Returns a plan price
  *
  * @param  {object}  state     global state
  * @param  {number}  productId the plan productId
  * @param  {boolean} isMonthly if true, returns monthly price
  * @returns {number}  plan price
  */
-export function getPlanRawPrice( state, productId, isMonthly = false ) {
+export function getDiscountedRawPrice( state, productId, isMonthly = false ) {
 	const plan = getPlan( state, productId );
-	if ( get( plan, 'raw_price', -1 ) < 0 ) {
+	if ( get( plan, 'raw_price', -1 ) < 0 || get( plan, 'orig_cost', -1 ) < 0 ) {
 		return null;
 	}
-	const price = get( plan, 'orig_cost', 0 ) || plan.raw_price;
 
-	return isMonthly ? calculateMonthlyPriceForPlan( plan.product_slug, price ) : price;
+	return isMonthly
+		? calculateMonthlyPriceForPlan( plan.product_slug, plan.raw_price )
+		: plan.raw_price;
 }

--- a/client/state/plans/selectors/get-discounted-raw-price.js
+++ b/client/state/plans/selectors/get-discounted-raw-price.js
@@ -4,7 +4,7 @@
 import { get } from 'lodash';
 
 /**
- * Internal Dependencies
+ * Internal dependencies
  */
 import { calculateMonthlyPriceForPlan } from 'lib/plans';
 import { getPlan } from './plan';

--- a/client/state/plans/selectors/index.js
+++ b/client/state/plans/selectors/index.js
@@ -1,2 +1,3 @@
 export { getPlan, getPlanBySlug, getPlans, getPlanSlug, isRequestingPlans } from './plan';
 export { getPlanRawPrice } from './get-plan-raw-price';
+export { getDiscountedRawPrice } from './get-discounted-raw-price';

--- a/client/state/plans/selectors/test/index.js
+++ b/client/state/plans/selectors/test/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { expect } from 'chai';
-
-/**
  * Internal dependencies
  */
 import { getDiscountedRawPrice, getPlanRawPrice } from '../';
@@ -33,25 +28,25 @@ describe( 'selectors', () => {
 				],
 			},
 		};
-		test( 'should return a plan price', () => {
+		it( 'should return a plan price', () => {
 			const rawPrice = getDiscountedRawPrice( state, 1008, false );
-			expect( rawPrice ).to.equal( 300 );
+			expect( rawPrice ).toEqual( 300 );
 		} );
-		test( 'should return a monthly price - annual term', () => {
+		it( 'should return a monthly price - annual term', () => {
 			const rawPrice = getDiscountedRawPrice( state, 1008, true );
-			expect( rawPrice ).to.equal( 25 );
+			expect( rawPrice ).toEqual( 25 );
 		} );
-		test( 'should return a monthly price - biennial term', () => {
+		it( 'should return a monthly price - biennial term', () => {
 			const rawPrice = getDiscountedRawPrice( state, 1028, false );
-			expect( rawPrice ).to.equal( 480 );
+			expect( rawPrice ).toEqual( 480 );
 		} );
-		test( 'should return a monthly price - monthly term', () => {
+		it( 'should return a monthly price - monthly term', () => {
 			const rawPrice = getDiscountedRawPrice( state, 1028, true );
-			expect( rawPrice ).to.equal( 20 );
+			expect( rawPrice ).toEqual( 20 );
 		} );
-		test( 'should return null if there is no discount', () => {
+		it( 'should return null if there is no discount', () => {
 			const rawPrice = getDiscountedRawPrice( state, 1003, false );
-			expect( rawPrice ).to.be.a( 'null' );
+			expect( rawPrice ).toBeNull();
 		} );
 	} );
 	describe( '#getPlanRawPrice()', () => {
@@ -78,29 +73,29 @@ describe( 'selectors', () => {
 				],
 			},
 		};
-		test( 'should return a plan price', () => {
+		it( 'should return a plan price', () => {
 			const rawPrice = getPlanRawPrice( state, 1008, false );
-			expect( rawPrice ).to.equal( 324 );
+			expect( rawPrice ).toEqual( 324 );
 		} );
-		test( 'should return a monthly price - annual term', () => {
+		it( 'should return a monthly price - annual term', () => {
 			const rawPrice = getPlanRawPrice( state, 1008, true );
-			expect( rawPrice ).to.equal( 27 );
+			expect( rawPrice ).toEqual( 27 );
 		} );
-		test( 'should return a monthly price - biennial term', () => {
+		it( 'should return a monthly price - biennial term', () => {
 			const rawPrice = getPlanRawPrice( state, 1028, false );
-			expect( rawPrice ).to.equal( 540 );
+			expect( rawPrice ).toEqual( 540 );
 		} );
-		test( 'should return a monthly price - monthly term', () => {
+		it( 'should return a monthly price - monthly term', () => {
 			const rawPrice = getPlanRawPrice( state, 1028, true );
-			expect( rawPrice ).to.equal( 22.5 );
+			expect( rawPrice ).toEqual( 22.5 );
 		} );
-		test( 'should return raw_price if there is no discount', () => {
+		it( 'should return raw_price if there is no discount', () => {
 			const rawPrice = getPlanRawPrice( state, 1003, false );
-			expect( rawPrice ).to.equal( 96 );
+			expect( rawPrice ).toEqual( 96 );
 		} );
-		test( 'should return monthly raw_price if there is no discount', () => {
+		it( 'should return monthly raw_price if there is no discount', () => {
 			const rawPrice = getPlanRawPrice( state, 1003, true );
-			expect( rawPrice ).to.equal( 8 );
+			expect( rawPrice ).toEqual( 8 );
 		} );
 	} );
 } );

--- a/client/state/plans/selectors/test/index.js
+++ b/client/state/plans/selectors/test/index.js
@@ -1,0 +1,106 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { getDiscountedRawPrice, getPlanRawPrice } from '../';
+
+describe( 'selectors', () => {
+	describe( '#getDiscountedRawPrice()', () => {
+		const state = {
+			plans: {
+				items: [
+					{
+						product_id: 1008,
+						product_slug: 'business-bundle',
+						raw_price: 300,
+						orig_cost: 324,
+					},
+					{
+						product_id: 1028,
+						product_slug: 'business-bundle-2y',
+						raw_price: 480,
+						orig_cost: 540,
+					},
+					{
+						product_id: 1003,
+						product_slug: 'value_bundle',
+						raw_price: 96,
+					},
+				],
+			},
+		};
+		test( 'should return a plan price', () => {
+			const rawPrice = getDiscountedRawPrice( state, 1008, false );
+			expect( rawPrice ).to.equal( 300 );
+		} );
+		test( 'should return a monthly price - annual term', () => {
+			const rawPrice = getDiscountedRawPrice( state, 1008, true );
+			expect( rawPrice ).to.equal( 25 );
+		} );
+		test( 'should return a monthly price - biennial term', () => {
+			const rawPrice = getDiscountedRawPrice( state, 1028, false );
+			expect( rawPrice ).to.equal( 480 );
+		} );
+		test( 'should return a monthly price - monthly term', () => {
+			const rawPrice = getDiscountedRawPrice( state, 1028, true );
+			expect( rawPrice ).to.equal( 20 );
+		} );
+		test( 'should return null if there is no discount', () => {
+			const rawPrice = getDiscountedRawPrice( state, 1003, false );
+			expect( rawPrice ).to.be.a( 'null' );
+		} );
+	} );
+	describe( '#getPlanRawPrice()', () => {
+		const state = {
+			plans: {
+				items: [
+					{
+						product_id: 1008,
+						product_slug: 'business-bundle',
+						raw_price: 300,
+						orig_cost: 324,
+					},
+					{
+						product_id: 1028,
+						product_slug: 'business-bundle-2y',
+						raw_price: 480,
+						orig_cost: 540,
+					},
+					{
+						product_id: 1003,
+						product_slug: 'value_bundle',
+						raw_price: 96,
+					},
+				],
+			},
+		};
+		test( 'should return a plan price', () => {
+			const rawPrice = getPlanRawPrice( state, 1008, false );
+			expect( rawPrice ).to.equal( 324 );
+		} );
+		test( 'should return a monthly price - annual term', () => {
+			const rawPrice = getPlanRawPrice( state, 1008, true );
+			expect( rawPrice ).to.equal( 27 );
+		} );
+		test( 'should return a monthly price - biennial term', () => {
+			const rawPrice = getPlanRawPrice( state, 1028, false );
+			expect( rawPrice ).to.equal( 540 );
+		} );
+		test( 'should return a monthly price - monthly term', () => {
+			const rawPrice = getPlanRawPrice( state, 1028, true );
+			expect( rawPrice ).to.equal( 22.5 );
+		} );
+		test( 'should return raw_price if there is no discount', () => {
+			const rawPrice = getPlanRawPrice( state, 1003, false );
+			expect( rawPrice ).to.equal( 96 );
+		} );
+		test( 'should return monthly raw_price if there is no discount', () => {
+			const rawPrice = getPlanRawPrice( state, 1003, true );
+			expect( rawPrice ).to.equal( 8 );
+		} );
+	} );
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

I'm working on adding a first-year only promotional discount in 3 currencies. When a 1-st year discount is available, it should modify the discount fields and the plan prices, and display them on /plans, checkout, and the cart. A problem appeared while testing that this 1st-year discount causes `/plans` and `/sites/plans` to return different values for these discounts.

This change proposes a fix that would lead to reading both the price and the discount from /sites/plans as opposed to reading the price from /plans and the discount from /sites/plans if a `siteId` is available.

The plans and sites/plans selectors use inconsistent naming and inconsistent arguments. I didn't attempt to address that. I think it should be done with a separate change if time allows. These selectors should have names indicating which price is with the discount applied, and which is original. The word `raw` indicates it's a number, perhaps not necessary.

#### Testing instructions

1. Enable the store sandbox
2. Apply D48562-code (combines 2 diffs)

### Test the Signup in MXN (or PHP, INR)
1. In order to ensure the display of MXN, my recommendation would be to hardcode WPCOM_Store::get_user_currency to return MXN
2. Sign up. You should see the plan step look like this, depending on the reskinSignupFlow variation:

<img width="1314" alt="Screenshot 2020-09-08 at 22 18 15" src="https://user-images.githubusercontent.com/82778/92518765-8bb5a000-f221-11ea-8af6-abea42fb7c75.png">
<img width="1314" alt="Screenshot 2020-09-08 at 22 17 53" src="https://user-images.githubusercontent.com/82778/92518766-8ce6cd00-f221-11ea-864d-ed01cd3580e9.png">

3. Remove the hardcoded MXN and reload the plans step
4. Prices should be normal, no strikethrough, no changes in alignment

### Test logged in Plans in MXN without plan credits
1. Ensure the user sees prices in MXN  (no need to hardcode for logged in users, it can be changed from Store Admin)
2. Go to /plans. Prices should look like this
<img width="1033" alt="Screenshot 2020-09-08 at 22 16 20" src="https://user-images.githubusercontent.com/82778/92518833-abe55f00-f221-11ea-99db-f2601f3e3e8c.png">

3. There's a tooltip that can be seen if the (i) is clicked:
<img width="352" alt="Screenshot 2020-08-21 at 15 46 50" src="https://user-images.githubusercontent.com/82778/90892457-02e7d900-e3c6-11ea-88d9-aac11987d43f.png">
4. Switch to another currency
<img width="1069" alt="Screenshot 2020-08-21 at 12 48 27" src="https://user-images.githubusercontent.com/82778/90878475-3f0f3f80-e3ae-11ea-858d-e519b9c78fa0.png">

### Test logged in Plans in MXN _with_ plan credits
1. Buy a plan
2. Ensure the currency is MXN
3. Users should see the appropriate Bundle Upsell discount with no first-year promotional prices anywhere visible

<img width="1033" alt="Screenshot 2020-09-08 at 22 14 48" src="https://user-images.githubusercontent.com/82778/92518865-bbfd3e80-f221-11ea-811a-53d7d4f99d5a.png">

4. Switch to another currency
<img width="1060" alt="Screenshot 2020-08-21 at 13 03 54" src="https://user-images.githubusercontent.com/82778/90878915-d2e10b80-e3ae-11ea-8bca-f53f40f29604.png">
5. The plan credit notice is affected by this change, make sure it makes sense:
<img width="1060" alt="Screenshot 2020-08-21 at 15 48 47" src="https://user-images.githubusercontent.com/82778/90892499-15621280-e3c6-11ea-9605-e9f93d407511.png">