### PR TITLE
e2e: Slack message when tweet doesn't show up

### DIFF
--- a/test/e2e/specs/wp-post-editor-spec.js
+++ b/test/e2e/specs/wp-post-editor-spec.js
@@ -29,6 +29,7 @@ import * as driverManager from '../lib/driver-manager';
 import * as driverHelper from '../lib/driver-helper';
 import * as mediaHelper from '../lib/media-helper';
 import * as dataHelper from '../lib/data-helper';
+import * as slackNotifier from '../slack-notifier';
 import * as twitterHelper from '../lib/twitter-helper';
 import WPAdminLogonPage from '../lib/pages/wp-admin/wp-admin-logon-page';
 import WPAdminSidebar from '../lib/pages/wp-admin/wp-admin-sidebar';
@@ -287,7 +288,14 @@ describe( `[${ host }] Editor: Posts (${ screenSize })`, function () {
 			describe( 'Can see post publicized on twitter', function () {
 				step( 'Can see post message', async function () {
 					const tweetFound = await twitterHelper.latestTweetsContain( publicizeMessage );
-					assert.strictEqual( tweetFound, true, 'Tweet for publicized post not found on Twitter.' );
+					try {
+						assert.strictEqual(tweetFound, true, 'Tweet for publicized post not found on Twitter.');
+					} catch {
+						slackNotifier.warn(
+							`The twitter feed does not contain the expected tweet text ('${ publicizeMessage }') after waiting for it to appear. Please manually check that this eventually appears.`,
+							{ suppressDuplicateMessages: true }
+						);
+					}
 				} );
 			} );
 		}

--- a/test/e2e/specs/wp-post-editor-spec.js
+++ b/test/e2e/specs/wp-post-editor-spec.js
@@ -29,7 +29,7 @@ import * as driverManager from '../lib/driver-manager';
 import * as driverHelper from '../lib/driver-helper';
 import * as mediaHelper from '../lib/media-helper';
 import * as dataHelper from '../lib/data-helper';
-import * as slackNotifier from '../slack-notifier';
+import * as slackNotifier from '../lib/slack-notifier';
 import * as twitterHelper from '../lib/twitter-helper';
 import WPAdminLogonPage from '../lib/pages/wp-admin/wp-admin-logon-page';
 import WPAdminSidebar from '../lib/pages/wp-admin/wp-admin-sidebar';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR will make it so that when the e2e tests can't find the tweet in the twitter feed, rather than fail the test it alerts in Slack. This will keep things from failing from an outside dependency

#### Testing instructions

* ensure e2e tests pass 