### PR TITLE
Offer Reset: make the PlansFilterBar stick to the top

### DIFF
--- a/client/my-sites/plans-v2/plans-filter-bar/index.tsx
+++ b/client/my-sites/plans-v2/plans-filter-bar/index.tsx
@@ -1,8 +1,9 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { useRef } from 'react';
 import { translate } from 'i18n-calypso';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -11,6 +12,7 @@ import SegmentedControl from 'components/segmented-control';
 import SelectDropdown from 'components/select-dropdown';
 import { TERM_MONTHLY, TERM_ANNUALLY } from 'lib/plans/constants';
 import { PRODUCT_TYPE_OPTIONS } from '../constants';
+import useDetectWindowBoundary from '../use-detect-window-boundary';
 
 /**
  * Type dependencies
@@ -35,8 +37,11 @@ const PlansFilterBar = ( {
 	onDurationChange,
 	onProductTypeChange,
 }: Props ) => {
+	const barRef = useRef< HTMLDivElement | null >( null );
+	const hasCrossed = useDetectWindowBoundary( barRef );
+
 	return (
-		<div className="plans-filter-bar">
+		<div ref={ barRef } className={ classNames( 'plans-filter-bar', { sticky: hasCrossed } ) }>
 			<SelectDropdown selectedText={ PRODUCT_TYPE_OPTIONS[ productType ].label }>
 				{ Object.values( PRODUCT_TYPE_OPTIONS ).map( ( option ) => (
 					<SelectDropdown.Item

--- a/client/my-sites/plans-v2/plans-filter-bar/style.scss
+++ b/client/my-sites/plans-v2/plans-filter-bar/style.scss
@@ -80,3 +80,25 @@
 		}
 	}
 }
+
+.plans-filter-bar.sticky {
+	position: fixed;
+
+	// This is the height of the masterbar
+	top: 47px;
+
+	width: 100%;
+
+	z-index: 2;
+}
+
+// This margin fills the gap that making the filter bar sticky leaves. Without it,
+// there is a noticeable jump in the UI every time the filter bar goes from sticky
+// to its normal position.
+.plans-filter-bar.sticky + .plans-v2__columns {
+	margin-top: 100px;
+
+	@include breakpoint-deprecated( '>660px' ) {
+		margin-top: 80px;
+	}
+}

--- a/client/my-sites/plans-v2/plans-filter-bar/style.scss
+++ b/client/my-sites/plans-v2/plans-filter-bar/style.scss
@@ -88,8 +88,17 @@
 	top: 47px;
 
 	width: 100%;
+	max-width: 1040px;
 
 	z-index: 2;
+
+	@include breakpoint-deprecated( '>660px' ) {
+		width: calc( 100% - 277px );
+	}
+
+	@include breakpoint-deprecated( '>960px' ) {
+		width: calc( 100% - 337px );
+	}
 }
 
 // This margin fills the gap that making the filter bar sticky leaves. Without it,

--- a/client/my-sites/plans-v2/plans-filter-bar/style.scss
+++ b/client/my-sites/plans-v2/plans-filter-bar/style.scss
@@ -1,3 +1,6 @@
+@import '~@wordpress/base-styles/breakpoints';
+@import '~@wordpress/base-styles/mixins';
+
 .plans-filter-bar {
 	$height: 36px;
 	$border-radius: 4px;
@@ -100,7 +103,7 @@
 
 	// At this screen size, div#content (wraps div#primary and div#secondary)
 	// has a left padding of 305px and a right padding of 32px which adds up to 337px.
-	@include breakpoint-deprecated( '>960px' ) {
+	@include break-large {
 		width: calc( 100% - 337px );
 	}
 }

--- a/client/my-sites/plans-v2/plans-filter-bar/style.scss
+++ b/client/my-sites/plans-v2/plans-filter-bar/style.scss
@@ -92,10 +92,14 @@
 
 	z-index: 2;
 
+	// At this screen size, div#content (wraps div#primary and div#secondary)
+	// has a left padding of 253px and a right padding of 24px which adds up to 277px.
 	@include breakpoint-deprecated( '>660px' ) {
 		width: calc( 100% - 277px );
 	}
 
+	// At this screen size, div#content (wraps div#primary and div#secondary)
+	// has a left padding of 305px and a right padding of 32px which adds up to 337px.
 	@include breakpoint-deprecated( '>960px' ) {
 		width: calc( 100% - 337px );
 	}

--- a/client/my-sites/plans-v2/style.scss
+++ b/client/my-sites/plans-v2/style.scss
@@ -30,6 +30,10 @@
 	color: var( --studio-color-gray-70 );
 }
 
+.selector__main {
+	position: relative;
+}
+
 .upsell__header {
 	text-align: center;
 

--- a/client/my-sites/plans-v2/use-detect-window-boundary.ts
+++ b/client/my-sites/plans-v2/use-detect-window-boundary.ts
@@ -1,0 +1,39 @@
+/**
+ * External dependencies
+ */
+import { MutableRefObject, useEffect, useRef, useState } from 'react';
+import { throttle } from 'lodash';
+
+/**
+ * Returns whether `elementRef` has touched/crossed the upper Window's boundary.
+ *
+ * @param {MutableRefObject} elementRef Reference to an HTMLElement
+ * @returns {boolean} Whether the element crossed the upper boundary
+ */
+const useDetectWindowBoundary = ( elementRef: MutableRefObject< HTMLDivElement | null > ) => {
+	// Indicates whether the elementRef has crossed the upper window boundary
+	const [ borderCrossed, setBorderCrossed ] = useState( false );
+
+	// Persist its initial value since it could change if the element position is changed.
+	const elementInitialOffsetTop = useRef< number | null >( null );
+
+	const addStickyClass = useRef< ( this: Window, e: Event ) => void >(
+		throttle( () => {
+			if ( ! elementInitialOffsetTop || ! elementInitialOffsetTop.current ) {
+				return;
+			}
+			setBorderCrossed( window.pageYOffset > elementInitialOffsetTop.current );
+		}, 50 )
+	);
+
+	useEffect( () => {
+		const { current: addStickyClassFn } = addStickyClass;
+		elementInitialOffsetTop.current = elementRef.current?.offsetTop || 0;
+		window.addEventListener( 'scroll', addStickyClassFn );
+		return () => window.removeEventListener( 'scroll', addStickyClassFn );
+	}, [ elementRef ] );
+
+	return borderCrossed;
+};
+
+export default useDetectWindowBoundary;

--- a/client/my-sites/plans-v2/use-detect-window-boundary.ts
+++ b/client/my-sites/plans-v2/use-detect-window-boundary.ts
@@ -14,21 +14,17 @@ const useDetectWindowBoundary = ( elementRef: MutableRefObject< HTMLDivElement |
 	// Indicates whether the elementRef has crossed the upper window boundary
 	const [ borderCrossed, setBorderCrossed ] = useState( false );
 
-	// Persist its initial value since it could change if the element position is changed.
-	const elementInitialOffsetTop = useRef< number | null >( null );
-
 	const addStickyClass = useRef< ( this: Window, e: Event ) => void >(
 		throttle( () => {
-			if ( ! elementInitialOffsetTop || ! elementInitialOffsetTop.current ) {
+			if ( ! elementRef || ! elementRef.current ) {
 				return;
 			}
-			setBorderCrossed( window.pageYOffset > elementInitialOffsetTop.current );
+			setBorderCrossed( window.pageYOffset > elementRef.current.offsetTop );
 		}, 50 )
 	);
 
 	useEffect( () => {
 		const { current: addStickyClassFn } = addStickyClass;
-		elementInitialOffsetTop.current = elementRef.current?.offsetTop || 0;
 		window.addEventListener( 'scroll', addStickyClassFn );
 		return () => window.removeEventListener( 'scroll', addStickyClassFn );
 	}, [ elementRef ] );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* We want to make the bar stick to the top to make it always visible.

#### Implementation notes

* Created a hook called `useDetectWindowBoundary` which I pretend to use on the Cart bar to accomplish the same behavior.

#### Testing instructions

* Run this PR with Offer Reset AB experiment on.
* Visit the Plans section/page.
* Verify that on mobile the `PlansFilterBar` components sticks to the top of the window when scrolling down.
* Verify that there is no noticeable jump in the UI when it goes from sticky to normal and the reverse.
* Verify that the same applies for the desktop version.

Fixes 1169247016322522-as-1187951765147441

#### Demo
##### Mobile
![Kapture 2020-08-20 at 12 56 27](https://user-images.githubusercontent.com/3418513/90795588-9b0d9180-e2e4-11ea-8f49-399f9a8c0d3d.gif)
