### PR TITLE
Social Previews: update Google Search preview to reflect current look

### DIFF
--- a/packages/social-previews/src/search-preview/index.jsx
+++ b/packages/social-previews/src/search-preview/index.jsx
@@ -17,8 +17,20 @@ import {
  */
 import './style.scss';
 
+const URL_LENGTH = 68;
 const TITLE_LENGTH = 63;
 const DESCRIPTION_LENGTH = 160;
+
+const googleUrl = ( url ) => {
+	const breadcrumb = url
+		.replace( /^[^/]+[/]*/, '' )
+		.split( '/' )
+		.join( ' › ' );
+
+	const truncateBreadcrumb = firstValid( shortEnough( URL_LENGTH ), hardTruncation( URL_LENGTH ) );
+
+	return truncateBreadcrumb( breadcrumb );
+};
 
 const googleTitle = firstValid(
 	shortEnough( TITLE_LENGTH ),
@@ -32,14 +44,12 @@ const googleDescription = firstValid(
 	hardTruncation( DESCRIPTION_LENGTH )
 );
 
-const googleUrl = hardTruncation( 79 );
-
 export default function SearchPreview( { description, title, url } ) {
 	return (
 		<div className="search-preview">
 			<div className="search-preview__display">
-				<div className="search-preview__title">{ googleTitle( title ) }</div>
 				<div className="search-preview__url">{ googleUrl( url ) } ▾</div>
+				<div className="search-preview__title">{ googleTitle( title ) }</div>
 				<div className="search-preview__description">
 					{ googleDescription( stripHtmlTags( description ) ) }
 				</div>

--- a/packages/social-previews/src/search-preview/style.scss
+++ b/packages/social-previews/src/search-preview/style.scss
@@ -11,6 +11,8 @@
 
 @import '../variables.scss';
 
+/* stylelint-disable scales/font-size */
+
 .search-preview__display {
 	border: 1px solid var( --color-neutral-0 );
 	font-family: arial, sans-serif;
@@ -20,9 +22,10 @@
 
 .search-preview__title {
 	color: #1a0dab; // matching Google results
-	font-size: 18px;
-	line-height: 1.2;
+	font-size: 20px;
+	line-height: 26px;
 	max-width: 616px;
+	margin-bottom: 7px;
 
 	&:hover {
 		cursor: pointer;
@@ -31,16 +34,17 @@
 }
 
 .search-preview__url {
-	color: #006621; // matching Google results
-	font-size: $font-body-small;
-	height: 17px;
-	line-height: 16px;
+	color: #3c4043; // matching Google results
+	font-size: 14px;
+	line-height: 18.2px;
 	max-width: 616px;
+	margin-bottom: 8px;
 }
 
 .search-preview__description {
-	color: #545454; // matching Google results
-	font-size: $font-body-small;
-	line-height: 1.4;
+	color: #3c4043; // matching Google results
+	font-size: 14px;
+	font-weight: 400;
+	line-height: 22.12px;// matching Google results
 	max-width: 616px;
 }

--- a/packages/social-previews/test/index.js
+++ b/packages/social-previews/test/index.js
@@ -298,12 +298,12 @@ describe( 'Search previews', () => {
 		const urlEl = wrapper.find( '.search-preview__url' );
 		expect( urlEl.exists() ).toBeTruthy();
 		expect( urlEl.text() ).toEqual(
-			'https://wordpress.com/alongpathnameheretoensuretruncationoccursbutitdoesneedtob' +
+			'wordpress.com › alongpathnameheretoensuretruncationoccursbutitdoesne' +
 				'…' +
 				' ' +
 				downArrowChar
 		);
 		const urlTextRaw = urlEl.text().replace( '…', '' ).replace( downArrowChar, '' ).trimEnd();
-		expect( urlTextRaw ).toHaveLength( 79 );
+		expect( urlTextRaw ).toHaveLength( 68 );
 	} );
 } );


### PR DESCRIPTION
This PR aims to bring the Google Search Preview of Social Previews more in line with the current look of Google Search's preview.

Note: This goal here is to improve on what we currently have, rather than having a perfect representation of the final Google Search result. The preview is meant as an approximation of what the Google Search result will look like. The breadcrumb will differ for example. There are a lot of different variables that influence the URL breadcrumb. We're not replicating that complexity here but go for a simple approach of splitting the URL at each `/`. 


The related issue is https://github.com/Automattic/wp-calypso/issues/44799.




## Screenshots

**Google Search Example Result**

<img width="625" alt="Screenshot 2020-08-20 at 18 27 52" src="https://user-images.githubusercontent.com/1562646/90798999-f191c480-e312-11ea-9b18-daab3de17f8c.png">


**Google Search Social Preview**

|Before|After|
|-|-|
| <img width="683" alt="Screenshot 2020-08-20 at 18 30 56" src="https://user-images.githubusercontent.com/1562646/90799305-52210180-e313-11ea-869f-b6c615c4a062.png"> | <img width="682" alt="Screenshot 2020-08-20 at 18 29 07" src="https://user-images.githubusercontent.com/1562646/90799149-1e45dc00-e313-11ea-92a9-7d2c7b3031e4.png"> |


## Changes proposed in this Pull Request

This PR introduces the following changes to the Google Search Preview:

- move URL to the top
- turn URL into a breadcrumb
- remove protocol from the URL
- adjust overall spacing
- update color and font settings of the URL
- update color and font settings of the description
- update font settings of the title

## Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- check out branch and `yarn start`

- Navigate to http://calypso.localhost:3000/view and pick a site
- once loaded, switch to the "Search & Social" Google Search preview and check changes described above

- Now navigate to a post or page with adequate content and select Preview
- once loaded, switch to the "Search & Social" Google Search preview and check changes described above
