### PR TITLE
Signup: add `pressable-nux` to exceptions list for .com Start flows

### DIFF
--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -99,7 +99,8 @@ export default {
 			context.pathname.indexOf( 'launch-site' ) >= 0 ||
 			context.params.flowName === 'user' ||
 			context.params.flowName === 'account' ||
-			context.params.flowName === 'crowdsignal'
+			context.params.flowName === 'crowdsignal' ||
+			context.params.flowName === 'pressable-nux'
 		) {
 			removeWhiteBackground();
 			next();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

*  Adds `pressable-nux` to exceptions list for .com `/start` flows

#### Testing instructions

- Be logged in
- Set `existingUsersGutenbergOnboard` AB test to `gutenberg` (e.g. by `localStorage.setItem( 'ABTests', '{"existingUsersGutenbergOnboard_20200819":"gutenberg"}' );` ) — or try many enough times while in English locale in USA or Canada, 50% chance!
- Open `/start/pressable-nux`
- End up where you're supposed to, instead of `/new`
