### PR TITLE
Offer Reset: fix issue that is preventing the "Included in your plan" label from being displayed

### DIFF
--- a/client/my-sites/plans-v2/utils.ts
+++ b/client/my-sites/plans-v2/utils.ts
@@ -126,7 +126,7 @@ export function productBadgeLabel(
 			: translate( 'You own this' );
 	}
 
-	if ( currentPlan && planHasFeature( currentPlan, product.productSlug ) ) {
+	if ( currentPlan && planHasFeature( currentPlan.product_slug, product.productSlug ) ) {
 		return translate( 'Included in your plan' );
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* There is an issue that prevents the "Included in your plan" from being displayed when users have a plan that include features provided by other products.

#### Testing instructions

* Run this PR with the Offer Reset AB experiment on.
* Visit the Plans page and purchase Jetpack Security Daily/Real-time or Jetpack Complete.
* Verify that products included in any of those plans are labeled with "Included in your plan".

Fixes 1169247016322522-as-1189915727920768

#### Demo
![Kapture 2020-08-20 at 15 55 17](https://user-images.githubusercontent.com/3418513/90813185-97d2cf80-e2fd-11ea-867f-b4c6fd9990d8.gif)
