### PR TITLE
Typography: Remove use of Noto Serif except for Reader

### DIFF
--- a/client/blocks/post-item/style.scss
+++ b/client/blocks/post-item/style.scss
@@ -56,10 +56,9 @@ $expanded-post-item-outline: 4px solid $post-item-border-color;
 }
 
 .post-item__title {
-	@extend %content-font;
 	margin: 0;
 	padding: 0;
-	font-weight: 700;
+	font-weight: 600;
 	font-size: $font-title-small;
 	line-height: 1.2;
 }

--- a/client/blocks/support-article-dialog/content.scss
+++ b/client/blocks/support-article-dialog/content.scss
@@ -1,39 +1,38 @@
 .support-article-dialog__story-content {
-	@extend %content-font;
 	margin: 0;
 	padding-top: 16px;
 	position: relative;
-	font-size: 17px;
+	font-size: $font-title-small;
 	line-height: 1.7;
 	overflow-wrap: break-word;
 	word-wrap: break-word;
 
 	h1 {
 		font-size: $font-title-large;
-		font-weight: 700;
+		font-weight: 600;
 		margin: 0 0 16px;
 	}
 
 	h2 {
 		font-size: $font-title-medium;
-		font-weight: 700;
+		font-weight: 600;
 		margin: 0 0 8px;
 	}
 
 	h3 {
 		font-size: $font-title-small;
-		font-weight: 700;
+		font-weight: 600;
 		margin: 0 0 8px;
 	}
 
 	h4 {
 		font-size: $font-title-small;
-		font-weight: 700;
+		font-weight: 600;
 		margin: 0 0 8px;
 	}
 
 	h5 {
-		font-weight: 700;
+		font-weight: 600;
 	}
 
 	p, > div {
@@ -192,7 +191,7 @@
 	sup, sub {
 		vertical-align: baseline;
 		position: relative;
-		font-size: 0.83em;
+		font-size: $font-body-extra-small;
 	}
 
 	sup {

--- a/client/blocks/support-article-dialog/style.scss
+++ b/client/blocks/support-article-dialog/style.scss
@@ -50,7 +50,7 @@
 	}
 
 	color: var( --color-neutral-70 );
-	font-size: 17px;
+	font-size: $font-title-small;
 	line-height: 28px;
 }
 
@@ -66,11 +66,10 @@
 	text-decoration: none;
 	clear: none;
 	color: var( --color-neutral-70 );
-	font-family: $serif;
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
 	font-size: $font-title-medium;
-	font-weight: 700;
+	font-weight: 600;
 	line-height: 34px;
 	margin: 56px 0 0;
 	max-width: 750px;

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -487,10 +487,6 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 	text-align: center;
 }
 
-.jetpack-connect__sso-display-name {
-	font-family: $serif;
-}
-
 .jetpack-connect__sso-user-email {
 	color: var( --color-neutral-20 );
 	font-weight: 400;

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -284,8 +284,6 @@
 // Comment Post Link Block
 
 .comment__post-link {
-	font-family: $serif;
-
 	a {
 		color: var( --color-text-subtle );
 	}

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -76,7 +76,6 @@
 	font-size: $font-body-small;
 	font-weight: 600;
 	white-space: pre;
-	font-family: $serif;
 	text-align: inherit;
 	line-height: normal;
 

--- a/client/my-sites/draft/style.scss
+++ b/client/my-sites/draft/style.scss
@@ -42,7 +42,6 @@
 }
 
 .draft__title {
-	font-family: $serif;
 	font-weight: 600;
 	font-size: $font-body;
 	line-height: 1.4;

--- a/client/my-sites/email/email-management/gsuite-user-item/style.scss
+++ b/client/my-sites/email/email-management/gsuite-user-item/style.scss
@@ -9,7 +9,6 @@
 .email-management {
 	.gsuite-user-item__email {
 		float: left;
-		font-family: $serif;
 		font-weight: 600;
 		line-height: 1.7;
 	}

--- a/client/my-sites/invites/invite-accept-logged-in/style.scss
+++ b/client/my-sites/invites/invite-accept-logged-in/style.scss
@@ -1,6 +1,5 @@
 .invite-accept-logged-in__join-as {
 	color: var( --color-neutral-60 );
-	font-family: $sans;
 	font-size: $font-title-small;
 	line-height: 24px;
 	margin-bottom: 16px;
@@ -12,7 +11,6 @@
 }
 
 .invite-accept-logged-in__join-as-username {
-	font-family: $serif;
 	font-weight: 600;
 }
 

--- a/client/my-sites/pages/style.scss
+++ b/client/my-sites/pages/style.scss
@@ -122,9 +122,8 @@
 
 .page__title,
 .page__title:visited {
-	@extend %content-font;
 	color: var( --color-neutral-70 );
-	font-weight: 700;
+	font-weight: 600;
 	font-size: $font-title-small;
 	line-height: 1.2;
 

--- a/client/my-sites/people/people-invite-details/style.scss
+++ b/client/my-sites/people/people-invite-details/style.scss
@@ -26,7 +26,6 @@
 
 	.people-invite-details__meta-item-user {
 		margin-right: 6px;
-		font-family: $serif;
 		font-size: $font-body;
 		font-weight: 600;
 		color: var( --color-text );

--- a/client/my-sites/resume-editing/style.scss
+++ b/client/my-sites/resume-editing/style.scss
@@ -44,7 +44,6 @@
 	display: block;
 	max-width: 25vw;
 	white-space: nowrap;
-	font-family: $serif;
 	font-size: $font-body-small;
 	line-height: 1.1;
 

--- a/client/signup/steps/rebrand-cities-welcome/style.scss
+++ b/client/signup/steps/rebrand-cities-welcome/style.scss
@@ -5,12 +5,11 @@
 	animation-fill-mode: backwards;
 
 	.formatted-header__title {
-		font-family: $serif;
 		color: var( --color-neutral-70 );
-		font-size: 34px;
+		font-size: $font-title-large;
 		font-weight: 600;
 		line-height: 1.2em;
-		margin-bottom: 0.2em;
+		margin-bottom: 0.3em !important;
 	}
 
 	@include breakpoint-deprecated( '>480px' ) {

--- a/client/signup/steps/rebrand-cities-welcome/style.scss
+++ b/client/signup/steps/rebrand-cities-welcome/style.scss
@@ -5,6 +5,7 @@
 	animation-fill-mode: backwards;
 
 	.formatted-header__title {
+		@extend .wp-brand-font;
 		color: var( --color-neutral-70 );
 		font-size: $font-title-large;
 		font-weight: 600;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove instances of Noto Serif from our UI.
* Exception: The Reader remains in serif for the time being, to better align with iOS patterns.

Visuals

Before | After
----- | -------
<img width="428" alt="before" src="https://user-images.githubusercontent.com/2124984/90911124-7e399280-e3a6-11ea-9134-f329b5876ac7.png"> | <img width="658" alt="after" src="https://user-images.githubusercontent.com/2124984/90911120-7da0fc00-e3a6-11ea-817f-1a03e83aa42b.png">
<img width="430" alt="before2" src="https://user-images.githubusercontent.com/2124984/90911126-7e399280-e3a6-11ea-9e43-ff307103a5b0.png"> | <img width="467" alt="after2" src="https://user-images.githubusercontent.com/2124984/90911121-7e399280-e3a6-11ea-8b30-12f38fe29861.png">
<img width="339" alt="before3" src="https://user-images.githubusercontent.com/2124984/90911127-7ed22900-e3a6-11ea-8a2b-c6e7a11ac81c.png"> | <img width="326" alt="after3" src="https://user-images.githubusercontent.com/2124984/90911122-7e399280-e3a6-11ea-8f35-ed03385c5755.png">
<img width="1680" alt="before" src="https://user-images.githubusercontent.com/2124984/90921945-20627600-e3b9-11ea-8fa4-0dacbdcfda6a.png"> | <img width="1680" alt="after" src="https://user-images.githubusercontent.com/2124984/90921941-1fc9df80-e3b9-11ea-9db9-e141a7fb2a61.png">
<img width="1040" alt="before2" src="https://user-images.githubusercontent.com/2124984/90923659-0fffca80-e3bc-11ea-964f-b9ca8a8035a7.png"> | <img width="1062" alt="Screen Shot 2020-09-04 at 11 48 23 AM" src="https://user-images.githubusercontent.com/2124984/92258329-a811af80-eea4-11ea-9b70-7fac0baca25e.png">
<img width="1116" alt="before3" src="https://user-images.githubusercontent.com/2124984/90923663-10986100-e3bc-11ea-94a2-bc29da7e8e47.png"> | <img width="1106" alt="after3" src="https://user-images.githubusercontent.com/2124984/90923658-0f673400-e3bc-11ea-8d03-03be43f09f39.png">
<img width="764" alt="before" src="https://user-images.githubusercontent.com/2124984/90926178-9cac8780-e3c0-11ea-8a78-43687b6bda35.png"> | <img width="752" alt="after" src="https://user-images.githubusercontent.com/2124984/90926191-a0400e80-e3c0-11ea-9d6d-08ba130e1b3a.png">
<img width="445" alt="before2" src="https://user-images.githubusercontent.com/2124984/90926179-9dddb480-e3c0-11ea-946e-2e7e42fa630a.png"> | <img width="447" alt="after2" src="https://user-images.githubusercontent.com/2124984/90926194-a0d8a500-e3c0-11ea-8c10-49081d1c0b69.png">


#### Testing instructions

* Switch to this PR
* Check out the instances above in the visuals (comment if you need instructions for reproducing these screens and I'll add them!) look for regressions or general broken-ness.
* Make sure everything in the Reader still looks OK and uses the serif fonts for headings and body copy.

See #44970
