### PR TITLE
Offer Reset: Add missing Jetpack Security slugs

### DIFF
--- a/packages/components/src/product-icon/config.js
+++ b/packages/components/src/product-icon/config.js
@@ -99,6 +99,10 @@ export const iconToProductSlugMap = {
 		'jetpack_security_daily_monthly_v2',
 		'jetpack_security_realtime_v2',
 		'jetpack_security_realtime_monthly_v2',
+		'jetpack_security_daily',
+		'jetpack_security_daily_monthly',
+		'jetpack_security_realtime',
+		'jetpack_security_realtime_monthly',
 	],
 };
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Make the `ProductIcon` component support Jetpack Security by adding its slugs to the config file.

#### Testing instructions

* Run this PR with Offer Reset AB experiment enabled.
* Purchase Jetpack Security Daily, Jetpack Security Real-time, or Jetpack Complete.
* Visit the My Plans page.
* Verify that the right icon is displayed in the plan's row.

Fixes 1169247016322522-as-1189915727920761

#### Demo
![image](https://user-images.githubusercontent.com/3418513/90825712-b0e47c00-e30f-11ea-9644-7079d71e20e8.png)
