### PR TITLE
User mentions: fix mentions at the end of comments

### DIFF
--- a/client/blocks/user-mentions/add.jsx
+++ b/client/blocks/user-mentions/add.jsx
@@ -260,6 +260,14 @@ export default ( WrappedComponent ) =>
 
 			// Move the caret to the end of the inserted username
 			node.selectionStart = lastAtSymbolPosition + newTextValue.length;
+
+			// Fire the onChange handler with a simulated event so the new text value is persisted to state
+			if ( ! this.props.onChange ) {
+				return;
+			}
+
+			const changeEvent = { target: { value: newTextValue } };
+			this.props.onChange( changeEvent );
 		};
 
 		updatePosition = ( state = this.state, newPosition ) => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In p5PDj3-4Uc-p2, @guarani discovered that a user mention inserted as the final text in a Reader comment would fail. For example, "hi @bluefuton" would save as "hi @". 

However, entering any text at all after the username (including punctuation) would mean the comment saved correctly.

It turns out that we weren't calling the onChange handler after inserting the username text. This wasn't noticed because it's very rare that the username is the last text in the comment.

This PR fixes the username insertion to call the onChange handler. This records the updated comment text correctly in the parent component's state.

#### Testing instructions

On an existing testing site, invite a different test user to administer your site:

https://wordpress.com/people/team/<your_url>

Go through the process of accepting the invite.

Now you should be able to @mention the other user in Reader comments for the test site. Go to a full post in Reader from the test site and scroll down to create a new comment.

Try creating the comment "hi @username" - you will have chosen the username from the user mentions popup. Don't type anything else, and then try to save the comment. With this PR applied, it should save correctly.

![2020-08-21 14-43-14 2020-08-21 14_43_55](https://user-images.githubusercontent.com/17325/90846694-d085ae00-e3bc-11ea-9e38-3ad35971efc2.gif)


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

