### PR TITLE
Align domain suffix and use smaller font on mobile

### DIFF
--- a/client/signup/steps/p2-site/style.scss
+++ b/client/signup/steps/p2-site/style.scss
@@ -1,11 +1,19 @@
+@import '~@wordpress/base-styles/breakpoints';
+@import '~@wordpress/base-styles/mixins';
+
 .p2-site__wordpress-domain-suffix {
 	color: var( --p2-color-link );
 	line-height: 22px;
 	pointer-events: none;
 	position: absolute;
-	font-size: $font-title-small;
-	top: 62px;
+	font-size: $font-body;
+	top: 64px;
 	right: 24px;
+
+	@include break-mobile {
+		font-size: $font-title-small;
+		top: 66px;
+	}
 }
 
 .p2-site__validation-site,
@@ -63,9 +71,13 @@
 	padding: 18px 24px;
 	line-height: 1;
 	border-radius: 2px;
-	font-size: $font-title-small;
+	font-size: $font-body;
 	color: var( --p2-color-text );
 	border-color: var( --p2-color-border );
+
+	@include break-mobile {
+		font-size: $font-title-small;
+	}
 
 	&:hover {
 		border-color: var( --p2-color-link );


### PR DESCRIPTION
On the `start/p2/p2-site` page, there were some issues with alignment of text and on mobile there was very little room for the text in the input fields because of the font size.


#### Changes proposed in this Pull Request

* Use a smaller font in the input fields on mobile
* Make sure the domain suffix is aligned with the input field text.

Before mobile:
![mob-before](https://user-images.githubusercontent.com/193283/90881939-5698f900-e3ab-11ea-82fe-43549f7f604a.png)

After mobile: 
![mob-after](https://user-images.githubusercontent.com/193283/90881972-63b5e800-e3ab-11ea-9072-03f23ef09124.png)

Before desktop:
![before](https://user-images.githubusercontent.com/193283/90881986-69133280-e3ab-11ea-8367-7fdf545e0db0.png)

After desktop:

![after](https://user-images.githubusercontent.com/193283/90881992-6e707d00-e3ab-11ea-8373-ade5d95bb9aa.png)


#### Testing instructions
Go to the `start/p2/p2-site` page.

*  Enter some text in both text fields and check that the size looks OK.
* Resize the browser to mobile size and check that the input field text looks smaller and OK. 

