### PR TITLE
Offer Reset: remove generic/option product card when user owns a subtype

### DIFF
--- a/client/my-sites/plans-v2/plans-column/index.tsx
+++ b/client/my-sites/plans-v2/plans-column/index.tsx
@@ -42,7 +42,9 @@ const PlansColumn = ( { duration, onPlanClick, productType, siteId }: PlanColumn
 				( product: SelectorProduct | null ): product is SelectorProduct =>
 					!! product &&
 					duration === product.term &&
-					PRODUCTS_TYPES[ productType ].includes( product.productSlug )
+					PRODUCTS_TYPES[ productType ].includes( product.productSlug ) &&
+					// Don't include a generic/option card is the user already owns a subtype
+					! product.subtypes.includes( currentPlan || '' )
 			);
 
 		// If the user does not own a current plan, get it and insert it on the top of the plan array.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* We don't need to show a generic/option card if the user already owns one the subtypes.

#### Testing instructions

* Run this PR with the Offer Reset AB experiment enabled.
* Visit the Plans page.
* Purchase either Jetpack Security Daily or Jetpack Security Real-time.
* Visit the Plans page.
* Verify that the Jetpack Security generic/option card is not present – there should be only one card that mentions Jetpack Security.

Fixes 1169247016322522-as-1189986731974002

#### Demo
##### Before
![image](https://user-images.githubusercontent.com/3418513/90898186-aae8ac80-e39c-11ea-92f3-a8f212f09119.png)

##### After
![image](https://user-images.githubusercontent.com/3418513/90898615-306c5c80-e39d-11ea-91d1-8bb5ba9e80c1.png)
