### PR TITLE
Gutenboarding: fix getting a plan via url param

### DIFF
--- a/client/landing/gutenboarding/hooks/use-selected-plan.ts
+++ b/client/landing/gutenboarding/hooks/use-selected-plan.ts
@@ -10,17 +10,22 @@ import { STORE_KEY as ONBOARD_STORE } from '../stores/onboard';
 import { PLANS_STORE } from '../stores/plans';
 import { usePlanRouteParam } from '../path';
 
+export function usePlanFromPath() {
+	const planPath = usePlanRouteParam();
+	return useSelect( ( select ) => select( PLANS_STORE ).getPlanByPath( planPath ) );
+}
+
 export function useSelectedPlan() {
 	const selectedPlan = useSelect( ( select ) => select( ONBOARD_STORE ).getPlan() );
 
-	const planPath = usePlanRouteParam();
-	const planFromPath = useSelect( ( select ) => select( PLANS_STORE ).getPlanByPath( planPath ) );
 	const isPlanFree = useSelect( ( select ) => select( PLANS_STORE ).isPlanFree );
 
 	const hasPaidDomain = useSelect( ( select ) => select( ONBOARD_STORE ).hasPaidDomain() );
 	const hasPaidDesign = useSelect( ( select ) => select( ONBOARD_STORE ).hasPaidDesign() );
 
 	const defaultPaidPlan = useSelect( ( select ) => select( PLANS_STORE ).getDefaultPaidPlan() );
+
+	const planFromPath = usePlanFromPath();
 
 	// If the selected plan is not a paid plan and the user selects a premium domain
 	// return the default paid plan.
@@ -37,6 +42,12 @@ export function useSelectedPlan() {
 	 * 3. selecting a paid domain or design
 	 */
 	return selectedPlan || planFromPath || defaultPlan;
+}
+
+export function useHasPaidPlanFromPath() {
+	const planFromPath = usePlanFromPath();
+	const isPlanFree = useSelect( ( select ) => select( PLANS_STORE ).isPlanFree );
+	return planFromPath && ! isPlanFree( planFromPath?.storeSlug );
 }
 
 export function useShouldSiteBePublic() {

--- a/client/landing/gutenboarding/hooks/use-step-navigation.ts
+++ b/client/landing/gutenboarding/hooks/use-step-navigation.ts
@@ -12,7 +12,7 @@ import { useI18n } from '@automattic/react-i18n';
 import { Step, usePath, useCurrentStep, StepType } from '../path';
 import { STORE_KEY as ONBOARD_STORE } from '../stores/onboard';
 import { USER_STORE } from '../stores/user';
-import { useShouldSiteBePublic } from './use-selected-plan';
+import { useShouldSiteBePublic, useHasPaidPlanFromPath } from './use-selected-plan';
 import useSignup from './use-signup';
 
 /**
@@ -77,12 +77,14 @@ export default function useStepNavigation(): { goBack: () => void; goNext: () =>
 		select( ONBOARD_STORE ).getState()
 	);
 	const plan = useSelect( ( select ) => select( ONBOARD_STORE ).getPlan() );
+	const hasPaidPlanFromPath = useHasPaidPlanFromPath();
 
 	if ( domain && ! hasUsedDomainsStep ) {
 		steps = steps.filter( ( step ) => step !== Step.Domains );
 	}
 
-	if ( plan && ! hasUsedPlansStep ) {
+	// If the user landed from a marketing page after selecting a paid plan, don't show the mandatory Plans step.
+	if ( hasPaidPlanFromPath || ( plan && ! hasUsedPlansStep ) ) {
 		steps = steps.filter( ( step ) => step !== Step.Plans );
 	}
 

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -236,7 +236,7 @@ export default {
 		localeExceptions: [ 'en', 'es' ],
 	},
 	existingUsersGutenbergOnboard: {
-		datestamp: '20200819',
+		datestamp: '20200824',
 		variations: {
 			gutenberg: 50,
 			control: 50,
@@ -244,6 +244,5 @@ export default {
 		defaultVariation: 'control',
 		allowExistingUsers: true,
 		localeTargets: [ 'en' ],
-		countryCodeTargets: [ 'US', 'CA' ],
 	},
 };

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -121,18 +121,17 @@ export default {
 			next();
 		} else {
 			const userLoggedIn = isUserLoggedIn( context.store.getState() );
+			if ( userLoggedIn && 'gutenberg' === abtest( 'existingUsersGutenbergOnboard' ) ) {
+				gutenbergRedirect( context.params.flowName );
+				return;
+			}
 
 			waitForData( {
 				geo: () => requestGeoLocation(),
 			} )
 				.then( ( { geo } ) => {
 					const countryCode = geo.data.body.country_short;
-					if (
-						userLoggedIn &&
-						'gutenberg' === abtest( 'existingUsersGutenbergOnboard', countryCode )
-					) {
-						gutenbergRedirect( context.params.flowName );
-					} else if ( 'gutenberg' === abtest( 'newSiteGutenbergOnboarding', countryCode ) ) {
+					if ( 'gutenberg' === abtest( 'newSiteGutenbergOnboarding', countryCode ) ) {
 						gutenbergRedirect( context.params.flowName );
 					} else if (
 						( ! user() || ! user().get() ) &&

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -65,9 +65,10 @@ const removeWhiteBackground = function () {
 
 const gutenbergRedirect = function ( flowName ) {
 	const url = new URL( window.location );
-	url.pathname = '/new';
-	if ( flowName ) {
-		url.pathname += `/${ flowName }`;
+	if ( [ 'beginner', 'personal', 'premium', 'business', 'ecommerce' ].includes( flowName ) ) {
+		url.pathname = `/new/${ flowName }`;
+	} else {
+		url.pathname = '/new';
 	}
 	window.location.replace( url.toString() );
 };

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -63,10 +63,12 @@ const removeWhiteBackground = function () {
 	document.body.classList.remove( 'is-white-signup' );
 };
 
-const gutenbergRedirect = function () {
+const gutenbergRedirect = function ( flowName ) {
 	const url = new URL( window.location );
 	url.pathname = '/new';
-
+	if ( flowName ) {
+		url.pathname += `/${ flowName }`;
+	}
 	window.location.replace( url.toString() );
 };
 
@@ -128,9 +130,9 @@ export default {
 						userLoggedIn &&
 						'gutenberg' === abtest( 'existingUsersGutenbergOnboard', countryCode )
 					) {
-						gutenbergRedirect();
+						gutenbergRedirect( context.params.flowName );
 					} else if ( 'gutenberg' === abtest( 'newSiteGutenbergOnboarding', countryCode ) ) {
-						gutenbergRedirect();
+						gutenbergRedirect( context.params.flowName );
 					} else if (
 						( ! user() || ! user().get() ) &&
 						-1 === context.pathname.indexOf( 'free' ) &&


### PR DESCRIPTION
Gutenboarding supports setting a custom flow via url params since https://github.com/Automattic/wp-calypso/issues/41576 but the param was never passed through the A/B test redirect.

If a new user goes to [wordpress.com](https://wordpress.com/) and choose to start with a plan, then they shouldn't be forced to make the plan selection again during the onboarding.

![Screenshot 2020-08-21 at 17 33 40](https://user-images.githubusercontent.com/14192054/90902028-827ca480-e3d4-11ea-8cfb-98f77a18a816.png)


#### Changes proposed in this Pull Request
* Update `/new` redirect to include flow name in the route. eg: `/new/personal`, `/new/premium`, etc.
* Consider a paid plan passed from URL as selected plan in Gutenboarding and skip Plans step.
* Reverted A/B targeting change introduced in #45026 and updated slug.

#### Testing instructions
* Go to https://calypso.live/?branch=fix/gutenboarding-plan-via-url-param
* Open console and run `localStorage.setItem( 'ABTests', '{"newSiteGutenbergOnboarding_20200818":"gutenberg", "existingUsersGutenbergOnboard_20200819":"gutenberg"}' )`
* Go to https://calypso.live/start/personal?branch=fix/gutenboarding-plan-via-url-param
* During the onboarding, after Style preview step, the site should be created and you should be redirected to `/checkout` where the _WordPress.com Personal_ plan should be in cart.
* Repeat the steps above for a new user and expect the same results.
* Nothing else should change in the flow. 