### PR TITLE
Jetpack Offer Reset: Add Jetpack Free

### DIFF
--- a/client/components/jetpack/card/jetpack-free-card/index.tsx
+++ b/client/components/jetpack/card/jetpack-free-card/index.tsx
@@ -6,11 +6,6 @@ import { useTranslate } from 'i18n-calypso';
 import { Button } from '@automattic/components';
 
 /**
- * Internal dependencies
- */
-import ExternalLink from 'components/external-link';
-
-/**
  * Style dependencies
  */
 import './style.scss';
@@ -29,7 +24,7 @@ const JetpackFreeCard: FunctionComponent = () => {
 						'Jetpack has many free features that are essential for every WordPress site. Get site stats, automated social media posting, downtime monitoring, brute force attack protection, activity log, & CDN (Content Delivery Network). {{a}}Learn more{{/a}}',
 						{
 							components: {
-								a: <ExternalLink icon={ true } href="https://jetpack.com/features/comparison/" />,
+								a: <a href="https://jetpack.com/features/comparison/" />,
 							},
 						}
 					) }

--- a/client/components/jetpack/card/jetpack-free-card/index.tsx
+++ b/client/components/jetpack/card/jetpack-free-card/index.tsx
@@ -1,0 +1,43 @@
+/**
+ * External dependencies
+ */
+import React, { FunctionComponent } from 'react';
+import { useTranslate } from 'i18n-calypso';
+import { Button } from '@automattic/components';
+
+/**
+ * Internal dependencies
+ */
+import ExternalLink from 'components/external-link';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+const JetpackFreeCard: FunctionComponent = () => {
+	const translate = useTranslate();
+
+	return (
+		<div className="jetpack-free-card">
+			<header className="jetpack-free-card__header">
+				<h3>{ translate( 'Jetpack Free' ) }</h3>
+			</header>
+			<div className="jetpack-free-card__body">
+				<p>
+					{ translate(
+						'Jetpack has many free features that are essential for every WordPress site. Get site stats, automated social media posting, downtime monitoring, brute force attack protection, activity log, & CDN (Content Delivery Network). {{a}}Learn more{{/a}}',
+						{
+							components: {
+								a: <ExternalLink icon={ true } href="https://jetpack.com/features/comparison/" />,
+							},
+						}
+					) }
+				</p>
+				<Button>{ translate( 'Start for free' ) }</Button>
+			</div>
+		</div>
+	);
+};
+
+export default JetpackFreeCard;

--- a/client/components/jetpack/card/jetpack-free-card/style.scss
+++ b/client/components/jetpack/card/jetpack-free-card/style.scss
@@ -1,0 +1,50 @@
+@import '~@wordpress/base-styles/breakpoints';
+@import '~@wordpress/base-styles/mixins';
+
+.jetpack-free-card {
+	box-sizing: border-box;
+
+	background: var( --color-surface );
+
+	border: 1px solid var( --color-border-subtle );
+	@media ( max-width: 660px ) {
+		border-left: none;
+		border-right: none;
+	}
+}
+
+.jetpack-free-card__header {
+	padding: 24px 16px;
+	border-bottom: solid 1px var( --color-border-subtle );
+
+	h3 {
+		font-size: $font-title-medium;
+		font-weight: 600;
+		line-height: rem( 30px ) / $font-title-medium;
+	}
+}
+
+.jetpack-free-card__body {
+	padding: 24px 16px;
+
+	display: grid;
+	grid-template-rows: auto auto;
+	@include break-medium {
+		grid-template-columns: 50% 50%;
+	}
+
+	p {
+		margin-bottom: 0;
+		@include break-medium {
+			margin-right: 24px;
+		}
+	}
+
+	button {
+		height: 40px;
+
+		@include break-medium {
+			margin-left: 24px;
+		}
+	}
+}

--- a/client/components/jetpack/card/jetpack-free-card/style.scss
+++ b/client/components/jetpack/card/jetpack-free-card/style.scss
@@ -11,6 +11,8 @@
 		border-left: none;
 		border-right: none;
 	}
+
+	margin-bottom: 24px;
 }
 
 .jetpack-free-card__header {

--- a/client/components/jetpack/card/jetpack-product-card/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card/style.scss
@@ -46,6 +46,10 @@ $jetpack-product-card-icon-size: 55px;
 		background: inherit;
 	}
 
+	&:last-child {
+		margin-bottom: 0;
+	}
+
 	.foldable-card {
 		margin-bottom: 0;
 	}

--- a/client/my-sites/plans-v2/selector.tsx
+++ b/client/my-sites/plans-v2/selector.tsx
@@ -20,6 +20,7 @@ import Main from 'components/main';
 import QueryProductsList from 'components/data/query-products-list';
 import QuerySitePurchases from 'components/data/query-site-purchases';
 import QuerySites from 'components/data/query-sites';
+import JetpackFreeCard from 'components/jetpack/card/jetpack-free-card';
 
 /**
  * Type dependencies
@@ -83,6 +84,9 @@ const SelectorPage = ( {
 					siteId={ siteId }
 				/>
 			</div>
+			<div className="selector__divider" />
+			<JetpackFreeCard />
+
 			<QueryProductsList />
 			{ siteId && <QuerySitePurchases siteId={ siteId } /> }
 			{ siteId && <QuerySites siteId={ siteId } /> }

--- a/client/my-sites/plans-v2/style.scss
+++ b/client/my-sites/plans-v2/style.scss
@@ -34,10 +34,14 @@
 	position: relative;
 }
 
+.selector__divider {
+	border-bottom: solid 1px var( --color-border-subtle );
+	margin: 40px 0;
+}
+
 /**
  * Upsell
  */
-
 .upsell__header {
 	text-align: center;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds the Jetpack Free card to the Offer Reset Plans page.

<img width="985" alt="image" src="https://user-images.githubusercontent.com/42627630/90902434-16794c80-e392-11ea-8adc-eda0a869dbc1.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Visit the Plans page.
2. Check that the Jetpack Free card shows and matches the Figma.