### PR TITLE
SSO Settings: Ensure Description Toggle is Translatable

### DIFF
--- a/client/my-sites/site-settings/sso.jsx
+++ b/client/my-sites/site-settings/sso.jsx
@@ -48,7 +48,7 @@ const Sso = ( {
 						siteId={ selectedSiteId }
 						moduleSlug="sso"
 						label={ translate( 'Allow users to log in to this site using WordPress.com accounts' ) }
-						description="Use WordPress.com's secure authentication"
+						description={ translate( "Use WordPress.com's secure authentication" ) }
 						disabled={ isRequestingSettings || isSavingSettings || ssoModuleUnavailable }
 					/>
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Ensures the description for the toggle under SSO settings is translatable

#### Testing instructions

Verify that this phrase still appears at `/settings/security` on a Jetpack site, and that it is now a translatable string (checking the code should be enough - I'm not sure it's possible to verify with the Community Translator yet). 

<img width="777" alt="Screenshot 2020-08-21 at 15 37 00" src="https://user-images.githubusercontent.com/43215253/90902361-3fb2d080-e3c4-11ea-937f-45ace8cc68ae.png">

cc @scottsweb 

Fixes #45064
