### PR TITLE
Typography: Update masterbar to use Recoleta package

### DIFF
--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -226,7 +226,7 @@
 		}
 
 		.login__form-header {
-			font-family: 'Recoleta', serif;
+			@extend .wp-brand-font;
 			font-size: $font-title-medium;
 			color: var( --color-text );
 			font-weight: 600;
@@ -474,7 +474,7 @@
 
 		a {
 			color: #999;
-			font-size: 0.9em;
+			font-size: $font-body-small;
 			font-weight: 600;
 			padding: 32px 10px;
 			text-decoration: none;
@@ -495,7 +495,7 @@
 		border-radius: 100px;
 		border: none;
 		color: #fff;
-		font-size: 1.1em;
+		font-size: $font-body;
 		padding: 15px 50px;
 		text-decoration: none;
 		text-transform: capitalize;
@@ -543,7 +543,7 @@
 		border-radius: 3px;
 		box-sizing: border-box;
 		color: #666;
-		font-size: 1.25em;
+		font-size: $font-title-small;
 		line-height: 1.563;
 		padding: 0.7em;
 		transition: all ease-in-out 0.2s;
@@ -698,13 +698,13 @@
 	}
 
 	.formatted-header__title {
-		font-size: 1.6em;
+		font-size: $font-title-medium;
 		font-family: $sans;
 		margin: 0 0 8px;
 		padding: 0;
 
 		@include breakpoint-deprecated( '>480px' ) {
-			font-size: 2em;
+			font-size: $font-title-large;
 			margin: 2em 0 0;
 		}
 	}
@@ -780,12 +780,12 @@
 	}
 
 	.wp-login__links {
-		font-size: 16px;
+		font-size: $font-body;
 		font-weight: 400;
 	}
 
 	.login__form-action button {
-		font-size: 16px;
+		font-size: $font-body;
 		line-height: 23px;
 	}
 
@@ -796,7 +796,7 @@
 	}
 
 	.login__form-signup-link {
-		font-size: 16px;
+		font-size: $font-body;
 		line-height: 24px;
 		padding-top: 0;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use the `.wp-brand-font` class rather than enqueuing Recoleta directly for the Crowdsignal login form header
* Update WooCommerce login screen with new font-size vars, results in some minor visual changes.

**Before**

<img width="1680" alt="before4" src="https://user-images.githubusercontent.com/2124984/90902619-bcc95000-e39a-11ea-8e3c-c29900d501f1.png">

**After**

<img width="610" alt="Screen Shot 2020-08-21 at 11 24 38 AM" src="https://user-images.githubusercontent.com/2124984/90907399-ec7b5680-e3a0-11ea-8c39-6080fa840be7.png">

<img width="1680" alt="after4" src="https://user-images.githubusercontent.com/2124984/90902633-c18e0400-e39a-11ea-893a-84360c55b537.png">


#### Testing instructions

* Switch to this PR
* In an incognito window or when logged out, visit the Crowdsignal.com login screen; replace the `wordpress.com` part of the URL with the URL to this test branch, or your local calypso host URL
* There should not be any visual changes to the Crowdsignal login form.
* In an incognito window or when logged out, visit the Woocommerce.com login screen; replace the `wordpress.com` part of the URL with the URL to this test branch or your local calypso host URL
* There should be minor visual changes to the Woocommerce login screen, shown above
