### PR TITLE
Gutenberg: Display a success notice after connecting to Stripe

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -73,6 +73,7 @@ interface Props {
 	siteAdminUrl: T.URL | null;
 	fseParentPageId: T.PostId;
 	parentPostId: T.PostId;
+	stripeConnectSuccess: 'gutenberg' | null;
 }
 
 interface State {
@@ -723,6 +724,7 @@ const mapStateToProps = (
 		parentPostId,
 		creatingNewHomepage,
 		editorType = 'post',
+		stripeConnectSuccess,
 	}: Props
 ) => {
 	const siteId = getSelectedSiteId( state );
@@ -744,6 +746,7 @@ const mapStateToProps = (
 		origin: window.location.origin,
 		'environment-id': config( 'env_id' ),
 		'new-homepage': creatingNewHomepage,
+		...( !! stripeConnectSuccess && { stripe_connect_success: stripeConnectSuccess } ),
 	} );
 
 	// needed for loading the editor in SU sessions

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -223,6 +223,7 @@ export const post = ( context, next ) => {
 			fseParentPageId={ fseParentPageId }
 			parentPostId={ parentPostId }
 			creatingNewHomepage={ postType === 'page' && has( context, 'query.new-homepage' ) }
+			stripeConnectSuccess={ context.query.stripe_connect_success ?? null }
 		/>
 	);
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

https://github.com/Automattic/jetpack/pull/16935 and D48460-code will ensure that users are sent back to `wordpress.com/block-editor` after they connect to Stripe from a Donations block.

The URL they are redirected to includes a `stripe_connect_success=gutenberg` query param intended for displaying a success notice:

https://github.com/Automattic/jetpack/blob/2c734c944805aadd51e0e84dadab58b854e09e6a/extensions/shared/stripe-connection-notification.js#L16-L23

This PR passes down the `stripe_connect_success` query param (if present) to the `iframe` rendering the block editor so the success notice is displayed.

<img width="682" alt="Screen Shot 2020-08-24 at 12 34 13" src="https://user-images.githubusercontent.com/1233880/91034968-2305db00-e606-11ea-8864-b623571039cc.png">


#### Testing instructions

* Go to `/block-editor/post/:site?stripe_connect_success=gutenberg`.
* Make sure the success notice is displayed.
* Remove the `stripe_connect_success` query param from the URL.
* Make sure the success notice is not displayed.