### PR TITLE
Atomic: Re-enable `wp-rocket`

### DIFF
--- a/client/my-sites/plugins/plugin-compatibility.js
+++ b/client/my-sites/plugins/plugin-compatibility.js
@@ -61,7 +61,6 @@ const incompatiblePlugins = new Set( [
 	'w3-total-cache',
 	'wp-cache',
 	'wp-fastest-cache',
-	'wp-rocket',
 	'wp-speed-of-light',
 	'wp-super-cache',
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Unblock WP Rocket.

#### Testing instructions

- Go to plugins
- Search for WP-Rocket
- See plugin not blocket