### PR TITLE
Prevent layout glitch when loading JITM block

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -198,6 +198,7 @@ class Layout extends Component {
 					{ config.isEnabled( 'jitms' ) && this.props.isEligibleForJITM && (
 						<AsyncLoad
 							require="blocks/jitm"
+							placeholder={ null }
 							messagePath={ `calypso:${ this.props.sectionJitmPath }:admin_notices` }
 							sectionName={ this.props.sectionName }
 						/>


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR prevents a tiny layout glitch that occurs on some pages, which is related to the loading of the `JITM` block.

### Implementation notes

The value of the `placeholder` prop might need to depend on the page. Raise your voice if this is breaking some UI.

### Testing instructions

- Download the PR or check the live link
- Go to a page where the glitch normally occurs, for instance `/plans/my-plan/:site`
- Check that there's no glitch anymore

### Screenshots

**Before**
![before-out](https://user-images.githubusercontent.com/1620183/90918997-a24fa080-e3b3-11ea-9180-fefa8b23ea35.gif)


**After**
![after-out](https://user-images.githubusercontent.com/1620183/90919009-a8458180-e3b3-11ea-9170-5eb499897bc4.gif)

