### PR TITLE
Add rollover for domain list

### DIFF
--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -185,6 +185,10 @@ input[type='radio'].domain-management-list-item__radio {
 	align-items: center;
 }
 
+.domain-item:hover {
+	background: var( --color-neutral-0 );
+}
+
 .list-header {
 	.info-popover {
 		vertical-align: middle;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a rollover colour for the domain listing to make it feel more interactive and more obvious that it's clickable. 

Before:
![image](https://user-images.githubusercontent.com/6981253/90919742-0030b800-e3b5-11ea-9de5-cc243ebab680.png)


After:
![image](https://user-images.githubusercontent.com/6981253/90919700-eee7ab80-e3b4-11ea-84c2-0cc856320821.png)


#### Testing instructions

Visit the domain listing screen, for a single site and all sites, and roll over a listing item to see the background colour change.
