### PR TITLE
Add rollover for domain setting screen options

### DIFF
--- a/client/my-sites/domains/domain-management/edit/navigation/style.scss
+++ b/client/my-sites/domains/domain-management/edit/navigation/style.scss
@@ -19,4 +19,8 @@
 			}
 		}
 	}
+
+	a:hover & {
+		background: var( --color-neutral-0 );
+	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a rollover for the domains settings options.

Before:
![image](https://user-images.githubusercontent.com/6981253/90921473-59e6b180-e3b8-11ea-964b-6573e0850a99.png)

After:
![image](https://user-images.githubusercontent.com/6981253/90921499-65d27380-e3b8-11ea-9f78-6a8bc4090e87.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Visit the settings screen for any domain and roll over the settings options below. You should see the background colour change. 

