### PR TITLE
Add missing icons to product card features

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card/features-item.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/features-item.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { isObject } from 'lodash';
 import React, { FunctionComponent } from 'react';
 
 /**
@@ -19,16 +20,20 @@ export type Props = {
 	item: ProductCardFeaturesItem;
 };
 
+type IconComponent = FunctionComponent< { icon: string; className?: string } >;
+
 const DEFAULT_ICON = 'checkmark';
 
 const JetpackProductCardFeaturesItem: FunctionComponent< Props > = ( { item } ) => {
 	const { icon, text, description, subitems } = item;
+	const iconName = ( isObject( icon ) ? icon?.icon : icon ) || DEFAULT_ICON;
+	const Icon = ( ( isObject( icon ) && icon?.component ) || Gridicon ) as IconComponent;
 
 	return (
 		<li className="jetpack-product-card__features-item">
 			<div className="jetpack-product-card__features-main">
 				<div className="jetpack-product-card__features-summary">
-					<Gridicon className="jetpack-product-card__features-icon" icon={ icon || DEFAULT_ICON } />
+					<Icon className="jetpack-product-card__features-icon" icon={ iconName } />
 					<p className="jetpack-product-card__features-text">{ preventWidows( text ) }</p>
 				</div>
 				{ description && <InfoPopover>{ preventWidows( description ) }</InfoPopover> }

--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -9,8 +9,9 @@ import { invoke } from 'lodash';
  * Internal dependencies
  */
 import * as constants from './constants';
-import { DOMAIN_PRICING_AND_AVAILABLE_TLDS } from 'lib/url/support';
+import MaterialIcon from 'components/material-icon';
 import ExternalLinkWithTracking from 'components/external-link/with-tracking';
+import { DOMAIN_PRICING_AND_AVAILABLE_TLDS } from 'lib/url/support';
 
 export const FEATURE_CATEGORIES = {
 	[ constants.FEATURE_CATEGORY_SECURITY ]: {
@@ -1109,7 +1110,7 @@ export const FEATURES_LIST = {
 
 	[ constants.FEATURE_PRODUCT_SCAN_V2 ]: {
 		getSlug: () => constants.FEATURE_PRODUCT_SCAN_V2,
-		getIcon: () => '',
+		getIcon: () => ( { icon: 'security', component: MaterialIcon } ),
 		getTitle: () => i18n.translate( 'Scan' ),
 		getDescription: () =>
 			i18n.translate(
@@ -1124,7 +1125,7 @@ export const FEATURES_LIST = {
 
 	[ constants.FEATURE_PRODUCT_SCAN_DAILY_V2 ]: {
 		getSlug: () => constants.FEATURE_PRODUCT_SCAN_DAILY_V2,
-		getIcon: () => '',
+		getIcon: () => ( { icon: 'security', component: MaterialIcon } ),
 		getTitle: () =>
 			i18n.translate( 'Scan {{em}}Daily{{/em}}', {
 				components: {
@@ -1144,7 +1145,7 @@ export const FEATURES_LIST = {
 
 	[ constants.FEATURE_PRODUCT_SCAN_REALTIME_V2 ]: {
 		getSlug: () => constants.FEATURE_PRODUCT_SCAN_REALTIME_V2,
-		getIcon: () => '',
+		getIcon: () => ( { icon: 'security', component: MaterialIcon } ),
 		getTitle: () =>
 			i18n.translate( 'Scan {{em}}Real-time{{/em}}', {
 				components: {
@@ -1184,6 +1185,7 @@ export const FEATURES_LIST = {
 
 	[ constants.FEATURE_ACTIVITY_LOG_V2 ]: {
 		getSlug: () => constants.FEATURE_ACTIVITY_LOG_V2,
+		getIcon: () => 'clipboard',
 		getTitle: () => i18n.translate( 'Activity log' ),
 		getDescription: () =>
 			i18n.translate(
@@ -1198,6 +1200,7 @@ export const FEATURES_LIST = {
 
 	[ constants.FEATURE_ACTIVITY_LOG_30_DAYS_V2 ]: {
 		getSlug: () => constants.FEATURE_ACTIVITY_LOG_30_DAYS_V2,
+		getIcon: () => 'clipboard',
 		getTitle: () => i18n.translate( 'Activity log: 30-day archive' ),
 		getDescription: () =>
 			i18n.translate(
@@ -1212,6 +1215,7 @@ export const FEATURES_LIST = {
 
 	[ constants.FEATURE_ACTIVITY_LOG_1_YEAR_V2 ]: {
 		getSlug: () => constants.FEATURE_ACTIVITY_LOG_1_YEAR_V2,
+		getIcon: () => 'clipboard',
 		getTitle: () => i18n.translate( 'Activity log: 1-year archive' ),
 		getDescription: () =>
 			i18n.translate(

--- a/client/my-sites/plans-v2/constants.ts
+++ b/client/my-sites/plans-v2/constants.ts
@@ -180,7 +180,7 @@ export const OPTION_PRODUCT_BACKUP: SelectorProduct = {
 				FEATURE_ACTIVITY_LOG_V2,
 				FEATURE_PRIORITY_SUPPORT_V2,
 			],
-			{ withoutDescription: true }
+			{ withoutDescription: true, withoutIcon: true }
 		),
 	},
 };

--- a/client/my-sites/plans-v2/types.ts
+++ b/client/my-sites/plans-v2/types.ts
@@ -3,7 +3,7 @@
  * Type dependencies
  */
 import type { TranslateResult } from 'i18n-calypso';
-import type { ReactNode } from 'react';
+import type { ReactNode, ReactElement } from 'react';
 import type { TERM_ANNUALLY, TERM_MONTHLY } from 'lib/plans/constants';
 import type { Purchase } from 'lib/purchases/types';
 import type {
@@ -50,7 +50,12 @@ export type SelectorProductCost = {
 };
 
 export type SelectorProductFeaturesItem = {
-	icon?: string;
+	icon?:
+		| string
+		| {
+				icon: string;
+				component?: ReactElement;
+		  };
 	text: TranslateResult;
 	description?: TranslateResult;
 	subitems?: SelectorProductFeaturesItem[];

--- a/client/my-sites/plans-v2/utils.ts
+++ b/client/my-sites/plans-v2/utils.ts
@@ -226,7 +226,10 @@ export function itemToSelectorProduct(
 			term: item.term,
 			features: {
 				items: item.features
-					? buildCardFeaturesFromItem( item.features, { withoutDescription: true } )
+					? buildCardFeaturesFromItem( item.features, {
+							withoutDescription: true,
+							withoutIcon: true,
+					  } )
 					: [],
 			},
 		};
@@ -273,7 +276,7 @@ export function itemToSelectorProduct(
  */
 export function buildCardFeatureItemFromFeatureKey(
 	featureKey: JetpackPlanCardFeature,
-	options?: { withoutDescription?: boolean }
+	options?: { withoutDescription?: boolean; withoutIcon?: boolean }
 ): SelectorProductFeaturesItem | undefined {
 	let feature;
 	let subFeaturesKeys;
@@ -289,7 +292,7 @@ export function buildCardFeatureItemFromFeatureKey(
 
 	if ( feature ) {
 		return {
-			icon: feature.getIcon?.(),
+			icon: options?.withoutIcon ? undefined : feature.getIcon?.(),
 			text: feature.getTitle(),
 			description: options?.withoutDescription ? undefined : feature.getDescription?.(),
 			subitems: subFeaturesKeys


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR adds missing icons to the Jetpack Complete and Security features.

### Implementation notes

Icons are a mix of `Gridicon`s and `MaterialIcon`s

### Testing instructions

- Visit the _Plans_ page with the offer reset flow enabled
- For Jetpack Complete, check that you see the icons under the "Security" features section
- Do the same for Jetpack Security
- Check that for products, you don't see any custom icon but only a checkmark

### Screenshots

#### Jetpack Complete
<img width="460" alt="Screen Shot 2020-08-21 at 2 48 01 PM" src="https://user-images.githubusercontent.com/1620183/90925905-01b3ad80-e3c0-11ea-988d-c518aabe2889.png">

#### Jetpack Security
<img width="436" alt="Screen Shot 2020-08-21 at 2 47 55 PM" src="https://user-images.githubusercontent.com/1620183/90925913-0710f800-e3c0-11ea-8320-2288ec044125.png">


#### Product (Jetpack Backup)
<img width="432" alt="Screen Shot 2020-08-21 at 2 50 41 PM" src="https://user-images.githubusercontent.com/1620183/90925918-0b3d1580-e3c0-11ea-9dc7-d4fb44a083e5.png">
