### PR TITLE
P2 signup: refactor to wp.com

### DIFF
--- a/client/signup/steps/p2-details/index.jsx
+++ b/client/signup/steps/p2-details/index.jsx
@@ -64,7 +64,7 @@ function P2Details( {
 			<div className="p2-details">
 				<div className="p2-details__site-part">
 					<h3 className="p2-details__site-title">{ siteTitle }</h3>
-					<div className="p2-details__blog-name">{ `${ site }.p2.blog` }</div>
+					<div className="p2-details__blog-name">{ `${ site }.wordpress.com` }</div>
 					<a
 						href="/nowhere"
 						className="p2-details__change-details-link"


### PR DESCRIPTION
In this PR we fix the `.p2.blog` address on the `P2Details` step in the P2 signup flow (`/start/p2`):

<img width="729" alt="Screen Shot on 2020-08-21 at 21-21-45" src="https://user-images.githubusercontent.com/4988512/90927375-46a60700-e3f5-11ea-85bc-f2775cfb8797.png">

## Testing instructions

Navigate to `/start/p2` and complete the first step. On the second step, verify the site address is `.wordpress.com`