### PR TITLE
Offer Reset: Jetpack Connect Tweaks

### DIFF
--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -24,6 +24,7 @@ import Plans from './plans';
 import PlansLanding from './plans-landing';
 import SearchPurchase from './search';
 import StoreHeader from './store-header';
+import StoreFooter from './store-footer';
 import { addQueryArgs, sectionify } from 'lib/route';
 import { getCurrentUserId } from 'state/current-user/selectors';
 import { getLocaleFromPath, removeLocaleFromPath, getPathParts } from 'lib/i18n-utils';
@@ -77,6 +78,7 @@ const removeSidebar = ( context ) => context.store.dispatch( hideSidebar() );
 export function offerResetContext( context, next ) {
 	removeSidebar( context );
 	context.header = <StoreHeader />;
+	context.footer = <StoreFooter />;
 	next();
 }
 

--- a/client/jetpack-connect/store-footer.tsx
+++ b/client/jetpack-connect/store-footer.tsx
@@ -1,0 +1,22 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import CartData from 'components/data/cart';
+import PaymentMethods from 'blocks/payment-methods';
+import JetpackFAQ from 'my-sites/plans-features-main/jetpack-faq';
+
+export default function StoreFooter() {
+	return (
+		<>
+			<CartData>
+				<PaymentMethods />
+			</CartData>
+			<JetpackFAQ />
+		</>
+	);
+}

--- a/client/jetpack-connect/store-header.tsx
+++ b/client/jetpack-connect/store-header.tsx
@@ -23,7 +23,7 @@ export default function StoreHeader() {
 	const currentRoute = useSelector( ( state ) => getCurrentRoute( state ) );
 	const isStoreLanding =
 		currentRoute === '/jetpack/connect/store' ||
-		currentRoute.startsWith( '/jetpack/connect/plans/' );
+		currentRoute.match( new RegExp( '^/jetpack/connect/plans/[^/]+$' ) );
 
 	const headerClass = classNames( 'jetpack-connect__main-logo', {
 		'add-bottom-margin': ! isStoreLanding,

--- a/client/jetpack-connect/store-header.tsx
+++ b/client/jetpack-connect/store-header.tsx
@@ -23,7 +23,7 @@ export default function StoreHeader() {
 	const currentRoute = useSelector( ( state ) => getCurrentRoute( state ) );
 	const isStoreLanding =
 		currentRoute === '/jetpack/connect/store' ||
-		currentRoute.match( new RegExp( '^/jetpack/connect/plans/[^/]+$' ) );
+		currentRoute.match( new RegExp( '^/jetpack/connect/plans/[^/]+/?(monthly|annual)?$' ) );
 
 	const headerClass = classNames( 'jetpack-connect__main-logo', {
 		'add-bottom-margin': ! isStoreLanding,

--- a/client/jetpack-connect/store-header.tsx
+++ b/client/jetpack-connect/store-header.tsx
@@ -17,7 +17,7 @@ import getCurrentRoute from 'state/selectors/get-current-route';
 
 import './style.scss';
 
-function StoreHeader() {
+export default function StoreHeader() {
 	const translate = useTranslate();
 	const partnerSlug = useSelector( ( state ) => getPartnerSlugFromQuery( state ) );
 	const currentRoute = useSelector( ( state ) => getCurrentRoute( state ) );
@@ -49,5 +49,3 @@ function StoreHeader() {
 		</>
 	);
 }
-
-export default StoreHeader;

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -1312,3 +1312,7 @@ body.is-section-jetpack-connect .layout {
 		color: var( --color-neutral-10 );
 	}
 }
+
+.layout.is-section-jetpack-connect .upsell .upsell__header .formatted-header {
+	color: inherit;
+}

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -177,7 +177,7 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 
 		.sites-dropdown__wrapper {
 			width: 100%;
-      margin-top: 20px;
+			margin-top: 20px;
 		}
 	}
 
@@ -1281,5 +1281,18 @@ body.is-section-jetpack-connect .layout {
 
 	.product-card__option-name {
 		text-align: left;
+	}
+}
+
+.is-section-jetpack-connect .plans-filter-bar {
+	background: var( --color-jetpack-onboarding-background );
+	border-width: 0;
+
+	&.sticky {
+		top: 0; // No masterbar here.
+	}
+
+	.select-dropdown .select-dropdown__header {
+		border-color: var( --color-primary );
 	}
 }

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -1296,3 +1296,13 @@ body.is-section-jetpack-connect .layout {
 		border-color: var( --color-primary );
 	}
 }
+
+.is-section-jetpack-connect .faq {
+	.faq__heading {
+		color: var( --color-text-inverted );
+	}
+
+	.faq__question {
+		color: var( --color-neutral-10 );
+	}
+}

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -14,7 +14,6 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 
 .is-section-jetpack-connect,
 .is-section-purchase-product {
-
 	.layout__content {
 		position: static;
 		// Adjust the padding as we no longer
@@ -72,8 +71,8 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 
 	.wpcom-colophon {
 		position: absolute;
-			bottom: 0;
-			left: 0;
+		bottom: 0;
+		left: 0;
 		width: 100%;
 		height: $colophon-height;
 	}
@@ -140,7 +139,6 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 	}
 }
 
-
 .jetpack-connect__wp-admin-dialog.dialog.card {
 	max-width: 400px;
 
@@ -189,24 +187,24 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 }
 
 .jetpack-connect__site-address {
-		padding: 0 24px 24px;
-		margin: 0 -24px;
-		border-bottom: 1px solid var( --color-border-subtle );
-		display: flex;
+	padding: 0 24px 24px;
+	margin: 0 -24px;
+	border-bottom: 1px solid var( --color-border-subtle );
+	display: flex;
 }
 
 .jetpack-connect__globe {
-		width: 32px;
-		height: 28px;
-		margin-top: -4px;
-		background-color: var( --color-neutral );
-		margin-right: 8px;
-		padding-top: 4px;
-		text-align: center;
+	width: 32px;
+	height: 28px;
+	margin-top: -4px;
+	background-color: var( --color-neutral );
+	margin-right: 8px;
+	padding-top: 4px;
+	text-align: center;
 
-		.gridicons-globe {
-			fill: var( --color-neutral-0 );
-		}
+	.gridicons-globe {
+		fill: var( --color-neutral-0 );
+	}
 }
 .jetpack-connect__wordpress-logo {
 	margin: 32px auto;
@@ -323,7 +321,8 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 	position: relative;
 	margin: 0;
 	line-height: 0;
-	box-shadow: 0 0 0 1px rgba( var( --color-neutral-10-rgb ), 0.5 ), 0 1px 2px var( --color-neutral-0 );
+	box-shadow: 0 0 0 1px rgba( var( --color-neutral-10-rgb ), 0.5 ),
+		0 1px 2px var( --color-neutral-0 );
 }
 
 .example-components__install-plugin-header {
@@ -431,7 +430,7 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 		border-color: var( --studio-jetpack-green-40 );
 		border-radius: 4px;
 		box-shadow: 0 2px 3px 0 rgba( var( --color-neutral-100 ), 0.2 ),
-		            0 4px 0 0 var( --studio-jetpack-green-60 );
+			0 4px 0 0 var( --studio-jetpack-green-60 );
 	}
 }
 
@@ -555,8 +554,8 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 	margin: 0 auto 16px;
 	border-radius: 3px;
 	box-shadow: 0 5px 5px -3px rgba( var( --color-neutral-100 ), 0.2 ),
-	            0 8px 10px 1px rgba( var( --color-neutral-100 ), 0.14 ),
-	            3px 14px 2px rgba( var( --color-neutral-100 ), 0.12 );
+		0 8px 10px 1px rgba( var( --color-neutral-100 ), 0.14 ),
+		3px 14px 2px rgba( var( --color-neutral-100 ), 0.12 );
 }
 
 .jetpack-connect__sso-terms-dialog {
@@ -860,7 +859,6 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 	}
 
 	.jetpack-connect__plan-info {
-
 		.formatted-header {
 			color: var( --color-text );
 		}
@@ -950,7 +948,8 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 	}
 
 	/** WooCommerce Onboarding Styles **/
-	&.is-jetpack-woocommerce-flow, &.is-jetpack-woo-dna-flow {
+	&.is-jetpack-woocommerce-flow,
+	&.is-jetpack-woo-dna-flow {
 		background-color: var( --color-woocommerce-onboarding-background );
 
 		.jetpack-connect__main-logo {
@@ -1066,7 +1065,8 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 			font-size: $font-body-small;
 		}
 
-		.signup-form__social, .login__form-social {
+		.signup-form__social,
+		.login__form-social {
 			padding-bottom: 0;
 			margin-top: 16px;
 			p {
@@ -1098,7 +1098,8 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 			}
 		}
 
-		.logged-out-form__footer, .login__form-footer {
+		.logged-out-form__footer,
+		.login__form-footer {
 			text-align: center;
 
 			.button {
@@ -1202,7 +1203,8 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 }
 
 body.is-section-jetpack-connect .layout {
-	&.is-jetpack-woocommerce-flow, &.is-jetpack-woo-dna-flow {
+	&.is-jetpack-woocommerce-flow,
+	&.is-jetpack-woo-dna-flow {
 		.wpcom-site__logo {
 			display: none;
 		}
@@ -1290,6 +1292,10 @@ body.is-section-jetpack-connect .layout {
 
 	&.sticky {
 		top: 0; // No masterbar here.
+		left: 0;
+
+		width: 100%;
+		max-width: none;
 	}
 
 	.select-dropdown .select-dropdown__header {

--- a/client/my-sites/plans-v2/controller.tsx
+++ b/client/my-sites/plans-v2/controller.tsx
@@ -14,7 +14,12 @@ import { stringToDuration } from './utils';
 export const productSelect = ( rootUrl: string ) => ( context: PageJS.Context, next: Function ) => {
 	const duration = stringToDuration( context.params.duration );
 	context.primary = (
-		<SelectorPage defaultDuration={ duration } rootUrl={ rootUrl } header={ context.header } />
+		<SelectorPage
+			defaultDuration={ duration }
+			rootUrl={ rootUrl }
+			header={ context.header }
+			footer={ context.footer }
+		/>
 	);
 	next();
 };
@@ -31,6 +36,7 @@ export const productDetails = ( rootUrl: string ) => (
 			duration={ duration }
 			rootUrl={ rootUrl }
 			header={ context.header }
+			footer={ context.footer }
 		/>
 	);
 	next();
@@ -45,6 +51,7 @@ export const productUpsell = ( rootUrl: string ) => ( context: PageJS.Context, n
 			duration={ duration }
 			rootUrl={ rootUrl }
 			header={ context.header }
+			footer={ context.footer }
 		/>
 	);
 	next();

--- a/client/my-sites/plans-v2/details.tsx
+++ b/client/my-sites/plans-v2/details.tsx
@@ -30,7 +30,7 @@ import type { DetailsPageProps, PurchaseCallback, SelectorProduct } from './type
 
 import './style.scss';
 
-const DetailsPage = ( { duration, productSlug, rootUrl, header }: DetailsPageProps ) => {
+const DetailsPage = ( { duration, productSlug, rootUrl, header, footer }: DetailsPageProps ) => {
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
 	const siteSlug = useSelector( ( state ) => getSelectedSiteSlug( state ) ) || '';
 	const currencyCode = useSelector( ( state ) => getCurrentUserCurrencyCode( state ) );
@@ -105,6 +105,7 @@ const DetailsPage = ( { duration, productSlug, rootUrl, header }: DetailsPagePro
 					);
 				} ) }
 			</div>
+			{ footer }
 		</Main>
 	);
 };

--- a/client/my-sites/plans-v2/plans-header.tsx
+++ b/client/my-sites/plans-v2/plans-header.tsx
@@ -2,20 +2,23 @@
  * External dependencies
  */
 import React from 'react';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import PlansNavigation from 'my-sites/plans/navigation';
 import CartData from 'components/data/cart';
+import FormattedHeader from 'components/formatted-header';
 
-const PlansHeader = () => {
-	return (
+const PlansHeader = () => (
+	<>
+		<FormattedHeader headerText={ translate( 'Plans' ) } align="left" brandFont />
 		<CartData>
 			<PlansNavigation path={ '/plans' } />
 		</CartData>
-	);
-};
+	</>
+);
 
 export default function setJetpackHeader( context: PageJS.Context ) {
 	context.header = <PlansHeader />;

--- a/client/my-sites/plans-v2/selector.tsx
+++ b/client/my-sites/plans-v2/selector.tsx
@@ -3,13 +3,11 @@
  */
 import React, { useState } from 'react';
 import { useSelector } from 'react-redux';
-import { translate } from 'i18n-calypso';
 import page from 'page';
 
 /**
  * Internal dependencies
  */
-import FormattedHeader from 'components/formatted-header';
 import PlansFilterBar from './plans-filter-bar';
 import PlansColumn from './plans-column';
 import ProductsColumn from './products-column';
@@ -40,6 +38,7 @@ const SelectorPage = ( {
 	defaultDuration = TERM_ANNUALLY,
 	rootUrl,
 	header,
+	footer,
 }: SelectorPageProps ) => {
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
 	const siteSlug = useSelector( ( state ) => getSelectedSiteSlug( state ) ) || '';
@@ -63,7 +62,6 @@ const SelectorPage = ( {
 
 	return (
 		<Main className="selector__main" wideLayout>
-			<FormattedHeader headerText={ translate( 'Plans' ) } align="left" brandFont />
 			{ header }
 			<PlansFilterBar
 				onProductTypeChange={ setProductType }
@@ -88,6 +86,7 @@ const SelectorPage = ( {
 			<QueryProductsList />
 			{ siteId && <QuerySitePurchases siteId={ siteId } /> }
 			{ siteId && <QuerySites siteId={ siteId } /> }
+			{ footer }
 		</Main>
 	);
 };

--- a/client/my-sites/plans-v2/types.ts
+++ b/client/my-sites/plans-v2/types.ts
@@ -25,6 +25,7 @@ export type PurchaseCallback = ( arg0: SelectorProduct, arg1?: Purchase ) => voi
 interface BasePageProps {
 	rootUrl: string;
 	header: ReactNode;
+	footer: ReactNode;
 }
 
 export interface SelectorPageProps extends BasePageProps {

--- a/client/my-sites/plans-v2/upsell.tsx
+++ b/client/my-sites/plans-v2/upsell.tsx
@@ -138,7 +138,7 @@ const UpsellComponent = ( {
 	);
 };
 
-const UpsellPage = ( { duration, productSlug, rootUrl, header }: UpsellPageProps ) => {
+const UpsellPage = ( { duration, productSlug, rootUrl, header, footer }: UpsellPageProps ) => {
 	const selectedSiteSlug = useSelector( ( state ) => getSelectedSiteSlug( state ) ) || '';
 	const isFetchingProducts = useSelector( ( state ) => isProductsListFetching( state ) );
 	const currencyCode = useSelector( ( state ) => getCurrentUserCurrencyCode( state ) );
@@ -196,6 +196,7 @@ const UpsellPage = ( { duration, productSlug, rootUrl, header }: UpsellPageProps
 				onPurchaseSingleProduct={ onPurchaseSingleProduct }
 				onPurchaseBothProducts={ onPurchaseBothProducts }
 			/>
+			{ footer }
 		</>
 	);
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This fixes some issues with Jetpack Connect plans page redesign:
  - Made background of filters black.
  - Add secure payment options.
  - FAQ section.
  - Text below Jetpack logo now only shows on selector page.
  - Removed errant header.

Notes:
- Missing Free plan selector. That's dependent on #45101.
- FAQ section is not an accordion- investigated and that was too complex for the current time.

#### Screenshots
<img width="1175" alt="Screen Shot 2020-08-21 at 4 01 52 PM" src="https://user-images.githubusercontent.com/1760168/90929935-ae455d80-e3c7-11ea-818d-6cdebb5c1974.png">
<img width="1216" alt="Screen Shot 2020-08-21 at 4 01 57 PM" src="https://user-images.githubusercontent.com/1760168/90929937-ae455d80-e3c7-11ea-83a3-84592931885c.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/jetpack/connect/[site]` with appropriate A/B test.
* Compare design to comp provided in ticket.
* Verify functionality is intact.

Fixes 1169247016322522-as-1189798974271601.