### PR TITLE
Display a loading state while Details page is loading

### DIFF
--- a/client/components/jetpack/card/product-card-placeholder/index.tsx
+++ b/client/components/jetpack/card/product-card-placeholder/index.tsx
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+import classNames from 'classnames';
+import React, { FunctionComponent } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+type Props = {
+	className?: string;
+};
+
+const ProductCardPlaceholder: FunctionComponent< Props > = ( { className } ) => {
+	return <div className={ classNames( className, 'product-card-placeholder' ) }></div>;
+};
+
+export default ProductCardPlaceholder;

--- a/client/components/jetpack/card/product-card-placeholder/style.scss
+++ b/client/components/jetpack/card/product-card-placeholder/style.scss
@@ -1,0 +1,33 @@
+$jetpack-product-card-circle-size: 65px;
+
+.product-card-placeholder {
+	@include placeholder( --color-neutral-10 );
+
+	position: relative;
+
+	display: block;
+
+	min-width: 300px;
+	min-height: 300px;
+	margin: calc( 24px + #{$jetpack-product-card-circle-size/2} ) 0 24px;
+
+	&::before {
+		content: '';
+
+		position: absolute;
+		top: -$jetpack-product-card-circle-size/2;
+		left: calc( 50% - #{$jetpack-product-card-circle-size/2} );
+
+		display: block;
+		box-sizing: border-box;
+		width: $jetpack-product-card-circle-size;
+		height: $jetpack-product-card-circle-size;
+
+		background: inherit;
+		border-radius: 50%;
+	}
+
+	@media ( min-width: 660px ) {
+		border-radius: 5px;
+	}
+}

--- a/client/my-sites/plans-v2/details.tsx
+++ b/client/my-sites/plans-v2/details.tsx
@@ -1,10 +1,10 @@
 /**
  * External dependencies
  */
+import { useTranslate } from 'i18n-calypso';
+import page from 'page';
 import React from 'react';
 import { useSelector } from 'react-redux';
-import page from 'page';
-import { useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -16,11 +16,13 @@ import {
 } from './constants';
 import ProductCard from './product-card';
 import { slugToSelectorProduct, durationToString } from './utils';
+import ProductCardPlaceholder from 'components/jetpack/card/product-card-placeholder';
 import FormattedHeader from 'components/formatted-header';
 import HeaderCake from 'components/header-cake';
 import Main from 'components/main';
 import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
 import { isProductsListFetching } from 'state/products-list/selectors/is-products-list-fetching';
+import { getProductsList } from 'state/products-list/selectors';
 import { getSelectedSiteSlug, getSelectedSiteId } from 'state/ui/selectors';
 
 /**
@@ -35,9 +37,11 @@ const DetailsPage = ( { duration, productSlug, rootUrl, header }: DetailsPagePro
 	const siteSlug = useSelector( ( state ) => getSelectedSiteSlug( state ) ) || '';
 	const currencyCode = useSelector( ( state ) => getCurrentUserCurrencyCode( state ) );
 	const isFetchingProducts = useSelector( ( state ) => isProductsListFetching( state ) );
+	const products = useSelector( ( state ) => getProductsList( state ) );
 	const translate = useTranslate();
 	const root = rootUrl.replace( ':site', siteSlug );
 	const durationSuffix = duration ? '/' + durationToString( duration ) : '';
+	const isLoading = ! currencyCode || ( isFetchingProducts && ! products );
 
 	// If the product slug isn't one that has options, proceed to the upsell.
 	if ( ! ( PRODUCTS_WITH_OPTIONS as readonly string[] ).includes( productSlug ) ) {
@@ -50,10 +54,6 @@ const DetailsPage = ( { duration, productSlug, rootUrl, header }: DetailsPagePro
 	if ( ! product ) {
 		page.redirect( root + durationSuffix );
 		return null;
-	}
-
-	if ( ! currencyCode || isFetchingProducts ) {
-		return null; // TODO: Loading component!
 	}
 
 	// Go to a new page for upsells.
@@ -87,23 +87,30 @@ const DetailsPage = ( { duration, productSlug, rootUrl, header }: DetailsPagePro
 				brandFont
 			/>
 			<div className="plans-v2__columns">
-				{ product.subtypes.map( ( subtypeSlug ) => {
-					const subtypeItem = slugToSelectorProduct( subtypeSlug );
-					if ( ! subtypeItem ) {
-						// Exit if invalid product.
-						return null;
-					}
-					return (
-						<ProductCard
-							key={ subtypeSlug }
-							item={ subtypeItem }
-							siteId={ siteId }
-							currencyCode={ currencyCode }
-							onClick={ () => selectProduct( subtypeItem ) }
-							className="details__column"
-						/>
-					);
-				} ) }
+				{ isLoading ? (
+					<>
+						<ProductCardPlaceholder className="details__column" />
+						<ProductCardPlaceholder className="details__column" />
+					</>
+				) : (
+					product.subtypes.map( ( subtypeSlug ) => {
+						const subtypeItem = slugToSelectorProduct( subtypeSlug );
+						if ( ! subtypeItem ) {
+							// Exit if invalid product.
+							return null;
+						}
+						return (
+							<ProductCard
+								key={ subtypeSlug }
+								item={ subtypeItem }
+								siteId={ siteId }
+								currencyCode={ currencyCode as string }
+								onClick={ () => selectProduct( subtypeItem ) }
+								className="details__column"
+							/>
+						);
+					} )
+				) }
 			</div>
 		</Main>
 	);


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR adds a loading state to the plans/products details page.

### Implementation notes

The PR also ensures the loading state is never shown once the products are loaded.

### Testing instructions

This PR is tricky to test, since products seem to be part of the initial page payload, or fetched quite early. With the fix, I never saw the loading state.

- Visit the _Plans_ page with the offer reset flow enabled
- Click on the Jetpack Security card and land on the details/options page
- You shouldn't have seen any loading state and the UI is displayed instantly
- Hard refresh the page
- Check that once the cards appear, they don't disappear

To check the actual loading state:

- Download the PR locally and in `client/my-sites/plans-v2/details.tsx`, update the `isLoading` declaration by `const isLoading = ! currencyCode || isFetchingProducts;`
- You should see the cards, the loading state, and the cards again (as in the capture below)
- If necessary, throttle the connection with your browser dev tools

_Note: there's a layout glitch due to the prices loading, which is part of another issue_

### Screenshots

This reflects the UI before the condition assigned to `isLoading` was updated.
![capture-out](https://user-images.githubusercontent.com/1620183/90932486-c5d31500-e3cc-11ea-99dc-f33a304ebde2.gif)
