### PR TITLE
Jetpack Offer Reset: Prevent prices from wrapping to second line

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card/style.scss
@@ -92,7 +92,7 @@ $jetpack-product-card-icon-size: 55px;
 }
 
 .jetpack-product-card__headings {
-	width: 66%;
+	flex: 1;
 	margin-right: 16px;
 }
 


### PR DESCRIPTION
On Jetpack Product Cards, this PR prevent the prices from wrapping to second line below the title, unless the title is extra long or unless the product card width cannot fit both the title(on left) and prices(on right) on same line.

Here is a screenshot where the price has wrapped to the second line below the title. (When it isn't supposed to.)

![Markup 2020-08-20 at 15 43 32 (1)](https://user-images.githubusercontent.com/11078128/90939090-95d14500-e3bf-11ea-9c76-17d1c66d7176.png)

 
#### Changes proposed in this Pull Request

Really small, simple CSS fix - Fixes the prices wrapping to the second line when they're not supposed to.

#### Testing instructions

- Enable the Offer Reset Flow in A/B tests.
- Visit the Plans section.

View the plans page in desktop view. All the prices in the product cards should be displaying on the same line to the right of the product card title.

You can shrink the viewport and observe that the prices don't wrap to the second line until the product container is very small(width) and there is just not enough room to fit the content on the same line, side-by-side.

Screenshots showing the prices on the same line, side-by-side with the title:

![Markup 2020-08-21 at 15 16 31](https://user-images.githubusercontent.com/11078128/90939918-d8941c80-e3c1-11ea-9eb8-4dff43e4c10a.png)
![Screenshot on 2020-08-21 at 15-16-53](https://user-images.githubusercontent.com/11078128/90939923-dc27a380-e3c1-11ea-8447-e8853fe34cad.png)
![Screenshot on 2020-08-21 at 15-17-16](https://user-images.githubusercontent.com/11078128/90939932-e21d8480-e3c1-11ea-8796-f0665133cb25.png)
![Screenshot on 2020-08-21 at 15-17-34](https://user-images.githubusercontent.com/11078128/90939936-e5b10b80-e3c1-11ea-8f43-7b5cf91d23c2.png)
