### PR TITLE
Fix Monthly Security Real-time card has wrong label (daily)

### DIFF
--- a/client/lib/plans/plans-list.js
+++ b/client/lib/plans/plans-list.js
@@ -1258,7 +1258,7 @@ export const PLANS_LIST = {
 	},
 
 	[ constants.PLAN_JETPACK_SECURITY_REALTIME_MONTHLY ]: {
-		...getPlanJetpackSecurityDailyDetails(),
+		...getPlanJetpackSecurityRealtimeDetails(),
 		...getMonthlyTimeframe(),
 		getAnnualSlug: () => constants.PLAN_JETPACK_SECURITY_REALTIME,
 		getStoreSlug: () => constants.PLAN_JETPACK_SECURITY_REALTIME_MONTHLY,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The Jetpack Product Card for **Monthly** _Security Real-time_ is displaying info for _Security Daily_ (See screenshot).  This PR fixes this, to display the correct **Real-time** card/info.

![Markup 2020-08-21 at 16 20 40](https://user-images.githubusercontent.com/11078128/90942770-08482200-e3cc-11ea-9277-92e030b9c688.png)


#### Testing instructions

1. Enable the Offer Reset Flow in A/B tests.
2. Visit the Plans section.
3. Select "**Monthly**" in the top filter bar.
4. On the **Security** product card, click "**Get Jetpack Security**" button.

5. You should then see the selection page with both options, _Security Daily_, and _Security Real-time_.  The _Security Real-time_ product card should display all real-time info.  (See screenshot):

![Markup 2020-08-21 at 16 24 45](https://user-images.githubusercontent.com/11078128/90943098-3843f500-e3cd-11ea-9ea4-1b3f74593370.png)
