### PR TITLE
Customize button to always navigate to customizer

### DIFF
--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -19,22 +19,22 @@ import {
 	showAutoLoadingHomepageWarning as showAutoLoadingHomepageWarningAction,
 } from 'state/themes/actions';
 import {
-	getThemeSignupUrl,
-	getThemePurchaseUrl,
-	getThemeDetailsUrl,
-	getThemeSupportUrl,
 	getJetpackUpgradeUrlIfPremiumTheme,
+	getThemeCustomizeUrl,
+	getThemeDetailsUrl,
 	getThemeHelpUrl,
-	isThemeActive,
-	isThemePremium,
+	getThemePurchaseUrl,
+	getThemeSignupUrl,
+	getThemeSupportUrl,
 	isPremiumThemeAvailable,
+	isThemeActive,
 	isThemeAvailableOnJetpackSite,
 	isThemeGutenbergFirst,
+	isThemePremium,
 } from 'state/themes/selectors';
 import { isJetpackSite, isJetpackSiteMultiSite } from 'state/sites/selectors';
 import canCurrentUser from 'state/selectors/can-current-user';
 import { getCurrentUser } from 'state/current-user/selectors';
-import getCustomizeOrEditFrontPageUrl from 'state/selectors/get-customize-or-edit-front-page-url';
 
 function getAllThemeOptions() {
 	const purchase = config.isEnabled( 'upgrades/checkout' )
@@ -112,7 +112,7 @@ function getAllThemeOptions() {
 			comment: 'label in the dialog for selecting a site for which to customize a theme',
 		} ),
 		icon: 'customize',
-		getUrl: getCustomizeOrEditFrontPageUrl,
+		getUrl: getThemeCustomizeUrl,
 		hideForTheme: ( state, themeId, siteId ) =>
 			! canCurrentUser( state, siteId, 'edit_theme_options' ) ||
 			! isThemeActive( state, themeId, siteId ),

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -20,7 +20,6 @@ import {
 } from 'state/themes/actions';
 import {
 	getJetpackUpgradeUrlIfPremiumTheme,
-	getThemeCustomizeUrl,
 	getThemeDetailsUrl,
 	getThemeHelpUrl,
 	getThemePurchaseUrl,
@@ -32,6 +31,8 @@ import {
 	isThemeGutenbergFirst,
 	isThemePremium,
 } from 'state/themes/selectors';
+
+import getCustomizeUrl from 'state/selectors/get-customize-url';
 import { isJetpackSite, isJetpackSiteMultiSite } from 'state/sites/selectors';
 import canCurrentUser from 'state/selectors/can-current-user';
 import { getCurrentUser } from 'state/current-user/selectors';
@@ -112,7 +113,7 @@ function getAllThemeOptions() {
 			comment: 'label in the dialog for selecting a site for which to customize a theme',
 		} ),
 		icon: 'customize',
-		getUrl: getThemeCustomizeUrl,
+		getUrl: getCustomizeUrl,
 		hideForTheme: ( state, themeId, siteId ) =>
 			! canCurrentUser( state, siteId, 'edit_theme_options' ) ||
 			! isThemeActive( state, themeId, siteId ),

--- a/client/state/selectors/get-customize-url.js
+++ b/client/state/selectors/get-customize-url.js
@@ -1,0 +1,22 @@
+/**
+ * Internal dependencies
+ */
+import { getThemeCustomizeUrl } from 'state/themes/selectors';
+import isSiteUsingFullSiteEditing from 'state/selectors/is-site-using-full-site-editing';
+import isSiteUsingCoreSiteEditor from 'state/selectors/is-site-using-core-site-editor';
+import getFrontPageEditorUrl from 'state/selectors/get-front-page-editor-url';
+/**
+ * Returns the URL for clicking on "Customize". The block editor URL is returned for sites with
+ * Full Site Editing or if they are using the Core Site Editor. Otherwise we return the
+ * Customizer URL.
+ *
+ * @param  {object}   state   Global state tree
+ * @param  {string}   themeId Theme ID
+ * @param  {number}   siteId  Site ID to open the customizer or block editor for
+ * @returns {string}           Customizer or Block Editor URL
+ */
+export default function getCustomizeUrl( state, themeId, siteId ) {
+	return isSiteUsingFullSiteEditing( state, siteId ) || isSiteUsingCoreSiteEditor( state, siteId )
+		? getFrontPageEditorUrl( state, siteId )
+		: getThemeCustomizeUrl( state, themeId, siteId );
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Ensures that the Customize button on the Themes page always navigates to Customizer.

#### Testing instructions

1. Make a new site on WP.com as a new user with a Free Plan.
2. Navigate to Themes under Design in Calypso. Ensure your current theme is Hever.
3. Click the button labelled Customize. It should navigate you to Customizer instead of the Page Editor

#### GIFs

![2020-08-21 23 13 57](https://user-images.githubusercontent.com/66652282/90947623-3d249b00-e405-11ea-829e-ec5dc3b9d3d4.gif)


Fixes #44429
