### PR TITLE
Sidebar: Prevent getUrlFromParts from throwing on an invalid jetpack url

### DIFF
--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -103,7 +103,6 @@ export class MySitesSidebar extends Component {
 		isJetpack: PropTypes.bool,
 		isAtomicSite: PropTypes.bool,
 	};
-	s;
 
 	expandSiteSection = () => this.props.expandSection( SIDEBAR_SECTION_SITE );
 

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -801,7 +801,7 @@ export class MySitesSidebar extends Component {
 			return null;
 		}
 
-		if ( ! site || ! site.options ) {
+		if ( ! site?.options?.admin_url ) {
 			return null;
 		}
 
@@ -810,12 +810,16 @@ export class MySitesSidebar extends Component {
 		if ( this.props.isJetpack && ! this.props.isAtomicSite && ! this.props.isVip ) {
 			const urlParts = getUrlParts( site.options.admin_url + 'admin.php' );
 			delete urlParts.search;
-			adminUrl = getUrlFromParts( {
-				...urlParts,
-				protocol: urlParts.protocol || 'https:',
-				searchParams: new URLSearchParams( { page: 'jetpack' } ),
-				hash: '/my-plan',
-			} ).href;
+			try {
+				adminUrl = getUrlFromParts( {
+					...urlParts,
+					protocol: urlParts.protocol || 'https:',
+					searchParams: new URLSearchParams( { page: 'jetpack' } ),
+					hash: '/my-plan',
+				} ).href;
+			} catch ( error ) {
+				return null;
+			}
 		}
 
 		/* eslint-disable wpcalypso/jsx-classname-namespace */

--- a/client/my-sites/sidebar/test/sidebar.js
+++ b/client/my-sites/sidebar/test/sidebar.js
@@ -184,4 +184,121 @@ describe( 'MySitesSidebar', () => {
 			expect( wrapper.html() ).not.toEqual( null );
 		} );
 	} );
+
+	describe( 'MySitesSidebar.wpAdmin()', () => {
+		test( 'Should return null if no site selected', () => {
+			const Sidebar = new MySitesSidebar( {
+				site: null,
+				siteSuffix: '',
+				translate: ( x ) => x,
+			} );
+			const Admin = () => Sidebar.wpAdmin();
+			const wrapper = shallow( <Admin /> );
+
+			expect( wrapper.html() ).toEqual( null );
+		} );
+
+		test( 'Should return null if no admin_url is set', () => {
+			const Sidebar = new MySitesSidebar( {
+				site: {
+					options: {
+						admin_url: '',
+					},
+				},
+				siteSuffix: '',
+				translate: ( x ) => x,
+			} );
+			const Admin = () => Sidebar.wpAdmin();
+			const wrapper = shallow( <Admin /> );
+
+			expect( wrapper.html() ).toEqual( null );
+		} );
+
+		test( 'Should not return null for a simple site', () => {
+			const Sidebar = new MySitesSidebar( {
+				site: {
+					options: {
+						admin_url: 'https://example.com/wp-admin/',
+					},
+				},
+				siteSuffix: '',
+				translate: ( x ) => x,
+			} );
+			const Admin = () => Sidebar.wpAdmin();
+			const wrapper = shallow( <Admin /> );
+
+			expect( wrapper.html() ).not.toEqual( null );
+		} );
+
+		test( 'Should not return null for an Atomic site', () => {
+			const Sidebar = new MySitesSidebar( {
+				isJetpack: true,
+				isAtomicSite: true,
+				site: {
+					options: {
+						admin_url: 'https://example.com/wp-admin/',
+					},
+				},
+				siteSuffix: '',
+				translate: ( x ) => x,
+			} );
+			const Admin = () => Sidebar.wpAdmin();
+			const wrapper = shallow( <Admin /> );
+
+			expect( wrapper.html() ).not.toEqual( null );
+		} );
+
+		test( 'Should not return null for a VIP site', () => {
+			const Sidebar = new MySitesSidebar( {
+				isVip: true,
+				site: {
+					options: {
+						admin_url: 'https://example.com/wp-admin/',
+					},
+				},
+				siteSuffix: '',
+				translate: ( x ) => x,
+			} );
+			const Admin = () => Sidebar.wpAdmin();
+			const wrapper = shallow( <Admin /> );
+
+			expect( wrapper.html() ).not.toEqual( null );
+		} );
+
+		test( 'Should not return null for a Jetpack site', () => {
+			const Sidebar = new MySitesSidebar( {
+				isJetpack: true,
+				isAtomicSite: false,
+				site: {
+					options: {
+						admin_url: 'https://example.com/wp-admin/',
+					},
+				},
+				siteSuffix: '',
+				translate: ( x ) => x,
+			} );
+			const Admin = () => Sidebar.wpAdmin();
+			const wrapper = shallow( <Admin /> );
+
+			expect( wrapper.html() ).not.toEqual( null );
+		} );
+
+		test( 'Should return null for a Jetpack site with an invalid admin_url', () => {
+			const Sidebar = new MySitesSidebar( {
+				isJetpack: true,
+				isAtomicSite: false,
+				site: {
+					options: {
+						admin_url: 'example\\.com',
+					},
+				},
+				siteSuffix: '',
+				translate: ( x ) => x,
+			} );
+			const Admin = () => Sidebar.wpAdmin();
+			const wrapper = shallow( <Admin /> );
+
+			expect( wrapper.html() ).toEqual( null );
+		} );
+	} );
 } );


### PR DESCRIPTION
If the `site.options.admin_url` is invalid (according to `getUrlParts`), it will return an object with empty properties. The code then passes those properties to `getUrlFromParts`, which throws if its object is missing any parts. This causes `MySitesSidebar` to throw an error during render.

This appears to be a regression added in https://github.com/Automattic/wp-calypso/pull/44688

This PR adds two guards to help with this situation: it prevents loading the wp-admin sidebar menu if `site.options.admin_url` is not set, and it also wraps the call to `getUrlFromParts` in a try/catch which will cause the wp-admin sidebar menu to also not be rendered if it fails to parse the url (rather than throwing an error).

Props to @desnum for reporting the bug and @automattic-ian for recording the console log error.

#### Screenshots

Before:
![before](https://user-images.githubusercontent.com/2036909/90967347-035a9f80-e4ac-11ea-8116-83a5692368ae.png)

After:
![after](https://user-images.githubusercontent.com/2036909/90967349-0786bd00-e4ac-11ea-9ad3-7e8bfc712324.png)


#### Testing instructions

A unit test is included that reproduces the error as reported. That should be sufficient. If you'd like to try testing manually, though:

- Load calypso and visit http://calypso.localhost:3000/stats for a Simple site or an Atomic site.
- Verify that the sidebar loads as expected.
- Somehow get a Jetpack (but not Atomic) site to have an invalid URL in `site.options.admin_url`. I'm not sure just yet how to do that organically (but it happened; see the report in this Slack thread: p1598112435009000-slack-C02DQP0FP). You can force this by applying the following patch locally:

```diff
diff --git a/client/my-sites/sidebar/index.jsx b/client/my-sites/sidebar/index.jsx
index f712660d62..06e6505f9f 100644
--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -1015,6 +1015,7 @@ function mapStateToProps( state ) {
                ? null
                : selectedSiteId || ( isSingleSite && getPrimarySiteId( state ) ) || null;
        const site = getSite( state, siteId );
+       site.options.admin_url = 'example\\.com';

        const isJetpack = isJetpackSite( state, siteId );
```

- Load calypso and visit http://calypso.localhost:3000/stats for that Jetpack site.
- Verify that the page does not throw an error and that the sidebar loads as expected.