### PR TITLE
Gutenboarding: Fix theme name + premium badge center alignment in design selection

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -90,7 +90,9 @@ const DesignSelector: React.FunctionComponent = () => {
 														className="design-selector__premium-badge-logo"
 														size={ 20 }
 													/>
-													<span>{ __( 'Premium' ) }</span>
+													<span className="design-selector__premium-badge-text">
+														{ __( 'Premium' ) }
+													</span>
 												</Badge>
 											</div>
 										</Tooltip>

--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -122,17 +122,21 @@
 
 	.design-selector__option-name {
 		@include onboarding-medium-text;
-		align-self: center;
+		align-items: center;
 		color: var( --studio-gray-40 );
-		padding: 2px 0; // To match line-alignment with premium badge
+		display: inline-flex;
+		font-size: $font-body-small;
 	}
 
 	.design-selector__premium-container {
 		margin-left: 6px;
+		/* stylelint-disable-next-line scales/font-size */
+		font-size: rem( 10px ); //typography-exception
+		text-transform: uppercase;
 	}
 
 	.design-selector__premium-badge {
-		background-color: var( --studio-black );
+		background-color: var( --studio-gray-80 );
 		border-radius: 1em;
 		color: var( --studio-white );
 		margin: 0;
@@ -141,7 +145,9 @@
 	}
 
 	.design-selector__premium-badge-logo {
+		height: auto;
 		margin-left: -4px;
+		width: 14px;
 
 		.jetpack-logo__icon-circle {
 			fill: transparent;

--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -26,6 +26,7 @@
 
 	.design-selector__design-option {
 		cursor: pointer;
+		font-family: inherit;
 		float: left;
 		width: 100%;
 		margin: 32px; // only applies in IE

--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -122,11 +122,11 @@
 	}
 
 	.design-selector__option-name {
-		@include onboarding-medium-text;
 		align-items: center;
 		color: var( --studio-gray-40 );
 		display: inline-flex;
 		font-size: $font-body-small;
+		margin-top: -0.1em;
 	}
 
 	.design-selector__premium-container {
@@ -157,5 +157,10 @@
 		.jetpack-logo__icon-triangle {
 			fill: var( --studio-white );
 		}
+	}
+
+	.design-selector__premium-badge-text {
+		display: inline-block;
+		margin-top: -0.05em;
 	}
 }

--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -107,11 +107,12 @@
 	}
 
 	.design-selector__option-meta {
-		display: inline-grid;
+		align-items: center;
+		display: inline-flex;
+		flex-wrap: wrap; // If theme name and premium badge don't fit on one line
+		justify-content: center;
 		margin-top: 8px;
 		width: 100%;
-		gap: 6px;
-		grid-template-columns: 1fr [name] auto [badge] 1fr;
 
 		> * {
 			// This is to create space between Tooltip component and other elements
@@ -123,14 +124,11 @@
 		@include onboarding-medium-text;
 		align-self: center;
 		color: var( --studio-gray-40 );
-		grid-area: name;
 		padding: 2px 0; // To match line-alignment with premium badge
-		text-align: center;
 	}
 
 	.design-selector__premium-container {
-		grid-area: badge;
-		text-align: left;
+		margin-left: 6px;
 	}
 
 	.design-selector__premium-badge {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Changed the layout of the `.design-selector__option-meta` element from `inline-grid` to `inline-flex`
* This allows for its content to be always horizontally centered, regardless of the theme being premium or not
* Theme name and premium label allowed to wrap on more lines, in case they don't fit into one line
* Added the `font-family: inherit` rule on the `.design-selector__design-option` button element, in order to prevent User Agent stylesheet from overriding the font family used for the theme name and premium badge
* Other typography-related adjustments:
  - Smaller font size for theme name
  - Smaller font size for premium badge. _(Note: it's now 10px, which is not one of the [allowed font sizes](https://github.com/Automattic/wp-calypso/blob/master/packages/typography/styles/variables.scss) — I've disabled the linter rule for now, and added the `//typography-exceptioninline` comment)_
  - Smaller icon size for premium badge
  - DIfferent background for the Premium badge (gray 80), instead of pure black
  - Uppercase text in the premium badge


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `yarn start`
* visit `localhost:3000/new`
* proceed through the onboarding flow until reaching the Design (theme) selection step
* scroll through the page until premium themes are shown
* notice how both non-premium and premium themes have their name center-aligned
* notice how the font used for the theme name and the premium badge is now aligned to the rest of the UI
* notice how the premium badge has now uppercase text and a dark gray background (instead of black


#### Before

![Theme names and premium label are not horizontally centered](https://user-images.githubusercontent.com/1083581/91046846-6ddd1e00-e619-11ea-9736-e2d5af390e47.png)


#### After

![Theme name and badge are centered](https://user-images.githubusercontent.com/1083581/91146819-b3502880-e6b7-11ea-9a9c-01c09f95c6fd.png)


Fixes #44685
