### PR TITLE
desktop: always persist e2e executables

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -770,6 +770,7 @@ jobs:
 
             yarn run test-desktop:e2e
       - run:
+          when: always
           name: Persist Mac Executable
           command: |
             # If this isn't a full artifact build, ensure to persist the built application for inspection
@@ -830,6 +831,7 @@ jobs:
 
             yarn run test-desktop:e2e
       - run:
+          when: always
           name: Persist Linux Executable
           command: |
             # If this isn't a full artifact build, ensure to persist the built application for inspection


### PR DESCRIPTION
### Description

Amending circle config to ensure that e2e executables are persisted even when e2e tests fail (this is useful for being able inspect runtime errors more conveniently).