### PR TITLE
Social Previews package: fix twitter social preview overflow

### DIFF
--- a/client/components/seo-preview-pane/style.scss
+++ b/client/components/seo-preview-pane/style.scss
@@ -38,7 +38,6 @@
 			justify-content: flex-start;
 			border-bottom: 1px solid #c8d7e1;
 
-
 			.vertical-menu__social-item {
 				border-top: 1px solid #c8d7e1;
 				padding: 0;
@@ -86,6 +85,7 @@
 
 .seo-preview-pane__preview-area {
 	margin: 10px auto;
+	max-width: 100%;
 }
 
 .seo-preview-pane__preview {
@@ -112,7 +112,10 @@
 		.reader-post-actions__item {
 			white-space: nowrap;
 
-			span, .comment-button, .like-button, .ellipsis-menu .button {
+			span,
+			.comment-button,
+			.like-button,
+			.ellipsis-menu .button {
 				cursor: default;
 				pointer-events: none;
 

--- a/packages/social-previews/CHANGELOG.md
+++ b/packages/social-previews/CHANGELOG.md
@@ -1,17 +1,23 @@
-Changelog
-========
+# Changelog
+
+#### v1.0.4 (2020-08-24)
+
+- Fixed Twitter styles for viewports < 600px in width
 
 #### v1.0.3 (2020-08-21)
+
 - Refreshed styles of Twitter, Facebook and Google previews to match their latest design.
 
 #### v1.0.2 (2020-08-03)
+
 - Remove `i18n-calypso` dependency by removing search preview header.
 - Strip html tags from descriptions for social previews.
 - Add helper function with enhanced regex for stripping html tags.
 
 #### v1.0.1 (2020-07-23)
+
 - Mark CSS and SCSS files as `sideEffects` to ensure they are not discarded during build processes tree-shaking.
 
-
 #### v1.0.0 (2020-07-22)
+
 - Initial release after extracting from Calypso.

--- a/packages/social-previews/package.json
+++ b/packages/social-previews/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/social-previews",
-	"version": "1.0.3",
+	"version": "1.0.4",
 	"description": "A suite of components to generate previews for a post for both social and search engines",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",

--- a/packages/social-previews/src/twitter-preview/style.scss
+++ b/packages/social-previews/src/twitter-preview/style.scss
@@ -14,15 +14,14 @@
 /* stylelint-disable scales/font-size */
 
 .twitter-preview {
-	width: inherit;
-	overflow-x: auto;
-	-webkit-overflow-scrolling: touch;
-	margin: 20px;
+	padding: 20px;
+	box-sizing: border-box;
 }
 
 .twitter-preview__summary,
 .twitter-preview__large_image_summary {
 	width: 506px;
+	max-width: 100%;
 	margin: 0 auto;
 	overflow: hidden;
 	border: 1px solid #e1e8ed;
@@ -42,16 +41,15 @@
 	background-position: center;
 }
 
-.twitter-preview__summary
-.twitter-preview__image {
+.twitter-preview__summary .twitter-preview__image {
 	float: left;
 	width: 125px;
 	height: 125px;
 }
 
-.twitter-preview__large_image_summary
-.twitter-preview__image {
+.twitter-preview__large_image_summary .twitter-preview__image {
 	width: 506px;
+	max-width: 100%;
 	height: 254px;
 	border-bottom: 1px solid #e1e8ed;
 }
@@ -67,15 +65,13 @@
 	overflow: hidden;
 }
 
-.twitter-preview__summary
-.twitter-preview__body {
+.twitter-preview__summary .twitter-preview__body {
 	margin-left: 125px;
 	border-left: 1px solid #e1e8ed;
 	height: 100%;
 }
 
-.twitter-preview__large_image_summary
-.twitter-preview__body {
+.twitter-preview__large_image_summary .twitter-preview__body {
 	padding-left: 1em;
 	padding-right: 1em;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix the twitter preview having `width: 506px` and thus preview overflowed for viewports < 600px in width 
* Fixes are done only in respect to the package so that the problem is ultimately fixed in jetpack. Calypso itself **doesn't** show Social Previews for viewports < 600px (when clicking preview)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
Before | After
-------|------
![SS 2020-08-24 at 19 33 22](https://user-images.githubusercontent.com/12430020/91071391-c5db4b00-e640-11ea-9c47-a6e348645392.gif)| ![SS 2020-08-24 at 19 37 35](https://user-images.githubusercontent.com/12430020/91071863-5ca80780-e641-11ea-8939-4e9b108e8f2e.gif)


* check out branch 
* `cd packages/social-previews && yarn link` and then `cd ../.. && yarn && yarn start`
* Navigate to http://calypso.localhost:3000/view and pick a site on a business plan
* Now navigate to a post or page with adequate content and select Preview
* once loaded, switch to the "Search & Social" Twitter preview and check changes described above

Fixes https://github.com/Automattic/jetpack/pull/16950#pullrequestreview-473315779
