### PR TITLE
Checkout: Allow India country codes to access new checkout

### DIFF
--- a/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
@@ -471,6 +471,7 @@ export function filterAppropriatePaymentMethods( {
 	const isPurchaseFree = total.amount.value === 0;
 	const isFullCredits =
 		! isPurchaseFree && credits?.amount.value > 0 && credits?.amount.value >= subtotal.amount.value;
+	const countryCode = select( 'wpcom' )?.getContactInfo?.()?.countryCode?.value ?? '';
 	debug( 'filtering payment methods with this input', {
 		total,
 		credits,
@@ -479,6 +480,7 @@ export function filterAppropriatePaymentMethods( {
 		serverAllowedPaymentMethods,
 		isPurchaseFree,
 		isFullCredits,
+		countryCode,
 	} );
 
 	return paymentMethodObjects
@@ -495,6 +497,17 @@ export function filterAppropriatePaymentMethods( {
 				return isFullCredits ? true : false;
 			}
 			return isFullCredits ? false : true;
+		} )
+		.filter( ( methodObject ) => {
+			// Some country-specific payment methods should only be available if that
+			// country is selected in the contact information.
+			if ( methodObject.id === 'netbanking' && countryCode !== 'IN' ) {
+				return false;
+			}
+			if ( methodObject.id === 'ebanx-tef' && countryCode !== 'BR' ) {
+				return false;
+			}
+			return true;
 		} )
 		.filter( ( methodObject ) => {
 			if ( methodObject.id.startsWith( 'existingCard-' ) ) {

--- a/client/my-sites/checkout/composite-checkout/payment-methods/netbanking.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/netbanking.js
@@ -253,8 +253,8 @@ function NetBankingPayButton( { disabled, store } ) {
 						payload: { paymentMethodId: 'netbanking' },
 					} );
 					submitTransaction( {
-						name: customerName?.value,
 						...massagedFields,
+						name: customerName?.value,
 						address: massagedFields?.address1,
 						items,
 						total,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This removes the gating blocking `IN` country codes from accessing new ("composite") checkout. Previously this country was blocked because we had lacked support for the "Netbanking" payment method in new checkout, but as of https://github.com/Automattic/wp-calypso/pull/44952 that should now be available.

This is similar to https://github.com/Automattic/wp-calypso/pull/44944 which allowed access for Brazil.

As a side effect, this also removes the `composite-checkout-force` config flag, since it is no longer necessary. It _does_ leave the `old-checkout-force` flag for the time being, so that we can still test old checkout if needed until it is removed.

#### Testing instructions

- Set your currency to INR.
- Apply D48222-code and sandbox the API; this will make it appear that you are in India.
- Visit checkout with a product in your cart.
- Verify that you see new checkout.
- Complete the form until you reach the final step where you select a payment method.
- Verify that "Netbanking" is an option.
- Select "Netbanking" and verify that you see the form fields for PAN, GSTIN, and other contact data appear.
- Try to submit the form without filling out the fields. Verify that you see error messages under each field.
- Fill in each field, but use invalid data for the PAN and GSTIN.
- Try to submit the form without filling out the fields. Verify that you see error messages under the invalid fields.
- Fill in valid PAN (eg: `ABCDE1234F`) and GSTIN (eg: `22AAAAA0000A1Z5`) data.
- Open your network tab in Devtools and make sure you have "Preserve log" checked so you don't lose data when redirecting.
- Try to submit the form. Verify that you are taken to the dLocal page.
- Verify that the data sent to the `/me/transactions` endpoint includes all the data from the form.