### PR TITLE
Style update in Security Daily card with upgrade nudge

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/index.tsx
@@ -98,6 +98,7 @@ const JetpackProductCard: FunctionComponent< Props > = ( {
 			className={ classNames( className, 'jetpack-product-card', {
 				'is-owned': isOwned,
 				'is-deprecated': isDeprecated,
+				'with-nudge': !! UpgradeNudge,
 			} ) }
 			data-icon={ iconSlug }
 		>

--- a/client/components/jetpack/card/jetpack-product-card/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card/style.scss
@@ -55,7 +55,7 @@ $jetpack-product-card-icon-size: 55px;
 		border-right: 1px solid var( --color-border-subtle );
 		border-radius: 5px;
 
-		.foldable-card {
+		&:not( .with-nudge ) .foldable-card {
 			border-bottom-left-radius: 5px;
 			border-bottom-right-radius: 5px;
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request

Removes the bottom border radius of the product card when an upgrade nudge is shown.

### Testing instructions

- Visit the _Plans_ page with the offer reset flow enabled
- Purchase Security _Daily_
- Go back to the _Plans_ page
- Check that in the Security _Daily_ card, you see the upgrade to Real-time nudge
- Check that the corners below the "Show features" toggle are not round (see capture)

### Screenshots

**Before**
![screenshot](https://user-images.githubusercontent.com/1620183/91086963-ada60480-e61d-11ea-8775-028e577cdadf.png)


**After**
<img width="565" alt="Screen Shot 2020-08-24 at 3 16 04 PM" src="https://user-images.githubusercontent.com/1620183/91086972-b3034f00-e61d-11ea-8eb7-39e1bc09b111.png">
