### PR TITLE
Prevent user from clicking on the domain connect toggle during an update

### DIFF
--- a/client/my-sites/domains/domain-management/dns/domain-connect-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/domain-connect-record.jsx
@@ -30,7 +30,7 @@ class DomainConnectRecord extends React.Component {
 	};
 
 	state = {
-		enabled: this.props.enabled,
+		dnsRecordIsBeingUpdated: false,
 	};
 
 	disableDomainConnect = () => {
@@ -41,21 +41,24 @@ class DomainConnectRecord extends React.Component {
 			type: 'TXT',
 		};
 
-		this.props.deleteDns( selectedDomainName, record ).then(
-			() => {
-				const successNoticeId = 'domain-connect-disable-success-notice';
-				this.props.successNotice( translate( 'The Domain Connect record has been disabled.' ), {
-					id: successNoticeId,
-					showDismiss: false,
-					duration: 5000,
-				} );
-			},
-			( error ) => {
-				this.props.errorNotice(
-					error.message || translate( 'The Domain Connect record could not be disabled.' )
-				);
-			}
-		);
+		this.props
+			.deleteDns( selectedDomainName, record )
+			.then(
+				() => {
+					const successNoticeId = 'domain-connect-disable-success-notice';
+					this.props.successNotice( translate( 'The Domain Connect record has been disabled.' ), {
+						id: successNoticeId,
+						showDismiss: false,
+						duration: 5000,
+					} );
+				},
+				( error ) => {
+					this.props.errorNotice(
+						error.message || translate( 'The Domain Connect record could not be disabled.' )
+					);
+				}
+			)
+			.then( () => this.setState( { dnsRecordIsBeingUpdated: false } ) );
 	};
 
 	enableDomainConnect() {
@@ -68,23 +71,26 @@ class DomainConnectRecord extends React.Component {
 
 		const normalizedData = getNormalizedData( record, this.props.selectedDomainName );
 
-		this.props.addDns( this.props.selectedDomainName, normalizedData ).then(
-			() => {
-				this.props.successNotice( translate( 'The Domain Connect record has been enabled.' ), {
-					showDismiss: false,
-					duration: 5000,
-				} );
-			},
-			( error ) => {
-				this.props.errorNotice(
-					error.message || translate( 'The Domain Connect record could not be enabled.' )
-				);
-			}
-		);
+		this.props
+			.addDns( this.props.selectedDomainName, normalizedData )
+			.then(
+				() => {
+					this.props.successNotice( translate( 'The Domain Connect record has been enabled.' ), {
+						showDismiss: false,
+						duration: 5000,
+					} );
+				},
+				( error ) => {
+					this.props.errorNotice(
+						error.message || translate( 'The Domain Connect record could not be enabled.' )
+					);
+				}
+			)
+			.then( () => this.setState( { dnsRecordIsBeingUpdated: false } ) );
 	}
 
 	handleToggle = () => {
-		// this.setState( { enabled: ! this.state.enabled } );
+		this.setState( { dnsRecordIsBeingUpdated: true } );
 		if ( this.props.enabled ) {
 			this.disableDomainConnect();
 		} else {
@@ -118,6 +124,7 @@ class DomainConnectRecord extends React.Component {
 									type="checkbox"
 									checked={ enabled }
 									value="active"
+									disabled={ this.state.dnsRecordIsBeingUpdated }
 								/>
 							</form>
 						}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Currently, the user can click on the Domain Connect record toggle button on the DNS Records page rapidly which will send multiple requests to the back end in rapid succession without waiting for the previous request to complete. Under certain circumstances, this can cause a race condition which will cause the Domain Connect record status to be inconsistent across different parts of the back-end systems.

This diff disables the toggle control while an update is being performed and re-enables it once the request promise has been fulfilled. This helps to prevent additional requests from being sent before the first one has completed.

#### Testing instructions

Before applying the PR, click the button rapidly and notice that multiple requests are sent rapidly.

![before 2020-08-24 15_29_36](https://user-images.githubusercontent.com/1379730/91087988-5012b780-e61f-11ea-8f3e-dfd5efde202e.gif)

After applying this PR, try clicking the button rapidly and notice that only a single request is sent.

![after 2020-08-24 15_34_13](https://user-images.githubusercontent.com/1379730/91088007-59038900-e61f-11ea-8e44-b3ce32de2310.gif)

