### PR TITLE
Checkout: Prevent CC loading form if showing ebanx fields

### DIFF
--- a/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-fields.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-fields.js
@@ -100,12 +100,14 @@ export default function CreditCardFields() {
 		},
 	};
 
+	const isLoaded = shouldShowContactFields ? true : isStripeFullyLoaded;
+
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
 		<StripeFields className="credit-card-form-fields">
-			{ ! isStripeFullyLoaded && <LoadingFields /> }
+			{ ! isLoaded && <LoadingFields /> }
 
-			<CreditCardFieldsWrapper isLoaded={ isStripeFullyLoaded }>
+			<CreditCardFieldsWrapper isLoaded={ isLoaded }>
 				<CreditCardField
 					id="cardholder-name"
 					type="Text"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The credit card form in new checkout displays a "loading" version of the fields (disabled fields and a spinner) while the Stripe fields finish rendering (this is done via stripe.js and iframes). However, if the user is in Brazil and using Brazilian currency, the credit card fields are rendered using Ebanx instead of Stripe, and therefore we don't need to wait for Stripe to load.

In this PR, we explicitly disable the loading state if using Ebanx.

#### Testing instructions

- Apply D48147-code to your sandbox to pretend to be in Brazil and sandbox the API.
- Set your currency to `BRL`.
- Visit checkout.
- In the contact information step, choose "Brazil" for the country.
- In the final step, choose "Credit or debit card".
- Verify that the form asks for all the Ebanx fields in addition to the credit card fields (Taxpayer Identification Number, Phone, etc.)