### PR TITLE
Checkout: Fix Tracks event string for ebanx-tef payment method

### DIFF
--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -326,9 +326,12 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 								?.name || '',
 					} )
 				);
+				const paymentMethodIdForTracks = action.payload.paymentMethodId
+					.replace( /-/, '_' )
+					.toLowerCase();
 				return reduxDispatch(
 					recordTracksEvent(
-						`calypso_checkout_composite_${ action.payload.paymentMethodId }_submit_clicked`,
+						`calypso_checkout_composite_${ paymentMethodIdForTracks }_submit_clicked`,
 						{}
 					)
 				);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This makes sure that any payment method ID strings being used as part of the "submit" Tracks event are lower-case and contain no hyphens, since upper-case letters and hyphens are disallowed by Tracks.

Fixes https://github.com/Automattic/wp-calypso/issues/45082

#### Testing instructions

- Apply D47729-code and sandbox the store to make it appear that you are coming from Brazil.
- Load calypso and run `localStorage.setItem('debug', 'calypso:analytics')` in your browser console. Then reload the page (keep the console open).
- Visit checkout and proceed to the payment method step.
- Select "Transferencia bancaria".
- Fill in the fields using test data, available at https://developer.ebanx.com/docs/resources/testCustomerData/#brazilian-test-data. (Note that CEP is the postal code, and CPF is the tax ID.)
- Submit the form.
- Verify that you see the Tracks event `calypso_checkout_composite_ebanx_tef_submit_clicked` in your console.