### PR TITLE
Add support for seoTitle, seoDescription on theme pages.

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -85,6 +85,8 @@ class ThemeSheet extends React.Component {
 			PropTypes.string,
 			PropTypes.bool, // happens if no content: false
 		] ),
+		seoTitle: PropTypes.string,
+		seoDescription: PropTypes.string,
 		supportDocumentation: PropTypes.string,
 		download: PropTypes.string,
 		taxonomies: PropTypes.object,
@@ -626,11 +628,18 @@ class ThemeSheet extends React.Component {
 
 		const plansUrl = siteSlug ? `/plans/${ siteSlug }/?plan=value_bundle` : '/plans';
 
-		const { canonicalUrl, currentUserId, description, name: themeName } = this.props;
+		const {
+			canonicalUrl,
+			currentUserId,
+			description,
+			seoDescription,
+			name: themeName,
+			seoTitle,
+		} = this.props;
 		const title =
-			themeName &&
+			( seoTitle || themeName ) &&
 			i18n.translate( '%(themeName)s Theme', {
-				args: { themeName },
+				args: { themeName: seoTitle || themeName },
 			} );
 
 		const metas = [
@@ -641,11 +650,11 @@ class ThemeSheet extends React.Component {
 			{ property: 'og:site_name', content: 'WordPress.com' },
 		];
 
-		if ( description ) {
+		if ( seoDescription || description ) {
 			metas.push( {
 				name: 'description',
 				property: 'og:description',
-				content: decodeEntities( description ),
+				content: decodeEntities( seoDescription || description ),
 			} );
 		}
 

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -632,10 +632,11 @@ class ThemeSheet extends React.Component {
 			canonicalUrl,
 			currentUserId,
 			description,
-			seoDescription,
 			name: themeName,
 			seoTitle,
+			seoDescription,
 		} = this.props;
+
 		const title =
 			( seoTitle || themeName ) &&
 			i18n.translate( '%(themeName)s Theme', {

--- a/client/state/themes/schema.js
+++ b/client/state/themes/schema.js
@@ -33,6 +33,8 @@ const themesSchema = {
 				theme_uri: { type: 'string' },
 				update: { type: [ 'null', 'object' ] },
 				version: { type: 'string' },
+				seo_title: { type: 'string' },
+				seo_description: { type: 'string' },
 			},
 		},
 	},

--- a/client/state/themes/utils.js
+++ b/client/state/themes/utils.js
@@ -63,6 +63,8 @@ export function normalizeJetpackTheme( theme = {} ) {
  */
 export function normalizeWpcomTheme( theme ) {
 	const attributesMap = {
+		seo_title: 'seoTitle',
+		seo_description: 'seoDescription',
 		description_long: 'descriptionLong',
 		support_documentation: 'supportDocumentation',
 		download_uri: 'download',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add support for `seoTitle`, `seoDescription` on theme pages.

#### Testing instructions

Can be tested as a part of D48535-code.
