### PR TITLE
Reader: remove the preloadReaderBundle handler

### DIFF
--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -21,7 +21,6 @@ import FeedError from 'reader/feed-error';
 import StreamComponent from 'reader/following/main';
 import { getPrettyFeedUrl, getPrettySiteUrl } from 'reader/route';
 import { recordTrack } from 'reader/stats';
-import { preload } from 'sections-helper';
 import { requestFeedDiscovery } from 'state/data-getters';
 import { waitForData } from 'state/data-layer/http-data';
 import AsyncLoad from 'components/async-load';
@@ -113,11 +112,6 @@ const exported = {
 			return page.redirect( redirect );
 		}
 
-		next();
-	},
-
-	preloadReaderBundle( context, next ) {
-		preload( 'reader' );
 		next();
 	},
 
@@ -316,7 +310,6 @@ export const {
 	legacyRedirects,
 	updateLastRoute,
 	incompleteUrlRedirects,
-	preloadReaderBundle,
 	sidebar,
 	unmountSidebar,
 	following,

--- a/client/reader/conversations/index.js
+++ b/client/reader/conversations/index.js
@@ -7,13 +7,12 @@ import page from 'page';
  * Internal dependencies
  */
 import { conversations, conversationsA8c } from './controller';
-import { initAbTests, preloadReaderBundle, sidebar, updateLastRoute } from 'reader/controller';
+import { initAbTests, sidebar, updateLastRoute } from 'reader/controller';
 import { makeLayout, render as clientRender } from 'controller';
 
 export default function () {
 	page(
 		'/read/conversations',
-		preloadReaderBundle,
 		updateLastRoute,
 		initAbTests,
 		sidebar,
@@ -24,7 +23,6 @@ export default function () {
 
 	page(
 		'/read/conversations/a8c',
-		preloadReaderBundle,
 		updateLastRoute,
 		initAbTests,
 		sidebar,

--- a/client/reader/discover/index.js
+++ b/client/reader/discover/index.js
@@ -7,18 +7,9 @@ import page from 'page';
  * Internal dependencies
  */
 import { discover } from './controller';
-import { initAbTests, preloadReaderBundle, sidebar, updateLastRoute } from 'reader/controller';
+import { initAbTests, sidebar, updateLastRoute } from 'reader/controller';
 import { makeLayout, render as clientRender } from 'controller';
 
 export default function () {
-	page(
-		'/discover',
-		preloadReaderBundle,
-		updateLastRoute,
-		initAbTests,
-		sidebar,
-		discover,
-		makeLayout,
-		clientRender
-	);
+	page( '/discover', updateLastRoute, initAbTests, sidebar, discover, makeLayout, clientRender );
 }

--- a/client/reader/index.js
+++ b/client/reader/index.js
@@ -14,7 +14,6 @@ import {
 	incompleteUrlRedirects,
 	initAbTests,
 	legacyRedirects,
-	preloadReaderBundle,
 	prettyRedirects,
 	readA8C,
 	sidebar,
@@ -48,16 +47,7 @@ export default async function () {
 	await lazyLoadDependencies();
 
 	if ( config.isEnabled( 'reader' ) ) {
-		page(
-			'/read',
-			preloadReaderBundle,
-			initAbTests,
-			updateLastRoute,
-			sidebar,
-			following,
-			makeLayout,
-			clientRender
-		);
+		page( '/read', initAbTests, updateLastRoute, sidebar, following, makeLayout, clientRender );
 
 		// Old and incomplete paths that should be redirected to /
 		page( '/read/following', '/read' );
@@ -68,7 +58,7 @@ export default async function () {
 		page( '/read/feed', '/read' );
 
 		// Feed stream
-		page( '/read/*', preloadReaderBundle, initAbTests );
+		page( '/read/*', initAbTests );
 		page( '/read/blog/feed/:feed_id', legacyRedirects );
 		page( '/read/feeds/:feed_id/posts', incompleteUrlRedirects );
 		page(

--- a/client/reader/liked-stream/index.js
+++ b/client/reader/liked-stream/index.js
@@ -7,13 +7,12 @@ import page from 'page';
  * Internal dependencies
  */
 import { likes } from './controller';
-import { preloadReaderBundle, initAbTests, updateLastRoute, sidebar } from 'reader/controller';
+import { initAbTests, updateLastRoute, sidebar } from 'reader/controller';
 import { makeLayout, render as clientRender } from 'controller';
 
 export default function () {
 	page(
 		'/activities/likes',
-		preloadReaderBundle,
 		initAbTests,
 		updateLastRoute,
 		sidebar,

--- a/client/reader/search/index.js
+++ b/client/reader/search/index.js
@@ -7,17 +7,9 @@ import page from 'page';
  * Internal dependencies
  */
 import { search } from './controller';
-import { preloadReaderBundle, sidebar, updateLastRoute } from 'reader/controller';
+import { sidebar, updateLastRoute } from 'reader/controller';
 import { makeLayout, render as clientRender } from 'controller';
 
 export default function () {
-	page(
-		'/read/search',
-		preloadReaderBundle,
-		updateLastRoute,
-		sidebar,
-		search,
-		makeLayout,
-		clientRender
-	);
+	page( '/read/search', updateLastRoute, sidebar, search, makeLayout, clientRender );
 }

--- a/client/reader/tag-stream/index.js
+++ b/client/reader/tag-stream/index.js
@@ -8,7 +8,7 @@ import { startsWith } from 'lodash';
  * Internal dependencies
  */
 import { tagListing } from './controller';
-import { initAbTests, preloadReaderBundle, sidebar, updateLastRoute } from 'reader/controller';
+import { initAbTests, sidebar, updateLastRoute } from 'reader/controller';
 import { makeLayout, render as clientRender } from 'controller';
 
 const redirectHashtaggedTags = ( context, next ) => {
@@ -19,6 +19,6 @@ const redirectHashtaggedTags = ( context, next ) => {
 };
 
 export default function () {
-	page( '/tag/*', preloadReaderBundle, redirectHashtaggedTags, initAbTests );
+	page( '/tag/*', redirectHashtaggedTags, initAbTests );
 	page( '/tag/:tag', updateLastRoute, sidebar, tagListing, makeLayout, clientRender );
 }


### PR DESCRIPTION
The `preloadReaderBundle` handler is always called from code in the `reader` chunk, so the operation is always noop (the bundle is already loaded).

The handler was added in #6974, at a time when `reader/discover` was a completely separate section, and when we used webpack 1 or 2 with a code splitting algorithm very different from today.

@blowery might know more details why this used to be useful.

I found this when looking for possible root causes of #45150. This is one of the places where the Reader router is in a somewhat messy state.