### PR TITLE
Reader: remove redundant section for feed pages

### DIFF
--- a/client/reader/index.js
+++ b/client/reader/index.js
@@ -89,9 +89,6 @@ export default async function () {
 		page( '/read/post/feed/:feed_id/:post_id', legacyRedirects );
 		page( '/read/post/id/:blog_id/:post_id', legacyRedirects );
 
-		// Old recommendations page
-		page( '/recommendations', '/read/search' );
-
 		// Old Freshly Pressed
 		page( '/read/fresh', '/discover' );
 	}

--- a/client/reader/search/index.js
+++ b/client/reader/search/index.js
@@ -11,5 +11,8 @@ import { sidebar, updateLastRoute } from 'reader/controller';
 import { makeLayout, render as clientRender } from 'controller';
 
 export default function () {
+	// Old recommendations page
+	page( '/recommendations', '/read/search' );
+
 	page( '/read/search', updateLastRoute, sidebar, search, makeLayout, clientRender );
 }

--- a/client/sections.js
+++ b/client/sections.js
@@ -309,14 +309,6 @@ const sections = [
 	},
 	{
 		name: 'reader',
-		paths: [ '/read/feeds/[^\\/]+', '/read/blogs/[^\\/]+', '/read/a8c', '/recommendations' ],
-		module: 'wp-calypso-client/reader',
-		secondary: true,
-		group: 'reader',
-		trackLoadPerformance: true,
-	},
-	{
-		name: 'reader',
 		paths: [ '/read/feeds/[^\\/]+/posts/[^\\/]+', '/read/blogs/[^\\/]+/posts/[^\\/]+' ],
 		module: 'wp-calypso-client/reader/full-post',
 		secondary: false,
@@ -356,7 +348,7 @@ const sections = [
 	},
 	{
 		name: 'reader',
-		paths: [ '/read/search' ],
+		paths: [ '/read/search', '/recommendations' ],
 		module: 'wp-calypso-client/reader/search',
 		secondary: true,
 		group: 'reader',


### PR DESCRIPTION
The section references the same module (`client/reader`) as the main `reader` section, and doesn't do anything useful. It was added in #25741 to support logged-out redirects, but these redirects were then implemented later at a framework level in #30537 and the Reader-specific redirect code was removed. After that, the section became an empty shell.

Also moves the `/recommendations` redirect handler to `reader/search`, potentially removing the need to load any other section than `reader/search` when handling the route.

This is another complexity-reducer PR inspired by debugging #45150.

**How to test:**
Verify the Reader routes for reading feeds (`/read/feeds`, `/read/blogs`, `/read/a8c`) and verify that `/recommendations` continues to redirect to `/read/search`.