### PR TITLE
Reader: remove async loading of blocks/reader-full-post

### DIFF
--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -129,10 +129,6 @@ const exported = {
 		next();
 	},
 
-	unmountSidebar( context, next ) {
-		next();
-	},
-
 	following( context, next ) {
 		const basePath = sectionify( context.path );
 		const fullAnalyticsPageTitle = analyticsPageTitle + ' > Following';
@@ -318,7 +314,6 @@ export const {
 	incompleteUrlRedirects,
 	preloadReaderBundle,
 	sidebar,
-	unmountSidebar,
 	following,
 	feedDiscovery,
 	feedListing,

--- a/client/reader/full-post/controller.js
+++ b/client/reader/full-post/controller.js
@@ -9,7 +9,7 @@ import { defer } from 'lodash';
  * Internal Dependencies
  */
 import { trackPageLoad } from 'reader/controller-helper';
-import AsyncLoad from 'components/async-load';
+import FullPostView from 'blocks/reader-full-post';
 
 const analyticsPageTitle = 'Reader';
 
@@ -21,38 +21,15 @@ const scrollTopIfNoHash = () =>
 	} );
 
 export function blogPost( context, next ) {
-	const blogId = context.params.blog,
-		postId = context.params.post,
-		basePath = '/read/blogs/:blog_id/posts/:post_id',
-		fullPageTitle = analyticsPageTitle + ' > Blog Post > ' + blogId + ' > ' + postId;
+	const blogId = context.params.blog;
+	const postId = context.params.post;
+	const basePath = '/read/blogs/:blog_id/posts/:post_id';
+	const fullPageTitle = analyticsPageTitle + ' > Blog Post > ' + blogId + ' > ' + postId;
 
 	let referral;
 	if ( context.query.ref_blog && context.query.ref_post ) {
 		referral = { blogId: context.query.ref_blog, postId: context.query.ref_post };
 	}
-	trackPageLoad( basePath, fullPageTitle, 'full_post' );
-
-	context.primary = (
-		<AsyncLoad
-			require="blocks/reader-full-post"
-			blogId={ blogId }
-			postId={ postId }
-			referral={ referral }
-			referralStream={ context.lastRoute }
-			onClose={ function () {
-				page.back( context.lastRoute || '/' );
-			} }
-		/>
-	);
-	scrollTopIfNoHash();
-	next();
-}
-
-export function feedPost( context, next ) {
-	const feedId = context.params.feed,
-		postId = context.params.post,
-		basePath = '/read/feeds/:feed_id/posts/:feed_item_id',
-		fullPageTitle = analyticsPageTitle + ' > Feed Post > ' + feedId + ' > ' + postId;
 
 	trackPageLoad( basePath, fullPageTitle, 'full_post' );
 
@@ -61,8 +38,32 @@ export function feedPost( context, next ) {
 	}
 
 	context.primary = (
-		<AsyncLoad
-			require="blocks/reader-full-post"
+		<FullPostView
+			blogId={ blogId }
+			postId={ postId }
+			referral={ referral }
+			referralStream={ context.lastRoute }
+			onClose={ closer }
+		/>
+	);
+	scrollTopIfNoHash();
+	next();
+}
+
+export function feedPost( context, next ) {
+	const feedId = context.params.feed;
+	const postId = context.params.post;
+	const basePath = '/read/feeds/:feed_id/posts/:feed_item_id';
+	const fullPageTitle = analyticsPageTitle + ' > Feed Post > ' + feedId + ' > ' + postId;
+
+	trackPageLoad( basePath, fullPageTitle, 'full_post' );
+
+	function closer() {
+		page.back( context.lastRoute || '/' );
+	}
+
+	context.primary = (
+		<FullPostView
 			feedId={ feedId }
 			postId={ postId }
 			onClose={ closer }

--- a/client/reader/full-post/index.js
+++ b/client/reader/full-post/index.js
@@ -7,27 +7,13 @@ import page from 'page';
  * Internal dependencies
  */
 import { blogPost, feedPost } from './controller';
-import { updateLastRoute, unmountSidebar } from 'reader/controller';
+import { updateLastRoute } from 'reader/controller';
 import { makeLayout, render as clientRender } from 'controller';
 
 export default function () {
 	// Feed full post
-	page(
-		'/read/feeds/:feed/posts/:post',
-		updateLastRoute,
-		unmountSidebar,
-		feedPost,
-		makeLayout,
-		clientRender
-	);
+	page( '/read/feeds/:feed/posts/:post', updateLastRoute, feedPost, makeLayout, clientRender );
 
 	// Blog full post
-	page(
-		'/read/blogs/:blog/posts/:post',
-		updateLastRoute,
-		unmountSidebar,
-		blogPost,
-		makeLayout,
-		clientRender
-	);
+	page( '/read/blogs/:blog/posts/:post', updateLastRoute, blogPost, makeLayout, clientRender );
 }


### PR DESCRIPTION
The Full Post View React component is used only in the reader/full-post section, which already has all the code splitting we need. The extra `<AsyncLoad>` step doesn't make anything smaller or faster, and only adds a placeholder and a delay before I see the post.

Also removes the `unmountSidebar` handler which has been a noop for a few years.

**How to test:**
Verify that the full post views (both feeds and blogs) continue to render correctly. You can also verify in Chrome Performance Devtools that there's one less placeholder (in the screenshot timeline).
