### PR TITLE
Masterbar: Fix redux connect in CheckoutMasterbar

### DIFF
--- a/client/layout/masterbar/checkout.jsx
+++ b/client/layout/masterbar/checkout.jsx
@@ -51,4 +51,4 @@ class CheckoutMasterbar extends React.Component {
 	}
 }
 
-export default connect( () => (null, { recordTracksEvent }) )( localize( CheckoutMasterbar ) );
+export default connect( null, { recordTracksEvent } )( localize( CheckoutMasterbar ) );


### PR DESCRIPTION
In #44746 we introduced a new `CheckoutMasterbar` component, but it's not properly connected to Redux, so it won't be recording events properly. This was likely caused by a bad rebase or something.

Luckily, it's not causing a fatal, so the only thing to fix here is the actual event recording.

#### Changes proposed in this Pull Request

* Fix syntax of `connect()` in the newly introduced `CheckoutMasterbar` component.

#### Testing instructions

* Type `localStorage.debug='calypso:analytics:tracks'` in your browser dev console.
* Follow test instructions of #44206 to get to the logged out checkout page.
* Press the (x) on the logged out checkout page.
* Verify the `calypso_masterbar_close_clicked` event is being recorded.
