### PR TITLE
Gutenboarding: Intentionally fail E2E gutenboarding tests

### DIFF
--- a/test/e2e/specs/wp-gutenboarding-spec.js
+++ b/test/e2e/specs/wp-gutenboarding-spec.js
@@ -32,6 +32,8 @@ before( async function () {
 describe( 'Gutenboarding: (' + screenSize + ')', function () {
 	this.timeout( mochaTimeOut );
 	describe( 'Visit Gutenboarding page as a new user @parallel @canary', function () {
+		throw 'Forcing Gutenboarding e2e tests to fail';
+
 		const siteTitle = dataHelper.randomPhrase();
 
 		before( async function () {


### PR DESCRIPTION
This is part of the onboarding process.

#### Changes proposed in this Pull Request

* Breaking intentionally tests in `test/e2e/specs/wp-gutenboarding-spec.js`

#### Testing instructions

* `cd test/e2e && ./node_modules/.bin/mocha specs/wp-gutenboarding-spec.js`
* Tests should fail with error message `Forcing Gutenboarding e2e tests to fail`

cc @yansern 
