### PR TITLE
Site setup: bulb with cross icon for disable plan message.

### DIFF
--- a/packages/plans-grid/src/plans-table/plan-item.tsx
+++ b/packages/plans-grid/src/plans-table/plan-item.tsx
@@ -4,7 +4,7 @@
 import * as React from 'react';
 import classNames from 'classnames';
 import { createInterpolateElement } from '@wordpress/element';
-import { Button, Tip } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { Icon, check, close } from '@wordpress/icons';
 import { useViewportMatch } from '@wordpress/compose';
 import { useI18n } from '@automattic/react-i18n';
@@ -191,7 +191,8 @@ const PlanItem: React.FunctionComponent< Props > = ( {
 								<li className="plan-item__feature-item">
 									{ disabledLabel ? (
 										<span className="plan-item__disabled-message">
-											<Tip>{ disabledLabel }</Tip>
+											{ CrossIcon }
+											{ disabledLabel }
 										</span>
 									) : (
 										domainMessage && (

--- a/packages/plans-grid/src/plans-table/style.scss
+++ b/packages/plans-grid/src/plans-table/style.scss
@@ -3,6 +3,9 @@
 @import '~@automattic/typography/styles/variables';
 @import '../variables.scss';
 
+/* stylelint-disable scales/font-size */
+// @TODO: re-enable lint rule in https://github.com/Automattic/wp-calypso/issues/44933
+
 .plans-table {
 	width: 100%;
 	display: flex;
@@ -315,23 +318,19 @@ ul.plan-item__feature-item-group {
 	}
 
 	.plan-item__disabled-message {
-		svg {
-			align-self: flex-start;
-			width: 18px;
-			height: 18px;
+		font-size: $font-body-small;
+		line-height: 20px;
+		letter-spacing: 0.2px;
+		font-weight: bold;
+		color: var( --studio-orange-40 );
+		display: flex;
 
+		svg {
+			flex-shrink: 0;
 			path {
 				fill: var( --studio-orange-40 );
 				stroke: var( --studio-orange-40 );
 			}
-		}
-
-		p {
-			font-size: $font-body-small;
-			line-height: 20px;
-			letter-spacing: 0.2px;
-			font-weight: bold;
-			color: var( --studio-orange-40 );
 		}
 	}
 }

--- a/packages/plans-grid/src/types-patch.ts
+++ b/packages/plans-grid/src/types-patch.ts
@@ -4,8 +4,4 @@ declare module '@wordpress/compose' {
 	export function useViewportMatch( viewport: breakpoint, operator?: operator ): boolean;
 }
 
-declare module '@wordpress/components' {
-	const Tip: React.ComponentType< { children: React.ReactNode } >;
-}
-
 export {};


### PR DESCRIPTION
### Changes proposed in this Pull Request
* Replace bulb icon with cross icon when displaying a message for disabled plan in Site setup flow.

### Testing instructions
* Build Editing Toolkit locally with the updated `@automattic/plans-grid` package and sync it to sandbox following guide at PCYsg-ly5-p2
* Create a site starting at [wordpress.com/new](https://wordpress.com/new)
* Sandbox the site.
* Click on _Complete Setup_ button to start Site setup flow.
* Pick a custom domain from _Select a domain_ step.
* Go to _Select a plan_ step and you should see the disabled message for the Free plan.

### Screenshots
#### Before
<img width="337" alt="Screenshot 2020-08-25 at 10 46 42" src="https://user-images.githubusercontent.com/14192054/91176576-24f59a00-e6eb-11ea-833a-4712f08b03d7.png">

#### After
<img width="337" alt="Screenshot 2020-08-25 at 15 38 15" src="https://user-images.githubusercontent.com/14192054/91176565-21621300-e6eb-11ea-9455-a007f8ab3b8c.png">