### PR TITLE
Gutenboarding: Fixed tooltip of theme premium badge showing in uppercase.

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -133,7 +133,6 @@
 		margin-left: 6px;
 		/* stylelint-disable-next-line scales/font-size */
 		font-size: rem( 10px ); //typography-exception
-		text-transform: uppercase;
 	}
 
 	.design-selector__premium-badge {
@@ -162,5 +161,6 @@
 	.design-selector__premium-badge-text {
 		display: inline-block;
 		margin-top: -0.05em;
+		text-transform: uppercase;
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixed tooltip on premium badge showing in uppercase.

#### Testing instructions

* Go to design step in `/new`.
* Hover on premium badge.
* Tooltip text should not be uppercase.

#### Screenshot
![image](https://user-images.githubusercontent.com/1287077/91177659-5dde4080-e6e4-11ea-81dc-7dffd73df350.png)
![image](https://user-images.githubusercontent.com/1287077/91177660-5e76d700-e6e4-11ea-9bfd-6caa321d14af.png)

Fixes #45179
