### PR TITLE
Do not force the path of TypeScript's incremental cache.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,6 @@ cached-requests.json
 /desktop/id_rsa
 /desktop/e2e/logs
 /desktop/e2e/screenshots
+
+# Typescript
+*.tsbuildinfo

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -8,7 +8,6 @@
 
 		"baseUrl": ".",
 		"rootDir": ".",
-		"tsBuildInfoFile": "../.tsc-cache/client",
 		"noEmit": false,
 		"emitDeclarationOnly": true,
 		"composite": true,

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
 		"clean:packages": "npx lerna run clean --stream",
 		"clean:public": "npx rimraf public",
 		"clean:translations": "npx rimraf build/strings calypso-strings.pot chunks-map.*.json",
-		"distclean": "yarn run clean && npx rimraf node_modules client/node_modules desktop/node_modules apps/*/node_modules packages/*/node_modules test/e2e/node_modules .tsc-cache .cache vendor",
+		"distclean": "yarn run clean && npx rimraf node_modules client/node_modules desktop/node_modules apps/*/node_modules packages/*/node_modules test/e2e/node_modules .cache vendor",
 		"docker": "docker run -it --name wp-calypso --rm -p 80:3000 wp-calypso",
 		"docker-jetpack-cloud": "docker run -it --env CALYPSO_ENV=jetpack-cloud-production --name wp-calypso --rm -p 80:3000 wp-calypso",
 		"download-languages-meta": "node bin/download-languages-meta.js",

--- a/packages/browser-data-collector/package.json
+++ b/packages/browser-data-collector/package.json
@@ -17,7 +17,7 @@
 		"url": "https://github.com/Automattic/wp-calypso/issues"
 	},
 	"scripts": {
-		"clean": "npx rimraf dist",
+		"clean": "tsc --build ./tsconfig.json --clean && tsc --build ./tsconfig-cjs.json --clean",
 		"prepublish": "yarn run clean",
 		"prepare": "tsc --project ./tsconfig.json && tsc --project ./tsconfig-cjs.json",
 		"watch": "tsc --project ./tsconfig.json --watch"

--- a/packages/browser-data-collector/package.json
+++ b/packages/browser-data-collector/package.json
@@ -17,7 +17,7 @@
 		"url": "https://github.com/Automattic/wp-calypso/issues"
 	},
 	"scripts": {
-		"clean": "npx rimraf dist \"../../.tsc-cache/packages__browser-data-collector*\"",
+		"clean": "npx rimraf dist",
 		"prepublish": "yarn run clean",
 		"prepare": "tsc --project ./tsconfig.json && tsc --project ./tsconfig-cjs.json",
 		"watch": "tsc --project ./tsconfig.json --watch"

--- a/packages/browser-data-collector/tsconfig-cjs.json
+++ b/packages/browser-data-collector/tsconfig-cjs.json
@@ -4,8 +4,6 @@
 		"module": "commonjs",
 		"outDir": "dist/cjs",
 		"composite": false,
-		"incremental": true,
-
-		"tsBuildInfoFile": "../../.tsc-cache/packages__browser-data-collector--cjs"
+		"incremental": true
 	}
 }

--- a/packages/browser-data-collector/tsconfig.json
+++ b/packages/browser-data-collector/tsconfig.json
@@ -28,8 +28,7 @@
 		"noEmitHelpers": true,
 		"importHelpers": true,
 
-		"composite": true,
-		"tsBuildInfoFile": "../../.tsc-cache/packages__browser-data-collector"
+		"composite": true
 	},
 	"include": [ "src" ],
 	"exclude": [ "**/docs/*", "**/test/*" ]

--- a/packages/calypso-analytics/package.json
+++ b/packages/calypso-analytics/package.json
@@ -25,7 +25,7 @@
 		"url": "https://github.com/Automattic/wp-calypso/issues"
 	},
 	"scripts": {
-		"clean": "npx rimraf dist",
+		"clean": "tsc --build ./tsconfig.json --clean && tsc --build ./tsconfig-cjs.json --clean",
 		"prepublish": "yarn run clean",
 		"prepare": "tsc --project ./tsconfig.json && tsc --project ./tsconfig-cjs.json",
 		"watch": "tsc --project ./tsconfig.json --watch"

--- a/packages/calypso-analytics/package.json
+++ b/packages/calypso-analytics/package.json
@@ -25,7 +25,7 @@
 		"url": "https://github.com/Automattic/wp-calypso/issues"
 	},
 	"scripts": {
-		"clean": "npx rimraf dist \"../../.tsc-cache/packages__calypso-analytics*\"",
+		"clean": "npx rimraf dist",
 		"prepublish": "yarn run clean",
 		"prepare": "tsc --project ./tsconfig.json && tsc --project ./tsconfig-cjs.json",
 		"watch": "tsc --project ./tsconfig.json --watch"

--- a/packages/calypso-analytics/tsconfig-cjs.json
+++ b/packages/calypso-analytics/tsconfig-cjs.json
@@ -6,7 +6,6 @@
 		"declarationDir": null,
 		"outDir": "dist/cjs",
 		"composite": false,
-		"incremental": true,
-		"tsBuildInfoFile": "../../.tsc-cache/packages__calypso-analytics--cjs"
+		"incremental": true
 	}
 }

--- a/packages/calypso-analytics/tsconfig.json
+++ b/packages/calypso-analytics/tsconfig.json
@@ -28,8 +28,7 @@
 		"noEmitHelpers": true,
 		"importHelpers": true,
 
-		"composite": true,
-		"tsBuildInfoFile": "../../.tsc-cache/packages__calypso-analytics"
+		"composite": true
 	},
 	"include": [ "src" ],
 	"exclude": [ "**/docs/*", "**/test/*" ]

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -40,7 +40,7 @@
 		"react-dom": "^16.8"
 	},
 	"scripts": {
-		"clean": "npx rimraf dist",
+		"clean": "npx rimraf dist && tsc --build --clean",
 		"prepublish": "yarn run clean",
 		"prepare": "transpile && tsc && copy-assets"
 	}

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -40,7 +40,7 @@
 		"react-dom": "^16.8"
 	},
 	"scripts": {
-		"clean": "npx rimraf dist \"../../.tsc-cache/packages__components*\"",
+		"clean": "npx rimraf dist",
 		"prepublish": "yarn run clean",
 		"prepare": "transpile && tsc && copy-assets"
 	}

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -7,6 +7,7 @@
 		"jsx": "react",
 		"declaration": true,
 		"declarationDir": "dist/types",
+		"outDir": "dist/types",
 		"emitDeclarationOnly": true,
 		"isolatedModules": true,
 

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -25,8 +25,7 @@
 		"types": [],
 		"rootDir": "src",
 
-		"composite": true,
-		"tsBuildInfoFile": "../../.tsc-cache/packages__components"
+		"composite": true
 	},
 	"include": [ "src" ],
 	"exclude": [ "**/docs/*", "**/test/*" ]

--- a/packages/data-stores/package.json
+++ b/packages/data-stores/package.json
@@ -26,7 +26,7 @@
 	],
 	"types": "dist/types",
 	"scripts": {
-		"clean": "npx rimraf dist",
+		"clean": "tsc --build ./tsconfig.json --clean && tsc --build ./tsconfig-cjs.json --clean",
 		"prepare": "tsc --project ./tsconfig.json && tsc --project ./tsconfig-cjs.json",
 		"prepublish": "yarn run clean",
 		"watch": "tsc --project ./tsconfig.json --watch"

--- a/packages/data-stores/package.json
+++ b/packages/data-stores/package.json
@@ -26,7 +26,7 @@
 	],
 	"types": "dist/types",
 	"scripts": {
-		"clean": "npx rimraf dist \"../../.tsc-cache/packages__data-stores*\"",
+		"clean": "npx rimraf dist",
 		"prepare": "tsc --project ./tsconfig.json && tsc --project ./tsconfig-cjs.json",
 		"prepublish": "yarn run clean",
 		"watch": "tsc --project ./tsconfig.json --watch"

--- a/packages/data-stores/tsconfig-cjs.json
+++ b/packages/data-stores/tsconfig-cjs.json
@@ -7,8 +7,6 @@
 		"declarationDir": null,
 		"outDir": "dist/cjs",
 		"composite": false,
-		"incremental": true,
-
-		"tsBuildInfoFile": "../../.tsc-cache/packages__data-stores--cjs"
+		"incremental": true
 	}
 }

--- a/packages/data-stores/tsconfig.json
+++ b/packages/data-stores/tsconfig.json
@@ -31,8 +31,7 @@
 		"noEmitHelpers": true,
 		"importHelpers": true,
 
-		"composite": true,
-		"tsBuildInfoFile": "../../.tsc-cache/packages__data-stores"
+		"composite": true
 	},
 	"include": [ "src" ],
 	"exclude": [ "**/docs/*", "**/test/*" ]

--- a/packages/domain-picker/package.json
+++ b/packages/domain-picker/package.json
@@ -24,7 +24,7 @@
 	},
 	"types": "dist/types",
 	"scripts": {
-		"clean": "npx rimraf dist ../../.tsc-cache/packages__domain-picker*",
+		"clean": "npx rimraf dist",
 		"prepare": "tsc --project ./tsconfig.json && tsc --project ./tsconfig-cjs.json && copy-assets",
 		"prepublish": "yarn run clean",
 		"watch": "tsc --project ./tsconfig.json --watch"

--- a/packages/domain-picker/package.json
+++ b/packages/domain-picker/package.json
@@ -24,7 +24,7 @@
 	},
 	"types": "dist/types",
 	"scripts": {
-		"clean": "npx rimraf dist",
+		"clean": "tsc --build ./tsconfig.json --clean && tsc --build ./tsconfig-cjs.json --clean",
 		"prepare": "tsc --project ./tsconfig.json && tsc --project ./tsconfig-cjs.json && copy-assets",
 		"prepublish": "yarn run clean",
 		"watch": "tsc --project ./tsconfig.json --watch"

--- a/packages/domain-picker/tsconfig-cjs.json
+++ b/packages/domain-picker/tsconfig-cjs.json
@@ -6,7 +6,6 @@
 		"declarationDir": null,
 		"outDir": "dist/cjs",
 		"composite": false,
-		"incremental": true,
-		"tsBuildInfoFile": "../../.tsc-cache/packages__domain-picker--cjs"
+		"incremental": true
 	}
 }

--- a/packages/domain-picker/tsconfig.json
+++ b/packages/domain-picker/tsconfig.json
@@ -28,8 +28,7 @@
 
 		"importsNotUsedAsValues": "error",
 		"importHelpers": true,
-		"composite": true,
-		"tsBuildInfoFile": "../../.tsc-cache/packages__domain-picker"
+		"composite": true
 	},
 	"include": [ "src" ],
 	"exclude": [ "**/test/*" ],

--- a/packages/media-library/package.json
+++ b/packages/media-library/package.json
@@ -25,7 +25,7 @@
 	"types": "dist/types",
 	"dependencies": {},
 	"scripts": {
-		"clean": "npx rimraf dist types \"../../.tsc-cache/packages__media-library*\"",
+		"clean": "npx rimraf dist",
 		"prepublish": "yarn run clean",
 		"prepare": "transpile && tsc && copy-assets"
 	}

--- a/packages/media-library/package.json
+++ b/packages/media-library/package.json
@@ -25,7 +25,7 @@
 	"types": "dist/types",
 	"dependencies": {},
 	"scripts": {
-		"clean": "npx rimraf dist",
+		"clean": "npx rimraf dist && tsc --build --clean",
 		"prepublish": "yarn run clean",
 		"prepare": "transpile && tsc && copy-assets"
 	}

--- a/packages/media-library/tsconfig.json
+++ b/packages/media-library/tsconfig.json
@@ -25,8 +25,7 @@
 		"typeRoots": [ "../../node_modules/@types" ],
 		"lib": [ "ESNext", "DOM" ],
 
-		"composite": true,
-		"tsBuildInfoFile": "../../.tsc-cache/packages__media-library"
+		"composite": true
 	},
 	"include": [ "src" ],
 	"exclude": [ "**/docs/*", "**/test/*" ]

--- a/packages/media-library/tsconfig.json
+++ b/packages/media-library/tsconfig.json
@@ -7,6 +7,7 @@
 		"jsx": "react",
 		"declaration": true,
 		"declarationDir": "dist/types",
+		"outDir": "dist/types",
 		"emitDeclarationOnly": true,
 		"isolatedModules": true,
 		"rootDir": "src",

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -24,7 +24,7 @@
 	},
 	"types": "dist/types",
 	"scripts": {
-		"clean": "npx rimraf dist ../../.tsc-cache/packages__onboarding*",
+		"clean": "npx rimraf dist",
 		"prepare": "tsc --project ./tsconfig.json && tsc --project ./tsconfig-cjs.json && copy-assets && npx copyfiles ./styles/** dist",
 		"prepublish": "yarn run clean",
 		"watch": "tsc --project ./tsconfig.json --watch"

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -24,7 +24,7 @@
 	},
 	"types": "dist/types",
 	"scripts": {
-		"clean": "npx rimraf dist",
+		"clean": "tsc --build ./tsconfig.json --clean && tsc --build ./tsconfig-cjs.json --clean",
 		"prepare": "tsc --project ./tsconfig.json && tsc --project ./tsconfig-cjs.json && copy-assets && npx copyfiles ./styles/** dist",
 		"prepublish": "yarn run clean",
 		"watch": "tsc --project ./tsconfig.json --watch"

--- a/packages/onboarding/tsconfig-cjs.json
+++ b/packages/onboarding/tsconfig-cjs.json
@@ -6,7 +6,6 @@
 		"declarationDir": null,
 		"outDir": "dist/cjs",
 		"composite": false,
-		"incremental": true,
-		"tsBuildInfoFile": "../../.tsc-cache/packages__onboarding--cjs"
+		"incremental": true
 	}
 }

--- a/packages/onboarding/tsconfig.json
+++ b/packages/onboarding/tsconfig.json
@@ -28,8 +28,7 @@
 
 		"importsNotUsedAsValues": "error",
 		"importHelpers": true,
-		"composite": true,
-		"tsBuildInfoFile": "../../.tsc-cache/packages__onboarding"
+		"composite": true
 	},
 	"include": [ "src" ],
 	"exclude": [ "**/test/*" ],

--- a/packages/plans-grid/package.json
+++ b/packages/plans-grid/package.json
@@ -24,7 +24,7 @@
 	},
 	"types": "dist/types",
 	"scripts": {
-		"clean": "npx rimraf dist ../../.tsc-cache/packages__plans-grid*",
+		"clean": "npx rimraf dist",
 		"prepare": "tsc --project ./tsconfig.json && tsc --project ./tsconfig-cjs.json && copy-assets",
 		"prepublish": "yarn run clean",
 		"watch": "tsc --project ./tsconfig.json --watch"

--- a/packages/plans-grid/package.json
+++ b/packages/plans-grid/package.json
@@ -24,7 +24,7 @@
 	},
 	"types": "dist/types",
 	"scripts": {
-		"clean": "npx rimraf dist",
+		"clean": "tsc --build ./tsconfig.json --clean && tsc --build ./tsconfig-cjs.json --clean",
 		"prepare": "tsc --project ./tsconfig.json && tsc --project ./tsconfig-cjs.json && copy-assets",
 		"prepublish": "yarn run clean",
 		"watch": "tsc --project ./tsconfig.json --watch"

--- a/packages/plans-grid/tsconfig-cjs.json
+++ b/packages/plans-grid/tsconfig-cjs.json
@@ -6,7 +6,6 @@
 		"declarationDir": null,
 		"outDir": "dist/cjs",
 		"composite": false,
-		"incremental": true,
-		"tsBuildInfoFile": "../../.tsc-cache/packages__plans-grid--cjs"
+		"incremental": true
 	}
 }

--- a/packages/plans-grid/tsconfig.json
+++ b/packages/plans-grid/tsconfig.json
@@ -28,8 +28,7 @@
 
 		"importsNotUsedAsValues": "error",
 		"importHelpers": true,
-		"composite": true,
-		"tsBuildInfoFile": "../../.tsc-cache/packages__plans-grid"
+		"composite": true
 	},
 	"include": [ "src" ],
 	"exclude": [ "**/test/*" ],

--- a/packages/react-i18n/package.json
+++ b/packages/react-i18n/package.json
@@ -25,7 +25,7 @@
 	],
 	"types": "dist/types",
 	"scripts": {
-		"clean": "npx rimraf dist",
+		"clean": "tsc --build ./tsconfig.json --clean && tsc --build ./tsconfig-cjs.json --clean",
 		"prepare": "tsc --project ./tsconfig.json && tsc --project ./tsconfig-cjs.json",
 		"prepublish": "yarn run clean",
 		"watch": "tsc --project ./tsconfig.json --watch"

--- a/packages/react-i18n/package.json
+++ b/packages/react-i18n/package.json
@@ -25,7 +25,7 @@
 	],
 	"types": "dist/types",
 	"scripts": {
-		"clean": "npx rimraf dist ../../.tsc-cache/packages__react-i18n*",
+		"clean": "npx rimraf dist",
 		"prepare": "tsc --project ./tsconfig.json && tsc --project ./tsconfig-cjs.json",
 		"prepublish": "yarn run clean",
 		"watch": "tsc --project ./tsconfig.json --watch"

--- a/packages/react-i18n/tsconfig-cjs.json
+++ b/packages/react-i18n/tsconfig-cjs.json
@@ -7,7 +7,6 @@
 		"declarationDir": null,
 		"outDir": "dist/cjs",
 		"composite": false,
-		"incremental": true,
-		"tsBuildInfoFile": "../../.tsc-cache/packages__react-i18n--cjs"
+		"incremental": true
 	}
 }

--- a/packages/react-i18n/tsconfig.json
+++ b/packages/react-i18n/tsconfig.json
@@ -28,8 +28,7 @@
 		"types": [],
 
 		"importHelpers": true,
-		"composite": true,
-		"tsBuildInfoFile": "../../.tsc-cache/packages__react-i18n"
+		"composite": true
 	},
 	"include": [ "src" ],
 	"exclude": [ "**/docs/*", "**/test/*" ]


### PR DESCRIPTION
### Background

TypeScript has incremental compilation since 3.4 (https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-4.html#faster-subsequent-builds-with-the---incremental-flag). This feature uses a file `tsbuildinfo`.

When this file is present, TypeScript may not re-generate the complied output, even if it is missing (see https://github.com/Automattic/wp-calypso/pull/44863#discussion_r476284289). 

### Changes

By not specifying a custom location for `tsBuildInfo`, TypeScript compiler will use the output directory of each project. This should make easier to persist the incremental file _and_ the compiled output together.

### Testing instructions

* Run `yarn build-packages`, note it creates a bunch of `.tsbuildinfo` files (`find . -name '*.tsbuildinfo' | grep -v node_modules`).
* Run it a second time, it should be faster now.

