### PR TITLE
Concierge page: upsell QS for Business plans without included sessions

### DIFF
--- a/client/me/concierge/main.js
+++ b/client/me/concierge/main.js
@@ -36,6 +36,7 @@ import PageViewTracker from 'lib/analytics/page-view-tracker';
 import ReauthRequired from 'me/reauth-required';
 import twoStepAuthorization from 'lib/two-step-authorization';
 import {
+	PLAN_BUSINESS_2_YEARS,
 	PLAN_BUSINESS_ONBOARDING_EXPIRE,
 	PLAN_BUSINESS_2Y_ONBOARDING_EXPIRE,
 } from 'lib/plans/constants';
@@ -98,7 +99,7 @@ export class ConciergeMain extends Component {
 		let hasBusinessOnboardingExpired;
 		if ( currentPlan ) {
 			const expiryDateMoment = this.props.moment( currentPlan.expiryDate );
-			const is2YearPlan = site.plan.product_id === 1028;
+			const is2YearPlan = currentPlan.productSlug === PLAN_BUSINESS_2_YEARS;
 			const businessOnboardingExpiration = this.props.moment(
 				is2YearPlan ? PLAN_BUSINESS_2Y_ONBOARDING_EXPIRE : PLAN_BUSINESS_ONBOARDING_EXPIRE
 			);
@@ -107,10 +108,10 @@ export class ConciergeMain extends Component {
 		}
 
 		const hasIncludedSessions = scheduleId === 1;
-		const hasPurchsedSessions = scheduleId > 1;
+		const hasPurchasedSessions = scheduleId > 1;
 
 		const isBusinessOnboardingAvailable =
-			hasPurchsedSessions || ( hasIncludedSessions && ! hasBusinessOnboardingExpired );
+			hasPurchasedSessions || ( hasIncludedSessions && ! hasBusinessOnboardingExpired );
 
 		if ( ! isBusinessOnboardingAvailable ) {
 			return <Upsell site={ site } />;

--- a/client/me/concierge/main.js
+++ b/client/me/concierge/main.js
@@ -110,10 +110,10 @@ export class ConciergeMain extends Component {
 		const hasIncludedSessions = scheduleId === 1;
 		const hasPurchasedSessions = scheduleId > 1;
 
-		const isBusinessOnboardingAvailable =
+		const hasAvailableSessions =
 			hasPurchasedSessions || ( hasIncludedSessions && ! hasBusinessOnboardingExpired );
 
-		if ( ! isBusinessOnboardingAvailable ) {
+		if ( ! hasAvailableSessions ) {
 			return <Upsell site={ site } />;
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This shows the QS upsell message for new Business plan users after implementing #44461.
Since new Business plans users don't have any included QS anymore, we'll need to use the same logic to show the upsell message that we use to hide the included QS session block on the /my-plan page.
Related info pbBQWj-eI-p2.

#### Testing instructions

##### Old Business plan ( included QS sessions)
* Go to [/concierge page](https://wordpress.com/me/concierge)
* Select a site with an old Business plan (opened before 07-31-2020)
* The scheduler should be visible
<img width="460px" src="https://user-images.githubusercontent.com/2749938/91179874-bebf4600-e6ef-11ea-897c-0f20b2881be7.png" />


##### New plan - no QS session
* Use a new Business plan (opened after 07-31-2020) or any cheaper/free plan
* Go to [/concierge page](https://wordpress.com/me/concierge) and select that plan
* The upsell banner should be visible
<img width="460px" src="https://user-images.githubusercontent.com/2749938/91179832-b23aed80-e6ef-11ea-8890-952cc853a677.png" />


##### New plan + purchased a QS session
* Use a new Business plan (opened after 07-31-2020) or any cheaper/free plan
* Purchase a QS [here](https://wordpress.com/checkout/offer-support-session) for that plan
* Go to [/concierge page](https://wordpress.com/me/concierge) and select that plan
* The scheduler should be visible

