### PR TITLE
fix(media/reducer): don't deselect non-transient items after requesti…

### DIFF
--- a/client/state/media/reducer.js
+++ b/client/state/media/reducer.js
@@ -289,12 +289,16 @@ export const selectedItems = withoutPersistence( ( state = {}, action ) => {
 			};
 		}
 		case MEDIA_ITEM_REQUEST_SUCCESS: {
-			const { mediaId: transientMediaId, siteId } = action;
+			const { mediaId: requestedMediaId, siteId } = action;
 			const media = state[ siteId ] ?? [];
+
+			const isTransient = typeof requestedMediaId === 'string';
 
 			return {
 				...state,
-				[ siteId ]: media.filter( ( mediaId ) => transientMediaId !== mediaId ),
+				[ siteId ]: media.filter(
+					( mediaId ) => ! ( isTransient && requestedMediaId === mediaId )
+				),
 			};
 		}
 		case MEDIA_DELETE: {

--- a/client/state/media/test/reducer.js
+++ b/client/state/media/test/reducer.js
@@ -607,8 +607,23 @@ describe( 'reducer', () => {
 		} );
 
 		test( 'should deselect any transient media item after its corresponding media was successfully uploaded', () => {
+			const transientMediaId = 'media-123';
 			const state = {
-				[ site.ID ]: [ 1, mediaId, 2 ],
+				[ site.ID ]: [ 1, transientMediaId, 2 ],
+			};
+			const result = selectedItems(
+				deepFreeze( state ),
+				successMediaItemRequest( siteId, transientMediaId )
+			);
+
+			expect( result ).to.deep.eql( {
+				[ site.ID ]: [ 1, 2 ],
+			} );
+		} );
+
+		test( 'should not deselect any non-transient media item after it got requested', () => {
+			const state = {
+				[ site.ID ]: [ 1, 2, mediaId ],
 			};
 			const result = selectedItems(
 				deepFreeze( state ),
@@ -616,7 +631,7 @@ describe( 'reducer', () => {
 			);
 
 			expect( result ).to.deep.eql( {
-				[ site.ID ]: [ 1, 2 ],
+				[ site.ID ]: [ 1, 2, mediaId ],
 			} );
 		} );
 


### PR DESCRIPTION
…ng them

#### Changes proposed in this Pull Request

* Change `media/reducer.selectedItems` to not deselect non-transient items after they got requested

#### Testing instructions

* Follow the steps provided in #44640 and make sure that bug is fixed
* Also, try uploading a new item to your media library and make sure selection works as expected (newly uploaded item should be selected before and after upload is successful)

Fixes #44640
