### PR TITLE
Revert "Gutenboarding: Intentionally fail E2E gutenboarding tests"

### DIFF
--- a/test/e2e/specs/wp-gutenboarding-spec.js
+++ b/test/e2e/specs/wp-gutenboarding-spec.js
@@ -32,8 +32,6 @@ before( async function () {
 describe( 'Gutenboarding: (' + screenSize + ')', function () {
 	this.timeout( mochaTimeOut );
 	describe( 'Visit Gutenboarding page as a new user @parallel @canary', function () {
-		throw 'Forcing Gutenboarding e2e tests to fail';
-
 		const siteTitle = dataHelper.randomPhrase();
 
 		before( async function () {


### PR DESCRIPTION
Reverts Automattic/wp-calypso#45175

Part of the onboarding process