### PR TITLE
Add translate function to Get started text

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
@@ -81,7 +81,7 @@ export const getTask = (
 				description: translate(
 					"Next, we'll guide you through setting up and launching your site."
 				),
-				actionText: 'Get started',
+				actionText: translate( 'Get started' ),
 				...( ! task.isCompleted && {
 					actionDispatch: requestSiteChecklistTaskUpdate,
 					actionDispatchArgs: [ siteId, task.id ],


### PR DESCRIPTION
The 'Get started' was not translated on the user home in Calypso because the text was not wrapped in the translate function.

* This PR adds `translate ()` to the text that was not wrapped for translation.

<img width="688" alt="Screen Shot 2020-08-25 at 8 42 10 AM" src="https://user-images.githubusercontent.com/36699353/91188879-083b7100-e6af-11ea-9d2e-b8261d392b0f.png">


#### Testing instructions

* Go to https://wordpress.com/home/ for a newly created site with user language set to one of mag-16 languages
* Check that the 'Get started' button is translated. 