### PR TITLE
Bump WordPress.com Editing Toolkit plugin to v2.0

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WordPress.com Editing Toolkit
  * Description: Enhances your page creation workflow within the Block Editor.
- * Version: 1.22
+ * Version: 2.0
  * Author: Automattic
  * Author URI: https://automattic.com/wordpress-plugins/
  * License: GPLv2 or later
@@ -35,7 +35,7 @@ namespace A8C\FSE;
  *
  * @var string
  */
-define( 'PLUGIN_VERSION', '1.22' );
+define( 'PLUGIN_VERSION', '2.0' );
 
 // Always include these helper files for dotcom FSE.
 require_once __DIR__ . '/dotcom-fse/helpers.php';

--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -3,7 +3,7 @@ Contributors: alexislloyd, allancole, automattic, bartkalisz, codebykat, copons,
 Tags: block, blocks, editor, gutenberg, page
 Requires at least: 5.0
 Tested up to: 5.4
-Stable tag: 1.22
+Stable tag: 2.0
 Requires PHP: 5.6.20
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -39,6 +39,9 @@ This plugin is experimental, so we don't provide any support for it outside of w
 
 
 == Changelog ==
+
+= 2.0 =
+* Replace all internal mentions of `full-site-editing` to `editing-toolkit`.
 
 = 1.22 =
 * Premium Content: load assets using proper hook (https://github.com/Automattic/wp-calypso/pull/44825)

--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -41,7 +41,9 @@ This plugin is experimental, so we don't provide any support for it outside of w
 == Changelog ==
 
 = 2.0 =
-* Replace all internal mentions of `full-site-editing` to `editing-toolkit`.
+* Rename directories from "full-site-editing*" to "editing-toolkit*" (https://github.com/Automattic/wp-calypso/pull/44501)
+* Update/premium content loading assets code cleanup (https://github.com/Automattic/wp-calypso/pull/45052)
+* FSE: Add Newspack assets unit tests (https://github.com/Automattic/wp-calypso/pull/43218)
 
 = 1.22 =
 * Premium Content: load assets using proper hook (https://github.com/Automattic/wp-calypso/pull/44825)

--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/wpcom-editing-toolkit",
-	"version": "1.22.0",
+	"version": "2.0.0",
 	"description": "Plugin for editing-related features.",
 	"sideEffects": true,
 	"repository": {

--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
 		"@automattic/data-stores": "^1.0.0-alpha.1",
 		"@automattic/effective-module-tree": "^0.1.0",
 		"@automattic/format-currency": "^1.0.0-alpha.0",
-		"@automattic/wpcom-editing-toolkit": "^1.5.0",
+		"@automattic/wpcom-editing-toolkit": "^2.0.0",
 		"@automattic/load-script": "^1.0.0",
 		"@automattic/material-design-icons": "^1.0.0",
 		"@automattic/media-library": "^1.0.0-alpha.0",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This release's changelog is:

* Rename directories from "full-site-editing*" to "editing-toolkit*" (#44501)
* Update/premium content loading assets code cleanup (#45052)
* FSE: Add Newspack assets unit tests (#43218)