### PR TITLE
Lasagna: make connect middleware behave like sync middleware

### DIFF
--- a/client/state/lasagna/connect/middleware.js
+++ b/client/state/lasagna/connect/middleware.js
@@ -10,6 +10,10 @@ let socketConnected = false;
 let socketConnecting = false;
 
 export default ( store ) => ( next ) => async ( action ) => {
+	// immediately pass the action onward to finish the typically
+	// sync expectations of redux mw -> reducers execution
+	const mwResult = next( action );
+
 	switch ( action.type ) {
 		case SECTION_SET: {
 			const { section } = action;
@@ -31,5 +35,5 @@ export default ( store ) => ( next ) => async ( action ) => {
 		}
 	}
 
-	return next( action );
+	return mwResult;
 };

--- a/client/state/lasagna/connect/middleware.js
+++ b/client/state/lasagna/connect/middleware.js
@@ -10,8 +10,6 @@ let socketConnected = false;
 let socketConnecting = false;
 
 export default ( store ) => ( next ) => async ( action ) => {
-	// immediately pass the action onward to finish the typically
-	// sync expectations of redux mw -> reducers execution
 	const mwResult = next( action );
 
 	switch ( action.type ) {

--- a/client/state/lasagna/post-channel/middleware.js
+++ b/client/state/lasagna/post-channel/middleware.js
@@ -85,6 +85,8 @@ const leaveChannel = ( topic ) => lasagna.leaveChannel( topic );
  * @param store middleware store
  */
 export default ( store ) => ( next ) => ( action ) => {
+	const mwResult = next( action );
+
 	switch ( action.type ) {
 		case READER_VIEWING_FULL_POST_SET: {
 			const joinParams = getJoinParams( store, action.postKey );
@@ -112,5 +114,5 @@ export default ( store ) => ( next ) => ( action ) => {
 		}
 	}
 
-	return next( action );
+	return mwResult;
 };

--- a/client/state/lasagna/user-channel/middleware.js
+++ b/client/state/lasagna/user-channel/middleware.js
@@ -34,10 +34,11 @@ const joinChannel = async ( store, topic ) => {
  * @param store middleware store
  */
 export default ( store ) => ( next ) => ( action ) => {
+	const mwResult = next( action );
 	const userId = getCurrentUserId( store.getState() );
 
 	if ( ! userId ) {
-		return next( action );
+		return mwResult;
 	}
 
 	const topic = channelTopicPrefix + userId;
@@ -49,5 +50,5 @@ export default ( store ) => ( next ) => ( action ) => {
 		}
 	}
 
-	return next( action );
+	return mwResult;
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Pass Redux actions onward immediately to complete the mw chain, reducers, etc before executing async Lasagna logic.

#### Testing instructions

- Make sure the Lasagna websocket connects when opening any part of the Reader section.
- Make sure it disconnects when leaving the Reader section.
- Make sure channel joins happen when you open a post full view.
- Make sure channel leaves happen when you leave a post full view.

Fixes #43001
