### PR TITLE
Checkout: update shopping-cart endpoint location when cached contact details change

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useEffect, useState, useRef, useCallback } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import { useTranslate } from 'i18n-calypso';
 import styled from '@emotion/styled';
 import {
@@ -29,6 +29,7 @@ import debugFactory from 'debug';
  */
 import { areDomainsInLineItems, isLineItemADomain } from '../hooks/has-domains';
 import useCouponFieldState from '../hooks/use-coupon-field-state';
+import useUpdateCartLocationWhenPaymentMethodChanges from '../hooks/use-update-cart-location-when-payment-method-changes';
 import WPCheckoutOrderReview from './wp-checkout-order-review';
 import WPCheckoutOrderSummary from './wp-checkout-order-summary';
 import WPContactForm from './wp-contact-form';
@@ -575,23 +576,6 @@ const CheckoutTermsUI = styled.div`
 		text-decoration: none;
 	}
 `;
-
-function useUpdateCartLocationWhenPaymentMethodChanges(
-	activePaymentMethod,
-	updateCartContactDetails
-) {
-	const previousPaymentMethodId = useRef();
-	const hasInitialized = useRef( false );
-	useEffect( () => {
-		if ( activePaymentMethod?.id && activePaymentMethod.id !== previousPaymentMethodId.current ) {
-			previousPaymentMethodId.current = activePaymentMethod.id;
-			if ( hasInitialized.current ) {
-				updateCartContactDetails();
-			}
-			hasInitialized.current = true;
-		}
-	}, [ activePaymentMethod, updateCartContactDetails ] );
-}
 
 function SubmitButtonHeader() {
 	const translate = useTranslate();

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -3,7 +3,7 @@
  */
 import page from 'page';
 import wp from 'lib/wp';
-import React, { useEffect, useState, useCallback, useMemo, useRef } from 'react';
+import React, { useEffect, useCallback, useMemo, useRef } from 'react';
 import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import debugFactory from 'debug';
@@ -35,11 +35,7 @@ import notices from 'notices';
 import { isJetpackSite } from 'state/sites/selectors';
 import isAtomicSite from 'state/selectors/is-site-automated-transfer';
 import isPrivateSite from 'state/selectors/is-private-site';
-import getContactDetailsCache from 'state/selectors/get-contact-details-cache';
-import {
-	requestContactDetailsCache,
-	updateContactDetailsCache,
-} from 'state/domains/management/actions';
+import { updateContactDetailsCache } from 'state/domains/management/actions';
 import QuerySitePurchases from 'components/data/query-site-purchases';
 import { getCurrentUserCountryCode } from 'state/current-user/selectors';
 import { StateSelect } from 'my-sites/domains/components/form';
@@ -84,6 +80,7 @@ import useCountryList from './hooks/use-country-list';
 import { colors } from '@automattic/color-studio';
 import { needsDomainDetails } from 'my-sites/checkout/composite-checkout/payment-method-helpers';
 import { isGSuiteProductSlug } from 'lib/gsuite';
+import useCachedDomainContactDetails from './hooks/use-cached-domain-contact-details';
 
 const debug = debugFactory( 'calypso:composite-checkout:composite-checkout' );
 
@@ -695,25 +692,6 @@ function useDetectedCountryCode() {
 			refHaveUsedDetectedCountryCode.current = true;
 		}
 	}, [ detectedCountryCode ] );
-}
-
-function useCachedDomainContactDetails() {
-	const reduxDispatch = useDispatch();
-	const [ haveRequestedCachedDetails, setHaveRequestedCachedDetails ] = useState( false );
-
-	useEffect( () => {
-		// Dispatch exactly once
-		if ( ! haveRequestedCachedDetails ) {
-			debug( 'requesting cached domain contact details' );
-			reduxDispatch( requestContactDetailsCache() );
-			setHaveRequestedCachedDetails( true );
-		}
-	}, [ haveRequestedCachedDetails, reduxDispatch ] );
-
-	const cachedContactDetails = useSelector( getContactDetailsCache );
-	if ( cachedContactDetails ) {
-		dispatch( 'wpcom' ).loadDomainContactDetailsFromCache( cachedContactDetails );
-	}
 }
 
 function getPlanProductSlugs(

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -343,7 +343,7 @@ export default function CompositeCheckout( {
 	);
 
 	useDetectedCountryCode();
-	useCachedDomainContactDetails();
+	useCachedDomainContactDetails( updateLocation );
 
 	useDisplayErrors( [ ...errors, loadingError ].filter( Boolean ), showErrorMessage );
 

--- a/client/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details.js
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details.js
@@ -29,12 +29,14 @@ export default function useCachedDomainContactDetails( updateCartLocation ) {
 	}, [ reduxDispatch ] );
 
 	const cachedContactDetails = useSelector( getContactDetailsCache );
-	if ( cachedContactDetails ) {
-		dispatch( 'wpcom' ).loadDomainContactDetailsFromCache( cachedContactDetails );
-		updateCartLocation( {
-			countryCode: cachedContactDetails.countryCode ?? '',
-			postalCode: cachedContactDetails.postalCode ?? '',
-			subdivisionCode: cachedContactDetails.state ?? '',
-		} );
-	}
+	useEffect( () => {
+		if ( cachedContactDetails ) {
+			dispatch( 'wpcom' ).loadDomainContactDetailsFromCache( cachedContactDetails );
+			updateCartLocation( {
+				countryCode: cachedContactDetails.countryCode ?? '',
+				postalCode: cachedContactDetails.postalCode ?? '',
+				subdivisionCode: cachedContactDetails.state ?? '',
+			} );
+		}
+	}, [ cachedContactDetails, updateCartLocation ] );
 }

--- a/client/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details.js
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details.js
@@ -1,0 +1,36 @@
+/**
+ * External dependencies
+ */
+import { useEffect, useState } from 'react';
+import { useSelector, useDispatch as useReduxDispatch } from 'react-redux';
+import { defaultRegistry } from '@automattic/composite-checkout';
+import debugFactory from 'debug';
+
+/**
+ * Internal dependencies
+ */
+import getContactDetailsCache from 'state/selectors/get-contact-details-cache';
+import { requestContactDetailsCache } from 'state/domains/management/actions';
+
+const { dispatch } = defaultRegistry;
+
+const debug = debugFactory( 'calypso:composite-checkout:use-cached-domain-contact-details' );
+
+export default function useCachedDomainContactDetails() {
+	const reduxDispatch = useReduxDispatch();
+	const [ haveRequestedCachedDetails, setHaveRequestedCachedDetails ] = useState( false );
+
+	useEffect( () => {
+		// Dispatch exactly once
+		if ( ! haveRequestedCachedDetails ) {
+			debug( 'requesting cached domain contact details' );
+			reduxDispatch( requestContactDetailsCache() );
+			setHaveRequestedCachedDetails( true );
+		}
+	}, [ haveRequestedCachedDetails, reduxDispatch ] );
+
+	const cachedContactDetails = useSelector( getContactDetailsCache );
+	if ( cachedContactDetails ) {
+		dispatch( 'wpcom' ).loadDomainContactDetailsFromCache( cachedContactDetails );
+	}
+}

--- a/client/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details.js
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useEffect, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import { useSelector, useDispatch as useReduxDispatch } from 'react-redux';
 import { defaultRegistry } from '@automattic/composite-checkout';
 import debugFactory from 'debug';
@@ -18,16 +18,15 @@ const debug = debugFactory( 'calypso:composite-checkout:use-cached-domain-contac
 
 export default function useCachedDomainContactDetails() {
 	const reduxDispatch = useReduxDispatch();
-	const [ haveRequestedCachedDetails, setHaveRequestedCachedDetails ] = useState( false );
+	const haveRequestedCachedDetails = useRef( false );
 
 	useEffect( () => {
-		// Dispatch exactly once
-		if ( ! haveRequestedCachedDetails ) {
+		if ( ! haveRequestedCachedDetails.current ) {
 			debug( 'requesting cached domain contact details' );
 			reduxDispatch( requestContactDetailsCache() );
-			setHaveRequestedCachedDetails( true );
+			haveRequestedCachedDetails.current = true;
 		}
-	}, [ haveRequestedCachedDetails, reduxDispatch ] );
+	}, [ reduxDispatch ] );
 
 	const cachedContactDetails = useSelector( getContactDetailsCache );
 	if ( cachedContactDetails ) {

--- a/client/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details.js
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details.js
@@ -16,7 +16,7 @@ const { dispatch } = defaultRegistry;
 
 const debug = debugFactory( 'calypso:composite-checkout:use-cached-domain-contact-details' );
 
-export default function useCachedDomainContactDetails() {
+export default function useCachedDomainContactDetails( updateCartLocation ) {
 	const reduxDispatch = useReduxDispatch();
 	const haveRequestedCachedDetails = useRef( false );
 
@@ -31,5 +31,10 @@ export default function useCachedDomainContactDetails() {
 	const cachedContactDetails = useSelector( getContactDetailsCache );
 	if ( cachedContactDetails ) {
 		dispatch( 'wpcom' ).loadDomainContactDetailsFromCache( cachedContactDetails );
+		updateCartLocation( {
+			countryCode: cachedContactDetails.countryCode ?? '',
+			postalCode: cachedContactDetails.postalCode ?? '',
+			subdivisionCode: cachedContactDetails.state ?? '',
+		} );
 	}
 }

--- a/client/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details.js
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-cached-domain-contact-details.js
@@ -31,7 +31,14 @@ export default function useCachedDomainContactDetails( updateCartLocation ) {
 	const cachedContactDetails = useSelector( getContactDetailsCache );
 	useEffect( () => {
 		if ( cachedContactDetails ) {
+			debug( 'using fetched cached domain contact details', cachedContactDetails );
 			dispatch( 'wpcom' ).loadDomainContactDetailsFromCache( cachedContactDetails );
+		}
+		if (
+			cachedContactDetails?.countryCode ||
+			cachedContactDetails?.postalCode ||
+			cachedContactDetails?.state
+		) {
 			updateCartLocation( {
 				countryCode: cachedContactDetails.countryCode ?? '',
 				postalCode: cachedContactDetails.postalCode ?? '',

--- a/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/types.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/types.ts
@@ -81,6 +81,7 @@ export type VariantRequestStatus = 'fresh' | 'pending' | 'valid' | 'error';
 export type CouponStatus = 'fresh' | 'pending' | 'applied' | 'invalid' | 'rejected' | 'error';
 
 export type ShoppingCartAction =
+	| { type: 'CLEAR_QUEUED_ACTIONS' }
 	| { type: 'REMOVE_CART_ITEM'; uuidToRemove: string }
 	| { type: 'ADD_CART_ITEM'; requestCartProductToAdd: RequestCartProduct }
 	| { type: 'SET_LOCATION'; location: CartLocation }
@@ -122,4 +123,5 @@ export type ShoppingCartState = {
 	loadingError?: string;
 	variantRequestStatus: VariantRequestStatus;
 	variantSelectOverride: { uuid: string; overrideSelectedProductSlug: string }[];
+	queuedActions: ShoppingCartAction[];
 };

--- a/client/my-sites/checkout/composite-checkout/hooks/use-update-cart-location-when-payment-method-changes.js
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-update-cart-location-when-payment-method-changes.js
@@ -1,0 +1,21 @@
+/**
+ * External dependencies
+ */
+import { useEffect, useRef } from 'react';
+
+export default function useUpdateCartLocationWhenPaymentMethodChanges(
+	activePaymentMethod,
+	updateCartContactDetails
+) {
+	const previousPaymentMethodId = useRef();
+	const hasInitialized = useRef( false );
+	useEffect( () => {
+		if ( activePaymentMethod?.id && activePaymentMethod.id !== previousPaymentMethodId.current ) {
+			previousPaymentMethodId.current = activePaymentMethod.id;
+			if ( hasInitialized.current ) {
+				updateCartContactDetails();
+			}
+			hasInitialized.current = true;
+		}
+	}, [ activePaymentMethod, updateCartContactDetails ] );
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This modifies the `useCachedDomainContactDetails()` React hook to also update the shopping-cart endpoint when it gets new cached details. Previously, if the user had cached contact details, those details would never be sent to the shopping-cart endpoint, with the result that taxes may not be displayed correctly.

In addition, this fixes an edge case bug which happened to be triggered by these changes. If you try to do most any cart action (eg: update the tax data, add a coupon, remove an item) while the cart is initially loading, it will trigger a race condition and can result in weird things happening (notably, a redirect to the plans page) since the cart will attempt to update and save the result while it's still waiting for the initial state.

To solve this, I added code such that if a cart action comes in while the initial cart is loading, the action gets queued instead of run, and then all queued actions are run in order once the cart has loaded.

Fixes https://github.com/Automattic/wp-calypso/issues/45189

#### Testing instructions

- Use an account that has no cached contact details (one that has not made a domain product purchase).
- Add a domain to your cart and visit checkout.
- Verify that the contact form loads without any JS errors.
- Use an account that has cached contact details (one that has purchased a domain product before) and that those details include a location which is taxable (eg: country `US`, postal code `10001`).
- Add a plan or domain to your cart and visit checkout.
- Verify that the contact form loads but that the contact step is marked completed (once the automatic validation completes) and you see the payment method step instead.
- Verify that taxes are displayed.