### PR TITLE
Remove extra Security options when editing cart

### DIFF
--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -271,7 +271,8 @@ export const TYPE_PERSONAL = 'TYPE_PERSONAL';
 export const TYPE_PREMIUM = 'TYPE_PREMIUM';
 export const TYPE_BUSINESS = 'TYPE_BUSINESS';
 export const TYPE_ECOMMERCE = 'TYPE_ECOMMERCE';
-export const TYPE_SECURITY = 'TYPE_SECURITY';
+export const TYPE_SECURITY_DAILY = 'TYPE_SECURITY_DAILY';
+export const TYPE_SECURITY_REALTIME = 'TYPE_SECURITY_REALTIME';
 export const TYPE_ALL = 'TYPE_ALL';
 
 export function isMonthly( plan ) {

--- a/client/lib/plans/plans-list.js
+++ b/client/lib/plans/plans-list.js
@@ -371,7 +371,7 @@ const getPlanBusinessDetails = () => ( {
 
 const getPlanJetpackSecurityDailyDetails = () => ( {
 	group: constants.GROUP_JETPACK,
-	type: constants.TYPE_SECURITY,
+	type: constants.TYPE_SECURITY_DAILY,
 	getTitle: () => translate( 'Security {{em}}Daily{{/em}}', { components: { em: <em /> } } ),
 	getAudience: () => translate(),
 	availableFor: ( plan ) =>
@@ -412,7 +412,7 @@ const getPlanJetpackSecurityDailyDetails = () => ( {
 
 const getPlanJetpackSecurityRealtimeDetails = () => ( {
 	group: constants.GROUP_JETPACK,
-	type: constants.TYPE_SECURITY,
+	type: constants.TYPE_SECURITY_REALTIME,
 	getTitle: () => translate( 'Security {{em}}Real-time{{/em}}', { components: { em: <em /> } } ),
 	getAudience: () => translate(),
 	availableFor: ( plan ) =>
@@ -1259,7 +1259,7 @@ export const PLANS_LIST = {
 	},
 
 	[ constants.PLAN_JETPACK_SECURITY_REALTIME_MONTHLY ]: {
-		...getPlanJetpackSecurityDailyDetails(),
+		...getPlanJetpackSecurityRealtimeDetails(),
 		...getMonthlyTimeframe(),
 		getAnnualSlug: () => constants.PLAN_JETPACK_SECURITY_REALTIME,
 		getStoreSlug: () => constants.PLAN_JETPACK_SECURITY_REALTIME_MONTHLY,


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR removes the Security Real-time items when editing a cart that has Security Daily, and vice-versa.

### Implementation notes

Using two different types for Security Daily and Real-time doesn't seem to have any impact on the rest of the code, though conceptually it feels a bit odd. Another solution could be to update the logic in `useVariantPlanProductSlugs`, but it felt like a rabbit hole for the time being.

### Testing instructions

- Visit the _Plans_ section with the offer reset flow enabled
- Try to purchase one of the two Security options, _Daily_ or _Real-time_
- In the checkout page, edit the cart
- You should be able to select a different term, but not a different option
- Repeat these steps for the other option

### Screenshots

Cart
<img width="585" alt="Screen Shot 2020-08-25 at 11 57 16 AM" src="https://user-images.githubusercontent.com/1620183/91214350-f246a400-e6e0-11ea-8cf5-2bac5f104486.png">

Cart edition before
![image](https://user-images.githubusercontent.com/1620183/91214416-07233780-e6e1-11ea-8cd1-209fa0a158bc.png)


Cart edition after
<img width="582" alt="Screen Shot 2020-08-25 at 11 57 20 AM" src="https://user-images.githubusercontent.com/1620183/91214367-f70b5800-e6e0-11ea-8b62-922a2595ac5c.png">
