### PR TITLE
Forms: Remove global form radio styles

### DIFF
--- a/client/assets/stylesheets/shared/_forms.scss
+++ b/client/assets/stylesheets/shared/_forms.scss
@@ -12,7 +12,6 @@ input[type='email'],
 input[type='number'],
 input[type='password'],
 input[type='checkbox'],
-input[type='radio'],
 input[type='tel'],
 input[type='url'],
 textarea {
@@ -45,8 +44,7 @@ input[type='url'] {
 
 /*Checkbooms*/
 
-input[type='checkbox'],
-input[type='radio'] {
+input[type='checkbox'] {
 	clear: none;
 	cursor: pointer;
 	display: inline-block;
@@ -63,8 +61,7 @@ input[type='radio'] {
 	appearance: none;
 }
 
-input[type='checkbox'] + span,
-input[type='radio'] + span {
+input[type='checkbox'] + span {
 	display: block;
 	margin-left: 24px;
 }
@@ -83,30 +80,6 @@ input[type='checkbox'] {
 
 	&:disabled:checked::before {
 		color: var( --color-neutral-20 );
-	}
-}
-
-input[type='radio'] {
-	border-radius: 50%;
-	margin-right: 4px;
-	line-height: 10px;
-
-	&:checked::before {
-		float: left;
-		display: inline-block;
-		content: '\2022';
-		margin: 3px;
-		width: 8px;
-		height: 8px;
-		text-indent: -9999px;
-		background: var( --color-primary );
-		vertical-align: middle;
-		border-radius: 50%;
-		animation: grow 0.2s ease-in-out;
-	}
-
-	&:disabled:checked::before {
-		background: var( --color-neutral-0 );
 	}
 }
 

--- a/client/blocks/nps-survey/recommendation-option.jsx
+++ b/client/blocks/nps-survey/recommendation-option.jsx
@@ -6,6 +6,12 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classNames from 'classnames';
 
+/**
+ * Internal dependencies
+ */
+import FormRadio from 'wp-calypso-client/components/forms/form-radio';
+import FormLabel from 'wp-calypso-client/components/forms/form-label';
+
 class RecommendationOption extends Component {
 	constructor( props ) {
 		super( props );
@@ -28,17 +34,16 @@ class RecommendationOption extends Component {
 		} );
 
 		return (
-			<label className={ className }>
-				<input
-					type="radio"
+			<FormLabel className={ className }>
+				<FormRadio
 					name="nps-survey-recommendation-option"
 					value={ this.props.value }
 					checked={ this.props.selected }
 					disabled={ this.props.disabled }
 					onChange={ this.handleChange }
+					label={ this.props.value }
 				/>
-				<span>{ this.props.value }</span>
-			</label>
+			</FormLabel>
 		);
 	}
 }

--- a/client/blocks/subscription-length-picker/option.jsx
+++ b/client/blocks/subscription-length-picker/option.jsx
@@ -14,6 +14,7 @@ import { localize } from 'i18n-calypso';
 
 import Badge from 'components/badge';
 import { TERM_ANNUALLY, TERM_BIENNIALLY, TERM_MONTHLY } from 'lib/plans/constants';
+import FormRadio from 'wp-calypso-client/components/forms/form-radio';
 
 const TYPE_NEW_SALE = 'new-sale';
 const TYPE_UPGRADE = 'upgrade';
@@ -55,9 +56,8 @@ export class SubscriptionLengthOption extends React.Component {
 		return (
 			<label className={ className } htmlFor={ this.htmlId }>
 				<div className="subscription-length-picker__option-radio-wrapper">
-					<input
+					<FormRadio
 						id={ this.htmlId }
-						type="radio"
 						className="subscription-length-picker__option-radio"
 						checked={ checked }
 						onChange={ this.handleChange }

--- a/client/components/domains/registrant-extra-info/fr-form.jsx
+++ b/client/components/domains/registrant-extra-info/fr-form.jsx
@@ -141,8 +141,8 @@ class RegistrantExtraInfoFrForm extends React.PureComponent {
 							id="registrantType"
 							checked={ 'individual' === registrantType }
 							onChange={ this.handleChangeContactExtraEvent }
+							label={ translate( 'An individual' ) }
 						/>
-						<span>{ translate( 'An individual' ) }</span>
 					</FormLabel>
 
 					<FormLabel>
@@ -151,8 +151,8 @@ class RegistrantExtraInfoFrForm extends React.PureComponent {
 							id="registrantType"
 							checked={ 'organization' === registrantType }
 							onChange={ this.handleChangeContactExtraEvent }
+							label={ translate( 'A company or organization' ) }
 						/>
-						<span>{ translate( 'A company or organization' ) }</span>
 					</FormLabel>
 				</FormFieldset>
 

--- a/client/components/forms/docs/example.jsx
+++ b/client/components/forms/docs/example.jsx
@@ -255,8 +255,8 @@ class FormFields extends React.PureComponent {
 								value="first"
 								checked={ 'first' === this.state.checkedRadio }
 								onChange={ this.handleRadioChange }
+								label="First radio"
 							/>
-							<span>First radio</span>
 						</FormLabel>
 
 						<FormLabel>
@@ -264,8 +264,8 @@ class FormFields extends React.PureComponent {
 								value="second"
 								checked={ 'second' === this.state.checkedRadio }
 								onChange={ this.handleRadioChange }
+								label="Second radio"
 							/>
-							<span>Second radio</span>
 						</FormLabel>
 					</FormFieldset>
 

--- a/client/components/forms/form-radio-with-thumbnail/index.jsx
+++ b/client/components/forms/form-radio-with-thumbnail/index.jsx
@@ -29,8 +29,7 @@ const FormRadioWithThumbnail = ( { label, thumbnail, ...otherProps } ) => {
 				>
 					{ imageUrl && <img src={ imageUrl } alt={ label } /> }
 				</div>
-				<FormRadio { ...otherProps } />
-				<span>{ label }</span>
+				<FormRadio label={ label } { ...otherProps } />
 			</FormLabel>
 		</div>
 	);

--- a/client/components/forms/form-radio/index.jsx
+++ b/client/components/forms/form-radio/index.jsx
@@ -4,9 +4,15 @@
 
 import React from 'react';
 import classnames from 'classnames';
+import { isNil } from 'lodash';
 
-const FormRadio = ( { className, ...otherProps } ) => (
-	<input { ...otherProps } type="radio" className={ classnames( className, 'form-radio' ) } />
+import './style.scss';
+
+const FormRadio = ( { className, label, ...otherProps } ) => (
+	<>
+		<input { ...otherProps } type="radio" className={ classnames( className, 'form-radio' ) } />
+		{ ! isNil( label ) && <span className="form-radio__label">{ label }</span> }
+	</>
 );
 
 export default FormRadio;

--- a/client/components/forms/form-radio/style.scss
+++ b/client/components/forms/form-radio/style.scss
@@ -3,15 +3,12 @@
 
 	clear: none;
 	cursor: pointer;
-	display: inline-block;
-	line-height: 0;
 	height: 16px;
 	margin: 2px 0 0;
 	float: left;
 	outline: 0;
 	padding: 0;
 	text-align: center;
-	vertical-align: middle;
 	width: 16px;
 	min-width: 16px;
 	appearance: none;
@@ -22,14 +19,12 @@
 
 	&:checked::before {
 		float: left;
-		display: inline-block;
 		content: '\2022';
 		margin: 3px;
 		width: 8px;
 		height: 8px;
 		text-indent: -9999px;
 		background: var( --color-primary );
-		vertical-align: middle;
 		border-radius: 50%;
 		animation: grow 0.2s ease-in-out;
 	}

--- a/client/components/forms/form-radio/style.scss
+++ b/client/components/forms/form-radio/style.scss
@@ -1,0 +1,45 @@
+.form-radio {
+	@extend %form-field;
+
+	clear: none;
+	cursor: pointer;
+	display: inline-block;
+	line-height: 0;
+	height: 16px;
+	margin: 2px 0 0;
+	float: left;
+	outline: 0;
+	padding: 0;
+	text-align: center;
+	vertical-align: middle;
+	width: 16px;
+	min-width: 16px;
+	appearance: none;
+
+	border-radius: 50%;
+	margin-right: 4px;
+	line-height: 10px;
+
+	&:checked::before {
+		float: left;
+		display: inline-block;
+		content: '\2022';
+		margin: 3px;
+		width: 8px;
+		height: 8px;
+		text-indent: -9999px;
+		background: var( --color-primary );
+		vertical-align: middle;
+		border-radius: 50%;
+		animation: grow 0.2s ease-in-out;
+	}
+
+	&:disabled:checked::before {
+		background: var( --color-neutral-0 );
+	}
+}
+
+.form-radio__label {
+	display: block;
+	margin-left: 24px;
+}

--- a/client/components/forms/form-radios-bar/index.jsx
+++ b/client/components/forms/form-radios-bar/index.jsx
@@ -31,7 +31,6 @@ const FormRadiosBar = ( { isThumbnail, checked, onChange, items } ) => {
 				) : (
 					<FormLabel key={ item.value + i }>
 						<FormRadio checked={ checked === item.value } onChange={ onChange } { ...item } />
-						<span>{ item.label }</span>
 					</FormLabel>
 				)
 			) }

--- a/client/components/marketing-survey/cancel-auto-renewal-form/index.jsx
+++ b/client/components/marketing-survey/cancel-auto-renewal-form/index.jsx
@@ -114,8 +114,8 @@ class CancelAutoRenewalForm extends Component {
 					value={ value }
 					onChange={ this.onRadioChange }
 					checked={ this.state.response === value }
+					label={ text }
 				/>
-				<span>{ text }</span>
 			</FormLabel>
 		);
 	};

--- a/client/components/marketing-survey/cancel-purchase-form/radio-option.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/radio-option.jsx
@@ -40,8 +40,8 @@ export const radioOption = (
 				value={ key }
 				checked={ key === radioValue }
 				onChange={ onRadioChange }
+				label={ radioPrompt }
 			/>
-			<span>{ radioPrompt }</span>
 			{ key === radioValue && textInput }
 		</FormLabel>
 	);

--- a/client/components/multiple-choice-question/answer.jsx
+++ b/client/components/multiple-choice-question/answer.jsx
@@ -29,8 +29,8 @@ const MultipleChoiceAnswer = ( {
 				} }
 				checked={ isSelected }
 				disabled={ disabled }
+				label={ answerText }
 			/>
-			<span>{ answerText }</span>
 			{ isSelected && (
 				<div className="multiple-choice-question__answer-item-content">
 					{ textInput && (

--- a/client/components/multiple-choice-question/test/__snapshots__/index.js.snap
+++ b/client/components/multiple-choice-question/test/__snapshots__/index.js.snap
@@ -20,7 +20,9 @@ exports[`MultipleChoiceQuestion should render with the minimum required properti
       type="radio"
       value="test-answer-1"
     />
-    <span>
+    <span
+      className="form-radio__label"
+    >
       Test Answer One
     </span>
   </label>
@@ -35,7 +37,9 @@ exports[`MultipleChoiceQuestion should render with the minimum required properti
       type="radio"
       value="test-answer-2"
     />
-    <span>
+    <span
+      className="form-radio__label"
+    >
       Test Answer Two
     </span>
   </label>
@@ -50,7 +54,9 @@ exports[`MultipleChoiceQuestion should render with the minimum required properti
       type="radio"
       value="test-answer-3"
     />
-    <span>
+    <span
+      className="form-radio__label"
+    >
       Test Answer Three
     </span>
   </label>
@@ -65,7 +71,9 @@ exports[`MultipleChoiceQuestion should render with the minimum required properti
       type="radio"
       value="test-answer-4"
     />
-    <span>
+    <span
+      className="form-radio__label"
+    >
       Test Answer Four
     </span>
   </label>

--- a/client/components/tinymce/plugins/wpcom-view/views/contact-form/preview-fields.jsx
+++ b/client/components/tinymce/plugins/wpcom-view/views/contact-form/preview-fields.jsx
@@ -11,6 +11,9 @@ import PreviewFieldset from './preview-fieldset';
 import PreviewLegend from './preview-legend';
 import PreviewRequired from './preview-required';
 
+import FormLabel from 'wp-calypso-client/components/forms/form-label';
+import FormRadio from 'wp-calypso-client/components/forms/form-radio';
+
 const textField = ( field, index ) => (
 	<PreviewFieldset key={ 'contact-form-field-' + index }>
 		<PreviewLegend { ...field } />
@@ -50,10 +53,9 @@ const radio = ( field, index ) => (
 	<PreviewFieldset key={ 'contact-form-field-' + index }>
 		<PreviewLegend { ...field } />
 		{ [].concat( field.options.split( ',' ) ).map( ( option, optionIndex ) => (
-			<label key={ 'contact-form-radio-' + optionIndex }>
-				<input type="radio" />
-				<span>{ option }</span>
-			</label>
+			<FormLabel key={ 'contact-form-radio-' + optionIndex }>
+				<FormRadio label={ option } />
+			</FormLabel>
 		) ) }
 	</PreviewFieldset>
 );

--- a/client/extensions/woocommerce/app/settings/payments/payment-method-paypal.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-paypal.js
@@ -88,10 +88,8 @@ class PaymentMethodPaypal extends Component {
 							value="sale"
 							checked={ 'sale' === settings.paymentaction.value }
 							onChange={ this.onEditFieldHandler }
+							label={ translate( 'Authorize and charge the customers credit card automatically' ) }
 						/>
-						<span>
-							{ translate( 'Authorize and charge the customers credit card automatically' ) }
-						</span>
 					</FormLabel>
 					<FormLabel>
 						<FormRadio
@@ -99,8 +97,8 @@ class PaymentMethodPaypal extends Component {
 							value="authorization"
 							checked={ 'authorization' === settings.paymentaction.value }
 							onChange={ this.onEditFieldHandler }
+							label={ translate( 'Authorize the customers credit card but charge manually' ) }
 						/>
-						<span>{ translate( 'Authorize the customers credit card but charge manually' ) }</span>
 					</FormLabel>
 				</FormFieldset>
 			</Dialog>

--- a/client/extensions/woocommerce/app/settings/payments/stripe/payment-method-stripe-connect-prompt.js
+++ b/client/extensions/woocommerce/app/settings/payments/stripe/payment-method-stripe-connect-prompt.js
@@ -37,8 +37,8 @@ class StripeConnectPrompt extends Component {
 							value={ isCreateSelected }
 							checked={ isCreateSelected }
 							onChange={ onSelectCreate }
+							label={ translate( 'Create a new Stripe account' ) }
 						/>
-						<span>{ translate( 'Create a new Stripe account' ) }</span>
 					</FormLabel>
 
 					<FormLabel>
@@ -46,8 +46,8 @@ class StripeConnectPrompt extends Component {
 							value={ ! isCreateSelected }
 							checked={ ! isCreateSelected }
 							onChange={ onSelectConnect }
+							label={ translate( 'I already have a Stripe account' ) }
 						/>
-						<span>{ translate( 'I already have a Stripe account' ) }</span>
 					</FormLabel>
 				</FormFieldset>
 			</div>

--- a/client/extensions/woocommerce/components/auth-capture-toggle/index.js
+++ b/client/extensions/woocommerce/components/auth-capture-toggle/index.js
@@ -33,10 +33,8 @@ class AuthCaptureToggle extends Component {
 						value="yes"
 						checked={ ! isAuthOnlyMode }
 						onChange={ onSelectCapture }
+						label={ translate( 'Authorize and charge the customers credit card automatically' ) }
 					/>
-					<span>
-						{ translate( 'Authorize and charge the customers credit card automatically' ) }
-					</span>
 				</FormLabel>
 				<FormLabel>
 					<FormRadio
@@ -44,8 +42,8 @@ class AuthCaptureToggle extends Component {
 						value="no"
 						checked={ isAuthOnlyMode }
 						onChange={ onSelectAuthOnly }
+						label={ translate( "Authorize the customer's credit card but charge manually" ) }
 					/>
-					<span>{ translate( "Authorize the customer's credit card but charge manually" ) }</span>
 				</FormLabel>
 			</FormFieldset>
 		);

--- a/client/extensions/woocommerce/woocommerce-services/components/radio-buttons/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/components/radio-buttons/index.js
@@ -15,13 +15,19 @@ import FormRadio from 'components/forms/form-radio';
 import sanitizeHTML from 'woocommerce/woocommerce-services/lib/utils/sanitize-html';
 import FieldDescription from 'woocommerce/woocommerce-services/components/field-description';
 
+import './style.scss';
+
 const RadioButton = ( { value, currentValue, setValue, description } ) => {
 	const onChange = () => setValue( value );
 
 	return (
 		<FormLabel>
 			<FormRadio value={ value } checked={ value === currentValue } onChange={ onChange } />
-			<span dangerouslySetInnerHTML={ sanitizeHTML( description ) } />
+			<div
+				// eslint-disable-next-line wpcalypso/jsx-classname-namespace
+				className="woocommerce-services-radio-buttons__description"
+				dangerouslySetInnerHTML={ sanitizeHTML( description ) }
+			/>
 		</FormLabel>
 	);
 };

--- a/client/extensions/woocommerce/woocommerce-services/components/radio-buttons/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/components/radio-buttons/style.scss
@@ -1,0 +1,3 @@
+.woocommerce-services-radio-buttons__description {
+    font-weight: 600;
+}

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/style.scss
@@ -43,9 +43,12 @@
 	@include breakpoint-deprecated( '>960px' ) {
 		flex-direction: row;
 	}
+
+	.form-radio__label {
+		font-weight: 600;
+	}
 }
 
-.address-step__suggestion-title,
 .address-step__unverifiable-title {
 	font-weight: 600;
 }

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/suggestion.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/suggestion.js
@@ -51,17 +51,15 @@ const AddressSuggestion = ( {
 				<RadioButton
 					checked={ ! selectNormalized }
 					onChange={ onToggleSelectNormalizedAddress( false ) }
+					label={ translate( 'Address entered' ) }
 				>
-					<span className="address-step__suggestion-title">{ translate( 'Address entered' ) }</span>
 					<AddressSummary values={ values } countryNames={ countryNames } />
 				</RadioButton>
 				<RadioButton
 					checked={ selectNormalized }
 					onChange={ onToggleSelectNormalizedAddress( true ) }
+					label={ translate( 'Suggested address' ) }
 				>
-					<span className="address-step__suggestion-title">
-						{ translate( 'Suggested address' ) }
-					</span>
 					<AddressSummary
 						values={ normalized }
 						originalValues={ values }

--- a/client/extensions/wp-super-cache/components/advanced/caching.jsx
+++ b/client/extensions/wp-super-cache/components/advanced/caching.jsx
@@ -91,12 +91,10 @@ const Caching = ( {
 								name="cache_type"
 								onChange={ handleRadio }
 								value="PHP"
-							/>
-							<span>
-								{ translate( 'Simple {{em}}(Recommended){{/em}}', {
+								label={ translate( 'Simple {{em}}(Recommended){{/em}}', {
 									components: { em: <em /> },
 								} ) }
-							</span>
+							/>
 						</FormLabel>
 
 						<FormLabel>
@@ -106,8 +104,8 @@ const Caching = ( {
 								name="cache_type"
 								onChange={ handleRadio }
 								value="mod_rewrite"
+								label={ translate( 'Expert' ) }
 							/>
-							<span>{ translate( 'Expert' ) }</span>
 						</FormLabel>
 						<FormSettingExplanation>
 							{ translate(

--- a/client/extensions/wp-super-cache/components/advanced/expiry-time.jsx
+++ b/client/extensions/wp-super-cache/components/advanced/expiry-time.jsx
@@ -80,19 +80,21 @@ const ExpiryTime = ( {
 						name="cache_schedule_type"
 						onChange={ handleRadio }
 						value="interval"
+						label={
+							<>
+								{ translate( 'Timer' ) }
+								<FormTextInput
+									disabled={ isDisabled || 'interval' !== cache_schedule_type }
+									min="1"
+									onChange={ handleChange( 'cache_time_interval' ) }
+									step="1"
+									type="number"
+									value={ cache_time_interval || '' }
+								/>
+								{ translate( 'seconds' ) }
+							</>
+						}
 					/>
-					<span>
-						{ translate( 'Timer' ) }
-						<FormTextInput
-							disabled={ isDisabled || 'interval' !== cache_schedule_type }
-							min="1"
-							onChange={ handleChange( 'cache_time_interval' ) }
-							step="1"
-							type="number"
-							value={ cache_time_interval || '' }
-						/>
-						{ translate( 'seconds' ) }
-					</span>
 				</FormLabel>
 				<FormSettingExplanation isIndented>
 					{ translate( 'Check for stale cached files every interval seconds.' ) }
@@ -105,16 +107,18 @@ const ExpiryTime = ( {
 						name="cache_schedule_type"
 						onChange={ handleRadio }
 						value="time"
+						label={
+							<>
+								{ translate( 'Clock' ) }
+								<FormTextInput
+									disabled={ isDisabled || 'time' !== cache_schedule_type }
+									onChange={ handleChange( 'cache_scheduled_time' ) }
+									value={ cache_scheduled_time || '' }
+								/>
+								{ translate( 'HH:MM' ) }
+							</>
+						}
 					/>
-					<span>
-						{ translate( 'Clock' ) }
-						<FormTextInput
-							disabled={ isDisabled || 'time' !== cache_schedule_type }
-							onChange={ handleChange( 'cache_scheduled_time' ) }
-							value={ cache_scheduled_time || '' }
-						/>
-						{ translate( 'HH:MM' ) }
-					</span>
 				</FormLabel>
 				<FormSettingExplanation isIndented>
 					{ translate(

--- a/client/lib/abtest/test-helper/index.js
+++ b/client/lib/abtest/test-helper/index.js
@@ -15,6 +15,7 @@ import classNames from 'classnames';
  */
 import { Card } from '@automattic/components';
 import { getAllTests, saveABTestVariation } from 'lib/abtest';
+import FormRadio from 'wp-calypso-client/components/forms/form-radio';
 
 /**
  * Style dependencies
@@ -44,9 +45,8 @@ class Test extends React.Component {
 									'test-helper__current-variation': variation === currentVariation,
 								} ) }
 							>
-								<input
+								<FormRadio
 									className="test-helper__choice-indicator"
-									type="radio"
 									checked={ variation === currentVariation }
 									readOnly
 								/>

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -684,8 +684,8 @@ const Account = createReactClass( {
 								onClick={ this.handleUsernameChangeBlogRadio }
 								value={ key }
 								checked={ key === this.state.usernameAction }
+								label={ message }
 							/>
-							<span>{ message }</span>
 						</FormLabel>
 					) )
 				}

--- a/client/me/purchases/cancel-purchase/refund-information.jsx
+++ b/client/me/purchases/cancel-purchase/refund-information.jsx
@@ -124,27 +124,29 @@ const CancelPurchaseRefundInformation = ( {
 								value="keep"
 								checked={ ! cancelBundledDomain }
 								onChange={ onCancelBundledDomainChange }
+								label={
+									<>
+										{ i18n.translate( 'Cancel the plan, but keep %(domain)s.', {
+											args: {
+												domain: includedDomainPurchase.meta,
+											},
+										} ) }
+										<br />
+										{ i18n.translate(
+											"You'll receive a partial refund of %(refundAmount)s -- the cost of the %(productName)s " +
+												'plan, minus %(domainCost)s for the domain. There will be no change to your domain ' +
+												"registration, and you're free to use it on WordPress.com or transfer it elsewhere.",
+											{
+												args: {
+													productName: getName( purchase ),
+													domainCost: includedDomainPurchase.costToUnbundleText,
+													refundAmount: purchase.refundText,
+												},
+											}
+										) }
+									</>
+								}
 							/>
-							<span>
-								{ i18n.translate( 'Cancel the plan, but keep %(domain)s.', {
-									args: {
-										domain: includedDomainPurchase.meta,
-									},
-								} ) }
-								<br />
-								{ i18n.translate(
-									"You'll receive a partial refund of %(refundAmount)s -- the cost of the %(productName)s " +
-										'plan, minus %(domainCost)s for the domain. There will be no change to your domain ' +
-										"registration, and you're free to use it on WordPress.com or transfer it elsewhere.",
-									{
-										args: {
-											productName: getName( purchase ),
-											domainCost: includedDomainPurchase.costToUnbundleText,
-											refundAmount: purchase.refundText,
-										},
-									}
-								) }
-							</span>
 						</FormLabel>,
 						<FormLabel key="cancel_bundled_domain">
 							<FormRadio
@@ -152,27 +154,29 @@ const CancelPurchaseRefundInformation = ( {
 								value="cancel"
 								checked={ cancelBundledDomain }
 								onChange={ onCancelBundledDomainChange }
+								label={
+									<>
+										{ i18n.translate( 'Cancel the plan {{em}}and{{/em}} the domain "%(domain)s."', {
+											args: {
+												domain: includedDomainPurchase.meta,
+											},
+											components: {
+												em: <em />,
+											},
+										} ) }
+										<br />
+										{ i18n.translate(
+											"You'll receive a full refund of %(planCost)s. The domain will be cancelled, and it's possible " +
+												"you'll lose it permanently.",
+											{
+												args: {
+													planCost: planCostText,
+												},
+											}
+										) }
+									</>
+								}
 							/>
-							<span>
-								{ i18n.translate( 'Cancel the plan {{em}}and{{/em}} the domain "%(domain)s."', {
-									args: {
-										domain: includedDomainPurchase.meta,
-									},
-									components: {
-										em: <em />,
-									},
-								} ) }
-								<br />
-								{ i18n.translate(
-									"You'll receive a full refund of %(planCost)s. The domain will be cancelled, and it's possible " +
-										"you'll lose it permanently.",
-									{
-										args: {
-											planCost: planCostText,
-										},
-									}
-								) }
-							</span>
 						</FormLabel>
 					);
 

--- a/client/my-sites/checkout/composite-checkout/components/radio-button.js
+++ b/client/my-sites/checkout/composite-checkout/components/radio-button.js
@@ -118,6 +118,21 @@ const RadioButtonWrapper = styled.div`
 const Radio = styled.input`
 	position: absolute;
 	opacity: 0;
+
+	clear: none;
+	cursor: pointer;
+	display: inline-block;
+	line-height: 0;
+	height: 16px;
+	margin: 2px 0 0;
+	float: left;
+	outline: 0;
+	padding: 0;
+	text-align: center;
+	vertical-align: middle;
+	width: 16px;
+	min-width: 16px;
+	appearance: none;
 `;
 
 const Label = styled.label`

--- a/client/my-sites/domains/domain-management/list/item.jsx
+++ b/client/my-sites/domains/domain-management/list/item.jsx
@@ -20,6 +20,7 @@ import Spinner from 'components/spinner';
 import { withLocalizedMoment } from 'components/localized-moment';
 import TrackComponentView from 'lib/analytics/track-component-view';
 import DomainNotice from 'my-sites/domains/domain-management/components/domain-notice';
+import FormRadio from 'wp-calypso-client/components/forms/form-radio';
 
 class ListItem extends React.PureComponent {
 	static propTypes = {
@@ -144,10 +145,9 @@ class ListItem extends React.PureComponent {
 		}
 
 		return (
-			<input
+			<FormRadio
 				id={ this.getInputId() }
 				className="domain-management-list-item__radio"
-				type="radio"
 				checked={ this.props.isSelected }
 				onChange={ noop }
 			/>

--- a/client/my-sites/earn/ads/form-settings.jsx
+++ b/client/my-sites/earn/ads/form-settings.jsx
@@ -165,8 +165,8 @@ class AdsFormSettings extends Component {
 						checked={ 'yes' === this.state.show_to_logged_in }
 						onChange={ this.handleChange }
 						disabled={ this.props.isLoading }
+						label={ translate( 'Run ads for all users' ) }
 					/>
-					<span>{ translate( 'Run ads for all users' ) }</span>
 				</FormLabel>
 
 				<FormLabel>
@@ -176,8 +176,8 @@ class AdsFormSettings extends Component {
 						checked={ 'no' === this.state.show_to_logged_in }
 						onChange={ this.handleChange }
 						disabled={ this.props.isLoading }
+						label={ translate( 'Run ads only for logged-out users (less revenue)' ) }
 					/>
-					<span>{ translate( 'Run ads only for logged-out users (less revenue)' ) }</span>
 				</FormLabel>
 
 				<FormLabel>
@@ -187,8 +187,8 @@ class AdsFormSettings extends Component {
 						checked={ 'pause' === this.state.show_to_logged_in }
 						onChange={ this.handleChange }
 						disabled={ this.props.isLoading }
+						label={ translate( 'Pause ads (no revenue)' ) }
 					/>
-					<span>{ translate( 'Pause ads (no revenue)' ) }</span>
 				</FormLabel>
 			</FormFieldset>
 		);

--- a/client/my-sites/exporter/export-card/post-type-options.jsx
+++ b/client/my-sites/exporter/export-card/post-type-options.jsx
@@ -66,8 +66,7 @@ class PostTypeOptions extends React.PureComponent {
 		return (
 			<div className="export-card__option-fieldset">
 				<Label>
-					<FormRadio checked={ isEnabled } onChange={ onSelect } />
-					<span>{ legend }</span>
+					<FormRadio checked={ isEnabled } onChange={ onSelect } label={ legend } />
 				</Label>
 
 				{ description && (

--- a/client/my-sites/marketing/buttons/style.jsx
+++ b/client/my-sites/marketing/buttons/style.jsx
@@ -13,6 +13,8 @@ import { recordTracksEvent } from 'lib/analytics/tracks';
 import { gaRecordEvent } from 'lib/analytics/ga';
 import getCurrentRouteParameterized from 'state/selectors/get-current-route-parameterized';
 import { getSelectedSiteId } from 'state/ui/selectors';
+import FormLabel from 'wp-calypso-client/components/forms/form-label';
+import FormRadio from 'wp-calypso-client/components/forms/form-radio';
 
 class SharingButtonsStyle extends React.Component {
 	static displayName = 'SharingButtonsStyle';
@@ -67,16 +69,15 @@ class SharingButtonsStyle extends React.Component {
 			},
 		].map( function ( option ) {
 			return (
-				<label key={ option.value }>
-					<input
+				<FormLabel key={ option.value }>
+					<FormRadio
 						name="sharing_button_style"
-						type="radio"
 						checked={ option.value === this.props.value }
 						onChange={ this.onChange.bind( null, option.value ) }
 						disabled={ this.props.disabled }
 					/>
 					{ option.label }
-				</label>
+				</FormLabel>
 			);
 		}, this );
 	};

--- a/client/my-sites/marketing/connections/account-dialog-account.jsx
+++ b/client/my-sites/marketing/connections/account-dialog-account.jsx
@@ -10,6 +10,7 @@ import Gridicon from 'components/gridicon';
  * Internal dependencies
  */
 import Image from 'components/image';
+import FormRadio from 'wp-calypso-client/components/forms/form-radio';
 
 /**
  * Style dependencies
@@ -27,8 +28,7 @@ const AccountDialogAccount = ( { account, conflicting, onChange, selected, defau
 			<label className="account-dialog-account__label">
 				{ conflicting && <Gridicon icon="notice" /> }
 				{ ! account.isConnected && (
-					<input
-						type="radio"
+					<FormRadio
 						onChange={ onChange }
 						checked={ selected }
 						className="account-dialog-account__input"

--- a/client/my-sites/migrate/components/import-type-choice/index.jsx
+++ b/client/my-sites/migrate/components/import-type-choice/index.jsx
@@ -9,6 +9,7 @@ import classNames from 'classnames';
  * Internal dependencies
  */
 import Badge from 'components/badge';
+import FormRadio from 'components/forms/form-radio';
 
 import './style.scss';
 import PropTypes from 'prop-types';
@@ -77,7 +78,7 @@ export default class ImportTypeChoice extends Component {
 				data-key={ key }
 				key={ key }
 			>
-				<input type="radio" checked={ this.state.activeItem === key } readOnly={ true } />
+				<FormRadio checked={ this.state.activeItem === key } readOnly={ true } />
 				<div className="import-type-choice__option-data">
 					<div className="import-type-choice__option-header">
 						<p className="import-type-choice__option-title">{ item.title }</p>

--- a/client/my-sites/people/delete-user/index.jsx
+++ b/client/my-sites/people/delete-user/index.jsx
@@ -258,9 +258,8 @@ class DeleteUser extends React.Component {
 								onChange={ this.handleRadioChange }
 								value="reassign"
 								checked={ 'reassign' === this.state.radioOption }
+								label={ this.getTranslatedAssignLabel() }
 							/>
-
-							<span>{ this.getTranslatedAssignLabel() }</span>
 						</FormLabel>
 
 						{ this.state.authorSelectorToggled ? (
@@ -273,17 +272,16 @@ class DeleteUser extends React.Component {
 								onChange={ this.handleRadioChange }
 								value="delete"
 								checked={ 'delete' === this.state.radioOption }
+								label={
+									this.props.user.name
+										? translate( 'Delete all content created by %(username)s', {
+												args: {
+													username: this.props.user.name ? this.props.user.name : '',
+												},
+										  } )
+										: translate( 'Delete all content created by this user' )
+								}
 							/>
-
-							<span>
-								{ this.props.user.name
-									? translate( 'Delete all content created by %(username)s', {
-											args: {
-												username: this.props.user.name ? this.props.user.name : '',
-											},
-									  } )
-									: translate( 'Delete all content created by this user' ) }
-							</span>
 						</FormLabel>
 					</FormFieldset>
 

--- a/client/my-sites/site-settings/date-time-format/date-format-option.jsx
+++ b/client/my-sites/site-settings/date-time-format/date-format-option.jsx
@@ -35,8 +35,8 @@ export const DateFormatOption = ( {
 					name="date_format"
 					onChange={ setDateFormat }
 					value={ format }
+					label={ phpToMomentDatetimeFormat( localizedDate, format ) }
 				/>
-				<span>{ phpToMomentDatetimeFormat( localizedDate, format ) }</span>
 			</FormLabel>
 		) ) }
 		<FormLabel className="date-time-format__custom-field">
@@ -46,25 +46,27 @@ export const DateFormatOption = ( {
 				name="date_format"
 				onChange={ setCustomDateFormat }
 				value={ dateFormat }
+				label={
+					<>
+						{ translate( 'Custom', { comment: 'Custom date/time format field' } ) }
+						<FormInput
+							disabled={ disabled }
+							name="date_format_custom"
+							onChange={ setCustomDateFormat }
+							type="text"
+							value={ dateFormat || '' }
+						/>
+						<FormSettingExplanation>
+							{ isCustom &&
+								dateFormat &&
+								translate( 'Preview: %s', {
+									args: phpToMomentDatetimeFormat( localizedDate, dateFormat ),
+									comment: 'Date/time format preview',
+								} ) }
+						</FormSettingExplanation>
+					</>
+				}
 			/>
-			<span>
-				{ translate( 'Custom', { comment: 'Custom date/time format field' } ) }
-				<FormInput
-					disabled={ disabled }
-					name="date_format_custom"
-					onChange={ setCustomDateFormat }
-					type="text"
-					value={ dateFormat || '' }
-				/>
-				<FormSettingExplanation>
-					{ isCustom &&
-						dateFormat &&
-						translate( 'Preview: %s', {
-							args: phpToMomentDatetimeFormat( localizedDate, dateFormat ),
-							comment: 'Date/time format preview',
-						} ) }
-				</FormSettingExplanation>
-			</span>
 		</FormLabel>
 	</FormFieldset>
 );

--- a/client/my-sites/site-settings/date-time-format/time-format-option.jsx
+++ b/client/my-sites/site-settings/date-time-format/time-format-option.jsx
@@ -37,8 +37,8 @@ export const TimeFormatOption = ( {
 					name="time_format"
 					onChange={ setTimeFormat }
 					value={ format }
+					label={ phpToMomentDatetimeFormat( localizedDate, format ) }
 				/>
-				<span>{ phpToMomentDatetimeFormat( localizedDate, format ) }</span>
 			</FormLabel>
 		) ) }
 		<FormLabel className="date-time-format__custom-field">
@@ -48,25 +48,27 @@ export const TimeFormatOption = ( {
 				name="time_format"
 				onChange={ setCustomTimeFormat }
 				value={ timeFormat }
+				label={
+					<>
+						{ translate( 'Custom', { comment: 'Custom date/time format field' } ) }
+						<FormInput
+							disabled={ disabled }
+							name="time_format_custom"
+							onChange={ setCustomTimeFormat }
+							type="text"
+							value={ timeFormat || '' }
+						/>
+						<FormSettingExplanation>
+							{ isCustom &&
+								timeFormat &&
+								translate( 'Preview: %s', {
+									args: phpToMomentDatetimeFormat( localizedDate, timeFormat ),
+									comment: 'Date/time format preview',
+								} ) }
+						</FormSettingExplanation>
+					</>
+				}
 			/>
-			<span>
-				{ translate( 'Custom', { comment: 'Custom date/time format field' } ) }
-				<FormInput
-					disabled={ disabled }
-					name="time_format_custom"
-					onChange={ setCustomTimeFormat }
-					type="text"
-					value={ timeFormat || '' }
-				/>
-				<FormSettingExplanation>
-					{ isCustom &&
-						timeFormat &&
-						translate( 'Preview: %s', {
-							args: phpToMomentDatetimeFormat( localizedDate, timeFormat ),
-							comment: 'Date/time format preview',
-						} ) }
-				</FormSettingExplanation>
-			</span>
 			<FormSettingExplanation>
 				<ExternalLink
 					href={ localizeUrl( 'https://wordpress.com/support/settings/time-settings/' ) }

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -324,8 +324,8 @@ export class SiteSettingsFormGeneral extends Component {
 								}
 								disabled={ isRequestingSettings }
 								onClick={ eventTracker( 'Clicked Site Visibility Radio Button' ) }
+								label={ translate( 'Coming Soon' ) }
 							/>
-							<span>{ translate( 'Coming Soon' ) }</span>
 						</FormLabel>
 						<FormSettingExplanation isIndented>
 							{ hasLocalizedText(
@@ -352,8 +352,8 @@ export class SiteSettingsFormGeneral extends Component {
 							}
 							disabled={ isRequestingSettings }
 							onClick={ eventTracker( 'Clicked Site Visibility Radio Button' ) }
+							label={ translate( 'Public' ) }
 						/>
-						<span>{ translate( 'Public' ) }</span>
 					</FormLabel>
 				) }
 				<FormSettingExplanation isIndented>
@@ -395,8 +395,8 @@ export class SiteSettingsFormGeneral extends Component {
 								}
 								disabled={ isRequestingSettings }
 								onClick={ eventTracker( 'Clicked Site Visibility Radio Button' ) }
+								label={ translate( 'Private' ) }
 							/>
-							<span>{ translate( 'Private' ) }</span>
 						</FormLabel>
 						<FormSettingExplanation isIndented>
 							{ hasLocalizedText(

--- a/client/my-sites/site-settings/theme-enhancements.jsx
+++ b/client/my-sites/site-settings/theme-enhancements.jsx
@@ -75,8 +75,8 @@ class ThemeEnhancements extends Component {
 					checked={ value === fields[ name ] }
 					onChange={ handleAutosavingRadio( name, value ) }
 					disabled={ this.isFormPending() }
+					label={ label }
 				/>
-				<span>{ label }</span>
 			</FormLabel>
 		);
 	}

--- a/client/post-editor/editor-post-formats/index.jsx
+++ b/client/post-editor/editor-post-formats/index.jsx
@@ -11,6 +11,7 @@ import Gridicon from 'components/gridicon';
 /**
  * Internal dependencies
  */
+import FormLabel from 'components/forms/form-label';
 import FormRadio from 'components/forms/form-radio';
 import QueryPostFormats from 'components/data/query-post-formats';
 import { recordEditorStat, recordEditorEvent } from 'state/posts/stats';
@@ -87,20 +88,22 @@ class EditorPostFormats extends React.Component {
 		return map( this.getPostFormats(), ( postFormatLabel, postFormatSlug ) => {
 			return (
 				<li key={ postFormatSlug } className="editor-post-formats__format">
-					<label>
+					<FormLabel>
 						<FormRadio
 							name="format"
 							value={ postFormatSlug }
 							checked={ postFormatSlug === selectedFormat }
 							onChange={ this.onChange }
+							label={
+								<>
+									<span className={ 'editor-post-formats__format-icon' }>
+										<Gridicon icon={ getPostFormatIcon( postFormatSlug ) } size={ 18 } />
+									</span>
+									{ postFormatLabel }
+								</>
+							}
 						/>
-						<span className="editor-post-formats__format-label">
-							<span className={ 'editor-post-formats__format-icon' }>
-								<Gridicon icon={ getPostFormatIcon( postFormatSlug ) } size={ 18 } />
-							</span>
-							{ postFormatLabel }
-						</span>
-					</label>
+					</FormLabel>
 				</li>
 			);
 		} );

--- a/client/post-editor/editor-post-formats/style.scss
+++ b/client/post-editor/editor-post-formats/style.scss
@@ -5,15 +5,16 @@
 
 .editor-post-formats__format {
 	margin: 12px 0;
+
+	.form-radio__label {
+		color: var( --color-text );
+		font-size: $font-body-extra-small;
+		position: relative;
+		padding-left: 26px;
+		cursor: pointer;
+	}
 }
 
-.editor-post-formats__format-label {
-	color: var( --color-text );
-	font-size: $font-body-extra-small;
-	position: relative;
-	padding-left: 26px;
-	cursor: pointer;
-}
 
 .editor-post-formats__format-icon {
 	position: absolute;

--- a/client/reader/list-manage/list-form.jsx
+++ b/client/reader/list-manage/list-form.jsx
@@ -83,8 +83,8 @@ export default function ListForm( { isCreateForm, isSubmissionDisabled, list, on
 						data-key="is_public"
 						onChange={ onChange }
 						value="public"
+						label={ translate( 'Everyone can view this list' ) }
 					/>
-					<span>{ translate( 'Everyone can view this list' ) }</span>
 				</FormLabel>
 
 				<FormLabel>
@@ -93,8 +93,8 @@ export default function ListForm( { isCreateForm, isSubmissionDisabled, list, on
 						data-key="is_public"
 						onChange={ onChange }
 						value="private"
+						label={ translate( 'Only I can view this list' ) }
 					/>
-					<span>{ translate( 'Only I can view this list' ) }</span>
 				</FormLabel>
 				<FormSettingExplanation>
 					{ translate(

--- a/packages/composite-checkout/src/components/radio-button.js
+++ b/packages/composite-checkout/src/components/radio-button.js
@@ -138,6 +138,21 @@ function handleWrapperDisabled( { disabled } ) {
 const Radio = styled.input`
 	position: absolute;
 	opacity: 0 !important;
+
+	clear: none;
+	cursor: pointer;
+	display: inline-block;
+	line-height: 0;
+	height: 16px;
+	margin: 2px 0 0;
+	float: left;
+	outline: 0;
+	padding: 0;
+	text-align: center;
+	vertical-align: middle;
+	width: 16px;
+	min-width: 16px;
+	appearance: none;
 `;
 
 const Label = styled.label`


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove global form radio styles in favor of specific component-level styling

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test all the following areas against production and this branch and ensure that they match stylistically and functionally:
    - [ ] NPS Survey "Would you recommend" options (see in devdocs)
    - [ ] Subscription length picker (devdocs)
    - [ ] French domain registration extra info (I couldn't figure out how to find this in the UI)
    - [ ] Devdocs `FormFields` example
    - [ ] Calypso UI Theme picker (in `me/account`)
    - [ ] Cancel auto-renewal and check the survey that happens
    - [ ] Cancel purchase form (go to a recent purchase and trash it and check the modal)
    - [ ] Classic editor Contact form preview (form buttons intentionally `noop`, but add a radio button one and make sure it renders correctly)
    - [ ] WooCommerce paypal settings modal (found in payments settings for store)
    - [ ] WooCommerce stripe settings modal (found in payments settings for store)
    - [ ] Auto capture toggle (I couldn't find this one)
    - [ ] [TODO]
* Ensure all `input type="radio"` have been replaced with `FormRadio`
