### PR TITLE
Jetpack Offer Reset: Show Jetpack Free in the connect flow

### DIFF
--- a/client/components/jetpack/card/jetpack-free-card/index.tsx
+++ b/client/components/jetpack/card/jetpack-free-card/index.tsx
@@ -2,8 +2,14 @@
  * External dependencies
  */
 import React, { FunctionComponent } from 'react';
+import { useSelector } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
 import { Button } from '@automattic/components';
+
+/**
+ * Internal dependencies
+ */
+import getJetpackWpAdminUrl from 'state/selectors/get-jetpack-wp-admin-url';
 
 /**
  * Style dependencies
@@ -12,6 +18,7 @@ import './style.scss';
 
 const JetpackFreeCard: FunctionComponent = () => {
 	const translate = useTranslate();
+	const wpAdminUrl = useSelector( getJetpackWpAdminUrl );
 
 	return (
 		<div className="jetpack-free-card">
@@ -29,7 +36,7 @@ const JetpackFreeCard: FunctionComponent = () => {
 						}
 					) }
 				</p>
-				<Button>{ translate( 'Start for free' ) }</Button>
+				<Button href={ wpAdminUrl }>{ translate( 'Start for free' ) }</Button>
 			</div>
 		</div>
 	);

--- a/client/components/jetpack/card/jetpack-free-card/style.scss
+++ b/client/components/jetpack/card/jetpack-free-card/style.scss
@@ -43,8 +43,8 @@
 	}
 
 	a {
+		text-align: center;
 		height: 40px;
-
 		@include break-medium {
 			margin-left: 24px;
 		}

--- a/client/components/jetpack/card/jetpack-free-card/style.scss
+++ b/client/components/jetpack/card/jetpack-free-card/style.scss
@@ -42,7 +42,7 @@
 		}
 	}
 
-	button {
+	a {
 		height: 40px;
 
 		@include break-medium {

--- a/client/my-sites/plans-v2/selector.tsx
+++ b/client/my-sites/plans-v2/selector.tsx
@@ -61,6 +61,10 @@ const SelectorPage = ( {
 		}
 	};
 
+	const isInConnectFlow =
+		/jetpack\/connect\/plans/.test( window.location.href ) &&
+		/source=jetpack-connect-plans/.test( window.location.href );
+
 	return (
 		<Main className="selector__main" wideLayout>
 			{ header }
@@ -84,8 +88,13 @@ const SelectorPage = ( {
 					siteId={ siteId }
 				/>
 			</div>
-			<div className="selector__divider" />
-			<JetpackFreeCard />
+
+			{ isInConnectFlow && (
+				<>
+					<div className="selector__divider" />
+					<JetpackFreeCard />
+				</>
+			) }
 
 			<QueryProductsList />
 			{ siteId && <QuerySitePurchases siteId={ siteId } /> }

--- a/client/my-sites/plans/current-plan/jetpack-checklist/index.tsx
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/index.tsx
@@ -20,13 +20,13 @@ import QueryJetpackProductInstallStatus from 'components/data/query-jetpack-prod
 import QueryRewindState from 'components/data/query-rewind-state';
 import QuerySiteChecklist from 'components/data/query-site-checklist';
 // eslint-disable-next-line no-restricted-imports
-import { format as formatUrl, parse as parseUrl } from 'url';
-import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSlug, getCustomizerUrl, getSiteProducts } from 'state/sites/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { requestGuidedTour } from 'state/guided-tours/actions';
 import { URL } from 'types';
 import { getSitePlanSlug } from 'state/sites/plans/selectors';
+import getJetpackWpAdminUrl from 'state/selectors/get-jetpack-wp-admin-url';
 import { isBusinessPlan, isPremiumPlan } from 'lib/plans';
 import { isJetpackAntiSpam } from 'lib/products-values';
 import withTrackingTool from 'lib/analytics/with-tracking-tool';
@@ -342,20 +342,12 @@ class JetpackChecklist extends PureComponent< Props & LocalizeProps > {
 }
 
 function mapStateToProps( state ) {
-	const site = getSelectedSite( state );
 	const siteId = getSelectedSiteId( state );
 	const productInstallStatus = getJetpackProductInstallStatus( state, siteId );
 	const rewindState = get( getRewindState( state, siteId ), 'state', 'uninitialized' );
 
 	// Link to "My Plan" page in Jetpack
-	let wpAdminUrl = get( site, 'options.admin_url' );
-	wpAdminUrl = wpAdminUrl
-		? formatUrl( {
-				...parseUrl( wpAdminUrl + 'admin.php' ),
-				query: { page: 'jetpack' },
-				hash: '/my-plan',
-		  } )
-		: undefined;
+	const wpAdminUrl = getJetpackWpAdminUrl( state );
 
 	const planSlug = getSitePlanSlug( state, siteId );
 	const isPremium = !! planSlug && isPremiumPlan( planSlug );

--- a/client/state/selectors/get-jetpack-wp-admin-url.js
+++ b/client/state/selectors/get-jetpack-wp-admin-url.js
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getSelectedSite } from 'state/ui/selectors';
+import { getUrlParts, getUrlFromParts } from 'lib/url';
+
+export default function getJetpackWpAdminUrl( state ) {
+	const site = getSelectedSite( state );
+
+	const adminUrl = get( site, 'options.admin_url' );
+	return adminUrl
+		? getUrlFromParts( {
+				...getUrlParts( adminUrl + 'admin.php' ),
+				search: '?page=jetpack',
+				hash: '/my-plan',
+		  } ).href
+		: undefined;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the Jetpack Free option to only show during the connect flow, and to have the appropriate href in the link going back to wp-admin.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go through the connect flow on a Jetpack site.
2. When you come to the plans page, scroll down and verify that the Free card shows and that it links back to wp-admin.
3. Visit the plans page directly and verify that the Free plan does not show.
4. Visit `/plans/my-plan/:site` and verify that the "Return to WP Admin" link in the checklist still works.
5. Visit the plans page by navigating to it from in Calypso and verify that the Free plan does not show.