### PR TITLE
Offer Reset: fix redirect loop when clicking on checkout page back button

### DIFF
--- a/client/my-sites/plans-v2/details.tsx
+++ b/client/my-sites/plans-v2/details.tsx
@@ -15,7 +15,7 @@ import {
 	OPTIONS_JETPACK_SECURITY_MONTHLY,
 } from './constants';
 import ProductCard from './product-card';
-import { slugToSelectorProduct, durationToString } from './utils';
+import { slugToSelectorProduct, durationToString, getProductUpsell, checkout } from './utils';
 import ProductCardPlaceholder from 'components/jetpack/card/product-card-placeholder';
 import FormattedHeader from 'components/formatted-header';
 import HeaderCake from 'components/header-cake';
@@ -57,11 +57,13 @@ const DetailsPage = ( { duration, productSlug, rootUrl, header, footer }: Detail
 	}
 
 	// Go to a new page for upsells.
-	const selectProduct: PurchaseCallback = ( selectedProduct: SelectorProduct ) => {
-		page(
-			`${ root }/${ selectedProduct.productSlug }/` +
-				`${ durationToString( selectedProduct.term ) }/additions`
-		);
+	const selectProduct: PurchaseCallback = ( { productSlug: slug, term }: SelectorProduct ) => {
+		if ( getProductUpsell( slug ) ) {
+			page( `${ root }/${ slug }/` + `${ durationToString( term ) }/additions` );
+			return;
+		}
+
+		checkout( siteSlug, slug );
 	};
 
 	const isBundle = [ OPTIONS_JETPACK_SECURITY, OPTIONS_JETPACK_SECURITY_MONTHLY ].includes(

--- a/client/my-sites/plans-v2/selector.tsx
+++ b/client/my-sites/plans-v2/selector.tsx
@@ -12,7 +12,7 @@ import PlansFilterBar from './plans-filter-bar';
 import PlansColumn from './plans-column';
 import ProductsColumn from './products-column';
 import { SECURITY } from './constants';
-import { durationToString } from './utils';
+import { durationToString, getProductUpsell, checkout } from './utils';
 import { TERM_ANNUALLY } from 'lib/plans/constants';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { managePurchase } from 'me/purchases/paths';
@@ -48,17 +48,25 @@ const SelectorPage = ( {
 
 	// Sends a user to a page based on whether there are subtypes.
 	const selectProduct: PurchaseCallback = ( product: SelectorProduct, purchase ) => {
-		const root = rootUrl.replace( ':site', siteSlug );
 		if ( purchase ) {
 			page( managePurchase( siteSlug, purchase.id ) );
 			return;
 		}
+
+		const root = rootUrl.replace( ':site', siteSlug );
 		const durationString = durationToString( currentDuration );
+
 		if ( product.subtypes.length ) {
 			page( `${ root }/${ product.productSlug }/${ durationString }/details` );
-		} else {
-			page( `${ root }/${ product.productSlug }/${ durationString }/additions` );
+			return;
 		}
+
+		if ( getProductUpsell( product.productSlug ) ) {
+			page( `${ root }/${ product.productSlug }/${ durationString }/additions` );
+			return;
+		}
+
+		checkout( siteSlug, product.productSlug );
 	};
 
 	return (

--- a/client/my-sites/plans-v2/upsell.tsx
+++ b/client/my-sites/plans-v2/upsell.tsx
@@ -1,10 +1,10 @@
 /**
  * External dependencies
  */
-import React, { useCallback } from 'react';
-import { useSelector } from 'react-redux';
 import page from 'page';
 import { useTranslate } from 'i18n-calypso';
+import React, { useCallback } from 'react';
+import { useSelector } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -16,8 +16,6 @@ import FormattedHeader from 'components/formatted-header';
 import HeaderCake from 'components/header-cake';
 import JetpackProductCard from 'components/jetpack/card/jetpack-product-card';
 import Main from 'components/main';
-import { addItem, addItems } from 'lib/cart/actions';
-import { jetpackProductItem } from 'lib/cart-values/cart-items';
 import { preventWidows } from 'lib/formatting';
 import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
 import { isProductsListFetching } from 'state/products-list/selectors';
@@ -29,6 +27,7 @@ import {
 	getOptionFromSlug,
 	getProductUpsell,
 	slugToSelectorProduct,
+	checkout,
 } from './utils';
 
 /**
@@ -160,22 +159,19 @@ const UpsellPage = ( { duration, productSlug, rootUrl, header, footer }: UpsellP
 	const upsellProductSlug = getProductUpsell( productSlug );
 	const upsellProduct = upsellProductSlug && slugToSelectorProduct( upsellProductSlug );
 
-	const goToCheckout = useCallback( () => {
-		page.redirect( `/checkout/${ selectedSiteSlug }` );
-	}, [ selectedSiteSlug ] );
+	const checkoutCb = useCallback( ( slugs ) => checkout( selectedSiteSlug, slugs ), [
+		selectedSiteSlug,
+	] );
 
-	const onPurchaseBothProducts = useCallback( () => {
-		addItems( [
-			jetpackProductItem( productSlug ),
-			jetpackProductItem( upsellProductSlug as string ),
-		] );
-		goToCheckout();
-	}, [ goToCheckout, productSlug, upsellProductSlug ] );
+	const onPurchaseBothProducts = useCallback(
+		() => checkoutCb( [ productSlug, upsellProductSlug ] ),
+		[ checkoutCb, productSlug, upsellProductSlug ]
+	);
 
-	const onPurchaseSingleProduct = useCallback( () => {
-		addItem( jetpackProductItem( productSlug ) );
-		goToCheckout();
-	}, [ goToCheckout, productSlug ] );
+	const onPurchaseSingleProduct = useCallback( () => checkoutCb( productSlug ), [
+		checkoutCb,
+		productSlug,
+	] );
 
 	const urlWithSiteSlug = rootUrl.replace( ':site', selectedSiteSlug );
 	const durationSuffix = duration ? durationToString( duration ) : '';

--- a/client/my-sites/plans-v2/utils.ts
+++ b/client/my-sites/plans-v2/utils.ts
@@ -3,6 +3,7 @@
  */
 import { translate, TranslateResult } from 'i18n-calypso';
 import { compact, get, isArray, isObject } from 'lodash';
+import page from 'page';
 import { createElement, Fragment } from 'react';
 
 /**
@@ -20,6 +21,8 @@ import {
 	FEATURED_PRODUCTS,
 	SUBTYPE_TO_OPTION,
 } from './constants';
+import { addItems } from 'lib/cart/actions';
+import { jetpackProductItem } from 'lib/cart-values/cart-items';
 import {
 	TERM_ANNUALLY,
 	TERM_MONTHLY,
@@ -426,4 +429,15 @@ export function getProductUpsell( slug: string ): string | null {
  */
 export function getOptionFromSlug( slug: string ): string | null {
 	return SUBTYPE_TO_OPTION[ slug ];
+}
+
+/**
+ * Adds products to the cart and redirects to the checkout page.
+ *
+ * @param {string} siteSlug Selected site
+ * @param {string | string[]} products Slugs of the products to add to the cart
+ */
+export function checkout( siteSlug: string, products: string | string[] ): void {
+	addItems( ( isArray( products ) ? products : [ products ] ).map( jetpackProductItem ) );
+	page.redirect( `/checkout/${ siteSlug }` );
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR prevents a redirect loop when clicking on the back button of the checkout page.

### Testing instructions

- Visit the _Plans_ page with the offer reset flow enabled
- Click on the call-to-action of a product card that has no option, e.g. Jetpack Complete
- You should land in the checkout page with Jetpack Complete in the cart
- Click on the X button and notice you're back in the _Plans_ page
- Empty the cart
- Click on the call-to-action of a product card that has an option but no upsell, e.g. Jetpack Security
- You should land in the details page
- Select and option and check that the back button works
- Finally, click on the call-to-action of a product card that has an option and an upsell, e.g. Jetpack Backup
- You should land in the details page, then the upsell page
- Select the upsell or not, and check that the back button works

### Screenshots

<img width="325" alt="Screen Shot 2020-08-21 at 3 51 39 PM" src="https://user-images.githubusercontent.com/1620183/91222792-b36b1b00-e6ed-11ea-899b-e0ed441aecdb.png">
