### PR TITLE
Correctly add Jetpack Search or WPCOM Search products to the shopping cart, regardless of checkout URL

### DIFF
--- a/client/my-sites/checkout/composite-checkout/add-items.ts
+++ b/client/my-sites/checkout/composite-checkout/add-items.ts
@@ -13,14 +13,7 @@ import {
 	themeItem,
 	jetpackProductItem,
 } from 'lib/cart-values/cart-items';
-import {
-	JETPACK_PRODUCTS_LIST,
-	JETPACK_SEARCH_PRODUCTS,
-	PRODUCT_JETPACK_SEARCH,
-	PRODUCT_JETPACK_SEARCH_MONTHLY,
-	PRODUCT_WPCOM_SEARCH,
-	PRODUCT_WPCOM_SEARCH_MONTHLY,
-} from 'lib/products-values/constants';
+import { JETPACK_PRODUCTS_LIST, JETPACK_SEARCH_PRODUCTS } from 'lib/products-values/constants';
 import type { RequestCartProduct } from './types/backend/shopping-cart-endpoint';
 import config from 'config';
 
@@ -78,12 +71,11 @@ export function createItemToAddToCart( {
 	// Search product
 	if ( productAlias && JETPACK_SEARCH_PRODUCTS.includes( productAlias ) && product_id ) {
 		cartItem = null;
+		let isSearchProduct = false;
 		// is site JP
 		if ( isJetpackNotAtomic ) {
 			debug( 'creating jetpack search product' );
-			cartItem = productAlias.includes( 'monthly' )
-				? jetpackProductItem( PRODUCT_JETPACK_SEARCH_MONTHLY )
-				: jetpackProductItem( PRODUCT_JETPACK_SEARCH );
+			isSearchProduct = true;
 		}
 		// is site WPCOM
 		else if (
@@ -92,13 +84,13 @@ export function createItemToAddToCart( {
 			! isPrivate
 		) {
 			debug( 'creating wpcom search product' );
-			cartItem = productAlias.includes( 'monthly' )
-				? jetpackProductItem( PRODUCT_WPCOM_SEARCH_MONTHLY )
-				: jetpackProductItem( PRODUCT_WPCOM_SEARCH );
+			isSearchProduct = true;
 		}
-
-		if ( cartItem ) {
-			cartItem.product_id = product_id;
+		if ( isSearchProduct ) {
+			cartItem = jetpackProductItem( productAlias );
+			if ( cartItem ) {
+				cartItem.product_id = product_id;
+			}
 		}
 	}
 

--- a/client/my-sites/checkout/composite-checkout/use-prepare-product-for-cart.js
+++ b/client/my-sites/checkout/composite-checkout/use-prepare-product-for-cart.js
@@ -175,9 +175,13 @@ function useAddProductFromSlug( {
 	// about which type of site the user has.
 	if ( productAlias && JETPACK_SEARCH_PRODUCTS.includes( productAlias ) ) {
 		if ( isJetpackNotAtomic ) {
-			productAlias = productAlias.includes( 'monthly' ) ? PRODUCT_JETPACK_SEARCH_MONTHLY : PRODUCT_JETPACK_SEARCH;
+			productAlias = productAlias.includes( 'monthly' )
+				? PRODUCT_JETPACK_SEARCH_MONTHLY
+				: PRODUCT_JETPACK_SEARCH;
 		} else {
-			productAlias = productAlias.includes( 'monthly' ) ? PRODUCT_WPCOM_SEARCH_MONTHLY : PRODUCT_WPCOM_SEARCH;
+			productAlias = productAlias.includes( 'monthly' )
+				? PRODUCT_WPCOM_SEARCH_MONTHLY
+				: PRODUCT_WPCOM_SEARCH;
 		}
 	}
 

--- a/client/my-sites/checkout/composite-checkout/use-prepare-product-for-cart.js
+++ b/client/my-sites/checkout/composite-checkout/use-prepare-product-for-cart.js
@@ -10,6 +10,13 @@ import debugFactory from 'debug';
  */
 import { getSelectedSiteSlug } from 'state/ui/selectors';
 import { getRenewalItemFromCartItem } from 'lib/cart-values/cart-items';
+import {
+	JETPACK_SEARCH_PRODUCTS,
+	PRODUCT_JETPACK_SEARCH,
+	PRODUCT_JETPACK_SEARCH_MONTHLY,
+	PRODUCT_WPCOM_SEARCH,
+	PRODUCT_WPCOM_SEARCH_MONTHLY,
+} from 'lib/products-values/constants';
 import { requestPlans } from 'state/plans/actions';
 import { getPlanBySlug, getPlans, isRequestingPlans } from 'state/plans/selectors';
 import {
@@ -160,6 +167,20 @@ function useAddProductFromSlug( {
 	const plans = useSelector( ( state ) => getPlans( state ) );
 	const isFetchingProducts = useSelector( ( state ) => isProductsListFetching( state ) );
 	const products = useSelector( ( state ) => getProductsList( state ) );
+
+	// Special handling for search products: Always add Jetpack Search to
+	// Jetpack sites and WPCOM Search to WordPress.com sites, regardless of
+	// which slug was provided. This allows e.g. code on jetpack.com to
+	// redirect to a valid checkout URL for a search purchase without worrying
+	// about which type of site the user has.
+	if ( productAlias && JETPACK_SEARCH_PRODUCTS.includes( productAlias ) ) {
+		if ( isJetpackNotAtomic ) {
+			productAlias = productAlias.includes( 'monthly' ) ? PRODUCT_JETPACK_SEARCH_MONTHLY : PRODUCT_JETPACK_SEARCH;
+		} else {
+			productAlias = productAlias.includes( 'monthly' ) ? PRODUCT_WPCOM_SEARCH_MONTHLY : PRODUCT_WPCOM_SEARCH;
+		}
+	}
+
 	const product = useSelector( ( state ) =>
 		getProductBySlug( state, getProductSlugFromAlias( productAlias ) )
 	);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Jetpack Search purchases on WordPress.com sites are currently mostly broken.

These purchase are typically initiated via a URL like `https://wordpress.com/checkout/[site]/jetpack_search_monthly`, but that is currently adding the wrong product to the shopping cart (it adds the one for Jetpack sites, not WordPress.com sites).

I think https://github.com/Automattic/wp-calypso/pull/44662 allowed the product to be added to the cart successfully, but it was still the wrong product.  Therefore, if you try to pay you get an error message because you can't buy a product intended for Jetpack sites on a WordPress.com site.  (Note that from just viewing the shopping cart, it's hard to tell the difference because the two versions of the product look the same and have the same prices.)

This pull request fixes the issue by moving some code around so that the correct product ID gets sent to the server along with the product slug when building the shopping cart.

See internal discussion: p10gg3-9uu-p2#comment-32008

#### Testing instructions

You can try any of the following URLs for both a WordPress.com site (must be a public/launched site, not a private one) *and* Jetpack site (neither of which has a Jetpack Search purchase), i.e. a total of 8 combinations:

```
http://calypso.localhost:3000/checkout/[site]/jetpack_search
http://calypso.localhost:3000/checkout/[site]/jetpack_search_monthly
http://calypso.localhost:3000/checkout/[site]/wpcom_search
http://calypso.localhost:3000/checkout/[site]/wpcom_search_monthly
```

Complete the purchase using a credit card (for Automatticians using the internal test environment you can use the test card numbers at https://stripe.com/docs/testing).  Make sure it works and that you are able to successfully purchase the expected product.

Without this diff, only half of those would work correctly (the `jetpack_...` URLs would fail for WordPress.com sites and vice-versa for the `wpcom_...` URLs).