### PR TITLE
Offer Reset: custom post-purchase Thank You for Jetpack Security and Jetpack Complete [v2]

### DIFF
--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
@@ -174,6 +174,71 @@ describe( 'getThankYouPageUrl', () => {
 		expect( url ).toBe( '/plans/my-plan/foo.bar?thank-you=true&product=jetpack_backup_daily' );
 	} );
 
+	it( 'redirects to the plans page with thank-you query string if there is a non-atomic jetpack product in the cart', () => {
+		const url = getThankYouPageUrl( {
+			...defaultArgs,
+			siteSlug: 'foo.bar',
+			purchaseId: '1234abcd',
+			isJetpackNotAtomic: true,
+			cart: {
+				products: [ { product_slug: 'jetpack_backup_realtime' } ],
+			},
+		} );
+		expect( url ).toBe( '/plans/my-plan/foo.bar?thank-you=true&product=jetpack_backup_realtime' );
+	} );
+
+	it( 'redirects to the plans page with thank-you query string if there is the non-atomic Jetpack Security plan', () => {
+		const url = getThankYouPageUrl( {
+			...defaultArgs,
+			siteSlug: 'foo.bar',
+			purchaseId: '1234abcd',
+			isJetpackNotAtomic: true,
+			product: 'jetpack_security_daily_monthly',
+		} );
+		expect( url ).toBe(
+			'/plans/my-plan/foo.bar?thank-you=true&product=jetpack_security_daily_monthly'
+		);
+	} );
+
+	it( 'redirects to the plans page with thank-you query string if non-atomic Jetpack Security plan is in the cart', () => {
+		const url = getThankYouPageUrl( {
+			...defaultArgs,
+			siteSlug: 'foo.bar',
+			purchaseId: '1234abcd',
+			isJetpackNotAtomic: true,
+			cart: {
+				products: [ { product_slug: 'jetpack_security_daily' } ],
+			},
+		} );
+		expect( url ).toBe( '/plans/my-plan/foo.bar?thank-you=true&product=jetpack_security_daily' );
+	} );
+
+	it( 'redirects to the plans page with thank-you query string if non-atomic Jetpack Complete plan is in the cart', () => {
+		const url = getThankYouPageUrl( {
+			...defaultArgs,
+			siteSlug: 'foo.bar',
+			purchaseId: '1234abcd',
+			isJetpackNotAtomic: true,
+			cart: {
+				products: [ { product_slug: 'jetpack_complete' } ],
+			},
+		} );
+		expect( url ).toBe( '/plans/my-plan/foo.bar?thank-you=true&product=jetpack_complete' );
+	} );
+
+	it( 'redirects to the plans page with thank-you query string and jetpack onboarding if there is a non-atomic legacy jetpack plan in the cart', () => {
+		const url = getThankYouPageUrl( {
+			...defaultArgs,
+			siteSlug: 'foo.bar',
+			purchaseId: '1234abcd',
+			isJetpackNotAtomic: true,
+			cart: {
+				products: [ { product_slug: 'jetpack_premium' } ],
+			},
+		} );
+		expect( url ).toBe( '/plans/my-plan/foo.bar?thank-you=true&install=all' );
+	} );
+
 	it( 'redirects to the plans page with thank-you query string and jetpack onboarding if there is a non-atomic jetpack plan', () => {
 		const url = getThankYouPageUrl( {
 			...defaultArgs,

--- a/client/my-sites/checkout/composite-checkout/use-get-thank-you-url.js
+++ b/client/my-sites/checkout/composite-checkout/use-get-thank-you-url.js
@@ -200,7 +200,9 @@ function getFallbackDestination( {
 			productsWithCustomThankYou.includes( product_slug )
 		)?.product_slug;
 
-		const purchasedProduct = productFromCart || productsWithCustomThankYou.find( product );
+		const purchasedProduct =
+			productFromCart ||
+			productsWithCustomThankYou.find( ( productWithCustom ) => productWithCustom === product );
 		if ( isJetpackNotAtomic && purchasedProduct ) {
 			debug( 'the site is jetpack and bought a jetpack product', siteSlug, purchasedProduct );
 			return `/plans/my-plan/${ siteSlug }?thank-you=true&product=${ purchasedProduct }`;

--- a/client/my-sites/checkout/composite-checkout/use-get-thank-you-url.js
+++ b/client/my-sites/checkout/composite-checkout/use-get-thank-you-url.js
@@ -29,7 +29,8 @@ import {
 } from 'lib/cart-values/cart-items';
 import { managePurchase } from 'me/purchases/paths';
 import { isValidFeatureKey } from 'lib/plans/features-list';
-import { JETPACK_BACKUP_PRODUCTS } from 'lib/products-values/constants';
+import { JETPACK_PRODUCTS_LIST } from 'lib/products-values/constants';
+import { JETPACK_RESET_PLANS } from 'lib/plans/constants';
 import { persistSignupDestination, retrieveSignupDestination } from 'signup/utils';
 import { getSelectedSite } from 'state/ui/selectors';
 import isEligibleForSignupDestination from 'state/selectors/is-eligible-for-signup-destination';
@@ -188,13 +189,24 @@ function getFallbackDestination( {
 	// - has a receipt number
 	// - does not have a receipt number but has an item in cart(as in the case of paying with a redirect payment type)
 	if ( siteSlug && ( ! isReceiptEmpty || ! isCartEmpty ) ) {
-		const isJetpackProduct = product && JETPACK_BACKUP_PRODUCTS.includes( product );
-		// If we just purchased a Jetpack product, redirect to the my plans page.
-		if ( isJetpackNotAtomic && isJetpackProduct ) {
-			debug( 'the site is jetpack and bought a jetpack product', siteSlug, product );
-			return `/plans/my-plan/${ siteSlug }?thank-you=true&product=${ product }`;
+		// If we just purchased a Jetpack product or a Jetpack plan (either Jetpack Security or Jetpack Complete),
+		// redirect to the my plans page. The product being purchased can come from the `product` prop or from the
+		// cart so we need to check both places.
+		const productsWithCustomThankYou = [ ...JETPACK_PRODUCTS_LIST, ...JETPACK_RESET_PLANS ];
+
+		// Check the cart (since our Thank You modal doesn't support multiple products, we only take the first
+		// one found).
+		const productFromCart = cart?.products?.find( ( { product_slug } ) =>
+			productsWithCustomThankYou.includes( product_slug )
+		)?.product_slug;
+
+		const purchasedProduct = productFromCart || productsWithCustomThankYou.find( product );
+		if ( isJetpackNotAtomic && purchasedProduct ) {
+			debug( 'the site is jetpack and bought a jetpack product', siteSlug, purchasedProduct );
+			return `/plans/my-plan/${ siteSlug }?thank-you=true&product=${ purchasedProduct }`;
 		}
-		// If we just purchased a Jetpack plan (not a Jetpack product), redirect to the Jetpack onboarding plugin install flow.
+
+		// If we just purchased a legacy Jetpack plan, redirect to the Jetpack onboarding plugin install flow.
 		if ( isJetpackNotAtomic ) {
 			debug( 'the site is jetpack and has no jetpack product' );
 			return `/plans/my-plan/${ siteSlug }?thank-you=true&install=all`;

--- a/client/my-sites/plans/current-plan/current-plan-thank-you/jetpack-complete.tsx
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you/jetpack-complete.tsx
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import { localize } from 'i18n-calypso';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { preventWidows } from 'lib/formatting';
+import ThankYou from './thank-you';
+
+const JetpackCompleteThankYou = ( { translate } ) => (
+	<ThankYou
+		illustration="/calypso/images/illustrations/security.svg"
+		showCalypsoIntro
+		showContinueButton
+		title={ translate( 'Welcome to Jetpack Complete' ) }
+	>
+		<p>
+			{ preventWidows(
+				translate(
+					"We've finished setting up anti-spam, backups & malware scanning for you. You are now ready to finish the rest of your security checklist."
+				)
+			) }
+		</p>
+	</ThankYou>
+);
+
+export default localize( JetpackCompleteThankYou );

--- a/client/my-sites/plans/current-plan/current-plan-thank-you/jetpack-security-daily.tsx
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you/jetpack-security-daily.tsx
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import { localize } from 'i18n-calypso';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { preventWidows } from 'lib/formatting';
+import ThankYou from './thank-you';
+
+const JetpackSecurityDailyThankYou = ( { translate } ) => (
+	<ThankYou
+		illustration="/calypso/images/illustrations/security.svg"
+		showCalypsoIntro
+		showContinueButton
+		title={ translate( 'Jetpack Security Daily' ) }
+	>
+		<p>
+			{ preventWidows(
+				translate(
+					"We've finished setting up anti-spam, backups & malware scanning for you. You are now ready to finish the rest of your security checklist."
+				)
+			) }
+		</p>
+	</ThankYou>
+);
+
+export default localize( JetpackSecurityDailyThankYou );

--- a/client/my-sites/plans/current-plan/current-plan-thank-you/jetpack-security-realtime.tsx
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you/jetpack-security-realtime.tsx
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import { localize } from 'i18n-calypso';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { preventWidows } from 'lib/formatting';
+import ThankYou from './thank-you';
+
+const JetpackSecurityRealtimeThankYou = ( { translate } ) => (
+	<ThankYou
+		illustration="/calypso/images/illustrations/security.svg"
+		showCalypsoIntro
+		showContinueButton
+		title={ translate( 'Jetpack Security Real-time' ) }
+	>
+		<p>
+			{ preventWidows(
+				translate(
+					"We've finished setting up anti-spam, backups & malware scanning for you. You are now ready to finish the rest of your security checklist."
+				)
+			) }
+		</p>
+	</ThankYou>
+);
+
+export default localize( JetpackSecurityRealtimeThankYou );

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { Component, Fragment } from 'react';
-import { get, startsWith } from 'lodash';
+import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
@@ -36,6 +36,12 @@ import {
 	PLAN_JETPACK_SECURITY_REALTIME,
 	PLAN_JETPACK_SECURITY_REALTIME_MONTHLY,
 } from 'lib/plans/constants';
+import {
+	JETPACK_ANTI_SPAM_PRODUCTS,
+	JETPACK_BACKUP_PRODUCTS,
+	JETPACK_SCAN_PRODUCTS,
+	JETPACK_SEARCH_PRODUCTS,
+} from 'lib/products-values/constants';
 import { isCloseToExpiration } from 'lib/purchases';
 import { getPurchaseByProductSlug } from 'lib/purchases/utils';
 import QuerySiteDomains from 'components/data/query-site-domains';
@@ -102,19 +108,19 @@ class CurrentPlan extends Component {
 	renderThankYou() {
 		const { currentPlan, product, selectedSite } = this.props;
 
-		if ( startsWith( product, 'jetpack_backup' ) ) {
+		if ( JETPACK_BACKUP_PRODUCTS.includes( product ) ) {
 			return <BackupProductThankYou />;
 		}
 
-		if ( startsWith( product, 'jetpack_scan' ) ) {
+		if ( JETPACK_SCAN_PRODUCTS.includes( product ) ) {
 			return <ScanProductThankYou />;
 		}
 
-		if ( startsWith( product, 'jetpack_anti_spam' ) ) {
+		if ( JETPACK_ANTI_SPAM_PRODUCTS.includes( product ) ) {
 			return <AntiSpamProductThankYou />;
 		}
 
-		if ( startsWith( product, 'jetpack_search' ) ) {
+		if ( JETPACK_SEARCH_PRODUCTS.includes( product ) ) {
 			const jetpackVersion = get( selectedSite, 'options.jetpack_version', 0 );
 			return <SearchProductThankYou { ...{ jetpackVersion } } />;
 		}

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -47,6 +47,7 @@ import BackupProductThankYou from './current-plan-thank-you/backup-thank-you';
 import ScanProductThankYou from './current-plan-thank-you/scan-thank-you';
 import AntiSpamProductThankYou from './current-plan-thank-you/anti-spam-thank-you';
 import SearchProductThankYou from './current-plan-thank-you/search-thank-you';
+import JetpackCompleteThankYou from './current-plan-thank-you/jetpack-complete';
 import { isFreeJetpackPlan, isFreePlan } from 'lib/products-values';
 import { getSitePurchases } from 'state/purchases/selectors';
 
@@ -107,6 +108,10 @@ class CurrentPlan extends Component {
 			const jetpackVersion = get( selectedSite, 'options.jetpack_version', 0 );
 
 			return <SearchProductThankYou { ...{ jetpackVersion } } />;
+		}
+
+		if ( startsWith( product, 'jetpack_complete' ) ) {
+			return <JetpackCompleteThankYou />;
 		}
 
 		if ( ! currentPlan || isFreePlan( currentPlan ) || isFreeJetpackPlan( currentPlan ) ) {

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -27,7 +27,15 @@ import QuerySites from 'components/data/query-sites';
 import QuerySitePlans from 'components/data/query-site-plans';
 import { shouldShowOfferResetFlow } from 'lib/abtest/getters';
 import { getPlan } from 'lib/plans';
-import { JETPACK_LEGACY_PLANS } from 'lib/plans/constants';
+import {
+	JETPACK_LEGACY_PLANS,
+	PLAN_JETPACK_COMPLETE,
+	PLAN_JETPACK_COMPLETE_MONTHLY,
+	PLAN_JETPACK_SECURITY_DAILY,
+	PLAN_JETPACK_SECURITY_DAILY_MONTHLY,
+	PLAN_JETPACK_SECURITY_REALTIME,
+	PLAN_JETPACK_SECURITY_REALTIME_MONTHLY,
+} from 'lib/plans/constants';
 import { isCloseToExpiration } from 'lib/purchases';
 import { getPurchaseByProductSlug } from 'lib/purchases/utils';
 import QuerySiteDomains from 'components/data/query-site-domains';
@@ -48,6 +56,8 @@ import ScanProductThankYou from './current-plan-thank-you/scan-thank-you';
 import AntiSpamProductThankYou from './current-plan-thank-you/anti-spam-thank-you';
 import SearchProductThankYou from './current-plan-thank-you/search-thank-you';
 import JetpackCompleteThankYou from './current-plan-thank-you/jetpack-complete';
+import JetpackSecurityDailyThankYou from './current-plan-thank-you/jetpack-security-daily';
+import JetpackSecurityRealtimeThankYou from './current-plan-thank-you/jetpack-security-realtime';
 import { isFreeJetpackPlan, isFreePlan } from 'lib/products-values';
 import { getSitePurchases } from 'state/purchases/selectors';
 
@@ -106,11 +116,22 @@ class CurrentPlan extends Component {
 
 		if ( startsWith( product, 'jetpack_search' ) ) {
 			const jetpackVersion = get( selectedSite, 'options.jetpack_version', 0 );
-
 			return <SearchProductThankYou { ...{ jetpackVersion } } />;
 		}
 
-		if ( startsWith( product, 'jetpack_complete' ) ) {
+		if (
+			[ PLAN_JETPACK_SECURITY_DAILY, PLAN_JETPACK_SECURITY_DAILY_MONTHLY ].includes( product )
+		) {
+			return <JetpackSecurityDailyThankYou />;
+		}
+
+		if (
+			[ PLAN_JETPACK_SECURITY_REALTIME, PLAN_JETPACK_SECURITY_REALTIME_MONTHLY ].includes( product )
+		) {
+			return <JetpackSecurityRealtimeThankYou />;
+		}
+
+		if ( [ PLAN_JETPACK_COMPLETE, PLAN_JETPACK_COMPLETE_MONTHLY ].includes( product ) ) {
 			return <JetpackCompleteThankYou />;
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add post-purchase Thank You notes/modals for Jetpack Security Daily/Real-time and Jetpack Complete.

This is a fixed version of #45196.

#### Implementation notes

* Instead of relying on what it's in the URL to get the purchased product, we inspect the current cart. If the cart doesn't have a Jetpack product or plan, we use what was passed in the URL.
* I also added unit test to make sure getting the product from the cart works as expected in the cases we want it to.
* The ThankYou components have some repetition. We will fix that in a following PR.

#### Testing instructions

* Run this PR with the Offer Reset AB test enabled.
* Visit the Plans page and purchase any of the new plans.
* Verify that you see a Thank You note that represents the purchased product.
* Repeat the process with an old Jetpack product (Backup or Scan) and verify they still work as before.

Fixes 1169247016322522-as-1189915727920775

#### Demo
![image](https://user-images.githubusercontent.com/3418513/91219388-f11d7300-e6f0-11ea-9fba-42350b90f8ed.png)

![image](https://user-images.githubusercontent.com/3418513/91219339-dba84900-e6f0-11ea-8b51-7904cfe4cda4.png)

![image](https://user-images.githubusercontent.com/3418513/91219327-d4813b00-e6f0-11ea-82b4-a28b21185017.png)

![image](https://user-images.githubusercontent.com/3418513/91219453-07c3ca00-e6f1-11ea-84ef-674fea0ea10f.png)

![image](https://user-images.githubusercontent.com/3418513/91219501-1ad69a00-e6f1-11ea-94c2-c0fd3f4cbe86.png)
