### PR TITLE
Editing Toolkit: Update the readme to include a "rename info" section

### DIFF
--- a/apps/editing-toolkit/README.md
+++ b/apps/editing-toolkit/README.md
@@ -2,17 +2,17 @@
 
 This plugin includes many sub-features which add blocks and new functionality to the Gutenberg editor. The plugin provides a single codebase which can be installed on any platform which requires these features, such as the WordPress.com multisite or other standalone WordPress instances.
 
-**Note: This plugin is currently being renamed from Full Site Editing Plugin to WordPress.com Editing Toolkit Plugin.**
-In the near future, the following will be changed:
+## Rename Info
+
+This plugin has been renamed from Full Site Editing Plugin to WordPress.com Editing Toolkit Plugin.
+The following changed to use "editing-toolkit" in place of "full-site-editing".
 
 - Directories and filenames referencing "full site editing"
 - Code referencing those filenames
 - Documentation
 - CI job names
 
-Those will be updated to use "editing-toolkit" in place of "full-site-editing."
-
-The following items will likely not change:
+The following items did not change:
 
 - The plugin slug, which will remain `full-site-editing` due to rename limitations in WordPress.
 - The root full-site-editing-plugin.php file (to preserve the plugin slug).


### PR DESCRIPTION
See https://github.com/Automattic/wp-calypso/pull/45186#issuecomment-680407680

With #44501 we renamed _most_ of the FSE plugin to Editing Toolkit.
When merging, I've missed this readme mentioning the ongoing renaming process.

I'm aware that some of the "did not change" items are being worked on (e.g. #44552), but I think we can still say that the rename has been completed, as the phrasing in the readme is clear enough imho regarding what has and has not been done.