### PR TITLE
Add "Change site address" menu in the domain list menus

### DIFF
--- a/client/my-sites/domains/domain-management/list/domain-item.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-item.jsx
@@ -26,6 +26,7 @@ import { resolveDomainStatus, isDomainInGracePeriod, isDomainUpdateable } from '
 import InfoPopover from 'components/info-popover';
 import { emailManagement } from 'my-sites/email/paths';
 import {
+	domainManagementChangeSiteAddress,
 	domainManagementContactsPrivacy,
 	domainManagementNameServers,
 	domainManagementTransfer,
@@ -223,6 +224,14 @@ class DomainItem extends PureComponent {
 							href={ domainManagementDns( site.slug, domain.domain, currentRoute ) }
 						>
 							{ translate( 'DNS Records' ) }
+						</PopoverMenuItem>
+					) }
+					{ domain.type === domainTypes.WPCOM && ! domainDetails?.isWpcomStagingDomain && (
+						<PopoverMenuItem
+							icon="list-unordered"
+							href={ domainManagementChangeSiteAddress( site.slug, domain.domain, currentRoute ) }
+						>
+							{ translate( 'Change site address' ) }
 						</PopoverMenuItem>
 					) }
 					{ domain.type === domainTypes.REGISTERED &&

--- a/client/my-sites/domains/domain-management/list/domain-item.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-item.jsx
@@ -228,7 +228,7 @@ class DomainItem extends PureComponent {
 					) }
 					{ domain.type === domainTypes.WPCOM && ! domainDetails?.isWpcomStagingDomain && (
 						<PopoverMenuItem
-							icon="list-unordered"
+							icon="reblog"
 							href={ domainManagementChangeSiteAddress( site.slug, domain.domain, currentRoute ) }
 						>
 							{ translate( 'Change site address' ) }

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -478,6 +478,8 @@ export class List extends React.Component {
 			return <ListItemPlaceholder />;
 		}
 
+		const moreThanOneDomain = domains.filter( ( domain ) => domain?.canSetAsPrimary ).length > 1;
+
 		return [
 			<CompactCard className="list__header-primary-domain" key="primary-domain-header">
 				<div className="list__header-primary-domain-info">
@@ -491,6 +493,7 @@ export class List extends React.Component {
 				<div className="list__header-primary-domain-buttons">
 					<Button
 						compact
+						disabled={ ! moreThanOneDomain }
 						className="list__change-primary-domain"
 						onClick={
 							this.state.changePrimaryDomainModeEnabled

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -543,7 +543,7 @@ export class List extends React.Component {
 			<DomainItem
 				key={ `${ domain.name }-${ index }` }
 				currentRoute={ currentRoute }
-				domain={ { domain: domain.name } }
+				domain={ domain }
 				domainDetails={ domain }
 				site={ selectedSite }
 				isManagingAllSites={ false }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds "Change site address" ellipsis menu
* Fixed a bug to show the ellipsis menus in the site specific domains list

#### Testing instructions

* Open a site specific list of domains and verify that there is a "Change site address" menu in the ellipsis menus for the wordpress.com subdomain
* Open a site specific list of domains and verify that you can see the ellipsis menus for all the items (before this PR only "Edit settings" was visible)
