### PR TITLE
Themes: Fix themes selection premium price display

### DIFF
--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -193,7 +193,7 @@ function bindIsInstallingTheme( state, siteId ) {
 }
 
 function bindGetPremiumThemePrice( state, siteId ) {
-	( themeId ) => getPremiumThemePrice( state, themeId, siteId );
+	return ( themeId ) => getPremiumThemePrice( state, themeId, siteId );
 }
 
 // Exporting this for use in recommended-themes.jsx


### PR DESCRIPTION
In #32139 we migrated the themes CSS to webpack, and in the process, we did some other code changes, too. Seems like we forgot to add a `return` in one of the functions that binds action creators, which caused the prices to not appear for premium themes. 

To repro, go to https://wordpress.com/themes/premium/:site where `:site` is a simple WP.com site on a free plan. You'll notice prices don't appear.

#### Changes proposed in this Pull Request

* Fix themes selection premium price display

Before:
![](https://cldup.com/8_ncg-YP8O.png)

After:
![](https://cldup.com/96NLlZokWZ.png)

#### Testing instructions

* Go to https://wordpress.com/themes/premium/:site where `:site` is a simple WP.com site on a free plan
* Verify theme prices appear properly.
