### PR TITLE
Offer Reset: update displayed price in product cards for yearly term

### DIFF
--- a/client/my-sites/plans-v2/use-item-price.ts
+++ b/client/my-sites/plans-v2/use-item-price.ts
@@ -40,8 +40,8 @@ const useItemPrice = ( item: SelectorProduct | null, monthlyItemSlug = '' ): Ite
 	if ( item && itemCost ) {
 		originalPrice = itemCost;
 		if ( monthlyItemCost && item.term !== TERM_MONTHLY ) {
-			originalPrice = monthlyItemCost * 12;
-			discountedPrice = itemCost;
+			originalPrice = monthlyItemCost;
+			discountedPrice = itemCost / 12;
 		}
 	}
 

--- a/client/my-sites/plans-v2/utils.ts
+++ b/client/my-sites/plans-v2/utils.ts
@@ -88,7 +88,7 @@ export function durationToString( duration: Duration ): DurationString {
 export function durationToText( duration: Duration ): TranslateResult {
 	return duration === TERM_MONTHLY
 		? translate( 'per month, billed monthly' )
-		: translate( 'per year' );
+		: translate( 'per month, billed yearly' );
 }
 
 /**


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR introduces a change in how plans are shown in product cards, when the selected term is Yearly. The card now shows how it costs per month, with the mention "billed yearly".

### Testing instructions

- Visit the _Plans_ page with the offer reset flow enabled
- With a monthly term, check that nothing changed
- With a yearly term, check that the price shown is the price per month and that the "per month, billed yearly" mention is present

### Screenshots

Yearly before
<img width="438" alt="Screen Shot 2020-08-26 at 10 12 02 AM" src="https://user-images.githubusercontent.com/1620183/91314484-9df50000-e784-11ea-8458-fecb4022a516.png">


Yearly after
<img width="443" alt="Screen Shot 2020-08-26 at 10 08 21 AM" src="https://user-images.githubusercontent.com/1620183/91314496-a0eff080-e784-11ea-8108-93e97d137b63.png">
