### PR TITLE
Use `toString` method to compare prop updates in DocumentHead's title setter

### DIFF
--- a/client/components/data/document-head/index.jsx
+++ b/client/components/data/document-head/index.jsx
@@ -45,6 +45,10 @@ class DocumentHead extends Component {
 	}
 
 	UNSAFE_componentWillReceiveProps( nextProps ) {
+		// The `title` prop is commonly receiving its value as a result from a `translate` call
+		// and in some cases it returns a React component instead of string.
+		// A shallow comparison of two React components may result in unnecessary title updates.
+		// To avoid that, we compare the string representation of the passed `title` prop value.
 		if (
 			nextProps.title !== undefined &&
 			this.props.title?.toString?.() !== nextProps.title?.toString?.()

--- a/client/components/data/document-head/index.jsx
+++ b/client/components/data/document-head/index.jsx
@@ -45,7 +45,10 @@ class DocumentHead extends Component {
 	}
 
 	UNSAFE_componentWillReceiveProps( nextProps ) {
-		if ( nextProps.title !== undefined && this.props.title !== nextProps.title ) {
+		if (
+			nextProps.title !== undefined &&
+			this.props.title?.toString?.() !== nextProps.title?.toString?.()
+		) {
 			this.props.setTitle( nextProps.title );
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use `toString` method to compare prop updates in DocumentHead's title setter, as it will provide better and more sustainable comparison, when a value other than a string is provided to the `title` prop. A common example is the use of `translate` as a prop value, and the returned value from the call is a React component, instead of a string.

#### Testing instructions

* Console log current and nextProps title value before the [document title setter action](https://github.com/Automattic/wp-calypso/blob/fix/document-head-title-setter/client/components/data/document-head/index.jsx#L52) - `console.log( this.props.title, nextProps.title )`
* Navigate through Calypso's pages and confirm that you are not getting the same current and next title prop logged in the console (e.g. the document title action setter is not being called with the same title)
* Confirm page title is being updated properly when switching between pages

Related: p1598448470010100-slack-i18n
