### PR TITLE
Show premium price for premium domain suggestions when there is free plan credit

### DIFF
--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -1269,6 +1269,10 @@ export function getDomainPriceRule( withPlansOnly, selectedSite, cart, suggestio
 		return 'FREE_DOMAIN';
 	}
 
+	if ( suggestion?.is_premium ) {
+		return 'PRICE';
+	}
+
 	if ( isDomainBeingUsedForPlan( cart, suggestion.domain_name ) ) {
 		return 'FREE_WITH_PLAN';
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* We need to show the premium price for premium domain suggestions when there is free plan credit because premium domains shouldn't bundle with plans

#### Testing instructions

* On site with plan and unused domain credit (or just add plan to your cart first)
* Search for premium domain like anna or dale (you should use the sandboxed public-api) 
* Verify that the domain premium price is shown instead of "free with your plan" that is displayed for regular priced domains
