### PR TITLE
Offer Reset: redirect to checkout if the site owns the upsell product

### DIFF
--- a/client/my-sites/plans-v2/details.tsx
+++ b/client/my-sites/plans-v2/details.tsx
@@ -23,6 +23,7 @@ import Main from 'components/main';
 import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
 import { isProductsListFetching } from 'state/products-list/selectors/is-products-list-fetching';
 import { getProductsList } from 'state/products-list/selectors';
+import { getSiteProducts } from 'state/sites/selectors';
 import { getSelectedSiteSlug, getSelectedSiteId } from 'state/ui/selectors';
 
 /**
@@ -37,6 +38,7 @@ const DetailsPage = ( { duration, productSlug, rootUrl, header, footer }: Detail
 	const siteSlug = useSelector( ( state ) => getSelectedSiteSlug( state ) ) || '';
 	const currencyCode = useSelector( ( state ) => getCurrentUserCurrencyCode( state ) );
 	const isFetchingProducts = useSelector( ( state ) => isProductsListFetching( state ) );
+	const siteProducts = useSelector( ( state ) => getSiteProducts( state, siteId ) );
 	const products = useSelector( ( state ) => getProductsList( state ) );
 	const translate = useTranslate();
 	const root = rootUrl.replace( ':site', siteSlug );
@@ -58,11 +60,16 @@ const DetailsPage = ( { duration, productSlug, rootUrl, header, footer }: Detail
 
 	// Go to a new page for upsells.
 	const selectProduct: PurchaseCallback = ( { productSlug: slug, term }: SelectorProduct ) => {
-		if ( getProductUpsell( slug ) ) {
+		const upsellProduct = getProductUpsell( slug );
+		if (
+			upsellProduct &&
+			! siteProducts.find(
+				( { productSlug: siteProductSlug } ) => siteProductSlug === upsellProduct
+			)
+		) {
 			page( `${ root }/${ slug }/` + `${ durationToString( term ) }/additions` );
 			return;
 		}
-
 		checkout( siteSlug, slug );
 	};
 

--- a/client/my-sites/plans-v2/selector.tsx
+++ b/client/my-sites/plans-v2/selector.tsx
@@ -14,6 +14,7 @@ import ProductsColumn from './products-column';
 import { SECURITY } from './constants';
 import { durationToString, getProductUpsell, checkout } from './utils';
 import { TERM_ANNUALLY } from 'lib/plans/constants';
+import { getSiteProducts } from 'state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { managePurchase } from 'me/purchases/paths';
 import Main from 'components/main';
@@ -43,6 +44,7 @@ const SelectorPage = ( {
 }: SelectorPageProps ) => {
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
 	const siteSlug = useSelector( ( state ) => getSelectedSiteSlug( state ) ) || '';
+	const siteProducts = useSelector( ( state ) => getSiteProducts( state, siteId ) );
 	const [ productType, setProductType ] = useState< ProductType >( SECURITY );
 	const [ currentDuration, setDuration ] = useState< Duration >( defaultDuration );
 
@@ -61,7 +63,13 @@ const SelectorPage = ( {
 			return;
 		}
 
-		if ( getProductUpsell( product.productSlug ) ) {
+		// Redirect to the Upsell page only if there is an upsell product and the site
+		// doesn't already own the product.
+		const upsellProduct = getProductUpsell( product.productSlug );
+		if (
+			upsellProduct &&
+			! siteProducts.find( ( { productSlug } ) => productSlug === upsellProduct )
+		) {
 			page( `${ root }/${ product.productSlug }/${ durationString }/additions` );
 			return;
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Redirect the user directly to the checkout page if the site already owns the upsell product.

#### Testing instructions

* Run this PR with the Offer Reset AB test enabled.
* With a site that has no plans or products visit the Plans page.
* Purchase Jetpack Scan Daily and go back to the Plans page.
* Select the Jetpack Backup generic/option card.
* In the Details page, select Jetpack Backup **Daily**.
* Verify that you landed in the checkout page without passing through the upsell page.
* Repeat the process by purchasing Jetpack Backup Daily first, and then purchasing Jetpack Scan.

Fixes 1169247016322522-as-1190551224035433

#### Demo

##### Site with Jetpack Scan Daily (no upsell when trying to purchase Jetpack Backup Daily)
![Kapture 2020-08-26 at 12 55 33](https://user-images.githubusercontent.com/3418513/91327154-8d9c4f80-e79b-11ea-83ad-ea961ebcfa4c.gif)

##### Site with Jetpack Backup Daily (no upsell or option when trying to purchase Jetpack Scan)
![Kapture 2020-08-26 at 12 57 49](https://user-images.githubusercontent.com/3418513/91327387-d0f6be00-e79b-11ea-844d-7503dc578bf8.gif)

