### PR TITLE
Gutenboarding: Adjust Colour of Premium Tooltip

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -133,6 +133,10 @@
 		margin-left: 6px;
 		/* stylelint-disable-next-line scales/font-size */
 		font-size: rem( 10px ); //typography-exception
+
+		.components-popover__content {
+			background-color: var( --studio-gray-80 );
+		}
 	}
 
 	.design-selector__premium-badge {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Ensures that the background colour of the popover is the same as the tooltip

#### Testing instructions

Visit `/new` and hover over the "Premium" badge to verify that the colour is the same as the badge. If you want to Inspect the colour but the popover keeps disappearing, you may want to try pausing the script execution after hovering over the "Premium" badge. (`Command + F8 + \` )

<img width="333" alt="Screenshot 2020-08-26 at 18 28 35" src="https://user-images.githubusercontent.com/43215253/91336745-4aa5a080-e7ca-11ea-8dd0-d8982a0cfd2d.png">

cc @ciampo 

Fixes #45217
