### PR TITLE
SPT: Exclude the template preview iframe from tabIndex and pointer events

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/components/block-iframe-preview.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/components/block-iframe-preview.js
@@ -74,9 +74,10 @@ const copyStylesToIframe = ( srcDocument, targetiFrameDocument ) => {
  * @param {object} props.className CSS class to apply to component
  * @param {string} props.bodyClassName CSS class to apply to the iframe's `<body>` tag
  * @param {number} props.viewportWidth pixel width of the viewable size of the preview
- * @param {Array}  props.blocks array of Gutenberg Block objects
+ * @param {Array} props.blocks array of Gutenberg Block objects
  * @param {object} props.settings block Editor settings object
  * @param {Function} props.setTimeout safe version of window.setTimeout via `withSafeTimeout`
+ * @param {string} props.title the template title
  */
 const BlockFramePreview = ( {
 	className = 'block-iframe-preview',
@@ -206,6 +207,7 @@ const BlockFramePreview = ( {
 				title={ __( 'Preview', 'full-site-editing' ) }
 				className={ classnames( 'editor-styles-wrapper', className ) }
 				style={ style }
+				tabindex="-1"
 			>
 				{ iframeRef.current?.contentDocument?.body &&
 					createPortal(

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -276,9 +276,9 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 	background: $template-selector-empty-background;
 	border-radius: 2px;
 	overflow: hidden;
-	box-shadow: 0 2px 2px 0 rgba( 0, 0, 0, 0.14 ),
-		0 3px 1px -2px rgba( 0, 0, 0, 0.12 ),
+	box-shadow: 0 2px 2px 0 rgba( 0, 0, 0, 0.14 ), 0 3px 1px -2px rgba( 0, 0, 0, 0.12 ),
 		0 1px 5px 0 rgba( 0, 0, 0, 0.2 );
+	pointer-events: none;
 
 	@media screen and ( min-width: $breakpoint-mobile ) {
 		display: block;
@@ -478,7 +478,11 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 	// flex: column; on the parent and flex-basis: 0; on the child in Safari causes a lot of weird overlapping layout
 	// issues in the iframe preview: https://github.com/Automattic/wp-calypso/issues/39874
 	// Using flex-basis: auto; on the child allows the height to be calculated properly
-	.wp-block-columns > .block-editor-inner-blocks > .block-editor-block-list__layout > [data-type='core/column'] .block-core-columns {
+	.wp-block-columns
+		> .block-editor-inner-blocks
+		> .block-editor-block-list__layout
+		> [data-type='core/column']
+		.block-core-columns {
 		flex-basis: auto;
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Prevent the user from focusing the template preview iframe, which in some cases can crash the editor.

I'm not exactly sure _why_ this happens, but _how_ is perfectly explained in #44038: some elements inside the template preview, when focused, throw a `getBoundingClientRect of undefined` error that crashes the editor.
The `Popover` component seems to be involved, but given how common that is, it doesn't narrow our investigation enough.

The approach proposed in this PR is indeed a workaround, and there are a11y concerns.
We are in fact making it impossible to <kbd>tab</kbd> into the template preview: screen readers won't be able to "explore" the preview anymore.
Given how the template selector is currenctly structured, I would probably question its a11y anyway (e.g. users need to <kbd>tab</kbd> through all templates before getting to the preview).

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Edit a page and change its layout to open the template selector.
* Select "Dalston".
* Click on the big preview and hit <kbd>tab</kbd>.
* Make sure the editor doesn't crash, and the close button is focused.
* Select "Dalston" again (or, rather, just click on its thumbnail to focus it again).
* Hit <kbd>tab</kbd> through all the templates.
* Make sure the next <kbd>tab</kbd> after the last template doesn't crash the editor, and focuses the primary "Use layout" button.

Fixes #44038
