### PR TITLE
Offer Reset: update copy in upsell page

### DIFF
--- a/client/lib/products-values/translations.js
+++ b/client/lib/products-values/translations.js
@@ -1,28 +1,57 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { createElement } from 'react';
 import { numberFormat, translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import { isEnabled } from 'config';
+import { shouldShowOfferResetFlow } from 'lib/abtest/getters';
 import * as CONSTANTS from './constants.js';
 
 // Translatable strings
 export const getJetpackProductsShortNames = () => {
 	return {
-		[ CONSTANTS.PRODUCT_JETPACK_BACKUP_DAILY ]: translate( 'Daily Backups' ),
-		[ CONSTANTS.PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY ]: translate( 'Daily Backups' ),
-		[ CONSTANTS.PRODUCT_JETPACK_BACKUP_REALTIME ]: translate( 'Real-Time Backups' ),
-		[ CONSTANTS.PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY ]: translate( 'Real-Time Backups' ),
+		[ CONSTANTS.PRODUCT_JETPACK_BACKUP_DAILY ]: shouldShowOfferResetFlow()
+			? translate( 'Backup {{em}}Daily{{/em}}', {
+					components: {
+						em: createElement( 'em' ),
+					},
+			  } )
+			: translate( 'Daily Backups' ),
+		[ CONSTANTS.PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY ]: shouldShowOfferResetFlow()
+			? translate( 'Backup {{em}}Daily{{/em}}', {
+					components: {
+						em: createElement( 'em' ),
+					},
+			  } )
+			: translate( 'Daily Backups' ),
+		[ CONSTANTS.PRODUCT_JETPACK_BACKUP_REALTIME ]: shouldShowOfferResetFlow()
+			? translate( 'Backup {{em}}Real-time{{/em}}', {
+					components: {
+						em: createElement( 'em' ),
+					},
+			  } )
+			: translate( 'Real-Time Backups' ),
+		[ CONSTANTS.PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY ]: shouldShowOfferResetFlow()
+			? translate( 'Backup {{em}}Real-time{{/em}}', {
+					components: {
+						em: createElement( 'em' ),
+					},
+			  } )
+			: translate( 'Real-Time Backups' ),
 		[ CONSTANTS.PRODUCT_JETPACK_SEARCH ]: translate( 'Search' ),
 		[ CONSTANTS.PRODUCT_JETPACK_SEARCH_MONTHLY ]: translate( 'Search' ),
 		[ CONSTANTS.PRODUCT_WPCOM_SEARCH ]: translate( 'Search' ),
 		[ CONSTANTS.PRODUCT_WPCOM_SEARCH_MONTHLY ]: translate( 'Search' ),
-		[ CONSTANTS.PRODUCT_JETPACK_SCAN ]: translate( 'Daily Scan' ),
-		[ CONSTANTS.PRODUCT_JETPACK_SCAN_MONTHLY ]: translate( 'Daily Scan' ),
+		[ CONSTANTS.PRODUCT_JETPACK_SCAN ]: shouldShowOfferResetFlow()
+			? translate( 'Scan' )
+			: translate( 'Daily Scan' ),
+		[ CONSTANTS.PRODUCT_JETPACK_SCAN_MONTHLY ]: shouldShowOfferResetFlow()
+			? translate( 'Scan' )
+			: translate( 'Daily Scan' ),
 		[ CONSTANTS.PRODUCT_JETPACK_ANTI_SPAM ]: translate( 'Anti-spam' ),
 		[ CONSTANTS.PRODUCT_JETPACK_ANTI_SPAM_MONTHLY ]: translate( 'Anti-spam' ),
 	};

--- a/client/my-sites/plans-v2/details.tsx
+++ b/client/my-sites/plans-v2/details.tsx
@@ -73,6 +73,7 @@ const DetailsPage = ( { duration, productSlug, rootUrl, header, footer }: Detail
 		checkout( siteSlug, slug );
 	};
 
+	const { shortName } = product;
 	const isBundle = [ OPTIONS_JETPACK_SECURITY, OPTIONS_JETPACK_SECURITY_MONTHLY ].includes(
 		productSlug
 	);
@@ -86,9 +87,11 @@ const DetailsPage = ( { duration, productSlug, rootUrl, header, footer }: Detail
 			</HeaderCake>
 			<FormattedHeader
 				headerText={
-					product.shortName
-						? translate( 'Great choice! Now select a %s option:', {
-								args: product.shortName,
+					shortName
+						? translate( 'Great choice! Now select a {{name/}} option:', {
+								components: {
+									name: <> { shortName }</>,
+								},
 								comment: 'Short name of the selected generic plan or product',
 						  } )
 						: translate( 'Great choice! Now select an option:' )

--- a/client/my-sites/plans-v2/style.scss
+++ b/client/my-sites/plans-v2/style.scss
@@ -56,7 +56,8 @@
 .upsell__subheader {
 	font-style: italic;
 
-	margin-bottom: 8px;
+	max-width: 500px;
+	margin: 0 auto 8px;
 }
 
 .upsell__saved-amount {

--- a/client/my-sites/plans-v2/upsell.tsx
+++ b/client/my-sites/plans-v2/upsell.tsx
@@ -3,7 +3,7 @@
  */
 import page from 'page';
 import { useTranslate } from 'i18n-calypso';
-import React, { useCallback, useMemo, ReactElement } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
 /**
@@ -65,8 +65,8 @@ const UpsellComponent = ( {
 		upsellProduct.monthlyProductSlug || ''
 	);
 
-	const { displayName: mainProductName } = mainProduct;
-	const { displayName: upsellProductName, productSlug: upsellSlug } = upsellProduct;
+	const { shortName: mainProductName } = mainProduct;
+	const { shortName: upsellProductName, productSlug: upsellSlug } = upsellProduct;
 
 	const isScanProduct = useMemo(
 		() => JETPACK_SCAN_PRODUCTS.some( ( slug ) => slug === upsellSlug ),
@@ -81,7 +81,7 @@ const UpsellComponent = ( {
 					headerText={ preventWidows(
 						translate( 'Would you like to add {{name/}}?', {
 							components: {
-								name: upsellProductName as ReactElement,
+								name: <>{ upsellProductName }</>,
 							},
 							comment: '{{name/}} is the name of a product such as Jetpack Scan or Jetpack Backup',
 						} )
@@ -100,8 +100,8 @@ const UpsellComponent = ( {
 								'Combine {{mainName/}} and {{upsellName/}} to give your site comprehensive protection from malware and other threats.',
 								{
 									components: {
-										mainName: mainProductName as ReactElement,
-										upsellName: upsellProductName as ReactElement,
+										mainName: <>{ mainProductName }</>,
+										upsellName: <>{ upsellProductName }</>,
 									},
 									comment:
 										"{{mainName/}} refers to the product the customer is purchasing (most likely Backup in that case), {{upsellName/}} to the product we're upselling (Scan in that case)",
@@ -122,7 +122,7 @@ const UpsellComponent = ( {
 					billingTimeFrame={ durationToText( upsellProduct.term ) }
 					buttonLabel={ translate( 'Yes, add {{name/}}', {
 						components: {
-							name: upsellProductName as ReactElement,
+							name: <>{ upsellProductName }</>,
 						},
 						comment:
 							'{{name/}} refers to a name of a product such as Jetpack Backup or Jetpack Scan',
@@ -133,7 +133,7 @@ const UpsellComponent = ( {
 					onButtonClick={ onPurchaseBothProducts }
 					cancelLabel={ translate( 'No, I do not want {{name/}}', {
 						components: {
-							name: upsellProductName as ReactElement,
+							name: <>{ upsellProductName }</>,
 						},
 						comment:
 							'{{name/}} refers to a name of a product such as Jetpack Backup or Jetpack Scan',

--- a/client/my-sites/plans-v2/upsell.tsx
+++ b/client/my-sites/plans-v2/upsell.tsx
@@ -16,7 +16,7 @@ import HeaderCake from 'components/header-cake';
 import JetpackProductCard from 'components/jetpack/card/jetpack-product-card';
 import Main from 'components/main';
 import { preventWidows } from 'lib/formatting';
-import { JETPACK_SCAN_PRODUCTS } from 'lib/products-values/constants';
+import { JETPACK_SCAN_PRODUCTS, JETPACK_BACKUP_PRODUCTS } from 'lib/products-values/constants';
 import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
 import { isProductsListFetching } from 'state/products-list/selectors';
 import { getSelectedSiteSlug } from 'state/ui/selectors';
@@ -72,6 +72,10 @@ const UpsellComponent = ( {
 		() => JETPACK_SCAN_PRODUCTS.some( ( slug ) => slug === upsellSlug ),
 		[ upsellSlug ]
 	);
+	const isBackupProduct = useMemo(
+		() => JETPACK_BACKUP_PRODUCTS.some( ( slug ) => slug === upsellSlug ),
+		[ upsellSlug ]
+	);
 
 	return (
 		<Main className="upsell">
@@ -93,20 +97,32 @@ const UpsellComponent = ( {
 					<Gridicon className="upsell__plus-icon" icon="plus-small" />
 					<ProductIcon className="upsell__product-icon" slug={ upsellProduct.iconSlug } />
 				</div>
-				{ isScanProduct && (
+				{ ( isScanProduct || isBackupProduct ) && (
 					<p className="upsell__subheader">
 						{ preventWidows(
-							translate(
-								'Combine {{mainName/}} and {{upsellName/}} to give your site comprehensive protection from malware and other threats.',
-								{
-									components: {
-										mainName: <>{ mainProductName }</>,
-										upsellName: <>{ upsellProductName }</>,
-									},
-									comment:
-										"{{mainName/}} refers to the product the customer is purchasing (most likely Backup in that case), {{upsellName/}} to the product we're upselling (Scan in that case)",
-								}
-							)
+							isScanProduct
+								? translate(
+										'Combine {{mainName/}} and {{upsellName/}} to give your site comprehensive protection from malware and other threats.',
+										{
+											components: {
+												mainName: <>{ mainProductName }</>,
+												upsellName: <>{ upsellProductName }</>,
+											},
+											comment:
+												"{{mainName/}} refers to the product the customer is purchasing (Backup in that case), {{upsellName/}} to the product we're upselling (Scan in that case)",
+										}
+								  )
+								: translate(
+										'Combine {{mainName/}} and {{upsellName/}} to be able to save every change and restore your site in one click.',
+										{
+											components: {
+												mainName: <>{ mainProductName }</>,
+												upsellName: <>{ upsellProductName }</>,
+											},
+											comment:
+												"{{mainName/}} refers to the product the customer is purchasing (Scan in that case), {{upsellName/}} to the product we're upselling (Backup in that case)",
+										}
+								  )
 						) }
 					</p>
 				) }

--- a/client/my-sites/plans-v2/upsell.tsx
+++ b/client/my-sites/plans-v2/upsell.tsx
@@ -3,20 +3,20 @@
  */
 import page from 'page';
 import { useTranslate } from 'i18n-calypso';
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo, ReactElement } from 'react';
 import { useSelector } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import { ProductIcon } from '@automattic/components';
-import { getCurrencyObject } from '@automattic/format-currency';
 import Gridicon from 'components/gridicon';
 import FormattedHeader from 'components/formatted-header';
 import HeaderCake from 'components/header-cake';
 import JetpackProductCard from 'components/jetpack/card/jetpack-product-card';
 import Main from 'components/main';
 import { preventWidows } from 'lib/formatting';
+import { JETPACK_SCAN_PRODUCTS } from 'lib/products-values/constants';
 import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
 import { isProductsListFetching } from 'state/products-list/selectors';
 import { getSelectedSiteSlug } from 'state/ui/selectors';
@@ -64,14 +64,14 @@ const UpsellComponent = ( {
 		upsellProduct,
 		upsellProduct.monthlyProductSlug || ''
 	);
-	const savedAmount = 100;
 
-	const { shortName: mainProductName } = mainProduct;
-	const { shortName: upsellProductName } = upsellProduct;
+	const { displayName: mainProductName } = mainProduct;
+	const { displayName: upsellProductName, productSlug: upsellSlug } = upsellProduct;
 
-	const { symbol: currencySymbol } = getCurrencyObject( originalPrice, currencyCode ) || {
-		symbol: '$',
-	};
+	const isScanProduct = useMemo(
+		() => JETPACK_SCAN_PRODUCTS.some( ( slug ) => slug === upsellSlug ),
+		[ upsellSlug ]
+	);
 
 	return (
 		<Main className="upsell">
@@ -79,9 +79,11 @@ const UpsellComponent = ( {
 			<div className="upsell__header">
 				<FormattedHeader
 					headerText={ preventWidows(
-						translate( 'Would you like to add %s?', {
-							args: [ upsellProductName ],
-							comment: '%s is the name of a product such as Jetpack Scan or Jetpack Backup',
+						translate( 'Would you like to add {{name/}}?', {
+							components: {
+								name: upsellProductName as ReactElement,
+							},
+							comment: '{{name/}} is the name of a product such as Jetpack Scan or Jetpack Backup',
 						} )
 					) }
 					brandFont
@@ -91,35 +93,23 @@ const UpsellComponent = ( {
 					<Gridicon className="upsell__plus-icon" icon="plus-small" />
 					<ProductIcon className="upsell__product-icon" slug={ upsellProduct.iconSlug } />
 				</div>
-				<p className="upsell__subheader">
-					{ preventWidows(
-						translate( 'Bundle %(mainProduct)s with %(upsellProduct)s and save!', {
-							args: {
-								mainProduct: mainProductName,
-								upsellProduct: upsellProductName,
-							},
-							comment:
-								'%(mainProduct)s and %(upsellProduct)s are abbreviated name of product such as Scan or Backup',
-						} )
-					) }
-				</p>
-				<p className="upsell__saved-amount">
-					{ preventWidows(
-						translate(
-							'Save %(currencySymbol)s%(savedAmount)d/year on %(upsellProduct)s when paired with %(mainProduct)s',
-							{
-								args: {
-									savedAmount,
-									mainProduct: mainProductName,
-									upsellProduct: upsellProductName,
-									currencySymbol,
-								},
-								comment:
-									'%(savedAmount)s refers to the saved amount by purchasing two products together such as Jetpack Backup and Jetpack Scan',
-							}
-						)
-					) }
-				</p>
+				{ isScanProduct && (
+					<p className="upsell__subheader">
+						{ preventWidows(
+							translate(
+								'Combine {{mainName/}} and {{upsellName/}} to give your site comprehensive protection from malware and other threats.',
+								{
+									components: {
+										mainName: mainProductName as ReactElement,
+										upsellName: upsellProductName as ReactElement,
+									},
+									comment:
+										"{{mainName/}} refers to the product the customer is purchasing (most likely Backup in that case), {{upsellName/}} to the product we're upselling (Scan in that case)",
+								}
+							)
+						) }
+					</p>
+				) }
 			</div>
 
 			<div className="upsell__product-card">
@@ -130,17 +120,23 @@ const UpsellComponent = ( {
 					description={ upsellProduct.description }
 					currencyCode={ currencyCode }
 					billingTimeFrame={ durationToText( upsellProduct.term ) }
-					buttonLabel={ translate( 'Yes, add %s', {
-						args: [ upsellProductName ],
-						comment: '%s refers to a name of a product such as Jetpack Backup or Jetpack Scan',
+					buttonLabel={ translate( 'Yes, add {{name/}}', {
+						components: {
+							name: upsellProductName as ReactElement,
+						},
+						comment:
+							'{{name/}} refers to a name of a product such as Jetpack Backup or Jetpack Scan',
 					} ) }
 					features={ upsellProduct.features }
 					discountedPrice={ discountedPrice }
 					originalPrice={ originalPrice }
 					onButtonClick={ onPurchaseBothProducts }
-					cancelLabel={ translate( 'No, I do not want %s', {
-						args: [ upsellProductName ],
-						comment: '%s refers to a name of a product such as Jetpack Backup or Jetpack Scan',
+					cancelLabel={ translate( 'No, I do not want {{name/}}', {
+						components: {
+							name: upsellProductName as ReactElement,
+						},
+						comment:
+							'{{name/}} refers to a name of a product such as Jetpack Backup or Jetpack Scan',
 					} ) }
 					onCancelClick={ onPurchaseSingleProduct }
 				/>


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR updates the copy of the page that prompts a user to buy Scan when they're purchasing Backup.

### Implementation notes

- There's no discount when buying both products.
- Updating the short names of the products wasn't straightforward. I needed to check that the parts of the code using them would still work with `TranslateResult` instead of just `string`. I tracked down the places in the codebase where it would be an issue, and the only one I found was `client/my-sites/plans-v2/details.tsx`.

### Testing instructions

- Visit the _Plans_ page with the offer reset flow enabled
- Make sure the site has no Jetpack plan or product
- Select Jetpack Backup
- Select Backup Daily
- Make sure the upsell page looks like the one in the capture
- Back to the _Plans_ page, select Scan and check the Backup upsell (see capture)
- Optionally, wander through the offer reset flow and check that names haven't changed

### Screenshots

**Before**
<img width="751" alt="Screen Shot 2020-08-26 at 4 33 00 PM" src="https://user-images.githubusercontent.com/1620183/91353929-eed31b80-e7b9-11ea-90ae-2d972c007e34.png">


**After (Scan upsell)**
<img width="748" alt="Screen Shot 2020-08-26 at 4 32 06 PM" src="https://user-images.githubusercontent.com/1620183/91353955-f397cf80-e7b9-11ea-9383-205f83f117d7.png">

**After (Backup upsell)**
<img width="744" alt="Screen Shot 2020-08-27 at 11 31 52 AM" src="https://user-images.githubusercontent.com/1620183/91463098-fc8bae00-e858-11ea-829e-77b2efb3d6b4.png">

