### PR TITLE
Add context to the word "Free" for translators

### DIFF
--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -135,7 +135,7 @@ class DomainProductPrice extends React.Component {
 		return (
 			<div className={ className }>
 				<div className={ productPriceClassName }>
-					<span>{ translate( 'Free' ) }</span>
+					<span>{ translate( 'Free', { context: 'Adjective refers to subdomain' } ) }</span>
 				</div>
 			</div>
 		);


### PR DESCRIPTION
Without context, free can be translated in different ways depending on whether it's an adjective, a verb, or the name of a plan. This change makes it so the translator can translate "Free" correctly in this context when referring to a free subdomain ('kostenlos' instead of 'free' (the translation for the plan name)).

<img width="897" alt="Screen Shot 2020-08-26 at 1 09 25 PM" src="https://user-images.githubusercontent.com/36699353/91345952-6777af00-e79d-11ea-8558-6179e0e63e8c.png">
