### PR TITLE
Prevent e2e error triggered in lib/abtest when user is not defined

### DIFF
--- a/client/lib/abtest/index.js
+++ b/client/lib/abtest/index.js
@@ -208,7 +208,7 @@ export const isUsingGivenLocales = ( localeTargets, experimentId = null ) => {
 		client.languages && client.languages.length ? client.languages[ 0 ] : 'en';
 	const localeFromSession = getLocaleSlug() || 'en';
 	const localeMatcher = new RegExp( '^(' + localeTargets.join( '|' ) + ')', 'i' );
-	const userLocale = user().get().localeSlug || 'en';
+	const userLocale = user().get()?.localeSlug || 'en';
 
 	if ( isUserSignedIn() && ! userLocale.match( localeMatcher ) ) {
 		debug( '%s: User has a %s locale', experimentId, userLocale );


### PR DESCRIPTION
### Changes proposed in this Pull Request

Using an a/b test experiment, a couple of PR failed with the error `cannot read property 'localeSlug' of undefined` when running the desktop build. This PR makes sure the tests don't fail and that the default locale is used.

### Testing instructions

Make sure all tests in this PR pass.