### PR TITLE
Offer Reset: show loading placeholder in upsell page

### DIFF
--- a/client/my-sites/plans-v2/style.scss
+++ b/client/my-sites/plans-v2/style.scss
@@ -42,6 +42,20 @@
 /**
  * Upsell
  */
+
+.upsell__header-placeholder {
+	@include placeholder( --color-neutral-10 );
+
+	min-height: 220px;
+	margin: 24px 0;
+}
+
+.upsell__product-card-placeholder {
+	@include placeholder( --color-neutral-10 );
+
+	min-height: 540px;
+}
+
 .upsell__header {
 	text-align: center;
 

--- a/client/my-sites/plans-v2/upsell.tsx
+++ b/client/my-sites/plans-v2/upsell.tsx
@@ -84,87 +84,90 @@ const UpsellComponent = ( {
 	return (
 		<Main className="upsell">
 			<HeaderCake onClick={ onBackButtonClick }>{ translate( 'Product Options' ) }</HeaderCake>
-			{ ! isLoading && (
-				<>
-					<div className="upsell__header">
-						<FormattedHeader
-							headerText={ preventWidows(
-								translate( 'Would you like to add {{name/}}?', {
-									components: {
-										name: <>{ upsellProductName }</>,
-									},
-									comment:
-										'{{name/}} is the name of a product such as Jetpack Scan or Jetpack Backup',
-								} )
-							) }
-							brandFont
-						/>
-						<div className="upsell__icons">
-							<ProductIcon className="upsell__product-icon" slug={ mainProduct.iconSlug } />
-							<Gridicon className="upsell__plus-icon" icon="plus-small" />
-							<ProductIcon className="upsell__product-icon" slug={ upsellProduct.iconSlug } />
-						</div>
-						{ ( isScanProduct || isBackupProduct ) && (
-							<p className="upsell__subheader">
-								{ preventWidows(
-									isScanProduct
-										? translate(
-												'Combine {{mainName/}} and {{upsellName/}} to give your site comprehensive protection from malware and other threats.',
-												{
-													components: {
-														mainName: <>{ mainProductName }</>,
-														upsellName: <>{ upsellProductName }</>,
-													},
-													comment:
-														"{{mainName/}} refers to the product the customer is purchasing (Backup in that case), {{upsellName/}} to the product we're upselling (Scan in that case)",
-												}
-										  )
-										: translate(
-												'Combine {{mainName/}} and {{upsellName/}} to be able to save every change and restore your site in one click.',
-												{
-													components: {
-														mainName: <>{ mainProductName }</>,
-														upsellName: <>{ upsellProductName }</>,
-													},
-													comment:
-														"{{mainName/}} refers to the product the customer is purchasing (Scan in that case), {{upsellName/}} to the product we're upselling (Backup in that case)",
-												}
-										  )
-								) }
-							</p>
+			{ isLoading ? (
+				<div className="upsell__header-placeholder" />
+			) : (
+				<div className="upsell__header">
+					<FormattedHeader
+						headerText={ preventWidows(
+							translate( 'Would you like to add {{name/}}?', {
+								components: {
+									name: <>{ upsellProductName }</>,
+								},
+								comment:
+									'{{name/}} is the name of a product such as Jetpack Scan or Jetpack Backup',
+							} )
 						) }
+						brandFont
+					/>
+					<div className="upsell__icons">
+						<ProductIcon className="upsell__product-icon" slug={ mainProduct.iconSlug } />
+						<Gridicon className="upsell__plus-icon" icon="plus-small" />
+						<ProductIcon className="upsell__product-icon" slug={ upsellProduct.iconSlug } />
 					</div>
-
-					<div className="upsell__product-card">
-						<JetpackProductCard
-							iconSlug={ upsellProduct.iconSlug }
-							productName={ upsellProduct.displayName }
-							subheadline={ upsellProduct.tagline }
-							description={ upsellProduct.description }
-							currencyCode={ currencyCode }
-							billingTimeFrame={ durationToText( upsellProduct.term ) }
-							buttonLabel={ translate( 'Yes, add {{name/}}', {
-								components: {
-									name: <>{ upsellProductName }</>,
-								},
-								comment:
-									'{{name/}} refers to a name of a product such as Jetpack Backup or Jetpack Scan',
-							} ) }
-							features={ upsellProduct.features }
-							discountedPrice={ discountedPrice }
-							originalPrice={ originalPrice }
-							onButtonClick={ onPurchaseBothProducts }
-							cancelLabel={ translate( 'No, I do not want {{name/}}', {
-								components: {
-									name: <>{ upsellProductName }</>,
-								},
-								comment:
-									'{{name/}} refers to a name of a product such as Jetpack Backup or Jetpack Scan',
-							} ) }
-							onCancelClick={ onPurchaseSingleProduct }
-						/>
-					</div>
-				</>
+					{ ( isScanProduct || isBackupProduct ) && (
+						<p className="upsell__subheader">
+							{ preventWidows(
+								isScanProduct
+									? translate(
+											'Combine {{mainName/}} and {{upsellName/}} to give your site comprehensive protection from malware and other threats.',
+											{
+												components: {
+													mainName: <>{ mainProductName }</>,
+													upsellName: <>{ upsellProductName }</>,
+												},
+												comment:
+													"{{mainName/}} refers to the product the customer is purchasing (Backup in that case), {{upsellName/}} to the product we're upselling (Scan in that case)",
+											}
+									  )
+									: translate(
+											'Combine {{mainName/}} and {{upsellName/}} to be able to save every change and restore your site in one click.',
+											{
+												components: {
+													mainName: <>{ mainProductName }</>,
+													upsellName: <>{ upsellProductName }</>,
+												},
+												comment:
+													"{{mainName/}} refers to the product the customer is purchasing (Scan in that case), {{upsellName/}} to the product we're upselling (Backup in that case)",
+											}
+									  )
+							) }
+						</p>
+					) }
+				</div>
+			) }
+			{ isLoading ? (
+				<div className="upsell__product-card-placeholder" />
+			) : (
+				<div className="upsell__product-card">
+					<JetpackProductCard
+						iconSlug={ upsellProduct.iconSlug }
+						productName={ upsellProduct.displayName }
+						subheadline={ upsellProduct.tagline }
+						description={ upsellProduct.description }
+						currencyCode={ currencyCode }
+						billingTimeFrame={ durationToText( upsellProduct.term ) }
+						buttonLabel={ translate( 'Yes, add {{name/}}', {
+							components: {
+								name: <>{ upsellProductName }</>,
+							},
+							comment:
+								'{{name/}} refers to a name of a product such as Jetpack Backup or Jetpack Scan',
+						} ) }
+						features={ upsellProduct.features }
+						discountedPrice={ discountedPrice }
+						originalPrice={ originalPrice }
+						onButtonClick={ onPurchaseBothProducts }
+						cancelLabel={ translate( 'No, I do not want {{name/}}', {
+							components: {
+								name: <>{ upsellProductName }</>,
+							},
+							comment:
+								'{{name/}} refers to a name of a product such as Jetpack Backup or Jetpack Scan',
+						} ) }
+						onCancelClick={ onPurchaseSingleProduct }
+					/>
+				</div>
 			) }
 		</Main>
 	);

--- a/client/my-sites/plans-v2/upsell.tsx
+++ b/client/my-sites/plans-v2/upsell.tsx
@@ -18,7 +18,7 @@ import Main from 'components/main';
 import { preventWidows } from 'lib/formatting';
 import { JETPACK_SCAN_PRODUCTS, JETPACK_BACKUP_PRODUCTS } from 'lib/products-values/constants';
 import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
-import { isProductsListFetching } from 'state/products-list/selectors';
+import { isProductsListFetching, getProductsList } from 'state/products-list/selectors';
 import { getSelectedSiteSlug } from 'state/ui/selectors';
 import useItemPrice from './use-item-price';
 import {
@@ -49,6 +49,7 @@ interface Props {
 	onBackButtonClick: () => void;
 	onPurchaseSingleProduct: () => void;
 	onPurchaseBothProducts: () => void;
+	isLoading: boolean;
 }
 
 const UpsellComponent = ( {
@@ -58,6 +59,7 @@ const UpsellComponent = ( {
 	onPurchaseBothProducts,
 	mainProduct,
 	upsellProduct,
+	isLoading,
 }: Props ) => {
 	const translate = useTranslate();
 
@@ -82,83 +84,88 @@ const UpsellComponent = ( {
 	return (
 		<Main className="upsell">
 			<HeaderCake onClick={ onBackButtonClick }>{ translate( 'Product Options' ) }</HeaderCake>
-			<div className="upsell__header">
-				<FormattedHeader
-					headerText={ preventWidows(
-						translate( 'Would you like to add {{name/}}?', {
-							components: {
-								name: <>{ upsellProductName }</>,
-							},
-							comment: '{{name/}} is the name of a product such as Jetpack Scan or Jetpack Backup',
-						} )
-					) }
-					brandFont
-				/>
-				<div className="upsell__icons">
-					<ProductIcon className="upsell__product-icon" slug={ mainProduct.iconSlug } />
-					<Gridicon className="upsell__plus-icon" icon="plus-small" />
-					<ProductIcon className="upsell__product-icon" slug={ upsellProduct.iconSlug } />
-				</div>
-				{ ( isScanProduct || isBackupProduct ) && (
-					<p className="upsell__subheader">
-						{ preventWidows(
-							isScanProduct
-								? translate(
-										'Combine {{mainName/}} and {{upsellName/}} to give your site comprehensive protection from malware and other threats.',
-										{
-											components: {
-												mainName: <>{ mainProductName }</>,
-												upsellName: <>{ upsellProductName }</>,
-											},
-											comment:
-												"{{mainName/}} refers to the product the customer is purchasing (Backup in that case), {{upsellName/}} to the product we're upselling (Scan in that case)",
-										}
-								  )
-								: translate(
-										'Combine {{mainName/}} and {{upsellName/}} to be able to save every change and restore your site in one click.',
-										{
-											components: {
-												mainName: <>{ mainProductName }</>,
-												upsellName: <>{ upsellProductName }</>,
-											},
-											comment:
-												"{{mainName/}} refers to the product the customer is purchasing (Scan in that case), {{upsellName/}} to the product we're upselling (Backup in that case)",
-										}
-								  )
+			{ ! isLoading && (
+				<>
+					<div className="upsell__header">
+						<FormattedHeader
+							headerText={ preventWidows(
+								translate( 'Would you like to add {{name/}}?', {
+									components: {
+										name: <>{ upsellProductName }</>,
+									},
+									comment:
+										'{{name/}} is the name of a product such as Jetpack Scan or Jetpack Backup',
+								} )
+							) }
+							brandFont
+						/>
+						<div className="upsell__icons">
+							<ProductIcon className="upsell__product-icon" slug={ mainProduct.iconSlug } />
+							<Gridicon className="upsell__plus-icon" icon="plus-small" />
+							<ProductIcon className="upsell__product-icon" slug={ upsellProduct.iconSlug } />
+						</div>
+						{ ( isScanProduct || isBackupProduct ) && (
+							<p className="upsell__subheader">
+								{ preventWidows(
+									isScanProduct
+										? translate(
+												'Combine {{mainName/}} and {{upsellName/}} to give your site comprehensive protection from malware and other threats.',
+												{
+													components: {
+														mainName: <>{ mainProductName }</>,
+														upsellName: <>{ upsellProductName }</>,
+													},
+													comment:
+														"{{mainName/}} refers to the product the customer is purchasing (Backup in that case), {{upsellName/}} to the product we're upselling (Scan in that case)",
+												}
+										  )
+										: translate(
+												'Combine {{mainName/}} and {{upsellName/}} to be able to save every change and restore your site in one click.',
+												{
+													components: {
+														mainName: <>{ mainProductName }</>,
+														upsellName: <>{ upsellProductName }</>,
+													},
+													comment:
+														"{{mainName/}} refers to the product the customer is purchasing (Scan in that case), {{upsellName/}} to the product we're upselling (Backup in that case)",
+												}
+										  )
+								) }
+							</p>
 						) }
-					</p>
-				) }
-			</div>
+					</div>
 
-			<div className="upsell__product-card">
-				<JetpackProductCard
-					iconSlug={ upsellProduct.iconSlug }
-					productName={ upsellProduct.displayName }
-					subheadline={ upsellProduct.tagline }
-					description={ upsellProduct.description }
-					currencyCode={ currencyCode }
-					billingTimeFrame={ durationToText( upsellProduct.term ) }
-					buttonLabel={ translate( 'Yes, add {{name/}}', {
-						components: {
-							name: <>{ upsellProductName }</>,
-						},
-						comment:
-							'{{name/}} refers to a name of a product such as Jetpack Backup or Jetpack Scan',
-					} ) }
-					features={ upsellProduct.features }
-					discountedPrice={ discountedPrice }
-					originalPrice={ originalPrice }
-					onButtonClick={ onPurchaseBothProducts }
-					cancelLabel={ translate( 'No, I do not want {{name/}}', {
-						components: {
-							name: <>{ upsellProductName }</>,
-						},
-						comment:
-							'{{name/}} refers to a name of a product such as Jetpack Backup or Jetpack Scan',
-					} ) }
-					onCancelClick={ onPurchaseSingleProduct }
-				/>
-			</div>
+					<div className="upsell__product-card">
+						<JetpackProductCard
+							iconSlug={ upsellProduct.iconSlug }
+							productName={ upsellProduct.displayName }
+							subheadline={ upsellProduct.tagline }
+							description={ upsellProduct.description }
+							currencyCode={ currencyCode }
+							billingTimeFrame={ durationToText( upsellProduct.term ) }
+							buttonLabel={ translate( 'Yes, add {{name/}}', {
+								components: {
+									name: <>{ upsellProductName }</>,
+								},
+								comment:
+									'{{name/}} refers to a name of a product such as Jetpack Backup or Jetpack Scan',
+							} ) }
+							features={ upsellProduct.features }
+							discountedPrice={ discountedPrice }
+							originalPrice={ originalPrice }
+							onButtonClick={ onPurchaseBothProducts }
+							cancelLabel={ translate( 'No, I do not want {{name/}}', {
+								components: {
+									name: <>{ upsellProductName }</>,
+								},
+								comment:
+									'{{name/}} refers to a name of a product such as Jetpack Backup or Jetpack Scan',
+							} ) }
+							onCancelClick={ onPurchaseSingleProduct }
+						/>
+					</div>
+				</>
+			) }
 		</Main>
 	);
 };
@@ -167,6 +174,8 @@ const UpsellPage = ( { duration, productSlug, rootUrl, header, footer }: UpsellP
 	const siteSlug = useSelector( ( state ) => getSelectedSiteSlug( state ) ) || '';
 	const isFetchingProducts = useSelector( ( state ) => isProductsListFetching( state ) );
 	const currencyCode = useSelector( ( state ) => getCurrentUserCurrencyCode( state ) );
+	const products = useSelector( ( state ) => getProductsList( state ) );
+	const isLoading = ! currencyCode || ( isFetchingProducts && ! products );
 
 	const mainProduct = slugToSelectorProduct( productSlug );
 	// TODO: Get upsells via API.
@@ -199,10 +208,6 @@ const UpsellPage = ( { duration, productSlug, rootUrl, header, footer }: UpsellP
 		return null;
 	}
 
-	if ( isFetchingProducts || ! currencyCode ) {
-		return <h1>Loading...</h1>;
-	}
-
 	// Construct a URL to send users to when they click the back button. Since at this moment
 	// there is only one Jetpack Scan option, the back button takes users back to the Selector
 	// page.
@@ -217,12 +222,13 @@ const UpsellPage = ( { duration, productSlug, rootUrl, header, footer }: UpsellP
 		<>
 			{ header }
 			<UpsellComponent
-				currencyCode={ currencyCode }
+				currencyCode={ currencyCode as string }
 				mainProduct={ mainProduct }
 				upsellProduct={ upsellProduct }
 				onPurchaseSingleProduct={ onPurchaseSingleProduct }
 				onPurchaseBothProducts={ onPurchaseBothProducts }
 				onBackButtonClick={ onBackButtonClick }
+				isLoading={ isLoading }
 			/>
 			{ footer }
 		</>


### PR DESCRIPTION
### Changes proposed in this Pull Request

Adds a loading state to the upsell page. The PR also makes sure that the loading state is shown only once.

### Testing instructions

- Visit the _Plans_ page with the offer reset flow enabled
- Make sure the site has no Jetpack plan or product
- Select Jetpack Backup > Backup Daily
- The upsell page should be instantly displayed
- Hard refresh the page
- Note the loading state (see capture)

_Note that the first placeholder is slightly shorter than the loaded header. I already took into account the copy updates brought by https://github.com/Automattic/wp-calypso/pull/45231._

### Screenshots

With loading placeholders
![capture-out](https://user-images.githubusercontent.com/1620183/91446990-28516880-e846-11ea-8683-0ab42efa53ea.gif)
