### PR TITLE
Checkout: Wrap analytics recording in try/catch

### DIFF
--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -20,419 +20,426 @@ const debug = debugFactory( 'calypso:composite-checkout:record-analytics' );
 
 export default function createAnalyticsEventHandler( reduxDispatch ) {
 	return function recordEvent( action ) {
-		debug( 'heard checkout event', action );
-		switch ( action.type ) {
-			case 'CHECKOUT_LOADED':
-				reduxDispatch(
-					recordTracksEvent( 'calypso_checkout_page_view', {
-						saved_cards: action.payload?.saved_cards,
-						is_renewal: action.payload?.is_renewal,
-						apple_pay_available: action.payload?.apple_pay_available,
-						product_slug: action.payload?.product_slug,
-						is_composite: true,
-					} )
-				);
-
-				return reduxDispatch( recordTracksEvent( 'calypso_checkout_composite_loaded', {} ) );
-
-			case 'PAYMENT_COMPLETE': {
-				const total_cost = action.payload.total.amount.value / 100; // TODO: This conversion only works for USD! We have to localize this or get it from the server directly (or better yet, just force people to use the integer version).
-
-				reduxDispatch(
-					recordTracksEvent( 'calypso_checkout_payment_success', {
-						coupon_code: action.payload.couponItem?.wpcom_meta.couponCode ?? '',
-						currency: action.payload.total.amount.currency,
-						payment_method:
-							translateCheckoutPaymentMethodToWpcomPaymentMethod( action.payload.paymentMethodId )
-								?.name || '',
-						total_cost,
-					} )
-				);
-
-				const transactionResult = select( 'wpcom' ).getTransactionResult();
-				recordPurchase( {
-					cart: {
-						total_cost,
-						currency: action.payload.total.amount.currency,
-						is_signup: action.payload.responseCart.is_signup,
-						products: action.payload.responseCart.products,
-						coupon_code: action.payload.couponItem?.wpcom_meta.couponCode ?? '',
-						total_tax: action.payload.responseCart.total_tax,
-					},
-					orderId: transactionResult.receipt_id,
-				} );
-
-				return reduxDispatch(
-					recordTracksEvent( 'calypso_checkout_composite_payment_complete', {
-						redirect_url: action.payload.url,
-						coupon_code: action.payload.couponItem?.wpcom_meta.couponCode ?? '',
-						total: action.payload.total.amount.value,
-						currency: action.payload.total.amount.currency,
-						payment_method:
-							translateCheckoutPaymentMethodToWpcomPaymentMethod( action.payload.paymentMethodId )
-								?.name || '',
-					} )
-				);
-			}
-
-			case 'CART_INIT_COMPLETE':
-				return reduxDispatch(
-					recordTracksEvent( 'calypso_checkout_composite_cart_loaded', {
-						products: action.payload.products
-							.map( ( product ) => product.product_slug )
-							.join( ',' ),
-					} )
-				);
-
-			case 'STEP_LOAD_ERROR':
-				reduxDispatch(
-					logStashLoadErrorEventAction( 'step_load', String( action.payload.message ), {
-						stepId: action.payload.stepId,
-					} )
-				);
-
-				return reduxDispatch(
-					recordTracksEvent( 'calypso_checkout_composite_step_load_error', {
-						error_message: String( action.payload.message ),
-						step_id: String( action.payload.stepId ),
-					} )
-				);
-
-			case 'SUBMIT_BUTTON_LOAD_ERROR':
-				reduxDispatch(
-					logStashLoadErrorEventAction( 'submit_button_load', String( action.payload ) )
-				);
-
-				return reduxDispatch(
-					recordTracksEvent( 'calypso_checkout_composite_submit_button_load_error', {
-						error_message: String( action.payload ),
-					} )
-				);
-
-			case 'PAYMENT_METHOD_LOAD_ERROR':
-				reduxDispatch(
-					logStashLoadErrorEventAction( 'payment_method_load', String( action.payload ) )
-				);
-
-				return reduxDispatch(
-					recordTracksEvent( 'calypso_checkout_composite_payment_method_load_error', {
-						error_message: String( action.payload ),
-					} )
-				);
-
-			case 'PAYMENT_METHOD_SELECT': {
-				reduxDispatch(
-					logStashEventAction( 'payment_method_select', { newMethodId: String( action.payload ) } )
-				);
-
-				// Need to convert to the slug format used in old checkout so events are comparable
-				const rawPaymentMethodSlug = String( action.payload );
-				const legacyPaymentMethodSlug = translateCheckoutPaymentMethodToTracksPaymentMethod(
-					rawPaymentMethodSlug
-				);
-
-				return reduxDispatch(
-					recordTracksEvent( 'calypso_checkout_switch_to_' + legacyPaymentMethodSlug )
-				);
-			}
-
-			case 'PAGE_LOAD_ERROR':
-				reduxDispatch( logStashLoadErrorEventAction( 'page_load', String( action.payload ) ) );
-
-				return reduxDispatch(
-					recordTracksEvent( 'calypso_checkout_composite_page_load_error', {
-						error_message: String( action.payload ),
-					} )
-				);
-
-			case 'STORED_CARD_ERROR':
-				return reduxDispatch(
-					recordTracksEvent( 'calypso_checkout_composite_stored_card_error', {
-						error_type: action.payload.type,
-						error_message: String( action.payload.message ),
-					} )
-				);
-
-			case 'CART_ERROR':
-				reduxDispatch(
-					logStashEventAction( 'calypso_checkout_composite_cart_error', {
-						type: action.payload.type,
-						message: action.payload.message,
-					} )
-				);
-
-				return reduxDispatch(
-					recordTracksEvent( 'calypso_checkout_composite_cart_error', {
-						error_type: action.payload.type,
-						error_message: String( action.payload.message ),
-					} )
-				);
-
-			case 'a8c_checkout_stripe_field_invalid_error':
-				return reduxDispatch(
-					recordTracksEvent( 'calypso_checkout_composite_stripe_field_invalid_error', {
-						error_type: action.payload.type,
-						error_field: action.payload.field,
-						error_message: action.payload.message,
-					} )
-				);
-
-			case 'a8c_checkout_add_coupon':
-				return reduxDispatch(
-					recordTracksEvent( 'calypso_checkout_composite_coupon_add_submit', {
-						coupon: action.payload.coupon,
-					} )
-				);
-
-			case 'a8c_checkout_cancel_delete_product':
-				return reduxDispatch(
-					recordTracksEvent( 'calypso_checkout_composite_cancel_delete_product' )
-				);
-
-			case 'a8c_checkout_delete_product':
-				return reduxDispatch(
-					recordTracksEvent( 'calypso_checkout_composite_delete_product', {
-						product_name: action.payload.product_name,
-					} )
-				);
-
-			case 'a8c_checkout_delete_product_press':
-				return reduxDispatch(
-					recordTracksEvent( 'calypso_checkout_composite_delete_product_press', {
-						product_name: action.payload.product_name,
-					} )
-				);
-
-			case 'a8c_checkout_add_coupon_error':
-				return reduxDispatch(
-					recordTracksEvent( 'calypso_checkout_composite_coupon_add_error', {
-						error_type: action.payload.type,
-					} )
-				);
-
-			case 'a8c_checkout_add_coupon_button_clicked':
-				return reduxDispatch(
-					recordTracksEvent( 'calypso_checkout_composite_add_coupon_clicked', {} )
-				);
-
-			case 'STEP_NUMBER_CHANGED':
-				if ( action.payload.stepNumber === 2 && action.payload.previousStepNumber === 1 ) {
+		try{
+			debug( 'heard checkout event', action );
+			switch ( action.type ) {
+				case 'CHECKOUT_LOADED':
 					reduxDispatch(
-						recordTracksEvent( 'calypso_checkout_composite_first_step_complete', {
+						recordTracksEvent( 'calypso_checkout_page_view', {
+							saved_cards: action.payload?.saved_cards,
+							is_renewal: action.payload?.is_renewal,
+							apple_pay_available: action.payload?.apple_pay_available,
+							product_slug: action.payload?.product_slug,
+							is_composite: true,
+						} )
+					);
+	
+					return reduxDispatch( recordTracksEvent( 'calypso_checkout_composite_loaded', {} ) );
+	
+				case 'PAYMENT_COMPLETE': {
+					const total_cost = action.payload.total.amount.value / 100; // TODO: This conversion only works for USD! We have to localize this or get it from the server directly (or better yet, just force people to use the integer version).
+	
+					reduxDispatch(
+						recordTracksEvent( 'calypso_checkout_payment_success', {
+							coupon_code: action.payload.couponItem?.wpcom_meta.couponCode ?? '',
+							currency: action.payload.total.amount.currency,
+							payment_method:
+								translateCheckoutPaymentMethodToWpcomPaymentMethod( action.payload.paymentMethodId )
+									?.name || '',
+							total_cost,
+						} )
+					);
+	
+					const transactionResult = select( 'wpcom' ).getTransactionResult();
+					recordPurchase( {
+						cart: {
+							total_cost,
+							currency: action.payload.total.amount.currency,
+							is_signup: action.payload.responseCart.is_signup,
+							products: action.payload.responseCart.products,
+							coupon_code: action.payload.couponItem?.wpcom_meta.couponCode ?? '',
+							total_tax: action.payload.responseCart.total_tax,
+						},
+						orderId: transactionResult.receipt_id,
+					} );
+	
+					return reduxDispatch(
+						recordTracksEvent( 'calypso_checkout_composite_payment_complete', {
+							redirect_url: action.payload.url,
+							coupon_code: action.payload.couponItem?.wpcom_meta.couponCode ?? '',
+							total: action.payload.total.amount.value,
+							currency: action.payload.total.amount.currency,
 							payment_method:
 								translateCheckoutPaymentMethodToWpcomPaymentMethod( action.payload.paymentMethodId )
 									?.name || '',
 						} )
 					);
 				}
-				return reduxDispatch(
-					recordTracksEvent( 'calypso_checkout_composite_step_changed', {
-						step: action.payload.stepNumber,
-					} )
-				);
-
-			case 'STRIPE_TRANSACTION_BEGIN': {
-				reduxDispatch(
-					recordTracksEvent( 'calypso_checkout_form_submit', {
-						credits: null,
-						payment_method: 'WPCOM_Billing_Stripe_Payment_Method',
-					} )
-				);
-				reduxDispatch(
-					recordTracksEvent( 'calypso_checkout_composite_form_submit', {
-						credits: null,
-						payment_method: 'WPCOM_Billing_Stripe_Payment_Method',
-					} )
-				);
-				return reduxDispatch(
-					recordTracksEvent( 'calypso_checkout_composite_stripe_submit_clicked', {} )
-				);
+	
+				case 'CART_INIT_COMPLETE':
+					return reduxDispatch(
+						recordTracksEvent( 'calypso_checkout_composite_cart_loaded', {
+							products: action.payload.products
+								.map( ( product ) => product.product_slug )
+								.join( ',' ),
+						} )
+					);
+	
+				case 'STEP_LOAD_ERROR':
+					reduxDispatch(
+						logStashLoadErrorEventAction( 'step_load', String( action.payload.message ), {
+							stepId: action.payload.stepId,
+						} )
+					);
+	
+					return reduxDispatch(
+						recordTracksEvent( 'calypso_checkout_composite_step_load_error', {
+							error_message: String( action.payload.message ),
+							step_id: String( action.payload.stepId ),
+						} )
+					);
+	
+				case 'SUBMIT_BUTTON_LOAD_ERROR':
+					reduxDispatch(
+						logStashLoadErrorEventAction( 'submit_button_load', String( action.payload ) )
+					);
+	
+					return reduxDispatch(
+						recordTracksEvent( 'calypso_checkout_composite_submit_button_load_error', {
+							error_message: String( action.payload ),
+						} )
+					);
+	
+				case 'PAYMENT_METHOD_LOAD_ERROR':
+					reduxDispatch(
+						logStashLoadErrorEventAction( 'payment_method_load', String( action.payload ) )
+					);
+	
+					return reduxDispatch(
+						recordTracksEvent( 'calypso_checkout_composite_payment_method_load_error', {
+							error_message: String( action.payload ),
+						} )
+					);
+	
+				case 'PAYMENT_METHOD_SELECT': {
+					reduxDispatch(
+						logStashEventAction( 'payment_method_select', { newMethodId: String( action.payload ) } )
+					);
+	
+					// Need to convert to the slug format used in old checkout so events are comparable
+					const rawPaymentMethodSlug = String( action.payload );
+					const legacyPaymentMethodSlug = translateCheckoutPaymentMethodToTracksPaymentMethod(
+						rawPaymentMethodSlug
+					);
+	
+					return reduxDispatch(
+						recordTracksEvent( 'calypso_checkout_switch_to_' + legacyPaymentMethodSlug )
+					);
+				}
+	
+				case 'PAGE_LOAD_ERROR':
+					reduxDispatch( logStashLoadErrorEventAction( 'page_load', String( action.payload ) ) );
+	
+					return reduxDispatch(
+						recordTracksEvent( 'calypso_checkout_composite_page_load_error', {
+							error_message: String( action.payload ),
+						} )
+					);
+	
+				case 'STORED_CARD_ERROR':
+					return reduxDispatch(
+						recordTracksEvent( 'calypso_checkout_composite_stored_card_error', {
+							error_type: action.payload.type,
+							error_message: String( action.payload.message ),
+						} )
+					);
+	
+				case 'CART_ERROR':
+					reduxDispatch(
+						logStashEventAction( 'calypso_checkout_composite_cart_error', {
+							type: action.payload.type,
+							message: action.payload.message,
+						} )
+					);
+	
+					return reduxDispatch(
+						recordTracksEvent( 'calypso_checkout_composite_cart_error', {
+							error_type: action.payload.type,
+							error_message: String( action.payload.message ),
+						} )
+					);
+	
+				case 'a8c_checkout_stripe_field_invalid_error':
+					return reduxDispatch(
+						recordTracksEvent( 'calypso_checkout_composite_stripe_field_invalid_error', {
+							error_type: action.payload.type,
+							error_field: action.payload.field,
+							error_message: action.payload.message,
+						} )
+					);
+	
+				case 'a8c_checkout_add_coupon':
+					return reduxDispatch(
+						recordTracksEvent( 'calypso_checkout_composite_coupon_add_submit', {
+							coupon: action.payload.coupon,
+						} )
+					);
+	
+				case 'a8c_checkout_cancel_delete_product':
+					return reduxDispatch(
+						recordTracksEvent( 'calypso_checkout_composite_cancel_delete_product' )
+					);
+	
+				case 'a8c_checkout_delete_product':
+					return reduxDispatch(
+						recordTracksEvent( 'calypso_checkout_composite_delete_product', {
+							product_name: action.payload.product_name,
+						} )
+					);
+	
+				case 'a8c_checkout_delete_product_press':
+					return reduxDispatch(
+						recordTracksEvent( 'calypso_checkout_composite_delete_product_press', {
+							product_name: action.payload.product_name,
+						} )
+					);
+	
+				case 'a8c_checkout_add_coupon_error':
+					return reduxDispatch(
+						recordTracksEvent( 'calypso_checkout_composite_coupon_add_error', {
+							error_type: action.payload.type,
+						} )
+					);
+	
+				case 'a8c_checkout_add_coupon_button_clicked':
+					return reduxDispatch(
+						recordTracksEvent( 'calypso_checkout_composite_add_coupon_clicked', {} )
+					);
+	
+				case 'STEP_NUMBER_CHANGED':
+					if ( action.payload.stepNumber === 2 && action.payload.previousStepNumber === 1 ) {
+						reduxDispatch(
+							recordTracksEvent( 'calypso_checkout_composite_first_step_complete', {
+								payment_method:
+									translateCheckoutPaymentMethodToWpcomPaymentMethod( action.payload.paymentMethodId )
+										?.name || '',
+							} )
+						);
+					}
+					return reduxDispatch(
+						recordTracksEvent( 'calypso_checkout_composite_step_changed', {
+							step: action.payload.stepNumber,
+						} )
+					);
+	
+				case 'STRIPE_TRANSACTION_BEGIN': {
+					reduxDispatch(
+						recordTracksEvent( 'calypso_checkout_form_submit', {
+							credits: null,
+							payment_method: 'WPCOM_Billing_Stripe_Payment_Method',
+						} )
+					);
+					reduxDispatch(
+						recordTracksEvent( 'calypso_checkout_composite_form_submit', {
+							credits: null,
+							payment_method: 'WPCOM_Billing_Stripe_Payment_Method',
+						} )
+					);
+					return reduxDispatch(
+						recordTracksEvent( 'calypso_checkout_composite_stripe_submit_clicked', {} )
+					);
+				}
+	
+				case 'EBANX_TRANSACTION_BEGIN': {
+					reduxDispatch(
+						recordTracksEvent( 'calypso_checkout_form_submit', {
+							credits: null,
+							payment_method: 'WPCOM_Billing_Ebanx',
+						} )
+					);
+					reduxDispatch(
+						recordTracksEvent( 'calypso_checkout_composite_form_submit', {
+							credits: null,
+							payment_method: 'WPCOM_Billing_Ebanx',
+						} )
+					);
+					return reduxDispatch(
+						recordTracksEvent( 'calypso_checkout_composite_stripe_submit_clicked', {} )
+					);
+				}
+	
+				case 'TRANSACTION_ERROR': {
+					reduxDispatch(
+						recordTracksEvent( 'calypso_checkout_payment_error', {
+							error_code: null,
+							reason: String( action.payload.message ),
+						} )
+					);
+					reduxDispatch(
+						recordTracksEvent( 'calypso_checkout_composite_payment_error', {
+							error_code: null,
+							payment_method:
+								translateCheckoutPaymentMethodToWpcomPaymentMethod( action.payload.paymentMethodId )
+									?.name || '',
+							reason: String( action.payload.message ),
+						} )
+					);
+					return reduxDispatch(
+						recordTracksEvent( 'calypso_checkout_composite_stripe_transaction_error', {
+							error_message: String( action.payload.message ),
+						} )
+					);
+				}
+	
+				case 'FREE_TRANSACTION_BEGIN': {
+					reduxDispatch(
+						recordTracksEvent( 'calypso_checkout_form_submit', {
+							credits: null,
+							payment_method: 'WPCOM_Billing_WPCOM',
+						} )
+					);
+					reduxDispatch(
+						recordTracksEvent( 'calypso_checkout_composite_form_submit', {
+							credits: null,
+							payment_method: 'WPCOM_Billing_WPCOM',
+						} )
+					);
+					return reduxDispatch(
+						recordTracksEvent( 'calypso_checkout_composite_free_purchase_submit_clicked', {} )
+					);
+				}
+	
+				case 'REDIRECT_TRANSACTION_BEGIN': {
+					reduxDispatch( recordTracksEvent( 'calypso_checkout_form_redirect', {} ) );
+					reduxDispatch(
+						recordTracksEvent( 'calypso_checkout_form_submit', {
+							credits: null,
+							payment_method:
+								translateCheckoutPaymentMethodToWpcomPaymentMethod( action.payload.paymentMethodId )
+									?.name || '',
+						} )
+					);
+					reduxDispatch(
+						recordTracksEvent( 'calypso_checkout_composite_form_submit', {
+							credits: null,
+							payment_method:
+								translateCheckoutPaymentMethodToWpcomPaymentMethod( action.payload.paymentMethodId )
+									?.name || '',
+						} )
+					);
+					const paymentMethodIdForTracks = action.payload.paymentMethodId
+						.replace( /-/, '_' )
+						.toLowerCase();
+					return reduxDispatch(
+						recordTracksEvent(
+							`calypso_checkout_composite_${ paymentMethodIdForTracks }_submit_clicked`,
+							{}
+						)
+					);
+				}
+	
+				case 'FULL_CREDITS_TRANSACTION_BEGIN': {
+					reduxDispatch(
+						recordTracksEvent( 'calypso_checkout_form_submit', {
+							credits: null,
+							payment_method: 'WPCOM_Billing_WPCOM',
+						} )
+					);
+					reduxDispatch(
+						recordTracksEvent( 'calypso_checkout_composite_form_submit', {
+							credits: null,
+							payment_method: 'WPCOM_Billing_WPCOM',
+						} )
+					);
+					return reduxDispatch(
+						recordTracksEvent( 'calypso_checkout_composite_full_credits_submit_clicked', {} )
+					);
+				}
+	
+				case 'EXISTING_CARD_TRANSACTION_BEGIN': {
+					reduxDispatch(
+						recordTracksEvent( 'calypso_checkout_form_submit', {
+							credits: null,
+							payment_method: 'WPCOM_Billing_MoneyPress_Stored',
+						} )
+					);
+					reduxDispatch(
+						recordTracksEvent( 'calypso_checkout_composite_form_submit', {
+							credits: null,
+							payment_method: 'WPCOM_Billing_MoneyPress_Stored',
+						} )
+					);
+					return reduxDispatch(
+						recordTracksEvent( 'calypso_checkout_composite_existing_card_submit_clicked', {} )
+					);
+				}
+	
+				case 'APPLE_PAY_TRANSACTION_BEGIN': {
+					reduxDispatch(
+						recordTracksEvent( 'calypso_checkout_form_submit', {
+							credits: null,
+							payment_method: 'WPCOM_Billing_Web_Payment',
+						} )
+					);
+					reduxDispatch(
+						recordTracksEvent( 'calypso_checkout_composite_form_submit', {
+							credits: null,
+							payment_method: 'WPCOM_Billing_Web_Payment',
+						} )
+					);
+					return reduxDispatch(
+						recordTracksEvent( 'calypso_checkout_composite_apple_pay_submit_clicked', {} )
+					);
+				}
+	
+				case 'APPLE_PAY_LOADING_ERROR':
+					return reduxDispatch(
+						recordTracksEvent( 'calypso_checkout_composite_apple_pay_error', {
+							error_message: String( action.payload ),
+							is_loading_error: true,
+						} )
+					);
+	
+				case 'VALIDATE_DOMAIN_CONTACT_INFO': {
+					// TODO: Decide what to do here
+					return;
+				}
+	
+				case 'SHOW_MODAL_AUTHORIZATION': {
+					return reduxDispatch( recordTracksEvent( 'calypso_checkout_modal_authorization', {} ) );
+				}
+	
+				case 'calypso_checkout_composite_summary_help_click': {
+					return reduxDispatch(
+						recordTracksEvent( 'calypso_checkout_composite_summary_help_click' )
+					);
+				}
+	
+				case 'CART_ADD_ITEM': {
+					return recordAddEvent( action.payload );
+				}
+	
+				case 'THANK_YOU_URL_GENERATED':
+					return reduxDispatch(
+						logStashEventAction( 'thank you url generated', {
+							url: action.payload.url,
+							arguments: action.payload.arguments,
+						} )
+					);
+	
+				default:
+					debug( 'unknown checkout event', action );
+					return reduxDispatch(
+						recordTracksEvent( 'calypso_checkout_composite_unknown_event', {
+							error_type: String( action.type ),
+						} )
+					);
 			}
-
-			case 'EBANX_TRANSACTION_BEGIN': {
-				reduxDispatch(
-					recordTracksEvent( 'calypso_checkout_form_submit', {
-						credits: null,
-						payment_method: 'WPCOM_Billing_Ebanx',
-					} )
-				);
-				reduxDispatch(
-					recordTracksEvent( 'calypso_checkout_composite_form_submit', {
-						credits: null,
-						payment_method: 'WPCOM_Billing_Ebanx',
-					} )
-				);
-				return reduxDispatch(
-					recordTracksEvent( 'calypso_checkout_composite_stripe_submit_clicked', {} )
-				);
-			}
-
-			case 'TRANSACTION_ERROR': {
-				reduxDispatch(
-					recordTracksEvent( 'calypso_checkout_payment_error', {
-						error_code: null,
-						reason: String( action.payload.message ),
-					} )
-				);
-				reduxDispatch(
-					recordTracksEvent( 'calypso_checkout_composite_payment_error', {
-						error_code: null,
-						payment_method:
-							translateCheckoutPaymentMethodToWpcomPaymentMethod( action.payload.paymentMethodId )
-								?.name || '',
-						reason: String( action.payload.message ),
-					} )
-				);
-				return reduxDispatch(
-					recordTracksEvent( 'calypso_checkout_composite_stripe_transaction_error', {
-						error_message: String( action.payload.message ),
-					} )
-				);
-			}
-
-			case 'FREE_TRANSACTION_BEGIN': {
-				reduxDispatch(
-					recordTracksEvent( 'calypso_checkout_form_submit', {
-						credits: null,
-						payment_method: 'WPCOM_Billing_WPCOM',
-					} )
-				);
-				reduxDispatch(
-					recordTracksEvent( 'calypso_checkout_composite_form_submit', {
-						credits: null,
-						payment_method: 'WPCOM_Billing_WPCOM',
-					} )
-				);
-				return reduxDispatch(
-					recordTracksEvent( 'calypso_checkout_composite_free_purchase_submit_clicked', {} )
-				);
-			}
-
-			case 'REDIRECT_TRANSACTION_BEGIN': {
-				reduxDispatch( recordTracksEvent( 'calypso_checkout_form_redirect', {} ) );
-				reduxDispatch(
-					recordTracksEvent( 'calypso_checkout_form_submit', {
-						credits: null,
-						payment_method:
-							translateCheckoutPaymentMethodToWpcomPaymentMethod( action.payload.paymentMethodId )
-								?.name || '',
-					} )
-				);
-				reduxDispatch(
-					recordTracksEvent( 'calypso_checkout_composite_form_submit', {
-						credits: null,
-						payment_method:
-							translateCheckoutPaymentMethodToWpcomPaymentMethod( action.payload.paymentMethodId )
-								?.name || '',
-					} )
-				);
-				const paymentMethodIdForTracks = action.payload.paymentMethodId
-					.replace( /-/, '_' )
-					.toLowerCase();
-				return reduxDispatch(
-					recordTracksEvent(
-						`calypso_checkout_composite_${ paymentMethodIdForTracks }_submit_clicked`,
-						{}
-					)
-				);
-			}
-
-			case 'FULL_CREDITS_TRANSACTION_BEGIN': {
-				reduxDispatch(
-					recordTracksEvent( 'calypso_checkout_form_submit', {
-						credits: null,
-						payment_method: 'WPCOM_Billing_WPCOM',
-					} )
-				);
-				reduxDispatch(
-					recordTracksEvent( 'calypso_checkout_composite_form_submit', {
-						credits: null,
-						payment_method: 'WPCOM_Billing_WPCOM',
-					} )
-				);
-				return reduxDispatch(
-					recordTracksEvent( 'calypso_checkout_composite_full_credits_submit_clicked', {} )
-				);
-			}
-
-			case 'EXISTING_CARD_TRANSACTION_BEGIN': {
-				reduxDispatch(
-					recordTracksEvent( 'calypso_checkout_form_submit', {
-						credits: null,
-						payment_method: 'WPCOM_Billing_MoneyPress_Stored',
-					} )
-				);
-				reduxDispatch(
-					recordTracksEvent( 'calypso_checkout_composite_form_submit', {
-						credits: null,
-						payment_method: 'WPCOM_Billing_MoneyPress_Stored',
-					} )
-				);
-				return reduxDispatch(
-					recordTracksEvent( 'calypso_checkout_composite_existing_card_submit_clicked', {} )
-				);
-			}
-
-			case 'APPLE_PAY_TRANSACTION_BEGIN': {
-				reduxDispatch(
-					recordTracksEvent( 'calypso_checkout_form_submit', {
-						credits: null,
-						payment_method: 'WPCOM_Billing_Web_Payment',
-					} )
-				);
-				reduxDispatch(
-					recordTracksEvent( 'calypso_checkout_composite_form_submit', {
-						credits: null,
-						payment_method: 'WPCOM_Billing_Web_Payment',
-					} )
-				);
-				return reduxDispatch(
-					recordTracksEvent( 'calypso_checkout_composite_apple_pay_submit_clicked', {} )
-				);
-			}
-
-			case 'APPLE_PAY_LOADING_ERROR':
-				return reduxDispatch(
-					recordTracksEvent( 'calypso_checkout_composite_apple_pay_error', {
-						error_message: String( action.payload ),
-						is_loading_error: true,
-					} )
-				);
-
-			case 'VALIDATE_DOMAIN_CONTACT_INFO': {
-				// TODO: Decide what to do here
-				return;
-			}
-
-			case 'SHOW_MODAL_AUTHORIZATION': {
-				return reduxDispatch( recordTracksEvent( 'calypso_checkout_modal_authorization', {} ) );
-			}
-
-			case 'calypso_checkout_composite_summary_help_click': {
-				return reduxDispatch(
-					recordTracksEvent( 'calypso_checkout_composite_summary_help_click' )
-				);
-			}
-
-			case 'CART_ADD_ITEM': {
-				return recordAddEvent( action.payload );
-			}
-
-			case 'THANK_YOU_URL_GENERATED':
-				return reduxDispatch(
-					logStashEventAction( 'thank you url generated', {
-						url: action.payload.url,
-						arguments: action.payload.arguments,
-					} )
-				);
-
-			default:
-				debug( 'unknown checkout event', action );
-				return reduxDispatch(
-					recordTracksEvent( 'calypso_checkout_composite_unknown_event', {
-						error_type: String( action.type ),
-					} )
-				);
+		} catch(err) {
+			debug( 'checkout event error', err.message );
+			return reduxDispatch(
+				logStashLoadErrorEventAction( 'calypso_checkout_composite_error', err.message )
+			);
 		}
 	};
 }

--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -20,7 +20,7 @@ const debug = debugFactory( 'calypso:composite-checkout:record-analytics' );
 
 export default function createAnalyticsEventHandler( reduxDispatch ) {
 	return function recordEvent( action ) {
-		try{
+		try {
 			debug( 'heard checkout event', action );
 			switch ( action.type ) {
 				case 'CHECKOUT_LOADED':
@@ -33,12 +33,9 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 							is_composite: true,
 						} )
 					);
-	
 					return reduxDispatch( recordTracksEvent( 'calypso_checkout_composite_loaded', {} ) );
-	
 				case 'PAYMENT_COMPLETE': {
 					const total_cost = action.payload.total.amount.value / 100; // TODO: This conversion only works for USD! We have to localize this or get it from the server directly (or better yet, just force people to use the integer version).
-	
 					reduxDispatch(
 						recordTracksEvent( 'calypso_checkout_payment_success', {
 							coupon_code: action.payload.couponItem?.wpcom_meta.couponCode ?? '',
@@ -49,7 +46,6 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 							total_cost,
 						} )
 					);
-	
 					const transactionResult = select( 'wpcom' ).getTransactionResult();
 					recordPurchase( {
 						cart: {
@@ -62,7 +58,6 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 						},
 						orderId: transactionResult.receipt_id,
 					} );
-	
 					return reduxDispatch(
 						recordTracksEvent( 'calypso_checkout_composite_payment_complete', {
 							redirect_url: action.payload.url,
@@ -75,7 +70,6 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 						} )
 					);
 				}
-	
 				case 'CART_INIT_COMPLETE':
 					return reduxDispatch(
 						recordTracksEvent( 'calypso_checkout_composite_cart_loaded', {
@@ -84,68 +78,58 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 								.join( ',' ),
 						} )
 					);
-	
 				case 'STEP_LOAD_ERROR':
 					reduxDispatch(
 						logStashLoadErrorEventAction( 'step_load', String( action.payload.message ), {
 							stepId: action.payload.stepId,
 						} )
 					);
-	
 					return reduxDispatch(
 						recordTracksEvent( 'calypso_checkout_composite_step_load_error', {
 							error_message: String( action.payload.message ),
 							step_id: String( action.payload.stepId ),
 						} )
 					);
-	
 				case 'SUBMIT_BUTTON_LOAD_ERROR':
 					reduxDispatch(
 						logStashLoadErrorEventAction( 'submit_button_load', String( action.payload ) )
 					);
-	
 					return reduxDispatch(
 						recordTracksEvent( 'calypso_checkout_composite_submit_button_load_error', {
 							error_message: String( action.payload ),
 						} )
 					);
-	
 				case 'PAYMENT_METHOD_LOAD_ERROR':
 					reduxDispatch(
 						logStashLoadErrorEventAction( 'payment_method_load', String( action.payload ) )
 					);
-	
 					return reduxDispatch(
 						recordTracksEvent( 'calypso_checkout_composite_payment_method_load_error', {
 							error_message: String( action.payload ),
 						} )
 					);
-	
 				case 'PAYMENT_METHOD_SELECT': {
 					reduxDispatch(
-						logStashEventAction( 'payment_method_select', { newMethodId: String( action.payload ) } )
+						logStashEventAction( 'payment_method_select', {
+							newMethodId: String( action.payload ),
+						} )
 					);
-	
 					// Need to convert to the slug format used in old checkout so events are comparable
 					const rawPaymentMethodSlug = String( action.payload );
 					const legacyPaymentMethodSlug = translateCheckoutPaymentMethodToTracksPaymentMethod(
 						rawPaymentMethodSlug
 					);
-	
 					return reduxDispatch(
 						recordTracksEvent( 'calypso_checkout_switch_to_' + legacyPaymentMethodSlug )
 					);
 				}
-	
 				case 'PAGE_LOAD_ERROR':
 					reduxDispatch( logStashLoadErrorEventAction( 'page_load', String( action.payload ) ) );
-	
 					return reduxDispatch(
 						recordTracksEvent( 'calypso_checkout_composite_page_load_error', {
 							error_message: String( action.payload ),
 						} )
 					);
-	
 				case 'STORED_CARD_ERROR':
 					return reduxDispatch(
 						recordTracksEvent( 'calypso_checkout_composite_stored_card_error', {
@@ -153,7 +137,6 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 							error_message: String( action.payload.message ),
 						} )
 					);
-	
 				case 'CART_ERROR':
 					reduxDispatch(
 						logStashEventAction( 'calypso_checkout_composite_cart_error', {
@@ -161,14 +144,12 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 							message: action.payload.message,
 						} )
 					);
-	
 					return reduxDispatch(
 						recordTracksEvent( 'calypso_checkout_composite_cart_error', {
 							error_type: action.payload.type,
 							error_message: String( action.payload.message ),
 						} )
 					);
-	
 				case 'a8c_checkout_stripe_field_invalid_error':
 					return reduxDispatch(
 						recordTracksEvent( 'calypso_checkout_composite_stripe_field_invalid_error', {
@@ -177,52 +158,46 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 							error_message: action.payload.message,
 						} )
 					);
-	
 				case 'a8c_checkout_add_coupon':
 					return reduxDispatch(
 						recordTracksEvent( 'calypso_checkout_composite_coupon_add_submit', {
 							coupon: action.payload.coupon,
 						} )
 					);
-	
 				case 'a8c_checkout_cancel_delete_product':
 					return reduxDispatch(
 						recordTracksEvent( 'calypso_checkout_composite_cancel_delete_product' )
 					);
-	
 				case 'a8c_checkout_delete_product':
 					return reduxDispatch(
 						recordTracksEvent( 'calypso_checkout_composite_delete_product', {
 							product_name: action.payload.product_name,
 						} )
 					);
-	
 				case 'a8c_checkout_delete_product_press':
 					return reduxDispatch(
 						recordTracksEvent( 'calypso_checkout_composite_delete_product_press', {
 							product_name: action.payload.product_name,
 						} )
 					);
-	
 				case 'a8c_checkout_add_coupon_error':
 					return reduxDispatch(
 						recordTracksEvent( 'calypso_checkout_composite_coupon_add_error', {
 							error_type: action.payload.type,
 						} )
 					);
-	
 				case 'a8c_checkout_add_coupon_button_clicked':
 					return reduxDispatch(
 						recordTracksEvent( 'calypso_checkout_composite_add_coupon_clicked', {} )
 					);
-	
 				case 'STEP_NUMBER_CHANGED':
 					if ( action.payload.stepNumber === 2 && action.payload.previousStepNumber === 1 ) {
 						reduxDispatch(
 							recordTracksEvent( 'calypso_checkout_composite_first_step_complete', {
 								payment_method:
-									translateCheckoutPaymentMethodToWpcomPaymentMethod( action.payload.paymentMethodId )
-										?.name || '',
+									translateCheckoutPaymentMethodToWpcomPaymentMethod(
+										action.payload.paymentMethodId
+									)?.name || '',
 							} )
 						);
 					}
@@ -231,7 +206,6 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 							step: action.payload.stepNumber,
 						} )
 					);
-	
 				case 'STRIPE_TRANSACTION_BEGIN': {
 					reduxDispatch(
 						recordTracksEvent( 'calypso_checkout_form_submit', {
@@ -249,7 +223,6 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 						recordTracksEvent( 'calypso_checkout_composite_stripe_submit_clicked', {} )
 					);
 				}
-	
 				case 'EBANX_TRANSACTION_BEGIN': {
 					reduxDispatch(
 						recordTracksEvent( 'calypso_checkout_form_submit', {
@@ -267,7 +240,6 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 						recordTracksEvent( 'calypso_checkout_composite_stripe_submit_clicked', {} )
 					);
 				}
-	
 				case 'TRANSACTION_ERROR': {
 					reduxDispatch(
 						recordTracksEvent( 'calypso_checkout_payment_error', {
@@ -290,7 +262,6 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 						} )
 					);
 				}
-	
 				case 'FREE_TRANSACTION_BEGIN': {
 					reduxDispatch(
 						recordTracksEvent( 'calypso_checkout_form_submit', {
@@ -308,7 +279,6 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 						recordTracksEvent( 'calypso_checkout_composite_free_purchase_submit_clicked', {} )
 					);
 				}
-	
 				case 'REDIRECT_TRANSACTION_BEGIN': {
 					reduxDispatch( recordTracksEvent( 'calypso_checkout_form_redirect', {} ) );
 					reduxDispatch(
@@ -337,7 +307,6 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 						)
 					);
 				}
-	
 				case 'FULL_CREDITS_TRANSACTION_BEGIN': {
 					reduxDispatch(
 						recordTracksEvent( 'calypso_checkout_form_submit', {
@@ -355,7 +324,6 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 						recordTracksEvent( 'calypso_checkout_composite_full_credits_submit_clicked', {} )
 					);
 				}
-	
 				case 'EXISTING_CARD_TRANSACTION_BEGIN': {
 					reduxDispatch(
 						recordTracksEvent( 'calypso_checkout_form_submit', {
@@ -373,7 +341,6 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 						recordTracksEvent( 'calypso_checkout_composite_existing_card_submit_clicked', {} )
 					);
 				}
-	
 				case 'APPLE_PAY_TRANSACTION_BEGIN': {
 					reduxDispatch(
 						recordTracksEvent( 'calypso_checkout_form_submit', {
@@ -391,7 +358,6 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 						recordTracksEvent( 'calypso_checkout_composite_apple_pay_submit_clicked', {} )
 					);
 				}
-	
 				case 'APPLE_PAY_LOADING_ERROR':
 					return reduxDispatch(
 						recordTracksEvent( 'calypso_checkout_composite_apple_pay_error', {
@@ -399,26 +365,21 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 							is_loading_error: true,
 						} )
 					);
-	
 				case 'VALIDATE_DOMAIN_CONTACT_INFO': {
 					// TODO: Decide what to do here
 					return;
 				}
-	
 				case 'SHOW_MODAL_AUTHORIZATION': {
 					return reduxDispatch( recordTracksEvent( 'calypso_checkout_modal_authorization', {} ) );
 				}
-	
 				case 'calypso_checkout_composite_summary_help_click': {
 					return reduxDispatch(
 						recordTracksEvent( 'calypso_checkout_composite_summary_help_click' )
 					);
 				}
-	
 				case 'CART_ADD_ITEM': {
 					return recordAddEvent( action.payload );
 				}
-	
 				case 'THANK_YOU_URL_GENERATED':
 					return reduxDispatch(
 						logStashEventAction( 'thank you url generated', {
@@ -426,7 +387,6 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 							arguments: action.payload.arguments,
 						} )
 					);
-	
 				default:
 					debug( 'unknown checkout event', action );
 					return reduxDispatch(
@@ -435,7 +395,7 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 						} )
 					);
 			}
-		} catch(err) {
+		} catch ( err ) {
 			debug( 'checkout event error', err.message );
 			return reduxDispatch(
 				logStashLoadErrorEventAction( 'calypso_checkout_composite_error', err.message )


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Wrap `recordEvent()` function body in try/catch. In case of exception, report to logstash.

Fixes https://github.com/Automattic/wp-calypso/issues/45226
