### PR TITLE
Editing Toolkit Sidebar: Update design

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/class-wpcom-block-editor-nav-sidebar.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/class-wpcom-block-editor-nav-sidebar.php
@@ -71,7 +71,6 @@ class WPCOM_Block_Editor_Nav_Sidebar {
 			'wpcom-block-editor-nav-sidebar-script',
 			'wpcomBlockEditorNavSidebar',
 			array(
-				'homeUrl'          => home_url(),
 				'postIdsToExclude' => $post_ids_to_exclude,
 			)
 		);

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/create-page/style.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/create-page/style.scss
@@ -5,7 +5,8 @@
 	background: inherit !important;
 	padding: 8px 11px !important;
 	color: $light-gray-900 !important;
-	margin: 5px;
+	margin: 0;
+	min-height: 45px;
 
 	&:focus {
 		color: $white;

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/create-page/style.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/create-page/style.scss
@@ -4,6 +4,8 @@
 	width: 100%;
 	background: inherit !important;
 	padding: 8px 11px !important;
+	color: $light-gray-900 !important;
+	margin: 5px;
 
 	&:focus {
 		color: $white;
@@ -12,5 +14,11 @@
 		outline: none !important;
 		border-radius: 0;
 		padding: 7px 10px !important;
+	}
+
+	svg {
+		background: white;
+		color: black;
+		border-radius: 2px;
 	}
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useLayoutEffect, useRef, useEffect, useState } from '@wordpress/element';
+import { useLayoutEffect, useRef } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { useDispatch, useSelect } from '@wordpress/data';
 import {
@@ -62,58 +62,6 @@ function WpcomBlockEditorNavSidebar() {
 
 		prevIsOpen.current = isOpen;
 	}, [ isOpen, prevIsOpen, setSidebarClosing ] );
-
-	const [ isScrollbarPresent, setIsScrollbarPresent ] = useState( false );
-	const observer = useRef< IntersectionObserver >();
-	/*
-	const itemRefs = useRef< ( HTMLElement | null )[] >( [] );
-*/
-
-	const containerMount = ( el: HTMLDivElement | null ) => {
-		if ( el ) {
-			el.focus();
-		}
-
-		if ( observer.current ) {
-			observer.current.disconnect();
-		}
-
-		if ( ! window.IntersectionObserver ) {
-			return;
-		}
-
-		observer.current = new window.IntersectionObserver(
-			( entries ) => {
-				// If one item isn't currently visible, then the scrollbar isn't present
-				const isPresent = entries.some( ( entry ) => ! entry.isIntersecting );
-				setIsScrollbarPresent( isPresent );
-			},
-			{
-				root: el,
-				threshold: [ 1 ], // We want to fire the above callback when an entry isn't 100% visible
-			}
-		);
-	};
-
-	/*	const itemMount = ( el: HTMLElement | null, itemIndex: number ) => {
-		itemRefs.current[ itemIndex ] = el;
-	};*/
-
-	useEffect( () => {
-		if ( ! observer.current ) {
-			return;
-		}
-
-		observer.current.disconnect();
-
-		/*		const nonSparse = itemRefs.current.filter( Boolean ) as HTMLElement[];
-
-		// We only need to observe the first and last item in the list, might be better for performance
-		const firstItem = nonSparse[ 0 ];
-		const lastItem = nonSparse[ nonSparse.length - 1 ];
-		if ( firstItem ) observer.current.observe( firstItem );
-		if ( lastItem ) observer.current.observe( lastItem );*/
-	}, [ currentPost, draftPosts, recentPosts, observer ] );
 
 	if ( ! postType ) {
 		// Still loading
@@ -188,7 +136,6 @@ function WpcomBlockEditorNavSidebar() {
 				className={ classNames( 'wpcom-block-editor-nav-sidebar-nav-sidebar__container', {
 					'is-sliding-left': isClosing,
 				} ) }
-				ref={ containerMount }
 				role="dialog"
 				tabIndex={ -1 }
 			>
@@ -268,11 +215,7 @@ function WpcomBlockEditorNavSidebar() {
 						</>
 					) }
 				</section>
-				<div
-					className={ classNames( 'wpcom-block-editor-nav-sidebar-nav-sidebar__bottom-buttons', {
-						'is-scrollbar-present': isScrollbarPresent,
-					} ) }
-				>
+				<div className="wpcom-block-editor-nav-sidebar-nav-sidebar__bottom-buttons">
 					<CreatePage postType={ postType } />
 				</div>
 			</div>

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
@@ -63,6 +63,12 @@ function WpcomBlockEditorNavSidebar() {
 		prevIsOpen.current = isOpen;
 	}, [ isOpen, prevIsOpen, setSidebarClosing ] );
 
+	const containerMount = ( el: HTMLDivElement | null ) => {
+		if ( el ) {
+			el.focus();
+		}
+	};
+
 	if ( ! postType ) {
 		// Still loading
 		return null;
@@ -136,6 +142,7 @@ function WpcomBlockEditorNavSidebar() {
 				className={ classNames( 'wpcom-block-editor-nav-sidebar-nav-sidebar__container', {
 					'is-sliding-left': isClosing,
 				} ) }
+				ref={ containerMount }
 				role="dialog"
 				tabIndex={ -1 }
 			>
@@ -178,7 +185,7 @@ function WpcomBlockEditorNavSidebar() {
 						/>
 					</ul>
 				) }
-				<section className="wpcom-block-editor-nav-sidebar-nav-sidebar__post-scroll-area">
+				<div className="wpcom-block-editor-nav-sidebar-nav-sidebar__post-scroll-area">
 					{ ! isEmpty( recentPosts ) && (
 						<>
 							<h3 className="wpcom-block-editor-nav-sidebar-nav-sidebar__list-subheading">
@@ -214,7 +221,7 @@ function WpcomBlockEditorNavSidebar() {
 							</ul>
 						</>
 					) }
-				</section>
+				</div>
 				<div className="wpcom-block-editor-nav-sidebar-nav-sidebar__bottom-buttons">
 					<CreatePage postType={ postType } />
 				</div>
@@ -234,7 +241,7 @@ function useNavItems(): Record< string, Post[] > {
 			getEditedPostAttribute,
 		} = select( 'core/editor' );
 
-		const statuses = select( 'core' ).getEntityRecords( 'root', 'status' ) as any[];
+		const statuses = select( 'core' ).getEntityRecords( 'root', 'status' );
 		if ( ! statuses ) {
 			return [];
 		}
@@ -258,7 +265,6 @@ function useNavItems(): Record< string, Post[] > {
 
 		const current = {
 			id: currentPostId,
-			slug: getEditedPostAttribute( 'slug' ),
 			status: isEditedPostNew() ? 'draft' : getEditedPostAttribute( 'status' ),
 			title: { raw: getEditedPostAttribute( 'title' ), rendered: '' },
 		};
@@ -282,7 +288,7 @@ function useNavItems(): Record< string, Post[] > {
 
 function usePostStatusLabels(): Record< string, string > {
 	return useSelect( ( select ) => {
-		const items = select( 'core' ).getEntityRecords( 'root', 'status' ) as [  ];
+		const items = select( 'core' ).getEntityRecords( 'root', 'status' );
 		return ( items || [] ).reduce(
 			( acc, { name, slug } ) => ( slug === 'publish' ? acc : { ...acc, [ slug ]: name } ),
 			{}

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
@@ -232,41 +232,43 @@ function WpcomBlockEditorNavSidebar() {
 						/>
 					</ul>
 				) }
-				{ posts.recent && posts.recent.length && (
-					<>
-						<h3 className="wpcom-block-editor-nav-sidebar-nav-sidebar__list-subheading">
-							{ __( 'Recently edited', 'full-site-editing' ) }
-						</h3>
-						<ul className="wpcom-block-editor-nav-sidebar-nav-sidebar__page-list">
-							{ posts.recent.map( ( item) => (
+				<section className="wpcom-block-editor-nav-sidebar-nav-sidebar__post-scroll-area">
+					{ posts.recent && posts.recent.length && (
+						<>
+							<h3 className="wpcom-block-editor-nav-sidebar-nav-sidebar__list-subheading">
+								{ __( 'Recently edited', 'full-site-editing' ) }
+							</h3>
+							<ul className="wpcom-block-editor-nav-sidebar-nav-sidebar__page-list">
+								{ posts.recent.map( ( item) => (
+									<NavItem
+										key={ item.id }
+										item={ item }
+										postType={ postType } // We know the post type of this item is always the same as the post type of the current editor
+										selected={ item.id === selectedItemId }
+										statusLabel={ statusLabels[ item.status ] }
+									/>
+								) ) }
+							</ul>
+						</>
+					) }
+					{ posts.drafts && posts.drafts.length && (
+						<>
+							<h3 className="wpcom-block-editor-nav-sidebar-nav-sidebar__list-subheading">
+								{ __( 'Drafts', 'full-site-editing' ) }
+							</h3>
+							<ul className="wpcom-block-editor-nav-sidebar-nav-sidebar__page-list">
+							{ posts.drafts.map( ( item ) => (
 								<NavItem
 									key={ item.id }
 									item={ item }
 									postType={ postType } // We know the post type of this item is always the same as the post type of the current editor
 									selected={ item.id === selectedItemId }
-									statusLabel={ statusLabels[ item.status ] }
 								/>
 							) ) }
-						</ul>
-					</>
-				) }
-				{ posts.drafts && posts.drafts.length && (
-					<>
-						<h3 className="wpcom-block-editor-nav-sidebar-nav-sidebar__list-subheading">
-							{ __( 'Drafts', 'full-site-editing' ) }
-						</h3>
-						<ul className="wpcom-block-editor-nav-sidebar-nav-sidebar__page-list">
-						{ posts.drafts.map( ( item ) => (
-							<NavItem
-								key={ item.id }
-								item={ item }
-								postType={ postType } // We know the post type of this item is always the same as the post type of the current editor
-								selected={ item.id === selectedItemId }
-							/>
-						) ) }
-						</ul>
-					</>
-				) }
+							</ul>
+						</>
+					) }
+				</section>
 				<div
 					className={ classNames( 'wpcom-block-editor-nav-sidebar-nav-sidebar__bottom-buttons', {
 						'is-scrollbar-present': isScrollbarPresent,

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
@@ -49,9 +49,7 @@ function WpcomBlockEditorNavSidebar() {
 	} );
 
 	const { current: currentPost, drafts: draftPosts, recent: recentPosts } = useNavItems();
-	console.log( 'posts', currentPost, draftPosts, recentPosts );
 	const statusLabels = usePostStatusLabels();
-
 	const prevIsOpen = useRef( isOpen );
 
 	// Using layout effect to prevent a brief moment in time where both `isOpen` and `isClosing`
@@ -66,9 +64,10 @@ function WpcomBlockEditorNavSidebar() {
 	}, [ isOpen, prevIsOpen, setSidebarClosing ] );
 
 	const [ isScrollbarPresent, setIsScrollbarPresent ] = useState( false );
-
 	const observer = useRef< IntersectionObserver >();
+	/*
 	const itemRefs = useRef< ( HTMLElement | null )[] >( [] );
+*/
 
 	const containerMount = ( el: HTMLDivElement | null ) => {
 		if ( el ) {
@@ -96,7 +95,7 @@ function WpcomBlockEditorNavSidebar() {
 		);
 	};
 
-/*	const itemMount = ( el: HTMLElement | null, itemIndex: number ) => {
+	/*	const itemMount = ( el: HTMLElement | null, itemIndex: number ) => {
 		itemRefs.current[ itemIndex ] = el;
 	};*/
 
@@ -107,14 +106,14 @@ function WpcomBlockEditorNavSidebar() {
 
 		observer.current.disconnect();
 
-		const nonSparse = itemRefs.current.filter( Boolean ) as HTMLElement[];
+		/*		const nonSparse = itemRefs.current.filter( Boolean ) as HTMLElement[];
 
 		// We only need to observe the first and last item in the list, might be better for performance
 		const firstItem = nonSparse[ 0 ];
 		const lastItem = nonSparse[ nonSparse.length - 1 ];
 		if ( firstItem ) observer.current.observe( firstItem );
-		if ( lastItem ) observer.current.observe( lastItem );
-	}, [ currentPost, draftPosts, recentPosts, itemRefs, observer ] );
+		if ( lastItem ) observer.current.observe( lastItem );*/
+	}, [ currentPost, draftPosts, recentPosts, observer ] );
 
 	if ( ! postType ) {
 		// Still loading

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
@@ -203,9 +203,9 @@ function WpcomBlockEditorNavSidebar() {
 						iconSize={ 36 }
 						onClick={ dismissSidebar }
 					/>
-				</div>
-				<div className="wpcom-block-editor-nav-sidebar-nav-sidebar__site-title">
-					<h2>{ decodeEntities( siteTitle ) } YOU'RE SANDBOXING!!!</h2>
+					<div className="wpcom-block-editor-nav-sidebar-nav-sidebar__site-title">
+						<h2>{ decodeEntities( siteTitle ) } YOU'RE SANDBOXING!!!</h2>
+					</div>
 				</div>
 				<Button
 					href={ closeUrl }
@@ -262,7 +262,6 @@ function WpcomBlockEditorNavSidebar() {
 								item={ item }
 								postType={ postType } // We know the post type of this item is always the same as the post type of the current editor
 								selected={ item.id === selectedItemId }
-								statusLabel={ statusLabels[ item.status ] }
 							/>
 						) ) }
 						</ul>

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/style.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/style.scss
@@ -62,15 +62,18 @@ $nav-header-background-color: #32373d; // WP-admin gray to match the close butto
 }
 
 .wpcom-block-editor-nav-sidebar-nav-sidebar__header {
-	min-height: $header-height;
 	box-sizing: content-box;
 	display: flex;
 	background-color: $nav-header-background-color;
+	align-items: stretch;
 }
 
 .wpcom-block-editor-nav-sidebar-nav-sidebar__site-title {
-	margin: 12px 0 12px 74px;
-	overflow: hidden;
+	margin: 0 0 0 74px;
+	align-items: center;
+	display: flex;
+	justify-content: center;
+	min-height: 60px;
 
 	h2 {
 		color: $white;
@@ -79,6 +82,9 @@ $nav-header-background-color: #32373d; // WP-admin gray to match the close butto
 		line-height: $default-line-height;
 		word-wrap: break-word;
 		font-weight: normal;
+		display: flex;
+		align-items: center;
+		padding: 10px 0;
 	}
 
 	a {
@@ -152,6 +158,7 @@ $nav-header-background-color: #32373d; // WP-admin gray to match the close butto
 
 	.is-selected {
 		font-size: $text-editor-font-size;
+		color: $white;
 	}
 	/*
 	@TODO Work out how we're going to handle overflow

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/style.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/style.scss
@@ -64,16 +64,13 @@ $sidebar-nav-header-background-color: #32373d; // WP-admin gray to match the clo
 
 .wpcom-block-editor-nav-sidebar-nav-sidebar__header {
 	box-sizing: content-box;
-	display: flex;
 	background-color: $sidebar-nav-header-background-color;
-	align-items: stretch;
 }
 
 .wpcom-block-editor-nav-sidebar-nav-sidebar__site-title {
 	margin: 0 0 0 74px;
 	align-items: center;
 	display: flex;
-	justify-content: center;
 	min-height: 60px;
 
 	h2 {
@@ -88,7 +85,8 @@ $sidebar-nav-header-background-color: #32373d; // WP-admin gray to match the clo
 		padding: 10px 10px 10px 0;
 	}
 
-	a {
+	a,
+	a.is-untitled {
 		color: $light-gray-800;
 
 		&:active,
@@ -108,14 +106,13 @@ $sidebar-nav-header-background-color: #32373d; // WP-admin gray to match the clo
 }
 
 .wpcom-block-editor-nav-sidebar-nav-sidebar__home-button {
-	height: 46px;
 	width: 100%;
 	border: none !important;
 	box-shadow: none !important;
 	color: $white;
 	flex-shrink: 0;
 	padding: 8px 11px !important;
-	margin: 14px 0;
+	margin: 12px 0;
 
 	&:hover,
 	&:not( [aria-disabled='true'] ):active {
@@ -158,7 +155,6 @@ $sidebar-nav-header-background-color: #32373d; // WP-admin gray to match the clo
 	}
 
 	.is-selected {
-		font-size: $text-editor-font-size;
 		color: $white;
 	}
 	/*
@@ -169,7 +165,7 @@ $sidebar-nav-header-background-color: #32373d; // WP-admin gray to match the clo
 
 .wpcom-block-editor-nav-sidebar-nav-sidebar__post-scroll-area {
 	overflow-y: auto;
-	margin-bottom: 54px;
+	margin-bottom: 50px;
 }
 
 .wpcom-block-editor-nav-sidebar-nav-sidebar__bottom-buttons {
@@ -179,7 +175,4 @@ $sidebar-nav-header-background-color: #32373d; // WP-admin gray to match the clo
 	width: 100%;
 	overflow: hidden;
 	background: $sidebar-background-color;
-	&.is-scrollbar-present {
-		border-top: 1px solid $dark-gray-600;
-	}
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/style.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/style.scss
@@ -4,8 +4,9 @@
 @import '~@wordpress/base-styles/z-index';
 
 $sidebar-width: 272px;
-$transition-period: 100ms;
-$nav-header-background-color: #32373d; // WP-admin gray to match the close button background hover color
+$sidebar-transition-period: 100ms;
+$sidebar-background-color: #23282e; // WP-admin gray to match the close button background color
+$sidebar-nav-header-background-color: #32373d; // WP-admin gray to match the close button background hover color
 
 .wpcom-block-editor-nav-sidebar-nav-sidebar__click-guard {
 	position: fixed;
@@ -15,11 +16,11 @@ $nav-header-background-color: #32373d; // WP-admin gray to match the close butto
 	bottom: 0;
 	// Use the same z-index as the edit-post-layout header
 	z-index: z-index( '.interface-interface-skeleton__header' );
-	animation: wpcom-block-editor-nav-sidebar-nav-sidebar__fade $transition-period ease-out forwards;
+	animation: wpcom-block-editor-nav-sidebar-nav-sidebar__fade $sidebar-transition-period ease-out forwards;
 	@include reduce-motion( 'animation' );
 
 	&.is-fading-out {
-		animation: wpcom-block-editor-nav-sidebar-nav-sidebar__fade $transition-period ease-in reverse;
+		animation: wpcom-block-editor-nav-sidebar-nav-sidebar__fade $sidebar-transition-period ease-in reverse;
 		@include reduce-motion( 'animation' );
 	}
 }
@@ -39,15 +40,15 @@ $nav-header-background-color: #32373d; // WP-admin gray to match the close butto
 	top: 0;
 	bottom: 0;
 	width: $sidebar-width;
-	background: #23282e; // WP-admin gray to match the close button background color
+	background: $sidebar-background-color;
 	display: flex;
 	flex-direction: column;
 	box-shadow: -5px 0 20px $black;
-	animation: wpcom-block-editor-nav-sidebar-nav-sidebar__slide $transition-period ease-out;
+	animation: wpcom-block-editor-nav-sidebar-nav-sidebar__slide $sidebar-transition-period ease-out;
 	@include reduce-motion( 'animation' );
 
 	&.is-sliding-left {
-		animation: wpcom-block-editor-nav-sidebar-nav-sidebar__slide $transition-period ease-in reverse;
+		animation: wpcom-block-editor-nav-sidebar-nav-sidebar__slide $sidebar-transition-period ease-in reverse;
 		@include reduce-motion( 'animation' );
 	}
 }
@@ -64,7 +65,7 @@ $nav-header-background-color: #32373d; // WP-admin gray to match the close butto
 .wpcom-block-editor-nav-sidebar-nav-sidebar__header {
 	box-sizing: content-box;
 	display: flex;
-	background-color: $nav-header-background-color;
+	background-color: $sidebar-nav-header-background-color;
 	align-items: stretch;
 }
 
@@ -84,7 +85,7 @@ $nav-header-background-color: #32373d; // WP-admin gray to match the close butto
 		font-weight: normal;
 		display: flex;
 		align-items: center;
-		padding: 10px 0;
+		padding: 10px 10px 10px 0;
 	}
 
 	a {
@@ -103,7 +104,7 @@ $nav-header-background-color: #32373d; // WP-admin gray to match the close butto
 	top: 0;
 	left: 0;
 	height: $header-height !important;
-	background-color: $nav-header-background-color !important;
+	background-color: $sidebar-nav-header-background-color !important;
 }
 
 .wpcom-block-editor-nav-sidebar-nav-sidebar__home-button {
@@ -168,10 +169,16 @@ $nav-header-background-color: #32373d; // WP-admin gray to match the close butto
 
 .wpcom-block-editor-nav-sidebar-nav-sidebar__post-scroll-area {
 	overflow-y: auto;
+	margin-bottom: 54px;
 }
 
 .wpcom-block-editor-nav-sidebar-nav-sidebar__bottom-buttons {
 	border-top: 1px solid $light-gray-900;
+	position: absolute;
+	bottom: 0;
+	width: 100%;
+	overflow: hidden;
+	background: $sidebar-background-color;
 	&.is-scrollbar-present {
 		border-top: 1px solid $dark-gray-600;
 	}

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/style.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/style.scss
@@ -5,6 +5,7 @@
 
 $sidebar-width: 272px;
 $transition-period: 100ms;
+$nav-header-background-color: #32373d; // WP-admin gray to match the close button background hover color
 
 .wpcom-block-editor-nav-sidebar-nav-sidebar__click-guard {
 	position: fixed;
@@ -61,22 +62,24 @@ $transition-period: 100ms;
 }
 
 .wpcom-block-editor-nav-sidebar-nav-sidebar__header {
-	height: $header-height;
+	min-height: $header-height;
 	box-sizing: content-box;
 	display: flex;
 	flex: $header-height 0 0;
+	background-color: $nav-header-background-color;
 }
 
 .wpcom-block-editor-nav-sidebar-nav-sidebar__site-title {
-	padding: 8px 16px;
-	margin-top: 14px;
+	margin: 12px 0 12px 74px;
+	overflow: hidden;
 
 	h2 {
 		color: $white;
 		margin: 0;
-		font-size: $big-font-size;
+		font-size: $text-editor-font-size;
 		line-height: $default-line-height;
 		word-wrap: break-word;
+		font-weight: normal;
 	}
 
 	a {
@@ -95,6 +98,7 @@ $transition-period: 100ms;
 	top: 0;
 	left: 0;
 	height: $header-height !important;
+	background-color: $nav-header-background-color !important;
 }
 
 .wpcom-block-editor-nav-sidebar-nav-sidebar__home-button {
@@ -127,15 +131,29 @@ $transition-period: 100ms;
 	padding: $grid-unit-05 $grid-unit-20;
 	font-size: $big-font-size;
 	color: $white;
+	margin: 0 0 8px 0;
 }
 
 .wpcom-block-editor-nav-sidebar-nav-sidebar__list-subheading {
 	font-size: $default-font-size;
+	font-weight: normal;
 }
 
 .wpcom-block-editor-nav-sidebar-nav-sidebar__page-list {
 	padding: 0;
 	margin: 0;
+
+	li {
+		margin-bottom: 2px;
+	}
+
+	a {
+		color: $light-gray-900;
+	}
+
+	.is-selected {
+		font-size: $text-editor-font-size;
+	}
 	/*
 	@TODO Work out how we're going to handle overflow
 	overflow-y: auto;

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/style.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/style.scss
@@ -122,16 +122,24 @@ $transition-period: 100ms;
 	}
 }
 
-.wpcom-block-editor-nav-sidebar-nav-sidebar__list-heading {
-	padding: $grid-unit-20;
+.wpcom-block-editor-nav-sidebar-nav-sidebar__list-heading,
+.wpcom-block-editor-nav-sidebar-nav-sidebar__list-subheading {
+	padding: $grid-unit-05 $grid-unit-20;
 	font-size: $big-font-size;
 	color: $white;
+}
+
+.wpcom-block-editor-nav-sidebar-nav-sidebar__list-subheading {
+	font-size: $default-font-size;
 }
 
 .wpcom-block-editor-nav-sidebar-nav-sidebar__page-list {
 	padding: 0;
 	margin: 0;
+	/*
+	@TODO Work out how we're going to handle overflow
 	overflow-y: auto;
+	*/
 }
 
 .wpcom-block-editor-nav-sidebar-nav-sidebar__bottom-buttons {

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/style.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/style.scss
@@ -65,7 +65,6 @@ $nav-header-background-color: #32373d; // WP-admin gray to match the close butto
 	min-height: $header-height;
 	box-sizing: content-box;
 	display: flex;
-	flex: $header-height 0 0;
 	background-color: $nav-header-background-color;
 }
 
@@ -131,7 +130,7 @@ $nav-header-background-color: #32373d; // WP-admin gray to match the close butto
 	padding: $grid-unit-05 $grid-unit-20;
 	font-size: $big-font-size;
 	color: $white;
-	margin: 0 0 8px 0;
+	margin: 0 0 8px;
 }
 
 .wpcom-block-editor-nav-sidebar-nav-sidebar__list-subheading {
@@ -141,7 +140,7 @@ $nav-header-background-color: #32373d; // WP-admin gray to match the close butto
 
 .wpcom-block-editor-nav-sidebar-nav-sidebar__page-list {
 	padding: 0;
-	margin: 0;
+	margin: 0 0 20px;
 
 	li {
 		margin-bottom: 2px;
@@ -160,7 +159,12 @@ $nav-header-background-color: #32373d; // WP-admin gray to match the close butto
 	*/
 }
 
+.wpcom-block-editor-nav-sidebar-nav-sidebar__post-scroll-area {
+	overflow-y: auto;
+}
+
 .wpcom-block-editor-nav-sidebar-nav-sidebar__bottom-buttons {
+	border-top: 1px solid $light-gray-900;
 	&.is-scrollbar-present {
 		border-top: 1px solid $dark-gray-600;
 	}

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/constants.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/constants.ts
@@ -3,13 +3,11 @@ export const STORE_KEY = 'automattic/block-editor-nav-sidebar';
 declare global {
 	interface Window {
 		wpcomBlockEditorNavSidebar?: {
-			homeUrl: string;
 			postIdsToExclude: string[];
 		};
 	}
 }
 
-export const SITE_HOME_URL = window.wpcomBlockEditorNavSidebar?.homeUrl;
 export const POST_IDS_TO_EXCLUDE = ( window.wpcomBlockEditorNavSidebar?.postIdsToExclude || [] )
 	.map( ( id ) => parseInt( id, 10 ) )
 	.filter( ( id ) => ! isNaN( id ) );

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/types.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/types.ts
@@ -2,5 +2,4 @@ export interface Post {
 	id: number;
 	status: string;
 	title: { raw: string; rendered: string };
-	slug?: string;
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/types.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/types.ts
@@ -2,4 +2,5 @@ export interface Post {
 	id: number;
 	status: string;
 	title: { raw: string; rendered: string };
+	slug?: string;
 }


### PR DESCRIPTION
## Changes proposed in this Pull Request

Updating the sidebar to match the design in https://github.com/Automattic/wp-calypso/issues/45240

![Aug-28-2020 15-28-06](https://user-images.githubusercontent.com/6458278/91524686-27eac780-e943-11ea-95ab-55eea89b5f5c.gif)

I left the draft/scheduled badges in there to distinguish between the two.

## Testing instructions

Tested in Chrome, Safari and IE Edge

Apply D48670-code to your sandbox

Sandbox a site and edit a page/post

Check that there is no regression in carried-over functionality 

Check that the design matches the updated screenshot in https://github.com/Automattic/wp-calypso/issues/45240

Tested with a long site title, e.g., 
<img width="536" alt="Screen Shot 2020-08-31 at 3 05 22 pm" src="https://user-images.githubusercontent.com/6458278/91684656-6a0e4600-eb9b-11ea-86a0-1d628d71ba66.png">


Fixes #45240
