### PR TITLE
Patterns API: Enable patterns lib in development and wpcalypso environments

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -69,7 +69,7 @@
 		"gutenboarding/alpha-templates": true,
 		"gutenboarding/feature-picker": true,
 		"gutenboarding/new-launch": true,
-		"gutenboarding/use-patterns": false,
+		"gutenboarding/use-patterns": true,
 		"gutenboarding/show-vertical-input": false,
 		"help": true,
 		"help/courses": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -55,6 +55,7 @@
 		"gutenboarding/alpha-templates": true,
 		"gutenboarding/language-picker": false,
 		"gutenboarding/new-launch": true,
+		"gutenboarding/use-patterns": true,
 		"happychat": true,
 		"help": true,
 		"help/courses": true,


### PR DESCRIPTION
Note: do not merge this until we have received translations for all of the Gutenboarding site designs.

#### Changes proposed in this Pull Request

* Enable the patterns lib in development and wpcalypso environments

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this PR locally and go to  calypso.localhost:3000/new/ko and ensure that the preview for Stratford is rendered using the Patterns lib (just testing that it's mostly in Korean will prove it)
* Complete creating your site, and confirm that the content in the editor is mostly in Korean (this will confirm that it's using the Patterns lib)

Fixes #
