### PR TITLE
[WIP] Coming Soon v2, hard-code site as public and with coming soon mode in Gutenboarding

### DIFF
--- a/client/landing/gutenboarding/stores/onboard/actions.ts
+++ b/client/landing/gutenboarding/stores/onboard/actions.ts
@@ -48,10 +48,13 @@ export function* createSite(
 
 	const defaultTheme = shouldEnableFse ? 'seedlet-blocks' : 'twentytwenty';
 
+	let public = isPublicSite; // This is just to silence the eslint error
+	public = 1;
+
 	const params: CreateSiteParams = {
 		blog_name: siteUrl?.split( '.wordpress' )[ 0 ],
 		blog_title: siteTitle,
-		public: isPublicSite ? 1 : -1,
+		public,
 		options: {
 			site_vertical: siteVertical?.id,
 			site_vertical_name: siteVertical?.label,
@@ -74,6 +77,8 @@ export function* createSite(
 				font_headings: selectedFonts.headings,
 			} ),
 			use_patterns: isEnabled( 'gutenboarding/use-patterns' ),
+			wpcom_coming_soon: 1,
+			wpcom_coming_soon_page: 0,
 		},
 		...( bearerToken && { authToken: bearerToken } ),
 	};


### PR DESCRIPTION
WIP: this likely won't be something to merge, but is just an exploration into Coming Soon v2 ideas

#### Changes proposed in this Pull Request

* Hard-code site as public during site creation (this implementation is not right, it's just hacked together)
* Add `wpcom_coming_soon` setting and `wpcom_coming_soon_page` of 0 as a default setting

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Apply D48675-code

* Create a site in Gutenboarding — it should be public, with the `wpcom_coming_soon` and `wpcom_coming_soon_page` options set on the newly created site.

Fixes #