### PR TITLE
Gutenboarding: restrict abtest allocation of existing users

### DIFF
--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -41,7 +41,7 @@ import { login } from 'lib/paths';
 import { waitForData } from 'state/data-layer/http-data';
 import { requestGeoLocation } from 'state/data-getters';
 import { getDotBlogVerticalId } from './config/dotblog-verticals';
-import { abtest } from 'lib/abtest';
+import { abtest, getABTestVariation } from 'lib/abtest';
 import Experiment, { DefaultVariation, Variation } from 'components/experiment';
 import user from 'lib/user';
 
@@ -131,7 +131,10 @@ export default {
 			} )
 				.then( ( { geo } ) => {
 					const countryCode = geo.data.body.country_short;
-					if ( 'gutenberg' === abtest( 'newSiteGutenbergOnboarding', countryCode ) ) {
+					if (
+						getABTestVariation( 'existingUsersGutenbergOnboard' ) !== 'control' &&
+						'gutenberg' === abtest( 'newSiteGutenbergOnboarding', countryCode )
+					) {
 						gutenbergRedirect( context.params.flowName );
 					} else if (
 						( ! user() || ! user().get() ) &&


### PR DESCRIPTION
Right now `newSiteGutenbergOnboarding` test (along all other signup tests) is fired for all users assigned to “control” variant of `existingUsersGutenbergOnboard`. With no way to add some exclusion to abtest config, we can add a specific check to avoid the interference.

**Update**: this change together with [the existing "return"](https://github.com/Automattic/wp-calypso/pull/45248/files#diff-46ce4cd8580489aebbb3447a87c3cb57R126) will prevent any logged-in user to be assigned to `newSiteGutenbergOnboarding`.