### PR TITLE
Add support for excludedTests when configuring A/B tests

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -185,6 +185,7 @@ export default {
 			'VN',
 			'ZA',
 		],
+		excludedTests: [ 'existingUsersGutenbergOnboard' ],
 	},
 	[ RUM_DATA_COLLECTION.AB_NAME ]: {
 		datestamp: '20200602',

--- a/client/lib/abtest/utility.js
+++ b/client/lib/abtest/utility.js
@@ -16,3 +16,7 @@ export function getActiveTestNames( { appendDatestamp = false, asCSV = false } =
 	);
 	return asCSV ? output.join( ',' ) : output;
 }
+
+export function getNameFromExperimentId( id ) {
+	return id.substring( 0, id.length - '_YYYYMMDD'.length );
+}

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -41,7 +41,7 @@ import { login } from 'lib/paths';
 import { waitForData } from 'state/data-layer/http-data';
 import { requestGeoLocation } from 'state/data-getters';
 import { getDotBlogVerticalId } from './config/dotblog-verticals';
-import { abtest } from 'lib/abtest';
+import { abtest, getABTestVariation } from 'lib/abtest';
 import Experiment, { DefaultVariation, Variation } from 'components/experiment';
 import user from 'lib/user';
 
@@ -131,7 +131,10 @@ export default {
 			} )
 				.then( ( { geo } ) => {
 					const countryCode = geo.data.body.country_short;
-					if ( 'gutenberg' === abtest( 'newSiteGutenbergOnboarding', countryCode ) ) {
+					if (
+						getABTestVariation( 'existingUsersGutenbergOnboard' ) !== 'control' &&
+						'gutenberg' === abtest( 'newSiteGutenbergOnboarding', countryCode )
+					) {
 						gutenbergRedirect( context.params.flowName );
 					} else if (
 						( ! user() || ! user().get() ) &&


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update `abtest` framework to handle `excludedTests` array instead of [doing this manually](https://github.com/Automattic/wp-calypso/pull/45248/files#diff-46ce4cd8580489aebbb3447a87c3cb57R135)

#### Testing instructions

* WIP
