### PR TITLE
Offer Reset: Set Plans page default duration to subscribed plan term/duration

### DIFF
--- a/client/my-sites/plans-v2/controller.tsx
+++ b/client/my-sites/plans-v2/controller.tsx
@@ -12,14 +12,15 @@ import UpsellPage from './upsell';
 import { stringToDuration } from './utils';
 import getCurrentPlanTerm from 'state/selectors/get-current-plan-term';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { TERM_ANNUALLY, TERM_MONTHLY } from 'lib/plans/constants';
+import { Duration } from 'my-sites/plans-v2/types';
+import { TERM_ANNUALLY } from 'lib/plans/constants';
 
 export const productSelect = ( rootUrl: string ) => ( context: PageJS.Context, next: Function ) => {
 	// Get the selected site's current plan term, and set it as default duration
 	const state = context.store.getState();
 	const siteId = getSelectedSiteId( state );
 	const duration =
-		siteId && getCurrentPlanTerm( state, siteId ) === 'TERM_MONTHLY' ? TERM_MONTHLY : TERM_ANNUALLY;
+		( siteId && ( getCurrentPlanTerm( state, siteId ) as Duration ) ) || TERM_ANNUALLY;
 
 	context.primary = (
 		<SelectorPage

--- a/client/my-sites/plans-v2/controller.tsx
+++ b/client/my-sites/plans-v2/controller.tsx
@@ -10,9 +10,17 @@ import SelectorPage from './selector';
 import DetailsPage from './details';
 import UpsellPage from './upsell';
 import { stringToDuration } from './utils';
+import getCurrentPlanTerm from 'state/selectors/get-current-plan-term';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { TERM_ANNUALLY, TERM_MONTHLY } from 'lib/plans/constants';
 
 export const productSelect = ( rootUrl: string ) => ( context: PageJS.Context, next: Function ) => {
-	const duration = stringToDuration( context.params.duration );
+	// Get the selected site's current plan term, and set it as default duration
+	const state = context.store.getState();
+	const siteId = getSelectedSiteId( state );
+	const duration =
+		siteId && getCurrentPlanTerm( state, siteId ) === 'TERM_MONTHLY' ? TERM_MONTHLY : TERM_ANNUALLY;
+
 	context.primary = (
 		<SelectorPage
 			defaultDuration={ duration }

--- a/client/my-sites/plans-v2/selector.tsx
+++ b/client/my-sites/plans-v2/selector.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useState, useMemo } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import page from 'page';
 
@@ -46,7 +46,7 @@ const SelectorPage = ( {
 	const [ productType, setProductType ] = useState< ProductType >( SECURITY );
 	const [ currentDuration, setDuration ] = useState< Duration >( defaultDuration );
 
-	useMemo( () => {
+	useEffect( () => {
 		setDuration( defaultDuration );
 	}, [ defaultDuration ] );
 

--- a/client/my-sites/plans-v2/selector.tsx
+++ b/client/my-sites/plans-v2/selector.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import page from 'page';
 
@@ -45,6 +45,10 @@ const SelectorPage = ( {
 	const siteSlug = useSelector( ( state ) => getSelectedSiteSlug( state ) ) || '';
 	const [ productType, setProductType ] = useState< ProductType >( SECURITY );
 	const [ currentDuration, setDuration ] = useState< Duration >( defaultDuration );
+
+	useMemo( () => {
+		setDuration( defaultDuration );
+	}, [ defaultDuration ] );
 
 	// Sends a user to a page based on whether there are subtypes.
 	const selectProduct: PurchaseCallback = ( product: SelectorProduct, purchase ) => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This PR sets the Plans Page default duration to either "Monthly" or "Annually" based on the site's current Plan term.


#### Testing instructions

1. Run this PR with Offer Reset A/B Test enabled.
2. Go to the Plans page.
3. In the top filter bar, notice the duration select (Monthly or Yearly), it should be defaulted to the selected site's subscription term.
4. Next, switch to another site that has a different subscription term, (Monthly or Yearly). It should always be defaulted to the sites's subscription term.  Or if free plan, defaulted to Yearly.

![chrome-capture (4)](https://user-images.githubusercontent.com/11078128/91488276-eafbd380-e863-11ea-83e1-f4cd1bd8136c.gif)

