### PR TITLE
Offer Reset: redirect to Selector page when selected site changes

### DIFF
--- a/client/jetpack-connect/index.js
+++ b/client/jetpack-connect/index.js
@@ -142,7 +142,7 @@ export default function () {
 	}
 
 	if ( shouldShowOfferResetFlow() ) {
-		plansV2( `/jetpack/connect/plans/:site`, siteSelection, controller.offerResetContext );
+		plansV2( `/jetpack/connect/plans`, siteSelection, controller.offerResetContext );
 	} else {
 		page(
 			'/jetpack/connect/plans/:interval(yearly|monthly)?/:site',

--- a/client/my-sites/plans-v2/details.tsx
+++ b/client/my-sites/plans-v2/details.tsx
@@ -9,7 +9,11 @@ import { useSelector } from 'react-redux';
 /**
  * Internal dependencies
  */
-import { OPTIONS_JETPACK_SECURITY, OPTIONS_JETPACK_SECURITY_MONTHLY } from './constants';
+import {
+	OPTIONS_JETPACK_SECURITY,
+	OPTIONS_JETPACK_SECURITY_MONTHLY,
+	PRODUCTS_WITH_OPTIONS,
+} from './constants';
 import ProductCard from './product-card';
 import {
 	slugToSelectorProduct,
@@ -45,6 +49,12 @@ const DetailsPage = ( { duration, productSlug, rootUrl, header, footer }: Detail
 	const products = useSelector( ( state ) => getProductsList( state ) );
 	const translate = useTranslate();
 	const isLoading = ! currencyCode || ( isFetchingProducts && ! products );
+
+	// If the product slug isn't one that has options, proceed to the upsell.
+	if ( ! ( PRODUCTS_WITH_OPTIONS as readonly string[] ).includes( productSlug ) ) {
+		page.redirect( getPathToUpsell( rootUrl, productSlug, duration as Duration, siteSlug ) );
+		return null;
+	}
 
 	const selectorPageUrl = getPathToSelector( rootUrl, duration, siteSlug );
 

--- a/client/my-sites/plans-v2/details.tsx
+++ b/client/my-sites/plans-v2/details.tsx
@@ -27,11 +27,12 @@ import { isProductsListFetching } from 'state/products-list/selectors/is-product
 import { getProductsList } from 'state/products-list/selectors';
 import { getSiteProducts } from 'state/sites/selectors';
 import { getSelectedSiteSlug, getSelectedSiteId } from 'state/ui/selectors';
+import withRedirectToSelector from './with-redirect-to-selector';
 
 /**
  * Type dependencies
  */
-import type { DetailsPageProps, PurchaseCallback, SelectorProduct } from './types';
+import type { Duration, DetailsPageProps, PurchaseCallback, SelectorProduct } from './types';
 
 import './style.scss';
 
@@ -63,7 +64,7 @@ const DetailsPage = ( { duration, productSlug, rootUrl, header, footer }: Detail
 				( { productSlug: siteProductSlug } ) => siteProductSlug === upsellProduct
 			)
 		) {
-			page( getPathToUpsell( rootUrl, slug, duration, siteSlug ) );
+			page( getPathToUpsell( rootUrl, slug, duration as Duration, siteSlug ) );
 			return;
 		}
 		checkout( siteSlug, slug );
@@ -122,4 +123,4 @@ const DetailsPage = ( { duration, productSlug, rootUrl, header, footer }: Detail
 	);
 };
 
-export default DetailsPage;
+export default withRedirectToSelector( DetailsPage );

--- a/client/my-sites/plans-v2/index.ts
+++ b/client/my-sites/plans-v2/index.ts
@@ -14,7 +14,15 @@ const trackedPage = ( url: string, ...rest: PageJS.Callback[] ) => {
 };
 
 export default function ( rootUrl: string, ...rest: PageJS.Callback[] ) {
-	trackedPage( `${ rootUrl }/:duration?`, ...rest, productSelect( rootUrl ) );
-	trackedPage( `${ rootUrl }/:product/:duration/details`, ...rest, productDetails( rootUrl ) );
-	trackedPage( `${ rootUrl }/:product/:duration/additions`, ...rest, productUpsell( rootUrl ) );
+	trackedPage( `${ rootUrl }/:duration?/:site?`, ...rest, productSelect( rootUrl ) );
+	trackedPage(
+		`${ rootUrl }/:product/:duration/details/:site?`,
+		...rest,
+		productDetails( rootUrl )
+	);
+	trackedPage(
+		`${ rootUrl }/:product/:duration/additions/:site?`,
+		...rest,
+		productUpsell( rootUrl )
+	);
 }

--- a/client/my-sites/plans-v2/selector.tsx
+++ b/client/my-sites/plans-v2/selector.tsx
@@ -12,7 +12,7 @@ import PlansFilterBar from './plans-filter-bar';
 import PlansColumn from './plans-column';
 import ProductsColumn from './products-column';
 import { SECURITY } from './constants';
-import { durationToString, getProductUpsell, checkout } from './utils';
+import { getProductUpsell, getPathToDetails, getPathToUpsell, checkout } from './utils';
 import { TERM_ANNUALLY } from 'lib/plans/constants';
 import { getSiteProducts } from 'state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
@@ -55,11 +55,8 @@ const SelectorPage = ( {
 			return;
 		}
 
-		const root = rootUrl.replace( ':site', siteSlug );
-		const durationString = durationToString( currentDuration );
-
 		if ( product.subtypes.length ) {
-			page( `${ root }/${ product.productSlug }/${ durationString }/details` );
+			page( getPathToDetails( rootUrl, product.productSlug, currentDuration, siteSlug ) );
 			return;
 		}
 
@@ -68,9 +65,9 @@ const SelectorPage = ( {
 		const upsellProduct = getProductUpsell( product.productSlug );
 		if (
 			upsellProduct &&
-			! siteProducts.find( ( { productSlug } ) => productSlug === upsellProduct )
+			! siteProducts?.find( ( { productSlug } ) => productSlug === upsellProduct )
 		) {
-			page( `${ root }/${ product.productSlug }/${ durationString }/additions` );
+			page( getPathToUpsell( rootUrl, product.productSlug, currentDuration, siteSlug ) );
 			return;
 		}
 

--- a/client/my-sites/plans-v2/types.ts
+++ b/client/my-sites/plans-v2/types.ts
@@ -42,6 +42,10 @@ export interface UpsellPageProps extends BasePageProps {
 	productSlug: string;
 }
 
+export interface WithRedirectToSelectorProps extends BasePageProps {
+	duration: Duration;
+}
+
 export type SelectorProductSlug = typeof PRODUCTS_WITH_OPTIONS[ number ];
 
 export type SelectorProductCost = {

--- a/client/my-sites/plans-v2/upsell.tsx
+++ b/client/my-sites/plans-v2/upsell.tsx
@@ -22,10 +22,11 @@ import { isProductsListFetching } from 'state/products-list/selectors';
 import { getSelectedSiteSlug } from 'state/ui/selectors';
 import useItemPrice from './use-item-price';
 import {
-	durationToString,
 	durationToText,
 	getOptionFromSlug,
 	getProductUpsell,
+	getPathToSelector,
+	getPathToDetails,
 	slugToSelectorProduct,
 	checkout,
 } from './utils';
@@ -150,7 +151,7 @@ const UpsellComponent = ( {
 };
 
 const UpsellPage = ( { duration, productSlug, rootUrl, header, footer }: UpsellPageProps ) => {
-	const selectedSiteSlug = useSelector( ( state ) => getSelectedSiteSlug( state ) ) || '';
+	const siteSlug = useSelector( ( state ) => getSelectedSiteSlug( state ) ) || '';
 	const isFetchingProducts = useSelector( ( state ) => isProductsListFetching( state ) );
 	const currencyCode = useSelector( ( state ) => getCurrentUserCurrencyCode( state ) );
 
@@ -159,9 +160,7 @@ const UpsellPage = ( { duration, productSlug, rootUrl, header, footer }: UpsellP
 	const upsellProductSlug = getProductUpsell( productSlug );
 	const upsellProduct = upsellProductSlug && slugToSelectorProduct( upsellProductSlug );
 
-	const checkoutCb = useCallback( ( slugs ) => checkout( selectedSiteSlug, slugs ), [
-		selectedSiteSlug,
-	] );
+	const checkoutCb = useCallback( ( slugs ) => checkout( siteSlug, slugs ), [ siteSlug ] );
 
 	const onPurchaseBothProducts = useCallback(
 		() => checkoutCb( [ productSlug, upsellProductSlug ] ),
@@ -173,12 +172,11 @@ const UpsellPage = ( { duration, productSlug, rootUrl, header, footer }: UpsellP
 		productSlug,
 	] );
 
-	const urlWithSiteSlug = rootUrl.replace( ':site', selectedSiteSlug );
-	const durationSuffix = duration ? durationToString( duration ) : '';
+	const selectorPageUrl = getPathToSelector( rootUrl, duration, siteSlug );
 
 	// If the product is not valid send the user to the selector page.
 	if ( ! mainProduct ) {
-		page.redirect( urlWithSiteSlug + '/' + durationSuffix );
+		page.redirect( selectorPageUrl );
 		return null;
 	}
 
@@ -197,8 +195,8 @@ const UpsellPage = ( { duration, productSlug, rootUrl, header, footer }: UpsellP
 	// page.
 	const productOption = getOptionFromSlug( productSlug );
 	const backUrl = productOption
-		? [ urlWithSiteSlug, productOption, durationSuffix, 'details' ].join( '/' )
-		: urlWithSiteSlug;
+		? getPathToDetails( rootUrl, productOption, duration, siteSlug )
+		: selectorPageUrl;
 
 	const onBackButtonClick = () => page( backUrl );
 

--- a/client/my-sites/plans-v2/upsell.tsx
+++ b/client/my-sites/plans-v2/upsell.tsx
@@ -30,6 +30,7 @@ import {
 	slugToSelectorProduct,
 	checkout,
 } from './utils';
+import withRedirectToSelector from './with-redirect-to-selector';
 
 /**
  * Style dependencies
@@ -39,7 +40,7 @@ import './style.scss';
 /**
  * Type dependencies
  */
-import type { SelectorProduct, UpsellPageProps } from './types';
+import type { Duration, SelectorProduct, UpsellPageProps } from './types';
 
 interface Props {
 	currencyCode: string;
@@ -195,7 +196,7 @@ const UpsellPage = ( { duration, productSlug, rootUrl, header, footer }: UpsellP
 	// page.
 	const productOption = getOptionFromSlug( productSlug );
 	const backUrl = productOption
-		? getPathToDetails( rootUrl, productOption, duration, siteSlug )
+		? getPathToDetails( rootUrl, productOption, duration as Duration, siteSlug )
 		: selectorPageUrl;
 
 	const onBackButtonClick = () => page( backUrl );
@@ -216,4 +217,4 @@ const UpsellPage = ( { duration, productSlug, rootUrl, header, footer }: UpsellP
 	);
 };
 
-export default UpsellPage;
+export default withRedirectToSelector( UpsellPage );

--- a/client/my-sites/plans-v2/utils.ts
+++ b/client/my-sites/plans-v2/utils.ts
@@ -441,3 +441,61 @@ export function checkout( siteSlug: string, products: string | string[] ): void 
 	addItems( ( isArray( products ) ? products : [ products ] ).map( jetpackProductItem ) );
 	page.redirect( `/checkout/${ siteSlug }` );
 }
+
+/**
+ * Returns a URL of the format `rootUrl/?duration/?siteSlug`. In most cases, `rootUrl` will
+ * be either '/jetpack/connect/plans' or '/plans'. The result will most likely look like
+ * '/plans/monthly/site-slug', '/plans/site-slug', or just '/plans'.
+ *
+ * @param {string} rootUrl Base URL that relates to the current flow (WordPress.com vs Jetpack Connect).
+ * @param {Duration} duration Monthly or annual
+ * @param {string} siteSlug (optional) The slug of the selected site
+ *
+ * @returns {string} The path to the Selector page
+ */
+export function getPathToSelector( rootUrl: string, duration?: Duration, siteSlug?: string ) {
+	const strDuration = duration ? durationToString( duration ) : null;
+	return [ rootUrl, strDuration, siteSlug ].filter( Boolean ).join( '/' );
+}
+
+/**
+ * Returns a URL of the format `rootUrl/productSlug/duration/details/?siteSlug` that
+ * points to the Details page.
+ *
+ * @param {string} rootUrl Base URL that relates to the current flow (WordPress.com vs Jetpack Connect).
+ * @param {string} productSlug Slug of the product
+ * @param {Duration} duration Monthly or annual
+ * @param {string} siteSlug (optional) The slug of the selected site
+ *
+ * @returns {string} The path to the Details page
+ */
+export function getPathToDetails(
+	rootUrl: string,
+	productSlug: string,
+	duration: Duration,
+	siteSlug?: string
+) {
+	const strDuration = durationToString( duration );
+	return [ rootUrl, productSlug, strDuration, 'details', siteSlug ].filter( Boolean ).join( '/' );
+}
+
+/**
+ * Returns a URL of the format `rootUrl/productSlug/duration/additions/?siteSlug` that
+ * points to the Upsell page.
+ *
+ * @param {string} rootUrl Base URL that relates to the current flow (WordPress.com vs Jetpack Connect).
+ * @param {string} productSlug Slug of the product
+ * @param {Duration} duration Monthly or annual
+ * @param {string} siteSlug (optional) The slug of the selected site
+ *
+ * @returns {string} The path to the Upsell page
+ */
+export function getPathToUpsell(
+	rootUrl: string,
+	productSlug: string,
+	duration: Duration,
+	siteSlug?: string
+) {
+	const strDuration = durationToString( duration );
+	return [ rootUrl, productSlug, strDuration, 'additions', siteSlug ].filter( Boolean ).join( '/' );
+}

--- a/client/my-sites/plans-v2/with-redirect-to-selector.tsx
+++ b/client/my-sites/plans-v2/with-redirect-to-selector.tsx
@@ -1,0 +1,37 @@
+/**
+ * External dependencies
+ */
+import page from 'page';
+import React, { useEffect, useRef } from 'react';
+import { useSelector } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { getSelectedSiteSlug } from 'state/ui/selectors';
+import { getPathToSelector } from './utils';
+import { WithRedirectToSelectorProps } from './types';
+
+const withRedirectToSelector = < T extends object >(
+	Component: React.ComponentType< T >
+): React.FC< T & WithRedirectToSelectorProps > => ( props: WithRedirectToSelectorProps ) => {
+	const { duration, rootUrl } = props;
+	const siteSlug = useSelector( getSelectedSiteSlug );
+	const previousSiteSlug = useRef< string | null >( null );
+
+	useEffect( () => {
+		if ( siteSlug && ! previousSiteSlug.current ) {
+			previousSiteSlug.current = siteSlug;
+			return;
+		}
+
+		if ( siteSlug && previousSiteSlug.current && siteSlug !== previousSiteSlug.current ) {
+			page.redirect( getPathToSelector( rootUrl, duration, siteSlug ) );
+			return;
+		}
+	}, [ siteSlug ] );
+
+	return <Component { ...( props as T ) } />;
+};
+
+export default withRedirectToSelector;

--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -29,7 +29,7 @@ export function plans( context, next ) {
 			return page.redirect( `/plans/${ context.params.site }` );
 		}
 		setJetpackPlansHeader( context );
-		return productSelect( '/plans/:site' )( context, next );
+		return productSelect( '/plans' )( context, next );
 	}
 
 	context.primary = (

--- a/client/my-sites/plans/index.js
+++ b/client/my-sites/plans/index.js
@@ -37,6 +37,6 @@ export default function () {
 	// This route renders the plans page for both WPcom and Jetpack sites.
 	trackedPage( '/plans/:intervalType?/:site', siteSelection, navigation, plans );
 	if ( shouldShowOfferResetFlow() ) {
-		plansV2( '/plans/:site', siteSelection, redirectToPlansIfNotJetpack, navigation );
+		plansV2( '/plans', siteSelection, redirectToPlansIfNotJetpack, navigation );
 	}
 }

--- a/client/my-sites/plans/test/index.js
+++ b/client/my-sites/plans/test/index.js
@@ -90,7 +90,7 @@ describe( 'Loads Jetpack plan page', () => {
 		shouldShowOfferResetFlow.mockReturnValueOnce( true );
 		router();
 		expect( plansV2 ).toHaveBeenCalledWith(
-			'/plans/:site',
+			'/plans',
 			siteSelection,
 			redirectToPlansIfNotJetpack,
 			navigation


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Redirect users back to the Selector page if users are either in the Details page or the Upsell page and the selected site changes.

#### Implementation notes

* I made the `:site` parameter optional in the URL. Some URLs didn't work at all when there was no site selected (Jetpack Connect flow without a selected site).
* I modev the `:site` to the end of the URL so the `SiteSelector` doesn't break the URL when the selected site gets changed. Also, this follow the implicit convention of having the site slug at the end of the URL.
* I created utility functions to construct URLs that target the Selector, Details, and Upsell pages so we can then change them in one central place.

#### Testing instructions

* Run this PR with the Offer Reset AB test enabled.
* Move around the Plans page, following all paths you can image without purchasing any product or plan (nothing changed in that regard).
* Visit the Details page of any product with options (Jetpack Security is an example).
* Refresh the page.
* Verify that you are still in the Details page.
* Change the selected site in the SiteSelector.
* Verify that you were redirected back to the Plans/Selector page.
* Visit the Upsell page of any product (Jetpack Backup Daily works here).
* Refresh the page.
* Verify that you are still in the Upsell page.
* Change the selected site in the SiteSelector.
* Verify that you were redirected back to the Plans/Selector page.
* Verify that you can still follow different paths in the Connect Flow by visiting `/jetpack/connect/plans` (you won't be able to change the site from there since there is no SiteSelector.

Fixes 1169247016322522-as-1190786894874681

#### Demo
![Kapture 2020-08-27 at 13 41 28](https://user-images.githubusercontent.com/3418513/91470458-1cc46880-e86b-11ea-99ba-db4607e8b1d9.gif)

