### PR TITLE
Premium Content: Fix duplicate Stripe nudge notification

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/editor.css
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/editor.css
@@ -4,7 +4,8 @@
 	color: #555d66;
 	display: flex;
 	flex-wrap: wrap;
-	font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
+	font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell,
+		'Helvetica Neue', sans-serif;
 	font-size: 13px;
 	position: relative;
 	margin: 0 0 0 -1px;
@@ -82,12 +83,18 @@
 	line-height: 36px;
 }
 
-.wp-block-premium-content-container---settings-add_plan .components-panel__row.plan-name .components-base-control,
-.wp-block-premium-content-container---settings-add_plan .components-panel__row.plan-interval .components-base-control {
+.wp-block-premium-content-container---settings-add_plan
+	.components-panel__row.plan-name
+	.components-base-control,
+.wp-block-premium-content-container---settings-add_plan
+	.components-panel__row.plan-interval
+	.components-base-control {
 	width: 100%;
 }
 
-.wp-block-premium-content-container---settings-add_plan .components-panel__row.plan-price .components-base-control {
+.wp-block-premium-content-container---settings-add_plan
+	.components-panel__row.plan-price
+	.components-base-control {
 	width: 45%;
 	margin: 0;
 }
@@ -123,6 +130,15 @@
 	margin: 0 8px 0 0;
 }
 
-.editor-styles-wrapper .wp-block-buttons .wp-block[data-type='jetpack/recurring-payments'] .wp-block-button:not( .alignleft ):not( .alignright ) {
+.editor-styles-wrapper
+	.wp-block-buttons
+	.wp-block[data-type='jetpack/recurring-payments']
+	.wp-block-button:not( .alignleft ):not( .alignright ) {
 	margin: 0;
+}
+
+/* Hide Stripe nudge from Jetpack payments block */
+/* https://github.com/Automattic/wp-calypso/issues/44332 */
+.wp-block-premium-content-container .jetpack-block-nudge {
+	display: none;
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/premium-content/style.css
+++ b/apps/editing-toolkit/editing-toolkit-plugin/premium-content/style.css
@@ -16,12 +16,6 @@
 	margin-bottom: 8px;
 }
 
-/* Hide Stripe nudge from Jetpack payments block */
-/* https://github.com/Automattic/wp-calypso/issues/44332 */
-.wp-block-premium-content-container .jetpack-block-nudge {
-	display: none;
-}
-
 /* Legacy Subscribe/Login buttons */
 
 .wp-block-premium-content-logged-out-view__buttons {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This change addresses a regression which reintroduced the bug described at #44332, where a user would see multiple nudge notifications to connect their account to Stripe if editing a post with a premium content block while not connected. As a result of #44825, the premium content block's initialization code is now split into separate hooks for the edit and front-end views, and the style necessary to hide the duplicate notification needs to be in `editor.css`, which is loaded on the edit view, rather than `style.css`, which is loaded on the front-end view.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure your account is not connected to Stripe.
* Load the version of the full-site-editing plugin from this PR following one of the methods detailed in PCYsg-ly5-p2.
* Create a new post or edit an existing one, and add a "Premium Content" block.
* Verify that under the Edit view in the "Non-Subscriber View" section, the user is only presented with a single message indicating they should connect the account to Stripe.

Fixes #44332
