### PR TITLE
Disable the add to cart button while premium pricing is pending

### DIFF
--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -127,6 +127,7 @@ class DomainRegistrationSuggestion extends React.Component {
 			suggestion,
 			translate,
 			pendingCheckSuggestion,
+			premiumDomain,
 		} = this.props;
 		const { domain_name: domain } = suggestion;
 		const isAdded = hasDomainInCart( cart, domain );
@@ -151,7 +152,9 @@ class DomainRegistrationSuggestion extends React.Component {
 					: translate( 'Select', { context: 'Domain mapping suggestion button' } );
 		}
 
-		if ( this.isUnavailableDomain( suggestion.domain_name ) ) {
+		if ( premiumDomain?.pending ) {
+			buttonStyles = { ...buttonStyles, disabled: true };
+		} else if ( this.isUnavailableDomain( suggestion.domain_name ) ) {
 			buttonStyles = { ...buttonStyles, disabled: true };
 			buttonContent = translate( 'Unavailable', {
 				context: 'Domain suggestion is not available for registration',

--- a/client/components/domains/premium-badge/index.jsx
+++ b/client/components/domains/premium-badge/index.jsx
@@ -18,7 +18,9 @@ class PremiumBadge extends React.Component {
 		return (
 			<Badge className="premium-badge">
 				{ translate( 'Premium domain' ) }
-				<InfoPopover iconSize="16">Premium domain names are short and easy to remember</InfoPopover>
+				<InfoPopover iconSize={ 16 }>
+					Premium domain names are short and easy to remember
+				</InfoPopover>
 			</Badge>
 		);
 	}

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -1212,6 +1212,13 @@ class RegisterDomainStep extends React.Component {
 
 	onAddDomain = ( suggestion ) => {
 		const domain = get( suggestion, 'domain_name' );
+		const { premiumDomains } = this.state;
+
+		// disable adding a domain to the cart while the premium price is still fetching
+		if ( premiumDomains?.[ domain ]?.pending ) {
+			return;
+		}
+
 		const isSubDomainSuggestion = get( suggestion, 'isSubDomainSuggestion' );
 		if ( ! hasDomainInCart( this.props.cart, domain ) && ! isSubDomainSuggestion ) {
 			this.setState( { pendingCheckSuggestion: suggestion } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* We want to disable the "Add to cart" button (actually the "Select" button) while the premium domain pricing is loading because otherwise the user doesn't really know how much a premium domain would cost.
* Fixed a warning with the `PremiumBadge` passing string instead of numeric `iconSize` property

It should look like this while loading the price:
<img width="539" alt="Screenshot 2020-08-27 at 22 52 39" src="https://user-images.githubusercontent.com/1355045/91488519-16101280-e8b8-11ea-8512-eb62cf637574.png">

#### Testing instructions

* Search for a premium domain and make sure the select button is disabled and can't be clicked while the premium price is loading. It might make sense to add some delay in the REST API endpoint in order to test this thoroughly.
* also verify that there is no warning about `iconSize` in the console
