### PR TITLE
Jetpack: Connect: Fix issue where incorrect WP 4.7 notice shows

### DIFF
--- a/client/jetpack-connect/jetpack-remote-install-notices.jsx
+++ b/client/jetpack-connect/jetpack-remote-install-notices.jsx
@@ -43,32 +43,22 @@ export class JetpackRemoteInstallNotices extends Component {
 
 	renderNotice() {
 		const { noticeType, siteToConnect, translate } = this.props;
+		const buttonLabel = translate( 'Install Jetpack manually' );
+		const redirectTo = addQueryArgs( { url: siteToConnect }, '/jetpack/connect/instructions' );
+
 		// default values for INSTALL_RESPONSE_ERROR,
 		let header = translate( 'Try Installing Manually' );
 		let subheader = translate(
 			"We were unable to install Jetpack. Don't worry—you can either install Jetpack manually or contact support for help."
 		);
-		let buttonLabel = translate( 'Install Jetpack manually' );
 		let noticeImage = '/calypso/images/illustrations/customizeTheme.svg';
-		let redirectTo = addQueryArgs( { url: siteToConnect }, '/jetpack/connect/instructions' );
 
 		switch ( noticeType ) {
 			case ACTIVATION_RESPONSE_ERROR:
+			case ACTIVATION_FAILURE:
 				subheader = translate(
 					"We were unable to activate Jetpack. Don't worry—you can either install Jetpack manually or contact support for help."
 				);
-				break;
-
-			case ACTIVATION_FAILURE:
-				header = translate( 'WordPress version update needed' );
-				subheader = translate(
-					'We were unable to install Jetpack because you are running an oudated version ' +
-						'of WordPress. Jetpack needs WordPress version 4.7 or higher. ' +
-						'Please update to the latest version by clicking below.'
-				);
-				noticeImage = '/calypso/images/illustrations/install-button.svg';
-				buttonLabel = translate( 'Update WordPress now' );
-				redirectTo = siteToConnect + '/wp-admin/update-core.php';
 				break;
 
 			case INVALID_PERMISSIONS:


### PR DESCRIPTION
For context, see p1HpG7-9YO-p2

#### Changes proposed in this Pull Request

This pull request removes the notice that WordPress 4.7 is the minimum. We are now at WP 5.5, 8 versions past 4.7. Further, that notice is also incorrectly shown any time that there is an error upon activation on the remote site.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up JN site
* SSH in
* Deactivate Jetpack
* Remove `wp-content/plugins/jetpack/load-jetpack.php` file
* Go to calypso.localhost:3000/jetpack/connect
* Enter in URL of JN site
* Enter in credentials
* Verify that you get a prompt to manually install Jetpack, as opposed to an incorrect WP 4.7+ notice

