### PR TITLE
Button: Use Button style component instead of raw button

### DIFF
--- a/client/auth/login.jsx
+++ b/client/auth/login.jsx
@@ -11,6 +11,7 @@ import { localize } from 'i18n-calypso';
  */
 import AuthCodeButton from './auth-code-button';
 import AuthStore from 'lib/oauth-store';
+import { Button } from '@automattic/components';
 import config from 'config';
 import FormButton from 'components/forms/form-button';
 import FormButtonsBar from 'components/forms/form-buttons-bar';
@@ -25,7 +26,6 @@ import WordPressLogo from 'components/wordpress-logo';
 import { login } from 'lib/oauth-store/actions';
 import { recordGoogleEvent } from 'state/analytics/actions';
 import { localizeUrl } from 'lib/i18n-utils';
-
 export class Auth extends Component {
 	state = {
 		login: '',
@@ -157,9 +157,9 @@ export class Auth extends Component {
 						<Gridicon icon="help" />
 					</a>
 					<div className="auth__links">
-						<button onClick={ this.toggleSelfHostedInstructions }>
+						<Button onClick={ this.toggleSelfHostedInstructions }>
 							{ translate( 'Add self-hosted site' ) }
-						</button>
+						</Button>
 						<a href={ config( 'signup_url' ) }>{ translate( 'Create account' ) }</a>
 					</div>
 					{ showInstructions && (

--- a/client/auth/self-hosted-instructions.jsx
+++ b/client/auth/self-hosted-instructions.jsx
@@ -5,15 +5,16 @@
 import React from 'react';
 import { useTranslate } from 'i18n-calypso';
 import Gridicon from 'components/gridicon';
+import { Button } from '@automattic/components';
 
 export default function SelfHostedInstructions( { onClickClose } ) {
 	const translate = useTranslate();
 
 	return (
 		<div className="auth__self-hosted-instructions">
-			<button onClick={ onClickClose } className="auth__self-hosted-instructions-close">
+			<Button onClick={ onClickClose } className="auth__self-hosted-instructions-close">
 				<Gridicon icon="cross" size={ 24 } />
-			</button>
+			</Button>
 
 			<h2>{ translate( 'Add self-hosted site' ) }</h2>
 			<p>

--- a/client/blocks/app-promo/index.jsx
+++ b/client/blocks/app-promo/index.jsx
@@ -14,7 +14,7 @@ import Gridicon from 'components/gridicon';
  */
 import { localize } from 'i18n-calypso';
 import { recordTracksEvent } from 'state/analytics/actions';
-import { Dialog } from '@automattic/components';
+import { Button, Dialog } from '@automattic/components';
 import { fetchUserSettings } from 'state/user-settings/actions';
 import getUserSettings from 'state/selectors/get-user-settings';
 import { sendEmailLogin } from 'state/auth/actions';
@@ -129,14 +129,14 @@ export class AppPromo extends React.Component {
 
 		return (
 			<div className="app-promo">
-				<button
+				<Button
 					tabIndex="0"
 					className="app-promo__dismiss"
 					onClick={ this.dismiss }
 					aria-label={ translate( 'Dismiss' ) }
 				>
 					<Gridicon icon="cross" size={ 24 } />
-				</button>
+				</Button>
 				<a
 					onClick={ this.recordClickEvent }
 					className="app-promo__link"
@@ -164,15 +164,15 @@ export class AppPromo extends React.Component {
 
 		return (
 			<div className="app-promo">
-				<button
+				<Button
 					tabIndex="0"
 					className="app-promo__dismiss"
 					onClick={ this.dismiss }
 					aria-label={ translate( 'Dismiss' ) }
 				>
 					<Gridicon icon="cross" size={ 24 } />
-				</button>
-				<button
+				</Button>
+				<Button
 					onClick={ this.sendMagicLink }
 					className="app-promo__link"
 					title="Try the mobile app!"
@@ -185,7 +185,7 @@ export class AppPromo extends React.Component {
 						alt="WordPress App Icon"
 					/>
 					{ 'WordPress.com in the palm of your hands — download the mobile app.' }
-				</button>
+				</Button>
 				<Dialog
 					className="app-promo__dialog"
 					isVisible={ this.state.showDialog }

--- a/client/blocks/comments/comment-actions.jsx
+++ b/client/blocks/comments/comment-actions.jsx
@@ -11,6 +11,7 @@ import { noop } from 'lodash';
 /**
  * Internal dependencies
  */
+import { Button } from '@automattic/components';
 import { changeCommentStatus } from 'state/comments/actions';
 import CommentLikeButtonContainer from './comment-likes';
 import CommentApproveAction from './comment-approve-action';
@@ -55,30 +56,30 @@ const CommentActions = ( {
 	return (
 		<div className="comments__comment-actions">
 			{ showReadMore && (
-				<button className="comments__comment-actions-read-more" onClick={ onReadMore }>
+				<Button className="comments__comment-actions-read-more" onClick={ onReadMore }>
 					<Gridicon
 						icon="chevron-down"
 						size={ 18 }
 						className="comments__comment-actions-read-more-icon"
 					/>
 					{ translate( 'Read More' ) }
-				</button>
+				</Button>
 			) }
 			{ showReplyButton && (
-				<button className="comments__comment-actions-reply" onClick={ handleReply }>
+				<Button className="comments__comment-actions-reply" onClick={ handleReply }>
 					<Gridicon icon="reply" size={ 18 } />
 					<span className="comments__comment-actions-reply-label">{ translate( 'Reply' ) }</span>
-				</button>
+				</Button>
 			) }
 			{ showCancelReplyButton && (
-				<button className="comments__comment-actions-cancel-reply" onClick={ onReplyCancel }>
+				<Button className="comments__comment-actions-cancel-reply" onClick={ onReplyCancel }>
 					{ translate( 'Cancel reply' ) }
-				</button>
+				</Button>
 			) }
 			{ showCancelEditButton && (
-				<button className="comments__comment-actions-cancel-reply" onClick={ editCommentCancel }>
+				<Button className="comments__comment-actions-cancel-reply" onClick={ editCommentCancel }>
 					{ translate( 'Cancel' ) }
-				</button>
+				</Button>
 			) }
 			<CommentLikeButtonContainer
 				className="comments__comment-actions-like"
@@ -90,18 +91,18 @@ const CommentActions = ( {
 			{ showModerationTools && (
 				<div className="comments__comment-actions-moderation-tools">
 					<CommentApproveAction { ...{ status, approveComment, unapproveComment } } />
-					<button className="comments__comment-actions-trash" onClick={ trashComment }>
+					<Button className="comments__comment-actions-trash" onClick={ trashComment }>
 						<Gridicon icon="trash" size={ 18 } />
 						<span className="comments__comment-actions-like-label">{ translate( 'Trash' ) }</span>
-					</button>
-					<button className="comments__comment-actions-spam" onClick={ spamComment }>
+					</Button>
+					<Button className="comments__comment-actions-spam" onClick={ spamComment }>
 						<Gridicon icon="spam" size={ 18 } />
 						<span className="comments__comment-actions-like-label">{ translate( 'Spam' ) }</span>
-					</button>
-					<button className="comments__comment-actions-edit" onClick={ editComment }>
+					</Button>
+					<Button className="comments__comment-actions-edit" onClick={ editComment }>
 						<Gridicon icon="pencil" size={ 18 } />
 						<span className="comments__comment-actions-like-label">{ translate( 'Edit' ) }</span>
-					</button>
+					</Button>
 					<EllipsisMenu toggleTitle={ translate( 'More' ) }>
 						<PopoverMenuItem
 							className={ classnames( 'comments__comment-actions-approve', {

--- a/client/blocks/comments/comment-approve-action.jsx
+++ b/client/blocks/comments/comment-approve-action.jsx
@@ -10,6 +10,11 @@ import Gridicon from 'components/gridicon';
 import classnames from 'classnames';
 
 /**
+ * Internal dependencies
+ */
+import { Button } from '@automattic/components';
+
+/**
  * Style dependencies
  */
 import './comment-approve-action.scss';
@@ -21,12 +26,12 @@ const CommentApproveAction = ( { translate, status, approveComment, unapproveCom
 	} );
 
 	return (
-		<button className={ buttonStyle } onClick={ ! isApproved ? approveComment : unapproveComment }>
+		<Button className={ buttonStyle } onClick={ ! isApproved ? approveComment : unapproveComment }>
 			<Gridicon icon="checkmark" size={ 18 } />
 			<span className="comments__comment-actions-like-label">
 				{ isApproved ? translate( 'Approved' ) : translate( 'Approve' ) }
 			</span>
-		</button>
+		</Button>
 	);
 };
 

--- a/client/blocks/comments/comment-edit-form.jsx
+++ b/client/blocks/comments/comment-edit-form.jsx
@@ -13,6 +13,7 @@ import { translate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import { Button } from '@automattic/components';
 import AutoDirection from 'components/auto-direction';
 import Notice from 'components/notice';
 import { editComment } from 'state/comments/actions';
@@ -168,13 +169,13 @@ class PostCommentForm extends Component {
 							/>
 						</AutoDirection>
 					</div>
-					<button
+					<Button
 						className={ buttonClasses }
 						disabled={ this.state.commentText.length === 0 }
 						onClick={ this.handleSubmit }
 					>
 						{ translate( 'Send' ) }
-					</button>
+					</Button>
 					{ this.renderError() }
 				</fieldset>
 			</form>

--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -427,14 +427,14 @@ class PostCommentList extends React.Component {
 					<div className="comments__info-bar">
 						{ this.props.showCommentCount && <CommentCount count={ actualCommentsCount } /> }
 						{ showViewMoreComments && (
-							<button className="comments__view-more" onClick={ this.viewEarlierCommentsHandler }>
+							<Button className="comments__view-more" onClick={ this.viewEarlierCommentsHandler }>
 								{ translate( 'Load more comments (Showing %(shown)d of %(total)d)', {
 									args: {
 										shown: displayedCommentsCount,
 										total: actualCommentsCount,
 									},
 								} ) }
-							</button>
+							</Button>
 						) }
 					</div>
 				) }
@@ -486,14 +486,14 @@ class PostCommentList extends React.Component {
 				) }
 				{ this.renderCommentsList( displayedComments ) }
 				{ showViewMoreComments && this.props.startingCommentId && (
-					<button className="comments__view-more" onClick={ this.viewLaterCommentsHandler }>
+					<Button className="comments__view-more" onClick={ this.viewLaterCommentsHandler }>
 						{ translate( 'Load more comments (Showing %(shown)d of %(total)d)', {
 							args: {
 								shown: displayedCommentsCount,
 								total: actualCommentsCount,
 							},
 						} ) }
-					</button>
+					</Button>
 				) }
 				<PostCommentFormRoot
 					post={ this.props.post }

--- a/client/blocks/comments/post-comment.jsx
+++ b/client/blocks/comments/post-comment.jsx
@@ -12,6 +12,7 @@ import classnames from 'classnames';
 /**
  * Internal dependencies
  */
+import { Button } from '@automattic/components';
 import { isEnabled } from 'config';
 import { getCurrentUser } from 'state/current-user/selectors';
 import TimeSince from 'components/time-since';
@@ -219,9 +220,9 @@ class PostComment extends React.PureComponent {
 		return (
 			<div>
 				{ !! replyVisibilityText && (
-					<button className="comments__view-replies-btn" onClick={ this.handleToggleRepliesClick }>
+					<Button className="comments__view-replies-btn" onClick={ this.handleToggleRepliesClick }>
 						<Gridicon icon="reply" size={ 18 } /> { replyVisibilityText }
-					</button>
+					</Button>
 				) }
 				{ showReplies && (
 					<ol className="comments__list">

--- a/client/blocks/conversation-caterpillar/index.jsx
+++ b/client/blocks/conversation-caterpillar/index.jsx
@@ -10,6 +10,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import { Button } from '@automattic/components';
 import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
 import { getPostCommentsTree, getDateSortedPostComments } from 'state/comments/selectors';
 import { expandComments } from 'state/comments/actions';
@@ -97,7 +98,7 @@ class ConversationCaterpillarComponent extends React.Component {
 					onClick={ this.handleTickle }
 					maxGravatarsToDisplay={ MAX_GRAVATARS_TO_DISPLAY }
 				/>
-				<button
+				<Button
 					className="conversation-caterpillar__count"
 					onClick={ this.handleTickle }
 					title={
@@ -136,7 +137,7 @@ class ConversationCaterpillarComponent extends React.Component {
 								commenterName: lastAuthorName,
 							},
 						} ) }
-				</button>
+				</Button>
 			</div>
 		);
 	}

--- a/client/blocks/image-editor/image-editor-toolbar.jsx
+++ b/client/blocks/image-editor/image-editor-toolbar.jsx
@@ -12,6 +12,7 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
+import { Button } from '@automattic/components';
 import PopoverMenu from 'components/popover/menu';
 import PopoverMenuItem from 'components/popover/menu-item';
 import { AspectRatios, MinimumImageDimensions } from 'state/editor/image-editor/constants';
@@ -196,7 +197,7 @@ export class ImageEditorToolbar extends Component {
 				'is-disabled': button && button.disabled,
 			} );
 			return button ? (
-				<button
+				<Button
 					key={ 'image-editor-toolbar-' + button.tool }
 					ref={ button.ref }
 					className={ buttonClasses }
@@ -204,7 +205,7 @@ export class ImageEditorToolbar extends Component {
 				>
 					<Gridicon icon={ button.icon } />
 					<span>{ button.text }</span>
-				</button>
+				</Button>
 			) : null;
 		} );
 	}

--- a/client/blocks/login/continue-as-user.jsx
+++ b/client/blocks/login/continue-as-user.jsx
@@ -75,7 +75,7 @@ function ContinueAsUser( { currentUser, redirectUrlFromQuery, onChangeAccount } 
 					components: {
 						br: <br />,
 						link: (
-							<button
+							<Button
 								type="button"
 								id="loginAsAnotherUser"
 								className="continue-as-user__change-user-link"

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -512,7 +512,7 @@ export class LoginForm extends Component {
 
 						<label htmlFor="usernameOrEmail">
 							{ this.isPasswordView() ? (
-								<button
+								<Button
 									type="button"
 									className="login__form-change-username"
 									onClick={ this.resetView }
@@ -521,7 +521,7 @@ export class LoginForm extends Component {
 									{ includes( this.state.usernameOrEmail, '@' )
 										? this.props.translate( 'Change Email Address' )
 										: this.props.translate( 'Change Username' ) }
-								</button>
+								</Button>
 							) : (
 								this.props.translate( 'Email Address or Username' )
 							) }

--- a/client/blocks/post-share/sharing-preview-modal.jsx
+++ b/client/blocks/post-share/sharing-preview-modal.jsx
@@ -8,7 +8,7 @@ import Gridicon from 'components/gridicon';
 /**
  * Internal dependencies
  */
-import { Dialog } from '@automattic/components';
+import { Button, Dialog } from '@automattic/components';
 import SharingPreviewPane from 'blocks/sharing-preview-pane';
 
 const SharingPreviewModal = ( props ) => {
@@ -17,9 +17,9 @@ const SharingPreviewModal = ( props ) => {
 	return (
 		<Dialog isVisible={ isVisible } additionalClassNames="post-share__sharing-preview-modal">
 			<header className="post-share__sharing-preview-modal-header">
-				<button onClick={ onClose } className="post-share__sharing-preview-modal-close">
+				<Button onClick={ onClose } className="post-share__sharing-preview-modal-close">
 					<Gridicon icon="cross" />
-				</button>
+				</Button>
 			</header>
 			<SharingPreviewPane { ...previewProps } />
 		</Dialog>

--- a/client/blocks/reader-export-button/index.jsx
+++ b/client/blocks/reader-export-button/index.jsx
@@ -10,6 +10,7 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
+import { Button } from '@automattic/components';
 import wpcom from 'lib/wp';
 import { errorNotice } from 'state/notices/actions';
 import Gridicon from 'components/gridicon';
@@ -72,10 +73,10 @@ class ReaderExportButton extends React.Component {
 
 	render() {
 		return (
-			<button className="reader-export-button" onClick={ this.onClick }>
+			<Button className="reader-export-button" onClick={ this.onClick }>
 				<Gridicon icon="cloud-download" className="reader-export-button__icon" />
 				<span className="reader-export-button__label">{ this.props.translate( 'Export' ) }</span>
-			</button>
+			</Button>
 		);
 	}
 }

--- a/client/blocks/reader-feed-header/index.jsx
+++ b/client/blocks/reader-feed-header/index.jsx
@@ -11,7 +11,7 @@ import config from 'config';
 /**
  * Internal Dependencies
  */
-import { Card } from '@automattic/components';
+import { Button, Card } from '@automattic/components';
 import ReaderFollowButton from 'reader/follow-button';
 import { isAuthorNameBlocked } from 'reader/lib/author-name-blocklist';
 import HeaderBack from 'reader/header-back';
@@ -103,7 +103,7 @@ class FeedHeader extends Component {
 							) }
 
 							{ config.isEnabled( 'reader/seen-posts' ) && feed && (
-								<button
+								<Button
 									onClick={ this.markAllAsSeen }
 									className="reader-feed-header__seen-button"
 									disabled={ feed.unseen_count === 0 }
@@ -112,7 +112,7 @@ class FeedHeader extends Component {
 									<span title={ translate( 'Mark all as seen' ) }>
 										{ translate( 'Mark all as seen' ) }
 									</span>
-								</button>
+								</Button>
 							) }
 						</div>
 					</div>

--- a/client/blocks/reader-post-card/blocked.jsx
+++ b/client/blocks/reader-post-card/blocked.jsx
@@ -10,7 +10,7 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import { unblockSite } from 'state/reader/site-blocks/actions';
-import { Card } from '@automattic/components';
+import { Button, Card } from '@automattic/components';
 import { recordTrack as recordReaderTrack } from 'reader/stats';
 import { bumpStat, recordGoogleEvent } from 'state/analytics/actions';
 
@@ -38,9 +38,9 @@ class PostBlocked extends React.Component {
 					{ translate( 'You have blocked %(site_name)s.', {
 						args: { site_name: post.site_name },
 					} ) }
-					<button onClick={ this.unblock } className="reader-post-card__blocked-undo">
+					<Button onClick={ this.unblock } className="reader-post-card__blocked-undo">
 						{ translate( 'Undo?' ) }
-					</button>
+					</Button>
 				</p>
 			</Card>
 		);

--- a/client/blocks/reader-site-notification-settings/index.jsx
+++ b/client/blocks/reader-site-notification-settings/index.jsx
@@ -9,6 +9,7 @@ import { find, get } from 'lodash';
 /**
  * Internal dependencies
  */
+import { Button } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'components/gridicon';
 import ReaderPopover from 'reader/components/reader-popover';
@@ -131,7 +132,7 @@ class ReaderSiteNotificationSettings extends Component {
 		return (
 			<div className="reader-site-notification-settings">
 				<QueryUserSettings />
-				<button
+				<Button
 					className="reader-site-notification-settings__button"
 					onClick={ this.togglePopoverVisibility }
 					ref={ this.spanRef }
@@ -143,7 +144,7 @@ class ReaderSiteNotificationSettings extends Component {
 					>
 						{ translate( 'Settings' ) }
 					</span>
-				</button>
+				</Button>
 
 				<ReaderPopover
 					onClose={ this.closePopover }

--- a/client/components/accordion/index.jsx
+++ b/client/components/accordion/index.jsx
@@ -11,6 +11,7 @@ import Gridicon from 'components/gridicon';
 /**
  * Internal dependencies
  */
+import { Button } from '@automattic/components';
 import AccordionStatus from './status';
 
 /**
@@ -84,14 +85,14 @@ export default class Accordion extends Component {
 				data-tip-target={ `accordion-${ e2eTitle }` }
 			>
 				<header className="accordion__header">
-					<button type="button" onClick={ this.toggleExpanded } className="accordion__toggle">
+					<Button type="button" onClick={ this.toggleExpanded } className="accordion__toggle">
 						{ icon && <span className="accordion__icon">{ icon }</span> }
 						<span className="accordion__title">{ title }</span>
 						{ subtitle && <span className="accordion__subtitle">{ subtitle }</span> }
 						<span className="accordion__arrow">
 							<Gridicon icon="dropdown" />
 						</span>
-					</button>
+					</Button>
 					{ status && <AccordionStatus { ...status } /> }
 				</header>
 				{ hasExpanded && (

--- a/client/components/clipboard-button-input/README.md
+++ b/client/components/clipboard-button-input/README.md
@@ -25,5 +25,5 @@ The following props can be passed to the ClipboardButtonInput component. With th
 | property   | type    | required | default | comment |
 | ---------- | ------- | -------- | ------- | ------- |
 | `value`    | String  | no       | `""`    | The value of the `<input />` element, and the text to be copied when clicking the copy button. |
-| `disabled` | Boolean | no       | `false` | Whether the children `<input />` and `<button />` should be rendered as `disabled`. |
+| `disabled` | Boolean | no       | `false` | Whether the children `<input />` and `<Button />` should be rendered as `disabled`. |
 | `hideHttp` | Boolean | no       | `false` | Allows URLs to be shown without `http://` or `https://` while keeping the scheme in the copyable value. |

--- a/client/components/date-picker/nav-bar.jsx
+++ b/client/components/date-picker/nav-bar.jsx
@@ -7,6 +7,11 @@ import classNames from 'classnames';
 import { noop } from 'lodash';
 import { translate } from 'i18n-calypso';
 
+/**
+ * Internal dependencies
+ */
+import { Button } from '@automattic/components';
+
 const handleMonthClick = ( onClick = noop ) => ( event ) => {
 	event.preventDefault();
 	onClick();
@@ -28,8 +33,8 @@ export const DatePickerNavBar = ( {
 	return (
 		<div className={ classes }>
 			{ showPreviousButton && (
-				<button
-					className="date-picker__previous-month button"
+				<Button
+					className="date-picker__previous-month"
 					type="button"
 					aria-label={ translate( 'Previous month (%s)', {
 						comment: 'Aria label for date picker controls',
@@ -38,12 +43,12 @@ export const DatePickerNavBar = ( {
 					onClick={ handleMonthClick( onPreviousClick ) }
 				>
 					{ localeUtils.formatMonthShort( previousMonth ) }
-				</button>
+				</Button>
 			) }
 
 			{ showNextButton && (
-				<button
-					className="date-picker__next-month button"
+				<Button
+					className="date-picker__next-month"
 					type="button"
 					aria-label={ translate( 'Next month (%s)', {
 						comment: 'Aria label for date picker controls',
@@ -52,7 +57,7 @@ export const DatePickerNavBar = ( {
 					onClick={ handleMonthClick( onNextClick ) }
 				>
 					{ localeUtils.formatMonthShort( nextMonth ) }
-				</button>
+				</Button>
 			) }
 		</div>
 	);

--- a/client/components/date-range/docs/example.jsx
+++ b/client/components/date-range/docs/example.jsx
@@ -7,7 +7,7 @@ import React, { Fragment, Component } from 'react';
 /**
  * Internal dependencies
  */
-import { Card } from '@automattic/components';
+import { Button, Card } from '@automattic/components';
 import DateRange from '../index.js';
 
 /*
@@ -18,9 +18,9 @@ class DateRangeExample extends Component {
 		// Note: you must ensure you pass the `ref` prop down to the element
 		const customTrigger = ( props ) => {
 			return (
-				<button ref={ props.buttonRef } onClick={ props.onTriggerClick }>
+				<Button ref={ props.buttonRef } onClick={ props.onTriggerClick }>
 					I am a custom Trigger element
-				</button>
+				</Button>
 			);
 		};
 

--- a/client/components/domains/map-domain-step/index.jsx
+++ b/client/components/domains/map-domain-step/index.jsx
@@ -34,6 +34,7 @@ import { NON_PRIMARY_DOMAINS_TO_FREE_USERS } from 'state/current-user/constants'
  * Style dependencies
  */
 import './style.scss';
+import { Button } from '@wordpress/components';
 
 class MapDomainStep extends React.Component {
 	static propTypes = {
@@ -119,15 +120,16 @@ class MapDomainStep extends React.Component {
 							onClick={ this.recordInputFocus }
 							autoFocus // eslint-disable-line jsx-a11y/no-autofocus
 						/>
-						<button
+						<Button
 							disabled={ ! getTld( searchQuery ) }
-							className="map-domain-step__go button is-primary"
+							primary
+							className="map-domain-step__go"
 							onClick={ this.recordGoButtonClick }
 						>
 							{ translate( 'Add', {
 								context: 'Upgrades: Label for mapping an existing domain',
 							} ) }
-						</button>
+						</Button>
 					</div>
 
 					{ this.domainRegistrationUpsell() }

--- a/client/components/domains/registrant-extra-info/test/uk-form.js
+++ b/client/components/domains/registrant-extra-info/test/uk-form.js
@@ -8,6 +8,7 @@ import { identity } from 'lodash';
 /**
  * Internal dependencies
  */
+import { Button } from '@automattic/components';
 import { RegistrantExtraInfoUkForm } from '../uk-form';
 import FormInputValidation from 'components/forms/form-input-validation';
 
@@ -75,7 +76,7 @@ describe( 'uk-form', () => {
 
 			const wrapper = shallow(
 				<RegistrantExtraInfoUkForm { ...testProps }>
-					<button className="test__hush-eslint .submit-button" />
+					<Button className="test__hush-eslint .submit-button" />
 				</RegistrantExtraInfoUkForm>
 			);
 
@@ -97,7 +98,7 @@ describe( 'uk-form', () => {
 
 			const wrapper = shallow(
 				<RegistrantExtraInfoUkForm { ...testProps }>
-					<button className="test__hush-eslint .submit-button" />
+					<Button className="test__hush-eslint .submit-button" />
 				</RegistrantExtraInfoUkForm>
 			);
 			expect( wrapper.find( 'button' ).prop( 'disabled' ) ).toBe( undefined );

--- a/client/components/dot-pager/index.jsx
+++ b/client/components/dot-pager/index.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { Children, useState } from 'react';
-import { Card } from '@automattic/components';
+import { Button, Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { times } from 'lodash';
 import classnames from 'classnames';
@@ -27,18 +27,18 @@ const Controls = ( { currentPage, numberOfPages, setCurrentPage } ) => {
 	return (
 		<ul className="dot-pager__controls" aria-label={ translate( 'Pager controls' ) }>
 			<li key="dot-pager-prev">
-				<button
+				<Button
 					className="dot-pager__control-prev"
 					disabled={ ! canGoBack }
 					aria-label={ translate( 'Previous' ) }
 					onClick={ () => setCurrentPage( currentPage - 1 ) }
 				>
 					<Gridicon icon="chevron-left" size={ 18 } />
-				</button>
+				</Button>
 			</li>
 			{ times( numberOfPages, ( page ) => (
 				<li key={ `page-${ page }` } aria-current={ page === currentPage ? 'page' : undefined }>
-					<button
+					<Button
 						key={ page.toString() }
 						className={ classnames( { 'dot-pager__control-current': page === currentPage } ) }
 						disabled={ page === currentPage }
@@ -50,14 +50,14 @@ const Controls = ( { currentPage, numberOfPages, setCurrentPage } ) => {
 				</li>
 			) ) }
 			<li key="dot-pager-next">
-				<button
+				<Button
 					className="dot-pager__control-next"
 					disabled={ ! canGoForward }
 					aria-label={ translate( 'Next' ) }
 					onClick={ () => setCurrentPage( currentPage + 1 ) }
 				>
 					<Gridicon icon="chevron-right" size={ 18 } />
-				</button>
+				</Button>
 			</li>
 		</ul>
 	);

--- a/client/components/foldable-card/docs/example.jsx
+++ b/client/components/foldable-card/docs/example.jsx
@@ -71,10 +71,8 @@ export default class FoldableCardExample extends PureComponent {
 								</div>
 							</div>
 						}
-						// eslint-disable-next-line wpcalypso/jsx-classname-namespace
-						summary={ <button className="button">Update</button> }
-						// eslint-disable-next-line wpcalypso/jsx-classname-namespace
-						expandedSummary={ <button className="button">Update</button> }
+						summary={ <Button>Update</Button> }
+						expandedSummary={ <Button>Update</Button> }
 						screenReaderText="More"
 					>
 						Nothing to see here. Keep walking!

--- a/client/components/foldable-card/index.jsx
+++ b/client/components/foldable-card/index.jsx
@@ -11,7 +11,7 @@ import { noop } from 'lodash';
 /**
  * Internal Dependencies
  */
-import { Card, CompactCard, ScreenReaderText } from '@automattic/components';
+import { Button, Card, CompactCard, ScreenReaderText } from '@automattic/components';
 import Gridicon from 'components/gridicon';
 
 /**
@@ -101,7 +101,7 @@ class FoldableCard extends Component {
 			const iconSize = 24;
 			const screenReaderText = this.props.screenReaderText || this.props.translate( 'More' );
 			return (
-				<button
+				<Button
 					disabled={ this.props.disabled }
 					type="button"
 					className="foldable-card__action foldable-card__expand"
@@ -109,7 +109,7 @@ class FoldableCard extends Component {
 				>
 					<ScreenReaderText>{ screenReaderText }</ScreenReaderText>
 					<Gridicon icon={ this.props.icon } size={ iconSize } />
-				</button>
+				</Button>
 			);
 		}
 	}

--- a/client/components/forms/sortable-list/README.md
+++ b/client/components/forms/sortable-list/README.md
@@ -17,8 +17,8 @@ Below is example usage for rendering an SortableList:
 
 ```jsx
 <SortableList>
-	<button className="button">First</button>
-	<button className="button">Second</button>
+	<Button>First</Button>
+	<Button>Second</Button>
 </SortableList>
 ```
 
@@ -47,7 +47,7 @@ class MyComponent extends Component {
 
 	render() {
 		const items = this.state.items.map( function( item ) {
-			return <button className="button">{ item }</button>;
+			return <Button>{ item }</Button>;
 		} );
 
 		return <SortableList onChange={ onChange }>{ items }</SortableList>;

--- a/client/components/forms/sortable-list/index.jsx
+++ b/client/components/forms/sortable-list/index.jsx
@@ -12,7 +12,7 @@ import Gridicon from 'components/gridicon';
 /**
  * Internal dependencies
  */
-import { ScreenReaderText } from '@automattic/components';
+import { Button, ScreenReaderText } from '@automattic/components';
 import { hasTouch } from 'lib/touch-detect';
 
 const debug = debugFactory( 'calypso:forms:sortable-list' );
@@ -336,7 +336,7 @@ class SortableList extends React.Component {
 
 		return (
 			<div className="sortable-list__navigation">
-				<button
+				<Button
 					type="button"
 					onClick={ this.moveItem.bind( null, 'previous' ) }
 					className="sortable-list__navigation-button is-previous"
@@ -344,8 +344,8 @@ class SortableList extends React.Component {
 				>
 					<ScreenReaderText>{ this.props.translate( 'Move previous' ) }</ScreenReaderText>
 					<Gridicon icon="chevron-down" size={ 24 } />
-				</button>
-				<button
+				</Button>
+				<Button
 					type="button"
 					onClick={ this.moveItem.bind( null, 'next' ) }
 					className="sortable-list__navigation-button is-next"
@@ -356,7 +356,7 @@ class SortableList extends React.Component {
 				>
 					<ScreenReaderText>{ this.props.translate( 'Move next' ) }</ScreenReaderText>
 					<Gridicon icon="chevron-up" size={ 24 } />
-				</button>
+				</Button>
 			</div>
 		);
 	};

--- a/client/components/global-notices/README.md
+++ b/client/components/global-notices/README.md
@@ -17,7 +17,7 @@ import { successNotices } from 'state/notices/actions';
 
 function MyComponent() {
   return (
-    <button onClick={ this.props.successNotice( 'Objective achieved!' ) } />Click me!</button>
+    <Button onClick={ this.props.successNotice( 'Objective achieved!' ) } />Click me!</Button>
   );
 }
 

--- a/client/components/info-popover/index.jsx
+++ b/client/components/info-popover/index.jsx
@@ -9,6 +9,7 @@ import { translate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import { Button } from '@automattic/components';
 import Gridicon from 'components/gridicon';
 import Popover from 'components/popover';
 import { gaRecordEvent } from 'lib/analytics/ga';
@@ -73,7 +74,7 @@ export default class InfoPopover extends Component {
 	render() {
 		return (
 			<Fragment>
-				<button
+				<Button
 					type="button"
 					aria-haspopup
 					aria-expanded={ this.state.showPopover }
@@ -85,7 +86,7 @@ export default class InfoPopover extends Component {
 					} ) }
 				>
 					<Gridicon icon={ this.props.icon } size={ this.props.iconSize } />
-				</button>
+				</Button>
 				{ this.state.showPopover && (
 					<Popover
 						autoRtl={ this.props.autoRtl }

--- a/client/components/jetpack/with-server-credentials-form/test/index.js
+++ b/client/components/jetpack/with-server-credentials-form/test/index.js
@@ -14,6 +14,7 @@ import * as actions from 'state/jetpack/credentials/actions';
 /**
  * Internal dependencies
  */
+import { Button } from '@automattic/components';
 import withServerCredentialsForm from 'components/jetpack/with-server-credentials-form';
 
 /**
@@ -104,17 +105,17 @@ function setup( { role = 'main', siteId = 9999, siteUrl = 'siteUrl' } = {} ) {
 
 				<div data-testid="advanced-section">{ showAdvancedSettings && 'Hidden content!' }</div>
 
-				<button type="button" onClick={ toggleAdvancedSettings }>
+				<Button type="button" onClick={ toggleAdvancedSettings }>
 					Advanced Section
-				</button>
+				</Button>
 
-				<button type="button" onClick={ handleDelete }>
+				<Button type="button" onClick={ handleDelete }>
 					Delete
-				</button>
+				</Button>
 
-				<button type="button" onClick={ handleSubmit }>
+				<Button type="button" onClick={ handleSubmit }>
 					Submit
-				</button>
+				</Button>
 			</form>
 		);
 	};

--- a/client/components/keyed-suggestions/index.jsx
+++ b/client/components/keyed-suggestions/index.jsx
@@ -22,6 +22,11 @@ import classNames from 'classnames';
 import i18n from 'i18n-calypso';
 
 /**
+ * Internal dependencies
+ */
+import { Button } from '@automattic/components';
+
+/**
  * Style dependencies
  */
 import './style.scss';
@@ -32,9 +37,9 @@ function SuggestionsButtonAll( props ) {
 	}
 
 	return (
-		<button className="keyed-suggestions__category-show-all" onClick={ click }>
+		<Button className="keyed-suggestions__category-show-all" onClick={ click }>
 			{ props.label }
-		</button>
+		</Button>
 	);
 }
 

--- a/client/components/language-picker/index.jsx
+++ b/client/components/language-picker/index.jsx
@@ -12,6 +12,7 @@ import { find, isString, noop } from 'lodash';
 /**
  * Internal dependencies
  */
+import { Button } from '@automattic/components';
 import config from 'config';
 import LanguagePickerModal from './modal';
 import { requestGeoLocation } from 'state/data-getters';
@@ -182,7 +183,7 @@ export class LanguagePicker extends PureComponent {
 
 		return (
 			<Fragment>
-				<button
+				<Button
 					type="button"
 					className="language-picker"
 					onClick={ this.handleClick }
@@ -198,7 +199,7 @@ export class LanguagePicker extends PureComponent {
 							<div className="language-picker__name-label">{ langName }</div>
 						</div>
 					</div>
-				</button>
+				</Button>
 				{ this.renderModal( language.langSlug ) }
 			</Fragment>
 		);

--- a/client/components/line-chart/docs/example.js
+++ b/client/components/line-chart/docs/example.js
@@ -8,7 +8,7 @@ import moment from 'moment';
 /**
  * Internal dependencies
  */
-import { Card } from '@automattic/components';
+import { Button, Card } from '@automattic/components';
 import LineChart from 'components/line-chart';
 
 const NUM_DATA_SERIES = 3;
@@ -93,9 +93,9 @@ export default class LineChartExample extends Component {
 	render() {
 		return (
 			<div>
-				<button className="docs__design-toggle button" onClick={ this.toggleDataControls }>
+				<Button className="docs__design-toggle" onClick={ this.toggleDataControls }>
 					{ this.state.showDataControls ? 'Hide Data Controls' : 'Show Data Controls' }
-				</button>
+				</Button>
 
 				<Card>
 					<LineChart

--- a/client/components/mobile-back-to-sidebar/index.jsx
+++ b/client/components/mobile-back-to-sidebar/index.jsx
@@ -9,6 +9,7 @@ import Gridicon from 'components/gridicon';
 /**
  * Internal Dependencies
  */
+import { Button } from '@automattic/components';
 import { setLayoutFocus } from 'state/ui/layout-focus/actions';
 
 /**
@@ -18,10 +19,10 @@ import './style.scss';
 
 function MobileBackToSidebar( { children, toggleSidebar } ) {
 	return (
-		<button className="mobile-back-to-sidebar" onClick={ toggleSidebar }>
+		<Button className="mobile-back-to-sidebar" onClick={ toggleSidebar }>
 			<Gridicon icon="chevron-left" className="mobile-back-to-sidebar__icon" />
 			<span className="mobile-back-to-sidebar__content">{ children }</span>
-		</button>
+		</Button>
 	);
 }
 

--- a/client/components/notice/docs/example.jsx
+++ b/client/components/notice/docs/example.jsx
@@ -7,6 +7,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
+import { Button } from '@automattic/components';
 import NoticeAction from 'components/notice/notice-action';
 import Notice from 'components/notice';
 
@@ -22,9 +23,9 @@ class Notices extends React.PureComponent {
 
 		return (
 			<div>
-				<button className="docs__design-toggle button" onClick={ this.toggleNotices }>
+				<Button className="docs__design-toggle" onClick={ this.toggleNotices }>
 					{ toggleNoticesText }
-				</button>
+				</Button>
 
 				<div>
 					<Notice showDismiss={ false } isCompact={ this.state.compactNotices ? true : null }>

--- a/client/components/notice/index.jsx
+++ b/client/components/notice/index.jsx
@@ -8,6 +8,10 @@ import classnames from 'classnames';
 import { noop } from 'lodash';
 import { localize } from 'i18n-calypso';
 
+/**
+ * Internal dependencies
+ */
+import { Button } from '@automattic/components';
 // @todo: Convert to import from `components/gridicon`
 // which makes Calypso mysteriously crash at the moment.
 //
@@ -141,13 +145,13 @@ export class Notice extends Component {
 				</span>
 				{ text ? children : null }
 				{ showDismiss && (
-					<button
+					<Button
 						className="notice__dismiss"
 						onClick={ onDismissClick }
 						aria-label={ translate( 'Dismiss' ) }
 					>
 						<Gridicon icon="cross" size={ 24 } />
-					</button>
+					</Button>
 				) }
 			</div>
 		);

--- a/client/components/pagination/docs/example.jsx
+++ b/client/components/pagination/docs/example.jsx
@@ -7,6 +7,7 @@ import React, { Component } from 'react';
 /**
  * Internal dependencies
  */
+import { Button } from '@automattic/components';
 import Pagination from 'components/pagination';
 
 class PaginationExample extends Component {
@@ -26,9 +27,9 @@ class PaginationExample extends Component {
 	render() {
 		return (
 			<div>
-				<button className="docs__design-toggle button" onClick={ this.toggleCompact }>
+				<Button className="docs__design-toggle" onClick={ this.toggleCompact }>
 					{ this.state.compact ? 'Normal' : 'Compact' }
-				</button>
+				</Button>
 				<Pagination
 					compact={ this.state.compact }
 					page={ this.state.page }

--- a/client/components/popover/README.md
+++ b/client/components/popover/README.md
@@ -148,12 +148,12 @@ The children to render inside of the `PopoverMenuItem`.
 ### `Popover` Usage
 
 ```jsx
-<button
-	ref="popoverButton" className="button"
+<Button
+	ref="popoverButton"
 	onClick={ this.TogglePopover }
 >
 	Show Popover
-</button>
+</Button>
 
 <Popover
 	context={ this.refs && this.refs.popoverButton }
@@ -169,12 +169,12 @@ The children to render inside of the `PopoverMenuItem`.
 ### `PopoverMenu` Usage
 
 ```jsx
-<button
-	ref="popoverMenuButton" className="button"
+<Button
+	ref="popoverMenuButton"
 	onClick={ this._onTogglePopoverMenu }
 >
 	Show Popover Menu
-</button>
+</Button>
 
 <PopoverMenu
 	context={ this.refs && this.refs.popoverMenuButton }

--- a/client/components/popover/docs/example.jsx
+++ b/client/components/popover/docs/example.jsx
@@ -7,6 +7,7 @@ import React, { PureComponent } from 'react';
 /**
  * Internal dependencies
  */
+import { Button } from '@automattic/components';
 import Popover from 'components/popover';
 import PopoverMenu from 'components/popover/menu';
 import PopoverMenuItem from 'components/popover/menu-item';
@@ -56,9 +57,9 @@ class PopoverExample extends PureComponent {
 	renderPopover() {
 		return (
 			<div>
-				<button className="button" ref="popoverButton" onClick={ this.swapPopoverVisibility }>
+				<Button ref="popoverButton" onClick={ this.swapPopoverVisibility }>
 					Show Popover
-				</button>
+				</Button>
 
 				<Popover
 					id="popover__basic-example"
@@ -77,9 +78,9 @@ class PopoverExample extends PureComponent {
 	renderMenuPopover() {
 		return (
 			<div>
-				<button className="button" ref="popoverMenuButton" onClick={ this.showPopoverMenu }>
+				<Button ref="popoverMenuButton" onClick={ this.showPopoverMenu }>
 					Show Popover Menu
-				</button>
+				</Button>
 
 				<br />
 

--- a/client/components/post-schedule/docs/example.jsx
+++ b/client/components/post-schedule/docs/example.jsx
@@ -11,7 +11,7 @@ import Gridicon from 'components/gridicon';
  */
 import PostSchedule from 'components/post-schedule';
 import Timezone from 'components/timezone';
-import { Card } from '@automattic/components';
+import { Button, Card } from '@automattic/components';
 import EventsTooltip from 'components/date-picker/events-tooltip';
 import { withLocalizedMoment } from 'components/localized-moment';
 
@@ -172,7 +172,7 @@ const PostScheduleExample = localize(
 
 									<Timezone selectedZone={ this.state.timezone } onSelect={ this.setTimezone } />
 
-									<button
+									<Button
 										className="card__property-action"
 										style={ {
 											top: '-8px',
@@ -182,7 +182,7 @@ const PostScheduleExample = localize(
 										href="#"
 									>
 										clean timezone
-									</button>
+									</Button>
 								</div>
 
 								<div className="card__block">
@@ -196,13 +196,13 @@ const PostScheduleExample = localize(
 										/>
 									</label>
 
-									<button
+									<Button
 										className="card__property-action"
 										onClick={ this.clearState.bind( this, 'gmtOffset' ) }
 										href="#"
 									>
 										clean gmtOffset
-									</button>
+									</Button>
 								</div>
 
 								<div className="card__block">
@@ -213,13 +213,13 @@ const PostScheduleExample = localize(
 										</div>
 									</label>
 
-									<button
+									<Button
 										className="card__property-action"
 										onClick={ this.clearState.bind( this, 'date' ) }
 										href="#"
 									>
 										clean selectedDay
-									</button>
+									</Button>
 								</div>
 							</Card>
 

--- a/client/components/post-schedule/header-controls.jsx
+++ b/client/components/post-schedule/header-controls.jsx
@@ -7,6 +7,11 @@ import React from 'react';
 import Gridicon from 'components/gridicon';
 
 /**
+ * Internal dependencies
+ */
+import { Button } from '@automattic/components';
+
+/**
  * Globals
  */
 const noop = () => {};
@@ -25,23 +30,23 @@ export default class extends React.Component {
 	render() {
 		return (
 			<div className="post-schedule__year-controls">
-				<button
+				<Button
 					className="post-schedule__year-control-up"
 					onClick={ () => {
 						this.props.onYearChange( 1 );
 					} }
 				>
 					<Gridicon icon="chevron-up" size={ 14 } />
-				</button>
+				</Button>
 
-				<button
+				<Button
 					className="post-schedule__year-control-down"
 					onClick={ () => {
 						this.props.onYearChange( -1 );
 					} }
 				>
 					<Gridicon icon="chevron-down" size={ 14 } />
-				</button>
+				</Button>
 			</div>
 		);
 	}

--- a/client/components/section-nav/index.jsx
+++ b/client/components/section-nav/index.jsx
@@ -11,6 +11,7 @@ import Gridicon from 'components/gridicon';
 /**
  * Internal Dependencies
  */
+import { Button } from '@automattic/components';
 import CommentNavigationTab from 'my-sites/comments/comment-navigation/comment-navigation-tab';
 import NavTabs from 'components/section-nav/tabs';
 import NavItem from 'components/section-nav/item';
@@ -58,10 +59,10 @@ class SectionNav extends Component {
 		}
 
 		return (
-			<button className="section-nav__mobile-header" onClick={ this.toggleMobileOpenState }>
+			<Button className="section-nav__mobile-header" onClick={ this.toggleMobileOpenState }>
 				<span className="section-nav__mobile-header-text">{ this.props.selectedText }</span>
 				<Gridicon icon="chevron-down" size={ 18 } />
-			</button>
+			</Button>
 		);
 	}
 

--- a/client/components/segmented-control/docs/example.jsx
+++ b/client/components/segmented-control/docs/example.jsx
@@ -6,6 +6,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
+import { Button } from '@automattic/components';
 import SegmentedControl from 'components/segmented-control';
 import SimplifiedSegmentedControl from 'components/segmented-control/simplified';
 
@@ -36,9 +37,9 @@ class SegmentedControlDemo extends React.PureComponent {
 
 		return (
 			<div>
-				<button className="docs__design-toggle button" onClick={ this.toggleCompact }>
+				<Button className="docs__design-toggle" onClick={ this.toggleCompact }>
 					{ this.state.compact ? 'Normal' : 'Compact' }
-				</button>
+				</Button>
 
 				<h3>Items passed as options prop</h3>
 				<SimplifiedSegmentedControl

--- a/client/components/select-dropdown/docs/example.jsx
+++ b/client/components/select-dropdown/docs/example.jsx
@@ -8,6 +8,7 @@ import Gridicon from 'components/gridicon';
 /**
  * Internal dependencies
  */
+import { Button } from '@automattic/components';
 import SelectDropdown from 'components/select-dropdown';
 
 class SelectDropdownExample extends React.PureComponent {
@@ -40,9 +41,9 @@ class SelectDropdownExample extends React.PureComponent {
 
 		return (
 			<div className="docs__select-dropdown-container">
-				<button className="docs__design-toggle button" onClick={ this.toggleButtons }>
+				<Button className="docs__design-toggle" onClick={ this.toggleButtons }>
 					{ toggleButtonsText }
-				</button>
+				</Button>
 
 				<h3>Items passed as options prop</h3>
 				<SelectDropdown

--- a/client/components/sidebar-navigation/index.jsx
+++ b/client/components/sidebar-navigation/index.jsx
@@ -10,6 +10,7 @@ import Gridicon from 'components/gridicon';
 /**
  * Internal Dependencies
  */
+import { Button } from '@automattic/components';
 import { setLayoutFocus } from 'state/ui/layout-focus/actions';
 import TranslatableString from 'components/translatable/proptype';
 
@@ -22,11 +23,11 @@ function SidebarNavigation( { sectionTitle, children, toggleSidebar } ) {
 	return (
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		<header className="current-section">
-			<button onClick={ toggleSidebar }>
+			<Button onClick={ toggleSidebar }>
 				<Gridicon icon="menu" />
 				{ children }
 				<h1 className="current-section__site-title">{ sectionTitle }</h1>
-			</button>
+			</Button>
 		</header>
 		/* eslint-enable wpcalypso/jsx-classname-namespace */
 	);

--- a/client/components/site-verticals-suggestion-search/popular-topics.jsx
+++ b/client/components/site-verticals-suggestion-search/popular-topics.jsx
@@ -10,6 +10,7 @@ import { shuffle } from 'lodash';
 /**
  * Internal dependencies
  */
+import { Button } from '@automattic/components';
 import { getSiteType } from 'state/signup/steps/site-type/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
 
@@ -77,7 +78,7 @@ class PopularTopics extends PureComponent {
 			<div className="site-verticals-suggestion-search__common-topics">
 				<div className="site-verticals-suggestion-search__heading">{ translate( 'Popular' ) }</div>
 				{ shuffledTopics.map( ( topic, index ) => (
-					<button
+					<Button
 						type="button"
 						key={ index }
 						value={ topic }
@@ -86,7 +87,7 @@ class PopularTopics extends PureComponent {
 						tabIndex="0"
 					>
 						{ topic }
-					</button>
+					</Button>
 				) ) }
 			</div>
 		);

--- a/client/components/social-buttons/apple.js
+++ b/client/components/social-buttons/apple.js
@@ -13,6 +13,7 @@ import { loadScript } from '@automattic/load-script';
 /**
  * Internal dependencies
  */
+import { Button } from '@automattic/components';
 import { isFormDisabled } from 'state/login/selectors';
 import requestExternalAccess from '@automattic/request-external-access';
 
@@ -144,8 +145,8 @@ class AppleLoginButton extends Component {
 				{ customButton ? (
 					customButton
 				) : (
-					<button
-						className={ classNames( 'social-buttons__button button', { disabled: isDisabled } ) }
+					<Button
+						className={ classNames( 'social-buttons__button', { disabled: isDisabled } ) }
 						onClick={ this.handleClick }
 					>
 						<AppleIcon isDisabled={ isDisabled } />
@@ -157,7 +158,7 @@ class AppleLoginButton extends Component {
 									'%(service)s is the name of a third-party authentication provider, e.g. "Google", "Facebook", "Apple" ...',
 							} ) }
 						</span>
-					</button>
+					</Button>
 				) }
 			</Fragment>
 		);

--- a/client/components/social-buttons/facebook.js
+++ b/client/components/social-buttons/facebook.js
@@ -13,6 +13,7 @@ import { noop } from 'lodash';
 /**
  * Internal dependencies
  */
+import { Button } from '@automattic/components';
 import FacebookIcon from 'components/social-icons/facebook';
 import { isFormDisabled } from 'state/login/selectors';
 
@@ -113,8 +114,8 @@ class FacebookLoginButton extends Component {
 
 		return (
 			<div className="social-buttons__button-container">
-				<button
-					className={ classNames( 'social-buttons__button button', { disabled: isDisabled } ) }
+				<Button
+					className={ classNames( 'social-buttons__button', { disabled: isDisabled } ) }
 					onClick={ this.handleClick }
 				>
 					<FacebookIcon />
@@ -126,7 +127,7 @@ class FacebookLoginButton extends Component {
 								'%(service)s is the name of a third-party authentication provider, e.g. "Google", "Facebook", "Apple" ...',
 						} ) }
 					</span>
-				</button>
+				</Button>
 			</div>
 		);
 	}

--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -12,6 +12,7 @@ import { noop } from 'lodash';
 /**
  * Internal dependencies
  */
+import { Button } from '@automattic/components';
 import GoogleIcon from 'components/social-icons/google';
 import Popover from 'components/popover';
 import { preventWidows } from 'lib/formatting';
@@ -209,8 +210,8 @@ class GoogleLoginButton extends Component {
 				{ customButton ? (
 					customButton
 				) : (
-					<button
-						className={ classNames( 'social-buttons__button button', { disabled: isDisabled } ) }
+					<Button
+						className={ classNames( 'social-buttons__button', { disabled: isDisabled } ) }
 						onMouseOver={ this.showError }
 						onFocus={ this.showError }
 						onMouseOut={ this.hideError }
@@ -226,7 +227,7 @@ class GoogleLoginButton extends Component {
 									'%(service)s is the name of a third-party authentication provider, e.g. "Google", "Facebook", "Apple" ...',
 							} ) }
 						</span>
-					</button>
+					</Button>
 				) }
 				<Popover
 					id="social-buttons__error"

--- a/client/components/theme/more-button.jsx
+++ b/client/components/theme/more-button.jsx
@@ -11,6 +11,7 @@ import Gridicon from 'components/gridicon';
 /**
  * Internal dependencies
  */
+import { Button } from '@automattic/components';
 import PopoverMenu from 'components/popover/menu';
 import PopoverMenuItem from 'components/popover/menu-item';
 import PopoverMenuSeparator from 'components/popover/menu-separator';
@@ -62,9 +63,9 @@ class ThemeMoreButton extends Component {
 
 		return (
 			<span className={ classes }>
-				<button ref={ this.moreButtonRef } onClick={ this.togglePopover }>
+				<Button ref={ this.moreButtonRef } onClick={ this.togglePopover }>
 					<Gridicon icon="ellipsis" size={ 24 } />
-				</button>
+				</Button>
 
 				{ this.state.showPopover && (
 					<PopoverMenu

--- a/client/components/tinymce/plugins/advanced/plugin.jsx
+++ b/client/components/tinymce/plugins/advanced/plugin.jsx
@@ -10,6 +10,7 @@ import { translate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import { Button } from '@automattic/components';
 import { savePreference, fetchPreferences } from 'state/preferences/actions';
 import { getPreference, isFetchingPreferences } from 'state/preferences/selectors';
 import Gridicon from 'components/gridicon';
@@ -70,11 +71,11 @@ function advanced( editor ) {
 			this.innerHtml(
 				ReactDomServer.renderToStaticMarkup(
 					// eslint-disable-next-line jsx-a11y/no-interactive-element-to-noninteractive-role
-					<button type="button" role="presentation" tabIndex="-1">
+					<Button type="button" role="presentation" tabIndex="-1">
 						{ /* eslint-disable wpcalypso/jsx-gridicon-size */ }
 						<Gridicon icon="ellipsis" size={ 28 } />
 						{ /* eslint-enable wpcalypso/jsx-gridicon-size */ }
-					</button>
+					</Button>
 				)
 			);
 		},

--- a/client/components/tinymce/plugins/contact-form/plugin.jsx
+++ b/client/components/tinymce/plugins/contact-form/plugin.jsx
@@ -10,6 +10,7 @@ import { renderToStaticMarkup } from 'react-dom/server';
 /**
  * Internal Dependencies
  */
+import { Button } from '@automattic/components';
 import ContactFormDialog from './dialog';
 import {
 	formClear,
@@ -96,9 +97,9 @@ function wpcomContactForm( editor ) {
 			this.innerHtml(
 				renderToStaticMarkup(
 					// eslint-disable-next-line jsx-a11y/no-interactive-element-to-noninteractive-role
-					<button type="button" role="presentation">
+					<Button type="button" role="presentation">
 						<Gridicon icon="mention" />
-					</button>
+					</Button>
 				)
 			);
 		},

--- a/client/components/tinymce/plugins/media/plugin.jsx
+++ b/client/components/tinymce/plugins/media/plugin.jsx
@@ -13,6 +13,7 @@ import closest from 'component-closest';
 /**
  * Internal dependencies
  */
+import { Button } from '@automattic/components';
 import * as MediaConstants from 'lib/media/constants';
 import { getThumbnailSizeDimensions } from 'lib/media/utils';
 import { deserialize } from 'lib/media-serialization';
@@ -474,11 +475,11 @@ function mediaButton( editor ) {
 			this.innerHtml(
 				ReactDomServer.renderToStaticMarkup(
 					// eslint-disable-next-line jsx-a11y/no-interactive-element-to-noninteractive-role
-					<button type="button" role="presentation" tabIndex="-1">
+					<Button type="button" role="presentation" tabIndex="-1">
 						{ /* eslint-disable wpcalypso/jsx-gridicon-size */ }
 						<Gridicon icon="image-multiple" size={ 20 } />
 						{ /* eslint-enable wpcalypso/jsx-gridicon-size */ }
-					</button>
+					</Button>
 				)
 			);
 		},

--- a/client/components/tinymce/plugins/wpcom-view/views/contact-form/index.jsx
+++ b/client/components/tinymce/plugins/wpcom-view/views/contact-form/index.jsx
@@ -8,6 +8,7 @@ import { deserialize } from 'components/tinymce/plugins/contact-form/shortcode-u
 /**
  * Internal dependencies
  */
+import { Button } from '@automattic/components';
 import { next } from 'lib/shortcode';
 import renderField from './preview-fields';
 
@@ -17,7 +18,7 @@ const ContactForm = localize( ( { content, translate } ) => {
 	return (
 		<div className="wpview-content wpview-type-contact-form">
 			{ [].concat( fields ).map( renderField ) }
-			<button disabled>{ translate( 'Submit' ) }</button>
+			<Button disabled>{ translate( 'Submit' ) }</Button>
 		</div>
 	);
 } );

--- a/client/components/tinymce/plugins/wplink/dialog.jsx
+++ b/client/components/tinymce/plugins/wplink/dialog.jsx
@@ -13,7 +13,7 @@ import { find } from 'lodash';
  */
 import { deserialize } from 'lib/media-serialization';
 import { url as mediaUrl } from 'lib/media/utils';
-import { Dialog } from '@automattic/components';
+import { Button, Dialog } from '@automattic/components';
 import FormTextInput from 'components/forms/form-text-input';
 import FormCheckbox from 'components/forms/form-checkbox';
 import FormButton from 'components/forms/form-button';
@@ -257,10 +257,10 @@ class LinkDialog extends React.Component {
 
 		if ( this.state.url && ! this.state.isNew ) {
 			buttons.push(
-				<button className={ 'wplink__remove-link' } onClick={ this.removeLink }>
+				<Button className={ 'wplink__remove-link' } onClick={ this.removeLink }>
 					<Gridicon icon="link-break" />
 					{ this.props.translate( 'Remove' ) }
-				</button>
+				</Button>
 			);
 		}
 

--- a/client/extensions/woocommerce/app/reviews/review-reply-create.js
+++ b/client/extensions/woocommerce/app/reviews/review-reply-create.js
@@ -13,6 +13,7 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
+import { Button } from '@automattic/components';
 import { createReviewReply } from 'woocommerce/state/sites/review-replies/actions';
 import { getCurrentUser } from 'state/current-user/selectors';
 import Gravatar from 'components/gravatar';
@@ -143,9 +144,9 @@ class ReviewReplyCreate extends Component {
 
 				<Gravatar className={ gravatarClasses } size={ 24 } user={ currentUser } />
 
-				<button className={ buttonClasses } disabled={ ! hasCommentText } onClick={ this.onSubmit }>
+				<Button className={ buttonClasses } disabled={ ! hasCommentText } onClick={ this.onSubmit }>
 					{ translate( 'Send' ) }
-				</button>
+				</Button>
 			</form>
 		);
 	}

--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -10,6 +10,7 @@ import { Title, SubTitle, ActionButtons, BackButton } from '@automattic/onboardi
 /**
  * Internal dependencies
  */
+import { Button } from '@automattic/components';
 import { STORE_KEY as ONBOARD_STORE } from '../../stores/onboard';
 
 import { useTrackStep } from '../../hooks/use-track-step';
@@ -56,7 +57,7 @@ const DesignSelector: React.FunctionComponent = () => {
 			<div className="design-selector__design-grid">
 				<div className="design-selector__grid">
 					{ getRandomizedDesigns().featured.map( ( design ) => (
-						<button
+						<Button
 							key={ design.slug }
 							className="design-selector__design-option"
 							data-e2e-button={ design.is_premium ? 'paidOption' : 'freeOption' }
@@ -99,7 +100,7 @@ const DesignSelector: React.FunctionComponent = () => {
 									) }
 								</span>
 							</span>
-						</button>
+						</Button>
 					) ) }
 				</div>
 			</div>

--- a/client/layout/community-translator/launcher.jsx
+++ b/client/layout/community-translator/launcher.jsx
@@ -386,7 +386,7 @@ class TranslatorLauncher extends React.Component {
 				{ shouldRenderLauncherButton && (
 					<Fragment>
 						<div className={ launcherClasses }>
-							<button
+							<Button
 								onClick={ this.toggle }
 								className="community-translator__button"
 								title={ translate( 'Community Translator' ) }
@@ -396,7 +396,7 @@ class TranslatorLauncher extends React.Component {
 									<span className="community-translator__badge">{ selectedLanguageSlug }</span>
 								) }
 								<div className="community-translator__text">{ buttonString }</div>
-							</button>
+							</Button>
 						</div>
 						{ infoDialogVisible && this.renderConfirmationModal() }
 					</Fragment>

--- a/client/layout/sidebar/heading.jsx
+++ b/client/layout/sidebar/heading.jsx
@@ -11,7 +11,7 @@ const SidebarHeading = ( { children, onClick, ...extraProps } ) => {
 
 	if ( onClick ) {
 		onKeyDown = ( event ) => {
-			// Trigger click for enter, similarly to default brower behavior for <a> or <button>
+			// Trigger click for enter, similarly to default browser behavior for <a> or <button>
 			if ( 13 === event.keyCode ) {
 				event.preventDefault();
 				onClick();

--- a/client/lib/form-state/examples/async-initialize.jsx
+++ b/client/lib/form-state/examples/async-initialize.jsx
@@ -9,6 +9,7 @@ import i18n from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import { Button } from '@automattic/components';
 import FormStateStore from '../';
 import createFormStore from '../store';
 
@@ -63,9 +64,9 @@ class AsyncInitialize extends React.Component {
 						disabled={ isFieldDisabled( this.state.form, 'lastName' ) }
 					/>
 
-					<button type="submit" className="button is-primary">
+					<Button type="submit" primary>
 						Submit
-					</button>
+					</Button>
 				</form>
 
 				<pre>{ JSON.stringify( this.state, null, 2 ) }</pre>

--- a/client/lib/form-state/examples/sync-initialize.jsx
+++ b/client/lib/form-state/examples/sync-initialize.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
 import debugModule from 'debug';
 import i18n from 'i18n-calypso';
@@ -9,6 +8,7 @@ import i18n from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import { Button } from '@automattic/components';
 import FormStateStore from '../';
 import createFormStore from '../store';
 
@@ -51,9 +51,9 @@ class SyncInitialize extends React.Component {
 						disabled={ isFieldDisabled( this.state.form, 'lastName' ) }
 					/>
 
-					<button type="submit" className="button is-primary">
+					<Button type="submit" primary>
 						Submit
-					</button>
+					</Button>
 				</form>
 
 				<pre>{ JSON.stringify( this.state, null, 2 ) }</pre>

--- a/client/lib/plugins/README.md
+++ b/client/lib/plugins/README.md
@@ -195,7 +195,7 @@ export default class extends React.Component {
 
 	render() {
 		return (
-			<button onClick={ this.updatePlugin } >Update { this.props.plugin.name }</button>
+			<Button onClick={ this.updatePlugin } >Update { this.props.plugin.name }</Button>
 		)
 	} 
 } );

--- a/client/lib/plugins/wporg-data/README.md
+++ b/client/lib/plugins/wporg-data/README.md
@@ -120,9 +120,9 @@ export class YourComponent extends Component {
 
 	render() {
 		return (
-			<button onClick={ this.updatePlugin }>
+			<Button onClick={ this.updatePlugin }>
 				Update { this.props.plugin.name }
-			</button>
+			</Button>
 		);
 	}
 }

--- a/client/lib/preferences-helper/preference.js
+++ b/client/lib/preferences-helper/preference.js
@@ -9,6 +9,7 @@ import { partial, isArray, isPlainObject } from 'lodash';
 /**
  * Internal dependencies
  */
+import { Button } from '@automattic/components';
 import { savePreference } from 'state/preferences/actions';
 import ArrayPreference from './array-preference';
 import ObjectPreference from './object-preference';
@@ -41,13 +42,13 @@ class Preference extends Component {
 		return (
 			<div>
 				<div className="preferences-helper__preference-header">
-					<button
+					<Button
 						className="preferences-helper__unset"
 						onClick={ partial( unsetPreference, name, null ) }
 						title={ translate( 'Unset Preference' ) }
 					>
 						{ 'X' }
-					</button>
+					</Button>
 					<span>{ name }</span>
 				</div>
 				{ preferenceHandler }

--- a/client/lib/track-form/README.md
+++ b/client/lib/track-form/README.md
@@ -32,7 +32,7 @@ Usage
     return (
       <Form onSubmit={ submit }>
         <FormInput value={ fields.name } onChange={ updateName } />
-        <button onClick={ reset }>Reset</button>
+        <Button onClick={ reset }>Reset</Button>
       </Form>
     );
   }

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -11,6 +11,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import { Button } from '@automattic/components';
 import config, { isEnabled } from 'config';
 import ExternalLink from 'components/external-link';
 import Gridicon from 'components/gridicon';
@@ -174,13 +175,13 @@ export class LoginLinks extends React.Component {
 		}
 
 		return (
-			<button
+			<Button
 				key="lost-phone-link"
 				data-e2e-link="lost-phone-link"
 				onClick={ this.handleLostPhoneLinkClick }
 			>
 				{ this.props.translate( "I can't access my phone" ) }
-			</button>
+			</Button>
 		);
 	}
 

--- a/client/mailing-lists/main.jsx
+++ b/client/mailing-lists/main.jsx
@@ -10,7 +10,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { Card } from '@automattic/components';
+import { Button, Card } from '@automattic/components';
 import notices from 'notices';
 import utils from './utils';
 import { preventWidows } from 'lib/formatting';
@@ -245,29 +245,30 @@ class MainComponent extends React.Component {
 					<h4>{ this.getCategoryName() }</h4>
 					<p>{ this.getCategoryDescription() }</p>
 					{ this.state.isSubscribed ? (
-						<button
-							className="mailing-lists__unsubscribe-button button is-primary"
+						<Button
+							primary
+							className="mailing-lists__unsubscribe-button"
 							onClick={ this.onUnsubscribeClick }
 						>
 							{ translate( 'Unsubscribe' ) }
-						</button>
+						</Button>
 					) : (
-						<button
-							className="mailing-lists__resubscribe-button button"
+						<Button
+							className="mailing-lists__resubscribe-button"
 							onClick={ this.onResubscribeClick }
 						>
 							{ translate( 'Resubscribe' ) }
-						</button>
+						</Button>
 					) }
 				</Card>
 
 				<p className="mailing-lists__manage-link">
-					<button
-						className="mailing-lists__manage-button button is-link"
+					<Button
+						className="mailing-lists__manage-button is-link"
 						onClick={ this.onManageUpdatesClick }
 					>
 						{ translate( 'Manage all your email subscriptions' ) }
-					</button>
+					</Button>
 				</p>
 			</div>
 		);

--- a/client/me/notification-settings/push-notification-settings/index.jsx
+++ b/client/me/notification-settings/push-notification-settings/index.jsx
@@ -653,13 +653,13 @@ class PushNotificationSettings extends React.Component {
 						) }
 					/>
 				</div>
-				<button
+				<Button
 					className="notification-settings-push-notification-settings__instruction-dismiss"
 					onClick={ this.props.toggleUnblockInstructions }
 				>
 					<Gridicon icon="cross" size={ 24 } />
 					<ScreenReaderText>{ this.props.translate( 'Dismiss' ) }</ScreenReaderText>
-				</button>
+				</Button>
 			</Dialog>
 			/* eslint-enable wpcalypso/jsx-classname-namespace */
 		);

--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -10,6 +10,7 @@ import { isEmpty, merge, minBy } from 'lodash';
 /**
  * Internal Dependencies
  */
+import { Button } from '@automattic/components';
 import { recordTracksEvent } from 'state/analytics/actions';
 import config from 'config';
 import {
@@ -387,7 +388,7 @@ class PurchaseNotice extends Component {
 			},
 			components: {
 				link: (
-					<button
+					<Button
 						className="manage-purchase__other-upgrades-button"
 						onClick={ this.openUpcomingRenewalsDialog }
 					/>

--- a/client/me/security-account-recovery/buttons.jsx
+++ b/client/me/security-account-recovery/buttons.jsx
@@ -9,6 +9,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
+import { Button } from '@automattic/components';
 import FormButtonsBar from 'components/forms/form-buttons-bar';
 import FormButton from 'components/forms/form-button';
 import Gridicon from 'components/gridicon';
@@ -37,13 +38,13 @@ class SecurityAccountRecoveryManageContactButtons extends React.Component {
 				</FormButton>
 
 				{ this.props.isDeletable ? (
-					<button
-						className={ 'security-account-recovery-contact__remove' }
+					<Button
+						className="security-account-recovery-contact__remove"
 						onClick={ this.props.onDelete }
 					>
 						<Gridicon icon="trash" size={ 24 } />
 						<span>{ this.props.translate( 'Remove' ) }</span>
-					</button>
+					</Button>
 				) : null }
 			</FormButtonsBar>
 		);

--- a/client/my-sites/activity/activity-log-banner/index.jsx
+++ b/client/my-sites/activity/activity-log-banner/index.jsx
@@ -10,7 +10,7 @@ import { noop } from 'lodash';
 /**
  * Internal dependencies
  */
-import { Card, ScreenReaderText } from '@automattic/components';
+import { Button, Card, ScreenReaderText } from '@automattic/components';
 import Gridicon from 'components/gridicon';
 
 /**
@@ -74,10 +74,10 @@ class ActivityLogBanner extends Component {
 					{ children && <div className="activity-log-banner__body">{ children }</div> }
 				</div>
 				{ isDismissable && (
-					<button className="activity-log-banner__dismiss" onClick={ onDismissClick } type="button">
+					<Button className="activity-log-banner__dismiss" onClick={ onDismissClick } type="button">
 						<ScreenReaderText>{ translate( 'Dismiss' ) }</ScreenReaderText>
 						<Gridicon icon="cross" size={ 24 } />
-					</button>
+					</Button>
 				) }
 			</Card>
 		);

--- a/client/my-sites/checkout/cart/cart-coupon.jsx
+++ b/client/my-sites/checkout/cart/cart-coupon.jsx
@@ -55,9 +55,9 @@ export class CartCoupon extends React.Component {
 						args: { coupon: this.appliedCouponCode },
 					} ) }
 				</span>{ ' ' }
-				<button onClick={ this.clearCoupon } className="button is-link cart__remove-link">
+				<Button onClick={ this.clearCoupon } className="is-link cart__remove-link">
 					{ this.props.translate( 'Remove' ) }
-				</button>
+				</Button>
 			</div>
 		);
 	}
@@ -69,9 +69,9 @@ export class CartCoupon extends React.Component {
 
 		return (
 			<div className="cart__coupon">
-				<button onClick={ this.toggleCouponDetails } className="button is-link cart__toggle-link">
+				<Button onClick={ this.toggleCouponDetails } className="is-link cart__toggle-link">
 					{ this.props.translate( 'Have a coupon code?' ) }
-				</button>
+				</Button>
 
 				{ this.renderCouponForm() }
 			</div>

--- a/client/my-sites/checkout/cart/cart-empty.jsx
+++ b/client/my-sites/checkout/cart/cart-empty.jsx
@@ -7,6 +7,11 @@ import { localize } from 'i18n-calypso';
 import React from 'react';
 import page from 'page';
 
+/**
+ * Internal dependencies
+ */
+import { Button } from '@automattic/components';
+
 class CartEmpty extends React.Component {
 	render() {
 		return (
@@ -15,14 +20,15 @@ class CartEmpty extends React.Component {
 					{ this.props.translate( 'There are no items in your cart.' ) }
 				</div>
 				<div className="cart-empty__buttons cart-buttons">
-					<button
-						className="cart-empty__checkout-button cart-checkout-button button is-primary"
+					<Button
+						primary
+						className="cart-empty__checkout-button cart-checkout-button"
 						onClick={ this.handleClick }
 					>
 						{ this.shouldShowPlanButton()
 							? this.props.translate( 'Add a plan' )
 							: this.props.translate( 'Add a domain' ) }
-					</button>
+					</Button>
 				</div>
 			</div>
 		);

--- a/client/my-sites/checkout/cart/cart-item.jsx
+++ b/client/my-sites/checkout/cart/cart-item.jsx
@@ -9,6 +9,7 @@ import { getCurrencyObject } from '@automattic/format-currency';
 /**
  * Internal dependencies
  */
+import { Button } from '@automattic/components';
 import Gridicon from 'components/gridicon';
 import { withLocalizedMoment } from 'components/localized-moment';
 import { gaRecordEvent } from 'lib/analytics/ga';
@@ -342,14 +343,14 @@ export class CartItem extends React.Component {
 
 		if ( canRemoveFromCart( cart, cartItem ) ) {
 			return (
-				<button
+				<Button
 					className="cart__remove-item"
 					onClick={ this.removeFromCart }
 					aria-label={ labelText }
 					title={ labelText }
 				>
 					<Gridicon icon="trash" size={ 24 } />
-				</button>
+				</Button>
 			);
 		}
 	}

--- a/client/my-sites/checkout/cart/cart-plan-ad-theme.jsx
+++ b/client/my-sites/checkout/cart/cart-plan-ad-theme.jsx
@@ -11,6 +11,7 @@ import page from 'page';
 /**
  * Internal dependencies
  */
+import { Button } from '@automattic/components';
 import CartAd from './cart-ad';
 import { abtest } from 'lib/abtest';
 import { premiumPlan, getAllCartItems } from 'lib/cart-values/cart-items';
@@ -70,9 +71,9 @@ class CartPlanAdTheme extends Component {
 					} }
 				/>
 				Get this theme for FREE when you upgrade to a Premium plan!{ ' ' }
-				<button className={ className } onClick={ this.addToCartAndRedirect }>
+				<Button className={ className } onClick={ this.addToCartAndRedirect }>
 					{ 'Upgrade Now' }
-				</button>
+				</Button>
 			</CartAd>
 		);
 	}

--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -440,9 +440,9 @@ export class CheckoutThankYouHeader extends PureComponent {
 		if ( isSearch ) {
 			return (
 				<div className="checkout-thank-you__header-button">
-					<button className={ headerButtonClassName } onClick={ this.goToCustomizer }>
+					<Button className={ headerButtonClassName } onClick={ this.goToCustomizer }>
 						{ translate( 'Try Search and customize it now' ) }
-					</button>
+					</Button>
 				</div>
 			);
 		}
@@ -460,9 +460,9 @@ export class CheckoutThankYouHeader extends PureComponent {
 		if ( primaryPurchase && isDelayedDomainTransfer( primaryPurchase ) ) {
 			return (
 				<div className="checkout-thank-you__header-button">
-					<button className={ headerButtonClassName } onClick={ this.startTransfer }>
+					<Button className={ headerButtonClassName } onClick={ this.startTransfer }>
 						{ translate( 'Start domain transfer' ) }
-					</button>
+					</Button>
 				</div>
 			);
 		}
@@ -478,9 +478,9 @@ export class CheckoutThankYouHeader extends PureComponent {
 		return (
 			<div className="checkout-thank-you__header-button">
 				{ this.maybeGetSecondaryButton() }
-				<button className={ headerButtonClassName } onClick={ clickHandler }>
+				<Button className={ headerButtonClassName } onClick={ clickHandler }>
 					{ this.getButtonText() }
-				</button>
+				</Button>
 			</div>
 		);
 	}

--- a/client/my-sites/checkout/checkout/new-card-form.jsx
+++ b/client/my-sites/checkout/checkout/new-card-form.jsx
@@ -9,6 +9,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import { Button } from '@automattic/components';
 import CreditCardFormFields from 'components/credit-card-form-fields';
 import { setNewCreditCardDetails } from 'lib/transaction/actions';
 import { INPUT_VALIDATION } from 'lib/store-transactions/step-types';
@@ -46,9 +47,9 @@ class NewCardForm extends Component {
 
 		return (
 			<div className="checkout__new-card">
-				<button type="button" className="checkout__new-card-toggle">
+				<Button type="button" className="checkout__new-card-toggle">
 					{ translate( '+ Use a New Credit/Debit Card' ) }
-				</button>
+				</Button>
 
 				<div className="checkout__new-card-fields">
 					{ hasStoredCards ? (

--- a/client/my-sites/checkout/checkout/payment-request-button.jsx
+++ b/client/my-sites/checkout/checkout/payment-request-button.jsx
@@ -8,6 +8,7 @@ import React, { useState } from 'react';
 /**
  * Internal dependencies
  */
+import { Button } from '@automattic/components';
 import { recordTracksEvent } from 'lib/analytics/tracks';
 
 // The react-stripe-elements PaymentRequestButtonElement cannot have its
@@ -38,37 +39,40 @@ export default function PaymentRequestButton( {
 
 	if ( isSubmitting ) {
 		return (
-			<button
-				className="web-payment-box__web-pay-button button checkout__pay-button-button button is-primary button-pay pay-button__button"
+			<Button
+				primary
+				className="web-payment-box__web-pay-button button checkout__pay-button-button button-pay pay-button__button"
 				disabled
 			>
 				{ translate( 'Completing your purchase', { context: 'Loading state on /checkout' } ) }
-			</button>
+			</Button>
 		);
 	}
 	if ( disabled ) {
 		return (
 			<React.Fragment>
-				<button
-					className="web-payment-box__web-pay-button button checkout__pay-button-button button is-primary button-pay pay-button__button"
+				<Button
+					primary
+					className="web-payment-box__web-pay-button checkout__pay-button-button button-pay pay-button__button"
 					disabled
 				>
 					{ disabledReason }
-				</button>
+				</Button>
 			</React.Fragment>
 		);
 	}
 
 	if ( paymentType === 'apple-pay' ) {
-		return <button className="payment-request-button" onClick={ onClick } />;
+		return <Button className="payment-request-button" onClick={ onClick } />;
 	}
 	return (
-		<button
-			className="web-payment-box__web-pay-button button checkout__pay-button-button button is-primary button-pay pay-button__button"
+		<Button
+			primary
+			className="web-payment-box__web-pay-button checkout__pay-button-button button-pay pay-button__button"
 			onClick={ onClick }
 		>
 			{ translate( 'Select a payment card', { context: 'Loading state on /checkout' } ) }
-		</button>
+		</Button>
 	);
 }
 

--- a/client/my-sites/checkout/checkout/paypal-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/paypal-payment-box.jsx
@@ -9,6 +9,7 @@ import debugFactory from 'debug';
 /**
  * Internal dependencies
  */
+import { Button } from '@automattic/components';
 import Gridicon from 'components/gridicon';
 import { recordTracksEvent } from 'lib/analytics/tracks';
 import { gaRecordEvent } from 'lib/analytics/ga';
@@ -190,9 +191,10 @@ export class PaypalPaymentBox extends React.Component {
 					<div className="checkout__payment-box-actions">
 						<div className="checkout__payment-box-buttons">
 							<span className="checkout__pay-button">
-								<button
+								<Button
+									primary
 									type="submit"
-									className="checkout__pay-button-button button is-primary"
+									className="checkout__pay-button-button"
 									disabled={
 										this.state.formDisabled ||
 										cart.hasPendingServerUpdates ||
@@ -200,7 +202,7 @@ export class PaypalPaymentBox extends React.Component {
 									}
 								>
 									{ this.renderButtonText() }
-								</button>
+								</Button>
 								<SubscriptionText cart={ this.props.cart } />
 							</span>
 

--- a/client/my-sites/checkout/checkout/redirect-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/redirect-payment-box.jsx
@@ -8,6 +8,7 @@ import { snakeCase, map, zipObject, isEmpty, mapValues, overSome, some } from 'l
 /**
  * Internal dependencies
  */
+import { Button } from '@automattic/components';
 import Gridicon from 'components/gridicon';
 import { localize } from 'i18n-calypso';
 import CartCoupon from 'my-sites/checkout/cart/cart-coupon';
@@ -341,15 +342,15 @@ export class RedirectPaymentBox extends PureComponent {
 					<div className="checkout__payment-box-actions">
 						<div className="checkout__payment-box-buttons">
 							<span className="checkout__pay-button">
-								<button
+								<Button
 									type="submit"
-									className="checkout__pay-button-button button is-primary "
+									className="checkout__pay-button-button"
 									disabled={
 										this.state.formDisabled || this.props.incompatibleProducts?.blockCheckout
 									}
 								>
 									{ this.renderButtonText() }
-								</button>
+								</Button>
 								<SubscriptionText cart={ this.props.cart } />
 							</span>
 

--- a/client/my-sites/checkout/composite-checkout/components/upsell.jsx
+++ b/client/my-sites/checkout/composite-checkout/components/upsell.jsx
@@ -3,12 +3,17 @@
  */
 import React from 'react';
 
+/**
+ * Internal dependencies
+ */
+import { Button } from '@automattic/components';
+
 export function UpSellCoupon( { onClick } ) {
 	return (
 		<div>
 			<h4>Exclusive offer</h4>
 			<p>Buy a quick start session and get 50% off.</p>
-			<button onClick={ onClick }>Add to cart</button>
+			<Button onClick={ onClick }>Add to cart</Button>
 		</div>
 	);
 }

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout.js
@@ -27,6 +27,7 @@ import debugFactory from 'debug';
 /**
  * Internal dependencies
  */
+import { Button } from '@automattic/components';
 import { areDomainsInLineItems, isLineItemADomain } from '../hooks/has-domains';
 import useCouponFieldState from '../hooks/use-coupon-field-state';
 import useUpdateCartLocationWhenPaymentMethodChanges from '../hooks/use-update-cart-location-when-payment-method-changes';
@@ -586,7 +587,7 @@ function SubmitButtonHeader() {
 		<SubmitButtonHeaderUI>
 			{ translate( 'By continuing, you agree to our {{button}}Terms of Service{{/button}}.', {
 				components: {
-					button: <button onClick={ scrollToTOS } />,
+					button: <Button onClick={ scrollToTOS } />,
 				},
 			} ) }
 		</SubmitButtonHeaderUI>

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/nav-item.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/nav-item.jsx
@@ -8,6 +8,7 @@ import classnames from 'classnames';
 /**
  * Internal dependencies
  */
+import { Button } from '@automattic/components';
 import Gridicon from 'components/gridicon';
 import { recordTracksEvent } from 'state/analytics/actions';
 
@@ -23,7 +24,7 @@ const NavItem = ( { text, taskId, isCompleted, isCurrent, onClick, useAccordionL
 		);
 
 	return (
-		<button
+		<Button
 			className={ classnames( 'nav-item', {
 				'is-current': isCurrent,
 			} ) }
@@ -50,7 +51,7 @@ const NavItem = ( { text, taskId, isCompleted, isCurrent, onClick, useAccordionL
 					size={ 18 }
 				/>
 			) }
-		</button>
+		</Button>
 	);
 };
 

--- a/client/my-sites/domains/components/domain-warnings/pending-gsuite-tos-notice-dialog.jsx
+++ b/client/my-sites/domains/components/domain-warnings/pending-gsuite-tos-notice-dialog.jsx
@@ -136,9 +136,9 @@ function PendingGSuiteTosNoticeDialog( props ) {
 		<Dialog className="domain-warnings__dialog" isVisible={ props.visible }>
 			<header>
 				<h1>{ translate( 'Log in to G Suite to finish setup' ) }</h1>
-				<button onClick={ onCloseClick }>
+				<Button onClick={ onCloseClick }>
 					<Gridicon icon="cross" />
-				</button>
+				</Button>
 			</header>
 
 			<p>{ password ? renderPasswordResetCopy() : renderEntryCopy() }</p>

--- a/client/my-sites/marketing/buttons/appearance.jsx
+++ b/client/my-sites/marketing/buttons/appearance.jsx
@@ -11,6 +11,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import { Button } from '@automattic/components';
 import ButtonsPreview from './preview';
 import ButtonsPreviewPlaceholder from './preview-placeholder';
 import ButtonsStyle from './style';
@@ -185,15 +186,16 @@ class SharingButtonsAppearance extends Component {
 					{ this.getReblogLikeOptionsElement() }
 				</div>
 
-				<button
+				<Button
+					primary
 					type="submit"
-					className="button is-primary sharing-buttons__submit"
+					className="sharing-buttons__submit"
 					disabled={ this.props.saving || ! this.props.initialized }
 				>
 					{ this.props.saving
 						? this.props.translate( 'Saving…' )
 						: this.props.translate( 'Save changes' ) }
-				</button>
+				</Button>
 			</div>
 		);
 		/* eslint-enable wpcalypso/jsx-classname-namespace */

--- a/client/my-sites/marketing/buttons/label-editor.jsx
+++ b/client/my-sites/marketing/buttons/label-editor.jsx
@@ -10,6 +10,7 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
+import { Button } from '@automattic/components';
 import { decodeEntities } from 'lib/formatting';
 
 const closeKeyCodes = [
@@ -92,9 +93,9 @@ class SharingButtonsLabelEditor extends React.Component {
 					{ this.getNoButtonsNoticeElement() }
 				</div>
 				<footer className="sharing-buttons-preview__panel-actions">
-					<button type="button" className="button" onClick={ this.props.onClose }>
+					<Button type="button" onClick={ this.props.onClose }>
 						{ this.props.translate( 'Close' ) }
-					</button>
+					</Button>
 				</footer>
 			</div>
 		);

--- a/client/my-sites/marketing/buttons/options.jsx
+++ b/client/my-sites/marketing/buttons/options.jsx
@@ -11,6 +11,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import { Button } from '@automattic/components';
 import MultiCheckbox from 'components/forms/multi-checkbox';
 import SupportInfo from 'components/support-info';
 import { getPostTypes } from 'state/post-types/selectors';
@@ -259,13 +260,13 @@ class SharingButtonsOptions extends Component {
 						{ this.getTwitterViaOptionElement() }
 					</div>
 
-					<button
+					<Button
 						type="submit"
-						className="button sharing-buttons__submit"
+						className="sharing-buttons__submit"
 						disabled={ saving || ! initialized }
 					>
 						{ saving ? translate( 'Saving…' ) : translate( 'Save changes' ) }
-					</button>
+					</Button>
 				</div>
 			</Fragment>
 		);

--- a/client/my-sites/marketing/buttons/preview-action.jsx
+++ b/client/my-sites/marketing/buttons/preview-action.jsx
@@ -10,6 +10,7 @@ import { omit, startsWith, endsWith } from 'lodash';
 /**
  * Internal dependencies
  */
+import { Button } from '@automattic/components';
 import Gridicon from 'components/gridicon';
 
 const SharingButtonsPreviewAction = ( props ) => {
@@ -23,14 +24,14 @@ const SharingButtonsPreviewAction = ( props ) => {
 	} );
 
 	return (
-		<button
+		<Button
 			type="button"
 			className={ classes }
 			{ ...omit( props, [ 'active', 'position', 'icon' ] ) }
 		>
 			{ icon && <Gridicon icon={ icon } size={ 18 } /> }
 			{ children }
-		</button>
+		</Button>
 	);
 };
 

--- a/client/my-sites/marketing/buttons/tray.jsx
+++ b/client/my-sites/marketing/buttons/tray.jsx
@@ -11,6 +11,7 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
+import { Button } from '@automattic/components';
 import SortableList from 'components/forms/sortable-list';
 import ButtonsPreviewButtons from './preview-buttons';
 import ButtonsPreviewButton from './preview-button';
@@ -214,23 +215,23 @@ class SharingButtonsTray extends React.Component {
 					{ this.getLimitedButtonsNoticeElement() }
 				</div>
 				<footer className="sharing-buttons-preview__panel-actions">
-					<button
+					<Button
 						type="button"
-						className="button sharing-buttons-preview__panel-action is-left"
+						className="sharing-buttons-preview__panel-action is-left"
 						onClick={ this.toggleReorder }
 						disabled={ this.getButtonsOfCurrentVisibility().length <= 1 }
 					>
 						{ this.state.isReordering
 							? this.props.translate( 'Add / Remove' )
 							: this.props.translate( 'Reorder' ) }
-					</button>
-					<button
+					</Button>
+					<Button
 						type="button"
-						className="button sharing-buttons-preview__panel-action"
+						className="sharing-buttons-preview__panel-action"
 						onClick={ this.props.onClose }
 					>
 						{ this.props.translate( 'Close' ) }
-					</button>
+					</Button>
 				</footer>
 			</div>
 		);

--- a/client/my-sites/media-library/list-item.tsx
+++ b/client/my-sites/media-library/list-item.tsx
@@ -8,6 +8,7 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
+import { Button } from '@automattic/components';
 import Spinner from 'components/spinner';
 import Gridicon from 'components/gridicon';
 import ListItemImage from './list-item-image';
@@ -132,7 +133,7 @@ export default class MediaLibraryListItem extends React.Component< Props & DivPr
 		}
 
 		return (
-			<button
+			<Button
 				className={ classes }
 				style={ styleWithDefaults }
 				onClick={ this.clickItem }
@@ -151,7 +152,7 @@ export default class MediaLibraryListItem extends React.Component< Props & DivPr
 					) }
 					{ showGalleryHelp && <EditorMediaModalGalleryHelp /> }
 				</figure>
-			</button>
+			</Button>
 		);
 	}
 }

--- a/client/my-sites/media-library/upload-url.jsx
+++ b/client/my-sites/media-library/upload-url.jsx
@@ -15,7 +15,7 @@ import { localize } from 'i18n-calypso';
  */
 import { bumpStat } from 'lib/analytics/mc';
 import FormTextInput from 'components/forms/form-text-input';
-import { ScreenReaderText } from '@automattic/components';
+import { Button, ScreenReaderText } from '@automattic/components';
 import { clearMediaItemErrors } from 'state/media/actions';
 import { addMedia } from 'state/media/thunks';
 
@@ -101,14 +101,14 @@ class MediaLibraryUploadUrl extends Component {
 
 				<div className="media-library__upload-url-button-group">
 					{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
-					<button type="submit" className="button is-primary">
+					<Button type="submit" primary>
 						{ translate( 'Upload', { context: 'verb' } ) }
-					</button>
+					</Button>
 
-					<button type="button" className="media-library__upload-url-cancel" onClick={ onClose }>
+					<Button type="button" className="media-library__upload-url-cancel" onClick={ onClose }>
 						<ScreenReaderText>{ translate( 'Cancel' ) }</ScreenReaderText>
 						<Gridicon icon="cross" />
-					</button>
+					</Button>
 				</div>
 			</form>
 		);

--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -587,9 +587,9 @@ class InvitePeople extends React.Component {
 					</span>
 					<span>
 						(
-						<button className="invite-people__link-disable" onClick={ this.disableInviteLinks }>
+						<Button className="invite-people__link-disable" onClick={ this.disableInviteLinks }>
 							{ translate( 'Disable invite link' ) }
-						</button>
+						</Button>
 						)
 					</span>
 				</div>

--- a/client/my-sites/plans-features-main/gutenboarding-header/index.jsx
+++ b/client/my-sites/plans-features-main/gutenboarding-header/index.jsx
@@ -8,6 +8,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import { Button } from '@automattic/components';
 import FormattedHeader from 'components/formatted-header';
 
 /**
@@ -24,9 +25,9 @@ const GutenboardingHeader = ( { headerText, subHeaderText, onFreePlanSelect, tra
 				isSecondary
 				align="left"
 			/>
-			<button className="gutenboarding-header__select-free-plan" onClick={ onFreePlanSelect }>
+			<Button className="gutenboarding-header__select-free-plan" onClick={ onFreePlanSelect }>
 				{ translate( 'Start with a free plan' ) }
-			</button>
+			</Button>
 		</div>
 	);
 };

--- a/client/my-sites/plugins/plugin-list-header/index.jsx
+++ b/client/my-sites/plugins/plugin-list-header/index.jsx
@@ -241,14 +241,14 @@ export class PluginsListHeader extends PureComponent {
 			);
 
 			rightSideButtons.push(
-				<button
+				<Button
 					key="plugin-list-header__buttons-close-button"
 					className="plugin-list-header__section-actions-close"
 					onClick={ this.props.toggleBulkManagement }
 					aria-label={ translate( 'Close' ) }
 				>
 					<Gridicon icon="cross" />
-				</button>
+				</Button>
 			);
 		}
 

--- a/client/my-sites/plugins/plugin-sections/index.jsx
+++ b/client/my-sites/plugins/plugin-sections/index.jsx
@@ -12,7 +12,7 @@ import classNames from 'classnames';
  */
 import Gridicon from 'components/gridicon';
 import { gaRecordEvent } from 'lib/analytics/ga';
-import { Card } from '@automattic/components';
+import { Button, Card } from '@automattic/components';
 import SectionNav from 'components/section-nav';
 import NavTabs from 'components/section-nav/tabs';
 import NavItem from 'components/section-nav/item';
@@ -155,12 +155,12 @@ class PluginSections extends React.Component {
 			return null;
 		}
 		const button = (
-			<button className="plugin-sections__read-more-link" onClick={ this.toggleReadMore }>
+			<Button className="plugin-sections__read-more-link" onClick={ this.toggleReadMore }>
 				<span className="plugin-sections__read-more-text">
 					{ this.props.translate( 'Read More' ) }
 				</span>
 				<Gridicon icon="chevron-down" size={ 18 } />
-			</button>
+			</Button>
 		);
 		return (
 			<div className="plugin-sections__read-more">

--- a/client/my-sites/plugins/plugin-site-update-indicator/index.jsx
+++ b/client/my-sites/plugins/plugin-site-update-indicator/index.jsx
@@ -8,6 +8,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
+import { Button } from '@automattic/components';
 import { recordTracksEvent } from 'lib/analytics/tracks';
 import { gaRecordEvent } from 'lib/analytics/ga';
 import Gridicon from 'components/gridicon';
@@ -76,14 +77,9 @@ class PluginSiteUpdateIndicator extends React.Component {
 		}
 		return (
 			<div className="plugin-site-update-indicator__button">
-				<button
-					className="button"
-					ref="updatePlugin"
-					onClick={ this.updatePlugin }
-					disabled={ isUpdating }
-				>
+				<Button ref="updatePlugin" onClick={ this.updatePlugin } disabled={ isUpdating }>
 					{ message }
-				</button>
+				</Button>
 			</div>
 		);
 	};

--- a/client/my-sites/site-indicator/index.jsx
+++ b/client/my-sites/site-indicator/index.jsx
@@ -258,21 +258,21 @@ class SiteIndicator extends Component {
 			<div className={ indicatorClass }>
 				{ ! this.state.expand && (
 					<Animate type="appear">
-						<button className="site-indicator__button" onClick={ this.toggleExpand }>
+						<Button className="site-indicator__button" onClick={ this.toggleExpand }>
 							{ /* eslint-disable wpcalypso/jsx-gridicon-size */ }
 							<Gridicon icon={ this.getIcon() } size={ 16 } />
 							{ /* eslint-enable wpcalypso/jsx-gridicon-size */ }
-						</button>
+						</Button>
 					</Animate>
 				) }
 				{ this.state.expand && (
 					<div className="site-indicator__message">
 						<div className="site-indicator__action">{ this.getText() }</div>
-						<button className="site-indicator__button" onClick={ this.toggleExpand }>
+						<Button className="site-indicator__button" onClick={ this.toggleExpand }>
 							<Animate type="appear">
 								<Gridicon icon="cross" size={ 18 } />
 							</Animate>
-						</button>
+						</Button>
 					</div>
 				) }
 			</div>

--- a/client/my-sites/site-settings/podcast-cover-image-setting/index.jsx
+++ b/client/my-sites/site-settings/podcast-cover-image-setting/index.jsx
@@ -199,7 +199,7 @@ class PodcastCoverImageSetting extends PureComponent {
 		} );
 
 		return (
-			<button
+			<Button
 				className={ classNames }
 				onClick={ this.showModal }
 				onMouseEnter={ this.preloadModal }
@@ -214,7 +214,7 @@ class PodcastCoverImageSetting extends PureComponent {
 					</span>
 				) }
 				{ isTransient && <Spinner /> }
-			</button>
+			</Button>
 		);
 	}
 

--- a/client/my-sites/site-settings/theme-setup/theme-setup-placeholder.jsx
+++ b/client/my-sites/site-settings/theme-setup/theme-setup-placeholder.jsx
@@ -7,6 +7,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
+import { Button } from '@automattic/components';
 
 const ThemeSetupPlaceholder = () => {
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
@@ -30,9 +31,7 @@ const ThemeSetupPlaceholder = () => {
 				</p>
 			</div>
 			<div className="action-panel__footer">
-				<button className="button theme-setup__button is-placeholder">
-					Set Up And Keep Content
-				</button>
+				<Button className="theme-setup__button is-placeholder">Set Up And Keep Content</Button>
 			</div>
 		</div>
 	);

--- a/client/my-sites/stats/stats-list/stats-list-item.jsx
+++ b/client/my-sites/stats/stats-list/stats-list-item.jsx
@@ -12,6 +12,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import { Button } from '@automattic/components';
 import { gaRecordEvent } from 'lib/analytics/ga';
 import Emojify from 'components/emojify';
 import { withLocalizedMoment } from 'components/localized-moment';
@@ -337,7 +338,7 @@ class StatsListItem extends React.Component {
 
 		if ( actions ) {
 			mobileActionToggle = (
-				<button
+				<Button
 					onClick={ this.actionMenuClick }
 					className={ classNames( toggleOptions ) }
 					title={ this.props.translate( 'Show Actions', {
@@ -345,7 +346,7 @@ class StatsListItem extends React.Component {
 					} ) }
 				>
 					<Gridicon icon="ellipsis" />
-				</button>
+				</Button>
 			);
 			rightClassOptions[ 'is-expanded' ] = this.state.actionMenuOpen;
 		}

--- a/client/post-editor/editor-drawer-well/index.jsx
+++ b/client/post-editor/editor-drawer-well/index.jsx
@@ -9,6 +9,11 @@ import { noop } from 'lodash';
 import Gridicon from 'components/gridicon';
 
 /**
+ * Internal dependencies
+ */
+import { Button } from '@automattic/components';
+
+/**
  * Style dependencies
  */
 import './style.scss';
@@ -41,7 +46,7 @@ export default class EditorDrawerWell extends Component {
 			<div className={ classes }>
 				<div className="editor-drawer-well__content">{ children }</div>
 				{ empty && (
-					<button
+					<Button
 						type="button"
 						onClick={ onClick }
 						disabled={ disabled }
@@ -49,7 +54,7 @@ export default class EditorDrawerWell extends Component {
 					>
 						{ icon && <Gridicon icon={ icon } className="editor-drawer-well__icon" /> }
 						<span className="editor-drawer-well__button button is-compact">{ label }</span>
-					</button>
+					</Button>
 				) }
 				{ this.props.customDropZone }
 			</div>

--- a/client/post-editor/editor-ground-control/history-button.jsx
+++ b/client/post-editor/editor-ground-control/history-button.jsx
@@ -9,17 +9,15 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import { Button } from '@automattic/components';
 import { openPostRevisionsDialog } from 'state/posts/revisions/actions';
 import { withAnalytics, recordTracksEvent } from 'state/analytics/actions';
 
 const HistoryButton = ( { translate, selectHistory } ) => (
 	<div className="editor-ground-control__history">
-		<button
-			className="editor-ground-control__history-button button is-link"
-			onClick={ selectHistory }
-		>
+		<Button className="editor-ground-control__history-button is-link" onClick={ selectHistory }>
 			{ translate( 'History' ) }
-		</button>
+		</Button>
 	</div>
 );
 

--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -183,7 +183,7 @@ export class EditorGroundControl extends React.Component {
 				/>
 				<Drafts />
 				{ userNeedsVerification && (
-					<button
+					<Button
 						className="editor-ground-control__email-verification-notice"
 						onClick={ this.props.onMoreInfoAboutEmailVerify }
 					>
@@ -195,7 +195,7 @@ export class EditorGroundControl extends React.Component {
 						<span className="editor-ground-control__email-verification-notice-more">
 							{ translate( 'Learn More' ) }
 						</span>
-					</button>
+					</Button>
 				) }
 				<QuickSaveButtons
 					isSaving={ isSaving }

--- a/client/post-editor/editor-ground-control/quick-save-buttons.jsx
+++ b/client/post-editor/editor-ground-control/quick-save-buttons.jsx
@@ -10,6 +10,7 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
+import { Button } from '@automattic/components';
 import { isPage, isPublished } from 'state/posts/utils';
 import HistoryButton from 'post-editor/editor-ground-control/history-button';
 import { recordEditorEvent, recordEditorStat } from 'state/posts/stats';
@@ -64,13 +65,13 @@ const QuickSaveButtons = ( {
 			{ showingSaveStatus && (
 				<div className="editor-ground-control__status">
 					{ isSaveAvailable && (
-						<button
-							className="editor-ground-control__save button is-link"
+						<Button
+							className="editor-ground-control__save is-link"
 							onClick={ onSaveButtonClick }
 							tabIndex={ 3 }
 						>
 							{ translate( 'Save' ) }
-						</button>
+						</Button>
 					) }
 					{ ! isSaveAvailable && showingStatusLabel && (
 						<span

--- a/client/post-editor/editor-gutenberg-opt-in-dialog/index.jsx
+++ b/client/post-editor/editor-gutenberg-opt-in-dialog/index.jsx
@@ -90,12 +90,12 @@ class EditorGutenbergOptInDialog extends Component {
 				<div className="editor-gutenberg-opt-in-dialog__illustration" />
 
 				<header>
-					<button
+					<Button
 						onClick={ this.useClassicEditor }
 						className="editor-gutenberg-opt-in-dialog__close"
 					>
 						<Gridicon icon="cross" />
-					</button>
+					</Button>
 				</header>
 
 				<h1>{ translate( 'Check out the new building blocks of the web' ) }</h1>

--- a/client/post-editor/editor-html-toolbar/index.jsx
+++ b/client/post-editor/editor-html-toolbar/index.jsx
@@ -513,49 +513,49 @@ export class EditorHtmlToolbar extends Component {
 
 		return (
 			<div className={ insertContentClasses }>
-				<button
+				<Button
 					className="editor-html-toolbar__insert-content-dropdown-item"
 					onClick={ this.openMediaModal }
 				>
 					<Gridicon icon="image" />
 					<span data-e2e-insert-type="media">{ translate( 'Media library' ) }</span>
-				</button>
+				</Button>
 
 				{ config.isEnabled( 'external-media/google-photos' ) && canUserUploadFiles && (
-					<button
+					<Button
 						className="editor-html-toolbar__insert-content-dropdown-item"
 						onClick={ this.openGoogleModal }
 					>
 						<Gridicon icon="shutter" />
 						<span data-e2e-insert-type="google-media">{ translate( 'Google Photos' ) }</span>
-					</button>
+					</Button>
 				) }
 
 				{ config.isEnabled( 'external-media/free-photo-library' ) && canUserUploadFiles && (
-					<button
+					<Button
 						className="editor-html-toolbar__insert-content-dropdown-item"
 						onClick={ this.openPexelsModal }
 					>
 						<Gridicon icon="image-multiple" />
 						<span data-e2e-insert-type="pexels">{ translate( 'Pexels free photos' ) }</span>
-					</button>
+					</Button>
 				) }
 
-				<button
+				<Button
 					className="editor-html-toolbar__insert-content-dropdown-item"
 					onClick={ this.openContactFormDialog }
 				>
 					<Gridicon icon="mention" />
 					<span data-e2e-insert-type="contact-form">{ translate( 'Contact form' ) }</span>
-				</button>
+				</Button>
 
-				<button
+				<Button
 					className="editor-html-toolbar__insert-content-dropdown-item"
 					onClick={ this.openSimplePaymentsDialog }
 				>
 					<Gridicon icon="money" />
 					<span data-e2e-insert-type="payment-button">{ translate( 'Payment button' ) }</span>
-				</button>
+				</Button>
 			</div>
 		);
 	};

--- a/client/post-editor/editor-revisions-list/item.jsx
+++ b/client/post-editor/editor-revisions-list/item.jsx
@@ -11,6 +11,7 @@ import { flow, get } from 'lodash';
 /**
  * Internal dependencies
  */
+import { Button } from '@automattic/components';
 import { selectPostRevision } from 'state/posts/revisions/actions';
 import { getPostRevisionAuthor } from 'state/posts/revisions/authors/selectors';
 import { isSingleUserSite } from 'state/sites/selectors';
@@ -41,7 +42,7 @@ class EditorRevisionsListItem extends PureComponent {
 		};
 
 		return (
-			<button
+			<Button
 				className="editor-revisions-list__button"
 				onClick={ this.selectRevision }
 				type="button"
@@ -83,7 +84,7 @@ class EditorRevisionsListItem extends PureComponent {
 						</span>
 					) }
 				</div>
-			</button>
+			</Button>
 		);
 	}
 }

--- a/client/post-editor/editor-status-label/placeholder.jsx
+++ b/client/post-editor/editor-status-label/placeholder.jsx
@@ -10,6 +10,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import { Button } from '@automattic/components';
 import { getEditedPost } from 'state/posts/selectors';
 import { getPostType } from 'state/post-types/selectors';
 import { getEditorPostId } from 'state/editor/selectors';
@@ -36,12 +37,12 @@ function EditorStatusLabelPlaceholder( { translate, siteId, typeSlug, type, clas
 	}
 
 	return (
-		<button className={ classes }>
+		<Button className={ classes }>
 			{ 'post' !== typeSlug && 'page' !== typeSlug && siteId && (
 				<QueryPostTypes siteId={ siteId } />
 			) }
 			<strong>{ label }</strong>
-		</button>
+		</Button>
 	);
 }
 

--- a/client/post-editor/media-modal/detail/detail-item.jsx
+++ b/client/post-editor/media-modal/detail/detail-item.jsx
@@ -228,10 +228,10 @@ export class EditorMediaModalDetailItem extends Component {
 		}
 
 		return (
-			<button onClick={ onShowPreviousItem } className="editor-media-modal-detail__previous">
+			<Button onClick={ onShowPreviousItem } className="editor-media-modal-detail__previous">
 				<Gridicon icon="chevron-left" size={ 36 } />
 				<ScreenReaderText>{ translate( 'Previous' ) }</ScreenReaderText>
-			</button>
+			</Button>
 		);
 	}
 
@@ -243,10 +243,10 @@ export class EditorMediaModalDetailItem extends Component {
 		}
 
 		return (
-			<button onClick={ onShowNextItem } className="editor-media-modal-detail__next">
+			<Button onClick={ onShowNextItem } className="editor-media-modal-detail__next">
 				<Gridicon icon="chevron-right" size={ 36 } />
 				<ScreenReaderText>{ translate( 'Next' ) }</ScreenReaderText>
-			</button>
+			</Button>
 		);
 	}
 

--- a/client/post-editor/media-modal/gallery/remove-button.jsx
+++ b/client/post-editor/media-modal/gallery/remove-button.jsx
@@ -11,7 +11,7 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import { ScreenReaderText } from '@automattic/components';
+import { Button, ScreenReaderText } from '@automattic/components';
 import getMediaLibrarySelectedItems from 'state/selectors/get-media-library-selected-items';
 import { setMediaLibrarySelectedItems } from 'state/media/actions';
 
@@ -38,14 +38,14 @@ class RemoveButton extends PureComponent {
 		const { translate } = this.props;
 
 		return (
-			<button
+			<Button
 				onClick={ this.remove }
 				onMouseDown={ ( event ) => event.stopPropagation() }
 				className="editor-media-modal-gallery__remove"
 			>
 				<ScreenReaderText>{ translate( 'Remove' ) }</ScreenReaderText>
 				<Gridicon icon="cross" />
-			</button>
+			</Button>
 		);
 	}
 }

--- a/client/reader/conversations/intro.jsx
+++ b/client/reader/conversations/intro.jsx
@@ -10,6 +10,7 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
+import { Button } from '@automattic/components';
 import QueryPreferences from 'components/data/query-preferences';
 import { savePreference } from 'state/preferences/actions';
 import { getPreference } from 'state/preferences/selectors';
@@ -102,7 +103,7 @@ class ConversationsIntro extends React.Component {
 					</div>
 					<img className="conversations__intro-character" src={ charactersImage } alt="" />
 
-					<button
+					<Button
 						className="conversations__intro-close"
 						onClick={ this.dismiss }
 						title={ translate( 'Close' ) }
@@ -113,7 +114,7 @@ class ConversationsIntro extends React.Component {
 							className="conversations__intro-close-icon"
 							title={ translate( 'Close' ) }
 						/>
-					</button>
+					</Button>
 				</div>
 			</header>
 		);

--- a/client/reader/following/intro.jsx
+++ b/client/reader/following/intro.jsx
@@ -10,6 +10,7 @@ import { bindActionCreators } from 'redux';
 /**
  * Internal dependencies
  */
+import { Button } from '@automattic/components';
 import QueryPreferences from 'components/data/query-preferences';
 import { savePreference } from 'state/preferences/actions';
 import { getPreference } from 'state/preferences/selectors';
@@ -75,7 +76,7 @@ class FollowingIntro extends React.Component {
 					</div>
 					<img className="following__intro-character" src={ readerImage } alt="" />
 
-					<button
+					<Button
 						className="following__intro-close"
 						onClick={ dismiss }
 						title={ translate( 'Close' ) }
@@ -87,7 +88,7 @@ class FollowingIntro extends React.Component {
 							title={ translate( 'Close' ) }
 						/>
 						<span className="following__intro-close-icon-bg" />
-					</button>
+					</Button>
 				</div>
 			</header>
 		);

--- a/client/reader/list-gap/index.jsx
+++ b/client/reader/list-gap/index.jsx
@@ -10,6 +10,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal Dependencies
  */
+import { Button } from '@automattic/components';
 import { fillGap } from 'state/reader/streams/actions';
 import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
 
@@ -48,13 +49,9 @@ class Gap extends React.Component {
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
 			<div className={ classes }>
-				<button
-					type="button"
-					className="button reader-list-gap__button"
-					onClick={ this.handleClick }
-				>
+				<Button type="button" className="reader-list-gap__button" onClick={ this.handleClick }>
 					{ translate( 'Load More Posts' ) }
-				</button>
+				</Button>
 			</div>
 		);
 		/* eslint-enable wpcalypso/jsx-classname-namespace */

--- a/client/reader/site-blocked/index.jsx
+++ b/client/reader/site-blocked/index.jsx
@@ -9,6 +9,7 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
+import { Button } from '@automattic/components';
 import ReaderMain from 'reader/components/reader-main';
 import MobileBackToSidebar from 'components/mobile-back-to-sidebar';
 import EmptyContent from 'components/empty-content';
@@ -35,9 +36,9 @@ class SiteBlocked extends React.Component {
 
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		const action = (
-			<button className="empty-content__action button is-primary" onClick={ this.unblockSite }>
+			<Button primary className="empty-content__action" onClick={ this.unblockSite }>
 				{ this.props.translate( 'Unblock' ) }
-			</button>
+			</Button>
 		);
 		/* eslint-enable wpcalypso/jsx-classname-namespace */
 

--- a/client/reader/update-notice/index.jsx
+++ b/client/reader/update-notice/index.jsx
@@ -12,6 +12,7 @@ import Gridicon from 'components/gridicon';
 /**
  * Internal dependencies
  */
+import { Button } from '@automattic/components';
 import DocumentHead from 'components/data/document-head';
 import { getDocumentHeadCappedUnreadCount } from 'state/document-head/selectors/get-document-head-capped-unread-count';
 import { getCommentById } from 'state/comments/selectors';
@@ -40,7 +41,7 @@ class UpdateNotice extends React.PureComponent {
 		} );
 
 		return (
-			<button className={ counterClasses } onClick={ this.handleClick }>
+			<Button className={ counterClasses } onClick={ this.handleClick }>
 				<DocumentHead unreadCount={ count } />
 				<Gridicon icon="arrow-up" size={ 18 } />
 				{ translate( '%s new post', '%s new posts', {
@@ -48,7 +49,7 @@ class UpdateNotice extends React.PureComponent {
 					count,
 					comment: '%s is the number of new posts. For example: "1" or "40+"',
 				} ) }
-			</button>
+			</Button>
 		);
 	}
 

--- a/client/signup/README.md
+++ b/client/signup/README.md
@@ -164,7 +164,7 @@ render() {
 	return (
 		<form onSubmit={ this.handleSubmit }>
 			<p>This is the step named { this.props.stepName }</p>
-			<button className="button" type="submit">Get started</button>
+			<Button type="submit">Get started</Button>
 		</form>
 	);
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Stop using the `button` element and use the `Button` component instead.

Note: This PR will get broken up into much smaller PRs

#### Testing instructions

* [TODO]

Related to https://github.com/Automattic/wp-calypso/issues/45259
