### PR TITLE
Remove domains, and emails, from plans navigation

### DIFF
--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -16,8 +16,8 @@ import EmptyContent from 'components/empty-content';
 import { DOMAINS_WITH_PLANS_ONLY } from 'state/current-user/constants';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import RegisterDomainStep from 'components/domains/register-domain-step';
-import PlansNavigation from 'my-sites/plans/navigation';
 import Main from 'components/main';
+import FormattedHeader from 'components/formatted-header';
 import { addItem, removeItem } from 'lib/cart/actions';
 import { canDomainAddGSuite } from 'lib/gsuite';
 import {
@@ -155,7 +155,7 @@ class DomainSearch extends Component {
 	}
 
 	render() {
-		const { selectedSite, selectedSiteSlug, translate } = this.props;
+		const { selectedSite, selectedSiteSlug, translate, isManagingAllDomains } = this.props;
 		const classes = classnames( 'main-column', {
 			'domain-search-page-wrapper': this.state.domainRegistrationAvailable,
 		} );
@@ -188,7 +188,13 @@ class DomainSearch extends Component {
 			content = (
 				<span>
 					<div className="domain-search__content">
-						<PlansNavigation cart={ this.props.cart } path={ this.props.context.path } />
+						<FormattedHeader
+							brandFont
+							headerText={
+								isManagingAllDomains ? translate( 'All Domains' ) : translate( 'Site Domains' )
+							}
+							align="left"
+						/>
 
 						<EmailVerificationGate
 							noticeText={ translate( 'You must verify your email to register new domains.' ) }

--- a/client/my-sites/plans/navigation.jsx
+++ b/client/my-sites/plans/navigation.jsx
@@ -5,7 +5,6 @@ import { isMobile } from '@automattic/viewport';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import { get } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -17,7 +16,6 @@ import SectionNav from 'components/section-nav';
 import NavTabs from 'components/section-nav/tabs';
 import NavItem from 'components/section-nav/item';
 import PopoverCart from 'my-sites/checkout/cart/popover-cart';
-import { isATEnabled } from 'lib/automated-transfer';
 import isSiteOnFreePlan from 'state/selectors/is-site-on-free-plan';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSite, isJetpackSite } from 'state/sites/selectors';
@@ -45,24 +43,15 @@ class PlansNavigation extends React.Component {
 			case '/plans/yearly':
 				return 'Plans';
 
-			case '/domains/manage':
-			case '/domains/add':
-				return 'Domains';
-
-			case '/email':
-				return 'Email';
-
 			default:
 				return path.split( '?' )[ 0 ].replace( /\//g, ' ' );
 		}
 	}
 
 	render() {
-		const { isJetpack, site, shouldShowMyPlan, translate } = this.props;
+		const { site, shouldShowMyPlan, translate } = this.props;
 		const path = sectionify( this.props.path );
 		const sectionTitle = this.getSectionTitle( path );
-		const userCanManageOptions = get( site, 'capabilities.manage_options', false );
-		const canManageDomain = userCanManageOptions && ( isATEnabled( site ) || ! isJetpack );
 		const cartToggleButton = this.cartToggleButton();
 		const hasPinnedItems = isMobile() && cartToggleButton != null;
 
@@ -90,19 +79,6 @@ class PlansNavigation extends React.Component {
 						>
 							{ translate( 'Plans' ) }
 						</NavItem>
-						{ canManageDomain && (
-							<NavItem
-								path={ `/domains/manage/${ site.slug }` }
-								selected={ path === '/domains/manage' || path === '/domains/add' }
-							>
-								{ translate( 'Domains' ) }
-							</NavItem>
-						) }
-						{ canManageDomain && (
-							<NavItem path={ `/email/${ site.slug }` } selected={ path === '/email' }>
-								{ translate( 'Email' ) }
-							</NavItem>
-						) }
 					</NavTabs>
 					{ cartToggleButton }
 				</SectionNav>


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This PR removes domains and emails from the plans navigation. 

**Before**
![image](https://user-images.githubusercontent.com/6981253/91518055-48703e80-e8bd-11ea-84a8-f03384068663.png)

![image](https://user-images.githubusercontent.com/6981253/91518080-558d2d80-e8bd-11ea-8c07-530a8f112c12.png)


**After**
![image](https://user-images.githubusercontent.com/6981253/91517956-14951900-e8bd-11ea-9896-600a04567301.png)

![image](https://user-images.githubusercontent.com/6981253/91517982-1f4fae00-e8bd-11ea-8b17-91f982583b3d.png)

#### Testing instructions

* Visit your plans and domians screens to make sure the domains and email menu items don't appear in the navigation.
* Preform a domain search and confirm that the plans navigation does not show.

