### PR TITLE
Add aria label to WP-icon button to indicate that it opens sidebar.

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
@@ -63,12 +63,6 @@ function WpcomBlockEditorNavSidebar() {
 		prevIsOpen.current = isOpen;
 	}, [ isOpen, prevIsOpen, setSidebarClosing ] );
 
-	const containerMount = ( el: HTMLDivElement | null ) => {
-		if ( el ) {
-			el.focus();
-		}
-	};
-
 	if ( ! postType ) {
 		// Still loading
 		return null;
@@ -162,7 +156,6 @@ function WpcomBlockEditorNavSidebar() {
 				className={ classNames( 'wpcom-block-editor-nav-sidebar-nav-sidebar__container', {
 					'is-sliding-left': isClosing,
 				} ) }
-				ref={ containerMount }
 				role="dialog"
 				tabIndex={ -1 }
 			>

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
@@ -27,11 +27,10 @@ import NavItem from '../nav-item';
 import { Post } from '../../types';
 import './style.scss';
 
-const Button = ( {
-	children,
-	...rest
-}: OriginalButton.Props & { icon?: any; iconSize?: number } ) => (
-	<OriginalButton { ...rest }>{ children }</OriginalButton>
+const Button = forwardRef(
+	( { children, ...rest }: OriginalButton.Props & { icon?: any; iconSize?: number } ) => (
+		<OriginalButton { ...rest }>{ children }</OriginalButton>
+	)
 );
 
 function WpcomBlockEditorNavSidebar() {
@@ -51,6 +50,7 @@ function WpcomBlockEditorNavSidebar() {
 	const { current: currentPost, drafts: draftPosts, recent: recentPosts } = useNavItems();
 	const statusLabels = usePostStatusLabels();
 	const prevIsOpen = useRef( isOpen );
+	const closeButtonRef = useRef();
 
 	// Using layout effect to prevent a brief moment in time where both `isOpen` and `isClosing`
 	// are both false, causing a flicker during the fade out animation.
@@ -61,6 +61,10 @@ function WpcomBlockEditorNavSidebar() {
 		}
 
 		prevIsOpen.current = isOpen;
+
+		if ( isOpen && closeButtonRef.current ) {
+			closeButtonRef.current.focus();
+		}
 	}, [ isOpen, prevIsOpen, setSidebarClosing ] );
 
 	const containerMount = ( el: HTMLDivElement | null ) => {
@@ -170,6 +174,7 @@ function WpcomBlockEditorNavSidebar() {
 					className="wpcom-block-editor-nav-sidebar-nav-sidebar__home-button"
 					icon={ chevronLeft }
 					onClick={ handleClose }
+					ref={ closeButtonRef }
 				>
 					{ closeLabel }
 				</Button>

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
@@ -103,10 +103,16 @@ function WpcomBlockEditorNavSidebar() {
 		postType.slug
 	);
 
-	const closeAriaLabel =
+	const dialogDescription =
 		postType.slug === 'page'
-			? __( 'Return to the Dashboard to view all pages', 'full-site-editing' )
-			: __( 'Return to the Dashboard to view all posts', 'full-site-editing' );
+			? __(
+					'Contains links to your dashboard or to edit other pages on your site. Press the Escape key to close.',
+					'full-site-editing'
+			  )
+			: __(
+					'Contains links to your dashboard or to edit other posts on your site. Press the Escape key to close.',
+					'full-site-editing'
+			  );
 
 	const dismissSidebar = () => {
 		if ( isOpen && ! isClosing ) {
@@ -144,6 +150,9 @@ function WpcomBlockEditorNavSidebar() {
 			onKeyDown={ handleKeyDown }
 		>
 			<div
+				aria-label={ __( 'Block editor sidebar', 'full-site-editing' ) }
+				// eslint-disable-next-line jsx-a11y/aria-props
+				aria-description={ dialogDescription }
 				className={ classNames( 'wpcom-block-editor-nav-sidebar-nav-sidebar__container', {
 					'is-sliding-left': isClosing,
 				} ) }
@@ -153,11 +162,7 @@ function WpcomBlockEditorNavSidebar() {
 			>
 				<div className="wpcom-block-editor-nav-sidebar-nav-sidebar__header">
 					<Button
-						// eslint-disable-next-line jsx-a11y/aria-props
-						aria-description={ __(
-							'You are viewing the sidebar. Press the Escape key to close.',
-							'full-site-editing'
-						) }
+						aria-label={ __( 'Close block editor sidebar', 'full-site-editing' ) }
 						className={ classNames(
 							'edit-post-fullscreen-mode-close',
 							'wpcom-block-editor-nav-sidebar-nav-sidebar__dismiss-sidebar-button'
@@ -171,7 +176,8 @@ function WpcomBlockEditorNavSidebar() {
 					</div>
 				</div>
 				<Button
-					aria-label={ closeAriaLabel }
+					// eslint-disable-next-line jsx-a11y/aria-props
+					aria-description={ __( 'Returns to the dashboard', 'full-site-editing' ) }
 					href={ closeUrl }
 					className="wpcom-block-editor-nav-sidebar-nav-sidebar__home-button"
 					icon={ chevronLeft }

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
@@ -153,7 +153,8 @@ function WpcomBlockEditorNavSidebar() {
 			>
 				<div className="wpcom-block-editor-nav-sidebar-nav-sidebar__header">
 					<Button
-						aria-label={ __(
+						// eslint-disable-next-line jsx-a11y/aria-props
+						aria-description={ __(
 							'You are viewing the sidebar. Press the Escape key to close.',
 							'full-site-editing'
 						) }

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
@@ -148,7 +148,10 @@ function WpcomBlockEditorNavSidebar() {
 			>
 				<div className="wpcom-block-editor-nav-sidebar-nav-sidebar__header">
 					<Button
-						aria-label={ __( 'open sidebar', 'full-site-editing' ) }
+						aria-label={ __(
+							'You are viewing the sidebar. To close select escape',
+							'full-site-editing'
+						) }
 						className={ classNames(
 							'edit-post-fullscreen-mode-close',
 							'wpcom-block-editor-nav-sidebar-nav-sidebar__dismiss-sidebar-button'

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
@@ -103,6 +103,11 @@ function WpcomBlockEditorNavSidebar() {
 		postType.slug
 	);
 
+	const closeAriaLabel =
+		postType.slug === 'page'
+			? __( 'View all pages in the Dashboard', 'full-site-editing' )
+			: __( 'View all posts in the Dashboard', 'full-site-editing' );
+
 	const dismissSidebar = () => {
 		if ( isOpen && ! isClosing ) {
 			toggleSidebar();
@@ -165,7 +170,7 @@ function WpcomBlockEditorNavSidebar() {
 					</div>
 				</div>
 				<Button
-					aria-label={ __( 'View all pages in Dashboard', 'full-site-editing' ) }
+					aria-label={ closeAriaLabel }
 					href={ closeUrl }
 					className="wpcom-block-editor-nav-sidebar-nav-sidebar__home-button"
 					icon={ chevronLeft }

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
@@ -27,10 +27,11 @@ import NavItem from '../nav-item';
 import { Post } from '../../types';
 import './style.scss';
 
-const Button = forwardRef(
-	( { children, ...rest }: OriginalButton.Props & { icon?: any; iconSize?: number } ) => (
-		<OriginalButton { ...rest }>{ children }</OriginalButton>
-	)
+const Button = ( {
+	children,
+	...rest
+}: OriginalButton.Props & { icon?: any; iconSize?: number } ) => (
+	<OriginalButton { ...rest }>{ children }</OriginalButton>
 );
 
 function WpcomBlockEditorNavSidebar() {
@@ -50,7 +51,6 @@ function WpcomBlockEditorNavSidebar() {
 	const { current: currentPost, drafts: draftPosts, recent: recentPosts } = useNavItems();
 	const statusLabels = usePostStatusLabels();
 	const prevIsOpen = useRef( isOpen );
-	const closeButtonRef = useRef();
 
 	// Using layout effect to prevent a brief moment in time where both `isOpen` and `isClosing`
 	// are both false, causing a flicker during the fade out animation.
@@ -61,10 +61,6 @@ function WpcomBlockEditorNavSidebar() {
 		}
 
 		prevIsOpen.current = isOpen;
-
-		if ( isOpen && closeButtonRef.current ) {
-			closeButtonRef.current.focus();
-		}
 	}, [ isOpen, prevIsOpen, setSidebarClosing ] );
 
 	const containerMount = ( el: HTMLDivElement | null ) => {
@@ -174,7 +170,6 @@ function WpcomBlockEditorNavSidebar() {
 					className="wpcom-block-editor-nav-sidebar-nav-sidebar__home-button"
 					icon={ chevronLeft }
 					onClick={ handleClose }
-					ref={ closeButtonRef }
 				>
 					{ closeLabel }
 				</Button>

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
@@ -165,6 +165,7 @@ function WpcomBlockEditorNavSidebar() {
 					</div>
 				</div>
 				<Button
+					aria-label={ __( 'View all pages in Dashboard', 'full-site-editing' ) }
 					href={ closeUrl }
 					className="wpcom-block-editor-nav-sidebar-nav-sidebar__home-button"
 					icon={ chevronLeft }

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
@@ -148,6 +148,7 @@ function WpcomBlockEditorNavSidebar() {
 			>
 				<div className="wpcom-block-editor-nav-sidebar-nav-sidebar__header">
 					<Button
+						aria-label={ __( 'open sidebar', 'full-site-editing' ) }
 						className={ classNames(
 							'edit-post-fullscreen-mode-close',
 							'wpcom-block-editor-nav-sidebar-nav-sidebar__dismiss-sidebar-button'

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
@@ -151,6 +151,7 @@ function WpcomBlockEditorNavSidebar() {
 		>
 			<div
 				aria-label={ __( 'Block editor sidebar', 'full-site-editing' ) }
+				// Waiting for jsx-a11y version bump to support aria-description attribute
 				// eslint-disable-next-line jsx-a11y/aria-props
 				aria-description={ dialogDescription }
 				className={ classNames( 'wpcom-block-editor-nav-sidebar-nav-sidebar__container', {
@@ -163,6 +164,9 @@ function WpcomBlockEditorNavSidebar() {
 				<div className="wpcom-block-editor-nav-sidebar-nav-sidebar__header">
 					<Button
 						aria-label={ __( 'Close block editor sidebar', 'full-site-editing' ) }
+						// We need to shift the focus to something because we are opening a modal
+						// eslint-disable-next-line jsx-a11y/no-autofocus
+						autoFocus
 						className={ classNames(
 							'edit-post-fullscreen-mode-close',
 							'wpcom-block-editor-nav-sidebar-nav-sidebar__dismiss-sidebar-button'
@@ -176,6 +180,7 @@ function WpcomBlockEditorNavSidebar() {
 					</div>
 				</div>
 				<Button
+					// Waiting for jsx-a11y version bump to support aria-description attribute
 					// eslint-disable-next-line jsx-a11y/aria-props
 					aria-description={ __( 'Returns to the dashboard', 'full-site-editing' ) }
 					href={ closeUrl }

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
@@ -149,7 +149,7 @@ function WpcomBlockEditorNavSidebar() {
 				<div className="wpcom-block-editor-nav-sidebar-nav-sidebar__header">
 					<Button
 						aria-label={ __(
-							'You are viewing the sidebar. To close select escape',
+							'You are viewing the sidebar. Press the Escape key to close.',
 							'full-site-editing'
 						) }
 						className={ classNames(

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
@@ -105,8 +105,8 @@ function WpcomBlockEditorNavSidebar() {
 
 	const closeAriaLabel =
 		postType.slug === 'page'
-			? __( 'View all pages in the Dashboard', 'full-site-editing' )
-			: __( 'View all posts in the Dashboard', 'full-site-editing' );
+			? __( 'Return to the Dashboard to view all pages', 'full-site-editing' )
+			: __( 'Return to the Dashboard to view all posts', 'full-site-editing' );
 
 	const dismissSidebar = () => {
 		if ( isOpen && ! isClosing ) {

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
@@ -30,7 +30,7 @@ import './style.scss';
 const Button = ( {
 	children,
 	...rest
-}: OriginalButton.Props & { icon?: any; iconSize?: number } ) => (
+}: OriginalButton.Props & { icon?: any; iconSize?: number; showTooltip?: boolean } ) => (
 	<OriginalButton { ...rest }>{ children }</OriginalButton>
 );
 
@@ -163,7 +163,8 @@ function WpcomBlockEditorNavSidebar() {
 			>
 				<div className="wpcom-block-editor-nav-sidebar-nav-sidebar__header">
 					<Button
-						aria-label={ __( 'Close block editor sidebar', 'full-site-editing' ) }
+						label={ __( 'Close block editor sidebar', 'full-site-editing' ) }
+						showTooltip
 						// We need to shift the focus to something because we are opening a modal
 						// eslint-disable-next-line jsx-a11y/no-autofocus
 						autoFocus

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
@@ -79,6 +79,11 @@ function WpcomBlockEditorNavSidebar() {
 		return null;
 	}
 
+	// The `closeUrl` "closes" the editor, returning the user to the dashboard.
+	// It often takes the user back to the pages or posts list, but can also be overridden
+	// (using the filter) to take the user to the customer homepage or themes gallery instance.
+	// `closeLabel` can be overridden in the same way to correctly label where the user will
+	// be taken to after closing the editor.
 	const defaultCloseUrl = addQueryArgs( 'edit.php', { post_type: postType.slug } );
 	const closeUrl = applyFilters( 'a8c.WpcomBlockEditorNavSidebar.closeUrl', defaultCloseUrl );
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/toggle-sidebar-button/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/toggle-sidebar-button/index.tsx
@@ -4,7 +4,7 @@
 import { Button as OriginalButton } from '@wordpress/components';
 import { wordpress } from '@wordpress/icons';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { __ } from '@wordpress/i18n/build-types';
+import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
 
 /**

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/toggle-sidebar-button/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/toggle-sidebar-button/index.tsx
@@ -4,6 +4,7 @@
 import { Button as OriginalButton } from '@wordpress/components';
 import { wordpress } from '@wordpress/icons';
 import { useDispatch, useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n/build-types';
 import classnames from 'classnames';
 
 /**
@@ -26,6 +27,7 @@ export default function ToggleSidebarButton() {
 
 	return (
 		<Button
+			aria-label={ __( 'Open sidebar', 'full-site-editing' ) }
 			className={ classnames(
 				'edit-post-fullscreen-mode-close',
 				'wpcom-block-editor-nav-sidebar-toggle-sidebar-button__button',

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/toggle-sidebar-button/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/toggle-sidebar-button/index.tsx
@@ -16,7 +16,7 @@ import './style.scss';
 const Button = ( {
 	children,
 	...rest
-}: OriginalButton.Props & { icon?: any; iconSize?: number } ) => (
+}: OriginalButton.Props & { icon?: any; iconSize?: number; showTooltip?: boolean } ) => (
 	<OriginalButton { ...rest }>{ children }</OriginalButton>
 );
 
@@ -27,7 +27,8 @@ export default function ToggleSidebarButton() {
 
 	return (
 		<Button
-			aria-label={ __( 'Open sidebar', 'full-site-editing' ) }
+			label={ __( 'Block editor sidebar', 'full-site-editing' ) }
+			showTooltip
 			className={ classnames(
 				'edit-post-fullscreen-mode-close',
 				'wpcom-block-editor-nav-sidebar-toggle-sidebar-button__button',


### PR DESCRIPTION
### Changes proposed in this Pull Request

- [x] For the W button: add an aria-label that describes what the button is for. Button when closed now reads "Open sidebar", when W button is open it should read "You are viewing sidebar. To close select "esc".
- [x]  Aria-label  for "View all pages" now  reads: "View all pages in Dashboard" (or posts as appropriate)
- [x] Look at https://www.w3.org/TR/wai-aria-practices/#dialog_modal for the correct implementation of role="dialog"
- [x] Use an h2 instead of a div for the “Posts” heading
- [x] Set autoFocus to (W) icon when sidebar opens

### Testing instructions
1. Open a site to edit in WP.com and navigate to edit a post or page:
2. Once in the editor, verify the (W) icon has the correct aria-label "Block editor sidebar)
3. click the (W) icon in the top left
3. Once the Block Editor Sidebar is open:
 * verify the (W) icon has the focus 
 * look in dev tools to verify aria-label/aria-description on (W) button (aria-description used for more descriptive info)
 * look in dev tools to verify aria-label on "View pages/posts" link
 * look in dev tools to verify Posts heading is an h2

Conversely, use a screen reader to verify the aria-labels and aria-descriptions mentioned above


Fixes # https://github.com/Automattic/wp-calypso/issues/45239
