### PR TITLE
fix(deps): update dependency esm to ^3.2.25

### DIFF
--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -36,7 +36,7 @@
 		"esformatter-quotes": "^1.0.3",
 		"esformatter-semicolons": "^1.1.2",
 		"esformatter-special-bangs": "^1.0.1",
-		"esm": "^3.2.10",
+		"esm": "^3.2.25",
 		"ffmpeg-static": "^2.4.0",
 		"fs-extra": "^0.22.1",
 		"grunt": "^1.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12195,10 +12195,10 @@ eslint@^7.1.0:
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
 
-esm@^3.2.10:
-  version "3.2.10"
-  resolved "https://registry.yarnpkg.com/esm/-/esm-3.2.10.tgz#fea61120e0d89b87897756f506f169c2fb0ca78e"
-  integrity sha512-r6v4kFfezz5/Qo6Q5ThaNPPUi7a2E3J4ZWxFuohhxJRAa6X7hg6Ca7GRPaixsi5ALcokhif/04Ys4zAxab4Edw==
+esm@^3.2.25:
+  version "3.2.25"
+  resolved "https://registry.yarnpkg.com/esm/-/esm-3.2.25.tgz#342c18c29d56157688ba5ce31f8431fbb795cc10"
+  integrity sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==
 
 espree@^6.1.2:
   version "6.1.2"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Static class properties loaded via esm were syntax errors (https://github.com/Automattic/wp-calypso/pull/45048#discussion_r478579271). This was due to outdated `esm` dependency so I'm upgrading here (see https://github.com/standard-things/esm/commit/98b1fb751878ad790e76c5b64f8ff597db4715d1).

[`esm`](https://github.com/standard-things/esm) is the loader used to support ECMAScript module syntax (import/export) in e2e tests. 

#### Testing instructions

* The e2e tests should run.
* This is included in https://github.com/Automattic/wp-calypso/pull/45048 and https://github.com/Automattic/wp-calypso/pull/45048/commits/509fec9d0b487cbcdfcc24c1cfc2b546817d7ceb (commit on that branch) includes static properties, so passing tests there indicate it was successful.