### PR TITLE
Components: Remove global input[type='url'] styles

### DIFF
--- a/client/assets/stylesheets/shared/_forms.scss
+++ b/client/assets/stylesheets/shared/_forms.scss
@@ -14,7 +14,6 @@ input[type='password'],
 input[type='checkbox'],
 input[type='radio'],
 input[type='tel'],
-input[type='url'],
 textarea {
 	@extend %form-field;
 }
@@ -29,7 +28,6 @@ input[type='email'],
 input[type='number'],
 input[type='password'],
 input[type='tel'],
-input[type='url'],
 textarea,
 select,
 label {
@@ -37,8 +35,7 @@ label {
 }
 
 input[type='password'],
-input[type='email'],
-input[type='url'] {
+input[type='email'] {
 	/*!rtl:ignore*/
 	direction: ltr;
 }

--- a/client/components/forms/form-text-input/index.jsx
+++ b/client/components/forms/form-text-input/index.jsx
@@ -6,6 +6,11 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { omit } from 'lodash';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 export default class FormTextInput extends PureComponent {
 	static propTypes = {
 		isError: PropTypes.bool,

--- a/client/components/forms/form-text-input/style.scss
+++ b/client/components/forms/form-text-input/style.scss
@@ -1,6 +1,12 @@
-input[type='email'].form-text-input,
-input[type='password'].form-text-input,
-input[type='url'].form-text-input,
-input[type='text'].form-text-input { // input[type="text"] is needed to override the default styles
-	-webkit-appearance: none;
+.form-text-input {
+	@at-root {
+		input[type='url'] {
+			@extend %form-field;
+
+			appearance: none;
+
+			/*!rtl:ignore*/
+			direction: ltr;
+		}
+	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove global form `input[type='url']` styles in favor of more specific component-level styling. See #45259

#### Testing instructions

* Test the following against production and ensure that they match stylistically and functionally:
  * `/media/:siteSlug`, click the arrow-down button next to the "Add New" button, and click "Add via URL".
  * `/me/account`, the URL address field on the profile form.
* Verify all `<input type="url />` use `<FormTextInput />`.

#### Notes:
* The `FormTextInput` stylesheet was not used at all. We're removing all the unused styles there and starting with a clean sheet that we'll populate as we migrate more of the fields.
* Since the `FormTextInput` stylesheet was not imported, we're now importing it in the `<FormTextInput />` component.