### PR TITLE
Use product data coming from the site instead of the generic product list

### DIFF
--- a/client/my-sites/plans-v2/details.tsx
+++ b/client/my-sites/plans-v2/details.tsx
@@ -22,13 +22,13 @@ import {
 	getPathToUpsell,
 	checkout,
 } from './utils';
+import QueryProducts from './query-products';
+import useIsLoading from './use-is-loading';
 import ProductCardPlaceholder from 'components/jetpack/card/product-card-placeholder';
 import FormattedHeader from 'components/formatted-header';
 import HeaderCake from 'components/header-cake';
 import Main from 'components/main';
 import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
-import { isProductsListFetching } from 'state/products-list/selectors/is-products-list-fetching';
-import { getProductsList } from 'state/products-list/selectors';
 import { getSiteProducts } from 'state/sites/selectors';
 import { getSelectedSiteSlug, getSelectedSiteId } from 'state/ui/selectors';
 import withRedirectToSelector from './with-redirect-to-selector';
@@ -44,11 +44,9 @@ const DetailsPage = ( { duration, productSlug, rootUrl, header, footer }: Detail
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
 	const siteSlug = useSelector( ( state ) => getSelectedSiteSlug( state ) ) || '';
 	const currencyCode = useSelector( ( state ) => getCurrentUserCurrencyCode( state ) );
-	const isFetchingProducts = useSelector( ( state ) => isProductsListFetching( state ) );
 	const siteProducts = useSelector( ( state ) => getSiteProducts( state, siteId ) );
-	const products = useSelector( ( state ) => getProductsList( state ) );
 	const translate = useTranslate();
-	const isLoading = ! currencyCode || ( isFetchingProducts && ! products );
+	const isLoading = useIsLoading( siteId );
 
 	// If the product slug isn't one that has options, proceed to the upsell.
 	if ( ! ( PRODUCTS_WITH_OPTIONS as readonly string[] ).includes( productSlug ) ) {
@@ -88,6 +86,7 @@ const DetailsPage = ( { duration, productSlug, rootUrl, header, footer }: Detail
 
 	return (
 		<Main className="details__main" wideLayout>
+			<QueryProducts />
 			{ header }
 			<HeaderCake onClick={ backButton }>
 				{ isBundle ? translate( 'Bundle Options' ) : translate( 'Product Options' ) }

--- a/client/my-sites/plans-v2/product-card/index.tsx
+++ b/client/my-sites/plans-v2/product-card/index.tsx
@@ -50,17 +50,19 @@ const itemToCard = ( { type }: SelectorProduct ) => {
 };
 
 interface UpgradeNudgeProps {
+	siteId: number | null;
 	item: SelectorProduct;
 	currencyCode: string;
 	onClick: PurchaseCallback;
 }
 
-const UpgradeNudgeWrapper = ( { item, currencyCode, onClick }: UpgradeNudgeProps ) => {
+const UpgradeNudgeWrapper = ( { siteId, item, currencyCode, onClick }: UpgradeNudgeProps ) => {
 	const upgradeToProductSlug =
 		getRealtimeFromDaily( item.costProductSlug || item.productSlug ) || '';
 	const selectorProductToUpgrade = slugToSelectorProduct( upgradeToProductSlug );
 
 	const { isFetching, originalPrice, discountedPrice } = useItemPrice(
+		siteId,
 		selectorProductToUpgrade,
 		selectorProductToUpgrade?.monthlyProductSlug || ''
 	);
@@ -114,7 +116,11 @@ const ProductCardWrapper = ( {
 	}, [ item.productSlug, sitePlan, siteProducts ] );
 
 	// Calculate the product price.
-	const { originalPrice, discountedPrice } = useItemPrice( item, item?.monthlyProductSlug || '' );
+	const { originalPrice, discountedPrice } = useItemPrice(
+		siteId,
+		item,
+		item?.monthlyProductSlug || ''
+	);
 
 	// Handles expiry.
 	const moment = useLocalizedMoment();
@@ -136,7 +142,12 @@ const ProductCardWrapper = ( {
 	const CardComponent = itemToCard( item ); // Get correct card component.
 
 	const UpgradeNudge = isOwned ? (
-		<UpgradeNudgeWrapper item={ item } currencyCode={ currencyCode } onClick={ onClick } />
+		<UpgradeNudgeWrapper
+			siteId={ siteId }
+			item={ item }
+			currencyCode={ currencyCode }
+			onClick={ onClick }
+		/>
 	) : null;
 
 	return (

--- a/client/my-sites/plans-v2/query-products/index.tsx
+++ b/client/my-sites/plans-v2/query-products/index.tsx
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+import React, { FunctionComponent } from 'react';
+import { useSelector } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import QueryProductsList from 'components/data/query-products-list';
+import QuerySiteProducts from 'components/data/query-site-products';
+import { getSelectedSiteId } from 'state/ui/selectors';
+
+const QueryProducts: FunctionComponent< {} > = () => {
+	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+
+	return <>{ siteId ? <QuerySiteProducts siteId={ siteId } /> : <QueryProductsList /> }</>;
+};
+
+export default QueryProducts;

--- a/client/my-sites/plans-v2/selector.tsx
+++ b/client/my-sites/plans-v2/selector.tsx
@@ -13,12 +13,12 @@ import PlansColumn from './plans-column';
 import ProductsColumn from './products-column';
 import { SECURITY } from './constants';
 import { getProductUpsell, getPathToDetails, getPathToUpsell, checkout } from './utils';
+import QueryProducts from './query-products';
 import { TERM_ANNUALLY } from 'lib/plans/constants';
 import { getSiteProducts } from 'state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { managePurchase } from 'me/purchases/paths';
 import Main from 'components/main';
-import QueryProductsList from 'components/data/query-products-list';
 import QuerySitePurchases from 'components/data/query-site-purchases';
 import QuerySites from 'components/data/query-sites';
 import JetpackFreeCard from 'components/jetpack/card/jetpack-free-card';
@@ -109,7 +109,7 @@ const SelectorPage = ( {
 				</>
 			) }
 
-			<QueryProductsList />
+			<QueryProducts />
 			{ siteId && <QuerySitePurchases siteId={ siteId } /> }
 			{ siteId && <QuerySites siteId={ siteId } /> }
 			{ footer }

--- a/client/my-sites/plans-v2/upsell.tsx
+++ b/client/my-sites/plans-v2/upsell.tsx
@@ -18,8 +18,9 @@ import Main from 'components/main';
 import { preventWidows } from 'lib/formatting';
 import { JETPACK_SCAN_PRODUCTS, JETPACK_BACKUP_PRODUCTS } from 'lib/products-values/constants';
 import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
-import { isProductsListFetching, getProductsList } from 'state/products-list/selectors';
-import { getSelectedSiteSlug } from 'state/ui/selectors';
+import { getSelectedSiteSlug, getSelectedSiteId } from 'state/ui/selectors';
+import QueryProducts from './query-products';
+import useIsLoading from './use-is-loading';
 import useItemPrice from './use-item-price';
 import {
 	durationToText,
@@ -175,10 +176,9 @@ const UpsellComponent = ( {
 
 const UpsellPage = ( { duration, productSlug, rootUrl, header, footer }: UpsellPageProps ) => {
 	const siteSlug = useSelector( ( state ) => getSelectedSiteSlug( state ) ) || '';
-	const isFetchingProducts = useSelector( ( state ) => isProductsListFetching( state ) );
+	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	const isLoading = useIsLoading( siteId );
 	const currencyCode = useSelector( ( state ) => getCurrentUserCurrencyCode( state ) );
-	const products = useSelector( ( state ) => getProductsList( state ) );
-	const isLoading = ! currencyCode || ( isFetchingProducts && ! products );
 
 	const mainProduct = slugToSelectorProduct( productSlug );
 	// TODO: Get upsells via API.
@@ -223,6 +223,7 @@ const UpsellPage = ( { duration, productSlug, rootUrl, header, footer }: UpsellP
 
 	return (
 		<>
+			<QueryProducts />
 			{ header }
 			<UpsellComponent
 				currencyCode={ currencyCode as string }

--- a/client/my-sites/plans-v2/upsell.tsx
+++ b/client/my-sites/plans-v2/upsell.tsx
@@ -44,6 +44,7 @@ import './style.scss';
 import type { Duration, SelectorProduct, UpsellPageProps } from './types';
 
 interface Props {
+	siteId: number | null;
 	currencyCode: string;
 	mainProduct: SelectorProduct;
 	upsellProduct: SelectorProduct;
@@ -54,6 +55,7 @@ interface Props {
 }
 
 const UpsellComponent = ( {
+	siteId,
 	currencyCode,
 	onBackButtonClick,
 	onPurchaseSingleProduct,
@@ -66,6 +68,7 @@ const UpsellComponent = ( {
 
 	// Upsell prices should come from the API with the upsell products
 	const { originalPrice, discountedPrice } = useItemPrice(
+		siteId,
 		upsellProduct,
 		upsellProduct.monthlyProductSlug || ''
 	);
@@ -226,6 +229,7 @@ const UpsellPage = ( { duration, productSlug, rootUrl, header, footer }: UpsellP
 			<QueryProducts />
 			{ header }
 			<UpsellComponent
+				siteId={ siteId }
 				currencyCode={ currencyCode as string }
 				mainProduct={ mainProduct }
 				upsellProduct={ upsellProduct }

--- a/client/my-sites/plans-v2/use-is-loading.ts
+++ b/client/my-sites/plans-v2/use-is-loading.ts
@@ -1,0 +1,54 @@
+/**
+ * External dependencies
+ */
+import { useSelector } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
+import { isProductsListFetching, getProductsList } from 'state/products-list/selectors';
+import {
+	isRequestingSiteProducts,
+	getAvailableProductsBySiteId,
+} from 'state/sites/products/selectors';
+
+type RawData = {
+	isFetching: boolean | null;
+	products: object[] | null;
+};
+
+const useProductListData = () => {
+	const isFetching = useSelector( ( state ) => !! isProductsListFetching( state ) );
+	const products = useSelector( ( state ) => getProductsList( state ) );
+
+	return {
+		isFetching,
+		products,
+	};
+};
+
+const useSiteAvailableProductData = ( siteId: number | null ) => {
+	const isFetching =
+		useSelector( ( state ) => siteId && !! isRequestingSiteProducts( state, siteId ) ) || null;
+	const products =
+		useSelector( ( state ) => siteId && getAvailableProductsBySiteId( state, siteId )?.data ) ||
+		null;
+
+	return {
+		isFetching,
+		products,
+	};
+};
+
+const useIsLoading = ( siteId: number | null ): boolean => {
+	const currencyCode = useSelector( ( state ) => getCurrentUserCurrencyCode( state ) );
+	const listData = useProductListData();
+	const siteData = useSiteAvailableProductData( siteId );
+	const isFetching = siteId ? siteData.isFetching : listData.isFetching;
+	const products = siteId ? siteData.products : listData.products;
+
+	return ! currencyCode || ( isFetching && ! products );
+};
+
+export default useIsLoading;

--- a/client/my-sites/plans-v2/use-is-loading.ts
+++ b/client/my-sites/plans-v2/use-is-loading.ts
@@ -18,7 +18,7 @@ type RawData = {
 	products: object[] | null;
 };
 
-const useProductListData = () => {
+const useProductListData = (): RawData => {
 	const isFetching = useSelector( ( state ) => !! isProductsListFetching( state ) );
 	const products = useSelector( ( state ) => getProductsList( state ) );
 
@@ -28,7 +28,7 @@ const useProductListData = () => {
 	};
 };
 
-const useSiteAvailableProductData = ( siteId: number | null ) => {
+const useSiteAvailableProductData = ( siteId: number | null ): RawData => {
 	const isFetching =
 		useSelector( ( state ) => siteId && !! isRequestingSiteProducts( state, siteId ) ) || null;
 	const products =
@@ -48,7 +48,7 @@ const useIsLoading = ( siteId: number | null ): boolean => {
 	const isFetching = siteId ? siteData.isFetching : listData.isFetching;
 	const products = siteId ? siteData.products : listData.products;
 
-	return ! currencyCode || ( isFetching && ! products );
+	return !! ( ! currencyCode || ( isFetching && ! products ) );
 };
 
 export default useIsLoading;

--- a/client/my-sites/plans-v2/use-item-price.ts
+++ b/client/my-sites/plans-v2/use-item-price.ts
@@ -20,7 +20,7 @@ import {
 import type { SelectorProduct } from './types';
 
 interface ItemPrices {
-	isFetching: boolean;
+	isFetching: boolean | null;
 	originalPrice: number;
 	discountedPrice?: number;
 }
@@ -31,7 +31,10 @@ interface ItemRawPrices {
 	monthlyItemCost: number | null;
 }
 
-const useProductListItemPrices = ( item: SelectorProduct | null, monthlyItemSlug = '' ) => {
+const useProductListItemPrices = (
+	item: SelectorProduct | null,
+	monthlyItemSlug = ''
+): ItemRawPrices => {
 	const isFetching = useSelector( ( state ) => !! isProductsListFetching( state ) );
 	const itemCost =
 		useSelector(
@@ -51,7 +54,7 @@ const useSiteAvailableProductPrices = (
 	siteId: number | null,
 	item: SelectorProduct | null,
 	monthlyItemSlug = ''
-) => {
+): ItemRawPrices => {
 	const isFetching =
 		useSelector( ( state ) => siteId && !! isRequestingSiteProducts( state, siteId ) ) || null;
 	const itemCost =

--- a/client/my-sites/plans-v2/use-item-price.ts
+++ b/client/my-sites/plans-v2/use-item-price.ts
@@ -9,6 +9,10 @@ import { useSelector } from 'react-redux';
 import { isProductsListFetching } from 'state/products-list/selectors/is-products-list-fetching';
 import { getProductCost } from 'state/products-list/selectors/get-product-cost';
 import { TERM_MONTHLY } from 'lib/plans/constants';
+import {
+	getSiteAvailableProductCost,
+	isRequestingSiteProducts,
+} from 'state/sites/products/selectors';
 
 /**
  * Type dependencies
@@ -21,12 +25,65 @@ interface ItemPrices {
 	discountedPrice?: number;
 }
 
-const useItemPrice = ( item: SelectorProduct | null, monthlyItemSlug = '' ): ItemPrices => {
+interface ItemRawPrices {
+	isFetching: boolean | null;
+	itemCost: number | null;
+	monthlyItemCost: number | null;
+}
+
+const useProductListItemPrices = ( item: SelectorProduct | null, monthlyItemSlug = '' ) => {
 	const isFetching = useSelector( ( state ) => !! isProductsListFetching( state ) );
-	const itemCost = useSelector(
-		( state ) => item && getProductCost( state, item.costProductSlug || item.productSlug )
-	);
-	const monthlyItemCost = useSelector( ( state ) => getProductCost( state, monthlyItemSlug ) );
+	const itemCost =
+		useSelector(
+			( state ) => item && getProductCost( state, item.costProductSlug || item.productSlug )
+		) || null;
+	const monthlyItemCost =
+		useSelector( ( state ) => getProductCost( state, monthlyItemSlug ) ) || null;
+
+	return {
+		isFetching,
+		itemCost,
+		monthlyItemCost,
+	};
+};
+
+const useSiteAvailableProductPrices = (
+	siteId: number | null,
+	item: SelectorProduct | null,
+	monthlyItemSlug = ''
+) => {
+	const isFetching =
+		useSelector( ( state ) => siteId && !! isRequestingSiteProducts( state, siteId ) ) || null;
+	const itemCost =
+		useSelector(
+			( state ) =>
+				siteId &&
+				item &&
+				getSiteAvailableProductCost( state, siteId, item.costProductSlug || item.productSlug )
+		) || null;
+	const monthlyItemCost =
+		useSelector(
+			( state ) => siteId && getSiteAvailableProductCost( state, siteId, monthlyItemSlug )
+		) || null;
+
+	return {
+		isFetching,
+		itemCost,
+		monthlyItemCost,
+	};
+};
+
+const useItemPrice = (
+	siteId: number | null,
+	item: SelectorProduct | null,
+	monthlyItemSlug = ''
+): ItemPrices => {
+	const listPrices = useProductListItemPrices( item, monthlyItemSlug );
+	const sitePrices = useSiteAvailableProductPrices( siteId, item, monthlyItemSlug );
+
+	const isFetching = siteId ? sitePrices.isFetching : listPrices.isFetching;
+	const itemCost = siteId ? sitePrices.itemCost : listPrices.itemCost;
+	const monthlyItemCost = siteId ? sitePrices.monthlyItemCost : listPrices.monthlyItemCost;
 
 	if ( isFetching ) {
 		return {

--- a/client/state/sites/products/selectors.js
+++ b/client/state/sites/products/selectors.js
@@ -28,3 +28,15 @@ export function isRequestingSiteProducts( state, siteId ) {
 	const products = getProductsBySiteId( state, siteId );
 	return products.isRequesting;
 }
+
+export function getSiteAvailableProduct( state, siteId, productSlug ) {
+	const { data } = getAvailableProductsBySiteId( state, siteId );
+
+	if ( data ) {
+		return data[ productSlug ];
+	}
+}
+
+export function getSiteAvailableProductCost( state, siteId, productSlug ) {
+	return getSiteAvailableProduct( state, siteId, productSlug )?.cost;
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request

So far, offer reset pages have been consuming product data coming from the `/products/` endpoint. This is an issue as some prices (for Jetpack Search) depends on site stats (number of search records). This PR fixes that by making sure product data coming from the `/sites/<site id>/products/` endpoint is used when available.

### Implementation notes

The gist of the PR was to make sure that components in `client/my-sites/plan-v2/` were using data from `state.sites.products[id]` instead of `state.productsList`, when a site is selected. If no site is selected (e.g. at `/jetpack/connect/plans/`) it falls back to using `state.productsList`. This logic is extracted in a couple of components and hooks, so that offer reset pages don't have to deal with it. Namely: `QueryProducts`, `useItemPrice`, and `useIsLoading`.

### Testing instructions

The first part is to check the price of Jetpack Search:

- Visit the _Plans_ page with the offer reset flow enabled, and with 'All' or 'Performance' selected in the type selector.
- Make sure your site doesn't have Jetpack Search already.
- Check that the price in the Jetpack Search product card depends on the site search records. You can update the number of records in your WPcom sandbox by hardcoding the value returned by `current_records ` in `wp-content/lib/jetpack-plans/search.php`.
- Next, navigate to `/jetpack/connect/plans/`, and make sure Search displays the lowest price point (see captures).
- Navigate to `/jetpack/connect/plans/:site`, and notice that Search price depends on your site records.

_Note: tiers are 0-100, 100-1k, 1k-10k, 10k-100k, 100k-1m, and 1m+._

Finally, do some regression testing and check that the selectors, details, and upsell page still work as expected. Try hard refreshing each page as well.

### Screenshots

Connect flow, no site selected, monthly
<img width="459" alt="Screen Shot 2020-08-28 at 2 45 51 PM" src="https://user-images.githubusercontent.com/1620183/91604739-333af480-e93d-11ea-9d13-6cda4926d4e7.png">


Connect flow, no site selected, yearly
<img width="464" alt="Screen Shot 2020-08-28 at 2 45 55 PM" src="https://user-images.githubusercontent.com/1620183/91604742-37671200-e93d-11ea-996f-94ffd3521ce0.png">

