### PR TITLE
P2: add is_p2_site to calypso_invite_account_created

### DIFF
--- a/client/lib/invites/actions.js
+++ b/client/lib/invites/actions.js
@@ -67,7 +67,10 @@ export function createAccount( userData, invite, callback ) {
 							error: error.error,
 						} );
 					} else {
-						recordTracksEvent( 'calypso_invite_account_created' );
+						recordTracksEvent( 'calypso_invite_account_created', {
+							is_p2_site: get( invite, 'site.is_wpforteams_site', false ),
+							inviter_blog_id: get( invite, 'site.ID', false ),
+						} );
 					}
 					callback( error, bearerToken );
 				}


### PR DESCRIPTION
In this PR, we add `is_p2_site` and `inviter_blog_id` to the `calypso_invite_account_created` event. We need the `is_p2_site` flag to determine if the newly created invited account was thanks to a P2.

## Testing instructions

Open an incognito window and using a 10 minute email, invite the email to a P2 site. While creating a new account, inspect the network call to the events API or simply `console.log` the data next to the event definition.

## Notes

The difference between `calypso_invite_account_created` and `calypso_invite_accepted`  is that `calypso_invite_accepted` is triggered at the last step when an invite is accepted for both users who created a new account and users who just logged in. `calypso_invite_account_created` is called just when an invited user is creating a new account.