### PR TITLE
Gutenboarding: add experimental features to Site setup

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/common/data-stores/launch/actions.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/common/data-stores/launch/actions.ts
@@ -64,6 +64,10 @@ export const closeSidebar = () => ( {
 	type: 'CLOSE_SIDEBAR' as const,
 } );
 
+export const enableExperimental = () => ( {
+	type: 'ENABLE_EXPERIMENTAL' as const,
+} );
+
 export type LaunchAction = ReturnType<
 	| typeof unsetDomain
 	| typeof setStep
@@ -74,4 +78,5 @@ export type LaunchAction = ReturnType<
 	| typeof unsetPlan
 	| typeof openSidebar
 	| typeof closeSidebar
+	| typeof enableExperimental
 >;

--- a/apps/editing-toolkit/editing-toolkit-plugin/common/data-stores/launch/index.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/common/data-stores/launch/index.ts
@@ -24,7 +24,7 @@ registerStore< State >( STORE_KEY, {
 	controls,
 	reducer: reducer as any,
 	selectors,
-	persist: [ 'domain', 'domainSearch', 'plan', 'confirmedDomainSelection' ],
+	persist: [ 'domain', 'domainSearch', 'plan', 'confirmedDomainSelection', 'isExperimental' ],
 } );
 
 declare module '@wordpress/data' {

--- a/apps/editing-toolkit/editing-toolkit-plugin/common/data-stores/launch/reducer.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/common/data-stores/launch/reducer.ts
@@ -67,6 +67,14 @@ const isSidebarOpen: Reducer< boolean, LaunchAction > = ( state = false, action 
 	return state;
 };
 
+const isExperimental: Reducer< boolean, LaunchAction > = ( state = false, action ) => {
+	if ( action.type === 'ENABLE_EXPERIMENTAL' ) {
+		return true;
+	}
+
+	return state;
+};
+
 const reducer = combineReducers( {
 	step,
 	domain,
@@ -74,6 +82,7 @@ const reducer = combineReducers( {
 	domainSearch,
 	plan,
 	isSidebarOpen,
+	isExperimental,
 } );
 
 export type State = ReturnType< typeof reducer >;

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-gutenboarding-launch/index.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-gutenboarding-launch/index.ts
@@ -52,6 +52,7 @@ function updateEditor() {
 
 		const isMobile = window.innerWidth < 768;
 		const isNewLaunch = window?.calypsoifyGutenberg?.isNewLaunch;
+		const isExperimental = window?.calypsoifyGutenberg?.isExperimental;
 
 		// Assert reason: We have an early return above with optional and falsy values. This should be a string.
 		const launchHref = window?.calypsoifyGutenberg?.frankenflowUrl as string;
@@ -75,9 +76,14 @@ function updateEditor() {
 
 			recordTracksEvent( 'calypso_newsite_editor_launch_click', {
 				is_new_flow: shouldOpenNewFlow,
+				is_experimental: isExperimental,
 			} );
 
 			if ( shouldOpenNewFlow ) {
+				// If we want to load experimental features, for now '?latest' query param should be added in URL.
+				// TODO: update this in calypsoify-iframe.tsx depending on abtest or other conditions.
+				isExperimental && dispatch( 'automattic/launch' ).enableExperimental();
+
 				// Open editor-site-launch sidebar
 				dispatch( 'automattic/launch' ).openSidebar();
 				setTimeout( () => {

--- a/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/plan-step/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/editor-site-launch/src/launch-steps/plan-step/index.tsx
@@ -18,6 +18,7 @@ import './styles.scss';
 const PlanStep: React.FunctionComponent< LaunchStepProps > = ( { onNextStep } ) => {
 	const domain = useSelect( ( select ) => select( LAUNCH_STORE ).getSelectedDomain() );
 	const LaunchStep = useSelect( ( select ) => select( LAUNCH_STORE ).getLaunchStep() );
+	const { isExperimental } = useSelect( ( select ) => select( LAUNCH_STORE ).getState() );
 
 	const { updatePlan, setStep } = useDispatch( LAUNCH_STORE );
 
@@ -58,6 +59,7 @@ const PlanStep: React.FunctionComponent< LaunchStepProps > = ( { onNextStep } ) 
 							  }
 							: undefined
 					}
+					isExperimental={ isExperimental }
 				/>
 			</div>
 		</LaunchStepContainer>

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -755,10 +755,11 @@ function getGutenboardingStatus( calypsoPort ) {
 		[ port2 ]
 	);
 	port1.onmessage = ( { data } ) => {
-		const { isGutenboarding, frankenflowUrl, isNewLaunch } = data;
+		const { isGutenboarding, frankenflowUrl, isNewLaunch, isExperimental } = data;
 		calypsoifyGutenberg.isGutenboarding = isGutenboarding;
 		calypsoifyGutenberg.frankenflowUrl = frankenflowUrl;
 		calypsoifyGutenberg.isNewLaunch = isNewLaunch;
+		calypsoifyGutenberg.isExperimental = isExperimental;
 		// Hook necessary if message recieved after editor has loaded.
 		window.wp.hooks.doAction( 'setGutenboardingStatus', isGutenboarding );
 	};

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -343,12 +343,14 @@ class CalypsoifyIframe extends Component<
 			const isGutenboarding =
 				this.props.siteCreationFlow === 'gutenboarding' && this.props.isSiteUnlaunched;
 			const frankenflowUrl = `${ window.location.origin }/start/new-launch?siteSlug=${ this.props.siteSlug }&source=editor`;
-			const isGutenboardingNewLaunch = config.isEnabled( 'gutenboarding/new-launch' );
+			const isNewLaunch = config.isEnabled( 'gutenboarding/new-launch' );
+			const isExperimental = new URLSearchParams( window?.location.search ).has( 'latest' );
 
 			ports[ 0 ].postMessage( {
 				isGutenboarding,
 				frankenflowUrl,
-				isNewLaunch: isGutenboardingNewLaunch,
+				isNewLaunch,
+				isExperimental,
 			} );
 		}
 

--- a/client/landing/gutenboarding/hooks/use-step-navigation.ts
+++ b/client/landing/gutenboarding/hooks/use-step-navigation.ts
@@ -88,6 +88,16 @@ export default function useStepNavigation(): { goBack: () => void; goNext: () =>
 		steps = steps.filter( ( step ) => step !== Step.Plans );
 	}
 
+	// Don't show the mandatory Plans step:
+	// - if the user landed from a marketing page after selecting a paid plan
+	// - if a plan has been selected using the PlansModal but only if there is no Features step
+	if (
+		hasPaidPlanFromPath ||
+		( ! steps.includes( Step.Features ) && plan && ! hasUsedPlansStep )
+	) {
+		steps = steps.filter( ( step ) => step !== Step.Plans );
+	}
+
 	const currentStepIndex = steps.findIndex( ( step ) => step === Step[ currentStep ] );
 	const previousStepPath = currentStepIndex > 0 ? makePath( steps[ currentStepIndex - 1 ] ) : '';
 	const nextStepPath =

--- a/client/landing/gutenboarding/hooks/use-step-navigation.ts
+++ b/client/landing/gutenboarding/hooks/use-step-navigation.ts
@@ -83,19 +83,14 @@ export default function useStepNavigation(): { goBack: () => void; goNext: () =>
 		steps = steps.filter( ( step ) => step !== Step.Domains );
 	}
 
-	// If the user landed from a marketing page after selecting a paid plan, don't show the mandatory Plans step.
-	if ( hasPaidPlanFromPath || ( plan && ! hasUsedPlansStep ) ) {
-		steps = steps.filter( ( step ) => step !== Step.Plans );
-	}
-
 	// Don't show the mandatory Plans step:
-	// - if the user landed from a marketing page after selecting a paid plan
+	// - if the user landed from a marketing page after selecting a paid plan (in this case, hide also the Features step)
 	// - if a plan has been selected using the PlansModal but only if there is no Features step
 	if (
 		hasPaidPlanFromPath ||
 		( ! steps.includes( Step.Features ) && plan && ! hasUsedPlansStep )
 	) {
-		steps = steps.filter( ( step ) => step !== Step.Plans );
+		steps = steps.filter( ( step ) => step !== Step.Plans && step !== Step.Features );
 	}
 
 	const currentStepIndex = steps.findIndex( ( step ) => step === Step[ currentStep ] );

--- a/client/landing/gutenboarding/onboarding-block/plans/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/plans/index.tsx
@@ -41,7 +41,7 @@ const PlansStep: React.FunctionComponent< Props > = ( { isModal } ) => {
 	const { setDomain, updatePlan, setHasUsedPlansStep } = useDispatch( ONBOARD_STORE );
 	React.useEffect( () => {
 		! isModal && setHasUsedPlansStep( true );
-	}, [] );
+	}, [] ); // eslint-disable-line react-hooks/exhaustive-deps
 
 	// Keep a copy of the selected plan locally so it's available when the component is unmounting
 	const selectedPlanRef = React.useRef< string | undefined >();

--- a/client/landing/gutenboarding/onboarding-block/plans/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/plans/index.tsx
@@ -95,7 +95,7 @@ const PlansStep: React.FunctionComponent< Props > = ( { isModal } ) => {
 				currentDomain={ domain }
 				onPlanSelect={ handlePlanSelect }
 				onPickDomainClick={ handlePickDomain }
-				singleColumn={ isExperimental && isEnabled( 'gutenboarding/feature-picker' ) }
+				isExperimental={ isExperimental && isEnabled( 'gutenboarding/feature-picker' ) }
 			/>
 		</div>
 	);

--- a/client/landing/gutenboarding/stores/onboard/actions.ts
+++ b/client/landing/gutenboarding/stores/onboard/actions.ts
@@ -82,10 +82,6 @@ export function* createSite(
 	return success;
 }
 
-export const enableExperimental = () => ( {
-	type: 'SET_ENABLE_EXPERIMENTAL' as const,
-} );
-
 export const removeFeature = ( featureId: FeatureId ) => ( {
 	type: 'REMOVE_FEATURE' as const,
 	featureId,
@@ -191,7 +187,6 @@ export function* updatePlan( planSlug: Plans.PlanSlug ) {
 
 export type OnboardAction = ReturnType<
 	| typeof addFeature
-	| typeof enableExperimental
 	| typeof removeFeature
 	| typeof resetFonts
 	| typeof resetOnboardStore

--- a/client/landing/gutenboarding/stores/onboard/reducer.ts
+++ b/client/landing/gutenboarding/stores/onboard/reducer.ts
@@ -78,9 +78,6 @@ const isExperimental: Reducer< boolean, OnboardAction > = (
 	state = hasExperimentalQueryParam(),
 	action
 ) => {
-	if ( action.type === 'SET_ENABLE_EXPERIMENTAL' ) {
-		return true;
-	}
 	if ( action.type === 'RESET_ONBOARD_STORE' ) {
 		return false;
 	}

--- a/packages/plans-grid/package.json
+++ b/packages/plans-grid/package.json
@@ -40,7 +40,8 @@
 		"classnames": "^2.2.6",
 		"lodash": "^4.17.15",
 		"tslib": "^1.10.0",
-		"uuid": "^7.0.2"
+		"uuid": "^7.0.2",
+		"debug": "^4.1.1"
 	},
 	"devDependencies": {
 		"@automattic/typography": "^1.0.0",

--- a/packages/plans-grid/src/plans-grid/index.tsx
+++ b/packages/plans-grid/src/plans-grid/index.tsx
@@ -26,7 +26,7 @@ export interface Props {
 	onPickDomainClick?: () => void;
 	currentDomain?: DomainSuggestions.DomainSuggestion;
 	disabledPlans?: { [ planSlug: string ]: string };
-	singleColumn?: boolean;
+	isExperimental?: boolean;
 }
 
 const PlansGrid: React.FunctionComponent< Props > = ( {
@@ -36,13 +36,13 @@ const PlansGrid: React.FunctionComponent< Props > = ( {
 	onPlanSelect,
 	onPickDomainClick,
 	disabledPlans,
-	singleColumn,
+	isExperimental,
 } ) => {
 	const { __ } = useI18n();
 
-	// Note: singleColumn prop would be always false until "gutenboarding/feature-picker" feature flag is enabled
+	// Note: isExperimental prop would be always false until "gutenboarding/feature-picker" feature flag is enabled
 	// and Gutenboarding flow is started with ?latest query param
-	singleColumn && console.log( 'display accordion' ); // eslint-disable-line no-console
+	isExperimental && console.log( 'display PlansGrid experimental version' ); // eslint-disable-line no-console
 
 	return (
 		<div className="plans-grid">

--- a/packages/plans-grid/src/plans-grid/index.tsx
+++ b/packages/plans-grid/src/plans-grid/index.tsx
@@ -5,6 +5,7 @@ import * as React from 'react';
 import { useI18n } from '@automattic/react-i18n';
 import type { Plans, DomainSuggestions } from '@automattic/data-stores';
 import { Title } from '@automattic/onboarding';
+import debugFactory from 'debug';
 
 /**
  * Internal dependencies
@@ -18,6 +19,8 @@ import PlansDetails from '../plans-details';
 import './style.scss';
 
 type PlansSlug = Plans.PlanSlug;
+
+const debug = debugFactory( 'plans-grid' );
 
 export interface Props {
 	header?: React.ReactElement;
@@ -42,7 +45,7 @@ const PlansGrid: React.FunctionComponent< Props > = ( {
 
 	// Note: isExperimental prop would be always false until "gutenboarding/feature-picker" feature flag is enabled
 	// and Gutenboarding flow is started with ?latest query param
-	isExperimental && console.log( 'display PlansGrid experimental version' ); // eslint-disable-line no-console
+	isExperimental && debug( 'PlansGrid experimental version is active' );
 
 	return (
 		<div className="plans-grid">


### PR DESCRIPTION
D49228-code should be merged to publish `wpcom-block-editor` changes.

### Changes proposed in this Pull Request
* Add support for experimental features in Site Setup.
* Use `debug` to log if the plans-grid is in experimental mode.

### Testing instructions
#### Test Site creation flow
- Go to `/new?fresh&latest`
- Open browser console and run `localStorage.setItem( 'debug', 'plans-grid' )` and then refresh.
- When reaching Plans step (or by opening PlansModal), the following debug message should be logged: `plans-grid PlansGrid experimental version is active`

#### Test Site Setup flow
- Sync wpcom-block-editor and Editing toolkit to your sandbox
- Create a site starting from `/new`. You should land in the editor.
- Sandbox the site and widgets
- Run the same debug command in console for `page.php`  
- Add `?latest` query param to the URL and refresh the page.
- Click on Complete Setup button to start Site setup flow and reproduce the last step from above when reaching _Select a plan_ step.

Fixes #44981