### PR TITLE
Fix broken 'Renew' buttons with new Jetpack plans

### DIFF
--- a/client/lib/products-values/is-plan.js
+++ b/client/lib/products-values/is-plan.js
@@ -7,6 +7,7 @@ import { isBlogger } from 'lib/products-values/is-blogger';
 import { isBusiness } from 'lib/products-values/is-business';
 import { isEcommerce } from 'lib/products-values/is-ecommerce';
 import { isEnterprise } from 'lib/products-values/is-enterprise';
+import { isJetpackPlan } from 'lib/products-values/is-jetpack-plan';
 import { isJpphpBundle } from 'lib/products-values/is-jpphp-bundle';
 import { isPersonal } from 'lib/products-values/is-personal';
 import { isPremium } from 'lib/products-values/is-premium';
@@ -22,6 +23,7 @@ export function isPlan( product ) {
 		isBusiness( product ) ||
 		isEcommerce( product ) ||
 		isEnterprise( product ) ||
+		isJetpackPlan( product ) ||
 		isJpphpBundle( product )
 	);
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR makes sure the _Renew_ buttons in the purchase page work with the new Jetpack plans.

### Implementation notes

Though the code update seems logical, I'm not sure it won't have any side effect, since `isPlan` is used in many places. A safer and more surgical implementation could be to add a condition in the `getRenewalItemFromProduct` function of `client/lib/cart-values/cart-items.js`.

### Testing instructions

- Visit the _My Plan_ page with the offer reset flow enabled and a site that has a new Jetpack plan (Security or Complete)
- Click 'Manage Plan' and land in `/me/purchases/:site/:purchaseId`
- Make sure that clicking on any of the _Renew_ button adds the plan to the cart and redirects you to the checkout page

### Screenshots

![screenshot](https://user-images.githubusercontent.com/1620183/91610518-62eefa00-e947-11ea-851f-36edbafb58cd.png)
![screenshot (1)](https://user-images.githubusercontent.com/1620183/91610521-65e9ea80-e947-11ea-8751-fee68af6f5a5.png)
