### PR TITLE
Pause Gutenboarding all users A/B test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -120,8 +120,8 @@ export default {
 	newSiteGutenbergOnboarding: {
 		datestamp: '20200818',
 		variations: {
-			gutenberg: 50,
-			control: 50,
+			gutenberg: 0,
+			control: 100,
 		},
 		defaultVariation: 'control',
 		allowExistingUsers: true,

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -236,7 +236,7 @@ export default {
 		localeExceptions: [ 'en', 'es' ],
 	},
 	existingUsersGutenbergOnboard: {
-		datestamp: '20200824',
+		datestamp: '20200828',
 		variations: {
 			gutenberg: 50,
 			control: 50,

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -131,9 +131,7 @@ export default {
 			} )
 				.then( ( { geo } ) => {
 					const countryCode = geo.data.body.country_short;
-					if ( 'gutenberg' === abtest( 'newSiteGutenbergOnboarding', countryCode ) ) {
-						gutenbergRedirect( context.params.flowName );
-					} else if (
+					if (
 						( ! user() || ! user().get() ) &&
 						-1 === context.pathname.indexOf( 'free' ) &&
 						-1 === context.pathname.indexOf( 'personal' ) &&


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Pause `newSiteGutenbergOnboarding` test (100% traffic goes to control)
* Remove the redirect from code to prevent interference with `existingUsersGutenbergOnboard`
* Update `existingUsersGutenbergOnboard` datestamp

#### Testing instructions
* Go to wordpress.com (production) and run `localStorage.setItem( 'ABTests', '{"newSiteGutenbergOnboarding_20200818":"gutenberg", "existingUsersGutenbergOnboard_20200824":"control"}' )` in browser console
* Go to [wordpress.com/start](http://wordpress.com/start) => you'll be redirected to `/new`
* Repeat the same thing on https://calypso.live/?branch=update/gutenboarding-new-site-abtest-pause => you'll continue the onboarding flow on `/start`
