### PR TITLE
[GB upgrade e2e] Fill all the popular blocks with the necessary minimum data for them to appear in the frontend and make sure each of them is displayed

### DIFF
--- a/test/e2e/lib/gutenberg/blocks/blog-posts-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/blog-posts-block-component.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { By } from 'selenium-webdriver';
+
+/**
  * Internal dependencies
  */
 import GutenbergBlockComponent from './gutenberg-block-component';
@@ -6,6 +11,9 @@ import GutenbergBlockComponent from './gutenberg-block-component';
 class BlogPostsBlockComponent extends GutenbergBlockComponent {
 	static blockTitle = 'Blog Posts';
 	static blockName = 'a8c/blog-posts';
+	static blockFrontendSelector = By.css(
+		'.entry-content .wp-block-newspack-blocks-homepage-articles'
+	);
 }
 
 export { BlogPostsBlockComponent };

--- a/test/e2e/lib/gutenberg/blocks/contact-form-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/contact-form-block-component.js
@@ -12,6 +12,7 @@ import GutenbergBlockComponent from './gutenberg-block-component';
 class ContactFormBlockComponent extends GutenbergBlockComponent {
 	static blockTitle = 'Form';
 	static blockName = 'jetpack/contact-form';
+	static blockFrontendSelector = By.css( '.entry-content .wp-block-jetpack-contact-form' );
 
 	async _postInit() {
 		return await driverHelper.clickWhenClickable(

--- a/test/e2e/lib/gutenberg/blocks/contact-info-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/contact-info-block-component.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { By } from 'selenium-webdriver';
+
+/**
  * Internal dependencies
  */
 import GutenbergBlockComponent from './gutenberg-block-component';
@@ -6,6 +11,48 @@ import GutenbergBlockComponent from './gutenberg-block-component';
 class ContactInfoBlockComponent extends GutenbergBlockComponent {
 	static blockTitle = 'Contact Info';
 	static blockName = 'jetpack/contact-info';
+
+	async fillUp( {
+		email,
+		phoneNumber,
+		streetAddress,
+		addressLine2,
+		addressLine3,
+		city,
+		state,
+		zipCode,
+		country,
+		linkToGmaps,
+	} ) {
+		const blockQuery = `div[id='${ this.blockID.slice( 1 ) }']`;
+
+		const selectField = ( name ) => By.css( `${ blockQuery } textarea[aria-label='${ name }']` );
+
+		const emailInputEl = await this.driver.findElement( selectField( 'Email' ) );
+		const phoneNumberInputEl = await this.driver.findElement( selectField( 'Phone number' ) );
+		const streetAddressInputEl = await this.driver.findElement( selectField( 'Street Address' ) );
+		const addressLine2InputEl = await this.driver.findElement( selectField( 'Address Line 2' ) );
+		const addressLine3InputEl = await this.driver.findElement( selectField( 'Address Line 3' ) );
+		const cityInputEl = await this.driver.findElement( selectField( 'City' ) );
+		const stateInputEl = await this.driver.findElement( selectField( 'State/Province/Region' ) );
+		const zipCodeInputEl = await this.driver.findElement( selectField( 'Postal/Zip Code' ) );
+		const countryInputEl = await this.driver.findElement( selectField( 'Country' ) );
+		const linkToGmapsEl = await this.driver.findElement(
+			By.css( `${ blockQuery } span.components-form-toggle` )
+		);
+
+		await emailInputEl.sendKeys( email );
+		await phoneNumberInputEl.sendKeys( phoneNumber );
+		await streetAddressInputEl.sendKeys( streetAddress );
+		await addressLine2InputEl.sendKeys( addressLine2 );
+		await addressLine3InputEl.sendKeys( addressLine3 );
+		await cityInputEl.sendKeys( city );
+		await stateInputEl.sendKeys( state );
+		await zipCodeInputEl.sendKeys( zipCode );
+		await countryInputEl.sendKeys( country );
+
+		if ( linkToGmaps ) await linkToGmapsEl.click();
+	}
 }
 
 export { ContactInfoBlockComponent };

--- a/test/e2e/lib/gutenberg/blocks/contact-info-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/contact-info-block-component.js
@@ -11,6 +11,7 @@ import GutenbergBlockComponent from './gutenberg-block-component';
 class ContactInfoBlockComponent extends GutenbergBlockComponent {
 	static blockTitle = 'Contact Info';
 	static blockName = 'jetpack/contact-info';
+	static blockFrontendSelector = By.css( '.entry-content .wp-block-jetpack-contact-info' );
 
 	async fillUp( {
 		email,

--- a/test/e2e/lib/gutenberg/blocks/dynamic-separator-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/dynamic-separator-block-component.js
@@ -20,29 +20,36 @@ class DynamicSeparatorBlockComponent extends GutenbergBlockComponent {
 	 *
 	 * @param {number} pixels the amount of pixerls to expand the HR ruler by, horizontally.
 	 */
-	async resizeTo( pixels ) {
+	async resizeBy( pixels ) {
 		// We need to move focus away from the layout grid, or any subsequent blocks inserted will be part of it
-		const thisBlockResizeHandleSelector = await this.driver.findElement(
+		const resizeHandleSelector = await this.driver.findElement(
 			By.css(
-				`div[${ this.blockID.slice(
+				`div[id='${ this.blockID.slice(
 					1
-				) }] div.components-resizable-box__handle.components-resizable-box__side-handle.components-resizable-box__handle-bottom`
+				) }'] div.components-resizable-box__handle.components-resizable-box__side-handle.components-resizable-box__handle-bottom`
 			)
 		);
 
 		const bbox = await this.driver.executeScript(
 			'return arguments[0].getBoundingClientRect()',
-			thisBlockResizeHandleSelector
+			resizeHandleSelector
 		);
 
 		const actions = await this.driver.actions( { bridge: true } );
 
+		const resizeHandleX = bbox.x + bbox.width / 2;
+		const resizeHandleY = bbox.y + bbox.height / 2;
+
 		await actions
 			.move( {
-				x: bbox.x + bbox.width / 2,
-				y: bbox.y + bbox.height / 2,
+				x: resizeHandleX,
+				y: resizeHandleY,
 			} )
-			.click()
+			.press()
+			.move( {
+				y: resizeHandleY + pixels,
+			} )
+			.release()
 			.perform();
 	}
 }

--- a/test/e2e/lib/gutenberg/blocks/dynamic-separator-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/dynamic-separator-block-component.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { By } from 'selenium-webdriver';
+
+/**
  * Internal dependencies
  */
 import GutenbergBlockComponent from './gutenberg-block-component';
@@ -6,6 +11,7 @@ import GutenbergBlockComponent from './gutenberg-block-component';
 class DynamicSeparatorBlockComponent extends GutenbergBlockComponent {
 	static blockTitle = 'Dynamic HR';
 	static blockName = 'coblocks/dynamic-separator';
+	static blockFrontendSelector = By.css( '.entry-content .wp-block-coblocks-dynamic-separator' );
 }
 
 export { DynamicSeparatorBlockComponent };

--- a/test/e2e/lib/gutenberg/blocks/dynamic-separator-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/dynamic-separator-block-component.js
@@ -12,6 +12,39 @@ class DynamicSeparatorBlockComponent extends GutenbergBlockComponent {
 	static blockTitle = 'Dynamic HR';
 	static blockName = 'coblocks/dynamic-separator';
 	static blockFrontendSelector = By.css( '.entry-content .wp-block-coblocks-dynamic-separator' );
+
+	/**
+	 * Expands the horizontal ruler by the amount of pixels specified. This is useful
+	 * to test the functionality of the Dynamic HR in the editor and later in the
+	 * frontend too.
+	 *
+	 * @param {number} pixels the amount of pixerls to expand the HR ruler by, horizontally.
+	 */
+	async resizeTo( pixels ) {
+		// We need to move focus away from the layout grid, or any subsequent blocks inserted will be part of it
+		const thisBlockResizeHandleSelector = await this.driver.findElement(
+			By.css(
+				`div[${ this.blockID.slice(
+					1
+				) }] div.components-resizable-box__handle.components-resizable-box__side-handle.components-resizable-box__handle-bottom`
+			)
+		);
+
+		const bbox = await this.driver.executeScript(
+			'return arguments[0].getBoundingClientRect()',
+			thisBlockResizeHandleSelector
+		);
+
+		const actions = await this.driver.actions( { bridge: true } );
+
+		await actions
+			.move( {
+				x: bbox.x + bbox.width / 2,
+				y: bbox.y + bbox.height / 2,
+			} )
+			.click()
+			.perform();
+	}
 }
 
 export { DynamicSeparatorBlockComponent };

--- a/test/e2e/lib/gutenberg/blocks/dynamic-separator-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/dynamic-separator-block-component.js
@@ -37,8 +37,9 @@ class DynamicSeparatorBlockComponent extends GutenbergBlockComponent {
 
 		const actions = await this.driver.actions( { bridge: true } );
 
-		const resizeHandleX = bbox.x + bbox.width / 2;
-		const resizeHandleY = bbox.y + bbox.height / 2;
+		// The move function only accepts integers and will fail on floats
+		const resizeHandleX = Math.trunc( bbox.x + bbox.width / 2 );
+		const resizeHandleY = Math.trunc( bbox.y + bbox.height / 2 );
 
 		await actions
 			.move( {

--- a/test/e2e/lib/gutenberg/blocks/gallery-masonry-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/gallery-masonry-block-component.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { By } from 'selenium-webdriver';
+
+/**
  * Internal dependencies
  */
 import GutenbergBlockComponent from './gutenberg-block-component';
@@ -6,6 +11,7 @@ import GutenbergBlockComponent from './gutenberg-block-component';
 class GalleryMasonryBlockComponent extends GutenbergBlockComponent {
 	static blockTitle = 'Masonry';
 	static blockName = 'coblocks/gallery-masonry';
+	static blockFrontendSelector = By.css( '.entry-content .wp-block-coblocks-gallery-masonry' );
 }
 
 export { GalleryMasonryBlockComponent };

--- a/test/e2e/lib/gutenberg/blocks/gallery-masonry-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/gallery-masonry-block-component.js
@@ -12,6 +12,24 @@ class GalleryMasonryBlockComponent extends GutenbergBlockComponent {
 	static blockTitle = 'Masonry';
 	static blockName = 'coblocks/gallery-masonry';
 	static blockFrontendSelector = By.css( '.entry-content .wp-block-coblocks-gallery-masonry' );
+
+	/**
+	 * Uploads images to the gallery.
+	 *
+	 * NOTE/TODO This is common to a few gallery-like blocks. DRY it using a mixin or common base class.
+	 *
+	 * @param {{imageName: string, fileName: string, file: string}} filesDetails a list of fileDetails
+	 */
+	async uploadImages( filesDetails ) {
+		// TODO Simplify this selector, given the block ID, a simpler CSS selector will work here
+		const fileInputSelector = By.css( `div[id="${ this.blockID.slice( 1 ) }"] input[type=file]` );
+
+		const fileInput = this.driver.findElement( fileInputSelector );
+
+		const files = filesDetails.map( ( f ) => f.file ).join( '\n ' );
+
+		fileInput.sendKeys( files );
+	}
 }
 
 export { GalleryMasonryBlockComponent };

--- a/test/e2e/lib/gutenberg/blocks/gallery-masonry-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/gallery-masonry-block-component.js
@@ -21,7 +21,6 @@ class GalleryMasonryBlockComponent extends GutenbergBlockComponent {
 	 * @param {{imageName: string, fileName: string, file: string}} filesDetails a list of fileDetails
 	 */
 	async uploadImages( filesDetails ) {
-		// TODO Simplify this selector, given the block ID, a simpler CSS selector will work here
 		const fileInputSelector = By.css( `div[id="${ this.blockID.slice( 1 ) }"] input[type=file]` );
 
 		const fileInput = this.driver.findElement( fileInputSelector );

--- a/test/e2e/lib/gutenberg/blocks/layout-grid-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/layout-grid-block-component.js
@@ -61,13 +61,13 @@ class LayoutGridBlockComponent extends GutenbergBlockComponent {
 		const blockId = await this.driver.findElement( insertedBlockSelector ).getAttribute( 'id' );
 
 		// We need to move focus away from the layout grid, or any subsequent blocks inserted will be part of it
-		const blockAppenderWrapper = await this.driver.findElement(
+		const blockAppenderWrapperSelector = await this.driver.findElement(
 			By.css( '.interface-interface-skeleton__content' )
 		);
 
 		const blockAppenderWrapperBox = await this.driver.executeScript(
 			'return arguments[0].getBoundingClientRect()',
-			blockAppenderWrapper
+			blockAppenderWrapperSelector
 		);
 
 		const actions = await this.driver.actions( { bridge: true } );

--- a/test/e2e/lib/gutenberg/blocks/layout-grid-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/layout-grid-block-component.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { By, Actions } from 'selenium-webdriver';
+import { By } from 'selenium-webdriver';
 
 /**
  * Internal dependencies
@@ -12,6 +12,7 @@ import * as driverHelper from '../../driver-helper';
 class LayoutGridBlockComponent extends GutenbergBlockComponent {
 	static blockTitle = 'Layout Grid';
 	static blockName = 'jetpack/layout-grid';
+	static blockFrontendSelector = By.css( '.entry-content .wp-block-jetpack-layout-grid' );
 
 	async setupColumns( no ) {
 		const columnButtonSelector = By.css( `${ this.blockID } button[aria-label="${ no } columns"]` );

--- a/test/e2e/lib/gutenberg/blocks/layout-grid-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/layout-grid-block-component.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { By } from 'selenium-webdriver';
+import { By, Actions } from 'selenium-webdriver';
 
 /**
  * Internal dependencies
@@ -64,6 +64,26 @@ class LayoutGridBlockComponent extends GutenbergBlockComponent {
 			`.wp-block-jetpack-layout-grid .block-editor-block-list__block[aria-label='Block: ${ blockClass.blockTitle }']`
 		);
 		const blockId = await this.driver.findElement( insertedBlockSelector ).getAttribute( 'id' );
+
+		// We need to move focus away from the layout grid, or any subsequent blocks inserted will be part of it
+		const blockAppenderWrapper = await this.driver.findElement(
+			By.css( '.interface-interface-skeleton__content' )
+		);
+
+		const blockAppenderWrapperBox = await this.driver.executeScript(
+			'return arguments[0].getBoundingClientRect()',
+			blockAppenderWrapper
+		);
+
+		const actions = await this.driver.actions( { bridge: true } );
+
+		await actions
+			.move( {
+				x: blockAppenderWrapperBox.x + blockAppenderWrapperBox.width / 2,
+				y: blockAppenderWrapperBox.bottom - 50,
+			} )
+			.click()
+			.perform();
 
 		return blockClass.Expect( this.driver, blockId );
 	}

--- a/test/e2e/lib/gutenberg/blocks/layout-grid-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/layout-grid-block-component.js
@@ -13,11 +13,6 @@ class LayoutGridBlockComponent extends GutenbergBlockComponent {
 	static blockTitle = 'Layout Grid';
 	static blockName = 'jetpack/layout-grid';
 
-	// TODO Simplify this selector, given the block ID, a simpler CSS selector will work here
-	fileInputSelector = By.xpath(
-		`//*[@id="${ this.blockID.slice( 1 ) }"]/div/div/div[3]/div[2]/input`
-	);
-
 	async setupColumns( no ) {
 		const columnButtonSelector = By.css( `${ this.blockID } button[aria-label="${ no } columns"]` );
 		await driverHelper.clickWhenClickable( this.driver, columnButtonSelector );

--- a/test/e2e/lib/gutenberg/blocks/layout-grid-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/layout-grid-block-component.js
@@ -1,11 +1,72 @@
 /**
+ * External dependencies
+ */
+import { By } from 'selenium-webdriver';
+
+/**
  * Internal dependencies
  */
 import GutenbergBlockComponent from './gutenberg-block-component';
+import * as driverHelper from '../../driver-helper';
 
 class LayoutGridBlockComponent extends GutenbergBlockComponent {
 	static blockTitle = 'Layout Grid';
 	static blockName = 'jetpack/layout-grid';
+
+	// TODO Simplify this selector, given the block ID, a simpler CSS selector will work here
+	fileInputSelector = By.xpath(
+		`//*[@id="${ this.blockID.slice( 1 ) }"]/div/div/div[3]/div[2]/input`
+	);
+
+	async setupColumns( no ) {
+		const columnButtonSelector = By.css( `${ this.blockID } button[aria-label="${ no } columns"]` );
+		await driverHelper.clickWhenClickable( this.driver, columnButtonSelector );
+	}
+
+	/**
+	 * Inserts a block into the specified grid column using the Quick Inserter.
+	 *
+	 * I'm not sure if this belongs here or extracted into a method in the GutenbergEditorComponent or maybe
+	 * its own QuickInserter class. I'll figure out later.
+	 * Also, the block wrapper div changes after you setup the number of columns you want. This makes it tricky
+	 * to scope the elements to the original block. I'm for now brute-forcing the selection by using a more
+	 * general selector.
+	 *
+	 * This probably won't support multiple instances of the same block. It hasn't been tested
+	 * with multiple layout grids on the page either, but it works fine for simple scenarios.
+	 *
+	 * @param { typeof GutenbergBlockComponent } blockClass A block class that responds to blockTitle and blockName
+	 * @param { number } column number to insert it into, from left to right, starts with 0.
+	 * @returns { GutenbergBlockComponent } instance of the added block
+	 **/
+	async insertBlock( blockClass, column ) {
+		const addColumnButtonsSelector = By.css(
+			`.wp-block-jetpack-layout-grid button[aria-label="Add block"]`
+		);
+		const allButtons = await this.driver.findElements( addColumnButtonsSelector );
+
+		await allButtons[ column ].click();
+
+		const inserterSearchInputSelector = By.css( 'input.block-editor-inserter__search-input' );
+
+		await driverHelper.setWhenSettable(
+			this.driver,
+			inserterSearchInputSelector,
+			blockClass.blockTitle
+		);
+
+		await driverHelper.clickWhenClickable(
+			this.driver,
+			By.css( `button.editor-block-list-item-${ blockClass.blockName.replace( '/', '-' ) }` )
+		);
+
+		const insertedBlockSelector = By.css(
+			`.wp-block-jetpack-layout-grid .block-editor-block-list__block[aria-label='Block: ${ blockClass.blockTitle }']`
+		);
+		const blockId = await this.driver.findElement( insertedBlockSelector ).getAttribute( 'id' );
+
+		return blockClass.Expect( this.driver, blockId );
+	}
 }
 
 export { LayoutGridBlockComponent };

--- a/test/e2e/lib/gutenberg/blocks/layout-grid-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/layout-grid-block-component.js
@@ -17,17 +17,15 @@ class LayoutGridBlockComponent extends GutenbergBlockComponent {
 	async setupColumns( no ) {
 		const columnButtonSelector = By.css( `${ this.blockID } button[aria-label="${ no } columns"]` );
 		await driverHelper.clickWhenClickable( this.driver, columnButtonSelector );
+
+		// Updates the blockId, since the block is replaced by another one upon the selection of the columns.
+		this.blockID = await this.driver
+			.findElement( By.css( 'div.block-editor-block-list__block.is-selected' ) )
+			.getAttribute( 'id' );
 	}
 
 	/**
 	 * Inserts a block into the specified grid column using the Quick Inserter.
-	 *
-	 * The block wrapper div changes after you setup the number of columns you want. This makes it tricky
-	 * to scope the elements to the original block. I'm for now brute-forcing the selection by using a more
-	 * general selector.
-	 *
-	 * This probably won't support multiple instances of the same block. It hasn't been tested
-	 * with multiple layout grids on the page either, but it works fine for simple scenarios.
 	 *
 	 * @param { typeof GutenbergBlockComponent } blockClass A block class that responds to blockTitle and blockName
 	 * @param { number } column number to insert it into, from left to right, starts with 0.
@@ -35,7 +33,7 @@ class LayoutGridBlockComponent extends GutenbergBlockComponent {
 	 **/
 	async insertBlock( blockClass, column ) {
 		const addColumnButtonsSelector = By.css(
-			`.wp-block-jetpack-layout-grid button[aria-label="Add block"]`
+			`div[id="${ this.blockID }"] div.wp-block-jetpack-layout-grid button[aria-label="Add block"]`
 		);
 		const allButtons = await this.driver.findElements( addColumnButtonsSelector );
 
@@ -61,7 +59,7 @@ class LayoutGridBlockComponent extends GutenbergBlockComponent {
 		);
 
 		const insertedBlockSelector = By.css(
-			`.wp-block-jetpack-layout-grid .block-editor-block-list__block[aria-label='Block: ${ blockClass.blockTitle }']`
+			`div[id="${ this.blockID }"] div.wp-block-jetpack-layout-grid .block-editor-block-list__block[aria-label='Block: ${ blockClass.blockTitle }']`
 		);
 		const blockId = await this.driver.findElement( insertedBlockSelector ).getAttribute( 'id' );
 

--- a/test/e2e/lib/gutenberg/blocks/layout-grid-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/layout-grid-block-component.js
@@ -14,6 +14,13 @@ class LayoutGridBlockComponent extends GutenbergBlockComponent {
 	static blockName = 'jetpack/layout-grid';
 	static blockFrontendSelector = By.css( '.entry-content .wp-block-jetpack-layout-grid' );
 
+	/**
+	 * Setups the number of columns for the layout grid block.
+	 *
+	 * This needs to be called before you call @see {@link insertBlock}.
+	 *
+	 * @param {number} no number of columns, 1 to 4 (based on the default buttons in the block).
+	 */
 	async setupColumns( no ) {
 		const columnButtonSelector = By.css( `${ this.blockID } button[aria-label="${ no } columns"]` );
 		await driverHelper.clickWhenClickable( this.driver, columnButtonSelector );
@@ -22,22 +29,25 @@ class LayoutGridBlockComponent extends GutenbergBlockComponent {
 		this.blockID = await this.driver
 			.findElement( By.css( 'div.block-editor-block-list__block.is-selected' ) )
 			.getAttribute( 'id' );
+
+		const addColumnButtonsSelector = By.css(
+			`div[id="${ this.blockID }"] div.wp-block-jetpack-layout-grid button[aria-label="Add block"]`
+		);
+
+		this.addBlockButtons = await this.driver.findElements( addColumnButtonsSelector );
 	}
 
 	/**
 	 * Inserts a block into the specified grid column using the Quick Inserter.
+	 *
+	 * You must call @see {@link setupColumns} before inserting an inner block using this method.
 	 *
 	 * @param { typeof GutenbergBlockComponent } blockClass A block class that responds to blockTitle and blockName
 	 * @param { number } column number to insert it into, from left to right, starts with 0.
 	 * @returns { GutenbergBlockComponent } instance of the added block
 	 **/
 	async insertBlock( blockClass, column ) {
-		const addColumnButtonsSelector = By.css(
-			`div[id="${ this.blockID }"] div.wp-block-jetpack-layout-grid button[aria-label="Add block"]`
-		);
-		const allButtons = await this.driver.findElements( addColumnButtonsSelector );
-
-		await allButtons[ column ].click();
+		await this.addBlockButtons[ column ].click();
 
 		const inserterSearchInputSelector = By.css( 'input.block-editor-inserter__search-input' );
 

--- a/test/e2e/lib/gutenberg/blocks/layout-grid-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/layout-grid-block-component.js
@@ -43,11 +43,12 @@ class LayoutGridBlockComponent extends GutenbergBlockComponent {
 	 * You must call @see {@link setupColumns} before inserting an inner block using this method.
 	 *
 	 * @param { typeof GutenbergBlockComponent } blockClass A block class that responds to blockTitle and blockName
-	 * @param { number } column number to insert it into, from left to right, starts with 0.
+	 * @param { number } column number to insert it into, from left to right, starts with 1 (to make it more natural based on the
+	 * input for the `setupColumns` method).
 	 * @returns { GutenbergBlockComponent } instance of the added block
 	 **/
 	async insertBlock( blockClass, column ) {
-		await this.addBlockButtons[ column ].click();
+		await this.addBlockButtons[ column - 1 ].click();
 
 		const inserterSearchInputSelector = By.css( 'input.block-editor-inserter__search-input' );
 

--- a/test/e2e/lib/gutenberg/blocks/layout-grid-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/layout-grid-block-component.js
@@ -22,9 +22,7 @@ class LayoutGridBlockComponent extends GutenbergBlockComponent {
 	/**
 	 * Inserts a block into the specified grid column using the Quick Inserter.
 	 *
-	 * I'm not sure if this belongs here or extracted into a method in the GutenbergEditorComponent or maybe
-	 * its own QuickInserter class. I'll figure out later.
-	 * Also, the block wrapper div changes after you setup the number of columns you want. This makes it tricky
+	 * The block wrapper div changes after you setup the number of columns you want. This makes it tricky
 	 * to scope the elements to the original block. I'm for now brute-forcing the selection by using a more
 	 * general selector.
 	 *
@@ -44,6 +42,12 @@ class LayoutGridBlockComponent extends GutenbergBlockComponent {
 		await allButtons[ column ].click();
 
 		const inserterSearchInputSelector = By.css( 'input.block-editor-inserter__search-input' );
+
+		await driverHelper.waitTillPresentAndDisplayed(
+			this.driver,
+			By.css( 'div.block-editor-inserter__quick-inserter.has-search.has-expand' ),
+			3000
+		);
 
 		await driverHelper.setWhenSettable(
 			this.driver,
@@ -75,8 +79,8 @@ class LayoutGridBlockComponent extends GutenbergBlockComponent {
 
 		await actions
 			.move( {
-				x: blockAppenderWrapperBox.x + blockAppenderWrapperBox.width / 2,
-				y: blockAppenderWrapperBox.bottom - 50,
+				x: Math.trunc( blockAppenderWrapperBox.x + blockAppenderWrapperBox.width / 2 ),
+				y: Math.trunc( blockAppenderWrapperBox.bottom - 50 ),
 			} )
 			.click()
 			.perform();

--- a/test/e2e/lib/gutenberg/blocks/layout-grid-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/layout-grid-block-component.js
@@ -29,26 +29,25 @@ class LayoutGridBlockComponent extends GutenbergBlockComponent {
 		this.blockID = await this.driver
 			.findElement( By.css( 'div.block-editor-block-list__block.is-selected' ) )
 			.getAttribute( 'id' );
-
-		const addColumnButtonsSelector = By.css(
-			`div[id="${ this.blockID }"] div.wp-block-jetpack-layout-grid button[aria-label="Add block"]`
-		);
-
-		this.addBlockButtons = await this.driver.findElements( addColumnButtonsSelector );
 	}
 
 	/**
-	 * Inserts a block into the specified grid column using the Quick Inserter.
+	 * Inserts a block in the last available grid for the layout grid.
 	 *
 	 * You must call @see {@link setupColumns} before inserting an inner block using this method.
 	 *
+	 * This will add to each column in sequence, from left to right.
+	 *
 	 * @param { typeof GutenbergBlockComponent } blockClass A block class that responds to blockTitle and blockName
-	 * @param { number } column number to insert it into, from left to right, starts with 1 (to make it more natural based on the
-	 * input for the `setupColumns` method).
 	 * @returns { GutenbergBlockComponent } instance of the added block
 	 **/
-	async insertBlock( blockClass, column ) {
-		await this.addBlockButtons[ column - 1 ].click();
+	async insertBlock( blockClass ) {
+		const addColumnButtonsSelector = By.css(
+			`div[id="${ this.blockID }"] div.wp-block-jetpack-layout-grid button[aria-label="Add block"]`
+		);
+		const buttons = await this.driver.findElements( addColumnButtonsSelector );
+
+		await buttons[ 0 ].click();
 
 		const inserterSearchInputSelector = By.css( 'input.block-editor-inserter__search-input' );
 

--- a/test/e2e/lib/gutenberg/blocks/rating-star-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/rating-star-block-component.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { By } from 'selenium-webdriver';
+
+/**
  * Internal dependencies
  */
 import GutenbergBlockComponent from './gutenberg-block-component';
@@ -6,6 +11,7 @@ import GutenbergBlockComponent from './gutenberg-block-component';
 class RatingStarBlockComponent extends GutenbergBlockComponent {
 	static blockTitle = 'Star Rating';
 	static blockName = 'jetpack/rating-star';
+	static blockFrontendSelector = By.css( '.entry-content .wp-block-jetpack-rating-star' );
 }
 
 export { RatingStarBlockComponent };

--- a/test/e2e/lib/gutenberg/blocks/rating-star-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/rating-star-block-component.js
@@ -7,6 +7,7 @@ import { By } from 'selenium-webdriver';
  * Internal dependencies
  */
 import GutenbergBlockComponent from './gutenberg-block-component';
+import * as driverHelper from '../../driver-helper';
 
 class RatingStarBlockComponent extends GutenbergBlockComponent {
 	static blockTitle = 'Star Rating';

--- a/test/e2e/lib/gutenberg/blocks/rating-star-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/rating-star-block-component.js
@@ -7,7 +7,6 @@ import { By } from 'selenium-webdriver';
  * Internal dependencies
  */
 import GutenbergBlockComponent from './gutenberg-block-component';
-import * as driverHelper from '../../driver-helper';
 
 class RatingStarBlockComponent extends GutenbergBlockComponent {
 	static blockTitle = 'Star Rating';

--- a/test/e2e/lib/gutenberg/blocks/slideshow-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/slideshow-block-component.js
@@ -12,6 +12,11 @@ class SlideshowBlockComponent extends GutenbergBlockComponent {
 	static blockTitle = 'Slideshow';
 	static blockName = 'jetpack/slideshow';
 
+	/**
+	 * Uploads images to the slideshow.
+	 *
+	 * @param {{imageName: string, fileName: string, file: string}} filesDetails a list of fileDetails
+	 */
 	async uploadImages( filesDetails ) {
 		// TODO Simplify this selector, given the block ID, a simpler CSS selector will work here
 		const fileInputSelector = By.css( `div[id="${ this.blockID.slice( 1 ) }"] input[type=file]` );

--- a/test/e2e/lib/gutenberg/blocks/slideshow-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/slideshow-block-component.js
@@ -11,6 +11,7 @@ import GutenbergBlockComponent from './gutenberg-block-component';
 class SlideshowBlockComponent extends GutenbergBlockComponent {
 	static blockTitle = 'Slideshow';
 	static blockName = 'jetpack/slideshow';
+	static blockFrontendSelector = By.css( '.entry-content .wp-block-jetpack-slideshow' );
 
 	/**
 	 * Uploads images to the slideshow.

--- a/test/e2e/lib/gutenberg/blocks/slideshow-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/slideshow-block-component.js
@@ -19,7 +19,6 @@ class SlideshowBlockComponent extends GutenbergBlockComponent {
 	 * @param {{imageName: string, fileName: string, file: string}} filesDetails a list of fileDetails
 	 */
 	async uploadImages( filesDetails ) {
-		// TODO Simplify this selector, given the block ID, a simpler CSS selector will work here
 		const fileInputSelector = By.css( `div[id="${ this.blockID.slice( 1 ) }"] input[type=file]` );
 
 		const fileInput = this.driver.findElement( fileInputSelector );

--- a/test/e2e/lib/gutenberg/blocks/slideshow-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/slideshow-block-component.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { By } from 'selenium-webdriver';
+
+/**
  * Internal dependencies
  */
 import GutenbergBlockComponent from './gutenberg-block-component';
@@ -6,6 +11,17 @@ import GutenbergBlockComponent from './gutenberg-block-component';
 class SlideshowBlockComponent extends GutenbergBlockComponent {
 	static blockTitle = 'Slideshow';
 	static blockName = 'jetpack/slideshow';
+
+	async uploadImages( filesDetails ) {
+		// TODO Simplify this selector, given the block ID, a simpler CSS selector will work here
+		const fileInputSelector = By.css( `div[id="${ this.blockID.slice( 1 ) }"] input[type=file]` );
+
+		const fileInput = this.driver.findElement( fileInputSelector );
+
+		const files = filesDetails.map( ( f ) => f.file ).join( '\n ' );
+
+		fileInput.sendKeys( files );
+	}
 }
 
 export { SlideshowBlockComponent };

--- a/test/e2e/lib/gutenberg/blocks/subscriptions-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/subscriptions-block-component.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { By } from 'selenium-webdriver';
+
+/**
  * Internal dependencies
  */
 import GutenbergBlockComponent from './gutenberg-block-component';
@@ -6,6 +11,7 @@ import GutenbergBlockComponent from './gutenberg-block-component';
 class SubscriptionsBlockComponent extends GutenbergBlockComponent {
 	static blockTitle = 'Subscription Form';
 	static blockName = 'jetpack/subscriptions';
+	static blockFrontendSelector = By.css( '.entry-content .wp-block-jetpack-subscriptions' );
 }
 
 export { SubscriptionsBlockComponent };

--- a/test/e2e/lib/gutenberg/blocks/tiled-gallery-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/tiled-gallery-block-component.js
@@ -13,6 +13,7 @@ class TiledGalleryBlockComponent extends GutenbergBlockComponent {
 	static blockName = 'jetpack/tiled-gallery';
 	static blockFrontendSelector = By.css( '.entry-content .wp-block-jetpack-tiled-gallery' );
 
+	// TODO Simplify this selector, given the block ID, a simpler CSS selector will work here
 	fileInputSelector = By.xpath(
 		`//*[@id="${ this.blockID.slice( 1 ) }"]/div/div/div[3]/div[2]/input`
 	);

--- a/test/e2e/lib/gutenberg/blocks/tiled-gallery-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/tiled-gallery-block-component.js
@@ -13,13 +13,13 @@ class TiledGalleryBlockComponent extends GutenbergBlockComponent {
 	static blockName = 'jetpack/tiled-gallery';
 	static blockFrontendSelector = By.css( '.entry-content .wp-block-jetpack-tiled-gallery' );
 
-	// TODO Simplify this selector, given the block ID, a simpler CSS selector will work here
-	fileInputSelector = By.xpath(
-		`//*[@id="${ this.blockID.slice( 1 ) }"]/div/div/div[3]/div[2]/input`
-	);
-
 	async uploadImages( filesDetails ) {
-		const fileInput = this.driver.findElement( this.fileInputSelector );
+		// TODO Simplify this selector, given the block ID, a simpler CSS selector will work here
+		const fileInputSelector = By.xpath(
+			`//*[@id="${ this.blockID.slice( 1 ) }"]/div/div/div[3]/div[2]/input`
+		);
+
+		const fileInput = this.driver.findElement( fileInputSelector );
 
 		const files = filesDetails.map( ( f ) => f.file ).join( '\n ' );
 

--- a/test/e2e/lib/gutenberg/blocks/tiled-gallery-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/tiled-gallery-block-component.js
@@ -19,7 +19,6 @@ class TiledGalleryBlockComponent extends GutenbergBlockComponent {
 	 * @param {{imageName: string, fileName: string, file: string}} filesDetails a list of fileDetails
 	 */
 	async uploadImages( filesDetails ) {
-		// TODO Simplify this selector, given the block ID, a simpler CSS selector will work here
 		const fileInputSelector = By.xpath(
 			`//*[@id="${ this.blockID.slice( 1 ) }"]/div/div/div[3]/div[2]/input`
 		);

--- a/test/e2e/lib/gutenberg/blocks/tiled-gallery-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/tiled-gallery-block-component.js
@@ -13,6 +13,11 @@ class TiledGalleryBlockComponent extends GutenbergBlockComponent {
 	static blockName = 'jetpack/tiled-gallery';
 	static blockFrontendSelector = By.css( '.entry-content .wp-block-jetpack-tiled-gallery' );
 
+	/**
+	 * Uploads images to the gallery.
+	 *
+	 * @param {{imageName: string, fileName: string, file: string}} filesDetails a list of fileDetails
+	 */
 	async uploadImages( filesDetails ) {
 		// TODO Simplify this selector, given the block ID, a simpler CSS selector will work here
 		const fileInputSelector = By.xpath(

--- a/test/e2e/lib/gutenberg/blocks/tiled-gallery-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/tiled-gallery-block-component.js
@@ -11,6 +11,7 @@ import GutenbergBlockComponent from './gutenberg-block-component';
 class TiledGalleryBlockComponent extends GutenbergBlockComponent {
 	static blockTitle = 'Tiled Gallery';
 	static blockName = 'jetpack/tiled-gallery';
+	static blockFrontendSelector = By.css( '.entry-content .wp-block-jetpack-tiled-gallery' );
 
 	fileInputSelector = By.xpath(
 		`//*[@id="${ this.blockID.slice( 1 ) }"]/div/div/div[3]/div[2]/input`

--- a/test/e2e/lib/gutenberg/blocks/youtube-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/youtube-block-component.js
@@ -5,7 +5,7 @@ import GutenbergBlockComponent from './gutenberg-block-component';
 
 class YoutubeBlockComponent extends GutenbergBlockComponent {
 	static blockTitle = 'YouTube';
-	static blockName = 'core-embed/youtube';
+	static blockName = 'core/embed';
 }
 
 export { YoutubeBlockComponent };

--- a/test/e2e/lib/gutenberg/blocks/youtube-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/youtube-block-component.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { By } from 'selenium-webdriver';
+
+/**
  * Internal dependencies
  */
 import GutenbergBlockComponent from './gutenberg-block-component';
@@ -6,6 +11,23 @@ import GutenbergBlockComponent from './gutenberg-block-component';
 class YoutubeBlockComponent extends GutenbergBlockComponent {
 	static blockTitle = 'YouTube';
 	static blockName = 'core/embed';
+	static blockFrontendSelector = By.css(
+		'.entry-content figure.wp-block-embed iframe.youtube-player'
+	);
+
+	async embed( videoURL ) {
+		const blockDivSelector = `div[id='${ this.blockID.slice( 1 ) }']`;
+
+		const embedInput = await this.driver.findElement(
+			By.css( `${ blockDivSelector } input[type='url']` )
+		);
+		const embedButton = await this.driver.findElement(
+			By.css( `${ blockDivSelector } button[type='submit']` )
+		);
+
+		await embedInput.sendKeys( videoURL );
+		await embedButton.click();
+	}
 }
 
 export { YoutubeBlockComponent };

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -149,24 +149,23 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		return contactFormBlock.insertSubject( subject );
 	}
 
-	toggleMoreToolsAndOptions() {
-		return driverHelper.clickWhenClickable(
+	async toggleMoreToolsAndOptions() {
+		await driverHelper.clickWhenClickable(
 			this.driver,
 			By.xpath( "//button[@aria-label='More tools & options']" )
 		);
+		await this.driver.sleep( 1000 );
 	}
 
 	async switchToCodeView() {
 		await this.toggleMoreToolsAndOptions();
 
-		// Now click to switch to the code editor
 		await driverHelper.clickWhenClickable(
 			this.driver,
 			By.xpath( "//div[@aria-label='More tools & options']/div[2]/div[2]/button[2]" )
 		);
 
 		const textAreaSelector = By.css( 'textarea.editor-post-text-editor' );
-
 		await driverHelper.waitTillPresentAndDisplayed( this.driver, textAreaSelector );
 
 		// close the menu

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -378,7 +378,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	 * You can just import the class of the block(s) you want to add and pass it to this function, which
 	 * also means we don't need to couple the block class with this one.
 	 *
-	 * @param { GutenbergBlockComponent } blockClass A block class that responds to title and name
+	 * @param { typeof GutenbergBlockComponent } blockClass A block class that responds to title and name
 	 */
 	async insertBlock( blockClass ) {
 		const blockID = await this.addBlock( blockClass.blockTitle );

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -354,6 +354,10 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		const inserterBlockItemSelector = By.css(
 			`.edit-post-layout__inserter-panel .block-editor-inserter__block-list button.editor-block-list-item-${ prefix }${ blockClass }`
 		);
+
+		// NOTE This could be a helper method in the block class? (start moving this knowledge over to blocks and not here...)
+		// alongisde the logic in the switch above, this method could be greatly simplified if the data needed here could be queried
+		// from the block class or a helper method that can get it from the block class (see the existing statics there for reference).
 		const insertedBlockSelector = By.css(
 			`.block-editor-block-list__block.${
 				hasChildBlocks ? 'has-child-selected' : 'is-selected'

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -152,8 +152,9 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	async toggleMoreToolsAndOptions() {
 		await driverHelper.clickWhenClickable(
 			this.driver,
-			By.xpath( "//button[@aria-label='More tools & options']" )
+			By.xpath( "//button[@aria-label='More tools & options' or @aria-label='Options']" )
 		);
+
 		await this.driver.sleep( 1000 );
 	}
 
@@ -162,7 +163,9 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 
 		await driverHelper.clickWhenClickable(
 			this.driver,
-			By.xpath( "//div[@aria-label='More tools & options']/div[2]/div[2]/button[2]" )
+			By.xpath(
+				"//div[@aria-label='More tools & options' or @aria-label='Options']/div[2]/div[2]/button[2]"
+			)
 		);
 
 		const textAreaSelector = By.css( 'textarea.editor-post-text-editor' );
@@ -179,7 +182,9 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 
 		await driverHelper.clickWhenClickable(
 			this.driver,
-			By.xpath( "//div[@aria-label='More tools & options']/div[2]/div[2]/button[1]" )
+			By.xpath(
+				"//div[@aria-label='More tools & options' or @aria-label='Options']/div[2]/div[2]/button[1]"
+			)
 		);
 
 		// close the menu
@@ -410,15 +415,28 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	}
 
 	async removeBlock( blockID ) {
-		const blockSelector = By.css( `.wp-block[id="${blockID}"]`);
-		await driverHelper.isEventuallyPresentAndDisplayed( this.driver, blockSelector, this.explicitWaitMS / 5 );
+		const blockSelector = By.css( `.wp-block[id="${ blockID }"]` );
+		await driverHelper.isEventuallyPresentAndDisplayed(
+			this.driver,
+			blockSelector,
+			this.explicitWaitMS / 5
+		);
 		await this.driver.findElement( blockSelector ).click();
-		await driverHelper.clickWhenClickable( this.driver, By.css( '.block-editor-block-settings-menu' ) );
-		await driverHelper.isEventuallyPresentAndDisplayed( this.driver, By.css( '.components-menu-group' ), this.explicitWaitMS / 5 );
+		await driverHelper.clickWhenClickable(
+			this.driver,
+			By.css( '.block-editor-block-settings-menu' )
+		);
+		await driverHelper.isEventuallyPresentAndDisplayed(
+			this.driver,
+			By.css( '.components-menu-group' ),
+			this.explicitWaitMS / 5
+		);
 		await this.driver.sleep( 1000 );
 		return await driverHelper.clickWhenClickable(
 			this.driver,
-			By.css( '.components-menu-group:last-of-type button.components-menu-item__button:last-of-type' )
+			By.css(
+				'.components-menu-group:last-of-type button.components-menu-item__button:last-of-type'
+			)
 		);
 	}
 

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -217,8 +217,10 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	}
 
 	async errorDisplayed() {
-		await this.driver.sleep( 1000 );
-		return await driverHelper.isElementPresent( this.driver, By.css( '.editor-error-boundary' ) );
+		return driverHelper.isEventuallyPresentAndDisplayed(
+			this.driver,
+			By.css( '.editor-error-boundary' )
+		);
 	}
 
 	async hasInvalidBlocks() {

--- a/test/e2e/lib/media-helper.js
+++ b/test/e2e/lib/media-helper.js
@@ -83,8 +83,6 @@ export function writeScreenshot( data, filenameCallback, metadata ) {
 		fs.mkdirSync( screenshotsDir );
 	}
 
-	console.debug( '**** writeScreenshot.screenshotDir =', screenshotsDir );
-
 	if ( typeof filenameCallback === 'function' ) {
 		filename = filenameCallback();
 	} else {
@@ -92,7 +90,6 @@ export function writeScreenshot( data, filenameCallback, metadata ) {
 	}
 	const screenshotPath = `${ screenshotsDir }/${ filename }.png`;
 
-	console.debug( '**** writeScreenshot.screenshotPath =', screenshotPath );
 	if ( typeof metadata === 'object' ) {
 		for ( const i in metadata ) {
 			pt = pt.pipe( pngitxt.set( i, metadata[ i ] ) );

--- a/test/e2e/lib/media-helper.js
+++ b/test/e2e/lib/media-helper.js
@@ -85,6 +85,7 @@ export function writeScreenshot( data, filenameCallback, metadata ) {
 	if ( ! fs.existsSync( screenShotDir ) ) {
 		fs.mkdirSync( screenShotDir );
 	}
+	console.debug( '**** writeScreenshot.screenshotDir =', screenShotDir );
 
 	if ( typeof filenameCallback === 'function' ) {
 		filename = filenameCallback();
@@ -92,6 +93,8 @@ export function writeScreenshot( data, filenameCallback, metadata ) {
 		filename = new Date().getTime().toString();
 	}
 	const screenshotPath = `${ screenShotDir }/${ filename }.png`;
+
+	console.debug( '**** writeScreenshot.screenshotPath =', screenshotPath );
 	if ( typeof metadata === 'object' ) {
 		for ( const i in metadata ) {
 			pt = pt.pipe( pngitxt.set( i, metadata[ i ] ) );

--- a/test/e2e/lib/media-helper.js
+++ b/test/e2e/lib/media-helper.js
@@ -69,30 +69,28 @@ export function deleteFile( fileDetails ) {
 	return fs.deleteSync( fileDetails.file );
 }
 
+export const screenshotsDir = path.resolve(
+	process.env.TEMP_ASSET_PATH || __dirname + '/..',
+	process.env.SCREENSHOTDIR || 'screenshots'
+);
+
 export function writeScreenshot( data, filenameCallback, metadata ) {
 	const buffer = Buffer.from( data, 'base64' );
 	let filename;
 	let pt = new PassThrough();
 
-	let screenShotBase = __dirname + '/..';
-	if ( process.env.TEMP_ASSET_PATH ) {
-		screenShotBase = process.env.TEMP_ASSET_PATH;
+	if ( ! fs.existsSync( screenshotsDir ) ) {
+		fs.mkdirSync( screenshotsDir );
 	}
 
-	const directoryName = screenShotsDir();
-
-	const screenShotDir = path.resolve( screenShotBase, directoryName );
-	if ( ! fs.existsSync( screenShotDir ) ) {
-		fs.mkdirSync( screenShotDir );
-	}
-	console.debug( '**** writeScreenshot.screenshotDir =', screenShotDir );
+	console.debug( '**** writeScreenshot.screenshotDir =', screenshotsDir );
 
 	if ( typeof filenameCallback === 'function' ) {
 		filename = filenameCallback();
 	} else {
 		filename = new Date().getTime().toString();
 	}
-	const screenshotPath = `${ screenShotDir }/${ filename }.png`;
+	const screenshotPath = `${ screenshotsDir }/${ filename }.png`;
 
 	console.debug( '**** writeScreenshot.screenshotPath =', screenshotPath );
 	if ( typeof metadata === 'object' ) {
@@ -119,8 +117,4 @@ export function writeTextLogFile( textContent, prefix, pathOverride ) {
 	fs.writeFileSync( logPath, textContent );
 
 	return logPath;
-}
-
-export function screenShotsDir() {
-	return process.env.SCREENSHOTDIR || 'screenshots';
 }

--- a/test/e2e/lib/mocha-hooks.js
+++ b/test/e2e/lib/mocha-hooks.js
@@ -64,6 +64,7 @@ afterEach( async function () {
 	let filenameCallback;
 
 	if ( this.currentTest.state === 'failed' ) {
+		console.error( this.currentTest.err );
 		const neverSaveScreenshots = config.get( 'neverSaveScreenshots' );
 		if ( neverSaveScreenshots ) {
 			return null;

--- a/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
@@ -72,7 +72,7 @@ describe( `[${ host }] Test popular Gutenberg blocks in edge and non-edge sites 
 					.then( ( url ) =>
 						mediaHelper.writeScreenshot(
 							data,
-							() => join( siteName, `${ siteName }-${ i }-${ now }.png` ),
+							() => join( siteName, `${ siteName }-${ i }-${ now }` ),
 							{ url }
 						)
 					);

--- a/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
@@ -271,7 +271,10 @@ describe( `[${ host }] Test popular Gutenberg blocks in edge and non-edge sites 
 			} );
 
 			step( 'Insert and configure coblocks/gallery-masonry', async function () {
-				await gEditorComponent.insertBlock( GalleryMasonryBlockComponent );
+				const galleryMasonryBlock = await gEditorComponent.insertBlock(
+					GalleryMasonryBlockComponent
+				);
+				await galleryMasonryBlock.uploadImages( sampleImages );
 			} );
 
 			step( 'Insert and configure jetpack/contact-info', async function () {

--- a/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
@@ -82,11 +82,8 @@ describe( `[${ host }] Test popular Gutenberg blocks in edge and non-edge sites 
 	}
 
 	async function assertNoErrorInEditor() {
-		assert.strictEqual(
-			await gEditorComponent.errorDisplayed(),
-			false,
-			'There is an error shown on the editor page!'
-		);
+		const errorDisplayed = await gEditorComponent.errorDisplayed();
+		assert.strictEqual( errorDisplayed, false, 'There is an error shown on the editor page!' );
 	}
 
 	async function assertNoInvalidBlocksInEditor() {
@@ -152,13 +149,14 @@ describe( `[${ host }] Test popular Gutenberg blocks in edge and non-edge sites 
 					SubscriptionsBlockComponent,
 					TiledGalleryBlockComponent,
 					YoutubeBlockComponent,
-				].map( async ( blockClass ) =>
+				].map( async ( blockClass ) => {
+					const displayed = await gEditorComponent.blockDisplayedInEditor( blockClass.blockName );
 					assert.strictEqual(
-						await gEditorComponent.blockDisplayedInEditor( blockClass.blockName ),
+						displayed,
 						true,
 						`The block "${ blockClass.blockName }" was not found in the editor`
-					)
-				)
+					);
+				} )
 			);
 		} );
 
@@ -236,8 +234,8 @@ describe( `[${ host }] Test popular Gutenberg blocks in edge and non-edge sites 
 				const layoutBlock = await gEditorComponent.insertBlock( LayoutGridBlockComponent );
 
 				await layoutBlock.setupColumns( 2 );
-				await layoutBlock.insertBlock( RatingStarBlockComponent, 0 );
-				await layoutBlock.insertBlock( DynamicSeparatorBlockComponent, 1 );
+				await layoutBlock.insertBlock( RatingStarBlockComponent, 1 );
+				await layoutBlock.insertBlock( DynamicSeparatorBlockComponent, 2 );
 			} );
 
 			step( 'Insert and configure core-embed/youtube', async function () {

--- a/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
@@ -61,6 +61,7 @@ describe( `[${ host }] Test popular Gutenberg blocks in edge and non-edge sites 
 		const now = Date.now() / 1000;
 
 		const siteSshotDir = join( mediaHelper.screenShotsDir(), siteName );
+		console.debug( '*** ABOUT TO CREATE THE siteSshotDir =', siteSshotDir );
 		await fs.access( siteSshotDir ).catch( () => fs.mkdir( siteSshotDir ) );
 
 		for ( let i = 0; i <= totalHeight / viewportHeight; i++ ) {

--- a/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
@@ -264,7 +264,10 @@ describe( `[${ host }] Test popular Gutenberg blocks in edge and non-edge sites 
 			} );
 
 			step( 'Insert and configure coblocks/dynamic-separator', async function () {
-				await gEditorComponent.insertBlock( DynamicSeparatorBlockComponent );
+				const dynamicSeparatorBlock = await gEditorComponent.insertBlock(
+					DynamicSeparatorBlockComponent
+				);
+				await dynamicSeparatorBlock.resizeBy( 150 );
 			} );
 
 			step( 'Insert and configure coblocks/gallery-masonry', async function () {

--- a/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
@@ -181,18 +181,16 @@ describe( `[${ host }] Test popular Gutenberg blocks in edge and non-edge sites 
 		} );
 
 		step( 'Blocks are displayed in the published page', async function () {
-			// TODO Some blocks are commente-out because they are not being displayed on the fronted due to not being fed with sample data/assets in the editor
-			// I will uncomment as I set them up.
 			await Promise.all(
 				[
 					BlogPostsBlockComponent,
 					ContactFormBlockComponent,
-					// ContactInfoBlockComponent,
+					ContactInfoBlockComponent,
 					DynamicSeparatorBlockComponent,
 					GalleryMasonryBlockComponent,
-					// LayoutGridBlockComponent,
+					LayoutGridBlockComponent,
 					RatingStarBlockComponent,
-					// SlideshowBlockComponent,
+					SlideshowBlockComponent,
 					SubscriptionsBlockComponent,
 					TiledGalleryBlockComponent,
 					YoutubeBlockComponent,
@@ -220,7 +218,7 @@ describe( `[${ host }] Test popular Gutenberg blocks in edge and non-edge sites 
 			// of the block into each block's class. This way, we could just loop through a list of block classes
 			// since the API would be the same.
 
-			/*step( 'Insert and configure jetpack/tiled-gallery', async function () {
+			step( 'Insert and configure jetpack/tiled-gallery', async function () {
 				const tiledGallery = await gEditorComponent.insertBlock( TiledGalleryBlockComponent );
 				await tiledGallery.uploadImages( sampleImages );
 			} );
@@ -275,14 +273,14 @@ describe( `[${ host }] Test popular Gutenberg blocks in edge and non-edge sites 
 					GalleryMasonryBlockComponent
 				);
 				await galleryMasonryBlock.uploadImages( sampleImages );
-			} );*/
+			} );
 
 			step( 'Insert and configure jetpack/contact-info', async function () {
 				const contactInfoBlock = await gEditorComponent.insertBlock( ContactInfoBlockComponent );
 				await contactInfoBlock.fillUp( {
 					email: 'awesome@possum.ttt',
 					phoneNumber: '555-234-4323',
-					streetAddress: 'e2e street',
+					streetAddress: 'E2E street',
 					addressLine2: 'underground bunker 2',
 					addressLine3: '#1111',
 					city: 'GutenPolis',

--- a/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
@@ -170,15 +170,15 @@ describe( `[${ host }] Test popular Gutenberg blocks in edge and non-edge sites 
 			await assertNoInvalidBlocksInEditor();
 		} );*/
 
-		step( 'Take screenshots of all the blocks in the editor', async function () {
+		/*step( 'Take screenshots of all the blocks in the editor', async function () {
 			await takeBlockScreenshots( siteName );
-		} );
+		} );*/
 	}
 
 	function verifyBlocksInPublishedPage( siteName ) {
-		step( 'Take screenshots of the published page', async function () {
+		/*step( 'Take screenshots of the published page', async function () {
 			await takePublishedScreenshots( siteName );
-		} );
+		} );*/
 
 		step( 'Blocks are displayed in the published page', async function () {
 			await Promise.all(
@@ -322,6 +322,6 @@ describe( `[${ host }] Test popular Gutenberg blocks in edge and non-edge sites 
 	} );
 } );
 
-after( async function () {
+/*after( async function () {
 	await Promise.all( sampleImages.map( ( fileDetails ) => mediaHelper.deleteFile( fileDetails ) ) );
-} );
+} );*/

--- a/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
@@ -194,7 +194,7 @@ describe( `[${ host }] Test popular Gutenberg blocks in edge and non-edge sites 
 					SubscriptionsBlockComponent,
 					TiledGalleryBlockComponent,
 					YoutubeBlockComponent,
-				].map( async ( blockClass ) =>
+				].map( ( blockClass ) =>
 					driverHelper.waitTillPresentAndDisplayed( driver, blockClass.blockFrontendSelector )
 				)
 			);

--- a/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
@@ -60,8 +60,14 @@ describe( `[${ host }] Test popular Gutenberg blocks in edge and non-edge sites 
 	async function takeScreenshot( siteName, totalHeight, viewportHeight, scrollCb ) {
 		const now = Date.now() / 1000;
 
-		const siteScreenshotsDir = join( mediaHelper.screenshotsDir, siteName );
+		// NOTE The gsub below is a hack to get rid of the **** wildcard and replace with "test" as `mkdir` doesn't seem to support it.
+		// Keep this until I better understand why this happens and or find a better way to solve this.
+		const siteScreenshotsDir = join( mediaHelper.screenshotsDir, siteName ).replace(
+			'****',
+			'test'
+		);
 		console.debug( '*** ABOUT TO CREATE THE siteSshotDir =', siteScreenshotsDir );
+
 		await fs.access( siteScreenshotsDir ).catch( () => fs.mkdir( siteScreenshotsDir ) );
 
 		for ( let i = 0; i <= totalHeight / viewportHeight; i++ ) {

--- a/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
@@ -61,7 +61,6 @@ describe( `[${ host }] Test popular Gutenberg blocks in edge and non-edge sites 
 		const now = Date.now() / 1000;
 
 		const siteScreenshotsDir = join( mediaHelper.screenshotsDir, siteName );
-		console.debug( '*** ABOUT TO CREATE THE siteSshotDir =', siteScreenshotsDir );
 		await fs
 			.access( siteScreenshotsDir )
 			.catch( () => fs.mkdir( siteScreenshotsDir, { recursive: true } ) );
@@ -236,8 +235,8 @@ describe( `[${ host }] Test popular Gutenberg blocks in edge and non-edge sites 
 				const layoutBlock = await gEditorComponent.insertBlock( LayoutGridBlockComponent );
 
 				await layoutBlock.setupColumns( 2 );
-				await layoutBlock.insertBlock( RatingStarBlockComponent, 1 );
-				await layoutBlock.insertBlock( DynamicSeparatorBlockComponent, 2 );
+				await layoutBlock.insertBlock( RatingStarBlockComponent );
+				await layoutBlock.insertBlock( DynamicSeparatorBlockComponent );
 			} );
 
 			step( 'Insert and configure core-embed/youtube', async function () {

--- a/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
@@ -195,7 +195,7 @@ describe( `[${ host }] Test popular Gutenberg blocks in edge and non-edge sites 
 					// SlideshowBlockComponent,
 					SubscriptionsBlockComponent,
 					TiledGalleryBlockComponent,
-					// YoutubeBlockComponent,
+					YoutubeBlockComponent,
 				].map( async ( blockClass ) =>
 					driverHelper.waitTillPresentAndDisplayed( driver, blockClass.blockFrontendSelector )
 				)
@@ -235,16 +235,15 @@ describe( `[${ host }] Test popular Gutenberg blocks in edge and non-edge sites 
 
 			step( 'Insert and configure jetpack/layout-grid', async function () {
 				const layoutBlock = await gEditorComponent.insertBlock( LayoutGridBlockComponent );
+
 				await layoutBlock.setupColumns( 2 );
-				const ratingStarInnerBlock = await layoutBlock.insertBlock( RatingStarBlockComponent, 0 );
-				const DynamicHRInnerBlock = await layoutBlock.insertBlock(
-					DynamicSeparatorBlockComponent,
-					1
-				);
+				await layoutBlock.insertBlock( RatingStarBlockComponent, 0 );
+				await layoutBlock.insertBlock( DynamicSeparatorBlockComponent, 1 );
 			} );
 
 			step( 'Insert and configure core-embed/youtube', async function () {
-				await gEditorComponent.insertBlock( YoutubeBlockComponent );
+				const youtubeBlock = await gEditorComponent.insertBlock( YoutubeBlockComponent );
+				await youtubeBlock.embed( 'https://www.youtube.com/watch?v=FhMO5QnRNvo' );
 			} );
 
 			step( 'Insert and configure a8c/blog-posts', async function () {

--- a/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
@@ -220,7 +220,7 @@ describe( `[${ host }] Test popular Gutenberg blocks in edge and non-edge sites 
 			// of the block into each block's class. This way, we could just loop through a list of block classes
 			// since the API would be the same.
 
-			step( 'Insert and configure jetpack/tiled-gallery', async function () {
+			/*step( 'Insert and configure jetpack/tiled-gallery', async function () {
 				const tiledGallery = await gEditorComponent.insertBlock( TiledGalleryBlockComponent );
 				await tiledGallery.uploadImages( sampleImages );
 			} );
@@ -275,10 +275,22 @@ describe( `[${ host }] Test popular Gutenberg blocks in edge and non-edge sites 
 					GalleryMasonryBlockComponent
 				);
 				await galleryMasonryBlock.uploadImages( sampleImages );
-			} );
+			} );*/
 
 			step( 'Insert and configure jetpack/contact-info', async function () {
-				await gEditorComponent.insertBlock( ContactInfoBlockComponent );
+				const contactInfoBlock = await gEditorComponent.insertBlock( ContactInfoBlockComponent );
+				await contactInfoBlock.fillUp( {
+					email: 'awesome@possum.ttt',
+					phoneNumber: '555-234-4323',
+					streetAddress: 'e2e street',
+					addressLine2: 'underground bunker 2',
+					addressLine3: '#1111',
+					city: 'GutenPolis',
+					state: 'Gutenfolia',
+					zipCode: '1337',
+					country: 'United Gutenberg States of Calypsoland',
+					linkToGmaps: true,
+				} );
 			} );
 
 			verifyBlocksInEditor( siteName );

--- a/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
@@ -3,7 +3,7 @@
  */
 import assert from 'assert';
 import config from 'config';
-import { times, sample } from 'lodash';
+import { times } from 'lodash';
 import { By } from 'selenium-webdriver';
 import { promises as fs } from 'fs';
 import { join } from 'path';
@@ -54,7 +54,7 @@ before( async function () {
 } );
 
 // Should we keep the @parallel tag here for this e2e test?
-describe( `[${ host }] Test popular Gutenberg blocks in edge and non-edge sites across most popular themes (${ screenSize })`, function () {
+describe( `[${ host }] Test popular Gutenberg blocks in edge and non-edge sites across most popular themes (${ screenSize }) @parallel`, function () {
 	this.timeout( mochaTimeOut );
 
 	async function takeScreenshot( siteName, totalHeight, viewportHeight, scrollCb ) {

--- a/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
@@ -62,7 +62,9 @@ describe( `[${ host }] Test popular Gutenberg blocks in edge and non-edge sites 
 
 		const siteScreenshotsDir = join( mediaHelper.screenshotsDir, siteName );
 		console.debug( '*** ABOUT TO CREATE THE siteSshotDir =', siteScreenshotsDir );
-		await fs.access( siteScreenshotsDir ).catch( () => fs.mkdir( siteScreenshotsDir ) );
+		await fs
+			.access( siteScreenshotsDir )
+			.catch( () => fs.mkdir( siteScreenshotsDir, { recursive: true } ) );
 
 		for ( let i = 0; i <= totalHeight / viewportHeight; i++ ) {
 			await scrollCb( i );

--- a/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
@@ -234,7 +234,13 @@ describe( `[${ host }] Test popular Gutenberg blocks in edge and non-edge sites 
 			} );
 
 			step( 'Insert and configure jetpack/layout-grid', async function () {
-				await gEditorComponent.insertBlock( LayoutGridBlockComponent );
+				const layoutBlock = await gEditorComponent.insertBlock( LayoutGridBlockComponent );
+				await layoutBlock.setupColumns( 2 );
+				const ratingStarInnerBlock = await layoutBlock.insertBlock( RatingStarBlockComponent, 0 );
+				const DynamicHRInnerBlock = await layoutBlock.insertBlock(
+					DynamicSeparatorBlockComponent,
+					1
+				);
 			} );
 
 			step( 'Insert and configure core-embed/youtube', async function () {

--- a/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
@@ -5,8 +5,8 @@ import assert from 'assert';
 import config from 'config';
 import { times } from 'lodash';
 import { By } from 'selenium-webdriver';
-import { promises as fs } from 'fs';
 import { join } from 'path';
+import { promises as fs } from 'fs';
 
 /**
  * Internal dependencies
@@ -60,9 +60,9 @@ describe( `[${ host }] Test popular Gutenberg blocks in edge and non-edge sites 
 	async function takeScreenshot( siteName, totalHeight, viewportHeight, scrollCb ) {
 		const now = Date.now() / 1000;
 
-		const siteSshotDir = join( mediaHelper.screenShotsDir(), siteName );
-		console.debug( '*** ABOUT TO CREATE THE siteSshotDir =', siteSshotDir );
-		await fs.access( siteSshotDir ).catch( () => fs.mkdir( siteSshotDir ) );
+		const siteScreenshotsDir = join( mediaHelper.screenshotsDir, siteName );
+		console.debug( '*** ABOUT TO CREATE THE siteSshotDir =', siteScreenshotsDir );
+		await fs.access( siteScreenshotsDir ).catch( () => fs.mkdir( siteScreenshotsDir ) );
 
 		for ( let i = 0; i <= totalHeight / viewportHeight; i++ ) {
 			await scrollCb( i );

--- a/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
@@ -170,15 +170,15 @@ describe( `[${ host }] Test popular Gutenberg blocks in edge and non-edge sites 
 			await assertNoInvalidBlocksInEditor();
 		} );*/
 
-		/*step( 'Take screenshots of all the blocks in the editor', async function () {
+		step( 'Take screenshots of all the blocks in the editor', async function () {
 			await takeBlockScreenshots( siteName );
-		} );*/
+		} );
 	}
 
 	function verifyBlocksInPublishedPage( siteName ) {
-		/*step( 'Take screenshots of the published page', async function () {
+		step( 'Take screenshots of the published page', async function () {
 			await takePublishedScreenshots( siteName );
-		} );*/
+		} );
 
 		step( 'Blocks are displayed in the published page', async function () {
 			await Promise.all(
@@ -322,6 +322,6 @@ describe( `[${ host }] Test popular Gutenberg blocks in edge and non-edge sites 
 	} );
 } );
 
-/*after( async function () {
+after( async function () {
 	await Promise.all( sampleImages.map( ( fileDetails ) => mediaHelper.deleteFile( fileDetails ) ) );
-} );*/
+} );

--- a/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
@@ -60,14 +60,8 @@ describe( `[${ host }] Test popular Gutenberg blocks in edge and non-edge sites 
 	async function takeScreenshot( siteName, totalHeight, viewportHeight, scrollCb ) {
 		const now = Date.now() / 1000;
 
-		// NOTE The gsub below is a hack to get rid of the **** wildcard and replace with "test" as `mkdir` doesn't seem to support it.
-		// Keep this until I better understand why this happens and or find a better way to solve this.
-		const siteScreenshotsDir = join( mediaHelper.screenshotsDir, siteName ).replace(
-			'****',
-			'test'
-		);
+		const siteScreenshotsDir = join( mediaHelper.screenshotsDir, siteName );
 		console.debug( '*** ABOUT TO CREATE THE siteSshotDir =', siteScreenshotsDir );
-
 		await fs.access( siteScreenshotsDir ).catch( () => fs.mkdir( siteScreenshotsDir ) );
 
 		for ( let i = 0; i <= totalHeight / viewportHeight; i++ ) {

--- a/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
@@ -18,6 +18,7 @@ import GutenbergEditorComponent from '../lib/gutenberg/gutenberg-editor-componen
 import * as driverManager from '../lib/driver-manager.js';
 import * as dataHelper from '../lib/data-helper.js';
 import * as mediaHelper from '../lib/media-helper';
+import * as driverHelper from '../lib/driver-helper';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
 const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
@@ -78,8 +79,6 @@ describe( `[${ host }] Test popular Gutenberg blocks in edge and non-edge sites 
 			} );
 		}
 	}
-
-	async function assertBlockIsDisplayed( blockClass ) {}
 
 	async function assertNoErrorInEditor() {
 		assert.strictEqual(
@@ -176,6 +175,34 @@ describe( `[${ host }] Test popular Gutenberg blocks in edge and non-edge sites 
 		} );
 	}
 
+	function verifyBlocksInPublishedPage( siteName ) {
+		step( 'Take screenshots of the published page', async function () {
+			await takePublishedScreenshots( siteName );
+		} );
+
+		step( 'Blocks are displayed in the published page', async function () {
+			// TODO Some blocks are commente-out because they are not being displayed on the fronted due to not being fed with sample data/assets in the editor
+			// I will uncomment as I set them up.
+			await Promise.all(
+				[
+					BlogPostsBlockComponent,
+					ContactFormBlockComponent,
+					// ContactInfoBlockComponent,
+					DynamicSeparatorBlockComponent,
+					GalleryMasonryBlockComponent,
+					// LayoutGridBlockComponent,
+					RatingStarBlockComponent,
+					// SlideshowBlockComponent,
+					SubscriptionsBlockComponent,
+					TiledGalleryBlockComponent,
+					// YoutubeBlockComponent,
+				].map( async ( blockClass ) =>
+					driverHelper.waitTillPresentAndDisplayed( driver, blockClass.blockFrontendSelector )
+				)
+			);
+		} );
+	}
+
 	[
 		'e2egbupgradehever',
 		'e2egbupgradeshawburn',
@@ -251,9 +278,7 @@ describe( `[${ host }] Test popular Gutenberg blocks in edge and non-edge sites 
 				}
 			);
 
-			step( 'Take screenshots of the published page', async function () {
-				await takePublishedScreenshots( siteName );
-			} );
+			verifyBlocksInPublishedPage( siteName );
 
 			describe( 'Test the same blocks in the corresponding edge site', function () {
 				const edgeSiteName = siteName + 'edge';
@@ -269,10 +294,7 @@ describe( `[${ host }] Test popular Gutenberg blocks in edge and non-edge sites 
 				} );
 
 				verifyBlocksInEditor( edgeSiteName );
-
-				step( 'Take screenshots of the published page', async function () {
-					await takePublishedScreenshots( siteName );
-				} );
+				verifyBlocksInPublishedPage( siteName );
 			} );
 		} );
 	} );

--- a/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
@@ -3,7 +3,7 @@
  */
 import assert from 'assert';
 import config from 'config';
-import { times } from 'lodash';
+import { times, sample } from 'lodash';
 import { By } from 'selenium-webdriver';
 import { promises as fs } from 'fs';
 import { join } from 'path';
@@ -43,14 +43,14 @@ let driver;
 let loginFlow;
 let gEditorComponent;
 let currentGutenbergBlocksCode;
-let galleryImages;
+let sampleImages;
 
 before( async function () {
 	this.timeout( startBrowserTimeoutMS );
 	driver = await driverManager.startBrowser();
 
 	loginFlow = new LoginFlow( driver, 'gutenbergUpgradeUser' );
-	galleryImages = times( 5, () => mediaHelper.createFile() );
+	sampleImages = times( 5, () => mediaHelper.createFile() );
 } );
 
 // Should we keep the @parallel tag here for this e2e test?
@@ -222,7 +222,7 @@ describe( `[${ host }] Test popular Gutenberg blocks in edge and non-edge sites 
 
 			step( 'Insert and configure jetpack/tiled-gallery', async function () {
 				const tiledGallery = await gEditorComponent.insertBlock( TiledGalleryBlockComponent );
-				await tiledGallery.uploadImages( galleryImages );
+				await tiledGallery.uploadImages( sampleImages );
 			} );
 
 			step( 'Insert and configure jetpack/contact-form', async function () {
@@ -255,7 +255,8 @@ describe( `[${ host }] Test popular Gutenberg blocks in edge and non-edge sites 
 			} );
 
 			step( 'Insert and configure jetpack/slideshow', async function () {
-				await gEditorComponent.insertBlock( SlideshowBlockComponent );
+				const slideshowBlock = await gEditorComponent.insertBlock( SlideshowBlockComponent );
+				await slideshowBlock.uploadImages( sampleImages );
 			} );
 
 			step( 'Insert and configure jetpack/rating-star', async function () {
@@ -306,7 +307,5 @@ describe( `[${ host }] Test popular Gutenberg blocks in edge and non-edge sites 
 } );
 
 after( async function () {
-	await Promise.all(
-		galleryImages.map( ( fileDetails ) => mediaHelper.deleteFile( fileDetails ) )
-	);
+	await Promise.all( sampleImages.map( ( fileDetails ) => mediaHelper.deleteFile( fileDetails ) ) );
 } );

--- a/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-upgrade-spec.js
@@ -164,7 +164,6 @@ describe( `[${ host }] Test popular Gutenberg blocks in edge and non-edge sites 
 		step( 'Blocks do not error in the editor', async function () {
 			await assertNoErrorInEditor();
 		} );
-
 		// Commented-out for now because of https://github.com/Automattic/jetpack/issues/16514
 		/*step( 'Blocks do not invalidate', async function () {
 			await assertNoInvalidBlocksInEditor();
@@ -208,7 +207,7 @@ describe( `[${ host }] Test popular Gutenberg blocks in edge and non-edge sites 
 		'e2egbupgradeexford',
 		'e2egbupgrademayland',
 	].forEach( ( siteName ) => {
-		describe( 'Can add most popular blocks to the editor without errors', function () {
+		describe( `[${ siteName }] Can add most popular blocks to the editor without errors`, function () {
 			step( `Login to ${ siteName }`, async function () {
 				await loginFlow.loginAndStartNewPost( `${ siteName }.wordpress.com`, true );
 				gEditorComponent = await GutenbergEditorComponent.Expect( driver );


### PR DESCRIPTION
### What 

Fill all the popular blocks with the necessary minimum data for them to appear in the frontend and make sure each of them is displayed.

### Why

The[ initial task](https://github.com/Automattic/wp-calypso/pull/45048) added the framework/PoC for automating our manual testing process. It only configured two blocks, though. The goal of this PR is to setup all of the popular blocks being tested as part of the upgrade E2E test, and verify them in the published page too (edge/non-edge and across the most popular themes)

Tracking issue: https://github.com/Automattic/wp-calypso/issues/45209 (_Fill all the popular blocks with the necessary minimum data for them to appear in the frontend and make sure each of them is displayed_)

### TODO
* [ ] Fix issues reported in CI
* [ ] Squash commits _(due to the nature of this changeset, where I need to test on CI, there are more commits than I'd like it to have, so some hygiene before merging would be nice)_
