### PR TITLE
Modularise home state

### DIFF
--- a/client/state/home/actions.js
+++ b/client/state/home/actions.js
@@ -8,7 +8,9 @@ import {
 	HOME_QUICK_LINKS_EXPAND,
 	HOME_QUICK_LINKS_COLLAPSE,
 } from 'state/action-types';
+
 import 'state/data-layer/wpcom/sites/home/layout';
+import 'state/home/init';
 
 export const requestHomeLayout = ( siteId, isDev = false, forcedView = null ) => ( {
 	type: HOME_LAYOUT_REQUEST,

--- a/client/state/home/init.js
+++ b/client/state/home/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'state/redux-store';
+import reducer from './reducer';
+
+registerReducer( [ 'home' ], reducer );

--- a/client/state/home/package.json
+++ b/client/state/home/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/home/reducer.js
+++ b/client/state/home/reducer.js
@@ -6,7 +6,7 @@ import {
 	HOME_QUICK_LINKS_EXPAND,
 	HOME_QUICK_LINKS_COLLAPSE,
 } from 'state/action-types';
-import { combineReducers, keyedReducer, withSchemaValidation } from 'state/utils';
+import { combineReducers, keyedReducer, withSchemaValidation, withStorageKey } from 'state/utils';
 
 export const layout = ( state = {}, action ) =>
 	action.type === HOME_LAYOUT_SET ? action.layout : state;
@@ -36,7 +36,9 @@ export const quickLinksToggleStatus = withSchemaValidation(
 	}
 );
 
-export default combineReducers( {
+const combinedReducer = combineReducers( {
 	quickLinksToggleStatus,
 	sites,
 } );
+
+export default withStorageKey( 'home', combinedReducer );

--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -22,7 +22,6 @@ import embeds from './embeds/reducer';
 import experiments from './experiments/reducer';
 import gsuiteUsers from './gsuite-users/reducer';
 import happychat from './happychat/reducer';
-import home from './home/reducer';
 import i18n from './i18n/reducer';
 import immediateLogin from './immediate-login/reducer';
 import importerNux from './importer-nux/reducer';
@@ -65,7 +64,6 @@ const reducers = {
 	experiments,
 	gsuiteUsers,
 	happychat,
-	home,
 	httpData,
 	i18n,
 	immediateLogin,

--- a/client/state/selectors/get-home-layout.js
+++ b/client/state/selectors/get-home-layout.js
@@ -1,4 +1,9 @@
 /**
+ * Internal dependencies
+ */
+import 'state/home/init';
+
+/**
  * Returns the Home layout for a given site.
  *
  * @param  {object}  state   Global state tree

--- a/client/state/selectors/is-home-quick-links-expanded.js
+++ b/client/state/selectors/is-home-quick-links-expanded.js
@@ -1,4 +1,9 @@
 /**
+ * Internal dependencies
+ */
+import 'state/home/init';
+
+/**
  * Returns true if the Home's Quick Links are expanded.
  *
  * @param  {object}  state   Global state tree


### PR DESCRIPTION
This PR is one of many working on modularising state in Calypso. This one handles home state.

For more details on state modularisation, see the [modularised state documentation](https://github.com/Automattic/wp-calypso/blob/master/docs/modularized-state.md) and p4TIVU-9lM-p2.

Note: I added reviewers that GitHub suggested. Please feel free to ignore the review request or pull in someone else if you're not comfortable reviewing this PR. Thank you!

Fixes #42442.

#### Changes proposed in this Pull Request

* Modularise home state

#### Testing instructions

* Install [Redux DevTools](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en).
* Open DevTools and switch to the Redux tab.
* Open `/read` on the live branch or your local copy of this branch.
* Click `State` on the top right to ensure you see all state, and not just the diff for the last action: 
![image](https://user-images.githubusercontent.com/409615/73774406-d3e87d80-477b-11ea-9f59-3e42cc00101f.png)
* Analyse the tree and note that there's no `home` key, even if you expand the list of keys. This indicates that the home state hasn't been loaded yet.
* Click `My Sites` on the top bar.
* Verify that a `home` key is added with the home state. This indicates that the home state has now been loaded.
* Verify that the `home` page functionality works normally. This indicates that I didn't mess up.