### PR TITLE
PostItem: Simplify condition for PostActionsEllipsisMenu

### DIFF
--- a/client/blocks/post-item/index.jsx
+++ b/client/blocks/post-item/index.jsx
@@ -203,12 +203,13 @@ class PostItem extends React.Component {
 						globalId={ globalId }
 						onClick={ this.clickHandler( 'image' ) }
 					/>
-					{ ! isTypeWpBlock && <PostActionsEllipsisMenu globalId={ globalId } /> }
-					{ isTypeWpBlock && (
+					{ isTypeWpBlock ? (
 						<PostActionsEllipsisMenu globalId={ globalId } includeDefaultActions={ false }>
 							<PostActionsEllipsisMenuEdit key="edit" />
 							<PostActionsEllipsisMenuTrash key="trash" />
 						</PostActionsEllipsisMenu>
+					) : (
+						<PostActionsEllipsisMenu globalId={ globalId } />
 					) }
 				</div>
 				{ hasExpandedContent && this.renderExpandedContent() }


### PR DESCRIPTION
This is a follow-up to https://github.com/Automattic/wp-calypso/pull/45210#discussion_r478230007, cc @jsnajdr.

#### Changes proposed in this Pull Request

* PostItem: Simplify condition for PostActionsEllipsisMenu

#### Testing instructions

* Verify the ellipsis menu still appears under the same conditions.
