### PR TITLE
Modularise plugins state

### DIFF
--- a/client/extensions/woocommerce/state/selectors/plugins.js
+++ b/client/extensions/woocommerce/state/selectors/plugins.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { every, find } from 'lodash';
+
 /**
  * Internal dependencies
  */
@@ -14,6 +15,8 @@ import {
 import { getRequiredPluginsForCalypso } from 'woocommerce/lib/get-required-plugins';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import createSelector from 'lib/create-selector';
+
+import 'state/plugins/init';
 
 const getWcsPluginData = createSelector(
 	( state, siteId ) => {

--- a/client/state/plugins/init.js
+++ b/client/state/plugins/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'state/redux-store';
+import reducer from './reducer';
+
+registerReducer( [ 'plugins' ], reducer );

--- a/client/state/plugins/installed/actions.js
+++ b/client/state/plugins/installed/actions.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import wpcom from 'lib/wp';
 
 /**
@@ -44,12 +43,14 @@ import {
 	REMOVE_PLUGIN,
 } from './constants';
 
+import 'state/plugins/init';
+
 /**
  * Return a SitePlugin instance used to handle the plugin
  *
  * @param {object} siteId - site ID
  * @param {string} pluginId - plugin identifier
- * @returns {SitePlugin} SitePlugin instance
+ * @returns {any} SitePlugin instance
  */
 const getPluginHandler = ( siteId, pluginId ) => {
 	const siteHandler = wpcom.site( siteId );

--- a/client/state/plugins/installed/selectors.js
+++ b/client/state/plugins/installed/selectors.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import { every, filter, find, get, pick, reduce, some, sortBy, values } from 'lodash';
 
 /**
@@ -13,6 +12,8 @@ import {
 	isJetpackSite,
 	isJetpackSiteSecondaryNetworkSite,
 } from 'state/sites/selectors';
+
+import 'state/plugins/init';
 
 const _filters = {
 	none: function () {

--- a/client/state/plugins/package.json
+++ b/client/state/plugins/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/plugins/premium/actions.js
+++ b/client/state/plugins/premium/actions.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import wpcom from 'lib/wp';
 import { get, keys } from 'lodash';
 
@@ -19,6 +18,8 @@ import {
 	PLUGIN_SETUP_FINISH,
 	PLUGIN_SETUP_ERROR,
 } from 'state/action-types';
+
+import 'state/plugins/init';
 
 /**
  *  Local variables;
@@ -44,7 +45,7 @@ const normalizePluginInstructions = ( data ) => {
  *
  * @param {object} site - site object
  * @param {string} plugin - plugin identifier
- * @returns {SitePlugin} SitePlugin instance
+ * @returns {any} SitePlugin instance
  */
 const getPluginHandler = ( site, plugin ) => {
 	const siteHandler = wpcom.site( site.ID );

--- a/client/state/plugins/premium/selectors.js
+++ b/client/state/plugins/premium/selectors.js
@@ -8,6 +8,8 @@ import { every, filter, find, get, includes, some } from 'lodash';
  */
 import createSelector from 'lib/create-selector';
 
+import 'state/plugins/init';
+
 export const isRequesting = function ( state, siteId ) {
 	// if the `isRequesting` attribute doesn't exist yet,
 	// we assume we are still launching the fetch action, so it's true

--- a/client/state/plugins/recommended/actions.js
+++ b/client/state/plugins/recommended/actions.js
@@ -8,6 +8,7 @@ import {
 } from 'state/action-types';
 
 import 'state/data-layer/wpcom/sites/plugins/recommended';
+import 'state/plugins/init';
 
 /**
  * Returns an action object that's bound to the data layer;

--- a/client/state/plugins/reducer.js
+++ b/client/state/plugins/reducer.js
@@ -1,18 +1,19 @@
 /**
  * Internal dependencies
  */
-
+import { combineReducers, withStorageKey } from 'state/utils';
 import wporg from './wporg/reducer';
-import { combineReducers } from 'state/utils';
 import premium from './premium/reducer';
 import installed from './installed/reducer';
 import upload from './upload/reducer';
 import recommended from './recommended/reducer';
 
-export default combineReducers( {
+const combinedReducer = combineReducers( {
 	wporg,
 	premium,
 	installed,
 	upload,
 	recommended,
 } );
+
+export default withStorageKey( 'plugins', combinedReducer );

--- a/client/state/plugins/upload/actions.js
+++ b/client/state/plugins/upload/actions.js
@@ -1,7 +1,6 @@
 /**
  * Internal dependencies
  */
-
 import {
 	PLUGIN_UPLOAD,
 	PLUGIN_UPLOAD_CLEAR,
@@ -11,12 +10,13 @@ import {
 } from 'state/action-types';
 
 import 'state/data-layer/wpcom/sites/plugins/new';
+import 'state/plugins/init';
 
 /**
  * Upload a plugin to a site.
  *
  * @param {number} siteId site ID
- * @param {File} file the plugin zip to upload
+ * @param {window.File} file the plugin zip to upload
  * @returns {object} action object
  */
 export function uploadPlugin( siteId, file ) {

--- a/client/state/plugins/wporg/actions.js
+++ b/client/state/plugins/wporg/actions.js
@@ -12,6 +12,8 @@ import { fetchPluginInformation } from 'lib/wporg';
 import { normalizePluginData } from 'lib/plugins/utils';
 import { WPORG_PLUGIN_DATA_RECEIVE, FETCH_WPORG_PLUGIN_DATA } from 'state/action-types';
 
+import 'state/plugins/init';
+
 // TODO: fix the selector in `selectors.js` to not return `true` by default
 function isFetching( state, pluginSlug ) {
 	return get( state, [ 'plugins', 'wporg', 'fetchingItems', pluginSlug ], false );

--- a/client/state/plugins/wporg/selectors.js
+++ b/client/state/plugins/wporg/selectors.js
@@ -1,3 +1,8 @@
+/**
+ * Internal dependencies
+ */
+import 'state/plugins/init';
+
 export function getAllPlugins( state ) {
 	return state?.plugins.wporg.items;
 }

--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -35,7 +35,6 @@ import notices from './notices/reducer';
 import { unseenCount as notificationsUnseenCount } from './notifications';
 import orderTransactions from './order-transactions/reducer';
 import pageTemplates from './page-templates/reducer';
-import plugins from './plugins/reducer';
 import postFormats from './post-formats/reducer';
 import receipts from './receipts/reducer';
 import rewind from './rewind/reducer';
@@ -79,7 +78,6 @@ const reducers = {
 	notificationsUnseenCount,
 	orderTransactions,
 	pageTemplates,
-	plugins,
 	postFormats,
 	receipts,
 	rewind,

--- a/client/state/selectors/get-plugin-upload-error.js
+++ b/client/state/selectors/get-plugin-upload-error.js
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import 'state/plugins/init';
 
 /**
  * Returns any error from a plugin uploaded to a site, or

--- a/client/state/selectors/get-plugin-upload-progress.js
+++ b/client/state/selectors/get-plugin-upload-progress.js
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import 'state/plugins/init';
 
 /**
  * Returns percentage of plugin zip uploaded to a site.

--- a/client/state/selectors/get-recommended-plugins.js
+++ b/client/state/selectors/get-recommended-plugins.js
@@ -4,6 +4,11 @@
 import { get } from 'lodash';
 
 /**
+ * Internal dependencies
+ */
+import 'state/plugins/init';
+
+/**
  * Returns a list of recommended plugins for the given site.
  *
  * @param  {object}                   state   Global state tree

--- a/client/state/selectors/get-uploaded-plugin-id.js
+++ b/client/state/selectors/get-uploaded-plugin-id.js
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import 'state/plugins/init';
 
 /**
  * Returns the ID of an uploaded plugin, or

--- a/client/state/selectors/is-plugin-active.js
+++ b/client/state/selectors/is-plugin-active.js
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
-
 import { find } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import 'state/plugins/init';
 
 /**
  * Returns a Boolean indicating if a site has a particular plugin that

--- a/client/state/selectors/is-plugin-upload-in-progress.js
+++ b/client/state/selectors/is-plugin-upload-in-progress.js
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import 'state/plugins/init';
 
 /**
  * Indicates whether a plugin upload is currently in progress


### PR DESCRIPTION
This PR is one of many working on modularising state in Calypso. This one handles plugins state.

For more details on state modularisation, see the [modularised state documentation](https://github.com/Automattic/wp-calypso/blob/master/docs/modularized-state.md) and p4TIVU-9lM-p2.

Note: I added reviewers that GitHub suggested. Please feel free to ignore the review request or pull in someone else if you're not comfortable reviewing this PR. Thank you!

Fixes #42467.

#### Changes proposed in this Pull Request

* Modularise plugins state
* Minor lint fixes

#### Testing instructions

Unfortunately, the library middleware loads plugin state pretty early on in the boot process, so it will currently remain a part of the critical path despite modularisation. As such, it should be sufficient to smoke-test plugin functionality and ensure that nothing obvious got broken.