### PR TITLE
eslintignore: add .cache/ and desktop/ directories

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
+.cache/
 .vscode
 .yarn
 /assets/
@@ -11,6 +12,11 @@ node_modules/
 /packages/calypso-codemods/tests
 /packages/wp-babel-makepot/test
 /packages/wpcom.js/webapp/tests/mocha.js
+/desktop/build/
+/desktop/client/
+/desktop/config/
+/desktop/public/
+/desktop/release/
 
 # Built packages
 /packages/*/dist/


### PR DESCRIPTION
The Prettier `reformat-files` script uses the `.eslintignore` file to detect files it should not format. This patch prevents the `yarn run reformat-files` from formatting JSON and JS files in these directories.

**How to test:**
Run the `yarn run reformat-files` script before and after. Verify that files in `.cache` and `desktop/release` or `desktop/public` directories are not formatted.