### PR TITLE
Jetpack Offer Reset: Add loading state for product card prices.

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/index.tsx
@@ -93,6 +93,26 @@ const JetpackProductCard: FunctionComponent< Props > = ( {
 	const parsedExpiryDate =
 		moment.isMoment( expiryDate ) && expiryDate.isValid() ? expiryDate : null;
 
+	const renderBillingTimeFrame = (
+		productExpiryDate: Moment | null,
+		billingTerm: TranslateResult
+	) => {
+		return productExpiryDate ? (
+			<time
+				className="jetpack-product-card__expiration-date"
+				dateTime={ productExpiryDate.format( 'YYYY-DD-YY' ) }
+			>
+				{ translate( 'expires %(date)s', {
+					args: {
+						date: productExpiryDate.format( 'L' ),
+					},
+				} ) }
+			</time>
+		) : (
+			<span className="jetpack-product-card__billing-time-frame">{ billingTerm }</span>
+		);
+	};
+
 	return (
 		<div
 			className={ classNames( className, 'jetpack-product-card', {
@@ -129,32 +149,31 @@ const JetpackProductCard: FunctionComponent< Props > = ( {
 						} ) }
 						ref={ priceEl }
 					>
-						<span className="jetpack-product-card__raw-price">
-							{ withStartingPrice && (
-								<span className="jetpack-product-card__from">{ translate( 'from' ) }</span>
-							) }
-							<PlanPrice
-								rawPrice={ originalPrice }
-								original={ isDiscounted }
-								currencyCode={ currencyCode }
-							/>
-							{ isDiscounted && (
-								<PlanPrice rawPrice={ discountedPrice } discounted currencyCode={ currencyCode } />
-							) }
-						</span>
-						{ parsedExpiryDate ? (
-							<time
-								className="jetpack-product-card__expiration-date"
-								dateTime={ parsedExpiryDate.format( 'YYYY-DD-YY' ) }
-							>
-								{ translate( 'expires %(date)s', {
-									args: {
-										date: parsedExpiryDate.format( 'L' ),
-									},
-								} ) }
-							</time>
+						{ currencyCode && originalPrice ? (
+							<span className="jetpack-product-card__raw-price">
+								{ withStartingPrice && (
+									<span className="jetpack-product-card__from">{ translate( 'from' ) }</span>
+								) }
+								<PlanPrice
+									rawPrice={ originalPrice }
+									original={ isDiscounted }
+									currencyCode={ currencyCode }
+								/>
+								{ isDiscounted && (
+									<PlanPrice
+										rawPrice={ discountedPrice }
+										discounted
+										currencyCode={ currencyCode }
+									/>
+								) }
+							</span>
 						) : (
-							<span className="jetpack-product-card__billing-time-frame">{ billingTimeFrame }</span>
+							<div className="jetpack-product-card__price-placeholder" />
+						) }
+						{ currencyCode && originalPrice ? (
+							renderBillingTimeFrame( parsedExpiryDate, billingTimeFrame )
+						) : (
+							<div className="jetpack-product-card__time-frame-placeholder" />
 						) }
 					</div>
 				</div>

--- a/client/components/jetpack/card/jetpack-product-card/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/index.tsx
@@ -34,7 +34,7 @@ type OwnProps = {
 	headingLevel?: number;
 	subheadline?: TranslateResult;
 	description?: ReactNode;
-	currencyCode: string;
+	currencyCode: string | null;
 	originalPrice: number;
 	discountedPrice?: number;
 	withStartingPrice?: boolean;

--- a/client/components/jetpack/card/jetpack-product-card/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card/style.scss
@@ -360,3 +360,19 @@ $jetpack-product-card-icon-size: 55px;
 	font-weight: 400;
 	text-decoration: underline;
 }
+
+/* Prices Loading state */
+.jetpack-product-card__price-placeholder {
+	@include placeholder( --color-neutral-10 );
+
+	width: 100px;
+	min-height: 36px;
+	margin-bottom: 4px;
+}
+
+.jetpack-product-card__time-frame-placeholder {
+	@include placeholder( --color-neutral-10 );
+
+	width: 100px;
+	height: 12px;
+}

--- a/client/components/jetpack/card/jetpack-product-card/upgrade-nudge.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/upgrade-nudge.tsx
@@ -28,7 +28,7 @@ import type { ProductCardFeaturesItem } from './types';
 type OwnProps = {
 	billingTimeFrame: TranslateResult;
 	className?: string;
-	currencyCode: string;
+	currencyCode: string | null;
 	discountedPrice?: number;
 	features?: ProductCardFeaturesItem[];
 	onUpgradeClick: () => void;

--- a/client/my-sites/plans-v2/plans-column/index.tsx
+++ b/client/my-sites/plans-v2/plans-column/index.tsx
@@ -63,10 +63,6 @@ const PlansColumn = ( { duration, onPlanClick, productType, siteId }: PlanColumn
 		return plans;
 	}, [ duration, productType, currentPlan ] );
 
-	if ( ! currencyCode ) {
-		return null; // TODO: Loading component!
-	}
-
 	return (
 		<div className="plans-column">
 			<FormattedHeader headerText={ translate( 'Plans' ) } isSecondary brandFont />

--- a/client/my-sites/plans-v2/product-card/index.tsx
+++ b/client/my-sites/plans-v2/product-card/index.tsx
@@ -52,7 +52,7 @@ const itemToCard = ( { type }: SelectorProduct ) => {
 interface UpgradeNudgeProps {
 	siteId: number | null;
 	item: SelectorProduct;
-	currencyCode: string;
+	currencyCode: string | null;
 	onClick: PurchaseCallback;
 }
 
@@ -87,7 +87,7 @@ interface ProductCardProps {
 	item: SelectorProduct;
 	onClick: PurchaseCallback;
 	siteId: number | null;
-	currencyCode: string;
+	currencyCode: string | null;
 	className?: string;
 	highlight?: boolean;
 }

--- a/client/my-sites/plans-v2/products-column/index.tsx
+++ b/client/my-sites/plans-v2/products-column/index.tsx
@@ -81,10 +81,6 @@ const ProductsColumn = ( {
 		[ duration, includedInPlanProducts, ownedProducts, productType ]
 	);
 
-	if ( ! currencyCode ) {
-		return null; // TODO: Loading component!
-	}
-
 	return (
 		<div className="plans-column products-column">
 			<FormattedHeader headerText={ translate( 'Individual Products' ) } isSecondary brandFont />


### PR DESCRIPTION
### Changes proposed in this Pull Request

Adds a loading placeholder while product prices are loading.

### Testing instructions

1. Run this PR with Offer Reset A/B Test enabled.
2. Go to the Plans page.
3. Verify that you see the loading placeholders while the product card prices are still loading.  Also verify that the positioning and size of placeholders looks good. 

### Screenshots:

_Loading state: Prices loading..._

![Markup 2020-08-31 at 11 09 54](https://user-images.githubusercontent.com/11078128/91752791-b8abe800-eb7b-11ea-9a3f-6020acc37260.png)

.
.
**_Loading state: Prices loaded._**

![Markup 2020-08-31 at 11 12 13](https://user-images.githubusercontent.com/11078128/91752838-ccefe500-eb7b-11ea-8189-e75ce52cd8da.png)
