### PR TITLE
Jetpack Offer Reset: Upgrade Nudge, align price left if price wrapped.

### DIFF
--- a/client/components/jetpack/card/jetpack-product-card/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card/style.scss
@@ -367,6 +367,7 @@ $jetpack-product-card-icon-size: 55px;
 
 	width: 100px;
 	min-height: 36px;
+	margin-left: 45px;
 	margin-bottom: 4px;
 }
 
@@ -375,4 +376,5 @@ $jetpack-product-card-icon-size: 55px;
 
 	width: 100px;
 	height: 12px;
+	margin-left: 45px;
 }

--- a/client/components/jetpack/card/jetpack-product-card/upgrade-nudge.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/upgrade-nudge.tsx
@@ -4,7 +4,7 @@
 import classNames from 'classnames';
 import { useTranslate, TranslateResult } from 'i18n-calypso';
 import { isFinite } from 'lodash';
-import React, { useCallback } from 'react';
+import React, { useRef, useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 /**
@@ -18,6 +18,7 @@ import { JETPACK_OFFER_RESET_UPGRADE_NUDGE_DISMISS } from 'my-sites/plans-v2/con
 import { savePreference } from 'state/preferences/actions';
 import { getPreference } from 'state/preferences/selectors';
 import { DEFAULT_UPGRADE_NUDGE_FEATURES } from './fixtures';
+import useFlexboxWrapDetection from './lib/use-flexbox-wrap-detection';
 
 /**
  * Type dependencies
@@ -47,6 +48,8 @@ const UpgradeNudge = ( {
 	selectorProduct,
 }: OwnProps ) => {
 	const translate = useTranslate();
+	const priceEl = useRef( null );
+	const isHeaderWrapped = useFlexboxWrapDetection( priceEl );
 	const isDiscounted = isFinite( discountedPrice );
 
 	const storedPreference = useSelector( ( state ) =>
@@ -83,7 +86,12 @@ const UpgradeNudge = ( {
 						<span className="jetpack-product-card__nudge-product-type">{ displayName }</span>
 					</h3>
 				</div>
-				<div className="jetpack-product-card__price">
+				<div
+					className={ classNames( 'jetpack-product-card__price', {
+						'is-left-aligned': isHeaderWrapped,
+					} ) }
+					ref={ priceEl }
+				>
 					<span className="jetpack-product-card__raw-price">
 						<PlanPrice
 							rawPrice={ originalPrice }


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Fixes Upgrade Nudge price to be left aligned when price is wrapped below the title.

### Testing instructions

1. Run this PR with Offer Reset A/B Test enabled.
2. Go to the Plans page.
3. Visually inspect the Upgrade Nudge price.  When the product card price is small enough to wrap to the second line, the price should be Left aligned, like shown in the screenshot labelled, "After".  (See screenshots)

_Before..._ 

![Markup 2020-08-31 at 15 58 56](https://user-images.githubusercontent.com/11078128/91777812-a5157700-eba5-11ea-997c-788e71ccf548.png)

.
.
**After.**

![Markup 2020-08-31 at 16 11 49](https://user-images.githubusercontent.com/11078128/91777836-ba8aa100-eba5-11ea-9ab2-7745f3de351f.png)



