### PR TITLE
FormTextInput: keep field value in sync with value prop

### DIFF
--- a/client/components/forms/form-text-input/index.jsx
+++ b/client/components/forms/form-text-input/index.jsx
@@ -26,7 +26,7 @@ export default class FormTextInput extends PureComponent {
 
 	updateValueIfNeeded( oldValue ) {
 		const { value } = this.props;
-		if ( oldValue !== value && value !== this.state.value ) {
+		if ( oldValue !== value || value !== this.state.value ) {
 			this.setState( { value } );
 		}
 	}


### PR DESCRIPTION
The `FormTextInput` component is a controlled component, meaning that it has an `onChange` prop and a `value` prop, and when you type in the field, the change is absorbed by React and the field value is only updated when the `value` prop gets modified.

In https://github.com/Automattic/wp-calypso/pull/43838 this behavior was modified by adding a second `value` stored in local state. This second value is directly updated by changing the field, acting as a sort of local cache within the component that can then be updated to match the `value` prop when it changes to match using the `updateValueIfNeeded()` function.

The problem is that it's possible for the two `value`s to become out of sync if the controlling component changes the value before it returns to the `FormTextInput` (typically called "masking"). This occurs in the following way:

1. The input field value is changed to '5'.
2. `onChange` in `FormTextInput` changes `state.value` to '5'.
3. The parent keeps the value as '5'.
4. The `value` prop becomes '5'.
3. `FormTextInput` renders, setting the input value to '5'.
5. `updateValueIfNeeded` changes `state.value` to '5'.
3. `FormTextInput` renders, keeping the same input value.
1. The text field value is changed again to '5a'.
2. `onChange` in `FormTextInput` changes `state.value` to '5a'.
3. The parent masks the value by removing the letter to '5'.
4. The `value` prop is '5', so it remains the same as it was.
5. `updateValueIfNeeded` does nothing because the old value prop (5) is the
same as the new value (5). Note that `state.value` is still '5a', and so
is the input field value.

This PR modifies the condition in `updateValueIfNeeded` so it checks not only that the `prop` changed, but also that the prop matches the state, updating the state if it differs.

#### Testing instructions

First test the same things as https://github.com/Automattic/wp-calypso/pull/43838 to make sure that fix is still working.

* Purchase any plan to see the checkout form.
* Enter the card holder name and delete a letter in the middle.
* The text cursor should not move to the end.

Next, visit checkout with a domain in your cart and verify that editing all the contact fields works as expected.