### PR TITLE
Stats: Display proper labels for x axis

### DIFF
--- a/client/components/chart/bar-container.jsx
+++ b/client/components/chart/bar-container.jsx
@@ -11,6 +11,8 @@ import React from 'react';
 import Bar from './bar';
 import XAxis from './x-axis';
 
+const X_AXIS_LABEL_WIDTH = 42;
+
 export default class ChartBarContainer extends React.PureComponent {
 	static propTypes = {
 		barClick: PropTypes.func,
@@ -46,7 +48,12 @@ export default class ChartBarContainer extends React.PureComponent {
 					) ) }
 				</div>
 				{ ! this.props.isPlaceholder && (
-					<XAxis data={ this.props.data } labelWidth={ 42 } isRtl={ this.props.isRtl } />
+					<XAxis
+						data={ this.props.data }
+						labelWidth={ X_AXIS_LABEL_WIDTH }
+						isRtl={ this.props.isRtl }
+						chartWidth={ this.props.chartWidth }
+					/>
 				) }
 			</>
 		);

--- a/client/components/chart/index.jsx
+++ b/client/components/chart/index.jsx
@@ -22,6 +22,7 @@ import BarContainer from './bar-container';
 import './style.scss';
 
 const isTouch = hasTouch();
+const CHART_PADDING = 20;
 
 /**
  * Auxiliary method to calculate the maximum value for the Y axis, based on a dataset.
@@ -66,7 +67,7 @@ function Chart( {
 } ) {
 	const [ tooltip, setTooltip ] = useState( { isTooltipVisible: false } );
 	const [ sizing, setSizing ] = useState( { clientWidth: 650, hasResized: false } );
-
+	const [ yAxisSize, setYAxisSize ] = useState( { clientWidth: 0, hasResized: false } );
 	const { hasResized } = sizing;
 
 	// Callback to handle tooltip changes.
@@ -79,12 +80,9 @@ function Chart( {
 		}
 	}, [] );
 
-	// Callback to handle element size changes.
-	// Needs to be memoized to avoid causing the `useWindowResizeCallback` custom hook to re-subscribe.
-	const handleContentRectChange = useCallback( ( contentRect ) => {
-		setSizing( ( prevSizing ) => {
-			const clientWidth = contentRect.width - 82;
-
+	const handleYAxisSizeChange = useCallback( ( contentRect ) => {
+		setYAxisSize( ( prevSizing ) => {
+			const clientWidth = contentRect.width;
 			if ( ! prevSizing.hasResized || clientWidth !== prevSizing.clientWidth ) {
 				return { clientWidth, hasResized: true };
 			}
@@ -92,11 +90,31 @@ function Chart( {
 		} );
 	}, [] );
 
+	const yAxisRef = useWindowResizeCallback( handleYAxisSizeChange );
+
+	// Callback to handle element size changes.
+	// Needs to be memoized to avoid causing the `useWindowResizeCallback` custom hook to re-subscribe.
+	const handleContentRectChange = useCallback(
+		( contentRect ) => {
+			setSizing( ( prevSizing ) => {
+				const effectiveYAxisSize =
+					yAxisRef && yAxisRef.current ? yAxisRef.current.clientWidth : yAxisSize.clientWidth;
+				const clientWidth = contentRect.width - effectiveYAxisSize;
+				if ( ! prevSizing.hasResized || clientWidth !== prevSizing.clientWidth ) {
+					return { clientWidth, hasResized: true };
+				}
+				return prevSizing;
+			} );
+		},
+		[ yAxisSize ]
+	);
+
 	// Subscribe to changes to element size and position.
 	const resizeRef = useWindowResizeCallback( handleContentRectChange );
 
 	const minWidth = isTouch ? minTouchBarWidth : minBarWidth;
-	const width = isTouch && sizing.clientWidth <= 0 ? 350 : sizing.clientWidth; // mobile safari bug with zero width
+
+	const width = isTouch && sizing.clientWidth <= 0 ? 350 : sizing.clientWidth - CHART_PADDING; // mobile safari bug with zero width
 	const maxBars = Math.floor( width / minWidth );
 
 	// Memoize data calculations to avoid performing them too often.
@@ -148,8 +166,8 @@ function Chart( {
 				) }
 			</div>
 			{ ! isPlaceholder && (
-				<div className="chart__y-axis">
-					<div className="chart__y-axis-width-fix">{ numberFormat( 100000 ) }</div>
+				<div ref={ yAxisRef } className="chart__y-axis">
+					<div className="chart__y-axis-width-fix">{ numberFormat( 1e5 ) }</div>
 					<div className="chart__y-axis-label is-hundred">
 						{ yMax > 1 ? numberFormat( yMax ) : numberFormat( yMax, 2 ) }
 					</div>

--- a/client/components/chart/x-axis.jsx
+++ b/client/components/chart/x-axis.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import React, { useLayoutEffect, useState, useRef } from 'react';
+import React, { useLayoutEffect, useState } from 'react';
 import { numberFormat } from 'i18n-calypso';
 
 /**
@@ -10,18 +10,14 @@ import { numberFormat } from 'i18n-calypso';
  */
 import Label from './label';
 
-const ModuleChartXAxis = ( { data, isRtl, labelWidth } ) => {
-	const axisRef = useRef( null );
-	const axisSpacerRef = useRef( null );
+const ModuleChartXAxis = ( { data, isRtl, labelWidth, chartWidth } ) => {
 	const dataCount = data.length || 1;
-
 	const [ spacing, setSpacing ] = useState( labelWidth );
-
 	const [ divisor, setDivisor ] = useState( 1 );
 
 	useLayoutEffect( () => {
 		const resize = () => {
-			const width = axisRef.current.clientWidth - axisSpacerRef.current.clientWidth;
+			const width = chartWidth;
 			const newSpacing = width / dataCount;
 
 			setSpacing( newSpacing );
@@ -35,7 +31,7 @@ const ModuleChartXAxis = ( { data, isRtl, labelWidth } ) => {
 		return () => {
 			window.removeEventListener( 'resize', resize );
 		};
-	}, [ dataCount, labelWidth ] );
+	}, [ dataCount, labelWidth, chartWidth ] );
 
 	const labels = data.map( function ( item, index ) {
 		const x = index * spacing + ( spacing - labelWidth ) / 2,
@@ -52,11 +48,9 @@ const ModuleChartXAxis = ( { data, isRtl, labelWidth } ) => {
 	} );
 
 	return (
-		<div ref={ axisRef } className="chart__x-axis">
+		<div className="chart__x-axis">
 			{ labels }
-			<div ref={ axisSpacerRef } className="chart__x-axis-label chart__x-axis-width-spacer">
-				{ numberFormat( 100000 ) }
-			</div>
+			<div className="chart__x-axis-label chart__x-axis-width-spacer">{ numberFormat( 1e5 ) }</div>
 		</div>
 	);
 };

--- a/client/lib/track-element-size/index.ts
+++ b/client/lib/track-element-size/index.ts
@@ -28,6 +28,20 @@ function rectIsEqual( prevRect: NullableDOMRect, nextRect: NullableDOMRect ) {
 	);
 }
 
+function rectIsZero( rect: NullableDOMRect ) {
+	if ( rect === null ) {
+		return null;
+	}
+	return (
+		rect.bottom === 0 &&
+		rect.left === 0 &&
+		rect.right === 0 &&
+		rect.top === 0 &&
+		rect.width === 0 &&
+		rect.height === 0
+	);
+}
+
 /**
  * React hook that subscribes a consumer to changes to the bounding client rect of an element, based
  * on window resize events.
@@ -52,9 +66,8 @@ export function useWindowResizeCallback(
 		// Measure the element in the DOM.
 		const measureElement = () => {
 			const rect = elementRef.current ? elementRef.current.getBoundingClientRect() : null;
-
 			// Avoid notifying consumer if nothing's changed.
-			if ( ! rectIsEqual( lastRect.current, rect ) ) {
+			if ( ! rectIsEqual( lastRect.current, rect ) && ! rectIsZero( rect ) ) {
 				lastRect.current = rect;
 
 				// Notify consumer of bounding client rect change.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Previously, despite entering the same startDate parameter in the URL, the x-axis labels would show inconsistent dates. The PR ensures that given the same startDate, the x-axis labels will show consistent date labels.

#### Testing instructions
1. Starting at URL: https://wordpress.com/stats/day/{site-URL}
2. Take note of how the bar graph displays
3. Modify the URL to view the daily stats for a date that falls before the current range of the bar graph, e.g. by appending `?startDate=2019-06-23`
4. Reload the page with the same start date. The x-axis should always read the same after each reload.

**Screenshots**

x-axis labels for August 28
<img width="1491" alt="Screen Shot 2020-09-01 at 4 10 16 PM" src="https://user-images.githubusercontent.com/66652282/91901253-f4bf7580-ec6d-11ea-9b46-8b5eb5521510.png">

x-axis labels for August 27
<img width="1497" alt="Screen Shot 2020-09-01 at 4 10 27 PM" src="https://user-images.githubusercontent.com/66652282/91901263-fa1cc000-ec6d-11ea-9559-4ebbf23955c0.png">


Fixes #35230
