### PR TITLE
Using labels and descriptions to describe sidebar elements

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useLayoutEffect, useRef, useEffect, useState } from '@wordpress/element';
+import { forwardRef, useLayoutEffect, useRef, useEffect, useState } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { useDispatch, useSelect } from '@wordpress/data';
 import {
@@ -28,11 +28,10 @@ import NavItem from '../nav-item';
 import { Post } from '../../types';
 import './style.scss';
 
-const Button = ( {
-	children,
-	...rest
-}: OriginalButton.Props & { icon?: any; iconSize?: number } ) => (
-	<OriginalButton { ...rest }>{ children }</OriginalButton>
+const Button = forwardRef(
+	( { children, ...rest }: OriginalButton.Props & { icon?: any; iconSize?: number } ) => (
+		<OriginalButton { ...rest }>{ children }</OriginalButton>
+	)
 );
 
 function WpcomBlockEditorNavSidebar() {
@@ -53,6 +52,7 @@ function WpcomBlockEditorNavSidebar() {
 	const statusLabels = usePostStatusLabels();
 
 	const prevIsOpen = useRef( isOpen );
+	const closeButtonRef = useRef();
 
 	// Using layout effect to prevent a brief moment in time where both `isOpen` and `isClosing`
 	// are both false, causing a flicker during the fade out animation.
@@ -63,6 +63,10 @@ function WpcomBlockEditorNavSidebar() {
 		}
 
 		prevIsOpen.current = isOpen;
+
+		if ( isOpen && closeButtonRef.current ) {
+			closeButtonRef.current.focus();
+		}
 	}, [ isOpen, prevIsOpen, setSidebarClosing ] );
 
 	const [ isScrollbarPresent, setIsScrollbarPresent ] = useState( false );
@@ -222,6 +226,7 @@ function WpcomBlockEditorNavSidebar() {
 					className="wpcom-block-editor-nav-sidebar-nav-sidebar__home-button"
 					icon={ arrowLeft }
 					onClick={ handleClose }
+					ref={ closeButtonRef }
 				>
 					{ closeLabel }
 				</Button>

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
@@ -71,10 +71,6 @@ function WpcomBlockEditorNavSidebar() {
 	const itemRefs = useRef< ( HTMLElement | null )[] >( [] );
 
 	const containerMount = ( el: HTMLDivElement | null ) => {
-		if ( el ) {
-			el.focus();
-		}
-
 		if ( observer.current ) {
 			observer.current.disconnect();
 		}
@@ -198,6 +194,7 @@ function WpcomBlockEditorNavSidebar() {
 		>
 			<div
 				aria-label={ __( 'Block editor sidebar', 'full-site-editing' ) }
+				// Waiting for jsx-a11y version bump to support aria-description attribute
 				// eslint-disable-next-line jsx-a11y/aria-props
 				aria-description={ dialogDescription }
 				className={ classNames( 'wpcom-block-editor-nav-sidebar-nav-sidebar__container', {
@@ -210,6 +207,9 @@ function WpcomBlockEditorNavSidebar() {
 				<div className="wpcom-block-editor-nav-sidebar-nav-sidebar__header">
 					<Button
 						aria-label={ __( 'Close block editor sidebar', 'full-site-editing' ) }
+						// We need to shift the focus to something because we are opening a modal
+						// eslint-disable-next-line jsx-a11y/no-autofocus
+						autoFocus
 						className={ classNames(
 							'edit-post-fullscreen-mode-close',
 							'wpcom-block-editor-nav-sidebar-nav-sidebar__dismiss-sidebar-button'
@@ -228,6 +228,7 @@ function WpcomBlockEditorNavSidebar() {
 					) }
 				</div>
 				<Button
+					// Waiting for jsx-a11y version bump to support aria-description attribute
 					// eslint-disable-next-line jsx-a11y/aria-props
 					aria-description={ __( 'Returns to the dashboard', 'full-site-editing' ) }
 					href={ closeUrl }

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
@@ -200,7 +200,8 @@ function WpcomBlockEditorNavSidebar() {
 			>
 				<div className="wpcom-block-editor-nav-sidebar-nav-sidebar__header">
 					<Button
-						aria-label={ __(
+						// eslint-disable-next-line jsx-a11y/aria-props
+						aria-description={ __(
 							'You are viewing the sidebar. Press the Escape key to close.',
 							'full-site-editing'
 						) }

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
@@ -195,6 +195,7 @@ function WpcomBlockEditorNavSidebar() {
 			>
 				<div className="wpcom-block-editor-nav-sidebar-nav-sidebar__header">
 					<Button
+						aria-label={ __( 'open sidebar', 'full-site-editing' ) }
 						className={ classNames(
 							'edit-post-fullscreen-mode-close',
 							'wpcom-block-editor-nav-sidebar-nav-sidebar__dismiss-sidebar-button'

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
@@ -195,7 +195,10 @@ function WpcomBlockEditorNavSidebar() {
 			>
 				<div className="wpcom-block-editor-nav-sidebar-nav-sidebar__header">
 					<Button
-						aria-label={ __( 'open sidebar', 'full-site-editing' ) }
+						aria-label={ __(
+							'You are viewing the sidebar. To close select escape',
+							'full-site-editing'
+						) }
 						className={ classNames(
 							'edit-post-fullscreen-mode-close',
 							'wpcom-block-editor-nav-sidebar-nav-sidebar__dismiss-sidebar-button'

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
@@ -217,6 +217,7 @@ function WpcomBlockEditorNavSidebar() {
 					) }
 				</div>
 				<Button
+					aria-label={ __( 'View all pages in Dashboard', 'full-site-editing' ) }
 					href={ closeUrl }
 					className="wpcom-block-editor-nav-sidebar-nav-sidebar__home-button"
 					icon={ arrowLeft }

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
@@ -31,7 +31,7 @@ import './style.scss';
 const Button = ( {
 	children,
 	...rest
-}: OriginalButton.Props & { icon?: any; iconSize?: number } ) => (
+}: OriginalButton.Props & { icon?: any; iconSize?: number; showTooltip?: boolean } ) => (
 	<OriginalButton { ...rest }>{ children }</OriginalButton>
 );
 
@@ -206,7 +206,8 @@ function WpcomBlockEditorNavSidebar() {
 			>
 				<div className="wpcom-block-editor-nav-sidebar-nav-sidebar__header">
 					<Button
-						aria-label={ __( 'Close block editor sidebar', 'full-site-editing' ) }
+						label={ __( 'Close block editor sidebar', 'full-site-editing' ) }
+						showTooltip
 						// We need to shift the focus to something because we are opening a modal
 						// eslint-disable-next-line jsx-a11y/no-autofocus
 						autoFocus

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
@@ -230,9 +230,9 @@ function WpcomBlockEditorNavSidebar() {
 				>
 					{ closeLabel }
 				</Button>
-				<div className="wpcom-block-editor-nav-sidebar-nav-sidebar__list-heading">
+				<h2 className="wpcom-block-editor-nav-sidebar-nav-sidebar__list-heading">
 					{ listHeading }
-				</div>
+				</h2>
 				<ul className="wpcom-block-editor-nav-sidebar-nav-sidebar__page-list">
 					{ items.map( ( item, index ) => (
 						<NavItem

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
@@ -152,8 +152,8 @@ function WpcomBlockEditorNavSidebar() {
 
 	const closeAriaLabel =
 		postType.slug === 'page'
-			? __( 'View all pages in the Dashboard', 'full-site-editing' )
-			: __( 'View all posts in the Dashboard', 'full-site-editing' );
+			? __( 'Return to the Dashboard to view all pages', 'full-site-editing' )
+			: __( 'Return to the Dashboard to view all posts', 'full-site-editing' );
 
 	const dismissSidebar = () => {
 		if ( isOpen && ! isClosing ) {

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { forwardRef, useLayoutEffect, useRef, useEffect, useState } from '@wordpress/element';
+import { useLayoutEffect, useRef, useEffect, useState } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { useDispatch, useSelect } from '@wordpress/data';
 import {
@@ -28,10 +28,11 @@ import NavItem from '../nav-item';
 import { Post } from '../../types';
 import './style.scss';
 
-const Button = forwardRef(
-	( { children, ...rest }: OriginalButton.Props & { icon?: any; iconSize?: number } ) => (
-		<OriginalButton { ...rest }>{ children }</OriginalButton>
-	)
+const Button = ( {
+	children,
+	...rest
+}: OriginalButton.Props & { icon?: any; iconSize?: number } ) => (
+	<OriginalButton { ...rest }>{ children }</OriginalButton>
 );
 
 function WpcomBlockEditorNavSidebar() {
@@ -52,7 +53,6 @@ function WpcomBlockEditorNavSidebar() {
 	const statusLabels = usePostStatusLabels();
 
 	const prevIsOpen = useRef( isOpen );
-	const closeButtonRef = useRef();
 
 	// Using layout effect to prevent a brief moment in time where both `isOpen` and `isClosing`
 	// are both false, causing a flicker during the fade out animation.
@@ -63,10 +63,6 @@ function WpcomBlockEditorNavSidebar() {
 		}
 
 		prevIsOpen.current = isOpen;
-
-		if ( isOpen && closeButtonRef.current ) {
-			closeButtonRef.current.focus();
-		}
 	}, [ isOpen, prevIsOpen, setSidebarClosing ] );
 
 	const [ isScrollbarPresent, setIsScrollbarPresent ] = useState( false );
@@ -226,7 +222,6 @@ function WpcomBlockEditorNavSidebar() {
 					className="wpcom-block-editor-nav-sidebar-nav-sidebar__home-button"
 					icon={ arrowLeft }
 					onClick={ handleClose }
-					ref={ closeButtonRef }
 				>
 					{ closeLabel }
 				</Button>

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
@@ -150,6 +150,11 @@ function WpcomBlockEditorNavSidebar() {
 		postType.slug
 	);
 
+	const closeAriaLabel =
+		postType.slug === 'page'
+			? __( 'View all pages in the Dashboard', 'full-site-editing' )
+			: __( 'View all posts in the Dashboard', 'full-site-editing' );
+
 	const dismissSidebar = () => {
 		if ( isOpen && ! isClosing ) {
 			toggleSidebar();
@@ -217,7 +222,7 @@ function WpcomBlockEditorNavSidebar() {
 					) }
 				</div>
 				<Button
-					aria-label={ __( 'View all pages in Dashboard', 'full-site-editing' ) }
+					aria-label={ closeAriaLabel }
 					href={ closeUrl }
 					className="wpcom-block-editor-nav-sidebar-nav-sidebar__home-button"
 					icon={ arrowLeft }

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
@@ -150,10 +150,16 @@ function WpcomBlockEditorNavSidebar() {
 		postType.slug
 	);
 
-	const closeAriaLabel =
+	const dialogDescription =
 		postType.slug === 'page'
-			? __( 'Return to the Dashboard to view all pages', 'full-site-editing' )
-			: __( 'Return to the Dashboard to view all posts', 'full-site-editing' );
+			? __(
+					'Contains links to your dashboard or to edit other pages on your site. Press the Escape key to close.',
+					'full-site-editing'
+			  )
+			: __(
+					'Contains links to your dashboard or to edit other posts on your site. Press the Escape key to close.',
+					'full-site-editing'
+			  );
 
 	const dismissSidebar = () => {
 		if ( isOpen && ! isClosing ) {
@@ -191,6 +197,9 @@ function WpcomBlockEditorNavSidebar() {
 			onKeyDown={ handleKeyDown }
 		>
 			<div
+				aria-label={ __( 'Block editor sidebar', 'full-site-editing' ) }
+				// eslint-disable-next-line jsx-a11y/aria-props
+				aria-description={ dialogDescription }
 				className={ classNames( 'wpcom-block-editor-nav-sidebar-nav-sidebar__container', {
 					'is-sliding-left': isClosing,
 				} ) }
@@ -200,11 +209,7 @@ function WpcomBlockEditorNavSidebar() {
 			>
 				<div className="wpcom-block-editor-nav-sidebar-nav-sidebar__header">
 					<Button
-						// eslint-disable-next-line jsx-a11y/aria-props
-						aria-description={ __(
-							'You are viewing the sidebar. Press the Escape key to close.',
-							'full-site-editing'
-						) }
+						aria-label={ __( 'Close block editor sidebar', 'full-site-editing' ) }
 						className={ classNames(
 							'edit-post-fullscreen-mode-close',
 							'wpcom-block-editor-nav-sidebar-nav-sidebar__dismiss-sidebar-button'
@@ -223,7 +228,8 @@ function WpcomBlockEditorNavSidebar() {
 					) }
 				</div>
 				<Button
-					aria-label={ closeAriaLabel }
+					// eslint-disable-next-line jsx-a11y/aria-props
+					aria-description={ __( 'Returns to the dashboard', 'full-site-editing' ) }
 					href={ closeUrl }
 					className="wpcom-block-editor-nav-sidebar-nav-sidebar__home-button"
 					icon={ arrowLeft }

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
@@ -122,6 +122,11 @@ function WpcomBlockEditorNavSidebar() {
 		return null;
 	}
 
+	// The `closeUrl` "closes" the editor, returning the user to the dashboard.
+	// It often takes the user back to the pages or posts list, but can also be overridden
+	// (using the filter) to take the user to the customer homepage or themes gallery instance.
+	// `closeLabel` can be overridden in the same way to correctly label where the user will
+	// be taken to after closing the editor.
 	const defaultCloseUrl = addQueryArgs( 'edit.php', { post_type: postType.slug } );
 	const closeUrl = applyFilters( 'a8c.WpcomBlockEditorNavSidebar.closeUrl', defaultCloseUrl );
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
@@ -196,7 +196,7 @@ function WpcomBlockEditorNavSidebar() {
 				<div className="wpcom-block-editor-nav-sidebar-nav-sidebar__header">
 					<Button
 						aria-label={ __(
-							'You are viewing the sidebar. To close select escape',
+							'You are viewing the sidebar. Press the Escape key to close.',
 							'full-site-editing'
 						) }
 						className={ classNames(

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/toggle-sidebar-button/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/toggle-sidebar-button/index.tsx
@@ -4,7 +4,7 @@
 import { Button as OriginalButton } from '@wordpress/components';
 import { wordpress } from '@wordpress/icons';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { __ } from '@wordpress/i18n/build-types';
+import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
 
 /**

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/toggle-sidebar-button/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/toggle-sidebar-button/index.tsx
@@ -4,6 +4,7 @@
 import { Button as OriginalButton } from '@wordpress/components';
 import { wordpress } from '@wordpress/icons';
 import { useDispatch, useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n/build-types';
 import classnames from 'classnames';
 
 /**
@@ -26,6 +27,7 @@ export default function ToggleSidebarButton() {
 
 	return (
 		<Button
+			aria-label={ __( 'Open sidebar', 'full-site-editing' ) }
 			className={ classnames(
 				'edit-post-fullscreen-mode-close',
 				'wpcom-block-editor-nav-sidebar-toggle-sidebar-button__button',

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/toggle-sidebar-button/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/toggle-sidebar-button/index.tsx
@@ -16,7 +16,7 @@ import './style.scss';
 const Button = ( {
 	children,
 	...rest
-}: OriginalButton.Props & { icon?: any; iconSize?: number } ) => (
+}: OriginalButton.Props & { icon?: any; iconSize?: number; showTooltip?: boolean } ) => (
 	<OriginalButton { ...rest }>{ children }</OriginalButton>
 );
 
@@ -27,7 +27,8 @@ export default function ToggleSidebarButton() {
 
 	return (
 		<Button
-			aria-label={ __( 'Open sidebar', 'full-site-editing' ) }
+			label={ __( 'Block editor sidebar', 'full-site-editing' ) }
+			showTooltip
 			className={ classnames(
 				'edit-post-fullscreen-mode-close',
 				'wpcom-block-editor-nav-sidebar-toggle-sidebar-button__button',


### PR DESCRIPTION
- The dialog close button gets the focus, not the dialog itself
- Names the sidebar the "Block Editor Sidebar"
- Uses a combination of labels _and_ descriptions. When using VoiceOver is reading things out, it reads the labels first and if you wait a little bit it will eventually read the description too.