### PR TITLE
Fix feature picker icon alignments

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/features/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/features/style.scss
@@ -31,7 +31,7 @@
 	margin: -12px;
 }
 
-.features__item.components-button.is-tertiary {
+.features__items > button.features__item.components-button.is-tertiary {
 	border: 1px solid var( --studio-gray-5 );
 	border-radius: 4px;
 	width: calc( 100% - 24px );
@@ -41,7 +41,6 @@
 	text-align: left;
 	position: relative;
 	padding: 16px;
-	padding-right: 32px; // Feels more balanced with icon on the left
 	align-items: start;
 	white-space: normal;
 	color: var( --studio-gray-100 );
@@ -73,7 +72,11 @@
 }
 
 .features__item-heading {
-	padding-left: 40px;
+	padding-left: 10px;
+}
+
+.features__item-image {
+	margin-top: 2px;
 }
 
 .features__item-name {
@@ -87,10 +90,4 @@
 	line-height: 1.3;
 	color: var( --studio-gray-40 );
 	margin: 4px 0;
-}
-
-.features__item-image {
-	position: absolute;
-	top: 16px;
-	left: 16px;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* It fixes the icons vertical alignment. Currently it looks like this:

**Before**:
![image](https://user-images.githubusercontent.com/17054134/91321088-8dfa1200-e7be-11ea-8f83-53c71977a754.png)
**After**:
![image](https://user-images.githubusercontent.com/17054134/91321173-a407d280-e7be-11ea-955b-c2a26ac9c0fa.png)


#### Testing instructions

1. Using incognito mode, visit [`new/features?flags=gutenboarding/feature-picker&latest`](https://hash-f2fe5da3bd6ad847526450f3c76f1f3a9860fc17.calypso.live/new/features?flags=gutenboarding/feature-picker&latest)
2. Icons should be well-aligned.

Superseeds https://github.com/Automattic/wp-calypso/pull/45249

