### PR TITLE
Fix blockquotes to appear as quotes in Notifications panel "single" views

### DIFF
--- a/apps/notifications/style.scss
+++ b/apps/notifications/style.scss
@@ -51,6 +51,11 @@
 			top: 47px;
 		}
 	}
+
+	.wpnc__em {
+		font-style: italic;
+		color: var( --color-neutral-40 );
+	}
 }
 
 #wpnc-panel.wide {


### PR DESCRIPTION
This looks to address the issue whereby Notification "Note"s which contain Gutenberg Quote blocks don't have any formatting or visual styling to indicate that they are a quotation.


## Changes proposed in this Pull Request

* Add styling to all em tags to appear italicised and slightly off grey.


## Testing instructions


* Setup a test site (I used [a p2 site](https://wordpress.com/start/p2)) and check that when you post a new Post you see a new Notification appear in the Calypso Notifications panel (look for little "bell" icon in top right corner).
* With this in place, try posting a **new post** using the Block Editor and containing a quote block.
* Look at your Notifications panel to see the new Note.
* Check the quotation element is clearly distinct as a quote (see screenshot below for example):
| Screenshot |
| ----- |
| <img width="851" alt="Screen Shot 2020-09-01 at 15 31 50" src="https://user-images.githubusercontent.com/444434/91864588-46650180-ec68-11ea-8058-f15364a876b9.png"> |

* Now repeat the same process but this time posting a **comment** using the **Gutenberg editor** on your p2.


Fixes https://github.com/Automattic/wp-calypso/issues/45120
