### PR TITLE
Components: Remove global checkbox styles

### DIFF
--- a/client/assets/stylesheets/shared/_forms.scss
+++ b/client/assets/stylesheets/shared/_forms.scss
@@ -11,7 +11,6 @@ input[type='search'],
 input[type='email'],
 input[type='number'],
 input[type='password'],
-input[type='checkbox'],
 input[type='tel'],
 input[type='url'],
 textarea {
@@ -42,47 +41,6 @@ input[type='url'] {
 	direction: ltr;
 }
 
-/*Checkbooms*/
-
-input[type='checkbox'] {
-	clear: none;
-	cursor: pointer;
-	display: inline-block;
-	line-height: 0;
-	height: 16px;
-	margin: 2px 0 0;
-	float: left;
-	outline: 0;
-	padding: 0;
-	text-align: center;
-	vertical-align: middle;
-	width: 16px;
-	min-width: 16px;
-	appearance: none;
-}
-
-input[type='checkbox'] + span {
-	display: block;
-	margin-left: 24px;
-}
-
-input[type='checkbox'] {
-	border-radius: 2px;
-
-	&:checked::before {
-		content: url( '/calypso/images/checkbox-icons/checkmark-primary.svg' );
-		width: 12px;
-		height: 12px;
-		margin: 1px auto;
-		display: inline-block;
-		speak: none;
-	}
-
-	&:disabled:checked::before {
-		color: var( --color-neutral-20 );
-	}
-}
-
 @keyframes grow {
 	0% {
 		transform: scale( 0.3 );
@@ -96,8 +54,6 @@ input[type='checkbox'] {
 		transform: scale( 1 );
 	}
 }
-
-/* end checkbooms */
 
 select {
 	background: var( --color-surface )

--- a/client/blocks/nps-survey/docs/example.jsx
+++ b/client/blocks/nps-survey/docs/example.jsx
@@ -10,6 +10,8 @@ import { noop } from 'lodash';
 /**
  * Internal dependencies
  */
+import FormInputCheckbox from 'components/forms/form-checkbox';
+import FormLabel from 'components/forms/form-label';
 import { NpsSurvey } from '../';
 import {
 	isNpsSurveySubmitted,
@@ -52,14 +54,14 @@ class NpsSurveyExample extends PureComponent {
 	renderOptions() {
 		return (
 			<div style={ { marginTop: '10px' } }>
-				<label style={ { display: 'block' } }>
-					<input type="checkbox" onClick={ this.toggleBusinessUser } />
-					The user subscribes the Business plan.
-				</label>
-				<label style={ { display: 'block' } }>
-					<input type="checkbox" onClick={ this.toggleConciergeSessionAvailability } />
-					The user is available for concierge sessions.
-				</label>
+				<FormLabel>
+					<FormInputCheckbox onClick={ this.toggleBusinessUser } />
+					<span>The user subscribes the Business plan.</span>
+				</FormLabel>
+				<FormLabel>
+					<FormInputCheckbox onClick={ this.toggleConciergeSessionAvailability } />
+					<span>The user is available for concierge sessions.</span>
+				</FormLabel>
 			</div>
 		);
 	}

--- a/client/components/bulk-select/docs/example.jsx
+++ b/client/components/bulk-select/docs/example.jsx
@@ -9,6 +9,8 @@ import React from 'react';
  */
 import { Card } from '@automattic/components';
 import BulkSelect from 'components/bulk-select';
+import FormInputCheckbox from 'components/forms/form-checkbox';
+import FormLabel from 'components/forms/form-label';
 
 export default class extends React.Component {
 	static displayName = 'BulkSelects';
@@ -21,7 +23,7 @@ export default class extends React.Component {
 	};
 
 	handleToggleAll = ( checkedState ) => {
-		let newElements = [];
+		const newElements = [];
 		this.state.elements.forEach( ( element ) => {
 			if ( typeof checkedState !== 'undefined' ) {
 				element.selected = checkedState;
@@ -46,10 +48,10 @@ export default class extends React.Component {
 				this.forceUpdate();
 			}.bind( this );
 			return (
-				<label key={ index }>
-					<input type="checkbox" onClick={ onClick } checked={ element.selected } readOnly />
+				<FormLabel key={ index }>
+					<FormInputCheckbox onClick={ onClick } checked={ element.selected } readOnly />
 					<span>{ element.title }</span>
-				</label>
+				</FormLabel>
 			);
 		} );
 	};

--- a/client/components/bulk-select/index.jsx
+++ b/client/components/bulk-select/index.jsx
@@ -11,6 +11,8 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import Count from 'components/count';
+import FormInputCheckbox from 'components/forms/form-checkbox';
+import FormLabel from 'components/forms/form-label';
 
 /**
  * Style dependencies
@@ -57,9 +59,8 @@ export class BulkSelect extends React.Component {
 
 		return (
 			<span className="bulk-select">
-				<label className="bulk-select__container">
-					<input
-						type="checkbox"
+				<FormLabel className="bulk-select__container">
+					<FormInputCheckbox
 						className={ inputClasses }
 						checked={ isChecked }
 						onChange={ this.handleToggleAll }
@@ -67,7 +68,7 @@ export class BulkSelect extends React.Component {
 					/>
 					<Count count={ this.props.selectedElements } />
 					{ this.getStateIcon() }
-				</label>
+				</FormLabel>
 			</span>
 		);
 	}

--- a/client/components/bulk-select/style.scss
+++ b/client/components/bulk-select/style.scss
@@ -2,11 +2,12 @@
 	display: inline-block;
 }
 
-.bulk-select__container {
+.bulk-select__container.form-label {
 	cursor: pointer;
 	display: flex;
 		align-items: center;
 	position: relative;
+	margin-bottom: 0;
 
 	.gridicon {
 		color: var( --color-primary );
@@ -19,6 +20,7 @@
 
 	> .count {
 		margin-left: 8px;
+		font-weight: 600;
 	}
 }
 

--- a/client/components/bulk-select/test/index.js
+++ b/client/components/bulk-select/test/index.js
@@ -6,7 +6,7 @@
  * External dependencies
  */
 import { assert } from 'chai';
-import { shallow } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 import { identity, noop } from 'lodash';
 import React from 'react';
 
@@ -77,7 +77,7 @@ describe( 'index', () => {
 	} );
 
 	test( 'should add the aria-label to the input', () => {
-		const bulkSelect = shallow(
+		const bulkSelect = mount(
 			<BulkSelect
 				translate={ identity }
 				selectedElements={ 2 }
@@ -90,7 +90,7 @@ describe( 'index', () => {
 	} );
 
 	test( 'should not mark the input readOnly', () => {
-		const bulkSelect = shallow(
+		const bulkSelect = mount(
 			<BulkSelect
 				translate={ identity }
 				selectedElements={ 2 }
@@ -107,7 +107,7 @@ describe( 'index', () => {
 		const callback = function () {
 			hasBeenCalled = true;
 		};
-		const bulkSelect = shallow(
+		const bulkSelect = mount(
 			<BulkSelect
 				translate={ identity }
 				selectedElements={ 0 }
@@ -124,7 +124,7 @@ describe( 'index', () => {
 			assert.equal( newState, true );
 			done();
 		};
-		const bulkSelect = shallow(
+		const bulkSelect = mount(
 			<BulkSelect
 				translate={ identity }
 				selectedElements={ 0 }
@@ -140,7 +140,7 @@ describe( 'index', () => {
 			assert.equal( newState, false );
 			done();
 		};
-		const bulkSelect = shallow(
+		const bulkSelect = mount(
 			<BulkSelect
 				translate={ identity }
 				selectedElements={ 1 }
@@ -156,7 +156,7 @@ describe( 'index', () => {
 			assert.equal( newState, false );
 			done();
 		};
-		const bulkSelect = shallow(
+		const bulkSelect = mount(
 			<BulkSelect
 				translate={ identity }
 				selectedElements={ 3 }

--- a/client/components/chart/legend-item.jsx
+++ b/client/components/chart/legend-item.jsx
@@ -4,6 +4,12 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
+/**
+ * Internal dependencies
+ */
+import FormInputCheckbox from 'components/forms/form-checkbox';
+import FormLabel from 'components/forms/form-label';
+
 export default class ChartLegendItem extends React.PureComponent {
 	static propTypes = {
 		attr: PropTypes.string.isRequired,
@@ -19,16 +25,15 @@ export default class ChartLegendItem extends React.PureComponent {
 	render() {
 		return (
 			<li className="chart__legend-option">
-				<label className="chart__legend-label is-selectable">
-					<input
+				<FormLabel className="chart__legend-label is-selectable">
+					<FormInputCheckbox
 						checked={ this.props.checked }
 						className="chart__legend-checkbox"
 						onChange={ this.clickHandler }
-						type="checkbox"
 					/>
 					<span className={ this.props.className } />
 					{ this.props.label }
-				</label>
+				</FormLabel>
 			</li>
 		);
 	}

--- a/client/components/chart/style.scss
+++ b/client/components/chart/style.scss
@@ -254,6 +254,13 @@ $y-axis-padding: 0 20px 0 10px;
 	display: inline-block;
 	padding: 12px 19px 10px 20px; // 1
 
+	&.form-label {
+		display: inline-block;
+		margin-bottom: 0;
+		font-weight: 400;
+		font-size: $font-body-extra-small;
+	}
+
 	&.is-selectable {
 		cursor: pointer;
 

--- a/client/components/forms/form-checkbox/index.jsx
+++ b/client/components/forms/form-checkbox/index.jsx
@@ -4,6 +4,11 @@
 import React from 'react';
 import classnames from 'classnames';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 const FormInputCheckbox = ( { className, ...otherProps } ) => (
 	<input { ...otherProps } type="checkbox" className={ classnames( className, 'form-checkbox' ) } />
 );

--- a/client/components/forms/form-checkbox/index.tsx
+++ b/client/components/forms/form-checkbox/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { FunctionComponent, InputHTMLAttributes } from 'react';
 import classnames from 'classnames';
 
 /**
@@ -9,7 +9,9 @@ import classnames from 'classnames';
  */
 import './style.scss';
 
-const FormInputCheckbox = ( { className, ...otherProps } ) => (
+type CheckboxProps = InputHTMLAttributes< HTMLInputElement >;
+
+const FormInputCheckbox: FunctionComponent< CheckboxProps > = ( { className, ...otherProps } ) => (
 	<input { ...otherProps } type="checkbox" className={ classnames( className, 'form-checkbox' ) } />
 );
 

--- a/client/components/forms/form-checkbox/style.scss
+++ b/client/components/forms/form-checkbox/style.scss
@@ -1,4 +1,4 @@
-input[type='checkbox'].form-checkbox {
+.form-checkbox {
 	@extend %form-field;
 
 	clear: none;

--- a/client/components/forms/form-checkbox/style.scss
+++ b/client/components/forms/form-checkbox/style.scss
@@ -1,0 +1,37 @@
+input[type='checkbox'].form-checkbox {
+	@extend %form-field;
+
+	clear: none;
+	cursor: pointer;
+	display: inline-block;
+	line-height: 0;
+	height: 16px;
+	margin: 2px 0 0;
+	float: left;
+	outline: 0;
+	padding: 0;
+	text-align: center;
+	vertical-align: middle;
+	width: 16px;
+	min-width: 16px;
+	appearance: none;
+	border-radius: 2px;
+
+	&:checked::before {
+		content: url( '/calypso/images/checkbox-icons/checkmark-primary.svg' );
+		width: 12px;
+		height: 12px;
+		margin: 1px auto;
+		display: inline-block;
+		speak: none;
+	}
+
+	&:disabled:checked::before {
+		color: var( --color-neutral-20 );
+	}
+
+	& + span {
+		display: block;
+		margin-left: 24px;
+	}
+}

--- a/client/components/forms/form-label/index.tsx
+++ b/client/components/forms/form-label/index.tsx
@@ -11,8 +11,8 @@ import { useTranslate } from 'i18n-calypso';
 import './style.scss';
 
 interface Props {
-	optional: boolean;
-	required: boolean;
+	optional?: boolean;
+	required?: boolean;
 }
 
 type LabelProps = LabelHTMLAttributes< HTMLLabelElement >;

--- a/client/components/forms/form-toggle/index.jsx
+++ b/client/components/forms/form-toggle/index.jsx
@@ -11,6 +11,11 @@ import classNames from 'classnames';
 import { noop } from 'lodash';
 
 /**
+ * Internal dependencies
+ */
+import FormInputCheckbox from 'components/forms/form-checkbox';
+
+/**
  * Style dependencies
  */
 import './style.scss';
@@ -87,10 +92,9 @@ export default class FormToggle extends PureComponent {
 
 		return (
 			<span className={ wrapperClasses }>
-				<input
+				<FormInputCheckbox
 					id={ id }
 					className={ toggleClasses }
-					type="checkbox"
 					checked={ this.props.checked }
 					readOnly={ true }
 					disabled={ this.props.disabled }

--- a/client/components/forms/form-toggle/test/index.jsx
+++ b/client/components/forms/form-toggle/test/index.jsx
@@ -93,7 +93,7 @@ describe( 'FormToggle', () => {
 					<FormToggle checked={ false } />
 				</div>
 			);
-			const toggleInputs = toggles.find( '.form-toggle' );
+			const toggleInputs = toggles.find( 'input.form-toggle' );
 			const ids = toggleInputs.map( ( input ) => input.props().id );
 
 			assert( ids.length === uniq( ids ).length );

--- a/client/components/forms/multi-checkbox/README.md
+++ b/client/components/forms/multi-checkbox/README.md
@@ -3,6 +3,8 @@ MultiCheckbox
 
 MultiCheckbox is a React component that can be used in forms to simplify the creation of checkbox inputs where multiple values are possible.
 
+Under the hood, it uses the FormLabel and FormInputCheckbox components.
+
 ## Example
 
 Below is an example use for the MultiCheckbox component:
@@ -20,8 +22,8 @@ This code snippet will generate the following output:
 
 ```html
 <div>
-	<label><input type="checkbox" name="favorite_numbers[]" value="1" checked="checked"><span>One</span></label>
-	<label><input type="checkbox" name="favorite_numbers[]" value="2"><span>Two</span></label>
+	<label class="form-label"><input type="checkbox" class="form-checkbox" name="favorite_numbers[]" value="1" checked="checked"><span>One</span></label>
+	<label class="form-label"><input type="checkbox" class="form-checkbox" name="favorite_numbers[]" value="2"><span>Two</span></label>
 </div>
 ```
 

--- a/client/components/forms/multi-checkbox/index.tsx
+++ b/client/components/forms/multi-checkbox/index.tsx
@@ -8,6 +8,12 @@ import { noop } from 'lodash';
  * Internal dependencies
  */
 import FormInputCheckbox from 'components/forms/form-checkbox';
+import FormLabel from 'components/forms/form-label';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
 
 type OptionValue = number | string;
 
@@ -67,7 +73,7 @@ export default function MultiCheckbox( props: Props & DivProps ) {
 	return (
 		<div className="multi-checkbox" { ...otherProps }>
 			{ options.map( ( option ) => (
-				<label key={ option.value }>
+				<FormLabel key={ option.value }>
 					<FormInputCheckbox
 						name={ name + '[]' }
 						value={ option.value }
@@ -76,7 +82,7 @@ export default function MultiCheckbox( props: Props & DivProps ) {
 						disabled={ disabled }
 					/>
 					<span>{ option.label }</span>
-				</label>
+				</FormLabel>
 			) ) }
 		</div>
 	);

--- a/client/components/forms/multi-checkbox/index.tsx
+++ b/client/components/forms/multi-checkbox/index.tsx
@@ -2,6 +2,12 @@
  * External dependencies
  */
 import React, { useCallback, useRef } from 'react';
+import { noop } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import FormInputCheckbox from 'components/forms/form-checkbox';
 
 type OptionValue = number | string;
 
@@ -30,7 +36,7 @@ export default function MultiCheckbox( props: Props & DivProps ) {
 		checked,
 		defaultChecked = [] as OptionValue[],
 		disabled = false,
-		onChange = () => {},
+		onChange = noop,
 		name = 'multiCheckbox',
 		options,
 		...otherProps
@@ -62,9 +68,8 @@ export default function MultiCheckbox( props: Props & DivProps ) {
 		<div className="multi-checkbox" { ...otherProps }>
 			{ options.map( ( option ) => (
 				<label key={ option.value }>
-					<input
+					<FormInputCheckbox
 						name={ name + '[]' }
-						type="checkbox"
 						value={ option.value }
 						checked={ checkedItems.includes( option.value ) }
 						onChange={ handleChange }

--- a/client/components/forms/multi-checkbox/style.scss
+++ b/client/components/forms/multi-checkbox/style.scss
@@ -1,0 +1,6 @@
+.multi-checkbox {
+	.form-label {
+		margin-bottom: 0;
+		font-size: $font-body;
+	}
+}

--- a/client/components/line-chart/docs/example.js
+++ b/client/components/line-chart/docs/example.js
@@ -9,6 +9,8 @@ import moment from 'moment';
  * Internal dependencies
  */
 import { Card } from '@automattic/components';
+import FormInputCheckbox from 'components/forms/form-checkbox';
+import FormLabel from 'components/forms/form-label';
 import LineChart from 'components/line-chart';
 
 const NUM_DATA_SERIES = 3;
@@ -107,7 +109,7 @@ export default class LineChartExample extends Component {
 
 				{ this.state.showDataControls && (
 					<div>
-						<label>
+						<FormLabel>
 							Data Min
 							<input
 								type="number"
@@ -115,9 +117,9 @@ export default class LineChartExample extends Component {
 								min="0"
 								onChange={ this.changeDataMin }
 							/>
-						</label>
+						</FormLabel>
 
-						<label>
+						<FormLabel>
 							Data Max
 							<input
 								type="number"
@@ -125,9 +127,9 @@ export default class LineChartExample extends Component {
 								min="0"
 								onChange={ this.changeDataMax }
 							/>
-						</label>
+						</FormLabel>
 
-						<label>
+						<FormLabel>
 							Series Length
 							<input
 								type="number"
@@ -135,17 +137,16 @@ export default class LineChartExample extends Component {
 								min="3"
 								onChange={ this.changeSeriesLength }
 							/>
-						</label>
+						</FormLabel>
 
 						<div>
-							<label>
-								<input
-									type="checkbox"
+							<FormLabel>
+								<FormInputCheckbox
 									checked={ this.state.fillArea }
 									onChange={ this.toggleFillArea }
 								/>
 								Fill Area
-							</label>
+							</FormLabel>
 						</div>
 					</div>
 				) }

--- a/client/components/pie-chart/docs/example.js
+++ b/client/components/pie-chart/docs/example.js
@@ -7,6 +7,8 @@ import React, { Component } from 'react';
  * Internal dependencies
  */
 import { Card } from '@automattic/components';
+import FormInputCheckbox from 'components/forms/form-checkbox';
+import FormLabel from 'components/forms/form-label';
 import PieChart from 'components/pie-chart';
 import PieChartLegend from 'components/pie-chart/legend';
 
@@ -107,13 +109,14 @@ class PieChartExample extends Component {
 										value={ this.state[ seriesName ].value }
 										onChange={ this.changeValue }
 									/>
-									<label>{ 'Show' }</label>{ ' ' }
-									<input
-										name={ seriesName }
-										type="checkbox"
-										checked={ this.state[ seriesName ].show }
-										onChange={ this.changeShow }
-									/>
+									<FormLabel>
+										<FormInputCheckbox
+											name={ seriesName }
+											checked={ this.state[ seriesName ].show }
+											onChange={ this.changeShow }
+										/>
+										<span>Show</span>
+									</FormLabel>
 								</div>
 							);
 						} ) }

--- a/client/components/pie-chart/docs/example.js
+++ b/client/components/pie-chart/docs/example.js
@@ -6,7 +6,7 @@ import React, { Component } from 'react';
 /**
  * Internal dependencies
  */
-import { Card } from '@automattic/components';
+import { Button, Card } from '@automattic/components';
 import FormInputCheckbox from 'components/forms/form-checkbox';
 import FormLabel from 'components/forms/form-label';
 import PieChart from 'components/pie-chart';
@@ -88,9 +88,9 @@ class PieChartExample extends Component {
 
 		return (
 			<div>
-				<a className="docs__design-toggle button" onClick={ this.changeShowDataControls }>
+				<Button className="docs__design-toggle" onClick={ this.changeShowDataControls }>
 					{ this.state.showDataControls ? 'Hide Data Controls' : 'Show Data Controls' }
-				</a>
+				</Button>
 
 				<Card>
 					<PieChart data={ data } title={ this.titleFunc } />

--- a/client/components/redux-forms/redux-form-toggle/index.jsx
+++ b/client/components/redux-forms/redux-form-toggle/index.jsx
@@ -25,7 +25,7 @@ class ReduxFormToggle extends Component {
 	};
 
 	render() {
-		return <Field component={ ToggleRenderer } type="checkbox" { ...this.props } />;
+		return <Field component={ ToggleRenderer } { ...this.props } />;
 	}
 }
 

--- a/client/components/redux-forms/redux-form-toggle/index.jsx
+++ b/client/components/redux-forms/redux-form-toggle/index.jsx
@@ -25,7 +25,7 @@ class ReduxFormToggle extends Component {
 	};
 
 	render() {
-		return <Field component={ ToggleRenderer } { ...this.props } />;
+		return <Field component={ ToggleRenderer } type="checkbox" { ...this.props } />;
 	}
 }
 

--- a/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
@@ -146,7 +146,7 @@ class ProductForm extends Component {
 						component={ renderPriceField }
 					/>
 					<div>
-						<ReduxFormFieldset name="multiple" type="checkbox" component={ CompactFormToggle }>
+						<ReduxFormFieldset name="multiple" component={ CompactFormToggle }>
 							{ translate( 'Allow people to buy more than one item at a time.' ) }
 						</ReduxFormFieldset>
 						<ReduxFormFieldset

--- a/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
@@ -146,7 +146,7 @@ class ProductForm extends Component {
 						component={ renderPriceField }
 					/>
 					<div>
-						<ReduxFormFieldset name="multiple" component={ CompactFormToggle }>
+						<ReduxFormFieldset name="multiple" type="checkbox" component={ CompactFormToggle }>
 							{ translate( 'Allow people to buy more than one item at a time.' ) }
 						</ReduxFormFieldset>
 						<ReduxFormFieldset

--- a/client/components/tinymce/plugins/wpcom-view/views/contact-form/preview-fields.jsx
+++ b/client/components/tinymce/plugins/wpcom-view/views/contact-form/preview-fields.jsx
@@ -11,6 +11,7 @@ import PreviewFieldset from './preview-fieldset';
 import PreviewLegend from './preview-legend';
 import PreviewRequired from './preview-required';
 
+import FormInputCheckbox from 'wp-calypso-client/components/forms/form-checkbox';
 import FormLabel from 'wp-calypso-client/components/forms/form-label';
 import FormRadio from 'wp-calypso-client/components/forms/form-radio';
 
@@ -30,11 +31,11 @@ const textarea = ( field, index ) => (
 
 const checkbox = ( field, index ) => (
 	<PreviewFieldset key={ 'contact-form-field-' + index }>
-		<label>
-			<input type="checkbox" />
+		<FormLabel>
+			<FormInputCheckbox />
 			{ field.label }
 			<PreviewRequired required={ field.required } />
-		</label>
+		</FormLabel>
 	</PreviewFieldset>
 );
 

--- a/client/extensions/woocommerce/components/bulk-select/index.js
+++ b/client/extensions/woocommerce/components/bulk-select/index.js
@@ -5,6 +5,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Gridicon from 'components/gridicon';
+import FormInputCheckbox from 'components/forms/form-checkbox';
 
 const BulkSelect = ( {
 	className,
@@ -31,9 +32,8 @@ const BulkSelect = ( {
 	return (
 		<span className={ containerClasses }>
 			<span className="bulk-select__container">
-				<input
+				<FormInputCheckbox
 					id={ id }
-					type="checkbox"
 					className={ inputClasses }
 					onChange={ handleToggle }
 					checked={ hasAllElementsSelected }

--- a/client/extensions/woocommerce/components/product-search/index.js
+++ b/client/extensions/woocommerce/components/product-search/index.js
@@ -14,6 +14,7 @@ import { areProductsLoading, getAllProducts } from 'woocommerce/state/sites/prod
 import { fetchProducts } from 'woocommerce/state/sites/products/actions';
 import { getLink } from 'woocommerce/lib/nav-utils';
 import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
+import FormInputCheckbox from 'components/forms/form-checkbox';
 import NoResults from 'my-sites/no-results';
 import Search from 'components/search';
 import ProductSearchRow from './row';
@@ -122,7 +123,7 @@ class ProductSearch extends Component {
 			<div className="product-search__list">
 				<div className="product-search__row is-placeholder">
 					<div className="product-search__row-item">
-						<input type="checkbox" disabled />
+						<FormInputCheckbox disabled />
 						<span className="product-search__list-image is-thumb-placeholder" />
 						<span className="product-search__row-title" />
 					</div>

--- a/client/extensions/woocommerce/woocommerce-services/components/checkbox/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/components/checkbox/style.scss
@@ -6,6 +6,10 @@
 	position: relative;
 	vertical-align: text-bottom;
 
+	&.form-toggle {
+		display: none;
+	}
+
 	input {
 		margin: 0;
 

--- a/client/layout/community-translator/launcher.jsx
+++ b/client/layout/community-translator/launcher.jsx
@@ -30,6 +30,8 @@ import { setLocale } from 'state/ui/language/actions';
 import getCurrentLocaleSlug from 'state/selectors/get-current-locale-slug';
 import QueryUserSettings from 'components/data/query-user-settings';
 import FormTextInput from 'components/forms/form-text-input';
+import FormInputCheckbox from 'components/forms/form-checkbox';
+import FormLabel from 'components/forms/form-label';
 
 /**
  * Style dependencies
@@ -354,10 +356,10 @@ class TranslatorLauncher extends React.Component {
 					) }
 				</p>
 				<p>
-					<label htmlFor="toggle">
-						<input type="checkbox" id="toggle" onClick={ this.toggleInfoCheckbox } />
+					<FormLabel htmlFor="toggle">
+						<FormInputCheckbox id="toggle" onClick={ this.toggleInfoCheckbox } />
 						<span>{ translate( "Don't show again" ) }</span>
-					</label>
+					</FormLabel>
 				</p>
 			</Dialog>
 		);

--- a/client/me/profile-links-add-wordpress/site.jsx
+++ b/client/me/profile-links-add-wordpress/site.jsx
@@ -8,6 +8,7 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
+import FormInputCheckbox from 'components/forms/form-checkbox';
 import Site from 'blocks/site';
 import { recordGoogleEvent } from 'state/analytics/actions';
 
@@ -41,15 +42,15 @@ class ProfileLinksAddWordPressSite extends Component {
 	render() {
 		const { checked, onChange, site } = this.props;
 
+		/* eslint-disable jsx-a11y/click-events-have-key-events,jsx-a11y/no-noninteractive-element-interactions */
 		return (
 			<li
 				key={ site.ID }
 				className="profile-links-add-wordpress__item"
 				onClick={ this.getCheckboxEventHandler( 'Add WordPress Site' ) }
 			>
-				<input
+				<FormInputCheckbox
 					className="profile-links-add-wordpress__checkbox"
-					type="checkbox"
 					name={ this.getInputName() }
 					onChange={ onChange }
 					checked={ checked }
@@ -57,6 +58,7 @@ class ProfileLinksAddWordPressSite extends Component {
 				<Site site={ site } indicator={ false } onSelect={ this.onSelect } />
 			</li>
 		);
+		/* eslint-enable jsx-a11y/click-events-have-key-events,jsx-a11y/no-noninteractive-element-interactions */
 	}
 }
 

--- a/client/my-sites/domains/domain-management/dns/domain-connect-record.jsx
+++ b/client/my-sites/domains/domain-management/dns/domain-connect-record.jsx
@@ -121,7 +121,6 @@ class DomainConnectRecord extends React.Component {
 									id="domain-connect-record"
 									name="domain-connect-record"
 									onChange={ this.handleToggle }
-									type="checkbox"
 									checked={ enabled }
 									value="active"
 									disabled={ this.state.dnsRecordIsBeingUpdated }

--- a/client/my-sites/domains/domain-management/name-servers/wpcom-nameservers-toggle.jsx
+++ b/client/my-sites/domains/domain-management/name-servers/wpcom-nameservers-toggle.jsx
@@ -32,7 +32,6 @@ class NameserversToggle extends React.PureComponent {
 						id="wp-nameservers"
 						name="wp-nameservers"
 						onChange={ this.handleToggle }
-						type="checkbox"
 						checked={ this.props.enabled }
 						value="active"
 					/>

--- a/client/my-sites/marketing/buttons/appearance.jsx
+++ b/client/my-sites/marketing/buttons/appearance.jsx
@@ -14,6 +14,8 @@ import { localize } from 'i18n-calypso';
 import ButtonsPreview from './preview';
 import ButtonsPreviewPlaceholder from './preview-placeholder';
 import ButtonsStyle from './style';
+import FormInputCheckbox from 'components/forms/form-checkbox';
+import FormLabel from 'components/forms/form-label';
 import SupportInfo from 'components/support-info';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
@@ -109,10 +111,9 @@ class SharingButtonsAppearance extends Component {
 	getReblogOptionElement() {
 		if ( ! this.props.isJetpack ) {
 			return (
-				<label>
-					<input
+				<FormLabel>
+					<FormInputCheckbox
 						name="disabled_reblogs"
-						type="checkbox"
 						checked={ this.isReblogButtonEnabled() }
 						onChange={ this.onReblogsLikesCheckboxClicked }
 						disabled={ ! this.props.initialized }
@@ -122,7 +123,7 @@ class SharingButtonsAppearance extends Component {
 							context: 'Sharing options: Checkbox label',
 						} ) }
 					</span>
-				</label>
+				</FormLabel>
 			);
 		}
 	}
@@ -138,10 +139,9 @@ class SharingButtonsAppearance extends Component {
 						: translate( 'Reblog & Like', { context: 'Sharing options: Header' } ) }
 				</legend>
 				{ this.getReblogOptionElement() }
-				<label>
-					<input
+				<FormLabel>
+					<FormInputCheckbox
 						name="disabled_likes"
-						type="checkbox"
 						checked={ this.isLikeButtonEnabled() }
 						onChange={ this.onReblogsLikesCheckboxClicked }
 						disabled={ ! this.props.initialized }
@@ -157,7 +157,7 @@ class SharingButtonsAppearance extends Component {
 						privacyLink={ false }
 						position={ 'bottom left' }
 					/>
-				</label>
+				</FormLabel>
 			</fieldset>
 		);
 	}

--- a/client/my-sites/marketing/buttons/options.jsx
+++ b/client/my-sites/marketing/buttons/options.jsx
@@ -11,6 +11,8 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import FormInputCheckbox from 'components/forms/form-checkbox';
+import FormLabel from 'components/forms/form-label';
 import MultiCheckbox from 'components/forms/multi-checkbox';
 import SupportInfo from 'components/support-info';
 import { getPostTypes } from 'state/post-types/selectors';
@@ -197,10 +199,9 @@ class SharingButtonsOptions extends Component {
 				<legend className="sharing-buttons__fieldset-heading">
 					{ translate( 'Comment Likes', { context: 'Sharing options: Header' } ) }
 				</legend>
-				<label>
-					<input
+				<FormLabel>
+					<FormInputCheckbox
 						name="jetpack_comment_likes_enabled"
-						type="checkbox"
 						checked={ checked }
 						onChange={ this.handleChange }
 						disabled={ ! initialized }
@@ -216,7 +217,7 @@ class SharingButtonsOptions extends Component {
 						privacyLink={ false }
 						position={ 'bottom left' }
 					/>
-				</label>
+				</FormLabel>
 			</fieldset>
 		);
 	}

--- a/client/my-sites/marketing/connections/connection.jsx
+++ b/client/my-sites/marketing/connections/connection.jsx
@@ -13,6 +13,7 @@ import Gridicon from 'components/gridicon';
 /**
  * Internal dependencies
  */
+import FormInputCheckbox from 'components/forms/form-checkbox';
 import { ScreenReaderText } from '@automattic/components';
 import { getCurrentUserId } from 'state/current-user/selectors';
 import canCurrentUser from 'state/selectors/can-current-user';
@@ -190,9 +191,8 @@ class SharingConnection extends Component {
 
 		if ( this.props.userHasCaps ) {
 			content.push(
-				<input
+				<FormInputCheckbox
 					key="checkbox"
-					type="checkbox"
 					checked={ this.isConnectionShared() }
 					onChange={ this.toggleSitewideConnection }
 					readOnly={ this.state.isSavingSitewide }

--- a/client/my-sites/plugins/plugin-action/test/index.jsx
+++ b/client/my-sites/plugins/plugin-action/test/index.jsx
@@ -27,7 +27,7 @@ describe( 'PluginAction', () => {
 		test( 'should render compact form toggle when no children passed', () => {
 			const wrapper = mount( <PluginAction /> );
 
-			expect( wrapper.find( '.form-toggle' ) ).to.have.lengthOf( 1 );
+			expect( wrapper.find( 'input.form-toggle' ) ).to.have.lengthOf( 1 );
 		} );
 
 		test( 'should render a plugin action label', () => {

--- a/client/my-sites/plugins/plugin-item/plugin-item.jsx
+++ b/client/my-sites/plugins/plugin-item/plugin-item.jsx
@@ -11,6 +11,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import FormInputCheckbox from 'components/forms/form-checkbox';
 import { CompactCard } from '@automattic/components';
 import PluginIcon from 'my-sites/plugins/plugin-icon/plugin-icon';
 import PluginActivateToggle from 'my-sites/plugins/plugin-activate-toggle';
@@ -331,10 +332,9 @@ class PluginItem extends Component {
 		return (
 			<CompactCard className={ pluginItemClasses }>
 				{ ! this.props.isSelectable ? null : (
-					<input
+					<FormInputCheckbox
 						className="plugin-item__checkbox"
 						id={ plugin.slug }
-						type="checkbox"
 						onClick={ this.props.onClick }
 						checked={ this.props.isSelected }
 						readOnly={ true }

--- a/client/my-sites/post-selector/docs/example.jsx
+++ b/client/my-sites/post-selector/docs/example.jsx
@@ -10,6 +10,7 @@ import { connect } from 'react-redux';
  */
 import PostSelector from '../';
 import FormLabel from 'components/forms/form-label';
+import FormInputCheckbox from 'components/forms/form-checkbox';
 import getPrimarySiteId from 'state/selectors/get-primary-site-id';
 
 class PostSelectorExample extends Component {
@@ -36,8 +37,7 @@ class PostSelectorExample extends Component {
 		return (
 			<div style={ { width: 300 } }>
 				<FormLabel>
-					<input
-						type="checkbox"
+					<FormInputCheckbox
 						checked={ this.state.showTypeLabels }
 						onChange={ this.toggleTypeLabels }
 					/>

--- a/client/post-editor/editor-fieldset/README.md
+++ b/client/post-editor/editor-fieldset/README.md
@@ -18,11 +18,11 @@ class MyComponent extends React.Component {
 		return (
 			<EditorFieldset legend="Settings">
 				<FormLabel>
-					<FormInputCheckbox>
+					<FormInputCheckbox />
 					<span>Option One</span>
 				</FormLabel>
 				<FormLabel>
-					<FormInputCheckbox>
+					<FormInputCheckbox />
 					<span>Option Two</span>
 				</FormLabel>
 			</EditorFieldset>

--- a/client/post-editor/editor-fieldset/README.md
+++ b/client/post-editor/editor-fieldset/README.md
@@ -10,13 +10,21 @@ The `<EditorFieldset />` component accepts a single `legend` prop to specify the
 ```jsx
 import React from 'react';
 import EditorFieldset from 'post-editor/editor-fieldset';
+import FormInputCheckbox from 'components/forms/form-checkbox';
+import FormLabel from 'components/forms/form-label';
 
 class MyComponent extends React.Component {
 	render() {
 		return (
 			<EditorFieldset legend="Settings">
-				<label><input type="checkbox"> Option One</label>
-				<label><input type="checkbox"> Option Two</label>
+				<FormLabel>
+					<FormInputCheckbox>
+					<span>Option One</span>
+				</FormLabel>
+				<FormLabel>
+					<FormInputCheckbox>
+					<span>Option Two</span>
+				</FormLabel>
 			</EditorFieldset>
 		);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove global form input[type='checkbox'] styles in favor of more specific component-level styling. See #45259.
* Update multiple `FormLabel` instances where applicable, because labels and checkboxes most often go together, and this is a good opportunity to fix them without introducing more edge cases.

The following use cases of checkboxes are consciously ignored:

* `calypso/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/blocks/navigation-menu/index.php` - this is part of FSE and it doesn't use Calypso components right now.
* `components/forms/multi-checkbox/README.md` - this displays an example output HTML, not React components
* `desktop/public_desktop/preferences.html` - this is an external preferences page for the desktop build that doesn't use Calypso components.

For the following use cases, it's fine for them to look different, because we're now using the proper components vs raw elements, and they were just dev docs examples.

* `/devdocs/blocks/nps-survey` - checkboxes at the bottom. 
* `/devdocs/design/bulk-selects` - checkboxes inside the example.
* `/devdocs/design/line-chart` - "Fill Area" checkbox when you click "Show Data Controls", plus all the 4 labels in that area.
* `/devdocs/design/pie-chart` - When you click "Show Data Controls", the "Show" labels and checkboxes.

#### Testing instructions

Test the following against production and ensure that they match stylistically and functionally:

* `/plugins/manage/:site` where `:site` is a Jetpack site with more than 1 installed plugin. Click the "Edit All" button to reveal the bulk select field.
* `/stats/day/:site`, where `:site` is a site with a bit of traffic. The changes affect the "Visitors" checkbox above the top graph.
* `/devdocs/design/form-fields` - checkbox fields there, together with the corresponding label.
* Toggle form field - test either on `settings/discussion/:site` or on `/devdocs/design/form-fields`, or any other page with toggles you'd like to test on (there are plenty on site settings pages).
* Multi checkbox field - `/marketing/sharing-buttons/:site`, the "Show like and sharing buttons on" section.
* `ReduxFormToggle` - testable on classic calypso editor, insert a Simple Payments button and test the toggle in the settings form
* `PreviewFields` - testable on classic calypso editor, insert a contact form and edit a field, then test the "Required" checkbox.
* `TranslatorLauncher` - testable by using a different than English language for your interface in Calypso, then clicking the globe on the bottom right of your screen on any screen that's not My Home, and verifying the checkbox in the dialog works and looks well.
* `ProfileLinksAddWordPressSite` - go to `/me`, click to add a new WordPress site to your profile at the bottom, and compare the checkboxes next to each WordPress site.
* `NameserversToggle` - go to `/domains/manage/:site/name-servers/:site` where `:site` is a site that WP.com controls the domain for. Verify toggle looks and works like it did before.
* `DomainConnectRecord` - go to `/domains/manage/:site/dns/:site` where `:site` is a site that WP.com controls the domain for. Verify toggle looks and works like it did before.
* `SharingButtonsAppearance` and `SharingButtonsOptions` - go to `/marketing/sharing-buttons/:site` where `:site` is a WP.com site, and test "Show reblog button" and "Show like button" checkboxes, as well as the checkbox under "Comment Likes".
* Publicize - `/marketing/connections/:site`, the checkbox for "Connection available to all administrators, editors, and authors" on an existing valid connection.
* Plugins - go to `/plugins/manage`, click "Edit All" to see the checkbox beside each plugin.

I need some help verifying we're not introducing regressions in the following WooCommerce test cases:
* `BulkSelect` component - testable in shipping zone location dialog with countries or predefined packages in WooCommerce Services - found in `/store/settings/shipping/:site` where `:site` is your site with WooCommerce and WooCommerce services plugins installed.
* Checkbox/toggle fields - available in product form in `/store/product/:site/:productId` where `:site` is your Woo site and `productId` is your WooCommerce product ID.
* Checkbox field in ProductSearch, testable in `/store/promotion/:site` where you select "Specific product" in the "Applies to" box, and the checkbox appears disabled in the placeholder while search is loading.

Finally, I need some help on how to reproduce all the instances that use the `extensions/woocommerce/woocommerce-services/components/checkbox` component, because I'm unable to reach those interfaces for some reason, likely due to a missing plugin or misconfigured settings. Is this code even used/accessed? Can it be removed? cc @c-shultz and @allendav as a Hydra representative.

#### Notes

Note that we're removing the `type="checkbox` prop from a couple of instances, where that makes sense because those internally use `FormInputCheckbox`:
* `ReduxFormToggle` in `components/redux-forms/redux-form-toggle/index.jsx`
* `ProductForm` in `components/tinymce/plugins/simple-payments/dialog/form.jsx`

Note: eslint errors in `client/my-sites/marketing/connections/connection.jsx` are expected, there are too many of them to be fixed in this already large PR.

See #45259 for rationale on why we're doing all this.
