### PR TITLE
Gutenberg: Restore visibility of Preview button for GB 8.9+

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/legacy-preview-button.scss
+++ b/apps/wpcom-block-editor/src/calypso/features/legacy-preview-button.scss
@@ -6,11 +6,17 @@
  * This can be removed once we support scaling down CSS to the new preview
  * @link https://github.com/Automattic/wp-calypso/issues/40401
  */
-@media ( min-width: 600px ) {
-	// Normally visible on mobile only, make it always visible
-	.editor-post-preview {
-		display: inline-flex;
+.edit-post-header__settings,
+.edit-site-header__actions {
+	@media ( min-width: 600px ) {
+		// Normally visible on mobile only, make it always visible
+		.editor-post-preview {
+			display: inline-flex;
+		}
 	}
+}
+
+@media ( min-width: 600px ) {
 	// Normally visible on desktops, make it always hidden
 	// .block-editor-post-preview__dropdown is the class name in versions >= 8.0
 	.editor-post-preview__dropdown,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

On a WP.com site running Gutenberg 8.9.0-rc.1 (by setting the Gutenberge Edge sticker), the Preview button was no longer showing:

![image](https://user-images.githubusercontent.com/96308/91859040-436b1080-ec6a-11ea-9b78-a412a099ad47.png)

This was [flagged by e2e tests](https://app.circleci.com/pipelines/github/Automattic/wp-e2e-tests-for-branches/36508/workflows/76325156-ed5c-447e-9fb0-42e3d9ffad49/jobs/98060):

```
Timed out waiting for element with css selector of '.components-button.editor-post-preview' to be clickable
```

The reason for this is https://github.com/WordPress/gutenberg/pull/24537, where specificity of the selector that hides that button was changed: https://github.com/WordPress/gutenberg/pull/24537/files#diff-ce54206cc6b38665b9e02a3e7dbb6c7fR37-R44

Our override has lesser specificity: https://github.com/Automattic/wp-calypso/blob/bef8c1df640b67d17e809da714a1985a6b42d8c9/apps/wpcom-block-editor/src/calypso/features/legacy-preview-button.scss#L9-L13

This PR updates our override to match Gutenberg's updated specificity, thus bringing back the "Preview" button:

![image](https://user-images.githubusercontent.com/96308/91862001-b88c1500-ec6d-11ea-9947-04e4704e68b7.png)

#### Testing instructions

- Sandbox `widgets.wp.com`.
- Sandbox a WP.com Simple site, and add the `gutenberg-edge` sticker to it.
- Apply D48898-code to your sandbox.
- Verify that the Preview button is back.
- For completeness' sake, remove the `gutenberg-edge` sticker and verify that the Preview button is still present.