### PR TITLE
i18n: Fix translations setup with locale variant

### DIFF
--- a/client/boot/locale.js
+++ b/client/boot/locale.js
@@ -97,12 +97,14 @@ export const setupLocale = ( currentUser, reduxStore ) => {
 		initLanguageEmpathyMode();
 	}
 
+	let userLocaleSlug = currentUser.localeVariant || currentUser.localeSlug;
 	const shouldUseFallbackLocale =
 		currentUser?.use_fallback_for_incomplete_languages &&
-		isTranslatedIncompletely( currentUser.localeSlug );
-	const userLocaleSlug = shouldUseFallbackLocale
-		? config( 'i18n_default_locale_slug' )
-		: currentUser.localeSlug;
+		isTranslatedIncompletely( userLocaleSlug );
+
+	if ( shouldUseFallbackLocale ) {
+		userLocaleSlug = config( 'i18n_default_locale_slug' );
+	}
 
 	if ( useTranslationChunks && '__requireChunkCallback__' in window ) {
 		const localeSlug = userLocaleSlug || getLocaleFromPathname();
@@ -122,8 +124,13 @@ export const setupLocale = ( currentUser, reduxStore ) => {
 			loadUserUndeployedTranslations( languageSlug );
 		}
 	} else if ( currentUser && currentUser.localeSlug ) {
-		// Use the current user's and load traslation data with a fetch request
-		reduxStore.dispatch( setLocale( userLocaleSlug, currentUser.localeVariant ) );
+		if ( shouldUseFallbackLocale ) {
+			// Use user locale fallback slug
+			reduxStore.dispatch( setLocale( userLocaleSlug ) );
+		} else {
+			// Use the current user's and load traslation data with a fetch request
+			reduxStore.dispatch( setLocale( currentUser.localeSlug, currentUser.localeVariant ) );
+		}
 	} else {
 		// For logged out Calypso pages, set the locale from slug
 		const pathLocaleSlug = getLocaleFromPathname();

--- a/client/server/render/index.js
+++ b/client/server/render/index.js
@@ -170,27 +170,29 @@ const getLanguageManifest = ( langSlug, target ) => {
 };
 
 export function attachI18n( context ) {
+	let localeSlug = getCurrentLocaleVariant( context.store.getState() ) || context.lang;
 	const shouldUseFallbackLocale =
-		context.user?.use_fallback_for_incomplete_languages && isTranslatedIncompletely( context.lang );
-	const langSlug = shouldUseFallbackLocale ? config( 'i18n_default_locale_slug' ) : context.lang;
+		context.user?.use_fallback_for_incomplete_languages && isTranslatedIncompletely( localeSlug );
 
-	if ( ! isDefaultLocale( langSlug ) ) {
-		const langFileName = getCurrentLocaleVariant( context.store.getState() ) || langSlug;
-
-		context.i18nLocaleScript = getLanguageFileUrl( langFileName, 'js', context.languageRevisions );
+	if ( shouldUseFallbackLocale ) {
+		localeSlug = config( 'i18n_default_locale_slug' );
 	}
 
-	if ( ! isDefaultLocale( langSlug ) && context.useTranslationChunks ) {
+	if ( ! isDefaultLocale( localeSlug ) ) {
+		context.i18nLocaleScript = getLanguageFileUrl( localeSlug, 'js', context.languageRevisions );
+	}
+
+	if ( ! isDefaultLocale( localeSlug ) && context.useTranslationChunks ) {
 		context.entrypoint.language = {};
 
-		const languageManifest = getLanguageManifest( langSlug, context.target );
+		const languageManifest = getLanguageManifest( localeSlug, context.target );
 
 		if ( languageManifest ) {
 			context.entrypoint.language.manifest = getLanguageManifestFileUrl( {
-				localeSlug: langSlug,
+				localeSlug: localeSlug,
 				fileType: 'js',
 				targetBuild: context.target,
-				hash: context?.languageRevisions?.hashes?.[ langSlug ],
+				hash: context?.languageRevisions?.hashes?.[ localeSlug ],
 			} );
 
 			context.entrypoint.language.translations = context.entrypoint.js
@@ -200,19 +202,19 @@ export function attachI18n( context ) {
 				.map( ( chunkId ) =>
 					getTranslationChunkFileUrl( {
 						chunkId,
-						localeSlug: langSlug,
+						localeSlug: localeSlug,
 						fileType: 'js',
 						targetBuild: context.target,
-						hash: context?.languageRevisions?.[ langSlug ],
+						hash: context?.languageRevisions?.[ localeSlug ],
 					} )
 				);
 		}
 	}
 
 	if ( context.store ) {
-		context.lang = getCurrentLocaleSlug( context.store.getState() ) || langSlug;
+		context.lang = getCurrentLocaleSlug( context.store.getState() ) || localeSlug;
 
-		const isLocaleRTL = isLocaleRtl( langSlug );
+		const isLocaleRTL = isLocaleRtl( localeSlug );
 		context.isRTL = isLocaleRTL !== null ? isLocaleRTL : context.isRTL;
 	}
 }


### PR DESCRIPTION
Initial translations setup on both the client and server side were not using the locale variant, which was causing parent locale translations to be bootstrapped to the page and not the locale variant ones. As a result, locale variant translations were fetched in the runtime which was causing some rendering glitches and additional network requests.

#### Changes proposed in this Pull Request

* Setup translations using `localeVariant` over `localeSlug` when available

#### Testing instructions

* Change UI language to `es-mx`
* Check "My sites" label in the master bar and confirm it renders initially and remains as "Mi sitio"
* Inspect network requests and confirm only `es-mx-*` translation files and none of the parent `es-*` are being fetched