### PR TITLE
Site Editor: remove duplicate menu item

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/site-editor/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/site-editor/index.php
@@ -28,22 +28,6 @@ function initialize_site_editor() {
 
 	// Force enable required Gutenberg experiments if they are not already active.
 	add_filter( 'pre_option_gutenberg-experiments', __NAMESPACE__ . '\enable_site_editor_experiment' );
-	// Add top level Site Editor menu item.
-	add_action( 'admin_menu', __NAMESPACE__ . '\add_site_editor_menu_item' );
-}
-
-/**
- * Add top level Site Editor menu item.
- */
-function add_site_editor_menu_item() {
-	add_menu_page(
-		__( 'Site Editor (beta)', 'full-site-editing' ),
-		__( 'Site Editor (beta)', 'full-site-editing' ),
-		'edit_theme_options',
-		'gutenberg-edit-site',
-		'gutenberg_edit_site_page',
-		'dashicons-edit'
-	);
 }
 
 /**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

After the latest Gutenberg update this manual addition is no longer needed.

#### Testing instructions

Apply the patch on FSE enabled site and verify that there is only one button in wp-admin menu, and that it works correctly.