### PR TITLE
Set font-headings and font-base properties on documentElement rather …

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/style-preview/preview.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/preview.tsx
@@ -132,11 +132,11 @@ const Preview: React.FunctionComponent< Props > = ( { viewport } ) => {
 			const iframeDocument = iframeWindow.document;
 			if ( selectedFonts ) {
 				const { headings, base } = selectedFonts;
-				iframeDocument.body.style.setProperty( '--font-headings', headings );
-				iframeDocument.body.style.setProperty( '--font-base', base );
+				iframeDocument.documentElement.style.setProperty( '--font-headings', headings );
+				iframeDocument.documentElement.style.setProperty( '--font-base', base );
 			} else {
-				iframeDocument.body.style.removeProperty( '--font-headings' );
-				iframeDocument.body.style.removeProperty( '--font-base' );
+				iframeDocument.documentElement.style.removeProperty( '--font-headings' );
+				iframeDocument.documentElement.style.removeProperty( '--font-base' );
 			}
 		}
 	}, [ previewHtml, selectedFonts ] );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* It fixes issue https://github.com/Automattic/wp-calypso/issues/42189 where the body font does not update when you are changing between fonts on style-preview.
* The issue was because the body font inherits from the `html` elements CSS variables. The CSS variables being set/updated were on the `body` so were not taking effect. To fix this we needed to change to set them on `documentElement`.

**Before:**
![captured (2)](https://user-images.githubusercontent.com/8639742/91872709-102b8000-ec70-11ea-8b08-8325b3733529.gif)

**After:**
![captured](https://user-images.githubusercontent.com/8639742/91872387-b75be780-ec6f-11ea-9cac-200a7fdc2885.gif)

#### Testing instructions

* In Incognito mode visit [/new](https://hash-f9a04a3f6a87f1482e4c20154e88db59fac6d5db.calypso.live/new)
* Go through the onboarding process until you get to "Pick a Font Pairing" or [/new/style](https://hash-f9a04a3f6a87f1482e4c20154e88db59fac6d5db.calypso.live/style)
* Change fonts on your selected theme. Body font should change along with header fonts now.

Fixes https://github.com/Automattic/wp-calypso/issues/42189
