### PR TITLE
Fix how premium domain suggestions are rendered when there is domain sale active

### DIFF
--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -415,24 +415,27 @@ const mapStateToProps = ( state, props ) => {
 	const productsList = getProductsList( state );
 	const currentUserCurrencyCode = getCurrentUserCurrencyCode( state );
 	const stripZeros = props.isEligibleVariantForDomainTest ? true : false;
+	const isPremium = props.premiumDomain?.is_premium || props.suggestion?.is_premium;
 
 	let productCost;
+	let productSaleCost;
 
-	if ( props.premiumDomain?.is_premium ) {
+	if ( isPremium ) {
 		productCost = props.premiumDomain?.cost;
 	} else {
 		productCost = getDomainPrice( productSlug, productsList, currentUserCurrencyCode, stripZeros );
-	}
-
-	return {
-		showHstsNotice: isHstsRequired( productSlug, productsList ),
-		productCost: productCost,
-		productSaleCost: getDomainSalePrice(
+		productSaleCost = getDomainSalePrice(
 			productSlug,
 			productsList,
 			currentUserCurrencyCode,
 			stripZeros
-		),
+		);
+	}
+
+	return {
+		showHstsNotice: isHstsRequired( productSlug, productsList ),
+		productCost,
+		productSaleCost,
 	};
 };
 


### PR DESCRIPTION
When there is domain sale we don't want that price to be applied to premium domain suggestions

#### Changes proposed in this Pull Request

* Update how we populate the `productCost` and `productSaleCost` for premium domain suggestions

#### Testing instructions

* In order to test this you need to follow the instructions in D48774-code
