### PR TITLE
Fix Notifications panel single detail for Note to handle quotes

### DIFF
--- a/apps/notifications/src/panel/templates/functions.jsx
+++ b/apps/notifications/src/panel/templates/functions.jsx
@@ -70,6 +70,14 @@ const toBlocks = ( text ) =>
 				? `<strong>${ raw.split( ':' )[ 0 ] }:</strong>${ raw.replace( /^[^:]+:/, '' ) }`
 				: raw;
 
+			if ( /^<blockquote/i.test( raw ) ) {
+				return {
+					out: out + raw,
+					inFence,
+					inList: false,
+				};
+			}
+
 			// inline `code` snippets
 			const coded = defined.replace( /`([^`]+)`/, '<code>$1</code>' );
 
@@ -176,8 +184,8 @@ export function getSignature( blocks, note ) {
 	}
 
 	return blocks.map( function ( block ) {
-		var type = 'text';
-		var id = null;
+		let type = 'text';
+		let id = null;
 
 		if ( 'undefined' !== typeof block.type ) {
 			type = block.type;
@@ -218,16 +226,16 @@ export function getSignature( blocks, note ) {
 }
 
 export function formatString() {
-	var args = [].slice.apply( arguments );
-	var str = args.shift();
+	const args = [].slice.apply( arguments );
+	const str = args.shift();
 
 	return str.replace( /{(\d+)}/g, function ( match, number ) {
-		return typeof args[ number ] != 'undefined' ? args[ number ] : match;
+		return typeof args[ number ] !== 'undefined' ? args[ number ] : match;
 	} );
 }
 
 export function zipWithSignature( blocks, note ) {
-	var signature = getSignature( blocks, note );
+	const signature = getSignature( blocks, note );
 
 	return blocks.map( function ( block, i ) {
 		return {


### PR DESCRIPTION
This looks to address the issue whereby Notification "Note"s which contain Gutenberg Quote blocks don't have any formatting or visual styling to indicate that they are a quotation.

The reason for this is that [a helper function `toBlocks`](https://github.com/Automattic/wp-calypso/blob/e634741511b4ec069de7303297f0cd71e4fd4329/apps/notifications/src/panel/templates/functions.jsx#L26) splits the HTML string on newline characters and then wraps each segment in a `<div>`.

https://github.com/Automattic/wp-calypso/blob/e634741511b4ec069de7303297f0cd71e4fd4329/apps/notifications/src/panel/templates/functions.jsx#L122-L126

This causes the `<blockquote>` to be divided by a <div> which breaks the HTML formatting. It looks a bit like this

```html
// broken - wrong!
<div><blockquote class="wpnc__blockquote"></div><div>This is a blockquote. Lorem ipsum dolor sit amet.</div>
```

This means the styles for blockquote in the Notifications panel are never applied because the HTML is totally broken.

## Changes proposed in this Pull Request

* Add regex to account for the presence of blockquote tag to avoid wrapping in `<div>` tag.

## Testing instructions


* Setup a test site (I used [a p2 site](https://wordpress.com/start/p2)).
* Go to Reader and then find your site, click `Settings` and enable the toggle for `Notify me of new posts` notifications 
![2020-09-01_13-32](https://user-images.githubusercontent.com/444434/91942453-e10a2280-ecf2-11ea-8983-3428c6f26d0b.png)
* Check that when you post a new Post you see a new Notification appear in the Calypso Notifications panel (look for little "bell" icon in top right corner). 
* With this in place, try posting a **new post** using the Block Editor and containing a quote block.
* Look at your Notifications panel to see the new Note.
* Check the quotation element is clearly distinct as a quote (see screenshot below for example):

| Screenshot |
| ----- |
| <img width="851" alt="Screen Shot 2020-09-01 at 15 31 50" src="https://user-images.githubusercontent.com/444434/91864588-46650180-ec68-11ea-8058-f15364a876b9.png"> |

* Now repeat the same process but this time posting a **comment** using the **Gutenberg editor** on your p2.

Fixes https://github.com/Automattic/wp-calypso/issues/45120
