### PR TITLE
composite-checkout: Use constants for transaction and form statuses

### DIFF
--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-review.js
@@ -4,7 +4,7 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
-import { useLineItems, useFormStatus } from '@automattic/composite-checkout';
+import { FormStatus, useLineItems, useFormStatus } from '@automattic/composite-checkout';
 import { useTranslate } from 'i18n-calypso';
 
 /**
@@ -104,7 +104,7 @@ function CouponFieldArea( {
 		return (
 			<CouponField
 				id="order-review-coupon"
-				disabled={ formStatus !== 'ready' }
+				disabled={ formStatus !== FormStatus.READY }
 				couponStatus={ couponStatus }
 				couponFieldStateProps={ couponFieldStateProps }
 			/>

--- a/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-checkout-order-summary.js
@@ -8,6 +8,7 @@ import { keyframes } from '@emotion/core';
 import {
 	CheckoutCheckIcon,
 	CheckoutSummaryCard,
+	FormStatus,
 	useEvents,
 	useFormStatus,
 	useLineItemsOfType,
@@ -44,7 +45,7 @@ export default function WPCheckoutOrderSummary() {
 	const total = useTotal();
 	const { formStatus } = useFormStatus();
 
-	const isCartUpdating = 'validating' === formStatus;
+	const isCartUpdating = FormStatus.VALIDATING === formStatus;
 
 	return (
 		<CheckoutSummaryCardUI

--- a/client/my-sites/checkout/composite-checkout/components/wp-contact-form.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-contact-form.js
@@ -5,6 +5,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import {
+	FormStatus,
 	useSelect,
 	useDispatch,
 	useFormStatus,
@@ -54,7 +55,7 @@ export default function WPContactForm( {
 	const contactInfo = useSelect( ( select ) => select( 'wpcom' ).getContactInfo() );
 	const { formStatus } = useFormStatus();
 	const isStepActive = useIsStepActive();
-	const isDisabled = ! isStepActive || formStatus !== 'ready';
+	const isDisabled = ! isStepActive || formStatus !== FormStatus.READY;
 	const isCachedContactFormValid = useIsCachedContactFormValid( contactValidationCallback );
 
 	useSkipToLastStepIfFormComplete( isCachedContactFormValid );

--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.js
@@ -4,7 +4,7 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
-import { CheckoutModal, useFormStatus, useEvents, Button } from '@automattic/composite-checkout';
+import { CheckoutModal, FormStatus, useFormStatus, useEvents, Button } from '@automattic/composite-checkout';
 import { useTranslate } from 'i18n-calypso';
 
 /**
@@ -47,7 +47,7 @@ function WPLineItem( {
 		createUserAndSiteBeforeTransaction
 	);
 	const onEvent = useEvents();
-	const isDisabled = formStatus !== 'ready';
+	const isDisabled = formStatus !== FormStatus.READY;
 
 	const isRenewal = item.wpcom_meta?.extra?.purchaseId;
 	// Show the variation picker when this is not a renewal
@@ -76,7 +76,7 @@ function WPLineItem( {
 				</LineItemMeta>
 			) }
 			{ isGSuite && <GSuiteUsersList item={ item } /> }
-			{ hasDeleteButton && formStatus === 'ready' && (
+			{ hasDeleteButton && formStatus === FormStatus.READY && (
 				<>
 					<DeleteButton
 						className="checkout-line-item__remove-product"

--- a/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.js
+++ b/client/my-sites/checkout/composite-checkout/components/wp-order-review-line-items.js
@@ -4,7 +4,13 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
-import { CheckoutModal, FormStatus, useFormStatus, useEvents, Button } from '@automattic/composite-checkout';
+import {
+	CheckoutModal,
+	FormStatus,
+	useFormStatus,
+	useEvents,
+	Button,
+} from '@automattic/composite-checkout';
 import { useTranslate } from 'i18n-calypso';
 
 /**

--- a/client/my-sites/checkout/composite-checkout/hooks/use-is-cached-contact-form-valid.js
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-is-cached-contact-form-valid.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { useEffect, useRef, useState } from 'react';
-import { useFormStatus } from '@automattic/composite-checkout';
+import { FormStatus, useFormStatus } from '@automattic/composite-checkout';
 import { useSelector } from 'react-redux';
 import debugFactory from 'debug';
 
@@ -27,7 +27,7 @@ export default function useIsCachedContactFormValid( contactValidationCallback )
 		}
 		if ( ! hasValidated.current && cachedContactDetails ) {
 			hasValidated.current = true;
-			if ( formStatus === 'ready' ) {
+			if ( formStatus === FormStatus.READY ) {
 				setFormValidating();
 				shouldResetFormStatus.current = true;
 			}

--- a/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/contact-fields.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/contact-fields.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { useFormStatus } from '@automattic/composite-checkout';
+import { FormStatus, useFormStatus } from '@automattic/composite-checkout';
 
 /**
  * Internal dependencies
@@ -17,7 +17,7 @@ export default function ContactFields( {
 	getErrorMessagesForField,
 } ) {
 	const { formStatus } = useFormStatus();
-	const isDisabled = formStatus !== 'ready';
+	const isDisabled = formStatus !== FormStatus.READY;
 	const countriesList = useCountryList( [] );
 
 	return (

--- a/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-cvv-field.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-cvv-field.js
@@ -4,7 +4,7 @@
 import React from 'react';
 import { useTranslate } from 'i18n-calypso';
 import { CardCvcElement } from 'react-stripe-elements';
-import { useFormStatus, useSelect } from '@automattic/composite-checkout';
+import { FormStatus, useFormStatus, useSelect } from '@automattic/composite-checkout';
 
 /**
  * Internal dependencies
@@ -34,7 +34,7 @@ export default function CreditCardCvvField( {
 } ) {
 	const translate = useTranslate();
 	const { formStatus } = useFormStatus();
-	const isDisabled = formStatus !== 'ready';
+	const isDisabled = formStatus !== FormStatus.READY;
 	const { cardCvc: cardCvcError } = useSelect( ( select ) =>
 		select( 'credit-card' ).getCardDataErrors()
 	);

--- a/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-expiry-field.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-expiry-field.js
@@ -4,7 +4,7 @@
 import React from 'react';
 import { useTranslate } from 'i18n-calypso';
 import { CardExpiryElement } from 'react-stripe-elements';
-import { useFormStatus, useSelect } from '@automattic/composite-checkout';
+import { FormStatus, useFormStatus, useSelect } from '@automattic/composite-checkout';
 
 /**
  * Internal dependencies
@@ -23,7 +23,7 @@ export default function CreditCardExpiryField( {
 } ) {
 	const translate = useTranslate();
 	const { formStatus } = useFormStatus();
-	const isDisabled = formStatus !== 'ready';
+	const isDisabled = formStatus !== FormStatus.READY;
 	const { cardExpiry: cardExpiryError } = useSelect( ( select ) =>
 		select( 'credit-card' ).getCardDataErrors()
 	);

--- a/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-fields.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-fields.js
@@ -5,7 +5,13 @@ import React, { useState, useEffect } from 'react';
 import styled from '@emotion/styled';
 import { useTheme } from 'emotion-theming';
 import { useI18n } from '@automattic/react-i18n';
-import { FormStatus, useEvents, useSelect, useDispatch, useFormStatus } from '@automattic/composite-checkout';
+import {
+	FormStatus,
+	useEvents,
+	useSelect,
+	useDispatch,
+	useFormStatus,
+} from '@automattic/composite-checkout';
 
 /**
  * Internal dependencies

--- a/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-fields.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-fields.js
@@ -5,7 +5,7 @@ import React, { useState, useEffect } from 'react';
 import styled from '@emotion/styled';
 import { useTheme } from 'emotion-theming';
 import { useI18n } from '@automattic/react-i18n';
-import { useEvents, useSelect, useDispatch, useFormStatus } from '@automattic/composite-checkout';
+import { FormStatus, useEvents, useSelect, useDispatch, useFormStatus } from '@automattic/composite-checkout';
 
 /**
  * Internal dependencies
@@ -78,7 +78,7 @@ export default function CreditCardFields() {
 		contactCountryCode === 'BR' &&
 		Boolean( cart?.allowed_payment_methods?.includes( paymentMethodClassName( 'ebanx' ) ) );
 	const { formStatus } = useFormStatus();
-	const isDisabled = formStatus !== 'ready';
+	const isDisabled = formStatus !== FormStatus.READY;
 
 	// Cache the country code in our store for use by the processor function
 	useEffect( () => {

--- a/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-number-field.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-number-field.js
@@ -4,7 +4,7 @@
 import React from 'react';
 import { useI18n } from '@automattic/react-i18n';
 import { CardNumberElement } from 'react-stripe-elements';
-import { useFormStatus, useSelect } from '@automattic/composite-checkout';
+import { FormStatus, useFormStatus, useSelect } from '@automattic/composite-checkout';
 
 /**
  * Internal dependencies
@@ -25,7 +25,7 @@ export default function CreditCardNumberField( {
 } ) {
 	const { __ } = useI18n();
 	const { formStatus } = useFormStatus();
-	const isDisabled = formStatus !== 'ready';
+	const isDisabled = formStatus !== FormStatus.READY;
 	const brand = useSelect( ( select ) => select( 'credit-card' ).getBrand() );
 	const { cardNumber: cardNumberError } = useSelect( ( select ) =>
 		select( 'credit-card' ).getCardDataErrors()

--- a/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-pay-button.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-pay-button.js
@@ -7,6 +7,7 @@ import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@automattic/react-i18n';
 import {
 	Button,
+	FormStatus,
 	usePaymentProcessor,
 	useTransactionStatus,
 	useLineItems,
@@ -126,7 +127,7 @@ export default function CreditCardPayButton( { disabled, store, stripe, stripeCo
 				}
 			} }
 			buttonType="primary"
-			isBusy={ 'submitting' === formStatus }
+			isBusy={ FormStatus.SUBMITTING === formStatus }
 			fullWidth
 		>
 			<ButtonContents formStatus={ formStatus } total={ total } />
@@ -136,10 +137,10 @@ export default function CreditCardPayButton( { disabled, store, stripe, stripeCo
 
 function ButtonContents( { formStatus, total } ) {
 	const { __ } = useI18n();
-	if ( formStatus === 'submitting' ) {
+	if ( formStatus === FormStatus.SUBMITTING ) {
 		return __( 'Processing…' );
 	}
-	if ( formStatus === 'ready' ) {
+	if ( formStatus === FormStatus.READY ) {
 		return sprintf( __( 'Pay %s' ), total.amount.displayValue );
 	}
 	return __( 'Please wait…' );

--- a/client/my-sites/checkout/composite-checkout/payment-methods/ebanx-tef.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/ebanx-tef.js
@@ -8,6 +8,7 @@ import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@automattic/react-i18n';
 import {
 	Button,
+	FormStatus,
 	usePaymentProcessor,
 	useTransactionStatus,
 	useLineItems,
@@ -163,7 +164,7 @@ function EbanxTefFields() {
 	const customerBank = useSelect( ( select ) => select( 'ebanx-tef' ).getCustomerBank() );
 	const { changeCustomerName, changeCustomerBank } = useDispatch( 'ebanx-tef' );
 	const { formStatus } = useFormStatus();
-	const isDisabled = formStatus !== 'ready';
+	const isDisabled = formStatus !== FormStatus.READY;
 	const countriesList = useCountryList( [] );
 
 	return (
@@ -342,7 +343,7 @@ function EbanxTefPayButton( { disabled, store } ) {
 				}
 			} }
 			buttonType="primary"
-			isBusy={ 'submitting' === formStatus }
+			isBusy={ FormStatus.SUBMITTING === formStatus }
 			fullWidth
 		>
 			<ButtonContents formStatus={ formStatus } total={ total } />
@@ -352,10 +353,10 @@ function EbanxTefPayButton( { disabled, store } ) {
 
 function ButtonContents( { formStatus, total } ) {
 	const { __ } = useI18n();
-	if ( formStatus === 'submitting' ) {
+	if ( formStatus === FormStatus.SUBMITTING ) {
 		return __( 'Processing…' );
 	}
-	if ( formStatus === 'ready' ) {
+	if ( formStatus === FormStatus.READY ) {
 		return sprintf( __( 'Pay %s' ), total.amount.displayValue );
 	}
 	return __( 'Please wait…' );

--- a/client/my-sites/checkout/composite-checkout/payment-methods/netbanking.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/netbanking.js
@@ -8,6 +8,7 @@ import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@automattic/react-i18n';
 import {
 	Button,
+	FormStatus,
 	usePaymentProcessor,
 	useTransactionStatus,
 	useLineItems,
@@ -153,7 +154,7 @@ function NetBankingFields() {
 	const customerName = useSelect( ( select ) => select( 'netbanking' ).getCustomerName() );
 	const { changeCustomerName } = useDispatch( 'netbanking' );
 	const { formStatus } = useFormStatus();
-	const isDisabled = formStatus !== 'ready';
+	const isDisabled = formStatus !== FormStatus.READY;
 	const countriesList = useCountryList( [] );
 
 	return (
@@ -269,7 +270,7 @@ function NetBankingPayButton( { disabled, store } ) {
 				}
 			} }
 			buttonType="primary"
-			isBusy={ 'submitting' === formStatus }
+			isBusy={ FormStatus.SUBMITTING === formStatus }
 			fullWidth
 		>
 			<ButtonContents formStatus={ formStatus } total={ total } />
@@ -279,10 +280,10 @@ function NetBankingPayButton( { disabled, store } ) {
 
 function ButtonContents( { formStatus, total } ) {
 	const { __ } = useI18n();
-	if ( formStatus === 'submitting' ) {
+	if ( formStatus === FormStatus.SUBMITTING ) {
 		return __( 'Processing…' );
 	}
-	if ( formStatus === 'ready' ) {
+	if ( formStatus === FormStatus.READY ) {
 		return sprintf( __( 'Pay %s' ), total.amount.displayValue );
 	}
 	return __( 'Please wait…' );

--- a/client/my-sites/checkout/composite-checkout/payment-methods/wechat.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/wechat.js
@@ -8,6 +8,7 @@ import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@automattic/react-i18n';
 import {
 	Button,
+	FormStatus,
 	usePaymentProcessor,
 	useTransactionStatus,
 	useLineItems,
@@ -91,7 +92,7 @@ function WeChatFields() {
 	const customerName = useSelect( ( select ) => select( 'wechat' ).getCustomerName() );
 	const { changeCustomerName } = useDispatch( 'wechat' );
 	const { formStatus } = useFormStatus();
-	const isDisabled = formStatus !== 'ready';
+	const isDisabled = formStatus !== FormStatus.READY;
 
 	return (
 		<WeChatFormWrapper>
@@ -212,7 +213,7 @@ function WeChatPayButton( { disabled, store, stripe, stripeConfiguration, siteSl
 				}
 			} }
 			buttonType="primary"
-			isBusy={ 'submitting' === formStatus }
+			isBusy={ FormStatus.SUBMITTING === formStatus }
 			fullWidth
 		>
 			<ButtonContents formStatus={ formStatus } total={ total } />
@@ -242,10 +243,10 @@ const WeChatPaymentQRcodeUI = styled( WeChatPaymentQRcode )`
 
 function ButtonContents( { formStatus, total } ) {
 	const { __ } = useI18n();
-	if ( formStatus === 'submitting' ) {
+	if ( formStatus === FormStatus.SUBMITTING ) {
 		return __( 'Processing…' );
 	}
-	if ( formStatus === 'ready' ) {
+	if ( formStatus === FormStatus.READY ) {
 		return sprintf( __( 'Pay %s' ), total.amount.displayValue );
 	}
 	return __( 'Please wait…' );

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -98,11 +98,11 @@ When a payment method is ready to submit its data, it can use an appropriate "pa
 
 When the `submitButton` component has been clicked, it should do the following:
 
-1. Call `setTransactionPending()` from [useTransactionStatus](#useTransactionStatus). This will change the [form status](#useFormStatus) to 'submitting' and disable the form.
+1. Call `setTransactionPending()` from [useTransactionStatus](#useTransactionStatus). This will change the [form status](#useFormStatus) to [`.SUBMITTING`](#FormStatus) and disable the form.
 2. Call the payment processor function returned from [usePaymentProcessor](#usePaymentProcessor]), passing whatever data that function requires. Each payment processor will be different, so you'll need to know the API of that function explicitly.
 3. Payment processor functions return a `Promise`. When the `Promise` resolves, call `setTransactionComplete()` from [useTransactionStatus](#useTransactionStatus) if the transaction was a success. Depending on the payment processor, some transactions might require additional actions before they are complete. If the transaction requires a redirect, call `setTransactionRedirecting(url: string)` instead. If the transaction requires 3DS auth, use `setTransactionAuthorizing(response: object)`.
 4. If the `Promise` rejects, call `setTransactionError(message: string)`.
-5. At this point the [CheckoutProvider](#CheckoutProvider) will automatically take action if the transaction status is 'complete' (call [onPaymentComplete](#CheckoutProvider)), 'error' (display the error and re-enable the form), or 'redirecting' (redirect to the url). No action will be taken if the status is 'authorizing'; the payment method must handle that status manually and eventually set one of the other statuses. If for some reason the transaction should be cancelled, call `resetTransaction()`.
+5. At this point the [CheckoutProvider](#CheckoutProvider) will automatically take action if the transaction status is [`.COMPLETE`](#TransactionStatus) (call [onPaymentComplete](#CheckoutProvider)), [`.ERROR`](#TransactionStatus) (display the error and re-enable the form), or [`.REDIRECTING`](#TransactionStatus) (redirect to the url). No action will be taken if the status is [`.AUTHORIZING`](#TransactionStatus); the payment method must handle that status manually and eventually set one of the other statuses. If for some reason the transaction should be cancelled, call `resetTransaction()`.
 
 ## Line Items
 
@@ -165,19 +165,19 @@ It has the following props.
 - `paymentMethods: object[]`. An array of [Payment Method objects](#payment-methods).
 - `paymentProcessors: object`. A key-value map of payment processor functions (see [Payment Methods](#payment-methods)).
 - `registry?: object`. An object returned by [createRegistry](#createRegistry). If not provided, the default registry will be used.
-- `isLoading?: boolean`. If set and true, the form will be replaced with a loading placeholder and the form status will be set to 'loading' (see [useFormStatus](#useFormStatus)).
-- `isValidating?: boolean`. If set and true, the form status will be set to 'validating' (see [useFormStatus](#useFormStatus)).
+- `isLoading?: boolean`. If set and true, the form will be replaced with a loading placeholder and the form status will be set to [`.LOADING`](#FormStatus) (see [useFormStatus](#useFormStatus)).
+- `isValidating?: boolean`. If set and true, the form status will be set to [`.VALIDATING`](#FormStatus) (see [useFormStatus](#useFormStatus)).
 - `redirectToUrl?: (url: string) => void`. Will be used by [useTransactionStatus](#useTransactionStatus) if it needs to redirect. If not set, it will change `window.location.href`.
 
 The line items are for display purposes only. They should also include subtotals, discounts, and taxes. No math will be performed on the line items. Instead, the amount to be charged will be specified by the required prop `total`, which is another line item.
 
 In addition, `CheckoutProvider` monitors the [transaction status](#useTransactionStatus) and will take actions when it changes.
 
-- If the `transactionStatus` changes to 'pending', the [form status](#useFormStatus) will be set to 'submitting'.
-- If the `transactionStatus` changes to 'error', the transaction status will be set to 'not-started', the [form status](#useFormStatus) will be set to 'ready', and the error message will be displayed.
-- If the `transactionStatus` changes to 'complete', the [form status](#useFormStatus) will be set to 'complete' (which will cause the `onPaymentComplete` function to be called).
-- If the `transactionStatus` changes to 'redirecting', the page will be redirected to the `transactionRedirectUrl` (or will display an error as above if there is no url).
-- If the `transactionStatus` changes to 'not-started', the [form status](#useFormStatus) will be set to 'ready'.
+- If the `transactionStatus` changes to [`.PENDING`](#TransactionStatus), the [form status](#useFormStatus) will be set to [`.SUBMITTING`](#FormStatus).
+- If the `transactionStatus` changes to [`.ERROR`](#TransactionStatus), the transaction status will be set to [`.NOT_STARTED`](#TransactionStatus), the [form status](#useFormStatus) will be set to [`.READY`](#FormStatus), and the error message will be displayed.
+- If the `transactionStatus` changes to [`.COMPLETE`](#TransactionStatus), the [form status](#useFormStatus) will be set to [`.COMPLETE`](#FormStatus) (which will cause the `onPaymentComplete` function to be called).
+- If the `transactionStatus` changes to [`.REDIRECTING`](#TransactionStatus), the page will be redirected to the `transactionRedirectUrl` (or will display an error as above if there is no url).
+- If the `transactionStatus` changes to [`.NOT_STARTED`](#TransactionStatus), the [form status](#useFormStatus) will be set to [`.READY`](#FormStatus).
 
 ### CheckoutReviewOrder
 
@@ -209,7 +209,7 @@ Creates the Checkout form and provides a wrapper for [CheckoutStep](#CheckoutSte
 This component's props are:
 
 - `submitButtonHeader: React.ReactNode`. Displays with the Checkout submit button.
-- `disableSubmitButton: boolean`. If true, the submit button will always be disabled. If false (the default), the submit button will be enabled only on the last step and only if the [formStatus](#useFormStatus) is 'ready'.
+- `disableSubmitButton: boolean`. If true, the submit button will always be disabled. If false (the default), the submit button will be enabled only on the last step and only if the [formStatus](#useFormStatus) is [`.READY`](#FormStatus).
 
 ## CheckoutStepBody
 
@@ -371,16 +371,26 @@ A React Hook that will return all the bound action creators for a [Data store](#
 
 A React Hook that will return the `onEvent` callback as passed to `CheckoutProvider`. Only works within [CheckoutProvider](#CheckoutProvider).
 
+### FormStatus
+
+An enum that holds the values of the [form status](#useFormStatus).
+
+- `.LOADING`
+- `.READY`
+- `.SUBMITTING`
+- `.VALIDATING`
+- `.COMPLETE`
+
 ### useFormStatus
 
 A React Hook that will return an object with the following properties. Used to represent and change the current status of the checkout form (eg: causing it to be disabled). This differs from the status of the transaction itself, which is handled by [useTransactionStatus](#useTransactionStatus).
 
-- `formStatus: string`. The current status of the form; one of 'loading', 'ready', 'validating', 'submitting', or 'complete'.
-- `setFormReady: () => void`. Function to change the form status to 'ready'.
-- `setFormLoading: () => void`. Function to change the form status to 'loading'.
-- `setFormValidating: () => void`. Function to change the form status to 'validating'.
-- `setFormSubmitting: () => void`. Function to change the form status to 'submitting'. Usually you can use [setTransactionPending](#useTransactionStatus) instead, which will call this.
-- `setFormComplete: () => void`. Function to change the form status to 'complete'. Note that this will trigger `onPaymentComplete` from [CheckoutProvider](#CheckoutProvider). Usually you can use [setTransactionComplete](#useTransactionStatus) instead, which will call this.
+- `formStatus: `[`FormStatus`](#FormStatus). The current status of the form.
+- `setFormReady: () => void`. Function to change the form status to [`.READY`](#FormStatus).
+- `setFormLoading: () => void`. Function to change the form status to [`.LOADING`](#FormStatus).
+- `setFormValidating: () => void`. Function to change the form status to [`.VALIDATING`](#FormStatus).
+- `setFormSubmitting: () => void`. Function to change the form status to [`.SUBMITTING`](#FormStatus). Usually you can use [setTransactionPending](#useTransactionStatus) instead, which will call this.
+- `setFormComplete: () => void`. Function to change the form status to [`.COMPLETE`](#FormStatus). Note that this will trigger `onPaymentComplete` from [CheckoutProvider](#CheckoutProvider). Usually you can use [setTransactionComplete](#useTransactionStatus) instead, which will call this.
 
 Only works within [CheckoutProvider](#CheckoutProvider) which may sometimes change the status itself based on its props.
 
@@ -436,21 +446,32 @@ A React Hook that will return a function to set a step to "complete". Only works
 
 A React Hook that returns the `total` property provided to the [CheckoutProvider](#checkoutprovider). This is the same as the second return value of [useLineItems](#useLineItems) but may be more semantic in some cases. Only works within `CheckoutProvider`.
 
+### TransactionStatus
+
+An enum that holds the values of the [transaction status](#useTransactionStatus).
+
+- `.NOT_STARTED`
+- `.PENDING`
+- `.AUTHORIZING`
+- `.COMPLETE`
+- `.REDIRECTING`
+- `.ERROR`
+
 ### useTransactionStatus
 
 A React Hook that returns an object with the following properties to be used by [payment methods](#payment-methods) for storing and communicating the current status of the transaction. This differs from the current status of the _form_, which is handled by [useFormStatus](#useFormStatus). Note, however, that [CheckoutProvider](#CheckoutProvider) will automatically perform certain actions when the transaction status changes. See [CheckoutProvider](#CheckoutProvider) for the details.
 
-- `transactionStatus: string`. The current status of the transaction; one of 'not-started', 'complete', 'error', 'pending', 'redirecting', 'authorizing'.
-- `previousTransactionStatus: string`. The last status of the transaction; one of 'not-started', 'complete', 'error', 'pending', 'redirecting', 'authorizing'.
-- `transactionError: string | null`. The most recent error message encountered by the transaction if its status is 'error'.
-- `transactionRedirectUrl: string | null`. The redirect url to use if the transaction status is 'redirecting'.
+- `transactionStatus: `[`TransactionStatus`](#TransactionStatus). The current status of the transaction.
+- `previousTransactionStatus: `[`TransactionStatus.`](#TransactionStatus). The last status of the transaction.
+- `transactionError: string | null`. The most recent error message encountered by the transaction if its status is [`.ERROR`](#TransactionStatus).
+- `transactionRedirectUrl: string | null`. The redirect url to use if the transaction status is [`.REDIRECTING`](#TransactionStatus).
 - `transactionLastResponse: object | null`. The most recent full response object as returned by the transaction's endpoint and passed to `setTransactionAuthorizing` or `setTransactionComplete`.
-- `resetTransaction: () => void`. Function to change the transaction status to 'not-started'.
-- `setTransactionComplete: ( object ) => void`. Function to change the transaction status to 'complete' and save the response object in `transactionLastResponse`.
-- `setTransactionError: ( string ) => void`. Function to change the transaction status to 'error' and save the error in `transactionError`.
-- `setTransactionPending: () => void`. Function to change the transaction status to 'pending'.
-- `setTransactionRedirecting: ( string ) => void`. Function to change the transaction status to 'redirecting' and save the redirect URL in `transactionRedirectUrl`.
-- `setTransactionAuthorizing: ( object ) => void`. Function to change the transaction status to 'authorizing' and save the response object in `transactionLastResponse`.
+- `resetTransaction: () => void`. Function to change the transaction status to [`.NOT_STARTED`](#TransactionStatus).
+- `setTransactionComplete: ( object ) => void`. Function to change the transaction status to [`.COMPLETE`](#TransactionStatus) and save the response object in `transactionLastResponse`.
+- `setTransactionError: ( string ) => void`. Function to change the transaction status to [`.ERROR`](#TransactionStatus) and save the error in `transactionError`.
+- `setTransactionPending: () => void`. Function to change the transaction status to [`.PENDING`](#TransactionStatus).
+- `setTransactionRedirecting: ( string ) => void`. Function to change the transaction status to [`.REDIRECTING`](#TransactionStatus) and save the redirect URL in `transactionRedirectUrl`.
+- `setTransactionAuthorizing: ( object ) => void`. Function to change the transaction status to [`.AUTHORIZING`](#TransactionStatus) and save the response object in `transactionLastResponse`.
 
 ## FAQ
 

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -247,7 +247,7 @@ A wrapper for [CheckoutStep](#CheckoutStep) objects that will connect the steps 
 
 ### CheckoutSummaryArea
 
-Renders its `children` prop and acts as a wrapper to flow outside of the [`CheckoutSteps`](#CehckoutSteps) wrapper (floated on desktop, collapsed on mobile). It has the following props.
+Renders its `children` prop and acts as a wrapper to flow outside of the [`CheckoutSteps`](#CheckoutSteps) wrapper (floated on desktop, collapsed on mobile). It has the following props.
 
 - `className?: string`. The className for the component.
 

--- a/packages/composite-checkout/demo/index.js
+++ b/packages/composite-checkout/demo/index.js
@@ -20,6 +20,7 @@ import {
 	createStripeMethod,
 	createStripePaymentMethodStore,
 	defaultRegistry,
+	FormStatus,
 	getDefaultOrderSummary,
 	getDefaultOrderReviewStep,
 	getDefaultOrderSummaryStep,
@@ -264,7 +265,7 @@ function ContactForm( { summary } ) {
 				type="text"
 				value={ country }
 				onChange={ onChangeCountry }
-				disabled={ formStatus !== 'ready' }
+				disabled={ formStatus !== FormStatus.READY }
 			/>
 		</Form>
 	);

--- a/packages/composite-checkout/src/components/checkout-payment-methods.tsx
+++ b/packages/composite-checkout/src/components/checkout-payment-methods.tsx
@@ -23,6 +23,7 @@ import {
 	useFormStatus,
 } from '../public-api';
 import CheckoutErrorBoundary from './checkout-error-boundary';
+import { FormStatus } from '../types';
 
 const debug = debugFactory( 'composite-checkout:checkout-payment-methods' );
 
@@ -146,7 +147,7 @@ function PaymentMethod( {
 			value={ id }
 			id={ id }
 			checked={ checked }
-			disabled={ formStatus !== 'ready' }
+			disabled={ formStatus !== FormStatus.READY }
 			onChange={ onClick ? () => onClick( id ) : undefined }
 			ariaLabel={ ariaLabel }
 			label={ label }

--- a/packages/composite-checkout/src/components/checkout-provider.tsx
+++ b/packages/composite-checkout/src/components/checkout-provider.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useEffect, useCallback, useMemo, useState, useRef, FunctionComponent } from 'react';
+import React, { FunctionComponent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ThemeProvider } from 'emotion-theming';
 import debugFactory from 'debug';
 import { useI18n } from '@automattic/react-i18n';
@@ -13,18 +13,18 @@ import { DataRegistry } from '@wordpress/data';
 import CheckoutContext from '../lib/checkout-context';
 import CheckoutErrorBoundary from './checkout-error-boundary';
 import { LineItemsProvider } from '../lib/line-items';
-import { RegistryProvider, defaultRegistry } from '../lib/registry';
+import { defaultRegistry, RegistryProvider } from '../lib/registry';
 import { useFormStatusManager } from '../lib/form-status';
 import { useTransactionStatusManager } from '../lib/transaction-status';
 import defaultTheme from '../lib/theme';
 import {
 	validateArg,
-	validateTotal,
 	validateLineItems,
 	validatePaymentMethods,
+	validateTotal,
 } from '../lib/validation';
 import TransactionStatusHandler from './transaction-status-handler';
-import { PaymentMethod, CheckoutProviderProps } from '../types';
+import { CheckoutProviderProps, FormStatus, PaymentMethod } from '../types';
 
 const debug = debugFactory( 'composite-checkout:checkout-provider' );
 
@@ -65,7 +65,7 @@ export const CheckoutProvider: FunctionComponent< CheckoutProviderProps > = ( pr
 	const transactionStatusManager = useTransactionStatusManager();
 	const didCallOnPaymentComplete = useRef( false );
 	useEffect( () => {
-		if ( formStatus === 'complete' && ! didCallOnPaymentComplete.current ) {
+		if ( formStatus === FormStatus.COMPLETE && ! didCallOnPaymentComplete.current ) {
 			debug( "form status is complete so I'm calling onPaymentComplete" );
 			didCallOnPaymentComplete.current = true;
 			onPaymentComplete( { paymentMethodId } );

--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -2,12 +2,12 @@
  * External dependencies
  */
 import React, {
-	useState,
+	Dispatch,
+	SetStateAction,
+	useCallback,
 	useContext,
 	useEffect,
-	useCallback,
-	SetStateAction,
-	Dispatch,
+	useState,
 } from 'react';
 import debugFactory from 'debug';
 import PropTypes from 'prop-types';
@@ -29,11 +29,12 @@ import {
 	getDefaultOrderSummary,
 	getDefaultOrderSummaryStep,
 	getDefaultPaymentMethodStep,
-	usePaymentMethod,
 	useEvents,
+	usePaymentMethod,
 } from '../public-api';
 import styled from '../lib/styled';
 import { Theme } from '../lib/theme';
+import { FormStatus } from '../types';
 
 const debug = debugFactory( 'composite-checkout:checkout' );
 
@@ -100,7 +101,7 @@ export function Checkout( {
 		...( isRTL() ? [ 'rtl' ] : [] ),
 	] );
 
-	if ( formStatus === 'loading' ) {
+	if ( formStatus === FormStatus.LOADING ) {
 		return (
 			<ContainerUI className={ classNames }>
 				<MainContentUI className={ joinClasses( [ className, 'checkout__content' ] ) }>
@@ -243,7 +244,9 @@ export function CheckoutStepArea( {
 					onError={ onSubmitButtonLoadError }
 				>
 					<CheckoutSubmitButton
-						disabled={ isThereAnotherNumberedStep || formStatus !== 'ready' || disableSubmitButton }
+						disabled={
+							isThereAnotherNumberedStep || formStatus !== FormStatus.READY || disableSubmitButton
+						}
 					/>
 				</CheckoutErrorBoundary>
 			</SubmitButtonWrapperUI>
@@ -448,7 +451,7 @@ export function CheckoutStepBody( {
 					isActive={ isStepActive }
 					isComplete={ isStepComplete }
 					onEdit={
-						formStatus === 'ready' && isStepComplete && goToThisStep && ! isStepActive
+						formStatus === FormStatus.READY && isStepComplete && goToThisStep && ! isStepActive
 							? goToThisStep
 							: undefined
 					}
@@ -461,18 +464,18 @@ export function CheckoutStepBody( {
 						<CheckoutNextStepButton
 							onClick={ goToNextStep }
 							value={
-								formStatus === 'validating'
+								formStatus === FormStatus.VALIDATING
 									? validatingButtonText || __( 'Please wait…' )
 									: nextStepButtonText || __( 'Continue' )
 							}
 							ariaLabel={
-								formStatus === 'validating'
+								formStatus === FormStatus.VALIDATING
 									? validatingButtonAriaLabel || __( 'Please wait…' )
 									: nextStepButtonAriaLabel || __( 'Continue to next step' )
 							}
 							buttonType="primary"
-							disabled={ formStatus !== 'ready' }
-							isBusy={ formStatus === 'validating' }
+							disabled={ formStatus !== FormStatus.READY }
+							isBusy={ formStatus === FormStatus.VALIDATING }
 						/>
 					) }
 				</StepContentUI>
@@ -505,7 +508,7 @@ interface CheckoutStepBodyProps {
 	goToThisStep?: () => void;
 	goToNextStep?: () => void;
 	activeStepContent?: React.ReactNode;
-	formStatus?: string;
+	formStatus?: FormStatus;
 	completeStepContent?: React.ReactNode;
 	validatingButtonText?: string;
 	validatingButtonAriaLabel?: string;
@@ -573,7 +576,7 @@ const CheckoutSummaryUI = styled.div`
 
 		.rtl & {
 			margin-right: 24px;
-			margin-left; 0;
+			margin-left: 0;
 		}
 	}
 `;

--- a/packages/composite-checkout/src/components/payment-request-button.tsx
+++ b/packages/composite-checkout/src/components/payment-request-button.tsx
@@ -11,7 +11,7 @@ import { useI18n } from '@automattic/react-i18n';
 import styled from '../lib/styled';
 import Button from './button';
 import { useFormStatus } from '../lib/form-status';
-import { StripePaymentRequest } from '../types';
+import { FormStatus, StripePaymentRequest } from '../types';
 
 // The react-stripe-elements PaymentRequestButtonElement cannot have its
 // paymentRequest updated once it has been rendered, so this is a custom one.
@@ -37,7 +37,7 @@ export default function PaymentRequestButton( {
 		disabled = true;
 	}
 
-	if ( formStatus === 'submitting' ) {
+	if ( formStatus === FormStatus.SUBMITTING ) {
 		return (
 			<Button disabled fullWidth>
 				{ __( 'Completing your purchase' ) }

--- a/packages/composite-checkout/src/components/transaction-status-handler.ts
+++ b/packages/composite-checkout/src/components/transaction-status-handler.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useEffect, useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import debugFactory from 'debug';
 import { useI18n } from '@automattic/react-i18n';
 
@@ -13,6 +13,7 @@ import useMessages from './use-messages';
 import useEvents from './use-events';
 import { useFormStatus } from '../lib/form-status';
 import { useTransactionStatus } from '../lib/transaction-status';
+import { TransactionStatus } from '../types';
 
 const debug = debugFactory( 'composite-checkout:transaction-status-handler' );
 
@@ -47,11 +48,15 @@ export function useTransactionStatusHandler( redirectToUrl: ( url: string ) => v
 	);
 	const redirectInfoMessage = __( 'Redirecting to payment partner…' );
 	useEffect( () => {
-		if ( transactionStatus === 'pending' && previousTransactionStatus !== 'pending' ) {
+		if ( transactionStatus === previousTransactionStatus ) {
+			return;
+		}
+
+		if ( transactionStatus === TransactionStatus.PENDING ) {
 			debug( 'transaction is beginning' );
 			setFormSubmitting();
 		}
-		if ( transactionStatus === 'error' && previousTransactionStatus !== 'error' ) {
+		if ( transactionStatus === TransactionStatus.ERROR ) {
 			debug( 'showing error', transactionError );
 			showErrorMessage( transactionError || genericErrorMessage );
 			onEvent( {
@@ -60,11 +65,11 @@ export function useTransactionStatusHandler( redirectToUrl: ( url: string ) => v
 			} );
 			resetTransaction();
 		}
-		if ( transactionStatus === 'complete' && previousTransactionStatus !== 'complete' ) {
+		if ( transactionStatus === TransactionStatus.COMPLETE ) {
 			debug( 'marking complete' );
 			setFormComplete();
 		}
-		if ( transactionStatus === 'redirecting' && previousTransactionStatus !== 'redirecting' ) {
+		if ( transactionStatus === TransactionStatus.REDIRECTING ) {
 			if ( ! transactionRedirectUrl ) {
 				debug( 'tried to redirect but there was no redirect url' );
 				setTransactionError( redirectErrormessage );
@@ -74,7 +79,7 @@ export function useTransactionStatusHandler( redirectToUrl: ( url: string ) => v
 			showInfoMessage( redirectInfoMessage );
 			redirectToUrl( transactionRedirectUrl );
 		}
-		if ( transactionStatus === 'not-started' && previousTransactionStatus !== 'not-started' ) {
+		if ( transactionStatus === TransactionStatus.NOT_STARTED ) {
 			debug( 'transaction status has been reset; enabling form' );
 			setFormReady();
 		}

--- a/packages/composite-checkout/src/lib/checkout-context.ts
+++ b/packages/composite-checkout/src/lib/checkout-context.ts
@@ -3,6 +3,7 @@
  */
 import { createContext } from 'react';
 import {
+	FormStatus,
 	PaymentMethod,
 	PaymentProcessorProp,
 	ReactStandardAction,
@@ -32,8 +33,8 @@ interface CheckoutContext {
 	showInfoMessage: ( message: string ) => void;
 	showSuccessMessage: ( message: string ) => void;
 	onEvent: ( action: ReactStandardAction ) => void;
-	formStatus: string;
-	setFormStatus: ( newStatus: string ) => void;
+	formStatus: FormStatus;
+	setFormStatus: ( newStatus: FormStatus ) => void;
 	transactionStatusManager: TransactionStatusManager;
 	paymentProcessors: PaymentProcessorProp;
 }
@@ -46,7 +47,7 @@ const defaultCheckoutContext: CheckoutContext = {
 	showInfoMessage: noop,
 	showSuccessMessage: noop,
 	onEvent: noop,
-	formStatus: 'loading',
+	formStatus: FormStatus.LOADING,
 	setFormStatus: noop,
 	transactionStatusManager: defaultTransactionStatusManager,
 	paymentProcessors: {},

--- a/packages/composite-checkout/src/lib/checkout-context.ts
+++ b/packages/composite-checkout/src/lib/checkout-context.ts
@@ -3,15 +3,16 @@
  */
 import { createContext } from 'react';
 import {
-	ReactStandardAction,
 	PaymentMethod,
 	PaymentProcessorProp,
+	ReactStandardAction,
+	TransactionStatus,
 	TransactionStatusManager,
 } from '../types';
 
 const defaultTransactionStatusManager: TransactionStatusManager = {
-	transactionStatus: 'not-started',
-	previousTransactionStatus: 'not-started',
+	transactionStatus: TransactionStatus.NOT_STARTED,
+	previousTransactionStatus: TransactionStatus.NOT_STARTED,
 	transactionError: null,
 	transactionLastResponse: null,
 	transactionRedirectUrl: null,

--- a/packages/composite-checkout/src/lib/form-status.ts
+++ b/packages/composite-checkout/src/lib/form-status.ts
@@ -1,14 +1,20 @@
 /**
  * External dependencies
  */
-import { useReducer, useMemo, useCallback, useContext, useEffect } from 'react';
+import { useCallback, useContext, useEffect, useMemo, useReducer } from 'react';
 import debugFactory from 'debug';
 
 /**
  * Internal dependencies
  */
 import CheckoutContext from '../lib/checkout-context';
-import { FormStatusManager, FormStatusController, ReactStandardAction } from '../types';
+import {
+	FormStatus,
+	FormStatusAction,
+	FormStatusController,
+	FormStatusManager,
+	FormStatusSetter,
+} from '../types';
 
 const debug = debugFactory( 'composite-checkout:form-status' );
 
@@ -16,11 +22,11 @@ export function useFormStatus(): FormStatusController {
 	const { formStatus, setFormStatus } = useContext( CheckoutContext );
 	const formStatusActions = useMemo(
 		() => ( {
-			setFormLoading: () => setFormStatus( 'loading' ),
-			setFormReady: () => setFormStatus( 'ready' ),
-			setFormSubmitting: () => setFormStatus( 'submitting' ),
-			setFormValidating: () => setFormStatus( 'validating' ),
-			setFormComplete: () => setFormStatus( 'complete' ),
+			setFormLoading: () => setFormStatus( FormStatus.LOADING ),
+			setFormReady: () => setFormStatus( FormStatus.READY ),
+			setFormSubmitting: () => setFormStatus( FormStatus.SUBMITTING ),
+			setFormValidating: () => setFormStatus( FormStatus.VALIDATING ),
+			setFormComplete: () => setFormStatus( FormStatus.COMPLETE ),
 		} ),
 		[ setFormStatus ]
 	);
@@ -39,9 +45,9 @@ export function useFormStatusManager(
 ): FormStatusManager {
 	const [ formStatus, dispatchFormStatus ] = useReducer(
 		formStatusReducer,
-		isLoading ? 'loading' : 'ready'
+		isLoading ? FormStatus.LOADING : FormStatus.READY
 	);
-	const setFormStatus = useCallback( ( payload ) => {
+	const setFormStatus = useCallback< FormStatusSetter >( ( payload ) => {
 		return dispatchFormStatus( { type: 'FORM_STATUS_CHANGE', payload } );
 	}, [] );
 
@@ -55,7 +61,7 @@ export function useFormStatusManager(
 	return [ formStatus, setFormStatus ];
 }
 
-function formStatusReducer( state: string, action: ReactStandardAction ): string {
+function formStatusReducer( state: FormStatus, action: FormStatusAction ): FormStatus {
 	switch ( action.type ) {
 		case 'FORM_STATUS_CHANGE':
 			validateStatus( action.payload );
@@ -80,12 +86,12 @@ function getNewStatusFromProps( {
 }: {
 	isLoading: boolean;
 	isValidating: boolean;
-} ): string {
+} ): FormStatus {
 	if ( isLoading ) {
-		return 'loading';
+		return FormStatus.LOADING;
 	}
 	if ( isValidating ) {
-		return 'validating';
+		return FormStatus.VALIDATING;
 	}
-	return 'ready';
+	return FormStatus.READY;
 }

--- a/packages/composite-checkout/src/lib/form-status.ts
+++ b/packages/composite-checkout/src/lib/form-status.ts
@@ -64,7 +64,7 @@ export function useFormStatusManager(
 function formStatusReducer( state: FormStatus, action: FormStatusAction ): FormStatus {
 	switch ( action.type ) {
 		case 'FORM_STATUS_CHANGE':
-			validateStatus( action.payload );
+			validateFormStatus( action.payload );
 			debug( 'setting form status to', action.payload );
 			return action.payload;
 		default:
@@ -72,10 +72,8 @@ function formStatusReducer( state: FormStatus, action: FormStatusAction ): FormS
 	}
 }
 
-const validStatuses = [ 'loading', 'ready', 'validating', 'submitting', 'complete' ] as const;
-
-function validateStatus( status: unknown ): asserts status is typeof validStatuses[ number ] {
-	if ( ! validStatuses.includes( status as never ) ) {
+function validateFormStatus( status: unknown ): asserts status is FormStatus {
+	if ( ! Object.values( FormStatus ).includes( status as never ) ) {
 		throw new Error( `Invalid form status '${ status }'` );
 	}
 }

--- a/packages/composite-checkout/src/lib/payment-methods/alipay.js
+++ b/packages/composite-checkout/src/lib/payment-methods/alipay.js
@@ -13,6 +13,7 @@ import { useI18n } from '@automattic/react-i18n';
 import Field from '../../components/field';
 import Button from '../../components/button';
 import {
+	FormStatus,
 	usePaymentProcessor,
 	useTransactionStatus,
 	useLineItems,
@@ -82,7 +83,7 @@ function AlipayFields() {
 	const customerName = useSelect( ( select ) => select( 'alipay' ).getCustomerName() );
 	const { changeCustomerName } = useDispatch( 'alipay' );
 	const { formStatus } = useFormStatus();
-	const isDisabled = formStatus !== 'ready';
+	const isDisabled = formStatus !== FormStatus.READY;
 
 	return (
 		<AlipayFormWrapper>
@@ -176,7 +177,7 @@ function AlipayPayButton( { disabled, store, stripe, stripeConfiguration } ) {
 				}
 			} }
 			buttonType="primary"
-			isBusy={ 'submitting' === formStatus }
+			isBusy={ FormStatus.SUBMITTING === formStatus }
 			fullWidth
 		>
 			<ButtonContents formStatus={ formStatus } total={ total } />
@@ -186,10 +187,10 @@ function AlipayPayButton( { disabled, store, stripe, stripeConfiguration } ) {
 
 function ButtonContents( { formStatus, total } ) {
 	const { __ } = useI18n();
-	if ( formStatus === 'submitting' ) {
+	if ( formStatus === FormStatus.SUBMITTING ) {
 		return __( 'Processing…' );
 	}
-	if ( formStatus === 'ready' ) {
+	if ( formStatus === FormStatus.READY ) {
 		return sprintf( __( 'Pay %s' ), total.amount.displayValue );
 	}
 	return __( 'Please wait…' );

--- a/packages/composite-checkout/src/lib/payment-methods/bancontact.js
+++ b/packages/composite-checkout/src/lib/payment-methods/bancontact.js
@@ -13,6 +13,7 @@ import { useI18n } from '@automattic/react-i18n';
 import Field from '../../components/field';
 import Button from '../../components/button';
 import {
+	FormStatus,
 	usePaymentProcessor,
 	useTransactionStatus,
 	useLineItems,
@@ -84,7 +85,7 @@ function BancontactFields() {
 	const customerName = useSelect( ( select ) => select( 'bancontact' ).getCustomerName() );
 	const { changeCustomerName } = useDispatch( 'bancontact' );
 	const { formStatus } = useFormStatus();
-	const isDisabled = formStatus !== 'ready';
+	const isDisabled = formStatus !== FormStatus.READY;
 
 	return (
 		<BancontactFormWrapper>
@@ -181,7 +182,7 @@ function BancontactPayButton( { disabled, store, stripe, stripeConfiguration } )
 				}
 			} }
 			buttonType="primary"
-			isBusy={ 'submitting' === formStatus }
+			isBusy={ FormStatus.SUBMITTING === formStatus }
 			fullWidth
 		>
 			<ButtonContents formStatus={ formStatus } total={ total } />
@@ -191,10 +192,10 @@ function BancontactPayButton( { disabled, store, stripe, stripeConfiguration } )
 
 function ButtonContents( { formStatus, total } ) {
 	const { __ } = useI18n();
-	if ( formStatus === 'submitting' ) {
+	if ( formStatus === FormStatus.SUBMITTING ) {
 		return __( 'Processing…' );
 	}
-	if ( formStatus === 'ready' ) {
+	if ( formStatus === FormStatus.READY ) {
 		return sprintf( __( 'Pay %s' ), total.amount.displayValue );
 	}
 	return __( 'Please wait…' );

--- a/packages/composite-checkout/src/lib/payment-methods/eps.js
+++ b/packages/composite-checkout/src/lib/payment-methods/eps.js
@@ -13,6 +13,7 @@ import { useI18n } from '@automattic/react-i18n';
 import Field from '../../components/field';
 import Button from '../../components/button';
 import {
+	FormStatus,
 	usePaymentProcessor,
 	useTransactionStatus,
 	useLineItems,
@@ -78,7 +79,7 @@ function EpsFields() {
 	const customerName = useSelect( ( select ) => select( 'eps' ).getCustomerName() );
 	const { changeCustomerName } = useDispatch( 'eps' );
 	const { formStatus } = useFormStatus();
-	const isDisabled = formStatus !== 'ready';
+	const isDisabled = formStatus !== FormStatus.READY;
 
 	return (
 		<EpsFormWrapper>
@@ -172,7 +173,7 @@ function EpsPayButton( { disabled, store, stripe, stripeConfiguration } ) {
 				}
 			} }
 			buttonType="primary"
-			isBusy={ 'submitting' === formStatus }
+			isBusy={ FormStatus.SUBMITTING === formStatus }
 			fullWidth
 		>
 			<ButtonContents formStatus={ formStatus } total={ total } />
@@ -182,10 +183,10 @@ function EpsPayButton( { disabled, store, stripe, stripeConfiguration } ) {
 
 function ButtonContents( { formStatus, total } ) {
 	const { __ } = useI18n();
-	if ( formStatus === 'submitting' ) {
+	if ( formStatus === FormStatus.SUBMITTING ) {
 		return __( 'Processing…' );
 	}
-	if ( formStatus === 'ready' ) {
+	if ( formStatus === FormStatus.READY ) {
 		return sprintf( __( 'Pay %s' ), total.amount.displayValue );
 	}
 	return __( 'Please wait…' );

--- a/packages/composite-checkout/src/lib/payment-methods/existing-credit-card.js
+++ b/packages/composite-checkout/src/lib/payment-methods/existing-credit-card.js
@@ -12,6 +12,7 @@ import { useI18n } from '@automattic/react-i18n';
  */
 import Button from '../../components/button';
 import {
+	FormStatus,
 	useMessages,
 	useLineItems,
 	useEvents,
@@ -198,7 +199,7 @@ function ExistingCardPayButton( {
 					} );
 			} }
 			buttonType="primary"
-			isBusy={ 'submitting' === formStatus }
+			isBusy={ FormStatus.SUBMITTING === formStatus }
 			fullWidth
 		>
 			<ButtonContents formStatus={ formStatus } total={ total } />
@@ -208,10 +209,10 @@ function ExistingCardPayButton( {
 
 function ButtonContents( { formStatus, total } ) {
 	const { __ } = useI18n();
-	if ( formStatus === 'submitting' ) {
+	if ( formStatus === FormStatus.SUBMITTING ) {
 		return __( 'Processing…' );
 	}
-	if ( formStatus === 'ready' ) {
+	if ( formStatus === FormStatus.READY ) {
 		return sprintf( __( 'Pay %s' ), total.amount.displayValue );
 	}
 	return __( 'Please wait…' );

--- a/packages/composite-checkout/src/lib/payment-methods/free-purchase.js
+++ b/packages/composite-checkout/src/lib/payment-methods/free-purchase.js
@@ -9,6 +9,7 @@ import { useI18n } from '@automattic/react-i18n';
  */
 import Button from '../../components/button';
 import {
+	FormStatus,
 	useLineItems,
 	useEvents,
 	useTransactionStatus,
@@ -66,7 +67,7 @@ function FreePurchaseSubmitButton( { disabled } ) {
 			disabled={ disabled }
 			onClick={ onClick }
 			buttonType="primary"
-			isBusy={ 'submitting' === formStatus }
+			isBusy={ FormStatus.SUBMITTING === formStatus }
 			fullWidth
 		>
 			<ButtonContents formStatus={ formStatus } />
@@ -76,10 +77,10 @@ function FreePurchaseSubmitButton( { disabled } ) {
 
 function ButtonContents( { formStatus } ) {
 	const { __ } = useI18n();
-	if ( formStatus === 'submitting' ) {
+	if ( formStatus === FormStatus.SUBMITTING ) {
 		return __( 'Processing…' );
 	}
-	if ( formStatus === 'ready' ) {
+	if ( formStatus === FormStatus.READY ) {
 		return __( 'Complete Checkout' );
 	}
 	return __( 'Please wait…' );

--- a/packages/composite-checkout/src/lib/payment-methods/full-credits.js
+++ b/packages/composite-checkout/src/lib/payment-methods/full-credits.js
@@ -10,6 +10,7 @@ import { useI18n } from '@automattic/react-i18n';
  */
 import Button from '../../components/button';
 import {
+	FormStatus,
 	useTransactionStatus,
 	usePaymentProcessor,
 	useLineItems,
@@ -68,7 +69,7 @@ function FullCreditsSubmitButton( { disabled } ) {
 			disabled={ disabled }
 			onClick={ onClick }
 			buttonType="primary"
-			isBusy={ 'submitting' === formStatus }
+			isBusy={ FormStatus.SUBMITTING === formStatus }
 			fullWidth
 		>
 			<ButtonContents formStatus={ formStatus } total={ total } />
@@ -78,10 +79,10 @@ function FullCreditsSubmitButton( { disabled } ) {
 
 function ButtonContents( { formStatus, total } ) {
 	const { __ } = useI18n();
-	if ( formStatus === 'submitting' ) {
+	if ( formStatus === FormStatus.SUBMITTING ) {
 		return __( 'Processing…' );
 	}
-	if ( formStatus === 'ready' ) {
+	if ( formStatus === FormStatus.READY ) {
 		return sprintf( __( 'Pay %s with WordPress.com Credits' ), total.amount.displayValue );
 	}
 	return __( 'Please wait…' );

--- a/packages/composite-checkout/src/lib/payment-methods/giropay.js
+++ b/packages/composite-checkout/src/lib/payment-methods/giropay.js
@@ -13,6 +13,7 @@ import { useI18n } from '@automattic/react-i18n';
 import Field from '../../components/field';
 import Button from '../../components/button';
 import {
+	FormStatus,
 	usePaymentProcessor,
 	useTransactionStatus,
 	useLineItems,
@@ -82,7 +83,7 @@ function GiropayFields() {
 	const customerName = useSelect( ( select ) => select( 'giropay' ).getCustomerName() );
 	const { changeCustomerName } = useDispatch( 'giropay' );
 	const { formStatus } = useFormStatus();
-	const isDisabled = formStatus !== 'ready';
+	const isDisabled = formStatus !== FormStatus.READY;
 
 	return (
 		<GiropayFormWrapper>
@@ -179,7 +180,7 @@ function GiropayPayButton( { disabled, store, stripe, stripeConfiguration } ) {
 				}
 			} }
 			buttonType="primary"
-			isBusy={ 'submitting' === formStatus }
+			isBusy={ FormStatus.SUBMITTING === formStatus }
 			fullWidth
 		>
 			<ButtonContents formStatus={ formStatus } total={ total } />
@@ -189,10 +190,10 @@ function GiropayPayButton( { disabled, store, stripe, stripeConfiguration } ) {
 
 function ButtonContents( { formStatus, total } ) {
 	const { __ } = useI18n();
-	if ( formStatus === 'submitting' ) {
+	if ( formStatus === FormStatus.SUBMITTING ) {
 		return __( 'Processing…' );
 	}
-	if ( formStatus === 'ready' ) {
+	if ( formStatus === FormStatus.READY ) {
 		return sprintf( __( 'Pay %s' ), total.amount.displayValue );
 	}
 	return __( 'Please wait…' );

--- a/packages/composite-checkout/src/lib/payment-methods/ideal.js
+++ b/packages/composite-checkout/src/lib/payment-methods/ideal.js
@@ -13,6 +13,7 @@ import { useI18n } from '@automattic/react-i18n';
 import Field from '../../components/field';
 import Button from '../../components/button';
 import {
+	FormStatus,
 	usePaymentProcessor,
 	useTransactionStatus,
 	useLineItems,
@@ -92,7 +93,7 @@ function IdealFields() {
 	const customerBank = useSelect( ( select ) => select( 'ideal' ).getCustomerBank() );
 	const { changeCustomerName, changeCustomerBank } = useDispatch( 'ideal' );
 	const { formStatus } = useFormStatus();
-	const isDisabled = formStatus !== 'ready';
+	const isDisabled = formStatus !== FormStatus.READY;
 
 	return (
 		<IdealFormWrapper>
@@ -249,7 +250,7 @@ function IdealPayButton( { disabled, store, stripe, stripeConfiguration } ) {
 				}
 			} }
 			buttonType="primary"
-			isBusy={ 'submitting' === formStatus }
+			isBusy={ FormStatus.SUBMITTING === formStatus }
 			fullWidth
 		>
 			<ButtonContents formStatus={ formStatus } total={ total } />
@@ -259,10 +260,10 @@ function IdealPayButton( { disabled, store, stripe, stripeConfiguration } ) {
 
 function ButtonContents( { formStatus, total } ) {
 	const { __ } = useI18n();
-	if ( formStatus === 'submitting' ) {
+	if ( formStatus === FormStatus.SUBMITTING ) {
 		return __( 'Processing…' );
 	}
-	if ( formStatus === 'ready' ) {
+	if ( formStatus === FormStatus.READY ) {
 		return sprintf( __( 'Pay %s' ), total.amount.displayValue );
 	}
 	return __( 'Please wait…' );

--- a/packages/composite-checkout/src/lib/payment-methods/p24.js
+++ b/packages/composite-checkout/src/lib/payment-methods/p24.js
@@ -13,6 +13,7 @@ import { useI18n } from '@automattic/react-i18n';
 import Field from '../../components/field';
 import Button from '../../components/button';
 import {
+	FormStatus,
 	usePaymentProcessor,
 	useTransactionStatus,
 	useLineItems,
@@ -88,7 +89,7 @@ function P24Fields() {
 	const customerEmail = useSelect( ( select ) => select( 'p24' ).getCustomerEmail() );
 	const { changeCustomerName, changeCustomerEmail } = useDispatch( 'p24' );
 	const { formStatus } = useFormStatus();
-	const isDisabled = formStatus !== 'ready';
+	const isDisabled = formStatus !== FormStatus.READY;
 
 	return (
 		<P24FormWrapper>
@@ -198,7 +199,7 @@ function P24PayButton( { disabled, store, stripe, stripeConfiguration } ) {
 				}
 			} }
 			buttonType="primary"
-			isBusy={ 'submitting' === formStatus }
+			isBusy={ FormStatus.SUBMITTING === formStatus }
 			fullWidth
 		>
 			<ButtonContents formStatus={ formStatus } total={ total } />
@@ -208,10 +209,10 @@ function P24PayButton( { disabled, store, stripe, stripeConfiguration } ) {
 
 function ButtonContents( { formStatus, total } ) {
 	const { __ } = useI18n();
-	if ( formStatus === 'submitting' ) {
+	if ( formStatus === FormStatus.SUBMITTING ) {
 		return __( 'Processing…' );
 	}
-	if ( formStatus === 'ready' ) {
+	if ( formStatus === FormStatus.READY ) {
 		return sprintf( __( 'Pay %s' ), total.amount.displayValue );
 	}
 	return __( 'Please wait…' );

--- a/packages/composite-checkout/src/lib/payment-methods/paypal.js
+++ b/packages/composite-checkout/src/lib/payment-methods/paypal.js
@@ -11,6 +11,8 @@ import { useI18n } from '@automattic/react-i18n';
  */
 import Button from '../../components/button';
 import {
+	FormStatus,
+	TransactionStatus,
 	useEvents,
 	usePaymentProcessor,
 	useTransactionStatus,
@@ -84,7 +86,7 @@ export function PaypalSubmitButton( { disabled } ) {
 			disabled={ disabled }
 			onClick={ onClick }
 			buttonType="paypal"
-			isBusy={ 'submitting' === formStatus }
+			isBusy={ FormStatus.SUBMITTING === formStatus }
 			fullWidth
 		>
 			<PayPalButtonContents formStatus={ formStatus } transactionStatus={ transactionStatus } />
@@ -94,13 +96,13 @@ export function PaypalSubmitButton( { disabled } ) {
 
 function PayPalButtonContents( { formStatus, transactionStatus } ) {
 	const { __ } = useI18n();
-	if ( transactionStatus === 'redirecting' ) {
+	if ( transactionStatus === TransactionStatus.REDIRECTING ) {
 		return <span>{ __( 'Redirecting to PayPal…' ) }</span>;
 	}
-	if ( formStatus === 'submitting' ) {
+	if ( formStatus === FormStatus.SUBMITTING ) {
 		return <span>{ __( 'Processing…' ) }</span>;
 	}
-	if ( formStatus === 'ready' ) {
+	if ( formStatus === FormStatus.READY ) {
 		return <ButtonPayPalIcon />;
 	}
 	return <span>{ __( 'Please wait…' ) }</span>;

--- a/packages/composite-checkout/src/lib/payment-methods/sofort.js
+++ b/packages/composite-checkout/src/lib/payment-methods/sofort.js
@@ -13,6 +13,7 @@ import { useI18n } from '@automattic/react-i18n';
 import Field from '../../components/field';
 import Button from '../../components/button';
 import {
+	FormStatus,
 	usePaymentProcessor,
 	useTransactionStatus,
 	useLineItems,
@@ -82,7 +83,7 @@ function SofortFields() {
 	const customerName = useSelect( ( select ) => select( 'sofort' ).getCustomerName() );
 	const { changeCustomerName } = useDispatch( 'sofort' );
 	const { formStatus } = useFormStatus();
-	const isDisabled = formStatus !== 'ready';
+	const isDisabled = formStatus !== FormStatus.READY;
 
 	return (
 		<SofortFormWrapper>
@@ -176,7 +177,7 @@ function SofortPayButton( { disabled, store, stripe, stripeConfiguration } ) {
 				}
 			} }
 			buttonType="primary"
-			isBusy={ 'submitting' === formStatus }
+			isBusy={ FormStatus.SUBMITTING === formStatus }
 			fullWidth
 		>
 			<ButtonContents formStatus={ formStatus } total={ total } />
@@ -186,10 +187,10 @@ function SofortPayButton( { disabled, store, stripe, stripeConfiguration } ) {
 
 function ButtonContents( { formStatus, total } ) {
 	const { __ } = useI18n();
-	if ( formStatus === 'submitting' ) {
+	if ( formStatus === FormStatus.SUBMITTING ) {
 		return __( 'Processing…' );
 	}
-	if ( formStatus === 'ready' ) {
+	if ( formStatus === FormStatus.READY ) {
 		return sprintf( __( 'Pay %s' ), total.amount.displayValue );
 	}
 	return __( 'Please wait…' );

--- a/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
@@ -21,6 +21,8 @@ import Button from '../../components/button';
 import PaymentLogo from './payment-logo';
 import { showStripeModalAuth } from '../stripe';
 import {
+	FormStatus,
+	TransactionStatus,
 	usePaymentProcessor,
 	useTransactionStatus,
 	useMessages,
@@ -406,7 +408,7 @@ function StripePayButton( { disabled, store, stripe, stripeConfiguration } ) {
 	useEffect( () => {
 		let isSubscribed = true;
 
-		if ( transactionStatus === 'authorizing' ) {
+		if ( transactionStatus === TransactionStatus.AUTHORIZING ) {
 			debug( 'showing auth' );
 			onEvent( { type: 'SHOW_MODAL_AUTHORIZATION' } );
 			showStripeModalAuth( {
@@ -470,7 +472,7 @@ function StripePayButton( { disabled, store, stripe, stripeConfiguration } ) {
 				}
 			} }
 			buttonType="primary"
-			isBusy={ 'submitting' === formStatus }
+			isBusy={ FormStatus.SUBMITTING === formStatus }
 			fullWidth
 		>
 			<ButtonContents formStatus={ formStatus } total={ total } />
@@ -480,10 +482,10 @@ function StripePayButton( { disabled, store, stripe, stripeConfiguration } ) {
 
 function ButtonContents( { formStatus, total } ) {
 	const { __ } = useI18n();
-	if ( formStatus === 'submitting' ) {
+	if ( formStatus === FormStatus.SUBMITTING ) {
 		return __( 'Processing…' );
 	}
-	if ( formStatus === 'ready' ) {
+	if ( formStatus === FormStatus.READY ) {
 		return sprintf( __( 'Pay %s' ), total.amount.displayValue );
 	}
 	return __( 'Please wait…' );

--- a/packages/composite-checkout/src/lib/transaction-status.ts
+++ b/packages/composite-checkout/src/lib/transaction-status.ts
@@ -1,22 +1,28 @@
 /**
  * External dependencies
  */
-import { useMemo, useContext, useCallback, useReducer } from 'react';
+import { useCallback, useContext, useMemo, useReducer } from 'react';
 
 /**
  * Internal dependencies
  */
 import CheckoutContext from '../lib/checkout-context';
-import { TransactionStatus, TransactionStatusAction, TransactionStatusManager } from '../types';
+import {
+	TransactionStatus,
+	TransactionStatusState,
+	TransactionStatusAction,
+	TransactionStatusManager,
+	TransactionStatusPayloads,
+} from '../types';
 
 export function useTransactionStatus(): TransactionStatusManager {
 	const { transactionStatusManager } = useContext( CheckoutContext );
 	return transactionStatusManager;
 }
 
-const initialState: TransactionStatus = {
-	previousTransactionStatus: 'not-started',
-	transactionStatus: 'not-started',
+const initialState: TransactionStatusState = {
+	previousTransactionStatus: TransactionStatus.NOT_STARTED,
+	transactionStatus: TransactionStatus.NOT_STARTED,
 	transactionError: null,
 	transactionLastResponse: null,
 	transactionRedirectUrl: null,
@@ -24,49 +30,54 @@ const initialState: TransactionStatus = {
 
 export function useTransactionStatusManager(): TransactionStatusManager {
 	const [ state, dispatch ] = useReducer( transactionStatusReducer, initialState );
-	const resetTransaction = useCallback(
+	const resetTransaction = useCallback< TransactionStatusManager[ 'resetTransaction' ] >(
 		() =>
 			dispatch( {
 				type: 'STATUS_SET',
-				payload: { status: 'not-started' },
-			} as TransactionStatusAction ),
+				payload: { status: TransactionStatus.NOT_STARTED },
+			} ),
 		[]
 	);
-	const setTransactionComplete = useCallback(
+	const setTransactionComplete = useCallback<
+		TransactionStatusManager[ 'setTransactionComplete' ]
+	>(
 		( response ) =>
 			dispatch( {
 				type: 'STATUS_SET',
-				payload: { status: 'complete', response },
-			} as TransactionStatusAction ),
+				payload: { status: TransactionStatus.COMPLETE, response },
+			} ),
 		[]
 	);
-	const setTransactionError = useCallback(
+	const setTransactionError = useCallback< TransactionStatusManager[ 'setTransactionError' ] >(
 		( errorMessage ) =>
 			dispatch( {
 				type: 'STATUS_SET',
-				payload: { status: 'error', error: errorMessage },
-			} as TransactionStatusAction ),
+				payload: { status: TransactionStatus.ERROR, error: errorMessage },
+			} ),
 		[]
 	);
-	const setTransactionPending = useCallback(
-		() =>
-			dispatch( { type: 'STATUS_SET', payload: { status: 'pending' } } as TransactionStatusAction ),
+	const setTransactionPending = useCallback< TransactionStatusManager[ 'setTransactionPending' ] >(
+		() => dispatch( { type: 'STATUS_SET', payload: { status: TransactionStatus.PENDING } } ),
 		[]
 	);
-	const setTransactionRedirecting = useCallback(
+	const setTransactionRedirecting = useCallback<
+		TransactionStatusManager[ 'setTransactionRedirecting' ]
+	>(
 		( url ) =>
 			dispatch( {
 				type: 'STATUS_SET',
-				payload: { status: 'redirecting', response: null, url },
-			} as TransactionStatusAction ),
+				payload: { status: TransactionStatus.REDIRECTING, url },
+			} ),
 		[]
 	);
-	const setTransactionAuthorizing = useCallback(
+	const setTransactionAuthorizing = useCallback<
+		TransactionStatusManager[ 'setTransactionAuthorizing' ]
+	>(
 		( response ) =>
 			dispatch( {
 				type: 'STATUS_SET',
-				payload: { status: 'authorizing', response },
-			} as TransactionStatusAction ),
+				payload: { status: TransactionStatus.AUTHORIZING, response },
+			} ),
 		[]
 	);
 
@@ -76,7 +87,7 @@ export function useTransactionStatusManager(): TransactionStatusManager {
 		transactionLastResponse,
 		transactionError,
 		transactionRedirectUrl,
-	}: TransactionStatus = state;
+	}: TransactionStatusState = state;
 
 	return useMemo(
 		() => ( {
@@ -109,12 +120,17 @@ export function useTransactionStatusManager(): TransactionStatusManager {
 }
 
 function transactionStatusReducer(
-	state: TransactionStatus,
+	state: TransactionStatusState,
 	action: TransactionStatusAction
-): TransactionStatus {
+): TransactionStatusState {
 	switch ( action.type ) {
 		case 'STATUS_SET': {
-			const { status, response, error = null, url = null } = action.payload;
+			const {
+				status,
+				response = null,
+				error = null,
+				url = null,
+			} = action.payload as TransactionStatusPayloads;
 			return {
 				...state,
 				previousTransactionStatus: state.transactionStatus,

--- a/packages/composite-checkout/src/public-api.ts
+++ b/packages/composite-checkout/src/public-api.ts
@@ -76,6 +76,7 @@ import { CheckIcon as CheckoutCheckIcon } from './components/shared-icons';
 import { useTransactionStatus } from './lib/transaction-status';
 import { usePaymentProcessor } from './lib/payment-processors';
 import checkoutTheme from './lib/theme';
+import { FormStatus, TransactionStatus } from './types';
 
 // Re-export the public API
 export {
@@ -148,4 +149,6 @@ export {
 	MainContentUI,
 	CheckoutStepAreaUI,
 	SubmitButtonWrapperUI,
+	FormStatus,
+	TransactionStatus,
 };

--- a/packages/composite-checkout/src/types.ts
+++ b/packages/composite-checkout/src/types.ts
@@ -91,29 +91,71 @@ export type PaymentProcessorFunction = (
 	...args: unknown[]
 ) => Promise< PaymentProcessorResponse >;
 
-export interface TransactionStatus {
-	transactionStatus: string;
-	previousTransactionStatus: string;
+export enum TransactionStatus {
+	NOT_STARTED = 'not-started',
+	PENDING = 'pending',
+	AUTHORIZING = 'authorizing',
+	COMPLETE = 'complete',
+	REDIRECTING = 'redirecting',
+	ERROR = 'error',
+}
+
+export interface TransactionStatusState {
+	transactionStatus: TransactionStatus;
+	previousTransactionStatus: TransactionStatus;
 	transactionLastResponse: PaymentProcessorResponse | null;
 	transactionError: string | null;
 	transactionRedirectUrl: string | null;
 }
 
-export interface TransactionStatusPayload {
-	status: 'not-started' | 'pending' | 'complete' | 'authorizing' | 'error' | 'redirecting';
-	response?: unknown | null;
+export interface TransactionStatusPayloads {
+	status: TransactionStatus;
+	response?: PaymentProcessorResponse;
 	error?: string;
 	url?: string;
 }
 
+export interface TransactionStatusPayloadNotStarted
+	extends Pick< TransactionStatusPayloads, 'status' > {
+	status: TransactionStatus.NOT_STARTED;
+}
+
+export interface TransactionStatusPayloadPending
+	extends Pick< TransactionStatusPayloads, 'status' > {
+	status: TransactionStatus.PENDING;
+}
+
+export interface TransactionStatusPayloadAuthorizing
+	extends Required< Pick< TransactionStatusPayloads, 'status' | 'response' > > {
+	status: TransactionStatus.AUTHORIZING;
+}
+
+export interface TransactionStatusPayloadComplete
+	extends Required< Pick< TransactionStatusPayloads, 'status' | 'response' > > {
+	status: TransactionStatus.COMPLETE;
+}
+
+export interface TransactionStatusPayloadRedirecting
+	extends Required< Pick< TransactionStatusPayloads, 'status' | 'url' > > {
+	status: TransactionStatus.REDIRECTING;
+}
+
+export interface TransactionStatusPayloadError
+	extends Required< Pick< TransactionStatusPayloads, 'status' | 'error' > > {
+	status: TransactionStatus.ERROR;
+}
+
+export type TransactionStatusPayload =
+	| TransactionStatusPayloadNotStarted
+	| TransactionStatusPayloadPending
+	| TransactionStatusPayloadAuthorizing
+	| TransactionStatusPayloadComplete
+	| TransactionStatusPayloadRedirecting
+	| TransactionStatusPayloadError;
+
 export type TransactionStatusAction = ReactStandardAction< 'STATUS_SET', TransactionStatusPayload >;
 
-export interface TransactionStatusManager {
-	transactionStatus: string;
-	previousTransactionStatus: string;
-	transactionError: string | null;
-	transactionLastResponse: PaymentProcessorResponse | null;
-	transactionRedirectUrl: string | null;
+export interface TransactionStatusManager extends TransactionStatusState {
 	resetTransaction: () => void;
 	setTransactionError: ( message: string ) => void;
 	setTransactionComplete: ( response: PaymentProcessorResponse ) => void;

--- a/packages/composite-checkout/src/types.ts
+++ b/packages/composite-checkout/src/types.ts
@@ -43,8 +43,21 @@ export interface LineItemAmount {
 
 export type ExternalLineItemAmount = Partial< LineItemAmount >;
 
-export interface FormStatusController {
-	formStatus: string;
+export enum FormStatus {
+	LOADING = 'loading',
+	READY = 'ready',
+	SUBMITTING = 'submitting',
+	VALIDATING = 'validating',
+	COMPLETE = 'complete',
+}
+
+export interface FormStatusState {
+	formStatus: FormStatus;
+}
+
+export type FormStatusAction = ReactStandardAction< 'FORM_STATUS_CHANGE', FormStatus >;
+
+export interface FormStatusController extends FormStatusState {
 	setFormReady: () => void;
 	setFormLoading: () => void;
 	setFormValidating: () => void;
@@ -52,7 +65,9 @@ export interface FormStatusController {
 	setFormComplete: () => void;
 }
 
-export type FormStatusManager = [ string, ( newStatus: string ) => void ];
+export type FormStatusSetter = ( newStatus: FormStatus ) => void;
+
+export type FormStatusManager = [ FormStatus, FormStatusSetter ];
 
 export type ReactStandardAction< T = string, P = unknown > = P extends void
 	? {

--- a/packages/composite-checkout/test/checkout-provider.js
+++ b/packages/composite-checkout/test/checkout-provider.js
@@ -10,6 +10,8 @@ import '@testing-library/jest-dom/extend-expect';
  */
 import {
 	CheckoutProvider,
+	FormStatus,
+	TransactionStatus,
 	useSelect,
 	useDispatch,
 	useRegisterStore,
@@ -21,25 +23,25 @@ const noop = () => {};
 
 const CustomFormWithFormStatus = () => {
 	const { formStatus, setFormComplete, setFormLoading, setFormSubmitting } = useFormStatus();
-	if ( formStatus === 'loading' ) {
+	if ( formStatus === FormStatus.LOADING ) {
 		return <div>Loading</div>;
 	}
-	if ( formStatus === 'submitting' ) {
+	if ( formStatus === FormStatus.SUBMITTING ) {
 		return <div>Submitting</div>;
 	}
-	if ( formStatus === 'complete' ) {
+	if ( formStatus === FormStatus.COMPLETE ) {
 		return <div>Form Complete</div>;
 	}
 	return (
 		<div>
 			<input type="text" />
-			<button disabled={ formStatus !== 'ready' } onClick={ setFormLoading }>
+			<button disabled={ formStatus !== FormStatus.READY } onClick={ setFormLoading }>
 				Load
 			</button>
-			<button disabled={ formStatus !== 'ready' } onClick={ setFormSubmitting }>
+			<button disabled={ formStatus !== FormStatus.READY } onClick={ setFormSubmitting }>
 				Submit
 			</button>
-			<button disabled={ formStatus !== 'ready' } onClick={ setFormComplete }>
+			<button disabled={ formStatus !== FormStatus.READY } onClick={ setFormComplete }>
 				Complete
 			</button>
 		</div>
@@ -56,26 +58,26 @@ const CustomFormWithTransactionStatus = () => {
 		setTransactionError,
 		setTransactionPending,
 	} = useTransactionStatus();
-	if ( formStatus === 'loading' ) {
+	if ( formStatus === FormStatus.LOADING ) {
 		return <div>Loading</div>;
 	}
-	if ( transactionStatus === 'redirecting' ) {
+	if ( transactionStatus === TransactionStatus.REDIRECTING ) {
 		return <div>Redirecting</div>;
 	}
 	if (
-		transactionStatus === 'not-started' &&
-		previousTransactionStatus === 'error' &&
-		formStatus === 'ready'
+		transactionStatus === TransactionStatus.NOT_STARTED &&
+		previousTransactionStatus === TransactionStatus.ERROR &&
+		formStatus === FormStatus.READY
 	) {
 		return <div>Showing Error</div>;
 	}
-	if ( transactionStatus === 'error' && formStatus !== 'ready' ) {
+	if ( transactionStatus === TransactionStatus.ERROR && formStatus !== FormStatus.READY ) {
 		return <div>Error State but Form Status is '{ formStatus }'</div>;
 	}
-	if ( formStatus === 'submitting' ) {
+	if ( formStatus === FormStatus.SUBMITTING ) {
 		return <div>Submitting</div>;
 	}
-	if ( formStatus === 'complete' ) {
+	if ( formStatus === FormStatus.COMPLETE ) {
 		return <div>Form Complete</div>;
 	}
 	return (
@@ -83,21 +85,21 @@ const CustomFormWithTransactionStatus = () => {
 			previous { previousTransactionStatus }
 			<input type="text" />
 			<button
-				disabled={ formStatus !== 'ready' }
+				disabled={ formStatus !== FormStatus.READY }
 				onClick={ () => setTransactionError( 'bad things happened' ) }
 			>
 				Cause Error
 			</button>
-			<button disabled={ formStatus !== 'ready' } onClick={ () => setTransactionPending() }>
+			<button disabled={ formStatus !== FormStatus.READY } onClick={ () => setTransactionPending() }>
 				Submit
 			</button>
 			<button
-				disabled={ formStatus !== 'ready' }
+				disabled={ formStatus !== FormStatus.READY }
 				onClick={ () => setTransactionRedirecting( 'url.here' ) }
 			>
 				Redirect
 			</button>
-			<button disabled={ formStatus !== 'ready' } onClick={ () => setTransactionComplete() }>
+			<button disabled={ formStatus !== FormStatus.READY } onClick={ () => setTransactionComplete() }>
 				Complete
 			</button>
 		</div>

--- a/packages/composite-checkout/test/checkout-provider.js
+++ b/packages/composite-checkout/test/checkout-provider.js
@@ -90,7 +90,10 @@ const CustomFormWithTransactionStatus = () => {
 			>
 				Cause Error
 			</button>
-			<button disabled={ formStatus !== FormStatus.READY } onClick={ () => setTransactionPending() }>
+			<button
+				disabled={ formStatus !== FormStatus.READY }
+				onClick={ () => setTransactionPending() }
+			>
 				Submit
 			</button>
 			<button
@@ -99,7 +102,10 @@ const CustomFormWithTransactionStatus = () => {
 			>
 				Redirect
 			</button>
-			<button disabled={ formStatus !== FormStatus.READY } onClick={ () => setTransactionComplete() }>
+			<button
+				disabled={ formStatus !== FormStatus.READY }
+				onClick={ () => setTransactionComplete() }
+			>
 				Complete
 			</button>
 		</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Create an enum for statuses
* Uses a base interface with commonalities between payloads—the reducer maps these fields to state with nulls where values are empty
* Leverage this base interface for each payload type, using `Pick` and `Required` to focus the type—with unique a `type` property
* Create a payload union type for each payload type to allow type guarding
* For each dispatching function return, pass its type with the `useCallback` generic to type incoming arguments

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Other than the type themselves, there is a change in the transaction status handler which shouldn't affect logic.

The form status validator now runs against the enum and should be testable each status change.

It's worth running through some of the common testing scenarios, although for the most part the unit and e2e tests should serve to prevent regressions.

Fixes #44999 #45333 