### PR TITLE
Jetpack Cloud: Add Jetpack Credentials Feature Flag

### DIFF
--- a/client/landing/jetpack-cloud/sections/settings/controller.js
+++ b/client/landing/jetpack-cloud/sections/settings/controller.js
@@ -6,9 +6,15 @@ import React from 'react';
 /**
  * Internal dependencies
  */
+import { isEnabled } from 'config';
 import SettingsPage from './main';
+import SettingsFlow from './flow';
 
 export function settings( context, next ) {
-	context.primary = <SettingsPage />;
+	context.primary = isEnabled( 'jetpack/server-credentials-advanced-flow' ) ? (
+		<SettingsFlow />
+	) : (
+		<SettingsPage />
+	);
 	next();
 }

--- a/client/landing/jetpack-cloud/sections/settings/flow.tsx
+++ b/client/landing/jetpack-cloud/sections/settings/flow.tsx
@@ -1,0 +1,12 @@
+/**
+ * External dependencies
+ */
+import React, { FunctionComponent } from 'react';
+
+const SettingsFlow: FunctionComponent = () => (
+	<div>
+		<p>{ 'Jetpack Cloud Setting Flow is a WIP.' }</p>
+	</div>
+);
+
+export default SettingsFlow;

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -23,6 +23,7 @@
 		"jetpack/backups-restore": true,
 		"jetpack/on-demand-scan": true,
 		"jetpack/pricing-page": true,
+		"jetpack/server-credentials-advanced-flow": false,
 		"layout/app-banner": false,
 		"layout/guided-tours": false,
 		"layout/nps-survey-notice": false,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -20,6 +20,7 @@
 		"jetpack/backups-restore": true,
 		"jetpack/on-demand-scan": true,
 		"jetpack/pricing-page": true,
+		"jetpack/server-credentials-advanced-flow": false,
 		"layout/app-banner": false,
 		"layout/guided-tours": false,
 		"layout/nps-survey-notice": false,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -22,6 +22,7 @@
 		"jetpack/backups-restore": true,
 		"jetpack/on-demand-scan": true,
 		"jetpack/pricing-page": false,
+		"jetpack/server-credentials-advanced-flow": false,
 		"layout/app-banner": false,
 		"layout/guided-tours": false,
 		"layout/nps-survey-notice": false,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -21,6 +21,7 @@
 		"jetpack/backups-restore": true,
 		"jetpack/on-demand-scan": true,
 		"jetpack/pricing-page": true,
+		"jetpack/server-credentials-advanced-flow": false,
 		"layout/app-banner": false,
 		"layout/guided-tours": false,
 		"layout/nps-survey-notice": false,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

**Motivation**: Create safe place to develop new Jetpack Server Credentials Project without affecting production

* Add `jetpack/server-credentials-advanced-flow` feature flag
* Add placeholder server credentials flow page 

![Untitled 9](https://user-images.githubusercontent.com/2810519/91886273-f40eeb00-ec3d-11ea-9b23-d921a062e487.png)

#### Testing instructions

1. boot Jetpack Cloud w/out new flag
2. verify `/settings/:siteSlug` matches production
3. boot Jetpack Cloud w/ new flag ( `env ENABLE_FEATURES=jetpack/server-credentials-advanced-flow yarn run start-jetpack-cloud`
4. verify the placeholder page appears at `/settings/:siteSlug`
