### PR TITLE
Checkout: Use line items to determine pre-purchase notices

### DIFF
--- a/client/my-sites/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout-system-decider.js
@@ -46,7 +46,7 @@ export default function CheckoutSystemDecider( {
 	const reduxDispatch = useDispatch();
 	const translate = useTranslate();
 
-	const prepurchaseNotices = <PrePurchaseNotices cart={ cart } />;
+	const prepurchaseNotices = <PrePurchaseNotices />;
 
 	const checkoutVariant = getCheckoutVariant();
 

--- a/client/my-sites/checkout/checkout/prepurchase-notices/index.jsx
+++ b/client/my-sites/checkout/checkout/prepurchase-notices/index.jsx
@@ -3,13 +3,17 @@
  */
 import React from 'react';
 import { useSelector } from 'react-redux';
+import { useLineItems } from '@automattic/composite-checkout';
 
 /**
  * Internal dependencies
  */
-import { getAllCartItems } from 'lib/cart-values/cart-items';
-import { isJetpackPlan } from 'lib/products-values/is-jetpack-plan';
-import { isJetpackBackup } from 'lib/products-values/is-jetpack-backup';
+import {
+	getProductFromSlug,
+	isJetpackBackup,
+	isJetpackBackupSlug,
+	isJetpackPlanSlug,
+} from 'lib/products-values';
 import getSelectedSite from 'state/ui/selectors/get-selected-site';
 import { getSitePlan, getSiteProducts, isJetpackMinimumVersion } from 'state/sites/selectors';
 import {
@@ -27,9 +31,18 @@ import './style.scss';
  * Renders the most appropriate pre-purchase notice (if applicable)
  * from a range of possible options.
  */
-const PrePurchaseNotices = ( { cart } ) => {
+const PrePurchaseNotices = () => {
 	const selectedSite = useSelector( getSelectedSite );
 	const siteId = selectedSite?.ID;
+
+	// We used to directly reference the cart itself here,
+	// but for some reason, cart items take ~20 seconds
+	// to populate in some cases, whereas line items are
+	// immediately available on page load.
+	const [ lineItems ] = useLineItems();
+	const cartItemSlugs = lineItems
+		.map( ( item ) => item.wpcom_meta?.product_slug )
+		.filter( ( item ) => item );
 
 	const currentSitePlan = useSelector( ( state ) => {
 		if ( ! siteId ) {
@@ -47,22 +60,17 @@ const PrePurchaseNotices = ( { cart } ) => {
 		return products.filter( ( p ) => ! p.expired );
 	} );
 
-	const cartItems = getAllCartItems( cart );
-	const backupProductInCart = cartItems.find( isJetpackBackup );
+	const backupSlugInCart = cartItemSlugs.find( isJetpackBackupSlug );
 
 	const cartPlanOverlapsSiteBackupPurchase = useSelector( ( state ) => {
-		const jetpackPlanInCart = cartItems.find( isJetpackPlan );
+		const planSlugInCart = cartItemSlugs.find( isJetpackPlanSlug );
 
-		return (
-			jetpackPlanInCart &&
-			isPlanIncludingSiteBackup( state, siteId, jetpackPlanInCart.product_slug )
-		);
+		return planSlugInCart && isPlanIncludingSiteBackup( state, siteId, planSlugInCart );
 	} );
 
 	const sitePlanIncludesCartBackupProduct = useSelector(
 		( state ) =>
-			backupProductInCart &&
-			isBackupProductIncludedInSitePlan( state, siteId, backupProductInCart.product_slug )
+			backupSlugInCart && isBackupProductIncludedInSitePlan( state, siteId, backupSlugInCart )
 	);
 
 	const BACKUP_MINIMUM_JETPACK_VERSION = '8.5';
@@ -91,19 +99,26 @@ const PrePurchaseNotices = ( { cart } ) => {
 		);
 	}
 
+	// Notices after this point require a Backup product to be in the cart
+	if ( ! backupSlugInCart ) {
+		return null;
+	}
+
+	const backupProductInCart = getProductFromSlug( backupSlugInCart );
+
 	// We're attempting to buy Jetpack Backup individually,
 	// but this site already has a plan that includes it
 	if ( sitePlanIncludesCartBackupProduct && currentSitePlan ) {
 		return (
 			<SitePlanIncludesCartProductNotice
 				plan={ currentSitePlan }
-				productSlug={ backupProductInCart.product_slug }
+				product={ backupProductInCart }
 				selectedSite={ selectedSite }
 			/>
 		);
 	}
 
-	if ( backupProductInCart && ! siteHasBackupMinimumPluginVersion ) {
+	if ( ! siteHasBackupMinimumPluginVersion ) {
 		return (
 			<JetpackPluginRequiredVersionNotice
 				product={ backupProductInCart }

--- a/client/my-sites/checkout/checkout/prepurchase-notices/site-plan-includes-cart-product-notice.tsx
+++ b/client/my-sites/checkout/checkout/prepurchase-notices/site-plan-includes-cart-product-notice.tsx
@@ -9,12 +9,11 @@ import { useSelector } from 'react-redux';
 /**
  * Internal Dependencies
  */
-import { getProductBySlug } from 'state/products-list/selectors';
 import { getJetpackProductDisplayName } from 'lib/products-values/get-jetpack-product-display-name';
 import { getSitePurchases } from 'state/purchases/selectors';
 import PrePurchaseNotice from './prepurchase-notice';
 import type { Plan } from 'state/plans/types';
-import type { RawSiteProduct } from 'state/sites/selectors/get-site-products';
+import type { Product } from 'lib/products-values/products-list';
 
 type Site = {
 	ID: number;
@@ -23,18 +22,15 @@ type Site = {
 
 type Props = {
 	plan: Plan;
-	productSlug: string;
+	product: Product;
 	selectedSite: Site;
 };
 
 const SitePlanIncludesCartProductNotice: FunctionComponent< Props > = ( {
 	plan,
-	productSlug,
+	product,
 	selectedSite,
 } ) => {
-	const product = useSelector( ( state ) =>
-		getProductBySlug( state, productSlug )
-	) as RawSiteProduct;
 	const translate = useTranslate();
 	const purchases = useSelector( ( state ) => getSitePurchases( state, selectedSite?.ID ) );
 	const purchase = isArray( purchases )


### PR DESCRIPTION
For some reason yet unknown to me, the array of cart items (`cart.products`, specifically) doesn't populate on the checkout page for several seconds, which delays rendering for any relevant pre-purchase notices. In my tests, this delay measured around 15-20 seconds -- easily enough time to complete the checkout process without being made aware of any potential issues.

Fixes `1164141197617539-as-1185663038055927`.
Follows up on #44943, #44886.

#### Changes proposed in this Pull Request

* Switch to using checkout line items as the data source for pre-purchase notices instead of the cart.

#### Testing instructions

-----

**Very important:** Before every test scenario, make sure your cart is completely **empty**. This, as far as I can tell, is the key to evoking a render delay. I encourage you to try this in a different environment so you can see first-hand the problem this PR is meant to address. (See also: "Reference video," below.)

-----

Testing instructions are roughly the same as #44943, which I'm copying below for quick reference. Pay special attention to how long notices to take to be rendered on the page; the delay should be imperceptible.

* Test that notices still show up as expected when the cart includes a Backup product that is covered by a site's existing plan. (For more info, see #44873.)
* Test that notices still show up as expected when the cart includes a plan that overlaps with Backup products already purchased for a site. (For more info, see #44873.)
* Test that notices still show up as expected for sites that need to upgrade their plugin to support Backup. (For more info, see #44886.)

#### Reference video

![prepurchase-render-delay](https://user-images.githubusercontent.com/670067/91888905-9d5fdc00-ec52-11ea-988b-d5581d637ddf.gif)
