### PR TITLE
P2: refactor wp-for-teams to p2 in signup

### DIFF
--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -449,11 +449,6 @@ export function createAccount(
 		}
 	}
 
-	// See client/signup/config/flows-pure.js p2 flow for more info.
-	if ( flowName === 'p2' ) {
-		flowName = 'wp-for-teams';
-	}
-
 	const state = reduxStore.getState();
 
 	const siteVertical = getSiteVertical( state );

--- a/client/my-sites/invites/invite-accept-logged-out/index.jsx
+++ b/client/my-sites/invites/invite-accept-logged-out/index.jsx
@@ -71,7 +71,7 @@ class InviteAcceptLoggedOut extends React.Component {
 		const enhancedUserData = { ...userData };
 
 		if ( get( invite, 'site.is_wpforteams_site', false ) ) {
-			enhancedUserData.signup_flow_name = 'wp-for-teams';
+			enhancedUserData.signup_flow_name = 'p2';
 		}
 
 		this.props.createAccount( enhancedUserData, invite, createAccountCallback );

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -265,19 +265,13 @@ export function generateFlows( {
 	}
 
 	if ( isEnabled( 'signup/wpforteams' ) ) {
-		flows[ 'wp-for-teams' ] = {
+		flows.p2 = {
 			steps: [ 'p2-site', 'p2-details', 'user' ],
 			destination: ( dependencies ) => `https://${ dependencies.siteSlug }`,
 			description: 'P2 signup flow',
-			lastModified: '2020-08-11',
+			lastModified: '2020-09-01',
 			showRecaptcha: true,
 		};
-
-		// Original name for the project was "WP for Teams". Since then, we've renamed it to "P2".
-		// However, backend and Marketing is expecting `wp-for-teams` as the `signup_flow_name` var
-		// so we force it in client/lib/signup/step-actions/index.js `createAccount` function.
-		// Keeping both flows for clarity.
-		flows.p2 = { ...flows[ 'wp-for-teams' ] };
 	}
 
 	flows.domain = {

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -115,7 +115,7 @@ function removeLoadingScreenClassNamesFromBody() {
 }
 
 function isWPForTeamsFlow( flowName ) {
-	return flowName === 'wp-for-teams' || flowName === 'p2';
+	return flowName === 'p2';
 }
 
 class Signup extends React.Component {


### PR DESCRIPTION
In this PR, we refactor all the occurrences of `signup_flow_name` from `wp-for-teams` to `p2`. It's required for tracking purposes and we need to match the value (`p2`) with the `flow` event property for the `calypso-*` signup events.

## Testing

See D48775-code for testing instructions as that patch is required for this to work.