### PR TITLE
Show the cart in the domain search screen header

### DIFF
--- a/client/my-sites/checkout/cart/header-cart.jsx
+++ b/client/my-sites/checkout/cart/header-cart.jsx
@@ -23,8 +23,10 @@ class HeaderCart extends React.Component {
 	};
 
 	togglePopoverCart = () => {
-		this.setState( {
-			isPopoverCartVisible: ! this.state.isPopoverCartVisible,
+		this.setState( ( state ) => {
+			return {
+				isPopoverCartVisible: ! state.isPopoverCartVisible,
+			};
 		} );
 	};
 

--- a/client/my-sites/checkout/cart/header-cart.jsx
+++ b/client/my-sites/checkout/cart/header-cart.jsx
@@ -1,0 +1,51 @@
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import React from 'react';
+import { noop, isEmpty } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getAllCartItems } from 'lib/cart-values/cart-items';
+import PopoverCart from './popover-cart';
+
+class HeaderCart extends React.Component {
+	static propTypes = {
+		cart: PropTypes.object,
+		selectedSite: PropTypes.object.isRequired,
+		currentRoute: PropTypes.string,
+	};
+
+	state = {
+		isPopoverCartVisible: false,
+	};
+
+	togglePopoverCart = () => {
+		this.setState( {
+			isPopoverCartVisible: ! this.state.isPopoverCartVisible,
+		} );
+	};
+
+	render() {
+		if ( isEmpty( getAllCartItems( this.props.cart ) ) ) {
+			return null;
+		}
+
+		return (
+			<PopoverCart
+				cart={ this.props.cart }
+				selectedSite={ this.props.selectedSite }
+				visible={ this.state.isPopoverCartVisible }
+				pinned={ false }
+				path={ this.props.currentRoute }
+				onToggle={ this.togglePopoverCart }
+				closeSectionNavMobilePanel={ noop }
+				compact
+			/>
+		);
+	}
+}
+
+export default HeaderCart;

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -49,15 +49,15 @@ import { getDomainManagementPath } from './utils';
 import DomainItem from './domain-item';
 import ListHeader from './list-header';
 import QuerySitePurchases from 'components/data/query-site-purchases';
-import PopoverCart from 'my-sites/checkout/cart/popover-cart';
 import InfoPopover from 'components/info-popover';
 import ExternalLink from 'components/external-link';
-import { getAllCartItems } from 'lib/cart-values/cart-items';
+import HeaderCart from 'my-sites/checkout/cart/header-cart';
 
 /**
  * Style dependencies
  */
 import './style.scss';
+import 'my-sites/domains/style.scss';
 
 export class List extends React.Component {
 	static propTypes = {
@@ -81,7 +81,6 @@ export class List extends React.Component {
 		settingPrimaryDomain: false,
 		changePrimaryDomainModeEnabled: false,
 		primaryDomainIndex: -1,
-		isPopoverCartVisible: false,
 	};
 
 	isLoading() {
@@ -172,43 +171,22 @@ export class List extends React.Component {
 		);
 	}
 
-	togglePopoverCart = () => {
-		this.setState( {
-			isPopoverCartVisible: ! this.state.isPopoverCartVisible,
-		} );
-	};
-
-	renderCart() {
-		if ( isEmpty( getAllCartItems( this.props.cart ) ) ) {
-			return null;
-		}
-
-		return (
-			<PopoverCart
-				cart={ this.props.cart }
-				selectedSite={ this.props.selectedSite }
-				visible={ this.state.isPopoverCartVisible }
-				pinned={ false }
-				path={ this.props.currentRoute }
-				onToggle={ this.togglePopoverCart }
-				closeSectionNavMobilePanel={ noop }
-				compact
-			/>
-		);
-	}
-
 	renderNewDesign() {
 		return (
 			<>
-				<div className="list__domains-header">
+				<div className="domains__header">
 					<FormattedHeader
 						brandFont
 						className="domain-management__page-heading"
 						headerText={ this.props.translate( 'Site Domains' ) }
 						align="left"
 					/>
-					<div className="list__domains-header-buttons">
-						{ this.renderCart() }
+					<div className="domains__header-buttons">
+						<HeaderCart
+							cart={ this.props.cart }
+							selectedSite={ this.props.selectedSite }
+							currentRoute={ this.props.currentRoute }
+						/>
 						{ this.addDomainButton() }
 					</div>
 				</div>

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -320,35 +320,6 @@ input[type='radio'].domain-management-list-item__radio {
 	@include placeholder( --color-neutral-5 );
 }
 
-.list__domains-header {
-	display: flex;
-	justify-content: space-between;
-	align-items: flex-start;
-
-	@include breakpoint-deprecated( '<660px' ) {
-		align-items: center;
-	}
-}
-
-.list__domains-header-buttons {
-	display: flex;
-
-	.popover-cart {
-		margin-right: 8px;
-	}
-
-	.popover-cart .header-button, .popover-cart .header-button:hover {
-		min-height: initial;
-		background: none;
-		color: var( --color-text );
-	}
-
-	.cart__count-badge .count {
-		top: -7px;
-		right: -3px;
-	}
-}
-
 .domain-item__enable-selection {
 	> .list__domain-transfer-lock, > .list__domain-privacy, > .list__domain-auto-renew, > .list__domain-email, > .list__domain-options {
 		visibility: hidden;

--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -39,11 +39,13 @@ import { recordAddDomainButtonClick, recordRemoveDomainButtonClick } from 'state
 import EmailVerificationGate from 'components/email-verification/email-verification-gate';
 import { getSuggestionsVendor } from 'lib/domains/suggestions';
 import NewDomainsRedirectionNoticeUpsell from 'my-sites/domains/domain-management/components/domain/new-domains-redirection-notice-upsell';
+import HeaderCart from 'my-sites/checkout/cart/header-cart';
 
 /**
  * Style dependencies
  */
 import './style.scss';
+import 'my-sites/domains/style.scss';
 
 class DomainSearch extends Component {
 	static propTypes = {
@@ -188,13 +190,25 @@ class DomainSearch extends Component {
 			content = (
 				<span>
 					<div className="domain-search__content">
-						<FormattedHeader
-							brandFont
-							headerText={
-								isManagingAllDomains ? translate( 'All Domains' ) : translate( 'Site Domains' )
-							}
-							align="left"
-						/>
+						{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
+						<div className="domains__header">
+							<FormattedHeader
+								brandFont
+								headerText={
+									isManagingAllDomains ? translate( 'All Domains' ) : translate( 'Site Domains' )
+								}
+								align="left"
+							/>
+							{ ! isManagingAllDomains /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ && (
+								<div className="domains__header-buttons">
+									<HeaderCart
+										cart={ this.props.cart }
+										selectedSite={ this.props.selectedSite }
+										currentRoute={ this.props.currentRoute }
+									/>
+								</div>
+							) }
+						</div>
 
 						<EmailVerificationGate
 							noticeText={ translate( 'You must verify your email to register new domains.' ) }

--- a/client/my-sites/domains/style.scss
+++ b/client/my-sites/domains/style.scss
@@ -11,6 +11,11 @@
 .domains__header-buttons {
 	display: flex;
 
+	> div {
+		margin-top: auto;
+		margin-bottom: auto;
+	}
+
 	.popover-cart {
 		margin-right: 8px;
 	}

--- a/client/my-sites/domains/style.scss
+++ b/client/my-sites/domains/style.scss
@@ -1,0 +1,28 @@
+.domains__header {
+	display: flex;
+	justify-content: space-between;
+	align-items: flex-start;
+
+	@include breakpoint-deprecated( '<660px' ) {
+		align-items: center;
+	}
+}
+
+.domains__header-buttons {
+	display: flex;
+
+	.popover-cart {
+		margin-right: 8px;
+	}
+
+	.popover-cart .header-button, .popover-cart .header-button:hover {
+		min-height: initial;
+		background: none;
+		color: var( --color-text );
+	}
+
+	.cart__count-badge .count {
+		top: -7px;
+		right: -3px;
+	}
+}


### PR DESCRIPTION
Recently in #45265 we removed the horizontal navigation in the domain search screen. However that also removed the popover cart as it was inside the horizontal navigation. So here's a PR that will show the cart in the new header.

#### Changes proposed in this Pull Request

*  Move the header cart component that we show in the domain management screen in a separate component so we can reuse it in the domain search screen too.

It looks like this (the cart is rendered only when there are products inside it):

<img width="1086" alt="Screenshot 2020-09-01 at 21 43 58" src="https://user-images.githubusercontent.com/1355045/91893959-98744a00-ec9d-11ea-9f4c-decad6f4827d.png">

#### Testing instructions

* Add a domain then go back to the site domains list - make sure the cart icon is shown
* Click on "Add a domain to this site" button
* Make sure the cart is rendered in the domain search screen too
