### PR TITLE
Add Step Progress Component

### DIFF
--- a/client/components/step-progress/README.md
+++ b/client/components/step-progress/README.md
@@ -1,3 +1,5 @@
 # Step Progress
 
-`<StepProgress />` is a React component for rendering a series of steps that need to be completed and the user's progress through those steps
+`<StepProgress />` is a React component for rendering a series of steps that need to be completed and the user's progress through those steps.
+
+This component is distinguished from `Wizard` and `WizardProgressBar` in that in renders each discrete step with a name.

--- a/client/components/step-progress/README.md
+++ b/client/components/step-progress/README.md
@@ -1,0 +1,3 @@
+# Step Progress
+
+`<StepProgress />` is a React component for rendering a series of steps that need to be completed and the user's progress through those steps

--- a/client/components/step-progress/README.md
+++ b/client/components/step-progress/README.md
@@ -3,3 +3,21 @@
 `<StepProgress />` is a React component for rendering a series of steps that need to be completed and the user's progress through those steps.
 
 This component is distinguished from `Wizard` and `WizardProgressBar` in that in renders each discrete step with a name.
+
+## Properties
+
+### `steps { string[] }`
+
+A list of the display name of the steps to progress through
+
+### `currentStep { number }`
+
+The zero-based index of the current step
+
+## Usage
+
+```jsx
+const steps = [ 'First Step', 'Second Phase', 'Verification' ];
+
+<StepProgress steps={ steps } currentStep={ 0 } />;
+```

--- a/client/components/step-progress/docs/example.tsx
+++ b/client/components/step-progress/docs/example.tsx
@@ -40,4 +40,6 @@ const StepProgressExample: FunctionComponent = () => {
 	);
 };
 
+StepProgressExample.displayName = 'StepProgressExample';
+
 export default StepProgressExample;

--- a/client/components/step-progress/docs/example.tsx
+++ b/client/components/step-progress/docs/example.tsx
@@ -1,0 +1,15 @@
+/**
+ * External dependencies
+ */
+import React, { FunctionComponent } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import StepProgress from 'components/step-progress';
+
+const StepProgressExample: FunctionComponent = () => (
+	<StepProgress steps={ [ 'first', 'second', 'third' ] } />
+);
+
+export default StepProgressExample;

--- a/client/components/step-progress/docs/example.tsx
+++ b/client/components/step-progress/docs/example.tsx
@@ -9,7 +9,10 @@ import React, { FunctionComponent } from 'react';
 import StepProgress from 'components/step-progress';
 
 const StepProgressExample: FunctionComponent = () => (
-	<StepProgress steps={ [ 'first', 'second', 'third' ] } />
+	<StepProgress
+		steps={ [ 'You got this!?', 'Host locator', 'Credentials', 'Verification' ] }
+		currentStep={ 1 }
+	/>
 );
 
 export default StepProgressExample;

--- a/client/components/step-progress/docs/example.tsx
+++ b/client/components/step-progress/docs/example.tsx
@@ -1,18 +1,43 @@
 /**
  * External dependencies
  */
-import React, { FunctionComponent } from 'react';
+import React, { FunctionComponent, useState } from 'react';
 
 /**
  * Internal dependencies
  */
+import { Button } from '@automattic/components';
 import StepProgress from 'components/step-progress';
 
-const StepProgressExample: FunctionComponent = () => (
-	<StepProgress
-		steps={ [ 'You got this!?', 'Host locator', 'Credentials', 'Verification' ] }
-		currentStep={ 1 }
-	/>
-);
+const steps = [ 'You got this!?', 'Host locator', 'Credentials', 'Verification' ];
+
+const StepProgressExample: FunctionComponent = () => {
+	const [ currentStep, setCurrentStep ] = useState( 0 );
+
+	return (
+		<div>
+			<div style={ { background: 'var( --color-surface )', padding: '30px' } }>
+				<StepProgress steps={ steps } currentStep={ currentStep } />
+			</div>
+
+			<div style={ { 'margin-top': '30px' } }>
+				<Button
+					disabled={ currentStep <= 0 }
+					onClick={ () => setCurrentStep( currentStep - 1 ) }
+					style={ { 'margin-right': '10px' } }
+				>
+					{ 'Previous Step' }
+				</Button>
+				<Button
+					primary
+					disabled={ currentStep >= steps.length - 1 }
+					onClick={ () => setCurrentStep( currentStep + 1 ) }
+				>
+					{ 'Next Step' }
+				</Button>
+			</div>
+		</div>
+	);
+};
 
 export default StepProgressExample;

--- a/client/components/step-progress/index.tsx
+++ b/client/components/step-progress/index.tsx
@@ -23,6 +23,15 @@ const StepProgress: FunctionComponent< Props > = ( { steps, currentStep } ) => {
 			: 'step-progress__element-number';
 	};
 
+	const getStepNameClass = ( stepNumber: number ): boolean => {
+		if ( currentStep === stepNumber ) {
+			return 'step-progress__element-step-name-current';
+		}
+		return stepNumber < currentStep
+			? 'step-progress__element-step-name-complete'
+			: 'step-progress__element-step-name';
+	};
+
 	return (
 		<div className="step-progress">
 			{ steps.map( ( stepName, index ) => (
@@ -30,7 +39,7 @@ const StepProgress: FunctionComponent< Props > = ( { steps, currentStep } ) => {
 					<div className="step-progress__element-visual">
 						<div className={ getElementNumberClass( index ) }>{ index + 1 }</div>
 					</div>
-					<div className="step-progress__element-step-name">{ stepName }</div>
+					<div className={ getStepNameClass( index ) }>{ stepName }</div>
 				</div>
 			) ) }
 		</div>

--- a/client/components/step-progress/index.tsx
+++ b/client/components/step-progress/index.tsx
@@ -3,19 +3,38 @@
  */
 import React, { FunctionComponent } from 'react';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 interface Props {
 	steps: string[];
 	currentStep: number;
 }
 
-const StepProgress: FunctionComponent< Props > = ( { steps } ) => (
-	<div className="step-progress">
-		<ol>
-			{ steps.map( ( stepName ) => (
-				<li>{ stepName }</li>
+const StepProgress: FunctionComponent< Props > = ( { steps, currentStep } ) => {
+	const getElementNumberClass = ( stepNumber: number ): boolean => {
+		if ( currentStep === stepNumber ) {
+			return 'step-progress__element-number-current';
+		}
+		return stepNumber < currentStep
+			? 'step-progress__element-number-complete'
+			: 'step-progress__element-number';
+	};
+
+	return (
+		<div className="step-progress">
+			{ steps.map( ( stepName, index ) => (
+				<div className="step-progress__element">
+					<div className="step-progress__element-visual">
+						<div className={ getElementNumberClass( index ) }>{ index + 1 }</div>
+					</div>
+					<div className="step-progress__element-step-name">{ stepName }</div>
+				</div>
 			) ) }
-		</ol>
-	</div>
-);
+		</div>
+	);
+};
 
 export default StepProgress;

--- a/client/components/step-progress/index.tsx
+++ b/client/components/step-progress/index.tsx
@@ -3,6 +3,19 @@
  */
 import React, { FunctionComponent } from 'react';
 
-const StepProgress: FunctionComponent = () => <div className="step-progress" />;
+interface Props {
+	steps: string[];
+	currentStep: number;
+}
+
+const StepProgress: FunctionComponent< Props > = ( { steps } ) => (
+	<div className="step-progress">
+		<ol>
+			{ steps.map( ( stepName ) => (
+				<li>{ stepName }</li>
+			) ) }
+		</ol>
+	</div>
+);
 
 export default StepProgress;

--- a/client/components/step-progress/index.tsx
+++ b/client/components/step-progress/index.tsx
@@ -14,7 +14,7 @@ interface Props {
 }
 
 const StepProgress: FunctionComponent< Props > = ( { steps, currentStep } ) => {
-	const getElementNumberClass = ( stepNumber: number ): boolean => {
+	const getElementNumberClass = ( stepNumber: number ) => {
 		if ( currentStep === stepNumber ) {
 			return 'step-progress__element-number-current';
 		}
@@ -23,7 +23,7 @@ const StepProgress: FunctionComponent< Props > = ( { steps, currentStep } ) => {
 			: 'step-progress__element-number';
 	};
 
-	const getStepNameClass = ( stepNumber: number ): boolean => {
+	const getStepNameClass = ( stepNumber: number ) => {
 		if ( currentStep === stepNumber ) {
 			return 'step-progress__element-step-name-current';
 		}

--- a/client/components/step-progress/index.tsx
+++ b/client/components/step-progress/index.tsx
@@ -1,0 +1,8 @@
+/**
+ * External dependencies
+ */
+import React, { FunctionComponent } from 'react';
+
+const StepProgress: FunctionComponent = () => <div className="step-progress" />;
+
+export default StepProgress;

--- a/client/components/step-progress/index.tsx
+++ b/client/components/step-progress/index.tsx
@@ -26,7 +26,7 @@ const StepProgress: FunctionComponent< Props > = ( { steps, currentStep } ) => {
 	return (
 		<div className="step-progress">
 			{ steps.map( ( stepName, index ) => (
-				<div className="step-progress__element">
+				<div className="step-progress__element" key={ `step-${ index }` }>
 					<div className="step-progress__element-visual">
 						<div className={ getElementNumberClass( index ) }>{ index + 1 }</div>
 					</div>

--- a/client/components/step-progress/style.scss
+++ b/client/components/step-progress/style.scss
@@ -2,10 +2,22 @@
 	display: flex;
 	flex-direction: row;
 	justify-content: space-between;
+	position: relative;
 
 	.step-progress__element {
 		display: flex;
 		flex-direction: column;
+	}
+
+	&::before {
+		background: var( --color-neutral-5 );
+		content: '';
+		height: 1px;
+		left: 5%;
+		position: absolute;
+		top: 12px;
+		width: 90%;
+		z-index: 0;
 	}
 }
 
@@ -14,16 +26,34 @@
 	display: flex;
 	justify-content: center;
 }
+
+.step-progress__element-visual {
+	position: relative;
+	// draw over the background line
+	&::before {
+		background: var( --color-surface );
+		content: '';
+		height: 1px;
+		left: 20%;
+		position: absolute;
+		top: 12px;
+		width: 60%;
+		z-index: 1;
+	}
+}
+
 .step-progress__element-number-current,
 .step-progress__element-number-complete,
 .step-progress__element-number {
+	z-index: 2;
 	border-radius: 50%;
 	background-color: var( --color-neutral-10 );
-	height: 24px;
-	width: 24px;
+	height: 25px;
+	width: 25px;
 	color: var( --color-text-inverted );
 	display: flex;
 	justify-content: center;
+	text-align: center;
 }
 
 .step-progress__element-number-current,

--- a/client/components/step-progress/style.scss
+++ b/client/components/step-progress/style.scss
@@ -4,11 +4,6 @@
 	justify-content: space-between;
 	position: relative;
 
-	.step-progress__element {
-		display: flex;
-		flex-direction: column;
-	}
-
 	&::before {
 		background: var( --color-neutral-5 );
 		content: '';
@@ -19,6 +14,11 @@
 		width: 90%;
 		z-index: 0;
 	}
+}
+
+.step-progress__element {
+	display: flex;
+	flex-direction: column;
 }
 
 .step-progress__element-visual,
@@ -40,6 +40,21 @@
 		width: 60%;
 		z-index: 1;
 	}
+}
+
+.step-progress__element-step-name-current,
+.step-progress__element-step-name-complete,
+.step-progress__element-step-name {
+	margin-top: 9px;
+	font-style: normal;
+	font-weight: normal;
+	font-size: 1;
+	line-height: 24px;
+}
+
+.step-progress__element-step-name-complete,
+.step-progress__element-step-name {
+	color: var( --color-text-subtle );
 }
 
 .step-progress__element-number-current,

--- a/client/components/step-progress/style.scss
+++ b/client/components/step-progress/style.scss
@@ -1,0 +1,32 @@
+.step-progress {
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
+
+	.step-progress__element {
+		display: flex;
+		flex-direction: column;
+	}
+}
+
+.step-progress__element-visual,
+.step-progress__element-step-name {
+	display: flex;
+	justify-content: center;
+}
+.step-progress__element-number-current,
+.step-progress__element-number-complete,
+.step-progress__element-number {
+	border-radius: 50%;
+	background-color: var( --color-neutral-10 );
+	height: 24px;
+	width: 24px;
+	color: var( --color-text-inverted );
+	display: flex;
+	justify-content: center;
+}
+
+.step-progress__element-number-current,
+.step-progress__element-number-complete {
+	background-color: var( --color-primary );
+}

--- a/client/devdocs/design/component-examples.js
+++ b/client/devdocs/design/component-examples.js
@@ -77,6 +77,7 @@ export { default as Spinner } from 'components/spinner/docs/example';
 export { default as SpinnerButton } from 'components/spinner-button/docs/example';
 export { default as SpinnerLine } from 'components/spinner-line/docs/example';
 export { default as SplitButton } from 'components/split-button/docs/example';
+export { default as StepProgress } from 'components/step-progress/docs/example';
 export { default as Suggestions } from '@automattic/components/src/suggestions/docs/example';
 export { default as TextareaAutosize } from 'components/textarea-autosize/docs/example';
 export { default as TextDiff } from 'components/text-diff/docs/example';

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -112,6 +112,7 @@ import Spinner from 'components/spinner/docs/example';
 import SpinnerButton from 'components/spinner-button/docs/example';
 import SpinnerLine from 'components/spinner-line/docs/example';
 import SplitButton from 'components/split-button/docs/example';
+import StepProgress from 'components/step-progress/docs/example';
 import Suggestions from '@automattic/components/src/suggestions/docs/example';
 import SuggestionSearchExample from 'components/suggestion-search/docs/example';
 import SupportInfoExample from 'components/support-info/docs/example';
@@ -272,6 +273,7 @@ export default class DesignAssets extends React.Component {
 					<SpinnerButton searchKeywords="loading input submit" readmeFilePath="spinner-button" />
 					<SpinnerLine searchKeywords="loading" readmeFilePath="spinner-line" />
 					<SplitButton readmeFilePath="split-button" />
+					<StepProgress readmeFilePath="step-progress" />
 					<Suggestions readmeFilePath="/packages/components/src/suggestions" />
 					<SuggestionSearchExample />
 					<SupportInfoExample />


### PR DESCRIPTION


#### Changes proposed in this Pull Request

**Motivation:** Add a component as part of the Jetpack Server Credentials Project

* Add StepProgress component
* Add StepProgressExample Component

<img width="936" alt="Screen Shot 2020-09-01 at 3 27 54 PM" src="https://user-images.githubusercontent.com/2810519/91912911-2d108500-ec69-11ea-93d5-1eeeb2813108.png">

#### Testing instructions

1. Navigate to `/devdocs/design/step-progress` on branch
2. Confirm the steps are swapped to primary color as they are reached
