### PR TITLE
Components: Use Button component in app-promo

### DIFF
--- a/client/blocks/app-promo/index.jsx
+++ b/client/blocks/app-promo/index.jsx
@@ -14,7 +14,7 @@ import Gridicon from 'components/gridicon';
  */
 import { localize } from 'i18n-calypso';
 import { recordTracksEvent } from 'state/analytics/actions';
-import { Dialog } from '@automattic/components';
+import { Button, Dialog } from '@automattic/components';
 import { fetchUserSettings } from 'state/user-settings/actions';
 import getUserSettings from 'state/selectors/get-user-settings';
 import { sendEmailLogin } from 'state/auth/actions';
@@ -129,15 +129,17 @@ export class AppPromo extends React.Component {
 
 		return (
 			<div className="app-promo">
-				<button
+				<Button
+					borderless
 					tabIndex="0"
 					className="app-promo__dismiss"
 					onClick={ this.dismiss }
 					aria-label={ translate( 'Dismiss' ) }
 				>
 					<Gridicon icon="cross" size={ 24 } />
-				</button>
-				<a
+				</Button>
+				<Button
+					borderless
 					onClick={ this.recordClickEvent }
 					className="app-promo__link"
 					title="Try the desktop app!"
@@ -153,7 +155,7 @@ export class AppPromo extends React.Component {
 						alt="WordPress Desktop Icon"
 					/>
 					{ promoItem.message }
-				</a>
+				</Button>
 			</div>
 		);
 	};
@@ -164,15 +166,17 @@ export class AppPromo extends React.Component {
 
 		return (
 			<div className="app-promo">
-				<button
+				<Button
+					borderless
 					tabIndex="0"
 					className="app-promo__dismiss"
 					onClick={ this.dismiss }
 					aria-label={ translate( 'Dismiss' ) }
 				>
 					<Gridicon icon="cross" size={ 24 } />
-				</button>
-				<button
+				</Button>
+				<Button
+					borderless
 					onClick={ this.sendMagicLink }
 					className="app-promo__link"
 					title="Try the mobile app!"
@@ -185,7 +189,7 @@ export class AppPromo extends React.Component {
 						alt="WordPress App Icon"
 					/>
 					{ 'WordPress.com in the palm of your hands — download the mobile app.' }
-				</button>
+				</Button>
 				<Dialog
 					className="app-promo__dialog"
 					isVisible={ this.state.showDialog }

--- a/client/blocks/app-promo/index.jsx
+++ b/client/blocks/app-promo/index.jsx
@@ -36,26 +36,26 @@ import './style.scss';
 
 const getRandomPromo = () => {
 	const promoOptions = [
-		{
-			promoCode: 'a0001',
-			message: 'WordPress.com your way — desktop app now available for Mac, Windows, and Linux.',
-			type: 'desktop',
-		},
-		{
-			promoCode: 'a0002',
-			message: 'Get the WordPress.com app for your desktop.',
-			type: 'desktop',
-		},
-		{
-			promoCode: 'a0003',
-			message: 'WordPress.com app now available for desktop.',
-			type: 'desktop',
-		},
-		{
-			promoCode: 'a0005',
-			message: 'Fast, distraction-free WordPress.com — download the desktop app.',
-			type: 'desktop',
-		},
+		// {
+		// 	promoCode: 'a0001',
+		// 	message: 'WordPress.com your way — desktop app now available for Mac, Windows, and Linux.',
+		// 	type: 'desktop',
+		// },
+		// {
+		// 	promoCode: 'a0002',
+		// 	message: 'Get the WordPress.com app for your desktop.',
+		// 	type: 'desktop',
+		// },
+		// {
+		// 	promoCode: 'a0003',
+		// 	message: 'WordPress.com app now available for desktop.',
+		// 	type: 'desktop',
+		// },
+		// {
+		// 	promoCode: 'a0005',
+		// 	message: 'Fast, distraction-free WordPress.com — download the desktop app.',
+		// 	type: 'desktop',
+		// },
 		{
 			promoCode: 'a0006',
 			message: 'WordPress.com in the palm of your hands — download the mobile app.',

--- a/client/blocks/app-promo/index.jsx
+++ b/client/blocks/app-promo/index.jsx
@@ -10,11 +10,16 @@ import store from 'store';
 import Gridicon from 'components/gridicon';
 
 /**
+ * WordPress dependencies
+ */
+import { Button } from '@wordpress/components';
+
+/**
  * Internal dependencies
  */
 import { localize } from 'i18n-calypso';
 import { recordTracksEvent } from 'state/analytics/actions';
-import { Button, Dialog } from '@automattic/components';
+import { Dialog } from '@automattic/components';
 import { fetchUserSettings } from 'state/user-settings/actions';
 import getUserSettings from 'state/selectors/get-user-settings';
 import { sendEmailLogin } from 'state/auth/actions';
@@ -130,7 +135,6 @@ export class AppPromo extends React.Component {
 		return (
 			<div className="app-promo">
 				<Button
-					borderless
 					tabIndex="0"
 					className="app-promo__dismiss"
 					onClick={ this.dismiss }
@@ -139,7 +143,6 @@ export class AppPromo extends React.Component {
 					<Gridicon icon="cross" size={ 24 } />
 				</Button>
 				<Button
-					borderless
 					onClick={ this.recordClickEvent }
 					className="app-promo__link"
 					title="Try the desktop app!"
@@ -167,7 +170,6 @@ export class AppPromo extends React.Component {
 		return (
 			<div className="app-promo">
 				<Button
-					borderless
 					tabIndex="0"
 					className="app-promo__dismiss"
 					onClick={ this.dismiss }
@@ -176,7 +178,6 @@ export class AppPromo extends React.Component {
 					<Gridicon icon="cross" size={ 24 } />
 				</Button>
 				<Button
-					borderless
 					onClick={ this.sendMagicLink }
 					className="app-promo__link"
 					title="Try the mobile app!"

--- a/client/blocks/app-promo/index.jsx
+++ b/client/blocks/app-promo/index.jsx
@@ -36,26 +36,26 @@ import './style.scss';
 
 const getRandomPromo = () => {
 	const promoOptions = [
-		// {
-		// 	promoCode: 'a0001',
-		// 	message: 'WordPress.com your way — desktop app now available for Mac, Windows, and Linux.',
-		// 	type: 'desktop',
-		// },
-		// {
-		// 	promoCode: 'a0002',
-		// 	message: 'Get the WordPress.com app for your desktop.',
-		// 	type: 'desktop',
-		// },
-		// {
-		// 	promoCode: 'a0003',
-		// 	message: 'WordPress.com app now available for desktop.',
-		// 	type: 'desktop',
-		// },
-		// {
-		// 	promoCode: 'a0005',
-		// 	message: 'Fast, distraction-free WordPress.com — download the desktop app.',
-		// 	type: 'desktop',
-		// },
+		{
+			promoCode: 'a0001',
+			message: 'WordPress.com your way — desktop app now available for Mac, Windows, and Linux.',
+			type: 'desktop',
+		},
+		{
+			promoCode: 'a0002',
+			message: 'Get the WordPress.com app for your desktop.',
+			type: 'desktop',
+		},
+		{
+			promoCode: 'a0003',
+			message: 'WordPress.com app now available for desktop.',
+			type: 'desktop',
+		},
+		{
+			promoCode: 'a0005',
+			message: 'Fast, distraction-free WordPress.com — download the desktop app.',
+			type: 'desktop',
+		},
 		{
 			promoCode: 'a0006',
 			message: 'WordPress.com in the palm of your hands — download the mobile app.',

--- a/client/blocks/app-promo/style.scss
+++ b/client/blocks/app-promo/style.scss
@@ -19,7 +19,7 @@
 .app-promo .app-promo__dismiss {
 	position: absolute;
 	right: 17px;
-	top: 3px;
+	top: 6px;
 	cursor: pointer;
 	padding: 5px 0;
 

--- a/client/blocks/app-promo/style.scss
+++ b/client/blocks/app-promo/style.scss
@@ -19,8 +19,9 @@
 .app-promo .app-promo__dismiss {
 	position: absolute;
 	right: 17px;
-	top: 12px;
+	top: 3px;
 	cursor: pointer;
+	padding: 5px 0;
 
 	svg {
 		fill: var( --color-neutral-10 );
@@ -31,13 +32,17 @@
 	display: block;
 	margin: 0 10px;
 	padding: 8px 34px 8px 50px;
+	border-radius: 0;
+	line-height: 1.5;
 	background-color: var( --color-surface );
 	color: var( --color-primary );
 	font-size: $font-body-extra-small;
 	box-shadow: 0 0 0 1px rgba( var( --color-neutral-10-rgb ), 0.5 ),
 		0 1px 2px var( --color-neutral-0 );
+	font-weight: 400;
 
 	&:hover {
+		color: var( --color-primary );
 		text-decoration: underline;
 		cursor: pointer;
 	}

--- a/client/blocks/app-promo/test/index.jsx
+++ b/client/blocks/app-promo/test/index.jsx
@@ -6,7 +6,7 @@
  * External dependencies
  */
 import { expect } from 'chai';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import React from 'react';
 
 describe( 'AppPromo', () => {
@@ -42,7 +42,7 @@ describe( 'AppPromo', () => {
 		} );
 
 		test( 'should render the promo text', () => {
-			const wrapper = shallow( AppPromoComponent );
+			const wrapper = mount( AppPromoComponent );
 
 			expect( wrapper.text() ).to.contain( appPromoDetails.message );
 		} );

--- a/client/reader/sidebar/promo.jsx
+++ b/client/reader/sidebar/promo.jsx
@@ -10,7 +10,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import AppPromo from 'blocks/app-promo';
+import AsyncLoad from 'components/async-load';
 import { getCurrentUserLocale } from 'state/current-user/selectors';
 import QueryUserSettings from 'components/data/query-user-settings';
 import config from 'config';
@@ -23,7 +23,12 @@ export const ReaderSidebarPromo = ( { currentUserLocale, shouldRenderAppPromo } 
 
 			{ shouldRenderAppPromo && (
 				<div className="sidebar__app-promo">
-					<AppPromo location="reader" locale={ currentUserLocale } />
+					<AsyncLoad
+						require="blocks/app-promo"
+						placeholder={ null }
+						location="reader"
+						locale={ currentUserLocale }
+					/>
 				</div>
 			) }
 		</Fragment>
@@ -44,7 +49,7 @@ export const shouldRenderAppPromo = ( options = {} ) => {
 		isUserLocaleEnglish = 'en' === options.currentUserLocale,
 		isDesktopPromoConfiguredToRun = config.isEnabled( 'desktop-promo' ),
 		isUserDesktopAppUser = haveUserSettingsLoaded || options.isDesktopAppUser,
-		isUserOnChromeOs = /\bCrOS\b/.test( navigator.userAgent ),
+		isUserOnChromeOs = /\bCrOS\b/.test( window.navigator.userAgent ),
 	} = options;
 
 	return (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Replace usage of `button` and anchor tags with `Button` component in `app-promo`

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Add an early return to `client/reader/sidebar/promo.jsx`'s `shouldRenderAppPromo` to return `true` (it's too difficult to coordinate a legitimate usage). Then open the reader sidebar and you'll see the app promo at the bottom. Make sure to force a mobile and desktop one to happen.

## Before:

<img width="1456" alt="Captura de Tela 2020-09-01 às 12 50 38" src="https://user-images.githubusercontent.com/24264157/91900199-2d9e2100-ec53-11ea-8f0f-b15cd1199a94.png">

## After:

<img width="1456" alt="Captura de Tela 2020-09-01 às 12 54 30" src="https://user-images.githubusercontent.com/24264157/91900205-30991180-ec53-11ea-8413-9a79d2a8f99c.png">


Related to #45259 
