### PR TITLE
Components: Remove global button styles from Post Comment Actions

### DIFF
--- a/client/blocks/comments/comment-actions.jsx
+++ b/client/blocks/comments/comment-actions.jsx
@@ -9,9 +9,13 @@ import classnames from 'classnames';
 import { noop } from 'lodash';
 
 /**
+ * WordPress dependencies
+ */
+import { Button } from '@wordpress/components';
+
+/**
  * Internal dependencies
  */
-import { Button } from '@automattic/components';
 import { changeCommentStatus } from 'state/comments/actions';
 import CommentLikeButtonContainer from './comment-likes';
 import CommentApproveAction from './comment-approve-action';
@@ -23,8 +27,6 @@ import PopoverMenuSeparator from 'components/popover/menu-separator';
  * Style dependencies
  */
 import './comment-actions.scss';
-
-const PlainButton = ( props ) => <Button { ...props } plain />;
 
 const CommentActions = ( {
 	post,
@@ -58,37 +60,34 @@ const CommentActions = ( {
 	return (
 		<div className="comments__comment-actions">
 			{ showReadMore && (
-				<PlainButton className="comments__comment-actions-read-more" onClick={ onReadMore }>
+				<Button className="comments__comment-actions-read-more" onClick={ onReadMore }>
 					<Gridicon
 						icon="chevron-down"
 						size={ 18 }
 						className="comments__comment-actions-read-more-icon"
 					/>
 					{ translate( 'Read More' ) }
-				</PlainButton>
+				</Button>
 			) }
 			{ showReplyButton && (
-				<PlainButton className="comments__comment-actions-reply" onClick={ handleReply }>
+				<Button className="comments__comment-actions-reply" onClick={ handleReply }>
 					<Gridicon icon="reply" size={ 18 } />
 					<span className="comments__comment-actions-reply-label">{ translate( 'Reply' ) }</span>
-				</PlainButton>
+				</Button>
 			) }
 			{ showCancelReplyButton && (
-				<PlainButton className="comments__comment-actions-cancel-reply" onClick={ onReplyCancel }>
+				<Button className="comments__comment-actions-cancel-reply" onClick={ onReplyCancel }>
 					{ translate( 'Cancel reply' ) }
-				</PlainButton>
+				</Button>
 			) }
 			{ showCancelEditButton && (
-				<PlainButton
-					className="comments__comment-actions-cancel-reply"
-					onClick={ editCommentCancel }
-				>
+				<Button className="comments__comment-actions-cancel-reply" onClick={ editCommentCancel }>
 					{ translate( 'Cancel' ) }
-				</PlainButton>
+				</Button>
 			) }
 			<CommentLikeButtonContainer
 				className="comments__comment-actions-like"
-				tagName={ PlainButton }
+				tagName={ Button }
 				siteId={ post.site_ID }
 				postId={ post.ID }
 				commentId={ commentId }
@@ -96,18 +95,18 @@ const CommentActions = ( {
 			{ showModerationTools && (
 				<div className="comments__comment-actions-moderation-tools">
 					<CommentApproveAction { ...{ status, approveComment, unapproveComment } } />
-					<PlainButton className="comments__comment-actions-trash" onClick={ trashComment }>
+					<Button className="comments__comment-actions-trash" onClick={ trashComment }>
 						<Gridicon icon="trash" size={ 18 } />
 						<span className="comments__comment-actions-like-label">{ translate( 'Trash' ) }</span>
-					</PlainButton>
-					<PlainButton className="comments__comment-actions-spam" onClick={ spamComment }>
+					</Button>
+					<Button className="comments__comment-actions-spam" onClick={ spamComment }>
 						<Gridicon icon="spam" size={ 18 } />
 						<span className="comments__comment-actions-like-label">{ translate( 'Spam' ) }</span>
-					</PlainButton>
-					<PlainButton className="comments__comment-actions-edit" onClick={ editComment }>
+					</Button>
+					<Button className="comments__comment-actions-edit" onClick={ editComment }>
 						<Gridicon icon="pencil" size={ 18 } />
 						<span className="comments__comment-actions-like-label">{ translate( 'Edit' ) }</span>
-					</PlainButton>
+					</Button>
 					<EllipsisMenu toggleTitle={ translate( 'More' ) }>
 						<PopoverMenuItem
 							className={ classnames( 'comments__comment-actions-approve', {

--- a/client/blocks/comments/comment-actions.jsx
+++ b/client/blocks/comments/comment-actions.jsx
@@ -24,10 +24,8 @@ import PopoverMenuSeparator from 'components/popover/menu-separator';
  */
 import './comment-actions.scss';
 
-const BorderlessCompactButtonTag = ( { children, ...props } ) => (
-	<Button { ...props } borderless compact>
-		{ children }
-	</Button>
+const BorderlessCompactButton = ( { children, ...props } ) => (
+	<Button { ...props } borderless compact />
 );
 
 const CommentActions = ( {
@@ -62,9 +60,7 @@ const CommentActions = ( {
 	return (
 		<div className="comments__comment-actions">
 			{ showReadMore && (
-				<Button
-					borderless
-					compact
+				<BorderlessCompactButton
 					className="comments__comment-actions-read-more"
 					onClick={ onReadMore }
 				>
@@ -74,42 +70,36 @@ const CommentActions = ( {
 						className="comments__comment-actions-read-more-icon"
 					/>
 					{ translate( 'Read More' ) }
-				</Button>
+				</BorderlessCompactButton>
 			) }
 			{ showReplyButton && (
-				<Button
-					borderless
-					compact
+				<BorderlessCompactButton
 					className="comments__comment-actions-reply"
 					onClick={ handleReply }
 				>
 					<Gridicon icon="reply" size={ 18 } />
 					<span className="comments__comment-actions-reply-label">{ translate( 'Reply' ) }</span>
-				</Button>
+				</BorderlessCompactButton>
 			) }
 			{ showCancelReplyButton && (
-				<Button
-					borderless
-					compact
+				<BorderlessCompactButton
 					className="comments__comment-actions-cancel-reply"
 					onClick={ onReplyCancel }
 				>
 					{ translate( 'Cancel reply' ) }
-				</Button>
+				</BorderlessCompactButton>
 			) }
 			{ showCancelEditButton && (
-				<Button
-					borderless
-					compact
+				<BorderlessCompactButton
 					className="comments__comment-actions-cancel-reply"
 					onClick={ editCommentCancel }
 				>
 					{ translate( 'Cancel' ) }
-				</Button>
+				</BorderlessCompactButton>
 			) }
 			<CommentLikeButtonContainer
 				className="comments__comment-actions-like"
-				tagName={ BorderlessCompactButtonTag }
+				tagName={ BorderlessCompactButton }
 				siteId={ post.site_ID }
 				postId={ post.ID }
 				commentId={ commentId }

--- a/client/blocks/comments/comment-actions.jsx
+++ b/client/blocks/comments/comment-actions.jsx
@@ -24,7 +24,7 @@ import PopoverMenuSeparator from 'components/popover/menu-separator';
  */
 import './comment-actions.scss';
 
-const BareButton = ( props ) => <Button { ...props } bare />;
+const PlainButton = ( props ) => <Button { ...props } plain />;
 
 const CommentActions = ( {
 	post,
@@ -58,37 +58,37 @@ const CommentActions = ( {
 	return (
 		<div className="comments__comment-actions">
 			{ showReadMore && (
-				<BareButton className="comments__comment-actions-read-more" onClick={ onReadMore }>
+				<PlainButton className="comments__comment-actions-read-more" onClick={ onReadMore }>
 					<Gridicon
 						icon="chevron-down"
 						size={ 18 }
 						className="comments__comment-actions-read-more-icon"
 					/>
 					{ translate( 'Read More' ) }
-				</BareButton>
+				</PlainButton>
 			) }
 			{ showReplyButton && (
-				<BareButton className="comments__comment-actions-reply" onClick={ handleReply }>
+				<PlainButton className="comments__comment-actions-reply" onClick={ handleReply }>
 					<Gridicon icon="reply" size={ 18 } />
 					<span className="comments__comment-actions-reply-label">{ translate( 'Reply' ) }</span>
-				</BareButton>
+				</PlainButton>
 			) }
 			{ showCancelReplyButton && (
-				<BareButton className="comments__comment-actions-cancel-reply" onClick={ onReplyCancel }>
+				<PlainButton className="comments__comment-actions-cancel-reply" onClick={ onReplyCancel }>
 					{ translate( 'Cancel reply' ) }
-				</BareButton>
+				</PlainButton>
 			) }
 			{ showCancelEditButton && (
-				<BareButton
+				<PlainButton
 					className="comments__comment-actions-cancel-reply"
 					onClick={ editCommentCancel }
 				>
 					{ translate( 'Cancel' ) }
-				</BareButton>
+				</PlainButton>
 			) }
 			<CommentLikeButtonContainer
 				className="comments__comment-actions-like"
-				tagName={ BareButton }
+				tagName={ PlainButton }
 				siteId={ post.site_ID }
 				postId={ post.ID }
 				commentId={ commentId }
@@ -96,18 +96,18 @@ const CommentActions = ( {
 			{ showModerationTools && (
 				<div className="comments__comment-actions-moderation-tools">
 					<CommentApproveAction { ...{ status, approveComment, unapproveComment } } />
-					<BareButton className="comments__comment-actions-trash" onClick={ trashComment }>
+					<PlainButton className="comments__comment-actions-trash" onClick={ trashComment }>
 						<Gridicon icon="trash" size={ 18 } />
 						<span className="comments__comment-actions-like-label">{ translate( 'Trash' ) }</span>
-					</BareButton>
-					<BareButton className="comments__comment-actions-spam" onClick={ spamComment }>
+					</PlainButton>
+					<PlainButton className="comments__comment-actions-spam" onClick={ spamComment }>
 						<Gridicon icon="spam" size={ 18 } />
 						<span className="comments__comment-actions-like-label">{ translate( 'Spam' ) }</span>
-					</BareButton>
-					<BareButton className="comments__comment-actions-edit" onClick={ editComment }>
+					</PlainButton>
+					<PlainButton className="comments__comment-actions-edit" onClick={ editComment }>
 						<Gridicon icon="pencil" size={ 18 } />
 						<span className="comments__comment-actions-like-label">{ translate( 'Edit' ) }</span>
-					</BareButton>
+					</PlainButton>
 					<EllipsisMenu toggleTitle={ translate( 'More' ) }>
 						<PopoverMenuItem
 							className={ classnames( 'comments__comment-actions-approve', {

--- a/client/blocks/comments/comment-actions.jsx
+++ b/client/blocks/comments/comment-actions.jsx
@@ -11,6 +11,7 @@ import { noop } from 'lodash';
 /**
  * Internal dependencies
  */
+import { Button } from '@automattic/components';
 import { changeCommentStatus } from 'state/comments/actions';
 import CommentLikeButtonContainer from './comment-likes';
 import CommentApproveAction from './comment-approve-action';
@@ -22,6 +23,12 @@ import PopoverMenuSeparator from 'components/popover/menu-separator';
  * Style dependencies
  */
 import './comment-actions.scss';
+
+const BorderlessCompactButtonTag = ( { children, ...props } ) => (
+	<Button { ...props } borderless compact>
+		{ children }
+	</Button>
+);
 
 const CommentActions = ( {
 	post,
@@ -55,34 +62,54 @@ const CommentActions = ( {
 	return (
 		<div className="comments__comment-actions">
 			{ showReadMore && (
-				<button className="comments__comment-actions-read-more" onClick={ onReadMore }>
+				<Button
+					borderless
+					compact
+					className="comments__comment-actions-read-more"
+					onClick={ onReadMore }
+				>
 					<Gridicon
 						icon="chevron-down"
 						size={ 18 }
 						className="comments__comment-actions-read-more-icon"
 					/>
 					{ translate( 'Read More' ) }
-				</button>
+				</Button>
 			) }
 			{ showReplyButton && (
-				<button className="comments__comment-actions-reply" onClick={ handleReply }>
+				<Button
+					borderless
+					compact
+					className="comments__comment-actions-reply"
+					onClick={ handleReply }
+				>
 					<Gridicon icon="reply" size={ 18 } />
 					<span className="comments__comment-actions-reply-label">{ translate( 'Reply' ) }</span>
-				</button>
+				</Button>
 			) }
 			{ showCancelReplyButton && (
-				<button className="comments__comment-actions-cancel-reply" onClick={ onReplyCancel }>
+				<Button
+					borderless
+					compact
+					className="comments__comment-actions-cancel-reply"
+					onClick={ onReplyCancel }
+				>
 					{ translate( 'Cancel reply' ) }
-				</button>
+				</Button>
 			) }
 			{ showCancelEditButton && (
-				<button className="comments__comment-actions-cancel-reply" onClick={ editCommentCancel }>
+				<Button
+					borderless
+					compact
+					className="comments__comment-actions-cancel-reply"
+					onClick={ editCommentCancel }
+				>
 					{ translate( 'Cancel' ) }
-				</button>
+				</Button>
 			) }
 			<CommentLikeButtonContainer
 				className="comments__comment-actions-like"
-				tagName="button"
+				tagName={ BorderlessCompactButtonTag }
 				siteId={ post.site_ID }
 				postId={ post.ID }
 				commentId={ commentId }

--- a/client/blocks/comments/comment-actions.jsx
+++ b/client/blocks/comments/comment-actions.jsx
@@ -24,9 +24,7 @@ import PopoverMenuSeparator from 'components/popover/menu-separator';
  */
 import './comment-actions.scss';
 
-const BorderlessCompactButton = ( { children, ...props } ) => (
-	<Button { ...props } borderless compact />
-);
+const BareButton = ( props ) => <Button { ...props } bare />;
 
 const CommentActions = ( {
 	post,
@@ -60,46 +58,37 @@ const CommentActions = ( {
 	return (
 		<div className="comments__comment-actions">
 			{ showReadMore && (
-				<BorderlessCompactButton
-					className="comments__comment-actions-read-more"
-					onClick={ onReadMore }
-				>
+				<BareButton className="comments__comment-actions-read-more" onClick={ onReadMore }>
 					<Gridicon
 						icon="chevron-down"
 						size={ 18 }
 						className="comments__comment-actions-read-more-icon"
 					/>
 					{ translate( 'Read More' ) }
-				</BorderlessCompactButton>
+				</BareButton>
 			) }
 			{ showReplyButton && (
-				<BorderlessCompactButton
-					className="comments__comment-actions-reply"
-					onClick={ handleReply }
-				>
+				<BareButton className="comments__comment-actions-reply" onClick={ handleReply }>
 					<Gridicon icon="reply" size={ 18 } />
 					<span className="comments__comment-actions-reply-label">{ translate( 'Reply' ) }</span>
-				</BorderlessCompactButton>
+				</BareButton>
 			) }
 			{ showCancelReplyButton && (
-				<BorderlessCompactButton
-					className="comments__comment-actions-cancel-reply"
-					onClick={ onReplyCancel }
-				>
+				<BareButton className="comments__comment-actions-cancel-reply" onClick={ onReplyCancel }>
 					{ translate( 'Cancel reply' ) }
-				</BorderlessCompactButton>
+				</BareButton>
 			) }
 			{ showCancelEditButton && (
-				<BorderlessCompactButton
+				<BareButton
 					className="comments__comment-actions-cancel-reply"
 					onClick={ editCommentCancel }
 				>
 					{ translate( 'Cancel' ) }
-				</BorderlessCompactButton>
+				</BareButton>
 			) }
 			<CommentLikeButtonContainer
 				className="comments__comment-actions-like"
-				tagName={ BorderlessCompactButton }
+				tagName={ BareButton }
 				siteId={ post.site_ID }
 				postId={ post.ID }
 				commentId={ commentId }
@@ -107,18 +96,18 @@ const CommentActions = ( {
 			{ showModerationTools && (
 				<div className="comments__comment-actions-moderation-tools">
 					<CommentApproveAction { ...{ status, approveComment, unapproveComment } } />
-					<button className="comments__comment-actions-trash" onClick={ trashComment }>
+					<BareButton className="comments__comment-actions-trash" onClick={ trashComment }>
 						<Gridicon icon="trash" size={ 18 } />
 						<span className="comments__comment-actions-like-label">{ translate( 'Trash' ) }</span>
-					</button>
-					<button className="comments__comment-actions-spam" onClick={ spamComment }>
+					</BareButton>
+					<BareButton className="comments__comment-actions-spam" onClick={ spamComment }>
 						<Gridicon icon="spam" size={ 18 } />
 						<span className="comments__comment-actions-like-label">{ translate( 'Spam' ) }</span>
-					</button>
-					<button className="comments__comment-actions-edit" onClick={ editComment }>
+					</BareButton>
+					<BareButton className="comments__comment-actions-edit" onClick={ editComment }>
 						<Gridicon icon="pencil" size={ 18 } />
 						<span className="comments__comment-actions-like-label">{ translate( 'Edit' ) }</span>
-					</button>
+					</BareButton>
 					<EllipsisMenu toggleTitle={ translate( 'More' ) }>
 						<PopoverMenuItem
 							className={ classnames( 'comments__comment-actions-approve', {

--- a/client/blocks/comments/comment-actions.scss
+++ b/client/blocks/comments/comment-actions.scss
@@ -5,7 +5,7 @@
 	list-style: none;
 	margin-top: -6px;
 	
-	.button-plain {
+	.components-button {
 		display: inline-block;
 		color: var( --color-text-subtle );
 		padding: 4px;

--- a/client/blocks/comments/comment-actions.scss
+++ b/client/blocks/comments/comment-actions.scss
@@ -4,45 +4,48 @@
 	font-size: $font-body-small;
 	list-style: none;
 	margin-top: -6px;
-
-	button {
+	
+	button.button {
 		display: inline-block;
-	color: var( --color-text-subtle );
+		color: var( --color-text-subtle );
 		padding: 4px;
 		margin-right: 8px;
-		margin-top: 0;
+		margin-top: 6px;
 		cursor: pointer;
 		font-size: $font-body-small;
-
+		font-weight: 400;
+		
+		.is-compact.gridicon,
 		.gridicon {
 			position: relative;
 			top: 4px;
 			margin-right: 4px;
 		}
-
+		
 		.gridicons-star,
 		.gridicons-star-outline {
 			top: 3px;
 		}
-
+		
 		.like-button__like-icons {
 			margin-right: 18px;
 		}
-
+		
 		&.comments__comment-actions-reply {
 			margin-left: -7px;
 		}
-
+		
 		&.like-button {
 			.gridicon {
+				top: 10px;
 				position: absolute;
 			}
 		}
-
+		
 		&:hover {
 			color: var( --color-primary );
 		}
-
+		
 		&.comments__comment-actions-cancel-reply {
 			float: right;
 			margin-top: 4px;
@@ -50,13 +53,13 @@
 			padding-right: 0;
 		}
 	}
-
+	
 	// Aligns Like icon to comment text when it's by itself
 	> :only-child {
 		left: -3px;
 		top: 3px;
 	}
-
+	
 	.comments__comment-actions-approve,
 	.comments__comment-actions-trash,
 	.comments__comment-actions-spam,

--- a/client/blocks/comments/comment-actions.scss
+++ b/client/blocks/comments/comment-actions.scss
@@ -5,12 +5,11 @@
 	list-style: none;
 	margin-top: -6px;
 	
-	button.button {
+	.button-bare {
 		display: inline-block;
 		color: var( --color-text-subtle );
 		padding: 4px;
 		margin-right: 8px;
-		margin-top: 6px;
 		cursor: pointer;
 		font-size: $font-body-small;
 		font-weight: 400;
@@ -37,7 +36,6 @@
 		
 		&.like-button {
 			.gridicon {
-				top: 10px;
 				position: absolute;
 			}
 		}

--- a/client/blocks/comments/comment-actions.scss
+++ b/client/blocks/comments/comment-actions.scss
@@ -5,7 +5,7 @@
 	list-style: none;
 	margin-top: -6px;
 	
-	.button-bare {
+	.button-plain {
 		display: inline-block;
 		color: var( --color-text-subtle );
 		padding: 4px;

--- a/client/blocks/comments/comment-actions.scss
+++ b/client/blocks/comments/comment-actions.scss
@@ -9,6 +9,7 @@
 		display: inline-block;
 		color: var( --color-text-subtle );
 		padding: 4px;
+		height: auto;
 		margin-right: 8px;
 		cursor: pointer;
 		font-size: $font-body-small;

--- a/client/blocks/comments/comment-actions.scss
+++ b/client/blocks/comments/comment-actions.scss
@@ -50,6 +50,16 @@
 			margin-right: 0;
 			padding-right: 0;
 		}
+
+		&.comments__comment-actions-read-more {
+			color: var( --color-primary );
+			margin: 0 10px 0 -3px;
+			padding-left: 0;
+			
+			.comments__comment-actions-read-more-icon {
+				fill: var( --color-primary );
+			}
+		}
 	}
 	
 	// Aligns Like icon to comment text when it's by itself
@@ -83,16 +93,6 @@
 			display: inline;
 		}
 	}
-}
-
-.comments__comment-actions .comments__comment-actions-read-more {
-	color: var( --color-primary );
-	margin: 0 10px 0 -3px;
-	padding-left: 0;
-}
-
-.comments__comment-actions-read-more-icon {
-	fill: var( --color-primary );
 }
 
 .comments__comment-actions-moderation-tools {

--- a/client/blocks/comments/comment-approve-action.jsx
+++ b/client/blocks/comments/comment-approve-action.jsx
@@ -12,7 +12,7 @@ import classnames from 'classnames';
 /**
  * Internal dependencies
  */
-import { Button } from '@automattic/components';
+import { Button } from '@wordpress/components';
 
 /**
  * Style dependencies
@@ -26,11 +26,7 @@ const CommentApproveAction = ( { translate, status, approveComment, unapproveCom
 	} );
 
 	return (
-		<Button
-			plain
-			className={ buttonStyle }
-			onClick={ ! isApproved ? approveComment : unapproveComment }
-		>
+		<Button className={ buttonStyle } onClick={ ! isApproved ? approveComment : unapproveComment }>
 			<Gridicon icon="checkmark" size={ 18 } />
 			<span className="comments__comment-actions-like-label">
 				{ isApproved ? translate( 'Approved' ) : translate( 'Approve' ) }

--- a/client/blocks/comments/comment-approve-action.jsx
+++ b/client/blocks/comments/comment-approve-action.jsx
@@ -27,7 +27,7 @@ const CommentApproveAction = ( { translate, status, approveComment, unapproveCom
 
 	return (
 		<Button
-			bare
+			plain
 			className={ buttonStyle }
 			onClick={ ! isApproved ? approveComment : unapproveComment }
 		>

--- a/client/blocks/comments/comment-approve-action.jsx
+++ b/client/blocks/comments/comment-approve-action.jsx
@@ -10,6 +10,11 @@ import Gridicon from 'components/gridicon';
 import classnames from 'classnames';
 
 /**
+ * Internal dependencies
+ */
+import { Button } from '@automattic/components';
+
+/**
  * Style dependencies
  */
 import './comment-approve-action.scss';
@@ -21,12 +26,16 @@ const CommentApproveAction = ( { translate, status, approveComment, unapproveCom
 	} );
 
 	return (
-		<button className={ buttonStyle } onClick={ ! isApproved ? approveComment : unapproveComment }>
+		<Button
+			bare
+			className={ buttonStyle }
+			onClick={ ! isApproved ? approveComment : unapproveComment }
+		>
 			<Gridicon icon="checkmark" size={ 18 } />
 			<span className="comments__comment-actions-like-label">
 				{ isApproved ? translate( 'Approved' ) : translate( 'Approve' ) }
 			</span>
-		</button>
+		</Button>
 	);
 };
 

--- a/client/blocks/comments/comment-approve-action.scss
+++ b/client/blocks/comments/comment-approve-action.scss
@@ -1,4 +1,4 @@
-.comments__comment-actions-approve {
+.comments__comment-actions-approve.components-button {
 	.gridicon .gridicon-checkmark,
 	&.is-approved {
 		color: var( --color-success );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use the `Button` component for the comment action buttons

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the reader and open a post's comments section. check that the buttons work and look like they do in production.

Related to #45259 
