### PR TITLE
[E2E] Embed block fixes

### DIFF
--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -279,6 +279,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 			case 'Instagram':
 			case 'Twitter':
 			case 'YouTube':
+				ariaLabel = 'Block: Embed';
 				prefix = 'embed-';
 				break;
 			case 'Form':

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -271,15 +271,24 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	// return blockID - top level block id which is looks like `block-b91ce479-fb2d-45b7-ad92-22ae7a58cf04`. Should be used for further interaction with added block.
 	async addBlock( title ) {
 		title = title.charAt( 0 ).toUpperCase() + title.slice( 1 ); // Capitalize block name
+		const customEmbedSelectorFor = ( embedType ) =>
+			` iframe[title='Embedded content from ${ embedType }']`;
 		let blockClass = kebabCase( title.toLowerCase() );
 		let hasChildBlocks = false;
 		let ariaLabel;
 		let prefix = '';
+		let customBlockSelector;
 		switch ( title ) {
 			case 'Instagram':
+				customBlockSelector = customEmbedSelectorFor( 'instagram.com' );
+				prefix = 'embed-';
+				break;
 			case 'Twitter':
+				customBlockSelector = customEmbedSelectorFor( 'twitter' );
+				prefix = 'embed-';
+				break;
 			case 'YouTube':
-				ariaLabel = 'Block: Embed';
+				customBlockSelector = customEmbedSelectorFor( 'youtube.com' );
 				prefix = 'embed-';
 				break;
 			case 'Form':
@@ -344,16 +353,22 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 				break;
 		}
 
-		const selectorAriaLabel = ariaLabel || `Block: ${ title }`;
+		const selectorAriaLabel = `[aria-label*='${ ariaLabel || `Block: ${ title }` }'`;
+
+		const buildBlockSelector = ( selector ) => {
+			return By.css(
+				`.block-editor-block-list__block.${
+					hasChildBlocks ? 'has-child-selected' : 'is-selected'
+				}${ selector }`
+			);
+		};
 
 		const inserterBlockItemSelector = By.css(
 			`.edit-post-layout__inserter-panel .block-editor-inserter__block-list button.editor-block-list-item-${ prefix }${ blockClass }`
 		);
-		const insertedBlockSelector = By.css(
-			`.block-editor-block-list__block.${
-				hasChildBlocks ? 'has-child-selected' : 'is-selected'
-			}[aria-label*='${ selectorAriaLabel }']`
-		);
+
+		const insertedBlockSelectorByAriaLabel = buildBlockSelector( selectorAriaLabel );
+		const insertedBlockSelectorByCustomSelector = buildBlockSelector( customBlockSelector );
 
 		await this.openBlockInserterAndSearch( title );
 
@@ -365,8 +380,20 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		// to cause the element to become stale.
 		await driverHelper.clickWhenClickable( this.driver, inserterBlockItemSelector );
 
-		await driverHelper.waitTillPresentAndDisplayed( this.driver, insertedBlockSelector );
-		return await this.driver.findElement( insertedBlockSelector ).getAttribute( 'id' );
+		await driverHelper
+			.waitTillPresentAndDisplayed( this.driver, insertedBlockSelectorByAriaLabel )
+			.catch( () =>
+				driverHelper.waitTillPresentAndDisplayed(
+					this.driver,
+					insertedBlockSelectorByCustomSelector
+				)
+			);
+
+		const element = await this.driver
+			.findElement( insertedBlockSelectorByAriaLabel )
+			.catch( () => this.driver.findElement( insertedBlockSelectorByCustomSelector ) );
+
+		return element.getAttribute( 'id' );
 	}
 
 	/**

--- a/test/e2e/lib/mocha-hooks.js
+++ b/test/e2e/lib/mocha-hooks.js
@@ -64,6 +64,7 @@ afterEach( async function () {
 	let filenameCallback;
 
 	if ( this.currentTest.state === 'failed' ) {
+		console.error( this.currentTest.err );
 		const neverSaveScreenshots = config.get( 'neverSaveScreenshots' );
 		if ( neverSaveScreenshots ) {
 			return null;

--- a/test/e2e/lib/mocha-hooks.js
+++ b/test/e2e/lib/mocha-hooks.js
@@ -64,7 +64,6 @@ afterEach( async function () {
 	let filenameCallback;
 
 	if ( this.currentTest.state === 'failed' ) {
-		console.error( this.currentTest.err );
 		const neverSaveScreenshots = config.get( 'neverSaveScreenshots' );
 		if ( neverSaveScreenshots ) {
 			return null;

--- a/test/e2e/specs/wp-calypso-gutenberg-coblocks-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-coblocks-spec.js
@@ -60,6 +60,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: CoBlocks (${ screenSize })`, fu
 
 		step( 'Can publish and view content', async function () {
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			await gEditorComponent.ensureSaved(); // Needed so that we get a stable post slug for the block.
 			return await gEditorComponent.publish( { visit: true, closePanel: false } );
 		} );
 

--- a/test/e2e/specs/wp-calypso-gutenberg-coblocks-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-coblocks-spec.js
@@ -60,7 +60,9 @@ describe( `[${ host }] Calypso Gutenberg Editor: CoBlocks (${ screenSize })`, fu
 
 		step( 'Can publish and view content', async function () {
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
-			await gEditorComponent.ensureSaved(); // Needed so that we get a stable post slug for the block.
+			// We need to save the post to get a stable post slug for the block's `url` attribute.
+			// See https://github.com/godaddy-wordpress/coblocks/issues/1663.
+			await gEditorComponent.ensureSaved();
 			return await gEditorComponent.publish( { visit: true, closePanel: false } );
 		} );
 

--- a/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -1166,7 +1166,8 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 			await gEditorComponent.enterTitle( 'Embeds: ' + blogPostTitle );
 
-			this.instagramEditorSelector = '.wp-block-embed-instagram';
+			this.instagramEditorSelector =
+				'.wp-block-embed iframe[title="Embedded content from instagram.com"]';
 			const blockIdInstagram = await gEditorComponent.addBlock( 'Instagram' );
 			const gEmbedsComponentInstagram = await EmbedsBlockComponent.Expect(
 				driver,
@@ -1175,7 +1176,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			await gEmbedsComponentInstagram.embedUrl( 'https://www.instagram.com/p/BlDOZMil933/' );
 			await gEmbedsComponentInstagram.isEmbeddedInEditor( this.instagramEditorSelector );
 
-			this.twitterEditorSelector = '.wp-block-embed-twitter';
+			this.twitterEditorSelector = '.wp-block-embed iframe[title="Embedded content from twitter"]';
 			const blockIdTwitter = await gEditorComponent.addBlock( 'Twitter' );
 			const gEmbedsComponentTwitter = await EmbedsBlockComponent.Expect( driver, blockIdTwitter );
 			await gEmbedsComponentTwitter.embedUrl(
@@ -1183,7 +1184,8 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			);
 			await gEmbedsComponentTwitter.isEmbeddedInEditor( this.twitterEditorSelector );
 
-			this.youtubeEditorSelector = '.wp-block-embed-youtube';
+			this.youtubeEditorSelector =
+				'.wp-block-embed iframe[title="Embedded content from youtube.com"]';
 			const blockIdYouTube = await gEditorComponent.addBlock( 'YouTube' );
 			const gEmbedsComponentYouTube = await EmbedsBlockComponent.Expect( driver, blockIdYouTube );
 			await gEmbedsComponentYouTube.embedUrl( 'https://www.youtube.com/watch?v=xifhQyopjZM' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

All embed blocks (the ones touched by our E2E tests at least) now follow a similar naming/classification standard. They now all have the same ariaLabel and embed prefix for the .editor-block-list-item CSS class. 

This fixes the selectors so that the elements can be found on the page.

#### Outstanding questions

* Is it a good idea to have identical `aria-labels` for these blocks? They are all "embed" blocks, but they serve different purposes.
