### PR TITLE
Fix fatal error loading the block list for the first time for a site

### DIFF
--- a/client/my-sites/activity/activity-log/index.jsx
+++ b/client/my-sites/activity/activity-log/index.jsx
@@ -560,7 +560,7 @@ class ActivityLog extends Component {
 	render() {
 		const { canViewActivityLog, siteId, translate } = this.props;
 
-		if ( false === canViewActivityLog ) {
+		if ( ! canViewActivityLog ) {
 			return (
 				<Main>
 					<QuerySitePurchases siteId={ siteId } />

--- a/client/my-sites/comment/main.jsx
+++ b/client/my-sites/comment/main.jsx
@@ -102,7 +102,7 @@ const mapStateToProps = ( state, ownProps ) => {
 	const comment = getSiteComment( state, siteId, commentId );
 	const postId = get( comment, 'post.ID' );
 
-	const canModerateComments = canCurrentUser( state, siteId, 'moderate_comments' ) !== false;
+	const canModerateComments = canCurrentUser( state, siteId, 'moderate_comments' );
 	const hasPermalink = includes( [ 'approved', 'unapproved' ], get( comment, 'status' ) );
 
 	return {

--- a/client/my-sites/comments/main.jsx
+++ b/client/my-sites/comments/main.jsx
@@ -125,7 +125,7 @@ const mapStateToProps = ( state, { postId, siteFragment } ) => {
 	const siteId = getSiteId( state, siteFragment );
 	const isPostView = !! postId;
 	const canModerateComments = canCurrentUser( state, siteId, 'edit_posts' );
-	const showPermissionError = false === canModerateComments;
+	const showPermissionError = ! canModerateComments;
 
 	const showCommentTree =
 		! showPermissionError && isPostView && isEnabled( 'comments/management/threaded-view' );

--- a/client/my-sites/types/main.jsx
+++ b/client/my-sites/types/main.jsx
@@ -34,13 +34,13 @@ function Types( {
 } ) {
 	return (
 		<Main wideLayout>
-			<DocumentHead title={ get( postType, 'label' ) } />
+			<DocumentHead title={ get( postType, 'label', '' ) } />
 			<PageViewTracker path={ siteId ? '/types/:site' : '/types' } title="Custom Post Type" />
 			<SidebarNavigation />
 			<FormattedHeader
 				brandFont
 				className="types__page-heading"
-				headerText={ get( postType, 'label' ) }
+				headerText={ get( postType, 'label', '' ) }
 				align="left"
 			/>
 			{ false !== userCanEdit &&
@@ -81,7 +81,7 @@ export default connect( ( state, ownProps ) => {
 	return {
 		siteId,
 		postType,
-		postTypeSupported: isPostTypeSupported( state, siteId, ownProps.query.type ),
-		userCanEdit: canCurrentUser( state, siteId, capability ),
+		postTypeSupported: isPostTypeSupported( state, siteId, ownProps.query.type ) || false,
+		userCanEdit: canCurrentUser( state, siteId, capability ) || false,
 	};
 } )( Types );

--- a/client/my-sites/types/main.jsx
+++ b/client/my-sites/types/main.jsx
@@ -43,8 +43,8 @@ function Types( {
 				headerText={ get( postType, 'label', '' ) }
 				align="left"
 			/>
-			{ false !== userCanEdit &&
-				false !== postTypeSupported && [
+			{ userCanEdit &&
+				postTypeSupported && [
 					<PostTypeFilter
 						key="filter"
 						query={ userCanEdit ? query : null }
@@ -57,8 +57,8 @@ function Types( {
 						scrollContainer={ document.body }
 					/>,
 				] }
-			{ false === postTypeSupported && <PostTypeUnsupported type={ query.type } /> }
-			{ false === userCanEdit && <PostTypeForbidden /> }
+			{ ! postTypeSupported && <PostTypeUnsupported type={ query.type } /> }
+			{ ! userCanEdit && <PostTypeForbidden /> }
 		</Main>
 	);
 }

--- a/client/my-sites/types/main.jsx
+++ b/client/my-sites/types/main.jsx
@@ -81,7 +81,7 @@ export default connect( ( state, ownProps ) => {
 	return {
 		siteId,
 		postType,
-		postTypeSupported: isPostTypeSupported( state, siteId, ownProps.query.type ) || false,
-		userCanEdit: canCurrentUser( state, siteId, capability ) || false,
+		postTypeSupported: isPostTypeSupported( state, siteId, ownProps.query.type ),
+		userCanEdit: canCurrentUser( state, siteId, capability ),
 	};
 } )( Types );

--- a/client/state/post-types/selectors.js
+++ b/client/state/post-types/selectors.js
@@ -103,18 +103,18 @@ export function postTypeSupports( state, siteId, slug, feature ) {
 
 /**
  * Returns true if the site supported the post type, false if the site does not
- * support the post type, or null if support cannot be determined (if site is
+ * support the post type, or if support cannot be determined (if site is
  * not currently known).
  *
  * @param  {object}   state  Global state tree
  * @param  {number}   siteId Site ID
  * @param  {string}   slug   Post type slug
- * @returns {?boolean}        Whether site supports post type
+ * @returns {boolean}        Whether site supports post type
  */
 export function isPostTypeSupported( state, siteId, slug ) {
 	const postTypes = getPostTypes( state, siteId );
 	if ( ! postTypes ) {
-		return null;
+		return false;
 	}
 
 	return !! postTypes[ slug ];

--- a/client/state/post-types/test/selectors.js
+++ b/client/state/post-types/test/selectors.js
@@ -205,7 +205,7 @@ describe( 'selectors', () => {
 	} );
 
 	describe( 'isPostTypeSupported', () => {
-		test( 'should return null if the site post types are not known', () => {
+		test( 'should return false if the site post types are not known', () => {
 			const isSupported = isPostTypeSupported(
 				{
 					postTypes: {
@@ -216,7 +216,7 @@ describe( 'selectors', () => {
 				'post'
 			);
 
-			expect( isSupported ).to.be.null;
+			expect( isSupported ).to.be.false;
 		} );
 
 		test( 'should return false if the post type is not supported', () => {

--- a/client/state/selectors/can-current-user.js
+++ b/client/state/selectors/can-current-user.js
@@ -6,7 +6,7 @@ import { isValidCapability } from 'state/current-user/selectors';
 
 /**
  * Returns true if the current user has the specified capability for the site,
- * false if the user does not have the capability, or null if the capability
+ * false if the user does not have the capability or if the capability
  * cannot be determined (if the site is not currently known, or if specifying
  * an invalid capability).
  *
@@ -15,11 +15,11 @@ import { isValidCapability } from 'state/current-user/selectors';
  * @param  {object}   state      Global state tree
  * @param  {number}   siteId     Site ID
  * @param  {string}   capability Capability label
- * @returns {?boolean}            Whether current user has capability
+ * @returns {boolean}            Whether current user has capability
  */
 export const canCurrentUser = ( state, siteId, capability ) => {
 	if ( ! isValidCapability( state, siteId, capability ) ) {
-		return null;
+		return false;
 	}
 
 	return state.currentUser.capabilities[ siteId ][ capability ];

--- a/client/state/selectors/can-site-view-atomic-hosting.js
+++ b/client/state/selectors/can-site-view-atomic-hosting.js
@@ -9,7 +9,7 @@ import canCurrentUser from 'state/selectors/can-current-user';
  * Returns true if hosting section should be viewable
  *
  * @param  {object}  state  Global state tree
- * @returns {?boolean}        Whether site can display the atomic hosting section
+ * @returns {boolean}        Whether site can display the atomic hosting section
  */
 export default function canSiteViewAtomicHosting( state ) {
 	const siteId = getSelectedSiteId( state );

--- a/client/state/selectors/test/can-current-user.js
+++ b/client/state/selectors/test/can-current-user.js
@@ -9,7 +9,7 @@ import { expect } from 'chai';
 import canCurrentUser from 'state/selectors/can-current-user';
 
 describe( 'canCurrentUser()', () => {
-	test( 'should return null if the site is not known', () => {
+	test( 'should return false if the site is not known', () => {
 		const isCapable = canCurrentUser(
 			{
 				currentUser: {
@@ -20,7 +20,7 @@ describe( 'canCurrentUser()', () => {
 			'manage_options'
 		);
 
-		expect( isCapable ).to.be.null;
+		expect( isCapable ).to.be.false;
 	} );
 
 	test( 'should return the value for the specified capability', () => {
@@ -41,7 +41,7 @@ describe( 'canCurrentUser()', () => {
 		expect( isCapable ).to.be.false;
 	} );
 
-	test( 'should return null if the capability is invalid', () => {
+	test( 'should return false if the capability is invalid', () => {
 		const isCapable = canCurrentUser(
 			{
 				currentUser: {
@@ -56,6 +56,6 @@ describe( 'canCurrentUser()', () => {
 			'manage_foo'
 		);
 
-		expect( isCapable ).to.be.null;
+		expect( isCapable ).to.be.false;
 	} );
 } );

--- a/client/state/sites/selectors/can-current-user-use-customer-home.js
+++ b/client/state/sites/selectors/can-current-user-use-customer-home.js
@@ -29,5 +29,5 @@ export default function canCurrentUserUseCustomerHome( state, siteId = null ) {
 	}
 
 	const site = getSite( state, siteId );
-	return site && !! canCurrentUser( state, siteId, 'manage_options' );
+	return site && canCurrentUser( state, siteId, 'manage_options' );
 }

--- a/client/state/sites/selectors/can-current-user-use-earn.js
+++ b/client/state/sites/selectors/can-current-user-use-earn.js
@@ -17,5 +17,5 @@ export default function canCurrentUserUseEarn( state, siteId = null ) {
 		siteId = getSelectedSiteId( state );
 	}
 	const site = getSite( state, siteId );
-	return site && !! canCurrentUser( state, siteId, 'manage_options' );
+	return site && canCurrentUser( state, siteId, 'manage_options' );
 }

--- a/client/state/sites/selectors/get-site-computed-attributes.js
+++ b/client/state/sites/selectors/get-site-computed-attributes.js
@@ -29,7 +29,7 @@ export default function getSiteComputedAttributes( state, siteId ) {
 	const computedAttributes = {
 		domain: getSiteDomain( state, siteId ),
 		hasConflict: isSiteConflicting( state, siteId ),
-		is_customizable: !! canCurrentUser( state, siteId, 'edit_theme_options' ),
+		is_customizable: canCurrentUser( state, siteId, 'edit_theme_options' ),
 		is_previewable: !! isSitePreviewable( state, siteId ),
 		options: getSiteOptions( state, siteId ),
 		slug: getSiteSlug( state, siteId ),

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -128,7 +128,7 @@ describe( 'selectors', () => {
 				canUpdateFiles: true,
 				isMainNetworkSite: false,
 				isSecondaryNetworkSite: false,
-				isSiteUpgradeable: null,
+				isSiteUpgradeable: false,
 				options: {
 					jetpack_version: '8.0',
 					unmapped_url: 'https://example.wordpress.com',


### PR DESCRIPTION
Users have been [complaining about crashes around reusable blocks for some time](https://github.com/Automattic/wp-calypso/issues/40229), I think that this bug may have been the root cause.

It appears that normally when loading the reusable block list, the users permissions will be cached, and the page will load correctly.

However, if the user's permissions are not cached,  the page will attempt to load with `postType` and `userCanEdit` set to `null`. This will cause several errors which prevent the page from loading. This PR adds null handling to the reusable block list page.

# To reproduce:
Have two sites set up, one that you haven't logged into for a while (sorry it's a bit vague)
In site one, navigate to the reusable blocks page
https://wordpress.com/types/wp_block/<YOUR_SITE.wordpress.com>
while on this page, switch sites to a site that you haven't logged into for a while
Observe JS errors prevent the page from loading

![Sep-02-2020 11-27-45](https://user-images.githubusercontent.com/22446385/91921853-dc079c00-ed0f-11ea-9333-2cd7ac8e51cc.gif)

fixes #40229

