### PR TITLE
Stats: Properly display new graph data when new data is received

### DIFF
--- a/client/state/stats/chart-tabs/reducer.js
+++ b/client/state/stats/chart-tabs/reducer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { pick, set, isEqual } from 'lodash';
+import { pick, set, isEqual, first } from 'lodash';
 
 /**
  * Internal dependencies
@@ -27,7 +27,10 @@ export const counts = withSchemaValidation(
 				case STATS_CHART_COUNTS_RECEIVE: {
 					// Workaround to prevent new data from being appended to previous data when range period differs.
 					// See https://github.com/Automattic/wp-calypso/pull/41441#discussion_r415918092
-					if ( action.data.length !== state.length ) {
+					if (
+						action.data.length !== state.length ||
+						! isEqual( first( action.data ).period, first( state ).period )
+					) {
 						return action.data;
 					}
 

--- a/client/state/stats/chart-tabs/test/reducer.js
+++ b/client/state/stats/chart-tabs/test/reducer.js
@@ -107,12 +107,6 @@ describe( 'reducer', () => {
 				[ siteId ]: {
 					[ period ]: [
 						{
-							period: '2018-09-20',
-							views: 247,
-							labelDay: 'Sep 20',
-							classNames: [],
-						},
-						{
 							period: '2018-09-30',
 							views: 487,
 							labelDay: 'Sep 30',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* We render a new set of data instead of appending data to the store when the first data point from the API is different from the first data point from our store. The previous behavior resulted in potential data points outside the bounds of the graph range and undefined values which resulted in empty graph states. If the dataset length or period differs from what is in the store, we assume that the data received is a new set of data.
* Considerations for how to solve this problem were documented here: https://github.com/Automattic/wp-calypso/issues/45315

#### Testing instructions

1. Starting at URL: `/stats/day/{site-URL}`
2. Take note of how the bar graph displays
3. Modify the URL to view the daily stats for a date that falls before the current range of the bar graph, e.g. by appending `?startDate=2019-06-23`
4. Reload the page with the same start date. The data on the graph should be consistent and should not be empty.
5. Change the startDate, and/or change the time period. Take note of the data and then reload the page. The data on the graph should be consistent and should not be empty.

Note: This PR branches from the changes implemented here: https://github.com/Automattic/wp-calypso/pull/45313 to ensure that the graphs show the correct labels on the x-axis. This PR should be merged after that PR is.

#### GIFs

Changing period
![2020-09-01 21 44 14](https://user-images.githubusercontent.com/66652282/91923366-2fd99d00-ec9e-11ea-841a-5a0b605f9c1d.gif)

Changing start date
![2020-09-01 21 43 51](https://user-images.githubusercontent.com/66652282/91923381-39fb9b80-ec9e-11ea-960b-67a2afc13d2f.gif)

Reloading the page and changing the start date in the URL
![2020-09-01 21 42 34](https://user-images.githubusercontent.com/66652282/91923414-53044c80-ec9e-11ea-9834-fbee258fe659.gif)



Fixes #45315
Fixes #45314
