### PR TITLE
Reader sidebar: improve resilience when displaying subscribed feeds

### DIFF
--- a/client/reader/sidebar/reader-sidebar-followed-sites/item.jsx
+++ b/client/reader/sidebar/reader-sidebar-followed-sites/item.jsx
@@ -10,6 +10,7 @@ import React, { Component } from 'react';
 import ReaderSidebarHelper from '../helper';
 import { recordAction, recordGaEvent, recordTrack } from 'reader/stats';
 import Count from 'components/count';
+import { formatUrlForDisplay } from 'reader/lib/feed-display-helper';
 
 /**
  * Styles
@@ -34,22 +35,36 @@ export class ReaderSidebarFollowingItem extends Component {
 	render() {
 		const { site, path } = this.props;
 
+		let streamLink;
+
+		if ( site.feed_ID ) {
+			streamLink = `/read/feeds/${ site.feed_ID }`;
+		} else if ( site.blog_ID ) {
+			// If subscription is missing a feed ID, fallback to blog stream
+			streamLink = `/read/blogs/${ site.blog_ID }`;
+		} else {
+			// Skip it
+			return null;
+		}
+
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
 			<li
 				key={ this.props.title }
-				className={ ReaderSidebarHelper.itemLinkClass( '/read/feeds/' + site.feed_ID, path, {
+				className={ ReaderSidebarHelper.itemLinkClass( streamLink, path, {
 					'sidebar-dynamic-menu__blog': true,
 				} ) }
 			>
 				<a
 					className="sidebar__menu-link sidebar__menu-link-reader"
-					href={ `/read/feeds/${ site.feed_ID }` }
+					href={ streamLink }
 					onClick={ this.handleSidebarClick }
 				>
 					<Favicon site={ site } className="sidebar__menu-item-siteicon" size={ 18 } />
 
-					<span className="sidebar__menu-item-sitename">{ site.name }</span>
+					<span className="sidebar__menu-item-sitename">
+						{ site.name || formatUrlForDisplay( site.URL ) }
+					</span>
 					{ site.unseen_count > 0 && <Count count={ site.unseen_count } compact /> }
 				</a>
 			</li>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In the updated Reader sidebar, we are displaying the user's subscribed feeds:

<img width="295" alt="Screen Shot 2020-09-02 at 17 43 33" src="https://user-images.githubusercontent.com/17325/91936391-d6c44480-ed43-11ea-877d-3930611ecfbb.png">

The sidebar expects a feed ID to be present in each case, but unfortunately not all subscription records have that available. This has lead to broken links in the sidebar (to `/feeds/undefined`) for some of my subscriptions.

This patch improves the resilience of subscription display by:
* Falling back to the blog stream if there's a blog ID available
* Skipping the subscription altogether if there is neither a feed ID or blog ID (unfortunately this can happen)
* Falling back to the feed URL if there's no site title to show

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
Load Reader and try clicking on your subscriptions to ensure a stream of posts is loaded. You can try subscribing to the following:

http://calypso.localhost:3000/read/feeds/52656883 (doesn't have a site name)
http://calypso.localhost:3000/read/blogs/96927810 (subscribe without associated feed)

The "no blog ID or feed ID" case is a bit tricker, but the one I had in my subs was a WordPress.com blog that is now deleted. Ideally the /read/following/mine endpoint should not be returning this at all (we know for sure that a *.wordpress.com site with a deleted blog is gone - it's a bit more complicated when there's a custom domain involved).