### PR TITLE
Nav sidebar: improve the experience of opening and closing the sidebar for assistive technology users

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/toggle-sidebar-button/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/toggle-sidebar-button/index.tsx
@@ -39,6 +39,8 @@ export default function ToggleSidebarButton() {
 			icon={ wordpress }
 			iconSize={ 36 }
 			onClick={ toggleSidebar }
+			aria-haspopup="dialog"
+			aria-expanded={ isSidebarOpen }
 		/>
 	);
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Tells assistive technology:
* that the (W) button that opens the navigation sidebar is controlling a dialog
* whether the dialog is visible or not

Also:
* returns focus back to the previous element after the sidebar is closed

Part of #45239

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D48946-code to your sandbox
* Open the block editor in a sandboxed site
* Inspect the (W) button in the top left
  * It should have the `aria-haspopup="dialog"` attribute
  * It should have the `aria-expanded="false"` attribute
* Open the nav sidebar
  * The same (W) button should have the `aria-expanded="true"` attribute
* Close the nav sidebar
  * The keyboard focus should return to the (W) button in the header

If you try in VoiceOver it doesn't change too much, but it does say now say that the button is "collapsed" when you focus on it.
