### PR TITLE
Add oneClickUpsell A/B test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -239,4 +239,13 @@ export default {
 		defaultVariation: 'control',
 		allowExistingUsers: false,
 	},
+	oneClickUpsell: {
+		datestamp: '20200909',
+		variations: {
+			test: 50,
+			control: 50,
+		},
+		defaultVariation: 'control',
+		allowExistingUsers: true,
+	},
 };

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -240,7 +240,7 @@ export default {
 		allowExistingUsers: false,
 	},
 	oneClickUpsell: {
-		datestamp: '20200909',
+		datestamp: '20200922',
 		variations: {
 			test: 50,
 			control: 50,

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -81,7 +81,7 @@ import getContactDetailsCache from 'state/selectors/get-contact-details-cache';
 import getUpgradePlanSlugFromPath from 'state/selectors/get-upgrade-plan-slug-from-path';
 import isDomainOnlySite from 'state/selectors/is-domain-only-site';
 import isEligibleForSignupDestination from 'state/selectors/is-eligible-for-signup-destination';
-import { getStoredCards } from 'state/stored-cards/selectors';
+import { getStoredCards, isFetchingStoredCards } from 'state/stored-cards/selectors';
 import { isValidFeatureKey } from 'lib/plans/features-list';
 import { getPlan, findPlansKeys } from 'lib/plans';
 import { GROUP_WPCOM } from 'lib/plans/constants';
@@ -952,11 +952,21 @@ export class Checkout extends React.Component {
 
 		if ( this.props.children ) {
 			this.props.setHeaderText( '' );
-			return React.Children.map( this.props.children, ( child ) => {
+			const children = React.Children.map( this.props.children, ( child ) => {
 				return React.cloneElement( child, {
+					cart: this.props.cart,
+					cards: this.props.cards,
+					isFetchingStoredCards: this.props.isFetchingStoredCards,
 					handleCheckoutCompleteRedirect: this.handleCheckoutCompleteRedirect,
 				} );
 			} );
+
+			return (
+				<>
+					<QueryStoredCards />
+					{ children }
+				</>
+			);
 		}
 
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
@@ -1000,6 +1010,7 @@ export default connect(
 			productsList: getProductsList( state ),
 			isProductsListFetching: isProductsListFetching( state ),
 			isPlansListFetching: isRequestingPlans( state ),
+			isFetchingStoredCards: isFetchingStoredCards( state ),
 			isPrivate: isPrivateSite( state, selectedSiteId ),
 			isSitePlansListFetching: isRequestingSitePlans( state, selectedSiteId ),
 			planSlug: getUpgradePlanSlugFromPath( state, selectedSiteId, props.product ),

--- a/client/my-sites/checkout/upsell-nudge/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/index.jsx
@@ -216,12 +216,16 @@ export class UpsellNudge extends React.Component {
 		return 'test' === abtest( 'oneClickUpsell' );
 	};
 
+	handleOneClickUpsellComplete = () => {
+		page( `/home/${ this.props.siteSlug }` );
+	};
+
 	renderPurchaseModal = () => {
 		return (
 			<PurchaseModal
 				cart={ this.props.cart }
 				cards={ this.props.cards }
-				onComplete={ () => this.props.handleCheckoutCompleteRedirect( true ) }
+				onComplete={ this.handleOneClickUpsellComplete }
 				onClose={ () => this.setState( { showPurchaseModal: false } ) }
 				siteSlug={ this.props.siteSlug }
 			/>

--- a/client/my-sites/checkout/upsell-nudge/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/index.jsx
@@ -223,6 +223,7 @@ export class UpsellNudge extends React.Component {
 				cards={ this.props.cards }
 				onComplete={ () => this.props.handleCheckoutCompleteRedirect( true ) }
 				onClose={ () => this.setState( { showPurchaseModal: false } ) }
+				siteSlug={ this.props.siteSlug }
 			/>
 		);
 	};

--- a/client/my-sites/checkout/upsell-nudge/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/index.jsx
@@ -207,9 +207,13 @@ export class UpsellNudge extends React.Component {
 	};
 
 	isEligibleForOneClickUpsellABTest = ( buttonAction ) => {
-		const { cards, upsellType } = this.props;
+		const { cards, siteSlug, upsellType } = this.props;
 
 		if ( 'accept' !== buttonAction || 'concierge-quickstart-session' !== upsellType ) {
+			return false;
+		}
+
+		if ( ! siteSlug ) {
 			return false;
 		}
 

--- a/client/my-sites/checkout/upsell-nudge/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/index.jsx
@@ -193,8 +193,11 @@ export class UpsellNudge extends React.Component {
 		);
 
 		if ( this.isEligibleForOneClickUpsellABTest( buttonAction ) ) {
+			this.setState( {
+				showPurchaseModal: true,
+				cartLastServerResponseDate: this.getCartUpdatedTime(),
+			} );
 			replaceCartWithItems( [ this.props.product ] );
-			this.setState( { showPurchaseModal: true } );
 			return;
 		}
 
@@ -223,6 +226,8 @@ export class UpsellNudge extends React.Component {
 	};
 
 	renderPurchaseModal = () => {
+		const isCartUpdating = this.state.cartLastServerResponseDate === this.getCartUpdatedTime();
+
 		return (
 			<PurchaseModal
 				cart={ this.props.cart }
@@ -230,6 +235,7 @@ export class UpsellNudge extends React.Component {
 				onComplete={ this.handleOneClickUpsellComplete }
 				onClose={ () => this.setState( { showPurchaseModal: false } ) }
 				siteSlug={ this.props.siteSlug }
+				isCartUpdating={ isCartUpdating }
 			/>
 		);
 	};
@@ -240,6 +246,10 @@ export class UpsellNudge extends React.Component {
 				<Gridicon icon="cross-small" />
 			</div>
 		);
+	};
+
+	getCartUpdatedTime = () => {
+		return this.props.cart?.client_metadata?.last_server_response_date;
 	};
 }
 

--- a/client/my-sites/checkout/upsell-nudge/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/index.jsx
@@ -40,6 +40,7 @@ import getUpgradePlanSlugFromPath from 'state/selectors/get-upgrade-plan-slug-fr
 import { PurchaseModal } from './purchase-modal';
 import { abtest } from 'lib/abtest';
 import { replaceCartWithItems } from 'lib/cart/actions';
+import Gridicon from 'components/gridicon';
 
 /**
  * Style dependencies
@@ -66,6 +67,7 @@ export class UpsellNudge extends React.Component {
 				{ ! hasSitePlans && <QuerySitePlans siteId={ selectedSiteId } /> }
 				{ isLoading ? this.renderPlaceholders() : this.renderContent() }
 				{ this.state.showPurchaseModal && this.renderPurchaseModal() }
+				{ this.preloadIconsForPurchaseModal() }
 			</Main>
 		);
 	}
@@ -229,6 +231,14 @@ export class UpsellNudge extends React.Component {
 				onClose={ () => this.setState( { showPurchaseModal: false } ) }
 				siteSlug={ this.props.siteSlug }
 			/>
+		);
+	};
+
+	preloadIconsForPurchaseModal = () => {
+		return (
+			<div className="upsell-nudge__hidden">
+				<Gridicon icon="cross-small" />
+			</div>
 		);
 	};
 }

--- a/client/my-sites/checkout/upsell-nudge/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/index.jsx
@@ -226,7 +226,7 @@ export class UpsellNudge extends React.Component {
 	};
 
 	handleOneClickUpsellComplete = () => {
-		page( `/home/${ this.props.siteSlug }` );
+		this.props.handleCheckoutCompleteRedirect( true );
 	};
 
 	renderPurchaseModal = () => {

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/constants.js
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/constants.js
@@ -1,0 +1,1 @@
+export const BEFORE_SUBMIT = 'before-submit';

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/content.jsx
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/content.jsx
@@ -1,0 +1,157 @@
+/**
+ * External dependencies
+ */
+import React, { useCallback } from 'react';
+import { sprintf } from '@wordpress/i18n';
+import { useTranslate } from 'i18n-calypso';
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+import { Button } from '@automattic/components';
+import { CheckoutCheckIcon } from '@automattic/composite-checkout';
+import PaymentLogo from '@automattic/composite-checkout/src/lib/payment-methods/payment-logo';
+import Gridicon from 'components/gridicon';
+import TermsOfService from 'my-sites/checkout/checkout/terms-of-service';
+import { formatDate } from './util';
+import { BEFORE_SUBMIT } from './constants';
+
+function PurchaseModalStep( { children } ) {
+	return (
+		<div className="purchase-modal__step">
+			<span className="purchase-modal__step-icon">
+				<CheckoutCheckIcon />
+			</span>
+			{ children }
+		</div>
+	);
+}
+
+function OrderStep( { siteSlug, product } ) {
+	const translate = useTranslate();
+	return (
+		<PurchaseModalStep>
+			<div className="purchase-modal__step-title">{ translate( 'Your order' ) }</div>
+			<div className="purchase-modal__step-content">
+				<div>{ translate( 'Site: %(siteSlug)s', { args: { siteSlug } } ) }</div>
+				<div className="purchase-modal__product">
+					<span className="purchase-modal__product-name">{ product?.product_name }</span>
+					<span className="purchase-modal__cost">{ product?.product_cost_display }</span>
+				</div>
+			</div>
+		</PurchaseModalStep>
+	);
+}
+
+function PaymentMethodStep( { siteSlug, card } ) {
+	const translate = useTranslate();
+	const clickHandler = useCallback( ( event ) => {
+		event.preventDefault();
+		page( event.target.href );
+	}, [] );
+	// translators: %s will be replaced with the last 4 digits of a credit card.
+	const maskedCard = sprintf( translate( '**** %s' ), card?.card || '' );
+
+	return (
+		<PurchaseModalStep>
+			<div className="purchase-modal__step-title">
+				{ translate( 'Payment method' ) }
+				<a href={ `/checkout/${ siteSlug }` } onClick={ clickHandler }>
+					{ translate( 'Edit' ) }
+				</a>
+			</div>
+			<div className="purchase-modal__step-content">
+				<div className="purchase-modal__card-holder">{ card?.name }</div>
+				<div>
+					<PaymentLogo brand={ card?.card_type } isSummary={ true } />
+					<span className="purchase-modal__card-number">{ maskedCard }</span>
+					<span className="purchase-modal__card-expiry">{ `${ translate(
+						'Expiry:'
+					) } ${ formatDate( card?.expiry ) }` }</span>
+				</div>
+			</div>
+		</PurchaseModalStep>
+	);
+}
+
+function TermsOfServiceSection() {
+	const translate = useTranslate();
+	return (
+		<>
+			<div className="purchase-modal__tos">
+				<strong>{ translate( 'By checking out:' ) }</strong>
+			</div>
+			<TermsOfService hasRenewableSubscription={ true } />
+		</>
+	);
+}
+
+function OrderReview( { shouldDisplayTax, tax, total } ) {
+	const translate = useTranslate();
+	return (
+		<dl className="purchase-modal__review">
+			{ shouldDisplayTax && <dt className="purchase-modal__tax">{ translate( 'Taxes' ) }</dt> }
+			{ shouldDisplayTax && <dd className="purchase-modal__tax">{ tax }</dd> }
+			<dt>{ translate( 'Total' ) }</dt>
+			<dd>{ total }</dd>
+		</dl>
+	);
+}
+
+function PayButton( { busy, totalCost, onClick } ) {
+	const translate = useTranslate();
+	// translators: The payText will be like "Pay $205.99".
+	const payText = sprintf( translate( 'Pay %s' ), totalCost || '…' );
+	const processingText = translate( 'Processing…' );
+
+	return (
+		<Button
+			primary={ ! busy }
+			busy={ busy }
+			disabled={ busy }
+			onClick={ onClick }
+			className="purchase-modal__pay-button"
+		>
+			{ busy ? processingText : payText }
+		</Button>
+	);
+}
+
+export default function PurchaseModalContent( {
+	cards,
+	cart,
+	onClose,
+	siteSlug,
+	step,
+	submitTransaction,
+} ) {
+	const translate = useTranslate();
+
+	return (
+		<>
+			<Button
+				borderless
+				className="purchase-modal__close"
+				aria-label={ translate( 'Close dialog' ) }
+				onClick={ onClose }
+			>
+				<Gridicon icon="cross-small" />
+			</Button>
+			<OrderStep siteSlug={ siteSlug } product={ cart.products?.[ 0 ] } />
+			<PaymentMethodStep siteSlug={ siteSlug } card={ cards?.[ 0 ] } />
+			<TermsOfServiceSection />
+			<hr />
+			<OrderReview
+				total={ cart.total_cost_display }
+				tax={ cart.total_tax_display }
+				shouldDisplayTax={ cart.tax?.display_taxes }
+			/>
+			<PayButton
+				busy={ BEFORE_SUBMIT !== step }
+				totalCost={ cart.total_cost_display }
+				onClick={ submitTransaction }
+			/>
+		</>
+	);
+}

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/content.jsx
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/content.jsx
@@ -13,7 +13,7 @@ import { Button } from '@automattic/components';
 import { CheckoutCheckIcon } from '@automattic/composite-checkout';
 import PaymentLogo from '@automattic/composite-checkout/src/lib/payment-methods/payment-logo';
 import Gridicon from 'components/gridicon';
-import TermsOfService from 'my-sites/checkout/checkout/terms-of-service';
+import CheckoutTerms from 'my-sites/checkout/checkout/checkout-terms';
 import { formatDate } from './util';
 import { BEFORE_SUBMIT } from './constants';
 
@@ -75,18 +75,6 @@ function PaymentMethodStep( { siteSlug, card } ) {
 	);
 }
 
-function TermsOfServiceSection() {
-	const translate = useTranslate();
-	return (
-		<>
-			<div className="purchase-modal__tos">
-				<strong>{ translate( 'By checking out:' ) }</strong>
-			</div>
-			<TermsOfService hasRenewableSubscription={ true } />
-		</>
-	);
-}
-
 function OrderReview( { shouldDisplayTax, tax, total } ) {
 	const translate = useTranslate();
 	return (
@@ -140,7 +128,7 @@ export default function PurchaseModalContent( {
 			</Button>
 			<OrderStep siteSlug={ siteSlug } product={ cart.products?.[ 0 ] } />
 			<PaymentMethodStep siteSlug={ siteSlug } card={ cards?.[ 0 ] } />
-			<TermsOfServiceSection />
+			<CheckoutTerms cart={ cart } />
 			<hr />
 			<OrderReview
 				total={ cart.total_cost_display }

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/index.jsx
@@ -138,7 +138,7 @@ export function PurchaseModal( { cart, cards, onComplete, onClose, siteSlug } ) 
 	} );
 
 	return (
-		<Dialog isVisible={ true } className="purchase-modal">
+		<Dialog isVisible={ true } baseClassName="purchase-modal dialog" onClose={ onClose }>
 			<Button
 				borderless
 				className="purchase-modal__close"

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/index.jsx
@@ -27,7 +27,6 @@ export function PurchaseModal( { cart, cards, isCartUpdating, onComplete, onClos
 		storedCard: cards?.[ 0 ],
 		onComplete,
 		onClose,
-		errorMessage: translate( 'Something went wrong…' ),
 		successMessage: translate( 'Your purchase has been completed!' ),
 	} );
 	const contentProps = {

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/index.jsx
@@ -1,0 +1,121 @@
+/**
+ * External dependencies
+ */
+import React, { useCallback, useEffect, useState } from 'react';
+import { useDispatch } from 'react-redux';
+import { useTranslate } from 'i18n-calypso';
+import { find, pick } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { recordTracksEvent } from 'lib/analytics/tracks';
+import { submit } from 'lib/store-transactions';
+import {
+	INPUT_VALIDATION,
+	RECEIVED_WPCOM_RESPONSE,
+	SUBMITTING_WPCOM_REQUEST,
+} from 'lib/store-transactions/step-types';
+import { preprocessCartForServer } from 'lib/cart-values';
+import { errorNotice } from 'state/notices/actions';
+import { Dialog } from '@automattic/components';
+import Spinner from 'components/spinner';
+import MaterialIcon from 'components/material-icon';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+const BEFORE_START = 'before-start';
+
+function extractStoredCardMetaValue( card, key ) {
+	return find( card.meta, [ 'meta_key', key ] )?.meta_value;
+}
+
+function generateTransactionData( cart, storedCard ) {
+	const countryCode = extractStoredCardMetaValue( storedCard, 'country_code' );
+	const postalCode = extractStoredCardMetaValue( storedCard, 'card_zip' );
+
+	return {
+		cart: {
+			...pick( cart, [ 'blog_id', 'cart_key' ] ),
+			...preprocessCartForServer( cart ),
+			create_new_blog: false,
+		},
+		domainDetails: null,
+		payment: {
+			paymentMethod: 'WPCOM_Billing_MoneyPress_Stored',
+			storedCard,
+			name: storedCard.name,
+			country: countryCode,
+			country_code: countryCode,
+			postal_code: postalCode,
+			zip: postalCode,
+		},
+	};
+}
+
+function PurchaseModalContent( { step } ) {
+	const translate = useTranslate();
+
+	if ( [ BEFORE_START, INPUT_VALIDATION, SUBMITTING_WPCOM_REQUEST ].includes( step ) ) {
+		return (
+			<>
+				<Spinner size={ 48 } />
+				<p>{ translate( 'Updating your order' ) }</p>
+			</>
+		);
+	}
+
+	if ( [ RECEIVED_WPCOM_RESPONSE ].includes( step ) ) {
+		return (
+			<>
+				<p>{ translate( 'Your order has been processed' ) }</p>
+				<MaterialIcon icon="check_circle" className="purchase-modal__success" />
+			</>
+		);
+	}
+
+	return null;
+}
+
+export function PurchaseModal( { cart, cards, onComplete, onClose } ) {
+	const [ step, setStep ] = useState( BEFORE_START );
+	const dispatch = useDispatch();
+	const onStep = useCallback(
+		( { name, data, error } ) => {
+			if ( error ) {
+				recordTracksEvent( 'calypso_oneclick_upsell_payment_error', {
+					error_code: error.code || error.error,
+					reason: error.message,
+				} );
+				dispatch( errorNotice( error.message ) );
+				onClose();
+				return;
+			}
+
+			setStep( name );
+
+			if ( RECEIVED_WPCOM_RESPONSE === name && data && ! error ) {
+				recordTracksEvent( 'calypso_oneclick_upsell_payment_success', {} );
+				onComplete?.();
+			}
+		},
+		[ step ]
+	);
+
+	useEffect( () => {
+		if ( step !== BEFORE_START ) {
+			return;
+		}
+
+		submit( generateTransactionData( cart, cards[ 0 ] ), onStep );
+	}, [ cart, cards ] );
+
+	return (
+		<Dialog isVisible={ true } className="purchase-modal">
+			<PurchaseModalContent step={ step } />
+		</Dialog>
+	);
+}

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/index.jsx
@@ -112,7 +112,13 @@ function PayButton( { busy, totalCost, onClick } ) {
 	const processingText = translate( 'Processing…' );
 
 	return (
-		<Button primary={ ! busy } busy={ busy } disabled={ busy } onClick={ onClick }>
+		<Button
+			primary={ ! busy }
+			busy={ busy }
+			disabled={ busy }
+			onClick={ onClick }
+			className="purchase-modal__pay-button"
+		>
 			{ busy ? processingText : payText }
 		</Button>
 	);
@@ -127,6 +133,8 @@ export function PurchaseModal( { cart, cards, onComplete, onClose, siteSlug } ) 
 		storedCard: cards?.[ 0 ],
 		onComplete,
 		onClose,
+		errorMessage: translate( 'Something went wrong…' ),
+		successMessage: translate( 'Your purchase has been completed!' ),
 	} );
 
 	return (

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/index.jsx
@@ -1,130 +1,24 @@
 /**
  * External dependencies
  */
-import React, { useCallback, useState } from 'react';
-import { sprintf } from '@wordpress/i18n';
+import React, { useState } from 'react';
 import { useTranslate } from 'i18n-calypso';
-import page from 'page';
 
 /**
  * Internal dependencies
  */
-import { Button, Dialog } from '@automattic/components';
-import { CheckoutCheckIcon } from '@automattic/composite-checkout';
-import PaymentLogo from '@automattic/composite-checkout/src/lib/payment-methods/payment-logo';
-import Gridicon from 'components/gridicon';
-import TermsOfService from 'my-sites/checkout/checkout/terms-of-service';
-import { formatDate, useSubmitTransaction } from './util';
+import { Dialog } from '@automattic/components';
+import { useSubmitTransaction } from './util';
+import { BEFORE_SUBMIT } from './constants';
+import Content from './content';
+import Placeholder from './placeholder';
 
 /**
  * Style dependencies
  */
 import './style.scss';
 
-const BEFORE_SUBMIT = 'before-submit';
-
-function PurchaseModalStep( { children } ) {
-	return (
-		<div className="purchase-modal__step">
-			<span className="purchase-modal__step-icon">
-				<CheckoutCheckIcon />
-			</span>
-			{ children }
-		</div>
-	);
-}
-
-function OrderStep( { siteSlug, product } ) {
-	const translate = useTranslate();
-	return (
-		<PurchaseModalStep>
-			<div className="purchase-modal__step-title">{ translate( 'Your order' ) }</div>
-			<div className="purchase-modal__step-content">
-				<div>{ translate( 'Site: %(siteSlug)s', { args: { siteSlug } } ) }</div>
-				<div className="purchase-modal__product">
-					<span className="purchase-modal__product-name">{ product?.product_name }</span>
-					<span className="purchase-modal__cost">{ product?.product_cost_display }</span>
-				</div>
-			</div>
-		</PurchaseModalStep>
-	);
-}
-
-function PaymentMethodStep( { siteSlug, card } ) {
-	const translate = useTranslate();
-	const clickHandler = useCallback( ( event ) => {
-		event.preventDefault();
-		page( event.target.href );
-	}, [] );
-	// translators: %s will be replaced with the last 4 digits of a credit card.
-	const maskedCard = sprintf( translate( '**** %s' ), card?.card || '' );
-
-	return (
-		<PurchaseModalStep>
-			<div className="purchase-modal__step-title">
-				{ translate( 'Payment method' ) }
-				<a href={ `/checkout/${ siteSlug }` } onClick={ clickHandler }>
-					{ translate( 'Edit' ) }
-				</a>
-			</div>
-			<div className="purchase-modal__step-content">
-				<div className="purchase-modal__card-holder">{ card?.name }</div>
-				<div>
-					<PaymentLogo brand={ card?.card_type } isSummary={ true } />
-					<span className="purchase-modal__card-number">{ maskedCard }</span>
-					<span className="purchase-modal__card-expiry">{ `${ translate(
-						'Expiry:'
-					) } ${ formatDate( card?.expiry ) }` }</span>
-				</div>
-			</div>
-		</PurchaseModalStep>
-	);
-}
-
-function TermsOfServiceSection() {
-	const translate = useTranslate();
-	return (
-		<>
-			<div className="purchase-modal__tos">
-				<strong>{ translate( 'By checking out:' ) }</strong>
-			</div>
-			<TermsOfService hasRenewableSubscription={ true } />
-		</>
-	);
-}
-
-function OrderReview( { shouldDisplayTax, tax, total } ) {
-	const translate = useTranslate();
-	return (
-		<dl className="purchase-modal__review">
-			{ shouldDisplayTax && <dt className="purchase-modal__tax">{ translate( 'Taxes' ) }</dt> }
-			{ shouldDisplayTax && <dd className="purchase-modal__tax">{ tax }</dd> }
-			<dt>{ translate( 'Total' ) }</dt>
-			<dd>{ total }</dd>
-		</dl>
-	);
-}
-
-function PayButton( { busy, totalCost, onClick } ) {
-	const translate = useTranslate();
-	// translators: The payText will be like "Pay $205.99".
-	const payText = sprintf( translate( 'Pay %s' ), totalCost || '…' );
-	const processingText = translate( 'Processing…' );
-
-	return (
-		<Button
-			primary={ ! busy }
-			busy={ busy }
-			disabled={ busy }
-			onClick={ onClick }
-			className="purchase-modal__pay-button"
-		>
-			{ busy ? processingText : payText }
-		</Button>
-	);
-}
-
-export function PurchaseModal( { cart, cards, onComplete, onClose, siteSlug } ) {
+export function PurchaseModal( { cart, cards, isCartUpdating, onComplete, onClose, siteSlug } ) {
 	const translate = useTranslate();
 	const [ step, setStep ] = useState( BEFORE_SUBMIT );
 	const submitTransaction = useSubmitTransaction( {
@@ -136,31 +30,18 @@ export function PurchaseModal( { cart, cards, onComplete, onClose, siteSlug } ) 
 		errorMessage: translate( 'Something went wrong…' ),
 		successMessage: translate( 'Your purchase has been completed!' ),
 	} );
+	const contentProps = {
+		cards,
+		cart,
+		onClose,
+		siteSlug,
+		step,
+		submitTransaction,
+	};
 
 	return (
 		<Dialog isVisible={ true } baseClassName="purchase-modal dialog" onClose={ onClose }>
-			<Button
-				borderless
-				className="purchase-modal__close"
-				aria-label={ translate( 'Close dialog' ) }
-				onClick={ onClose }
-			>
-				<Gridicon icon="cross-small" />
-			</Button>
-			<OrderStep siteSlug={ siteSlug } product={ cart.products?.[ 0 ] } />
-			<PaymentMethodStep siteSlug={ siteSlug } card={ cards?.[ 0 ] } />
-			<TermsOfServiceSection />
-			<hr />
-			<OrderReview
-				total={ cart.total_cost_display }
-				tax={ cart.total_tax_display }
-				shouldDisplayTax={ cart.tax?.display_taxes }
-			/>
-			<PayButton
-				busy={ BEFORE_SUBMIT !== step }
-				totalCost={ cart.total_cost_display }
-				onClick={ submitTransaction }
-			/>
+			{ isCartUpdating ? <Placeholder /> : <Content { ...contentProps } /> }
 		</Dialog>
 	);
 }

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/index.jsx
@@ -1,121 +1,158 @@
 /**
  * External dependencies
  */
-import React, { useCallback, useEffect, useState } from 'react';
-import { useDispatch } from 'react-redux';
+import React, { useCallback, useState } from 'react';
+import { sprintf } from '@wordpress/i18n';
 import { useTranslate } from 'i18n-calypso';
-import { find, pick } from 'lodash';
+import page from 'page';
 
 /**
  * Internal dependencies
  */
-import { recordTracksEvent } from 'lib/analytics/tracks';
-import { submit } from 'lib/store-transactions';
-import {
-	INPUT_VALIDATION,
-	RECEIVED_WPCOM_RESPONSE,
-	SUBMITTING_WPCOM_REQUEST,
-} from 'lib/store-transactions/step-types';
-import { preprocessCartForServer } from 'lib/cart-values';
-import { errorNotice } from 'state/notices/actions';
-import { Dialog } from '@automattic/components';
-import Spinner from 'components/spinner';
-import MaterialIcon from 'components/material-icon';
+import { Button, Dialog } from '@automattic/components';
+import { CheckoutCheckIcon } from '@automattic/composite-checkout';
+import PaymentLogo from '@automattic/composite-checkout/src/lib/payment-methods/payment-logo';
+import Gridicon from 'components/gridicon';
+import TermsOfService from 'my-sites/checkout/checkout/terms-of-service';
+import { formatDate, useSubmitTransaction } from './util';
 
 /**
  * Style dependencies
  */
 import './style.scss';
 
-const BEFORE_START = 'before-start';
+const BEFORE_SUBMIT = 'before-submit';
 
-function extractStoredCardMetaValue( card, key ) {
-	return find( card.meta, [ 'meta_key', key ] )?.meta_value;
-}
-
-function generateTransactionData( cart, storedCard ) {
-	const countryCode = extractStoredCardMetaValue( storedCard, 'country_code' );
-	const postalCode = extractStoredCardMetaValue( storedCard, 'card_zip' );
-
-	return {
-		cart: {
-			...pick( cart, [ 'blog_id', 'cart_key' ] ),
-			...preprocessCartForServer( cart ),
-			create_new_blog: false,
-		},
-		domainDetails: null,
-		payment: {
-			paymentMethod: 'WPCOM_Billing_MoneyPress_Stored',
-			storedCard,
-			name: storedCard.name,
-			country: countryCode,
-			country_code: countryCode,
-			postal_code: postalCode,
-			zip: postalCode,
-		},
-	};
-}
-
-function PurchaseModalContent( { step } ) {
-	const translate = useTranslate();
-
-	if ( [ BEFORE_START, INPUT_VALIDATION, SUBMITTING_WPCOM_REQUEST ].includes( step ) ) {
-		return (
-			<>
-				<Spinner size={ 48 } />
-				<p>{ translate( 'Updating your order' ) }</p>
-			</>
-		);
-	}
-
-	if ( [ RECEIVED_WPCOM_RESPONSE ].includes( step ) ) {
-		return (
-			<>
-				<p>{ translate( 'Your order has been processed' ) }</p>
-				<MaterialIcon icon="check_circle" className="purchase-modal__success" />
-			</>
-		);
-	}
-
-	return null;
-}
-
-export function PurchaseModal( { cart, cards, onComplete, onClose } ) {
-	const [ step, setStep ] = useState( BEFORE_START );
-	const dispatch = useDispatch();
-	const onStep = useCallback(
-		( { name, data, error } ) => {
-			if ( error ) {
-				recordTracksEvent( 'calypso_oneclick_upsell_payment_error', {
-					error_code: error.code || error.error,
-					reason: error.message,
-				} );
-				dispatch( errorNotice( error.message ) );
-				onClose();
-				return;
-			}
-
-			setStep( name );
-
-			if ( RECEIVED_WPCOM_RESPONSE === name && data && ! error ) {
-				recordTracksEvent( 'calypso_oneclick_upsell_payment_success', {} );
-				onComplete?.();
-			}
-		},
-		[ step ]
+function PurchaseModalStep( { children } ) {
+	return (
+		<div className="purchase-modal__step">
+			<span className="purchase-modal__step-icon">
+				<CheckoutCheckIcon />
+			</span>
+			{ children }
+		</div>
 	);
+}
 
-	useEffect( () => {
-		if ( step !== BEFORE_START ) {
-			return;
-		}
+function OrderStep( { siteSlug, product } ) {
+	const translate = useTranslate();
+	return (
+		<PurchaseModalStep>
+			<div className="purchase-modal__step-title">{ translate( 'Your order' ) }</div>
+			<div className="purchase-modal__step-content">
+				<div>{ translate( 'Site: %(siteSlug)s', { args: { siteSlug } } ) }</div>
+				<div className="purchase-modal__product">
+					<span className="purchase-modal__product-name">{ product?.product_name }</span>
+					<span className="purchase-modal__cost">{ product?.product_cost_display }</span>
+				</div>
+			</div>
+		</PurchaseModalStep>
+	);
+}
 
-		submit( generateTransactionData( cart, cards[ 0 ] ), onStep );
-	}, [ cart, cards ] );
+function PaymentMethodStep( { siteSlug, card } ) {
+	const translate = useTranslate();
+	const clickHandler = useCallback( ( event ) => {
+		event.preventDefault();
+		page( event.target.href );
+	}, [] );
+	// translators: %s will be replaced with the last 4 digits of a credit card.
+	const maskedCard = sprintf( translate( '**** %s' ), card?.card || '' );
+
+	return (
+		<PurchaseModalStep>
+			<div className="purchase-modal__step-title">
+				{ translate( 'Payment method' ) }
+				<a href={ `/checkout/${ siteSlug }` } onClick={ clickHandler }>
+					{ translate( 'Edit' ) }
+				</a>
+			</div>
+			<div className="purchase-modal__step-content">
+				<div className="purchase-modal__card-holder">{ card?.name }</div>
+				<div>
+					<PaymentLogo brand={ card?.card_type } isSummary={ true } />
+					<span className="purchase-modal__card-number">{ maskedCard }</span>
+					<span className="purchase-modal__card-expiry">{ `${ translate(
+						'Expiry:'
+					) } ${ formatDate( card?.expiry ) }` }</span>
+				</div>
+			</div>
+		</PurchaseModalStep>
+	);
+}
+
+function TermsOfServiceSection() {
+	const translate = useTranslate();
+	return (
+		<>
+			<div className="purchase-modal__tos">
+				<strong>{ translate( 'By checking out:' ) }</strong>
+			</div>
+			<TermsOfService hasRenewableSubscription={ true } />
+		</>
+	);
+}
+
+function OrderReview( { shouldDisplayTax, tax, total } ) {
+	const translate = useTranslate();
+	return (
+		<dl className="purchase-modal__review">
+			{ shouldDisplayTax && <dt className="purchase-modal__tax">{ translate( 'Taxes' ) }</dt> }
+			{ shouldDisplayTax && <dd className="purchase-modal__tax">{ tax }</dd> }
+			<dt>{ translate( 'Total' ) }</dt>
+			<dd>{ total }</dd>
+		</dl>
+	);
+}
+
+function PayButton( { busy, totalCost, onClick } ) {
+	const translate = useTranslate();
+	// translators: The payText will be like "Pay $205.99".
+	const payText = sprintf( translate( 'Pay %s' ), totalCost || '…' );
+	const processingText = translate( 'Processing…' );
+
+	return (
+		<Button primary={ ! busy } busy={ busy } disabled={ busy } onClick={ onClick }>
+			{ busy ? processingText : payText }
+		</Button>
+	);
+}
+
+export function PurchaseModal( { cart, cards, onComplete, onClose, siteSlug } ) {
+	const translate = useTranslate();
+	const [ step, setStep ] = useState( BEFORE_SUBMIT );
+	const submitTransaction = useSubmitTransaction( {
+		cart,
+		setStep,
+		storedCard: cards?.[ 0 ],
+		onComplete,
+		onClose,
+	} );
 
 	return (
 		<Dialog isVisible={ true } className="purchase-modal">
-			<PurchaseModalContent step={ step } />
+			<Button
+				borderless
+				className="purchase-modal__close"
+				aria-label={ translate( 'Close dialog' ) }
+				onClick={ onClose }
+			>
+				<Gridicon icon="cross-small" />
+			</Button>
+			<OrderStep siteSlug={ siteSlug } product={ cart.products?.[ 0 ] } />
+			<PaymentMethodStep siteSlug={ siteSlug } card={ cards?.[ 0 ] } />
+			<TermsOfServiceSection />
+			<hr />
+			<OrderReview
+				total={ cart.total_cost_display }
+				tax={ cart.total_tax_display }
+				shouldDisplayTax={ cart.tax?.display_taxes }
+			/>
+			<PayButton
+				busy={ BEFORE_SUBMIT !== step }
+				totalCost={ cart.total_cost_display }
+				onClick={ submitTransaction }
+			/>
 		</Dialog>
 	);
 }

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/placeholder.jsx
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/placeholder.jsx
@@ -1,0 +1,39 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+function OrderStep() {
+	return (
+		<div className="purchase-modal__step is-placeholder">
+			<span className="purchase-modal__step-icon is-placeholder"></span>
+			<div className="purchase-modal__step-title is-placeholder"></div>
+			<div className="purchase-modal__step-content is-placeholder"></div>
+		</div>
+	);
+}
+
+function OrderReview() {
+	return (
+		<dl className="purchase-modal__review is-placeholder">
+			<dt></dt>
+			<dd></dd>
+		</dl>
+	);
+}
+
+function PayButton() {
+	return <div className="purchase-modal__pay-button is-placeholder">Pay button</div>;
+}
+
+export default function PurchaseModalPlaceHolder() {
+	return (
+		<>
+			<OrderStep />
+			<OrderStep />
+			<hr />
+			<OrderReview />
+			<PayButton />
+		</>
+	);
+}

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/style.scss
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/style.scss
@@ -117,19 +117,21 @@ $left-margin: 36px;
 }
 
 /**
- * Terms of Service
+ * Checkout Terms
  */
-.purchase-modal__tos {
-	margin: $font-body-extra-small 0 0 $left-margin;
-	font-size: $font-body-extra-small;
-}
-
-.purchase-modal .checkout__terms {
+.checkout__terms,
+.checkout__concierge-refund-policy,
+.checkout__bundled-domain-notice {
 	margin: 4px 0;
 	padding-left: $left-margin;
 	position: relative;
+	font-size: $font-body-extra-small;
 
-	svg {
+	.purchase-modal__step + & {
+		margin-top: 1em;
+	}
+
+	> svg {
 		position: absolute;
 		top: 0;
 		left: ( $left-margin - 24px );

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/style.scss
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/style.scss
@@ -3,37 +3,24 @@ $left-margin: 36px;
 .purchase-modal {
 	--padding: -16px;
 
-	@media ( min-width: 480px ) {
-		--padding: -24px;
-	}
-
 	display: flex;
 	flex-direction: column;
 	align-items: flex-start;
 	width: 450px;
 
 	@media ( max-width: 480px ) {
+		--padding: -24px;
 		width: unset;
-	}
-
-	> p {
-		margin: 1em 0;
 	}
 
 	> hr {
 		width: calc( 100% + var( --padding ) * -2 );
 		margin: 16px var( --padding );
 
-		// stylelint-disable-next-line unit-whitelist
+		// stylelint-disable-next-line unit-allowed-list
 		@media screen, ( -webkit-min-device-pixel-ratio: 1.25 ), ( min-resolution: 120dpi ) {
 			height: 0.5px;
 		}
-	}
-
-	> .button.is-primary {
-		align-self: flex-end;
-		margin-top: 16px;
-		min-width: 35%;
 	}
 }
 
@@ -146,4 +133,13 @@ $left-margin: 36px;
 	font-weight: normal;
 	color: var( --color-neutral-40 );
 	font-size: $font-body-small;
+}
+
+/**
+ * Pay button
+ */
+.purchase-modal__pay-button {
+	align-self: flex-end;
+	margin-top: 16px;
+	min-width: 35%;
 }

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/style.scss
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/style.scss
@@ -1,15 +1,33 @@
 $left-margin: 36px;
 
-.purchase-modal {
-	--padding: -16px;
+@keyframes purchaseModalBackdropfadeIn {
+	0% {
+		opacity: 0;
+		transform: scale( 1.05 );
+	}
+	100% {
+		opacity: 1;
+		transform: scale( 1 );
+	}
+}
+
+.purchase-modal.dialog__backdrop {
+	animation: purchaseModalBackdropfadeIn 0.2s ease-out;
+	animation-fill-mode: backwards;
+}
+
+.purchase-modal.dialog__content {
+	--padding: -24px;
 
 	display: flex;
 	flex-direction: column;
 	align-items: flex-start;
-	width: 450px;
+	width: 460px;
+	max-width: 100%;
+	box-sizing: border-box;
 
 	@media ( max-width: 480px ) {
-		--padding: -24px;
+		--padding: -16px;
 		width: unset;
 	}
 
@@ -140,6 +158,7 @@ $left-margin: 36px;
  */
 .purchase-modal__pay-button {
 	align-self: flex-end;
-	margin-top: 16px;
+	margin-top: 32px;
 	min-width: 35%;
+	font-size: 1rem;
 }

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/style.scss
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/style.scss
@@ -1,18 +1,149 @@
+$left-margin: 36px;
+
 .purchase-modal {
+	--padding: -16px;
+
+	@media ( min-width: 480px ) {
+		--padding: -24px;
+	}
+
 	display: flex;
 	flex-direction: column;
-	align-items: center;
+	align-items: flex-start;
 	width: 450px;
-	max-width: 90%;
+
+	@media ( max-width: 480px ) {
+		width: unset;
+	}
 
 	> p {
 		margin: 1em 0;
 	}
+
+	> hr {
+		width: calc( 100% + var( --padding ) * -2 );
+		margin: 16px var( --padding );
+
+		// stylelint-disable-next-line unit-whitelist
+		@media screen, ( -webkit-min-device-pixel-ratio: 1.25 ), ( min-resolution: 120dpi ) {
+			height: 0.5px;
+		}
+	}
+
+	> .button.is-primary {
+		align-self: flex-end;
+		margin-top: 16px;
+		min-width: 35%;
+	}
 }
 
-.purchase-modal__success {
-	fill: var( --color-success );
-	width: 48px;
-	height: 48px;
+/**
+ * Close button
+ */
+.purchase-modal__close {
+	position: absolute;
+	top: 0;
+	right: 4px;
+	padding: 4px;
 }
 
+/**
+ * Order steps
+ */
+.purchase-modal__step {
+	position: relative;
+	margin: 0 0 24px $left-margin;
+	align-self: stretch;
+
+	&-icon {
+		position: absolute;
+		width: 27px;
+		height: 27px;
+		top: 0;
+		left: -$left-margin;
+		border-radius: 50%;
+		background: #008a20;
+		text-align: center;
+
+		> svg {
+			margin-top: 4px;
+		}
+	}
+}
+
+.purchase-modal__step-title {
+	> a {
+		display: inline-block;
+		margin-left: 0.5em;
+		text-decoration: underline;
+	}
+}
+
+.purchase-modal__step-content {
+	color: var( --color-neutral-40 );
+	font-size: $font-body-small;
+}
+
+.purchase-modal__product {
+	display: flex;
+	justify-content: space-between;
+	color: var( --color-neutral-60 );
+}
+
+.purchase-modal__card-number {
+	display: inline-block;
+	margin: 0 0.5em;
+}
+
+/**
+ * Terms of Service
+ */
+.purchase-modal__tos {
+	margin: $font-body-extra-small 0 0 $left-margin;
+	font-size: $font-body-extra-small;
+}
+
+.purchase-modal .checkout__terms {
+	margin: 4px 0;
+	padding-left: $left-margin;
+	position: relative;
+
+	svg {
+		position: absolute;
+		top: 0;
+		left: ( $left-margin - 24px );
+		width: 16px;
+		height: 16px;
+	}
+
+	p {
+		font-size: $font-body-extra-small;
+		margin: 0;
+		word-break: break-word;
+	}
+}
+
+/**
+ * Taxes and cost
+ */
+.purchase-modal__review {
+	display: flex;
+	align-self: stretch;
+	justify-content: space-between;
+	flex-wrap: wrap;
+
+	> dt {
+		width: 60%;
+		margin-left: $left-margin;
+	}
+
+	> dd {
+		margin: 0;
+	}
+}
+
+.purchase-modal__tax {
+	font-weight: normal;
+	color: var( --color-neutral-40 );
+	font-size: $font-body-small;
+}

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/style.scss
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/style.scss
@@ -34,6 +34,7 @@ $left-margin: 36px;
 	> hr {
 		width: calc( 100% + var( --padding ) * -2 );
 		margin: 16px var( --padding );
+		background: var( --color-neutral-5 );
 
 		// stylelint-disable-next-line unit-allowed-list
 		@media screen, ( -webkit-min-device-pixel-ratio: 1.25 ), ( min-resolution: 120dpi ) {
@@ -185,7 +186,7 @@ $left-margin: 36px;
  */
 .purchase-modal__pay-button {
 	align-self: flex-end;
-	margin-top: 32px;
+	margin-top: 24px;
 	min-width: 35%;
 	font-size: 1rem;
 

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/style.scss
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/style.scss
@@ -1,0 +1,18 @@
+.purchase-modal {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	width: 450px;
+	max-width: 90%;
+
+	> p {
+		margin: 1em 0;
+	}
+}
+
+.purchase-modal__success {
+	fill: var( --color-success );
+	width: 48px;
+	height: 48px;
+}
+

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/style.scss
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/style.scss
@@ -59,20 +59,24 @@ $left-margin: 36px;
 	position: relative;
 	margin: 0 0 24px $left-margin;
 	align-self: stretch;
+}
 
-	&-icon {
-		position: absolute;
-		width: 27px;
-		height: 27px;
-		top: 0;
-		left: -$left-margin;
-		border-radius: 50%;
-		background: #008a20;
-		text-align: center;
+.purchase-modal__step-icon {
+	position: absolute;
+	width: 27px;
+	height: 27px;
+	top: 0;
+	left: -$left-margin;
+	border-radius: 50%;
+	background: #008a20;
+	text-align: center;
 
-		> svg {
-			margin-top: 4px;
-		}
+	> svg {
+		margin-top: 4px;
+	}
+
+	&.is-placeholder {
+		@include placeholder();
 	}
 }
 
@@ -82,11 +86,22 @@ $left-margin: 36px;
 		margin-left: 0.5em;
 		text-decoration: underline;
 	}
+
+	&.is-placeholder {
+		@include placeholder();
+		width: 20em;
+	}
 }
 
 .purchase-modal__step-content {
 	color: var( --color-neutral-40 );
 	font-size: $font-body-small;
+
+	&.is-placeholder {
+		@include placeholder();
+		margin-top: 2px;
+		width: 15em;
+	}
 }
 
 .purchase-modal__product {
@@ -145,6 +160,18 @@ $left-margin: 36px;
 	> dd {
 		margin: 0;
 	}
+
+	&.is-placeholder {
+		> dt {
+			@include placeholder();
+			width: 8em;
+		}
+
+		> dd {
+			@include placeholder();
+			width: 5em;
+		}
+	}
 }
 
 .purchase-modal__tax {
@@ -161,4 +188,9 @@ $left-margin: 36px;
 	margin-top: 32px;
 	min-width: 35%;
 	font-size: 1rem;
+
+	&.is-placeholder {
+		@include placeholder();
+		height: 2rem;
+	}
 }

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/util.js
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/util.js
@@ -46,7 +46,6 @@ export function useSubmitTransaction( {
 	setStep,
 	onClose,
 	onComplete,
-	errorMessage,
 	successMessage,
 } ) {
 	return useCallback( () => {
@@ -57,7 +56,7 @@ export function useSubmitTransaction( {
 					error_code: error.code || error.error,
 					reason: error.message,
 				} );
-				notices.error( errorMessage );
+				notices.error( error.message );
 				onClose();
 				return;
 			}
@@ -72,7 +71,7 @@ export function useSubmitTransaction( {
 				onComplete?.();
 			}
 		} );
-	}, [ cart, storedCard, setStep, onClose, onComplete, errorMessage, successMessage ] );
+	}, [ cart, storedCard, setStep, onClose, onComplete, successMessage ] );
 }
 
 export function formatDate( cardExpiry ) {

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/util.js
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/util.js
@@ -1,0 +1,77 @@
+/**
+ * External dependencies
+ */
+import { useCallback } from 'react';
+import { useDispatch } from 'react-redux';
+import { find, pick } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { RECEIVED_WPCOM_RESPONSE } from 'lib/store-transactions/step-types';
+import { preprocessCartForServer } from 'lib/cart-values';
+import { submit } from 'lib/store-transactions';
+import { recordTracksEvent } from 'lib/analytics/tracks';
+import { errorNotice } from 'state/notices/actions';
+
+function extractStoredCardMetaValue( card, key ) {
+	return find( card.meta, [ 'meta_key', key ] )?.meta_value;
+}
+
+function generateTransactionData( cart, storedCard ) {
+	const countryCode = extractStoredCardMetaValue( storedCard, 'country_code' );
+	const postalCode = extractStoredCardMetaValue( storedCard, 'card_zip' );
+
+	return {
+		cart: {
+			...pick( cart, [ 'blog_id', 'cart_key' ] ),
+			...preprocessCartForServer( cart ),
+			create_new_blog: false,
+		},
+		domainDetails: null,
+		payment: {
+			paymentMethod: 'WPCOM_Billing_MoneyPress_Stored',
+			storedCard,
+			name: storedCard.name,
+			country: countryCode,
+			country_code: countryCode,
+			postal_code: postalCode,
+			zip: postalCode,
+		},
+	};
+}
+
+export function useSubmitTransaction( { cart, storedCard, setStep, onClose, onComplete } ) {
+	const dispatch = useDispatch();
+	return useCallback( () => {
+		const transactionData = generateTransactionData( cart, storedCard );
+		submit( transactionData, ( { name, data, error } ) => {
+			if ( error ) {
+				recordTracksEvent( 'calypso_oneclick_upsell_payment_error', {
+					error_code: error.code || error.error,
+					reason: error.message,
+				} );
+				dispatch( errorNotice( error.message ) );
+				onClose();
+				return;
+			}
+
+			setStep( name );
+
+			if ( RECEIVED_WPCOM_RESPONSE === name && data && ! error ) {
+				recordTracksEvent( 'calypso_oneclick_upsell_payment_success', {} );
+				onComplete?.();
+			}
+		} );
+	}, [ cart, storedCard, setStep ] );
+}
+
+export function formatDate( cardExpiry ) {
+	const expiryDate = new Date( cardExpiry );
+	const formattedDate = expiryDate.toLocaleDateString( 'en-US', {
+		month: '2-digit',
+		year: '2-digit',
+	} );
+
+	return formattedDate;
+}

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/util.js
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/util.js
@@ -72,7 +72,7 @@ export function useSubmitTransaction( {
 				onComplete?.();
 			}
 		} );
-	}, [ cart, storedCard, setStep, onClose, onComplete ] );
+	}, [ cart, storedCard, setStep, onClose, onComplete, errorMessage, successMessage ] );
 }
 
 export function formatDate( cardExpiry ) {

--- a/client/my-sites/checkout/upsell-nudge/style.scss
+++ b/client/my-sites/checkout/upsell-nudge/style.scss
@@ -28,3 +28,12 @@
     display: flex;
     justify-content: space-between;
 }
+
+.upsell-nudge__hidden {
+	position: absolute;
+	top: -9px;
+	left: -9px;
+	width: 0;
+	height: 0;
+	overflow: hidden;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds oneClickUpsell A/B test. See pcbrnV-aX-p2 for more details. 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure you're assigned to `test` group of `oneClickUpsell` abtest.
* Purchase Personal or Premium dotcom plan for your website.
* You may need to remember the receipt ID.
* Visit `/checkout/offer-quickstart-session/RECEIPT_ID/YOUR_SITE_SLUG`. Please replace RECEIPT_ID and YOUR_SITE_SLUG with your owns. It would look like `/checkout/offer-quickstart-session/1234567/testblog.woordpress.com`.
* Ensure you have one or more stored credit cards.
* Click the "Yes, I want a WordPress Expert by my side!" button.
* You should be able to see a modal dialog as below:
  <img width="788" alt="Checkout_‹_Quick_Start_Session_—_WordPress_com" src="https://user-images.githubusercontent.com/212034/94092862-c9880a80-fe56-11ea-9e7d-1260138bee12.png">
* Click on the Pay button and the transaction of purchasing Concierge Session is going to be _automatically_ processed.
* When everything goes okay, a sucess notification appears on the homepage of your site. Otherwise, an error notification appears.
  <img width="961" alt="My_Home_‹_Site_Title_—_WordPress_com" src="https://user-images.githubusercontent.com/212034/93323074-17958080-f84f-11ea-9d65-54925c3ad644.png">
