### PR TITLE
Reader: consolidate use of formatUrlForDisplay

### DIFF
--- a/client/blocks/reader-list-item/index.jsx
+++ b/client/blocks/reader-list-item/index.jsx
@@ -1,5 +1,5 @@
 /**
- * External Dependencies
+ * External dependencies
  */
 import React from 'react';
 import classnames from 'classnames';
@@ -7,7 +7,7 @@ import { flowRight as compose, isEmpty, get } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
- * Internal Dependencies
+ * Internal dependencies
  */
 import ReaderAvatar from 'blocks/reader-avatar';
 import FollowButton from 'reader/follow-button';
@@ -20,25 +20,16 @@ import {
 	getFeedUrl,
 	getSiteUrl,
 } from 'reader/get-helpers';
-import { untrailingslashit } from 'lib/route';
 import ReaderListItemPlaceholder from 'blocks/reader-list-item/placeholder';
 import { recordTrack, recordTrackWithRailcar } from 'reader/stats';
 import ExternalLink from 'components/external-link';
 import { withLocalizedMoment } from 'components/localized-moment';
+import { formatUrlForDisplay } from 'reader/lib/feed-display-helper';
 
 /**
  * Style dependencies
  */
 import './style.scss';
-
-/**
- * Takes in a string and removes the starting https, www., and removes a trailing slash
- *
- * @param {string} url - the url to format
- * @returns {string} - the formatted url.  e.g. "https://www.wordpress.com/" --> "wordpress.com"
- */
-const formatUrlForDisplay = ( url ) =>
-	untrailingslashit( url.replace( /^https?:\/\/(www\.)?/, '' ) );
 
 function ReaderListItem( {
 	moment,

--- a/client/blocks/reader-subscription-list-item/index.jsx
+++ b/client/blocks/reader-subscription-list-item/index.jsx
@@ -1,5 +1,5 @@
 /**
- * External Dependencies
+ * External dependencies
  */
 import React from 'react';
 import classnames from 'classnames';
@@ -7,7 +7,7 @@ import { flowRight as compose, isEmpty, get } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
- * Internal Dependencies
+ * Internal dependencies
  */
 import ReaderAvatar from 'blocks/reader-avatar';
 import FollowButton from 'reader/follow-button';
@@ -20,25 +20,16 @@ import {
 	getFeedUrl,
 	getSiteUrl,
 } from 'reader/get-helpers';
-import { untrailingslashit } from 'lib/route';
 import ReaderSubscriptionListItemPlaceholder from 'blocks/reader-subscription-list-item/placeholder';
 import { recordTrack, recordTrackWithRailcar } from 'reader/stats';
 import ExternalLink from 'components/external-link';
 import { withLocalizedMoment } from 'components/localized-moment';
+import { formatUrlForDisplay } from 'reader/lib/feed-display-helper';
 
 /**
  * Style dependencies
  */
 import './style.scss';
-
-/**
- * Takes in a string and removes the starting https, www., and removes a trailing slash
- *
- * @param {string} url - the url to format
- * @returns {string} - the formatted url.  e.g. "https://www.wordpress.com/" --> "wordpress.com"
- */
-const formatUrlForDisplay = ( url ) =>
-	untrailingslashit( url.replace( /^https?:\/\/(www\.)?/, '' ) );
 
 function ReaderSubscriptionListItem( {
 	moment,

--- a/client/reader/lib/feed-display-helper/index.js
+++ b/client/reader/lib/feed-display-helper/index.js
@@ -2,15 +2,20 @@
  * Internal dependencies
  */
 import { getSiteUrl as getSiteUrlFromRoute, getFeedUrl } from 'reader/route';
-import { withoutHttp } from 'lib/url';
 
 const exported = {
+	/**
+	 * Remove the starting https, www. and trailing slash from a URL string
+	 *
+	 * @param {string} url URL to format
+	 * @returns {string} Formatted URL e.g. "https://www.wordpress.com/" --> "wordpress.com"
+	 */
 	formatUrlForDisplay: function ( url ) {
 		if ( ! url ) {
 			return;
 		}
 
-		return withoutHttp( url ).replace( /\/$/, '' );
+		return url.replace( /^https?:\/\/(www\.)?/, '' ).replace( /\/$/, '' );
 	},
 
 	// Use either the site name, feed name or display URL for the feed name


### PR DESCRIPTION
#### Changes proposed in this Pull Request

While working on https://github.com/Automattic/wp-calypso/pull/45348, I noticed that in Reader we have three functions called `formatUrlForDisplay` and that they format things slightly differently (some with `www.`, some without).

For consistency's sake and to DRY things up, I have settled on a single implementation.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Ensure your subscriptions load correctly at http://calypso.localhost:3000/following/manage.
