### PR TITLE
My Home: Update Stats Text for Sites Under a Week Old

### DIFF
--- a/client/my-sites/customer-home/cards/features/stats/index.jsx
+++ b/client/my-sites/customer-home/cards/features/stats/index.jsx
@@ -46,6 +46,7 @@ export const StatsV2 = ( {
 	isSiteUnlaunched,
 	mostPopularDay,
 	mostPopularTime,
+	siteCreatedAt,
 	siteId,
 	siteSlug,
 	topPage,
@@ -67,6 +68,12 @@ export const StatsV2 = ( {
 			dispatch( requestChartCounts( chartQuery ) );
 		}
 	}, [ isSiteUnlaunched ] );
+
+	const WEEK_IN_MS = 7 * 24 * 60 * 60 * 1000;
+	const siteOlderThanAWeek = Date.now() - new Date( siteCreatedAt ).getTime() > WEEK_IN_MS;
+	const statsPlaceholderMessage = siteOlderThanAWeek
+		? translate( "No traffic this week, but don't give up!" )
+		: translate( "No traffic yet, but you'll get there!" );
 
 	return (
 		<div className="stats">
@@ -99,7 +106,7 @@ export const StatsV2 = ( {
 				) }
 				{ ! isSiteUnlaunched && ( isLoading || views === 0 ) && (
 					<Chart data={ placeholderChartData } isPlaceholder>
-						{ isLoading ? <Spinner /> : translate( "No traffic this week, but don't give up!" ) }
+						{ isLoading ? <Spinner /> : statsPlaceholderMessage }
 					</Chart>
 				) }
 				{ ! isSiteUnlaunched && ! isLoading && views === 0 && (
@@ -258,6 +265,7 @@ const mapStateToProps = ( state ) => {
 	const siteId = getSelectedSiteId( state );
 	const siteSlug = getSelectedSiteSlug( state );
 	const isSiteUnlaunched = isUnlaunchedSite( state, siteId );
+	const siteCreatedAt = getSiteOption( state, siteId, 'created_at' );
 
 	const { chartQuery, insightsQuery, topPostsQuery, visitsQuery } = getStatsQueries(
 		state,
@@ -284,6 +292,7 @@ const mapStateToProps = ( state ) => {
 		insightsQuery,
 		isLoading: canShowStatsData ? statsData.chartData.length !== chartQuery.quantity : isLoading,
 		isSiteUnlaunched,
+		siteCreatedAt,
 		siteId,
 		siteSlug,
 		topPostsQuery,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Switches the wording of the Stats placeholder on My Home to the one in the original issue 

#### Testing instructions

Verify that the text is updated for sites under a week old - there should also be no changes to sites that are any older. 

<img width="726" alt="Screenshot 2020-09-02 at 08 10 54" src="https://user-images.githubusercontent.com/43215253/91943282-3e52a380-ecf4-11ea-9b78-0a878e099d3e.png">

cc @mmtr 

Fixes #45327
