### PR TITLE
Collect RUM stats for 100% users

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -4,11 +4,6 @@
  * paths here (e.g. `import * from '../../lib/`)
  */
 
-/**
- * Internal dependencies
- */
-import * as RUM_DATA_COLLECTION from '../../lib/performance-tracking/const';
-
 export default {
 	cartNudgeUpdateToPremium: {
 		datestamp: '20180917',
@@ -185,16 +180,6 @@ export default {
 			'VN',
 			'ZA',
 		],
-	},
-	[ RUM_DATA_COLLECTION.AB_NAME ]: {
-		datestamp: '20200602',
-		variations: {
-			[ RUM_DATA_COLLECTION.AB_VARIATION_ON ]: 50,
-			[ RUM_DATA_COLLECTION.AB_VARIATION_OFF ]: 50,
-		},
-		defaultVariation: RUM_DATA_COLLECTION.AB_VARIATION_OFF,
-		localeTargets: 'any',
-		allowExistingUsers: true,
 	},
 	showBusinessPlanBump: {
 		datestamp: '20300619',

--- a/client/lib/performance-tracking/README.md
+++ b/client/lib/performance-tracking/README.md
@@ -9,7 +9,7 @@ This lib provides wrappers around `@automattic/browser-data-collector`
 
 It provides a function `startPerformanceTracking()` that accepts the name of the page being tracked and a flag for full page loads. It is a simple
 wrapper around the `start` method in `@automattic/browser-data-collector` with an additional check to validate that the performance tracking is
-enabled for this environment (by checking the feature flag `rum-tracking/logstash`) and user (by checking the abtest `rumDataCollection`).
+enabled for this environment (by checking the feature flag `rum-tracking/logstash`).
 
 Unless there is a specialized wrapper (eg: middleware `performanceTrackerStart`), using this function is the recommended approach to track performance
 of loading pages in Calypso.

--- a/client/lib/performance-tracking/const.js
+++ b/client/lib/performance-tracking/const.js
@@ -1,1 +1,0 @@
-export const CONFIG_NAME = 'rum-tracking/logstash';

--- a/client/lib/performance-tracking/const.js
+++ b/client/lib/performance-tracking/const.js
@@ -1,4 +1,1 @@
 export const CONFIG_NAME = 'rum-tracking/logstash';
-export const AB_NAME = 'rumDataCollection';
-export const AB_VARIATION_ON = 'collectData';
-export const AB_VARIATION_OFF = 'noData';

--- a/client/lib/performance-tracking/lib.js
+++ b/client/lib/performance-tracking/lib.js
@@ -7,7 +7,6 @@ import { start, stop } from '@automattic/browser-data-collector';
  * Internal dependencies
  */
 import config from 'config';
-import { CONFIG_NAME } from './const';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite, isSingleUserSite } from 'state/sites/selectors';
 import isSiteWpcomAtomic from 'state/selectors/is-site-wpcom-atomic';
@@ -46,7 +45,7 @@ const buildMetadataCollector = ( metadata = {} ) => {
 };
 
 const isPerformanceTrackingEnabled = () => {
-	return config.isEnabled( CONFIG_NAME );
+	return config.isEnabled( 'rum-tracking/logstash' );
 };
 
 export const startPerformanceTracking = ( name, { fullPageLoad = false } = {} ) => {

--- a/client/lib/performance-tracking/lib.js
+++ b/client/lib/performance-tracking/lib.js
@@ -7,8 +7,7 @@ import { start, stop } from '@automattic/browser-data-collector';
  * Internal dependencies
  */
 import config from 'config';
-import { abtest } from 'lib/abtest';
-import { CONFIG_NAME, AB_NAME, AB_VARIATION_ON } from './const';
+import { CONFIG_NAME } from './const';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite, isSingleUserSite } from 'state/sites/selectors';
 import isSiteWpcomAtomic from 'state/selectors/is-site-wpcom-atomic';
@@ -47,9 +46,7 @@ const buildMetadataCollector = ( metadata = {} ) => {
 };
 
 const isPerformanceTrackingEnabled = () => {
-	const isEnabledForEnvironment = config.isEnabled( CONFIG_NAME );
-	const isEnabledForCurrentInteraction = abtest( AB_NAME ) === AB_VARIATION_ON;
-	return isEnabledForEnvironment && isEnabledForCurrentInteraction;
+	return config.isEnabled( CONFIG_NAME );
 };
 
 export const startPerformanceTracking = ( name, { fullPageLoad = false } = {} ) => {

--- a/client/lib/performance-tracking/test/lib.js
+++ b/client/lib/performance-tracking/test/lib.js
@@ -8,7 +8,6 @@ import { start, stop } from '@automattic/browser-data-collector';
  */
 import config from 'config';
 import { startPerformanceTracking, stopPerformanceTracking } from '../lib';
-import { abtest } from 'lib/abtest';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite, isSingleUserSite } from 'state/sites/selectors';
 import isSiteWpcomAtomic from 'state/selectors/is-site-wpcom-atomic';
@@ -19,9 +18,6 @@ jest.mock( 'config', () => ( {
 jest.mock( '@automattic/browser-data-collector', () => ( {
 	start: jest.fn(),
 	stop: jest.fn(),
-} ) );
-jest.mock( 'lib/abtest', () => ( {
-	abtest: jest.fn(),
 } ) );
 jest.mock( 'state/ui/selectors', () => ( {
 	getSelectedSiteId: jest.fn(),
@@ -36,16 +32,10 @@ const withFeatureEnabled = () =>
 	config.isEnabled.mockImplementation( ( key ) => key === 'rum-tracking/logstash' );
 const withFeatureDisabled = () =>
 	config.isEnabled.mockImplementation( ( key ) => key !== 'rum-tracking/logstash' );
-const withABTestEnabled = () =>
-	abtest.mockImplementation( ( test ) =>
-		test === 'rumDataCollection' ? 'collectData' : 'noData'
-	);
-const withABTestDisabled = () => abtest.mockImplementation( () => 'noData' );
 
 describe( 'startPerformanceTracking', () => {
 	beforeEach( () => {
 		withFeatureEnabled();
-		withABTestEnabled();
 	} );
 
 	afterEach( () => {
@@ -60,14 +50,6 @@ describe( 'startPerformanceTracking', () => {
 
 	it( 'do not start measuring when the config flag is off', () => {
 		withFeatureDisabled();
-
-		startPerformanceTracking( 'pageName' );
-
-		expect( start ).not.toHaveBeenCalled();
-	} );
-
-	it( 'do not start measuring when the abtest is disabled', () => {
-		withABTestDisabled();
 
 		startPerformanceTracking( 'pageName' );
 
@@ -111,7 +93,6 @@ describe( 'startPerformanceTracking', () => {
 describe( 'stopPerformanceTracking', () => {
 	beforeEach( () => {
 		withFeatureEnabled();
-		withABTestEnabled();
 	} );
 
 	afterEach( () => {
@@ -126,14 +107,6 @@ describe( 'stopPerformanceTracking', () => {
 
 	it( 'do not stop measuring when the config flag is off', () => {
 		withFeatureDisabled();
-
-		stopPerformanceTracking( 'pageName' );
-
-		expect( stop ).not.toHaveBeenCalled();
-	} );
-
-	it( 'do not stop measuring when the abtest is disabled', () => {
-		withABTestDisabled();
 
 		stopPerformanceTracking( 'pageName' );
 


### PR DESCRIPTION
### Background

When we introduced RUM for Calypso, we initially open it to a subset of users (https://github.com/Automattic/wp-calypso/pull/43182).

Opening it to 100% will give us more samples for low-traffic pages, making the results more statistically significant.

### Changes

* Remove abtest for RUM

### Testing

Open calypso.live page, verify there is no abtest for RUM and still you get a request to `/logstash` with RUM data when you navigate to the Reader.
