### PR TITLE
Update/lazy load gutenboarding plans

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/edit.tsx
+++ b/client/landing/gutenboarding/onboarding-block/edit.tsx
@@ -12,7 +12,7 @@ import { isEnabled } from 'config';
  */
 import { STORE_KEY } from '../stores/onboard';
 import { SITE_STORE } from '../stores/site';
-import AsyncLoad from '../../../components/async-load';
+import Plans from './plans';
 import DesignSelector from './design-selector';
 import CreateSite from './create-site';
 import CreateSiteError from './create-site-error';
@@ -118,22 +118,11 @@ const OnboardingEdit: React.FunctionComponent< BlockEditProps< Attributes > > = 
 				</Route>
 
 				<Route path={ makePath( Step.Plans ) }>
-					{ canUseStyleStep() ? (
-						<AsyncLoad
-							require="landing/gutenboarding/onboarding-block/plans/index"
-							placeholder={ null }
-						/>
-					) : (
-						redirectToLatestStep
-					) }
+					{ canUseStyleStep() ? <Plans /> : redirectToLatestStep }
 				</Route>
 
 				<Route path={ makePath( Step.PlansModal ) }>
-					<AsyncLoad
-						require="landing/gutenboarding/onboarding-block/plans/index"
-						placeholder={ null }
-						isModal
-					/>
+					<Plans isModal />
 				</Route>
 
 				<Route path={ makePath( Step.LanguageModal ) }>

--- a/client/landing/gutenboarding/onboarding-block/edit.tsx
+++ b/client/landing/gutenboarding/onboarding-block/edit.tsx
@@ -12,7 +12,6 @@ import { isEnabled } from 'config';
  */
 import { STORE_KEY } from '../stores/onboard';
 import { SITE_STORE } from '../stores/site';
-import Plans from './plans';
 import DesignSelector from './design-selector';
 import CreateSite from './create-site';
 import CreateSiteError from './create-site-error';
@@ -21,6 +20,7 @@ import { Step, usePath, useNewQueryParam } from '../path';
 import AcquireIntent from './acquire-intent';
 import StylePreview from './style-preview';
 import Features from './features';
+import Plans from './plans';
 import Domains from './domains';
 import Language from './language';
 

--- a/client/landing/gutenboarding/onboarding-block/edit.tsx
+++ b/client/landing/gutenboarding/onboarding-block/edit.tsx
@@ -12,6 +12,7 @@ import { isEnabled } from 'config';
  */
 import { STORE_KEY } from '../stores/onboard';
 import { SITE_STORE } from '../stores/site';
+import AsyncLoad from '../../../components/async-load';
 import DesignSelector from './design-selector';
 import CreateSite from './create-site';
 import CreateSiteError from './create-site-error';
@@ -20,7 +21,6 @@ import { Step, usePath, useNewQueryParam } from '../path';
 import AcquireIntent from './acquire-intent';
 import StylePreview from './style-preview';
 import Features from './features';
-import Plans from './plans';
 import Domains from './domains';
 import Language from './language';
 
@@ -118,11 +118,22 @@ const OnboardingEdit: React.FunctionComponent< BlockEditProps< Attributes > > = 
 				</Route>
 
 				<Route path={ makePath( Step.Plans ) }>
-					{ canUseStyleStep() ? <Plans /> : redirectToLatestStep }
+					{ canUseStyleStep() ? (
+						<AsyncLoad
+							require="landing/gutenboarding/onboarding-block/plans/index"
+							placeholder={ null }
+						/>
+					) : (
+						redirectToLatestStep
+					) }
 				</Route>
 
 				<Route path={ makePath( Step.PlansModal ) }>
-					<Plans isModal />
+					<AsyncLoad
+						require="landing/gutenboarding/onboarding-block/plans/index"
+						placeholder={ null }
+						isModal
+					/>
 				</Route>
 
 				<Route path={ makePath( Step.LanguageModal ) }>

--- a/client/landing/gutenboarding/onboarding-block/plans/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/plans/index.tsx
@@ -19,7 +19,7 @@ import { STORE_KEY as ONBOARD_STORE } from '../../stores/onboard';
 import { PLANS_STORE } from '../../stores/plans';
 import { Step, usePath } from '../../path';
 import { useFreeDomainSuggestion } from '../../hooks/use-free-domain-suggestion';
-import AsyncLoad from '../../../../components/async-load';
+import AsyncLoad from 'components/async-load';
 
 type PlanSlug = Plans.PlanSlug;
 

--- a/client/landing/gutenboarding/onboarding-block/plans/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/plans/index.tsx
@@ -6,7 +6,6 @@ import { isEnabled } from 'config';
 import { useHistory } from 'react-router-dom';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useI18n } from '@automattic/react-i18n';
-import PlansGrid from '@automattic/plans-grid';
 import type { Plans } from '@automattic/data-stores';
 import { Title, SubTitle, ActionButtons, BackButton } from '@automattic/onboarding';
 
@@ -20,6 +19,7 @@ import { STORE_KEY as ONBOARD_STORE } from '../../stores/onboard';
 import { PLANS_STORE } from '../../stores/plans';
 import { Step, usePath } from '../../path';
 import { useFreeDomainSuggestion } from '../../hooks/use-free-domain-suggestion';
+import AsyncLoad from '../../../../components/async-load';
 
 type PlanSlug = Plans.PlanSlug;
 
@@ -90,7 +90,9 @@ const PlansStep: React.FunctionComponent< Props > = ( { isModal } ) => {
 
 	return (
 		<div className="gutenboarding-page plans">
-			<PlansGrid
+			<AsyncLoad
+				require="@automattic/plans-grid"
+				placeholder={ null }
 				header={ header }
 				currentDomain={ domain }
 				onPlanSelect={ handlePlanSelect }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Lazy loading in the `<PlansGrid />` component to reduce bundle size.

#### Testing instructions

* Start the Gutenboarding experience by going to [/new](https://hash-845e5937054bbb0d9c7a7cc3879e257c349fef5c.calypso.live/new)
* Go through the experience until you see "View plans" in the top right on the [new/design](https://hash-845e5937054bbb0d9c7a7cc3879e257c349fef5c.calypso.live/new/design) step.
* Open DevTools > Network > Filter: "async"
* Click "View plans" and you should see the network request for `async-load-automattic-plans-grid.js` whilst also seeing the "Choose a plan" page loading correctly.

Fixes https://github.com/Automattic/wp-calypso/issues/41481
