### PR TITLE
Update Live Chat Support to be lowercase for plan data

### DIFF
--- a/packages/data-stores/src/plans/plans-data.ts
+++ b/packages/data-stores/src/plans/plans-data.ts
@@ -11,7 +11,7 @@ import type { Plan } from './types';
 
 const mainFeatures = [
 	'Remove WordPress.com ads',
-	'Email & basic Live Chat Support',
+	'Email & basic live chat support',
 	'Collect recurring payments',
 	'Collect one-time payments',
 	'Earn ad revenue',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update Live Chat Support to be lowercase for plan data

**Before:**
<img width="1463" alt="Screenshot 2020-09-02 at 14 48 38" src="https://user-images.githubusercontent.com/8639742/91991950-77f2d100-ed2b-11ea-8603-f4381c845d90.png">

**After:**
<img width="1468" alt="Screenshot 2020-09-02 at 14 48 50" src="https://user-images.githubusercontent.com/8639742/91991997-8214cf80-ed2b-11ea-8403-9448bfcf7052.png">

#### Testing instructions

* Enter Gutenboarding experience [url here]
* Progress through steps until Plans step [url here]
* What once was "Email & basic Live Chat Support" should now read "Email & basic live chat support" under each paid plan.

Fixes https://github.com/Automattic/wp-calypso/issues/42586
