### PR TITLE
Components: Remove global input[type='search'] styles

### DIFF
--- a/client/assets/stylesheets/shared/_forms.scss
+++ b/client/assets/stylesheets/shared/_forms.scss
@@ -7,7 +7,6 @@ form {
 	@extend %form;
 }
 input[type='text'],
-input[type='search'],
 input[type='email'],
 input[type='number'],
 input[type='password'],
@@ -22,7 +21,6 @@ textarea {
 
 fieldset,
 input[type='text'],
-input[type='search'],
 input[type='email'],
 input[type='number'],
 input[type='password'],
@@ -179,12 +177,4 @@ select {
 		color: transparent;
 		text-shadow: 0 0 0 var( --color-neutral-70 );
 	}
-}
-
-/*Search Inputs*/
-input[type='search']::-webkit-search-decoration {
-	// We don't use the native results="" UI
-	// Ensures the input text is flush to the start of the element, as in regular text inputs
-	// See, for example, http://geek.michaelgrace.org/2011/06/webkit-search-input-styling/
-	display: none;
 }

--- a/client/blocks/term-tree-selector/search.jsx
+++ b/client/blocks/term-tree-selector/search.jsx
@@ -7,6 +7,11 @@ import React from 'react';
 import Gridicon from 'components/gridicon';
 
 /**
+ * Internal dependencies
+ */
+import FormTextInput from 'components/forms/form-text-input';
+
+/**
  * Style dependencies
  */
 import './search.scss';
@@ -17,7 +22,7 @@ function TermTreeSelectorSearch( { searchTerm, onSearch } ) {
 	return (
 		<div className="term-tree-selector__search">
 			<Gridicon icon="search" size={ 18 } />
-			<input
+			<FormTextInput
 				type="search"
 				placeholder={ translate( 'Search…', { textOnly: true } ) }
 				value={ searchTerm }

--- a/client/components/forms/form-text-input/style.scss
+++ b/client/components/forms/form-text-input/style.scss
@@ -1,12 +1,20 @@
 .form-text-input {
 	@at-root {
-		input[type='url'] {
+		input[type='url'],
+		input[type='search'] {
 			@extend %form-field;
 
 			appearance: none;
 
 			/*!rtl:ignore*/
 			direction: ltr;
+		}
+
+		input[type='search']::-webkit-search-decoration {
+			// We don't use the native results="" UI
+			// Ensures the input text is flush to the start of the element, as in regular text inputs
+			// See, for example, http://geek.michaelgrace.org/2011/06/webkit-search-input-styling/
+			display: none;
 		}
 	}
 }

--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -11,6 +11,7 @@ import i18n from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import FormTextInput from 'components/forms/form-text-input';
 import Gridicon from 'components/gridicon';
 import Spinner from 'components/spinner';
 import TranslatableString from 'components/translatable/proptype';
@@ -349,7 +350,7 @@ class Search extends Component {
 					{ ! this.props.hideOpenIcon && <Gridicon icon="search" className="search__open-icon" /> }
 				</div>
 				<div className={ fadeDivClass }>
-					<input
+					<FormTextInput
 						type="search"
 						id={ 'search-component-' + this.instanceId }
 						autoFocus={ this.props.autoFocus } // eslint-disable-line jsx-a11y/no-autofocus

--- a/client/my-sites/post-selector/search.jsx
+++ b/client/my-sites/post-selector/search.jsx
@@ -7,6 +7,11 @@ import { localize } from 'i18n-calypso';
 import React from 'react';
 import Gridicon from 'components/gridicon';
 
+/**
+ * Internal dependencies
+ */
+import FormTextInput from 'components/forms/form-text-input';
+
 class PostSelectorSearch extends React.Component {
 	static displayName = 'PostSelectorSearch';
 
@@ -19,7 +24,7 @@ class PostSelectorSearch extends React.Component {
 		return (
 			<div className="post-selector__search">
 				<Gridicon icon="search" size={ 18 } />
-				<input
+				<FormTextInput
 					type="search"
 					placeholder={ this.props.translate( 'Search…', { textOnly: true } ) }
 					value={ this.props.searchTerm }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove global form `input[type='search']` styles in favor of more specific component-level styling. See #45259

#### Testing instructions

* Test the following against production and ensure that they match stylistically and functionally:
  * `/devdocs/blocks/post-selector` - the search form at the top of the component
  * `/settings/podcasting/:site` - the taxonomy term search form at the top
  * `/devdocs/design/search` - the search form in both example instances
* Verify all `<input type="search" />` use `<FormTextInput />`.
