### PR TITLE
Fix styling issues in Jetpack connect-in-place page

### DIFF
--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -1279,6 +1279,8 @@ body.is-section-jetpack-connect .layout {
 
 		width: 100%;
 		max-width: none;
+
+		border-bottom: solid 1px #333;
 	}
 
 	.select-dropdown .select-dropdown__header {

--- a/client/my-sites/plans-v2/details.tsx
+++ b/client/my-sites/plans-v2/details.tsx
@@ -118,14 +118,14 @@ const DetailsPage = ( { duration, productSlug, rootUrl, header, footer }: Detail
 							return null;
 						}
 						return (
-							<ProductCard
-								key={ subtypeSlug }
-								item={ subtypeItem }
-								siteId={ siteId }
-								currencyCode={ currencyCode as string }
-								onClick={ () => selectProduct( subtypeItem ) }
-								className="details__column"
-							/>
+							<div key={ subtypeSlug } className="details__column">
+								<ProductCard
+									item={ subtypeItem }
+									siteId={ siteId }
+									currencyCode={ currencyCode as string }
+									onClick={ () => selectProduct( subtypeItem ) }
+								/>
+							</div>
 						);
 					} )
 				) }

--- a/client/my-sites/plans-v2/selector.tsx
+++ b/client/my-sites/plans-v2/selector.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import page from 'page';
 
@@ -79,9 +79,12 @@ const SelectorPage = ( {
 		checkout( siteSlug, product.productSlug );
 	};
 
-	const isInConnectFlow =
-		/jetpack\/connect\/plans/.test( window.location.href ) &&
-		/source=jetpack-connect-plans/.test( window.location.href );
+	const isInConnectFlow = useMemo(
+		() =>
+			/jetpack\/connect\/plans/.test( window.location.href ) ||
+			/source=jetpack-connect-plans/.test( window.location.href ),
+		[]
+	);
 
 	const showJetpackFreeCard = isInConnectFlow || isJetpackCloud();
 

--- a/client/my-sites/plans-v2/style.scss
+++ b/client/my-sites/plans-v2/style.scss
@@ -5,6 +5,8 @@
 	.plans-v2__columns {
 		display: flex;
 
+		margin-bottom: 24px;
+
 		& > .plans-column,
 		& > .details__column {
 			flex-basis: 50%;
@@ -42,6 +44,11 @@
 /**
  * Upsell
  */
+
+.upsell.main {
+	padding-bottom: 0;
+	margin-bottom: 24px;
+}
 
 .upsell__header-placeholder {
 	@include placeholder( --color-neutral-10 );


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR does 3 things (see captures):

1. it standardizes the spacing above the payment methods amongst pages
2. it adds a bottom border to the filter bar, when docked to the top of the page
3. it displays the Jetpack Free card

### Testing instructions

Visit `/jetpack/connect/plans/:site` with the offer reset flow enabled

1. Check that the spacing above the payment methods is the same in the selector, details, and upsell pages
2. Check that the filter bar has a border when it's docked to the top of the page
3. Check that the Jetpack Free card is displayed

### Screenshots

Payment methods
_Before_
<img width="515" alt="Screen Shot 2020-09-02 at 10 11 37 AM" src="https://user-images.githubusercontent.com/1620183/91999685-a7451600-ed0a-11ea-9fc4-0f8fbebc45ec.png">

_After_
<img width="537" alt="Screen Shot 2020-09-02 at 10 11 50 AM" src="https://user-images.githubusercontent.com/1620183/91999691-aa400680-ed0a-11ea-84e4-010e688598d9.png">


Filter bar border
<img width="893" alt="Screen Shot 2020-09-02 at 10 48 51 AM" src="https://user-images.githubusercontent.com/1620183/91999627-9ac0bd80-ed0a-11ea-8650-ff45373b6f5d.png">


Jetpack Free card
<img width="876" alt="Screen Shot 2020-09-02 at 10 48 45 AM" src="https://user-images.githubusercontent.com/1620183/91999601-93011900-ed0a-11ea-869f-08fc7799662a.png">
