### PR TITLE
Site Editor: fix loading order on Dotcom after 8.9.0 update

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -47,7 +47,11 @@ function load_core_site_editor() {
 	require_once __DIR__ . '/site-editor/index.php';
 	initialize_site_editor();
 }
-add_action( 'plugins_loaded', __NAMESPACE__ . '\load_core_site_editor' );
+// Change priority so this code is loaded before Gutenberg. This is needed because
+// FSE files are conditionally loaded based on the existence of experiment option
+// as of https://github.com/WordPress/gutenberg/pull/24182. initialize_site_editor
+// is setting the required option and needs to kick in first.
+add_action( 'plugins_loaded', __NAMESPACE__ . '\load_core_site_editor', 7 );
 
 /**
  * Load dotcom-FSE.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes the broken site editor on Dotcom by making sure that experiment option is
overridden on time.

#### Testing instructions

1. Make sure that you are using the site with Gutenberg edge sticker.
2. Apply the generated patch and make sure that the site editor loads.