### PR TITLE
Fix Jetpack Free card styling issues

### DIFF
--- a/client/components/jetpack/card/jetpack-free-card/index.tsx
+++ b/client/components/jetpack/card/jetpack-free-card/index.tsx
@@ -2,23 +2,20 @@
  * External dependencies
  */
 import React, { FunctionComponent } from 'react';
-import { useSelector } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
 import { Button } from '@automattic/components';
-
-/**
- * Internal dependencies
- */
-import getJetpackWpAdminUrl from 'state/selectors/get-jetpack-wp-admin-url';
 
 /**
  * Style dependencies
  */
 import './style.scss';
 
-const JetpackFreeCard: FunctionComponent = () => {
+type Props = {
+	buttonUrl: string;
+};
+
+const JetpackFreeCard: FunctionComponent< Props > = ( { buttonUrl } ) => {
 	const translate = useTranslate();
-	const wpAdminUrl = useSelector( getJetpackWpAdminUrl );
 
 	return (
 		<div className="jetpack-free-card">
@@ -36,7 +33,11 @@ const JetpackFreeCard: FunctionComponent = () => {
 						}
 					) }
 				</p>
-				<Button href={ wpAdminUrl }>{ translate( 'Start for free' ) }</Button>
+				{ buttonUrl && (
+					<Button className="jetpack-free-card__button" href={ buttonUrl } type="button">
+						{ translate( 'Start for free' ) }
+					</Button>
+				) }
 			</div>
 		</div>
 	);

--- a/client/components/jetpack/card/jetpack-free-card/index.tsx
+++ b/client/components/jetpack/card/jetpack-free-card/index.tsx
@@ -2,20 +2,24 @@
  * External dependencies
  */
 import React, { FunctionComponent } from 'react';
+import { useSelector } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
 import { Button } from '@automattic/components';
+
+/**
+ * Internal dependencies
+ */
+import { JPC_PATH_REMOTE_INSTALL } from 'jetpack-connect/constants';
+import getJetpackWpAdminUrl from 'state/selectors/get-jetpack-wp-admin-url';
 
 /**
  * Style dependencies
  */
 import './style.scss';
 
-type Props = {
-	buttonUrl: string;
-};
-
-const JetpackFreeCard: FunctionComponent< Props > = ( { buttonUrl } ) => {
+const JetpackFreeCard: FunctionComponent = () => {
 	const translate = useTranslate();
+	const wpAdminUrl = useSelector( getJetpackWpAdminUrl );
 
 	return (
 		<div className="jetpack-free-card">
@@ -33,11 +37,12 @@ const JetpackFreeCard: FunctionComponent< Props > = ( { buttonUrl } ) => {
 						}
 					) }
 				</p>
-				{ buttonUrl && (
-					<Button className="jetpack-free-card__button" href={ buttonUrl } type="button">
-						{ translate( 'Start for free' ) }
-					</Button>
-				) }
+				<Button
+					className="jetpack-free-card__button"
+					href={ wpAdminUrl || JPC_PATH_REMOTE_INSTALL }
+				>
+					{ translate( 'Start for free' ) }
+				</Button>
 			</div>
 		</div>
 	);

--- a/client/components/jetpack/card/jetpack-free-card/style.scss
+++ b/client/components/jetpack/card/jetpack-free-card/style.scss
@@ -29,24 +29,29 @@
 .jetpack-free-card__body {
 	padding: 24px 16px;
 
-	display: grid;
-	grid-template-rows: auto auto;
 	@include break-medium {
-		grid-template-columns: 50% 50%;
+		display: flex;
+		align-items: flex-start;
 	}
 
 	p {
 		margin-bottom: 0;
+
 		@include break-medium {
+			width: 50%;
 			margin-right: 24px;
 		}
 	}
+}
 
-	a {
-		text-align: center;
-		height: 40px;
-		@include break-medium {
-			margin-left: 24px;
-		}
+.jetpack-free-card__button {
+	display: block;
+
+	margin-top: 24px;
+
+	@include break-medium {
+		flex: 1;
+
+		margin-top: 0;
 	}
 }

--- a/client/my-sites/plans-v2/selector.tsx
+++ b/client/my-sites/plans-v2/selector.tsx
@@ -14,7 +14,6 @@ import ProductsColumn from './products-column';
 import { SECURITY } from './constants';
 import { getProductUpsell, getPathToDetails, getPathToUpsell, checkout } from './utils';
 import QueryProducts from './query-products';
-import { JPC_PATH_REMOTE_INSTALL } from 'jetpack-connect/constants';
 import isJetpackCloud from 'lib/jetpack/is-jetpack-cloud';
 import { TERM_ANNUALLY } from 'lib/plans/constants';
 import { getSiteProducts } from 'state/sites/selectors';
@@ -24,7 +23,6 @@ import Main from 'components/main';
 import QuerySitePurchases from 'components/data/query-site-purchases';
 import QuerySites from 'components/data/query-sites';
 import JetpackFreeCard from 'components/jetpack/card/jetpack-free-card';
-import getJetpackWpAdminUrl from 'state/selectors/get-jetpack-wp-admin-url';
 
 /**
  * Type dependencies
@@ -48,7 +46,6 @@ const SelectorPage = ( {
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
 	const siteSlug = useSelector( ( state ) => getSelectedSiteSlug( state ) ) || '';
 	const siteProducts = useSelector( ( state ) => getSiteProducts( state, siteId ) );
-	const wpAdminUrl = useSelector( getJetpackWpAdminUrl );
 	const [ productType, setProductType ] = useState< ProductType >( SECURITY );
 	const [ currentDuration, setDuration ] = useState< Duration >( defaultDuration );
 
@@ -118,7 +115,7 @@ const SelectorPage = ( {
 			{ showJetpackFreeCard && (
 				<>
 					<div className="selector__divider" />
-					<JetpackFreeCard buttonUrl={ wpAdminUrl || JPC_PATH_REMOTE_INSTALL } />
+					<JetpackFreeCard />
 				</>
 			) }
 

--- a/client/my-sites/plans-v2/selector.tsx
+++ b/client/my-sites/plans-v2/selector.tsx
@@ -14,6 +14,7 @@ import ProductsColumn from './products-column';
 import { SECURITY } from './constants';
 import { getProductUpsell, getPathToDetails, getPathToUpsell, checkout } from './utils';
 import QueryProducts from './query-products';
+import { JPC_PATH_REMOTE_INSTALL } from 'jetpack-connect/constants';
 import isJetpackCloud from 'lib/jetpack/is-jetpack-cloud';
 import { TERM_ANNUALLY } from 'lib/plans/constants';
 import { getSiteProducts } from 'state/sites/selectors';
@@ -23,6 +24,7 @@ import Main from 'components/main';
 import QuerySitePurchases from 'components/data/query-site-purchases';
 import QuerySites from 'components/data/query-sites';
 import JetpackFreeCard from 'components/jetpack/card/jetpack-free-card';
+import getJetpackWpAdminUrl from 'state/selectors/get-jetpack-wp-admin-url';
 
 /**
  * Type dependencies
@@ -46,6 +48,7 @@ const SelectorPage = ( {
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
 	const siteSlug = useSelector( ( state ) => getSelectedSiteSlug( state ) ) || '';
 	const siteProducts = useSelector( ( state ) => getSiteProducts( state, siteId ) );
+	const wpAdminUrl = useSelector( getJetpackWpAdminUrl );
 	const [ productType, setProductType ] = useState< ProductType >( SECURITY );
 	const [ currentDuration, setDuration ] = useState< Duration >( defaultDuration );
 
@@ -115,7 +118,7 @@ const SelectorPage = ( {
 			{ showJetpackFreeCard && (
 				<>
 					<div className="selector__divider" />
-					<JetpackFreeCard />
+					<JetpackFreeCard buttonUrl={ wpAdminUrl || JPC_PATH_REMOTE_INSTALL } />
 				</>
 			) }
 

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -13,6 +13,7 @@
 	margin: 0;
 	outline: 0;
 	overflow: hidden;
+	text-align: center;
 	text-overflow: ellipsis;
 	text-decoration: none;
 	vertical-align: top;


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR fixes a couple of styling issues in the Jetpack Free card. It also fixes the button link in Jetpack cloud.

Fixes 1169247016322522-as-1191767071741497

### Testing instructions

- Visit `/jetpack/connect/plans/:site/` with the offer reset flow enabled
- Check that the Jetpack Free card plan at the bottom of the page looks like the capture below, and that the button redirects to the WP admin
- Run Jetpack cloud and go to `/pricing/`
- Check that the Jetpack Free card plan at the bottom of the page looks like the capture below, and that the button redirects to the install page

### Screenshots

#### In-place-connect

Before
<img width="395" alt="Screen Shot 2020-09-02 at 11 13 18 AM" src="https://user-images.githubusercontent.com/1620183/92009184-1ffd9f80-ed16-11ea-984b-bd28fe19daca.png">
<img width="1070" alt="Screen Shot 2020-09-02 at 11 19 55 AM" src="https://user-images.githubusercontent.com/1620183/92009210-2855da80-ed16-11ea-94ef-46eaf19ae685.png">


After
<img width="396" alt="Screen Shot 2020-09-02 at 12 02 18 PM" src="https://user-images.githubusercontent.com/1620183/92009103-00ff0d80-ed16-11ea-8734-10252eeec2db.png">

<img width="988" alt="Screen Shot 2020-09-02 at 12 06 48 PM" src="https://user-images.githubusercontent.com/1620183/92009065-f3498800-ed15-11ea-9bb8-e04ad4123a89.png">



#### Cloud

Before
<img width="407" alt="Screen Shot 2020-09-02 at 11 24 55 AM" src="https://user-images.githubusercontent.com/1620183/92009128-0b210c00-ed16-11ea-9cd5-124f8bbb9088.png">
<img width="994" alt="Screen Shot 2020-09-02 at 11 24 42 AM" src="https://user-images.githubusercontent.com/1620183/92009144-12481a00-ed16-11ea-846a-ea69e65cdd96.png">


After
<img width="396" alt="Screen Shot 2020-09-02 at 12 03 03 PM" src="https://user-images.githubusercontent.com/1620183/92009085-fb092c80-ed15-11ea-887d-c13c3dc9210b.png">

<img width="987" alt="Screen Shot 2020-09-02 at 12 07 08 PM" src="https://user-images.githubusercontent.com/1620183/92009046-edec3d80-ed15-11ea-8fda-8ca0bc0da7a2.png">