### PR TITLE
Update how we handle premium domains for TLDs we don't support

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -789,7 +789,7 @@ class RegisterDomainStep extends React.Component {
 					const isAvailableSupportedPremiumDomain =
 						config.isEnabled( 'domains/premium-domain-purchases' ) &&
 						domainAvailability.AVAILABLE_PREMIUM === status &&
-						result?.premium_domains_supported;
+						result?.is_supported_premium_domain;
 					resolve( {
 						status: ! isAvailable && ! isAvailableSupportedPremiumDomain ? status : null,
 						trademarkClaimsNoticeInfo: get( result, 'trademark_claims_notice_info', null ),
@@ -837,7 +837,7 @@ class RegisterDomainStep extends React.Component {
 					const isAvailableSupportedPremiumDomain =
 						config.isEnabled( 'domains/premium-domain-purchases' ) &&
 						AVAILABLE_PREMIUM === status &&
-						result?.premium_domains_supported;
+						result?.is_supported_premium_domain;
 
 					// Mapped status always overrides other statuses.
 					const availabilityStatus = isDomainMapped ? mappable : status;

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -224,6 +224,7 @@ class RegisterDomainStep extends React.Component {
 		return {
 			availabilityError: null,
 			availabilityErrorData: null,
+			availabilityErrorDomain: null,
 			availableTlds: [],
 			bloggerFilterAdded: false,
 			clickedExampleSuggestion: false,
@@ -244,6 +245,7 @@ class RegisterDomainStep extends React.Component {
 			subdomainSearchResults: null,
 			suggestionError: null,
 			suggestionErrorData: null,
+			suggestionErrorDomain: null,
 			pendingCheckSuggestion: null,
 			unavailableDomains: [],
 			trademarkClaimsNoticeInfo: null,
@@ -408,11 +410,12 @@ class RegisterDomainStep extends React.Component {
 		const {
 			availabilityError,
 			availabilityErrorData,
-			lastDomainSearched,
+			availabilityErrorDomain,
 			showAvailabilityNotice,
 			showSuggestionNotice,
 			suggestionError,
 			suggestionErrorData,
+			suggestionErrorDomain,
 			trademarkClaimsNoticeInfo,
 		} = this.state;
 
@@ -421,10 +424,10 @@ class RegisterDomainStep extends React.Component {
 		}
 
 		const { message: suggestionMessage, severity: suggestionSeverity } = showSuggestionNotice
-			? getAvailabilityNotice( lastDomainSearched, suggestionError, suggestionErrorData )
+			? getAvailabilityNotice( suggestionErrorDomain, suggestionError, suggestionErrorData )
 			: {};
 		const { message: availabilityMessage, severity: availabilitySeverity } = showAvailabilityNotice
-			? getAvailabilityNotice( lastDomainSearched, availabilityError, availabilityErrorData )
+			? getAvailabilityNotice( availabilityErrorDomain, availabilityError, availabilityErrorData )
 			: {};
 
 		const searchBoxClassName = classNames( 'register-domain-step__search', {
@@ -631,6 +634,7 @@ class RegisterDomainStep extends React.Component {
 		const nextState = {
 			availabilityError: null,
 			availabilityErrorData: null,
+			availabilityErrorDomain: null,
 			exactMatchDomain: null,
 			lastDomainSearched: null,
 			loadingResults,
@@ -639,6 +643,7 @@ class RegisterDomainStep extends React.Component {
 			showSuggestionNotice: false,
 			suggestionError: null,
 			suggestionErrorData: null,
+			suggestionErrorDomain: null,
 			...stateOverride,
 		};
 		debug( 'Repeating a search with the following input for setState', nextState );
@@ -730,6 +735,7 @@ class RegisterDomainStep extends React.Component {
 				isInitialQueryActive,
 				availabilityError: null,
 				availabilityErrorData: null,
+				availabilityErrorDomain: null,
 				exactMatchDomain: null,
 				lastDomainSearched: null,
 				lastQuery: cleanedQuery,
@@ -742,6 +748,7 @@ class RegisterDomainStep extends React.Component {
 				subdomainSearchResults: null,
 				suggestionError: null,
 				suggestionErrorData: null,
+				suggestionErrorDomain: null,
 			},
 			callback
 		);
@@ -1462,6 +1469,7 @@ class RegisterDomainStep extends React.Component {
 			showAvailabilityNotice: true,
 			availabilityError: error,
 			availabilityErrorData: errorData,
+			availabilityErrorDomain: domain,
 		} );
 	}
 
@@ -1477,6 +1485,7 @@ class RegisterDomainStep extends React.Component {
 			showSuggestionNotice: true,
 			suggestionError: error,
 			suggestionErrorData: errorData,
+			suggestionErrorDomain: domain,
 		} );
 	}
 }

--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -359,7 +359,7 @@ function getAvailabilityNotice( domain, error, errorData ) {
 
 		case domainAvailability.AVAILABLE_PREMIUM:
 			message = translate(
-				"Sorry, {{strong}}%(domain)s{{/strong}} is a premium domain. We don't support purchases of this type of premium domains on WordPress.com, but if you purchase the domain elsewhere, you can {{a}}map it to your site{{/a}}.",
+				"Sorry, {{strong}}%(domain)s{{/strong}} is a premium domain. We don't support purchasing this premium domain on WordPress.com, but if you purchase the domain elsewhere, you can {{a}}map it to your site{{/a}}.",
 				{
 					args: { domain },
 					components: {

--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -359,7 +359,7 @@ function getAvailabilityNotice( domain, error, errorData ) {
 
 		case domainAvailability.AVAILABLE_PREMIUM:
 			message = translate(
-				"Sorry, {{strong}}%(domain)s{{/strong}} is a premium domain. We don't support purchases of premium domains on WordPress.com, but if you purchase this domain elsewhere, you can {{a}}map it to your site{{/a}}.",
+				"Sorry, {{strong}}%(domain)s{{/strong}} is a premium domain. We don't support purchases of this type of premium domains on WordPress.com, but if you purchase the domain elsewhere, you can {{a}}map it to your site{{/a}}.",
 				{
 					args: { domain },
 					components: {


### PR DESCRIPTION
There were some issues with how we handle the availability responses for premium domains we don't support so here's a fix.

#### Changes proposed in this Pull Request

* Updated the notification copy for available premium domains we don't support (see screenshot) because the old one imposed that we don't support any premium domains
* Properly handle `available_premium` status responsed from the availability endpoint for FQDNs searches and for the availability pre-check

<img width="1065" alt="Screenshot 2020-09-02 at 20 29 23" src="https://user-images.githubusercontent.com/1355045/92017604-b359c380-ed5c-11ea-80b3-61955813f490.png">


#### Testing instructions

* Apply D48991-code
* Enter a premium .blog domain in the search box in Calypso domain search - no notification should be shown and the domain should be displayed as suggestion. Try clicking on it - it should be added to your cart.
* Enter a premium domain that's not .blog - verify that we show the proper message.
* Try looking for premium that's not .blog but that's returned from the suggestion endpoint (short searches like sale, sales, anna, etc usually return some results). If you click on one of those suggestions the availability pre-check should be fired and it should say "Unavailable".Then if you search for the same thing again it should disappear from the suggestion results.
