### PR TITLE
Fix: Use FormRadio and FormCheckbox components for term-tree-selector

### DIFF
--- a/client/blocks/term-tree-selector/terms.jsx
+++ b/client/blocks/term-tree-selector/terms.jsx
@@ -22,6 +22,9 @@ import {
 /**
  * Internal dependencies
  */
+import FormCheckbox from 'components/forms/form-checkbox';
+import FormRadio from 'components/forms/form-radio';
+import FormLabel from 'components/forms/form-label';
 import { gaRecordEvent } from 'lib/analytics/ga';
 import NoResults from './no-results';
 import Search from './search';
@@ -324,13 +327,12 @@ class TermTreeSelectorList extends Component {
 		const isPodcastingCategory = taxonomy === 'category' && podcastingCategoryId === itemId;
 		const name = decodeEntities( item.name ) || translate( 'Untitled' );
 		const checked = includes( selected, itemId );
-		const inputType = multiple ? 'checkbox' : 'radio';
+		const InputComponent = multiple ? FormCheckbox : FormRadio;
 		const disabled =
 			multiple && checked && defaultTermId && 1 === selected.length && defaultTermId === itemId;
 
 		const input = (
-			<input
-				type={ inputType }
+			<InputComponent
 				value={ itemId }
 				onChange={ onChange }
 				disabled={ disabled }
@@ -375,16 +377,14 @@ class TermTreeSelectorList extends Component {
 			return this.renderItem( item );
 		}
 
+		const InputComponent = this.props.multiple ? FormCheckbox : FormRadio;
+
 		return (
 			<div key="placeholder" className="term-tree-selector__list-item is-placeholder">
-				<label>
-					<input
-						type={ this.props.multiple ? 'checkbox' : 'radio' }
-						disabled
-						className="term-tree-selector__input"
-					/>
+				<FormLabel>
+					<InputComponent disabled className="term-tree-selector__input" />
 					<span className="term-tree-selector__label">{ this.props.translate( 'Loading…' ) }</span>
-				</label>
+				</FormLabel>
 			</div>
 		);
 	};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update `term-tree-selector` to use the `FormRadio` and `FormCheckbox` components. This was breaking podcast category selection:

<img width="1456" alt="Captura de Tela 2020-09-02 às 10 43 12" src="https://user-images.githubusercontent.com/24264157/92018307-d60ebc80-ed09-11ea-9ee3-6b4e09c51c9c.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the podcast category creation window by going to `settings/podcasting/:site` and clicking "Add New Category". Toggle the form to display the parent categories and ensure that selecting categories works and that the selected category is the parent of the new category added.
* Go to the classic editor and ensure that post categories continue to work.

<img width="1456" alt="Captura de Tela 2020-09-02 às 10 44 33" src="https://user-images.githubusercontent.com/24264157/92018461-0b1b0f00-ed0a-11ea-98f7-32fbc2c4bb25.png">
<img width="290" alt="Captura de Tela 2020-09-02 às 10 46 48" src="https://user-images.githubusercontent.com/24264157/92018476-0f472c80-ed0a-11ea-86e8-c8494770ec97.png">

Caused by #45198 