### PR TITLE
Plans: Add Tracks events for new filters and products with subtypes

### DIFF
--- a/client/my-sites/plans-v2/selector.tsx
+++ b/client/my-sites/plans-v2/selector.tsx
@@ -2,12 +2,13 @@
  * External dependencies
  */
 import React, { useState, useEffect, useMemo } from 'react';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import page from 'page';
 
 /**
  * Internal dependencies
  */
+import { recordTracksEvent } from 'state/analytics/actions/record';
 import PlansFilterBar from './plans-filter-bar';
 import PlansColumn from './plans-column';
 import ProductsColumn from './products-column';
@@ -43,6 +44,8 @@ const SelectorPage = ( {
 	header,
 	footer,
 }: SelectorPageProps ) => {
+	const dispatch = useDispatch();
+
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
 	const siteSlug = useSelector( ( state ) => getSelectedSiteSlug( state ) ) || '';
 	const siteProducts = useSelector( ( state ) => getSiteProducts( state, siteId ) );
@@ -61,6 +64,12 @@ const SelectorPage = ( {
 		}
 
 		if ( product.subtypes.length ) {
+			dispatch(
+				recordTracksEvent( 'calypso_product_subtypes_view', {
+					product_slug: product.productSlug,
+					duration: currentDuration,
+				} )
+			);
 			page( getPathToDetails( rootUrl, product.productSlug, currentDuration, siteSlug ) );
 			return;
 		}
@@ -79,6 +88,26 @@ const SelectorPage = ( {
 		checkout( siteSlug, product.productSlug );
 	};
 
+	const trackProductTypeChange = ( selectedType: ProductType ) => {
+		if ( selectedType === productType ) {
+			return;
+		}
+
+		dispatch( recordTracksEvent( 'calypso_plans_type_change', { product_type: selectedType } ) );
+		setProductType( selectedType );
+	};
+
+	const trackDurationChange = ( selectedDuration: Duration ) => {
+		if ( selectedDuration === currentDuration ) {
+			return;
+		}
+
+		dispatch(
+			recordTracksEvent( 'calypso_plans_duration_change', { duration: selectedDuration } )
+		);
+		setDuration( selectedDuration );
+	};
+
 	const isInConnectFlow = useMemo(
 		() =>
 			/jetpack\/connect\/plans/.test( window.location.href ) ||
@@ -92,9 +121,9 @@ const SelectorPage = ( {
 		<Main className="selector__main" wideLayout>
 			{ header }
 			<PlansFilterBar
-				onProductTypeChange={ setProductType }
+				onProductTypeChange={ trackProductTypeChange }
 				productType={ productType }
-				onDurationChange={ setDuration }
+				onDurationChange={ trackDurationChange }
 				duration={ currentDuration }
 			/>
 			<div className="plans-v2__columns">


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add the `calypso_plans_type_change` event to the new Plans page, which triggers when someone changes the product type filter (i.e., Security, Performance, or All).
* Add the `calypso_plans_duration_change` event to the new Plans page, which triggers when someone changes the product duration (i.e., Monthly or Annual).
* Add the `calypso_product_subtypes_view` event to the new Plans page, which triggers when someone selects a product that has one or more sub-types (e.g., Backup, which has Daily and Real-time variants).

*Partially* fixes `1169247016322522-as-1191023234087521`.

#### Testing instructions

* Ensure that your environment has enabled the `showOfferResetFlow` A/B test.
* Visit the **Plans** page.
* Open your browser's DevTools window to the **Network** panel and monitor for **Image** requests.
* Select different values in the Duration toggle. Verify that for each change in value, a request goes out to `t.gif` with the following properties in its query string:
  * `_en`: `calypso_plans_duration_change`
  * `duration`: `TERM_MONTHLY` | `TERM_ANNUALLY` (whichever you selected)
* Select different values in the Type dropdown. Verify that for each change in value, a request goes out to `t.gif` with the following properties in its query string:
  * `_en`: `calypso_plans_type_change`
  * `product_type`: `security` | `performance` | `all` (whichever you selected)
* Select a product with at least one sub-type (e.g., Jetpack Backup). (You must not already own this product.) Verify that a request goes out to `t.gif` with the following properties in its query string:
  * `_en`: `calypso_product_subtypes_view`
  * `product_slug`: `jetpack_backup` (should match the product you selected)
  * `duration`: `TERM_MONTHLY` | `TERM_ANNUALLY` (whichever you selected)

#### Reference screenshot

<img width="1051" alt="image" src="https://user-images.githubusercontent.com/670067/92020832-5f2fee80-ed1e-11ea-8a1b-507118288a35.png">

<img width="529" alt="image" src="https://user-images.githubusercontent.com/670067/92021020-b5049680-ed1e-11ea-8053-73a35d3276ab.png">
