### PR TITLE
Store: Fix plugin install on Store/Woo feature.

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/required-plugins-install-view.js
+++ b/client/extensions/woocommerce/app/dashboard/required-plugins-install-view.js
@@ -233,7 +233,7 @@ class RequiredPluginsInstallView extends Component {
 	};
 
 	doInstallation = () => {
-		const { pluginsStatus, site, sitePlugins, wporgPlugins } = this.props;
+		const { pluginsStatus, site, sitePlugins } = this.props;
 
 		// If we are working on nothing presently, get the next thing to install and install it
 		if ( 0 === this.state.workingOn.length ) {
@@ -248,10 +248,13 @@ class RequiredPluginsInstallView extends Component {
 			}
 
 			const workingOn = toInstall.shift();
-			const thisPlugin = wporgPlugins?.[ workingOn ] ?? {};
-			// Set a default ID if needed.
-			thisPlugin.id = thisPlugin.id || thisPlugin.slug;
-			this.props.installPlugin( site.ID, thisPlugin );
+			// In lieu of waiting on details of plugins from wporg, let's assemble the object ourselves.
+			const plugin = {
+				id: workingOn,
+				slug: workingOn,
+			};
+
+			this.props.installPlugin( site.ID, plugin );
 
 			this.setState( {
 				toInstall,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We had a report in Slack that the Store on WordPress.com setup flow was no longer functional. While the feature is not actively promoted, one can still enter in this UI for Woo through the following:

- On a Business Plan site, trigger transfer to AT by installing WooCommerce
- Then the "Store" link in the calypso sidebar directs users to the Store on WordPress.com UI.
- The Setup flow here requires that the site also has `woocommerce-services` installed, and that is what is currently broken.

From what I could see, it seems the data from the wp.org repository wasn't being returned in time for the call to install the `woocommerce-services` plugin, so for this fix I instead just created the object that is needed for the `installPlugin` flow. This remedies the problem, and seems like a valid solution since we have no plans on auto-installing other plugins in this way, and we are still considering sunsetting this Woo UI in Calypso too.

#### Testing instructions

This flow is best tested with a Business Plan site

* On your business plan site, ensure you have WooCommerce installed
* Also, uninstall `woocommerce-services` if it is installed/active on your test site.
* checkout this branch locally
* Next visit `http://calypso.localhost:3000/store/YOURSITESLUGHERE`, and note the plugin install screen appears:

<img width="1110" alt="image" src="https://user-images.githubusercontent.com/22080/92027150-0872e680-ed17-11ea-863a-a840293fd404.png">

* And the `woocommerce-services` plugin is installed, and eventually you can see the Dashboard of Store on WordPress.com:

<img width="1606" alt="image" src="https://user-images.githubusercontent.com/22080/92027239-22acc480-ed17-11ea-9869-b86356be691c.png">
