### PR TITLE
Bump WordPress.com Editing Toolkit plugin to v2.1

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WordPress.com Editing Toolkit
  * Description: Enhances your page creation workflow within the Block Editor.
- * Version: 2.0
+ * Version: 2.1
  * Author: Automattic
  * Author URI: https://automattic.com/wordpress-plugins/
  * License: GPLv2 or later
@@ -35,7 +35,7 @@ namespace A8C\FSE;
  *
  * @var string
  */
-define( 'PLUGIN_VERSION', '2.0' );
+define( 'PLUGIN_VERSION', '2.1' );
 
 // Always include these helper files for dotcom FSE.
 require_once __DIR__ . '/dotcom-fse/helpers.php';

--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -49,6 +49,11 @@ This plugin is experimental, so we don't provide any support for it outside of w
 * Update the Editing Toolkit readme (https://github.com/Automattic/wp-calypso/pull/45212)
 * Premium Content: Fix redirect behavior after connecting to Stripe (https://github.com/Automattic/wp-calypso/pull/45204)
 * Hide editor sidebar first time users sees the editor (https://github.com/Automattic/wp-calypso/pull/43716)
+* Add an aria-label to (W), in header and sidebar, that describes what the button is for, when sidebar is closed "Open sidebar", when W button is open "You are viewing sidebar. To close select "esc". (https://github.com/Automattic/wp-calypso/pull/45266)
+* Add aria-label for "View all pages" link: aria-label="View all pages in Dashboard" (or posts as appropriate)  (https://github.com/Automattic/wp-calypso/pull/45266)
+* Use an h2 instead of a div for the “Posts” heading  (https://github.com/Automattic/wp-calypso/pull/45266)
+* Set autoFocus to (W) icon when sidebar opens  (https://github.com/Automattic/wp-calypso/pull/45266)
+
 
 = 2.0 =
 * Rename directories from "full-site-editing*" to "editing-toolkit*" (https://github.com/Automattic/wp-calypso/pull/44501)

--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -3,7 +3,7 @@ Contributors: alexislloyd, allancole, automattic, bartkalisz, codebykat, copons,
 Tags: block, blocks, editor, gutenberg, page
 Requires at least: 5.0
 Tested up to: 5.4
-Stable tag: 2.0
+Stable tag: 2.1
 Requires PHP: 5.6.20
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -39,6 +39,16 @@ This plugin is experimental, so we don't provide any support for it outside of w
 
 
 == Changelog ==
+
+= 2.1 =
+* Fix site editor loading problem with Gutenberg 8.9.0 (https://github.com/Automattic/wp-calypso/pull/45360)
+* Added fallback for site vertical (https://github.com/Automattic/wp-calypso/pull/45010)
+* Update pages sidebar design in block editor (https://github.com/Automattic/wp-calypso/pull/45242)
+* Fix FSE Mailerlite translations namespacing (https://github.com/Automattic/wp-calypso/pull/45206)
+* Premium Content: Fix duplicate Stripe nudge notification (https://github.com/Automattic/wp-calypso/pull/45255)
+* Update the Editing Toolkit readme (https://github.com/Automattic/wp-calypso/pull/45212)
+* Premium Content: Fix redirect behavior after connecting to Stripe (https://github.com/Automattic/wp-calypso/pull/45204)
+* Hide editor sidebar first time users sees the editor (https://github.com/Automattic/wp-calypso/pull/43716)
 
 = 2.0 =
 * Rename directories from "full-site-editing*" to "editing-toolkit*" (https://github.com/Automattic/wp-calypso/pull/44501)

--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/wpcom-editing-toolkit",
-	"version": "2.0.0",
+	"version": "2.1.0",
 	"description": "Plugin for editing-related features.",
 	"sideEffects": true,
 	"repository": {

--- a/package.json
+++ b/package.json
@@ -181,7 +181,7 @@
 		"@automattic/webpack-inline-constant-exports-plugin": "^0.0.1",
 		"@automattic/wp-babel-makepot": "^1.0.0",
 		"@automattic/wpcom-block-editor": "^1.0.0-alpha.0",
-		"@automattic/wpcom-editing-toolkit": "^2.0.0",
+		"@automattic/wpcom-editing-toolkit": "^2.1.0",
 		"@babel/cli": "^7.10.5",
 		"@babel/core": "^7.11.1",
 		"@babel/register": "^7.10.5",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Release 2.1 version of Editing Toolkit plugin.

#### Testing instructions

1. Apply the generated diff to your sandbox.
2. Test new updates listed in the changelog.