### PR TITLE
Earn: Only display commission rates once earnings data is received.

### DIFF
--- a/client/my-sites/earn/memberships/index.jsx
+++ b/client/my-sites/earn/memberships/index.jsx
@@ -74,7 +74,7 @@ class MembershipsSection extends Component {
 		}
 	}
 	renderEarnings() {
-		const { translate } = this.props;
+		const { commission, currency, forecast, lastMonth, siteId, total, translate } = this.props;
 		return (
 			<div>
 				<SectionHeader label={ this.props.translate( 'Earnings' ) } />
@@ -111,25 +111,26 @@ class MembershipsSection extends Component {
 						</ul>
 					</div>
 					<div className="memberships__earnings-breakdown-notes">
-						{ translate(
-							'On your current plan, WordPress.com charges {{em}}%(commission)s{{/em}}.{{br/}} Additionally, Stripe charges are typically %(stripe)s. {{a}}Learn more{{/a}}',
-							{
-								args: {
-									commission: '' + parseFloat( this.props.commission ) * 100 + '%',
-									stripe: '2.9%+30c',
-								},
-								components: {
-									em: <em />,
-									br: <br />,
-									a: (
-										<ExternalLink
-											href="https://wordpress.com/support/recurring-payments-button/#related-fees"
-											icon={ true }
-										/>
-									),
-								},
-							}
-						) }
+						{ commission &&
+							translate(
+								'On your current plan, WordPress.com charges {{em}}%(commission)s{{/em}}.{{br/}} Additionally, Stripe charges are typically %(stripe)s. {{a}}Learn more{{/a}}',
+								{
+									args: {
+										commission: '' + parseFloat( commission ) * 100 + '%',
+										stripe: '2.9%+30c',
+									},
+									components: {
+										em: <em />,
+										br: <br />,
+										a: (
+											<ExternalLink
+												href="https://wordpress.com/support/recurring-payments-button/#related-fees"
+												icon={ true }
+											/>
+										),
+									},
+								}
+							) }
 					</div>
 				</Card>
 			</div>

--- a/client/my-sites/earn/memberships/index.jsx
+++ b/client/my-sites/earn/memberships/index.jsx
@@ -77,8 +77,8 @@ class MembershipsSection extends Component {
 		const { commission, currency, forecast, lastMonth, siteId, total, translate } = this.props;
 		return (
 			<div>
-				<SectionHeader label={ this.props.translate( 'Earnings' ) } />
-				<QueryMembershipsEarnings siteId={ this.props.siteId } />
+				<SectionHeader label={ translate( 'Earnings' ) } />
+				<QueryMembershipsEarnings siteId={ siteId } />
 				<Card>
 					<div className="memberships__module-content module-content">
 						<ul className="memberships__earnings-breakdown-list">
@@ -87,7 +87,7 @@ class MembershipsSection extends Component {
 									{ translate( 'Total earnings', { context: 'Sum of earnings' } ) }
 								</span>
 								<span className="memberships__earnings-breakdown-value">
-									{ formatCurrency( this.props.total, this.props.currency ) }
+									{ formatCurrency( total, currency ) }
 								</span>
 							</li>
 							<li className="memberships__earnings-breakdown-item">
@@ -95,7 +95,7 @@ class MembershipsSection extends Component {
 									{ translate( 'Last 30 days', { context: 'Sum of earnings over last 30 days' } ) }
 								</span>
 								<span className="memberships__earnings-breakdown-value">
-									{ formatCurrency( this.props.lastMonth, this.props.currency ) }
+									{ formatCurrency( lastMonth, currency ) }
 								</span>
 							</li>
 							<li className="memberships__earnings-breakdown-item">
@@ -105,7 +105,7 @@ class MembershipsSection extends Component {
 									} ) }
 								</span>
 								<span className="memberships__earnings-breakdown-value">
-									{ formatCurrency( this.props.forecast, this.props.currency ) }
+									{ formatCurrency( forecast, currency ) }
 								</span>
 							</li>
 						</ul>

--- a/client/state/memberships/earnings/selectors.js
+++ b/client/state/memberships/earnings/selectors.js
@@ -20,6 +20,6 @@ export function getEarningsWithDefaultsForSiteId( state, siteId ) {
 		last_month: earnings.last_month ?? 0,
 		forecast: earnings.forecast ?? 0,
 		currency: earnings.currency ?? 'USD',
-		commission: earnings.commission ?? false,
+		commission: earnings.commission ?? null,
 	};
 }

--- a/client/state/memberships/earnings/selectors.js
+++ b/client/state/memberships/earnings/selectors.js
@@ -20,6 +20,6 @@ export function getEarningsWithDefaultsForSiteId( state, siteId ) {
 		last_month: earnings.last_month ?? 0,
 		forecast: earnings.forecast ?? 0,
 		currency: earnings.currency ?? 'USD',
-		commission: earnings.commission ?? '0.1',
+		commission: earnings.commission ?? false,
 	};
 }


### PR DESCRIPTION
In #45304, we discovered that eCommerce sites were showing an errant 10% commission, when it should be 0% – the cause is two-fold. First, #42955 introduces a `getEarningsWithDefaultsForSiteId` selector that [returns a default commission value](https://github.com/Automattic/wp-calypso/blob/master/client/state/memberships/earnings/selectors.js#L23) of `0.1` (10%) if `QueryMembershipEarnings` data hasn't been received yet (something that users just shouldn't ever see, considering how confusing it is – we don't even have plans that charge that high). Secondly, it appears `QueryMembershipEarnings` is also returning the same 10% commission rate from the API.

This PR addresses the first issue, by only displaying the commission data once we've received actual earnings information from the query component. The second issue will be dealt with separately server-side.

<img width="1197" alt="Screen Shot 2020-09-02 at 2 49 01 PM" src="https://user-images.githubusercontent.com/349751/92040373-8e009180-ed2b-11ea-86ba-afb44defeeb9.png">


#### Testing instructions

* Choose a test Simple site that has a plan upgrade and a Stripe connection.
* On this branch, go to `/earn/payments/:site`.
* Verify you do _not_ see "... WordPress charges 10%" when the page loads, and that when the percentage does display, it's [correct to your plan](https://wordpress.com/support/wordpress-editor/blocks/payments/#related-fees).