### PR TITLE
Ignore the editing toolkit build artifacts in `.cache`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ cached-requests.json
 /apps/*/dist/
 /apps/*/types/
 /packages/*/dist/
+/apps/*/.cache/
 
 # webpack assets
 /assets*.json

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
 		"clean:packages": "npx lerna run clean --stream",
 		"clean:public": "npx rimraf public",
 		"clean:translations": "npx rimraf build/strings calypso-strings.pot chunks-map.*.json",
-		"distclean": "yarn run clean && npx rimraf node_modules client/node_modules desktop/node_modules apps/*/node_modules packages/*/node_modules test/e2e/node_modules .cache vendor",
+		"distclean": "yarn run clean && npx rimraf node_modules client/node_modules desktop/node_modules apps/*/node_modules packages/*/node_modules test/e2e/node_modules .cache apps/*/.cache vendor",
 		"docker": "docker run -it --name wp-calypso --rm -p 80:3000 wp-calypso",
 		"docker-jetpack-cloud": "docker run -it --env CALYPSO_ENV=jetpack-cloud-production --name wp-calypso --rm -p 80:3000 wp-calypso",
 		"download-languages-meta": "node bin/download-languages-meta.js",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Git ignores files in the `apps/editing-toolkit/.cache` directory. Not sure when these intermediary files became part of the build, but it might be here? #44861

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Build editing toolkit with something like `cd apps/editing-toolkit && yarn dev --sync`
* `git status`
* There shouldn't be ~100 files in a `apps/editing-toolkit/.cache` directory
