### PR TITLE
Signup Reskin: Pauses the test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -210,7 +210,7 @@ export default {
 		countryCodeTargets: [ 'US', 'CA' ],
 	},
 	reskinSignupFlow: {
-		datestamp: '20200903',
+		datestamp: '21200903',
 		variations: {
 			reskinned: 50,
 			control: 50,

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -210,15 +210,14 @@ export default {
 		countryCodeTargets: [ 'US', 'CA' ],
 	},
 	reskinSignupFlow: {
-		datestamp: '20200824',
+		datestamp: '20200903',
 		variations: {
 			reskinned: 50,
 			control: 50,
 		},
 		defaultVariation: 'control',
 		allowExistingUsers: false,
-		localeTargets: 'any',
-		localeExceptions: [ 'en', 'es' ],
+		localeTargets: [ 'en', 'es' ],
 	},
 	existingUsersGutenbergOnboard: {
 		datestamp: '20200828',

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -217,7 +217,8 @@ export default {
 		},
 		defaultVariation: 'control',
 		allowExistingUsers: false,
-		localeTargets: [ 'en', 'es' ],
+		localeTargets: 'any',
+		localeExceptions: [ 'en', 'es' ],
 	},
 	existingUsersGutenbergOnboard: {
 		datestamp: '20200828',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

~* Changes the locale targets of the `reskinSignupFlow` test to `en, es`.~
* Pauses the test by setting the datestamp to the future.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* Go to /start/new.
* Make sure you're not assigned to reskinned group of reskinSignupFlow a/b test.
* Check this for EN/ES locale and any other locale.

