### PR TITLE
Sidebar: fixup styles to work without the CSS reset

### DIFF
--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -32,6 +32,7 @@
 	// Reset lists to avoid bullets and margins.
 	ul {
 		margin: 0;
+		padding: 0;
 	}
 
 	li {
@@ -59,6 +60,8 @@
 	font-size: $font-body;
 	font-weight: 600;
 	padding: 16px 8px 6px 16px;
+	margin: 0;
+	outline: 0;
 }
 
 // Sidebar menu icons for main sections


### PR DESCRIPTION
While playing with the Gutenlypso prototype in #44801, I noticed a broken sidebar:

<img width="277" alt="Screenshot 2020-09-03 at 14 59 32" src="https://user-images.githubusercontent.com/664258/92119086-a3db8880-edf7-11ea-9127-4edd552bb83c.png">

It's caused by missing styles that used to be directly on the `ul` and `h2` elements in the CSS reset. This PR adds them to the specific `.sidebar_...` rules.

**How to test:**
On `master`, this change shouldn't have any observable effects. In the #44801 branch:
- the horizontal identation of sidebar items should be removed
- the vertical space between items should be smaller
- after clicking on an expandable item, e.g., "Site", you shouldn't see a blue focus ring (added by default on the `<h2 tabindex=0>` that has been made interactive by the `tabindex` attr)
