### PR TITLE
Plans: Add the selected site ID to new Tracks events from #45366

### DIFF
--- a/client/my-sites/plans-v2/selector.tsx
+++ b/client/my-sites/plans-v2/selector.tsx
@@ -66,6 +66,7 @@ const SelectorPage = ( {
 		if ( product.subtypes.length ) {
 			dispatch(
 				recordTracksEvent( 'calypso_product_subtypes_view', {
+					site_id: siteId,
 					product_slug: product.productSlug,
 					duration: currentDuration,
 				} )
@@ -93,7 +94,12 @@ const SelectorPage = ( {
 			return;
 		}
 
-		dispatch( recordTracksEvent( 'calypso_plans_type_change', { product_type: selectedType } ) );
+		dispatch(
+			recordTracksEvent( 'calypso_plans_type_change', {
+				site_id: siteId,
+				product_type: selectedType,
+			} )
+		);
 		setProductType( selectedType );
 	};
 
@@ -103,7 +109,10 @@ const SelectorPage = ( {
 		}
 
 		dispatch(
-			recordTracksEvent( 'calypso_plans_duration_change', { duration: selectedDuration } )
+			recordTracksEvent( 'calypso_plans_duration_change', {
+				site_id: siteId,
+				duration: selectedDuration,
+			} )
 		);
 		setDuration( selectedDuration );
 	};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add the currently selected site ID to the set of parameters for Tracks events added in #45366.

#### Testing instructions

Testing is the same as described in #45366, copied below for easy reference.

**!!! Important:** The only additional criteria is that the events described should include `site_id` as a parameter, and this parameter value should match the ID of the currently selected site.

* Ensure that your environment has enabled the `showOfferResetFlow` A/B test.
* Visit the **Plans** page.
* Open your browser's DevTools window to the **Network** panel and monitor for **Image** requests.
* Select different values in the Duration toggle. Verify that for each change in value, a request goes out to `t.gif` with the following properties in its query string:
  * `_en`: `calypso_plans_duration_change`
  * `duration`: `TERM_MONTHLY` | `TERM_ANNUALLY` (whichever you selected)
* Select different values in the Type dropdown. Verify that for each change in value, a request goes out to `t.gif` with the following properties in its query string:
  * `_en`: `calypso_plans_type_change`
  * `product_type`: `security` | `performance` | `all` (whichever you selected)
* Select a product with at least one sub-type (e.g., Jetpack Backup). (You must not already own this product.) Verify that a request goes out to `t.gif` with the following properties in its query string:
  * `_en`: `calypso_product_subtypes_view`
  * `product_slug`: `jetpack_backup` (should match the product you selected)
  * `duration`: `TERM_MONTHLY` | `TERM_ANNUALLY` (whichever you selected)
