### PR TITLE
@automattic/components: Add bare Button style

### DIFF
--- a/package.json
+++ b/package.json
@@ -364,6 +364,7 @@
 		"source-map-support": "^0.5.19",
 		"stackframe": "^1.1.0",
 		"stacktrace-gps": "^3.0.3",
+		"style-loader": "^1.2.1",
 		"stylelint": "^9.10.1",
 		"supertest": "^4.0.2",
 		"svgstore-cli": "^1.3.1",

--- a/packages/components/src/button/README.md
+++ b/packages/components/src/button/README.md
@@ -36,6 +36,7 @@ export default function RockOnButton() {
 - **Scary**: Use when the action will delete customer data or be otherwise difficult to recover from. Destructive buttons should trigger a confirmation dialog before the action is completed. Be thoughtful about using destructive buttons because they can feel stressful for customers.
 - **Borderless**: Use for less important or less commonly used actions since they’re less prominent.
 - **Busy**: Use when a button has been pressed and the associated action is in progress.
+- **Bare**: Use when you need a "button-as-div", to reset all styles from a button that will then be augmented by a consumer. For example, if you need something to _behave_ as a button but not _appear_ as a button, this is a good option.
 
 #### Icon buttons
 

--- a/packages/components/src/button/docs/example.jsx
+++ b/packages/components/src/button/docs/example.jsx
@@ -166,6 +166,10 @@ export default class ButtonExample extends React.PureComponent {
 						<span>Primary scary busy button</span>
 					</Button>
 				</div>
+
+				<div className="docs__design-button-row">
+					<Button bare>Bare button</Button>
+				</div>
 			</Card>
 		),
 	};

--- a/packages/components/src/button/index.jsx
+++ b/packages/components/src/button/index.jsx
@@ -12,6 +12,7 @@ import './style.scss';
 
 export default class Button extends PureComponent {
 	static propTypes = {
+		bare: PropTypes.bool,
 		compact: PropTypes.bool,
 		primary: PropTypes.bool,
 		scary: PropTypes.bool,
@@ -28,16 +29,18 @@ export default class Button extends PureComponent {
 	};
 
 	render() {
-		const className = classNames( 'button', this.props.className, {
-			'is-compact': this.props.compact,
-			'is-primary': this.props.primary,
-			'is-scary': this.props.scary,
-			'is-busy': this.props.busy,
-			'is-borderless': this.props.borderless,
-		} );
+		const className = this.props.bare
+			? classNames( 'button-bare', this.props.className )
+			: classNames( 'button', this.props.className, {
+					'is-compact': this.props.compact,
+					'is-primary': this.props.primary,
+					'is-scary': this.props.scary,
+					'is-busy': this.props.busy,
+					'is-borderless': this.props.borderless,
+			  } );
 
 		if ( this.props.href ) {
-			const { compact, primary, scary, busy, borderless, type, ...props } = this.props;
+			const { compact, primary, scary, busy, borderless, bare, type, ...props } = this.props;
 
 			// block referrers when external link
 			const rel = props.target
@@ -47,7 +50,7 @@ export default class Button extends PureComponent {
 			return <a { ...props } rel={ rel } className={ className } />;
 		}
 
-		const { compact, primary, scary, busy, borderless, target, rel, ...props } = this.props;
+		const { compact, primary, scary, busy, borderless, bare, target, rel, ...props } = this.props;
 
 		return <button { ...props } className={ className } />;
 	}

--- a/packages/components/src/button/index.stories.jsx
+++ b/packages/components/src/button/index.stories.jsx
@@ -11,7 +11,7 @@ export default { title: 'Button' };
 const helloWorld = `Hello World!`;
 const handleClick = action( 'click' );
 
-const ButtonVariantions = ( props ) => (
+const ButtonVariations = ( props ) => (
 	<>
 		<Button onClick={ handleClick } { ...props }>
 			{ helloWorld }
@@ -22,10 +22,11 @@ const ButtonVariantions = ( props ) => (
 	</>
 );
 
-export const Normal = () => <ButtonVariantions />;
-export const Compact = () => <ButtonVariantions compact />;
-export const Busy = () => <ButtonVariantions busy />;
-export const Scary = () => <ButtonVariantions scary />;
-export const Borderless = () => <ButtonVariantions borderless />;
-export const Disabled = () => <ButtonVariantions disabled />;
-export const Link = () => <ButtonVariantions href="https://www.google.com/" target="_blank" />;
+export const Normal = () => <ButtonVariations />;
+export const Compact = () => <ButtonVariations compact />;
+export const Busy = () => <ButtonVariations busy />;
+export const Scary = () => <ButtonVariations scary />;
+export const Borderless = () => <ButtonVariations borderless />;
+export const Disabled = () => <ButtonVariations disabled />;
+export const Link = () => <ButtonVariations href="https://www.google.com/" target="_blank" />;
+export const Bare = () => <ButtonVariations bare />;

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -292,6 +292,16 @@
 	}
 }
 
+.button-bare {
+	appearance: none;
+	background: transparent;
+	border: none;
+	font-size: inherit;
+	outline: 0;
+	padding: 0;
+	vertical-align: baseline;
+}
+
 // ==========================================================================
 // Deprecated styles
 // ==========================================================================

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -295,8 +295,10 @@
 .button-bare {
 	appearance: none;
 	background: transparent;
+	color: inherit;
 	border: none;
 	font-size: inherit;
+	font-weight: inherit;
 	outline: 0;
 	padding: 0;
 	vertical-align: baseline;

--- a/yarn.lock
+++ b/yarn.lock
@@ -25643,6 +25643,14 @@ style-loader@^1.0.0:
     loader-utils "^1.2.3"
     schema-utils "^2.6.4"
 
+style-loader@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-1.2.1.tgz#c5cbbfbf1170d076cfdd86e0109c5bba114baa1a"
+  integrity sha512-ByHSTQvHLkWE9Ir5+lGbVOXhxX10fbprhLvdg96wedFZb4NDekDPxVKv5Fwmio+QcMlkkNfuK+5W1peQ5CUhZg==
+  dependencies:
+    loader-utils "^2.0.0"
+    schema-utils "^2.6.6"
+
 style-search@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/style-search/-/style-search-0.1.0.tgz#7958c793e47e32e07d2b5cafe5c0bf8e12e77902"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add missing `style-loader` dependency that is needed by storybook
    * I'm not sure if this was broken before somehow? When I tried to run storybook I kept getting a module-not-found error for style-loader 🤷‍♀️ 
* Add a new `bare` styled "button-as-div" as suggested by @jsnajdr here: https://github.com/Automattic/wp-calypso/pull/45344#pullrequestreview-481633595

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run `yarn run components:storybook:start` and ensure all buttons continue to work and that the "bare" button has the correct resets applied.
