### PR TITLE
Update the copy of some features in the Jetpack Complete plan card

### DIFF
--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -1243,7 +1243,7 @@ export const FEATURES_LIST = {
 
 	[ constants.FEATURE_PRODUCT_SEARCH_V2 ]: {
 		getSlug: () => constants.FEATURE_PRODUCT_SEARCH_V2,
-		getTitle: () => i18n.translate( 'Search' ),
+		getTitle: () => i18n.translate( 'Search: up to 100k records' ),
 		getDescription: () =>
 			i18n.translate(
 				'Help your site visitors find answers instantly so they keep reading and buying. Powerful filtering and customization options. {{link}}Learn more.{{/link}}',
@@ -1271,7 +1271,7 @@ export const FEATURES_LIST = {
 
 	[ constants.FEATURE_CRM_V2 ]: {
 		getSlug: () => constants.FEATURE_CRM_V2,
-		getTitle: () => i18n.translate( 'CRM' ),
+		getTitle: () => i18n.translate( 'CRM: Entrepreneur bundle' ),
 		getDescription: () =>
 			i18n.translate(
 				'The most simple and powerful WordPress CRM. Improve customer relationships and increase profits. {{link}}Learn more{{/link}}.',
@@ -1330,7 +1330,12 @@ export const FEATURES_LIST = {
 		getTitle: () => i18n.translate( 'Unlimited premium themes' ),
 		getDescription: () =>
 			i18n.translate(
-				'Unlimited access to all of our advanced premium themes, including designs specifically tailored for businesses.'
+				'Unlimited access to all of our advanced premium themes, including designs specifically tailored for businesses. {{link}}Learn more{{/link}}.',
+				{
+					components: {
+						link: <a href="https://jetpack.com/features/design/themes/" />,
+					},
+				}
 			),
 	},
 
@@ -1338,7 +1343,14 @@ export const FEATURES_LIST = {
 		getSlug: () => constants.FEATURE_PRIORITY_SUPPORT_V2,
 		getTitle: () => i18n.translate( 'Priority support' ),
 		getDescription: () =>
-			i18n.translate( 'Get fast WordPress support from the WordPress experts. ' ),
+			i18n.translate(
+				'Get fast WordPress support from the WordPress experts. {{link}}Learn more{{/link}}.',
+				{
+					components: {
+						link: <a href="https://jetpack.com/features/security/expert-priority-support/" />,
+					},
+				}
+			),
 	},
 
 	[ constants.FEATURE_SECURE_STORAGE_V2 ]: {


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR updates the copy of some features, in Jetpack Complete.


### Testing instructions

- Visit the _Plans_ page with the offer reset flow enabled
- Toggle on the features of the Jetpack Complete plan card
- Verify that you see the 4 updates below and that the links in the tooltips work


### Screenshots

1.

_Before_
<img width="558" alt="Screen Shot 2020-09-03 at 1 36 50 PM" src="https://user-images.githubusercontent.com/1620183/92150393-59550e80-eded-11ea-9a62-ad6edce9c541.png">

_After_
<img width="548" alt="Screen Shot 2020-09-03 at 1 42 34 PM" src="https://user-images.githubusercontent.com/1620183/92150406-5e19c280-eded-11ea-9553-cbf08ea4913c.png">

2.

_Before_
<img width="435" alt="Screen Shot 2020-09-03 at 1 44 16 PM" src="https://user-images.githubusercontent.com/1620183/92150426-65d96700-eded-11ea-9aa9-e7b91013bdbd.png">

_After_
<img width="439" alt="Screen Shot 2020-09-03 at 1 44 40 PM" src="https://user-images.githubusercontent.com/1620183/92150441-6a058480-eded-11ea-8865-50c374a69976.png">


3.

_Before_
<img width="439" alt="Screen Shot 2020-09-03 at 1 45 04 PM" src="https://user-images.githubusercontent.com/1620183/92150453-6e31a200-eded-11ea-8483-ebd5e13d8baf.png">

_After_
<img width="441" alt="Screen Shot 2020-09-03 at 1 46 13 PM" src="https://user-images.githubusercontent.com/1620183/92150466-71c52900-eded-11ea-91c1-e895313ccc1f.png">

4.

_Before_
<img width="550" alt="Screen Shot 2020-09-03 at 1 47 47 PM" src="https://user-images.githubusercontent.com/1620183/92150483-77227380-eded-11ea-9532-d2f3cf992152.png">

_After_
<img width="550" alt="Screen Shot 2020-09-03 at 1 49 57 PM" src="https://user-images.githubusercontent.com/1620183/92150494-7be72780-eded-11ea-9118-733e28017ebf.png">

