### PR TITLE
Remove no-longer-used Apple Pay merchant validation endpoint

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -2536,10 +2536,6 @@ Undocumented.prototype.getDomainConnectSyncUxUrl = function (
 	);
 };
 
-Undocumented.prototype.applePayMerchantValidation = function ( validationURL ) {
-	return this.wpcom.req.get( '/apple-pay/merchant-validation/', { validation_url: validationURL } );
-};
-
 Undocumented.prototype.domainsVerifyRegistrantEmail = function ( domain, email, token ) {
 	return this.wpcom.req.get( `/domains/${ domain }/verify-email`, { email, token } );
 };


### PR DESCRIPTION
This pull request just removes the method which is used to call the `apple-pay/merchant-validation` endpoint on the server.

It's no longer used in Calypso, and it hasn't been relevant for a while since we now do Apple Pay entirely via Stripe.

See also: D49069-code
