### PR TITLE
Re-merge "[E2E] Embed block fixes"

### DIFF
--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -279,6 +279,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 			case 'Instagram':
 			case 'Twitter':
 			case 'YouTube':
+				ariaLabel = 'Block: Embed';
 				prefix = 'embed-';
 				break;
 			case 'Form':

--- a/test/e2e/specs/wp-calypso-gutenberg-coblocks-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-coblocks-spec.js
@@ -60,6 +60,9 @@ describe( `[${ host }] Calypso Gutenberg Editor: CoBlocks (${ screenSize })`, fu
 
 		step( 'Can publish and view content', async function () {
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			// We need to save the post to get a stable post slug for the block's `url` attribute.
+			// See https://github.com/godaddy-wordpress/coblocks/issues/1663.
+			await gEditorComponent.ensureSaved();
 			return await gEditorComponent.publish( { visit: true, closePanel: false } );
 		} );
 

--- a/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -1166,7 +1166,8 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 			await gEditorComponent.enterTitle( 'Embeds: ' + blogPostTitle );
 
-			this.instagramEditorSelector = '.wp-block-embed-instagram';
+			this.instagramEditorSelector =
+				'.wp-block-embed iframe[title="Embedded content from instagram.com"]';
 			const blockIdInstagram = await gEditorComponent.addBlock( 'Instagram' );
 			const gEmbedsComponentInstagram = await EmbedsBlockComponent.Expect(
 				driver,
@@ -1175,7 +1176,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			await gEmbedsComponentInstagram.embedUrl( 'https://www.instagram.com/p/BlDOZMil933/' );
 			await gEmbedsComponentInstagram.isEmbeddedInEditor( this.instagramEditorSelector );
 
-			this.twitterEditorSelector = '.wp-block-embed-twitter';
+			this.twitterEditorSelector = '.wp-block-embed iframe[title="Embedded content from twitter"]';
 			const blockIdTwitter = await gEditorComponent.addBlock( 'Twitter' );
 			const gEmbedsComponentTwitter = await EmbedsBlockComponent.Expect( driver, blockIdTwitter );
 			await gEmbedsComponentTwitter.embedUrl(
@@ -1183,7 +1184,8 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			);
 			await gEmbedsComponentTwitter.isEmbeddedInEditor( this.twitterEditorSelector );
 
-			this.youtubeEditorSelector = '.wp-block-embed-youtube';
+			this.youtubeEditorSelector =
+				'.wp-block-embed iframe[title="Embedded content from youtube.com"]';
 			const blockIdYouTube = await gEditorComponent.addBlock( 'YouTube' );
 			const gEmbedsComponentYouTube = await EmbedsBlockComponent.Expect( driver, blockIdYouTube );
 			await gEmbedsComponentYouTube.embedUrl( 'https://www.youtube.com/watch?v=xifhQyopjZM' );


### PR DESCRIPTION
https://github.com/Automattic/wp-calypso/pull/45345 had been merged before we released Gutenberg 8.9 and it had GB 8.9-specific changes. We needed to revert here: Automattic/wp-calypso#45394. This basically "merges" https://github.com/Automattic/wp-calypso/pull/45345 again.