### PR TITLE
Bump WordPress.com Editing Toolkit plugin to v2.2

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WordPress.com Editing Toolkit
  * Description: Enhances your page creation workflow within the Block Editor.
- * Version: 2.1
+ * Version: 2.2
  * Author: Automattic
  * Author URI: https://automattic.com/wordpress-plugins/
  * License: GPLv2 or later
@@ -35,7 +35,7 @@ namespace A8C\FSE;
  *
  * @var string
  */
-define( 'PLUGIN_VERSION', '2.1' );
+define( 'PLUGIN_VERSION', '2.2' );
 
 // Always include these helper files for dotcom FSE.
 require_once __DIR__ . '/dotcom-fse/helpers.php';

--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -2,8 +2,8 @@
 Contributors: alexislloyd, allancole, automattic, bartkalisz, codebykat, copons, dmsnell, get_dave, glendaviesnz, gwwar, iamtakashi, iandstewart, jeryj, Joen, jonsurrell, kwight, marekhrabe, mattwiebe, mkaz, mmtr86, mppfeiffer, noahtallen, nosolosw, nrqsnchz, obenland, okenobi, owolski, philipmjackson, vindl
 Tags: block, blocks, editor, gutenberg, page
 Requires at least: 5.0
-Tested up to: 5.4
-Stable tag: 2.1
+Tested up to: 5.5
+Stable tag: 2.2
 Requires PHP: 5.6.20
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -39,6 +39,9 @@ This plugin is experimental, so we don't provide any support for it outside of w
 
 
 == Changelog ==
+
+= 2.2 =
+* Improve experience of opening and closing the sidebar with assistive technology (https://github.com/Automattic/wp-calypso/pull/45349)
 
 = 2.1 =
 * Fix site editor loading problem with Gutenberg 8.9.0 (https://github.com/Automattic/wp-calypso/pull/45360)

--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/wpcom-editing-toolkit",
-	"version": "2.1.0",
+	"version": "2.2.0",
 	"description": "Plugin for editing-related features.",
 	"sideEffects": true,
 	"repository": {

--- a/package.json
+++ b/package.json
@@ -181,7 +181,7 @@
 		"@automattic/webpack-inline-constant-exports-plugin": "^0.0.1",
 		"@automattic/wp-babel-makepot": "^1.0.0",
 		"@automattic/wpcom-block-editor": "^1.0.0-alpha.0",
-		"@automattic/wpcom-editing-toolkit": "^2.1.0",
+		"@automattic/wpcom-editing-toolkit": "^2.2.0",
 		"@babel/cli": "^7.10.5",
 		"@babel/core": "^7.11.1",
 		"@babel/register": "^7.10.5",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Bump to version 2.2
* Update release notes

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply generated diff to sandbox
* Test changes listed in release notes are present
* Install build on an atomic site
* Test that editor works on atomic with and without gutenberg plugin enabled

