### PR TITLE
Components: Remove global input[type='tel'] styles

### DIFF
--- a/client/assets/stylesheets/shared/_forms.scss
+++ b/client/assets/stylesheets/shared/_forms.scss
@@ -10,7 +10,6 @@ input[type='text'],
 input[type='email'],
 input[type='number'],
 input[type='password'],
-input[type='tel'],
 textarea {
 	@extend %form-field;
 }
@@ -24,7 +23,6 @@ input[type='text'],
 input[type='email'],
 input[type='number'],
 input[type='password'],
-input[type='tel'],
 textarea,
 select,
 label {

--- a/client/components/forms/form-tel-input/index.jsx
+++ b/client/components/forms/form-tel-input/index.jsx
@@ -1,10 +1,11 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+
+import FormTextInput from 'components/forms/form-text-input';
 
 export default function FormTelInput( { className, isError, isValid, ...props } ) {
 	const classes = classNames( 'form-tel-input', className, {
@@ -12,7 +13,7 @@ export default function FormTelInput( { className, isError, isValid, ...props } 
 		'is-valid': isValid,
 	} );
 
-	return <input pattern="[0-9\-() +]*" { ...props } type="tel" className={ classes } />;
+	return <FormTextInput pattern="[0-9\-() +]*" { ...props } type="tel" className={ classes } />;
 }
 
 FormTelInput.propTypes = {

--- a/client/components/forms/form-tel-input/style.scss
+++ b/client/components/forms/form-tel-input/style.scss
@@ -1,3 +1,0 @@
-.form-tel-input {
-	-webkit-appearance: none;
-}

--- a/client/components/forms/form-text-input/style.scss
+++ b/client/components/forms/form-text-input/style.scss
@@ -1,9 +1,13 @@
 .form-text-input {
 	@at-root {
 		input[type='url'],
+		input[type='tel'],
 		input[type='search'] {
 			@extend %form-field;
+		}
 
+		input[type='url'],
+		input[type='search'] {
 			appearance: none;
 
 			/*!rtl:ignore*/

--- a/client/components/forms/form-verification-code-input/index.jsx
+++ b/client/components/forms/form-verification-code-input/index.jsx
@@ -8,6 +8,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
+import FormTextInput from 'components/forms/form-text-input';
 import constants from 'me/constants';
 
 /**
@@ -53,7 +54,7 @@ export default class FormVerificationCodeInput extends React.Component {
 		}
 
 		return (
-			<input
+			<FormTextInput
 				autoComplete="off"
 				className={ classes }
 				pattern="[0-9 ]*"

--- a/client/components/phone-input/index.jsx
+++ b/client/components/phone-input/index.jsx
@@ -88,7 +88,7 @@ function PhoneInput( {
 				onKeyUp={ handleCursorMove }
 				name={ name }
 				value={ displayValue }
-				ref={ numberInputRef }
+				inputRef={ numberInputRef }
 				type="tel"
 				disabled={ disabled }
 				className={ classnames( 'phone-input__number-input', {

--- a/client/components/phone-input/index.jsx
+++ b/client/components/phone-input/index.jsx
@@ -12,6 +12,7 @@ import debugFactory from 'debug';
  * Internal dependencies
  */
 import FormCountrySelect from 'components/forms/form-country-select';
+import FormTextInput from 'components/forms/form-text-input';
 import {
 	formatNumber,
 	toIcannFormat,
@@ -80,7 +81,7 @@ function PhoneInput( {
 
 	return (
 		<div className={ classnames( className, 'phone-input' ) }>
-			<input
+			<FormTextInput
 				placeholder={ translate( 'Phone' ) }
 				onChange={ handleInput }
 				onClick={ handleCursorMove }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove global form `input[type='tel']` styles in favor of more specific component-level styling. See #45259.

#### Testing instructions

* Test the following against production and ensure that they match stylistically and functionally:
  * `/devdocs/design/form-fields` - the 3 examples with "Form Tel Input"
  * `/devdocs/design/form-fields` - the Form Phone Input examples
  * `/me/security` - visit after deleting the `twostep_auth` cookie for `public-api.wordpress.com`, and compare the input field in the provided 2FA input form.
* Verify all `<input type="tel" />` instances use `<FormTextInput />`.

#### Notes/questions

Should we completely remove the `FormTelInput` component? It seems to be used only in devdocs, and all production instances use `FormTextInput` with `type="tel"` and additional props. There is also a phone number component, which is much more powerful. For me, that makes that `FormTelInput` component pretty useless. What are your thoughts, @Automattic/team-calypso folks?