### PR TITLE
Add multi-stage docker file for CI image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,6 @@
 Dockerfile
+Dockerfile.base
+bin/build-docker.sh
 /.tsc-cache
 /.cache
 .dockerignore

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,0 +1,52 @@
+#### builder image
+FROM node:12.18.0 as builder
+
+ARG node_memory=8192
+WORKDIR /calypso
+ENV YARN_CACHE_FOLDER=/calypso/.cache/yarn
+ENV NPM_CONFIG_CACHE=/calypso/.cache
+ENV NVM_DIR=/calypso/.nvm
+ENV NODE_ENV=production
+ENV CALYPSO_ENV=production
+ENV NODE_OPTIONS=--max-old-space-size=$node_memory
+ENV CHROMEDRIVER_SKIP_DOWNLOAD=true
+ENV PUPPETEER_SKIP_DOWNLOAD=true
+ENV HOME=/calypso
+
+RUN git clone https://github.com/nvm-sh/nvm.git "$NVM_DIR" \
+	&& git -C "$NVM_DIR" checkout v0.35.3
+
+COPY . .
+
+# Run nvm.sh in a different dir so it doesn't try to use the version specified in /calypso/.nvmrc.
+# If not, it will fail the image generation
+RUN cd / \
+	&& . "$NVM_DIR/nvm.sh" \
+	&& cd $HOME \
+	&& nvm install \
+	&& nvm use \
+	# Prime yarn cache
+	&& yarn \
+	# Prime webpack caches
+	&& yarn build-client-both
+
+ENTRYPOINT [ "/bin/bash" ]
+
+#### ci image
+FROM node:12.18.0 as ci
+
+ARG node_memory=8192
+ARG UID=1003
+
+WORKDIR /calypso
+ENV YARN_CACHE_FOLDER=/calypso/.cache/yarn
+ENV NPM_CONFIG_CACHE=/calypso/.cache
+ENV NVM_DIR=/calypso/.nvm
+ENV NODE_OPTIONS=--max-old-space-size=$node_memory
+ENV HOME=/calypso
+
+RUN chown $UID /calypso
+# Copy nvm cache so we don't need to download it again
+COPY --from=builder --chown=$UID /calypso/.nvm /calypso/.nvm
+# Copy all other caches (webpack, babel, yarn...)
+COPY --from=builder --chown=$UID /calypso/.cache /calypso/.cache

--- a/bin/build-docker.sh
+++ b/bin/build-docker.sh
@@ -15,5 +15,5 @@ CI_IMAGE_NAME="registry.a8c.com/calypso/ci"
 BUILDER_IMAGE="${BUILDER_IMAGE_NAME}:${VERSION}"
 CI_IMAGE="${CI_IMAGE_NAME}:${VERSION}"
 
-docker build -f Dockerfile.base --target builder -t "$BUILDER_IMAGE" .
+docker build -f Dockerfile.base --no-cache --target builder -t "$BUILDER_IMAGE" .
 docker build -f Dockerfile.base --target ci -t "$CI_IMAGE" .

--- a/bin/build-docker.sh
+++ b/bin/build-docker.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if [[ -z "${1:-}" ]] ; then
+    echo "Missing version. Usage:"
+	echo "$0 <version>"
+    exit 1
+fi
+
+VERSION="$1"
+BUILDER_IMAGE_NAME="registry.a8c.com/calypso/base"
+CI_IMAGE_NAME="registry.a8c.com/calypso/ci"
+BUILDER_IMAGE="${BUILDER_IMAGE_NAME}:${VERSION}"
+CI_IMAGE="${CI_IMAGE_NAME}:${VERSION}"
+
+docker build -f Dockerfile.base --target builder -t "$BUILDER_IMAGE" .
+docker build -f Dockerfile.base --target ci -t "$CI_IMAGE" .


### PR DESCRIPTION
### Changes proposed in this Pull Request

Adds a new Dockerfile used to generate an image that will be used to run CI tests in TeamCity (see https://github.com/Automattic/wp-calypso/pull/45399/files#diff-e9c4033904a319e2d4b3dd1f864d1966R71).

This CI image is like `node:12.18.0` with:
* Extra env options to configure the cache and max memory
* `/calypso/.nvm` with a nvm cache for faster Node installation
* `/calypso/.cache/yarn` with yarn cache for faster dependency installation
* `/calypso/.cache/*` with all webpack caches (babel, terser...) for faster compilations

### Testing instructions

Checkout the branch and run `./bin/build-docker.sh foo` (it will take a while, ~30m in my machine). You should end up with two new docker images, you can see them with `docker image ls`:

```
REPOSITORY         TAG                                               IMAGE ID            CREATED             SIZE
XXX/calypso/ci     foo                                               1fa1b89c3a1b        3 minutes ago       2.25GB
XXX/calypso/base   foo                                               af7d28124568        7 minutes ago       3.78GB
```

To check the content of the cache, run `docker run --rm -ti --entrypoint /bin/sh XXX/calypso/ci:foo  -c "ls -la /calypso/.cache"`