### PR TITLE
Editor Deprecation: Remove Calypsoification when redirecting to wp-admin

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -691,6 +691,7 @@ class CalypsoifyIframe extends Component<
 							onLoad={ () => {
 								this.onIframeLoaded( iframeUrl );
 							} }
+							style={ { display: isIframeLoaded ? 'block' : 'none' } }
 						/>
 						/* eslint-enable jsx-a11y/iframe-has-title */
 					) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

On sites with the classic editor plugin installed, the user eventually
gets redirected to wp-admin. This can also happen when the editor
doesn't load correctly in the iframe. Currently they are left in a
Calypsoified classic editor. This is an attempt to turn that off and
return them to a vanilla wp-admin.

#### Testing instructions

On a Jetpack/Atomic site with the classic editor installed and with a user that has the `editor_deprecation_group` attribute set to `true`, create or edit a post in Calypso. You'll eventually be redirected to wp-admin. Unfortunately you will be in a Calypsoified editor for a few seconds. I need to work out if we can prevent that.

