### PR TITLE
Inline Help: Add Managing Purchases Link

### DIFF
--- a/client/blocks/inline-help/contextual-help.js
+++ b/client/blocks/inline-help/contextual-help.js
@@ -13,6 +13,9 @@ import { localizeUrl } from 'lib/i18n-utils';
 /**
  * Module variables
  */
+
+/* eslint-disable inclusive-language/use-inclusive-words */
+// All usage of the word "master" here refers to the verb (ie. "to learn"), not a synonym of "primary".
 const getFallbackLinks = () => [
 	{
 		link: localizeUrl(
@@ -251,7 +254,7 @@ const getContextLinksForSection = () => ( {
 		{
 			link: localizeUrl( 'https://wordpress.com/support/manage-purchases/' ),
 			post_id: 111349,
-			title: translate( 'Manage Purchases' ),
+			title: translate( 'Managing Purchases, Renewals, and Cancellations' ),
 			description: translate(
 				'Have a question or need to change something about a purchase you have made? Learn how.'
 			),
@@ -1491,7 +1494,6 @@ export function getContextResults( section ) {
 	// If true, still display fallback links in addition (as opposed to instead
 	// of) the other context links.
 	if ( section === 'home' ) {
-		const links = get( contextLinksForSection, section, fallbackLinks );
 		return compact( [ tour, video, ...getFallbackLinks(), ...links ] );
 	}
 

--- a/client/blocks/inline-help/contextual-help.js
+++ b/client/blocks/inline-help/contextual-help.js
@@ -1042,6 +1042,14 @@ const getContextLinksForSection = () => ( {
 				'A domain name is an address people use to visit your site. It tells the web browser where to look for your site. Just like a street address, a domain is how people visit your website online. And, like having a sign in front of your store, a custom domain name helps give your site a professional look.'
 			),
 		},
+		{
+			link: localizeUrl( 'https://wordpress.com/support/manage-purchases/' ),
+			post_id: 111349,
+			title: translate( 'Managing Purchases, Renewals, and Cancellations' ),
+			description: translate(
+				'Have a question or need to change something about a purchase you have made? Learn how.'
+			),
+		},
 	],
 } );
 let contextLinksForSection = getContextLinksForSection();

--- a/client/blocks/inline-help/contextual-help.js
+++ b/client/blocks/inline-help/contextual-help.js
@@ -624,6 +624,14 @@ const getContextLinksForSection = () => ( {
 				'Get ready to publish! Our five-step checklist walks you through all the fundamentals.'
 			),
 		},
+		{
+			link: localizeUrl( 'https://wordpress.com/support/manage-purchases/' ),
+			post_id: 111349,
+			title: translate( 'Managing Purchases, Renewals, and Cancellations' ),
+			description: translate(
+				'Have a question or need to change something about a purchase you have made? Learn how.'
+			),
+		},
 	],
 	themes: [
 		{
@@ -737,6 +745,14 @@ const getContextLinksForSection = () => ( {
 			title: translate( 'Jetpack Plans' ),
 			description: translate(
 				'Learn about the free Jetpack plugin, its benefits, and the useful capabilities and features that a Jetpack plan unlocks.'
+			),
+		},
+		{
+			link: localizeUrl( 'https://wordpress.com/support/manage-purchases/' ),
+			post_id: 111349,
+			title: translate( 'Managing Purchases, Renewals, and Cancellations' ),
+			description: translate(
+				'Have a question or need to change something about a purchase you have made? Learn how.'
 			),
 		},
 	],
@@ -867,6 +883,14 @@ const getContextLinksForSection = () => ( {
 			link: localizeUrl( 'https://learn.wordpress.com/' ),
 			title: translate( 'Self-guided Online Tutorial' ),
 			description: translate( 'A step-by-step guide to getting familiar with the platform.' ),
+		},
+		{
+			link: localizeUrl( 'https://wordpress.com/support/manage-purchases/' ),
+			post_id: 111349,
+			title: translate( 'Managing Purchases, Renewals, and Cancellations' ),
+			description: translate(
+				'Have a question or need to change something about a purchase you have made? Learn how.'
+			),
 		},
 	],
 	comments: [

--- a/client/blocks/inline-help/contextual-help.js
+++ b/client/blocks/inline-help/contextual-help.js
@@ -132,6 +132,16 @@ const getContextLinksForSection = () => ( {
 			),
 		},
 	],
+	home: [
+		{
+			link: localizeUrl( 'https://wordpress.com/support/manage-purchases/' ),
+			post_id: 111349,
+			title: translate( 'Managing Purchases' ),
+			description: translate(
+				'Have a question or need to change something about a purchase you have made? Learn how.'
+			),
+		},
+	],
 	me: [
 		{
 			link: localizeUrl( 'https://wordpress.com/support/manage-my-profile/' ),
@@ -1469,5 +1479,13 @@ export function getContextResults( section ) {
 	const video = first( get( videosForSection, section ) );
 	const tour = first( get( toursForSection, section ) );
 	const links = get( contextLinksForSection, section, fallbackLinks );
+
+	// If true, still display fallback links in addition (as opposed to instead
+	// of) the other context links.
+	if ( section === 'home' ) {
+		const links = get( contextLinksForSection, section, fallbackLinks );
+		return compact( [ tour, video, ...getFallbackLinks(), ...links ] );
+	}
+
 	return compact( [ tour, video, ...links ] );
 }

--- a/client/blocks/inline-help/inline-help-search-results.jsx
+++ b/client/blocks/inline-help/inline-help-search-results.jsx
@@ -81,7 +81,7 @@ function HelpSearchResults( {
 		} else if ( hasAPIResults ) {
 			resultsSpeak();
 		}
-	}, [ isSearching ] );
+	}, [ isSearching, hasAPIResults, searchQuery ] );
 
 	function getTitleBySectionType( type, query = '' ) {
 		let title = '';
@@ -146,7 +146,13 @@ function HelpSearchResults( {
 
 		// Unless searching with Inline Help or on the Purchases section, hide the
 		// "Managing Purchases" documentation link for users who have not made a purchase.
-		if ( post_id === 111349 && ! isSearching && ! hasAPIResults && ! hasPurchases && sectionName !== 'purchases' ) {
+		if (
+			post_id === 111349 &&
+			! isSearching &&
+			! hasAPIResults &&
+			! hasPurchases &&
+			sectionName !== 'purchases'
+		) {
 			return null;
 		}
 

--- a/client/blocks/inline-help/inline-help-search-results.jsx
+++ b/client/blocks/inline-help/inline-help-search-results.jsx
@@ -146,7 +146,7 @@ function HelpSearchResults( {
 
 		// Unless searching with Inline Help or on the Purchases section, hide the
 		// "Managing Purchases" documentation link for users who have not made a purchase.
-		if ( post_id === 111349 && ! isSearching && ! hasPurchases && sectionName !== 'purchases' ) {
+		if ( post_id === 111349 && ! isSearching && ! hasAPIResults && ! hasPurchases && sectionName !== 'purchases' ) {
 			return null;
 		}
 

--- a/client/blocks/inline-help/inline-help-search-results.jsx
+++ b/client/blocks/inline-help/inline-help-search-results.jsx
@@ -17,11 +17,15 @@ import { recordTracksEvent } from 'state/analytics/actions';
 import QueryInlineHelpSearch from 'components/data/query-inline-help-search';
 import PlaceholderLines from './placeholder-lines';
 import { decodeEntities, preventWidows } from 'lib/formatting';
+import QueryUserPurchases from 'components/data/query-user-purchases';
+import { getSectionName } from 'state/ui/selectors';
 import getSearchResultsByQuery from 'state/inline-help/selectors/get-inline-help-search-results-for-query';
 import getSelectedResultIndex from 'state/inline-help/selectors/get-selected-result-index';
 import getInlineHelpCurrentlySelectedResult from 'state/inline-help/selectors/get-inline-help-currently-selected-result';
 import isRequestingInlineHelpSearchResultsForQuery from 'state/inline-help/selectors/is-requesting-inline-help-search-results-for-query';
 import hasInlineHelpAPIResults from 'state/selectors/has-inline-help-api-results';
+import hasCancelableUserPurchases from 'state/selectors/has-cancelable-user-purchases';
+import { getCurrentUserId } from 'state/current-user/selectors';
 import { selectResult } from 'state/inline-help/actions';
 import { localizeUrl } from 'lib/i18n-utils';
 import Gridicon from 'components/gridicon';
@@ -44,12 +48,15 @@ const resultsSpeak = debounceSpeak( { message: 'Search results loaded.' } );
 const errorSpeak = debounceSpeak( { message: 'No search results found.' } );
 
 function HelpSearchResults( {
+	currentUserId,
 	hasAPIResults = false,
+	hasPurchases,
 	isSearching = false,
 	onSelect,
 	onAdminSectionSelect = noop,
 	searchQuery = '',
 	searchResults = [],
+	sectionName,
 	selectedResultIndex = -1,
 	selectSearchResult,
 	translate = identity,
@@ -123,12 +130,25 @@ function HelpSearchResults( {
 	};
 
 	const renderHelpLink = ( result ) => {
-		const { link, key, title, support_type = SUPPORT_TYPE_API_HELP, icon = 'domains' } = result;
+		const {
+			link,
+			key,
+			title,
+			support_type = SUPPORT_TYPE_API_HELP,
+			icon = 'domains',
+			post_id,
+		} = result;
 		const resultIndex = searchResults.findIndex( ( r ) => r.link === link );
 
 		const classes = classNames( 'inline-help__results-item', {
 			'is-selected': selectedResultIndex === resultIndex,
 		} );
+
+		// Unless searching with Inline Help or on the Purchases section, hide the
+		// "Managing Purchases" documentation link for users who have not made a purchase.
+		if ( post_id === 111349 && ! isSearching && ! hasPurchases && sectionName !== 'purchases' ) {
+			return null;
+		}
 
 		return (
 			<Fragment key={ link ?? key }>
@@ -216,6 +236,7 @@ function HelpSearchResults( {
 	return (
 		<>
 			<QueryInlineHelpSearch query={ searchQuery } />
+			{ currentUserId && <QueryUserPurchases userId={ currentUserId } /> }
 			{ renderSearchResults() }
 		</>
 	);
@@ -236,11 +257,14 @@ HelpSearchResults.propTypes = {
 
 export default connect(
 	( state, ownProps ) => ( {
+		currentUserId: getCurrentUserId( state ),
 		searchResults: getSearchResultsByQuery( state ),
 		isSearching: isRequestingInlineHelpSearchResultsForQuery( state, ownProps.searchQuery ),
 		selectedResultIndex: getSelectedResultIndex( state ),
 		hasAPIResults: hasInlineHelpAPIResults( state ),
 		selectedResult: getInlineHelpCurrentlySelectedResult( state ),
+		hasPurchases: hasCancelableUserPurchases( state, getCurrentUserId( state ) ),
+		sectionName: getSectionName( state ),
 	} ),
 	{
 		track: recordTracksEvent,

--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -80,6 +80,13 @@ class Help extends React.PureComponent {
 					'Limit your site’s visibility or make it completely private.'
 				),
 			},
+			{
+				link: 'https://wordpress.com/support/manage-purchases/',
+				title: this.props.translate( 'Managing Purchases, Renewals, and Cancellations' ),
+				description: this.props.translate(
+					'Have a question or need to change something about a purchase you have made? Learn how.'
+				),
+			},
 		];
 
 		return (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Includes the link to [this document](https://wordpress.com/support/manage-purchases/) on the requested sections. The only exception is for the My Home: @michaeldcain - Inline Help appears to be hidden for the My Home section, should it be made visible?

As requested, it's only visible for people who have made a purchase, unless they're on the Purchases section (where the link is already present) as I think that's what the original issue implies.

#### Testing instructions

Check the sections mentioned in the original issue, and verify the "Managing Purchases, Renewals, and Cancellations" link appears if you have a purchase which you can manage/renew/cancel.

<img width="501" alt="Screenshot 2020-09-04 at 17 09 15" src="https://user-images.githubusercontent.com/43215253/92261501-6ea36900-eed1-11ea-9d77-f97b99adfb03.png">

cc @michaeldcain 

Fixes #45383
