### PR TITLE
Earn: Properly display commission values of 0.

### DIFF
--- a/client/my-sites/earn/memberships/index.jsx
+++ b/client/my-sites/earn/memberships/index.jsx
@@ -111,7 +111,7 @@ class MembershipsSection extends Component {
 						</ul>
 					</div>
 					<div className="memberships__earnings-breakdown-notes">
-						{ commission &&
+						{ commission !== null &&
 							translate(
 								'On your current plan, WordPress.com charges {{em}}%(commission)s{{/em}}.{{br/}} Additionally, Stripe charges are typically %(stripe)s. {{a}}Learn more{{/a}}',
 								{


### PR DESCRIPTION
Ecommerce plans on dotcom are charged a commission rate of 0%, which will not properly display with the recently-added #45373. This PR corrects the check to allow a `0` value for `earnings.commission`.

<img width="1180" alt="Screen Shot 2020-09-04 at 10 25 37 AM" src="https://user-images.githubusercontent.com/349751/92269467-12bcee00-ee99-11ea-9415-f4143efaff13.png">


#### Testing instructions

* Sandbox the API and apply D49085-code.
* Go to `/earn/payments/:site`, where the site has a plan other than eCommerce and a connected Stripe account.
* Verify the [commission amount](https://wordpress.com/support/wordpress-editor/blocks/payments/#related-fees) displayed is correct.
* Load the same page with a site on an eCommerce plan and Stripe connected.
* Verify the 0% commission is properly displayed.

Fixes #45304