### PR TITLE
Jetpack Offer Reset: Show different plans page Header if coming from in-place connection flow.

### DIFF
--- a/client/my-sites/plans-v2/plans-header.tsx
+++ b/client/my-sites/plans-v2/plans-header.tsx
@@ -23,12 +23,14 @@ const StandardPlansHeader = () => (
 );
 const ConnectFlowPlansHeader = () => (
 	<>
-		<FormattedHeader
-			headerText={ translate( 'Explore our Jetpack plans' ) }
-			subHeaderText={ translate( "Now that you're set up, pick a plan that suits your needs." ) }
-			align="left"
-			brandFont
-		/>
+		<div className="plans-v2__heading">
+			<FormattedHeader
+				headerText={ translate( 'Explore our Jetpack plans' ) }
+				subHeaderText={ translate( "Now that you're set up, pick a plan that suits your needs." ) }
+				align="left"
+				brandFont
+			/>
+		</div>
 		<CartData>
 			<PlansNavigation path={ '/plans' } />
 		</CartData>

--- a/client/my-sites/plans-v2/plans-header.tsx
+++ b/client/my-sites/plans-v2/plans-header.tsx
@@ -26,7 +26,7 @@ const ConnectFlowPlansHeader = () => (
 		<div className="plans-v2__heading">
 			<FormattedHeader
 				headerText={ translate( 'Explore our Jetpack plans' ) }
-				subHeaderText={ translate( "Now that you're set up, pick a plan that suits your needs." ) }
+				subHeaderText={ translate( "Now that you're set up, pick a plan that fits your needs." ) }
 				align="left"
 				brandFont
 			/>
@@ -41,10 +41,9 @@ const PlansHeader = ( { context }: { context: PageJS.Context } ) => {
 	const state = context.store.getState();
 	const siteId = getSelectedSiteId( state );
 
+	// When coming from in-connect flow, the url contains 'source=jetpack-plans' query param.
 	const isInConnectFlow = useMemo(
-		() =>
-			/jetpack\/connect\/plans/.test( window.location.href ) ||
-			/source=jetpack-(connect-)?plans/.test( window.location.href ),
+		() => context.query?.source && context.query.source === 'jetpack-plans',
 		[ siteId ]
 	);
 

--- a/client/my-sites/plans-v2/plans-header.tsx
+++ b/client/my-sites/plans-v2/plans-header.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { useState, useMemo } from 'react';
 import { translate } from 'i18n-calypso';
 
 /**
@@ -10,8 +10,10 @@ import { translate } from 'i18n-calypso';
 import PlansNavigation from 'my-sites/plans/navigation';
 import CartData from 'components/data/cart';
 import FormattedHeader from 'components/formatted-header';
+import Notice from 'components/notice';
+import { getSelectedSiteId } from 'state/ui/selectors';
 
-const PlansHeader = () => (
+const StandardPlansHeader = () => (
 	<>
 		<FormattedHeader headerText={ translate( 'Plans' ) } align="left" brandFont />
 		<CartData>
@@ -19,7 +21,47 @@ const PlansHeader = () => (
 		</CartData>
 	</>
 );
+const ConnectFlowPlansHeader = () => (
+	<>
+		<FormattedHeader
+			headerText={ translate( 'Explore our Jetpack plans' ) }
+			subHeaderText={ translate( "Now that you're set up, pick a plan that suits your needs." ) }
+			align="left"
+			brandFont
+		/>
+		<CartData>
+			<PlansNavigation path={ '/plans' } />
+		</CartData>
+	</>
+);
+
+const PlansHeader = ( { context }: { context: PageJS.Context } ) => {
+	const state = context.store.getState();
+	const siteId = getSelectedSiteId( state );
+
+	const isInConnectFlow = useMemo(
+		() =>
+			/jetpack\/connect\/plans/.test( window.location.href ) ||
+			/source=jetpack-(connect-)?plans/.test( window.location.href ),
+		[ siteId ]
+	);
+
+	const [ showNotice, setShowNotice ] = useState( true );
+
+	return isInConnectFlow ? (
+		<>
+			{ showNotice && (
+				<Notice status="is-success" onDismissClick={ () => setShowNotice( false ) }>
+					{ translate( 'Jetpack is now connected. Next select a plan.' ) }
+				</Notice>
+			) }
+			<ConnectFlowPlansHeader />
+		</>
+	) : (
+		<StandardPlansHeader />
+	);
+};
 
 export default function setJetpackHeader( context: PageJS.Context ) {
-	context.header = <PlansHeader />;
+	context.header = <PlansHeader context={ context } />;
 }

--- a/client/my-sites/plans-v2/style.scss
+++ b/client/my-sites/plans-v2/style.scss
@@ -178,6 +178,9 @@
 
 .records-details__timeframe {
 	margin-top: -4px;
-
 	font-size: 0.75rem;
+}
+
+.plans-v2__heading {
+	padding: 1rem 0;
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request

If user is coming to the plans page from the in-place flow, The plans page header shows:
1. A notification to the top of the page with check icon  and message "Jetpack is now connected. Next select a plan"
2. Main heading that reads, "Explore our Jetpack Plans" 
3. Subheading that reads, "Now that you're set up, pick a plan that suits your needs."

Otherwise, show the standard Plans page header.

### Testing instructions

Fixes: 1169247016322522-as-1189571103989169

1. Go to the Jetpack Dashboard in wp-admin of your Jurassic Ninja site.
2. Select the "Plans"  tab/link, this will take you to the 'Plans' page on wp.com. (Make sure you have _offerResetFlow A/B_ test enabled)  OR  You can just add `?source=jetpack-plans` to the plans page URL, for example: `http://calypso.localhost:3000/plans/:SITE/?source=jetpack-plans`
3. Confirm that you see the custom header (1, 2, and 3 of the changes proposed above) when coming from the wp-admin Jetpack dashboard (in-place connection flow). (see screenshot)

_Showing custom header when coming from 'In-place Flow'_

![Markup 2020-09-08 at 05 45 44](https://user-images.githubusercontent.com/11078128/92479332-413c1100-f198-11ea-9958-b261973a367f.png)

4. Next, view the plans page when not coming from the 'In-place Flow'.  You can do this by switching sites, and then switching back again to the "Plans" page.  You should see the standard header. (See screenshot) 

_Showing standard header when **not** coming from 'In-place Flow'_

![Screenshot on 2020-09-08 at 05-46-24](https://user-images.githubusercontent.com/11078128/92479681-b871a500-f198-11ea-95a5-4cce339dafa6.png)

