### PR TITLE
Don't filter the deleted DNS records from the returned data

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import debugFactory from 'debug';
-import { camelCase, isPlainObject, omit, pick, reject, snakeCase, set } from 'lodash';
+import { camelCase, isPlainObject, omit, pick, snakeCase, set } from 'lodash';
 import { stringify } from 'qs';
 
 /**
@@ -1705,8 +1705,7 @@ Undocumented.prototype.fetchDns = function ( domainName, fn ) {
 };
 
 Undocumented.prototype.updateDns = function ( domain, records, fn ) {
-	const filtered = reject( records, 'isBeingDeleted' ),
-		body = { dns: JSON.stringify( filtered ) };
+	const body = { dns: JSON.stringify( records ) };
 
 	return this.wpcom.req.post( '/domains/' + domain + '/dns', body, fn );
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In order to match changes made for the DNS update endpoint, we no longer want to filter out the deleted DNS records before posting the data to the endpoint. This will be handled within the endpoint code now.

See D49122-code

#### Testing instructions

Apply the back-end patch and try making various DNS updates from the DNS management page. Double-check the DNS values on the server. Make sure the changes match.

Make sure you try adding/removing custom A records as well.
