### PR TITLE
Login: Use Button component instead of button

### DIFF
--- a/client/blocks/login/continue-as-user.jsx
+++ b/client/blocks/login/continue-as-user.jsx
@@ -75,7 +75,8 @@ function ContinueAsUser( { currentUser, redirectUrlFromQuery, onChangeAccount } 
 					components: {
 						br: <br />,
 						link: (
-							<button
+							<Button
+								bare
 								type="button"
 								id="loginAsAnotherUser"
 								className="continue-as-user__change-user-link"

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -512,7 +512,7 @@ export class LoginForm extends Component {
 
 						<label htmlFor="usernameOrEmail">
 							{ this.isPasswordView() ? (
-								<Button bare className="login__form-change-username" onClick={ this.resetView }>
+								<Button plain className="login__form-change-username" onClick={ this.resetView }>
 									<Gridicon icon="arrow-left" size={ 18 } />
 									{ includes( this.state.usernameOrEmail, '@' )
 										? this.props.translate( 'Change Email Address' )

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -512,16 +512,12 @@ export class LoginForm extends Component {
 
 						<label htmlFor="usernameOrEmail">
 							{ this.isPasswordView() ? (
-								<button
-									type="button"
-									className="login__form-change-username"
-									onClick={ this.resetView }
-								>
+								<Button bare className="login__form-change-username" onClick={ this.resetView }>
 									<Gridicon icon="arrow-left" size={ 18 } />
 									{ includes( this.state.usernameOrEmail, '@' )
 										? this.props.translate( 'Change Email Address' )
 										: this.props.translate( 'Change Username' ) }
-								</button>
+								</Button>
 							) : (
 								this.props.translate( 'Email Address or Username' )
 							) }

--- a/client/components/social-buttons/apple.js
+++ b/client/components/social-buttons/apple.js
@@ -13,6 +13,7 @@ import { loadScript } from '@automattic/load-script';
 /**
  * Internal dependencies
  */
+import { Button } from '@automattic/components';
 import { isFormDisabled } from 'state/login/selectors';
 import requestExternalAccess from '@automattic/request-external-access';
 
@@ -144,8 +145,8 @@ class AppleLoginButton extends Component {
 				{ customButton ? (
 					customButton
 				) : (
-					<button
-						className={ classNames( 'social-buttons__button button', { disabled: isDisabled } ) }
+					<Button
+						className={ classNames( 'social-buttons__button', { disabled: isDisabled } ) }
 						onClick={ this.handleClick }
 					>
 						<AppleIcon isDisabled={ isDisabled } />
@@ -157,7 +158,7 @@ class AppleLoginButton extends Component {
 									'%(service)s is the name of a third-party authentication provider, e.g. "Google", "Facebook", "Apple" ...',
 							} ) }
 						</span>
-					</button>
+					</Button>
 				) }
 			</Fragment>
 		);

--- a/client/components/social-buttons/facebook.js
+++ b/client/components/social-buttons/facebook.js
@@ -13,6 +13,7 @@ import { noop } from 'lodash';
 /**
  * Internal dependencies
  */
+import { Button } from '@automattic/components';
 import FacebookIcon from 'components/social-icons/facebook';
 import { isFormDisabled } from 'state/login/selectors';
 
@@ -113,8 +114,8 @@ class FacebookLoginButton extends Component {
 
 		return (
 			<div className="social-buttons__button-container">
-				<button
-					className={ classNames( 'social-buttons__button button', { disabled: isDisabled } ) }
+				<Button
+					className={ classNames( 'social-buttons__button', { disabled: isDisabled } ) }
 					onClick={ this.handleClick }
 				>
 					<FacebookIcon />
@@ -126,7 +127,7 @@ class FacebookLoginButton extends Component {
 								'%(service)s is the name of a third-party authentication provider, e.g. "Google", "Facebook", "Apple" ...',
 						} ) }
 					</span>
-				</button>
+				</Button>
 			</div>
 		);
 	}

--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -12,6 +12,7 @@ import { noop } from 'lodash';
 /**
  * Internal dependencies
  */
+import { Button } from '@automattic/components';
 import GoogleIcon from 'components/social-icons/google';
 import Popover from 'components/popover';
 import { preventWidows } from 'lib/formatting';
@@ -209,8 +210,8 @@ class GoogleLoginButton extends Component {
 				{ customButton ? (
 					customButton
 				) : (
-					<button
-						className={ classNames( 'social-buttons__button button', { disabled: isDisabled } ) }
+					<Button
+						className={ classNames( 'social-buttons__button', { disabled: isDisabled } ) }
 						onMouseOver={ this.showError }
 						onFocus={ this.showError }
 						onMouseOut={ this.hideError }
@@ -226,7 +227,7 @@ class GoogleLoginButton extends Component {
 									'%(service)s is the name of a third-party authentication provider, e.g. "Google", "Facebook", "Apple" ...',
 							} ) }
 						</span>
-					</button>
+					</Button>
 				) }
 				<Popover
 					id="social-buttons__error"

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -176,7 +176,7 @@ export class LoginLinks extends React.Component {
 
 		return (
 			<Button
-				bare
+				plain
 				key="lost-phone-link"
 				data-e2e-link="lost-phone-link"
 				onClick={ this.handleLostPhoneLinkClick }

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -11,6 +11,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import { Button } from '@automattic/components';
 import config, { isEnabled } from 'config';
 import ExternalLink from 'components/external-link';
 import Gridicon from 'components/gridicon';
@@ -174,13 +175,14 @@ export class LoginLinks extends React.Component {
 		}
 
 		return (
-			<button
+			<Button
+				bare
 				key="lost-phone-link"
 				data-e2e-link="lost-phone-link"
 				onClick={ this.handleLostPhoneLinkClick }
 			>
 				{ this.props.translate( "I can't access my phone" ) }
-			</button>
+			</Button>
 		);
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update the login form to use the `Button` component rather than directly using the `button` tag.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure the following buttons on the login form appear and behave as in production:
    * "Change username" button (type a username or email and then check the button above the disabled username box)
    * All three social icons, Facebook, Google and Apple login buttons (Just check they look the same and that they trigger the beginning of oauth, no need to test the actual oauth flow)
    * "I can't access my phone" (login with an account that uses 2FA and check that the button is rendered correctly in the list below the 2FA box. Check it and ensure it takes you to the backup code screen)
* Ensure there are no more raw usages of "button," neither the tag nor the class name, on the login form.


Related to #45259 
