### PR TITLE
Update cloud pricing page styles

### DIFF
--- a/client/landing/jetpack-cloud/sections/pricing/style.scss
+++ b/client/landing/jetpack-cloud/sections/pricing/style.scss
@@ -1,5 +1,10 @@
+@import '~@automattic/typography/styles/fonts';
+@import '~@automattic/typography/styles/variables';
+
 .is-group-jetpack-cloud.is-section-jetpack-cloud-pricing {
 	background-color: var( --color-surface );
+
+	font-family: 'Noto Sans', $sans;
 }
 
 .is-group-jetpack-cloud.is-section-jetpack-cloud-pricing .plans-filter-bar.sticky {

--- a/client/landing/jetpack-cloud/sections/pricing/style.scss
+++ b/client/landing/jetpack-cloud/sections/pricing/style.scss
@@ -1,19 +1,123 @@
+@import '~@wordpress/base-styles/breakpoints';
+@import '~@wordpress/base-styles/mixins';
 @import '~@automattic/typography/styles/fonts';
-@import '~@automattic/typography/styles/variables';
 
 .is-group-jetpack-cloud.is-section-jetpack-cloud-pricing {
 	background-color: var( --color-surface );
 
 	font-family: 'Noto Sans', $sans;
-}
 
-.is-group-jetpack-cloud.is-section-jetpack-cloud-pricing .plans-filter-bar.sticky {
-	top: 0; // No masterbar here.
-	left: 0;
+	.plans-filter-bar.sticky {
+		top: 0; // No masterbar here.
+		left: 0;
 
-	width: 100%;
-	max-width: none;
+		width: 100%;
+		max-width: none;
 
-	border-left: none;
-	border-right: none;
+		border-left: none;
+		border-right: none;
+	}
+
+	.header {
+		margin-bottom: 24px;
+		padding: 0 5%;
+
+		color: #4f748e;
+
+		@include break-medium {
+			margin-top: 48px;
+			margin-bottom: 40px;
+			padding: 0;
+		}
+
+		.formatted-header__title {
+			margin: 0 0 36px;
+
+			color: var( --color-text );
+
+			font-size: rem( 21px );
+
+			@include break-medium {
+				margin: 1.5rem 0 40px;
+
+				font-size: rem( 35px );
+			}
+		}
+	}
+
+	.jetpack-product-card {
+		.jetpack-product-card__product-name {
+			font-size: rem( 21px );
+		}
+
+		.jetpack-product-card__from,
+		.jetpack-product-card__billing-time-frame,
+		.jetpack-product-card__subheadline {
+			color: #8c8f94;
+
+			font-size: rem( 11px );
+
+			@include break-medium {
+				font-size: rem( 13px );
+			}
+		}
+
+		.jetpack-product-card__description {
+			font-size: rem( 15px );
+		}
+	}
+
+	.plan-price {
+		font-size: rem( 21px );
+
+		@include break-medium {
+			font-size: rem( 30px );
+		}
+
+		&.is-original {
+			color: #8c8f94;
+		}
+
+		.plan-price__integer {
+			font-weight: 400;
+		}
+	}
+
+	.foldable-card {
+		font-size: rem( 13px );
+	}
+
+	.jetpack-free-card {
+		.jetpack-free-card__header {
+			font-size: rem( 21px );
+		}
+
+		.jetpack-free-card__body {
+			font-size: rem( 15px );
+		}
+	}
+
+	.faq {
+		margin-bottom: 16px;
+
+		@include break-medium {
+			margin-bottom: 48px;
+		}
+
+		.faq__heading {
+			margin: 56px 0 24px;
+
+			color: #2e4453;
+
+			font-size: rem( 26px );
+			font-weight: 400;
+			text-align: center;
+
+			@include break-medium {
+				margin: 64px 0;
+
+				font-size: rem( 35px );
+			}
+		}
+	}
 }

--- a/client/sections.js
+++ b/client/sections.js
@@ -453,6 +453,13 @@ const sections = [
 		module: 'wp-calypso-client/landing/jetpack-cloud/sections/pricing',
 		group: 'jetpack-cloud',
 		enableLoggedOut: true,
+		links: [
+			{
+				rel: 'stylesheet',
+				href:
+					'https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap',
+			},
+		],
 	},
 ];
 

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -35,6 +35,7 @@ import {
 import stateCache from 'server/state-cache';
 import getBootstrappedUser from 'server/user-bootstrap';
 import { createReduxStore } from 'state';
+import { setDocumentHeadLink } from 'state/document-head/actions';
 import { setStore } from 'state/redux-store';
 import initialReducer from 'state/reducer';
 import { DESERIALIZE, LOCALE_SET } from 'state/action-types';
@@ -687,6 +688,12 @@ export default function pages() {
 
 			if ( section.group && req.context ) {
 				req.context.sectionGroup = section.group;
+			}
+
+			if ( Array.isArray( section.links ) ) {
+				section.links.forEach( ( link ) =>
+					req.context.store.dispatch( setDocumentHeadLink( link ) )
+				);
 			}
 
 			next();

--- a/client/state/document-head/reducer.js
+++ b/client/state/document-head/reducer.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { uniqWith, isEqual } from 'lodash';
+
+/**
  * Internal dependencies
  */
 import { combineReducers, withSchemaValidation } from 'state/utils';
@@ -48,7 +53,8 @@ export const meta = withSchemaValidation( metaSchema, ( state = DEFAULT_META_STA
 export const link = withSchemaValidation( linkSchema, ( state = [], action ) => {
 	switch ( action.type ) {
 		case DOCUMENT_HEAD_LINK_SET:
-			return action.link;
+			// Prevent duplicate objects
+			return uniqWith( [ ...state, action.link ], isEqual );
 	}
 
 	return state;

--- a/client/state/document-head/test/reducer.js
+++ b/client/state/document-head/test/reducer.js
@@ -92,15 +92,16 @@ describe( 'reducer', () => {
 			const state = deepFreeze( [ { rel: 'some-rel', href: 'https://wordpress.org' } ] );
 			const newState = link( state, {
 				type: DOCUMENT_HEAD_LINK_SET,
-				link: [
-					{
-						rel: 'another-rel',
-						href: 'https://automattic.com',
-					},
-				],
+				link: {
+					rel: 'another-rel',
+					href: 'https://automattic.com',
+				},
 			} );
 
-			const expectedState = [ { rel: 'another-rel', href: 'https://automattic.com' } ];
+			const expectedState = [
+				{ rel: 'some-rel', href: 'https://wordpress.org' },
+				{ rel: 'another-rel', href: 'https://automattic.com' },
+			];
 
 			expect( newState ).to.eql( expectedState );
 		} );


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR updates the styles of the pricing page in cloud, mostly to match jetpack.com typefaces.

Fixes 1169247016322522-as-1191918158300076

### Testing instructions

- Run Jetpack cloud and visit `/pricing`.
- For developers: check the code and that the page doesn't look broken.
- For designers: check that the page matches what's expected. Parts of the mockups seemed a bit outdated, so I used my best judgement.
- 

### Screenshots

#### Mobile
![screencapture-jetpack-cloud-localhost-3000-pricing-2020-09-04-16_33_46](https://user-images.githubusercontent.com/1620183/92283175-54678c00-eecd-11ea-87e4-4ef1c7487796.png)


#### Desktop
![screencapture-jetpack-cloud-localhost-3000-pricing-2020-09-04-16_32_37](https://user-images.githubusercontent.com/1620183/92283186-5893a980-eecd-11ea-95a0-58ff8e2bc5d6.png)
