### PR TITLE
Composite Checkout: allow passing more than one product in the url

### DIFF
--- a/client/my-sites/checkout/composite-checkout/use-prepare-product-for-cart.js
+++ b/client/my-sites/checkout/composite-checkout/use-prepare-product-for-cart.js
@@ -179,9 +179,13 @@ function useAddProductFromSlug( {
 					const validProduct = products[ getProductSlugFromAlias( productAlias ) ];
 					return validProduct ? { ...validProduct, product_alias: productAlias } : validProduct;
 				} )
-				// Remove invalid products
-				.filter( Boolean ),
-		[ isJetpackNotAtomic, productAliasFromUrl, products ]
+				// Remove plans since they are handled in another hook and there is no need to support
+				// combinations of plans and products in the cart
+				.filter(
+					( product ) =>
+						product && ! plans.find( ( plan ) => plan.product_slug === product.product_slug )
+				),
+		[ isJetpackNotAtomic, plans, productAliasFromUrl, products ]
 	);
 
 	useEffect( () => {

--- a/client/my-sites/checkout/composite-checkout/use-prepare-product-for-cart.js
+++ b/client/my-sites/checkout/composite-checkout/use-prepare-product-for-cart.js
@@ -169,9 +169,8 @@ function useAddProductFromSlug( {
 	// work with an array of products even if `productAliasFromUrl` includes only one.
 	const validProducts = useMemo(
 		() =>
-			productAliasFromUrl &&
 			productAliasFromUrl
-				.split( ',' )
+				?.split( ',' )
 				// Special treatment for Jetpack Search products
 				.map( ( productAlias ) => getJetpackSearchForSite( productAlias, isJetpackNotAtomic ) )
 				// Get the product information if it exists, and keep a reference to its product alias
@@ -184,7 +183,7 @@ function useAddProductFromSlug( {
 				.filter(
 					( product ) =>
 						product && ! plans.find( ( plan ) => plan.product_slug === product.product_slug )
-				),
+				) ?? [],
 		[ isJetpackNotAtomic, plans, productAliasFromUrl, products ]
 	);
 
@@ -209,11 +208,10 @@ function useAddProductFromSlug( {
 			debug( 'waiting on products/plans fetch' );
 			return;
 		}
-		if ( ! validProducts || validProducts.length < 1 ) {
+		if ( validProducts.length < 1 ) {
 			debug(
-				'there is a request to add one ore more products but no product was found',
-				productAliasFromUrl,
-				validProducts
+				'there is a request to add one or more products but no product was found',
+				productAliasFromUrl
 			);
 			setState( { canInitializeCart: true } );
 			return;
@@ -228,7 +226,7 @@ function useAddProductFromSlug( {
 			} )
 		);
 
-		if ( ! cartProducts || cartProducts.length < 1 ) {
+		if ( cartProducts.length < 1 ) {
 			debug(
 				'there is a request to add a one or more products but creating them failed',
 				productAliasFromUrl


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Make it possible to pass more than one product in the URL. Currently, our composite checkout module doesn't support a URL like `/checkout/:site/jetpack_backup_daily,jetpack_scan`. This PR attempts to change that by making the checkout logic work with multiple products separated by comma.

#### Implementation notes

* Only multiple products can be added to the cart, not plans. Plans must be purchased individually.

#### Testing instructions

* Run this PR.
* Pick a self-hosted Jetpack site.

**Single product in the URL**
* Visit `http://calypso.localhost:3000/checkout/:site/jetpack_backup_daily`.
* Verify that the cart contains Jetpack Backup Daily and nothing else. 
* Remove everything from the cart. 

**Two products in the URL**
* Visit `http://calypso.localhost:3000/checkout/:site/jetpack_backup_daily,jetpack_scan`.
* Verify that the cart contains Jetpack Backup Daily and Jetpack Scan.
* Remove everything from the cart.
* Visit `http://calypso.localhost:3000/checkout/:site/jetpack_scan_monthly,jetpack_backup_daily_monthly`.
* Verify that the cart contains Jetpack Backup Daily **Monthly** and Jetpack Scan **Monthly**.
* Remove everything from the cart.

**One plan**
* Visit `http://calypso.localhost:3000/checkout/:site/jetpack_security_daily`.
* Verify that the cart contains Jetpack Security Daily.
* Remove everything from the cart.

**Two plans**
* Visit `http://calypso.localhost:3000/checkout/:site/jetpack_comple,jetpack_security_daily`.
* Verify that you are redirected to the plans page.

Fixes 1169247016322522-as-1192418633472161

#### Demo

![Kapture 2020-09-04 at 18 26 59](https://user-images.githubusercontent.com/3418513/92286040-48cf9180-eedc-11ea-805a-043c4d315218.gif)

