### PR TITLE
Coming soon: Send `public_coming_soon` site creation flag in development builds

### DIFF
--- a/client/landing/gutenboarding/hooks/use-on-login.ts
+++ b/client/landing/gutenboarding/hooks/use-on-login.ts
@@ -11,7 +11,7 @@ import { useI18n } from '@automattic/react-i18n';
 import { STORE_KEY as ONBOARD_STORE } from '../stores/onboard';
 import { USER_STORE } from '../stores/user';
 import { SITE_STORE } from '../stores/site';
-import { useShouldSiteBePublic } from './use-selected-plan';
+import { useNewSiteVisibility } from './use-selected-plan';
 import { useNewQueryParam } from '../path';
 
 /**
@@ -26,11 +26,11 @@ export default function useOnSignup() {
 	const newSite = useSelect( ( select ) => select( SITE_STORE ).getNewSite() );
 
 	const shouldTriggerCreate = useNewQueryParam();
-	const shouldSiteBePublic = useShouldSiteBePublic();
+	const visibility = useNewSiteVisibility();
 
 	React.useEffect( () => {
 		if ( ! isCreatingSite && ! newSite && currentUser && shouldTriggerCreate ) {
-			createSite( currentUser.username, i18nLocale, undefined, shouldSiteBePublic );
+			createSite( currentUser.username, i18nLocale, undefined, visibility );
 		}
 	}, [
 		createSite,
@@ -39,6 +39,6 @@ export default function useOnSignup() {
 		newSite,
 		i18nLocale,
 		shouldTriggerCreate,
-		shouldSiteBePublic,
+		visibility,
 	] );
 }

--- a/client/landing/gutenboarding/hooks/use-on-signup.ts
+++ b/client/landing/gutenboarding/hooks/use-on-signup.ts
@@ -29,7 +29,7 @@ export default function useOnSignup() {
 		( username: string, bearerToken?: string, isPublicSite?: number ) => {
 			createSite( username, i18nLocale, bearerToken, isPublicSite );
 		},
-		[ createSite ]
+		[ createSite, i18nLocale ]
 	);
 
 	React.useEffect( () => {

--- a/client/landing/gutenboarding/hooks/use-on-signup.ts
+++ b/client/landing/gutenboarding/hooks/use-on-signup.ts
@@ -11,7 +11,7 @@ import { useI18n } from '@automattic/react-i18n';
 import { STORE_KEY as ONBOARD_STORE } from '../stores/onboard';
 import { USER_STORE } from '../stores/user';
 import { SITE_STORE } from '../stores/site';
-import { useShouldSiteBePublic } from './use-selected-plan';
+import { useNewSiteVisibility } from './use-selected-plan';
 
 /**
  * After signup a site is automatically created using the username and bearerToken
@@ -23,10 +23,10 @@ export default function useOnSignup() {
 
 	const newUser = useSelect( ( select ) => select( USER_STORE ).getNewUser() );
 	const newSite = useSelect( ( select ) => select( SITE_STORE ).getNewSite() );
-	const shouldSiteBePublic = useShouldSiteBePublic();
+	const visibility = useNewSiteVisibility();
 
 	const handleCreateSite = React.useCallback(
-		( username: string, bearerToken?: string, isPublicSite?: boolean ) => {
+		( username: string, bearerToken?: string, isPublicSite?: number ) => {
 			createSite( username, i18nLocale, bearerToken, isPublicSite );
 		},
 		[ createSite ]
@@ -34,7 +34,7 @@ export default function useOnSignup() {
 
 	React.useEffect( () => {
 		if ( newUser && newUser.bearerToken && newUser.username && ! newSite ) {
-			handleCreateSite( newUser.username, newUser.bearerToken, shouldSiteBePublic );
+			handleCreateSite( newUser.username, newUser.bearerToken, visibility );
 		}
-	}, [ newSite, newUser, i18nLocale, handleCreateSite, shouldSiteBePublic ] );
+	}, [ newSite, newUser, i18nLocale, handleCreateSite, visibility ] );
 }

--- a/client/landing/gutenboarding/hooks/use-on-site-creation.ts
+++ b/client/landing/gutenboarding/hooks/use-on-site-creation.ts
@@ -12,7 +12,7 @@ import { STORE_KEY as ONBOARD_STORE } from '../stores/onboard';
 import { USER_STORE } from '../stores/user';
 import { SITE_STORE } from '../stores/site';
 import { recordOnboardingComplete } from '../lib/analytics';
-import { useSelectedPlan, useShouldSiteBePublic } from './use-selected-plan';
+import { useSelectedPlan, useShouldRedirectToEditorAfterCheckout } from './use-selected-plan';
 import { clearLastNonEditorRoute } from '../lib/clear-last-non-editor-route';
 
 const wpcom = wp.undocumented();
@@ -62,7 +62,7 @@ export default function useOnSiteCreation() {
 	const newSite = useSelect( ( select ) => select( SITE_STORE ).getNewSite() );
 	const newUser = useSelect( ( select ) => select( USER_STORE ).getNewUser() );
 	const selectedPlan = useSelectedPlan();
-	const shouldSiteBePublic = useShouldSiteBePublic();
+	const shouldRedirectToEditorAfterCheckout = useShouldRedirectToEditorAfterCheckout();
 	const design = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedDesign() );
 
 	const { resetOnboardStore, setIsRedirecting, setSelectedSite } = useDispatch( ONBOARD_STORE );
@@ -109,9 +109,9 @@ export default function useOnSiteCreation() {
 						? `site-editor%2F${ newSite.site_slug }`
 						: `block-editor%2Fpage%2F${ newSite.site_slug }%2Fhome`;
 
-					const redirectionUrl = shouldSiteBePublic
-						? `/checkout/${ newSite.site_slug }?preLaunch=1&isGutenboardingCreate=1`
-						: `/checkout/${ newSite.site_slug }?preLaunch=1&isGutenboardingCreate=1&redirect_to=%2F${ editorUrl }`;
+					const redirectionUrl = shouldRedirectToEditorAfterCheckout
+						? `/checkout/${ newSite.site_slug }?preLaunch=1&isGutenboardingCreate=1&redirect_to=%2F${ editorUrl }`
+						: `/checkout/${ newSite.site_slug }?preLaunch=1&isGutenboardingCreate=1`;
 					window.location.href = redirectionUrl;
 				};
 				recordOnboardingComplete( {
@@ -142,7 +142,7 @@ export default function useOnSiteCreation() {
 		setIsRedirecting,
 		setSelectedSite,
 		flowCompleteTrackingParams,
-		shouldSiteBePublic,
+		shouldRedirectToEditorAfterCheckout,
 		design,
 	] );
 }

--- a/client/landing/gutenboarding/hooks/use-selected-plan.ts
+++ b/client/landing/gutenboarding/hooks/use-selected-plan.ts
@@ -67,6 +67,9 @@ export function useNewSiteVisibility(): Site.Visibility {
 	return Site.Visibility.Private;
 }
 
-export function useShouldSiteBePublic() {
-	return useNewSiteVisibility() !== -1;
+export function useShouldRedirectToEditorAfterCheckout() {
+	// The ecommerce plan follows another flow, so we shouldn't interrupt
+	// it by trying to redirect to the editor.
+	const currentSlug = useSelectedPlan()?.storeSlug;
+	return ! useSelect( ( select ) => select( PLANS_STORE ).isPlanEcommerce( currentSlug ) );
 }

--- a/client/landing/gutenboarding/hooks/use-selected-plan.ts
+++ b/client/landing/gutenboarding/hooks/use-selected-plan.ts
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { Site } from '@automattic/data-stores';
 import { useSelect } from '@wordpress/data';
 
 /**
@@ -51,11 +52,21 @@ export function useHasPaidPlanFromPath() {
 	return planFromPath && ! isPlanFree( planFromPath?.storeSlug );
 }
 
-export function useShouldSiteBePublic() {
+export function useNewSiteVisibility(): Site.Visibility {
 	const currentSlug = useSelectedPlan()?.storeSlug;
 	const isEcommerce = useSelect( ( select ) =>
 		select( PLANS_STORE ).isPlanEcommerce( currentSlug )
 	);
 
-	return isEnabled( 'gutenboarding/public-coming-soon' ) ? true : isEcommerce;
+	if ( isEcommerce ) {
+		return Site.Visibility.PublicIndexed;
+	} else if ( isEnabled( 'gutenboarding/public-coming-soon' ) ) {
+		return Site.Visibility.PublicNotIndexed;
+	}
+
+	return Site.Visibility.Private;
+}
+
+export function useShouldSiteBePublic() {
+	return useNewSiteVisibility() !== -1;
 }

--- a/client/landing/gutenboarding/hooks/use-selected-plan.ts
+++ b/client/landing/gutenboarding/hooks/use-selected-plan.ts
@@ -9,6 +9,7 @@ import { useSelect } from '@wordpress/data';
 import { STORE_KEY as ONBOARD_STORE } from '../stores/onboard';
 import { PLANS_STORE } from '../stores/plans';
 import { usePlanRouteParam } from '../path';
+import { isEnabled } from 'config';
 
 export function usePlanFromPath() {
 	const planPath = usePlanRouteParam();
@@ -52,5 +53,9 @@ export function useHasPaidPlanFromPath() {
 
 export function useShouldSiteBePublic() {
 	const currentSlug = useSelectedPlan()?.storeSlug;
-	return useSelect( ( select ) => select( PLANS_STORE ).isPlanEcommerce( currentSlug ) );
+	const isEcommerce = useSelect( ( select ) =>
+		select( PLANS_STORE ).isPlanEcommerce( currentSlug )
+	);
+
+	return isEnabled( 'gutenboarding/public-coming-soon' ) ? true : isEcommerce;
 }

--- a/client/landing/gutenboarding/hooks/use-step-navigation.ts
+++ b/client/landing/gutenboarding/hooks/use-step-navigation.ts
@@ -12,7 +12,7 @@ import { useI18n } from '@automattic/react-i18n';
 import { Step, usePath, useCurrentStep, StepType } from '../path';
 import { STORE_KEY as ONBOARD_STORE } from '../stores/onboard';
 import { USER_STORE } from '../stores/user';
-import { useShouldSiteBePublic, useHasPaidPlanFromPath } from './use-selected-plan';
+import { useNewSiteVisibility, useHasPaidPlanFromPath } from './use-selected-plan';
 import useSignup from './use-signup';
 
 /**
@@ -64,11 +64,11 @@ export default function useStepNavigation(): { goBack: () => void; goNext: () =>
 	// @TODO: move site creation to a separate hook or an action on the ONBOARD store
 	const currentUser = useSelect( ( select ) => select( USER_STORE ).getCurrentUser() );
 	const { createSite } = useDispatch( ONBOARD_STORE );
-	const shouldSiteBePublic = useShouldSiteBePublic();
+	const newSiteVisibility = useNewSiteVisibility();
 	const { onSignupDialogOpen } = useSignup();
 	const handleSiteCreation = () =>
 		currentUser
-			? createSite( currentUser.username, i18nLocale, undefined, shouldSiteBePublic )
+			? createSite( currentUser.username, i18nLocale, undefined, newSiteVisibility )
 			: onSignupDialogOpen();
 
 	// Logic necessary to skip Domains or Plans steps

--- a/client/landing/gutenboarding/onboarding-block/plans/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/plans/index.tsx
@@ -55,24 +55,36 @@ const PlansStep: React.FunctionComponent< Props > = ( { isModal } ) => {
 
 	const freeDomainSuggestion = useFreeDomainSuggestion();
 
+	const [ planUpdated, setPlanUpdated ] = React.useState( false );
+
 	const recommendedPlan = useRecommendedPlan();
 
 	const handleBack = () => ( isModal ? history.goBack() : goBack() );
-	const handlePlanSelect = ( planSlug: PlanSlug ) => {
+	const handlePlanSelect = async ( planSlug: PlanSlug ) => {
 		// When picking a free plan, if there is a paid domain selected, it's changed automatically to a free domain
 		if ( isPlanFree( planSlug ) && ! domain?.is_free ) {
 			setDomain( freeDomainSuggestion );
 		}
 
-		updatePlan( planSlug );
+		await updatePlan( planSlug );
 
-		if ( isModal ) {
-			history.goBack();
-		} else {
-			goNext();
-		}
+		// We need all hooks to have updated before calling the `goNext()` function,
+		// so we defer by setting a flag and waiting for it to update.
+		setPlanUpdated( true );
 	};
 	const handlePickDomain = () => history.push( makePath( Step.DomainsModal ) );
+
+	React.useEffect( () => {
+		if ( planUpdated ) {
+			if ( isModal ) {
+				history.goBack();
+			} else {
+				goNext();
+			}
+
+			setPlanUpdated( false );
+		}
+	}, [ goNext, history, isModal, planUpdated ] );
 
 	const header = (
 		<>

--- a/client/landing/gutenboarding/stores/onboard/actions.ts
+++ b/client/landing/gutenboarding/stores/onboard/actions.ts
@@ -79,6 +79,7 @@ export function* createSite(
 			} ),
 			use_patterns: isEnabled( 'gutenboarding/use-patterns' ),
 			selected_features: selectedFeatures,
+			public_coming_soon: isEnabled( 'gutenboarding/public-coming-soon' ) || undefined,
 		},
 		...( bearerToken && { authToken: bearerToken } ),
 	};

--- a/client/landing/gutenboarding/stores/onboard/actions.ts
+++ b/client/landing/gutenboarding/stores/onboard/actions.ts
@@ -34,7 +34,7 @@ export function* createSite(
 	username: string,
 	languageSlug: string,
 	bearerToken?: string,
-	isPublicSite = false
+	isPublicSite = isEnabled( 'gutenboarding/public-coming-soon' )
 ) {
 	const {
 		domain,

--- a/client/landing/gutenboarding/stores/onboard/actions.ts
+++ b/client/landing/gutenboarding/stores/onboard/actions.ts
@@ -34,7 +34,9 @@ export function* createSite(
 	username: string,
 	languageSlug: string,
 	bearerToken?: string,
-	isPublicSite = isEnabled( 'gutenboarding/public-coming-soon' )
+	visibility: number = isEnabled( 'gutenboarding/public-coming-soon' )
+		? Site.Visibility.PublicNotIndexed
+		: Site.Visibility.Private
 ) {
 	const {
 		domain,
@@ -55,7 +57,7 @@ export function* createSite(
 	const params: CreateSiteParams = {
 		blog_name: siteUrl?.split( '.wordpress' )[ 0 ],
 		blog_title: siteTitle,
-		public: isPublicSite ? Site.Visibility.PublicIndexed : Site.Visibility.Private,
+		public: visibility,
 		options: {
 			site_vertical: siteVertical?.id,
 			site_vertical_name: siteVertical?.label,
@@ -79,7 +81,10 @@ export function* createSite(
 			} ),
 			use_patterns: isEnabled( 'gutenboarding/use-patterns' ),
 			selected_features: selectedFeatures,
-			public_coming_soon: isEnabled( 'gutenboarding/public-coming-soon' ) || undefined,
+			...( isEnabled( 'gutenboarding/public-coming-soon' ) &&
+				visibility === Site.Visibility.PublicNotIndexed && {
+					public_coming_soon: true,
+				} ),
 		},
 		...( bearerToken && { authToken: bearerToken } ),
 	};

--- a/client/landing/gutenboarding/stores/onboard/actions.ts
+++ b/client/landing/gutenboarding/stores/onboard/actions.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import type { DomainSuggestions, Site, VerticalsTemplates, Plans } from '@automattic/data-stores';
+import { DomainSuggestions, Site, VerticalsTemplates, Plans } from '@automattic/data-stores';
 import { dispatch, select } from '@wordpress/data-controls';
 import guessTimezone from '../../../../lib/i18n-utils/guess-timezone';
 import { getLanguage } from 'lib/i18n-utils';
@@ -55,7 +55,7 @@ export function* createSite(
 	const params: CreateSiteParams = {
 		blog_name: siteUrl?.split( '.wordpress' )[ 0 ],
 		blog_title: siteTitle,
-		public: isPublicSite ? 1 : -1,
+		public: isPublicSite ? Site.Visibility.PublicIndexed : Site.Visibility.Private,
 		options: {
 			site_vertical: siteVertical?.id,
 			site_vertical_name: siteVertical?.label,

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -30,11 +30,17 @@ export type NewSiteResponse =
 	| NewSiteErrorResponse
 	| NewSiteErrorCreateBlog;
 
+export enum Visibility {
+	PublicIndexed = 1,
+	PublicNotIndexed = 0,
+	Private = -1,
+}
+
 export interface CreateSiteParams {
 	blog_name: string;
 	blog_title?: string;
 	authToken?: string;
-	public?: number;
+	public?: Visibility;
 	options?: {
 		site_vertical?: string;
 		site_vertical_name?: string;

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -52,6 +52,7 @@ export interface CreateSiteParams {
 		font_base?: string;
 		use_patterns?: boolean;
 		selected_features?: string[];
+		public_coming_soon?: boolean;
 	};
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Opt-in to coming soon v2 behaviour if `?public-coming-soon` is present and on `wpcalypso.wordpress.com` or a development build
* Send `public_coming_soon` flag to `/sites/new` endpoint
* Disable private-by-default behaviour
* Set new coming-soon sites as non-indexable

The `public_coming_soon` API option was merged in D49202-code, and it just sets the `wpcom_public_coming_soon` site option.

Part of #45019

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new site with `localhost:3000/new?flags=gutenboarding/public-coming-soon`
* The `?flags` query param will disappear as you go through the flow, but that's ok
* Open network tools and preserve log to make it easier to inspect the call to `/sites/new`
* Create a site with any plan other than ecommerce
* Check that the call to `/sites/new` included a `public_coming_soon=true` option.
* After site creation you should be taken to the editor (notice the launch button is missing, we'll fix that in #45016)
* Go to the site settings in calypso and see that the site is public but with indexing disabled
* Create a new ecommerce with with the `?flags=gutenboarding/public-coming-soon` flag set, it should still be created public and indexable
* Create new sites without the `?flags` flag set, it should behave as before
* Were you redirected to the correct place after gutenboarding? Even after going through the checkout? For ecommerce sites your site should go atomic and you should land on a store onboarding flow. For all other plans you should eventually drop into the editor.