### PR TITLE
EditingToolkitSidebar: add tracking events

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/create-page/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/create-page/index.tsx
@@ -6,6 +6,7 @@ import { Button as OriginalButton } from '@wordpress/components';
 import { applyFilters } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { plus } from '@wordpress/icons';
 
 /**
@@ -43,6 +44,10 @@ export default function CreatePage( { postType }: Props ) {
 		postType.slug
 	);
 
+	const trackEvent = () => {
+		recordTracksEvent( `calypso_editor_sidebar_${ postType.slug }_add` );
+	};
+
 	return (
 		<Button
 			target={ applyFilters( 'a8c.WpcomBlockEditorNavSidebar.linkTarget', undefined ) }
@@ -50,6 +55,7 @@ export default function CreatePage( { postType }: Props ) {
 			className="wpcom-block-editor-nav-sidebar-create-page"
 			href={ url }
 			icon={ plus }
+			onClick={ trackEvent }
 		>
 			{ label }
 		</Button>

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/create-page/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/create-page/index.tsx
@@ -45,7 +45,7 @@ export default function CreatePage( { postType }: Props ) {
 	);
 
 	const trackEvent = () => {
-		recordTracksEvent( `calypso_editor_sidebar_${ postType.slug }_add` );
+		recordTracksEvent( `calypso_editor_sidebar_item_add`, { post_type: postType.slug } );
 	};
 
 	return (

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-item/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-item/index.tsx
@@ -7,6 +7,7 @@ import { forwardRef } from '@wordpress/element';
 import { _x } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { applyFilters } from '@wordpress/hooks';
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 
 /**
  * Internal dependencies
@@ -38,12 +39,16 @@ const NavItem = forwardRef< HTMLLIElement, NavItemProps >(
 			item.id,
 			postType.slug
 		);
+		const trackEvent = () => {
+			recordTracksEvent( `calypso_editor_sidebar_${ postType.slug }_open` );
+		};
 
 		return (
 			<li ref={ ref }>
 				<Button
 					className={ buttonClasses }
 					href={ editUrl }
+					onClick={ trackEvent }
 					target={ applyFilters( 'a8c.WpcomBlockEditorNavSidebar.linkTarget', undefined ) }
 				>
 					<div className={ titleClasses } title={ item.title?.raw }>

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-item/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-item/index.tsx
@@ -40,7 +40,7 @@ const NavItem = forwardRef< HTMLLIElement, NavItemProps >(
 			postType.slug
 		);
 		const trackEvent = () => {
-			recordTracksEvent( `calypso_editor_sidebar_${ postType.slug }_open` );
+			recordTracksEvent( 'calypso_editor_sidebar_item_edit', { post_type: postType.slug } );
 		};
 
 		return (

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
@@ -114,7 +114,7 @@ function WpcomBlockEditorNavSidebar() {
 	const handleClose = ( e: React.MouseEvent ) => {
 		if ( hasAction( 'a8c.wpcom-block-editor.closeEditor' ) ) {
 			e.preventDefault();
-			recordTracksEvent( 'calypso_editor_sidebar_close' );
+			recordTracksEvent( 'calypso_editor_sidebar_editor_close' );
 			doAction( 'a8c.wpcom-block-editor.closeEditor' );
 		}
 	};

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
@@ -138,6 +138,7 @@ function WpcomBlockEditorNavSidebar() {
 			  );
 
 	const dismissSidebar = () => {
+		recordTracksEvent( 'calypso_editor_sidebar_dismiss' );
 		if ( isOpen && ! isClosing ) {
 			toggleSidebar();
 		}

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
@@ -138,8 +138,8 @@ function WpcomBlockEditorNavSidebar() {
 			  );
 
 	const dismissSidebar = () => {
-		recordTracksEvent( 'calypso_editor_sidebar_dismiss' );
 		if ( isOpen && ! isClosing ) {
+			recordTracksEvent( 'calypso_editor_sidebar_dismiss' );
 			toggleSidebar();
 		}
 	};

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
@@ -4,6 +4,7 @@
 import { forwardRef, useLayoutEffect, useRef, useEffect } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { useDispatch, useSelect } from '@wordpress/data';
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import {
 	Button as OriginalButton,
 	IsolatedEventContainer,
@@ -113,6 +114,7 @@ function WpcomBlockEditorNavSidebar() {
 	const handleClose = ( e: React.MouseEvent ) => {
 		if ( hasAction( 'a8c.wpcom-block-editor.closeEditor' ) ) {
 			e.preventDefault();
+			recordTracksEvent( 'calypso_editor_sidebar_close' );
 			doAction( 'a8c.wpcom-block-editor.closeEditor' );
 		}
 	};

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/toggle-sidebar-button/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/toggle-sidebar-button/index.tsx
@@ -4,6 +4,7 @@
 import { Button as OriginalButton } from '@wordpress/components';
 import { wordpress } from '@wordpress/icons';
 import { useDispatch, useSelect } from '@wordpress/data';
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
 
@@ -25,6 +26,11 @@ export default function ToggleSidebarButton() {
 	const isSidebarOpen = useSelect( ( select ) => select( STORE_KEY ).isSidebarOpened() );
 	const isSidebarClosing = useSelect( ( select ) => select( STORE_KEY ).isSidebarClosing() );
 
+	const handleClick = () => {
+		recordTracksEvent( `calypso_editor_sidebar_open` );
+		toggleSidebar();
+	};
+
 	return (
 		<Button
 			label={ __( 'Block editor sidebar', 'full-site-editing' ) }
@@ -38,7 +44,7 @@ export default function ToggleSidebarButton() {
 			) }
 			icon={ wordpress }
 			iconSize={ 36 }
-			onClick={ toggleSidebar }
+			onClick={ handleClick }
 			aria-haspopup="dialog"
 			aria-expanded={ isSidebarOpen }
 		/>


### PR DESCRIPTION
### Changes proposed in this Pull Request

Adds tracking events for
* When the sidebar is opened
* When the user goes back to the dashboard, closing the editor
* When the user navigates to an existing post/page
* When the user clicks on "add a new post/page"
* When sidebar is dismissed

### Testing instructions

* Add diff D49173-code to your sandbox for testing
* open dev tools  and paste this in console: localStorage.setItem('debug', 'calypso:analytics');   this will allow verification of analytics in the dev tools console
* Some events can't be viewed in the console due to a page load, in this case verify the even in Tracks: 

**Open sidebar**
    * click the (W)
    * Verify `calypso:analytics Recording event "calypso_editor_sidebar_open" ` in dev tools console

**Close editor / back to dashboard** 
    * When sidebar is open
    * click All Posts (or All Pages)
    *Verify `calypso:analytics Record event "calypso_editor_sidebar_editor_close` in dev tools console

**Navigate to an existing post/page**
    * When sidebar is open
    * click the Post or Page name in the sidebar list
    * Verify event in tracks: calypso_editor_sidebar_item_edit

**Click on add new post/page button**
    * When sidebar is open
    * click Add new page/post
    * Verify in tracks calypso_editor_sidebar_item_add

**Sidebar is dismissed/closed**
    * When sidebar is open
    * press esc or click (W) or click anywhere outside sidebar
    * Verify `calypso:analytics Record event "calypso_editor_sidebar_dismiss"` in dev tools console

### Issue
Fixes # https://github.com/Automattic/wp-calypso/issues/44907