### PR TITLE
Fix/teamcity remove docker integration

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -6,7 +6,6 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.perfmon
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.pullRequests
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.ScriptBuildStep
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
-import jetbrains.buildServer.configs.kotlin.v2019_2.projectFeatures.dockerRegistry
 import jetbrains.buildServer.configs.kotlin.v2019_2.projectFeatures.githubConnection
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.schedule
@@ -55,11 +54,6 @@ project {
 	}
 
 	features {
-		dockerRegistry {
-			id = "PROJECT_EXT_6"
-			name = "Docker Registry"
-			url = "https://registry.a8c.com"
-		}
 		githubConnection {
 			id = "PROJECT_EXT_8"
 			displayName = "GitHub.com"

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -131,9 +131,7 @@ object BuildBaseImages : BuildType({
 		perfmon {
 		}
 		dockerSupport {
-			loginToRegistry = on {
-				dockerRegistryId = "PROJECT_EXT_6"
-			}
+			cleanupPushedImages = true
 		}
 	}
 })


### PR DESCRIPTION
### Changes

- Do not log in internal docker registry, it is not needed for the agents.
- Clean up pushed images to not waste space

More info: https://www.jetbrains.com/help/teamcity/integrating-teamcity-with-docker.html#Docker+Support+Build+Feature