### PR TITLE
Border radius changes for cloud.jetpack.com

### DIFF
--- a/client/components/activity-card/style.scss
+++ b/client/components/activity-card/style.scss
@@ -1,6 +1,5 @@
 .activity-card {
 	.card {
-		border-radius: 2px;
 		padding: 16px;
 	}
 

--- a/client/components/activity-card/style.scss
+++ b/client/components/activity-card/style.scss
@@ -1,6 +1,7 @@
 .activity-card {
 	.card {
 		padding: 16px;
+		border-radius: var( --jetpack-corners-sharp );
 	}
 
 	.activity-card__actor {

--- a/client/components/jetpack/log-item/style.scss
+++ b/client/components/jetpack/log-item/style.scss
@@ -1,5 +1,4 @@
 .log-item {
-	border-radius: 2px;
 	--color-log-item: var( --color-text );
 
 	$highlights: ( 'info': 'primary-20', 'success': 'success-20', 'error': 'error-50', 'warning': 'warning-20' );

--- a/client/components/jetpack/log-item/style.scss
+++ b/client/components/jetpack/log-item/style.scss
@@ -1,4 +1,5 @@
 .log-item {
+	border-radius: var( --jetpack-corners-sharp );
 	--color-log-item: var( --color-text );
 
 	$highlights: ( 'info': 'primary-20', 'success': 'success-20', 'error': 'error-50', 'warning': 'warning-20' );

--- a/client/components/jetpack/threat-item-subheader/style.scss
+++ b/client/components/jetpack/threat-item-subheader/style.scss
@@ -41,7 +41,7 @@
 		letter-spacing: 1px;
 		text-align: center;
 		text-transform: uppercase;
-		border-radius: 2px;
+		border-radius: 3px;
 		color: #fff;
 
 		&.is-fixed {

--- a/client/components/jetpack/threat-item-subheader/style.scss
+++ b/client/components/jetpack/threat-item-subheader/style.scss
@@ -41,7 +41,7 @@
 		letter-spacing: 1px;
 		text-align: center;
 		text-transform: uppercase;
-		border-radius: 3px;
+		border-radius: var( --jetpack-corners-soft );
 		color: #fff;
 
 		&.is-fixed {

--- a/client/components/jetpack/threat-item/style.scss
+++ b/client/components/jetpack/threat-item/style.scss
@@ -81,6 +81,5 @@
 		margin-inline-end: 5px;
 		border-width: 1px;
 		border-style: solid;
-		border-radius: 2px;
 	}
 }

--- a/client/components/jetpack/threat-item/style.scss
+++ b/client/components/jetpack/threat-item/style.scss
@@ -81,6 +81,6 @@
 		margin-inline-end: 5px;
 		border-width: 1px;
 		border-style: solid;
-		border-radius: 3px;
+		border-radius: var( --jetpack-corners-soft );
 	}
 }

--- a/client/components/jetpack/threat-item/style.scss
+++ b/client/components/jetpack/threat-item/style.scss
@@ -81,5 +81,6 @@
 		margin-inline-end: 5px;
 		border-width: 1px;
 		border-style: solid;
+		border-radius: 3px;
 	}
 }

--- a/client/landing/jetpack-cloud/style.scss
+++ b/client/landing/jetpack-cloud/style.scss
@@ -37,7 +37,7 @@
 	color: var( --color-primary-60 );
 	background: var( --studio-white );
 	border: 1px solid var( --color-primary-40 );
-	border-radius: 2px;
+	border-radius: 3px;
 
 	&:hover,
 	&:focus {

--- a/client/landing/jetpack-cloud/style.scss
+++ b/client/landing/jetpack-cloud/style.scss
@@ -1,3 +1,10 @@
+// custom properties for Jetpack
+:root {
+	// border-radius
+	--jetpack-corners-sharp: 0px;
+	--jetpack-corners-soft: 3px;
+}
+
 .theme-jetpack-cloud,
 .color-scheme.is-jetpack-cloud {
 	.main {
@@ -37,7 +44,7 @@
 	color: var( --color-primary-60 );
 	background: var( --studio-white );
 	border: 1px solid var( --color-primary-40 );
-	border-radius: 3px;
+	border-radius: var( --jetpack-corners-soft );
 
 	&:hover,
 	&:focus {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Implement sharp corners on all cards
* Implement 3px border radius on buttons

p6TEKc-3Pn-p2#comment-8096

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use `yarn run start-jetpack-cloud`  and add `jetpack.cloud.localhost` to your hosts file
* Visit: http://jetpack.cloud.localhost:3000/
* Test the following changes:

**Before cards:**

![Screenshot 2020-09-07 at 11 29 21](https://user-images.githubusercontent.com/411945/92379422-bd3a4880-f107-11ea-87f2-1bea47fb730f.png)

![Screenshot 2020-09-07 at 11 47 47](https://user-images.githubusercontent.com/411945/92379569-f8d51280-f107-11ea-81fe-c92fd1e96853.png)

**After cards:**

![Screenshot 2020-09-07 at 11 37 56](https://user-images.githubusercontent.com/411945/92379453-ca573780-f107-11ea-9eff-89c4a71931ef.png)

![Screenshot 2020-09-07 at 11 50 12](https://user-images.githubusercontent.com/411945/92379586-0094b700-f108-11ea-9929-cbf1ef78bf03.png)

**Before badges:**

![Screenshot 2020-09-07 at 11 39 43](https://user-images.githubusercontent.com/411945/92379485-d8a55380-f107-11ea-999b-8ce582652abb.png)

**After badges:**

![Screenshot 2020-09-07 at 11 47 17](https://user-images.githubusercontent.com/411945/92379515-e65ad900-f107-11ea-858e-6465ee26398a.png)

**After buttons:**

![Screenshot 2020-09-07 at 12 33 08](https://user-images.githubusercontent.com/411945/92379625-11452d00-f108-11ea-8dc3-fb85dd222d35.png)

Possible enhancement could be to move these to some CSS variables?
