### PR TITLE
Pass ports within data for more predictable messaging API functionality

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -934,6 +934,7 @@ function initPort( message ) {
 						multiple: this.props.multiple,
 						value: this.props.value,
 					},
+					ports: [ mediaSelectChannel.port2, mediaCancelChannel.port2 ],
 				},
 				[ mediaSelectChannel.port2, mediaCancelChannel.port2 ]
 			);

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -232,7 +232,14 @@ class CalypsoifyIframe extends Component<
 		// any other message is unknown and may indicate a bug
 	};
 
-	onIframePortMessage = ( { data, data: { ports } }: MessageEvent ) => {
+	onIframePortMessage = ( event: MessageEvent ) => {
+		const { data, ports: backCompatPorts } = event;
+
+		// in a previous release of wpcom-block-editor, ports array wasn't explicitly passed into the data object
+		// and the MessageEvent.ports prop was used instead. This gives support for both versions of wpcom-block-editor
+		// see: https://github.com/Automattic/wp-calypso/pull/45436
+		const ports = data.ports ?? backCompatPorts;
+
 		/* eslint-disable @typescript-eslint/no-explicit-any */
 		const { action, payload }: { action: EditorActions; payload: any } = data;
 

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -232,7 +232,7 @@ class CalypsoifyIframe extends Component<
 		// any other message is unknown and may indicate a bug
 	};
 
-	onIframePortMessage = ( { data, ports }: MessageEvent ) => {
+	onIframePortMessage = ( { data, data: { ports } }: MessageEvent ) => {
 		/* eslint-disable @typescript-eslint/no-explicit-any */
 		const { action, payload }: { action: EditorActions; payload: any } = data;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR passes the `ports` objects into the `data` object _and_ within the transferables array. I just learned that this is how [the API is meant to be used](https://developer.mozilla.org/en-US/docs/Web/API/Worker/postMessage#Main_thread_code:~:text=%2F%2F%20The%20array%20buffer%20that%20we%20passed%20to%20the%20transferrable%20section%203%20lines%20below).

The transerrables array elements are "neutered" (made unusable in the sender window) then their ownership is transferred to the target window, in order to access those elements, they still need to be passed within the `data` object. If you pass objects within the `data` object that are not neutered/transferred, you won't be able to access these objects in the target window. Neither transferring them only won't give you access to use them.

Before this PR, we conflated `MessageEvent.ports` with the transferred `ports` array. It's easy to make this mistake because both are exactly two ports of the same `MessagePort` type, but they're not the same. 

The [`MessageEvent.ports`](https://developer.mozilla.org/en-US/docs/Web/API/MessageEvent#Properties:~:text=MessageEvent.ports) is a default prop that contains the two ports that I frankly didn't spend much energy learning about, I learned though that they're definitely not [the ports we mean to transfer to the iframe.](https://github.com/Automattic/wp-calypso/blob/fix/image-picker-iframe-comms/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js#L938).

My theory on why the old code worked anyways, is that they can indeed be the same ports we transfer, but **not** the same array that contained them. Meaning even though the elements may or may not be the same, their order is under no obligation to be the same.

This theory isn't much supported and can be wrong, but I feel this change here is still justified, because:

1. It uses the API as documented. 
2. It relies on our own `data` object structure to access `ports`. As opposed to browser internals.
3. It fixes the issue.

#### Testing instructions

**Using Firefox:**

1. Sandbox a site.
2. After checking this branch out, sync your local `wpcom-block-editor` with it ([using this](https://github.com/Automattic/wp-calypso/blob/master/apps/wpcom-block-editor/README.md#user-content-dev-workflow:~:text=Watch%20for%20file%20changes%20and%20upload%20build%20output%20to%20your%20sandbox)).
3. Try to repro in Firefox as explained in the issue #44097. 


Fixes: https://github.com/Automattic/wp-calypso/issues/44097