### PR TITLE
Offer Reset: integrate Pricing page with Jetpack Connect flow

### DIFF
--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -35,6 +35,7 @@ import { login } from 'lib/paths';
 import { parseAuthorizationQuery } from './utils';
 import { persistMobileRedirect, retrieveMobileRedirect, storePlan } from './persistence-utils';
 import { startAuthorizeStep } from 'state/jetpack-connect/actions';
+import { OFFER_RESET_FLOW_TYPES } from 'state/jetpack-connect/constants';
 import {
 	PLAN_JETPACK_BUSINESS,
 	PLAN_JETPACK_BUSINESS_MONTHLY,
@@ -80,6 +81,12 @@ export function offerResetContext( context, next ) {
 }
 
 const getPlanSlugFromFlowType = ( type, interval = 'yearly' ) => {
+	// Return early if `type` is already a real product slug that is part
+	// of the Offer Reset flow.
+	if ( OFFER_RESET_FLOW_TYPES.includes( type ) ) {
+		return type;
+	}
+
 	const planSlugs = {
 		yearly: {
 			personal: PLAN_JETPACK_PERSONAL,

--- a/client/jetpack-connect/index.js
+++ b/client/jetpack-connect/index.js
@@ -12,9 +12,10 @@ import * as controller from './controller';
 import { login } from 'lib/paths';
 import { siteSelection } from 'my-sites/controller';
 import { makeLayout, render as clientRender } from 'controller';
-import { getLanguageRouteParam } from 'lib/i18n-utils';
 import { shouldShowOfferResetFlow } from 'lib/abtest/getters';
+import { getLanguageRouteParam } from 'lib/i18n-utils';
 import plansV2 from 'my-sites/plans-v2';
+import { OFFER_RESET_FLOW_TYPES } from 'state/jetpack-connect/constants';
 
 /**
  * Style dependencies
@@ -34,6 +35,7 @@ export default function () {
 		'scan',
 		'realtimebackup',
 		'antispam',
+		...OFFER_RESET_FLOW_TYPES,
 	].join( '|' );
 
 	page(

--- a/client/jetpack-connect/index.js
+++ b/client/jetpack-connect/index.js
@@ -35,33 +35,20 @@ export default function () {
 		'scan',
 		'realtimebackup',
 		'antispam',
+		'jetpack_search',
+		'wpcom_search',
 		...OFFER_RESET_FLOW_TYPES,
 	].join( '|' );
 
 	page(
 		`/jetpack/connect/:type(${ planTypeString })/:interval(yearly|monthly)?`,
+		controller.loginBeforeJetpackSearch,
 		controller.persistMobileAppFlow,
 		controller.setMasterbar,
 		controller.connect,
 		makeLayout,
 		clientRender
 	);
-
-	if ( isLoggedOut ) {
-		page(
-			'/jetpack/connect/:type(jetpack_search|wpcom_search)/:interval(yearly|monthly)?',
-			( { path } ) => page( login( { isNative: true, isJetpack: true, redirectTo: path } ) )
-		);
-	} else {
-		page(
-			'/jetpack/connect/:type(jetpack_search|wpcom_search)/:interval(yearly|monthly)?',
-			controller.persistMobileAppFlow,
-			controller.setMasterbar,
-			controller.purchase,
-			makeLayout,
-			clientRender
-		);
-	}
 
 	if ( config.isEnabled( 'jetpack/connect/remote-install' ) ) {
 		page(

--- a/client/my-sites/plans-v2/utils.ts
+++ b/client/my-sites/plans-v2/utils.ts
@@ -448,8 +448,16 @@ export function getOptionFromSlug( slug: string ): string | null {
  * @param {string | string[]} products Slugs of the products to add to the cart
  */
 export function checkout( siteSlug: string, products: string | string[] ): void {
-	addItems( ( isArray( products ) ? products : [ products ] ).map( jetpackProductItem ) );
-	page.redirect( `/checkout/${ siteSlug }` );
+	const productsArray = isArray( products ) ? products : [ products ];
+	if ( siteSlug ) {
+		addItems( productsArray.map( jetpackProductItem ) );
+		page.redirect( `/checkout/${ siteSlug }` );
+	} else {
+		// There is not siteSlug, we need to redirect the user to the site selection
+		// step of the flow. Since purchases of multiple products are allowed, we need
+		// to pass all products separated by comma in the URL.
+		page.redirect( `/jetpack/connect/${ productsArray.join( ',' ) }` );
+	}
 }
 
 /**

--- a/client/state/jetpack-connect/constants.js
+++ b/client/state/jetpack-connect/constants.js
@@ -1,16 +1,32 @@
+/**
+ * Internal dependencies
+ */
+import { shouldShowOfferResetFlow } from 'lib/abtest/getters';
+import { JETPACK_RESET_PLANS } from 'lib/plans/constants';
+import { JETPACK_PRODUCTS_LIST } from 'lib/products-values/constants';
+
 export const JETPACK_CONNECT_TTL = 60 * 60 * 1000; // 1 hour
 export const JETPACK_CONNECT_TTL_SECONDS = JETPACK_CONNECT_TTL / 60;
 export const JETPACK_CONNECT_AUTHORIZE_TTL = 60 * 60 * 1000; // 1 hour
 export const AUTH_ATTEMPS_TTL = 60 * 1000; // 1 minute
 
+// Since Offer Reset relies in this flow, we need to make sure we are supporting
+// all types that are part of Offer Reset.
+export const OFFER_RESET_FLOW_TYPES = shouldShowOfferResetFlow()
+	? [ ...JETPACK_RESET_PLANS, ...JETPACK_PRODUCTS_LIST ]
+	: [];
+
 export const FLOW_TYPES = [
-	'install',
-	'personal',
-	'premium',
-	'pro',
-	'jetpack_search',
-	'backup',
-	'realtimebackup',
-	'scan',
-	'antispam',
+	...new Set( [
+		'install',
+		'personal',
+		'premium',
+		'pro',
+		'jetpack_search',
+		'backup',
+		'realtimebackup',
+		'scan',
+		'antispam',
+		...OFFER_RESET_FLOW_TYPES,
+	] ),
 ];

--- a/client/state/jetpack-connect/constants.js
+++ b/client/state/jetpack-connect/constants.js
@@ -4,16 +4,23 @@
 import { shouldShowOfferResetFlow } from 'lib/abtest/getters';
 import { JETPACK_RESET_PLANS } from 'lib/plans/constants';
 import { JETPACK_PRODUCTS_LIST } from 'lib/products-values/constants';
-
+import { UPSELL_PRODUCT_MATRIX } from 'my-sites/plans-v2/constants';
 export const JETPACK_CONNECT_TTL = 60 * 60 * 1000; // 1 hour
 export const JETPACK_CONNECT_TTL_SECONDS = JETPACK_CONNECT_TTL / 60;
 export const JETPACK_CONNECT_AUTHORIZE_TTL = 60 * 60 * 1000; // 1 hour
 export const AUTH_ATTEMPS_TTL = 60 * 1000; // 1 minute
 
+// Offer Reset allows users to purchase two products at the same time. The allowed
+// combinations are stored in `OFFER_RESET_COMBINED_FLOW_TYPES`. From this matrix,
+// we get a list of strings that follow the `productSlug1,productSlug2` pattern.
+export const OFFER_RESET_COMBINED_FLOW_TYPES = shouldShowOfferResetFlow()
+	? Object.entries( UPSELL_PRODUCT_MATRIX ).map( ( fromTo ) => fromTo.join( ',' ) )
+	: [];
+
 // Since Offer Reset relies in this flow, we need to make sure we are supporting
 // all types that are part of Offer Reset.
 export const OFFER_RESET_FLOW_TYPES = shouldShowOfferResetFlow()
-	? [ ...JETPACK_RESET_PLANS, ...JETPACK_PRODUCTS_LIST ]
+	? [ ...JETPACK_RESET_PLANS, ...JETPACK_PRODUCTS_LIST, ...OFFER_RESET_COMBINED_FLOW_TYPES ]
 	: [];
 
 export const FLOW_TYPES = [


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Make it possible to purchase products from the new pricing page.

#### Implementations notes

* I simplified, I believe, the Connect Flow by removing a couple of paths. Now Search products follow the same route that the rest of the products follow.
* I made the Connect Flow support two products in the URL (only for a specific set of them). In #45418, we made the Composite Checkout support passing two products in URL.
* In the Plans grid, if there is no site slug, instead of redirecting users to the checkout page, we redirect them to `jetpack/connect/:items`, since from there users will be asked for a site and to log in if needed.

#### Testing instructions

* Run this PR in one terminal with `yarn start`. Once that finishes, open another terminal window/tab and run `yarn start-jetpack-cloud-p`. We need both builds working at the same time.
* Visit `http://jetpack.cloud.localhost:3001/pricing` (on port 3001, not 3000).
* Follow any product path (bonus point if you try with an upsell flow) and click the CTA to make the purchase. Nothing will happen because the URL will point to Jetpack Cloud when it should point to Calypso. Your URL may look like `http://jetpack.cloud.localhost:3001/jetpack/connect/jetpack_backup_daily,jetpack_scan`, so copy it and replace the port from 3001 to 3000. That will run the page in the Calypso build because that is where the Connect Flow lives (the last part of the purchase flow from the pricing page).
* Enter a valid site URL for a Jetpack site.
* Verify that you got to the checkout page with the selected product(s) in the cart.
* Repeat the test with other products.
* Make sure to test this in an incognito window.
* Make sure we didn't introduce any regressions and test the normal flow from the Plans grid in Calypso.

Fixes 1169247016322522-as-1189391103512226

#### Demo
![Kapture 2020-09-08 at 11 42 29](https://user-images.githubusercontent.com/3418513/92491343-81b38300-f1c8-11ea-9799-5017c68cba9e.gif)
