### PR TITLE
Reader: Allow using the post card comment and like buttons with the keyboard

### DIFF
--- a/client/blocks/comment-button/style.scss
+++ b/client/blocks/comment-button/style.scss
@@ -9,7 +9,6 @@
 	position: relative;
 
 	&:hover,
-	&:focus,
 	&:active {
 		color: var( --color-primary );
 	}
@@ -28,6 +27,10 @@
 .comment-button__label {
 	font-size: $font-body-small;
 	margin-left: 4px;
+
+	&:empty {
+		display: none;
+	}
 }
 
 .comment-button__icon {

--- a/client/blocks/like-button/style.scss
+++ b/client/blocks/like-button/style.scss
@@ -73,4 +73,8 @@
 	margin-left: 1px;
 	font-size: $font-body-small;
 	min-width: 10px;
+
+	&:empty {
+		display: none;
+	}
 }

--- a/client/blocks/reader-post-actions/index.jsx
+++ b/client/blocks/reader-post-actions/index.jsx
@@ -89,7 +89,7 @@ const ReaderPostActions = ( props ) => {
 						key="comment-button"
 						commentCount={ post.discussion.comment_count }
 						onClick={ onCommentClick }
-						tagName="div"
+						tagName="button"
 						size={ iconSize }
 					/>
 				</li>
@@ -103,7 +103,7 @@ const ReaderPostActions = ( props ) => {
 						post={ post }
 						site={ site }
 						fullPost={ fullPost }
-						tagName="div"
+						tagName="button"
 						forceCounter={ true }
 						iconSize={ iconSize }
 						showZeroCount={ false }

--- a/client/blocks/reader-post-actions/style.scss
+++ b/client/blocks/reader-post-actions/style.scss
@@ -27,4 +27,18 @@
 	&:last-child {
 		margin-right: 0;
 	}
+
+	& > button {
+		line-height: inherit;
+
+		&:focus {
+			outline: thin dotted;
+		}
+
+		.accessible-focus &:focus {
+			border-radius: 2px;
+			border-color: var( --color-primary );
+			box-shadow: 0 0 0 2px var( --color-primary-light );
+		}
+	}
 }


### PR DESCRIPTION
As reported in #44852, users couldn't use the keyboard to focus on the comments and like buttons shown at the bottom of a post card.

Both the component that renders the comments button and the one that renders the like button receive the tag name as a prop. It seems that the most cost-effective alternative is to specify a `button` tag instead of a `div` to render the buttons and to adjust the styles when focused, so they match the other card buttons. However, in the long term, it would be a good idea to consider refactoring these two components to use the `Button` component from `@automattic/components`, as the options and share buttons do.

#### Changes proposed in this Pull Request

* Changed the tag used to render the comments and like buttons. Now a `button` element is used instead of a `div`.
* Took advantage of accessible-focus module to style the buttons when focused.

##### Before
![Video showing the behavior before the fix](https://user-images.githubusercontent.com/5444806/89965465-4bafcd00-dc23-11ea-974c-bbc669787e8f.gif)

##### After
![Video showing the behavior after the fix](https://user-images.githubusercontent.com/5444806/92415132-e5d53900-f12d-11ea-9406-6433f650aec3.gif)

#### Testing instructions

##### Comment button

* Starting at URL: https://wordpress.com/read/search?q=coffee
* Press the Tab key until reaching the comment button, in the first post
* Verify that the comment button can be focused
* Verify that the comment button has a blue outline
* Press the Enter key
* Verify that the page has been redirected to the comments section of the post

##### Like button

* Starting at URL: https://wordpress.com/read/search?q=coffee
* Press the Tab key until reaching the like button, in the first post
* Verify that the like button can be focused
* Verify that the like button has a blue outline
* Press the Enter key
* Verify that the likes count has been incremented by one
* Press the Enter key
* Verify that the likes count has been decremented by one

Similar steps should be followed in /read, and in a full post view (for example, /read/blogs/31293899/posts/21431)

Fixes #44852 

cc: @bluefuton 