### PR TITLE
Add experimentation platform paths to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -84,3 +84,10 @@
 # FSE Workflow Files
 /.github/workflows/editing-toolkit-plugin.yml @Automattic/cylon
 /.github/workflows/send-calypso-app-build-trigger.sh @Automattic/cylon
+
+# Experimentation platform legacy library and new client
+/client/lib/abtest @Automattic/experimentation-platform
+/client/components/data/query-experiments @Automattic/experimentation-platform
+/client/components/experiment @Automattic/experimentation-platform
+/client/state/data-layer/wpcom/experiments @Automattic/experimentation-platform
+/client/state/experiments @Automattic/experimentation-platform


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add experimentation platform paths to CODEOWNERS so that @Automattic/experimentation-platform would get pinged for review when these files change.