### PR TITLE
[TeamCity] - Do not litmit branch checkout for docker builds

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -78,10 +78,6 @@ object BuildBaseImages : BuildType({
 		root(WpCalypso)
 
 		cleanCheckout = true
-		branchFilter = """
-			+:master
-		""".trimIndent()
-		excludeDefaultBranchChanges = true
 	}
 
 	steps {


### PR DESCRIPTION
### Changes proposed in this Pull Request

The job "Build base images" should be running every 24h on master but it is not. I think it is caused by having a branch checkout limit. This PR changes it.
