### PR TITLE
Use alpine and multi-stage builds (feedback required)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM node:12.18.0
+FROM node:12.18.0 as builder
 LABEL maintainer="Automattic"
 
-WORKDIR    /calypso
+WORKDIR /calypso
 
 
-ENV        CONTAINER 'docker'
-ENV        PROGRESS=true
+ENV CONTAINER 'docker'
+ENV PROGRESS=true
 
 # Build a "base" layer
 #
@@ -17,26 +17,45 @@ ENV        PROGRESS=true
 # env-config.sh
 #   used by systems to overwrite some defaults
 #   such as the apt and npm mirrors
-COPY       ./env-config.sh /tmp/env-config.sh
-RUN        bash /tmp/env-config.sh
+COPY ./env-config.sh /tmp/env-config.sh
+RUN bash /tmp/env-config.sh
 
 # Build a "source" layer
 #
 # This layer is populated with up-to-date files from
 # Calypso development.
 COPY . /calypso/
-RUN yarn install --frozen-lockfile && yarn cache clean
+RUN yarn install --frozen-lockfile
 
 
 # Build the final layer
 #
 # This contains built environments of Calypso. It will
 # change any time any of the Calypso source-code changes.
-ARG        commit_sha="(unknown)"
-ENV        COMMIT_SHA $commit_sha
+ARG commit_sha="(unknown)"
+ENV COMMIT_SHA $commit_sha
 
-ARG        workers
-RUN        WORKERS=$workers CALYPSO_ENV=production BUILD_TRANSLATION_CHUNKS=true yarn run build && rm -fr .cache
+ARG workers
+RUN WORKERS=$workers CALYPSO_ENV=production BUILD_TRANSLATION_CHUNKS=true yarn run build
 
-USER       nobody
-CMD        NODE_ENV=production node build/server.js
+
+FROM node:12.18.0-alpine as app
+
+ARG commit_sha="(unknown)"
+ENV COMMIT_SHA=$commit_sha
+ENV NODE_ENV=production
+WORKDIR /calypso
+RUN apk add --no-cache tini
+COPY --from=builder --chown=nobody:nobody /calypso/node_modules /calypso/node_modules/
+COPY --from=builder --chown=nobody:nobody /calypso/packages /calypso/packages/
+COPY --from=builder --chown=nobody:nobody /calypso/config /calypso/config/
+COPY --from=builder --chown=nobody:nobody /calypso/client/node_modules /calypso/client/node_modules/
+COPY --from=builder --chown=nobody:nobody /calypso/client/server/devdocs/search-index.js /calypso/client/server/devdocs/
+COPY --from=builder --chown=nobody:nobody /calypso/client/server/bundler/*.json /calypso/client/server/bundler/
+COPY --from=builder --chown=nobody:nobody /calypso/client/webpack.config.js /calypso/client/
+COPY --from=builder --chown=nobody:nobody /calypso/build /calypso/build/
+COPY --from=builder --chown=nobody:nobody /calypso/public /calypso/public/
+
+USER nobody
+ENTRYPOINT ["/sbin/tini", "--"]
+CMD ["node", "build/server.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN yarn install --frozen-lockfile
 #
 # This contains built environments of Calypso. It will
 # change any time any of the Calypso source-code changes.
-RUN yarn run build
+RUN yarn run build && rm -fr .cache
 
 ###################
 FROM node:12.18.0-alpine as app


### PR DESCRIPTION
# Status

**Not for merge**. I just wanted to know if calypso.live works (it does) and get feedback from you. Before landing this change I'd like to increase log/metrics coverage to make sure nothing breaks in prod, and maybe split this PR into two smaller changes (multi-stage and then alpine).

### Background

Our base image is huge, 2.81 Gb. There are multiple causes for this size, but for this PR these to are relevant:

* We use image based on [buildpack-deps](https://hub.docker.com/_/buildpack-deps/), which is a bit bloated. It adds ~800Mb of unused software
* We copy all wp-calypso source in the image, including files that are never needed by the Node.js server.

### Changes

(This is based on the work in https://github.com/Automattic/wp-calypso/pull/21537)

* Introduce multi-stage builds. Having a 'builder' step separate from an 'app' step allow us to have more control about what ends in the final image.

* Use Alpine-based image for the 'app' image. The 'builder' is still based of buildpack-deps (so we have all the tools available to install and compile binary dependencies), but the 'app' image doesn't need any of those, only `node`

* Use [tini](https://github.com/krallin/tini) as the main process to get signal handling for free. This is mostly for developer friendliness, so the image can be killed with `Ctrl+c`

* Do not run `env-config.sh` for the `app` image. As far as I know, this setting is used to set Debian mirrors and NPM registry, both only needed for the `base` image.

Image content:
<details>
<summary>Before this change (3gb):</summary>

```
Permission     UID:GID       Size  Filetree
drwxr-xr-x         0:0     5.4 MB  ├─⊕ bin
drwxr-xr-x         0:0        0 B  ├── boot
drwxr-xr-x         0:0     2.0 GB  ├── calypso
drwxr-xr-x         0:0      43 kB  │   ├─⊕ .circleci
-rw-r--r--         0:0      390 B  │   ├── .editorconfig
-rw-r--r--         0:0      697 B  │   ├── .eslintignore
-rw-r--r--         0:0     7.7 kB  │   ├── .eslintrc.js
-rw-r--r--         0:0       68 B  │   ├── .gitattributes
drwxr-xr-x         0:0      18 kB  │   ├─⊕ .github
-rw-r--r--         0:0     1.4 kB  │   ├── .gitignore
-rw-r--r--         0:0        8 B  │   ├── .nvmrc
-rw-r--r--         0:0      137 B  │   ├── .prettierrc
-rw-r--r--         0:0       73 B  │   ├── .rtlcssrc
-rw-r--r--         0:0     2.5 kB  │   ├── .stylelintrc
drwxr-xr-x         0:0      13 kB  │   ├─⊕ .teamcity
drwxr-xr-x         0:0     156 kB  │   ├─⊕ .tsc-cache
drwxr-xr-x         0:0     5.6 MB  │   ├─⊕ .yarn
-rw-r--r--         0:0      128 B  │   ├── .yarnrc
-rw-r--r--         0:0     2.5 kB  │   ├── CODE-OF-CONDUCT.md
-rw-r--r--         0:0      73 kB  │   ├── CREDITS.md
-rw-r--r--         0:0      15 kB  │   ├── LICENSE.md
-rw-r--r--         0:0     3.3 kB  │   ├── README.md
-rw-r--r--         0:0      401 B  │   ├── Vagrantfile
-rw-r--r--         0:0      847 B  │   ├── Vagrantfile-boot2docker
drwxr-xr-x         0:0      64 MB  │   ├─⊕ apps
-rw-r--r--         0:0      855 B  │   ├── babel.config.js
drwxr-xr-x         0:0      72 kB  │   ├─⊕ bin
drwxr-xr-x         0:0      16 MB  │   ├─⊕ build
-rw-r--r--         0:0     1.5 MB  │   ├── calypso-strings.pot
-rw-r--r--         0:0     1.2 MB  │   ├── chunks-map.evergreen.json
-rw-r--r--         0:0     1.2 MB  │   ├── chunks-map.fallback.json
drwxr-xr-x         0:0      40 MB  │   ├─⊕ client
-rw-r--r--         0:0      276 B  │   ├── composer.json
-rw-r--r--         0:0      11 kB  │   ├── composer.lock
drwxr-xr-x         0:0      63 kB  │   ├─⊕ config
drwxr-xr-x         0:0     1.1 MB  │   ├─⊕ desktop
drwxr-xr-x         0:0     289 kB  │   ├─⊕ docs
-rw-r--r--         0:0      435 B  │   ├── env-config.sh
-rw-r--r--         0:0      487 B  │   ├── jsconfig.json
-rw-r--r--         0:0      195 B  │   ├── lerna.json
drwxr-xr-x         0:0     1.5 GB  │   ├─⊕ node_modules
-rw-r--r--         0:0     1.1 kB  │   ├── npmpackagejsonlint.config.js
-rw-r--r--         0:0      20 kB  │   ├── package.json
drwxr-xr-x         0:0      18 MB  │   ├─⊕ packages
drwxr-xr-x         0:0     371 MB  │   ├─⊕ public
-rw-r--r--         0:0     1.5 kB  │   ├── renovate.json
drwxr-xr-x         0:0      22 MB  │   ├─⊕ static
drwxr-xr-x         0:0     4.1 MB  │   ├─⊕ test
-rw-r--r--         0:0       34 B  │   ├── tslint.json
-rw-r--r--         0:0     1.2 MB  │   └── yarn.lock
drwxr-xr-x         0:0        0 B  ├── dev
drwxr-xr-x         0:0     1.3 MB  ├─⊕ etc
drwxr-xr-x         0:0     4.4 kB  ├─⊕ home
drwxr-xr-x         0:0      13 MB  ├─⊕ lib
drwxr-xr-x         0:0        0 B  ├─⊕ lib64
drwxr-xr-x         0:0        0 B  ├── media
drwxr-xr-x         0:0        0 B  ├── mnt
drwxr-xr-x         0:0     5.3 MB  ├─⊕ opt
drwxr-xr-x         0:0        0 B  ├── proc
drwx------         0:0      11 MB  ├─⊕ root
drwxr-xr-x         0:0        0 B  ├─⊕ run
drwxr-xr-x         0:0     4.2 MB  ├─⊕ sbin
drwxr-xr-x         0:0        0 B  ├── srv
drwxr-xr-x         0:0        0 B  ├── sys
drwxrwxrwx         0:0      39 MB  ├─⊕ tmp
drwxr-xr-x         0:0     869 MB  ├─⊕ usr
drwxr-xr-x         0:0      10 MB  └─⊕ var
```
</details>

<details>
<summary>After this change (1.98gb)</summary>

```
Permission     UID:GID       Size  Filetree
drwxr-xr-x         0:0     841 kB  ├─⊕ bin
drwxr-xr-x         0:0     1.9 GB  ├── calypso
drwxr-xr-x 65534:65534      16 MB  │   ├─⊕ build
drwxr-xr-x 65534:65534      14 MB  │   ├─⊕ client
drwxr-xr-x 65534:65534      74 kB  │   ├─⊕ config
drwxr-xr-x 65534:65534     1.5 GB  │   ├─⊕ node_modules
drwxr-xr-x 65534:65534      18 MB  │   ├─⊕ packages
drwxr-xr-x 65534:65534     371 MB  │   └─⊕ public
drwxr-xr-x         0:0        0 B  ├── dev
drwxr-xr-x         0:0     327 kB  ├─⊕ etc
drwxr-xr-x         0:0        0 B  ├─⊕ home
drwxr-xr-x         0:0     3.8 MB  ├─⊕ lib
drwxr-xr-x         0:0        0 B  ├─⊕ media
drwxr-xr-x         0:0        0 B  ├── mnt
drwxr-xr-x         0:0     5.3 MB  ├─⊕ opt
dr-xr-xr-x         0:0        0 B  ├── proc
drwx------         0:0      12 kB  ├─⊕ root
drwxr-xr-x         0:0        0 B  ├── run
drwxr-xr-x         0:0     253 kB  ├─⊕ sbin
drwxr-xr-x         0:0        0 B  ├── srv
drwxr-xr-x         0:0        0 B  ├── sys
drwxrwxrwx         0:0     2.3 MB  ├─⊕ tmp
drwxr-xr-x         0:0      77 MB  ├─⊕ usr
drwxr-xr-x         0:0        0 B  └─⊕ var
```

</details>

### References

* [multi-stage builds](https://docs.docker.com/develop/develop-images/multistage-build/)
* [node-alpine](https://hub.docker.com/_/node)
* [What is advantage of Tini?](https://github.com/krallin/tini/issues/8)

Previous art:
* Docker deep dive (p4TIVU-8Ou-p2)
* https://github.com/Automattic/wp-calypso/pull/19962
* https://github.com/Automattic/wp-calypso/pull/21537 

### Testing instructions

* Check that the live branch works as expected.
* Checkout this branch and run `yarn build-docker && yarn docker` (more info in the Field Guide). Ensure Calypso works.
* Checkout the image size with `docker image ls`. Ensure it is smaller than the image from master.
* Inspect the content with `dive wp-calypso` (you may need https://github.com/wagoodman/dive). Verify there are not unexpected files.