### PR TITLE
Components: Remove global input[type='number'] styles

### DIFF
--- a/client/assets/stylesheets/shared/_forms.scss
+++ b/client/assets/stylesheets/shared/_forms.scss
@@ -8,7 +8,6 @@ form {
 }
 input[type='text'],
 input[type='email'],
-input[type='number'],
 textarea {
 	@extend %form-field;
 }
@@ -20,7 +19,6 @@ textarea {
 fieldset,
 input[type='text'],
 input[type='email'],
-input[type='number'],
 textarea,
 select,
 label {

--- a/client/components/forms/form-text-input/style.scss
+++ b/client/components/forms/form-text-input/style.scss
@@ -3,6 +3,7 @@
 		input[type='url']#{&},
 		input[type='password']#{&},
 		input[type='tel']#{&},
+		input[type='number']#{&},
 		input[type='search']#{&} {
 			@extend %form-field;
 		}

--- a/client/components/line-chart/docs/example.js
+++ b/client/components/line-chart/docs/example.js
@@ -11,6 +11,7 @@ import moment from 'moment';
 import { Card } from '@automattic/components';
 import FormInputCheckbox from 'components/forms/form-checkbox';
 import FormLabel from 'components/forms/form-label';
+import FormTextInput from 'components/forms/form-text-input';
 import LineChart from 'components/line-chart';
 
 const NUM_DATA_SERIES = 3;
@@ -111,7 +112,7 @@ export default class LineChartExample extends Component {
 					<div>
 						<FormLabel>
 							Data Min
-							<input
+							<FormTextInput
 								type="number"
 								value={ this.state.dataMin }
 								min="0"
@@ -121,7 +122,7 @@ export default class LineChartExample extends Component {
 
 						<FormLabel>
 							Data Max
-							<input
+							<FormTextInput
 								type="number"
 								value={ this.state.dataMax }
 								min="0"
@@ -131,7 +132,7 @@ export default class LineChartExample extends Component {
 
 						<FormLabel>
 							Series Length
-							<input
+							<FormTextInput
 								type="number"
 								value={ this.state.seriesLength }
 								min="3"

--- a/client/components/pie-chart/docs/example.js
+++ b/client/components/pie-chart/docs/example.js
@@ -9,6 +9,7 @@ import React, { Component } from 'react';
 import { Button, Card } from '@automattic/components';
 import FormInputCheckbox from 'components/forms/form-checkbox';
 import FormLabel from 'components/forms/form-label';
+import FormTextInput from 'components/forms/form-text-input';
 import PieChart from 'components/pie-chart';
 import PieChartLegend from 'components/pie-chart/legend';
 
@@ -103,7 +104,7 @@ class PieChartExample extends Component {
 							return (
 								<div key={ seriesName }>
 									<h2>{ this.state[ seriesName ].name }</h2>
-									<input
+									<FormTextInput
 										name={ seriesName }
 										type="number"
 										value={ this.state[ seriesName ].value }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove global form `input[type='number']` styles in favor of more specific component-level styling. See #45259.

#### Testing instructions

* Test the following against production and ensure that they match stylistically and functionally:
  * `/devdocs/design/form-fields` - the "Form Currency Input" fields.
  * `/devdocs/design/line-chart` - the number fields that appear when you toggle the "Show Data Controls" button.
  * `/devdocs/design/pie-chart` - the number fields that appear when you toggle the "Show Data Controls" button.
  * Feel free to test any of the other instances that use the `number` type of field, although the above should be enough.
* Verify all `<input type="number" />` instances use either `<FormTextInput />` or `<FormTextInputWithAffixes />`. 

#### Notes

The following use cases are consciously ignored:
* `apps/editing-toolkit/editing-toolkit-plugin/premium-content/blocks/container/inspector.js` - this uses `@wordpress/components`.
