### PR TITLE
Replace calypso/config with calypso/server/config in server tests

### DIFF
--- a/test/server/jest.config.js
+++ b/test/server/jest.config.js
@@ -11,8 +11,12 @@ module.exports = {
 		),
 	},
 	transformIgnorePatterns: [
-		'node_modules[\\/\\\\](?!redux-form|draft-js)(?!.*\\.(?:gif|jpg|jpeg|png|svg|scss|sass|css))',
+		'node_modules[\\/\\\\](?!redux-form|draft-js|calypso)(?!.*\\.(?:gif|jpg|jpeg|png|svg|scss|sass|css))',
 	],
+	moduleNameMapper: {
+		'^calypso/config$': 'calypso/server/config',
+		'^calypso/config/(.*)$': 'calypso/server/config/$1',
+	},
 	testMatch: [ '<rootDir>/server/**/test/*.[jt]s?(x)', '!**/.eslintrc.*' ],
 	timers: 'fake',
 	setupFiles: [ 'regenerator-runtime/runtime' ], // some NPM-published packages depend on the global


### PR DESCRIPTION
### Background

See #44602

### Changes

Adds support for using `calypso` package in server tests:

* Replaces imports of `calypso/config` with `calypso/server/config`.
* Adds `node_modules/calypso` to the packages being transpiled

### Testing instructions

* Verify server tests are still working
