### PR TITLE
Nav Unification: Update masterbar

### DIFF
--- a/client/assets/stylesheets/_nav-unification.scss
+++ b/client/assets/stylesheets/_nav-unification.scss
@@ -32,6 +32,9 @@
 		height: $nav-unification-masterbar-height;
 		border-bottom: none;
 		font-size: $nav-unification-masterbar-font-size;
+		-webkit-box-shadow: inset 0 -1px 0 #333;
+		-moz-box-shadow: inset 0 -1px 0 #333;
+		box-shadow: inset 0 -1px 0 #333;
 	}
 
 	// client/layout/masterbar/style.scss
@@ -89,7 +92,6 @@
 				color: $nav-unification-primary;
 			}
 		}
-
 	}
 
 	// client/layout/masterbar/style.scss
@@ -104,7 +106,6 @@
 		}
 	}
 
-	
 	.masterbar__item-notifications {
 		padding-right: 5px;
 		padding-left: 5px;
@@ -127,7 +128,6 @@
 
 	// client/layout/masterbar/style.scss
 	@include breakpoint-deprecated( '>960px' ) {
-
 		.masterbar__toggle-drafts.button.is-borderless {
 			margin-left: -23px;
 		}
@@ -135,7 +135,6 @@
 
 	// breakpoint used in wp-admin
 	@media only screen and ( max-width: 782px ) {
-
 		// client/layout/style.scss
 		.layout__secondary {
 			top: $nav-unification-masterbar-height-mobile;
@@ -169,7 +168,6 @@
 
 		// client/layout/masterbar/style.scss
 		.masterbar__item-me {
-
 			// fix for profile picture currently hidden in production
 			.masterbar__item-content {
 				display: block;
@@ -185,16 +183,12 @@
 		.masterbar__item-notifications .masterbar__notifications-bubble {
 			top: 10px;
 		}
-
 	}
 
 	// client/layout/masterbar/style.scss
 	@include breakpoint-deprecated( '<480px' ) {
-		
 		.masterbar__item-bubble {
 			transform: translate( -14px, -14px );
 		}
 	}
-
 }
-

--- a/client/assets/stylesheets/_nav-unification.scss
+++ b/client/assets/stylesheets/_nav-unification.scss
@@ -14,6 +14,7 @@
 	$nav-unification-primary: #23282d;
 	$nav-unification-secondary: #101517;
 	$nav-unification-masterbar-height: 32px;
+	$nav-unification-masterbar-height-mobile: 46px;
 	$nav-unification-masterbar-font-size: 13px;
 
 	// packages/calypso-color-schemes/src/shared/color-schemes/_default.scss
@@ -117,4 +118,61 @@
 		top: $nav-unification-masterbar-height;
 	}
 
+	// breakpoint used in wp-admin
+	@media only screen and ( max-width: 782px ) {
+
+		// client/layout/style.scss
+		.layout__secondary {
+			top: $nav-unification-masterbar-height-mobile;
+		}
+
+		// client/layout/masterbar/style.scss
+		.masterbar {
+			height: $nav-unification-masterbar-height-mobile;
+		}
+
+		// client/layout/masterbar/style.scss
+		.masterbar__item {
+			height: $nav-unification-masterbar-height-mobile;
+			line-height: $nav-unification-masterbar-height-mobile;
+		}
+
+		// client/layout/masterbar/style.scss
+		.masterbar__item-new,
+		.masterbar__toggle-drafts.button.is-borderless {
+			height: 36px;
+			margin-top: 5px;
+		}
+
+		.masterbar__toggle-drafts.button.is-borderless {
+			margin-left: -20px;
+		}
+
+		// client/layout/masterbar/style.scss
+		.masterbar__item-bubble {
+			top: 9px;
+			left: 2px;
+		}
+
+		// client/layout/masterbar/style.scss
+		.masterbar__item-me {
+
+			// fix for profile picture currently hidden in production
+			.masterbar__item-content {
+				display: block;
+			}
+			.gravatar {
+				top: 12px;
+				left: 20px;
+			}
+		}
+
+		// apps/notifications/style.scss
+		#wpnc-panel {
+			top: $nav-unification-masterbar-height-mobile;
+		}
+
+	}
+
 }
+

--- a/client/assets/stylesheets/_nav-unification.scss
+++ b/client/assets/stylesheets/_nav-unification.scss
@@ -1,0 +1,63 @@
+
+/**
+ * Nav unification styles
+ *
+ * This file contains all relevant styles for the nav unification prototype (see pbAPfg-O2).
+ * Using a single place to store these styles will allow us to easily (re)move them later.
+ * Depending on the outcome they'll either be deleted or moved to the relevant places.
+ * 
+ * IMPORTANT: When adding to this file please also add the source file in a comment.
+ */
+
+.is-nav-unification {
+	$nav-unification-primary: #23282d;
+
+	// packages/calypso-color-schemes/src/shared/color-schemes/_default.scss
+	--color-masterbar-background: #23282d;
+	--color-masterbar-border: #333;
+	--color-masterbar-item-hover-background: #333;
+	--color-masterbar-item-active-background: #fff;
+	--color-masterbar-unread-dot-background: #f0821e;
+
+	// client/layout/masterbar/style.scss
+	.masterbar__item {
+		&.is-active {
+			.masterbar__item-content {
+				color: $nav-unification-primary;
+			}
+
+			.gridicon {
+				fill: $nav-unification-primary;
+			}
+		}
+	}
+
+	// client/layout/masterbar/style.scss
+	.masterbar__item-new {
+		&:hover {
+			background: #e9e9ea;
+			color: $nav-unification-primary;
+		}
+
+		.masterbar__item-content {
+			color: $nav-unification-primary;
+		}
+		.gridicon {
+			fill: $nav-unification-primary;
+		}
+	}
+
+	// client/layout/masterbar/style.scss
+	.masterbar__toggle-drafts.button.is-borderless {
+		&:hover {
+			background-color: #e9e9ea;
+
+			.count {
+				border-color: $nav-unification-primary;
+				color: $nav-unification-primary;
+			}
+		}
+
+	}
+
+}

--- a/client/assets/stylesheets/_nav-unification.scss
+++ b/client/assets/stylesheets/_nav-unification.scss
@@ -21,7 +21,6 @@
 	--color-masterbar-background: #101517;
 	--color-masterbar-item-hover-background: #333;
 	--color-masterbar-item-active-background: #23282d;
-	--color-masterbar-unread-dot-background: #f0821e;
 
 	// client/layout/style.scss
 	.layout__secondary {

--- a/client/assets/stylesheets/_nav-unification.scss
+++ b/client/assets/stylesheets/_nav-unification.scss
@@ -11,6 +11,8 @@
 
 .is-nav-unification {
 	$nav-unification-primary: #23282d;
+	$nav-unification-masterbar-height: 32px;
+	$nav-unification-masterbar-font-size: 13px;
 
 	// packages/calypso-color-schemes/src/shared/color-schemes/_default.scss
 	--color-masterbar-background: #23282d;
@@ -19,8 +21,24 @@
 	--color-masterbar-item-active-background: #fff;
 	--color-masterbar-unread-dot-background: #f0821e;
 
+	// client/layout/style.scss
+	.layout__secondary {
+		top: $nav-unification-masterbar-height;
+	}
+
+	// client/layout/masterbar/style.scss
+	.masterbar {
+		height: $nav-unification-masterbar-height;
+		border-bottom: none;
+		font-size: $nav-unification-masterbar-font-size;
+	}
+
 	// client/layout/masterbar/style.scss
 	.masterbar__item {
+		height: $nav-unification-masterbar-height;
+		font-size: $nav-unification-masterbar-font-size;
+		line-height: $nav-unification-masterbar-height;
+
 		&.is-active {
 			.masterbar__item-content {
 				color: $nav-unification-primary;
@@ -33,7 +51,16 @@
 	}
 
 	// client/layout/masterbar/style.scss
+
+	.masterbar__item-new,
+	.masterbar__toggle-drafts.button.is-borderless {
+		height: 24px;
+		margin: 4px 8px;
+		border-radius: 5px;
+	}
+
 	.masterbar__item-new {
+
 		&:hover {
 			background: #e9e9ea;
 			color: $nav-unification-primary;
@@ -47,8 +74,9 @@
 		}
 	}
 
-	// client/layout/masterbar/style.scss
 	.masterbar__toggle-drafts.button.is-borderless {
+		margin-left: -26px;
+
 		&:hover {
 			background-color: #e9e9ea;
 
@@ -58,6 +86,22 @@
 			}
 		}
 
+	}
+
+	// client/layout/masterbar/style.scss
+	.masterbar__item-me {
+		padding-right: 8px;
+		padding-left: 8px;
+		.gravatar {
+			top: 5px;
+			left: 9px;
+		}
+	}
+
+	// client/layout/masterbar/style.scss
+	.masterbar__item-notifications {
+		padding-right: 5px;
+		padding-left: 5px;
 	}
 
 }

--- a/client/assets/stylesheets/_nav-unification.scss
+++ b/client/assets/stylesheets/_nav-unification.scss
@@ -79,7 +79,7 @@
 	}
 
 	.masterbar__toggle-drafts.button.is-borderless {
-		margin-left: -23px;
+		margin-left: -20px;
 
 		&:hover {
 			background-color: #e9e9ea;
@@ -96,13 +96,15 @@
 	.masterbar__item-me {
 		padding-right: 8px;
 		padding-left: 8px;
+
 		.gravatar {
-			top: 5px;
-			left: 8px;
+			top: 50%;
+			left: 50%;
+			transform: translate( -50%, -50% );
 		}
 	}
 
-	// client/layout/masterbar/style.scss
+	
 	.masterbar__item-notifications {
 		padding-right: 5px;
 		padding-left: 5px;
@@ -115,6 +117,20 @@
 	// apps/notifications/style.scss
 	#wpnc-panel {
 		top: $nav-unification-masterbar-height;
+	}
+
+	// client/layout/masterbar/style.scss
+	.masterbar__item-notifications .masterbar__notifications-bubble {
+		top: 3px;
+		transform: translateX( 1px );
+	}
+
+	// client/layout/masterbar/style.scss
+	@include breakpoint-deprecated( '>960px' ) {
+
+		.masterbar__toggle-drafts.button.is-borderless {
+			margin-left: -23px;
+		}
 	}
 
 	// breakpoint used in wp-admin
@@ -143,14 +159,12 @@
 			margin-top: 5px;
 		}
 
-		.masterbar__toggle-drafts.button.is-borderless {
-			margin-left: -20px;
-		}
-
 		// client/layout/masterbar/style.scss
 		.masterbar__item-bubble {
-			top: 9px;
-			left: 2px;
+			top: 50%;
+			left: 50%;
+			margin: 0;
+			transform: translate( -39px, -14px );
 		}
 
 		// client/layout/masterbar/style.scss
@@ -160,10 +174,6 @@
 			.masterbar__item-content {
 				display: block;
 			}
-			.gravatar {
-				top: 12px;
-				left: 20px;
-			}
 		}
 
 		// apps/notifications/style.scss
@@ -171,6 +181,19 @@
 			top: $nav-unification-masterbar-height-mobile;
 		}
 
+		// client/layout/masterbar/style.scss
+		.masterbar__item-notifications .masterbar__notifications-bubble {
+			top: 10px;
+		}
+
+	}
+
+	// client/layout/masterbar/style.scss
+	@include breakpoint-deprecated( '<480px' ) {
+		
+		.masterbar__item-bubble {
+			transform: translate( -14px, -14px );
+		}
 	}
 
 }

--- a/client/assets/stylesheets/_nav-unification.scss
+++ b/client/assets/stylesheets/_nav-unification.scss
@@ -32,9 +32,9 @@
 		height: $nav-unification-masterbar-height;
 		border-bottom: none;
 		font-size: $nav-unification-masterbar-font-size;
-		-webkit-box-shadow: inset 0 -1px 0 #333;
-		-moz-box-shadow: inset 0 -1px 0 #333;
-		box-shadow: inset 0 -1px 0 #333;
+		-webkit-box-shadow: inset 0 -1px 0 var( --color-masterbar-item-hover-background );
+		-moz-box-shadow: inset 0 -1px 0 var( --color-masterbar-item-hover-background );
+		box-shadow: inset 0 -1px 0 var( --color-masterbar-item-hover-background );
 	}
 
 	// client/layout/masterbar/style.scss

--- a/client/assets/stylesheets/_nav-unification.scss
+++ b/client/assets/stylesheets/_nav-unification.scss
@@ -1,3 +1,4 @@
+/* stylelint-disable selector-max-id */
 
 /**
  * Nav unification styles
@@ -11,14 +12,14 @@
 
 .is-nav-unification {
 	$nav-unification-primary: #23282d;
+	$nav-unification-secondary: #101517;
 	$nav-unification-masterbar-height: 32px;
 	$nav-unification-masterbar-font-size: 13px;
 
 	// packages/calypso-color-schemes/src/shared/color-schemes/_default.scss
-	--color-masterbar-background: #23282d;
-	--color-masterbar-border: #333;
+	--color-masterbar-background: #101517;
 	--color-masterbar-item-hover-background: #333;
-	--color-masterbar-item-active-background: #fff;
+	--color-masterbar-item-active-background: #23282d;
 	--color-masterbar-unread-dot-background: #f0821e;
 
 	// client/layout/style.scss
@@ -36,18 +37,15 @@
 	// client/layout/masterbar/style.scss
 	.masterbar__item {
 		height: $nav-unification-masterbar-height;
+		padding: 0 8px;
 		font-size: $nav-unification-masterbar-font-size;
 		line-height: $nav-unification-masterbar-height;
+	}
 
-		&.is-active {
-			.masterbar__item-content {
-				color: $nav-unification-primary;
-			}
-
-			.gridicon {
-				fill: $nav-unification-primary;
-			}
-		}
+	// client/layout/masterbar/style.scss
+	.masterbar__item-bubble {
+		top: 2px;
+		left: -7px;
 	}
 
 	// client/layout/masterbar/style.scss
@@ -60,6 +58,7 @@
 	}
 
 	.masterbar__item-new {
+		padding: 0 10px;
 
 		&:hover {
 			background: #e9e9ea;
@@ -71,11 +70,16 @@
 		}
 		.gridicon {
 			fill: $nav-unification-primary;
+			transform: translateX( 1px );
+
+			+ .masterbar__item-content {
+				padding: 0 1px 0 5px;
+			}
 		}
 	}
 
 	.masterbar__toggle-drafts.button.is-borderless {
-		margin-left: -26px;
+		margin-left: -23px;
 
 		&:hover {
 			background-color: #e9e9ea;
@@ -94,7 +98,7 @@
 		padding-left: 8px;
 		.gravatar {
 			top: 5px;
-			left: 9px;
+			left: 8px;
 		}
 	}
 
@@ -102,6 +106,15 @@
 	.masterbar__item-notifications {
 		padding-right: 5px;
 		padding-left: 5px;
+
+		.gridicon {
+			margin-top: 1px;
+		}
+	}
+
+	// apps/notifications/style.scss
+	#wpnc-panel {
+		top: $nav-unification-masterbar-height;
 	}
 
 }

--- a/client/assets/stylesheets/style.scss
+++ b/client/assets/stylesheets/style.scss
@@ -17,4 +17,4 @@
 
 // Styles for the nav unification prototype (see pbAPfg-O2)
 // TODO: depending on project outcome move or delete styles
-@import 'nav-unification';
+@import './_nav-unification';

--- a/client/assets/stylesheets/style.scss
+++ b/client/assets/stylesheets/style.scss
@@ -14,3 +14,7 @@
 @import 'main';
 
 @import './_p2-vars.scss';
+
+// Styles for the nav unification prototype (see pbAPfg-O2)
+// TODO: depending on project outcome move or delete styles
+@import 'nav-unification';

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -152,6 +152,7 @@ class Layout extends Component {
 					config.isEnabled( 'woocommerce/onboarding-oauth' ) &&
 					isWooOAuth2Client( this.props.oauth2Client ) &&
 					this.props.wccomFrom,
+				'is-nav-unification': config.isEnabled( 'nav-unification' ),
 			}
 		);
 

--- a/config/development.json
+++ b/config/development.json
@@ -138,7 +138,7 @@
 		"me/notifications": true,
 		"my-sites/checkout/web-payment/apple-pay": true,
 		"my-sites/checkout/web-payment/basic-card": false,
-		"nav-unification": true,
+		"nav-unification": false,
 		"nps-survey/devdocs": true,
 		"nps-survey/dev-trigger": true,
 		"network-connection": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is PR is a first step towards implementing the changes to the masterbar suggested in https://github.com/Automattic/wp-calypso/issues/45393.

#### Screenshots

Current PR state compared to wp-admin (in code-D49342):

![masterbar)](https://user-images.githubusercontent.com/1562646/92712922-a0e21a00-f35a-11ea-9de3-549443e41e8c.gif)



#### Notes

This is a prototype and it's hidden behind a feature flag. We'll continue iterating on it.

As the prototype uses an additional class for scoping some styles of other masterbar states like support session and jetpack will be overridden due to the increased specificity. This is expected for this prototype. 

When Calypso loads you'll see an initial flash of the app shell with the old nav styles. This is because we're using a feature flag to attach a class to the layout that gets processed once the client side JS kicks in. Once we move the styles to be the default, the app shell will look like the unified masterbar.



#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

This is behind a feature flag so we can iterate on it. Testing should mainly ensure something isn't fundamentally broken.
 
* Visit https://calypso.live/?branch=update/nav-unification-masterbar&flags=nav-unification
* Locally: `yarn && yarn start`, visit isit http://calypso.localhost:3000/, add `?flags=nav-unification` to the end of the URL to see changes
* Compare to wp-admin with code-D49342 applied
* Desktop viewports should look almost identical
* Mobile viewports will differ due to different navigation concepts (see https://github.com/Automattic/wp-calypso/issues/45393) 
