### PR TITLE
Gutenboarding: Handle Domain Suggestion APIs failures

### DIFF
--- a/packages/data-stores/src/domain-suggestions/actions.ts
+++ b/packages/data-stores/src/domain-suggestions/actions.ts
@@ -14,14 +14,9 @@ export const receiveCategories = ( categories: DomainCategory[] ) =>
 		categories,
 	} as const );
 
-export const receiveDomainSuggestions = (
-	queryObject: DomainSuggestionQuery,
-	suggestions: DomainSuggestion[] | undefined
-) =>
+export const fetchDomainSuggestions = () =>
 	( {
-		type: 'RECEIVE_DOMAIN_SUGGESTIONS',
-		queryObject,
-		suggestions,
+		type: 'FETCH_DOMAIN_SUGGESTIONS',
 	} as const );
 
 export const receiveDomainAvailability = ( domainName: string, availability: DomainAvailability ) =>
@@ -31,6 +26,27 @@ export const receiveDomainAvailability = ( domainName: string, availability: Dom
 		availability,
 	} as const );
 
+export const receiveDomainSuggestionsSuccess = (
+	queryObject: DomainSuggestionQuery,
+	suggestions: DomainSuggestion[] | undefined
+) =>
+	( {
+		type: 'RECEIVE_DOMAIN_SUGGESTIONS_SUCCESS',
+		queryObject,
+		suggestions,
+		timeStamp: Date.now(),
+	} as const );
+
+export const receiveDomainSuggestionsError = ( errorMessage: string ) =>
+	( {
+		type: 'RECEIVE_DOMAIN_SUGGESTIONS_ERROR',
+		errorMessage,
+	} as const );
+
 export type Action = ReturnType<
-	typeof receiveCategories | typeof receiveDomainSuggestions | typeof receiveDomainAvailability
+	| typeof receiveCategories
+	| typeof fetchDomainSuggestions
+	| typeof receiveDomainSuggestionsSuccess
+	| typeof receiveDomainSuggestionsError
+	| typeof receiveDomainAvailability
 >;

--- a/packages/data-stores/src/domain-suggestions/actions.ts
+++ b/packages/data-stores/src/domain-suggestions/actions.ts
@@ -17,6 +17,7 @@ export const receiveCategories = ( categories: DomainCategory[] ) =>
 export const fetchDomainSuggestions = () =>
 	( {
 		type: 'FETCH_DOMAIN_SUGGESTIONS',
+		timeStamp: Date.now(),
 	} as const );
 
 export const receiveDomainAvailability = ( domainName: string, availability: DomainAvailability ) =>
@@ -41,6 +42,7 @@ export const receiveDomainSuggestionsError = ( errorMessage: string ) =>
 	( {
 		type: 'RECEIVE_DOMAIN_SUGGESTIONS_ERROR',
 		errorMessage,
+		timeStamp: Date.now(),
 	} as const );
 
 export type Action = ReturnType<

--- a/packages/data-stores/src/domain-suggestions/constants.ts
+++ b/packages/data-stores/src/domain-suggestions/constants.ts
@@ -1,1 +1,8 @@
 export const STORE_KEY = 'automattic/domains/suggestions';
+
+export enum DataState {
+	Failure = 'failure',
+	Pending = 'pending',
+	Success = 'success',
+	Uninitialized = 'uninitialized',
+}

--- a/packages/data-stores/src/domain-suggestions/constants.ts
+++ b/packages/data-stores/src/domain-suggestions/constants.ts
@@ -1,6 +1,6 @@
 export const STORE_KEY = 'automattic/domains/suggestions';
 
-export enum DataState {
+export enum DataStatus {
 	Failure = 'failure',
 	Pending = 'pending',
 	Success = 'success',

--- a/packages/data-stores/src/domain-suggestions/reducer.ts
+++ b/packages/data-stores/src/domain-suggestions/reducer.ts
@@ -7,18 +7,10 @@ import { combineReducers } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import type { DomainSuggestion, DomainCategory, DomainAvailability, TimestampMS } from './types';
-import type { Action } from './actions';
+import type { DomainCategory, DomainAvailability, DomainSuggestionState } from './types';
 import { DataStatus } from './constants';
+import type { Action } from './actions';
 import { stringifyDomainQueryObject } from './utils';
-
-export interface DomainSuggestionState {
-	state: DataStatus;
-	data: Record< string, DomainSuggestion[] | undefined >;
-	errorMessage: string | null;
-	lastUpdated: TimestampMS;
-	pendingSince: TimestampMS | undefined;
-}
 
 const initialDomainSuggestionState: DomainSuggestionState = {
 	state: DataStatus.Uninitialized,
@@ -28,7 +20,7 @@ const initialDomainSuggestionState: DomainSuggestionState = {
 	pendingSince: undefined,
 };
 
-const domainSuggestions: Reducer< DomainSuggestionState, Action > = (
+export const domainSuggestions: Reducer< DomainSuggestionState, Action > = (
 	state = initialDomainSuggestionState,
 	action
 ) => {

--- a/packages/data-stores/src/domain-suggestions/reducer.ts
+++ b/packages/data-stores/src/domain-suggestions/reducer.ts
@@ -33,14 +33,12 @@ const domainSuggestions: Reducer< DomainSuggestionState, Action > = (
 	state = initialDomainSuggestionState,
 	action
 ) => {
-	const timeNow = Date.now();
-
 	if ( action.type === 'FETCH_DOMAIN_SUGGESTIONS' ) {
 		return {
 			...state,
 			state: DataStatus.Pending,
 			errorMessage: null,
-			pendingSince: timeNow,
+			pendingSince: action.timeStamp,
 		};
 	}
 
@@ -53,7 +51,7 @@ const domainSuggestions: Reducer< DomainSuggestionState, Action > = (
 				[ stringifyDomainQueryObject( action.queryObject ) ]: action.suggestions,
 			},
 			errorMessage: null,
-			lastUpdated: timeNow,
+			lastUpdated: action.timeStamp,
 			pendingSince: undefined,
 		};
 	}
@@ -63,7 +61,7 @@ const domainSuggestions: Reducer< DomainSuggestionState, Action > = (
 			...state,
 			state: DataStatus.Failure,
 			errorMessage: action.errorMessage,
-			lastUpdated: timeNow,
+			lastUpdated: action.timeStamp,
 			pendingSince: undefined,
 		};
 	}

--- a/packages/data-stores/src/domain-suggestions/reducer.ts
+++ b/packages/data-stores/src/domain-suggestions/reducer.ts
@@ -10,11 +10,11 @@ import type { TimestampMS } from 'wp-calypso-client/types';
  */
 import type { DomainSuggestion, DomainCategory, DomainAvailability } from './types';
 import type { Action } from './actions';
-import { DataState } from './constants';
+import { DataStatus } from './constants';
 import { stringifyDomainQueryObject } from './utils';
 
 export interface DomainSuggestionState {
-	state: DataState;
+	state: DataStatus;
 	data: Record< string, DomainSuggestion[] | undefined >;
 	errorMessage: string | null;
 	lastUpdated: TimestampMS;
@@ -22,7 +22,7 @@ export interface DomainSuggestionState {
 }
 
 const initialDomainSuggestionState: DomainSuggestionState = {
-	state: DataState.Uninitialized,
+	state: DataStatus.Uninitialized,
 	data: {},
 	errorMessage: null,
 	lastUpdated: -Infinity,
@@ -38,7 +38,7 @@ const domainSuggestions: Reducer< DomainSuggestionState, Action > = (
 	if ( action.type === 'FETCH_DOMAIN_SUGGESTIONS' ) {
 		return {
 			...state,
-			state: DataState.Pending,
+			state: DataStatus.Pending,
 			errorMessage: null,
 			pendingSince: timeNow,
 		};
@@ -47,7 +47,7 @@ const domainSuggestions: Reducer< DomainSuggestionState, Action > = (
 	if ( action.type === 'RECEIVE_DOMAIN_SUGGESTIONS_DATA' ) {
 		return {
 			...state,
-			state: DataState.Success,
+			state: DataStatus.Success,
 			data: {
 				...state.data,
 				[ stringifyDomainQueryObject( action.queryObject ) ]: action.suggestions,
@@ -61,7 +61,7 @@ const domainSuggestions: Reducer< DomainSuggestionState, Action > = (
 	if ( action.type === 'RECEIVE_DOMAIN_SUGGESTIONS_ERROR' ) {
 		return {
 			...state,
-			state: DataState.Failure,
+			state: DataStatus.Failure,
 			errorMessage: action.errorMessage,
 			lastUpdated: timeNow,
 			pendingSince: undefined,

--- a/packages/data-stores/src/domain-suggestions/reducer.ts
+++ b/packages/data-stores/src/domain-suggestions/reducer.ts
@@ -3,12 +3,11 @@
  */
 import type { Reducer } from 'redux';
 import { combineReducers } from '@wordpress/data';
-import type { TimestampMS } from 'wp-calypso-client/types';
 
 /**
  * Internal dependencies
  */
-import type { DomainSuggestion, DomainCategory, DomainAvailability } from './types';
+import type { DomainSuggestion, DomainCategory, DomainAvailability, TimestampMS } from './types';
 import type { Action } from './actions';
 import { DataStatus } from './constants';
 import { stringifyDomainQueryObject } from './utils';

--- a/packages/data-stores/src/domain-suggestions/reducer.ts
+++ b/packages/data-stores/src/domain-suggestions/reducer.ts
@@ -42,7 +42,7 @@ const domainSuggestions: Reducer< DomainSuggestionState, Action > = (
 		};
 	}
 
-	if ( action.type === 'RECEIVE_DOMAIN_SUGGESTIONS_DATA' ) {
+	if ( action.type === 'RECEIVE_DOMAIN_SUGGESTIONS_SUCCESS' ) {
 		return {
 			...state,
 			state: DataStatus.Success,

--- a/packages/data-stores/src/domain-suggestions/resolvers.ts
+++ b/packages/data-stores/src/domain-suggestions/resolvers.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { stringify } from 'qs';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -66,12 +67,16 @@ export function* __internalGetDomainSuggestions(
 		} );
 	} catch ( e ) {
 		// e.g. no connection, or JSON parsing error
-		return receiveDomainSuggestionsError( e.message || 'Error while fetching server response' );
+		return receiveDomainSuggestionsError(
+			e.message || ( translate( 'Error while fetching server response' ) as string )
+		);
 	}
 
 	if ( ! suggestions || suggestions === '' ) {
 		// Other internal server errors
-		return receiveDomainSuggestionsError( 'Invalid response from the server' );
+		return receiveDomainSuggestionsError(
+			translate( 'Invalid response from the server' ) as string
+		);
 	}
 
 	return receiveDomainSuggestionsSuccess( queryObject, suggestions );

--- a/packages/data-stores/src/domain-suggestions/resolvers.ts
+++ b/packages/data-stores/src/domain-suggestions/resolvers.ts
@@ -49,11 +49,25 @@ export function* __internalGetDomainSuggestions(
 		return receiveDomainSuggestions( queryObject, [] );
 	}
 
-	const suggestions = yield wpcomRequest( {
-		apiVersion: '1.1',
-		path: '/domains/suggestions',
-		query: stringify( queryObject ),
-	} );
+	let suggestions;
+	try {
+		// wpcomRequest should return a list of suggested domains
+		suggestions = yield wpcomRequest( {
+			apiVersion: '1.1',
+			path: '/domains/suggestions',
+			query: stringify( queryObject ),
+		} );
+	} catch ( e ) {
+		// Network request failed (e.g. no connection)
+		// console.log( `Error while requesting suggested domains ${ e }` );
+		// TODO: commaunicate the error to the UI
+	}
+
+	if ( suggestions === '' ) {
+		// APIs failed (e.g. JSON response was malformed, internal errors)
+		// (see https://github.com/Automattic/wp-calypso/issues/43503)
+		// TODO: commaunicate the error to the UI
+	}
 
 	return receiveDomainSuggestions( queryObject, suggestions );
 }

--- a/packages/data-stores/src/domain-suggestions/resolvers.ts
+++ b/packages/data-stores/src/domain-suggestions/resolvers.ts
@@ -66,12 +66,12 @@ export function* __internalGetDomainSuggestions(
 		} );
 	} catch ( e ) {
 		// e.g. no connection, or JSON parsing error
-		return receiveDomainSuggestionsError( e.message );
+		return receiveDomainSuggestionsError( `Error while fetching server response, ${ e.message }` );
 	}
 
 	if ( ! suggestions || suggestions === '' ) {
-		// Other internal errors
-		return receiveDomainSuggestionsError( 'Invalid response' );
+		// Other internal server errors
+		return receiveDomainSuggestionsError( 'Invalid response from the server' );
 	}
 
 	return receiveDomainSuggestionsSuccess( queryObject, suggestions );

--- a/packages/data-stores/src/domain-suggestions/resolvers.ts
+++ b/packages/data-stores/src/domain-suggestions/resolvers.ts
@@ -66,7 +66,7 @@ export function* __internalGetDomainSuggestions(
 		} );
 	} catch ( e ) {
 		// e.g. no connection, or JSON parsing error
-		return receiveDomainSuggestionsError( `Error while fetching server response, ${ e.message }` );
+		return receiveDomainSuggestionsError( e.message || 'Error while fetching server response' );
 	}
 
 	if ( ! suggestions || suggestions === '' ) {

--- a/packages/data-stores/src/domain-suggestions/selectors.ts
+++ b/packages/data-stores/src/domain-suggestions/selectors.ts
@@ -6,7 +6,7 @@ import { select } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { STORE_KEY } from './constants';
+import { STORE_KEY, DataState } from './constants';
 import type { DomainSuggestionQuery } from './types';
 import type { State } from './reducer';
 import { stringifyDomainQueryObject } from './utils';
@@ -41,6 +41,16 @@ const createSelectors = ( vendor: string ) => {
 		return select( STORE_KEY ).__internalGetDomainSuggestions( normalizedQuery );
 	}
 
+	function getDomainState( state: State ): DataState {
+		return state.domainSuggestions.state;
+	}
+
+	function getDomainErrorMessage( state: State ): string | null {
+		return state.domainSuggestions.errorMessage;
+	}
+
+	// TODO: reconcile this function with "Pending" status?
+	// It doesn't seem to be used
 	function isLoadingDomainSuggestions(
 		_state: State,
 		search: string,
@@ -94,7 +104,7 @@ const createSelectors = ( vendor: string ) => {
 	 * @returns suggestions
 	 */
 	function __internalGetDomainSuggestions( state: State, queryObject: DomainSuggestionQuery ) {
-		return state.domainSuggestions[ stringifyDomainQueryObject( queryObject ) ];
+		return state.domainSuggestions.data[ stringifyDomainQueryObject( queryObject ) ];
 	}
 
 	function isAvailable( state: State, domainName: string ) {
@@ -108,6 +118,8 @@ const createSelectors = ( vendor: string ) => {
 	return {
 		getCategories,
 		getDomainSuggestions,
+		getDomainState,
+		getDomainErrorMessage,
 		getDomainSuggestionVendor,
 		isLoadingDomainSuggestions,
 		__internalGetDomainSuggestions,

--- a/packages/data-stores/src/domain-suggestions/selectors.ts
+++ b/packages/data-stores/src/domain-suggestions/selectors.ts
@@ -6,7 +6,7 @@ import { select } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { STORE_KEY, DataState } from './constants';
+import { STORE_KEY, DataStatus } from './constants';
 import type { DomainSuggestionQuery } from './types';
 import type { State } from './reducer';
 import { stringifyDomainQueryObject } from './utils';
@@ -41,7 +41,7 @@ const createSelectors = ( vendor: string ) => {
 		return select( STORE_KEY ).__internalGetDomainSuggestions( normalizedQuery );
 	}
 
-	function getDomainState( state: State ): DataState {
+	function getDomainState( state: State ): DataStatus {
 		return state.domainSuggestions.state;
 	}
 

--- a/packages/data-stores/src/domain-suggestions/test/reducer.ts
+++ b/packages/data-stores/src/domain-suggestions/test/reducer.ts
@@ -1,0 +1,105 @@
+/**
+ * Internal dependencies
+ */
+
+import { domainSuggestions } from '../reducer';
+import type { DomainSuggestionState, DomainSuggestion } from '../types';
+import { DataStatus } from '../constants';
+
+describe( 'domainSuggestions', () => {
+	const initialTimeStamp = Date.now();
+	const initialState: DomainSuggestionState = {
+		state: DataStatus.Uninitialized,
+		data: undefined,
+		errorMessage: null,
+		lastUpdated: initialTimeStamp,
+		pendingSince: undefined,
+	};
+
+	it( 'goes into a state of pending when fetching results', () => {
+		const now = Date.now();
+		const state = domainSuggestions( initialState, {
+			type: 'FETCH_DOMAIN_SUGGESTIONS',
+			timeStamp: now,
+		} );
+
+		const expectedState: DomainSuggestionState = {
+			state: DataStatus.Pending,
+			data: undefined,
+			errorMessage: null,
+			lastUpdated: initialTimeStamp,
+			pendingSince: now,
+		};
+		expect( state ).toEqual( expectedState );
+	} );
+
+	it( 'goes into a state of errored when fetching results have failed', () => {
+		const now = Date.now();
+		const errorMessage = 'An unexpected error has occured';
+		const state = domainSuggestions( initialState, {
+			type: 'RECEIVE_DOMAIN_SUGGESTIONS_ERROR',
+			timeStamp: now,
+			errorMessage,
+		} );
+
+		const expectedState: DomainSuggestionState = {
+			state: DataStatus.Failure,
+			data: undefined,
+			errorMessage: errorMessage,
+			lastUpdated: now,
+			pendingSince: undefined,
+		};
+		expect( state ).toEqual( expectedState );
+	} );
+
+	it( 'goes into a state of success when fetching results have returned results', () => {
+		const queryObject = {
+			include_dotblogsubdomain: false,
+			include_wordpressdotcom: true,
+			locale: 'en',
+			only_wordpressdotcom: false,
+			quantity: 11,
+			query: 'test site',
+			vendor: 'variation4_front',
+		};
+		const suggestions: DomainSuggestion[] = [
+			{
+				domain_name: 'test.site',
+				relevance: 1,
+				supports_privacy: true,
+				vendor: 'donuts',
+				match_reasons: [ 'tld-common', 'tld-exact' ],
+				product_id: 78,
+				product_slug: 'dotsite_domain',
+				cost: '$25.00',
+			},
+			{
+				domain_name: 'hot-test-site.com',
+				relevance: 1,
+				supports_privacy: true,
+				vendor: 'donuts',
+				match_reasons: [ 'tld-common' ],
+				product_id: 6,
+				product_slug: 'domain_reg',
+				cost: '$18.00',
+			},
+		];
+		const now = Date.now();
+		const state = domainSuggestions( initialState, {
+			type: 'RECEIVE_DOMAIN_SUGGESTIONS_SUCCESS',
+			queryObject,
+			suggestions,
+			timeStamp: now,
+		} );
+
+		const expectedState: DomainSuggestionState = {
+			state: DataStatus.Success,
+			data: { [ JSON.stringify( queryObject ) ]: suggestions },
+			errorMessage: null,
+			lastUpdated: now,
+			pendingSince: undefined,
+		};
+		expect( state ).toEqual( expectedState );
+		expect( state.data[ JSON.stringify( queryObject ) ].length ).toEqual( suggestions.length );
+	} );
+} );

--- a/packages/data-stores/src/domain-suggestions/test/selectors.ts
+++ b/packages/data-stores/src/domain-suggestions/test/selectors.ts
@@ -1,0 +1,132 @@
+/**
+ * External dependencies
+ */
+import { select, subscribe } from '@wordpress/data';
+import wpcomRequest from 'wpcom-proxy-request';
+
+/**
+ * Internal dependencies
+ */
+import { register } from '..';
+import { DataStatus } from '../constants';
+
+jest.mock( 'wpcom-proxy-request', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+	requestAllBlogsAccess: jest.fn( () => Promise.resolve() ),
+} ) );
+
+let store: ReturnType< typeof register >;
+
+const options = {
+	category_slug: undefined,
+	include_dotblogsubdomain: false,
+	include_wordpressdotcom: true,
+	locale: 'en',
+	quantity: 11,
+};
+const apiResponse = [
+	{
+		domain_name: 'test.site',
+		relevance: 1,
+		supports_privacy: true,
+		vendor: 'donuts',
+		match_reasons: [ 'tld-common', 'tld-exact' ],
+		product_id: 78,
+		product_slug: 'dotsite_domain',
+		cost: '$25.00',
+	},
+	{
+		domain_name: 'hot-test-site.com',
+		relevance: 1,
+		supports_privacy: true,
+		vendor: 'donuts',
+		match_reasons: [ 'tld-common' ],
+		product_id: 6,
+		product_slug: 'domain_reg',
+		cost: '$18.00',
+	},
+];
+
+beforeAll( () => {
+	store = register( { vendor: 'variation2_front' } );
+} );
+
+beforeEach( () => {
+	( wpcomRequest as jest.Mock ).mockReset();
+} );
+
+describe( 'getDomainSuggestions', () => {
+	it( 'resolves the state via an API call and caches the resolver on success', async () => {
+		( wpcomRequest as jest.Mock ).mockResolvedValue( apiResponse );
+
+		const query = 'test query one';
+		const listenForStateUpdate = () => {
+			return new Promise( ( resolve ) => {
+				const unsubscribe = subscribe( () => {
+					unsubscribe();
+					resolve();
+				} );
+			} );
+		};
+
+		// Status should be uninitialized before first call
+		expect( select( store ).getDomainState() ).toEqual( DataStatus.Uninitialized );
+
+		// First call returns undefined
+		expect( select( store ).getDomainSuggestions( query, options ) ).toEqual( undefined );
+
+		// Status should be pending while we wait for the response
+		expect( select( store ).getDomainState() ).toEqual( DataStatus.Pending );
+
+		await listenForStateUpdate();
+
+		// Status should be successful once we get the response
+		expect( select( store ).getDomainState() ).toEqual( DataStatus.Success );
+
+		// By the second call, the resolver will have resolved
+		expect( select( store ).getDomainSuggestions( query, options ) ).toEqual( apiResponse );
+
+		await listenForStateUpdate();
+
+		// The resolver should now be cached with an `isStarting` value of false
+
+		expect(
+			select( 'core/data' ).isResolving( store, 'getDomainSuggestions', [ query, options ] )
+		).toStrictEqual( false );
+	} );
+} );
+
+describe( 'getDomainErrorMessage', () => {
+	it( 'should return null if no error message', () => {
+		expect( select( store ).getDomainErrorMessage() ).toEqual( null );
+	} );
+
+	it( 'should return correct error message if no suggestions are returned', async () => {
+		( wpcomRequest as jest.Mock ).mockResolvedValue( null );
+
+		const query = 'test query two';
+		const listenForStateUpdate = () => {
+			return new Promise( ( resolve ) => {
+				const unsubscribe = subscribe( () => {
+					unsubscribe();
+					resolve();
+				} );
+			} );
+		};
+
+		// The error message should start off as a null value
+		expect( select( store ).getDomainErrorMessage() ).toBeFalsy();
+
+		// First call returns undefined
+		select( store ).getDomainSuggestions( query, options );
+		await listenForStateUpdate();
+
+		// By the second call, the resolver will have resolved
+		select( store ).getDomainSuggestions( query, options );
+		await listenForStateUpdate();
+
+		// The promise resolves null suggestions so we should now have an error message
+		expect( select( store ).getDomainErrorMessage() ).toBeTruthy();
+	} );
+} );

--- a/packages/data-stores/src/domain-suggestions/types.ts
+++ b/packages/data-stores/src/domain-suggestions/types.ts
@@ -1,3 +1,6 @@
+/**
+ * Internal dependencies
+ */
 import type { DataStatus } from './constants';
 
 export interface DomainSuggestionQuery {

--- a/packages/data-stores/src/domain-suggestions/types.ts
+++ b/packages/data-stores/src/domain-suggestions/types.ts
@@ -183,3 +183,5 @@ export interface DomainAvailability {
 	 */
 	vendor?: string;
 }
+
+export type TimestampMS = ReturnType< typeof Date.now >;

--- a/packages/data-stores/src/domain-suggestions/types.ts
+++ b/packages/data-stores/src/domain-suggestions/types.ts
@@ -1,3 +1,5 @@
+import type { DataStatus } from './constants';
+
 export interface DomainSuggestionQuery {
 	/**
 	 * True to include .blog subdomain suggestions
@@ -185,3 +187,30 @@ export interface DomainAvailability {
 }
 
 export type TimestampMS = ReturnType< typeof Date.now >;
+
+export interface DomainSuggestionState {
+	/**
+	 * The state of the DomainSuggestions e.g. pending, failure etc
+	 */
+	state: DataStatus;
+
+	/**
+	 * Domain suggestion data typically returned from the API
+	 */
+	data: Record< string, DomainSuggestion[] | undefined >;
+
+	/**
+	 * Error message
+	 */
+	errorMessage: string | null;
+
+	/**
+	 * Timestamp from last updated attempt
+	 */
+	lastUpdated: TimestampMS;
+
+	/**
+	 * Pending timestamp
+	 */
+	pendingSince: TimestampMS | undefined;
+}

--- a/packages/domain-picker/src/domain-picker/index.tsx
+++ b/packages/domain-picker/src/domain-picker/index.tsx
@@ -205,6 +205,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 					onChange={ handleInputChange }
 					onBlur={ onDomainSearchBlurValue }
 					value={ domainSearch }
+					disabled={ showErrorMessage }
 				/>
 			</div>
 			{ showErrorMessage && (

--- a/packages/domain-picker/src/domain-picker/index.tsx
+++ b/packages/domain-picker/src/domain-picker/index.tsx
@@ -213,9 +213,13 @@ const DomainPicker: FunctionComponent< Props > = ( {
 					<p className="domain-picker__error-message">
 						<span>{ __( 'An error has occurred, please check your connection and retry' ) }</span>
 					</p>
-					<button className="domain-picker__error-retry" onClick={ retryDomainSuggestionRequest }>
+					<Button
+						isPrimary
+						className="domain-picker__error-retry-btn"
+						onClick={ retryDomainSuggestionRequest }
+					>
 						Retry
-					</button>
+					</Button>
 				</div>
 			) }
 			{ showDomainSuggestionsResults && (

--- a/packages/domain-picker/src/domain-picker/index.tsx
+++ b/packages/domain-picker/src/domain-picker/index.tsx
@@ -185,7 +185,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 	};
 
 	const showErrorMessage = domainSuggestionState === DataState.Failure;
-	const isDomainSearchEmpty = domainSearch.trim()?.length <= 1;
+	const isDomainSearchEmpty = domainSearch.trim?.().length <= 1;
 	const showDomainSuggestionsResults = ! showErrorMessage && ! isDomainSearchEmpty;
 	const showDomainSuggestionsEmpty = ! showErrorMessage && isDomainSearchEmpty;
 

--- a/packages/domain-picker/src/domain-picker/index.tsx
+++ b/packages/domain-picker/src/domain-picker/index.tsx
@@ -211,7 +211,8 @@ const DomainPicker: FunctionComponent< Props > = ( {
 			{ showErrorMessage && (
 				<div className="domain-picker__error">
 					<p className="domain-picker__error-message">
-						<span>{ __( 'An error has occurred, please check your connection and retry' ) }</span>
+						{ __( 'An error has occurred, please check your connection and retry.' ) }
+						{ domainSuggestionErrorMessage && ` ${ domainSuggestionErrorMessage }` }
 					</p>
 					<Button
 						isPrimary

--- a/packages/domain-picker/src/domain-picker/index.tsx
+++ b/packages/domain-picker/src/domain-picker/index.tsx
@@ -211,8 +211,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 			{ showErrorMessage && (
 				<div className="domain-picker__error">
 					<p className="domain-picker__error-message">
-						<span>{ __( 'An error has occurred ' ) }</span>
-						<small>{ domainSuggestionErrorMessage }</small>
+						<span>{ __( 'An error has occurred, please check your connection and retry' ) }</span>
 					</p>
 					<button className="domain-picker__error-retry" onClick={ retryDomainSuggestionRequest }>
 						Retry

--- a/packages/domain-picker/src/domain-picker/index.tsx
+++ b/packages/domain-picker/src/domain-picker/index.tsx
@@ -9,7 +9,7 @@ import { Icon, search } from '@wordpress/icons';
 import { getNewRailcarId, recordTrainTracksRender } from '@automattic/calypso-analytics';
 import { useI18n } from '@automattic/react-i18n';
 import type { DomainSuggestions } from '@automattic/data-stores';
-import { DataState } from '@automattic/data-stores/src/domain-suggestions/constants';
+import { DataStatus } from '@automattic/data-stores/src/domain-suggestions/constants';
 
 /**
  * Internal dependencies
@@ -184,7 +184,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 		onSetDomainSearch( searchQuery );
 	};
 
-	const showErrorMessage = domainSuggestionState === DataState.Failure;
+	const showErrorMessage = domainSuggestionState === DataStatus.Failure;
 	const isDomainSearchEmpty = domainSearch.trim?.().length <= 1;
 	const showDomainSuggestionsResults = ! showErrorMessage && ! isDomainSearchEmpty;
 	const showDomainSuggestionsEmpty = ! showErrorMessage && isDomainSearchEmpty;

--- a/packages/domain-picker/src/domain-picker/index.tsx
+++ b/packages/domain-picker/src/domain-picker/index.tsx
@@ -205,7 +205,6 @@ const DomainPicker: FunctionComponent< Props > = ( {
 					onChange={ handleInputChange }
 					onBlur={ onDomainSearchBlurValue }
 					value={ domainSearch }
-					disabled={ showErrorMessage }
 				/>
 			</div>
 			{ showErrorMessage && (

--- a/packages/domain-picker/src/domain-picker/style.scss
+++ b/packages/domain-picker/src/domain-picker/style.scss
@@ -314,3 +314,15 @@
 	font-size: $font-body-extra-small;
 	color: var( --studio-gray-40 );
 }
+
+.domain-picker__error {
+	margin-top: 24px;
+
+	#{&}-message {
+		@include onboarding-medium-text;
+	}
+
+	#{&}-retry-btn {
+		margin-top: 16px;
+	}
+}

--- a/packages/domain-picker/src/hooks/use-domain-suggestions.ts
+++ b/packages/domain-picker/src/hooks/use-domain-suggestions.ts
@@ -11,7 +11,7 @@ import { useDebounce } from 'use-debounce';
  */
 import { DOMAIN_SUGGESTIONS_STORE, DOMAIN_SEARCH_DEBOUNCE_INTERVAL } from '../constants';
 
-type ReturnType = {
+type DomainSuggestionsResult = {
 	allDomainSuggestions: DomainSuggestion[] | undefined;
 	errorMessage: string | null;
 	state: DataStatus;
@@ -23,7 +23,7 @@ export function useDomainSuggestions(
 	quantity: number,
 	domainCategory?: string,
 	locale = 'en'
-): ReturnType | undefined {
+): DomainSuggestionsResult | undefined {
 	const [ domainSearch ] = useDebounce( searchTerm, DOMAIN_SEARCH_DEBOUNCE_INTERVAL );
 
 	// eslint-disable-next-line @typescript-eslint/ban-ts-ignore

--- a/packages/domain-picker/src/hooks/use-domain-suggestions.ts
+++ b/packages/domain-picker/src/hooks/use-domain-suggestions.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { useSelect, useDispatch } from '@wordpress/data';
-import type { DataState } from '@automattic/data-stores/src/domain-suggestions/constants';
+import type { DataStatus } from '@automattic/data-stores/src/domain-suggestions/constants';
 import type { DomainSuggestion } from '@automattic/data-stores/src/domain-suggestions/types';
 import { useDebounce } from 'use-debounce';
 
@@ -14,7 +14,7 @@ import { DOMAIN_SUGGESTIONS_STORE, DOMAIN_SEARCH_DEBOUNCE_INTERVAL } from '../co
 type ReturnType = {
 	allDomainSuggestions: DomainSuggestion[] | undefined;
 	errorMessage: string | null;
-	state: DataState;
+	state: DataStatus;
 	retryRequest: () => void;
 };
 

--- a/packages/domain-picker/src/hooks/use-domain-suggestions.ts
+++ b/packages/domain-picker/src/hooks/use-domain-suggestions.ts
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
+import type { DataState } from '@automattic/data-stores/src/domain-suggestions/constants';
+import type { DomainSuggestion } from '@automattic/data-stores/src/domain-suggestions/types';
 import { useDebounce } from 'use-debounce';
 
 /**
@@ -9,20 +11,41 @@ import { useDebounce } from 'use-debounce';
  */
 import { DOMAIN_SUGGESTIONS_STORE, DOMAIN_SEARCH_DEBOUNCE_INTERVAL } from '../constants';
 
+type ReturnType = {
+	allDomainSuggestions: DomainSuggestion[] | undefined;
+	errorMessage: string | null;
+	state: DataState;
+	retryRequest: () => void;
+};
+
 export function useDomainSuggestions(
 	searchTerm = '',
 	quantity: number,
 	domainCategory?: string,
 	locale = 'en'
-) {
+): ReturnType | undefined {
 	const [ domainSearch ] = useDebounce( searchTerm, DOMAIN_SEARCH_DEBOUNCE_INTERVAL );
+
+	// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+	// @ts-ignore
+	// Missing types for invalidateResolutionForStoreSelector
+	// (https://github.com/WordPress/gutenberg/blob/master/packages/data/src/namespace-store/metadata/actions.js#L57)
+	const { invalidateResolutionForStoreSelector } = useDispatch( DOMAIN_SUGGESTIONS_STORE );
 
 	return useSelect(
 		( select ) => {
 			if ( ! domainSearch || domainSearch.length < 2 ) {
 				return;
 			}
-			return select( DOMAIN_SUGGESTIONS_STORE ).getDomainSuggestions( domainSearch, {
+			const { getDomainSuggestions, getDomainState, getDomainErrorMessage } = select(
+				DOMAIN_SUGGESTIONS_STORE
+			);
+
+			const retryRequest = (): void => {
+				invalidateResolutionForStoreSelector( '__internalGetDomainSuggestions' );
+			};
+
+			const allDomainSuggestions = getDomainSuggestions( domainSearch, {
 				// Avoid `only_wordpressdotcom` — it seems to fail to find results sometimes
 				include_wordpressdotcom: true,
 				include_dotblogsubdomain: false,
@@ -30,6 +53,12 @@ export function useDomainSuggestions(
 				locale,
 				category_slug: domainCategory,
 			} );
+
+			const state = getDomainState();
+
+			const errorMessage = getDomainErrorMessage();
+
+			return { allDomainSuggestions, state, errorMessage, retryRequest };
 		},
 		[ domainSearch, domainCategory, quantity ]
 	);

--- a/packages/domain-picker/src/hooks/use-domain-suggestions.ts
+++ b/packages/domain-picker/src/hooks/use-domain-suggestions.ts
@@ -29,7 +29,7 @@ export function useDomainSuggestions(
 	// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
 	// @ts-ignore
 	// Missing types for invalidateResolutionForStoreSelector
-	// (https://github.com/WordPress/gutenberg/blob/master/packages/data/src/namespace-store/metadata/actions.js#L57)
+	// (see packages/data/src/namespace-store/metadata/actions.js#L57)
 	const { invalidateResolutionForStoreSelector } = useDispatch( DOMAIN_SUGGESTIONS_STORE );
 
 	return useSelect(


### PR DESCRIPTION
### Changes proposed in this Pull Request

- Refactor the `@wordpress/data` store in `packages/data-stores/src/domain-suggestions` so that it handles (in the store's state) the different errors that can happen while calling the Domain Suggestion APIs:
  - network failure
  - malformed JSON response from the APIs
  - JSON response containing an error message (eg. when the query contains non-latin characters)
  - empty string response (which is also a sign of a server error)

- Show an error message to the user, together with a "Retry" button which re-triggers the call to the APIs
  - I applied a minor refactor to the logic behind showing different parts of the UI (e.g. show error message vs show domain suggestion results)
  - I also refactored the return value `useDomainSuggestion()` hook — it now returns an object with all the variables and functions needed by the UI
  - The API call is re-triggered by invalidating the cached results of the store resolver
  - While the error message is displayed, the text field for the domain query is disabled — this is to avoid that the user can trigger a new Domain Suggestion search during an error state.
  - _Please note that I didn't follow any design spec for this part of the layout_.

- The shape of the store's state is heavily inspired by the [http-data module](https://github.com/Automattic/wp-calypso/blob/master/client/state/data-layer/http-data.ts#L17-L41)

### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#### First scenario: network failure
1.  Go to http://calypso.localhost:3000/new and enter a site name
2. Wait for the domain suggestion to load successfully
3. Open the dev tools, go to the Network tab, and simulate "Offline" network conditions
4. Type in the text field to trigger a new domain suggestion query
5. Notice how an error message is shown
6. Open the dev tools, go to the Network tab switch back to "Online" network conditions
7. Click on the "Retry" button
8. The Domain Suggestion loads successfully

#### Second scenario: non-latin characters
1.  Go to http://calypso.localhost:3000/new and enter a site name
2. Wait for the domain suggestion to load successfully
3. Type some non-latin characters in the text field to trigger a new domain suggestion query
4. Notice how an error message is shown
5. Type a new query using latin characters
6. The Domain Suggestion loads successfully

#### Third scenario: malformed server response

1. With a fresh & up-to-date version of the sandbox, edit the `~/public-html/public.api/rest/wpcom-json-endpoints/class.wpcom-store-domains-api-endpoints.php` file, and add this code as the first line of the `callback` function: `if ( A8C_PROXIED_REQUEST ) { var_dump('test'); exit(); }`
2. Change your hosts file and add a rule to redirect `public-api.wordpress.com` to your sandbox
3. Clear DNS and hosts cache
4.  Go to http://calypso.localhost:3000/new and enter a site name
5. Notice how an error message is shown (you can check that the response received from the Domain Suggestion APIs contains indeed the "test" string from the sandbox)
6. Disable the hosts rule mapping the APIs to the sandbox and clear DNS and hosts cache
7. Type a new query in the text field to trigger a new Domain Suggestion query
8. The Domain Suggestion loads successfully


### Before

(Notice how the UI just hangs on the user without any visible error message)

<img width="1792" alt="Screenshot 2020-09-08 at 17 13 23" src="https://user-images.githubusercontent.com/1083581/92495147-d968e300-f1f6-11ea-9ac4-193dc61aaa82.png">


### After

(error message + "Retry" button are shown)

<img width="1792" alt="Screenshot 2020-09-08 at 17 13 51" src="https://user-images.githubusercontent.com/1083581/92495177-e4bc0e80-f1f6-11ea-9c30-c11e2eb30d0d.png">


Fixes #43503

Partially related to #44421, although that issue seems to be more related to domain availability checking. But it would be good if the code was already structured to allow for the changes required by that issue.

---

### Questions / notes:

- Specifically, regarding types, it seems that [`invalidateResolutionForStoreSelector`](https://github.com/WordPress/gutenberg/blob/master/packages/data/src/namespace-store/metadata/actions.js#L57) is not typed as an action returned by `useDispatch` — for now I just ignored the TypeScript warning, but that needs to be addressed
- Error messages: especially in the light of future work (see #44421), should we structure error messages in a different way? How would we handle i18n for the error messages?