### PR TITLE
Checkout: Add the action data to `calypso_checkout_composite_error`

### DIFF
--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -402,6 +402,13 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 			// kind of data. It should make no assumptions about the data it uses.
 			// There's no fallback for the fallback!
 			debug( 'checkout event error', err.message );
+			reduxDispatch(
+				recordTracksEvent( 'calypso_checkout_composite_error', {
+					error_message: err.message,
+					type: String( action?.type ),
+					payload: String( action?.payload ),
+				} )
+			);
 			return reduxDispatch(
 				logStashLoadErrorEventAction( 'calypso_checkout_composite_error', err.message, {
 					type: String( action?.type ),

--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -396,9 +396,17 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 					);
 			}
 		} catch ( err ) {
+			// This is a fallback to catch any errors caused by the analytics code
+			// (particularly for the error reporting analytics code). Anything in
+			// this block should remain very simple and extremely tolerant of any
+			// kind of data. It should make no assumptions about the data it uses.
+			// There's no fallback for the fallback!
 			debug( 'checkout event error', err.message );
 			return reduxDispatch(
-				logStashLoadErrorEventAction( 'calypso_checkout_composite_error', err.message )
+				logStashLoadErrorEventAction( 'calypso_checkout_composite_error', err.message, {
+					type: String( action?.type ),
+					payload: String( action?.payload ),
+				} )
 			);
 		}
 	};


### PR DESCRIPTION
The `calypso_checkout_composite_error` Tracks event (added by https://github.com/Automattic/wp-calypso/pull/45241) is triggered when there is an unexpected error while trying to record an event (possibly an error report itself). However, the error reporting in that fallback event is very basic and doesn't necessarily let us find out what caused the issue.

This change adds additional data about the action being processed and also logs the error to Tracks, which collects additional data on its own.

#### Testing instructions

- Cause an error by following the [instructions here](https://github.com/Automattic/wp-calypso/pull/45241#pullrequestreview-478956393).
- Verify that the error is reported with the action `type` and `payload` (the payload is likely to be unreadable but that's expected; it's hard to know how to coerce unknown data to a string but it might sometimes be useful). You can do this as follows.

For the Logstash event, examine your browser's devtools network tab and look for a call to the https://public-api.wordpress.com/rest/v1.1/logstash endpoint.

For the Tracks event, before the test, run `localStorage.setItem('debug', 'calypso:analytics')` in your browser console and reload the page. After you trigger the error, look for this in your console: `calypso:analytics Recording event "calypso_checkout_composite_error" with actual props`.