### PR TITLE
Search: Fix border radii on search inputs

### DIFF
--- a/client/components/search/style.scss
+++ b/client/components/search/style.scss
@@ -24,7 +24,6 @@
 		display: flex;
 		align-items: center;
 		background-color: var( --color-surface );
-		border-radius: 0;
 		height: 100%;
 
 		.accessible-focus &:focus {
@@ -159,7 +158,7 @@
 	}
 
 	.search__input-fade {
-		border-radius: inherit;
+		border-radius: 0;
 		flex: 1 1 auto;
 		height: 100%;
 		position: relative;

--- a/client/components/search/style.scss
+++ b/client/components/search/style.scss
@@ -24,7 +24,7 @@
 		display: flex;
 		align-items: center;
 		background-color: var( --color-surface );
-		border-radius: inherit;
+		border-radius: 0;
 		height: 100%;
 
 		.accessible-focus &:focus {
@@ -113,7 +113,7 @@
 	height: 100%;
 	background: var( --color-surface );
 	appearance: none;
-	border-radius: inherit;
+	border-radius: 0;
 	box-sizing: border-box;
 	padding: 0;
 	-webkit-appearance: none;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Noticed by @sirreal, this fixes a visual bug introduced by #44939 where the child elements of a search input (search icon, text input, close icon) had rounded corners. This was most noticeable when using a color scheme with a dark sidebar background color, like Sunset.

**Before**

<img width="384" alt="Screen Shot 2020-09-08 at 1 20 23 PM" src="https://user-images.githubusercontent.com/2124984/92508513-c47c5780-f1d6-11ea-8bd2-8aff96bd2795.png">

**After**

<img width="382" alt="Screen Shot 2020-09-08 at 1 22 33 PM" src="https://user-images.githubusercontent.com/2124984/92508530-ca723880-f1d6-11ea-9938-1b55fd9f58a0.png">


#### Testing instructions

* Switch to this PR and change your dashboard color scheme under Me -> Account settings to something with a dark background, like Midnight or Sunset.
* Go to My Sites and open Switch sites at the top of the left sidebar.
* You should see a solid search input field. Type something into the field; it should remain one solid background color with no rounding of the icons or text input.
* Look at other instances of the search field across Calypso; Pages, Posts, Reader, etc. to make sure this doesn't cause additional visual regressions or bugs.
