### PR TITLE
Button: Rename bare button to plain

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-alpha.3
+
+- Add `plain` prop to `Button`
+
 ## 1.0.0-alpha.2
 
 - Added missing dependency on `@babel/runtime`

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/components",
-	"version": "1.0.0-alpha.1",
+	"version": "1.0.0-alpha.3",
 	"description": "Automattic Components",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",

--- a/packages/components/src/button/README.md
+++ b/packages/components/src/button/README.md
@@ -21,6 +21,7 @@ export default function RockOnButton() {
 
 | Name         | Type     | Default | Description                                                                        |
 | ------------ | -------- | ------- | ---------------------------------------------------------------------------------- |
+| `plain`    | `bool`   | false   | Renders a button with no user-agent styles                                                   |
 | `compact`    | `bool`   | false   | Decreases the size of the button                                                   |
 | `primary`    | `bool`   | false   | Provides extra visual weight and identifies the primary action in a set of buttons |
 | `borderless` | `bool`   | false   | Renders a button without borders                                                   |
@@ -36,7 +37,7 @@ export default function RockOnButton() {
 - **Scary**: Use when the action will delete customer data or be otherwise difficult to recover from. Destructive buttons should trigger a confirmation dialog before the action is completed. Be thoughtful about using destructive buttons because they can feel stressful for customers.
 - **Borderless**: Use for less important or less commonly used actions since they’re less prominent.
 - **Busy**: Use when a button has been pressed and the associated action is in progress.
-- **Bare**: Use when you need a "button-as-div", to reset all styles from a button that will then be augmented by a consumer. For example, if you need something to _behave_ as a button but not _appear_ as a button, this is a good option.
+- **Plain**: Use when you need a "button-as-div", to reset all styles from a button that will then be augmented by a consumer. For example, if you need something to _behave_ as a button but not _appear_ as a button, this is a good option.
 
 #### Icon buttons
 

--- a/packages/components/src/button/docs/example.jsx
+++ b/packages/components/src/button/docs/example.jsx
@@ -168,7 +168,7 @@ export default class ButtonExample extends React.PureComponent {
 				</div>
 
 				<div className="docs__design-button-row">
-					<Button bare>Bare button</Button>
+					<Button plain>Plain button</Button>
 				</div>
 			</Card>
 		),

--- a/packages/components/src/button/index.jsx
+++ b/packages/components/src/button/index.jsx
@@ -12,7 +12,7 @@ import './style.scss';
 
 export default class Button extends PureComponent {
 	static propTypes = {
-		bare: PropTypes.bool,
+		plain: PropTypes.bool,
 		compact: PropTypes.bool,
 		primary: PropTypes.bool,
 		scary: PropTypes.bool,
@@ -29,8 +29,8 @@ export default class Button extends PureComponent {
 	};
 
 	render() {
-		const className = this.props.bare
-			? classNames( 'button-bare', this.props.className )
+		const className = this.props.plain
+			? classNames( 'button-plain', this.props.className )
 			: classNames( 'button', this.props.className, {
 					'is-compact': this.props.compact,
 					'is-primary': this.props.primary,
@@ -40,7 +40,7 @@ export default class Button extends PureComponent {
 			  } );
 
 		if ( this.props.href ) {
-			const { compact, primary, scary, busy, borderless, bare, type, ...props } = this.props;
+			const { compact, primary, scary, busy, borderless, plain, type, ...props } = this.props;
 
 			// block referrers when external link
 			const rel = props.target
@@ -50,7 +50,7 @@ export default class Button extends PureComponent {
 			return <a { ...props } rel={ rel } className={ className } />;
 		}
 
-		const { compact, primary, scary, busy, borderless, bare, target, rel, ...props } = this.props;
+		const { compact, primary, scary, busy, borderless, plain, target, rel, ...props } = this.props;
 
 		return <button { ...props } className={ className } />;
 	}

--- a/packages/components/src/button/index.stories.jsx
+++ b/packages/components/src/button/index.stories.jsx
@@ -29,4 +29,4 @@ export const Scary = () => <ButtonVariations scary />;
 export const Borderless = () => <ButtonVariations borderless />;
 export const Disabled = () => <ButtonVariations disabled />;
 export const Link = () => <ButtonVariations href="https://www.google.com/" target="_blank" />;
-export const Bare = () => <ButtonVariations bare />;
+export const Plain = () => <ButtonVariations plain />;

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -293,7 +293,7 @@
 	}
 }
 
-.button-bare {
+.button-plain {
 	appearance: none;
 	background: transparent;
 	color: inherit;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Rename the `bare` prop to `plain` per the discussion in this PR: https://github.com/Automattic/wp-calypso/pull/45344

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure plain button is working in the storybook

Fixes #
