### PR TITLE
Offer Reset: improvements to product card badges

### DIFF
--- a/client/components/jetpack/card/jetpack-bundle-card/style.scss
+++ b/client/components/jetpack/card/jetpack-bundle-card/style.scss
@@ -9,7 +9,13 @@
 		border-color: $jetpack-bundle-card-color;
 	}
 
-	.jetpack-product-card__badge {
-		color: $jetpack-bundle-card-color;
+	&.is-featured {
+		.jetpack-product-card__badge {
+			border: 1px solid $jetpack-bundle-card-color;
+
+			color: $jetpack-bundle-card-color;
+
+			background-color: var( --color-surface );
+		}
 	}
 }

--- a/client/components/jetpack/card/jetpack-plan-card/style.scss
+++ b/client/components/jetpack/card/jetpack-plan-card/style.scss
@@ -13,10 +13,6 @@
 		border-color: $jetpack-plan-card-color;
 	}
 
-	.jetpack-product-card__badge {
-		color: $jetpack-plan-card-color;
-	}
-
 	&.is-deprecated {
 		.plan-price {
 			border-color: var( --color-text );

--- a/client/components/jetpack/card/jetpack-product-card/index.tsx
+++ b/client/components/jetpack/card/jetpack-product-card/index.tsx
@@ -123,6 +123,7 @@ const JetpackProductCard: FunctionComponent< Props > = ( {
 				'is-owned': isOwned,
 				'is-deprecated': isDeprecated,
 				'with-nudge': !! UpgradeNudge,
+				'is-featured': isHighlighted,
 			} ) }
 			data-icon={ iconSlug }
 		>

--- a/client/components/jetpack/card/jetpack-product-card/style.scss
+++ b/client/components/jetpack/card/jetpack-product-card/style.scss
@@ -203,20 +203,13 @@ $jetpack-product-card-icon-size: 55px;
 	height: $jetpack-product-card-badge-height;
 	padding: 0 16px;
 
-	background: var( --color-surface );
-	border: 1px solid currentColor;
+	background: var( --color-neutral-40 );
 	border-radius: 2px;
-	color: $jetpack-product-card-color;
+	color: var( --color-text-inverted );
 
 	font-size: 0.75rem;
 	line-height: $jetpack-product-card-badge-height;
 	text-transform: uppercase;
-}
-
-.jetpack-product-card.is-owned .jetpack-product-card__badge {
-	background-color: var( --color-neutral-40 );
-	border: none;
-	color: var( --color-text-inverted );
 }
 
 .jetpack-product-card__body {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Make all badges look the same (gray) except the one used for a featured/highlighted product card.

#### Testing instructions

* Run this PR.
* Visit the `/plans` section.
* Make sure all badges are gray except the one used for the featured Jetpack Security card.
* Try purchasing different plans and products to see all of them in action. The list of possible badges are: "Your Plan", "You own this", "Included in your plan", and "Best Value".

Fixes #

#### Demo
![image](https://user-images.githubusercontent.com/3418513/92521024-e97ec380-f1f2-11ea-8d3a-08caa4a16273.png)
![image](https://user-images.githubusercontent.com/3418513/92521046-f4395880-f1f2-11ea-9cc1-186874bb061f.png)
![image](https://user-images.githubusercontent.com/3418513/92521062-fac7d000-f1f2-11ea-86de-18fbf8605746.png)
![image](https://user-images.githubusercontent.com/3418513/92521079-01564780-f1f3-11ea-994f-04e8a674ad37.png)


