### PR TITLE
Show the price in Search product card when no site is selected

### DIFF
--- a/client/my-sites/plans-v2/product-card/index.tsx
+++ b/client/my-sites/plans-v2/product-card/index.tsx
@@ -29,6 +29,7 @@ import JetpackBundleCard from 'components/jetpack/card/jetpack-bundle-card';
 import JetpackProductCard from 'components/jetpack/card/jetpack-product-card';
 import JetpackProductCardUpgradeNudge from 'components/jetpack/card/jetpack-product-card/upgrade-nudge';
 import { planHasFeature } from 'lib/plans';
+import { JETPACK_SEARCH_PRODUCTS } from 'lib/products-values/constants';
 import { isCloseToExpiration } from 'lib/purchases';
 import { getPurchaseByProductSlug } from 'lib/purchases/utils';
 
@@ -171,7 +172,10 @@ const ProductCardWrapper = ( {
 			children={ item.children }
 			originalPrice={ originalPrice }
 			discountedPrice={ discountedPrice }
-			withStartingPrice={ item.subtypes.length > 0 }
+			withStartingPrice={
+				// Search has several pricing tiers
+				item.subtypes.length > 0 || JETPACK_SEARCH_PRODUCTS.includes( item.product_slug )
+			}
 			isOwned={ isOwned }
 			isDeprecated={ item.legacy }
 			className={ className }
@@ -179,7 +183,11 @@ const ProductCardWrapper = ( {
 			expiryDate={ showExpiryNotice && purchase ? moment( purchase.expiryDate ) : undefined }
 			isHighlighted={ isHighlighted }
 			isExpanded={ isHighlighted && ! isMobile }
-			hidePrice={ item.hidePrice }
+			hidePrice={
+				// Don't hide price if siteId is not defined, since it most likely won't be shown
+				// in other parts of the card (e.g. Jetpack Search)
+				siteId && item.hidePrice
+			}
 		/>
 	);
 };


### PR DESCRIPTION
### Changes proposed in this Pull Request

The price at the top of the Search product card has initially been removed, since the pricing tier was displayed in the body of the card. However, when no site is selected, this pricing tier doesn't exist and the product card is left with no mention of the price. This PR fixes that.

### Testing instructions

- Download the PR and run Calypso locally
- Visit the _Plans_ page with the offer reset flow enabled, and select the _Performance_ option
- Check that you see the pricing tier in the body of the Search card (see capture)
- Visit `/jetpack/connect/store`
- Check that you see no pricing tier in the body of the Search card, and that you see that starting price at the top (see capture)
- Run Jetpack cloud (you can run it concurrently to Calypso with `yarn start-jetpack-cloud-p`) and visit `/pricing`
- Check that you see no pricing tier in the body of the Search card, and that you see that starting price at the top (see capture)

### Screenshots

_Calypso, site selected_
<img width="449" alt="Screen Shot 2020-09-08 at 4 00 16 PM" src="https://user-images.githubusercontent.com/1620183/92523803-f7cae080-f1ee-11ea-989a-8cccc437bf7a.png">


_Jetpack connect, no site selected_
<img width="484" alt="Screen Shot 2020-09-08 at 4 08 00 PM" src="https://user-images.githubusercontent.com/1620183/92523806-fa2d3a80-f1ee-11ea-8e28-00fb6c080018.png">


_Jetpack cloud pricing page, no site selected_
<img width="497" alt="Screen Shot 2020-09-08 at 4 07 00 PM" src="https://user-images.githubusercontent.com/1620183/92523817-ff8a8500-f1ee-11ea-83fd-c88eda02a959.png">

