### PR TITLE
Checkout: Use the total_cost cart field for the PAYMENT_COMPLETE analytics

### DIFF
--- a/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-helpers.js
@@ -45,7 +45,6 @@ export function useStoredCards( getStoredCards, onEvent, isLoggedOutCart ) {
 			return getStoredCards();
 		}
 
-		// TODO: handle errors
 		fetchStoredCards()
 			.then( ( cards ) => {
 				debug( 'stored cards fetched', cards );

--- a/client/my-sites/checkout/composite-checkout/payment-method-processors.js
+++ b/client/my-sites/checkout/composite-checkout/payment-method-processors.js
@@ -72,7 +72,6 @@ export function genericRedirectProcessor(
 	);
 	// save result so we can get receipt_id and failed_purchases in getThankYouPageUrl
 	pending.then( ( result ) => {
-		// TODO: do this automatically when calling setTransactionComplete
 		dispatch( 'wpcom' ).setTransactionResponse( result );
 	} );
 	return pending;
@@ -96,7 +95,6 @@ export function applePayProcessor(
 	);
 	// save result so we can get receipt_id and failed_purchases in getThankYouPageUrl
 	pending.then( ( result ) => {
-		// TODO: do this automatically when calling setTransactionComplete
 		dispatch( 'wpcom' ).setTransactionResponse( result );
 	} );
 	return pending;
@@ -127,7 +125,6 @@ export async function stripeCardProcessor(
 	);
 	// save result so we can get receipt_id and failed_purchases in getThankYouPageUrl
 	pending.then( ( result ) => {
-		// TODO: do this automatically when calling setTransactionComplete
 		dispatch( 'wpcom' ).setTransactionResponse( result );
 	} );
 	return pending;
@@ -155,7 +152,6 @@ export async function ebanxCardProcessor(
 		wpcomTransaction
 	);
 	pending.then( ( result ) => {
-		// TODO: do this automatically when calling setTransactionComplete
 		dispatch( 'wpcom' ).setTransactionResponse( result );
 	} );
 	return pending;
@@ -202,7 +198,6 @@ export async function existingCardProcessor(
 	);
 	// save result so we can get receipt_id and failed_purchases in getThankYouPageUrl
 	pending.then( ( result ) => {
-		// TODO: do this automatically when calling setTransactionComplete
 		dispatch( 'wpcom' ).setTransactionResponse( result );
 	} );
 	return pending;
@@ -249,7 +244,6 @@ export async function fullCreditsProcessor(
 	);
 	// save result so we can get receipt_id and failed_purchases in getThankYouPageUrl
 	pending.then( ( result ) => {
-		// TODO: do this automatically when calling setTransactionComplete
 		dispatch( 'wpcom' ).setTransactionResponse( result );
 	} );
 	return pending;
@@ -293,7 +287,6 @@ export async function payPalProcessor(
 	);
 	// save result so we can get receipt_id and failed_purchases in getThankYouPageUrl
 	pending.then( ( result ) => {
-		// TODO: do this automatically when calling setTransactionComplete
 		dispatch( 'wpcom' ).setTransactionResponse( result );
 	} );
 	return pending;

--- a/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-pay-button.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/credit-card/credit-card-pay-button.js
@@ -111,12 +111,10 @@ export default function CreditCardPayButton( { disabled, store, stripe, stripeCo
 							paymentPartner,
 						} )
 							.then( ( ebanxResponse ) => {
-								// TODO
 								debug( 'ebanx transaction is successful', ebanxResponse );
 								setTransactionComplete();
 							} )
 							.catch( ( error ) => {
-								// TODO
 								debug( 'ebanx transaction error', error );
 								setTransactionError( error );
 							} );

--- a/client/my-sites/checkout/composite-checkout/payment-methods/ebanx-tef.js
+++ b/client/my-sites/checkout/composite-checkout/payment-methods/ebanx-tef.js
@@ -448,7 +448,6 @@ function EbanxTefLogo( { className } ) {
 }
 
 function getBankOptions( __ ) {
-	// Source TODO
 	const banks = [
 		{ value: 'banrisul', label: 'Banrisul' },
 		{ value: 'bradesco', label: 'Bradesco' },

--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -35,7 +35,7 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 					);
 					return reduxDispatch( recordTracksEvent( 'calypso_checkout_composite_loaded', {} ) );
 				case 'PAYMENT_COMPLETE': {
-					const total_cost = action.payload.total.amount.value / 100; // TODO: This conversion only works for USD! We have to localize this or get it from the server directly (or better yet, just force people to use the integer version).
+					const total_cost = action.payload.responseCart.total_cost;
 					reduxDispatch(
 						recordTracksEvent( 'calypso_checkout_payment_success', {
 							coupon_code: action.payload.couponItem?.wpcom_meta.couponCode ?? '',

--- a/client/my-sites/checkout/composite-checkout/types/backend/shopping-cart-endpoint.ts
+++ b/client/my-sites/checkout/composite-checkout/types/backend/shopping-cart-endpoint.ts
@@ -61,6 +61,7 @@ export interface ResponseCart {
 	products: ( TempResponseCartProduct | ResponseCartProduct )[];
 	total_tax_integer: number;
 	total_tax_display: string;
+	total_cost: number; // Please try not to use this
 	total_cost_integer: number;
 	total_cost_display: string;
 	coupon_savings_total_integer: number;
@@ -106,6 +107,7 @@ export const emptyResponseCart = {
 	products: [],
 	total_tax_integer: 0,
 	total_tax_display: '0',
+	total_cost: 0,
 	total_cost_integer: 0,
 	total_cost_display: '0',
 	coupon_savings_total_integer: 0,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In addition to some new events of its own, new checkout duplicates the same analytics events as old checkout, including several events when a payment is complete that expect the cart total to be in the (now deprecated) decimal form. That is, USD $50 is now used internally as 5000, but these events would prefer it was 50.00. Originally we solved this by dividing the total by 100, and we planned to replace it when we opened up support in new checkout for international currencies, but it was overlooked.

This change replaces that calculation with the deprecated decimal data still returned by the shopping-cart endpoint.

Fixes https://github.com/Automattic/wp-calypso/issues/45415

#### Testing instructions

- Visit checkout.
- Run `localStorage.setItem('debug', 'calypso:analytics')` in your browser console and reload the page. 
- Make sure your browser's console is set to preserve logs after redirect.
- Complete a purchase. Note that this must be for a non-redirect payment method such as a credit card.
- Look for this in your console logs: `calypso:analytics Recording event "calypso_checkout_payment_success" with actual props` and be sure that the `total_cost` data is correctly there as a decimal.