### PR TITLE
Checkout: Add warnings when useInitializeCartFromServer is used incorrectly

### DIFF
--- a/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/use-initialize-cart-from-server.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/use-initialize-cart-from-server.ts
@@ -31,6 +31,9 @@ export default function useInitializeCartFromServer(
 	onEvent?: ( arg0: ReactStandardAction ) => void
 ): void {
 	const isInitialized = useRef( false );
+	const initializedProducts = useRef< RequestCartProduct[] | null >( null );
+	const initializedCoupon = useRef< string | null >( null );
+
 	useEffect( () => {
 		if ( cacheStatus !== 'fresh' ) {
 			debug( 'not initializing cart; cacheStatus is not fresh' );
@@ -43,10 +46,32 @@ export default function useInitializeCartFromServer(
 
 		if ( isInitialized.current ) {
 			debug( 'not initializing cart; already initialized' );
+			if ( productsToAddOnInitialize !== initializedProducts.current ) {
+				// eslint-disable-next-line no-console
+				console.warn(
+					'The products list provided to useInitializeCartFromServer',
+					productsToAddOnInitialize,
+					'did not match the products list used for initialization',
+					initializedProducts.current,
+					'; they will not be added because the cart has already initialized. productsToAddOnInitialize should not change once canInitializeCart is true!'
+				);
+			}
+			if ( couponToAddOnInitialize !== initializedCoupon.current ) {
+				// eslint-disable-next-line no-console
+				console.warn(
+					'The coupon provided to useInitializeCartFromServer',
+					couponToAddOnInitialize,
+					'did not match the coupon used for initialization',
+					initializedCoupon.current,
+					'; it will not be added because the cart has already initialized. couponToAddOnInitialize should not change once canInitializeCart is true!'
+				);
+			}
 			return;
 		}
 		isInitialized.current = true;
 		debug( `initializing the cart; cacheStatus is ${ cacheStatus }` );
+		initializedProducts.current = productsToAddOnInitialize;
+		initializedCoupon.current = couponToAddOnInitialize;
 
 		getCart()
 			.then( ( response ) => {


### PR DESCRIPTION
useInitializeCartFromServer can be provided with two arguments that are used for initialization: `productsToAddOnInitialize` and `couponToAddOnInitialize`. However, it's expected that neither argument will change once the cart has initialized because after that point the hook will not use those arguments.

This change adds a console warning if either of those arguments change (note that for `productsToAddOnInitialize` this is a referential equality check, so it may be incorrect if the array is regenerated).

#### Testing instructions

- Start Calypso with `ENABLE_FEATURES=force-sympathy yarn start` to prevent caching.
- Make sure your shopping cart is empty.
- Visit a renewal URL directly (not by following a link).
- Verify that you see no warnings about `couponToAddOnInitialize` or `productsToAddOnInitialize` and the page loads with the renewal in your cart.
