### PR TITLE
Checkout: Convert usePrepareProductsForCart to TypeScript

### DIFF
--- a/client/lib/cart-values/types.ts
+++ b/client/lib/cart-values/types.ts
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import type { GSuiteProductUser } from 'lib/gsuite/new-users';
-import type { WPCOMTransactionEndpointDomainDetails } from 'my-sites/checkout/composite-checkout/types/transaction-endpoint';
+import type { DomainContactDetails } from 'my-sites/checkout/composite-checkout/types/backend/domain-contact-details-components';
 
 export type CartItemValue = {
 	product_id?: number;
@@ -23,7 +23,7 @@ export type CartItemExtra = {
 	source?: string;
 	domain_to_bundle?: string;
 	google_apps_users?: GSuiteProductUser[];
-	google_apps_registration_data?: WPCOMTransactionEndpointDomainDetails;
+	google_apps_registration_data?: DomainContactDetails;
 	purchaseId?: string;
 	purchaseDomain?: string;
 	purchaseType?: string;

--- a/client/my-sites/checkout/composite-checkout/add-items.ts
+++ b/client/my-sites/checkout/composite-checkout/add-items.ts
@@ -26,11 +26,11 @@ export function createItemToAddToCart( {
 	isJetpackNotAtomic,
 	isPrivate,
 }: {
-	planSlug?: string | undefined;
-	productAlias?: string | undefined;
 	product_id: number;
-	isJetpackNotAtomic?: boolean | undefined;
-	isPrivate?: boolean | undefined;
+	planSlug?: string;
+	productAlias?: string;
+	isJetpackNotAtomic?: boolean;
+	isPrivate?: boolean;
 } ): RequestCartProduct | null {
 	let cartItem, cartMeta;
 

--- a/client/my-sites/checkout/composite-checkout/add-items.ts
+++ b/client/my-sites/checkout/composite-checkout/add-items.ts
@@ -26,11 +26,11 @@ export function createItemToAddToCart( {
 	isJetpackNotAtomic,
 	isPrivate,
 }: {
-	planSlug: string | undefined;
-	productAlias: string | undefined;
+	planSlug?: string | undefined;
+	productAlias?: string | undefined;
 	product_id: number;
-	isJetpackNotAtomic: boolean | undefined;
-	isPrivate: boolean | undefined;
+	isJetpackNotAtomic?: boolean | undefined;
+	isPrivate?: boolean | undefined;
 } ): RequestCartProduct | null {
 	let cartItem, cartMeta;
 

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -28,9 +28,8 @@ import {
 	useIsApplePayAvailable,
 	filterAppropriatePaymentMethods,
 } from './payment-method-helpers';
-import usePrepareProductsForCart, {
-	useFetchProductsIfNotLoaded,
-} from './use-prepare-product-for-cart';
+import usePrepareProductsForCart from './use-prepare-product-for-cart';
+import useFetchProductsIfNotLoaded from './hooks/use-fetch-products-if-not-loaded';
 import notices from 'notices';
 import { isJetpackSite } from 'state/sites/selectors';
 import isAtomicSite from 'state/selectors/is-site-automated-transfer';

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -28,7 +28,7 @@ import {
 	useIsApplePayAvailable,
 	filterAppropriatePaymentMethods,
 } from './payment-method-helpers';
-import usePrepareProductsForCart from './use-prepare-product-for-cart';
+import usePrepareProductsForCart from './hooks/use-prepare-products-for-cart';
 import useFetchProductsIfNotLoaded from './hooks/use-fetch-products-if-not-loaded';
 import notices from 'notices';
 import { isJetpackSite } from 'state/sites/selectors';

--- a/client/my-sites/checkout/composite-checkout/hooks/use-fetch-products-if-not-loaded.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-fetch-products-if-not-loaded.ts
@@ -1,0 +1,27 @@
+/**
+ * External dependencies
+ */
+import { useEffect } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import debugFactory from 'debug';
+
+/**
+ * Internal dependencies
+ */
+import { getProductsList, isProductsListFetching } from 'state/products-list/selectors';
+import { requestProductsList } from 'state/products-list/actions';
+
+const debug = debugFactory( 'calypso:composite-checkout:use-prepare-product-for-cart' );
+
+export default function useFetchProductsIfNotLoaded() {
+	const reduxDispatch = useDispatch();
+	const isFetchingProducts = useSelector( ( state ) => isProductsListFetching( state ) );
+	const products = useSelector( ( state ) => getProductsList( state ) );
+	useEffect( () => {
+		if ( ! isFetchingProducts && Object.keys( products || {} ).length < 1 ) {
+			debug( 'fetching products list' );
+			reduxDispatch( requestProductsList() );
+			return;
+		}
+	}, [ isFetchingProducts, products, reduxDispatch ] );
+}

--- a/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
@@ -31,6 +31,10 @@ interface PreparedProductsForCart {
 	canInitializeCart: boolean;
 }
 
+function doesValueExist< T >( value: T ): value is Exclude< T, null > {
+	return !! value;
+}
+
 export default function usePrepareProductsForCart( {
 	siteId,
 	product: productAlias,
@@ -119,7 +123,7 @@ function useAddRenewalItems( {
 					selectedSiteSlug
 				);
 			} )
-			.filter( < T >( x: T ): x is Exclude< T, null > => !! x );
+			.filter( doesValueExist );
 		debug( 'preparing renewals requested in url', productsForCart );
 		setState( { productsForCart, canInitializeCart: true } );
 	}, [
@@ -264,7 +268,7 @@ function useAddProductFromSlug( {
 					isPrivate,
 				} )
 			)
-			.filter( < T >( x: T ): x is Exclude< T, null > => !! x );
+			.filter( doesValueExist );
 
 		if ( cartProducts.length < 1 ) {
 			debug(

--- a/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
@@ -9,7 +9,7 @@ import debugFactory from 'debug';
  * Internal dependencies
  */
 import { getSelectedSiteSlug } from 'state/ui/selectors';
-import { getRenewalItemFromCartItem } from 'lib/cart-values/cart-items';
+import { getRenewalItemFromCartItem, CartItemValue } from 'lib/cart-values/cart-items';
 import {
 	JETPACK_SEARCH_PRODUCTS,
 	PRODUCT_JETPACK_SEARCH,
@@ -342,7 +342,7 @@ function createRenewalItemToAddToCart(
 		return null;
 	}
 
-	return getRenewalItemFromCartItem(
+	const renewalItem = getRenewalItemFromCartItem(
 		{
 			meta,
 			product_slug: productSlug,
@@ -352,7 +352,17 @@ function createRenewalItemToAddToCart(
 			id: purchaseId,
 			domain: selectedSiteSlug,
 		}
-	) as RequestCartProduct;
+	);
+	if ( ! isRequestCartProduct( renewalItem ) ) {
+		return null;
+	}
+	return renewalItem;
+}
+
+function isRequestCartProduct(
+	product: CartItemValue | RequestCartProduct
+): product is RequestCartProduct {
+	return ( product as RequestCartProduct ).product_slug !== undefined;
 }
 
 /*

--- a/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
@@ -114,6 +114,7 @@ function useAddRenewalItems( {
 				const product = products[ slug ];
 				if ( ! product ) {
 					debug( 'no product found with slug', productSlug );
+					// TODO: show and record an error
 					return null;
 				}
 				return createRenewalItemToAddToCart(
@@ -164,6 +165,7 @@ function useAddPlanFromSlug( {
 		}
 		if ( ! plan ) {
 			debug( 'there is a request to add a plan but no plan was found', planSlug );
+			// TODO: show and record an error
 			setState( { productsForCart: [], canInitializeCart: true } );
 			return;
 		}
@@ -174,6 +176,7 @@ function useAddPlanFromSlug( {
 		} );
 		if ( ! cartProduct ) {
 			debug( 'there is a request to add a plan but creating an item failed', planSlug );
+			// TODO: show and record an error
 			setState( { productsForCart: [], canInitializeCart: true } );
 			return;
 		}
@@ -255,6 +258,7 @@ function useAddProductFromSlug( {
 				'there is a request to add one or more products but no product was found',
 				productAliasFromUrl
 			);
+			// TODO: show and record an error
 			setState( { productsForCart: [], canInitializeCart: true } );
 			return;
 		}
@@ -275,6 +279,7 @@ function useAddProductFromSlug( {
 				'there is a request to add a one or more products but creating them failed',
 				productAliasFromUrl
 			);
+			// TODO: show and record an error
 			setState( { productsForCart: [], canInitializeCart: true } );
 			return;
 		}

--- a/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-prepare-products-for-cart.ts
@@ -31,7 +31,7 @@ interface PreparedProductsForCart {
 	canInitializeCart: boolean;
 }
 
-function doesValueExist< T >( value: T ): value is Exclude< T, null > {
+function doesValueExist< T >( value: T ): value is Exclude< T, null | undefined > {
 	return !! value;
 }
 

--- a/client/my-sites/checkout/composite-checkout/use-prepare-product-for-cart.js
+++ b/client/my-sites/checkout/composite-checkout/use-prepare-product-for-cart.js
@@ -20,7 +20,6 @@ import {
 import { requestPlans } from 'state/plans/actions';
 import { getPlanBySlug, getPlans, isRequestingPlans } from 'state/plans/selectors';
 import { getProductsList, isProductsListFetching } from 'state/products-list/selectors';
-import { requestProductsList } from 'state/products-list/actions';
 import getUpgradePlanSlugFromPath from 'state/selectors/get-upgrade-plan-slug-from-path';
 import { createItemToAddToCart } from './add-items';
 
@@ -253,19 +252,6 @@ function useAddProductFromSlug( {
 		isFetchingProducts,
 		setState,
 	] );
-}
-
-export function useFetchProductsIfNotLoaded() {
-	const reduxDispatch = useDispatch();
-	const isFetchingProducts = useSelector( ( state ) => isProductsListFetching( state ) );
-	const products = useSelector( ( state ) => getProductsList( state ) );
-	useEffect( () => {
-		if ( ! isFetchingProducts && Object.keys( products || {} ).length < 1 ) {
-			debug( 'fetching products list' );
-			reduxDispatch( requestProductsList() );
-			return;
-		}
-	}, [ isFetchingProducts, products, reduxDispatch ] );
 }
 
 function useFetchPlansIfNotLoaded() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR converts the `usePrepareProductsForCart` hook in checkout and its associated code to TypeScript. This should have no functional change, although it may indeed fix several edge case bugs since it adds more guards that were not present before.

Depends on https://github.com/Automattic/wp-calypso/pull/45518

#### Testing instructions

- Visit checkout with a URL that includes a plan, eg: `/checkout/example.com/premium`
- Verify that checkout loads with that product in the cart and that there are no errors.
- Once a product is in the cart, visit checkout again with a URL that does not include a product, eg: `/checkout/example.com` and verify that the product remains and that there are no errors.
- Visit checkout with a URL that includes a non-plan product, eg: `/checkout/example.com/theme:ovation`
- Verify that checkout loads with that product in the cart and that there are no errors.
- Visit checkout with a URL that includes a renewal, eg: `checkout/value_bundle/renew/9000001/example.com`
- Verify that checkout loads with that product in the cart and that there are no errors.
