### PR TITLE
Make filter bar sticky in cloud pricing page on desktop

### DIFF
--- a/client/landing/jetpack-cloud/sections/pricing/style.scss
+++ b/client/landing/jetpack-cloud/sections/pricing/style.scss
@@ -16,6 +16,11 @@
 
 		border-left: none;
 		border-right: none;
+
+		@include break-large {
+			// This is the height of the jpcom masterbar
+			top: 94px;
+		}
 	}
 
 	.header {

--- a/client/my-sites/plans-v2/plans-filter-bar/index.tsx
+++ b/client/my-sites/plans-v2/plans-filter-bar/index.tsx
@@ -11,6 +11,7 @@ import classNames from 'classnames';
  */
 import SegmentedControl from 'components/segmented-control';
 import SelectDropdown from 'components/select-dropdown';
+import isJetpackCloud from 'lib/jetpack/is-jetpack-cloud';
 import { TERM_MONTHLY, TERM_ANNUALLY } from 'lib/plans/constants';
 import { masterbarIsVisible } from 'state/ui/selectors';
 import { PRODUCT_TYPE_OPTIONS } from '../constants';
@@ -33,7 +34,8 @@ interface Props {
 	onProductTypeChange: Function;
 }
 
-const MASTERBAR_HEIGHT = 47;
+const CALYPSO_MASTERBAR_HEIGHT = 47;
+const CLOUD_MASTERBAR_HEIGHT = 94;
 
 const PlansFilterBar = ( {
 	duration,
@@ -41,11 +43,16 @@ const PlansFilterBar = ( {
 	onDurationChange,
 	onProductTypeChange,
 }: Props ) => {
+	const isCloud = isJetpackCloud();
+	const masterbarSelector = isCloud ? '.jpcom-masterbar' : '.masterbar';
+	const masterbarDefaultHeight = isCloud ? CLOUD_MASTERBAR_HEIGHT : CALYPSO_MASTERBAR_HEIGHT;
+
 	const barRef = useRef< HTMLDivElement | null >( null );
 	const isMasterbarVisible = useSelector( masterbarIsVisible );
 	// if we can find the masterbar in the DOM, get its height directly from the element.
-	const masterbarHeight = document.querySelector( '.masterbar' )?.offsetHeight || MASTERBAR_HEIGHT;
-	const masterbarOffset = isMasterbarVisible ? masterbarHeight : 0;
+	const masterbarHeight =
+		document.querySelector( masterbarSelector )?.offsetHeight || masterbarDefaultHeight;
+	const masterbarOffset = isMasterbarVisible || isCloud ? masterbarHeight : 0;
 	const hasCrossed = useDetectWindowBoundary( barRef, masterbarOffset );
 
 	return (


### PR DESCRIPTION
### Changes proposed in this Pull Request

Title sums it up. On desktop, the filter bar in the pricing page of Jetpack cloud is now sticky as you scroll.

### Testing instructions

- Run Calypso with this PR locally, with the offer reset flow enabled
- Visit `/plans` and check that the filter bar behaves as before, both on desktop and mobile
- Visit `/jetpack/connect/plans` and check that the filter bar behaves as before, both on desktop and mobile
- Run Jetpack cloud (you can run it concurrently to Calypso with `yarn start-jetpack-cloud-p`)
- Visit `/pricing` and check that the filter bar is sticky both on mobile and desktop as you scroll

### Screenshots

#### Mobile
<img width="511" alt="Screen Shot 2020-09-08 at 5 35 57 PM" src="https://user-images.githubusercontent.com/1620183/92542161-0bd60880-f216-11ea-9135-7190d67e4f03.png">

#### Desktop
<img width="1142" alt="Screen Shot 2020-09-08 at 5 36 07 PM" src="https://user-images.githubusercontent.com/1620183/92542174-11cbe980-f216-11ea-95b5-c1683c57d43b.png">
