### PR TITLE
Clean up output directory after running the test

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -10,7 +10,7 @@ node_modules/
 !.eslintrc.js
 /client/server/devdocs/search-index.js
 /packages/calypso-codemods/tests
-/packages/wp-babel-makepot/test
+/packages/wp-babel-makepot/test/examples
 /packages/wpcom.js/webapp/tests/mocha.js
 /desktop/build/
 /desktop/client/

--- a/packages/wp-babel-makepot/package.json
+++ b/packages/wp-babel-makepot/package.json
@@ -38,6 +38,7 @@
 		"lodash.mergewith": "^4.6.2"
 	},
 	"devDependencies": {
-		"jest": "^26.4.0"
+		"jest": "^26.4.0",
+		"rimraf": "^3.0.0"
 	}
 }

--- a/packages/wp-babel-makepot/test/index.js
+++ b/packages/wp-babel-makepot/test/index.js
@@ -4,7 +4,7 @@
 const fs = require( 'fs' );
 const glob = require( 'glob' );
 const path = require( 'path' );
-const rimraf = require('rimraf');
+const rimraf = require( 'rimraf' );
 
 /**
  * Internal dependencies
@@ -28,9 +28,9 @@ describe( 'makePot', () => {
 		concatPot( potOutputDir, concatenatedPotOutputPath );
 	} );
 
-	afterAll(() => {
-		rimraf.sync(potOutputDir);
-	})
+	afterAll( () => {
+		rimraf.sync( potOutputDir );
+	} );
 
 	test( 'pot files should match their snapshots', () => {
 		const potGlob = path.join( __dirname, '**', '*.pot' );

--- a/packages/wp-babel-makepot/test/index.js
+++ b/packages/wp-babel-makepot/test/index.js
@@ -4,6 +4,7 @@
 const fs = require( 'fs' );
 const glob = require( 'glob' );
 const path = require( 'path' );
+const rimraf = require('rimraf');
 
 /**
  * Internal dependencies
@@ -26,6 +27,10 @@ describe( 'makePot', () => {
 
 		concatPot( potOutputDir, concatenatedPotOutputPath );
 	} );
+
+	afterAll(() => {
+		rimraf.sync(potOutputDir);
+	})
 
 	test( 'pot files should match their snapshots', () => {
 		const potGlob = path.join( __dirname, '**', '*.pot' );


### PR DESCRIPTION
### Background

The test for `@automattic/wp-babel-makepot` generates POT translations for a set of example files and a concatenation of said POT translations. Then it writes both (individual files and concatenation) to the filesystem under `packages/wp-babel-makepot/test/output`.

If the test is run twice (or if there are existing files in that path), the concatenation process will result in a double concatenation (the new POT files + the old concatenated file). This breaks the test.

### Changes

- Remove `packages/wp-babel-makepot/test/output` after the test is run.

### Testing instructions

* Run `yarn test-packages packages/wp-babel-makepot/test/index.js` twice. It should fail in master, but work in this branch.
