### PR TITLE
Atomic: Disable PHP 7.2

### DIFF
--- a/client/my-sites/hosting/php-version-card/index.js
+++ b/client/my-sites/hosting/php-version-card/index.js
@@ -55,6 +55,7 @@ const PhpVersionCard = ( {
 					comment: 'PHP Version for a version switcher',
 				} ),
 				value: '7.2',
+				disabled: true,
 			},
 			{
 				label: translate( '7.3 (recommended)', {
@@ -90,6 +91,11 @@ const PhpVersionCard = ( {
 						value={ selectedValue }
 					>
 						{ getPhpVersions().map( ( option ) => {
+							// Show disabled PHP versions only if the site is still using it.
+							if ( option.value !== version && option?.disabled ) {
+								return null;
+							}
+
 							return (
 								<option
 									disabled={ option.value === version }

--- a/client/my-sites/hosting/php-version-card/index.js
+++ b/client/my-sites/hosting/php-version-card/index.js
@@ -55,7 +55,7 @@ const PhpVersionCard = ( {
 					comment: 'PHP Version for a version switcher',
 				} ),
 				value: '7.2',
-				disabled: true,
+				disabled: true, // EOL 30th November, 2020
 			},
 			{
 				label: translate( '7.3 (recommended)', {

--- a/client/my-sites/hosting/php-version-card/index.js
+++ b/client/my-sites/hosting/php-version-card/index.js
@@ -91,8 +91,8 @@ const PhpVersionCard = ( {
 						value={ selectedValue }
 					>
 						{ getPhpVersions().map( ( option ) => {
-							// Show disabled PHP versions only if the site is still using it.
-							if ( option.value !== version && option?.disabled ) {
+							// Show disabled PHP version only if the site is still using it.
+							if ( option.value !== version && option.disabled ) {
 								return null;
 							}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We're deprecating PHP 7.2, as it's EOL is 20th November 2020.

#### Testing instructions

- Load an Atomic site with PHP version 7.2
- Make sure it shows as selected
- Update PHP version to 7.3/7.4
- Make sure no more 7.2 in the dropdown