### PR TITLE
Components: Remove global select field styles

### DIFF
--- a/client/assets/stylesheets/shared/_forms.scss
+++ b/client/assets/stylesheets/shared/_forms.scss
@@ -24,7 +24,6 @@ input[type='email'],
 input[type='number'],
 input[type='password'],
 textarea,
-select,
 label {
 	box-sizing: border-box;
 }
@@ -33,89 +32,4 @@ input[type='password'],
 input[type='email'] {
 	/*!rtl:ignore*/
 	direction: ltr;
-}
-
-select {
-	background: var( --color-surface )
-		url( 'data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+PHN2ZyB3aWR0aD0iMjBweCIgaGVpZ2h0PSIyMHB4IiB2aWV3Qm94PSIwIDAgMjAgMjAiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgeG1sbnM6c2tldGNoPSJodHRwOi8vd3d3LmJvaGVtaWFuY29kaW5nLmNvbS9za2V0Y2gvbnMiPiAgICAgICAgPHRpdGxlPmFycm93LWRvd248L3RpdGxlPiAgICA8ZGVzYz5DcmVhdGVkIHdpdGggU2tldGNoLjwvZGVzYz4gICAgPGRlZnM+PC9kZWZzPiAgICA8ZyBpZD0iUGFnZS0xIiBzdHJva2U9Im5vbmUiIHN0cm9rZS13aWR0aD0iMSIgZmlsbD0ibm9uZSIgZmlsbC1ydWxlPSJldmVub2RkIiBza2V0Y2g6dHlwZT0iTVNQYWdlIj4gICAgICAgIDxnIGlkPSJhcnJvdy1kb3duIiBza2V0Y2g6dHlwZT0iTVNBcnRib2FyZEdyb3VwIiBmaWxsPSIjQzhEN0UxIj4gICAgICAgICAgICA8cGF0aCBkPSJNMTUuNSw2IEwxNyw3LjUgTDEwLjI1LDE0LjI1IEwzLjUsNy41IEw1LDYgTDEwLjI1LDExLjI1IEwxNS41LDYgWiIgaWQ9IkRvd24tQXJyb3ciIHNrZXRjaDp0eXBlPSJNU1NoYXBlR3JvdXAiPjwvcGF0aD4gICAgICAgIDwvZz4gICAgPC9nPjwvc3ZnPg==' )
-		no-repeat right 10px center;
-	border-color: var( --color-neutral-10 );
-	border-style: solid;
-	border-radius: 2px;
-	border-width: 1px;
-	color: var( --color-neutral-70 );
-	cursor: pointer;
-	display: inline-block;
-	margin: 0;
-	outline: 0;
-	overflow: hidden;
-	font-size: $font-body;
-	font-weight: 400;
-	line-height: 1.4em;
-	text-overflow: ellipsis;
-	text-decoration: none;
-	vertical-align: top;
-	white-space: nowrap;
-	box-sizing: border-box;
-	padding: 7px 32px 9px 14px; // Aligns the text to the 8px baseline grid and adds padding on right to allow for the arrow.
-	-webkit-appearance: none;
-	-moz-appearance: none;
-	appearance: none;
-
-	&:hover {
-		background-image: url( 'data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+PHN2ZyB3aWR0aD0iMjBweCIgaGVpZ2h0PSIyMHB4IiB2aWV3Qm94PSIwIDAgMjAgMjAiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgeG1sbnM6c2tldGNoPSJodHRwOi8vd3d3LmJvaGVtaWFuY29kaW5nLmNvbS9za2V0Y2gvbnMiPiAgICAgICAgPHRpdGxlPmFycm93LWRvd248L3RpdGxlPiAgICA8ZGVzYz5DcmVhdGVkIHdpdGggU2tldGNoLjwvZGVzYz4gICAgPGRlZnM+PC9kZWZzPiAgICA8ZyBpZD0iUGFnZS0xIiBzdHJva2U9Im5vbmUiIHN0cm9rZS13aWR0aD0iMSIgZmlsbD0ibm9uZSIgZmlsbC1ydWxlPSJldmVub2RkIiBza2V0Y2g6dHlwZT0iTVNQYWdlIj4gICAgICAgIDxnIGlkPSJhcnJvdy1kb3duIiBza2V0Y2g6dHlwZT0iTVNBcnRib2FyZEdyb3VwIiBmaWxsPSIjYThiZWNlIj4gICAgICAgICAgICA8cGF0aCBkPSJNMTUuNSw2IEwxNyw3LjUgTDEwLjI1LDE0LjI1IEwzLjUsNy41IEw1LDYgTDEwLjI1LDExLjI1IEwxNS41LDYgWiIgaWQ9IkRvd24tQXJyb3ciIHNrZXRjaDp0eXBlPSJNU1NoYXBlR3JvdXAiPjwvcGF0aD4gICAgICAgIDwvZz4gICAgPC9nPjwvc3ZnPg==' );
-	}
-
-	&:focus {
-		background-image: url( 'data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+PHN2ZyB3aWR0aD0iMjBweCIgaGVpZ2h0PSIyMHB4IiB2aWV3Qm94PSIwIDAgMjAgMjAiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgeG1sbnM6c2tldGNoPSJodHRwOi8vd3d3LmJvaGVtaWFuY29kaW5nLmNvbS9za2V0Y2gvbnMiPiA8dGl0bGU+YXJyb3ctZG93bjwvdGl0bGU+IDxkZXNjPkNyZWF0ZWQgd2l0aCBTa2V0Y2guPC9kZXNjPiA8ZGVmcz48L2RlZnM+IDxnIGlkPSJQYWdlLTEiIHN0cm9rZT0ibm9uZSIgc3Ryb2tlLXdpZHRoPSIxIiBmaWxsPSJub25lIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiIHNrZXRjaDp0eXBlPSJNU1BhZ2UiPiA8ZyBpZD0iYXJyb3ctZG93biIgc2tldGNoOnR5cGU9Ik1TQXJ0Ym9hcmRHcm91cCIgZmlsbD0iIzJlNDQ1MyI+IDxwYXRoIGQ9Ik0xNS41LDYgTDE3LDcuNSBMMTAuMjUsMTQuMjUgTDMuNSw3LjUgTDUsNiBMMTAuMjUsMTEuMjUgTDE1LjUsNiBaIiBpZD0iRG93bi1BcnJvdyIgc2tldGNoOnR5cGU9Ik1TU2hhcGVHcm91cCI+PC9wYXRoPiA8L2c+IDwvZz48L3N2Zz4=' );
-		border-color: var( --color-primary );
-		box-shadow: 0 0 0 2px var( --color-primary-10 );
-		outline: 0;
-		-moz-outline: none;
-		-moz-user-focus: ignore;
-	}
-
-	&:disabled,
-	&:hover:disabled {
-		background: url( 'data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+PHN2ZyB3aWR0aD0iMjBweCIgaGVpZ2h0PSIyMHB4IiB2aWV3Qm94PSIwIDAgMjAgMjAiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgeG1sbnM6c2tldGNoPSJodHRwOi8vd3d3LmJvaGVtaWFuY29kaW5nLmNvbS9za2V0Y2gvbnMiPiAgICAgICAgPHRpdGxlPmFycm93LWRvd248L3RpdGxlPiAgICA8ZGVzYz5DcmVhdGVkIHdpdGggU2tldGNoLjwvZGVzYz4gICAgPGRlZnM+PC9kZWZzPiAgICA8ZyBpZD0iUGFnZS0xIiBzdHJva2U9Im5vbmUiIHN0cm9rZS13aWR0aD0iMSIgZmlsbD0ibm9uZSIgZmlsbC1ydWxlPSJldmVub2RkIiBza2V0Y2g6dHlwZT0iTVNQYWdlIj4gICAgICAgIDxnIGlkPSJhcnJvdy1kb3duIiBza2V0Y2g6dHlwZT0iTVNBcnRib2FyZEdyb3VwIiBmaWxsPSIjZTllZmYzIj4gICAgICAgICAgICA8cGF0aCBkPSJNMTUuNSw2IEwxNyw3LjUgTDEwLjI1LDE0LjI1IEwzLjUsNy41IEw1LDYgTDEwLjI1LDExLjI1IEwxNS41LDYgWiIgaWQ9IkRvd24tQXJyb3ciIHNrZXRjaDp0eXBlPSJNU1NoYXBlR3JvdXAiPjwvcGF0aD4gICAgICAgIDwvZz4gICAgPC9nPjwvc3ZnPg==' )
-			no-repeat right 10px center;
-	}
-
-	// A smaller variant that works well when presented inline with text
-	&.is-compact {
-		min-width: 0;
-		padding: 0 20px 2px 6px;
-		margin: 0 4px;
-		background-position: right 5px center;
-		background-size: 12px 12px;
-	}
-
-	// Make it display:block when it follows a label
-	label &,
-	label + & {
-		display: block;
-		min-width: 200px;
-
-		&.is-compact {
-			display: inline-block;
-			min-width: 0;
-		}
-	}
-
-	// IE: Remove the default arrow
-	&::-ms-expand {
-		display: none;
-	}
-
-	// IE: Remove default background and color styles on focus
-	&::-ms-value {
-		background: none;
-		color: var( --color-neutral-70 );
-	}
-
-	// Firefox: Remove the focus outline, see http://stackoverflow.com/questions/3773430/remove-outline-from-select-box-in-ff/18853002#18853002
-	&:-moz-focusring {
-		color: transparent;
-		text-shadow: 0 0 0 var( --color-neutral-70 );
-	}
 }

--- a/client/blocks/site-address-changer/index.jsx
+++ b/client/blocks/site-address-changer/index.jsx
@@ -19,6 +19,7 @@ import FormButtonsBar from 'components/forms/form-buttons-bar';
 import FormTextInputWithAffixes from 'components/forms/form-text-input-with-affixes';
 import FormInputValidation from 'components/forms/form-input-validation';
 import FormLabel from 'components/forms/form-label';
+import FormSelect from 'components/forms/form-select';
 import ConfirmationDialog from './dialog';
 import TrackComponentView from 'lib/analytics/track-component-view';
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -245,7 +246,7 @@ export class SiteAddressChanger extends Component {
 			<span className="site-address-changer__affix">
 				{ newDomainSuffix }
 				<Gridicon icon="chevron-down" size={ 18 } className="site-address-changer__select-icon" />
-				<select
+				<FormSelect
 					className="site-address-changer__select"
 					value={ newDomainSuffix }
 					onChange={ this.onDomainSuffixChange }
@@ -255,7 +256,7 @@ export class SiteAddressChanger extends Component {
 							{ suffix }
 						</option>
 					) ) }
-				</select>
+				</FormSelect>
 			</span>
 		);
 	}

--- a/client/components/forms/form-country-select/index.jsx
+++ b/client/components/forms/form-country-select/index.jsx
@@ -8,6 +8,11 @@ import { isEmpty, omit } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
+ * Internal dependencies
+ */
+import FormSelect from 'components/forms/form-select';
+
+/**
  * Style dependencies
  */
 import './style.scss';
@@ -46,7 +51,7 @@ export class FormCountrySelect extends Component {
 		const options = this.getOptions();
 
 		return (
-			<select
+			<FormSelect
 				{ ...omit( this.props, [
 					'className',
 					'countriesList',
@@ -65,7 +70,7 @@ export class FormCountrySelect extends Component {
 						</option>
 					);
 				} ) }
-			</select>
+			</FormSelect>
 		);
 	}
 }

--- a/client/components/forms/form-currency-input/index.jsx
+++ b/client/components/forms/form-currency-input/index.jsx
@@ -10,6 +10,7 @@ import { find, get } from 'lodash';
 /**
  * Internal dependencies
  */
+import FormSelect from 'components/forms/form-select';
 import FormTextInputWithAffixes from 'components/forms/form-text-input-with-affixes';
 
 /**
@@ -37,12 +38,12 @@ function renderAffix( currencyValue, onCurrencyChange, currencyList ) {
 		currencyValue
 	);
 
-	// For an editable currency, display a <select> overlay
+	// For an editable currency, display a <FormSelect> overlay
 	return (
 		<span className="form-currency-input__affix">
 			{ currencyLabel }
 			<Gridicon icon="chevron-down" size={ 18 } className="form-currency-input__select-icon" />
-			<select
+			<FormSelect
 				className="form-currency-input__select"
 				value={ currencyValue }
 				onChange={ onCurrencyChange }
@@ -53,7 +54,7 @@ function renderAffix( currencyValue, onCurrencyChange, currencyList ) {
 						{ label }
 					</option>
 				) ) }
-			</select>
+			</FormSelect>
 		</span>
 	);
 }

--- a/client/components/forms/form-select/style.scss
+++ b/client/components/forms/form-select/style.scss
@@ -1,5 +1,86 @@
 .form-select {
-	margin-bottom: 1em;
+	background: var( --color-surface )
+		url( 'data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+PHN2ZyB3aWR0aD0iMjBweCIgaGVpZ2h0PSIyMHB4IiB2aWV3Qm94PSIwIDAgMjAgMjAiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgeG1sbnM6c2tldGNoPSJodHRwOi8vd3d3LmJvaGVtaWFuY29kaW5nLmNvbS9za2V0Y2gvbnMiPiAgICAgICAgPHRpdGxlPmFycm93LWRvd248L3RpdGxlPiAgICA8ZGVzYz5DcmVhdGVkIHdpdGggU2tldGNoLjwvZGVzYz4gICAgPGRlZnM+PC9kZWZzPiAgICA8ZyBpZD0iUGFnZS0xIiBzdHJva2U9Im5vbmUiIHN0cm9rZS13aWR0aD0iMSIgZmlsbD0ibm9uZSIgZmlsbC1ydWxlPSJldmVub2RkIiBza2V0Y2g6dHlwZT0iTVNQYWdlIj4gICAgICAgIDxnIGlkPSJhcnJvdy1kb3duIiBza2V0Y2g6dHlwZT0iTVNBcnRib2FyZEdyb3VwIiBmaWxsPSIjQzhEN0UxIj4gICAgICAgICAgICA8cGF0aCBkPSJNMTUuNSw2IEwxNyw3LjUgTDEwLjI1LDE0LjI1IEwzLjUsNy41IEw1LDYgTDEwLjI1LDExLjI1IEwxNS41LDYgWiIgaWQ9IkRvd24tQXJyb3ciIHNrZXRjaDp0eXBlPSJNU1NoYXBlR3JvdXAiPjwvcGF0aD4gICAgICAgIDwvZz4gICAgPC9nPjwvc3ZnPg==' )
+		no-repeat right 10px center;
+	border-color: var( --color-neutral-10 );
+	border-style: solid;
+	border-radius: 2px;
+	border-width: 1px;
+	color: var( --color-neutral-70 );
+	cursor: pointer;
+	display: inline-block;
+	margin: 0 0 1em;
+	outline: 0;
+	overflow: hidden;
+	font-size: $font-body;
+	font-weight: 400;
+	line-height: 1.4em;
+	text-overflow: ellipsis;
+	text-decoration: none;
+	vertical-align: top;
+	white-space: nowrap;
+	box-sizing: border-box;
+	padding: 7px 32px 9px 14px; // Aligns the text to the 8px baseline grid and adds padding on right to allow for the arrow.
+	-webkit-appearance: none;
+	-moz-appearance: none;
+	appearance: none;
+
+	&:hover {
+		background-image: url( 'data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+PHN2ZyB3aWR0aD0iMjBweCIgaGVpZ2h0PSIyMHB4IiB2aWV3Qm94PSIwIDAgMjAgMjAiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgeG1sbnM6c2tldGNoPSJodHRwOi8vd3d3LmJvaGVtaWFuY29kaW5nLmNvbS9za2V0Y2gvbnMiPiAgICAgICAgPHRpdGxlPmFycm93LWRvd248L3RpdGxlPiAgICA8ZGVzYz5DcmVhdGVkIHdpdGggU2tldGNoLjwvZGVzYz4gICAgPGRlZnM+PC9kZWZzPiAgICA8ZyBpZD0iUGFnZS0xIiBzdHJva2U9Im5vbmUiIHN0cm9rZS13aWR0aD0iMSIgZmlsbD0ibm9uZSIgZmlsbC1ydWxlPSJldmVub2RkIiBza2V0Y2g6dHlwZT0iTVNQYWdlIj4gICAgICAgIDxnIGlkPSJhcnJvdy1kb3duIiBza2V0Y2g6dHlwZT0iTVNBcnRib2FyZEdyb3VwIiBmaWxsPSIjYThiZWNlIj4gICAgICAgICAgICA8cGF0aCBkPSJNMTUuNSw2IEwxNyw3LjUgTDEwLjI1LDE0LjI1IEwzLjUsNy41IEw1LDYgTDEwLjI1LDExLjI1IEwxNS41LDYgWiIgaWQ9IkRvd24tQXJyb3ciIHNrZXRjaDp0eXBlPSJNU1NoYXBlR3JvdXAiPjwvcGF0aD4gICAgICAgIDwvZz4gICAgPC9nPjwvc3ZnPg==' );
+	}
+
+	&:focus {
+		background-image: url( 'data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+PHN2ZyB3aWR0aD0iMjBweCIgaGVpZ2h0PSIyMHB4IiB2aWV3Qm94PSIwIDAgMjAgMjAiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgeG1sbnM6c2tldGNoPSJodHRwOi8vd3d3LmJvaGVtaWFuY29kaW5nLmNvbS9za2V0Y2gvbnMiPiA8dGl0bGU+YXJyb3ctZG93bjwvdGl0bGU+IDxkZXNjPkNyZWF0ZWQgd2l0aCBTa2V0Y2guPC9kZXNjPiA8ZGVmcz48L2RlZnM+IDxnIGlkPSJQYWdlLTEiIHN0cm9rZT0ibm9uZSIgc3Ryb2tlLXdpZHRoPSIxIiBmaWxsPSJub25lIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiIHNrZXRjaDp0eXBlPSJNU1BhZ2UiPiA8ZyBpZD0iYXJyb3ctZG93biIgc2tldGNoOnR5cGU9Ik1TQXJ0Ym9hcmRHcm91cCIgZmlsbD0iIzJlNDQ1MyI+IDxwYXRoIGQ9Ik0xNS41LDYgTDE3LDcuNSBMMTAuMjUsMTQuMjUgTDMuNSw3LjUgTDUsNiBMMTAuMjUsMTEuMjUgTDE1LjUsNiBaIiBpZD0iRG93bi1BcnJvdyIgc2tldGNoOnR5cGU9Ik1TU2hhcGVHcm91cCI+PC9wYXRoPiA8L2c+IDwvZz48L3N2Zz4=' );
+		border-color: var( --color-primary );
+		box-shadow: 0 0 0 2px var( --color-primary-10 );
+		outline: 0;
+		-moz-outline: none;
+		-moz-user-focus: ignore;
+	}
+
+	&:disabled,
+	&:hover:disabled {
+		background: url( 'data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+PHN2ZyB3aWR0aD0iMjBweCIgaGVpZ2h0PSIyMHB4IiB2aWV3Qm94PSIwIDAgMjAgMjAiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgeG1sbnM6c2tldGNoPSJodHRwOi8vd3d3LmJvaGVtaWFuY29kaW5nLmNvbS9za2V0Y2gvbnMiPiAgICAgICAgPHRpdGxlPmFycm93LWRvd248L3RpdGxlPiAgICA8ZGVzYz5DcmVhdGVkIHdpdGggU2tldGNoLjwvZGVzYz4gICAgPGRlZnM+PC9kZWZzPiAgICA8ZyBpZD0iUGFnZS0xIiBzdHJva2U9Im5vbmUiIHN0cm9rZS13aWR0aD0iMSIgZmlsbD0ibm9uZSIgZmlsbC1ydWxlPSJldmVub2RkIiBza2V0Y2g6dHlwZT0iTVNQYWdlIj4gICAgICAgIDxnIGlkPSJhcnJvdy1kb3duIiBza2V0Y2g6dHlwZT0iTVNBcnRib2FyZEdyb3VwIiBmaWxsPSIjZTllZmYzIj4gICAgICAgICAgICA8cGF0aCBkPSJNMTUuNSw2IEwxNyw3LjUgTDEwLjI1LDE0LjI1IEwzLjUsNy41IEw1LDYgTDEwLjI1LDExLjI1IEwxNS41LDYgWiIgaWQ9IkRvd24tQXJyb3ciIHNrZXRjaDp0eXBlPSJNU1NoYXBlR3JvdXAiPjwvcGF0aD4gICAgICAgIDwvZz4gICAgPC9nPjwvc3ZnPg==' )
+			no-repeat right 10px center;
+	}
+
+	// A smaller variant that works well when presented inline with text
+	&.is-compact {
+		min-width: 0;
+		padding: 0 20px 2px 6px;
+		margin: 0 4px;
+		background-position: right 5px center;
+		background-size: 12px 12px;
+	}
+
+	// Make it display:block when it follows a label
+	label &,
+	label + & {
+		display: block;
+		min-width: 200px;
+
+		&.is-compact {
+			display: inline-block;
+			min-width: 0;
+		}
+	}
+
+	// IE: Remove the default arrow
+	&::-ms-expand {
+		display: none;
+	}
+
+	// IE: Remove default background and color styles on focus
+	&::-ms-value {
+		background: none;
+		color: var( --color-neutral-70 );
+	}
+
+	// Firefox: Remove the focus outline, see http://stackoverflow.com/questions/3773430/remove-outline-from-select-box-in-ff/18853002#18853002
+	&:-moz-focusring {
+		color: transparent;
+		text-shadow: 0 0 0 var( --color-neutral-70 );
+	}
 
 	&.is-error {
 		border-color: var( --color-error );

--- a/client/components/forms/select-opt-groups.jsx
+++ b/client/components/forms/select-opt-groups.jsx
@@ -1,14 +1,18 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
 import { omit } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import FormSelect from 'components/forms/form-select';
 
 const SelectOptGroups = ( props ) => {
 	const { optGroups, ...selectProps } = props;
 	return (
-		<select { ...omit( selectProps, [ 'moment', 'numberFormat', 'translate' ] ) }>
+		<FormSelect { ...omit( selectProps, [ 'moment', 'numberFormat', 'translate' ] ) }>
 			{ optGroups.map( ( optGroup ) => (
 				<optgroup label={ optGroup.label } key={ `optgroup-${ optGroup.label }` }>
 					{ optGroup.options.map( ( option ) => (
@@ -18,7 +22,7 @@ const SelectOptGroups = ( props ) => {
 					) ) }
 				</optgroup>
 			) ) }
-		</select>
+		</FormSelect>
 	);
 };
 

--- a/client/components/info-popover/docs/example.jsx
+++ b/client/components/info-popover/docs/example.jsx
@@ -7,6 +7,8 @@ import React from 'react';
 /**
  * Internal dependencies
  */
+import FormLabel from 'components/forms/form-label';
+import FormSelect from 'components/forms/form-select';
 import InfoPopover from 'components/info-popover';
 
 class InfoPopoverExample extends React.PureComponent {
@@ -19,9 +21,9 @@ class InfoPopoverExample extends React.PureComponent {
 	render() {
 		return (
 			<div>
-				<label>
+				<FormLabel>
 					Position
-					<select value={ this.state.popoverPosition } onChange={ this._changePopoverPosition }>
+					<FormSelect value={ this.state.popoverPosition } onChange={ this._changePopoverPosition }>
 						<option value="top">top</option>
 						<option value="top left">top left</option>
 						<option value="top right">top right</option>
@@ -30,8 +32,8 @@ class InfoPopoverExample extends React.PureComponent {
 						<option value="bottom">bottom</option>
 						<option value="bottom left">bottom left</option>
 						<option value="bottom right">bottom right</option>
-					</select>
-				</label>
+					</FormSelect>
+				</FormLabel>
 
 				<br />
 

--- a/client/components/popover/docs/example.jsx
+++ b/client/components/popover/docs/example.jsx
@@ -7,6 +7,8 @@ import React, { PureComponent } from 'react';
 /**
  * Internal dependencies
  */
+import FormLabel from 'components/forms/form-label';
+import FormSelect from 'components/forms/form-select';
 import Popover from 'components/popover';
 import PopoverMenu from 'components/popover/menu';
 import PopoverMenuItem from 'components/popover/menu-item';
@@ -102,9 +104,9 @@ class PopoverExample extends PureComponent {
 	render() {
 		return (
 			<div>
-				<label>
+				<FormLabel>
 					Position
-					<select value={ this.state.popoverPosition } onChange={ this.changePopoverPosition }>
+					<FormSelect value={ this.state.popoverPosition } onChange={ this.changePopoverPosition }>
 						<option value="top">top</option>
 						<option value="top left">top left</option>
 						<option value="top right">top right</option>
@@ -114,8 +116,8 @@ class PopoverExample extends PureComponent {
 						<option value="bottom left">bottom left</option>
 						<option value="bottom right">bottom right</option>
 						<option value="custom">custom</option>
-					</select>
-				</label>
+					</FormSelect>
+				</FormLabel>
 
 				<hr />
 

--- a/client/components/timezone/index.jsx
+++ b/client/components/timezone/index.jsx
@@ -11,6 +11,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import FormSelect from 'components/forms/form-select';
 import QueryTimezones from 'components/data/query-timezones';
 import getRawOffsets from 'state/selectors/get-raw-offsets';
 import getTimezones from 'state/selectors/get-timezones';
@@ -61,14 +62,14 @@ class Timezone extends Component {
 	render() {
 		const { selectedZone } = this.props;
 		return (
-			<select onChange={ this.onSelect } value={ selectedZone || '' }>
+			<FormSelect onChange={ this.onSelect } value={ selectedZone || '' }>
 				<QueryTimezones />
 				{ this.renderOptionsByContinent() }
 				<optgroup label="UTC">
 					<option value="UTC">UTC</option>
 				</optgroup>
 				{ this.props.includeManualOffsets && this.renderManualUtcOffsets() }
-			</select>
+			</FormSelect>
 		);
 	}
 }

--- a/client/components/tinymce/plugins/wpcom-view/views/contact-form/preview-fields.jsx
+++ b/client/components/tinymce/plugins/wpcom-view/views/contact-form/preview-fields.jsx
@@ -14,6 +14,7 @@ import PreviewRequired from './preview-required';
 import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormRadio from 'calypso/components/forms/form-radio';
+import FormSelect from 'calypso/components/forms/form-select';
 
 const textField = ( field, index ) => (
 	<PreviewFieldset key={ 'contact-form-field-' + index }>
@@ -42,11 +43,11 @@ const checkbox = ( field, index ) => (
 const select = ( field, index ) => (
 	<PreviewFieldset key={ 'contact-form-field-' + index }>
 		<PreviewLegend { ...field } />
-		<select>
+		<FormSelect>
 			{ [].concat( field.options.split( ',' ) ).map( ( option, optionIndex ) => (
 				<option key={ 'contact-form-select-option-' + optionIndex }>{ option }</option>
 			) ) }
-		</select>
+		</FormSelect>
 	</PreviewFieldset>
 );
 

--- a/client/components/tooltip/docs/example.jsx
+++ b/client/components/tooltip/docs/example.jsx
@@ -7,6 +7,8 @@ import React, { PureComponent } from 'react';
 /**
  * Internal dependencies
  */
+import FormLabel from 'components/forms/form-label';
+import FormSelect from 'components/forms/form-select';
 import TooltipComponent from 'components/tooltip';
 
 class Tooltip extends PureComponent {
@@ -40,9 +42,9 @@ class Tooltip extends PureComponent {
 
 		return (
 			<div>
-				<label>
+				<FormLabel>
 					Position
-					<select value={ this.state.position } onChange={ this.changePosition }>
+					<FormSelect value={ this.state.position } onChange={ this.changePosition }>
 						<option value="top">top</option>
 						<option value="top left">top left</option>
 						<option value="top right">top right</option>
@@ -51,8 +53,8 @@ class Tooltip extends PureComponent {
 						<option value="bottom">bottom</option>
 						<option value="bottom left">bottom left</option>
 						<option value="bottom right">bottom right</option>
-					</select>
-				</label>
+					</FormSelect>
+				</FormLabel>
 
 				<hr />
 

--- a/client/my-sites/google-my-business/stats/chart.js
+++ b/client/my-sites/google-my-business/stats/chart.js
@@ -12,6 +12,7 @@ import { localize } from 'i18n-calypso';
  */
 import { Card } from '@automattic/components';
 import CardHeading from 'components/card-heading';
+import FormSelect from 'components/forms/form-select';
 import getGoogleMyBusinessStats from 'state/selectors/get-google-my-business-stats';
 import getGoogleMyBusinessStatsError from 'state/selectors/get-google-my-business-stats-error';
 import LineChart from 'components/line-chart';
@@ -293,7 +294,7 @@ class GoogleMyBusinessStatsChart extends Component {
 							</CardHeading>
 						</div>
 					) }
-					<select
+					<FormSelect
 						className="gmb-stats__chart-interval"
 						onChange={ this.handleIntervalChange }
 						value={ interval }
@@ -301,7 +302,7 @@ class GoogleMyBusinessStatsChart extends Component {
 						<option value="week">{ translate( 'Week' ) }</option>
 						<option value="month">{ translate( 'Month' ) }</option>
 						<option value="quarter">{ translate( 'Quarter' ) }</option>
-					</select>
+					</FormSelect>
 
 					<div className="gmb-stats__chart">{ this.renderChart() }</div>
 				</Card>

--- a/client/my-sites/marketing/connections/mailchimp-settings.jsx
+++ b/client/my-sites/marketing/connections/mailchimp-settings.jsx
@@ -9,6 +9,7 @@ import { isArray } from 'lodash';
 /**
  * Internal dependencies
  */
+import FormSelect from 'components/forms/form-select';
 import { requestSettingsUpdate } from 'state/mailchimp/settings/actions';
 import QueryMailchimpLists from 'components/data/query-mailchimp-lists';
 import QueryMailchimpSettings from 'components/data/query-mailchimp-settings';
@@ -117,7 +118,7 @@ const MailchimpSettings = ( {
 					showDismiss={ false }
 				/>
 			) }
-			<select value={ mailchimpListId } onChange={ chooseMailchimpList }>
+			<FormSelect value={ mailchimpListId } onChange={ chooseMailchimpList }>
 				<option key="none" value={ 0 }>
 					{ translate( 'Do not save subscribers to Mailchimp for this site' ) }
 				</option>
@@ -127,7 +128,7 @@ const MailchimpSettings = ( {
 							{ list.name }
 						</option>
 					) ) }
-			</select>
+			</FormSelect>
 			{ common }
 		</div>
 	);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove global form `select` styles in favor of more specific component-level styling. See #45259.

#### Testing instructions

* Test the following against production and ensure that they match stylistically and functionally:
  * `/devdocs/design/form-fields`:
    *  Select
    * Form Select
    * Form Country Select
    * Form US State Select
    * Editable Form Currency Input
  * `/domains/manage/sub.main.blog/change-site-address/sub.main.blog` - where `sub.main.blog` is a .blog subdomain. To create one, go to photo.blog and click the button at the bottom. Here you should test the select field on the right, where you pick the primary domain.
  * `/devdocs/design/info-popover` - the Position field
  * `/devdocs/design/popover` - the Position field
  * `/devdocs/design/timezone`
  * `/devdocs/design/tooltip` - the Position field
  * `/post/:siteSlug/:postId` - editing a post with the classic editor, insert a Contact form and insert a new Dropdown field.
  * `/google-my-business/stats/:siteSlug` - the interval field that manages the chart - requires you to have connected to Google My Business and have a physical location setup in the connected account.
  * `/marketing/connections/:siteSlug` - the select field under "What Mailchimp list should subscribers be added to" in your Mailchimp connection. To test this, you need to have connected to Mailchimp, and to have at least one list in your account.
* Verify all `<select />` instances use `<FormSelect />`. 

#### Notes

* Lint errors are expected and are not being introduced by this PR. I'm consciously not fixing them, to avoid from creating a huge PR.
* We're consciously ignoring the <select> instances in the composite-checkout package because it doesn't use Calypso components.
