### PR TITLE
Editing Toolkit: Remove swiper dependency

### DIFF
--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -139,7 +139,6 @@
 		"react": "^16.12.0",
 		"react-dom": "^16.12.0",
 		"redux": "^4.0.5",
-		"swiper": "^4.5.1",
 		"utility-types": "^3.10.0"
 	},
 	"devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -25980,7 +25980,7 @@ swap-case@^1.1.0:
     lower-case "^1.1.1"
     upper-case "^1.1.1"
 
-swiper@4.5.1, swiper@^4.5.1:
+swiper@4.5.1:
   version "4.5.1"
   resolved "https://registry.yarnpkg.com/swiper/-/swiper-4.5.1.tgz#ed43998e780ceb478610079c8d23fd425eca636f"
   integrity sha512-se6I7PWWu950NAMXXT+ENtF/6SVb8mPyO+bTfNxbQBILSeLqsYp3Ndap+YOA0EczOIUlea274PKejT6gKZDseA==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Remove `swiper` dependency.

Swiper was added by https://github.com/Automattic/wp-calypso/pull/30352/files#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R194 but those blocks were moved to Jetpack in https://github.com/Automattic/wp-calypso/pull/31759/files#diff-b9cfc7f2cdf78a7f4b91a753d10865a2 .

We are still using `swiper` for building `newspack-blocks` in `editing-toolkit` but since we have `newspack-blocks` as a dependency (which has `swiper` as a dependency) we still have access to `swiper`. It doesn't need to be included in the `package.json`. This also makes sure we use the correct version of `swiper`.

I was thinking about adding it as a peer dependency, but then we should do it for every dependency of `newspack-blocks`. 