### PR TITLE
Gutenboarding: add site_count to signup start events

### DIFF
--- a/client/landing/gutenboarding/gutenboard.tsx
+++ b/client/landing/gutenboarding/gutenboard.tsx
@@ -19,12 +19,12 @@ import Header from './components/header';
 import SignupForm from './components/signup-form';
 import { name, settings } from './onboarding-block';
 import { fontPairings, getFontTitle } from './constants';
-import { recordOnboardingStart } from './lib/analytics';
 import useOnSiteCreation from './hooks/use-on-site-creation';
 import { usePageViewTracksEvents } from './hooks/use-page-view-tracks-events';
 import useSignup from './hooks/use-signup';
 import useOnSignup from './hooks/use-on-signup';
 import useOnLogin from './hooks/use-on-login';
+import useTrackOnboardingStart from './hooks/use-track-onboarding-start';
 
 import './style.scss';
 
@@ -36,6 +36,7 @@ const Gutenboard: React.FunctionComponent = () => {
 	useOnSignup();
 	useOnSiteCreation();
 	usePageViewTracksEvents();
+	useTrackOnboardingStart();
 	const { showSignupDialog, onSignupDialogClose } = useSignup();
 
 	// TODO: Explore alternatives for loading fonts and optimizations
@@ -61,8 +62,6 @@ const Gutenboard: React.FunctionComponent = () => {
 			document.head.appendChild( linkBase );
 			document.head.appendChild( linkHeadings );
 		} );
-
-		recordOnboardingStart();
 	}, [] ); // eslint-disable-line react-hooks/exhaustive-deps
 
 	// @TODO: This is currently needed in addition to the routing (inside the Onboarding Block)

--- a/client/landing/gutenboarding/hooks/use-track-onboarding-start.ts
+++ b/client/landing/gutenboarding/hooks/use-track-onboarding-start.ts
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import * as React from 'react';
+import { useSelect, useDispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { recordOnboardingStart } from '../lib/analytics';
+import { USER_STORE } from '../stores/user';
+import { STORE_KEY as ONBOARD_STORE } from '../stores/onboard';
+
+/**
+ * Records an event in tracks on starting the onboarding flow, after trying to get the current user
+ */
+
+export default function useTrackOnboardingStart() {
+	const currentUser = useSelect( ( select ) => select( USER_STORE ).getCurrentUser() );
+	const { hasOnboardingStarted } = useSelect( ( select ) => select( ONBOARD_STORE ).getState() );
+	const { startOnboarding } = useDispatch( ONBOARD_STORE );
+
+	React.useEffect( () => {
+		if ( ! hasOnboardingStarted && currentUser !== undefined ) {
+			const ref = new URLSearchParams( window.location.search ).get( 'ref' ) || '';
+			const siteCount = currentUser?.site_count ?? 0;
+			recordOnboardingStart( ref, siteCount );
+			startOnboarding();
+		}
+	}, [ currentUser ] );
+}

--- a/client/landing/gutenboarding/hooks/use-track-onboarding-start.ts
+++ b/client/landing/gutenboarding/hooks/use-track-onboarding-start.ts
@@ -27,5 +27,5 @@ export default function useTrackOnboardingStart() {
 			recordOnboardingStart( ref, siteCount );
 			startOnboarding();
 		}
-	}, [ currentUser ] );
+	}, [ currentUser, hasOnboardingStarted, startOnboarding ] );
 }

--- a/client/landing/gutenboarding/lib/analytics/index.ts
+++ b/client/landing/gutenboarding/lib/analytics/index.ts
@@ -30,15 +30,16 @@ export function trackEventWithFlow( eventId: string, params = {}, flow = FLOW_ID
  * Analytics call at the start of the Gutenboarding flow
  *
  * @param {string} ref  The value of a `ref` query parameter, usually set by marketing landing pages
+ * @param {number} site_count The number of sites owned by the current user or 0 if there is no logged in user
  */
-export function recordOnboardingStart( ref = '' ): void {
+export function recordOnboardingStart( ref = '', site_count: number ): void {
 	if ( ! ref ) {
 		ref = new URLSearchParams( window.location.search ).get( 'ref' ) || ref;
 	}
 
-	trackEventWithFlow( 'calypso_newsite_start', { ref } );
+	trackEventWithFlow( 'calypso_newsite_start', { ref, site_count } );
 	// Also fire the signup start|complete events. See: pbmFJ6-95-p2
-	trackEventWithFlow( 'calypso_signup_start', { ref } );
+	trackEventWithFlow( 'calypso_signup_start', { ref, site_count } );
 }
 
 /**

--- a/client/landing/gutenboarding/stores/onboard/actions.ts
+++ b/client/landing/gutenboarding/stores/onboard/actions.ts
@@ -185,6 +185,10 @@ export function* updatePlan( planSlug: Plans.PlanSlug ) {
 	yield setPlan( plan );
 }
 
+export const startOnboarding = () => ( {
+	type: 'ONBOARDING_START' as const,
+} );
+
 export type OnboardAction = ReturnType<
 	| typeof addFeature
 	| typeof removeFeature
@@ -207,4 +211,5 @@ export type OnboardAction = ReturnType<
 	| typeof setSiteVertical
 	| typeof skipSiteVertical
 	| typeof togglePageLayout
+	| typeof startOnboarding
 >;

--- a/client/landing/gutenboarding/stores/onboard/index.ts
+++ b/client/landing/gutenboarding/stores/onboard/index.ts
@@ -40,6 +40,7 @@ registerStore< State >( STORE_KEY, {
 		'siteTitle',
 		'siteVertical',
 		'wasVerticalSkipped',
+		'hasOnboardingStarted',
 	],
 } );
 

--- a/client/landing/gutenboarding/stores/onboard/index.ts
+++ b/client/landing/gutenboarding/stores/onboard/index.ts
@@ -40,7 +40,6 @@ registerStore< State >( STORE_KEY, {
 		'siteTitle',
 		'siteVertical',
 		'wasVerticalSkipped',
-		'hasOnboardingStarted',
 	],
 } );
 

--- a/client/landing/gutenboarding/stores/onboard/reducer.ts
+++ b/client/landing/gutenboarding/stores/onboard/reducer.ts
@@ -221,6 +221,16 @@ const wasVerticalSkipped: Reducer< boolean, OnboardAction > = ( state = false, a
 	return state;
 };
 
+const hasOnboardingStarted: Reducer< boolean, OnboardAction > = ( state = false, action ) => {
+	if ( action.type === 'ONBOARDING_START' ) {
+		return true;
+	}
+	if ( action.type === 'RESET_ONBOARD_STORE' ) {
+		return false;
+	}
+	return state;
+};
+
 const reducer = combineReducers( {
 	domain,
 	domainSearch,
@@ -240,6 +250,7 @@ const reducer = combineReducers( {
 	wasVerticalSkipped,
 	isExperimental,
 	randomizedDesigns,
+	hasOnboardingStarted,
 } );
 
 export type State = ReturnType< typeof reducer >;

--- a/packages/data-stores/src/user/types.ts
+++ b/packages/data-stores/src/user/types.ts
@@ -28,6 +28,11 @@ export interface CurrentUser {
 	 * The bootstrapped user's locale variant, e.g. `es-mx`.
 	 */
 	localeVariant: string;
+
+	/**
+	 * The user's existing sites count.
+	 */
+	site_count: number;
 }
 
 export interface NewUser {


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Add `site_count` prop to `calypso_signup_start` and `calypso_newsite_start` tracks events.

#### Testing instructions
* Go to `/new` in a browser where you are logged in.
* Open console and run `localStorage.setItem('debug', 'calypso:analytics')` to log tracks events.
* Go to `/new?fresh`
* `calypso_signup_start` and `calypso_newsite_start` events should fire with prop `site_count: [your number of sites]`
* Refresh the page or open `/new` in another tab. No `*_start` event should fire unless local storage is cleared or a site is created.
* Repeat the steps above in a browser where there is no logged in user. `site_count` should be `0`.
