### PR TITLE
Styles: Move grow keyframes to animations

### DIFF
--- a/client/assets/stylesheets/shared/_animation.scss
+++ b/client/assets/stylesheets/shared/_animation.scss
@@ -23,6 +23,21 @@
 	}
 }
 
+// Useful for the checked state of radio button fields
+@keyframes grow {
+	0% {
+		transform: scale( 0.3 );
+	}
+
+	60% {
+		transform: scale( 1.15 );
+	}
+
+	100% {
+		transform: scale( 1 );
+	}
+}
+
 // Pulsing background color for loading placeholders
 @keyframes pulse-light {
 	50% {

--- a/client/assets/stylesheets/shared/_forms.scss
+++ b/client/assets/stylesheets/shared/_forms.scss
@@ -35,20 +35,6 @@ input[type='email'] {
 	direction: ltr;
 }
 
-@keyframes grow {
-	0% {
-		transform: scale( 0.3 );
-	}
-
-	60% {
-		transform: scale( 1.15 );
-	}
-
-	100% {
-		transform: scale( 1 );
-	}
-}
-
 select {
 	background: var( --color-surface )
 		url( 'data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+PHN2ZyB3aWR0aD0iMjBweCIgaGVpZ2h0PSIyMHB4IiB2aWV3Qm94PSIwIDAgMjAgMjAiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgeG1sbnM6c2tldGNoPSJodHRwOi8vd3d3LmJvaGVtaWFuY29kaW5nLmNvbS9za2V0Y2gvbnMiPiAgICAgICAgPHRpdGxlPmFycm93LWRvd248L3RpdGxlPiAgICA8ZGVzYz5DcmVhdGVkIHdpdGggU2tldGNoLjwvZGVzYz4gICAgPGRlZnM+PC9kZWZzPiAgICA8ZyBpZD0iUGFnZS0xIiBzdHJva2U9Im5vbmUiIHN0cm9rZS13aWR0aD0iMSIgZmlsbD0ibm9uZSIgZmlsbC1ydWxlPSJldmVub2RkIiBza2V0Y2g6dHlwZT0iTVNQYWdlIj4gICAgICAgIDxnIGlkPSJhcnJvdy1kb3duIiBza2V0Y2g6dHlwZT0iTVNBcnRib2FyZEdyb3VwIiBmaWxsPSIjQzhEN0UxIj4gICAgICAgICAgICA8cGF0aCBkPSJNMTUuNSw2IEwxNyw3LjUgTDEwLjI1LDE0LjI1IEwzLjUsNy41IEw1LDYgTDEwLjI1LDExLjI1IEwxNS41LDYgWiIgaWQ9IkRvd24tQXJyb3ciIHNrZXRjaDp0eXBlPSJNU1NoYXBlR3JvdXAiPjwvcGF0aD4gICAgICAgIDwvZz4gICAgPC9nPjwvc3ZnPg==' )


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Move the `grow` keyframes to `animations.scss` where the rest of the custom animation keyframes live.

#### Testing instructions

* Go to `/devdocs/design/form-fields`
* Verify that when checking a checkbox, the little checked circle inside still animates in a growing notion.

#### Context

Discovered while working on #45259.