### PR TITLE
Editing Toolkit: Load patterns after core patterns

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -271,7 +271,7 @@ function load_block_patterns() {
 
 	Block_Patterns::get_instance();
 }
-add_action( 'plugins_loaded', __NAMESPACE__ . '\load_block_patterns' );
+add_action( 'init', __NAMESPACE__ . '\load_block_patterns', 20 );
 
 /**
  * Load Premium Content Block


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Core patterns are added at `init` action.
https://github.com/WordPress/WordPress/blob/3dda74c3377243797ceffb429f94e0ea63ad6d75/wp-includes/default-filters.php#L304

We were using `plugins_loaded` action to add our patterns and remove core patterns. Since `plugins_loaded` runs before `init` action, core patterns weren't being removed.

This PR changes `plugins_loaded` to `init` with a priority of `20` so it runs after the core hook. Which means core patterns will be registered by this time and they will be removed successfully.

#### Testing instructions

Testing locally

* run yarn dev
* cd to wp-calypso/apps/editing-toolkit
* run yarn wp-env start
* You should be able to access a WordPress instance at localhost:4013
* Make sure core patterns aren't present ( Except Two Columns of Text )

Fixes #44709
