### PR TITLE
Skip Jetpack "New Site" screen when creating a new site

### DIFF
--- a/client/blocks/inline-help/admin-sections.js
+++ b/client/blocks/inline-help/admin-sections.js
@@ -367,7 +367,7 @@ export const adminSections = memoize( ( siteId, siteSlug, state ) => [
 	},
 	{
 		title: translate( 'Create a new site' ),
-		link: '/jetpack/new?ref=calypso-selector',
+		link: '/start',
 		synonyms: [ 'site' ],
 		icon: 'cog',
 	},

--- a/client/blocks/inline-help/admin-sections.js
+++ b/client/blocks/inline-help/admin-sections.js
@@ -8,6 +8,7 @@ import { getCustomizerUrl } from 'state/sites/selectors';
 /**
  * Internal Dependencies
  */
+import config from 'config';
 import { getLocaleSlug } from 'lib/i18n-utils';
 import { SUPPORT_TYPE_ADMIN_SECTION } from './constants';
 
@@ -367,7 +368,7 @@ export const adminSections = memoize( ( siteId, siteSlug, state ) => [
 	},
 	{
 		title: translate( 'Create a new site' ),
-		link: '/start',
+		link: `${ config( 'signup_url' ) }?ref=calypso-selector`,
 		synonyms: [ 'site' ],
 		icon: 'cog',
 	},

--- a/client/components/site-selector/add-site.jsx
+++ b/client/components/site-selector/add-site.jsx
@@ -13,10 +13,6 @@ import { Button } from '@automattic/components';
 import { recordTracksEvent } from 'state/analytics/actions';
 
 class SiteSelectorAddSite extends Component {
-	getAddNewSiteUrl() {
-		return '/jetpack/new/?ref=calypso-selector';
-	}
-
 	recordAddNewSite = () => {
 		this.props.recordTracksEvent( 'calypso_add_new_wordpress_click' );
 	};
@@ -25,7 +21,7 @@ class SiteSelectorAddSite extends Component {
 		const { translate } = this.props;
 		return (
 			<span className="site-selector__add-new-site">
-				<Button borderless href={ this.getAddNewSiteUrl() } onClick={ this.recordAddNewSite }>
+				<Button borderless href="/start" onClick={ this.recordAddNewSite }>
 					<Gridicon icon="add-outline" /> { translate( 'Add new site' ) }
 				</Button>
 			</span>

--- a/client/components/site-selector/add-site.jsx
+++ b/client/components/site-selector/add-site.jsx
@@ -9,6 +9,7 @@ import Gridicon from 'components/gridicon';
 /**
  * Internal dependencies
  */
+import config from 'config';
 import { Button } from '@automattic/components';
 import { recordTracksEvent } from 'state/analytics/actions';
 
@@ -21,7 +22,11 @@ class SiteSelectorAddSite extends Component {
 		const { translate } = this.props;
 		return (
 			<span className="site-selector__add-new-site">
-				<Button borderless href="/start" onClick={ this.recordAddNewSite }>
+				<Button
+					borderless
+					href={ `${ config( 'signup_url' ) }?ref=calypso-selector` }
+					onClick={ this.recordAddNewSite }
+				>
 					<Gridicon icon="add-outline" /> { translate( 'Add new site' ) }
 				</Button>
 			</span>

--- a/client/jetpack-connect/index.js
+++ b/client/jetpack-connect/index.js
@@ -154,7 +154,7 @@ export default function () {
 
 	page( '/jetpack/sso/:siteId?/:ssoNonce?', controller.sso, makeLayout, clientRender );
 	page( '/jetpack/sso/*', controller.sso, makeLayout, clientRender );
-	// Redirect to '/start' instead of showing Jetpack modal
-	page( '/jetpack/new', '/start' );
+	// Skip Jetpack modal
+	page( '/jetpack/new', config( 'signup_url' ) );
 	page( '/jetpack/new/*', '/jetpack/connect' );
 }

--- a/client/jetpack-connect/index.js
+++ b/client/jetpack-connect/index.js
@@ -154,7 +154,10 @@ export default function () {
 
 	page( '/jetpack/sso/:siteId?/:ssoNonce?', controller.sso, makeLayout, clientRender );
 	page( '/jetpack/sso/*', controller.sso, makeLayout, clientRender );
-	// Skip Jetpack modal
+	// The /jetpack/new route previously allowed to create a .com site and
+	// connect a Jetpack site. The redirect rule will skip this page and take
+	// the user directly to the .com site creation flow.
+	// See https://github.com/Automattic/wp-calypso/issues/45486
 	page( '/jetpack/new', config( 'signup_url' ) );
 	page( '/jetpack/new/*', '/jetpack/connect' );
 }

--- a/client/jetpack-connect/index.js
+++ b/client/jetpack-connect/index.js
@@ -154,6 +154,7 @@ export default function () {
 
 	page( '/jetpack/sso/:siteId?/:ssoNonce?', controller.sso, makeLayout, clientRender );
 	page( '/jetpack/sso/*', controller.sso, makeLayout, clientRender );
-	page( '/jetpack/new', controller.newSite, makeLayout, clientRender );
+	// Redirect to '/start' instead of showing Jetpack modal
+	page( '/jetpack/new', '/start' );
 	page( '/jetpack/new/*', '/jetpack/connect' );
 }

--- a/client/me/account-close/confirm-dialog.jsx
+++ b/client/me/account-close/confirm-dialog.jsx
@@ -76,7 +76,7 @@ class AccountCloseConfirmDialog extends React.Component {
 			{
 				englishText: 'Start a new site',
 				text: translate( 'Start a new site' ),
-				href: '/jetpack/new',
+				href: '/start',
 				supportLink:
 					'https://wordpress.com/support/create-a-blog/#adding-a-new-site-or-blog-to-an-existing-account',
 				supportPostId: 3991,

--- a/client/me/account-close/confirm-dialog.jsx
+++ b/client/me/account-close/confirm-dialog.jsx
@@ -10,6 +10,7 @@ import page from 'page';
 /**
  * Internal dependencies
  */
+import config from 'config';
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Dialog, Button } from '@automattic/components';
 import Gridicon from 'components/gridicon';
@@ -76,7 +77,7 @@ class AccountCloseConfirmDialog extends React.Component {
 			{
 				englishText: 'Start a new site',
 				text: translate( 'Start a new site' ),
-				href: '/start',
+				href: config( 'signup_url' ),
 				supportLink:
 					'https://wordpress.com/support/create-a-blog/#adding-a-new-site-or-blog-to-an-existing-account',
 				supportPostId: 3991,

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -847,13 +847,10 @@ export class MySitesSidebar extends Component {
 		this.props.recordGoogleEvent( 'Sidebar', 'Clicked WP Admin' );
 	};
 
-	focusContent = () => {
+	trackAddNewSiteClick = () => {
+		this.props.recordTracksEvent( 'calypso_add_new_wordpress_click' );
 		this.props.setLayoutFocus( 'content' );
 	};
-
-	getAddNewSiteUrl() {
-		return '/jetpack/new/?ref=calypso-selector';
-	}
 
 	addNewSite() {
 		if ( this.props.currentUser.visible_site_count > 1 ) {
@@ -863,8 +860,8 @@ export class MySitesSidebar extends Component {
 		return (
 			<SidebarItem
 				label={ this.props.translate( 'Add new site' ) }
-				link={ this.getAddNewSiteUrl() }
-				onNavigate={ this.focusContent }
+				link="/start"
+				onNavigate={ this.trackAddNewSiteClick }
 				icon="add-outline"
 			/>
 		);

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -13,7 +13,7 @@ import { ProgressBar } from '@automattic/components';
 /**
  * Internal dependencies
  */
-import { isEnabled } from 'config';
+import config, { isEnabled } from 'config';
 import CurrentSite from 'my-sites/current-site';
 import ExpandableSidebarMenu from 'layout/sidebar/expandable';
 import ExternalLink from 'components/external-link';
@@ -860,7 +860,7 @@ export class MySitesSidebar extends Component {
 		return (
 			<SidebarItem
 				label={ this.props.translate( 'Add new site' ) }
-				link="/start"
+				link={ `${ config( 'signup_url' ) }?ref=calypso-selector` }
 				onNavigate={ this.trackAddNewSiteClick }
 				icon="add-outline"
 			/>

--- a/test/e2e/specs/wp-signup-spec.js
+++ b/test/e2e/specs/wp-signup-spec.js
@@ -14,10 +14,10 @@ import * as dataHelper from '../lib/data-helper.js';
 
 import WPHomePage from '../lib/pages/wp-home-page.js';
 import StartPage from '../lib/pages/signup/start-page.js';
-import JetpackAddNewSitePage from '../lib/pages/signup/jetpack-add-new-site-page';
+// import JetpackAddNewSitePage from '../lib/pages/signup/jetpack-add-new-site-page';
 
 import AboutPage from '../lib/pages/signup/about-page.js';
-import CustomerHomePage from '../lib/pages/customer-home-page';
+// import CustomerHomePage from '../lib/pages/customer-home-page';
 import DomainFirstPage from '../lib/pages/signup/domain-first-page';
 import ReaderLandingPage from '../lib/pages/signup/reader-landing-page';
 import PickAPlanPage from '../lib/pages/signup/pick-a-plan-page.js';
@@ -26,8 +26,8 @@ import CheckOutPage from '../lib/pages/signup/checkout-page';
 import ImportFromURLPage from '../lib/pages/signup/import-from-url-page';
 import SiteTypePage from '../lib/pages/signup/site-type-page';
 import SiteTitlePage from '../lib/pages/signup/site-title-page';
-import LoginPage from '../lib/pages/login-page';
-import MagicLoginPage from '../lib/pages/magic-login-page';
+// import LoginPage from '../lib/pages/login-page';
+// import MagicLoginPage from '../lib/pages/magic-login-page';
 import ReaderPage from '../lib/pages/reader-page';
 import DomainOnlySettingsPage from '../lib/pages/domain-only-settings-page';
 import DomainDetailsPage from '../lib/pages/domain-details-page';
@@ -55,7 +55,7 @@ import LaunchSiteFlow from '../lib/flows/launch-site-flow.js';
 import ActivateAccountFlow from '../lib/flows/activate-account-flow';
 
 import * as sharedSteps from '../lib/shared-steps/wp-signup-spec';
-import AccountSettingsPage from '../lib/pages/account/account-settings-page';
+// import AccountSettingsPage from '../lib/pages/account/account-settings-page';
 import MyHomePage from '../lib/pages/my-home-page';
 import GutenbergEditorComponent from '../lib/gutenberg/gutenberg-editor-component';
 
@@ -78,117 +78,118 @@ before( async function () {
 describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 	this.timeout( mochaTimeOut );
 
-	describe( 'Sign up for a free WordPress.com site from the Jetpack new site page, and log in via a magic link @signup @email', function () {
-		const blogName = dataHelper.getNewBlogName();
-		// const expectedBlogAddresses = dataHelper.getExpectedFreeAddresses( blogName );
-		const emailAddress = dataHelper.getEmailAddress( blogName, signupInboxId );
-		let magicLoginLink;
+	// eslint-disable-next-line jest/no-commented-out-tests
+	// describe( 'Sign up for a free WordPress.com site from the Jetpack new site page, and log in via a magic link @signup @email', function () {
+	// 	const blogName = dataHelper.getNewBlogName();
+	// 	// const expectedBlogAddresses = dataHelper.getExpectedFreeAddresses( blogName );
+	// 	const emailAddress = dataHelper.getEmailAddress( blogName, signupInboxId );
+	// 	let magicLoginLink;
 
-		before( async function () {
-			return await driverManager.ensureNotLoggedIn( driver );
-		} );
+	// 	before( async function () {
+	// 		return await driverManager.ensureNotLoggedIn( driver );
+	// 	} );
 
-		step(
-			'Can visit the Jetpack Add New Site page and choose "Create a shiny new WordPress.com site"',
-			async function () {
-				const jetpackAddNewSitePage = await JetpackAddNewSitePage.Visit( driver );
-				await jetpackAddNewSitePage.createNewWordPressDotComSite();
-			}
-		);
+	// 	step(
+	// 		'Can visit the Jetpack Add New Site page and choose "Create a shiny new WordPress.com site"',
+	// 		async function () {
+	// 			const jetpackAddNewSitePage = await JetpackAddNewSitePage.Visit( driver );
+	// 			await jetpackAddNewSitePage.createNewWordPressDotComSite();
+	// 		}
+	// 	);
 
-		step( 'Can see the account page and enter account details', async function () {
-			const createYourAccountPage = await CreateYourAccountPage.Expect( driver );
-			return await createYourAccountPage.enterAccountDetailsAndSubmit(
-				emailAddress,
-				blogName,
-				passwordForTestAccounts
-			);
-		} );
+	// 	step( 'Can see the account page and enter account details', async function () {
+	// 		const createYourAccountPage = await CreateYourAccountPage.Expect( driver );
+	// 		return await createYourAccountPage.enterAccountDetailsAndSubmit(
+	// 			emailAddress,
+	// 			blogName,
+	// 			passwordForTestAccounts
+	// 		);
+	// 	} );
 
-		step(
-			'Can then see the domains page, and Can search for a blog name, can see and select a free .wordpress address in the results',
-			async function () {
-				const findADomainComponent = await FindADomainComponent.Expect( driver );
-				await findADomainComponent.searchForBlogNameAndWaitForResults( blogName );
-				// See https://github.com/Automattic/wp-calypso/pull/38641/
-				// await findADomainComponent.checkAndRetryForFreeBlogAddresses(
-				// 	expectedBlogAddresses,
-				// 	blogName
-				// );
-				// const actualAddress = await findADomainComponent.freeBlogAddress();
-				// assert(
-				// 	expectedBlogAddresses.indexOf( actualAddress ) > -1,
-				// 	`The displayed free blog address: '${ actualAddress }' was not the expected addresses: '${ expectedBlogAddresses }'`
-				// );
-				return await findADomainComponent.selectFreeAddress();
-			}
-		);
+	// 	step(
+	// 		'Can then see the domains page, and Can search for a blog name, can see and select a free .wordpress address in the results',
+	// 		async function () {
+	// 			const findADomainComponent = await FindADomainComponent.Expect( driver );
+	// 			await findADomainComponent.searchForBlogNameAndWaitForResults( blogName );
+	// 			// See https://github.com/Automattic/wp-calypso/pull/38641/
+	// 			// await findADomainComponent.checkAndRetryForFreeBlogAddresses(
+	// 			// 	expectedBlogAddresses,
+	// 			// 	blogName
+	// 			// );
+	// 			// const actualAddress = await findADomainComponent.freeBlogAddress();
+	// 			// assert(
+	// 			// 	expectedBlogAddresses.indexOf( actualAddress ) > -1,
+	// 			// 	`The displayed free blog address: '${ actualAddress }' was not the expected addresses: '${ expectedBlogAddresses }'`
+	// 			// );
+	// 			return await findADomainComponent.selectFreeAddress();
+	// 		}
+	// 	);
 
-		step( 'Can see the plans page and pick the free plan', async function () {
-			const pickAPlanPage = await PickAPlanPage.Expect( driver );
-			return await pickAPlanPage.selectFreePlan();
-		} );
+	// 	step( 'Can see the plans page and pick the free plan', async function () {
+	// 		const pickAPlanPage = await PickAPlanPage.Expect( driver );
+	// 		return await pickAPlanPage.selectFreePlan();
+	// 	} );
 
-		step(
-			'Can then see the sign up processing page which will finish automatically move along',
-			async function () {
-				return await new SignUpStep( driver ).continueAlong( blogName, passwordForTestAccounts );
-			}
-		);
+	// 	step(
+	// 		'Can then see the sign up processing page which will finish automatically move along',
+	// 		async function () {
+	// 			return await new SignUpStep( driver ).continueAlong( blogName, passwordForTestAccounts );
+	// 		}
+	// 	);
 
-		sharedSteps.canSeeTheOnboardingChecklist();
+	// 	sharedSteps.canSeeTheOnboardingChecklist();
 
-		step( 'Can log out and request a magic link', async function () {
-			if ( process.env.HORIZON_TESTS === 'true' ) {
-				return this.skip();
-			}
-			await driverManager.ensureNotLoggedIn( driver );
-			const loginPage = await LoginPage.Visit( driver );
-			return await loginPage.requestMagicLink( emailAddress );
-		} );
+	// 	step( 'Can log out and request a magic link', async function () {
+	// 		if ( process.env.HORIZON_TESTS === 'true' ) {
+	// 			return this.skip();
+	// 		}
+	// 		await driverManager.ensureNotLoggedIn( driver );
+	// 		const loginPage = await LoginPage.Visit( driver );
+	// 		return await loginPage.requestMagicLink( emailAddress );
+	// 	} );
 
-		step( 'Can see email containing magic link', async function () {
-			if ( process.env.HORIZON_TESTS === 'true' ) {
-				return this.skip();
-			}
-			const emailClient = new EmailClient( signupInboxId );
-			const validator = ( emails ) =>
-				emails.find( ( email ) => email.subject.includes( 'WordPress.com' ) );
-			const emails = await emailClient.pollEmailsByRecipient( emailAddress, validator );
-			assert.strictEqual(
-				emails.length,
-				2,
-				'The number of newly registered emails is not equal to 2 (activation and magic link)'
-			);
-			for ( const email of emails ) {
-				if ( email.subject.includes( 'WordPress.com' ) ) {
-					return ( magicLoginLink = email.html.links[ 0 ].href );
-				}
-			}
-			return assert(
-				magicLoginLink !== undefined,
-				'Could not locate the magic login link email link'
-			);
-		} );
+	// 	step( 'Can see email containing magic link', async function () {
+	// 		if ( process.env.HORIZON_TESTS === 'true' ) {
+	// 			return this.skip();
+	// 		}
+	// 		const emailClient = new EmailClient( signupInboxId );
+	// 		const validator = ( emails ) =>
+	// 			emails.find( ( email ) => email.subject.includes( 'WordPress.com' ) );
+	// 		const emails = await emailClient.pollEmailsByRecipient( emailAddress, validator );
+	// 		assert.strictEqual(
+	// 			emails.length,
+	// 			2,
+	// 			'The number of newly registered emails is not equal to 2 (activation and magic link)'
+	// 		);
+	// 		for ( const email of emails ) {
+	// 			if ( email.subject.includes( 'WordPress.com' ) ) {
+	// 				return ( magicLoginLink = email.html.links[ 0 ].href );
+	// 			}
+	// 		}
+	// 		return assert(
+	// 			magicLoginLink !== undefined,
+	// 			'Could not locate the magic login link email link'
+	// 		);
+	// 	} );
 
-		step( 'Can visit the magic link and we should be logged in', async function () {
-			if ( process.env.HORIZON_TESTS === 'true' ) {
-				return this.skip();
-			}
-			await driver.get( magicLoginLink );
-			const magicLoginPage = await MagicLoginPage.Expect( driver );
-			await magicLoginPage.finishLogin();
-			try {
-				await CustomerHomePage.Expect( driver );
-			} catch ( e ) {
-				await ReaderPage.Expect( driver );
-			}
-		} );
+	// 	step( 'Can visit the magic link and we should be logged in', async function () {
+	// 		if ( process.env.HORIZON_TESTS === 'true' ) {
+	// 			return this.skip();
+	// 		}
+	// 		await driver.get( magicLoginLink );
+	// 		const magicLoginPage = await MagicLoginPage.Expect( driver );
+	// 		await magicLoginPage.finishLogin();
+	// 		try {
+	//  		await CustomerHomePage.Expect( driver );
+	// 		} catch ( e ) {
+	// 			await ReaderPage.Expect( driver );
+	// 		}
+	// 	} );
 
-		after( 'Can delete our newly created account', async function () {
-			return await new DeleteAccountFlow( driver ).deleteAccount( blogName );
-		} );
-	} );
+	// 	after( 'Can delete our newly created account', async function () {
+	// 		return await new DeleteAccountFlow( driver ).deleteAccount( blogName );
+	// 	} );
+	// } );
 
 	describe( 'Sign up for a free site, see the site preview, activate email and can publish @signup', function () {
 		const blogName = dataHelper.getNewBlogName();
@@ -1647,99 +1648,99 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 
 	// Disable test while Passwordless functionality is completely switched off
 	// https://github.com/Automattic/wp-calypso/pull/37054
-	describe.skip( 'Passwordless signup @parallel', function () {
-		const blogName = dataHelper.getNewBlogName();
-		const emailAddress = dataHelper.getEmailAddress( blogName, signupInboxId );
-		const expectedBlogAddresses = dataHelper.getExpectedFreeAddresses( blogName );
-		let verificationLink;
+	// describe.skip( 'Passwordless signup @parallel', function () {
+	// 	const blogName = dataHelper.getNewBlogName();
+	// 	const emailAddress = dataHelper.getEmailAddress( blogName, signupInboxId );
+	// 	const expectedBlogAddresses = dataHelper.getExpectedFreeAddresses( blogName );
+	// 	let verificationLink;
 
-		before( async function () {
-			await driverManager.ensureNotLoggedIn( driver );
-		} );
+	// 	before( async function () {
+	// 		await driverManager.ensureNotLoggedIn( driver );
+	// 	} );
 
-		step(
-			'Can visit the Jetpack Add New Site page and choose "Create a shiny new WordPress.com site"',
-			async function () {
-				const jetpackAddNewSitePage = await JetpackAddNewSitePage.Visit( driver );
-				await jetpackAddNewSitePage.overrideABTestInLocalStorage(
-					'passwordlessSignup',
-					'passwordless'
-				);
-				return await jetpackAddNewSitePage.createNewWordPressDotComSite();
-			}
-		);
+	// 	step(
+	// 		'Can visit the Jetpack Add New Site page and choose "Create a shiny new WordPress.com site"',
+	// 		async function () {
+	// 			const jetpackAddNewSitePage = await JetpackAddNewSitePage.Visit( driver );
+	// 			await jetpackAddNewSitePage.overrideABTestInLocalStorage(
+	// 				'passwordlessSignup',
+	// 				'passwordless'
+	// 			);
+	// 			return await jetpackAddNewSitePage.createNewWordPressDotComSite();
+	// 		}
+	// 	);
 
-		step( 'Can see passwordless Start page and enter an email', async function () {
-			const createYourAccountPage = await CreateYourAccountPage.Expect( driver );
-			return await createYourAccountPage.enterEmailAndSubmit( emailAddress );
-		} );
+	// 	step( 'Can see passwordless Start page and enter an email', async function () {
+	// 		const createYourAccountPage = await CreateYourAccountPage.Expect( driver );
+	// 		return await createYourAccountPage.enterEmailAndSubmit( emailAddress );
+	// 	} );
 
-		step(
-			'Can then see the domains page, and Can search for a blog name, can see and select a free .wordpress address in the results',
-			async function () {
-				const findADomainComponent = await FindADomainComponent.Expect( driver );
-				await findADomainComponent.searchForBlogNameAndWaitForResults( blogName );
-				await findADomainComponent.checkAndRetryForFreeBlogAddresses(
-					expectedBlogAddresses,
-					blogName
-				);
-				const actualAddress = await findADomainComponent.freeBlogAddress();
-				assert(
-					expectedBlogAddresses.indexOf( actualAddress ) > -1,
-					`The displayed free blog address: '${ actualAddress }' was not the expected addresses: '${ expectedBlogAddresses }'`
-				);
-				return await findADomainComponent.selectFreeAddress();
-			}
-		);
+	// 	step(
+	// 		'Can then see the domains page, and Can search for a blog name, can see and select a free .wordpress address in the results',
+	// 		async function () {
+	// 			const findADomainComponent = await FindADomainComponent.Expect( driver );
+	// 			await findADomainComponent.searchForBlogNameAndWaitForResults( blogName );
+	// 			await findADomainComponent.checkAndRetryForFreeBlogAddresses(
+	// 				expectedBlogAddresses,
+	// 				blogName
+	// 			);
+	// 			const actualAddress = await findADomainComponent.freeBlogAddress();
+	// 			assert(
+	// 				expectedBlogAddresses.indexOf( actualAddress ) > -1,
+	// 				`The displayed free blog address: '${ actualAddress }' was not the expected addresses: '${ expectedBlogAddresses }'`
+	// 			);
+	// 			return await findADomainComponent.selectFreeAddress();
+	// 		}
+	// 	);
 
-		step( 'Can see the plans page and pick the free plan', async function () {
-			const pickAPlanPage = await PickAPlanPage.Expect( driver );
-			return await pickAPlanPage.selectFreePlan();
-		} );
+	// 	step( 'Can see the plans page and pick the free plan', async function () {
+	// 		const pickAPlanPage = await PickAPlanPage.Expect( driver );
+	// 		return await pickAPlanPage.selectFreePlan();
+	// 	} );
 
-		step(
-			'Can then see the sign up processing page which will finish automatically move along',
-			async function () {
-				return await new SignUpStep( driver ).continueAlong( blogName, passwordForTestAccounts );
-			}
-		);
+	// 	step(
+	// 		'Can then see the sign up processing page which will finish automatically move along',
+	// 		async function () {
+	// 			return await new SignUpStep( driver ).continueAlong( blogName, passwordForTestAccounts );
+	// 		}
+	// 	);
 
-		sharedSteps.canSeeTheOnboardingChecklist();
+	// 	sharedSteps.canSeeTheOnboardingChecklist();
 
-		step( 'Can see email containing verification link', async function () {
-			if ( process.env.HORIZON_TESTS === 'true' ) {
-				return this.skip();
-			}
+	// 	step( 'Can see email containing verification link', async function () {
+	// 		if ( process.env.HORIZON_TESTS === 'true' ) {
+	// 			return this.skip();
+	// 		}
 
-			const emailClient = await new EmailClient( signupInboxId );
-			const validator = ( emails ) =>
-				emails.find( ( email ) => email.subject.includes( emailAddress ) );
-			const emails = await emailClient.pollEmailsByRecipient( emailAddress, validator );
+	// 		const emailClient = await new EmailClient( signupInboxId );
+	// 		const validator = ( emails ) =>
+	// 			emails.find( ( email ) => email.subject.includes( emailAddress ) );
+	// 		const emails = await emailClient.pollEmailsByRecipient( emailAddress, validator );
 
-			for ( const email of emails ) {
-				if ( email.subject.includes( emailAddress ) ) {
-					return ( verificationLink = email.html.links[ 0 ].href );
-				}
-			}
-			return assert( verificationLink !== undefined, 'Could not locate the login link email.' );
-		} );
+	// 		for ( const email of emails ) {
+	// 			if ( email.subject.includes( emailAddress ) ) {
+	// 				return ( verificationLink = email.html.links[ 0 ].href );
+	// 			}
+	// 		}
+	// 		return assert( verificationLink !== undefined, 'Could not locate the login link email.' );
+	// 	} );
 
-		step( 'Can open verification link and verify account', async function () {
-			if ( process.env.HORIZON_TESTS === 'true' ) {
-				return this.skip();
-			}
-			await driver.get( verificationLink );
-			const myHomePage = await MyHomePage.Expect( this.driver );
-			return await myHomePage.isEmailVerified();
-		} );
+	// 	step( 'Can open verification link and verify account', async function () {
+	// 		if ( process.env.HORIZON_TESTS === 'true' ) {
+	// 			return this.skip();
+	// 		}
+	// 		await driver.get( verificationLink );
+	// 		const myHomePage = await MyHomePage.Expect( this.driver );
+	// 		return await myHomePage.isEmailVerified();
+	// 	} );
 
-		after( 'Can delete our newly created account', async function () {
-			// Get username from Account settings page
-			// (it's automatically generated for passwordless signup)
-			const accountSettingsPage = await AccountSettingsPage.Visit( this.driver );
-			const username = await accountSettingsPage.getUsername();
+	// 	after( 'Can delete our newly created account', async function () {
+	// 		// Get username from Account settings page
+	// 		// (it's automatically generated for passwordless signup)
+	// 		const accountSettingsPage = await AccountSettingsPage.Visit( this.driver );
+	// 		const username = await accountSettingsPage.getUsername();
 
-			return await new DeleteAccountFlow( driver ).deleteAccount( username );
-		} );
-	} );
+	// 		return await new DeleteAccountFlow( driver ).deleteAccount( username );
+	// 	} );
+	// } );
 } );

--- a/test/e2e/specs/wp-signup-spec.js
+++ b/test/e2e/specs/wp-signup-spec.js
@@ -14,10 +14,10 @@ import * as dataHelper from '../lib/data-helper.js';
 
 import WPHomePage from '../lib/pages/wp-home-page.js';
 import StartPage from '../lib/pages/signup/start-page.js';
-// import JetpackAddNewSitePage from '../lib/pages/signup/jetpack-add-new-site-page';
+import JetpackAddNewSitePage from '../lib/pages/signup/jetpack-add-new-site-page';
 
 import AboutPage from '../lib/pages/signup/about-page.js';
-// import CustomerHomePage from '../lib/pages/customer-home-page';
+import CustomerHomePage from '../lib/pages/customer-home-page';
 import DomainFirstPage from '../lib/pages/signup/domain-first-page';
 import ReaderLandingPage from '../lib/pages/signup/reader-landing-page';
 import PickAPlanPage from '../lib/pages/signup/pick-a-plan-page.js';
@@ -26,8 +26,8 @@ import CheckOutPage from '../lib/pages/signup/checkout-page';
 import ImportFromURLPage from '../lib/pages/signup/import-from-url-page';
 import SiteTypePage from '../lib/pages/signup/site-type-page';
 import SiteTitlePage from '../lib/pages/signup/site-title-page';
-// import LoginPage from '../lib/pages/login-page';
-// import MagicLoginPage from '../lib/pages/magic-login-page';
+import LoginPage from '../lib/pages/login-page';
+import MagicLoginPage from '../lib/pages/magic-login-page';
 import ReaderPage from '../lib/pages/reader-page';
 import DomainOnlySettingsPage from '../lib/pages/domain-only-settings-page';
 import DomainDetailsPage from '../lib/pages/domain-details-page';
@@ -55,7 +55,7 @@ import LaunchSiteFlow from '../lib/flows/launch-site-flow.js';
 import ActivateAccountFlow from '../lib/flows/activate-account-flow';
 
 import * as sharedSteps from '../lib/shared-steps/wp-signup-spec';
-// import AccountSettingsPage from '../lib/pages/account/account-settings-page';
+import AccountSettingsPage from '../lib/pages/account/account-settings-page';
 import MyHomePage from '../lib/pages/my-home-page';
 import GutenbergEditorComponent from '../lib/gutenberg/gutenberg-editor-component';
 
@@ -78,118 +78,117 @@ before( async function () {
 describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 	this.timeout( mochaTimeOut );
 
-	// eslint-disable-next-line jest/no-commented-out-tests
-	// describe( 'Sign up for a free WordPress.com site from the Jetpack new site page, and log in via a magic link @signup @email', function () {
-	// 	const blogName = dataHelper.getNewBlogName();
-	// 	// const expectedBlogAddresses = dataHelper.getExpectedFreeAddresses( blogName );
-	// 	const emailAddress = dataHelper.getEmailAddress( blogName, signupInboxId );
-	// 	let magicLoginLink;
+	describe( 'Sign up for a free WordPress.com site from the Jetpack new site page, and log in via a magic link @signup @email', function () {
+		const blogName = dataHelper.getNewBlogName();
+		// const expectedBlogAddresses = dataHelper.getExpectedFreeAddresses( blogName );
+		const emailAddress = dataHelper.getEmailAddress( blogName, signupInboxId );
+		let magicLoginLink;
 
-	// 	before( async function () {
-	// 		return await driverManager.ensureNotLoggedIn( driver );
-	// 	} );
+		before( async function () {
+			return await driverManager.ensureNotLoggedIn( driver );
+		} );
 
-	// 	step(
-	// 		'Can visit the Jetpack Add New Site page and choose "Create a shiny new WordPress.com site"',
-	// 		async function () {
-	// 			const jetpackAddNewSitePage = await JetpackAddNewSitePage.Visit( driver );
-	// 			await jetpackAddNewSitePage.createNewWordPressDotComSite();
-	// 		}
-	// 	);
+		step(
+			'Can visit the Jetpack Add New Site page and choose "Create a shiny new WordPress.com site"',
+			async function () {
+				const jetpackAddNewSitePage = await JetpackAddNewSitePage.Visit( driver );
+				await jetpackAddNewSitePage.createNewWordPressDotComSite();
+			}
+		);
 
-	// 	step( 'Can see the account page and enter account details', async function () {
-	// 		const createYourAccountPage = await CreateYourAccountPage.Expect( driver );
-	// 		return await createYourAccountPage.enterAccountDetailsAndSubmit(
-	// 			emailAddress,
-	// 			blogName,
-	// 			passwordForTestAccounts
-	// 		);
-	// 	} );
+		step( 'Can see the account page and enter account details', async function () {
+			const createYourAccountPage = await CreateYourAccountPage.Expect( driver );
+			return await createYourAccountPage.enterAccountDetailsAndSubmit(
+				emailAddress,
+				blogName,
+				passwordForTestAccounts
+			);
+		} );
 
-	// 	step(
-	// 		'Can then see the domains page, and Can search for a blog name, can see and select a free .wordpress address in the results',
-	// 		async function () {
-	// 			const findADomainComponent = await FindADomainComponent.Expect( driver );
-	// 			await findADomainComponent.searchForBlogNameAndWaitForResults( blogName );
-	// 			// See https://github.com/Automattic/wp-calypso/pull/38641/
-	// 			// await findADomainComponent.checkAndRetryForFreeBlogAddresses(
-	// 			// 	expectedBlogAddresses,
-	// 			// 	blogName
-	// 			// );
-	// 			// const actualAddress = await findADomainComponent.freeBlogAddress();
-	// 			// assert(
-	// 			// 	expectedBlogAddresses.indexOf( actualAddress ) > -1,
-	// 			// 	`The displayed free blog address: '${ actualAddress }' was not the expected addresses: '${ expectedBlogAddresses }'`
-	// 			// );
-	// 			return await findADomainComponent.selectFreeAddress();
-	// 		}
-	// 	);
+		step(
+			'Can then see the domains page, and Can search for a blog name, can see and select a free .wordpress address in the results',
+			async function () {
+				const findADomainComponent = await FindADomainComponent.Expect( driver );
+				await findADomainComponent.searchForBlogNameAndWaitForResults( blogName );
+				// See https://github.com/Automattic/wp-calypso/pull/38641/
+				// await findADomainComponent.checkAndRetryForFreeBlogAddresses(
+				// 	expectedBlogAddresses,
+				// 	blogName
+				// );
+				// const actualAddress = await findADomainComponent.freeBlogAddress();
+				// assert(
+				// 	expectedBlogAddresses.indexOf( actualAddress ) > -1,
+				// 	`The displayed free blog address: '${ actualAddress }' was not the expected addresses: '${ expectedBlogAddresses }'`
+				// );
+				return await findADomainComponent.selectFreeAddress();
+			}
+		);
 
-	// 	step( 'Can see the plans page and pick the free plan', async function () {
-	// 		const pickAPlanPage = await PickAPlanPage.Expect( driver );
-	// 		return await pickAPlanPage.selectFreePlan();
-	// 	} );
+		step( 'Can see the plans page and pick the free plan', async function () {
+			const pickAPlanPage = await PickAPlanPage.Expect( driver );
+			return await pickAPlanPage.selectFreePlan();
+		} );
 
-	// 	step(
-	// 		'Can then see the sign up processing page which will finish automatically move along',
-	// 		async function () {
-	// 			return await new SignUpStep( driver ).continueAlong( blogName, passwordForTestAccounts );
-	// 		}
-	// 	);
+		step(
+			'Can then see the sign up processing page which will finish automatically move along',
+			async function () {
+				return await new SignUpStep( driver ).continueAlong( blogName, passwordForTestAccounts );
+			}
+		);
 
-	// 	sharedSteps.canSeeTheOnboardingChecklist();
+		sharedSteps.canSeeTheOnboardingChecklist();
 
-	// 	step( 'Can log out and request a magic link', async function () {
-	// 		if ( process.env.HORIZON_TESTS === 'true' ) {
-	// 			return this.skip();
-	// 		}
-	// 		await driverManager.ensureNotLoggedIn( driver );
-	// 		const loginPage = await LoginPage.Visit( driver );
-	// 		return await loginPage.requestMagicLink( emailAddress );
-	// 	} );
+		step( 'Can log out and request a magic link', async function () {
+			if ( process.env.HORIZON_TESTS === 'true' ) {
+				return this.skip();
+			}
+			await driverManager.ensureNotLoggedIn( driver );
+			const loginPage = await LoginPage.Visit( driver );
+			return await loginPage.requestMagicLink( emailAddress );
+		} );
 
-	// 	step( 'Can see email containing magic link', async function () {
-	// 		if ( process.env.HORIZON_TESTS === 'true' ) {
-	// 			return this.skip();
-	// 		}
-	// 		const emailClient = new EmailClient( signupInboxId );
-	// 		const validator = ( emails ) =>
-	// 			emails.find( ( email ) => email.subject.includes( 'WordPress.com' ) );
-	// 		const emails = await emailClient.pollEmailsByRecipient( emailAddress, validator );
-	// 		assert.strictEqual(
-	// 			emails.length,
-	// 			2,
-	// 			'The number of newly registered emails is not equal to 2 (activation and magic link)'
-	// 		);
-	// 		for ( const email of emails ) {
-	// 			if ( email.subject.includes( 'WordPress.com' ) ) {
-	// 				return ( magicLoginLink = email.html.links[ 0 ].href );
-	// 			}
-	// 		}
-	// 		return assert(
-	// 			magicLoginLink !== undefined,
-	// 			'Could not locate the magic login link email link'
-	// 		);
-	// 	} );
+		step( 'Can see email containing magic link', async function () {
+			if ( process.env.HORIZON_TESTS === 'true' ) {
+				return this.skip();
+			}
+			const emailClient = new EmailClient( signupInboxId );
+			const validator = ( emails ) =>
+				emails.find( ( email ) => email.subject.includes( 'WordPress.com' ) );
+			const emails = await emailClient.pollEmailsByRecipient( emailAddress, validator );
+			assert.strictEqual(
+				emails.length,
+				2,
+				'The number of newly registered emails is not equal to 2 (activation and magic link)'
+			);
+			for ( const email of emails ) {
+				if ( email.subject.includes( 'WordPress.com' ) ) {
+					return ( magicLoginLink = email.html.links[ 0 ].href );
+				}
+			}
+			return assert(
+				magicLoginLink !== undefined,
+				'Could not locate the magic login link email link'
+			);
+		} );
 
-	// 	step( 'Can visit the magic link and we should be logged in', async function () {
-	// 		if ( process.env.HORIZON_TESTS === 'true' ) {
-	// 			return this.skip();
-	// 		}
-	// 		await driver.get( magicLoginLink );
-	// 		const magicLoginPage = await MagicLoginPage.Expect( driver );
-	// 		await magicLoginPage.finishLogin();
-	// 		try {
-	//  		await CustomerHomePage.Expect( driver );
-	// 		} catch ( e ) {
-	// 			await ReaderPage.Expect( driver );
-	// 		}
-	// 	} );
+		step( 'Can visit the magic link and we should be logged in', async function () {
+			if ( process.env.HORIZON_TESTS === 'true' ) {
+				return this.skip();
+			}
+			await driver.get( magicLoginLink );
+			const magicLoginPage = await MagicLoginPage.Expect( driver );
+			await magicLoginPage.finishLogin();
+			try {
+				await CustomerHomePage.Expect( driver );
+			} catch ( e ) {
+				await ReaderPage.Expect( driver );
+			}
+		} );
 
-	// 	after( 'Can delete our newly created account', async function () {
-	// 		return await new DeleteAccountFlow( driver ).deleteAccount( blogName );
-	// 	} );
-	// } );
+		after( 'Can delete our newly created account', async function () {
+			return await new DeleteAccountFlow( driver ).deleteAccount( blogName );
+		} );
+	} );
 
 	describe( 'Sign up for a free site, see the site preview, activate email and can publish @signup', function () {
 		const blogName = dataHelper.getNewBlogName();
@@ -1648,99 +1647,99 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 
 	// Disable test while Passwordless functionality is completely switched off
 	// https://github.com/Automattic/wp-calypso/pull/37054
-	// describe.skip( 'Passwordless signup @parallel', function () {
-	// 	const blogName = dataHelper.getNewBlogName();
-	// 	const emailAddress = dataHelper.getEmailAddress( blogName, signupInboxId );
-	// 	const expectedBlogAddresses = dataHelper.getExpectedFreeAddresses( blogName );
-	// 	let verificationLink;
+	describe.skip( 'Passwordless signup @parallel', function () {
+		const blogName = dataHelper.getNewBlogName();
+		const emailAddress = dataHelper.getEmailAddress( blogName, signupInboxId );
+		const expectedBlogAddresses = dataHelper.getExpectedFreeAddresses( blogName );
+		let verificationLink;
 
-	// 	before( async function () {
-	// 		await driverManager.ensureNotLoggedIn( driver );
-	// 	} );
+		before( async function () {
+			await driverManager.ensureNotLoggedIn( driver );
+		} );
 
-	// 	step(
-	// 		'Can visit the Jetpack Add New Site page and choose "Create a shiny new WordPress.com site"',
-	// 		async function () {
-	// 			const jetpackAddNewSitePage = await JetpackAddNewSitePage.Visit( driver );
-	// 			await jetpackAddNewSitePage.overrideABTestInLocalStorage(
-	// 				'passwordlessSignup',
-	// 				'passwordless'
-	// 			);
-	// 			return await jetpackAddNewSitePage.createNewWordPressDotComSite();
-	// 		}
-	// 	);
+		step(
+			'Can visit the Jetpack Add New Site page and choose "Create a shiny new WordPress.com site"',
+			async function () {
+				const jetpackAddNewSitePage = await JetpackAddNewSitePage.Visit( driver );
+				await jetpackAddNewSitePage.overrideABTestInLocalStorage(
+					'passwordlessSignup',
+					'passwordless'
+				);
+				return await jetpackAddNewSitePage.createNewWordPressDotComSite();
+			}
+		);
 
-	// 	step( 'Can see passwordless Start page and enter an email', async function () {
-	// 		const createYourAccountPage = await CreateYourAccountPage.Expect( driver );
-	// 		return await createYourAccountPage.enterEmailAndSubmit( emailAddress );
-	// 	} );
+		step( 'Can see passwordless Start page and enter an email', async function () {
+			const createYourAccountPage = await CreateYourAccountPage.Expect( driver );
+			return await createYourAccountPage.enterEmailAndSubmit( emailAddress );
+		} );
 
-	// 	step(
-	// 		'Can then see the domains page, and Can search for a blog name, can see and select a free .wordpress address in the results',
-	// 		async function () {
-	// 			const findADomainComponent = await FindADomainComponent.Expect( driver );
-	// 			await findADomainComponent.searchForBlogNameAndWaitForResults( blogName );
-	// 			await findADomainComponent.checkAndRetryForFreeBlogAddresses(
-	// 				expectedBlogAddresses,
-	// 				blogName
-	// 			);
-	// 			const actualAddress = await findADomainComponent.freeBlogAddress();
-	// 			assert(
-	// 				expectedBlogAddresses.indexOf( actualAddress ) > -1,
-	// 				`The displayed free blog address: '${ actualAddress }' was not the expected addresses: '${ expectedBlogAddresses }'`
-	// 			);
-	// 			return await findADomainComponent.selectFreeAddress();
-	// 		}
-	// 	);
+		step(
+			'Can then see the domains page, and Can search for a blog name, can see and select a free .wordpress address in the results',
+			async function () {
+				const findADomainComponent = await FindADomainComponent.Expect( driver );
+				await findADomainComponent.searchForBlogNameAndWaitForResults( blogName );
+				await findADomainComponent.checkAndRetryForFreeBlogAddresses(
+					expectedBlogAddresses,
+					blogName
+				);
+				const actualAddress = await findADomainComponent.freeBlogAddress();
+				assert(
+					expectedBlogAddresses.indexOf( actualAddress ) > -1,
+					`The displayed free blog address: '${ actualAddress }' was not the expected addresses: '${ expectedBlogAddresses }'`
+				);
+				return await findADomainComponent.selectFreeAddress();
+			}
+		);
 
-	// 	step( 'Can see the plans page and pick the free plan', async function () {
-	// 		const pickAPlanPage = await PickAPlanPage.Expect( driver );
-	// 		return await pickAPlanPage.selectFreePlan();
-	// 	} );
+		step( 'Can see the plans page and pick the free plan', async function () {
+			const pickAPlanPage = await PickAPlanPage.Expect( driver );
+			return await pickAPlanPage.selectFreePlan();
+		} );
 
-	// 	step(
-	// 		'Can then see the sign up processing page which will finish automatically move along',
-	// 		async function () {
-	// 			return await new SignUpStep( driver ).continueAlong( blogName, passwordForTestAccounts );
-	// 		}
-	// 	);
+		step(
+			'Can then see the sign up processing page which will finish automatically move along',
+			async function () {
+				return await new SignUpStep( driver ).continueAlong( blogName, passwordForTestAccounts );
+			}
+		);
 
-	// 	sharedSteps.canSeeTheOnboardingChecklist();
+		sharedSteps.canSeeTheOnboardingChecklist();
 
-	// 	step( 'Can see email containing verification link', async function () {
-	// 		if ( process.env.HORIZON_TESTS === 'true' ) {
-	// 			return this.skip();
-	// 		}
+		step( 'Can see email containing verification link', async function () {
+			if ( process.env.HORIZON_TESTS === 'true' ) {
+				return this.skip();
+			}
 
-	// 		const emailClient = await new EmailClient( signupInboxId );
-	// 		const validator = ( emails ) =>
-	// 			emails.find( ( email ) => email.subject.includes( emailAddress ) );
-	// 		const emails = await emailClient.pollEmailsByRecipient( emailAddress, validator );
+			const emailClient = await new EmailClient( signupInboxId );
+			const validator = ( emails ) =>
+				emails.find( ( email ) => email.subject.includes( emailAddress ) );
+			const emails = await emailClient.pollEmailsByRecipient( emailAddress, validator );
 
-	// 		for ( const email of emails ) {
-	// 			if ( email.subject.includes( emailAddress ) ) {
-	// 				return ( verificationLink = email.html.links[ 0 ].href );
-	// 			}
-	// 		}
-	// 		return assert( verificationLink !== undefined, 'Could not locate the login link email.' );
-	// 	} );
+			for ( const email of emails ) {
+				if ( email.subject.includes( emailAddress ) ) {
+					return ( verificationLink = email.html.links[ 0 ].href );
+				}
+			}
+			return assert( verificationLink !== undefined, 'Could not locate the login link email.' );
+		} );
 
-	// 	step( 'Can open verification link and verify account', async function () {
-	// 		if ( process.env.HORIZON_TESTS === 'true' ) {
-	// 			return this.skip();
-	// 		}
-	// 		await driver.get( verificationLink );
-	// 		const myHomePage = await MyHomePage.Expect( this.driver );
-	// 		return await myHomePage.isEmailVerified();
-	// 	} );
+		step( 'Can open verification link and verify account', async function () {
+			if ( process.env.HORIZON_TESTS === 'true' ) {
+				return this.skip();
+			}
+			await driver.get( verificationLink );
+			const myHomePage = await MyHomePage.Expect( this.driver );
+			return await myHomePage.isEmailVerified();
+		} );
 
-	// 	after( 'Can delete our newly created account', async function () {
-	// 		// Get username from Account settings page
-	// 		// (it's automatically generated for passwordless signup)
-	// 		const accountSettingsPage = await AccountSettingsPage.Visit( this.driver );
-	// 		const username = await accountSettingsPage.getUsername();
+		after( 'Can delete our newly created account', async function () {
+			// Get username from Account settings page
+			// (it's automatically generated for passwordless signup)
+			const accountSettingsPage = await AccountSettingsPage.Visit( this.driver );
+			const username = await accountSettingsPage.getUsername();
 
-	// 		return await new DeleteAccountFlow( driver ).deleteAccount( username );
-	// 	} );
-	// } );
+			return await new DeleteAccountFlow( driver ).deleteAccount( username );
+		} );
+	} );
 } );

--- a/test/e2e/specs/wp-signup-spec.js
+++ b/test/e2e/specs/wp-signup-spec.js
@@ -88,13 +88,9 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 			return await driverManager.ensureNotLoggedIn( driver );
 		} );
 
-		step(
-			'Can visit the Jetpack Add New Site page and choose "Create a shiny new WordPress.com site"',
-			async function () {
-				const jetpackAddNewSitePage = await JetpackAddNewSitePage.Visit( driver );
-				await jetpackAddNewSitePage.createNewWordPressDotComSite();
-			}
-		);
+		step( 'Can create a new WordPress site', async function () {
+			await StartPage.Visit( this.driver, StartPage.getStartURL() );
+		} );
 
 		step( 'Can see the account page and enter account details', async function () {
 			const createYourAccountPage = await CreateYourAccountPage.Expect( driver );


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Change links that are pointing to `/jetpack/new` to link directly to the dotcom site creation flow without any intermediate steps
* Redirect from the `/jetpack/new` page to dotcom site creation flow (aka `/start`)

### Testing instructions

There are 4 places where the user can choose to create a new site and is currently sent to the `/jetpack/new` page:

#### In the "site list" section of the left sidebar (when the user has more than 1 site)

* Log in to calypso (user needs to have more than 1 site)
* Click on "Switch site" at the top of the left sidebar
* Scroll the sidebar content all the way to the bottom
* Click on the "Add new site" link
* The button should take to the dotcom site creation flow without any intermediate steps (i.e. no Jetpack modal shown)

![Add a new site - sites list](https://user-images.githubusercontent.com/1083581/92622402-45b21800-f2c5-11ea-95a2-925156ab7fe4.png)

#### At the bottom of the left sidebar (when the user has only 1 site)

* Log in to calypso (user needs to have only 1 site)
* Click on the "Add new site" link at the bottom of the left sidebar
* The button should take to the dotcom site creation flow without any intermediate steps (i.e. no Jetpack modal shown)

![Add a new site - left sidebar with only 1 site](https://user-images.githubusercontent.com/1083581/92622716-a80b1880-f2c5-11ea-8729-f63a67812b35.png)

#### In the help widget

* Log in to calypso (user needs to have only 1 site)
* Scroll the "My Home" page down until you see the "Help" widget
* Type "new site" in the widget and wait for the results to load
* Click on the "Create a new site" search result
* The link should take to the dotcom site creation flow without any intermediate steps (i.e. no Jetpack modal shown)

![Add a new site - help widget](https://user-images.githubusercontent.com/1083581/92622290-2d41fd80-f2c5-11ea-8192-ece33688121e.png)

#### In the "Close account" confirmation dialog (only available if the user doesn't have any atomic site, and doesn't have any cancelable purchases)

* Log in to calypso (tested with a sample user having only 1 site on a free plan)
* Navigate to `/me/account/close`
* Click on "Close account button"
* Click on the "Start a new site" link in the confirmation dialog
* The link should take to the dotcom site creation flow without any intermediate steps (i.e. no Jetpack modal shown)

![Add a new site - close account](https://user-images.githubusercontent.com/1083581/92622264-261aef80-f2c5-11ea-9abd-479bed427181.png)


### Notes

The actual code for the Jetpack modal page will be removed in a future PR



Partially covers changes proposed in #45486