### PR TITLE
Editing Toolkit: Add ES5 check

### DIFF
--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -68,6 +68,7 @@
 		"build:wpcom-block-editor-nav-sidebar": "NODE_ENV=production yarn run wpcom-block-editor-nav-sidebar",
 		"dev": "node bin/npm-run-build.js --dev",
 		"build": "node bin/npm-run-build.js --build",
+		"postbuild": "yarn validate-fallback-es5",
 		"test:js": "npx wp-scripts test-unit-js --config='bin/js-unit-config.js' --colors",
 		"test:js:help": "npx wp-scripts test-unit-js --config='bin/js-unit-config.js' --help --colors",
 		"test:js:watch": "npx wp-scripts test-unit-js --config='bin/js-unit-config.js' --watch --colors",
@@ -79,7 +80,8 @@
 		"prebuild": "yarn run clean",
 		"predev": "yarn run clean",
 		"sync:newspack-blocks": "./bin/sync-newspack-blocks.sh",
-		"wpcom-sync": "./bin/wpcom-watch-and-sync.sh"
+		"wpcom-sync": "./bin/wpcom-watch-and-sync.sh",
+		"validate-fallback-es5": "npx eslint --parser-options=ecmaVersion:5 --no-eslintrc --no-ignore --no-inline-config ./editing-toolkit-plugin/*/dist/*.js"
 	},
 	"dependencies": {
 		"@automattic/calypso-analytics": "^1.0.0-alpha.1",

--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -68,7 +68,7 @@
 		"build:wpcom-block-editor-nav-sidebar": "NODE_ENV=production yarn run wpcom-block-editor-nav-sidebar",
 		"dev": "node bin/npm-run-build.js --dev",
 		"build": "node bin/npm-run-build.js --build",
-		"postbuild": "yarn validate-fallback-es5",
+		"postbuild": "yarn validate-es5",
 		"test:js": "npx wp-scripts test-unit-js --config='bin/js-unit-config.js' --colors",
 		"test:js:help": "npx wp-scripts test-unit-js --config='bin/js-unit-config.js' --help --colors",
 		"test:js:watch": "npx wp-scripts test-unit-js --config='bin/js-unit-config.js' --watch --colors",
@@ -81,7 +81,7 @@
 		"predev": "yarn run clean",
 		"sync:newspack-blocks": "./bin/sync-newspack-blocks.sh",
 		"wpcom-sync": "./bin/wpcom-watch-and-sync.sh",
-		"validate-fallback-es5": "npx eslint --parser-options=ecmaVersion:5 --no-eslintrc --no-ignore --no-inline-config ./editing-toolkit-plugin/*/dist/*.js"
+		"validate-es5": "npx eslint --parser-options=ecmaVersion:5 --no-eslintrc --no-ignore --no-inline-config ./editing-toolkit-plugin/*/dist/*.js"
 	},
 	"dependencies": {
 		"@automattic/calypso-analytics": "^1.0.0-alpha.1",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

After the `build` script it checks the output files to make sure they are ES5 compatible.
Since IE11 doesn't support ES6 we need to make sure all the output files are ES5 compatible.

#### Testing instructions

Make sure build doesn't fail.
