### PR TITLE
Reader: Enable photon on external images with size parameters

### DIFF
--- a/client/lib/post-normalizer/test/index.js
+++ b/client/lib/post-normalizer/test/index.js
@@ -22,7 +22,6 @@ import safeImageProperties from '../rule-safe-image-properties';
 import makeLinksSafe from '../rule-make-links-safe';
 import keepValidImages from '../rule-keep-valid-images';
 import createBetterExcerpt from '../rule-create-better-excerpt';
-import waitForImagesToLoad from '../rule-wait-for-images-to-load';
 import withContentDOM from '../rule-with-content-dom';
 import detectMedia from '../rule-content-detect-media';
 import detectPolls from '../rule-content-detect-polls';
@@ -524,63 +523,6 @@ describe( 'index', () => {
 		} );
 	} );
 
-	describe( 'waitForImagesToLoad', () => {
-		test.skip( 'should fire when all images have loaded or errored', () => {
-			// these need to be objects that mimic the Image object
-			const completeImage = {
-					complete: true,
-					src: 'http://example.com/one',
-				},
-				loadingImage = {
-					complete: false,
-					src: 'http://example.com/two',
-					load: function () {
-						this.onload();
-					},
-				},
-				erroringImage = {
-					complete: false,
-					src: 'http://example.com/three',
-					error: function () {
-						this.onerror();
-					},
-				};
-
-			loadingImage.load = loadingImage.load.bind( loadingImage );
-			erroringImage.error = erroringImage.error.bind( erroringImage );
-
-			const post = {
-				content_images: [ completeImage, loadingImage, erroringImage ],
-			};
-
-			setTimeout( loadingImage.load, 1 );
-			setTimeout( erroringImage.error, 2 );
-
-			return waitForImagesToLoad( post );
-		} );
-
-		test.skip( 'should dedupe the images to check', async () => {
-			const first = {
-					complete: true,
-					src: 'http://example.com/one',
-				},
-				firstDupe = {
-					complete: true,
-					src: 'http://example.com/one',
-				},
-				second = {
-					complete: true,
-					src: 'http://example.com/three',
-				},
-				post = {
-					content_images: [ first, second, firstDupe ],
-				};
-
-			const normalized = await waitForImagesToLoad( post );
-			expect( normalized.images ).toHaveLength( 2 );
-		} );
-	} );
-
 	describe( 'canonical image picker', () => {
 		test( 'can pick the canonical image from images', () => {
 			const postRunThroughWaitForImagesToLoad = {
@@ -902,60 +844,59 @@ describe( 'index', () => {
 	} );
 
 	describe( 'The fancy excerpt creator', () => {
-		function assertExcerptBecomes( source, expected ) {
-			const normalized = createBetterExcerpt( { content: source } );
-			expect( normalized.better_excerpt ).toBe( expected );
-		}
-
 		test( 'strips empty elements, leading brs, and styling attributes', () => {
-			assertExcerptBecomes(
-				`<br>
+			expect(
+				createBetterExcerpt( {
+					content: `<br>
                 <p>&nbsp;</p>
                 <p class="wp-caption">caption</p>
                 <p><img src="http://example.com/image.jpg"></p>
                 <p align="left" style="text-align:right"><a href="http://wikipedia.org">Giraffes</a> are <br>great</p>
                 <p></p>`,
-				'<p>Giraffes are <br>great</p>'
-			);
+				} ).better_excerpt
+			).toBe( '<p>Giraffes are <br>great</p>' );
 		} );
 
 		test( 'strips leading brs even if they are nested', () => {
-			assertExcerptBecomes(
-				'<p><br>deep meaning lies within</p>',
-				'<p>deep meaning lies within</p>'
-			);
+			expect(
+				createBetterExcerpt( { content: '<p><br>deep meaning lies within</p>' } ).better_excerpt
+			).toBe( '<p>deep meaning lies within</p>' );
 		} );
 
 		test( 'strips multiple leading brs even if nested', () => {
-			assertExcerptBecomes(
-				'<p><br><br><br></p><br><p><br></p>deep meaning lies within',
-				'deep meaning lies within'
-			);
+			expect(
+				createBetterExcerpt( {
+					content: '<p><br><br><br></p><br><p><br></p>deep meaning lies within',
+				} ).better_excerpt
+			).toBe( 'deep meaning lies within' );
 		} );
 
 		test( 'only trims break if there is no preceding text', () => {
-			assertExcerptBecomes( '<p>one<br>two</p>', '<p>one<br>two</p>' );
+			expect( createBetterExcerpt( { content: '<p>one<br>two</p>' } ).better_excerpt ).toBe(
+				'<p>one<br>two</p>'
+			);
 		} );
 
 		test( 'limits the excerpt to 3 elements', () => {
-			assertExcerptBecomes(
-				'<p>one</p><p>two</p><p>three</p><p>four</p>',
-				'<p>one</p><p>two</p><p>three</p>'
-			);
+			expect(
+				createBetterExcerpt( { content: '<p>one</p><p>two</p><p>three</p><p>four</p>' } )
+					.better_excerpt
+			).toBe( '<p>one</p><p>two</p><p>three</p>' );
 		} );
 
 		test( 'limits the excerpt to 3 elements after trimming', () => {
-			assertExcerptBecomes(
-				'<br /><p></p><p>one</p><p>two</p><p></p><br><p>three</p><p>four</p><br><p></p>',
-				'<p>one</p><p>two</p><br>'
-			);
+			expect(
+				createBetterExcerpt( {
+					content: '<br /><p></p><p>one</p><p>two</p><p></p><br><p>three</p><p>four</p><br><p></p>',
+				} ).better_excerpt
+			).toBe( '<p>one</p><p>two</p><br>' );
 		} );
 
 		test( 'removes style tags', () => {
-			assertExcerptBecomes(
-				'<style>#foo{ color: blue; }</style><p>hi there</p>',
-				'<p>hi there</p>'
-			);
+			expect(
+				createBetterExcerpt( { content: '<style>#foo{ color: blue; }</style><p>hi there</p>' } )
+					.better_excerpt
+			).toBe( '<p>hi there</p>' );
 		} );
 
 		test( 'builds the content without html', () => {

--- a/client/lib/post-normalizer/test/index.js
+++ b/client/lib/post-normalizer/test/index.js
@@ -460,6 +460,21 @@ describe( 'index', () => {
 			);
 		} );
 
+		test( 'can route images with known size parameters through photon if a size is specified', () => {
+			const post = {
+				content:
+					'<img src="http://example.com/example.jpg?w=10"><img src="http://example.com/example2.jpg?h=10">' +
+					'<img src="http://example.com/example3.jpg?fit=full"><img src="http://example.com/example4.jpg?resize=min">',
+			};
+			const normalized = withContentDOM( [ makeImagesSafe( 400 ) ] )( post );
+			expect( normalized.content ).toBe(
+				'<img src="http://example.com/example.jpg-SAFE?quality=80&amp;strip=info&amp;w=400">' +
+					'<img src="http://example.com/example2.jpg-SAFE?quality=80&amp;strip=info&amp;w=400">' +
+					'<img src="http://example.com/example3.jpg-SAFE?quality=80&amp;strip=info&amp;w=400">' +
+					'<img src="http://example.com/example4.jpg-SAFE?quality=80&amp;strip=info&amp;w=400">'
+			);
+		} );
+
 		test( 'can remove images that cannot be made safe', () => {
 			safeImageUrlFake.setReturns( null );
 			const post = {

--- a/client/lib/post-normalizer/test/mocks/lib/safe-image-url.js
+++ b/client/lib/post-normalizer/test/mocks/lib/safe-image-url.js
@@ -2,11 +2,24 @@
  * A stub that makes safe-image-url deterministic
  *
  */
+/**
+ * Internal dependencies
+ */
+import { getUrlParts, getUrlFromParts } from 'lib/url/url-parts';
 
 let returnValue;
 
 function makeSafe( url ) {
-	return returnValue !== undefined ? returnValue : url + '-SAFE';
+	const parts = getUrlParts( url );
+	if ( ! parts.protocol ) {
+		parts.protocol = 'fake';
+	}
+	parts.pathname += '-SAFE';
+	let newUrl = getUrlFromParts( parts ).toString();
+	if ( 'fake' === parts.protocol ) {
+		newUrl = newUrl.substring( 5 );
+	}
+	return returnValue !== undefined ? returnValue : newUrl;
 }
 
 makeSafe.setReturns = function ( val ) {

--- a/client/lib/post-normalizer/utils/max-width-photonish-url.js
+++ b/client/lib/post-normalizer/utils/max-width-photonish-url.js
@@ -8,6 +8,11 @@ const IMAGE_SCALE_FACTOR =
 
 const DEFAULT_PHOTON_QUALITY = 80; // 80 was chosen after some heuristic testing as the best blend of size and quality
 
+const SERVICE_HOSTNAME_PATTERNS = {
+	photon: /(^[is]\d\.wp\.com|(^|\.)wordpress\.com)$/,
+	gravatar: /(^|\.)gravatar\.com$/,
+};
+
 export function maxWidthPhotonishURL( imageURL, width ) {
 	if ( ! imageURL ) {
 		return imageURL;
@@ -21,20 +26,26 @@ export function maxWidthPhotonishURL( imageURL, width ) {
 		return imageURL;
 	}
 
+	const service = Object.keys( SERVICE_HOSTNAME_PATTERNS ).find( ( key ) =>
+		urlParts.hostname.match( SERVICE_HOSTNAME_PATTERNS[ key ] )
+	);
+
+	if ( ! service ) {
+		// This is not Photon.
+		return imageURL;
+	}
+
 	// From this point on, we should only have absolute and scheme-relative URLs.
-
-	const isGravatar = urlParts.host.indexOf( 'gravatar.com' ) !== -1;
-
 	delete urlParts.search;
 	// strip other sizing params
 	for ( const param of [ 'h', 'crop', 'resize', 'fit' ] ) {
 		urlParts.searchParams.delete( param );
 	}
 
-	const sizeParam = isGravatar ? 's' : 'w';
+	const sizeParam = 'gravatar' === service ? 's' : 'w';
 	urlParts.searchParams.set( sizeParam, width * IMAGE_SCALE_FACTOR );
 
-	if ( ! isGravatar ) {
+	if ( 'gravatar' !== service ) {
 		// gravatar doesn't support these, only photon / files.wordpress
 		urlParts.searchParams.set( 'quality', DEFAULT_PHOTON_QUALITY );
 		urlParts.searchParams.set( 'strip', 'info' ); // strip all exif data, leave ICC intact

--- a/client/lib/post-normalizer/utils/max-width-photonish-url.js
+++ b/client/lib/post-normalizer/utils/max-width-photonish-url.js
@@ -30,11 +30,6 @@ export function maxWidthPhotonishURL( imageURL, width ) {
 		urlParts.hostname.match( SERVICE_HOSTNAME_PATTERNS[ key ] )
 	);
 
-	if ( ! service ) {
-		// This is not Photon.
-		return imageURL;
-	}
-
 	// From this point on, we should only have absolute and scheme-relative URLs.
 	delete urlParts.search;
 	// strip other sizing params

--- a/client/lib/safe-image-url/index.js
+++ b/client/lib/safe-image-url/index.js
@@ -6,7 +6,7 @@ import photon from 'photon';
 /**
  * Internal dependencies
  */
-import { getUrlParts } from 'lib/url/url-parts';
+import { getUrlParts, getUrlFromParts } from 'lib/url/url-parts';
 
 /**
  * Pattern matching URLs to be left unmodified.
@@ -30,6 +30,13 @@ if ( typeof globalThis.location === 'object' ) {
 const REGEXP_A8C_HOST = /^([-a-zA-Z0-9_]+\.)*(gravatar\.com|wordpress\.com|wp\.com|a8c\.com)$/;
 
 /**
+ * Query parameters to be treated as image dimensions
+ *
+ * @type {string[]}
+ */
+const SIZE_PARAMS = [ 'w', 'h', 'resize', 'fit', 's' ];
+
+/**
  * Generate a safe version of the provided URL
  *
  * Images that Calypso uses have to be provided by a trusted TLS host. To do
@@ -51,22 +58,34 @@ export default function safeImageUrl( url ) {
 		return url;
 	}
 
-	const { hostname, pathname, search } = getUrlParts( url );
+	const parsedUrl = getUrlParts( url );
+	if ( ! parsedUrl.protocol ) {
+		return url;
+	}
 
-	if ( REGEXP_A8C_HOST.test( hostname ) ) {
+	if ( REGEXP_A8C_HOST.test( parsedUrl.hostname ) ) {
 		// Safely promote Automattic domains to HTTPS
-		return url.replace( /^http:/, 'https:' );
+		return ( parsedUrl.protocol = 'https:' );
 	}
 
 	// If there's a query string, bail out because Photon doesn't support them on external URLs
-	if ( search ) {
-		return null;
+	if ( parsedUrl.search ) {
+		// If it's just size parameters, let's remove them
+		SIZE_PARAMS.forEach( ( param ) => parsedUrl.searchParams.delete( param ) );
+
+		// There are still parameters left, since they might be needed to retrieve the image, bail out
+		if ( parsedUrl.searchParams.length ) {
+			return null;
+		}
+
+		// Ensure we're creating a new URL without the size parameters
+		delete parsedUrl.search;
 	}
 
 	// Photon doesn't support SVGs
-	if ( pathname.endsWith( '.svg' ) ) {
+	if ( parsedUrl.pathname.endsWith( '.svg' ) ) {
 		return null;
 	}
 
-	return photon( url );
+	return photon( getUrlFromParts( parsedUrl ) );
 }

--- a/client/lib/safe-image-url/index.js
+++ b/client/lib/safe-image-url/index.js
@@ -59,13 +59,11 @@ export default function safeImageUrl( url ) {
 	}
 
 	const parsedUrl = getUrlParts( url );
-	if ( ! parsedUrl.protocol ) {
-		return url;
-	}
 
 	if ( REGEXP_A8C_HOST.test( parsedUrl.hostname ) ) {
 		// Safely promote Automattic domains to HTTPS
-		return ( parsedUrl.protocol = 'https:' );
+		parsedUrl.protocol = 'https';
+		return getUrlFromParts( parsedUrl ).toString();
 	}
 
 	// If there's a query string, bail out because Photon doesn't support them on external URLs
@@ -80,6 +78,7 @@ export default function safeImageUrl( url ) {
 
 		// Ensure we're creating a new URL without the size parameters
 		delete parsedUrl.search;
+		url = getUrlFromParts( parsedUrl ).toString();
 	}
 
 	// Photon doesn't support SVGs
@@ -87,5 +86,5 @@ export default function safeImageUrl( url ) {
 		return null;
 	}
 
-	return photon( getUrlFromParts( parsedUrl ) );
+	return photon( url );
 }

--- a/client/lib/safe-image-url/test/index.js
+++ b/client/lib/safe-image-url/test/index.js
@@ -96,6 +96,21 @@ describe( 'safeImageUrl()', () => {
 			expect( safeImageUrl( 'https://example.com/foo.png?width=90' ) ).toBeNull();
 		} );
 
+		test( 'should remove known resize parameters from urls', () => {
+			expect( safeImageUrl( 'https://example.com/foo.jpg?w=123' ) ).toEqual(
+				'https://i0.wp.com/example.com/foo.jpg?ssl=1'
+			);
+			expect( safeImageUrl( 'https://example.com/foo.jpg?h=123' ) ).toEqual(
+				'https://i0.wp.com/example.com/foo.jpg?ssl=1'
+			);
+			expect( safeImageUrl( 'https://example.com/foo.jpg?resize=width' ) ).toEqual(
+				'https://i0.wp.com/example.com/foo.jpg?ssl=1'
+			);
+			expect( safeImageUrl( 'https://example.com/foo.jpg?fit=min' ) ).toEqual(
+				'https://i0.wp.com/example.com/foo.jpg?ssl=1'
+			);
+		} );
+
 		test( 'should return null for SVG images', () => {
 			expect( safeImageUrl( 'https://example.com/foo.svg' ) ).toBeNull();
 			expect( safeImageUrl( 'https://example.com/foo.svg?ssl=1' ) ).toBeNull();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Before this patch, if an image contains any parameter, we just don't display it since we can't route it through Photon. Often images, though, already contain some "size parameters"  (like `w`), either because it already uses a Photon site that we cannot detect (like an Atomic site) or some other internal service to resize the image. 

Part of the problem is also that we attach URL parameters to URLs that we think might be Photon URLs, causing the non-action down the stream (since the URL now has URL parameters).

With this patch, we attempt to remove the size URL parameters and also only modify known Photon URLs.

#### Testing instructions

Find a site through a search that has image URLs (see p5PDj3-4Up-p2) and verify that the images now show.