### PR TITLE
Checkout: Rename analytics action props for calypso_checkout_composite_error

### DIFF
--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -405,14 +405,14 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 			reduxDispatch(
 				recordTracksEvent( 'calypso_checkout_composite_error', {
 					error_message: err.message,
-					type: String( action?.type ),
-					payload: String( action?.payload ),
+					action_type: String( action?.type ),
+					action_payload: String( action?.payload ),
 				} )
 			);
 			return reduxDispatch(
 				logStashLoadErrorEventAction( 'calypso_checkout_composite_error', err.message, {
-					type: String( action?.type ),
-					payload: String( action?.payload ),
+					action_type: String( action?.type ),
+					action_payload: String( action?.payload ),
 				} )
 			);
 		}


### PR DESCRIPTION
If they have the key `type`, it will be overridden by the actual type.

This is a follow-up to https://github.com/Automattic/wp-calypso/pull/45471 which added new properties to the `calypso_checkout_composite_error` Logstash event so that we can determine the action type that caused the error. However, in that PR I used the key `type` for the action type, which is then immediately overridden by the `type` of the logstash event.

This PR renames the `type` to `action_type` so that it will be preserved.

#### Testing instructions

- Cause an error by following the [instructions here](https://github.com/Automattic/wp-calypso/pull/45241#pullrequestreview-478956393).
- Verify that the error is reported with the action `action_type` and `action_payload` (the payload is likely to be unreadable but that's expected; it's hard to know how to coerce unknown data to a string but it might sometimes be useful). You can do this as follows.

For the Logstash event, examine your browser's devtools network tab and look for a call to the https://public-api.wordpress.com/rest/v1.1/logstash endpoint.

For the Tracks event, before the test, run `localStorage.setItem('debug', 'calypso:analytics')` in your browser console and reload the page. After you trigger the error, look for this in your console: `calypso:analytics Recording event "calypso_checkout_composite_error" with actual props`.