### PR TITLE
SiteSetupList: add a unique key to each return statement

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
@@ -4,7 +4,7 @@
 import { Card } from '@automattic/components';
 import { isDesktop, isWithinBreakpoint, subscribeIsWithinBreakpoint } from '@automattic/viewport';
 import { translate } from 'i18n-calypso';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, Fragment } from 'react';
 import { connect, useDispatch } from 'react-redux';
 import page from 'page';
 import classnames from 'classnames';
@@ -233,7 +233,7 @@ const SiteSetupList = ( {
 					const isCompleted = task.isCompleted;
 
 					return (
-						<>
+						<Fragment key={ task.id }>
 							<NavItem
 								key={ task.id }
 								taskId={ task.id }
@@ -268,7 +268,7 @@ const SiteSetupList = ( {
 									useAccordionLayout={ useAccordionLayout }
 								/>
 							) : null }
-						</>
+						</Fragment>
 					);
 				} ) }
 			</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add a unique key to each return statement by using `Fragment`
Attempts to fix the following console error
![](https://cln.sh/ZHJbm1+)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch locally
* `yarn && yarn start`
* Create a new free site
* Go to https://wordpress.com/home for that site
* Open the console
* You should not get the following error
![](https://cln.sh/ZHJbm1+)