### PR TITLE
Nav Unification: left nav geometries 

### DIFF
--- a/client/assets/stylesheets/shared/_variables.scss
+++ b/client/assets/stylesheets/shared/_variables.scss
@@ -3,8 +3,8 @@
 // =======================
 
 // Sidebar size limits
-$sidebar-width-max: 200px;
-$sidebar-width-min: 160px;
+$sidebar-width-max: 272px;
+$sidebar-width-min: 228px;
 
 // =======================
 // Components

--- a/client/assets/stylesheets/shared/_variables.scss
+++ b/client/assets/stylesheets/shared/_variables.scss
@@ -3,8 +3,10 @@
 // =======================
 
 // Sidebar size limits
-$sidebar-width-max: 272px;
-$sidebar-width-min: 228px;
+:root {
+	--sidebar-width-max: 272px;
+	--sidebar-width-min: 228px;
+}
 
 // =======================
 // Components

--- a/client/assets/stylesheets/shared/_variables.scss
+++ b/client/assets/stylesheets/shared/_variables.scss
@@ -1,12 +1,10 @@
-
 // =======================
 // Layout
 // =======================
 
 // Sidebar size limits
-$sidebar-width-max: 272px;
-$sidebar-width-min: 228px;
-
+$sidebar-width-max: 200px;
+$sidebar-width-min: 160px;
 
 // =======================
 // Components

--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -145,7 +145,10 @@ class Site extends React.Component {
 					<div className="site__info">
 						<div className="site__title">{ site.title }</div>
 						<div className="site__domain">
-							{ this.props.homeLink
+							{ /* eslint-disable-next-line no-nested-ternary */ }
+							{ isEnabled( 'nav-unification' )
+								? site.domain
+								: this.props.homeLink
 								? translate( 'View %(domain)s', {
 										args: { domain: site.domain },
 								  } )

--- a/client/components/domains/trademark-claims-notice/style.scss
+++ b/client/components/domains/trademark-claims-notice/style.scss
@@ -19,7 +19,7 @@
 			margin-bottom: 150px;
 		}
 
-		@include breakpoint-deprecated('>800px') {
+		@include breakpoint-deprecated( '>800px' ) {
 			margin-bottom: 53px;
 
 			body.is-section-signup & {
@@ -56,12 +56,12 @@
 		left: 0;
 		right: 0;
 		margin: 0;
-		padding: 1px 31px 0 ($sidebar-width-max + 32px);
+		padding: 1px 31px 0 ( var( --sidebar-width-max ) + 32px );
 		box-sizing: border-box;
 		overflow: hidden;
 
-		@include breakpoint-deprecated('<960px') {
-			padding: 1px 23px 0 ($sidebar-width-min + 24px);
+		@include breakpoint-deprecated( '<960px' ) {
+			padding: 1px 23px 0 ( var( --sidebar-width-min ) + 24px );
 		}
 
 		body.is-section-signup & {
@@ -74,11 +74,11 @@
 			background: var( --color-surface-backdrop );
 			padding: 0 1px 32px;
 
-			@include breakpoint-deprecated('<960px') {
+			@include breakpoint-deprecated( '<960px' ) {
 				padding: 0 1px 24px;
 			}
 
-			@include breakpoint-deprecated('<660px') {
+			@include breakpoint-deprecated( '<660px' ) {
 				padding: 0 1px;
 			}
 
@@ -86,13 +86,13 @@
 				background: var( --color-primary );
 				padding: 0;
 
-				@include breakpoint-deprecated('>800px') {
+				@include breakpoint-deprecated( '>800px' ) {
 					padding: 0 0 32px;
 				}
 			}
 		}
 
-		@include breakpoint-deprecated('<660px') {
+		@include breakpoint-deprecated( '<660px' ) {
 			margin-left: 0;
 			padding: 0;
 			padding-top: 47px;
@@ -108,7 +108,7 @@
 				width: 100%;
 				margin: 0 0 10px;
 
-				@include breakpoint-deprecated('>800px') {
+				@include breakpoint-deprecated( '>800px' ) {
 					width: auto;
 					margin: 0 0 0 14px;
 				}

--- a/client/components/domains/trademark-claims-notice/style.scss
+++ b/client/components/domains/trademark-claims-notice/style.scss
@@ -56,12 +56,12 @@
 		left: 0;
 		right: 0;
 		margin: 0;
-		padding: 1px 31px 0 ( var( --sidebar-width-max ) + 32px );
+		padding: 1px 31px 0 calc( var( --sidebar-width-max ) + 32px );
 		box-sizing: border-box;
 		overflow: hidden;
 
 		@include breakpoint-deprecated( '<960px' ) {
-			padding: 1px 23px 0 ( var( --sidebar-width-min ) + 24px );
+			padding: 1px 23px 0 calc( var( --sidebar-width-min ) + 24px );
 		}
 
 		body.is-section-signup & {

--- a/client/components/jetpack/masterbar/style.scss
+++ b/client/components/jetpack/masterbar/style.scss
@@ -8,11 +8,11 @@
 		width: auto;
 
 		@include breakpoint-deprecated( '>660px' ) {
-			min-width: $sidebar-width-min;
+			min-width: var( --sidebar-width-min );
 		}
 
 		@include breakpoint-deprecated( '>960px' ) {
-			min-width: $sidebar-width-max;
+			min-width: var( --sidebar-width-max );
 		}
 
 		.masterbar__item-content {

--- a/client/components/tinymce/style.scss
+++ b/client/components/tinymce/style.scss
@@ -57,9 +57,9 @@
 			border-right-width: 0;
 
 			.focus-sidebar & {
-				width: calc( 100% - ( #{$sidebar-width-max + 1} ) );
+				width: calc( 100% - ( #{var( --sidebar-width-max ) + 1} ) );
 				@include breakpoint-deprecated( '660px-960px' ) {
-					width: calc( 100% - ( #{$sidebar-width-min + 1} ) );
+					width: calc( 100% - ( #{var( --sidebar-width-min ) + 1} ) );
 				}
 				margin: 0;
 			}
@@ -96,7 +96,7 @@
 		}
 
 		.focus-sidebar & {
-			@media screen and ( max-width: ( 700px + $sidebar-width-min ) ) {
+			@media screen and ( max-width: ( 700px + var( --sidebar-width-min ) ) ) {
 				border-left-width: 0;
 				border-right-width: 0;
 			}
@@ -181,7 +181,8 @@
 
 .mce-toolbar
 	.mce-btn-group
-	.mce-btn.mce-toolbar-segment-end:not( .mce-hidden ) + .mce-btn.mce-toolbar-segment-start {
+	.mce-btn.mce-toolbar-segment-end:not( .mce-hidden )
+	+ .mce-btn.mce-toolbar-segment-start {
 	margin-left: 2px;
 
 	&::before {

--- a/client/components/tinymce/style.scss
+++ b/client/components/tinymce/style.scss
@@ -57,9 +57,9 @@
 			border-right-width: 0;
 
 			.focus-sidebar & {
-				width: calc( 100% - ( #{var( --sidebar-width-max ) + 1} ) );
+				width: calc( 100% - var( --sidebar-width-max ) - 1px );
 				@include breakpoint-deprecated( '660px-960px' ) {
-					width: calc( 100% - ( #{var( --sidebar-width-min ) + 1} ) );
+					width: calc( 100% - var( --sidebar-width-min ) - 1px );
 				}
 				margin: 0;
 			}

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -1,3 +1,6 @@
+$sidebar-item-padding: 8px 0;
+$font-size: rem( 14px );
+
 .sidebar {
 	// Setting the position and clearing some
 	// margins and paddings.
@@ -57,9 +60,10 @@
 // like in Reader, and for the expandable menus.
 .sidebar__heading {
 	color: var( --color-sidebar-text-alternative );
-	font-size: $font-body;
-	font-weight: 600;
-	padding: 16px 8px 6px 16px;
+	font-size: $font-size;
+	font-weight: 400;
+	line-height: 1.3;
+	padding: $sidebar-item-padding;
 	margin: 0;
 	outline: 0;
 }
@@ -67,7 +71,9 @@
 // Sidebar menu icons for main sections
 .sidebar__menu-icon {
 	fill: var( --color-sidebar-gridicon-fill );
-	margin-right: 11px;
+	margin: 0 8px;
+	width: 20px;
+	height: 20px;
 	flex-shrink: 0;
 }
 
@@ -110,10 +116,10 @@
 // Menu links: The actual anchor tags that contain links to
 // various sections of Calypso.
 .sidebar__menu-link {
-	font-size: $font-body;
+	font-size: $font-size;
 	line-height: 1.2;
 	position: relative;
-	padding: 10px 16px 10px 20px;
+	padding: $sidebar-item-padding;
 	box-sizing: border-box;
 	overflow: hidden;
 	display: flex;
@@ -216,8 +222,8 @@
 .sidebar__menu.is-togglable {
 	.sidebar__heading {
 		display: flex;
-		padding: 10px 16px 10px 20px;
-		font-weight: 600;
+		padding: $sidebar-item-padding;
+		font-weight: 400;
 		cursor: pointer;
 
 		&:hover {
@@ -238,6 +244,8 @@
 	.sidebar__expandable-arrow {
 		transition: transform 0.1s linear;
 		fill: var( --color-sidebar-gridicon-fill );
+		width: 20px;
+		height: 20px;
 	}
 
 	.sidebar__menu-link {

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -1,6 +1,3 @@
-$sidebar-item-padding: 8px 0;
-$font-size: rem( 14px );
-
 .sidebar {
 	// Setting the position and clearing some
 	// margins and paddings.
@@ -60,10 +57,9 @@ $font-size: rem( 14px );
 // like in Reader, and for the expandable menus.
 .sidebar__heading {
 	color: var( --color-sidebar-text-alternative );
-	font-size: $font-size;
-	font-weight: 400;
-	line-height: 1.3;
-	padding: $sidebar-item-padding;
+	font-size: $font-body;
+	font-weight: 600;
+	padding: 16px 8px 6px 16px;
 	margin: 0;
 	outline: 0;
 }
@@ -71,9 +67,7 @@ $font-size: rem( 14px );
 // Sidebar menu icons for main sections
 .sidebar__menu-icon {
 	fill: var( --color-sidebar-gridicon-fill );
-	margin: 0 8px;
-	width: 20px;
-	height: 20px;
+	margin-right: 11px;
 	flex-shrink: 0;
 }
 
@@ -116,10 +110,10 @@ $font-size: rem( 14px );
 // Menu links: The actual anchor tags that contain links to
 // various sections of Calypso.
 .sidebar__menu-link {
-	font-size: $font-size;
+	font-size: $font-body;
 	line-height: 1.2;
 	position: relative;
-	padding: $sidebar-item-padding;
+	padding: 10px 16px 10px 20px;
 	box-sizing: border-box;
 	overflow: hidden;
 	display: flex;
@@ -222,8 +216,8 @@ $font-size: rem( 14px );
 .sidebar__menu.is-togglable {
 	.sidebar__heading {
 		display: flex;
-		padding: $sidebar-item-padding;
-		font-weight: 400;
+		padding: 10px 16px 10px 20px;
+		font-weight: 600;
 		cursor: pointer;
 
 		&:hover {
@@ -244,8 +238,6 @@ $font-size: rem( 14px );
 	.sidebar__expandable-arrow {
 		transition: transform 0.1s linear;
 		fill: var( --color-sidebar-gridicon-fill );
-		width: 20px;
-		height: 20px;
 	}
 
 	.sidebar__menu-link {

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -24,7 +24,7 @@
 	@include clear-fix;
 	position: relative;
 	margin: 0;
-	padding: 79px 32px 32px ( $sidebar-width-max + 32px + 1px );
+	padding: 79px 32px 32px ( var( --sidebar-width-max ) + 32px + 1px );
 	box-sizing: border-box;
 	overflow: hidden;
 
@@ -44,12 +44,12 @@
 	// displays at full height.
 	.is-section-preview & {
 		height: 100%;
-		padding: 47px 0 0 ( $sidebar-width-max + 1px );
+		padding: 47px 0 0 ( var( --sidebar-width-max ) + 1px );
 	}
 
 	// Tablets
 	@include breakpoint-deprecated( '<960px' ) {
-		padding: 71px 24px 24px ( $sidebar-width-min + 24px + 1px );
+		padding: 71px 24px 24px ( var( --sidebar-width-min ) + 24px + 1px );
 
 		.has-no-sidebar & {
 			padding-left: 24px;
@@ -102,11 +102,11 @@
 	color: var( --color-sidebar-text );
 	background: var( --color-sidebar-background );
 	border-right: 1px solid var( --color-sidebar-border );
-	width: $sidebar-width-max;
+	width: var( --sidebar-width-max );
 	overflow: hidden;
 
 	@include breakpoint-deprecated( '<960px' ) {
-		width: $sidebar-width-min;
+		width: var( --sidebar-width-min );
 	}
 
 	@include breakpoint-deprecated( '<660px' ) {
@@ -133,7 +133,7 @@
 	bottom: 0;
 	left: 0;
 	pointer-events: none;
-	transform: translateX( -$sidebar-width-max );
+	transform: translateX( -var( --sidebar-width-max ) );
 
 	.site,
 	.all-sites {
@@ -210,8 +210,7 @@
 	}
 
 	.app-promo .app-promo__link {
-		box-shadow: 0 0 0 1px var( --color-sidebar-border ),
-			0 1px 2px var( --color-sidebar-border );
+		box-shadow: 0 0 0 1px var( --color-sidebar-border ), 0 1px 2px var( --color-sidebar-border );
 	}
 }
 
@@ -248,7 +247,7 @@
 
 	.layout__secondary .sidebar {
 		pointer-events: none;
-		transform: translateX( $sidebar-width-max );
+		transform: translateX( var( --sidebar-width-max ) );
 
 		@include breakpoint-deprecated( '<660px' ) {
 			transform: translateX( 100% );

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -24,7 +24,7 @@
 	@include clear-fix;
 	position: relative;
 	margin: 0;
-	padding: 79px 32px 32px ( var( --sidebar-width-max ) + 32px + 1px );
+	padding: 79px 32px 32px calc( var( --sidebar-width-max ) + 32px + 1px );
 	box-sizing: border-box;
 	overflow: hidden;
 
@@ -44,12 +44,12 @@
 	// displays at full height.
 	.is-section-preview & {
 		height: 100%;
-		padding: 47px 0 0 ( var( --sidebar-width-max ) + 1px );
+		padding: 47px 0 0 calc( var( --sidebar-width-max ) + 1px );
 	}
 
 	// Tablets
 	@include breakpoint-deprecated( '<960px' ) {
-		padding: 71px 24px 24px ( var( --sidebar-width-min ) + 24px + 1px );
+		padding: 71px 24px 24px calc( var( --sidebar-width-min ) + 24px + 1px );
 
 		.has-no-sidebar & {
 			padding-left: 24px;

--- a/client/my-sites/sidebar-unified/index.jsx
+++ b/client/my-sites/sidebar-unified/index.jsx
@@ -25,6 +25,8 @@ import SidebarSeparator from 'layout/sidebar/separator';
 import 'layout/sidebar-unified/style.scss';
 import 'state/admin-menu/init';
 
+import './style.scss';
+
 export const MySitesSidebarUnified = ( { path } ) => {
 	const menuItems = useSiteMenuItems();
 	const isAllDomainsView = useDomainsViewStatus();

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -1,35 +1,112 @@
-// This files overrides client/layout/sidebar/style.scss
-// Changes should be merged before nav unification goes to production
+// The following changes should be merged before nav unification goes to production
+
 // Override Global Vars
-$sidebar-width-max: 200px;
-$sidebar-width-min: 228px;
+.nav-unification {
+	--sidebar-width-max: 200px;
+	--sidebar-width-min: 200px;
+	--color-sidebar-background: #23282d;
+	--color-sidebar-background-rgb: 35, 40, 45;
+	--color-sidebar-border: var( --color-surface-backdrop );
+	--color-sidebar-text: #eee;
+	--color-sidebar-gridicon-fill: var( --color-sidebar-text );
+}
 
 // Local Vars
 $sidebar-item-padding: 8px 0;
 $font-size: rem( 14px );
 
 .sidebar {
-	.sidebar__heading {
+	background-color: var( --color-sidebar-background );
+
+	hr {
+		margin: 0 0 11px 0;
+	}
+
+	.sidebar__heading,
+	.sidebar__menu-link {
+		position: relative;
 		font-size: $font-size;
 		font-weight: 400;
 		line-height: 1.3;
+		padding: 0;
+		color: var( --color-sidebar-text );
+		align-items: center;
+
+		&:hover {
+			background-color: #191e23;
+			color: #00b9eb;
+		}
+	}
+
+	.sidebar__expandable-title,
+	.sidebar__menu-link-text {
 		padding: $sidebar-item-padding;
 	}
 
-	.sidebar__menu-link {
-		font-size: $font-size;
-		padding: $sidebar-item-padding;
+	// .sidebar__menu-link {
+	// 	font-size: $font-size;
+	// 	font-weight: 400;
+	// 	line-height: 1.3;
+	// 	padding: $sidebar-item-padding;
+	// 	color: #eee;
+	// }
+
+	.sidebar__expandable-arrow,
+	.gridicons-external {
+		display: none;
+		width: 20px;
+		height: 20px;
 	}
 
 	.sidebar__menu.is-togglable {
 		.sidebar__heading {
-			padding: $sidebar-item-padding;
+			padding: 0;
 			font-weight: 400;
+
+			&:hover {
+				background-color: #191e23;
+				color: #00b9eb;
+			}
+		}
+	}
+
+	.sidebar__menu.is-toggle-open .sidebar__heading {
+		background: #0073aa;
+		color: white;
+
+		&:after {
+			right: 0;
+			border: solid 8px transparent;
+			content: ' ';
+			height: 0;
+			width: 0;
+			position: absolute;
+			pointer-events: none;
+			border-right-color: #f1f1f1;
+			top: 50%;
+			margin-top: -8px;
+		}
+	}
+
+	.sidebar__expandable-content {
+		background: #32373c;
+		padding: 7px 0 8px;
+
+		.sidebar__menu-link {
+			padding: 5px 12px;
+			font-size: 13px;
+			line-height: 1.4;
+			font-weight: 500;
+			color: #b4b9be;
+
+			&:hover {
+				background-color: transparent;
+				color: white;
+			}
 		}
 
-		.sidebar__expandable-arrow {
-			width: 20px;
-			height: 20px;
+		.sidebar__menu-link-text {
+			padding: 0;
 		}
 	}
 }

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -32,6 +32,7 @@ $font-size: rem( 14px );
 			padding: 0;
 			color: var( --color-sidebar-text );
 			align-items: center;
+			padding-left: 8px;
 
 			&:hover {
 				background-color: #191e23;
@@ -44,14 +45,6 @@ $font-size: rem( 14px );
 			padding: $sidebar-item-padding;
 		}
 
-		// .sidebar__menu-link {
-		// 	font-size: $font-size;
-		// 	font-weight: 400;
-		// 	line-height: 1.3;
-		// 	padding: $sidebar-item-padding;
-		// 	color: #eee;
-		// }
-
 		.sidebar__expandable-arrow,
 		.gridicons-external {
 			display: none;
@@ -61,7 +54,7 @@ $font-size: rem( 14px );
 
 		.sidebar__menu.is-togglable {
 			.sidebar__heading {
-				padding: 0;
+				padding: 0 0 0 8px;
 				font-weight: 400;
 
 				&:hover {
@@ -110,5 +103,12 @@ $font-size: rem( 14px );
 				padding: 0;
 			}
 		}
+	}
+
+	//client/my-sites/current-site/style.scss
+	.current-site .site,
+	.current-site .all-sites,
+	.current-site__switch-sites {
+		border-color: transparent;
 	}
 }

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -1,0 +1,35 @@
+// This files overrides client/layout/sidebar/style.scss
+// Changes should be merged before nav unification goes to production
+// Override Global Vars
+$sidebar-width-max: 200px;
+$sidebar-width-min: 228px;
+
+// Local Vars
+$sidebar-item-padding: 8px 0;
+$font-size: rem( 14px );
+
+.sidebar {
+	.sidebar__heading {
+		font-size: $font-size;
+		font-weight: 400;
+		line-height: 1.3;
+		padding: $sidebar-item-padding;
+	}
+
+	.sidebar__menu-link {
+		font-size: $font-size;
+		padding: $sidebar-item-padding;
+	}
+
+	.sidebar__menu.is-togglable {
+		.sidebar__heading {
+			padding: $sidebar-item-padding;
+			font-weight: 400;
+		}
+
+		.sidebar__expandable-arrow {
+			width: 20px;
+			height: 20px;
+		}
+	}
+}

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -11,6 +11,7 @@
 	--color-sidebar-border: var( --color-surface-backdrop );
 	--color-sidebar-text: #eee;
 	--color-sidebar-gridicon-fill: var( --color-sidebar-text );
+	--color-sidebar-text-alternative: #a2aab2;
 }
 
 // Local Vars
@@ -22,7 +23,7 @@ $font-size: rem( 14px );
 	.sidebar {
 		background-color: var( --color-sidebar-background );
 
-		hr {
+		.sidebar__separator {
 			margin: 0 0 11px;
 		}
 
@@ -91,9 +92,10 @@ $font-size: rem( 14px );
 
 			.sidebar__menu-link {
 				padding: 5px 12px;
-				// font-size: rem( 13px );
+				/* stylelint-disable-next-line scales/font-size */
+				font-size: rem( 13px );
 				line-height: 1.4;
-				font-weight: 600;
+				font-weight: 400;
 				color: #b4b9be;
 
 				&:hover {

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -1,7 +1,7 @@
 // The following changes should be merged before nav unification goes to production
 
 // Override Global Vars
-.nav-unification {
+.is-nav-unification {
 	--sidebar-width-max: 200px;
 	--sidebar-width-min: 200px;
 	--color-sidebar-background: #23282d;
@@ -15,98 +15,100 @@
 $sidebar-item-padding: 8px 0;
 $font-size: rem( 14px );
 
-.sidebar {
-	background-color: var( --color-sidebar-background );
+.is-nav-unification {
+	.sidebar {
+		background-color: var( --color-sidebar-background );
 
-	hr {
-		margin: 0 0 11px 0;
-	}
-
-	.sidebar__heading,
-	.sidebar__menu-link {
-		position: relative;
-		font-size: $font-size;
-		font-weight: 400;
-		line-height: 1.3;
-		padding: 0;
-		color: var( --color-sidebar-text );
-		align-items: center;
-
-		&:hover {
-			background-color: #191e23;
-			color: #00b9eb;
+		hr {
+			margin: 0 0 11px;
 		}
-	}
 
-	.sidebar__expandable-title,
-	.sidebar__menu-link-text {
-		padding: $sidebar-item-padding;
-	}
-
-	// .sidebar__menu-link {
-	// 	font-size: $font-size;
-	// 	font-weight: 400;
-	// 	line-height: 1.3;
-	// 	padding: $sidebar-item-padding;
-	// 	color: #eee;
-	// }
-
-	.sidebar__expandable-arrow,
-	.gridicons-external {
-		display: none;
-		width: 20px;
-		height: 20px;
-	}
-
-	.sidebar__menu.is-togglable {
-		.sidebar__heading {
-			padding: 0;
+		.sidebar__heading,
+		.sidebar__menu-link {
+			position: relative;
+			font-size: $font-size;
 			font-weight: 400;
+			line-height: 1.3;
+			padding: 0;
+			color: var( --color-sidebar-text );
+			align-items: center;
 
 			&:hover {
 				background-color: #191e23;
 				color: #00b9eb;
 			}
 		}
-	}
 
-	.sidebar__menu.is-toggle-open .sidebar__heading {
-		background: #0073aa;
-		color: white;
-
-		&:after {
-			right: 0;
-			border: solid 8px transparent;
-			content: ' ';
-			height: 0;
-			width: 0;
-			position: absolute;
-			pointer-events: none;
-			border-right-color: #f1f1f1;
-			top: 50%;
-			margin-top: -8px;
+		.sidebar__expandable-title,
+		.sidebar__menu-link-text {
+			padding: $sidebar-item-padding;
 		}
-	}
 
-	.sidebar__expandable-content {
-		background: #32373c;
-		padding: 7px 0 8px;
+		// .sidebar__menu-link {
+		// 	font-size: $font-size;
+		// 	font-weight: 400;
+		// 	line-height: 1.3;
+		// 	padding: $sidebar-item-padding;
+		// 	color: #eee;
+		// }
 
-		.sidebar__menu-link {
-			padding: 5px 12px;
-			font-size: 13px;
-			line-height: 1.4;
-			font-weight: 500;
-			color: #b4b9be;
+		.sidebar__expandable-arrow,
+		.gridicons-external {
+			display: none;
+			width: 20px;
+			height: 20px;
+		}
 
-			&:hover {
-				background-color: transparent;
-				color: white;
+		.sidebar__menu.is-togglable {
+			.sidebar__heading {
+				padding: 0;
+				font-weight: 400;
+
+				&:hover {
+					background-color: #191e23;
+					color: #00b9eb;
+				}
 			}
 		}
 
-		.sidebar__menu-link-text {
-			padding: 0;
+		.sidebar__menu.is-toggle-open .sidebar__heading {
+			background: #0073aa;
+			color: white;
+
+			&::after {
+				right: 0;
+				border: solid 8px transparent;
+				content: ' ';
+				height: 0;
+				width: 0;
+				position: absolute;
+				pointer-events: none;
+				border-right-color: #f1f1f1;
+				top: 50%;
+				margin-top: -8px;
+			}
+		}
+
+		.sidebar__expandable-content {
+			background: #32373c;
+			padding: 7px 0 8px;
+
+			.sidebar__menu-link {
+				padding: 5px 12px;
+				// font-size: rem( 13px );
+				line-height: 1.4;
+				font-weight: 600;
+				color: #b4b9be;
+
+				&:hover {
+					background-color: transparent;
+					color: white;
+				}
+			}
+
+			.sidebar__menu-link-text {
+				padding: 0;
+			}
 		}
 	}
 }

--- a/client/my-sites/sidebar-unified/style.scss
+++ b/client/my-sites/sidebar-unified/style.scss
@@ -1,9 +1,11 @@
-// The following changes should be merged before nav unification goes to production
+// The following changes should be merged in their respective files before nav unification goes to production
 
 // Override Global Vars
 .is-nav-unification {
+	// client/assets/stylesheets/shared/_variables.scss
 	--sidebar-width-max: 200px;
 	--sidebar-width-min: 200px;
+
 	--color-sidebar-background: #23282d;
 	--color-sidebar-background-rgb: 35, 40, 45;
 	--color-sidebar-border: var( --color-surface-backdrop );
@@ -16,6 +18,7 @@ $sidebar-item-padding: 8px 0;
 $font-size: rem( 14px );
 
 .is-nav-unification {
+	// client/layout/sidebar/style.scss
 	.sidebar {
 		background-color: var( --color-sidebar-background );
 

--- a/client/post-editor/editor-confirmation-sidebar/style.scss
+++ b/client/post-editor/editor-confirmation-sidebar/style.scss
@@ -29,7 +29,7 @@
 .editor-confirmation-sidebar__sidebar {
 	display: flex;
 	flex-direction: column;
-	width: $sidebar-width-max;
+	width: var( --sidebar-width-max );
 	background: var( --color-neutral-0 );
 	border-left: 1px solid var( --color-neutral-5 );
 	border-right: none;
@@ -38,12 +38,12 @@
 	top: 0;
 	bottom: 0;
 	left: auto;
-	right: -$sidebar-width-max;
+	right: -var( --sidebar-width-max );
 	z-index: z-index( 'root', '.editor-confirmation-sidebar__sidebar' );
 	transition: all 0.15s cubic-bezier( 0.075, 0.82, 0.165, 1 );
 
 	&.is-active {
-		transform: translateX( -$sidebar-width-max );
+		transform: translateX( -var( --sidebar-width-max ) );
 	}
 
 	@include breakpoint-deprecated( '<660px' ) {
@@ -75,8 +75,7 @@
 	padding: 0 24px;
 	box-sizing: border-box;
 	background: var( --color-surface );
-	box-shadow:
-		0 0 0 1px rgba( var( --color-neutral-10-rgb ), 0.5 ),
+	box-shadow: 0 0 0 1px rgba( var( --color-neutral-10-rgb ), 0.5 ),
 		0 1px 2px var( --color-neutral-0 );
 }
 

--- a/client/post-editor/editor-ground-control/style.scss
+++ b/client/post-editor/editor-ground-control/style.scss
@@ -25,7 +25,7 @@
 
 .editor-ground-control .site {
 	flex: 0 0 auto;
-	max-width: $sidebar-width-max;
+	max-width: var( --sidebar-width-max );
 
 	@include breakpoint-deprecated( '<660px' ) {
 		display: none;

--- a/client/post-editor/editor-html-toolbar/style.scss
+++ b/client/post-editor/editor-html-toolbar/style.scss
@@ -22,11 +22,11 @@
 		}
 
 		.focus-sidebar & {
-			@media screen and ( max-width: ( 700px + $sidebar-width-max ) ) {
+			@media screen and ( max-width: ( 700px + var( --sidebar-width-max ) ) ) {
 				border-left-width: 0;
 				border-right-width: 0;
 			}
-  		}
+		}
 	}
 
 	&.is-pinned .editor-html-toolbar__wrapper {
@@ -41,22 +41,22 @@
 
 		.focus-sidebar &,
 		.has-chat & {
-			width: calc( 100% - ( #{ $sidebar-width-max + 1 } ) );
+			width: calc( 100% - ( #{var( --sidebar-width-max )} + 1 ) );
 		}
 
 		.focus-sidebar.has-chat & {
-			width: calc( 100% - ( #{ ( $sidebar-width-max * 2 ) + 1 } ) );
+			width: calc( 100% - ( ( #{var( --sidebar-width-max )} * 2 ) + 1 ) );
 			left: 0;
 		}
 
 		@include breakpoint-deprecated( '660px-960px' ) {
 			.focus-sidebar &,
 			.has-chat & {
-				width: calc( 100% - ( #{ $sidebar-width-max + 1 } ) );
+				width: calc( 100% - ( #{var( --sidebar-width-max )} + 1 ) );
 			}
 
 			.focus-sidebar.has-chat & {
-				width: calc( 100% - ( #{ ( $sidebar-width-max * 2 ) + 1 } ) );
+				width: calc( 100% - ( ( #{var( --sidebar-width-max )} * 2 ) + 1 ) );
 			}
 		}
 	}
@@ -199,7 +199,8 @@
 		}
 
 		&:hover {
-			.gridicon, span {
+			.gridicon,
+			span {
 				color: var( --color-accent );
 			}
 		}

--- a/client/post-editor/editor-html-toolbar/style.scss
+++ b/client/post-editor/editor-html-toolbar/style.scss
@@ -41,22 +41,22 @@
 
 		.focus-sidebar &,
 		.has-chat & {
-			width: calc( 100% - ( #{var( --sidebar-width-max )} + 1 ) );
+			width: calc( 100% - var( --sidebar-width-max ) - 1px );
 		}
 
 		.focus-sidebar.has-chat & {
-			width: calc( 100% - ( ( #{var( --sidebar-width-max )} * 2 ) + 1 ) );
+			width: calc( 100% - var( --sidebar-width-max ) * 2 - 1px );
 			left: 0;
 		}
 
 		@include breakpoint-deprecated( '660px-960px' ) {
 			.focus-sidebar &,
 			.has-chat & {
-				width: calc( 100% - ( #{var( --sidebar-width-max )} + 1 ) );
+				width: calc( 100% - var( --sidebar-width-max ) - 1px );
 			}
 
 			.focus-sidebar.has-chat & {
-				width: calc( 100% - ( ( #{var( --sidebar-width-max )} * 2 ) + 1 ) );
+				width: calc( 100% - var( --sidebar-width-max ) * 2 - 1px );
 			}
 		}
 	}

--- a/client/post-editor/editor-sidebar/style.scss
+++ b/client/post-editor/editor-sidebar/style.scss
@@ -1,8 +1,8 @@
 .editor-sidebar {
-    position: fixed;
-    top: 46px;
-    right: -$sidebar-width-max;
-    bottom: 0;
+	position: fixed;
+	top: 46px;
+	right: -var( --sidebar-width-max );
+	bottom: 0;
 	display: flex;
 	flex-direction: column;
 	z-index: z-index( 'root', '.editor-sidebar' );
@@ -16,7 +16,7 @@
 	overflow-x: hidden;
 
 	.focus-sidebar & {
-		transform: translateX( -$sidebar-width-max );
+		transform: translateX( -var( --sidebar-width-max ) );
 	}
 
 	.focus-sidebar .is-loading & {
@@ -25,9 +25,8 @@
 
 	@include breakpoint-deprecated( '>660px' ) {
 		border-right: 1px solid var( --color-neutral-5 );
-		width: $sidebar-width-max;
+		width: var( --sidebar-width-max );
 	}
-
 
 	@include breakpoint-deprecated( '<660px' ) {
 		position: relative;
@@ -46,7 +45,7 @@
 }
 
 .editor-sidebar .sidebar__footer {
-  height: 45px;
+	height: 45px;
 	align-items: center;
 	padding: 0;
 	border-top: 1px solid var( --color-neutral-5 );

--- a/client/post-editor/editor-visibility/style.scss
+++ b/client/post-editor/editor-visibility/style.scss
@@ -17,11 +17,11 @@
 	}
 
 	.select-dropdown__header {
-		max-width: calc( var( --sidebar-width-max ) - $accordion-padding * 2 );
+		max-width: calc( var( --sidebar-width-max ) - $accordion-padding * 2px );
 
 		@include breakpoint-deprecated( '<660px' ) {
 			max-width: 100%;
-			min-width: calc( var( --sidebar-width-max ) - $accordion-padding * 2 );
+			min-width: calc( var( --sidebar-width-max ) - $accordion-padding * 2px );
 		}
 	}
 

--- a/client/post-editor/editor-visibility/style.scss
+++ b/client/post-editor/editor-visibility/style.scss
@@ -17,11 +17,11 @@
 	}
 
 	.select-dropdown__header {
-		max-width: ( var( --sidebar-width-max ) - $accordion-padding * 2 );
+		max-width: calc( var( --sidebar-width-max ) - $accordion-padding * 2 );
 
 		@include breakpoint-deprecated( '<660px' ) {
 			max-width: 100%;
-			min-width: ( var( --sidebar-width-max ) - $accordion-padding * 2 );
+			min-width: calc( var( --sidebar-width-max ) - $accordion-padding * 2 );
 		}
 	}
 

--- a/client/post-editor/editor-visibility/style.scss
+++ b/client/post-editor/editor-visibility/style.scss
@@ -17,11 +17,11 @@
 	}
 
 	.select-dropdown__header {
-		max-width: ( $sidebar-width-max - $accordion-padding * 2 );
+		max-width: ( var( --sidebar-width-max ) - $accordion-padding * 2 );
 
 		@include breakpoint-deprecated( '<660px' ) {
 			max-width: 100%;
-			min-width: ( $sidebar-width-max - $accordion-padding * 2 );
+			min-width: ( var( --sidebar-width-max ) - $accordion-padding * 2 );
 		}
 	}
 

--- a/client/post-editor/editor-visibility/style.scss
+++ b/client/post-editor/editor-visibility/style.scss
@@ -17,11 +17,11 @@
 	}
 
 	.select-dropdown__header {
-		max-width: calc( var( --sidebar-width-max ) - $accordion-padding * 2px );
+		max-width: calc( var( --sidebar-width-max ) - ( #{$accordion-padding} * 2 ) );
 
 		@include breakpoint-deprecated( '<660px' ) {
 			max-width: 100%;
-			min-width: calc( var( --sidebar-width-max ) - $accordion-padding * 2px );
+			min-width: calc( var( --sidebar-width-max ) - ( #{$accordion-padding} * 2 ) );
 		}
 	}
 

--- a/client/post-editor/style.scss
+++ b/client/post-editor/style.scss
@@ -67,7 +67,7 @@
 	.focus-sidebar &,
 	.focus-editor-confirmation-sidebar & {
 		left: calc( var( --sidebar-width-max ) / -2 );
-		width: calc( 100% - ( #{var( --sidebar-width-max )} ) ); // subtract sidebar width
+		width: calc( 100% - var( --sidebar-width-max ) ); // subtract sidebar width
 	}
 }
 

--- a/client/post-editor/style.scss
+++ b/client/post-editor/style.scss
@@ -1,4 +1,3 @@
-
 @import url( '//s1.wp.com/wp-includes/css/dashicons.css?v=20150727' );
 
 .is-group-editor.layout {
@@ -67,8 +66,8 @@
 
 	.focus-sidebar &,
 	.focus-editor-confirmation-sidebar & {
-		left: ( $sidebar-width-max / -2 );
-		width: calc( 100% - ( #{$sidebar-width-max} ) ); // subtract sidebar width
+		left: ( var( --sidebar-width-max ) / -2 );
+		width: calc( 100% - ( #{var( --sidebar-width-max )} ) ); // subtract sidebar width
 	}
 }
 

--- a/client/post-editor/style.scss
+++ b/client/post-editor/style.scss
@@ -66,7 +66,7 @@
 
 	.focus-sidebar &,
 	.focus-editor-confirmation-sidebar & {
-		left: ( var( --sidebar-width-max ) / -2 );
+		left: calc( var( --sidebar-width-max ) / -2 );
 		width: calc( 100% - ( #{var( --sidebar-width-max )} ) ); // subtract sidebar width
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Make all the changes needed so that left nav looks (not works) like the wp-admin (spacing, margin, padding perspective) and basic colors
![](https://cln.sh/Ml1qtx+)

#### Testing instructions
* Apply D49204-code
* ~Apply D49005-code~ Now merged.
* Apply sticker to your sandbox `wp blog-stickers add --sticker=nav-unification --who=<username> --blog_id=<blog_id>`
* Run calyspo and add `?flags=nav-unification` to the url
* Go to your sandboxed site, it should look like per spacing, margin, padding perspective
![](https://cln.sh/vR9V7J+)

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


Fixes #45460