### PR TITLE
Plans: Exclude site_id in Tracks events when no site is selected

### DIFF
--- a/client/my-sites/plans-v2/selector.tsx
+++ b/client/my-sites/plans-v2/selector.tsx
@@ -66,7 +66,7 @@ const SelectorPage = ( {
 		if ( product.subtypes.length ) {
 			dispatch(
 				recordTracksEvent( 'calypso_product_subtypes_view', {
-					site_id: siteId,
+					site_id: siteId || undefined,
 					product_slug: product.productSlug,
 					duration: currentDuration,
 				} )
@@ -96,7 +96,7 @@ const SelectorPage = ( {
 
 		dispatch(
 			recordTracksEvent( 'calypso_plans_type_change', {
-				site_id: siteId,
+				site_id: siteId || undefined,
 				product_type: selectedType,
 			} )
 		);
@@ -110,7 +110,7 @@ const SelectorPage = ( {
 
 		dispatch(
 			recordTracksEvent( 'calypso_plans_duration_change', {
-				site_id: siteId,
+				site_id: siteId || undefined,
 				duration: selectedDuration,
 			} )
 		);


### PR DESCRIPTION
Follows up on #45384.

#### Changes proposed in this Pull Request

* For new Tracks events on the Plans page, set the `site_id` parameter to `undefined` if it's null, excluding it from the outgoing request.

#### Testing instructions

Testing steps are similar to #45384. For the following scenarios on cloud.jetpack.com/pricing, verify that `site_id` is not included in the outgoing Tracks request, since no site is selected in that context.

* Visit the Pricing page on Jetpack Cloud in your testing environment.
* Open your browser's DevTools window to the **Network** panel and monitor for **Image** requests.
* Select different values in the Duration toggle. Verify that for each change in value, a request goes out to `t.gif`, and that `site_id` is not part of the query string parameters.
* Select different values in the Type dropdown. Verify that for each change in value, a request goes out to `t.gif`, and that `site_id` is not part of the query string parameters.
* Select a product with at least one sub-type (e.g., Jetpack Backup). Verify that a request goes out to `t.gif`, and that `site_id` is not part of the query string parameters.