### PR TITLE
Minor style updates to cloud pricing page on mobile

### DIFF
--- a/client/landing/jetpack-cloud/sections/pricing/jpcom-masterbar/style.scss
+++ b/client/landing/jetpack-cloud/sections/pricing/jpcom-masterbar/style.scss
@@ -34,11 +34,14 @@ $jpcom-gray-darken30: darken( $jpcom-gray, 30% ); // #3d596d
 }
 
 .jpcom-masterbar__inner {
-	display: flex;
-	justify-content: space-between;
-	flex-wrap: wrap;
+	// Breakpoint taken from jetpack.com, not standard in Calypso
+	@media ( min-width: 375px ) {
+		display: flex;
+		justify-content: space-between;
+		flex-wrap: wrap;
 
-	text-align: left;
+		text-align: left;
+	}
 
 	@include break-large {
 		flex-wrap: nowrap;
@@ -104,7 +107,12 @@ $jpcom-gray-darken30: darken( $jpcom-gray, 30% ); // #3d596d
 }
 
 .jpcom-masterbar__nav-item {
-	padding: 0 3px;
+	padding: 0 30px;
+
+	// Breakpoint taken from jetpack.com, not standard in Calypso
+	@media ( min-width: 375px ) {
+		padding: 0 3px;
+	}
 
 	a {
 		color: $jpcom-primary;
@@ -115,15 +123,19 @@ $jpcom-gray-darken30: darken( $jpcom-gray, 30% ); // #3d596d
 
 		padding: 10px 0;
 
-		margin-left: 16px;
-
 		font-weight: 600;
-		font-size: 1.1em;
+		font-size: 0.875rem;
 
 		border-bottom: 2px transparent solid;
 		border-radius: 0;
 
 		transition: all 0.5s ease-in-out;
+
+		@media ( min-width: 375px ) {
+			margin-left: 16px;
+
+			font-size: 1.125rem;
+		}
 
 		@include break-large {
 			width: inherit;
@@ -143,6 +155,16 @@ $jpcom-gray-darken30: darken( $jpcom-gray, 30% ); // #3d596d
 }
 
 .jpcom-masterbar__navbutton.mobilenav {
+	width: 100%;
+	margin-top: 24px;
+
+	// Breakpoint taken from jetpack.com, not standard in Calypso
+	@media ( min-width: 375px ) {
+		width: auto;
+		margin-top: 0;
+		margin-bottom: 8px;
+	}
+
 	@include break-large {
 		display: none;
 	}
@@ -152,8 +174,7 @@ $jpcom-gray-darken30: darken( $jpcom-gray, 30% ); // #3d596d
 	flex-grow: 0;
 	flex-shrink: 0;
 
-	padding: 1em;
-	margin-bottom: 8px;
+	padding: 16px;
 
 	color: $jpcom-gray-darken30;
 	font-weight: bold;

--- a/client/my-sites/plans-v2/style.scss
+++ b/client/my-sites/plans-v2/style.scss
@@ -37,8 +37,14 @@
 }
 
 .selector__divider {
-	border-bottom: solid 1px var( --color-border-subtle );
 	margin: 40px 0;
+
+	border-bottom: solid 1px var( --color-border-subtle );
+	visibility: hidden;
+
+	@include break-large {
+		visibility: visible;
+	}
 }
 
 /**


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR updates the styles of the menu and hides the divider in the pricing page on mobile.

### Testing instructions

- Run Jetpack cloud locally
- Visit `/pricing`
- Check that you see what's in the mockups below

### Screenshots

#### Menu <375px

_Before_
<img width="388" alt="Screen Shot 2020-09-09 at 11 28 18 AM" src="https://user-images.githubusercontent.com/1620183/92622212-cc99cd00-f292-11ea-87d2-417b172e11a5.png">
<img width="389" alt="Screen Shot 2020-09-09 at 11 28 23 AM" src="https://user-images.githubusercontent.com/1620183/92622223-cefc2700-f292-11ea-88f5-272b87a0a6c2.png">

_After_
<img width="385" alt="Screen Shot 2020-09-09 at 11 27 43 AM" src="https://user-images.githubusercontent.com/1620183/92622234-d3284480-f292-11ea-8ed6-0a7d51728422.png">
<img width="386" alt="Screen Shot 2020-09-09 at 11 27 49 AM" src="https://user-images.githubusercontent.com/1620183/92622239-d4597180-f292-11ea-98a4-a7b00225be0a.png">


#### Menu <960px (no change)

_Before_
<img width="614" alt="Screen Shot 2020-09-09 at 11 29 01 AM" src="https://user-images.githubusercontent.com/1620183/92622328-eaffc880-f292-11ea-8bf6-1f1eabe709ce.png">
<img width="617" alt="Screen Shot 2020-09-09 at 11 29 06 AM" src="https://user-images.githubusercontent.com/1620183/92622344-edfab900-f292-11ea-9ec4-42561bbd1c13.png">


_After_
<img width="617" alt="Screen Shot 2020-09-09 at 11 28 45 AM" src="https://user-images.githubusercontent.com/1620183/92622368-f226d680-f292-11ea-8464-6dccd0b6d847.png">
<img width="619" alt="Screen Shot 2020-09-09 at 11 28 49 AM" src="https://user-images.githubusercontent.com/1620183/92622373-f3580380-f292-11ea-9995-7e931ff8eeb4.png">


#### Menu >= 960px (no change)

_Before_
<img width="981" alt="Screen Shot 2020-09-09 at 11 29 55 AM" src="https://user-images.githubusercontent.com/1620183/92622437-ffdc5c00-f292-11ea-9821-da3bea81fdb3.png">

_After_
<img width="978" alt="Screen Shot 2020-09-09 at 11 29 46 AM" src="https://user-images.githubusercontent.com/1620183/92622457-07036a00-f293-11ea-881e-9ffb5e5fb37f.png">


#### Divider, mobile

_Before_
<img width="396" alt="Screen Shot 2020-09-09 at 11 36 08 AM" src="https://user-images.githubusercontent.com/1620183/92621936-762c8e80-f292-11ea-80bc-e5a281b5f7ab.png">


_After_
<img width="414" alt="Screen Shot 2020-09-09 at 11 35 51 AM" src="https://user-images.githubusercontent.com/1620183/92621949-7a58ac00-f292-11ea-8719-018821495fcc.png">
