### PR TITLE
Checkout: Wait for products to be fetched before preparing renewals

### DIFF
--- a/client/my-sites/checkout/composite-checkout/use-prepare-product-for-cart.js
+++ b/client/my-sites/checkout/composite-checkout/use-prepare-product-for-cart.js
@@ -24,7 +24,7 @@ import { requestProductsList } from 'state/products-list/actions';
 import getUpgradePlanSlugFromPath from 'state/selectors/get-upgrade-plan-slug-from-path';
 import { createItemToAddToCart } from './add-items';
 
-const debug = debugFactory( 'calypso:composite-checkout:use-prepare-product-for-cart' );
+const debug = debugFactory( 'calypso:composite-checkout:use-prepare-products-for-cart' );
 
 export default function usePrepareProductsForCart( {
 	siteId,
@@ -66,7 +66,7 @@ function useAddRenewalItems( { originalPurchaseId, productAlias, setState } ) {
 		if ( ! originalPurchaseId ) {
 			return;
 		}
-		if ( isFetchingProducts ) {
+		if ( isFetchingProducts || Object.keys( products || {} ).length < 1 ) {
 			debug( 'waiting on products fetch for renewal' );
 			return;
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

`usePrepareProductsForCart` waits for all the required data to load before trying to generate its output, but it's possible for a render to occur when `isProductsListFetching` returns false but `getProductsList` is still empty (I think this is just because they are different parts of Redux state and sometimes one has updated before the other?). Most of the parts of `usePrepareProductsForCart` account for this and check that both `isProductsListFetching` is false and `getProductsList` is not empty, but that guard is not in place in `useAddRenewalItems`.

In this PR, we add that guard to `useAddRenewalItems` also.

props to @DavidRothstein for figuring out how to reproduce this bug!

#### Testing instructions

- Start Calypso with `ENABLE_FEATURES=force-sympathy yarn start` to prevent caching.
- Make sure your shopping cart is empty.
- Visit a renewal URL directly (pasted or typed into your URL bar, not by clicking a link).
- Verify that the page loads with the renewal in your cart.
