### PR TITLE
Gutenboarding: release Feature picker and plan recommendation

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -221,7 +221,7 @@ export default {
 		localeExceptions: [ 'en', 'es' ],
 	},
 	existingUsersGutenbergOnboard: {
-		datestamp: '20200828',
+		datestamp: '20200911',
 		variations: {
 			gutenberg: 50,
 			control: 50,

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -120,8 +120,13 @@ export default {
 
 			next();
 		} else {
+			const flowName = getFlowName( context.params );
 			const userLoggedIn = isUserLoggedIn( context.store.getState() );
-			if ( userLoggedIn && 'gutenberg' === abtest( 'existingUsersGutenbergOnboard' ) ) {
+			if (
+				userLoggedIn &&
+				flowName === 'onboarding' &&
+				'gutenberg' === abtest( 'existingUsersGutenbergOnboard' )
+			) {
 				gutenbergRedirect( context.params.flowName );
 				return;
 			}

--- a/config/production.json
+++ b/config/production.json
@@ -40,7 +40,7 @@
 		"external-media/free-photo-library": true,
 		"gdpr-banner": true,
 		"google-my-business": true,
-		"gutenboarding/feature-picker": false,
+		"gutenboarding/feature-picker": true,
 		"gutenboarding/new-launch": true,
 		"gutenboarding/use-patterns": false,
 		"happychat": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -46,7 +46,7 @@
 		"gutenboarding/mshot-preview": false,
 		"gutenboarding/style-preview-verticals": false,
 		"gutenboarding/language-picker": false,
-		"gutenboarding/feature-picker": false,
+		"gutenboarding/feature-picker": true,
 		"gutenboarding/new-launch": true,
 		"happychat": true,
 		"help": true,


### PR DESCRIPTION
#### Checklist before merging this PR:
- [x] merge #45054 
- [x] release a new version of Editing Toolkit plugin #45536
- [x] test on horizon both Gutenboarding and Site setup flows

#### Changes proposed in this Pull Request
* Enable feature picker and PlansGrid accordion in production
* Update signup controller to run Gutenboarding test only for 'onboarding' flow
* Update `existingUsersGutenbergOnboard` A/B test datestamp

#### Testing instructions
* Go to https://calypso.live/?branch=update/gutenboarding-enable-feature-picker
* Open console and run `localStorage.setItem( 'ABTests', '{"existingUsersGutenbergOnboard_20200910":"gutenberg"}' )`
* Go to `/start` => you should be redirected to /new
* Go to `/start/rewind-auto-config` or `/start/` + [[any other flow](https://github.com/Automattic/wp-calypso/blob/master/client/signup/config/flows-pure.js)] => no redirect

Fixes #45232
