### PR TITLE
CartFreeUserPlanUpsell: Only add a planItem to the cart if it exists

### DIFF
--- a/client/my-sites/checkout/cart/cart-free-user-plan-upsell.jsx
+++ b/client/my-sites/checkout/cart/cart-free-user-plan-upsell.jsx
@@ -130,8 +130,10 @@ class CartFreeUserPlanUpsell extends React.Component {
 
 	addPlanToCart = () => {
 		const planCartItem = planItem( PLAN_PERSONAL, {} );
-		this.props.addItemToCart( planCartItem );
-		this.props.clickUpsellAddToCart();
+		if ( planCartItem ) {
+			this.props.addItemToCart( planCartItem );
+			this.props.clickUpsellAddToCart();
+		}
 	};
 
 	render() {


### PR DESCRIPTION
It's currently not possible for a call like `planItem(PLAN_PERSONAL, {})` to return `null`, but the function is allowed to do so, so for safety and future-proofing, let's just guard against that possibility here.

#### Testing instructions

- Add a domain to your cart for an account that has no plan. 
- Visit composite checkout and verify that you see the upsell in the sidebar. 
- Verify that clicking the CTA button successfully adds the Personal Plan to the cart and verify that the upsell disappears.

