### PR TITLE
Fix bug where setting the homepage would not be saved if post editor was not preloaded

### DIFF
--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -50,11 +50,10 @@ import isJetpackModuleActive from 'state/selectors/is-jetpack-module-active';
 import canCurrentUser from 'state/selectors/can-current-user';
 import config from 'config';
 
-import 'state/data-layer/wpcom/sites/homepage';
-
 const recordEvent = partial( recordGoogleEvent, 'Pages' );
 
 function preloadEditor() {
+	// preloading the post editor is also neccessary to set the homepage and coming soon page.
 	preload( 'post-editor' );
 }
 
@@ -221,11 +220,7 @@ class Page extends Component {
 		}
 
 		return (
-			<PopoverMenuItem
-				onClick={ this.editPage }
-				onMouseOver={ preloadEditor }
-				onFocus={ preloadEditor }
-			>
+			<PopoverMenuItem onClick={ this.editPage }>
 				<Gridicon icon="pencil" size={ 18 } />
 				{ this.props.translate( 'Edit' ) }
 			</PopoverMenuItem>
@@ -747,6 +742,7 @@ class Page extends Component {
 
 	handleMenuToggle = ( isVisible ) => {
 		if ( isVisible ) {
+			preloadEditor();
 			// record a GA event when the menu is opened
 			this.props.recordMoreOptions();
 		}

--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -50,6 +50,8 @@ import isJetpackModuleActive from 'state/selectors/is-jetpack-module-active';
 import canCurrentUser from 'state/selectors/can-current-user';
 import config from 'config';
 
+import 'state/data-layer/wpcom/sites/homepage';
+
 const recordEvent = partial( recordGoogleEvent, 'Pages' );
 
 function preloadEditor() {


### PR DESCRIPTION
### To reproduce
* Open the popover menu for a page
* Do not mouse over the **Edit** button
* Change the homepage
* Reload the page
* The homepage will switch back to the old homepage

In this gif I change the homepage to *Contact* page and when I reload the page, the change has not been applied.

![Sep-10-2020 09-16-54](https://user-images.githubusercontent.com/22446385/92664144-8e5de580-f346-11ea-9061-6b3eafd2e553.gif)

### Explaination
Setting a new homepage is achieved by posting to the 'homepage' endpoint.
This is done by an action handler registered in `state/data-layer/wpcom/sites/homepage/index.js`
But the file `state/data-layer/wpcom/sites/homepage/index.js` is not included in the main calypso bundle
It is included in the `post-editor` bundle.
On the **Pages** page, mousing over the **Edit** button preloads the `post-editor` bundle
With the `post-editor` bundle loaded, the `state/data-layer/wpcom/sites/homepage/index.js` file is loaded and updating the homepage makes the correct http POST request
But if the user does not mouse over the **Edit** button, and instead sets the homepage immediately ( e.g. by moving their mouse from the side of the menu ), then the homepage will not actually be updated.
This PR preloads the  `state/data-layer/wpcom/sites/homepage/index.js` file from `client/my-sites/pages/page/index.js` so that the correct call to set the homepage will always be made