### PR TITLE
@automattic/social-previews 1.1.0

### DIFF
--- a/docs/monorepo.md
+++ b/docs/monorepo.md
@@ -186,7 +186,7 @@ yarn run build-packages
 
 ### Getting NPM permissions to publish in the `@automattic` scope
 
-To publish packages in the `@automattic` scope, and to update packages owned by the `automattic` organization, you need to be a member of this organization on npmjs.com. If you're an Automattician, ask around to find an organization owner or admin who will add you as a member. Publish packages under your own name, so that people can find you and ping you in case anything goes wrong with the published package.
+To publish packages in the `@automattic` scope, and to update packages owned by the `automattic` organization, you need to be a member of this organization on npmjs.com. If you're an Automattician, you can add yourself to the organization, using the credentials found in the secret store.
 
 ### Publishing all outdated packages
 

--- a/packages/social-previews/CHANGELOG.md
+++ b/packages/social-previews/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+#### v1.1.0 (2020-09-10)
+
+- Twitter: Add previewing for attached images, videos, or quoted tweets.
+- Twitter: Add support for previewing entire threads.
+
 #### v1.0.4 (2020-08-24)
 
 - Fixed Twitter styles for viewports < 600px in width

--- a/packages/social-previews/README.md
+++ b/packages/social-previews/README.md
@@ -49,6 +49,47 @@ import { SearchPreview } from '@automattic/social-previews';
 />;
 ```
 
+Twitter previews support the same properties for previewing a single tweet, but can also preview multiple tweets in the form of a Twitter thread. For that, the `tweets` property takes an array of tweets. Each item in this array can take additional information about the tweet, giving the preview a more native feel.
+
+```js
+import { TwitterPreview } from '@automattic/social-previews';
+
+const tweetTemplate = {
+	date: Date.now(),
+	name: 'My Account Name',
+	profileImage: 'https://abs.twimg.com/sticky/default_profile_images/default_profile_bigger.png',
+	screenName: '@myAccount',
+}
+
+<TwitterPreview
+	tweets={ [
+		{
+			...tweetTemplate,
+			text: 'This is the first tweet in a thread, it only has text in it.',
+		},
+		{
+			...tweetTemplate,
+			text: 'The second tweet has some images attached, too!',
+			media: [
+				{
+					{
+						alt: 'The alt text for the first image.',
+						url: 'https://url.for.the/first/image.png',
+						type: 'image/png',
+					},
+					{
+						alt: 'The alt text for the second image.',
+						url: 'https://url.for.the/second/image.png',
+						type: 'image/png',
+					},
+
+				}
+			]
+		}
+	] }
+/>;
+```
+
 ## Properties
 
 There are a number of common properties used across all components:

--- a/packages/social-previews/package.json
+++ b/packages/social-previews/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/social-previews",
-	"version": "1.0.4",
+	"version": "1.1.0",
 	"description": "A suite of components to generate previews for a post for both social and search engines",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",


### PR DESCRIPTION
Version bump for the `@automattic/social-previews` package, to release the changes implemented in #44956.

