### PR TITLE
Pages: preloading editor when the ellipsis menu is opened

### DIFF
--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -747,6 +747,7 @@ class Page extends Component {
 		if ( isVisible ) {
 			// record a GA event when the menu is opened
 			this.props.recordMoreOptions();
+			preloadEditor();
 		}
 	};
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Following on from the bug identified in https://github.com/Automattic/wp-calypso/pull/45532, this is just a test to see if we can preload when the ellipses opens.

#### Testing instructions

See #45532


