### PR TITLE
Bump WordPress.com Editing Toolkit plugin to v2.3

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WordPress.com Editing Toolkit
  * Description: Enhances your page creation workflow within the Block Editor.
- * Version: 2.2
+ * Version: 2.3
  * Author: Automattic
  * Author URI: https://automattic.com/wordpress-plugins/
  * License: GPLv2 or later
@@ -35,7 +35,7 @@ namespace A8C\FSE;
  *
  * @var string
  */
-define( 'PLUGIN_VERSION', '2.2' );
+define( 'PLUGIN_VERSION', '2.3' );
 
 // Always include these helper files for dotcom FSE.
 require_once __DIR__ . '/dotcom-fse/helpers.php';

--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -43,6 +43,7 @@ This plugin is experimental, so we don't provide any support for it outside of w
 = 2.3 =
 * Bump NewsPack version to 1.8.0 (https://github.com/Automattic/wp-calypso/pull/45423)
 * Starter Page Templates: Add Current layout to page layout picker when editing a homepage (https://github.com/Automattic/wp-calypso/pull/43980)
+* Add tracks events for the block editor sidebar (https://github.com/Automattic/wp-calypso/pull/45429)
 
 = 2.2 =
 * Improve experience of opening and closing the sidebar with assistive technology (https://github.com/Automattic/wp-calypso/pull/45349)

--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -45,6 +45,7 @@ This plugin is experimental, so we don't provide any support for it outside of w
 * Starter Page Templates: Add Current layout to page layout picker when editing a homepage (https://github.com/Automattic/wp-calypso/pull/43980)
 * Add tracks events for the block editor sidebar (https://github.com/Automattic/wp-calypso/pull/45429)
 * Site setup: add PlansGrid accordion (https://github.com/Automattic/wp-calypso/pull/45054)
+* Disable the sidebar if the editor is not in fullscreen mode (https://github.com/Automattic/wp-calypso/pull/45561)
 
 = 2.2 =
 * Improve experience of opening and closing the sidebar with assistive technology (https://github.com/Automattic/wp-calypso/pull/45349)

--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -44,6 +44,7 @@ This plugin is experimental, so we don't provide any support for it outside of w
 * Bump NewsPack version to 1.8.0 (https://github.com/Automattic/wp-calypso/pull/45423)
 * Starter Page Templates: Add Current layout to page layout picker when editing a homepage (https://github.com/Automattic/wp-calypso/pull/43980)
 * Add tracks events for the block editor sidebar (https://github.com/Automattic/wp-calypso/pull/45429)
+* Site setup: add PlansGrid accordion (https://github.com/Automattic/wp-calypso/pull/45054)
 
 = 2.2 =
 * Improve experience of opening and closing the sidebar with assistive technology (https://github.com/Automattic/wp-calypso/pull/45349)

--- a/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
+++ b/apps/editing-toolkit/editing-toolkit-plugin/readme.txt
@@ -3,7 +3,7 @@ Contributors: alexislloyd, allancole, automattic, bartkalisz, codebykat, copons,
 Tags: block, blocks, editor, gutenberg, page
 Requires at least: 5.0
 Tested up to: 5.5
-Stable tag: 2.2
+Stable tag: 2.3
 Requires PHP: 5.6.20
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -39,6 +39,10 @@ This plugin is experimental, so we don't provide any support for it outside of w
 
 
 == Changelog ==
+
+= 2.3 =
+* Bump NewsPack version to 1.8.0 (https://github.com/Automattic/wp-calypso/pull/45423)
+* Starter Page Templates: Add Current layout to page layout picker when editing a homepage (https://github.com/Automattic/wp-calypso/pull/43980)
 
 = 2.2 =
 * Improve experience of opening and closing the sidebar with assistive technology (https://github.com/Automattic/wp-calypso/pull/45349)

--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/wpcom-editing-toolkit",
-	"version": "2.2.0",
+	"version": "2.3.0",
 	"description": "Plugin for editing-related features.",
 	"sideEffects": true,
 	"repository": {

--- a/package.json
+++ b/package.json
@@ -181,7 +181,7 @@
 		"@automattic/webpack-inline-constant-exports-plugin": "^0.0.1",
 		"@automattic/wp-babel-makepot": "^1.0.0",
 		"@automattic/wpcom-block-editor": "^1.0.0-alpha.0",
-		"@automattic/wpcom-editing-toolkit": "^2.2.0",
+		"@automattic/wpcom-editing-toolkit": "^2.3.0",
 		"@babel/cli": "^7.10.5",
 		"@babel/core": "^7.11.1",
 		"@babel/register": "^7.10.5",


### PR DESCRIPTION
#### Changes included in this release

* https://github.com/Automattic/wp-calypso/pull/43980 (added to notes)
* https://github.com/Automattic/wp-calypso/pull/45280
* https://github.com/Automattic/wp-calypso/pull/45429 (added to notes)
* https://github.com/Automattic/wp-calypso/pull/44888
* https://github.com/Automattic/wp-calypso/pull/45423 (added to notes)
* https://github.com/Automattic/wp-calypso/pull/45502
* https://github.com/Automattic/wp-calypso/pull/45054 (added to notes)
* https://github.com/Automattic/wp-calypso/pull/45561 (added to notes)

#### Testing instructions

* Apply generated diff to sandbox
* Test changes listed in release notes are present
* Install build on an atomic site
* Test that editor works on atomic with and without gutenberg plugin enabled