### PR TITLE
Posts: Fix potential async state issue

### DIFF
--- a/client/my-sites/post-type-list/post-action-counts/index.jsx
+++ b/client/my-sites/post-type-list/post-action-counts/index.jsx
@@ -48,7 +48,9 @@ class PostActionCounts extends PureComponent {
 		this.onActionClick( 'likes' )();
 		event.preventDefault();
 
-		this.setState( { showLikesPopover: ! this.state.showLikesPopover } );
+		this.setState( ( { showLikesPopover } ) => ( {
+			showLikesPopover: ! showLikesPopover,
+		} ) );
 	};
 
 	closeLikesPopover = () => {


### PR DESCRIPTION
This is a follow-up to #45293.

#### Changes proposed in this Pull Request

* Use callback to set the component state to avoid async state update conflicts - see https://reactjs.org/docs/state-and-lifecycle.html#state-updates-may-be-asynchronous for motivation.

#### Testing instructions

* Go to http://calypso.localhost:3000/posts/:site where `:site` is a public site with some traffic.
* Play with the popover that appears when you click on "% Likes" of a post, and verify it works like it did before:
  * Clicking it initially opens the popover.
  * Clicking anywhere closes the popover.
  * Clicking on another popover closes the previous popover in favor of the new one.
* Verify tests still pass.
