### PR TITLE
Inline Help: Fix manage posts link

### DIFF
--- a/client/blocks/inline-help/admin-sections.js
+++ b/client/blocks/inline-help/admin-sections.js
@@ -337,7 +337,7 @@ export const adminSections = memoize( ( siteId, siteSlug, state ) => [
 	},
 	{
 		title: translate( 'Manage my blog posts' ),
-		link: '/posts/${ siteSlug }',
+		link: `/posts/${ siteSlug }`,
 		synonyms: [ 'lists', 'posts' ],
 		icon: 'my-sites',
 	},


### PR DESCRIPTION
Currently, if you go to Customer Home (`/home/:siteSlug`) and in the inline help section search for "my blog posts" or something similar, you'll get a result "Manage my blog posts". This link currently doesn't work right. Seems like this has been introduced in #43790 and was caused by the fact that the path string isn't a string literal, but was meant to be.

#### Changes proposed in this Pull Request

* Inline Help: Fix manage posts link by changing the path to a string literal.

#### Testing instructions

* Go to `/home/:siteSlug`.
* In the inline help search field, search for "my blog posts"
* Verify the "Manage my blog posts" article link works correctly.
