### PR TITLE
Dial up concierge upsell offer and include Business plan

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -69,10 +69,10 @@ export default {
 	},
 	conciergeUpsellDial: {
 		//this test is used to dial down the upsell offer
-		datestamp: '20200421',
+		datestamp: '20200910',
 		variations: {
-			offer: 50,
-			noOffer: 50,
+			offer: 75,
+			noOffer: 25,
 		},
 		defaultVariation: 'noOffer',
 		allowExistingUsers: true,

--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -47,6 +47,7 @@ import {
 	isBlogger,
 	isPersonal,
 	isPremium,
+	isBusiness,
 	isSiteRedirect,
 	isSpaceUpgrade,
 	isUnlimitedSpace,
@@ -353,6 +354,10 @@ export function hasPersonalPlan( cart ) {
 
 export function hasPremiumPlan( cart ) {
 	return some( getAllCartItems( cart ), isPremium );
+}
+
+export function hasBusinessPlan( cart ) {
+	return some( getAllCartItems( cart ), isBusiness );
 }
 
 export function hasDomainCredit( cart ) {

--- a/client/my-sites/checkout/composite-checkout/use-get-thank-you-url.js
+++ b/client/my-sites/checkout/composite-checkout/use-get-thank-you-url.js
@@ -388,6 +388,7 @@ export function useGetThankYouUrl( {
 		const isTransactionResultEmpty = isEmpty( transactionResult );
 
 		if ( siteSlug === 'no-user' || ! siteSlug ) {
+			// eslint-disable-next-line react-hooks/exhaustive-deps
 			siteSlug = select( 'wpcom' ).getSiteSlug();
 		}
 

--- a/client/my-sites/checkout/composite-checkout/use-get-thank-you-url.js
+++ b/client/my-sites/checkout/composite-checkout/use-get-thank-you-url.js
@@ -25,6 +25,7 @@ import {
 	hasBloggerPlan,
 	hasPersonalPlan,
 	hasPremiumPlan,
+	hasBusinessPlan,
 	hasEcommercePlan,
 } from 'lib/cart-values/cart-items';
 import { managePurchase } from 'me/purchases/paths';
@@ -267,7 +268,10 @@ function getRedirectUrlForConciergeNudge( {
 		config.isEnabled( 'upsell/concierge-session' ) &&
 		! hasConciergeSession( cart ) &&
 		! hasJetpackPlan( cart ) &&
-		( hasBloggerPlan( cart ) || hasPersonalPlan( cart ) || hasPremiumPlan( cart ) )
+		( hasBloggerPlan( cart ) ||
+			hasPersonalPlan( cart ) ||
+			hasPremiumPlan( cart ) ||
+			hasBusinessPlan( cart ) )
 	) {
 		// A user just purchased one of the qualifying plans
 		// Show them the concierge session upsell page


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Per the request in pbBQWj-hz-p2#comment-997, we are dialling up the concierge upsell offers. It will now be shown to 75% of EN.
Business user will now be added to the upsell offers.

#### Testing instructions

Go through the signup flow at /start and purchase a:
- Personal or Premium plans to check for regression.
- Business plan to check that it now also show the upsell.

When in the "offer" variation, you should be shown the concierge upsell. When in "noOffer" variation, you should not be shown the upsell.

