### PR TITLE
Language picker: Fix input element ref

### DIFF
--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -361,7 +361,7 @@ class Search extends Component {
 						placeholder={ placeholder }
 						role="searchbox"
 						value={ searchValue }
-						ref={ this.setSearchInputRef }
+						inputRef={ this.setSearchInputRef }
 						onChange={ this.onChange }
 						onKeyUp={ this.keyUp }
 						onKeyDown={ this.keyDown }


### PR DESCRIPTION
Input component in the search bar of the language picker has been replaced with `FormTextInput` component in https://github.com/Automattic/wp-calypso/pull/45358. As a result, the `this.searchInput` reference is being set to the component instead of the input DOM element, which is throwing error when trying to access `this.searchInput.blur()`

#### Changes proposed in this Pull Request

* Use `inputRef` ref proxy prop to set reference to the input element in the language picker search bar.

**Before:**
![CleanShot 2020-09-10 at 15 54 22](https://user-images.githubusercontent.com/2722412/92731714-1dd2bb00-f37e-11ea-9d6f-05c4d133e77a.gif)

**After:**
![CleanShot 2020-09-10 at 15 53 01](https://user-images.githubusercontent.com/2722412/92731720-20351500-f37e-11ea-8c20-30b0b4596d5c.gif)

#### Testing instructions

* Go to Account Settings `/me/account` and open language picker.
* Start typing text that would return language items, e.g. `French`
* Click on the close button next to the search field and confirm it blurs the field and closes the search bar.