### PR TITLE
Add locale to pricing page URL (in cloud)

### DIFF
--- a/client/landing/jetpack-cloud/sections/pricing/controller.tsx
+++ b/client/landing/jetpack-cloud/sections/pricing/controller.tsx
@@ -9,8 +9,15 @@ import React from 'react';
 import { hideMasterbar } from 'state/ui/actions';
 import Header from './header';
 import JetpackComFooter from './jpcom-footer';
+import { setLocale } from 'state/ui/language/actions';
 
 export function jetpackPricingContext( context, next ) {
+	const { locale } = context.params;
+
+	if ( locale ) {
+		context.store.dispatch( setLocale( locale ) );
+	}
+
 	context.store.dispatch( hideMasterbar() );
 	context.header = <Header />;
 	context.footer = <JetpackComFooter />;

--- a/client/landing/jetpack-cloud/sections/pricing/index.ts
+++ b/client/landing/jetpack-cloud/sections/pricing/index.ts
@@ -10,5 +10,5 @@ import * as controller from './controller';
 import './style.scss';
 
 export default function () {
-	plansV2( `/pricing`, controller.jetpackPricingContext );
+	plansV2( `/:locale?/pricing`, controller.jetpackPricingContext );
 }

--- a/client/sections.js
+++ b/client/sections.js
@@ -449,7 +449,7 @@ const sections = [
 	},
 	{
 		name: 'jetpack-cloud-pricing',
-		paths: [ '/pricing' ],
+		paths: [ '/pricing', '/[^\\/]+/pricing' ],
 		module: 'calypso/landing/jetpack-cloud/sections/pricing',
 		group: 'jetpack-cloud',
 		enableLoggedOut: true,


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR allows to display the pricing page in the locale specified in its URL.

The goal is, as users navigate through jetpack.com in their language, to not break their experience and show them the new pricing page in the same language (the pricing page lives in cloud.jetpack.com, not jetpack.com).

Fixes 1169247016322522-as-1191918158300069

### Implementation notes

In jetpack.com, the locale is represented in URLs by a subdomain, e.g. `fr.jetpack.com`. The idea is to redirect the URL `fr.jetpack.com/pricing` to `cloud.jetpack.com/fr/pricing`.

### Testing instructions

- Download the PR locally and run Jetpack cloud
- Visit `/pricing`
- You should see the page in the language set in your Calypso preferences
- Visit `/fr/pricing`, or use any other locale you're familiar with
- Check that the page is displayed in this language (**note: all strings are not translated yet, so you just need to identify one or some texts in that language**)

### Screenshots

`/pricing`
<img width="890" alt="Screen Shot 2020-09-10 at 9 05 38 AM" src="https://user-images.githubusercontent.com/1620183/92732715-d1b75480-f344-11ea-9a6b-adedad9103ab.png">



`/fr/pricing`
<img width="891" alt="Screen Shot 2020-09-10 at 9 05 22 AM" src="https://user-images.githubusercontent.com/1620183/92732731-d67c0880-f344-11ea-8aad-5ae40b233e0f.png">
