### PR TITLE
Language Picker: Use lighter color for links in language item tooltip

### DIFF
--- a/client/components/language-picker/modal.scss
+++ b/client/components/language-picker/modal.scss
@@ -80,6 +80,10 @@
 
 .language-picker__modal-tooltip {
 	z-index: z-index( 'root', 'popover.is-dialog-visible' );
+
+	a {
+		color: var( --color-link-20 );
+	}
 }
 
 .language-picker__modal-list {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use lighter link color for links in language picker items' tooltips to improve readability.

**Before:**
![image](https://user-images.githubusercontent.com/2722412/92734929-a56df900-f381-11ea-8182-adc2b284a6cf.png)


**After:**
![image](https://user-images.githubusercontent.com/2722412/92734749-7ce5ff00-f381-11ea-8aeb-f5820bbaee67.png)


#### Testing instructions

* Go to Account Settings `/me/account` and open language picker.
* Hover over language item with tooltip.
* Confirm lighter link color reads better across different color schemes.