### PR TITLE
react-i18n: Add empathy mode

### DIFF
--- a/client/components/calypso-i18n-provider/index.tsx
+++ b/client/components/calypso-i18n-provider/index.tsx
@@ -9,7 +9,7 @@ import i18n from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import I18nEmpathyManager from 'components/i18n-empathy-manager';
+import I18nEmpathyManager from 'calypso/components/i18n-empathy-manager';
 
 const CalypsoI18nProvider: React.FunctionComponent = ( { children } ) => {
 	const [ localeData, setLocaleData ] = React.useState( i18n.getLocale() );

--- a/client/components/calypso-i18n-provider/index.tsx
+++ b/client/components/calypso-i18n-provider/index.tsx
@@ -6,6 +6,11 @@ import { setLocaleData as setWpI18nLocaleData } from '@wordpress/i18n';
 import { I18nProvider } from '@automattic/react-i18n';
 import i18n from 'i18n-calypso';
 
+/**
+ * Internal dependencies
+ */
+import I18nEmpathyManager from 'components/i18n-empathy-manager';
+
 const CalypsoI18nProvider: React.FunctionComponent = ( { children } ) => {
 	const [ localeData, setLocaleData ] = React.useState( i18n.getLocale() );
 
@@ -25,7 +30,12 @@ const CalypsoI18nProvider: React.FunctionComponent = ( { children } ) => {
 		};
 	}, [] );
 
-	return <I18nProvider localeData={ localeData }>{ children }</I18nProvider>;
+	return (
+		<I18nProvider localeData={ localeData }>
+			<I18nEmpathyManager />
+			{ children }
+		</I18nProvider>
+	);
 };
 
 export default CalypsoI18nProvider;

--- a/client/components/i18n-empathy-manager/index.tsx
+++ b/client/components/i18n-empathy-manager/index.tsx
@@ -1,0 +1,45 @@
+/**
+ * External dependencies
+ */
+import * as React from 'react';
+import { useI18n } from '@automattic/react-i18n';
+
+const I18nEmpathyManager: React.FunctionComponent = () => {
+	const {
+		localeData,
+		hasTranslation,
+		registerTranslationHook,
+		unregisterTranslationHook,
+	} = useI18n();
+
+	const emapthyModeTranslationHook = (
+		_translation: string,
+		originalArgs: ( string | number )[],
+		fnName: string
+	) => {
+		const [ singular ] = originalArgs;
+		let context;
+
+		if ( fnName === '_x' ) {
+			context = originalArgs[ 1 ];
+		} else if ( fnName === '_nx' ) {
+			context = originalArgs[ 3 ];
+		}
+
+		// @todo: should use `i18nEmpathyTranslate`, instead of singular
+		// @todo2: shuold use dymanic placeholder for fallback
+		return hasTranslation( singular, context ) ? singular : "👉 I don't Understand";
+	};
+
+	React.useEffect( () => {
+		if ( registerTranslationHook && unregisterTranslationHook ) {
+			registerTranslationHook( emapthyModeTranslationHook );
+
+			return () => unregisterTranslationHook( emapthyModeTranslationHook );
+		}
+	}, [ localeData ] );
+
+	return null;
+};
+
+export default I18nEmpathyManager;

--- a/client/components/i18n-empathy-manager/index.tsx
+++ b/client/components/i18n-empathy-manager/index.tsx
@@ -5,37 +5,30 @@ import * as React from 'react';
 import { useI18n } from '@automattic/react-i18n';
 
 const I18nEmpathyManager: React.FunctionComponent = () => {
-	const {
-		localeData,
-		hasTranslation,
-		registerTranslationHook,
-		unregisterTranslationHook,
-	} = useI18n();
-
-	const emapthyModeTranslationHook = (
-		_translation: string,
-		originalArgs: ( string | number )[],
-		fnName: string
-	) => {
-		const [ singular ] = originalArgs;
-		let context;
-
-		if ( fnName === '_x' ) {
-			context = originalArgs[ 1 ];
-		} else if ( fnName === '_nx' ) {
-			context = originalArgs[ 3 ];
-		}
-
-		// @todo: should use `i18nEmpathyTranslate`, instead of singular
-		// @todo2: shuold use dymanic placeholder for fallback
-		return hasTranslation( singular, context ) ? singular : "👉 I don't Understand";
-	};
+	const { localeData, hasTranslation, addFilter, removeFilter } = useI18n();
 
 	React.useEffect( () => {
-		if ( registerTranslationHook && unregisterTranslationHook ) {
-			registerTranslationHook( emapthyModeTranslationHook );
+		if ( addFilter ) {
+			addFilter(
+				'translation',
+				'i18n-empathy-mode',
+				( _translation: string, originalArgs: ( string | number )[], fnName: string ) => {
+					const [ singular ] = originalArgs;
+					let context;
 
-			return () => unregisterTranslationHook( emapthyModeTranslationHook );
+					if ( fnName === '_x' ) {
+						context = originalArgs[ 1 ];
+					} else if ( fnName === '_nx' ) {
+						context = originalArgs[ 3 ];
+					}
+
+					// @todo: should use `i18nEmpathyTranslate`, instead of singular
+					// @todo2: shuold use dymanic placeholder for fallback
+					return hasTranslation( singular, context ) ? singular : "👉 I don't Understand";
+				}
+			);
+
+			return () => removeFilter( 'translation', 'i18n-empathy-mode' );
 		}
 	}, [ localeData ] );
 

--- a/client/components/i18n-empathy-manager/index.tsx
+++ b/client/components/i18n-empathy-manager/index.tsx
@@ -8,8 +8,8 @@ import { createI18n } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import config from 'config';
-import userFactory from 'lib/user';
+import config from 'calypso/config';
+import userFactory from 'calypso/lib/user';
 
 const placeholderOriginalString = "I don't understand";
 
@@ -46,18 +46,14 @@ const I18nEmpathyManager: React.FunctionComponent = () => {
 
 		const placeholder = __( "I don't understand" );
 
-		if ( ! addFilter || ! removeFilter ) {
+		if ( ! hasTranslation ) {
 			return;
 		}
 
 		addFilter(
-			'translation',
-			'i18n-empathy-mode',
-			(
-				translation: string,
-				originalArgs: ( string | number )[],
-				fnName: '__' | '_n' | '_nx' | '_x'
-			) => {
+			'postTranslation',
+			'calypso/i18n-empathy-mode',
+			( translation: string, originalArgs: string[], fnName: '__' | '_n' | '_nx' | '_x' ) => {
 				const [ singular ] = originalArgs;
 				let context;
 
@@ -83,7 +79,9 @@ const I18nEmpathyManager: React.FunctionComponent = () => {
 			}
 		);
 
-		return () => removeFilter( 'translation', 'i18n-empathy-mode' );
+		return () => {
+			removeFilter( 'postTranslation', 'calypso/i18n-empathy-mode' );
+		};
 	}, [ localeData ] );
 
 	return null;

--- a/client/lib/user/user.d.ts
+++ b/client/lib/user/user.d.ts
@@ -75,4 +75,5 @@ export type OptionalUserData = {
 	user_URL: string;
 	username: string;
 	visible_site_count: number;
+	i18n_empathy_mode: boolean;
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add Empathy mode for react-i18n

**Before:**
![image](https://user-images.githubusercontent.com/2722412/93190992-aff70c80-f74c-11ea-9c6e-93658b715cfa.png)

**After:**
![image](https://user-images.githubusercontent.com/2722412/93191233-f482a800-f74c-11ea-91f2-6d920cafd33c.png)

#### Testing instructions

1. Change your UI language to a language with low translations percentage and enable Empathy Mode from http://calypso.localhost:3000/me/account
2. Go to a section that's using `@wordpress/i18n` translate functions and has missing translations and confirm it renders the empathy mode placeholder - "I don't understand" or its corresponding translation for the selected locale. For example, use Bulgarian and go to http://calypso.localhost:3000/checkout/{site}?retry=1#step2

**Dependencies:**
https://github.com/Automattic/wp-calypso/pull/44743