### PR TITLE
Offer Reset: redirect to /pricing when locale is included in the URL

### DIFF
--- a/client/landing/jetpack-cloud/sections/pricing/controller.tsx
+++ b/client/landing/jetpack-cloud/sections/pricing/controller.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import page from 'page';
 
 /**
  * Internal dependencies
@@ -16,6 +17,7 @@ export function jetpackPricingContext( context, next ) {
 
 	if ( locale ) {
 		context.store.dispatch( setLocale( locale ) );
+		page.redirect( '/pricing' );
 	}
 
 	context.store.dispatch( hideMasterbar() );

--- a/client/landing/jetpack-cloud/sections/pricing/index.ts
+++ b/client/landing/jetpack-cloud/sections/pricing/index.ts
@@ -10,5 +10,6 @@ import * as controller from './controller';
 import './style.scss';
 
 export default function () {
-	plansV2( `/:locale?/pricing`, controller.jetpackPricingContext );
+	plansV2( `/:locale/pricing`, controller.jetpackPricingContext );
+	plansV2( `/pricing`, controller.jetpackPricingContext );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* When a locale is present in the `/:locale?/pricing` URL, set the locale in Calypso, and then redirect the user to `/pricing`. 

#### Testing instructions

* Run this PR (Jetpack cloud version).
* Visit `http://jetpack.cloud.localhost:3000/pricing/` and move around the flows to verify that everything work as expected.
* Visit `http://jetpack.cloud.localhost:3000/:locale/pricing/`, where `:locale` can be any of the supported languages (e.g.: `en`, `de`, `fr`, `es`).
* Verify that you were redirected to `http://jetpack.cloud.localhost:3000/pricing/`.
* Verify that the app kept the locale and didn't revert to English.
* Move around the page and verify that you can see the details and upsells pages.

Fixes a small bug introduced in #45545 
