### PR TITLE
Checkout: Remove onEvent from useShoppingCartManager

### DIFF
--- a/client/my-sites/checkout/cart/upcoming-renewals-reminder.tsx
+++ b/client/my-sites/checkout/cart/upcoming-renewals-reminder.tsx
@@ -24,9 +24,8 @@ import {
 	getRenewableSitePurchases,
 	hasLoadedUserPurchasesFromServer,
 } from 'state/purchases/selectors';
-import UpcomingRenewalsDialog, {
-	Purchase,
-} from 'me/purchases/upcoming-renewals/upcoming-renewals-dialog';
+import UpcomingRenewalsDialog from 'me/purchases/upcoming-renewals/upcoming-renewals-dialog';
+import type { Purchase } from 'lib/purchases/types';
 import { MockResponseCart } from 'my-sites/checkout/composite-checkout/components/secondary-cart-promotions';
 import { useLocalizedMoment } from 'components/localized-moment';
 

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -197,6 +197,7 @@ export default function CompositeCheckout( {
 		isPendingUpdate: isCartPendingUpdate,
 		responseCart,
 		loadingError: cartLoadingError,
+		loadingErrorType: cartLoadingErrorType,
 		addItem,
 		variantSelectOverride,
 	} = useShoppingCartManager( {
@@ -377,7 +378,9 @@ export default function CompositeCheckout( {
 	} );
 
 	useActOnceOnStrings( [ cartLoadingError ].filter( Boolean ), ( messages ) => {
-		messages.forEach( ( message ) => recordEvent( { type: 'CART_ERROR', payload: message } ) );
+		messages.forEach( ( message ) =>
+			recordEvent( { type: 'CART_ERROR', payload: { type: cartLoadingErrorType, message } } )
+		);
 	} );
 
 	// Display errors. Note that we display all errors if any of them change,

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -82,6 +82,7 @@ import useCachedDomainContactDetails from './hooks/use-cached-domain-contact-det
 import CartMessages from 'my-sites/checkout/cart/cart-messages';
 import useActOnceOnStrings from './hooks/use-act-once-on-strings';
 import useRedirectIfCartEmpty from './hooks/use-redirect-if-cart-empty';
+import useEffectOnChange from './hooks/use-effect-on-change';
 
 const debug = debugFactory( 'calypso:composite-checkout:composite-checkout' );
 
@@ -208,6 +209,13 @@ export default function CompositeCheckout( {
 		getCart: getCart || wpcomGetCart,
 		onEvent: recordEvent,
 	} );
+
+	useEffectOnChange( () => {
+		recordEvent( {
+			type: 'CART_INIT_COMPLETE',
+			payload: responseCart,
+		} );
+	}, [ isLoadingCart ] );
 
 	const {
 		items,

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -354,6 +354,10 @@ export default function CompositeCheckout( {
 		);
 	} );
 
+	useActOnceOnStrings( [ cartLoadingError ].filter( Boolean ), ( messages ) => {
+		messages.forEach( ( message ) => recordEvent( { type: 'CART_ERROR', payload: message } ) );
+	} );
+
 	// Display errors. Note that we display all errors if any of them change,
 	// because notices.error() otherwise will remove the previously displayed
 	// errors.

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -208,9 +208,9 @@ export default function CompositeCheckout( {
 		couponToAddOnInitialize: couponCodeFromUrl,
 		setCart: setCart || wpcomSetCart,
 		getCart: getCart || wpcomGetCart,
-		onEvent: recordEvent,
 	} );
 
+	// This will record cart items being added when the page loads
 	useEffectOnChange(
 		( previous ) => {
 			if ( productsForCart.length > 0 && productsForCart !== previous ) {
@@ -223,6 +223,25 @@ export default function CompositeCheckout( {
 			}
 		},
 		[ productsForCart ]
+	);
+
+	// This will record cart items being added after the page loads
+	useEffectOnChange(
+		( previous ) => {
+			if (
+				! isLoadingCart &&
+				isCartPendingUpdate &&
+				responseCart.products.length > previous.length
+			) {
+				responseCart.products.forEach( ( productToAdd ) => {
+					recordEvent( {
+						type: 'CART_ADD_ITEM',
+						payload: productToAdd,
+					} );
+				} );
+			}
+		},
+		[ responseCart.products ]
 	);
 
 	useEffectOnChange( () => {

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -225,25 +225,6 @@ export default function CompositeCheckout( {
 		[ productsForCart ]
 	);
 
-	// This will record cart items being added after the page loads
-	useEffectOnChange(
-		( previous ) => {
-			if (
-				! isLoadingCart &&
-				isCartPendingUpdate &&
-				responseCart.products.length > previous.length
-			) {
-				responseCart.products.forEach( ( productToAdd ) => {
-					recordEvent( {
-						type: 'CART_ADD_ITEM',
-						payload: productToAdd,
-					} );
-				} );
-			}
-		},
-		[ responseCart.products ]
-	);
-
 	useEffectOnChange( () => {
 		recordEvent( {
 			type: 'CART_INIT_COMPLETE',
@@ -503,8 +484,15 @@ export default function CompositeCheckout( {
 	// Often products are added using just the product_slug but missing the
 	// product_id; this adds it.
 	const addItemWithEssentialProperties = useCallback(
-		( cartItem ) => addItem( fillInSingleCartItemAttributes( cartItem, products ) ),
-		[ addItem, products ]
+		( cartItem ) => {
+			const adjustedItem = fillInSingleCartItemAttributes( cartItem, products );
+			recordEvent( {
+				type: 'CART_ADD_ITEM',
+				payload: adjustedItem,
+			} );
+			addItem( adjustedItem );
+		},
+		[ addItem, products, recordEvent ]
 	);
 
 	const includeDomainDetails = needsDomainDetails( responseCart );

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -210,6 +210,22 @@ export default function CompositeCheckout( {
 		onEvent: recordEvent,
 	} );
 
+	useEffectOnChange(
+		// FIXME: we need to modify the hook to pass the previous value to the callback
+		( previous ) => {
+			// FIXME: productsForCart is recreated so this won't work; we want this block to run only once but only once productsForCart is set
+			if ( productsForCart.length > 0 && productsForCart !== previous ) {
+				productsForCart.forEach( ( productToAdd ) => {
+					recordEvent( {
+						type: 'CART_ADD_ITEM',
+						payload: productToAdd,
+					} );
+				} );
+			}
+		},
+		[ productsForCart ]
+	);
+
 	useEffectOnChange( () => {
 		recordEvent( {
 			type: 'CART_INIT_COMPLETE',

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -211,9 +211,7 @@ export default function CompositeCheckout( {
 	} );
 
 	useEffectOnChange(
-		// FIXME: we need to modify the hook to pass the previous value to the callback
 		( previous ) => {
-			// FIXME: productsForCart is recreated so this won't work; we want this block to run only once but only once productsForCart is set
 			if ( productsForCart.length > 0 && productsForCart !== previous ) {
 				productsForCart.forEach( ( productToAdd ) => {
 					recordEvent( {

--- a/client/my-sites/checkout/composite-checkout/hooks/use-effect-on-change.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-effect-on-change.ts
@@ -10,9 +10,9 @@ import { useEffect, useRef } from 'react';
  *
  * Also, there is no clean-up function (the return value of the callback has no effect).
  */
-export default function useEffectOnChange(
-	handleChange: () => void,
-	dependencies: unknown[]
+export default function useEffectOnChange< T >(
+	handleChange: ( previous: T[] ) => void,
+	dependencies: T[]
 ): void {
 	const previous = useRef( dependencies );
 	useEffect( () => {
@@ -22,9 +22,11 @@ export default function useEffectOnChange(
 				didChange = true;
 			}
 		} );
-		previous.current = dependencies;
 		if ( didChange ) {
-			handleChange();
+			handleChange( previous.current );
 		}
-	}, [ dependencies ] ); // eslint-disable-line react-hooks/exhaustive-deps
+		previous.current = dependencies;
+		// Only depend on the dependencies; if handleChange is an anonymous
+		// function, there's no need to run this every time it changes.
+	}, dependencies ); // eslint-disable-line react-hooks/exhaustive-deps
 }

--- a/client/my-sites/checkout/composite-checkout/hooks/use-effect-on-change.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-effect-on-change.ts
@@ -6,9 +6,15 @@ import { useEffect, useRef } from 'react';
 /*
  * Run a callback function any time one of the dependencies changes
  *
- * Similar to useEffect but will not run its effects on the first call.
+ * This is similar to useEffect, but there are several differences:
  *
- * Also, there is no clean-up function (the return value of the callback has no effect).
+ * - This hook will not run its callback the first time it is called; it will
+ * only run when one of its dependencies has changed from its previous value.
+ *
+ * - This hook has no cleanup function. The return value of the callback has no
+ * effect.
+ *
+ * - The callback function will be passed the previous value as an argument.
  */
 export default function useEffectOnChange< T >(
 	handleChange: ( previous: T[] ) => void,

--- a/client/my-sites/checkout/composite-checkout/hooks/use-effect-on-change.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-effect-on-change.ts
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import { useEffect, useRef } from 'react';
+
+/*
+ * Run a callback function any time one of the dependencies changes
+ *
+ * Similar to useEffect but will not run its effects on the first call.
+ *
+ * Also, there is no clean-up function (the return value of the callback has no effect).
+ */
+export default function useEffectOnChange(
+	handleChange: () => void,
+	dependencies: unknown[]
+): void {
+	const previous = useRef( dependencies );
+	useEffect( () => {
+		let didChange = false;
+		dependencies.forEach( ( value, index ) => {
+			if ( value !== previous.current[ index ] ) {
+				didChange = true;
+			}
+		} );
+		previous.current = dependencies;
+		if ( didChange ) {
+			handleChange();
+		}
+	}, [ dependencies ] ); // eslint-disable-line react-hooks/exhaustive-deps
+}

--- a/client/my-sites/checkout/composite-checkout/hooks/use-effect-on-change.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-effect-on-change.ts
@@ -11,8 +11,8 @@ import { useEffect, useRef } from 'react';
  * - This hook will not run its callback the first time it is called; it will
  * only run when one of its dependencies has changed from its previous value.
  *
- * - This hook has no cleanup function. The return value of the callback has no
- * effect.
+ * - This hook has no cleanup function. The return value of the callback is
+ * unused, unlike the cleanup functionality of the `useEffect` return value.
  *
  * - The callback function will be passed the previous value as an argument.
  */

--- a/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/index.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/index.ts
@@ -17,6 +17,7 @@ import {
 	CacheStatus,
 	CouponStatus,
 	VariantRequestStatus,
+	ShoppingCartError,
 } from './types';
 import useShoppingCartReducer from './use-shopping-cart-reducer';
 import useInitializeCartFromServer from './use-initialize-cart-from-server';
@@ -44,6 +45,7 @@ export default function useShoppingCartManager( {
 	const couponStatus: CouponStatus = hookState.couponStatus;
 	const cacheStatus: CacheStatus = hookState.cacheStatus;
 	const loadingError: string | undefined = hookState.loadingError;
+	const loadingErrorType: ShoppingCartError | undefined = hookState.loadingErrorType;
 	const variantRequestStatus: VariantRequestStatus = hookState.variantRequestStatus;
 	const variantSelectOverride = hookState.variantSelectOverride;
 
@@ -111,6 +113,7 @@ export default function useShoppingCartManager( {
 	return {
 		isLoading: cacheStatus === 'fresh',
 		loadingError: cacheStatus === 'error' ? loadingError : null,
+		loadingErrorType,
 		isPendingUpdate: cacheStatus !== 'valid',
 		addItem,
 		removeItem,

--- a/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/index.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/index.ts
@@ -55,8 +55,7 @@ export default function useShoppingCartManager( {
 		couponToAddOnInitialize,
 		getServerCart,
 		setServerCart,
-		hookDispatch,
-		onEvent
+		hookDispatch
 	);
 
 	// Asynchronously re-validate when the cache is dirty.

--- a/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/index.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/index.ts
@@ -30,7 +30,6 @@ export default function useShoppingCartManager( {
 	couponToAddOnInitialize,
 	setCart,
 	getCart,
-	onEvent,
 }: ShoppingCartManagerArguments ): ShoppingCartManager {
 	const cartKeyString = String( cartKey || 'no-site' );
 	const setServerCart = useCallback( ( cartParam ) => setCart( cartKeyString, cartParam ), [
@@ -66,12 +65,8 @@ export default function useShoppingCartManager( {
 	const addItem: ( arg0: RequestCartProduct ) => void = useCallback(
 		( requestCartProductToAdd ) => {
 			hookDispatch( { type: 'ADD_CART_ITEM', requestCartProductToAdd } );
-			onEvent?.( {
-				type: 'CART_ADD_ITEM',
-				payload: requestCartProductToAdd,
-			} );
 		},
-		[ hookDispatch, onEvent ]
+		[ hookDispatch ]
 	);
 
 	const removeItem: ( arg0: string ) => void = useCallback(

--- a/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/index.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/index.ts
@@ -120,5 +120,5 @@ export default function useShoppingCartManager( {
 		variantSelectOverride,
 		changeItemVariant,
 		responseCart,
-	} as ShoppingCartManager;
+	};
 }

--- a/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/index.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/index.ts
@@ -61,7 +61,7 @@ export default function useShoppingCartManager( {
 	);
 
 	// Asynchronously re-validate when the cache is dirty.
-	useCartUpdateAndRevalidate( cacheStatus, responseCart, setServerCart, hookDispatch, onEvent );
+	useCartUpdateAndRevalidate( cacheStatus, responseCart, setServerCart, hookDispatch );
 
 	const addItem: ( arg0: RequestCartProduct ) => void = useCallback(
 		( requestCartProductToAdd ) => {

--- a/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/types.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/types.ts
@@ -17,7 +17,6 @@ export interface ShoppingCartManagerArguments {
 	couponToAddOnInitialize: string | null;
 	setCart: ( cartKey: string, arg1: RequestCart ) => Promise< ResponseCart >;
 	getCart: ( cartKey: string ) => Promise< ResponseCart >;
-	onEvent?: ( action: ReactStandardAction ) => void;
 }
 
 export interface VariantSelectOverride {

--- a/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/types.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/types.ts
@@ -121,6 +121,7 @@ export type ShoppingCartState = {
 	couponStatus: CouponStatus;
 	cacheStatus: CacheStatus;
 	loadingError?: string;
+	loadingErrorType?: ShoppingCartError;
 	variantRequestStatus: VariantRequestStatus;
 	variantSelectOverride: { uuid: string; overrideSelectedProductSlug: string }[];
 	queuedActions: ShoppingCartAction[];

--- a/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/types.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/types.ts
@@ -27,6 +27,7 @@ export interface VariantSelectOverride {
 export interface ShoppingCartManager {
 	isLoading: boolean;
 	loadingError: string | null | undefined;
+	loadingErrorType: ShoppingCartError | undefined;
 	isPendingUpdate: boolean;
 	addItem: ( arg0: RequestCartProduct ) => void;
 	removeItem: ( arg0: string ) => void;

--- a/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/use-cart-update-and-revalidate.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/use-cart-update-and-revalidate.ts
@@ -44,10 +44,10 @@ export default function useCartUpdateAndRevalidate(
 				hookDispatch( { type: 'CLEAR_VARIANT_SELECT_OVERRIDE' } );
 			} )
 			.catch( ( error ) => {
-				debug( 'error while fetching cart', error );
+				debug( 'error while setting cart', error );
 				hookDispatch( {
 					type: 'RAISE_ERROR',
-					error: 'GET_SERVER_CART_ERROR',
+					error: 'SET_SERVER_CART_ERROR',
 					message: error.message,
 				} );
 			} );

--- a/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/use-cart-update-and-revalidate.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/use-cart-update-and-revalidate.ts
@@ -13,7 +13,7 @@ import {
 	RequestCart,
 	convertRawResponseCartToResponseCart,
 } from '../../types/backend/shopping-cart-endpoint';
-import { CacheStatus, ShoppingCartAction, ReactStandardAction } from './types';
+import { CacheStatus, ShoppingCartAction } from './types';
 
 const debug = debugFactory( 'calypso:composite-checkout:use-cart-update-and-revalidate' );
 
@@ -21,8 +21,7 @@ export default function useCartUpdateAndRevalidate(
 	cacheStatus: CacheStatus,
 	responseCart: ResponseCart,
 	setServerCart: ( arg0: RequestCart ) => Promise< ResponseCart >,
-	hookDispatch: ( arg0: ShoppingCartAction ) => void,
-	onEvent?: ( arg0: ReactStandardAction ) => void
+	hookDispatch: ( arg0: ShoppingCartAction ) => void
 ): void {
 	useEffect( () => {
 		if ( cacheStatus !== 'invalid' ) {
@@ -51,11 +50,6 @@ export default function useCartUpdateAndRevalidate(
 					error: 'GET_SERVER_CART_ERROR',
 					message: error.message,
 				} );
-				// TODO: log the request (at least the products) so we can see why it failed
-				onEvent?.( {
-					type: 'CART_ERROR',
-					payload: { type: 'SET_SERVER_CART_ERROR', message: error.message },
-				} );
 			} );
-	}, [ setServerCart, cacheStatus, responseCart, onEvent, hookDispatch ] );
+	}, [ setServerCart, cacheStatus, responseCart, hookDispatch ] );
 }

--- a/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/use-initialize-cart-from-server.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/use-initialize-cart-from-server.ts
@@ -16,7 +16,7 @@ import {
 	convertRawResponseCartToResponseCart,
 	addCouponToResponseCart,
 } from '../../types/backend/shopping-cart-endpoint';
-import { CacheStatus, ShoppingCartAction, ReactStandardAction } from './types';
+import { CacheStatus, ShoppingCartAction } from './types';
 
 const debug = debugFactory( 'calypso:composite-checkout:use-initialize-cart-from-server' );
 
@@ -27,8 +27,7 @@ export default function useInitializeCartFromServer(
 	couponToAddOnInitialize: string | null,
 	getCart: () => Promise< ResponseCart >,
 	setCart: ( arg0: RequestCart ) => Promise< ResponseCart >,
-	hookDispatch: ( arg0: ShoppingCartAction ) => void,
-	onEvent?: ( arg0: ReactStandardAction ) => void
+	hookDispatch: ( arg0: ShoppingCartAction ) => void
 ): void {
 	const isInitialized = useRef( false );
 	useEffect( () => {
@@ -61,13 +60,10 @@ export default function useInitializeCartFromServer(
 					);
 					let responseCart = convertRawResponseCartToResponseCart( response );
 					if ( productsToAddOnInitialize?.length ) {
-						responseCart = productsToAddOnInitialize.reduce( ( updatedCart, productToAdd ) => {
-							onEvent?.( {
-								type: 'CART_ADD_ITEM',
-								payload: productToAdd,
-							} );
-							return addItemToResponseCart( updatedCart, productToAdd );
-						}, responseCart );
+						responseCart = productsToAddOnInitialize.reduce(
+							( updatedCart, productToAdd ) => addItemToResponseCart( updatedCart, productToAdd ),
+							responseCart
+						);
 					}
 					if ( couponToAddOnInitialize ) {
 						responseCart = addCouponToResponseCart( responseCart, couponToAddOnInitialize );
@@ -96,7 +92,6 @@ export default function useInitializeCartFromServer(
 		cacheStatus,
 		canInitializeCart,
 		hookDispatch,
-		onEvent,
 		getCart,
 		productsToAddOnInitialize,
 		couponToAddOnInitialize,

--- a/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/use-initialize-cart-from-server.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/use-initialize-cart-from-server.ts
@@ -83,10 +83,6 @@ export default function useInitializeCartFromServer(
 					type: 'RECEIVE_INITIAL_RESPONSE_CART',
 					initialResponseCart,
 				} );
-				onEvent?.( {
-					type: 'CART_INIT_COMPLETE',
-					payload: initialResponseCart,
-				} );
 			} )
 			.catch( ( error ) => {
 				debug( 'error while initializing cart', error );

--- a/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/use-initialize-cart-from-server.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/use-initialize-cart-from-server.ts
@@ -95,10 +95,6 @@ export default function useInitializeCartFromServer(
 					error: 'GET_SERVER_CART_ERROR',
 					message: error.message,
 				} );
-				onEvent?.( {
-					type: 'CART_ERROR',
-					payload: { type: 'GET_SERVER_CART_ERROR', message: error.message },
-				} );
 			} );
 	}, [
 		cacheStatus,

--- a/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/use-shopping-cart-reducer.ts
+++ b/client/my-sites/checkout/composite-checkout/hooks/use-shopping-cart-manager/use-shopping-cart-reducer.ts
@@ -192,6 +192,7 @@ function shoppingCartReducer(
 						...state,
 						cacheStatus: 'error',
 						loadingError: action.message,
+						loadingErrorType: action.error,
 					};
 				default:
 					return state;
@@ -215,7 +216,6 @@ function shoppingCartReducer(
 function getInitialShoppingCartState(): ShoppingCartState {
 	return {
 		responseCart: emptyResponseCart,
-		loadingError: '',
 		cacheStatus: 'fresh',
 		couponStatus: 'fresh',
 		variantRequestStatus: 'fresh',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR refactors `useShoppingCartManager` to remove the `onEvent` prop. The prop was added as a general side-effect event dispatcher, but it's not typed and it's a leaky abstraction on the hook. Checkout uses it to record analytics events for things like when the shopping cart loads and when new products are added. We can use the hook's returned state in order to record these events rather than forcing the hook to be aware of the API of our analytics handler.

Right now the handling of these events is moved to the `CompositeCheckout` component, as it is the only place where `useShoppingCartManager` is used. In the future, the hook can be moved to a parent context wrapper, and the analytics hooks can be moved there as well, which will keep them bundled with the cart manager without needing to include them in the hook itself.

#### Testing instructions

- Visit calypso, enable record-analytics debugging by typing `localStorage.setItem('debug', 'calypso:composite-checkout:record-analytics')` into your console, and then reloading the page.
- When loading checkout, make sure that the `CART_INIT_COMPLETE` event happens in the console, that it happens after the cart is initialized, and that it only happens once.
- When loading checkout with a URL that includes a product, like `/checkout/example.com/premium`, make sure that the `CART_ADD_ITEM` event happens in your console, that it has the correct product listed, and that it happens only once.
- _After_ loading checkout, break the shopping cart endpoint by applying D50045-code, then change the postal code in the contact step and press "Continue" (this will force the shopping cart endpoint to be called). Make sure you see a `CART_ERROR` event in your console with the payload type of `SET_SERVER_CART_ERROR` and an error message that mentions a 500 status code. Verify that this only happens once. (Make sure to undo the diff to continue testing.)
- Add a domain to your cart for an account that has no plan, then visit checkout and verify that you see the upsell in the sidebar (or the collapsed header at mobile width). Verify that clicking the "Add to Cart" button in the upsell successfully adds the Personal Plan to the cart and that you see the `CART_ADD_ITEM` event appear in your console. Make sure the event has the correct product listed and that it happens only once.