### PR TITLE
Start: Do not redirect site-clone flow to gutenboarding

### DIFF
--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -103,7 +103,8 @@ export default {
 			context.params.flowName === 'user' ||
 			context.params.flowName === 'account' ||
 			context.params.flowName === 'crowdsignal' ||
-			context.params.flowName === 'pressable-nux'
+			context.params.flowName === 'pressable-nux' ||
+			context.params.flowName === 'clone-site'
 		) {
 			removeWhiteBackground();
 			next();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Do not redirect the `clone-site` flow to gutenboarding

See JPOP issue 5493

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open WP.com in staging
* Hover over the bug in the bottom right, click on abtests, and ensure that `gutenberg` is selected for the `existingUsersGutenbergOnboard` test
* Go to wordpress.com/start/clone-site/$site, where $site is any connected Jetpack site
* Verify that you are redirected to wordpress.com/new
* Checkout PR
* Follow steps to make sure test is selected correctly
* Go to calypso.localhost:3000/start/clone-site/$site as above
* Ensure that you see some UI to start the cloning process

Fixes #
