### PR TITLE
Editing Toolkit Sidebar: Disable if the editor is not in fullscreen mode

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/attach-sidebar.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/attach-sidebar.tsx
@@ -45,7 +45,13 @@ registerPlugin( 'a8c-full-site-editing-nav-sidebar', {
 
 		// Uses presence of data store to detect whether this is the experimental site editor.
 		const isSiteEditor = useSelect( ( select ) => !! select( 'core/edit-site' ) );
-		if ( isSiteEditor ) {
+
+		// Disable sidebar nav if the editor is not in fullscreen mode
+		const isFullscreenActive = useSelect( ( select ) =>
+			select( 'core/edit-post' ).isFeatureActive( 'fullscreenMode' )
+		);
+
+		if ( isSiteEditor || ! isFullscreenActive ) {
 			return null;
 		}
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

The sidebar nav is active in the editor when fullscreen mode is off. It looks strange. We decided to disable it in that context. See the discussion over at: p1599758388052500-slack-CHN6J22MP

Current behaviour: https://d.pr/v/6Swgs8/dFhe2qqkHd

This change disables the sidebar when NOT in fullscreen mode.

![Sep-11-2020 09-36-18](https://user-images.githubusercontent.com/6458278/92825008-6e93f380-f412-11ea-886c-169ee671b084.gif)

## Testing instructions

Apply D49396-code and sandbox your test site.

From `{yourtestsite}/wp-admin/`, open a new post. 

Toggle Fullscreen mode and check that the sidebar is disabled when fullscreen mode is off.

Then look at this random photo:

![image](https://user-images.githubusercontent.com/6458278/92825412-dba78900-f412-11ea-8293-f215245b57de.png)


Fixes #
