### PR TITLE
Reader: hide glossary hovercard content

### DIFF
--- a/client/reader/style.scss
+++ b/client/reader/style.scss
@@ -361,3 +361,8 @@
 .is-reader-page .search-stream__single-column-results .empty-content {
 	margin-top: 0;
 }
+
+// This is a quick fix for definition hovercards https://github.com/Automattic/wp-calypso/issues/45563
+.reader-hovercard-popover {
+	display: none;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Today I started seeing glossary definition content in Reader posts and comments:

https://github.com/Automattic/wp-calypso/issues/45563

I've let the original developers of the feature know in a comment on pb6Nl-cQ4-p2. In the meantime, this is a band-aid to hide the hovercard content in Reader comments and posts.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Visit the post referenced in #45563 and ensure the API glossary definition isn't shown in the body text like this:

 <img width="749" alt="92840581-60a39a00-f435-11ea-9160-3c3f22099020" src="https://user-images.githubusercontent.com/17325/92857904-7753ec00-f449-11ea-9d47-d901a19c34ea.png">
