### PR TITLE
Adds support for importing `calypso` package in Desktop source

### DIFF
--- a/client/webpack.config.desktop.js
+++ b/client/webpack.config.desktop.js
@@ -78,12 +78,17 @@ module.exports = {
 		// These are Calypso server modules we don't need, so let's not bundle them
 		'webpack.config',
 		'server/devdocs/search-index',
+		'calypso/server/devdocs/search-index',
 	],
 	resolve: {
 		extensions: [ '.json', '.js', '.jsx', '.ts', '.tsx' ],
 		modules: [ __dirname, 'node_modules' ],
 		alias: {
 			config: 'server/config',
+			'calypso/config': 'server/config',
+			// Alias calypso to ./client. This allows for smaller bundles, as it ensures that
+			// importing `./client/file.js` is the same thing than importing `calypso/file.js`
+			calypso: __dirname,
 		},
 	},
 	plugins: [
@@ -92,6 +97,10 @@ module.exports = {
 		new webpack.DefinePlugin( { 'global.GENTLY': false } ),
 		new webpack.NormalModuleReplacementPlugin(
 			/^my-sites[/\\]themes[/\\]theme-upload$/,
+			'components/empty-component'
+		), // Depends on BOM
+		new webpack.NormalModuleReplacementPlugin(
+			/^calypso[/\\]my-sites[/\\]themes[/\\]theme-upload$/,
 			'components/empty-component'
 		), // Depends on BOM
 	],


### PR DESCRIPTION
### Background

See #44602

### Changes

Changes webpack config for desktop source to support imports from `calypso` package:

* Alilas `calypso/config` to `./client/server/config`
* Do not bundle `calypso/server/devdocs/search-index`
* Replace `calypso/my-sites/themes/theme-upload` with an empty component

### Test

1. Checkout this branch and run `yarn` to install deps.
2. Change the severity of `wpcalypso/no-package-relative-imports` from `off` to `warn` in `./eslintrc.js`
3. Auto-fix the above rule by running
    ```
    ./node_modules/.bin/eslint-nibble --ext .js,.jsx,.ts,.tsx --rule wpcalypso/no-package-relative-imports client/server/devdocs
    ./node_modules/.bin/eslint-nibble --ext .js,.jsx,.ts,.tsx --rule wpcalypso/no-package-relative-imports client/my-sites/themes
    ```
4. Do a desktop build with `yarn build-desktop:source`

Step (4) should fail in master with two errors, but it should work in this branch.
