### PR TITLE
Server build: create a self-contained JS bundle with all node_modules included

### DIFF
--- a/client/webpack.config.node.js
+++ b/client/webpack.config.node.js
@@ -170,6 +170,9 @@ const webpackConfig = {
 			BUILD_TIMESTAMP: JSON.stringify( new Date().toISOString() ),
 			COMMIT_SHA: JSON.stringify( commitSha ),
 			'process.env.NODE_ENV': JSON.stringify( bundleEnv ),
+			// The `formidable` package (used by `superagent`) contains conditional code that hijacks
+			// the `require` function. That breaks webpack.
+			'global.GENTLY': false,
 		} ),
 		new webpack.NormalModuleReplacementPlugin(
 			/^my-sites[/\\]themes[/\\]theme-upload$/,


### PR DESCRIPTION
Helps make the Calypso server+client a well-defined artifact that can be tarballed and deployed on just about any server with a good-enough version of Node.js.

Currently, one major obstacle is the `node_modules` folder that contains 1.5GB of modules that are mostly build tools and are not needed at runtime. But we don't know who is who.

The first thing that this PR adds is a `yarn run analyze-bundles:server` command that creates `webpack-analyze-bundles` overview of the bundle contents.

Then I enforce bundling `node_modules` by removing the use of the `webpack-node-externals` plugin.

**Before:**
This is how the bundle looks before this patch, with `node_modules` still external to the bundle:

Chunk sizes (the `parsed` sizes, as `gzipped` is not relevant for server):
<img width="351" alt="Screenshot 2020-09-11 at 08 56 47" src="https://user-images.githubusercontent.com/664258/92884551-3be9fb00-f412-11ea-9fcf-77d5e034bdcf.png">

Chunk layout:
<img width="1469" alt="Screenshot 2020-09-11 at 09 19 03" src="https://user-images.githubusercontent.com/664258/92884617-4b694400-f412-11ea-9cba-09c86ffb6328.png">

Even the existing server bundle seems fairly bloated. It shouldn't contain the moment locales at all, as server doesn't do anything localized. Another things that are surprising to see in the bundle are:
- the `reader` state. There's no SSR in Reader so the state is very unlikely to be used. I think this comes from the Reader social preview -- we talked about this few months ago with @getdave when he was working on `social-preview`. It would be nice to add a streamlined Reader preview component to that package, too.
- `inline-help` code. Probably dragged in by the `Layout` component.
- `lib/plans` and `lib/purchases`.

One thing that would be nice to have is creating separate chunks for isomorphic sections (like `login` or `themes`) and loading them dynamically (on first request for that section, just like in client) rather than synchronously. Then it becomes better visible whether a particular module is used by the base server, or one of the isomorphic section (and which one).

**After:**

Chunk sizes (still `parsed`):
<img width="353" alt="Screenshot 2020-09-11 at 09 08 34" src="https://user-images.githubusercontent.com/664258/92887086-82d8f000-f414-11ea-9756-b524704e278e.png">

Chunk layout:
<img width="1469" alt="Screenshot 2020-09-11 at 09 15 54" src="https://user-images.githubusercontent.com/664258/92887238-9f752800-f414-11ea-8c0e-eeeb0a93cf42.png">

The most important information is that the `node_modules` are 60% of the bundle and the remaining 40% is the original app code.

The main sources of bloat that I see here:
- the `caniuse-lite` data. It's used by `browserslist-useragent` used by the `isUAInBrowserslist` function that determines whether the browser deserves the `evergreen` or the `fallback` assets.
- the `moment-locale` data. What is new after this patch is that something is requiring `moment-locale` synchronously and it's no longer in a separate chunk.
- it seems we're bundling `lodash` twice. The server should use the `lodash-es` replacement plugin.
- the `request` library (can't find where it's used) depends on several exotic crypto librares (`sshpk`, `tweetnacl`) and also on `mime-db`