### PR TITLE
Docs: add "chromedriver not found" workaround

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -30,6 +30,7 @@ Automated end-to-end acceptance tests for the [wp-calypso](https://github.com/Au
   - [Launch Logged-In Window](docs/miscellaneous.md#launch-logged-in-window)
   - [User account requirements](docs/miscellaneous.md#user-account-requirements)
   - [List of wrapper repos & friends](docs/miscellaneous.md#list-of-wrapper-repos--friends)
+  - [How to fix the `chromedriver not found` error when running e2e tests locally](docs/miscellaneous.md#how-to-fix-the-chromedriver-not-found-error-when-running-e2e-tests-locally)
 
 ## Pre-requisites
 

--- a/test/e2e/docs/miscellaneous.md
+++ b/test/e2e/docs/miscellaneous.md
@@ -8,6 +8,7 @@
 - [User account requirements](#user-account-requirements)
 - [List of wrapper repos & friends](#list-of-wrapper-repos--friends)
 - [What to name your branch](#what-to-name-your-branch)
+- [How to fix the `chromedriver not found` error when running e2e tests locally](#how-to-fix-the-chromedriver-not-found-error-when-running-e2e-tests-locally)
 
 ## NodeJS Version
 
@@ -61,3 +62,16 @@ Friends:
 
 - Use the same naming conventions as listed in [wp-calypso](https://github.com/Automattic/wp-calypso/blob/HEAD/docs/git-workflow.md#branch-naming-scheme)
 - If you have changes to jetpack tests, be sure to add "jetpack" into your branch name so those tests are run on CI
+
+## How to fix the `chromedriver not found` error when running e2e tests locally
+
+When runnning e2e tests locally, an error can appear about chromedriver not being found in `/wp-calypso/node_modules/chromedriver/lib/chromedriver/chromedriver`
+
+This is likely due to a few `env` variables that are recommended by `yarn calypso-doctor`, since installing `chromedriver` is really slow and not needed most of the time. In particular:
+
+- `CHROMEDRIVER_SKIP_DOWNLOAD`
+- `PUPPETEER_SKIP_DOWNLOAD`
+
+You can force the download of `chromedriver` by overriding the environment variablew, and forcing a fresh install:
+
+`CHROMEDRIVER_SKIP_DOWNLOAD='' PUPPETEER_SKIP_DOWNLOAD='' yarn install --force`


### PR DESCRIPTION
Document the workaround to fix the "`chromedriver` not found" error encountered when running e2e tests locally.

A separate PR will be opened to work on a better fix (as highlighted in https://github.com/Automattic/wp-calypso/issues/45537#issuecomment-690105075)


Partially covers #45537
