### PR TITLE
Gutenboarding reset selected features on site creation

### DIFF
--- a/client/landing/gutenboarding/stores/onboard/reducer.ts
+++ b/client/landing/gutenboarding/stores/onboard/reducer.ts
@@ -165,6 +165,10 @@ const selectedFeatures: Reducer< FeatureId[], OnboardAction > = (
 		return state.filter( ( id ) => id !== action.featureId );
 	}
 
+	if ( action.type === 'RESET_ONBOARD_STORE' ) {
+		return [];
+	}
+
 	return state;
 };
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Reset feature selection after creating a site

#### Testing instructions
* Go to [/new](https://calypso.live/new?branch=update/gutenboarding-feature-picker-reset-selection)
* Create a site after selecting some features
* Go to [/new](https://calypso.live/new?branch=update/gutenboarding-feature-picker-reset-selection) again
* When reaching Features step, no feature should be selected
