### PR TITLE
Gutenboarding: use selected_features when creating a site

### DIFF
--- a/client/landing/gutenboarding/stores/onboard/actions.ts
+++ b/client/landing/gutenboarding/stores/onboard/actions.ts
@@ -36,10 +36,14 @@ export function* createSite(
 	bearerToken?: string,
 	isPublicSite = false
 ) {
-	const { domain, selectedDesign, selectedFonts, siteTitle, siteVertical }: State = yield select(
-		ONBOARD_STORE,
-		'getState'
-	);
+	const {
+		domain,
+		selectedDesign,
+		selectedFonts,
+		siteTitle,
+		siteVertical,
+		selectedFeatures,
+	}: State = yield select( ONBOARD_STORE, 'getState' );
 
 	const shouldEnableFse = !! selectedDesign?.is_fse;
 
@@ -74,6 +78,7 @@ export function* createSite(
 				font_headings: selectedFonts.headings,
 			} ),
 			use_patterns: isEnabled( 'gutenboarding/use-patterns' ),
+			selected_features: selectedFeatures,
 		},
 		...( bearerToken && { authToken: bearerToken } ),
 	};

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -51,6 +51,7 @@ export interface CreateSiteParams {
 		font_headings?: string;
 		font_base?: string;
 		use_patterns?: boolean;
+		selected_features?: string[];
 	};
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Save selected features as site options to use in Site setup flow.

#### Testing instructions

* Apply D49420-code and sandbox public API
* Create a site starting from [/new](https://calypso.live/?branch=update/gutenboarding-save-selected-features)
* When landing in editor, open console, select the [iframed post.php window scope](https://cloudup.com/caRMFEKucA8) and run `wp.data.select( 'automattic/site' ).getSite(window._currentSiteId).options.selected_features` to get selected features. If the first call returns `undefined`, re-run the statement.
* `selected_features` should be saved in site options only for sites created in Gutenboarding.

Fixes #45148 