### PR TITLE
Email: Update email provider comparison page copy

### DIFF
--- a/client/my-sites/email/email-providers-comparison/index.jsx
+++ b/client/my-sites/email/email-providers-comparison/index.jsx
@@ -54,7 +54,7 @@ class EmailProvidersComparison extends React.Component {
 			>
 				<p>
 					{ translate(
-						'Pick from one of our flexible options to connect your domain with email ' +
+						'Pick one of our flexible options to connect your domain with email ' +
 							'and start getting emails @%(domainName)s today.',
 						translateArgs
 					) }


### PR DESCRIPTION
We decided to use `Pick one of the options` instead of `Pick from one of the options`.