### PR TITLE
P2 Invite Links: Filter out expired invites

### DIFF
--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -470,6 +470,7 @@ class InvitePeople extends React.Component {
 		this.setState( {
 			isGeneratingInviteLinks: true,
 		} );
+
 		return this.props.generateInviteLinks( this.props.siteId );
 	};
 
@@ -484,6 +485,9 @@ class InvitePeople extends React.Component {
 			</div>,
 			( accepted ) => {
 				if ( accepted ) {
+					this.setState( {
+						isGeneratingInviteLinks: false,
+					} );
 					this.props.disableInviteLinks( this.props.siteId );
 				}
 			},

--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -485,10 +485,8 @@ class InvitePeople extends React.Component {
 			</div>,
 			( accepted ) => {
 				if ( accepted ) {
-					this.setState( {
-						isGeneratingInviteLinks: false,
-					} );
 					this.props.disableInviteLinks( this.props.siteId );
+					this.setState( this.resetState() );
 				}
 			},
 			this.props.translate( 'Disable' )

--- a/client/state/invites/reducer.js
+++ b/client/state/invites/reducer.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { includes, map, pick, zipObject } from 'lodash';
+import moment from 'moment';
 
 /**
  * Internal dependencies
@@ -106,7 +107,12 @@ export const links = withSchemaValidation( inviteLinksSchema, ( state = {}, acti
 	switch ( action.type ) {
 		case INVITES_REQUEST_SUCCESS: {
 			let inviteLinks = {};
+			const currentDate = moment();
 			action.links.forEach( ( link ) => {
+				// Do not process expired links
+				if ( currentDate.isAfter( link.expiry * 1000 ) ) {
+					return;
+				}
 				const linkForState = {
 					key: link.invite_key,
 					link: link.link,

--- a/client/state/invites/reducer.js
+++ b/client/state/invites/reducer.js
@@ -110,7 +110,7 @@ export const links = withSchemaValidation( inviteLinksSchema, ( state = {}, acti
 			const currentDate = moment();
 			action.links.forEach( ( link ) => {
 				// Do not process expired links
-				if ( currentDate.isAfter( link.expiry * 1000 ) ) {
+				if ( link.expiry && currentDate.isAfter( link.expiry * 1000 ) ) {
 					return;
 				}
 				const linkForState = {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes a bug that causes some invite links to display even when user has disabled all invites. (Reason: expired links were being loaded into state, when only unexpired links should be.)
* Fixes a small bug that fails to reset the busy state of the Generate button, which caused the button to appear busy even when not.

#### Testing instructions
* Visit the **Invite People** section of a site with known expired invite links, like lighthousep2.
* If you see Invite Links, disable them using the `Disable invite link` link below the role selectors. Expected result: You should now see the Generate button again.
* If you don't see Invite Links, generate them, and then disable them. Expected result: You should always go back to the Generate button view when disabling links.
