### PR TITLE
fix(ci): restore CONFIG_ENV variable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -646,6 +646,7 @@ jobs:
       PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: 'true'
       NODE_OPTIONS: --max-old-space-size=6144
       YARN_CACHE_FOLDER: ~/.cache/yarn
+      CONFIG_ENV: release
     steps:
       - checkout
       - when:

--- a/desktop/bin/build-desktop-config.js
+++ b/desktop/bin/build-desktop-config.js
@@ -13,7 +13,9 @@ let env;
 try {
 	env = JSON.parse( fs.readFileSync( TARGET_CONFIG, 'utf-8' ) );
 } catch ( e ) {
-	console.error( 'Error reading target config: ', e.message );
+	if ( process.env.CI ) {
+		console.error( 'Error reading target config: ', e.message );
+	}
 }
 
 const config = JSON.stringify( Object.assign( base, env ), null, 2 );

--- a/desktop/bin/build-desktop-config.js
+++ b/desktop/bin/build-desktop-config.js
@@ -12,7 +12,9 @@ const base = JSON.parse( fs.readFileSync( BASE_CONFIG, 'utf-8' ) );
 let env;
 try {
 	env = JSON.parse( fs.readFileSync( TARGET_CONFIG, 'utf-8' ) );
-} catch {}
+} catch ( e ) {
+	console.error( 'Error reading target config: ', e.message );
+}
 
 const config = JSON.stringify( Object.assign( base, env ), null, 2 );
 


### PR DESCRIPTION
### Description

This PR restores the `CONFIG_ENV` variable, which was erroneously dropped during migration from the wp-desktop repo. Omitting this variable results in failure to create a valid auto-updater config. 

Unfortunately this part of the build process has been silently failing as the failure case in the `try/catch` logic of the supporting node script was not logged to the console (meaning that the auto-updater included in builds published to this repo so far have been invalid). 😞 