### PR TITLE
Tracking: add a global handler to track embed variations

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -35,7 +35,7 @@ function globalEventPropsHandler( block, parentBlock ) {
 		return { variation_slug: block.attributes.providerNameSlug };
 	}
 
-	// Pick up variation slug from `core/embed` block.
+	// Pick up variation slug from `core/social-link` block.
 	if ( block.name === 'core/social-link' && block?.attributes.service ) {
 		return { variation_slug: block.attributes.service };
 	}

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -17,27 +17,23 @@ import delegateEventTracking from './tracking/delegate-event-tracking';
 const debug = debugFactory( 'wpcom-block-editor:tracking' );
 
 /**
- * Global handler. Use this function
- * when you need to inspect the block
+ * Global handler.
+ * Use this function when you need to inspect the block
  * to get specific data and populate the record.
  *
  * @param {object} block - Block object data.
  * @param {object} parentBlock - Block object data.
- * @return {object} Record properties object.
+ * @returns {object} Record properties object.
  */
 function globalEventPropsHandler( block, parentBlock ) {
 	// Pick up block variation slug from embed block.
-	if (
-		! block?.name ||
-		block.name !== 'core/embed' ||
-		! block?.attributes.providerNameSlug
-	) {
+	if ( ! block?.name || block.name !== 'core/embed' || ! block?.attributes.providerNameSlug ) {
 		return {};
 	}
 
 	return {
 		variation_slug: block.attributes.providerNameSlug,
-	}
+	};
 }
 /**
  * Looks up the block name based on its id.

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -17,6 +17,29 @@ import delegateEventTracking from './tracking/delegate-event-tracking';
 const debug = debugFactory( 'wpcom-block-editor:tracking' );
 
 /**
+ * Global handler. Use this function
+ * when you need to inspect the block
+ * to get specific data and populate the record.
+ *
+ * @param {object} block - Block object data.
+ * @param {object} parentBlock - Block object data.
+ * @return {object} Record properties object.
+ */
+function globalEventPropsHandler( block, parentBlock ) {
+	// Pick up block variation slug from embed block.
+	if (
+		! block?.name ||
+		block.name !== 'core/embed' ||
+		! block?.attributes.providerNameSlug
+	) {
+		return {};
+	}
+
+	return {
+		variation_slug: block.attributes.providerNameSlug,
+	}
+}
+/**
  * Looks up the block name based on its id.
  *
  * @param {string} blockId Block identifier.
@@ -72,6 +95,7 @@ function trackBlocksHandler( blocks, eventName, propertiesHandler = noop, parent
 
 		const eventProperties = {
 			...propertiesHandler( block, parentBlock ),
+			...globalEventPropsHandler( block, parentBlock ),
 			inner_block: !! parentBlock,
 		};
 

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -90,8 +90,8 @@ function trackBlocksHandler( blocks, eventName, propertiesHandler = noop, parent
 		block = ensureBlockObject( block );
 
 		const eventProperties = {
-			...propertiesHandler( block, parentBlock ),
 			...globalEventPropsHandler( block, parentBlock ),
+			...propertiesHandler( block, parentBlock ),
 			inner_block: !! parentBlock,
 		};
 

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -31,12 +31,12 @@ function globalEventPropsHandler( block, parentBlock ) {
 	}
 
 	// Pick up variation slug from `core/embed` block.
-	if ( block.name === 'core/embed' && block?.attributes.providerNameSlug ) {
+	if ( block.name === 'core/embed' && block?.attributes?.providerNameSlug ) {
 		return { variation_slug: block.attributes.providerNameSlug };
 	}
 
 	// Pick up variation slug from `core/social-link` block.
-	if ( block.name === 'core/social-link' && block?.attributes.service ) {
+	if ( block.name === 'core/social-link' && block?.attributes?.service ) {
 		return { variation_slug: block.attributes.service };
 	}
 

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -26,14 +26,21 @@ const debug = debugFactory( 'wpcom-block-editor:tracking' );
  * @returns {object} Record properties object.
  */
 function globalEventPropsHandler( block, parentBlock ) {
-	// Pick up block variation slug from embed block.
-	if ( ! block?.name || block.name !== 'core/embed' || ! block?.attributes.providerNameSlug ) {
+	if ( ! block?.name ) {
 		return {};
 	}
 
-	return {
-		variation_slug: block.attributes.providerNameSlug,
-	};
+	// Pick up variation slug from `core/embed` block.
+	if ( block.name === 'core/embed' && block?.attributes.providerNameSlug ) {
+		return { variation_slug: block.attributes.providerNameSlug };
+	}
+
+	// Pick up variation slug from `core/embed` block.
+	if ( block.name === 'core/social-link' && block?.attributes.service ) {
+		return { variation_slug: block.attributes.service };
+	}
+
+	return {};
 }
 /**
  * Looks up the block name based on its id.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This patch adds a global handler to be able to pick up information from blocks at a global level, to populate track-event properties, before recording it.

<img src="https://user-images.githubusercontent.com/77539/94081597-7621a800-fdd5-11ea-994d-5c2785eb422a.png" width="500" />

#### Testing instructions

Instructions in D50097-code

Fixes #
