### PR TITLE
Activity Log: Refactor and add test coverage for FormattedBlock et al

### DIFF
--- a/client/components/notes-formatted-block/blocks.jsx
+++ b/client/components/notes-formatted-block/blocks.jsx
@@ -1,0 +1,135 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { startsWith } from 'lodash';
+
+const blocksByType = {};
+export function getBlockByType( type ) {
+	return blocksByType[ type ];
+}
+
+function assignBlockType( type, block ) {
+	blocksByType[ type ] = block;
+}
+
+export const Strong = ( { children } ) => <strong>{ children }</strong>;
+assignBlockType( 'b', Strong );
+
+export const Emphasis = ( { children } ) => <em>{ children }</em>;
+assignBlockType( 'i', Emphasis );
+
+export const Preformatted = ( { children } ) => <pre>{ children }</pre>;
+assignBlockType( 'pre', Preformatted );
+
+export const Link = ( { content, onClick, children } ) => {
+	const { activity, section, intent } = content;
+
+	const url = startsWith( content.url, 'https://wordpress.com/' )
+		? content.url.substr( 21 )
+		: content.url;
+	return (
+		<a
+			href={ url }
+			onClick={ onClick }
+			data-activity={ activity }
+			data-section={ section }
+			data-intent={ intent }
+		>
+			{ children }
+		</a>
+	);
+};
+assignBlockType( 'a', Link );
+assignBlockType( 'link', Link );
+
+export const FilePath = ( { children } ) => (
+	<div>
+		<code>{ children }</code>
+	</div>
+);
+assignBlockType( 'filepath', FilePath );
+
+export const Post = ( { content, children } ) => {
+	if ( content.isTrashed ) {
+		return <a href={ `/posts/${ content.siteId }/trash` }>{ children }</a>;
+	}
+
+	return (
+		<a href={ `/read/blogs/${ content.siteId }/posts/${ content.postId }` }>
+			<em>{ children }</em>
+		</a>
+	);
+};
+assignBlockType( 'post', Post );
+
+export const Comment = ( { content, children } ) => (
+	<a
+		href={ `/read/blogs/${ content.siteId }/posts/${ content.postId }#comment-${ content.commentId }` }
+	>
+		{ children }
+	</a>
+);
+assignBlockType( 'comment', Comment );
+
+export const Person = ( { content, onClick, meta, children } ) => (
+	<a
+		href={ `/people/edit/${ content.siteId }/${ content.name }` }
+		onClick={ onClick }
+		data-activity={ meta.activity }
+		data-section="users"
+		data-intent="edit"
+	>
+		<strong>{ children }</strong>
+	</a>
+);
+assignBlockType( 'person', Person );
+
+export const Plugin = ( { content, onClick, meta, children } ) => (
+	<a
+		href={ `/plugins/${ content.pluginSlug }/${ content.siteSlug }` }
+		onClick={ onClick }
+		data-activity={ meta.activity }
+		data-section="plugins"
+		data-intent="view"
+	>
+		{ children }
+	</a>
+);
+assignBlockType( 'plugin', Plugin );
+
+export const Theme = ( { content, onClick, meta, children } ) => {
+	const { themeUri, themeSlug, siteSlug } = content;
+	if ( ! themeUri ) {
+		return children;
+	}
+
+	if ( /wordpress\.com/.test( themeUri ) ) {
+		return (
+			<a
+				href={ `/theme/${ themeSlug }/${ siteSlug }` }
+				onClick={ onClick }
+				data-activity={ meta.activity }
+				data-section="themes"
+				data-intent="view"
+			>
+				{ children }
+			</a>
+		);
+	}
+
+	return (
+		<a
+			href={ themeUri }
+			target="_blank"
+			rel="noopener noreferrer"
+			onClick={ onClick }
+			data-activity={ meta.activity }
+			data-section="themes"
+			data-intent="view"
+		>
+			{ children }
+		</a>
+	);
+};
+assignBlockType( 'theme', Theme );

--- a/client/components/notes-formatted-block/index.jsx
+++ b/client/components/notes-formatted-block/index.jsx
@@ -2,149 +2,33 @@
  * External dependencies
  */
 import React from 'react';
-import { startsWith } from 'lodash';
 
-export const FormattedBlock = ( { content = {}, onClick = null, meta = {} } ) => {
-	const {
-		siteId,
-		children,
-		commentId,
-		isTrashed,
-		name,
-		postId,
-		text = null,
-		type,
-		siteSlug,
-		pluginSlug,
-		themeSlug,
-		themeUri,
-	} = content;
-	const { activity, intent, section } = meta;
+/**
+ * Internal dependencies
+ */
+import { getBlockByType } from './blocks';
 
+const FormattedBlock = ( { content = {}, onClick = null, meta = {} } ) => {
 	if ( 'string' === typeof content ) {
 		return content;
 	}
 
-	if ( undefined === type && ! children ) {
+	const { children: nestedContent, text = null, type } = content;
+
+	if ( undefined === type && ! nestedContent ) {
 		return text;
 	}
 
-	const descent = children.map( ( child, key ) => (
+	const children = nestedContent.map( ( child, key ) => (
 		<FormattedBlock key={ key } content={ child } onClick={ onClick } meta={ meta } />
 	) );
 
-	switch ( type ) {
-		case 'a':
-		case 'link':
-			const url = startsWith( content.url, 'https://wordpress.com/' )
-				? content.url.substr( 21 )
-				: content.url;
-			return (
-				<a
-					href={ url }
-					onClick={ onClick }
-					data-activity={ activity }
-					data-section={ section }
-					data-intent={ intent }
-				>
-					{ descent }
-				</a>
-			);
-
-		case 'b':
-			return <strong>{ descent }</strong>;
-
-		case 'comment':
-			return (
-				<a href={ `/read/blogs/${ siteId }/posts/${ postId }#comment-${ commentId }` }>
-					{ descent }
-				</a>
-			);
-
-		case 'filepath':
-			return (
-				<div>
-					<code>{ descent }</code>
-				</div>
-			);
-
-		case 'i':
-			return <em>{ descent }</em>;
-
-		case 'person':
-			return (
-				<a
-					href={ `/people/edit/${ siteId }/${ name }` }
-					onClick={ onClick }
-					data-activity={ activity }
-					data-section="users"
-					data-intent="edit"
-				>
-					<strong>{ descent }</strong>
-				</a>
-			);
-
-		case 'plugin':
-			return (
-				<a
-					href={ `/plugins/${ pluginSlug }/${ siteSlug }` }
-					onClick={ onClick }
-					data-activity={ activity }
-					data-section="plugins"
-					data-intent="view"
-				>
-					{ descent }
-				</a>
-			);
-
-		case 'post':
-			return isTrashed ? (
-				<a href={ `/posts/${ siteId }/trash` }>{ descent }</a>
-			) : (
-				<a href={ `/read/blogs/${ siteId }/posts/${ postId }` }>
-					<em>{ descent }</em>
-				</a>
-			);
-
-		case 'pre':
-			return <pre>{ descent }</pre>;
-
-		case 'theme':
-			if ( ! themeUri ) {
-				return descent;
-			}
-
-			if ( /wordpress\.com/.test( themeUri ) ) {
-				return (
-					<a
-						href={ `/theme/${ themeSlug }/${ siteSlug }` }
-						onClick={ onClick }
-						data-activity={ activity }
-						data-section="themes"
-						data-intent="view"
-					>
-						{ descent }
-					</a>
-				);
-			}
-
-			return (
-				<a
-					href={ themeUri }
-					target="_blank"
-					rel="noopener noreferrer"
-					onClick={ onClick }
-					data-activity={ activity }
-					data-section="themes"
-					data-intent="view"
-				>
-					{ descent }
-				</a>
-			);
-
-		default:
-			return descent;
+	const blockToRender = getBlockByType( type );
+	if ( blockToRender ) {
+		return blockToRender( { content, onClick, meta, children } );
 	}
+
+	return <>{ children }</>;
 };
 
 export default FormattedBlock;

--- a/client/components/notes-formatted-block/test/blocks.js
+++ b/client/components/notes-formatted-block/test/blocks.js
@@ -1,0 +1,89 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import * as Blocks from '../blocks';
+
+describe( 'Link block', () => {
+	test( 'relativizes links to wordpress.com', () => {
+		const pathAbsoluteUrl = '/my/test/link?with=params&more=stuff+plus%20junk';
+		const link = shallow(
+			<Blocks.Link content={ { url: `https://wordpress.com${ pathAbsoluteUrl }` } } />
+		);
+
+		expect( link.prop( 'href' ) ).toEqual( pathAbsoluteUrl );
+	} );
+
+	test( 'renders links to non-WordPress sites as-is', () => {
+		const arbitraryUrl = 'http://iscalypsofastyet.com/p/buildlog?branch=master';
+		const link = shallow( <Blocks.Link content={ { url: arbitraryUrl } } /> );
+
+		expect( link.prop( 'href' ) ).toEqual( arbitraryUrl );
+	} );
+} );
+
+describe( 'Post block', () => {
+	test( 'links to the Trash page if the post is in the trash', () => {
+		const content = {
+			siteId: 1,
+			isTrashed: true,
+		};
+
+		const post = shallow( <Blocks.Post content={ content } /> );
+
+		expect( post.prop( 'href' ) ).toEqual( `/posts/${ content.siteId }/trash` );
+	} );
+
+	test( 'links to the post itself if the post is not trashed', () => {
+		const content = {
+			siteId: 1,
+			postId: 10,
+			isTrashed: false,
+		};
+
+		const post = shallow( <Blocks.Post content={ content } /> );
+
+		expect( post.prop( 'href' ) ).toEqual(
+			`/read/blogs/${ content.siteId }/posts/${ content.postId }`
+		);
+	} );
+} );
+
+describe( 'Theme block', () => {
+	test( 'uses a relative link if the theme URI points to wordpress.com', () => {
+		const content = {
+			themeUri: 'https://wordpress.com/noneofthispartmatters',
+			themeSlug: 'mythemeslug',
+			siteSlug: 'mysiteslug',
+		};
+
+		const theme = shallow( <Blocks.Theme content={ content } meta={ {} } /> );
+
+		expect( theme.prop( 'href' ) ).toEqual( `/theme/${ content.themeSlug }/${ content.siteSlug }` );
+	} );
+
+	test( 'opens the original theme URI in a new tab if it does not point to wordpress.com', () => {
+		const content = {
+			themeUri: 'https://mycoolthemesite.example/thebestthemeever',
+			themeSlug: 'best-theme-ever',
+			siteSlug: 'asleep-newt.jurassic.ninja',
+		};
+
+		const theme = shallow( <Blocks.Theme content={ content } meta={ {} } /> );
+
+		expect( theme.prop( 'href' ) ).toEqual( content.themeUri );
+		expect( theme.prop( 'target' ) ).toEqual( '_blank' );
+		expect( theme.prop( 'rel' ) ).toEqual( 'noopener noreferrer' );
+	} );
+
+	test( 'does not render a link if no theme URI is present', () => {
+		const theme = shallow( <Blocks.Theme content={ {} } /> );
+
+		expect( theme.exists( 'a' ) ).toBe( false );
+	} );
+} );

--- a/client/components/notes-formatted-block/test/index.js
+++ b/client/components/notes-formatted-block/test/index.js
@@ -1,0 +1,85 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { render, shallow } from 'enzyme';
+
+/**
+ * Mock dependencies
+ */
+jest.mock( 'components/notes-formatted-block/blocks' );
+import { getBlockByType } from '../blocks';
+
+/**
+ * Internal dependencies
+ */
+import FormattedBlock from '..';
+
+describe( 'FormattedBlock', () => {
+	beforeEach( () => jest.resetAllMocks() );
+
+	test( 'displays string content as-is', () => {
+		const content = 'my content';
+		const block = render( <FormattedBlock content={ content } /> );
+
+		expect( block.html() ).toEqual( content );
+	} );
+
+	test( 'displays content text as-is if there is no nested content and the content type is undefined', () => {
+		const text = 'my content text';
+		const block = render( <FormattedBlock content={ { text } } /> );
+
+		expect( block.html() ).toEqual( text );
+	} );
+
+	test( 'displays nested content as FormattedBlocks if content type is not supported', () => {
+		const onClick = jest.fn();
+		const meta = {};
+		const children = [
+			'example1',
+			{
+				text: 'example2',
+			},
+			{
+				children: [ 'example3a', 'example3b' ],
+			},
+		];
+
+		const block = shallow(
+			<FormattedBlock content={ { children } } onClick={ onClick } meta={ meta } />
+		);
+
+		expect( block.children().length ).toEqual( children.length );
+
+		expect(
+			block
+				.children()
+				.everyWhere(
+					( child ) =>
+						child.type() === FormattedBlock &&
+						child.prop( 'onClick' ) === onClick &&
+						child.prop( 'meta' ) === meta
+				)
+		).toEqual( true );
+	} );
+
+	test( 'displays the correct block with correct props if the content type is supported', () => {
+		const myBlock = ( props ) => <div type="myfakeblock" { ...props }></div>;
+		getBlockByType.mockImplementation( () => myBlock );
+
+		const onClick = jest.fn();
+		const meta = {};
+		const children = [ {}, {}, {} ];
+		const content = { type: 'doesnotmatter', children };
+
+		const block = shallow(
+			<FormattedBlock content={ content } onClick={ onClick } meta={ meta } />
+		);
+
+		expect( block.type() ).toEqual( 'div' );
+		expect( block.prop( 'content' ) ).toEqual( content );
+		expect( block.prop( 'onClick' ) ).toEqual( onClick );
+		expect( block.prop( 'meta' ) ).toEqual( meta );
+		expect( block.children().length ).toEqual( children.length );
+	} );
+} );


### PR DESCRIPTION
Relates to `1164141197617539-as-1192179611031378` (preliminary work).

#### Changes proposed in this Pull Request

* Refactor the `FormattedBlock` to make it more easily testable and extensible.
* Split specific block types into their own components, putting them all in `blocks.jsx`.
* Add unit tests to cover `FormattedBlock` and branching logic in the blocks for links, posts, and themes.

NOTE: This pull request lays groundwork that will make resolving `1164141197617539-as-1192179611031378` much easier for all block types, not just the one for plugin changes.

#### Testing instructions

* Run all unit tests to make sure they still pass.
* For both Jetpack Cloud and Calypso, test that all behavior for Activity Log cards -- and specifically, all links -- matches the current production deployment. Here's a list of notable events that have their own cards:
  * Post changes (created, modified, deleted)
  * Comment changes (modified, deleted, etc.)
  * People changes (added to/removed from your site's team, etc.)
  * Plugin changes (installed, removed, etc.)
  * Theme changes (for WordPress.com, but also for other sites like WordPress.org)

#### Reference screenshots

<img width="356" alt="Screen Shot 2020-09-11 at 14 24 33" src="https://user-images.githubusercontent.com/670067/92965889-343f4c00-f43c-11ea-834e-e2aec41c8042.png">
<img width="1057" alt="Screen Shot 2020-09-11 at 14 36 30" src="https://user-images.githubusercontent.com/670067/92965892-34d7e280-f43c-11ea-8528-e1c447461d76.png">
