### PR TITLE
Offer Reset: Move the header into the Upsell component

### DIFF
--- a/client/my-sites/plans-v2/upsell.tsx
+++ b/client/my-sites/plans-v2/upsell.tsx
@@ -63,6 +63,7 @@ const UpsellComponent = ( {
 	mainProduct,
 	upsellProduct,
 	isLoading,
+	header,
 }: Props ) => {
 	const translate = useTranslate();
 
@@ -86,7 +87,8 @@ const UpsellComponent = ( {
 	);
 
 	return (
-		<Main className="upsell">
+		<Main className="upsell" wideLayout>
+			{ header }
 			<HeaderCake onClick={ onBackButtonClick }>{ translate( 'Product Options' ) }</HeaderCake>
 			{ isLoading ? (
 				<div className="upsell__header-placeholder" />
@@ -227,7 +229,6 @@ const UpsellPage = ( { duration, productSlug, rootUrl, header, footer }: UpsellP
 	return (
 		<>
 			<QueryProducts />
-			{ header }
 			<UpsellComponent
 				siteId={ siteId }
 				currencyCode={ currencyCode as string }
@@ -237,6 +238,7 @@ const UpsellPage = ( { duration, productSlug, rootUrl, header, footer }: UpsellP
 				onPurchaseBothProducts={ onPurchaseBothProducts }
 				onBackButtonClick={ onBackButtonClick }
 				isLoading={ isLoading }
+				header={ header }
 			/>
 			{ footer }
 		</>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes a small layout issue affecting the Upsell page. See the Demo section for a better representation of the problem.

#### Testing instructions

* Run this PR with `yarn start-jetpack-cloud`.
* The error manifest when you move from the Details page to the Upsell, therefore, you need to select a product that has a both Daily and Real-time flavors, and includes an upsell to another product. At this moment, the only product that fits this description is Jetpack Backup.
* Move between the two pages and verify there is no change in the position of the master bar. You can repeat the exercise in production to see how the layout changes every time you visit the Upsell page.

Fixes 1169247016322522-as-1193281023077033

#### Demo
##### Before
![Kapture 2020-09-10 at 17 06 12](https://user-images.githubusercontent.com/3418513/92967120-129b9000-f44f-11ea-8614-585249215330.gif)

##### After
![Kapture 2020-09-11 at 16 52 33](https://user-images.githubusercontent.com/3418513/92967223-3e1e7a80-f44f-11ea-9977-7202fe8b054e.gif)