### PR TITLE
Adding script to sync notifications app to a sandbox wpcom installation

### DIFF
--- a/apps/notifications/bin/wpcom-watch-and-sync.sh
+++ b/apps/notifications/bin/wpcom-watch-and-sync.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+LOCAL_PATH="./dist/"
+REMOTE_PATH="/home/wpcom/public_html/widgets.wp.com/notifications"
+REMOTE_SSH="wpcom-sandbox"
+rsync -ahz $LOCAL_PATH $REMOTE_SSH:$REMOTE_PATH

--- a/apps/notifications/package.json
+++ b/apps/notifications/package.json
@@ -19,7 +19,8 @@
 	"scripts": {
 		"clean": "npx rimraf dist",
 		"prebuild": "yarn run clean",
-		"build": "calypso-build --config='./webpack.config.js'"
+		"build": "calypso-build --config='./webpack.config.js'",
+		"sync": "yarn run clean && yarn run build && sh ./bin/wpcom-watch-and-sync.sh"
 	},
 	"dependencies": {
 		"@automattic/calypso-color-schemes": "^2.1.1",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR adds a `yarn` script to the notifications app (`/apps/notifications/`) for syncing Calypso notification code changes to a WPCOM sandbox for server-side testing.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow the prerequisite setup instructions for adding an SSH alias for your sandbox described in PCYsg-ly5-p2 "Editing Toolkit plugin and your WP.com sandbox"
    * The process for this PR is roughly the same as that used for the Editing Toolkit plugin; this documentation will be adapted for the notification app once this change is approved.
* Make a change in `/apps/notifications/`
* CD into `/apps/notifications/` and run the command `yarn sync`.
* Verify that your change is reflected both in `/apps/notifications/dist` and on your sandbox in `~/public_html/widgets.wp.com/notifications/`.