### PR TITLE
Signup A/B test: Remove username field

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -1073,11 +1073,10 @@ export default connect(
 		isJetpackWooDnaFlow: wooDnaConfig( getCurrentQueryArguments( state ) ).isWooDnaFlow(),
 		from: get( getCurrentQueryArguments( state ), 'from' ),
 		wccomFrom: get( getCurrentQueryArguments( state ), 'wccom-from' ),
-		// displayUsernameInput:
-		// 	[ 'onboarding', 'personal', 'premium', 'business', 'ecommerce' ].includes(
-		// 		ownProps.flowName
-		// 	) && 'control' === abtest( 'removeUsernameInSignup' ),
-		displayUsernameInput: true,
+		displayUsernameInput:
+			! [ 'onboarding', 'personal', 'premium', 'business', 'ecommerce' ].includes(
+				ownProps.flowName
+			) || 'control' === abtest( 'removeUsernameInSignup' ),
 	} ),
 	{
 		trackLoginMidFlow: () => recordTracksEventWithClientId( 'calypso_signup_login_midflow' ),

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -460,14 +460,18 @@ class SignupForm extends Component {
 	}
 
 	getUserData() {
-		return {
-			username: formState.getFieldValue( this.state.form, 'username' ),
-			password: formState.getFieldValue( this.state.form, 'password' ),
-			email: formState.getFieldValue( this.state.form, 'email' ),
+		const extraFields = {
 			extra: {
 				first_name: formState.getFieldValue( this.state.form, 'firstName' ),
 				last_name: formState.getFieldValue( this.state.form, 'lastName' ),
 			},
+		};
+
+		return {
+			username: formState.getFieldValue( this.state.form, 'username' ),
+			password: formState.getFieldValue( this.state.form, 'password' ),
+			email: formState.getFieldValue( this.state.form, 'email' ),
+			...( this.props.displayNameInput && extraFields ),
 		};
 	}
 
@@ -1061,7 +1065,7 @@ function TrackRender( { children, eventName } ) {
 }
 
 export default connect(
-	( state ) => ( {
+	( state, ownProps ) => ( {
 		oauth2Client: getCurrentOAuth2Client( state ),
 		sectionName: getSectionName( state ),
 		isJetpackWooCommerceFlow:
@@ -1069,6 +1073,10 @@ export default connect(
 		isJetpackWooDnaFlow: wooDnaConfig( getCurrentQueryArguments( state ) ).isWooDnaFlow(),
 		from: get( getCurrentQueryArguments( state ), 'from' ),
 		wccomFrom: get( getCurrentQueryArguments( state ), 'wccom-from' ),
+		displayUsernameInput:
+			[ 'onboarding', 'personal', 'premium', 'business', 'ecommerce' ].includes(
+				ownProps.flowName
+			) && 'variantRemoveUsername' !== abtest( 'removeUsernameInSignup' ),
 	} ),
 	{
 		trackLoginMidFlow: () => recordTracksEventWithClientId( 'calypso_signup_login_midflow' ),

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -1073,10 +1073,11 @@ export default connect(
 		isJetpackWooDnaFlow: wooDnaConfig( getCurrentQueryArguments( state ) ).isWooDnaFlow(),
 		from: get( getCurrentQueryArguments( state ), 'from' ),
 		wccomFrom: get( getCurrentQueryArguments( state ), 'wccom-from' ),
-		displayUsernameInput:
-			[ 'onboarding', 'personal', 'premium', 'business', 'ecommerce' ].includes(
-				ownProps.flowName
-			) && 'control' === abtest( 'removeUsernameInSignup' ),
+		// displayUsernameInput:
+		// 	[ 'onboarding', 'personal', 'premium', 'business', 'ecommerce' ].includes(
+		// 		ownProps.flowName
+		// 	) && 'control' === abtest( 'removeUsernameInSignup' ),
+		displayUsernameInput: true,
 	} ),
 	{
 		trackLoginMidFlow: () => recordTracksEventWithClientId( 'calypso_signup_login_midflow' ),

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -1065,19 +1065,34 @@ function TrackRender( { children, eventName } ) {
 }
 
 export default connect(
-	( state, ownProps ) => ( {
-		oauth2Client: getCurrentOAuth2Client( state ),
-		sectionName: getSectionName( state ),
-		isJetpackWooCommerceFlow:
-			'woocommerce-onboarding' === get( getCurrentQueryArguments( state ), 'from' ),
-		isJetpackWooDnaFlow: wooDnaConfig( getCurrentQueryArguments( state ) ).isWooDnaFlow(),
-		from: get( getCurrentQueryArguments( state ), 'from' ),
-		wccomFrom: get( getCurrentQueryArguments( state ), 'wccom-from' ),
-		displayUsernameInput:
-			! [ 'onboarding', 'personal', 'premium', 'business', 'ecommerce' ].includes(
-				ownProps.flowName
-			) || 'control' === abtest( 'removeUsernameInSignup' ),
-	} ),
+	( state, ownProps ) => {
+		const isDisplayUsernamePropSet = ownProps.hasOwnProperty( 'displayUsernameInput' );
+		const eligibleFlowsForRemoveUsernameTest = [
+			'onboarding',
+			'personal',
+			'premium',
+			'business',
+			'ecommerce',
+		];
+		let displayUsernameInput = true;
+
+		if ( eligibleFlowsForRemoveUsernameTest.includes( ownProps.flowName ) ) {
+			displayUsernameInput = 'control' === abtest( 'removeUsernameInSignup' );
+		} else if ( isDisplayUsernamePropSet ) {
+			displayUsernameInput = ownProps.displayUsernameInput;
+		}
+
+		return {
+			oauth2Client: getCurrentOAuth2Client( state ),
+			sectionName: getSectionName( state ),
+			isJetpackWooCommerceFlow:
+				'woocommerce-onboarding' === get( getCurrentQueryArguments( state ), 'from' ),
+			isJetpackWooDnaFlow: wooDnaConfig( getCurrentQueryArguments( state ) ).isWooDnaFlow(),
+			from: get( getCurrentQueryArguments( state ), 'from' ),
+			wccomFrom: get( getCurrentQueryArguments( state ), 'wccom-from' ),
+			displayUsernameInput,
+		};
+	},
 	{
 		trackLoginMidFlow: () => recordTracksEventWithClientId( 'calypso_signup_login_midflow' ),
 		createSocialUserFailed,

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -1076,7 +1076,7 @@ export default connect(
 		displayUsernameInput:
 			[ 'onboarding', 'personal', 'premium', 'business', 'ecommerce' ].includes(
 				ownProps.flowName
-			) && 'variantRemoveUsername' !== abtest( 'removeUsernameInSignup' ),
+			) && 'control' === abtest( 'removeUsernameInSignup' ),
 	} ),
 	{
 		trackLoginMidFlow: () => recordTracksEventWithClientId( 'calypso_signup_login_midflow' ),

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -221,4 +221,13 @@ export default {
 		allowExistingUsers: true,
 		localeTargets: [ 'en' ],
 	},
+	removeUsernameInSignup: {
+		datestamp: '20200914',
+		variations: {
+			variantRemoveUsername: 50,
+			control: 50,
+		},
+		defaultVariation: 'control',
+		allowExistingUsers: false,
+	},
 };


### PR DESCRIPTION
Check P2 post pbxNRc-rq-p2.

#### Changes proposed in this Pull Request

* A/B test to remove the username field in signup in the flows - `onboarding`, `personal`, `premium`, `business`, `ecommerce`.

#### Testing instructions

Depends on D49474-code.
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Assign yourself to the variant, and go through the signup flow at `/start/user`. 
* Verify that signup completes successfully. A random username should have been assigned to you, and your activation email's subject line should contain your email address. 
* Verify the above two steps for the flows - `onboarding`, `personal`, `premium`, `business`, `ecommerce`.
* Verify that the `control` group experience is unaffected. 

