### PR TITLE
Gutenboarding: experimental forked flows

### DIFF
--- a/client/landing/gutenboarding/hooks/use-on-site-creation.ts
+++ b/client/landing/gutenboarding/hooks/use-on-site-creation.ts
@@ -56,7 +56,7 @@ interface Cart {
  **/
 
 export default function useOnSiteCreation() {
-	const { domain } = useSelect( ( select ) => select( ONBOARD_STORE ).getState() );
+	const { domain, isExperimental } = useSelect( ( select ) => select( ONBOARD_STORE ).getState() );
 	const hasPaidDomain = useSelect( ( select ) => select( ONBOARD_STORE ).hasPaidDomain() );
 	const isRedirecting = useSelect( ( select ) => select( ONBOARD_STORE ).getIsRedirecting() );
 	const newSite = useSelect( ( select ) => select( SITE_STORE ).getNewSite() );
@@ -109,10 +109,12 @@ export default function useOnSiteCreation() {
 						? `site-editor%2F${ newSite.site_slug }`
 						: `block-editor%2Fpage%2F${ newSite.site_slug }%2Fhome`;
 
-					const redirectionUrl = shouldSiteBePublic
+					const gutenboardingRedirectionUrl = shouldSiteBePublic
 						? `/checkout/${ newSite.site_slug }?preLaunch=1&isGutenboardingCreate=1`
 						: `/checkout/${ newSite.site_slug }?preLaunch=1&isGutenboardingCreate=1&redirect_to=%2F${ editorUrl }`;
-					window.location.href = redirectionUrl;
+					window.location.href = isExperimental
+						? `/checkout/${ newSite.site_slug }`
+						: gutenboardingRedirectionUrl;
 				};
 				recordOnboardingComplete( {
 					...flowCompleteTrackingParams,
@@ -144,5 +146,6 @@ export default function useOnSiteCreation() {
 		flowCompleteTrackingParams,
 		shouldSiteBePublic,
 		design,
+		isExperimental,
 	] );
 }

--- a/client/landing/gutenboarding/hooks/use-selected-plan.ts
+++ b/client/landing/gutenboarding/hooks/use-selected-plan.ts
@@ -24,15 +24,18 @@ export function useSelectedPlan() {
 	const hasPaidDomain = useSelect( ( select ) => select( ONBOARD_STORE ).hasPaidDomain() );
 	const hasPaidDesign = useSelect( ( select ) => select( ONBOARD_STORE ).hasPaidDesign() );
 
+	const defaultPaidPlan = useSelect( ( select ) => select( PLANS_STORE ).getDefaultPaidPlan() );
+
 	const planFromPath = usePlanFromPath();
 
-	// If the selected plan is not a paid plan and the user selects a premium domain
-	// return the default paid plan.
-	if ( isPlanFree( selectedPlan?.storeSlug ) && recommendedPlan ) {
-		return recommendedPlan;
-	}
+	// Use recommendedPlan with priority over the plan derived from domain and design selection
+	const defaultPlan =
+		recommendedPlan || ( ( hasPaidDomain || hasPaidDesign ) && defaultPaidPlan ) || undefined;
 
-	const defaultPlan = hasPaidDomain || hasPaidDesign ? recommendedPlan : undefined;
+	// If the selected plan is free and the user selection determines a paid plan, return the paid plan
+	if ( isPlanFree( selectedPlan?.storeSlug ) && defaultPlan ) {
+		return defaultPlan;
+	}
 
 	/**
 	 * Plan is decided in this order

--- a/client/landing/gutenboarding/hooks/use-selected-plan.ts
+++ b/client/landing/gutenboarding/hooks/use-selected-plan.ts
@@ -9,6 +9,7 @@ import { useSelect } from '@wordpress/data';
 import { STORE_KEY as ONBOARD_STORE } from '../stores/onboard';
 import { PLANS_STORE } from '../stores/plans';
 import { usePlanRouteParam } from '../path';
+import useRecommendedPlan from './use-recommended-plan';
 
 export function usePlanFromPath() {
 	const planPath = usePlanRouteParam();
@@ -17,23 +18,21 @@ export function usePlanFromPath() {
 
 export function useSelectedPlan() {
 	const selectedPlan = useSelect( ( select ) => select( ONBOARD_STORE ).getPlan() );
-
+	const recommendedPlan = useRecommendedPlan();
 	const isPlanFree = useSelect( ( select ) => select( PLANS_STORE ).isPlanFree );
 
 	const hasPaidDomain = useSelect( ( select ) => select( ONBOARD_STORE ).hasPaidDomain() );
 	const hasPaidDesign = useSelect( ( select ) => select( ONBOARD_STORE ).hasPaidDesign() );
 
-	const defaultPaidPlan = useSelect( ( select ) => select( PLANS_STORE ).getDefaultPaidPlan() );
-
 	const planFromPath = usePlanFromPath();
 
 	// If the selected plan is not a paid plan and the user selects a premium domain
 	// return the default paid plan.
-	if ( isPlanFree( selectedPlan?.storeSlug ) && hasPaidDomain ) {
-		return defaultPaidPlan;
+	if ( isPlanFree( selectedPlan?.storeSlug ) && recommendedPlan ) {
+		return recommendedPlan;
 	}
 
-	const defaultPlan = hasPaidDomain || hasPaidDesign ? defaultPaidPlan : undefined;
+	const defaultPlan = hasPaidDomain || hasPaidDesign ? recommendedPlan : undefined;
 
 	/**
 	 * Plan is decided in this order

--- a/client/landing/gutenboarding/onboarding-block/domains/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/domains/index.tsx
@@ -47,6 +47,8 @@ const DomainsStep: React.FunctionComponent< Props > = ( { isModal } ) => {
 	// using the selector will get the explicit domain search query with site title and vertical as fallbacks
 	const domainSearch = useSelect( ( select ) => select( ONBOARD_STORE ).getDomainSearch() );
 
+	const { isExperimental } = useSelect( ( select ) => select( ONBOARD_STORE ).getState() );
+
 	const { setDomain, setDomainSearch, setHasUsedDomainsStep } = useDispatch( ONBOARD_STORE );
 
 	React.useEffect( () => {
@@ -86,7 +88,7 @@ const DomainsStep: React.FunctionComponent< Props > = ( { isModal } ) => {
 				<SubTitle>{ __( 'Free for the first year with any paid plan.' ) }</SubTitle>
 			</div>
 			<ActionButtons>
-				<BackButton onClick={ handleBack } />
+				{ ( isModal || ! isExperimental ) && <BackButton onClick={ handleBack } /> }
 				{ domain ? <NextButton onClick={ handleNext } /> : <SkipButton onClick={ handleNext } /> }
 			</ActionButtons>
 		</div>

--- a/client/landing/gutenboarding/onboarding-block/edit.tsx
+++ b/client/landing/gutenboarding/onboarding-block/edit.tsx
@@ -28,7 +28,9 @@ import './colors.scss';
 import './style.scss';
 
 const OnboardingEdit: React.FunctionComponent< BlockEditProps< Attributes > > = () => {
-	const { selectedDesign, siteTitle } = useSelect( ( select ) => select( STORE_KEY ).getState() );
+	const { selectedDesign, siteTitle, isExperimental } = useSelect( ( select ) =>
+		select( STORE_KEY ).getState()
+	);
 	const isRedirecting = useSelect( ( select ) => select( STORE_KEY ).getIsRedirecting() );
 	const isCreatingSite = useSelect( ( select ) => select( SITE_STORE ).isFetchingSite() );
 	const newSiteError = useSelect( ( select ) => select( SITE_STORE ).getNewSiteError() );
@@ -87,6 +89,13 @@ const OnboardingEdit: React.FunctionComponent< BlockEditProps< Attributes > > = 
 				/>
 			) }
 			<Switch>
+				<Route exact path="/">
+					<Redirect
+						push={ false }
+						to={ makePath( isExperimental ? Step.Domains : Step.IntentGathering ) }
+					/>
+				</Route>
+
 				<Route exact path={ makePath( Step.IntentGathering ) }>
 					<AcquireIntent />
 				</Route>
@@ -113,6 +122,10 @@ const OnboardingEdit: React.FunctionComponent< BlockEditProps< Attributes > > = 
 
 				<Route path={ makePath( Step.Plans ) }>
 					{ canUseStyleStep() ? <Plans /> : redirectToLatestStep }
+				</Route>
+
+				<Route path={ makePath( Step.PlansCompare ) }>
+					<Plans isMultiColumn />
 				</Route>
 
 				<Route path={ makePath( Step.PlansModal ) }>

--- a/client/landing/gutenboarding/onboarding-block/features/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/features/index.tsx
@@ -30,8 +30,9 @@ import './style.scss';
 
 const FeaturesStep: React.FunctionComponent = () => {
 	const { __ } = useI18n();
-	const { goBack, goNext } = useStepNavigation();
+	const { goBack, goNext, endFlow } = useStepNavigation();
 
+	const { isExperimental } = useSelect( ( select ) => select( ONBOARD_STORE ).getState() );
 	const selectedFeatures = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedFeatures() );
 	const { addFeature, removeFeature } = useDispatch( ONBOARD_STORE );
 
@@ -44,6 +45,12 @@ const FeaturesStep: React.FunctionComponent = () => {
 			addFeature( featureId );
 		}
 	};
+
+	const skipButton = isExperimental ? (
+		<SkipButton onClick={ endFlow }>{ __( 'Create a free site' ) }</SkipButton>
+	) : (
+		<SkipButton onClick={ goNext } />
+	);
 
 	return (
 		<div className="gutenboarding-page features">
@@ -58,11 +65,7 @@ const FeaturesStep: React.FunctionComponent = () => {
 				</div>
 				<ActionButtons>
 					<BackButton onClick={ goBack } />
-					{ hasSelectedFeatures ? (
-						<NextButton onClick={ goNext } />
-					) : (
-						<SkipButton onClick={ goNext } />
-					) }
+					{ hasSelectedFeatures ? <NextButton onClick={ goNext } /> : skipButton }
 				</ActionButtons>
 			</div>
 			<div className="features__body">

--- a/client/landing/gutenboarding/onboarding-block/plans/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/plans/index.tsx
@@ -26,13 +26,14 @@ type PlanSlug = Plans.PlanSlug;
 
 interface Props {
 	isModal?: boolean;
+	isMultiColumn?: boolean;
 }
 
-const PlansStep: React.FunctionComponent< Props > = ( { isModal } ) => {
+const PlansStep: React.FunctionComponent< Props > = ( { isModal, isMultiColumn } ) => {
 	const { __ } = useI18n();
 	const history = useHistory();
 	const makePath = usePath();
-	const { goBack, goNext } = useStepNavigation();
+	const { goBack, goNext, endFlow } = useStepNavigation();
 
 	const plan = useSelectedPlan();
 	const domain = useSelect( ( select ) => select( ONBOARD_STORE ).getSelectedDomain() );
@@ -51,6 +52,7 @@ const PlansStep: React.FunctionComponent< Props > = ( { isModal } ) => {
 
 	useTrackStep( isModal ? 'PlansModal' : 'Plans', () => ( {
 		selected_plan: selectedPlanRef.current,
+		multi_column: isMultiColumn,
 	} ) );
 
 	const freeDomainSuggestion = useFreeDomainSuggestion();
@@ -65,6 +67,9 @@ const PlansStep: React.FunctionComponent< Props > = ( { isModal } ) => {
 		}
 
 		updatePlan( planSlug );
+		if ( isMultiColumn && ! isPlanFree( planSlug ) ) {
+			return endFlow();
+		}
 
 		if ( isModal ) {
 			history.goBack();
@@ -97,7 +102,7 @@ const PlansStep: React.FunctionComponent< Props > = ( { isModal } ) => {
 				currentDomain={ domain }
 				onPlanSelect={ handlePlanSelect }
 				onPickDomainClick={ handlePickDomain }
-				isExperimental={ isEnabled( 'gutenboarding/feature-picker' ) }
+				isExperimental={ isEnabled( 'gutenboarding/feature-picker' ) && ! isMultiColumn }
 				recommendedPlan={ recommendedPlan }
 			/>
 		</div>

--- a/client/landing/gutenboarding/path.ts
+++ b/client/landing/gutenboarding/path.ts
@@ -14,7 +14,7 @@ const plansPaths = Plans.plansPaths;
 // `undefined`, as that's what matching our `path` pattern against a route with no explicit
 // step fragment will return.
 export const Step = {
-	IntentGathering: undefined,
+	IntentGathering: 'site-name',
 	DesignSelection: 'design',
 	Style: 'style',
 	Features: 'features',
@@ -26,6 +26,7 @@ export const Step = {
 	DomainsModal: 'domains-modal',
 	PlansModal: 'plans-modal',
 	LanguageModal: 'language-modal',
+	PlansCompare: 'compare-plans',
 } as const;
 
 // We remove falsey `steps` with `.filter( Boolean )` as they'd mess up our |-separated route pattern.

--- a/client/landing/gutenboarding/stores/onboard/reducer.ts
+++ b/client/landing/gutenboarding/stores/onboard/reducer.ts
@@ -161,6 +161,10 @@ const selectedFeatures: Reducer< FeatureId[], OnboardAction > = (
 		return [ ...state, action.featureId ];
 	}
 
+	if ( action.type === 'SET_DOMAIN' && action.domain && ! action.domain?.is_free ) {
+		return [ ...state, 'domain' ];
+	}
+
 	if ( action.type === 'REMOVE_FEATURE' ) {
 		return state.filter( ( id ) => id !== action.featureId );
 	}

--- a/client/landing/gutenboarding/stores/onboard/selectors.ts
+++ b/client/landing/gutenboarding/stores/onboard/selectors.ts
@@ -2,13 +2,13 @@
  * Internal dependencies
  */
 import type { State } from './reducer';
+import { FEATURE_LIST } from '../../onboarding-block/features/data';
 
 export const getIsRedirecting = ( state: State ) => state.isRedirecting;
 export const getPlan = ( state: State ) => state.plan;
 export const getRandomizedDesigns = ( state: State ) => state.randomizedDesigns;
 export const getSelectedDesign = ( state: State ) => state.selectedDesign;
 export const getSelectedDomain = ( state: State ) => state.domain;
-export const getSelectedFeatures = ( state: State ) => state.selectedFeatures;
 export const getSelectedFonts = ( state: State ) => state.selectedFonts;
 export const getSelectedSite = ( state: State ) => state.selectedSite;
 export const getSelectedSiteTitle = ( state: State ) => state.siteTitle;
@@ -32,3 +32,8 @@ export const wasVerticalSkipped = ( state: State ): boolean => state.wasVertical
 // Selectors dependent on other selectors (cannot be put in alphabetical order)
 export const getDomainSearch = ( state: State ) =>
 	state.domainSearch || getSelectedSiteTitle( state ) || getSelectedVertical( state )?.label;
+
+export const getSelectedFeatures = ( state: State ) => [
+	...state.selectedFeatures,
+	...( hasPaidDomain( state ) ? [ FEATURE_LIST.domain.id ] : [] ),
+];

--- a/client/landing/gutenboarding/stores/onboard/selectors.ts
+++ b/client/landing/gutenboarding/stores/onboard/selectors.ts
@@ -2,13 +2,13 @@
  * Internal dependencies
  */
 import type { State } from './reducer';
-import { FEATURE_LIST } from '../../onboarding-block/features/data';
 
 export const getIsRedirecting = ( state: State ) => state.isRedirecting;
 export const getPlan = ( state: State ) => state.plan;
 export const getRandomizedDesigns = ( state: State ) => state.randomizedDesigns;
 export const getSelectedDesign = ( state: State ) => state.selectedDesign;
 export const getSelectedDomain = ( state: State ) => state.domain;
+export const getSelectedFeatures = ( state: State ) => state.selectedFeatures;
 export const getSelectedFonts = ( state: State ) => state.selectedFonts;
 export const getSelectedSite = ( state: State ) => state.selectedSite;
 export const getSelectedSiteTitle = ( state: State ) => state.siteTitle;
@@ -32,8 +32,3 @@ export const wasVerticalSkipped = ( state: State ): boolean => state.wasVertical
 // Selectors dependent on other selectors (cannot be put in alphabetical order)
 export const getDomainSearch = ( state: State ) =>
 	state.domainSearch || getSelectedSiteTitle( state ) || getSelectedVertical( state )?.label;
-
-export const getSelectedFeatures = ( state: State ) => [
-	...state.selectedFeatures,
-	...( hasPaidDomain( state ) ? [ FEATURE_LIST.domain.id ] : [] ),
-];

--- a/packages/domain-picker/src/domain-picker/index.tsx
+++ b/packages/domain-picker/src/domain-picker/index.tsx
@@ -185,6 +185,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 					onChange={ handleInputChange }
 					onBlur={ onDomainSearchBlurValue }
 					value={ domainSearch }
+					autoFocus // eslint-disable-line jsx-a11y/no-autofocus
 				/>
 			</div>
 			{ domainSearch.trim()?.length > 1 ? (


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Start Gutenboarding with a 2-step flow and then fork it by plan selection:
  * if a **paid plan** is selected, the site is created and user is redirected to `/checkout`.
 Demo: https://cloudup.com/cMWCCFrxVEs
  * if **Free plan** is selected, flow continues with Gutenboarding wizard-like experience.
Demo: https://cloudup.com/cCHwCyTYUKT
* Any Gutenboarding customisation is removed from `/checkout`.

#### Testing instructions
* Go to https://hash-2e9c372ad7cb1b215b6757343491b6942e0dcdd0.calypso.live/new?latest
* After selecting a domain and a paid plan the site should be created and you should land on `/checkout`
* After selecting a free plan, the flow should continue with design, fonts and features steps.
* On `/features` step, if there is no selection made, _Create a free site_ button is displayed and this would be the final step.
* If there is a selected feature, then _Continue_ button should take you to the next step (Plans accordion).