### PR TITLE
add(media): utility functions to create and check for transient ids

### DIFF
--- a/client/lib/media/utils/create-transient-media-id.js
+++ b/client/lib/media/utils/create-transient-media-id.js
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import { uniqueId } from 'lodash';
+import impureLodash from 'lib/impure-lodash';
+
+const { uniqueId } = impureLodash;
 
 /**
  * Returns an ID for transient media items. To be consistent in creating

--- a/client/lib/media/utils/create-transient-media-id.js
+++ b/client/lib/media/utils/create-transient-media-id.js
@@ -11,8 +11,6 @@ const { uniqueId } = impureLodash;
  *
  * @param {string} moreSpecificPrefix can be used to further specify the prefix
  */
-function createTransientMediaId( moreSpecificPrefix = '' ) {
+export function createTransientMediaId( moreSpecificPrefix = '' ) {
 	return uniqueId( `media-${ moreSpecificPrefix }` );
 }
-
-export default createTransientMediaId;

--- a/client/lib/media/utils/create-transient-media-id.js
+++ b/client/lib/media/utils/create-transient-media-id.js
@@ -1,0 +1,16 @@
+/**
+ * External dependencies
+ */
+import { uniqueId } from 'lodash';
+
+/**
+ * Returns an ID for transient media items. To be consistent in creating
+ * transient media IDs they are all prefixed with 'media-'
+ *
+ * @param {string} moreSpecifiedPrefix can be used to further specify the prefix
+ */
+function createTransientMediaId( moreSpecifiedPrefix = '' ) {
+	return uniqueId( `media-${ moreSpecifiedPrefix }` );
+}
+
+export default createTransientMediaId;

--- a/client/lib/media/utils/create-transient-media-id.js
+++ b/client/lib/media/utils/create-transient-media-id.js
@@ -9,10 +9,10 @@ const { uniqueId } = impureLodash;
  * Returns an ID for transient media items. To be consistent in creating
  * transient media IDs they are all prefixed with 'media-'
  *
- * @param {string} moreSpecifiedPrefix can be used to further specify the prefix
+ * @param {string} moreSpecificPrefix can be used to further specify the prefix
  */
-function createTransientMediaId( moreSpecifiedPrefix = '' ) {
-	return uniqueId( `media-${ moreSpecifiedPrefix }` );
+function createTransientMediaId( moreSpecificPrefix = '' ) {
+	return uniqueId( `media-${ moreSpecificPrefix }` );
 }
 
 export default createTransientMediaId;

--- a/client/lib/media/utils/create-transient-media.js
+++ b/client/lib/media/utils/create-transient-media.js
@@ -8,7 +8,7 @@ import path from 'path';
  */
 import { getFileExtension } from 'lib/media/utils/get-file-extension';
 import { getMimeType } from 'lib/media/utils/get-mime-type';
-import createTransientMediaId from 'lib/media/utils/create-transient-media-id';
+import { createTransientMediaId } from 'lib/media/utils';
 
 /**
  * Returns an object describing a transient media item which can be used in

--- a/client/lib/media/utils/create-transient-media.js
+++ b/client/lib/media/utils/create-transient-media.js
@@ -6,11 +6,9 @@ import path from 'path';
 /**
  * Internal dependencies
  */
-import impureLodash from 'lib/impure-lodash';
 import { getFileExtension } from 'lib/media/utils/get-file-extension';
 import { getMimeType } from 'lib/media/utils/get-mime-type';
-
-const { uniqueId } = impureLodash;
+import createTransientMediaId from 'lib/media/utils/create-transient-media-id';
 
 /**
  * Returns an object describing a transient media item which can be used in
@@ -22,7 +20,7 @@ const { uniqueId } = impureLodash;
 export function createTransientMedia( file ) {
 	const transientMedia = {
 		transient: true,
-		ID: uniqueId( 'media-' ),
+		ID: createTransientMediaId(),
 	};
 
 	if ( 'string' === typeof file ) {

--- a/client/lib/media/utils/index.js
+++ b/client/lib/media/utils/index.js
@@ -21,3 +21,4 @@ export { playtime } from 'lib/media/utils/playtime';
 export { sortItemsByDate } from 'lib/media/utils/sort-items-by-date';
 export { url } from 'lib/media/utils/url';
 export { validateMediaItem } from 'lib/media/utils/validate-media-item';
+export { createTransientMediaId } from 'lib/media/utils/create-transient-media-id';

--- a/client/lib/media/utils/is-transient-media-id.js
+++ b/client/lib/media/utils/is-transient-media-id.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { startsWith } from 'lodash';
-
-/**
  * Check whether a given string is a transient media ID. Transient media IDs
  * are strings and start with 'media-'. Persisted media IDs are numbers.
  *
@@ -11,7 +6,7 @@ import { startsWith } from 'lodash';
  * @returns {boolean} true if given id is a transient media id, false otherwise
  */
 function isTransientMediaId( id ) {
-	return typeof id === 'string' && startsWith( id, 'media-' );
+	return typeof id === 'string' && id.startsWith( 'media-' );
 }
 
 export default isTransientMediaId;

--- a/client/lib/media/utils/is-transient-media-id.js
+++ b/client/lib/media/utils/is-transient-media-id.js
@@ -1,0 +1,17 @@
+/**
+ * External dependencies
+ */
+import { startsWith } from 'lodash';
+
+/**
+ * Check whether a given string is a transient media ID. Transient media IDs
+ * are strings and start with 'media-'. Persisted media IDs are numbers.
+ *
+ * @param {string} id a media id we want to check
+ * @returns {boolean} true if given id is a transient media id, false otherwise
+ */
+function isTransientMediaId( id ) {
+	return typeof id === 'string' && startsWith( id, 'media-' );
+}
+
+export default isTransientMediaId;

--- a/client/lib/media/utils/test/create-transient-media-id.js
+++ b/client/lib/media/utils/test/create-transient-media-id.js
@@ -1,0 +1,20 @@
+/**
+ * Internal dependencies
+ */
+import createTransientMediaId from '../create-transient-media-id';
+
+describe( 'createTransientMediaId()', () => {
+	test( `should return a string prefixed with 'media-'`, () => {
+		const result = createTransientMediaId();
+
+		expect( typeof result ).toBe( 'string' );
+		expect( result.startsWith( 'media-' ) ).toBe( true );
+	} );
+
+	test( `should return a string prefixed with 'media-' and given enhanced prefix string`, () => {
+		const result = createTransientMediaId( 'arbitrary-enhanced-prefix' );
+
+		expect( typeof result ).toBe( 'string' );
+		expect( result.startsWith( 'media-arbitrary-enhanced-prefix' ) ).toBe( true );
+	} );
+} );

--- a/client/lib/media/utils/test/create-transient-media-id.js
+++ b/client/lib/media/utils/test/create-transient-media-id.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import createTransientMediaId from '../create-transient-media-id';
+import { createTransientMediaId } from '../create-transient-media-id';
 
 describe( 'createTransientMediaId()', () => {
 	test( `should return a string prefixed with 'media-'`, () => {

--- a/client/lib/media/utils/test/is-transient-media-id.js
+++ b/client/lib/media/utils/test/is-transient-media-id.js
@@ -1,0 +1,16 @@
+/**
+ * Internal dependencies
+ */
+import isTransientMediaId from '../is-transient-media-id';
+
+describe( 'isTransientMediaId()', () => {
+	test( 'should return true if given string is a valid transient media id', () => {
+		expect( isTransientMediaId( 'media-f293j02' ) ).toBe( true );
+		expect( isTransientMediaId( 'media-enhanced-prefix-f293j02' ) ).toBe( true );
+	} );
+
+	test( 'should return false if given string is not a valid transient media id', () => {
+		expect( isTransientMediaId( 'f293j02' ) ).toBe( false );
+		expect( isTransientMediaId( 3279878932 ) ).toBe( false );
+	} );
+} );

--- a/client/my-sites/site-settings/podcast-cover-image-setting/index.jsx
+++ b/client/my-sites/site-settings/podcast-cover-image-setting/index.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { head, isEqual, partial, uniqueId } from 'lodash';
+import { head, isEqual, partial } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -28,6 +28,7 @@ import { ModalViews } from 'state/ui/media-modal/constants';
 import resizeImageUrl from 'lib/resize-image-url';
 import { AspectRatios } from 'state/editor/image-editor/constants';
 import Spinner from 'components/spinner';
+import createTransientMediaId from 'lib/media/utils/create-transient-media-id';
 
 /**
  * Debug
@@ -85,7 +86,7 @@ class PodcastCoverImageSetting extends PureComponent {
 	async uploadCoverImage( blob, fileName ) {
 		// Upload media using a manually generated ID so that we can continue
 		// to reference it within this function
-		const transientMediaId = uniqueId( 'podcast-cover-image' );
+		const transientMediaId = createTransientMediaId( 'podcast-cover-image' );
 
 		this.setState( { transientMediaId } );
 		this.onUploadStateChange( true );

--- a/client/my-sites/site-settings/podcast-cover-image-setting/index.jsx
+++ b/client/my-sites/site-settings/podcast-cover-image-setting/index.jsx
@@ -28,7 +28,7 @@ import { ModalViews } from 'state/ui/media-modal/constants';
 import resizeImageUrl from 'lib/resize-image-url';
 import { AspectRatios } from 'state/editor/image-editor/constants';
 import Spinner from 'components/spinner';
-import createTransientMediaId from 'lib/media/utils/create-transient-media-id';
+import { createTransientMediaId } from 'lib/media/utils';
 
 /**
  * Debug

--- a/client/post-editor/editor-featured-image/dropzone.jsx
+++ b/client/post-editor/editor-featured-image/dropzone.jsx
@@ -3,7 +3,7 @@
  */
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { head, uniqueId } from 'lodash';
+import { head } from 'lodash';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'components/gridicon';
 
@@ -20,6 +20,7 @@ import { getSelectedSiteId, getSelectedSite } from 'state/ui/selectors';
 import { getEditorPostId } from 'state/editor/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { userCan } from 'lib/site/utils';
+import createTransientMediaId from 'lib/media/utils/create-transient-media-id';
 
 class FeaturedImageDropZone extends Component {
 	onFilesDrop = async ( files ) => {
@@ -38,7 +39,7 @@ class FeaturedImageDropZone extends Component {
 			return false;
 		}
 
-		const transientId = uniqueId( 'featured-image' );
+		const transientId = createTransientMediaId( 'featured-image' );
 
 		const file = {
 			ID: transientId,

--- a/client/post-editor/editor-featured-image/dropzone.jsx
+++ b/client/post-editor/editor-featured-image/dropzone.jsx
@@ -11,7 +11,7 @@ import Gridicon from 'components/gridicon';
  * Internal dependencies
  */
 import DropZone from 'components/drop-zone';
-import { filterItemsByMimePrefix } from 'lib/media/utils';
+import { filterItemsByMimePrefix, createTransientMediaId } from 'lib/media/utils';
 import FeaturedImageDropZoneIcon from './dropzone-icon';
 
 import { addMedia } from 'state/media/thunks';
@@ -20,7 +20,6 @@ import { getSelectedSiteId, getSelectedSite } from 'state/ui/selectors';
 import { getEditorPostId } from 'state/editor/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { userCan } from 'lib/site/utils';
-import createTransientMediaId from 'lib/media/utils/create-transient-media-id';
 
 class FeaturedImageDropZone extends Component {
 	onFilesDrop = async ( files ) => {

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -16,7 +16,6 @@ import {
 	noop,
 	partial,
 	some,
-	uniqueId,
 	values,
 } from 'lodash';
 
@@ -46,6 +45,7 @@ import VideoEditor from 'blocks/video-editor';
 import MediaModalDialog from './dialog';
 import MediaModalDetail from './detail';
 import { withAnalytics, bumpStat, recordGoogleEvent } from 'state/analytics/actions';
+import createTransientMediaId from 'lib/media/utils/create-transient-media-id';
 
 /**
  * Style dependencies
@@ -215,7 +215,7 @@ export class EditorMediaModal extends Component {
 
 		if ( selectedItems.length && this.state.source !== '' ) {
 			const itemsWithTransientId = selectedItems.map( ( item ) =>
-				Object.assign( {}, item, { ID: uniqueId( 'media-' ), transient: true } )
+				Object.assign( {}, item, { ID: createTransientMediaId(), transient: true } )
 			);
 			this.copyExternalAfterLoadingWordPressLibrary( itemsWithTransientId, this.state.source );
 		} else {

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -45,7 +45,6 @@ import VideoEditor from 'blocks/video-editor';
 import MediaModalDialog from './dialog';
 import MediaModalDetail from './detail';
 import { withAnalytics, bumpStat, recordGoogleEvent } from 'state/analytics/actions';
-import createTransientMediaId from 'lib/media/utils/create-transient-media-id';
 
 /**
  * Style dependencies
@@ -215,7 +214,7 @@ export class EditorMediaModal extends Component {
 
 		if ( selectedItems.length && this.state.source !== '' ) {
 			const itemsWithTransientId = selectedItems.map( ( item ) =>
-				Object.assign( {}, item, { ID: createTransientMediaId(), transient: true } )
+				Object.assign( {}, item, { ID: MediaUtils.createTransientMediaId(), transient: true } )
 			);
 			this.copyExternalAfterLoadingWordPressLibrary( itemsWithTransientId, this.state.source );
 		} else {

--- a/client/state/media/thunks/upload-site-icon.js
+++ b/client/state/media/thunks/upload-site-icon.js
@@ -4,7 +4,7 @@
 import { saveSiteSettings, updateSiteSettings } from 'state/site-settings/actions';
 import { errorNotice } from 'state/notices/actions';
 import { addMedia } from 'state/media/thunks/add-media';
-import createTransientMediaId from 'lib/media/utils/create-transient-media-id';
+import { createTransientMediaId } from 'lib/media/utils';
 
 const updateSiteIcon = ( siteId, mediaId ) => updateSiteSettings( siteId, { site_icon: mediaId } );
 

--- a/client/state/media/thunks/upload-site-icon.js
+++ b/client/state/media/thunks/upload-site-icon.js
@@ -1,14 +1,10 @@
 /**
- * External dependencies
- */
-import uniqueId from 'lodash/uniqueId';
-
-/**
  * Internal dependencies
  */
 import { saveSiteSettings, updateSiteSettings } from 'state/site-settings/actions';
 import { errorNotice } from 'state/notices/actions';
 import { addMedia } from 'state/media/thunks/add-media';
+import createTransientMediaId from 'lib/media/utils/create-transient-media-id';
 
 const updateSiteIcon = ( siteId, mediaId ) => updateSiteSettings( siteId, { site_icon: mediaId } );
 
@@ -35,7 +31,8 @@ export const uploadSiteIcon = (
 ) => async ( dispatch ) => {
 	// Upload media using a manually generated ID so that we can continue
 	// to reference it within this function
-	const transientMediaId = uniqueId( 'site-icon' );
+	const transientMediaId = createTransientMediaId( 'site-icon' );
+
 	const file = {
 		ID: transientMediaId,
 		fileContents: blob,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Based of [feedback in #45183](https://github.com/Automattic/wp-calypso/pull/45183#discussion_r476470125) I extracted two functions which are intended to help with creating and checking for transient media ids.

* Create `createTransientMediaId` and `isTransientMediaId` utility/helper functions
* Replace existing usages of `uniqueId( 'media-' )` (or similar) to create transient media ids

#### Testing instructions

Make sure any of the following work as expected (use new images which are not persisted/uploaded yet):
  * Uploading and setting a new site icon
  * Uploading and setting a new podcast cover image
  * Uploading and setting a featured image on a post/page using the classic post editor
  * Search in Pexels, select a single or multiple items and hit _Copy to media library_

related to #45183 and general media reduxification efforts
