### PR TITLE
Merge unified sidebar experiment

### DIFF
--- a/client/my-sites/navigation/index.jsx
+++ b/client/my-sites/navigation/index.jsx
@@ -26,11 +26,14 @@ class MySitesNavigation extends React.Component {
 			siteBasePath: this.props.siteBasePath,
 		};
 
-		const asyncSidebar = config.isEnabled( 'jetpack-cloud' ) ? (
-			<AsyncLoad require="components/jetpack/sidebar" { ...asyncProps } />
-		) : (
-			<AsyncLoad require="my-sites/sidebar" { ...asyncProps } />
-		);
+		let asyncSidebar = null;
+		if ( config.isEnabled( 'jetpack-cloud' ) ) {
+			asyncSidebar = <AsyncLoad require="components/jetpack/sidebar" { ...asyncProps } />;
+		} else if ( config.isEnabled( 'nav-unification' ) ) {
+			asyncSidebar = <AsyncLoad require="my-sites/sidebar-unified/switcher" { ...asyncProps } />;
+		} else {
+			asyncSidebar = <AsyncLoad require="my-sites/sidebar" { ...asyncProps } />;
+		}
 
 		return (
 			<div>

--- a/client/my-sites/sidebar-unified/index.jsx
+++ b/client/my-sites/sidebar-unified/index.jsx
@@ -25,6 +25,8 @@ import CurrentSite from 'my-sites/current-site';
 import MySitesSidebarUnifiedItem from './item';
 import MySitesSidebarUnifiedMenu from './menu';
 import Sidebar from 'layout/sidebar';
+import SidebarSeparator from 'layout/sidebar/separator';
+import SidebarMenu from 'layout/sidebar/menu';
 
 export const MySitesSidebarUnified = ( { path } ) => {
 	const reduxDispatch = useDispatch();
@@ -61,10 +63,14 @@ export const MySitesSidebarUnified = ( { path } ) => {
 			<CurrentSite forceAllSitesView={ isAllDomainsView } />
 			{ menuItems.map( ( item, i ) => {
 				if ( 'type' in item && item.type === 'separator' ) {
-					return <hr key={ i } />;
+					return <SidebarSeparator key={ i } />;
 				}
 				if ( ! ( 'children' in item ) || item.children.length === 0 ) {
-					return <MySitesSidebarUnifiedItem key={ item.slug } path={ path } { ...item } />;
+					return (
+						<SidebarMenu key={ item.slug }>
+							<MySitesSidebarUnifiedItem key={ `${ item.slug }-item` } path={ path } { ...item } />
+						</SidebarMenu>
+					);
 				}
 				return <MySitesSidebarUnifiedMenu key={ item.slug } path={ path } { ...item } />;
 			} ) }

--- a/client/my-sites/sidebar-unified/index.jsx
+++ b/client/my-sites/sidebar-unified/index.jsx
@@ -1,0 +1,74 @@
+/**
+ * MySitesSidebarUnified
+ *   Renders the Sidebar for "My Sites", except all of the menus and items are
+ *   driven off a WPCom endpoint: /sites/${sideId}/admin-menu, which is loaded
+ *   into state.adminMenu in a data layer.
+ *
+ *    Currently experimental/WIP.
+ **/
+
+/**
+ * External dependencies
+ */
+import React, { useEffect } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { getCurrentRoute } from 'state/selectors/get-current-route';
+import { getSelectedSite } from 'state/ui/selectors';
+import { isUnderDomainManagementAll } from 'my-sites/domains/paths';
+import { isUnderEmailManagementAll } from 'my-sites/email/paths';
+import { requestAdminMenu } from '../../state/admin-menu/actions';
+import CurrentSite from 'my-sites/current-site';
+import MySitesSidebarUnifiedItem from './item';
+import MySitesSidebarUnifiedMenu from './menu';
+import Sidebar from 'layout/sidebar';
+
+export const MySitesSidebarUnified = ( { path } ) => {
+	const reduxDispatch = useDispatch();
+	const selectedSite = useSelector( ( state ) => getSelectedSite( state ) );
+	useEffect( () => {
+		if ( selectedSite !== null && selectedSite.ID ) {
+			reduxDispatch( requestAdminMenu( selectedSite.ID ) );
+		}
+	}, [ reduxDispatch, selectedSite ] );
+
+	// Extract this?
+	const menuItems = useSelector( ( state ) => {
+		const thisSelectedSite = getSelectedSite( state );
+		if (
+			thisSelectedSite !== null &&
+			thisSelectedSite.ID &&
+			state.adminMenu != null &&
+			thisSelectedSite.ID in state.adminMenu
+		) {
+			return Object.values( state.adminMenu[ thisSelectedSite.ID ] );
+		}
+		return [];
+	} );
+
+	// Extract this?
+	const isAllDomainsView = useSelector( ( state ) => {
+		const currentRoute = getCurrentRoute( state );
+		return isUnderDomainManagementAll( currentRoute ) || isUnderEmailManagementAll( currentRoute );
+	} );
+
+	//console.log( { menuItems } );
+	return (
+		<Sidebar>
+			<CurrentSite forceAllSitesView={ isAllDomainsView } />
+			{ menuItems.map( ( item, i ) => {
+				if ( 'type' in item && item.type === 'separator' ) {
+					return <hr key={ i } />;
+				}
+				if ( ! ( 'children' in item ) || item.children.length === 0 ) {
+					return <MySitesSidebarUnifiedItem key={ item.slug } path={ path } { ...item } />;
+				}
+				return <MySitesSidebarUnifiedMenu key={ item.slug } path={ path } { ...item } />;
+			} ) }
+		</Sidebar>
+	);
+};
+export default MySitesSidebarUnified;

--- a/client/my-sites/sidebar-unified/item.jsx
+++ b/client/my-sites/sidebar-unified/item.jsx
@@ -1,0 +1,82 @@
+/**
+ * MySitesSidebarUnifiedItem
+ *
+ * Renders a sidebar menu item with no child items.
+ * This could be a top level item, or a child item nested under a top level menu.
+ * These two cases might be to be split up?
+ */
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { useSelector } from 'react-redux';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import { getSelectedSite } from 'state/ui/selectors';
+import SidebarItem from 'layout/sidebar/item';
+import StatsSparkline from 'blocks/stats-sparkline';
+
+const onNav = () => null;
+
+const removePrefix = ( str, prefix ) => {
+	if ( str == null || typeof str !== 'string' ) {
+		return str;
+	}
+	const hasPrefix = str.indexOf( prefix ) === 0;
+	if ( ! hasPrefix ) {
+		return str;
+	}
+	return str.substr( prefix.length );
+};
+
+// selected={ itemLinkMatches( [ '/domains', '/email' ], path ) }
+
+export const MySitesSidebarUnifiedItem = ( { title, icon, url, path, slug } ) => {
+	const selectedSite = useSelector( ( state ) => getSelectedSite( state ) );
+	const fixedUrl = removePrefix( url, 'https://wordpress.com' );
+	const selected = path === fixedUrl;
+	let customIcon = null;
+	if ( icon && typeof icon === 'string' && icon.match( /data:image/ ) ) {
+		// TODO: Change sidebar__menu-icon to sidebar-unified__menu-icon and
+		// copy the CSS rules
+		// I would do now, but this will cause a conflict w/ the update/left-nav-geometries
+		// branch
+		// eslint-disable-next-line
+		customIcon = <img src={ icon } className="sidebar__menu-icon" alt="" />;
+	}
+
+	let children = null;
+
+	// "Stats" item has sparkline inside of it
+	const isStats = typeof slug === 'string' && slug.includes( '-comstats' );
+	if ( isStats && selectedSite && selectedSite.ID ) {
+		// TODO: Change sidebar__menu-icon to sidebar-unified__menu-icon and
+		// copy the CSS rules
+		// eslint-disable-next-line
+		children = <StatsSparkline className="sidebar__sparkline" siteId={ selectedSite.ID } />;
+	}
+
+	return (
+		<SidebarItem
+			label={ title }
+			link={ fixedUrl }
+			onNavigate={ onNav }
+			selected={ selected }
+			customIcon={ customIcon }
+		>
+			{ children }
+		</SidebarItem>
+	);
+};
+
+MySitesSidebarUnifiedItem.propTypes = {
+	path: PropTypes.string,
+	title: PropTypes.string,
+	icon: PropTypes.string,
+	url: PropTypes.string,
+};
+
+export default MySitesSidebarUnifiedItem;

--- a/client/my-sites/sidebar-unified/item.jsx
+++ b/client/my-sites/sidebar-unified/item.jsx
@@ -15,6 +15,7 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
+import { decodeEntities } from 'lib/formatting';
 import { getSelectedSite } from 'state/ui/selectors';
 import SidebarItem from 'layout/sidebar/item';
 import StatsSparkline from 'blocks/stats-sparkline';
@@ -61,7 +62,7 @@ export const MySitesSidebarUnifiedItem = ( { title, icon, url, path, slug } ) =>
 
 	return (
 		<SidebarItem
-			label={ title }
+			label={ decodeEntities( title ) }
 			link={ fixedUrl }
 			onNavigate={ onNav }
 			selected={ selected }

--- a/client/my-sites/sidebar-unified/menu.jsx
+++ b/client/my-sites/sidebar-unified/menu.jsx
@@ -1,0 +1,99 @@
+/**
+ * MySitesSidebarUnifiedMenu
+ *
+ * Renders a top level menu item with children.
+ * This item can be expanded and collapsed by clicking.
+ **/
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import { isSidebarSectionOpen } from 'state/my-sites/sidebar/selectors';
+import { toggleMySitesSidebarSection as toggleSection } from 'state/my-sites/sidebar/actions';
+import ExpandableSidebarMenu from 'layout/sidebar/expandable';
+import MySitesSidebarUnifiedItem from './item';
+
+export const MySitesSidebarUnifiedMenu = ( { slug, title, icon, children, path } ) => {
+	const reduxDispatch = useDispatch();
+	const sectionId = 'SIDEBAR_SECTION_' + slug;
+	const isExpanded = useSelector( ( state ) => isSidebarSectionOpen( state, sectionId ) );
+	return (
+		<ExpandableSidebarMenu
+			onClick={ () => reduxDispatch( toggleSection( sectionId ) ) }
+			expanded={ isExpanded }
+			title={ title }
+			materialIcon={ icon }
+		>
+			{ Object.values( children ).map( ( item ) => (
+				<MySitesSidebarUnifiedItem key={ item.slug } path={ path } { ...item } />
+			) ) }
+		</ExpandableSidebarMenu>
+	);
+};
+
+MySitesSidebarUnifiedMenu.propTypes = {
+	path: PropTypes.string,
+	title: PropTypes.string,
+	icon: PropTypes.string,
+	children: PropTypes.oneOfType( [ PropTypes.object, PropTypes.array ] ).isRequired,
+	/*
+	Example of children shape (object):
+	{
+		"1": {
+			"title": "Feedback",
+			"url": "https://wp.com",
+			"icon": null,
+			"type": "menu-item"
+		},
+		"2": {
+			"title": "Polls",
+			"url": "https://wp.com",
+			"icon": null,
+			"type": "menu-item"
+		},
+		"3": {
+			"title": "Ratings",
+			"url": "https://wp.com",
+			"icon": null,
+			"type": "menu-item"
+		}
+	}
+
+	Example of children shape (array):
+	[
+		{
+			"title": "Settings",
+			"url": "https://wp.com",
+			"icon": null,
+			"type": "menu-item"
+		},
+		{
+			"title": "Domains",
+			"url": "https://wp.com",
+			"icon": null,
+			"type": "menu-item"
+		},
+		{
+			"title": "Debug Bar Extender",
+			"url": "https://wp.com",
+			"icon": null,
+			"type": "menu-item"
+		},
+		{
+			"title": "Hosting Configuration",
+			"url": "https://wp.com",
+			"icon": null,
+			"type": "menu-item"
+		}
+	]
+	*/
+};
+
+export default MySitesSidebarUnifiedMenu;

--- a/client/my-sites/sidebar-unified/switcher.jsx
+++ b/client/my-sites/sidebar-unified/switcher.jsx
@@ -1,0 +1,44 @@
+/**
+ * MySitesSidebarUnifiedSwitcher
+ *   This is a development component to make comparing the prod and unified sidebars easier.
+ *   Click the link to switch between the two versions of the sidebar.
+ *
+ *    Currently experimental/WIP.
+ **/
+
+/**
+ * External dependencies
+ */
+import React, { useState } from 'react';
+import MySitesSidebarUnified from './index';
+import MySitesSidebar from '../sidebar/index';
+
+export const MySitesSidebarUnifiedSwitcher = ( props ) => {
+	const [ isUnified, setUnified ] = useState( true );
+
+	return (
+		<>
+			<div
+				role="link"
+				tabIndex={ 0 }
+				style={ {
+					position: 'absolute',
+					zIndex: 1000,
+					backgroundColor: '#633',
+					right: 0,
+					cursor: 'pointer',
+					textDecoration: 'underline',
+					fontSize: '11px',
+				} }
+				onClick={ () => setUnified( ! isUnified ) }
+				onKeyDown={ () => setUnified( ! isUnified ) }
+			>
+				{ isUnified && <span>Unified SB</span> }
+				{ ! isUnified && <span>Prod SB</span> }
+			</div>
+			{ isUnified && <MySitesSidebarUnified { ...props } /> }
+			{ ! isUnified && <MySitesSidebar { ...props } /> }
+		</>
+	);
+};
+export default MySitesSidebarUnifiedSwitcher;


### PR DESCRIPTION
This essentially attempts to remerge https://github.com/Automattic/wp-calypso/pull/45531.

The only additional changes are:

* Decode HTML entities in `title` of each menu item before display.
* Ensure single/standalone menu items are wrapped in a `<ul>` - this matches existing Calypso HTML structure.

#### Testing instructions

As per https://github.com/Automattic/wp-calypso/pull/45531

