### PR TITLE
Components: Unglobalize input styles

### DIFF
--- a/client/components/forms/form-text-input/style.scss
+++ b/client/components/forms/form-text-input/style.scss
@@ -1,20 +1,20 @@
 .form-text-input {
 	@at-root {
-		input[type='url'],
-		input[type='tel'],
-		input[type='search'] {
+		input[type='url']#{&},
+		input[type='tel']#{&},
+		input[type='search']#{&} {
 			@extend %form-field;
 		}
 
-		input[type='url'],
-		input[type='search'] {
+		input[type='url']#{&},
+		input[type='search']#{&} {
 			appearance: none;
 
 			/*!rtl:ignore*/
 			direction: ltr;
 		}
 
-		input[type='search']::-webkit-search-decoration {
+		input[type='search']#{&}::-webkit-search-decoration {
 			// We don't use the native results="" UI
 			// Ensures the input text is flush to the start of the element, as in regular text inputs
 			// See, for example, http://geek.michaelgrace.org/2011/06/webkit-search-input-styling/

--- a/client/components/phone-input/style.scss
+++ b/client/components/phone-input/style.scss
@@ -66,7 +66,7 @@ select.phone-input__country-select {
 	position: relative;
 	width: 100%;
 
-	.phone-input__number-input {
+	.phone-input__number-input.form-text-input {
 		padding-left: 70px;
 	}
 }

--- a/client/components/search/style.scss
+++ b/client/components/search/style.scss
@@ -103,7 +103,7 @@
 	}
 }
 
-.search__input[type='search'] {
+.search__input.form-text-input[type='search'] {
 	flex: 1 1 auto;
 	display: none;
 	z-index: z-index( '.search', '.search__input' );


### PR DESCRIPTION
As @saramarcondes identified, for search, tel, and URL fields, we currently don't use component-specific styles. It's because we used `@at-root` but then didn't apply the selector in question to all the nested rules. This PR addresses that.

#### Changes proposed in this Pull Request

* Components: change `FormTextInput` styles to be component-specific vs global.

#### Testing instructions
* For all the following test steps, inspect the relevant elements, and verify CSS rules are no longer assigned to global elements, but instead all of them are relative to `.form-text-input`.
* Go through the testing instructions of those PRs:
  * #45358
  * #45400
  * #45270
