### PR TITLE
Remove overrides of 'import/no-extraneous-dependencies' in apps/editing-toolkit

### DIFF
--- a/apps/editing-toolkit/bin/js-unit-config.js
+++ b/apps/editing-toolkit/bin/js-unit-config.js
@@ -11,8 +11,6 @@
  * config file for e2e tests.
  */
 
-/* eslint-disable import/no-extraneous-dependencies */
-
 // @wordpress/scripts manually adds additional Jest config ontop of
 // @wordpress/jest-preset-default so we pull in this file to extend it
 const defaults = require( '@wordpress/scripts/config/jest-unit.config.js' );

--- a/apps/editing-toolkit/bin/npm-run-build.js
+++ b/apps/editing-toolkit/bin/npm-run-build.js
@@ -2,7 +2,6 @@
  **** WARNING: No ES6 modules here. Not transpiled! ****
  */
 /* eslint-disable import/no-nodejs-modules */
-/* eslint-disable import/no-extraneous-dependencies */
 /* eslint-disable no-console */
 /* eslint-disable no-process-exit */
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/blocks/navigation-menu/edit.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/blocks/navigation-menu/edit.js
@@ -1,5 +1,4 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
-/* eslint-disable import/no-extraneous-dependencies */
 /**
  * WordPress dependencies
  */

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/blocks/navigation-menu/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/blocks/navigation-menu/index.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
 /**
  * WordPress dependencies
  */

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/blocks/post-content/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/blocks/post-content/index.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
 /**
  * External dependencies
  */

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/blocks/site-credit/edit.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/blocks/site-credit/edit.js
@@ -1,5 +1,4 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
-/* eslint-disable import/no-extraneous-dependencies */
 /* global fullSiteEditing */
 /**
  * External dependencies

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/blocks/site-credit/footer-credit-choices.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/blocks/site-credit/footer-credit-choices.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
 /* eslint-disable wpcalypso/import-docblock */
 /* global fullSiteEditing */
 /**

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/blocks/site-credit/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/blocks/site-credit/index.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
 /**
  * WordPress dependencies
  */

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/blocks/site-description/edit.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/blocks/site-description/edit.js
@@ -1,5 +1,4 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
-/* eslint-disable import/no-extraneous-dependencies */
 /**
  * External dependencies
  */

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/blocks/site-description/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/blocks/site-description/index.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
 /**
  * WordPress dependencies
  */

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/blocks/site-title/edit.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/blocks/site-title/edit.js
@@ -1,5 +1,4 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
-/* eslint-disable import/no-extraneous-dependencies */
 /**
  * External dependencies
  */

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/blocks/site-title/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/blocks/site-title/index.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
 /**
  * WordPress dependencies
  */

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/blocks/template/edit.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/blocks/template/edit.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 /* global fullSiteEditing */
 /**

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/lib/site-options/use-previous.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/lib/site-options/use-previous.js
@@ -1,5 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
-
 /**
  * External dependencies
  */

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/lib/site-options/use-site-options.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/lib/site-options/use-site-options.js
@@ -1,5 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
-
 /**
  * External dependencies
  */

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/lib/site-options/with-site-options.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/lib/site-options/with-site-options.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
 /**
  * External dependencies
  */

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/plugins/close-button-override/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/plugins/close-button-override/index.js
@@ -3,13 +3,11 @@
 /**
  * External dependencies
  */
-/* eslint-disable import/no-extraneous-dependencies */
 import domReady from '@wordpress/dom-ready';
 import ReactDOM from 'react-dom';
 import { __ } from '@wordpress/i18n';
 import { Button, Dashicon } from '@wordpress/components';
 import { useState } from '@wordpress/element';
-/* eslint-disable import/no-extraneous-dependencies */
 
 /**
  * Internal dependencies

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/plugins/editor-template-classes/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/plugins/editor-template-classes/index.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
 /* global fullSiteEditing */
 /**
  * External dependencies

--- a/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/tests/fse-back-button.spec.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/dotcom-fse/tests/fse-back-button.spec.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-/* eslint-disable import/no-extraneous-dependencies */
 const { createNewPost } = require( '@wordpress/e2e-test-utils' );
 
 import { activateTheme } from '../../e2e-test-helpers';

--- a/apps/editing-toolkit/editing-toolkit-plugin/e2e-test-helpers/activate-theme.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/e2e-test-helpers/activate-theme.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
 /**
  * External dependencies
  */

--- a/apps/editing-toolkit/editing-toolkit-plugin/newspack-blocks/blog-posts-block-editor.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/newspack-blocks/blog-posts-block-editor.js
@@ -1,11 +1,9 @@
-/* eslint-disable import/no-extraneous-dependencies */
 /**
  * External dependencies
  */
 import { registerBlockType } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 import { addFilter } from '@wordpress/hooks';
-/* eslint-enable import/no-extraneous-dependencies */
 
 /**
  * Internal dependencies

--- a/apps/editing-toolkit/editing-toolkit-plugin/newspack-blocks/carousel-block-editor.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/newspack-blocks/carousel-block-editor.js
@@ -1,10 +1,8 @@
-/* eslint-disable import/no-extraneous-dependencies */
 /**
  * External dependencies
  */
 import { registerBlockType } from '@wordpress/blocks';
 import { addFilter } from '@wordpress/hooks';
-/* eslint-enable import/no-extraneous-dependencies */
 
 /**
  * External dependencies

--- a/apps/editing-toolkit/editing-toolkit-plugin/posts-list-block/blocks/posts-list/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/posts-list-block/blocks/posts-list/index.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
 /**
  * WordPress dependencies
  */
@@ -12,7 +11,6 @@ import { Placeholder, RangeControl, PanelBody, Notice } from '@wordpress/compone
 import { Fragment } from '@wordpress/element';
 import { InspectorControls } from '@wordpress/block-editor';
 import { select, dispatch } from '@wordpress/data';
-/* eslint-enable import/no-extraneous-dependencies */
 
 /**
  * Internal dependencies

--- a/apps/editing-toolkit/editing-toolkit-plugin/posts-list-block/blocks/posts-list/transforms.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/posts-list-block/blocks/posts-list/transforms.js
@@ -2,12 +2,10 @@
  * External dependencies
  */
 
-/* eslint-disable import/no-extraneous-dependencies */
 /**
  * WordPress dependencies
  */
 import { createBlock } from '@wordpress/blocks';
-/* eslint-enable import/no-extraneous-dependencies */
 
 const HOMEPAGE_POSTS_BLOCK_TYPES = [ 'a8c/blog-posts', 'newspack-blocks/homepage-articles' ];
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/index.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
 /**
  * External dependencies
  */
@@ -14,7 +13,6 @@ import { PageTemplatesPlugin } from './page-template-modal';
 import SidebarTemplatesPlugin from './page-template-modal/components/sidebar-modal-opener';
 import { initializeWithIdentity } from './page-template-modal/utils/tracking';
 import './store';
-/* eslint-enable import/no-extraneous-dependencies */
 
 // Load config passed from backend.
 const {

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/components/block-iframe-preview.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/components/block-iframe-preview.js
@@ -7,7 +7,6 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-/* eslint-disable import/no-extraneous-dependencies */
 import {
 	createPortal,
 	useRef,
@@ -22,7 +21,6 @@ import { withSelect } from '@wordpress/data';
 import { compose, withSafeTimeout } from '@wordpress/compose';
 
 import { __ } from '@wordpress/i18n';
-/* eslint-enable import/no-extraneous-dependencies */
 
 import CustomBlockPreview from './block-preview';
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/components/sidebar-modal-opener.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/components/sidebar-modal-opener.js
@@ -1,5 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
-
 /**
  * External dependencies
  */
@@ -12,7 +10,6 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { PageTemplatesPlugin } from '../index';
-/* eslint-enable import/no-extraneous-dependencies */
 class SidebarModalOpener extends Component {
 	state = {
 		isWarningOpen: false,

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
@@ -1,19 +1,15 @@
 /**
  * External dependencies
  */
-/* eslint-disable import/no-extraneous-dependencies */
 import { isEmpty, isArray, noop, map } from 'lodash';
-/* eslint-enable import/no-extraneous-dependencies */
 import classnames from 'classnames';
 
 /**
  * WordPress dependencies
  */
-/* eslint-disable import/no-extraneous-dependencies */
 import { withInstanceId, compose } from '@wordpress/compose';
 import { BaseControl } from '@wordpress/components';
 import { memo } from '@wordpress/element';
-/* eslint-enable import/no-extraneous-dependencies */
 
 /**
  * Internal dependencies

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
@@ -1,9 +1,7 @@
 /**
  * External dependencies
  */
-/* eslint-disable import/no-extraneous-dependencies */
 import { isNil, isEmpty } from 'lodash';
-/* eslint-enable import/no-extraneous-dependencies */
 import classnames from 'classnames';
 
 /**

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
@@ -1,9 +1,7 @@
 /**
  * WordPress dependencies
  */
-/* eslint-disable import/no-extraneous-dependencies */
 import { __ } from '@wordpress/i18n';
-/* eslint-enable import/no-extraneous-dependencies */
 
 /**
  * Internal dependencies

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/components/test/helpers/templates-blocks-helpers.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/components/test/helpers/templates-blocks-helpers.js
@@ -1,9 +1,7 @@
 /**
  * External dependencies
  */
-/* eslint-disable import/no-extraneous-dependencies */
 import { uniqueId, range, toArray } from 'lodash';
-/* eslint-enable import/no-extraneous-dependencies */
 
 export const templatesFixture = [
 	{

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/components/test/template-selector-control.test.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/components/test/template-selector-control.test.js
@@ -1,10 +1,8 @@
 /**
  * External dependencies
  */
-/* eslint-disable import/no-extraneous-dependencies */
 import { uniqueId, omit } from 'lodash';
 import { render, fireEvent } from '@testing-library/react';
-/* eslint-enable import/no-extraneous-dependencies */
 
 import { templatesFixture, blocksByTemplatesFixture } from './helpers/templates-blocks-helpers';
 import { TemplateSelectorControl } from '../template-selector-control';

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/components/test/template-selector-preview.test.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/components/test/template-selector-preview.test.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-/* eslint-disable import/no-extraneous-dependencies */
 
 import { render } from '@testing-library/react';
 import { blocksFixture } from './helpers/templates-blocks-helpers';

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/page-template-modal/index.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
 /**
  * External dependencies
  */
@@ -35,7 +34,6 @@ import replacePlaceholders from './utils/replace-placeholders';
 import ensureAssets from './utils/ensure-assets';
 import mapBlocksRecursively from './utils/map-blocks-recursively';
 import containsMissingBlock from './utils/contains-missing-block';
-/* eslint-enable import/no-extraneous-dependencies */
 
 const INSERTING_HOOK_NAME = 'isInsertingPageTemplate';
 const INSERTING_HOOK_NAMESPACE = 'automattic/full-site-editing/inserting-template';

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/store.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/store.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
 /**
  * External dependencies
  */

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/store.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/store.ts
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
 /**
  * External dependencies
  */

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/disable-core-nux.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/disable-core-nux.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
 /**
  * External dependencies
  */

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/store.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/store.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
 /**
  * External dependencies
  */

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/wpcom-nux.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/wpcom-nux.js
@@ -1,7 +1,6 @@
 /*** THIS MUST BE THE FIRST THING EVALUATED IN THIS SCRIPT *****/
 import './public-path';
 
-/* eslint-disable import/no-extraneous-dependencies */
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 /**
  * External dependencies

--- a/apps/editing-toolkit/webpack.config.js
+++ b/apps/editing-toolkit/webpack.config.js
@@ -8,7 +8,6 @@
  */
 const _ = require( 'lodash' );
 const DependencyExtractionWebpackPlugin = require( '@wordpress/dependency-extraction-webpack-plugin' );
-// eslint-disable-next-line import/no-extraneous-dependencies
 const getBaseWebpackConfig = require( '@automattic/calypso-build/webpack.config.js' );
 const path = require( 'path' );
 


### PR DESCRIPTION
Removes overrides of eslint rule `import/no-extraneous-dependencies`, they are not needed anymore.

Running eslint in `apps/editing-toolkit` and comparing the results with master shows there are no new errors introduced when the override is deleted:

```
$ ./node_modules/.bin/eslint apps/editing-toolkit

# In master
✖ 49 problems (26 errors, 23 warnings)

# In this branch
✖ 49 problems (26 errors, 23 warnings)
```

The linting job will fail because I changed files that have other errors. Please ignore.