### PR TITLE
Remove overrides of 'import/no-extraneous-dependencies' in apps/wpcom-block-editor

### DIFF
--- a/apps/wpcom-block-editor/.eslintrc.js
+++ b/apps/wpcom-block-editor/.eslintrc.js
@@ -1,6 +1,5 @@
 module.exports = {
 	rules: {
-		'import/no-extraneous-dependencies': [ 'error', { packageDir: __dirname } ],
 		'react/react-in-jsx-scope': 0,
 	},
 };

--- a/apps/wpcom-block-editor/bin/npm-run-build.js
+++ b/apps/wpcom-block-editor/bin/npm-run-build.js
@@ -4,7 +4,6 @@
  **** WARNING: No ES6 modules here. Not transpiled! ****
  */
 /* eslint-disable import/no-nodejs-modules */
-/* eslint-disable import/no-extraneous-dependencies */
 /* eslint-disable no-console */
 
 const runAll = require( 'npm-run-all' );

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
 /* global calypsoifyGutenberg, Image, MessageChannel, MessagePort, requestAnimationFrame */
 
 /**

--- a/apps/wpcom-block-editor/src/calypso/features/tinymce.js
+++ b/apps/wpcom-block-editor/src/calypso/features/tinymce.js
@@ -1,5 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
-
 /**
  * External dependencies
  */

--- a/apps/wpcom-block-editor/src/default/features/rich-text.js
+++ b/apps/wpcom-block-editor/src/default/features/rich-text.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
 /* global wpcomGutenberg */
 
 /**

--- a/apps/wpcom-block-editor/src/default/features/switch-to-classic.js
+++ b/apps/wpcom-block-editor/src/default/features/switch-to-classic.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
 /* global wpcomGutenberg */
 
 /**

--- a/apps/wpcom-block-editor/src/utils.js
+++ b/apps/wpcom-block-editor/src/utils.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
 /**
  * External dependencies
  */

--- a/apps/wpcom-block-editor/src/wpcom/editor.js
+++ b/apps/wpcom-block-editor/src/wpcom/editor.js
@@ -1,12 +1,8 @@
-/* eslint-disable import/no-extraneous-dependencies */
-
 /**
  * WordPress dependencies
  */
 
 import { registerPlugin } from '@wordpress/plugins';
-
-/* eslint-enable import/no-extraneous-dependencies */
 
 /**
  * Internal dependencies

--- a/apps/wpcom-block-editor/src/wpcom/features/convert-to-blocks-button.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/convert-to-blocks-button.js
@@ -1,5 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
-
 /**
  * External dependencies
  */
@@ -15,7 +13,6 @@ import { __ } from '@wordpress/i18n';
 import { compose } from '@wordpress/compose';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { rawHandler, serialize } from '@wordpress/blocks';
-/* eslint-enable import/no-extraneous-dependencies */
 
 /**
  * Internal dependencies

--- a/apps/wpcom-block-editor/src/wpcom/features/deprecate-coblocks-buttons.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/deprecate-coblocks-buttons.js
@@ -1,5 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
-
 /**
  * External dependencies
  */

--- a/apps/wpcom-block-editor/src/wpcom/features/fix-block-invalidation-errors.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/fix-block-invalidation-errors.js
@@ -1,5 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
-
 /**
  * External dependencies
  */

--- a/apps/wpcom-block-editor/src/wpcom/features/images.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/images.js
@@ -1,9 +1,7 @@
-/* eslint-disable import/no-extraneous-dependencies */
 /**
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-/* eslint-enable import/no-extraneous-dependencies */
 
 export const ClassicBlockImage = ( props ) => (
 	/* eslint-disable wpcalypso/jsx-classname-namespace */

--- a/apps/wpcom-block-editor/src/wpcom/features/reorder-block-categories.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/reorder-block-categories.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
 /**
  * External dependencies
  */

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
 /**
  * External dependencies
  */
@@ -13,7 +12,6 @@ import debugFactory from 'debug';
  */
 import tracksRecordEvent from './tracking/track-record-event';
 import delegateEventTracking from './tracking/delegate-event-tracking';
-/* eslint-enable import/no-extraneous-dependencies */
 
 // Debugger.
 const debug = debugFactory( 'wpcom-block-editor:tracking' );

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/track-record-event.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/track-record-event.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
 /**
  * External dependencies
  */

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-inserter-inline-search-term.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-inserter-inline-search-term.js
@@ -1,5 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
-
 /**
  * External dependencies
  */

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-inserter-menu-search-term.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-inserter-menu-search-term.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
 /**
  * External dependencies
  */
@@ -10,8 +9,6 @@ import { debounce } from 'lodash';
 import { useState } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { __experimentalInserterMenuExtension as InserterMenuExtension } from '@wordpress/block-editor';
-
-/* eslint-enable import/no-extraneous-dependencies */
 
 /**
  * Internal dependencies

--- a/apps/wpcom-block-editor/src/wpcom/features/use-classic-block-guide.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/use-classic-block-guide.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
 /**
  * External dependencies
  */
@@ -9,7 +8,6 @@ import { useDispatch } from '@wordpress/data';
 import url from 'url'; // eslint-disable-line no-restricted-imports
 import { __ } from '@wordpress/i18n';
 import { registerPlugin } from '@wordpress/plugins';
-/* eslint-enable import/no-extraneous-dependencies */
 
 /**
  * Internal dependencies

--- a/apps/wpcom-block-editor/webpack.config.js
+++ b/apps/wpcom-block-editor/webpack.config.js
@@ -6,7 +6,6 @@
 /**
  * External dependencies
  */
-// eslint-disable-next-line import/no-extraneous-dependencies
 const DependencyExtractionWebpackPlugin = require( '@wordpress/dependency-extraction-webpack-plugin' );
 const getBaseWebpackConfig = require( '@automattic/calypso-build/webpack.config.js' );
 const path = require( 'path' );


### PR DESCRIPTION
Removes overrides of eslint rule `import/no-extraneous-dependencies`, they are not needed anymore.

Running eslint in `apps/wpcom-block-editor` and comparing the results with master shows there are no new errors introduced when the override is deleted:

```
$ ./node_modules/.bin/eslint --ext .js --ext .jsx --ext .ts --ext .tsx apps/editing-toolkit

# In master
✖ 2 problems (2 errors, 0 warnings)

# In this branch
✖ 2 problems (2 errors, 0 warnings)
```

The linting job will fail because I changed files that have other errors. Please ignore.