### PR TITLE
Reduxify/remove media store from calypsoify iframe

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -4,17 +4,7 @@
  */
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
-import {
-	endsWith,
-	get,
-	map,
-	partial,
-	pickBy,
-	startsWith,
-	isArray,
-	flowRight,
-	difference,
-} from 'lodash';
+import { endsWith, map, partial, pickBy, startsWith, isArray, flowRight, difference } from 'lodash';
 /* eslint-disable no-restricted-imports */
 import url from 'url';
 import { localize, LocalizeProps } from 'i18n-calypso';
@@ -542,12 +532,12 @@ class CalypsoifyIframe extends Component<
 			return;
 		}
 		const payload = {
-			id: get( mediaItem, 'ID' ),
-			height: get( mediaItem, 'height' ),
+			id: mediaItem?.ID,
+			transientId: mediaItem?.ID,
+			height: mediaItem?.height,
+			width: mediaItem?.width,
+			url: mediaItem?.URL,
 			status,
-			transientId: get( mediaItem, 'ID' ),
-			url: get( mediaItem, 'URL' ),
-			width: get( mediaItem, 'width' ),
 		};
 		this.iframePort.postMessage( { action: 'updateImageBlocks', payload } );
 	};

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -178,7 +178,7 @@ class CalypsoifyIframe extends Component<
 			diff.forEach( ( mediaItem ) => {
 				const status =
 					currentMedia.find( ( item ) => item.ID === mediaItem.ID ) !== undefined
-						? 'udpated'
+						? 'updated'
 						: 'removed';
 
 				this.updateImageBlocks( mediaItem, status );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Calypsoify Iframe: remove usage of `MediaStore`

#### Testing instructions

1. Open a post using Gutenframe (Gutenberg on WP.com) which contains an image block; then hit reload to get a clean state
2. Now try to replace the image and open the media library; that should then trigger a call as described below
3. Deleting an item from the media library (any) should also trigger a call as described below

* Make sure `iframePort.postMessage` is called whenever an item in the media library got updated or deleted. You can either set a breakpoint [on the affected line](https://github.com/Automattic/wp-calypso/pull/45625/files#diff-59c0336bfc8e2c9de7a26194d97da7eaR542) via browser devtools or add a `debugger` statement in your local dev environment. Then compare the `payload` object and verify its got all the correct properties.
* I'm currently not sure about how to debug the effects of that call and make sure they're the same as on prod; comparing the calls should at least give a little bit of confidence that we're not breaking anything.

related to #43663
