### PR TITLE
Remove overrides of 'import/no-extraneous-dependencies' in apps/o2-blocks

### DIFF
--- a/apps/o2-blocks/.eslintrc.js
+++ b/apps/o2-blocks/.eslintrc.js
@@ -1,6 +1,5 @@
 module.exports = {
 	rules: {
-		'import/no-extraneous-dependencies': 0,
 		'react/react-in-jsx-scope': 0,
 		'wpcalypso/jsx-classname-namespace': 0,
 	},


### PR DESCRIPTION
Removes overrides of eslint rule `import/no-extraneous-dependencies`, they are not needed anymore.

Running eslint in `apps/o2-blocks` and comparing the results with master shows there are no new errors introduced when the override is deleted:

```
$ ./node_modules/.bin/eslint --ext .js --ext .jsx --ext .ts --ext .tsx apps/o2-blocks

# In master
✖ 4 problems (4 errors, 0 warnings)

# In this branch
✖ 4 problems (4 errors, 0 warnings)
```

The linting job will fail because I changed files that have other errors. Please ignore.