### PR TITLE
Add support for analyzing server bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ test-results*.xml
 /chart.json
 /style.json
 /client/stats.json
+/client/stats-server.json
 /client/chart.json
 /client/style.json
 spec-xunit-reporter-0.0.1.tgz

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
 	},
 	"scripts": {
 		"analyze-bundles": "yarn run build-client-stats && webpack-bundle-analyzer client/stats.json public/evergreen -h 127.0.0.1 -p 9898 -s gzip",
+		"analyze-bundles:server": "yarn run build-server-stats && webpack-bundle-analyzer client/stats-server.json build -h 127.0.0.1 -p 9898 -s parsed",
 		"analyze-icfy": "yarn run build-client-stats && node --max-old-space-size=4096 bin/icfy-analyze.js",
 		"autoprefixer": "postcss -u autoprefixer -r --no-map --config packages/calypso-build/postcss.config.js",
 		"postcss": "postcss -r --config packages/calypso-build/postcss.config.js",
@@ -75,6 +76,7 @@
 		"build-static": "npx ncp static public",
 		"prebuild-server": "mkdirp build",
 		"build-server": "BROWSERSLIST_ENV=server webpack --config client/webpack.config.node.js --display errors-only",
+		"build-server-stats": "NODE_ENV=production CALYPSO_ENV=production EMIT_STATS=true yarn run build-server",
 		"build-client": "yarn run build-client-evergreen",
 		"build-client-do": "node ${NODE_ARGS:---max-old-space-size=8192} ./node_modules/webpack/bin/webpack.js --config client/webpack.config.js --display errors-only",
 		"build-client-fallback": "BROWSERSLIST_ENV=defaults yarn run build-client-do",
@@ -148,6 +150,8 @@
 		"validate-fallback-es5": "npx eslint --parser-options=ecmaVersion:5 --no-eslintrc --no-ignore ./public/fallback/*.js",
 		"prewhybundled": "NODE_ENV=production CALYPSO_ENV=production EMIT_STATS=withreasons CONCATENATE_MODULES=false yarn run -s build-client-evergreen",
 		"whybundled": "whybundled client/stats.json",
+		"prewhybundled:server": "NODE_ENV=production CALYPSO_ENV=production EMIT_STATS=withreasons CONCATENATE_MODULES=false yarn run -s build-server",
+		"whybundled:server": "whybundled client/stats-server.json",
 		"composite-checkout-demo": "webpack-dev-server --config ./packages/composite-checkout/webpack.config.demo.js --mode development",
 		"components:storybook:start": "start-storybook -c packages/components/.storybook",
 		"media-library:storybook:start": "start-storybook -c packages/media-library/.storybook -h calypso.localhost -p 3001"


### PR DESCRIPTION
Support for two new commands:
- `yarn run analyze-bundles:server`: shows a visualization of the server bundle contents
- `yarn run whybundled:server`: produces a report of bundled modules and reasons for bundling

The client counterparts, without the `:server` suffix, already exist for a long time.

Spinoff from #45570 which is already big and might never be merged. Let's land some parts independently.