### PR TITLE
Remove overrides of 'import/no-extraneous-dependencies' in client/desktop

### DIFF
--- a/client/desktop/app-handlers/crash-reporting/index.js
+++ b/client/desktop/app-handlers/crash-reporting/index.js
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-const { app, crashReporter } = require( 'electron' ); // eslint-disable-line import/no-extraneous-dependencies
+const { app, crashReporter } = require( 'electron' );
 
 /**
  * Internal dependencies

--- a/client/desktop/app-handlers/exceptions/index.js
+++ b/client/desktop/app-handlers/exceptions/index.js
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-const { app, dialog } = require( 'electron' ); // eslint-disable-line import/no-extraneous-dependencies
+const { app, dialog } = require( 'electron' );
 
 /**
  * Internal dependencies

--- a/client/desktop/app-handlers/logging/ipc-handler/index.js
+++ b/client/desktop/app-handlers/logging/ipc-handler/index.js
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-const { ipcMain: ipc } = require( 'electron' ); // eslint-disable-line import/no-extraneous-dependencies
+const { ipcMain: ipc } = require( 'electron' );
 
 module.exports = {
 	/**

--- a/client/desktop/app-handlers/preferences/index.js
+++ b/client/desktop/app-handlers/preferences/index.js
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-const { dialog, ipcMain: ipc } = require( 'electron' ); // eslint-disable-line import/no-extraneous-dependencies
+const { dialog, ipcMain: ipc } = require( 'electron' );
 
 /**
  * Internal dependencies

--- a/client/desktop/app-handlers/printer/index.js
+++ b/client/desktop/app-handlers/printer/index.js
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-const { BrowserWindow, ipcMain: ipc } = require( 'electron' ); // eslint-disable-line import/no-extraneous-dependencies
+const { BrowserWindow, ipcMain: ipc } = require( 'electron' );
 
 /**
  * Internal dependencies

--- a/client/desktop/app-handlers/secrets/index.js
+++ b/client/desktop/app-handlers/secrets/index.js
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-const { ipcMain: ipc } = require( 'electron' ); // eslint-disable-line import/no-extraneous-dependencies
+const { ipcMain: ipc } = require( 'electron' );
 
 /**
  * Internal dependencies

--- a/client/desktop/app-handlers/updater/auto-updater/index.js
+++ b/client/desktop/app-handlers/updater/auto-updater/index.js
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-const { app } = require( 'electron' ); // eslint-disable-line import/no-extraneous-dependencies
+const { app } = require( 'electron' );
 const { autoUpdater } = require( 'electron-updater' );
 
 /**

--- a/client/desktop/app-handlers/updater/index.js
+++ b/client/desktop/app-handlers/updater/index.js
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-const { app } = require( 'electron' ); // eslint-disable-line import/no-extraneous-dependencies
+const { app } = require( 'electron' );
 
 /**
  * Internal dependencies

--- a/client/desktop/app-handlers/updater/manual-updater/index.js
+++ b/client/desktop/app-handlers/updater/manual-updater/index.js
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-const { app, shell } = require( 'electron' ); // eslint-disable-line import/no-extraneous-dependencies
+const { app, shell } = require( 'electron' );
 const fetch = require( 'electron-fetch' ).default;
 const yaml = require( 'js-yaml' );
 const semver = require( 'semver' );

--- a/client/desktop/env.js
+++ b/client/desktop/env.js
@@ -2,7 +2,7 @@
  * External Dependencies
  */
 const path = require( 'path' );
-const { app } = require( 'electron' ); // eslint-disable-line import/no-extraneous-dependencies
+const { app } = require( 'electron' );
 const makeDir = require( 'make-dir' );
 
 /**

--- a/client/desktop/lib/app-instance/index.js
+++ b/client/desktop/lib/app-instance/index.js
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-const { app } = require( 'electron' ); // eslint-disable-line import/no-extraneous-dependencies
+const { app } = require( 'electron' );
 
 /**
  * Internal dependencies

--- a/client/desktop/lib/cookie-auth/index.js
+++ b/client/desktop/lib/cookie-auth/index.js
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-const { ipcMain: ipc } = require( 'electron' ); // eslint-disable-line import/no-extraneous-dependencies
+const { ipcMain: ipc } = require( 'electron' );
 const https = require( 'https' ); // eslint-disable-line import/no-nodejs-modules
 const url = require( 'url' );
 const events = require( 'events' );

--- a/client/desktop/lib/crash-tracker/index.js
+++ b/client/desktop/lib/crash-tracker/index.js
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-const { app } = require( 'electron' ); // eslint-disable-line import/no-extraneous-dependencies
+const { app } = require( 'electron' );
 const request = require( 'superagent' ); // eslint-disable-line no-restricted-modules
 const path = require( 'path' );
 

--- a/client/desktop/lib/debug-tools/index.js
+++ b/client/desktop/lib/debug-tools/index.js
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-const { dialog } = require( 'electron' ); // eslint-disable-line import/no-extraneous-dependencies
+const { dialog } = require( 'electron' );
 
 module.exports = {
 	dialog: function ( message ) {

--- a/client/desktop/lib/menu/app-menu.js
+++ b/client/desktop/lib/menu/app-menu.js
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-const { dialog } = require( 'electron' ); // eslint-disable-line import/no-extraneous-dependencies
+const { dialog } = require( 'electron' );
 
 /**
  * Internal dependencies

--- a/client/desktop/lib/menu/debug-menu.js
+++ b/client/desktop/lib/menu/debug-menu.js
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-const { BrowserWindow } = require( 'electron' ); // eslint-disable-line import/no-extraneous-dependencies
+const { BrowserWindow } = require( 'electron' );
 
 module.exports = [
 	{

--- a/client/desktop/lib/menu/help-menu.js
+++ b/client/desktop/lib/menu/help-menu.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-const { shell } = require( 'electron' ); // eslint-disable-line import/no-extraneous-dependencies
+const { shell } = require( 'electron' );
 const ipc = require( 'desktop/lib/calypso-commands' );
 const zipLogs = require( '../../window-handlers/get-logs' );
 

--- a/client/desktop/lib/menu/index.js
+++ b/client/desktop/lib/menu/index.js
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-const { Menu } = require( 'electron' ); // eslint-disable-line import/no-extraneous-dependencies
+const { Menu } = require( 'electron' );
 
 /**
  * Internal dependencies

--- a/client/desktop/lib/menu/view-menu.js
+++ b/client/desktop/lib/menu/view-menu.js
@@ -1,4 +1,4 @@
-const { BrowserWindow } = require( 'electron' ); // eslint-disable-line import/no-extraneous-dependencies
+const { BrowserWindow } = require( 'electron' );
 
 /**
  * Internal dependencies

--- a/client/desktop/lib/platform/linux/index.js
+++ b/client/desktop/lib/platform/linux/index.js
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-const { app } = require( 'electron' ); // eslint-disable-line import/no-extraneous-dependencies
+const { app } = require( 'electron' );
 
 /**
  * Internal dependencies

--- a/client/desktop/lib/platform/mac/index.js
+++ b/client/desktop/lib/platform/mac/index.js
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-const { app, Menu } = require( 'electron' ); // eslint-disable-line import/no-extraneous-dependencies
+const { app, Menu } = require( 'electron' );
 
 /**
  * Internal dependencies

--- a/client/desktop/lib/platform/windows/index.js
+++ b/client/desktop/lib/platform/windows/index.js
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-const { Tray, Menu, app } = require( 'electron' ); // eslint-disable-line import/no-extraneous-dependencies
+const { Tray, Menu, app } = require( 'electron' );
 
 /**
  * Internal dependencies

--- a/client/desktop/lib/platform/windows/tray-menu.js
+++ b/client/desktop/lib/platform/windows/tray-menu.js
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-const { app } = require( 'electron' ); // eslint-disable-line import/no-extraneous-dependencies
+const { app } = require( 'electron' );
 
 /**
  * Internal dependencies

--- a/client/desktop/lib/settings/settings-file.js
+++ b/client/desktop/lib/settings/settings-file.js
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-const { app } = require( 'electron' ); // eslint-disable-line import/no-extraneous-dependencies
+const { app } = require( 'electron' );
 const path = require( 'path' );
 const fs = require( 'fs' ); // eslint-disable-line import/no-nodejs-modules
 

--- a/client/desktop/lib/updater/index.js
+++ b/client/desktop/lib/updater/index.js
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-const { app, dialog, BrowserWindow } = require( 'electron' ); // eslint-disable-line import/no-extraneous-dependencies
+const { app, dialog, BrowserWindow } = require( 'electron' );
 const { EventEmitter } = require( 'events' );
 
 /**

--- a/client/desktop/lib/window-manager/index.js
+++ b/client/desktop/lib/window-manager/index.js
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-const electron = require( 'electron' ); // eslint-disable-line import/no-extraneous-dependencies
+const electron = require( 'electron' );
 const BrowserWindow = electron.BrowserWindow;
 const app = electron.app;
 const path = require( 'path' );

--- a/client/desktop/server/index.js
+++ b/client/desktop/server/index.js
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-const { app, BrowserWindow, ipcMain: ipc } = require( 'electron' ); // eslint-disable-line import/no-extraneous-dependencies
+const { app, BrowserWindow, ipcMain: ipc } = require( 'electron' );
 const url = require( 'url' );
 const path = require( 'path' );
 

--- a/client/desktop/server/server.js
+++ b/client/desktop/server/server.js
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-import { dialog } from 'electron'; // eslint-disable-line import/no-extraneous-dependencies
+import { dialog } from 'electron';
 import http from 'http'; // eslint-disable-line import/no-nodejs-modules
 import portscanner from 'portscanner';
 

--- a/client/desktop/window-handlers/debug-tools/index.js
+++ b/client/desktop/window-handlers/debug-tools/index.js
@@ -1,4 +1,4 @@
-const { ipcMain: ipc } = require( 'electron' ); // eslint-disable-line import/no-extraneous-dependencies
+const { ipcMain: ipc } = require( 'electron' );
 
 module.exports = function ( mainWindow ) {
 	ipc.on( 'toggle-dev-tools', function () {

--- a/client/desktop/window-handlers/external-links/editor/index.js
+++ b/client/desktop/window-handlers/external-links/editor/index.js
@@ -3,7 +3,7 @@
  */
 const { URL } = require( 'url' );
 const { promisify } = require( 'util' ); // eslint-disable-line import/no-nodejs-modules
-const { dialog, ipcMain: ipc } = require( 'electron' ); // eslint-disable-line import/no-extraneous-dependencies
+const { dialog, ipcMain: ipc } = require( 'electron' );
 
 /**
  * Internal dependencies

--- a/client/desktop/window-handlers/external-links/index.js
+++ b/client/desktop/window-handlers/external-links/index.js
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-const { ipcMain: ipc } = require( 'electron' ); // eslint-disable-line import/no-extraneous-dependencies
+const { ipcMain: ipc } = require( 'electron' );
 const { URL, format } = require( 'url' );
 
 /**

--- a/client/desktop/window-handlers/external-links/open-in-browser/index.js
+++ b/client/desktop/window-handlers/external-links/open-in-browser/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 const { URL } = require( 'url' );
-const { shell } = require( 'electron' ); // eslint-disable-line import/no-extraneous-dependencies
+const { shell } = require( 'electron' );
 
 /**
  * Internal dependencies

--- a/client/desktop/window-handlers/failed-to-load/index.js
+++ b/client/desktop/window-handlers/failed-to-load/index.js
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-const { app, dialog } = require( 'electron' ); // eslint-disable-line import/no-extraneous-dependencies
+const { app, dialog } = require( 'electron' );
 
 /**
  * Internal dependencies

--- a/client/desktop/window-handlers/get-logs/index.js
+++ b/client/desktop/window-handlers/get-logs/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 const path = require( 'path' );
-const { app, dialog } = require( 'electron' ); // eslint-disable-line import/no-extraneous-dependencies
+const { app, dialog } = require( 'electron' );
 
 /**
  * Internal dependencies

--- a/client/desktop/window-handlers/login-status/index.js
+++ b/client/desktop/window-handlers/login-status/index.js
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-const { app, ipcMain: ipc } = require( 'electron' ); // eslint-disable-line import/no-extraneous-dependencies
+const { app, ipcMain: ipc } = require( 'electron' );
 
 /**
  * Internal dependencies

--- a/client/desktop/window-handlers/notifications/index.js
+++ b/client/desktop/window-handlers/notifications/index.js
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-const { ipcMain: ipc } = require( 'electron' ); // eslint-disable-line import/no-extraneous-dependencies
+const { ipcMain: ipc } = require( 'electron' );
 
 /**
  * Internal dependencies

--- a/client/desktop/window-handlers/spellcheck/index.js
+++ b/client/desktop/window-handlers/spellcheck/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-const { Menu, MenuItem } = require( 'electron' ); // eslint-disable-line import/no-extraneous-dependencies
+const { Menu, MenuItem } = require( 'electron' );
 
 module.exports = function ( mainWindow ) {
 	mainWindow.webContents.on( 'context-menu', ( event, params ) => {


### PR DESCRIPTION
Removes overrides of eslint rule `import/no-extraneous-dependencies`, they are not needed anymore.

Running eslint in `client/desktop` and comparing the results with master shows there are no new errors introduced when the override is deleted:

```
$ ./node_modules/.bin/eslint --ext .js --ext .jsx --ext .ts --ext .tsx client/desktop

# In master
✖ 1 problem (0 errors, 1 warning)

# In this branch
✖ 1 problem (0 errors, 1 warning)
```

The linting job may fail because I changed files that have other errors. Please ignore.