### PR TITLE
Re-introduce "Adds support for importing `calypso` package in Desktop source""

### DIFF
--- a/client/webpack.config.desktop.js
+++ b/client/webpack.config.desktop.js
@@ -78,12 +78,17 @@ module.exports = {
 		// These are Calypso server modules we don't need, so let's not bundle them
 		'webpack.config',
 		'server/devdocs/search-index',
+		'calypso/server/devdocs/search-index',
 	],
 	resolve: {
 		extensions: [ '.json', '.js', '.jsx', '.ts', '.tsx' ],
 		modules: [ __dirname, 'node_modules' ],
 		alias: {
 			config: 'server/config',
+			'calypso/config': 'server/config',
+			// Alias calypso to ./client. This allows for smaller bundles, as it ensures that
+			// importing `./client/file.js` is the same thing than importing `calypso/file.js`
+			calypso: __dirname,
 		},
 	},
 	plugins: [
@@ -92,6 +97,10 @@ module.exports = {
 		new webpack.DefinePlugin( { 'global.GENTLY': false } ),
 		new webpack.NormalModuleReplacementPlugin(
 			/^my-sites[/\\]themes[/\\]theme-upload$/,
+			'components/empty-component'
+		), // Depends on BOM
+		new webpack.NormalModuleReplacementPlugin(
+			/^calypso[/\\]my-sites[/\\]themes[/\\]theme-upload$/,
 			'components/empty-component'
 		), // Depends on BOM
 	],


### PR DESCRIPTION
The original PR (#45569) was reverted (#45612) because e2e broke right after I merged it.
Turns out this wasn't the cause, so I'm reverting the revert.