### PR TITLE
My Sites sidebar: Show items from admin-menu state

### DIFF
--- a/client/layout/sidebar-unified/style.scss
+++ b/client/layout/sidebar-unified/style.scss
@@ -1,0 +1,18 @@
+// Sidebar menu icons for main sections
+/*
+.sidebar-unified__menu-icon {
+	fill: var( --color-sidebar-gridicon-fill );
+	margin-right: 11px;
+	flex-shrink: 0;
+}
+*/
+
+.sidebar-unified__switcher {
+	position: absolute;
+	z-index: 1000;
+	background-color: #633;
+	right: 0;
+	cursor: pointer;
+	text-decoration: underline;
+	font-size: 0.75rem;
+}

--- a/client/layout/sidebar-unified/style.scss
+++ b/client/layout/sidebar-unified/style.scss
@@ -1,12 +1,3 @@
-// Sidebar menu icons for main sections
-/*
-.sidebar-unified__menu-icon {
-	fill: var( --color-sidebar-gridicon-fill );
-	margin-right: 11px;
-	flex-shrink: 0;
-}
-*/
-
 .sidebar-unified__switcher {
 	position: absolute;
 	z-index: 1000;
@@ -15,4 +6,22 @@
 	cursor: pointer;
 	text-decoration: underline;
 	font-size: 0.75rem;
+}
+
+.sidebar-unified__sparkline {
+	width: 80px;
+	height: 24px;
+}
+
+/*
+ * Because the sparkline is an image, there's an exception here
+ * where specific color schemes are targeted instead of using
+ * CSS variables. This ensures that the sparkline can still be
+ * seen (as white) on some of the darker color schemes.
+ */
+.is-classic-blue .sidebar__menu li.stats.selected .sidebar-unified__sparkline,
+.is-powder-snow .sidebar__menu li.stats.selected .sidebar-unified__sparkline,
+.is-nightfall .sidebar__menu li.stats.selected .sidebar-unified__sparkline {
+	filter: brightness( 100 );
+	-webkit-filter: brightness( 100 );
 }

--- a/client/layout/sidebar/custom-icon.jsx
+++ b/client/layout/sidebar/custom-icon.jsx
@@ -15,11 +15,7 @@ import React from 'react';
 const SidebarCustomIcon = ( props ) => {
 	const { alt, className, ...rest } = props;
 	return (
-		<img
-			alt={ alt != null ? alt : '' }
-			className={ 'sidebar__menu-icon ' + ( className != null ? className : '' ) }
-			{ ...rest }
-		/>
+		<img alt={ alt || '' } className={ 'sidebar__menu-icon ' + ( className || '' ) } { ...rest } />
 	);
 };
 export default SidebarCustomIcon;

--- a/client/layout/sidebar/custom-icon.jsx
+++ b/client/layout/sidebar/custom-icon.jsx
@@ -1,0 +1,16 @@
+/**
+ * External dependencies
+ */
+
+import React from 'react';
+const SidebarCustomIcon = ( props ) => {
+	const { alt, className, ...rest } = props;
+	return (
+		<img
+			alt={ alt != null ? alt : '' }
+			className={ 'sidebar__menu-icon ' + ( className != null ? className : '' ) }
+			{ ...rest }
+		/>
+	);
+};
+export default SidebarCustomIcon;

--- a/client/layout/sidebar/custom-icon.jsx
+++ b/client/layout/sidebar/custom-icon.jsx
@@ -1,4 +1,13 @@
 /**
+ * SidebarCustomIcon -
+ *   Renders an <img> tag with props supplied, but adds
+ *   className="sidebar__menu-icon" to the supplied className.
+ *
+ *   Purpose: To display a custom icon in the sidebar when using a
+ *   source other than grid icons or material icons.
+ **/
+
+/**
  * External dependencies
  */
 

--- a/client/my-sites/navigation/index.jsx
+++ b/client/my-sites/navigation/index.jsx
@@ -26,11 +26,14 @@ class MySitesNavigation extends React.Component {
 			siteBasePath: this.props.siteBasePath,
 		};
 
-		const asyncSidebar = config.isEnabled( 'jetpack-cloud' ) ? (
-			<AsyncLoad require="components/jetpack/sidebar" { ...asyncProps } />
-		) : (
-			<AsyncLoad require="my-sites/sidebar" { ...asyncProps } />
-		);
+		let asyncSidebar = null;
+		if ( config.isEnabled( 'jetpack-cloud' ) ) {
+			asyncSidebar = <AsyncLoad require="components/jetpack/sidebar" { ...asyncProps } />;
+		} else if ( config.isEnabled( 'nav-unification' ) ) {
+			asyncSidebar = <AsyncLoad require="my-sites/sidebar-unified/switcher" { ...asyncProps } />;
+		} else {
+			asyncSidebar = <AsyncLoad require="my-sites/sidebar" { ...asyncProps } />;
+		}
 
 		return (
 			<div>

--- a/client/my-sites/sidebar-unified/index.jsx
+++ b/client/my-sites/sidebar-unified/index.jsx
@@ -25,6 +25,7 @@ import CurrentSite from 'my-sites/current-site';
 import MySitesSidebarUnifiedItem from './item';
 import MySitesSidebarUnifiedMenu from './menu';
 import Sidebar from 'layout/sidebar';
+import SidebarSeparator from 'layout/sidebar/separator';
 
 export const MySitesSidebarUnified = ( { path } ) => {
 	const reduxDispatch = useDispatch();
@@ -61,7 +62,7 @@ export const MySitesSidebarUnified = ( { path } ) => {
 			<CurrentSite forceAllSitesView={ isAllDomainsView } />
 			{ menuItems.map( ( item, i ) => {
 				if ( 'type' in item && item.type === 'separator' ) {
-					return <hr key={ i } />;
+					return <SidebarSeparator key={ i } />;
 				}
 				if ( ! ( 'children' in item ) || item.children.length === 0 ) {
 					return <MySitesSidebarUnifiedItem key={ item.slug } path={ path } { ...item } />;

--- a/client/my-sites/sidebar-unified/index.jsx
+++ b/client/my-sites/sidebar-unified/index.jsx
@@ -60,7 +60,9 @@ export const MySitesSidebarUnified = ( { path } ) => {
 					return <SidebarSeparator key={ i } />;
 				}
 				if ( ! ( 'children' in item ) || item.children.length === 0 ) {
-					return <MySitesSidebarUnifiedItem key={ item.slug } path={ path } { ...item } />;
+					return (
+						<MySitesSidebarUnifiedItem isTopLevel key={ item.slug } path={ path } { ...item } />
+					);
 				}
 				return <MySitesSidebarUnifiedMenu key={ item.slug } path={ path } { ...item } />;
 			} ) }

--- a/client/my-sites/sidebar-unified/index.jsx
+++ b/client/my-sites/sidebar-unified/index.jsx
@@ -28,6 +28,8 @@ import MySitesSidebarUnifiedMenu from './menu';
 import Sidebar from 'layout/sidebar';
 import SidebarSeparator from 'layout/sidebar/separator';
 
+import 'layout/sidebar-unified/style.scss';
+
 export const MySitesSidebarUnified = ( { path } ) => {
 	const reduxDispatch = useDispatch();
 	const selectedSiteId = useSelector( getSelectedSiteId );

--- a/client/my-sites/sidebar-unified/index.jsx
+++ b/client/my-sites/sidebar-unified/index.jsx
@@ -1,0 +1,74 @@
+/**
+ * MySitesSidebarUnified
+ *   Renders the Sidebar for "My Sites", except all of the menus and items are
+ *   driven off a WPCom endpoint: /sites/${sideId}/admin-menu, which is loaded
+ *   into state.adminMenu in a data layer.
+ *
+ *    Currently experimental/WIP.
+ **/
+
+/**
+ * External dependencies
+ */
+import React, { useEffect } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { getCurrentRoute } from 'state/selectors/get-current-route';
+import { getSelectedSite } from 'state/ui/selectors';
+import { isUnderDomainManagementAll } from 'my-sites/domains/paths';
+import { isUnderEmailManagementAll } from 'my-sites/email/paths';
+import { requestAdminMenu } from '../../state/admin-menu/actions';
+import CurrentSite from 'my-sites/current-site';
+import MySitesSidebarUnifiedItem from './item';
+import MySitesSidebarUnifiedMenu from './menu';
+import Sidebar from 'layout/sidebar';
+
+export const MySitesSidebarUnified = ( { path } ) => {
+	const reduxDispatch = useDispatch();
+	const selectedSite = useSelector( ( state ) => getSelectedSite( state ) );
+	useEffect( () => {
+		if ( selectedSite !== null && selectedSite.ID ) {
+			reduxDispatch( requestAdminMenu( selectedSite.ID ) );
+		}
+	}, [ reduxDispatch, selectedSite ] );
+
+	// Extract this?
+	const menuItems = useSelector( ( state ) => {
+		const thisSelectedSite = getSelectedSite( state );
+		if (
+			thisSelectedSite !== null &&
+			thisSelectedSite.ID &&
+			state.adminMenu != null &&
+			thisSelectedSite.ID in state.adminMenu
+		) {
+			return Object.values( state.adminMenu[ thisSelectedSite.ID ] );
+		}
+		return [];
+	} );
+
+	// Extract this?
+	const isAllDomainsView = useSelector( ( state ) => {
+		const currentRoute = getCurrentRoute( state );
+		return isUnderDomainManagementAll( currentRoute ) || isUnderEmailManagementAll( currentRoute );
+	} );
+
+	//console.log( { menuItems } );
+	return (
+		<Sidebar>
+			<CurrentSite forceAllSitesView={ isAllDomainsView } />
+			{ menuItems.map( ( item, i ) => {
+				if ( 'type' in item && item.type === 'separator' ) {
+					return <hr key={ i } />;
+				}
+				if ( ! ( 'children' in item ) || item.children.length === 0 ) {
+					return <MySitesSidebarUnifiedItem key={ item.slug } path={ path } { ...item } />;
+				}
+				return <MySitesSidebarUnifiedMenu key={ item.slug } path={ path } { ...item } />;
+			} ) }
+		</Sidebar>
+	);
+};
+export default MySitesSidebarUnified;

--- a/client/my-sites/sidebar-unified/index.jsx
+++ b/client/my-sites/sidebar-unified/index.jsx
@@ -18,6 +18,7 @@ import { useSelector, useDispatch } from 'react-redux';
  */
 import { getCurrentRoute } from 'state/selectors/get-current-route';
 import { getSelectedSiteId } from 'state/ui/selectors';
+import { getAdminMenu } from 'state/admin-menu/selectors';
 import { isUnderDomainManagementAll } from 'my-sites/domains/paths';
 import { isUnderEmailManagementAll } from 'my-sites/email/paths';
 import { requestAdminMenu } from '../../state/admin-menu/actions';
@@ -38,11 +39,8 @@ export const MySitesSidebarUnified = ( { path } ) => {
 
 	// Extract this?
 	const menuItems = useSelector( ( state ) => {
-		const siteId = getSelectedSiteId( state );
-		if ( siteId != null && state.adminMenu != null && siteId in state.adminMenu ) {
-			return Object.values( state.adminMenu[ siteId ] );
-		}
-		return [];
+		const menu = getAdminMenu( state, getSelectedSiteId( state ) );
+		return menu != null ? Object.values( menu ) : [];
 	} );
 
 	// Extract this?

--- a/client/my-sites/sidebar-unified/index.jsx
+++ b/client/my-sites/sidebar-unified/index.jsx
@@ -17,7 +17,7 @@ import { useSelector, useDispatch } from 'react-redux';
  * Internal dependencies
  */
 import { getCurrentRoute } from 'state/selectors/get-current-route';
-import { getSelectedSite } from 'state/ui/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
 import { isUnderDomainManagementAll } from 'my-sites/domains/paths';
 import { isUnderEmailManagementAll } from 'my-sites/email/paths';
 import { requestAdminMenu } from '../../state/admin-menu/actions';
@@ -29,23 +29,18 @@ import SidebarSeparator from 'layout/sidebar/separator';
 
 export const MySitesSidebarUnified = ( { path } ) => {
 	const reduxDispatch = useDispatch();
-	const selectedSite = useSelector( ( state ) => getSelectedSite( state ) );
+	const selectedSiteId = useSelector( getSelectedSiteId );
 	useEffect( () => {
-		if ( selectedSite !== null && selectedSite.ID ) {
-			reduxDispatch( requestAdminMenu( selectedSite.ID ) );
+		if ( selectedSiteId !== null ) {
+			reduxDispatch( requestAdminMenu( selectedSiteId ) );
 		}
-	}, [ reduxDispatch, selectedSite ] );
+	}, [ reduxDispatch, selectedSiteId ] );
 
 	// Extract this?
 	const menuItems = useSelector( ( state ) => {
-		const thisSelectedSite = getSelectedSite( state );
-		if (
-			thisSelectedSite !== null &&
-			thisSelectedSite.ID &&
-			state.adminMenu != null &&
-			thisSelectedSite.ID in state.adminMenu
-		) {
-			return Object.values( state.adminMenu[ thisSelectedSite.ID ] );
+		const siteId = getSelectedSiteId( state );
+		if ( siteId != null && state.adminMenu != null && siteId in state.adminMenu ) {
+			return Object.values( state.adminMenu[ siteId ] );
 		}
 		return [];
 	} );

--- a/client/my-sites/sidebar-unified/index.jsx
+++ b/client/my-sites/sidebar-unified/index.jsx
@@ -29,6 +29,7 @@ import Sidebar from 'layout/sidebar';
 import SidebarSeparator from 'layout/sidebar/separator';
 
 import 'layout/sidebar-unified/style.scss';
+import 'state/admin-menu/init';
 
 export const MySitesSidebarUnified = ( { path } ) => {
 	const reduxDispatch = useDispatch();

--- a/client/my-sites/sidebar-unified/item.jsx
+++ b/client/my-sites/sidebar-unified/item.jsx
@@ -1,0 +1,82 @@
+/**
+ * MySitesSidebarUnifiedItem
+ *
+ * Renders a sidebar menu item with no child items.
+ * This could be a top level item, or a child item nested under a top level menu.
+ * These two cases might be to be split up?
+ */
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { useSelector } from 'react-redux';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import { getSelectedSite } from 'state/ui/selectors';
+import SidebarItem from 'layout/sidebar/item';
+import StatsSparkline from 'blocks/stats-sparkline';
+
+const onNav = () => null;
+
+const removePrefix = ( str, prefix ) => {
+	if ( str == null || typeof str !== 'string' ) {
+		return str;
+	}
+	const hasPrefix = str.indexOf( prefix ) === 0;
+	if ( ! hasPrefix ) {
+		return str;
+	}
+	return str.substr( prefix.length );
+};
+
+// selected={ itemLinkMatches( [ '/domains', '/email' ], path ) }
+
+export const MySitesSidebarUnifiedItem = ( { title, icon, url, path, slug } ) => {
+	const selectedSite = useSelector( ( state ) => getSelectedSite( state ) );
+	const fixedUrl = removePrefix( url, 'https://wordpress.com' );
+	const selected = path === fixedUrl;
+	let customIcon = null;
+	if ( icon && typeof icon === 'string' && icon.match( /data:image/ ) ) {
+		// TODO: Change sidebar__menu-icon to sidebar-unified__menu-icon and
+		// copy the CSS rules
+		// I would do now, but this will cause a conflict w/ the update/left-nav-geometries
+		// branch
+		// eslint-disable-next-line
+		customIcon = <img src={ icon } className="sidebar__menu-icon" alt="" />;
+	}
+
+	let children = null;
+
+	// "Stats" item has sparkline inside of it
+	const isStats = typeof slug === 'string' && slug.includes( '-comstats' );
+	if ( isStats && selectedSite && selectedSite.ID ) {
+		// TODO: Change sidebar__menu-icon to sidebar-unified__menu-icon and
+		// copy the CSS rules
+		// eslint-disable-next-line
+		children = <StatsSparkline className="sidebar__sparkline" siteId={ selectedSite.ID } />;
+	}
+
+	return (
+		<SidebarItem
+			label={ title }
+			link={ fixedUrl }
+			onNavigate={ onNav }
+			selected={ selected }
+			customIcon={ customIcon }
+		>
+			{ children }
+		</SidebarItem>
+	);
+};
+
+MySitesSidebarUnifiedItem.propTypes = {
+	path: PropTypes.string,
+	title: PropTypes.string,
+	icon: PropTypes.string,
+	url: PropTypes.string,
+};
+
+export default MySitesSidebarUnifiedItem;

--- a/client/my-sites/sidebar-unified/item.jsx
+++ b/client/my-sites/sidebar-unified/item.jsx
@@ -22,17 +22,6 @@ import StatsSparkline from 'blocks/stats-sparkline';
 
 const onNav = () => null;
 
-const removePrefix = ( str, prefix ) => {
-	if ( str == null || typeof str !== 'string' ) {
-		return str;
-	}
-	const hasPrefix = str.indexOf( prefix ) === 0;
-	if ( ! hasPrefix ) {
-		return str;
-	}
-	return str.substr( prefix.length );
-};
-
 // selected={ itemLinkMatches( [ '/domains', '/email' ], path ) }
 
 const blankSvg =
@@ -41,8 +30,7 @@ const blankSvgStyle = { height: '24px', width: '24px' };
 
 export const MySitesSidebarUnifiedItem = ( { title, icon, url, path, slug, isTopLevel } ) => {
 	const selectedSiteId = useSelector( getSelectedSiteId );
-	const fixedUrl = removePrefix( url, 'https://wordpress.com' );
-	const selected = path === fixedUrl;
+	const selected = path === url;
 	let customIcon = null;
 	if ( icon && typeof icon === 'string' && icon.match( /data:image/ ) ) {
 		customIcon = <SidebarCustomIcon src={ icon } />;
@@ -64,7 +52,7 @@ export const MySitesSidebarUnifiedItem = ( { title, icon, url, path, slug, isTop
 	return (
 		<SidebarItem
 			label={ title }
-			link={ fixedUrl }
+			link={ url }
 			onNavigate={ onNav }
 			selected={ selected }
 			customIcon={ customIcon }

--- a/client/my-sites/sidebar-unified/item.jsx
+++ b/client/my-sites/sidebar-unified/item.jsx
@@ -15,7 +15,7 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import { getSelectedSite } from 'state/ui/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
 import SidebarItem from 'layout/sidebar/item';
 import SidebarCustomIcon from 'layout/sidebar/custom-icon';
 import StatsSparkline from 'blocks/stats-sparkline';
@@ -40,7 +40,7 @@ const blankSvg =
 const blankSvgStyle = { height: '24px', width: '24px' };
 
 export const MySitesSidebarUnifiedItem = ( { title, icon, url, path, slug, isTopLevel } ) => {
-	const selectedSite = useSelector( ( state ) => getSelectedSite( state ) );
+	const selectedSiteId = useSelector( getSelectedSiteId );
 	const fixedUrl = removePrefix( url, 'https://wordpress.com' );
 	const selected = path === fixedUrl;
 	let customIcon = null;
@@ -54,11 +54,11 @@ export const MySitesSidebarUnifiedItem = ( { title, icon, url, path, slug, isTop
 
 	// "Stats" item has sparkline inside of it
 	const isStats = typeof slug === 'string' && slug.includes( '-comstats' );
-	if ( isStats && selectedSite && selectedSite.ID ) {
+	if ( isStats && selectedSiteId ) {
 		// TODO: Change sidebar__menu-icon to sidebar-unified__menu-icon and
 		// copy the CSS rules
 		// eslint-disable-next-line
-		children = <StatsSparkline className="sidebar__sparkline" siteId={ selectedSite.ID } />;
+		children = <StatsSparkline className="sidebar__sparkline" siteId={ selectedSiteId } />;
 	}
 
 	return (

--- a/client/my-sites/sidebar-unified/item.jsx
+++ b/client/my-sites/sidebar-unified/item.jsx
@@ -17,6 +17,7 @@ import PropTypes from 'prop-types';
  */
 import { getSelectedSite } from 'state/ui/selectors';
 import SidebarItem from 'layout/sidebar/item';
+import SidebarCustomIcon from 'layout/sidebar/custom-icon';
 import StatsSparkline from 'blocks/stats-sparkline';
 
 const onNav = () => null;
@@ -44,20 +45,9 @@ export const MySitesSidebarUnifiedItem = ( { title, icon, url, path, slug } ) =>
 	const selected = path === fixedUrl;
 	let customIcon = null;
 	if ( icon && typeof icon === 'string' && icon.match( /data:image/ ) ) {
-		// TODO: Change sidebar__menu-icon to sidebar-unified__menu-icon and
-		// copy the CSS rules
-		// I would do now, but this will cause a conflict w/ the update/left-nav-geometries
-		// branch
-		// eslint-disable-next-line
-		customIcon = <img src={ icon } className="sidebar__menu-icon" alt="" />;
+		customIcon = <SidebarCustomIcon src={ icon } />;
 	} else {
-		// Demo workaround for items missing icons
-		// TODO: Change sidebar__menu-icon to sidebar-unified__menu-icon (See above)
-		/* eslint-disable wpcalypso/jsx-classname-namespace */
-		customIcon = (
-			<img src={ blankSvg } style={ blankSvgStyle } className="sidebar__menu-icon" alt="" />
-		);
-		/* eslint-enable wpcalypso/jsx-classname-namespace */
+		customIcon = <SidebarCustomIcon crc={ blankSvg } style={ blankSvgStyle } />;
 	}
 
 	let children = null;

--- a/client/my-sites/sidebar-unified/item.jsx
+++ b/client/my-sites/sidebar-unified/item.jsx
@@ -43,10 +43,7 @@ export const MySitesSidebarUnifiedItem = ( { title, icon, url, path, slug, isTop
 	// "Stats" item has sparkline inside of it
 	const isStats = typeof slug === 'string' && slug.includes( '-comstats' );
 	if ( isStats && selectedSiteId ) {
-		// TODO: Change sidebar__menu-icon to sidebar-unified__menu-icon and
-		// copy the CSS rules
-		// eslint-disable-next-line
-		children = <StatsSparkline className="sidebar__sparkline" siteId={ selectedSiteId } />;
+		children = <StatsSparkline className="sidebar-unified__sparkline" siteId={ selectedSiteId } />;
 	}
 
 	return (

--- a/client/my-sites/sidebar-unified/item.jsx
+++ b/client/my-sites/sidebar-unified/item.jsx
@@ -34,6 +34,10 @@ const removePrefix = ( str, prefix ) => {
 
 // selected={ itemLinkMatches( [ '/domains', '/email' ], path ) }
 
+const blankSvg =
+	"data:image/svg+xml;charset=utf8,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E";
+const blankSvgStyle = { height: '24px', width: '24px' };
+
 export const MySitesSidebarUnifiedItem = ( { title, icon, url, path, slug } ) => {
 	const selectedSite = useSelector( ( state ) => getSelectedSite( state ) );
 	const fixedUrl = removePrefix( url, 'https://wordpress.com' );
@@ -46,6 +50,14 @@ export const MySitesSidebarUnifiedItem = ( { title, icon, url, path, slug } ) =>
 		// branch
 		// eslint-disable-next-line
 		customIcon = <img src={ icon } className="sidebar__menu-icon" alt="" />;
+	} else {
+		// Demo workaround for items missing icons
+		// TODO: Change sidebar__menu-icon to sidebar-unified__menu-icon (See above)
+		/* eslint-disable wpcalypso/jsx-classname-namespace */
+		customIcon = (
+			<img src={ blankSvg } style={ blankSvgStyle } className="sidebar__menu-icon" alt="" />
+		);
+		/* eslint-enable wpcalypso/jsx-classname-namespace */
 	}
 
 	let children = null;

--- a/client/my-sites/sidebar-unified/item.jsx
+++ b/client/my-sites/sidebar-unified/item.jsx
@@ -39,14 +39,14 @@ const blankSvg =
 	"data:image/svg+xml;charset=utf8,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E";
 const blankSvgStyle = { height: '24px', width: '24px' };
 
-export const MySitesSidebarUnifiedItem = ( { title, icon, url, path, slug } ) => {
+export const MySitesSidebarUnifiedItem = ( { title, icon, url, path, slug, isTopLevel } ) => {
 	const selectedSite = useSelector( ( state ) => getSelectedSite( state ) );
 	const fixedUrl = removePrefix( url, 'https://wordpress.com' );
 	const selected = path === fixedUrl;
 	let customIcon = null;
 	if ( icon && typeof icon === 'string' && icon.match( /data:image/ ) ) {
 		customIcon = <SidebarCustomIcon src={ icon } />;
-	} else {
+	} else if ( isTopLevel ) {
 		customIcon = <SidebarCustomIcon crc={ blankSvg } style={ blankSvgStyle } />;
 	}
 
@@ -75,6 +75,7 @@ export const MySitesSidebarUnifiedItem = ( { title, icon, url, path, slug } ) =>
 };
 
 MySitesSidebarUnifiedItem.propTypes = {
+	isTopLevel: PropTypes.bool,
 	path: PropTypes.string,
 	title: PropTypes.string,
 	icon: PropTypes.string,

--- a/client/my-sites/sidebar-unified/menu.jsx
+++ b/client/my-sites/sidebar-unified/menu.jsx
@@ -1,0 +1,99 @@
+/**
+ * MySitesSidebarUnifiedMenu
+ *
+ * Renders a top level menu item with children.
+ * This item can be expanded and collapsed by clicking.
+ **/
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import { isSidebarSectionOpen } from 'state/my-sites/sidebar/selectors';
+import { toggleMySitesSidebarSection as toggleSection } from 'state/my-sites/sidebar/actions';
+import ExpandableSidebarMenu from 'layout/sidebar/expandable';
+import MySitesSidebarUnifiedItem from './item';
+
+export const MySitesSidebarUnifiedMenu = ( { slug, title, icon, children, path } ) => {
+	const reduxDispatch = useDispatch();
+	const sectionId = 'SIDEBAR_SECTION_' + slug;
+	const isExpanded = useSelector( ( state ) => isSidebarSectionOpen( state, sectionId ) );
+	return (
+		<ExpandableSidebarMenu
+			onClick={ () => reduxDispatch( toggleSection( sectionId ) ) }
+			expanded={ isExpanded }
+			title={ title }
+			materialIcon={ icon }
+		>
+			{ Object.values( children ).map( ( item ) => (
+				<MySitesSidebarUnifiedItem key={ item.slug } path={ path } { ...item } />
+			) ) }
+		</ExpandableSidebarMenu>
+	);
+};
+
+MySitesSidebarUnifiedMenu.propTypes = {
+	path: PropTypes.string,
+	title: PropTypes.string,
+	icon: PropTypes.string,
+	children: PropTypes.oneOfType( [ PropTypes.object, PropTypes.array ] ).isRequired,
+	/*
+	Example of children shape (object):
+	{
+		"1": {
+			"title": "Feedback",
+			"url": "https://wp.com",
+			"icon": null,
+			"type": "menu-item"
+		},
+		"2": {
+			"title": "Polls",
+			"url": "https://wp.com",
+			"icon": null,
+			"type": "menu-item"
+		},
+		"3": {
+			"title": "Ratings",
+			"url": "https://wp.com",
+			"icon": null,
+			"type": "menu-item"
+		}
+	}
+
+	Example of children shape (array):
+	[
+		{
+			"title": "Settings",
+			"url": "https://wp.com",
+			"icon": null,
+			"type": "menu-item"
+		},
+		{
+			"title": "Domains",
+			"url": "https://wp.com",
+			"icon": null,
+			"type": "menu-item"
+		},
+		{
+			"title": "Debug Bar Extender",
+			"url": "https://wp.com",
+			"icon": null,
+			"type": "menu-item"
+		},
+		{
+			"title": "Hosting Configuration",
+			"url": "https://wp.com",
+			"icon": null,
+			"type": "menu-item"
+		}
+	]
+	*/
+};
+
+export default MySitesSidebarUnifiedMenu;

--- a/client/my-sites/sidebar-unified/switcher.jsx
+++ b/client/my-sites/sidebar-unified/switcher.jsx
@@ -1,0 +1,44 @@
+/**
+ * MySitesSidebarUnifiedSwitcher
+ *   This is a development component to make comparing the prod and unified sidebars easier.
+ *   Click the link to switch between the two versions of the sidebar.
+ *
+ *    Currently experimental/WIP.
+ **/
+
+/**
+ * External dependencies
+ */
+import React, { useState } from 'react';
+import MySitesSidebarUnified from './index';
+import MySitesSidebar from '../sidebar/index';
+
+export const MySitesSidebarUnifiedSwitcher = ( props ) => {
+	const [ isUnified, setUnified ] = useState( true );
+
+	return (
+		<>
+			<div
+				role="link"
+				tabIndex={ 0 }
+				style={ {
+					position: 'absolute',
+					zIndex: 1000,
+					backgroundColor: '#633',
+					right: 0,
+					cursor: 'pointer',
+					textDecoration: 'underline',
+					fontSize: '11px',
+				} }
+				onClick={ () => setUnified( ! isUnified ) }
+				onKeyDown={ () => setUnified( ! isUnified ) }
+			>
+				{ isUnified && <span>Unified SB</span> }
+				{ ! isUnified && <span>Prod SB</span> }
+			</div>
+			{ isUnified && <MySitesSidebarUnified { ...props } /> }
+			{ ! isUnified && <MySitesSidebar { ...props } /> }
+		</>
+	);
+};
+export default MySitesSidebarUnifiedSwitcher;

--- a/client/my-sites/sidebar-unified/switcher.jsx
+++ b/client/my-sites/sidebar-unified/switcher.jsx
@@ -19,17 +19,9 @@ export const MySitesSidebarUnifiedSwitcher = ( props ) => {
 	return (
 		<>
 			<div
+				className="sidebar-unified__switcher"
 				role="link"
 				tabIndex={ 0 }
-				style={ {
-					position: 'absolute',
-					zIndex: 1000,
-					backgroundColor: '#633',
-					right: 0,
-					cursor: 'pointer',
-					textDecoration: 'underline',
-					fontSize: '11px',
-				} }
 				onClick={ () => setUnified( ! isUnified ) }
 				onKeyDown={ () => setUnified( ! isUnified ) }
 			>

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -3,10 +3,10 @@
 	height: 24px;
 }
 
-/* 
+/*
  * Because the sparkline is an image, there's an exception here
- * where specific color schemes are targeted instead of using 
- * CSS variables. This ensures that the sparkline can still be 
+ * where specific color schemes are targeted instead of using
+ * CSS variables. This ensures that the sparkline can still be
  * seen (as white) on some of the darker color schemes.
  */
 .is-classic-blue .sidebar__menu li.stats.selected .sidebar__sparkline,

--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -10,7 +10,6 @@
  */
 import { combineReducers } from 'state/utils';
 import { reducer as httpData } from 'state/data-layer/http-data';
-import config from 'config';
 
 /**
  * Reducers
@@ -94,11 +93,5 @@ const reducers = {
 	userSettings,
 	users,
 };
-
-// TODO: remove this once admin-menu state is consumed by UI components
-// to allow it to be loaded on demand as modularized state.
-if ( config.isEnabled( 'nav-unification' ) ) {
-	import( 'state/admin-menu/init' );
-}
 
 export default combineReducers( reducers );


### PR DESCRIPTION
_Note: These are the same changes that were in #45531, which were reverted due to failing smoke tests, which were related to end of day limits on account creation, not the PR changes._

#### Changes proposed in this Pull Request

* My sites sidebar is driven off the state in admin-menu (see: #45495)
* WIP, But behind a feature flag (`nav-unification`)
* "My sites" sidebar acts the same if the feature flag is off

#### Testing instructions

* Apply D49204-code
* Apply D49005-code
* Comment out the sticker check in admin-plugins/admin-menu.php
* Run calypso
* Visit http://calypso.localhost:3000/?flags=nav-unification

See: #45435


