### PR TITLE
Server build: nice names for the bundle and its chunks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,4 +39,4 @@ ARG        workers
 RUN        WORKERS=$workers CALYPSO_ENV=production BUILD_TRANSLATION_CHUNKS=true yarn run build && rm -fr .cache
 
 USER       nobody
-CMD        NODE_ENV=production node build/bundle.js
+CMD        NODE_ENV=production node build/server.js

--- a/client/webpack.config.desktop.js
+++ b/client/webpack.config.desktop.js
@@ -13,6 +13,7 @@ module.exports = {
 	output: {
 		path: path.resolve( 'desktop/build' ),
 		filename: 'desktop.js',
+		chunkFilename: 'desktop.[name].js',
 		libraryTarget: 'commonjs2',
 	},
 	target: 'electron-main',

--- a/client/webpack.config.node.js
+++ b/client/webpack.config.node.js
@@ -59,7 +59,7 @@ function getExternals() {
 			],
 		} ),
 		// Some imports should be resolved to runtime `require()` calls, with paths relative
-		// to the path of the `build/bundle.js` bundle.
+		// to the path of the `build/server.js` bundle.
 		{
 			// Don't bundle webpack.config, as it depends on absolute paths (__dirname)
 			'webpack.config': {
@@ -87,7 +87,8 @@ const webpackConfig = {
 	target: 'node',
 	output: {
 		path: buildDir,
-		filename: 'bundle.js',
+		filename: 'server.js',
+		chunkFilename: 'server.[name].js',
 	},
 	mode: isDevelopment ? 'development' : 'production',
 	optimization: { minimize: false },

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
 		"start-jetpack-cloud-p": "PORT=3001 CALYPSO_ENV=jetpack-cloud-development yarn run build-server",
 		"poststart-jetpack-cloud-p": "PORT=3001 CALYPSO_ENV=jetpack-cloud-development yarn run start-build-web",
 		"reformat-files": "./node_modules/.bin/prettier --ignore-path .eslintignore --write \"**/*.{js,jsx,json,ts,tsx}\"",
-		"start-build-do": "node ${NODE_ARGS:---max-old-space_size=8192} build/bundle.js",
+		"start-build-do": "node ${NODE_ARGS:---max-old-space_size=8192} build/server.js",
 		"start-build-fallback": "BROWSERSLIST_ENV=defaults yarn run start-build-do",
 		"start-build-evergreen": "BROWSERSLIST_ENV=evergreen yarn run start-build-do",
 		"start-build-if-desktop": "node -e \"(process.env.CALYPSO_ENV === 'desktop' || process.env.CALYPSO_ENV === 'desktop-development') && process.exit(1)\" || yarn run start-build-fallback",


### PR DESCRIPTION
The name of the server bundle -- `build/bundle.js` -- doesn't convey any meaning about what the file is, i.e., Calypso server. I remember that, as a Calypso beginner, I've been confused by the server code for a long time.

This PR renames the bundle to `build/server.js`.

It also gives nicer names to the server-side dynamic chunks.

**Before:**
```
build/0.bundle.js
build/1.bundle.js
build/2.bundle.js
build/4.bundle.js
build/bundle.js
```

**After:**
```
build/server.4.js
build/server.js
build/server.lib-analytics-signup.js
build/server.moment-locale-af.js
build/server.vendors~moment-locale-af.js
```

With the new chunk naming, we see what each chunk contains (except no.4 which is a shared chunk) and it also shows some optimization opportunities: we do moment locales wrong, the `vendors` cache group is not useful in Node.js, as the chunks are not HTTP-downloaded and cached, ...

**How to test:**
Verify that everything works and that I replaced all usages of `build/bundle.js`.

Also verify that the desktop build also uses chunk names for filenames. Run `yarn run build-desktop` and check.