### PR TITLE
E2E: Re-enable signup canary test

### DIFF
--- a/test/e2e/lib/components/find-a-domain-component.js
+++ b/test/e2e/lib/components/find-a-domain-component.js
@@ -103,7 +103,7 @@ export default class FindADomainComponent extends AsyncBaseContainer {
 
 	async skipSuggestion() {
 		// currently used in 'launch-site' and 'new-launch' signup flows
-		const skipSuggestion = By.css( '.domain-skip-suggestion > .button.domain-suggestion__action' );
+		const skipSuggestion = By.css( '.domain-skip-suggestion .button.domain-suggestion__action' );
 		return await driverHelper.clickWhenClickable(
 			this.driver,
 			skipSuggestion,

--- a/test/e2e/specs/wp-signup-spec.js
+++ b/test/e2e/specs/wp-signup-spec.js
@@ -360,7 +360,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 		} );
 	} );
 
-	describe.skip( 'Sign up for a site on a premium paid plan through main flow in USD currency and launch @parallel @canary', function () {
+	describe( 'Sign up for a site on a premium paid plan through main flow in USD currency and launch @parallel @canary', function () {
 		const blogName = dataHelper.getNewBlogName();
 		const expectedBlogAddresses = dataHelper.getExpectedFreeAddresses( blogName );
 		const emailAddress = dataHelper.getEmailAddress( blogName, signupInboxId );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates e2e test to pass with both variants of the `domainStepCopyUpdates` A/B test to support this change: https://github.com/Automattic/wp-calypso/pull/44961/files#diff-8722702d3bce35cb2607583bae20aad5