### PR TITLE
Editing Toolkit: Remove no-inline-config flag from es5 validation

### DIFF
--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -81,7 +81,7 @@
 		"predev": "yarn run clean",
 		"sync:newspack-blocks": "./bin/sync-newspack-blocks.sh",
 		"wpcom-sync": "./bin/wpcom-watch-and-sync.sh",
-		"validate-es5": "npx eslint --parser-options=ecmaVersion:5 --no-eslintrc --no-ignore --no-inline-config ./editing-toolkit-plugin/*/dist/*.js"
+		"validate-es5": "npx eslint --parser-options=ecmaVersion:5 --no-eslintrc --no-ignore ./editing-toolkit-plugin/*/dist/*.js"
 	},
 	"dependencies": {
 		"@automattic/calypso-analytics": "^1.0.0-alpha.1",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Remove no-inline-config from ES5 validation script. This is not required since we are checking minimized code which doesn't contain any comments.

#### Testing instructions

`yarn build` should run without errors
